### PR TITLE
Move invariant field update lemmas

### DIFF
--- a/proof/crefine/ARM/ArchMove_C.thy
+++ b/proof/crefine/ARM/ArchMove_C.thy
@@ -77,7 +77,7 @@ lemma setCTE_asidpool':
    apply (simp add: updateObject_cte)
    apply (clarsimp simp: updateObject_cte typeError_def magnitudeCheck_def in_monad
                    split: kernel_object.splits if_splits option.splits)
-  apply (clarsimp simp: ps_clear_upd' lookupAround2_char1)
+  apply (clarsimp simp: ps_clear_upd lookupAround2_char1)
   done
 
 lemma empty_fail_findPDForASID[iff]:

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -1599,7 +1599,7 @@ lemma setCTE_asidpool':
    apply (simp add: updateObject_cte)
    apply (clarsimp simp: updateObject_cte typeError_def magnitudeCheck_def in_monad
                    split: kernel_object.splits if_splits option.splits)
-  apply (clarsimp simp: ps_clear_upd' lookupAround2_char1)
+  apply (clarsimp simp: ps_clear_upd lookupAround2_char1)
   done
 
 lemmas udpateCap_asidpool' = updateCap_ko_at_ap_inv'

--- a/proof/crefine/X64/VSpace_C.thy
+++ b/proof/crefine/X64/VSpace_C.thy
@@ -2307,7 +2307,7 @@ lemma setCTE_asidpool':
    apply (simp add: updateObject_cte)
    apply (clarsimp simp: updateObject_cte typeError_def magnitudeCheck_def in_monad
                    split: kernel_object.splits if_splits option.splits)
-  apply (clarsimp simp: ps_clear_upd' lookupAround2_char1)
+  apply (clarsimp simp: ps_clear_upd lookupAround2_char1)
   done
 
 (* FIXME: move *)

--- a/proof/refine/ARM/ArchAcc_R.thy
+++ b/proof/refine/ARM/ArchAcc_R.thy
@@ -1425,14 +1425,6 @@ lemma clearMemory_vms':
   apply (rule clearMemory_um_eq_0)
   done
 
-lemma ct_not_inQ_ksMachineState_update[simp]:
-  "ct_not_inQ (s\<lparr>ksMachineState := v\<rparr>) = ct_not_inQ s"
-  by (simp add: ct_not_inQ_def)
-
-lemma ct_in_current_domain_ksMachineState_update[simp]:
-  "ct_idle_or_in_cur_domain' (s\<lparr>ksMachineState := v\<rparr>) = ct_idle_or_in_cur_domain' s"
-  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-
 lemma dmo_clearMemory_invs'[wp]:
   "\<lbrace>invs'\<rbrace> doMachineOp (clearMemory w sz) \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (simp add: doMachineOp_def split_def)

--- a/proof/refine/ARM/Arch_R.thy
+++ b/proof/refine/ARM/Arch_R.thy
@@ -1288,7 +1288,7 @@ lemma setTCB_pdpt_bits'[wp]:
    setObject a (tcb::tcb)
   \<lbrace>\<lambda>rv. ko_wp_at' (\<lambda>ko. P (vs_entry_align ko)) p\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd'
+                        projectKOs pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = tcb,simplified])

--- a/proof/refine/ARM/Arch_R.thy
+++ b/proof/refine/ARM/Arch_R.thy
@@ -1244,16 +1244,6 @@ lemma invokeArch_tcb_at':
   apply (wp, clarsimp simp: pred_tcb_at')
   done
 
-(* FIXME random place to have these *)
-lemma pspace_no_overlap_queuesL1 [simp]:
-  "pspace_no_overlap' w sz (ksReadyQueuesL1Bitmap_update f s) = pspace_no_overlap' w sz s"
-  by (simp add: pspace_no_overlap'_def)
-
-(* FIXME random place to have these *)
-lemma pspace_no_overlap_queuesL2 [simp]:
-  "pspace_no_overlap' w sz (ksReadyQueuesL2Bitmap_update f s) = pspace_no_overlap' w sz s"
-  by (simp add: pspace_no_overlap'_def)
-
 crunch pspace_no_overlap'[wp]: setThreadState "pspace_no_overlap' w s"
   (simp: unless_def)
 
@@ -1830,7 +1820,7 @@ crunch typ_at' [wp]: "Arch.finaliseCap" "\<lambda>s. P (typ_at' T p s)"
 crunch cte_wp_at':  "Arch.finaliseCap" "cte_wp_at' P p"
   (wp: crunch_wps getASID_wp simp: crunch_simps)
 
-lemma invs_asid_table_strenghten':
+lemma invs_asid_table_strengthen':
   "invs' s \<and> asid_pool_at' ap s \<and> asid \<le> 2 ^ asid_high_bits - 1 \<longrightarrow>
    invs' (s\<lparr>ksArchState :=
             armKSASIDTable_update (\<lambda>_. (armKSASIDTable \<circ> ksArchState) s(asid \<mapsto> ap)) (ksArchState s)\<rparr>)"
@@ -1871,7 +1861,7 @@ lemma performASIDControlInvocation_invs' [wp]:
    apply fastforce
   apply (rule hoare_pre)
    apply (wp hoare_vcg_const_imp_lift)
-       apply (strengthen invs_asid_table_strenghten')
+       apply (strengthen invs_asid_table_strengthen')
        apply (wp cteInsert_simple_invs)
       apply (wp createObjects'_wp_subst[OF
                 createObjects_no_cte_invs [where sz = pageBits and ty="Inl (KOArch (KOASIDPool pool))" for pool]]

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -565,6 +565,14 @@ where
  "not_recursive_ctes s \<equiv> {ptr. \<exists>cap. cteCaps_of s ptr = Some cap
                              \<and> \<not> (isZombie cap \<and> capZombiePtr cap = ptr)}"
 
+lemma not_recursive_ctes_wu [simp]:
+  "not_recursive_ctes (ksWorkUnitsCompleted_update f s) = not_recursive_ctes s"
+  by (simp add: not_recursive_ctes_def)
+
+lemma not_recursive_ctes_irq_state_independent[simp, intro!]:
+  "not_recursive_ctes (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := x \<rparr>\<rparr>) = not_recursive_ctes s"
+  by (simp add: not_recursive_ctes_def)
+
 lemma capSwap_not_recursive:
   "\<lbrace>\<lambda>s. card (not_recursive_ctes s) \<le> n
      \<and> cte_wp_at' (\<lambda>cte. \<not> (isZombie (cteCap cte) \<and> capZombiePtr (cteCap cte) = p1)) p1 s
@@ -705,24 +713,6 @@ lemma case_Zombie_assert_fold:
   "(case cap of Zombie ptr zb n \<Rightarrow> haskell_assertE (P ptr) str | _ \<Rightarrow> returnOk ())
        = assertE (isZombie cap \<longrightarrow> P (capZombiePtr cap))"
   by (cases cap, simp_all add: isCap_simps assertE_def)
-
-lemma not_recursive_ctes_wu [simp]:
-  "not_recursive_ctes (ksWorkUnitsCompleted_update f s) = not_recursive_ctes s"
-  by (simp add: not_recursive_ctes_def)
-
-lemma not_recursive_ctes_irq_state_independent[simp, intro!]:
-  "not_recursive_ctes (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := x \<rparr>\<rparr>) = not_recursive_ctes s"
-  by (simp add: not_recursive_ctes_def)
-
-lemma typ_at'_irq_state_independent[simp, intro!]:
-  "P (typ_at' T p (s \<lparr>ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr>\<rparr>))
-   = P (typ_at' T p s)"
-  by (simp add: typ_at'_def)
-
-lemma sch_act_simple_irq_state_independent[intro!, simp]:
-  "sch_act_simple (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr> \<rparr>) =
-   sch_act_simple s"
-  by (simp add: sch_act_simple_def)
 
 termination finaliseSlot'
   apply (rule finaliseSlot'.termination,
@@ -5835,14 +5825,6 @@ lemmas setThreadState_cap_to'[wp]
 crunch cap_to'[wp]: cancelSignal "ex_cte_cap_wp_to' P p"
   (simp: crunch_simps wp: crunch_wps)
 
-lemma ex_cte_cap_wp_to'_ksReadyQueuesL1Bitmap[simp]:
-   "ex_cte_cap_wp_to' P p (s\<lparr> ksReadyQueuesL1Bitmap := x \<rparr>) = ex_cte_cap_wp_to' P p s"
-   unfolding ex_cte_cap_wp_to'_def by simp
-
-lemma ex_cte_cap_wp_to'_ksReadyQueuesL2Bitmap[simp]:
-   "ex_cte_cap_wp_to' P p (s\<lparr> ksReadyQueuesL2Bitmap := x \<rparr>) = ex_cte_cap_wp_to' P p s"
-   unfolding ex_cte_cap_wp_to'_def by simp
-
 lemma emptySlot_deletes [wp]:
   "\<lbrace>\<top>\<rbrace> emptySlot p opt \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. cteCap c = NullCap) p s\<rbrace>"
   apply (simp add: emptySlot_def case_Null_If)
@@ -6119,14 +6101,6 @@ lemmas preemptionPoint_invR =
 
 lemmas preemptionPoint_invE =
   valid_validE_E [OF preemptionPoint_inv]
-
-lemma sch_act_simple_wu [simp, intro!]:
-  "sch_act_simple (ksWorkUnitsCompleted_update f s) = sch_act_simple s"
-  by (simp add: sch_act_simple_def)
-
-lemma ex_cte_cap_to'_wu [simp, intro!]:
-  "ex_cte_cap_to' p (ksWorkUnitsCompleted_update f s) = ex_cte_cap_to' p s"
-  by (simp add: ex_cte_cap_to'_def)
 
 lemma finaliseSlot_invs':
   assumes finaliseCap:

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -1306,7 +1306,7 @@ lemma weak_derived_updateCapData:
   apply (clarsimp simp: Let_def isCap_simps updateCapData_def)
   done
 
-lemma maskCapRights_Reply:
+lemma maskCapRights_Reply[simp]:
   "isReplyCap (maskCapRights r c) = isReplyCap c"
   apply (insert capMasterCap_maskCapRights)
   apply (rule master_eqI, rule isCap_Master)

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -772,7 +772,7 @@ lemma setObject_cte_obj_at_tcb':
   \<lbrace>\<lambda>_ s. P' (obj_at' P p s)\<rbrace>"
   apply (clarsimp simp: setObject_def in_monad split_def
                         valid_def lookupAround2_char1
-                        obj_at'_def ps_clear_upd' projectKOs
+                        obj_at'_def ps_clear_upd projectKOs
              split del: if_split)
   apply (clarsimp elim!: rsubst[where P=P'])
   apply (clarsimp simp: updateObject_cte in_monad objBits_simps

--- a/proof/refine/ARM/CSpace_R.thy
+++ b/proof/refine/ARM/CSpace_R.thy
@@ -2527,10 +2527,10 @@ lemma setCTE_ko_wp_at_live[wp]:
                  elim!: rsubst[where P=P])
   apply (drule(1) updateObject_cte_is_tcb_or_cte [OF _ refl, rotated])
   apply (elim exE conjE disjE)
-   apply (clarsimp simp: ps_clear_upd' objBits_simps
+   apply (clarsimp simp: ps_clear_upd objBits_simps
                          lookupAround2_char1)
    apply (simp add: tcb_cte_cases_def split: if_split_asm)
-  apply (clarsimp simp: ps_clear_upd' objBits_simps)
+  apply (clarsimp simp: ps_clear_upd objBits_simps)
   done
 
 lemma setCTE_iflive':
@@ -2588,10 +2588,10 @@ lemma setCTE_ko_wp_at_not_live[wp]:
                  elim!: rsubst[where P=P])
   apply (drule(1) updateObject_cte_is_tcb_or_cte [OF _ refl, rotated])
   apply (elim exE conjE disjE)
-   apply (clarsimp simp: ps_clear_upd' objBits_simps
+   apply (clarsimp simp: ps_clear_upd objBits_simps
                          lookupAround2_char1)
    apply (simp add: tcb_cte_cases_def split: if_split_asm)
-  apply (clarsimp simp: ps_clear_upd' objBits_simps)
+  apply (clarsimp simp: ps_clear_upd objBits_simps)
   done
 
 lemma setUntypedCapAsFull_ko_wp_not_at'[wp]:

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -85,10 +85,6 @@ lemma descendants_range_inD':
   done
 end
 
-interpretation clear_um:
-  p_arch_idle_update_int_eq "clear_um S"
-  by unfold_locales (simp_all add: clear_um_def)
-
 context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma descendants_range'_def2:
@@ -1476,7 +1472,7 @@ proof (simp add: invs'_def valid_state'_def valid_pspace'_def
     done
 
   from sa_simp ctnotinQ
-  show "ct_not_inQ ?state''"
+  show "ct_not_inQ state'"
     apply (clarsimp simp: ct_not_inQ_def pred_tcb_at'_def)
     apply (drule obj_at'_and
                    [THEN iffD2, OF conjI,
@@ -1489,7 +1485,7 @@ proof (simp add: invs'_def valid_state'_def valid_pspace'_def
     apply (clarsimp dest!: ex_nonz_cap_notRange)
     done
 
-  from ctcd show "ct_idle_or_in_cur_domain' ?state''"
+  from ctcd show "ct_idle_or_in_cur_domain' state'"
     apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
     apply (intro impI)
     apply (elim disjE impE)
@@ -1658,13 +1654,6 @@ lemma deleteObjects_st_tcb_at':
   apply (simp add: delete_locale_def)
   done
 
-lemma ex_cte_cap_wp_to'_gsCNodes_update[simp]:
-  "ex_cte_cap_wp_to' P p (gsCNodes_update f s') = ex_cte_cap_wp_to' P p s'"
-  by (simp add: ex_cte_cap_wp_to'_def)
-lemma ex_cte_cap_wp_to'_gsUserPages_update[simp]:
-  "ex_cte_cap_wp_to' P p (gsUserPages_update f s') = ex_cte_cap_wp_to' P p s'"
-  by (simp add: ex_cte_cap_wp_to'_def)
-
 lemma deleteObjects_cap_to':
   "\<lbrace>cte_wp_at' (\<lambda>c. cteCap c = UntypedCap d ptr bits idx) p
      and invs' and ct_active' and sch_act_simple
@@ -1712,19 +1701,6 @@ lemma valid_untyped_no_overlap:
     apply (clarsimp simp:p_assoc_help)
    apply fastforce+
   done
-
-lemma pspace_no_overlap'_gsCNodes_update[simp]:
-  "pspace_no_overlap' p b (gsCNodes_update f s') = pspace_no_overlap' p b s'"
-  by (simp add: pspace_no_overlap'_def)
-
-lemma pspace_no_overlap'_gsUserPages_update[simp]:
-  "pspace_no_overlap' p b (gsUserPages_update f s') = pspace_no_overlap' p b s'"
-  by (simp add: pspace_no_overlap'_def)
-
-lemma pspace_no_overlap'_ksMachineState_update[simp]:
-  "pspace_no_overlap' p n (ksMachineState_update f s) =
-   pspace_no_overlap' p n s"
-  by (simp add: pspace_no_overlap'_def)
 
 lemma deleteObject_no_overlap[wp]:
   "\<lbrace>valid_cap' (UntypedCap d ptr bits idx) and valid_pspace'\<rbrace>
@@ -3718,11 +3694,6 @@ lemma new_cap_object_comm_helper:
   apply (drule_tac x = "parent " in spec)
    apply clarsimp
   done
-
-lemma pspace_no_overlap_gsUntypedZeroRanges[simp]:
-  "pspace_no_overlap' ptr n (gsUntypedZeroRanges_update f s)
-    = pspace_no_overlap' ptr n s"
-  by (simp add: pspace_no_overlap'_def)
 
 crunch pspace_aligned'[wp]: updateNewFreeIndex "pspace_aligned'"
 crunch pspace_distinct'[wp]: updateNewFreeIndex "pspace_distinct'"

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -2330,10 +2330,6 @@ lemma finaliseCap_True_invs[wp]:
 
 crunch invs'[wp]: flushSpace "invs'" (ignore: doMachineOp)
 
-lemma ct_not_inQ_ksArchState_update[simp]:
-  "ct_not_inQ (s\<lparr>ksArchState := v\<rparr>) = ct_not_inQ s"
-  by (simp add: ct_not_inQ_def)
-
 lemma invs_asid_update_strg':
   "invs' s \<and> tab = armKSASIDTable (ksArchState s) \<longrightarrow>
    invs' (s\<lparr>ksArchState := armKSASIDTable_update
@@ -3650,10 +3646,6 @@ crunch ct__in_cur_domain'[wp]: copyGlobalMappings ct_idle_or_in_cur_domain'
 
 crunch gsUntypedZeroRanges[wp]: copyGlobalMappings "\<lambda>s. P (gsUntypedZeroRanges s)"
   (wp: crunch_wps)
-
-lemma ct_in_current_domain_ArchState_update[simp]:
-  "ct_idle_or_in_cur_domain' (s\<lparr>ksArchState := v\<rparr>) = ct_idle_or_in_cur_domain' s"
-  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
 
 lemma threadSet_ct_idle_or_in_cur_domain':
   "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>

--- a/proof/refine/ARM/InterruptAcc_R.thy
+++ b/proof/refine/ARM/InterruptAcc_R.thy
@@ -118,31 +118,25 @@ lemma preemptionPoint_inv:
           | simp)+
   done
 
-lemma invs'_wu [simp, intro!]:
-  "invs' (ksWorkUnitsCompleted_update f s) = invs' s"
-  apply (simp add: invs'_def cur_tcb'_def valid_state'_def Invariants_H.valid_queues_def
-                   valid_queues'_def valid_irq_node'_def valid_machine_state'_def
-                   ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                   bitmapQ_defs valid_queues_no_bitmap_def)
-  done
+lemma ct_running_irq_state_independent[intro!, simp]:
+  "ct_running (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
+   = ct_running s"
+  by (simp add: ct_in_state_def)
 
-lemma ct_in_state'_irq_state_independent [simp, intro!]:
-  "ct_in_state' x (s\<lparr>ksMachineState := ksMachineState s
-                          \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>) =
-   ct_in_state' x s"
-  by (simp add: ct_in_state'_def irq_state_independent_H_def)+
+lemma ct_idle_irq_state_independent[intro!, simp]:
+  "ct_idle (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
+   = ct_idle s"
+  by (simp add: ct_in_state_def)
 
-lemma ex_cte_cap_wp_to'_irq_state_independent [simp, intro!]:
-  "ex_cte_cap_wp_to' x y (s\<lparr>ksMachineState := ksMachineState s
-                          \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>) =
-   ex_cte_cap_wp_to' x y s"
-  by (simp add: ex_cte_cap_wp_to'_def irq_state_independent_H_def)+
+lemma typ_at'_irq_state_independent[simp, intro!]:
+  "P (typ_at' T p (s \<lparr>ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr>\<rparr>))
+   = P (typ_at' T p s)"
+  by (simp add: typ_at'_def)
 
-lemma ps_clear_irq_state_independent [simp, intro!]:
-  "ps_clear a b (s\<lparr>ksMachineState := ksMachineState s
-                    \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>) =
-   ps_clear a b s"
-  by (simp add: ps_clear_def)
+lemma sch_act_simple_irq_state_independent[intro!, simp]:
+  "sch_act_simple (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr> \<rparr>) =
+   sch_act_simple s"
+  by (simp add: sch_act_simple_def)
 
 lemma invs'_irq_state_independent [simp, intro!]:
   "invs' (s\<lparr>ksMachineState := ksMachineState s

--- a/proof/refine/ARM/Interrupt_R.thy
+++ b/proof/refine/ARM/Interrupt_R.thy
@@ -434,18 +434,11 @@ lemma isnt_irq_handler_strg:
   "(\<not> isIRQHandlerCap cap) \<longrightarrow> (\<forall>irq. cap = IRQHandlerCap irq \<longrightarrow> P irq)"
   by (clarsimp simp: isCap_simps)
 
-lemma ct_in_current_domain_ksMachineState:
-  "ct_idle_or_in_cur_domain' (ksMachineState_update p s) = ct_idle_or_in_cur_domain' s"
-  apply (simp add:ct_idle_or_in_cur_domain'_def)
-  apply (simp add:tcb_in_cur_domain'_def)
-  done
-
 lemma invoke_arch_irq_handler_invs'[wp]:
   "\<lbrace>invs' and irq_handler_inv_valid' i\<rbrace> ARM_H.invokeIRQHandler i \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (cases i; wpsimp wp: dmo_maskInterrupt simp: ARM_H.invokeIRQHandler_def)
   apply (clarsimp simp: invs'_def valid_state'_def valid_irq_masks'_def
-                        valid_machine_state'_def ct_not_inQ_def
-                        ct_in_current_domain_ksMachineState)
+                        valid_machine_state'_def ct_not_inQ_def)
   done
 
 lemma invoke_irq_handler_invs'[wp]:
@@ -472,9 +465,6 @@ lemma IRQHandler_valid':
   "(s' \<turnstile>' IRQHandlerCap irq) = (irq \<le> maxIRQ)"
   by (simp add: valid_cap'_def capAligned_def word_bits_conv)
 
-lemma valid_mdb_interrupts'[simp]:
-  "valid_mdb' (ksInterruptState_update f s) = valid_mdb' s"
-  by (simp add: valid_mdb'_def)
 crunch valid_mdb'[wp]: setIRQState "valid_mdb'"
 crunch cte_wp_at[wp]: setIRQState "cte_wp_at' P p"
 
@@ -627,23 +617,12 @@ lemma dec_domain_time_corres:
   apply (clarsimp simp:state_relation_def)
   done
 
-lemma weak_sch_act_wf_updateDomainTime[simp]:
-  "weak_sch_act_wf m (s\<lparr>ksDomainTime := t\<rparr>)
-   = weak_sch_act_wf m s"
-  by (simp add:weak_sch_act_wf_def tcb_in_cur_domain'_def )
-
 lemma tcbSchedAppend_valid_objs':
   "\<lbrace>valid_objs'\<rbrace>tcbSchedAppend t \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
   apply (simp add:tcbSchedAppend_def)
-  apply (wp hoare_unless_wp
-    threadSet_valid_objs' threadGet_wp
-    | simp add:valid_tcb_tcbQueued)+
+  apply (wpsimp wp: hoare_unless_wp threadSet_valid_objs' threadGet_wp)
   apply (clarsimp simp add:obj_at'_def typ_at'_def)
   done
-
-lemma valid_tcb_tcbTimeSlice_update[simp]:
-  "valid_tcb' (tcbTimeSlice_update (\<lambda>_. timeSlice) tcb) s = valid_tcb' tcb s"
-  by (simp add:valid_tcb'_def tcb_cte_cases_def)
 
 lemma thread_state_case_if:
  "(case state of Structures_A.thread_state.Running \<Rightarrow> f | _ \<Rightarrow> g) =
@@ -806,24 +785,6 @@ lemma handle_interrupt_corres:
    apply clarsimp
   apply clarsimp
   done
-
-lemma ksDomainTime_invs[simp]:
-  "invs' (a\<lparr>ksDomainTime := t\<rparr>) = invs' a"
-  by (simp add:invs'_def valid_state'_def
-    cur_tcb'_def ct_not_inQ_def ct_idle_or_in_cur_domain'_def
-    tcb_in_cur_domain'_def valid_machine_state'_def)
-
-lemma valid_machine_state'_ksDomainTime[simp]:
-  "valid_machine_state' (a\<lparr>ksDomainTime := t\<rparr>) = valid_machine_state' a"
-  by (simp add:valid_machine_state'_def)
-
-lemma cur_tcb'_ksDomainTime[simp]:
-  "cur_tcb' (a\<lparr>ksDomainTime := 0\<rparr>) = cur_tcb' a"
-  by (simp add:cur_tcb'_def)
-
-lemma ct_idle_or_in_cur_domain'_ksDomainTime[simp]:
-  "ct_idle_or_in_cur_domain' (a\<lparr>ksDomainTime := t \<rparr>) = ct_idle_or_in_cur_domain' a"
-  by (simp add:ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
 
 lemma threadSet_ksDomainTime[wp]:
   "\<lbrace>\<lambda>s. P (ksDomainTime s)\<rbrace> threadSet f ptr \<lbrace>\<lambda>rv s. P (ksDomainTime s)\<rbrace>"

--- a/proof/refine/ARM/InvariantUpdates_H.thy
+++ b/proof/refine/ARM/InvariantUpdates_H.thy
@@ -1,0 +1,372 @@
+(*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory InvariantUpdates_H
+imports Invariants_H
+begin
+
+(* FIXME: use locales to shorten this work *)
+
+lemma ps_clear_domE[elim?]:
+  "\<lbrakk> ps_clear x n s; dom (ksPSpace s) = dom (ksPSpace s') \<rbrakk> \<Longrightarrow> ps_clear x n s'"
+  by (simp add: ps_clear_def)
+
+lemma ps_clear_upd:
+  "ksPSpace s y = Some v \<Longrightarrow>
+    ps_clear x n (ksPSpace_update (\<lambda>a. ksPSpace s(y \<mapsto> v')) s') = ps_clear x n s"
+  by (rule iffI | clarsimp elim!: ps_clear_domE | fastforce)+
+
+lemmas ps_clear_updE[elim] = iffD2[OF ps_clear_upd, rotated]
+
+lemma ct_not_inQ_ksMachineState_update[simp]:
+  "ct_not_inQ (ksMachineState_update f s) = ct_not_inQ s"
+  by (simp add: ct_not_inQ_def)
+
+lemma ct_in_current_domain_ksMachineState[simp]:
+  "ct_idle_or_in_cur_domain' (ksMachineState_update p s) = ct_idle_or_in_cur_domain' s"
+  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+
+lemma invs'_machine:
+  assumes mask: "irq_masks (f (ksMachineState s)) =
+                 irq_masks (ksMachineState s)"
+  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
+                valid_machine_state' s"
+  shows "invs' (ksMachineState_update f s) = invs' s"
+proof -
+  show ?thesis
+    apply (cases "ksSchedulerAction s")
+    apply (simp_all add: invs'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
+                    vms ct_not_inQ_def
+                    state_refs_of'_def ps_clear_def
+                    valid_irq_node'_def mask
+              cong: option.case_cong)
+    done
+qed
+
+lemma invs_no_cicd'_machine:
+  assumes mask: "irq_masks (f (ksMachineState s)) =
+                 irq_masks (ksMachineState s)"
+  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
+                valid_machine_state' s"
+  shows "invs_no_cicd' (ksMachineState_update f s) = invs_no_cicd' s"
+proof -
+  show ?thesis
+    apply (cases "ksSchedulerAction s")
+    apply (simp_all add: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
+                    vms ct_not_inQ_def
+                    state_refs_of'_def ps_clear_def
+                    valid_irq_node'_def mask
+              cong: option.case_cong)
+    done
+qed
+
+lemma pspace_no_overlap_queues [simp]:
+  "pspace_no_overlap' w sz (ksReadyQueues_update f s) = pspace_no_overlap' w sz s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap'_ksSchedulerAction[simp]:
+  "pspace_no_overlap' a b (ksSchedulerAction_update f s) =
+   pspace_no_overlap' a b s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma ksReadyQueues_update_id[simp]:
+  "ksReadyQueues_update id s = s"
+  by simp
+
+lemma ct_not_inQ_ksReadyQueues_update[simp]:
+  "ct_not_inQ (ksReadyQueues_update f s) = ct_not_inQ s"
+  by (simp add: ct_not_inQ_def)
+
+lemma inQ_context[simp]:
+  "inQ d p (tcbArch_update f tcb) = inQ d p tcb"
+  by (cases tcb, simp add: inQ_def)
+
+lemma valid_tcb'_tcbQueued[simp]:
+  "valid_tcb' (tcbQueued_update f tcb) = valid_tcb' tcb"
+  by (cases tcb, rule ext, simp add: valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_tcb'_tcbFault_update[simp]:
+  "valid_tcb' tcb s \<Longrightarrow> valid_tcb' (tcbFault_update f tcb) s"
+  by (clarsimp simp: valid_tcb'_def  tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_tcb'_tcbTimeSlice_update[simp]:
+  "valid_tcb' (tcbTimeSlice_update f tcb) s = valid_tcb' tcb s"
+  by (simp add:valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_queues_ksSchedulerAction_update[simp]:
+  "valid_queues (ksSchedulerAction_update f s) = valid_queues s"
+ unfolding valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
+ by simp
+
+lemma valid_queues'_ksSchedulerAction_update[simp]:
+  "valid_queues' (ksSchedulerAction_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma ex_cte_cap_wp_to'_gsCNodes_update[simp]:
+  "ex_cte_cap_wp_to' P p (gsCNodes_update f s') = ex_cte_cap_wp_to' P p s'"
+  by (simp add: ex_cte_cap_wp_to'_def)
+lemma ex_cte_cap_wp_to'_gsUserPages_update[simp]:
+  "ex_cte_cap_wp_to' P p (gsUserPages_update f s') = ex_cte_cap_wp_to' P p s'"
+  by (simp add: ex_cte_cap_wp_to'_def)
+
+lemma pspace_no_overlap'_gsCNodes_update[simp]:
+  "pspace_no_overlap' p b (gsCNodes_update f s') = pspace_no_overlap' p b s'"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap'_gsUserPages_update[simp]:
+  "pspace_no_overlap' p b (gsUserPages_update f s') = pspace_no_overlap' p b s'"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap'_ksMachineState_update[simp]:
+  "pspace_no_overlap' p n (ksMachineState_update f s) =
+   pspace_no_overlap' p n s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap_gsUntypedZeroRanges[simp]:
+  "pspace_no_overlap' ptr n (gsUntypedZeroRanges_update f s)
+    = pspace_no_overlap' ptr n s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma vms'_ct[simp]:
+  "valid_machine_state' (ksCurThread_update f s) = valid_machine_state' s"
+  by (simp add: valid_machine_state'_def)
+
+lemma tcb_in_cur_domain_ct[simp]:
+  "tcb_in_cur_domain' t  (ksCurThread_update f s) = tcb_in_cur_domain' t s"
+  by (fastforce simp: tcb_in_cur_domain'_def)
+
+lemma valid_queues'_ksCurDomain[simp]:
+  "valid_queues' (ksCurDomain_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksDomScheduleIdx[simp]:
+  "valid_queues' (ksDomScheduleIdx_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksDomSchedule[simp]:
+  "valid_queues' (ksDomSchedule_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksDomainTime[simp]:
+  "valid_queues' (ksDomainTime_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksWorkUnitsCompleted[simp]:
+  "valid_queues' (ksWorkUnitsCompleted_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues_ksCurDomain[simp]:
+  "valid_queues (ksCurDomain_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksDomScheduleIdx[simp]:
+  "valid_queues (ksDomScheduleIdx_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksDomSchedule[simp]:
+  "valid_queues (ksDomSchedule_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksDomainTime[simp]:
+  "valid_queues (ksDomainTime_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksWorkUnitsCompleted[simp]:
+  "valid_queues (ksWorkUnitsCompleted_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_irq_node'_ksCurDomain[simp]:
+  "valid_irq_node' w (ksCurDomain_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksDomScheduleIdx[simp]:
+  "valid_irq_node' w (ksDomScheduleIdx_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksDomSchedule[simp]:
+  "valid_irq_node' w (ksDomSchedule_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksDomainTime[simp]:
+  "valid_irq_node' w (ksDomainTime_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksWorkUnitsCompleted[simp]:
+  "valid_irq_node' w (ksWorkUnitsCompleted_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma ex_cte_cap_wp_to_work_units[simp]:
+  "ex_cte_cap_wp_to' P slot (ksWorkUnitsCompleted_update f s)
+    = ex_cte_cap_wp_to' P slot s"
+  by (simp add: ex_cte_cap_wp_to'_def)
+
+add_upd_simps "ct_in_state' P (gsUntypedZeroRanges_update f s)"
+declare upd_simps[simp]
+
+lemma ct_not_inQ_ksArchState_update[simp]:
+  "ct_not_inQ (ksArchState_update f s) = ct_not_inQ s"
+  by (simp add: ct_not_inQ_def)
+
+lemma ct_in_current_domain_ArchState_update[simp]:
+  "ct_idle_or_in_cur_domain' (ksArchState_update f s) = ct_idle_or_in_cur_domain' s"
+  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+
+lemma pspace_no_overlap_queuesL1 [simp]:
+  "pspace_no_overlap' w sz (ksReadyQueuesL1Bitmap_update f s) = pspace_no_overlap' w sz s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap_queuesL2 [simp]:
+  "pspace_no_overlap' w sz (ksReadyQueuesL2Bitmap_update f s) = pspace_no_overlap' w sz s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma tcb_in_cur_domain'_ksSchedulerAction_update[simp]:
+  "tcb_in_cur_domain' t (ksSchedulerAction_update f s) = tcb_in_cur_domain' t s"
+  by (simp add: tcb_in_cur_domain'_def)
+
+lemma ct_idle_or_in_cur_domain'_ksSchedulerAction_update[simp]:
+  "b \<noteq> ResumeCurrentThread \<Longrightarrow>
+   ct_idle_or_in_cur_domain' (s\<lparr>ksSchedulerAction := b\<rparr>)"
+  apply (clarsimp simp add: ct_idle_or_in_cur_domain'_def)
+  done
+
+lemma sch_act_simple_wu [simp, intro!]:
+  "sch_act_simple (ksWorkUnitsCompleted_update f s) = sch_act_simple s"
+  by (simp add: sch_act_simple_def)
+
+lemma sch_act_simple_ksPSpace_update[simp]:
+  "sch_act_simple (ksPSpace_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma ps_clear_ksReadyQueue[simp]:
+  "ps_clear x n (ksReadyQueues_update f s) = ps_clear x n s"
+  by (simp add: ps_clear_def)
+
+lemma inQ_tcbIPCBuffer_update_idem[simp]:
+  "inQ d p (tcbIPCBuffer_update f ko) = inQ d p ko"
+  by (clarsimp simp: inQ_def)
+
+lemma valid_mdb_interrupts'[simp]:
+  "valid_mdb' (ksInterruptState_update f s) = valid_mdb' s"
+  by (simp add: valid_mdb'_def)
+
+lemma vms_ksReadyQueues_update[simp]:
+  "valid_machine_state' (ksReadyQueues_update f s) = valid_machine_state' s"
+  by (simp add: valid_machine_state'_def)
+
+lemma ct_in_state'_ksMachineState_update[simp]:
+  "ct_in_state' x (ksMachineState_update f s) = ct_in_state' x s"
+  by (simp add: ct_in_state'_def)+
+
+lemma ex_cte_cap_wp_to'_ksMachineState_update[simp]:
+  "ex_cte_cap_wp_to' x y (ksMachineState_update f s) = ex_cte_cap_wp_to' x y s"
+  by (simp add: ex_cte_cap_wp_to'_def)+
+
+lemma ps_clear_ksMachineState_update[simp]:
+  "ps_clear a b (ksMachineState_update f s) = ps_clear a b s"
+  by (simp add: ps_clear_def)
+
+lemma ct_in_state_ksSched[simp]:
+  "ct_in_state' P (ksSchedulerAction_update f s) = ct_in_state' P s"
+  unfolding ct_in_state'_def
+  apply auto
+  done
+
+lemma invs'_wu [simp]:
+  "invs' (ksWorkUnitsCompleted_update f s) = invs' s"
+  apply (simp add: invs'_def cur_tcb'_def valid_state'_def Invariants_H.valid_queues_def
+                   valid_queues'_def valid_irq_node'_def valid_machine_state'_def
+                   ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                   bitmapQ_defs valid_queues_no_bitmap_def)
+  done
+
+lemma valid_arch_state'_interrupt[simp]:
+  "valid_arch_state' (ksInterruptState_update f s) = valid_arch_state' s"
+  by (simp add: valid_arch_state'_def cong: option.case_cong)
+
+lemma valid_bitmapQ_ksSchedulerAction_upd[simp]:
+  "valid_bitmapQ (ksSchedulerAction_update f s) = valid_bitmapQ s"
+  unfolding bitmapQ_defs by simp
+
+lemma bitmapQ_no_L1_orphans_ksSchedulerAction_upd[simp]:
+  "bitmapQ_no_L1_orphans (ksSchedulerAction_update f s) = bitmapQ_no_L1_orphans s"
+  unfolding bitmapQ_defs by simp
+
+lemma bitmapQ_no_L2_orphans_ksSchedulerAction_upd[simp]:
+  "bitmapQ_no_L2_orphans (ksSchedulerAction_update f s) = bitmapQ_no_L2_orphans s"
+  unfolding bitmapQ_defs by simp
+
+lemma cur_tcb'_ksReadyQueuesL1Bitmap_upd[simp]:
+  "cur_tcb' (ksReadyQueuesL1Bitmap_update f s) = cur_tcb' s"
+  unfolding cur_tcb'_def by simp
+
+lemma cur_tcb'_ksReadyQueuesL2Bitmap_upd[simp]:
+  "cur_tcb' (ksReadyQueuesL2Bitmap_update f s) = cur_tcb' s"
+  unfolding cur_tcb'_def by simp
+
+lemma ex_cte_cap_wp_to'_ksReadyQueuesL1Bitmap[simp]:
+   "ex_cte_cap_wp_to' P p (ksReadyQueuesL1Bitmap_update f s) = ex_cte_cap_wp_to' P p s"
+   unfolding ex_cte_cap_wp_to'_def by simp
+
+lemma ex_cte_cap_wp_to'_ksReadyQueuesL2Bitmap[simp]:
+   "ex_cte_cap_wp_to' P p (ksReadyQueuesL2Bitmap_update f s) = ex_cte_cap_wp_to' P p s"
+   unfolding ex_cte_cap_wp_to'_def by simp
+
+lemma sch_act_simple_readyQueue[simp]:
+  "sch_act_simple (ksReadyQueues_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma sch_act_simple_ksReadyQueuesL1Bitmap[simp]:
+  "sch_act_simple (ksReadyQueuesL1Bitmap_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma sch_act_simple_ksReadyQueuesL2Bitmap[simp]:
+  "sch_act_simple (ksReadyQueuesL2Bitmap_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma ksDomainTime_invs[simp]:
+  "invs' (ksDomainTime_update f s) = invs' s"
+  by (simp add:invs'_def valid_state'_def
+    cur_tcb'_def ct_not_inQ_def ct_idle_or_in_cur_domain'_def
+    tcb_in_cur_domain'_def valid_machine_state'_def)
+
+lemma valid_machine_state'_ksDomainTime[simp]:
+  "valid_machine_state' (ksDomainTime_update f s) = valid_machine_state' s"
+  by (simp add:valid_machine_state'_def)
+
+lemma cur_tcb'_ksDomainTime[simp]:
+  "cur_tcb' (ksDomainTime_update f s) = cur_tcb' s"
+  by (simp add:cur_tcb'_def)
+
+lemma ct_idle_or_in_cur_domain'_ksDomainTime[simp]:
+  "ct_idle_or_in_cur_domain' (ksDomainTime_update f s) = ct_idle_or_in_cur_domain' s"
+  by (simp add:ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+
+lemma sch_act_sane_ksMachineState[simp]:
+  "sch_act_sane (ksMachineState_update f s) = sch_act_sane s"
+  by (simp add: sch_act_sane_def)
+
+lemma ct_not_inQ_update_cnt[simp]:
+  "ct_not_inQ (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
+   by (simp add: ct_not_inQ_def)
+
+lemma ct_not_inQ_update_stt[simp]:
+  "ct_not_inQ (s\<lparr>ksSchedulerAction := SwitchToThread t\<rparr>)"
+   by (simp add: ct_not_inQ_def)
+
+lemma invs'_update_cnt[elim!]:
+  "invs' s \<Longrightarrow> invs' (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
+   by (clarsimp simp: invs'_def valid_state'_def valid_queues_def valid_queues'_def
+                      valid_irq_node'_def cur_tcb'_def ct_idle_or_in_cur_domain'_def
+                      tcb_in_cur_domain'_def valid_queues_no_bitmap_def
+                      bitmapQ_no_L2_orphans_def bitmapQ_no_L1_orphans_def)
+
+end

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -2376,7 +2376,7 @@ lemma threadSet_not_tcb[wp]:
                      setObject_def in_monad loadObject_default_def
                      ko_wp_at'_def projectKOs split_def in_magnitude_check
                      objBits_simps' updateObject_default_def
-                     ps_clear_upd' projectKO_opt_tcb)
+                     ps_clear_upd projectKO_opt_tcb)
 
 lemma setThreadState_not_tcb[wp]:
   "\<lbrace>ko_wp_at' (\<lambda>x. P x \<and> (projectKO_opt x = (None :: tcb option))) p\<rbrace>
@@ -2425,7 +2425,7 @@ lemma setObject_ko_wp_at':
   by (clarsimp simp: setObject_def valid_def in_monad
                      ko_wp_at'_def x split_def n
                      updateObject_default_def
-                     objBits_def[symmetric] ps_clear_upd'
+                     objBits_def[symmetric] ps_clear_upd
                      in_magnitude_check v projectKOs)
 
 lemma rescheduleRequired_unlive:

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -53,6 +53,20 @@ definition valid_inQ_queues :: "KernelStateData_H.kernel_state \<Rightarrow> boo
   "valid_inQ_queues \<equiv>
      \<lambda>s. \<forall>d p. (\<forall>t\<in>set (ksReadyQueues s (d, p)). obj_at' (inQ d p) t s) \<and> distinct (ksReadyQueues s (d, p))"
 
+lemma valid_inQ_queues_ksSchedulerAction_update[simp]:
+  "valid_inQ_queues (ksSchedulerAction_update f s) = valid_inQ_queues s"
+  by (simp add: valid_inQ_queues_def)
+
+lemma valid_inQ_queues_ksReadyQueuesL1Bitmap_upd[simp]:
+  "valid_inQ_queues (ksReadyQueuesL1Bitmap_update f s) = valid_inQ_queues s"
+  unfolding valid_inQ_queues_def
+  by simp
+
+lemma valid_inQ_queues_ksReadyQueuesL2Bitmap_upd[simp]:
+  "valid_inQ_queues (ksReadyQueuesL2Bitmap_update f s) = valid_inQ_queues s"
+  unfolding valid_inQ_queues_def
+  by simp
+
 defs capHasProperty_def:
   "capHasProperty ptr P \<equiv> cte_wp_at' (\<lambda>c. P (cteCap c)) ptr"
 end
@@ -1276,16 +1290,6 @@ lemma threadSet_valid_inQ_queues:
   apply (fastforce)
   done
 
-lemma valid_inQ_queues_ksReadyQueuesL1Bitmap_upd[simp]:
-  "valid_inQ_queues (s\<lparr>ksReadyQueuesL1Bitmap := f\<rparr>) = valid_inQ_queues s"
-  unfolding valid_inQ_queues_def
-  by simp
-
-lemma valid_inQ_queues_ksReadyQueuesL2Bitmap_upd[simp]:
-  "valid_inQ_queues (s\<lparr>ksReadyQueuesL2Bitmap := f\<rparr>) = valid_inQ_queues s"
-  unfolding valid_inQ_queues_def
-  by simp
-
 (* reorder the threadSet before the setQueue, useful for lemmas that don't refer to bitmap *)
 lemma setQueue_after_addToBitmap:
   "(setQueue d p q >>= (\<lambda>rv. (when P (addToBitmap d p)) >>= (\<lambda>rv. threadSet f t))) =
@@ -1322,10 +1326,6 @@ lemma tcbSchedEnqueue_valid_inQ_queues[wp]:
  *)
 definition
   "removeFromBitmap_conceal d p q t \<equiv> when (null [x\<leftarrow>q . x \<noteq> t]) (removeFromBitmap d p)"
-
-lemma valid_inQ_queues_ksSchedulerAction_update[simp]:
-  "valid_inQ_queues (ksSchedulerAction_update f s) = valid_inQ_queues s"
-  by (simp add: valid_inQ_queues_def)
 
 lemma rescheduleRequired_valid_inQ_queues[wp]:
   "\<lbrace>valid_inQ_queues\<rbrace> rescheduleRequired \<lbrace>\<lambda>_. valid_inQ_queues\<rbrace>"

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -1064,8 +1064,6 @@ crunch typ_at'[wp]: transferCaps "\<lambda>s. P (typ_at' T p s)"
 
 lemmas transferCaps_typ_ats[wp] = typ_at_lifts [OF transferCaps_typ_at']
 
-declare maskCapRights_Reply [simp]
-
 lemma isIRQControlCap_mask [simp]:
   "isIRQControlCap (maskCapRights R c) = isIRQControlCap c"
   apply (case_tac c)
@@ -2038,9 +2036,6 @@ lemma cancelIPC_valid_queues'[wp]:
 
 crunch valid_objs'[wp]: handleFaultReply valid_objs'
 
-lemma valid_tcb'_tcbFault_update[simp]: "\<And>tcb s. valid_tcb' tcb s \<Longrightarrow> valid_tcb' (tcbFault_update f tcb) s"
-  by (clarsimp simp: valid_tcb'_def  tcb_cte_cases_def)
-
 lemma cte_wp_at_is_reply_cap_toI:
   "cte_wp_at ((=) (cap.ReplyCap t False rights)) ptr s
    \<Longrightarrow> cte_wp_at (is_reply_cap_to t) ptr s"
@@ -2315,19 +2310,6 @@ lemmas transferCapsToSlots_pred_tcb_at' =
 crunches doIPCTransfer, possibleSwitchTo
   for pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
   (wp: mapM_wp' crunch_wps simp: zipWithM_x_mapM)
-
-
-(* FIXME move *)
-lemma tcb_in_cur_domain'_ksSchedulerAction_update[simp]:
-  "tcb_in_cur_domain' t (ksSchedulerAction_update f s) = tcb_in_cur_domain' t s"
-by (simp add: tcb_in_cur_domain'_def)
-
-(* FIXME move *)
-lemma ct_idle_or_in_cur_domain'_ksSchedulerAction_update[simp]:
-  "b\<noteq> ResumeCurrentThread \<Longrightarrow>
-   ct_idle_or_in_cur_domain' (s\<lparr>ksSchedulerAction := b\<rparr>)"
-  apply (clarsimp simp add: ct_idle_or_in_cur_domain'_def)
-  done
 
 lemma setSchedulerAction_ct_in_domain:
  "\<lbrace>\<lambda>s. ct_idle_or_in_cur_domain' s

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -188,13 +188,6 @@ lemma updateObject_default_result:
   "(x, s'') \<in> fst (updateObject_default e ko p q n s) \<Longrightarrow> x = injectKO e"
   by (clarsimp simp add: updateObject_default_def in_monad)
 
-lemma ps_clear_upd':
-  "ksPSpace s y = Some v \<Longrightarrow>
-    ps_clear x n (s' \<lparr> ksPSpace := ksPSpace s(y \<mapsto> v')\<rparr>) = ps_clear x n s"
-  by (rule iffI | clarsimp elim!: ps_clear_domE | fastforce)+
-
-lemmas ps_clear_updE'[elim] = iffD2[OF ps_clear_upd', rotated]
-
 lemma obj_at_setObject1:
   assumes R: "\<And>(v::'a::pspace_storable) p q n ko s x s''.
                 (x, s'') \<in> fst (updateObject v ko p q n s) \<Longrightarrow> x = injectKO v"
@@ -235,7 +228,7 @@ lemma obj_at_setObject2:
    apply (clarsimp simp: lookupAround2_char1)
    apply (drule iffD1 [OF project_koType, OF exI])
    apply simp
-  apply (clarsimp simp: ps_clear_upd' lookupAround2_char1)
+  apply (clarsimp simp: ps_clear_upd lookupAround2_char1)
   done
 
 lemma updateObject_ep_eta:
@@ -261,11 +254,11 @@ lemma setObject_typ_at_inv:
   "\<lbrace>typ_at' T p'\<rbrace> setObject p v \<lbrace>\<lambda>r. typ_at' T p'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def)
   apply (clarsimp simp: valid_def typ_at'_def ko_wp_at'_def in_monad
-                        lookupAround2_char1 ps_clear_upd')
+                        lookupAround2_char1 ps_clear_upd)
   apply (drule updateObject_type)
   apply clarsimp
   apply (drule objBits_type)
-  apply (simp add: ps_clear_upd')
+  apply (simp add: ps_clear_upd)
   done
 
 lemma setObject_typ_at_not:
@@ -300,19 +293,19 @@ lemma setObject_cte_wp_at2':
   apply (erule rsubst[where P=P'])
   apply (rule iffI)
    apply (erule disjEI)
-    apply (clarsimp simp: ps_clear_upd' lookupAround2_char1 y)
+    apply (clarsimp simp: ps_clear_upd lookupAround2_char1 y)
    apply (erule exEI [where 'a=word32])
-   apply (clarsimp simp: ps_clear_upd' lookupAround2_char1)
+   apply (clarsimp simp: ps_clear_upd lookupAround2_char1)
    apply (drule(1) x)
     apply (clarsimp simp: lookupAround2_char1 prod_eqI)
    apply (fastforce dest: bspec [OF _ ranI])
   apply (erule disjEI)
-   apply (clarsimp simp: ps_clear_upd' lookupAround2_char1
+   apply (clarsimp simp: ps_clear_upd lookupAround2_char1
                   split: if_split_asm)
    apply (frule updateObject_type)
    apply (case_tac ba, simp_all add: y)[1]
   apply (erule exEI)
-  apply (clarsimp simp: ps_clear_upd' lookupAround2_char1
+  apply (clarsimp simp: ps_clear_upd lookupAround2_char1
                  split: if_split_asm)
   apply (frule updateObject_type)
   apply (case_tac ba, simp_all)
@@ -380,7 +373,7 @@ lemma obj_at_setObject3:
                             setObject_def split_def projectKOs
                             project_inject objBits_def[symmetric]
                             R updateObject_default_def
-                            in_magnitude_check P ps_clear_upd')
+                            in_magnitude_check P ps_clear_upd)
   apply fastforce
   done
 
@@ -398,7 +391,7 @@ lemma setObject_tcb_strongest:
   apply (simp add: setObject_def split_def)
   apply (clarsimp simp: valid_def obj_at'_def split_def in_monad
                         updateObject_default_def projectKOs
-                        ps_clear_upd')
+                        ps_clear_upd)
   done
 
 lemma getObject_obj_at':
@@ -509,7 +502,7 @@ lemma get_ntfn'_valid_ntfn[wp]:
 lemma setObject_distinct[wp]:
   shows     "\<lbrace>pspace_distinct'\<rbrace> setObject p val \<lbrace>\<lambda>rv. pspace_distinct'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_distinct'_def ps_clear_upd'
+                        projectKOs pspace_distinct'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm
                  dest!: updateObject_objBitsKO)
@@ -520,7 +513,7 @@ lemma setObject_distinct[wp]:
 lemma setObject_aligned[wp]:
   shows     "\<lbrace>pspace_aligned'\<rbrace> setObject p val \<lbrace>\<lambda>rv. pspace_aligned'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd'
+                        projectKOs pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm
                  dest!: updateObject_objBitsKO)
@@ -1056,7 +1049,7 @@ lemma setObject_ko_wp_at:
                  elim!: rsubst[where P=P]
              split del: if_split)
   apply (rule iffI)
-   apply (clarsimp simp: n ps_clear_upd' objBits_def[symmetric]
+   apply (clarsimp simp: n ps_clear_upd objBits_def[symmetric]
                   split: if_split_asm)
   apply (clarsimp simp: n project_inject objBits_def[symmetric]
                         ps_clear_upd
@@ -1212,7 +1205,7 @@ lemma setObject_no_0_obj' [wp]:
   "\<lbrace>no_0_obj'\<rbrace> setObject p v \<lbrace>\<lambda>r. no_0_obj'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def)
   apply (clarsimp simp: valid_def no_0_obj'_def ko_wp_at'_def in_monad
-                        lookupAround2_char1 ps_clear_upd')
+                        lookupAround2_char1 ps_clear_upd)
   done
 
 lemma valid_updateCapDataI:

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -173,17 +173,6 @@ lemma updateObject_cte_is_tcb_or_cte:
 
 declare plus_1_less[simp]
 
-lemma ps_clear_domE[elim?]:
-  "\<lbrakk> ps_clear x n s; dom (ksPSpace s) = dom (ksPSpace s') \<rbrakk> \<Longrightarrow> ps_clear x n s'"
-  by (simp add: ps_clear_def)
-
-lemma ps_clear_upd:
-  "ksPSpace s y = Some v \<Longrightarrow>
-    ps_clear x n (ksPSpace_update (\<lambda>a. ksPSpace s(y \<mapsto> v')) s') = ps_clear x n s"
-  by (rule iffI | clarsimp elim!: ps_clear_domE | fastforce)+
-
-lemmas ps_clear_updE[elim] = iffD2[OF ps_clear_upd, rotated]
-
 lemma updateObject_default_result:
   "(x, s'') \<in> fst (updateObject_default e ko p q n s) \<Longrightarrow> x = injectKO e"
   by (clarsimp simp add: updateObject_default_def in_monad)

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -15,7 +15,7 @@ lemma set_ep_valid_duplicate' [wp]:
   setEndpoint ep v  \<lbrace>\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (simp add:setEndpoint_def)
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd'
+                        projectKOs pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = v,simplified])
@@ -33,7 +33,7 @@ lemma set_ntfn_valid_duplicate' [wp]:
   setNotification ep v  \<lbrace>\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (simp add:setNotification_def)
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd'
+                        projectKOs pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = v,simplified])
@@ -51,7 +51,7 @@ lemma setCTE_valid_duplicates'[wp]:
   setCTE p cte \<lbrace>\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (simp add:setCTE_def)
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd'
+                        projectKOs pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = cte,simplified])
@@ -1420,7 +1420,7 @@ lemma set_asid_pool_valid_duplicates'[wp]:
   setObject a (pool::asidpool)
   \<lbrace>\<lambda>r s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd'
+                        projectKOs pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = pool,simplified])

--- a/proof/refine/ARM/Refine.thy
+++ b/proof/refine/ARM/Refine.thy
@@ -324,16 +324,6 @@ lemma do_user_op_invs2:
     do_user_op_invs | simp | force)+
   done
 
-lemma ct_running_irq_state_independent[intro!, simp]:
-  "ct_running (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
-   = ct_running s"
-  by (simp add: ct_in_state_def)
-
-lemma ct_idle_irq_state_independent[intro!, simp]:
-  "ct_idle (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
-   = ct_idle s"
-  by (simp add: ct_in_state_def)
-
 lemmas ext_init_def = ext_init_det_ext_ext_def ext_init_unit_def
 
 lemma valid_list_init[simp]:

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -1188,11 +1188,6 @@ lemma update_gs_simps[simp]:
                                else ups x)"
   by (simp_all add: update_gs_def)
 
-lemma caps_of_state_kheap_ekheap[simp]: "caps_of_state (kheap_update f (ekheap_update ef s)) =
-       caps_of_state (kheap_update f s)"
-  apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-  done
-
 lemma retype_state_relation:
   notes data_map_insert_def[simp del]
   assumes  sr:   "(s, s') \<in> state_relation"

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -804,29 +804,17 @@ lemma setCurThread_invs_no_cicd':
      setCurThread t
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
 proof -
-  have obj_at'_ct: "\<And>f P addr s.
-       obj_at' P addr (ksCurThread_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
-  have valid_pspace'_ct: "\<And>s f.
-       valid_pspace' (ksCurThread_update f s) = valid_pspace' s"
-    by simp
-  have vms'_ct: "\<And>s f.
-       valid_machine_state' (ksCurThread_update f s) = valid_machine_state' s"
-    by (simp add: valid_machine_state'_def)
   have ct_not_inQ_ct: "\<And>s t . \<lbrakk> ct_not_inQ s; obj_at' (\<lambda>x. \<not> tcbQueued x) t s\<rbrakk> \<Longrightarrow> ct_not_inQ (s\<lparr> ksCurThread := t \<rparr>)"
     apply (simp add: ct_not_inQ_def o_def)
     done
-  have tcb_in_cur_domain_ct: "\<And>s f t.
-       tcb_in_cur_domain' t  (ksCurThread_update f s)= tcb_in_cur_domain' t s"
-    by (fastforce simp: tcb_in_cur_domain'_def)
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (clarsimp simp add: all_invs_but_ct_idle_or_in_cur_domain'_def invs'_def cur_tcb'_def valid_state'_def obj_at'_ct
-                              valid_pspace'_ct vms'_ct Invariants_H.valid_queues_def
+    apply (clarsimp simp add: all_invs_but_ct_idle_or_in_cur_domain'_def invs'_def cur_tcb'_def
+                              valid_state'_def Invariants_H.valid_queues_def
                               sch_act_wf ct_in_state'_def state_refs_of'_def
                               ps_clear_def valid_irq_node'_def valid_queues'_def ct_not_inQ_ct
-                              tcb_in_cur_domain_ct ct_idle_or_in_cur_domain'_def
+                              ct_idle_or_in_cur_domain'_def
                               bitmapQ_defs valid_queues_no_bitmap_def
                         cong: option.case_cong)
     done
@@ -914,9 +902,6 @@ lemma idle'_not_tcbQueued':
 lemma setCurThread_invs_no_cicd'_idle_thread:
   "\<lbrace>invs_no_cicd' and (\<lambda>s. t = ksIdleThread s) \<rbrace> setCurThread t \<lbrace>\<lambda>rv. invs'\<rbrace>"
 proof -
-  have vms'_ct: "\<And>s f.
-       valid_machine_state' (ksCurThread_update f s) = valid_machine_state' s"
-    by (simp add: valid_machine_state'_def)
   have ct_not_inQ_ct: "\<And>s t . \<lbrakk> ct_not_inQ s; obj_at' (\<lambda>x. \<not> tcbQueued x) t s\<rbrakk> \<Longrightarrow> ct_not_inQ (s\<lparr> ksCurThread := t \<rparr>)"
     apply (simp add: ct_not_inQ_def o_def)
     done
@@ -926,7 +911,7 @@ proof -
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (clarsimp simp add: vms'_ct ct_not_inQ_ct idle'_activatable' idle'_not_tcbQueued'[simplified o_def]
+    apply (clarsimp simp add: ct_not_inQ_ct idle'_activatable' idle'_not_tcbQueued'[simplified o_def]
                               invs'_def cur_tcb'_def valid_state'_def valid_idle'_def
                               sch_act_wf ct_in_state'_def state_refs_of'_def
                               ps_clear_def valid_irq_node'_def
@@ -1076,25 +1061,20 @@ lemma switchToThread_invs[wp]:
 lemma setCurThread_ct_in_state:
   "\<lbrace>obj_at' (P \<circ> tcbState) t\<rbrace> setCurThread t \<lbrace>\<lambda>rv. ct_in_state' P\<rbrace>"
 proof -
-  have obj_at'_ct: "\<And>P addr f s.
-       obj_at' P addr (ksCurThread_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (simp add: ct_in_state'_def pred_tcb_at'_def obj_at'_ct o_def)
+    apply (simp add: ct_in_state'_def pred_tcb_at'_def o_def)
     done
 qed
 
 lemma switchToThread_ct_in_state[wp]:
   "\<lbrace>obj_at' (P \<circ> tcbState) t\<rbrace> switchToThread t \<lbrace>\<lambda>rv. ct_in_state' P\<rbrace>"
 proof -
-  have P: "\<And>f x. tcbState (tcbTimeSlice_update f x) = tcbState x"
-    by (case_tac x, simp)
   show ?thesis
     apply (simp add: Thread_H.switchToThread_def tcbSchedEnqueue_def unless_def)
     apply (wp setCurThread_ct_in_state Arch_switchToThread_obj_at
-         | simp add: P o_def cong: if_cong)+
+         | simp add: o_def cong: if_cong)+
     done
 qed
 
@@ -1478,14 +1458,6 @@ lemma corres_assert_assume_r:
   \<Longrightarrow> corres dc P (Q and (\<lambda>s. Q')) f (assert Q' >>= g)"
   by (force simp: corres_underlying_def assert_def return_def bind_def fail_def)
 
-lemma cur_tcb'_ksReadyQueuesL1Bitmap_upd[simp]:
-  "cur_tcb' (s\<lparr>ksReadyQueuesL1Bitmap := x\<rparr>) = cur_tcb' s"
-  unfolding cur_tcb'_def by simp
-
-lemma cur_tcb'_ksReadyQueuesL2Bitmap_upd[simp]:
-  "cur_tcb' (s\<lparr>ksReadyQueuesL2Bitmap := x\<rparr>) = cur_tcb' s"
-  unfolding cur_tcb'_def by simp
-
 crunch cur[wp]: tcbSchedEnqueue cur_tcb'
   (simp: unless_def)
 
@@ -1674,66 +1646,6 @@ lemma next_domain_corres:
   apply (rule corres_modify)
   apply (simp add: state_relation_def Let_def dschLength_def dschDomain_def)
   done
-
-lemma valid_queues'_ksCurDomain[simp]:
-  "valid_queues' (ksCurDomain_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksDomScheduleIdx[simp]:
-  "valid_queues' (ksDomScheduleIdx_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksDomSchedule[simp]:
-  "valid_queues' (ksDomSchedule_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksDomainTime[simp]:
-  "valid_queues' (ksDomainTime_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksWorkUnitsCompleted[simp]:
-  "valid_queues' (ksWorkUnitsCompleted_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues_ksCurDomain[simp]:
-  "Invariants_H.valid_queues (ksCurDomain_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksDomScheduleIdx[simp]:
-  "Invariants_H.valid_queues (ksDomScheduleIdx_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksDomSchedule[simp]:
-  "Invariants_H.valid_queues (ksDomSchedule_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksDomainTime[simp]:
-  "Invariants_H.valid_queues (ksDomainTime_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksWorkUnitsCompleted[simp]:
-  "Invariants_H.valid_queues (ksWorkUnitsCompleted_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_irq_node'_ksCurDomain[simp]:
-  "valid_irq_node' w (ksCurDomain_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksDomScheduleIdx[simp]:
-  "valid_irq_node' w (ksDomScheduleIdx_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksDomSchedule[simp]:
-  "valid_irq_node' w (ksDomSchedule_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksDomainTime[simp]:
-  "valid_irq_node' w (ksDomainTime_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksWorkUnitsCompleted[simp]:
-  "valid_irq_node' w (ksWorkUnitsCompleted_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
 
 lemma next_domain_valid_sched[wp]:
   "\<lbrace> valid_sched and (\<lambda>s. scheduler_action s  = choose_new_thread)\<rbrace> next_domain \<lbrace> \<lambda>_. valid_sched \<rbrace>"
@@ -2001,28 +1913,12 @@ lemma ssa_all_invs_but_ct_not_inQ':
    (\<lambda>s. sa = ResumeCurrentThread \<longrightarrow> ksCurThread s = ksIdleThread s \<or> tcb_in_cur_domain' (ksCurThread s) s)\<rbrace>
    setSchedulerAction sa \<lbrace>\<lambda>rv. all_invs_but_ct_not_inQ'\<rbrace>"
 proof -
-  have obj_at'_sa: "\<And>P addr f s.
-       obj_at' P addr (ksSchedulerAction_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
-  have valid_pspace'_sa: "\<And>f s.
-       valid_pspace' (ksSchedulerAction_update f s) = valid_pspace' s"
-    by simp
-  have iflive_sa: "\<And>f s.
-       if_live_then_nonz_cap' (ksSchedulerAction_update f s)
-         = if_live_then_nonz_cap' s"
-    by fastforce
-  have ifunsafe_sa[simp]: "\<And>f s.
-       if_unsafe_then_cap' (ksSchedulerAction_update f s) = if_unsafe_then_cap' s"
-    by fastforce
-  have idle_sa[simp]: "\<And>f s.
-       valid_idle' (ksSchedulerAction_update f s) = valid_idle' s"
-    by fastforce
   show ?thesis
     apply (simp add: setSchedulerAction_def)
     apply wp
     apply (clarsimp simp add: invs'_def valid_state'_def cur_tcb'_def
-                              obj_at'_sa valid_pspace'_sa Invariants_H.valid_queues_def
-                              state_refs_of'_def iflive_sa ps_clear_def
+                              Invariants_H.valid_queues_def
+                              state_refs_of'_def ps_clear_def
                               valid_irq_node'_def valid_queues'_def
                               tcb_in_cur_domain'_def ct_idle_or_in_cur_domain'_def
                               bitmapQ_defs valid_queues_no_bitmap_def
@@ -2071,13 +1967,10 @@ lemma switchToThread_ct_not_queued_2:
 lemma setCurThread_obj_at':
   "\<lbrace> obj_at' P t \<rbrace> setCurThread t \<lbrace>\<lambda>rv s. obj_at' P (ksCurThread s) s \<rbrace>"
 proof -
-  have obj_at'_ct: "\<And>P addr f s.
-       obj_at' P addr (ksCurThread_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (simp add: ct_in_state'_def st_tcb_at'_def obj_at'_ct)
+    apply (simp add: ct_in_state'_def st_tcb_at'_def)
     done
 qed
 
@@ -2099,16 +1992,11 @@ lemma switchToIdleThread_activatable_2[wp]:
   done
 
 lemma switchToThread_tcb_in_cur_domain':
-  "\<lbrace>tcb_in_cur_domain' thread\<rbrace> ThreadDecls_H.switchToThread thread
-  \<lbrace>\<lambda>y s. tcb_in_cur_domain' (ksCurThread s) s\<rbrace>"
-  apply (simp add: Thread_H.switchToThread_def)
-  apply (rule hoare_pre)
-  apply (wp)
-    apply (simp add: ARM_H.switchToThread_def setCurThread_def)
-    apply (wp tcbSchedDequeue_not_tcbQueued | simp )+
-   apply (simp add:tcb_in_cur_domain'_def)
-   apply (wp tcbSchedDequeue_tcbDomain | wps)+
-  apply (clarsimp simp:tcb_in_cur_domain'_def)
+  "\<lbrace>tcb_in_cur_domain' thread\<rbrace>
+   ThreadDecls_H.switchToThread thread
+   \<lbrace>\<lambda>y s. tcb_in_cur_domain' (ksCurThread s) s\<rbrace>"
+  apply (simp add: Thread_H.switchToThread_def setCurThread_def)
+  apply (wpsimp wp: tcbSchedDequeue_not_tcbQueued)
   done
 
 lemma chooseThread_invs_no_cicd'_posts: (* generic version *)
@@ -2286,13 +2174,10 @@ lemma schedule_sch_act_simple:
 lemma ssa_ct:
   "\<lbrace>ct_in_state' P\<rbrace> setSchedulerAction sa \<lbrace>\<lambda>rv. ct_in_state' P\<rbrace>"
 proof -
-  have obj_at'_sa: "\<And>P addr f s.
-       obj_at' P addr (ksSchedulerAction_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
   show ?thesis
     apply (unfold setSchedulerAction_def)
     apply wp
-    apply (clarsimp simp add: ct_in_state'_def pred_tcb_at'_def obj_at'_sa)
+    apply (clarsimp simp add: ct_in_state'_def pred_tcb_at'_def)
     done
 qed
 

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -9,7 +9,7 @@
 *)
 
 theory StateRelation
-imports Invariants_H
+imports InvariantUpdates_H
 begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -1178,7 +1178,7 @@ lemma setTCB_valid_duplicates'[wp]:
  "\<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace>
   setObject a (tcb::tcb) \<lbrace>\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd'
+                        projectKOs pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = tcb,simplified])

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -280,11 +280,6 @@ lemma msg_from_syserr_map[simp]:
   apply (case_tac err,clarsimp+)
   done
 
-(* FIXME: move *)
-lemma non_exst_same_timeSlice_upd[simp]:
-  "non_exst_same tcb (tcbDomain_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
 lemma threadSet_tcbDomain_update_ct_not_inQ:
   "\<lbrace>ct_not_inQ \<rbrace> threadSet (tcbDomain_update (\<lambda>_. domain)) t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
   apply (simp add: threadSet_def ct_not_inQ_def)
@@ -1820,10 +1815,6 @@ lemma hc_invs'[wp]:
   apply (wp)
   apply (clarsimp)
   done
-
-lemma sch_act_sane_ksMachineState [iff]:
-  "sch_act_sane (s\<lparr>ksMachineState := b\<rparr>) = sch_act_sane s"
-  by (simp add: sch_act_sane_def)
 
 lemma cteInsert_sane[wp]:
   "\<lbrace>sch_act_sane\<rbrace> cteInsert newCap srcSlot destSlot \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -137,54 +137,6 @@ lemma valid_objs'_maxPriority:
   apply (clarsimp simp: valid_tcb'_def)
   done
 
-lemma invs'_machine:
-  assumes mask: "irq_masks (f (ksMachineState s)) =
-                 irq_masks (ksMachineState s)"
-  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
-                valid_machine_state' s"
-  shows "invs' (ksMachineState_update f s) = invs' s"
-proof -
-  have valid_pspace'_machine: "\<And>f s.
-       valid_pspace' (ksMachineState_update f s) = valid_pspace' s"
-    by simp
-  have valid_idle'_machine: "\<And>f s.
-       valid_idle' (ksMachineState_update f s) = valid_idle' s"
-    by fastforce
-  show ?thesis
-    apply (cases "ksSchedulerAction s")
-    apply (simp_all add: invs'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
-                    vms ct_not_inQ_def
-                    state_refs_of'_def ps_clear_def
-                    valid_irq_node'_def mask
-              cong: option.case_cong)
-    done
-qed
-
-lemma invs_no_cicd'_machine:
-  assumes mask: "irq_masks (f (ksMachineState s)) =
-                 irq_masks (ksMachineState s)"
-  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
-                valid_machine_state' s"
-  shows "invs_no_cicd' (ksMachineState_update f s) = invs_no_cicd' s"
-proof -
-  have valid_pspace'_machine: "\<And>f s.
-       valid_pspace' (ksMachineState_update f s) = valid_pspace' s"
-    by simp
-  have valid_idle'_machine: "\<And>f s.
-       valid_idle' (ksMachineState_update f s) = valid_idle' s"
-    by fastforce
-  show ?thesis
-    apply (cases "ksSchedulerAction s")
-    apply (simp_all add: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
-                    vms ct_not_inQ_def
-                    state_refs_of'_def ps_clear_def
-                    valid_irq_node'_def mask
-              cong: option.case_cong)
-    done
-qed
-
 lemma doMachineOp_irq_states':
   assumes masks: "\<And>P. \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks s)\<rbrace>"
   shows "\<lbrace>valid_irq_states'\<rbrace> doMachineOp f \<lbrace>\<lambda>rv. valid_irq_states'\<rbrace>"
@@ -676,15 +628,6 @@ lemma threadSet_pspace_no_overlap' [wp]:
   apply (clarsimp simp: obj_at'_def)
   done
 
-lemma pspace_no_overlap_queues [simp]:
-  "pspace_no_overlap' w sz (ksReadyQueues_update f s) = pspace_no_overlap' w sz s"
-  by (simp add: pspace_no_overlap'_def)
-
-lemma pspace_no_overlap'_ksSchedulerAction[simp]:
-  "pspace_no_overlap' a b (ksSchedulerAction_update f s) =
-   pspace_no_overlap' a b s"
-  by (simp add: pspace_no_overlap'_def)
-
 lemma threadSet_global_refsT:
   assumes x: "\<forall>tcb. \<forall>(getF, setF) \<in> ran tcb_cte_cases.
                  getF (F tcb) = getF tcb"
@@ -989,10 +932,6 @@ lemma threadSet_valid_queues_Qf:
   apply (clarsimp simp: valid_queues'_def subset_iff)
   done
 
-lemma ksReadyQueues_update_id:
-  "ksReadyQueues_update id s = s"
-  by simp
-
 lemma addToQs_subset:
   "set (qs p) \<subseteq> set (addToQs F t qs p)"
 by (clarsimp simp: addToQs_def split_def)
@@ -1237,10 +1176,6 @@ lemma threadSet_vms'[wp]:
   apply (simp add: valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def)
   by (intro hoare_vcg_all_lift hoare_vcg_disj_lift; wp)
 
-lemma ct_not_inQ_ksReadyQueues_update[simp]:
-  "ct_not_inQ (ksReadyQueues_update f s) = ct_not_inQ s"
-  by (simp add: ct_not_inQ_def)
-
 lemma threadSet_not_inQ:
   "\<lbrace>ct_not_inQ and (\<lambda>s. (\<exists>tcb. tcbQueued (F tcb) \<and> \<not> tcbQueued tcb)
                           \<longrightarrow> ksSchedulerAction s = ResumeCurrentThread
@@ -1481,10 +1416,6 @@ lemma asUser_typ_at' [wp]:
   by (simp add: asUser_def bind_assoc split_def, wp select_f_inv)
 
 lemmas asUser_typ_ats[wp] = typ_at_lifts [OF asUser_typ_at']
-
-lemma inQ_context[simp]:
-  "inQ d p (tcbArch_update f tcb) = inQ d p tcb"
-  by (cases tcb, simp add: inQ_def)
 
 lemma asUser_invs[wp]:
   "\<lbrace>invs' and tcb_at' t\<rbrace> asUser t m \<lbrace>\<lambda>rv. invs'\<rbrace>"
@@ -1896,6 +1827,10 @@ definition
 where
  "weak_sch_act_wf sa = (\<lambda>s. \<forall>t. sa = SwitchToThread t \<longrightarrow> st_tcb_at' runnable' t s \<and> tcb_in_cur_domain' t s)"
 
+lemma weak_sch_act_wf_updateDomainTime[simp]:
+  "weak_sch_act_wf m (ksDomainTime_update f s) = weak_sch_act_wf m s"
+  by (simp add:weak_sch_act_wf_def tcb_in_cur_domain'_def )
+
 lemma set_sa_corres:
   "sched_act_relation sa sa'
     \<Longrightarrow> corres dc \<top> \<top> (set_scheduler_action sa) (setSchedulerAction sa')"
@@ -2138,14 +2073,9 @@ lemma sbn_corres:
 crunches rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotification
   for tcb'[wp]: "tcb_at' addr"
 
-lemma valid_tcb_tcbQueued:
-  "valid_tcb' (tcbQueued_update f tcb) = valid_tcb' tcb"
-  by (cases tcb, rule ext, simp add: valid_tcb'_def tcb_cte_cases_def)
-
 crunches rescheduleRequired, removeFromBitmap
   for valid_objs'[wp]: valid_objs'
-  (simp: unless_def valid_tcb_tcbQueued crunch_simps)
-
+  (simp: crunch_simps)
 
 lemma tcbSchedDequeue_valid_objs' [wp]: "\<lbrace> valid_objs' \<rbrace> tcbSchedDequeue t \<lbrace>\<lambda>_. valid_objs' \<rbrace>"
   unfolding tcbSchedDequeue_def
@@ -2878,11 +2808,6 @@ lemma tcbSchedAppend_valid_queues[wp]:
    unfolding tcbSchedAppend_def
    by (fastforce intro:  tcbSchedEnqueueOrAppend_valid_queues)
 
-lemma valid_queues_ksSchedulerAction_update[simp]:
-  "Invariants_H.valid_queues (ksSchedulerAction_update f s) = Invariants_H.valid_queues s"
- unfolding Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
- by simp
-
 lemma rescheduleRequired_valid_queues[wp]:
   "\<lbrace>\<lambda>s. Invariants_H.valid_queues s \<and> valid_objs' s \<and>
         weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
@@ -2900,18 +2825,6 @@ lemma rescheduleRequired_valid_queues_sch_act_simple:
   apply (simp add: rescheduleRequired_def)
   apply (wp | wpc | simp | fastforce simp: Invariants_H.valid_queues_def sch_act_simple_def)+
   done
-
-lemma valid_bitmapQ_ksSchedulerAction_upd[simp]:
-  "valid_bitmapQ (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>) = valid_bitmapQ s"
-  unfolding bitmapQ_defs by simp
-
-lemma bitmapQ_no_L1_orphans_ksSchedulerAction_upd[simp]:
-  "bitmapQ_no_L1_orphans (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>) = bitmapQ_no_L1_orphans s"
-  unfolding bitmapQ_defs by simp
-
-lemma bitmapQ_no_L2_orphans_ksSchedulerAction_upd[simp]:
-  "bitmapQ_no_L2_orphans (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>) = bitmapQ_no_L2_orphans s"
-  unfolding bitmapQ_defs by simp
 
 lemma rescheduleRequired_valid_bitmapQ_sch_act_simple:
   "\<lbrace> valid_bitmapQ and sch_act_simple\<rbrace>
@@ -3043,10 +2956,6 @@ lemma tcbSchedEnqueue_valid_queues'[wp]:
   apply (clarsimp simp: obj_at'_def)
   done
 
-lemma valid_queues'_ksSchedulerAction_update[simp]:
-  "Invariants_H.valid_queues' (ksSchedulerAction_update f s) = Invariants_H.valid_queues' s"
-  by (simp add: valid_queues'_def)
-
 lemma rescheduleRequired_valid_queues'_weak[wp]:
   "\<lbrace>\<lambda>s. valid_queues' s \<and> weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
     rescheduleRequired
@@ -3081,7 +2990,8 @@ lemma setBoundNotification_valid_queues'[wp]:
   apply (fastforce simp: inQ_def obj_at'_def pred_tcb_at'_def)
   done
 
-lemma valid_tcb'_tcbState_update:"\<And>tcb s st . \<lbrakk> valid_tcb_state' st s; valid_tcb' tcb s \<rbrakk> \<Longrightarrow> valid_tcb' (tcbState_update (\<lambda>_. st) tcb) s"
+lemma valid_tcb'_tcbState_update:
+  "\<lbrakk> valid_tcb_state' st s; valid_tcb' tcb s \<rbrakk> \<Longrightarrow> valid_tcb' (tcbState_update (\<lambda>_. st) tcb) s"
   apply (clarsimp simp: valid_tcb'_def tcb_cte_cases_def valid_tcb_state'_def)
   done
 
@@ -4087,14 +3997,6 @@ lemma tcbSchedAppend_ct_not_inQ:
       done
   qed
 
-lemma ct_not_inQ_update_cnt:
-  "ct_not_inQ s \<Longrightarrow> ct_not_inQ (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
-   by (simp add: ct_not_inQ_def)
-
-lemma ct_not_inQ_update_stt:
-  "ct_not_inQ s \<Longrightarrow> ct_not_inQ (s\<lparr>ksSchedulerAction := SwitchToThread t\<rparr>)"
-   by (simp add: ct_not_inQ_def)
-
 lemma setSchedulerAction_direct:
   "\<lbrace>\<top>\<rbrace> setSchedulerAction sa \<lbrace>\<lambda>_ s. ksSchedulerAction s = sa\<rbrace>"
   by (wpsimp simp: setSchedulerAction_def)
@@ -4123,10 +4025,9 @@ lemma possibleSwitchTo_ct_not_inQ:
     possibleSwitchTo t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
   (is "\<lbrace>?PRE\<rbrace> _ \<lbrace>_\<rbrace>")
   apply (simp add: possibleSwitchTo_def curDomain_def)
-  apply (wp static_imp_wp rescheduleRequired_ct_not_inQ tcbSchedEnqueue_ct_not_inQ threadGet_wp
-       | wpc
-       | (rule hoare_post_imp[OF _ rescheduleRequired_sa_cnt], fastforce)
-       | clarsimp simp: ct_not_inQ_update_stt bitmap_fun_defs)+
+  apply (wpsimp wp: static_imp_wp rescheduleRequired_ct_not_inQ tcbSchedEnqueue_ct_not_inQ
+                    threadGet_wp
+       | (rule hoare_post_imp[OF _ rescheduleRequired_sa_cnt], fastforce))+
   apply (fastforce simp: obj_at'_def)
   done
 
@@ -4522,6 +4423,18 @@ where
   "non_exst_same' (KOTCB tcb) (KOTCB tcb') = non_exst_same tcb tcb'" |
   "non_exst_same' _ _ = True"
 
+lemma non_exst_same_prio_upd[simp]:
+  "non_exst_same tcb (tcbPriority_update f tcb)"
+  by (cases tcb, simp add: non_exst_same_def)
+
+lemma non_exst_same_timeSlice_upd[simp]:
+  "non_exst_same tcb (tcbTimeSlice_update f tcb)"
+  by (cases tcb, simp add: non_exst_same_def)
+
+lemma non_exst_same_domain_upd[simp]:
+  "non_exst_same tcb (tcbDomain_update f tcb)"
+  by (cases tcb, simp add: non_exst_same_def)
+
 lemma set_eobject_corres':
   assumes e: "etcb_relation etcb tcb'"
   assumes z: "\<And>s. obj_at' P ptr s
@@ -4622,14 +4535,6 @@ lemma ethread_set_corresT:
 
 lemmas ethread_set_corres =
     ethread_set_corresT [OF _ all_tcbI, OF _ ball_tcb_cte_casesI]
-
-lemma non_exst_same_prio_upd[simp]:
-  "non_exst_same tcb (tcbPriority_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma non_exst_same_timeSlice_upd[simp]:
-  "non_exst_same tcb (tcbTimeSlice_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
 
 lemma archTcbUpdate_aux2: "(\<lambda>tcb. tcb\<lparr> tcbArch := f (tcbArch tcb)\<rparr>) = tcbArch_update f"
   by (rule ext, case_tac tcb, simp)

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -702,26 +702,6 @@ lemma out_corresT:
 
 lemmas out_corres = out_corresT [OF _ all_tcbI, OF ball_tcb_cap_casesI ball_tcb_cte_casesI]
 
-lemma sch_act_simple_readyQueue[simp]:
-  "sch_act_simple (s\<lparr>ksReadyQueues := a\<rparr>) = sch_act_simple s"
-  apply (simp add: sch_act_simple_def)
-  done
-
-lemma sch_act_simple_ksReadyQueuesL1Bitmap[simp]:
-  "sch_act_simple (s\<lparr>ksReadyQueuesL1Bitmap := a\<rparr>) = sch_act_simple s"
-  apply (simp add: sch_act_simple_def)
-  done
-
-lemma sch_act_simple_ksReadyQueuesL2Bitmap[simp]:
-  "sch_act_simple (s\<lparr>ksReadyQueuesL2Bitmap := a\<rparr>) = sch_act_simple s"
-  apply (simp add: sch_act_simple_def)
-  done
-
-lemma sch_act_simple_updateObject[simp]:
-  "sch_act_simple (s\<lparr>ksPSpace := a \<rparr>) = sch_act_simple s"
-  apply (simp add: sch_act_simple_def)
-  done
-
 lemma tcbSchedDequeue_sch_act_simple[wp]:
   "tcbSchedDequeue t \<lbrace>sch_act_simple\<rbrace>"
   by (wpsimp simp: sch_act_simple_def)
@@ -750,10 +730,6 @@ lemma setP_vq[wp]:
                   tcbSchedDequeue_not_in_queue tcbSchedEnqueue_valid_objs' tcbSchedDequeue_valid_queues
           | clarsimp simp: valid_objs'_maxDomain valid_objs'_maxPriority)+
   done
-
-lemma ps_clear_ksReadyQueue[simp]:
-  "ps_clear x n (ksReadyQueues_update f s) = ps_clear x n s"
-  by (simp add: ps_clear_def)
 
 lemma valid_queues_subsetE':
   "\<lbrakk> valid_queues' s; ksPSpace s = ksPSpace s';
@@ -798,14 +774,6 @@ lemma setQueue_ex_idle_cap[wp]:
    \<lbrace>\<lambda>rv s. ex_nonz_cap_to' (ksIdleThread s) s\<rbrace>"
   by (simp add: setQueue_def, wp,
       simp add: ex_nonz_cap_to'_def cte_wp_at_pspaceI)
-
-lemma tcbPriority_ts_safe:
-  "tcbState (tcbPriority_update f tcb) = tcbState tcb"
-  by (case_tac tcb, simp)
-
-lemma tcbQueued_ts_safe:
-  "tcbState (tcbQueued_update f tcb) = tcbState tcb"
-  by (case_tac tcb, simp)
 
 lemma tcbPriority_caps_safe:
   "\<forall>tcb. \<forall>x\<in>ran tcb_cte_cases. (\<lambda>(getF, setF). getF (tcbPriority_update f tcb) = getF tcb) x"
@@ -1099,10 +1067,6 @@ lemma assertDerived_wp_weak:
   apply (wpsimp simp: assertDerived_def)
   done
 
-lemma tcbMCP_ts_safe:
-  "tcbState (tcbMCP_update f tcb) = tcbState tcb"
-  by (case_tac tcb, simp)
-
 lemma tcbMCP_caps_safe:
   "\<forall>tcb. \<forall>x\<in>ran tcb_cte_cases. (\<lambda>(getF, setF). getF (tcbMCP_update f tcb) = getF tcb) x"
   by (rule all_tcbI, rule ball_tcb_cte_casesI, simp+)
@@ -1276,10 +1240,6 @@ lemma threadSet_valid_queues'_no_state2:
              split del: if_split cong: if_cong)
   apply (fastforce simp: projectKOs inQ_def split: if_split_asm)
   done
-
-lemma inQ_tcbIPCBuffer_update_idem[simp]:
-  "inQ d p (tcbIPCBuffer_update (\<lambda>_. x) ko) = inQ d p ko"
-  by (clarsimp simp: inQ_def)
 
 lemma getThreadBufferSlot_dom_tcb_cte_cases:
   "\<lbrace>\<top>\<rbrace> getThreadBufferSlot a \<lbrace>\<lambda>rv s. rv \<in> (+) a ` dom tcb_cte_cases\<rbrace>"

--- a/proof/refine/ARM/Untyped_R.thy
+++ b/proof/refine/ARM/Untyped_R.thy
@@ -4385,11 +4385,6 @@ crunch ct_in_state'[wp]: doMachineOp "ct_in_state' P"
 crunch st_tcb_at'[wp]: doMachineOp "st_tcb_at' P p"
   (simp: crunch_simps ct_in_state'_def)
 
-lemma ex_cte_cap_wp_to_work_units[simp]:
-  "ex_cte_cap_wp_to' P slot (ksWorkUnitsCompleted_update f s)
-    = ex_cte_cap_wp_to' P slot s"
-  by (simp add: ex_cte_cap_wp_to'_def)
-
 lemma ex_cte_cap_wp_to_irq_state_independent_H[simp]:
   "irq_state_independent_H (ex_cte_cap_wp_to' P slot)"
   by (simp add: ex_cte_cap_wp_to'_def)
@@ -4425,9 +4420,6 @@ lemma setCTE_ct_in_state:
   apply (rule hoare_pre, wp ct_in_state'_decomp setCTE_pred_tcb_at')
   apply (auto simp: ct_in_state'_def)
   done
-
-add_upd_simps "ct_in_state' P (gsUntypedZeroRanges_update f s)"
-declare upd_simps[simp]
 
 crunch ct_in_state[wp]: updateFreeIndex "ct_in_state' P"
 crunch nosch[wp]: updateFreeIndex "\<lambda>s. P (ksSchedulerAction s)"

--- a/proof/refine/ARM/VSpace_R.thy
+++ b/proof/refine/ARM/VSpace_R.thy
@@ -2573,14 +2573,13 @@ lemma findFreeHWASID_invs:
              ct_not_inQ_def
            split del: if_split)
   apply (intro conjI)
-    apply (fastforce dest: no_irq_use [OF no_irq_invalidateLocalTLB_ASID])
-   apply clarsimp
-   apply (drule_tac x=p in spec)
-   apply (drule use_valid)
+   apply (fastforce dest: no_irq_use [OF no_irq_invalidateLocalTLB_ASID])
+  apply clarsimp
+  apply (drule_tac x=p in spec)
+  apply (drule use_valid)
     apply (rule_tac p=p in invalidateLocalTLB_ASID_underlying_memory)
-    apply blast
-   apply clarsimp
-  apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+   apply blast
+  apply clarsimp
   done
 
 lemma findFreeHWASID_invs_no_cicd':

--- a/proof/refine/ARM/VSpace_R.thy
+++ b/proof/refine/ARM/VSpace_R.thy
@@ -1848,10 +1848,10 @@ lemma setCTE_vs_entry_align[wp]:
                  elim!: rsubst[where P=P])
   apply (drule(1) updateObject_cte_is_tcb_or_cte [OF _ refl, rotated])
   apply (elim exE conjE disjE)
-   apply (clarsimp simp: ps_clear_upd' objBits_simps
+   apply (clarsimp simp: ps_clear_upd objBits_simps
                          lookupAround2_char1)
    apply (simp add:vs_entry_align_def)
-  apply (clarsimp simp: ps_clear_upd' objBits_simps vs_entry_align_def)
+  apply (clarsimp simp: ps_clear_upd objBits_simps vs_entry_align_def)
   done
 
 lemma updateCap_vs_entry_align[wp]:
@@ -2037,7 +2037,7 @@ lemma setCTE_valid_duplicates'[wp]:
   setCTE p cte \<lbrace>\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (simp add:setCTE_def)
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd'
+                        projectKOs pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = cte,simplified])
@@ -2801,7 +2801,7 @@ lemma storePDE_state_refs' [wp]:
   apply (clarsimp simp: storePDE_def)
   apply (clarsimp simp: setObject_def valid_def in_monad split_def
                         updateObject_default_def projectKOs objBits_simps
-                        in_magnitude_check state_refs_of'_def ps_clear_upd'
+                        in_magnitude_check state_refs_of'_def ps_clear_upd
                  elim!: rsubst[where P=P] intro!: ext
              split del: if_split cong: option.case_cong if_cong)
   apply (simp split: option.split)
@@ -2988,7 +2988,7 @@ lemma storePTE_state_refs' [wp]:
   apply (clarsimp simp: storePTE_def)
   apply (clarsimp simp: setObject_def valid_def in_monad split_def
                         updateObject_default_def projectKOs objBits_simps
-                        in_magnitude_check state_refs_of'_def ps_clear_upd'
+                        in_magnitude_check state_refs_of'_def ps_clear_upd
                  elim!: rsubst[where P=P] intro!: ext
              split del: if_split cong: option.case_cong if_cong)
   apply (simp split: option.split)
@@ -3179,7 +3179,7 @@ lemma setASIDPool_state_refs' [wp]:
   "\<lbrace>\<lambda>s. P (state_refs_of' s)\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>rv s. P (state_refs_of' s)\<rbrace>"
   apply (clarsimp simp: setObject_def valid_def in_monad split_def
                         updateObject_default_def projectKOs objBits_simps
-                        in_magnitude_check state_refs_of'_def ps_clear_upd'
+                        in_magnitude_check state_refs_of'_def ps_clear_upd
                  elim!: rsubst[where P=P] intro!: ext
              split del: if_split cong: option.case_cong if_cong)
   apply (simp split: option.split)

--- a/proof/refine/ARM_HYP/ArchAcc_R.thy
+++ b/proof/refine/ARM_HYP/ArchAcc_R.thy
@@ -1670,14 +1670,6 @@ lemma clearMemory_vms':
   apply (rule clearMemory_um_eq_0)
   done
 
-lemma ct_not_inQ_ksMachineState_update[simp]:
-  "ct_not_inQ (s\<lparr>ksMachineState := v\<rparr>) = ct_not_inQ s"
-  by (simp add: ct_not_inQ_def)
-
-lemma ct_in_current_domain_ksMachineState_update[simp]:
-  "ct_idle_or_in_cur_domain' (s\<lparr>ksMachineState := v\<rparr>) = ct_idle_or_in_cur_domain' s"
-  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-
 lemma dmo_clearMemory_invs'[wp]:
   "\<lbrace>invs'\<rbrace> doMachineOp (clearMemory w sz) \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (simp add: doMachineOp_def split_def)

--- a/proof/refine/ARM_HYP/Arch_R.thy
+++ b/proof/refine/ARM_HYP/Arch_R.thy
@@ -1460,16 +1460,6 @@ lemma invokeArch_tcb_at':
   apply wpsimp
   done
 
-(* FIXME random place to have these *)
-lemma pspace_no_overlap_queuesL1 [simp]:
-  "pspace_no_overlap' w sz (ksReadyQueuesL1Bitmap_update f s) = pspace_no_overlap' w sz s"
-  by (simp add: pspace_no_overlap'_def)
-
-(* FIXME random place to have these *)
-lemma pspace_no_overlap_queuesL2 [simp]:
-  "pspace_no_overlap' w sz (ksReadyQueuesL2Bitmap_update f s) = pspace_no_overlap' w sz s"
-  by (simp add: pspace_no_overlap'_def)
-
 crunch pspace_no_overlap'[wp]: setThreadState "pspace_no_overlap' w s"
   (simp: unless_def)
 
@@ -2111,7 +2101,7 @@ crunch typ_at' [wp]: "Arch.finaliseCap" "\<lambda>s. P (typ_at' T p s)"
 crunch cte_wp_at':  "Arch.finaliseCap" "cte_wp_at' P p"
   (wp: crunch_wps getASID_wp simp: crunch_simps)
 
-lemma invs_asid_table_strenghten':
+lemma invs_asid_table_strengthen':
   "invs' s \<and> asid_pool_at' ap s \<and> asid \<le> 2 ^ asid_high_bits - 1 \<longrightarrow>
    invs' (s\<lparr>ksArchState :=
             armKSASIDTable_update (\<lambda>_. (armKSASIDTable \<circ> ksArchState) s(asid \<mapsto> ap)) (ksArchState s)\<rparr>)"
@@ -2152,7 +2142,7 @@ lemma performASIDControlInvocation_invs' [wp]:
    apply fastforce
   apply (rule hoare_pre)
    apply (wp hoare_vcg_const_imp_lift)
-       apply (strengthen invs_asid_table_strenghten')
+       apply (strengthen invs_asid_table_strengthen')
        apply (wp cteInsert_simple_invs)
       apply (wp createObjects'_wp_subst[OF
                 createObjects_no_cte_invs [where sz = pageBits and ty="Inl (KOArch (KOASIDPool pool))" for pool]]

--- a/proof/refine/ARM_HYP/CNodeInv_R.thy
+++ b/proof/refine/ARM_HYP/CNodeInv_R.thy
@@ -565,6 +565,14 @@ where
  "not_recursive_ctes s \<equiv> {ptr. \<exists>cap. cteCaps_of s ptr = Some cap
                              \<and> \<not> (isZombie cap \<and> capZombiePtr cap = ptr)}"
 
+lemma not_recursive_ctes_wu [simp]:
+  "not_recursive_ctes (ksWorkUnitsCompleted_update f s) = not_recursive_ctes s"
+  by (simp add: not_recursive_ctes_def)
+
+lemma not_recursive_ctes_irq_state_independent[simp, intro!]:
+  "not_recursive_ctes (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := x \<rparr>\<rparr>) = not_recursive_ctes s"
+  by (simp add: not_recursive_ctes_def)
+
 lemma capSwap_not_recursive:
   "\<lbrace>\<lambda>s. card (not_recursive_ctes s) \<le> n
      \<and> cte_wp_at' (\<lambda>cte. \<not> (isZombie (cteCap cte) \<and> capZombiePtr (cteCap cte) = p1)) p1 s
@@ -707,24 +715,6 @@ lemma case_Zombie_assert_fold:
   "(case cap of Zombie ptr zb n \<Rightarrow> haskell_assertE (P ptr) str | _ \<Rightarrow> returnOk ())
        = assertE (isZombie cap \<longrightarrow> P (capZombiePtr cap))"
   by (cases cap, simp_all add: isCap_simps assertE_def)
-
-lemma not_recursive_ctes_wu [simp]:
-  "not_recursive_ctes (ksWorkUnitsCompleted_update f s) = not_recursive_ctes s"
-  by (simp add: not_recursive_ctes_def)
-
-lemma not_recursive_ctes_irq_state_independent[simp, intro!]:
-  "not_recursive_ctes (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := x \<rparr>\<rparr>) = not_recursive_ctes s"
-  by (simp add: not_recursive_ctes_def)
-
-lemma typ_at'_irq_state_independent[simp, intro!]:
-  "P (typ_at' T p (s \<lparr>ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr>\<rparr>))
-   = P (typ_at' T p s)"
-  by (simp add: typ_at'_def)
-
-lemma sch_act_simple_irq_state_independent[intro!, simp]:
-  "sch_act_simple (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr> \<rparr>) =
-   sch_act_simple s"
-  by (simp add: sch_act_simple_def)
 
 termination finaliseSlot'
   apply (rule finaliseSlot'.termination,
@@ -5899,10 +5889,6 @@ lemma cancelIPC_cap_to'[wp]:
                | wpcw | wp (once) hoare_drop_imps)+
   done
 
-lemma ex_cte_cap_wp_to'_ksReadyQueuesL1Bitmap[simp]:
-   "ex_cte_cap_wp_to' P p (s\<lparr> ksReadyQueuesL1Bitmap := x \<rparr>) = ex_cte_cap_wp_to' P p s"
-   unfolding ex_cte_cap_wp_to'_def by simp
-
 lemma emptySlot_deletes [wp]:
   "\<lbrace>\<top>\<rbrace> emptySlot p opt \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. cteCap c = NullCap) p s\<rbrace>"
   apply (simp add: emptySlot_def case_Null_If)
@@ -6179,14 +6165,6 @@ lemmas preemptionPoint_invR =
 
 lemmas preemptionPoint_invE =
   valid_validE_E [OF preemptionPoint_inv]
-
-lemma sch_act_simple_wu [simp, intro!]:
-  "sch_act_simple (ksWorkUnitsCompleted_update f s) = sch_act_simple s"
-  by (simp add: sch_act_simple_def)
-
-lemma ex_cte_cap_to'_wu [simp, intro!]:
-  "ex_cte_cap_to' p (ksWorkUnitsCompleted_update f s) = ex_cte_cap_to' p s"
-  by (simp add: ex_cte_cap_to'_def)
 
 lemma finaliseSlot_invs':
   assumes finaliseCap:

--- a/proof/refine/ARM_HYP/CSpace1_R.thy
+++ b/proof/refine/ARM_HYP/CSpace1_R.thy
@@ -1343,7 +1343,7 @@ lemma weak_derived_updateCapData:
   apply (clarsimp simp: Let_def isCap_simps updateCapData_def)
   done
 
-lemma maskCapRights_Reply:
+lemma maskCapRights_Reply[simp]:
   "isReplyCap (maskCapRights r c) = isReplyCap c"
   apply (insert capMasterCap_maskCapRights)
   apply (rule master_eqI, rule isCap_Master)

--- a/proof/refine/ARM_HYP/Detype_R.thy
+++ b/proof/refine/ARM_HYP/Detype_R.thy
@@ -85,10 +85,6 @@ lemma descendants_range_inD':
   done
 end
 
-interpretation clear_um:
-  p_arch_idle_update_int_eq "clear_um S"
-  by unfold_locales (simp_all add: clear_um_def)
-
 context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma descendants_range'_def2:
@@ -1539,7 +1535,7 @@ proof (simp add: invs'_def valid_state'_def valid_pspace'_def
     done
 
   from sa_simp ctnotinQ
-  show "ct_not_inQ ?state''"
+  show "ct_not_inQ state'"
     apply (clarsimp simp: ct_not_inQ_def pred_tcb_at'_def)
     apply (drule obj_at'_and
                    [THEN iffD2, OF conjI,
@@ -1552,7 +1548,7 @@ proof (simp add: invs'_def valid_state'_def valid_pspace'_def
     apply (clarsimp dest!: ex_nonz_cap_notRange)
     done
 
-  from ctcd show "ct_idle_or_in_cur_domain' ?state''"
+  from ctcd show "ct_idle_or_in_cur_domain' state'"
     apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
     apply (intro impI)
     apply (elim disjE impE)
@@ -1721,13 +1717,6 @@ lemma deleteObjects_st_tcb_at':
   apply (simp add: delete_locale_def)
   done
 
-lemma ex_cte_cap_wp_to'_gsCNodes_update[simp]:
-  "ex_cte_cap_wp_to' P p (gsCNodes_update f s') = ex_cte_cap_wp_to' P p s'"
-  by (simp add: ex_cte_cap_wp_to'_def)
-lemma ex_cte_cap_wp_to'_gsUserPages_update[simp]:
-  "ex_cte_cap_wp_to' P p (gsUserPages_update f s') = ex_cte_cap_wp_to' P p s'"
-  by (simp add: ex_cte_cap_wp_to'_def)
-
 lemma deleteObjects_cap_to':
   "\<lbrace>cte_wp_at' (\<lambda>c. cteCap c = UntypedCap d ptr bits idx) p
      and invs' and ct_active' and sch_act_simple
@@ -1775,19 +1764,6 @@ lemma valid_untyped_no_overlap:
     apply (clarsimp simp:p_assoc_help)
    apply fastforce+
   done
-
-lemma pspace_no_overlap'_gsCNodes_update[simp]:
-  "pspace_no_overlap' p b (gsCNodes_update f s') = pspace_no_overlap' p b s'"
-  by (simp add: pspace_no_overlap'_def)
-
-lemma pspace_no_overlap'_gsUserPages_update[simp]:
-  "pspace_no_overlap' p b (gsUserPages_update f s') = pspace_no_overlap' p b s'"
-  by (simp add: pspace_no_overlap'_def)
-
-lemma pspace_no_overlap'_ksMachineState_update[simp]:
-  "pspace_no_overlap' p n (ksMachineState_update f s) =
-   pspace_no_overlap' p n s"
-  by (simp add: pspace_no_overlap'_def)
 
 lemma deleteObject_no_overlap[wp]:
   "\<lbrace>valid_cap' (UntypedCap d ptr bits idx) and valid_pspace'\<rbrace>
@@ -3660,11 +3636,6 @@ lemma new_cap_object_comm_helper:
   apply (drule_tac x = "parent " in spec)
    apply clarsimp
   done
-
-lemma pspace_no_overlap_gsUntypedZeroRanges[simp]:
-  "pspace_no_overlap' ptr n (gsUntypedZeroRanges_update f s)
-    = pspace_no_overlap' ptr n s"
-  by (simp add: pspace_no_overlap'_def)
 
 crunch pspace_aligned'[wp]: updateNewFreeIndex "pspace_aligned'"
 crunch pspace_distinct'[wp]: updateNewFreeIndex "pspace_distinct'"

--- a/proof/refine/ARM_HYP/Finalise_R.thy
+++ b/proof/refine/ARM_HYP/Finalise_R.thy
@@ -1449,10 +1449,6 @@ lemma emptySlot_untyped_ranges[wp]:
   apply (simp add: untypedZeroRange_def isCap_simps)
   done
 
-lemma valid_arch_state'_interrupt[simp]:
-  "valid_arch_state' (ksInterruptState_update f s) = valid_arch_state' s"
-  by (simp add: valid_arch_state'_def cong: option.case_cong)
-
 crunch valid_arch'[wp]: emptySlot valid_arch_state'
   (wp: crunch_wps)
 
@@ -4146,10 +4142,6 @@ crunch ct__in_cur_domain'[wp]: copyGlobalMappings ct_idle_or_in_cur_domain'
 
 crunch gsUntypedZeroRanges[wp]: copyGlobalMappings "\<lambda>s. P (gsUntypedZeroRanges s)"
   (wp: crunch_wps)
-
-lemma ct_in_current_domain_ArchState_update[simp]:
-  "ct_idle_or_in_cur_domain' (s\<lparr>ksArchState := v\<rparr>) = ct_idle_or_in_cur_domain' s"
-  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
 
 lemma threadSet_ct_idle_or_in_cur_domain':
   "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>

--- a/proof/refine/ARM_HYP/InterruptAcc_R.thy
+++ b/proof/refine/ARM_HYP/InterruptAcc_R.thy
@@ -123,31 +123,25 @@ lemma preemptionPoint_inv:
           | simp)+
   done
 
-lemma invs'_wu [simp, intro!]:
-  "invs' (ksWorkUnitsCompleted_update f s) = invs' s"
-  apply (simp add: invs'_def cur_tcb'_def valid_state'_def Invariants_H.valid_queues_def
-                   valid_queues'_def valid_irq_node'_def valid_machine_state'_def
-                   ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                   bitmapQ_defs valid_queues_no_bitmap_def)
-  done
+lemma ct_running_irq_state_independent[intro!, simp]:
+  "ct_running (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
+   = ct_running s"
+  by (simp add: ct_in_state_def)
 
-lemma ct_in_state'_irq_state_independent [simp, intro!]:
-  "ct_in_state' x (s\<lparr>ksMachineState := ksMachineState s
-                          \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>) =
-   ct_in_state' x s"
-  by (simp add: ct_in_state'_def irq_state_independent_H_def)+
+lemma ct_idle_irq_state_independent[intro!, simp]:
+  "ct_idle (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
+   = ct_idle s"
+  by (simp add: ct_in_state_def)
 
-lemma ex_cte_cap_wp_to'_irq_state_independent [simp, intro!]:
-  "ex_cte_cap_wp_to' x y (s\<lparr>ksMachineState := ksMachineState s
-                          \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>) =
-   ex_cte_cap_wp_to' x y s"
-  by (simp add: ex_cte_cap_wp_to'_def irq_state_independent_H_def)+
+lemma typ_at'_irq_state_independent[simp, intro!]:
+  "P (typ_at' T p (s \<lparr>ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr>\<rparr>))
+   = P (typ_at' T p s)"
+  by (simp add: typ_at'_def)
 
-lemma ps_clear_irq_state_independent [simp, intro!]:
-  "ps_clear a b (s\<lparr>ksMachineState := ksMachineState s
-                    \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>) =
-   ps_clear a b s"
-  by (simp add: ps_clear_def)
+lemma sch_act_simple_irq_state_independent[intro!, simp]:
+  "sch_act_simple (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr> \<rparr>) =
+   sch_act_simple s"
+  by (simp add: sch_act_simple_def)
 
 lemma invs'_irq_state_independent [simp, intro!]:
   "invs' (s\<lparr>ksMachineState := ksMachineState s

--- a/proof/refine/ARM_HYP/Interrupt_R.thy
+++ b/proof/refine/ARM_HYP/Interrupt_R.thy
@@ -425,12 +425,6 @@ lemma isnt_irq_handler_strg:
   "(\<not> isIRQHandlerCap cap) \<longrightarrow> (\<forall>irq. cap = IRQHandlerCap irq \<longrightarrow> P irq)"
   by (clarsimp simp: isCap_simps)
 
-lemma ct_in_current_domain_ksMachineState:
-  "ct_idle_or_in_cur_domain' (ksMachineState_update p s) = ct_idle_or_in_cur_domain' s"
-  apply (simp add:ct_idle_or_in_cur_domain'_def)
-  apply (simp add:tcb_in_cur_domain'_def)
-  done
-
 lemma invoke_irq_handler_invs'[wp]:
   "\<lbrace>invs' and irq_handler_inv_valid' i\<rbrace>
     InterruptDecls_H.invokeIRQHandler i \<lbrace>\<lambda>rv. invs'\<rbrace>"
@@ -458,9 +452,6 @@ lemma IRQHandler_valid':
   "(s' \<turnstile>' IRQHandlerCap irq) = (irq \<le> maxIRQ)"
   by (simp add: valid_cap'_def capAligned_def word_bits_conv)
 
-lemma valid_mdb_interrupts'[simp]:
-  "valid_mdb' (ksInterruptState_update f s) = valid_mdb' s"
-  by (simp add: valid_mdb'_def)
 crunch valid_mdb'[wp]: setIRQState "valid_mdb'"
 crunch cte_wp_at[wp]: setIRQState "cte_wp_at' P p"
 
@@ -613,23 +604,12 @@ lemma dec_domain_time_corres:
   apply (clarsimp simp:state_relation_def)
   done
 
-lemma weak_sch_act_wf_updateDomainTime[simp]:
-  "weak_sch_act_wf m (s\<lparr>ksDomainTime := t\<rparr>)
-   = weak_sch_act_wf m s"
-  by (simp add:weak_sch_act_wf_def tcb_in_cur_domain'_def )
-
 lemma tcbSchedAppend_valid_objs':
   "\<lbrace>valid_objs'\<rbrace>tcbSchedAppend t \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
   apply (simp add:tcbSchedAppend_def)
-  apply (wp hoare_unless_wp
-    threadSet_valid_objs' threadGet_wp
-    | simp add:valid_tcb_tcbQueued)+
+  apply (wpsimp wp: hoare_unless_wp threadSet_valid_objs' threadGet_wp)
   apply (clarsimp simp add:obj_at'_def typ_at'_def)
   done
-
-lemma valid_tcb_tcbTimeSlice_update[simp]:
-  "valid_tcb' (tcbTimeSlice_update (\<lambda>_. timeSlice) tcb) s = valid_tcb' tcb s"
-  by (simp add:valid_tcb'_def tcb_cte_cases_def)
 
 lemma thread_state_case_if:
  "(case state of Structures_A.thread_state.Running \<Rightarrow> f | _ \<Rightarrow> g) =
@@ -1069,24 +1049,6 @@ lemma handle_interrupt_corres:
    apply clarsimp
   apply corressimp
   done
-
-lemma ksDomainTime_invs[simp]:
-  "invs' (a\<lparr>ksDomainTime := t\<rparr>) = invs' a"
-  by (simp add:invs'_def valid_state'_def
-    cur_tcb'_def ct_not_inQ_def ct_idle_or_in_cur_domain'_def
-    tcb_in_cur_domain'_def valid_machine_state'_def)
-
-lemma valid_machine_state'_ksDomainTime[simp]:
-  "valid_machine_state' (a\<lparr>ksDomainTime := t\<rparr>) = valid_machine_state' a"
-  by (simp add:valid_machine_state'_def)
-
-lemma cur_tcb'_ksDomainTime[simp]:
-  "cur_tcb' (a\<lparr>ksDomainTime := 0\<rparr>) = cur_tcb' a"
-  by (simp add:cur_tcb'_def)
-
-lemma ct_idle_or_in_cur_domain'_ksDomainTime[simp]:
-  "ct_idle_or_in_cur_domain' (a\<lparr>ksDomainTime := t \<rparr>) = ct_idle_or_in_cur_domain' a"
-  by (simp add:ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
 
 lemma threadSet_ksDomainTime[wp]:
   "\<lbrace>\<lambda>s. P (ksDomainTime s)\<rbrace> threadSet f ptr \<lbrace>\<lambda>rv s. P (ksDomainTime s)\<rbrace>"

--- a/proof/refine/ARM_HYP/InvariantUpdates_H.thy
+++ b/proof/refine/ARM_HYP/InvariantUpdates_H.thy
@@ -1,0 +1,372 @@
+(*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory InvariantUpdates_H
+imports Invariants_H
+begin
+
+(* FIXME: use locales to shorten this work *)
+
+lemma ps_clear_domE[elim?]:
+  "\<lbrakk> ps_clear x n s; dom (ksPSpace s) = dom (ksPSpace s') \<rbrakk> \<Longrightarrow> ps_clear x n s'"
+  by (simp add: ps_clear_def)
+
+lemma ps_clear_upd:
+  "ksPSpace s y = Some v \<Longrightarrow>
+    ps_clear x n (ksPSpace_update (\<lambda>a. ksPSpace s(y \<mapsto> v')) s') = ps_clear x n s"
+  by (rule iffI | clarsimp elim!: ps_clear_domE | fastforce)+
+
+lemmas ps_clear_updE[elim] = iffD2[OF ps_clear_upd, rotated]
+
+lemma ct_not_inQ_ksMachineState_update[simp]:
+  "ct_not_inQ (ksMachineState_update f s) = ct_not_inQ s"
+  by (simp add: ct_not_inQ_def)
+
+lemma ct_in_current_domain_ksMachineState[simp]:
+  "ct_idle_or_in_cur_domain' (ksMachineState_update p s) = ct_idle_or_in_cur_domain' s"
+  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+
+lemma invs'_machine:
+  assumes mask: "irq_masks (f (ksMachineState s)) =
+                 irq_masks (ksMachineState s)"
+  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
+                valid_machine_state' s"
+  shows "invs' (ksMachineState_update f s) = invs' s"
+proof -
+  show ?thesis
+    apply (cases "ksSchedulerAction s")
+    apply (simp_all add: invs'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
+                    vms ct_not_inQ_def
+                    state_refs_of'_def ps_clear_def
+                    valid_irq_node'_def mask
+              cong: option.case_cong)
+    done
+qed
+
+lemma invs_no_cicd'_machine:
+  assumes mask: "irq_masks (f (ksMachineState s)) =
+                 irq_masks (ksMachineState s)"
+  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
+                valid_machine_state' s"
+  shows "invs_no_cicd' (ksMachineState_update f s) = invs_no_cicd' s"
+proof -
+  show ?thesis
+    apply (cases "ksSchedulerAction s")
+    apply (simp_all add: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
+                    vms ct_not_inQ_def
+                    state_refs_of'_def ps_clear_def
+                    valid_irq_node'_def mask
+              cong: option.case_cong)
+    done
+qed
+
+lemma pspace_no_overlap_queues [simp]:
+  "pspace_no_overlap' w sz (ksReadyQueues_update f s) = pspace_no_overlap' w sz s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap'_ksSchedulerAction[simp]:
+  "pspace_no_overlap' a b (ksSchedulerAction_update f s) =
+   pspace_no_overlap' a b s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma ksReadyQueues_update_id[simp]:
+  "ksReadyQueues_update id s = s"
+  by simp
+
+lemma ct_not_inQ_ksReadyQueues_update[simp]:
+  "ct_not_inQ (ksReadyQueues_update f s) = ct_not_inQ s"
+  by (simp add: ct_not_inQ_def)
+
+lemma inQ_context[simp]:
+  "inQ d p (tcbArch_update f tcb) = inQ d p tcb"
+  by (cases tcb, simp add: inQ_def)
+
+lemma valid_tcb'_tcbQueued[simp]:
+  "valid_tcb' (tcbQueued_update f tcb) = valid_tcb' tcb"
+  by (cases tcb, rule ext, simp add: valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_tcb'_tcbFault_update[simp]:
+  "valid_tcb' tcb s \<Longrightarrow> valid_tcb' (tcbFault_update f tcb) s"
+  by (clarsimp simp: valid_tcb'_def  tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_tcb'_tcbTimeSlice_update[simp]:
+  "valid_tcb' (tcbTimeSlice_update f tcb) s = valid_tcb' tcb s"
+  by (simp add:valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_queues_ksSchedulerAction_update[simp]:
+  "valid_queues (ksSchedulerAction_update f s) = valid_queues s"
+ unfolding valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
+ by simp
+
+lemma valid_queues'_ksSchedulerAction_update[simp]:
+  "valid_queues' (ksSchedulerAction_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma ex_cte_cap_wp_to'_gsCNodes_update[simp]:
+  "ex_cte_cap_wp_to' P p (gsCNodes_update f s') = ex_cte_cap_wp_to' P p s'"
+  by (simp add: ex_cte_cap_wp_to'_def)
+lemma ex_cte_cap_wp_to'_gsUserPages_update[simp]:
+  "ex_cte_cap_wp_to' P p (gsUserPages_update f s') = ex_cte_cap_wp_to' P p s'"
+  by (simp add: ex_cte_cap_wp_to'_def)
+
+lemma pspace_no_overlap'_gsCNodes_update[simp]:
+  "pspace_no_overlap' p b (gsCNodes_update f s') = pspace_no_overlap' p b s'"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap'_gsUserPages_update[simp]:
+  "pspace_no_overlap' p b (gsUserPages_update f s') = pspace_no_overlap' p b s'"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap'_ksMachineState_update[simp]:
+  "pspace_no_overlap' p n (ksMachineState_update f s) =
+   pspace_no_overlap' p n s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap_gsUntypedZeroRanges[simp]:
+  "pspace_no_overlap' ptr n (gsUntypedZeroRanges_update f s)
+    = pspace_no_overlap' ptr n s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma vms'_ct[simp]:
+  "valid_machine_state' (ksCurThread_update f s) = valid_machine_state' s"
+  by (simp add: valid_machine_state'_def)
+
+lemma tcb_in_cur_domain_ct[simp]:
+  "tcb_in_cur_domain' t  (ksCurThread_update f s) = tcb_in_cur_domain' t s"
+  by (fastforce simp: tcb_in_cur_domain'_def)
+
+lemma valid_queues'_ksCurDomain[simp]:
+  "valid_queues' (ksCurDomain_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksDomScheduleIdx[simp]:
+  "valid_queues' (ksDomScheduleIdx_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksDomSchedule[simp]:
+  "valid_queues' (ksDomSchedule_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksDomainTime[simp]:
+  "valid_queues' (ksDomainTime_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksWorkUnitsCompleted[simp]:
+  "valid_queues' (ksWorkUnitsCompleted_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues_ksCurDomain[simp]:
+  "valid_queues (ksCurDomain_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksDomScheduleIdx[simp]:
+  "valid_queues (ksDomScheduleIdx_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksDomSchedule[simp]:
+  "valid_queues (ksDomSchedule_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksDomainTime[simp]:
+  "valid_queues (ksDomainTime_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksWorkUnitsCompleted[simp]:
+  "valid_queues (ksWorkUnitsCompleted_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_irq_node'_ksCurDomain[simp]:
+  "valid_irq_node' w (ksCurDomain_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksDomScheduleIdx[simp]:
+  "valid_irq_node' w (ksDomScheduleIdx_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksDomSchedule[simp]:
+  "valid_irq_node' w (ksDomSchedule_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksDomainTime[simp]:
+  "valid_irq_node' w (ksDomainTime_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksWorkUnitsCompleted[simp]:
+  "valid_irq_node' w (ksWorkUnitsCompleted_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma ex_cte_cap_wp_to_work_units[simp]:
+  "ex_cte_cap_wp_to' P slot (ksWorkUnitsCompleted_update f s)
+    = ex_cte_cap_wp_to' P slot s"
+  by (simp add: ex_cte_cap_wp_to'_def)
+
+add_upd_simps "ct_in_state' P (gsUntypedZeroRanges_update f s)"
+declare upd_simps[simp]
+
+lemma ct_not_inQ_ksArchState_update[simp]:
+  "ct_not_inQ (ksArchState_update f s) = ct_not_inQ s"
+  by (simp add: ct_not_inQ_def)
+
+lemma ct_in_current_domain_ArchState_update[simp]:
+  "ct_idle_or_in_cur_domain' (ksArchState_update f s) = ct_idle_or_in_cur_domain' s"
+  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+
+lemma pspace_no_overlap_queuesL1 [simp]:
+  "pspace_no_overlap' w sz (ksReadyQueuesL1Bitmap_update f s) = pspace_no_overlap' w sz s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap_queuesL2 [simp]:
+  "pspace_no_overlap' w sz (ksReadyQueuesL2Bitmap_update f s) = pspace_no_overlap' w sz s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma tcb_in_cur_domain'_ksSchedulerAction_update[simp]:
+  "tcb_in_cur_domain' t (ksSchedulerAction_update f s) = tcb_in_cur_domain' t s"
+  by (simp add: tcb_in_cur_domain'_def)
+
+lemma ct_idle_or_in_cur_domain'_ksSchedulerAction_update[simp]:
+  "b \<noteq> ResumeCurrentThread \<Longrightarrow>
+   ct_idle_or_in_cur_domain' (s\<lparr>ksSchedulerAction := b\<rparr>)"
+  apply (clarsimp simp add: ct_idle_or_in_cur_domain'_def)
+  done
+
+lemma sch_act_simple_wu [simp, intro!]:
+  "sch_act_simple (ksWorkUnitsCompleted_update f s) = sch_act_simple s"
+  by (simp add: sch_act_simple_def)
+
+lemma sch_act_simple_ksPSpace_update[simp]:
+  "sch_act_simple (ksPSpace_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma ps_clear_ksReadyQueue[simp]:
+  "ps_clear x n (ksReadyQueues_update f s) = ps_clear x n s"
+  by (simp add: ps_clear_def)
+
+lemma inQ_tcbIPCBuffer_update_idem[simp]:
+  "inQ d p (tcbIPCBuffer_update f ko) = inQ d p ko"
+  by (clarsimp simp: inQ_def)
+
+lemma valid_mdb_interrupts'[simp]:
+  "valid_mdb' (ksInterruptState_update f s) = valid_mdb' s"
+  by (simp add: valid_mdb'_def)
+
+lemma vms_ksReadyQueues_update[simp]:
+  "valid_machine_state' (ksReadyQueues_update f s) = valid_machine_state' s"
+  by (simp add: valid_machine_state'_def)
+
+lemma ct_in_state'_ksMachineState_update[simp]:
+  "ct_in_state' x (ksMachineState_update f s) = ct_in_state' x s"
+  by (simp add: ct_in_state'_def)+
+
+lemma ex_cte_cap_wp_to'_ksMachineState_update[simp]:
+  "ex_cte_cap_wp_to' x y (ksMachineState_update f s) = ex_cte_cap_wp_to' x y s"
+  by (simp add: ex_cte_cap_wp_to'_def)+
+
+lemma ps_clear_ksMachineState_update[simp]:
+  "ps_clear a b (ksMachineState_update f s) = ps_clear a b s"
+  by (simp add: ps_clear_def)
+
+lemma ct_in_state_ksSched[simp]:
+  "ct_in_state' P (ksSchedulerAction_update f s) = ct_in_state' P s"
+  unfolding ct_in_state'_def
+  apply auto
+  done
+
+lemma invs'_wu[simp]:
+  "invs' (ksWorkUnitsCompleted_update f s) = invs' s"
+  apply (simp add: invs'_def cur_tcb'_def valid_state'_def Invariants_H.valid_queues_def
+                   valid_queues'_def valid_irq_node'_def valid_machine_state'_def
+                   ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                   bitmapQ_defs valid_queues_no_bitmap_def)
+  done
+
+lemma valid_arch_state'_interrupt[simp]:
+  "valid_arch_state' (ksInterruptState_update f s) = valid_arch_state' s"
+  by (simp add: valid_arch_state'_def cong: option.case_cong)
+
+lemma valid_bitmapQ_ksSchedulerAction_upd[simp]:
+  "valid_bitmapQ (ksSchedulerAction_update f s) = valid_bitmapQ s"
+  unfolding bitmapQ_defs by simp
+
+lemma bitmapQ_no_L1_orphans_ksSchedulerAction_upd[simp]:
+  "bitmapQ_no_L1_orphans (ksSchedulerAction_update f s) = bitmapQ_no_L1_orphans s"
+  unfolding bitmapQ_defs by simp
+
+lemma bitmapQ_no_L2_orphans_ksSchedulerAction_upd[simp]:
+  "bitmapQ_no_L2_orphans (ksSchedulerAction_update f s) = bitmapQ_no_L2_orphans s"
+  unfolding bitmapQ_defs by simp
+
+lemma cur_tcb'_ksReadyQueuesL1Bitmap_upd[simp]:
+  "cur_tcb' (ksReadyQueuesL1Bitmap_update f s) = cur_tcb' s"
+  unfolding cur_tcb'_def by simp
+
+lemma cur_tcb'_ksReadyQueuesL2Bitmap_upd[simp]:
+  "cur_tcb' (ksReadyQueuesL2Bitmap_update f s) = cur_tcb' s"
+  unfolding cur_tcb'_def by simp
+
+lemma ex_cte_cap_wp_to'_ksReadyQueuesL1Bitmap[simp]:
+   "ex_cte_cap_wp_to' P p (ksReadyQueuesL1Bitmap_update f s) = ex_cte_cap_wp_to' P p s"
+   unfolding ex_cte_cap_wp_to'_def by simp
+
+lemma ex_cte_cap_wp_to'_ksReadyQueuesL2Bitmap[simp]:
+   "ex_cte_cap_wp_to' P p (ksReadyQueuesL2Bitmap_update f s) = ex_cte_cap_wp_to' P p s"
+   unfolding ex_cte_cap_wp_to'_def by simp
+
+lemma sch_act_simple_readyQueue[simp]:
+  "sch_act_simple (ksReadyQueues_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma sch_act_simple_ksReadyQueuesL1Bitmap[simp]:
+  "sch_act_simple (ksReadyQueuesL1Bitmap_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma sch_act_simple_ksReadyQueuesL2Bitmap[simp]:
+  "sch_act_simple (ksReadyQueuesL2Bitmap_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma ksDomainTime_invs[simp]:
+  "invs' (ksDomainTime_update f s) = invs' s"
+  by (simp add:invs'_def valid_state'_def
+    cur_tcb'_def ct_not_inQ_def ct_idle_or_in_cur_domain'_def
+    tcb_in_cur_domain'_def valid_machine_state'_def)
+
+lemma valid_machine_state'_ksDomainTime[simp]:
+  "valid_machine_state' (ksDomainTime_update f s) = valid_machine_state' s"
+  by (simp add:valid_machine_state'_def)
+
+lemma cur_tcb'_ksDomainTime[simp]:
+  "cur_tcb' (ksDomainTime_update f s) = cur_tcb' s"
+  by (simp add:cur_tcb'_def)
+
+lemma ct_idle_or_in_cur_domain'_ksDomainTime[simp]:
+  "ct_idle_or_in_cur_domain' (ksDomainTime_update f s) = ct_idle_or_in_cur_domain' s"
+  by (simp add:ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+
+lemma sch_act_sane_ksMachineState[simp]:
+  "sch_act_sane (ksMachineState_update f s) = sch_act_sane s"
+  by (simp add: sch_act_sane_def)
+
+lemma ct_not_inQ_update_cnt[simp]:
+  "ct_not_inQ (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
+   by (simp add: ct_not_inQ_def)
+
+lemma ct_not_inQ_update_stt[simp]:
+  "ct_not_inQ (s\<lparr>ksSchedulerAction := SwitchToThread t\<rparr>)"
+   by (simp add: ct_not_inQ_def)
+
+lemma invs'_update_cnt[elim!]:
+  "invs' s \<Longrightarrow> invs' (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
+   by (clarsimp simp: invs'_def valid_state'_def valid_queues_def valid_queues'_def
+                      valid_irq_node'_def cur_tcb'_def ct_idle_or_in_cur_domain'_def
+                      tcb_in_cur_domain'_def valid_queues_no_bitmap_def
+                      bitmapQ_no_L2_orphans_def bitmapQ_no_L1_orphans_def)
+
+end

--- a/proof/refine/ARM_HYP/IpcCancel_R.thy
+++ b/proof/refine/ARM_HYP/IpcCancel_R.thy
@@ -53,6 +53,20 @@ definition valid_inQ_queues :: "KernelStateData_H.kernel_state \<Rightarrow> boo
   "valid_inQ_queues \<equiv>
      \<lambda>s. \<forall>d p. (\<forall>t\<in>set (ksReadyQueues s (d, p)). obj_at' (inQ d p) t s) \<and> distinct (ksReadyQueues s (d, p))"
 
+lemma valid_inQ_queues_ksSchedulerAction_update[simp]:
+  "valid_inQ_queues (ksSchedulerAction_update f s) = valid_inQ_queues s"
+  by (simp add: valid_inQ_queues_def)
+
+lemma valid_inQ_queues_ksReadyQueuesL1Bitmap_upd[simp]:
+  "valid_inQ_queues (ksReadyQueuesL1Bitmap_update f s) = valid_inQ_queues s"
+  unfolding valid_inQ_queues_def
+  by simp
+
+lemma valid_inQ_queues_ksReadyQueuesL2Bitmap_upd[simp]:
+  "valid_inQ_queues (ksReadyQueuesL2Bitmap_update f s) = valid_inQ_queues s"
+  unfolding valid_inQ_queues_def
+  by simp
+
 defs capHasProperty_def:
   "capHasProperty ptr P \<equiv> cte_wp_at' (\<lambda>c. P (cteCap c)) ptr"
 end
@@ -1285,16 +1299,6 @@ lemma threadSet_valid_inQ_queues:
   apply (fastforce)
   done
 
-lemma valid_inQ_queues_ksReadyQueuesL1Bitmap_upd[simp]:
-  "valid_inQ_queues (s\<lparr>ksReadyQueuesL1Bitmap := f\<rparr>) = valid_inQ_queues s"
-  unfolding valid_inQ_queues_def
-  by simp
-
-lemma valid_inQ_queues_ksReadyQueuesL2Bitmap_upd[simp]:
-  "valid_inQ_queues (s\<lparr>ksReadyQueuesL2Bitmap := f\<rparr>) = valid_inQ_queues s"
-  unfolding valid_inQ_queues_def
-  by simp
-
 (* reorder the threadSet before the setQueue, useful for lemmas that don't refer to bitmap *)
 lemma setQueue_after_addToBitmap:
   "(setQueue d p q >>= (\<lambda>rv. (when P (addToBitmap d p)) >>= (\<lambda>rv. threadSet f t))) =
@@ -1336,10 +1340,6 @@ lemma removeFromBitmap_conceal_valid_inQ_queues[wp]:
   "\<lbrace> valid_inQ_queues \<rbrace> removeFromBitmap_conceal d p q t \<lbrace> \<lambda>_. valid_inQ_queues \<rbrace>"
   unfolding valid_inQ_queues_def removeFromBitmap_conceal_def
   by (wp|clarsimp simp: bitmap_fun_defs)+
-
-lemma valid_inQ_queues_ksSchedulerAction_update[simp]:
-  "valid_inQ_queues (ksSchedulerAction_update f s) = valid_inQ_queues s"
-  by (simp add: valid_inQ_queues_def)
 
 lemma rescheduleRequired_valid_inQ_queues[wp]:
   "\<lbrace>valid_inQ_queues\<rbrace> rescheduleRequired \<lbrace>\<lambda>_. valid_inQ_queues\<rbrace>"

--- a/proof/refine/ARM_HYP/Ipc_R.thy
+++ b/proof/refine/ARM_HYP/Ipc_R.thy
@@ -1083,8 +1083,6 @@ crunch typ_at'[wp]: transferCaps "\<lambda>s. P (typ_at' T p s)"
 
 lemmas transferCaps_typ_ats[wp] = typ_at_lifts [OF transferCaps_typ_at']
 
-declare maskCapRights_Reply [simp]
-
 lemma isIRQControlCap_mask [simp]:
   "isIRQControlCap (maskCapRights R c) = isIRQControlCap c"
   apply (case_tac c)
@@ -2166,9 +2164,6 @@ lemma cancelIPC_valid_queues'[wp]:
 crunches archThreadGet, handleFaultReply
   for valid_objs'[wp]: valid_objs'
 
-lemma valid_tcb'_tcbFault_update[simp]: "\<And>tcb s. valid_tcb' tcb s \<Longrightarrow> valid_tcb' (tcbFault_update f tcb) s"
-  by (clarsimp simp: valid_tcb'_def  tcb_cte_cases_def)
-
 lemma cte_wp_at_is_reply_cap_toI:
   "cte_wp_at ((=) (cap.ReplyCap t False rights)) ptr s
    \<Longrightarrow> cte_wp_at (is_reply_cap_to t) ptr s"
@@ -2443,19 +2438,6 @@ lemmas transferCapsToSlots_pred_tcb_at' =
 crunches doIPCTransfer, possibleSwitchTo
   for pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
   (wp: mapM_wp' crunch_wps simp: zipWithM_x_mapM)
-
-
-(* FIXME move *)
-lemma tcb_in_cur_domain'_ksSchedulerAction_update[simp]:
-  "tcb_in_cur_domain' t (ksSchedulerAction_update f s) = tcb_in_cur_domain' t s"
-by (simp add: tcb_in_cur_domain'_def)
-
-(* FIXME move *)
-lemma ct_idle_or_in_cur_domain'_ksSchedulerAction_update[simp]:
-  "b\<noteq> ResumeCurrentThread \<Longrightarrow>
-   ct_idle_or_in_cur_domain' (s\<lparr>ksSchedulerAction := b\<rparr>)"
-  apply (clarsimp simp add: ct_idle_or_in_cur_domain'_def)
-  done
 
 lemma setSchedulerAction_ct_in_domain:
  "\<lbrace>\<lambda>s. ct_idle_or_in_cur_domain' s

--- a/proof/refine/ARM_HYP/KHeap_R.thy
+++ b/proof/refine/ARM_HYP/KHeap_R.thy
@@ -241,17 +241,6 @@ lemma updateObject_cte_is_tcb_or_cte:
 
 declare plus_1_less[simp]
 
-lemma ps_clear_domE[elim?]:
-  "\<lbrakk> ps_clear x n s; dom (ksPSpace s) = dom (ksPSpace s') \<rbrakk> \<Longrightarrow> ps_clear x n s'"
-  by (simp add: ps_clear_def)
-
-lemma ps_clear_upd:
-  "ksPSpace s y = Some v \<Longrightarrow>
-    ps_clear x n (ksPSpace_update (\<lambda>a. ksPSpace s(y \<mapsto> v')) s') = ps_clear x n s"
-  by (rule iffI | clarsimp elim!: ps_clear_domE | fastforce)+
-
-lemmas ps_clear_updE[elim] = iffD2[OF ps_clear_upd, rotated]
-
 lemma updateObject_default_result:
   "(x, s'') \<in> fst (updateObject_default e ko p q n s) \<Longrightarrow> x = injectKO e"
   by (clarsimp simp add: updateObject_default_def in_monad)

--- a/proof/refine/ARM_HYP/Refine.thy
+++ b/proof/refine/ARM_HYP/Refine.thy
@@ -324,16 +324,6 @@ lemma do_user_op_invs2:
     do_user_op_invs | simp | force)+
   done
 
-lemma ct_running_irq_state_independent[intro!, simp]:
-  "ct_running (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
-   = ct_running s"
-  by (simp add: ct_in_state_def)
-
-lemma ct_idle_irq_state_independent[intro!, simp]:
-  "ct_idle (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
-   = ct_idle s"
-  by (simp add: ct_in_state_def)
-
 lemmas ext_init_def = ext_init_det_ext_ext_def ext_init_unit_def
 
 lemma valid_list_init[simp]:

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -1201,11 +1201,6 @@ lemma update_gs_simps[simp]:
                                else ups x)"
   by (simp_all add: update_gs_def)
 
-lemma caps_of_state_kheap_ekheap[simp]: "caps_of_state (kheap_update f (ekheap_update ef s)) =
-       caps_of_state (kheap_update f s)"
-  apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-  done
-
 lemma retype_state_relation:
   notes data_map_insert_def[simp del]
   assumes  sr:   "(s, s') \<in> state_relation"

--- a/proof/refine/ARM_HYP/Schedule_R.thy
+++ b/proof/refine/ARM_HYP/Schedule_R.thy
@@ -878,29 +878,17 @@ lemma setCurThread_invs_no_cicd':
      setCurThread t
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
 proof -
-  have obj_at'_ct: "\<And>f P addr s.
-       obj_at' P addr (ksCurThread_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
-  have valid_pspace'_ct: "\<And>s f.
-       valid_pspace' (ksCurThread_update f s) = valid_pspace' s"
-    by simp
-  have vms'_ct: "\<And>s f.
-       valid_machine_state' (ksCurThread_update f s) = valid_machine_state' s"
-    by (simp add: valid_machine_state'_def)
   have ct_not_inQ_ct: "\<And>s t . \<lbrakk> ct_not_inQ s; obj_at' (\<lambda>x. \<not> tcbQueued x) t s\<rbrakk> \<Longrightarrow> ct_not_inQ (s\<lparr> ksCurThread := t \<rparr>)"
     apply (simp add: ct_not_inQ_def o_def)
     done
-  have tcb_in_cur_domain_ct: "\<And>s f t.
-       tcb_in_cur_domain' t  (ksCurThread_update f s)= tcb_in_cur_domain' t s"
-    by (fastforce simp: tcb_in_cur_domain'_def)
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (clarsimp simp add: all_invs_but_ct_idle_or_in_cur_domain'_def invs'_def cur_tcb'_def valid_state'_def obj_at'_ct
-                              valid_pspace'_ct vms'_ct Invariants_H.valid_queues_def
+    apply (clarsimp simp add: all_invs_but_ct_idle_or_in_cur_domain'_def invs'_def cur_tcb'_def
+                              valid_state'_def Invariants_H.valid_queues_def
                               sch_act_wf ct_in_state'_def state_refs_of'_def
                               ps_clear_def valid_irq_node'_def valid_queues'_def ct_not_inQ_ct
-                              tcb_in_cur_domain_ct ct_idle_or_in_cur_domain'_def
+                              ct_idle_or_in_cur_domain'_def
                               bitmapQ_defs valid_queues_no_bitmap_def
                         cong: option.case_cong)
     done
@@ -988,9 +976,6 @@ lemma idle'_not_tcbQueued':
 lemma setCurThread_invs_no_cicd'_idle_thread:
   "\<lbrace>invs_no_cicd' and (\<lambda>s. t = ksIdleThread s) \<rbrace> setCurThread t \<lbrace>\<lambda>rv. invs'\<rbrace>"
 proof -
-  have vms'_ct: "\<And>s f.
-       valid_machine_state' (ksCurThread_update f s) = valid_machine_state' s"
-    by (simp add: valid_machine_state'_def)
   have ct_not_inQ_ct: "\<And>s t . \<lbrakk> ct_not_inQ s; obj_at' (\<lambda>x. \<not> tcbQueued x) t s\<rbrakk> \<Longrightarrow> ct_not_inQ (s\<lparr> ksCurThread := t \<rparr>)"
     apply (simp add: ct_not_inQ_def o_def)
     done
@@ -1000,7 +985,7 @@ proof -
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (clarsimp simp add: vms'_ct ct_not_inQ_ct idle'_activatable' idle'_not_tcbQueued'[simplified o_def]
+    apply (clarsimp simp add: ct_not_inQ_ct idle'_activatable' idle'_not_tcbQueued'[simplified o_def]
                               invs'_def cur_tcb'_def valid_state'_def valid_idle'_def
                               sch_act_wf ct_in_state'_def state_refs_of'_def
                               ps_clear_def valid_irq_node'_def
@@ -1211,25 +1196,20 @@ lemma switchToThread_invs[wp]:
 lemma setCurThread_ct_in_state:
   "\<lbrace>obj_at' (P \<circ> tcbState) t\<rbrace> setCurThread t \<lbrace>\<lambda>rv. ct_in_state' P\<rbrace>"
 proof -
-  have obj_at'_ct: "\<And>P addr f s.
-       obj_at' P addr (ksCurThread_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (simp add: ct_in_state'_def pred_tcb_at'_def obj_at'_ct o_def)
+    apply (simp add: ct_in_state'_def pred_tcb_at'_def o_def)
     done
 qed
 
 lemma switchToThread_ct_in_state[wp]:
   "\<lbrace>obj_at' (P \<circ> tcbState) t\<rbrace> switchToThread t \<lbrace>\<lambda>rv. ct_in_state' P\<rbrace>"
 proof -
-  have P: "\<And>f x. tcbState (tcbTimeSlice_update f x) = tcbState x"
-    by (case_tac x, simp)
   show ?thesis
     apply (simp add: Thread_H.switchToThread_def tcbSchedEnqueue_def unless_def)
     apply (wp setCurThread_ct_in_state Arch_switchToThread_obj_at
-         | simp add: P o_def cong: if_cong)+
+         | simp add: o_def cong: if_cong)+
     done
 qed
 
@@ -1624,14 +1604,6 @@ lemma corres_assert_assume_r:
   \<Longrightarrow> corres dc P (Q and (\<lambda>s. Q')) f (assert Q' >>= g)"
   by (force simp: corres_underlying_def assert_def return_def bind_def fail_def)
 
-lemma cur_tcb'_ksReadyQueuesL1Bitmap_upd[simp]:
-  "cur_tcb' (s\<lparr>ksReadyQueuesL1Bitmap := x\<rparr>) = cur_tcb' s"
-  unfolding cur_tcb'_def by simp
-
-lemma cur_tcb'_ksReadyQueuesL2Bitmap_upd[simp]:
-  "cur_tcb' (s\<lparr>ksReadyQueuesL2Bitmap := x\<rparr>) = cur_tcb' s"
-  unfolding cur_tcb'_def by simp
-
 crunch cur[wp]: tcbSchedEnqueue cur_tcb'
   (simp: unless_def)
 
@@ -1846,66 +1818,6 @@ lemma next_domain_corres:
   apply (rule corres_modify)
   apply (simp add: state_relation_def Let_def dschLength_def dschDomain_def)
   done
-
-lemma valid_queues'_ksCurDomain[simp]:
-  "valid_queues' (ksCurDomain_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksDomScheduleIdx[simp]:
-  "valid_queues' (ksDomScheduleIdx_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksDomSchedule[simp]:
-  "valid_queues' (ksDomSchedule_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksDomainTime[simp]:
-  "valid_queues' (ksDomainTime_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksWorkUnitsCompleted[simp]:
-  "valid_queues' (ksWorkUnitsCompleted_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues_ksCurDomain[simp]:
-  "Invariants_H.valid_queues (ksCurDomain_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksDomScheduleIdx[simp]:
-  "Invariants_H.valid_queues (ksDomScheduleIdx_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksDomSchedule[simp]:
-  "Invariants_H.valid_queues (ksDomSchedule_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksDomainTime[simp]:
-  "Invariants_H.valid_queues (ksDomainTime_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksWorkUnitsCompleted[simp]:
-  "Invariants_H.valid_queues (ksWorkUnitsCompleted_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_irq_node'_ksCurDomain[simp]:
-  "valid_irq_node' w (ksCurDomain_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksDomScheduleIdx[simp]:
-  "valid_irq_node' w (ksDomScheduleIdx_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksDomSchedule[simp]:
-  "valid_irq_node' w (ksDomSchedule_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksDomainTime[simp]:
-  "valid_irq_node' w (ksDomainTime_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksWorkUnitsCompleted[simp]:
-  "valid_irq_node' w (ksWorkUnitsCompleted_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
 
 lemma next_domain_valid_sched[wp]:
   "\<lbrace> valid_sched and (\<lambda>s. scheduler_action s  = choose_new_thread)\<rbrace> next_domain \<lbrace> \<lambda>_. valid_sched \<rbrace>"
@@ -2177,28 +2089,12 @@ lemma ssa_all_invs_but_ct_not_inQ':
    (\<lambda>s. sa = ResumeCurrentThread \<longrightarrow> ksCurThread s = ksIdleThread s \<or> tcb_in_cur_domain' (ksCurThread s) s)\<rbrace>
    setSchedulerAction sa \<lbrace>\<lambda>rv. all_invs_but_ct_not_inQ'\<rbrace>"
 proof -
-  have obj_at'_sa: "\<And>P addr f s.
-       obj_at' P addr (ksSchedulerAction_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
-  have valid_pspace'_sa: "\<And>f s.
-       valid_pspace' (ksSchedulerAction_update f s) = valid_pspace' s"
-    by simp
-  have iflive_sa: "\<And>f s.
-       if_live_then_nonz_cap' (ksSchedulerAction_update f s)
-         = if_live_then_nonz_cap' s"
-    by fastforce
-  have ifunsafe_sa[simp]: "\<And>f s.
-       if_unsafe_then_cap' (ksSchedulerAction_update f s) = if_unsafe_then_cap' s"
-    by fastforce
-  have idle_sa[simp]: "\<And>f s.
-       valid_idle' (ksSchedulerAction_update f s) = valid_idle' s"
-    by fastforce
   show ?thesis
     apply (simp add: setSchedulerAction_def)
     apply wp
     apply (clarsimp simp add: invs'_def valid_state'_def cur_tcb'_def
-                              obj_at'_sa valid_pspace'_sa Invariants_H.valid_queues_def
-                              state_refs_of'_def iflive_sa ps_clear_def
+                              Invariants_H.valid_queues_def
+                              state_refs_of'_def ps_clear_def
                               valid_irq_node'_def valid_queues'_def
                               tcb_in_cur_domain'_def ct_idle_or_in_cur_domain'_def
                               bitmapQ_defs valid_queues_no_bitmap_def
@@ -2247,13 +2143,10 @@ lemma switchToThread_ct_not_queued_2:
 lemma setCurThread_obj_at':
   "\<lbrace> obj_at' P t \<rbrace> setCurThread t \<lbrace>\<lambda>rv s. obj_at' P (ksCurThread s) s \<rbrace>"
 proof -
-  have obj_at'_ct: "\<And>P addr f s.
-       obj_at' P addr (ksCurThread_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (simp add: ct_in_state'_def st_tcb_at'_def obj_at'_ct)
+    apply (simp add: ct_in_state'_def st_tcb_at'_def)
     done
 qed
 
@@ -2275,16 +2168,11 @@ lemma switchToIdleThread_activatable_2[wp]:
   done
 
 lemma switchToThread_tcb_in_cur_domain':
-  "\<lbrace>tcb_in_cur_domain' thread\<rbrace> ThreadDecls_H.switchToThread thread
-  \<lbrace>\<lambda>y s. tcb_in_cur_domain' (ksCurThread s) s\<rbrace>"
-  apply (simp add: Thread_H.switchToThread_def)
-  apply (rule hoare_pre)
-  apply (wp)
-    apply (simp add: ARM_HYP_H.switchToThread_def setCurThread_def)
-    apply (wp tcbSchedDequeue_not_tcbQueued | simp )+
-   apply (simp add:tcb_in_cur_domain'_def)
-   apply (wp tcbSchedDequeue_tcbDomain | wps)+
-  apply (clarsimp simp:tcb_in_cur_domain'_def)
+  "\<lbrace>tcb_in_cur_domain' thread\<rbrace>
+   ThreadDecls_H.switchToThread thread
+   \<lbrace>\<lambda>y s. tcb_in_cur_domain' (ksCurThread s) s\<rbrace>"
+  apply (simp add: Thread_H.switchToThread_def setCurThread_def)
+  apply (wpsimp wp: tcbSchedDequeue_not_tcbQueued)
   done
 
 lemma chooseThread_invs_no_cicd'_posts: (* generic version *)
@@ -2451,13 +2339,10 @@ lemma schedule_sch_act_simple:
 lemma ssa_ct:
   "\<lbrace>ct_in_state' P\<rbrace> setSchedulerAction sa \<lbrace>\<lambda>rv. ct_in_state' P\<rbrace>"
 proof -
-  have obj_at'_sa: "\<And>P addr f s.
-       obj_at' P addr (ksSchedulerAction_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
   show ?thesis
     apply (unfold setSchedulerAction_def)
     apply wp
-    apply (clarsimp simp add: ct_in_state'_def pred_tcb_at'_def obj_at'_sa)
+    apply (clarsimp simp add: ct_in_state'_def pred_tcb_at'_def)
     done
 qed
 

--- a/proof/refine/ARM_HYP/StateRelation.thy
+++ b/proof/refine/ARM_HYP/StateRelation.thy
@@ -9,7 +9,7 @@
 *)
 
 theory StateRelation
-imports Invariants_H
+imports InvariantUpdates_H
 begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -280,11 +280,6 @@ lemma msg_from_syserr_map[simp]:
   apply (case_tac err,clarsimp+)
   done
 
-(* FIXME: move *)
-lemma non_exst_same_timeSlice_upd[simp]:
-  "non_exst_same tcb (tcbDomain_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
 lemma threadSet_tcbDomain_update_ct_idle_or_in_cur_domain':
   "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. ksSchedulerAction s \<noteq> ResumeCurrentThread) \<rbrace>
      threadSet (tcbDomain_update (\<lambda>_. domain)) t
@@ -1820,10 +1815,6 @@ lemma hc_invs'[wp]:
   apply (wp)
   apply (clarsimp)
   done
-
-lemma sch_act_sane_ksMachineState [iff]:
-  "sch_act_sane (s\<lparr>ksMachineState := b\<rparr>) = sch_act_sane s"
-  by (simp add: sch_act_sane_def)
 
 lemma cteInsert_sane[wp]:
   "\<lbrace>sch_act_sane\<rbrace> cteInsert newCap srcSlot destSlot \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"

--- a/proof/refine/ARM_HYP/TcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/TcbAcc_R.thy
@@ -151,54 +151,6 @@ lemma valid_objs'_maxPriority:
   apply (clarsimp simp: valid_tcb'_def)
   done
 
-lemma invs'_machine:
-  assumes mask: "irq_masks (f (ksMachineState s)) =
-                 irq_masks (ksMachineState s)"
-  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
-                valid_machine_state' s"
-  shows "invs' (ksMachineState_update f s) = invs' s"
-proof -
-  have valid_pspace'_machine: "\<And>f s.
-       valid_pspace' (ksMachineState_update f s) = valid_pspace' s"
-    by simp
-  have valid_idle'_machine: "\<And>f s.
-       valid_idle' (ksMachineState_update f s) = valid_idle' s"
-    by fastforce
-  show ?thesis
-    apply (cases "ksSchedulerAction s")
-    apply (simp_all add: invs'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
-                    vms ct_not_inQ_def
-                    state_refs_of'_def ps_clear_def
-                    valid_irq_node'_def mask
-              cong: option.case_cong)
-    done
-qed
-
-lemma invs_no_cicd'_machine:
-  assumes mask: "irq_masks (f (ksMachineState s)) =
-                 irq_masks (ksMachineState s)"
-  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
-                valid_machine_state' s"
-  shows "invs_no_cicd' (ksMachineState_update f s) = invs_no_cicd' s"
-proof -
-  have valid_pspace'_machine: "\<And>f s.
-       valid_pspace' (ksMachineState_update f s) = valid_pspace' s"
-    by simp
-  have valid_idle'_machine: "\<And>f s.
-       valid_idle' (ksMachineState_update f s) = valid_idle' s"
-    by fastforce
-  show ?thesis
-    apply (cases "ksSchedulerAction s")
-    apply (simp_all add: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
-                    vms ct_not_inQ_def
-                    state_refs_of'_def ps_clear_def
-                    valid_irq_node'_def mask
-              cong: option.case_cong)
-    done
-qed
-
 lemma doMachineOp_irq_states':
   assumes masks: "\<And>P. \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks s)\<rbrace>"
   shows "\<lbrace>valid_irq_states'\<rbrace> doMachineOp f \<lbrace>\<lambda>rv. valid_irq_states'\<rbrace>"
@@ -692,15 +644,6 @@ lemma threadSet_pspace_no_overlap' [wp]:
   apply (clarsimp simp: obj_at'_def)
   done
 
-lemma pspace_no_overlap_queues [simp]:
-  "pspace_no_overlap' w sz (ksReadyQueues_update f s) = pspace_no_overlap' w sz s"
-  by (simp add: pspace_no_overlap'_def)
-
-lemma pspace_no_overlap'_ksSchedulerAction[simp]:
-  "pspace_no_overlap' a b (ksSchedulerAction_update f s) =
-   pspace_no_overlap' a b s"
-  by (simp add: pspace_no_overlap'_def)
-
 lemma threadSet_global_refsT:
   assumes x: "\<forall>tcb. \<forall>(getF, setF) \<in> ran tcb_cte_cases.
                  getF (F tcb) = getF tcb"
@@ -1017,10 +960,6 @@ lemma threadSet_valid_queues_Qf:
   apply (clarsimp simp: valid_queues'_def subset_iff)
   done
 
-lemma ksReadyQueues_update_id:
-  "ksReadyQueues_update id s = s"
-  by simp
-
 lemma addToQs_subset:
   "set (qs p) \<subseteq> set (addToQs F t qs p)"
 by (clarsimp simp: addToQs_def split_def)
@@ -1264,14 +1203,6 @@ lemma threadSet_vms'[wp]:
   "\<lbrace>valid_machine_state'\<rbrace> threadSet F t \<lbrace>\<lambda>rv. valid_machine_state'\<rbrace>"
   apply (simp add: valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def)
   by (intro hoare_vcg_all_lift hoare_vcg_disj_lift; wp)
-
-lemma vms_ksReadyQueues_update[simp]:
-  "valid_machine_state' (ksReadyQueues_update f s) = valid_machine_state' s"
-  by (simp add: valid_machine_state'_def)
-
-lemma ct_not_inQ_ksReadyQueues_update[simp]:
-  "ct_not_inQ (ksReadyQueues_update f s) = ct_not_inQ s"
-  by (simp add: ct_not_inQ_def)
 
 lemma threadSet_not_inQ:
   "\<lbrace>ct_not_inQ and (\<lambda>s. (\<exists>tcb. tcbQueued (F tcb) \<and> \<not> tcbQueued tcb)
@@ -1521,10 +1452,6 @@ lemma asUser_typ_at' [wp]:
   by (simp add: asUser_def bind_assoc split_def, wp select_f_inv)
 
 lemmas asUser_typ_ats[wp] = typ_at_lifts [OF asUser_typ_at']
-
-lemma inQ_context[simp]:
-  "inQ d p (tcbArch_update f tcb) = inQ d p tcb"
-  by (cases tcb, simp add: inQ_def)
 
 lemma asUser_invs[wp]:
   "\<lbrace>invs' and tcb_at' t\<rbrace> asUser t m \<lbrace>\<lambda>rv. invs'\<rbrace>"
@@ -1979,6 +1906,10 @@ definition
 where
  "weak_sch_act_wf sa = (\<lambda>s. \<forall>t. sa = SwitchToThread t \<longrightarrow> st_tcb_at' runnable' t s \<and> tcb_in_cur_domain' t s)"
 
+lemma weak_sch_act_wf_updateDomainTime[simp]:
+  "weak_sch_act_wf m (ksDomainTime_update f s) = weak_sch_act_wf m s"
+  by (simp add:weak_sch_act_wf_def tcb_in_cur_domain'_def )
+
 lemma set_sa_corres:
   "sched_act_relation sa sa'
     \<Longrightarrow> corres dc \<top> \<top> (set_scheduler_action sa) (setSchedulerAction sa')"
@@ -2221,14 +2152,9 @@ lemma sbn_corres:
 crunches rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotification
   for tcb'[wp]: "tcb_at' addr"
 
-lemma valid_tcb_tcbQueued:
-  "valid_tcb' (tcbQueued_update f tcb) = valid_tcb' tcb"
-  by (cases tcb, rule ext, simp add: valid_tcb'_def tcb_cte_cases_def)
-
 crunches rescheduleRequired, removeFromBitmap
   for valid_objs'[wp]: valid_objs'
-  (simp: unless_def valid_tcb_tcbQueued crunch_simps)
-
+  (simp: crunch_simps)
 
 lemma tcbSchedDequeue_valid_objs' [wp]: "\<lbrace> valid_objs' \<rbrace> tcbSchedDequeue t \<lbrace>\<lambda>_. valid_objs' \<rbrace>"
   unfolding tcbSchedDequeue_def
@@ -2966,11 +2892,6 @@ lemma tcbSchedAppend_valid_queues[wp]:
    unfolding tcbSchedAppend_def
    by (fastforce intro:  tcbSchedEnqueueOrAppend_valid_queues)
 
-lemma valid_queues_ksSchedulerAction_update[simp]:
-  "Invariants_H.valid_queues (ksSchedulerAction_update f s) = Invariants_H.valid_queues s"
- unfolding Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
- by simp
-
 lemma rescheduleRequired_valid_queues[wp]:
   "\<lbrace>\<lambda>s. Invariants_H.valid_queues s \<and> valid_objs' s \<and>
         weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
@@ -2988,18 +2909,6 @@ lemma rescheduleRequired_valid_queues_sch_act_simple:
   apply (simp add: rescheduleRequired_def)
   apply (wp | wpc | simp | fastforce simp: Invariants_H.valid_queues_def sch_act_simple_def)+
   done
-
-lemma valid_bitmapQ_ksSchedulerAction_upd[simp]:
-  "valid_bitmapQ (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>) = valid_bitmapQ s"
-  unfolding bitmapQ_defs by simp
-
-lemma bitmapQ_no_L1_orphans_ksSchedulerAction_upd[simp]:
-  "bitmapQ_no_L1_orphans (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>) = bitmapQ_no_L1_orphans s"
-  unfolding bitmapQ_defs by simp
-
-lemma bitmapQ_no_L2_orphans_ksSchedulerAction_upd[simp]:
-  "bitmapQ_no_L2_orphans (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>) = bitmapQ_no_L2_orphans s"
-  unfolding bitmapQ_defs by simp
 
 lemma rescheduleRequired_valid_bitmapQ_sch_act_simple:
   "\<lbrace> valid_bitmapQ and sch_act_simple\<rbrace>
@@ -3131,10 +3040,6 @@ lemma tcbSchedEnqueue_valid_queues'[wp]:
   apply (clarsimp simp: obj_at'_def)
   done
 
-lemma valid_queues'_ksSchedulerAction_update[simp]:
-  "Invariants_H.valid_queues' (ksSchedulerAction_update f s) = Invariants_H.valid_queues' s"
-  by (simp add: valid_queues'_def)
-
 lemma rescheduleRequired_valid_queues'_weak[wp]:
   "\<lbrace>\<lambda>s. valid_queues' s \<and> weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
     rescheduleRequired
@@ -3169,7 +3074,8 @@ lemma setBoundNotification_valid_queues'[wp]:
   apply (fastforce simp: inQ_def obj_at'_def pred_tcb_at'_def)
   done
 
-lemma valid_tcb'_tcbState_update:"\<And>tcb s st . \<lbrakk> valid_tcb_state' st s; valid_tcb' tcb s \<rbrakk> \<Longrightarrow> valid_tcb' (tcbState_update (\<lambda>_. st) tcb) s"
+lemma valid_tcb'_tcbState_update:
+  "\<lbrakk> valid_tcb_state' st s; valid_tcb' tcb s \<rbrakk> \<Longrightarrow> valid_tcb' (tcbState_update (\<lambda>_. st) tcb) s"
   apply (clarsimp simp: valid_tcb'_def tcb_cte_cases_def valid_tcb_state'_def)
   done
 
@@ -4209,27 +4115,6 @@ lemma tcbSchedAppend_ct_not_inQ:
       done
   qed
 
-lemma ct_not_inQ_update_cnt:
-  "ct_not_inQ s \<Longrightarrow> ct_not_inQ (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
-   by (simp add: ct_not_inQ_def)
-
-lemma ct_not_inQ_update_stt:
-  "ct_not_inQ s \<Longrightarrow> ct_not_inQ (s\<lparr>ksSchedulerAction := SwitchToThread t\<rparr>)"
-   by (simp add: ct_not_inQ_def)
-
-lemma valid_bitmapQ_upd_scheduler_action:
-  "valid_bitmapQ (s\<lparr>ksSchedulerAction := x \<rparr>) = valid_bitmapQ s"
-  unfolding bitmapQ_defs
-  by simp
-
-lemma invs'_update_cnt:
-  "invs' s \<Longrightarrow> invs' (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
-   by (clarsimp simp: invs'_def valid_state'_def ct_not_inQ_update_cnt
-                      valid_queues_def valid_queues'_def valid_irq_node'_def
-                      cur_tcb'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                      valid_bitmapQ_upd_scheduler_action valid_queues_no_bitmap_def
-                      bitmapQ_no_L2_orphans_def bitmapQ_no_L1_orphans_def)
-
 lemma setSchedulerAction_direct:
   "\<lbrace>\<top>\<rbrace> setSchedulerAction sa \<lbrace>\<lambda>_ s. ksSchedulerAction s = sa\<rbrace>"
   by (wpsimp simp: setSchedulerAction_def)
@@ -4258,10 +4143,9 @@ lemma possibleSwitchTo_ct_not_inQ:
     possibleSwitchTo t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
   (is "\<lbrace>?PRE\<rbrace> _ \<lbrace>_\<rbrace>")
   apply (simp add: possibleSwitchTo_def curDomain_def)
-  apply (wp static_imp_wp rescheduleRequired_ct_not_inQ tcbSchedEnqueue_ct_not_inQ threadGet_wp
-       | wpc
-       | (rule hoare_post_imp[OF _ rescheduleRequired_sa_cnt], fastforce)
-       | clarsimp simp: ct_not_inQ_update_stt bitmap_fun_defs)+
+  apply (wpsimp wp: static_imp_wp rescheduleRequired_ct_not_inQ tcbSchedEnqueue_ct_not_inQ
+                    threadGet_wp
+       | (rule hoare_post_imp[OF _ rescheduleRequired_sa_cnt], fastforce))+
   apply (fastforce simp: obj_at'_def)
   done
 
@@ -4690,6 +4574,18 @@ where
   "non_exst_same' (KOTCB tcb) (KOTCB tcb') = non_exst_same tcb tcb'" |
   "non_exst_same' _ _ = True"
 
+lemma non_exst_same_prio_upd[simp]:
+  "non_exst_same tcb (tcbPriority_update f tcb)"
+  by (cases tcb, simp add: non_exst_same_def)
+
+lemma non_exst_same_timeSlice_upd[simp]:
+  "non_exst_same tcb (tcbTimeSlice_update f tcb)"
+  by (cases tcb, simp add: non_exst_same_def)
+
+lemma non_exst_same_domain_upd[simp]:
+  "non_exst_same tcb (tcbDomain_update f tcb)"
+  by (cases tcb, simp add: non_exst_same_def)
+
 lemma set_eobject_corres':
   assumes e: "etcb_relation etcb tcb'"
   assumes z: "\<And>s. obj_at' P ptr s
@@ -4790,14 +4686,6 @@ lemma ethread_set_corresT:
 
 lemmas ethread_set_corres =
     ethread_set_corresT [OF _ all_tcbI, OF _ ball_tcb_cte_casesI]
-
-lemma non_exst_same_prio_upd[simp]:
-  "non_exst_same tcb (tcbPriority_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma non_exst_same_timeSlice_upd[simp]:
-  "non_exst_same tcb (tcbTimeSlice_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
 
 end
 end

--- a/proof/refine/ARM_HYP/Tcb_R.thy
+++ b/proof/refine/ARM_HYP/Tcb_R.thy
@@ -744,10 +744,6 @@ lemma setP_vq[wp]:
            | clarsimp simp: valid_objs'_maxDomain valid_objs'_maxPriority)+
   done
 
-lemma ps_clear_ksReadyQueue[simp]:
-  "ps_clear x n (ksReadyQueues_update f s) = ps_clear x n s"
-  by (simp add: ps_clear_def)
-
 lemma valid_queues_subsetE':
   "\<lbrakk> valid_queues' s; ksPSpace s = ksPSpace s';
      \<forall>x. set (ksReadyQueues s x) \<subseteq> set (ksReadyQueues s' x) \<rbrakk>
@@ -756,10 +752,6 @@ lemma valid_queues_subsetE':
                 ps_clear_def subset_iff projectKOs)
 
 crunch vq'[wp]: getCurThread valid_queues'
-
-lemma valid_queues_ksSchedulerAction_update [simp]:
-  "valid_queues' (ksSchedulerAction_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
 
 lemma setP_vq'[wp]:
   "\<lbrace>\<lambda>s. valid_queues' s \<and> tcb_at' t s \<and> sch_act_wf (ksSchedulerAction s) s \<and> p \<le> maxPriority\<rbrace>
@@ -796,14 +788,6 @@ lemma setQueue_ex_idle_cap[wp]:
    \<lbrace>\<lambda>rv s. ex_nonz_cap_to' (ksIdleThread s) s\<rbrace>"
   by (simp add: setQueue_def, wp,
       simp add: ex_nonz_cap_to'_def cte_wp_at_pspaceI)
-
-lemma tcbPriority_ts_safe:
-  "tcbState (tcbPriority_update f tcb) = tcbState tcb"
-  by (case_tac tcb, simp)
-
-lemma tcbQueued_ts_safe:
-  "tcbState (tcbQueued_update f tcb) = tcbState tcb"
-  by (case_tac tcb, simp)
 
 lemma tcbPriority_caps_safe:
   "\<forall>tcb. \<forall>x\<in>ran tcb_cte_cases. (\<lambda>(getF, setF). getF (tcbPriority_update f tcb) = getF tcb) x"
@@ -1235,10 +1219,6 @@ proof -
    apply (clarsimp simp: cur_tcb'_def valid_irq_node'_def valid_queues'_def o_def)
   by (fastforce simp: domains ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def z a)
 qed
-
-lemma inQ_tcbIPCBuffer_update_idem[simp]:
-  "inQ d p (tcbIPCBuffer_update (\<lambda>_. x) ko) = inQ d p ko"
-  by (clarsimp simp: inQ_def)
 
 lemma getThreadBufferSlot_dom_tcb_cte_cases:
   "\<lbrace>\<top>\<rbrace> getThreadBufferSlot a \<lbrace>\<lambda>rv s. rv \<in> (+) a ` dom tcb_cte_cases\<rbrace>"

--- a/proof/refine/ARM_HYP/Untyped_R.thy
+++ b/proof/refine/ARM_HYP/Untyped_R.thy
@@ -4436,11 +4436,6 @@ crunch ct_in_state'[wp]: doMachineOp "ct_in_state' P"
 crunch st_tcb_at'[wp]: doMachineOp "st_tcb_at' P p"
   (simp: crunch_simps ct_in_state'_def)
 
-lemma ex_cte_cap_wp_to_work_units[simp]:
-  "ex_cte_cap_wp_to' P slot (ksWorkUnitsCompleted_update f s)
-    = ex_cte_cap_wp_to' P slot s"
-  by (simp add: ex_cte_cap_wp_to'_def)
-
 lemma ex_cte_cap_wp_to_irq_state_independent_H[simp]:
   "irq_state_independent_H (ex_cte_cap_wp_to' P slot)"
   by (simp add: ex_cte_cap_wp_to'_def)
@@ -4476,9 +4471,6 @@ lemma setCTE_ct_in_state:
   apply (rule hoare_pre, wp ct_in_state'_decomp setCTE_pred_tcb_at')
   apply (auto simp: ct_in_state'_def)
   done
-
-add_upd_simps "ct_in_state' P (gsUntypedZeroRanges_update f s)"
-declare upd_simps[simp]
 
 crunch ct_in_state[wp]: updateFreeIndex "ct_in_state' P"
 crunch nosch[wp]: updateFreeIndex "\<lambda>s. P (ksSchedulerAction s)"

--- a/proof/refine/ARM_HYP/VSpace_R.thy
+++ b/proof/refine/ARM_HYP/VSpace_R.thy
@@ -3263,14 +3263,13 @@ lemma findFreeHWASID_invs:
              ct_not_inQ_def
            split del: if_split)
   apply (intro conjI)
-    apply (fastforce dest: no_irq_use [OF no_irq_invalidateLocalTLB_ASID])
-   apply clarsimp
-   apply (drule_tac x=p in spec)
-   apply (drule use_valid)
+   apply (fastforce dest: no_irq_use [OF no_irq_invalidateLocalTLB_ASID])
+  apply clarsimp
+  apply (drule_tac x=p in spec)
+  apply (drule use_valid)
     apply (rule_tac p=p in invalidateLocalTLB_ASID_underlying_memory)
-    apply blast
-   apply clarsimp
-  apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+   apply blast
+  apply clarsimp
   done
 
 lemma findFreeHWASID_invs_no_cicd':
@@ -3409,10 +3408,6 @@ crunch ksIdleThread[wp]: asUser "\<lambda>s. P (ksIdleThread s)"
 (wp: crunch_wps simp: crunch_simps)
 crunch ksQ[wp]: asUser "\<lambda>s. P (ksReadyQueues s)"
 (wp: crunch_wps simp: crunch_simps)
-
-lemma ct_not_inQ_ksArchState_update[simp]:
-  "ct_not_inQ (s\<lparr>ksArchState := v\<rparr>) = ct_not_inQ s"
-  by (simp add: ct_not_inQ_def)
 
 lemma dmo_machine_op_lift_invs'[wp]:
   "doMachineOp (machine_op_lift f) \<lbrace>invs'\<rbrace>"
@@ -4006,8 +4001,6 @@ lemma invs'_armHSCurVCPU_update[simp]:
              valid_queues'_def valid_irq_node'_def valid_irq_handlers'_def
              irq_issued'_def irqs_masked'_def valid_machine_state'_def
              cur_tcb'_def)
-  apply (simp_all add: ct_in_state'_def tcb_in_cur_domain'_def
-                       ct_idle_or_in_cur_domain'_def ct_not_inQ_def)
   done
 
 lemma armHSCurVCPU_None_invs'[wp]:

--- a/proof/refine/ARM_HYP/orphanage/Orphanage.thy
+++ b/proof/refine/ARM_HYP/orphanage/Orphanage.thy
@@ -8,6 +8,6 @@ theory Orphanage
 imports Refine.Refine
 begin
 
-(* FIXME: palce holder, Orphanage not proved for ARM_HYP *)
+(* FIXME: place holder, Orphanage not proved for ARM_HYP *)
 
 end

--- a/proof/refine/Move_R.thy
+++ b/proof/refine/Move_R.thy
@@ -250,4 +250,10 @@ lemma check_active_irq_invs_just_idle:
         and (\<lambda>s. 0 < domain_time s) and valid_domain_list \<rbrace>"
   by (wpsimp simp: check_active_irq_def ct_in_state_def)
 
+lemma caps_of_state_kheap_ekheap[simp]:
+  "caps_of_state (kheap_update f (ekheap_update ef s))
+     = caps_of_state (kheap_update f s)"
+  apply (simp add: trans_state_update[symmetric] del: trans_state_update)
+  done
+
 end

--- a/proof/refine/RISCV64/ArchAcc_R.thy
+++ b/proof/refine/RISCV64/ArchAcc_R.thy
@@ -1115,14 +1115,6 @@ lemma clearMemory_vms':
   apply (rule clearMemory_um_eq_0)
   done
 
-lemma ct_not_inQ_ksMachineState_update[simp]:
-  "ct_not_inQ (s\<lparr>ksMachineState := v\<rparr>) = ct_not_inQ s"
-  by (simp add: ct_not_inQ_def)
-
-lemma ct_in_current_domain_ksMachineState_update[simp]:
-  "ct_idle_or_in_cur_domain' (s\<lparr>ksMachineState := v\<rparr>) = ct_idle_or_in_cur_domain' s"
-  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-
 lemma dmo_clearMemory_invs'[wp]:
   "\<lbrace>invs'\<rbrace> doMachineOp (clearMemory w sz) \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (simp add: doMachineOp_def split_def)

--- a/proof/refine/RISCV64/Arch_R.thy
+++ b/proof/refine/RISCV64/Arch_R.thy
@@ -1036,14 +1036,6 @@ lemma invokeArch_tcb_at':
                   wp: performASIDControlInvocation_tcb_at')
   done
 
-lemma pspace_no_overlap_queuesL1 [simp]:
-  "pspace_no_overlap' w sz (ksReadyQueuesL1Bitmap_update f s) = pspace_no_overlap' w sz s"
-  by (simp add: pspace_no_overlap'_def)
-
-lemma pspace_no_overlap_queuesL2 [simp]:
-  "pspace_no_overlap' w sz (ksReadyQueuesL2Bitmap_update f s) = pspace_no_overlap' w sz s"
-  by (simp add: pspace_no_overlap'_def)
-
 crunch pspace_no_overlap'[wp]: setThreadState "pspace_no_overlap' w s"
   (simp: unless_def)
 

--- a/proof/refine/RISCV64/CNodeInv_R.thy
+++ b/proof/refine/RISCV64/CNodeInv_R.thy
@@ -563,6 +563,14 @@ where
  "not_recursive_ctes s \<equiv> {ptr. \<exists>cap. cteCaps_of s ptr = Some cap
                              \<and> \<not> (isZombie cap \<and> capZombiePtr cap = ptr)}"
 
+lemma not_recursive_ctes_wu [simp]:
+  "not_recursive_ctes (ksWorkUnitsCompleted_update f s) = not_recursive_ctes s"
+  by (simp add: not_recursive_ctes_def)
+
+lemma not_recursive_ctes_irq_state_independent[simp, intro!]:
+  "not_recursive_ctes (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := x \<rparr>\<rparr>) = not_recursive_ctes s"
+  by (simp add: not_recursive_ctes_def)
+
 lemma capSwap_not_recursive:
   "\<lbrace>\<lambda>s. card (not_recursive_ctes s) \<le> n
      \<and> cte_wp_at' (\<lambda>cte. \<not> (isZombie (cteCap cte) \<and> capZombiePtr (cteCap cte) = p1)) p1 s
@@ -700,24 +708,6 @@ lemma case_Zombie_assert_fold:
   "(case cap of Zombie ptr zb n \<Rightarrow> haskell_assertE (P ptr) str | _ \<Rightarrow> returnOk ())
        = assertE (isZombie cap \<longrightarrow> P (capZombiePtr cap))"
   by (cases cap, simp_all add: isCap_simps assertE_def)
-
-lemma not_recursive_ctes_wu [simp]:
-  "not_recursive_ctes (ksWorkUnitsCompleted_update f s) = not_recursive_ctes s"
-  by (simp add: not_recursive_ctes_def)
-
-lemma not_recursive_ctes_irq_state_independent[simp, intro!]:
-  "not_recursive_ctes (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := x \<rparr>\<rparr>) = not_recursive_ctes s"
-  by (simp add: not_recursive_ctes_def)
-
-lemma typ_at'_irq_state_independent[simp, intro!]:
-  "P (typ_at' T p (s \<lparr>ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr>\<rparr>))
-   = P (typ_at' T p s)"
-  by (simp add: typ_at'_def)
-
-lemma sch_act_simple_irq_state_independent[intro!, simp]:
-  "sch_act_simple (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr> \<rparr>) =
-   sch_act_simple s"
-  by (simp add: sch_act_simple_def)
 
 termination finaliseSlot'
   apply (rule finaliseSlot'.termination,
@@ -5846,10 +5836,6 @@ lemma cancelIPC_cap_to'[wp]:
                | wpcw | wp (once) hoare_drop_imps)+
   done
 
-lemma ex_cte_cap_wp_to'_ksReadyQueuesL1Bitmap[simp]:
-   "ex_cte_cap_wp_to' P p (s\<lparr> ksReadyQueuesL1Bitmap := x \<rparr>) = ex_cte_cap_wp_to' P p s"
-   unfolding ex_cte_cap_wp_to'_def by simp
-
 lemma emptySlot_deletes [wp]:
   "\<lbrace>\<top>\<rbrace> emptySlot p opt \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. cteCap c = NullCap) p s\<rbrace>"
   apply (simp add: emptySlot_def case_Null_If)
@@ -6129,14 +6115,6 @@ lemmas preemptionPoint_invR =
 
 lemmas preemptionPoint_invE =
   valid_validE_E [OF preemptionPoint_inv]
-
-lemma sch_act_simple_wu [simp, intro!]:
-  "sch_act_simple (ksWorkUnitsCompleted_update f s) = sch_act_simple s"
-  by (simp add: sch_act_simple_def)
-
-lemma ex_cte_cap_to'_wu [simp, intro!]:
-  "ex_cte_cap_to' p (ksWorkUnitsCompleted_update f s) = ex_cte_cap_to' p s"
-  by (simp add: ex_cte_cap_to'_def)
 
 lemma finaliseSlot_invs':
   assumes finaliseCap:

--- a/proof/refine/RISCV64/CSpace1_R.thy
+++ b/proof/refine/RISCV64/CSpace1_R.thy
@@ -828,14 +828,6 @@ lemma setCTE_tcb_in_cur_domain':
   apply (wp setObject_cte_obj_at_tcb' | simp)+
   done
 
-lemma tcbCTable_upd_simp [simp]:
-  "tcbCTable (tcbCTable_update (\<lambda>_. x) tcb) = x"
-  by (cases tcb) simp
-
-lemma tcbVTable_upd_simp [simp]:
-  "tcbVTable (tcbVTable_update (\<lambda>_. x) tcb) = x"
-  by (cases tcb) simp
-
 lemma setCTE_ctes_of_wp [wp]:
   "\<lbrace>\<lambda>s. P (ctes_of s (p \<mapsto> cte))\<rbrace>
   setCTE p cte
@@ -1345,7 +1337,7 @@ lemma weak_derived_updateCapData:
   apply (clarsimp simp: Let_def isCap_simps updateCapData_def)
   done
 
-lemma maskCapRights_Reply:
+lemma maskCapRights_Reply[simp]:
   "isReplyCap (maskCapRights r c) = isReplyCap c"
   apply (insert capMasterCap_maskCapRights)
   apply (rule master_eqI, rule isCap_Master)

--- a/proof/refine/RISCV64/CSpace1_R.thy
+++ b/proof/refine/RISCV64/CSpace1_R.thy
@@ -792,7 +792,7 @@ lemma setObject_cte_obj_at_tcb':
   \<lbrace>\<lambda>_ s. P' (obj_at' P p s)\<rbrace>"
   apply (clarsimp simp: setObject_def in_monad split_def
                         valid_def lookupAround2_char1
-                        obj_at'_def ps_clear_upd')
+                        obj_at'_def ps_clear_upd)
   apply (clarsimp elim!: rsubst[where P=P'])
   apply (clarsimp simp: updateObject_cte in_monad objBits_simps
                         tcbCTableSlot_def tcbVTableSlot_def x

--- a/proof/refine/RISCV64/CSpace_R.thy
+++ b/proof/refine/RISCV64/CSpace_R.thy
@@ -2525,10 +2525,10 @@ lemma setCTE_ko_wp_at_live[wp]:
                  elim!: rsubst[where P=P])
   apply (drule(1) updateObject_cte_is_tcb_or_cte [OF _ refl, rotated])
   apply (elim exE conjE disjE)
-   apply (clarsimp simp: ps_clear_upd' objBits_simps
+   apply (clarsimp simp: ps_clear_upd objBits_simps
                          lookupAround2_char1)
    apply (simp add: tcb_cte_cases_def split: if_split_asm)
-  apply (clarsimp simp: ps_clear_upd' objBits_simps)
+  apply (clarsimp simp: ps_clear_upd objBits_simps)
   done
 
 lemma setCTE_iflive':
@@ -2586,10 +2586,10 @@ lemma setCTE_ko_wp_at_not_live[wp]:
                  elim!: rsubst[where P=P])
   apply (drule(1) updateObject_cte_is_tcb_or_cte [OF _ refl, rotated])
   apply (elim exE conjE disjE)
-   apply (clarsimp simp: ps_clear_upd' objBits_simps
+   apply (clarsimp simp: ps_clear_upd objBits_simps
                          lookupAround2_char1)
    apply (simp add: tcb_cte_cases_def split: if_split_asm)
-  apply (clarsimp simp: ps_clear_upd' objBits_simps)
+  apply (clarsimp simp: ps_clear_upd objBits_simps)
   done
 
 lemma setUntypedCapAsFull_ko_wp_not_at'[wp]:

--- a/proof/refine/RISCV64/Detype_R.thy
+++ b/proof/refine/RISCV64/Detype_R.thy
@@ -86,10 +86,6 @@ lemma descendants_range_inD':
   done
 end
 
-interpretation clear_um:
-  p_arch_idle_update_int_eq "clear_um S"
-  by unfold_locales (simp_all add: clear_um_def)
-
 context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma descendants_range'_def2:
@@ -1401,7 +1397,7 @@ proof (simp add: invs'_def valid_state'_def valid_pspace'_def
     done
 
   from sa_simp ctnotinQ
-  show "ct_not_inQ ?state''"
+  show "ct_not_inQ state'"
     apply (clarsimp simp: ct_not_inQ_def pred_tcb_at'_def)
     apply (drule obj_at'_and
                    [THEN iffD2, OF conjI,
@@ -1413,7 +1409,7 @@ proof (simp add: invs'_def valid_state'_def valid_pspace'_def
     apply (clarsimp dest!: ex_nonz_cap_notRange)
     done
 
-  from ctcd show "ct_idle_or_in_cur_domain' ?state''"
+  from ctcd show "ct_idle_or_in_cur_domain' state'"
     apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
     apply (intro impI)
     apply (elim disjE impE)
@@ -1581,14 +1577,6 @@ lemma deleteObjects_st_tcb_at':
   apply (simp add: delete_locale_def)
   done
 
-lemma ex_cte_cap_wp_to'_gsCNodes_update[simp]:
-  "ex_cte_cap_wp_to' P p (gsCNodes_update f s') = ex_cte_cap_wp_to' P p s'"
-  by (simp add: ex_cte_cap_wp_to'_def)
-
-lemma ex_cte_cap_wp_to'_gsUserPages_update[simp]:
-  "ex_cte_cap_wp_to' P p (gsUserPages_update f s') = ex_cte_cap_wp_to' P p s'"
-  by (simp add: ex_cte_cap_wp_to'_def)
-
 lemma deleteObjects_cap_to':
   "\<lbrace>cte_wp_at' (\<lambda>c. cteCap c = UntypedCap d ptr bits idx) p
      and invs' and ct_active' and sch_act_simple
@@ -1636,19 +1624,6 @@ lemma valid_untyped_no_overlap:
     apply (clarsimp simp:p_assoc_help mask_def)
    apply (fastforce simp: mask_def add_diff_eq)+
   done
-
-lemma pspace_no_overlap'_gsCNodes_update[simp]:
-  "pspace_no_overlap' p b (gsCNodes_update f s') = pspace_no_overlap' p b s'"
-  by (simp add: pspace_no_overlap'_def)
-
-lemma pspace_no_overlap'_gsUserPages_update[simp]:
-  "pspace_no_overlap' p b (gsUserPages_update f s') = pspace_no_overlap' p b s'"
-  by (simp add: pspace_no_overlap'_def)
-
-lemma pspace_no_overlap'_ksMachineState_update[simp]:
-  "pspace_no_overlap' p n (ksMachineState_update f s) =
-   pspace_no_overlap' p n s"
-  by (simp add: pspace_no_overlap'_def)
 
 lemma deleteObject_no_overlap[wp]:
   "\<lbrace>valid_cap' (UntypedCap d ptr bits idx) and valid_pspace'\<rbrace>
@@ -3233,11 +3208,6 @@ lemma new_cap_object_comm_helper:
   apply (drule_tac x = "parent " in spec)
    apply clarsimp
   done
-
-lemma pspace_no_overlap_gsUntypedZeroRanges[simp]:
-  "pspace_no_overlap' ptr n (gsUntypedZeroRanges_update f s)
-    = pspace_no_overlap' ptr n s"
-  by (simp add: pspace_no_overlap'_def)
 
 crunch pspace_aligned'[wp]: updateNewFreeIndex "pspace_aligned'"
 crunch pspace_canonical'[wp]: updateNewFreeIndex "pspace_canonical'"

--- a/proof/refine/RISCV64/Finalise_R.thy
+++ b/proof/refine/RISCV64/Finalise_R.thy
@@ -2379,10 +2379,6 @@ lemma finaliseCap_True_invs[wp]:
     apply (wp irqs_masked_lift| simp | wpc)+
   done
 
-lemma ct_not_inQ_ksArchState_update[simp]:
-  "ct_not_inQ (s\<lparr>ksArchState := v\<rparr>) = ct_not_inQ s"
-  by (simp add: ct_not_inQ_def)
-
 lemma invs_asid_update_strg':
   "invs' s \<and> tab = riscvKSASIDTable (ksArchState s) \<longrightarrow>
    invs' (s\<lparr>ksArchState := riscvKSASIDTable_update
@@ -3648,10 +3644,6 @@ lemma finalise_cap_corres:
   done
 
 context begin interpretation Arch . (*FIXME: arch_split*)
-
-lemma ct_in_current_domain_ArchState_update[simp]:
-  "ct_idle_or_in_cur_domain' (s\<lparr>ksArchState := v\<rparr>) = ct_idle_or_in_cur_domain' s"
-  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
 
 lemma threadSet_ct_idle_or_in_cur_domain':
   "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>

--- a/proof/refine/RISCV64/InterruptAcc_R.thy
+++ b/proof/refine/RISCV64/InterruptAcc_R.thy
@@ -117,31 +117,25 @@ lemma preemptionPoint_inv:
           | simp)+
   done
 
-lemma invs'_wu [simp, intro!]:
-  "invs' (ksWorkUnitsCompleted_update f s) = invs' s"
-  apply (simp add: invs'_def cur_tcb'_def valid_state'_def Invariants_H.valid_queues_def
-                   valid_queues'_def valid_irq_node'_def valid_machine_state'_def
-                   ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                   bitmapQ_defs valid_queues_no_bitmap_def)
-  done
+lemma ct_running_irq_state_independent[intro!, simp]:
+  "ct_running (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
+   = ct_running s"
+  by (simp add: ct_in_state_def)
 
-lemma ct_in_state'_irq_state_independent [simp, intro!]:
-  "ct_in_state' x (s\<lparr>ksMachineState := ksMachineState s
-                          \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>) =
-   ct_in_state' x s"
-  by (simp add: ct_in_state'_def irq_state_independent_H_def)+
+lemma ct_idle_irq_state_independent[intro!, simp]:
+  "ct_idle (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
+   = ct_idle s"
+  by (simp add: ct_in_state_def)
 
-lemma ex_cte_cap_wp_to'_irq_state_independent [simp, intro!]:
-  "ex_cte_cap_wp_to' x y (s\<lparr>ksMachineState := ksMachineState s
-                          \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>) =
-   ex_cte_cap_wp_to' x y s"
-  by (simp add: ex_cte_cap_wp_to'_def irq_state_independent_H_def)+
+lemma typ_at'_irq_state_independent[simp, intro!]:
+  "P (typ_at' T p (s \<lparr>ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr>\<rparr>))
+   = P (typ_at' T p s)"
+  by (simp add: typ_at'_def)
 
-lemma ps_clear_irq_state_independent [simp, intro!]:
-  "ps_clear a b (s\<lparr>ksMachineState := ksMachineState s
-                    \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>) =
-   ps_clear a b s"
-  by (simp add: ps_clear_def)
+lemma sch_act_simple_irq_state_independent[intro!, simp]:
+  "sch_act_simple (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr> \<rparr>) =
+   sch_act_simple s"
+  by (simp add: sch_act_simple_def)
 
 lemma invs'_irq_state_independent [simp, intro!]:
   "invs' (s\<lparr>ksMachineState := ksMachineState s

--- a/proof/refine/RISCV64/Interrupt_R.thy
+++ b/proof/refine/RISCV64/Interrupt_R.thy
@@ -420,12 +420,6 @@ lemma isnt_irq_handler_strg:
   "(\<not> isIRQHandlerCap cap) \<longrightarrow> (\<forall>irq. cap = IRQHandlerCap irq \<longrightarrow> P irq)"
   by (clarsimp simp: isCap_simps)
 
-lemma ct_in_current_domain_ksMachineState:
-  "ct_idle_or_in_cur_domain' (ksMachineState_update p s) = ct_idle_or_in_cur_domain' s"
-  apply (simp add:ct_idle_or_in_cur_domain'_def)
-  apply (simp add:tcb_in_cur_domain'_def)
-  done
-
 lemma plic_complete_claim_irq_masks[wp]:
   "RISCV64.plic_complete_claim irq \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace>"
   unfolding RISCV64.plic_complete_claim_def by wp
@@ -463,10 +457,6 @@ lemma invoke_irq_handler_invs'[wp]:
 lemma IRQHandler_valid':
   "(s' \<turnstile>' IRQHandlerCap irq) = (irq \<le> maxIRQ \<and> irq \<noteq> irqInvalid)"
   by (simp add: valid_cap'_def capAligned_def word_bits_conv)
-
-lemma valid_mdb_interrupts'[simp]:
-  "valid_mdb' (ksInterruptState_update f s) = valid_mdb' s"
-  by (simp add: valid_mdb'_def)
 
 crunch valid_mdb'[wp]: setIRQState "valid_mdb'"
 
@@ -618,23 +608,12 @@ lemma dec_domain_time_corres:
   apply (clarsimp simp:state_relation_def)
   done
 
-lemma weak_sch_act_wf_updateDomainTime[simp]:
-  "weak_sch_act_wf m (s\<lparr>ksDomainTime := t\<rparr>)
-   = weak_sch_act_wf m s"
-  by (simp add:weak_sch_act_wf_def tcb_in_cur_domain'_def )
-
 lemma tcbSchedAppend_valid_objs':
   "\<lbrace>valid_objs'\<rbrace>tcbSchedAppend t \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
   apply (simp add:tcbSchedAppend_def)
-  apply (wp hoare_unless_wp
-    threadSet_valid_objs' threadGet_wp
-    | simp add:valid_tcb_tcbQueued)+
+  apply (wpsimp wp: hoare_unless_wp threadSet_valid_objs' threadGet_wp)
   apply (clarsimp simp add:obj_at'_def typ_at'_def)
   done
-
-lemma valid_tcb_tcbTimeSlice_update[simp]:
-  "valid_tcb' (tcbTimeSlice_update (\<lambda>_. timeSlice) tcb) s = valid_tcb' tcb s"
-  by (simp add:valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
 
 lemma thread_state_case_if:
  "(case state of Structures_A.thread_state.Running \<Rightarrow> f | _ \<Rightarrow> g) =
@@ -778,24 +757,6 @@ apply (rule corres_split_deprecated)
     apply (clarsimp simp: invs_distinct invs_psp_aligned)
    apply clarsimp
   done
-
-lemma ksDomainTime_invs[simp]:
-  "invs' (a\<lparr>ksDomainTime := t\<rparr>) = invs' a"
-  by (simp add:invs'_def valid_state'_def
-    cur_tcb'_def ct_not_inQ_def ct_idle_or_in_cur_domain'_def
-    tcb_in_cur_domain'_def valid_machine_state'_def)
-
-lemma valid_machine_state'_ksDomainTime[simp]:
-  "valid_machine_state' (a\<lparr>ksDomainTime := t\<rparr>) = valid_machine_state' a"
-  by (simp add:valid_machine_state'_def)
-
-lemma cur_tcb'_ksDomainTime[simp]:
-  "cur_tcb' (a\<lparr>ksDomainTime := 0\<rparr>) = cur_tcb' a"
-  by (simp add:cur_tcb'_def)
-
-lemma ct_idle_or_in_cur_domain'_ksDomainTime[simp]:
-  "ct_idle_or_in_cur_domain' (a\<lparr>ksDomainTime := t \<rparr>) = ct_idle_or_in_cur_domain' a"
-  by (simp add:ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
 
 lemma threadSet_ksDomainTime[wp]:
   "\<lbrace>\<lambda>s. P (ksDomainTime s)\<rbrace> threadSet f ptr \<lbrace>\<lambda>rv s. P (ksDomainTime s)\<rbrace>"

--- a/proof/refine/RISCV64/InvariantUpdates_H.thy
+++ b/proof/refine/RISCV64/InvariantUpdates_H.thy
@@ -1,0 +1,372 @@
+(*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory InvariantUpdates_H
+imports Invariants_H
+begin
+
+(* FIXME: use locales to shorten this work *)
+
+lemma ps_clear_domE[elim?]:
+  "\<lbrakk> ps_clear x n s; dom (ksPSpace s) = dom (ksPSpace s') \<rbrakk> \<Longrightarrow> ps_clear x n s'"
+  by (simp add: ps_clear_def)
+
+lemma ps_clear_upd:
+  "ksPSpace s y = Some v \<Longrightarrow>
+    ps_clear x n (ksPSpace_update (\<lambda>a. ksPSpace s(y \<mapsto> v')) s') = ps_clear x n s"
+  by (rule iffI | clarsimp elim!: ps_clear_domE | fastforce)+
+
+lemmas ps_clear_updE[elim] = iffD2[OF ps_clear_upd, rotated]
+
+lemma ct_not_inQ_ksMachineState_update[simp]:
+  "ct_not_inQ (ksMachineState_update f s) = ct_not_inQ s"
+  by (simp add: ct_not_inQ_def)
+
+lemma ct_in_current_domain_ksMachineState[simp]:
+  "ct_idle_or_in_cur_domain' (ksMachineState_update p s) = ct_idle_or_in_cur_domain' s"
+  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+
+lemma invs'_machine:
+  assumes mask: "irq_masks (f (ksMachineState s)) =
+                 irq_masks (ksMachineState s)"
+  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
+                valid_machine_state' s"
+  shows "invs' (ksMachineState_update f s) = invs' s"
+proof -
+  show ?thesis
+    apply (cases "ksSchedulerAction s")
+    apply (simp_all add: invs'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
+                    vms ct_not_inQ_def
+                    state_refs_of'_def ps_clear_def
+                    valid_irq_node'_def mask
+              cong: option.case_cong)
+    done
+qed
+
+lemma invs_no_cicd'_machine:
+  assumes mask: "irq_masks (f (ksMachineState s)) =
+                 irq_masks (ksMachineState s)"
+  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
+                valid_machine_state' s"
+  shows "invs_no_cicd' (ksMachineState_update f s) = invs_no_cicd' s"
+proof -
+  show ?thesis
+    apply (cases "ksSchedulerAction s")
+    apply (simp_all add: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
+                    vms ct_not_inQ_def
+                    state_refs_of'_def ps_clear_def
+                    valid_irq_node'_def mask
+              cong: option.case_cong)
+    done
+qed
+
+lemma pspace_no_overlap_queues [simp]:
+  "pspace_no_overlap' w sz (ksReadyQueues_update f s) = pspace_no_overlap' w sz s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap'_ksSchedulerAction[simp]:
+  "pspace_no_overlap' a b (ksSchedulerAction_update f s) =
+   pspace_no_overlap' a b s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma ksReadyQueues_update_id[simp]:
+  "ksReadyQueues_update id s = s"
+  by simp
+
+lemma ct_not_inQ_ksReadyQueues_update[simp]:
+  "ct_not_inQ (ksReadyQueues_update f s) = ct_not_inQ s"
+  by (simp add: ct_not_inQ_def)
+
+lemma inQ_context[simp]:
+  "inQ d p (tcbArch_update f tcb) = inQ d p tcb"
+  by (cases tcb, simp add: inQ_def)
+
+lemma valid_tcb'_tcbQueued[simp]:
+  "valid_tcb' (tcbQueued_update f tcb) = valid_tcb' tcb"
+  by (cases tcb, rule ext, simp add: valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_tcb'_tcbFault_update[simp]:
+  "valid_tcb' tcb s \<Longrightarrow> valid_tcb' (tcbFault_update f tcb) s"
+  by (clarsimp simp: valid_tcb'_def  tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_tcb'_tcbTimeSlice_update[simp]:
+  "valid_tcb' (tcbTimeSlice_update f tcb) s = valid_tcb' tcb s"
+  by (simp add:valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_queues_ksSchedulerAction_update[simp]:
+  "valid_queues (ksSchedulerAction_update f s) = valid_queues s"
+ unfolding valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
+ by simp
+
+lemma valid_queues'_ksSchedulerAction_update[simp]:
+  "valid_queues' (ksSchedulerAction_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma ex_cte_cap_wp_to'_gsCNodes_update[simp]:
+  "ex_cte_cap_wp_to' P p (gsCNodes_update f s') = ex_cte_cap_wp_to' P p s'"
+  by (simp add: ex_cte_cap_wp_to'_def)
+lemma ex_cte_cap_wp_to'_gsUserPages_update[simp]:
+  "ex_cte_cap_wp_to' P p (gsUserPages_update f s') = ex_cte_cap_wp_to' P p s'"
+  by (simp add: ex_cte_cap_wp_to'_def)
+
+lemma pspace_no_overlap'_gsCNodes_update[simp]:
+  "pspace_no_overlap' p b (gsCNodes_update f s') = pspace_no_overlap' p b s'"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap'_gsUserPages_update[simp]:
+  "pspace_no_overlap' p b (gsUserPages_update f s') = pspace_no_overlap' p b s'"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap'_ksMachineState_update[simp]:
+  "pspace_no_overlap' p n (ksMachineState_update f s) =
+   pspace_no_overlap' p n s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap_gsUntypedZeroRanges[simp]:
+  "pspace_no_overlap' ptr n (gsUntypedZeroRanges_update f s)
+    = pspace_no_overlap' ptr n s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma vms'_ct[simp]:
+  "valid_machine_state' (ksCurThread_update f s) = valid_machine_state' s"
+  by (simp add: valid_machine_state'_def)
+
+lemma tcb_in_cur_domain_ct[simp]:
+  "tcb_in_cur_domain' t  (ksCurThread_update f s) = tcb_in_cur_domain' t s"
+  by (fastforce simp: tcb_in_cur_domain'_def)
+
+lemma valid_queues'_ksCurDomain[simp]:
+  "valid_queues' (ksCurDomain_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksDomScheduleIdx[simp]:
+  "valid_queues' (ksDomScheduleIdx_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksDomSchedule[simp]:
+  "valid_queues' (ksDomSchedule_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksDomainTime[simp]:
+  "valid_queues' (ksDomainTime_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksWorkUnitsCompleted[simp]:
+  "valid_queues' (ksWorkUnitsCompleted_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues_ksCurDomain[simp]:
+  "valid_queues (ksCurDomain_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksDomScheduleIdx[simp]:
+  "valid_queues (ksDomScheduleIdx_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksDomSchedule[simp]:
+  "valid_queues (ksDomSchedule_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksDomainTime[simp]:
+  "valid_queues (ksDomainTime_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksWorkUnitsCompleted[simp]:
+  "valid_queues (ksWorkUnitsCompleted_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_irq_node'_ksCurDomain[simp]:
+  "valid_irq_node' w (ksCurDomain_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksDomScheduleIdx[simp]:
+  "valid_irq_node' w (ksDomScheduleIdx_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksDomSchedule[simp]:
+  "valid_irq_node' w (ksDomSchedule_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksDomainTime[simp]:
+  "valid_irq_node' w (ksDomainTime_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksWorkUnitsCompleted[simp]:
+  "valid_irq_node' w (ksWorkUnitsCompleted_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma ex_cte_cap_wp_to_work_units[simp]:
+  "ex_cte_cap_wp_to' P slot (ksWorkUnitsCompleted_update f s)
+    = ex_cte_cap_wp_to' P slot s"
+  by (simp add: ex_cte_cap_wp_to'_def)
+
+add_upd_simps "ct_in_state' P (gsUntypedZeroRanges_update f s)"
+declare upd_simps[simp]
+
+lemma ct_not_inQ_ksArchState_update[simp]:
+  "ct_not_inQ (ksArchState_update f s) = ct_not_inQ s"
+  by (simp add: ct_not_inQ_def)
+
+lemma ct_in_current_domain_ArchState_update[simp]:
+  "ct_idle_or_in_cur_domain' (ksArchState_update f s) = ct_idle_or_in_cur_domain' s"
+  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+
+lemma pspace_no_overlap_queuesL1 [simp]:
+  "pspace_no_overlap' w sz (ksReadyQueuesL1Bitmap_update f s) = pspace_no_overlap' w sz s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap_queuesL2 [simp]:
+  "pspace_no_overlap' w sz (ksReadyQueuesL2Bitmap_update f s) = pspace_no_overlap' w sz s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma tcb_in_cur_domain'_ksSchedulerAction_update[simp]:
+  "tcb_in_cur_domain' t (ksSchedulerAction_update f s) = tcb_in_cur_domain' t s"
+  by (simp add: tcb_in_cur_domain'_def)
+
+lemma ct_idle_or_in_cur_domain'_ksSchedulerAction_update[simp]:
+  "b \<noteq> ResumeCurrentThread \<Longrightarrow>
+   ct_idle_or_in_cur_domain' (s\<lparr>ksSchedulerAction := b\<rparr>)"
+  apply (clarsimp simp add: ct_idle_or_in_cur_domain'_def)
+  done
+
+lemma sch_act_simple_wu [simp, intro!]:
+  "sch_act_simple (ksWorkUnitsCompleted_update f s) = sch_act_simple s"
+  by (simp add: sch_act_simple_def)
+
+lemma sch_act_simple_ksPSpace_update[simp]:
+  "sch_act_simple (ksPSpace_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma ps_clear_ksReadyQueue[simp]:
+  "ps_clear x n (ksReadyQueues_update f s) = ps_clear x n s"
+  by (simp add: ps_clear_def)
+
+lemma inQ_tcbIPCBuffer_update_idem[simp]:
+  "inQ d p (tcbIPCBuffer_update f ko) = inQ d p ko"
+  by (clarsimp simp: inQ_def)
+
+lemma valid_mdb_interrupts'[simp]:
+  "valid_mdb' (ksInterruptState_update f s) = valid_mdb' s"
+  by (simp add: valid_mdb'_def)
+
+lemma vms_ksReadyQueues_update[simp]:
+  "valid_machine_state' (ksReadyQueues_update f s) = valid_machine_state' s"
+  by (simp add: valid_machine_state'_def)
+
+lemma ct_in_state'_ksMachineState_update[simp]:
+  "ct_in_state' x (ksMachineState_update f s) = ct_in_state' x s"
+  by (simp add: ct_in_state'_def)+
+
+lemma ex_cte_cap_wp_to'_ksMachineState_update[simp]:
+  "ex_cte_cap_wp_to' x y (ksMachineState_update f s) = ex_cte_cap_wp_to' x y s"
+  by (simp add: ex_cte_cap_wp_to'_def)+
+
+lemma ps_clear_ksMachineState_update[simp]:
+  "ps_clear a b (ksMachineState_update f s) = ps_clear a b s"
+  by (simp add: ps_clear_def)
+
+lemma ct_in_state_ksSched[simp]:
+  "ct_in_state' P (ksSchedulerAction_update f s) = ct_in_state' P s"
+  unfolding ct_in_state'_def
+  apply auto
+  done
+
+lemma invs'_wu [simp]:
+  "invs' (ksWorkUnitsCompleted_update f s) = invs' s"
+  apply (simp add: invs'_def cur_tcb'_def valid_state'_def Invariants_H.valid_queues_def
+                   valid_queues'_def valid_irq_node'_def valid_machine_state'_def
+                   ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                   bitmapQ_defs valid_queues_no_bitmap_def)
+  done
+
+lemma valid_arch_state'_interrupt[simp]:
+  "valid_arch_state' (ksInterruptState_update f s) = valid_arch_state' s"
+  by (simp add: valid_arch_state'_def cong: option.case_cong)
+
+lemma valid_bitmapQ_ksSchedulerAction_upd[simp]:
+  "valid_bitmapQ (ksSchedulerAction_update f s) = valid_bitmapQ s"
+  unfolding bitmapQ_defs by simp
+
+lemma bitmapQ_no_L1_orphans_ksSchedulerAction_upd[simp]:
+  "bitmapQ_no_L1_orphans (ksSchedulerAction_update f s) = bitmapQ_no_L1_orphans s"
+  unfolding bitmapQ_defs by simp
+
+lemma bitmapQ_no_L2_orphans_ksSchedulerAction_upd[simp]:
+  "bitmapQ_no_L2_orphans (ksSchedulerAction_update f s) = bitmapQ_no_L2_orphans s"
+  unfolding bitmapQ_defs by simp
+
+lemma cur_tcb'_ksReadyQueuesL1Bitmap_upd[simp]:
+  "cur_tcb' (ksReadyQueuesL1Bitmap_update f s) = cur_tcb' s"
+  unfolding cur_tcb'_def by simp
+
+lemma cur_tcb'_ksReadyQueuesL2Bitmap_upd[simp]:
+  "cur_tcb' (ksReadyQueuesL2Bitmap_update f s) = cur_tcb' s"
+  unfolding cur_tcb'_def by simp
+
+lemma ex_cte_cap_wp_to'_ksReadyQueuesL1Bitmap[simp]:
+   "ex_cte_cap_wp_to' P p (ksReadyQueuesL1Bitmap_update f s) = ex_cte_cap_wp_to' P p s"
+   unfolding ex_cte_cap_wp_to'_def by simp
+
+lemma ex_cte_cap_wp_to'_ksReadyQueuesL2Bitmap[simp]:
+   "ex_cte_cap_wp_to' P p (ksReadyQueuesL2Bitmap_update f s) = ex_cte_cap_wp_to' P p s"
+   unfolding ex_cte_cap_wp_to'_def by simp
+
+lemma sch_act_simple_readyQueue[simp]:
+  "sch_act_simple (ksReadyQueues_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma sch_act_simple_ksReadyQueuesL1Bitmap[simp]:
+  "sch_act_simple (ksReadyQueuesL1Bitmap_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma sch_act_simple_ksReadyQueuesL2Bitmap[simp]:
+  "sch_act_simple (ksReadyQueuesL2Bitmap_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma ksDomainTime_invs[simp]:
+  "invs' (ksDomainTime_update f s) = invs' s"
+  by (simp add:invs'_def valid_state'_def
+    cur_tcb'_def ct_not_inQ_def ct_idle_or_in_cur_domain'_def
+    tcb_in_cur_domain'_def valid_machine_state'_def)
+
+lemma valid_machine_state'_ksDomainTime[simp]:
+  "valid_machine_state' (ksDomainTime_update f s) = valid_machine_state' s"
+  by (simp add:valid_machine_state'_def)
+
+lemma cur_tcb'_ksDomainTime[simp]:
+  "cur_tcb' (ksDomainTime_update f s) = cur_tcb' s"
+  by (simp add:cur_tcb'_def)
+
+lemma ct_idle_or_in_cur_domain'_ksDomainTime[simp]:
+  "ct_idle_or_in_cur_domain' (ksDomainTime_update f s) = ct_idle_or_in_cur_domain' s"
+  by (simp add:ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+
+lemma sch_act_sane_ksMachineState[simp]:
+  "sch_act_sane (ksMachineState_update f s) = sch_act_sane s"
+  by (simp add: sch_act_sane_def)
+
+lemma ct_not_inQ_update_cnt[simp]:
+  "ct_not_inQ (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
+   by (simp add: ct_not_inQ_def)
+
+lemma ct_not_inQ_update_stt[simp]:
+  "ct_not_inQ (s\<lparr>ksSchedulerAction := SwitchToThread t\<rparr>)"
+   by (simp add: ct_not_inQ_def)
+
+lemma invs'_update_cnt[elim!]:
+  "invs' s \<Longrightarrow> invs' (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
+   by (clarsimp simp: invs'_def valid_state'_def valid_queues_def valid_queues'_def
+                      valid_irq_node'_def cur_tcb'_def ct_idle_or_in_cur_domain'_def
+                      tcb_in_cur_domain'_def valid_queues_no_bitmap_def
+                      bitmapQ_no_L2_orphans_def bitmapQ_no_L1_orphans_def)
+
+end

--- a/proof/refine/RISCV64/IpcCancel_R.thy
+++ b/proof/refine/RISCV64/IpcCancel_R.thy
@@ -43,6 +43,20 @@ definition valid_inQ_queues :: "KernelStateData_H.kernel_state \<Rightarrow> boo
   "valid_inQ_queues \<equiv>
      \<lambda>s. \<forall>d p. (\<forall>t\<in>set (ksReadyQueues s (d, p)). obj_at' (inQ d p) t s) \<and> distinct (ksReadyQueues s (d, p))"
 
+lemma valid_inQ_queues_ksSchedulerAction_update[simp]:
+  "valid_inQ_queues (ksSchedulerAction_update f s) = valid_inQ_queues s"
+  by (simp add: valid_inQ_queues_def)
+
+lemma valid_inQ_queues_ksReadyQueuesL1Bitmap_upd[simp]:
+  "valid_inQ_queues (ksReadyQueuesL1Bitmap_update f s) = valid_inQ_queues s"
+  unfolding valid_inQ_queues_def
+  by simp
+
+lemma valid_inQ_queues_ksReadyQueuesL2Bitmap_upd[simp]:
+  "valid_inQ_queues (ksReadyQueuesL2Bitmap_update f s) = valid_inQ_queues s"
+  unfolding valid_inQ_queues_def
+  by simp
+
 defs capHasProperty_def:
   "capHasProperty ptr P \<equiv> cte_wp_at' (\<lambda>c. P (cteCap c)) ptr"
 
@@ -1226,16 +1240,6 @@ lemma threadSet_valid_inQ_queues:
   apply (fastforce)
   done
 
-lemma valid_inQ_queues_ksReadyQueuesL1Bitmap_upd[simp]:
-  "valid_inQ_queues (s\<lparr>ksReadyQueuesL1Bitmap := f\<rparr>) = valid_inQ_queues s"
-  unfolding valid_inQ_queues_def
-  by simp
-
-lemma valid_inQ_queues_ksReadyQueuesL2Bitmap_upd[simp]:
-  "valid_inQ_queues (s\<lparr>ksReadyQueuesL2Bitmap := f\<rparr>) = valid_inQ_queues s"
-  unfolding valid_inQ_queues_def
-  by simp
-
 (* reorder the threadSet before the setQueue, useful for lemmas that don't refer to bitmap *)
 lemma setQueue_after_addToBitmap:
   "(setQueue d p q >>= (\<lambda>rv. (when P (addToBitmap d p)) >>= (\<lambda>rv. threadSet f t))) =
@@ -1277,10 +1281,6 @@ lemma removeFromBitmap_conceal_valid_inQ_queues[wp]:
   "\<lbrace> valid_inQ_queues \<rbrace> removeFromBitmap_conceal d p q t \<lbrace> \<lambda>_. valid_inQ_queues \<rbrace>"
   unfolding valid_inQ_queues_def removeFromBitmap_conceal_def
   by (wp|clarsimp simp: bitmap_fun_defs)+
-
-lemma valid_inQ_queues_ksSchedulerAction_update[simp]:
-  "valid_inQ_queues (ksSchedulerAction_update f s) = valid_inQ_queues s"
-  by (simp add: valid_inQ_queues_def)
 
 lemma rescheduleRequired_valid_inQ_queues[wp]:
   "\<lbrace>valid_inQ_queues\<rbrace> rescheduleRequired \<lbrace>\<lambda>_. valid_inQ_queues\<rbrace>"
@@ -2088,7 +2088,7 @@ lemma ep_q_refs_max:
 lemma rescheduleRequired_invs'[wp]:
   "\<lbrace>invs'\<rbrace> rescheduleRequired \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: rescheduleRequired_def)
-  apply (wp ssa_invs' | simp add: invs'_update_cnt | wpc)+
+  apply (wpsimp wp: ssa_invs')
   apply (clarsimp simp: invs'_def valid_state'_def)
   done
 

--- a/proof/refine/RISCV64/IpcCancel_R.thy
+++ b/proof/refine/RISCV64/IpcCancel_R.thy
@@ -2344,7 +2344,7 @@ lemma threadSet_not_tcb[wp]:
                      setObject_def in_monad loadObject_default_def
                      ko_wp_at'_def split_def in_magnitude_check
                      objBits_simps' updateObject_default_def
-                     ps_clear_upd' projectKO_opt_tcb)
+                     ps_clear_upd projectKO_opt_tcb)
 
 lemma setThreadState_not_tcb[wp]:
   "\<lbrace>ko_wp_at' (\<lambda>x. P x \<and> (projectKO_opt x = (None :: tcb option))) p\<rbrace>
@@ -2393,7 +2393,7 @@ lemma setObject_ko_wp_at':
   by (clarsimp simp: setObject_def valid_def in_monad
                      ko_wp_at'_def x split_def n
                      updateObject_default_def
-                     objBits_def[symmetric] ps_clear_upd'
+                     objBits_def[symmetric] ps_clear_upd
                      in_magnitude_check v)
 
 lemma rescheduleRequired_unlive:

--- a/proof/refine/RISCV64/Ipc_R.thy
+++ b/proof/refine/RISCV64/Ipc_R.thy
@@ -1068,8 +1068,6 @@ crunch typ_at'[wp]: transferCaps "\<lambda>s. P (typ_at' T p s)"
 
 lemmas transferCaps_typ_ats[wp] = typ_at_lifts [OF transferCaps_typ_at']
 
-declare maskCapRights_Reply [simp]
-
 lemma isIRQControlCap_mask [simp]:
   "isIRQControlCap (maskCapRights R c) = isIRQControlCap c"
   apply (case_tac c)
@@ -2099,10 +2097,6 @@ lemma cancelIPC_valid_queues'[wp]:
 
 crunch valid_objs'[wp]: handleFaultReply valid_objs'
 
-lemma valid_tcb'_tcbFault_update[simp]:
-  "\<And>tcb s. valid_tcb' tcb s \<Longrightarrow> valid_tcb' (tcbFault_update f tcb) s"
-  by (clarsimp simp: valid_tcb'_def  tcb_cte_cases_def cteSizeBits_def)
-
 lemma cte_wp_at_is_reply_cap_toI:
   "cte_wp_at ((=) (cap.ReplyCap t False rights)) ptr s
    \<Longrightarrow> cte_wp_at (is_reply_cap_to t) ptr s"
@@ -2381,19 +2375,6 @@ lemmas transferCapsToSlots_pred_tcb_at' =
 crunches doIPCTransfer, possibleSwitchTo
   for pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
   (wp: mapM_wp' crunch_wps simp: zipWithM_x_mapM)
-
-
-(* FIXME move *)
-lemma tcb_in_cur_domain'_ksSchedulerAction_update[simp]:
-  "tcb_in_cur_domain' t (ksSchedulerAction_update f s) = tcb_in_cur_domain' t s"
-by (simp add: tcb_in_cur_domain'_def)
-
-(* FIXME move *)
-lemma ct_idle_or_in_cur_domain'_ksSchedulerAction_update[simp]:
-  "b\<noteq> ResumeCurrentThread \<Longrightarrow>
-   ct_idle_or_in_cur_domain' (s\<lparr>ksSchedulerAction := b\<rparr>)"
-  apply (clarsimp simp add: ct_idle_or_in_cur_domain'_def)
-  done
 
 lemma setSchedulerAction_ct_in_domain:
  "\<lbrace>\<lambda>s. ct_idle_or_in_cur_domain' s

--- a/proof/refine/RISCV64/KHeap_R.thy
+++ b/proof/refine/RISCV64/KHeap_R.thy
@@ -170,17 +170,6 @@ lemma updateObject_cte_is_tcb_or_cte:
 
 declare plus_1_less[simp]
 
-lemma ps_clear_domE[elim?]:
-  "\<lbrakk> ps_clear x n s; dom (ksPSpace s) = dom (ksPSpace s') \<rbrakk> \<Longrightarrow> ps_clear x n s'"
-  by (simp add: ps_clear_def)
-
-lemma ps_clear_upd:
-  "ksPSpace s y = Some v \<Longrightarrow>
-    ps_clear x n (ksPSpace_update (\<lambda>a. ksPSpace s(y \<mapsto> v')) s') = ps_clear x n s"
-  by (rule iffI | clarsimp elim!: ps_clear_domE | fastforce)+
-
-lemmas ps_clear_updE[elim] = iffD2[OF ps_clear_upd, rotated]
-
 lemma updateObject_default_result:
   "(x, s'') \<in> fst (updateObject_default e ko p q n s) \<Longrightarrow> x = injectKO e"
   by (clarsimp simp add: updateObject_default_def in_monad)

--- a/proof/refine/RISCV64/KHeap_R.thy
+++ b/proof/refine/RISCV64/KHeap_R.thy
@@ -185,13 +185,6 @@ lemma updateObject_default_result:
   "(x, s'') \<in> fst (updateObject_default e ko p q n s) \<Longrightarrow> x = injectKO e"
   by (clarsimp simp add: updateObject_default_def in_monad)
 
-lemma ps_clear_upd':
-  "ksPSpace s y = Some v \<Longrightarrow>
-    ps_clear x n (s' \<lparr> ksPSpace := ksPSpace s(y \<mapsto> v')\<rparr>) = ps_clear x n s"
-  by (rule iffI | clarsimp elim!: ps_clear_domE | fastforce)+
-
-lemmas ps_clear_updE' = iffD2[OF ps_clear_upd', rotated]
-
 lemma obj_at_setObject1:
   assumes R: "\<And>(v::'a::pspace_storable) p q n ko s x s''.
                 (x, s'') \<in> fst (updateObject v ko p q n s) \<Longrightarrow> x = injectKO v"
@@ -230,7 +223,7 @@ lemma obj_at_setObject2:
    apply (clarsimp simp: lookupAround2_char1)
    apply (drule iffD1 [OF project_koType, OF exI])
    apply simp
-  apply (clarsimp simp: ps_clear_upd' lookupAround2_char1)
+  apply (clarsimp simp: ps_clear_upd lookupAround2_char1)
   done
 
 lemma updateObject_ep_eta:
@@ -256,11 +249,11 @@ lemma setObject_typ_at_inv:
   "\<lbrace>typ_at' T p'\<rbrace> setObject p v \<lbrace>\<lambda>r. typ_at' T p'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def)
   apply (clarsimp simp: valid_def typ_at'_def ko_wp_at'_def in_monad
-                        lookupAround2_char1 ps_clear_upd')
+                        lookupAround2_char1 ps_clear_upd)
   apply (drule updateObject_type)
   apply clarsimp
   apply (drule objBits_type)
-  apply (simp add: ps_clear_upd')
+  apply (simp add: ps_clear_upd)
   done
 
 lemma setObject_typ_at_not:
@@ -295,19 +288,19 @@ lemma setObject_cte_wp_at2':
   apply (erule rsubst[where P=P'])
   apply (rule iffI)
    apply (erule disjEI)
-    apply (clarsimp simp: ps_clear_upd' lookupAround2_char1 y)
+    apply (clarsimp simp: ps_clear_upd lookupAround2_char1 y)
    apply (erule exEI [where 'a=machine_word])
-   apply (clarsimp simp: ps_clear_upd' lookupAround2_char1)
+   apply (clarsimp simp: ps_clear_upd lookupAround2_char1)
    apply (drule(1) x)
     apply (clarsimp simp: lookupAround2_char1 prod_eqI)
    apply (fastforce dest: bspec [OF _ ranI])
   apply (erule disjEI)
-   apply (clarsimp simp: ps_clear_upd' lookupAround2_char1
+   apply (clarsimp simp: ps_clear_upd lookupAround2_char1
                   split: if_split_asm)
    apply (frule updateObject_type)
    apply (case_tac ba, simp_all add: y)[1]
   apply (erule exEI)
-  apply (clarsimp simp: ps_clear_upd' lookupAround2_char1
+  apply (clarsimp simp: ps_clear_upd lookupAround2_char1
                  split: if_split_asm)
   apply (frule updateObject_type)
   apply (case_tac ba, simp_all)
@@ -379,7 +372,7 @@ lemma obj_at_setObject3:
   shows "\<lbrace>(\<lambda>s. P v)\<rbrace> setObject p v \<lbrace>\<lambda>rv. obj_at' P p\<rbrace>"
   apply (clarsimp simp add: valid_def in_monad obj_at'_def
                             setObject_def split_def project_inject objBits_def[symmetric]
-                            R updateObject_default_def in_magnitude_check P ps_clear_upd')
+                            R updateObject_default_def in_magnitude_check P ps_clear_upd)
   apply fastforce
   done
 
@@ -396,7 +389,7 @@ lemma setObject_tcb_strongest:
    apply simp
   apply (simp add: setObject_def split_def)
   apply (clarsimp simp: valid_def obj_at'_def split_def in_monad
-                        updateObject_default_def ps_clear_upd')
+                        updateObject_default_def ps_clear_upd)
   done
 
 lemma getObject_obj_at':
@@ -505,7 +498,7 @@ lemma get_ntfn'_valid_ntfn[wp]:
 lemma setObject_distinct[wp]:
   shows     "\<lbrace>pspace_distinct'\<rbrace> setObject p val \<lbrace>\<lambda>rv. pspace_distinct'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad lookupAround2_char1
-                        pspace_distinct'_def ps_clear_upd' objBits_def[symmetric]
+                        pspace_distinct'_def ps_clear_upd objBits_def[symmetric]
                  split: if_split_asm
                  dest!: updateObject_objBitsKO)
    apply (fastforce dest: bspec[OF _ domI])
@@ -515,7 +508,7 @@ lemma setObject_distinct[wp]:
 lemma setObject_aligned[wp]:
   shows     "\<lbrace>pspace_aligned'\<rbrace> setObject p val \<lbrace>\<lambda>rv. pspace_aligned'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad lookupAround2_char1
-                        pspace_aligned'_def ps_clear_upd' objBits_def[symmetric]
+                        pspace_aligned'_def ps_clear_upd objBits_def[symmetric]
                  split: if_split_asm
                  dest!: updateObject_objBitsKO)
    apply (fastforce dest: bspec[OF _ domI])
@@ -525,7 +518,7 @@ lemma setObject_aligned[wp]:
 lemma setObject_canonical[wp]:
   shows     "\<lbrace>pspace_canonical'\<rbrace> setObject p val \<lbrace>\<lambda>rv. pspace_canonical'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad lookupAround2_char1
-                        pspace_canonical'_def ps_clear_upd' objBits_def[symmetric]
+                        pspace_canonical'_def ps_clear_upd objBits_def[symmetric]
                  split: if_split_asm
                  dest!: updateObject_objBitsKO)
    apply (fastforce dest: bspec[OF _ domI])
@@ -535,7 +528,7 @@ lemma setObject_canonical[wp]:
 lemma setObject_in_kernel_mappings[wp]:
   shows     "\<lbrace>pspace_in_kernel_mappings'\<rbrace> setObject p val \<lbrace>\<lambda>rv. pspace_in_kernel_mappings'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad lookupAround2_char1
-                        pspace_in_kernel_mappings'_def ps_clear_upd' objBits_def[symmetric]
+                        pspace_in_kernel_mappings'_def ps_clear_upd objBits_def[symmetric]
                  split: if_split_asm
                  dest!: updateObject_objBitsKO)
    apply (fastforce dest: bspec[OF _ domI])
@@ -1076,7 +1069,7 @@ lemma setObject_ko_wp_at:
                  elim!: rsubst[where P=P]
              split del: if_split)
   apply (rule iffI)
-   apply (clarsimp simp: n ps_clear_upd' objBits_def[symmetric]
+   apply (clarsimp simp: n ps_clear_upd objBits_def[symmetric]
                   split: if_split_asm)
   apply (clarsimp simp: n project_inject objBits_def[symmetric]
                         ps_clear_upd
@@ -1229,7 +1222,7 @@ lemma setObject_no_0_obj' [wp]:
   "\<lbrace>no_0_obj'\<rbrace> setObject p v \<lbrace>\<lambda>r. no_0_obj'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def)
   apply (clarsimp simp: valid_def no_0_obj'_def ko_wp_at'_def in_monad
-                        lookupAround2_char1 ps_clear_upd')
+                        lookupAround2_char1 ps_clear_upd)
   done
 
 lemma valid_updateCapDataI:

--- a/proof/refine/RISCV64/Refine.thy
+++ b/proof/refine/RISCV64/Refine.thy
@@ -318,16 +318,6 @@ lemma do_user_op_invs2:
     do_user_op_invs | simp | force)+
   done
 
-lemma ct_running_irq_state_independent[intro!, simp]:
-  "ct_running (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
-   = ct_running s"
-  by (simp add: ct_in_state_def)
-
-lemma ct_idle_irq_state_independent[intro!, simp]:
-  "ct_idle (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
-   = ct_idle s"
-  by (simp add: ct_in_state_def)
-
 lemmas ext_init_def = ext_init_det_ext_ext_def ext_init_unit_def
 
 lemma valid_list_init[simp]:

--- a/proof/refine/RISCV64/Retype_R.thy
+++ b/proof/refine/RISCV64/Retype_R.thy
@@ -1157,6 +1157,17 @@ global_interpretation update_gs: PSpace_update_eq "update_gs ty us ptrs"
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
+lemma ksMachineState_update_gs[simp]:
+  "ksMachineState (update_gs tp us addrs s) = ksMachineState s"
+  by (simp add: update_gs_def
+         split: aobject_type.splits Structures_A.apiobject_type.splits)
+
+lemma update_gs_ksMachineState_update_swap:
+  "update_gs tp us addrs (ksMachineState_update f s) =
+   ksMachineState_update f (update_gs tp us addrs s)"
+  by (simp add: update_gs_def
+         split: aobject_type.splits Structures_A.apiobject_type.splits)
+
 lemma update_gs_id:
   "tp \<in> no_gs_types \<Longrightarrow> update_gs tp us addrs = id"
   by (simp add: no_gs_types_def update_gs_def
@@ -1172,11 +1183,6 @@ lemma update_gs_simps[simp]:
   "update_gs (ArchObject HugePageObj) us ptrs =
    gsUserPages_update (\<lambda>ups x. if x \<in> ptrs then Some RISCVHugePage else ups x)"
   by (simp_all add: update_gs_def)
-
-lemma caps_of_state_kheap_ekheap[simp]: "caps_of_state (kheap_update f (ekheap_update ef s)) =
-       caps_of_state (kheap_update f s)"
-  apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-  done
 
 lemma retype_state_relation:
   notes data_map_insert_def[simp del]
@@ -2478,16 +2484,6 @@ lemmas object_splits =
   RISCV64_H.object_type.split_asm
   sum.split_asm kernel_object.split_asm
   arch_kernel_object.split_asm
-
-lemma ksMachineState_update_gs[simp]:
-  "ksMachineState (update_gs tp us addrs s) = ksMachineState s"
-  by (simp add: update_gs_def
-         split: aobject_type.splits Structures_A.apiobject_type.splits)
-lemma update_gs_ksMachineState_update_swap:
-  "update_gs tp us addrs (ksMachineState_update f s) =
-   ksMachineState_update f (update_gs tp us addrs s)"
-  by (simp add: update_gs_def
-         split: aobject_type.splits Structures_A.apiobject_type.splits)
 
 declare hoare_in_monad_post[wp del]
 declare univ_get_wp[wp del]

--- a/proof/refine/RISCV64/Schedule_R.thy
+++ b/proof/refine/RISCV64/Schedule_R.thy
@@ -694,29 +694,17 @@ lemma setCurThread_invs_no_cicd':
      setCurThread t
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
 proof -
-  have obj_at'_ct: "\<And>f P addr s.
-       obj_at' P addr (ksCurThread_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
-  have valid_pspace'_ct: "\<And>s f.
-       valid_pspace' (ksCurThread_update f s) = valid_pspace' s"
-    by simp
-  have vms'_ct: "\<And>s f.
-       valid_machine_state' (ksCurThread_update f s) = valid_machine_state' s"
-    by (simp add: valid_machine_state'_def)
   have ct_not_inQ_ct: "\<And>s t . \<lbrakk> ct_not_inQ s; obj_at' (\<lambda>x. \<not> tcbQueued x) t s\<rbrakk> \<Longrightarrow> ct_not_inQ (s\<lparr> ksCurThread := t \<rparr>)"
     apply (simp add: ct_not_inQ_def o_def)
     done
-  have tcb_in_cur_domain_ct: "\<And>s f t.
-       tcb_in_cur_domain' t  (ksCurThread_update f s)= tcb_in_cur_domain' t s"
-    by (fastforce simp: tcb_in_cur_domain'_def)
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (clarsimp simp add: all_invs_but_ct_idle_or_in_cur_domain'_def invs'_def cur_tcb'_def valid_state'_def obj_at'_ct
-                              valid_pspace'_ct vms'_ct Invariants_H.valid_queues_def
+    apply (clarsimp simp add: all_invs_but_ct_idle_or_in_cur_domain'_def invs'_def cur_tcb'_def
+                              valid_state'_def Invariants_H.valid_queues_def
                               sch_act_wf ct_in_state'_def state_refs_of'_def
                               ps_clear_def valid_irq_node'_def valid_queues'_def ct_not_inQ_ct
-                              tcb_in_cur_domain_ct ct_idle_or_in_cur_domain'_def
+                              ct_idle_or_in_cur_domain'_def
                               bitmapQ_defs valid_queues_no_bitmap_def
                         cong: option.case_cong)
     done
@@ -803,9 +791,6 @@ qed
 lemma setCurThread_invs_no_cicd'_idle_thread:
   "\<lbrace>invs_no_cicd' and (\<lambda>s. t = ksIdleThread s) \<rbrace> setCurThread t \<lbrace>\<lambda>rv. invs'\<rbrace>"
 proof -
-  have vms'_ct: "\<And>s f.
-       valid_machine_state' (ksCurThread_update f s) = valid_machine_state' s"
-    by (simp add: valid_machine_state'_def)
   have ct_not_inQ_ct: "\<And>s t . \<lbrakk> ct_not_inQ s; obj_at' (\<lambda>x. \<not> tcbQueued x) t s\<rbrakk> \<Longrightarrow> ct_not_inQ (s\<lparr> ksCurThread := t \<rparr>)"
     apply (simp add: ct_not_inQ_def o_def)
     done
@@ -815,7 +800,7 @@ proof -
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (clarsimp simp add: vms'_ct ct_not_inQ_ct idle'_activatable' idle'_not_tcbQueued'[simplified o_def]
+    apply (clarsimp simp add: ct_not_inQ_ct idle'_activatable' idle'_not_tcbQueued'[simplified o_def]
                               invs'_def cur_tcb'_def valid_state'_def valid_idle'_def
                               sch_act_wf ct_in_state'_def state_refs_of'_def
                               ps_clear_def valid_irq_node'_def
@@ -1053,25 +1038,20 @@ lemma switchToThread_invs[wp]:
 lemma setCurThread_ct_in_state:
   "\<lbrace>obj_at' (P \<circ> tcbState) t\<rbrace> setCurThread t \<lbrace>\<lambda>rv. ct_in_state' P\<rbrace>"
 proof -
-  have obj_at'_ct: "\<And>P addr f s.
-       obj_at' P addr (ksCurThread_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (simp add: ct_in_state'_def pred_tcb_at'_def obj_at'_ct o_def)
+    apply (simp add: ct_in_state'_def pred_tcb_at'_def o_def)
     done
 qed
 
 lemma switchToThread_ct_in_state[wp]:
   "\<lbrace>obj_at' (P \<circ> tcbState) t\<rbrace> switchToThread t \<lbrace>\<lambda>rv. ct_in_state' P\<rbrace>"
 proof -
-  have P: "\<And>f x. tcbState (tcbTimeSlice_update f x) = tcbState x"
-    by (case_tac x, simp)
   show ?thesis
     apply (simp add: Thread_H.switchToThread_def tcbSchedEnqueue_def unless_def)
     apply (wp setCurThread_ct_in_state Arch_switchToThread_obj_at
-         | simp add: P o_def cong: if_cong)+
+         | simp add: o_def cong: if_cong)+
     done
 qed
 
@@ -1438,14 +1418,6 @@ lemma corres_assert_assume_r:
   \<Longrightarrow> corres dc P (Q and (\<lambda>s. Q')) f (assert Q' >>= g)"
   by (force simp: corres_underlying_def assert_def return_def bind_def fail_def)
 
-lemma cur_tcb'_ksReadyQueuesL1Bitmap_upd[simp]:
-  "cur_tcb' (s\<lparr>ksReadyQueuesL1Bitmap := x\<rparr>) = cur_tcb' s"
-  unfolding cur_tcb'_def by simp
-
-lemma cur_tcb'_ksReadyQueuesL2Bitmap_upd[simp]:
-  "cur_tcb' (s\<lparr>ksReadyQueuesL2Bitmap := x\<rparr>) = cur_tcb' s"
-  unfolding cur_tcb'_def by simp
-
 crunch cur[wp]: tcbSchedEnqueue cur_tcb'
   (simp: unless_def)
 
@@ -1659,66 +1631,6 @@ lemma next_domain_corres:
   apply (rule corres_modify)
   apply (simp add: state_relation_def Let_def dschLength_def dschDomain_def)
   done
-
-lemma valid_queues'_ksCurDomain[simp]:
-  "valid_queues' (ksCurDomain_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksDomScheduleIdx[simp]:
-  "valid_queues' (ksDomScheduleIdx_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksDomSchedule[simp]:
-  "valid_queues' (ksDomSchedule_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksDomainTime[simp]:
-  "valid_queues' (ksDomainTime_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksWorkUnitsCompleted[simp]:
-  "valid_queues' (ksWorkUnitsCompleted_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues_ksCurDomain[simp]:
-  "Invariants_H.valid_queues (ksCurDomain_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksDomScheduleIdx[simp]:
-  "Invariants_H.valid_queues (ksDomScheduleIdx_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksDomSchedule[simp]:
-  "Invariants_H.valid_queues (ksDomSchedule_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksDomainTime[simp]:
-  "Invariants_H.valid_queues (ksDomainTime_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksWorkUnitsCompleted[simp]:
-  "Invariants_H.valid_queues (ksWorkUnitsCompleted_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_irq_node'_ksCurDomain[simp]:
-  "valid_irq_node' w (ksCurDomain_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksDomScheduleIdx[simp]:
-  "valid_irq_node' w (ksDomScheduleIdx_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksDomSchedule[simp]:
-  "valid_irq_node' w (ksDomSchedule_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksDomainTime[simp]:
-  "valid_irq_node' w (ksDomainTime_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksWorkUnitsCompleted[simp]:
-  "valid_irq_node' w (ksWorkUnitsCompleted_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
 
 lemma next_domain_valid_sched[wp]:
   "\<lbrace> valid_sched and (\<lambda>s. scheduler_action s  = choose_new_thread)\<rbrace> next_domain \<lbrace> \<lambda>_. valid_sched \<rbrace>"
@@ -1984,28 +1896,12 @@ lemma ssa_all_invs_but_ct_not_inQ':
    (\<lambda>s. sa = ResumeCurrentThread \<longrightarrow> ksCurThread s = ksIdleThread s \<or> tcb_in_cur_domain' (ksCurThread s) s)\<rbrace>
    setSchedulerAction sa \<lbrace>\<lambda>rv. all_invs_but_ct_not_inQ'\<rbrace>"
 proof -
-  have obj_at'_sa: "\<And>P addr f s.
-       obj_at' P addr (ksSchedulerAction_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
-  have valid_pspace'_sa: "\<And>f s.
-       valid_pspace' (ksSchedulerAction_update f s) = valid_pspace' s"
-    by simp
-  have iflive_sa: "\<And>f s.
-       if_live_then_nonz_cap' (ksSchedulerAction_update f s)
-         = if_live_then_nonz_cap' s"
-    by fastforce
-  have ifunsafe_sa[simp]: "\<And>f s.
-       if_unsafe_then_cap' (ksSchedulerAction_update f s) = if_unsafe_then_cap' s"
-    by fastforce
-  have idle_sa[simp]: "\<And>f s.
-       valid_idle' (ksSchedulerAction_update f s) = valid_idle' s"
-    by fastforce
   show ?thesis
     apply (simp add: setSchedulerAction_def)
     apply wp
     apply (clarsimp simp add: invs'_def valid_state'_def cur_tcb'_def
-                              obj_at'_sa valid_pspace'_sa Invariants_H.valid_queues_def
-                              state_refs_of'_def iflive_sa ps_clear_def
+                              Invariants_H.valid_queues_def
+                              state_refs_of'_def ps_clear_def
                               valid_irq_node'_def valid_queues'_def
                               tcb_in_cur_domain'_def ct_idle_or_in_cur_domain'_def
                               bitmapQ_defs valid_queues_no_bitmap_def
@@ -2054,13 +1950,10 @@ lemma switchToThread_ct_not_queued_2:
 lemma setCurThread_obj_at':
   "\<lbrace> obj_at' P t \<rbrace> setCurThread t \<lbrace>\<lambda>rv s. obj_at' P (ksCurThread s) s \<rbrace>"
 proof -
-  have obj_at'_ct: "\<And>P addr f s.
-       obj_at' P addr (ksCurThread_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (simp add: ct_in_state'_def st_tcb_at'_def obj_at'_ct)
+    apply (simp add: ct_in_state'_def st_tcb_at'_def)
     done
 qed
 
@@ -2082,16 +1975,11 @@ lemma switchToIdleThread_activatable_2[wp]:
   done
 
 lemma switchToThread_tcb_in_cur_domain':
-  "\<lbrace>tcb_in_cur_domain' thread\<rbrace> ThreadDecls_H.switchToThread thread
-  \<lbrace>\<lambda>y s. tcb_in_cur_domain' (ksCurThread s) s\<rbrace>"
-  apply (simp add: Thread_H.switchToThread_def)
-  apply (rule hoare_pre)
-  apply (wp)
-    apply (simp add: RISCV64_H.switchToThread_def setCurThread_def)
-    apply (wp tcbSchedDequeue_not_tcbQueued | simp )+
-   apply (simp add:tcb_in_cur_domain'_def)
-   apply (wp tcbSchedDequeue_tcbDomain | wps)+
-  apply (clarsimp simp:tcb_in_cur_domain'_def)
+  "\<lbrace>tcb_in_cur_domain' thread\<rbrace>
+   ThreadDecls_H.switchToThread thread
+   \<lbrace>\<lambda>y s. tcb_in_cur_domain' (ksCurThread s) s\<rbrace>"
+  apply (simp add: Thread_H.switchToThread_def setCurThread_def)
+  apply (wpsimp wp: tcbSchedDequeue_not_tcbQueued)
   done
 
 lemma chooseThread_invs_no_cicd'_posts: (* generic version *)
@@ -2258,13 +2146,10 @@ lemma schedule_sch_act_simple:
 lemma ssa_ct:
   "\<lbrace>ct_in_state' P\<rbrace> setSchedulerAction sa \<lbrace>\<lambda>rv. ct_in_state' P\<rbrace>"
 proof -
-  have obj_at'_sa: "\<And>P addr f s.
-       obj_at' P addr (ksSchedulerAction_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
   show ?thesis
     apply (unfold setSchedulerAction_def)
     apply wp
-    apply (clarsimp simp add: ct_in_state'_def pred_tcb_at'_def obj_at'_sa)
+    apply (clarsimp simp add: ct_in_state'_def pred_tcb_at'_def)
     done
 qed
 

--- a/proof/refine/RISCV64/StateRelation.thy
+++ b/proof/refine/RISCV64/StateRelation.thy
@@ -9,7 +9,7 @@
 *)
 
 theory StateRelation
-imports Invariants_H
+imports InvariantUpdates_H
 begin
 
 context begin interpretation Arch .

--- a/proof/refine/RISCV64/Syscall_R.thy
+++ b/proof/refine/RISCV64/Syscall_R.thy
@@ -279,11 +279,6 @@ lemma msg_from_syserr_map[simp]:
   apply (case_tac err,clarsimp+)
   done
 
-(* FIXME: move *)
-lemma non_exst_same_timeSlice_upd[simp]:
-  "non_exst_same tcb (tcbDomain_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
 lemma threadSet_tcbDomain_update_ct_idle_or_in_cur_domain':
   "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. ksSchedulerAction s \<noteq> ResumeCurrentThread) \<rbrace>
      threadSet (tcbDomain_update (\<lambda>_. domain)) t
@@ -1785,10 +1780,6 @@ lemma hc_invs'[wp]:
   apply (wp)
   apply (clarsimp)
   done
-
-lemma sch_act_sane_ksMachineState [iff]:
-  "sch_act_sane (s\<lparr>ksMachineState := b\<rparr>) = sch_act_sane s"
-  by (simp add: sch_act_sane_def)
 
 lemma cteInsert_sane[wp]:
   "\<lbrace>sch_act_sane\<rbrace> cteInsert newCap srcSlot destSlot \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"

--- a/proof/refine/RISCV64/TcbAcc_R.thy
+++ b/proof/refine/RISCV64/TcbAcc_R.thy
@@ -187,54 +187,6 @@ lemma valid_objs'_maxPriority:
   apply (clarsimp simp: valid_tcb'_def)
   done
 
-lemma invs'_machine:
-  assumes mask: "irq_masks (f (ksMachineState s)) =
-                 irq_masks (ksMachineState s)"
-  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
-                valid_machine_state' s"
-  shows "invs' (ksMachineState_update f s) = invs' s"
-proof -
-  have valid_pspace'_machine: "\<And>f s.
-       valid_pspace' (ksMachineState_update f s) = valid_pspace' s"
-    by simp
-  have valid_idle'_machine: "\<And>f s.
-       valid_idle' (ksMachineState_update f s) = valid_idle' s"
-    by fastforce
-  show ?thesis
-    apply (cases "ksSchedulerAction s")
-    apply (simp_all add: invs'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
-                    vms ct_not_inQ_def
-                    state_refs_of'_def ps_clear_def
-                    valid_irq_node'_def mask
-              cong: option.case_cong)
-    done
-qed
-
-lemma invs_no_cicd'_machine:
-  assumes mask: "irq_masks (f (ksMachineState s)) =
-                 irq_masks (ksMachineState s)"
-  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
-                valid_machine_state' s"
-  shows "invs_no_cicd' (ksMachineState_update f s) = invs_no_cicd' s"
-proof -
-  have valid_pspace'_machine: "\<And>f s.
-       valid_pspace' (ksMachineState_update f s) = valid_pspace' s"
-    by simp
-  have valid_idle'_machine: "\<And>f s.
-       valid_idle' (ksMachineState_update f s) = valid_idle' s"
-    by fastforce
-  show ?thesis
-    apply (cases "ksSchedulerAction s")
-    apply (simp_all add: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
-                    vms ct_not_inQ_def
-                    state_refs_of'_def ps_clear_def
-                    valid_irq_node'_def mask
-              cong: option.case_cong)
-    done
-qed
-
 lemma doMachineOp_irq_states':
   assumes masks: "\<And>P. \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks s)\<rbrace>"
   shows "\<lbrace>valid_irq_states'\<rbrace> doMachineOp f \<lbrace>\<lambda>rv. valid_irq_states'\<rbrace>"
@@ -717,15 +669,6 @@ lemma threadSet_pspace_no_overlap' [wp]:
   apply (clarsimp simp: obj_at'_def)
   done
 
-lemma pspace_no_overlap_queues [simp]:
-  "pspace_no_overlap' w sz (ksReadyQueues_update f s) = pspace_no_overlap' w sz s"
-  by (simp add: pspace_no_overlap'_def)
-
-lemma pspace_no_overlap'_ksSchedulerAction[simp]:
-  "pspace_no_overlap' a b (ksSchedulerAction_update f s) =
-   pspace_no_overlap' a b s"
-  by (simp add: pspace_no_overlap'_def)
-
 lemma threadSet_global_refsT:
   assumes x: "\<forall>tcb. \<forall>(getF, setF) \<in> ran tcb_cte_cases.
                  getF (F tcb) = getF tcb"
@@ -1027,10 +970,6 @@ lemma threadSet_valid_queues_Qf:
   apply (clarsimp simp: valid_queues'_def subset_iff)
   done
 
-lemma ksReadyQueues_update_id:
-  "ksReadyQueues_update id s = s"
-  by simp
-
 lemma addToQs_subset:
   "set (qs p) \<subseteq> set (addToQs F t qs p)"
 by (clarsimp simp: addToQs_def split_def)
@@ -1267,14 +1206,6 @@ lemma threadSet_vms'[wp]:
   "\<lbrace>valid_machine_state'\<rbrace> threadSet F t \<lbrace>\<lambda>rv. valid_machine_state'\<rbrace>"
   apply (simp add: valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def)
   by (intro hoare_vcg_all_lift hoare_vcg_disj_lift; wp)
-
-lemma vms_ksReadyQueues_update[simp]:
-  "valid_machine_state' (ksReadyQueues_update f s) = valid_machine_state' s"
-  by (simp add: valid_machine_state'_def)
-
-lemma ct_not_inQ_ksReadyQueues_update[simp]:
-  "ct_not_inQ (ksReadyQueues_update f s) = ct_not_inQ s"
-  by (simp add: ct_not_inQ_def)
 
 lemma threadSet_not_inQ:
   "\<lbrace>ct_not_inQ and (\<lambda>s. (\<exists>tcb. tcbQueued (F tcb) \<and> \<not> tcbQueued tcb)
@@ -1515,10 +1446,6 @@ lemma asUser_typ_at' [wp]:
   by (simp add: asUser_def bind_assoc split_def, wp select_f_inv)
 
 lemmas asUser_typ_ats[wp] = typ_at_lifts [OF asUser_typ_at']
-
-lemma inQ_context[simp]:
-  "inQ d p (tcbArch_update f tcb) = inQ d p tcb"
-  by (cases tcb, simp add: inQ_def)
 
 lemma asUser_invs[wp]:
   "\<lbrace>invs' and tcb_at' t\<rbrace> asUser t m \<lbrace>\<lambda>rv. invs'\<rbrace>"
@@ -1933,6 +1860,10 @@ definition
 where
  "weak_sch_act_wf sa = (\<lambda>s. \<forall>t. sa = SwitchToThread t \<longrightarrow> st_tcb_at' runnable' t s \<and> tcb_in_cur_domain' t s)"
 
+lemma weak_sch_act_wf_updateDomainTime[simp]:
+  "weak_sch_act_wf m (ksDomainTime_update f s) = weak_sch_act_wf m s"
+  by (simp add:weak_sch_act_wf_def tcb_in_cur_domain'_def )
+
 lemma set_sa_corres:
   "sched_act_relation sa sa'
     \<Longrightarrow> corres dc \<top> \<top> (set_scheduler_action sa) (setSchedulerAction sa')"
@@ -2180,13 +2111,9 @@ lemma sbn_corres:
 crunches rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotification
   for tcb'[wp]: "tcb_at' addr"
 
-lemma valid_tcb_tcbQueued:
-  "valid_tcb' (tcbQueued_update f tcb) = valid_tcb' tcb"
-  by (cases tcb, rule ext, simp add: valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
-
 crunches rescheduleRequired, removeFromBitmap
   for valid_objs'[wp]: valid_objs'
-  (simp: unless_def valid_tcb_tcbQueued crunch_simps)
+  (simp: unless_def crunch_simps)
 
 
 lemma tcbSchedDequeue_valid_objs' [wp]: "\<lbrace> valid_objs' \<rbrace> tcbSchedDequeue t \<lbrace>\<lambda>_. valid_objs' \<rbrace>"
@@ -2925,11 +2852,6 @@ lemma tcbSchedAppend_valid_queues[wp]:
    unfolding tcbSchedAppend_def
    by (fastforce intro:  tcbSchedEnqueueOrAppend_valid_queues)
 
-lemma valid_queues_ksSchedulerAction_update[simp]:
-  "Invariants_H.valid_queues (ksSchedulerAction_update f s) = Invariants_H.valid_queues s"
- unfolding Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
- by simp
-
 lemma rescheduleRequired_valid_queues[wp]:
   "\<lbrace>\<lambda>s. Invariants_H.valid_queues s \<and> valid_objs' s \<and>
         weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
@@ -2947,18 +2869,6 @@ lemma rescheduleRequired_valid_queues_sch_act_simple:
   apply (simp add: rescheduleRequired_def)
   apply (wp | wpc | simp | fastforce simp: Invariants_H.valid_queues_def sch_act_simple_def)+
   done
-
-lemma valid_bitmapQ_ksSchedulerAction_upd[simp]:
-  "valid_bitmapQ (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>) = valid_bitmapQ s"
-  unfolding bitmapQ_defs by simp
-
-lemma bitmapQ_no_L1_orphans_ksSchedulerAction_upd[simp]:
-  "bitmapQ_no_L1_orphans (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>) = bitmapQ_no_L1_orphans s"
-  unfolding bitmapQ_defs by simp
-
-lemma bitmapQ_no_L2_orphans_ksSchedulerAction_upd[simp]:
-  "bitmapQ_no_L2_orphans (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>) = bitmapQ_no_L2_orphans s"
-  unfolding bitmapQ_defs by simp
 
 lemma rescheduleRequired_valid_bitmapQ_sch_act_simple:
   "\<lbrace> valid_bitmapQ and sch_act_simple\<rbrace>
@@ -3090,10 +3000,6 @@ lemma tcbSchedEnqueue_valid_queues'[wp]:
   apply (clarsimp simp: obj_at'_def)
   done
 
-lemma valid_queues'_ksSchedulerAction_update[simp]:
-  "Invariants_H.valid_queues' (ksSchedulerAction_update f s) = Invariants_H.valid_queues' s"
-  by (simp add: valid_queues'_def)
-
 lemma rescheduleRequired_valid_queues'_weak[wp]:
   "\<lbrace>\<lambda>s. valid_queues' s \<and> weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
     rescheduleRequired
@@ -3128,7 +3034,8 @@ lemma setBoundNotification_valid_queues'[wp]:
   apply (fastforce simp: inQ_def obj_at'_def pred_tcb_at'_def)
   done
 
-lemma valid_tcb'_tcbState_update:"\<And>tcb s st . \<lbrakk> valid_tcb_state' st s; valid_tcb' tcb s \<rbrakk> \<Longrightarrow> valid_tcb' (tcbState_update (\<lambda>_. st) tcb) s"
+lemma valid_tcb'_tcbState_update:
+  "\<lbrakk> valid_tcb_state' st s; valid_tcb' tcb s \<rbrakk> \<Longrightarrow> valid_tcb' (tcbState_update (\<lambda>_. st) tcb) s"
   apply (clarsimp simp: valid_tcb'_def tcb_cte_cases_def cteSizeBits_def valid_tcb_state'_def)
   done
 
@@ -4178,27 +4085,6 @@ lemma tcbSchedAppend_ct_not_inQ:
       done
   qed
 
-lemma ct_not_inQ_update_cnt:
-  "ct_not_inQ s \<Longrightarrow> ct_not_inQ (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
-   by (simp add: ct_not_inQ_def)
-
-lemma ct_not_inQ_update_stt:
-  "ct_not_inQ s \<Longrightarrow> ct_not_inQ (s\<lparr>ksSchedulerAction := SwitchToThread t\<rparr>)"
-   by (simp add: ct_not_inQ_def)
-
-lemma valid_bitmapQ_upd_scheduler_action:
-  "valid_bitmapQ (s\<lparr>ksSchedulerAction := x \<rparr>) = valid_bitmapQ s"
-  unfolding bitmapQ_defs
-  by simp
-
-lemma invs'_update_cnt:
-  "invs' s \<Longrightarrow> invs' (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
-   by (clarsimp simp: invs'_def valid_state'_def ct_not_inQ_update_cnt
-                      valid_queues_def valid_queues'_def valid_irq_node'_def
-                      cur_tcb'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                      valid_bitmapQ_upd_scheduler_action valid_queues_no_bitmap_def
-                      bitmapQ_no_L2_orphans_def bitmapQ_no_L1_orphans_def)
-
 lemma setSchedulerAction_direct:
   "\<lbrace>\<top>\<rbrace> setSchedulerAction sa \<lbrace>\<lambda>_ s. ksSchedulerAction s = sa\<rbrace>"
   by (wpsimp simp: setSchedulerAction_def)
@@ -4227,10 +4113,9 @@ lemma possibleSwitchTo_ct_not_inQ:
     possibleSwitchTo t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
   (is "\<lbrace>?PRE\<rbrace> _ \<lbrace>_\<rbrace>")
   apply (simp add: possibleSwitchTo_def curDomain_def)
-  apply (wp static_imp_wp rescheduleRequired_ct_not_inQ tcbSchedEnqueue_ct_not_inQ threadGet_wp
-       | wpc
-       | (rule hoare_post_imp[OF _ rescheduleRequired_sa_cnt], fastforce)
-       | clarsimp simp: ct_not_inQ_update_stt bitmap_fun_defs)+
+  apply (wpsimp wp: static_imp_wp rescheduleRequired_ct_not_inQ tcbSchedEnqueue_ct_not_inQ
+                    threadGet_wp
+       | (rule hoare_post_imp[OF _ rescheduleRequired_sa_cnt], fastforce))+
   apply (fastforce simp: obj_at'_def)
   done
 
@@ -4659,6 +4544,18 @@ where
   "non_exst_same' (KOTCB tcb) (KOTCB tcb') = non_exst_same tcb tcb'" |
   "non_exst_same' _ _ = True"
 
+lemma non_exst_same_prio_upd[simp]:
+  "non_exst_same tcb (tcbPriority_update f tcb)"
+  by (cases tcb, simp add: non_exst_same_def)
+
+lemma non_exst_same_timeSlice_upd[simp]:
+  "non_exst_same tcb (tcbTimeSlice_update f tcb)"
+  by (cases tcb, simp add: non_exst_same_def)
+
+lemma non_exst_same_domain_upd[simp]:
+  "non_exst_same tcb (tcbDomain_update f tcb)"
+  by (cases tcb, simp add: non_exst_same_def)
+
 lemma set_eobject_corres':
   assumes e: "etcb_relation etcb tcb'"
   assumes z: "\<And>s. obj_at' P ptr s
@@ -4760,14 +4657,6 @@ lemma ethread_set_corresT:
 
 lemmas ethread_set_corres =
     ethread_set_corresT [OF _ all_tcbI, OF _ ball_tcb_cte_casesI]
-
-lemma non_exst_same_prio_upd[simp]:
-  "non_exst_same tcb (tcbPriority_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma non_exst_same_timeSlice_upd[simp]:
-  "non_exst_same tcb (tcbTimeSlice_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
 
 end
 end

--- a/proof/refine/RISCV64/Tcb_R.thy
+++ b/proof/refine/RISCV64/Tcb_R.thy
@@ -1128,10 +1128,6 @@ lemma threadSet_valid_queues'_no_state2:
   apply (fastforce simp: inQ_def split: if_split_asm)
   done
 
-lemma inQ_tcbIPCBuffer_update_idem[simp]:
-  "inQ d p (tcbIPCBuffer_update (\<lambda>_. x) ko) = inQ d p ko"
-  by (clarsimp simp: inQ_def)
-
 lemma getThreadBufferSlot_dom_tcb_cte_cases:
   "\<lbrace>\<top>\<rbrace> getThreadBufferSlot a \<lbrace>\<lambda>rv s. rv \<in> (+) a ` dom tcb_cte_cases\<rbrace>"
   by (wpsimp simp: tcb_cte_cases_def getThreadBufferSlot_def locateSlot_conv cte_level_bits_def

--- a/proof/refine/RISCV64/Untyped_R.thy
+++ b/proof/refine/RISCV64/Untyped_R.thy
@@ -4396,11 +4396,6 @@ crunch ct_in_state'[wp]: doMachineOp "ct_in_state' P"
 crunch st_tcb_at'[wp]: doMachineOp "st_tcb_at' P p"
   (simp: crunch_simps ct_in_state'_def)
 
-lemma ex_cte_cap_wp_to_work_units[simp]:
-  "ex_cte_cap_wp_to' P slot (ksWorkUnitsCompleted_update f s)
-    = ex_cte_cap_wp_to' P slot s"
-  by (simp add: ex_cte_cap_wp_to'_def)
-
 lemma ex_cte_cap_wp_to_irq_state_independent_H[simp]:
   "irq_state_independent_H (ex_cte_cap_wp_to' P slot)"
   by (simp add: ex_cte_cap_wp_to'_def)
@@ -4436,9 +4431,6 @@ lemma setCTE_ct_in_state:
   apply (rule hoare_pre, wp ct_in_state'_decomp setCTE_pred_tcb_at')
   apply (auto simp: ct_in_state'_def)
   done
-
-add_upd_simps "ct_in_state' P (gsUntypedZeroRanges_update f s)"
-declare upd_simps[simp]
 
 crunch ct_in_state[wp]: updateFreeIndex "ct_in_state' P"
 crunch nosch[wp]: updateFreeIndex "\<lambda>s. P (ksSchedulerAction s)"

--- a/proof/refine/RISCV64/VSpace_R.thy
+++ b/proof/refine/RISCV64/VSpace_R.thy
@@ -1084,7 +1084,7 @@ lemma setASIDPool_state_refs' [wp]:
   "\<lbrace>\<lambda>s. P (state_refs_of' s)\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>rv s. P (state_refs_of' s)\<rbrace>"
   apply (clarsimp simp: setObject_def valid_def in_monad split_def
                         updateObject_default_def objBits_simps
-                        in_magnitude_check state_refs_of'_def ps_clear_upd'
+                        in_magnitude_check state_refs_of'_def ps_clear_upd
                  elim!: rsubst[where P=P] intro!: ext
              split del: if_split cong: option.case_cong if_cong)
   apply (simp split: option.split)
@@ -1259,7 +1259,7 @@ lemma setObject_cte_obj_at_ap':
   \<lbrace>\<lambda>_ s. P' (obj_at' P p s)\<rbrace>"
   apply (clarsimp simp: setObject_def in_monad split_def
                         valid_def lookupAround2_char1
-                        obj_at'_def ps_clear_upd'
+                        obj_at'_def ps_clear_upd
              split del: if_split)
   apply (clarsimp elim!: rsubst[where P=P'])
   apply (clarsimp simp: updateObject_cte in_monad objBits_simps
@@ -1278,7 +1278,7 @@ lemma storePTE_asid_pool_obj_at'[wp]:
   apply (simp add: storePTE_def)
   apply (clarsimp simp: setObject_def in_monad split_def
                         valid_def lookupAround2_char1
-                        obj_at'_def ps_clear_upd'
+                        obj_at'_def ps_clear_upd
              split del: if_split)
   apply (clarsimp elim!: rsubst[where P=P])
   apply (clarsimp simp: updateObject_default_def in_monad)

--- a/proof/refine/RISCV64/orphanage/Orphanage.thy
+++ b/proof/refine/RISCV64/orphanage/Orphanage.thy
@@ -180,33 +180,65 @@ lemma almost_no_orphans_disj:
   apply (auto intro: pred_tcb_at')
   done
 
+lemma no_orphans_update_simps[simp]:
+  "no_orphans (gsCNodes_update f s) = no_orphans s"
+  "no_orphans (gsUserPages_update g s) = no_orphans s"
+  "no_orphans (gsUntypedZeroRanges_update h s) = no_orphans s"
+  by (simp_all add: no_orphans_def all_active_tcb_ptrs_def
+                    is_active_tcb_ptr_def all_queued_tcb_ptrs_def)
+
+lemma no_orphans_ksReadyQueuesL1Bitmap_update[simp]:
+  "no_orphans (ksReadyQueuesL1Bitmap_update f s) = no_orphans s"
+  unfolding no_orphans_def all_active_tcb_ptrs_def all_queued_tcb_ptrs_def is_active_tcb_ptr_def
+  by auto
+
+lemma no_orphans_ksReadyQueuesL2Bitmap_update[simp]:
+  "no_orphans (ksReadyQueuesL2Bitmap_update f s) = no_orphans s"
+  unfolding no_orphans_def all_active_tcb_ptrs_def all_queued_tcb_ptrs_def is_active_tcb_ptr_def
+  by auto
+
+lemma no_orphans_ksIdle[simp]:
+   "no_orphans (ksIdleThread_update f s) = no_orphans s"
+  unfolding no_orphans_def all_active_tcb_ptrs_def all_queued_tcb_ptrs_def is_active_tcb_ptr_def
+  apply auto
+  done
+
+lemma no_orphans_ksWorkUnits [simp]:
+   "no_orphans (ksWorkUnitsCompleted_update f s) = no_orphans s"
+  unfolding no_orphans_def all_active_tcb_ptrs_def all_queued_tcb_ptrs_def is_active_tcb_ptr_def
+  apply auto
+  done
+
+lemma no_orphans_irq_state_independent[intro!, simp]:
+  "no_orphans (s \<lparr>ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr> \<rparr>)
+   = no_orphans s"
+  by (simp add: no_orphans_def all_active_tcb_ptrs_def
+                all_queued_tcb_ptrs_def is_active_tcb_ptr_def)
+
+add_upd_simps "no_orphans (gsUntypedZeroRanges_update f s)"
+declare upd_simps[simp]
+
+lemma almost_no_orphans_ksReadyQueuesL1Bitmap_update[simp]:
+  "almost_no_orphans t (ksReadyQueuesL1Bitmap_update f s) = almost_no_orphans t s"
+  unfolding almost_no_orphans_def all_active_tcb_ptrs_def all_queued_tcb_ptrs_def is_active_tcb_ptr_def
+  by auto
+
+lemma almost_no_orphans_ksReadyQueuesL2Bitmap_update[simp]:
+  "almost_no_orphans t (ksReadyQueuesL2Bitmap_update f s) = almost_no_orphans t s"
+  unfolding almost_no_orphans_def all_active_tcb_ptrs_def all_queued_tcb_ptrs_def is_active_tcb_ptr_def
+  by auto
+
+lemma all_active_tcb_ptrs_queue [simp]:
+  "all_active_tcb_ptrs (ksReadyQueues_update f s) = all_active_tcb_ptrs s"
+  by (clarsimp simp: all_active_tcb_ptrs_def is_active_tcb_ptr_def)
+
 (****************************************************************************************************)
 
 crunch ksCurThread [wp]: setVMRoot "\<lambda> s. P (ksCurThread s)"
 (wp: crunch_wps simp: crunch_simps)
 
-lemma no_orphans_ksReadyQueuesL1Bitmap_update[simp]:
-  "no_orphans (s\<lparr> ksReadyQueuesL1Bitmap := x \<rparr>) = no_orphans s"
-  unfolding no_orphans_def all_active_tcb_ptrs_def all_queued_tcb_ptrs_def is_active_tcb_ptr_def
-  by auto
-
-lemma no_orphans_ksReadyQueuesL2Bitmap_update[simp]:
-  "no_orphans (s\<lparr> ksReadyQueuesL2Bitmap := x \<rparr>) = no_orphans s"
-  unfolding no_orphans_def all_active_tcb_ptrs_def all_queued_tcb_ptrs_def is_active_tcb_ptr_def
-  by auto
-
 crunch no_orphans [wp]: addToBitmap "no_orphans"
 crunch no_orphans [wp]: removeFromBitmap "no_orphans"
-
-lemma almost_no_orphans_ksReadyQueuesL1Bitmap_update[simp]:
-  "almost_no_orphans t (s\<lparr> ksReadyQueuesL1Bitmap := x \<rparr>) = almost_no_orphans t s"
-  unfolding almost_no_orphans_def all_active_tcb_ptrs_def all_queued_tcb_ptrs_def is_active_tcb_ptr_def
-  by auto
-
-lemma almost_no_orphans_ksReadyQueuesL2Bitmap_update[simp]:
-  "almost_no_orphans t (s\<lparr> ksReadyQueuesL2Bitmap := x \<rparr>) = almost_no_orphans t s"
-  unfolding almost_no_orphans_def all_active_tcb_ptrs_def all_queued_tcb_ptrs_def is_active_tcb_ptr_def
-  by auto
 
 crunch almost_no_orphans [wp]: addToBitmap "almost_no_orphans x"
 crunch almost_no_orphans [wp]: removeFromBitmap "almost_no_orphans x"
@@ -254,10 +286,6 @@ lemma threadSet_almost_no_orphans:
   unfolding almost_no_orphans_disj all_queued_tcb_ptrs_def
   apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift threadSet_st_tcb_at2 | clarsimp)+
   done
-
-lemma all_active_tcb_ptrs_queue [simp]:
-  "all_active_tcb_ptrs (ksReadyQueues_update f s) = all_active_tcb_ptrs s"
-  by (clarsimp simp: all_active_tcb_ptrs_def is_active_tcb_ptr_def)
 
 lemma setQueue_no_orphans_enq:
   "\<lbrace> \<lambda>s. no_orphans s \<and> set (ksReadyQueues s (d, prio)) \<subseteq> set qs \<rbrace>
@@ -579,19 +607,6 @@ lemma switchToIdleThread_no_orphans' [wp]:
   apply (auto simp: no_orphans_disj all_queued_tcb_ptrs_def is_active_tcb_ptr_def
                     st_tcb_at_neg' tcb_at_typ_at')
   done
-
-lemma ct_in_state_ksSched [simp]:
-  "ct_in_state' activatable' (ksSchedulerAction_update f s) = ct_in_state' activatable' s"
-  unfolding ct_in_state'_def
-  apply auto
-  done
-
-lemma no_orphans_ksIdle [simp]:
-   "no_orphans (ksIdleThread_update f s) = no_orphans s"
-  unfolding no_orphans_def all_active_tcb_ptrs_def all_queued_tcb_ptrs_def is_active_tcb_ptr_def
-  apply auto
-  done
-
 
 crunch no_orphans [wp]: "Arch.switchToThread" "no_orphans"
   (wp: no_orphans_lift)
@@ -1400,13 +1415,6 @@ lemma copyGlobalMappings_no_orphans [wp]:
   apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift)
   done
 
-lemma no_orphans_update_simps[simp]:
-  "no_orphans (gsCNodes_update f s) = no_orphans s"
-  "no_orphans (gsUserPages_update g s) = no_orphans s"
-  "no_orphans (gsUntypedZeroRanges_update h s) = no_orphans s"
-  by (simp_all add: no_orphans_def all_active_tcb_ptrs_def
-                    is_active_tcb_ptr_def all_queued_tcb_ptrs_def)
-
 crunch no_orphans [wp]: insertNewCap "no_orphans"
 (wp: hoare_drop_imps)
 
@@ -1506,21 +1514,6 @@ lemma deleteObjects_no_orphans [wp]:
   apply (clarsimp simp: pred_tcb_at'_def obj_at_delete'[simplified field_simps]
                   cong: if_cong)
   done
-
-lemma no_orphans_ksWorkUnits [simp]:
-   "no_orphans (ksWorkUnitsCompleted_update f s) = no_orphans s"
-  unfolding no_orphans_def all_active_tcb_ptrs_def all_queued_tcb_ptrs_def is_active_tcb_ptr_def
-  apply auto
-  done
-
-lemma no_orphans_irq_state_independent[intro!, simp]:
-  "no_orphans (s \<lparr>ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr> \<rparr>)
-   = no_orphans s"
-  by (simp add: no_orphans_def all_active_tcb_ptrs_def
-                all_queued_tcb_ptrs_def is_active_tcb_ptr_def)
-
-add_upd_simps "no_orphans (gsUntypedZeroRanges_update f s)"
-declare upd_simps[simp]
 
 crunch no_orphans[wp]: updateFreeIndex "no_orphans"
 

--- a/proof/refine/X64/ArchAcc_R.thy
+++ b/proof/refine/X64/ArchAcc_R.thy
@@ -1977,14 +1977,6 @@ lemma clearMemory_vms':
   apply (rule clearMemory_um_eq_0)
   done
 
-lemma ct_not_inQ_ksMachineState_update[simp]:
-  "ct_not_inQ (s\<lparr>ksMachineState := v\<rparr>) = ct_not_inQ s"
-  by (simp add: ct_not_inQ_def)
-
-lemma ct_in_current_domain_ksMachineState_update[simp]:
-  "ct_idle_or_in_cur_domain' (s\<lparr>ksMachineState := v\<rparr>) = ct_idle_or_in_cur_domain' s"
-  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-
 lemma dmo_clearMemory_invs'[wp]:
   "\<lbrace>invs'\<rbrace> doMachineOp (clearMemory w sz) \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (simp add: doMachineOp_def split_def)

--- a/proof/refine/X64/Arch_R.thy
+++ b/proof/refine/X64/Arch_R.thy
@@ -1540,16 +1540,6 @@ lemma invokeArch_tcb_at':
                   wp: performASIDControlInvocation_tcb_at')
   done
 
-(* FIXME random place to have these *)
-lemma pspace_no_overlap_queuesL1 [simp]:
-  "pspace_no_overlap' w sz (ksReadyQueuesL1Bitmap_update f s) = pspace_no_overlap' w sz s"
-  by (simp add: pspace_no_overlap'_def)
-
-(* FIXME random place to have these *)
-lemma pspace_no_overlap_queuesL2 [simp]:
-  "pspace_no_overlap' w sz (ksReadyQueuesL2Bitmap_update f s) = pspace_no_overlap' w sz s"
-  by (simp add: pspace_no_overlap'_def)
-
 crunch pspace_no_overlap'[wp]: setThreadState "pspace_no_overlap' w s"
   (simp: unless_def)
 

--- a/proof/refine/X64/CNodeInv_R.thy
+++ b/proof/refine/X64/CNodeInv_R.thy
@@ -563,6 +563,14 @@ where
  "not_recursive_ctes s \<equiv> {ptr. \<exists>cap. cteCaps_of s ptr = Some cap
                              \<and> \<not> (isZombie cap \<and> capZombiePtr cap = ptr)}"
 
+lemma not_recursive_ctes_wu [simp]:
+  "not_recursive_ctes (ksWorkUnitsCompleted_update f s) = not_recursive_ctes s"
+  by (simp add: not_recursive_ctes_def)
+
+lemma not_recursive_ctes_irq_state_independent[simp, intro!]:
+  "not_recursive_ctes (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := x \<rparr>\<rparr>) = not_recursive_ctes s"
+  by (simp add: not_recursive_ctes_def)
+
 lemma capSwap_not_recursive:
   "\<lbrace>\<lambda>s. card (not_recursive_ctes s) \<le> n
      \<and> cte_wp_at' (\<lambda>cte. \<not> (isZombie (cteCap cte) \<and> capZombiePtr (cteCap cte) = p1)) p1 s
@@ -700,24 +708,6 @@ lemma case_Zombie_assert_fold:
   "(case cap of Zombie ptr zb n \<Rightarrow> haskell_assertE (P ptr) str | _ \<Rightarrow> returnOk ())
        = assertE (isZombie cap \<longrightarrow> P (capZombiePtr cap))"
   by (cases cap, simp_all add: isCap_simps assertE_def)
-
-lemma not_recursive_ctes_wu [simp]:
-  "not_recursive_ctes (ksWorkUnitsCompleted_update f s) = not_recursive_ctes s"
-  by (simp add: not_recursive_ctes_def)
-
-lemma not_recursive_ctes_irq_state_independent[simp, intro!]:
-  "not_recursive_ctes (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := x \<rparr>\<rparr>) = not_recursive_ctes s"
-  by (simp add: not_recursive_ctes_def)
-
-lemma typ_at'_irq_state_independent[simp, intro!]:
-  "P (typ_at' T p (s \<lparr>ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr>\<rparr>))
-   = P (typ_at' T p s)"
-  by (simp add: typ_at'_def)
-
-lemma sch_act_simple_irq_state_independent[intro!, simp]:
-  "sch_act_simple (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr> \<rparr>) =
-   sch_act_simple s"
-  by (simp add: sch_act_simple_def)
 
 termination finaliseSlot'
   apply (rule finaliseSlot'.termination,
@@ -5950,10 +5940,6 @@ lemma cancelIPC_cap_to'[wp]:
                | wpcw | wp (once) hoare_drop_imps)+
   done
 
-lemma ex_cte_cap_wp_to'_ksReadyQueuesL1Bitmap[simp]:
-   "ex_cte_cap_wp_to' P p (s\<lparr> ksReadyQueuesL1Bitmap := x \<rparr>) = ex_cte_cap_wp_to' P p s"
-   unfolding ex_cte_cap_wp_to'_def by simp
-
 lemma emptySlot_deletes [wp]:
   "\<lbrace>\<top>\<rbrace> emptySlot p opt \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. cteCap c = NullCap) p s\<rbrace>"
   apply (simp add: emptySlot_def case_Null_If)
@@ -6246,14 +6232,6 @@ lemmas preemptionPoint_invR =
 
 lemmas preemptionPoint_invE =
   valid_validE_E [OF preemptionPoint_inv]
-
-lemma sch_act_simple_wu [simp, intro!]:
-  "sch_act_simple (ksWorkUnitsCompleted_update f s) = sch_act_simple s"
-  by (simp add: sch_act_simple_def)
-
-lemma ex_cte_cap_to'_wu [simp, intro!]:
-  "ex_cte_cap_to' p (ksWorkUnitsCompleted_update f s) = ex_cte_cap_to' p s"
-  by (simp add: ex_cte_cap_to'_def)
 
 lemma finaliseSlot_invs':
   assumes finaliseCap:

--- a/proof/refine/X64/CSpace1_R.thy
+++ b/proof/refine/X64/CSpace1_R.thy
@@ -832,14 +832,6 @@ lemma setCTE_tcb_in_cur_domain':
   apply (wp setObject_cte_obj_at_tcb' | simp)+
   done
 
-lemma tcbCTable_upd_simp [simp]:
-  "tcbCTable (tcbCTable_update (\<lambda>_. x) tcb) = x"
-  by (cases tcb) simp
-
-lemma tcbVTable_upd_simp [simp]:
-  "tcbVTable (tcbVTable_update (\<lambda>_. x) tcb) = x"
-  by (cases tcb) simp
-
 lemma setCTE_ctes_of_wp [wp]:
   "\<lbrace>\<lambda>s. P (ctes_of s (p \<mapsto> cte))\<rbrace>
   setCTE p cte
@@ -1354,7 +1346,7 @@ lemma weak_derived_updateCapData:
   apply (clarsimp simp: Let_def isCap_simps updateCapData_def)
   done
 
-lemma maskCapRights_Reply:
+lemma maskCapRights_Reply[simp]:
   "isReplyCap (maskCapRights r c) = isReplyCap c"
   apply (insert capMasterCap_maskCapRights)
   apply (rule master_eqI, rule isCap_Master)

--- a/proof/refine/X64/CSpace1_R.thy
+++ b/proof/refine/X64/CSpace1_R.thy
@@ -795,7 +795,7 @@ lemma setObject_cte_obj_at_tcb':
   \<lbrace>\<lambda>_ s. P' (obj_at' P p s)\<rbrace>"
   apply (clarsimp simp: setObject_def in_monad split_def
                         valid_def lookupAround2_char1
-                        obj_at'_def ps_clear_upd' projectKOs
+                        obj_at'_def ps_clear_upd projectKOs
              split del: if_split)
   apply (clarsimp elim!: rsubst[where P=P'])
   apply (clarsimp simp: updateObject_cte in_monad objBits_simps

--- a/proof/refine/X64/CSpace_R.thy
+++ b/proof/refine/X64/CSpace_R.thy
@@ -2626,10 +2626,10 @@ lemma setCTE_ko_wp_at_live[wp]:
                  elim!: rsubst[where P=P])
   apply (drule(1) updateObject_cte_is_tcb_or_cte [OF _ refl, rotated])
   apply (elim exE conjE disjE)
-   apply (clarsimp simp: ps_clear_upd' objBits_simps
+   apply (clarsimp simp: ps_clear_upd objBits_simps
                          lookupAround2_char1)
    apply (simp add: tcb_cte_cases_def split: if_split_asm)
-  apply (clarsimp simp: ps_clear_upd' objBits_simps)
+  apply (clarsimp simp: ps_clear_upd objBits_simps)
   done
 
 lemma setCTE_iflive':
@@ -2687,10 +2687,10 @@ lemma setCTE_ko_wp_at_not_live[wp]:
                  elim!: rsubst[where P=P])
   apply (drule(1) updateObject_cte_is_tcb_or_cte [OF _ refl, rotated])
   apply (elim exE conjE disjE)
-   apply (clarsimp simp: ps_clear_upd' objBits_simps
+   apply (clarsimp simp: ps_clear_upd objBits_simps
                          lookupAround2_char1)
    apply (simp add: tcb_cte_cases_def split: if_split_asm)
-  apply (clarsimp simp: ps_clear_upd' objBits_simps)
+  apply (clarsimp simp: ps_clear_upd objBits_simps)
   done
 
 lemma setUntypedCapAsFull_ko_wp_not_at'[wp]:

--- a/proof/refine/X64/Detype_R.thy
+++ b/proof/refine/X64/Detype_R.thy
@@ -85,10 +85,6 @@ lemma descendants_range_inD':
   done
 end
 
-interpretation clear_um:
-  p_arch_idle_update_int_eq "clear_um S"
-  by unfold_locales (simp_all add: clear_um_def)
-
 context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma descendants_range'_def2:
@@ -1506,7 +1502,7 @@ proof (simp add: invs'_def valid_state'_def valid_pspace'_def
     done
 
   from sa_simp ctnotinQ
-  show "ct_not_inQ ?state''"
+  show "ct_not_inQ state'"
     apply (clarsimp simp: ct_not_inQ_def pred_tcb_at'_def)
     apply (drule obj_at'_and
                    [THEN iffD2, OF conjI,
@@ -1519,7 +1515,7 @@ proof (simp add: invs'_def valid_state'_def valid_pspace'_def
     apply (clarsimp dest!: ex_nonz_cap_notRange)
     done
 
-  from ctcd show "ct_idle_or_in_cur_domain' ?state''"
+  from ctcd show "ct_idle_or_in_cur_domain' state'"
     apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
     apply (intro impI)
     apply (elim disjE impE)
@@ -1688,13 +1684,6 @@ lemma deleteObjects_st_tcb_at':
   apply (simp add: delete_locale_def)
   done
 
-lemma ex_cte_cap_wp_to'_gsCNodes_update[simp]:
-  "ex_cte_cap_wp_to' P p (gsCNodes_update f s') = ex_cte_cap_wp_to' P p s'"
-  by (simp add: ex_cte_cap_wp_to'_def)
-lemma ex_cte_cap_wp_to'_gsUserPages_update[simp]:
-  "ex_cte_cap_wp_to' P p (gsUserPages_update f s') = ex_cte_cap_wp_to' P p s'"
-  by (simp add: ex_cte_cap_wp_to'_def)
-
 lemma deleteObjects_cap_to':
   "\<lbrace>cte_wp_at' (\<lambda>c. cteCap c = UntypedCap d ptr bits idx) p
      and invs' and ct_active' and sch_act_simple
@@ -1742,19 +1731,6 @@ lemma valid_untyped_no_overlap:
     apply (clarsimp simp:p_assoc_help)
    apply fastforce+
   done
-
-lemma pspace_no_overlap'_gsCNodes_update[simp]:
-  "pspace_no_overlap' p b (gsCNodes_update f s') = pspace_no_overlap' p b s'"
-  by (simp add: pspace_no_overlap'_def)
-
-lemma pspace_no_overlap'_gsUserPages_update[simp]:
-  "pspace_no_overlap' p b (gsUserPages_update f s') = pspace_no_overlap' p b s'"
-  by (simp add: pspace_no_overlap'_def)
-
-lemma pspace_no_overlap'_ksMachineState_update[simp]:
-  "pspace_no_overlap' p n (ksMachineState_update f s) =
-   pspace_no_overlap' p n s"
-  by (simp add: pspace_no_overlap'_def)
 
 lemma deleteObject_no_overlap[wp]:
   "\<lbrace>valid_cap' (UntypedCap d ptr bits idx) and valid_pspace'\<rbrace>
@@ -3931,11 +3907,6 @@ lemma new_cap_object_comm_helper:
   apply (drule_tac x = "parent " in spec)
    apply clarsimp
   done
-
-lemma pspace_no_overlap_gsUntypedZeroRanges[simp]:
-  "pspace_no_overlap' ptr n (gsUntypedZeroRanges_update f s)
-    = pspace_no_overlap' ptr n s"
-  by (simp add: pspace_no_overlap'_def)
 
 crunch pspace_aligned'[wp]: updateNewFreeIndex "pspace_aligned'"
 crunch pspace_canonical'[wp]: updateNewFreeIndex "pspace_canonical'"

--- a/proof/refine/X64/Finalise_R.thy
+++ b/proof/refine/X64/Finalise_R.thy
@@ -2508,10 +2508,6 @@ lemma finaliseCap_True_invs[wp]:
     apply (wp irqs_masked_lift| simp | wpc)+
   done
 
-lemma ct_not_inQ_ksArchState_update[simp]:
-  "ct_not_inQ (s\<lparr>ksArchState := v\<rparr>) = ct_not_inQ s"
-  by (simp add: ct_not_inQ_def)
-
 lemma invs_asid_update_strg':
   "invs' s \<and> tab = x64KSASIDTable (ksArchState s) \<longrightarrow>
    invs' (s\<lparr>ksArchState := x64KSASIDTable_update
@@ -3861,10 +3857,6 @@ crunch valid_irq_states'[wp]: copyGlobalMappings "valid_irq_states'"
 
 crunch ksDomScheduleIdx[wp]: copyGlobalMappings "\<lambda>s. P (ksDomScheduleIdx s)"
   (wp: crunch_wps)
-
-lemma ct_in_current_domain_ArchState_update[simp]:
-  "ct_idle_or_in_cur_domain' (s\<lparr>ksArchState := v\<rparr>) = ct_idle_or_in_cur_domain' s"
-  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
 
 lemma threadSet_ct_idle_or_in_cur_domain':
   "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>

--- a/proof/refine/X64/InterruptAcc_R.thy
+++ b/proof/refine/X64/InterruptAcc_R.thy
@@ -119,31 +119,25 @@ lemma preemptionPoint_inv:
           | simp)+
   done
 
-lemma invs'_wu [simp, intro!]:
-  "invs' (ksWorkUnitsCompleted_update f s) = invs' s"
-  apply (simp add: invs'_def cur_tcb'_def valid_state'_def Invariants_H.valid_queues_def
-                   valid_queues'_def valid_irq_node'_def valid_machine_state'_def
-                   ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                   bitmapQ_defs valid_queues_no_bitmap_def)
-  done
+lemma ct_running_irq_state_independent[intro!, simp]:
+  "ct_running (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
+   = ct_running s"
+  by (simp add: ct_in_state_def)
 
-lemma ct_in_state'_irq_state_independent [simp, intro!]:
-  "ct_in_state' x (s\<lparr>ksMachineState := ksMachineState s
-                          \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>) =
-   ct_in_state' x s"
-  by (simp add: ct_in_state'_def irq_state_independent_H_def)+
+lemma ct_idle_irq_state_independent[intro!, simp]:
+  "ct_idle (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
+   = ct_idle s"
+  by (simp add: ct_in_state_def)
 
-lemma ex_cte_cap_wp_to'_irq_state_independent [simp, intro!]:
-  "ex_cte_cap_wp_to' x y (s\<lparr>ksMachineState := ksMachineState s
-                          \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>) =
-   ex_cte_cap_wp_to' x y s"
-  by (simp add: ex_cte_cap_wp_to'_def irq_state_independent_H_def)+
+lemma typ_at'_irq_state_independent[simp, intro!]:
+  "P (typ_at' T p (s \<lparr>ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr>\<rparr>))
+   = P (typ_at' T p s)"
+  by (simp add: typ_at'_def)
 
-lemma ps_clear_irq_state_independent [simp, intro!]:
-  "ps_clear a b (s\<lparr>ksMachineState := ksMachineState s
-                    \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>) =
-   ps_clear a b s"
-  by (simp add: ps_clear_def)
+lemma sch_act_simple_irq_state_independent[intro!, simp]:
+  "sch_act_simple (s \<lparr> ksMachineState := ksMachineState s \<lparr> irq_state := f (irq_state (ksMachineState s)) \<rparr> \<rparr>) =
+   sch_act_simple s"
+  by (simp add: sch_act_simple_def)
 
 lemma invs'_irq_state_independent [simp, intro!]:
   "invs' (s\<lparr>ksMachineState := ksMachineState s

--- a/proof/refine/X64/Interrupt_R.thy
+++ b/proof/refine/X64/Interrupt_R.thy
@@ -430,12 +430,6 @@ lemma safe_ioport_insert'_ntfn_strg:
   "isNotificationCap cap \<longrightarrow> safe_ioport_insert' cap cap' s"
   by (clarsimp simp: isCap_simps)
 
-lemma ct_in_current_domain_ksMachineState:
-  "ct_idle_or_in_cur_domain' (ksMachineState_update p s) = ct_idle_or_in_cur_domain' s"
-  apply (simp add:ct_idle_or_in_cur_domain'_def)
-  apply (simp add:tcb_in_cur_domain'_def)
-  done
-
 lemma invoke_irq_handler_invs'[wp]:
   "\<lbrace>invs' and irq_handler_inv_valid' i\<rbrace>
     InterruptDecls_H.invokeIRQHandler i \<lbrace>\<lambda>rv. invs'\<rbrace>"
@@ -462,10 +456,6 @@ lemma invoke_irq_handler_invs'[wp]:
 lemma IRQHandler_valid':
   "(s' \<turnstile>' IRQHandlerCap irq) = (irq \<le> maxIRQ)"
   by (simp add: valid_cap'_def capAligned_def word_bits_conv)
-
-lemma valid_mdb_interrupts'[simp]:
-  "valid_mdb' (ksInterruptState_update f s) = valid_mdb' s"
-  by (simp add: valid_mdb'_def)
 
 crunch valid_mdb'[wp]: setIRQState "valid_mdb'"
 crunch cte_wp_at[wp]: setIRQState "cte_wp_at' P p"
@@ -674,23 +664,12 @@ lemma dec_domain_time_corres:
   apply (clarsimp simp:state_relation_def)
   done
 
-lemma weak_sch_act_wf_updateDomainTime[simp]:
-  "weak_sch_act_wf m (s\<lparr>ksDomainTime := t\<rparr>)
-   = weak_sch_act_wf m s"
-  by (simp add:weak_sch_act_wf_def tcb_in_cur_domain'_def )
-
 lemma tcbSchedAppend_valid_objs':
   "\<lbrace>valid_objs'\<rbrace>tcbSchedAppend t \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
   apply (simp add:tcbSchedAppend_def)
-  apply (wp hoare_unless_wp
-    threadSet_valid_objs' threadGet_wp
-    | simp add:valid_tcb_tcbQueued)+
+  apply (wpsimp wp: hoare_unless_wp threadSet_valid_objs' threadGet_wp)
   apply (clarsimp simp add:obj_at'_def typ_at'_def)
   done
-
-lemma valid_tcb_tcbTimeSlice_update[simp]:
-  "valid_tcb' (tcbTimeSlice_update (\<lambda>_. timeSlice) tcb) s = valid_tcb' tcb s"
-  by (simp add:valid_tcb'_def tcb_cte_cases_def)
 
 lemma thread_state_case_if:
  "(case state of Structures_A.thread_state.Running \<Rightarrow> f | _ \<Rightarrow> g) =
@@ -852,24 +831,6 @@ lemma handle_interrupt_corres:
     apply clarsimp
    apply clarsimp
   done
-
-lemma ksDomainTime_invs[simp]:
-  "invs' (a\<lparr>ksDomainTime := t\<rparr>) = invs' a"
-  by (simp add:invs'_def valid_state'_def
-    cur_tcb'_def ct_not_inQ_def ct_idle_or_in_cur_domain'_def
-    tcb_in_cur_domain'_def valid_machine_state'_def)
-
-lemma valid_machine_state'_ksDomainTime[simp]:
-  "valid_machine_state' (a\<lparr>ksDomainTime := t\<rparr>) = valid_machine_state' a"
-  by (simp add:valid_machine_state'_def)
-
-lemma cur_tcb'_ksDomainTime[simp]:
-  "cur_tcb' (a\<lparr>ksDomainTime := 0\<rparr>) = cur_tcb' a"
-  by (simp add:cur_tcb'_def)
-
-lemma ct_idle_or_in_cur_domain'_ksDomainTime[simp]:
-  "ct_idle_or_in_cur_domain' (a\<lparr>ksDomainTime := t \<rparr>) = ct_idle_or_in_cur_domain' a"
-  by (simp add:ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
 
 lemma threadSet_ksDomainTime[wp]:
   "\<lbrace>\<lambda>s. P (ksDomainTime s)\<rbrace> threadSet f ptr \<lbrace>\<lambda>rv s. P (ksDomainTime s)\<rbrace>"

--- a/proof/refine/X64/InvariantUpdates_H.thy
+++ b/proof/refine/X64/InvariantUpdates_H.thy
@@ -1,0 +1,380 @@
+(*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory InvariantUpdates_H
+imports Invariants_H
+begin
+
+(* FIXME: use locales to shorten this work *)
+
+lemma ps_clear_domE[elim?]:
+  "\<lbrakk> ps_clear x n s; dom (ksPSpace s) = dom (ksPSpace s') \<rbrakk> \<Longrightarrow> ps_clear x n s'"
+  by (simp add: ps_clear_def)
+
+lemma ps_clear_upd:
+  "ksPSpace s y = Some v \<Longrightarrow>
+    ps_clear x n (ksPSpace_update (\<lambda>a. ksPSpace s(y \<mapsto> v')) s') = ps_clear x n s"
+  by (rule iffI | clarsimp elim!: ps_clear_domE | fastforce)+
+
+lemmas ps_clear_updE[elim] = iffD2[OF ps_clear_upd, rotated]
+
+lemma ct_not_inQ_ksMachineState_update[simp]:
+  "ct_not_inQ (ksMachineState_update f s) = ct_not_inQ s"
+  by (simp add: ct_not_inQ_def)
+
+lemma ct_in_current_domain_ksMachineState[simp]:
+  "ct_idle_or_in_cur_domain' (ksMachineState_update p s) = ct_idle_or_in_cur_domain' s"
+  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+
+lemma invs'_machine:
+  assumes mask: "irq_masks (f (ksMachineState s)) =
+                 irq_masks (ksMachineState s)"
+  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
+                valid_machine_state' s"
+  shows "invs' (ksMachineState_update f s) = invs' s"
+proof -
+  show ?thesis
+    apply (cases "ksSchedulerAction s")
+    apply (simp_all add: invs'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
+                    vms ct_not_inQ_def
+                    state_refs_of'_def ps_clear_def
+                    valid_irq_node'_def mask
+              cong: option.case_cong)
+    done
+qed
+
+lemma invs_no_cicd'_machine:
+  assumes mask: "irq_masks (f (ksMachineState s)) =
+                 irq_masks (ksMachineState s)"
+  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
+                valid_machine_state' s"
+  shows "invs_no_cicd' (ksMachineState_update f s) = invs_no_cicd' s"
+proof -
+  show ?thesis
+    apply (cases "ksSchedulerAction s")
+    apply (simp_all add: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
+                    vms ct_not_inQ_def
+                    state_refs_of'_def ps_clear_def
+                    valid_irq_node'_def mask
+              cong: option.case_cong)
+    done
+qed
+
+lemma pspace_no_overlap_queues [simp]:
+  "pspace_no_overlap' w sz (ksReadyQueues_update f s) = pspace_no_overlap' w sz s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap'_ksSchedulerAction[simp]:
+  "pspace_no_overlap' a b (ksSchedulerAction_update f s) =
+   pspace_no_overlap' a b s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma ksReadyQueues_update_id[simp]:
+  "ksReadyQueues_update id s = s"
+  by simp
+
+lemma ct_not_inQ_ksReadyQueues_update[simp]:
+  "ct_not_inQ (ksReadyQueues_update f s) = ct_not_inQ s"
+  by (simp add: ct_not_inQ_def)
+
+lemma inQ_context[simp]:
+  "inQ d p (tcbArch_update f tcb) = inQ d p tcb"
+  by (cases tcb, simp add: inQ_def)
+
+lemma valid_tcb'_tcbQueued[simp]:
+  "valid_tcb' (tcbQueued_update f tcb) = valid_tcb' tcb"
+  by (cases tcb, rule ext, simp add: valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_tcb'_tcbFault_update[simp]:
+  "valid_tcb' tcb s \<Longrightarrow> valid_tcb' (tcbFault_update f tcb) s"
+  by (clarsimp simp: valid_tcb'_def  tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_tcb'_tcbTimeSlice_update[simp]:
+  "valid_tcb' (tcbTimeSlice_update f tcb) s = valid_tcb' tcb s"
+  by (simp add:valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_queues_ksSchedulerAction_update[simp]:
+  "valid_queues (ksSchedulerAction_update f s) = valid_queues s"
+ unfolding valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
+ by simp
+
+lemma valid_queues'_ksSchedulerAction_update[simp]:
+  "valid_queues' (ksSchedulerAction_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma ex_cte_cap_wp_to'_gsCNodes_update[simp]:
+  "ex_cte_cap_wp_to' P p (gsCNodes_update f s') = ex_cte_cap_wp_to' P p s'"
+  by (simp add: ex_cte_cap_wp_to'_def)
+lemma ex_cte_cap_wp_to'_gsUserPages_update[simp]:
+  "ex_cte_cap_wp_to' P p (gsUserPages_update f s') = ex_cte_cap_wp_to' P p s'"
+  by (simp add: ex_cte_cap_wp_to'_def)
+
+lemma pspace_no_overlap'_gsCNodes_update[simp]:
+  "pspace_no_overlap' p b (gsCNodes_update f s') = pspace_no_overlap' p b s'"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap'_gsUserPages_update[simp]:
+  "pspace_no_overlap' p b (gsUserPages_update f s') = pspace_no_overlap' p b s'"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap'_ksMachineState_update[simp]:
+  "pspace_no_overlap' p n (ksMachineState_update f s) =
+   pspace_no_overlap' p n s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap_gsUntypedZeroRanges[simp]:
+  "pspace_no_overlap' ptr n (gsUntypedZeroRanges_update f s)
+    = pspace_no_overlap' ptr n s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma vms'_ct[simp]:
+  "valid_machine_state' (ksCurThread_update f s) = valid_machine_state' s"
+  by (simp add: valid_machine_state'_def)
+
+lemma tcb_in_cur_domain_ct[simp]:
+  "tcb_in_cur_domain' t  (ksCurThread_update f s) = tcb_in_cur_domain' t s"
+  by (fastforce simp: tcb_in_cur_domain'_def)
+
+lemma valid_queues'_ksCurDomain[simp]:
+  "valid_queues' (ksCurDomain_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksDomScheduleIdx[simp]:
+  "valid_queues' (ksDomScheduleIdx_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksDomSchedule[simp]:
+  "valid_queues' (ksDomSchedule_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksDomainTime[simp]:
+  "valid_queues' (ksDomainTime_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues'_ksWorkUnitsCompleted[simp]:
+  "valid_queues' (ksWorkUnitsCompleted_update f s) = valid_queues' s"
+  by (simp add: valid_queues'_def)
+
+lemma valid_queues_ksCurDomain[simp]:
+  "valid_queues (ksCurDomain_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksDomScheduleIdx[simp]:
+  "valid_queues (ksDomScheduleIdx_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksDomSchedule[simp]:
+  "valid_queues (ksDomSchedule_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksDomainTime[simp]:
+  "valid_queues (ksDomainTime_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_queues_ksWorkUnitsCompleted[simp]:
+  "valid_queues (ksWorkUnitsCompleted_update f s) = valid_queues s"
+  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
+
+lemma valid_irq_node'_ksCurDomain[simp]:
+  "valid_irq_node' w (ksCurDomain_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksDomScheduleIdx[simp]:
+  "valid_irq_node' w (ksDomScheduleIdx_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksDomSchedule[simp]:
+  "valid_irq_node' w (ksDomSchedule_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksDomainTime[simp]:
+  "valid_irq_node' w (ksDomainTime_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma valid_irq_node'_ksWorkUnitsCompleted[simp]:
+  "valid_irq_node' w (ksWorkUnitsCompleted_update f s) = valid_irq_node' w s"
+  by (simp add: valid_irq_node'_def)
+
+lemma ex_cte_cap_wp_to_work_units[simp]:
+  "ex_cte_cap_wp_to' P slot (ksWorkUnitsCompleted_update f s)
+    = ex_cte_cap_wp_to' P slot s"
+  by (simp add: ex_cte_cap_wp_to'_def)
+
+add_upd_simps "ct_in_state' P (gsUntypedZeroRanges_update f s)"
+declare upd_simps[simp]
+
+lemma ct_not_inQ_ksArchState_update[simp]:
+  "ct_not_inQ (ksArchState_update f s) = ct_not_inQ s"
+  by (simp add: ct_not_inQ_def)
+
+lemma ct_in_current_domain_ArchState_update[simp]:
+  "ct_idle_or_in_cur_domain' (ksArchState_update f s) = ct_idle_or_in_cur_domain' s"
+  by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+
+lemma pspace_no_overlap_queuesL1 [simp]:
+  "pspace_no_overlap' w sz (ksReadyQueuesL1Bitmap_update f s) = pspace_no_overlap' w sz s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma pspace_no_overlap_queuesL2 [simp]:
+  "pspace_no_overlap' w sz (ksReadyQueuesL2Bitmap_update f s) = pspace_no_overlap' w sz s"
+  by (simp add: pspace_no_overlap'_def)
+
+lemma tcb_in_cur_domain'_ksSchedulerAction_update[simp]:
+  "tcb_in_cur_domain' t (ksSchedulerAction_update f s) = tcb_in_cur_domain' t s"
+  by (simp add: tcb_in_cur_domain'_def)
+
+lemma ct_idle_or_in_cur_domain'_ksSchedulerAction_update[simp]:
+  "b \<noteq> ResumeCurrentThread \<Longrightarrow>
+   ct_idle_or_in_cur_domain' (s\<lparr>ksSchedulerAction := b\<rparr>)"
+  apply (clarsimp simp add: ct_idle_or_in_cur_domain'_def)
+  done
+
+lemma sch_act_simple_wu [simp, intro!]:
+  "sch_act_simple (ksWorkUnitsCompleted_update f s) = sch_act_simple s"
+  by (simp add: sch_act_simple_def)
+
+lemma sch_act_simple_ksPSpace_update[simp]:
+  "sch_act_simple (ksPSpace_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma ps_clear_ksReadyQueue[simp]:
+  "ps_clear x n (ksReadyQueues_update f s) = ps_clear x n s"
+  by (simp add: ps_clear_def)
+
+lemma inQ_tcbIPCBuffer_update_idem[simp]:
+  "inQ d p (tcbIPCBuffer_update f ko) = inQ d p ko"
+  by (clarsimp simp: inQ_def)
+
+lemma valid_mdb_interrupts'[simp]:
+  "valid_mdb' (ksInterruptState_update f s) = valid_mdb' s"
+  by (simp add: valid_mdb'_def)
+
+lemma vms_ksReadyQueues_update[simp]:
+  "valid_machine_state' (ksReadyQueues_update f s) = valid_machine_state' s"
+  by (simp add: valid_machine_state'_def)
+
+lemma ct_in_state'_ksMachineState_update[simp]:
+  "ct_in_state' x (ksMachineState_update f s) = ct_in_state' x s"
+  by (simp add: ct_in_state'_def)+
+
+lemma ex_cte_cap_wp_to'_ksMachineState_update[simp]:
+  "ex_cte_cap_wp_to' x y (ksMachineState_update f s) = ex_cte_cap_wp_to' x y s"
+  by (simp add: ex_cte_cap_wp_to'_def)+
+
+lemma ps_clear_ksMachineState_update[simp]:
+  "ps_clear a b (ksMachineState_update f s) = ps_clear a b s"
+  by (simp add: ps_clear_def)
+
+lemma ct_in_state_ksSched[simp]:
+  "ct_in_state' P (ksSchedulerAction_update f s) = ct_in_state' P s"
+  unfolding ct_in_state'_def
+  apply auto
+  done
+
+lemma invs'_wu [simp]:
+  "invs' (ksWorkUnitsCompleted_update f s) = invs' s"
+  apply (simp add: invs'_def cur_tcb'_def valid_state'_def Invariants_H.valid_queues_def
+                   valid_queues'_def valid_irq_node'_def valid_machine_state'_def
+                   ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                   bitmapQ_defs valid_queues_no_bitmap_def)
+  done
+
+lemma valid_arch_state'_interrupt[simp]:
+  "valid_arch_state' (ksInterruptState_update f s) = valid_arch_state' s"
+  by (simp add: valid_arch_state'_def cong: option.case_cong)
+
+context begin interpretation Arch . (*FIXME: arch_split*)
+
+lemma valid_ioports_cr3_update[simp]:
+  "valid_ioports' (s\<lparr>ksArchState := x64KSCurrentUserCR3_update (\<lambda>_. c) (ksArchState s)\<rparr>) = valid_ioports' s"
+  by (clarsimp simp: valid_ioports'_simps)
+
+end
+
+lemma valid_bitmapQ_ksSchedulerAction_upd[simp]:
+  "valid_bitmapQ (ksSchedulerAction_update f s) = valid_bitmapQ s"
+  unfolding bitmapQ_defs by simp
+
+lemma bitmapQ_no_L1_orphans_ksSchedulerAction_upd[simp]:
+  "bitmapQ_no_L1_orphans (ksSchedulerAction_update f s) = bitmapQ_no_L1_orphans s"
+  unfolding bitmapQ_defs by simp
+
+lemma bitmapQ_no_L2_orphans_ksSchedulerAction_upd[simp]:
+  "bitmapQ_no_L2_orphans (ksSchedulerAction_update f s) = bitmapQ_no_L2_orphans s"
+  unfolding bitmapQ_defs by simp
+
+lemma cur_tcb'_ksReadyQueuesL1Bitmap_upd[simp]:
+  "cur_tcb' (ksReadyQueuesL1Bitmap_update f s) = cur_tcb' s"
+  unfolding cur_tcb'_def by simp
+
+lemma cur_tcb'_ksReadyQueuesL2Bitmap_upd[simp]:
+  "cur_tcb' (ksReadyQueuesL2Bitmap_update f s) = cur_tcb' s"
+  unfolding cur_tcb'_def by simp
+
+lemma ex_cte_cap_wp_to'_ksReadyQueuesL1Bitmap[simp]:
+   "ex_cte_cap_wp_to' P p (ksReadyQueuesL1Bitmap_update f s) = ex_cte_cap_wp_to' P p s"
+   unfolding ex_cte_cap_wp_to'_def by simp
+
+lemma ex_cte_cap_wp_to'_ksReadyQueuesL2Bitmap[simp]:
+   "ex_cte_cap_wp_to' P p (ksReadyQueuesL2Bitmap_update f s) = ex_cte_cap_wp_to' P p s"
+   unfolding ex_cte_cap_wp_to'_def by simp
+
+lemma sch_act_simple_readyQueue[simp]:
+  "sch_act_simple (ksReadyQueues_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma sch_act_simple_ksReadyQueuesL1Bitmap[simp]:
+  "sch_act_simple (ksReadyQueuesL1Bitmap_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma sch_act_simple_ksReadyQueuesL2Bitmap[simp]:
+  "sch_act_simple (ksReadyQueuesL2Bitmap_update f s) = sch_act_simple s"
+  apply (simp add: sch_act_simple_def)
+  done
+
+lemma ksDomainTime_invs[simp]:
+  "invs' (ksDomainTime_update f s) = invs' s"
+  by (simp add:invs'_def valid_state'_def
+    cur_tcb'_def ct_not_inQ_def ct_idle_or_in_cur_domain'_def
+    tcb_in_cur_domain'_def valid_machine_state'_def)
+
+lemma valid_machine_state'_ksDomainTime[simp]:
+  "valid_machine_state' (ksDomainTime_update f s) = valid_machine_state' s"
+  by (simp add:valid_machine_state'_def)
+
+lemma cur_tcb'_ksDomainTime[simp]:
+  "cur_tcb' (ksDomainTime_update f s) = cur_tcb' s"
+  by (simp add:cur_tcb'_def)
+
+lemma ct_idle_or_in_cur_domain'_ksDomainTime[simp]:
+  "ct_idle_or_in_cur_domain' (ksDomainTime_update f s) = ct_idle_or_in_cur_domain' s"
+  by (simp add:ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+
+lemma sch_act_sane_ksMachineState[simp]:
+  "sch_act_sane (ksMachineState_update f s) = sch_act_sane s"
+  by (simp add: sch_act_sane_def)
+
+lemma ct_not_inQ_update_cnt[simp]:
+  "ct_not_inQ (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
+   by (simp add: ct_not_inQ_def)
+
+lemma ct_not_inQ_update_stt[simp]:
+  "ct_not_inQ (s\<lparr>ksSchedulerAction := SwitchToThread t\<rparr>)"
+   by (simp add: ct_not_inQ_def)
+
+lemma invs'_update_cnt[elim!]:
+  "invs' s \<Longrightarrow> invs' (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
+   by (clarsimp simp: invs'_def valid_state'_def valid_queues_def valid_queues'_def
+                      valid_irq_node'_def cur_tcb'_def ct_idle_or_in_cur_domain'_def
+                      tcb_in_cur_domain'_def valid_queues_no_bitmap_def
+                      bitmapQ_no_L2_orphans_def bitmapQ_no_L1_orphans_def)
+
+end

--- a/proof/refine/X64/IpcCancel_R.thy
+++ b/proof/refine/X64/IpcCancel_R.thy
@@ -53,6 +53,20 @@ definition valid_inQ_queues :: "KernelStateData_H.kernel_state \<Rightarrow> boo
   "valid_inQ_queues \<equiv>
      \<lambda>s. \<forall>d p. (\<forall>t\<in>set (ksReadyQueues s (d, p)). obj_at' (inQ d p) t s) \<and> distinct (ksReadyQueues s (d, p))"
 
+lemma valid_inQ_queues_ksSchedulerAction_update[simp]:
+  "valid_inQ_queues (ksSchedulerAction_update f s) = valid_inQ_queues s"
+  by (simp add: valid_inQ_queues_def)
+
+lemma valid_inQ_queues_ksReadyQueuesL1Bitmap_upd[simp]:
+  "valid_inQ_queues (ksReadyQueuesL1Bitmap_update f s) = valid_inQ_queues s"
+  unfolding valid_inQ_queues_def
+  by simp
+
+lemma valid_inQ_queues_ksReadyQueuesL2Bitmap_upd[simp]:
+  "valid_inQ_queues (ksReadyQueuesL2Bitmap_update f s) = valid_inQ_queues s"
+  unfolding valid_inQ_queues_def
+  by simp
+
 defs capHasProperty_def:
   "capHasProperty ptr P \<equiv> cte_wp_at' (\<lambda>c. P (cteCap c)) ptr"
 end
@@ -1269,16 +1283,6 @@ lemma threadSet_valid_inQ_queues:
   apply (fastforce)
   done
 
-lemma valid_inQ_queues_ksReadyQueuesL1Bitmap_upd[simp]:
-  "valid_inQ_queues (s\<lparr>ksReadyQueuesL1Bitmap := f\<rparr>) = valid_inQ_queues s"
-  unfolding valid_inQ_queues_def
-  by simp
-
-lemma valid_inQ_queues_ksReadyQueuesL2Bitmap_upd[simp]:
-  "valid_inQ_queues (s\<lparr>ksReadyQueuesL2Bitmap := f\<rparr>) = valid_inQ_queues s"
-  unfolding valid_inQ_queues_def
-  by simp
-
 (* reorder the threadSet before the setQueue, useful for lemmas that don't refer to bitmap *)
 lemma setQueue_after_addToBitmap:
   "(setQueue d p q >>= (\<lambda>rv. (when P (addToBitmap d p)) >>= (\<lambda>rv. threadSet f t))) =
@@ -1320,10 +1324,6 @@ lemma removeFromBitmap_conceal_valid_inQ_queues[wp]:
   "\<lbrace> valid_inQ_queues \<rbrace> removeFromBitmap_conceal d p q t \<lbrace> \<lambda>_. valid_inQ_queues \<rbrace>"
   unfolding valid_inQ_queues_def removeFromBitmap_conceal_def
   by (wp|clarsimp simp: bitmap_fun_defs)+
-
-lemma valid_inQ_queues_ksSchedulerAction_update[simp]:
-  "valid_inQ_queues (ksSchedulerAction_update f s) = valid_inQ_queues s"
-  by (simp add: valid_inQ_queues_def)
 
 lemma rescheduleRequired_valid_inQ_queues[wp]:
   "\<lbrace>valid_inQ_queues\<rbrace> rescheduleRequired \<lbrace>\<lambda>_. valid_inQ_queues\<rbrace>"

--- a/proof/refine/X64/IpcCancel_R.thy
+++ b/proof/refine/X64/IpcCancel_R.thy
@@ -2427,7 +2427,7 @@ lemma threadSet_not_tcb[wp]:
                      setObject_def in_monad loadObject_default_def
                      ko_wp_at'_def projectKOs split_def in_magnitude_check
                      objBits_simps' updateObject_default_def
-                     ps_clear_upd' projectKO_opt_tcb)
+                     ps_clear_upd projectKO_opt_tcb)
 
 lemma setThreadState_not_tcb[wp]:
   "\<lbrace>ko_wp_at' (\<lambda>x. P x \<and> (projectKO_opt x = (None :: tcb option))) p\<rbrace>
@@ -2476,7 +2476,7 @@ lemma setObject_ko_wp_at':
   by (clarsimp simp: setObject_def valid_def in_monad
                      ko_wp_at'_def x split_def n
                      updateObject_default_def
-                     objBits_def[symmetric] ps_clear_upd'
+                     objBits_def[symmetric] ps_clear_upd
                      in_magnitude_check v projectKOs)
 
 lemma rescheduleRequired_unlive:

--- a/proof/refine/X64/Ipc_R.thy
+++ b/proof/refine/X64/Ipc_R.thy
@@ -1099,8 +1099,6 @@ crunch typ_at'[wp]: transferCaps "\<lambda>s. P (typ_at' T p s)"
 
 lemmas transferCaps_typ_ats[wp] = typ_at_lifts [OF transferCaps_typ_at']
 
-declare maskCapRights_Reply [simp]
-
 lemma isIRQControlCap_mask [simp]:
   "isIRQControlCap (maskCapRights R c) = isIRQControlCap c"
   apply (case_tac c)
@@ -2152,9 +2150,6 @@ lemma cancelIPC_valid_queues'[wp]:
 
 crunch valid_objs'[wp]: handleFaultReply valid_objs'
 
-lemma valid_tcb'_tcbFault_update[simp]: "\<And>tcb s. valid_tcb' tcb s \<Longrightarrow> valid_tcb' (tcbFault_update f tcb) s"
-  by (clarsimp simp: valid_tcb'_def  tcb_cte_cases_def)
-
 lemma cte_wp_at_is_reply_cap_toI:
   "cte_wp_at ((=) (cap.ReplyCap t False rights)) ptr s
    \<Longrightarrow> cte_wp_at (is_reply_cap_to t) ptr s"
@@ -2428,19 +2423,6 @@ lemmas transferCapsToSlots_pred_tcb_at' =
 crunches doIPCTransfer, possibleSwitchTo
   for  pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
   (wp: mapM_wp' crunch_wps simp: zipWithM_x_mapM)
-
-
-(* FIXME move *)
-lemma tcb_in_cur_domain'_ksSchedulerAction_update[simp]:
-  "tcb_in_cur_domain' t (ksSchedulerAction_update f s) = tcb_in_cur_domain' t s"
-by (simp add: tcb_in_cur_domain'_def)
-
-(* FIXME move *)
-lemma ct_idle_or_in_cur_domain'_ksSchedulerAction_update[simp]:
-  "b\<noteq> ResumeCurrentThread \<Longrightarrow>
-   ct_idle_or_in_cur_domain' (s\<lparr>ksSchedulerAction := b\<rparr>)"
-  apply (clarsimp simp add: ct_idle_or_in_cur_domain'_def)
-  done
 
 lemma setSchedulerAction_ct_in_domain:
  "\<lbrace>\<lambda>s. ct_idle_or_in_cur_domain' s

--- a/proof/refine/X64/KHeap_R.thy
+++ b/proof/refine/X64/KHeap_R.thy
@@ -175,17 +175,6 @@ lemma updateObject_cte_is_tcb_or_cte:
 
 declare plus_1_less[simp]
 
-lemma ps_clear_domE[elim?]:
-  "\<lbrakk> ps_clear x n s; dom (ksPSpace s) = dom (ksPSpace s') \<rbrakk> \<Longrightarrow> ps_clear x n s'"
-  by (simp add: ps_clear_def)
-
-lemma ps_clear_upd:
-  "ksPSpace s y = Some v \<Longrightarrow>
-    ps_clear x n (ksPSpace_update (\<lambda>a. ksPSpace s(y \<mapsto> v')) s') = ps_clear x n s"
-  by (rule iffI | clarsimp elim!: ps_clear_domE | fastforce)+
-
-lemmas ps_clear_updE[elim] = iffD2[OF ps_clear_upd, rotated]
-
 lemma updateObject_default_result:
   "(x, s'') \<in> fst (updateObject_default e ko p q n s) \<Longrightarrow> x = injectKO e"
   by (clarsimp simp add: updateObject_default_def in_monad)

--- a/proof/refine/X64/KHeap_R.thy
+++ b/proof/refine/X64/KHeap_R.thy
@@ -190,13 +190,6 @@ lemma updateObject_default_result:
   "(x, s'') \<in> fst (updateObject_default e ko p q n s) \<Longrightarrow> x = injectKO e"
   by (clarsimp simp add: updateObject_default_def in_monad)
 
-lemma ps_clear_upd':
-  "ksPSpace s y = Some v \<Longrightarrow>
-    ps_clear x n (s' \<lparr> ksPSpace := ksPSpace s(y \<mapsto> v')\<rparr>) = ps_clear x n s"
-  by (rule iffI | clarsimp elim!: ps_clear_domE | fastforce)+
-
-lemmas ps_clear_updE'[elim] = iffD2[OF ps_clear_upd', rotated]
-
 lemma obj_at_setObject1:
   assumes R: "\<And>(v::'a::pspace_storable) p q n ko s x s''.
                 (x, s'') \<in> fst (updateObject v ko p q n s) \<Longrightarrow> x = injectKO v"
@@ -237,7 +230,7 @@ lemma obj_at_setObject2:
    apply (clarsimp simp: lookupAround2_char1)
    apply (drule iffD1 [OF project_koType, OF exI])
    apply simp
-  apply (clarsimp simp: ps_clear_upd' lookupAround2_char1)
+  apply (clarsimp simp: ps_clear_upd lookupAround2_char1)
   done
 
 lemma updateObject_ep_eta:
@@ -263,11 +256,11 @@ lemma setObject_typ_at_inv:
   "\<lbrace>typ_at' T p'\<rbrace> setObject p v \<lbrace>\<lambda>r. typ_at' T p'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def)
   apply (clarsimp simp: valid_def typ_at'_def ko_wp_at'_def in_monad
-                        lookupAround2_char1 ps_clear_upd')
+                        lookupAround2_char1 ps_clear_upd)
   apply (drule updateObject_type)
   apply clarsimp
   apply (drule objBits_type)
-  apply (simp add: ps_clear_upd')
+  apply (simp add: ps_clear_upd)
   done
 
 lemma setObject_typ_at_not:
@@ -302,19 +295,19 @@ lemma setObject_cte_wp_at2':
   apply (erule rsubst[where P=P'])
   apply (rule iffI)
    apply (erule disjEI)
-    apply (clarsimp simp: ps_clear_upd' lookupAround2_char1 y)
+    apply (clarsimp simp: ps_clear_upd lookupAround2_char1 y)
    apply (erule exEI [where 'a=machine_word])
-   apply (clarsimp simp: ps_clear_upd' lookupAround2_char1)
+   apply (clarsimp simp: ps_clear_upd lookupAround2_char1)
    apply (drule(1) x)
     apply (clarsimp simp: lookupAround2_char1 prod_eqI)
    apply (fastforce dest: bspec [OF _ ranI])
   apply (erule disjEI)
-   apply (clarsimp simp: ps_clear_upd' lookupAround2_char1
+   apply (clarsimp simp: ps_clear_upd lookupAround2_char1
                   split: if_split_asm)
    apply (frule updateObject_type)
    apply (case_tac ba, simp_all add: y)[1]
   apply (erule exEI)
-  apply (clarsimp simp: ps_clear_upd' lookupAround2_char1
+  apply (clarsimp simp: ps_clear_upd lookupAround2_char1
                  split: if_split_asm)
   apply (frule updateObject_type)
   apply (case_tac ba, simp_all)
@@ -391,7 +384,7 @@ lemma obj_at_setObject3:
                             setObject_def split_def projectKOs
                             project_inject objBits_def[symmetric]
                             R updateObject_default_def
-                            in_magnitude_check P ps_clear_upd')
+                            in_magnitude_check P ps_clear_upd)
   apply fastforce
   done
 
@@ -409,7 +402,7 @@ lemma setObject_tcb_strongest:
   apply (simp add: setObject_def split_def)
   apply (clarsimp simp: valid_def obj_at'_def split_def in_monad
                         updateObject_default_def projectKOs
-                        ps_clear_upd')
+                        ps_clear_upd)
   done
 
 lemma getObject_obj_at':
@@ -518,7 +511,7 @@ lemma get_ntfn'_valid_ntfn[wp]:
 lemma setObject_distinct[wp]:
   shows     "\<lbrace>pspace_distinct'\<rbrace> setObject p val \<lbrace>\<lambda>rv. pspace_distinct'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_distinct'_def ps_clear_upd'
+                        projectKOs pspace_distinct'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm
                  dest!: updateObject_objBitsKO)
@@ -529,7 +522,7 @@ lemma setObject_distinct[wp]:
 lemma setObject_aligned[wp]:
   shows     "\<lbrace>pspace_aligned'\<rbrace> setObject p val \<lbrace>\<lambda>rv. pspace_aligned'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd'
+                        projectKOs pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm
                  dest!: updateObject_objBitsKO)
@@ -540,7 +533,7 @@ lemma setObject_aligned[wp]:
 lemma setObject_canonical[wp]:
   shows     "\<lbrace>pspace_canonical'\<rbrace> setObject p val \<lbrace>\<lambda>rv. pspace_canonical'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_canonical'_def ps_clear_upd'
+                        projectKOs pspace_canonical'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm
                  dest!: updateObject_objBitsKO)
@@ -551,7 +544,7 @@ lemma setObject_canonical[wp]:
 lemma setObject_in_kernel_mappings[wp]:
   shows     "\<lbrace>pspace_in_kernel_mappings'\<rbrace> setObject p val \<lbrace>\<lambda>rv. pspace_in_kernel_mappings'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_in_kernel_mappings'_def ps_clear_upd'
+                        projectKOs pspace_in_kernel_mappings'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm
                  dest!: updateObject_objBitsKO)
@@ -1109,7 +1102,7 @@ lemma setObject_ko_wp_at:
                  elim!: rsubst[where P=P]
              split del: if_split)
   apply (rule iffI)
-   apply (clarsimp simp: n ps_clear_upd' objBits_def[symmetric]
+   apply (clarsimp simp: n ps_clear_upd objBits_def[symmetric]
                   split: if_split_asm)
   apply (clarsimp simp: n project_inject objBits_def[symmetric]
                         ps_clear_upd
@@ -1265,7 +1258,7 @@ lemma setObject_no_0_obj' [wp]:
   "\<lbrace>no_0_obj'\<rbrace> setObject p v \<lbrace>\<lambda>r. no_0_obj'\<rbrace>"
   apply (clarsimp simp: setObject_def split_def)
   apply (clarsimp simp: valid_def no_0_obj'_def ko_wp_at'_def in_monad
-                        lookupAround2_char1 ps_clear_upd')
+                        lookupAround2_char1 ps_clear_upd)
   done
 
 lemma valid_updateCapDataI:

--- a/proof/refine/X64/Refine.thy
+++ b/proof/refine/X64/Refine.thy
@@ -324,16 +324,6 @@ lemma do_user_op_invs2:
     do_user_op_invs | simp | force)+
   done
 
-lemma ct_running_irq_state_independent[intro!, simp]:
-  "ct_running (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
-   = ct_running s"
-  by (simp add: ct_in_state_def)
-
-lemma ct_idle_irq_state_independent[intro!, simp]:
-  "ct_idle (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
-   = ct_idle s"
-  by (simp add: ct_in_state_def)
-
 lemmas ext_init_def = ext_init_det_ext_ext_def ext_init_unit_def
 
 lemma valid_list_init[simp]:

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -1197,11 +1197,6 @@ lemma update_gs_simps[simp]:
    gsUserPages_update (\<lambda>ups x. if x \<in> ptrs then Some X64HugePage else ups x)"
   by (simp_all add: update_gs_def)
 
-lemma caps_of_state_kheap_ekheap[simp]: "caps_of_state (kheap_update f (ekheap_update ef s)) =
-       caps_of_state (kheap_update f s)"
-  apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-  done
-
 lemma retype_state_relation:
   notes data_map_insert_def[simp del]
   assumes  sr:   "(s, s') \<in> state_relation"

--- a/proof/refine/X64/Schedule_R.thy
+++ b/proof/refine/X64/Schedule_R.thy
@@ -764,29 +764,17 @@ lemma setCurThread_invs_no_cicd':
      setCurThread t
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
 proof -
-  have obj_at'_ct: "\<And>f P addr s.
-       obj_at' P addr (ksCurThread_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
-  have valid_pspace'_ct: "\<And>s f.
-       valid_pspace' (ksCurThread_update f s) = valid_pspace' s"
-    by simp
-  have vms'_ct: "\<And>s f.
-       valid_machine_state' (ksCurThread_update f s) = valid_machine_state' s"
-    by (simp add: valid_machine_state'_def)
   have ct_not_inQ_ct: "\<And>s t . \<lbrakk> ct_not_inQ s; obj_at' (\<lambda>x. \<not> tcbQueued x) t s\<rbrakk> \<Longrightarrow> ct_not_inQ (s\<lparr> ksCurThread := t \<rparr>)"
     apply (simp add: ct_not_inQ_def o_def)
     done
-  have tcb_in_cur_domain_ct: "\<And>s f t.
-       tcb_in_cur_domain' t  (ksCurThread_update f s)= tcb_in_cur_domain' t s"
-    by (fastforce simp: tcb_in_cur_domain'_def)
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (clarsimp simp add: all_invs_but_ct_idle_or_in_cur_domain'_def invs'_def cur_tcb'_def valid_state'_def obj_at'_ct
-                              valid_pspace'_ct vms'_ct Invariants_H.valid_queues_def
+    apply (clarsimp simp add: all_invs_but_ct_idle_or_in_cur_domain'_def invs'_def cur_tcb'_def
+                              valid_state'_def Invariants_H.valid_queues_def
                               sch_act_wf ct_in_state'_def state_refs_of'_def
                               ps_clear_def valid_irq_node'_def valid_queues'_def ct_not_inQ_ct
-                              tcb_in_cur_domain_ct ct_idle_or_in_cur_domain'_def
+                              ct_idle_or_in_cur_domain'_def
                               bitmapQ_defs valid_queues_no_bitmap_def
                         cong: option.case_cong)
     done
@@ -874,9 +862,6 @@ lemma idle'_not_tcbQueued':
 lemma setCurThread_invs_no_cicd'_idle_thread:
   "\<lbrace>invs_no_cicd' and (\<lambda>s. t = ksIdleThread s) \<rbrace> setCurThread t \<lbrace>\<lambda>rv. invs'\<rbrace>"
 proof -
-  have vms'_ct: "\<And>s f.
-       valid_machine_state' (ksCurThread_update f s) = valid_machine_state' s"
-    by (simp add: valid_machine_state'_def)
   have ct_not_inQ_ct: "\<And>s t . \<lbrakk> ct_not_inQ s; obj_at' (\<lambda>x. \<not> tcbQueued x) t s\<rbrakk> \<Longrightarrow> ct_not_inQ (s\<lparr> ksCurThread := t \<rparr>)"
     apply (simp add: ct_not_inQ_def o_def)
     done
@@ -886,7 +871,7 @@ proof -
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (clarsimp simp add: vms'_ct ct_not_inQ_ct idle'_activatable' idle'_not_tcbQueued'[simplified o_def]
+    apply (clarsimp simp add: ct_not_inQ_ct idle'_activatable' idle'_not_tcbQueued'[simplified o_def]
                               invs'_def cur_tcb'_def valid_state'_def valid_idle'_def
                               sch_act_wf ct_in_state'_def state_refs_of'_def
                               ps_clear_def valid_irq_node'_def
@@ -1066,25 +1051,20 @@ lemma switchToThread_invs[wp]:
 lemma setCurThread_ct_in_state:
   "\<lbrace>obj_at' (P \<circ> tcbState) t\<rbrace> setCurThread t \<lbrace>\<lambda>rv. ct_in_state' P\<rbrace>"
 proof -
-  have obj_at'_ct: "\<And>P addr f s.
-       obj_at' P addr (ksCurThread_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (simp add: ct_in_state'_def pred_tcb_at'_def obj_at'_ct o_def)
+    apply (simp add: ct_in_state'_def pred_tcb_at'_def o_def)
     done
 qed
 
 lemma switchToThread_ct_in_state[wp]:
   "\<lbrace>obj_at' (P \<circ> tcbState) t\<rbrace> switchToThread t \<lbrace>\<lambda>rv. ct_in_state' P\<rbrace>"
 proof -
-  have P: "\<And>f x. tcbState (tcbTimeSlice_update f x) = tcbState x"
-    by (case_tac x, simp)
   show ?thesis
     apply (simp add: Thread_H.switchToThread_def tcbSchedEnqueue_def unless_def)
     apply (wp setCurThread_ct_in_state Arch_switchToThread_obj_at
-         | simp add: P o_def cong: if_cong)+
+         | simp add: o_def cong: if_cong)+
     done
 qed
 
@@ -1458,14 +1438,6 @@ lemma corres_assert_assume_r:
   \<Longrightarrow> corres dc P (Q and (\<lambda>s. Q')) f (assert Q' >>= g)"
   by (force simp: corres_underlying_def assert_def return_def bind_def fail_def)
 
-lemma cur_tcb'_ksReadyQueuesL1Bitmap_upd[simp]:
-  "cur_tcb' (s\<lparr>ksReadyQueuesL1Bitmap := x\<rparr>) = cur_tcb' s"
-  unfolding cur_tcb'_def by simp
-
-lemma cur_tcb'_ksReadyQueuesL2Bitmap_upd[simp]:
-  "cur_tcb' (s\<lparr>ksReadyQueuesL2Bitmap := x\<rparr>) = cur_tcb' s"
-  unfolding cur_tcb'_def by simp
-
 crunch cur[wp]: tcbSchedEnqueue cur_tcb'
   (simp: unless_def)
 
@@ -1680,66 +1652,6 @@ lemma next_domain_corres:
   apply (rule corres_modify)
   apply (simp add: state_relation_def Let_def dschLength_def dschDomain_def)
   done
-
-lemma valid_queues'_ksCurDomain[simp]:
-  "valid_queues' (ksCurDomain_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksDomScheduleIdx[simp]:
-  "valid_queues' (ksDomScheduleIdx_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksDomSchedule[simp]:
-  "valid_queues' (ksDomSchedule_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksDomainTime[simp]:
-  "valid_queues' (ksDomainTime_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues'_ksWorkUnitsCompleted[simp]:
-  "valid_queues' (ksWorkUnitsCompleted_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma valid_queues_ksCurDomain[simp]:
-  "Invariants_H.valid_queues (ksCurDomain_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksDomScheduleIdx[simp]:
-  "Invariants_H.valid_queues (ksDomScheduleIdx_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksDomSchedule[simp]:
-  "Invariants_H.valid_queues (ksDomSchedule_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksDomainTime[simp]:
-  "Invariants_H.valid_queues (ksDomainTime_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_queues_ksWorkUnitsCompleted[simp]:
-  "Invariants_H.valid_queues (ksWorkUnitsCompleted_update f s) = Invariants_H.valid_queues s"
-  by (simp add: Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
-lemma valid_irq_node'_ksCurDomain[simp]:
-  "valid_irq_node' w (ksCurDomain_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksDomScheduleIdx[simp]:
-  "valid_irq_node' w (ksDomScheduleIdx_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksDomSchedule[simp]:
-  "valid_irq_node' w (ksDomSchedule_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksDomainTime[simp]:
-  "valid_irq_node' w (ksDomainTime_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksWorkUnitsCompleted[simp]:
-  "valid_irq_node' w (ksWorkUnitsCompleted_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
 
 lemma next_domain_valid_sched[wp]:
   "\<lbrace> valid_sched and (\<lambda>s. scheduler_action s  = choose_new_thread)\<rbrace> next_domain \<lbrace> \<lambda>_. valid_sched \<rbrace>"
@@ -2008,28 +1920,12 @@ lemma ssa_all_invs_but_ct_not_inQ':
    (\<lambda>s. sa = ResumeCurrentThread \<longrightarrow> ksCurThread s = ksIdleThread s \<or> tcb_in_cur_domain' (ksCurThread s) s)\<rbrace>
    setSchedulerAction sa \<lbrace>\<lambda>rv. all_invs_but_ct_not_inQ'\<rbrace>"
 proof -
-  have obj_at'_sa: "\<And>P addr f s.
-       obj_at' P addr (ksSchedulerAction_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
-  have valid_pspace'_sa: "\<And>f s.
-       valid_pspace' (ksSchedulerAction_update f s) = valid_pspace' s"
-    by simp
-  have iflive_sa: "\<And>f s.
-       if_live_then_nonz_cap' (ksSchedulerAction_update f s)
-         = if_live_then_nonz_cap' s"
-    by fastforce
-  have ifunsafe_sa[simp]: "\<And>f s.
-       if_unsafe_then_cap' (ksSchedulerAction_update f s) = if_unsafe_then_cap' s"
-    by fastforce
-  have idle_sa[simp]: "\<And>f s.
-       valid_idle' (ksSchedulerAction_update f s) = valid_idle' s"
-    by fastforce
   show ?thesis
     apply (simp add: setSchedulerAction_def)
     apply wp
     apply (clarsimp simp add: invs'_def valid_state'_def cur_tcb'_def
-                              obj_at'_sa valid_pspace'_sa Invariants_H.valid_queues_def
-                              state_refs_of'_def iflive_sa ps_clear_def
+                              Invariants_H.valid_queues_def
+                              state_refs_of'_def ps_clear_def
                               valid_irq_node'_def valid_queues'_def
                               tcb_in_cur_domain'_def ct_idle_or_in_cur_domain'_def
                               bitmapQ_defs valid_queues_no_bitmap_def
@@ -2078,13 +1974,10 @@ lemma switchToThread_ct_not_queued_2:
 lemma setCurThread_obj_at':
   "\<lbrace> obj_at' P t \<rbrace> setCurThread t \<lbrace>\<lambda>rv s. obj_at' P (ksCurThread s) s \<rbrace>"
 proof -
-  have obj_at'_ct: "\<And>P addr f s.
-       obj_at' P addr (ksCurThread_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (simp add: ct_in_state'_def st_tcb_at'_def obj_at'_ct)
+    apply (simp add: ct_in_state'_def st_tcb_at'_def)
     done
 qed
 
@@ -2106,16 +1999,11 @@ lemma switchToIdleThread_activatable_2[wp]:
   done
 
 lemma switchToThread_tcb_in_cur_domain':
-  "\<lbrace>tcb_in_cur_domain' thread\<rbrace> ThreadDecls_H.switchToThread thread
-  \<lbrace>\<lambda>y s. tcb_in_cur_domain' (ksCurThread s) s\<rbrace>"
-  apply (simp add: Thread_H.switchToThread_def)
-  apply (rule hoare_pre)
-  apply (wp)
-    apply (simp add: X64_H.switchToThread_def setCurThread_def)
-    apply (wp tcbSchedDequeue_not_tcbQueued | simp )+
-   apply (simp add:tcb_in_cur_domain'_def)
-   apply (wp tcbSchedDequeue_tcbDomain | wps)+
-  apply (clarsimp simp:tcb_in_cur_domain'_def)
+  "\<lbrace>tcb_in_cur_domain' thread\<rbrace>
+   ThreadDecls_H.switchToThread thread
+   \<lbrace>\<lambda>y s. tcb_in_cur_domain' (ksCurThread s) s\<rbrace>"
+  apply (simp add: Thread_H.switchToThread_def setCurThread_def)
+  apply (wpsimp wp: tcbSchedDequeue_not_tcbQueued)
   done
 
 lemma chooseThread_invs_no_cicd'_posts: (* generic version *)
@@ -2282,13 +2170,10 @@ lemma schedule_sch_act_simple:
 lemma ssa_ct:
   "\<lbrace>ct_in_state' P\<rbrace> setSchedulerAction sa \<lbrace>\<lambda>rv. ct_in_state' P\<rbrace>"
 proof -
-  have obj_at'_sa: "\<And>P addr f s.
-       obj_at' P addr (ksSchedulerAction_update f s) = obj_at' P addr s"
-    by (fastforce intro: obj_at'_pspaceI)
   show ?thesis
     apply (unfold setSchedulerAction_def)
     apply wp
-    apply (clarsimp simp add: ct_in_state'_def pred_tcb_at'_def obj_at'_sa)
+    apply (clarsimp simp add: ct_in_state'_def pred_tcb_at'_def)
     done
 qed
 

--- a/proof/refine/X64/StateRelation.thy
+++ b/proof/refine/X64/StateRelation.thy
@@ -9,7 +9,7 @@
 *)
 
 theory StateRelation
-imports Invariants_H
+imports InvariantUpdates_H
 begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)

--- a/proof/refine/X64/Syscall_R.thy
+++ b/proof/refine/X64/Syscall_R.thy
@@ -279,11 +279,6 @@ lemma msg_from_syserr_map[simp]:
   apply (case_tac err,clarsimp+)
   done
 
-(* FIXME: move *)
-lemma non_exst_same_timeSlice_upd[simp]:
-  "non_exst_same tcb (tcbDomain_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
 lemma threadSet_tcbDomain_update_ct_idle_or_in_cur_domain':
   "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. ksSchedulerAction s \<noteq> ResumeCurrentThread) \<rbrace>
      threadSet (tcbDomain_update (\<lambda>_. domain)) t
@@ -1790,10 +1785,6 @@ lemma hc_invs'[wp]:
   apply (wp)
   apply (clarsimp)
   done
-
-lemma sch_act_sane_ksMachineState [iff]:
-  "sch_act_sane (s\<lparr>ksMachineState := b\<rparr>) = sch_act_sane s"
-  by (simp add: sch_act_sane_def)
 
 lemma cteInsert_sane[wp]:
   "\<lbrace>sch_act_sane\<rbrace> cteInsert newCap srcSlot destSlot \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"

--- a/proof/refine/X64/TcbAcc_R.thy
+++ b/proof/refine/X64/TcbAcc_R.thy
@@ -166,54 +166,6 @@ lemma valid_objs'_maxPriority:
   apply (clarsimp simp: valid_tcb'_def)
   done
 
-lemma invs'_machine:
-  assumes mask: "irq_masks (f (ksMachineState s)) =
-                 irq_masks (ksMachineState s)"
-  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
-                valid_machine_state' s"
-  shows "invs' (ksMachineState_update f s) = invs' s"
-proof -
-  have valid_pspace'_machine: "\<And>f s.
-       valid_pspace' (ksMachineState_update f s) = valid_pspace' s"
-    by simp
-  have valid_idle'_machine: "\<And>f s.
-       valid_idle' (ksMachineState_update f s) = valid_idle' s"
-    by fastforce
-  show ?thesis
-    apply (cases "ksSchedulerAction s")
-    apply (simp_all add: invs'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
-                    vms ct_not_inQ_def
-                    state_refs_of'_def ps_clear_def
-                    valid_irq_node'_def mask
-              cong: option.case_cong)
-    done
-qed
-
-lemma invs_no_cicd'_machine:
-  assumes mask: "irq_masks (f (ksMachineState s)) =
-                 irq_masks (ksMachineState s)"
-  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
-                valid_machine_state' s"
-  shows "invs_no_cicd' (ksMachineState_update f s) = invs_no_cicd' s"
-proof -
-  have valid_pspace'_machine: "\<And>f s.
-       valid_pspace' (ksMachineState_update f s) = valid_pspace' s"
-    by simp
-  have valid_idle'_machine: "\<And>f s.
-       valid_idle' (ksMachineState_update f s) = valid_idle' s"
-    by fastforce
-  show ?thesis
-    apply (cases "ksSchedulerAction s")
-    apply (simp_all add: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                    valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
-                    vms ct_not_inQ_def
-                    state_refs_of'_def ps_clear_def
-                    valid_irq_node'_def mask
-              cong: option.case_cong)
-    done
-qed
-
 lemma doMachineOp_irq_states':
   assumes masks: "\<And>P. \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks s)\<rbrace>"
   shows "\<lbrace>valid_irq_states'\<rbrace> doMachineOp f \<lbrace>\<lambda>rv. valid_irq_states'\<rbrace>"
@@ -707,15 +659,6 @@ lemma threadSet_pspace_no_overlap' [wp]:
   apply (clarsimp simp: obj_at'_def)
   done
 
-lemma pspace_no_overlap_queues [simp]:
-  "pspace_no_overlap' w sz (ksReadyQueues_update f s) = pspace_no_overlap' w sz s"
-  by (simp add: pspace_no_overlap'_def)
-
-lemma pspace_no_overlap'_ksSchedulerAction[simp]:
-  "pspace_no_overlap' a b (ksSchedulerAction_update f s) =
-   pspace_no_overlap' a b s"
-  by (simp add: pspace_no_overlap'_def)
-
 lemma threadSet_global_refsT:
   assumes x: "\<forall>tcb. \<forall>(getF, setF) \<in> ran tcb_cte_cases.
                  getF (F tcb) = getF tcb"
@@ -1020,10 +963,6 @@ lemma threadSet_valid_queues_Qf:
   apply (clarsimp simp: valid_queues'_def subset_iff)
   done
 
-lemma ksReadyQueues_update_id:
-  "ksReadyQueues_update id s = s"
-  by simp
-
 lemma addToQs_subset:
   "set (qs p) \<subseteq> set (addToQs F t qs p)"
 by (clarsimp simp: addToQs_def split_def)
@@ -1261,14 +1200,6 @@ lemma threadSet_vms'[wp]:
   "\<lbrace>valid_machine_state'\<rbrace> threadSet F t \<lbrace>\<lambda>rv. valid_machine_state'\<rbrace>"
   apply (simp add: valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def)
   by (intro hoare_vcg_all_lift hoare_vcg_disj_lift; wp)
-
-lemma vms_ksReadyQueues_update[simp]:
-  "valid_machine_state' (ksReadyQueues_update f s) = valid_machine_state' s"
-  by (simp add: valid_machine_state'_def)
-
-lemma ct_not_inQ_ksReadyQueues_update[simp]:
-  "ct_not_inQ (ksReadyQueues_update f s) = ct_not_inQ s"
-  by (simp add: ct_not_inQ_def)
 
 lemma threadSet_not_inQ:
   "\<lbrace>ct_not_inQ and (\<lambda>s. (\<exists>tcb. tcbQueued (F tcb) \<and> \<not> tcbQueued tcb)
@@ -1509,10 +1440,6 @@ lemma asUser_typ_at' [wp]:
   by (simp add: asUser_def bind_assoc split_def, wp select_f_inv)
 
 lemmas asUser_typ_ats[wp] = typ_at_lifts [OF asUser_typ_at']
-
-lemma inQ_context[simp]:
-  "inQ d p (tcbArch_update f tcb) = inQ d p tcb"
-  by (cases tcb, simp add: inQ_def)
 
 lemma asUser_invs[wp]:
   "\<lbrace>invs' and tcb_at' t\<rbrace> asUser t m \<lbrace>\<lambda>rv. invs'\<rbrace>"
@@ -1928,6 +1855,10 @@ definition
 where
  "weak_sch_act_wf sa = (\<lambda>s. \<forall>t. sa = SwitchToThread t \<longrightarrow> st_tcb_at' runnable' t s \<and> tcb_in_cur_domain' t s)"
 
+lemma weak_sch_act_wf_updateDomainTime[simp]:
+  "weak_sch_act_wf m (ksDomainTime_update f s) = weak_sch_act_wf m s"
+  by (simp add:weak_sch_act_wf_def tcb_in_cur_domain'_def )
+
 lemma set_sa_corres:
   "sched_act_relation sa sa'
     \<Longrightarrow> corres dc \<top> \<top> (set_scheduler_action sa) (setSchedulerAction sa')"
@@ -2171,14 +2102,9 @@ crunches rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotificati
   for tcb'[wp]: "tcb_at' addr"
   (simp: unless_def)
 
-lemma valid_tcb_tcbQueued:
-  "valid_tcb' (tcbQueued_update f tcb) = valid_tcb' tcb"
-  by (cases tcb, rule ext, simp add: valid_tcb'_def tcb_cte_cases_def)
-
 crunches rescheduleRequired, removeFromBitmap
   for valid_objs'[wp]: valid_objs'
-  (simp: unless_def valid_tcb_tcbQueued crunch_simps)
-
+  (simp: crunch_simps)
 
 lemma tcbSchedDequeue_valid_objs' [wp]: "\<lbrace> valid_objs' \<rbrace> tcbSchedDequeue t \<lbrace>\<lambda>_. valid_objs' \<rbrace>"
   unfolding tcbSchedDequeue_def
@@ -2918,11 +2844,6 @@ lemma tcbSchedAppend_valid_queues[wp]:
    unfolding tcbSchedAppend_def
    by (fastforce intro:  tcbSchedEnqueueOrAppend_valid_queues)
 
-lemma valid_queues_ksSchedulerAction_update[simp]:
-  "Invariants_H.valid_queues (ksSchedulerAction_update f s) = Invariants_H.valid_queues s"
- unfolding Invariants_H.valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
- by simp
-
 lemma rescheduleRequired_valid_queues[wp]:
   "\<lbrace>\<lambda>s. Invariants_H.valid_queues s \<and> valid_objs' s \<and>
         weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
@@ -2940,18 +2861,6 @@ lemma rescheduleRequired_valid_queues_sch_act_simple:
   apply (simp add: rescheduleRequired_def)
   apply (wp | wpc | simp | fastforce simp: Invariants_H.valid_queues_def sch_act_simple_def)+
   done
-
-lemma valid_bitmapQ_ksSchedulerAction_upd[simp]:
-  "valid_bitmapQ (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>) = valid_bitmapQ s"
-  unfolding bitmapQ_defs by simp
-
-lemma bitmapQ_no_L1_orphans_ksSchedulerAction_upd[simp]:
-  "bitmapQ_no_L1_orphans (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>) = bitmapQ_no_L1_orphans s"
-  unfolding bitmapQ_defs by simp
-
-lemma bitmapQ_no_L2_orphans_ksSchedulerAction_upd[simp]:
-  "bitmapQ_no_L2_orphans (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>) = bitmapQ_no_L2_orphans s"
-  unfolding bitmapQ_defs by simp
 
 lemma rescheduleRequired_valid_bitmapQ_sch_act_simple:
   "\<lbrace> valid_bitmapQ and sch_act_simple\<rbrace>
@@ -3083,10 +2992,6 @@ lemma tcbSchedEnqueue_valid_queues'[wp]:
   apply (clarsimp simp: obj_at'_def)
   done
 
-lemma valid_queues'_ksSchedulerAction_update[simp]:
-  "Invariants_H.valid_queues' (ksSchedulerAction_update f s) = Invariants_H.valid_queues' s"
-  by (simp add: valid_queues'_def)
-
 lemma rescheduleRequired_valid_queues'_weak[wp]:
   "\<lbrace>\<lambda>s. valid_queues' s \<and> weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
     rescheduleRequired
@@ -3121,7 +3026,8 @@ lemma setBoundNotification_valid_queues'[wp]:
   apply (fastforce simp: inQ_def obj_at'_def pred_tcb_at'_def)
   done
 
-lemma valid_tcb'_tcbState_update:"\<And>tcb s st . \<lbrakk> valid_tcb_state' st s; valid_tcb' tcb s \<rbrakk> \<Longrightarrow> valid_tcb' (tcbState_update (\<lambda>_. st) tcb) s"
+lemma valid_tcb'_tcbState_update:
+  "\<lbrakk> valid_tcb_state' st s; valid_tcb' tcb s \<rbrakk> \<Longrightarrow> valid_tcb' (tcbState_update (\<lambda>_. st) tcb) s"
   apply (clarsimp simp: valid_tcb'_def tcb_cte_cases_def valid_tcb_state'_def)
   done
 
@@ -4174,27 +4080,6 @@ lemma tcbSchedAppend_ct_not_inQ:
       done
   qed
 
-lemma ct_not_inQ_update_cnt:
-  "ct_not_inQ s \<Longrightarrow> ct_not_inQ (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
-   by (simp add: ct_not_inQ_def)
-
-lemma ct_not_inQ_update_stt:
-  "ct_not_inQ s \<Longrightarrow> ct_not_inQ (s\<lparr>ksSchedulerAction := SwitchToThread t\<rparr>)"
-   by (simp add: ct_not_inQ_def)
-
-lemma valid_bitmapQ_upd_scheduler_action:
-  "valid_bitmapQ (s\<lparr>ksSchedulerAction := x \<rparr>) = valid_bitmapQ s"
-  unfolding bitmapQ_defs
-  by simp
-
-lemma invs'_update_cnt:
-  "invs' s \<Longrightarrow> invs' (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
-   by (clarsimp simp: invs'_def valid_state'_def ct_not_inQ_update_cnt
-                      valid_queues_def valid_queues'_def valid_irq_node'_def
-                      cur_tcb'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                      valid_bitmapQ_upd_scheduler_action valid_queues_no_bitmap_def
-                      bitmapQ_no_L2_orphans_def bitmapQ_no_L1_orphans_def)
-
 lemma setSchedulerAction_direct:
   "\<lbrace>\<top>\<rbrace> setSchedulerAction sa \<lbrace>\<lambda>_ s. ksSchedulerAction s = sa\<rbrace>"
   by (wpsimp simp: setSchedulerAction_def)
@@ -4223,10 +4108,9 @@ lemma possibleSwitchTo_ct_not_inQ:
     possibleSwitchTo t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
   (is "\<lbrace>?PRE\<rbrace> _ \<lbrace>_\<rbrace>")
   apply (simp add: possibleSwitchTo_def curDomain_def)
-  apply (wp static_imp_wp rescheduleRequired_ct_not_inQ tcbSchedEnqueue_ct_not_inQ threadGet_wp
-       | wpc
-       | (rule hoare_post_imp[OF _ rescheduleRequired_sa_cnt], fastforce)
-       | clarsimp simp: ct_not_inQ_update_stt bitmap_fun_defs)+
+  apply (wpsimp wp: static_imp_wp rescheduleRequired_ct_not_inQ tcbSchedEnqueue_ct_not_inQ
+                    threadGet_wp
+       | (rule hoare_post_imp[OF _ rescheduleRequired_sa_cnt], fastforce))+
   apply (fastforce simp: obj_at'_def)
   done
 
@@ -4657,6 +4541,18 @@ where
   "non_exst_same' (KOTCB tcb) (KOTCB tcb') = non_exst_same tcb tcb'" |
   "non_exst_same' _ _ = True"
 
+lemma non_exst_same_prio_upd[simp]:
+  "non_exst_same tcb (tcbPriority_update f tcb)"
+  by (cases tcb, simp add: non_exst_same_def)
+
+lemma non_exst_same_timeSlice_upd[simp]:
+  "non_exst_same tcb (tcbTimeSlice_update f tcb)"
+  by (cases tcb, simp add: non_exst_same_def)
+
+lemma non_exst_same_domain_upd[simp]:
+  "non_exst_same tcb (tcbDomain_update f tcb)"
+  by (cases tcb, simp add: non_exst_same_def)
+
 lemma set_eobject_corres':
   assumes e: "etcb_relation etcb tcb'"
   assumes z: "\<And>s. obj_at' P ptr s
@@ -4758,14 +4654,6 @@ lemma ethread_set_corresT:
 
 lemmas ethread_set_corres =
     ethread_set_corresT [OF _ all_tcbI, OF _ ball_tcb_cte_casesI]
-
-lemma non_exst_same_prio_upd[simp]:
-  "non_exst_same tcb (tcbPriority_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma non_exst_same_timeSlice_upd[simp]:
-  "non_exst_same tcb (tcbTimeSlice_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
 
 end
 end

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -1155,10 +1155,6 @@ lemma threadSet_valid_queues'_no_state2:
   apply (fastforce simp: projectKOs inQ_def split: if_split_asm)
   done
 
-lemma inQ_tcbIPCBuffer_update_idem[simp]:
-  "inQ d p (tcbIPCBuffer_update (\<lambda>_. x) ko) = inQ d p ko"
-  by (clarsimp simp: inQ_def)
-
 lemma getThreadBufferSlot_dom_tcb_cte_cases:
   "\<lbrace>\<top>\<rbrace> getThreadBufferSlot a \<lbrace>\<lambda>rv s. rv \<in> (+) a ` dom tcb_cte_cases\<rbrace>"
   by (wpsimp simp: tcb_cte_cases_def getThreadBufferSlot_def locateSlot_conv cte_level_bits_def

--- a/proof/refine/X64/Untyped_R.thy
+++ b/proof/refine/X64/Untyped_R.thy
@@ -4520,11 +4520,6 @@ crunch ct_in_state'[wp]: doMachineOp "ct_in_state' P"
 crunch st_tcb_at'[wp]: doMachineOp "st_tcb_at' P p"
   (simp: crunch_simps ct_in_state'_def)
 
-lemma ex_cte_cap_wp_to_work_units[simp]:
-  "ex_cte_cap_wp_to' P slot (ksWorkUnitsCompleted_update f s)
-    = ex_cte_cap_wp_to' P slot s"
-  by (simp add: ex_cte_cap_wp_to'_def)
-
 lemma ex_cte_cap_wp_to_irq_state_independent_H[simp]:
   "irq_state_independent_H (ex_cte_cap_wp_to' P slot)"
   by (simp add: ex_cte_cap_wp_to'_def)
@@ -4560,9 +4555,6 @@ lemma setCTE_ct_in_state:
   apply (rule hoare_pre, wp ct_in_state'_decomp setCTE_pred_tcb_at')
   apply (auto simp: ct_in_state'_def)
   done
-
-add_upd_simps "ct_in_state' P (gsUntypedZeroRanges_update f s)"
-declare upd_simps[simp]
 
 crunch ct_in_state[wp]: updateFreeIndex "ct_in_state' P"
 crunch nosch[wp]: updateFreeIndex "\<lambda>s. P (ksSchedulerAction s)"

--- a/proof/refine/X64/VSpace_R.thy
+++ b/proof/refine/X64/VSpace_R.thy
@@ -1749,7 +1749,7 @@ lemma storePDE_state_refs' [wp]:
   apply (clarsimp simp: storePDE_def)
   apply (clarsimp simp: setObject_def valid_def in_monad split_def
                         updateObject_default_def projectKOs objBits_simps
-                        in_magnitude_check state_refs_of'_def ps_clear_upd'
+                        in_magnitude_check state_refs_of'_def ps_clear_upd
                  elim!: rsubst[where P=P] intro!: ext
              split del: if_split cong: option.case_cong if_cong)
   apply (simp split: option.split)
@@ -1777,7 +1777,7 @@ lemma storePDPTE_state_refs' [wp]:
   apply (clarsimp simp: storePDPTE_def)
   apply (clarsimp simp: setObject_def valid_def in_monad split_def
                         updateObject_default_def projectKOs objBits_simps
-                        in_magnitude_check state_refs_of'_def ps_clear_upd'
+                        in_magnitude_check state_refs_of'_def ps_clear_upd
                  elim!: rsubst[where P=P] intro!: ext
              split del: if_split cong: option.case_cong if_cong)
   apply (simp split: option.split)
@@ -1805,7 +1805,7 @@ lemma storePML4E_state_refs' [wp]:
   apply (clarsimp simp: storePML4E_def)
   apply (clarsimp simp: setObject_def valid_def in_monad split_def
                         updateObject_default_def projectKOs objBits_simps
-                        in_magnitude_check state_refs_of'_def ps_clear_upd'
+                        in_magnitude_check state_refs_of'_def ps_clear_upd
                  elim!: rsubst[where P=P] intro!: ext
              split del: if_split cong: option.case_cong if_cong)
   apply (simp split: option.split)
@@ -2340,7 +2340,7 @@ lemma setASIDPool_state_refs' [wp]:
   "\<lbrace>\<lambda>s. P (state_refs_of' s)\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>rv s. P (state_refs_of' s)\<rbrace>"
   apply (clarsimp simp: setObject_def valid_def in_monad split_def
                         updateObject_default_def projectKOs objBits_simps
-                        in_magnitude_check state_refs_of'_def ps_clear_upd'
+                        in_magnitude_check state_refs_of'_def ps_clear_upd
                  elim!: rsubst[where P=P] intro!: ext
              split del: if_split cong: option.case_cong if_cong)
   apply (simp split: option.split)
@@ -2625,7 +2625,7 @@ lemma setObject_cte_obj_at_ap':
   \<lbrace>\<lambda>_ s. P' (obj_at' P p s)\<rbrace>"
   apply (clarsimp simp: setObject_def in_monad split_def
                         valid_def lookupAround2_char1
-                        obj_at'_def ps_clear_upd' projectKOs
+                        obj_at'_def ps_clear_upd projectKOs
              split del: if_split)
   apply (clarsimp elim!: rsubst[where P=P'])
   apply (clarsimp simp: updateObject_cte in_monad objBits_simps

--- a/proof/refine/X64/VSpace_R.thy
+++ b/proof/refine/X64/VSpace_R.thy
@@ -1527,10 +1527,6 @@ crunches doMachineOp
   and ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
   and ioports'[wp]: valid_ioports'
 
-lemma valid_ioports_cr3_update[elim!]:
-  "valid_ioports' s \<Longrightarrow> valid_ioports' (s\<lparr>ksArchState := x64KSCurrentUserCR3_update (\<lambda>_. c) (ksArchState s)\<rparr>)"
-  by (clarsimp simp: valid_ioports'_simps)
-
 lemma setCurrentUserCR3_invs' [wp]:
   "\<lbrace>invs' and K (valid_cr3' c)\<rbrace> setCurrentUserCR3 c \<lbrace>\<lambda>rv. invs'\<rbrace>"
   unfolding setCurrentUserCR3_def

--- a/proof/refine/X64/orphanage/Orphanage.thy
+++ b/proof/refine/X64/orphanage/Orphanage.thy
@@ -8,6 +8,6 @@ theory Orphanage
 imports Refine.Refine
 begin
 
-(* FIXME: palce holder, Orphanage not proved for X64 *)
+(* FIXME: place holder, Orphanage not proved for X64 *)
 
 end


### PR DESCRIPTION
This creates a new file early in the dependency tree to contain all of the lemmas showing that various invariants are preserved by different updates to the kernel state. There are no guarantees that I found and moved all of these lemmas, and suggestions are welcome for the name of this file (it is currently `InvariantUpdates_H.thy`).

This is just a first step towards cleaning these lemmas up. There are multiple locales in `Invariants_H` that could be updated to generate these lemmas (e.g. `PSpace_update_eq`), and there is also the experimental `add_upd_simps` that we could be improving and using more often.

The diff didn't apply neatly to the other architectures, so at the moment this is just for arm. 