### PR TITLE
rt haskell refine: make reply functions more consistent

### DIFF
--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3597,7 +3597,7 @@ lemma replyPop_valid_objs'[wp]:
                in hoare_weaken_pre[rotated])
    apply (fastforce intro!: reply_ko_at_valid_objs_valid_reply')
   apply (intro hoare_seq_ext[OF _ assert_sp])
-  apply (rule hoare_seq_ext_skip, wpsimp wp: replyUnlink_valid_objs')
+  apply (rule hoare_seq_ext, wpsimp wp: replyUnlink_valid_objs')
   apply (rule hoare_when_cases, clarsimp)
   apply (rule hoare_seq_ext[OF _ assert_sp])
   apply (rule hoare_seq_ext_skip, wpsimp wp: schedContextDonate_valid_objs')+
@@ -3798,11 +3798,13 @@ lemma replyPop_valid_inQ_queues[wp]:
    \<lbrace>\<lambda>_. valid_inQ_queues\<rbrace>"
   (is "valid ?pre _ _")
   apply (clarsimp simp: replyPop_def)
+  apply (rule hoare_seq_ext[OF _ get_reply_sp'])
   apply (repeat_unless \<open>rule hoare_seq_ext[OF _ gts_sp']\<close>
                        \<open>rule hoare_seq_ext_skip, solves wpsimp\<close>)
   apply (rule_tac Q="?pre and tcb_at' tcbPtr" in hoare_weaken_pre[rotated])
    apply fastforce
-  apply (rule hoare_seq_ext_skip, wpsimp wp: replyUnlink_valid_objs')+
+  apply (intro hoare_seq_ext[OF _ assert_sp])
+  apply (rule hoare_seq_ext, wpsimp wp: replyUnlink_valid_objs')
   apply (rule hoare_when_cases, clarsimp)
   apply (wpsimp wp: set_sc'.valid_inQ_queues hoare_drop_imps schedContextDonate_valid_inQ_queues
                     threadGet_wp

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -573,13 +573,13 @@ lemma reply_remove_tcb_corres:
           apply (case_tac sc_ptr_opt; simp split del: if_split)
            apply (case_tac "replyNext rv"; simp split del: if_split)
             apply (rule corres_symb_exec_r)
-               apply (rule corres_symb_exec_r)
+(*                apply (rule corres_symb_exec_r)
                   apply (fold dc_def)
                   apply (rule corres_guard_imp)
                     apply (rule reply_unlink_tcb_corres)
                     apply (rule disjI2)
                     apply fastforce
-                   apply simp+
+                   apply simp+ *)
   sorry
 
 lemma cancel_ipc_corres:

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -1898,7 +1898,8 @@ lemma replyUnlink_weak_sch_act_wf:
   apply (wp weak_sch_act_wf_lift)
   sorry
 
-crunches unbindMaybeNotification, schedContextMaybeUnbindNtfn, isFinalCapability
+crunches unbindMaybeNotification, schedContextMaybeUnbindNtfn, isFinalCapability,
+         cleanReply, schedContextDonate
   for sch_act_not[wp]: "sch_act_not t"
   (wp: crunch_wps simp: crunch_simps)
 

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -82,8 +82,6 @@ This module specifies the behavior of reply objects.
 >     assert (isReply state) "replyPop: thread state must be BlockedOnReply"
 >     assert (replyObject state == Just replyPtr) "replyPop: thread state must have replyPtr as its reply"
 
->     replyUnlink replyPtr tcbPtr
-
 >     prevReplyPtrOpt <- return $ replyPrev reply
 >     nextReplyPtrOpt <- return $ replyNext reply
 >     when (nextReplyPtrOpt /= Nothing) $ do
@@ -97,7 +95,8 @@ This module specifies the behavior of reply objects.
 >             prevReplyPtr <- return $ fromJust prevReplyPtrOpt
 >             prevReply <- getReply prevReplyPtr
 >             setReply prevReplyPtr (prevReply { replyNext = replyNext reply })
->         cleanReply replyPtr
+>     replyUnlink replyPtr tcbPtr
+>     cleanReply replyPtr
 
 > replyRemove :: PPtr Reply -> PPtr TCB -> Kernel ()
 > replyRemove replyPtr tcbPtr = do
@@ -123,8 +122,8 @@ This module specifies the behavior of reply objects.
 >                prevReply <- getReply prevReplyPtr
 >                setReply prevReplyPtr (prevReply { replyNext = Nothing })
 
->            cleanReply replyPtr
 >            replyUnlink replyPtr tcbPtr
+>            cleanReply replyPtr
 
 
 > replyRemoveTCB :: PPtr TCB -> Kernel ()
@@ -153,8 +152,8 @@ This module specifies the behavior of reply objects.
 >         prevReply <- getReply prevReplyPtr
 >         setReply prevReplyPtr (prevReply { replyNext = Nothing })
 
->     cleanReply rptr
 >     replyUnlink rptr tptr
+>     cleanReply rptr
 
 > replyUnlink :: PPtr Reply -> PPtr TCB -> Kernel ()
 > replyUnlink replyPtr tcbPtr = do


### PR DESCRIPTION
This involves small refactors to replyPop, replyRemove and replyRemoveTCB, and also makes these functions slightly easier to prove properties about. The existing proofs about them are also updated.