### PR TITLE
rt: more consistent thread_state discriminators

### DIFF
--- a/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
@@ -1643,7 +1643,7 @@ lemma (* finalise_cap_invs *)[Finalise_AI_asms]:
                     | solves \<open>clarsimp dest!: no_cap_to_idle_sc_ptr\<close>
                     | solves \<open> clarsimp,
                                (frule (2) reply_tcb_state_refs[OF _ invs_valid_objs invs_sym_refs],
-                                fastforce simp: obj_at_def, clarsimp),
+                                fastforce simp: obj_at_def),
                                 (auto simp: reply_tcb_reply_at_def pred_tcb_at_def obj_at_def)\<close>)+
   apply clarsimp
   apply (frule cte_wp_at_valid_objs_valid_cap, clarsimp)

--- a/proof/invariant-abstract/Finalise_AI.thy
+++ b/proof/invariant-abstract/Finalise_AI.thy
@@ -640,58 +640,11 @@ lemma symreftype_neq:
        tcb_st_refs_of_def ep_q_refs_of_def ntfn_q_refs_of_def
       split: ntfn.splits endpoint.splits thread_state.splits if_split_asm option.splits
       dest!: symreftype_inverse')
-(*
-lemma reply_unlink_tcb_invs:
-  "\<lbrace>invs and (\<lambda>s. reply_tcb_reply_at (\<lambda>t. \<exists>tp. t = (Some tp)
-          \<and> st_tcb_at (\<lambda>st. st = BlockedOnReply (Some rptr) \<or>
-                            (st = BlockedOnReceive ep (Some rptr) \<and> ko_at (Endpoint IdleEP) ep s)) tp s) rptr s)\<rbrace>
-      reply_unlink_tcb rptr \<lbrace>\<lambda>rv. invs\<rbrace>"
-  apply (clarsimp simp: reply_unlink_tcb_def)
-  apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
-  apply (wpsimp simp: invs_def valid_state_def valid_pspace_def
-      wp: sts_only_idle valid_irq_node_typ gts_inv hoare_drop_imp split_del: if_split)
-  apply (frule ko_at_state_refs_ofD)
-  apply (erule (1) obj_at_valid_objsE)
-  apply (clarsimp simp: valid_obj_def valid_reply_def)
-  apply (rule conjI, clarsimp)
-   apply (drule (1) if_live_then_nonz_capD2)
-    apply (clarsimp simp: live_def live_reply_def)
-   apply simp
-  apply (rule conjI)
-   apply (erule delta_sym_refs)
-    apply (clarsimp split: if_split_asm)
-   apply (clarsimp split: if_split_asm split del: if_split simp: get_refs_def2)
-       apply (erule (1) obj_at_valid_objsE)
-       apply (clarsimp simp: valid_obj_def valid_reply_def valid_bound_obj_def tcb_at_def dest!: get_tcb_SomeD)
-      apply (clarsimp dest!: symreftype_neq)
-     apply (erule (1) obj_at_valid_objsE)
-     apply (clarsimp simp: valid_obj_def valid_reply_def valid_bound_obj_def is_tcb is_sc_obj_def obj_at_def)
-    apply (erule (1) obj_at_valid_objsE)
-    apply (clarsimp simp: valid_obj_def valid_reply_def valid_bound_obj_def is_tcb is_sc_obj_def obj_at_def)
-    apply (clarsimp simp: state_refs_of_def obj_at_def get_refs_def2 tcb_st_refs_of_def reply_tcb_reply_at_def pred_tcb_at_def)
-    apply (case_tac "tcb_state tcb"; simp)
-   apply (erule (1) obj_at_valid_objsE)
-   apply (clarsimp simp: valid_obj_def valid_reply_def valid_bound_obj_def is_tcb is_sc_obj_def obj_at_def
-      split: option.splits)
-   apply (fastforce simp: state_refs_of_def obj_at_def get_refs_def2 reply_tcb_reply_at_def pred_tcb_at_def)
-  apply (erule (1) obj_at_valid_objsE)
-  apply (simp add: valid_obj_def valid_reply_def valid_bound_obj_def obj_at_def is_tcb
-      pred_tcb_at_def reply_tcb_reply_at_def split: kernel_object.splits)
-  apply (case_tac "tcb_state tcb"; simp)
-   apply (drule_tac p=y in if_live_then_nonz_capD2, simp)
-    apply (simp add: live_def pred_tcb_at_def obj_at_def)
-   apply (clarsimp dest!: idle_no_ex_cap)
-  apply (drule_tac p=y in if_live_then_nonz_capD2, simp)
-   apply (simp add: live_def pred_tcb_at_def obj_at_def)
-  apply (clarsimp dest!: idle_no_ex_cap)
-  done*)
 
 lemma reply_tcb_state_refs:
   "\<lbrakk>reply_tcb reply = Some t; valid_objs s; sym_refs (state_refs_of s);
     kheap s rptr = Some (Reply reply)\<rbrakk>
