### PR TITLE
Weaken tcbSchedDequeue preconditions

### DIFF
--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3025,9 +3025,10 @@ lemma schedContextDonate_valid_queues:
    apply (rule hoare_when_cases, clarsimp)
    apply (rule_tac B="\<lambda>_. ?pre" in hoare_seq_ext[rotated])
     apply (wpsimp wp: tcbSchedDequeue_valid_queues)
-    apply (fastforce dest!: sc_ko_at_valid_objs_valid_sc'
-                     intro: valid_objs'_maxDomain valid_objs'_maxPriority
-                      simp: valid_sched_context'_def)
+    apply (drule sc_ko_at_valid_objs_valid_sc'; clarsimp simp: valid_sched_context'_def)
+    apply (frule (1) valid_objs'_maxDomain)
+    apply (frule (1) valid_objs'_maxPriority)
+    apply (clarsimp simp: obj_at'_def)
    apply (rule hoare_seq_ext_skip)
     apply (wpsimp wp: threadSet_valid_queues_new threadSet_valid_objs')
     apply (clarsimp simp: obj_at'_def inQ_def valid_tcb'_def tcb_cte_cases_def)

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -1645,24 +1645,6 @@ lemma tcbSchedDequeue_t_notksQ:
 
 crunch ct_idle_or_in_cur_domain'[wp]: tcbSchedDequeue ct_idle_or_in_cur_domain'
 
-lemma tcbSchedDequeue_invs':
-  "\<lbrace>\<lambda>s. invs' s \<and> tcb_at' t s\<rbrace>
-   tcbSchedDequeue t
-   \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: invs'_def valid_state'_def)
-  apply (wp tcbSchedDequeue_valid_queues_weak valid_irq_handlers_lift
-            valid_irq_node_lift valid_irq_handlers_lift'
-            tcbSchedDequeue_irq_states irqs_masked_lift cur_tcb_lift
-            untyped_ranges_zero_lift
-         | clarsimp simp add: cteCaps_of_def valid_queues_def o_def)+
-  apply (rule conjI)
-   apply (fastforce simp: obj_at'_def inQ_def st_tcb_at'_def valid_queues_no_bitmap_except_def)
-  apply (rule conjI)
-   using valid_queues_obj_at'D inQ_def valid_queues_def apply blast
-  apply (fastforce simp: valid_pspace'_def intro: obj_at'_conjI
-                   elim: valid_objs'_maxDomain valid_objs'_maxPriority)
-  done
-
 lemma asUser_sch_act_simple[wp]:
   "\<lbrace>sch_act_simple\<rbrace> asUser s t \<lbrace>\<lambda>_. sch_act_simple\<rbrace>"
   unfolding sch_act_simple_def

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -557,6 +557,10 @@ lemma tcbSchedDequeue_not_in_queue:
    apply (fastforce simp: valid_queues_def valid_queues_no_bitmap_def obj_at'_def projectKOs inQ_def )
   apply (wp tcbSchedDequeue_not_queued tcbSchedDequeue_valid_queues |
          simp add: valid_objs'_maxDomain valid_objs'_maxPriority)+
+  apply (clarsimp)
+  apply (frule (1) valid_objs'_maxDomain)
+  apply (frule (1) valid_objs'_maxPriority)
+  apply (clarsimp simp: obj_at'_def)
   done
 
 lemma threadSet_ct_in_state':


### PR DESCRIPTION
Some lemmas about `tcbSchedDequeue` had preconditions involving `tcb_at'` that were too strong due to the use of `threadGet_const_tcb_at` instead of `threadGet_wp`.