### PR TITLE
Rt sc replies relation #2

### DIFF
--- a/lib/Monad_WP/OptionMonad.thy
+++ b/lib/Monad_WP/OptionMonad.thy
@@ -40,6 +40,18 @@ lemma opt_mapE:
   "\<lbrakk> (f |> g) s = Some v; \<And>v'. \<lbrakk>f s = Some v'; g v' = Some v \<rbrakk> \<Longrightarrow> P \<rbrakk> \<Longrightarrow> P"
   by (auto simp: in_opt_map_eq)
 
+lemma opt_map_left_Some:
+  "f x = Some y \<Longrightarrow> (f |> g) x = g y"
+  by (clarsimp simp: opt_map_def)
+
+lemma opt_map_left_None:
+  "f x = None \<Longrightarrow> (f |> g) x = None"
+  by (clarsimp simp: opt_map_def)
+
+lemma opt_map_assoc:
+  "f |> (g |> h) = f |> g |> h"
+  by (fastforce simp: opt_map_def split: option.splits)
+
 lemma opt_map_upd_None:
   "f(x := None) |> g = (f |> g)(x := None)"
   by (auto simp: opt_map_def)
@@ -49,6 +61,11 @@ lemma opt_map_upd_Some:
   by (auto simp: opt_map_def)
 
 lemmas opt_map_upd[simp] = opt_map_upd_None opt_map_upd_Some
+
+lemma case_opt_map_distrib:
+  "((\<lambda>s. case_option None g (f s)) |> h)
+   = ((\<lambda>s. case_option None (g |> h) (f s)))"
+  by (fastforce simp: opt_map_def split: option.splits)
 
 declare None_upd_eq[simp]
 


### PR DESCRIPTION
This adds a few lemmas about `replyPrev` and `replyNext`.

This also adds opt_map_SomeD, which is
```
lemma opt_map_SomeD:
   "f x = Some y \<Longrightarrow> (f |> g) x = g y"
```
and it might be good to add this to the simp set. But that requires some work to fix proofs, so I haven’t done that yet.

I think it makes sense because, for `opt_map` and `Some`, it seems that we currently only have lemmas for cases where the whole computation returns `Some`, but even without that knowledge we should be able to proceed with the computation from the inside if we know enough to do so. Currently, if we want to do that, we effectively have to unfold `opt_map` which is often less than ideal typically because you have other `opt_map`s in the subgoal that you’d rather not unfold. Let me know if I am missing something.

Also, I realise that the lemma could do with a better name in the similar way as `get_tcb_SomeD` is not quite right. 
