### PR TITLE
Improve `sts_invs_minor'`

### DIFF
--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -1911,7 +1911,7 @@ lemma (in delete_one_conc) suspend_invs'[wp]:
   apply (rule_tac B="\<lambda>_. ?pre and st_tcb_at' ((=) Inactive) t"
                in hoare_seq_ext[rotated])
    apply (wpsimp wp: sts_invs_minor' sts_st_tcb_at'_cases)
-   apply (fastforce simp: st_tcb_at'_def obj_at'_def)
+   apply (fastforce simp: valid_tcb_state'_def)
   apply (wpsimp wp: tcbReleaseRemove_invs' schedContextCancelYieldTo_invs')
   done
 

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -2654,9 +2654,12 @@ lemma send_signal_corres:
   apply (simp add: invs'_def valid_state'_def valid_ntfn'_def)
   done *)
 
-lemma valid_Running'[simp]:
+lemma valid_simple'[simp]:
   "valid_tcb_state' Running = \<top>"
-  by (rule ext, simp add: valid_tcb_state'_def)
+  "valid_tcb_state' Inactive = \<top>"
+  "valid_tcb_state' Restart = \<top>"
+  "valid_tcb_state' IdleThreadState = \<top>"
+  by (rule ext, simp add: valid_tcb_state'_def)+
 
 lemma possibleSwitchTo_ksQ':
   "\<lbrace>(\<lambda>s. t' \<notin> set (ksReadyQueues s p) \<and> sch_act_not t' s) and K(t' \<noteq> t)\<rbrace>
@@ -4310,8 +4313,9 @@ lemma si_invs'_helper:
               | (Some aa, False, b) \<Rightarrow> setThreadState Structures_H.thread_state.Inactive t
   \<lbrace>\<lambda>b s. invs' s \<and> tcb_at' d s \<and> ex_nonz_cap_to' d s\<rbrace>"
   apply (wpsimp wp: ex_nonz_cap_to_pres' schedContextDonate_invs' replyPush_invs' sts_invs_minor')
-  apply (subgoal_tac "st_tcb_at' (\<lambda>st'. tcb_st_refs_of' st' = {}) t s \<and> t \<noteq> ksIdleThread s")
-   apply (auto simp: invs'_def valid_state'_def pred_tcb_at'_def obj_at'_def dest: global'_no_ex_cap)
+  apply (subgoal_tac "t \<noteq> ksIdleThread s")
+   apply (auto simp: invs'_def valid_state'_def pred_tcb_at'_def obj_at'_def valid_tcb_state'_def
+               dest: global'_no_ex_cap)
   done
 
 lemma si_invs'[wp]:

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -5241,11 +5241,11 @@ lemma valid_tcb_state'_same_tcb_st_refs_of':
   by (metis pair_inject reftype.distinct prod.inject)
 
 lemma sts_invs_minor':
-  "\<lbrace>st_tcb_at' (\<lambda>st'. tcb_st_refs_of' st' = tcb_st_refs_of' st
-                   \<and> (st \<noteq> Inactive \<and> \<not> idle' st \<longrightarrow>
+  "\<lbrace>st_tcb_at' (\<lambda>st'. (st \<noteq> Inactive \<and> \<not> idle' st \<longrightarrow>
                       st' \<noteq> Inactive \<and> \<not> idle' st')) t
       and (\<lambda>s. t = ksIdleThread s \<longrightarrow> idle' st)
       and sch_act_not t
+      and valid_tcb_state' st
       and invs'\<rbrace>
    setThreadState st t
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
@@ -5254,8 +5254,6 @@ lemma sts_invs_minor':
               simp: cteCaps_of_def o_def)
   apply (intro conjI impI)
     apply clarsimp
-   apply (frule tcb_in_valid_state', clarsimp+)
-   apply (erule (1) valid_tcb_state'_same_tcb_st_refs_of')
   apply (erule if_live_then_nonz_capE')
   apply (clarsimp simp: pred_tcb_at'_def ko_wp_at'_def obj_at'_def projectKO_eq projectKO_tcb)
   done


### PR DESCRIPTION
Previously, sym_refs' was inside invs' and so setThreadState needed to be careful about modifying references coming from tcb thread states. Now that sym_refs' has been removed, it is easier to reason about how setThreadState interacts with invs'.

This is a small improvement that should make the lemma much more useable.