### PR TITLE
Simplify handling of round_robin sched contexts

### DIFF
--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -178,7 +178,7 @@ crunch domain_list_inv[wp]: commit_time "\<lambda>s. P (domain_list s)"
   (simp: Let_def wp: get_sched_context_wp get_refills_wp wp: crunch_wps)
 
 crunch domain_list_inv[wp]: refill_new "\<lambda>s. P (domain_list s)"
-  (simp: Let_def wp: get_sched_context_wp get_refills_wp wp: crunch_wps)
+  (simp: Let_def crunch_simps wp: get_sched_context_wp get_refills_wp wp: crunch_wps)
 
 crunch domain_list_inv[wp]: refill_update "\<lambda>s. P (domain_list s)"
   (simp: Let_def wp: get_sched_context_wp get_refills_wp wp: crunch_wps)

--- a/proof/invariant-abstract/Deterministic_AI.thy
+++ b/proof/invariant-abstract/Deterministic_AI.thy
@@ -4107,7 +4107,7 @@ lemma end_timeslice_valid_list[wp]:
 lemma charge_budget_valid_list[wp]:
   "\<lbrace>valid_list\<rbrace> charge_budget consumed canTimeout \<lbrace>\<lambda>_.valid_list\<rbrace>"
   by (wpsimp simp: charge_budget_def Let_def set_refills_def is_round_robin_def
-                   refill_budget_check_round_robin_def
+                   refill_budget_check_round_robin_def refill_reset_rr_def
                wp: assert_inv
       | intro conjI)+
 

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -1968,6 +1968,10 @@ lemma refill_budget_check_bound_sc:
   by (wpsimp simp: refill_budget_check_def is_round_robin_def
                wp: set_refills_bound_sc)
 
+lemma refill_reset_rr_invs[wp]:
+  "refill_reset_rr csc_ptr \<lbrace>invs\<rbrace>"
+  unfolding refill_reset_rr_def by wpsimp
+
 lemma charge_budget_invs:
   "\<lbrace>invs\<rbrace>
    charge_budget consumed canTimeout

--- a/proof/invariant-abstract/SchedContext_AI.thy
+++ b/proof/invariant-abstract/SchedContext_AI.thy
@@ -843,16 +843,8 @@ lemma sc_and_timer_activatable:
            wp: hoare_drop_imp modify_wp hoare_vcg_if_lift2 set_next_interrupt_activatable)
   done
 
-lemma refill_new_typ_at[wp]:
-  "refill_new sc_ptr new_period new_budget new_max_refills
-   \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace>"
-  by (wpsimp simp: refill_new_def wp: get_sched_context_wp)
-
-lemma refill_update_typ_at[wp]: (* check the definition *)
-  "refill_update sc_ptr new_period new_budget new_max_refills
-   \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace>"
-  supply if_split [split del]
-  by (wpsimp simp: refill_update_def wp: get_sched_context_wp)
+crunches refill_new, refill_update
+  for typ_at[wp]: "\<lambda>s. P (typ_at T p s)"
 
 lemma sched_context_resume_typ_at[wp]:
   "\<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> sched_context_resume sc_ptr
@@ -1414,13 +1406,23 @@ lemma set_sc_obj_ref_not_ko_at_wp[wp]:
   apply (clarsimp simp: obj_at_def)
   done
 
+lemma maybe_add_empty_tail_invs[wp]:
+  "\<lbrace>invs and K (sc_ptr \<noteq> idle_sc_ptr)\<rbrace>
+   maybe_add_empty_tail sc_ptr
+   \<lbrace>\<lambda>_. invs\<rbrace>"
+  by (wpsimp simp: maybe_add_empty_tail_def is_round_robin_def
+        split_del: if_split
+               wp: set_sc_obj_ref_invs_no_change hoare_vcg_all_lift hoare_vcg_imp_lift'
+                   hoare_vcg_disj_lift )
+     (clarsimp)
+
 lemma refill_new_invs[wp]:
   "\<lbrace>invs and K (sc_ptr \<noteq> idle_sc_ptr)\<rbrace>
    refill_new sc_ptr max_refills budget period
    \<lbrace>\<lambda>_. invs\<rbrace>"
   by (wpsimp simp: refill_new_def split_del: if_split
-             wp: set_sc_obj_ref_invs_no_change hoare_vcg_all_lift hoare_vcg_imp_lift'
-                 hoare_vcg_disj_lift )
+               wp: set_sc_obj_ref_invs_no_change hoare_vcg_all_lift hoare_vcg_imp_lift'
+                   hoare_vcg_disj_lift )
 
 
 lemma set_consumed_invs[wp]:

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -2666,45 +2666,31 @@ lemma updateRefillHd_def2:
   by (clarsimp simp: updateRefillHd_def updateScPtr_def)
 
 lemma refillBudgetCheckRoundRobin_invs'[wp]:
