### PR TITLE
Prove `decode_set_sched_params_corres`

### DIFF
--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -808,6 +808,21 @@ lemma corres_initial_splitE:
   apply simp
   done
 
+lemma corres_split_liftEE:
+  assumes "corres_underlying sr nf nf' r' P P' a c"
+          "\<And>rv rv'. r' rv rv' \<Longrightarrow>
+                     corres_underlying sr nf nf' (r \<oplus> s) (R rv) (R' rv') (b rv) (d rv')"
+          "\<lbrace>Q\<rbrace> a \<lbrace>R\<rbrace>"
+          "\<lbrace>Q'\<rbrace> c \<lbrace>R'\<rbrace>"
+  shows "corres_underlying sr nf nf' (r \<oplus> s) (P and Q) (P' and Q')
+             (liftE a >>=E b) (liftE c >>=E d)"
+  apply (insert assms)
+  apply (rule corres_initial_splitE; clarsimp?)
+     apply (erule corres_guard_imp; clarsimp)
+    apply fastforce
+   apply (rule hoare_weaken_pre; fastforce)+
+  done
+
 lemma corres_assert_assume:
   "\<lbrakk> P' \<Longrightarrow> corres_underlying sr nf nf' r P Q f (g ()); \<And>s. Q s \<Longrightarrow> P' \<rbrakk> \<Longrightarrow>
   corres_underlying sr nf nf' r P Q f (assert P' >>= g)"

--- a/lib/NonDetMonadLemmaBucket.thy
+++ b/lib/NonDetMonadLemmaBucket.thy
@@ -658,6 +658,18 @@ lemma liftE_bind:
   "(liftE m >>= m') = (m >>= (\<lambda>rv. m' (Inr rv)))"
   by (simp add: liftE_def)
 
+lemma liftE_bindE_bind:
+  "doE x <- liftE (f >>= g);
+       h x
+   odE =
+   doE x <- liftE f;
+       y <- liftE (g x);
+       h y
+   odE"
+  unfolding liftE_def bindE_def lift_def
+  apply (clarsimp simp: bind_assoc)
+  done
+
 lemma catch_throwError: "catch (throwError ft) g = g ft"
   by (simp add: catch_def throwError_bind)
 

--- a/proof/invariant-abstract/Tcb_AI.thy
+++ b/proof/invariant-abstract/Tcb_AI.thy
@@ -1115,7 +1115,7 @@ lemma check_handler_ep_wpE[wp]:
 
 lemma decode_update_sc_inv[wp]:
   "\<lbrace>P\<rbrace> decode_update_sc cap slot sc_cap \<lbrace>\<lambda>_. P\<rbrace>"
-  unfolding decode_update_sc_def by (wpsimp wp: hoare_drop_imps)
+  unfolding decode_update_sc_def is_blocked_def by (wpsimp wp: hoare_drop_imps)
 
 context Tcb_AI
 begin
@@ -1130,7 +1130,7 @@ lemma decode_set_sched_params_wf[wp]:
                           \<and> no_cap_to_obj_dr_emp (fst x) s)\<rbrace>
    decode_set_sched_params args (ThreadCap t) slot excaps
    \<lbrace>tcb_inv_wf\<rbrace>, -"
-  unfolding decode_set_sched_params_def decode_update_sc_def
+  unfolding decode_set_sched_params_def decode_update_sc_def is_blocked_def
   apply (wpsimp simp: get_tcb_obj_ref_def
                 wp: check_prio_wp_weak whenE_throwError_wp thread_get_wp gts_wp
                 split_del: if_split)

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -791,6 +791,15 @@ lemma isCNodeCap_cap_map [simp]:
    apply clarsimp+
   done
 
+lemma cap_rel_valid_fh:
+  "cap_relation a b \<Longrightarrow> valid_fault_handler a = isValidFaultHandler b"
+  apply (case_tac a
+         ; case_tac b
+         ; simp add: valid_fault_handler_def isValidFaultHandler_def)
+  apply (rule iffI
+         ; clarsimp simp: has_handler_rights_def split: bool.split_asm)
+  done
+
 lemma sts_rel_idle :
   "thread_state_relation st IdleThreadState = (st = Structures_A.IdleThreadState)"
   by (cases st, auto)

--- a/spec/abstract/Decode_A.thy
+++ b/spec/abstract/Decode_A.thy
@@ -317,29 +317,29 @@ where
  odE"
 
 definition
-  decode_update_sc :: "cap \<Rightarrow> cslot_ptr \<Rightarrow> cap \<Rightarrow> (tcb_invocation,'z::state_ext) se_monad"
+  decode_update_sc :: "cap \<Rightarrow> cslot_ptr \<Rightarrow> cap \<Rightarrow> (obj_ref option,'z::state_ext) se_monad"
 where
   "decode_update_sc cap slot sc_cap \<equiv>
