### PR TITLE
arm_hyp: proof updates for seL4 commit 93ab2543d9d8

### DIFF
--- a/spec/abstract/ARM_HYP/VCPU_A.thy
+++ b/spec/abstract/ARM_HYP/VCPU_A.thy
@@ -67,9 +67,8 @@ where
        | _ \<Rightarrow> (False, False));
 
      if on_cur_vcpu
-       then if reg = VCPURegSCTLR
-              then if active then do_machine_op getSCTLR
-                             else vcpu_read_reg vcpu_ptr VCPURegSCTLR
+       then if vcpuRegSavedWhenDisabled reg \<and> \<not>active
+              then vcpu_read_reg vcpu_ptr reg
               else do_machine_op $ readVCPUHardwareReg reg
        else vcpu_read_reg vcpu_ptr reg
   od"
@@ -85,9 +84,8 @@ where
        | _ \<Rightarrow> (False, False));
 
      if on_cur_vcpu
-       then if reg = VCPURegSCTLR
-         then if active then do_machine_op $ setSCTLR val
-                        else vcpu_write_reg vcpu_ptr reg val
+       then if vcpuRegSavedWhenDisabled reg \<and> \<not>active
+         then vcpu_write_reg vcpu_ptr reg val
          else do_machine_op $ writeVCPUHardwareReg reg val
        else vcpu_write_reg vcpu_ptr reg val
   od"

--- a/spec/haskell/src/SEL4/Machine/RegisterSet/ARM.lhs
+++ b/spec/haskell/src/SEL4/Machine/RegisterSet/ARM.lhs
@@ -96,6 +96,10 @@ This module defines the ARM register set.
 > vcpuRegNum :: Int
 > vcpuRegNum = fromEnum (maxBound :: VCPUReg)
 
+> vcpuRegSavedWhenDisabled :: VCPUReg -> Bool
+> vcpuRegSavedWhenDisabled VCPURegSCTLR = True
+> vcpuRegSavedWhenDisabled _ = False
+
 #endif
 
 > initContext :: [(Register, Word)]

--- a/spec/haskell/src/SEL4/Object/VCPU/ARM.lhs
+++ b/spec/haskell/src/SEL4/Object/VCPU/ARM.lhs
@@ -30,7 +30,7 @@ hypervisor extensions on ARM.
 > import SEL4.API.InvocationLabels.ARM
 > import SEL4.API.Invocation
 > import SEL4.API.Invocation.ARM as ArchInv
-> import SEL4.Machine.RegisterSet.ARM (Register(..), VCPUReg(..), vcpuRegNum)
+> import SEL4.Machine.RegisterSet.ARM (Register(..), VCPUReg(..), vcpuRegNum, vcpuRegSavedWhenDisabled)
 > import SEL4.API.Types
 > import SEL4.API.InvocationLabels
 > import SEL4.API.Failures.TARGET
@@ -172,9 +172,8 @@ Currently, there is only one VCPU register available for reading/writing by the 
 >         _ -> (False, False)
 >
 >     if onCurVCPU
->         then if reg == VCPURegSCTLR
->                 then if active then doMachineOp getSCTLR
->                                else vcpuReadReg vcpuPtr VCPURegSCTLR
+>         then if vcpuRegSavedWhenDisabled reg && not active
+>                 then vcpuReadReg vcpuPtr reg
 >                 else doMachineOp $ readVCPUHardwareReg reg
 >         else vcpuReadReg vcpuPtr reg
 
@@ -186,9 +185,8 @@ Currently, there is only one VCPU register available for reading/writing by the 
 >         _ -> (False, False)
 >
 >     if onCurVCPU
->         then if reg == VCPURegSCTLR
->                 then if active then doMachineOp $ setSCTLR val
->                                else vcpuWriteReg vcpuPtr reg val
+>         then if vcpuRegSavedWhenDisabled reg && not active
+>                 then vcpuWriteReg vcpuPtr reg val
 >                 else doMachineOp $ writeVCPUHardwareReg reg val
 >         else vcpuWriteReg vcpuPtr reg val
 


### PR DESCRIPTION
The seL4/seL4@93ab2543d9d8 commit factors out special treatment of specific VCPU
registers, and this commit updates the ARM_HYP proofs accordingly.