### PR TITLE
mcs: improve typ_at_props locales and typ_at lifting

### DIFF
--- a/lib/HaskellLemmaBucket.thy
+++ b/lib/HaskellLemmaBucket.thy
@@ -119,19 +119,35 @@ lemma distinct_prop_breakD:
   apply fastforce
   done
 
-lemma stateAssert_wp:
+lemma stateAssert_wp[wp]:
   "\<lbrace>\<lambda>s. P s \<longrightarrow> Q () s\<rbrace> stateAssert P e \<lbrace>Q\<rbrace>"
   by (clarsimp simp: stateAssert_def) wp
 
-lemma haskell_assert_wp:
+lemma stateAssert_inv:
+  "\<lbrace>P\<rbrace> stateAssert Q l \<lbrace>\<lambda>_. P\<rbrace>"
+  by wpsimp
+
+lemma haskell_assert_wp[wp]:
   "\<lbrace>\<lambda>s. Q \<longrightarrow> P s\<rbrace> haskell_assert Q xs \<lbrace>\<lambda>_. P\<rbrace>"
-  by simp wp
+  by wpsimp
+
+lemma haskell_assert_inv:
+  "\<lbrace>P\<rbrace> haskell_assert Q l \<lbrace>\<lambda>_. P\<rbrace>"
+  by wpsimp
+
+lemma maybeToMonad_wp[wp]:
+  "\<lbrace>\<lambda>s. x \<noteq> None \<longrightarrow> Q (the x) s\<rbrace> maybeToMonad x \<lbrace>Q\<rbrace>"
+  by wpsimp
+
+lemma maybeToMonad_inv:
+  "\<lbrace>P\<rbrace> maybeToMonad x \<lbrace>\<lambda>_. P\<rbrace>"
+  by wpsimp
 
 lemma stateAssertE_sp:
   "\<lbrace>P\<rbrace> stateAssertE Q l \<lbrace>\<lambda>_. P and Q\<rbrace>, \<lbrace>\<lambda>_. R\<rbrace>"
   by (clarsimp simp: valid_def validE_def stateAssertE_def stateAssert_def in_monad)
 
-lemma stateAssertE_wp:
+lemma stateAssertE_wp[wp]:
   "\<lbrace>\<lambda>s. Q () \<longrightarrow> P s\<rbrace> stateAssertE Q l \<lbrace>\<lambda>_. P\<rbrace>"
   by (wpsimp simp: stateAssertE_def stateAssert_def)
 

--- a/lib/NICTATools.thy
+++ b/lib/NICTATools.thy
@@ -16,6 +16,7 @@ imports
   TSubst
   Time_Methods_Cmd
   Try_Attribute
+  Repeat_Attribute
   Trace_Schematic_Insts
   Insulin
   ShowTypes

