### PR TITLE
mcs: strengthen typ_at_lifts

### DIFF
--- a/lib/NonDetMonadLemmaBucket.thy
+++ b/lib/NonDetMonadLemmaBucket.thy
@@ -1532,17 +1532,11 @@ lemma valid_case_option_post_wp:
   by (cases ep, simp_all add: hoare_vcg_prop)
 
 lemma P_bool_lift:
-  assumes t: "\<lbrace>Q\<rbrace> f \<lbrace>\<lambda>r. Q\<rbrace>"
-  assumes f: "\<lbrace>\<lambda>s. \<not>Q s\<rbrace> f \<lbrace>\<lambda>r s. \<not>Q s\<rbrace>"
+  assumes t: "P = id \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>\<lambda>r. Q\<rbrace>"
+  assumes f: "P = Not \<Longrightarrow> \<lbrace>\<lambda>s. \<not>Q s\<rbrace> f \<lbrace>\<lambda>r s. \<not>Q s\<rbrace>"
   shows "\<lbrace>\<lambda>s. P (Q s)\<rbrace> f \<lbrace>\<lambda>r s. P (Q s)\<rbrace>"
-  apply (clarsimp simp: valid_def)
-  apply (subgoal_tac "Q b = Q s")
-   apply simp
-  apply (rule iffI)
-   apply (rule classical)
-   apply (drule (1) use_valid [OF _ f])
-   apply simp
-  apply (erule (1) use_valid [OF _ t])
+  apply (cases P rule: bool_to_bool_cases)
+     apply (wpsimp wp: t f simp: id_def)+
   done
 
 lemma fail_inv :

--- a/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
@@ -1719,17 +1719,9 @@ lemmas set_vm_root_typ_ats [wp] = abs_typ_at_lifts [OF set_vm_root_typ_at]
 lemma valid_pte_lift3:
   assumes x: "(\<And>P T p. \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>)"
   shows "\<lbrace>\<lambda>s. P (valid_pte pte s)\<rbrace> f \<lbrace>\<lambda>rv s. P (valid_pte pte s)\<rbrace>"
-  apply (insert bool_function_four_cases[where f=P])
-  apply (erule disjE)
-   apply (cases pte)
-     apply (simp add: data_at_def | wp hoare_vcg_const_imp_lift x)+
-  apply (erule disjE)
-   apply (cases pte)
-     apply (simp add: data_at_def | wp hoare_vcg_disj_lift hoare_vcg_const_imp_lift x)+
-  apply (erule disjE)
-   apply (simp | wp)+
+  apply (cases P rule: bool_to_bool_cases; wpsimp; cases pte)
+       apply (wpsimp simp:data_at_def wp: hoare_vcg_disj_lift hoare_vcg_const_imp_lift x)+
   done
-
 
 lemma set_cap_valid_pte_stronger:
   "\<lbrace>\<lambda>s. P (valid_pte pte s)\<rbrace> set_cap cap p \<lbrace>\<lambda>rv s. P (valid_pte pte s)\<rbrace>"

--- a/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
@@ -2724,15 +2724,8 @@ lemmas set_vm_root_typ_ats [wp] = abs_typ_at_lifts [OF set_vm_root_typ_at]
 lemma valid_pte_lift3:
   assumes x: "(\<And>P T p. \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>)"
   shows "\<lbrace>\<lambda>s. P (valid_pte pte s)\<rbrace> f \<lbrace>\<lambda>rv s. P (valid_pte pte s)\<rbrace>"
-  apply (insert bool_function_four_cases[where f=P])
-  apply (erule disjE)
-   apply (cases pte)
-     apply (simp add: data_at_def | wp hoare_vcg_const_imp_lift x)+
-  apply (erule disjE)
-   apply (cases pte)
-     apply (simp add: data_at_def | wp hoare_vcg_disj_lift hoare_vcg_const_imp_lift x)+
-  apply (erule disjE)
-   apply (simp | wp)+
+  apply (cases P rule: bool_to_bool_cases; wpsimp; cases pte)
+       apply (wpsimp simp:data_at_def wp: hoare_vcg_disj_lift hoare_vcg_const_imp_lift x)+
   done
 
 

