### PR TITLE
arm-hyp: proof updates for seL4 c381c7e14c

### DIFF
--- a/proof/crefine/ARM_HYP/Machine_C.thy
+++ b/proof/crefine/ARM_HYP/Machine_C.thy
@@ -724,21 +724,9 @@ lemma invalidateCacheRange_I_ccorres:
            (Call invalidateCacheRange_I_'proc)"
   apply (rule ccorres_gen_asm[where G=\<top>, simplified])
   apply (cinit' lift: start_' end_' pstart_')
-   apply (clarsimp simp: word_sle_def whileAnno_def)
-   apply (simp add: invalidateCacheRange_I_def)
-   apply csymbr
-   apply (rule cacheRangeOp_ccorres[simplified dc_def])
-     apply (rule empty_fail_invalidateByVA_I)
-    apply clarsimp
-    apply (cinitlift index_')
-    apply (rule ccorres_guard_imp2)
-     apply csymbr
-     apply (ctac add: invalidateByVA_I_ccorres[unfolded dc_def])
-    apply (clarsimp simp: lineStart_def cacheLineBits_def shiftr_shiftl1
-                          mask_out_sub_mask)
-    apply (drule_tac s="w1 && mask 6" in sym, simp add: cache_range_lineIndex_helper)
-   apply (vcg exspec=invalidateByVA_I_modifies)
-  apply clarsimp
+   apply (unfold invalidateCacheRange_I_def)
+   apply (ctac add: invalidate_I_PoU_ccorres)
+  apply simp
   done
 
 lemma branchFlushRange_ccorres:

--- a/proof/invariant-abstract/ARM_HYP/Machine_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/Machine_AI.thy
@@ -274,7 +274,7 @@ lemma no_fail_cleanCacheRange_RAM[simp, wp]:
 
 lemma no_fail_invalidateCacheRange_I[simp, wp]:
   "no_fail \<top> (invalidateCacheRange_I s e p)"
-  by (simp add: invalidateCacheRange_I_def, wp no_fail_invalidateByVA_I)
+  by (simp add: invalidateCacheRange_I_def, wp no_fail_invalidate_I_PoU)
 
 lemma no_fail_invalidateCacheRange_RAM[simp, wp]:
   "no_fail \<top> (invalidateCacheRange_RAM s e p)"
@@ -634,7 +634,7 @@ lemma no_irq_cleanCacheRange_RAM[simp, wp]:
 
 lemma no_irq_invalidateCacheRange_I[simp, wp]:
   "no_irq (invalidateCacheRange_I s e p)"
-  by (simp add: invalidateCacheRange_I_def, wp no_irq_invalidateByVA_I)
+  by (simp add: invalidateCacheRange_I_def, wp no_irq_invalidate_I_PoU)
 
 lemma no_irq_when:
   "\<lbrakk>P \<Longrightarrow> no_irq f\<rbrakk> \<Longrightarrow> no_irq (when P f)"
@@ -853,7 +853,7 @@ lemma empty_fail_cleanCacheRange_RAM[simp, intro!]:
 
 lemma empty_fail_invalidateCacheRange_I[simp, intro!]:
   "empty_fail (invalidateCacheRange_I s e p)"
-  by (simp add: invalidateCacheRange_I_def empty_fail_invalidateByVA_I)
+  by (simp add: invalidateCacheRange_I_def empty_fail_invalidate_I_PoU)
 
 lemma empty_fail_invalidateCacheRange_RAM[simp, intro!]:
   "empty_fail (invalidateCacheRange_RAM s e p)"

--- a/spec/machine/ARM_HYP/MachineOps.thy
+++ b/spec/machine/ARM_HYP/MachineOps.thy
@@ -441,7 +441,8 @@ where
 definition
   invalidateCacheRange_I :: "machine_word \<Rightarrow> machine_word \<Rightarrow> paddr \<Rightarrow> unit machine_monad"
 where
-  "invalidateCacheRange_I vstart vend pstart \<equiv> cacheRangeOp invalidateByVA_I vstart vend pstart"
+  "invalidateCacheRange_I vstart vend pstart \<equiv> invalidate_I_PoU"
+  (* for other than A53 and A35: "cacheRangeOp invalidateByVA_I vstart vend pstart" *)
 
 definition
   branchFlushRange :: "machine_word \<Rightarrow> machine_word \<Rightarrow> paddr \<Rightarrow> unit machine_monad"


### PR DESCRIPTION
seL4 commit seL4/seL4@c381c7e14c (PR seL4/seL4#289) changes cache flushing behaviour for the
verified ARM_HYP configuration. This commit adjusts accordingly.

