### PR TITLE
rt lib+aspec+ainvs: replace sort_queue

### DIFF
--- a/lib/HaskellLib_H.thy
+++ b/lib/HaskellLib_H.thy
@@ -539,14 +539,6 @@ syntax (input)
 
 lemma "[(x,1) . x \<leftarrow> [0..10]] = [(x,1) | x \<leftarrow> [0..10]]" by (rule refl)
 
-primrec findIndex' :: "nat \<Rightarrow> ('a \<Rightarrow> bool) \<Rightarrow> 'a list \<Rightarrow> nat option" where
-  "findIndex' _ _ [] = None"
-| "findIndex' n P (x#xs) = (if P x then Some n else findIndex' (Suc n) P xs)"
-
-definition
-  findIndex :: "('a \<Rightarrow> bool) \<Rightarrow> 'a list \<Rightarrow> nat option" where
-  "findIndex = findIndex' 0"
-
 definition
   whileM :: "('s, bool) nondet_monad \<Rightarrow> ('s, 'a) nondet_monad \<Rightarrow> ('s, unit) nondet_monad" where
   "whileM C B \<equiv> do

--- a/lib/Lib.thy
+++ b/lib/Lib.thy
@@ -2729,4 +2729,28 @@ text \<open>Prevent clarsimp and others from creating Some from not None by fold
 definition
   "not_None x = (x \<noteq> None)"
 
+primrec findIndex' :: "nat \<Rightarrow> ('a \<Rightarrow> bool) \<Rightarrow> 'a list \<Rightarrow> nat option" where
+  "findIndex' _ _ [] = None"
+| "findIndex' n P (x#xs) = (if P x then Some n else findIndex' (Suc n) P xs)"
+
+definition
+  findIndex :: "('a \<Rightarrow> bool) \<Rightarrow> 'a list \<Rightarrow> nat option" where
+  "findIndex = findIndex' 0"
+
+lemma findIndex'_app:
+  "findIndex' n P (xs @ ys) = (if \<exists>x \<in> set xs. P x then findIndex' n P xs
+                                                   else findIndex' (n + length xs) P ys)"
+  by (induct xs arbitrary: n; clarsimp)
+
+lemma findIndex_member:
+  "tptr \<in> set xs \<Longrightarrow>
+   \<exists>ys zs. xs = ys @ tptr # zs \<and> tptr \<notin> set ys \<and> findIndex (\<lambda>x. x = tptr) xs = Some (length ys)"
+  apply (induct xs; clarsimp)
+  apply (case_tac "tptr=a"; clarsimp)
+   apply (rule_tac x="[]" in exI)
+   apply (clarsimp simp: findIndex_def)
+  apply (rule_tac x="a#ys" in exI)
+  apply (clarsimp simp: findIndex_def findIndex'_app)
+  done
+
 end

--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -615,7 +615,6 @@ crunch domain_time_inv[wp]: cancel_badged_sends "\<lambda>s::det_state. P (domai
      simp: filterM_mapM crunch_simps
        wp: crunch_wps)
 
