### PR TITLE
decode sched control

### DIFF
--- a/proof/invariant-abstract/DetSchedInvs_AI.thy
+++ b/proof/invariant-abstract/DetSchedInvs_AI.thy
@@ -1484,7 +1484,7 @@ definition rr_valid_refills :: "refill list \<Rightarrow> nat \<Rightarrow> tick
       \<and> length refills = 2
       \<and> MIN_BUDGET \<le> budget
       \<and> refill_max = MIN_REFILLS
-      \<and> budget \<le> MAX_SC_PERIOD)"
+      \<and> budget \<le> MAX_PERIOD)"
 
 definition sp_valid_refills :: "refill list \<Rightarrow> nat \<Rightarrow> ticks \<Rightarrow> ticks \<Rightarrow> bool" where
   "sp_valid_refills refills refill_max period budget \<equiv>
@@ -1498,7 +1498,7 @@ definition sp_valid_refills :: "refill list \<Rightarrow> nat \<Rightarrow> tick
       \<and> MIN_BUDGET \<le> budget
       \<and> budget \<le> period
       \<and> MIN_REFILLS \<le> refill_max
-      \<and> period \<le> MAX_SC_PERIOD)"
+      \<and> period \<le> MAX_PERIOD)"
 
 \<comment> \<open>unat is monotonic on le\<close>
 lemma unat_le_mono:
@@ -1629,7 +1629,7 @@ lemmas consumed_time_bounded_def = consumed_time_bounded_2_def
 
 definition current_time_bounded_2 where
   "current_time_bounded_2 k curtime \<equiv>
-   unat curtime + unat kernelWCET_ticks + k * unat MAX_SC_PERIOD \<le> unat max_time"
+   unat curtime + unat kernelWCET_ticks + k * unat MAX_PERIOD \<le> unat max_time"
 
 abbreviation current_time_bounded :: "nat \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
   "current_time_bounded k s \<equiv> current_time_bounded_2 k (cur_time s)"
@@ -2353,7 +2353,7 @@ lemmas valid_ready_qs_def = valid_ready_qs_2_def valid_ready_queued_thread_2_def
 
 definition bounded_release_time_2 :: "time \<Rightarrow> time \<Rightarrow> bool" where
   "bounded_release_time_2 curtime reltime \<equiv>
-     unat reltime \<le> unat curtime + unat kernelWCET_ticks + unat MAX_SC_PERIOD"
+     unat reltime \<le> unat curtime + unat kernelWCET_ticks + unat MAX_PERIOD"
 
 abbreviation cfg_bounded_release_time :: "time \<Rightarrow> sc_refill_cfg \<Rightarrow> bool" where
   "cfg_bounded_release_time t cfg \<equiv>

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -7359,7 +7359,7 @@ lemma refill_new_not_active_sc:
 lemma refill_new_bounded_release_time[wp]:
   "\<lbrace>\<lambda>s. if p = scp
         then (\<exists>sc n. kheap s p = Some (SchedContext sc n)
-             \<and> unat (cur_time s) + unat MAX_SC_PERIOD \<le> unat max_time)
+             \<and> unat (cur_time s) + unat MAX_PERIOD \<le> unat max_time)
         else bounded_release_time scp s\<rbrace>
    refill_new p max_refills budget period
    \<lbrace>\<lambda>s. bounded_release_time scp\<rbrace>"
@@ -7378,8 +7378,8 @@ lemma refill_new_valid_refills[wp]:
   "\<lbrace>(\<lambda>s. unat (cur_time s) + unat period \<le> unat max_time)
     and (\<lambda>s. if scptr \<noteq> p then valid_refills scptr s else \<exists>sc n. ko_at (SchedContext sc n) p s)
     and K (if period=0
-           then max_refills = MIN_REFILLS \<and> MIN_BUDGET \<le> budget \<and> budget \<le> MAX_SC_PERIOD
-           else MIN_REFILLS \<le> max_refills \<and> budget \<le> period \<and> MIN_BUDGET \<le> budget \<and> period \<le> MAX_SC_PERIOD)\<rbrace>
+           then max_refills = MIN_REFILLS \<and> MIN_BUDGET \<le> budget \<and> budget \<le> MAX_PERIOD
+           else MIN_REFILLS \<le> max_refills \<and> budget \<le> period \<and> MIN_BUDGET \<le> budget \<and> period \<le> MAX_PERIOD)\<rbrace>
    refill_new p max_refills budget period
    \<lbrace>\<lambda>_. valid_refills scptr\<rbrace>"
   supply if_split [split del]
@@ -7400,9 +7400,9 @@ lemma refill_update_valid_refills:
                                    \<and> unat (r_time (refill_hd sc)) + 2 * unat new_period
                                      \<le> unat max_time) p s))
     and K (if new_period = 0
-           then new_max_refills = MIN_REFILLS \<and> MIN_BUDGET \<le> new_budget \<and> new_budget \<le> MAX_SC_PERIOD
+           then new_max_refills = MIN_REFILLS \<and> MIN_BUDGET \<le> new_budget \<and> new_budget \<le> MAX_PERIOD
            else MIN_REFILLS \<le> new_max_refills \<and> MIN_BUDGET \<le> new_budget
-                \<and> new_period \<le> MAX_SC_PERIOD \<and> new_budget \<le> new_period)\<rbrace>
+                \<and> new_period \<le> MAX_PERIOD \<and> new_budget \<le> new_period)\<rbrace>
    refill_update p new_period new_budget new_max_refills
    \<lbrace>\<lambda>_. valid_refills scptr\<rbrace>"
   supply if_split [split del]
@@ -7536,7 +7536,7 @@ lemma valid_refills_r_amount_bounded_sc_budget:
   done
 
 lemma valid_refills_r_amount_bounded_max_sc_period:
-  "sc_valid_refills sc \<Longrightarrow> r_amount (refill_hd sc) \<le> MAX_SC_PERIOD"
+  "sc_valid_refills sc \<Longrightarrow> r_amount (refill_hd sc) \<le> MAX_PERIOD"
   apply (clarsimp simp: sc_valid_refills_def rr_valid_refills_def split: if_splits)
   apply (rule order_trans[rotated], assumption)
   apply (rule valid_refills_r_amount_bounded_sc_budget)
@@ -7629,7 +7629,7 @@ lemma sc_refill_ready_release_time_well_bounded:
    \<Longrightarrow> current_time_bounded 2 s
    \<Longrightarrow> valid_refills p s
    \<Longrightarrow> sc_refill_ready (cur_time s) sc
