### PR TITLE
rt refine+haskell: prove tc_corres_caps and tc_corres_sched

### DIFF
--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -1509,13 +1509,13 @@ lemma corres_assert_assume_l:
   by (force simp: corres_underlying_def assert_def return_def bind_def fail_def)
 
 lemma corres_assert_assume_r:
-  "corres_underlying sr nf nf' dc P Q f (g ())
-  \<Longrightarrow> corres_underlying sr nf nf' dc P (Q and (\<lambda>s. Q')) f (assert Q' >>= g)"
+  "corres_underlying sr nf nf' rrel P Q f (g ())
+  \<Longrightarrow> corres_underlying sr nf nf' rrel P (Q and (\<lambda>s. Q')) f (assert Q' >>= g)"
   by (force simp: corres_underlying_def assert_def return_def bind_def fail_def)
 
 lemma corres_assert_opt_assume_l:
-  "corres_underlying sr nf nf' dc P Q (f (the X)) g
-  \<Longrightarrow> corres_underlying sr nf nf' dc (P and K (X \<noteq> None)) Q (assert_opt X >>= f) g"
+  "corres_underlying sr nf nf' rrel P Q (f (the X)) g
+  \<Longrightarrow> corres_underlying sr nf nf' rrel (P and K (X \<noteq> None)) Q (assert_opt X >>= f) g"
   by (force simp: corres_underlying_def assert_opt_def return_def bind_def fail_def)
 
 end

--- a/proof/invariant-abstract/Ipc_AI.thy
+++ b/proof/invariant-abstract/Ipc_AI.thy
@@ -2633,6 +2633,9 @@ lemma tcb_at_cte_at_3:
   "tcb_at tcb s \<Longrightarrow> cte_at (tcb, tcb_cnode_index 3) s"
   by (auto simp: obj_at_def cte_at_cases is_tcb)
 
+lemma tcb_at_cte_at_4:
+  "tcb_at tcb s \<Longrightarrow> cte_at (tcb, tcb_cnode_index 4) s"
+  by (auto simp: obj_at_def cte_at_cases is_tcb)
 
 context Ipc_AI begin
 crunch valid_irq_states[wp]: do_ipc_transfer "valid_irq_states :: 'state_ext state \<Rightarrow> bool"

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -2288,10 +2288,10 @@ proof -
   apply (drule(1) src_in_range)+
   apply (drule base_member_set[OF pspace_alignedD'])
     apply simp
-   apply (simp add:objBitsKO_bounded2[unfolded word_bits_def,simplified])
+   apply (simp add: objBitsKO_bounded[unfolded word_bits_def,simplified])
   apply (drule base_member_set[OF pspace_alignedD'])
     apply simp
-   apply (simp add:objBitsKO_bounded2[unfolded word_bits_def,simplified])
+   apply (simp add: objBitsKO_bounded[unfolded word_bits_def,simplified])
   apply (clarsimp simp:field_simps)
   apply blast
   done

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -134,6 +134,31 @@ lemma no_fail_getObject_tcb [wp]:
   apply (fastforce split: option.split_asm simp: objBits_simps' archObjSize_def)
   done
 
+lemma lookupAround2_same1[simp]:
+  "(fst (lookupAround2 x s) = Some (x, y)) = (s x = Some y)"
+  apply (rule iffI)
+   apply (simp add: lookupAround2_char1)
+  apply (simp add: lookupAround2_known1)
+  done
+
+lemma objBitsKO_bounded[simp]:
+  "objBitsKO ko < word_bits"
+  using scBits_max
+  by (simp add: objBits_simps' word_bits_def pageBits_def archObjSize_def pdeBits_def pteBits_def
+           split: Structures_H.kernel_object.split arch_kernel_object.split)
+
+lemma no_fail_getObject_sc[wp]:
+  "no_fail (sc_at' t) (getObject t :: sched_context kernel)"
+  apply (simp add: getObject_def split_def)
+  apply (rule no_fail_pre)
+   apply wp
+  apply (clarsimp simp: obj_at'_def projectKOs cong: conj_cong)
+  apply (rule ps_clear_lookupAround2, simp+)
+   apply (simp add: p_assoc_help)
+   apply (erule is_aligned_no_wrap'[OF _ word32_power_less_1[OF objBitsKO_bounded]])
+  apply (clarsimp simp: objBits_simps' simp del: lookupAround2_same1 split: option.splits)
+  done
+
 lemma typ_at_to_obj_at':
   "typ_at' (koType (TYPE ('a :: pspace_storable))) p s
      = obj_at' (\<top> :: 'a \<Rightarrow> bool) p s"
@@ -159,7 +184,7 @@ lemma corres_get_tcb [corres]:
   apply (clarsimp simp add: obj_at_def is_tcb obj_at'_def projectKO_def
                             projectKO_opt_tcb split_def
                             getObject_def loadObject_default_def in_monad)
-  apply (case_tac koa)
+  apply (case_tac obj)
    apply (simp_all add: fail_def return_def)
   apply (case_tac bb)
    apply (simp_all add: fail_def return_def)
@@ -169,13 +194,6 @@ lemma corres_get_tcb [corres]:
    apply blast
   apply (clarsimp simp add: other_obj_relation_def
                             lookupAround2_known1)
-  done
-
-lemma lookupAround2_same1[simp]:
-  "(fst (lookupAround2 x s) = Some (x, y)) = (s x = Some y)"
-  apply (rule iffI)
-   apply (simp add: lookupAround2_char1)
-  apply (simp add: lookupAround2_known1)
   done
 
 lemma getObject_tcb_at':

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -2052,8 +2052,7 @@ crunches setPriority, setMCPriority
        wp: setObject_ksInterrupt updateObject_default_inv crunch_wps
      simp: crunch_simps)
 
-crunches installFaultHandler, installThreadBuffer, installVRoot, installCRoot,
-         installTimeoutHandler
+crunches installTCBCap, installThreadBuffer
   for valid_duplicates'[wp]: "(\<lambda>s. vs_valid_duplicates' (ksPSpace s))"
   (wp:  crunch_wps checkCap_inv
    simp: crunch_simps getThreadVSpaceRoot_def getThreadFaultHandlerSlot_def

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -56,12 +56,6 @@ lemma createObjects_ret:
                         shiftl_t2n power_add)
   done
 
-lemma objBitsKO_bounded2[simp]:
-  "objBitsKO ko < word_bits"
-  using scBits_max
-  by (simp add: objBits_simps' word_bits_def pageBits_def archObjSize_def pdeBits_def pteBits_def
-           split: Structures_H.kernel_object.split arch_kernel_object.split)
-
 declare select_singleton_is_return[simp]
 
 definition

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -403,6 +403,8 @@ lemma pinv_corres:
             and (\<lambda>s. schact_is_rct s)
             and current_time_bounded 1
             and ct_active
+            and ct_released
+            and ct_not_in_release_q
             and (\<lambda>s. (\<exists>w w2 b c. i = Invocations_A.InvokeEndpoint w w2 b c) \<longrightarrow> st_tcb_at simple (cur_thread s) s))
      (invs' and sch_act_simple and valid_invocation' i' and ct_active' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
      (perform_invocation block call can_donate i) (performInvocation block call can_donate i')"

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -1398,6 +1398,12 @@ proof -
     done
 qed
 
+lemma threadSet_mdb':
+  "\<lbrace>valid_mdb' and obj_at' (\<lambda>t. \<forall>(getF, setF) \<in> ran tcb_cte_cases. getF t = getF (f t)) t\<rbrace>
+   threadSet f t
+   \<lbrace>\<lambda>rv. valid_mdb'\<rbrace>"
+  by (wpsimp wp: setObject_tcb_mdb' getTCB_wp simp: threadSet_def obj_at'_def)
+
 lemma threadSet_sch_act:
   "(\<And>tcb. tcbState (F tcb) = tcbState tcb \<and> tcbDomain (F tcb) = tcbDomain tcb) \<Longrightarrow>
   \<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>

--- a/spec/haskell/src/SEL4/API/Invocation.lhs
+++ b/spec/haskell/src/SEL4/API/Invocation.lhs
@@ -69,7 +69,7 @@ The following data type defines the set of possible TCB invocation operations. T
 >             tcSchedFaultHandler :: Maybe (Capability, PPtr CTE),
 >             tcSchedMCPriority :: Maybe (Priority, PPtr TCB),
 >             tcSchedPriority :: Maybe (Priority, PPtr TCB),
->             tcSchedSchedContext :: Maybe (PPtr SchedContext) }
+>             tcSchedSchedContext :: Maybe (Maybe (PPtr SchedContext)) }
 >         | NotificationControl {
 >             notificationTCB :: PPtr TCB,
 >             notificationPtr :: Maybe (PPtr Notification) }

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -232,8 +232,8 @@ This module uses the C preprocessor to select a target architecture.
 
 > refillReady :: PPtr SchedContext -> Kernel Bool
 > refillReady scPtr = do
->     curTime <- getCurTime
 >     sc <- getSchedContext scPtr
+>     curTime <- getCurTime
 >     return $ rTime (refillHd sc) <= curTime + kernelWCETTicks
 
 > refillUpdate :: PPtr SchedContext -> Ticks -> Ticks -> Int -> Kernel ()

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -286,7 +286,7 @@ The "SetSchedParams" call sets both the priority and the MCP in a single call.
 >         tcSchedFaultHandler = Just (fhCap, fhSlot),
 >         tcSchedMCPriority = Just (fromIntegral newMCP, authTCB),
 >         tcSchedPriority = Just (fromIntegral newPrio, authTCB),
->         tcSchedSchedContext = scPtr }
+>         tcSchedSchedContext = Just scPtr }
 > decodeSetSchedParams _ _ _ _ = throw TruncatedMessage
 
 \subsubsection{The Set IPC Buffer Call}
@@ -416,50 +416,37 @@ This is to ensure that the source capability is not made invalid by the deletion
 >         setTLSBaseNewBase = tls_base }
 > decodeSetTLSBase _ _ = throw TruncatedMessage
 
-> installTCBCap :: PPtr TCB -> Capability -> PPtr CTE -> Int -> Maybe (Capability, PPtr CTE) -> KernelP ()
-> installTCBCap _ _ _ _ Nothing = return ()
-> installTCBCap target tcap slot n (Just (newCap, srcSlot)) = do
-
-Using case instead of if-then-else will make the code compact, but we prefer the latter due to the current Haskell translator.
-
->     rootSlot <-
->         if n == 0
->             then withoutPreemption $ getThreadCSpaceRoot target
->             else if n == 1
->                  then withoutPreemption $ getThreadVSpaceRoot target
->                  else if n == 3
->                       then withoutPreemption $ getThreadFaultHandlerSlot target
->                       else if n == 4
->                            then withoutPreemption $ getThreadTimeoutHandlerSlot target
->                            else fail "installTCBCap: improper index"
->     cteDelete rootSlot True
->     unless (isNullCap newCap) $
->         withoutPreemption $ checkCapAt newCap srcSlot
->                           $ checkCapAt tcap slot
->                           $ assertDerived srcSlot newCap
->                           $ cteInsert newCap srcSlot rootSlot
-
-> installFaultHandler :: PPtr TCB -> PPtr CTE -> Maybe (Capability, PPtr CTE) -> KernelP ()
-> installFaultHandler target slot fh = installTCBCap target (ThreadCap target) slot 3 fh
-
-> installTimeoutHandler :: PPtr TCB -> PPtr CTE -> Maybe (Capability, PPtr CTE) -> KernelP ()
-> installTimeoutHandler target slot th = installTCBCap target (ThreadCap target) slot 4 th
-
-> installCRoot :: PPtr TCB -> PPtr CTE -> Maybe (Capability, PPtr CTE) -> KernelP ()
-> installCRoot target slot croot = installTCBCap target (ThreadCap target) slot 0 croot
-
-> installVRoot :: PPtr TCB -> PPtr CTE -> Maybe (Capability, PPtr CTE) -> KernelP ()
-> installVRoot target slot vroot = installTCBCap target (ThreadCap target) slot 1 vroot
+> installTCBCap :: PPtr TCB -> PPtr CTE -> Int -> Maybe (Capability, PPtr CTE) -> KernelP ()
+> installTCBCap target slot n slot_opt =
+>     maybe (return ()) (\(newCap, srcSlot) -> do
+>         let tCap = ThreadCap { capTCBPtr = target }
+>         rootSlot <-
+>             if n == 0
+>                 then withoutPreemption $ getThreadCSpaceRoot target
+>                 else if n == 1
+>                      then withoutPreemption $ getThreadVSpaceRoot target
+>                      else if n == 3
+>                           then withoutPreemption $ getThreadFaultHandlerSlot target
+>                           else if n == 4
+>                                then withoutPreemption $ getThreadTimeoutHandlerSlot target
+>                                else fail "installTCBCap: improper index"
+>         cteDelete rootSlot True
+>         unless (isNullCap newCap) $
+>             withoutPreemption $ checkCapAt newCap srcSlot
+>                               $ checkCapAt tCap slot
+>                               $ assertDerived srcSlot newCap
+>                               $ cteInsert newCap srcSlot rootSlot)
+>       slot_opt
 
 > installThreadBuffer :: PPtr TCB -> PPtr CTE -> Maybe (VPtr, Maybe (Capability, PPtr CTE)) -> KernelP ()
 > installThreadBuffer target slot tb
 >   = maybe (return ())
 >       (\(ptr, frame) -> do
+>           let tCap = ThreadCap { capTCBPtr = target }
 >           bufferSlot <- withoutPreemption $ getThreadBufferSlot target
 >           cteDelete bufferSlot True
 >           withoutPreemption $ do
 >               threadSet (\t -> t {tcbIPCBuffer = ptr}) target
->               let tCap = ThreadCap { capTCBPtr = target }
 >               maybe (return ())
 >                   (\(newCap, srcSlot) ->
 >                       checkCapAt newCap srcSlot
@@ -496,16 +483,16 @@ The use of "checkCapAt" addresses a corner case in which the only capability to 
 
 > invokeTCB (ThreadControlCaps target slot faultHandler timeoutHandler cRoot vRoot buffer)
 >   = do
->         installFaultHandler target slot faultHandler
->         installTimeoutHandler target slot timeoutHandler
->         installCRoot target slot cRoot
->         installVRoot target slot vRoot
+>         installTCBCap target slot 3 faultHandler
+>         installTCBCap target slot 4 timeoutHandler
+>         installTCBCap target slot 0 cRoot
+>         installTCBCap target slot 1 vRoot
 >         installThreadBuffer target slot buffer
 >         return []
 
-> invokeTCB (ThreadControlSched target slot faultHandler priority mcPriority sc)
+> invokeTCB (ThreadControlSched target slot faultHandler mcPriority priority sc)
 >   = do
->         installFaultHandler target slot faultHandler
+>         installTCBCap target slot 3 faultHandler
 >         withoutPreemption $ do
 >             let mcPriority' = mapMaybe fst mcPriority
 >             maybe (return ()) (setMCPriority target) mcPriority'
@@ -513,10 +500,12 @@ The use of "checkCapAt" addresses a corner case in which the only capability to 
 >             maybe (return ()) (setPriority target) priority'
 >             targetScOpt <- mapTCBPtr target tcbSchedContext
 >             case sc of
->                 Just scPtr -> when (sc /= targetScOpt) $ schedContextBindTCB scPtr target
->                 Nothing -> case targetScOpt of
->                     Just targetSc -> schedContextUnbindTCB targetSc
->                     Nothing -> return ()
+>                 Nothing -> return ()
+>                 Just Nothing -> case targetScOpt of
+>                                     Nothing -> return ()
+>                                     Just targetSc -> schedContextUnbindTCB targetSc
+>                 Just (Just scPtr) ->
+>                     when (sc /= Just targetScOpt) $ schedContextBindTCB scPtr target
 >         return []
 
 \subsubsection{Register State}


### PR DESCRIPTION
Prove `tc_corres_caps` and `tc_corres_sched`. Some changes to the specs based on what I've proved as part of my patch. Priority proofs are still sorried. Some adjustments to the main two lemmas will be needed soon.