### PR TITLE
rt: make valid_replies' easier to prove

### DIFF
--- a/proof/invariant-abstract/DetSchedAux_AI.thy
+++ b/proof/invariant-abstract/DetSchedAux_AI.thy
@@ -1119,12 +1119,13 @@ lemma ball_filterM_scheme:
 
 (* FIXME: Move *)
 lemma st_tcb_reply_state_refs:
-  "\<lbrakk>valid_objs s; sym_refs (state_refs_of s); st_tcb_at ((=) (BlockedOnReply rp)) thread s\<rbrakk>
-  \<Longrightarrow> \<exists>reply. (kheap s rp = Some (Reply reply) \<and> reply_tcb reply = Some thread)"
-  apply (frule (1) st_tcb_at_valid_st2)
-  apply (drule (1) sym_refs_st_tcb_atD[rotated])
-  apply (clarsimp simp: get_refs_def2 obj_at_def valid_tcb_state_def is_reply
-                  split: thread_state.splits if_splits)
+  "\<lbrakk>st_tcb_at ((=) (Structures_A.thread_state.BlockedOnReply rp)) thread s; sym_refs (state_refs_of s)\<rbrakk>
+  \<Longrightarrow> \<exists>reply. (kheap s rp = Some (kernel_object.Reply reply) \<and> reply_tcb reply = Some thread)"
+  apply (clarsimp simp: pred_tcb_at_def)
+  apply (drule (1) sym_refs_obj_atD[where p=thread])
+  apply (clarsimp simp: state_refs_of_def obj_at_def tcb_st_refs_of_def
+                 split: Structures_A.thread_state.splits)
+  apply (rename_tac ko; case_tac ko; clarsimp simp: get_refs_def2)
   done
 
 (* FIXME move *)

--- a/proof/invariant-abstract/IpcDet_AI.thy
+++ b/proof/invariant-abstract/IpcDet_AI.thy
@@ -1471,7 +1471,6 @@ lemma valid_replies_2_inj_onD:
 
 lemma sym_refs_reply_sc_reply_at:
   "sym_refs (state_refs_of s) \<Longrightarrow>