-   \<Longrightarrow> unat (r_time (refill_hd sc)) + unat MAX_SC_PERIOD + unat MAX_SC_PERIOD \<le> unat max_time"
+   \<Longrightarrow> unat (r_time (refill_hd sc)) + unat MAX_PERIOD + unat MAX_PERIOD \<le> unat max_time"
   apply (clarsimp simp: current_time_bounded_def refill_ready_def mult_2 add.assoc[symmetric])
   apply (erule order_trans[rotated], clarsimp)
   apply (rule order_trans[OF _ unat_plus_gt])
@@ -8202,7 +8202,7 @@ lemma refill_budget_check_no_overflow_schedule_used_helper:
     refills_sum (sc_refills sc) = sc_budget sc; ordered_disjoint (sc_refills sc);
     no_overflow (sc_refills sc); window (sc_refills sc) (sc_period sc);
     MIN_BUDGET \<le> r_amount (refill_hd sc); sc_refills sc \<noteq> []; MIN_BUDGET \<le> sc_budget sc;
-    sc_budget sc \<le> sc_period sc;  sc_period sc \<le> MAX_SC_PERIOD;
+    sc_budget sc \<le> sc_period sc;  sc_period sc \<le> MAX_PERIOD;
      unat (r_amount (refill_hd sc)) \<le> unat (sc_period sc)\<rbrakk>
    \<Longrightarrow> no_overflow
         (schedule_used (length (sc_refills sc) = sc_refill_max sc)
@@ -8313,7 +8313,7 @@ lemma refill_budget_check_r_time_plus_sum_bounded_helper:
     refills_sum (sc_refills sc) = sc_budget sc; ordered_disjoint (sc_refills sc);
     no_overflow (sc_refills sc); window (sc_refills sc) (sc_period sc);
     MIN_BUDGET \<le> r_amount (refill_hd sc); sc_refills sc \<noteq> [];  MIN_BUDGET \<le> sc_budget sc;
-    sc_budget sc \<le> sc_period sc;  sc_period sc \<le> MAX_SC_PERIOD\<rbrakk>
+    sc_budget sc \<le> sc_period sc;  sc_period sc \<le> MAX_PERIOD\<rbrakk>
    \<Longrightarrow> unat
          (r_time
            (hd (MIN_BUDGET_merge
@@ -8555,7 +8555,7 @@ lemma refill_budget_check_round_robin_valid_refills[wp]:
    "\<lbrace>valid_refills p
      and (\<lambda>s. pred_map (\<lambda>cfg. scrc_period cfg = 0) (sc_refill_cfgs_of s) (cur_sc s))
      and (\<lambda>s. is_refill_sufficient usage (cur_sc s) s)
-     and K (unat usage + unat MAX_SC_PERIOD \<le> unat max_time)\<rbrace>
+     and K (unat usage + unat MAX_PERIOD \<le> unat max_time)\<rbrace>
     refill_budget_check_round_robin usage
     \<lbrace>\<lambda>_. valid_refills p\<rbrace>"
   supply if_split[split del]
@@ -8576,7 +8576,7 @@ lemma refill_budget_check_round_robin_valid_refills[wp]:
 lemma consumed_time_bounded_helper:
   "consumed_time_bounded s
    \<Longrightarrow> current_time_bounded 1 s
-   \<Longrightarrow> unat (consumed_time s) + unat MAX_SC_PERIOD \<le> unat max_time"
+   \<Longrightarrow> unat (consumed_time s) + unat MAX_PERIOD \<le> unat max_time"
   unfolding consumed_time_bounded_def current_time_bounded_def
   by linarith
 
@@ -9193,7 +9193,7 @@ lemma refill_budget_check_round_robin_valid_ready_qs_offset_ready_and_sufficient
         \<and> active_sc_valid_refills s
         \<and> pred_map (\<lambda>cfg. scrc_period cfg = 0) (sc_refill_cfgs_of s) (cur_sc s)
         \<and> cur_sc_offset_ready usage s \<and> cur_sc_offset_sufficient usage s
-        \<and> current_time_bounded 2 s \<and> unat usage + unat MAX_SC_PERIOD \<le> unat max_time\<rbrace>
+        \<and> current_time_bounded 2 s \<and> unat usage + unat MAX_PERIOD \<le> unat max_time\<rbrace>
    refill_budget_check_round_robin usage
    \<lbrace>\<lambda>_. valid_ready_qs\<rbrace>"
   apply (rule hoare_lift_Pf2[where f="ready_queues", rotated], wpsimp)
@@ -9219,7 +9219,7 @@ lemma refill_budget_check_round_robin_valid_ready_qs:
   "\<lbrace>\<lambda>s. valid_ready_qs s \<and>
          active_sc_valid_refills s \<and>
          current_time_bounded 2 s \<and> pred_map (\<lambda>cfg. scrc_period cfg = 0) (sc_refill_cfgs_of s) (cur_sc s) \<and>
-         unat usage + unat MAX_SC_PERIOD \<le> unat max_time \<and>
+         unat usage + unat MAX_PERIOD \<le> unat max_time \<and>
         ((cur_sc_offset_ready usage s \<and> cur_sc_offset_sufficient usage s )
          \<or> (sc_not_in_ready_q (cur_sc s) s))\<rbrace>
    refill_budget_check_round_robin usage
@@ -9491,7 +9491,7 @@ lemma refill_budget_check_bounded_release_time:
 lemma refill_budget_check_round_robin_active_sc_valid_refills:
   "\<lbrace>active_sc_valid_refills
     and (\<lambda>s. pred_map (\<lambda>cfg. scrc_period cfg = 0) (sc_refill_cfgs_of s) (cur_sc s))
-    and K (unat consumed + unat MAX_SC_PERIOD \<le> unat max_time)
+    and K (unat consumed + unat MAX_PERIOD \<le> unat max_time)
     and cur_sc_offset_sufficient consumed
     and current_time_bounded 1\<rbrace>
    refill_budget_check_round_robin consumed
@@ -9501,8 +9501,8 @@ lemma refill_budget_check_round_robin_active_sc_valid_refills:
 
 lemma cur_sc_bounded_release_helper:
   "kheap s (cur_sc s) = Some (SchedContext sc n)
-  \<Longrightarrow> sc_period sc \<le> MAX_SC_PERIOD
-  \<Longrightarrow> unat (r_time (refill_hd sc)) + unat (sc_period sc) + unat MAX_SC_PERIOD + unat consumed \<le> unat max_time
+  \<Longrightarrow> sc_period sc \<le> MAX_PERIOD
+  \<Longrightarrow> unat (r_time (refill_hd sc)) + unat (sc_period sc) + unat MAX_PERIOD + unat consumed \<le> unat max_time
   \<Longrightarrow> unat (r_time (refill_hd sc)) + 2 * unat (sc_period sc) + unat consumed \<le> unat max_time"
   by (simp add: word_le_nat_alt)
 
@@ -9637,7 +9637,7 @@ lemma refill_unblock_check_bounded_release_time:
   apply (clarsimp simp: obj_at_def refills_merge_prefix_r_time_hd current_time_bounded_def
                         bounded_release_time_def)
   apply (subgoal_tac "unat (cur_time s + kernelWCET_ticks)
-              \<le> unat (cur_time s) + unat kernelWCET_ticks + unat MAX_SC_PERIOD", clarsimp)
+              \<le> unat (cur_time s) + unat kernelWCET_ticks + unat MAX_PERIOD", clarsimp)
   by (rule order_trans, rule unat_plus_gt, simp)
 
 lemma refill_unblock_check_active_sc_valid_refills:
@@ -13813,9 +13813,9 @@ lemma refill_update_valid_blocked:
 
 lemma refill_new_active_sc_valid_refills:
   "\<lbrace>active_sc_valid_refills
-    and (\<lambda>s. unat (cur_time s) + unat MAX_SC_PERIOD \<le> unat max_time)
-    and K (period \<noteq> 0 \<longrightarrow> MIN_REFILLS \<le> max_refills \<and> budget \<le> period \<and> MIN_BUDGET \<le> budget \<and> period \<le> MAX_SC_PERIOD)
-    and K (period = 0 \<longrightarrow> MIN_REFILLS = max_refills \<and> MIN_BUDGET \<le> budget \<and> budget \<le> MAX_SC_PERIOD)
+    and (\<lambda>s. unat (cur_time s) + unat MAX_PERIOD \<le> unat max_time)
+    and K (period \<noteq> 0 \<longrightarrow> MIN_REFILLS \<le> max_refills \<and> budget \<le> period \<and> MIN_BUDGET \<le> budget \<and> period \<le> MAX_PERIOD)
+    and K (period = 0 \<longrightarrow> MIN_REFILLS = max_refills \<and> MIN_BUDGET \<le> budget \<and> budget \<le> MAX_PERIOD)
     and (\<lambda>s. \<exists>sc n. kheap s p = Some (SchedContext sc n)) \<rbrace>
    refill_new p max_refills budget period
    \<lbrace>\<lambda>rv. active_sc_valid_refills\<rbrace>"
@@ -13850,8 +13850,8 @@ lemma refill_update_active_sc_valid_refills:
   "\<lbrace>active_sc_valid_refills
     and current_time_bounded 3
     and K (period \<noteq> 0 \<longrightarrow> MIN_REFILLS \<le> max_refills \<and> budget \<le> period \<and> MIN_BUDGET \<le> budget
-                          \<and> period \<le> MAX_SC_PERIOD)
-    and K (period = 0 \<longrightarrow> MIN_REFILLS = max_refills \<and> MIN_BUDGET \<le> budget \<and> budget \<le> MAX_SC_PERIOD)
+                          \<and> period \<le> MAX_PERIOD)
+    and K (period = 0 \<longrightarrow> MIN_REFILLS = max_refills \<and> MIN_BUDGET \<le> budget \<and> budget \<le> MAX_PERIOD)
     and is_active_sc p\<rbrace>
    refill_update p period budget max_refills
    \<lbrace>\<lambda>rv. active_sc_valid_refills\<rbrace>"
@@ -14960,7 +14960,7 @@ lemma charge_budget_released_ipc_queues:
     and active_sc_valid_refills
     and current_time_bounded 3
     and cur_sc_active
-    and K (unat consumed + unat MAX_SC_PERIOD \<le> unat max_time)
+    and K (unat consumed + unat MAX_PERIOD \<le> unat max_time)
     and cur_sc_offset_ready 0\<rbrace>
    charge_budget consumed canTimeout
    \<lbrace>\<lambda>_. released_ipc_queues :: 'state_ext state \<Rightarrow> _\<rbrace>"
@@ -14996,7 +14996,7 @@ lemma charge_budget_valid_ready_qs:
     and cur_sc_chargeable
     and cur_sc_not_blocked
     and cur_sc_active
-    and K(unat consumed + unat MAX_SC_PERIOD \<le> unat max_time)
+    and K(unat consumed + unat MAX_PERIOD \<le> unat max_time)
     and cur_sc_offset_ready 0
     and current_time_bounded 3\<rbrace>
    charge_budget consumed canTimeout
@@ -15044,7 +15044,7 @@ crunches end_timeslice
 
 lemma charge_budget_active_sc_valid_refills:
   "\<lbrace>active_sc_valid_refills
-    and K (unat consumed + unat MAX_SC_PERIOD \<le> unat max_time)
+    and K (unat consumed + unat MAX_PERIOD \<le> unat max_time)
     and current_time_bounded 3
     and cur_sc_offset_ready 0\<rbrace>
    charge_budget consumed canTimeout
@@ -15118,7 +15118,7 @@ lemma charge_budget_valid_sched:
     and cur_sc_active
     and current_time_bounded 3
     and (\<lambda>s. (canTimeout \<longrightarrow> cur_sc_tcb_are_bound s \<longrightarrow> cur_sc_active s))
-    and K (unat consumed + unat MAX_SC_PERIOD \<le> unat max_time)
+    and K (unat consumed + unat MAX_PERIOD \<le> unat max_time)
     and cur_sc_offset_ready 0\<rbrace>
    charge_budget consumed canTimeout
    \<lbrace>\<lambda>_. valid_sched :: 'state_ext state \<Rightarrow> _\<rbrace>"
@@ -15448,21 +15448,21 @@ lemma next_time_bounded_current_time_bounded:
   done
 
 lemma next_time_bounded_weaken1:
-  "next_time_bounded 1 s \<Longrightarrow> pred_next_time (\<lambda>x. unat x + unat MAX_SC_PERIOD \<le> unat max_time) s"
+  "next_time_bounded 1 s \<Longrightarrow> pred_next_time (\<lambda>x. unat x + unat MAX_PERIOD \<le> unat max_time) s"
   by (erule pred_next_time_strengthen, clarsimp simp: current_time_bounded_def)
 
 lemma current_time_bounded_weaken1:
-  "current_time_bounded 2 s \<Longrightarrow> 2 * unat MAX_SC_PERIOD \<le> unat max_time"
+  "current_time_bounded 2 s \<Longrightarrow> 2 * unat MAX_PERIOD \<le> unat max_time"
   by (clarsimp simp: current_time_bounded_def)
 
 lemmas next_time_bounded_weaken2 = next_time_bounded_current_time_bounded[THEN current_time_bounded_weaken1]
 
 lemma current_time_bounded1_drop_WCET:
-  "current_time_bounded 1 s \<Longrightarrow> unat (cur_time s) + unat MAX_SC_PERIOD \<le> unat max_time"
+  "current_time_bounded 1 s \<Longrightarrow> unat (cur_time s) + unat MAX_PERIOD \<le> unat max_time"
   by (clarsimp simp: current_time_bounded_def)
 
 lemma current_time_bounded_drop_WCET:
-  "current_time_bounded k s \<Longrightarrow> unat (cur_time s) + k * unat MAX_SC_PERIOD \<le> unat max_time"
+  "current_time_bounded k s \<Longrightarrow> unat (cur_time s) + k * unat MAX_PERIOD \<le> unat max_time"
   by (clarsimp simp: current_time_bounded_def)
 
 abbreviation (input) iscc_valid_sched_predicate where
@@ -15574,7 +15574,7 @@ lemma invoke_sched_control_configure_valid_sched:
                              \<and> current_time_bounded 0 s
                              \<and> sc_refill_max_sc_at (\<lambda>rm. rm = sc_refill_max sc) sc_ptr s
                              \<and> sc_tcb_sc_at (\<lambda>to. to = sc_tcb sc) sc_ptr s
-                             \<and> period \<le> MAX_SC_PERIOD
+                             \<and> period \<le> MAX_PERIOD
                              \<and> cur_sc_offset_ready (consumed_time s) s
                              \<and> cur_sc_offset_sufficient (consumed_time s) s
                              \<and> cur_sc_in_release_q_imp_zero_consumed s
@@ -15639,7 +15639,7 @@ lemma invoke_sched_control_configure_valid_sched:
   apply (subst return_bind)
   apply (rename_tac tcb_ptr)
   apply (rule_tac B="\<lambda>rv s. iscc_valid_sched_predicate sc_ptr tcb_ptr mrefills budget s
-                            \<and> budget \<le> period \<and> period \<le> MAX_SC_PERIOD \<and> current_time_bounded 3 s
+                            \<and> budget \<le> period \<and> period \<le> MAX_PERIOD \<and> current_time_bounded 3 s
                             \<and> ex_nonz_cap_to sc_ptr s \<and> consumed_time_bounded s
                             \<and> sc_refill_max_sc_at (\<lambda>rm. rm = sc_refill_max sc) sc_ptr s
                             \<and> sc_tcb_sc_at (\<lambda>to. to = sc_tcb sc) sc_ptr s
@@ -15655,7 +15655,7 @@ lemma invoke_sched_control_configure_valid_sched:
    apply (clarsimp simp: valid_sched_valid_sched_except_blocked)
 
   apply (rule_tac B="\<lambda>rv s. iscc_valid_sched_predicate sc_ptr tcb_ptr mrefills budget s
-                            \<and> budget \<le> period \<and> period \<le> MAX_SC_PERIOD \<and> current_time_bounded 3 s
+                            \<and> budget \<le> period \<and> period \<le> MAX_PERIOD \<and> current_time_bounded 3 s
                             \<and> ex_nonz_cap_to sc_ptr s \<and> consumed_time_bounded s
                             \<and> sc_refill_max_sc_at (\<lambda>rm. rm = sc_refill_max sc) sc_ptr s
                             \<and> sc_tcb_sc_at (\<lambda>to. to = sc_tcb sc) sc_ptr s
@@ -15678,7 +15678,7 @@ lemma invoke_sched_control_configure_valid_sched:
   apply (rule hoare_seq_ext[OF _ gets_sp])
   apply (rename_tac csc)
   apply (rule_tac B="\<lambda>rv s. iscc_valid_sched_predicate sc_ptr tcb_ptr mrefills budget s
-                            \<and> budget \<le> period \<and> period \<le> MAX_SC_PERIOD \<and> current_time_bounded 3 s
+                            \<and> budget \<le> period \<and> period \<le> MAX_PERIOD \<and> current_time_bounded 3 s
                             \<and> sc_tcb_sc_at (\<lambda>tcb. tcb = sc_tcb sc) sc_ptr s
                             \<and> sc_refill_max_sc_at (\<lambda>rm. rm = sc_refill_max sc) sc_ptr s
                             \<and> not_in_release_q tcb_ptr s \<and> consumed_time_bounded s
@@ -15705,7 +15705,7 @@ lemma invoke_sched_control_configure_valid_sched:
     apply (clarsimp simp: vs_all_heap_simps obj_at_def)
 
   apply (rule_tac B="\<lambda>rv s. valid_sched_except_blocked s
-                            \<and> budget \<le> period \<and> period \<le> MAX_SC_PERIOD \<and> current_time_bounded 3 s
+                            \<and> budget \<le> period \<and> period \<le> MAX_PERIOD \<and> current_time_bounded 3 s
                             \<and> valid_blocked_except tcb_ptr s \<and> consumed_time_bounded s
                             \<and> invs s
                             \<and> pred_map_eq (Some sc_ptr) (tcb_scps_of s) tcb_ptr
@@ -15718,7 +15718,7 @@ lemma invoke_sched_control_configure_valid_sched:
    apply (rename_tac thread_state2)
    apply (simp only: valid_sched_def cong: conj_cong)
    apply (rule_tac B="\<lambda>rv s. valid_sched_except_blocked s
-                             \<and> budget \<le> period \<and> period \<le> MAX_SC_PERIOD \<and> current_time_bounded 3 s
+                             \<and> budget \<le> period \<and> period \<le> MAX_PERIOD \<and> current_time_bounded 3 s
                              \<and> valid_blocked_except tcb_ptr s
                              \<and> invs s \<and> consumed_time_bounded s
                              \<and> (runnable thread_state2
@@ -16158,7 +16158,7 @@ lemma handle_yield_valid_sched:
   apply (intro conjI)
      apply (clarsimp)
     apply (drule ct_not_blocked_cur_sc_not_blocked; simp)
-   apply (rule_tac y=" unat MAX_SC_PERIOD + unat MAX_SC_PERIOD" in order_trans[rotated])
+   apply (rule_tac y=" unat MAX_PERIOD + unat MAX_PERIOD" in order_trans[rotated])
     apply (clarsimp simp: current_time_bounded_def)
    apply (rule add_mono[rotated], simp)
    apply (clarsimp simp: valid_sched_def active_sc_valid_refills_def)
@@ -17333,9 +17333,9 @@ lemma ct_not_blocked_cur_sc_not_blocked_trivial:
 
 lemma refill_bounded_helper:
   "valid_refills (cur_sc s) s
-   \<Longrightarrow> 2*unat MAX_SC_PERIOD \<le> unat max_time
+   \<Longrightarrow> 2*unat MAX_PERIOD \<le> unat max_time
    \<Longrightarrow> (\<forall>sc. (\<exists>n. kheap s (cur_sc s) = Some (SchedContext sc n)) \<longrightarrow>
-                   unat (r_amount (refill_hd sc)) + unat MAX_SC_PERIOD \<le> unat max_time)"
+                   unat (r_amount (refill_hd sc)) + unat MAX_PERIOD \<le> unat max_time)"
   apply clarsimp
   apply (erule order_trans[rotated])
   apply (clarsimp simp: vs_all_heap_simps valid_refills_def)
@@ -17452,9 +17452,9 @@ lemma update_time_stamp_cur_sc_offset_ready_cs[wp]:
   done
 
 lemma strengthen_consumed_time_bound:
-  "unat (cur_time s) + unat MAX_SC_PERIOD \<le> unat max_time
+  "unat (cur_time s) + unat MAX_PERIOD \<le> unat max_time
    \<and> unat (consumed_time s) \<le> unat (cur_time s)
-   \<Longrightarrow> unat (consumed_time s) + unat MAX_SC_PERIOD \<le> unat max_time"
+   \<Longrightarrow> unat (consumed_time s) + unat MAX_PERIOD \<le> unat max_time"
   by linarith
 
 end
@@ -18691,7 +18691,7 @@ lemma charge_budget_ready_if_schedulable[wp]:
     and active_sc_valid_refills
     and (\<lambda>s. heap_refs_inv (sc_tcbs_of s) (tcb_scps_of s))
     and current_time_bounded 3
-    and (\<lambda>s. unat consumed + unat MAX_SC_PERIOD \<le> unat max_time)
+    and (\<lambda>s. unat consumed + unat MAX_PERIOD \<le> unat max_time)
     and cur_sc_offset_ready 0\<rbrace>
    charge_budget consumed x
    \<lbrace>\<lambda>_. ct_ready_if_schedulable :: det_state \<Rightarrow> _\<rbrace>"
@@ -18769,7 +18769,7 @@ lemma check_budget_ct_ready_if_schedulable[wp]:
     and cur_sc_active and current_time_bounded 3
     and (\<lambda>s. heap_refs_inv (sc_tcbs_of s) (tcb_scps_of s))
     and (\<lambda>s. cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s)
-    and (\<lambda>s. unat (consumed_time s) + unat MAX_SC_PERIOD \<le> unat max_time)\<rbrace>
+    and (\<lambda>s. unat (consumed_time s) + unat MAX_PERIOD \<le> unat max_time)\<rbrace>
    check_budget
    \<lbrace>\<lambda>_. ct_ready_if_schedulable :: det_state \<Rightarrow> _\<rbrace>"
   unfolding check_budget_def
@@ -21782,7 +21782,7 @@ lemma check_budget_restart_ct_ready_if_schedulable[wp]:
     and cur_sc_active and current_time_bounded 3
     and (\<lambda>s. heap_refs_inv (sc_tcbs_of s) (tcb_scps_of s))
     and (\<lambda>s. cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s)
-    and (\<lambda>s. unat (consumed_time s) + unat MAX_SC_PERIOD \<le> unat max_time)\<rbrace>
+    and (\<lambda>s. unat (consumed_time s) + unat MAX_PERIOD \<le> unat max_time)\<rbrace>
    check_budget_restart
    \<lbrace>\<lambda>rv s:: det_state. ct_ready_if_schedulable s\<rbrace>"
   unfolding check_budget_restart_def
@@ -22119,7 +22119,7 @@ lemma handle_yield_ct_ready_if_schedulable[wp]:
   apply (wpsimp wp: charge_budget_ready_if_schedulable get_refills_wp)
   apply (intro conjI)
     apply (erule invs_sc_tcbs_sym_heap_refs)
-   apply (rule_tac y=" unat MAX_SC_PERIOD + unat MAX_SC_PERIOD" in order_trans[rotated])
+   apply (rule_tac y=" unat MAX_PERIOD + unat MAX_PERIOD" in order_trans[rotated])
     apply (clarsimp simp: current_time_bounded_def)
    apply (rule add_mono[rotated], simp)
    apply (clarsimp simp: valid_sched_def active_sc_valid_refills_def)

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -596,8 +596,8 @@ where
     "valid_sched_control_inv (InvokeSchedControlConfigure scptr budget period mrefills badge)
      = (obj_at (\<lambda>ko. \<exists>sc n. ko = SchedContext sc n \<and> valid_refills_number mrefills n) scptr
         and ex_nonz_cap_to scptr and K (MIN_REFILLS \<le> mrefills) \<comment> \<open>mrefills = MIN_REFILLS + extra_refills\<close>
-        and K (budget \<le> MAX_SC_PERIOD \<and> budget \<ge> MIN_BUDGET)
-        and K (period \<le> MAX_SC_PERIOD \<and> budget \<ge> MIN_BUDGET)
+        and K (budget \<le> MAX_PERIOD \<and> budget \<ge> MIN_BUDGET)
+        and K (period \<le> MAX_PERIOD \<and> budget \<ge> MIN_BUDGET)
         and K (budget \<le> period))"
 
 
@@ -1875,10 +1875,14 @@ lemma decode_sched_control_inv_wf:
    prefer 2
    apply (drule hd_in_set, simp)
   apply (clarsimp simp add: valid_cap_def obj_at_def is_sc_obj_def split: cap.split_asm)
+  apply (rename_tac ko)
   apply (case_tac ko; simp)
   apply (clarsimp simp: valid_refills_number_def max_refills_cap_def
-                        us_to_ticks_mono[simplified mono_def] MIN_BUDGET_def MIN_BUDGET_US_def
-                        not_less)
+                        MIN_BUDGET_def MIN_BUDGET_US_def MAX_PERIOD_def not_less
+                        us_to_ticks_mono[simplified mono_def] kernelWCET_ticks_def)
+  apply (insert us_to_ticks_mult)
+  using kernelWCET_ticks_no_overflow apply clarsimp
+  using mono_def apply blast
   done
 
 end

--- a/spec/abstract/ARM/Arch_Structs_A.thy
+++ b/spec/abstract/ARM/Arch_Structs_A.thy
@@ -323,14 +323,6 @@ definition
 where
   "arch_tcb_get_registers \<equiv> arch_tcb_context_get"
 
-text \<open>
-  This matches @{text "60 * 60 * MS_IN_S"} because it should be in micro-seconds.
-\<close>
-definition
-  MAX_SC_PERIOD :: "64 word" (* FIXME RT: Rename this to MAX_BUDGET_US to match  *)
-where
-  "MAX_SC_PERIOD \<equiv> 60 * 60 * 1000"
-
 end
 
 end

--- a/spec/abstract/Decode_A.thy
+++ b/spec/abstract/Decode_A.thy
@@ -587,14 +587,14 @@ where
     target_cap \<leftarrow> returnOk $ hd excaps;
     whenE (\<not>is_sched_context_cap target_cap) $ throwError (InvalidCapability 1);
     sc_ptr \<leftarrow> returnOk $ obj_ref_of target_cap;
-    whenE ((us_to_ticks budget_\<mu>s) > MAX_SC_PERIOD \<or> (us_to_ticks budget_\<mu>s) < MIN_BUDGET) $
-      throwError (RangeError (ucast MIN_BUDGET_US) (ucast MAX_SC_PERIOD));
-    whenE ((us_to_ticks period_\<mu>s) > MAX_SC_PERIOD \<or> (us_to_ticks period_\<mu>s) < MIN_BUDGET) $
-      throwError (RangeError (ucast MIN_BUDGET_US) (ucast MAX_SC_PERIOD));
+    whenE (MAX_PERIOD_US < budget_\<mu>s \<or> budget_\<mu>s < MIN_BUDGET_US) $
+      throwError (RangeError (ucast MIN_BUDGET_US) (ucast MAX_PERIOD_US));
+    whenE (MAX_PERIOD_US < period_\<mu>s \<or> period_\<mu>s < MIN_BUDGET_US) $
+      throwError (RangeError (ucast MIN_BUDGET_US) (ucast MAX_PERIOD_US));
     whenE (period_\<mu>s < budget_\<mu>s) $
       throwError (RangeError (ucast MIN_BUDGET_US) (ucast period_\<mu>s));
     whenE (unat extra_refills + MIN_REFILLS > max_refills_cap target_cap) $
-      throwError (RangeError 0 (of_nat (max_refills_cap target_cap) - MIN_REFILLS));
+      throwError (RangeError 0 (of_nat (max_refills_cap target_cap - MIN_REFILLS)));
     assertE (MIN_REFILLS \<le> unat extra_refills + MIN_REFILLS);
     returnOk $ InvokeSchedControlConfigure sc_ptr
        (us_to_ticks budget_\<mu>s) (us_to_ticks period_\<mu>s) (unat extra_refills + MIN_REFILLS) badge

--- a/spec/abstract/RISCV64/Arch_Structs_A.thy
+++ b/spec/abstract/RISCV64/Arch_Structs_A.thy
@@ -309,13 +309,5 @@ definition arch_tcb_get_registers :: "arch_tcb \<Rightarrow> register \<Rightarr
   where
   "arch_tcb_get_registers a_tcb \<equiv> user_regs (tcb_context a_tcb)"
 
-text \<open>
-  This matches @{text "60 * 60 * MS_IN_S"} because it should be in micro-seconds.
-\<close>
-definition
-  MAX_SC_PERIOD :: "64 word" (* FIXME RT: Rename this to MAX_BUDGET_US to match  *)
-where
-  "MAX_SC_PERIOD \<equiv> 60 * 60 * 1000"
-
 end
 end

--- a/spec/abstract/Structures_A.thy
+++ b/spec/abstract/Structures_A.thy
@@ -53,7 +53,6 @@ requalify_consts
   untyped_min_bits
   untyped_max_bits
   msg_label_bits
-  MAX_SC_PERIOD
 
 requalify_facts
   kernelWCET_ticks_pos2
@@ -522,9 +521,6 @@ definition
       tcb_domain     = domain,
       tcb_arch       = default_arch_tcb\<rparr>"
 
-type_synonym ticks = "64 word"
-type_synonym time  = "64 word"
-
 record refill =
   r_time   :: time
   r_amount :: time
@@ -542,10 +538,13 @@ record sched_context =
   sc_replies    :: "obj_ref list"
 
 definition "MIN_REFILLS = 2"
-definition "MIN_BUDGET = 2 * kernelWCET_ticks"
+
 definition "MIN_BUDGET_US = 2 * kernelWCET_us"
+definition "MIN_BUDGET = 2 * kernelWCET_ticks"
 
 lemma MIN_BUDGET_pos: "0 < MIN_BUDGET" using MIN_BUDGET_def kernelWCET_ticks_pos2 by clarsimp
+
+definition "MAX_PERIOD = us_to_ticks MAX_PERIOD_US"
 
 definition "min_sched_context_bits = 8"
 

--- a/spec/design/skel/ARM/Hardware_H.thy
+++ b/spec/design/skel/ARM/Hardware_H.thy
@@ -19,7 +19,7 @@ definition ticksToUs :: "word64 \<Rightarrow> word64" where
   "ticksToUs \<equiv> ticks_to_us"
 
 definition maxUsToTicks :: "word64" where
-  "maxUsToTicks \<equiv> 60 * 60 * 1000" (* FIXME RT: sync with aspec and C *)
+  "maxUsToTicks \<equiv> max_us_to_ticks"
 
 definition maxTicksToUs :: "word64" where
   "maxTicksToUs \<equiv> max_ticks_to_us"
@@ -30,7 +30,10 @@ definition kernelWCETTicks :: "word64" where
 definition kernelWCETUs :: "word64" where
   "kernelWCETUs \<equiv> kernelWCET_us"
 
-#INCLUDE_HASKELL SEL4/Machine/Hardware/ARM.lhs Platform=Platform.ARM CONTEXT ARM_H NOT getMemoryRegions getDeviceRegions getKernelDevices loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt setDeadline configureTimer resetTimer debugPrint getRestartPC setNextPC clearMemory clearMemoryVM initMemory freeMemory writeTTBR0 setGlobalPD  setTTBCR setHardwareASID invalidateLocalTLB invalidateLocalTLB_ASID invalidateLocalTLB_VAASID cleanByVA cleanByVA_PoU invalidateByVA invalidateByVA_I invalidate_I_PoU cleanInvalByVA branchFlush clean_D_PoU cleanInvalidate_D_PoC cleanInvalidate_D_PoU cleanInvalidateL2Range invalidateL2Range cleanL2Range isb dsb dmb getIFSR getDFSR getFAR HardwareASID wordFromPDE wordFromPTE VMFaultType VMPageSize HypFaultType pageBits pageBitsForSize toPAddr cacheLineBits cacheLine lineStart cacheRangeOp cleanCacheRange_PoC cleanInvalidateCacheRange_RAM cleanCacheRange_RAM cleanCacheRange_PoU invalidateCacheRange_RAM invalidateCacheRange_I branchFlushRange cleanCaches_PoU cleanInvalidateL1Caches addrFromPPtr ptrFromPAddr initIRQController setIRQTrigger MachineData getCurrentTime usToTicks ticksToUs maxUsToTicks maxTicksToUs ackDeadlineIRQ
+definition maxPeriodUs :: "word64" where
+  "maxPeriodUs \<equiv> MAX_PERIOD_US"
+
+#INCLUDE_HASKELL SEL4/Machine/Hardware/ARM.lhs Platform=Platform.ARM CONTEXT ARM_H NOT getMemoryRegions getDeviceRegions getKernelDevices loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt setDeadline configureTimer resetTimer debugPrint getRestartPC setNextPC clearMemory clearMemoryVM initMemory freeMemory writeTTBR0 setGlobalPD  setTTBCR setHardwareASID invalidateLocalTLB invalidateLocalTLB_ASID invalidateLocalTLB_VAASID cleanByVA cleanByVA_PoU invalidateByVA invalidateByVA_I invalidate_I_PoU cleanInvalByVA branchFlush clean_D_PoU cleanInvalidate_D_PoC cleanInvalidate_D_PoU cleanInvalidateL2Range invalidateL2Range cleanL2Range isb dsb dmb getIFSR getDFSR getFAR HardwareASID wordFromPDE wordFromPTE VMFaultType VMPageSize HypFaultType pageBits pageBitsForSize toPAddr cacheLineBits cacheLine lineStart cacheRangeOp cleanCacheRange_PoC cleanInvalidateCacheRange_RAM cleanCacheRange_RAM cleanCacheRange_PoU invalidateCacheRange_RAM invalidateCacheRange_I branchFlushRange cleanCaches_PoU cleanInvalidateL1Caches addrFromPPtr ptrFromPAddr initIRQController setIRQTrigger MachineData getCurrentTime usToTicks ticksToUs maxUsToTicks maxTicksToUs maxPeriodUs ackDeadlineIRQ
 
 end
 

--- a/spec/design/skel/RISCV64/Hardware_H.thy
+++ b/spec/design/skel/RISCV64/Hardware_H.thy
@@ -19,7 +19,7 @@ definition ticksToUs :: "word64 \<Rightarrow> word64" where
   "ticksToUs \<equiv> ticks_to_us"
 
 definition maxUsToTicks :: "word64" where
-  "maxUsToTicks \<equiv> 60 * 60 * 1000" (* FIXME RT: sync with aspec and C *)
+  "maxUsToTicks \<equiv> max_us_to_ticks"
 
 definition maxTicksToUs :: "word64" where
   "maxTicksToUs \<equiv> max_ticks_to_us"
@@ -30,7 +30,10 @@ definition kernelWCETTicks :: "word64" where
 definition kernelWCETUs :: "word64" where
   "kernelWCETUs \<equiv> kernelWCET_us"
 
-#INCLUDE_HASKELL SEL4/Machine/Hardware/RISCV64.hs Platform=Platform.RISCV64 CONTEXT RISCV64_H NOT plic_complete_claim getMemoryRegions getDeviceRegions getKernelDevices loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt setDeadline configureTimer resetTimer debugPrint getRestartPC setNextPC clearMemory clearMemoryVM initMemory freeMemory setHardwareASID wordFromPDE wordFromPTE VMFaultType HypFaultType VMPageSize pageBits pageBitsForSize toPAddr addrFromPPtr ptrFromPAddr sfence physBase ptTranslationBits vmFaultTypeFSR read_sbadaddr setVSpaceRoot hwASIDFlush setIRQTrigger getCurrentTime usToTicks ticksToUs maxUsToTicks maxTicksToUs ackDeadlineIRQ
+definition maxPeriodUs :: "word64" where
+  "maxPeriodUs \<equiv> MAX_PERIOD_US"
+
+#INCLUDE_HASKELL SEL4/Machine/Hardware/RISCV64.hs Platform=Platform.RISCV64 CONTEXT RISCV64_H NOT plic_complete_claim getMemoryRegions getDeviceRegions getKernelDevices loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt setDeadline configureTimer resetTimer debugPrint getRestartPC setNextPC clearMemory clearMemoryVM initMemory freeMemory setHardwareASID wordFromPDE wordFromPTE VMFaultType HypFaultType VMPageSize pageBits pageBitsForSize toPAddr addrFromPPtr ptrFromPAddr sfence physBase ptTranslationBits vmFaultTypeFSR read_sbadaddr setVSpaceRoot hwASIDFlush setIRQTrigger getCurrentTime usToTicks ticksToUs maxUsToTicks maxTicksToUs maxPeriodUs ackDeadlineIRQ
 
 end
 

--- a/spec/design/skel/SchedContext_H.thy
+++ b/spec/design/skel/SchedContext_H.thy
@@ -25,6 +25,7 @@ requalify_consts
   ticksToUs
   maxTicksToUs
   getCurrentTime
+  maxPeriodUs
 end
 
 #INCLUDE_HASKELL SEL4/Object/SchedContext.lhs bodies_only

--- a/spec/haskell/src/SEL4/Machine/Hardware.lhs
+++ b/spec/haskell/src/SEL4/Machine/Hardware.lhs
@@ -243,3 +243,6 @@ The constant "nullPointer" is a physical pointer guaranteed to be invalid.
 > usToTicks :: Word64 -> Word64
 > usToTicks = Arch.usToTicks
 
+> maxPeriodUs :: Word64
+> maxPeriodUs = Arch.maxPeriodUs
+

--- a/spec/haskell/src/SEL4/Machine/Hardware/ARM.lhs
+++ b/spec/haskell/src/SEL4/Machine/Hardware/ARM.lhs
@@ -901,3 +901,6 @@ FIXME ARMHYP consider moving to platform code?
 > maxTicksToUs :: Word64
 > maxTicksToUs = undefined
 
+> maxPeriodUs :: Word64
+> maxPeriodUs = undefined
+

--- a/spec/haskell/src/SEL4/Machine/Hardware/RISCV64.hs
+++ b/spec/haskell/src/SEL4/Machine/Hardware/RISCV64.hs
@@ -336,6 +336,9 @@ maxUsToTicks = undefined
 maxTicksToUs :: Word64
 maxTicksToUs = undefined
 
+maxPeriodUs :: Word64
+maxPeriodUs = undefined
+
 debugPrint :: String -> MachineMonad ()
 debugPrint str = liftIO $ putStrLn str
 

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -745,10 +745,10 @@ The domain cap is invoked to set the domain of a given TCB object to a given val
 >     targetCap <- return $ head excaps
 >     when (not (isSchedContextCap targetCap)) $ throw (InvalidCapability 1)
 >     scPtr <- return $ capSchedContextPtr targetCap
->     when (budgetUs > maxUsToTicks || budgetUs < minBudgetUs) $
->         throw (RangeError (fromIntegral minBudgetUs) (fromIntegral maxUsToTicks))
->     when (periodUs > maxUsToTicks || periodUs < minBudgetUs) $
->         throw (RangeError (fromIntegral minBudgetUs) (fromIntegral maxUsToTicks))
+>     when (budgetUs > maxPeriodUs || budgetUs < minBudgetUs) $
+>         throw (RangeError (fromIntegral minBudgetUs) (fromIntegral maxPeriodUs))
+>     when (periodUs > maxPeriodUs || periodUs < minBudgetUs) $
+>         throw (RangeError (fromIntegral minBudgetUs) (fromIntegral maxPeriodUs))
 >     when (periodUs < budgetUs) $
 >         throw (RangeError (fromIntegral minBudgetUs) (fromIntegral periodUs))
 >     when (fromIntegral extraRefills + minRefills > refillAbsoluteMax(targetCap)) $

--- a/spec/machine/MachineExports.thy
+++ b/spec/machine/MachineExports.thy
@@ -20,6 +20,8 @@ requalify_types
   vmfault_type
   hyp_fault_type
   irq
+  ticks
+  time
 
 requalify_consts
   getActiveIRQ
@@ -55,6 +57,8 @@ requalify_consts
   kernelWCET_ticks
   maxTimer_us
   max_ticks_to_us
+  max_us_to_ticks
+  MAX_PERIOD_US
   us_to_ticks
   ticks_to_us
   setDeadline
@@ -64,6 +68,7 @@ requalify_facts
   us_to_ticks_zero
   us_to_ticks_nonzero
   kernelWCET_ticks_no_overflow
+  us_to_ticks_mult
   kernelWCET_ticks_def
   replicate_no_overflow
 

--- a/spec/machine/RISCV64/MachineOps.thy
+++ b/spec/machine/RISCV64/MachineOps.thy
@@ -82,22 +82,32 @@ definition configureTimer :: "irq machine_monad"
 consts' maxTimer_us :: "64 word"
 consts' timerPrecision :: "64 word"
 consts' max_ticks_to_us :: "64 word"
-(*
-consts' us_to_ticks :: "64 word \<Rightarrow> 64 word"
-*)
+consts' max_us_to_ticks :: "64 word"
+
+ text \<open>
+   This matches @{text "60 * 60 * MS_IN_S * US_IN_MS"} because it should be in micro-seconds.
+ \<close>
+ definition
+   MAX_PERIOD_US :: "64 word"
+ where
+   "MAX_PERIOD_US \<equiv> 60 * 60 * 1000 * 1000"
+
 end
 
 qualify RISCV64 (in Arch)
 
+type_synonym ticks = "64 word"
+type_synonym time  = "64 word"
+
 axiomatization
-  kernelWCET_us :: "64 word"
+  kernelWCET_us :: ticks
 where
   kernelWCET_us_pos: "0 < kernelWCET_us"
 and
   kernelWCET_us_pos2: "0 < 2 * kernelWCET_us"
 
 axiomatization
-  us_to_ticks :: "64 word \<Rightarrow> 64 word"
+  us_to_ticks :: "ticks \<Rightarrow> ticks"
 where
   us_to_ticks_mono[intro!]: "mono us_to_ticks"
 and
@@ -105,10 +115,13 @@ and
 and
   us_to_ticks_nonzero: "y \<noteq> 0 \<Longrightarrow> us_to_ticks y \<noteq> 0"
 and
-  kernelWCET_ticks_no_overflow: "4 * unat (us_to_ticks (kernelWCET_us)) \<le> unat (max_word :: 64 word)"
+  kernelWCET_ticks_no_overflow: "4 * unat (us_to_ticks (kernelWCET_us)) \<le> unat (max_word :: ticks)"
+and
+  us_to_ticks_mult: "unat n * unat (us_to_ticks a) \<le> unat (max_word :: ticks)
+                     \<Longrightarrow> n * us_to_ticks a = us_to_ticks (n * a)"
 
 axiomatization
-  ticks_to_us :: "64 word \<Rightarrow> 64 word"
+  ticks_to_us :: "ticks \<Rightarrow> ticks"
 
 end_qualify
 
@@ -118,7 +131,7 @@ definition
   "kernelWCET_ticks = us_to_ticks (kernelWCET_us)"
 
 lemma replicate_no_overflow:
-  "n * unat (a :: 64 word) \<le> unat (upper_bound :: 64 word)
+  "n * unat (a :: ticks) \<le> unat (upper_bound :: ticks)
    \<Longrightarrow> unat (word_of_int n * a) = n * unat a"
   by (metis (mono_tags, hide_lams) le_unat_uoi of_nat_mult word_of_nat word_unat.Rep_inverse)
 
@@ -126,7 +139,7 @@ lemma kernelWCET_ticks_pos2: "0 < 2 * kernelWCET_ticks"
   apply (simp add: kernelWCET_ticks_def word_less_nat_alt)
   apply (subgoal_tac "unat (2 * us_to_ticks kernelWCET_us) = 2 * unat (us_to_ticks kernelWCET_us)")
    using RISCV64.kernelWCET_us_pos2 RISCV64.us_to_ticks_nonzero unat_gt_0 apply force
-  apply (subgoal_tac "2 * unat (us_to_ticks kernelWCET_us) \<le> unat (max_word :: 64 word)")
+  apply (subgoal_tac "2 * unat (us_to_ticks kernelWCET_us) \<le> unat (max_word :: ticks)")
    using replicate_no_overflow apply fastforce
   using kernelWCET_ticks_no_overflow by force
 


### PR DESCRIPTION
There is a constant `maxPeriodUs` in the C. For verified configurations, the `maxPeriodUs` in the C is defined in the C to be equal to one hour. See 

https://bitbucket.ts.data61.csiro.au/projects/SEL4/repos/sel4/pull-requests/1882/overview

for the changes to the C and where this constant originates. This is the maximum number of microseconds that the user may set as the period of a scheduling context. The equivalent in the abstract spec is `MAX_PERIOD_US`, and in the Haskell, this is `maxPeriodUs`, which is defined to be equal to `MAX_PERIOD_US`. In the abstract spec, we define `MAX_PERIOD = us_to_ticks MAX_PERIOD_US`, and similarly for the Haskell. 

The definition of `decode_sched_control_invocation` is changed so that all values given by the user are considered to be in microseconds. `decodeSchedControl_Configure` in the Haskell is modified to correctly use `maxPeriodUs` (rather than the `maxUsToTicks` which is used only for configurations for which `KernelStaticMaxPeriodUs` in the C is not defined).

A new rule in the axiomatization of `us_to_ticks` is introduced, though the correctness of this approach is debatable.

This is targeted to my decodeSchedContext PR, which I will rebase soonish