### PR TITLE
Remove runnable

### DIFF
--- a/proof/refine/ARM/CSpace_R.thy
+++ b/proof/refine/ARM/CSpace_R.thy
@@ -1082,27 +1082,13 @@ lemma bitmapQ_no_L2_orphans_lift:
 
 lemma valid_queues_lift_asm:
   assumes tat1: "\<And>d p tcb. \<lbrace>obj_at' (inQ d p) tcb and Q \<rbrace> f \<lbrace>\<lambda>_. obj_at' (inQ d p) tcb\<rbrace>"
-  and     tat2: "\<And>tcb. \<lbrace>st_tcb_at' runnable' tcb and Q \<rbrace> f \<lbrace>\<lambda>_. st_tcb_at' runnable' tcb\<rbrace>"
   and     prq: "\<And>P. \<lbrace>\<lambda>s. P (ksReadyQueues s) \<rbrace> f \<lbrace>\<lambda>_ s. P (ksReadyQueues s)\<rbrace>"
   and     prqL1: "\<And>P. \<lbrace>\<lambda>s. P (ksReadyQueuesL1Bitmap s)\<rbrace> f \<lbrace>\<lambda>_ s. P (ksReadyQueuesL1Bitmap s)\<rbrace>"
   and     prqL2: "\<And>P. \<lbrace>\<lambda>s. P (ksReadyQueuesL2Bitmap s)\<rbrace> f \<lbrace>\<lambda>_ s. P (ksReadyQueuesL2Bitmap s)\<rbrace>"
-  shows   "\<lbrace>Invariants_H.valid_queues and Q\<rbrace> f \<lbrace>\<lambda>_. Invariants_H.valid_queues\<rbrace>"
-  proof -
-    have tat:  "\<And>d p tcb. \<lbrace>obj_at' (inQ d p) tcb and st_tcb_at' runnable' tcb and Q\<rbrace> f
-                         \<lbrace>\<lambda>_. obj_at' (inQ d p) tcb and st_tcb_at' runnable' tcb\<rbrace>"
-      apply (rule hoare_chain [OF hoare_vcg_conj_lift [OF tat1 tat2]])
-       apply (fastforce)+
-       done
-    have tat_combined: "\<And>d p tcb. \<lbrace>obj_at' (inQ d p and runnable' \<circ> tcbState) tcb and Q\<rbrace> f
-                         \<lbrace>\<lambda>_. obj_at' (inQ d p and runnable' \<circ> tcbState) tcb\<rbrace>"
-      apply (rule hoare_chain [OF tat])
-       apply (fastforce simp add: obj_at'_and pred_tcb_at'_def o_def)+
-      done
-    show ?thesis unfolding valid_queues_def valid_queues_no_bitmap_def
-      by (wp tat_combined prq prqL1 prqL2 valid_bitmapQ_lift bitmapQ_no_L2_orphans_lift
-             bitmapQ_no_L1_orphans_lift hoare_vcg_all_lift hoare_vcg_conj_lift hoare_Ball_helper)
-         simp_all
-  qed
+  shows   "\<lbrace>valid_queues and Q\<rbrace> f \<lbrace>\<lambda>_. valid_queues\<rbrace>"
+  unfolding valid_queues_def valid_queues_no_bitmap_def
+  by (wpsimp wp: tat1 prq prqL1 prqL2 valid_bitmapQ_lift bitmapQ_no_L2_orphans_lift
+                 bitmapQ_no_L1_orphans_lift hoare_vcg_all_lift hoare_Ball_helper)
 
 lemmas valid_queues_lift = valid_queues_lift_asm[where Q="\<lambda>_. True", simplified]
 

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -78,7 +78,6 @@ crunch obj_at'[wp]: postCapDeletion "\<lambda>s. Q (obj_at' P p s)"
 
 lemmas postCapDeletion_valid_queues[wp] =
     valid_queues_lift [OF postCapDeletion_obj_at'
-                          postCapDeletion_pred_tcb_at'
                           postCapDeletion_ksRQ]
 
 crunch inQ[wp]: clearUntypedFreeIndex "\<lambda>s. P (obj_at' (inQ d p) t s)"
@@ -2800,10 +2799,11 @@ lemma cancelIPC_cteCaps_of:
    \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
   apply (simp add: cancelIPC_def Let_def capHasProperty_def locateSlot_conv)
   apply (rule hoare_seq_ext_skip, wpsimp)
+  apply (rule hoare_seq_ext_skip, wpsimp)
   apply (rule hoare_pre)
    apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw
-        | simp add: cte_wp_at_ctes_of
-        | wp (once) hoare_drop_imps ctes_of_cteCaps_of_lift)+
+          | simp add: cte_wp_at_ctes_of
+          | wp (once) hoare_drop_imps ctes_of_cteCaps_of_lift)+
           apply (wp hoare_convert_imp hoare_vcg_all_lift
                     threadSet_ctes_of threadSet_cteCaps_of
                | clarsimp)+

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -1035,9 +1035,12 @@ definition
   valid_queues_no_bitmap :: "kernel_state \<Rightarrow> bool"
 where
  "valid_queues_no_bitmap \<equiv> \<lambda>s.
