### PR TITLE
reply_unlink_sc update

### DIFF
--- a/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
@@ -576,11 +576,12 @@ lemma reply_unlink_sc_not_live:
   "\<lbrace>obj_at (\<lambda>ko. \<exists>r. ko = Reply r \<and> reply_tcb r = None) reply and invs\<rbrace>
      reply_unlink_sc sc_ptr reply
    \<lbrace>\<lambda>rv. obj_at (\<lambda>ko. \<not> live ko \<and> is_reply ko) reply\<rbrace>"
+  unfolding reply_unlink_sc_def
   apply (wpsimp wp: update_sched_context_obj_at_impossible
                     simple_obj_set_prop_at get_simple_ko_wp
                     set_simple_ko_obj_at_disjoint hoare_vcg_all_lift
-              simp: reply_unlink_sc_def is_reply update_sk_obj_ref_def
-        | wp (once) hoare_drop_imps)+
+              simp: is_reply
+        | wp (once) hoare_drop_imps | simp)+
   apply (clarsimp simp: obj_at_def live_def live_reply_def invs_reply_tcb_None_reply_sc_None)
   done
 
@@ -606,8 +607,7 @@ lemma reply_unlink_sc_None:
   apply (wpsimp simp: is_reply update_sk_obj_ref_def
                wp: update_sched_context_obj_at_impossible simple_obj_set_prop_at get_simple_ko_wp
                    set_simple_ko_obj_at_disjoint hoare_vcg_all_lift assert_wp hoare_vcg_const_imp_lift
-        | wp (once) hoare_drop_imps)+
-  apply (rule conjI, clarsimp)
+        | wp (once) hoare_drop_imps | simp)+
    apply (erule_tac p=scp in obj_at_valid_objsE, assumption)
    apply (clarsimp simp: valid_obj_def valid_sched_context_def dest!:distinct_hd_not_in_tl)
   apply (clarsimp simp: obj_at_def)

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -3474,9 +3474,7 @@ lemma reply_unlink_sc_valid_sched_misc[wp]:
           (ready_queues s) (release_queue s) (scheduler_action s)
           (etcbs_of s) (tcb_sts_of s) (tcb_scps_of s) (tcb_faults_of s)
           (sc_refill_cfgs_of s)\<rbrace>"
-  apply (wpsimp simp: reply_unlink_sc_def
-                  wp: update_sk_obj_ref_wps set_simple_ko_wps get_simple_ko_wp)
-  by (auto simp: obj_at_kh_kheap_simps vs_all_heap_simps pred_map_simps fun_upd_def)
+  by (wpsimp simp: reply_unlink_sc_def wp: get_simple_ko_wp)
 
 lemma reply_unlink_tcb_valid_sched_pred_lift:
   assumes "\<lbrace>\<lambda>s::'z::state_ext state. valid_sched_pred_strong P' s\<rbrace>

--- a/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
@@ -959,11 +959,12 @@ lemma reply_unlink_sc_not_live:
   "\<lbrace>obj_at (\<lambda>ko. \<exists>r. ko = Reply r \<and> reply_tcb r = None) reply and invs\<rbrace>
      reply_unlink_sc sc_ptr reply
    \<lbrace>\<lambda>rv. obj_at (\<lambda>ko. \<not> live ko \<and> is_reply ko) reply\<rbrace>"
+  unfolding reply_unlink_sc_def
   apply (wpsimp wp: update_sched_context_obj_at_impossible
                     simple_obj_set_prop_at get_simple_ko_wp
                     set_simple_ko_obj_at_disjoint hoare_vcg_all_lift
-              simp: reply_unlink_sc_def is_reply update_sk_obj_ref_def
-        | wp (once) hoare_drop_imps)+
+              simp: is_reply
+        | wp (once) hoare_drop_imps | simp)+
   apply (clarsimp simp: obj_at_def live_def live_reply_def invs_reply_tcb_None_reply_sc_None)
   done
 
