### PR TITLE
Prove schedContextUnbindTCB_invs'

### DIFF
--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -1653,10 +1653,6 @@ lemma dit_corres:
     apply (wp|simp add: obj_at_def is_tcb valid_pspace'_def)+
   done
 
-lemma setSchedContext_pde_mappings':
-  "setSchedContext p sc \<lbrace>valid_pde_mappings'\<rbrace>"
-  by (wp valid_pde_mappings_lift')
-
 lemma live_sc'_scConsumed_update[simp]:
   "live_sc' (scConsumed_update f koc) = live_sc' koc"
   by (clarsimp simp: live_sc'_def)
@@ -3322,13 +3318,6 @@ lemma completeSignal_invs:
   done *)
 
 lemmas threadSet_urz = untyped_ranges_zero_lift[where f="cteCaps_of", OF _ threadSet_cteCaps_of]
-
-lemma setSchedContext_urz[wp]:
-  "setSchedContext p sc \<lbrace> untyped_ranges_zero' \<rbrace>"
-  apply (simp add: cteCaps_of_def)
-  apply (rule hoare_pre, wp untyped_ranges_zero_lift)
-  apply (simp add: o_def)
-  done
 
 crunches doIPCTransfer
   for urz[wp]: "untyped_ranges_zero'"

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -506,37 +506,6 @@ lemma copyreg_invs':
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   by (rule hoare_strengthen_post, rule copyreg_invs'', simp)
 
-lemma threadSet_valid_queues_no_state:
-  "\<lbrace>Invariants_H.valid_queues and (\<lambda>s. \<forall>p. t \<notin> set (ksReadyQueues s p))\<rbrace>
-     threadSet f t \<lbrace>\<lambda>_. Invariants_H.valid_queues\<rbrace>"
-  apply (simp add: threadSet_def)
-  apply wp
-   apply (simp add: valid_queues_def valid_queues_no_bitmap_def' pred_tcb_at'_def)
-   apply (wp hoare_Ball_helper
-             hoare_vcg_all_lift
-             setObject_tcb_strongest)[1]
-  apply (wp getObject_tcb_wp)
-  apply (clarsimp simp: valid_queues_def valid_queues_no_bitmap_def' pred_tcb_at'_def)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemma threadSet_valid_queues'_no_state:
-  "(\<And>tcb. tcbQueued tcb = tcbQueued (f tcb))
-  \<Longrightarrow> \<lbrace>valid_queues' and (\<lambda>s. \<forall>p. t \<notin> set (ksReadyQueues s p))\<rbrace>
-     threadSet f t \<lbrace>\<lambda>_. valid_queues'\<rbrace>"
-  apply (simp add: valid_queues'_def threadSet_def obj_at'_real_def
-                split del: if_split)
-  apply (simp only: imp_conv_disj)
-  apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift)
-     apply (wp setObject_ko_wp_at | simp add: objBits_simps')+
-    apply (wp getObject_tcb_wp updateObject_default_inv
-               | simp split del: if_split)+
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs
-                        objBits_simps addToQs_def
-             split del: if_split cong: if_cong)
-  apply (fastforce simp: projectKOs inQ_def split: if_split_asm)
-  done
-
 lemma gts_isRunnable_corres:
   "corres (\<lambda>ts runn. runnable ts = runn) (tcb_at t) (tcb_at' t)
      (get_thread_state t) (isRunnable t)"

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -412,6 +412,7 @@ This module uses the C preprocessor to select a target architecture.
 
 > schedContextUnbindTCB :: PPtr SchedContext -> Kernel ()
 > schedContextUnbindTCB scPtr = do
+>     stateAssert sym_refs_asrt "Assert that `sym_refs (state_refs_of' s)` holds"
 >     sc <- getSchedContext scPtr
 >     let tptrOpt = scTCB sc
 >     assert (tptrOpt /= Nothing) "schedContextUnbind: option of TCB pointer must not be Nothing"


### PR DESCRIPTION
Proved `schedContextUnbindTCB_invs'` + moved a few lemmas around + introduced a counterpart to `same_caps` from AInvs for reasoning about `ex_nonz_cap_to'` after an update.