### PR TITLE
rt: fix ts-2019 branch for github CI tests

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -50,6 +50,7 @@ jobs:
       uses: seL4/ci-actions/run-proofs@master
       with:
         L4V_ARCH: ${{ matrix.arch }}
+        isa_branch: ts-2019
         session: ExecSpec ASpecDoc AInvs
 
   refine:
@@ -71,4 +72,5 @@ jobs:
       uses: seL4/ci-actions/run-proofs@master
       with:
         L4V_ARCH: ${{ matrix.arch }}
+        isa_branch: ts-2019
         session: Refine


### PR DESCRIPTION
This is in preparation for the repo manifest switching over to Isabelle2020.
Until we have merged the Isabelle2020 update, this commit will make sure the
github tests continue to run Isabelle2019 for this branch.
