### PR TITLE
Update set_next_interrupt

### DIFF
--- a/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
@@ -1685,10 +1685,6 @@ lemma dmo_setDeadline[wp]: "\<lbrace>invs\<rbrace> do_machine_op (setDeadline t)
   apply(erule (1) use_valid[OF _ setDeadline_irq_masks])
   done
 
-lemma set_next_timer_interrupt_invs [wp]:
-  "\<lbrace>invs\<rbrace> set_next_timer_interrupt t' \<lbrace>\<lambda>_. invs\<rbrace>"
-  by (wpsimp simp: set_next_timer_interrupt_def)
-
 lemma svr_invs [wp]:
   "\<lbrace>invs\<rbrace> set_vm_root t' \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: set_vm_root_def)

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -3235,10 +3235,6 @@ crunches commit_domain_time
   for obj_at[wp]: "\<lambda>s. N (obj_at P t s)"
   and kheap[wp]: "\<lambda>s. P (kheap s)"
 
-lemma set_next_timer_interrupt_valid_sched[wp]:
-  "set_next_timer_interrupt thread_time \<lbrace>valid_sched_pred_strong P\<rbrace>"
-  by (wpsimp simp: set_next_timer_interrupt_def)
-
 lemma set_next_interrupt_valid_sched[wp]:
   "set_next_interrupt \<lbrace>valid_sched_pred_strong P\<rbrace>"
   by (wpsimp simp: set_next_interrupt_def wp: hoare_drop_imp)

--- a/proof/invariant-abstract/SchedContext_AI.thy
+++ b/proof/invariant-abstract/SchedContext_AI.thy
@@ -727,7 +727,7 @@ lemma refill_unblock_check_bound_sc_tcb_at [wp]:
   by (wpsimp simp: refill_unblock_check_def get_refills_def is_round_robin_def)
 
 lemma set_next_interrupt_invs[wp]: "\<lbrace>invs\<rbrace> set_next_interrupt \<lbrace>\<lambda>rv. invs\<rbrace>"
-  by (wpsimp wp: hoare_drop_imp get_sched_context_wp set_next_timer_interrupt_invs
+  by (wpsimp wp: hoare_drop_imp get_sched_context_wp dmo_setDeadline
            simp: set_next_interrupt_def)
 
 lemma valid_state_consumed_time_update[iff]:
@@ -832,23 +832,11 @@ lemma switch_sched_context_ct_in_state[wp]:
   by (wpsimp simp: switch_sched_context_def get_tcb_queue_def get_sc_obj_ref_def
              wp: hoare_drop_imp hoare_vcg_if_lift2)
 
-(* FIXME Move *)
-context Arch begin global_naming ARM
-
-lemma set_next_interrupt_activatable:
-  "\<lbrace>ct_in_state activatable\<rbrace> set_next_timer_interrupt t \<lbrace>\<lambda>rv. ct_in_state activatable\<rbrace>"
-  apply (clarsimp simp: set_next_timer_interrupt_def)
-  apply (wpsimp simp: ct_in_state_def wp: ct_in_state_thread_state_lift)
-  done
-
-end
-
 lemma set_next_interrupt_activatable:
   "\<lbrace>ct_in_state activatable\<rbrace> set_next_interrupt \<lbrace>\<lambda>rv. ct_in_state activatable\<rbrace>"
-  apply (clarsimp simp: set_next_interrupt_def set_next_timer_interrupt_def)
+  apply (clarsimp simp: set_next_interrupt_def)
   apply (wpsimp simp: ct_in_state_def
-      wp: hoare_drop_imp ct_in_state_thread_state_lift
-         ARM.set_next_interrupt_activatable[simplified ARM.set_next_interrupt_activatable, simplified])
+      wp: hoare_drop_imp ct_in_state_thread_state_lift)
   done
 
 

--- a/proof/invariant-abstract/VSpace_AI.thy
+++ b/proof/invariant-abstract/VSpace_AI.thy
@@ -16,7 +16,7 @@ context begin interpretation Arch .
 requalify_facts
    pspace_respects_device_region_dmo
    cap_refs_respects_device_region_dmo
-   set_next_timer_interrupt_invs
+   dmo_setDeadline
 end
 
 lemmas device_region_dmos = pspace_respects_device_region_dmo

--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -71,16 +71,6 @@ definition
   "dec_domain_time = modify (\<lambda>s. s\<lparr>domain_time := domain_time s - 1\<rparr>)"
 
 definition
-  set_next_timer_interrupt :: "time \<Rightarrow> (unit, 'z::state_ext) s_monad"
-where
-  "set_next_timer_interrupt thread_time = do
-     cur_tm \<leftarrow> gets cur_time;
-     domain_tm \<leftarrow> gets domain_time;
-     new_domain_tm \<leftarrow> return $ cur_tm + domain_tm;
-     do_machine_op $ setDeadline (min thread_time new_domain_tm - timerPrecision)
-  od"
-
-definition
   set_next_interrupt :: "(unit, 'z::state_ext) s_monad"
 where
   "set_next_interrupt = do
@@ -89,15 +79,21 @@ where
      sc_opt \<leftarrow> get_tcb_obj_ref tcb_sched_context cur_th;
      sc_ptr \<leftarrow> assert_opt sc_opt;
      sc \<leftarrow> get_sched_context sc_ptr;
-     new_thread_time \<leftarrow> return $ cur_tm + r_amount (refill_hd sc);
+     next_interrupt \<leftarrow> return $ cur_tm + r_amount (refill_hd sc);
+     next_interrupt \<leftarrow>
+     if num_domains > 1 then do
+       domain_tm \<leftarrow> gets domain_time;
+       return $ min next_interrupt (cur_tm + domain_tm) od
+     else
+       return next_interrupt;
      rq \<leftarrow> gets release_queue;
-     new_thread_time \<leftarrow> if rq = [] then return new_thread_time else do
+     next_interrupt \<leftarrow> if rq = [] then return next_interrupt else do
        rqsc_opt \<leftarrow> get_tcb_obj_ref tcb_sched_context (hd rq);
        rqsc_ptr \<leftarrow> assert_opt rqsc_opt;
        rqsc \<leftarrow> get_sched_context rqsc_ptr;
-       return $ min (r_time (refill_hd rqsc)) new_thread_time
+       return $ min (r_time (refill_hd rqsc)) next_interrupt
      od;
-     set_next_timer_interrupt new_thread_time
+     do_machine_op $ setDeadline (next_interrupt - timerPrecision)
   od"
 
 definition


### PR DESCRIPTION
It appears that set_next_interrupt was not in line with master MCS kernel. This spec update should bring us back in line with master.

See https://github.com/seL4/seL4/blob/master/src/kernel/thread.c#L566