--- a/lib/Repeat_Attribute.thy
+++ b/lib/Repeat_Attribute.thy
@@ -1,0 +1,78 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *)
+
+theory Repeat_Attribute
+imports Main
+begin
+
+ML \<open>
+local
+
+val attribute_generic = Context.cases Attrib.attribute_global Attrib.attribute
+
+fun apply_attributes attrs thm ctxt =
+  let
+    val (thm', ctxt') = fold (uncurry o Thm.apply_attribute) attrs (thm, ctxt)
+  in if Thm.eq_thm (thm, thm')
+     then (SOME ctxt', SOME thm)
+     else
+       apply_attributes attrs thm' ctxt'
+       handle e =>
+         (if Exn.is_interrupt e then Exn.reraise e else ();
+          (SOME ctxt', SOME thm'))
+  end
+
+fun repeat_attribute_cmd attr_srcs (ctxt, thm) =
+  let val attrs = map (attribute_generic ctxt) attr_srcs
+  in apply_attributes attrs thm ctxt end
+
+in
+
+val _ = Theory.setup
+  (Attrib.setup @{binding REPEAT}
+    (Attrib.attribs >> repeat_attribute_cmd)
+    "higher order attribute combinator to repeatedly apply other attributes one or more times")
+
+end
+\<close>
+
+text \<open>
+
+  The @{attribute REPEAT} attribute is an attribute combinator that repeatedly applies
+  other attributes one or more times. It will stop applying the attributes once they can
+  either no longer be applied, or if applying them would not change the theorem being
+  modified.
+
+  Usage:
+    thm foo[REPEAT [<attributes>]]
+
+\<close>
+
+section \<open>Examples\<close>
+
+experiment begin
+  lemma test1: "True \<Longrightarrow> True" .
+  lemma test2: "True \<Longrightarrow> True \<Longrightarrow> True" .
+  lemmas tests = test1 test2
+  text \<open>
+    `tests[OF TrueI]` would only discharge one of the assumptions of @{thm test2}, but
+    @{attribute REPEAT} handles both cases.
+  \<close>
+  thm tests[REPEAT [OF TrueI]]
+
+  text \<open>
+    @{attribute REPEAT} succesfully terminates when applying an attribute that could loop,
+    such as @{attribute simplified} and @{attribute simp}. Importantly, it still updates
+    the context if necessary, in this case by adding P to the simp set.
+  \<close>
+  lemma
+    assumes P[REPEAT[simplified], REPEAT [simp]]: "P \<or> False"
+    shows P
+    by simp
+
+end
+
+end

--- a/proof/access-control/CNode_AC.thy
+++ b/proof/access-control/CNode_AC.thy
@@ -141,8 +141,6 @@ where
   | CancelBadgedSendsCall cap \<Rightarrow> pas_cap_cur_auth aag cap
   | RevokeCall ptr \<Rightarrow> is_subject aag (fst ptr))"
 
-declare resolve_address_bits'.simps[simp del]
-
 lemma resolve_address_bits_authorised_aux:
   "s \<turnstile> \<lbrace>pas_refined aag and K (is_cnode_cap (fst (cap, cref))
                                \<longrightarrow> (\<forall>x \<in> obj_refs (fst (cap, cref)). is_subject aag x))\<rbrace>

--- a/proof/bisim/Separation.thy
+++ b/proof/bisim/Separation.thy
@@ -89,7 +89,7 @@ lemma separate_cnode_cap_rab:
                                                                      (throwError (GuardMismatch (length cref) guard))
                                        | _ \<Rightarrow> throwError InvalidRoot)"
   unfolding separate_cnode_cap_def resolve_address_bits_def
-  by (auto simp: word_bits_def split: cap.split_asm)
+  by (auto simp: word_bits_def resolve_address_bits'.simps split: cap.split_asm)
 
 definition
   "separate_state s \<equiv> \<forall>p. tcb_at p s \<longrightarrow> separate_tcb p (caps_of_state s)"

--- a/proof/bisim/Syscall_S.thy
+++ b/proof/bisim/Syscall_S.thy
@@ -97,6 +97,7 @@ lemma bisim_rab:
                                 | _ \<Rightarrow> throwError undefined
                         odE)
                       (resolve_address_bits (cap, cref))"