-   reply_at reply_ptr s \<Longrightarrow>
    sc_replies_sc_at ((=) (reply_ptr # list)) sc_ptr s \<Longrightarrow>
    reply_sc_reply_at (\<lambda>sp. sp = (Some sc_ptr)) reply_ptr s"
   apply (subgoal_tac "(sc_ptr, ReplySchedContext) \<in> state_refs_of s reply_ptr")
@@ -1479,6 +1478,18 @@ lemma sym_refs_reply_sc_reply_at:
    apply (case_tac x2; clarsimp simp: get_refs_def reply_sc_reply_at_def obj_at_def split: option.splits)
   apply (erule sym_refsE)
   apply (clarsimp simp: sc_replies_sc_at_def obj_at_def is_reply_def split: option.splits)
+  apply (fastforce simp: state_refs_of_def refs_of_def get_refs_def split: option.splits)
+  done
+
+lemma sym_refs_sc_replies_sc_at:
+  "sym_refs (state_refs_of s) \<Longrightarrow>
+   reply_sc_reply_at (\<lambda>sp. sp = (Some sc_ptr)) reply_ptr s \<Longrightarrow>
+   \<exists>list. sc_replies_sc_at ((=) (reply_ptr # list)) sc_ptr s"
+  apply (subgoal_tac "(reply_ptr, SCReply) \<in> state_refs_of s sc_ptr")
+   apply (clarsimp simp: state_refs_of_def refs_of_def split: option.splits)
+   apply (case_tac x2; clarsimp simp: get_refs_def sc_replies_sc_at_def obj_at_def split: option.splits)
+  apply (erule sym_refsE)
+  apply (clarsimp simp: reply_sc_reply_at_def obj_at_def is_reply_def split: option.splits)
   apply (fastforce simp: state_refs_of_def refs_of_def get_refs_def split: option.splits)
   done
 

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3015,8 +3015,9 @@ method cancelIPC_makes_unlive_hammer =
 
 lemma cancelIPC_makes_unlive:
   "\<lbrace>\<lambda>s. obj_at' (\<lambda>reply. replyTCB reply = Some tptr) rptr s
-        \<and> weak_sch_act_wf (ksSchedulerAction s) s \<and> valid_replies' s\<rbrace>
-   cancelIPC  tptr
+        \<and> weak_sch_act_wf (ksSchedulerAction s) s \<and> valid_replies' s
+        \<and> valid_replies'_sc_asrt rptr s\<rbrace>
+   cancelIPC tptr
    \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') rptr\<rbrace>"
   unfolding cancelIPC_def blockedCancelIPC_def Let_def getBlockingObject_def sym_refs_asrt_def
   apply simp
@@ -3028,7 +3029,8 @@ lemma cancelIPC_makes_unlive:
           apply (wpsimp wp: hoare_pre_cont, cancelIPC_makes_unlive_hammer)
          apply (wpsimp wp: setThreadState_unlive_other replyUnlink_makes_unlive
                            hoare_vcg_all_lift hoare_drop_imps threadSet_weak_sch_act_wf)
-         apply (frule (1) valid_replies'_other_state; clarsimp)
+         apply (frule (1) valid_replies'_other_state;
+                clarsimp simp: valid_replies'_sc_asrt_replySc_None)
          apply cancelIPC_makes_unlive_hammer
         (* BlockedOnReply*)
         apply (wpsimp wp: replyRemoveTCB_makes_unlive threadSet_pred_tcb_no_state
@@ -3040,7 +3042,8 @@ lemma cancelIPC_makes_unlive:
 
 lemma replyClear_makes_unlive:
   "\<lbrace>\<lambda>s. obj_at' (\<lambda>reply. replyTCB reply = Some tptr) rptr s
-        \<and> weak_sch_act_wf (ksSchedulerAction s) s \<and> valid_replies' s\<rbrace>
+        \<and> weak_sch_act_wf (ksSchedulerAction s) s \<and> valid_replies' s
+        \<and> valid_replies'_sc_asrt rptr s\<rbrace>
    replyClear rptr tptr
    \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') rptr\<rbrace>"
   apply (simp add: replyClear_def)
@@ -3271,6 +3274,8 @@ lemma (in delete_one_conc_pre) finaliseCap_replaceable:
   apply (rule conjI; clarsimp)
    apply (clarsimp simp: obj_at'_def)
   apply (frule (1) valid_replies'_no_tcb[OF ko_at_obj_at', simplified], clarsimp)
+   apply (clarsimp simp: valid_replies'_sc_asrt_def obj_at'_def projectKOs
+                         getHeadScPtr_None_iff)
   apply (clarsimp simp: ko_wp_at'_def obj_at'_def live_reply'_def projectKOs)
   done
 

--- a/spec/design/skel/KernelStateData_H.thy
+++ b/spec/design/skel/KernelStateData_H.thy
@@ -93,7 +93,7 @@ where
     return r
   od"
 
-#INCLUDE_HASKELL SEL4/Model/StateData.lhs decls_only ONLY capHasProperty sym_refs_asrt ready_qs_runnable
-#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue Kernel assert stateAssert findM funArray newKernelState capHasProperty ifM whenM whileM andM orM maybeToMonad sym_refs_asrt ready_qs_runnable
+#INCLUDE_HASKELL SEL4/Model/StateData.lhs decls_only ONLY capHasProperty sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable
+#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue Kernel assert stateAssert findM funArray newKernelState capHasProperty ifM whenM whileM andM orM maybeToMonad sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable
 
 end

--- a/spec/haskell/src/SEL4/Model/StateData.lhs
+++ b/spec/haskell/src/SEL4/Model/StateData.lhs
@@ -380,4 +380,10 @@ using the rule `state_refs_of_cross_eq`.
 > sym_refs_asrt :: KernelState -> Bool
 > sym_refs_asrt _ = True
 
+We would also like to use the fact that `valid_replies'` holds for replies linked to an SC. We
+does this by adding an assertion and proving it True by using .
+
+> valid_replies'_sc_asrt :: PPtr Reply -> KernelState -> Bool
+> valid_replies'_sc_asrt _ _ = True
+
 

--- a/spec/haskell/src/SEL4/Object/ObjectType.lhs
+++ b/spec/haskell/src/SEL4/Object/ObjectType.lhs
@@ -134,6 +134,8 @@ When the last capability to an endpoint is deleted, any IPC operations currently
 >     when final $ do
 >         stateAssert sym_refs_asrt
 >             "Assert that `sym_refs (state_refs_of' s)` holds"
+>         stateAssert (valid_replies'_sc_asrt ptr)
+>             "Assert that `valid_replies'` holds"
 >         tptrOpt <- getReplyTCB ptr
 >         when (tptrOpt /= Nothing) $ do
 >             replyClear ptr (fromJust tptrOpt)


### PR DESCRIPTION
This updates valid_replies' to only hold for replies with pointers to other replies. Replies connected to an SC are instead handled by an assertion and a cross lemma, using the abstract valid_replies invariant.