### PR TITLE
rt reply pop tweaks

### DIFF
--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3468,12 +3468,18 @@ lemma setQueue_valid_reply'[wp]:
   apply (fastforce simp: valid_reply'_def valid_bound_obj'_def split: option.splits)
   done
 
+lemma valid_sched_context_size'_scReply_update[simp]:
+  "valid_sched_context_size' (scReply_update f ko) = valid_sched_context_size' ko"
+  by (clarsimp simp: valid_sched_context_size'_def scBits_simps objBits_simps)
+
 lemma replyPop_valid_queues:
   "\<lbrace>valid_queues and valid_objs'\<rbrace> replyPop replyPtr tcbPtr \<lbrace>\<lambda>_. valid_queues\<rbrace>"
   apply (clarsimp simp: replyPop_def)
   apply (wpsimp wp: schedContextDonate_valid_queues replyUnlink_valid_objs'
-                    hoare_drop_imps hoare_vcg_if_lift2
-         | intro conjI impI)+
+                    hoare_drop_imps hoare_vcg_if_lift2 updateReply_valid_objs'_preserved
+         | intro conjI impI
+         | clarsimp dest!: reply_ko_at_valid_objs_valid_reply' sc_ko_at_valid_objs_valid_sc'
+                     simp: valid_sched_context'_def valid_reply'_def)+
   done
 
 lemma threadSet_valid_reply'[wp]:
@@ -3522,22 +3528,15 @@ lemma replyPop_valid_objs'[wp]:
   apply (rule hoare_seq_ext[OF _ get_reply_sp'])
   apply (repeat_unless \<open>rule hoare_seq_ext[OF _ gts_sp']\<close>
                        \<open>rule hoare_seq_ext_skip, solves wpsimp\<close>)
-  apply (rule_tac Q="valid_objs' and valid_reply' reply and tcb_at' tcbPtr"
+  apply (rule_tac Q="valid_objs' and ko_at' reply replyPtr and tcb_at' tcbPtr"
                in hoare_weaken_pre[rotated])
-   apply (fastforce intro!: reply_ko_at_valid_objs_valid_reply')
-  apply (intro hoare_seq_ext[OF _ assert_sp])
-  apply (rule hoare_seq_ext, wpsimp wp: replyUnlink_valid_objs')
-  apply (rule hoare_when_cases, clarsimp)
-  apply (rule hoare_seq_ext[OF _ assert_sp])
-  apply (rule hoare_seq_ext_skip; wp)
-     apply (wp hoare_vcg_if_lift hoare_vcg_imp_lift hoare_vcg_all_lift)
-    apply (rule getSchedContext_wp)
-   apply (rule_tac Q="\<lambda>_. valid_objs' and valid_reply' reply" in hoare_strengthen_post[rotated])
-    apply (fastforce dest: sc_ko_at_valid_objs_valid_sc' reply_ko_at_valid_objs_valid_reply'
+   apply clarsimp
+  apply (wpsimp wp: updateReply_valid_objs'_preserved replyUnlink_valid_objs'
+                 hoare_vcg_if_lift hoare_drop_imps schedContextDonate_valid_objs'
+           simp: valid_reply'_def split_del: if_split cong: conj_cong)
+  by (clarsimp dest!: sc_ko_at_valid_objs_valid_sc' reply_ko_at_valid_objs_valid_reply'
                      simp: valid_reply'_def valid_sched_context_size'_def
                            valid_sched_context'_def objBits_def objBitsKO_def)
-   apply (wpsimp wp: schedContextDonate_valid_objs')+
-  done
 
 lemma replyRemove_valid_queues:
   "\<lbrace>valid_queues and valid_objs'\<rbrace> replyRemove replyPtr tcbPtr \<lbrace>\<lambda>_. valid_queues\<rbrace>"
@@ -3725,15 +3724,15 @@ lemma replyPop_valid_inQ_queues[wp]:
   apply (rule hoare_seq_ext[OF _ get_reply_sp'])
   apply (repeat_unless \<open>rule hoare_seq_ext[OF _ gts_sp']\<close>
                        \<open>rule hoare_seq_ext_skip, solves wpsimp\<close>)
-  apply (rule_tac Q="?pre and tcb_at' tcbPtr" in hoare_weaken_pre[rotated])
+  apply (rule_tac Q="?pre and tcb_at' tcbPtr and ko_at' reply replyPtr"
+         in hoare_weaken_pre[rotated])
    apply fastforce
-  apply (intro hoare_seq_ext[OF _ assert_sp])
-  apply (rule hoare_seq_ext, wpsimp wp: replyUnlink_valid_objs')
-  apply (rule hoare_when_cases, clarsimp)
-  apply (wpsimp wp: set_sc'.valid_inQ_queues hoare_drop_imps schedContextDonate_valid_inQ_queues
-                    threadGet_wp
-         | intro conjI impI)+
-  apply (clarsimp simp: obj_at'_def projectKOs)
+  apply (wpsimp wp: schedContextDonate_valid_inQ_queues
+                    updateReply_valid_objs'_preserved replyUnlink_valid_objs'
+                    hoare_vcg_if_lift hoare_drop_imps
+              cong: conj_cong simp: valid_reply'_def)
+  apply (clarsimp dest!: sc_ko_at_valid_objs_valid_sc' reply_ko_at_valid_objs_valid_reply'
+                   simp: valid_sched_context'_def valid_reply'_def)
   done
 
 crunches replyRemove, replyClear

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -2914,10 +2914,9 @@ lemma replyPop_makes_unlive:
    replyPop rptr tptr
    \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') rptr\<rbrace>"
   apply (simp add: replyPop_def)
-  apply (wpsimp wp: replyUnlink_makes_unlive cleanReply_obj_at_next_prev_none
-                    hoare_vcg_if_lift threadGet_wp
+  by (wpsimp wp: replyUnlink_makes_unlive cleanReply_obj_at_next_prev_none
+                    hoare_vcg_if_lift
          | wp (once) hoare_drop_imps)+
-  by (clarsimp simp: obj_at'_def)
 
 lemma replyRemove_makes_unlive:
   "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
@@ -3531,12 +3530,13 @@ lemma replyPop_valid_objs'[wp]:
   apply (rule_tac Q="valid_objs' and ko_at' reply replyPtr and tcb_at' tcbPtr"
                in hoare_weaken_pre[rotated])
    apply clarsimp
-  apply (wpsimp wp: updateReply_valid_objs'_preserved replyUnlink_valid_objs'
-                 hoare_vcg_if_lift hoare_drop_imps schedContextDonate_valid_objs'
-           simp: valid_reply'_def split_del: if_split cong: conj_cong)
+  apply (wpsimp wp: replyUnlink_valid_objs' schedContextDonate_valid_objs')
+         apply (rule_tac Q="\<lambda>_. valid_objs' and tcb_at' tcbPtr" in hoare_strengthen_post[rotated])
+          apply clarsimp
+         apply (wpsimp wp: updateReply_valid_objs'_preserved hoare_drop_imps
+                     simp: valid_reply'_def)+
   by (clarsimp dest!: sc_ko_at_valid_objs_valid_sc' reply_ko_at_valid_objs_valid_reply'
-                     simp: valid_reply'_def valid_sched_context_size'_def
-                           valid_sched_context'_def objBits_def objBitsKO_def)
+                simp: valid_reply'_def valid_sched_context'_def)
 
 lemma replyRemove_valid_queues:
   "\<lbrace>valid_queues and valid_objs'\<rbrace> replyRemove replyPtr tcbPtr \<lbrace>\<lambda>_. valid_queues\<rbrace>"
@@ -3727,10 +3727,11 @@ lemma replyPop_valid_inQ_queues[wp]:
   apply (rule_tac Q="?pre and tcb_at' tcbPtr and ko_at' reply replyPtr"
          in hoare_weaken_pre[rotated])
    apply fastforce
-  apply (wpsimp wp: schedContextDonate_valid_inQ_queues
-                    updateReply_valid_objs'_preserved replyUnlink_valid_objs'
-                    hoare_vcg_if_lift hoare_drop_imps
-              cong: conj_cong simp: valid_reply'_def)
+  apply (wpsimp wp: schedContextDonate_valid_inQ_queues replyUnlink_valid_objs')
+         apply (rule_tac Q="\<lambda>_. valid_inQ_queues and valid_objs' and tcb_at' tcbPtr" in hoare_strengthen_post[rotated])
+          apply clarsimp
+  apply (wpsimp wp: updateReply_valid_objs'_preserved hoare_drop_imps
+              simp: valid_reply'_def)+
   apply (clarsimp dest!: sc_ko_at_valid_objs_valid_sc' reply_ko_at_valid_objs_valid_reply'
                    simp: valid_sched_context'_def valid_reply'_def)
   done

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -1839,7 +1839,7 @@ lemma handleFaultReply_cur' [wp]:
 lemma replyRemove_valid_objs'[wp]:
   "replyRemove replyPtr tcbPtr \<lbrace>valid_objs'\<rbrace>"
   unfolding replyRemove_def
-  by (wpsimp wp: updateReply_valid_objs'_preserved replyUnlink_valid_objs'
+  by (wpsimp wp: updateReply_valid_objs' replyUnlink_valid_objs'
                  hoare_vcg_if_lift hoare_drop_imps
            simp: valid_reply'_def split_del: if_split)
 

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -1838,30 +1838,10 @@ lemma handleFaultReply_cur' [wp]:
 
 lemma replyRemove_valid_objs'[wp]:
   "replyRemove replyPtr tcbPtr \<lbrace>valid_objs'\<rbrace>"
-  apply (clarsimp simp: replyRemove_def)
-  apply (rule hoare_seq_ext[OF _ get_reply_sp'], rename_tac reply)
-  apply (intro hoare_seq_ext[OF _ assert_opt_sp] hoare_seq_ext[OF _ assert_sp]
-               hoare_seq_ext[OF _ gts_sp'])
-  apply (rule hoare_if; (solves wpsimp)?)
-  apply (rule_tac Q="valid_objs' and valid_reply' reply" in hoare_weaken_pre[rotated])
-   apply (fastforce dest: reply_ko_at_valid_objs_valid_reply')
-  apply (rule hoare_seq_ext_skip)
-   apply (clarsimp simp: when_def pred_conj_def)
-   apply (rule hoare_vcg_conj_lift)
-    apply (wpsimp wp: set_reply_valid_objs')
-    apply (fastforce dest: reply_ko_at_valid_objs_valid_reply'
-                     simp: valid_reply'_def)
-   apply (wpsimp wp: set_reply'.set_wp)
-   apply (clarsimp simp: valid_reply'_def valid_bound_obj'_def)
-   apply (fastforce simp: obj_at'_def projectKOs objBitsKO_def split: option.splits)
-  apply (rule_tac B="\<lambda>_. valid_objs'" in hoare_seq_ext[rotated])
-   apply (clarsimp simp: when_def)
-   apply (intro conjI impI; (solves wpsimp)?)
-   apply (wpsimp wp: set_reply_valid_objs')
-   apply (fastforce dest: reply_ko_at_valid_objs_valid_reply'
-                    simp: valid_reply'_def)
-  apply (wpsimp wp: replyUnlink_valid_objs')
-  done
+  unfolding replyRemove_def
+  by (wpsimp wp: updateReply_valid_objs'_preserved replyUnlink_valid_objs'
+                 hoare_vcg_if_lift hoare_drop_imps
+           simp: valid_reply'_def split_del: if_split)
 
 lemma emptySlot_weak_sch_act[wp]:
   "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -80,13 +80,13 @@ This module specifies the behavior of reply objects.
 >     when (nextReplyPtrOpt /= Nothing) $ do
 >         assert (isHead nextReplyPtrOpt) "the reply must be at the head"
 >         scPtr <- return $ theHeadScPtr nextReplyPtrOpt
->         tcbScPtrOpt <- threadGet tcbSchedContext tcbPtr
->         when (tcbScPtrOpt == Nothing) $ schedContextDonate scPtr tcbPtr
 >         sc <- getSchedContext scPtr
+>         tcbScPtrOpt <- threadGet tcbSchedContext tcbPtr
 >         setSchedContext scPtr (sc { scReply = prevReplyPtrOpt })
 >         when (prevReplyPtrOpt /= Nothing) $ do
 >             prevReplyPtr <- return $ fromJust prevReplyPtrOpt
 >             updateReply prevReplyPtr (\reply -> reply { replyNext = replyNext reply })
+>         when (tcbScPtrOpt == Nothing) $ schedContextDonate scPtr tcbPtr
 >     cleanReply replyPtr
 >     replyUnlink replyPtr tcbPtr
 

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -86,8 +86,7 @@ This module specifies the behavior of reply objects.
 >         setSchedContext scPtr (sc { scReply = prevReplyPtrOpt })
 >         when (prevReplyPtrOpt /= Nothing) $ do
 >             prevReplyPtr <- return $ fromJust prevReplyPtrOpt
->             prevReply <- getReply prevReplyPtr
->             setReply prevReplyPtr (prevReply { replyNext = replyNext reply })
+>             updateReply prevReplyPtr (\reply -> reply { replyNext = replyNext reply })
 >     cleanReply replyPtr
 >     replyUnlink replyPtr tcbPtr
 
@@ -107,13 +106,11 @@ This module specifies the behavior of reply objects.
 >        else do
 >            when (nextReplyPtrOpt /= Nothing) $ do
 >                nextReplyPtr <- return $ theReplyNextPtr nextReplyPtrOpt
->                nextReply <- getReply nextReplyPtr
->                setReply nextReplyPtr (nextReply { replyPrev = Nothing })
+>                updateReply nextReplyPtr (\reply -> reply { replyPrev = Nothing })
 
 >            when (prevReplyPtrOpt /= Nothing) $ do
 >                prevReplyPtr <- return $ fromJust prevReplyPtrOpt
->                prevReply <- getReply prevReplyPtr
->                setReply prevReplyPtr (prevReply { replyNext = Nothing })
+>                updateReply prevReplyPtr (\reply -> reply { replyNext = Nothing })
 
 >            cleanReply replyPtr
 >            replyUnlink replyPtr tcbPtr

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -81,11 +81,11 @@ This module specifies the behavior of reply objects.
 >         assert (isHead nextReplyPtrOpt) "the reply must be at the head"
 >         scPtr <- return $ theHeadScPtr nextReplyPtrOpt
 >         sc <- getSchedContext scPtr
->         tcbScPtrOpt <- threadGet tcbSchedContext tcbPtr
 >         setSchedContext scPtr (sc { scReply = prevReplyPtrOpt })
 >         when (prevReplyPtrOpt /= Nothing) $ do
 >             prevReplyPtr <- return $ fromJust prevReplyPtrOpt
 >             updateReply prevReplyPtr (\reply -> reply { replyNext = replyNext reply })
+>         tcbScPtrOpt <- threadGet tcbSchedContext tcbPtr
 >         when (tcbScPtrOpt == Nothing) $ schedContextDonate scPtr tcbPtr
 >     cleanReply replyPtr
 >     replyUnlink replyPtr tcbPtr

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -84,7 +84,7 @@ This module specifies the behavior of reply objects.
 >         setSchedContext scPtr (sc { scReply = prevReplyPtrOpt })
 >         when (prevReplyPtrOpt /= Nothing) $ do
 >             prevReplyPtr <- return $ fromJust prevReplyPtrOpt
->             updateReply prevReplyPtr (\reply -> reply { replyNext = replyNext reply })
+>             updateReply prevReplyPtr (\prevReply -> prevReply { replyNext = replyNext reply })
 >             updateReply replyPtr (\reply -> reply { replyNext = Nothing })
 >         tcbScPtrOpt <- threadGet tcbSchedContext tcbPtr
 >         when (tcbScPtrOpt == Nothing) $ schedContextDonate scPtr tcbPtr

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -85,6 +85,7 @@ This module specifies the behavior of reply objects.
 >         when (prevReplyPtrOpt /= Nothing) $ do
 >             prevReplyPtr <- return $ fromJust prevReplyPtrOpt
 >             updateReply prevReplyPtr (\reply -> reply { replyNext = replyNext reply })
+>             updateReply replyPtr (\reply -> reply { replyNext = Nothing })
 >         tcbScPtrOpt <- threadGet tcbSchedContext tcbPtr
 >         when (tcbScPtrOpt == Nothing) $ schedContextDonate scPtr tcbPtr
 >     cleanReply replyPtr


### PR DESCRIPTION
This PR contains some spec updates for `repplyPop` and the proof fixes

- use `updateReply` where possible
- contains Victor’s commit from #175: move `schedContextDonate` to just before `cleanReply`
- move `threadGet` to just before `schedContextDonate`