+  using resolve_address_bits'.simps[simp]
   unfolding resolve_address_bits_def
   apply (cases "length cref < word_bits")
    apply (auto intro!: bisim_underlyingI

--- a/proof/refine/ARM/ArchAcc_R.thy
+++ b/proof/refine/ARM/ArchAcc_R.thy
@@ -1173,10 +1173,16 @@ lemma lookup_pt_slot_corres [@lift_corres_args, corres]:
 
 declare in_set_zip_refl[simp]
 
-crunch typ_at'[wp]: copyGlobalMappings "\<lambda>s. P (typ_at' T p s)"
+crunches copyGlobalMappings
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  and sc_at'_n[wp]: "\<lambda>s. P (sc_at'_n n p s)"
   (wp: mapM_x_wp')
+end
 
-lemmas copyGlobalMappings_typ_ats[wp] = typ_at_lifts [OF copyGlobalMappings_typ_at']
+sublocale Arch < copyGlobalMappings: typ_at_all_props' "copyGlobalMappings newPD"
+  by typ_at_props'
+
+context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma arch_cap_rights_update:
   "acap_relation c c' \<Longrightarrow>

--- a/proof/refine/ARM/Bits_R.thy
+++ b/proof/refine/ARM/Bits_R.thy
@@ -21,7 +21,7 @@ crunch_ignore (add:
   debugPrint setNextPC maskInterrupt clearMemory throw_on_false
   unifyFailure ignoreFailure empty_on_failure emptyOnFailure clearMemoryVM null_cap_on_failure
   setNextPC getRestartPC assertDerived throw_on_false getObject setObject updateObject loadObject
-  ifM andM orM whenM whileM)
+  ifM andM orM whenM whileM haskell_assert)
 
 context Arch begin (*FIXME: arch_split*)
 

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -6531,18 +6531,18 @@ lemma replyPop_st_tcb_at':
   by (wpsimp wp: setThreadState_st_tcb_at'_test_unaffected replyUnlink_st_tcb_at'
                  hoare_drop_imp hoare_vcg_if_lift2  )
 
-lemma replyRemove_sc_tcb_at':
+lemma replyRemove_st_tcb_at':
   assumes x[simp]: "\<And>st. simple' st \<Longrightarrow> P st"
   shows "replyRemove a b \<lbrace>st_tcb_at' P t\<rbrace>"
   unfolding replyRemove_def
-  by (wpsimp wp: setThreadState_st_tcb_at'_test_unaffected replyPop_st_tcb_at' hoare_drop_imp hoare_vcg_if_lift2
-                 replyUnlink_st_tcb_at')
+  by (wpsimp wp: setThreadState_st_tcb_at'_test_unaffected replyPop_st_tcb_at'
+                 hoare_drop_imps hoare_vcg_if_lift2 replyUnlink_st_tcb_at')
 
 lemma replyClear_st_tcb_at':
   assumes x[simp]: "\<And>st. simple' st \<Longrightarrow> P st"
   shows "replyClear a b \<lbrace>st_tcb_at' P t\<rbrace>"
   unfolding replyClear_def
-  by (wpsimp wp: replyUnlink_st_tcb_at' replyRemove_sc_tcb_at' cancelIPC_st_tcb_at hoare_drop_imp)
+  by (wpsimp wp: replyUnlink_st_tcb_at' replyRemove_st_tcb_at' cancelIPC_st_tcb_at hoare_drop_imp)
 
 lemma finaliseCap2_st_tcb_at':
   assumes x[simp]: "\<And>st. simple' st \<Longrightarrow> P st"
@@ -8541,7 +8541,7 @@ lemma cteMove_invs' [wp]:
    apply ((rule hoare_vcg_conj_lift, (wp cteMove_ifunsafe')[1])
                   | rule hoare_vcg_conj_lift[rotated])+
       apply (unfold cteMove_def)
-      apply (wp cur_tcb_lift valid_queues_lift haskell_assert_inv
+      apply (wp cur_tcb_lift valid_queues_lift hoare_drop_imps
                 sch_act_wf_lift ct_idle_or_in_cur_domain'_lift2 tcb_in_cur_domain'_lift)+
   apply (clarsimp simp: o_def)
   done

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -593,47 +593,47 @@ proof (induct a arbitrary: c' cref' bits rule: resolve_address_bits'.induct)
         apply (simp add: caps isCap_defs Let_def whenE_bindE_throwError_to_if)
         apply (subst cnode_cap_case_if)
         apply (corressimp search: getSlotCap_corres IH
-                              wp: get_cap_wp getSlotCap_valid no_fail_stateAssert
-                            simp: locateSlot_conv)
+                              wp: get_cap_wp getSlotCap_valid hoare_drop_imps
+                            simp: locateSlot_conv stateAssert_def)
         apply (simp add: drop_postfix_eq)
         apply clarsimp
         apply (prove "is_aligned ptr (cte_level_bits + cbits) \<and> cbits \<le> word_bits - cte_level_bits")
-        apply (erule valid_CNodeCapE; fastforce simp: cte_level_bits_def)
+         apply (erule valid_CNodeCapE; fastforce simp: cte_level_bits_def)
         subgoal premises prems for s s' x
           apply (insert prems)
           apply (rule context_conjI)
-            apply (simp add: guard_mask_shift[OF \<open>to_bl _ = _\<close>, where guard=guard,symmetric])
-            apply (simp add: caps lookup_failure_map_def)
-            apply (rule conjI)
-            apply (clarsimp split: if_splits)
-            apply (intro conjI impI allI;clarsimp?)
-            apply (subst \<open>to_bl _ = _\<close>[symmetric])
-            apply (drule postfix_dropD)
-            apply clarsimp
-            apply (prove "32 + (cbits + length guard) - length cref =
-                         (cbits + length guard) + (32 - length cref)")
-             apply (drule len_drop_lemma, simp, arith)
-            apply simp
-            apply (subst drop_drop [symmetric])
-           subgoal by simp
-              apply (erule (2) valid_CNodeCapE)
-              apply (rule cap_table_at_cte_at[OF _ refl])
-              apply (simp add: obj_at_def is_cap_table_def well_formed_cnode_n_def)
-             apply (frule (2) cte_wp_valid_cap)
+           apply (simp add: guard_mask_shift[OF \<open>to_bl _ = _\<close>, where guard=guard,symmetric])
+          apply (simp add: caps lookup_failure_map_def)
+          apply (rule conjI)
+           apply (clarsimp split: if_splits)
+           apply (intro conjI impI allI;clarsimp?)
+             apply (subst \<open>to_bl _ = _\<close>[symmetric])
+             apply (drule postfix_dropD)
+             apply clarsimp
+             apply (prove "32 + (cbits + length guard) - length cref =
+                          (cbits + length guard) + (32 - length cref)")
+              apply (drule len_drop_lemma, simp, arith)
+             apply simp
+             apply (subst drop_drop [symmetric])
+             subgoal by simp
+            apply (erule (2) valid_CNodeCapE)
+            apply (rule cap_table_at_cte_at[OF _ refl])
+            apply (simp add: obj_at_def is_cap_table_def well_formed_cnode_n_def)
+           apply (frule (2) cte_wp_valid_cap)
            apply (rule context_conjI)
            apply (intro conjI impI allI;clarsimp?)
             apply (erule (2) valid_CNodeCapE)
             apply (erule (3) cte_map_shift')
             apply simp
-              apply (erule (1) cte_map_shift; assumption?)
-              subgoal by simp
-              apply (clarsimp simp: cte_level_bits_def)
-           apply (rule conjI)
-             apply (clarsimp simp: valid_cap_def cap_table_at_gsCNodes isCap_simps)
-             apply (rule and_mask_less_size, simp add: word_bits_def word_size cte_level_bits_def)
-           apply (clarsimp split: if_splits)
-           done
-         done
+           apply (erule (1) cte_map_shift; assumption?)
+           subgoal by simp
+          apply (clarsimp simp: cte_level_bits_def)
+          apply (rule conjI)
+           apply (clarsimp simp: valid_cap_def cap_table_at_gsCNodes isCap_simps)
+          apply (rule and_mask_less_size, simp add: word_bits_def word_size cte_level_bits_def)
+          apply (clarsimp split: if_splits)
+          done
+        done
     }
     ultimately
     show ?thesis by fast

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -512,8 +512,6 @@ lemma cap_table_at_gsCNodes:
   apply blast
   done
 
-declare resolve_address_bits'.simps[simp del]
-
 lemma getSlotCap_valid:
   "\<lbrace>\<lambda>s. valid_objs' s \<and> (cte_wp_at' (\<lambda>_. True) p s \<longrightarrow> (\<forall>cap. valid_cap' cap s \<longrightarrow> Q cap s))\<rbrace>
   getSlotCap p \<lbrace>Q\<rbrace>"

--- a/proof/refine/ARM/CSpace_R.thy
+++ b/proof/refine/ARM/CSpace_R.thy
@@ -3344,7 +3344,7 @@ lemma lookupSlotForCNodeOp_inv'[wp]:
 lemma loadWordUser_inv [wp]:
   "\<lbrace>P\<rbrace> loadWordUser p \<lbrace>\<lambda>rv. P\<rbrace>"
   unfolding loadWordUser_def
-  by (wp dmo_inv' loadWord_inv)
+  by (wpsimp wp: dmo_inv' loadWord_inv)
 
 lemma capTransferFromWords_inv:
   "\<lbrace>P\<rbrace> capTransferFromWords buffer \<lbrace>\<lambda>_. P\<rbrace>"

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -2035,7 +2035,7 @@ qed
 lemmas pspace_no_overlap'_lift2 = pspace_no_overlap'_lift[where Q=\<top>, simplified]
 
 crunches setCTE, insertNewCap
-  for sc_at'_n[wp]: "sc_at'_n n p"
+  for sc_at'_n[wp]: "\<lambda>s. P (sc_at'_n n p s)"
   (simp: crunch_simps wp: crunch_wps)
 
 lemma setCTE_pspace_no_overlap':

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -895,6 +895,7 @@ lemma blockedCancelIPC_st_tcb_at:
   unfolding blockedCancelIPC_def Let_def getBlockingObject_def
   apply (wpsimp wp: setThreadState_st_tcb_at'_cases replyUnlink_st_tcb_at' hoare_vcg_imp_lift'
                     getEndpoint_wp)
+  apply fastforce
   done
 
 lemma cancelIPC_st_tcb_at:

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -2040,7 +2040,8 @@ lemma cancelIPC_weak_sch_act_wf[wp]:
    cancelIPC tptr
    \<lbrace>\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
   unfolding cancelIPC_def blockedCancelIPC_def Let_def getBlockingObject_def
-  apply (wpsimp wp: gts_wp' threadSet_weak_sch_act_wf | wp (once) hoare_drop_imp)+
+  apply (wpsimp wp: gts_wp' threadSet_weak_sch_act_wf hoare_vcg_all_lift
+         | wp (once) hoare_drop_imps)+
   done
 
 lemma replyClear_weak_sch_act_wf[wp]:
@@ -3271,8 +3272,6 @@ lemma getSlotCap_cte_wp_at:
   done
 
 crunch no_0_obj'[wp]: setThreadState no_0_obj'
-
-declare haskell_assert_inv[wp del]
 
 lemma cteInsert_cap_to':
   "\<lbrace>ex_nonz_cap_to' p and cte_wp_at' (\<lambda>c. cteCap c = NullCap) dest\<rbrace>

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -2083,7 +2083,6 @@ lemma tc_caps_valid_duplicates':
   apply (rule hoare_walk_assmsE)
     apply (clarsimp simp: pred_conj_def option.splits [where P="\<lambda>x. x s" for s])
     apply ((wp case_option_wp threadSet_invs_trivial static_imp_wp setMCPriority_invs'
-               typ_at_lifts[OF setMCPriority_typ_at']
                hoare_vcg_all_lift threadSet_cap_to' | clarsimp simp: inQ_def)+)[2]
   apply ((simp only: simp_thms cases_simp cong: conj_cong
           | (wp cteDelete_deletes cteDelete_invs' cteDelete_sch_act_simple
@@ -2095,7 +2094,7 @@ lemma tc_caps_valid_duplicates':
               checkCap_inv[where P="\<lambda>s. P (ksReadyQueues s)" for P]
               checkCap_inv[where P="\<lambda>s. vs_valid_duplicates' (ksPSpace s)"]
               checkCap_inv[where P=sch_act_simple] cteDelete_valid_duplicates' hoare_vcg_const_imp_lift_R
-              typ_at_lifts[OF setPriority_typ_at'] assertDerived_wp threadSet_cte_wp_at'
+              assertDerived_wp threadSet_cte_wp_at'
               hoare_vcg_all_lift_R hoare_vcg_all_lift static_imp_wp)[1]
           | wpc
           | simp add: inQ_def
@@ -2126,7 +2125,6 @@ lemma tc_sched_valid_duplicates':
   apply (rule hoare_walk_assmsE)
     apply (clarsimp simp: pred_conj_def option.splits [where P="\<lambda>x. x s" for s])
     apply ((wp case_option_wp threadSet_invs_trivial static_imp_wp setMCPriority_invs'
-               typ_at_lifts[OF setMCPriority_typ_at']
                hoare_vcg_all_lift threadSet_cap_to' | clarsimp simp: inQ_def)+)[2]
   apply ((simp only: simp_thms cases_simp cong: conj_cong
           | (wp cteDelete_deletes cteDelete_invs' cteDelete_sch_act_simple
@@ -2138,7 +2136,7 @@ lemma tc_sched_valid_duplicates':
               checkCap_inv[where P="\<lambda>s. P (ksReadyQueues s)" for P]
               checkCap_inv[where P="\<lambda>s. vs_valid_duplicates' (ksPSpace s)"]
               checkCap_inv[where P=sch_act_simple] cteDelete_valid_duplicates' hoare_vcg_const_imp_lift_R
-              typ_at_lifts[OF setPriority_typ_at'] assertDerived_wp threadSet_cte_wp_at'
+              assertDerived_wp threadSet_cte_wp_at'
               hoare_vcg_all_lift_R hoare_vcg_all_lift static_imp_wp)[1]
           | wpc
           | simp add: inQ_def

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -46,10 +46,12 @@ lemma replyUnlink_st_tcb_at'_sym_ref:
 crunches cleanReply
   for st_tcb_at'[wp]: "st_tcb_at' P t"
   and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  and sc_at'_n[wp]: "\<lambda>s. P (sc_at'_n n p s)"
   and weak_sch_act_wf[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
   (rule: weak_sch_act_wf_lift)
 
-lemmas cleanReply_typ_ats[wp] = typ_at_lifts[OF cleanReply_typ_at']
+global_interpretation cleanReply: typ_at_all_props' "cleanReply p"
+  by typ_at_props'
 
 lemma replyRemoveTCB_st_tcb_at'_Inactive':
   "\<lbrace>\<top>\<rbrace>
@@ -255,6 +257,7 @@ crunches replyRemoveTCB
   and global_refs'[wp]: "valid_global_refs'"
   and valid_arch'[wp]: "valid_arch_state'"
   and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  and sc_at'_n[wp]: "\<lambda>s. P (sc_at'_n T p s)"
   and vms'[wp]: "valid_machine_state'"
   and valid_queues'[wp]: valid_queues'
   and valid_queues[wp]: valid_queues
@@ -264,6 +267,9 @@ crunches replyRemoveTCB
   and pspace_domain_valid[wp]: pspace_domain_valid
   (wp: crunch_wps hoare_vcg_if_lift
    simp: pred_tcb_at'_def if_distribR if_bool_eq_conj)
+
+global_interpretation replyUnlink: typ_at_all_props' "replyUnlink replyPtr tcbPtr"
+  by typ_at_props'
 
 (* FIXME RT: move to...? *)
 lemma valid_mdb'_lift:

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -71,7 +71,7 @@ lemma replyRemoveTCB_st_tcb_at'_cases:
    replyRemoveTCB t'
    \<lbrace>\<lambda>_. st_tcb_at' P t\<rbrace>"
   unfolding replyRemoveTCB_def cleanReply_def
-  apply (wpsimp wp: replyUnlink_st_tcb_at' hoare_vcg_imp_lift' gts_wp')
+  apply (wpsimp wp: replyUnlink_st_tcb_at' hoare_vcg_imp_lift' gts_wp' haskell_assert_inv)
   apply (case_tac "t = t'"; clarsimp simp: pred_tcb_at'_def)
   done
 
@@ -103,7 +103,7 @@ lemma replyRemoveTCB_st_tcb_at'_sym_ref:
                                                               (replyPrev_update Map.empty r))"]
                     set_reply'.set_no_update[where upd="\<lambda>r. (replyNext_update Map.empty r)"]
                     set_reply'.set_no_update[where upd="\<lambda>r. (replyPrev_update Map.empty r)"]
-                    hoare_vcg_imp_lift set_reply'.get_ko_at'
+                    hoare_vcg_imp_lift set_reply'.get_ko_at' haskell_assert_inv
               simp: disj_imp)
        apply (rule_tac Q="\<lambda>_. obj_at' (\<lambda>r. replyTCB r = Some tptr) rptr" in hoare_post_imp,
               clarsimp)
@@ -286,7 +286,7 @@ lemma replyRemoveTCB_valid_pspace'[wp]:
   unfolding replyRemoveTCB_def valid_pspace'_def cleanReply_def
   supply set_reply'.set_wp[wp del] if_split[split del]
   apply (wpsimp wp: valid_mdb'_lift updateReply_valid_objs'_preserved hoare_vcg_if_lift
-                    hoare_vcg_imp_lift gts_wp')
+                    hoare_vcg_imp_lift gts_wp' haskell_assert_inv)
   apply (clarsimp simp: valid_reply'_def if_bool_eq_conj if_distribR)
   apply (case_tac "replyPrev ko = None"; clarsimp)
    apply (drule(1) sc_ko_at_valid_objs_valid_sc'

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -1434,9 +1434,9 @@ lemma setCurThread_const:
 
 
 
-crunch it[wp]: switchToIdleThread "\<lambda>s. P (ksIdleThread s)"
-crunch it[wp]: switchToThread "\<lambda>s. P (ksIdleThread s)"
-    (ignore: clearExMonitor)
+crunches switchToIdleThread, switchToThread, chooseThread
+  for it[wp]: "\<lambda>s. P (ksIdleThread s)"
+  (wp: crunch_wps)
 
 lemma switchToIdleThread_curr_is_idle:
   "\<lbrace>\<top>\<rbrace> switchToIdleThread \<lbrace>\<lambda>rv s. ksCurThread s = ksIdleThread s\<rbrace>"
@@ -1446,15 +1446,6 @@ lemma switchToIdleThread_curr_is_idle:
    apply (wp setCurThread_const)
   apply (simp)
  done
-
-lemma chooseThread_it[wp]:
-  "\<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace> chooseThread \<lbrace>\<lambda>_ s. P (ksIdleThread s)\<rbrace>"
-  by (wp|clarsimp simp: chooseThread_def curDomain_def numDomains_def bitmap_fun_defs|assumption)+
-
-lemma threadGet_inv [wp]: "\<lbrace>P\<rbrace> threadGet f t \<lbrace>\<lambda>rv. P\<rbrace>"
-  apply (simp add: threadGet_def)
-  apply (wp | simp)+
-  done
 
 lemma corres_split_sched_act:
   "\<lbrakk>sched_act_relation act act';

--- a/proof/refine/ARM/Untyped_R.thy
+++ b/proof/refine/ARM/Untyped_R.thy
@@ -2711,7 +2711,12 @@ lemma no_default_zombie:
   "cap_relation (default_cap tp p sz d) cap \<Longrightarrow> \<not>isZombie cap"
   by (cases tp, auto simp: isCap_simps)
 
-lemmas updateNewFreeIndex_typ_ats[wp] = typ_at_lifts[OF updateNewFreeIndex_typ_at']
+end
+
+global_interpretation updateNewFreeIndex: typ_at_all_props' "updateNewFreeIndex slot"
+  by typ_at_props'
+
+context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma updateNewFreeIndex_valid_objs[wp]:
   "\<lbrace>valid_objs'\<rbrace> updateNewFreeIndex slot \<lbrace>\<lambda>_. valid_objs'\<rbrace>"

--- a/proof/refine/ARM_HYP/CSpace1_R.thy
+++ b/proof/refine/ARM_HYP/CSpace1_R.thy
@@ -530,8 +530,6 @@ lemma cap_table_at_gsCNodes:
   apply blast
   done
 
-declare resolve_address_bits'.simps[simp del]
-
 lemma getSlotCap_valid:
   "\<lbrace>\<lambda>s. valid_objs' s \<and> (cte_wp_at' (\<lambda>_. True) p s \<longrightarrow> (\<forall>cap. valid_cap' cap s \<longrightarrow> Q cap s))\<rbrace>
   getSlotCap p \<lbrace>Q\<rbrace>"

--- a/proof/refine/RISCV64/CSpace1_R.thy
+++ b/proof/refine/RISCV64/CSpace1_R.thy
@@ -523,8 +523,6 @@ lemma cap_table_at_gsCNodes:
   apply blast
   done
 
-declare resolve_address_bits'.simps[simp del]
-
 lemma rab_corres':
   "\<lbrakk> cap_relation (fst a) c'; drop (64-bits) (to_bl cref') = snd a;
      bits = length (snd a) \<rbrakk> \<Longrightarrow>

--- a/proof/refine/X64/CSpace1_R.thy
+++ b/proof/refine/X64/CSpace1_R.thy
@@ -525,8 +525,6 @@ lemma cap_table_at_gsCNodes:
   apply blast
   done
 
-declare resolve_address_bits'.simps[simp del]
-
 lemma rab_corres':
   "\<lbrakk> cap_relation (fst a) c'; drop (64-bits) (to_bl cref') = snd a;
      bits = length (snd a) \<rbrakk> \<Longrightarrow>

--- a/spec/abstract/CSpace_A.thy
+++ b/spec/abstract/CSpace_A.thy
@@ -200,6 +200,8 @@ termination
   apply (auto simp: whenE_def returnOk_def return_def rab_termination)
   done
 
+declare resolve_address_bits'.simps[simp del]
+
 definition resolve_address_bits where
 "resolve_address_bits \<equiv> resolve_address_bits' TYPE('z::state_ext)"
 


### PR DESCRIPTION
This makes the locales explicitly discharge all `typ_at_lifts` assumptions and updates the proofs to use the locales instead of manually instantiating `typ_at_lifts` with a lemmas command.

To properly discharge all of the assumptions I added a `REPEAT` attribute, that applies the given attributes one or more times. This should successfully handle almost all standard uses of attributes that I have been able to think of, with the only exception being `symmetric` which will loop. We could guard against this by passing along all seen thms and checking that we haven't looped to any previous one, but this is a bit unpleasant and wouldn't perform well in complicated cases. Opinions and suggestions welcome!

As side distractions, while doing this I also added wp rules for several Haskell assert functions and moved some proofs outside of the anonymous locale that we use to access `Arch` facts. I think the first change is definitely helpful and will lead to more consistent behaviour, although it did require some annoying updates to existing proofs. Moving proofs out of the locale is less beneficial, and I mainly did it because I was already needing to drop out of and back in to the anonymous locale. I guess it might make a future arch split slightly easier?