### PR TITLE
riscv crefine and SEAR: arch-split SEAR and custom proofs about clz and ctz

### DIFF
--- a/lib/Word_Lib/Word_Lemmas_Internal.thy
+++ b/lib/Word_Lib/Word_Lemmas_Internal.thy
@@ -412,4 +412,215 @@ lemma upcast_less_unat_less:
   shows "unat x < y"
   by (rule unat_mono[OF less, simplified unat_ucast_up_simp[OF len] unat_of_nat_eq[OF bound]])
 
+lemma word_ctz_max:
+  "word_ctz w \<le> size w"
+  unfolding word_ctz_def
+  by (rule order_trans[OF List.length_takeWhile_le], clarsimp simp: word_size)
+
+lemma scast_of_nat_small:
+  "x < 2 ^ (LENGTH('a) - 1) \<Longrightarrow> scast (of_nat x :: 'a :: len word) = (of_nat x :: 'b :: len word)"
+  apply (rule sym, subst word_unat.inverse_norm)
+  apply (simp add: scast_def word_of_int[symmetric]
+                   of_nat_nat[symmetric] unat_def[symmetric])
+  apply (simp add: int_eq_sint unat_of_nat)
+  done
+
+lemmas casts_of_nat_small = ucast_of_nat_small scast_of_nat_small
+
+\<comment>\<open>The conditions under which `takeWhile P xs = take n xs` and `dropWhile P xs = drop n xs`\<close>
+definition list_while_len where
+  "list_while_len P n xs \<equiv> (\<forall>i. i < n \<longrightarrow> i < length xs \<longrightarrow> P (xs ! i))
+                            \<and> (n < length xs \<longrightarrow> \<not> P (xs ! n))"
+
+lemma list_while_len_iff_takeWhile_eq_take:
+  "list_while_len P n xs \<longleftrightarrow> takeWhile P xs = take n xs"
+  unfolding list_while_len_def
+  apply (rule iffI[OF takeWhile_eq_take_P_nth], simp+)
+  apply (intro conjI allI impI)
+   apply (rule takeWhile_take_has_property_nth, clarsimp)
+  apply (drule_tac f=length in arg_cong, simp)
+  apply (induct xs arbitrary: n; clarsimp split: if_splits)
+  done
+
+lemma list_while_len_exists:
+  "\<exists>n. list_while_len P n xs"
+  apply (induction xs; simp add: list_while_len_def)
+  apply (rename_tac x xs)
+  apply (erule exE)
+  apply (case_tac "P x")
+   apply (rule_tac x="Suc n" in exI, clarsimp)
+   apply (case_tac i; simp)
+  apply (rule_tac x=0 in exI, simp)
+  done
+
+lemma takeWhile_truncate:
+  "length (takeWhile P xs) \<le> m
+   \<Longrightarrow> takeWhile P (take m xs) = takeWhile P xs"
+  apply (cut_tac list_while_len_exists[where P=P and xs=xs], clarsimp)
+  apply (case_tac "n \<le> m")
+   apply (subgoal_tac "list_while_len P n (take m xs)")
+    apply(simp add: list_while_len_iff_takeWhile_eq_take)
+   apply (clarsimp simp: list_while_len_def)
+  apply (simp add: list_while_len_iff_takeWhile_eq_take)
+  done
+
+lemma word_clz_shiftr_1:
+  fixes z::"'a::len word"
+  assumes wordsize: "1 < LENGTH('a)"
+  shows "z \<noteq> 0 \<Longrightarrow> word_clz (z >> 1) = word_clz z + 1"
+  supply word_size [simp]
+  apply (clarsimp simp: word_clz_def)
+  using wordsize apply (subst bl_shiftr, simp)
+  apply (subst takeWhile_append2; simp add: wordsize)
+  apply (subst takeWhile_truncate)
+  using word_clz_nonzero_max[where w=z]
+   apply (clarsimp simp: word_clz_def)
+   apply simp+
+  done
+
+lemma shiftr_Suc:
+  fixes x::"'a::len word"
+  shows "x >> (Suc n) = x >> n >> 1"
+  by (clarsimp simp: shiftr_shiftr)
+
+lemma word_clz_shiftr:
+  fixes z :: "'a::len word"
+  shows "n < LENGTH('a) \<Longrightarrow> mask n < z \<Longrightarrow> word_clz (z >> n) = word_clz z + n"
+  apply (simp add: le_mask_iff Not_eq_iff[THEN iffD2, OF le_mask_iff, simplified not_le]
+                   word_neq_0_conv)
+  apply (induction n; simp)
+  apply (subgoal_tac "0 < z >> n")
+   apply (subst shiftr_Suc)
+   apply (subst word_clz_shiftr_1; simp)
+  apply (clarsimp simp: word_less_nat_alt shiftr_div_2n' div_mult2_eq)
+  apply (case_tac "unat z div 2 ^ n = 0"; simp)
+  apply (clarsimp simp: div_eq_0_iff)
+  done
+
+lemma mask_to_bl_exists_True:
+  "x && mask n \<noteq> 0 \<Longrightarrow> \<exists>m. (rev (to_bl x)) ! m \<and> m < n"
+  apply (subgoal_tac "\<not>(\<forall>m. m < n \<longrightarrow> \<not>(rev (to_bl x)) ! m)", fastforce)
+  apply (intro notI)
+  apply (subgoal_tac "x && mask n = 0", clarsimp)
+  apply (clarsimp simp: eq_zero_set_bl in_set_conv_nth)
+  apply (subst (asm) to_bl_nth, clarsimp simp: word_size)
+  apply (clarsimp simp: word_size)
+  apply (drule_tac x="LENGTH('a) - Suc i" in spec, simp)
+  apply (subst (asm) rev_nth, simp)
+  apply (subst (asm) to_bl_nth; clarsimp simp: word_size)
+  done
+
+lemma word_ctz_shiftr_1:
+  fixes z::"'a::len word"
+  assumes wordsize: "1 < LENGTH('a)"
+  shows "z \<noteq> 0 \<Longrightarrow> 1 \<le> word_ctz z \<Longrightarrow> word_ctz (z >> 1) = word_ctz z - 1"
+  supply word_size [simp]
+  apply (clarsimp simp: word_ctz_def)
+  using wordsize apply (subst bl_shiftr, simp)
+  apply (simp add: rev_take )
+  apply (subgoal_tac
+         "length (takeWhile Not (rev (to_bl z))) - Suc 0
+          = length (takeWhile Not (take 1 (rev (to_bl z)) @ drop 1 (rev (to_bl z)))) - Suc 0")
+   apply (subst (asm) takeWhile_append2)
+    apply clarsimp
+    apply (case_tac "rev (to_bl z)"; simp)
+   apply clarsimp
+   apply (subgoal_tac "\<exists>m. (rev (to_bl z)) ! m \<and> m < LENGTH('a)", clarsimp)
+    apply (case_tac m)
+     apply (case_tac "rev (to_bl z)"; simp)
+    apply (subst takeWhile_append1, subst in_set_conv_nth)
+      apply (rule_tac x=nat in exI)
+      apply (intro conjI)
+       apply (clarsimp simp: wordsize)
+       using wordsize apply linarith
+      apply (rule refl, clarsimp)
+    apply simp
+   apply (rule mask_to_bl_exists_True, simp)
+  apply simp
+  done
+
+lemma word_ctz_bound_below_helper:
+  fixes x :: "'a::len word"
+  assumes sz: "n \<le> LENGTH('a)"
+  shows "x && mask n = 0
+         \<Longrightarrow> to_bl x = (take (LENGTH('a) - n) (to_bl x) @ replicate n False)"
+  apply (subgoal_tac "replicate n False = drop (LENGTH('a) - n) (to_bl x)")
+   apply (subgoal_tac "True \<notin> set (drop (LENGTH('a) - n) (to_bl x))")
+    apply (drule list_of_false, clarsimp simp: sz)
+   apply (drule_tac sym[where t="drop n x" for n x], clarsimp)
+  apply (rule sym)
+  apply (rule is_aligned_drop; clarsimp simp: is_aligned_mask sz)
+  done
+
+lemma word_ctz_bound_below:
+  fixes x :: "'a::len word"
+  assumes sz[simp]: "n \<le> LENGTH('a)"
+  shows "x && mask n = 0 \<Longrightarrow> n \<le> word_ctz x"
+  apply (clarsimp simp: word_ctz_def)
+  apply (subst word_ctz_bound_below_helper[OF sz]; simp)
+  apply (subst takeWhile_append2; clarsimp)
+  done
+
+lemma word_ctz_bound_above:
+  fixes x :: "'a::len word"
+  shows "x && mask n \<noteq> 0 \<Longrightarrow> word_ctz x < n"
+  apply (cases "n \<le> LENGTH('a)")
+   apply (frule mask_to_bl_exists_True, clarsimp)
+   apply (clarsimp simp: word_ctz_def)
+   apply (subgoal_tac "m < length ((rev (to_bl x)))")
+    apply (subst id_take_nth_drop[where xs="rev (to_bl x)"], assumption)
+    apply (subst takeWhile_tail, simp)
+    apply (rule order.strict_trans1)
+     apply (rule List.length_takeWhile_le)
+    apply simp
+   apply (erule order.strict_trans2, clarsimp)
+  apply (simp add: not_le)
+  apply (erule le_less_trans[OF word_ctz_max, simplified word_size])
+  done
+
+lemma word_ctz_shiftr:
+  fixes z::"'a::len word"
+  assumes nz: "z \<noteq> 0"
+  shows "n < LENGTH('a) \<Longrightarrow> n \<le> word_ctz z \<Longrightarrow> word_ctz (z >> n) = word_ctz z - n"
+  apply (induction n; simp)
+  apply (subst shiftr_Suc)
+  apply (subst word_ctz_shiftr_1, simp)
+    apply clarsimp
+    apply (subgoal_tac "word_ctz z < n", clarsimp)
+    apply (rule word_ctz_bound_above, clarsimp simp: word_size)
+    apply (subst (asm) and_mask_eq_iff_shiftr_0[symmetric], clarsimp simp: nz)
+   apply (rule word_ctz_bound_below, clarsimp simp: word_size)
+   apply (rule mask_zero)
+   apply (rule is_aligned_shiftr, simp add: is_aligned_mask)
+   apply (case_tac "z && mask (Suc n) = 0", simp)
+   apply (frule word_ctz_bound_above[rotated]; clarsimp simp: word_size)
+  apply simp
+  done
+
+\<comment> \<open>Useful for solving goals of the form `(w::32 word) <= 0xFFFFFFFF` by simplification\<close>
+lemma word_less_max_simp:
+  fixes w :: "'a::len word"
+  assumes "max_w = -1"
+  shows "w \<le> max_w"
+  unfolding assms by simp
+
+lemma word_and_mask_word_ctz_zero:
+  assumes "l = word_ctz w"
+  shows "w && mask l = 0"
+  unfolding word_ctz_def assms
+  apply (word_eqI)
+  apply (drule takeWhile_take_has_property_nth)
+  apply (simp add: test_bit_bl)
+  done
+
+lemma word_ctz_len_word_and_mask_zero:
+  fixes w :: "'a::len word"
+  shows "word_ctz w = LENGTH('a) \<Longrightarrow> w = 0"
+  by (drule sym, drule word_and_mask_word_ctz_zero, simp)
+
+lemma word_le_1:
+  fixes w :: "'a::len word"
+  shows "w \<le> 1 \<longleftrightarrow> w = 0 \<or> w = 1"
+  using dual_order.antisym lt1_neq0 word_zero_le by blast
+
 end

--- a/proof/ROOT
+++ b/proof/ROOT
@@ -206,6 +206,8 @@ session SimplExportAndRefine in "asmrefine" = SimplExport +
     "SEL4GraphRefine"
 
 session SimplExport in "asmrefine/export" = CSpec +
+  directories
+    "$L4V_ARCH"
   theories
     "SEL4SimplExport"
 

--- a/proof/asmrefine/export/ARM/ArchSEL4SimplExport.thy
+++ b/proof/asmrefine/export/ARM/ArchSEL4SimplExport.thy
@@ -1,0 +1,31 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchSEL4SimplExport
+imports "AsmRefine.SimplExport" "CSpec.Substitute"
+begin
+
+context kernel_all_substitute begin
+
+lemma ctzl_body_refines:
+  "simple_simpl_refines \<Gamma> (Guard ImpossibleSpec \<lbrace>\<acute>x \<noteq> 0\<rbrace>
+    (\<acute>ret__long :== ucast (bv_ctz (\<acute>x)))) ctzl_body"
+  apply (simp add: ctzl_body_def)
+  apply (rule simple_simpl_refines_guarded_Basic_guarded_spec_body)
+  apply (clarsimp simp: bv_ctz_def meq_def)
+  done
+
+lemma clzl_body_refines:
+  "simple_simpl_refines \<Gamma> (Guard ImpossibleSpec \<lbrace>\<acute>x \<noteq> 0\<rbrace>
+    (\<acute>ret__long :== ucast (bv_clz (\<acute>x)))) clzl_body"
+  apply (simp add: clzl_body_def)
+  apply (rule simple_simpl_refines_guarded_Basic_guarded_spec_body)
+  apply (clarsimp simp: bv_clz_def meq_def)
+  done
+
+end
+
+end

--- a/proof/asmrefine/export/RISCV64/ArchSEL4SimplExport.thy
+++ b/proof/asmrefine/export/RISCV64/ArchSEL4SimplExport.thy
@@ -1,0 +1,11 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchSEL4SimplExport
+imports "AsmRefine.SimplExport"
+begin
+
+end

--- a/proof/asmrefine/export/RISCV64/ArchSEL4SimplExport.thy
+++ b/proof/asmrefine/export/RISCV64/ArchSEL4SimplExport.thy
@@ -5,7 +5,7 @@
  *)
 
 theory ArchSEL4SimplExport
-imports "AsmRefine.SimplExport"
+imports "AsmRefine.SimplExport" "CSpec.Substitute"
 begin
 
 end

--- a/proof/asmrefine/export/SEL4SimplExport.thy
+++ b/proof/asmrefine/export/SEL4SimplExport.thy
@@ -5,7 +5,7 @@
  *)
 
 theory SEL4SimplExport
-imports "ArchSEL4SimplExport" "CSpec.Substitute"
+imports "ArchSEL4SimplExport"
 begin
 
 ML \<open>

--- a/proof/asmrefine/export/SEL4SimplExport.thy
+++ b/proof/asmrefine/export/SEL4SimplExport.thy
@@ -5,7 +5,7 @@
  *)
 
 theory SEL4SimplExport
