### PR TITLE
Remove sym_refs

### DIFF
--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -1277,6 +1277,12 @@ lemma corres_stateAssert_add_assertion:
    apply (wp | rule no_fail_pre)+
   done
 
+lemma corres_stateAssertE_add_assertion:
+  "\<lbrakk> corres_underlying sr nf nf' (i \<oplus> r) P (Q and Q') f (g ());
+     \<And>s s'. \<lbrakk> (s, s') \<in> sr; P s; P' s; Q s' \<rbrakk> \<Longrightarrow> Q' s' \<rbrakk>
+   \<Longrightarrow> corres_underlying sr nf nf' (i \<oplus> r) (P and P') Q f (stateAssertE Q' [] >>=E g)"
+  by (clarsimp simp: stateAssertE_def liftE_bindE corres_stateAssert_add_assertion)
+
 lemma corres_add_noop_lhs:
   "corres_underlying sr nf nf' r P P' (return () >>= (\<lambda>_. f)) g
       \<Longrightarrow> corres_underlying sr nf nf' r P P' f g"

--- a/lib/HaskellLemmaBucket.thy
+++ b/lib/HaskellLemmaBucket.thy
@@ -127,6 +127,18 @@ lemma haskell_assert_wp:
   "\<lbrace>\<lambda>s. Q \<longrightarrow> P s\<rbrace> haskell_assert Q xs \<lbrace>\<lambda>_. P\<rbrace>"
   by simp wp
 
+lemma stateAssertE_sp:
+  "\<lbrace>P\<rbrace> stateAssertE Q l \<lbrace>\<lambda>_. P and Q\<rbrace>, \<lbrace>\<lambda>_. R\<rbrace>"
+  by (clarsimp simp: valid_def validE_def stateAssertE_def stateAssert_def in_monad)
+
+lemma stateAssertE_wp:
+  "\<lbrace>\<lambda>s. Q () \<longrightarrow> P s\<rbrace> stateAssertE Q l \<lbrace>\<lambda>_. P\<rbrace>"
+  by (wpsimp simp: stateAssertE_def stateAssert_def)
+
+lemma stateAssertE_inv:
+  "\<lbrace>P\<rbrace> stateAssertE Q l \<lbrace>\<lambda>_. P\<rbrace>"
+  by (clarsimp simp: valid_def stateAssertE_def stateAssert_def in_monad)
+
 lemma init_append_last:
   "xs \<noteq> [] \<Longrightarrow> init xs @ [last xs] = xs"
   apply (induct xs rule: rev_induct)

--- a/lib/HaskellLib_H.thy
+++ b/lib/HaskellLib_H.thy
@@ -57,6 +57,10 @@ definition
  "stateAssert P L \<equiv> get >>= (\<lambda>s. assert (P s))"
 
 definition
+  stateAssertE :: "('a \<Rightarrow> bool) \<Rightarrow> unit list \<Rightarrow> ('a, 'e + unit) nondet_monad" where
+ "stateAssertE P L \<equiv> liftE (stateAssert P L)"
+
+definition
   haskell_fail :: "unit list \<Rightarrow> ('a, 'b) nondet_monad" where
   haskell_fail_def[simp]:
  "haskell_fail L \<equiv> fail"

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -8680,8 +8680,8 @@ lemma invokeCNode_invs' [wp]:
   unfolding invokeCNode_def
   apply (wpsimp wp: cteRevoke_invs' cteInsert_invs cteMove_ex cteMove_cte_wp_at
                     getCTE_wp cteDelete_invs'
-                simp: unless_def getSlotCap_def locateSlot_conv
-                split_del: if_split)
+              simp: unless_def getSlotCap_def locateSlot_conv
+         split_del: if_split)
   apply (cases cinv; clarsimp)
     apply (clarsimp simp: cte_wp_at_ctes_of is_derived'_def isCap_simps badge_derived'_def)
     apply (erule(1) valid_irq_handlers_ctes_ofD)

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -2226,31 +2226,22 @@ lemma unbindNotification_invs[wp]:
   apply clarsimp
   apply (rule hoare_seq_ext[OF _ get_ntfn_sp'])
   apply (rule hoare_pre)
-  apply (wp sbn'_valid_pspace'_inv sbn_sch_act' sbn_valid_queues valid_irq_node_lift
-            irqs_masked_lift setBoundNotification_ct_not_inQ
-            untyped_ranges_zero_lift | clarsimp simp: cteCaps_of_def o_def)+
+   apply (wp sbn'_valid_pspace'_inv sbn_sch_act' sbn_valid_queues valid_irq_node_lift
+             irqs_masked_lift setBoundNotification_ct_not_inQ
+             untyped_ranges_zero_lift | clarsimp simp: cteCaps_of_def o_def)+
   apply (rule conjI)
-   apply (clarsimp elim!: obj_atE'
-                    simp: projectKOs
-                   dest!: pred_tcb_at')
-  apply (clarsimp simp: pred_tcb_at' conj_comms)
-  apply (intro conjI)
-    apply (frule obj_at_valid_objs', clarsimp+)
-    apply (simp add: valid_ntfn'_def valid_obj'_def projectKOs
-              split: ntfn.splits)
-   apply clarsimp
+   apply (frule obj_at_valid_objs', clarsimp+)
+   apply (simp add: valid_ntfn'_def valid_obj'_def projectKOs
+             split: ntfn.splits)
+  apply (rule conjI)
+   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def)
+  apply (rule conjI)
+   apply (clarsimp simp: pred_tcb_at' conj_comms)
    apply (erule if_live_then_nonz_capE')
    apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs live_ntfn'_def)
-  apply (frule(1) sym_refs_bound_tcb_atD')
-  apply (frule(1) sym_refs_obj_atD')
-  apply (clarsimp simp: refs_of_rev')
-  apply normalise_obj_at'
-  apply (subst delta_sym_refs, assumption)
-    apply (auto split: if_split_asm)[1]
-   apply (auto simp: tcb_st_not_Bound ntfn_q_refs_of'_mult tcb_bound_refs'_not_Bound
-                     get_refs_NTFNSchedContext_not_Bound
-              split: if_split_asm)[1]
-  apply clarsimp
+  apply (frule obj_at_valid_objs', clarsimp+)
+  apply (simp add: valid_ntfn'_def valid_obj'_def projectKOs
+            split: ntfn.splits)
   done
 
 lemma ntfn_bound_tcb_at':
@@ -2808,6 +2799,7 @@ lemma cancelIPC_cteCaps_of:
      cancelIPC t
    \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
   apply (simp add: cancelIPC_def Let_def capHasProperty_def locateSlot_conv)
+  apply (rule hoare_seq_ext_skip, wpsimp)
   apply (rule hoare_pre)
    apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw
         | simp add: cte_wp_at_ctes_of

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -8,6 +8,7 @@ theory KHeap_R
 imports
   "AInvs.ArchDetSchedSchedule_AI"
   Machine_R
+  "../Move_R"
 begin
 
 lemma lookupAround2_known1:
@@ -2575,9 +2576,6 @@ lemma set_ntfn_minor_invs':
   apply (clarsimp simp add: invs'_def valid_state'_def cteCaps_of_def)
   apply (wpsimp wp: irqs_masked_lift valid_irq_node_lift untyped_ranges_zero_lift
               simp: o_def)
-  apply (clarsimp elim!: rsubst[where P=sym_refs]
-                 intro!: ext
-                  dest!: obj_at_state_refs_ofD')
   done
 
 lemma ep_redux_simps':
@@ -3209,6 +3207,11 @@ lemma state_refs_of_cross_eq:
   done
 
 end
+
+method add_sym_refs =
+  rule_tac Q="(\<lambda>s. sym_refs (state_refs_of' s))" in corres_cross_add_guard
+  , (frule invs_sym_refs)?, (frule invs_psp_aligned)?, (frule invs_distinct)?
+  , fastforce dest: state_refs_of_cross_eq
 
 lemma state_refs_of_cross:
   "\<lbrakk>P (state_refs_of s); (s, s') \<in> state_relation; pspace_aligned s; pspace_distinct s\<rbrakk>

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -1346,7 +1346,8 @@ lemma deleteObjects_valid_duplicates'[wp]:
    \<rbrace> deleteObjects ptr sz
    \<lbrace>\<lambda>r s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (rule hoare_gen_asm)
-  apply (clarsimp simp:deleteObjects_def2)
+  apply (clarsimp simp: deleteObjects_def2)
+  apply (rule hoare_seq_ext_skip, wpsimp)
   apply (wp hoare_drop_imps|simp)+
   apply clarsimp
   apply (simp add:deletionIsSafe_def)
@@ -2180,16 +2181,18 @@ lemma performInvocation_valid_duplicates'[wp]:
   RetypeDecls_H.performInvocation isBlocking isCall canDonate i
   \<lbrace>\<lambda>_ s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (clarsimp simp: performInvocation_def)
-  apply (simp add:ct_in_state'_def)
+  apply (simp add: ct_in_state'_def)
   apply (rule hoare_name_pre_state)
   apply (rule hoare_pre)
-  apply wpc
-   apply (wp performArchInvocation_valid_duplicates' |simp)+
+   apply wpc
+              apply (wpsimp wp: performArchInvocation_valid_duplicates'
+                          simp: stateAssertE_def stateAssert_def)+
   apply (cases i)
-  apply (clarsimp simp: simple_sane_strg sch_act_simple_def
-                    ct_in_state'_def ct_active_runnable'[unfolded ct_in_state'_def]
-                  | wp tcbinv_invs' arch_performInvocation_invs'
-                  | rule conjI | erule active_ex_cap')+
+             apply (clarsimp simp: simple_sane_strg sch_act_simple_def ct_in_state'_def
+                        ct_active_runnable'[unfolded ct_in_state'_def]
+                    | wp tcbinv_invs' arch_performInvocation_invs'
+                    | rule conjI
+                    | erule active_ex_cap')+
   apply simp
   done
 

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -5348,8 +5348,6 @@ proof -
       apply (rule hoare_vcg_conj_lift)
        apply (simp add: createObjects_def)
        apply (wp createObjects_state_refs_of'')
-      apply (rule hoare_vcg_conj_lift)
-       apply (simp add: createObjects_def)
        apply (wpsimp wp: createObjects_list_refs_of_replies'')
       apply (rule hoare_vcg_conj_lift)
        apply (simp add: createObjects_def)

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -5279,10 +5279,6 @@ lemma sts_invs_minor':
   apply (intro conjI)
      apply clarsimp
     defer
-    apply (clarsimp dest!: st_tcb_at_state_refs_ofD'
-                    elim!: rsubst[where P=sym_refs]
-                   intro!: ext)
-    using tcb_bound_refs'_helper apply presburger
    apply (clarsimp elim!: st_tcb_ex_cap'')
   apply (frule tcb_in_valid_state', clarsimp+)
   apply (erule (1) valid_tcb_state'_same_tcb_st_refs_of')

--- a/spec/design/skel/KernelStateData_H.thy
+++ b/spec/design/skel/KernelStateData_H.thy
@@ -93,7 +93,7 @@ where
     return r
   od"
 
-#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue Kernel assert stateAssert findM funArray newKernelState capHasProperty ifM whenM whileM andM orM maybeToMonad
-#INCLUDE_HASKELL SEL4/Model/StateData.lhs decls_only ONLY capHasProperty
+#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue Kernel assert stateAssert findM funArray newKernelState capHasProperty ifM whenM whileM andM orM maybeToMonad sym_refs_asrt
+#INCLUDE_HASKELL SEL4/Model/StateData.lhs decls_only ONLY capHasProperty sym_refs_asrt
 
 end

--- a/spec/haskell/src/SEL4/Model/PSpace.lhs
+++ b/spec/haskell/src/SEL4/Model/PSpace.lhs
@@ -226,6 +226,8 @@ No type checks are performed when deleting objects; "deleteObjects" simply delet
 
 > deleteObjects :: PPtr a -> Int -> Kernel ()
 > deleteObjects ptr bits = do
+>         stateAssert sym_refs_asrt
+>             "Assert that `sym_refs (state_refs_of' s)` holds"
 >         unless (fromPPtr ptr .&. mask bits == 0) $
 >             alignError bits
 >         stateAssert (deletionIsSafe ptr bits)

--- a/spec/haskell/src/SEL4/Model/Preemption.lhs
+++ b/spec/haskell/src/SEL4/Model/Preemption.lhs
@@ -52,5 +52,3 @@ In preemptible code, the kernel may explicitly mark a preemption point with the 
 >       case preempt of
 >           Just irq -> throwError irq
 >           Nothing -> return ()
-
-

--- a/spec/haskell/src/SEL4/Model/StateData.lhs
+++ b/spec/haskell/src/SEL4/Model/StateData.lhs
@@ -365,4 +365,11 @@ The function "findM" searches a list, returning the first item for which the giv
 >     r <- f x
 >     if r then return $ Just x else findM f xs
 
+In many places, we would like to be able to use the fact that `sym_refs (state_refs_of' s)`
+holds. We add an assertion that it does hold. We may prove this assertion is true
+using the rule `state_refs_of_cross_eq`.
+
+> sym_refs_asrt :: KernelState -> Bool
+> sym_refs_asrt _ = True
+
 

--- a/spec/haskell/src/SEL4/Object/Endpoint.lhs
+++ b/spec/haskell/src/SEL4/Object/Endpoint.lhs
@@ -206,6 +206,8 @@ If a thread is waiting for an IPC operation, it may be necessary to move the thr
 
 > cancelIPC :: PPtr TCB -> Kernel ()
 > cancelIPC tptr = do
+>         stateAssert sym_refs_asrt
+>             "Assert that `sym_refs (state_refs_of' s)` holds"
 >         state <- getThreadState tptr
 >         threadSet (\tcb -> tcb {tcbFault = Nothing}) tptr
 >         case state of
@@ -249,6 +251,8 @@ If an endpoint is deleted, then every pending IPC operation using it must be can
 
 > cancelAllIPC :: PPtr Endpoint -> Kernel ()
 > cancelAllIPC epptr = do
+>         stateAssert sym_refs_asrt
+>             "Assert that `sym_refs (state_refs_of' s)` holds"
 >         ep <- getEndpoint epptr
 >         case ep of
 >             IdleEP ->
@@ -273,6 +277,8 @@ If a badged endpoint is recycled, then cancel every pending send operation using
 
 > cancelBadgedSends :: PPtr Endpoint -> Word -> Kernel ()
 > cancelBadgedSends epptr badge = do
+>     stateAssert sym_refs_asrt
+>         "Assert that `sym_refs (state_refs_of' s)` holds"
 >     ep <- getEndpoint epptr
 >     case ep of
 >         IdleEP -> return ()

--- a/spec/haskell/src/SEL4/Object/ObjectType.lhs
+++ b/spec/haskell/src/SEL4/Object/ObjectType.lhs
@@ -489,6 +489,8 @@ This function just dispatches invocations to the type-specific invocation functi
 > performInvocation :: Bool -> Bool -> Bool -> Invocation -> KernelP [Word]
 >
 > performInvocation _ _ _ (InvokeUntyped invok) = do
+>     stateAssert sym_refs_asrt
+>         "Assert that `sym_refs (state_refs_of' s)` holds"
 >     invokeUntyped invok
 >     return $ []
 >
@@ -515,6 +517,8 @@ This function just dispatches invocations to the type-specific invocation functi
 >     return $ []
 >
 > performInvocation _ _ _ (InvokeCNode invok) = do
+>     stateAssert sym_refs_asrt
+>         "Assert that `sym_refs (state_refs_of' s)` holds"
 >     invokeCNode invok
 >     return $ []
 >


### PR DESCRIPTION
This PR removes sym_refs (state_refs_of' s) from invs'. See the commit messages for a quick run-down.

I was not sure whether I have the best approach to the definition of `stateAssertE`. I'm happy to reformulate it. And happy to move things around, too