-  \<Longrightarrow> \<exists>tcb. kheap s t = Some (TCB tcb) \<and>
-     st_tcb_at (\<lambda>st. st = BlockedOnReply rptr
-                    \<or> (\<exists>ep pl. st = BlockedOnReceive ep (Some rptr) pl)) t s"
+  \<Longrightarrow> st_tcb_at (\<lambda>st. reply_object st = Some rptr) t s"
   apply (erule (1) valid_objsE)
   apply (drule sym_refs_ko_atD[rotated])
    apply (simp add: obj_at_def)

--- a/proof/invariant-abstract/Interrupt_AI.thy
+++ b/proof/invariant-abstract/Interrupt_AI.thy
@@ -261,11 +261,11 @@ crunch interrupt_states[wp]: cancel_ipc "\<lambda>s. P (interrupt_states s)"
   (wp: hoare_drop_imps)
 
 lemma cancel_ipc_noreply_interrupt_states:
-  "\<lbrace>\<lambda>s. st_tcb_at (\<lambda>st. \<forall>r. st \<noteq> BlockedOnReply r) t s \<and> P (interrupt_states s) \<rbrace>
-         cancel_ipc t \<lbrace> \<lambda>_ s. P (interrupt_states s) \<rbrace>"
+  "\<lbrace>\<lambda>s. st_tcb_at (Not \<circ> is_blocked_on_reply) t s \<and> P (interrupt_states s) \<rbrace>
+   cancel_ipc t
+   \<lbrace> \<lambda>_ s. P (interrupt_states s) \<rbrace>"
   apply (simp add: cancel_ipc_def)
-   apply (wpsimp wp: gts_wp)+
-  done
+  by (wpsimp wp: gts_wp)
 
 lemma send_signal_interrupt_states[wp_unsafe]:
   "\<lbrace>\<lambda>s. P (interrupt_states s) \<and> valid_objs s\<rbrace> send_signal a b \<lbrace>\<lambda>_ s. P (interrupt_states s)\<rbrace>"

--- a/proof/invariant-abstract/Invariants_AI.thy
+++ b/proof/invariant-abstract/Invariants_AI.thy
@@ -1064,8 +1064,7 @@ lemmas valid_replies_defs = valid_replies_2_def replies_with_sc_def replies_bloc
 
 abbreviation
   "fault_tcb_states st \<equiv>
-     (\<exists>ep data. st = BlockedOnSend ep data) \<or> (\<exists>ep. st = BlockedOnReply ep) \<or>
-     st = Inactive"
+     is_blocked_on_send st \<or> is_blocked_on_reply st \<or> st = Inactive"
 
 definition
   "fault_tcbs_valid_states_except_set TS \<equiv>
@@ -1340,6 +1339,9 @@ abbreviation
                  st = Running \<or>
                  st = Restart \<or>
                  idle st \<or> awaiting_reply st"
+
+abbreviation
+  "is_reply_state st \<equiv> is_blocked_on_reply st \<or> is_blocked_on_receive st"
 
 abbreviation
   "ct_active \<equiv> ct_in_state active"
@@ -1618,7 +1620,6 @@ lemma tcb_st_refs_of_simps[simp]: (* ARMHYP add TCBHypRef? *)
  "tcb_st_refs_of (Running)               = {}"
  "tcb_st_refs_of (Inactive)              = {}"
  "tcb_st_refs_of (Restart)               = {}"
-(* "tcb_st_refs_of (YieldTo t)             = {(t, TCBYieldTo)}"*)
  "tcb_st_refs_of (BlockedOnReply r')      = {(r', TCBReply)}"
  "tcb_st_refs_of (IdleThreadState)       = {}"
  "\<And>x. tcb_st_refs_of (BlockedOnReceive x r data)  = (if bound r then {(x, TCBBlockedRecv), (the r, TCBReply)} else {(x, TCBBlockedRecv)})"
