### PR TITLE
rt heap_path/sym_heap lemmas

### DIFF
--- a/lib/Heap_List.thy
+++ b/lib/Heap_List.thy
@@ -8,7 +8,7 @@
    Loosely after ~~/src/HOL/Hoare/Pointer_Examples.thy *)
 
 theory Heap_List
-imports Main
+imports Main "HOL-Library.Prefix_Order"
 begin
 
 (* Given a heap projection that returns the next-pointer for an object at address x,
@@ -78,5 +78,193 @@ lemma heap_list_is_walk':
 lemma heap_list_is_walk:
   "heap_list hp x xs \<Longrightarrow> heap_walk hp x [] = xs"
   using heap_list_is_walk' by fastforce
+
+lemma heap_path_end_unique:
+  "heap_path hp x xs y \<Longrightarrow> heap_path hp x xs y' \<Longrightarrow> y = y'"
+  by (induct xs arbitrary: x; clarsimp)
+
+lemma heap_path_head:
+  "heap_path hp x xs y \<Longrightarrow> xs \<noteq> [] \<Longrightarrow> x = Some (hd xs)"
+  by (induct xs arbitrary: x; clarsimp)
+
+lemma heap_path_non_nil_lookup_next:
+  "heap_path hp x (xs@z#ys) y \<Longrightarrow> hp z = (case ys of [] \<Rightarrow> y | _ \<Rightarrow> Some (hd ys))"
+  by (cases ys; fastforce)
+
+lemma heap_path_prefix:
+  "heap_path hp st ls ed \<Longrightarrow> \<forall>xs\<le>ls. heap_path hp st xs (if xs = [] then st else hp (last xs))"
+  apply clarsimp
+  apply (erule Prefix_Order.prefixE)
+  by (metis append_butlast_last_id heap_path_append heap_path_non_nil_lookup_next list.case(1))
+
+lemma heap_path_butlast:
+  "heap_path hp st ls ed \<Longrightarrow> ls \<noteq> [] \<Longrightarrow> heap_path hp st (butlast ls) (Some (last ls))"
+  by (induct ls rule: rev_induct; simp)
+
+lemma in_list_decompose_takeWhile:
+  "x \<in> set xs \<Longrightarrow>
+   xs = (takeWhile ((\<noteq>) x) xs) @ x # (drop (length (takeWhile ((\<noteq>) x) xs) + 1) xs)"
+  by (induct xs arbitrary: x; clarsimp)
+
+lemma takeWhile_neq_hd_eq_Nil[simp]:
+  "takeWhile ((\<noteq>) (hd xs)) xs = Nil"
+  by (metis (full_types) hd_Cons_tl takeWhile.simps(1) takeWhile.simps(2))
+
+lemma heap_not_in_dom[simp]:
+  "ptr \<notin> dom hp \<Longrightarrow> hp(ptr := None) = hp"
+  by (auto simp: dom_def)
+
+lemma heap_path_takeWhile_lookup_next:
+  "\<lbrakk> heap_path hp st rs ed; r \<in> set rs \<rbrakk>
+   \<Longrightarrow> heap_path hp st (takeWhile ((\<noteq>) r) rs) (Some r)"
+  apply (drule heap_path_prefix)
+  apply (subgoal_tac "takeWhile ((\<noteq>) r) rs @ [r] \<le> rs", fastforce)
+  by (fastforce dest!: in_list_decompose_takeWhile intro: Prefix_Order.prefixI)
+
+lemma heap_path_heap_upd_not_in:
+  "\<lbrakk>heap_path hp st rs ed; r \<notin> set rs\<rbrakk> \<Longrightarrow> heap_path (hp(r:= x)) st rs ed"
+  by (induct rs arbitrary: st; clarsimp)
+
+lemma heap_walk_lb:
+  "heap_walk hp x xs \<ge> xs"
+  apply (induct xs rule: heap_walk.induct; clarsimp)
+  by (metis Prefix_Order.prefixE Prefix_Order.prefixI append_assoc)
+
+lemma heal_walk_Some_nonempty':
+  "heap_walk hp (Some x) [] > []"
+  by (fastforce intro: heap_walk_lb less_le_trans[where y="[x]"])
+
+lemma heal_walk_Some_nonempty:
+  "heap_walk hp (Some x) [] \<noteq> []"
+  by (metis less_list_def heal_walk_Some_nonempty')
+
+lemma heap_walk_Nil_None:
+  "heap_walk hp st [] = [] \<Longrightarrow> st = None"
+   by (case_tac st; simp only: heal_walk_Some_nonempty)
+
+lemma heap_list_last_None:
+  "heap_list hp st xs \<Longrightarrow> xs \<noteq> [] \<Longrightarrow> hp (last xs) = None"
+  by (induct xs rule: rev_induct; clarsimp)
+
+(* sym_heap *)
+
+abbreviation sym_heap where
+  "sym_heap hp hp' \<equiv> \<forall>p p'. hp p = Some p' \<longleftrightarrow> hp' p' = Some p"
+
+lemma sym_heap_symmetric:
+  "sym_heap hp hp' \<longleftrightarrow> sym_heap hp' hp" by blast
+
+lemma sym_heap_None:
+  "\<lbrakk>sym_heap hp hp'; hp p = None\<rbrakk> \<Longrightarrow> \<forall>p'. hp' p' \<noteq> Some p" by force
+
+lemma sym_heap_path_reverse:
+  "sym_heap hp hp' \<Longrightarrow>
+      heap_path hp (Some p) (p#ps) (Some p')
+          \<longleftrightarrow> heap_path hp' (Some p') (p'#(rev ps)) (Some p)"
+  by (induct ps arbitrary: p p' rule: rev_induct; force)
+
+lemma sym_heap_list_rev_Cons:
+  "\<lbrakk>sym_heap hp hp'; heap_list hp (Some p) (p#ps)\<rbrakk>
+  \<Longrightarrow> heap_path hp' (Some (last (p#ps))) (rev ps) (Some p)"
+  supply rev.simps[simp del]
+  apply (induct ps arbitrary: p rule: rev_induct; simp add: rev.simps)
+  by (auto dest!: sym_heap_path_reverse[THEN iffD1])
+
+lemma sym_heap_list_rev:
+  "\<lbrakk>sym_heap hp hp'; heap_list hp (Some p) ps\<rbrakk>
+  \<Longrightarrow> heap_path hp' (Some (last ps)) (butlast (rev ps)) (Some p)
+      \<and> hp (last ps) = None"
+  apply (induct ps arbitrary: p rule: rev_induct, simp)
+  apply (frule heap_path_head; clarsimp)
+  by (auto dest!: sym_heap_path_reverse[THEN iffD1])
+
+(* more on heap_path : next/prev in path *)
+
+lemma heap_path_extend:
+  "heap_path hp st (ls @ [p]) (hp p) \<longleftrightarrow> heap_path hp st ls (Some p)"
+  by (induct ls rule: rev_induct; simp)
+
+lemma heap_path_prefix_heap_list:
+  "\<lbrakk>heap_list hp st xs; heap_path hp st ys ed\<rbrakk> \<Longrightarrow> ys \<le> xs"
+  apply (induct xs arbitrary: ys st, simp)
+  apply (case_tac ys; clarsimp)
+  done
+
+lemma distinct_decompose2:
+  "\<lbrakk>distinct xs; xs = ys @ x # y # zs\<rbrakk>
+   \<Longrightarrow> x \<noteq> y \<and> x \<notin> set ys \<and> y \<notin> set ys \<and> x \<notin> set zs \<and> y \<notin> set zs"
+  by (simp add: in_set_conv_decomp)
+
+lemma heap_path_distinct_next_cases: (* the other direction needs sym_heap *)
+  "\<lbrakk>heap_path hp st xs ed; distinct xs; p \<in> set xs; hp p = Some np\<rbrakk>
+  \<Longrightarrow> ed = Some p \<or> ed = Some np \<or> np \<in> set xs"
+  apply (cases ed; simp)
+   apply (frule in_list_decompose_takeWhile)
+   apply (subgoal_tac "heap_list hp st (takeWhile ((\<noteq>) p) xs @ p # drop (length (takeWhile ((\<noteq>) p) xs) + 1) xs)")
+   apply (drule heap_path_non_nil_lookup_next)
+   apply (case_tac "drop (length (takeWhile ((\<noteq>) p) xs) + 1) xs"; simp)
+   apply (metis in_set_dropD list.set_intros(1))
+  apply simp
+  apply (frule in_list_decompose_takeWhile)
+  apply (subgoal_tac "heap_path hp st (takeWhile ((\<noteq>) p) xs @ p # drop (length (takeWhile ((\<noteq>) p) xs) + 1) xs) ed")
+  apply (frule heap_path_non_nil_lookup_next)
+  apply (case_tac "drop (length (takeWhile ((\<noteq>) p) xs) + 1) xs", simp)
+  apply (simp split: if_split_asm)
+  apply (drule (1) distinct_decompose2)
+  apply clarsimp
+  by (metis in_set_dropD list.set_intros(1)) simp
+
+lemma heap_list_next_in_list:
+  "\<lbrakk>heap_list hp st xs; p \<in> set xs; hp p = Some np\<rbrakk>
+  \<Longrightarrow> np \<in> set xs"
+   apply (subgoal_tac "distinct xs")
+   by (fastforce dest!: heap_path_distinct_next_cases) (erule heap_list_distinct)
+
+lemma heap_path_distinct_sym_prev_cases:
+  "\<lbrakk>heap_path hp st xs ed; distinct xs; np \<in> set xs; hp p = Some np; sym_heap hp hp'\<rbrakk>
+  \<Longrightarrow> st = Some np \<or> p \<in> set xs"
+  apply (cases st; simp)
+  apply (rename_tac stp)
+  apply (case_tac "stp = np"; simp)
+  apply (cases xs; simp del: heap_path.simps)
+  apply (frule heap_path_head, simp)
+  apply (cases ed, clarsimp)
+   apply (drule sym_heap_list_rev_Cons, fastforce)
+   apply (drule heap_path_distinct_next_cases[where hp=hp']; simp)
+   apply fastforce
+  apply (simp del: heap_path.simps)
+  apply (drule (1) sym_heap_path_reverse[where hp'=hp', THEN iffD1])
+  apply simp
+  apply (frule heap_path_distinct_next_cases[where hp=hp']; simp)
+  apply fastforce
+  done
+
+lemma heap_list_prev_cases:
+  "\<lbrakk>heap_list hp st xs; np \<in> set xs; hp p = Some np; sym_heap hp hp'\<rbrakk>
+  \<Longrightarrow> st = Some np \<or> p \<in> set xs"
+   apply (subgoal_tac "distinct xs")
+   by (fastforce dest!: heap_path_distinct_sym_prev_cases) (erule heap_list_distinct)
+
+lemma heap_list_prev_not_in:
+  "\<lbrakk>heap_list hp st xs; np \<notin> set xs; hp p = Some np\<rbrakk>
+  \<Longrightarrow> p \<notin> set xs"
+  by (meson heap_list_next_in_list)
+
+lemma heap_path_distinct_prev_not_in:
+  "\<lbrakk>heap_path hp st xs ed; distinct xs; np \<notin> set xs; hp p = Some np; ed \<noteq> Some np; ed \<noteq> Some p\<rbrakk>
+  \<Longrightarrow> p \<notin> set xs"
+  using heap_path_distinct_next_cases
+  by fastforce
+
+lemma heap_path_distinct_next_not_in:
+  "\<lbrakk>heap_path hp st xs ed; distinct xs; p \<notin> set xs; hp p = Some np;
+    sym_heap hp hp'; st \<noteq> Some np\<rbrakk>
+  \<Longrightarrow> np \<notin> set xs"
+  by (fastforce dest!: heap_path_distinct_sym_prev_cases[simplified])
+
+lemma heap_list_next_not_in:
+  "\<lbrakk>heap_list hp st xs; p \<notin> set xs; hp p = Some np; sym_heap hp hp'; st \<noteq> Some np\<rbrakk>
+  \<Longrightarrow> np \<notin> set xs"
+  by (fastforce dest!: heap_list_prev_cases[simplified])
 
 end

--- a/lib/Lib.thy
+++ b/lib/Lib.thy
@@ -20,7 +20,6 @@ imports
   Eval_Bool
   NICTATools
   Heap_List
-  "HOL-Library.Prefix_Order"
   "HOL-Word.Word"
 begin
 
@@ -2630,6 +2629,15 @@ lemma hd_opt_rev_simps[simp]:
   "hd_opt xs = None \<longleftrightarrow> xs = []"
   "hd_opt xs = Some x \<longleftrightarrow> (\<exists>xs'. xs = x # xs')"
   by (cases xs; simp)+
+
+lemma hd_opt_append[simp]:
+  "xs \<noteq> [] \<Longrightarrow> hd_opt (xs @ ys) = Some (hd xs)"
+  "xs = [] \<Longrightarrow> hd_opt (xs @ ys) = hd_opt ys"
+  by (induct xs; simp) simp
+
+lemma hd_opt_rev[simp]:
+  "hd_opt (rev xs) = (if xs = [] then None else Some (last xs))"
+  by (metis Nil_is_rev_conv hd_opt_simps(1) hd_opt_simps(2) last_rev list.exhaust list.sel(1) rev_rev_ident)
 
 lemma distinct_hd_not_in_tl:
   "distinct xs \<Longrightarrow> hd xs \<notin> set (tl xs)"

--- a/proof/invariant-abstract/DetSchedInvs_AI.thy
+++ b/proof/invariant-abstract/DetSchedInvs_AI.thy
@@ -1101,18 +1101,18 @@ abbreviation heap_ref_eq :: "'a \<Rightarrow> 'b \<Rightarrow> ('b \<rightharpoo
   "heap_ref_eq r p heap \<equiv> pred_map_eq (Some r) heap p"
 
 definition heap_refs_retract_at :: "('a \<rightharpoonup> 'b option) \<Rightarrow> ('b \<rightharpoonup> 'a option) \<Rightarrow> 'a \<Rightarrow> bool" where
-  "heap_refs_retract_at heap sym_heap p \<equiv> \<forall>r. heap_ref_eq r p heap \<longrightarrow> heap_ref_eq p r sym_heap"
+  "heap_refs_retract_at heap symheap p \<equiv> \<forall>r. heap_ref_eq r p heap \<longrightarrow> heap_ref_eq p r symheap"
 
 definition heap_refs_retract :: "('a \<rightharpoonup> 'b option) \<Rightarrow> ('b \<rightharpoonup> 'a option) \<Rightarrow> bool" where
-  "heap_refs_retract heap sym_heap \<equiv> \<forall>p. heap_refs_retract_at heap sym_heap p"
+  "heap_refs_retract heap symheap \<equiv> \<forall>p. heap_refs_retract_at heap symheap p"
 
 definition heap_refs_inv :: "('a \<rightharpoonup> 'b option) \<Rightarrow> ('b \<rightharpoonup> 'a option) \<Rightarrow> bool" where
-  "heap_refs_inv heap sym_heap \<equiv> heap_refs_retract heap sym_heap \<and> heap_refs_retract sym_heap heap"
+  "heap_refs_inv heap symheap \<equiv> heap_refs_retract heap symheap \<and> heap_refs_retract symheap heap"
 
 lemmas heap_refs_inv_defs = heap_refs_inv_def heap_refs_retract_def heap_refs_retract_at_def
 
 lemma heap_refs_inv_def2:
-  "heap_refs_inv heap sym_heap \<equiv> \<forall>p q. heap_ref_eq q p heap \<longleftrightarrow> heap_ref_eq p q sym_heap"
+  "heap_refs_inv heap symheap \<equiv> \<forall>p q. heap_ref_eq q p heap \<longleftrightarrow> heap_ref_eq p q symheap"
   by (auto simp: atomize_eq heap_refs_inv_defs)
 
 definition heap_refs_inj_at_ref :: "'a \<Rightarrow> 'b \<Rightarrow> ('a \<rightharpoonup> 'b option) \<Rightarrow> bool" where
@@ -1127,39 +1127,39 @@ definition heap_refs_inj :: "('a \<rightharpoonup> 'b option) \<Rightarrow> bool
 lemmas heap_ref_inj_defs = heap_refs_inj_def heap_refs_inj_at_def heap_refs_inj_at_ref_def
 
 lemma heap_refs_retract_atD:
-  assumes "heap_refs_retract_at heap sym_heap p"
+  assumes "heap_refs_retract_at heap symheap p"
   assumes "heap_ref_eq r p heap"
-  shows "heap_ref_eq p r sym_heap"
+  shows "heap_ref_eq p r symheap"
   using assms by (auto simp: heap_refs_retract_at_def)
 
 lemma heap_refs_retract_heap_refs_retract_at[simp, elim!]:
-  "heap_refs_retract heap sym_heap \<Longrightarrow> heap_refs_retract_at heap sym_heap p"
+  "heap_refs_retract heap symheap \<Longrightarrow> heap_refs_retract_at heap symheap p"
   by (auto simp: heap_refs_retract_def)
 
 lemmas heap_refs_retractD = heap_refs_retract_atD[OF heap_refs_retract_heap_refs_retract_at]
 
 lemma heap_refs_retractE:
-  assumes "heap_refs_retract heap sym_heap"
+  assumes "heap_refs_retract heap symheap"
   assumes "\<And>p r. heap_ref_eq r p heap'
-                  \<longrightarrow> (heap_ref_eq r p heap \<longrightarrow> heap_ref_eq p r sym_heap)
+                  \<longrightarrow> (heap_ref_eq r p heap \<longrightarrow> heap_ref_eq p r symheap)
                   \<longrightarrow> heap_ref_eq p r sym_heap'"
   shows "heap_refs_retract heap' sym_heap'"
   using assms by (simp add: heap_refs_inv_defs)
 
 lemma heap_refs_inv_retractD:
-  "heap_refs_inv heap sym_heap \<Longrightarrow> heap_refs_retract heap sym_heap"
+  "heap_refs_inv heap symheap \<Longrightarrow> heap_refs_retract heap symheap"
   by (simp add: heap_refs_inv_def)
 
 lemma heap_refs_inv_retract_symD:
-  "heap_refs_inv heap sym_heap \<Longrightarrow> heap_refs_retract sym_heap heap"
+  "heap_refs_inv heap symheap \<Longrightarrow> heap_refs_retract symheap heap"
   by (simp add: heap_refs_inv_def)
 
 lemma heap_refs_inv_inv:
-  "heap_refs_inv heap sym_heap \<Longrightarrow> heap_refs_inv sym_heap heap"
+  "heap_refs_inv heap symheap \<Longrightarrow> heap_refs_inv symheap heap"
   by (simp add: heap_refs_inv_def)
 
 lemma heap_refs_retract_heap_ref_inj:
-  assumes "heap_refs_retract heap sym_heap"
+  assumes "heap_refs_retract heap symheap"
   shows "heap_refs_inj heap"
   using assms
   apply (clarsimp simp: heap_ref_inj_defs)
@@ -1187,9 +1187,9 @@ lemmas heap_refs_inj_eq = heap_refs_inj_at_eq[OF heap_refs_injD]
 lemmas heap_refs_retract_inj_eq = heap_refs_inj_eq[OF heap_refs_retract_heap_ref_inj]
 
 lemma heap_refs_retract_at_eq:
-  "heap_refs_retract_at heap sym_heap p
+  "heap_refs_retract_at heap symheap p
    \<Longrightarrow> heap_ref_eq r p heap
-   \<Longrightarrow> heap_ref_eq p' r sym_heap
+   \<Longrightarrow> heap_ref_eq p' r symheap
    \<Longrightarrow> p' = p"
   by (auto simp: pred_map_simps dest!: heap_refs_retract_atD)
 


### PR DESCRIPTION
This PR contains `heap_path` related lemmas that I wrote for proving the `reply_remove_tcb_corres` lemma. It might be good to merge this first instead of keeping these lemmas back. It also removes a few sorries.

- misc lemmas for `heap_path`: `heap_path_prefix`, `heap_path_takeWhile_lookup_next` and others for looking at and around a middle point of the path
- introduces `sym_heap` and related lemmas: when two heaps are injective and each is an inverse of the other, they are `sym_heap`, and a path in one implies a reversed path in the other (plus some details about the ends)
- proof that `replyPrevs_of s'` and `replyNexts_of s'` are `sym_heap` if you can assume `sym_refs (list_refs_of_replies’ s’)`, and various lemmas derived from there
- some cleanup
