### PR TITLE
complete github CI check for MCS 

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -12,6 +12,20 @@ on:
   pull_request:
 
 jobs:
+  haskell:
+    name: Haskell
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ARM]
+    steps:
+    - name: compile Haskell
+      uses: seL4/ci-actions/run-proofs@master
+      with:
+        L4V_ARCH: ${{ matrix.arch }}
+        session: HaskellKernel tests-xml-correct
+
   ainvs:
     name: AInvs
     runs-on: ubuntu-latest
@@ -30,7 +44,7 @@ jobs:
       uses: seL4/ci-actions/run-proofs@master
       with:
         L4V_ARCH: ${{ matrix.arch }}
-        session: ExecSpec AInvs
+        session: ExecSpec ASpecDoc AInvs
 
   refine:
     name: Refine

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -20,6 +20,12 @@ jobs:
       matrix:
         arch: [ARM]
     steps:
+    - name: Cache ~/.stack
+      uses: actions/cache@v2
+      with:
+        path: ~/.stack
+        key: ${{ runner.os }}-stack-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-stack-
     - name: compile Haskell
       uses: seL4/ci-actions/run-proofs@master
       with:

--- a/spec/haskell/Makefile
+++ b/spec/haskell/Makefile
@@ -74,6 +74,7 @@ build-riscv: sandbox $(BOOT_FILES)
 # cabal package database is missing, the build will fail.
 
 .stack-work:
+	mkdir ~/.stack
 	stack --install-ghc build cabal-install
 
 $(CUSTOM_BOOT_FILES):


### PR DESCRIPTION
This should now run all tests the internal testboard currently runs on github.

Unfortunately, once we get to CRefine github CI will runners be too small to do that, but until then we can enjoy completeness. 
