### PR TITLE
sendIPC_corres

### DIFF
--- a/proof/invariant-abstract/IpcDet_AI.thy
+++ b/proof/invariant-abstract/IpcDet_AI.thy
@@ -2008,16 +2008,15 @@ lemma si_invs'_helper_fault:
         sym_refs (state_hyp_refs_of s)\<rbrace>
     do
       recv_state <- get_thread_state dest;
-      (reply, reply_can_grant) <- case recv_state of
-                                    BlockedOnReceive _ reply data \<Rightarrow>
-                                      return (reply, receiver_can_grant data)
+      reply <- case recv_state of BlockedOnReceive _ reply data \<Rightarrow>
+                                      return reply
                                   | _ \<Rightarrow> fail;
       y <- do_ipc_transfer tptr (Some epptr) ba cg dest;
       y <- maybeM (reply_unlink_tcb dest) reply;
       sc_opt <- get_tcb_obj_ref tcb_sched_context dest;
       fault <- thread_get tcb_fault tptr;
       y <- if call \<or> (\<exists>y. fault = Some y)
-           then if (cg \<or> reply_can_grant) \<and> (\<exists>y. reply = Some y)
+           then if (cg \<or> cgr) \<and> (\<exists>y. reply = Some y)
                 then reply_push tptr dest (the reply) can_donate
                 else set_thread_state tptr Inactive
            else when (can_donate \<and> sc_opt = None) (do thread_sc <- get_tcb_obj_ref tcb_sched_context tptr;
@@ -2124,16 +2123,16 @@ lemma si_invs'_helper:
         sym_refs (state_hyp_refs_of s)\<rbrace>
     do
       recv_state <- get_thread_state dest;
-      (reply, reply_can_grant) <- case recv_state of
+      reply <- case recv_state of
                                     BlockedOnReceive _ reply data \<Rightarrow>
-                                      return (reply, receiver_can_grant data)
+                                      return reply
                                   | _ \<Rightarrow> fail;
       y <- do_ipc_transfer tptr (Some epptr) ba cg dest;
       y <- maybeM (reply_unlink_tcb dest) reply;
       sc_opt <- get_tcb_obj_ref tcb_sched_context dest;
       fault <- thread_get tcb_fault tptr;
       y <- if call \<or> (\<exists>y. fault = Some y)
-           then if (cg \<or> reply_can_grant) \<and> (\<exists>y. reply = Some y)
+           then if (cg \<or> cgr) \<and> (\<exists>y. reply = Some y)
                 then reply_push tptr dest (the reply) can_donate
                 else set_thread_state tptr Inactive
            else when (can_donate \<and> sc_opt = None) (do thread_sc <- get_tcb_obj_ref tcb_sched_context tptr;

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -1288,7 +1288,7 @@ lemma emptySlot_valid_global_refs[wp]:
   done
 
 lemmas doMachineOp_irq_handlers[wp]
-    = valid_irq_handlers_lift'' [OF doMachineOp_ctes doMachineOp_ksInterrupt]
+    = valid_irq_handlers_lift'' [OF doMachineOp_ksPSpace doMachineOp_ksInterrupt]
 
 lemma deletedIRQHandler_irq_handlers'[wp]:
   "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (IRQHandlerCap irq \<notin> ran (cteCaps_of s))\<rbrace>
@@ -3514,11 +3514,10 @@ lemma tcbSchedDequeue_valid_tcbs'[wp]:
   apply (clarsimp simp: valid_tcb'_def tcb_cte_cases_def)
   done
 
-lemma schedContextDonate_valid_queues:
+lemma schedContextDonate_valid_queues[wp]:
   "\<lbrace>valid_queues and valid_objs'\<rbrace> schedContextDonate scPtr tcbPtr \<lbrace>\<lambda>_. valid_queues\<rbrace>"
   (is "valid ?pre _ _")
   apply (clarsimp simp: schedContextDonate_def)
-  apply (rule hoare_seq_ext[OF _ stateAssert_sp])
   apply (rule hoare_seq_ext[OF _ get_sc_sp'])
   apply (rule_tac B="\<lambda>_. ?pre" in hoare_seq_ext[rotated])
    apply (rule hoare_when_cases, clarsimp)
@@ -3589,7 +3588,6 @@ lemma schedContextDonate_valid_objs':
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   (is "valid ?pre _ _")
   apply (clarsimp simp: schedContextDonate_def)
-  apply (rule hoare_seq_ext[OF _ stateAssert_sp])
   apply (rule hoare_seq_ext[OF _ get_sc_sp'], rename_tac sc)
   apply (rule_tac Q="?pre and valid_sched_context' sc and K (valid_sched_context_size' sc) and sc_at' scPtr"
                in hoare_weaken_pre[rotated])
@@ -3858,7 +3856,6 @@ lemma schedContextDonate_valid_inQ_queues:
    \<lbrace>\<lambda>_. valid_inQ_queues\<rbrace>"
   (is "valid ?pre _ _")
   apply (clarsimp simp: schedContextDonate_def)
-  apply (rule hoare_seq_ext[OF _ stateAssert_sp])
   apply (rule hoare_seq_ext[OF _ get_sc_sp'], rename_tac sc)
   apply (rule_tac B="\<lambda>_. ?pre" in hoare_seq_ext[rotated])
    apply (rule hoare_when_cases, clarsimp)

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -293,8 +293,6 @@ abbreviation tcbs_scs_sym_refs where
 abbreviation replies_scs_sym_refs where
   "replies_scs_sym_refs s \<equiv> sqheap_refs_inv (scReplies_of s) (replySCs_of s)"
 
-lemmas tcbs_scs_sym_refs_def = sqheap_refs_inv_def sqheap_refs_retract_def sqheap_refs_retract_at_def
-
 definition
   max_ipc_words :: word32 where
   "max_ipc_words \<equiv> capTransferDataSize + msgMaxLength + msgMaxExtraCaps + 2"

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -2840,14 +2840,6 @@ crunches doIPCTransfer
   for replySCs_of[wp]: "\<lambda>s. P (replySCs_of s)"
   (wp: crunch_wps simp: crunch_simps)
 
-(*   "corres dc (all_invs_but_fault_tcbs and fault_tcbs_valid_states_except_set {t} and valid_list
-                                      and valid_sched_except_blocked_except_released_ipc_qs
-                                      and )
-             (invs' and sch_act_not t and tcb_at' t and ep_at' ep)
-             (send_ipc bl call bg cg cgr cd t ep) (sendIPC bl call bg cg cgr cd t ep)"
-
-*)
-
 (* FIXME RT: replace get_ep_valid_ep with this better version *)
 lemma get_ep_valid_ep'[wp]:
   "\<lbrace> valid_objs and ep_at ep \<rbrace>
@@ -3714,43 +3706,6 @@ lemma maybeDonateSc_corres:
                 apply (wpsimp wp: refillUnblockCheck_invs')
                apply wpsimp
               apply wpsimp
-(*
-             apply (rule_tac Q="\<lambda>_. invs and valid_ready_qs and
-                       active_sc_valid_refills and valid_release_q and
-                       sc_not_in_release_q xa and active_sc_valid_refills and
-                       current_time_bounded 1 and sc_tcb_sc_at ((=) (Some tcb_ptr)) xa"
-                    in hoare_strengthen_post[rotated])
-              apply (fastforce simp: sc_at_pred_n_def obj_at_def)
-             apply (wpsimp wp: sched_context_donate_invs
-                               sched_context_donate_sc_not_in_release_q
-                               sched_context_donate_sc_tcb_sc_at)
-            apply (wpsimp wp: schedContextDonate_invs')
-           apply (wpsimp wp: get_simple_ko_wp getNotification_wp)+
-       apply (clarsimp simp: tcb_relation_def)
-      apply (wpsimp wp: thread_get_wp' threadGet_wp)+
-    apply (clarsimp simp: tcb_at_kh_simps pred_map_eq_normalise split: option.splits cong: conj_cong)
-    apply (rename_tac sc_ptr)
-    apply (subgoal_tac "sc_at sc_ptr s", clarsimp)
-     apply (subgoal_tac "pred_map_eq None (tcb_scps_of s) tcb_ptr", clarsimp)
-      apply (intro conjI)
-         apply (clarsimp simp: obj_at_def)
-         apply (drule (1) ntfn_sc_sym_refsD; clarsimp simp: obj_at_def)
-         apply (erule (1) if_live_then_nonz_cap_invs)
-         apply (clarsimp simp: live_def live_sc_def)
-        apply (erule (1) weak_valid_sched_action_no_sc_sched_act_not)
-       apply (erule (1) valid_release_q_no_sc_not_in_release_q)
-      apply (clarsimp simp: )
-      apply (drule heap_refs_retractD[OF invs_retract_tcb_scps, rotated], simp)
-      apply (clarsimp simp: vs_all_heap_simps obj_at_def)
-     apply (clarsimp simp: vs_all_heap_simps obj_at_def)
-    apply (frule valid_objs_ko_at[where ptr=ntfn_ptr, rotated], clarsimp)
-    apply (clarsimp simp: valid_obj_def valid_ntfn_def)
-   apply (clarsimp simp: tcb_at'_ex_eq_all split: option.splits)
-   apply (rename_tac sc_ptr)
-   apply (subgoal_tac "sc_at' sc_ptr s'", clarsimp)
-    apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
-    apply (intro conjI)
-*)
              apply wpsimp
             apply (rule_tac Q="\<lambda>_. invs and valid_ready_qs and
                       active_sc_valid_refills and valid_release_q and
@@ -5559,6 +5514,7 @@ lemma replyPush_if_live_then_nonz_cap':
                      wp: updateReply_iflive'_weak updateReply_reply_at'_true updateReply_valid_objs'
                          hoare_vcg_all_lift hoare_vcg_imp_lift' updateReply_obj_at')
   apply clarsimp
+find_theorems valid_tcb_state' -valid
   apply (intro conjI)
    apply (clarsimp simp: valid_reply'_def obj_at'_def)
   apply (intro allI impI, clarsimp)
@@ -5573,8 +5529,8 @@ lemma replyPush_if_live_then_nonz_cap':
     apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
     apply (clarsimp simp: valid_tcb'_def)
    apply (subgoal_tac "pred_map_eq scp (tcb_scs_of' s) callerPtr")
-    apply (fastforce simp: tcbs_scs_sym_refs_def)
-   apply (clarsimp simp: pred_map_eq_def pred_map_def opt_map_def obj_at'_real_def ko_wp_at'_def
+    apply (fastforce simp: sqheap_refs_inv_defs)
+   apply_trace (clarsimp simp: pred_map_eq_def pred_map_def opt_map_def obj_at'_real_def ko_wp_at'_def
                          projectKOs pred_tcb_at'_def)
   apply (clarsimp simp: valid_idle'_def)
   done
@@ -5611,13 +5567,13 @@ lemma tcbs_scs_sym_refs_equiv:
    obj_at' (\<lambda>x. scTCB x = Some t) y s = obj_at' (\<lambda>x. tcbSchedContext x = Some y) t s"
   apply (rule iffI; subgoal_tac "sc_at' y s \<and> tcb_at' t s", clarsimp)
      apply (clarsimp simp: sc_tcbs_of_pred_map_equiv tcb_scs_of_pred_map_equiv)
-     apply (clarsimp simp: tcbs_scs_sym_refs_def tcb_scs_of_pred_map_equiv)
+     apply (clarsimp simp: sqheap_refs_inv_defs tcb_scs_of_pred_map_equiv)
     apply (frule obj_at'_typ_at', simp)
     apply (frule obj_at_ko_at', clarsimp)
     apply (frule (1) sc_ko_at_valid_objs_valid_sc')
     apply (clarsimp simp: valid_sched_context'_def)
    apply (clarsimp simp: sc_tcbs_of_pred_map_equiv tcb_scs_of_pred_map_equiv)
-   apply (clarsimp simp: tcbs_scs_sym_refs_def tcb_scs_of_pred_map_equiv)
+   apply (clarsimp simp: sqheap_refs_inv_defs tcb_scs_of_pred_map_equiv)
   apply (frule obj_at'_typ_at', simp)
   apply (frule obj_at_ko_at', clarsimp)
   apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
@@ -6103,7 +6059,7 @@ lemma sdjfkh[wp]:
   apply (clarsimp simp: tcb_at'_ex_eq_all)
   apply (drule sym, simp)
   apply (subgoal_tac "pred_map_eq (the (tcbSchedContext tcb)) (tcb_scs_of' s) t")
-   apply (clarsimp simp: tcbs_scs_sym_refs_def pred_map_eq_upd)
+   apply (clarsimp simp: sqheap_refs_inv_defs pred_map_eq_upd)
    apply (auto)[1]
   using sdfjkh apply metis
   using sdfjkh apply metis
@@ -6171,6 +6127,11 @@ lemma cleanReply_replies_scs_sym_refs :
   apply (wpsimp wp: hoare_drop_imp | wps)+
   done
 
+lemma isHead345:
+  "reply_at' ya s \<Longrightarrow>
+   (replyNexts_of s ya \<noteq> None) \<Longrightarrow> (replySCs_of s ya = None)"
+   by (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
+
 lemma ri_inv345s' [wp]:
   "\<lbrace>replies_scs_sym_refs and (\<lambda>s. sym_refs (list_refs_of_replies' s))\<rbrace>
   replyRemoveTCB t
@@ -6179,40 +6140,50 @@ lemma ri_inv345s' [wp]:
   unfolding replyRemoveTCB_def
   apply (clarsimp simp: bind_assoc updateReply_def)
   apply wpsimp
-  apply (wpsimp wp: cleanReply_replies_scs_sym_refs)
-  apply wp
-
-  apply wps
-         apply wpsimp
-        apply (rule_tac Q="\<lambda>replya s. (replySCs_of s) (the (replyPrev reply)) = None \<and>
-                 sqheap_refs_inv (scReplies_of s)
-                  (\<lambda>a. if a = rptr then None
-                        else replySCs_of s a)"
-       in hoare_strengthen_post[rotated])
-  subgoal sorry (* fine *)
-        apply_trace (wpsimp)
-       apply (wp hoare_vcg_if_lift2 hoare_drop_imp[where R="\<lambda>r s. ko_at' a b s " for a b]
-                         hoare_vcg_imp_lift' hoare_vcg_all_lift)
-          apply wps
-          apply (wpsimp wp: setSchedContext_scReplies_of)
-         apply wpsimp
+         apply (wpsimp wp: cleanReply_replies_scs_sym_refs)
         apply wp
          apply wps
          apply wpsimp
+        apply (rule_tac Q="\<lambda>_ s. (replySCs_of s) (the (replyPrev reply)) = None \<and>
+                 sqheap_refs_inv (scReplies_of s)
+                  (\<lambda>a. if a = rptr then None else replySCs_of s a)"
+       in hoare_strengthen_post[rotated], clarsimp)
         apply wpsimp
-       apply (wp hoare_vcg_if_lift2 hoare_drop_imp[where R="\<lambda>r s. ko_at' a b s " for a b]
-                         hoare_vcg_imp_lift' hoare_vcg_all_lift)
+       apply (rule_tac Q="\<lambda>_ s. (replyPrev reply \<noteq> None \<longrightarrow>
+             reply_at' (the (replyPrev reply)) s \<longrightarrow> (replySCs_of s) (the (replyPrev reply)) = None) \<and>
+                sqheap_refs_inv (scReplies_of s)
+                 (\<lambda>a. if a = rptr then None else replySCs_of s a)"
+      in hoare_strengthen_post[rotated])
+        apply (clarsimp split: if_splits simp: obj_at'_def)
+       apply (wp hoare_vcg_if_lift2 hoare_vcg_imp_lift' hoare_vcg_all_lift)
          apply wps
-
          apply (wpsimp wp: setSchedContext_scReplies_of)
         apply wpsimp
        apply wp
         apply wps
         apply wpsimp
        apply wpsimp
-      apply (rule_tac Q="\<lambda>replya s. replies_scs_sym_refs s \<and> sym_refs (list_refs_of_replies' s)"
-     in hoare_strengthen_post[rotated])
-       apply (clarsimp split: if_splits)
+      apply wpsimp
+     apply (rule_tac Q="\<lambda>replya s. replies_scs_sym_refs s \<and> sym_refs (list_refs_of_replies' s)"
+    in hoare_strengthen_post[rotated])
+      apply (clarsimp split: if_splits )
+      apply (safe)
+            apply (clarsimp simp: isHead_to_head)
+            apply (erule isHead345)
+            apply (subgoal_tac "replyPrevs_of s r = Some ya")
+             apply (simp add: sym_refs_replyNext_replyPrev_sym[symmetric])
+            apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
+ apply (clarsimp simp: isHead_to_head)
+  subgoal sorry
+ apply (clarsimp simp: isHead_to_head)
+            apply (erule isHead345)
+            apply (subgoal_tac "replyPrevs_of s r = Some ya")
+             apply (simp add: sym_refs_replyNext_replyPrev_sym[symmetric])
+            apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
+apply (clarsimp simp: sqheap_refs_inv_defs split: if_splits)
+  subgoal sorry (* fine *)
+  subgoal sorry (* fine *)
+  subgoal sorry (* fine *)
   subgoal sorry (* fine *)
       apply (wpsimp wp: hoare_drop_imp)+
   done
@@ -6227,8 +6198,7 @@ lemma ri_isdfnsvs' [wp]:
   cancelIPC t
   \<lbrace>\<lambda>_. replies_scs_sym_refs\<rbrace>" (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
   unfolding cancelIPC_def
-  apply (wpsimp wp: gts_wp')
-  sorry (* boring *)
+  by (wpsimp wp: gts_wp', simp add: comp_def)
 
 (* t = ksCurThread s *)
 lemma ri_invs' [wp]:
@@ -6305,11 +6275,10 @@ lemma ri_invs' [wp]:
                    split: option.splits)
   apply (frule invs'_tcbs_scs_sym_refs, fastforce, fastforce, fastforce)
   apply (frule sym_refs_replies_scs, fastforce, fastforce, fastforce)
-  apply (clarsimp cong: conj_cong)
-(*   apply (fastforce simp: invs'_def valid_state'_def valid_idle'_def idle_tcb'_def
-                         valid_pspace'_def
-                         pred_tcb_at'_def obj_at'_def projectKOs isCap_simps isSend_def) *)
-  sorry (* boring -- same as above *)
+  apply (clarsimp simp: comp_def invs'_def valid_state'_def valid_pspace'_def cong: conj_cong)
+  apply (fastforce simp: valid_idle'_def idle_tcb'_def
+                         pred_tcb_at'_def obj_at'_def projectKOs isCap_simps isSend_def)
+  done
 
 lemma replyUnlink_invs':
   "\<lbrace>\<lambda>s. invs' s \<and> tcbPtr \<noteq> ksIdleThread s\<rbrace> replyUnlink replyPtr tcbPtr \<lbrace>\<lambda>_. invs'\<rbrace>"

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -3659,8 +3659,8 @@ lemma schedContextDonate_invs':
    apply (rule_tac hoare_weaken_pre[OF hoare_pre_cont])
    apply (clarsimp simp: obj_at'_def)
   apply (wp schedContextDonate_valid_pspace'
-                    schedContextDonate_valid_queues schedContextDonate_valid_queues'
-                    schedContextDonate_valid_idle' schedContextDonate_if_live_then_nonz_cap')
+            schedContextDonate_valid_queues schedContextDonate_valid_queues'
+            schedContextDonate_valid_idle' schedContextDonate_if_live_then_nonz_cap')
   apply clarsimp
   apply (clarsimp simp: obj_at'_def projectKO_eq projectKO_sc)
   apply (auto dest!: global'_sc_no_ex_cap
@@ -5543,7 +5543,7 @@ lemma replySCs_of_retract:
    replies_scs_sym_refs s \<Longrightarrow>
      \<forall>x xa. obj_at' (\<lambda>a. scReply a = Some x) xa s \<longrightarrow>
             obj_at' (\<lambda>a. replyNext a = Some (Head xa)) x s"
-  apply (clarsimp simp: )
+  apply clarsimp
   apply (subgoal_tac "pred_map_eq x (scReplies_of s) xa")
    apply (subgoal_tac "pred_map_eq xa (replySCs_of s) x")
     apply (subgoal_tac "reply_at' x s")
@@ -5602,8 +5602,7 @@ lemma replyPush_if_live_then_nonz_cap':
 (\<forall>rp scp. obj_at' (\<lambda>ko. scReply ko = Some rp) scp s
                                          \<longrightarrow>  obj_at' (\<lambda>ko. replyNext ko = Some (Head scp)) rp s)) \<and>
                                 ex_nonz_cap_to' calleePtr s \<and> ex_nonz_cap_to' replyPtr s \<and>
-                                valid_objs' s \<and> if_live_then_nonz_cap' s \<and> reply_at' replyPtr s
-                                 "
+                                valid_objs' s \<and> if_live_then_nonz_cap' s \<and> reply_at' replyPtr s"
                     in hoare_strengthen_post[rotated], clarsimp)
        apply (wp hoare_vcg_all_lift hoare_vcg_imp_lift')
       apply (simp (no_asm_use) add: split del: if_split
@@ -5646,9 +5645,9 @@ lemma not_idle_scTCB0:
    obj_at' (\<lambda>x.  tcbSchedContext x = Some t) y s \<Longrightarrow>
    sc_at' t s"
   apply (subgoal_tac "tcb_at' y s")
-  apply (frule obj_at_ko_at', clarsimp)
-  apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
-  apply (clarsimp simp: valid_tcb'_def obj_at'_real_def ko_wp_at'_def projectKO_tcb projectKO_sc)+
+   apply (frule obj_at_ko_at', clarsimp)
+   apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
+   apply (clarsimp simp: valid_tcb'_def obj_at'_real_def ko_wp_at'_def projectKO_tcb projectKO_sc)+
   done
 
 lemma sdsfdf[elim!]:
@@ -5661,17 +5660,17 @@ lemma not_idle_scTCB99:
    obj_at' (\<lambda>x. scTCB x = Some t) y s \<Longrightarrow>
    tcb_at' t s"
   apply (subgoal_tac "sc_at' y s")
-  apply (frule obj_at_ko_at'[where P=\<top>], clarsimp)
-  apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-  apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKO_tcb projectKO_sc
-                        valid_sched_context'_def)+
+   apply (frule obj_at_ko_at'[where P=\<top>], clarsimp)
+   apply (frule (1) sc_ko_at_valid_objs_valid_sc')
+   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKO_tcb projectKO_sc
+                         valid_sched_context'_def)+
   done
 
 lemma sc_tcbs_of_pred_map_equiv:
   "sc_at' y s \<Longrightarrow>
    obj_at' (\<lambda>x. scTCB x = Some t) y s = pred_map_eq t (scTCBs_of s) y"
   by (clarsimp simp: obj_at'_real_def ko_wp_at'_def pred_map_eq_def pred_map_def
-                        projectKO_sc opt_map_def)
+                     projectKO_sc opt_map_def)
 
 lemma tcb_scs_of_pred_map_equiv:
   "tcb_at' y s \<Longrightarrow>
@@ -5715,10 +5714,10 @@ lemma not_idle_tcbSC:
    tcb_at' y s \<Longrightarrow>
    obj_at' (\<lambda>x. tcbSchedContext x \<noteq> Some idle_sc_ptr) y s"
   apply (subgoal_tac "\<not>obj_at' (\<lambda>x. tcbSchedContext x = Some idle_sc_ptr) y s")
-  apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
+   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
   apply clarsimp
   apply (subst (asm) tcbs_scs_sym_refs_equiv[symmetric], clarsimp+)
-  apply (clarsimp simp: valid_idle'_def)
+   apply (clarsimp simp: valid_idle'_def)
   apply (clarsimp simp: valid_idle'_def obj_at'_real_def ko_wp_at'_def idle_tcb'_def)
   done
 
@@ -6269,8 +6268,8 @@ lemma SCReply_pred_map_state_refs_of':
   "\<lbrakk>pred_map ((=) r) (scReplies_of s) p; pspace_aligned' s; pspace_distinct' s\<rbrakk>
    \<Longrightarrow> (r, SCReply) \<in> state_refs_of' s p"
   apply (subgoal_tac "sc_at' p s")
-  apply (clarsimp simp: pred_map_def state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_sc
-                        tcb_of'_Some)
+   apply (clarsimp simp: pred_map_def state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_sc
+                         tcb_of'_Some)
   apply (erule (1) KOSC_sc_at'[rotated])
   apply (clarsimp simp: pred_map_def projectKO_sc)
   done
@@ -6287,7 +6286,7 @@ lemma ReplySC_pred_map_state_refs_of':
   "\<lbrakk>pred_map ((=) r) (replySCs_of s) p; pspace_aligned' s; pspace_distinct' s\<rbrakk>
    \<Longrightarrow> (r, ReplySchedContext) \<in> state_refs_of' s p"
   apply (subgoal_tac "reply_at' p s")
-  apply (clarsimp simp: pred_map_def state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_reply)
+   apply (clarsimp simp: pred_map_def state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_reply)
   apply (erule (1) KOReply_reply_at'[rotated])
   apply (clarsimp simp: pred_map_def projectKO_reply)
   done

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -2934,13 +2934,15 @@ lemma sendIPC_corres:
                                apply (wpsimp wp: set_thread_state_valid_sched_action)
                               apply wpsimp
                              apply (clarsimp simp: fault_rel_optionation_def)
-                           apply (rule_tac Q="\<lambda>_.  valid_objs and pspace_aligned and pspace_distinct and tcb_at a and
-                     valid_sched_action" in hoare_strengthen_post[rotated])
+                           apply (rule_tac Q="\<lambda>_. valid_objs and pspace_aligned and pspace_distinct 
+                                    and tcb_at a and valid_sched_action" 
+                                    in hoare_strengthen_post[rotated])
                                apply clarsimp
                             apply (wpsimp wp: set_thread_state_valid_sched_action sched_context_donate_valid_sched_action
                                               thread_get_wp' reply_push_valid_objs)
-                           apply (rule_tac Q="\<lambda>_.  valid_objs' and valid_release_queue_iff and
-                valid_queues and valid_queues'" in hoare_strengthen_post[rotated])
+                           apply (rule_tac Q="\<lambda>_. valid_objs' and valid_release_queue_iff and
+                                    valid_queues and valid_queues'" 
+                                    in hoare_strengthen_post[rotated])
                                apply clarsimp
                            apply (wpsimp wp: threadGet_wp schedContextDonate_valid_objs')
                           apply (clarsimp simp: tcb_relation_def)
@@ -2953,16 +2955,16 @@ lemma sendIPC_corres:
                     apply (rule corres_option_split[OF refl corres_return_trivial])
                     apply (rule reply_unlink_tcb_corres)
                    apply (rule_tac Q="\<lambda>_. valid_objs and pspace_aligned and pspace_distinct and
-                            scheduler_act_not t and valid_sched_action and valid_replies and tcb_at t
-      and tcb_at a
-      and scheduler_act_not a and (\<lambda>s. data \<noteq> None \<longrightarrow> reply_at (the data) s \<and>
-                                                ex_nonz_cap_to (the data) s \<and>
-                                                reply_tcb_reply_at (\<lambda>tptr. tptr = None) (the data) s
-                                                \<and> reply_sc_reply_at (\<lambda>tptr. tptr = None) (the data) s \<and>
-                                                the data \<notin> fst ` replies_with_sc s
-                                                )
-      and K (t \<noteq> idle_thread_ptr)
-      and (\<lambda>s. cd \<longrightarrow> bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) t s)" in hoare_strengthen_post[rotated])
+                            scheduler_act_not t and valid_sched_action and valid_replies and 
+                            tcb_at t and tcb_at a and scheduler_act_not a and 
+                            (\<lambda>s. data \<noteq> None \<longrightarrow> reply_at (the data) s \<and> 
+                                 ex_nonz_cap_to (the data) s \<and>
+                                 reply_tcb_reply_at (\<lambda>tptr. tptr = None) (the data) s \<and>
+                                 reply_sc_reply_at (\<lambda>tptr. tptr = None) (the data) s \<and>
+                                 the data \<notin> fst ` replies_with_sc s) and 
+                            K (t \<noteq> idle_thread_ptr) and 
+                            (\<lambda>s. cd \<longrightarrow> bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) t s)" 
+                            in hoare_strengthen_post[rotated])
                     apply (clarsimp cong: conj_cong)
                     apply (frule valid_sched_action_weak_valid_sched_action, simp)
                     apply (frule valid_objs_valid_tcbs, simp)
@@ -2972,16 +2974,19 @@ lemma sendIPC_corres:
                     apply (frule (1) valid_objs_ko_at)
                     apply (clarsimp simp: pred_tcb_at_def obj_at_def valid_obj_def valid_tcb_def)
                    apply (wpsimp wp: reply_unlink_tcb_valid_sched_action
-               reply_unlink_tcb_valid_replies_BlockedOnReceive
-               reply_unlink_tcb_sym_refs_BlockedOnReceive
-               reply_unlink_tcb_reply_tcb_reply_at[where P=id, simplified]
-               reply_unlink_tcb_st_tcb_at[where P=id, simplified]
-               replies_with_sc_lift)
+                                     reply_unlink_tcb_valid_replies_BlockedOnReceive
+                                     reply_unlink_tcb_sym_refs_BlockedOnReceive
+                                     reply_unlink_tcb_reply_tcb_reply_at[where P=id, simplified]
+                                     reply_unlink_tcb_st_tcb_at[where P=id, simplified]
+                                     replies_with_sc_lift)
                   apply (rule_tac Q="\<lambda>_. tcb_at' t and tcb_at' a and valid_release_queue and
-           valid_release_queue' and
-           valid_queues and valid_objs' and
-           valid_queues'
-           and (\<lambda>s. data \<noteq> None \<longrightarrow> reply_at' (the data) s \<and> replySCs_of s (the data) = None)" in hoare_strengthen_post[rotated])
+                                         valid_release_queue' and
+                                         valid_queues and valid_objs' and
+                                         valid_queues' and 
+                                         (\<lambda>s. data \<noteq> None \<longrightarrow> 
+                                              reply_at' (the data) s \<and> 
+                                              replySCs_of s (the data) = None)" 
+                                         in hoare_strengthen_post[rotated])
                    apply (clarsimp cong: conj_cong)
                    apply (frule valid_objs'_valid_tcbs')
                    apply (drule obj_at_ko_at')+
@@ -2989,17 +2994,17 @@ lemma sendIPC_corres:
                   apply wpsimp
                  apply (wpfix add: receive_reply_sel)
                  apply (rule_tac Q="\<lambda>_. valid_objs and pspace_aligned and pspace_distinct and
-                        valid_replies and
-                        scheduler_act_not t and valid_sched_action and tcb_at t and tcb_at a and
-                        if_live_then_nonz_cap and scheduler_act_not a and
-                        K (t \<noteq> idle_thread_ptr) and
-                        (\<lambda>s. cd \<longrightarrow> bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) t s) and (\<lambda>s. data \<noteq> None
-                        \<longrightarrow> st_tcb_at ((=) (Structures_A.thread_state.BlockedOnReceive ep data pl)) a s \<and>
-                        ex_nonz_cap_to (the data) s \<and>
-                        reply_tcb_reply_at ((=) (Some a)) (the data) s \<and>
-                        reply_sc_reply_at (\<lambda>a. a = None) (the data) s \<and>
-                        the data \<notin> fst ` replies_with_sc s)"
-                        in hoare_strengthen_post[rotated])
+                          valid_replies and
+                          scheduler_act_not t and valid_sched_action and tcb_at t and tcb_at a and
+                          if_live_then_nonz_cap and scheduler_act_not a and
+                          K (t \<noteq> idle_thread_ptr) and
+                          (\<lambda>s. cd \<longrightarrow> bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) t s) and (\<lambda>s. data \<noteq> None
+                          \<longrightarrow> st_tcb_at ((=) (Structures_A.thread_state.BlockedOnReceive ep data pl)) a s \<and>
+                          ex_nonz_cap_to (the data) s \<and>
+                          reply_tcb_reply_at ((=) (Some a)) (the data) s \<and>
+                          reply_sc_reply_at (\<lambda>a. a = None) (the data) s \<and>
+                          the data \<notin> fst ` replies_with_sc s)"
+                          in hoare_strengthen_post[rotated])
                apply (clarsimp split: option.splits)
                   apply (intro conjI)
                     apply (erule valid_objs_valid_tcbs)
@@ -3010,18 +3015,16 @@ lemma sendIPC_corres:
                 apply (wpfix add: Structures_H.thread_state.sel)
                 apply (rule_tac Q="\<lambda>_. tcb_at' t and tcb_at' a and valid_release_queue and
                                        valid_release_queue' and valid_queues and valid_objs' and
-                                       valid_queues' and (\<lambda>s. data \<noteq> None \<longrightarrow> reply_at' (the data) s \<and> replySCs_of s (the data) = None)"
-                       in hoare_strengthen_post[rotated])
+                                       valid_queues' and (\<lambda>s. data \<noteq> None \<longrightarrow> reply_at' (the data) s \<and> 
+                                       replySCs_of s (the data) = None)"
+                                       in hoare_strengthen_post[rotated])
                  apply (fastforce split: option.splits)
                 apply (wpsimp wp: hoare_vcg_imp_lift)
                apply (assumption)
               apply (prop_tac "(tcb_at' t and tcb_at' a and valid_pspace' and cur_tcb' and
-             (\<lambda>s. ep_at' ep s) and
-             (\<lambda>b.  valid_release_queue b \<and>
-                   valid_release_queue' b \<and>
-                   valid_queues b \<and>
-                   (valid_objs' and valid_mdb') b \<and>
-                   valid_queues' b)) s'", assumption)
+                                ep_at' ep and valid_release_queue and valid_release_queue' and 
+                                valid_queues and valid_objs' and valid_mdb' and valid_queues') s'", 
+                     assumption)
     apply clarsimp
     apply (case_tac data; clarsimp simp: receive_reply_def)
     apply (subgoal_tac "reply_at' aa s'", simp)
@@ -5634,31 +5637,11 @@ lemma bindScReply_valid_idle':
   unfolding bindScReply_def
   by (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift set_reply'.obj_at')
 
-lemma not_idle_scTCB0:
-  "valid_objs' s \<Longrightarrow>
-   obj_at' (\<lambda>x.  tcbSchedContext x = Some t) y s \<Longrightarrow>
-   sc_at' t s"
-  apply (subgoal_tac "tcb_at' y s")
-   apply (frule obj_at_ko_at', clarsimp)
-   apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
-   apply (clarsimp simp: valid_tcb'_def obj_at'_real_def ko_wp_at'_def projectKO_tcb projectKO_sc)+
-  done
-
-lemma sdsfdf[elim!]:
+(* FIXME: move up quite high (kheap) *)
+lemma obj_at'_typ_at'[elim!]:
   "obj_at' (P :: ('a :: pspace_storable) \<Rightarrow> bool) y s \<Longrightarrow>
    obj_at' (\<top> :: ('a :: pspace_storable) \<Rightarrow> bool) y s"
   by (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
-
-lemma not_idle_scTCB99:
-  "valid_objs' s \<Longrightarrow>
-   obj_at' (\<lambda>x. scTCB x = Some t) y s \<Longrightarrow>
-   tcb_at' t s"
-  apply (subgoal_tac "sc_at' y s")
-   apply (frule obj_at_ko_at'[where P=\<top>], clarsimp)
-   apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKO_tcb projectKO_sc
-                         valid_sched_context'_def)+
-  done
 
 lemma sc_tcbs_of_pred_map_equiv:
   "sc_at' y s \<Longrightarrow>
@@ -5680,10 +5663,16 @@ lemma tcbs_scs_sym_refs_equiv:
   apply (rule iffI; subgoal_tac "sc_at' y s \<and> tcb_at' t s", clarsimp)
      apply (clarsimp simp: sc_tcbs_of_pred_map_equiv tcb_scs_of_pred_map_equiv)
      apply (clarsimp simp: tcbs_scs_sym_refs_def tcb_scs_of_pred_map_equiv)
-    apply (clarsimp simp: not_idle_scTCB99)
+    apply (frule obj_at'_typ_at', simp)
+    apply (frule obj_at_ko_at', clarsimp)
+    apply (frule (1) sc_ko_at_valid_objs_valid_sc')
+    apply (clarsimp simp: valid_sched_context'_def)
    apply (clarsimp simp: sc_tcbs_of_pred_map_equiv tcb_scs_of_pred_map_equiv)
    apply (clarsimp simp: tcbs_scs_sym_refs_def tcb_scs_of_pred_map_equiv)
-  apply (clarsimp simp: not_idle_scTCB0)
+  apply (frule obj_at'_typ_at', simp)
+  apply (frule obj_at_ko_at', clarsimp)
+  apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
+  apply (clarsimp simp: valid_tcb'_def)
   done
 
 lemma not_idle_scTCB:
@@ -6231,8 +6220,9 @@ lemma TCBSchedContext_ref_pred_map_equiv:
 lemma invs'_tcbs_scs_sym_refs:
   "\<lbrakk>sym_refs (state_refs_of' s); pspace_aligned' s; pspace_distinct' s; valid_objs' s\<rbrakk>
    \<Longrightarrow> tcbs_scs_sym_refs s"
-  apply (auto simp: sqheap_refs_inv_def sqheap_refs_retract_def sqheap_refs_retract_at_def
-                    pred_map_eq_def)
+  apply (clarsimp simp: sqheap_refs_inv_def sqheap_refs_retract_def sqheap_refs_retract_at_def
+                        pred_map_eq_def)
+  apply (intro conjI impI allI)
    apply (frule (2) TCBSC_pred_map_state_refs_of')
    apply (rule SCTcb_ref_pred_map_equiv)
     apply (erule sym_refsE, simp)

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -2803,12 +2803,6 @@ lemma replyPush_valid_objs'[wp]:
   apply (force simp: valid_tcb_state'_def valid_tcb'_def valid_bound_sc'_def)
   done
 
-(* FIXME RT: move *)
-lemma isBlockedOnReceive_equiv:
-  "isBlockedOnReceive st = (\<exists>a b c. st = BlockedOnReceive a b c)"
-  unfolding isBlockedOnReceive_def
-  by (case_tac st; simp)
-
 crunches reply_unlink_tcb
   for sc_replies_sc_at[wp]: "\<lambda>s. Q (sc_replies_sc_at P scp s)"
   (wp: crunch_wps)

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -6157,7 +6157,7 @@ crunches cancelIPC
   (wp: crunch_wps threadSet_tcb_scs_of'_inv
  ignore: setSchedContext threadSet)
 
-lemma sdfjkh:
+lemma sdfjkh1:
   "pred_map P (\<lambda>a. if a = r then A a else B a) t = (if t = r then ((pred_map P A r)) else (pred_map P B t))"
   by (clarsimp simp: pred_map_def)
 
@@ -6175,13 +6175,16 @@ lemma ri_isdfnvs' [wp]:
   apply wps
   apply (wpsimp wp: hoare_drop_imp)
   apply wpsimp
-  apply (auto simp: sqheap_refs_inv_defs sdfjkh pred_map_eq_def split: if_splits)
+  apply (auto simp: sqheap_refs_inv_defs sdfjkh1 pred_map_eq_def split: if_splits)
   apply (subgoal_tac "\<not> (\<exists>p. pred_map ((=) p) (replySCs_of s) t)")
   apply (fastforce)
   apply (simp only: pred_map_def)
   apply (fastforce)
   apply (simp only: pred_map_def)
   done
+
+term replies_with_sc
+find_theorems valid_replies
 
 lemma ri_inv345s' [wp]:
   "\<lbrace>replies_scs_sym_refs and (\<lambda>s. replySCs_of s t = None)\<rbrace>
@@ -6195,7 +6198,7 @@ lemma ri_inv345s' [wp]:
   apply wpsimp
   apply wpsimp
   apply (wpsimp wp: hoare_vcg_if_lift2)
- oops
+  sorry
 
 crunches blockedCancelIPC
   for replies_scs_sym_refs[wp]: replies_scs_sym_refs

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -3930,4 +3930,9 @@ lemma valid_tcb_state'_simps[simp]:
   "valid_tcb_state' (thread_state.BlockedOnReply r) s = valid_bound_reply' r s"
   by (clarsimp simp: valid_tcb_state'_def)+
 
+lemma isBlockedOnReceive_equiv:
+  "isBlockedOnReceive st = (\<exists>a b c. st = BlockedOnReceive a b c)"
+  unfolding isBlockedOnReceive_def
+  by (case_tac st; simp)
+
 end

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -3909,5 +3909,25 @@ lemma threadGet_getObject:
                    od"
   apply (simp add: threadGet_def threadRead_def oliftM_def getObject_def[symmetric])
   done
+  
+crunches doMachineOp
+  for ksPSpace[wp]: "\<lambda>s. P (ksPSpace s)"
+
+definition receive_reply :: "Structures_A.thread_state \<Rightarrow> obj_ref option" where
+  "receive_reply st \<equiv> case st of
+           (Structures_A.thread_state.BlockedOnReceive ep reply_opt pl) \<Rightarrow> reply_opt"
+
+lemma receive_reply_sel:
+  "receive_reply (Structures_A.thread_state.BlockedOnReceive ep reply_opt pl) = reply_opt"
+  by (simp add: receive_reply_def)
+
+lemma valid_tcb_state'_simps[simp]:
+  "valid_tcb_state' thread_state.Running s = True"
+  "valid_tcb_state' thread_state.Inactive s = True"
+  "valid_tcb_state' thread_state.Restart s = True"
+  "valid_tcb_state' thread_state.IdleThreadState s = True"
+  "valid_tcb_state' (thread_state.BlockedOnSend ref b c d e) s = ep_at' ref s"
+  "valid_tcb_state' (thread_state.BlockedOnReply r) s = valid_bound_reply' r s"
+  by (clarsimp simp: valid_tcb_state'_def)+
 
 end

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -428,7 +428,7 @@ lemma pinv_corres:
             apply (rule corres_guard_imp)
               apply (rule corres_split_deprecated [OF _ gct_corres])
                 apply simp
-                apply (rule corres_split_deprecated [OF _ send_ipc_corres])
+                apply (rule corres_split_deprecated [OF _ sendIPC_corres])
                    apply (rule corres_trivial)
                    apply simp
                   apply simp
@@ -437,7 +437,8 @@ lemma pinv_corres:
                                    fault_tcbs_valid_states_to_except_set schact_is_rct_sane
                                    ct_in_state_def released_sc_tcb_at_def active_sc_tcb_at_def2)
              apply (intro conjI)
-              apply (fastforce elim: st_tcb_ex_cap)
+               apply (fastforce elim: st_tcb_ex_cap)
+              apply fastforce
              apply (fastforce simp: pred_tcb_at_def obj_at_def dest: invs_cur_sc_tcb_symref)
             apply (clarsimp simp: pred_conj_def invs'_def cur_tcb'_def simple_sane_strg
                                   sch_act_simple_def)

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -437,9 +437,7 @@ lemma pinv_corres:
                                    fault_tcbs_valid_states_to_except_set schact_is_rct_sane
                                    ct_in_state_def released_sc_tcb_at_def active_sc_tcb_at_def2)
              apply (intro conjI)
-                apply (fastforce elim: st_tcb_ex_cap)
-               apply fastforce
-              apply fastforce
+              apply (fastforce elim: st_tcb_ex_cap)
              apply (fastforce simp: pred_tcb_at_def obj_at_def dest: invs_cur_sc_tcb_symref)
             apply (clarsimp simp: pred_conj_def invs'_def cur_tcb'_def simple_sane_strg
                                   sch_act_simple_def)

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -437,7 +437,8 @@ lemma pinv_corres:
                                    fault_tcbs_valid_states_to_except_set schact_is_rct_sane
                                    ct_in_state_def released_sc_tcb_at_def active_sc_tcb_at_def2)
              apply (intro conjI)
-               apply (fastforce elim: st_tcb_ex_cap)
+                apply (fastforce elim: st_tcb_ex_cap)
+               apply fastforce
               apply fastforce
              apply (fastforce simp: pred_tcb_at_def obj_at_def dest: invs_cur_sc_tcb_symref)
             apply (clarsimp simp: pred_conj_def invs'_def cur_tcb'_def simple_sane_strg

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -400,7 +400,7 @@ lemma pinv_corres:
   "\<lbrakk> inv_relation i i'; call \<longrightarrow> block \<rbrakk> \<Longrightarrow>
    corres (dc \<oplus> (=))
      (einvs and valid_invocation i
-            and (\<lambda>s. schact_is_rct s)
+            and schact_is_rct
             and current_time_bounded 1
             and ct_active
             and ct_released
@@ -437,8 +437,9 @@ lemma pinv_corres:
                                    fault_tcbs_valid_states_to_except_set schact_is_rct_sane
                                    ct_in_state_def released_sc_tcb_at_def active_sc_tcb_at_def2)
              apply (intro conjI)
-              apply (fastforce elim: st_tcb_ex_cap)
-             apply (clarsimp simp: pred_tcb_at_def obj_at_def)
+               apply (fastforce elim: st_tcb_ex_cap)
+              apply fastforce
+             apply (fastforce simp: pred_tcb_at_def obj_at_def dest: invs_cur_sc_tcb_symref)
             apply (clarsimp simp: pred_conj_def invs'_def cur_tcb'_def simple_sane_strg
                                   sch_act_simple_def)
            apply (rule corres_guard_imp)

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -1016,7 +1016,7 @@ lemma reorder_ntfn_corres:
               apply (rule set_ntfn_corres)
               apply (clarsimp simp: ntfn_relation_def)
              apply clarsimp
-             apply (rule tcb_ep_append_corres)
+             apply (rule tcbEPAppend_corres)
             apply wp
            apply wp
           apply (rule tcb_ep_dequeue_corres)
@@ -1074,7 +1074,7 @@ lemma reorder_ep_corres:
                  apply (rule set_ep_corres)
                  apply (case_tac rv; clarsimp simp: ep_relation_def updateEpQueue_def)
                 apply clarsimp
-                apply (rule tcb_ep_append_corres)
+                apply (rule tcbEPAppend_corres)
                apply wp
               apply wp
              apply (rule tcb_ep_dequeue_corres)
@@ -3254,9 +3254,6 @@ lemma get_sc_released_corres:
            apply (clarsimp simp: sc_relation_def active_sc_def)
           apply (clarsimp simp: state_relation_def)
          apply wpsimp+
-      apply (clarsimp simp: obj_at'_def)
-     apply (clarsimp simp: state_relation_def)
-     apply wpsimp+
    apply (fastforce simp: obj_at_def sc_at_pred_n_def is_obj_defs valid_obj_def)
   apply clarsimp
   done

--- a/proof/refine/Move_R.thy
+++ b/proof/refine/Move_R.thy
@@ -430,4 +430,12 @@ lemma schedule_sched_act_rct[wp]:
 
 (* END: scheduler_action lemmas needed in Refine.thy *)
 
+lemma tcb_obj_at_equiv:
+  "tcb_at g s \<Longrightarrow> obj_at (P s) g s = (\<forall>ko. ko_at ko g s \<and> is_tcb ko \<longrightarrow> P s ko)"
+  by (clarsimp simp: obj_at_def is_tcb)
+
+lemma sc_at_ppred_exm:
+  "sc_at g s \<Longrightarrow> sc_at_ppred p P g s = (\<not> sc_at_ppred p (\<lambda>x. \<not> P x) g s)"
+  by (clarsimp simp: sc_at_pred_n_def obj_at_def is_sc_obj pred_neg_def)
+
 end

--- a/spec/abstract/Ipc_A.thy
+++ b/spec/abstract/Ipc_A.thy
@@ -289,8 +289,8 @@ where
                 set_endpoint epptr $ (case queue of [] \<Rightarrow> IdleEP
                                                      | _ \<Rightarrow> RecvEP queue);
                 recv_state \<leftarrow> get_thread_state dest;
-                (reply, reply_can_grant) \<leftarrow> case recv_state
-                  of (BlockedOnReceive _ reply data) \<Rightarrow> return (reply, receiver_can_grant data)
+                reply \<leftarrow> case recv_state
+                  of (BlockedOnReceive _ reply data) \<Rightarrow> return reply
                   | _ \<Rightarrow> fail;
                 do_ipc_transfer thread (Some epptr) badge can_grant dest;
                 maybeM (reply_unlink_tcb dest) reply;
@@ -298,7 +298,7 @@ where
 
                 fault \<leftarrow> thread_get tcb_fault thread;
                 if call \<or> fault \<noteq> None then
-                  if (can_grant \<or> reply_can_grant) \<and> reply \<noteq> None then
+                  if (can_grant \<or> can_grant_reply) \<and> reply \<noteq> None then
                     reply_push thread dest (the reply) can_donate
                   else
                     set_thread_state thread Inactive

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -52,8 +52,6 @@ This module specifies the behavior of reply objects.
 
 > replyPush :: PPtr TCB -> PPtr TCB -> PPtr Reply -> Bool -> Kernel ()
 > replyPush callerPtr calleePtr replyPtr canDonate = do
->     stateAssert sym_refs_asrt
->         "replyPush: `sym_refs (state_refs_of' s)` must hold"
 >     stateAssert (valid_replies'_sc_asrt replyPtr)
 >         "replyPush: valid_replies'_sc holds for replyPtr"
 >     scPtrOptDonated <- threadGet tcbSchedContext callerPtr

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -577,8 +577,6 @@ This module uses the C preprocessor to select a target architecture.
 
 > schedContextDonate :: PPtr SchedContext -> PPtr TCB -> Kernel ()
 > schedContextDonate scPtr tcbPtr = do
->     stateAssert sym_refs_asrt
->         "Assert that `sym_refs (state_refs_of' s)` holds"
 >     sc <- getSchedContext scPtr
 >     fromOpt <- return $ scTCB sc
 >     when (fromOpt /= Nothing) $ do


### PR DESCRIPTION
Solves `send_ipc_corres` but does a large number of other things too.
* moves `schedContextDonate_corres` and weakens the preconditions
* moves `replyPush_corres` and weakens the preconditions
* removes `sym_refs_assrt` from `schedContextDonate`
* removes `sym_refs_assrt` from `replyPush`
* Updated abstract to match C
* Updated Haskell to match abstract
* Adds a new heap and new `sym_refs` on some heap projections.