### PR TITLE
rt: use updateReply everywhere

### DIFF
--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3163,7 +3163,7 @@ lemma schedContextUnbindReply_obj_at'_not_reply:
   "(\<And>ko f. P (scReply_update f ko) = P ko)
    \<Longrightarrow> schedContextUnbindReply scPtr \<lbrace>obj_at' P p\<rbrace>"
   apply (clarsimp simp: schedContextUnbindReply_def)
-  apply (wpsimp wp: set_sc'.obj_at'_strongest set_reply'.set_wp)
+  apply (wpsimp wp: set_sc'.obj_at'_strongest updateReply_wp_all)
   by (auto simp: obj_at'_def projectKOs)
 
 lemma schedContextUnbindReply_obj_at'_reply_None:

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -14,7 +14,7 @@ This module specifies the behavior of reply objects.
 \begin{impdetails}
 
 % {-# BOOT-IMPORTS: SEL4.Machine SEL4.Model SEL4.Object.Structures #-}
-% {-# BOOT-EXPORTS: replyRemove replyRemoveTCB replyPush replyUnlink getReply setReply #-}
+% {-# BOOT-EXPORTS: replyRemove replyRemoveTCB replyPush replyUnlink updateReply #-}
 
 > import {-# SOURCE #-} SEL4.Kernel.Thread(getThreadState, setThreadState)
 > import SEL4.Machine.RegisterSet(PPtr)
@@ -28,6 +28,11 @@ This module specifies the behavior of reply objects.
 
 \end{impdetails}
 
+> getReply :: PPtr Reply -> Kernel Reply
+> getReply rptr = getObject rptr
+
+> setReply :: PPtr Reply -> Reply -> Kernel ()
+> setReply rptr r = setObject rptr r
 
 > updateReply :: PPtr Reply -> (Reply -> Reply) -> Kernel ()
 > updateReply replyPtr upd = do
@@ -161,9 +166,3 @@ on the thread state of the replyTCB of the replyPtr
 > cleanReply replyPtr = do
 >     updateReply replyPtr $ \reply -> reply { replyPrev = Nothing }
 >     updateReply replyPtr $ \reply -> reply { replyNext = Nothing }
-
-> getReply :: PPtr Reply -> Kernel Reply
-> getReply rptr = getObject rptr
-
-> setReply :: PPtr Reply -> Reply -> Kernel ()
-> setReply rptr r = setObject rptr r

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -464,8 +464,7 @@ This module uses the C preprocessor to select a target architecture.
 >     replyPtrOpt <- return $ scReply sc
 >     when (replyPtrOpt /= Nothing) $ do
 >         replyPtr <- return $ fromJust replyPtrOpt
->         reply <- getReply replyPtr
->         setReply replyPtr (reply { replyNext = Nothing })
+>         updateReply replyPtr (\reply -> reply { replyNext = Nothing })
 >         setSchedContext scPtr (sc { scReply = Nothing })
 
 > schedContextZeroRefillMax :: PPtr SchedContext -> Kernel ()
@@ -557,8 +556,7 @@ This module uses the C preprocessor to select a target architecture.
 >         let replyPtrOpt = scReply sc
 >         when (replyPtrOpt /= Nothing) $ do
 >             let replyPtr = fromJust replyPtrOpt
->             reply <- getReply replyPtr
->             setReply replyPtr (reply { replyNext = Nothing })
+>             updateReply replyPtr (\reply -> reply { replyNext = Nothing })
 >             setSchedContext scPtr $ sc { scReply = Nothing }
 >     InvokeSchedContextYieldTo scPtr buffer -> do
 >         schedContextYieldTo scPtr buffer


### PR DESCRIPTION
This changes all of the remaining `getReply; setReply` patterns to use `updateReply`, except for `replyPop` which is left for https://github.com/seL4/l4v/pull/185.