### PR TITLE
rt sr_inv_ul

### DIFF
--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -1515,4 +1515,113 @@ lemma corres_assert_opt_assume_l:
   \<Longrightarrow> corres_underlying sr nf nf' dc (P and K (X \<noteq> None)) Q (assert_opt X >>= f) g"
   by (force simp: corres_underlying_def assert_opt_def return_def bind_def fail_def)
 
+section \<open> Preservation of state_relation for the concrete side symbolic execution \<close>
+
+(** sr_inv **)
+
+definition sr_inv_ul :: "('a \<times> 'b) set \<Rightarrow> ('a \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> (unit \<times> 'b) set \<times> 'c) \<Rightarrow> bool" where
+  "sr_inv_ul sr P P' f \<equiv>
+       \<forall>s s' t'. (s, s') \<in> sr \<longrightarrow> P s \<longrightarrow> P' s'
+              \<longrightarrow> ((), t') \<in> fst (f s') \<longrightarrow> (s, t') \<in> sr"
+
+lemma corres_noop_assm: (* check equivalence *)
+  "(\<forall>s. P s \<longrightarrow> \<lbrace>P' and (\<lambda>s'. (s, s') \<in> sr)\<rbrace> m \<lbrace>\<lambda>_ s'. (s, s') \<in> sr\<rbrace>) \<longleftrightarrow> sr_inv_ul sr P P' m"
+  by (fastforce simp: valid_def sr_inv_ul_def)
+
+lemma sr_inv_ul_imp:
+  "\<lbrakk>sr_inv_ul sr Q Q' f; \<And>s. P s \<Longrightarrow> Q s; \<And>s. P' s \<Longrightarrow> Q' s\<rbrakk> \<Longrightarrow> sr_inv_ul sr P P' f "
+  by (clarsimp simp: sr_inv_ul_def)
+
+lemma sr_inv_stronger_imp:
+  "\<lbrakk>sr_inv_ul sr Q Q' f;
+    \<And>s s'. \<lbrakk>P s; P' s'; (s, s') \<in> sr\<rbrakk> \<Longrightarrow> Q s;
+    \<And>s s'. \<lbrakk>P s; P' s'; (s, s') \<in> sr\<rbrakk> \<Longrightarrow> Q' s'\<rbrakk>
+   \<Longrightarrow> sr_inv_ul sr P P' f"
+  by (clarsimp simp: sr_inv_ul_def)
+
+lemma sr_inv_ul_cross:
+  "\<lbrakk>sr_inv_ul sr P (P' and Q') f; \<And>s s'. P s \<Longrightarrow> P' s' \<Longrightarrow> Q' s'\<rbrakk> \<Longrightarrow> sr_inv_ul sr P P' f "
+  by (clarsimp simp: sr_inv_stronger_imp)
+
+lemma sr_inv_ul_cross_str:
+  "\<lbrakk>sr_inv_ul sr P (P' and Q') f; \<And>s s'. (s, s') \<in> sr \<Longrightarrow> P s \<Longrightarrow> P' s' \<Longrightarrow> Q' s'\<rbrakk> \<Longrightarrow> sr_inv_ul sr P P' f "
+  by (clarsimp simp: sr_inv_stronger_imp)
+
+lemma return_sr_inv[simp]:
+  "sr_inv_ul sr P P' (return x)"
+  by (clarsimp simp: sr_inv_ul_def return_def)
+
+lemma sr_inv_ul_bind:
+  "\<lbrakk> sr_inv_ul sr P P' g; \<lbrace>P'\<rbrace> g \<lbrace> \<lambda>rv. Q' rv\<rbrace>; \<And>rv. sr_inv_ul sr P (Q' rv) (f rv) \<rbrakk>
+   \<Longrightarrow> sr_inv_ul sr P P' (g >>= f)"
+  apply (unfold sr_inv_ul_def valid_def)
+  apply clarify
+  apply (drule_tac x=s' in spec)
+  apply (drule (1) mp)
+  apply (unfold in_bind)
+  apply clarify
+  apply (drule_tac x=s and y=s' in spec2)
+  apply (drule_tac x=s'' in spec)
+  apply clarify
+  apply (drule_tac x=x in meta_spec)
+  apply (drule_tac x=s and y=s'' in spec2)
+  apply (drule_tac x=t' in spec)
+  apply (drule_tac x="(x, s'')" in bspec, simp)
+  apply simp
+  done
+
+lemma corres_noop_sr_inv:
+  assumes P: "sr_inv_ul sr P P' f"
+  assumes nf': "\<And>s. \<lbrakk> P s; nf' \<rbrakk> \<Longrightarrow> no_fail (\<lambda>s'. (s, s') \<in> sr \<and> P' s') f"
+  assumes r: "r () x"
+  shows "corres_underlying sr nf nf' r P P' (return x) f"
+  using P r
+  apply (simp add: corres_underlying_def return_def split_def)
+  apply (clarsimp simp: sr_inv_ul_def)
+  apply (drule_tac x=a and y=b in spec2, clarsimp)
+  apply (insert nf')
+  apply (clarsimp simp: valid_def no_fail_def)
+  done
+
+(* corres_symb_exec_r_sr basically combines the two lemmas corres_split_noop_rhs and corres_noop
+   in one and separates out the sr_inv part *)
+lemma corres_symb_exec_r_sr:
+  assumes z: "corres_underlying sr nf nf' r P Q' x y"
+  assumes sr: "sr_inv_ul sr P P' m"
+  assumes ex: "\<lbrace> P' \<rbrace> m \<lbrace>\<lambda>_. Q'\<rbrace>"
+  assumes nf: "nf' \<Longrightarrow> no_fail P' m"
+  shows "corres_underlying sr nf nf' r P P' x (m >>= (\<lambda>_. y))"
+  using sr z ex nf
+  unfolding corres_underlying_def sr_inv_ul_def
+  apply (clarsimp simp: corres_underlying_def bind_def)
+  apply (rename_tac s s')
+  apply (rule conjI; clarsimp simp: in_monad)
+   apply (drule_tac x=s and y=s' in spec2, clarsimp)
+   apply (rename_tac t' rv' s'')
+   apply (drule_tac x="(s, t')" in bspec, simp)
+   apply clarsimp
+   apply (drule use_valid[OF _ ex], simp)
+   apply clarsimp
+   apply (drule_tac x="(rv', s'')" in bspec, simp)
+   apply simp
+  apply (drule_tac x=s and y=s' in spec2, clarsimp simp: no_failD valid_def)
+  apply (rename_tac t')
+  apply (drule_tac x=t' in spec, clarsimp)
+  apply (drule_tac x=s' in spec, clarsimp)
+  apply (drule bspec[of "fst _"], simp)
+  apply clarsimp
+  apply ( drule_tac x="(s, t')" in bspec, simp)
+  by clarsimp
+
+lemma corres_noop_sr:
+  assumes sr: "sr_inv_ul sr P P' f"
+  assumes ex: "\<lbrace> P' \<rbrace> f \<lbrace>\<lambda>rv _. r x rv\<rbrace>"
+  assumes nf': "\<And>s. \<lbrakk> P s; nf' \<rbrakk> \<Longrightarrow> no_fail (\<lambda>s'. (s, s') \<in> sr \<and> P' s') f"
+  shows "corres_underlying sr nf nf' r P P' (return x) f"
+  using sr ex
+  apply (clarsimp simp: sr_inv_ul_def corres_underlying_def return_def)
+  apply (clarsimp simp: no_failD[OF nf'[simplified]] valid_def)
+  apply (drule_tac x=b in spec, clarsimp)
+  done
+
 end

--- a/proof/refine/ARM/Corres.thy
+++ b/proof/refine/ARM/Corres.thy
@@ -23,4 +23,12 @@ abbreviation
 abbreviation
   "ex_abs \<equiv> ex_abs_underlying state_relation"
 
+abbreviation "sr_inv P P' f \<equiv> sr_inv_ul state_relation P P' f"
+
+lemmas sr_inv_def = sr_inv_ul_def
+
+lemmas sr_inv_imp = sr_inv_ul_imp[of state_relation]
+
+lemmas sr_inv_bind = sr_inv_ul_bind[where sr=state_relation]
+
 end

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -3561,16 +3561,15 @@ lemma get_sched_context_exs_valid:
               split: Structures_A.kernel_object.splits)
 
 lemma no_fail_simple_ko_at:
-  "\<lbrakk>inj C; is_simple_type (C ko)\<rbrakk> \<Longrightarrow> no_fail (ko_at (C ko) p) (get_simple_ko C p)"
-  apply (wpsimp simp: get_simple_ko_def obj_at_def wp: get_object_wp)
-  by (auto simp: partial_inv_def inj_def split: if_splits)
+  "no_fail (ntfn_at p) (get_notification p)"
+  "no_fail (ep_at p) (get_endpoint p)"
+  "no_fail (reply_at p) (get_reply p)"
+  by (wpsimp simp: get_simple_ko_def obj_at_def is_obj_defs a_type_def partial_inv_def
+               wp: get_object_wp split:  Structures_A.kernel_object.splits)+
 
-lemmas no_fail_get_notification[wp] =
-  no_fail_simple_ko_at[where C=kernel_object.Notification, simplified]
-lemmas no_fail_get_reply[wp] =
-  no_fail_simple_ko_at[where C=kernel_object.Reply, simplified]
-lemmas no_fail_get_endpoint[wp] =
-  no_fail_simple_ko_at[where C=kernel_object.Endpoint, simplified]
+lemmas no_fail_get_notification[wp] = no_fail_simple_ko_at(1)
+lemmas no_fail_get_reply[wp] = no_fail_simple_ko_at(2)
+lemmas no_fail_get_endpoint[wp] = no_fail_simple_ko_at(3)
 
 lemma get_sched_context_no_fail:
   "no_fail (\<lambda>s. sc_at ptr s) (get_sched_context ptr)"

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -634,4 +634,77 @@ lemma replyRemoveTCB_invs':
               simp: cteCaps_of_def)
   done
 
+context begin interpretation Arch .
+
+lemma pspace_relation_reply_update_conc_only:
+  "\<lbrakk> pspace_relation s s'; s x = Some (Structures_A.Reply reply); s' x = Some (KOReply reply');
+     reply_relation reply new\<rbrakk>
+       \<Longrightarrow> pspace_relation s (s'(x \<mapsto> (KOReply new)))"
+  apply (simp add: pspace_relation_def pspace_dom_update dom_fun_upd2
+              del: dom_fun_upd)
+  apply (erule conjE)
+  apply (rule ballI, drule(1) bspec)
+  apply (clarsimp simp: split_def)
+  apply (drule bspec, simp)
+  apply (clarsimp simp: obj_relation_cuts_def2 cte_relation_def
+                        pte_relation_def pde_relation_def
+                 split: Structures_A.kernel_object.split_asm arch_kernel_obj.split_asm if_split_asm)
+  done
+end
+
+lemma replyPrevs_of_replyNext_update:
+  "ko_at' reply' rp s' \<Longrightarrow>
+      replyPrevs_of (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto>
+                            KOReply (reply' \<lparr> replyNext := v \<rparr>))\<rparr>) = replyPrevs_of s'"
+  apply (clarsimp simp: obj_at'_def projectKOs isNext_def
+                 split: option.split_asm reply_next.split_asm)
+  by (fastforce simp: projectKO_opt_reply opt_map_def)
+
+lemma scs_of'_replyNext_update:
+  "ko_at' reply' rp s' \<Longrightarrow>
+      scs_of' (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto>
+                            KOReply (reply' \<lparr> replyNext := v \<rparr>))\<rparr>) = scs_of' s'"
+  apply (clarsimp simp: obj_at'_def projectKOs isNext_def
+                 split: option.split_asm reply_next.split_asm)
+  by (fastforce simp: projectKO_opt_sc opt_map_def)
+
+lemma scs_of'_replyPrev_update:
+  "ko_at' reply' rp s' \<Longrightarrow>
+      scs_of' (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto>
+                            KOReply (reply' \<lparr> replyPrev := v \<rparr>))\<rparr>) = scs_of' s'"
+  apply (clarsimp simp: obj_at'_def projectKOs isNext_def
+                 split: option.split_asm reply_next.split_asm)
+  by (fastforce simp: projectKO_opt_sc opt_map_def)
+
+lemma sc_replies_relation_replyNext_update:
+  "\<lbrakk>sc_replies_relation s s'; ko_at' reply' rp s'\<rbrakk>
+     \<Longrightarrow> sc_replies_relation s(s'\<lparr>ksPSpace := (ksPSpace s')(rp \<mapsto>
+                                           KOReply (reply' \<lparr> replyNext := v \<rparr>))\<rparr>)"
+  by (clarsimp simp: scs_of'_replyNext_update[simplified]
+                     replyPrevs_of_replyNext_update[simplified])
+
+(* an example of an sr_inv lemma; to be used in reply_remove_tcb_corres *)
+lemma replyNext_Next_update_sr_inv:
+   "\<lbrakk>\<not>isHead v; isNext (replyNext r')\<rbrakk> \<Longrightarrow>
+    sr_inv P (P' and ko_at' r' rp)
+       (setReply rp (r' \<lparr> replyNext := v \<rparr>))"
+  unfolding sr_inv_def
+  apply (clarsimp simp: cleanReply_def in_monad setReply_def setObject_def
+                        exec_get split_def getReply_def projectKOs objBits_simps
+                        updateObject_default_def ARM_H.fromPPtr_def obj_at'_def
+                        in_magnitude_check replySizeBits_def
+                 split: option.split_asm)
+  apply (clarsimp simp: state_relation_def map_to_ctes_upd_other)
+  apply (frule reply_at'_cross[where ptr=rp])
+   apply (clarsimp simp: obj_at'_def objBits_simps projectKOs replySizeBits_def)
+  apply (rule conjI; clarsimp simp: obj_at_def is_reply)
+   apply (frule (1) pspace_relation_absD)
+   apply (erule (2) pspace_relation_reply_update_conc_only)
+   apply (clarsimp simp: reply_relation_def getHeadScPtr_def isNext_def isHead_def
+                  split: reply_next.splits option.splits)
+  apply (rule sc_replies_relation_replyNext_update[simplified])
+   apply simp
+  by (clarsimp simp: obj_at'_def objBits_simps projectKOs replySizeBits_def)
+
+
 end

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -637,9 +637,9 @@ lemma replyRemoveTCB_invs':
 context begin interpretation Arch .
 
 lemma pspace_relation_reply_update_conc_only:
-  "\<lbrakk> pspace_relation s s'; s x = Some (Structures_A.Reply reply); s' x = Some (KOReply reply');
+  "\<lbrakk> pspace_relation ps ps'; ps x = Some (Structures_A.Reply reply); ps' x = Some (KOReply reply');
      reply_relation reply new\<rbrakk>
-       \<Longrightarrow> pspace_relation s (s'(x \<mapsto> (KOReply new)))"
+   \<Longrightarrow> pspace_relation ps (ps'(x \<mapsto> (KOReply new)))"
   apply (simp add: pspace_relation_def pspace_dom_update dom_fun_upd2
               del: dom_fun_upd)
   apply (erule conjE)
@@ -650,6 +650,7 @@ lemma pspace_relation_reply_update_conc_only:
                         pte_relation_def pde_relation_def
                  split: Structures_A.kernel_object.split_asm arch_kernel_obj.split_asm if_split_asm)
   done
+
 end
 
 lemma replyPrevs_of_replyNext_update:
@@ -660,27 +661,18 @@ lemma replyPrevs_of_replyNext_update:
                  split: option.split_asm reply_next.split_asm)
   by (fastforce simp: projectKO_opt_reply opt_map_def)
 
-lemma scs_of'_replyNext_update:
-  "ko_at' reply' rp s' \<Longrightarrow>
-      scs_of' (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto>
-                            KOReply (reply' \<lparr> replyNext := v \<rparr>))\<rparr>) = scs_of' s'"
-  apply (clarsimp simp: obj_at'_def projectKOs isNext_def
-                 split: option.split_asm reply_next.split_asm)
-  by (fastforce simp: projectKO_opt_sc opt_map_def)
-
-lemma scs_of'_replyPrev_update:
-  "ko_at' reply' rp s' \<Longrightarrow>
-      scs_of' (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto>
-                            KOReply (reply' \<lparr> replyPrev := v \<rparr>))\<rparr>) = scs_of' s'"
+lemma scs_of'_reply_update:
+  "reply_at' rp s' \<Longrightarrow>
+      scs_of' (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto> KOReply reply)\<rparr>) = scs_of' s'"
   apply (clarsimp simp: obj_at'_def projectKOs isNext_def
                  split: option.split_asm reply_next.split_asm)
   by (fastforce simp: projectKO_opt_sc opt_map_def)
 
 lemma sc_replies_relation_replyNext_update:
   "\<lbrakk>sc_replies_relation s s'; ko_at' reply' rp s'\<rbrakk>
-     \<Longrightarrow> sc_replies_relation s(s'\<lparr>ksPSpace := (ksPSpace s')(rp \<mapsto>
+     \<Longrightarrow> sc_replies_relation s (s'\<lparr>ksPSpace := (ksPSpace s')(rp \<mapsto>
                                            KOReply (reply' \<lparr> replyNext := v \<rparr>))\<rparr>)"
-  by (clarsimp simp: scs_of'_replyNext_update[simplified]
+  by (clarsimp simp: scs_of'_reply_update[simplified] obj_at'_def
                      replyPrevs_of_replyNext_update[simplified])
 
 (* an example of an sr_inv lemma; to be used in reply_remove_tcb_corres *)

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -15,11 +15,12 @@ defs replyUnlink_assertion_def:
 
 
 crunches updateReply
-  for tcb_at'[wp]: "\<lambda>s. P (tcb_at' t s)"
-  and st_tcb_at'[wp]: "\<lambda>s. P (st_tcb_at' P' t' s)"
-  and ksReadyQueues[wp]: "\<lambda>s. P (ksReadyQueues s p) t"
+  for pred_tcb_at'[wp]: "\<lambda>s. P (pred_tcb_at' proj test t s)"
+  and tcb_at'[wp]: "\<lambda>s. P (tcb_at' t s)"
+  and ksReadyQueues[wp]: "\<lambda>s. P (ksReadyQueues s)"
   and ksSchedulerAction[wp]: "\<lambda>s. P (ksSchedulerAction s)"
   and valid_queues[wp]: "valid_queues"
+  and reply_at'[wp]: "\<lambda>s. P (reply_at' rp s)"
 
 lemma replyTCB_update_reply_projs[wp]:
   "\<lbrace>\<lambda>s. P (replyNexts_of s) (replyPrevs_of s)

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -2300,7 +2300,7 @@ lemma isSchedulable_corres:
   done
 
 lemma get_simple_ko_exs_valid:
-  "\<lbrakk>inj C; ko_at (C ko) p s; is_simple_type (C ko)\<rbrakk> \<Longrightarrow> \<lbrace>(=) s\<rbrace> get_simple_ko C p \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
+  "\<lbrakk>inj C; \<exists>ko. ko_at (C ko) p s \<and> is_simple_type (C ko)\<rbrakk> \<Longrightarrow> \<lbrace>(=) s\<rbrace> get_simple_ko C p \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
   by (auto simp: get_simple_ko_def get_object_def gets_def return_def get_def
                      partial_inv_def exs_valid_def bind_def obj_at_def is_reply fail_def inj_def split: prod.splits)
 


### PR DESCRIPTION
In symbolic execution on the concrete side, the state sometimes changes but in such a way that the state relation is still preserved. We encounter this situation quite often in the MCS verification.

There is existing corres lemmas that cater for this situation, namely, `corres_noop` (corres with `return ()` on the abstract side, which is rarely used so far), but only in combination with something like `corres_split_noop_rhs` (which inserts `return` on the abstract side). Since we have many situations that we want to do this, it is nicer to write a rule that does these steps as one symbolic execution.

Also, in `corres_noop`, the state relation preservation condition is integrated in a Hoare triple together with normal preconditions and postconditions. It is often the case that there are existing wp rules that we can use for these normal pre- and post-conditions, while we do need to show that the state relation is preserved, and they do not interact (although we do have some situations that they do interact). `sr_inv_ul` is for packaging up the proof for the preservation of state relation so that we can reuse it for such cases.

The rule `corres_symb_exec_r_sr` is a symbolic execution rule for the concrete side where the concrete state is modified, and defined in terms of `sr_inv_ul`.

So, this PR contains:
- `sr_inv_ul` and related basic lemmas
- `corres_symb_exec_r_sr`
- proof of `replyNext_Next_update_sr_inv`: an example of `sr_inv`

(one thing: I am not too sure is the naming of `sr_inv_ul`...)