-crunch domain_time_inv[wp]: sort_queue "\<lambda>s. P (domain_time s)" (wp: mapM_wp')
 crunch domain_time_inv[wp]: update_time_stamp "\<lambda>s. P (domain_time s)"
 
 context DetSchedDomainTime_AI_2 begin

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -6650,13 +6650,13 @@ lemma set_mcpriority_bound_sc_tcb_at_cur_thread[wp]:
 
 lemma reorder_ntfn_bound_sc_tcb_at_cur_thread[wp]:
   "\<lbrace>\<lambda>s. bound_sc_tcb_at P (cur_thread s) s\<rbrace>
-   reorder_ntfn a
+   reorder_ntfn ntfn_ptr tptr
    \<lbrace>\<lambda>_. \<lambda>s. bound_sc_tcb_at P (cur_thread s) s\<rbrace>"
   by (rule_tac f="cur_thread" in hoare_lift_Pf; wpsimp)
 
 lemma reorder_ep_bound_sc_tcb_at_cur_thread[wp]:
   "\<lbrace>\<lambda>s. bound_sc_tcb_at P (cur_thread s) s\<rbrace>
-   reorder_ep a
+   reorder_ep ep_ptr tptr
    \<lbrace>\<lambda>_. \<lambda>s. bound_sc_tcb_at P (cur_thread s) s\<rbrace>"
   by (rule_tac f="cur_thread" in hoare_lift_Pf; wpsimp)
 

--- a/proof/invariant-abstract/EmptyFail_AI.thy
+++ b/proof/invariant-abstract/EmptyFail_AI.thy
@@ -448,6 +448,10 @@ crunch (empty_fail) empty_fail[wp, intro!, simp]:
 crunch (empty_fail) empty_fail[wp, intro!, simp]: sc_and_timer
   (wp: empty_fail_setDeadline simp: Let_def)
 
+lemma empty_fail_tcb_ep_find_index[wp]:
+  "empty_fail (tcb_ep_find_index t q n)"
+  by (induct n; wpsimp simp: tcb_ep_find_index.simps)
+
 context EmptyFail_AI_schedule begin
 
 lemma schedule_choose_new_thread_empty_fail[intro!, wp, simp]:

--- a/proof/invariant-abstract/Finalise_AI.thy
+++ b/proof/invariant-abstract/Finalise_AI.thy
@@ -1579,4 +1579,11 @@ crunches test_reschedule, tcb_release_remove
   and obj_at[wp]: "\<lambda>s. P (obj_at Q p s)"
   (wp: crunch_wps simp: crunch_simps)
 
+lemma tcb_ep_find_index_inv[wp]:
+  "tcb_ep_find_index tptr qs curindex \<lbrace>P\<rbrace>"
+  by (induct curindex) (wpsimp | simp add: tcb_ep_find_index.simps)+
+
+crunches tcb_ep_dequeue, tcb_ep_append
+  for inv[wp]: P
+
 end

--- a/proof/invariant-abstract/IpcCancel_AI.thy
+++ b/proof/invariant-abstract/IpcCancel_AI.thy
@@ -2641,7 +2641,7 @@ lemma reply_unlink_tcb_ct_active[wp]:
 
 crunches
   tcb_sched_action, reschedule_required, tcb_sched_action, tcb_release_remove,
-  test_reschedule, tcb_release_enqueue, sort_queue, sched_context_unbind_reply,
+  test_reschedule, tcb_release_enqueue, sched_context_unbind_reply,
   sched_context_unbind_ntfn
   for ct_in_state[wp]: "ct_in_state P"
   (wp: crunch_wps simp: crunch_simps)

--- a/proof/invariant-abstract/Ipc_AI.thy
+++ b/proof/invariant-abstract/Ipc_AI.thy
@@ -2791,10 +2791,6 @@ crunches complete_signal, do_nbrecv_failed_transfer, reply_push, receive_signal
 crunches get_endpoint
   for inv[wp]: "P"
 
-lemma sort_queue_inv:
-  "\<lbrace> P \<rbrace> sort_queue ls \<lbrace> \<lambda>rv. P \<rbrace>"
-  by (wpsimp simp: sort_queue_def wp: mapM_wp) auto
-
 context Ipc_AI begin
 
 lemma hoare_drop_imp_under_All:
@@ -2805,8 +2801,7 @@ lemma receive_ipc_cap_to[wp]:
   "receive_ipc thread cap is_blocking reply_cap \<lbrace>ex_nonz_cap_to p :: 'state_ext state \<Rightarrow> bool\<rbrace>"
   supply if_cong[cong]
   by (wpsimp simp: receive_ipc_def
-               wp: hoare_drop_imps sort_queue_inv fail_wp cancel_ipc_cap_to
-                   hoare_drop_imp_under_All)
+               wp: hoare_drop_imps fail_wp cancel_ipc_cap_to hoare_drop_imp_under_All)
 
 end
 
@@ -2881,9 +2876,6 @@ lemma maybe_donate_sc_pred_tcb_at:
   apply wpsimp
   done
 