@@ -1723,8 +1724,6 @@ lemma st_tcb_at_refs_of_rev:
      = st_tcb_at (\<lambda>ts. \<exists>pl. ts = BlockedOnSend x pl   ) t s"
   "obj_at (\<lambda>ko. (x, TCBSignal) \<in> refs_of ko) t s
      = st_tcb_at (\<lambda>ts.      ts = BlockedOnNotification x) t s"
-(*  "obj_at (\<lambda>ko. (x, TCBYieldTo) \<in> refs_of ko) t s
-     = st_tcb_at (\<lambda>ts.      ts = YieldTo x) t s"*)
   by (auto simp add: refs_of_rev pred_tcb_at_def)
 
 

--- a/proof/invariant-abstract/IpcDet_AI.thy
+++ b/proof/invariant-abstract/IpcDet_AI.thy
@@ -441,7 +441,7 @@ lemma receive_ipc_blocked_invs':
       apply (cases ep; clarsimp)
       apply (frule invs_valid_objs, erule valid_objsE, simp add: obj_at_def)
       apply (clarsimp simp add: valid_obj_def valid_ep_def)
-      by (fastforce dest!: ep_queued_st_tcb_at[where P="\<lambda>st. \<exists>e p p' r. st \<in> {BlockedOnSend e p, BlockedOnReceive e r p'}"]
+      by (fastforce dest!: ep_queued_st_tcb_at[where P="is_blocked_on_send or is_blocked_on_receive"]
                      simp: ep_q_refs_of_def invs_valid_objs invs_sym_refs pred_tcb_at_def obj_at_def)+
     have ep_queue:
       "ep_q_refs_of ep = set queue \<times> {EPRecv}"
@@ -1615,7 +1615,7 @@ lemma active_st_tcb_at_not_in_replies_blocked:
   by (clarsimp simp: st_tcb_at_def replies_blocked_def obj_at_def)
 
 lemma no_reply_in_ts_rv_False:
-  "\<lbrace>st_tcb_at (\<lambda>st. (\<exists>x y pl. (st = BlockedOnReceive x (Some y) pl)) \<or> (\<exists>y. (st = BlockedOnReply y))) caller\<rbrace>
+  "\<lbrace>st_tcb_at (\<lambda>st. (\<exists>y. reply_object st = Some y)) caller\<rbrace>
    no_reply_in_ts caller
    \<lbrace>\<lambda>ts_reply s. \<not> ts_reply\<rbrace>"
   apply (wpsimp simp: no_reply_in_ts_def get_thread_state_def wp: thread_get_wp)
@@ -2107,7 +2107,7 @@ lemma si_invs'_helper_fault:
    apply (subgoal_tac "dest \<noteq> tptr")
     apply (fastforce elim!: fault_tcbs_valid_states_except_set_not_fault_tcb_states
                             pred_tcb_weakenE
-                      simp: pred_neg_def)
+                      simp: pred_neg_def is_blocked_thread_state_defs)
    apply (fastforce simp: st_tcb_at_def obj_at_def)
   apply (clarsimp simp: st_tcb_at_def obj_at_def)
   apply (subgoal_tac "valid_obj dest (TCB tcb) s")

--- a/proof/invariant-abstract/Ipc_AI.thy
+++ b/proof/invariant-abstract/Ipc_AI.thy
@@ -2315,7 +2315,7 @@ lemma maybe_donate_sc_invs[wp]:
   done
 
 lemma set_thread_state_not_BOReply_valid_replies:
-  "\<lbrace>valid_replies and st_tcb_at (\<lambda>st. \<forall>r. st \<noteq> BlockedOnReply r) t\<rbrace>
+  "\<lbrace>valid_replies and st_tcb_at (\<lambda>st. \<not> is_blocked_on_reply st) t\<rbrace>
    set_thread_state t st
    \<lbrace>\<lambda>r. valid_replies\<rbrace>"
   apply (wpsimp wp: sts_valid_replies)
@@ -2437,7 +2437,7 @@ lemma cancel_ipc_simple2:
   done
 
 lemma cancel_ipc_cte_wp_at_not_reply_state:
-  "\<lbrace>\<lambda>s. \<forall>r. st_tcb_at ((\<noteq>) (BlockedOnReply r)) t s \<and> cte_wp_at P p s\<rbrace>
+  "\<lbrace>\<lambda>s. st_tcb_at (Not \<circ> is_blocked_on_reply) t s \<and> cte_wp_at P p s\<rbrace>
     cancel_ipc t
    \<lbrace>\<lambda>r. cte_wp_at P p\<rbrace>"
   apply (simp add: cancel_ipc_def)

--- a/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
@@ -1597,7 +1597,7 @@ lemma (* finalise_cap_invs *)[Finalise_AI_asms]:
                     | solves \<open>clarsimp dest!: no_cap_to_idle_sc_ptr\<close>
                     | solves \<open> clarsimp,
                                (frule (2) reply_tcb_state_refs[OF _ invs_valid_objs invs_sym_refs],
-                                fastforce simp: obj_at_def, clarsimp),
+                                fastforce simp: obj_at_def),
                                 (auto simp: reply_tcb_reply_at_def pred_tcb_at_def obj_at_def)\<close>)+
   apply clarsimp
   apply (frule cte_wp_at_valid_objs_valid_cap, clarsimp)

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -228,7 +228,8 @@ lemma check_budget_restart_invs[wp]:
   apply (wpsimp wp: gts_wp)
   apply (frule invs_fault_tcbs_valid_states)
   apply (frule_tac t="cur_thread s" in fault_tcbs_valid_states_not_fault_tcb_states)
