### PR TITLE
c-parser: improve asm support in modifies proofs

### DIFF
--- a/tools/c-parser/CProof.thy
+++ b/tools/c-parser/CProof.thy
@@ -422,12 +422,21 @@ lemma asm_specE:
 
 lemmas state_eqE = arg_cong[where f="\<lambda>s. (globals s, state.more s)", elim_format]
 
-lemmas asm_store_eq_helper
-    = arg_cong2[where f="(=)" and a="asm_store f v s"]
-      arg_cong2[where f="(=)" and c="asm_store f v s"] for f v s
-
 definition asm_semantics_ok_to_ignore :: "'a itself \<Rightarrow> bool \<Rightarrow> string \<Rightarrow> bool" where
   "asm_semantics_ok_to_ignore ti volatile specifier
     = (\<forall>xs gl. snd ` asm_semantics specifier xs (gl :: (heap_mem \<times> 'a)) = {gl})"
+
+lemma asm_spec_preserves:
+  assumes spec: "\<And>t v' (gl'::heap_mem \<times> 'a).
+                 \<lbrakk> gdata (asm_store gdata gl' (globals \<sigma>)) = gdata (globals \<sigma>);
+                   globals t = globals (lhs v' (globals_update (asm_store gdata gl') \<sigma>)) \<rbrakk>
+                 \<Longrightarrow> t \<in> Q"
+  shows "\<Gamma> \<turnstile>\<^bsub>/F\<^esub> {\<sigma>} Spec (asm_spec (ti::'a itself) gdata vol spec lhs vs) Q, A"
+  apply (rule HoarePartial.Spec, simp)
+  apply (intro conjI allI impI asm_spec_enabled)
+  apply (elim asm_specE state_eqE)
+  apply clarsimp
+  apply (erule (1) spec)
+  done
 
 end

--- a/tools/c-parser/modifies_proofs.ML
+++ b/tools/c-parser/modifies_proofs.ML
@@ -226,23 +226,31 @@ in
   Seq.of_list res
 end
 
+fun seq_all_new i = let
+  fun before_all_new s t = t THEN_ALL_NEW s
+in
+  fn (x::xs) => fold before_all_new xs x i
+   | [] => all_tac
+end
+
 fun modifies_tactic mod_inv_prop ctxt = let
   val mip_intros = [mod_inv_prop] RL @{thms modifies_inv_intros}
-  val gsurj = Proof_Context.get_thm ctxt "globals.surjective"
-  val geqs = map (fn t => [gsurj, gsurj] MRS t) @{thms asm_store_eq_helper}
-  val gsp = Proof_Context.get_thms ctxt "globals.splits"
+  val globals_equality = Proof_Context.get_thms ctxt "globals.equality"
+  fun asm_spec_tactic i =
+    seq_all_new i [
+      resolve_tac ctxt @{thms asm_spec_preserves},
+      asm_lr_simp_tac (ctxt addsimps @{thms mex_def meq_def})
+    ]
 in
-  EVERY [
-    HoarePackage.hoare_rule_tac ctxt @{thms HoarePartial.ProcNoRec1} 1,
-    REPEAT_ALL_NEW (resolve_tac ctxt (@{thms allI} @ mip_intros)) 1,
-    ALLGOALS (modifies_vcg_tactic ctxt),
-    ALLGOALS (clarsimp_tac ctxt),
-    ALLGOALS (TRY o resolve_tac ctxt @{thms asm_spec_enabled}),
-    ALLGOALS (clarsimp_tac
-                (ctxt addSEs @{thms asm_specE state_eqE} addsimps (gsp @ @{thms state.splits}))),
-    ALLGOALS (clarsimp_tac (ctxt addsimps geqs)),
-    ALLGOALS (TRY o REPEAT_ALL_NEW (resolve_tac ctxt [exI])),
-    ALLGOALS (asm_full_simp_tac ctxt)
+  seq_all_new 1 [
+    HoarePackage.hoare_rule_tac ctxt @{thms HoarePartial.ProcNoRec1},
+    REPEAT_ALL_NEW (resolve_tac ctxt (@{thms allI} @ mip_intros)),
+    asm_spec_tactic ORELSE' modifies_vcg_tactic ctxt,
+    TRY o clarsimp_tac ctxt,
+    TRY o REPEAT_ALL_NEW (resolve_tac ctxt [exI]),
+    resolve_tac ctxt globals_equality,
+    asm_lr_simp_tac ctxt,
+    resolve_tac ctxt @{thms surjective_pairing}
   ]
 end
 


### PR DESCRIPTION
This commit adds support for inline assembly whose `lhs` updates a
global variable (such as the heap).

Prior to this commit, the modifies prover assumed that the `lhs` update
of an `asm_spec` only updated local variables. Specifically, the use of
`asm_store_eq_helper[OF globals.surjective globals.surjective]` as a
rewrite rule assumes that `globals (lhs v s)` simplifies to `globals s`,
exposing the `asm_store` inside `s` to the rewrite rule.

This commit avoids the assumption by using `globals.equality` as an
introduction rule. This produces more subgoals, but the subgoals are
relatively simple, so the perfomance is essentially unchanged.