### PR TITLE
regression: use `python3` for tests-xml-correct

### DIFF
--- a/misc/regression/tests.xml
+++ b/misc/regression/tests.xml
@@ -58,7 +58,7 @@
 
     <!-- Ensure that all of our XML files are strictly correct. -->
     <test name="tests-xml-correct" cwd="../../" cpu-timeout="60">
-        find . -name tests.xml -print0 | xargs -0 python misc/regression/testspec.py
+        find . -name tests.xml -print0 | xargs -0 misc/regression/testspec.py
     </test>
 
 </testsuite>


### PR DESCRIPTION
PEP 394 expects that Python 3 installations provide a `python3` command,
but does not require a `python` command. Some distributions (including
Debian) are no longer providing a `python` command, but do provide
`python3`.

In this change, the `python3` interpreter is invoked via the existing
`#!` line in the `testspec.py` script.