-   apply (fastforce simp: pred_neg_def elim: pred_tcb_weakenE)
+   apply (fastforce simp: pred_neg_def is_blocked_thread_state_defs
+                    elim: pred_tcb_weakenE)
   apply (case_tac st; clarsimp)
    apply (frule invs_iflive,
           clarsimp simp: if_live_then_nonz_cap_def pred_tcb_at_def obj_at_def live_def)+

--- a/proof/invariant-abstract/TcbAcc_AI.thy
+++ b/proof/invariant-abstract/TcbAcc_AI.thy
@@ -2634,13 +2634,13 @@ lemma gts_wp:
   by (wpsimp wp: thread_get_wp' simp: pred_tcb_at_def obj_at_def)
 
 lemma replies_blocked_upd_tcb_st_not_BlockedonReply:
-  "\<lbrakk>kheap s t = Some (TCB tcb); \<forall>r. tcb_state tcb \<noteq> BlockedOnReply r;
-  \<forall>r. st \<noteq> BlockedOnReply r\<rbrakk> \<Longrightarrow>
+  "\<lbrakk>kheap s t = Some (TCB tcb); \<not> is_blocked_on_reply (tcb_state tcb);
+    \<not> is_blocked_on_reply st\<rbrakk> \<Longrightarrow>
   replies_blocked_upd_tcb_st st t (replies_blocked s) = replies_blocked s"
-  apply  (rule set_eqI[OF iffI])
+  apply (rule set_eqI[OF iffI])
    apply (clarsimp simp: replies_blocked_upd_tcb_st_def split: if_splits)
   apply (clarsimp simp: replies_blocked_upd_tcb_st_def replies_blocked_def
-      pred_tcb_at_def obj_at_def)
+                        pred_tcb_at_def obj_at_def)
   done
 
 global_interpretation set_thread_state: non_sc_op "set_thread_state t st"

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -2573,7 +2573,7 @@ proof -
                           simp: obj_at_def valid_obj_def)
        apply (intro conjI impI allI ballI; fastforce?)
           apply (fastforce dest!: in_send_ep_queue_TCBBlockedSend
-                            simp: is_blocked_on_send_recv_def vs_all_heap_simps obj_at_def
+                            simp: vs_all_heap_simps obj_at_def
                                   state_refs_of_def tcb_st_refs_of_def refs_of_def get_refs_def2
                            split: option.splits Structures_A.thread_state.splits
                                   Structures_A.kernel_object.splits)
@@ -2590,7 +2590,7 @@ proof -
                         simp: obj_at_def valid_obj_def)
      apply (intro conjI impI allI ballI; fastforce?)
          apply (fastforce dest!: in_recv_ep_queue_TCBBlockedRecv
-                           simp: is_blocked_on_send_recv_def vs_all_heap_simps obj_at_def
+                           simp: vs_all_heap_simps obj_at_def
                                  state_refs_of_def tcb_st_refs_of_def refs_of_def get_refs_def2
                           split: option.splits Structures_A.thread_state.splits
                                  Structures_A.kernel_object.splits)

--- a/spec/abstract/Structures_A.thy
+++ b/spec/abstract/Structures_A.thy
@@ -384,12 +384,70 @@ datatype thread_state
   = Running
   | Inactive
   | Restart
