### PR TITLE
rt Reader Monad update (abstract)

### DIFF
--- a/proof/invariant-abstract/ARM/ArchADT_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchADT_AI.thy
@@ -194,94 +194,96 @@ lemma get_pd_entry_None_iff_get_pde_fail:
   "is_aligned pd_ref pd_bits \<Longrightarrow>
    get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj)) pd_ref vptr = None \<longleftrightarrow>
    get_pde (pd_ref + (vptr >> 20 << 2)) s = ({}, True)"
-apply (subgoal_tac "(vptr >> 20 << 2) && ~~ mask pd_bits = 0")
- apply (clarsimp simp add: get_pd_entry_def get_arch_obj_def
-            split: option.splits Structures_A.kernel_object.splits
-                   arch_kernel_obj.splits)
- apply (clarsimp simp add: get_pde_def get_pd_def bind_def return_def assert_def
-  get_object_def simpler_gets_def fail_def split_def mask_out_sub_mask mask_eqs)
- apply (subgoal_tac "pd_ref + (vptr >> 20 << 2) -
-                    (pd_ref + (vptr >> 20 << 2) && mask pd_bits) = pd_ref")
-  apply (simp (no_asm_simp) add: fail_def return_def)
-  apply clarsimp
- apply (simp add: mask_add_aligned pd_bits_def pageBits_def)
-apply (simp add: pd_bits_def pageBits_def)
-apply (simp add: and_not_mask)
-apply (simp add: shiftl_shiftr3 word_size shiftr_shiftr)
-apply (subgoal_tac "vptr >> 32 = 0", simp)
-apply (cut_tac shiftr_less_t2n'[of vptr 32 0], simp)
- apply (simp add: mask_eq_iff)
- apply (cut_tac lt2p_lem[of 32 vptr])
-  apply (cut_tac word_bits_len_of, simp+)
-done
+  apply (subgoal_tac "(vptr >> 20 << 2) && ~~ mask pd_bits = 0")
+   apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
+                  split: option.splits Structures_A.kernel_object.splits
+                         arch_kernel_obj.splits)
+   apply (clarsimp simp: get_pde_def get_pd_def bind_def return_def assert_def mask_eqs
+                         get_object_def simpler_gets_def fail_def split_def mask_out_sub_mask
+                         gets_the_def assert_opt_def)
+   apply (subgoal_tac "pd_ref + (vptr >> 20 << 2) -
+                      (pd_ref + (vptr >> 20 << 2) && mask pd_bits) = pd_ref")
+    apply (simp (no_asm_simp) add: fail_def return_def)
+   apply clarsimp
+   apply (simp add: mask_add_aligned pd_bits_def pageBits_def)
+  apply (simp add: pd_bits_def pageBits_def)
+  apply (simp add: and_not_mask)
+  apply (simp add: shiftl_shiftr3 word_size shiftr_shiftr)
+  apply (subgoal_tac "vptr >> 32 = 0", simp)
+  apply (cut_tac shiftr_less_t2n'[of vptr 32 0], simp)
+   apply (simp add: mask_eq_iff)
+  apply (cut_tac lt2p_lem[of 32 vptr])
+   apply (cut_tac word_bits_len_of, simp+)
+  done
 
 lemma get_pd_entry_Some_eq_get_pde:
   "is_aligned pd_ref pd_bits \<Longrightarrow>
    get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj)) pd_ref vptr = Some x \<longleftrightarrow>
    get_pde (pd_ref + (vptr >> 20 << 2)) s = ({(x,s)}, False)"
-apply (subgoal_tac "(vptr >> 20 << 2) && ~~ mask pd_bits = 0")
- apply (clarsimp simp add: get_pd_entry_def get_arch_obj_def
-            split: option.splits Structures_A.kernel_object.splits
-                   arch_kernel_obj.splits)
- apply (clarsimp simp add: get_pde_def get_pd_def bind_def return_def assert_def
-            get_object_def simpler_gets_def fail_def split_def mask_out_sub_mask
-            mask_eqs)
- apply (subgoal_tac "pd_ref + (vptr >> 20 << 2) -
-                    (pd_ref + (vptr >> 20 << 2) && mask pd_bits) = pd_ref")
-  apply (simp (no_asm_simp) add: fail_def return_def)
-  apply (clarsimp simp add: mask_add_aligned pd_bits_def pageBits_def)
-  apply (cut_tac shiftl_shiftr_id[of 2 "vptr >> 20"])
-    apply (simp add: word_bits_def)+
-  apply (cut_tac shiftr_less_t2n'[of vptr 20 30])
-    apply (simp add: word_bits_def)
-   apply (simp add: mask_eq_iff)
-   apply (cut_tac lt2p_lem[of 50 vptr])
-    apply (cut_tac word_bits_len_of, simp+)
- apply (simp add: mask_add_aligned pd_bits_def pageBits_def)
-apply (simp add: pd_bits_def pageBits_def)
-apply (simp add: and_not_mask)
-apply (simp add: shiftl_shiftr3 word_size shiftr_shiftr)
-apply (subgoal_tac "vptr >> 32 = 0", simp)
-apply (cut_tac shiftr_less_t2n'[of vptr 32 0], simp)
- apply (simp add: mask_eq_iff)
- apply (cut_tac lt2p_lem[of 32 vptr])
-  apply (cut_tac word_bits_len_of, simp+)
-done
+  apply (subgoal_tac "(vptr >> 20 << 2) && ~~ mask pd_bits = 0")
+   apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
+                  split: option.splits Structures_A.kernel_object.splits
+                         arch_kernel_obj.splits)
+   apply (clarsimp simp: get_pde_def get_pd_def bind_def return_def assert_def
+                         get_object_def simpler_gets_def fail_def split_def mask_out_sub_mask
+                         mask_eqs gets_the_def assert_opt_def)
+   apply (subgoal_tac "pd_ref + (vptr >> 20 << 2) -
+                      (pd_ref + (vptr >> 20 << 2) && mask pd_bits) = pd_ref")
+    apply (simp (no_asm_simp) add: fail_def return_def)
+    apply (clarsimp simp: mask_add_aligned pd_bits_def pageBits_def)
+    apply (cut_tac shiftl_shiftr_id[of 2 "vptr >> 20"])
+      apply (simp add: word_bits_def)+
+      apply (cut_tac shiftr_less_t2n'[of vptr 20 30])
+        apply (simp add: word_bits_def)
+        apply (simp add: mask_eq_iff)
+        apply (cut_tac lt2p_lem[of 50 vptr])
+         apply (cut_tac word_bits_len_of, simp+)
+         apply (simp add: mask_add_aligned pd_bits_def pageBits_def)
+         apply (simp add: pd_bits_def pageBits_def)
+         apply (simp add: and_not_mask)
+         apply (simp add: shiftl_shiftr3 word_size shiftr_shiftr)
+         apply (subgoal_tac "vptr >> 32 = 0", simp)
+          apply (cut_tac shiftr_less_t2n'[of vptr 32 0], simp)
+            apply (simp add: mask_eq_iff)
+            apply (cut_tac lt2p_lem[of 32 vptr])
+             apply (cut_tac word_bits_len_of, simp+)
+  done
 
 lemma get_pt_entry_None_iff_get_pte_fail:
   "is_aligned pt_ref pt_bits \<Longrightarrow>
    get_pt_entry (\<lambda>obj. get_arch_obj (kheap s obj)) pt_ref vptr = None \<longleftrightarrow>
    get_pte (pt_ref + ((vptr >> 12) && 0xFF << 2)) s = ({}, True)"
-apply (clarsimp simp add: get_pt_entry_def get_arch_obj_def
-             split: option.splits Structures_A.kernel_object.splits
-                    arch_kernel_obj.splits)
-apply (clarsimp simp add: get_pte_def get_pt_def bind_def return_def assert_def
-  get_object_def simpler_gets_def fail_def split_def mask_out_sub_mask mask_eqs)
-apply (subgoal_tac "pt_ref + ((vptr >> 12) && 0xFF << 2) -
-                    (pt_ref + ((vptr >> 12) && 0xFF << 2) && mask pt_bits) =
-                    pt_ref")
- apply (simp (no_asm_simp) add: fail_def return_def)
- apply clarsimp
-apply (simp add: mask_add_aligned pt_bits_def pageBits_def)
-apply (cut_tac and_mask_shiftl_comm[of 8 2 "vptr >> 12"])
- apply (simp_all add: word_size mask_def AND_twice)
-done
+  apply (clarsimp simp: get_pt_entry_def get_arch_obj_def
+                 split: option.splits Structures_A.kernel_object.splits
+                        arch_kernel_obj.splits)
+  apply (clarsimp simp: get_pte_def get_pt_def bind_def return_def assert_def mask_eqs
+                        get_object_def simpler_gets_def fail_def split_def mask_out_sub_mask
+                        gets_the_def assert_opt_def)
+  apply (subgoal_tac "pt_ref + ((vptr >> 12) && 0xFF << 2) -
+                      (pt_ref + ((vptr >> 12) && 0xFF << 2) && mask pt_bits) =
+                      pt_ref")
+   apply (simp (no_asm_simp) add: fail_def return_def)
+   apply clarsimp
+   apply (simp add: mask_add_aligned pt_bits_def pageBits_def)
+   apply (cut_tac and_mask_shiftl_comm[of 8 2 "vptr >> 12"])
+    apply (simp_all add: word_size mask_def AND_twice)
+  done
 
 lemma get_pt_entry_Some_eq_get_pte:
   "is_aligned pt_ref pt_bits \<Longrightarrow>
    get_pt_entry (\<lambda>obj. get_arch_obj (kheap s obj)) pt_ref vptr = Some x \<longleftrightarrow>
    get_pte (pt_ref + ((vptr >> 12) && mask 8 << 2)) s = ({(x,s)}, False)"
-  apply (clarsimp simp add: get_pt_entry_def get_arch_obj_def
-             split: option.splits Structures_A.kernel_object.splits
-                    arch_kernel_obj.splits)
-  apply (clarsimp simp add: get_pte_def get_pt_def bind_def return_def
-            assert_def get_object_def simpler_gets_def fail_def split_def
-            mask_out_sub_mask mask_eqs)
+  apply (clarsimp simp: get_pt_entry_def get_arch_obj_def
+                 split: option.splits Structures_A.kernel_object.splits
+                        arch_kernel_obj.splits)
+  apply (clarsimp simp: get_pte_def get_pt_def bind_def return_def
+                        assert_def get_object_def simpler_gets_def fail_def split_def
+                        mask_out_sub_mask mask_eqs gets_the_def assert_opt_def)
   apply (subgoal_tac "pt_ref + ((vptr >> 12) && mask 8 << 2) -
                       (pt_ref + ((vptr >> 12) && mask 8 << 2) && mask pt_bits) =
                       pt_ref")
    apply (simp (no_asm_simp) add: fail_def return_def)
-   apply (clarsimp simp add: mask_add_aligned pt_bits_def pageBits_def
+   apply (clarsimp simp: mask_add_aligned pt_bits_def pageBits_def
               word_size
               and_mask_shiftr_comm and_mask_shiftl_comm shiftr_shiftr AND_twice)
    apply (cut_tac shiftl_shiftr_id[of 2 "(vptr >> 12)"])
@@ -293,7 +295,7 @@ lemma get_pt_entry_Some_eq_get_pte:
      apply (cut_tac word_bits_len_of, simp+)
   apply (simp add: mask_add_aligned pt_bits_def pageBits_def
                    word_size and_mask_shiftl_comm  AND_twice)
-done
+  done
 
 definition
   "get_pt_info ahp pt_ref vptr \<equiv>
@@ -354,13 +356,13 @@ lemma lookup_pt_slot_fail:
   "is_aligned pd pd_bits \<Longrightarrow>
    lookup_pt_slot pd vptr s = ({},True) \<longleftrightarrow>
    (\<forall>pdo. kheap s pd \<noteq> Some (ArchObj (PageDirectory pdo)))"
-apply (frule pd_shifting'[of _ vptr])
-by (auto simp add: lookup_pt_slot_def lookup_pd_slot_def liftE_def bindE_def
-        returnOk_def lift_def bind_def split_def throwError_def return_def
-        get_pde_def get_pd_def Union_eq get_object_def simpler_gets_def
-        assert_def fail_def mask_eqs
-      split: sum.splits if_split_asm Structures_A.kernel_object.splits
-             arch_kernel_obj.splits pde.splits)
+  apply (frule pd_shifting'[of _ vptr])
+  by (fastforce simp: lookup_pt_slot_def lookup_pd_slot_def liftE_def bindE_def
+                      returnOk_def lift_def bind_def split_def throwError_def return_def
+                      get_pde_def get_pd_def Union_eq get_object_def simpler_gets_def
+                      assert_def fail_def mask_eqs gets_the_def assert_opt_def
+               split: sum.splits if_split_asm Structures_A.kernel_object.splits
+                      arch_kernel_obj.splits pde.splits option.splits)
 
 (* FIXME: Lemma can be found in ArchAcc_R *)
 lemma shiftr_shiftl_mask_pd_bits:
@@ -390,23 +392,23 @@ lemma lookup_pt_slot_no_fail:
         ({(Inl (ExceptionTypes_A.MissingCapability 20),s)},False)
     | SuperSectionPDE _ _ _ \<Rightarrow>
         ({(Inl (ExceptionTypes_A.MissingCapability 20),s)},False)  )"
-apply (frule pd_shifting'[of _ vptr])
-apply (cut_tac shiftr_shiftl_mask_pd_bits[of vptr])
-apply (subgoal_tac "vptr >> 20 << 2 >> 2 = vptr >> 20")
-defer
- apply (rule shiftl_shiftr_id)
-  apply (simp_all add: word_bits_def)
-  apply (cut_tac shiftr_less_t2n'[of vptr 20 30])
-    apply (simp add: word_bits_def)
-   apply (simp add: mask_eq_iff)
-   apply (cut_tac lt2p_lem[of 32 vptr])
-    apply (cut_tac word_bits_len_of, simp_all)
-by (clarsimp simp add: lookup_pt_slot_def lookup_pd_slot_def liftE_def bindE_def
-        returnOk_def lift_def bind_def split_def throwError_def return_def
-        get_pde_def get_pd_def Union_eq get_object_def simpler_gets_def
-        assert_def fail_def mask_add_aligned
-      split: sum.splits if_split_asm kernel_object.splits arch_kernel_obj.splits
-             pde.splits)
+  apply (frule pd_shifting'[of _ vptr])
+  apply (cut_tac shiftr_shiftl_mask_pd_bits[of vptr])
+  apply (subgoal_tac "vptr >> 20 << 2 >> 2 = vptr >> 20")
+   defer
+   apply (rule shiftl_shiftr_id)
+    apply (simp_all add: word_bits_def)
+   apply (cut_tac shiftr_less_t2n'[of vptr 20 30])
+     apply (simp add: word_bits_def)
+    apply (simp add: mask_eq_iff)
+    apply (cut_tac lt2p_lem[of 32 vptr])
+     apply (cut_tac word_bits_len_of, simp_all)
+  by (clarsimp simp: lookup_pt_slot_def lookup_pd_slot_def liftE_def bindE_def
+                     returnOk_def lift_def bind_def split_def throwError_def return_def
+                     get_pde_def get_pd_def Union_eq get_object_def simpler_gets_def
+                     assert_def fail_def mask_add_aligned gets_the_def assert_opt_def
+              split: sum.splits if_split_asm kernel_object.splits arch_kernel_obj.splits
+                     pde.splits)
 
 lemma get_page_info_pte:
   "is_aligned pd_ref pd_bits \<Longrightarrow>

--- a/proof/invariant-abstract/ARM/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchAcc_AI.thy
@@ -1147,8 +1147,9 @@ lemma simpler_set_pt_def:
            ({((), s\<lparr>kheap := kheap s(p \<mapsto> ArchObj (PageTable pt))\<rparr>)}, False)
         else ({}, True))"
   apply (rule ext)
-  apply (clarsimp simp: set_pt_def set_object_def get_object_def assert_def
-                        put_def get_def simpler_gets_def bind_def return_def fail_def)
+  apply (clarsimp simp: set_pt_def set_object_def get_object_def assert_def read_object_def assert_opt_def
+                        put_def get_def simpler_gets_def bind_def return_def fail_def gets_the_def
+                 split: option.split)
   apply (rule conjI)
    apply (clarsimp simp: set_pt_def set_object_def get_object_def assert_def
                          put_def get_def simpler_gets_def bind_def
@@ -3328,7 +3329,7 @@ proof -
      prefer 2
      apply assumption
     apply (rule ext)
-    apply (simp add: get_tcb_def)
+    apply (simp add: get_tcb_def read_object_def)
     apply (case_tac "kheap s t"; simp)
     apply (case_tac a; simp)
     apply (clarsimp simp: arch_tcb_context_set_def arch_tcb_context_get_def)

--- a/proof/invariant-abstract/ARM/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchInvariants_AI.thy
@@ -1273,11 +1273,12 @@ lemma valid_pd_kernel_mappings [iff]:
 (* FIXME: Clagged *)
 lemma get_cap_update [iff]:
   "(fst (get_cap p (f s)) = {(cap, f s)}) = (fst (get_cap p s) = {(cap, s)})"
-  apply (simp add: get_cap_def get_object_def bind_assoc
-                   exec_gets split_def assert_def pspace)
+  apply (simp add: get_cap_def get_object_def bind_assoc read_object_def gets_the_def
+                   exec_gets split_def assert_def pspace assert_opt_def
+            split: option.splits)
   apply (clarsimp simp: fail_def)
-  apply (case_tac y, simp_all add: assert_opt_def split: option.splits)
-      apply (simp_all add: return_def fail_def assert_def bind_def)
+  apply (rename_tac ko, case_tac ko, simp_all add: assert_opt_def split: option.splits)
+        apply (simp_all add: return_def fail_def assert_def bind_def)
   done
 
 (* FIXME: Clagged *)

--- a/proof/invariant-abstract/ARM/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchTcb_AI.thy
@@ -226,7 +226,6 @@ lemma as_user_ipc_tcb_cap_valid4[wp]:
   apply (clarsimp simp: tcb_cap_valid_def obj_at_def
                         pred_tcb_at_def is_tcb
                  dest!: get_tcb_SomeD)
-  apply (clarsimp simp: get_tcb_def)
   done
 
 lemma thread_set_mcp_ex_nonz_cap_to[wp]:

--- a/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
@@ -1844,9 +1844,9 @@ lemma simpler_set_pd_def:
               False)
         else ({}, True))"
   apply (rule ext)
-  apply (auto simp: set_pd_def get_object_def simpler_gets_def assert_def
+  apply (auto simp: set_pd_def get_object_def simpler_gets_def assert_def gets_the_def assert_opt_def
                     return_def fail_def set_object_def get_def put_def bind_def a_type_def
-          split: Structures_A.kernel_object.split arch_kernel_obj.split)
+             split: Structures_A.kernel_object.split arch_kernel_obj.split option.splits)
   done
 
 lemma set_pd_valid_vs_lookup_map:
@@ -2817,7 +2817,8 @@ lemma simpler_store_pde_def:
         | _ => ({}, True))"
   apply     (auto simp: store_pde_def simpler_set_pd_def get_object_def simpler_gets_def assert_def
                         return_def fail_def set_object_def get_def put_def bind_def get_pd_def
-                  split: Structures_A.kernel_object.splits option.splits arch_kernel_obj.splits if_split_asm)
+                        gets_the_def assert_opt_def
+                 split: Structures_A.kernel_object.splits option.splits arch_kernel_obj.splits if_split_asm)
   done
 
 lemma pde_update_valid_vspace_objs:

--- a/proof/invariant-abstract/BCorres_AI.thy
+++ b/proof/invariant-abstract/BCorres_AI.thy
@@ -14,6 +14,14 @@ abbreviation "bcorres \<equiv> bcorres_underlying truncate_state"
 
 abbreviation "s_bcorres \<equiv> s_bcorres_underlying truncate_state"
 
+lemma get_object_bcorres[wp]:
+  "bcorres (get_object p) (get_object p)"
+  apply (simp add: get_object_def)
+  apply (simp add: gets_the_def gets_def bind_def get_def return_def assert_opt_def read_object_def)
+  apply (simp add: bcorres_underlying_def s_bcorres_underlying_def fail_def return_def
+            split: option.splits)
+  done
+
 lemma dxo_bcorres[wp]:
   "bcorres (do_extended_op f) (do_extended_op f)"
   apply (simp add: do_extended_op_def)
@@ -76,15 +84,15 @@ crunch (bcorres) bcorres[wp]:
 lemma get_cap_det:
   "(r,s') \<in> fst (get_cap p s) \<Longrightarrow> get_cap p s = ({(r,s)}, False)"
   apply (cases p)
-  apply (clarsimp simp add: in_monad get_cap_def get_object_def
-                     split: kernel_object.split_asm)
-   apply (clarsimp simp add: bind_def return_def assert_opt_def simpler_gets_def)
-  apply (simp add: bind_def simpler_gets_def return_def assert_opt_def)
-  done
+  apply (clarsimp simp: in_monad get_cap_def get_object_def read_object_def)
+  apply (rename_tac ko caps; case_tac ko; simp add: fail_def)
+  by (clarsimp simp: in_monad gets_the_def gets_def get_def bind_assoc assert_opt_def
+                     fail_def return_def bind_def
+              split: option.splits)+
 
 lemma get_object_bcorres_any[wp]:
   "bcorres_underlying (trans_state e) (get_object a) (get_object a)"
-  by (wpsimp simp: get_object_def)
+  by (wpsimp simp: get_object_def read_object_def)
 
 lemma get_cap_bcorres_any:
   "bcorres_underlying (trans_state e) (get_cap x) (get_cap x)"
@@ -111,6 +119,9 @@ lemma get_cap_helper:
 lemma is_final_cap_bcorres[wp]:
   "bcorres (is_final_cap a) (is_final_cap a)"
   by (simp add: is_final_cap_def is_final_cap'_def gets_def get_cap_helper | wp)+
+
+lemma read_object_truncate[simp]: "read_object a (truncate_state s) = read_object a s"
+  by (clarsimp simp: read_object_def)
 
 lemma get_tcb_truncate[simp]: "get_tcb a (truncate_state s) = get_tcb a s"
   by (simp add: get_tcb_def)
@@ -166,9 +177,5 @@ lemma preemption_point_bcorres[wp]:
   unfolding preemption_point_def by wpsimp
 
 crunch (bcorres) bcorres[wp]: cap_swap_for_delete truncate_state
-
-lemma gets_the_get_tcb_bcorres[wp]:
-  "bcorres (gets_the (get_tcb a)) (gets_the (get_tcb a)) "
-  by (wpsimp simp: gets_the_def bcorres_underlying_def assert_opt_def split: option.splits|rule conjI)+
 
 end

--- a/proof/invariant-abstract/CNodeInv_AI.thy
+++ b/proof/invariant-abstract/CNodeInv_AI.thy
@@ -2356,7 +2356,7 @@ end
 
 
 lemma get_object_some: "kheap s ptr = Some ko \<Longrightarrow> get_object ptr s = ({(ko, s)}, False)"
-  by (clarsimp simp: get_object_def gets_def get_def bind_def assert_def return_def)
+  by (clarsimp simp: get_object_def gets_def get_def bind_def assert_def return_def gets_the_def)
 
 lemma set_cap_id:
   "cte_wp_at ((=) c) p s \<Longrightarrow> set_cap c p s = ({((),s)}, False)"
@@ -2364,7 +2364,7 @@ lemma set_cap_id:
   apply (cases p)
   apply (erule disjE)
    apply clarsimp
-   apply (simp add: set_cap_def get_object_def bind_assoc exec_gets)
+   apply (simp add: set_cap_def get_object_def bind_assoc exec_gets gets_the_def)
    apply (rule conjI)
     apply (clarsimp simp: set_object_def)
     apply (frule get_object_some)
@@ -2375,7 +2375,7 @@ lemma set_cap_id:
     apply (rule ext, simp)
    apply (clarsimp simp: get_object_def gets_def get_def bind_def assert_def return_def)
   apply clarsimp
-  apply (simp add: set_cap_def get_object_def bind_assoc
+  apply (simp add: set_cap_def get_object_def bind_assoc gets_the_def
                    exec_gets set_object_def exec_get put_def)
   apply (clarsimp simp: tcb_cap_cases_def
                  split: if_split_asm,

--- a/proof/invariant-abstract/CSpace_AI.thy
+++ b/proof/invariant-abstract/CSpace_AI.thy
@@ -160,7 +160,7 @@ lemma unpleasant_helper:
 
 lemma get_object_det:
   "(r,s') \<in> fst (get_object p s) \<Longrightarrow> get_object p s = ({(r,s)}, False)"
-  by (auto simp: in_monad get_object_def bind_def gets_def get_def return_def)
+  by (auto simp: in_monad get_object_def bind_def gets_def get_def return_def gets_the_def)
 
 
 lemma get_object_at_obj:
@@ -412,7 +412,7 @@ lemma gets_the_tcb_get_cap:
   apply (clarsimp simp add: tcb_at_def liftM_def bind_def assert_opt_def
                             gets_the_def simpler_gets_def return_def)
   apply (clarsimp    dest!: get_tcb_SomeD
-                  simp add: get_cap_def tcb_cnode_map_def
+                  simp add: get_cap_def tcb_cnode_map_def gets_the_def
                             get_object_def bind_def simpler_gets_def
                             return_def assert_def fail_def assert_opt_def)
   done
@@ -483,12 +483,11 @@ lemma set_cap_cte_eq:
   cte_at p' s \<and> cte_wp_at P p t = (if p = p' then P c else cte_wp_at P p s)"
   apply (cases p)
   apply (cases p')
-  apply (auto simp: set_cap_def2 split_def in_monad cte_wp_at_cases
-                    get_object_def set_object_def wf_cs_upd
-             split: Structures_A.kernel_object.splits if_split_asm
-                    option.splits,
-         auto simp: tcb_cap_cases_def split: if_split_asm)
-  done
+  apply (clarsimp simp: set_cap_def2 split_def in_monad set_object_def
+                       get_object_def tcb_cap_cases_def a_type_def cte_wp_at_cases wf_cs_upd
+                split: if_split_asm option.splits)
+  by (simp_all add: return_def tcb_cap_cases_def fail_def
+             split: kernel_object.splits if_split_asm, auto)
 
 
 lemma descendants_of_cte_at:
@@ -515,10 +514,10 @@ lemma descendants_of_cte_at2:
 
 lemma in_set_cap_cte_at:
   "(x, s') \<in> fst (set_cap c p' s) \<Longrightarrow> cte_at p s' = cte_at p s"
-  by (fastforce simp: cte_at_cases set_cap_def split_def wf_cs_upd
-                     in_monad get_object_def set_object_def
-               split: Structures_A.kernel_object.splits if_split_asm)
-
+  by (clarsimp simp: cte_at_cases set_cap_def split_def
+                     in_monad get_object_def set_object_def)
+     (auto simp: tcb_cap_cases_def return_def fail_def wf_cs_upd
+          split: if_split_asm kernel_object.split_asm)
 
 lemma in_set_cap_cte_at_swp:
   "(x, s') \<in> fst (set_cap c p' s) \<Longrightarrow> swp cte_at s' = swp cte_at s"
@@ -906,13 +905,14 @@ lemma cap_master_cap_simps:
 lemma is_original_cap_set_cap:
   "(x,s') \<in> fst (set_cap p c s) \<Longrightarrow> is_original_cap s' = is_original_cap s"
   by (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def
-               split: if_split_asm Structures_A.kernel_object.splits)
-
+               split: if_split_asm)
+     (simp add: tcb_cap_cases_def return_def fail_def split: if_split_asm kernel_object.split_asm)
 
 lemma mdb_set_cap:
   "(x,s') \<in> fst (set_cap p c s) \<Longrightarrow> cdt s' = cdt s"
   by (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def
-               split: if_split_asm Structures_A.kernel_object.splits)
+               split: if_split_asm)
+     (simp add: tcb_cap_cases_def return_def fail_def split: if_split_asm kernel_object.split_asm)
 
 (* FIXME: rename *)
 lemma yes_indeed [simp]:
@@ -3996,9 +3996,10 @@ lemma set_original_set_cap_comm:
   apply (rule ext)
   apply (clarsimp simp: bind_def split_def set_cap_def set_original_def
                         get_object_def set_object_def get_def put_def
-                        simpler_gets_def simpler_modify_def
-                        assert_def return_def fail_def)
-  apply (case_tac y;
+                        simpler_gets_def simpler_modify_def gets_the_def
+                        assert_def return_def fail_def assert_opt_def
+                 split: option.splits)
+  apply (rename_tac y; case_tac y;
          simp add: return_def fail_def)
   done
 

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -13752,7 +13752,7 @@ lemma update_sched_context_known_sc:
   assumes "kheap s sc_ptr = Some (SchedContext sc n)"
   shows "update_sched_context sc_ptr (\<lambda>_. f sc) s = update_sched_context sc_ptr f s"
   using assms
-  by (auto simp: obj_at_def update_sched_context_def get_object_def set_object_def
+  by (auto simp: obj_at_def update_sched_context_def get_object_def set_object_def gets_the_def
                  gets_def get_def assert_def return_def put_def fail_def bind_def)
 
 lemma sc_ready_times_cong:

--- a/proof/invariant-abstract/Deterministic_AI.thy
+++ b/proof/invariant-abstract/Deterministic_AI.thy
@@ -3141,8 +3141,9 @@ lemma set_cap_exst_update:
   "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),exst_update f s') \<in> fst (set_cap c p (exst_update f s))"
   apply (cases p)
   apply (clarsimp simp add: set_cap_def in_monad get_object_def)
-  apply (case_tac y)
-      apply (auto simp add: in_monad set_object_def get_object_def split: if_split_asm)
+  apply (rename_tac obj; case_tac obj)
+      apply (auto simp: in_monad set_object_def get_object_def
+                 split: if_split_asm kernel_object.splits)
   done
 
 lemma no_parent_not_next_slot:

--- a/proof/invariant-abstract/Finalise_AI.thy
+++ b/proof/invariant-abstract/Finalise_AI.thy
@@ -365,18 +365,17 @@ lemma set_cap_revokable_update:
   ((),is_original_cap_update f s') \<in> fst (set_cap c p (is_original_cap_update f s))"
   apply (cases p)
   apply (clarsimp simp add: set_cap_def in_monad get_object_def)
-  apply (case_tac y)
-  apply (auto simp add: in_monad set_object_def get_object_def split: if_split_asm)
-  done
-
+  apply (rename_tac obj; case_tac obj)
+  by (auto simp: in_monad set_object_def get_object_def
+          split: if_split_asm kernel_object.split_asm)
 
 lemma set_cap_cdt_update:
   "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),cdt_update f s') \<in> fst (set_cap c p (cdt_update f s))"
   apply (cases p)
   apply (clarsimp simp add: set_cap_def in_monad get_object_def)
-  apply (case_tac y)
-  apply (auto simp add: in_monad set_object_def get_object_def split: if_split_asm)
-  done
+  apply (rename_tac obj; case_tac obj)
+  by (auto simp: in_monad set_object_def get_object_def
+          split: if_split_asm kernel_object.split_asm)
 
 lemma tcb_cap_cases_lt:
   "n < 5 \<Longrightarrow> tcb_cap_cases (nat_to_cref 3 n) \<noteq> None"

--- a/proof/invariant-abstract/Invariants_AI.thy
+++ b/proof/invariant-abstract/Invariants_AI.thy
@@ -1379,6 +1379,8 @@ abbreviation (input)
 \<comment> \<open>---------------------------------------------------------------------------\<close>
 section "Lemmas"
 
+declare read_object_def[simp]
+
 lemma valid_bound_obj_None[simp]:
   "valid_bound_obj f None = \<top>"
   by (auto simp: valid_bound_obj_def)
@@ -1425,7 +1427,7 @@ lemmas is_obj_defs = is_ep is_ntfn is_tcb is_reply is_cap_table is_sc_obj_def
 lemma obj_at_get_object:
   "obj_at P ref s \<Longrightarrow> fst (get_object ref s) \<noteq> {}"
   by (auto simp: obj_at_def get_object_def gets_def get_def
-                 return_def assert_def bind_def)
+                 return_def assert_def bind_def gets_the_def)
 
 lemma ko_at_tcb_at:
   "ko_at (TCB t) p s \<Longrightarrow> tcb_at p s"
@@ -2075,15 +2077,14 @@ lemma cte_wp_at_cases:
                              P (get tcb)))"
   apply (cases t)
   apply (cases "kheap s (fst t)")
-   apply (simp add: cte_wp_at_def get_cap_def
+   apply (simp add: cte_wp_at_def get_cap_def gets_the_def
                     get_object_def gets_def get_def return_def assert_def
-                    fail_def bind_def)
+                    fail_def bind_def assert_opt_def)+
   apply (simp add: cte_wp_at_def get_cap_def tcb_cnode_map_def bind_def
                    get_object_def assert_opt_def return_def gets_def get_def
-                   assert_def fail_def dom_def
+                   assert_def fail_def dom_def tcb_cap_cases_def
               split: if_split_asm kernel_object.splits
                      option.splits)
-  apply (simp add: tcb_cap_cases_def)
   done
 
 lemma cte_wp_at_cases2:

--- a/proof/invariant-abstract/KHeapPre_AI.thy
+++ b/proof/invariant-abstract/KHeapPre_AI.thy
@@ -39,7 +39,7 @@ lemma dmo_return [simp]:
 
 lemma get_object_sp:
   "\<lbrace>P\<rbrace> get_object p \<lbrace>\<lambda>r. P and ko_at r p\<rbrace>"
-  apply (simp add: get_object_def)
+  apply (simp add: get_object_def gets_the_def read_object_def)
   apply wp
   apply (auto simp add: obj_at_def)
   done
@@ -133,9 +133,18 @@ lemma set_object_neg_ko:
   done
 
 lemma get_tcb_SomeD: "get_tcb t s = Some v \<Longrightarrow> kheap s t = Some (TCB v)"
-  apply (case_tac "kheap s t", simp_all add: get_tcb_def)
+  apply (case_tac "kheap s t", simp_all add: get_tcb_def read_object_def)
   apply (case_tac a, simp_all)
   done
+
+lemma get_tcb_read_object_Some:
+  "get_tcb t s = Some tcb \<longleftrightarrow> read_object t s = Some (TCB tcb)"
+  by (rule iffI;
+      clarsimp simp: get_tcb_def split: option.splits kernel_object.split_asm)
+
+lemma the_get_tcb_kheap_Some[simp]:
+  "kheap s p = Some (TCB tcb) \<Longrightarrow> the (get_tcb p s) = tcb"
+  by (clarsimp simp: get_tcb_def obind_def read_object_def)
 
 lemma get_tcb_at: "tcb_at t s \<Longrightarrow> (\<exists>tcb. get_tcb t s = Some tcb)"
   by (simp add: tcb_at_def)
@@ -186,7 +195,7 @@ lemma get_object_wp:
 
 lemma get_tcb_rev:
   "kheap s p = Some (TCB t)\<Longrightarrow> get_tcb p s = Some t"
-  by (clarsimp simp:get_tcb_def)
+  by (clarsimp simp:get_tcb_def read_object_def)
 
 lemma get_tcb_obj_atE[elim!]:
   "\<lbrakk> get_tcb t s = Some tcb; get_tcb t s = Some tcb \<Longrightarrow> P (TCB tcb) \<rbrakk> \<Longrightarrow> obj_at P t s"

--- a/proof/invariant-abstract/LevityCatch_AI.thy
+++ b/proof/invariant-abstract/LevityCatch_AI.thy
@@ -39,10 +39,12 @@ lemma const_on_failure_wp :
 
 lemma get_cap_id:
   "(v, s') \<in> fst (get_cap p s) \<Longrightarrow> (s' = s)"
-  by (clarsimp simp: get_cap_def get_object_def in_monad
-                     split_def
-              split: Structures_A.kernel_object.splits)
-
+  by (clarsimp simp: get_cap_def get_object_def read_object_def gets_the_def
+                     split_def gets_def get_def assert_opt_def bind_def
+                     return_def fail_def assert_def
+              split: option.splits)
+     (rename_tac ko a; case_tac ko;
+      simp add: fail_def bind_def return_def assert_def split: if_split_asm)
 
 lemmas cap_irq_opt_simps[simp] =
   cap_irq_opt_def [split_simps cap.split sum.split]

--- a/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
@@ -388,10 +388,9 @@ lemma arch_thread_set_cap_refs_respects_device_region[wp]:
   "\<lbrace>cap_refs_respects_device_region\<rbrace>
      arch_thread_set p v
    \<lbrace>\<lambda>s. cap_refs_respects_device_region\<rbrace>"
-  apply (simp add: arch_thread_set_def set_object_def get_object_def)
+  apply (simp add: arch_thread_set_def set_object_def get_object_def gets_the_def assert_opt_def)
   apply wp
   apply (clarsimp dest!: get_tcb_SomeD simp del: fun_upd_apply)
-  apply (subst get_tcb_rev, assumption, subst option.sel)+
   apply (subst cap_refs_respects_region_cong)
     prefer 3
     apply assumption
@@ -450,14 +449,10 @@ lemma arch_thread_set_pred_tcb_at[wp_unsafe]:
 
 lemma arch_thread_set_if_unsafe_then_cap[wp]:
   "\<lbrace>if_unsafe_then_cap\<rbrace> arch_thread_set p v \<lbrace>\<lambda>rv. if_unsafe_then_cap\<rbrace>"
-  apply (simp add: arch_thread_set_def)
+  apply (simp add: arch_thread_set_def gets_the_def assert_opt_def)
   apply (wp get_object_wp set_object_ifunsafe)
   apply (clarsimp split: kernel_object.splits arch_kernel_obj.splits
                   dest!: get_tcb_SomeD)
-  apply (subst get_tcb_rev)
-  apply assumption
-  apply simp
-  apply (subst get_tcb_rev, assumption, simp)+
   apply (clarsimp simp: obj_at_def tcb_cap_cases_def)
   done
 
@@ -479,7 +474,6 @@ lemma arch_thread_set_valid_ioc[wp]:
                   simp del: fun_upd_apply
                   split: kernel_object.splits arch_kernel_obj.splits
                   dest!: get_tcb_SomeD)
-  apply (subst get_tcb_rev, assumption, subst option.sel)+
   apply (subst arch_tcb_update_aux3)
   apply (subst cte_wp_at_update_some_tcb,assumption)
    apply (clarsimp simp: tcb_cnode_map_def)+
@@ -493,10 +487,6 @@ lemma arch_thread_set_zombies_final[wp]: "\<lbrace>zombies_final\<rbrace> arch_t
   apply (wp get_object_wp set_object_zombies)
   apply (clarsimp split: kernel_object.splits arch_kernel_obj.splits
                   dest!: get_tcb_SomeD)
-  apply (subst get_tcb_rev)
-  apply assumption
-  apply simp
-  apply (subst get_tcb_rev, assumption, simp)+
   apply (clarsimp simp: obj_at_def tcb_cap_cases_def)
   done
 
@@ -526,7 +516,6 @@ lemma arch_thread_set_valid_objs_context[wp]:
   apply (clarsimp simp: Ball_def obj_at_def valid_objs_def dest!: get_tcb_SomeD)
   apply (erule_tac x=v in allE)
   apply (clarsimp simp: dom_def)
-  apply (subst get_tcb_rev, assumption, subst option.sel)+
   apply (clarsimp simp:valid_obj_def valid_tcb_def tcb_cap_cases_def)
   done
 
@@ -543,7 +532,6 @@ lemma arch_thread_sym_refs[wp]:
   apply (simp add: arch_thread_set_def set_object_def get_object_def)
   apply wp
   apply (clarsimp simp del: fun_upd_apply dest!: get_tcb_SomeD)
-  apply (subst get_tcb_rev, assumption, subst option.sel)+
   apply (subst arch_tcb_update_aux3)
   apply (subst sym_refs_update_some_tcb[where f="tcb_arch_update f"])
     apply assumption
@@ -573,7 +561,6 @@ lemma arch_thread_set_if_live_then_nonz_cap':
   apply (wp set_object_iflive)
   apply (clarsimp simp: ex_nonz_cap_to_def if_live_then_nonz_cap_def
                   dest!: get_tcb_SomeD)
-  apply (subst get_tcb_rev, assumption, subst option.sel)+
   apply (clarsimp simp: obj_at_def tcb_cap_cases_def)
   apply (erule_tac x=v in allE, drule mp; assumption?)
   apply (clarsimp simp: live_def)
@@ -1384,7 +1371,6 @@ lemma arch_thread_set_cte_wp_at[wp]:
   apply (simp add: arch_thread_set_def)
   apply (wp set_object_wp)
   apply (clarsimp dest!: get_tcb_SomeD simp del: fun_upd_apply)
-  apply (subst get_tcb_rev, assumption, subst option.sel)+
   apply (subst arch_tcb_update_aux3)
   apply (subst cte_wp_at_update_some_tcb[where f="tcb_arch_update f"])
     apply (clarsimp simp: tcb_cnode_map_def)+

--- a/proof/invariant-abstract/RISCV64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchInvariants_AI.thy
@@ -2669,10 +2669,11 @@ lemma valid_vso_at_update [iff]:
 (* FIXME: move to generic *)
 lemma get_cap_update [iff]:
   "(fst (get_cap p (f s)) = {(cap, f s)}) = (fst (get_cap p s) = {(cap, s)})"
-  apply (simp add: get_cap_def get_object_def bind_assoc
-                   exec_gets split_def assert_def pspace)
+  apply (simp add: get_cap_def get_object_def bind_assoc gets_the_def read_object_def
+                   exec_gets split_def assert_def pspace assert_opt_def
+            split: option.splits)
   apply (clarsimp simp: fail_def)
-  apply (case_tac y, simp_all add: assert_opt_def split: option.splits)
+  apply (rename_tac obj; case_tac obj, simp_all add: assert_opt_def split: option.splits)
       apply (simp_all add: return_def fail_def assert_def bind_def)
   done
 

--- a/proof/invariant-abstract/RealTime_AI.thy
+++ b/proof/invariant-abstract/RealTime_AI.thy
@@ -995,7 +995,7 @@ lemma empty_fail_put[intro!, simp]:
 lemma set_refills_empty_fail [simp]: (* FIXME RT: move *)
   "empty_fail (set_refills sc_ptr refills)"
   by (auto simp: set_refills_def get_sched_context_def update_sched_context_def get_object_def
-                 set_object_def
+                 set_object_def gets_the_def
           intro!: empty_fail_bind empty_fail_get
           split: kernel_object.splits)
 

--- a/proof/invariant-abstract/SubMonad_AI.thy
+++ b/proof/invariant-abstract/SubMonad_AI.thy
@@ -29,7 +29,7 @@ schematic_goal assert_get_tcb_pspace:
   apply (unfold gets_the_def)
   apply (rule submonad_bind_alt [OF submonad_args_pspace])
      apply (rule gets_submonad [OF submonad_args_pspace _ refl])
-     apply (simp add: get_tcb_def)
+     apply (simp add: get_tcb_def read_object_def)
     apply (rule assert_opt_submonad [OF submonad_args_pspace])
    apply simp
   apply (rule empty_fail_assert_opt)

--- a/proof/invariant-abstract/TcbAcc_AI.thy
+++ b/proof/invariant-abstract/TcbAcc_AI.thy
@@ -99,8 +99,9 @@ lemma (in TcbAcc_AI_arch_tcb_context_set_eq) thread_get_as_user:
   apply (rule bind_cong [OF refl])
   apply (clarsimp simp: gets_the_member set_object_def get_object_def in_monad bind_assoc
                         gets_def put_def bind_def get_def return_def select_f_def
-                 dest!: get_tcb_SomeD)
-  apply (subgoal_tac "kheap s(t \<mapsto> TCB v) = kheap s", simp)
+                        gets_the_def assert_opt_def get_tcb_def
+                 split: option.split_asm kernel_object.split_asm)
+  apply (rename_tac v; subgoal_tac "kheap s(t \<mapsto> TCB v) = kheap s", simp)
   apply fastforce
   done
 
@@ -2290,7 +2291,6 @@ lemma sts_tcb_ko_at:
   apply (simp add: set_thread_state_def set_object_def get_object_def)
   apply (wp|simp)+
   apply (clarsimp simp: obj_at_def dest!: get_tcb_SomeD)
-  apply (simp add: get_tcb_def)
   done
 
 

--- a/proof/refine/ARM/ArchAcc_R.thy
+++ b/proof/refine/ARM/ArchAcc_R.thy
@@ -336,7 +336,7 @@ lemma get_asid_pool_corres [corres]:
    apply wp
    apply (fastforce simp: typ_at_to_obj_at_arches
                     dest: no_ofailD[OF no_ofail_asidpool_at'_readObject])
-  apply (clarsimp simp: in_monad loadObject_default_def projectKOs)
+  apply (clarsimp simp: in_monad loadObject_default_def projectKOs gets_the_def)
   apply (simp add: bind_assoc exec_gets)
   apply (drule asid_pool_at_ko)
   apply (clarsimp simp: obj_at_def)
@@ -420,7 +420,7 @@ lemma get_pde_corres [corres]:
   apply wp
    apply (fastforce simp: typ_at_to_obj_at_arches dest: no_ofailD[OF no_ofail_pde_at'_readObject])
    apply simp
-  apply (clarsimp simp: in_monad loadObject_default_def projectKOs)
+  apply (clarsimp simp: in_monad loadObject_default_def projectKOs gets_the_def)
   apply (simp add: bind_assoc exec_gets)
   apply (clarsimp simp: pde_at_def obj_at_def)
   apply (clarsimp simp add: a_type_def return_def
@@ -499,7 +499,7 @@ lemma get_master_pde_corres [@lift_corres_args, corres]:
     apply (rule corres_no_failI)
      apply wp
    apply (fastforce simp: typ_at_to_obj_at_arches dest: no_ofailD[OF no_ofail_pde_at'_readObject])
-    apply (clarsimp simp: in_monad loadObject_default_def
+    apply (clarsimp simp: in_monad loadObject_default_def gets_the_def
                           projectKOs and_not_mask_twice)
     apply (simp add: bind_assoc exec_gets)
     apply (clarsimp simp: pde_at_def obj_at_def)
@@ -516,7 +516,7 @@ lemma get_master_pde_corres [@lift_corres_args, corres]:
                      in pde_relation_alignedD)
          apply assumption
         apply (simp add:mask_pd_bits_inner_beauty)
-       apply (clarsimp simp: pde_relation_aligned_def
+       apply (clarsimp simp: pde_relation_aligned_def gets_the_def exec_gets return_def
                       split: if_splits ARM_H.pde.splits)
        apply (drule_tac p' = "p && ~~ mask 6" in valid_duplicates'_D[rotated])
           apply (simp add:is_aligned_neg_mask is_aligned_weaken[where y = 2])
@@ -542,7 +542,7 @@ lemma get_master_pde_corres [@lift_corres_args, corres]:
       apply (frule_tac x = "(ucast (p && mask pd_bits >> 2))" in pde_relation_alignedD)
         apply assumption
        apply (simp add:mask_pd_bits_inner_beauty)
-      apply (clarsimp simp:pde_relation_aligned_def
+      apply (clarsimp simp:pde_relation_aligned_def gets_the_def exec_gets return_def
         split:if_splits ARM_H.pde.splits)
       apply (drule_tac p' = "p && ~~ mask 6" in valid_duplicates'_D[rotated])
          apply (simp add:is_aligned_neg_mask is_aligned_weaken[where y = 2])
@@ -566,7 +566,7 @@ lemma get_master_pde_corres [@lift_corres_args, corres]:
      apply (frule_tac x = "(ucast (p && mask pd_bits >> 2))" in pde_relation_alignedD)
        apply assumption
       apply (simp add:mask_pd_bits_inner_beauty)
-     apply (clarsimp simp:pde_relation_aligned_def
+     apply (clarsimp simp:pde_relation_aligned_def gets_the_def exec_gets return_def
        split:if_splits ARM_H.pde.splits)
      apply (drule_tac p' = "p && ~~ mask 6" in valid_duplicates'_D[rotated])
         apply (simp add:is_aligned_neg_mask is_aligned_weaken[where y = 2])
@@ -655,7 +655,7 @@ lemma get_pte_corres [corres]:
    apply (fastforce simp: typ_at_to_obj_at_arches dest: no_ofailD[OF no_ofail_pte_at'_readObject])
    apply simp
   apply (clarsimp simp: in_monad loadObject_default_def projectKOs)
-  apply (simp add: bind_assoc exec_gets)
+  apply (simp add: bind_assoc exec_gets gets_the_def)
   apply (clarsimp simp: obj_at_def pte_at_def)
   apply (clarsimp simp add: a_type_def return_def
                   split: if_split_asm Structures_A.kernel_object.splits arch_kernel_obj.splits)
@@ -734,7 +734,7 @@ lemma get_master_pte_corres [@lift_corres_args, corres]:
    apply (fastforce simp: typ_at_to_obj_at_arches dest: no_ofailD[OF no_ofail_pte_at'_readObject])
     apply simp
     apply (clarsimp simp: in_monad loadObject_default_def
-      projectKOs and_not_mask_twice)
+      projectKOs and_not_mask_twice gets_the_def)
     apply (simp add: bind_assoc exec_gets)
     apply (clarsimp simp: pte_at_def obj_at_def)
     apply (clarsimp split:ARM_A.pte.splits)
@@ -749,7 +749,7 @@ lemma get_master_pte_corres [@lift_corres_args, corres]:
       apply (frule_tac x = "(ucast (p && mask pt_bits >> 2))" in pte_relation_alignedD)
         apply assumption
        apply (simp add:mask_pt_bits_inner_beauty)
-      apply (clarsimp simp:pte_relation_aligned_def
+      apply (clarsimp simp:pte_relation_aligned_def gets_the_def exec_gets return_def
         split:if_splits ARM_H.pte.splits)
       apply (drule_tac p' = "p && ~~ mask 6" in valid_duplicates'_D[rotated])
          apply (simp add:is_aligned_weaken[where y = 2] is_aligned_neg_mask)
@@ -808,7 +808,7 @@ lemma get_master_pte_corres [@lift_corres_args, corres]:
                  in pte_relation_alignedD)
      apply assumption
     apply (simp add:mask_pt_bits_inner_beauty)
-   apply (clarsimp simp:pte_relation_aligned_def
+   apply (clarsimp simp:pte_relation_aligned_def gets_the_def exec_gets return_def
      split:if_splits ARM_H.pte.splits)
    apply (drule_tac p' = "p && ~~ mask 6" in valid_duplicates'_D[rotated])
       apply (simp add:is_aligned_weaken[where y = 2] is_aligned_neg_mask)
@@ -868,8 +868,8 @@ lemma set_pd_corres [@lift_corres_args, corres]:
    apply (simp add: objBits_simps archObjSize_def word_bits_def)
   apply (clarsimp simp: setObject_def in_monad split_def updateObject_default_def projectKOs)
   apply (simp add: in_magnitude_check objBits_simps archObjSize_def pageBits_def pdeBits_def)
-  apply (clarsimp simp: obj_at_def exec_gets)
-  apply (clarsimp simp: set_object_def bind_assoc exec_get)
+  apply (clarsimp simp: obj_at_def gets_the_def)
+  apply (clarsimp simp: set_object_def bind_assoc exec_get exec_gets)
   apply (clarsimp simp: put_def)
   apply (clarsimp simp: state_relation_def mask_pd_bits_inner_beauty)
   apply (rule conjI)
@@ -943,8 +943,8 @@ lemma set_pt_corres [@lift_corres_args, corres]:
    apply (simp add: objBits_simps archObjSize_def word_bits_def)
   apply (clarsimp simp: setObject_def in_monad split_def updateObject_default_def projectKOs)
   apply (simp add: in_magnitude_check objBits_simps archObjSize_def pageBits_def pteBits_def)
-  apply (clarsimp simp: obj_at_def exec_gets)
-  apply (clarsimp simp: set_object_def bind_assoc exec_get)
+  apply (clarsimp simp: obj_at_def gets_the_def)
+  apply (clarsimp simp: set_object_def bind_assoc exec_get exec_gets)
   apply (clarsimp simp: put_def)
   apply (clarsimp simp: state_relation_def mask_pt_bits_inner_beauty)
   apply (rule conjI)
@@ -1005,13 +1005,13 @@ lemma store_pde_corres [@lift_corres_args, corres]:
   apply (rule corres_symb_exec_l)
      apply (erule set_pd_corres[OF _ refl])
     apply (clarsimp simp: exs_valid_def get_pd_def get_object_def exec_gets bind_assoc
-                          obj_at_def pde_at_def)
+                          obj_at_def pde_at_def gets_the_def)
     apply (clarsimp simp: a_type_def return_def
                     split: Structures_A.kernel_object.splits arch_kernel_obj.splits if_split_asm)
    apply wp
    apply clarsimp
   apply (clarsimp simp: get_pd_def obj_at_def no_fail_def pde_at_def
-                        get_object_def bind_assoc exec_gets)
+                        get_object_def bind_assoc exec_gets gets_the_def)
   apply (clarsimp simp: a_type_def return_def
                   split: Structures_A.kernel_object.splits arch_kernel_obj.splits if_split_asm)
   done
@@ -1031,14 +1031,14 @@ lemma store_pte_corres [@lift_corres_args, corres]:
   apply (simp add: store_pte_def storePTE_def)
   apply (rule corres_symb_exec_l)
      apply (erule set_pt_corres[OF _ refl])
-    apply (clarsimp simp: exs_valid_def get_pt_def get_object_def
+    apply (clarsimp simp: exs_valid_def get_pt_def get_object_def gets_the_def
                           exec_gets bind_assoc obj_at_def pte_at_def)
     apply (clarsimp simp: a_type_def return_def
                     split: Structures_A.kernel_object.splits arch_kernel_obj.splits if_split_asm)
    apply wp
    apply clarsimp
   apply (clarsimp simp: get_pt_def obj_at_def pte_at_def no_fail_def
-                        get_object_def bind_assoc exec_gets)
+                        get_object_def bind_assoc exec_gets gets_the_def)
   apply (clarsimp simp: a_type_def return_def
                   split: Structures_A.kernel_object.splits arch_kernel_obj.splits if_split_asm)
   done

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -1683,14 +1683,14 @@ lemma set_cap_not_quite_corres_prequel:
    apply (frule tcb_cases_related2)
    apply (clarsimp simp: set_cap_def2 split_def bind_def get_object_def
                          simpler_gets_def assert_def fail_def return_def
-                         set_object_def get_def put_def)
+                         set_object_def get_def put_def gets_the_def)
    apply (erule(2) pspace_relation_update_tcbs)
    apply (simp add: c)
   apply clarsimp
   apply (frule(5) cte_map_pulls_cte_to_abstract[OF p])
   apply (clarsimp simp: set_cap_def split_def bind_def get_object_def
                         simpler_gets_def assert_def fail_def return_def
-                        set_object_def get_def put_def domI
+                        set_object_def get_def put_def domI gets_the_def
                         a_type_def[split_simps kernel_object.split arch_kernel_obj.split])
   apply (erule(1) valid_objsE)
   apply (clarsimp simp: valid_obj_def valid_cs_def valid_cs_size_def exI)
@@ -1779,8 +1779,9 @@ lemma set_cap_not_quite_corres:
   apply (prop_tac "sc_replies_of x = sc_replies_of s")
    apply (erule use_valid[OF _ set_cap.valid_sched_pred], simp)
   apply (clarsimp simp: set_cap_def split_def in_monad set_object_def
-                        get_object_def
-                 split: Structures_A.kernel_object.split_asm if_split_asm)
+                        get_object_def)
+  apply (rename_tac obj ps' x' obj' kobj)
+  apply (case_tac obj; clarsimp simp: fail_def return_def split: if_split_asm)
   done
 
 lemma descendants_of_eq':
@@ -3750,8 +3751,9 @@ lemma set_untyped_cap_corres:
    apply clarsimp
 
   apply (frule setCTE_pspace_only)
-  apply (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def
-                 split: if_split_asm Structures_A.kernel_object.splits)
+  apply (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def)
+  apply (rename_tac obj ps' s'' obj' kobj; case_tac obj;
+         simp add: fail_def return_def split: if_split_asm)
   done
 
 lemma getCTE_get:

--- a/proof/refine/ARM/CSpace_R.thy
+++ b/proof/refine/ARM/CSpace_R.thy
@@ -5597,8 +5597,9 @@ lemma updateCap_same_master:
        apply (subst conj_assoc[symmetric])
        apply (rule conjI)
         apply (frule setCTE_pspace_only)
-        apply (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def
-                         split: if_split_asm Structures_A.kernel_object.splits)
+        apply (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def)
+        apply (rename_tac obj ps' s'' obj' kobj; case_tac obj;
+               simp add: return_def fail_def split: if_split_asm)
        apply (rule conjI)
         apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv data_at_def)
         apply (intro allI conjI)
@@ -5615,8 +5616,9 @@ lemma updateCap_same_master:
          prefer 2
          apply (frule setCTE_pspace_only)
          apply clarsimp
-         apply (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def
-                         split: if_split_asm Structures_A.kernel_object.splits)
+         apply (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def)
+        apply (rename_tac obj s'' obj' kobj; case_tac obj;
+               simp add: return_def fail_def split: if_split_asm)
         apply (frule set_cap_caps_of_state_monad)
         apply (drule is_original_cap_set_cap)
         apply clarsimp

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -1465,7 +1465,7 @@ lemma set_cap_trans_state:
   "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),trans_state f s') \<in> fst (set_cap c p (trans_state f s))"
   apply (cases p)
   apply (clarsimp simp add: set_cap_def in_monad set_object_def get_object_def)
-  apply (case_tac y)
+  apply (rename_tac obj s'' obj' kobj; case_tac obj)
   apply (auto simp add: in_monad set_object_def split: if_split_asm)
   done
 

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -5476,7 +5476,7 @@ lemma handleTimeout_corres:
              apply (rule corres_split_catch[OF _ send_fault_ipc_corres])
                   apply (fastforce simp: tcb_relation_def)+
               apply (wp getTCB_wp)+
-        apply (fastforce simp: pred_tcb_at_def cte_wp_at_def obj_at_def is_tcb_def get_cap_def
+        apply (fastforce simp: pred_tcb_at_def cte_wp_at_def obj_at_def is_tcb_def get_cap_def gets_the_def
                                get_object_def get_tcb_def valid_obj_def valid_tcb_def bind_def
                                return_def tcb_cap_cases_def tcb_cnode_map_def simpler_gets_def
                          dest: invs_valid_objs)
@@ -5492,7 +5492,7 @@ lemma handleTimeout_corres:
    apply (auto simp: other_obj_relation_def tcb_relation_def cap_relation_def
                      cte_wp_at_caps_of_state caps_of_state_def tcb_cnode_map_def
                      get_object_def get_tcb_def get_cap_def simpler_gets_def
-                     return_def bind_def is_cap_simps isCap_simps)
+                     return_def bind_def is_cap_simps isCap_simps gets_the_def)
   done
 
 lemma hf_invs' [wp]:

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -1108,7 +1108,7 @@ lemma get_ep_corres [corres]:
      (get_endpoint ptr) (getEndpoint ptr)"
   apply (rule corres_no_failI)
    apply wp
-  apply (simp add: get_simple_ko_def getEndpoint_def get_object_def
+  apply (simp add: get_simple_ko_def getEndpoint_def get_object_def gets_the_def
                    getObject_def bind_assoc ep_at_def2)
   apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def)
   apply (clarsimp simp: assert_def fail_def obj_at_def return_def is_ep partial_inv_def)
@@ -1588,7 +1588,7 @@ lemma get_ntfn_corres:
   apply (rule corres_no_failI)
    apply wp
   apply (simp add: get_simple_ko_def getNotification_def get_object_def
-                   getObject_def bind_assoc)
+                   getObject_def bind_assoc gets_the_def)
   apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def)
   apply (clarsimp simp: assert_def fail_def obj_at_def return_def is_ntfn partial_inv_def)
   apply (clarsimp simp add: state_relation_def pspace_relation_def obj_at'_def projectKOs)
@@ -1603,7 +1603,7 @@ lemma get_reply_corres:
   apply (rule corres_no_failI)
    apply wp
   apply (simp add: get_simple_ko_def getReply_def get_object_def
-                   getObject_def bind_assoc)
+                   getObject_def bind_assoc gets_the_def)
   apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def)
   apply (clarsimp simp: assert_def fail_def obj_at_def return_def is_reply partial_inv_def)
   apply (clarsimp simp add: state_relation_def pspace_relation_def obj_at'_def projectKOs)
@@ -1626,7 +1626,7 @@ lemma get_sc_corres:
   apply (rule corres_no_failI)
    apply wp
   apply (simp add: get_sched_context_def getSchedContext_def get_object_def
-                   getObject_def bind_assoc)
+                   getObject_def bind_assoc gets_the_def)
   apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def)
   apply (clarsimp simp: assert_def fail_def obj_at_def return_def is_sc_obj_def
                  split: Structures_A.kernel_object.splits)
@@ -1643,7 +1643,7 @@ lemma get_sc_corres_size:
   apply (rule corres_no_failI)
    apply wp
   apply (simp add: get_sched_context_def getSchedContext_def get_object_def
-                   getObject_def bind_assoc)
+                   getObject_def bind_assoc gets_the_def)
   apply (clarsimp simp: in_monad split_def bind_def gets_def get_def)
   apply (clarsimp simp: assert_def fail_def obj_at_def return_def is_sc_obj
                  split: Structures_A.kernel_object.splits)
@@ -3756,7 +3756,7 @@ lemma get_sched_context_exs_valid:
   "\<exists>sc n. kheap s scp = Some (Structures_A.SchedContext sc n)
    \<Longrightarrow> \<lbrace>(=) s\<rbrace> get_sched_context scp \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
   by (clarsimp simp: get_sched_context_def get_object_def obj_at_def bind_def is_sc_obj_def
-                     gets_def get_def return_def exs_valid_def
+                     gets_def get_def return_def exs_valid_def gets_the_def
               split: Structures_A.kernel_object.splits)
 
 lemma no_fail_simple_ko_at:
@@ -3773,7 +3773,7 @@ lemmas no_fail_get_endpoint[wp] = no_fail_simple_ko_at(3)
 lemma get_sched_context_no_fail:
   "no_fail (\<lambda>s. sc_at ptr s) (get_sched_context ptr)"
   by (clarsimp simp: get_sched_context_def no_fail_def bind_def get_object_def return_def get_def
-                     gets_def obj_at_def is_sc_obj_def
+                     gets_def obj_at_def is_sc_obj_def gets_the_def
               split: Structures_A.kernel_object.splits)
 
 (* this let us cross the sc size information from concrete to abstract *)

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -621,7 +621,7 @@ lemma set_reply_obj_ref_noop:
    (return ())
    (set_reply_obj_ref (K id) rptr x)"
   by (clarsimp simp: set_simple_ko_def monadic_rewrite_def exec_gets
-                     update_sk_obj_ref_def
+                     update_sk_obj_ref_def gets_the_def
                      get_simple_ko_def partial_inv_inj_Some get_object_def bind_assoc obj_at_def
                      is_reply_def2 set_object_def exec_get put_id_return)
 

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -627,12 +627,12 @@ lemma threadSet_corres_noopT:
 proof -
   have S: "\<And>t s. tcb_at t s \<Longrightarrow> return v s = (thread_set id t >>= (\<lambda>x. return v)) s"
     apply (clarsimp simp: tcb_at_def)
-    apply (simp add: return_def thread_set_def gets_the_def
-                     assert_opt_def simpler_gets_def set_object_def get_object_def
-                     put_def get_def bind_def assert_def a_type_def[split_simps kernel_object.split arch_kernel_obj.split])
+    apply (clarsimp simp: return_def thread_set_def gets_the_def
+                          assert_opt_def simpler_gets_def set_object_def get_object_def
+                          put_def get_def bind_def assert_def a_type_def[split_simps kernel_object.split arch_kernel_obj.split]
+                   dest!: get_tcb_SomeD)
     apply (subgoal_tac "kheap s(t \<mapsto> TCB tcb) = kheap s", simp)
      apply (simp add: map_upd_triv get_tcb_SomeD)
-    apply (simp add: get_tcb_SomeD map_upd_triv)
     done
   show ?thesis
     apply (rule stronger_corres_guard_imp)
@@ -2341,8 +2341,9 @@ lemma isSchedulable_corres:
 
 lemma get_simple_ko_exs_valid:
   "\<lbrakk>inj C; \<exists>ko. ko_at (C ko) p s \<and> is_simple_type (C ko)\<rbrakk> \<Longrightarrow> \<lbrace>(=) s\<rbrace> get_simple_ko C p \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
-  by (auto simp: get_simple_ko_def get_object_def gets_def return_def get_def
-                     partial_inv_def exs_valid_def bind_def obj_at_def is_reply fail_def inj_def split: prod.splits)
+  by (fastforce simp: get_simple_ko_def get_object_def gets_def return_def get_def
+                      partial_inv_def exs_valid_def bind_def obj_at_def is_reply fail_def inj_def
+                      gets_the_def assert_def)
 
 lemmas get_notification_exs_valid[wp] =
   get_simple_ko_exs_valid[where C=kernel_object.Notification, simplified]

--- a/proof/refine/ARM/VSpace_R.thy
+++ b/proof/refine/ARM/VSpace_R.thy
@@ -116,7 +116,7 @@ lemma find_pd_for_asid_eq_helper:
   apply (drule ucast_up_inj, simp)
   apply (simp add: find_pd_for_asid_def bind_assoc
                    word_neq_0_conv[symmetric] liftE_bindE)
-  apply (simp add: exec_gets liftE_bindE bind_assoc
+  apply (simp add: exec_gets liftE_bindE bind_assoc gets_the_def
                    get_asid_pool_def get_object_def)
   apply (simp add: mask_asid_low_bits_ucast_ucast)
   apply (drule ucast_up_inj, simp)
@@ -139,7 +139,7 @@ lemma find_pd_for_asid_assert_eq:
                   cong: bind_apply_cong)
   apply (clarsimp split: Structures_A.kernel_object.splits
                          arch_kernel_obj.splits if_split_asm)
-  apply (simp add: get_pde_def get_pd_def get_object_def
+  apply (simp add: get_pde_def get_pd_def get_object_def gets_the_def
                    bind_assoc pd_bits_def pdBits_def pdeBits_def pageBits_def)
   apply (simp add: exec_gets)
   done
@@ -221,7 +221,7 @@ lemma find_pd_for_asid_assert_corres:
            apply (clarsimp split: Structures_A.kernel_object.splits
                                   arch_kernel_obj.splits if_split_asm)
            apply (simp add: get_pde_def exs_valid_def bind_def return_def
-                            get_pd_def get_object_def simpler_gets_def)
+                            get_pd_def get_object_def simpler_gets_def gets_the_def)
           apply wp
           apply simp
          apply (simp add: get_pde_def get_pd_def)

--- a/proof/refine/Move_R.thy
+++ b/proof/refine/Move_R.thy
@@ -441,7 +441,8 @@ lemma update_sched_context_decompose:
   apply (rule ext)
   by (clarsimp simp: update_sched_context_def get_object_def set_object_def a_type_simps
                      gets_def get_def put_def return_def fail_def assert_def bind_def
-              split: Structures_A.kernel_object.splits)
+                     gets_the_def assert_opt_def
+              split: Structures_A.kernel_object.splits option.splits)
 
 (* FIXME RT: move to Lib? *)
 lemma maybeM_when:


### PR DESCRIPTION
This adds the reader monad to the abstract spec.

I’ve tweaked the definitions so that the changes with the proofs are more or less minimum. This might mean that we are not quite making use of the reader monad in full, but I think this is what we want for now.

The main thing to note is: `read_object p s = kheap s p`

