### PR TITLE
arm crefine: fix `decodeARMMMUInvocation` branch hint

### DIFF
--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -3352,7 +3352,6 @@ lemma Arch_decodeInvocation_ccorres:
                   apply (rule_tac P = "rv'a = from_bool (\<not>( isUntypedCap (fst (hd extraCaps)) \<and>
                             capBlockSize (fst (hd extraCaps)) = objBits (makeObject ::asidpool)
                             ))" in ccorres_gen_asm2)
-                  apply csymbr
                 apply (rule ccorres_symb_exec_r)
                   apply (rule_tac xf'=ret__int_' in ccorres_abstract, ceqv)
                   apply (rule_tac P = "rv'b = from_bool (\<not>( isUntypedCap (fst (hd extraCaps)) \<and>

--- a/proof/crefine/ARM_HYP/Arch_C.thy
+++ b/proof/crefine/ARM_HYP/Arch_C.thy
@@ -3755,7 +3755,6 @@ lemma decodeARMMMUInvocation_ccorres:
                   apply (rule_tac P = "rv'a = from_bool (\<not>( isUntypedCap (fst (hd extraCaps)) \<and>
                             capBlockSize (fst (hd extraCaps)) = objBits (makeObject ::asidpool)
                             ))" in ccorres_gen_asm2)
-                  apply csymbr
                 apply (rule ccorres_symb_exec_r)
                   apply (rule_tac xf'=ret__int_' in ccorres_abstract, ceqv)
                   apply (rule_tac P = "rv'b = from_bool (\<not>( isUntypedCap (fst (hd extraCaps)) \<and>


### PR DESCRIPTION
A previous update to C code added a disjunct to an `if` condition
outside the existing `unlikely` branch hint. This commit is the proof
update for a C patch that extends the branch hint to the full `if`
condition.

Corresponding seL4 PR: https://github.com/seL4/seL4/pull/310

This change is motivated by a C parser update I'm working on, which is in turn required for BV and MCS verification. Without this change, the C parser update would require some proof updates. I figure it's better to do any proof updates with this patch, which I think makes a small improvement to the kernel. After this change, the C parser update won't require any further l4v proof updates.

For a preview of the C parser update, see https://github.com/seL4/l4v/pull/230. (Note that the C parser PR is rebased over this one, so until this PR is merged, the changes here also appear in the C parser PR.)