-lemmas sort_queue_pred_tcb_at =
-  sort_queue_inv[where P="pred_tcb_at proj P t" and ls=q for proj P t q]
-
 lemma rai_pred_tcb_neq:
   "\<lbrace>pred_tcb_at proj P t' and K (t \<noteq> t')\<rbrace> receive_signal t cap is_blocking
    \<lbrace>\<lambda>rv. pred_tcb_at proj P t'\<rbrace>"
@@ -2895,8 +2887,7 @@ lemma rai_pred_tcb_neq:
      apply (wpsimp wp: schedule_tcb_pred_tcb_at maybe_return_sc_pred_tcb_at sts_st_tcb_at_neq)
     apply (wpsimp simp: do_nbrecv_failed_transfer_def)
    apply (case_tac is_blocking; simp)
-    apply (wpsimp wp: schedule_tcb_pred_tcb_at maybe_return_sc_pred_tcb_at sort_queue_pred_tcb_at
-                      sts_st_tcb_at_neq)
+    apply (wpsimp wp: schedule_tcb_pred_tcb_at maybe_return_sc_pred_tcb_at sts_st_tcb_at_neq)
    apply (wpsimp simp: do_nbrecv_failed_transfer_def)
   apply (wpsimp wp: maybe_donate_sc_pred_tcb_at)
   done

--- a/proof/invariant-abstract/RealTime_AI.thy
+++ b/proof/invariant-abstract/RealTime_AI.thy
@@ -1100,12 +1100,6 @@ lemma charge_budget_inv[wp]: "(\<And>s f. P (trans_state f s) = P s)
 *)
 
 
-
-lemma sort_queue_notin_inv: "\<lbrace>K (t \<notin> set ls) and P t\<rbrace> sort_queue ls \<lbrace>\<lambda>rv. P t\<rbrace>"
-  apply (wpsimp simp: sort_queue_def wp: mapM_wp)
-  apply auto
-  done
-
 crunches sched_context_donate
   for st_tcb_at[wp]: "\<lambda>s. Q (st_tcb_at P t s)"
   and fault_tcb_at[wp]: "\<lambda>s. Q (fault_tcb_at P t s)"

--- a/spec/abstract/Ipc_A.thy
+++ b/spec/abstract/Ipc_A.thy
@@ -280,7 +280,7 @@ where
                                      sender_can_grant = can_grant,
                                      sender_can_grant_reply = can_grant_reply,
                                      sender_is_call = call\<rparr>);
-               qs' \<leftarrow> sort_queue (queue @ [thread]);
+               qs' \<leftarrow> tcb_ep_append thread queue;
                set_endpoint epptr $ SendEP qs'
              od
        | (IdleEP, False) \<Rightarrow> return ()
@@ -393,7 +393,7 @@ where
                                                             \<lparr>receiver_can_grant = (AllowGrant \<in> rights)\<rparr>);
                   when (reply \<noteq> None) $ set_reply_obj_ref reply_tcb_update (the reply) (Some thread);
                   \<^cancel>\<open>FIXME RT: schedule_tcb?\<close>
-                  qs' \<leftarrow> sort_queue (queue @ [thread]);
+                  qs' \<leftarrow> tcb_ep_append thread queue;
                   set_endpoint epptr (RecvEP qs')
                 od
               | False \<Rightarrow> do_nbrecv_failed_transfer thread)
@@ -515,7 +515,7 @@ where
                    (case is_blocking of
                      True \<Rightarrow> do
                           set_thread_state thread (BlockedOnNotification ntfnptr);
-                          qs' \<leftarrow> sort_queue (queue @ [thread]);
+                          qs' \<leftarrow> tcb_ep_append thread queue;
                           set_notification ntfnptr $ ntfn_obj_update (K (WaitingNtfn qs')) ntfn;
                           maybe_return_sc ntfnptr thread;
                           schedule_tcb thread


### PR DESCRIPTION
Replace the implementation of sort_queue with tcb_ep_dequeue and tcb_ep_append to match the Haskell and C implementations. Keeping sort_queue would require us to prove a new invariant instead and would also make the refinement more difficult.