### PR TITLE
haskell: deal with existing "~/.stack"

### DIFF
--- a/spec/haskell/Makefile
+++ b/spec/haskell/Makefile
@@ -74,7 +74,7 @@ build-riscv: sandbox $(BOOT_FILES)
 # cabal package database is missing, the build will fail.
 
 .stack-work:
-	mkdir ~/.stack
+	mkdir -p ~/.stack
 	stack --install-ghc build cabal-install
 
 $(CUSTOM_BOOT_FILES):


### PR DESCRIPTION
Bring happiness to both bamboo and github: create ~/.stack, but don't fail if it's there.

(forgot to cherry-pick this one, and it's of course the only one that github tests are not going to pick up) 
