### PR TITLE
crefine: proof update for seL4 7cc50c3039

### DIFF
--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -2232,10 +2232,6 @@ lemma invokeUntyped_Retype_ccorres:
          rule_tac P="ptr_fetch = ptr_base" in ccorres_gen_asm2)
        apply csymbr
        apply csymbr
-       apply (rule ccorres_move_c_guard_cte)
-       apply csymbr
-       apply (rule ccorres_abstract_cleanup)
-       apply csymbr
        apply (simp add: from_bool_0 del: Collect_const)
        apply (rule_tac xf'=xfdc and r'=dc in ccorres_splitE)
            apply (rule ccorres_Cond_rhs)
@@ -2272,7 +2268,7 @@ lemma invokeUntyped_Retype_ccorres:
              apply (frule cap_get_tag_isCap_unfolded_H_cap)
              apply (cut_tac some_range_cover_arithmetic)
              apply (case_tac cte', clarsimp simp: modify_map_def fun_eq_iff split: if_split)
-             apply (simp add: mex_def meq_def ptr_base_eq del: split_paired_Ex)
+             apply (simp add: mex_def meq_def ptr_base_eq)
              apply (rule exI, strengthen refl, simp)
              apply (strengthen globals.fold_congs, simp add: field_simps)
             apply ceqv

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -2387,10 +2387,6 @@ lemma invokeUntyped_Retype_ccorres:
          rule_tac P="ptr_fetch = ptr_base" in ccorres_gen_asm2)
        apply csymbr
        apply csymbr
-       apply (rule ccorres_move_c_guard_cte)
-       apply csymbr
-       apply (rule ccorres_abstract_cleanup)
-       apply csymbr
        apply (simp add: from_bool_0 del: Collect_const)
        apply (rule_tac xf'=xfdc and r'=dc in ccorres_splitE)
            apply (rule ccorres_Cond_rhs)
@@ -2427,7 +2423,7 @@ lemma invokeUntyped_Retype_ccorres:
              apply (frule cap_get_tag_isCap_unfolded_H_cap)
              apply (cut_tac some_range_cover_arithmetic)
              apply (case_tac cte', clarsimp simp: modify_map_def fun_eq_iff split: if_split)
-             apply (simp add: mex_def meq_def ptr_base_eq del: split_paired_Ex)
+             apply (simp add: mex_def meq_def ptr_base_eq)
              apply (rule exI, strengthen refl, simp)
              apply (strengthen globals.fold_congs, simp add: field_simps)
             apply ceqv

--- a/proof/crefine/RISCV64/Invoke_C.thy
+++ b/proof/crefine/RISCV64/Invoke_C.thy
@@ -2348,10 +2348,6 @@ lemma invokeUntyped_Retype_ccorres:
          rule_tac P="ptr_fetch = ptr_base" in ccorres_gen_asm2)
        apply csymbr
        apply csymbr
-       apply (rule ccorres_move_c_guard_cte)
-       apply csymbr
-       apply (rule ccorres_abstract_cleanup)
-       apply csymbr
        apply (simp add: from_bool_0 del: Collect_const)
        apply (rule_tac xf'=xfdc and r'=dc in ccorres_splitE)
            apply (rule ccorres_Cond_rhs)
@@ -2390,7 +2386,7 @@ lemma invokeUntyped_Retype_ccorres:
              apply (frule cap_get_tag_isCap_unfolded_H_cap)
              apply (cut_tac some_range_cover_arithmetic)
              apply (case_tac cte', clarsimp simp: modify_map_def fun_eq_iff split: if_split)
-             apply (simp add: mex_def meq_def ptr_base_eq del: split_paired_Ex)
+             apply (simp add: mex_def meq_def ptr_base_eq)
              apply (rule exI, strengthen refl, simp)
              apply (strengthen globals.fold_congs, simp add: field_simps)
             apply ceqv

--- a/proof/crefine/X64/Invoke_C.thy
+++ b/proof/crefine/X64/Invoke_C.thy
@@ -2384,10 +2384,6 @@ lemma invokeUntyped_Retype_ccorres:
          rule_tac P="ptr_fetch = ptr_base" in ccorres_gen_asm2)
        apply csymbr
        apply csymbr
-       apply (rule ccorres_move_c_guard_cte)
-       apply csymbr
-       apply (rule ccorres_abstract_cleanup)
-       apply csymbr
        apply (simp add: from_bool_0 del: Collect_const)
        apply (rule_tac xf'=xfdc and r'=dc in ccorres_splitE)
            apply (rule ccorres_Cond_rhs)
@@ -2424,7 +2420,7 @@ lemma invokeUntyped_Retype_ccorres:
              apply (frule cap_get_tag_isCap_unfolded_H_cap)
              apply (cut_tac some_range_cover_arithmetic)
              apply (case_tac cte', clarsimp simp: modify_map_def fun_eq_iff split: if_split)
-             apply (simp add: mex_def meq_def ptr_base_eq del: split_paired_Ex)
+             apply (simp add: mex_def meq_def ptr_base_eq)
              apply (rule exI, strengthen refl, simp)
              apply (strengthen globals.fold_congs, simp add: field_simps)
             apply ceqv


### PR DESCRIPTION
The corresponding seL4 patch removes an unused line in `invokeUntyped_Retype`

The CI tests will fail, because there is a corresponding seL4 PR that needs to be merged at the same time for this.

Testboard with everything green is [here](https://bamboo.ts.data61.csiro.au/browse/L4V-TESTBOARD-665)