### PR TITLE
clib: add a `hoarep_rewrite` method

### DIFF
--- a/lib/clib/CCorres_Rewrite.thy
+++ b/lib/clib/CCorres_Rewrite.thy
@@ -8,40 +8,48 @@ theory CCorres_Rewrite
 imports Corres_UL_C Simpl_Rewrite
 begin
 
-text \<open>A simple proof method for rewriting Simpl programs under @{term ccorres_underlying}.\<close>
+text \<open>Simple proof methods for rewriting Simpl programs under @{term ccorres_underlying}
+      and @{term hoarep}.\<close>
 
-locale ccorres_rewrite_locale =
-  simpl_rewrite \<Gamma> "ccorres_underlying sr \<Gamma> r xf r' xf' P P' hs H"
-  for \<Gamma> sr r xf r' xf' P P' hs H
-
-global_interpretation ccorres_rewrite: ccorres_rewrite_locale
-  by unfold_locales (auto simp: simpl_rewrite_base.com_eq_def semantic_equiv_def ceqv_def
-                          elim: ccorres_semantic_equivD2)
+lemma ccorres_com_eq_hom:
+  "com_eq_hom \<Gamma> (ccorres_underlying sr \<Gamma> r xf r' xf' P P' hs H)"
+  by (auto simp: com_eq_hom_def com_eq_def semantic_equiv_def ceqv_def
+           elim: ccorres_semantic_equivD2)
 
 method ccorres_rewrite declares C_simp C_simp_pre C_simp_simps C_simp_throws
-  = ccorres_rewrite.simpl_rewrite
+  = simpl_rewrite hom: ccorres_com_eq_hom
 
-abbreviation "com_eq \<Gamma> \<equiv> ccorres_rewrite.com_eq \<Gamma> True"
-abbreviation "never_continues \<Gamma> \<equiv> ccorres_rewrite.never_continues \<Gamma> True"
+lemma hoarep_com_eq_hom:
+  "com_eq_hom \<Gamma> (\<lambda>c. hoarep \<Gamma> {} F P c Q A)"
+  by (auto simp: com_eq_hom_def com_eq_def ceqv_def
+           elim: exec_eq_is_valid_eq0[rotated])
 
-lemmas com_eq_def = ccorres_rewrite.com_eq_def
-lemmas never_continues_def = ccorres_rewrite.never_continues_def
+lemma hoarep_spec_com_eq_hom:
+  "com_eq_hom \<Gamma> (\<lambda>c. \<forall>s. hoarep \<Gamma> {} (F s) (P s) c (Q s) (A s))"
+  by (fastforce simp: com_eq_hom_def com_eq_def ceqv_def
+                elim: exec_eq_is_valid_eq0[rotated])
+
+method hoarep_rewrite declares C_simp C_simp_pre C_simp_simps C_simp_throws
+  = (match conclusion in \<open>hoarep \<Gamma> {} F P c Q A\<close> for \<Gamma> F P c Q A
+                           \<Rightarrow> \<open>simpl_rewrite hom: hoarep_com_eq_hom\<close>
+                       \<bar> \<open>\<forall>s. hoarep \<Gamma> {} (F s) (P s) c (Q s) (A s)\<close> for \<Gamma> F P c Q A
+                           \<Rightarrow> \<open>simpl_rewrite hom: hoarep_spec_com_eq_hom\<close>)
 
 text \<open>Some CRefine proofs remove Collect_const from the @{method simp} set,
       but we almost always want @{method ccorres_rewrite} to use it to simplify
       trivial @{text IF} and @{text WHILE} conditions.\<close>
 declare Collect_const [C_simp_simps]
 
-text \<open>Test that the @{command named_theorems} @{thm C_simp} still works in the
-      @{term ccorres_rewrite_locale} interpretation.\<close>
+text \<open>Test\<close>
 
 lemma
-  assumes c3: "com_eq \<Gamma> c3 c"
-  assumes c: "com_eq \<Gamma> (c;;c) c"
+  assumes c3: "com_equiv \<Gamma> c3 c"
+  assumes c: "com_equiv \<Gamma> (c;;c) c"
   shows "ccorres_underlying sr \<Gamma> r xf r' xf' P P' hs H
                             (c;; Guard f UNIV (IF X THEN c ELSE c FI);; Cond {} Skip (Skip;;c2);;
                              Skip;;
                              (IF False THEN Skip ELSE SKIP;; TRY THROW CATCH c3 END FI;; SKIP))"
+  supply Collect_const[simp del]
   apply ccorres_rewrite
   apply (match conclusion in "ccorres_underlying sr \<Gamma> r xf r' xf' P P' hs H (c;;c;;c2;;c3)" \<Rightarrow> \<open>-\<close>)
   apply (ccorres_rewrite C_simp: c3)

--- a/lib/clib/SIMPL_Lemmas.thy
+++ b/lib/clib/SIMPL_Lemmas.thy
@@ -167,8 +167,8 @@ lemma ceqv_sym [sym]:
 lemma exec_eq_is_valid_eq0:
   fixes P :: "'a set"
   assumes eq: "\<And>t t'. (\<Gamma> \<turnstile> \<langle>a, Normal t\<rangle> \<Rightarrow> t') = (\<Gamma> \<turnstile> \<langle>a', Normal t\<rangle> \<Rightarrow> t')"
