### PR TITLE
rt: set refills to empty in finalise_cap

### DIFF
--- a/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
@@ -813,8 +813,9 @@ lemma sched_context_unbind_yield_from_not_live:
   apply (auto simp: obj_at_def live_def live_sc_def)
   done
 
-lemma sc_refill_max_update_not_live[wp]:
-  "update_sched_context sc_ptr (sc_refill_max_update f) \<lbrace>obj_at (Not \<circ> live) sc\<rbrace>"
+lemma sched_context_zero_refill_max_not_live[wp]:
+  "sched_context_zero_refill_max sc_ptr \<lbrace>obj_at (Not \<circ> live) sc\<rbrace>"
+  apply (clarsimp simp: sched_context_zero_refill_max_def set_refills_def)
   apply (wpsimp simp: wp: update_sched_context_wp)
   apply (auto simp: obj_at_def live_def live_sc_def)
   done
@@ -973,7 +974,7 @@ lemma finalise_cap_replaceable [Finalise_AI_asms]:
         | hammer
         | wp (once) sched_context_unbind_yield_from_not_live[unfolded o_def]
         | wp (once) hoare_drop_imps; wp (once) hoare_vcg_conj_lift,
-          wp (once) sc_refill_max_update_not_live[unfolded o_def])+)[1]
+          wp (once) sched_context_zero_refill_max_not_live[unfolded o_def])+)[1]
       \<comment> \<open>schedcontrol\<close>
       apply ((wpsimp | hammer)+)[1]
      \<comment> \<open>irqcontrol\<close>

--- a/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
@@ -460,19 +460,15 @@ lemma fast_finalise_valid_pdpt_objs[wp]:
       wpsimp simp: set_refills_def o_def
                wp: get_sched_context_wp hoare_vcg_if_lift2 hoare_drop_imps)
 
-crunch valid_pdpt_objs[wp]: prepare_thread_delete "valid_pdpt_objs"
-
-crunch valid_pdpt_objs[wp]: unbind_notification,deleting_irq_handler "valid_pdpt_objs"
+crunches
+  prepare_thread_delete, unbind_notification, deleting_irq_handler, set_asid_pool,
+  invalidate_asid_entry, unbind_from_sc, suspend, sched_context_zero_refill_max
+  for valid_pdpt_objs[wp]: "valid_pdpt_objs"
   (wp: maybeM_inv simp: unless_def)
 
-crunch valid_pdpt_objs[wp]: set_asid_pool,invalidate_asid_entry "valid_pdpt_objs"
-  (ignore: set_object wp: get_object_wp)
-
-crunch valid_pdpt_objs[wp]: delete_asid_pool,arch_finalise_cap "valid_pdpt_objs"
+crunches delete_asid_pool, arch_finalise_cap
+  for valid_pdpt_objs[wp]: "valid_pdpt_objs"
   (wp: crunch_wps select_wp preemption_point_inv simp: crunch_simps unless_def ignore:set_object)
-
-crunch valid_pdpt_objs[wp]: unbind_from_sc,suspend "valid_pdpt_objs"
-  (wp: maybeM_inv)
 
 lemma finalise_cap_valid_pdpt_objs[wp]:
   "\<lbrace>valid_pdpt_objs\<rbrace> finalise_cap c b \<lbrace>\<lambda>rv. valid_pdpt_objs\<rbrace>"

--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -152,7 +152,7 @@ crunch domain_list_inv[wp]: reschedule_required,schedule_tcb "\<lambda>s. P (dom
 crunch domain_list_inv[wp]: reply_unlink_tcb, reply_unlink_sc, tcb_sched_action "\<lambda>s. P (domain_list s)"
   (wp: crunch_wps hoare_unless_wp maybeM_inv select_inv gets_the_inv simp: crunch_simps set_object_def)
 
