### PR TITLE
enable theory lint action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,3 +32,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/style@master
+
+  thylint:
+    name: 'Theory Linter'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: seL4/ci-actions/thylint@master
+    - uses: yuzutech/annotations-action@v0.2.1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        title: 'File annotations for theory linter'
+        input: './annotations.json'
+      if: always()


### PR DESCRIPTION
This started out as test for seL4/ci-actions#40, and can now be merged to activate the theory lint check.