-  and     vl: "\<Gamma> \<turnstile> P a Q"
-  shows   "\<Gamma> \<turnstile> P a' Q"
+  and     vl: "\<Gamma>\<turnstile>\<^bsub>/F\<^esub> P a Q,A"
+  shows   "\<Gamma>\<turnstile>\<^bsub>/F\<^esub> P a' Q,A"
   using vl
   apply -
   apply (drule hoare_sound)
@@ -184,7 +184,7 @@ lemma exec_eq_is_valid_eq0:
 lemma exec_eq_is_valid_eq:
   fixes P :: "'a set"
   assumes eq: "\<And>t t'. (\<Gamma> \<turnstile> \<langle>a, Normal t\<rangle> \<Rightarrow> t') = (\<Gamma> \<turnstile> \<langle>a', Normal t\<rangle> \<Rightarrow> t')"
-  shows     vl: "(\<Gamma> \<turnstile> P a Q) = (\<Gamma> \<turnstile> P a' Q)"
+  shows     vl: "hoarep \<Gamma> {} F P a Q A = hoarep \<Gamma> {} F P a' Q A"
   apply rule
    apply (erule exec_eq_is_valid_eq0 [OF eq])
   apply (erule exec_eq_is_valid_eq0 [OF eq [symmetric]])

--- a/lib/clib/Simpl_Rewrite.thy
+++ b/lib/clib/Simpl_Rewrite.thy
@@ -14,6 +14,30 @@ imports
   "Lib.Apply_Debug"
 begin
 
