### PR TITLE
fix AutoCorresSEL4 session

### DIFF
--- a/proof/Makefile
+++ b/proof/Makefile
@@ -19,7 +19,7 @@ report-regression:
 #
 
 # Refine heaps.
-HEAPS += AInvs BaseRefine BaseRefine2 Refine RefineOrphanage
+HEAPS += AInvs BaseRefine Refine RefineOrphanage
 
 # CRefine heaps.
 HEAPS += CKernel CSpec CBaseRefine CRefine
@@ -45,7 +45,9 @@ BaseRefine Refine DBaseRefine DRefine: design-spec
 
 # CKernel uses the `machinety=machine_state` option for `install_C_file`,
 # and therefore depends on `design-spec`.
-CKernel CSpec CBaseRefine CRefine SimplExportAndRefine: c-kernel design-spec
+CKernel CSpec : c-kernel design-spec
+
+CBaseRefine CRefine SimplExportAndRefine : c-kernel design-spec ASpec-files
 
 # Preprocess the kernel's source code and bitfield theory files.
 c-kernel: .FORCE
@@ -56,6 +58,10 @@ c-kernel: .FORCE
 design-spec: .FORCE
 	cd ../spec && $(ISABELLE_TOOL) env make design-spec
 .PHONY: design-spec
+
+ASpec-files: .FORCE
+	cd ../spec && make ASpec-files
+.PHONY: ASpec-files
 
 include ../misc/isa-common.mk
 

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -38,7 +38,9 @@ ASPEC_GITREV_FILE=abstract/document/gitrev.tex
 GIT_ROOT_FILE=abstract/document/git-root.tex
 
 # NOTE: The abstract spec imports Events from Haskell hence the dependency
-ASpec: $(ASPEC_VERSION_FILE) $(GIT_ROOT_FILE) $(ASPEC_GITREV_FILE) design-spec
+ASpec: ASpec-files design-spec
+
+ASpec-files: $(ASPEC_VERSION_FILE) $(GIT_ROOT_FILE) $(ASPEC_GITREV_FILE)
 
 $(ASPEC_VERSION_FILE): $(SEL4_VERSION)
 	cp $< $@

--- a/tools/autocorres/ROOT
+++ b/tools/autocorres/ROOT
@@ -24,5 +24,6 @@ session AutoCorresSEL4 in "test-seL4" = CBaseRefine +
     Lib
     CLib
     CParser
+    AutoCorres
   theories
     "TestSEL4"

--- a/tools/autocorres/test-seL4/TestSEL4.thy
+++ b/tools/autocorres/test-seL4/TestSEL4.thy
@@ -6,7 +6,7 @@
 
 theory TestSEL4
 imports
-  AutoCorres
+  "AutoCorres.AutoCorres"
   "CSpec.KernelInc_C"
 begin
 


### PR DESCRIPTION
This session wasn't included in the testboard and of course promptly failed.

The fix is a) a small tweak in the imports, and b) a slight refactor in the Makefile to make sure the ASpec doc version files are generated early enough.