### PR TITLE
rt haskell: refactor replyRemove to match the c

### DIFF
--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -110,23 +110,21 @@ This module specifies the behavior of reply objects.
 
 >     nextReplyPtrOpt <- return $ replyNext reply
 >     prevReplyPtrOpt <- return $ replyPrev reply
->     if nextReplyPtrOpt /= Nothing
->        then
->            if isHead nextReplyPtrOpt
->               then replyPop replyPtr tcbPtr
->               else do
->                   nextReplyPtr <- return $ theReplyNextPtr nextReplyPtrOpt
->                   nextReply <- getReply nextReplyPtr
->                   setReply nextReplyPtr (nextReply { replyPrev = Nothing })
->                   replyUnlink replyPtr tcbPtr
->         else replyUnlink replyPtr tcbPtr
+>     if nextReplyPtrOpt /= Nothing && isHead nextReplyPtrOpt
+>        then replyPop replyPtr tcbPtr
+>        else do
+>            when (nextReplyPtrOpt /= Nothing) $ do
+>                nextReplyPtr <- return $ theReplyNextPtr nextReplyPtrOpt
+>                nextReply <- getReply nextReplyPtr
+>                setReply nextReplyPtr (nextReply { replyPrev = Nothing })
 
->     when (prevReplyPtrOpt /= Nothing) $ do
->         prevReplyPtr <- return $ fromJust prevReplyPtrOpt
->         prevReply <- getReply prevReplyPtr
->         setReply prevReplyPtr (prevReply { replyNext = Nothing })
+>            when (prevReplyPtrOpt /= Nothing) $ do
+>                prevReplyPtr <- return $ fromJust prevReplyPtrOpt
+>                prevReply <- getReply prevReplyPtr
+>                setReply prevReplyPtr (prevReply { replyNext = Nothing })
 
->     cleanReply replyPtr
+>            cleanReply replyPtr
+>            replyUnlink replyPtr tcbPtr
 
 
 > replyRemoveTCB :: PPtr TCB -> Kernel ()


### PR DESCRIPTION
The [C code](https://github.com/seL4/seL4/blob/master/src/object/reply.c#L101) returns early in the `reply_pop` branch, which leads to different behaviour than the previous Haskell implementation. While refactoring this I also moved the `replyUnlink` calls to the end of the function, which is consistent with `replyRemoveTCB` and I think will be convenient when proving hoare triples for `replyRemove`.

It might not be necessary to completely refactor the C code in the same way, but it would make crefine easier if we did. At the very least I think that we should move the `reply_unlink` calls to the end of `reply_remove` there as well.