### PR TITLE
misc: support marginal comments in Vim syntax

### DIFF
--- a/misc/vim/isabelle.vim
+++ b/misc/vim/isabelle.vim
@@ -108,6 +108,8 @@ syntax region IsabelleComment matchgroup=IsabelleComment start="(\*" end="\*)" c
 syntax match IsabelleCommentStart "(\*" contained nextgroup=IsabelleCommentContent contains=IsabelleCommentStart
 syntax match IsabelleCommentContent ".*" contained
 
+syntax region IsabelleComment matchgroup=IsabelleComment fold start="\\<comment>\s*\\<open>" end="\\<close>" contains=IsabelleSpecial keepend
+
 " You can use LaTeX within text {* ... *} blocks and friends and sometimes it
 " is useful to have syntax highlighting enabled within these blocks when
 " working on a PDF-destined theory. This is off by default because it can be a
@@ -640,10 +642,11 @@ syn match IsabelleSpecial /\\<s>/ conceal cchar=𝗌
 syn match IsabelleSpecial /\\<Leftrightarrow>/ conceal cchar=⇔
 syn match IsabelleSpecial /\\<heartsuit>/ conceal cchar=♡
 syn match IsabelleSpecial /\\<four>/ conceal cchar=𝟰
-syn match IsabelleSpecial /\\<open>/ conceal cchar=‹
-syn match IsabelleSpecial /\\<close>/ conceal cchar=›
+syn match IsabelleSpecial /\\<open>/ conceal cchar=‹ transparent
+syn match IsabelleSpecial /\\<close>/ conceal cchar=› transparent
+syn match IsabelleSpecial /\\<comment>/ conceal cchar=— transparent
 
-syn cluster IsabelleInnerStuff contains=IsabelleSpecial
+syn cluster IsabelleInnerStuff contains=IsabelleSpecial,IsabelleComment
 
 " Enable folding of proofs and locales. Note that the starting regex needs to
 " match with zero width to preserve syntax highlighting of the opening command.


### PR DESCRIPTION
This adds Vim syntax highlighting for the newer `— ‹ ... ›` style marginal comments. It could do with a bit of improvement, as the escape sequences aren't properly concealed even at `conceallevel=2`. I tried meddling with `hs` and `ms` on the region start but the best I could manage was conceal only if the comment was not preceded by the start of the line, which seemed worse. If any reader has greater Vim fu and knows how to do this, please feel free to amend.

Is there any interest in upstreaming this into Vim? It probably needs some review from the Vim maintainers, but they're generally pretty accepting of new syntax highlighting.