### PR TITLE
[MCS] revert notification binding changes

### DIFF
--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -642,7 +642,7 @@ lemma handle_invocation_domain_time_inv[wp]:
      (clarsimp simp: word_gt_0)
 
 crunch domain_time_inv[wp]: receive_ipc,lookup_reply "\<lambda>s::det_state. P (domain_time s)"
-  (wp: hoare_drop_imp)
+  (wp: crunch_wps simp: crunch_simps)
 
 crunch domain_time_inv[wp]: receive_signal "\<lambda>s::det_state. P (domain_time s)"
   (wp: hoare_drop_imp hoare_vcg_if_lift2)

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -1241,6 +1241,9 @@ lemma lookup_reply_ex_cap[wp]:
   apply (wpsimp wp: hoare_drop_imps)
   done
 
+crunches lookup_reply
+  for cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
+
 lemma hw_invs[wp]:
   "\<lbrace>invs and ct_active\<rbrace>
      handle_recv is_blocking can_reply

--- a/spec/abstract/Ipc_A.thy
+++ b/spec/abstract/Ipc_A.thy
@@ -376,7 +376,8 @@ where
      if ntfnptr \<noteq> None \<and> isActive ntfn
      then
        complete_signal (the ntfnptr) thread
-     else
+     else do
+       when (ntfnptr \<noteq> None \<and> is_blocking) $ maybe_return_sc (the ntfnptr) thread;
        case ep
          of IdleEP \<Rightarrow> (case is_blocking of
               True \<Rightarrow> do
@@ -425,6 +426,7 @@ where
               \<^cancel>\<open>FIXME RT: the C code has a test here for (refiil_sufficient sender'sc \<or> sender's sc is None)\<close>
               od
             od
+     od
    od"
 
 section \<open>Asynchronous Message Transfers\<close>

--- a/spec/abstract/SchedContext_A.thy
+++ b/spec/abstract/SchedContext_A.thy
@@ -423,7 +423,9 @@ where
     when (nsc_opt = tsc_opt \<and> nsc_opt \<noteq> None) $ do
       sc_ptr \<leftarrow> assert_opt nsc_opt;
       set_tcb_obj_ref tcb_sched_context_update tcb_ptr None;
-      set_sc_obj_ref sc_tcb_update sc_ptr None
+      set_sc_obj_ref sc_tcb_update sc_ptr None;
+      ct \<leftarrow> gets cur_thread;
+      when (tcb_ptr = ct) reschedule_required
     od
   od"
 

--- a/spec/haskell/src/SEL4/Kernel/Thread.lhs
+++ b/spec/haskell/src/SEL4/Kernel/Thread.lhs
@@ -356,7 +356,7 @@ We check here that the candidate has the highest priority in the system.
 >
 >             idleThread <- getIdleThread
 >             targetPrio <- threadGet tcbPriority candidate
->             curPrio <- threadGet tcbPriority curThread
+>             curPrio <- if (idleThread == curThread) then (return 0) else (threadGet tcbPriority curThread)
 >             fastfail <- scheduleSwitchThreadFastfail curThread idleThread curPrio targetPrio
 >
 >             curDom <- curDomain

--- a/spec/haskell/src/SEL4/Kernel/Thread.lhs
+++ b/spec/haskell/src/SEL4/Kernel/Thread.lhs
@@ -356,7 +356,7 @@ We check here that the candidate has the highest priority in the system.
 >
 >             idleThread <- getIdleThread
 >             targetPrio <- threadGet tcbPriority candidate
->             curPrio <- if (idleThread == curThread) then (return 0) else (threadGet tcbPriority curThread)
+>             curPrio <- if idleThread == curThread then return 0 else threadGet tcbPriority curThread
 >             fastfail <- scheduleSwitchThreadFastfail curThread idleThread curPrio targetPrio
 >
 >             curDom <- curDomain

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -686,6 +686,8 @@ This module uses the C preprocessor to select a target architecture.
 >         scPtr <- return $ fromJust nscOpt
 >         sc <- getSchedContext scPtr
 >         setSchedContext scPtr (sc { scTCB = Nothing })
+>         cur <- getCurThread
+>         when (tcbPtr == cur) rescheduleRequired
 
 > tcbReleaseEnqueue :: PPtr TCB -> Kernel ()
 > tcbReleaseEnqueue tcbPtr = do


### PR DESCRIPTION
This PR updates the aspec, ainvs, haskell, and refine proofs to properly re-sync the `rt` branch with `master` with respect to `maybe_return_sc`: both in its contents, and where it is called.