--- a/proof/invariant-abstract/RISCV64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchVSpace_AI.thy
@@ -306,15 +306,8 @@ lemmas set_vm_root_typ_ats [wp] = abs_typ_at_lifts [OF set_vm_root_typ_at]
 lemma valid_pte_lift3:
   assumes x: "(\<And>P T p. \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>)"
   shows "\<lbrace>\<lambda>s. P (valid_pte level pte s)\<rbrace> f \<lbrace>\<lambda>rv s. P (valid_pte level pte s)\<rbrace>"
-  apply (insert bool_function_four_cases[where f=P])
-  apply (erule disjE)
-   apply (cases pte)
-     apply (simp add: data_at_def | wp hoare_vcg_const_imp_lift hoare_vcg_disj_lift x)+
-  apply (erule disjE)
-   apply (cases pte)
-     apply (simp add: data_at_def | wp hoare_vcg_disj_lift hoare_vcg_const_imp_lift x)+
-  apply (erule disjE)
-   apply (simp | wp)+
+  apply (cases P rule: bool_to_bool_cases; wpsimp; cases pte)
+       apply (wpsimp simp:data_at_def wp: hoare_vcg_disj_lift hoare_vcg_const_imp_lift x)+
   done
 
 

--- a/proof/invariant-abstract/VSpacePre_AI.thy
+++ b/proof/invariant-abstract/VSpacePre_AI.thy
@@ -70,10 +70,6 @@ lemma invs_valid_irq_states[elim!]:
   "invs s \<Longrightarrow> valid_irq_states s"
   by(auto simp: invs_def valid_state_def)
 
