### PR TITLE
ainvs cleanup: requalify some arch lemmas proved in ArchRetype_AI

### DIFF
--- a/proof/invariant-abstract/ARM/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchRetype_AI.thy
@@ -1354,24 +1354,13 @@ lemma valid_arch_mdb_detype:
          (\<lambda>p. if fst p \<in> untyped_range cap then None else caps_of_state s p)"
   by auto
 
-end
-
-lemmas clearMemory_invs[wp] = ARM.clearMemory_invs
-
-lemmas invs_irq_state_independent[intro!, simp]
-    = ARM.invs_irq_state_independent
-
-lemmas init_arch_objects_invs_from_restricted
-    = ARM.init_arch_objects_invs_from_restricted
-
-lemmas caps_region_kernel_window_imp
-    = ARM.caps_region_kernel_window_imp
-
 lemmas init_arch_objects_wps
-    = ARM.init_arch_objects_cte_wp_at
-      ARM.init_arch_objects_valid_cap
-      ARM.init_arch_objects_cap_table
-      ARM.init_arch_objects_excap
-      ARM.init_arch_objects_st_tcb_at
+    = init_arch_objects_cte_wp_at
+      init_arch_objects_valid_cap
+      init_arch_objects_cap_table
+      init_arch_objects_excap
+      init_arch_objects_st_tcb_at
+
+end
 
 end

--- a/proof/invariant-abstract/ARM_HYP/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchRetype_AI.thy
@@ -1206,24 +1206,13 @@ lemma valid_arch_mdb_detype:
          (\<lambda>p. if fst p \<in> untyped_range cap then None else caps_of_state s p)"
   by auto
 
-end
-
-lemmas clearMemory_invs[wp] = ARM_HYP.clearMemory_invs
-
-lemmas invs_irq_state_independent[intro!, simp]
-    = ARM_HYP.invs_irq_state_independent
-
-lemmas init_arch_objects_invs_from_restricted
-    = ARM_HYP.init_arch_objects_invs_from_restricted
-
-lemmas caps_region_kernel_window_imp
-    = ARM_HYP.caps_region_kernel_window_imp
-
 lemmas init_arch_objects_wps
-    = ARM_HYP.init_arch_objects_cte_wp_at
-      ARM_HYP.init_arch_objects_valid_cap
-      ARM_HYP.init_arch_objects_cap_table
-      ARM_HYP.init_arch_objects_excap
-      ARM_HYP.init_arch_objects_st_tcb_at
+    = init_arch_objects_cte_wp_at
+      init_arch_objects_valid_cap
+      init_arch_objects_cap_table
+      init_arch_objects_excap
+      init_arch_objects_st_tcb_at
+
+end
 
 end

--- a/proof/invariant-abstract/Detype_AI.thy
+++ b/proof/invariant-abstract/Detype_AI.thy
@@ -12,8 +12,17 @@ context begin interpretation Arch .
 
 requalify_facts
   valid_arch_mdb_detype
+  clearMemory_invs
+  invs_irq_state_independent
+  init_arch_objects_invs_from_restricted
+  caps_region_kernel_window_imp
+  init_arch_objects_wps
 
 end
+
+declare clearMemory_invs[wp]
+
+declare invs_irq_state_independent[intro!, simp]
 
 locale Detype_AI =
   fixes state_ext_type :: "'a :: state_ext itself"

--- a/proof/invariant-abstract/RISCV64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchRetype_AI.thy
@@ -1039,24 +1039,13 @@ lemma valid_arch_mdb_detype:
          (\<lambda>p. if fst p \<in> untyped_range cap then None else caps_of_state s p)"
   by (auto simp: valid_arch_mdb_def)
 
-end
-
-lemmas clearMemory_invs[wp] = RISCV64.clearMemory_invs
-
-lemmas invs_irq_state_independent[intro!, simp]
-    = RISCV64.invs_irq_state_independent
-
-lemmas init_arch_objects_invs_from_restricted
-    = RISCV64.init_arch_objects_invs_from_restricted
-
-lemmas caps_region_kernel_window_imp
-    = RISCV64.caps_region_kernel_window_imp
-
 lemmas init_arch_objects_wps
-    = RISCV64.init_arch_objects_cte_wp_at
-      RISCV64.init_arch_objects_valid_cap
-      RISCV64.init_arch_objects_cap_table
-      RISCV64.init_arch_objects_excap
-      RISCV64.init_arch_objects_st_tcb_at
+    = init_arch_objects_cte_wp_at
+      init_arch_objects_valid_cap
+      init_arch_objects_cap_table
+      init_arch_objects_excap
+      init_arch_objects_st_tcb_at
+
+end
 
 end

--- a/proof/invariant-abstract/X64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/X64/ArchRetype_AI.thy
@@ -1280,25 +1280,13 @@ lemma valid_arch_mdb_detype:
          (\<lambda>p. if fst p \<in> untyped_range cap then None else caps_of_state s p)"
   by (simp add: valid_arch_mdb_def ioport_revocable_def detype_def)
 
-end
-
-lemmas clearMemory_invs[wp] = X64.clearMemory_invs
-
-lemmas invs_irq_state_independent[intro!, simp]
-    = X64.invs_irq_state_independent
-
-lemmas caps_region_kernel_window_imp
-    = X64.caps_region_kernel_window_imp
-
-
-lemmas init_arch_objects_invs_from_restricted
-    = X64.init_arch_objects_invs_from_restricted
-
 lemmas init_arch_objects_wps
-    = X64.init_arch_objects_cte_wp_at
-      X64.init_arch_objects_valid_cap
-      X64.init_arch_objects_cap_table
-      X64.init_arch_objects_excap
-      X64.init_arch_objects_st_tcb_at
+    = init_arch_objects_cte_wp_at
+      init_arch_objects_valid_cap
+      init_arch_objects_cap_table
+      init_arch_objects_excap
+      init_arch_objects_st_tcb_at
+
+end
 
 end


### PR DESCRIPTION
This PR is for the master branch.

While working on the preemption_point spec update for MCS, I noticed some odd requalification work-around at the end of ArchRetype_AI, when it is perfectly fine to do requalification normally.

For MCS, it makes sense to clean this up on this occasion, and I thought I might as well do it for the master, too.

I am running the testboard here: [testboard](https://bamboo.ts.data61.csiro.au/browse/L4V-TESTBOARD3)
but it looks like something is not quite right with it. I think the testing will be operating in a useful way, but it is running on its own new branch. Is this what is expected??


Signed-off-by: Miki Tanaka <miki.tanaka@data61.csiro.au>