### PR TITLE
Remove setReplyTCB and getReplyTCB

### DIFF
--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -6552,7 +6552,7 @@ lemma finaliseCap2_st_tcb_at':
   apply (simp add: finaliseCap_def Let_def
                    getThreadCSpaceRoot deletingIRQHandler_def
              cong: if_cong split del: if_split)
-  apply (wpsimp wp: cancelAllIPC_st_tcb_at cancelAllSignals_st_tcb_at getReplyTCB_inv
+  apply (wpsimp wp: cancelAllIPC_st_tcb_at cancelAllSignals_st_tcb_at
                     replyClear_st_tcb_at' suspend_st_tcb_at' cteDeleteOne_st_tcb_at getCTE_wp'
                     hoare_drop_imp hoare_vcg_if_lift2 hoare_vcg_all_lift)
   done

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -155,11 +155,11 @@ lemma gts_wf''[wp]:
   apply (fastforce simp: valid_obj'_def valid_tcb'_def)
   done
 
-lemma setReplyTCB_corres:
+lemma replyTCB_update_corres:
   "corres dc (reply_at rp) (reply_at' rp)
             (set_reply_obj_ref reply_tcb_update rp new)
-            (setReplyTCB new rp)"
-  apply (simp add: update_sk_obj_ref_def setReplyTCB_def updateReply_def)
+            (updateReply rp (replyTCB_update (\<lambda>_. new)))"
+  apply (simp add: update_sk_obj_ref_def updateReply_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF _ get_reply_corres])
       apply (rule set_reply_corres)
@@ -194,7 +194,7 @@ lemma reply_unlink_tcb_corres:
    apply clarsimp
    apply (drule (1) st_tcb_at_coerce_concrete; clarsimp simp: state_relation_def)
    apply (fastforce simp: pred_tcb_at'_def obj_at'_def)
-  apply (simp add: reply_unlink_tcb_def replyUnlink_def getReplyTCB_def liftM_def)
+  apply (simp add: reply_unlink_tcb_def replyUnlink_def liftM_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF _ get_reply_corres])
       apply (rule corres_assert_gen_asm_l)
