### PR TITLE
Haskell fix

### DIFF
--- a/spec/haskell/src/SEL4/Model/StateData.lhs
+++ b/spec/haskell/src/SEL4/Model/StateData.lhs
@@ -347,7 +347,7 @@ The function "assert" is used to state that a predicate must be true at a given 
 
 The function "stateAssert" is similar to "assert", except that it reads the current state. This is typically used for more complex assertions that cannot be easily expressed in Haskell; in this case, the asserted function is "const True" in Haskell but is replaced with something stronger in the Isabelle translation.
 
-> stateAssert :: (KernelState -> Bool) -> String -> Kernel ()
+> stateAssert :: MonadState s m => (s -> Bool) -> String -> m ()
 > stateAssert f e = get >>= \s -> assert (f s) e
 
 The "capHasProperty" function is used with "stateAssert". As explained above, it is "const True" here, but is strengthened to actually check the capability in the translation to Isabelle.

--- a/tools/haskell-translator/lhs_pars.py
+++ b/tools/haskell-translator/lhs_pars.py
@@ -468,7 +468,7 @@ def type_sig_transform(tree_element):
     return (line, [])
 
 
-ignore_classes = {'Error': 1}
+ignore_classes = {'Error': 1, 'MonadState': 1}
 hand_classes = {'Bits': ['HS_bit'],
                 'Num': ['minus', 'one', 'zero', 'plus', 'numeral'],
                 'FiniteBits': ['finiteBit']}
@@ -489,7 +489,9 @@ def type_transform(string):
             instances = [lhs]
         var_annotes = {}
         for instance in instances:
-            (name, var) = instance.split()
+            # multi-var type classes must be in the ignore list; discard
+            # all vars after first:
+            (name, var) = instance.split()[0:2]
             if name in ignore_classes:
                 continue
             if name in hand_classes:


### PR DESCRIPTION
This fixes the Haskell compile breakage introduced in #51.

It turns out that to do that, we need to teach the Haskell translator how to deal with (and ignore) multi-variable type classes.