+text \<open>One layer of context around a Simpl program.
+
+      For example, if the current focus is the first branch of a @{term Cond},
+      then the context consists of a constructor @{text CondTC} which indicates
+      this is the context, and carries everything but but the focused branch,
+      i.e. the condition and the second branch.
+
+      The @{text CondFC} and @{text HandlerC} cases each carry an extra bit of
+      information, which indicates whether the left-hand branch @{text never_continues}.
+      The assumption here is that we always traverse Simpl programs left-to-right.
+      @{text Seq2C} does not require an extra bit, because we never enter the second
+      command of a @{term Seq} if the first command @{text never_continues}.\<close>
+
+datatype ('s,'p,'f) com_ctxt
+  = Seq1C "('s,'p,'f) com" \<comment> \<open>first command of a @{term Seq}\<close>
+  | Seq2C "('s,'p,'f) com" \<comment> \<open>second command of a @{term Seq}\<close>
+  | CondTC "'s bexp" "('s,'p,'f) com" \<comment> \<open>first branch of a @{term Cond}\<close>
+  | CondFC "'s bexp" "('s,'p,'f) com" bool \<comment> \<open>second branch of a @{term Cond}\<close>
+  | WhileC "'s bexp" \<comment> \<open>body of a @{term While}\<close>
+  | WhileAnnoC "'s bexp" "'s assn" "('s \<times> 's) assn" \<comment> \<open>body of a @{term whileAnno}\<close>
+  | GuardC "'f" "'s bexp" \<comment> \<open>body of a @{term Guard}\<close>
+  | TryC "('s,'p,'f) com" \<comment> \<open>body of a @{term Catch}\<close>
+  | HandlerC "('s,'p,'f) com" bool \<comment> \<open>handler of a @{term Catch}\<close>
+
 text \<open>Definitions and lemmas for reasoning about equivalence of Simpl programs.\<close>
 
 named_theorems C_simp
@@ -21,7 +45,7 @@ named_theorems C_simp_pre
 named_theorems C_simp_simps
 named_theorems C_simp_throws
 
-locale simpl_rewrite_base =
+context
   fixes \<Gamma> :: "'p \<Rightarrow> ('s,'p,'f) com option"
 begin
 
@@ -46,9 +70,7 @@ lemma com_eq_guard_False:
 
 text \<open>Most @{text com_eq} simplification rules will be unguarded, however.\<close>
 
-abbreviation
-  "com_equiv \<equiv> com_eq True"
-
+abbreviation "com_equiv \<equiv> com_eq True"
 notation com_equiv (infix "\<sim>" 10)
 
 text \<open>@{term "com_eq"} is an equivalence relation.\<close>
@@ -204,13 +226,15 @@ lemma com_eq_Catch_Throw [C_simp]:
 
 text \<open>An assertion expressing that a Simpl program never finishes normally.\<close>
 
-definition
-  "never_continues t c \<equiv> t \<longrightarrow> (\<forall>s s'. \<not> \<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal s')"
+definition never_continues_if :: "bool \<Rightarrow> ('s,'p,'f) com \<Rightarrow> bool" where
+  never_continues_def: "never_continues_if t c \<equiv> t \<longrightarrow> (\<forall>s s'. \<not> \<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal s')"
+
+abbreviation "never_continues \<equiv> never_continues_if True"
 
 text \<open>Commands sequenced after a command that @{term never_continues} may be ignored.\<close>
 
 lemma never_continues_def2:
-  "never_continues t c \<equiv> t \<longrightarrow> (\<forall>r. (c;;r) \<sim> c)"
+  "never_continues_if t c \<equiv> t \<longrightarrow> (\<forall>r. (c;;r) \<sim> c)"
   unfolding atomize_eq never_continues_def com_eq_def
   apply (rule iffI; erule (1) imp_forward; clarsimp)
    apply (rule iffI)
@@ -224,20 +248,20 @@ lemma never_continues_def2:
 text \<open>Rules for rewriting the arguments of @{term never_continues}.\<close>
 
 lemma never_continues_weaken_guard:
-  "never_continues t c \<Longrightarrow> (t' \<Longrightarrow> t) \<Longrightarrow> never_continues t' c"
+  "never_continues_if t c \<Longrightarrow> (t' \<Longrightarrow> t) \<Longrightarrow> never_continues_if t' c"
   by (simp add: never_continues_def)
 
 lemma never_continues_rewrite_com_eq:
-  "c \<sim> c' \<Longrightarrow> never_continues t c \<Longrightarrow> never_continues t c'"
+  "c \<sim> c' \<Longrightarrow> never_continues_if t c \<Longrightarrow> never_continues_if t c'"
   apply (simp add: never_continues_def2)
   apply (elim imp_forward all_forward, assumption)
   apply (rule com_eq_trans, rule com_eq_Seq, erule com_eq_sym, rule com_eq_refl)
   by (erule com_eq_trans[rotated])
 
-text \<open>Rules of the form @{term "never_continues True c"} may be added to @{text C_simp_throws}.\<close>
+text \<open>Rules of the form @{term "never_continues c"} may be added to @{text C_simp_throws}.\<close>
 
 lemma never_continues_Throw [C_simp_throws]:
-  "never_continues True Throw"
+  "never_continues Throw"
   by (auto simp: never_continues_def elim: exec_elim_cases)
 
 lemma While_UNIV_helper:
@@ -245,28 +269,28 @@ lemma While_UNIV_helper:
   by (induct rule: exec.induct) auto
 
 lemma never_continues_While_UNIV [C_simp_throws]:
-  "never_continues True (While UNIV c)"
+  "never_continues (While UNIV c)"
   by (auto simp: never_continues_def elim: While_UNIV_helper)
 
 lemma never_continues_While_True [C_simp_throws]:
-  "never_continues True (WHILE True DO c OD)"
+  "never_continues (WHILE True DO c OD)"
   by (simp add: whileAnno_def never_continues_While_UNIV)
 
 lemma never_continues_Guard_False [C_simp_throws]:
-  "never_continues True (Guard f {} c)"
+  "never_continues (Guard f {} c)"
   by (auto simp: never_continues_def elim: exec_elim_cases)
 
 text \<open>Structural decomposition of Simpl programs under @{term never_continues}.\<close>
 
 lemma never_continues_Seq1:
-  "never_continues t c1 \<Longrightarrow> never_continues t (c1;;c2)"
+  "never_continues_if t c1 \<Longrightarrow> never_continues_if t (c1;;c2)"
   apply (clarsimp simp: never_continues_def2)
   apply (frule spec[of _ c2], erule com_eq_trans[rotated, OF com_eq_sym])
   apply (rule com_eq_trans[OF com_eq_Seq_assoc_r])
   by simp
 
 lemma never_continues_Seq2:
-  "never_continues t c2 \<Longrightarrow> never_continues t (c1;;c2)"
+  "never_continues_if t c2 \<Longrightarrow> never_continues_if t (c1;;c2)"
   apply (clarsimp simp: never_continues_def2)
   apply (rule com_eq_trans[OF com_eq_Seq_assoc_r])
   apply (rule com_eq_Seq[OF com_eq_refl])
@@ -276,225 +300,219 @@ lemmas never_continues_Seqs =
   never_continues_Seq1 never_continues_Seq2
 
 lemma never_continues_Cond:
-  "never_continues t1 c1 \<Longrightarrow> never_continues t2 c2 \<Longrightarrow> never_continues (t1 \<and> t2) (Cond b c1 c2)"
+  "never_continues_if t1 c1 \<Longrightarrow> never_continues_if t2 c2 \<Longrightarrow> never_continues_if (t1 \<and> t2) (Cond b c1 c2)"
   by (auto simp: never_continues_def elim: exec_elim_cases)
 
 lemma never_continues_Guard:
-  "never_continues t c \<Longrightarrow> never_continues t (Guard f b c)"
+  "never_continues_if t c \<Longrightarrow> never_continues_if t (Guard f b c)"
   by (auto simp: never_continues_def elim: exec_elim_cases)
 
 lemma never_continues_Catch:
-  "never_continues tc c \<Longrightarrow> never_continues th h \<Longrightarrow> never_continues (tc \<and> th) (Catch c h)"
+  "never_continues_if tc c \<Longrightarrow> never_continues_if th h \<Longrightarrow> never_continues_if (tc \<and> th) (Catch c h)"
   by (auto simp: never_continues_def elim: exec_elim_cases)
 
 text \<open>If all else fails...\<close>
 
 lemma never_continues_False:
-  "never_continues False c"
+  "never_continues_if False c"
   by (simp add: never_continues_def)
-
-end
-
-text \<open>One layer of context around a Simpl program.
-
-      For example, if the current focus is the first branch of a @{term Cond},
-      then the context consists of a constructor @{text CondTC} which indicates
-      this is the context, and carries everything but but the focused branch,
-      i.e. the condition and the second branch.
-
-      The @{text CondFC} and @{text HandlerC} cases each carry an extra bit of
-      information, which indicates whether the left-hand branch @{text never_continues}.
-      The assumption here is that we always traverse Simpl programs left-to-right.
-      @{text Seq2C} does not require an extra bit, because we never enter the second
-      command of a @{term Seq} if the first command @{text never_continues}.\<close>
-
-datatype ('s,'p,'f) com_ctxt
-  = Seq1C "('s,'p,'f) com" \<comment> \<open>first command of a @{term Seq}\<close>
-  | Seq2C "('s,'p,'f) com" \<comment> \<open>second command of a @{term Seq}\<close>
-  | CondTC "'s bexp" "('s,'p,'f) com" \<comment> \<open>first branch of a @{term Cond}\<close>
-  | CondFC "'s bexp" "('s,'p,'f) com" bool \<comment> \<open>second branch of a @{term Cond}\<close>
-  | WhileC "'s bexp" \<comment> \<open>body of a @{term While}\<close>
-  | WhileAnnoC "'s bexp" "'s assn" "('s \<times> 's) assn" \<comment> \<open>body of a @{term whileAnno}\<close>
-  | GuardC "'f" "'s bexp" \<comment> \<open>body of a @{term Guard}\<close>
-  | TryC "('s,'p,'f) com" \<comment> \<open>body of a @{term Catch}\<close>
-  | HandlerC "('s,'p,'f) com" bool \<comment> \<open>handler of a @{term Catch}\<close>
 
 text \<open>Rewrite Simpl programs under a predicate @{term P} which is preserved by @{term com_eq}.\<close>
 
-locale simpl_rewrite = simpl_rewrite_base \<Gamma>
-  for \<Gamma> :: "'p \<Rightarrow> ('s,'p,'f) com option" +
+definition com_eq_hom :: "(('s,'p,'f) com \<Rightarrow> bool) \<Rightarrow> bool" where
+  "com_eq_hom P \<equiv> \<forall>c c'. (c \<sim> c') \<longrightarrow> P c' \<longrightarrow> P c"
+
+context
   fixes P :: "('s,'p,'f) com \<Rightarrow> bool"
-  assumes inv: "\<And>c c'. c \<sim> c' \<Longrightarrow> P c' \<Longrightarrow> P c"
+  assumes com_eq_hom: "com_eq_hom P"
 begin
+
+lemma com_eq_homD:
+  "c \<sim> c' \<Longrightarrow> P c' \<longrightarrow> P c"
+  using com_eq_hom by (simp add: com_eq_hom_def)
 
 text \<open>Calculate @{term P} for a Simpl program consisting of a sub-program in a nest of contexts.\<close>
 
 fun
-  ctxt_P :: "('s,'p,'f) com \<Rightarrow> ('s,'p,'f) com_ctxt list \<Rightarrow> bool"
+  com_ctxt_P :: "('s,'p,'f) com \<Rightarrow> ('s,'p,'f) com_ctxt list \<Rightarrow> bool"
 where
-    "ctxt_P c [] = P c"
-  | "ctxt_P c (Seq1C c' # cs) = ctxt_P (Seq c c') cs"
-  | "ctxt_P c (Seq2C c' # cs) = ctxt_P (Seq c' c) cs"
-  | "ctxt_P c (CondTC b c' # cs) = ctxt_P (Cond b c c') cs"
-  | "ctxt_P c (CondFC b c' t # cs) = (never_continues t c' \<longrightarrow> ctxt_P (Cond b c' c) cs)"
-  | "ctxt_P c (WhileC b # cs) = ctxt_P (While b c) cs"
-  | "ctxt_P c (WhileAnnoC b I V # cs) = ctxt_P (whileAnno b I V c) cs"
-  | "ctxt_P c (GuardC f b # cs) = ctxt_P (Guard f b c) cs"
-  | "ctxt_P c (TryC c' # cs) = ctxt_P (Catch c c') cs"
-  | "ctxt_P c (HandlerC c' t # cs) = (never_continues t c' \<longrightarrow> ctxt_P (Catch c' c) cs)"
+    "com_ctxt_P c [] = P c"
+  | "com_ctxt_P c (Seq1C c' # cs) = com_ctxt_P (Seq c c') cs"
+  | "com_ctxt_P c (Seq2C c' # cs) = com_ctxt_P (Seq c' c) cs"
+  | "com_ctxt_P c (CondTC b c' # cs) = com_ctxt_P (Cond b c c') cs"
+  | "com_ctxt_P c (CondFC b c' t # cs) = (never_continues_if t c' \<longrightarrow> com_ctxt_P (Cond b c' c) cs)"
+  | "com_ctxt_P c (WhileC b # cs) = com_ctxt_P (While b c) cs"
+  | "com_ctxt_P c (WhileAnnoC b I V # cs) = com_ctxt_P (whileAnno b I V c) cs"
+  | "com_ctxt_P c (GuardC f b # cs) = com_ctxt_P (Guard f b c) cs"
+  | "com_ctxt_P c (TryC c' # cs) = com_ctxt_P (Catch c c') cs"
+  | "com_ctxt_P c (HandlerC c' t # cs) = (never_continues_if t c' \<longrightarrow> com_ctxt_P (Catch c' c) cs)"
 
 text \<open>For the current focus, we add a flag @{term t} of type @{typ "bool option"}.
       @{term t} is None until we have finished rewriting sub-programs.
       It is @{term "Some t"} when rewriting has finished for the current focus, and
-      the result satisfies @{term "never_continues t"}.\<close>
+      the result satisfies @{term "never_continues_if t"}.\<close>
 
 definition
-  "nc_opt t \<equiv> never_continues (case_option False id t)"
+  "never_continues_opt t \<equiv> never_continues_if (case_option False id t)"
 
 definition
-  "focus c t cs \<equiv> nc_opt t c \<longrightarrow> ctxt_P c cs"
+  "com_ctxt_focus c t cs \<equiv> never_continues_opt t c \<longrightarrow> com_ctxt_P c cs"
 
-lemmas focus_defs = focus_def nc_opt_def
+lemmas com_ctxt_focus_defs = com_ctxt_focus_def never_continues_opt_def
 
-lemma nc_opt_None:
-  "nc_opt None t"
-  by (simp add: nc_opt_def never_continues_False)
+lemma never_continues_opt_None:
+  "never_continues_opt None t"
+  by (simp add: never_continues_opt_def never_continues_False)
 
 text \<open>Rules for beginning and ending the rewriting process.\<close>
 
-lemma enter_focus:
-  "focus c None [] \<Longrightarrow> P c"
-  by (simp add: focus_defs never_continues_False)
+lemma com_ctxt_focus_enter:
+  "com_ctxt_focus c None [] \<Longrightarrow> P c"
+  by (simp add: com_ctxt_focus_defs never_continues_False)
 
-lemma exit_focus:
-  "P c \<Longrightarrow> focus c t []"
-  by (simp add: focus_defs)
+lemma com_ctxt_focus_exit:
+  "P c \<Longrightarrow> com_ctxt_focus c t []"
+  by (simp add: com_ctxt_focus_defs)
 
 text \<open>Rules for rewriting at the current focus.\<close>
 
 lemma nc_opt_rewrite_com_eq:
-  "c \<sim> c' \<Longrightarrow> nc_opt t c \<Longrightarrow> nc_opt t c'"
-  by (simp add: nc_opt_def never_continues_rewrite_com_eq)
+  "c \<sim> c' \<Longrightarrow> never_continues_opt t c \<Longrightarrow> never_continues_opt t c'"
+  by (simp add: never_continues_opt_def never_continues_rewrite_com_eq)
 
 lemma ctxt_P_rewrite_com_eq:
-  "c \<sim> c' \<Longrightarrow> ctxt_P c' cs \<Longrightarrow> ctxt_P c cs"
+  "c \<sim> c' \<Longrightarrow> com_ctxt_P c' cs \<Longrightarrow> com_ctxt_P c cs"
   proof (induct cs arbitrary: c c')
-    case Nil thus ?case by (simp add: inv)
+    case Nil thus ?case by (simp add: com_eq_homD)
   next
     case (Cons c'' cs) show ?case using Cons.prems(2)
       by (cases c''; clarsimp elim!: Cons.hyps[rotated];
           intro com_eq_intros com_eq_refl Cons.prems(1))
   qed
 
-lemma rewrite_focus:
-  "com_eq p c c' \<Longrightarrow> p \<Longrightarrow> focus c' t cs \<Longrightarrow> focus c t cs"
-  by (simp add: focus_def nc_opt_rewrite_com_eq ctxt_P_rewrite_com_eq)
+lemma com_ctxt_focus_rewrite:
+  "com_eq p c c' \<Longrightarrow> p \<Longrightarrow> com_ctxt_focus c' t cs \<Longrightarrow> com_ctxt_focus c t cs"
+  by (simp add: com_ctxt_focus_def nc_opt_rewrite_com_eq ctxt_P_rewrite_com_eq)
 
 text \<open>Rules to set the @{term never_continues} flag for the current focus.\<close>
 
-lemma focus_set_never_continues:
-  "never_continues t c \<Longrightarrow> focus c (Some t) cs \<Longrightarrow> focus c None cs"
-  by (simp add: focus_defs)
+lemma com_ctxt_focus_set_never_continues:
+  "never_continues_if t c \<Longrightarrow> com_ctxt_focus c (Some t) cs \<Longrightarrow> com_ctxt_focus c None cs"
+  by (simp add: com_ctxt_focus_defs)
 
-lemma focus_update_never_continues:
-  "never_continues t c \<Longrightarrow> focus c (Some (t \<or> t')) cs \<Longrightarrow> focus c (Some t') cs"
-  by (cases t; cases t'; simp add: focus_defs)
+lemma com_ctxt_focus_update_never_continues:
+  "never_continues_if t c \<Longrightarrow> com_ctxt_focus c (Some (t \<or> t')) cs \<Longrightarrow> com_ctxt_focus c (Some t') cs"
+  by (cases t; cases t'; simp add: com_ctxt_focus_defs)
 
-lemmas focus_never_continues =
-  focus_update_never_continues[where t'=True, simplified]
-  focus_update_never_continues[where t'=False, simplified]
-  focus_set_never_continues
+lemmas com_ctxt_focus_never_continues =
+  com_ctxt_focus_update_never_continues[where t'=True, simplified]
+  com_ctxt_focus_update_never_continues[where t'=False, simplified]
+  com_ctxt_focus_set_never_continues
 
 text \<open>Rules for moving the focus down the left spine.\<close>
 
-lemma focus_left:
-  "focus c None (Seq1C c' # cs) \<Longrightarrow> focus (Seq c c') None cs"
-  "focus c None (CondTC b c' # cs) \<Longrightarrow> focus (Cond b c c') None cs"
-  "focus c None (WhileC b # cs) \<Longrightarrow> focus (While b c) None cs"
-  "focus c None (WhileAnnoC b I V # cs) \<Longrightarrow> focus (whileAnno b I V c) None cs"
-  "focus c None (GuardC f b # cs) \<Longrightarrow> focus (Guard f b c) None cs"
-  "focus c None (TryC c' # cs) \<Longrightarrow> focus (Catch c c') None cs"
-  by (auto simp: focus_def nc_opt_None)
+lemma com_ctxt_focus_left:
+  "com_ctxt_focus c None (Seq1C c' # cs) \<Longrightarrow> com_ctxt_focus (Seq c c') None cs"
+  "com_ctxt_focus c None (CondTC b c' # cs) \<Longrightarrow> com_ctxt_focus (Cond b c c') None cs"
+  "com_ctxt_focus c None (WhileC b # cs) \<Longrightarrow> com_ctxt_focus (While b c) None cs"
+  "com_ctxt_focus c None (WhileAnnoC b I V # cs) \<Longrightarrow> com_ctxt_focus (whileAnno b I V c) None cs"
+  "com_ctxt_focus c None (GuardC f b # cs) \<Longrightarrow> com_ctxt_focus (Guard f b c) None cs"
+  "com_ctxt_focus c None (TryC c' # cs) \<Longrightarrow> com_ctxt_focus (Catch c c') None cs"
+  by (auto simp: com_ctxt_focus_def never_continues_opt_None)
 
 text \<open>Rules for moving the focus to the right sibling.\<close>
 
-lemma focus_right:
-  "focus c' None (Seq2C c # cs) \<Longrightarrow> focus c (Some False) (Seq1C c' # cs)"
-  "focus c' None (CondFC b c t # cs) \<Longrightarrow> focus c (Some t) (CondTC b c' # cs)"
-  "focus c' None (HandlerC c t # cs) \<Longrightarrow> focus c (Some t) (TryC c' # cs)"
-  by (auto simp: focus_defs never_continues_False)
+lemma com_ctxt_focus_right:
+  "com_ctxt_focus c' None (Seq2C c # cs) \<Longrightarrow> com_ctxt_focus c (Some False) (Seq1C c' # cs)"
+  "com_ctxt_focus c' None (CondFC b c t # cs) \<Longrightarrow> com_ctxt_focus c (Some t) (CondTC b c' # cs)"
+  "com_ctxt_focus c' None (HandlerC c t # cs) \<Longrightarrow> com_ctxt_focus c (Some t) (TryC c' # cs)"
+  by (auto simp: com_ctxt_focus_defs never_continues_False)
 
 text \<open>Rules for moving the focus up to the parent.\<close>
 
-lemma ctxt_P_Seq1:
-  "never_continues True c \<Longrightarrow> ctxt_P c cs \<Longrightarrow> ctxt_P (Seq c c') cs"
+lemma com_ctxt_P_Seq1:
+  "never_continues c \<Longrightarrow> com_ctxt_P c cs \<Longrightarrow> com_ctxt_P (Seq c c') cs"
   by (auto simp: never_continues_def2 elim: ctxt_P_rewrite_com_eq)
 
-lemma unfocus_simple:
-  "focus c (Some True) cs \<Longrightarrow> focus c (Some True) (Seq1C c' # cs)"
-  "focus (Seq c' c) (Some t) cs \<Longrightarrow> focus c (Some t) (Seq2C c' # cs)"
-  "focus (While b c) (Some False) cs \<Longrightarrow> focus c (Some t) (WhileC b # cs)"
-  "focus (whileAnno b I V c) (Some False) cs \<Longrightarrow> focus c (Some t) (WhileAnnoC b I V # cs)"
-  "focus (Guard f b c) (Some t) cs \<Longrightarrow> focus c (Some t) (GuardC f b # cs)"
-  by (auto simp: focus_defs never_continues_False ctxt_P_Seq1 never_continues_Seq2 never_continues_Guard)
+lemma com_ctxt_unfocus_simple:
+  "com_ctxt_focus c (Some True) cs \<Longrightarrow> com_ctxt_focus c (Some True) (Seq1C c' # cs)"
+  "com_ctxt_focus (Seq c' c) (Some t) cs \<Longrightarrow> com_ctxt_focus c (Some t) (Seq2C c' # cs)"
+  "com_ctxt_focus (While b c) (Some False) cs \<Longrightarrow> com_ctxt_focus c (Some t) (WhileC b # cs)"
+  "com_ctxt_focus (whileAnno b I V c) (Some False) cs \<Longrightarrow> com_ctxt_focus c (Some t) (WhileAnnoC b I V # cs)"
+  "com_ctxt_focus (Guard f b c) (Some t) cs \<Longrightarrow> com_ctxt_focus c (Some t) (GuardC f b # cs)"
+  by (auto simp: com_ctxt_focus_defs never_continues_False com_ctxt_P_Seq1 never_continues_Seq2 never_continues_Guard)
 
-lemma unfocus_complex:
-  "focus (Cond b c' c) (Some (t' \<and> t)) cs \<Longrightarrow> focus c (Some t) (CondFC b c' t' # cs)"
-  "focus (Catch c' c) (Some (t' \<and> t)) cs \<Longrightarrow> focus c (Some t) (HandlerC c' t' # cs)"
-  by (auto simp: focus_defs never_continues_False never_continues_Cond never_continues_Catch)
+lemma com_ctxt_unfocus_complex:
+  "com_ctxt_focus (Cond b c' c) (Some (t' \<and> t)) cs \<Longrightarrow> com_ctxt_focus c (Some t) (CondFC b c' t' # cs)"
+  "com_ctxt_focus (Catch c' c) (Some (t' \<and> t)) cs \<Longrightarrow> com_ctxt_focus c (Some t) (HandlerC c' t' # cs)"
+  by (auto simp: com_ctxt_focus_defs never_continues_False never_continues_Cond never_continues_Catch)
 
-lemmas unfocus =
-  unfocus_complex[where t=True and t'=True, simplified]
-  unfocus_complex[where t=False, simplified]
-  unfocus_complex[where t'=False, simplified]
-  unfocus_simple
+lemmas com_ctxt_unfocus =
+  com_ctxt_unfocus_complex[where t=True and t'=True, simplified]
+  com_ctxt_unfocus_complex[where t=False, simplified]
+  com_ctxt_unfocus_complex[where t'=False, simplified]
+  com_ctxt_unfocus_simple
+
+end
+end
 
 text \<open>Methods to automate rewriting.\<close>
 
-method do_rewrite uses ruleset declares C_simp_simps =
-  (rule rewrite_focus, rule ruleset,
+method do_rewrite uses hom ruleset declares C_simp_simps =
+  (rule com_ctxt_focus_rewrite[OF hom], rule ruleset,
    #break "simpl_rewrite_rewrite", (simp add: C_simp_simps; fail))+
 
-method rewrite_pre declares C_simp_pre C_simp_simps =
-  (do_rewrite ruleset: C_simp_pre)
+method rewrite_pre uses hom declares C_simp_pre C_simp_simps =
+  (do_rewrite hom: hom ruleset: C_simp_pre)
 
-method rewrite_post declares C_simp C_simp_simps =
-  (do_rewrite ruleset: C_simp)
+method rewrite_post uses hom declares C_simp C_simp_simps =
+  (do_rewrite hom: hom ruleset: C_simp)
 
-method never_continues declares C_simp_throws =
-  (rule focus_never_continues, rule C_simp_throws never_continues_False)
+method never_continues_if uses hom declares C_simp_throws =
+  (rule com_ctxt_focus_never_continues[OF hom], rule C_simp_throws never_continues_False)
 
-method children methods do_focus declares C_simp C_simp_pre C_simp_simps C_simp_throws =
-  (rule focus_left, do_focus, (rule focus_right, do_focus)?, rule unfocus)?
+method children methods do_focus uses hom declares C_simp C_simp_pre C_simp_simps C_simp_throws =
+  (rule com_ctxt_focus_left[OF hom],
+   do_focus, (rule com_ctxt_focus_right[OF hom], do_focus)?,
+   rule com_ctxt_unfocus[OF hom])?
 
-method do_focus declares C_simp C_simp_pre C_simp_simps C_simp_throws =
-  (#break "simpl_rewrite_step", rewrite_pre?, children \<open>do_focus\<close>,
-   #break "simpl_rewrite_step", rewrite_post?, never_continues)
+method do_focus uses hom declares C_simp C_simp_pre C_simp_simps C_simp_throws =
+  (#break "simpl_rewrite_step", (rewrite_pre hom: hom)?, children \<open>do_focus hom: hom\<close> hom: hom,
+   #break "simpl_rewrite_step", (rewrite_post hom: hom)?, never_continues_if hom: hom)
 
-method simpl_rewrite declares C_simp C_simp_pre C_simp_simps C_simp_throws =
-  changed \<open>rule enter_focus, do_focus, rule exit_focus\<close>
+method simpl_rewrite uses hom declares C_simp C_simp_pre C_simp_simps C_simp_throws =
+  changed \<open>rule com_ctxt_focus_enter[OF hom], do_focus hom: hom, rule com_ctxt_focus_exit[OF hom]\<close>
 
 text \<open>Tests\<close>
+
+experiment
+  fixes \<Gamma> :: "'p \<Rightarrow> ('s,'p,'f) com option"
+  fixes P :: "('s,'p,'f) com \<Rightarrow> bool"
+  assumes hom: "com_eq_hom \<Gamma> P"
+begin
+
+abbreviation "com_equiv_ex \<equiv> com_equiv \<Gamma>"
+notation com_equiv_ex (infix "\<sim>" 10)
 
 lemma
   assumes c3: "c3 \<sim> c"
   assumes c: "(c;;c) \<sim> c"
   shows "P (c;; Guard f UNIV (IF X THEN c ELSE c FI);; Cond {} Skip (Skip;;c2);; Skip;;
             (IF False THEN Skip ELSE SKIP;; TRY THROW CATCH c3 END FI;; SKIP))"
-  apply simpl_rewrite
+  apply (simpl_rewrite hom: hom)
   apply (match conclusion in "P (c;;c;;c2;;c3)" \<Rightarrow> \<open>-\<close>)
-  apply (simpl_rewrite C_simp: c3)
+  apply (simpl_rewrite hom: hom C_simp: c3)
   apply (match conclusion in "P (c;;c;;c2;;c)" \<Rightarrow> \<open>-\<close>)
-  apply (simpl_rewrite C_simp: c)
+  apply (simpl_rewrite hom: hom C_simp: c)
   apply (match conclusion in "P (c;;c2;;c)" \<Rightarrow> \<open>-\<close>)
-  apply (fails \<open>simpl_rewrite\<close>)
+  apply (fails \<open>simpl_rewrite hom: hom\<close>)
   oops
 
 text \<open>Test for @{text WHILE} (@{term whileAnno}) case.\<close>
 
 lemma
   "P (WHILE b DO Guard f g c;; IF False THEN c2 FI OD;; SKIP)"
-  apply simpl_rewrite
+  apply (simpl_rewrite hom: hom)
   apply (match conclusion in "P (WHILE b DO Guard f g c OD)" \<Rightarrow> \<open>-\<close>)
   oops
 
@@ -506,7 +524,7 @@ lemma
       ELSE
         (SKIP ;; SKIP) ;; (Guard f UNIV c ;; SKIP)
       FI)"
-  apply simpl_rewrite
+  apply (simpl_rewrite hom: hom)
   apply (match conclusion in "P c" \<Rightarrow> \<open>-\<close>)
   oops
 
@@ -528,7 +546,7 @@ lemma
           WHILE False DO c4 OD ;; (c3 ;; SKIP)
         FI
       FI)"
-  apply (simpl_rewrite C_simp: com_eq_Cond_redundant)
+  apply (simpl_rewrite hom: hom C_simp: com_eq_Cond_redundant)
   apply (match conclusion in "P (IF b THEN c1 ELSE c3 FI)" \<Rightarrow> \<open>-\<close>)
   oops
 
@@ -536,7 +554,7 @@ text \<open>Test False guard avoids looping.\<close>
 
 lemma
   "P (SKIP ;; Guard f {} (IF b THEN c ELSE c FI) ;; SKIP)"
-  apply simpl_rewrite
+  apply (simpl_rewrite hom: hom)
   apply (match conclusion in "P (Guard f {} SKIP)" \<Rightarrow> \<open>-\<close>)
   oops
 
@@ -544,7 +562,7 @@ text \<open>Test that everything after a deeply nested Throw is discarded.\<clos
 
 lemma
   "P (c0;; (c1;; (c2;; (c3;; (c4;; Throw;; c5);; c6);; c7);; c8);; c9)"
-  apply simpl_rewrite
+  apply (simpl_rewrite hom: hom)
   apply (match conclusion in "P (c0;; (c1;; (c2;; (c3;; (c4;; Throw)))))" \<Rightarrow> \<open>-\<close>)
   oops
 
@@ -553,7 +571,7 @@ text \<open>Test that rewriting can simplify conditions, also using assumptions 
 lemma
   assumes "\<And>s. A s \<Longrightarrow> C s"
   shows "\<forall>s. Q s = (A s \<longrightarrow> B s \<longrightarrow> C s) \<Longrightarrow> P (Cond {s. \<not> Q s} c1 c2)"
-  apply (simpl_rewrite C_simp_simps: assms)
+  apply (simpl_rewrite hom: hom C_simp_simps: assms)
   apply (match premises in "\<forall>s. Q s = (A s \<longrightarrow> B s \<longrightarrow> C s)" \<Rightarrow> \<open>match conclusion in "P c2" \<Rightarrow> \<open>-\<close>\<close>)
   oops
 


### PR DESCRIPTION
This is like `ccorres_rewrite`, but for `hoarep`, and uses the same
infrastructure.

The interaction between the `simpl_rewrite` locale and the
`simpl_rewrite` method was confusing, and didn't work well with multiple
interpretations. We replace it with a simple anonymous context. Since
that puts more things in the global namespace, we rename many of them.
The `simpl_rewrite` method is now parameterised by a `hom` fact which
determines the predicate under which we are rewriting.

This also includes a slight generalisation of `exec_eq_is_valid_eq`,
which allows a similar generalisation of `hoarep_rewrite`.