### PR TITLE
reply remove tcb corres

### DIFF
--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -1515,4 +1515,113 @@ lemma corres_assert_opt_assume_l:
   \<Longrightarrow> corres_underlying sr nf nf' dc (P and K (X \<noteq> None)) Q (assert_opt X >>= f) g"
   by (force simp: corres_underlying_def assert_opt_def return_def bind_def fail_def)
 
+section \<open> Preservation of state_relation for the concrete side symbolic execution \<close>
+
+(** sr_inv **)
+
+definition sr_inv_ul :: "('a \<times> 'b) set \<Rightarrow> ('a \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> (unit \<times> 'b) set \<times> 'c) \<Rightarrow> bool" where
+  "sr_inv_ul sr P P' f \<equiv>
+       \<forall>s s' t'. (s, s') \<in> sr \<longrightarrow> P s \<longrightarrow> P' s'
+              \<longrightarrow> ((), t') \<in> fst (f s') \<longrightarrow> (s, t') \<in> sr"
+
+lemma corres_noop_assm: (* check equivalence *)
+  "(\<forall>s. P s \<longrightarrow> \<lbrace>P' and (\<lambda>s'. (s, s') \<in> sr)\<rbrace> m \<lbrace>\<lambda>_ s'. (s, s') \<in> sr\<rbrace>) \<longleftrightarrow> sr_inv_ul sr P P' m"
+  by (fastforce simp: valid_def sr_inv_ul_def)
+
+lemma sr_inv_ul_imp:
+  "\<lbrakk>sr_inv_ul sr Q Q' f; \<And>s. P s \<Longrightarrow> Q s; \<And>s. P' s \<Longrightarrow> Q' s\<rbrakk> \<Longrightarrow> sr_inv_ul sr P P' f "
+  by (clarsimp simp: sr_inv_ul_def)
+
+lemma sr_inv_stronger_imp:
+  "\<lbrakk>sr_inv_ul sr Q Q' f;
+    \<And>s s'. \<lbrakk>P s; P' s'; (s, s') \<in> sr\<rbrakk> \<Longrightarrow> Q s;
+    \<And>s s'. \<lbrakk>P s; P' s'; (s, s') \<in> sr\<rbrakk> \<Longrightarrow> Q' s'\<rbrakk>
+   \<Longrightarrow> sr_inv_ul sr P P' f"
+  by (clarsimp simp: sr_inv_ul_def)
+
+lemma sr_inv_ul_cross:
+  "\<lbrakk>sr_inv_ul sr P (P' and Q') f; \<And>s s'. P s \<Longrightarrow> P' s' \<Longrightarrow> Q' s'\<rbrakk> \<Longrightarrow> sr_inv_ul sr P P' f "
+  by (clarsimp simp: sr_inv_stronger_imp)
+
+lemma sr_inv_ul_cross_str:
+  "\<lbrakk>sr_inv_ul sr P (P' and Q') f; \<And>s s'. (s, s') \<in> sr \<Longrightarrow> P s \<Longrightarrow> P' s' \<Longrightarrow> Q' s'\<rbrakk> \<Longrightarrow> sr_inv_ul sr P P' f "
+  by (clarsimp simp: sr_inv_stronger_imp)
+
+lemma return_sr_inv[simp]:
+  "sr_inv_ul sr P P' (return x)"
+  by (clarsimp simp: sr_inv_ul_def return_def)
+
+lemma sr_inv_ul_bind:
+  "\<lbrakk> sr_inv_ul sr P P' g; \<lbrace>P'\<rbrace> g \<lbrace> \<lambda>rv. Q' rv\<rbrace>; \<And>rv. sr_inv_ul sr P (Q' rv) (f rv) \<rbrakk>
+   \<Longrightarrow> sr_inv_ul sr P P' (g >>= f)"
+  apply (unfold sr_inv_ul_def valid_def)
+  apply clarify
+  apply (drule_tac x=s' in spec)
+  apply (drule (1) mp)
+  apply (unfold in_bind)
+  apply clarify
+  apply (drule_tac x=s and y=s' in spec2)
+  apply (drule_tac x=s'' in spec)
+  apply clarify
+  apply (drule_tac x=x in meta_spec)
+  apply (drule_tac x=s and y=s'' in spec2)
+  apply (drule_tac x=t' in spec)
+  apply (drule_tac x="(x, s'')" in bspec, simp)
+  apply simp
+  done
+
+lemma corres_noop_sr_inv:
+  assumes P: "sr_inv_ul sr P P' f"
+  assumes nf': "\<And>s. \<lbrakk> P s; nf' \<rbrakk> \<Longrightarrow> no_fail (\<lambda>s'. (s, s') \<in> sr \<and> P' s') f"
+  assumes r: "r () x"
+  shows "corres_underlying sr nf nf' r P P' (return x) f"
+  using P r
+  apply (simp add: corres_underlying_def return_def split_def)
+  apply (clarsimp simp: sr_inv_ul_def)
+  apply (drule_tac x=a and y=b in spec2, clarsimp)
+  apply (insert nf')
+  apply (clarsimp simp: valid_def no_fail_def)
+  done
+
+(* corres_symb_exec_r_sr basically combines the two lemmas corres_split_noop_rhs and corres_noop
+   in one and separates out the sr_inv part *)
+lemma corres_symb_exec_r_sr:
+  assumes z: "corres_underlying sr nf nf' r P Q' x y"
+  assumes sr: "sr_inv_ul sr P P' m"
+  assumes ex: "\<lbrace> P' \<rbrace> m \<lbrace>\<lambda>_. Q'\<rbrace>"
+  assumes nf: "nf' \<Longrightarrow> no_fail P' m"
+  shows "corres_underlying sr nf nf' r P P' x (m >>= (\<lambda>_. y))"
+  using sr z ex nf
+  unfolding corres_underlying_def sr_inv_ul_def
+  apply (clarsimp simp: corres_underlying_def bind_def)
+  apply (rename_tac s s')
+  apply (rule conjI; clarsimp simp: in_monad)
+   apply (drule_tac x=s and y=s' in spec2, clarsimp)
+   apply (rename_tac t' rv' s'')
+   apply (drule_tac x="(s, t')" in bspec, simp)
+   apply clarsimp
+   apply (drule use_valid[OF _ ex], simp)
+   apply clarsimp
+   apply (drule_tac x="(rv', s'')" in bspec, simp)
+   apply simp
+  apply (drule_tac x=s and y=s' in spec2, clarsimp simp: no_failD valid_def)
+  apply (rename_tac t')
+  apply (drule_tac x=t' in spec, clarsimp)
+  apply (drule_tac x=s' in spec, clarsimp)
+  apply (drule bspec[of "fst _"], simp)
+  apply clarsimp
+  apply ( drule_tac x="(s, t')" in bspec, simp)
+  by clarsimp
+
+lemma corres_noop_sr:
+  assumes sr: "sr_inv_ul sr P P' f"
+  assumes ex: "\<lbrace> P' \<rbrace> f \<lbrace>\<lambda>rv _. r x rv\<rbrace>"
+  assumes nf': "\<And>s. \<lbrakk> P s; nf' \<rbrakk> \<Longrightarrow> no_fail (\<lambda>s'. (s, s') \<in> sr \<and> P' s') f"
+  shows "corres_underlying sr nf nf' r P P' (return x) f"
+  using sr ex
+  apply (clarsimp simp: sr_inv_ul_def corres_underlying_def return_def)
+  apply (clarsimp simp: no_failD[OF nf'[simplified]] valid_def)
+  apply (drule_tac x=b in spec, clarsimp)
+  done
+
 end

--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -951,6 +951,11 @@ qed
 (* for instantiations *)
 lemma corres_inst: "corres_underlying sr nf nf' r P P' f g \<Longrightarrow> corres_underlying sr nf nf' r P P' f g" .
 
+(* for instantiations; only need to specify what you are adding *)
+lemma corres_inst_add:
+  "corres_underlying sr nf nf' r (P and Q) (P' and Q') f g
+   \<Longrightarrow> corres_underlying sr nf nf' r (P and Q) (P' and Q') f g" .
+
 lemma corres_assert_opt_assume:
   assumes "\<And>x. P' = Some x \<Longrightarrow> corres_underlying sr nf nf' r P Q f (g x)"
   assumes "\<And>s. Q s \<Longrightarrow> P' \<noteq> None"

--- a/lib/MonadicRewrite.thy
+++ b/lib/MonadicRewrite.thy
@@ -507,6 +507,30 @@ next
     by (fastforce simp: corres_underlying_def split_def)
 qed
 
+lemma monadic_rewrite_corres':
+  assumes cu: "corres_underlying R False nf' r P P' a c'"
+  and     me: "monadic_rewrite False True Q c c'"
+  shows   "corres_underlying R False nf' r  P (P' and Q) a c"
+proof (rule corres_underlyingI)
+  fix s t rv' t'
+  assume st: "(s, t) \<in> R" and pq: "(P' and Q) t" and ps: "P s" and ct: "(rv', t') \<in> fst (c t)"
+  from pq have P't: "P' t" and Qt: "Q t" by simp_all
+
+  from me ct Qt have c't: "(rv', t') \<in> fst (c' t)"
+   by (clarsimp simp: monadic_rewrite_def)
+
+  from cu st ps P't c't obtain s' rv where
+     as: "(rv, s') \<in> fst (a s)" and rest: "nf' \<longrightarrow> \<not> snd (c' t)" "(s', t') \<in> R" "r rv rv'"
+    by (fastforce elim: corres_underlyingE)
+
+  with rest as show "\<exists>(rv, s')\<in>fst (a s). (s', t') \<in> R \<and> r rv rv'" by auto
+next
+  fix s t
+  assume "(s, t) \<in> R" "(P' and Q) t" "P s" "nf'"
+  thus "\<not> snd (c t)" using cu me
+    by (fastforce simp: corres_underlying_def split_def monadic_rewrite_def)
+qed
+
 lemma monadic_rewrite_refine_valid:
   "monadic_rewrite F E P f g
     \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>

--- a/proof/refine/ARM/Corres.thy
+++ b/proof/refine/ARM/Corres.thy
@@ -23,4 +23,12 @@ abbreviation
 abbreviation
   "ex_abs \<equiv> ex_abs_underlying state_relation"
 
+abbreviation "sr_inv P P' f \<equiv> sr_inv_ul state_relation P P' f"
+
+lemmas sr_inv_def = sr_inv_ul_def
+
+lemmas sr_inv_imp = sr_inv_ul_imp[of state_relation]
+
+lemmas sr_inv_bind = sr_inv_ul_bind[where sr=state_relation]
+
 end

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -4053,17 +4053,16 @@ declare upd_simps[simp]
 lemma heap_ls_next_takeWhile_append:
   "\<lbrakk>heap_ls hp st xs; p \<in> set xs; hp p = Some np\<rbrakk>
   \<Longrightarrow>takeWhile ((\<noteq>) np) xs = (takeWhile ((\<noteq>) p) xs) @ [p]"
-   apply (prop_tac "distinct xs")
-    apply (erule heap_ls_distinct)
-   apply (frule in_list_decompose_takeWhile)
-   apply (prop_tac "heap_ls hp st (takeWhile ((\<noteq>) p) xs @ p # drop (length (takeWhile ((\<noteq>) p) xs) + 1) xs)")
-    apply simp
-   apply (drule heap_path_non_nil_lookup_next)
-   apply (case_tac "drop (length (takeWhile ((\<noteq>) p) xs) + 1) xs"; simp)
-   apply (prop_tac "np \<in> set xs")
-    apply (erule (2) heap_ls_next_in_list)
-   apply (frule in_list_decompose_takeWhile[where x=np])
-   apply (drule (1) distinct_inj_middle[where x=np and xa="takeWhile ((\<noteq>) np) xs" and ya="takeWhile ((\<noteq>) p) xs @ [p]"])
+  apply (frule heap_ls_distinct)
+  apply (frule in_list_decompose_takeWhile)
+  apply (prop_tac "heap_ls hp st (takeWhile ((\<noteq>) p) xs @ p # drop (length (takeWhile ((\<noteq>) p) xs) + 1) xs)")
+   apply simp
+  apply (drule heap_path_non_nil_lookup_next)
+  apply (case_tac "drop (length (takeWhile ((\<noteq>) p) xs) + 1) xs"; simp)
+  apply (prop_tac "np \<in> set xs")
+   apply (erule (2) heap_ls_next_in_list)
+  apply (frule in_list_decompose_takeWhile[where x=np])
+  apply (drule (1) distinct_inj_middle[where x=np and xa="takeWhile ((\<noteq>) np) xs" and ya="takeWhile ((\<noteq>) p) xs @ [p]"])
    apply simp+
   done
 

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -3800,6 +3800,10 @@ lemma invs_valid_release_queue' [elim!]:
   "invs' s \<Longrightarrow> valid_release_queue' s"
   by (simp add: invs'_def valid_state'_def)
 
+lemma invs_sym_list_refs_of_replies'[elim!]:
+  "invs' s \<Longrightarrow> sym_refs (list_refs_of_replies' s)"
+  by (simp add: invs'_def valid_state'_def)
+
 lemma invs_valid_idle'[elim!]:
   "invs' s \<Longrightarrow> valid_idle' s"
   by (fastforce simp: invs'_def valid_state'_def)
@@ -3891,6 +3895,7 @@ lemmas invs'_implies =
   invs_queues'
   invs_valid_release_queue
   invs_valid_release_queue'
+  invs_sym_list_refs_of_replies'
 
 lemma valid_bitmap_valid_bitmapQ_exceptE:
   "\<lbrakk> valid_bitmapQ_except d p s ; (bitmapQ d p s \<longleftrightarrow> ksReadyQueues s (d,p) \<noteq> []) ;

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -634,4 +634,77 @@ lemma replyRemoveTCB_invs':
               simp: cteCaps_of_def)
   done
 
+context begin interpretation Arch .
+
+lemma pspace_relation_reply_update_conc_only:
+  "\<lbrakk> pspace_relation s s'; s x = Some (Structures_A.Reply reply); s' x = Some (KOReply reply');
+     reply_relation reply new\<rbrakk>
+       \<Longrightarrow> pspace_relation s (s'(x \<mapsto> (KOReply new)))"
+  apply (simp add: pspace_relation_def pspace_dom_update dom_fun_upd2
+              del: dom_fun_upd)
+  apply (erule conjE)
+  apply (rule ballI, drule(1) bspec)
+  apply (clarsimp simp: split_def)
+  apply (drule bspec, simp)
+  apply (clarsimp simp: obj_relation_cuts_def2 cte_relation_def
+                        pte_relation_def pde_relation_def
+                 split: Structures_A.kernel_object.split_asm arch_kernel_obj.split_asm if_split_asm)
+  done
+end
+
+lemma replyPrevs_of_replyNext_update:
+  "ko_at' reply' rp s' \<Longrightarrow>
+      replyPrevs_of (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto>
+                            KOReply (reply' \<lparr> replyNext := v \<rparr>))\<rparr>) = replyPrevs_of s'"
+  apply (clarsimp simp: obj_at'_def projectKOs isNext_def
+                 split: option.split_asm reply_next.split_asm)
+  by (fastforce simp: projectKO_opt_reply opt_map_def)
+
+lemma scs_of'_replyNext_update:
+  "ko_at' reply' rp s' \<Longrightarrow>
+      scs_of' (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto>
+                            KOReply (reply' \<lparr> replyNext := v \<rparr>))\<rparr>) = scs_of' s'"
+  apply (clarsimp simp: obj_at'_def projectKOs isNext_def
+                 split: option.split_asm reply_next.split_asm)
+  by (fastforce simp: projectKO_opt_sc opt_map_def)
+
+lemma scs_of'_replyPrev_update:
+  "ko_at' reply' rp s' \<Longrightarrow>
+      scs_of' (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto>
+                            KOReply (reply' \<lparr> replyPrev := v \<rparr>))\<rparr>) = scs_of' s'"
+  apply (clarsimp simp: obj_at'_def projectKOs isNext_def
+                 split: option.split_asm reply_next.split_asm)
+  by (fastforce simp: projectKO_opt_sc opt_map_def)
+
+lemma sc_replies_relation_replyNext_update:
+  "\<lbrakk>sc_replies_relation s s'; ko_at' reply' rp s'\<rbrakk>
+     \<Longrightarrow> sc_replies_relation s(s'\<lparr>ksPSpace := (ksPSpace s')(rp \<mapsto>
+                                           KOReply (reply' \<lparr> replyNext := v \<rparr>))\<rparr>)"
+  by (clarsimp simp: scs_of'_replyNext_update[simplified]
+                     replyPrevs_of_replyNext_update[simplified])
+
+(* an example of an sr_inv lemma; to be used in reply_remove_tcb_corres *)
+lemma replyNext_Next_update_sr_inv:
+   "\<lbrakk>\<not>isHead v; isNext (replyNext r')\<rbrakk> \<Longrightarrow>
+    sr_inv P (P' and ko_at' r' rp)
+       (setReply rp (r' \<lparr> replyNext := v \<rparr>))"
+  unfolding sr_inv_def
+  apply (clarsimp simp: cleanReply_def in_monad setReply_def setObject_def
+                        exec_get split_def getReply_def projectKOs objBits_simps
+                        updateObject_default_def ARM_H.fromPPtr_def obj_at'_def
+                        in_magnitude_check replySizeBits_def
+                 split: option.split_asm)
+  apply (clarsimp simp: state_relation_def map_to_ctes_upd_other)
+  apply (frule reply_at'_cross[where ptr=rp])
+   apply (clarsimp simp: obj_at'_def objBits_simps projectKOs replySizeBits_def)
+  apply (rule conjI; clarsimp simp: obj_at_def is_reply)
+   apply (frule (1) pspace_relation_absD)
+   apply (erule (2) pspace_relation_reply_update_conc_only)
+   apply (clarsimp simp: reply_relation_def getHeadScPtr_def isNext_def isHead_def
+                  split: reply_next.splits option.splits)
+  apply (rule sc_replies_relation_replyNext_update[simplified])
+   apply simp
+  by (clarsimp simp: obj_at'_def objBits_simps projectKOs replySizeBits_def)
+
+
 end

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -637,9 +637,9 @@ lemma replyRemoveTCB_invs':
 context begin interpretation Arch .
 
 lemma pspace_relation_reply_update_conc_only:
-  "\<lbrakk> pspace_relation s s'; s x = Some (Structures_A.Reply reply); s' x = Some (KOReply reply');
+  "\<lbrakk> pspace_relation ps ps'; ps x = Some (Structures_A.Reply reply); ps' x = Some (KOReply reply');
      reply_relation reply new\<rbrakk>
-       \<Longrightarrow> pspace_relation s (s'(x \<mapsto> (KOReply new)))"
+   \<Longrightarrow> pspace_relation ps (ps'(x \<mapsto> (KOReply new)))"
   apply (simp add: pspace_relation_def pspace_dom_update dom_fun_upd2
               del: dom_fun_upd)
   apply (erule conjE)
@@ -650,6 +650,7 @@ lemma pspace_relation_reply_update_conc_only:
                         pte_relation_def pde_relation_def
                  split: Structures_A.kernel_object.split_asm arch_kernel_obj.split_asm if_split_asm)
   done
+
 end
 
 lemma replyPrevs_of_replyNext_update:
@@ -660,27 +661,18 @@ lemma replyPrevs_of_replyNext_update:
                  split: option.split_asm reply_next.split_asm)
   by (fastforce simp: projectKO_opt_reply opt_map_def)
 
-lemma scs_of'_replyNext_update:
-  "ko_at' reply' rp s' \<Longrightarrow>
-      scs_of' (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto>
-                            KOReply (reply' \<lparr> replyNext := v \<rparr>))\<rparr>) = scs_of' s'"
-  apply (clarsimp simp: obj_at'_def projectKOs isNext_def
-                 split: option.split_asm reply_next.split_asm)
-  by (fastforce simp: projectKO_opt_sc opt_map_def)
-
-lemma scs_of'_replyPrev_update:
-  "ko_at' reply' rp s' \<Longrightarrow>
-      scs_of' (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto>
-                            KOReply (reply' \<lparr> replyPrev := v \<rparr>))\<rparr>) = scs_of' s'"
+lemma scs_of'_reply_update:
+  "reply_at' rp s' \<Longrightarrow>
+      scs_of' (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto> KOReply reply)\<rparr>) = scs_of' s'"
   apply (clarsimp simp: obj_at'_def projectKOs isNext_def
                  split: option.split_asm reply_next.split_asm)
   by (fastforce simp: projectKO_opt_sc opt_map_def)
 
 lemma sc_replies_relation_replyNext_update:
   "\<lbrakk>sc_replies_relation s s'; ko_at' reply' rp s'\<rbrakk>
-     \<Longrightarrow> sc_replies_relation s(s'\<lparr>ksPSpace := (ksPSpace s')(rp \<mapsto>
+     \<Longrightarrow> sc_replies_relation s (s'\<lparr>ksPSpace := (ksPSpace s')(rp \<mapsto>
                                            KOReply (reply' \<lparr> replyNext := v \<rparr>))\<rparr>)"
-  by (clarsimp simp: scs_of'_replyNext_update[simplified]
+  by (clarsimp simp: scs_of'_reply_update[simplified] obj_at'_def
                      replyPrevs_of_replyNext_update[simplified])
 
 (* an example of an sr_inv lemma; to be used in reply_remove_tcb_corres *)

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -646,8 +646,7 @@ lemma replyNext_Next_update_sr_inv:
    apply (erule (2) pspace_relation_reply_update_conc_only)
    apply (clarsimp simp: reply_relation_def getHeadScPtr_def isNext_def isHead_def
                   split: reply_next.splits option.splits)
-  apply (rule sc_replies_relation_replyNext_update[simplified])
-   apply simp
+  apply (erule sc_replies_relation_replyNext_update[simplified])
   by (clarsimp simp: obj_at'_def objBits_simps projectKOs replySizeBits_def)
 
 (* for reply_remove_tcb_corres *)
@@ -655,7 +654,7 @@ lemma replyNext_Next_update_sr_inv:
 (** sym_refs and prev/next; scReply and replySc *)
 
 lemma sym_refs_replySc_scReplies_of:
-  "\<lbrakk>reply_at' rp s';sym_refs (state_refs_of' s'); sc_at' scp s'\<rbrakk>
+  "\<lbrakk>reply_at' rp s'; sym_refs (state_refs_of' s'); sc_at' scp s'\<rbrakk>
    \<Longrightarrow> (replies_of' s' |> replySc) rp = Some scp \<longleftrightarrow> scReplies_of s' scp = Some rp"
   apply (rule iffI)
    apply (drule_tac tp=SCReply and x=rp and y=scp in sym_refsE;
@@ -695,7 +694,6 @@ lemma sc_replies_relation_prevs_list':
      kheap s scp = Some (kernel_object.SchedContext sc n)\<rbrakk>
     \<Longrightarrow> heap_ls (replyPrevs_of s') (scReplies_of s' scp) (sc_replies sc)"
   apply (clarsimp simp: sc_replies_relation_def sc_replies_of_scs_def scs_of_kh_def map_project_def)
-  apply (drule_tac x=scp and y="sc_replies sc" in spec2)
   apply (clarsimp simp: opt_map_left_Some sc_of_def)
   done
 
@@ -731,7 +729,6 @@ lemma sc_replies_relation_sc_with_reply_cross_eq_pred:
   apply (case_tac "rp \<in> set (sc_replies sc)"; simp)
   apply (prop_tac "\<forall>xs. rp \<notin> set xs \<longrightarrow> takeWhile ((\<noteq>) rp) xs = xs")
    using takeWhile_eq_all_conv apply blast
-  apply (drule_tac x="sc_replies sc" in spec)
   apply clarsimp
   using heap_path_end_unique by blast
 
@@ -746,7 +743,7 @@ lemma sc_replies_relation_sc_with_reply_cross_eq:
 lemma sc_replies_relation_sc_with_reply_None:
   "\<lbrakk>sc_replies_relation s s'; reply_at rp s; ko_at' (reply'::reply) rp s';
     sc_with_reply rp s = None; valid_replies s\<rbrakk>
-     \<Longrightarrow> sc_replies_relation s(s'\<lparr>ksPSpace := (ksPSpace s')(rp \<mapsto> KOReply (f reply'))\<rparr>)"
+     \<Longrightarrow> sc_replies_relation s (s'\<lparr>ksPSpace := (ksPSpace s')(rp \<mapsto> KOReply (f reply'))\<rparr>)"
   apply (clarsimp simp: sc_replies_relation_def)
   apply (rename_tac scp replies)
   apply (drule_tac x=scp and y=replies in spec2)
@@ -789,15 +786,11 @@ lemma next_reply_in_sc_replies:
   using heap_ls_unique sc_replies_relation_prevs_list' apply blast
   apply simp
   apply (frule (3) heap_ls_prev_cases[OF _ _ _ reply_sym_heap_Prev_Next])
-  apply (frule (1) sym_refs_replySCs_of_None)
+  apply (drule (1) sym_refs_replySCs_of_None)
    apply (erule replyNexts_Some_replySCs_None)
-  apply (drule_tac x=scp in spec)
   apply (clarsimp simp: vs_heap_simps)
-  apply (frule (2) heap_ls_next_takeWhile_append[where p=nrp])
-  apply (frule in_list_decompose_takeWhile[where x=rp])
-  apply (frule in_list_decompose_takeWhile[where x=nrp])
-  apply auto
-  done
+  apply (drule (2) heap_ls_next_takeWhile_append)
+  by (force dest!: in_list_decompose_takeWhile)
 
 lemma prev_reply_in_sc_replies:
   "\<lbrakk>sc_replies_relation s s'; sc_with_reply rp s = Some scp; sym_refs (list_refs_of_replies' s');

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -464,11 +464,9 @@ abbreviation sc_replies_relation :: "det_state \<Rightarrow> kernel_state \<Righ
 
 lemmas sc_replies_relation_def = sc_replies_relation_2_def
 
-abbreviation sc_replies_relation_obj ::
-  "Structures_A.kernel_object \<Rightarrow> kernel_object \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref) \<Rightarrow> bool" where
-  "sc_replies_relation_obj obj obj' nexts \<equiv>
-   case (obj, obj') of
-     (Structures_A.SchedContext sc _, KOSchedContext sc') \<Rightarrow>
+abbreviation (input) sc_replies_relation_obj ::
+  "Structures_A.sched_context \<Rightarrow> sched_context \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref) \<Rightarrow> bool" where
+  "sc_replies_relation_obj sc sc' nexts \<equiv>
        heap_ls nexts (scReply sc') (sc_replies sc)"
 
 primrec

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -900,14 +900,13 @@ lemma sc_replies_prevs_walk:
   apply (clarsimp simp: opt_map_def projectKO_opt_sc)
   done
 
-lemma sc_replies_relation_prevs_list:
+lemma sc_replies_relation_prevs_list':
   "\<lbrakk> sc_replies_relation s s';
-     kheap s x = Some (kernel_object.SchedContext sc n);
-     ksPSpace s' x = Some (KOSchedContext sc')\<rbrakk>
-    \<Longrightarrow> heap_ls (replyPrevs_of s') (scReply sc') (sc_replies sc)"
+     kheap s scp = Some (kernel_object.SchedContext sc n)\<rbrakk>
+    \<Longrightarrow> heap_ls (replyPrevs_of s') (scReplies_of s' scp) (sc_replies sc)"
   apply (clarsimp simp: sc_replies_relation_def sc_replies_of_scs_def scs_of_kh_def map_project_def)
-  apply (drule_tac x=x and y="sc_replies sc" in spec2)
-  apply (clarsimp simp: sc_of_def opt_map_def projectKO_opt_sc split: option.splits)
+  apply (drule_tac x=scp and y="sc_replies sc" in spec2)
+  apply (clarsimp simp: opt_map_left_Some sc_of_def)
   done
 
 lemma list_refs_of_replies'_reftype[simp]:

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -158,7 +158,7 @@ lemma set_object_valid_tcbs[wp]:
   done
 
 lemma set_reply_obj_ref_valid_tcb[wp]:
-  "set_reply_obj_ref reply_tcb_update rp opt \<lbrace>valid_tcb ptr tcb\<rbrace>"
+  "set_reply_obj_ref f rp opt \<lbrace>valid_tcb ptr tcb\<rbrace>"
   apply (clarsimp simp: update_sk_obj_ref_def set_simple_ko_def)
   apply (wpsimp wp: set_object_typ_ats get_object_wp)
   done
@@ -172,40 +172,30 @@ lemma set_simple_ko_not_tcb_at[wp]:
   done
 
 lemma set_reply_obj_ref_not_tcb_at[wp]:
-  "set_reply_obj_ref reply_tcb_update rp opt \<lbrace>\<lambda>s. \<not> ko_at (TCB tcb) t s\<rbrace>"
+  "set_reply_obj_ref f rp opt \<lbrace>\<lambda>s. \<not> ko_at (TCB tcb) t s\<rbrace>"
   apply (clarsimp simp: update_sk_obj_ref_def)
   apply (wpsimp wp: set_simple_ko_wp get_simple_ko_wp)
   apply (clarsimp simp: obj_at_def sk_obj_at_pred_def pred_neg_def split: if_splits)
   done
 
 lemma set_reply_obj_ref_valid_tcbs[wp]:
-  "set_reply_obj_ref reply_tcb_update rp opt \<lbrace>valid_tcbs\<rbrace>"
+  "set_reply_obj_ref f rp opt \<lbrace>valid_tcbs\<rbrace>"
   unfolding valid_tcbs_def
   apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' simp: pred_neg_def)
   done
 
-lemma set_endpoint_valid_tcb[wp]:
-  "set_endpoint ep endpoint \<lbrace>valid_tcb ptr tcb\<rbrace>"
+lemma set_simple_ko_valid_tcb[wp]:
+  "set_simple_ko C p obj \<lbrace>valid_tcb ptr tcb\<rbrace>"
   apply (clarsimp simp: set_simple_ko_def)
   apply (wpsimp wp: set_object_typ_ats get_object_wp)+
   done
 
-lemma set_endpoint_valid_tcbs[wp]:
-  "set_endpoint ep endpoint \<lbrace>valid_tcbs\<rbrace>"
+lemma set_simple_ko_valid_tcbs[wp]:
+  "set_endpoint ep eval \<lbrace>valid_tcbs\<rbrace>"
+  "set_notification ntfnptr nval \<lbrace>valid_tcbs\<rbrace>"
+  "set_reply rptr rval \<lbrace>valid_tcbs\<rbrace>"
   unfolding valid_tcbs_def
-  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')
-  done
-
-lemma set_notification_valid_tcb[wp]:
-  "set_notification ntfnptr val \<lbrace>valid_tcb ptr tcb\<rbrace>"
-  apply (clarsimp simp: set_simple_ko_def)
-  apply (wpsimp wp: get_object_wp)
-  done
-
-lemma set_notification_valid_tcbs[wp]:
-  "set_notification ntfnptr val \<lbrace>valid_tcbs\<rbrace>"
-  unfolding valid_tcbs_def
-  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')
+  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')+
   done
 
 context begin interpretation Arch .


### PR DESCRIPTION
This adds the proof of new `reply_remove_tcb_corres` lemma, and all the other lemmas it needs.

Lemmas are roughly grouped as:
- `sr_inv_ul` (mostly reviewed in #160 )
- various `heap_path` and `sym_heap` lemmas (some were in #158 )
- concrete version `sc_with_reply’` and cross lemmas for it
- `cleanReply` lemmas
- various wp rules, for `sc_with_reply’` and others
- a bunch of corres rules for modifying the reply queue
- and others 

There are a few lemmas that are tweaks of existing lemmas in AInvs. These could replace the originals most of the time but that requires fixing AInvs, which I will do separately. Also, most of what’s added in IpcCancel_R could go into Reply_R, but that requires moving `reply_unlink_tcb_corres` and its dependencies first, which again I defer for now.

This altogether is about 2000 lines of new proof, and that’s just for one corres rule for a new function for MCS.
