### PR TITLE
thylint: ignore annotation errors

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,4 +43,5 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         title: 'File annotations for theory linter'
         input: './annotations.json'
+      continue-on-error: true
       if: always()


### PR DESCRIPTION
The annotation action only works for in-repo pull requests. This flag
ignores any errors from this action so that forked pull requests don't
get spurious test failures.
