### PR TITLE
rt: finish most of finaliseCap_replaceable

### DIFF
--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -6454,7 +6454,8 @@ crunches "Arch.finaliseCap", unbindMaybeNotification, prepareThreadDelete,
   for st_tcb_at'[wp]: "st_tcb_at' P t"
   (simp: crunch_simps wp: crunch_wps getObject_inv loadObject_default_inv)
 
-crunches schedContextDonate, replyUnlink, schedContextUnbindAllTCBs, unbindFromSC
+crunches schedContextDonate, replyUnlink, schedContextUnbindAllTCBs, unbindFromSC,
+         schedContextZeroRefillMax, schedContextUnbindYieldFrom, schedContextUnbindReply
   for st_tcb_at'[wp]: "st_tcb_at' P t"
   (simp: crunch_simps wp: threadSet_pred_tcb_no_state crunch_wps)
 

--- a/proof/refine/ARM/CSpace_I.thy
+++ b/proof/refine/ARM/CSpace_I.thy
@@ -14,8 +14,8 @@ begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemmas capUntypedPtr_simps[simp] = capUntypedPtr_def[split_simps capability.split]
-lemmas arch_capUntypedPtr_simps[simp] = ARM_H.capUntypedPtr_def[split_simps arch_capability.split]
+lemmas capUntypedPtr_simps[simp] = capUntypedPtr_def[split_simps capability.split, simplified PPtr_def id_def]
+lemmas arch_capUntypedPtr_simps[simp] = ARM_H.capUntypedPtr_def[split_simps arch_capability.split, simplified PPtr_def id_def]
 
 lemma rights_mask_map_UNIV [simp]:
   "rights_mask_map UNIV = allRights"

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -1705,7 +1705,8 @@ crunch valid_duplicates'[wp]:
   (wp: crunch_wps simp: crunch_simps unless_def)
 
 crunches deleteASIDPool, unbindNotification, prepareThreadDelete, unbindFromSC,
-         schedContextUnbindAllTCBs
+         schedContextUnbindAllTCBs, schedContextZeroRefillMax, schedContextUnbindYieldFrom,
+         schedContextUnbindReply
   for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
   (wp: crunch_wps simp: crunch_simps unless_def)
 

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -1585,7 +1585,7 @@ lemma setObject_valid_tcbs':
    apply clarsimp
    apply (erule (1) use_valid[OF _ setObject_valid_tcb'])
   apply (drule spec, erule mp)
-  apply (clarsimp simp: setObject_def in_monad split_def lookupAround2_char1 ARM_H.fromPPtr_def)
+  apply (clarsimp simp: setObject_def in_monad split_def lookupAround2_char1)
   apply (rename_tac s ptr' new_tcb' ptr'' old_tcb_ko' s' f)
   apply (case_tac "ptr'' = ptr'"; clarsimp)
   apply (prop_tac "\<exists>old_tcb' :: tcb. projectKO_opt old_tcb_ko' = Some old_tcb'")

--- a/spec/haskell/src/SEL4/Object/ObjectType.lhs
+++ b/spec/haskell/src/SEL4/Object/ObjectType.lhs
@@ -166,22 +166,9 @@ Threads are treated as special capability nodes; they also become zombies when t
 > finaliseCap (SchedContextCap { capSchedContextPtr = scPtr }) True _ = do
 >     schedContextUnbindAllTCBs scPtr
 >     schedContextUnbindNtfn scPtr
-
->     sc <- getSchedContext scPtr
->     replyPtrOpt <- return $ scReply sc
->     when (replyPtrOpt /= Nothing) $ do
->         replyPtr <- return $ fromJust replyPtrOpt
->         reply <- getReply replyPtr
->         setReply replyPtr (reply { replyNext = Nothing })
->         setSchedContext scPtr (sc { scReply = Nothing })
-
->     sc <- getSchedContext scPtr
->     when (scYieldFrom sc /= Nothing) $ do
->         schedContextCompleteYieldTo $ fromJust $ scYieldFrom sc
-
->     sc <- getSchedContext scPtr
->     setSchedContext scPtr $ sc { scRefillMax = 0 }
-
+>     schedContextUnbindReply scPtr
+>     schedContextUnbindYieldFrom scPtr
+>     schedContextZeroRefillMax scPtr
 >     return (NullCap, NullCap)
 
 Zombies have already been finalised.


### PR DESCRIPTION
The remaining subgoal involves showing that a reply that isn't linked to a tcb does not have any prev/next pointers. Unfortunately, we can only get from the abstract invariants that it is not part of a queue connected to a scheduling context. To solve this properly we expect that we will need a new Haskell-level invariant.