### PR TITLE
Add tcb arg to replyUnlink etc.

### DIFF
--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -2907,7 +2907,7 @@ lemmas setThreadState_st_tcb_at_simplish
     = setThreadState_st_tcb_at_simplish'[unfolded pred_disj_def]
 
 lemma replyUnlink_st_tcb_at_simplish:
-  "replyUnlink r \<lbrace>st_tcb_at' (\<lambda>st. P st \<or> simple' st) t\<rbrace>"
+  "replyUnlink r t' \<lbrace>st_tcb_at' (\<lambda>st. P st \<or> simple' st) t\<rbrace>"
   supply if_split [split del]
   unfolding replyUnlink_def
   apply (wpsimp wp: sts_st_tcb' hoare_vcg_if_lift2 hoare_vcg_imp_lift' gts_wp'

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -63,8 +63,7 @@ end
 lemma cancelIPC_simple[wp]:
   "\<lbrace>\<top>\<rbrace> cancelIPC t \<lbrace>\<lambda>rv. st_tcb_at' simple' t\<rbrace>"
   unfolding cancelIPC_def
-  apply (wpsimp wp: setThreadState_st_tcb replyRemoveTCB_st_tcb_at'_Inactive cancelSignal_simple
-                    replyUnlink_st_tcb_at'_wp set_reply'.set_wp gts_wp' threadSet_wp
+  apply (wpsimp wp: setThreadState_st_tcb gts_wp' threadSet_wp
               simp: Let_def tcb_obj_at'_pred_tcb'_set_obj'_iff)
   apply (clarsimp simp: st_tcb_at'_def o_def obj_at'_def isBlockedOnReply_def)
   done
@@ -112,6 +111,7 @@ lemma cancelSignal_st_tcb_at':
                     hoare_drop_imp[where R="\<lambda>rv _. \<exists>a b. delete t (f rv) = a # b" for f])
   done
 
+(* FIXME RT: Michael to fix and use in his next PR
 lemma cancelIPC_simple'_not_awaiting_reply:
   "\<lbrace>\<lambda>s. sym_refs (state_refs_of' s)\<rbrace>
    cancelIPC t
@@ -129,7 +129,7 @@ lemma cancelIPC_simple'_not_awaiting_reply:
    apply (frule(1) sym_ref_Receive_or_Reply_replyTCB', fast)
    apply (clarsimp simp: obj_at'_def projectKO_eq project_inject)
   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def)
-  done
+  done*)
 
 context begin interpretation Arch .
 crunch typ_at'[wp]: emptySlot "\<lambda>s. P (typ_at' T p s)"
@@ -165,7 +165,7 @@ lemma gts_wf''[wp]:
 
 lemma replyUnlink_valid_objs':
   "\<lbrace>valid_objs'\<rbrace>
-   replyUnlink rptr
+   replyUnlink rptr tptr
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   apply (clarsimp simp: replyUnlink_def setReplyTCB_def getReplyTCB_def liftM_def)
   apply (wpsimp wp: set_reply_valid_objs' hoare_vcg_all_lift gts_wp'
@@ -198,7 +198,7 @@ lemma reply_unlink_tcb_corres:
      (valid_objs and pspace_aligned and pspace_distinct
        and st_tcb_at ((=) st) t and reply_tcb_reply_at ((=) (Some t)) rp)
           (valid_objs' and valid_release_queue_iff)
-        (reply_unlink_tcb t rp) (replyUnlink rp)" (is "_ \<Longrightarrow> corres _ _ ?conc_guard _ _")
+        (reply_unlink_tcb t rp) (replyUnlink rp t)" (is "_ \<Longrightarrow> corres _ _ ?conc_guard _ _")
   apply (rule_tac Q="?conc_guard
               and st_tcb_at' (\<lambda>st. st = BlockedOnReceive ep (receiver_can_grant pl) (Some rp)
                                  \<or> st = BlockedOnReply (Some rp)) t" in corres_cross_over_guard)
@@ -253,7 +253,7 @@ lemma blocked_cancel_ipc_corres:
                else
                  return $ epQueue_update (%_. (remove1 t (epQueue ep))) ep;
                y \<leftarrow> setEndpoint epPtr ep';
-               case reply_opt of None \<Rightarrow> return () | Some reply \<Rightarrow> replyUnlink reply;
+               case reply_opt of None \<Rightarrow> return () | Some reply \<Rightarrow> replyUnlink reply t;
                setThreadState Structures_H.thread_state.Inactive t
             od)" (is "\<lbrakk> _ ; _ ; _ \<rbrakk> \<Longrightarrow> corres _ (?abs_guard and _) (?conc_guard and _) _ _")
   apply (simp add: blocked_cancel_ipc_def gbep_ret)
@@ -845,7 +845,7 @@ crunches setReply, setSchedContext
   (simp: crunch_simps sch_act_simple_def wp: crunch_wps)
 
 lemma replyUnlink_sch_act_simple[wp]:
-  "replyUnlink t' \<lbrace>sch_act_simple\<rbrace>"
+  "replyUnlink r t' \<lbrace>sch_act_simple\<rbrace>"
   apply (simp add: replyUnlink_def setReplyTCB_def getReplyTCB_def)
   by (wpsimp wp: hoare_drop_imps)
 
@@ -1313,7 +1313,7 @@ lemma setThreadState_inQ[wp]:
   done
 
 lemma replyUnlink_valid_inQ_queues[wp]:
-  "replyUnlink replyPtr \<lbrace>valid_inQ_queues\<rbrace>"
+  "replyUnlink replyPtr tcbPtr \<lbrace>valid_inQ_queues\<rbrace>"
   apply (clarsimp simp: replyUnlink_def setReplyTCB_def getReplyTCB_def)
   apply (wpsimp wp: set_reply'.set_wp gts_wp')
   apply (fastforce simp: valid_inQ_queues_def obj_at'_def projectKOs)
@@ -2191,7 +2191,7 @@ lemma cancelSignal_queues[wp]:
   done
 
 lemma replyUnlink_valid_queues[wp]:
-  "replyUnlink replyPtr \<lbrace>valid_queues\<rbrace>"
+  "replyUnlink replyPtr tcbPtr \<lbrace>valid_queues\<rbrace>"
   apply (clarsimp simp: replyUnlink_def setReplyTCB_def getReplyTCB_def)
   apply (wpsimp wp: sts_valid_queues gts_wp')
   apply (fastforce simp: replyUnlink_assertion_def valid_queues_def valid_queues_no_bitmap_def
@@ -2231,7 +2231,7 @@ lemma cancelIPC_queues[wp]:
    apply (fastforce simp: st_tcb_at'_def obj_at'_def projectKOs objBitsKO_def
                    intro: tcbFault_update_valid_queues)
   apply (wpsimp wp: setThreadState_not_runnable'_valid_queues hoare_vcg_all_lift hoare_drop_imps
-                    replyUnlink_st_tcb_at'_Inactive)
+                    replyUnlink_st_tcb_at')
   apply (fastforce simp: st_tcb_at'_def obj_at'_def)
   done
 
@@ -2664,7 +2664,7 @@ lemma cancel_all_invs'_helper:
                               else state_refs_of' s x)
               \<and>  (\<forall>x \<in> set q. ex_nonz_cap_to' x s))\<rbrace>
    mapM_x (\<lambda>t. do st <- getThreadState t;
-                  y <- case if isReceive st then replyObject st else None of None \<Rightarrow> return () | Some x \<Rightarrow> replyUnlink x;
+                  y <- case if isReceive st then replyObject st else None of None \<Rightarrow> return () | Some x \<Rightarrow> replyUnlink x t;
                   fault <- threadGet tcbFault t;
                   if fault = None then do y <- setThreadState Structures_H.thread_state.Restart t;
                                           possibleSwitchTo t
@@ -2941,7 +2941,7 @@ lemma setThreadState_valid_ep'[wp]:
   done
 
 lemma replyUnlink_valid_ep'[wp]:
-  "replyUnlink replyPtr \<lbrace>valid_ep' ep\<rbrace>"
+  "replyUnlink replyPtr tcbPtr \<lbrace>valid_ep' ep\<rbrace>"
   apply (clarsimp simp: replyUnlink_def setReplyTCB_def getReplyTCB_def)
   apply (wpsimp wp: set_reply'.set_wp gts_wp')
   apply (fastforce simp: valid_ep'_def obj_at'_def projectKOs objBitsKO_def split: endpoint.splits)
@@ -2995,7 +2995,7 @@ lemma cancelAllIPC_st_tcb_at:
   unfolding cancelAllIPC_def
   apply (rule hoare_gen_asm)
   apply (wpsimp wp: mapM_x_wp' sts_st_tcb_at'_cases hoare_vcg_imp_lift threadGet_obj_at'_field
-                    hoare_vcg_disj_lift replyUnlink_st_tcb_at'_wp hoare_vcg_all_lift
+                    hoare_vcg_disj_lift replyUnlink_st_tcb_at' hoare_vcg_all_lift
                     getEndpoint_wp replyUnlink_tcb_obj_at'_no_change
               simp: obj_at'_ignoring_obj[where P="tcb_at' a b" for a b]
                     obj_at'_ignoring_obj[where P="st_tcb_at' a b c" for a b c]
@@ -3089,7 +3089,7 @@ lemma setThreadState_Inactive_unlive:
 
 lemma replyUnlink_unlive:
   "\<lbrace>ko_wp_at' (Not \<circ> live') p and sch_act_not p\<rbrace>
-   replyUnlink replyPtr
+   replyUnlink replyPtr tcbPtr
    \<lbrace>\<lambda>_. ko_wp_at' (Not o live') p\<rbrace>"
   apply (clarsimp simp: replyUnlink_def setReplyTCB_def getReplyTCB_def)
   apply (wpsimp wp: setThreadState_Inactive_unlive set_reply'.set_wp gts_wp')

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -1825,7 +1825,7 @@ lemma handleFaultReply_cur' [wp]:
   done
 
 lemma replyClear_valid_objs'[wp]:
-  "replyClear r \<lbrace>valid_objs'\<rbrace>"
+  "replyClear r t \<lbrace>valid_objs'\<rbrace>"
   sorry
 
 lemma schedContextUnbindNtfn_valid_objs'[wp]:
@@ -1875,7 +1875,7 @@ crunches replyUnlink
   (simp: crunch_simps wp: crunch_wps)
 
 lemma replyUnlink_weak_sch_act_wf[wp]:
-  "replyUnlink r \<lbrace> \<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s \<rbrace>"
+  "replyUnlink r t \<lbrace> \<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s \<rbrace>"
   sorry
 
 crunches finaliseCapTrue_standin
@@ -1939,7 +1939,7 @@ lemma possibleSwitchTo_weak_sch_act_wf[wp]:
   sorry
 
 lemma replyUnlink_sch_act_no[wp]:
-  "replyUnlink r \<lbrace> sch_act_not t \<rbrace>"
+  "replyUnlink r t' \<lbrace> sch_act_not t \<rbrace>"
   by wpsimp
 
 lemma schedContextDonate_valid_queues':

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -2789,7 +2789,7 @@ lemma threadSet_queued_sch_act_wf[wp]:
   done
 
 lemma tcbSchedEnqueue_pred_tcb_at'[wp]:
-  "\<lbrace>\<lambda>s. pred_tcb_at' proj P' t' s \<rbrace> tcbSchedEnqueue t \<lbrace>\<lambda>_ s. pred_tcb_at' proj P' t' s\<rbrace>"
+  "\<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s) \<rbrace> tcbSchedEnqueue t \<lbrace>\<lambda>_ s. P (pred_tcb_at' proj P' t' s)\<rbrace>"
   apply (simp add: tcbSchedEnqueue_def when_def unless_def)
   apply (wp threadSet_pred_tcb_no_state crunch_wps | clarsimp simp: tcb_to_itcb'_def)+
   done
@@ -4182,7 +4182,7 @@ lemma lipcb_corres:
 crunch inv[wp]: lookupIPCBuffer P
 
 crunches scheduleTCB, possibleSwitchTo
-  for pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
+  for pred_tcb_at'[wp]: "\<lambda>s. P' (pred_tcb_at' proj P t s)"
   (wp: crunch_wps simp: crunch_simps)
 
 lemma setThreadState_st_tcb':
@@ -5016,6 +5016,13 @@ lemma sts_st_tcb_at'_cases:
   apply (wp sts_st_tcb')
   apply fastforce
   done
+
+lemma sts_st_tcb_at'_cases_strong:
+  "\<lbrace>\<lambda>s. tcb_at' t s \<longrightarrow> (t = t' \<longrightarrow> P (P' ts)) \<and> (t \<noteq> t' \<longrightarrow> P (st_tcb_at' P' t' s))\<rbrace>
+   setThreadState ts t
+   \<lbrace>\<lambda>rv s. P (st_tcb_at' P' t' s) \<rbrace>"
+  unfolding setThreadState_def
+  by (wpsimp wp: scheduleTCB_pred_tcb_at' threadSet_pred_tcb_at_state)
 
 lemma threadSet_ct_running':
   "(\<And>tcb. tcbState (f tcb) = tcbState tcb) \<Longrightarrow>

--- a/spec/haskell/src/SEL4/Kernel/Thread.lhs
+++ b/spec/haskell/src/SEL4/Kernel/Thread.lhs
@@ -197,7 +197,7 @@ Replies sent by the "Reply" and "ReplyRecv" system calls can either be normal IP
 >             if not $ isReply state
 >                 then return ()
 >                 else do
->                     replyRemove reply
+>                     replyRemove reply receiver
 >                     faultOpt <- threadGet tcbFault receiver
 >                     case faultOpt of
 >                         Nothing -> do

--- a/spec/haskell/src/SEL4/Object/Endpoint.lhs
+++ b/spec/haskell/src/SEL4/Object/Endpoint.lhs
@@ -92,7 +92,7 @@ If the endpoint is receiving, then a thread is removed from its queue, and an IP
 >                 fault <- threadGet tcbFault thread
 >                 let replyOpt = replyObject recvState
 >                 case replyOpt of
->                     Just reply -> replyUnlink reply
+>                     Just reply -> replyUnlink reply dest
 >                     _ -> return ()
 >                 case (call, fault, canGrant || canGrantReply, replyOpt) of
 >                     (False, Nothing, _, _) -> do
@@ -236,7 +236,7 @@ If the thread is blocking on an endpoint, then the endpoint is fetched and the t
 >                 setEndpoint epptr ep'
 >                 case replyOpt of
 >                     Nothing -> return ()
->                     Just reply -> replyUnlink reply
+>                     Just reply -> replyUnlink reply tptr
 
 Finally, replace the IPC block with a fault block (which will retry the operation if the thread is resumed).
 
@@ -260,7 +260,7 @@ If an endpoint is deleted, then every pending IPC operation using it must be can
 >                     let replyOpt = if isReceive st then replyObject st else Nothing
 >                     case replyOpt of
 >                         Nothing -> return ()
->                         Just reply -> replyUnlink reply
+>                         Just reply -> replyUnlink reply t
 >                     fault <- threadGet tcbFault t
 >                     if isNothing fault
 >                         then do

--- a/spec/haskell/src/SEL4/Object/ObjectType.lhs
+++ b/spec/haskell/src/SEL4/Object/ObjectType.lhs
@@ -133,7 +133,8 @@ When the last capability to an endpoint is deleted, any IPC operations currently
 > finaliseCap (ReplyCap { capReplyPtr = ptr }) final _ = do
 >     when final $ do
 >         tptrOpt <- getReplyTCB ptr
->         when (tptrOpt /= Nothing) $ replyClear ptr
+>         when (tptrOpt /= Nothing) $ do
+>             replyClear ptr (fromJust tptrOpt)
 >     return (NullCap, NullCap)
 
 No action need be taken for Null or Domain capabilities.


### PR DESCRIPTION
This updates Haskell replyUnlink, replyRemove, replyPop, and replyClear to take a tcb ref argument, which should be appropriately linked to the first argument.

This corresponds to the C change in seL4 [PR#1808](https://bitbucket.ts.data61.csiro.au/projects/SEL4/repos/sel4/pull-requests/1808/overview) (on the internal bitbucket). 