-lemma bool_function_four_cases:
-  "f = Not \<or> f = id \<or> f = (\<lambda>_. True) \<or> f = (\<lambda>_. False)"
-  by (auto simp add: fun_eq_iff all_bool_eq)
-
 lemma uint_ucast:
   "(x :: ('a :: len) word) < 2 ^ len_of TYPE ('b)
     \<Longrightarrow> uint (ucast x :: ('b :: len) word) = uint x"

--- a/proof/invariant-abstract/X64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/X64/ArchVSpace_AI.thy
@@ -963,15 +963,8 @@ lemmas set_vm_root_typ_ats [wp] = abs_typ_at_lifts [OF set_vm_root_typ_at]
 lemma valid_pte_lift3:
   assumes x: "(\<And>P T p. \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>)"
   shows "\<lbrace>\<lambda>s. P (valid_pte pte s)\<rbrace> f \<lbrace>\<lambda>rv s. P (valid_pte pte s)\<rbrace>"
-  apply (insert bool_function_four_cases[where f=P])
-  apply (erule disjE)
-   apply (cases pte)
-     apply (simp add: data_at_def | wp hoare_vcg_const_imp_lift x)+
-  apply (erule disjE)
-   apply (cases pte)
-     apply (simp add: data_at_def | wp hoare_vcg_disj_lift hoare_vcg_const_imp_lift x)+
-  apply (erule disjE)
-   apply (simp | wp)+
+  apply (cases P rule: bool_to_bool_cases; wpsimp; cases pte)
+     apply (wpsimp simp:data_at_def wp: hoare_vcg_disj_lift hoare_vcg_const_imp_lift x)+
   done
 
 lemma set_cap_valid_pte_stronger:
@@ -981,15 +974,8 @@ lemma set_cap_valid_pte_stronger:
 lemma valid_pde_lift3:
   assumes x: "(\<And>P T p. \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>)"
   shows "\<lbrace>\<lambda>s. P (valid_pde pde s)\<rbrace> f \<lbrace>\<lambda>rv s. P (valid_pde pde s)\<rbrace>"
-  apply (insert bool_function_four_cases[where f=P])
-  apply (erule disjE)
-   apply (cases pde)
-     apply (simp add: data_at_def | wp hoare_vcg_const_imp_lift x)+
-  apply (erule disjE)
-   apply (cases pde)
-     apply (simp add: data_at_def | wp hoare_vcg_disj_lift hoare_vcg_const_imp_lift x)+
-  apply (erule disjE)
-   apply (simp | wp)+
+  apply (cases P rule: bool_to_bool_cases; wpsimp; cases pde)
+       apply (wpsimp simp:data_at_def wp: hoare_vcg_disj_lift hoare_vcg_const_imp_lift x)+
   done
 
 lemma set_cap_valid_pde_stronger:
@@ -999,15 +985,8 @@ lemma set_cap_valid_pde_stronger:
 lemma valid_pdpte_lift3:
   assumes x: "(\<And>P T p. \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>)"
   shows "\<lbrace>\<lambda>s. P (valid_pdpte pdpte s)\<rbrace> f \<lbrace>\<lambda>rv s. P (valid_pdpte pdpte s)\<rbrace>"
-  apply (insert bool_function_four_cases[where f=P])
-  apply (erule disjE)
-   apply (cases pdpte)
-     apply (simp add: data_at_def | wp hoare_vcg_const_imp_lift x)+
-  apply (erule disjE)
-   apply (cases pdpte)
-     apply (simp add: data_at_def | wp hoare_vcg_disj_lift hoare_vcg_const_imp_lift x)+
-  apply (erule disjE)
-   apply (simp | wp)+
+  apply (cases P rule: bool_to_bool_cases; wpsimp; cases pdpte)
+       apply (wpsimp simp:data_at_def wp: hoare_vcg_disj_lift hoare_vcg_const_imp_lift x)+
   done
 
 lemma set_cap_valid_pdpte_stronger:

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -2596,48 +2596,66 @@ proof -
                         ko_wp_at'_def objBits_simps' P Q conj_comms cte_level_bits_def)
 qed
 
-lemma typ_at_lift_tcb':
-  "\<lbrace>typ_at' TCBT p\<rbrace> f \<lbrace>\<lambda>_. typ_at' TCBT p\<rbrace> \<Longrightarrow> \<lbrace>tcb_at' p\<rbrace> f \<lbrace>\<lambda>_. tcb_at' p\<rbrace>"
+lemma typ_at_lift_tcb'_strong:
+  "f \<lbrace>\<lambda>s. P (typ_at' TCBT p s)\<rbrace> \<Longrightarrow> f \<lbrace>\<lambda>s. P (tcb_at' p s)\<rbrace>"
   by (simp add: typ_at_tcb')
 
-lemma typ_at_lift_ep':
-  "\<lbrace>typ_at' EndpointT p\<rbrace> f \<lbrace>\<lambda>_. typ_at' EndpointT p\<rbrace> \<Longrightarrow> \<lbrace>ep_at' p\<rbrace> f \<lbrace>\<lambda>_. ep_at' p\<rbrace>"
+lemma typ_at_lift_ep'_strong:
+  "f \<lbrace>\<lambda>s. P (typ_at' EndpointT p s)\<rbrace> \<Longrightarrow> f \<lbrace>\<lambda>s. P (ep_at' p s)\<rbrace>"
   by (simp add: typ_at_ep)
 
-lemma typ_at_lift_ntfn':
-  "\<lbrace>typ_at' NotificationT p\<rbrace> f \<lbrace>\<lambda>_. typ_at' NotificationT p\<rbrace> \<Longrightarrow> \<lbrace>ntfn_at' p\<rbrace> f \<lbrace>\<lambda>_. ntfn_at' p\<rbrace>"
+lemma typ_at_lift_ntfn'_strong:
+  "f \<lbrace>\<lambda>s. P (typ_at' NotificationT p s)\<rbrace> \<Longrightarrow> f \<lbrace>\<lambda>s. P (ntfn_at' p s)\<rbrace>"
   by (simp add: typ_at_ntfn)
 
-lemma typ_at_lift_cte':
-  "\<lbrace>typ_at' CTET p\<rbrace> f \<lbrace>\<lambda>_. typ_at' CTET p\<rbrace> \<Longrightarrow> \<lbrace>real_cte_at' p\<rbrace> f \<lbrace>\<lambda>_. real_cte_at' p\<rbrace>"
+lemma typ_at_lift_cte'_strong:
+  "f \<lbrace>\<lambda>s. P (typ_at' CTET p s)\<rbrace> \<Longrightarrow> f \<lbrace>\<lambda>s. P (real_cte_at' p s)\<rbrace>"
   by (simp add: typ_at_cte)
 
-lemma typ_at_lift_sc':
-  "f \<lbrace>typ_at' SchedContextT p\<rbrace> \<Longrightarrow> f \<lbrace>sc_at' p\<rbrace>"
+lemma typ_at_lift_sc'_strong:
+  "f \<lbrace>\<lambda>s. P (typ_at' SchedContextT p s)\<rbrace> \<Longrightarrow> f \<lbrace>\<lambda>s. P (sc_at' p s)\<rbrace>"
   by (simp add: typ_ats')
 
-lemma typ_at_lift_reply':
-  "f \<lbrace>typ_at' ReplyT p\<rbrace> \<Longrightarrow> f \<lbrace>reply_at' p\<rbrace>"
+lemma typ_at_lift_reply'_strong:
+  "f \<lbrace>\<lambda>s. P (typ_at' ReplyT p s)\<rbrace> \<Longrightarrow> f \<lbrace>\<lambda>s. P (reply_at' p s)\<rbrace>"
   by (simp add: typ_ats')
 
 lemma typ_at_lift_cte_at':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows      "\<lbrace>cte_at' c\<rbrace> f \<lbrace>\<lambda>rv. cte_at' c\<rbrace>"
+  assumes x: "\<And>P T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  shows      "f \<lbrace>\<lambda>s. P (cte_at' c s)\<rbrace>"
   apply (simp only: cte_at_typ')
-  apply (wp hoare_vcg_disj_lift hoare_vcg_ex_lift x)
+  apply (rule P_bool_lift[where P=P])
+   apply (wpsimp wp: hoare_vcg_disj_lift hoare_vcg_ex_lift hoare_vcg_all_lift x)+
   done
 
-lemma typ_at_lift_page_directory_at':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows      "\<lbrace>page_directory_at' p\<rbrace> f \<lbrace>\<lambda>rv. page_directory_at' p\<rbrace>"
+lemma typ_at_lift_page_directory_at'_strong:
+  assumes x: "\<And>p. f \<lbrace>\<lambda>s. P (typ_at' (ArchT PDET) p s)\<rbrace>"
+  shows      "f \<lbrace>\<lambda>s. P (page_directory_at' p s)\<rbrace>"
   unfolding page_directory_at'_def All_less_Ball
-  by (wp hoare_vcg_const_Ball_lift x)
+  using x
+  apply -
+  apply (rule P_bool_lift[where P=P])
+  apply (wpsimp wp: hoare_vcg_const_Ball_lift hoare_vcg_bex_lift hoare_vcg_imp_lift
+         | fastforce)+
+  done
 
-lemma typ_at_lift_page_table_at':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows      "\<lbrace>page_table_at' p\<rbrace> f \<lbrace>\<lambda>rv. page_table_at' p\<rbrace>"
+lemma typ_at_lift_page_table_at'_strong:
+  assumes x: "\<And>p. f \<lbrace>\<lambda>s. P (typ_at' (ArchT PTET) p s)\<rbrace>"
+  shows      "f \<lbrace>\<lambda>s. P (page_table_at' p s)\<rbrace>"
   unfolding page_table_at'_def All_less_Ball
-  by (wp hoare_vcg_const_Ball_lift x)
+  using x
+  apply -
+  apply (rule P_bool_lift[where P=P])
+  apply (wpsimp wp: hoare_vcg_const_Ball_lift hoare_vcg_bex_lift hoare_vcg_imp_lift
+         | fastforce)+
+  done
+
+lemmas typ_at_lifts_strong =
+  typ_at_lift_tcb'_strong typ_at_lift_ep'_strong
+  typ_at_lift_ntfn'_strong typ_at_lift_cte'_strong
+  typ_at_lift_reply'_strong typ_at_lift_sc'_strong
+  typ_at_lift_page_directory_at'_strong
+  typ_at_lift_page_table_at'_strong
 
 lemma ko_wp_typ_at':
   "ko_wp_at' P p s \<Longrightarrow> \<exists>T. typ_at' T p s"
@@ -2685,44 +2703,44 @@ lemma typ_at_lift_valid_cap':
   apply (simp add: valid_cap'_def)
   apply wp
   apply (case_tac cap;
-         simp add: valid_cap'_def P [where P=id, simplified] typ_at_lift_tcb'
-                   hoare_vcg_prop typ_at_lift_ep' typ_at_lift_reply'
-                   typ_at_lift_ntfn' typ_at_lift_cte_at' typ_at_lift_sc'
-                   hoare_vcg_conj_lift [OF typ_at_lift_cte_at']
-                   hoare_vcg_conj_lift)
+         wpsimp wp: valid_cap'_def P typ_at_lifts_strong
+                    hoare_vcg_prop  typ_at_lift_cte_at'
+                    hoare_vcg_conj_lift [OF typ_at_lift_cte_at']
+                    hoare_vcg_conj_lift)
      apply (rename_tac zombie_type nat)
      apply (case_tac zombie_type; simp)
-      apply (wp typ_at_lift_tcb' P hoare_vcg_all_lift typ_at_lift_cte')+
+      apply (wp typ_at_lifts_strong[where P=id, simplified] P
+                hoare_vcg_all_lift)+
     apply (rename_tac arch_capability)
     apply (case_tac arch_capability,
            simp_all add: P [where P=id, simplified] page_table_at'_def
                          hoare_vcg_prop page_directory_at'_def All_less_Ball
               split del: if_split)
        apply (wp hoare_vcg_const_Ball_lift P typ_at_lift_valid_untyped' sz
-                 hoare_vcg_all_lift typ_at_lift_cte')+
+                 hoare_vcg_all_lift typ_at_lifts_strong)+
   done
 
 lemma typ_at_lift_valid_irq_node':
   assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
   shows      "\<lbrace>valid_irq_node' p\<rbrace> f \<lbrace>\<lambda>_. valid_irq_node' p\<rbrace>"
   apply (simp add: valid_irq_node'_def)
-  apply (wp hoare_vcg_all_lift P typ_at_lift_cte')
+  apply (wp hoare_vcg_all_lift P typ_at_lifts_strong)
   done
 
 lemma valid_pde_lift':
   assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
   shows "\<lbrace>\<lambda>s. valid_pde' pde s\<rbrace> f \<lbrace>\<lambda>rv s. valid_pde' pde s\<rbrace>"
-  by (cases pde) (simp add: valid_mapping'_def|wp x typ_at_lift_page_table_at')+
+  by (cases pde) (simp add: valid_mapping'_def|wp x typ_at_lifts_strong[where P=id])+
 
 lemma valid_pte_lift':
   assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
   shows "\<lbrace>\<lambda>s. valid_pte' pte s\<rbrace> f \<lbrace>\<lambda>rv s. valid_pte' pte s\<rbrace>"
-  by (cases pte) (simp add: valid_mapping'_def|wp x typ_at_lift_page_directory_at')+
+  by (cases pte) (simp add: valid_mapping'_def|wp x typ_at_lifts_strong[where P=id])+
 
 lemma valid_asid_pool_lift':
   assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
   shows "\<lbrace>\<lambda>s. valid_asid_pool' ap s\<rbrace> f \<lbrace>\<lambda>rv s. valid_asid_pool' ap s\<rbrace>"
-  by (cases ap) (simp|wp x typ_at_lift_page_directory_at' hoare_vcg_const_Ball_lift)+
+  by (cases ap) (simp|wp x typ_at_lifts_strong[where P=id] hoare_vcg_const_Ball_lift)+
 
 lemma valid_bound_tcb_lift:
   "(\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>_. typ_at' T p\<rbrace>) \<Longrightarrow>
@@ -2739,12 +2757,44 @@ lemma valid_bound_reply_lift:
   \<lbrace>valid_bound_reply' tcb\<rbrace> f \<lbrace>\<lambda>_. valid_bound_reply' tcb\<rbrace>"
   by (auto simp: valid_bound_tcb'_def valid_def typ_ats'[symmetric] split: option.splits)
 
-lemmas typ_at_lifts = typ_at_lift_tcb' typ_at_lift_ep'
-                      typ_at_lift_ntfn' typ_at_lift_cte'
-                      typ_at_lift_reply' typ_at_lift_sc'
+context begin
+\<comment>\<open>
+  We're using @{command ML_goal} here because there are two useful formulations
+  of typ_at lifting lemmas and we do not want to write all of the possibilities
+  out by hand. If we use typ_at_lift_tcb' as an example, then the first is
+  @{term "\<lbrace>\<lambda>s. P (typ_at' TCBT p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' TCBT p s)\<rbrace>
+          \<Longrightarrow> \<lbrace>\<lambda>s. P (tcb_at' p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (tcb_at' p s)\<rbrace>"} and the second is
+  @{term "(\<And>P. \<lbrace>\<lambda>s. P (typ_at' TCBT p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' TCBT p s)\<rbrace>)
+          \<Longrightarrow> \<lbrace>\<lambda>s. P (tcb_at' p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (tcb_at' p s)\<rbrace>"}.
+  The first form is stronger, and therefore preferred for backward reasoning
+  using rule. However, since the P in the premise is free in the first form,
+  forward unification using the OF attribute produces flex-flex pairs which
+  causes problems. The second form avoids the unification issue by demanding
+  that there is a P that is free in the lemma supplied to the OF attribute.
+  However, it can only be applied if @{term f} preserves both
+  @{term "typ_at' TCBT p s"} and @{term "\<not> typ_at' TCBT p s"}.
+  The following @{command ML_goal} generates lemmas of the second form based on
+  the previously proven stronger lemmas of the first form.
+\<close>
+ML \<open>
+local
+  val strong_thms = @{thms typ_at_lifts_strong[no_vars]};
+  fun abstract_P term = Logic.all (Free ("P", @{typ "bool \<Rightarrow> bool"})) term
+  fun abstract thm =
+    @{const Pure.imp} $
+      abstract_P (hd (Thm.prems_of thm)) $
+      Thm.concl_of thm
+in
+  val typ_at_lifts_internal_goals = List.map abstract strong_thms
+end
+\<close>
+
+private ML_goal typ_at_lifts_internal:
+  \<open>typ_at_lifts_internal_goals\<close>
+  by (auto simp: typ_at_lifts_strong)
+
+lemmas typ_at_lifts = typ_at_lifts_internal
                       typ_at_lift_cte_at'
-                      typ_at_lift_page_table_at'
-                      typ_at_lift_page_directory_at'
                       typ_at_lift_valid_untyped'
                       typ_at_lift_valid_cap'
                       valid_pde_lift'
@@ -2753,6 +2803,7 @@ lemmas typ_at_lifts = typ_at_lift_tcb' typ_at_lift_ep'
                       valid_bound_tcb_lift
                       valid_bound_reply_lift
                       valid_bound_sc_lift
+end
 
 lemma mdb_next_unfold:
   "s \<turnstile> c \<leadsto> c' = (\<exists>z. s c = Some z \<and> c' = mdbNext (cteMDBNode z))"

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -718,8 +718,9 @@ lemma cur_thread_update_corres:
   apply (simp add: state_relation_def swp_def)
   done
 
-lemma arch_switch_thread_tcb_at' [wp]: "\<lbrace>tcb_at' t\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
-  by (unfold ARM_H.switchToThread_def, wp typ_at_lift_tcb')
+lemma arch_switch_thread_tcb_at' [wp]:
+  "Arch.switchToThread t \<lbrace>\<lambda>s. P (tcb_at' t s)\<rbrace>"
+  by (unfold ARM_H.switchToThread_def, wp typ_at_lifts)
 
 crunch typ_at'[wp]: "switchToThread" "\<lambda>s. P (typ_at' T p s)"
   (ignore: clearExMonitor)

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -460,7 +460,7 @@ lemmas threadSet_corres_noop_split =
     threadSet_corres_noop_splitT [OF _ all_tcbI, OF _ ball_tcb_cte_casesI]
 
 lemma threadSet_tcb' [wp]:
-  "\<lbrace>tcb_at' t\<rbrace> threadSet f t' \<lbrace>\<lambda>rv. tcb_at' t\<rbrace>"
+  "threadSet f t' \<lbrace>\<lambda>s. P (tcb_at' t s)\<rbrace>"
   by (wpsimp simp: threadSet_def)
 
 (* The function "thread_set f p" updates a TCB at p using function f.
@@ -1185,7 +1185,7 @@ proof -
      apply (frule_tac P=P' and Q="\<lambda>tcb. \<not> P' tcb" in pred_tcb_at_conj')
      apply (clarsimp)+
     apply (wp hoare_convert_imp pos)
-    apply (clarsimp simp: typ_at_tcb' [symmetric] pred_tcb_at'_def not_obj_at'
+    apply (clarsimp simp: tcb_at_typ_at' pred_tcb_at'_def not_obj_at'
                    elim!: obj_at'_weakenE)
     done
 qed


### PR DESCRIPTION
This extends typ_at_lifts to also handle the negated versions. As part of this it produces two different formulations of the lifting lemmas, using ML_goal instead of manually duplicating all of them.