### PR TITLE
c-parser: avoid cleaning `umm_heap/ARM_HYP`

### DIFF
--- a/tools/c-parser/standalone-parser/Makefile
+++ b/tools/c-parser/standalone-parser/Makefile
@@ -42,14 +42,6 @@ standalone-tokenizer stp_all: $(TOKENIZERS)
 
 include $(STP_PFX)/../Makefile
 
-# This is only used for ARM_HYP and ARM since the former is a copy of the latter
-UMM_HEAP_ARM_HYP=$(realpath $(STP_PFX)/../umm_heap)/ARM_HYP
-UMM_HEAP_ARM=$(realpath $(STP_PFX)/../umm_heap/ARM)
-
-$(UMM_HEAP_ARM_HYP)/% : $(UMM_HEAP_ARM)/%
-	mkdir -p $(UMM_HEAP_ARM_HYP)
-	cp -p $< $@
-
 STP_CLEAN_TARGETS := $(STPARSERS) $(TOKENIZERS) $(STP_PFX)/c-parser.o $(STP_PFX)/table.ML
 
 $(STP_PFX)/table.ML: $(ISABELLE_HOME)/src/Pure/General/table.ML
@@ -141,6 +133,5 @@ clean: stp_clean
 
 stp_clean:
 	-/bin/rm -f $(STP_CLEAN_TARGETS)
-	-/bin/rm -fr $(UMM_HEAP_ARM_HYP)
 
 endif


### PR DESCRIPTION
Initially the `Makefile` copied `umm_heap/ARM_HYP` from `umm_heap/ARM`,
and deleted `umm_heap/ARM_HYP` during `make clean`. However, the
contents of `umm_heap/ARM_HYP` have since been committed, so this is no
longer appropriate.

Reported-by: Michael Norrish <Michael.Norrish@data61.csiro.au>
Signed-off-by: Matthew Brecknell <Matthew.Brecknell@data61.csiro.au>