### PR TITLE
some lemmas for handling sched_context size + improved `update_sc_no_reply_stack_update_corres`

### DIFF
--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -1178,6 +1178,18 @@ lemma corres_move_asm:
 
 lemmas corres_cross_over_guard = corres_move_asm[rotated]
 
+lemma corres_cross_add_guard:
+  "\<lbrakk> \<And>s s'. \<lbrakk>(s,s') \<in> sr; P s; P' s'\<rbrakk> \<Longrightarrow> Q s';
+     corres_underlying sr nf nf' r P  (P' and Q) f g\<rbrakk>
+    \<Longrightarrow> corres_underlying sr nf nf' r P P' f g"
+  by (fastforce simp: corres_underlying_def)
+
+lemma corres_cross_add_abs_guard:
+  "\<lbrakk> \<And>s s'. \<lbrakk>(s,s') \<in> sr; P s; P' s'\<rbrakk> \<Longrightarrow> Q s;
+     corres_underlying sr nf nf' r (P and Q)  P' f g\<rbrakk>
+    \<Longrightarrow> corres_underlying sr nf nf' r P P' f g"
+  by (fastforce simp: corres_underlying_def)
+
 lemma corres_cross_back:
   "\<lbrakk> \<And>s s'. \<lbrakk> (s,s') \<in> sr; P' s' \<rbrakk> \<Longrightarrow> P s; \<And>s. Q' s \<Longrightarrow> P' s;
      corres_underlying sr nf nf' r (Q and P) Q' f g \<rbrakk>

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -9,6 +9,7 @@ imports
   LevityCatch
   "AInvs.ArchDetSchedSchedule_AI"
   "Lib.AddUpdSimps"
+  ArchMove_R
 begin
 
 (* FIXME: this should go somewhere in spec *)

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -8,7 +8,6 @@ theory KHeap_R
 imports
   "AInvs.ArchDetSchedSchedule_AI"
   Machine_R
-  "../Move_R"
 begin
 
 lemma lookupAround2_known1:
@@ -3390,13 +3389,6 @@ lemma ko_at'_cross:
                      scBits_simps sc_relation_def objBits_simps
               split: Structures_A.kernel_object.split_asm if_split_asm
                      ARM_A.arch_kernel_obj.split_asm)
-
-(* FIXME RT: move *)
-lemma corres_cross_add_abs_guard:
-  "\<lbrakk> \<And>s s'. \<lbrakk>(s,s') \<in> sr; P s; P' s'\<rbrakk> \<Longrightarrow> Q s;
-     corres_underlying sr nf nf' r (P and Q)  P' f g\<rbrakk>
-    \<Longrightarrow> corres_underlying sr nf nf' r P P' f g"
-  by (fastforce simp: corres_underlying_def)
 
 lemma update_sc_no_reply_stack_update_corres:
   "\<lbrakk>\<forall>sc n sc'. sc_relation sc n sc' \<longrightarrow> sc_relation (f sc) n (f' sc');

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -1483,7 +1483,7 @@ lemma get_sc_corres_size:
    apply wp
   apply (simp add: get_sched_context_def getSchedContext_def get_object_def
                    getObject_def bind_assoc)
-  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def)
+  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def)
   apply (clarsimp simp: assert_def fail_def obj_at_def return_def
                  split: Structures_A.kernel_object.splits)
   apply (clarsimp simp: loadObject_default_def in_monad projectKOs

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -2307,13 +2307,6 @@ lemma thread_get_exs_valid:
   by (clarsimp simp: thread_get_def get_tcb_def gets_the_def gets_def return_def get_def
                      exs_valid_def tcb_at_def bind_def)
 
-lemma get_sched_context_exs_valid:
-  "\<exists>sc n. kheap s scp = Some (Structures_A.SchedContext sc n)
-   \<Longrightarrow> \<lbrace>(=) s\<rbrace> get_sched_context scp \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
-  by (clarsimp simp: get_sched_context_def get_object_def obj_at_def bind_def is_sc_obj_def
-                     gets_def get_def return_def exs_valid_def
-              split: Structures_A.kernel_object.splits)
-
 lemma get_reply_exs_valid:
   "reply_at rp s \<Longrightarrow> \<lbrace>(=) s\<rbrace> get_reply rp \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
   by (clarsimp simp: get_simple_ko_def get_object_def gets_def return_def get_def
@@ -2369,12 +2362,6 @@ lemma get_sc_refill_ready_sp:
                    \<and> (rv = sc_refill_ready (cur_time s) sc))
            \<and> P s\<rbrace>"
   by (wpsimp simp: obj_at_def)
-
-lemma get_sched_context_no_fail:
-  "no_fail (\<lambda>s. sc_at ptr s) (get_sched_context ptr)"
-  by (clarsimp simp: get_sched_context_def no_fail_def bind_def get_object_def return_def get_def
-                     gets_def obj_at_def is_sc_obj_def
-              split: Structures_A.kernel_object.splits)
 
 lemma rescheduleRequired_corres:
   "corres dc (valid_tcbs and weak_valid_sched_action and pspace_aligned and pspace_distinct)

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -5,7 +5,7 @@
  *)
 
 theory TcbAcc_R
-imports CSpace_R ArchMove_R
+imports CSpace_R
 begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)

--- a/proof/refine/Move_R.thy
+++ b/proof/refine/Move_R.thy
@@ -345,10 +345,4 @@ lemma Reply_or_Receive_reply_at:
   apply (drule (1) st_tcb_at_valid_st2)
   by (fastforce simp: obj_at_def valid_tcb_state_def)
 
-lemma corres_cross_add_guard:
-  "\<lbrakk> \<And>s s'. \<lbrakk>(s,s') \<in> sr; P s; P' s'\<rbrakk> \<Longrightarrow> Q s';
-     corres_underlying sr nf nf' r P  (P' and Q) f g\<rbrakk>
-    \<Longrightarrow> corres_underlying sr nf nf' r P P' f g"
-  by (fastforce simp: corres_underlying_def)
-
 end


### PR DESCRIPTION
- the main purpose of this commit is to have a more usable
`update_sc_no_reply_stack_update_corres` lemma.

In order to match up `update_sched_context` with `setSchedContext` which is actully `setObject`, we need to consider `set_object` updating the abstract heap with a new scheduling context with some particular `n`. The new `update_sc_no_reply_stack_update_corres` gets this from the concrete side object `sc’`.

- this also led to cleaning up the way we deal with the scheduling
context sizes. This commit adds a few lemmas that provide ways to
handle scheduling context sizes explicitly.
  See `get_sc_corres_size`.

- this also adds `sc_obj_at_cross` and `corres_cross_add_abs_guard`
- also includes some cleanup for `ArchMove_R` import

Signed-off-by: Miki Tanaka <miki.tanaka@data61.csiro.au>