-   (\<forall>d p. (\<forall>t \<in> set (ksReadyQueues s (d, p)). obj_at' (inQ d p and runnable' \<circ> tcbState) t s)
-    \<and>  distinct (ksReadyQueues s (d, p))
-    \<and> (d > maxDomain \<or> p > maxPriority \<longrightarrow> ksReadyQueues s (d,p) = []))"
+   (\<forall>d p. (\<forall>t \<in> set (ksReadyQueues s (d, p)). obj_at' (inQ d p) t s)
+          \<and> distinct (ksReadyQueues s (d, p))
+          \<and> (d > maxDomain \<or> p > maxPriority \<longrightarrow> ksReadyQueues s (d,p) = []))"
+
+defs ready_qs_runnable_def:
+  "ready_qs_runnable \<equiv> \<lambda>s. \<forall>d p. \<forall>t \<in> set (ksReadyQueues s (d, p)). st_tcb_at' runnable' t s"
 
 definition
   (* A priority is used as a two-part key into the bitmap structure. If an L2 bitmap entry
@@ -3495,15 +3498,7 @@ lemma objBitsT_simps:
 lemma valid_queues_obj_at'D:
    "\<lbrakk> t \<in> set (ksReadyQueues s (d, p)); valid_queues s \<rbrakk>
         \<Longrightarrow> obj_at' (inQ d p) t s"
-  apply (unfold valid_queues_def valid_queues_no_bitmap_def)
-  apply (elim conjE)
-  apply (drule_tac x=d in spec)
-  apply (drule_tac x=p in spec)
-  apply (clarsimp)
-  apply (drule(1) bspec)
-  apply (erule obj_at'_weakenE)
-  apply (clarsimp)
-  done
+  by (fastforce simp: valid_queues_def valid_queues_no_bitmap_def)
 
 lemma obj_at'_and:
   "obj_at' (P and P') t s = (obj_at' P t s \<and> obj_at' P' t s)"
@@ -3558,9 +3553,9 @@ lemma pred_tcb_at'_imp:
 
 lemma valid_queues_no_bitmap_def':
   "valid_queues_no_bitmap =
-     (\<lambda>s. \<forall>d p. (\<forall>t\<in>set (ksReadyQueues s (d, p)).
-                  obj_at' (inQ d p) t s \<and> st_tcb_at' runnable' t s) \<and>
-                  distinct (ksReadyQueues s (d, p)) \<and> (d > maxDomain \<or> p > maxPriority \<longrightarrow> ksReadyQueues s (d,p) = []))"
+     (\<lambda>s. \<forall>d p. (\<forall>t\<in>set (ksReadyQueues s (d, p)). obj_at' (inQ d p) t s) \<and>
+                distinct (ksReadyQueues s (d, p)) \<and>
+                (d > maxDomain \<or> p > maxPriority \<longrightarrow> ksReadyQueues s (d,p) = []))"
   apply (rule ext, rule iffI)
   apply (clarsimp simp: valid_queues_def valid_queues_no_bitmap_def obj_at'_and pred_tcb_at'_def o_def
                   elim!: obj_at'_weakenE)+

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -5044,8 +5044,6 @@ lemma createObjects_queues:
   \<lbrace>\<lambda>rv. valid_queues\<rbrace>"
   apply (wp valid_queues_lift_asm [unfolded pred_conj_def, OF createObjects_orig_obj_at3]
             createObjects_pred_tcb_at' [unfolded pred_conj_def])
-      apply fastforce
-     apply wp+
   apply fastforce
   done
 

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -702,6 +702,10 @@ lemma state_relation_pspace_relation[elim!]:
   "(s,s') \<in> state_relation \<Longrightarrow> pspace_relation (kheap s) (ksPSpace s')"
   by (simp add: state_relation_def)
 
+lemma state_relation_ready_queues_relation[elim!]:
+  "(s, s') \<in> state_relation \<Longrightarrow> ready_queues_relation (ready_queues s) (ksReadyQueues s')"
+  by (simp add: state_relation_def)
+
 lemma state_relation_release_queue_relation:
   "(s,s') \<in> state_relation \<Longrightarrow> release_queue_relation (release_queue s) (ksReleaseQueue s')"
   by (clarsimp simp: state_relation_def)

--- a/spec/design/skel/KernelStateData_H.thy
+++ b/spec/design/skel/KernelStateData_H.thy
@@ -93,7 +93,7 @@ where
     return r
   od"
 
-#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue Kernel assert stateAssert findM funArray newKernelState capHasProperty ifM whenM whileM andM orM maybeToMonad sym_refs_asrt
-#INCLUDE_HASKELL SEL4/Model/StateData.lhs decls_only ONLY capHasProperty sym_refs_asrt
+#INCLUDE_HASKELL SEL4/Model/StateData.lhs decls_only ONLY capHasProperty sym_refs_asrt ready_qs_runnable
+#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue Kernel assert stateAssert findM funArray newKernelState capHasProperty ifM whenM whileM andM orM maybeToMonad sym_refs_asrt ready_qs_runnable
 
 end

--- a/spec/haskell/src/SEL4/Kernel/Thread.lhs
+++ b/spec/haskell/src/SEL4/Kernel/Thread.lhs
@@ -435,6 +435,7 @@ Note also that the level 2 bitmap array is stored in reverse in order to get bet
 
 > chooseThread :: Kernel ()
 > chooseThread = do
+>     stateAssert ready_qs_runnable "Threads in the ready queues are runnable'"
 >     curdom <- if numDomains > 1 then curDomain else return 0
 >     l1 <- getReadyQueuesL1Bitmap curdom
 >     if l1 /= 0
@@ -461,6 +462,8 @@ To switch to a new thread, we call the architecture-specific thread switch funct
 
 > switchToThread :: PPtr TCB -> Kernel ()
 > switchToThread thread = do
+>         stateAssert ready_qs_runnable
+>            "Threads in the ready queues are runnable'"
 >         Arch.switchToThread thread
 >         tcbSchedDequeue thread
 >         setCurThread thread
@@ -469,6 +472,8 @@ Switching to the idle thread is similar, except that we call a different archite
 
 > switchToIdleThread :: Kernel ()
 > switchToIdleThread = do
+>         stateAssert ready_qs_runnable
+>             "Threads in the ready queues are runnable'"
 >         thread <- getIdleThread
 >         Arch.switchToIdleThread
 >         setCurThread thread

--- a/spec/haskell/src/SEL4/Model/StateData.lhs
+++ b/spec/haskell/src/SEL4/Model/StateData.lhs
@@ -165,7 +165,15 @@ replaces the previous one.
 > getCurThread = gets ksCurThread
 
 > setCurThread :: PPtr TCB -> Kernel ()
-> setCurThread tptr = modify (\ks -> ks { ksCurThread = tptr })
+> setCurThread tptr = do
+>   stateAssert ready_qs_runnable "Threads in the ready queues are runnable'"
+>   modify (\ks -> ks { ksCurThread = tptr })
+
+In many places, we would like to be able to use the fact that threads in the
+ready queues have runnable' thread state. We add an assertion that it does hold.
+
+> ready_qs_runnable :: KernelState -> Bool
+> ready_qs_runnable _ = True
 
 Similarly, these functions access the idle thread pointer, the ready queue for a given priority level (adjusted to account for the active security domain), the requested action of the scheduler, and the interrupt handler state.
 

--- a/spec/haskell/src/SEL4/Object/Endpoint.lhs
+++ b/spec/haskell/src/SEL4/Object/Endpoint.lhs
@@ -211,6 +211,8 @@ If a thread is waiting for an IPC operation, it may be necessary to move the thr
 > cancelIPC tptr = do
 >         stateAssert sym_refs_asrt
 >             "Assert that `sym_refs (state_refs_of' s)` holds"
+>         stateAssert ready_qs_runnable
+>             "Threads in the ready queues are runnable'"
 >         state <- getThreadState tptr
 >         threadSet (\tcb -> tcb {tcbFault = Nothing}) tptr
 >         case state of

--- a/spec/haskell/src/SEL4/Object/Notification.lhs
+++ b/spec/haskell/src/SEL4/Object/Notification.lhs
@@ -163,6 +163,8 @@ The following function will remove the given thread from the queue of the notifi
 
 > cancelSignal :: PPtr TCB -> PPtr Notification -> Kernel ()
 > cancelSignal threadPtr ntfnPtr = do
+>         stateAssert ready_qs_runnable
+>             "Threads in the ready queues are runnable'"
 >         ntfn <- getNotification ntfnPtr
 >         assert (isWaiting (ntfnObj ntfn))
 >             "cancelSignal: notification object must be waiting"

--- a/spec/haskell/src/SEL4/Object/Structures.lhs
+++ b/spec/haskell/src/SEL4/Object/Structures.lhs
@@ -576,3 +576,5 @@ Various operations on the free index of an Untyped cap.
 >         startPtr = getFreeRef (capPtr cap) (capFreeIndex cap)
 >         endPtr = capPtr cap + PPtr (2 ^ capBlockSize cap) - 1
 > untypedZeroRange _ = Nothing
+
+

--- a/spec/haskell/src/SEL4/Object/Structures.lhs
+++ b/spec/haskell/src/SEL4/Object/Structures.lhs
@@ -576,5 +576,3 @@ Various operations on the free index of an Untyped cap.
 >         startPtr = getFreeRef (capPtr cap) (capFreeIndex cap)
 >         endPtr = capPtr cap + PPtr (2 ^ capBlockSize cap) - 1
 > untypedZeroRange _ = Nothing
-
-


### PR DESCRIPTION
This removes the condition on the thread state from `valid_queues` by using asserts instead (similar to the `sym_refs_asrt`)