-crunch domain_list_inv[wp]: reply_remove, sched_context_unbind_tcb "\<lambda>s. P (domain_list s)"
+crunch domain_list_inv[wp]: reply_remove, sched_context_unbind_tcb, sched_context_zero_refill_max "\<lambda>s. P (domain_list s)"
   (wp: hoare_drop_imps get_simple_ko_wp)
 
 crunch domain_list_inv[wp]: cancel_all_ipc, cancel_all_signals "\<lambda>s. P (domain_list s)"
@@ -167,9 +167,6 @@ lemma rec_del_domain_list[wp]:
 
 crunch domain_list_inv[wp]: cap_delete, activate_thread "\<lambda>s::det_state. P (domain_list s)"
   (wp: hoare_drop_imp)
-
-crunch domain_list_inv[wp]: possible_switch_to "\<lambda>s. P (domain_list s)"
-  (simp: get_tcb_obj_ref_def wp: hoare_vcg_if_lift2 hoare_drop_imp)
 
 crunch domain_list_inv[wp]: awaken "\<lambda>s. P (domain_list s)"
   (wp: hoare_drop_imp dxo_wp_weak mapM_x_wp simp: Let_def)

--- a/proof/invariant-abstract/Finalise_AI.thy
+++ b/proof/invariant-abstract/Finalise_AI.thy
@@ -406,15 +406,11 @@ lemma empty_slot_caps_of_state:
 crunch caps_of_state[wp]: cancel_all_ipc, cancel_all_signals "\<lambda>s. P (caps_of_state s)"
   (wp: mapM_x_wp' crunch_wps)
 
-crunch caps_of_state[wp]: reply_unlink_tcb, reply_unlink_sc "\<lambda>s. P (caps_of_state s)"
-  (wp: maybeM_inv mapM_x_wp' crunch_wps)
-
-crunch caps_of_state[wp]: tcb_release_remove "\<lambda>s. P (caps_of_state s)"
-
-crunch caps_of_state[wp]:
+crunches
   unbind_notification, sched_context_unbind_ntfn, sched_context_maybe_unbind_ntfn,
   unbind_maybe_notification, unbind_from_sc, sched_context_unbind_tcb,
-  sched_context_unbind_yield_from, update_sk_obj_ref "\<lambda>s. P (caps_of_state s)"
+  sched_context_unbind_yield_from, update_sk_obj_ref, sched_context_zero_refill_max
+  for caps_of_state[wp]: "\<lambda>s. P (caps_of_state s)"
   (wp: crunch_wps maybeM_inv
    ignore: set_object set_tcb_obj_ref tcb_release_remove)
 
@@ -839,8 +835,9 @@ lemma sc_refill_max_update_cur_sc_tcb[wp]:
   apply (clarsimp simp: sc_at_pred_n_def obj_at_def)
   done
 
-lemma reset_sc_refill_max_invs[wp]:
-  "\<lbrace>invs and K (p \<noteq> idle_sc_ptr)\<rbrace> set_sc_obj_ref sc_refill_max_update p n \<lbrace>\<lambda>_. invs\<rbrace>"
+lemma sched_context_zero_refill_max_invs[wp]:
+  "\<lbrace>invs and K (p \<noteq> idle_sc_ptr)\<rbrace> sched_context_zero_refill_max p \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (clarsimp simp: sched_context_zero_refill_max_def)
   by (wpsimp wp: set_sc_obj_ref_invs_no_change)
 
 lemma (in Finalise_AI_1) fast_finalise_invs:
@@ -1068,7 +1065,7 @@ crunch cte_wp_at[wp]: cancel_ipc "cte_wp_at P p"
 
 crunches
   fast_finalise, sched_context_unbind_all_tcbs, sched_context_unbind_yield_from,
-  sched_context_unbind_reply, sched_context_unbind_ntfn
+  sched_context_unbind_reply, sched_context_unbind_ntfn, sched_context_zero_refill_max
   for cte_wp_at[wp]: "cte_wp_at P p"
   (wp: crunch_wps ignore: set_tcb_obj_ref simp: crunch_simps)
 
@@ -1165,7 +1162,7 @@ locale Finalise_AI_3 = Finalise_AI_2 a b
 crunches
   suspend, unbind_maybe_notification, unbind_notification, deleting_irq_handler,
   sched_context_unbind_all_tcbs, sched_context_unbind_yield_from,
-  sched_context_unbind_reply, sched_context_unbind_ntfn
+  sched_context_unbind_reply, sched_context_unbind_ntfn, sched_context_zero_refill_max
   for irq_node[wp]: "\<lambda>s. P (interrupt_irq_node s)"
   (wp: crunch_wps select_wp maybeM_inv simp: crunch_simps)
 

--- a/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
@@ -1197,8 +1197,9 @@ lemma sched_context_unbind_yield_from_not_live:
   apply (auto simp: obj_at_def live_def live_sc_def)
   done
 
-lemma sc_refill_max_update_not_live[wp]:
-  "update_sched_context sc_ptr (sc_refill_max_update f) \<lbrace>obj_at (Not \<circ> live) sc\<rbrace>"
+lemma sched_context_zero_refill_max_not_live[wp]:
+  "sched_context_zero_refill_max sc_ptr \<lbrace>obj_at (Not \<circ> live) sc\<rbrace>"
+  apply (clarsimp simp: sched_context_zero_refill_max_def set_refills_def)
   apply (wpsimp simp: wp: update_sched_context_wp)
   apply (auto simp: obj_at_def live_def live_sc_def)
   done
@@ -1357,7 +1358,7 @@ lemma finalise_cap_replaceable [Finalise_AI_asms]:
               | hammer
               | wp (once) sched_context_unbind_yield_from_not_live[unfolded o_def]
               | wp (once) hoare_drop_imps; wp (once) hoare_vcg_conj_lift,
-                wp (once) sc_refill_max_update_not_live[unfolded o_def])+)[1]
+                wp (once) sched_context_zero_refill_max_not_live[unfolded o_def])+)[1]
      \<comment> \<open>schedcontrol\<close>
       apply ((wpsimp | hammer)+)[1]
      \<comment> \<open>irqcontrol\<close>