@@ -204,12 +204,12 @@ lemma reply_unlink_tcb_corres:
       apply (rule corres_split[OF _ gts_corres])
         apply (rule corres_assert_gen_asm_l)
         apply (rule corres_stateAssert_implied[where P'=\<top>, simplified])
-         apply (rule corres_split[OF _ setReplyTCB_corres])
+         apply (rule corres_split[OF _ replyTCB_update_corres])
            apply (rule sts_corres)
            apply (clarsimp simp: thread_state_relation_def)
           apply wpsimp
 
-         apply (wpsimp simp: setReplyTCB_def updateReply_def)
+         apply (wpsimp simp: updateReply_def)
         apply (fastforce simp: replyUnlink_assertion_def thread_state_relation_def)
        apply (wpsimp wp: hoare_vcg_disj_lift gts_wp get_simple_ko_wp)+
    apply (clarsimp simp: sk_obj_at_pred_def obj_at_def is_reply pred_tcb_at_def is_tcb)
@@ -245,7 +245,7 @@ lemma setEndpoint_valid_tcbs'[wp]:
 
 lemma replyUnlink_valid_tcbs'[wp]:
   "replyUnlink replyPtr tcbPtr \<lbrace>valid_tcbs'\<rbrace>"
-  apply (clarsimp simp: replyUnlink_def getReply_def setReplyTCB_def getReplyTCB_def
+  apply (clarsimp simp: replyUnlink_def getReply_def
                         updateReply_def)
   apply (wpsimp wp: set_reply'.getObject_wp set_reply'.getObject_wp gts_wp'
               simp: valid_tcb_state'_def )
@@ -1285,7 +1285,7 @@ lemma setThreadState_inQ[wp]:
 
 lemma replyUnlink_valid_inQ_queues[wp]:
   "replyUnlink replyPtr tcbPtr \<lbrace>valid_inQ_queues\<rbrace>"
-  apply (clarsimp simp: replyUnlink_def setReplyTCB_def getReplyTCB_def updateReply_def)
+  apply (clarsimp simp: replyUnlink_def updateReply_def)
   apply (wpsimp wp: set_reply'.set_wp gts_wp')
   apply (fastforce simp: valid_inQ_queues_def obj_at'_def projectKOs)
   done
@@ -1951,7 +1951,7 @@ lemmas (in delete_one_conc_pre) suspend_makes_simple' =
 
 crunches cancelSignal, replyUnlink, cleanReply
   for valid_queues[wp]: valid_queues
-  (simp: setReplyTCB_def getReplyTCB_def crunch_simps wp: crunch_wps)
+  (simp: crunch_simps wp: crunch_wps)
 
 lemma tcbFault_update_valid_queues:
   "\<lbrakk>ko_at' tcb t s; valid_queues s\<rbrakk>
@@ -2744,14 +2744,14 @@ qed
 
 lemma replyUnlink_sch_act[wp]:
   "replyUnlink r t \<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (simp only: replyUnlink_def setReplyTCB_def getReplyTCB_def liftM_def)
+  apply (simp only: replyUnlink_def liftM_def)
   apply (wpsimp wp: sts_sch_act' gts_wp')
   apply (fastforce simp: replyUnlink_assertion_def st_tcb_at'_def obj_at'_def)
   done
 
 lemma replyUnlink_list_refs_of_replies'[wp]:
   "replyUnlink r t \<lbrace>\<lambda>s. P (list_refs_of_replies' s)\<rbrace>"
-  unfolding replyUnlink_def setReplyTCB_def updateReply_def getReplyTCB_def
+  unfolding replyUnlink_def updateReply_def
   apply (wpsimp simp: updateObject_default_def setObject_def split_def wp: gts_wp')
   apply (erule arg_cong[where f=P, THEN iffD1, rotated])
   apply (rule ext)
@@ -2764,7 +2764,7 @@ lemma replyUnlink_valid_pspace'[wp]:
   "\<lbrace>\<lambda>s. valid_pspace' s\<rbrace>
    replyUnlink r t
    \<lbrace>\<lambda>_ s. valid_pspace' s\<rbrace>"
-  unfolding replyUnlink_def setReplyTCB_def updateReply_def getReplyTCB_def
+  unfolding replyUnlink_def updateReply_def
   apply (wpsimp wp: gts_wp' simp: valid_tcb_state'_def)
   apply (frule valid_pspace_valid_objs')
   apply (frule(1) reply_ko_at_valid_objs_valid_reply')
@@ -2776,7 +2776,7 @@ lemma replyUnlink_if_live_then_nonz_cap'[wp]:
   "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s\<rbrace>
    replyUnlink r t
    \<lbrace>\<lambda>_ s. if_live_then_nonz_cap' s\<rbrace>"
-  unfolding replyUnlink_def setReplyTCB_def updateReply_def getReplyTCB_def
+  unfolding replyUnlink_def updateReply_def
   apply (wpsimp wp: gts_wp')
   apply (erule if_live_then_nonz_capE')
   apply normalise_obj_at'
@@ -2787,7 +2787,7 @@ lemma replyUnlink_valid_idle'[wp]:
   "\<lbrace>\<lambda>s. valid_idle' s \<and> valid_pspace' s \<and> t \<noteq> ksIdleThread s\<rbrace>
    replyUnlink r t
    \<lbrace>\<lambda>_ s. valid_idle' s\<rbrace>"
-  unfolding replyUnlink_def setReplyTCB_def updateReply_def getReplyTCB_def
+  unfolding replyUnlink_def updateReply_def
   apply (wpsimp wp: gts_wp' simp: valid_reply'_def)
   apply (frule valid_pspace_valid_objs')
   apply (frule(1) reply_ko_at_valid_objs_valid_reply')
@@ -2797,14 +2797,14 @@ lemma replyUnlink_valid_idle'[wp]:
 
 lemma replyUnlink_valid_irq_node'[wp]:
   "replyUnlink r t \<lbrace>\<lambda> s. valid_irq_node' (irq_node' s) s\<rbrace>"
-  unfolding replyUnlink_def setReplyTCB_def getReplyTCB_def
+  unfolding replyUnlink_def
   by (wpsimp wp: valid_irq_node_lift gts_wp')
 
 lemma replyUnlink_ksQ[wp]:
   "\<lbrace>\<lambda>s. P (ksReadyQueues s p) t\<rbrace>
    replyUnlink r t
    \<lbrace>\<lambda>_ s. P (ksReadyQueues s p) t\<rbrace>"
-  unfolding replyUnlink_def setReplyTCB_def getReplyTCB_def
+  unfolding replyUnlink_def
   by (wpsimp wp: gts_wp' sts_ksQ)
 
 lemma weak_sch_act_wf_D1:
@@ -3094,7 +3094,7 @@ lemma setThreadState_valid_ep'[wp]:
 
 lemma replyUnlink_valid_ep'[wp]:
   "replyUnlink replyPtr tcbPtr \<lbrace>valid_ep' ep\<rbrace>"
-  apply (clarsimp simp: replyUnlink_def setReplyTCB_def getReplyTCB_def updateReply_def)
+  apply (clarsimp simp: replyUnlink_def updateReply_def)
   apply (wpsimp wp: set_reply'.set_wp gts_wp')
   apply (fastforce simp: valid_ep'_def obj_at'_def projectKOs objBitsKO_def split: endpoint.splits)
   done
@@ -3245,7 +3245,7 @@ lemma replyUnlink_unlive:
   "\<lbrace>ko_wp_at' (Not \<circ> live') p and sch_act_not p\<rbrace>
    replyUnlink replyPtr tcbPtr
    \<lbrace>\<lambda>_. ko_wp_at' (Not o live') p\<rbrace>"
-  apply (clarsimp simp: replyUnlink_def setReplyTCB_def getReplyTCB_def updateReply_def)
+  apply (clarsimp simp: replyUnlink_def updateReply_def)
   apply (wpsimp wp: setThreadState_Inactive_unlive set_reply'.set_wp gts_wp')
   apply (fastforce simp: ko_wp_at'_def obj_at'_def projectKOs is_aligned_def ps_clear_def
                          objBitsKO_def live'_def live_reply'_def)

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -2507,9 +2507,6 @@ interpretation threadSet: pspace_only' "threadSet f p"
   apply (fastforce dest: set_tcb'.pspace)
   done
 
-lemmas getReplyTCB_wp =
-  set_reply'.get_wp[THEN liftM_wp, where f=replyTCB, folded getReplyTCB_def]
-
 context begin interpretation Arch . (*FIXME: arch_split*)
 
 (* aliases for compatibility with master *)

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -13,33 +13,25 @@ defs replyUnlink_assertion_def:
     \<equiv> \<lambda>replyPtr state s. state = BlockedOnReply (Some replyPtr)
                           \<or> (\<exists>ep d. state = BlockedOnReceive ep d (Some replyPtr))"
 
-crunches setReplyTCB
-  for pred_tcb_at'[wp]: "\<lambda>s. P (pred_tcb_at' proj test t s)"
-  and tcb_at'[wp]: "\<lambda>s. P (tcb_at' t s)"
-  and ksReadyQueues[wp]: "\<lambda>s. P (ksReadyQueues s)"
-  and ksSchedulerAction[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-  and valid_queues[wp]: "valid_queues"
-  and reply_at'[wp]: "\<lambda>s. P (reply_at' rp s)"
-
-crunches getReplyTCB
-  for inv: "P"
+crunches updateReply
+  for tcb_at'[wp]: "\<lambda>s. P (tcb_at' t s)"
+  and st_tcb_at'[wp]: "\<lambda>s. P (st_tcb_at' P' t' s)"
+  and ksReadyQueues[wp]: "\<lambda>s. P (ksReadyQueues s p) t"
 
 lemma replyUnlink_st_tcb_at':
   "\<lbrace>\<lambda>s. tcb_at' t s \<longrightarrow> (t' = t \<longrightarrow> P (P' Inactive)) \<and> (t' \<noteq> t \<longrightarrow> P (st_tcb_at' P' t' s))\<rbrace>
     replyUnlink r t
    \<lbrace>\<lambda>rv s. P (st_tcb_at' P' t' s)\<rbrace>"
   unfolding replyUnlink_def
-  apply (wpsimp simp: getReplyTCB_def
-                  wp: sts_st_tcb_at'_cases_strong gts_wp' hoare_vcg_imp_lift
-                cong: conj_cong split: if_split_asm)
-  done
+  by (wpsimp wp: sts_st_tcb_at'_cases_strong gts_wp' hoare_vcg_imp_lift
+           cong: conj_cong split: if_split_asm)
 
 lemma replyUnlink_st_tcb_at'_sym_ref:
   "\<lbrace>\<lambda>s. reply_at' rptr s \<longrightarrow>
           obj_at' (\<lambda>reply. replyTCB reply = Some tptr) rptr s \<and> test Inactive\<rbrace>
    replyUnlink rptr tptr
    \<lbrace>\<lambda>_. st_tcb_at' test tptr\<rbrace>"
-  apply (wpsimp simp: replyUnlink_def getReplyTCB_def
+  apply (wpsimp simp: replyUnlink_def
                   wp: sts_st_tcb_at'_cases gts_wp')
   apply (fastforce simp: obj_at'_def projectKOs)
   done
@@ -86,7 +78,7 @@ lemma replyUnlink_tcb_obj_at'_no_change:
    replyUnlink rptr tptr'
    \<lbrace>\<lambda>_ s. P (obj_at' Q tptr s)\<rbrace>"
   unfolding replyUnlink_def scheduleTCB_def rescheduleRequired_def
-            setReplyTCB_def getReplyTCB_def updateReply_def
+            updateReply_def
   apply (rule hoare_gen_asm)
   apply (wpsimp wp: setThreadState_tcb_obj_at'_no_change gts_wp')
   done
@@ -117,9 +109,11 @@ lemma replyRemoveTCB_st_tcb_at'_sym_ref:
   apply (clarsimp simp: obj_at'_def pred_tcb_at'_def)
   done
 
-lemma setReplyTCB_list_refs_of_replies':
-  "setReplyTCB tcb rptr \<lbrace>\<lambda>s. P (list_refs_of_replies' s)\<rbrace>"
-  unfolding setReplyTCB_def updateReply_def
+lemma updateReply_list_refs_of_replies'_inv:
+  "\<forall>ko. replyNext_of (f ko) = replyNext_of ko \<Longrightarrow>
+   \<forall>ko. replyPrev (f ko) = replyPrev ko \<Longrightarrow>
+   updateReply rptr f \<lbrace>\<lambda>s. P (list_refs_of_replies' s)\<rbrace>"
+  unfolding updateReply_def
   apply wpsimp
   apply (erule rsubst[where P=P])
   apply (rule ext)
@@ -136,7 +130,7 @@ lemma setReply_valid_pde_mappings'[wp]:
 
 lemma replyUnlink_valid_pspace'[wp]:
   "replyUnlink rptr tptr \<lbrace>valid_pspace'\<rbrace>"
-  unfolding replyUnlink_def setReplyTCB_def getReplyTCB_def replyUnlink_assertion_def
+  unfolding replyUnlink_def replyUnlink_assertion_def
             updateReply_def
   apply (wpsimp wp: sts'_valid_pspace'_inv hoare_vcg_imp_lift'
               simp: valid_tcb_state'_def valid_pspace'_def)
@@ -149,23 +143,23 @@ lemma replyUnlink_idle'[wp]:
   "\<lbrace>valid_idle' and valid_pspace' and (\<lambda>s. tptr \<noteq> ksIdleThread s)\<rbrace>
    replyUnlink rptr tptr
    \<lbrace>\<lambda>_. valid_idle'\<rbrace>"
-  unfolding replyUnlink_def setReplyTCB_def replyUnlink_assertion_def updateReply_def
-  apply (wpsimp wp: getReplyTCB_wp hoare_vcg_imp_lift'
+  unfolding replyUnlink_def replyUnlink_assertion_def updateReply_def
+  apply (wpsimp wp: hoare_vcg_imp_lift'
               simp: pred_tcb_at'_def)
   apply normalise_obj_at'
   apply (frule(1) reply_ko_at_valid_objs_valid_reply'[OF _ valid_pspace_valid_objs'])
   apply (clarsimp simp: valid_reply'_def)
   done
 
-lemma replyUnlink_valid_queues[wp]:
-  "replyUnlink rptr tptr \<lbrace>valid_queues\<rbrace>"
-  unfolding replyUnlink_def replyUnlink_assertion_def getReplyTCB_def
-  apply (wpsimp wp: setThreadState_valid_queues' gts_wp' hoare_vcg_imp_lift')
-  done
+crunches replyUnlink
+  for valid_queues[wp]: valid_queues
+  (wp: crunch_wps)
 
-lemma setReplyTCB_replyNexts_replyPrevs[wp]:
-  "setReplyTCB tcb rptr \<lbrace>\<lambda>s. P (replyNexts_of s) (replyPrevs_of s)\<rbrace>"
-  unfolding setReplyTCB_def updateReply_def
+lemma updateReply_replyNexts_replyPrevs_inv:
+  "\<forall>ko. replyNext_of (f ko) = replyNext_of ko \<Longrightarrow>
+   \<forall>ko. replyPrev (f ko) = replyPrev ko \<Longrightarrow>
+  updateReply rptr f \<lbrace>\<lambda>s. P (replyNexts_of s) (replyPrevs_of s)\<rbrace>"
+  unfolding updateReply_def
   apply wpsimp
   apply (erule rsubst2[where P=P])
    apply (clarsimp simp: ext opt_map_def list_refs_of_reply'_def obj_at'_def projectKO_eq
@@ -234,7 +228,7 @@ crunches replyUnlink
   and ksArchState[wp]: "\<lambda>s. P (ksArchState s)"
   and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
   and sch_act_not[wp]: "sch_act_not t"
-  (wp: crunch_wps)
+  (wp: crunch_wps updateReply_list_refs_of_replies'_inv updateReply_replyNexts_replyPrevs_inv)
 
 crunches replyRemoveTCB
   for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
@@ -281,9 +275,9 @@ lemma valid_mdb'_lift:
 
 lemma replyUnlink_valid_objs'[wp]:
   "replyUnlink rptr tptr \<lbrace>valid_objs'\<rbrace>"
-  unfolding replyUnlink_def getReplyTCB_def
+  unfolding replyUnlink_def
   apply (wpsimp wp: updateReply_valid_objs'_preserved[where upd="replyTCB_update (\<lambda>_. tptrOpt)"
-                                                      for tptrOpt, folded setReplyTCB_def] gts_wp'
+                                                      for tptrOpt] gts_wp'
               simp: valid_tcb_state'_def)
   apply (clarsimp simp: valid_reply'_def)
   done
@@ -341,16 +335,25 @@ lemma updateReply_valid_pspace':
   apply (wpsimp wp: updateReply_valid_pspace'_strong)
   done
 
-lemma setReplyTCB_None_iflive'[wp]:
-  "setReplyTCB None rptr \<lbrace>if_live_then_nonz_cap'\<rbrace>"
-  unfolding setReplyTCB_def
-  apply (wpsimp wp: updateReply_iflive' simp: live_reply'_def)
+lemma updateReply_iflive'_strong:
+  "\<lbrace>if_live_then_nonz_cap' and
+    (\<lambda>s. \<forall>ko. ko_at' ko rptr s \<and> \<not> live_reply' ko \<and> live_reply' (f ko)\<longrightarrow> ex_nonz_cap_to' rptr s)\<rbrace>
+   updateReply rptr f
+   \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
+  unfolding if_live_then_nonz_cap'_def
+  apply (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift)
+    apply (wpsimp wp: updateReply_wp_all)
+   apply wpsimp
+  apply clarsimp
+  apply (drule_tac x=x in spec)
+  apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def ps_clear_def projectKO_reply)
+  apply (case_tac "x=rptr"; clarsimp)
   done
 
 lemma replyUnlink_iflive'[wp]:
   "replyUnlink rptr tptr \<lbrace>if_live_then_nonz_cap'\<rbrace>"
   unfolding replyUnlink_def
-  apply (wpsimp wp: setReplyTCB_None_iflive' gts_wp' getReplyTCB_wp)
+  apply (wpsimp wp: updateReply_iflive' gts_wp' simp: live_reply'_def)
   done
 
 lemma cleanReply_iflive'[wp]:
@@ -571,14 +574,14 @@ lemma replyUnlink_sch_act[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s \<and> sch_act_not t s\<rbrace>
    replyUnlink r t
    \<lbrace>\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (clarsimp simp: replyUnlink_def setReplyTCB_def getReplyTCB_def liftM_def)
+  apply (clarsimp simp: replyUnlink_def liftM_def)
   by (wpsimp wp: sts_sch_act' hoare_drop_imp)
 
 lemma replyUnlink_weak_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s \<and> sch_act_not t s\<rbrace>
    replyUnlink r t
    \<lbrace>\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  unfolding replyUnlink_def setReplyTCB_def getReplyTCB_def updateReply_def
+  unfolding replyUnlink_def updateReply_def
   by (wpsimp wp: hoare_vcg_imp_lift hoare_vcg_all_lift gts_wp'
            simp: weak_sch_act_wf_def)
 

--- a/spec/haskell/src/SEL4/Kernel/Thread.lhs
+++ b/spec/haskell/src/SEL4/Kernel/Thread.lhs
@@ -190,7 +190,7 @@ Replies sent by the "Reply" and "ReplyRecv" system calls can either be normal IP
 
 > doReplyTransfer :: PPtr TCB -> PPtr Reply -> Bool -> Kernel ()
 > doReplyTransfer sender reply grant = do
->     receiverOpt <- getReplyTCB reply
+>     receiverOpt <- liftM replyTCB (getReply reply)
 >     case receiverOpt of
 >         Nothing -> return ()
 >         Just receiver -> do

--- a/spec/haskell/src/SEL4/Object/ObjectType.lhs
+++ b/spec/haskell/src/SEL4/Object/ObjectType.lhs
@@ -136,7 +136,7 @@ When the last capability to an endpoint is deleted, any IPC operations currently
 >             "Assert that `sym_refs (state_refs_of' s)` holds"
 >         stateAssert (valid_replies'_sc_asrt ptr)
 >             "Assert that `valid_replies'` holds"
->         tptrOpt <- getReplyTCB ptr
+>         tptrOpt <- liftM replyTCB (getReply ptr)
 >         when (tptrOpt /= Nothing) $ do
 >             replyClear ptr (fromJust tptrOpt)
 >     return (NullCap, NullCap)

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -7,14 +7,14 @@
 This module specifies the behavior of reply objects.
 
 > module SEL4.Object.Reply (
->         replyRemove, replyPush, replyUnlink, getReply, setReply, getReplyTCB,
->         replyRemoveTCB, setReplyTCB, updateReply
+>         replyRemove, replyPush, replyUnlink, getReply, setReply,
+>         replyRemoveTCB, updateReply
 >     ) where
 
 \begin{impdetails}
 
 % {-# BOOT-IMPORTS: SEL4.Machine SEL4.Model SEL4.Object.Structures #-}
-% {-# BOOT-EXPORTS: replyRemove replyRemoveTCB replyPush replyUnlink getReply setReply getReplyTCB #-}
+% {-# BOOT-EXPORTS: replyRemove replyRemoveTCB replyPush replyUnlink getReply setReply #-}
 
 > import {-# SOURCE #-} SEL4.Kernel.Thread(getThreadState, setThreadState)
 > import SEL4.Machine.RegisterSet(PPtr)
@@ -39,7 +39,7 @@ This module specifies the behavior of reply objects.
 >     stateAssert sym_refs_asrt
 >         "Assert that `sym_refs (state_refs_of' s)` holds"
 >     scPtrOptDonated <- threadGet tcbSchedContext callerPtr
->     tptrOpt <- getReplyTCB replyPtr
+>     tptrOpt <- liftM replyTCB (getReply replyPtr)
 >     assert (tptrOpt == Nothing) "Reply object shouldn't have unexecuted reply!"
 
 >     scPtrOptCallee <- threadGet tcbSchedContext calleePtr
@@ -55,7 +55,7 @@ This module specifies the behavior of reply objects.
 >     tsCallee <- getThreadState calleePtr
 >     assert (replyObject tsCallee == Nothing) "tcb callee should not be in a existing call stack"
 
->     setReplyTCB (Just callerPtr) replyPtr
+>     updateReply replyPtr (\reply -> reply { replyTCB = Just callerPtr })
 >     setThreadState (BlockedOnReply (Just replyPtr)) callerPtr
 
 >     when (scPtrOptDonated /= Nothing && canDonate) $ do
@@ -162,13 +162,13 @@ This module specifies the behavior of reply objects.
 
 > replyUnlink :: PPtr Reply -> PPtr TCB -> Kernel ()
 > replyUnlink replyPtr tcbPtr = do
->     tptrOpt <- getReplyTCB replyPtr
+>     tptrOpt <- liftM replyTCB (getReply replyPtr)
 >     tptr <- maybeToMonad tptrOpt
 >     assert (tptr == tcbPtr) "replyTCB must be equal to tcbPtr"
 >     state <- getThreadState tcbPtr
 >     stateAssert (replyUnlink_assertion replyPtr state)
 >             "Relation between the thread state of the replyTCB and replyPtr"
->     setReplyTCB Nothing replyPtr
+>     updateReply replyPtr (\reply -> reply { replyTCB = Nothing })
 >     setThreadState Inactive tcbPtr
 
 In "replyUnlink" above, as in the abstract specification,  we make an assertion
@@ -187,9 +187,3 @@ on the thread state of the replyTCB of the replyPtr
 
 > setReply :: PPtr Reply -> Reply -> Kernel ()
 > setReply rptr r = setObject rptr r
-
-> getReplyTCB :: PPtr Reply -> Kernel (Maybe (PPtr TCB))
-> getReplyTCB r = liftM replyTCB (getReply r)
-
-> setReplyTCB :: Maybe (PPtr TCB) -> PPtr Reply -> Kernel ()
-> setReplyTCB tptrOpt rptr = updateReply rptr (\reply -> reply { replyTCB = tptrOpt })


### PR DESCRIPTION
Because setReplyTCB is only called in 4 places, and it is just a wrapper for updateReply, having it as a separate definition means writing double the lemmas, or just unfolding the definition in many places. It is simpler just to remove the function altogether. This should streamline a few proofs and reduce duplicated work.

I have also done the same with getReplyTCB.