### PR TITLE
rt cleanup + some bits for reply_remove_tcb corres

### DIFF
--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -972,6 +972,11 @@ qed
 (* for instantiations *)
 lemma corres_inst: "corres_underlying sr nf nf' r P P' f g \<Longrightarrow> corres_underlying sr nf nf' r P P' f g" .
 
+(* for instantiations; only need to specify what you are adding *)
+lemma corres_inst_add:
+  "corres_underlying sr nf nf' r (P and Q) (P' and Q') f g
+   \<Longrightarrow> corres_underlying sr nf nf' r (P and Q) (P' and Q') f g" .
+
 lemma corres_assert_opt_assume:
   assumes "\<And>x. P' = Some x \<Longrightarrow> corres_underlying sr nf nf' r P Q f (g x)"
   assumes "\<And>s. Q s \<Longrightarrow> P' \<noteq> None"

--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -1551,4 +1551,115 @@ lemma corres_assert_opt_assume_l:
   \<Longrightarrow> corres_underlying sr nf nf' rrel (P and K (X \<noteq> None)) Q (assert_opt X >>= f) g"
   by (force simp: corres_underlying_def assert_opt_def return_def bind_def fail_def)
 
+section \<open> Preservation of state_relation for the concrete side symbolic execution \<close>
+
+(** sr_inv **)
+
+(* In symbolic execution on the concrete side, the state does change
+sometimes but in a way that the state relation is still preserved. We
+encounter this situation quite often in the MCS verification.
+
+Such situations can be handled using existing corres_noop (corres with
+return () on the abstract side, which is rarely used so far), combined
+with other lemmas like corres_split_noop_rhs (which inserts return on
+the abstract side). However, in corres_noop, the state relation
+preservation condition is embedded in a Hoare triple assumption as
+part of the precondition and the postcondition. It is often the case
+that there are existing wp rules that we can use for these normal pre-
+and post-conditions, but we still need to show that the state relation
+is preserved.
+
+In MCS verification, we have significantly more situations that we
+want to do this kind of symbolic execution. sr_inv_ul is for packaging
+up the proof for the preservation of state relation so that we can
+reuse it for such cases.
+
+The rule corres_symb_exec_r_sr is a symbolic execution rule for the
+concrete side where the concrete state is modified, and defined in
+terms of sr_inv_ul.  *)
+
+definition
+  sr_inv_ul :: "('a \<times> 'b) set \<Rightarrow> ('a \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> (unit \<times> 'b) set \<times> 'c) \<Rightarrow> bool" where
+  "sr_inv_ul sr P P' f \<equiv>
+       \<forall>s s' t' x. (s, s') \<in> sr \<longrightarrow> P s \<longrightarrow> P' s'
+              \<longrightarrow> (x, t') \<in> fst (f s') \<longrightarrow> (s, t') \<in> sr"
+
+lemma corres_noop_assm: (* check equivalence *)
+  "(\<forall>s. P s \<longrightarrow> \<lbrace>P' and (\<lambda>s'. (s, s') \<in> sr)\<rbrace> m \<lbrace>\<lambda>_ s'. (s, s') \<in> sr\<rbrace>) \<longleftrightarrow> sr_inv_ul sr P P' m"
+  by (fastforce simp: valid_def sr_inv_ul_def)
+
+lemma sr_inv_stronger_imp:
+  "\<lbrakk>sr_inv_ul sr Q Q' f;
+    \<And>s s'. \<lbrakk>P s; P' s'; (s, s') \<in> sr\<rbrakk> \<Longrightarrow> Q s;
+    \<And>s s'. \<lbrakk>P s; P' s'; (s, s') \<in> sr\<rbrakk> \<Longrightarrow> Q' s'\<rbrakk>
+   \<Longrightarrow> sr_inv_ul sr P P' f"
+  by (clarsimp simp: sr_inv_ul_def)
+
+lemma sr_inv_ul_imp:
+  "\<lbrakk>sr_inv_ul sr Q Q' f; \<And>s. P s \<Longrightarrow> Q s; \<And>s. P' s \<Longrightarrow> Q' s\<rbrakk> \<Longrightarrow> sr_inv_ul sr P P' f "
+  by (clarsimp simp: sr_inv_stronger_imp)
+
+lemma return_sr_inv[simp]:
+  "sr_inv_ul sr P P' (return x)"
+  by (clarsimp simp: sr_inv_ul_def return_def)
+
+lemma sr_inv_ul_bind:
+  "\<lbrakk> \<And>rv. sr_inv_ul sr P (Q' rv) (f rv); sr_inv_ul sr P P' g; \<lbrace>P'\<rbrace> g \<lbrace> \<lambda>rv. Q' rv\<rbrace> \<rbrakk>
+   \<Longrightarrow> sr_inv_ul sr P P' (g >>= f)"
+  apply (unfold sr_inv_ul_def valid_def)
+  apply clarify
+  apply (drule_tac x=s' in spec)
+  apply (drule (1) mp)
+  apply (unfold in_bind)
+  apply clarify
+  apply (drule_tac x=s and y=s' in spec2)
+  apply (drule_tac x=s'' in spec)
+  apply (drule_tac x=x in meta_spec)
+  apply (drule_tac x=s and y=s'' in spec2)
+  apply (drule_tac x=t' in spec)
+  apply (drule_tac x="(x, s'')" in bspec, simp)
+  apply simp
+  done
+
+lemma corres_noop_sr:
+  assumes sr: "sr_inv_ul sr P P' f"
+  assumes ex: "\<lbrace> P' \<rbrace> f \<lbrace>\<lambda>rv _. r x rv\<rbrace>"
+  assumes nf': "\<And>s. \<lbrakk> P s; nf' \<rbrakk> \<Longrightarrow> no_fail (\<lambda>s'. (s, s') \<in> sr \<and> P' s') f"
+  shows "corres_underlying sr nf nf' r P P' (return x) f"
+  using sr ex
+  apply (clarsimp simp: sr_inv_ul_def corres_underlying_def return_def)
+  apply (clarsimp simp: no_failD[OF nf'[simplified]] valid_def)
+  apply (drule_tac x=b in spec, clarsimp)
+  done
+
+(* corres_symb_exec_r_sr basically combines the two lemmas corres_split_noop_rhs and corres_noop
+   in one and separates out the sr_inv part *)
+lemma corres_symb_exec_r_sr:
+  assumes z: "corres_underlying sr nf nf' r P Q' x y"
+  assumes sr: "sr_inv_ul sr P P' m"
+  assumes ex: "\<lbrace> P' \<rbrace> m \<lbrace>\<lambda>_. Q'\<rbrace>"
+  assumes nf: "\<And>s. \<lbrakk> P s; nf' \<rbrakk> \<Longrightarrow> no_fail (\<lambda>s'. (s, s') \<in> sr \<and> P' s') m"
+  shows "corres_underlying sr nf nf' r P P' x (m >>= (\<lambda>_. y))"
+  using sr z ex nf
+  unfolding corres_underlying_def sr_inv_ul_def
+  apply (clarsimp simp: corres_underlying_def bind_def)
+  apply (rename_tac s s')
+  apply (rule conjI; clarsimp simp: in_monad)
+   apply (drule_tac x=s and y=s' in spec2, clarsimp)
+   apply (rename_tac t' rv' s'')
+   apply (drule_tac x="(s, t')" in bspec, simp)
+   apply clarsimp
+   apply (drule use_valid[OF _ ex], simp)
+   apply clarsimp
+   apply (drule_tac x="(rv', s'')" in bspec, simp)
+   apply simp
+  apply (drule_tac x=s and y=s' in spec2, clarsimp simp: no_failD[OF nf] valid_def)
+  apply (rename_tac t')
+  apply (drule_tac x=s in meta_spec)
+  apply (drule_tac x=s' in spec, clarsimp)
+  apply (drule bspec[of "fst _"], simp)
+  apply clarsimp
+  apply (drule_tac x="(s, t')" in bspec, simp)
+  by clarsimp
+
 end

--- a/lib/ListLibLemmas.thy
+++ b/lib/ListLibLemmas.thy
@@ -222,22 +222,6 @@ lemma after_can_split: "after_in_list list x = Some y \<Longrightarrow> \<exists
   apply simp
   done
 
-lemma distinct_inj_middle: "distinct list \<Longrightarrow> list = (xa @ x # xb) \<Longrightarrow> list = (ya @ x # yb) \<Longrightarrow> xa = ya \<and> xb = yb"
-  apply (induct list arbitrary: xa ya)
-  apply simp
-  apply clarsimp
-  apply (case_tac "xa")
-   apply simp
-   apply (case_tac "ya")
-    apply simp
-   apply clarsimp
-  apply clarsimp
-  apply (case_tac "ya")
-   apply (simp (no_asm_simp))
-   apply simp
-  apply clarsimp
-  done
-
 
 lemma after_can_split_distinct:
   "distinct list \<Longrightarrow> after_in_list list x = Some y \<Longrightarrow> \<exists>!ys. \<exists>!xs. list = xs @ (x # y # ys)"

--- a/lib/MonadicRewrite.thy
+++ b/lib/MonadicRewrite.thy
@@ -507,6 +507,30 @@ next
     by (fastforce simp: corres_underlying_def split_def)
 qed
 
+lemma monadic_rewrite_corres':
+  assumes cu: "corres_underlying R False nf' r P P' a c'"
+  and     me: "monadic_rewrite False True Q c c'"
+  shows   "corres_underlying R False nf' r  P (P' and Q) a c"
+proof (rule corres_underlyingI)
+  fix s t rv' t'
+  assume st: "(s, t) \<in> R" and pq: "(P' and Q) t" and ps: "P s" and ct: "(rv', t') \<in> fst (c t)"
+  from pq have P't: "P' t" and Qt: "Q t" by simp_all
+
+  from me ct Qt have c't: "(rv', t') \<in> fst (c' t)"
+   by (clarsimp simp: monadic_rewrite_def)
+
+  from cu st ps P't c't obtain s' rv where
+     as: "(rv, s') \<in> fst (a s)" and rest: "nf' \<longrightarrow> \<not> snd (c' t)" "(s', t') \<in> R" "r rv rv'"
+    by (fastforce elim: corres_underlyingE)
+
+  with rest as show "\<exists>(rv, s')\<in>fst (a s). (s', t') \<in> R \<and> r rv rv'" by auto
+next
+  fix s t
+  assume "(s, t) \<in> R" "(P' and Q) t" "P s" "nf'"
+  thus "\<not> snd (c t)" using cu me
+    by (fastforce simp: corres_underlying_def split_def monadic_rewrite_def)
+qed
+
 lemma monadic_rewrite_refine_valid:
   "monadic_rewrite F E P f g
     \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>

--- a/proof/refine/ARM/Corres.thy
+++ b/proof/refine/ARM/Corres.thy
@@ -23,4 +23,12 @@ abbreviation
 abbreviation
   "ex_abs \<equiv> ex_abs_underlying state_relation"
 
+abbreviation "sr_inv P P' f \<equiv> sr_inv_ul state_relation P P' f"
+
+lemmas sr_inv_def = sr_inv_ul_def
+
+lemmas sr_inv_imp = sr_inv_ul_imp[of state_relation]
+
+lemmas sr_inv_bind = sr_inv_ul_bind[where sr=state_relation]
+
 end

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -3835,6 +3835,10 @@ lemma invs_valid_release_queue' [elim!]:
   "invs' s \<Longrightarrow> valid_release_queue' s"
   by (simp add: invs'_def valid_state'_def)
 
+lemma invs_sym_list_refs_of_replies'[elim!]:
+  "invs' s \<Longrightarrow> sym_refs (list_refs_of_replies' s)"
+  by (simp add: invs'_def valid_state'_def)
+
 lemma invs_valid_idle'[elim!]:
   "invs' s \<Longrightarrow> valid_idle' s"
   by (fastforce simp: invs'_def valid_state'_def)
@@ -3926,6 +3930,7 @@ lemmas invs'_implies =
   invs_queues'
   invs_valid_release_queue
   invs_valid_release_queue'
+  invs_sym_list_refs_of_replies'
 
 lemma valid_bitmap_valid_bitmapQ_exceptE:
   "\<lbrakk> valid_bitmapQ_except d p s ; (bitmapQ d p s \<longleftrightarrow> ksReadyQueues s (d,p) \<noteq> []) ;

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -1046,4 +1046,68 @@ lemma updateReply_replyNext_Nothing_invs':
                   dest: pspace_alignedD' pspace_distinctD')
   done
 
+context begin interpretation Arch .
+
+lemma pspace_relation_reply_update_conc_only:
+  "\<lbrakk> pspace_relation ps ps'; ps x = Some (Structures_A.Reply reply); ps' x = Some (KOReply reply');
+     reply_relation reply new\<rbrakk>
+   \<Longrightarrow> pspace_relation ps (ps'(x \<mapsto> (KOReply new)))"
+  apply (simp add: pspace_relation_def pspace_dom_update dom_fun_upd2
+              del: dom_fun_upd)
+  apply (erule conjE)
+  apply (rule ballI, drule(1) bspec)
+  apply (clarsimp simp: split_def)
+  apply (drule bspec, simp)
+  apply (clarsimp simp: obj_relation_cuts_def2 cte_relation_def
+                        pte_relation_def pde_relation_def
+                 split: Structures_A.kernel_object.split_asm arch_kernel_obj.split_asm if_split_asm)
+  done
+
+end
+
+lemma replyPrevs_of_replyNext_update:
+  "ko_at' reply' rp s' \<Longrightarrow>
+      replyPrevs_of (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto>
+                            KOReply (reply' \<lparr> replyNext := v \<rparr>))\<rparr>) = replyPrevs_of s'"
+  apply (clarsimp simp: obj_at'_def projectKOs isNext_def
+                 split: option.split_asm reply_next.split_asm)
+  by (fastforce simp: projectKO_opt_reply opt_map_def)
+
+lemma scs_of'_reply_update:
+  "reply_at' rp s' \<Longrightarrow>
+      scs_of' (s'\<lparr>ksPSpace := ksPSpace s'(rp \<mapsto> KOReply reply)\<rparr>) = scs_of' s'"
+  apply (clarsimp simp: obj_at'_def projectKOs isNext_def
+                 split: option.split_asm reply_next.split_asm)
+  by (fastforce simp: projectKO_opt_sc opt_map_def)
+
+lemma sc_replies_relation_replyNext_update:
+  "\<lbrakk>sc_replies_relation s s'; ko_at' reply' rp s'\<rbrakk>
+     \<Longrightarrow> sc_replies_relation s (s'\<lparr>ksPSpace := (ksPSpace s')(rp \<mapsto>
+                                           KOReply (reply' \<lparr> replyNext := v \<rparr>))\<rparr>)"
+  by (clarsimp simp: scs_of'_reply_update[simplified] obj_at'_def
+                     replyPrevs_of_replyNext_update[simplified])
+
+(* an example of an sr_inv lemma; to be used in reply_remove_tcb_corres *)
+lemma replyNext_Next_update_sr_inv:
+   "\<lbrakk>\<not>isHead v; isNext (replyNext r')\<rbrakk> \<Longrightarrow>
+    sr_inv P (P' and ko_at' r' rp)
+       (setReply rp (r' \<lparr> replyNext := v \<rparr>))"
+  unfolding sr_inv_def
+  apply (clarsimp simp: cleanReply_def in_monad setReply_def setObject_def
+                        exec_get split_def getReply_def projectKOs objBits_simps
+                        updateObject_default_def ARM_H.fromPPtr_def obj_at'_def
+                        in_magnitude_check replySizeBits_def
+                 split: option.split_asm)
+  apply (clarsimp simp: state_relation_def map_to_ctes_upd_other)
+  apply (frule reply_at'_cross[where ptr=rp])
+   apply (clarsimp simp: obj_at'_def objBits_simps projectKOs replySizeBits_def)
+  apply (rule conjI; clarsimp simp: obj_at_def is_reply)
+   apply (frule (1) pspace_relation_absD)
+   apply (erule (2) pspace_relation_reply_update_conc_only)
+   apply (clarsimp simp: reply_relation_def getHeadScPtr_def isNext_def isHead_def
+                  split: reply_next.splits option.splits)
+  apply (rule sc_replies_relation_replyNext_update[simplified])
+   apply simp
+  by (clarsimp simp: obj_at'_def objBits_simps projectKOs replySizeBits_def)
+
 end

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -158,7 +158,7 @@ lemma set_object_valid_tcbs[wp]:
   done
 
 lemma set_reply_obj_ref_valid_tcb[wp]:
-  "set_reply_obj_ref reply_tcb_update rp opt \<lbrace>valid_tcb ptr tcb\<rbrace>"
+  "set_reply_obj_ref f rp opt \<lbrace>valid_tcb ptr tcb\<rbrace>"
   apply (clarsimp simp: update_sk_obj_ref_def set_simple_ko_def)
   apply (wpsimp wp: set_object_typ_ats get_object_wp)
   done
@@ -172,40 +172,30 @@ lemma set_simple_ko_not_tcb_at[wp]:
   done
 
 lemma set_reply_obj_ref_not_tcb_at[wp]:
-  "set_reply_obj_ref reply_tcb_update rp opt \<lbrace>\<lambda>s. \<not> ko_at (TCB tcb) t s\<rbrace>"
+  "set_reply_obj_ref f rp opt \<lbrace>\<lambda>s. \<not> ko_at (TCB tcb) t s\<rbrace>"
   apply (clarsimp simp: update_sk_obj_ref_def)
   apply (wpsimp wp: set_simple_ko_wp get_simple_ko_wp)
   apply (clarsimp simp: obj_at_def sk_obj_at_pred_def pred_neg_def split: if_splits)
   done
 
 lemma set_reply_obj_ref_valid_tcbs[wp]:
-  "set_reply_obj_ref reply_tcb_update rp opt \<lbrace>valid_tcbs\<rbrace>"
+  "set_reply_obj_ref f rp opt \<lbrace>valid_tcbs\<rbrace>"
   unfolding valid_tcbs_def
   apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' simp: pred_neg_def)
   done
 
-lemma set_endpoint_valid_tcb[wp]:
-  "set_endpoint ep endpoint \<lbrace>valid_tcb ptr tcb\<rbrace>"
+lemma set_simple_ko_valid_tcb[wp]:
+  "set_simple_ko C p obj \<lbrace>valid_tcb ptr tcb\<rbrace>"
   apply (clarsimp simp: set_simple_ko_def)
   apply (wpsimp wp: set_object_typ_ats get_object_wp)+
   done
 
-lemma set_endpoint_valid_tcbs[wp]:
-  "set_endpoint ep endpoint \<lbrace>valid_tcbs\<rbrace>"
+lemma set_simple_ko_valid_tcbs[wp]:
+  "set_endpoint ep eval \<lbrace>valid_tcbs\<rbrace>"
+  "set_notification ntfnptr nval \<lbrace>valid_tcbs\<rbrace>"
+  "set_reply rptr rval \<lbrace>valid_tcbs\<rbrace>"
   unfolding valid_tcbs_def
-  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')
-  done
-
-lemma set_notification_valid_tcb[wp]:
-  "set_notification ntfnptr val \<lbrace>valid_tcb ptr tcb\<rbrace>"
-  apply (clarsimp simp: set_simple_ko_def)
-  apply (wpsimp wp: get_object_wp)
-  done
-
-lemma set_notification_valid_tcbs[wp]:
-  "set_notification ntfnptr val \<lbrace>valid_tcbs\<rbrace>"
-  unfolding valid_tcbs_def
-  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')
+  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')+
   done
 
 (* FIXME RT: move/cleanup as part of consolidating valid_objs/valid_tcbs *)


### PR DESCRIPTION
This PR contains more of the on-going cleanup, as well as several small additions and abstractions that are part of the `reply_remove_tcb_corres` PR (#180 ).

At this point, I am giving up on merging #180 as is mainly because of the complications from reply related duplications and changes. This contains part of that PR that can be merged without more work. For the rest, I am planning to quickly redo it on top of the current rt, and will include there some refactors for reusing some part for `replyRemove` and `replyPop`.

A full description of `sr_inv_ul` can be found in #160 .