-imports "AsmRefine.SimplExport" "CSpec.Substitute"
+imports "ArchSEL4SimplExport" "CSpec.Substitute"
 begin
 
 ML \<open>
@@ -15,22 +15,6 @@ val csenv = let
 \<close>
 
 context kernel_all_substitute begin
-
-lemma ctzl_body_refines:
-  "simple_simpl_refines \<Gamma> (Guard ImpossibleSpec \<lbrace>\<acute>x \<noteq> 0\<rbrace>
-    (\<acute>ret__long :== ucast (bv_ctz (\<acute>x)))) ctzl_body"
-  apply (simp add: ctzl_body_def)
-  apply (rule simple_simpl_refines_guarded_Basic_guarded_spec_body)
-  apply (clarsimp simp: bv_ctz_def meq_def)
-  done
-
-lemma clzl_body_refines:
-  "simple_simpl_refines \<Gamma> (Guard ImpossibleSpec \<lbrace>\<acute>x \<noteq> 0\<rbrace>
-    (\<acute>ret__long :== ucast (bv_clz (\<acute>x)))) clzl_body"
-  apply (simp add: clzl_body_def)
-  apply (rule simple_simpl_refines_guarded_Basic_guarded_spec_body)
-  apply (clarsimp simp: bv_clz_def meq_def)
-  done
 
 declare ctcb_offset_defs[simp]
 
@@ -44,4 +28,3 @@ ML \<open>
 end
 
 end
-

--- a/proof/crefine/Move_C.thy
+++ b/proof/crefine/Move_C.thy
@@ -1347,4 +1347,16 @@ lemma tcbSchedEnqueue_queued_queues_inv:
   apply normalise_obj_at'
   done
 
+(* FIXME BV: generalise *)
+lemma word_clz_1[simp]:
+  "word_clz (1::32 word) = 31"
+  "word_clz (1::64 word) = 63"
+  by (clarsimp simp: word_clz_def to_bl_def)+
+
+(* FIXME BV: generalise *)
+lemma word_ctz_0[simp]:
+  "word_ctz (0::32 word) = 32"
+  "word_ctz (0::64 word) = 64"
+  by (clarsimp simp: word_ctz_def to_bl_def)+
+
 end

--- a/proof/crefine/RISCV64/IpcCancel_C.thy
+++ b/proof/crefine/RISCV64/IpcCancel_C.thy
@@ -2099,15 +2099,6 @@ lemma ksReadyQueuesL2Bitmap_nonzeroI:
    apply clarsimp
    done
 
