### PR TITLE
Reader Monad update

### DIFF
--- a/lib/HaskellLib_H.thy
+++ b/lib/HaskellLib_H.thy
@@ -34,6 +34,12 @@ definition
  "runState f s \<equiv> THE x. x \<in> fst (f s)"
 
 definition
+  "runReaderT \<equiv> id"
+
+abbreviation (input)
+  "getsJust \<equiv> gets_the"
+
+definition
   sassert :: "bool \<Rightarrow> 'a \<Rightarrow> 'a" where
  "sassert P \<equiv> if P then id else (\<lambda>x. undefined)"
 

--- a/lib/HaskellLib_H.thy
+++ b/lib/HaskellLib_H.thy
@@ -15,13 +15,14 @@ imports
   NatBitwise
   "More_Numeral_Type"
   "Monad_WP/WhileLoopRules"
+  "Monad_WP/OptionMonadWP"
 begin
 
 abbreviation (input) "flip \<equiv> swp"
 
 abbreviation(input) bind_drop :: "('a, 'c) nondet_monad \<Rightarrow> ('a, 'b) nondet_monad
                       \<Rightarrow> ('a, 'b) nondet_monad" (infixl ">>'_" 60)
-  where "bind_drop \<equiv> (\<lambda>x y. bind x (K_bind y))"
+  where "bind_drop \<equiv> (\<lambda>x y. NonDetMonad.bind x (K_bind y))"
 
 lemma bind_drop_test:
   "foldr bind_drop x (return ()) = sequence_x x"
@@ -602,5 +603,14 @@ lemma whileM_inv:
   shows "whileM P f \<lbrace>Q\<rbrace>"
   unfolding whileM_def
   by (wpsimp wp: whileLoop_wp[where I="\<lambda>_. Q"])
+
+definition ohaskell_fail :: "unit list \<Rightarrow> ('s, 'a) lookup" where
+  "ohaskell_fail = K ofail"
+
+definition ohaskell_assert :: "bool \<Rightarrow> unit list \<Rightarrow> ('s, unit) lookup" where
+  "ohaskell_assert P ls \<equiv> if P then oreturn () else ofail"
+
+lemmas omonad_defs = ofail_def oreturn_def oassert_def oassert_opt_def asks_def
+                     ohaskell_assert_def ohaskell_fail_def ounless_def owhen_def
 
 end

--- a/lib/Monad_WP/OptionMonad.thy
+++ b/lib/Monad_WP/OptionMonad.thy
@@ -91,9 +91,22 @@ definition
 definition
   "oassert P \<equiv> if P then oreturn () else ofail"
 
-definition oapply :: "'a \<Rightarrow> ('a \<Rightarrow> 'b option) \<Rightarrow> 'b option"
-  where
+definition
+  "oassert_opt r \<equiv> case r of None \<Rightarrow> ofail | Some x \<Rightarrow> oreturn x"
+
+definition oapply :: "'a \<Rightarrow> ('a \<Rightarrow> 'b option) \<Rightarrow> 'b option" where
   "oapply x \<equiv> \<lambda>s. s x"
+
+definition oliftM :: "('a \<Rightarrow> 'b) \<Rightarrow> ('s,'a) lookup \<Rightarrow> ('s,'b) lookup" where
+  "oliftM f m \<equiv> do { x \<leftarrow> m; oreturn (f x) }"
+
+(* Reader monad interface: *)
+abbreviation (input)
+  "ask \<equiv> Some"
+
+definition
+  "asks f = do { v <- ask; oreturn (f v) }"
+
 
 text \<open>
   If the result can be an exception.

--- a/lib/Monad_WP/OptionMonad.thy
+++ b/lib/Monad_WP/OptionMonad.thy
@@ -113,6 +113,8 @@ abbreviation (input)
 definition
   "asks f = do { v <- ask; oreturn (f v) }"
 
+abbreviation
+  "ogets \<equiv> asks"
 
 text \<open>
   If the result can be an exception.

--- a/lib/Monad_WP/OptionMonad.thy
+++ b/lib/Monad_WP/OptionMonad.thy
@@ -100,6 +100,12 @@ definition oapply :: "'a \<Rightarrow> ('a \<Rightarrow> 'b option) \<Rightarrow
 definition oliftM :: "('a \<Rightarrow> 'b) \<Rightarrow> ('s,'a) lookup \<Rightarrow> ('s,'b) lookup" where
   "oliftM f m \<equiv> do { x \<leftarrow> m; oreturn (f x) }"
 
+definition ounless :: "bool \<Rightarrow> ('s, unit) lookup \<Rightarrow> ('s, unit) lookup" where
+  "ounless P f \<equiv> if P then oreturn () else f"
+
+definition owhen :: "bool \<Rightarrow> ('s, unit) lookup \<Rightarrow> ('s, unit) lookup" where
+  "owhen P f \<equiv> if P then f else oreturn ()"
+
 (* Reader monad interface: *)
 abbreviation (input)
   "ask \<equiv> Some"

--- a/lib/Monad_WP/OptionMonadND.thy
+++ b/lib/Monad_WP/OptionMonadND.thy
@@ -23,10 +23,9 @@ translations
   "DO x <- a; e OD"        == "a |>> (\<lambda>x. e)"
 
 
-definition
- ogets :: "('a \<Rightarrow> 'b) \<Rightarrow> ('a \<Rightarrow> 'b option)"
-where
- "ogets f \<equiv> (\<lambda>s. Some (f s))"
+lemma ogets_def:
+  "ogets f = (\<lambda>s. Some (f s))"
+  by (clarsimp simp: asks_def obind_def)
 
 definition
   ocatch :: "('s,('e + 'a)) lookup \<Rightarrow> ('e \<Rightarrow> ('s,'a) lookup) \<Rightarrow> ('s, 'a) lookup"

--- a/lib/Monad_WP/OptionMonadWP.thy
+++ b/lib/Monad_WP/OptionMonadWP.thy
@@ -22,8 +22,15 @@ declare K_def [simp]
    TODO: design a sensible syntax for them. *)
 
 (* Partial correctness. *)
-definition ovalid :: "('s \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 'a option) \<Rightarrow> ('a \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> bool" where
-  "ovalid P f Q \<equiv> \<forall>s r. P s \<and> f s = Some r \<longrightarrow> Q r s"
+definition ovalid :: "('s \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 'a option) \<Rightarrow> ('a \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> bool"
+  ("o\<lbrace>_\<rbrace>/ _ /\<lbrace>_\<rbrace>") where
+  "o\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<equiv> \<forall>s r. P s \<and> f s = Some r \<longrightarrow> Q r s"
+
+abbreviation (input)
+  oinvariant :: "('s,'a) lookup \<Rightarrow> ('s \<Rightarrow> bool) \<Rightarrow> bool" ("_ o\<lbrace>_\<rbrace>" [59,0] 60)
+where
+  "oinvariant f P \<equiv> o\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. P\<rbrace>"
+
 (* Total correctness. *)
 definition ovalidNF :: "('s \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 'a option) \<Rightarrow> ('a \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> bool" where
   "ovalidNF P f Q \<equiv> \<forall>s. P s \<longrightarrow> (f s \<noteq> None \<and> (\<forall>r. f s = Some r \<longrightarrow> Q r s))"

--- a/proof/invariant-abstract/RISCV64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchSchedule_AI.thy
@@ -10,6 +10,8 @@ begin
 
 context Arch begin global_naming RISCV64
 
+declare opt_mapE[rule del]
+
 named_theorems Schedule_AI_asms
 
 lemma dmo_mapM_storeWord_0_invs[wp,Schedule_AI_asms]:

