### PR TITLE
rt: cancel IPC when finalising reply caps 

### DIFF
--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -631,10 +631,8 @@ lemma suspend_not_recursive_ctes:
   unfolding updateRestartPC_def
   apply (wp threadSet_ctes_of | simp add: unless_def del: o_apply)+
          apply (fold cteCaps_of_def)
-         apply (wp cancelIPC_cteCaps_of gts_wp' stateAssert_wp hoare_vcg_all_lift hoare_drop_imps)+
+         apply (wp gts_wp' stateAssert_wp hoare_vcg_all_lift hoare_drop_imps)+
   apply (clarsimp elim!: rsubst[where P=P] intro!: set_eqI)
-  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-  apply (auto simp: isCap_simps finaliseCap_def Let_def)
   done
 
 crunches schedContextUnbindTCB, schedContextCompleteYieldTo, unbindNotification,
@@ -6477,7 +6475,7 @@ lemma replyClear_st_tcb_at':
   assumes x[simp]: "\<And>st. simple' st \<Longrightarrow> P st"
   shows "replyClear a b \<lbrace>st_tcb_at' P t\<rbrace>"
   unfolding replyClear_def
-  by (wpsimp wp: replyUnlink_st_tcb_at' replyRemove_sc_tcb_at' hoare_drop_imp)
+  by (wpsimp wp: replyUnlink_st_tcb_at' replyRemove_sc_tcb_at' cancelIPC_st_tcb_at hoare_drop_imp)
 
 lemma finaliseCap2_st_tcb_at':
   assumes x[simp]: "\<And>st. simple' st \<Longrightarrow> P st"

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -3301,6 +3301,10 @@ lemma pred_tcb_at' [elim!]:
   "pred_tcb_at' proj P t s \<Longrightarrow> tcb_at' t s"
   by (auto simp add: pred_tcb_at'_def obj_at'_def)
 
+lemma pred_tcb_at'_True[simp]:
+  "pred_tcb_at' proj \<top> p s = tcb_at' p s"
+  by (clarsimp simp: pred_tcb_at'_def obj_at'_def)
+
 lemma valid_pspace_mdb' [elim!]:
   "valid_pspace' s \<Longrightarrow> valid_mdb' s"
   by (simp add: valid_pspace'_def)

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -1008,15 +1008,6 @@ lemma (in delete_one_conc_pre) cancelIPC_tcb_at_runnable':
 crunch ksCurDomain[wp]: cancelSignal "\<lambda>s. P (ksCurDomain s)"
   (wp: crunch_wps)
 
-lemma (in delete_one_conc_pre) cancelIPC_ksCurDomain[wp]:
-  "\<lbrace>\<lambda>s. P (ksCurDomain s)\<rbrace> cancelIPC t \<lbrace>\<lambda>_ s. P (ksCurDomain s)\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def)
-  apply (wp hoare_vcg_conj_lift delete_one_ksCurDomain
-       | wpc
-       | rule hoare_drop_imps
-       | simp add: o_def if_fun_split)+
-  sorry
-
 (* FIXME move *)
 lemma setBoundNotification_not_ntfn:
   "(\<And>tcb ntfn. P (tcb\<lparr>tcbBoundNotification := ntfn\<rparr>) \<longleftrightarrow> P tcb)
@@ -1042,24 +1033,6 @@ lemma cancelSignal_tcb_obj_at':
      \<Longrightarrow> cancelSignal t word \<lbrace>obj_at' P t'\<rbrace>"
   apply (simp add: cancelSignal_def)
   apply (wpsimp wp: setThreadState_not_st getNotification_wp)
-  done
-
-lemma (in delete_one_conc_pre) cancelIPC_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace> cancelIPC t \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def)
-  apply (wp hoare_vcg_conj_lift
-            setThreadState_not_st delete_one_tcbDomain_obj_at' cancelSignal_tcb_obj_at'
-       | wpc
-       | rule hoare_drop_imps
-       | simp add: o_def if_fun_split)+
-  sorry
-
-lemma (in delete_one_conc_pre) cancelIPC_tcb_in_cur_domain':
-  "\<lbrace>tcb_in_cur_domain' t'\<rbrace> cancelIPC t \<lbrace>\<lambda>_. tcb_in_cur_domain' t'\<rbrace>"
-  apply (simp add: tcb_in_cur_domain'_def)
-  apply (rule hoare_pre)
-   apply wps
-   apply (wp cancelIPC_tcbDomain_obj_at' | simp)+
   done
 
 (* FIXME RT: not true any more
@@ -1355,13 +1328,6 @@ lemma replyRemoveTCB_valid_inQ_queues[wp]:
   apply (clarsimp simp: replyRemoveTCB_def)
   apply (rule hoare_seq_ext_skip, (solves \<open>wpsimp\<close>)?)+
   apply wpsimp
-  done
-
-lemma (in delete_one_conc_pre) cancelIPC_valid_inQ_queues[wp]:
-  "\<lbrace>valid_inQ_queues\<rbrace> cancelIPC t \<lbrace>\<lambda>_. valid_inQ_queues\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def)
-  apply (wpsimp wp: hoare_drop_imps delete_one_inQ_queues threadSet_valid_inQ_queues)
-  apply (clarsimp simp: valid_inQ_queues_def inQ_def)
   done
 
 lemma valid_queues_inQ_queues:

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -38,7 +38,6 @@ lemma replyRemoveTCB_st_tcb_at'_Inactive':
    \<lbrace>\<lambda>_. st_tcb_at' ((=) Inactive) tptr\<rbrace>"
   unfolding replyRemoveTCB_def
   apply (wpsimp wp: replyUnlink_st_tcb_at')
-  apply (clarsimp simp: pred_tcb_at'_def)
   done
 
 lemma replyRemoveTCB_st_tcb_at'[wp]:

--- a/spec/haskell/src/SEL4/Object/Endpoint.lhs
+++ b/spec/haskell/src/SEL4/Object/Endpoint.lhs
@@ -21,7 +21,7 @@ This module specifies the contents and behaviour of a synchronous IPC endpoint.
 > import SEL4.API.Types
 > import SEL4.Machine
 > import SEL4.Model
-> import SEL4.Object.Reply(getReplyTCB, replyClear, replyPush, replyRemove, replyUnlink, replyRemoveTCB, setReplyTCB)
+> import SEL4.Object.Reply(getReplyTCB, replyPush, replyRemove, replyUnlink, replyRemoveTCB, setReplyTCB)
 > import SEL4.Object.SchedContext
 > import SEL4.Object.Structures
 > import SEL4.Object.Instances()

--- a/spec/haskell/src/SEL4/Object/ObjectType.lhs
+++ b/spec/haskell/src/SEL4/Object/ObjectType.lhs
@@ -573,3 +573,10 @@ The following two functions returns the base and size of the object a capability
 > capUntypedSize (IRQHandlerCap {})
 >     = 1 -- error in haskell
 
+> replyClear :: PPtr Reply -> PPtr TCB -> Kernel ()
+> replyClear rptr tptr = do
+>     state <- getThreadState $ tptr
+>     case state of
+>         BlockedOnReply _ -> replyRemove rptr tptr
+>         BlockedOnReceive {} -> cancelIPC tptr
+>         _ -> fail "replyClear: invalid state of replyTCB"

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -7,14 +7,14 @@
 This module specifies the behavior of reply objects.
 
 > module SEL4.Object.Reply (
->         replyClear, replyRemove, replyPush, replyUnlink, getReply, setReply, getReplyTCB,
+>         replyRemove, replyPush, replyUnlink, getReply, setReply, getReplyTCB,
 >         replyRemoveTCB, setReplyTCB
 >     ) where
 
 \begin{impdetails}
 
 % {-# BOOT-IMPORTS: SEL4.Machine SEL4.Model SEL4.Object.Structures #-}
-% {-# BOOT-EXPORTS: replyClear replyRemove replyRemoveTCB replyPush replyUnlink getReply setReply getReplyTCB #-}
+% {-# BOOT-EXPORTS: replyRemove replyRemoveTCB replyPush replyUnlink getReply setReply getReplyTCB #-}
 
 > import {-# SOURCE #-} SEL4.Kernel.Thread(getThreadState, setThreadState)
 > import SEL4.Machine.RegisterSet(PPtr)
@@ -191,11 +191,3 @@ on the thread state of the replyTCB of the replyPtr
 > setReplyTCB tptrOpt rptr = do
 >     r <- getReply rptr
 >     setReply rptr (r { replyTCB = tptrOpt})
-
-> replyClear :: PPtr Reply -> PPtr TCB -> Kernel ()
-> replyClear rptr tptr = do
->     state <- getThreadState $ tptr
->     case state of
->         BlockedOnReply _ -> replyRemove rptr tptr
->         BlockedOnReceive {} -> replyUnlink rptr tptr
->         _ -> fail "replyClear: invalid state of replyTCB"


### PR DESCRIPTION
Deleting a reply object that is linked to a BlockedOnReceive thread is unusual behaviour and it's not clear what the expected behaviour should be. Previously replyUnlink was used, but it sets the thread to Inactive while leaving it in the endpoint's queue which breaks the invariants. Calling cancelIPC at least guarantees that the system ends up in a consistent state.

While updating the proofs I was able to delete or prove a few sorries and some crunches became more powerful, which unfortunately might end up conflicting with other ongoing work.