### PR TITLE
sc replies relation

### DIFF
--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -1868,7 +1868,7 @@ lemma updateCap_stuff:
          (ksArchState s'' = ksArchState s') \<and>
          (pspace_aligned' s' \<longrightarrow> pspace_aligned' s'') \<and>
          (pspace_distinct' s' \<longrightarrow> pspace_distinct' s'') \<and>
-         replyNexts_of s'' = replyNexts_of s' \<and>
+         replyPrevs_of s'' = replyPrevs_of s' \<and>
          scReplies_of s'' = scReplies_of s' \<and>
          ksConsumedTime s'' = ksConsumedTime s' \<and>
          ksCurTime s'' = ksCurTime s' \<and>
@@ -2498,7 +2498,7 @@ lemma updateMDB_the_lot:
          ksCurTime s''        = ksCurTime s' \<and>
          ksCurSc s''          = ksCurSc s' \<and>
          ksReprogramTimer s'' = ksReprogramTimer s' \<and>
-         replyNexts_of s'' = replyNexts_of s' \<and>
+         replyPrevs_of s'' = replyPrevs_of s' \<and>
          scReplies_of s'' = scReplies_of s'"
   using assms
   apply (simp add: updateMDB_eqs updateMDB_pspace_relation split del: if_split)
@@ -4948,7 +4948,7 @@ lemma updateMDB_the_lot':
          ksCurTime s''        = ksCurTime s' \<and>
          ksCurSc s''          = ksCurSc s' \<and>
          ksReprogramTimer s'' = ksReprogramTimer s' \<and>
-         replyNexts_of s'' = replyNexts_of s' \<and>
+         replyPrevs_of s'' = replyPrevs_of s' \<and>
          scReplies_of s'' = scReplies_of s'"
   by (rule updateMDB_the_lot; fastforce intro: assms)
 

--- a/proof/refine/ARM/CSpace_R.thy
+++ b/proof/refine/ARM/CSpace_R.thy
@@ -3620,7 +3620,7 @@ lemma corres_caps_decomposition:
               \<Longrightarrow> cdt_relation ((\<noteq>) None \<circ> new_caps s) (new_mdb s) (new_ctes s')
                   \<and> cdt_list_relation (new_list s) (new_mdb s) (new_ctes s')
                   \<and> sc_replies_relation_2 (new_sc_replies_of s) (new_scs_of' s' |> scReply)
-                      (new_replies_of' s' |> replyNext_of)
+                      (new_replies_of' s' |> replyPrev)
                   \<and> release_queue_relation (new_release_queue s) (new_ksReleaseQueue s')
                   \<and> sched_act_relation (new_action s) (new_sa' s')
                   \<and> ready_queues_relation (new_queues s) (new_rqs' s')

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -847,11 +847,11 @@ lemma freeMemory_deletionIsSafe[wp]:
   apply (clarsimp simp: deletionIsSafe_def)
   done
 
-lemma detype_ReplyNexts_of:
+lemma detype_ReplyPrevs_of:
   "\<lbrakk>pspace_aligned' s'; pspace_distinct' s'; \<forall>p. p \<in> S \<longrightarrow> \<not> ko_wp_at' live' p s'\<rbrakk>
-   \<Longrightarrow> ((\<lambda>x. if x \<in> S then None else ksPSpace s' x) |> reply_of' |> replyNext_of)
-       = replyNexts_of s'"
-  apply (prop_tac "\<And>p reply_ptr. (replyNexts_of s' p = Some reply_ptr) \<Longrightarrow> p \<notin> S")
+   \<Longrightarrow> ((\<lambda>x. if x \<in> S then None else ksPSpace s' x) |> reply_of' |> replyPrev)
+       = replyPrevs_of s'"
+  apply (prop_tac "\<And>p reply_ptr. (replyPrevs_of s' p = Some reply_ptr) \<Longrightarrow> p \<notin> S")
    apply (clarsimp simp: opt_map_def split: option.splits)
    apply (drule_tac x=p in spec)
    apply (clarsimp simp: ko_wp_at'_def pred_neg_def live'_def projectKOs live_reply'_def
@@ -869,9 +869,9 @@ lemma detype_sc_replies_relation:
                          ((\<lambda>x. if lower \<le> x \<and> x \<le> upper
                                then None else ksPSpace s' x) |> sc_of' |> scReply)
                          ((\<lambda>x. if lower \<le> x \<and> x \<le> upper
-                               then None else ksPSpace s' x) |> reply_of' |> replyNext_of)"
+                               then None else ksPSpace s' x) |> reply_of' |> replyPrev)"
   apply (clarsimp simp: sc_replies_relation_def detype_def)
-  apply (frule detype_ReplyNexts_of[where S="{lower..upper}"]; simp)
+  apply (frule detype_ReplyPrevs_of[where S="{lower..upper}"]; simp)
   apply (clarsimp simp: vs_all_heap_simps opt_map_def in_opt_map_eq
                  split: if_splits Structures_A.kernel_object.splits)
   done

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -217,6 +217,9 @@ abbreviation replies_of' :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> re
 abbreviation replyNexts_of :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> obj_ref option" where
   "replyNexts_of s \<equiv> replies_of' s |> replyNext_of"
 
+abbreviation replyPrevs_of :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> obj_ref option" where
+  "replyPrevs_of s \<equiv> replies_of' s |> replyPrev"
+
 abbreviation sc_of' :: "kernel_object \<Rightarrow> sched_context option" where
   "sc_of' \<equiv> projectKO_opt"
 

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -184,7 +184,7 @@ lemma setReplyTCB_corres:
     apply (rule corres_split[OF _ get_reply_corres])
       apply (rule set_reply_corres)
       apply (simp add: reply_relation_def)
-  by (wpsimp simp: obj_at'_def replyNext_same_def)+
+  by (wpsimp simp: obj_at'_def replyPrev_same_def)+
 
 defs replyUnlink_assertion_def:
   "replyUnlink_assertion

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -1236,7 +1236,7 @@ proof -
     done
 qed
 
-lemma retype_replyNexts_of:
+lemma retype_replyPrevs_of:
   assumes  pr: "pspace_relation (kheap s) (ksPSpace s')"
       and  vs: "valid_pspace s" "valid_mdb s"
       and vs': "pspace_aligned' s'" "pspace_distinct' s'"
@@ -1248,9 +1248,9 @@ lemma retype_replyNexts_of:
       and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
       and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
-  "replyNexts_of
+  "replyPrevs_of
      (s'\<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s')\<rparr>)
-    = replyNexts_of s'" (is "replyNexts_of ?ps' = replyNexts_of s'")
+    = replyPrevs_of s'" (is "replyPrevs_of ?ps' = replyPrevs_of s'")
 proof -
   note dom_same' = retype_ksPSpace_dom_same[OF vs' pn' ko tysc cover num_r]
   show ?thesis
@@ -1312,7 +1312,7 @@ proof -
      apply (simp add: obj_relation_retype_addrs_eq[OF not_unt tysc num_r orr cover,symmetric])
     apply (clarsimp simp: scs_of_kh_def opt_map_Some sc_of_def sc_replies_of_scs_def map_project_Some)
     apply (fold foldr_upd_app_if[folded data_map_insert_def])
-    apply (simp only: retype_replyNexts_of[OF pr vs vs' pn pn' ko tysc cover orr num_r, simplified])
+    apply (simp only: retype_replyPrevs_of[OF pr vs vs' pn pn' ko tysc cover orr num_r, simplified])
     apply (clarsimp simp: pspace_relation_def)
     apply (drule_tac x=p in bspec, fastforce)
     apply (prop_tac "p \<in> dom (ksPSpace s')")
@@ -1565,7 +1565,7 @@ lemma retype_state_relation:
 
   thus
     "sc_replies_relation_2 (sc_replies_of_kh ?ps) (?ps' |> sc_of' |> scReply)
-                                                     (?ps' |> reply_of' |> replyNext_of)"
+                                                     (?ps' |> reply_of' |> replyPrev)"
     using retype_sc_replies_relation [OF _ pspr vs vs' pn pn' ko tysc cover orr num_r]
     by clarsimp
 qed


### PR DESCRIPTION
This commits flips the traversal direction of `sc_replies_relation`, to follow the `replyPrev` links instead of the `replyNext` links.

This means that we have the following:
- `reply_relation reply reply'` gives `reply_sc reply = replySc reply’”
- `sc_replies_relation s s'` gives 1)`hd (sc_replies sc) = scReply sc’`; and 2) `sc_replies sc` equals to the `replyPrev` traversal of the linked list starting from `scReply sc’`
- we need `sym_refs (list_refs_of_replies’ s') to know that the `replyNext` traversal matches the `replyPrev` traversal

This is a minimal and necessary change to `sc_replies_relation` (meaning this should be merged). 

There is also a question of whether it helps or makes it more painful to include the “Next” traversal in the relation or not. My plan is to experiment a bit more as I continue working on `reply_remove_tcb`, and it should go into a separate PR if there should be a further change. 