### PR TITLE
regression: increase CRefine timeout

### DIFF
--- a/proof/tests.xml
+++ b/proof/tests.xml
@@ -29,7 +29,7 @@
         <test name="CKernel" cpu-timeout="28800">make CKernel</test>
         <test name="CSpec" cpu-timeout="14400">make CSpec</test>
         <test name="CBaseRefine" cpu-timeout="28800">make CBaseRefine</test>
-        <test name="CRefine" cpu-timeout="28800">make CRefine</test>
+        <test name="CRefine" cpu-timeout="36000">make CRefine</test>
     </sequence>
 
     <!-- DRefine -->


### PR DESCRIPTION
CRefine takes longer with Isabelle2020, so this gives more headroom.

Yes, the "proof performance" label is meant to be ironic. :-)