### PR TITLE
c-parser: make default SML compiler Poly/ML (not mlton)

### DIFF
--- a/tools/c-parser/Makefile
+++ b/tools/c-parser/Makefile
@@ -64,13 +64,12 @@ all_tests_$(L4V_ARCH).thy: testfiles testfiles/*.c ../../misc/scripts/gen_isabel
 tools_all: $(CPARSER_PFX)/tools/mllex/mllex $(CPARSER_PFX)/tools/mlyacc/mlyacc
 
 MLYACC=$(MLYACC_PFX)/mlyacc
-RUN_MLYACC=$(TOOLRUN_PFX)$(MLYACC)
 
 %.lex.sml: %.lex $(MLLEX)
-	$(RUN_MLLEX) $<
+	$(MLLEX) $<
 
 %.grm.sml %.grm.sig: %.grm $(MLYACC)
-	$(RUN_MLYACC) $<
+	$(MLYACC) $<
 
 GRAMMAR_PRODUCTS = StrictC.lex.sml StrictC.grm.sig StrictC.grm.sml
 

--- a/tools/c-parser/globalmakevars
+++ b/tools/c-parser/globalmakevars
@@ -15,7 +15,7 @@ GLOB_PFX := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 -include $(GLOB_PFX)/globalmakevars.local
 CC ?= gcc
 
-SML_COMPILER ?= mlton
+SML_COMPILER ?= poly
 #ifndef SML_COMPILER
 #SML_COMPILER := $(if $(shell which mlton),mlton,poly)
 #endif
@@ -36,9 +36,7 @@ MACOSP := $(findstring Darwin,$(OS))
 DYLIB := $(if $(MACOSP),DYLD_LIBRARY_PATH,LD_LIBRARY_PATH)
 DYLIB_SFX := $(if $(MACOSP),dylib,so)
 
-POLY_MACHINE_LDFLAGS := $(if $(MACOSP),-segprot POLY rwx rwx,)
-
-POLYCC := $(CC) $(POLY_CC_FLAGS) -L$(LIBPOLY_DIR) -lgmp -lpolymain -lpolyml -lstdc++ -lpthread -ldl $(POLY_MACHINE_LDFLAGS)
+POLYC := $(ML_HOME)/polyc
 
 
 ifndef LIBPOLYML
@@ -47,7 +45,6 @@ endif
 
 DYLIB_VAL := $($(DYLIB))
 SETDYLIB := $(DYLIB)=$(LIBPOLY_DIR)$(if $(DYLIB_VAL),:$(DYLIB_VAL),)
-TOOLRUN_PFX := $(if $(findstring poly,$(SML_COMPILER)),$(SETDYLIB) ,)
 POLY := $(SETDYLIB) $(ML_HOME)/poly
 
 GLOBAL_MAKES_INCLUDED=true

--- a/tools/c-parser/standalone-parser/Makefile
+++ b/tools/c-parser/standalone-parser/Makefile
@@ -50,7 +50,7 @@ $(UMM_HEAP_ARM_HYP)/% : $(UMM_HEAP_ARM)/%
 	mkdir -p $(UMM_HEAP_ARM_HYP)
 	cp -p $< $@
 
-STP_CLEAN_TARGETS := $(STPARSERS) $(TOKENIZERS) $(STP_PFX)/c-parser.o $(STP_PFX)/table.ML
+STP_CLEAN_TARGETS := $(STPARSERS) $(TOKENIZERS) $(STP_PFX)/table.ML
 
 $(STP_PFX)/table.ML: $(ISABELLE_HOME)/src/Pure/General/table.ML
 	sed -e '/ML.pretty-printing/,/final.declarations/d' < $< > $@
@@ -108,28 +108,19 @@ else ifeq ($(SML_COMPILER),poly)
 # compilation with polyml may be bit-rotted
 #
 
-PARSER0_DEPS := $(shell perl -e 'use Cwd "abs_path"; while (<>) { if (/ml$$|sig$$/i && !/^ *mlton/) { tr/ //d; print abs_path("$(STP_PFX)/$$_"); }}' < $(STP_PFX)/c-parser.mlb)
-PARSER_DEPS := $(PARSER0_DEPS) $(realpath $(STP_PFX)/c-parser.mlb) $(STP_PFX)/table.ML
+PARSER_DEPS := $(shell perl -e 'use Cwd "abs_path"; while (<>) { if (/ml$$|sig$$/i && !/^ *mlton/ && !/L4V_ARCH/) { tr/ //d; print abs_path("$(STP_PFX)/$$_"); }}' < $(STP_PFX)/c-parser.mlb) $(STP_PFX)/table.ML $(realpath $(STP_PFX)/c-parser.mlb)
+TOKENIZER_DEPS := $(shell perl -e 'use Cwd "abs_path"; while (<>) { if (/ml$$|sig$$/i && !/^ *mlton/ && !/L4V_ARCH/) { tr/ //d; print abs_path("$(STP_PFX)/$$_"); }}' < $(STP_PFX)/tokenizer.mlb) $(STP_PFX)/table.ML $(realpath $(STP_PFX)/tokenizer.mlb)
 
-TOKENIZER0_DEPS := $(shell perl -e 'use Cwd "abs_path"; while (<>) { if (/ml$$|sig$$/i && !/^ *mlton/) { tr/ //d; print abs_path("$(STP_PFX)/$$_"); }}' < $(STP_PFX)/tokenizer.mlb)
-TOKENIZER_DEPS := $(TOKENIZER0_DEPS) $(realpath $(STP_PFX)/tokenzier.mlb) $(STP_PFX)/table.ML
+.PHONY: stp_pdeps
+stp_pdeps:
+	@echo "PARSER_DEPS_ARM = $(PARSER_DEPS_ARM)"
 
-$(STPARSER): $(STP_PFX)/c-parser.o $(LIBPOLYML)
-	$(POLYCC) -o $@ $<
+$(STP_PFX)/%/c-parser: $(STP_PFX)/poly-cparser.ML $(PARSER_DEPS) $(STP_PFX)/../umm_heap/%/TargetNumbers.ML | $(STP_PFX)/%
+	STP_PFX=$(STP_PFX) STP_ARCH=$(lastword $(filter-out c-parser,$(subst /, ,$@))) $(POLYC) -o $@ $<
 
-$(STP_PFX)/c-parser.o: $(STP_PFX)/poly-cparser.ML $(PARSER_DEPS)
-	STP_PFX=$(STP_PFX) $(POLY) < $<
+$(STP_PFX)/%/tokenizer: $(STP_PFX)/poly-tokenizer.ML $(TOKENIZER_DEPS) $(STP_PFX)/../umm_heap/%/TargetNumbers.ML | $(STP_PFX)/%
+	STP_PFX=$(STP_PFX) STP_ARCH=$(lastword $(filter-out tokenizer,$(subst /, ,$@))) $(POLYC) -o $@ $<
 
-$(STP_PFX)/tokenizer: $(STP_PFX)/tokenizer.o $(LIBPOLYML)
-	$(POLYCC) -o $@ $<
-
-$(STP_PFX)/tokenizer.o: $(STP_PFX)/poly-tokenizer.ML $(TOKENIZER_DEPS)
-	STP_PFX=$(STP_PFX) $(POLY) < $<
-
-
-.PHONY: stp_deps
-stp_deps:
-	@echo $(PARSER_DEPS)
 
 else
 $(error Can only cope with SML_COMPILER as "poly" or "mlton"; got $(SML_COMPILER))

--- a/tools/c-parser/standalone-parser/main.sml
+++ b/tools/c-parser/standalone-parser/main.sml
@@ -13,7 +13,6 @@ open OS.Process
 fun die s = (print s; print "\n"; exit failure)
 fun warn s = (TextIO.output(TextIO.stdErr, s^"\n");
               TextIO.flushOut TextIO.stdErr)
-val execname = CommandLine.name
 
 
 val _ = Feedback.errorThreshold := NONE;
@@ -507,9 +506,9 @@ fun docpp (SOME p) {includes, filename} =
   end
   | docpp NONE {filename, ...} = (filename, false)
 
-val usage_msg = GetOpt.usageInfo {
+fun usage_msg () = GetOpt.usageInfo {
     header =
-    "Usage: \n  "^execname()^" [options] filename\n\n\
+    "Usage: \n  "^CommandLine.name()^" [options] filename\n\n\
     \Use -l to adjust error lookahead. (The higher the number, the more the parser\n\
     \will try to make sense of stuff with parse errors.)\n\n\
     \For no analyses at all (not even typechecking), use --rawsyntaxonly.\n\n\
@@ -525,12 +524,12 @@ fun doit args =
         GetOpt.getOpt {argOrder = GetOpt.RequireOrder, options = options,
                        errFn = die} args
     val _ = if !show_help then
-              (print usage_msg ; OS.Process.exit OS.Process.success)
-            else if !bad_option then die usage_msg
+              (print (usage_msg()) ; OS.Process.exit OS.Process.success)
+            else if !bad_option then die (usage_msg())
             else ()
   in
     case realargs of
-      [] => die usage_msg
+      [] => die (usage_msg())
     | [fname] =>
       let
         val (ast,n) = StrictCParser.parse (docpp (!cpp)) (!error_lookahead)
@@ -559,7 +558,7 @@ fun doit args =
             do_analyses (List.rev (!analyses))
           end
       end
-    | _ => die usage_msg
+    | _ => die (usage_msg())
   end
 
 end;

--- a/tools/c-parser/standalone-parser/poly-cparser.ML
+++ b/tools/c-parser/standalone-parser/poly-cparser.ML
@@ -7,9 +7,24 @@ val _ = PolyML.Compiler.prompt1:="";
 val _ = PolyML.Compiler.prompt2:="";
 val _ = PolyML.print_depth 0;
 val dir = valOf (OS.Process.getEnv "STP_PFX")
+val l4v_arch = valOf (OS.Process.getEnv "STP_ARCH")
 
 infix |>
 fun x |> f = f x
+
+fun replace tgt replacement s =
+    let
+      val ss = Substring.full s
+      val (pfx_s,sfx_s) = Substring.position tgt ss
+    in
+      if Substring.size sfx_s = 0 then s
+      else
+        Substring.concat [
+          pfx_s,
+          Substring.full replacement,
+          Substring.triml (String.size tgt) sfx_s
+        ]
+    end
 
 fun readmlb fname = let
   val istr = TextIO.openIn fname
@@ -18,6 +33,7 @@ fun readmlb fname = let
         NONE => ()
       | SOME s => let
           open Substring
+          val s = replace "$(L4V_ARCH)" l4v_arch s
           val s = s |> full |> dropr Char.isSpace |> dropl Char.isSpace |> string
           val lower_s = CharVector.map Char.toLower s
         in
@@ -48,6 +64,3 @@ val _ = readmlb (dir ^ "/c-parser.mlb");
 
 
 fun main() = Main.doit (CommandLine.arguments())
-
-val _ = PolyML.shareCommonData main;
-val _ = PolyML.export(dir ^ "/c-parser", main);

--- a/tools/c-parser/standalone-parser/poly-tokenizer.ML
+++ b/tools/c-parser/standalone-parser/poly-tokenizer.ML
@@ -7,9 +7,24 @@ val _ = PolyML.Compiler.prompt1:="";
 val _ = PolyML.Compiler.prompt2:="";
 val _ = PolyML.print_depth 0;
 val dir = valOf (OS.Process.getEnv "STP_PFX")
+val l4v_arch = valOf (OS.Process.getEnv "STP_ARCH")
 
 infix |>
 fun x |> f = f x
+
+fun replace tgt replacement s =
+    let
+      val ss = Substring.full s
+      val (pfx_s,sfx_s) = Substring.position tgt ss
+    in
+      if Substring.size sfx_s = 0 then s
+      else
+        Substring.concat [
+          pfx_s,
+          Substring.full replacement,
+          Substring.triml (String.size tgt) sfx_s
+        ]
+    end
 
 fun readmlb fname = let
   val istr = TextIO.openIn fname
@@ -18,6 +33,7 @@ fun readmlb fname = let
         NONE => ()
       | SOME s => let
           open Substring
+          val s = replace "$(L4V_ARCH)" l4v_arch s
           val s = s |> full |> dropr Char.isSpace |> dropl Char.isSpace |> string
           val lower_s = CharVector.map Char.toLower s
         in

--- a/tools/c-parser/tools/mllex/Makefile
+++ b/tools/c-parser/tools/mllex/Makefile
@@ -14,10 +14,6 @@ all: $(MLLEX)
 
 include $(MLLEX_PFX)/../../globalmakevars
 
-RUN_MLLEX=$(TOOLRUN_PFX)$(MLLEX)
-
-
-
 ifeq ($(SML_COMPILER),mlton)
 #
 # Compilation if the compiler is mlton
@@ -34,19 +30,9 @@ else ifeq ($(SML_COMPILER),poly)
 #
 # set POLY_CC_FLAGS to -m32 if you are using 32bit poly on a 64bit architecture
 
-$(MLLEX): $(MLLEX)0
-	/bin/echo "#! /bin/sh" > $@
-	/bin/echo >> $@
-	/bin/echo "$(TOOLRUN_PFX)$< \"\$$@\"" >> $@
-	chmod +x $@
+$(MLLEX): $(MLLEX_PFX)/poly-mllex.ML $(MLLEX_PFX)/mllex.ML
+	MLLEX_PFX=$(MLLEX_PFX) $(POLYC) -o $@ $<
 
-
-$(MLLEX)0: $(MLLEX_PFX)/mllex.o
-	$(POLYCC) -o $@ $<
-
-
-$(MLLEX_PFX)/mllex.o: $(MLLEX_PFX)/poly-mllex.ML $(MLLEX_PFX)/mllex.ML
-	MLLEX_PFX=$(MLLEX_PFX) $(POLY) < $<
 
 else
 $(error Can only cope with SML_COMPILER as "poly" or "mlton")

--- a/tools/c-parser/tools/mllex/poly-mllex.ML
+++ b/tools/c-parser/tools/mllex/poly-mllex.ML
@@ -20,7 +20,3 @@ in
            OS.Process.exit OS.Process.failure)
   | args => List.app LexGen.lexGen args
 end;
-
-val _ = PolyML.shareCommonData main;
-val _ = PolyML.export(dir ^ "/mllex", main);
-

--- a/tools/c-parser/tools/mlyacc/Makefile
+++ b/tools/c-parser/tools/mlyacc/Makefile
@@ -15,7 +15,7 @@ include $(MLYACC_PFX)/../../globalmakevars
 include $(MLYACC_PFX)/../mllex/Makefile
 
 $(MLYACC_PFX)/src/yacc.lex.sml: $(MLYACC_PFX)/src/yacc.lex $(MLLEX)
-	$(RUN_MLLEX) $<
+	$(MLLEX) $<
 
 ifeq ($(SML_COMPILER),mlton)
 #
@@ -35,15 +35,6 @@ else ifeq ($(SML_COMPILER),poly)
 # set POLY_CC_FLAGS to -m32 if you are using 32bit poly on a 64bit architecture
 
 
-$(MLYACC_PFX)/mlyacc: $(MLYACC_PFX)/mlyacc0
-	/bin/echo "#! /bin/sh" > $@
-	/bin/echo >> $@
-	/bin/echo "$(TOOLRUN_PFX)$< \"\$$@\"" >> $@
-	chmod +x $@
-
-$(MLYACC_PFX)/mlyacc0: $(MLYACC_PFX)/mlyacc.o
-	$(POLYCC) -o $@ $<
-
 MLY_SRCDEPS0 = absyn-sig absyn core coreutils grammar graph hdr lalr link look \
            mklrtable mkprstruct parse poly-main shrink sigs utils verbose \
 	   yacc
@@ -52,11 +43,12 @@ MLY_SRCDEPS = $(patsubst %,src/%,$(MLY_SRCDEPS1))
 
 MLY_LIBDEPS0 = base-sig join lrtable parser2 stream
 MLY_LIBDEPS = $(patsubst %,mlyacclib/MLY_%.ML,$(LIBDEPS0))
-
 MLY_DEPS = $(patsubst %,$(MLYACC_PFX)/%,$(MLY_LIBDEPS) $(MLY_SRCDEPS))
 
-$(MLYACC_PFX)/mlyacc.o: $(MLYACC_PFX)/poly-mlyacc.ML $(MLY_DEPS)
-	MLYACC_PFX=$(MLYACC_PFX) $(SETDYLIB) $(POLY) < $<
+$(MLYACC_PFX)/mlyacc: $(MLYACC_PFX)/poly-mlyacc.ML $(MLY_DEPS)
+	MLYACC_PFX=$(MLYACC_PFX) $(POLYC) -o $@ $<
+
+
 
 else
 $(error Can only cope with SML_COMPILER as "poly" or "mlton")
@@ -73,6 +65,6 @@ clean: mlyacc_clean
 cparser_clean: mlyacc_clean
 
 mlyacc_clean:
-	-/bin/rm -f $(MLYACC_PFX)/mlyacc.o $(MLYACC_PFX)/mlyacc $(MLYACC_PFX)/src/yacc.lex.sml
+	-/bin/rm -f $(MLYACC_PFX)/mlyacc $(MLYACC_PFX)/src/yacc.lex.sml
 
 endif

--- a/tools/c-parser/tools/mlyacc/poly-mlyacc.ML
+++ b/tools/c-parser/tools/mlyacc/poly-mlyacc.ML
@@ -45,8 +45,3 @@ val _ = u "link";
 val _ = use (dir ^ "/src/poly-main.ML");
 
 fun main () = main.main (CommandLine.arguments ());
-
-val _ = PolyML.shareCommonData main;
-val _ = PolyML.export (dir ^ "/mlyacc", main);
-
-


### PR DESCRIPTION
With `polyc` usable in Isabelle2019, using Poly/ML to compile the standalone tools, `mllex` and `mlyacc` is pretty straightforward. 