--- a/proof/refine/ARM/ArchAcc_R.thy
+++ b/proof/refine/ARM/ArchAcc_R.thy
@@ -79,6 +79,54 @@ end
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
+method readObject_arch_obj_at'_method
+  =  clarsimp simp: readObject_def obind_def omonad_defs split_def loadObject_default_def obj_at'_def
+                    objBits_simps archObjSize_def projectKOs bit_simps' typ_at_to_obj_at_arches
+             split: option.splits if_split_asm
+
+lemma readObject_misc_arch_ko_at'[simp, dest!]:
+  shows
+  readObject_ko_at'_pte: "readObject p s = Some (pte :: pte) \<Longrightarrow> ko_at' pte p s" and
+  readObject_ko_at'_pde: "readObject p s = Some (pde :: pde) \<Longrightarrow> ko_at' pde p s" and
+  readObject_ko_at'_asidpool: "readObject p s = Some (asidp :: asidpool) \<Longrightarrow> ko_at' asidp p s"
+   by readObject_arch_obj_at'_method+
+
+
+lemma readObject_misc_arch_obj_at'[simp]:
+  shows
+  readObject_pte_at'[simplified]: "bound (readObject p s ::pte option) \<Longrightarrow> pte_at' p s" and
+  readObject_pde_at'[simplified]: "bound (readObject p s ::pde option) \<Longrightarrow> pde_at' p s" and
+  readObject_asid_pool_at'[simplified]: "bound (readObject p s ::asidpool option) \<Longrightarrow> asid_pool_at' p s"
+   by readObject_arch_obj_at'_method+
+
+method no_ofail_readObject_method =
+  clarsimp simp: obj_at'_def readObject_def obind_def omonad_defs split_def projectKO_eq no_ofail_def,
+  rule ps_clear_lookupAround2, assumption+, simp,
+  blast intro: is_aligned_no_overflow,
+  clarsimp simp: bit_simps' project_inject obj_at_simps lookupAround2_known1 split: option.splits
+
+lemma no_ofail_arch_obj_at'_readObject_pte[simp]:
+  "no_ofail (obj_at' (P::pte \<Rightarrow> bool) p) (readObject p::pte kernel_r)"
+  by no_ofail_readObject_method
+
+lemma no_ofail_arch_obj_at'_readObject_pde[simp]:
+  "no_ofail (obj_at' (P::pde \<Rightarrow> bool) p) (readObject p::pde kernel_r)"
+  by no_ofail_readObject_method
+
+lemma no_ofail_arch_obj_at'_readObject_asidpool[simp]:
+  "no_ofail (obj_at' (P::asidpool \<Rightarrow> bool) p) (readObject p::asidpool kernel_r)"
+  by no_ofail_readObject_method
+
+lemma no_ofail_arch_misc_readObject:
+  shows
+  no_ofail_pte_at'_readObject[simp]: "no_ofail (pte_at' p) (readObject p::pte kernel_r)" and
+  no_ofail_pde_at'_readObject[simp]: "no_ofail (pde_at' p) (readObject p::pde kernel_r)" and
+  no_ofail_asidpool_at'_readObject[simp]: "no_ofail (asid_pool_at' p) (readObject p::asidpool kernel_r)"
+  by (clarsimp simp: typ_at_to_obj_at_arches no_ofail_def
+              dest!: no_ofailD[OF no_ofail_arch_obj_at'_readObject_pte]
+                     no_ofailD[OF no_ofail_arch_obj_at'_readObject_pde]
+                     no_ofailD[OF no_ofail_arch_obj_at'_readObject_asidpool])+
+
 (* aliases for compatibility with master *)
 
 lemmas getPTE_wp = setObject_pte.get_wp
@@ -285,32 +333,17 @@ lemma get_asid_pool_corres [corres]:
           (get_asid_pool p) (getObject p')"
   apply (simp add: getObject_def get_asid_pool_def get_object_def split_def)
   apply (rule corres_no_failI)
-   apply (rule no_fail_pre, wp)
-   apply (clarsimp simp: typ_at'_def ko_wp_at'_def)
-   apply (case_tac ko; simp)
-   apply (rename_tac arch_kernel_object)
-   apply (case_tac arch_kernel_object, simp_all)[1]
-   apply (clarsimp simp: lookupAround2_known1
-                         projectKOs)
-   apply (clarsimp simp: obj_at'_def projectKOs objBits_simps
-                         archObjSize_def)
-   apply (erule (1) ps_clear_lookupAround2)
-     apply simp
-    apply (erule is_aligned_no_overflow)
-   apply simp
-   apply (clarsimp simp add: objBits_simps archObjSize_def
-                      split: option.split)
+   apply wp
+   apply (fastforce simp: typ_at_to_obj_at_arches
+                    dest: no_ofailD[OF no_ofail_asidpool_at'_readObject])
   apply (clarsimp simp: in_monad loadObject_default_def projectKOs)
   apply (simp add: bind_assoc exec_gets)
   apply (drule asid_pool_at_ko)
   apply (clarsimp simp: obj_at_def)
   apply (simp add: return_def)
-  apply (simp add: in_magnitude_check objBits_simps
-                   archObjSize_def pageBits_def)
-  apply clarsimp
   apply (clarsimp simp: state_relation_def pspace_relation_def)
   apply (drule bspec, blast)
-  apply (clarsimp simp: other_obj_relation_def asid_pool_relation_def)
+  apply (clarsimp simp: other_obj_relation_def asid_pool_relation_def obj_at'_def projectKOs)
   done
 
 lemma aligned_distinct_relation_asid_pool_atI'[elim]:
@@ -384,25 +417,16 @@ lemma get_pde_corres [corres]:
      (get_pde p) (getObject p')"
   apply (simp add: getObject_def get_pde_def get_pd_def get_object_def split_def bind_assoc)
   apply (rule corres_no_failI)
-   apply (rule no_fail_pre, wp)
-   apply (clarsimp simp: ko_wp_at'_def typ_at'_def lookupAround2_known1)
-   apply (case_tac ko; simp)
-   apply (rename_tac arch_kernel_object)
-   apply (case_tac arch_kernel_object; simp add: projectKOs)
-   apply (clarsimp simp: objBits_def cong: option.case_cong)
-   apply (erule (1) ps_clear_lookupAround2)
-     apply simp
-    apply (erule is_aligned_no_overflow)
-    apply (simp add: objBits_simps archObjSize_def word_bits_def)
+  apply wp
+   apply (fastforce simp: typ_at_to_obj_at_arches dest: no_ofailD[OF no_ofail_pde_at'_readObject])
    apply simp
   apply (clarsimp simp: in_monad loadObject_default_def projectKOs)
   apply (simp add: bind_assoc exec_gets)
   apply (clarsimp simp: pde_at_def obj_at_def)
   apply (clarsimp simp add: a_type_def return_def
                   split: if_split_asm Structures_A.kernel_object.splits arch_kernel_obj.splits)
-  apply (clarsimp simp: typ_at'_def ko_wp_at'_def)
+  apply (clarsimp simp: obj_at'_def projectKOs)
   apply (simp add: in_magnitude_check objBits_simps archObjSize_def pageBits_def pdeBits_def)
-  apply (clarsimp simp: bind_def)
   apply (clarsimp simp: state_relation_def pspace_relation_def)
   apply (drule bspec, blast)
   apply (clarsimp simp: other_obj_relation_def pde_relation_def)
@@ -473,19 +497,10 @@ lemma get_master_pde_corres [@lift_corres_args, corres]:
     apply (simp add: getObject_def get_pde_def get_pd_def  get_object_def
       split_def bind_assoc pde_relation_aligned_def get_master_pde_def)
     apply (rule corres_no_failI)
-     apply (rule no_fail_pre, wp)
-     apply (clarsimp simp: ko_wp_at'_def typ_at'_def lookupAround2_known1)
-     apply (case_tac ko, simp_all)[1]
-     apply (rename_tac arch_kernel_object)
-     apply (case_tac arch_kernel_object, simp_all add: projectKOs)[1]
-     apply (clarsimp simp: objBits_def cong: option.case_cong)
-     apply (erule (1) ps_clear_lookupAround2)
-       apply simp
-      apply (erule is_aligned_no_overflow)
-     apply (simp add: objBits_simps archObjSize_def word_bits_def)
-    apply simp
+     apply wp
+   apply (fastforce simp: typ_at_to_obj_at_arches dest: no_ofailD[OF no_ofail_pde_at'_readObject])
     apply (clarsimp simp: in_monad loadObject_default_def
-      projectKOs and_not_mask_twice)
+                          projectKOs and_not_mask_twice)
     apply (simp add: bind_assoc exec_gets)
     apply (clarsimp simp: pde_at_def obj_at_def)
     apply (clarsimp split:ARM_A.pde.splits)
@@ -494,8 +509,8 @@ lemma get_master_pde_corres [@lift_corres_args, corres]:
        apply (clarsimp simp add: a_type_def return_def get_pd_def
                   bind_def get_pde_def get_object_def gets_def get_def
                   split: if_split_asm Structures_A.kernel_object.splits arch_kernel_obj.splits)
-       apply (clarsimp simp:typ_at'_def ko_wp_at'_def)
-       apply (clarsimp simp: in_magnitude_check objBits_simps archObjSize_def pageBits_def pdeBits_def)
+       apply (clarsimp simp: obj_at'_def projectKOs)
+       apply (clarsimp simp: objBits_simps archObjSize_def pageBits_def pdeBits_def)
        apply (clarsimp simp:state_relation_def)
        apply (frule_tac x = "(ucast (p && mask pd_bits >> 2))"
                      in pde_relation_alignedD)
@@ -521,8 +536,8 @@ lemma get_master_pde_corres [@lift_corres_args, corres]:
       apply (clarsimp simp add: a_type_def return_def get_pd_def
         bind_def get_pde_def get_object_def gets_def get_def
         split: if_split_asm Structures_A.kernel_object.splits arch_kernel_obj.splits)
-      apply (clarsimp simp:typ_at'_def ko_wp_at'_def)
-      apply (clarsimp simp: in_magnitude_check objBits_simps archObjSize_def pageBits_def pdeBits_def)
+      apply (clarsimp simp: obj_at'_def projectKOs)
+      apply (clarsimp simp: objBits_simps archObjSize_def pageBits_def pdeBits_def)
       apply (clarsimp simp:state_relation_def)
       apply (frule_tac x = "(ucast (p && mask pd_bits >> 2))" in pde_relation_alignedD)
         apply assumption
@@ -545,8 +560,8 @@ lemma get_master_pde_corres [@lift_corres_args, corres]:
      apply (clarsimp simp add: a_type_def return_def get_pd_def
        bind_def get_pde_def get_object_def gets_def get_def
        split: if_split_asm Structures_A.kernel_object.splits arch_kernel_obj.splits)
-     apply (clarsimp simp:typ_at'_def ko_wp_at'_def)
-     apply (clarsimp simp: in_magnitude_check objBits_simps archObjSize_def pageBits_def pdeBits_def)
+      apply (clarsimp simp: obj_at'_def projectKOs)
+     apply (clarsimp simp: objBits_simps archObjSize_def pageBits_def pdeBits_def)
      apply (clarsimp simp:state_relation_def)
      apply (frule_tac x = "(ucast (p && mask pd_bits >> 2))" in pde_relation_alignedD)
        apply assumption
@@ -569,8 +584,8 @@ lemma get_master_pde_corres [@lift_corres_args, corres]:
     apply (clarsimp simp add: a_type_def return_def get_pd_def
       bind_def get_pde_def get_object_def gets_def get_def
       split: if_split_asm Structures_A.kernel_object.splits arch_kernel_obj.splits)
-    apply (clarsimp simp:typ_at'_def ko_wp_at'_def)
-    apply (clarsimp simp: in_magnitude_check objBits_simps archObjSize_def pageBits_def pdeBits_def)
+    apply (clarsimp simp: obj_at'_def projectKOs)
+    apply (clarsimp simp: objBits_simps archObjSize_def pageBits_def pdeBits_def)
     apply (clarsimp simp:state_relation_def)
     apply (drule_tac s = a and s' = b and p = "p && ~~ mask 6"
       in aligned_distinct_relation_pde_atI'[rotated -1])
@@ -636,25 +651,16 @@ lemma get_pte_corres [corres]:
      (get_pte p) (getObject p')"
   apply (simp add: getObject_def get_pte_def get_pt_def get_object_def split_def bind_assoc)
   apply (rule corres_no_failI)
-   apply (rule no_fail_pre, wp)
-   apply (clarsimp simp: ko_wp_at'_def typ_at'_def lookupAround2_known1)
-   apply (case_tac ko, simp_all)[1]
-   apply (rename_tac arch_kernel_object)
-   apply (case_tac arch_kernel_object, simp_all add: projectKOs)[1]
-   apply (clarsimp simp: objBits_def cong: option.case_cong)
-   apply (erule (1) ps_clear_lookupAround2)
-     apply simp
-    apply (erule is_aligned_no_overflow)
-    apply (simp add: objBits_simps archObjSize_def word_bits_def)
+  apply wp
+   apply (fastforce simp: typ_at_to_obj_at_arches dest: no_ofailD[OF no_ofail_pte_at'_readObject])
    apply simp
   apply (clarsimp simp: in_monad loadObject_default_def projectKOs)
   apply (simp add: bind_assoc exec_gets)
   apply (clarsimp simp: obj_at_def pte_at_def)
   apply (clarsimp simp add: a_type_def return_def
                   split: if_split_asm Structures_A.kernel_object.splits arch_kernel_obj.splits)
-  apply (clarsimp simp: typ_at'_def ko_wp_at'_def)
-  apply (simp add: in_magnitude_check objBits_simps archObjSize_def pageBits_def pteBits_def)
-  apply (clarsimp simp: bind_def)
+  apply (clarsimp simp: obj_at'_def projectKOs)
+  apply (simp add: objBits_simps archObjSize_def pageBits_def pteBits_def)
   apply (clarsimp simp: state_relation_def pspace_relation_def)
   apply (drule bspec, blast)
   apply (clarsimp simp: other_obj_relation_def pte_relation_def)
@@ -724,16 +730,8 @@ lemma get_master_pte_corres [@lift_corres_args, corres]:
     apply (simp add: getObject_def get_pte_def get_pt_def  get_object_def
       split_def bind_assoc pte_relation_aligned_def get_master_pte_def)
     apply (rule corres_no_failI)
-     apply (rule no_fail_pre, wp)
-     apply (clarsimp simp: ko_wp_at'_def typ_at'_def lookupAround2_known1)
-     apply (case_tac ko, simp_all)[1]
-     apply (rename_tac arch_kernel_object)
-     apply (case_tac arch_kernel_object, simp_all add: projectKOs)[1]
-     apply (clarsimp simp: objBits_def cong: option.case_cong)
-     apply (erule (1) ps_clear_lookupAround2)
-       apply simp
-      apply (erule is_aligned_no_overflow)
-     apply (simp add: objBits_simps archObjSize_def word_bits_def)
+   apply wp
+   apply (fastforce simp: typ_at_to_obj_at_arches dest: no_ofailD[OF no_ofail_pte_at'_readObject])
     apply simp
     apply (clarsimp simp: in_monad loadObject_default_def
       projectKOs and_not_mask_twice)
@@ -745,8 +743,8 @@ lemma get_master_pte_corres [@lift_corres_args, corres]:
       apply (clarsimp simp add: a_type_def return_def get_pt_def
                   bind_def get_pte_def get_object_def gets_def get_def
                   split: if_split_asm Structures_A.kernel_object.splits arch_kernel_obj.splits)
-      apply (clarsimp simp:typ_at'_def ko_wp_at'_def)
-      apply (clarsimp simp: in_magnitude_check objBits_simps archObjSize_def pageBits_def pteBits_def)
+      apply (clarsimp simp: obj_at'_def projectKOs)
+      apply (clarsimp simp: objBits_simps archObjSize_def pageBits_def pteBits_def)
       apply (clarsimp simp:state_relation_def)
       apply (frule_tac x = "(ucast (p && mask pt_bits >> 2))" in pte_relation_alignedD)
         apply assumption
@@ -769,8 +767,8 @@ lemma get_master_pte_corres [@lift_corres_args, corres]:
      apply (clarsimp simp add: a_type_def return_def get_pt_def
        bind_def get_pte_def get_object_def gets_def get_def
        split: if_split_asm Structures_A.kernel_object.splits arch_kernel_obj.splits)
-     apply (clarsimp simp:typ_at'_def ko_wp_at'_def)
-     apply (clarsimp simp: in_magnitude_check objBits_simps archObjSize_def pageBits_def pteBits_def)
+      apply (clarsimp simp: obj_at'_def projectKOs)
+     apply (clarsimp simp: objBits_simps archObjSize_def pageBits_def pteBits_def)
      apply (clarsimp simp:state_relation_def)
      apply (drule_tac s = a and s' = b and p = "p && ~~ mask 6"
       in aligned_distinct_relation_pte_atI'[rotated -1])
@@ -802,8 +800,8 @@ lemma get_master_pte_corres [@lift_corres_args, corres]:
                bind_def get_pte_def get_object_def gets_def get_def
             split: if_split_asm Structures_A.kernel_object.splits
                    arch_kernel_obj.splits)
-   apply (clarsimp simp:typ_at'_def ko_wp_at'_def)
-   apply (clarsimp simp: in_magnitude_check objBits_simps
+      apply (clarsimp simp: obj_at'_def projectKOs)
+   apply (clarsimp simp: objBits_simps
                          archObjSize_def pageBits_def pteBits_def)
    apply (clarsimp simp:state_relation_def)
    apply (frule_tac x = "(ucast (p && mask pt_bits >> 2))"

--- a/proof/refine/ARM/Bits_R.thy
+++ b/proof/refine/ARM/Bits_R.thy
@@ -139,7 +139,7 @@ lemma projectKO_user_data_device:
 lemmas projectKOs =
   projectKO_ntfn projectKO_ep projectKO_cte projectKO_tcb projectKO_reply projectKO_sc
   projectKO_ASID projectKO_PTE projectKO_PDE projectKO_user_data projectKO_user_data_device
-  projectKO_eq projectKO_eq2
+  projectKO_eq
 
 lemma capAligned_epI:
   "ep_at' p s \<Longrightarrow> capAligned (EndpointCap p a b c d e)"

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -183,23 +183,20 @@ lemma can_be_is:
   apply (auto simp: Let_def)[1]
   done
 
+lemma no_ofail_cte_wp_at'_readObject[simp]:
+  "no_ofail (cte_wp_at' (P::cte \<Rightarrow> bool) p) (readObject p::cte kernel_r)"
+  by (clarsimp simp: cte_wp_at'_def getObject_def readObject_def obind_def omonad_defs split_def
+                     no_ofail_def gets_the_def gets_def get_def bind_def
+                     return_def assert_opt_def fail_def
+              split: option.splits)
+
+lemma no_fail_getObject [wp]:
+  "no_fail (cte_at' p) (getObject p::cte kernel)"
+  by (clarsimp simp: getCTE_def getObject_def no_ofail_gets_the)
+
 lemma no_fail_getCTE [wp]:
   "no_fail (cte_at' p) (getCTE p)"
-  apply (simp add: getCTE_def getObject_def split_def
-                   loadObject_cte alignCheck_def unless_def
-                   alignError_def is_aligned_mask[symmetric]
-             cong: kernel_object.case_cong)
-  apply (rule no_fail_pre, (wp | wpc)+)
-  apply (clarsimp simp: cte_wp_at'_def getObject_def
-                        loadObject_cte split_def in_monad
-                 dest!: in_singleton
-             split del: if_split)
-  apply (clarsimp simp: in_monad typeError_def objBits_simps
-                        magnitudeCheck_def
-                 split: kernel_object.split_asm if_split_asm option.split_asm
-             split del: if_split)
-       apply simp+
-  done
+  by (wpsimp simp: getCTE_def)
 
 lemma tcb_cases_related:
   "tcb_cap_cases ref = Some (getF, setF, restr) \<Longrightarrow>
@@ -2188,24 +2185,33 @@ lemma ctes_of_valid:
   apply (fastforce)
   done
 
-lemma no_fail_setCTE [wp]:
-  "no_fail (cte_at' p) (setCTE p c)"
-  apply (clarsimp simp: setCTE_def setObject_def split_def unless_def
-                        updateObject_cte alignCheck_def alignError_def
-                        typeError_def is_aligned_mask[symmetric]
-                  cong: kernel_object.case_cong)
+lemma readObject_cte_at'[simplified]:
+  "bound (readObject p s :: cte option) \<Longrightarrow> cte_at' p s"
+  unfolding cte_wp_at'_def getObject_def
+  by (clarsimp simp: omonad_defs split_def gets_the_def exec_gets return_def)
+
+lemma readObject_cte_ko_at':
+  "readObject p s = Some (cte :: cte) \<Longrightarrow> cte_wp_at' ((=) cte) p s"
+  unfolding cte_wp_at'_def getObject_def
+  by (clarsimp simp: omonad_defs split_def gets_the_def exec_gets return_def)
+
+lemma no_fail_setObject_cte [wp]:
+  "no_fail (cte_at' t) (setObject t (t'::cte))"
+  unfolding setObject_def
+  apply (clarsimp simp: updateObject_cte gets_the_def alignCheck_def is_aligned_mask[symmetric]
+             split del: if_split cong: kernel_object.case_cong)
   apply (wp|wpc)+
   apply (clarsimp simp: cte_wp_at'_def getObject_def split_def
-                        in_monad loadObject_cte
-                 dest!: in_singleton
-             split del: if_split)
-  apply (clarsimp simp: typeError_def alignCheck_def alignError_def
-                        in_monad is_aligned_mask[symmetric] objBits_simps
-                        magnitudeCheck_def
-                 split: kernel_object.split_asm if_split_asm option.splits
-             split del: if_split)
-    apply simp_all
-  done
+                        in_monad loadObject_cte readObject_def omonad_defs
+                 dest!: in_singleton split: option.splits split del: if_split)
+  by (fastforce simp: read_typeError_def objBits_simps
+                      read_magnitudeCheck_def ohaskell_assert_def
+               split: kernel_object.split_asm if_split_asm
+           split del: if_split)
+
+lemma no_fail_setCTE [wp]:
+  "no_fail (cte_at' p) (setCTE p c)"
+  unfolding setCTE_def by wp
 
 lemma no_fail_updateCap [wp]:
   "no_fail (cte_at' p) (updateCap p cap')"

--- a/proof/refine/ARM/CSpace_I.thy
+++ b/proof/refine/ARM/CSpace_I.thy
@@ -819,14 +819,9 @@ lemma capBadge_maskCapRights[simp]:
 
 lemma getObject_cte_det:
   "(r::cte,s') \<in> fst (getObject p s) \<Longrightarrow> fst (getObject p s) = {(r,s)} \<and> s' = s"
-  apply (clarsimp simp add: getObject_def bind_def get_def gets_def
-                            return_def loadObject_cte split_def)
-  apply (clarsimp split: kernel_object.split_asm if_split_asm option.split_asm
-                   simp: in_monad typeError_def alignError_def magnitudeCheck_def)
-       apply (simp_all add: bind_def return_def assert_opt_def split_def
-                            alignCheck_def is_aligned_mask[symmetric]
-                            unless_def when_def magnitudeCheck_def)
-  done
+  by (clarsimp simp: getObject_def in_monad split_def obind_def gets_def get_def
+                     readObject_def omonad_defs bind_def return_def gets_the_def assert_opt_def
+              split: option.splits)
 
 lemma cte_wp_at_obj_cases':
   "cte_wp_at' P p s =

--- a/proof/refine/ARM/EmptyFail.thy
+++ b/proof/refine/ARM/EmptyFail.thy
@@ -12,38 +12,26 @@ begin
    Unless there is a good reason, they should all be [intro!, wp, simp] *)
 
 lemma empty_fail_projectKO [simp, intro!]:
-  "empty_fail (projectKO v)"
-  unfolding empty_fail_def projectKO_def
-  by (simp add: return_def fail_def split: option.splits)
+  "empty_fail (gets_the $ projectKO v)" by wpsimp
 
 lemma empty_fail_alignCheck [intro!, wp, simp]:
   "empty_fail (alignCheck a b)"
-  unfolding alignCheck_def
-  by (simp add: alignError_def)
+  unfolding alignCheck_def by wpsimp
 
 lemma empty_fail_magnitudeCheck [intro!, wp, simp]:
   "empty_fail (magnitudeCheck a b c)"
-  unfolding magnitudeCheck_def
-  by (simp split: option.splits)
+  unfolding magnitudeCheck_def by wpsimp
 
 lemma empty_fail_loadObject_default [intro!, wp, simp]:
-  shows "empty_fail (loadObject_default x b c d)"
-  by (auto simp: loadObject_default_def
-           split: option.splits)
+  shows "empty_fail (gets_the $ loadObject_default x b c d)" by wpsimp
 
 lemma empty_fail_threadGet [intro!, wp, simp]:
   "empty_fail (threadGet f p)"
-  by (simp add: threadGet_def getObject_def split_def)
+  by (wpsimp simp: threadGet_def)
 
 lemma empty_fail_getCTE [intro!, wp, simp]:
   "empty_fail (getCTE slot)"
-  apply (simp add: getCTE_def getObject_def split_def)
-  apply (intro empty_fail_bind, simp_all)
-  apply (simp add: loadObject_cte typeError_def alignCheck_def alignError_def
-                   magnitudeCheck_def
-            split: Structures_H.kernel_object.split)
-  apply (auto split: option.split)
-  done
+  by (wpsimp simp: getCTE_def getObject_def)
 
 lemma empty_fail_updateObject_cte [intro!, wp, simp]:
   "empty_fail (updateObject (v :: cte) ko a b c)"
@@ -65,16 +53,13 @@ lemma empty_fail_getSlotCap [intro!, wp, simp]:
 context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma empty_fail_getObject:
-  assumes x: "(\<And>b c d. empty_fail (loadObject x b c d::'a :: pspace_storable kernel))"
-  shows "empty_fail (getObject x :: 'a :: pspace_storable kernel)"
-  apply (simp add: getObject_def split_def)
-  apply (safe intro!: empty_fail_bind empty_fail_gets empty_fail_assert_opt)
-  apply (rule x)
+  "empty_fail (getObject x :: 'a :: pspace_storable kernel)"
+  apply (wpsimp simp: getObject_def split_def)
   done
 
 lemma empty_fail_getObject_tcb [intro!, wp, simp]:
   shows "empty_fail (getObject x :: tcb kernel)"
-  by (auto intro: empty_fail_getObject)
+  by (wpsimp wp: empty_fail_getObject)
 
 lemma empty_fail_updateTrackedFreeIndex [intro!, wp, simp]:
   shows "empty_fail (updateTrackedFreeIndex p idx)"
@@ -97,7 +82,7 @@ lemma empty_fail_getIRQSlot [intro!, wp, simp]:
 
 lemma empty_fail_getObject_ntfn [intro!, wp, simp]:
   "empty_fail (getObject p :: Structures_H.notification kernel)"
-  by (simp add: empty_fail_getObject)
+  by (wpsimp wp: empty_fail_getObject)
 
 lemma empty_fail_getNotification [intro!, wp, simp]:
   "empty_fail (getNotification ep)"
@@ -111,11 +96,11 @@ lemma empty_fail_lookupIPCBuffer [intro!, wp, simp]:
 
 lemma empty_fail_updateObject_default [intro!, wp, simp]:
   "empty_fail (updateObject_default v ko a b c)"
-  by (simp add: updateObject_default_def typeError_def unless_def split: kernel_object.splits )
+  by (wpsimp simp: updateObject_default_def)
 
 lemma empty_fail_threadSet [intro!, wp, simp]:
   "empty_fail (threadSet f p)"
-  by (simp add: threadSet_def getObject_def setObject_def split_def)
+  by (wpsimp simp: threadSet_def setObject_def)
 
 lemma empty_fail_getThreadState[iff]:
   "empty_fail (getThreadState t)"

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3763,11 +3763,11 @@ lemma setQueue_after_removeFromBitmap:
    apply (simp add: setQueue_after)
   apply (simp add: setQueue_def when_def)
   apply (subst oblivious_modify_swap)
-   apply (fastforce simp: threadSet_def getObject_def setObject_def
-                          loadObject_default_def bitmap_fun_defs
-                          split_def projectKO_def2 alignCheck_assert
-                          magnitudeCheck_assert updateObject_default_def
-                   intro: oblivious_bind)
+   apply (fastforce simp: threadSet_def getObject_def setObject_def readObject_def
+                          loadObject_default_def bitmap_fun_defs gets_the_def obind_def
+                          split_def projectKO_def alignCheck_assert read_magnitudeCheck_assert
+                          magnitudeCheck_assert updateObject_default_def omonad_defs
+                   intro: oblivious_bind split: option.splits)
   apply clarsimp
   done
 

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -159,7 +159,7 @@ lemma invs_weak_sch_act_wf[elim!]:
 (* FIXME RT: move to TcbAcc_R and replace gts_wf' with this *)
 lemma gts_wf''[wp]:
   "\<lbrace>valid_objs'\<rbrace> getThreadState t \<lbrace>valid_tcb_state'\<rbrace>"
-  apply (simp add: getThreadState_def threadGet_def liftM_def)
+  apply (simp add: getThreadState_def threadGet_getObject liftM_def)
   apply (wp getObject_tcb_wp)
   apply clarsimp
   apply (drule obj_at_ko_at', clarsimp)
@@ -1196,11 +1196,11 @@ lemma setQueue_after_addToBitmap:
    apply (simp add: setQueue_after)
   apply (simp add: setQueue_def when_def)
   apply (subst oblivious_modify_swap)
-  apply (simp add: threadSet_def getObject_def setObject_def
-                   loadObject_default_def bitmap_fun_defs
-                   split_def projectKO_def2 alignCheck_assert
-                   magnitudeCheck_assert updateObject_default_def)
-  apply (intro oblivious_bind, simp_all)
+  apply (simp add: threadSet_def getObject_def setObject_def readObject_def
+                   loadObject_default_def bitmap_fun_defs gets_the_def omonad_defs
+                   split_def projectKO_def alignCheck_assert read_magnitudeCheck_assert
+                   magnitudeCheck_assert updateObject_default_def obind_def)
+  apply (intro oblivious_bind, simp_all split: option.splits)
   apply (clarsimp simp: bind_assoc)
   done
 
@@ -1301,9 +1301,7 @@ lemma valid_queues_inQ_queues:
 
 lemma asUser_tcbQueued_inv[wp]:
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t'\<rbrace> asUser t m \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t'\<rbrace>"
-  apply (simp add: asUser_def tcb_in_cur_domain'_def threadGet_def)
-  apply (wp threadSet_obj_at'_strongish getObject_tcb_wp | wpc | simp | clarsimp simp: obj_at'_def)+
-  done
+  by (wpsimp wp: getObject_tcb_wp simp: obj_at'_def asUser_def tcb_in_cur_domain'_def threadGet_getObject)
 
 lemma asUser_valid_inQ_queues[wp]:
   "\<lbrace> valid_inQ_queues \<rbrace> asUser t f \<lbrace>\<lambda>rv. valid_inQ_queues \<rbrace>"
@@ -3181,16 +3179,11 @@ lemma rescheduleRequired_unlive[wp]:
   "\<lbrace>\<lambda>s. ko_wp_at' (Not \<circ> live') p s \<and> sch_act_not p s\<rbrace>
    rescheduleRequired
    \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') p\<rbrace>"
-  apply (simp add: rescheduleRequired_def)
-  apply (wp | simp | wpc)+
-   apply (simp add: tcbSchedEnqueue_def unless_def
-                    threadSet_def setQueue_def threadGet_def)
-   apply (wpsimp wp: setObject_ko_wp_at getObject_tcb_wp isSchedulable_wp
-               simp: objBits_simps' bitmap_fun_defs)+
-  apply (clarsimp simp: o_def)
-  apply (drule obj_at_ko_at')
-  apply clarsimp
-  done
+  unfolding rescheduleRequired_def
+  apply (wpsimp wp: setObject_ko_wp_at getObject_tcb_wp isSchedulable_wp
+              simp: objBits_simps' bitmap_fun_defs tcbSchedEnqueue_def unless_def
+                    threadSet_def setQueue_def threadGet_getObject)+
+  by (fastforce simp: o_def dest!: obj_at_ko_at'[where P=\<top>])
 
 lemma tcbSchedEnqueue_unlive_other:
   "\<lbrace>ko_wp_at' (Not \<circ> live') p and K (p \<noteq> t)\<rbrace>
@@ -3612,7 +3605,7 @@ lemma suspend_unqueued:
   "\<lbrace>\<top>\<rbrace> suspend t \<lbrace>\<lambda>rv. obj_at' (Not \<circ> tcbQueued) t\<rbrace>"
   apply (simp add: suspend_def unless_def tcbSchedDequeue_def)
   apply (wp hoare_vcg_if_lift hoare_vcg_conj_lift hoare_vcg_imp_lift)
-          apply (wpsimp simp: threadGet_def comp_def wp: getObject_tcb_wp)+
+          apply (wpsimp simp: threadGet_getObject comp_def wp: getObject_tcb_wp)+
       apply (rule hoare_strengthen_post, rule hoare_post_taut)
       apply (fastforce simp: obj_at'_def projectKOs)
      apply (rule hoare_post_taut)

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -1572,7 +1572,7 @@ lemma mk_ft_msg_corres:
      apply (rule corres_split_eqr [OF _ user_mapM_getRegister_corres])
        apply (rule corres_trivial, simp)
       apply (wp | simp)+
-   apply (clarsimp simp: threadGet_def liftM_def)
+   apply (clarsimp simp: threadGet_getObject)
    apply (rule corres_guard_imp)
      apply (rule corres_split[OF _ assert_get_tcb_corres])
        apply (rename_tac tcb tcb')
@@ -1764,7 +1764,7 @@ lemma lookupIPCBuffer_valid_ipc_buffer [wp]:
   "\<lbrace>valid_objs'\<rbrace> VSpace_H.lookupIPCBuffer b s \<lbrace>case_option \<top> valid_ipc_buffer_ptr'\<rbrace>"
   unfolding lookupIPCBuffer_def ARM_H.lookupIPCBuffer_def
   apply (simp add: Let_def getSlotCap_def getThreadBufferSlot_def
-                   locateSlot_conv threadGet_def comp_def)
+                   locateSlot_conv threadGet_getObject)
   apply (wp getCTE_wp getObject_tcb_wp | wpc)+
   apply (clarsimp simp del: imp_disjL)
   apply (drule obj_at_ko_at')
@@ -4776,7 +4776,7 @@ lemma receiveSignal_corres:
 lemma tg_sp':
   "\<lbrace>P\<rbrace> threadGet f p \<lbrace>\<lambda>t. obj_at' (\<lambda>t'. f t' = t) p and P\<rbrace>"
   including no_pre
-  apply (simp add: threadGet_def)
+  apply (simp add: threadGet_getObject)
   apply wp
   apply (rule hoare_strengthen_post)
    apply (rule getObject_tcb_sp)
@@ -5691,7 +5691,7 @@ lemma hf_invs' [wp]:
    apply (intro conjI impI allI; fastforce?)
      apply (clarsimp simp: valid_release_queue'_def obj_at'_def)
     apply (clarsimp simp: pred_tcb_at'_def obj_at'_def)
-   apply (clarsimp simp: ex_nonz_cap_to'_def pred_tcb_at'_def return_def
+   apply (clarsimp simp: ex_nonz_cap_to'_def pred_tcb_at'_def return_def oassert_opt_def
                          fail_def obj_at'_def projectKO_def projectKO_tcb
                   split: option.splits)
    apply (rule_tac x="t+0x30" in exI)

--- a/proof/refine/ARM/LevityCatch.thy
+++ b/proof/refine/ARM/LevityCatch.thy
@@ -13,12 +13,14 @@ begin
 (* Try again, clagged from Include *)
 no_notation bind_drop (infixl ">>" 60)
 
+lemma read_magnitudeCheck_assert:
+  "read_magnitudeCheck x y n = oassert (case y of None \<Rightarrow> True | Some z \<Rightarrow> 1 << n \<le> z - x)"
+  by (fastforce simp: read_magnitudeCheck_def split: option.split)
+
 lemma magnitudeCheck_assert:
   "magnitudeCheck x y n = assert (case y of None \<Rightarrow> True | Some z \<Rightarrow> 1 << n \<le> z - x)"
-  apply (simp add: magnitudeCheck_def assert_def when_def
-            split: option.split)
-  apply fastforce
-  done
+  by (simp add: magnitudeCheck_def read_magnitudeCheck_assert)
+
 context begin interpretation Arch . (*FIXME: arch_split*)
 lemmas makeObject_simps =
   makeObject_endpoint makeObject_notification makeObject_cte
@@ -26,16 +28,18 @@ lemmas makeObject_simps =
   makeObject_asidpool
 end
 
-lemma projectKO_inv : "\<lbrace>P\<rbrace> projectKO ko \<lbrace>\<lambda>rv. P\<rbrace>"
-  by (simp add: projectKO_def fail_def valid_def return_def
-           split: option.splits)
+lemma projectKO_inv : "\<lbrace>P\<rbrace> gets_the $ projectKO ko \<lbrace>\<lambda>rv. P\<rbrace>"
+  by wpsimp
 
 (****** From GeneralLib *******)
 
+lemma read_alignCheck_assert:
+  "read_alignCheck ptr n = oassert (is_aligned ptr n)"
+  by (simp add: is_aligned_mask read_alignCheck_def read_alignError_def ounless_def)
+
 lemma alignCheck_assert:
   "alignCheck ptr n = assert (is_aligned ptr n)"
-  by (simp add: is_aligned_mask alignCheck_def assert_def
-                alignError_def unless_def when_def)
+  by (simp add: read_alignCheck_assert alignCheck_def)
 
 lemma magnitudeCheck_inv:   "\<lbrace>P\<rbrace> magnitudeCheck x y n \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (clarsimp simp add: magnitudeCheck_def split: option.splits)

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -19,9 +19,10 @@ lemma set_ep_valid_duplicate' [wp]:
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = v,simplified])
-  apply (clarsimp simp:updateObject_default_def assert_def bind_def
-    alignCheck_def in_monad when_def alignError_def magnitudeCheck_def
-    assert_opt_def return_def fail_def split:if_splits option.splits)
+  apply (clarsimp simp: updateObject_default_def assert_def bind_def when_def
+                        alignError_def magnitudeCheck_def read_magnitudeCheck_def
+                        assert_opt_def return_def fail_def
+                 split: if_splits option.splits)
    apply (rule_tac ko = ba in valid_duplicates'_non_pd_pt_I)
        apply simp+
   apply (rule_tac ko = ba in valid_duplicates'_non_pd_pt_I)
@@ -37,9 +38,10 @@ lemma set_ntfn_valid_duplicate' [wp]:
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = v,simplified])
-  apply (clarsimp simp:updateObject_default_def assert_def bind_def
-    alignCheck_def in_monad when_def alignError_def magnitudeCheck_def
-    assert_opt_def return_def fail_def split:if_splits option.splits)
+  apply (clarsimp simp: updateObject_default_def assert_def bind_def when_def
+                        alignError_def magnitudeCheck_def read_magnitudeCheck_def
+                        assert_opt_def return_def fail_def
+                 split: if_splits option.splits)
    apply (rule_tac ko = ba in valid_duplicates'_non_pd_pt_I)
        apply simp+
   apply (rule_tac ko = ba in valid_duplicates'_non_pd_pt_I)
@@ -727,7 +729,7 @@ lemma copyGlobalMappings_ksPSpace_stable:
         updateObject_default_def
         split: option.splits)+
      apply (clarsimp simp: objBits_simps archObjSize_def obj_at'_def scBits_simps
-                           projectKO_def projectKO_opt_pde fail_def return_def)
+                           projectKO_def projectKO_opt_pde fail_def return_def oassert_opt_def)
      apply (intro conjI impI)
        apply (clarsimp simp: obj_at'_def objBits_simps scBits_simps
                              projectKO_def projectKO_opt_pde fail_def return_def pde.exhaust
@@ -795,7 +797,7 @@ lemma copyGlobalMappings_ksPSpace_same:
     updateObject_default_def
     split: option.splits)+
     apply (clarsimp simp:objBits_simps archObjSize_def)
-    apply (clarsimp simp:obj_at'_def objBits_simps
+    apply (clarsimp simp:obj_at'_def objBits_simps oassert_opt_def
       projectKO_def projectKO_opt_pde fail_def return_def
       split: Structures_H.kernel_object.splits
       arch_kernel_object.splits)
@@ -1452,8 +1454,7 @@ crunch valid_duplicates'[wp]:
 lemma get_asid_valid_duplicates'[wp]:
   "\<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace>
   getObject param_b \<lbrace>\<lambda>(pool::asidpool) s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
-  apply (simp add:getObject_def split_def| wp)+
-  apply (simp add:loadObject_default_def|wp)+
+  apply (simp add:getObject_def | wp)+
   done
 
 lemma set_asid_pool_valid_duplicates'[wp]:
@@ -1509,7 +1510,7 @@ lemma storePDE_no_duplicates':
      Structures_H.kernel_object.splits ARM_H.pde.splits
      ARM_H.pte.splits)
   apply (clarsimp split:option.splits)
-  apply (drule_tac p = x and p' = y in valid_duplicates'_D)
+  apply (drule_tac p = x in valid_duplicates'_D)
    apply simp+
   done
 
@@ -1542,7 +1543,7 @@ lemma storePTE_no_duplicates':
      Structures_H.kernel_object.splits ARM_H.pde.splits
      ARM_H.pte.splits)
   apply (clarsimp split:option.splits)
-  apply (drule_tac p = x and p' = y in valid_duplicates'_D)
+  apply (drule_tac p = x in valid_duplicates'_D)
    apply simp+
   done
 
@@ -1557,7 +1558,7 @@ lemma checkMappingPPtr_SmallPage:
    apply (wp unlessE_wp getPTE_wp |wpc|simp add:)+
   apply (clarsimp simp:ko_wp_at'_def obj_at'_def)
   apply (clarsimp simp:projectKO_def projectKO_opt_pte
-    return_def fail_def vs_entry_align_def
+    return_def fail_def vs_entry_align_def oassert_opt_def
     split:kernel_object.splits
     arch_kernel_object.splits option.splits)
   done
@@ -1569,7 +1570,7 @@ lemma checkMappingPPtr_Section:
    apply (wp unlessE_wp getPDE_wp |wpc|simp add:)+
   apply (clarsimp simp:ko_wp_at'_def obj_at'_def)
   apply (clarsimp simp:projectKO_def projectKO_opt_pde
-    return_def fail_def vs_entry_align_def
+    return_def fail_def vs_entry_align_def oassert_opt_def
     split:kernel_object.splits
     arch_kernel_object.splits option.splits)
   done
@@ -1597,7 +1598,7 @@ lemma lookupPTSlot_aligned:
   apply (wp|wpc|simp)+
   apply (wp getPDE_wp)
   apply (clarsimp simp:obj_at'_def vmsz_aligned_def)
-  apply (clarsimp simp:projectKO_def fail_def
+  apply (clarsimp simp:projectKO_def fail_def oassert_opt_def
     projectKO_opt_pde return_def lookup_pt_slot_no_fail_def
     split:option.splits Structures_H.kernel_object.splits
     arch_kernel_object.splits)

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -3303,7 +3303,6 @@ lemma getObject_valid_pde'[wp]:
      apply (simp add: objBits_simps archObjSize_def pdeBits_def)
     apply (rule getObject_inv[where P=valid_objs'])
     apply (simp add: loadObject_default_inv)
-   apply simp
   apply (clarsimp simp: projectKOs valid_obj'_def dest!: obj_at_valid_objs')
   done
 

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -285,9 +285,9 @@ lemma tcbSchedAppend_valid_queues'[wp]:
                    in hoare_post_imp)
         apply (clarsimp simp: valid_queues'_def obj_at'_def projectKOs inQ_def)
        apply (wp setQueue_valid_queues' | simp | simp add: setQueue_def)+
-     apply (wp getObject_tcb_wp | simp add: threadGet_def)+
+     apply (wp getObject_tcb_wp | simp add: threadGet_getObject)+
      apply (clarsimp simp: obj_at'_def inQ_def projectKOs valid_queues'_def)
-    apply (wp getObject_tcb_wp | simp add: threadGet_def)+
+    apply (wp getObject_tcb_wp | simp add: threadGet_getObject)+
   apply (clarsimp simp: obj_at'_def)
   done
 
@@ -2900,7 +2900,7 @@ lemma inReleaseQueue_wp:
   "\<lbrace>\<lambda>s. \<forall>ko. ko_at' ko tcb_ptr s \<longrightarrow> P (tcbInReleaseQueue ko) s\<rbrace>
    inReleaseQueue tcb_ptr
    \<lbrace>P\<rbrace>"
-  unfolding inReleaseQueue_def threadGet_def
+  unfolding inReleaseQueue_def threadGet_getObject
   apply (wpsimp wp: getObject_tcb_wp)
   apply (clarsimp simp: obj_at'_def)
   done

--- a/proof/refine/ARM/SubMonad_R.thy
+++ b/proof/refine/ARM/SubMonad_R.thy
@@ -64,12 +64,12 @@ definition
 lemma threadGet_stateAssert_gets_asUser:
   "threadGet (atcbContextGet o tcbArch) t = do stateAssert (tcb_at' t) []; gets (asUser_fetch t) od"
   apply (rule is_stateAssert_gets [OF _ _ empty_fail_threadGet no_fail_threadGet])
-    apply (clarsimp simp: threadGet_def liftM_def, wp)
-   apply (simp add: threadGet_def liftM_def, wp getObject_tcb_at')
-  apply (simp add: threadGet_def liftM_def, wp)
-   apply (rule hoare_strengthen_post, rule getObject_obj_at')
-     apply (simp add: objBits_simps')+
-   apply (clarsimp simp: obj_at'_def asUser_fetch_def projectKOs atcbContextGet_def o_def)+
+    apply (clarsimp simp: threadGet_def liftM_def, wp, simp)
+   apply (simp add: threadGet_def liftM_def, wp getObject_tcb_at',
+          clarsimp simp: threadRead_tcb_at')
+  apply (wpsimp simp: threadGet_def)
+  apply (drule use_ovalid[OF ovalid_threadRead_sp], simp)
+  apply (clarsimp simp: obj_at'_def asUser_fetch_def projectKOs atcbContextGet_def o_def)
   done
 
 lemma threadSet_modify_asUser:

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -2133,25 +2133,29 @@ lemma installThreadBuffer_corres:
   done
 
 lemma tcb_at_cte_at'_0: "tcb_at' a s \<Longrightarrow> cte_at' (cte_map (a, tcb_cnode_index 0)) s"
-  apply (clarsimp simp: obj_at'_def projectKO_def fail_def return_def projectKO_tcb split: option.splits)
+  apply (clarsimp simp: obj_at'_def projectKO_def fail_def return_def projectKO_tcb oassert_opt_def
+                 split: option.splits)
   apply (rule_tac ptr'=a in cte_wp_at_tcbI'; simp add: objBitsKO_def)
   apply (simp add: cte_map_def tcb_cnode_index_def cte_level_bits_def)
   done
 
 lemma tcb_at_cte_at'_1: "tcb_at' a s \<Longrightarrow> cte_at' (cte_map (a, tcb_cnode_index (Suc 0))) s"
-  apply (clarsimp simp: obj_at'_def projectKO_def fail_def return_def projectKO_tcb split: option.splits)
+  apply (clarsimp simp: obj_at'_def projectKO_def fail_def return_def projectKO_tcb oassert_opt_def
+                 split: option.splits)
   apply (rule_tac ptr'=a in cte_wp_at_tcbI'; simp add: objBitsKO_def)
   apply (simp add: cte_map_def tcb_cnode_index_def cte_level_bits_def of_bl_def)
   done
 
 lemma tcb_at_cte_at'_3: "tcb_at' a s \<Longrightarrow> cte_at' (cte_map (a, tcb_cnode_index 3)) s"
-  apply (clarsimp simp: obj_at'_def projectKO_def fail_def return_def projectKO_tcb split: option.splits)
+  apply (clarsimp simp: obj_at'_def projectKO_def fail_def return_def projectKO_tcb oassert_opt_def
+                 split: option.splits)
   apply (rule_tac ptr'=a in cte_wp_at_tcbI'; simp add: objBitsKO_def)
   apply (simp add: cte_map_def tcb_cnode_index_def cte_level_bits_def)
   done
 
 lemma tcb_at_cte_at'_4: "tcb_at' a s \<Longrightarrow> cte_at' (cte_map (a, tcb_cnode_index 4)) s"
-  apply (clarsimp simp: obj_at'_def projectKO_def fail_def return_def projectKO_tcb split: option.splits)
+  apply (clarsimp simp: obj_at'_def projectKO_def fail_def return_def projectKO_tcb oassert_opt_def
+                 split: option.splits)
   apply (rule_tac ptr'=a in cte_wp_at_tcbI'; simp add: objBitsKO_def)
   apply (simp add: cte_map_def tcb_cnode_index_def cte_level_bits_def)
   done
@@ -2490,7 +2494,7 @@ lemma setMCPriority_ex_nonz_cap_to'[wp]:
   by (wpsimp wp: threadSet_cap_to' simp: setMCPriority_def)
 
 lemma mapTCBPtr_threadGet: "mapTCBPtr t f = threadGet f t"
-  by (clarsimp simp: mapTCBPtr_def threadGet_def liftM_def)
+  by (clarsimp simp: mapTCBPtr_def threadGet_getObject)
 
 lemma monadic_rewrite_bind_unbind:
   "monadic_rewrite False True (tcb_at t)
@@ -3108,7 +3112,7 @@ lemma decode_set_mcpriority_corres:
 
 lemma getMCP_sp:
   "\<lbrace>P\<rbrace> threadGet tcbMCP t \<lbrace>\<lambda>rv. mcpriority_tcb_at' (\<lambda>st. st = rv) t and P\<rbrace>"
-  apply (simp add: threadGet_def)
+  apply (simp add: threadGet_getObject)
   apply wp
   apply (simp add: o_def pred_tcb_at'_def)
   apply (wp getObject_tcb_wp)
@@ -3951,7 +3955,7 @@ lemma decodeBindNotification_wf:
   apply (rule hoare_pre)
    apply (wp getNotification_wp getObject_tcb_wp
         | wpc
-        | simp add: threadGet_def getBoundNotification_def)+
+        | simp add: threadGet_getObject getBoundNotification_def)+
   apply (fastforce simp: valid_cap'_def[where c="capability.ThreadCap t"]
                          is_ntfn invs_def valid_state'_def valid_pspace'_def
                          projectKOs null_def pred_tcb_at'_def obj_at'_def
@@ -3963,7 +3967,7 @@ lemma decodeUnbindNotification_wf:
      decodeUnbindNotification (capability.ThreadCap t)
    \<lbrace>tcb_inv_wf'\<rbrace>,-"
   apply (simp add: decodeUnbindNotification_def)
-  apply (wp getObject_tcb_wp | wpc | simp add: threadGet_def getBoundNotification_def)+
+  apply (wp getObject_tcb_wp | wpc | simp add: threadGet_getObject getBoundNotification_def)+
   apply (auto simp: obj_at'_def pred_tcb_at'_def)
   done
 

--- a/spec/design/skel/ARM/ArchObjInsts_H.thy
+++ b/spec/design/skel/ARM/ArchObjInsts_H.thy
@@ -147,7 +147,7 @@ definition
 
 definition
   loadObject_asidpool[simp]:
- "(loadObject p q n obj) :: asidpool kernel \<equiv>
+ "(loadObject p q n obj) :: asidpool kernel_r \<equiv>
     loadObject_default p q n obj"
 
 definition

--- a/spec/design/skel/KernelStateData_H.thy
+++ b/spec/design/skel/KernelStateData_H.thy
@@ -94,6 +94,6 @@ where
   od"
 
 #INCLUDE_HASKELL SEL4/Model/StateData.lhs decls_only ONLY capHasProperty sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2
-#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue Kernel assert stateAssert findM funArray newKernelState capHasProperty ifM whenM whileM andM orM maybeToMonad sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2
+#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue ReaderM Kernel KernelR getsJust assert stateAssert funOfM condition whileLoop findM funArray newKernelState capHasProperty ifM whenM whileM andM orM maybeToMonad sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2
 
 end

--- a/spec/design/skel/KernelStateData_H.thy
+++ b/spec/design/skel/KernelStateData_H.thy
@@ -79,6 +79,11 @@ type_synonym 'a kernel = "(kernel_state, 'a) nondet_monad"
 translations
   (type) "'c kernel" <= (type) "(kernel_state, 'c) nondet_monad"
 
+type_synonym 'a kernel_r = "(kernel_state, 'a) lookup"
+
+translations
+  (type) "'c kernel_r" <= (type) "(kernel_state, 'c) lookup"
+
 subsection "Kernel Functions"
 
 subsubsection "Initial Kernel State"

--- a/spec/design/skel/ObjectInstances_H.thy
+++ b/spec/design/skel/ObjectInstances_H.thy
@@ -25,8 +25,8 @@ requalify_consts
 end
 
 lemma projectKO_eq2:
-  "((obj,s') \<in> fst (projectKO ko s)) = (projectKO_opt ko = Some obj \<and> s' = s)"
-  by (auto simp: projectKO_def fail_def return_def split: option.splits)
+  "(projectKO ko s = Some obj) = (projectKO_opt ko = Some obj)"
+  by (auto simp: projectKO_def ofail_def oreturn_def oassert_opt_def split: option.splits)
 
 
 \<comment> \<open>-----------------------------------\<close>
@@ -232,22 +232,7 @@ end
 instantiation reply :: pspace_storable
 begin
 
-(* reply extra instance defs *)
-
-
-definition
-  makeObject_reply: "(makeObject :: reply)  \<equiv> Reply Nothing Nothing Nothing"
-
-definition
-  loadObject_reply[simp]:
- "(loadObject p q n obj) :: reply kernel \<equiv>
-    loadObject_default p q n obj"
-
-definition
-  updateObject_reply[simp]:
- "updateObject (val :: reply) \<equiv>
-    updateObject_default val"
-
+#INCLUDE_HASKELL SEL4/Object/Instances.lhs instanceproofs bodies_only ONLY Reply
 
 instance
   apply (intro_classes)
@@ -274,7 +259,7 @@ definition
 
 definition
   loadObject_sc[simp]:
-  "(loadObject p q n obj) :: sched_context kernel \<equiv>
+  "(loadObject p q n obj) :: sched_context kernel_r \<equiv>
      loadObject_default p q n obj"
 
 definition

--- a/spec/design/skel/PSpaceStorable_H.thy
+++ b/spec/design/skel/PSpaceStorable_H.thy
@@ -54,22 +54,6 @@ where
 | "koTypeOf (KOKernelData) = KernelDataT"
 | "koTypeOf (KOArch e) = ArchT (archTypeOf e)"
 
-(* FIXME: move *)
-definition ounless :: "bool \<Rightarrow> unit kernel_r \<Rightarrow> unit kernel_r"
-where "ounless P f \<equiv> if P then oreturn () else f"
-
-(* FIXME: move *)
-definition owhen :: "bool \<Rightarrow> unit kernel_r \<Rightarrow> unit kernel_r"
-where "owhen P f \<equiv> if P then f else oreturn ()"
-
-(* FIXME: move *)
-definition ohaskell_fail :: "unit list \<Rightarrow> 'a kernel_r" where
-  "ohaskell_fail ls = K None"
-
-(* FIXME: move *)
-definition ohaskell_assert :: "bool \<Rightarrow> unit list \<Rightarrow> unit kernel_r" where
-  "ohaskell_assert P ls \<equiv> if P then oreturn () else ofail"
-
 definition
   read_typeError :: "unit list \<Rightarrow> kernel_object \<Rightarrow> 'a kernel_r" where
   "read_typeError t1 t2 \<equiv> ofail"

--- a/spec/design/skel/RISCV64/ArchObjInsts_H.thy
+++ b/spec/design/skel/RISCV64/ArchObjInsts_H.thy
@@ -110,7 +110,7 @@ definition
 
 definition
   loadObject_asidpool[simp]:
- "(loadObject p q n obj) :: asidpool kernel \<equiv>
+ "(loadObject p q n obj) :: asidpool kernel_r \<equiv>
     loadObject_default p q n obj"
 
 definition

--- a/spec/haskell/src/SEL4/Model/PSpace.lhs
+++ b/spec/haskell/src/SEL4/Model/PSpace.lhs
@@ -72,8 +72,7 @@ The "loadObject" and "updateObject" functions are used to insert or extract an o
 The default definitions are sufficient for most kernel objects. There is one exception in the platform-independent code, for "CTE" objects; it can be found in \autoref{sec:object.instances}.
 \end{impdetails}
 
->     loadObject :: (Monad m) => Word -> Word -> Maybe Word ->
->                                 KernelObject -> m a
+>     loadObject :: Word -> Word -> Maybe Word -> KernelObject -> KernelR a
 >     loadObject ptr ptr' next obj = do
 >         unless (ptr == ptr') $ fail $ "no object at address given in pspace,target=" ++ (show ptr) ++",lookup=" ++ (show ptr')
 >         val <- projectKO obj
@@ -81,7 +80,7 @@ The default definitions are sufficient for most kernel objects. There is one exc
 >         sizeCheck ptr next (objBits val)
 >         return val
 
->     updateObject :: (Monad m) => a -> KernelObject -> Word ->
+>     updateObject :: Monad m => a -> KernelObject -> Word ->
 >                         Word -> Maybe Word -> m KernelObject
 >     updateObject val oldObj ptr ptr' next = do
 >         unless (ptr == ptr') $ fail $ "no object at address given in pspace,target=" ++ (show ptr) ++",lookup=" ++ (show ptr')

--- a/spec/haskell/src/SEL4/Model/PSpace.lhs
+++ b/spec/haskell/src/SEL4/Model/PSpace.lhs
@@ -20,7 +20,7 @@ This module contains the data structure and operations for the physical memory m
 % {-# BOOT-IMPORTS: Data.Map SEL4.Object.Structures SEL4.Machine.RegisterSet #-}
 % {-# BOOT-EXPORTS: PSpace #PRegion newPSpace #-}
 
-> import Prelude hiding (Word, read)
+> import Prelude hiding (Word)
 > import SEL4.Model.StateData
 > import SEL4.Object.Structures
 
@@ -129,7 +129,7 @@ requested type.
 >         loadObject (fromPPtr ptr) ptr' after val
 
 > getObject :: PSpaceStorable a => PPtr a -> Kernel a
-> getObject ptr = read (readObject ptr)
+> getObject ptr = getsJust (readObject ptr)
 
 > setObject :: PSpaceStorable a => PPtr a -> a -> Kernel ()
 > setObject ptr val = do

--- a/spec/haskell/src/SEL4/Model/StateData.lhs
+++ b/spec/haskell/src/SEL4/Model/StateData.lhs
@@ -134,14 +134,17 @@ Kernel functions are sequences of operations that transform a "KernelState" obje
 
 Note that there is no error-signalling mechanism available to functions in "Kernel". Therefore, all errors encountered in such functions are fatal, and will halt the kernel. See \autoref{sec:model.failures} for the definition of monads used for error handling.
 
-Read-only functions on the kernel state (excluding the machine state):
+Read-only, potentially failing functions:
 
-> type KernelR = Reader KernelState
+> type ReaderM s = ReaderT s Maybe
+> type KernelR = ReaderM KernelState
 
-To run a "Reader" inside a state monad stack, use "read":
+To run a "ReaderM" inside a state monad stack, e.g. the "Kernel" monad, use "read":
 
-> read :: Monad m => Reader s a -> StateT s m a
-> read r = gets (runReader r)
+> read :: Monad m => ReaderM s a -> StateT s m a
+> read r = do
+>     x <- gets (runReaderT r)
+>     maybe (fail "must return something") return x
 
 \subsubsection{Scheduler Queues}
 

--- a/spec/haskell/src/SEL4/Model/StateData.lhs
+++ b/spec/haskell/src/SEL4/Model/StateData.lhs
@@ -23,7 +23,7 @@ We use the C preprocessor to select a target architecture.
 
 The architecture-specific definitions are imported qualified with the "Arch" prefix.
 
-> import Prelude hiding (Word, read)
+> import Prelude hiding (Word)
 > import qualified SEL4.Model.StateData.TARGET as Arch
 
 \begin{impdetails}
@@ -139,10 +139,10 @@ Read-only, potentially failing functions:
 > type ReaderM s = ReaderT s Maybe
 > type KernelR = ReaderM KernelState
 
-To run a "ReaderM" inside a state monad stack, e.g. the "Kernel" monad, use "read":
+To run a "ReaderM" inside a state monad stack, e.g. the "Kernel" monad, use "getsJust":
 
-> read :: Monad m => ReaderM s a -> StateT s m a
-> read r = do
+> getsJust :: Monad m => ReaderM s a -> StateT s m a
+> getsJust r = do
 >     x <- gets (runReaderT r)
 >     maybe (fail "must return something") return x
 

--- a/spec/haskell/src/SEL4/Object/Instances.lhs
+++ b/spec/haskell/src/SEL4/Object/Instances.lhs
@@ -83,7 +83,7 @@ As mentioned in the documentation for the type class "PSpaceStorable", there is 
 
 >     loadObject ptr ptr' next obj = case obj of
 >         KOCTE cte -> do
->             unless (ptr == ptr') $ fail "no CTE found in pspace at address"
+>             assert (ptr == ptr') "no CTE found in pspace at address"
 >             alignCheck ptr (objBits cte)
 >             sizeCheck ptr next (objBits cte)
 >             return cte

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -16,7 +16,7 @@ This module uses the C preprocessor to select a target architecture.
 
 > module SEL4.Object.SchedContext (
 >         schedContextUnbindAllTCBs, invokeSchedContext,
->         invokeSchedControlConfigure, getSchedContext,
+>         invokeSchedControlConfigure, getSchedContext, readSchedContext,
 >         schedContextUnbindTCB, schedContextBindTCB, schedContextResume,
 >         setSchedContext, updateTimeStamp, commitTime, rollbackTime,
 >         refillHd, refillTl, minBudget, minBudgetUs, refillCapacity, refillBudgetCheck,
@@ -33,7 +33,7 @@ This module uses the C preprocessor to select a target architecture.
 
 \begin{impdetails}
 
-> import Prelude hiding (Word)
+> import Prelude hiding (Word, read)
 > import SEL4.Config
 > import SEL4.Machine.Hardware
 > import SEL4.Machine.RegisterSet(PPtr(..), Word)
@@ -42,7 +42,7 @@ This module uses the C preprocessor to select a target architecture.
 > import {-# SOURCE #-} SEL4.Kernel.VSpace(lookupIPCBuffer)
 > import SEL4.Model.Failures
 > import SEL4.Model.Preemption(KernelP, withoutPreemption)
-> import SEL4.Model.PSpace(getObject, setObject)
+> import SEL4.Model.PSpace(getObject, readObject, setObject)
 > import SEL4.Model.StateData
 > import {-# SOURCE #-} SEL4.Object.Notification
 > import {-# SOURCE #-} SEL4.Object.Reply
@@ -66,6 +66,9 @@ This module uses the C preprocessor to select a target architecture.
 
 > getSchedContext :: PPtr SchedContext -> Kernel SchedContext
 > getSchedContext = getObject
+
+> readSchedContext :: PPtr SchedContext -> KernelR SchedContext
+> readSchedContext = readObject
 
 > setSchedContext :: PPtr SchedContext -> SchedContext -> Kernel ()
 > setSchedContext = setObject

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -33,7 +33,7 @@ This module uses the C preprocessor to select a target architecture.
 
 \begin{impdetails}
 
-> import Prelude hiding (Word, read)
+> import Prelude hiding (Word)
 > import SEL4.Config
 > import SEL4.Machine.Hardware
 > import SEL4.Machine.RegisterSet(PPtr(..), Word)

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -61,6 +61,7 @@ This module uses the C preprocessor to select a target architecture.
 > import Data.Maybe(fromJust)
 > import Data.WordLib
 > import Control.Monad.State(runState)
+> import Control.Monad.Reader(runReader)
 
 \end{impdetails}
 
@@ -944,8 +945,11 @@ This function will return a physical pointer to a thread's IPC buffer slot, used
 The following two trivial functions will get or set a given field of a
 TCB, using a pointer to the TCB.
 
+> threadRead :: (TCB -> a) -> PPtr TCB -> KernelR a
+> threadRead f tptr = liftM f $ readObject tptr
+
 > threadGet :: (TCB -> a) -> PPtr TCB -> Kernel a
-> threadGet f tptr = liftM f $ getObject tptr
+> threadGet f tptr = read (threadRead f tptr)
 
 > threadSet :: (TCB -> TCB) -> PPtr TCB -> Kernel ()
 > threadSet f tptr = do

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -34,7 +34,7 @@ This module uses the C preprocessor to select a target architecture.
 % {-# BOOT-IMPORTS: SEL4.API.Types SEL4.API.Failures SEL4.Machine SEL4.Model SEL4.Object.Structures SEL4.API.Invocation #-}
 % {-# BOOT-EXPORTS: threadGet threadSet asUser setMRs setMessageInfo getThreadCSpaceRoot getThreadVSpaceRoot decodeTCBInvocation invokeTCB getThreadBufferSlot decodeDomainInvocation archThreadSet archThreadGet sanitiseRegister decodeSchedContextInvocation decodeSchedControlInvocation checkBudget chargeBudget replaceAt tcbEPAppend tcbEPDequeue setTimeArg #-}
 
-> import Prelude hiding (Word)
+> import Prelude hiding (Word, read)
 > import SEL4.Config
 > import SEL4.API.Types
 > import SEL4.API.Failures
@@ -61,7 +61,7 @@ This module uses the C preprocessor to select a target architecture.
 > import Data.Maybe(fromJust)
 > import Data.WordLib
 > import Control.Monad.State(runState)
-> import Control.Monad.Reader(runReader)
+> import Control.Monad.Reader(runReaderT)
 
 \end{impdetails}
 

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -34,7 +34,7 @@ This module uses the C preprocessor to select a target architecture.
 % {-# BOOT-IMPORTS: SEL4.API.Types SEL4.API.Failures SEL4.Machine SEL4.Model SEL4.Object.Structures SEL4.API.Invocation #-}
 % {-# BOOT-EXPORTS: threadGet threadSet asUser setMRs setMessageInfo getThreadCSpaceRoot getThreadVSpaceRoot decodeTCBInvocation invokeTCB getThreadBufferSlot decodeDomainInvocation archThreadSet archThreadGet sanitiseRegister decodeSchedContextInvocation decodeSchedControlInvocation checkBudget chargeBudget replaceAt tcbEPAppend tcbEPDequeue setTimeArg #-}
 
-> import Prelude hiding (Word, read)
+> import Prelude hiding (Word)
 > import SEL4.Config
 > import SEL4.API.Types
 > import SEL4.API.Failures
@@ -949,7 +949,7 @@ TCB, using a pointer to the TCB.
 > threadRead f tptr = liftM f $ readObject tptr
 
 > threadGet :: (TCB -> a) -> PPtr TCB -> Kernel a
-> threadGet f tptr = read (threadRead f tptr)
+> threadGet f tptr = getsJust (threadRead f tptr)
 
 > threadSet :: (TCB -> TCB) -> PPtr TCB -> Kernel ()
 > threadSet f tptr = do

--- a/tools/haskell-translator/lhs_pars.py
+++ b/tools/haskell-translator/lhs_pars.py
@@ -631,6 +631,10 @@ def constructor_reversing(tokens):
         rbrack = braces.str(')', '+', '+')
         comma = braces.str(',', '+', '+')
         return [lbrack, tokens[1], comma, tokens[2], rbrack, tokens[0]]
+    elif tokens[0] == 'state_t':
+        # bail on inline monad constructions,
+        # such functions must be explicitly ignored in the skeleton file
+        return []
     else:
         print("Error parsing " + filename)
         print("Can't deal with %s" % tokens)

--- a/tools/haskell-translator/lhs_pars.py
+++ b/tools/haskell-translator/lhs_pars.py
@@ -1887,6 +1887,7 @@ def split_on_unmatched_bracket(elts, n=None):
 
     return (elts, [], n)
 
+
 nondet_m = 'nondet'
 option_m = 'option'
 error_m = 'error'
@@ -1903,7 +1904,7 @@ error_m_map = {
     'stateAssert': 'stateAssertE'
 }
 
-syscall_m_map = {k:v+"E" for (k,v) in error_m_map.items()}
+syscall_m_map = {k: v+"E" for (k, v) in error_m_map.items()}
 
 option_m_map = {
     'return': 'oreturn',
@@ -1929,8 +1930,9 @@ monad_braces = {
     nondet_m: ('(do', 'od)'),
     error_m: ('(doE', 'odE)'),
     syscall_m: ('(doEE', 'odEE)'),
-    option_m: ('do {', 'odO'), # odO will later be replaced by } (and } by \rparr)
+    option_m: ('do {', 'odO'),  # odO will later be replaced by } (and } by \rparr)
 }
+
 
 def monad_ops(type):
     """return operators that have to be adjusted for given monad type"""
@@ -1946,6 +1948,7 @@ def monad_op(type, op):
         return monad_op_map[type][op]
     else:
         return op
+
 
 def monad_type_acquire(sig, type=nondet_m):
     # note kernel appears after kernel_f/kernel_monad


### PR DESCRIPTION
This PR contains the reader monad changes separated out from the awaken PR, plus the proof fixes for Refine.

Rough descriptions of the changes are as follows: 

Haskell:
- adding `KernelR`, using ReaderM (from Control.Monad.Reader), which takes a KernelState and returns a Maybe value
- new definition of `getObject` via `readObject`
- some getter functions are redefined via `readObject` (due to the awaken PR) but not all

Haskell translator:
- updates for handling the reader monad

Design:
- new definitions of alignment related functions, `magnitudeCheck`, etc., via the reader versions of them
- `loadObject` is now in `kernel_r`, while `updateObject` is still in `kernel`. So, alignment checks in `loadObject_default` now uses the reader version of the functions.

Refine:
- proof fixes for the `getObject` change and others
- definitions of `no_fail_r` and `ovalid`


--------

A few comments:
- there are things that need to be moved to better places. For instance,`no_fail_r`. 
- `ovalid` is currently not very useful, but concept-wise it is quite clear and it is rather hard to read without at least an abbreviation.
- most of the Haskell updates are by Gerwin. Also the initial lib and haskell-translator setup.

