### PR TITLE
Update switch_sched_context

### DIFF
--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -108,15 +108,11 @@ where
     cur_th \<leftarrow> gets cur_thread;
     sc_opt \<leftarrow> get_tcb_obj_ref tcb_sched_context cur_th;
     scp \<leftarrow> assert_opt sc_opt;
-    sc' \<leftarrow> get_sched_context scp;
+    sc' \<leftarrow> get_sched_context cur_sc;
 
     when (scp \<noteq> cur_sc \<and> 0 < sc_refill_max sc') $ do
       modify (\<lambda>s. s\<lparr>reprogram_timer := True\<rparr>);
-      refill_unblock_check scp;
-      sc \<leftarrow> get_sched_context scp;
-      curtime \<leftarrow> gets cur_time;
-      assert $ sc_refill_sufficient 0 sc;
-      assert $ sc_refill_ready curtime sc   \<comment> \<open>asserting @{text \<open>ready & sufficient\<close>}\<close>
+      refill_unblock_check scp
      od;
 
     reprogram \<leftarrow> gets reprogram_timer;

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -1052,10 +1052,10 @@ On some architectures, the thread context may include registers that may be modi
 > switchSchedContext :: Kernel ()
 > switchSchedContext = do
 >     scPtr <- getCurSc
->     sc <- getSchedContext scPtr
 >     ct <- getCurThread
 >     scOpt <- threadGet tcbSchedContext ct
 >     csc <- return $ fromJust scOpt
+>     sc <- getSchedContext scPtr
 >     when (csc /= scPtr && scRefillMax sc /= 0) $ do
 >         setReprogramTimer True
 >         refillUnblockCheck csc


### PR DESCRIPTION
This is a very simple improvement that removes some assertions from the abstract spec and tweaks the haskell spec to match the abstract spec.

No proof changes are required because this change is so small.