### PR TITLE
rt_replyPush

### DIFF
--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -222,7 +222,7 @@ crunch domain_list_inv[wp]: do_ipc_transfer "\<lambda>s::det_state. P (domain_li
 
 lemma reply_push_domain_list_inv[wp]:
   "\<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace> reply_push param_a param_b param_c param_d \<lbrace>\<lambda>_ s. P (domain_list s)\<rbrace>"
-  by (wpsimp simp: reply_push_def split_del: if_split
+  by (wpsimp simp: reply_push_def bind_sc_reply_def split_del: if_split
     wp: hoare_vcg_if_lift2 hoare_vcg_all_lift hoare_drop_imp get_sched_context_wp)
 
 lemma send_ipc_domain_list_inv[wp]:

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -16994,12 +16994,6 @@ lemma reply_push_released_if_bound_not_callee:
   apply (simp add: reply_push_def)
   apply (rule hoare_seq_ext[OF _ gsc_sp])
   apply (rule hoare_seq_ext[OF _ gsc_sp])
-  apply (rule hoare_seq_ext[OF _ grt_sp])
-  apply (rule hoare_seq_ext[OF _ assert_sp])
-  apply (rule hoare_seq_ext[OF _ no_reply_in_ts_inv])
-  apply (rule hoare_seq_ext[OF _ assert_inv])
-  apply (rule hoare_seq_ext[OF _ no_reply_in_ts_inv])
-  apply (rule hoare_seq_ext[OF _ assert_inv])
   apply (case_tac sc_caller; simp)
    apply wpsimp
   apply (wpsimp wp: sched_context_donate_released_if_bound_not_callee
@@ -18491,25 +18485,16 @@ lemma reply_push_ct_ready_if_schedulable:
   supply if_split [split del]
   unfolding reply_push_def
   apply (wpsimp wp: sched_context_donate_ct_ready_if_schedulable)
-              apply (wpsimp wp: set_thread_state_ct_ready_if_schedulable_strong assert_inv hoare_vcg_if_lift2
-                                hoare_vcg_imp_lift' hoare_vcg_all_lift get_simple_ko_wp)
-             apply (wpsimp wp: set_thread_state_ct_ready_if_schedulable_strong assert_inv hoare_vcg_if_lift2
-                               hoare_vcg_imp_lift' hoare_vcg_all_lift)
-            apply (rule_tac Q="\<lambda>_ s. caller = cur_thread s
-                                     \<and> ct_ready_if_schedulable s
-                                     \<and> bound_sc_tcb_at ((=) sc_caller) caller s
-                                     \<and> bound_sc_tcb_at ((=) sc_callee) callee s"
-                   in hoare_post_imp)
-             apply (clarsimp simp: tcb_at_kh_simps pred_map_eq_normalise split: if_split)
-             apply (fastforce simp: tcb_at_kh_simps vs_all_heap_simps)
-            apply (clarsimp simp: tcb_at_kh_simps pred_map_eq_normalise split: if_split)
-            apply (wpsimp wp: set_thread_state_ct_ready_if_schedulable_strong assert_inv hoare_vcg_if_lift2
-                              hoare_vcg_imp_lift' hoare_vcg_all_lift get_simple_ko_wp)
-           apply (clarsimp cong: conj_cong)
-           apply (wpsimp wp: hoare_drop_imp)+
-    apply (wpsimp wp: get_tcb_obj_ref_wp)
-   apply (wpsimp wp: get_tcb_obj_ref_wp)
-  apply (auto simp: tcb_at_kh_simps vs_all_heap_simps obj_at_def)[1]
+      apply (rule_tac Q="\<lambda>_ s. caller = cur_thread s
+                               \<and> ct_ready_if_schedulable s
+                               \<and> bound_sc_tcb_at ((=) sc_caller) caller s
+                               \<and> bound_sc_tcb_at ((=) sc_callee) callee s"
+             in hoare_post_imp)
+       apply (clarsimp simp: tcb_at_kh_simps pred_map_eq_normalise split: if_split)
+       apply (fastforce simp: vs_all_heap_simps obj_at_def)
+      apply (wpsimp wp: set_thread_state_ct_ready_if_schedulable_strong)
+     apply (wpsimp wp: get_tcb_obj_ref_wp)+
+  apply (clarsimp simp: tcb_at_kh_simps vs_all_heap_simps obj_at_def)
   done
 
 lemma reply_unlink_tcb_fault_tcb_at_ct[wp]:
@@ -21903,10 +21888,6 @@ lemma reply_push_ct_ready_if_schedulable_callee:
              apply (fastforce split: if_split simp: obj_at_def)
             apply (wpsimp wp: set_thread_state_ct_ready_if_schedulable_strong assert_inv hoare_vcg_if_lift2
                               hoare_vcg_all_lift hoare_vcg_imp_lift)
-           apply (wpsimp wp: set_thread_state_ct_ready_if_schedulable_strong assert_inv hoare_vcg_if_lift2
-                             hoare_vcg_all_lift)
-          apply (wpsimp wp: set_thread_state_ct_ready_if_schedulable_strong assert_inv hoare_vcg_if_lift2
-                            hoare_vcg_all_lift)
          apply (rule_tac
                   Q="\<lambda>_ s. ct_ready_if_schedulable s
                            \<and> (can_donate \<longrightarrow>

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -8597,7 +8597,7 @@ lemma reply_push_valid_sched_misc[wp]:
           (etcbs_of s) (tcb_faults_of s) (sc_refill_cfgs_of s)
           (ep_send_qs_of s) (ep_recv_qs_of s)\<rbrace>"
   by (wpsimp wp: get_simple_ko_wp hoare_vcg_if_lift2 hoare_drop_imps hoare_vcg_all_lift
-           simp: reply_push_def)
+           simp: reply_push_def bind_sc_reply_def)
 
 crunch valid_refills[wp]: set_cdt,set_original,set_extra_badge "valid_refills scp"
   (wp_del: set_original_wp)
@@ -10894,14 +10894,14 @@ lemma possible_switch_to_not_queued[wp]:
 lemma reply_push_scheduler_act_not[wp]:
   "\<lbrace>scheduler_act_not t\<rbrace>
      reply_push caller callee reply_ptr can_donate \<lbrace>\<lambda>rv. scheduler_act_not t\<rbrace>"
-  apply (clarsimp simp: reply_push_def)
+  apply (clarsimp simp: reply_push_def bind_sc_reply_def)
   by (wpsimp wp: hoare_drop_imp get_sched_context_wp hoare_vcg_if_lift2 hoare_vcg_all_lift
              split_del: if_split)
 
 lemma reply_push_not_queued[wp]:
   "\<lbrace>not_queued t and scheduler_act_not t\<rbrace>
      reply_push caller callee reply_ptr can_donate \<lbrace>\<lambda>rv. not_queued t\<rbrace>"
-  apply (clarsimp simp: reply_push_def)
+  apply (clarsimp simp: reply_push_def bind_sc_reply_def)
   by (wpsimp wp: hoare_drop_imp get_sched_context_wp hoare_vcg_if_lift2 hoare_vcg_all_lift
              split_del: if_split)
 
@@ -10981,7 +10981,7 @@ lemma set_sc_replies_valid_sched:
   by (wpsimp wp: set_sc_replies_active_reply_scs simp: valid_sched_def)
 
 method reply_push_begin_valid_sched_proof
-  = (simp add: reply_push_def
+  = (simp add: reply_push_def bind_sc_reply_def
      , intro hoare_seq_ext[OF _ gsc_sp]
      , simp add: pred_conj_def obj_at_kh_kheap_simps pred_map_eq_normalise)
 
@@ -11167,7 +11167,7 @@ lemma reply_push_released_if_bound_callee:
    reply_push caller callee reply_ptr can_donate
    \<lbrace>\<lambda>r. released_if_bound_sc_tcb_at callee\<rbrace>"
   supply if_split[split del]
-  apply (simp add: reply_push_def)
+  apply (simp add: reply_push_def bind_sc_reply_def)
   apply (rule hoare_seq_ext[OF _ gsc_sp])+
   apply (rule hoare_seq_ext_skip, solves \<open>wpsimp\<close>)+
   apply (rule hoare_when_cases; clarsimp simp: pred_conj_def obj_at_kh_kheap_simps pred_map_eq_normalise)
@@ -11257,7 +11257,7 @@ lemma reply_push_st_tcb_at_BlockedOnReply:
      reply_push caller callee reply_ptr can_donate
    \<lbrace>\<lambda>rv. st_tcb_at P t\<rbrace>"
   supply if_split [split del]
-  unfolding reply_push_def
+  unfolding reply_push_def bind_sc_reply_def
   by (wpsimp wp: hoare_drop_imp hoare_vcg_if_lift2 sts_st_tcb_at_cases hoare_vcg_all_lift)
 
 lemma sched_context_donate_tcb_scps_of_retract[wp]:
@@ -11286,7 +11286,7 @@ lemma reply_push_tcb_scps_of_retract[wp]:
    reply_push caller callee reply_ptr can_donate
    \<lbrace>\<lambda>rv s. heap_refs_retract (tcb_scps_of s) (sc_tcbs_of s)\<rbrace>"
   supply if_split [split del]
-  unfolding reply_push_def
+  unfolding reply_push_def bind_sc_reply_def
   apply (wpsimp wp: hoare_vcg_if_lift2 sts_st_tcb_at_cases hoare_vcg_all_lift get_simple_ko_wp
                     sched_context_donate_tcb_scps_of_retract)
   apply (rule_tac Q= "\<lambda>_ s. heap_refs_retract (tcb_scps_of s) (sc_tcbs_of s) \<and>
@@ -11958,7 +11958,7 @@ lemma reply_push_weak_valid_sched_action_no_donation:
      scheduler_act_not thread\<rbrace>
    reply_push thread dest ya False
    \<lbrace>\<lambda>rv. weak_valid_sched_action\<rbrace>"
-  unfolding reply_push_def
+  unfolding reply_push_def bind_sc_reply_def
   apply clarsimp
   by (wpsimp wp: set_thread_state_weak_valid_sched_action hoare_drop_imps
                  update_sk_obj_ref_lift)
@@ -11967,7 +11967,7 @@ lemma reply_push_valid_blocked_no_donation:
   "\<lbrace> valid_blocked_except_set (insert thread S)\<rbrace>
    reply_push thread dest ya False
    \<lbrace>\<lambda>rv. valid_blocked_except_set S\<rbrace>"
-  unfolding reply_push_def
+  unfolding reply_push_def bind_sc_reply_def
   apply clarsimp
   by (wpsimp wp: set_thread_state_not_runnable_valid_blocked_remove hoare_drop_imps
                  update_sk_obj_ref_lift)
@@ -11976,7 +11976,7 @@ lemma reply_push_valid_blocked_no_donation':
   "\<lbrace> valid_blocked_except_set S\<rbrace>
    reply_push thread dest ya False
    \<lbrace>\<lambda>rv. valid_blocked_except_set S\<rbrace>"
-  unfolding reply_push_def
+  unfolding reply_push_def bind_sc_reply_def
   apply clarsimp
   by (wpsimp wp: set_thread_state_not_runnable_valid_blocked_remove hoare_drop_imps
                  update_sk_obj_ref_lift)
@@ -14122,7 +14122,7 @@ lemma refill_new_is_sc_active:
 
 lemma reply_push_sc_tcb_sc_at:
   "reply_push caller callee reply_ptr False \<lbrace>sc_tcb_sc_at P sc_ptr\<rbrace>"
-  unfolding reply_push_def
+  unfolding reply_push_def bind_sc_reply_def
   apply clarsimp
   by (wpsimp wp: hoare_drop_imps)
 
@@ -14577,7 +14577,7 @@ lemma update_time_stamp_valid_sched[wp]:
 
 lemma reply_push_scheduler_act_sane[wp]:
   "reply_push caller callee reply_ptr can_donate \<lbrace>scheduler_act_sane:: 'state_ext state \<Rightarrow> _\<rbrace>"
-  unfolding reply_push_def
+  unfolding reply_push_def bind_sc_reply_def
   by (wpsimp wp: hoare_drop_imp hoare_vcg_all_lift | safe)+
 
 lemma invoke_tcb_cur_sc_chargeable:
@@ -16079,7 +16079,7 @@ context DetSchedSchedule_AI begin
 lemma reply_push_cannot_donate_active_sc_tcb_at[wp]:
   "reply_push caller callee reply_ptr False
    \<lbrace>\<lambda>(s:: 'state_ext state). active_sc_tcb_at t s\<rbrace>"
-  unfolding reply_push_def
+  unfolding reply_push_def bind_sc_reply_def
   by (wpsimp wp: hoare_drop_imp)
 
 lemma send_ipc_cannot_donate_active_sc_tcb_at[wp]:
@@ -16934,7 +16934,7 @@ lemma reply_push_ct_in_state:
   "\<lbrace>ct_in_state P and (\<lambda>s. caller = cur_thread s \<longrightarrow> (\<forall>y. P (BlockedOnReply y)))\<rbrace>
    reply_push caller callee reply_ptr can_donate
    \<lbrace>\<lambda>_. ct_in_state P :: 'state_ext state \<Rightarrow> _\<rbrace>"
-  unfolding reply_push_def
+  unfolding reply_push_def bind_sc_reply_def
   by (wpsimp wp: sts_ctis_neq hoare_vcg_if_lift2 hoare_drop_imp hoare_vcg_all_lift
                  get_simple_ko_wp)
 
@@ -16991,7 +16991,7 @@ lemma reply_push_released_if_bound_not_callee:
    reply_push caller callee reply_ptr can_donate
    \<lbrace>\<lambda>_. released_if_bound_sc_tcb_at t\<rbrace>"
   supply if_weak_cong[cong del]
-  apply (simp add: reply_push_def)
+  apply (simp add: reply_push_def bind_sc_reply_def)
   apply (rule hoare_seq_ext[OF _ gsc_sp])
   apply (rule hoare_seq_ext[OF _ gsc_sp])
   apply (case_tac sc_caller; simp)
@@ -18483,7 +18483,7 @@ lemma reply_push_ct_ready_if_schedulable:
    reply_push caller callee reply_ptr can_donate
    \<lbrace>\<lambda>_. ct_ready_if_schedulable\<rbrace>"
   supply if_split [split del]
-  unfolding reply_push_def
+  unfolding reply_push_def bind_sc_reply_def
   apply (wpsimp wp: sched_context_donate_ct_ready_if_schedulable)
       apply (rule_tac Q="\<lambda>_ s. caller = cur_thread s
                                \<and> ct_ready_if_schedulable s
@@ -19555,7 +19555,7 @@ lemma reply_push_cur_sc_not_in_release_q[wp]:
   "\<lbrace>\<lambda>s. sc_not_in_release_q sc_ptr s \<and> not_in_release_q callee s\<rbrace>
    reply_push caller callee reply_ptr can_donate
    \<lbrace>\<lambda>_ s :: det_state. sc_not_in_release_q sc_ptr s\<rbrace>"
-  apply (clarsimp simp: reply_push_def when_def)
+  apply (clarsimp simp: reply_push_def bind_sc_reply_def when_def)
   apply (rule hoare_seq_ext_skip, wpsimp wp: get_simple_ko_wp)+
   apply (rule hoare_if; (solves \<open>wpsimp\<close>)?)
   apply (rule hoare_seq_ext_skip, wpsimp wp: get_simple_ko_wp)+
@@ -20956,7 +20956,7 @@ lemma reply_push_cur_sc_in_release_q_imp_zero_consumed[wp]:
    reply_push caller callee reply_ptr can_donate
    \<lbrace>\<lambda>_. cur_sc_in_release_q_imp_zero_consumed :: det_state \<Rightarrow> _\<rbrace>"
   supply if_split [split del]
-  unfolding reply_push_def
+  unfolding reply_push_def bind_sc_reply_def
   apply (wpsimp wp: get_simple_ko_wp)
             apply (rule_tac Q="\<lambda>_. cur_sc_in_release_q_imp_zero_consumed
                                    and valid_release_q
@@ -21858,7 +21858,8 @@ lemma reply_push_ct_ready_if_schedulable_callee:
    reply_push caller callee reply_ptr can_donate
    \<lbrace>\<lambda>_. ct_ready_if_schedulable :: det_state \<Rightarrow> _\<rbrace>"
   supply if_split [split del]
-  unfolding reply_push_def
+  unfolding reply_push_def bind_sc_reply_def
+  apply (simp add: bind_assoc)
   apply wpsimp
                  apply (wpsimp wp: sched_context_donate_ct_ready_if_schedulable_strong)
                 apply (rule_tac Q="\<lambda>_ s. callee = cur_thread s \<and> is_refill_ready (the sc_caller) s

--- a/proof/invariant-abstract/Deterministic_AI.thy
+++ b/proof/invariant-abstract/Deterministic_AI.thy
@@ -4047,7 +4047,7 @@ crunch (empty_fail)empty_fail[wp]: set_priority,set_mcpriority
 
 lemma reply_push_valid_list[wp]:
   "\<lbrace>valid_list\<rbrace> reply_push caller callee reply_ptr can_donate \<lbrace>\<lambda>_. valid_list\<rbrace>"
-  by (wpsimp simp: reply_push_def
+  by (wpsimp simp: reply_push_def bind_sc_reply_def
     wp: get_simple_ko_wp hoare_drop_imp get_sched_context_wp hoare_vcg_all_lift hoare_vcg_if_lift2)
 
 lemma copy_mrs_valid_list[wp]:

--- a/proof/invariant-abstract/InvariantsPre_AI.thy
+++ b/proof/invariant-abstract/InvariantsPre_AI.thy
@@ -280,6 +280,18 @@ lemma delta_sym_refs:
   apply (erule(1) y)
   done
 
+lemma delta_sym_refs_insert_only:
+  assumes x: "sym_refs rfs'"
+      and diff: "p2 \<noteq> p1"
+      and y: "p1refs = rfs' p1"
+      and z: "p2refs = rfs' p2"
+      and symrefrel: "tp' = symreftype tp"
+  shows "sym_refs (\<lambda>p. if p = p1 then (insert (p2, tp) p1refs)
+                  else if p = p2 then (insert (p1, tp') p2refs)
+                  else rfs' p)"
+  apply (rule delta_sym_refs[OF x])
+  using diff by (auto simp: y z symrefrel split: if_splits)
+
 abbreviation (input)
   "bound a \<equiv> a \<noteq> None"
 

--- a/proof/invariant-abstract/IpcDet_AI.thy
+++ b/proof/invariant-abstract/IpcDet_AI.thy
@@ -932,13 +932,6 @@ lemma reply_push_sender_sc_Some_invs:
   apply (clarsimp simp: reply_push_def)
   apply (rule hoare_seq_ext[OF _ gsc_sp])
   apply (rule hoare_seq_ext[OF _ gsc_sp])
-  apply (rule hoare_seq_ext[OF _ liftM_wp[where P=P and Q="\<lambda>r. P" for P, simplified,
-                                          OF get_simple_ko_inv]])
-  apply (rule hoare_seq_ext[OF _ assert_inv])
-  apply (rule hoare_seq_ext[OF _ no_reply_in_ts_inv])
-  apply (rule hoare_seq_ext[OF _ assert_inv])
-  apply (rule hoare_seq_ext[OF _ no_reply_in_ts_inv])
-  apply (rule hoare_seq_ext[OF _ assert_inv])
   apply (rule_tac S="sender_sc = sc_caller \<and> sender \<noteq> thread \<and> sender \<noteq> reply_ptr \<and> thread \<noteq> reply_ptr"
            in hoare_gen_asm'', fastforce simp: sk_obj_at_pred_def pred_tcb_at_def obj_at_def)
   apply (rule subst[of "do _ <- do _ <- a; b od; c od"
@@ -1012,8 +1005,10 @@ lemma reply_push_sender_sc_Some_invs:
                          sym_refs_bound_sc_tcb_iff_sc_tcb_sc_at)
                        (* sc_caller has non-empty sc_replies *)
   apply (clarsimp simp: invs_def valid_state_def valid_pspace_def)
-  apply (rule conjI, clarsimp simp: reply_sc_reply_at_def obj_at_def is_reply_def)
-  apply (rule conjI, clarsimp simp:  obj_at_def is_reply_def)
+  apply (prop_tac "reply_at reply_ptr s",
+         clarsimp simp: reply_sc_reply_at_def obj_at_def is_reply_def, simp)
+  apply (prop_tac "reply_at x s",
+         erule (1) valid_objs_sc_replies_reply_at, simp, simp)
   apply (rule conjI, rule replies_blocked_list_all_reply_at, assumption)
    apply (drule valid_replies_2D1)
    apply (rule_tac B="fst ` replies_with_sc s" in subset_trans; simp?)
@@ -1022,7 +1017,8 @@ lemma reply_push_sender_sc_Some_invs:
   apply (rule conjI, clarsimp)
    apply (drule sc_replies_sc_at_hd_SCReply_ref)
    apply (drule sym_refsD, assumption)
-   apply (clarsimp simp: state_refs_of_def reply_sc_reply_at_def obj_at_def)
+   apply (clarsimp simp: state_refs_of_def reply_sc_reply_at_def obj_at_def get_refs_def
+                  split: option.splits)
   apply (rule conjI, clarsimp)
    apply (subgoal_tac "(reply_ptr, sc_caller) \<in> replies_with_sc s", fastforce simp: image_def)
    apply (clarsimp simp: replies_with_sc_def sc_replies_sc_at_def obj_at_def)
@@ -1063,22 +1059,21 @@ lemma reply_push_sender_sc_Some_invs:
          apply (fastforce dest: reply_reftypes reply_at_ppred_reply_at)
         apply (fastforce dest: SCReply_ref_fst_replies_with_sc)
        apply (case_tac "sc_caller = x"; clarsimp)
-        apply (fastforce dest: SCReply_ref_fst_replies_with_sc)
+        apply_trace (fastforce dest: SCReply_ref_fst_replies_with_sc)
        apply (case_tac "y = x"; clarsimp)
         apply (fastforce dest: SCReply_ref_fst_replies_with_sc)
        apply (fastforce dest: SCReply_ref_fst_replies_with_sc)
-      apply (case_tac "y = reply_ptr"; clarsimp)
-       apply (fastforce dest: reply_reftypes reply_at_ppred_reply_at)
-      apply (safe; simp)[1]
-       apply (fastforce simp: valid_reply_def obj_at_def is_sc_obj_def dest: valid_objs_valid_reply)
-      apply (fastforce simp: valid_reply_def obj_at_def is_sc_obj_def dest: valid_objs_valid_reply)
+      apply (fastforce simp: sc_at_pred_n_def obj_at_def reply_sc_reply_at_def)
      apply (case_tac "reply_ptr = x"; clarsimp)
       apply (clarsimp simp: reply_sc_reply_at_def obj_at_def)
+      apply (prop_tac "(reply_ptr, sc_caller) \<in> replies_with_sc s")
+       apply (clarsimp simp: replies_with_sc_def sc_at_pred_n_def obj_at_def)
+       apply (metis cons_set_intro)
+      apply fastforce
      apply (clarsimp simp: reply_sc_reply_at_def obj_at_def)
      apply (fastforce dest: sc_replies_sc_at_state_refs_of[OF eq_commute, THEN iffD2])
     apply (safe; simp?)[1]
-      apply (fastforce simp: valid_reply_def obj_at_def reply_sc_reply_at_def is_sc_obj_def
-                       dest: valid_objs_valid_reply)
+      apply (fastforce simp: sc_at_pred_n_def obj_at_def reply_sc_reply_at_def)
      apply (fastforce dest: reply_reftypes reply_at_ppred_reply_at)
     apply (drule SCReply_ref_replies_with_sc)
     apply (subgoal_tac "(x, sc_caller) \<in> replies_with_sc s")
@@ -1511,11 +1506,8 @@ lemma reply_push_invs_helper:
          \<and> reply_ptr \<notin> fst ` replies_with_sc s \<rbrace>
     when (sc_callee = None \<and> donate) (do
       sc_replies <- liftM sc_replies (get_sched_context sc_ptr);
-      y <- case sc_replies of [] \<Rightarrow> assert True
-              | r # x \<Rightarrow> do reply <- get_reply r;
-                            assert (reply_sc reply = sc_caller);
-                            set_reply_obj_ref reply_sc_update r None
-                         od;
+      y <- case sc_replies of [] \<Rightarrow> return ()
+              | r # x \<Rightarrow> set_reply_obj_ref reply_sc_update r None;
       y <- set_sc_obj_ref sc_replies_update sc_ptr (reply_ptr # sc_replies);
       y <- set_reply_obj_ref reply_sc_update reply_ptr (Some sc_ptr);
       sched_context_donate sc_ptr callee
@@ -1559,34 +1551,20 @@ lemma reply_push_invs_helper:
     apply (wpsimp wp: set_sc_replies_valid_replies update_sched_context_valid_idle)
    apply (wpsimp simp: get_simple_ko_def get_object_def
                    wp: valid_sc_typ_list_all_reply valid_ioports_lift)
-  apply (clarsimp split: if_splits, intro conjI impI)
-                apply (clarsimp simp: is_reply obj_at_def is_sc_obj_def)+
-        apply (subgoal_tac "reply_sc_reply_at (\<lambda>sp. sp = Some sc_ptr) reply_ptr s")
-         apply (clarsimp simp:reply_sc_reply_at_def obj_at_def)
-        apply (fastforce simp: sym_refs_reply_sc_reply_at invs_sym_refs reply_at_ppred_reply_at)
-       apply (clarsimp simp: is_reply obj_at_def is_sc_obj_def)+
-  apply (clarsimp simp: invs_def valid_state_def valid_pspace_def sc_replies_sc_at_def
-                        valid_obj_def valid_sched_context_def
-                 elim!: obj_at_valid_objsE)
-  apply (drule_tac s="a # list" in sym, simp)
-  apply (rule conjI, clarsimp simp: obj_at_def is_reply)
-  apply (rule conjI, clarsimp simp: replies_with_sc_def image_def sc_replies_sc_at_def obj_at_def)
-   apply (subgoal_tac "reply_ptr \<in>  set (sc_replies sc)")
-    apply (drule_tac x=sc_ptr in spec, fastforce)
-   apply fastforce
-  apply (rule conjI, rule replies_with_sc_upd_replies_valid_replies_add_one, clarsimp)
+  apply (subgoal_tac "list_all (\<lambda>r. reply_at r s) (a # list) \<and> reply_ptr \<notin> set (a # list) \<and> distinct (a # list)")
+  apply (clarsimp simp: invs_def valid_pspace_def valid_state_def)
+  apply (intro conjI)
+  apply (rule replies_with_sc_upd_replies_valid_replies_add_one, simp)
      apply (clarsimp simp:replies_blocked_def image_def, fastforce)
     apply simp
    apply (clarsimp simp:sc_replies_sc_at_def obj_at_def)
-  apply (rule conjI)
    apply (erule delta_sym_refs)
-    apply (clarsimp split: if_splits
-                    elim!: delta_sym_refs)
-   apply (clarsimp simp: reply_sc_reply_at_def obj_at_def state_refs_of_def get_refs_def2
-                          pred_tcb_at_def is_tcb
+     apply (clarsimp split: if_splits
+                     elim!: delta_sym_refs)
+    apply (clarsimp simp: reply_sc_reply_at_def obj_at_def state_refs_of_def get_refs_def2
+                          pred_tcb_at_def is_tcb is_reply is_sc_obj sc_at_pred_n_def
                    split: if_splits
                    elim!: delta_sym_refs)
-    apply (safe; clarsimp?)
    apply (safe; clarsimp?)
    apply (subgoal_tac "(a,y) \<in> replies_with_sc s \<and> (a,sc_ptr) \<in> replies_with_sc s")
     apply (clarsimp dest!: valid_replies_2_inj_onD )
@@ -1599,8 +1577,18 @@ lemma reply_push_invs_helper:
      apply (clarsimp simp: replies_with_sc_def sc_replies_sc_at_def obj_at_def split: option.splits)
     apply (erule valid_objs_valid_reply, assumption)
    apply(clarsimp simp: replies_with_sc_def sc_replies_sc_at_def obj_at_def)
+  apply (metis cons_set_intro)
   apply (fastforce simp: idle_sc_no_ex_cap tcb_at_def is_tcb_def
                    dest: pred_tcb_at_tcb_at get_tcb_SomeD)
+  apply (clarsimp simp: pred_tcb_at_def obj_at_def is_tcb)
+  apply (clarsimp simp del: distinct.simps list.pred_inject insert_iff)
+  apply (frule sc_replies_sc_at_subset_fst_replies_with_sc)
+  apply (frule invs_valid_objs)
+  apply (intro conjI)
+    apply (erule replies_blocked_list_all_reply_at)
+    apply (meson dual_order.trans invs_valid_replies valid_replies_defs(1))
+   apply fastforce
+  apply (erule (1) valid_objs_sc_replies_distinct)
   done
 
 lemma sts_in_replies_blocked:
@@ -1626,19 +1614,13 @@ lemma reply_push_invs':
   "\<lbrace>all_invs_but_fault_tcbs and fault_tcbs_valid_states_except_set {caller} and
     ex_nonz_cap_to callee and ex_nonz_cap_to caller and ex_nonz_cap_to reply_ptr and
     st_tcb_at active caller and st_tcb_at ((=) Inactive) callee and
-    reply_sc_reply_at (\<lambda>sc. sc = None) reply_ptr\<rbrace>
+    reply_sc_reply_at (\<lambda>sc. sc = None) reply_ptr and reply_tcb_reply_at (\<lambda>tptr. tptr = None) reply_ptr\<rbrace>
    reply_push caller callee reply_ptr can_donate
    \<lbrace>\<lambda>rv. invs\<rbrace>"
   supply if_weak_cong[cong del]
   apply (simp add: reply_push_def)
   apply (rule hoare_seq_ext[OF _ gsc_sp])
   apply (rule hoare_seq_ext[OF _ gsc_sp])
-  apply (rule hoare_seq_ext[OF _ grt_sp])
-  apply (rule hoare_seq_ext[OF _ assert_sp])
-  apply (rule hoare_seq_ext[OF _ no_reply_in_ts_inv])
-  apply (rule hoare_seq_ext[OF _ assert_inv])
-  apply (rule hoare_seq_ext[OF _ no_reply_in_ts_inv])
-  apply (rule hoare_seq_ext[OF _ assert_inv])
   apply (case_tac sc_caller; simp)
    apply (wpsimp simp: invs_def valid_state_def valid_pspace_def
                    wp: sts_only_idle valid_irq_node_typ set_reply_tcb_valid_tcb_state
@@ -1659,6 +1641,7 @@ lemma reply_push_invs':
                           tcb_st_refs_of_def reply_tcb_reply_at_def
                    split: if_splits thread_state.splits)
    apply (clarsimp simp: idle_no_ex_cap)
+
   apply (wpsimp wp: reply_push_invs_helper)
     apply (wpsimp simp: invs_def valid_state_def valid_pspace_def
                     wp: sts_only_idle valid_irq_node_typ sts_valid_replies
@@ -1704,7 +1687,8 @@ lemma reply_push_invs':
 lemma reply_push_invs:
   "\<lbrace>invs and ex_nonz_cap_to callee and ex_nonz_cap_to caller and ex_nonz_cap_to reply_ptr and
     st_tcb_at active caller and st_tcb_at ((=) Inactive) callee and
-    reply_sc_reply_at (\<lambda>sc. sc = None) reply_ptr\<rbrace>
+    reply_sc_reply_at (\<lambda>sc. sc = None) reply_ptr and
+    reply_tcb_reply_at (\<lambda>tptr. tptr = None) reply_ptr\<rbrace>
    reply_push caller callee reply_ptr can_donate
    \<lbrace>\<lambda>rv. invs\<rbrace>"
   by (wpsimp wp: reply_push_invs' simp: invs_def valid_state_def valid_pspace_def) auto
@@ -1907,7 +1891,8 @@ lemma si_invs'_helper_some_reply:
         fault_tcbs_valid_states_except_set {tptr} s \<and>
         ex_nonz_cap_to tptr s \<and> ex_nonz_cap_to dest s \<and> reply = Some rptr \<and> ex_nonz_cap_to rptr s \<and>
         reply_sc_reply_at (\<lambda>sc. sc = None) rptr s \<and> fault_tcb_at ((=) None) dest s \<and>
-        (can_donate \<longrightarrow> bound_sc_tcb_at bound tptr s) \<and> Q s\<rbrace>
+        (can_donate \<longrightarrow> bound_sc_tcb_at bound tptr s) \<and> reply_tcb_reply_at (\<lambda>tptr. tptr = None) rptr s
+        \<and> Q s\<rbrace>
    do sc_opt <- get_tcb_obj_ref tcb_sched_context dest;
       fault <- thread_get tcb_fault tptr;
       y <- if call \<or> (\<exists>y. fault = Some y)
@@ -2070,7 +2055,8 @@ lemma si_invs'_helper_fault:
      apply (wpsimp wp: reply_unlink_tcb_st_tcb_at')
     apply (wpsimp wp: reply_unlink_tcb_sym_refs_BlockedOnReceive
                       reply_unlink_tcb_valid_replies_BlockedOnReceive
-                      reply_unlink_tcb_bound_sc_tcb_at hoare_vcg_imp_lift)
+                      reply_unlink_tcb_bound_sc_tcb_at hoare_vcg_imp_lift
+                      reply_unlink_tcb_reply_tcb_reply_at)
    apply (wpsimp wp: hoare_ex_wp valid_irq_node_typ hoare_vcg_imp_lift)
   apply clarsimp
   apply (subgoal_tac "reply_tcb_reply_at (\<lambda>b. b = Some dest) rptr s")

--- a/proof/invariant-abstract/RealTime_AI.thy
+++ b/proof/invariant-abstract/RealTime_AI.thy
@@ -1108,7 +1108,7 @@ lemma reply_push_st_tcb_at[wp]:
   "\<lbrace>st_tcb_at P t and K (t \<noteq> caller) and K (t \<noteq> callee)\<rbrace>
      reply_push caller callee reply_ptr can_donate
    \<lbrace>\<lambda>rv. st_tcb_at P t\<rbrace>"
-  by (wpsimp simp: reply_push_def update_sk_obj_ref_def get_thread_state_def
+  by (wpsimp simp: reply_push_def bind_sc_reply_def update_sk_obj_ref_def get_thread_state_def
                    thread_get_def no_reply_in_ts_def comp_def
                wp: weak_if_wp sts_st_tcb_at_cases hoare_vcg_all_lift hoare_vcg_const_imp_lift
          | wp (once) hoare_drop_imp)+

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -2751,7 +2751,7 @@ lemma schedContextUnbindTCB_invs'_helper:
   done
 
 crunches tcbReleaseRemove, tcbSchedDequeue, rescheduleRequired
-  for obj_at'_sc[wp]: "obj_at' (P :: sched_context \<Rightarrow> bool) p"
+  for obj_at'_sc[wp]: "\<lambda>s. Q (obj_at' (P :: sched_context \<Rightarrow> bool) p s)"
   (wp: crunch_wps)
 
 lemma schedContextUnbindTCB_invs':

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -166,20 +166,6 @@ lemma replyTCB_update_corres:
       apply (simp add: reply_relation_def)
   by (wpsimp simp: obj_at'_def replyPrev_same_def)+
 
-lemma setReply_valid_tcb'[wp]:
-  "setReply rp new  \<lbrace>valid_tcb' tcb\<rbrace>"
-  apply (clarsimp simp: setReply_def)
-  apply (rule setObject_valid_tcb')
-  done
-
-lemma setReply_valid_tcbs'[wp]:
-  "setReply rp new  \<lbrace>valid_tcbs'\<rbrace>"
-  unfolding valid_tcbs'_def
-  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')
-    apply (wpsimp simp: setReply_def )+
-    apply (wpsimp wp: set_reply'.setObject_wp)+
-  done
-
 lemma reply_unlink_tcb_corres:
   "\<lbrakk>st = Structures_A.BlockedOnReceive ep (Some rp) pl
     \<or> st = Structures_A.BlockedOnReply rp\<rbrakk> \<Longrightarrow>
@@ -1834,7 +1820,6 @@ lemma tcbReleaseRemove_valid_objs'[wp]:
   apply (rule hoare_seq_ext[OF _ gets_sp])
   apply (rule hoare_seq_ext_skip, wpsimp)
   apply (wpsimp wp: threadSet_valid_objs')
-  apply (clarsimp simp: valid_tcb'_def valid_cap'_def tcb_cte_cases_def)
   done
 
 lemma tcbReleaseRemove_valid_mdb'[wp]:

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -2601,10 +2601,6 @@ lemma scRefills_length_replaceAt_Hd:
    0 < scRefillMax ko \<longrightarrow> (\<forall>val. length (replaceAt (scRefillHead ko) (scRefills ko) val) = length (scRefills ko))"
   by (clarsimp, subst length_replaceAt; clarsimp simp: valid_sched_context'_def)
 
-lemma ko_at'_inj:
-  "ko_at' ko ptr  s \<Longrightarrow> ko_at' ko' ptr s \<Longrightarrow> ko' = ko"
-  by (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
-
 lemma refillAddTail_invs'[wp]:
   "refillAddTail scPtr t \<lbrace>invs'\<rbrace>"
   apply (simp add: refillAddTail_def)
@@ -3001,9 +2997,7 @@ crunches tcbReleaseDequeue
 lemma tcbReleaseDequeue_valid_objs'[wp]:
   "tcbReleaseDequeue \<lbrace>valid_objs'\<rbrace>"
   unfolding tcbReleaseDequeue_def
-  apply (wpsimp simp: setReprogramTimer_def setReleaseQueue_def wp: threadSet_valid_objs')
-  apply (fastforce simp: valid_tcb'_def tcbInReleaseQueue_update_tcb_cte_cases)
-  done
+  by (wpsimp simp: setReprogramTimer_def setReleaseQueue_def wp: threadSet_valid_objs')
 
 lemma tcbReleaseDequeue_sch_act_wf[wp]:
   "tcbReleaseDequeue \<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"

--- a/proof/refine/Move_R.thy
+++ b/proof/refine/Move_R.thy
@@ -345,4 +345,8 @@ lemma Reply_or_Receive_reply_at:
   apply (drule (1) st_tcb_at_valid_st2)
   by (fastforce simp: obj_at_def valid_tcb_state_def)
 
+lemma valid_tcb_state_BlockedOnReply[simp]:
+  "valid_tcb_state (Structures_A.thread_state.BlockedOnReply reply_ptr) = reply_at reply_ptr"
+  by (rule ext, simp add: valid_tcb_state_def)
+
 end

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -39,39 +39,16 @@ This module specifies the behavior of reply objects.
 >     stateAssert sym_refs_asrt
 >         "Assert that `sym_refs (state_refs_of' s)` holds"
 >     scPtrOptDonated <- threadGet tcbSchedContext callerPtr
->     tptrOpt <- liftM replyTCB (getReply replyPtr)
->     assert (tptrOpt == Nothing) "Reply object shouldn't have unexecuted reply!"
-
 >     scPtrOptCallee <- threadGet tcbSchedContext calleePtr
->     canDonate <- return (if scPtrOptCallee /= Nothing then False else canDonate)
-
->     reply <- getReply replyPtr
->     assert (replyPrev reply == Nothing) "replyPush: replyPrev must be Nothing"
->     assert (replyNext reply == Nothing) "replyPush: replyNext must be Nothing"
-
->     tsCaller <- getThreadState callerPtr
->     assert (replyObject tsCaller == Nothing) "tcb caller should not be in a existing call stack"
-
->     tsCallee <- getThreadState calleePtr
->     assert (replyObject tsCallee == Nothing) "tcb callee should not be in a existing call stack"
 
 >     updateReply replyPtr (\reply -> reply { replyTCB = Just callerPtr })
 >     setThreadState (BlockedOnReply (Just replyPtr)) callerPtr
 
->     when (scPtrOptDonated /= Nothing && canDonate) $ do
->         assert (scPtrOptCallee == Nothing) "replyPush: callee must not have a scheduling context"
-
+>     when (scPtrOptDonated /= Nothing && scPtrOptCallee == Nothing && canDonate) $ do
 >         scDonated <- getSchedContext (fromJust scPtrOptDonated)
 >         oldReplyPtrOpt <- return $ scReply scDonated
-
->         when (oldReplyPtrOpt /= Nothing) $ do
->             oldReplyPtr <- return $ fromJust oldReplyPtrOpt
->             oldReply <- getReply oldReplyPtr
->             assert (replyNext oldReply == Just (Head $ fromJust scPtrOptDonated))
->                 "replyPush: scheduling context and reply must have reference to each other"
-
->         reply' <- getReply replyPtr
->         setReply replyPtr (reply' { replyPrev = oldReplyPtrOpt, replyNext = Just (Head $ fromJust scPtrOptDonated) })
+>         reply <- getReply replyPtr
+>         setReply replyPtr (reply { replyPrev = oldReplyPtrOpt, replyNext = Just (Head $ fromJust scPtrOptDonated) })
 >         when (oldReplyPtrOpt /= Nothing) $ do
 >             oldReplyPtr <- return $ fromJust oldReplyPtrOpt
 >             oldReply <- getReply oldReplyPtr


### PR DESCRIPTION
This proves `replyPush_corres` and adds proofs about a new function `bindScReply`.
* A large number of reply-related lemmas are moved to Reply_R and some new ones added.
* Tweaks to `donateSchedContext_corres` only weaken the preconditions slightly.
* Moving `donateSchedContext_corres` is isolated to a separate commit to make reviewing easier
* Some `FIXME RT: move` comments remain. I would rather not resolve them now, but I can if needed.

This PR replaces the previous one (https://github.com/seL4/l4v/pull/146) which I will decline since so much has changed.