@@ -989,8 +990,7 @@ lemma reply_unlink_sc_None:
   apply (wpsimp simp: is_reply update_sk_obj_ref_def
                wp: update_sched_context_obj_at_impossible simple_obj_set_prop_at get_simple_ko_wp
                    set_simple_ko_obj_at_disjoint hoare_vcg_all_lift assert_wp hoare_vcg_const_imp_lift
-        | wp (once) hoare_drop_imps)+
-  apply (rule conjI, clarsimp)
+        | wp (once) hoare_drop_imps | simp)+
    apply (erule_tac p=scp in obj_at_valid_objsE, assumption)
    apply (clarsimp simp: valid_obj_def valid_sched_context_def dest!:distinct_hd_not_in_tl)
   apply (clarsimp simp: obj_at_def)

--- a/proof/invariant-abstract/RealTime_AI.thy
+++ b/proof/invariant-abstract/RealTime_AI.thy
@@ -825,10 +825,10 @@ lemma reply_remove_arch[wp]:
 
 lemma reply_unlink_sc_valid_objs [wp]:
   "\<lbrace>valid_objs\<rbrace> reply_unlink_sc scp rp \<lbrace>\<lambda>_. valid_objs\<rbrace>"
-  apply (simp add: reply_unlink_sc_def)
+  apply (simp add: reply_unlink_sc_def liftM_def)
   apply (wpsimp simp: reply_at_typ sc_at_typ
                   wp: valid_sc_typ_list_all_reply[simplified reply_at_typ]
-                      hoare_vcg_imp_lift hoare_vcg_ex_lift
+                      hoare_vcg_imp_lift hoare_vcg_ex_lift abs_typ_at_lifts
                       hoare_vcg_all_lift get_simple_ko_wp)
   apply (safe;
          clarsimp elim!: obj_at_valid_objsE
@@ -940,8 +940,6 @@ lemma reply_unlink_sc_iflive[wp]:
   apply (wpsimp wp: hoare_vcg_imp_lift hoare_vcg_ex_lift hoare_vcg_disj_lift
                     hoare_vcg_all_lift get_simple_ko_wp)
   apply (safe; (drule(1) ko_at_obj_congD; clarsimp)+)
-     apply (fastforce simp: live_def live_sc_def obj_at_def
-                     dest!: if_live_then_nonz_capD2 valid_objs_ko_at)
     apply (fastforce simp: live_def obj_at_def live_reply_def
                     dest!: if_live_then_nonz_capD2 valid_objs_ko_at)
    apply (subgoal_tac "xa \<in> set (sc_replies scb)")

--- a/spec/abstract/IpcCancel_A.thy
+++ b/spec/abstract/IpcCancel_A.thy
@@ -148,11 +148,11 @@ where
      if hd sc_replies = reply_ptr
      then do  \<comment> \<open>if it is the head\<close>
        assert (reply_sc reply = Some sc_ptr); \<comment> \<open>only the head of the list should point to the sc\<close>
-       set_reply reply_ptr (reply_sc_update (K None) reply); \<comment> \<open>set @{text reply_sc} to None\<close>
+       update_sched_context sc_ptr (sc_replies_update tl); \<comment> \<open>pop the head\<close>
        case tl sc_replies of
            [] \<Rightarrow> return ()
          | r'#_ \<Rightarrow> set_reply_obj_ref reply_sc_update r' (Some sc_ptr); \<comment> \<open>fix up the refs\<close>
-       set_sc_obj_ref sc_replies_update sc_ptr (tl sc_replies) \<comment> \<open>pop the head\<close>
+       set_reply reply_ptr (reply_sc_update (K None) reply) \<comment> \<open>set @{text reply_sc} to None\<close>
      od
      else do
        assert (reply_sc reply = None); \<comment> \<open>only the head of the list should point to the sc\<close>


### PR DESCRIPTION
This PR contains:

1. tweak the if-true branch of reply_unlink_sc to match replyPop
    
    - reorder to align with replyPop
    - use update_sched_context instead of set_sc_obj_ref

2. some proof fixes for the above change