-    if sc_cap = NullCap then doE
-      tcb_ptr \<leftarrow> returnOk $ obj_ref_of cap;
-      ct_ptr \<leftarrow> liftE $ gets cur_thread;
-      whenE (tcb_ptr = ct_ptr) $ throwError IllegalOperation;
-      returnOk $ ThreadControlSched (obj_ref_of cap) slot None None None (Some None)
-  odE
-    else doE
-      tcb_ptr \<leftarrow> returnOk $ obj_ref_of cap;
-      unlessE (is_sched_context_cap sc_cap) $ throwError (InvalidCapability 0);
-      sc_ptr \<leftarrow> returnOk $ obj_ref_of sc_cap;
-      sc_ptr' \<leftarrow> liftE $ get_tcb_obj_ref tcb_sched_context tcb_ptr;
-      whenE (sc_ptr' \<noteq> None) $ throwError IllegalOperation;
-      sc \<leftarrow> liftE $ get_sched_context sc_ptr;
-      whenE (sc_tcb sc \<noteq> None) $ throwError IllegalOperation;
-      st \<leftarrow> liftE $ get_thread_state tcb_ptr;
-      released \<leftarrow> liftE $ get_sc_released sc_ptr;
-      whenE (ipc_queued_thread_state st \<and> \<not>released) $
-        throwError IllegalOperation;
-      returnOk $ ThreadControlSched tcb_ptr slot None None None (Some (Some sc_ptr))
-    odE"
+    (case sc_cap of
+       NullCap \<Rightarrow>
+         doE tcb_ptr \<leftarrow> returnOk $ obj_ref_of cap;
+             ct_ptr \<leftarrow> liftE $ gets cur_thread;
+             whenE (tcb_ptr = ct_ptr) $ throwError IllegalOperation;
+             returnOk None
+         odE
+     | SchedContextCap _ _ \<Rightarrow>
+         doE tcb_ptr \<leftarrow> returnOk $ obj_ref_of cap;
+             sc_ptr \<leftarrow> returnOk $ obj_ref_of sc_cap;
+             sc_ptr' \<leftarrow> liftE $ get_tcb_obj_ref tcb_sched_context tcb_ptr;
+             whenE (sc_ptr' \<noteq> None) $ throwError IllegalOperation;
+             sc \<leftarrow> liftE $ get_sched_context sc_ptr;
+             whenE (sc_tcb sc \<noteq> None) $ throwError IllegalOperation;
+             blocked \<leftarrow> liftE $ is_blocked tcb_ptr;
+             released \<leftarrow> liftE $ get_sc_released sc_ptr;
+             whenE (blocked \<and> \<not>released) $ throwError IllegalOperation;
+             returnOk $ Some sc_ptr
+         odE
+     | _ \<Rightarrow> throwError (InvalidCapability 2))"
 
 definition
   decode_tcb_configure ::
@@ -436,7 +436,7 @@ where
      fh \<leftarrow> check_handler_ep 3 fh_arg;
      returnOk $ ThreadControlSched (obj_ref_of cap) slot (Some fh)
                               (Some (new_mcp, auth_tcb)) (Some (new_prio, auth_tcb))
-                              (tc_new_sc sc)
+                              (Some sc)
      odE"
 
 definition

--- a/spec/abstract/KHeap_A.thy
+++ b/spec/abstract/KHeap_A.thy
@@ -429,6 +429,11 @@ where
    od"
 
 definition
+  is_blocked :: "obj_ref \<Rightarrow> (bool,'z::state_ext) s_monad"
+where
+  "is_blocked thread = (liftM ipc_queued_thread_state $ get_thread_state thread)"
+
+definition
   tcb_sched_enqueue :: "obj_ref \<Rightarrow> obj_ref list \<Rightarrow> obj_ref list" where
   "tcb_sched_enqueue thread queue \<equiv> if thread \<notin> set queue then thread # queue else queue"
 

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -268,11 +268,11 @@ The "SetSchedParams" call sets both the priority and the MCP in a single call.
 >         SchedContextCap { capSchedContextPtr = scPtr } -> do
 >             tcbSc <- withoutFailure $ threadGet tcbSchedContext tcbPtr
 >             when (tcbSc /= Nothing) $ throw IllegalOperation
->             scTcb <- withoutFailure $ mapScPtr scPtr scTCB
->             when (scTcb /= Nothing) $ throw IllegalOperation
->             blockedAndUnreleased <- withoutFailure $
->                 (isBlocked tcbPtr) `andM` (liftM not $ scReleased scPtr)
->             when blockedAndUnreleased $ throw IllegalOperation
+>             sc <- withoutFailure $ getSchedContext scPtr
+>             when (scTCB sc /= Nothing) $ throw IllegalOperation
+>             blocked <- withoutFailure $ isBlocked tcbPtr
+>             released <- withoutFailure $ scReleased scPtr
+>             when (blocked && not released) $ throw IllegalOperation
 >             return $ Just scPtr
 >         NullCap -> do
 >             curTcbPtr <- withoutFailure getCurThread


### PR DESCRIPTION
Also involves some uninteresting spec updates to make the corres proof easier.
* Changes `decode_update_sc` to return just the updated SC parameter (rather than a whole invocation from which we just extract the SC parameter anyway), and changes it to use pattern matching rather than chained checks - this is both easier to read and matches the Haskell and C.
* Removes `andM` from `decodeSetSchedParams`. Turns out reasoning about corres for `andM` is really, _really_ fiddly - I spent at least a day trying to figure out how to prove and use `monadic_rewrite` rules to massage it into a better form before bailing.