### PR TITLE
activate_thread: proofs for corres lemma and invs' lemma.

### DIFF
--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -505,6 +505,10 @@ lemma corres_if3:
                                     (if G then a else b) (if G' then c else d)"
   by simp
 
+lemmas corres_when2 =
+    corres_if3[where b="return ()" and d="return ()"
+                and Q="\<top>" and Q'="\<top>" and r=dc, unfolded if_apply_def2, simplified,
+                folded when_def]
 
 text \<open>Some equivalences about liftM and other useful simps\<close>
 

--- a/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
@@ -1574,7 +1574,7 @@ qed
 
 lemma decode_invocation_valid_pdpt[wp]:
   "\<lbrace>invs and valid_cap cap and valid_pdpt_objs\<rbrace>
-     decode_invocation first_phase label args cap_index slot cap excaps
+     decode_invocation first_phase label args cap_index slot cap excaps buffer
    \<lbrace>invocation_duplicates_valid\<rbrace>,-"
   apply (simp add: decode_invocation_def split del: if_split)
   apply (rule hoare_pre)

--- a/proof/invariant-abstract/IpcCancel_AI.thy
+++ b/proof/invariant-abstract/IpcCancel_AI.thy
@@ -2579,7 +2579,6 @@ lemma complete_yield_to_invs:
   apply (case_tac yt_opt; simp)
    apply wpsimp
   apply (rule hoare_seq_ext[OF _ lookup_ipc_buffer_inv])
-  apply (rule hoare_seq_ext[OF _ assert_opt_inv])
   apply (rule hoare_seq_ext[rotated])
    apply (rule_tac Q="K (yt_opt = Some a) and
          (bound_yt_tcb_at ((=) (Some a)) tcb_ptr and

--- a/proof/invariant-abstract/IpcCancel_AI.thy
+++ b/proof/invariant-abstract/IpcCancel_AI.thy
@@ -2608,7 +2608,7 @@ lemma complete_yield_to_invs:
     apply (clarsimp split: if_split_asm simp:  split del: if_split)
         apply ((fastforce simp: state_refs_of_def get_refs_def2 dest!: symreftype_inverse')+)[4]
    apply (fastforce dest!: sym_ref_tcb_yt)
-  apply (intro conjI)
+  apply (rule conjI[rotated])
    apply (clarsimp dest!: idle_no_ex_cap)
   apply (clarsimp simp: pred_tcb_at_def obj_at_def sym_refs_def)
   apply (erule_tac x = tcb_ptr in allE)

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -212,7 +212,7 @@ lemma complete_yield_to_valid_idle[wp]:
    apply wpsimp
   apply (rule hoare_seq_ext[OF _ lookup_ipc_buffer_inv])
   apply (wpsimp wp: update_sched_context_valid_idle)
-  apply (rule conjI)
+  apply (rule conjI[rotated])
    apply (clarsimp simp: obj_at_def valid_idle_def pred_tcb_at_def)
   apply (clarsimp simp: sym_refs_def)
   apply (erule_tac x = tcb_ptr in allE)

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -226,7 +226,6 @@ lemma complete_yield_to_only_idle[wp]:
   apply (case_tac yt_opt; simp)
    apply wpsimp
   apply (rule hoare_seq_ext[OF _ lookup_ipc_buffer_inv])
-  apply (rule hoare_seq_ext[OF _ assert_opt_inv])
   by (wpsimp wp: sts_only_idle)
 
 
@@ -237,7 +236,6 @@ lemma complete_yield_to_iflive[wp]:
   apply (case_tac yt_opt; simp)
    apply wpsimp
   apply (rule hoare_seq_ext[OF _ lookup_ipc_buffer_inv])
-  apply (rule hoare_seq_ext[OF _ assert_opt_inv])
   by wpsimp
 
 lemma complete_yield_to_ex_nonz[wp]:
@@ -247,7 +245,6 @@ lemma complete_yield_to_ex_nonz[wp]:
   apply (case_tac yt_opt; simp)
    apply wpsimp
   apply (rule hoare_seq_ext[OF _ lookup_ipc_buffer_inv])
-  apply (rule hoare_seq_ext[OF _ assert_opt_inv])
   by wpsimp
 
 crunches complete_yield_to
@@ -478,7 +475,6 @@ lemma complete_yield_to_ex_nonz_ct[wp]:
   apply (case_tac yt_opt; simp)
    apply wpsimp
   apply (rule hoare_seq_ext[OF _ lookup_ipc_buffer_inv])
-  apply (rule hoare_seq_ext[OF _ assert_opt_inv])
   by wpsimp
 
 lemma set_yf_sc_yf_sc_at:

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -678,7 +678,7 @@ lemma sts_Restart_stay_simple:
 lemma decode_inv_inv[wp]:
   notes if_split [split del]
   shows
-  "\<lbrace>P\<rbrace> decode_invocation first_phase label args cap_index slot cap excaps \<lbrace>\<lambda>rv. P\<rbrace>"
+  "\<lbrace>P\<rbrace> decode_invocation first_phase label args cap_index slot cap excaps buffer \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (case_tac cap, simp_all add: decode_invocation_def)
           apply (wp decode_tcb_inv_inv decode_domain_inv_inv
                     decode_sched_context_inv_inv decode_sched_control_inv_inv
@@ -714,7 +714,7 @@ lemma decode_inv_wf[wp]:
            and (\<lambda>s. \<forall>x \<in> set excaps. \<forall>r\<in>zobj_refs (fst x). ex_nonz_cap_to r s)
            and (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at ((=) (fst x)) (snd x) s)
            and (\<lambda>s. \<forall>x \<in> set excaps. ex_cte_cap_wp_to is_cnode_cap (snd x) s)\<rbrace>
-     decode_invocation first_phase label args cap_index slot cap excaps
+     decode_invocation first_phase label args cap_index slot cap excaps buffer
    \<lbrace>valid_invocation\<rbrace>,-"
   apply (simp add: decode_invocation_def cong: cap.case_cong if_cong split del: if_split)
   apply (wpsimp wp: decode_tcb_inv_wf decode_domain_inv_wf[simplified split_def]
@@ -1583,7 +1583,7 @@ lemma perform_invocation_not_blocking_not_calling_ct_active[wp]:
 
 lemma decode_invocation_safe_invocation[wp]:
   "\<lbrace>\<top>\<rbrace>
-     decode_invocation True label args cap_index slot cap excaps
+     decode_invocation True label args cap_index slot cap excaps buffer
    \<lbrace>\<lambda>i _. safe_invocation i\<rbrace>,-"
   apply (simp add: decode_invocation_def)
   by (wpsimp simp: o_def split_def)

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -4759,7 +4759,7 @@ lemma createObjects_setDomain_commute:
   apply (clarsimp split:Structures_H.kernel_object.splits)
   done
 
-
+(* FIXME RT: unused? *)
 lemma createObjects_setDomains_commute:
   "monad_commute
       (\<lambda>s. \<forall>x\<in> set xs. tcb_at' (f x) s \<and>

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -1701,7 +1701,7 @@ crunches schedContextCancelYieldTo
   (wp: crunch_wps simp: crunch_simps tcb_cte_cases_def)
 
 lemma schedContextCancelYieldTo_invs':
-  "\<lbrace>invs' and sch_act_simple and tcb_at' t and (\<lambda>s. t \<noteq> ksIdleThread s)\<rbrace>
+  "\<lbrace>invs' and sch_act_simple and tcb_at' t\<rbrace>
    schedContextCancelYieldTo t
    \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def setSchedContext_def)

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -424,7 +424,7 @@ next
     apply (rule corres_const_on_failure)
     apply (simp add: dc_def[symmetric] split del: if_split)
     apply (rule corres_guard_imp)
-      apply (rule corres_if2)
+      apply (rule corres_if3)
         apply (case_tac "fst x", auto simp add: isCap_simps)[1]
        apply (rule corres_split [OF _ corres_set_extra_badge])
           apply (drule conjunct1)
@@ -1795,7 +1795,7 @@ lemma dit_corres:
      defer
      apply (rule corres_guard_imp)
        apply (subst case_option_If)+
-       apply (rule corres_if2)
+       apply (rule corres_if3)
          apply (simp add: fault_rel_optionation_def)
         apply (rule corres_split_eqr [OF _ lipcb_corres'])
           apply (simp add: dc_def[symmetric])

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -2238,13 +2238,8 @@ lemma activate_sch_valid_duplicates'[wp]:
   apply (simp add: activateThread_def getCurThread_def
              cong: if_cong Structures_H.thread_state.case_cong)
   apply (rule hoare_seq_ext [OF _ gets_sp])
-  apply (rule hoare_seq_ext[where B="\<lambda>st s. (runnable' or idle') st \<and>
-                                            vs_valid_duplicates' (ksPSpace s)"])
-   apply (wpsimp wp: threadGet_wp hoare_drop_imps)
-   apply (clarsimp simp: obj_at'_def)
-  apply (wp gts_wp')
-  apply (clarsimp simp: pred_tcb_at'_def ct_in_state'_def obj_at'_def)
-  done
+  apply (wpsimp wp: threadGet_wp hoare_drop_imps)
+  by (fastforce simp: obj_at'_def)
 
 crunches receiveSignal, receiveIPC, handleYield, "VSpace_H.handleVMFault", handleHypervisorFault,
          lookupReply, checkBudgetRestart

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -20,11 +20,6 @@ lemma invs_no_cicd'_queues:
   unfolding invs_no_cicd'_def
   by simp
 
-lemma corres_if2:
- "\<lbrakk> G = G'; G \<Longrightarrow> corres r P P' a c; \<not> G' \<Longrightarrow> corres r Q Q' b d \<rbrakk>
-    \<Longrightarrow> corres r (if G then P else Q) (if G' then P' else Q') (if G then a else b) (if G' then c else d)"
-  by simp
-
 lemma findM_awesome':
   assumes x: "\<And>x xs. suffix (x # xs) xs' \<Longrightarrow>
                   corres (\<lambda>a b. if b then (\<exists>a'. a = Some a' \<and> r a' (Some x)) else a = None)
@@ -49,7 +44,7 @@ proof -
     apply (subst P)
     apply (rule corres_guard_imp)
       apply (rule corres_split [OF _ x])
-         apply (rule corres_if2)
+         apply (rule corres_if3)
            apply (case_tac ra, clarsimp+)[1]
           apply (rule corres_trivial, clarsimp)
           apply (case_tac ra, simp_all)[1]
@@ -1751,7 +1746,6 @@ lemma chooseThread_corres:
               apply (rule corres_guard_imp)
                 apply (rule_tac P=\<top> and P'=\<top> in guarded_switch_to_chooseThread_fragment_corres)
                apply (wp | clarsimp simp: getQueue_def getReadyQueuesL2Bitmap_def)+
-      apply (clarsimp simp: if_apply_def2)
       apply (wp hoare_vcg_conj_lift hoare_vcg_imp_lift ksReadyQueuesL1Bitmap_return_wp)
      apply (simp add: curDomain_def, wp)+
    apply (clarsimp simp: valid_sched_def DetSchedInvs_AI.valid_ready_qs_def max_non_empty_queue_def)

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -176,8 +176,8 @@ lemma decode_invocation_corres:
            (invs' and valid_cap' cap' and cte_at' slot'
             and (\<lambda>s. \<forall>x\<in>set excaps'. s \<turnstile>' fst x \<and> cte_at' (snd x) s)
             and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
-      (decode_invocation first_phase (mi_label mi) args cptr slot cap excaps)
-      (RetypeDecls_H.decodeInvocation (mi_label mi) args' cptr' slot' cap' excaps' first_phase)"
+      (decode_invocation first_phase (mi_label mi) args cptr slot cap excaps buffer)
+      (RetypeDecls_H.decodeInvocation (mi_label mi) args' cptr' slot' cap' excaps' first_phase buffer)"
   apply (rule corres_gen_asm)
   apply (unfold decode_invocation_def decodeInvocation_def)
   apply (case_tac cap, simp_all only: cap.simps)
@@ -583,7 +583,7 @@ crunches decodeDomainInvocation, decodeSchedContextInvocation, decodeSchedContro
   (wp: crunch_wps simp: crunch_simps)
 
 lemma decode_inv_inv'[wp]:
-  "\<lbrace>P\<rbrace> decodeInvocation label args cap_index slot cap excaps first_phase \<lbrace>\<lambda>rv. P\<rbrace>"
+  "\<lbrace>P\<rbrace> decodeInvocation label args cap_index slot cap excaps first_phase buffer \<lbrace>\<lambda>rv. P\<rbrace>"
   unfolding decodeInvocation_def Let_def
   by (wpsimp split: capability.split_asm simp: isCap_defs)
 
@@ -618,7 +618,7 @@ lemma decode_inv_wf'[wp]:
           and (\<lambda>s. \<forall>x \<in> set excaps. ex_cte_cap_wp_to' isCNodeCap (snd x) s)
           and (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at' (badge_derived' (fst x) \<circ> cteCap) (snd x) s)
           and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))\<rbrace>
-     decodeInvocation label args cap_index slot cap excaps first_phase
+     decodeInvocation label args cap_index slot cap excaps first_phase buffer
    \<lbrace>valid_invocation'\<rbrace>,-"
   apply (case_tac cap,
          simp_all add: decodeInvocation_def Let_def isCap_defs uncurry_def split_def

--- a/spec/abstract/Invocations_A.thy
+++ b/spec/abstract/Invocations_A.thy
@@ -57,11 +57,11 @@ datatype tcb_invocation =
   | SetTLSBase obj_ref machine_word
 
 datatype sched_context_invocation =
-    InvokeSchedContextConsumed obj_ref "data list"
+    InvokeSchedContextConsumed obj_ref "obj_ref option"
   | InvokeSchedContextBind obj_ref cap
   | InvokeSchedContextUnbindObject obj_ref cap
   | InvokeSchedContextUnbind obj_ref cap
-  | InvokeSchedContextYieldTo obj_ref "data list"
+  | InvokeSchedContextYieldTo obj_ref "obj_ref option"
 
 datatype sched_control_invocation =
     InvokeSchedControlConfigure obj_ref ticks ticks nat badge

--- a/spec/abstract/SchedContext_A.thy
+++ b/spec/abstract/SchedContext_A.thy
@@ -339,8 +339,8 @@ where
      maybeM (\<lambda>sc_ptr. do
          buf \<leftarrow> lookup_ipc_buffer True tcb_ptr;
          set_consumed sc_ptr buf;
-         set_tcb_obj_ref tcb_yield_to_update tcb_ptr None;
-         set_sc_obj_ref sc_yield_from_update sc_ptr None
+         set_sc_obj_ref sc_yield_from_update sc_ptr None;
+         set_tcb_obj_ref tcb_yield_to_update tcb_ptr None
        od) yt_opt
     od"
 

--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -264,7 +264,7 @@ where
 definition
   sched_context_yield_to :: "obj_ref \<Rightarrow> data option \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
-  "sched_context_yield_to sc_ptr args \<equiv> do
+  "sched_context_yield_to sc_ptr buffer \<equiv> do
     sc_yf_opt \<leftarrow> get_sc_obj_ref sc_yield_from sc_ptr;
     when (sc_yf_opt \<noteq> None) $ do
       complete_yield_to (the sc_yf_opt); \<comment> \<open>@{text \<open>sc_yield_from = None\<close>}\<close>
@@ -289,7 +289,7 @@ where
       then do
         tcb_sched_action tcb_sched_dequeue tcb_ptr;
         tcb_sched_action tcb_sched_enqueue tcb_ptr; \<comment> \<open>@{text \<open>schedulable & dequeued & sufficient & ready\<close>}\<close>
-        set_consumed sc_ptr args
+        set_consumed sc_ptr buffer
       od
       else do
         set_sc_obj_ref sc_yield_from_update sc_ptr (Some ct_ptr);
@@ -300,7 +300,7 @@ where
         reschedule_required
       od
     od
-    else set_consumed sc_ptr args
+    else set_consumed sc_ptr buffer
   od"
 
 

--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -262,7 +262,7 @@ where
   "parse_time_arg i args \<equiv> (ucast (args!(i+1)) << 32) + ucast (args!i)"
 
 definition
-  sched_context_yield_to :: "obj_ref \<Rightarrow> data list \<Rightarrow> (unit, 'z::state_ext) s_monad"
+  sched_context_yield_to :: "obj_ref \<Rightarrow> data option \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
   "sched_context_yield_to sc_ptr args \<equiv> do
     sc_yf_opt \<leftarrow> get_sc_obj_ref sc_yield_from sc_ptr;

--- a/spec/abstract/Syscall_A.thy
+++ b/spec/abstract/Syscall_A.thy
@@ -244,7 +244,7 @@ where
       (\<lambda>fault. when blocking $ handle_fault thread fault)
       (\<lambda>(slot,cap,extracaps,buffer). doE
             args \<leftarrow> liftE $ get_mrs thread buffer info;
-            decode_invocation first_phase (mi_label info) args cptr slot cap extracaps
+            decode_invocation first_phase (mi_label info) args cptr slot cap extracaps buffer
        odE)
       (\<lambda>err. when calling $
             reply_from_kernel thread $ msg_from_syscall_error err)

--- a/spec/haskell/src/SEL4/API/Invocation.lhs
+++ b/spec/haskell/src/SEL4/API/Invocation.lhs
@@ -97,7 +97,7 @@ The following data type defines the set of possible TCB invocation operations. T
 > data SchedContextInvocation
 >         = InvokeSchedContextConsumed {
 >             consumedScPtr :: PPtr SchedContext,
->             consumedbuffer :: [Word] }
+>             consumedbuffer :: Maybe (PPtr Word) }
 >         | InvokeSchedContextBind {
 >             bindScPtr :: PPtr SchedContext,
 >             bindCap :: Capability }
@@ -107,7 +107,7 @@ The following data type defines the set of possible TCB invocation operations. T
 >         | InvokeSchedContextUnbind { unbindScPtr :: PPtr SchedContext }
 >         | InvokeSchedContextYieldTo {
 >             yieldToScPtr :: PPtr SchedContext,
->             yieldTobuffer :: [Word] }
+>             yieldTobuffer :: Maybe (PPtr Word) }
 >         deriving Show
 
 > data SchedControlInvocation

--- a/spec/haskell/src/SEL4/API/Syscall.lhs
+++ b/spec/haskell/src/SEL4/API/Syscall.lhs
@@ -250,7 +250,7 @@ If there was no fault, then the capability, message registers and message label 
 
 >         (\(slot, cap, extracaps, buffer) -> do
 >             args <- withoutFailure $ getMRs thread buffer info
->             decodeInvocation (msgLabel info) args cptr slot cap extracaps firstPhase)
+>             decodeInvocation (msgLabel info) args cptr slot cap extracaps firstPhase buffer)
 
 If a system call error was encountered while decoding the operation, and the user is waiting for a reply, then generate an error message.
 

--- a/spec/haskell/src/SEL4/Kernel/Thread.lhs
+++ b/spec/haskell/src/SEL4/Kernel/Thread.lhs
@@ -81,11 +81,10 @@ The "activateThread" function is used to prepare a thread to run. If the thread 
 > activateThread :: Kernel ()
 > activateThread = do
 >         thread <- getCurThread
->         state <- getThreadState thread
 >         scPtrOpt <- threadGet tcbYieldTo thread
 >         when (scPtrOpt /= Nothing) $ do
 >             schedContextCompleteYieldTo thread
->             assert (state == Running) "activateThread: thread state must be Running when tcbYieldTo is not Nothing"
+>         state <- getThreadState thread
 >         case state of
 >             Running -> return ()
 >             Restart -> do

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -696,9 +696,9 @@ The domain cap is invoked to set the domain of a given TCB object to a given val
 >         _ -> throw (InvalidCapability 1)
 >     return $ InvokeSchedContextUnbindObject scPtr cap
 
-> decodeSchedContext_YieldTo :: PPtr SchedContext -> [Word] ->
+> decodeSchedContext_YieldTo :: PPtr SchedContext -> Maybe (PPtr Word) ->
 >     KernelF SyscallError SchedContextInvocation
-> decodeSchedContext_YieldTo scPtr args = do
+> decodeSchedContext_YieldTo scPtr buffer = do
 >     sc <- withoutFailure $ getSchedContext scPtr
 >     when (scTCB sc == Nothing) $ throw IllegalOperation
 >     ctPtr <- withoutFailure $ getCurThread
@@ -706,14 +706,14 @@ The domain cap is invoked to set the domain of a given TCB object to a given val
 >     ct <- withoutFailure $ getObject ctPtr
 >     priority <- withoutFailure $ threadGet tcbPriority $ fromJust $ scTCB sc
 >     when (priority > tcbMCP ct) $ throw IllegalOperation
->     return $ InvokeSchedContextYieldTo scPtr args
+>     return $ InvokeSchedContextYieldTo scPtr buffer
 
-> decodeSchedContextInvocation :: Word -> PPtr SchedContext -> [Capability] -> [Word] ->
+> decodeSchedContextInvocation :: Word -> PPtr SchedContext -> [Capability] -> Maybe (PPtr Word) ->
 >     KernelF SyscallError SchedContextInvocation
-> decodeSchedContextInvocation label scPtr excaps args = do
+> decodeSchedContextInvocation label scPtr excaps buffer = do
 >     case genInvocationType label of
 >         SchedContextConsumed -> do
->             return $ InvokeSchedContextConsumed scPtr args
+>             return $ InvokeSchedContextConsumed scPtr buffer
 >         SchedContextBind -> decodeSchedContext_Bind scPtr excaps
 >         SchedContextUnbindObject -> decodeSchedContext_UnbindObject scPtr excaps
 >         SchedContextUnbind -> do
@@ -721,7 +721,7 @@ The domain cap is invoked to set the domain of a given TCB object to a given val
 >             sc <- withoutFailure $ getSchedContext scPtr
 >             when (fromJust (scTCB sc) == ctPtr) $ throw IllegalOperation
 >             return $ InvokeSchedContextUnbind scPtr
->         SchedContextYieldTo -> decodeSchedContext_YieldTo scPtr args
+>         SchedContextYieldTo -> decodeSchedContext_YieldTo scPtr buffer
 >         _ -> throw IllegalOperation
 
 > decodeSchedControl_Configure :: [Capability] -> [Word] ->


### PR DESCRIPTION
This solves `activateThread_invs'` and `activateThread_corres` but requires a number of small spec-changes:
* haskell for activateThread was slightly out-of-date
* Update ipc buffer handling: the code now does a lookup before invocation decoding and is passed all the way down.
* Fix ordering of commands for inlining of cancel_yield_to into complete_yield_to.