-  "refillBudgetCheckRoundRobin consumed \<lbrace>invs'\<rbrace>"
+  "\<lbrace>invs' and (\<lambda>s. active_sc_at' (ksCurSc s) s)\<rbrace>
+   refillBudgetCheckRoundRobin consumed
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
   supply if_split [split del]
   apply (simp add: refillBudgetCheckRoundRobin_def)
   apply (wpsimp simp: updateRefillTl_def2 updateRefillHd_def2 wp: updateScPtr_refills_invs')
-          apply (rule_tac Q="\<lambda>_. invs' and active_sc_at' scPtr" in hoare_strengthen_post[rotated])
-           apply clarsimp
-           apply (intro conjI)
-            apply (fastforce dest: invs'_ko_at_idle_sc_is_idle')
-           apply (intro allI impI)
-           apply (frule (1) invs'_ko_at_valid_sched_context', clarsimp)
-           apply (frule scRefills_length_replaceAt_Tail)
-           apply (clarsimp simp: valid_sched_context'_def active_sc_at'_def obj_at'_real_def
-                                 ko_wp_at'_def valid_sched_context_size'_def objBits_def objBitsKO_def)
-          apply (wpsimp wp: updateScPtr_refills_invs' getCurTime_wp updateScPtr_active_sc_at')
-         apply (wpsimp wp: getCurTime_wp)
-        apply (wpsimp simp: setRefillHd_def updateRefillHd_def2
-                        wp: updateScPtr_refills_invs' mapScPtr_wp)
-        apply (rule_tac Q="\<lambda>_. invs' and active_sc_at' scPtr" in hoare_strengthen_post[rotated])
-         apply clarsimp
-         apply (intro conjI)
-          apply (fastforce dest: invs'_ko_at_idle_sc_is_idle')
-         apply (intro allI impI)
-         apply (frule invs'_ko_at_valid_sched_context', simp, clarsimp)
-           apply (frule scRefills_length_replaceAt_Hd)
-         apply (clarsimp simp: valid_sched_context'_def active_sc_at'_def obj_at'_real_def ko_wp_at'_def
-                               valid_sched_context_size'_def objBits_def objBitsKO_def)
-        apply (wpsimp wp: updateScPtr_refills_invs' updateScPtr_active_sc_at' mapScPtr_wp scActive_wp)+
-  apply (subgoal_tac "(\<forall>ko. ko_at' ko idle_sc_ptr s \<longrightarrow> idle_sc' ko)", clarsimp)
-   apply (intro conjI)
-    apply (intro allI impI)
-    apply (frule invs'_ko_at_valid_sched_context', simp, clarsimp)
-    apply (frule scRefills_length_replaceAt_Hd)
-    apply (clarsimp simp: valid_sched_context'_def active_sc_at'_def obj_at'_real_def ko_wp_at'_def
-                          valid_sched_context_size'_def objBits_def objBitsKO_def)
-   apply (intro allI impI)
-   apply (frule invs'_ko_at_valid_sched_context', simp, clarsimp)
-   apply (clarsimp simp: valid_sched_context'_def active_sc_at'_def obj_at'_real_def ko_wp_at'_def
-                         valid_sched_context_size'_def objBits_def objBitsKO_def)
-  apply (fastforce dest: invs'_ko_at_idle_sc_is_idle')
+    apply (rule_tac Q="\<lambda>_. invs' and active_sc_at' scPtr" in hoare_strengthen_post[rotated])
+     apply clarsimp
+     apply (intro conjI)
+      apply (fastforce dest: invs'_ko_at_idle_sc_is_idle')
+     apply (intro allI impI)
+     apply (frule (1) invs'_ko_at_valid_sched_context', clarsimp)
+     apply (frule scRefills_length_replaceAt_Tail)
+     apply (clarsimp simp: valid_sched_context'_def active_sc_at'_def obj_at'_real_def
+                           ko_wp_at'_def valid_sched_context_size'_def objBits_def objBitsKO_def)
+    apply (wpsimp wp: updateScPtr_refills_invs' getCurTime_wp updateScPtr_active_sc_at')
+   apply (wpsimp wp: )
+  apply clarsimp
+  apply (intro conjI)
+   apply (fastforce dest: invs'_ko_at_idle_sc_is_idle')
+  apply (intro allI impI)
+  apply (frule invs'_ko_at_valid_sched_context', simp, clarsimp)
+  apply (frule scRefills_length_replaceAt_Hd)
+  apply (clarsimp simp: valid_sched_context'_def active_sc_at'_def obj_at'_real_def ko_wp_at'_def
+                        valid_sched_context_size'_def objBits_def objBitsKO_def)
   done
 
 lemma scheduleUsed_invs'[wp]:
@@ -2821,7 +2807,7 @@ lemma commitTime_invs':
        apply (wpsimp wp: isRoundRobin_wp)
       apply (fastforce dest: invs'_ko_at_idle_sc_is_idle')
      apply (wpsimp wp: getConsumedTime_wp mapScPtr_wp getCurSc_wp)+
-  done
+  by (clarsimp simp: active_sc_at'_def obj_at'_real_def ko_wp_at'_def)
 
 crunches refillUnblockCheckMergable
   for inv[wp]: P

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -992,7 +992,7 @@ On some architectures, the thread context may include registers that may be modi
 > chargeBudget consumed canTimeoutFault isCurCPU = do
 >     scPtr <- getCurSc
 >     ifM (isRoundRobin scPtr)
->       (refillBudgetCheckRoundRobin consumed)
+>       (refillResetRR scPtr)
 >       (refillBudgetCheck consumed)
 >     updateScPtr scPtr $ \sc -> sc { scConsumed = scConsumed sc + consumed }
 >     setConsumedTime 0


### PR DESCRIPTION
This change to the abstract spec bring the `rt` branch closer to `master` by simplifying how round-robin scheduling contexts are handled in some cases.

It based on the commit here:
https://bitbucket.ts.data61.csiro.au/projects/SEL4/repos/sel4/pull-requests/1781/commits/17e54fa8d0e389b44c7f87b91c35b568fcc14924#include/kernel/sporadic.h
in the pull-request here:
https://bitbucket.ts.data61.csiro.au/projects/SEL4/repos/sel4/pull-requests/1781/commits