### PR TITLE
lib: avoid internal index names

### DIFF
--- a/lib/Lib.thy
+++ b/lib/Lib.thy
@@ -1997,15 +1997,15 @@ lemma dom_eqD:
   "\<lbrakk> f x = Some v; dom f = S \<rbrakk> \<Longrightarrow> x \<in> S"
   by clarsimp
 
-lemma exception_set_finite_1:
+lemma exception_set_finite1:
   "finite {x. P x} \<Longrightarrow> finite {x. (x = y \<longrightarrow> Q x) \<and> P x}"
   by (simp add: Collect_conj_eq)
 
-lemma exception_set_finite_2:
+lemma exception_set_finite2:
   "finite {x. P x} \<Longrightarrow> finite {x. x \<noteq> y \<longrightarrow> P x}"
   by (simp add: imp_conv_disj)
 
-lemmas exception_set_finite = exception_set_finite_1 exception_set_finite_2
+lemmas exception_set_finite = exception_set_finite1 exception_set_finite2
 
 lemma exfEI:
   "\<lbrakk> \<exists>x. P x; \<And>x. P x \<Longrightarrow> Q (f x) \<rbrakk> \<Longrightarrow> \<exists>x. Q x"


### PR DESCRIPTION
The lemma set `exception_set_finite` contained the members
`exception_set_finite_1` and `exception_set_finite_2`. The `_1`/`_2`
suffix clashes with the internal `(1)` suffix for lemma set references,
which in some code paths is internally represented as `_1`, leading to
an error message.

Curiously this error message only occurs when the proof is run
single-threaded, so it has gone unnoticed for quite some time.