-lemma clzl_spec:
-  "\<forall>s. \<Gamma> \<turnstile> {\<sigma>. s = \<sigma> \<and> x_' s \<noteq> 0} Call clzl_'proc
-       \<lbrace>\<acute>ret__long = of_nat (word_clz (x_' s)) \<rbrace>"
-  apply (rule allI, rule conseqPre, vcg)
-  apply clarsimp
-  apply (rule_tac x="ret__long_'_update f x" for f in exI)
-  apply (simp add: mex_def meq_def)
-  done
-
 lemma l1index_to_prio_spec:
   "\<forall>s. \<Gamma> \<turnstile> {s} Call l1index_to_prio_'proc
        \<lbrace>\<acute>ret__unsigned_long = l1index_' s << wordRadix \<rbrace>"

--- a/proof/crefine/RISCV64/Machine_C.thy
+++ b/proof/crefine/RISCV64/Machine_C.thy
@@ -130,6 +130,155 @@ lemma dmo_if:
   "(doMachineOp (if a then b else c)) = (if a then (doMachineOp b) else (doMachineOp c))"
   by (simp split: if_split)
 
-end
+(* Count leading and trailing zeros. *)
 
+(* FIXME: move *)
+lemma word_ctz_max:
+  "word_ctz w \<le> size w"
+  sorry
+
+(* FIXME move *)
+lemma scast_of_nat_small:
+  "x < 2 ^ (LENGTH('a) - 1) \<Longrightarrow> scast (of_nat x :: 'a :: len word) = (of_nat x :: 'b :: len word)"
+  apply (rule sym, subst word_unat.inverse_norm)
+  apply (simp add: scast_def word_of_int[symmetric]
+                   of_nat_nat[symmetric] unat_def[symmetric])
+  apply (simp add: int_eq_sint unat_of_nat)
+  done
+
+(* FIXME move *)
+lemmas casts_of_nat_small = ucast_of_nat_small scast_of_nat_small
+
+(* FIXME: move *)
+lemma hoarep_Seq_nothrow:
+  assumes c: "hoarep \<Gamma> \<Theta> F P c Q {}"
+  assumes d: "hoarep \<Gamma> \<Theta> F Q d R A"
+  shows "hoarep \<Gamma> \<Theta> F P (Seq c d) R A"
+  by (rule hoarep.Seq[OF HoarePartialDef.conseqPrePost[OF c] d]; simp)
+
+definition clz32_step where
+  "clz32_step i \<equiv> \<acute>mask___unsigned :== \<acute>mask___unsigned >> unat ((1::32 sword) << unat i);;
+                 \<acute>bits :== SCAST(32 signed \<rightarrow> 32) (if \<acute>mask___unsigned < \<acute>x___unsigned then 1 else 0) << unat i;;
+                 Guard ShiftError \<lbrace>\<acute>bits < SCAST(32 signed \<rightarrow> 32) 0x20\<rbrace> (\<acute>x___unsigned :== \<acute>x___unsigned >> unat \<acute>bits);;
+                 \<acute>count :== \<acute>count - \<acute>bits"
+
+(* FIXME: figure out what this should be *)
+definition clz32_invariant where
+  "clz32_invariant i s \<equiv> {s'. undefined ''clz32_invariant'' i s s'}"
+
+lemma clz32_step:
+  "\<Gamma> \<turnstile> (clz32_invariant (i+1) s) clz32_step i (clz32_invariant i s)"
+  unfolding clz32_step_def
+  apply (vcg, clarsimp simp: clz32_invariant_def)
+  sorry
+
+lemma clz32_spec:
+  "\<forall>s. \<Gamma> \<turnstile> {s} Call clz32_'proc \<lbrace>\<acute>ret__unsigned = of_nat (word_clz (x___unsigned_' s))\<rbrace>"
+  apply (hoare_rule HoarePartial.ProcNoRec1)
+  apply (hoarep_rewrite, fold clz32_step_def)
+  apply (intro allI hoarep.Catch[OF _ hoarep.Skip])
+  apply (rule_tac Q="clz32_invariant 0 s" in hoarep_Seq_nothrow[OF _ creturn_wp])
+  apply (rule HoarePartial.SeqSwap[OF clz32_step], simp)+
+  apply (rule conseqPre, vcg)
+  apply (all \<open>clarsimp simp: clz32_invariant_def\<close>)
+  sorry
+
+definition clz64_step where
+  "clz64_step i \<equiv> \<acute>mask___unsigned_longlong :== \<acute>mask___unsigned_longlong >> unat ((1::32 sword) << unat i);;
+                   \<acute>bits :== SCAST(32 signed \<rightarrow> 32) (if \<acute>mask___unsigned_longlong < \<acute>x___unsigned_longlong then 1 else 0) << unat i;;
+                   Guard ShiftError \<lbrace>\<acute>bits < SCAST(32 signed \<rightarrow> 32) 0x40\<rbrace> (\<acute>x___unsigned_longlong :== \<acute>x___unsigned_longlong >> unat \<acute>bits);;
+                   \<acute>count :== \<acute>count - \<acute>bits"
+
+(* FIXME: figure out what this should be *)
+definition clz64_invariant where
+  "clz64_invariant i s \<equiv> {s'. undefined ''clz64_invariant'' i s s'}"
+
+lemma clz64_step:
+  "\<Gamma> \<turnstile> (clz64_invariant (i+1) s) clz64_step i (clz64_invariant i s)"
+  unfolding clz64_step_def
+  apply (vcg, clarsimp simp: clz64_invariant_def)
+  sorry
+
+lemma clz64_spec:
+  "\<forall>s. \<Gamma> \<turnstile> {s} Call clz64_'proc \<lbrace>\<acute>ret__unsigned = of_nat (word_clz (x___unsigned_longlong_' s))\<rbrace>"
+  apply (hoare_rule HoarePartial.ProcNoRec1)
+  apply (hoarep_rewrite, fold clz64_step_def)
+  apply (intro allI hoarep.Catch[OF _ hoarep.Skip])
+  apply (rule_tac Q="clz64_invariant 0 s" in hoarep_Seq_nothrow[OF _ creturn_wp])
+  apply (rule HoarePartial.SeqSwap[OF clz64_step], simp)+
+  apply (rule conseqPre, vcg)
+  apply (all \<open>clarsimp simp: clz64_invariant_def\<close>)
+  sorry
+
+definition ctz32_step where
+  "ctz32_step i \<equiv> \<acute>mask___unsigned :== \<acute>mask___unsigned >> unat ((1::32 sword) << unat i);;
+                   \<acute>bits :== SCAST(32 signed \<rightarrow> 32) (if \<acute>x___unsigned && \<acute>mask___unsigned = SCAST(32 signed \<rightarrow> 32) 0 then 1 else 0) << unat i;;
+                   Guard ShiftError \<lbrace>\<acute>bits < SCAST(32 signed \<rightarrow> 32) 0x20\<rbrace> (\<acute>x___unsigned :== \<acute>x___unsigned >> unat \<acute>bits);;
+                   \<acute>count :== \<acute>count + \<acute>bits"
+
+(* FIXME: figure out what this should be *)
+definition ctz32_invariant where
+  "ctz32_invariant i s \<equiv> {s'. undefined ''ctz32_invariant'' i s s'}"
+
+lemma ctz32_step:
+  "\<Gamma> \<turnstile> (ctz32_invariant (i+1) s) ctz32_step i (ctz32_invariant i s)"
+  unfolding ctz32_step_def
+  apply (vcg, clarsimp simp: ctz32_invariant_def)
+  sorry
+
+lemma ctz32_spec:
+  "\<forall>s. \<Gamma> \<turnstile> {s} Call ctz32_'proc \<lbrace>\<acute>ret__unsigned = of_nat (word_ctz (x___unsigned_' s))\<rbrace>"
+  apply (hoare_rule HoarePartial.ProcNoRec1)
+  apply (hoarep_rewrite, fold ctz32_step_def)
+  apply (intro allI hoarep.Catch[OF _ hoarep.Skip])
+  apply (rule_tac Q="ctz32_invariant 0 s" in hoarep_Seq_nothrow[OF _ creturn_wp])
+  apply (rule HoarePartial.SeqSwap[OF ctz32_step], simp)+
+  apply (rule conseqPre, vcg)
+  apply (all \<open>clarsimp simp: ctz32_invariant_def\<close>)
+  sorry
+
+definition ctz64_step where
+  "ctz64_step i \<equiv> \<acute>mask___unsigned_longlong :== \<acute>mask___unsigned_longlong >> unat ((1::32 sword) << unat i);;
+                   \<acute>bits :== SCAST(32 signed \<rightarrow> 32) (if \<acute>x___unsigned_longlong && \<acute>mask___unsigned_longlong = SCAST(32 signed \<rightarrow> 64) 0 then 1 else 0) << unat i;;
+                   Guard ShiftError \<lbrace>\<acute>bits < SCAST(32 signed \<rightarrow> 32) 0x40\<rbrace> (\<acute>x___unsigned_longlong :== \<acute>x___unsigned_longlong >> unat \<acute>bits);;
+                   \<acute>count :== \<acute>count + \<acute>bits"
+
+(* FIXME: figure out what this should be *)
+definition ctz64_invariant where
+  "ctz64_invariant i s \<equiv> {s'. undefined ''ctz64_invariant'' i s s'}"
+
+lemma ctz64_step:
+  "\<Gamma> \<turnstile> (ctz64_invariant (i+1) s) ctz64_step i (ctz64_invariant i s)"
+  unfolding ctz64_step_def
+  apply (vcg, clarsimp simp: ctz64_invariant_def)
+  sorry
+
+lemma ctz64_spec:
+  "\<forall>s. \<Gamma> \<turnstile> {s} Call ctz64_'proc \<lbrace>\<acute>ret__unsigned = of_nat (word_ctz (x___unsigned_longlong_' s))\<rbrace>"
+  apply (hoare_rule HoarePartial.ProcNoRec1)
+  apply (hoarep_rewrite, fold ctz64_step_def)
+  apply (intro allI hoarep.Catch[OF _ hoarep.Skip])
+  apply (rule_tac Q="ctz64_invariant 0 s" in hoarep_Seq_nothrow[OF _ creturn_wp])
+  apply (rule HoarePartial.SeqSwap[OF ctz64_step], simp)+
+  apply (rule conseqPre, vcg)
+  apply (all \<open>clarsimp simp: ctz64_invariant_def\<close>)
+  sorry
+
+(* The library implementations would allow us to weaken the preconditions to allow zero inputs,
+   but we keep the stronger preconditions to preserve older proofs that use these specs. *)
+lemma clzl_spec:
+  "\<forall>s. \<Gamma> \<turnstile> {\<sigma>. s = \<sigma> \<and> x___unsigned_long_' s \<noteq> 0}
+   Call clzl_'proc
+   \<lbrace>\<acute>ret__long = of_nat (word_clz (x___unsigned_long_' s))\<rbrace>"
+  apply (rule allI, rule conseqPre, vcg)
+  by (clarsimp simp: casts_of_nat_small[OF word_clz_max[THEN le_less_trans]] word_size)
+
+lemma ctzl_spec:
+  "\<forall>s. \<Gamma> \<turnstile> {\<sigma>. s = \<sigma> \<and> x___unsigned_long_' s \<noteq> 0}
+   Call ctzl_'proc
+   \<lbrace>\<acute>ret__long = of_nat (word_ctz (x___unsigned_long_' s))\<rbrace>"
+  apply (rule allI, rule conseqPre, vcg)
+  by (clarsimp simp: casts_of_nat_small[OF word_ctz_max[THEN le_less_trans]] word_size)
+
+end
 end

--- a/proof/crefine/RISCV64/Machine_C.thy
+++ b/proof/crefine/RISCV64/Machine_C.thy
@@ -132,12 +132,13 @@ lemma dmo_if:
 
 (* Count leading and trailing zeros. *)
 
-(* FIXME: move *)
+(* FIXME BV: move *)
 lemma word_ctz_max:
   "word_ctz w \<le> size w"
-  sorry
+  unfolding word_ctz_def
+  by (rule order_trans[OF List.length_takeWhile_le], clarsimp simp: word_size)
 
-(* FIXME move *)
+(* FIXME BV: move *)
 lemma scast_of_nat_small:
   "x < 2 ^ (LENGTH('a) - 1) \<Longrightarrow> scast (of_nat x :: 'a :: len word) = (of_nat x :: 'b :: len word)"
   apply (rule sym, subst word_unat.inverse_norm)
@@ -146,10 +147,10 @@ lemma scast_of_nat_small:
   apply (simp add: int_eq_sint unat_of_nat)
   done
 
-(* FIXME move *)
+(* FIXME BV: move *)
 lemmas casts_of_nat_small = ucast_of_nat_small scast_of_nat_small
 
-(* FIXME: move *)
+(* FIXME BV: move *)
 lemma hoarep_Seq_nothrow:
   assumes c: "hoarep \<Gamma> \<Theta> F P c Q {}"
   assumes d: "hoarep \<Gamma> \<Theta> F Q d R A"
@@ -162,15 +163,146 @@ definition clz32_step where
                  Guard ShiftError \<lbrace>\<acute>bits < SCAST(32 signed \<rightarrow> 32) 0x20\<rbrace> (\<acute>x___unsigned :== \<acute>x___unsigned >> unat \<acute>bits);;
                  \<acute>count :== \<acute>count - \<acute>bits"
 
-(* FIXME: figure out what this should be *)
 definition clz32_invariant where
-  "clz32_invariant i s \<equiv> {s'. undefined ''clz32_invariant'' i s s'}"
+  "clz32_invariant i s \<equiv> {s'.
+   mask___unsigned_' s' \<ge> x___unsigned_' s'
+   \<and> of_nat (word_clz (x___unsigned_' s')) + count_' s' = of_nat (word_clz (x___unsigned_' s)) + 32
+   \<and> mask___unsigned_' s' = mask (2 ^ unat i)}"
+
+\<comment>\<open> This function returns an expression stating that "if xs contains an element satisfying P, then
+    the nth element of xs is the *first* that satisfies P". \<close>
+definition first_in_list where
+  "first_in_list P n xs \<equiv> (\<forall>i. i < n \<longrightarrow> i < length xs \<longrightarrow> \<not> P (xs ! i)) \<and>
+                           (n < length xs \<longrightarrow> P (xs ! n))"
+
+\<comment>\<open> There is always some n at which P (x ! n) or P contains no such element \<close>
+lemma first_in_list_exists:
+  "\<exists>n. first_in_list P n xs"
+  apply (induction xs; simp add: first_in_list_def)
+  apply (erule exE)
+  apply (case_tac "P x1")
+   apply (rule_tac x=0 in exI, simp)
+  apply (rule_tac x="Suc n" in exI, clarsimp)
+  apply (case_tac i; simp)
+  done
+
+\<comment>\<open> If you know where P first fails to be true, then you know how to compute takeWhile with take. \<close>
+lemma takeWhile_take_equiv:
+  "first_in_list (not P) n xs \<Longrightarrow> takeWhile P xs = take n xs"
+  apply (rule takeWhile_eq_take_P_nth)
+  apply (clarsimp simp: first_in_list_def pred_neg_def)
+  apply (clarsimp simp: first_in_list_def pred_neg_def)
+  done
+
+\<comment>\<open> If you know that P fails to be true early enough, then truncating the input does not effect the
+    output of takeWhile. \<close>
+lemma takeWhile_truncate:
+  "length (takeWhile P xs) \<le> m
+  \<Longrightarrow> takeWhile P (take m xs) = takeWhile P xs"
+  apply (subgoal_tac "\<exists>n. first_in_list (not P) n xs")
+   apply (clarsimp)
+   apply (case_tac "n \<le> m")
+    apply (subgoal_tac "first_in_list (not P) n (take m xs)")
+     apply (drule takeWhile_take_equiv, simp)
+     apply (drule takeWhile_take_equiv, simp)
+    apply (clarsimp simp: first_in_list_def)
+   apply (subst (asm) takeWhile_take_equiv, assumption)
+   apply (clarsimp simp: first_in_list_def pred_neg_def)
+  apply (rule first_in_list_exists)
+  done
+
+lemma word_clz_shiftr_1:
+  fixes z::"'a::len word"
+  assumes wordsize: "1 < LENGTH('a)"
+  shows "z \<noteq> 0 \<Longrightarrow> word_clz (z >> 1) = word_clz z + 1"
+  supply word_size [simp]
+  apply (clarsimp simp: word_clz_def)
+  using wordsize apply (subst bl_shiftr, simp)
+  apply (subst takeWhile_append2; simp add: wordsize)
+  apply (subst takeWhile_truncate)
+  using word_clz_nonzero_max[where w=z]
+  apply (clarsimp simp: word_clz_def)
+  apply simp+
+  done
+
+(* FIXME BV: generalise and move *)
+lemma word_clz_1[simp]:
+  "word_clz (1::32 word) = 31"
+  "word_clz (1::64 word) = 63"
+  by (clarsimp simp: word_clz_def to_bl_def)+
+
+lemma shiftr_Suc:
+  fixes x::"'a::len word"
+  shows "x >> (Suc n) = x >> n >> 1"
+  by (clarsimp simp: shiftr_shiftr)
+
+lemma shiftl_Suc:
+  fixes x::"'a::len word"
+  shows "x << (Suc n) = x << n << 1"
+  by (clarsimp simp: shiftl_shiftl)
+
+lemma word_clz_shiftr:
+  fixes z::"'a::len word"
+  shows "n < LENGTH('a) \<Longrightarrow> z >> n \<noteq> 0 \<Longrightarrow> word_clz (z >> n) = word_clz z + n"
+  apply (induction n; simp)
+  apply (subgoal_tac "0 \<noteq> z >> n")
+  apply (subst shiftr_Suc)
+  apply (subst word_clz_shiftr_1; simp)
+  apply (clarsimp simp: word_less_nat_alt shiftr_div_2n' div_mult2_eq)
+  apply (case_tac "unat z div 2 ^ n = 0"; simp)
+  apply (clarsimp simp: div_eq_0_iff)
+  done
+
+lemma word_clz_shiftr':
+  fixes z::"'a::len word"
+  shows "n < LENGTH('a) \<Longrightarrow> z > mask n \<Longrightarrow> word_clz (z >> n) = word_clz z + n"
+  apply (erule word_clz_shiftr)
+  apply (clarsimp simp: mask_def)
+  apply (clarsimp simp: word_less_nat_alt word_le_nat_alt shiftr_div_2n' div_mult2_eq)
+  apply (case_tac "unat z div 2 ^ n = 0"; simp)
+  apply (clarsimp simp: div_eq_0_iff)
+  done
 
 lemma clz32_step:
-  "\<Gamma> \<turnstile> (clz32_invariant (i+1) s) clz32_step i (clz32_invariant i s)"
+  "unat (i :: 32 sword) < 5 \<Longrightarrow>
+   \<Gamma> \<turnstile> (clz32_invariant (i+1) s) clz32_step i (clz32_invariant i s)"
   unfolding clz32_step_def
   apply (vcg, clarsimp simp: clz32_invariant_def)
-  sorry
+  \<comment> \<open>Introduce some trivial but useful facts so that most later goals are solved with simp\<close>
+  apply (prop_tac "i \<noteq> -1", clarsimp simp: unat_minus_one_word)
+  apply (frule unat_Suc2)
+  apply (prop_tac "(2 :: nat) ^ unat i < (32 :: nat)",
+         clarsimp simp: power_strict_increasing_iff[where b=2 and y=5, simplified])
+  apply (prop_tac "(2 :: nat) ^ unat (i + 1) \<le> (32 :: nat)",
+         clarsimp simp: unat_Suc2 power_increasing_iff[where b=2 and y=4, simplified])
+  apply (intro conjI impI; clarsimp)
+       apply (clarsimp simp: word_less_nat_alt)
+      apply (erule le_shiftr)
+     apply (clarsimp simp: word_size shiftr_mask2 word_clz_shiftr')
+    apply (clarsimp simp: shiftr_mask2)
+   apply fastforce
+  apply (clarsimp simp: shiftr_mask2)
+  done
+
+(* FIXME BV: generalise this? *)
+lemma word32_le_1:
+  "(a :: 32 word) \<le> 1 = (a = 0 \<or> a = 1)"
+  apply (word_bitwise)
+  by fastforce
+
+lemma word64_le_1:
+  "(a :: 64 word) \<le> 1 = (a = 0 \<or> a = 1)"
+  apply (word_bitwise)
+  by fastforce
+
+(* FIXME BV: move *)
+lemma max_word_max32:
+  "(a :: 32 word) \<le> 0xFFFFFFFF"
+  by (word_bitwise)
+
+lemma max_word_max64:
+  "(a :: 64 word) \<le> 0xFFFFFFFFFFFFFFFF"
+  by (word_bitwise)
 
 lemma clz32_spec:
   "\<forall>s. \<Gamma> \<turnstile> {s} Call clz32_'proc \<lbrace>\<acute>ret__unsigned = of_nat (word_clz (x___unsigned_' s))\<rbrace>"
@@ -178,10 +310,10 @@ lemma clz32_spec:
   apply (hoarep_rewrite, fold clz32_step_def)
   apply (intro allI hoarep.Catch[OF _ hoarep.Skip])
   apply (rule_tac Q="clz32_invariant 0 s" in hoarep_Seq_nothrow[OF _ creturn_wp])
-  apply (rule HoarePartial.SeqSwap[OF clz32_step], simp)+
-  apply (rule conseqPre, vcg)
-  apply (all \<open>clarsimp simp: clz32_invariant_def\<close>)
-  sorry
+   apply (rule HoarePartial.SeqSwap[OF clz32_step], simp, simp)+
+   apply (rule conseqPre, vcg)
+   apply (all \<open>clarsimp simp: clz32_invariant_def mask_def max_word_max32\<close>)
+  by (fastforce simp: word32_le_1)
 
 definition clz64_step where
   "clz64_step i \<equiv> \<acute>mask___unsigned_longlong :== \<acute>mask___unsigned_longlong >> unat ((1::32 sword) << unat i);;
@@ -189,15 +321,39 @@ definition clz64_step where
                    Guard ShiftError \<lbrace>\<acute>bits < SCAST(32 signed \<rightarrow> 32) 0x40\<rbrace> (\<acute>x___unsigned_longlong :== \<acute>x___unsigned_longlong >> unat \<acute>bits);;
                    \<acute>count :== \<acute>count - \<acute>bits"
 
-(* FIXME: figure out what this should be *)
 definition clz64_invariant where
-  "clz64_invariant i s \<equiv> {s'. undefined ''clz64_invariant'' i s s'}"
+  "clz64_invariant i s \<equiv> {s'.
+   mask___unsigned_longlong_' s' \<ge> x___unsigned_longlong_' s'
+   \<and> of_nat (word_clz (x___unsigned_longlong_' s')) + count_' s' = of_nat (word_clz (x___unsigned_longlong_' s)) + 64
+   \<and> mask___unsigned_longlong_' s' = mask (2 ^ unat i)}"
 
 lemma clz64_step:
-  "\<Gamma> \<turnstile> (clz64_invariant (i+1) s) clz64_step i (clz64_invariant i s)"
+  "unat (i :: 32 sword) < 6 \<Longrightarrow>
+   \<Gamma> \<turnstile> (clz64_invariant (i+1) s) clz64_step i (clz64_invariant i s)"
   unfolding clz64_step_def
   apply (vcg, clarsimp simp: clz64_invariant_def)
-  sorry
+  \<comment> \<open>Introduce some trivial but useful facts so that most later goals are solved with simp\<close>
+  apply (prop_tac "i \<noteq> -1", clarsimp simp: unat_minus_one_word)
+  apply (frule unat_Suc2)
+  apply (prop_tac "(2 :: nat) ^ unat i < (64 :: nat)",
+         clarsimp simp: power_strict_increasing_iff[where b=2 and y=6, simplified])
+  apply (prop_tac "(2 :: nat) ^ unat (i + 1) \<le> (64 :: nat)",
+         clarsimp simp: unat_Suc2 power_increasing_iff[where b=2 and y=5, simplified])
+  apply (intro conjI impI; clarsimp)
+       apply (clarsimp simp: word_less_nat_alt)
+      apply (erule le_shiftr)
+     apply (clarsimp simp: word_size shiftr_mask2 word_clz_shiftr')
+    apply (clarsimp simp: shiftr_mask2)
+   apply fastforce
+  apply (clarsimp simp: shiftr_mask2)
+  done
+
+lemma word_clz_not_minus_1:
+  "of_nat (word_clz (w :: 64 word)) \<noteq> (max_word :: 32 word)"
+  unfolding not_max_word_iff_less
+  apply (rule word_of_nat_less)
+  apply (rule le_less_trans[OF word_clz_max[where w=w]])
+  by (simp add: word_size max_word_def)
 
 lemma clz64_spec:
   "\<forall>s. \<Gamma> \<turnstile> {s} Call clz64_'proc \<lbrace>\<acute>ret__unsigned = of_nat (word_clz (x___unsigned_longlong_' s))\<rbrace>"
@@ -205,10 +361,120 @@ lemma clz64_spec:
   apply (hoarep_rewrite, fold clz64_step_def)
   apply (intro allI hoarep.Catch[OF _ hoarep.Skip])
   apply (rule_tac Q="clz64_invariant 0 s" in hoarep_Seq_nothrow[OF _ creturn_wp])
-  apply (rule HoarePartial.SeqSwap[OF clz64_step], simp)+
-  apply (rule conseqPre, vcg)
-  apply (all \<open>clarsimp simp: clz64_invariant_def\<close>)
-  sorry
+   apply (rule HoarePartial.SeqSwap[OF clz64_step], simp, simp)+
+   apply (rule conseqPre, vcg)
+   apply (all \<open>clarsimp simp: clz64_invariant_def mask_def max_word_max64\<close>)
+  apply (clarsimp simp: word64_le_1)
+  apply (erule disjE; clarsimp)
+  apply (subst add.commute)
+  apply (subst ucast_increment[symmetric])
+   apply (rule word_clz_not_minus_1)
+  apply (clarsimp)
+  done
+
+lemma word_ctz_bound_below_helper:
+  fixes x :: "'a::len word"
+  assumes sz: "n \<le> LENGTH('a)"
+  shows "x && mask n = 0
+   \<Longrightarrow> to_bl x = (take (LENGTH('a) - n) (to_bl x) @ replicate n False)"
+  apply (subgoal_tac "replicate n False = drop (LENGTH('a) - n) (to_bl x)")
+   apply (subgoal_tac "True \<notin> set (drop (LENGTH('a) - n) (to_bl x))")
+    apply (drule list_of_false, clarsimp simp: sz)
+   apply (drule_tac sym[where t="drop n x" for n x], clarsimp)
+  apply (rule sym)
+  apply (rule is_aligned_drop; clarsimp simp: is_aligned_mask sz)
+  done
+
+lemma word_ctz_bound_below:
+  fixes x :: "'a::len word"
+  assumes sz[simp]: "n \<le> LENGTH('a)"
+  shows "x && mask n = 0 \<Longrightarrow> n \<le> word_ctz x"
+  apply (clarsimp simp: word_ctz_def)
+  apply (subst word_ctz_bound_below_helper[OF sz]; simp)
+  apply (subst takeWhile_append2; clarsimp)
+  done
+
+lemma mask_to_bl_exists_True:
+  "x && mask n \<noteq> 0 \<Longrightarrow> \<exists>m. (rev (to_bl x)) ! m \<and> m < n"
+  apply (subgoal_tac "\<not>(\<forall>m. m < n \<longrightarrow> \<not>(rev (to_bl x)) ! m)", fastforce)
+  apply (intro notI)
+  apply (subgoal_tac "x && mask n = 0", clarsimp)
+  apply (clarsimp simp: eq_zero_set_bl in_set_conv_nth)
+  apply (subst (asm) to_bl_nth, clarsimp simp: word_size)
+  apply (clarsimp simp: and_bang word_size)
+  apply (drule_tac x="LENGTH('a) - Suc i" in spec, simp)
+  apply (subst (asm) rev_nth, simp)
+  apply (subst (asm) to_bl_nth; clarsimp simp: word_size)
+  done
+
+lemma word_ctz_bound_above:
+  fixes x :: "'a::len word"
+  assumes sz: "n \<le> LENGTH('a)"
+  shows "x && mask n \<noteq> 0 \<Longrightarrow> word_ctz x < n"
+  apply (frule mask_to_bl_exists_True, clarsimp)
+  apply (clarsimp simp: word_ctz_def)
+  apply (subgoal_tac "m < length ((rev (to_bl x)))")
+  apply (subst id_take_nth_drop[where xs="rev (to_bl x)"], assumption)
+  apply (subst takeWhile_tail, simp)
+  apply (rule order.strict_trans1)
+  apply (rule List.length_takeWhile_le)
+  apply (simp add: length_take)
+  apply (erule order.strict_trans2, clarsimp simp: sz)
+  done
+
+lemma word_ctz_shiftr_1:
+  fixes z::"'a::len word"
+  assumes wordsize: "1 < LENGTH('a)"
+  shows "z \<noteq> 0 \<Longrightarrow> 1 \<le> word_ctz z \<Longrightarrow> word_ctz (z >> 1) = word_ctz z - 1"
+  supply word_size [simp]
+  apply (clarsimp simp: word_ctz_def)
+  using wordsize apply (subst bl_shiftr, simp)
+  apply (simp add: rev_take )
+   apply (subgoal_tac
+ "length (takeWhile Not (rev (to_bl z))) - Suc 0 = length (takeWhile Not (take 1 (rev (to_bl z)) @
+    drop 1 (rev (to_bl z)))) - Suc 0")
+   apply (subst (asm) takeWhile_append2)
+    apply clarsimp
+    apply (case_tac "rev (to_bl z)"; simp)
+   apply clarsimp
+   apply (subgoal_tac "\<exists>m. (rev (to_bl z)) ! m \<and> m < LENGTH('a)", clarsimp)
+    apply (case_tac m)
+     apply (case_tac "rev (to_bl z)"; simp)
+    apply (subst takeWhile_append1, subst in_set_conv_nth)
+      apply (rule_tac x=nat in exI)
+      apply (intro conjI)
+       apply (clarsimp simp: length_drop wordsize)
+       using wordsize
+       apply linarith
+      apply (rule refl, clarsimp)
+    apply simp
+   apply (rule mask_to_bl_exists_True, simp)
+  apply simp
+  done
+
+lemma word_ctz_shiftr:
+  fixes z::"'a::len word"
+  assumes nz: "z \<noteq> 0"
+  shows "n < LENGTH('a) \<Longrightarrow> n \<le> word_ctz z \<Longrightarrow> word_ctz (z >> n) = word_ctz z - n"
+  apply (induction n; simp)
+  apply (subst shiftr_Suc)
+  apply (subst word_ctz_shiftr_1, simp)
+    apply (clarsimp simp del: word_neq_0_conv)
+    apply (subgoal_tac "word_ctz z < n", clarsimp)
+    apply (rule word_ctz_bound_above, clarsimp simp: word_size)
+    apply (subst (asm) and_mask_eq_iff_shiftr_0[symmetric], clarsimp simp: nz)
+   apply (rule word_ctz_bound_below, clarsimp simp: word_size)
+   apply (rule mask_zero)
+   apply (rule is_aligned_shiftr, simp add: is_aligned_mask)
+   apply (case_tac "z && mask (Suc n) = 0", simp)
+   apply (frule word_ctz_bound_above[rotated]; clarsimp simp: word_size)
+   apply simp
+  done
+
+lemma word_ctz_0[simp]:
+  "word_ctz (0::32 word) = 32"
+  "word_ctz (0::64 word) = 64"
+  by (clarsimp simp: word_ctz_def to_bl_def)+
 
 definition ctz32_step where
   "ctz32_step i \<equiv> \<acute>mask___unsigned :== \<acute>mask___unsigned >> unat ((1::32 sword) << unat i);;
@@ -216,26 +482,79 @@ definition ctz32_step where
                    Guard ShiftError \<lbrace>\<acute>bits < SCAST(32 signed \<rightarrow> 32) 0x20\<rbrace> (\<acute>x___unsigned :== \<acute>x___unsigned >> unat \<acute>bits);;
                    \<acute>count :== \<acute>count + \<acute>bits"
 
-(* FIXME: figure out what this should be *)
 definition ctz32_invariant where
-  "ctz32_invariant i s \<equiv> {s'. undefined ''ctz32_invariant'' i s s'}"
+  "ctz32_invariant (i :: 32 sword) s \<equiv> {s'.
+     (x___unsigned_' s' \<noteq> 0 \<longrightarrow> (of_nat (word_ctz (x___unsigned_' s')) + count_' s' = of_nat (word_ctz (x___unsigned_' s))
+   \<and> (word_ctz (x___unsigned_' s') < 2 ^ unat i)))
+   \<and> (x___unsigned_' s' = 0 \<longrightarrow> (count_' s' + (0x1 << (unat i)) = 33 \<and> x___unsigned_' s = 0))
+   \<and> mask___unsigned_' s' = mask (2 ^ unat i)}"
+
+lemma mask_shiftr_zero:
+  "\<lbrakk>x && mask a = 0;  x >> a = 0\<rbrakk> \<Longrightarrow> x = 0"
+  by (simp add: and_mask_eq_iff_shiftr_0[symmetric])
+
+lemma word_ctz_32:
+  "word_ctz (x :: 32 word) = 32 \<Longrightarrow> x = 0"
+  apply (clarsimp simp: word_ctz_def)
+  apply (word_bitwise)
+  by (auto split: if_splits)
 
 lemma ctz32_step:
-  "\<Gamma> \<turnstile> (ctz32_invariant (i+1) s) ctz32_step i (ctz32_invariant i s)"
+  "unat (i :: 32 sword) < 5 \<Longrightarrow>
+   \<Gamma> \<turnstile> (ctz32_invariant (i+1) s) ctz32_step i (ctz32_invariant i s)"
+  supply word_neq_0_conv [simp del]
   unfolding ctz32_step_def
   apply (vcg, clarsimp simp: ctz32_invariant_def)
-  sorry
+  apply (prop_tac "i \<noteq> -1", clarsimp simp: unat_minus_one_word)
+  apply (frule unat_Suc2)
+  apply (prop_tac "(2 :: nat) ^ unat i < (32 :: nat)",
+         clarsimp simp: power_strict_increasing_iff[where b=2 and y=5, simplified])
+  apply (prop_tac "(2 :: nat) ^ unat (i + 1) \<le> (32 :: nat)",
+         clarsimp simp: unat_Suc2 power_increasing_iff[where b=2 and y=4, simplified])
+  apply (intro conjI; intro impI)
+   apply (intro conjI)
+      apply (clarsimp simp: word_less_nat_alt)
+     apply (intro impI)
+     apply (subgoal_tac "x___unsigned_' x \<noteq> 0")
+      apply (intro conjI, clarsimp)
+       apply (subst word_ctz_shiftr, clarsimp, clarsimp)
+        apply (rule word_ctz_bound_below, clarsimp simp: shiftr_mask2)
+        apply (clarsimp simp: shiftr_mask2 is_aligned_mask[symmetric])
+       apply (subst of_nat_diff)
+        apply (rule word_ctz_bound_below, clarsimp simp: shiftr_mask2)
+        apply (clarsimp simp: shiftr_mask2)
+     apply fastforce
+      apply (subst word_ctz_shiftr, clarsimp, clarsimp)
+       apply (rule word_ctz_bound_below, clarsimp simp: shiftr_mask2)
+       apply (clarsimp simp: shiftr_mask2 is_aligned_mask[symmetric])
+      apply (fastforce elim: is_aligned_weaken)
+     apply fastforce
+    apply (intro impI conjI; clarsimp simp: shiftr_mask2)
+     apply (subgoal_tac "x___unsigned_' x = 0", clarsimp)
+      apply (subst add.commute, simp)
+     apply (fastforce simp: shiftr_mask2 word_neq_0_conv elim: mask_shiftr_zero)
+    apply (frule (1) mask_shiftr_zero, simp)
+   apply (clarsimp simp: shiftr_mask2)
+  by (fastforce simp: shiftr_mask2 intro: word_ctz_bound_above)
 
 lemma ctz32_spec:
   "\<forall>s. \<Gamma> \<turnstile> {s} Call ctz32_'proc \<lbrace>\<acute>ret__unsigned = of_nat (word_ctz (x___unsigned_' s))\<rbrace>"
+  supply word_neq_0_conv [simp del]
   apply (hoare_rule HoarePartial.ProcNoRec1)
   apply (hoarep_rewrite, fold ctz32_step_def)
   apply (intro allI hoarep.Catch[OF _ hoarep.Skip])
   apply (rule_tac Q="ctz32_invariant 0 s" in hoarep_Seq_nothrow[OF _ creturn_wp])
-  apply (rule HoarePartial.SeqSwap[OF ctz32_step], simp)+
-  apply (rule conseqPre, vcg)
-  apply (all \<open>clarsimp simp: ctz32_invariant_def\<close>)
-  sorry
+   apply (rule HoarePartial.SeqSwap[OF ctz32_step], simp, simp)+
+   apply (rule conseqPre, vcg)
+   apply (clarsimp simp: ctz32_invariant_def)
+   apply (clarsimp simp: mask_def)
+   apply (subgoal_tac "word_ctz (x___unsigned_' s) \<le> size (x___unsigned_' s)")
+    apply (clarsimp simp: word_size)
+  using word_ctz_32 apply force
+   apply (rule word_ctz_max)
+  apply (clarsimp simp: ctz32_invariant_def)
+  apply (case_tac "x___unsigned_' x = 0"; clarsimp)
+  done
 
 definition ctz64_step where
   "ctz64_step i \<equiv> \<acute>mask___unsigned_longlong :== \<acute>mask___unsigned_longlong >> unat ((1::32 sword) << unat i);;
@@ -243,15 +562,61 @@ definition ctz64_step where
                    Guard ShiftError \<lbrace>\<acute>bits < SCAST(32 signed \<rightarrow> 32) 0x40\<rbrace> (\<acute>x___unsigned_longlong :== \<acute>x___unsigned_longlong >> unat \<acute>bits);;
                    \<acute>count :== \<acute>count + \<acute>bits"
 
-(* FIXME: figure out what this should be *)
 definition ctz64_invariant where
-  "ctz64_invariant i s \<equiv> {s'. undefined ''ctz64_invariant'' i s s'}"
+  "ctz64_invariant i s \<equiv> {s'.
+     (x___unsigned_longlong_' s' \<noteq> 0 \<longrightarrow> (of_nat (word_ctz (x___unsigned_longlong_' s')) + count_' s' = of_nat (word_ctz (x___unsigned_longlong_' s))
+   \<and> (word_ctz (x___unsigned_longlong_' s') < 2 ^ unat i)))
+   \<and> (x___unsigned_longlong_' s' = 0 \<longrightarrow> (count_' s' + (0x1 << (unat i)) = 65 \<and> x___unsigned_longlong_' s = 0))
+   \<and> mask___unsigned_longlong_' s' = mask (2 ^ unat i)}"
 
 lemma ctz64_step:
-  "\<Gamma> \<turnstile> (ctz64_invariant (i+1) s) ctz64_step i (ctz64_invariant i s)"
+  "unat (i :: 32 sword) < 6 \<Longrightarrow>
+   \<Gamma> \<turnstile> (ctz64_invariant (i+1) s) ctz64_step i (ctz64_invariant i s)"
+supply word_neq_0_conv [simp del]
   unfolding ctz64_step_def
   apply (vcg, clarsimp simp: ctz64_invariant_def)
-  sorry
+  apply (prop_tac "i \<noteq> -1", clarsimp simp: unat_minus_one_word)
+  apply (frule unat_Suc2)
+  apply (prop_tac "(2 :: nat) ^ unat i < (64 :: nat)",
+         clarsimp simp: power_strict_increasing_iff[where b=2 and y=6, simplified])
+  apply (prop_tac "(2 :: nat) ^ unat (i + 1) \<le> (64 :: nat)",
+         clarsimp simp: unat_Suc2 power_increasing_iff[where b=2 and y=5, simplified])
+  apply (intro conjI; intro impI)
+   apply (intro conjI)
+      apply (clarsimp simp: word_less_nat_alt)
+     apply (intro impI)
+     apply (subgoal_tac "x___unsigned_longlong_' x \<noteq> 0")
+      apply (intro conjI, clarsimp)
+       apply (subst word_ctz_shiftr, clarsimp, clarsimp)
+        apply (rule word_ctz_bound_below, clarsimp simp: shiftr_mask2)
+        apply (clarsimp simp: shiftr_mask2 is_aligned_mask[symmetric])
+       apply (subst of_nat_diff)
+        apply (rule word_ctz_bound_below, clarsimp simp: shiftr_mask2)
+        apply (clarsimp simp: shiftr_mask2)
+     apply fastforce
+      apply (subst word_ctz_shiftr, clarsimp, clarsimp)
+       apply (rule word_ctz_bound_below, clarsimp simp: shiftr_mask2)
+       apply (clarsimp simp: shiftr_mask2 is_aligned_mask[symmetric])
+      apply (fastforce elim: is_aligned_weaken)
+     apply fastforce
+    apply (intro impI conjI; clarsimp simp: shiftr_mask2)
+     apply (subgoal_tac "x___unsigned_longlong_' x = 0", clarsimp)
+      apply (subst add.commute, simp)
+     apply (fastforce simp: shiftr_mask2 word_neq_0_conv elim: mask_shiftr_zero)
+    apply (frule (1) mask_shiftr_zero, simp)
+   apply (clarsimp simp: shiftr_mask2)
+  by (fastforce simp: shiftr_mask2 intro: word_ctz_bound_above)
+
+lemma word_and_mask_word_ctz_zero:
+  assumes "l = word_ctz w"
+  shows "w && mask l = 0"
+  unfolding word_ctz_def assms
+  apply (word_eqI)
+  apply (drule takeWhile_take_has_property_nth)
+  apply (simp add: test_bit_bl)
+  done
+
+lemmas word_ctz_64 = word_and_mask_word_ctz_zero[where 'a=64 and l=64, simplified]
 
 lemma ctz64_spec:
   "\<forall>s. \<Gamma> \<turnstile> {s} Call ctz64_'proc \<lbrace>\<acute>ret__unsigned = of_nat (word_ctz (x___unsigned_longlong_' s))\<rbrace>"
@@ -259,10 +624,18 @@ lemma ctz64_spec:
   apply (hoarep_rewrite, fold ctz64_step_def)
   apply (intro allI hoarep.Catch[OF _ hoarep.Skip])
   apply (rule_tac Q="ctz64_invariant 0 s" in hoarep_Seq_nothrow[OF _ creturn_wp])
-  apply (rule HoarePartial.SeqSwap[OF ctz64_step], simp)+
-  apply (rule conseqPre, vcg)
-  apply (all \<open>clarsimp simp: ctz64_invariant_def\<close>)
-  sorry
+   apply (rule HoarePartial.SeqSwap[OF ctz64_step], simp, simp)+
+   apply (rule conseqPre, vcg)
+   apply (clarsimp simp: ctz64_invariant_def)
+   apply (clarsimp simp: mask_def)
+   apply (subgoal_tac "word_ctz (x___unsigned_longlong_' s) \<le> size (x___unsigned_longlong_' s)")
+    apply (clarsimp simp: word_size)
+    apply (erule le_neq_trans, clarsimp)
+  using word_ctz_64 apply force
+   apply (rule word_ctz_max)
+  apply (clarsimp simp: ctz64_invariant_def)
+  apply (case_tac "x___unsigned_longlong_' x = 0"; clarsimp)
+  done
 
 (* The library implementations would allow us to weaken the preconditions to allow zero inputs,
    but we keep the stronger preconditions to preserve older proofs that use these specs. *)

--- a/proof/crefine/RISCV64/Machine_C.thy
+++ b/proof/crefine/RISCV64/Machine_C.thy
@@ -132,31 +132,6 @@ lemma dmo_if:
 
 (* Count leading and trailing zeros. *)
 
-(* FIXME BV: move *)
-lemma word_ctz_max:
-  "word_ctz w \<le> size w"
-  unfolding word_ctz_def
-  by (rule order_trans[OF List.length_takeWhile_le], clarsimp simp: word_size)
-
-(* FIXME BV: move *)
-lemma scast_of_nat_small:
-  "x < 2 ^ (LENGTH('a) - 1) \<Longrightarrow> scast (of_nat x :: 'a :: len word) = (of_nat x :: 'b :: len word)"
-  apply (rule sym, subst word_unat.inverse_norm)
-  apply (simp add: scast_def word_of_int[symmetric]
-                   of_nat_nat[symmetric] unat_def[symmetric])
-  apply (simp add: int_eq_sint unat_of_nat)
-  done
-
-(* FIXME BV: move *)
-lemmas casts_of_nat_small = ucast_of_nat_small scast_of_nat_small
-
-(* FIXME BV: move *)
-lemma hoarep_Seq_nothrow:
-  assumes c: "hoarep \<Gamma> \<Theta> F P c Q {}"
-  assumes d: "hoarep \<Gamma> \<Theta> F Q d R A"
-  shows "hoarep \<Gamma> \<Theta> F P (Seq c d) R A"
-  by (rule hoarep.Seq[OF HoarePartialDef.conseqPrePost[OF c] d]; simp)
-
 definition clz32_step where
   "clz32_step i \<equiv> \<acute>mask___unsigned :== \<acute>mask___unsigned >> unat ((1::32 sword) << unat i);;
                  \<acute>bits :== SCAST(32 signed \<rightarrow> 32) (if \<acute>mask___unsigned < \<acute>x___unsigned then 1 else 0) << unat i;;
@@ -168,100 +143,6 @@ definition clz32_invariant where
    mask___unsigned_' s' \<ge> x___unsigned_' s'
    \<and> of_nat (word_clz (x___unsigned_' s')) + count_' s' = of_nat (word_clz (x___unsigned_' s)) + 32
    \<and> mask___unsigned_' s' = mask (2 ^ unat i)}"
-
-\<comment>\<open> This function returns an expression stating that "if xs contains an element satisfying P, then
-    the nth element of xs is the *first* that satisfies P". \<close>
-definition first_in_list where
-  "first_in_list P n xs \<equiv> (\<forall>i. i < n \<longrightarrow> i < length xs \<longrightarrow> \<not> P (xs ! i)) \<and>
-                           (n < length xs \<longrightarrow> P (xs ! n))"
-
-\<comment>\<open> There is always some n at which P (x ! n) or P contains no such element \<close>
-lemma first_in_list_exists:
-  "\<exists>n. first_in_list P n xs"
-  apply (induction xs; simp add: first_in_list_def)
-  apply (erule exE)
-  apply (case_tac "P x1")
-   apply (rule_tac x=0 in exI, simp)
-  apply (rule_tac x="Suc n" in exI, clarsimp)
-  apply (case_tac i; simp)
-  done
-
-\<comment>\<open> If you know where P first fails to be true, then you know how to compute takeWhile with take. \<close>
-lemma takeWhile_take_equiv:
-  "first_in_list (not P) n xs \<Longrightarrow> takeWhile P xs = take n xs"
-  apply (rule takeWhile_eq_take_P_nth)
-  apply (clarsimp simp: first_in_list_def pred_neg_def)
-  apply (clarsimp simp: first_in_list_def pred_neg_def)
-  done
-
-\<comment>\<open> If you know that P fails to be true early enough, then truncating the input does not effect the
-    output of takeWhile. \<close>
-lemma takeWhile_truncate:
-  "length (takeWhile P xs) \<le> m
-  \<Longrightarrow> takeWhile P (take m xs) = takeWhile P xs"
-  apply (subgoal_tac "\<exists>n. first_in_list (not P) n xs")
-   apply (clarsimp)
-   apply (case_tac "n \<le> m")
-    apply (subgoal_tac "first_in_list (not P) n (take m xs)")
-     apply (drule takeWhile_take_equiv, simp)
-     apply (drule takeWhile_take_equiv, simp)
-    apply (clarsimp simp: first_in_list_def)
-   apply (subst (asm) takeWhile_take_equiv, assumption)
-   apply (clarsimp simp: first_in_list_def pred_neg_def)
-  apply (rule first_in_list_exists)
-  done
-
-lemma word_clz_shiftr_1:
-  fixes z::"'a::len word"
-  assumes wordsize: "1 < LENGTH('a)"
-  shows "z \<noteq> 0 \<Longrightarrow> word_clz (z >> 1) = word_clz z + 1"
-  supply word_size [simp]
-  apply (clarsimp simp: word_clz_def)
-  using wordsize apply (subst bl_shiftr, simp)
-  apply (subst takeWhile_append2; simp add: wordsize)
-  apply (subst takeWhile_truncate)
-  using word_clz_nonzero_max[where w=z]
-  apply (clarsimp simp: word_clz_def)
-  apply simp+
-  done
-
-(* FIXME BV: generalise and move *)
-lemma word_clz_1[simp]:
-  "word_clz (1::32 word) = 31"
-  "word_clz (1::64 word) = 63"
-  by (clarsimp simp: word_clz_def to_bl_def)+
-
-lemma shiftr_Suc:
-  fixes x::"'a::len word"
-  shows "x >> (Suc n) = x >> n >> 1"
-  by (clarsimp simp: shiftr_shiftr)
-
-lemma shiftl_Suc:
-  fixes x::"'a::len word"
-  shows "x << (Suc n) = x << n << 1"
-  by (clarsimp simp: shiftl_shiftl)
-
-lemma word_clz_shiftr:
-  fixes z::"'a::len word"
-  shows "n < LENGTH('a) \<Longrightarrow> z >> n \<noteq> 0 \<Longrightarrow> word_clz (z >> n) = word_clz z + n"
-  apply (induction n; simp)
-  apply (subgoal_tac "0 \<noteq> z >> n")
-  apply (subst shiftr_Suc)
-  apply (subst word_clz_shiftr_1; simp)
-  apply (clarsimp simp: word_less_nat_alt shiftr_div_2n' div_mult2_eq)
-  apply (case_tac "unat z div 2 ^ n = 0"; simp)
-  apply (clarsimp simp: div_eq_0_iff)
-  done
-
-lemma word_clz_shiftr':
-  fixes z::"'a::len word"
-  shows "n < LENGTH('a) \<Longrightarrow> z > mask n \<Longrightarrow> word_clz (z >> n) = word_clz z + n"
-  apply (erule word_clz_shiftr)
-  apply (clarsimp simp: mask_def)
-  apply (clarsimp simp: word_less_nat_alt word_le_nat_alt shiftr_div_2n' div_mult2_eq)
-  apply (case_tac "unat z div 2 ^ n = 0"; simp)
-  apply (clarsimp simp: div_eq_0_iff)
-  done
 
 lemma clz32_step:
   "unat (i :: 32 sword) < 5 \<Longrightarrow>
@@ -278,31 +159,11 @@ lemma clz32_step:
   apply (intro conjI impI; clarsimp)
        apply (clarsimp simp: word_less_nat_alt)
       apply (erule le_shiftr)
-     apply (clarsimp simp: word_size shiftr_mask2 word_clz_shiftr')
+     apply (clarsimp simp: word_size shiftr_mask2 word_clz_shiftr)
     apply (clarsimp simp: shiftr_mask2)
    apply fastforce
   apply (clarsimp simp: shiftr_mask2)
   done
-
-(* FIXME BV: generalise this? *)
-lemma word32_le_1:
-  "(a :: 32 word) \<le> 1 = (a = 0 \<or> a = 1)"
-  apply (word_bitwise)
-  by fastforce
-
-lemma word64_le_1:
-  "(a :: 64 word) \<le> 1 = (a = 0 \<or> a = 1)"
-  apply (word_bitwise)
-  by fastforce
-
-(* FIXME BV: move *)
-lemma max_word_max32:
-  "(a :: 32 word) \<le> 0xFFFFFFFF"
-  by (word_bitwise)
-
-lemma max_word_max64:
-  "(a :: 64 word) \<le> 0xFFFFFFFFFFFFFFFF"
-  by (word_bitwise)
 
 lemma clz32_spec:
   "\<forall>s. \<Gamma> \<turnstile> {s} Call clz32_'proc \<lbrace>\<acute>ret__unsigned = of_nat (word_clz (x___unsigned_' s))\<rbrace>"
@@ -312,8 +173,8 @@ lemma clz32_spec:
   apply (rule_tac Q="clz32_invariant 0 s" in hoarep_Seq_nothrow[OF _ creturn_wp])
    apply (rule HoarePartial.SeqSwap[OF clz32_step], simp, simp)+
    apply (rule conseqPre, vcg)
-   apply (all \<open>clarsimp simp: clz32_invariant_def mask_def max_word_max32\<close>)
-  by (fastforce simp: word32_le_1)
+   apply (all \<open>clarsimp simp: clz32_invariant_def mask_def word_less_max_simp\<close>)
+  by (fastforce simp: word_le_1)
 
 definition clz64_step where
   "clz64_step i \<equiv> \<acute>mask___unsigned_longlong :== \<acute>mask___unsigned_longlong >> unat ((1::32 sword) << unat i);;
@@ -342,18 +203,11 @@ lemma clz64_step:
   apply (intro conjI impI; clarsimp)
        apply (clarsimp simp: word_less_nat_alt)
       apply (erule le_shiftr)
-     apply (clarsimp simp: word_size shiftr_mask2 word_clz_shiftr')
+     apply (clarsimp simp: word_size shiftr_mask2 word_clz_shiftr)
     apply (clarsimp simp: shiftr_mask2)
    apply fastforce
   apply (clarsimp simp: shiftr_mask2)
   done
-
-lemma word_clz_not_minus_1:
-  "of_nat (word_clz (w :: 64 word)) \<noteq> (max_word :: 32 word)"
-  unfolding not_max_word_iff_less
-  apply (rule word_of_nat_less)
-  apply (rule le_less_trans[OF word_clz_max[where w=w]])
-  by (simp add: word_size max_word_def)
 
 lemma clz64_spec:
   "\<forall>s. \<Gamma> \<turnstile> {s} Call clz64_'proc \<lbrace>\<acute>ret__unsigned = of_nat (word_clz (x___unsigned_longlong_' s))\<rbrace>"
@@ -363,118 +217,17 @@ lemma clz64_spec:
   apply (rule_tac Q="clz64_invariant 0 s" in hoarep_Seq_nothrow[OF _ creturn_wp])
    apply (rule HoarePartial.SeqSwap[OF clz64_step], simp, simp)+
    apply (rule conseqPre, vcg)
-   apply (all \<open>clarsimp simp: clz64_invariant_def mask_def max_word_max64\<close>)
-  apply (clarsimp simp: word64_le_1)
+   apply (all \<open>clarsimp simp: clz64_invariant_def mask_def word_less_max_simp\<close>)
+  apply (clarsimp simp: word_le_1)
   apply (erule disjE; clarsimp)
   apply (subst add.commute)
   apply (subst ucast_increment[symmetric])
-   apply (rule word_clz_not_minus_1)
-  apply (clarsimp)
+   apply (simp add: not_max_word_iff_less)
+   apply (rule word_of_nat_less)
+   apply (rule le_less_trans[OF word_clz_max])
+   apply (simp add: word_size max_word_def)
+  apply clarsimp
   done
-
-lemma word_ctz_bound_below_helper:
-  fixes x :: "'a::len word"
-  assumes sz: "n \<le> LENGTH('a)"
-  shows "x && mask n = 0
-   \<Longrightarrow> to_bl x = (take (LENGTH('a) - n) (to_bl x) @ replicate n False)"
-  apply (subgoal_tac "replicate n False = drop (LENGTH('a) - n) (to_bl x)")
-   apply (subgoal_tac "True \<notin> set (drop (LENGTH('a) - n) (to_bl x))")
-    apply (drule list_of_false, clarsimp simp: sz)
-   apply (drule_tac sym[where t="drop n x" for n x], clarsimp)
-  apply (rule sym)
-  apply (rule is_aligned_drop; clarsimp simp: is_aligned_mask sz)
-  done
-
-lemma word_ctz_bound_below:
-  fixes x :: "'a::len word"
-  assumes sz[simp]: "n \<le> LENGTH('a)"
-  shows "x && mask n = 0 \<Longrightarrow> n \<le> word_ctz x"
-  apply (clarsimp simp: word_ctz_def)
-  apply (subst word_ctz_bound_below_helper[OF sz]; simp)
-  apply (subst takeWhile_append2; clarsimp)
-  done
-
-lemma mask_to_bl_exists_True:
-  "x && mask n \<noteq> 0 \<Longrightarrow> \<exists>m. (rev (to_bl x)) ! m \<and> m < n"
-  apply (subgoal_tac "\<not>(\<forall>m. m < n \<longrightarrow> \<not>(rev (to_bl x)) ! m)", fastforce)
-  apply (intro notI)
-  apply (subgoal_tac "x && mask n = 0", clarsimp)
-  apply (clarsimp simp: eq_zero_set_bl in_set_conv_nth)
-  apply (subst (asm) to_bl_nth, clarsimp simp: word_size)
-  apply (clarsimp simp: and_bang word_size)
-  apply (drule_tac x="LENGTH('a) - Suc i" in spec, simp)
-  apply (subst (asm) rev_nth, simp)
-  apply (subst (asm) to_bl_nth; clarsimp simp: word_size)
-  done
-
-lemma word_ctz_bound_above:
-  fixes x :: "'a::len word"
-  assumes sz: "n \<le> LENGTH('a)"
-  shows "x && mask n \<noteq> 0 \<Longrightarrow> word_ctz x < n"
-  apply (frule mask_to_bl_exists_True, clarsimp)
-  apply (clarsimp simp: word_ctz_def)
-  apply (subgoal_tac "m < length ((rev (to_bl x)))")
-  apply (subst id_take_nth_drop[where xs="rev (to_bl x)"], assumption)
-  apply (subst takeWhile_tail, simp)
-  apply (rule order.strict_trans1)
-  apply (rule List.length_takeWhile_le)
-  apply (simp add: length_take)
-  apply (erule order.strict_trans2, clarsimp simp: sz)
-  done
-
-lemma word_ctz_shiftr_1:
-  fixes z::"'a::len word"
-  assumes wordsize: "1 < LENGTH('a)"
-  shows "z \<noteq> 0 \<Longrightarrow> 1 \<le> word_ctz z \<Longrightarrow> word_ctz (z >> 1) = word_ctz z - 1"
-  supply word_size [simp]
-  apply (clarsimp simp: word_ctz_def)
-  using wordsize apply (subst bl_shiftr, simp)
-  apply (simp add: rev_take )
-   apply (subgoal_tac
- "length (takeWhile Not (rev (to_bl z))) - Suc 0 = length (takeWhile Not (take 1 (rev (to_bl z)) @
-    drop 1 (rev (to_bl z)))) - Suc 0")
-   apply (subst (asm) takeWhile_append2)
-    apply clarsimp
-    apply (case_tac "rev (to_bl z)"; simp)
-   apply clarsimp
-   apply (subgoal_tac "\<exists>m. (rev (to_bl z)) ! m \<and> m < LENGTH('a)", clarsimp)
-    apply (case_tac m)
-     apply (case_tac "rev (to_bl z)"; simp)
-    apply (subst takeWhile_append1, subst in_set_conv_nth)
-      apply (rule_tac x=nat in exI)
-      apply (intro conjI)
-       apply (clarsimp simp: length_drop wordsize)
-       using wordsize
-       apply linarith
-      apply (rule refl, clarsimp)
-    apply simp
-   apply (rule mask_to_bl_exists_True, simp)
-  apply simp
-  done
-
-lemma word_ctz_shiftr:
-  fixes z::"'a::len word"
-  assumes nz: "z \<noteq> 0"
-  shows "n < LENGTH('a) \<Longrightarrow> n \<le> word_ctz z \<Longrightarrow> word_ctz (z >> n) = word_ctz z - n"
-  apply (induction n; simp)
-  apply (subst shiftr_Suc)
-  apply (subst word_ctz_shiftr_1, simp)
-    apply (clarsimp simp del: word_neq_0_conv)
-    apply (subgoal_tac "word_ctz z < n", clarsimp)
-    apply (rule word_ctz_bound_above, clarsimp simp: word_size)
-    apply (subst (asm) and_mask_eq_iff_shiftr_0[symmetric], clarsimp simp: nz)
-   apply (rule word_ctz_bound_below, clarsimp simp: word_size)
-   apply (rule mask_zero)
-   apply (rule is_aligned_shiftr, simp add: is_aligned_mask)
-   apply (case_tac "z && mask (Suc n) = 0", simp)
-   apply (frule word_ctz_bound_above[rotated]; clarsimp simp: word_size)
-   apply simp
-  done
-
-lemma word_ctz_0[simp]:
-  "word_ctz (0::32 word) = 32"
-  "word_ctz (0::64 word) = 64"
-  by (clarsimp simp: word_ctz_def to_bl_def)+
 
 definition ctz32_step where
   "ctz32_step i \<equiv> \<acute>mask___unsigned :== \<acute>mask___unsigned >> unat ((1::32 sword) << unat i);;
@@ -488,16 +241,6 @@ definition ctz32_invariant where
    \<and> (word_ctz (x___unsigned_' s') < 2 ^ unat i)))
    \<and> (x___unsigned_' s' = 0 \<longrightarrow> (count_' s' + (0x1 << (unat i)) = 33 \<and> x___unsigned_' s = 0))
    \<and> mask___unsigned_' s' = mask (2 ^ unat i)}"
-
-lemma mask_shiftr_zero:
-  "\<lbrakk>x && mask a = 0;  x >> a = 0\<rbrakk> \<Longrightarrow> x = 0"
-  by (simp add: and_mask_eq_iff_shiftr_0[symmetric])
-
-lemma word_ctz_32:
-  "word_ctz (x :: 32 word) = 32 \<Longrightarrow> x = 0"
-  apply (clarsimp simp: word_ctz_def)
-  apply (word_bitwise)
-  by (auto split: if_splits)
 
 lemma ctz32_step:
   "unat (i :: 32 sword) < 5 \<Longrightarrow>
@@ -523,7 +266,7 @@ lemma ctz32_step:
        apply (subst of_nat_diff)
         apply (rule word_ctz_bound_below, clarsimp simp: shiftr_mask2)
         apply (clarsimp simp: shiftr_mask2)
-     apply fastforce
+       apply fastforce
       apply (subst word_ctz_shiftr, clarsimp, clarsimp)
        apply (rule word_ctz_bound_below, clarsimp simp: shiftr_mask2)
        apply (clarsimp simp: shiftr_mask2 is_aligned_mask[symmetric])
@@ -532,8 +275,8 @@ lemma ctz32_step:
     apply (intro impI conjI; clarsimp simp: shiftr_mask2)
      apply (subgoal_tac "x___unsigned_' x = 0", clarsimp)
       apply (subst add.commute, simp)
-     apply (fastforce simp: shiftr_mask2 word_neq_0_conv elim: mask_shiftr_zero)
-    apply (frule (1) mask_shiftr_zero, simp)
+     apply (fastforce simp: shiftr_mask2 word_neq_0_conv and_mask_eq_iff_shiftr_0[symmetric])
+    apply (simp add: and_mask_eq_iff_shiftr_0[symmetric])
    apply (clarsimp simp: shiftr_mask2)
   by (fastforce simp: shiftr_mask2 intro: word_ctz_bound_above)
 
@@ -550,7 +293,7 @@ lemma ctz32_spec:
    apply (clarsimp simp: mask_def)
    apply (subgoal_tac "word_ctz (x___unsigned_' s) \<le> size (x___unsigned_' s)")
     apply (clarsimp simp: word_size)
-  using word_ctz_32 apply force
+  using word_ctz_len_word_and_mask_zero apply force
    apply (rule word_ctz_max)
   apply (clarsimp simp: ctz32_invariant_def)
   apply (case_tac "x___unsigned_' x = 0"; clarsimp)
@@ -602,21 +345,10 @@ supply word_neq_0_conv [simp del]
     apply (intro impI conjI; clarsimp simp: shiftr_mask2)
      apply (subgoal_tac "x___unsigned_longlong_' x = 0", clarsimp)
       apply (subst add.commute, simp)
-     apply (fastforce simp: shiftr_mask2 word_neq_0_conv elim: mask_shiftr_zero)
-    apply (frule (1) mask_shiftr_zero, simp)
+     apply (fastforce simp: shiftr_mask2 word_neq_0_conv and_mask_eq_iff_shiftr_0[symmetric])
+    apply (simp add: and_mask_eq_iff_shiftr_0[symmetric])
    apply (clarsimp simp: shiftr_mask2)
   by (fastforce simp: shiftr_mask2 intro: word_ctz_bound_above)
-
-lemma word_and_mask_word_ctz_zero:
-  assumes "l = word_ctz w"
-  shows "w && mask l = 0"
-  unfolding word_ctz_def assms
-  apply (word_eqI)
-  apply (drule takeWhile_take_has_property_nth)
-  apply (simp add: test_bit_bl)
-  done
-
-lemmas word_ctz_64 = word_and_mask_word_ctz_zero[where 'a=64 and l=64, simplified]
 
 lemma ctz64_spec:
   "\<forall>s. \<Gamma> \<turnstile> {s} Call ctz64_'proc \<lbrace>\<acute>ret__unsigned = of_nat (word_ctz (x___unsigned_longlong_' s))\<rbrace>"
@@ -631,7 +363,7 @@ lemma ctz64_spec:
    apply (subgoal_tac "word_ctz (x___unsigned_longlong_' s) \<le> size (x___unsigned_longlong_' s)")
     apply (clarsimp simp: word_size)
     apply (erule le_neq_trans, clarsimp)
-  using word_ctz_64 apply force
+    using word_ctz_len_word_and_mask_zero[where 'a=64] apply force
    apply (rule word_ctz_max)
   apply (clarsimp simp: ctz64_invariant_def)
   apply (case_tac "x___unsigned_longlong_' x = 0"; clarsimp)

--- a/proof/crefine/RISCV64/Syscall_C.thy
+++ b/proof/crefine/RISCV64/Syscall_C.thy
@@ -1595,16 +1595,6 @@ lemma ucast_maxIRQ_is_not_less:
   apply (erule notE)
   using ucast_up_mono by fastforce
 
-(* FIXME ARMHYP: move *)
-lemma ctzl_spec:
-  "\<forall>s. \<Gamma> \<turnstile> {\<sigma>. s = \<sigma> \<and> x_' s \<noteq> 0} Call ctzl_'proc
-       \<lbrace>\<acute>ret__long = of_nat (word_ctz (x_' s)) \<rbrace>"
-  apply (rule allI, rule conseqPre, vcg)
-  apply clarsimp
-  apply (rule_tac x="ret__long_'_update f x" for f in exI)
-  apply (simp add: mex_def meq_def)
-  done
-
 lemma ccorres_return_void_C_Seq:
   "ccorres_underlying sr \<Gamma> r rvxf arrel xf P P' hs X (return_void_C) \<Longrightarrow>
       ccorres_underlying sr \<Gamma> r rvxf arrel xf P P' hs X (return_void_C ;; Z)"

--- a/tools/c-parser/CProof.thy
+++ b/tools/c-parser/CProof.thy
@@ -439,4 +439,18 @@ lemma asm_spec_preserves:
   apply (erule (1) spec)
   done
 
+lemma hoarep_Seq:
+  assumes a: "A \<subseteq> C"
+  assumes b: "B \<subseteq> C"
+  assumes c: "hoarep \<Gamma> \<Theta> F P c Q A"
+  assumes d: "hoarep \<Gamma> \<Theta> F Q d R B"
+  shows "hoarep \<Gamma> \<Theta> F P (Seq c d) R C"
+proof -
+  note post = HoarePartialDef.conseqPost[OF _ subset_refl]
+  show ?thesis
+  by (rule hoarep.Seq[OF post[OF c a] post[OF d b]])
+qed
+
+lemmas hoarep_Seq_nothrow = hoarep_Seq[OF empty_subsetI subset_refl]
+
 end


### PR DESCRIPTION
Some architectures support count-leading-zeroes and count-trailings-zeros functions within the instruction set and others do not. This means that binary verification must treat them differently on RISCV64 than on ARM. In ARM their behaviour is axiomatized because we must make basic assumptions about the semantics of instructions. In RISCV, we must verify the C code which implements these functions. As a result, instructions to the CParser must be updated, and that creates a hole in the existing CRefine proofs for RISCV64.

This work supplies the appropriate CRefine proofs, and arch-splits the SimplExportAndRefine session so that this issue is handled appropriatelt on different architectures.