### PR TITLE
cherry-pick thylint action from master branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,3 +32,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/style@master
+
+  thylint:
+    name: 'Theory Linter'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: seL4/ci-actions/thylint@master
+    - uses: yuzutech/annotations-action@v0.2.1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        title: 'File annotations for theory linter'
+        input: './annotations.json'
+      if: always()


### PR DESCRIPTION
This github action checks PRs for unwanted outer syntax commands like
`sorry`, `sledgehammer`, or `thm`. The check is non-required, so can be
ignored for those cases where the command is wanted after all.

In addition to console output, the action annotates the sources in the
"changed files" tab. This only works for PRs from within the same repo,
unfortunately (forks have insufficient rights for annotations)
