### PR TITLE
rt refine: make more use of reply projections

### DIFF
--- a/lib/Lib.thy
+++ b/lib/Lib.thy
@@ -2554,6 +2554,14 @@ lemma rsubst2:
   "\<lbrakk>P s x; s = t; x = y\<rbrakk> \<Longrightarrow> P t y"
   by simp
 
+lemma rsubst3:
+  "\<lbrakk>P a b c ; a = s; b = t; c = u\<rbrakk> \<Longrightarrow> P s t u"
+  by simp
+
+lemma rsubst4:
+  "\<lbrakk>P a b c d; a = s; b = t; c = u; d = v\<rbrakk> \<Longrightarrow> P s t u v"
+  by simp
+
 lemma ex_impE: "((\<exists>x. P x) \<longrightarrow> Q) \<Longrightarrow> P x \<Longrightarrow> Q"
   by blast
 


### PR DESCRIPTION
This was factored out of my ongoing `valid_replies'` work so that it could be used in other PRs. It updates various lemmas that are connected to `valid_replies'` to use projections instead of `obj_at'`.