### PR TITLE
rt: update unbindFromSC

### DIFF
--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -2863,7 +2863,8 @@ lemma unbindFromSC_bound_sc_tcb_at'_None:
    unbindFromSC t
    \<lbrace>\<lambda>rv. bound_sc_tcb_at' ((=) None) t\<rbrace>"
   apply (simp add: unbindFromSC_def)
-  apply (wpsimp wp: schedContextUnbindTCB_bound_sc_tcb_at'_None set_tcb'.get_wp get_sc_inv')
+  apply (wpsimp wp: schedContextUnbindTCB_bound_sc_tcb_at'_None threadGet_wp get_sc_inv'
+                    hoare_drop_imp)
   apply (auto simp: pred_tcb_at'_def obj_at'_def)
   done
 

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -475,12 +475,13 @@ This module uses the C preprocessor to select a target architecture.
 
 > unbindFromSC :: PPtr TCB -> Kernel ()
 > unbindFromSC tptr = do
->     tcb <- getObject tptr
->     when (tcbSchedContext tcb /= Nothing) $ do
->         let scPtr = fromJust $ tcbSchedContext tcb
+>     sc_ptr_opt <- threadGet tcbSchedContext tptr
+>     when (sc_ptr_opt /= Nothing) $ do
+>         let scPtr = fromJust sc_ptr_opt
 >         schedContextUnbindTCB scPtr
 >         sc <- getSchedContext scPtr
->         schedContextCompleteYieldTo $ fromJust $ scYieldFrom sc
+>         when (scYieldFrom sc /= Nothing) $
+>             schedContextCompleteYieldTo $ fromJust $ scYieldFrom sc
 
 > postpone :: PPtr SchedContext -> Kernel ()
 > postpone scPtr = do


### PR DESCRIPTION
This updates the Haskell so that `unbindFromSC` checks the `scYieldFrom` field before accessing it and also makes it better match the abstract.