### PR TITLE
asmrefine: support small array index types

### DIFF
--- a/lib/Word_Lib/Word_Lemmas_Internal.thy
+++ b/lib/Word_Lib/Word_Lemmas_Internal.thy
@@ -400,4 +400,16 @@ lemma le_smaller_mask:
   "\<lbrakk> x \<le> mask n; n \<le> m \<rbrakk> \<Longrightarrow> x \<le> mask m"
   by (erule (1) order.trans[OF _ mask_mono])
 
+(* The strange phrasing and ordering of assumptions is to support using this as a
+   conditional simp rule when y is a concrete value. For example, as a simp rule,
+   it will solve a goal of the form:
+     UCAST(8 \<rightarrow> 32) x < 0x20 \<Longrightarrow> unat x < 32
+   This is used in an obscure corner of SimplExportAndRefine. *)
+lemma upcast_less_unat_less:
+  assumes less: "UCAST('a \<rightarrow> 'b) x < UCAST('a \<rightarrow> 'b) (of_nat y)"
+  assumes len: "LENGTH('a::len) \<le> LENGTH('b::len)"
+  assumes bound: "y < 2 ^ LENGTH('a)"
+  shows "unat x < y"
+  by (rule unat_mono[OF less, simplified unat_ucast_up_simp[OF len] unat_of_nat_eq[OF bound]])
+
 end

--- a/tools/asmrefine/ProveGraphRefine.thy
+++ b/tools/asmrefine/ProveGraphRefine.thy
@@ -484,7 +484,7 @@ fun prove_ptr_safe reason ctxt = DETERM o
                    ptr_safe_Array_element unat_less_helper unat_def[symmetric]
                    ptr_safe_Array_element_0
                    h_t_valid_Array_element' h_t_valid_field
-                   nat_uint_less_helper})
+                   nat_uint_less_helper upcast_less_unat_less})
         THEN_ALL_NEW except_tac ctxt
             ("prove_ptr_safe: failed for " ^ reason)
     )


### PR DESCRIPTION
This is a small preemptive update to asmrefine to support a forthcoming kernel patch that will speed up binary verification for the RISC-V MCS kernel. The kernel patch will compress read-only data, by making `register_t` a `typedef` of `uint8_t`, whereas it was previously `word_t`. Lists of registers used in IPC messages are therefore correspondingly smaller, and cause less overhead in binary verification. This asmrefine patch adds support for indexing into the user context with a variable of type `uint8_t`.