### PR TITLE
rt refine: finish replyClear_makes_unlive

### DIFF
--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3605,7 +3605,7 @@ lemma replyPop_valid_objs'[wp]:
                in hoare_weaken_pre[rotated])
    apply (fastforce intro!: reply_ko_at_valid_objs_valid_reply')
   apply (intro hoare_seq_ext[OF _ assert_sp])
-  apply (rule hoare_seq_ext_skip, wpsimp wp: replyUnlink_valid_objs')
+  apply (rule hoare_seq_ext, wpsimp wp: replyUnlink_valid_objs')
   apply (rule hoare_when_cases, clarsimp)
   apply (rule hoare_seq_ext[OF _ assert_sp])
   apply (rule hoare_seq_ext_skip; wp)
@@ -3802,11 +3802,13 @@ lemma replyPop_valid_inQ_queues[wp]:
    \<lbrace>\<lambda>_. valid_inQ_queues\<rbrace>"
   (is "valid ?pre _ _")
   apply (clarsimp simp: replyPop_def)
+  apply (rule hoare_seq_ext[OF _ get_reply_sp'])
   apply (repeat_unless \<open>rule hoare_seq_ext[OF _ gts_sp']\<close>
                        \<open>rule hoare_seq_ext_skip, solves wpsimp\<close>)
   apply (rule_tac Q="?pre and tcb_at' tcbPtr" in hoare_weaken_pre[rotated])
    apply fastforce
-  apply (rule hoare_seq_ext_skip, wpsimp wp: replyUnlink_valid_objs')+
+  apply (intro hoare_seq_ext[OF _ assert_sp])
+  apply (rule hoare_seq_ext, wpsimp wp: replyUnlink_valid_objs')
   apply (rule hoare_when_cases, clarsimp)
   apply (wpsimp wp: set_sc'.valid_inQ_queues hoare_drop_imps schedContextDonate_valid_inQ_queues
                     threadGet_wp

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -2020,7 +2020,7 @@ crunches replyUnlink
   (simp: crunch_simps wp: crunch_wps)
 
 crunches unbindMaybeNotification, schedContextMaybeUnbindNtfn, isFinalCapability,
-         cleanReply
+         cleanReply, schedContextDonate
   for sch_act_not[wp]: "sch_act_not t"
   (wp: crunch_wps simp: crunch_simps)
 

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -47,7 +47,7 @@ crunches cleanReply
   for st_tcb_at'[wp]: "st_tcb_at' P t"
   and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   and weak_sch_act_wf[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
-  (wp: crunch_wps weak_sch_act_wf_lift simp: crunch_simps ignore: threadSet)
+  (rule: weak_sch_act_wf_lift)
 
 lemmas cleanReply_typ_ats[wp] = typ_at_lifts[OF cleanReply_typ_at']
 

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -43,12 +43,20 @@ lemma replyUnlink_st_tcb_at'_sym_ref:
   apply (fastforce simp: obj_at'_def projectKOs)
   done
 
+crunches cleanReply
+  for st_tcb_at'[wp]: "st_tcb_at' P t"
+  and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  and weak_sch_act_wf[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
+  (wp: crunch_wps weak_sch_act_wf_lift simp: crunch_simps ignore: threadSet)
+
+lemmas cleanReply_typ_ats[wp] = typ_at_lifts[OF cleanReply_typ_at']
+
 lemma replyRemoveTCB_st_tcb_at'_Inactive':
   "\<lbrace>\<top>\<rbrace>
    replyRemoveTCB tptr
    \<lbrace>\<lambda>_. st_tcb_at' ((=) Inactive) tptr\<rbrace>"
   unfolding replyRemoveTCB_def
-  apply (wpsimp wp: replyUnlink_st_tcb_at')
+  apply (wpsimp wp: replyUnlink_st_tcb_at' hoare_vcg_if_lift split_del: if_split)
   done
 
 lemma replyRemoveTCB_st_tcb_at'[wp]:
@@ -102,10 +110,7 @@ lemma replyRemoveTCB_st_tcb_at'_sym_ref:
        apply wp
       apply (rule_tac Q="\<lambda>_. obj_at' (\<lambda>r. replyTCB r = Some tptr) rptr" in hoare_post_imp,
              clarsimp)
-      apply wpsimp
-     apply wpsimp
-    apply (wpsimp wp: haskell_assert_wp)
-   apply (wpsimp wp: gts_wp')
+      apply (wpsimp wp: gts_wp')+
   apply (clarsimp simp: obj_at'_def pred_tcb_at'_def)
   done
 

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -90,8 +90,6 @@ This module specifies the behavior of reply objects.
 >     assert (isReply state) "replyPop: thread state must be BlockedOnReply"
 >     assert (replyObject state == Just replyPtr) "replyPop: thread state must have replyPtr as its reply"
 
->     replyUnlink replyPtr tcbPtr
-
 >     prevReplyPtrOpt <- return $ replyPrev reply
 >     nextReplyPtrOpt <- return $ replyNext reply
 >     when (nextReplyPtrOpt /= Nothing) $ do
@@ -105,7 +103,8 @@ This module specifies the behavior of reply objects.
 >             prevReplyPtr <- return $ fromJust prevReplyPtrOpt
 >             prevReply <- getReply prevReplyPtr
 >             setReply prevReplyPtr (prevReply { replyNext = replyNext reply })
->         cleanReply replyPtr
+>     cleanReply replyPtr
+>     replyUnlink replyPtr tcbPtr
 
 > replyRemove :: PPtr Reply -> PPtr TCB -> Kernel ()
 > replyRemove replyPtr tcbPtr = do
@@ -133,7 +132,6 @@ This module specifies the behavior of reply objects.
 
 >            cleanReply replyPtr
 >            replyUnlink replyPtr tcbPtr
-
 
 > replyRemoveTCB :: PPtr TCB -> Kernel ()
 > replyRemoveTCB tptr = do


### PR DESCRIPTION
Doing this requires introducing a new invariant called `valid_replies'`. Adding this to `invs'` and proving that it is preserved still needs to be done.