### PR TITLE
Prove suspend_corres

### DIFF
--- a/proof/invariant-abstract/CNodeInv_AI.thy
+++ b/proof/invariant-abstract/CNodeInv_AI.thy
@@ -2023,13 +2023,22 @@ lemma tcb_valid_nonspecial_cap:
   apply (clarsimp simp: eq_commute)
   done
 
+lemma sched_context_cancel_yield_to_halted:
+  "sched_context_cancel_yield_to thread \<lbrace>st_tcb_at halted thread\<rbrace>"
+  apply (clarsimp simp: sched_context_cancel_yield_to_def get_tcb_obj_ref_def)
+  apply (wpsimp wp: thread_get_wp)
+  apply (clarsimp simp: pred_tcb_at_def obj_at_def is_tcb_def)
+  done
 
 lemma suspend_makes_halted[wp]:
   "\<lbrace>valid_objs\<rbrace> SchedContext_A.suspend thread \<lbrace>\<lambda>_. st_tcb_at halted thread\<rbrace>"
   unfolding SchedContext_A.suspend_def
-  by (wp hoare_strengthen_post [OF sts_st_tcb_at]
-    | clarsimp elim!: pred_tcb_weakenE)+
-
+  apply (simp flip: bind_assoc)
+  apply (rule hoare_seq_ext[OF sched_context_cancel_yield_to_halted])
+  apply (simp add: bind_assoc)
+  apply (wp hoare_strengthen_post [OF sts_st_tcb_at] gbn_wp
+         | clarsimp elim!: pred_tcb_weakenE)+
+  done
 
 lemmas tcb_at_cte_at_2 = tcb_at_cte_at [where ref="tcb_cnode_index 2",
                                         simplified dom_tcb_cap_cases]

--- a/proof/invariant-abstract/Finalise_AI.thy
+++ b/proof/invariant-abstract/Finalise_AI.thy
@@ -461,7 +461,8 @@ lemma suspend_caps_of_state:
            \<and> P (caps_of_state s)\<rbrace>
      suspend t
    \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
-  by (wpsimp wp: cancel_ipc_caps_of_state hoare_drop_imps simp: suspend_def fun_upd_def[symmetric])+
+  by (wpsimp wp: cancel_ipc_caps_of_state hoare_drop_imps
+           simp: suspend_def sched_context_cancel_yield_to_def fun_upd_def[symmetric])+
 
 lemma suspend_final_cap:
   "\<lbrace>\<lambda>s. is_final_cap' cap s \<and> \<not> can_fast_finalise cap

--- a/proof/invariant-abstract/Tcb_AI.thy
+++ b/proof/invariant-abstract/Tcb_AI.thy
@@ -146,8 +146,8 @@ lemma suspend_nonz_cap_to_tcb[wp]:
   "\<lbrace>\<lambda>s. ex_nonz_cap_to t s \<and> tcb_at t s \<and> valid_objs s\<rbrace>
      suspend t'
    \<lbrace>\<lambda>rv s. ex_nonz_cap_to t s\<rbrace>"
-  unfolding suspend_def
-  by (wpsimp wp: cancel_ipc_ex_nonz_cap_to_tcb wp: hoare_drop_imps)
+  unfolding suspend_def sched_context_cancel_yield_to_def
+  by (wpsimp wp: cancel_ipc_ex_nonz_cap_to_tcb hoare_drop_imps)
 
 lemmas suspend_tcb_at[wp] = tcb_at_typ_at [OF suspend_typ_at]
 


### PR DESCRIPTION
This proves `suspend_corres`.

I reordered the abstract definition of `suspend` to make the corres proof more straightforward. I also introduced the definition `sched_context_cancel_yield_to`, in analogy with the Haskell and C definitions