-(*  | YieldTo obj_ref (* sc ref *)*)
   | BlockedOnReceive obj_ref "obj_ref option" receiver_payload
   | BlockedOnSend obj_ref sender_payload
   | BlockedOnReply obj_ref
   | BlockedOnNotification obj_ref
   | IdleThreadState
+
+(* FIXME RT: generating the following discriminators and selectors automatically breaks
+             unrelated proofs in strange ways *)
+
+fun reply_object where
+  "reply_object (BlockedOnReceive _ reply_opt _) = reply_opt"
+| "reply_object (BlockedOnReply reply) = Some reply"
+| "reply_object _ = None"
+
+definition is_blocked_on_receive where
+ "is_blocked_on_receive st \<equiv>
+    \<exists>ep reply_opt receiver_data. st = BlockedOnReceive ep reply_opt receiver_data"
+
+definition is_blocked_on_send :: "thread_state \<Rightarrow> bool" where
+  "is_blocked_on_send st \<equiv> \<exists>ep sender_data. st = BlockedOnSend ep sender_data"
+
+definition is_blocked_on_reply :: "thread_state \<Rightarrow> bool" where
+  "is_blocked_on_reply st \<equiv> \<exists>reply. st = BlockedOnReply reply"
+
+definition is_blocked_on_ntfn :: "thread_state \<Rightarrow> bool" where
+  "is_blocked_on_ntfn st \<equiv> \<exists>ntfn. st = BlockedOnNotification ntfn"
+
+lemmas is_blocked_thread_state_defs
+  = is_blocked_on_receive_def is_blocked_on_send_def is_blocked_on_reply_def is_blocked_on_ntfn_def
+
+lemma is_blocked_thread_state_simps[simp]:
+  "\<not> is_blocked_on_receive Running"
+  "\<not> is_blocked_on_receive Inactive"
+  "\<not> is_blocked_on_receive Restart"
+  "  is_blocked_on_receive (BlockedOnReceive ep reply_opt receiver_data)"
+  "\<not> is_blocked_on_receive (BlockedOnSend ep sender_data)"
+  "\<not> is_blocked_on_receive (BlockedOnReply reply)"
+  "\<not> is_blocked_on_receive (BlockedOnNotification ntfn)"
+  "\<not> is_blocked_on_receive IdleThreadState"
+  "\<not> is_blocked_on_send Running"
+  "\<not> is_blocked_on_send Inactive"
+  "\<not> is_blocked_on_send Restart"
+  "\<not> is_blocked_on_send (BlockedOnReceive ep reply_opt receiver_data)"
+  "  is_blocked_on_send (BlockedOnSend ep sender_data)"
+  "\<not> is_blocked_on_send (BlockedOnReply reply)"
+  "\<not> is_blocked_on_send (BlockedOnNotification ntfn)"
+  "\<not> is_blocked_on_send IdleThreadState"
+  "\<not> is_blocked_on_reply Running"
+  "\<not> is_blocked_on_reply Inactive"
+  "\<not> is_blocked_on_reply Restart"
+  "\<not> is_blocked_on_reply (BlockedOnReceive ep reply_opt receiver_data)"
+  "\<not> is_blocked_on_reply (BlockedOnSend ep sender_data)"
+  "  is_blocked_on_reply (BlockedOnReply reply)"
+  "\<not> is_blocked_on_reply (BlockedOnNotification ntfn)"
+  "\<not> is_blocked_on_reply IdleThreadState"
+  "\<not> is_blocked_on_ntfn Running"
+  "\<not> is_blocked_on_ntfn Inactive"
+  "\<not> is_blocked_on_ntfn Restart"
+  "\<not> is_blocked_on_ntfn (BlockedOnReceive ep reply_opt receiver_data)"
+  "\<not> is_blocked_on_ntfn (BlockedOnSend ep sender_data)"
+  "\<not> is_blocked_on_ntfn (BlockedOnReply reply)"
+  " is_blocked_on_ntfn (BlockedOnNotification ntfn)"
+  "\<not> is_blocked_on_ntfn IdleThreadState"
+  by (auto simp: is_blocked_thread_state_defs)
 
 type_synonym priority = word8
 type_synonym domain = word8


### PR DESCRIPTION
It's not clear that this is much nicer, but it at least makes the names and locations of these functions more consistent.

Unfortunately, using the standard discriminators and selectors that the datatype package can generate led to confusing issues with unrelated proofs breaking. I wasn't able to fix this and ended up manually defining them.

The actual goal that started me down this path was wanting a nice way to define `is_reply_state`.