--- a/spec/abstract/CSpace_A.thy
+++ b/spec/abstract/CSpace_A.thy
@@ -513,7 +513,7 @@ where
          when final $ sched_context_unbind_ntfn sc;
          when final $ sched_context_unbind_reply sc;
          when final $ sched_context_unbind_yield_from sc;
-         when final $ set_sc_obj_ref sc_refill_max_update sc 0;
+         when final $ sched_context_zero_refill_max sc;
          return (NullCap, NullCap)
       od"
 | "finalise_cap SchedControlCap          final = return (NullCap, NullCap)"

--- a/spec/abstract/SchedContext_A.thy
+++ b/spec/abstract/SchedContext_A.thy
@@ -381,6 +381,13 @@ where
      when (sc' \<noteq> Some sc_ptr) $ sched_context_bind_tcb sc_ptr tcb_ptr
    od"
 
+definition
+  sched_context_zero_refill_max :: "obj_ref \<Rightarrow> (unit, 'z::state_ext) s_monad"
+where
+  "sched_context_zero_refill_max sc_ptr = do
+     set_sc_obj_ref sc_refill_max_update sc_ptr 0;
+     set_refills sc_ptr []
+   od"
 
 text \<open> Unbind TCB from its scheduling context, if there is one bound. \<close>
 definition


### PR DESCRIPTION
This is to make it possible to prove correspondence when setting `sc_refill_max` to `0` in `finalise_cap`. Due to how the state relation is defined, in Haskell doing this implicitly also leads to an empty refill list, and this change makes the abstract do the same thing.

There was potentially an alternative solution involving updating the state_relation. We decided to go with this option because we found it more intuitive, and it also has the potential to simplify some of the abstract invariants. For example, it might now be possible to prove that some invariants hold for all scheduling contexts instead of just active ones.