### PR TITLE
Fixes to send_ipc and sendIPC

### DIFF
--- a/lib/Heap_List.thy
+++ b/lib/Heap_List.thy
@@ -148,20 +148,21 @@ lemma heap_ls_last_None:
 
 (* sym_heap *)
 
-abbreviation sym_heap where
+definition sym_heap where
   "sym_heap hp hp' \<equiv> \<forall>p p'. hp p = Some p' \<longleftrightarrow> hp' p' = Some p"
 
 lemma sym_heap_symmetric:
-  "sym_heap hp hp' \<longleftrightarrow> sym_heap hp' hp" by blast
+  "sym_heap hp hp' \<longleftrightarrow> sym_heap hp' hp" 
+  unfolding sym_heap_def by blast
 
 lemma sym_heap_None:
-  "\<lbrakk>sym_heap hp hp'; hp p = None\<rbrakk> \<Longrightarrow> \<forall>p'. hp' p' \<noteq> Some p" by force
+  "\<lbrakk>sym_heap hp hp'; hp p = None\<rbrakk> \<Longrightarrow> \<forall>p'. hp' p' \<noteq> Some p" unfolding sym_heap_def by force
 
 lemma sym_heap_path_reverse:
   "sym_heap hp hp' \<Longrightarrow>
       heap_path hp (Some p) (p#ps) (Some p')
           \<longleftrightarrow> heap_path hp' (Some p') (p'#(rev ps)) (Some p)"
-  by (induct ps arbitrary: p p' rule: rev_induct; force)
+  unfolding sym_heap_def by (induct ps arbitrary: p p' rule: rev_induct; force)
 
 lemma sym_heap_ls_rev_Cons:
   "\<lbrakk>sym_heap hp hp'; heap_ls hp (Some p) (p#ps)\<rbrakk>
@@ -229,13 +230,13 @@ lemma heap_path_distinct_sym_prev_cases:
   apply (cases xs; simp del: heap_path.simps)
   apply (frule heap_path_head, simp)
   apply (cases ed, clarsimp)
-   apply (drule sym_heap_ls_rev_Cons, fastforce)
-   apply (drule heap_path_distinct_next_cases[where hp=hp']; simp)
-   apply fastforce
+   apply (frule sym_heap_ls_rev_Cons, fastforce)
+   apply (drule heap_path_distinct_next_cases[where hp=hp']; simp add: sym_heap_def)
+   apply simp
   apply (simp del: heap_path.simps)
-  apply (drule (1) sym_heap_path_reverse[where hp'=hp', THEN iffD1])
+  apply (frule (1) sym_heap_path_reverse[where hp'=hp', THEN iffD1])
   apply simp
-  apply (frule heap_path_distinct_next_cases[where hp=hp']; simp)
+  apply (frule heap_path_distinct_next_cases[where hp=hp']; simp add: sym_heap_def)
   apply fastforce
   done
 

--- a/proof/invariant-abstract/IpcDet_AI.thy
+++ b/proof/invariant-abstract/IpcDet_AI.thy
@@ -1987,16 +1987,15 @@ lemma si_invs'_helper_fault:
         sym_refs (state_hyp_refs_of s)\<rbrace>
     do
       recv_state <- get_thread_state dest;
-      (reply, reply_can_grant) <- case recv_state of
-                                    BlockedOnReceive _ reply data \<Rightarrow>
-                                      return (reply, receiver_can_grant data)
+      reply <- case recv_state of BlockedOnReceive _ reply data \<Rightarrow>
+                                      return reply
                                   | _ \<Rightarrow> fail;
       y <- do_ipc_transfer tptr (Some epptr) ba cg dest;
       y <- maybeM (reply_unlink_tcb dest) reply;
       sc_opt <- get_tcb_obj_ref tcb_sched_context dest;
       fault <- thread_get tcb_fault tptr;
       y <- if call \<or> (\<exists>y. fault = Some y)
-           then if (cg \<or> reply_can_grant) \<and> (\<exists>y. reply = Some y)
+           then if (cg \<or> cgr) \<and> (\<exists>y. reply = Some y)
                 then reply_push tptr dest (the reply) can_donate
                 else set_thread_state tptr Inactive
            else when (can_donate \<and> sc_opt = None) (do thread_sc <- get_tcb_obj_ref tcb_sched_context tptr;
@@ -2103,16 +2102,16 @@ lemma si_invs'_helper:
         sym_refs (state_hyp_refs_of s)\<rbrace>
     do
       recv_state <- get_thread_state dest;
-      (reply, reply_can_grant) <- case recv_state of
+      reply <- case recv_state of
                                     BlockedOnReceive _ reply data \<Rightarrow>
-                                      return (reply, receiver_can_grant data)
+                                      return reply
                                   | _ \<Rightarrow> fail;
       y <- do_ipc_transfer tptr (Some epptr) ba cg dest;
       y <- maybeM (reply_unlink_tcb dest) reply;
       sc_opt <- get_tcb_obj_ref tcb_sched_context dest;
       fault <- thread_get tcb_fault tptr;
       y <- if call \<or> (\<exists>y. fault = Some y)
-           then if (cg \<or> reply_can_grant) \<and> (\<exists>y. reply = Some y)
+           then if (cg \<or> cgr) \<and> (\<exists>y. reply = Some y)
                 then reply_push tptr dest (the reply) can_donate
                 else set_thread_state tptr Inactive
            else when (can_donate \<and> sc_opt = None) (do thread_sc <- get_tcb_obj_ref tcb_sched_context tptr;

--- a/proof/refine/ARM/Bits_R.thy
+++ b/proof/refine/ARM/Bits_R.thy
@@ -110,6 +110,10 @@ lemma sc_of'_Sched[simp]:
   "sc_of' (KOSchedContext sc) = Some sc"
   by (simp add: projectKO_sc)
 
+lemma tcb_of'_TCB[simp]:
+  "tcb_of' (KOTCB tcb) = Some tcb"
+  by (simp add: projectKO_tcb)
+
 lemma projectKO_ASID:
   "(projectKO_opt ko = Some t) = (ko = KOArch (KOASIDPool t))"
   by (cases ko)

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -1828,7 +1828,7 @@ lemma setObject_cte_scs_of'_use_valid_ksPSpace:
   assumes step: "(x, s\<lparr>ksPSpace := ps\<rparr>) \<in> fst (setObject p (cte :: cte) s)"
       and pre: "P (scs_of' s)"
   shows "P (ps |> sc_of')"
-  using use_valid[OF step setObject_cte_scs_of'] pre
+  using use_valid[OF step setObject_scs_of'(1)] pre
   by auto
 
 lemma updateCap_stuff:

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -4796,7 +4796,6 @@ lemma createTCBs_tcb_at':
     apply simp
    apply simp
   apply (clarsimp simp: retype_obj_at_disj')
-  apply (clarsimp simp: projectKO_opt_tcb)
   apply (clarsimp simp: new_cap_addrs_def image_def)
   apply (drule_tac x = "unat x" in bspec)
    apply (simp add:objBits_simps' shiftl_t2n)

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3901,11 +3901,12 @@ lemma schedContextUnbindReply_invs'[wp]:
   unfolding schedContextUnbindReply_def
   apply (wpsimp wp: setSchedContext_invs' updateReply_replyNext_Nothing_invs'
                     hoare_vcg_imp_lift typ_at_lifts)
-  apply (frule ko_at_valid_objs'; (fastforce simp: projectKOs)?)
+  apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def sym_refs_asrt_def)
+  apply (frule (1) ko_at_valid_objs', clarsimp simp: projectKOs)
+  apply (frule (2) sym_refs_replies_scs)
   apply (intro conjI)
-     apply (subst sym_refs_replySCs_of_scReplies_of; (fastforce simp: sym_refs_asrt_def)?)
-     apply (fastforce simp: obj_at'_def opt_map_def projectKOs split: option.splits)
-    apply (fastforce elim: if_live_then_nonz_capE'[OF invs_iflive']
+     apply (fastforce simp: obj_at'_def opt_map_def projectKOs sym_heap_def split: option.splits)
+    apply (fastforce elim: if_live_then_nonz_capE'
                      simp: ko_wp_at'_def obj_at'_def projectKOs live_sc'_def)
    apply (auto simp: valid_obj'_def valid_sched_context'_def valid_sched_context_size'_def
                      objBits_simps')

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3717,7 +3717,6 @@ lemma schedContextDonate_valid_inQ_queues:
    \<lbrace>\<lambda>_. valid_inQ_queues\<rbrace>"
   (is "valid ?pre _ _")
   apply (clarsimp simp: schedContextDonate_def)
-  apply (rule hoare_seq_ext[OF _ stateAssert_sp])
   apply (rule hoare_seq_ext[OF _ get_sc_sp'], rename_tac sc)
   apply (rule_tac B="\<lambda>_. ?pre" in hoare_seq_ext[rotated])
    apply (rule hoare_when_cases, clarsimp)

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -260,6 +260,33 @@ abbreviation tcbs_of' :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> tcb o
 abbreviation tcb_scs_of' :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> obj_ref option" where
   "tcb_scs_of' s \<equiv> tcbs_of' s |> tcbSchedContext"
 
+abbreviation scTCBs_of :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> obj_ref option" where
+  "scTCBs_of s \<equiv> scs_of' s |> scTCB"
+
+(* 
+  sym_heapd is a definition version of sym_heap (abbreviation).
+  This is temporary for now, it should be combined with sym_heap properly,
+  either within the current PR, or later.
+*)
+
+definition sym_heapd :: "('a \<rightharpoonup> 'b) \<Rightarrow> ('b \<rightharpoonup> 'a) \<Rightarrow> bool" where
+  "sym_heapd h1 h2 \<equiv> \<forall>p q. pred_map_eq q h1 p \<longleftrightarrow> pred_map_eq p h2 q"
+
+lemma sym_heapd_def2:
+  "sym_heapd h1 h2 = 
+  ((\<forall>p q. pred_map_eq q h1 p \<longrightarrow> pred_map_eq p h2 q) \<and> (\<forall>p q. pred_map_eq q h2 p \<longrightarrow> pred_map_eq p h1 q))"
+  unfolding sym_heapd_def by fastforce
+
+lemma sym_heapd_sym:
+  "sym_heapd h1 h2 = sym_heapd h2 h1"
+  unfolding sym_heapd_def by fastforce
+
+abbreviation tcbs_scs_sym_refs where
+  "tcbs_scs_sym_refs s \<equiv> sym_heapd (tcb_scs_of' s) (scTCBs_of s)"
+
+abbreviation replies_scs_sym_refs where
+  "replies_scs_sym_refs s \<equiv> sym_heapd (scReplies_of s) (replySCs_of s)"
+
 definition
   tcb_cte_cases :: "word32 \<rightharpoonup> ((tcb \<Rightarrow> cte) \<times> ((cte \<Rightarrow> cte) \<Rightarrow> tcb \<Rightarrow> tcb))" where
  "tcb_cte_cases \<equiv> [    0 \<mapsto> (tcbCTable, tcbCTable_update),

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -256,14 +256,14 @@ abbreviation tcb_of' :: "kernel_object \<Rightarrow> tcb option" where
 abbreviation tcbs_of' :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> tcb option" where
   "tcbs_of' s \<equiv> ksPSpace s |> tcb_of'"
 
-abbreviation tcb_scs_of' :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> obj_ref option" where
-  "tcb_scs_of' s \<equiv> tcbs_of' s |> tcbSchedContext"
+abbreviation tcbSCs_of' :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> obj_ref option" where
+  "tcbSCs_of' s \<equiv> tcbs_of' s |> tcbSchedContext"
 
 abbreviation scTCBs_of :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> obj_ref option" where
   "scTCBs_of s \<equiv> scs_of' s |> scTCB"
 
 abbreviation scTCB_sym_refs where
-  "scTCB_sym_refs s \<equiv> sym_heap (tcb_scs_of' s) (scTCBs_of s)"
+  "scTCB_sym_refs s \<equiv> sym_heap (tcbSCs_of' s) (scTCBs_of s)"
 
 abbreviation scReply_sym_refs where
   "scReply_sym_refs s \<equiv> sym_heap (scReplies_of s) (replySCs_of s)"

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -250,9 +250,8 @@ abbreviation scs_of' :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> sched_
 abbreviation scReplies_of :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> obj_ref option" where
   "scReplies_of s \<equiv> scs_of' s |> scReply"
 
-definition tcb_of' :: "kernel_object \<Rightarrow> tcb option" where
-  "tcb_of' kobj \<equiv> (case kobj of KOTCB tcb \<Rightarrow> Some tcb
-                               | _         \<Rightarrow> None)"
+abbreviation tcb_of' :: "kernel_object \<Rightarrow> tcb option" where
+  "tcb_of' \<equiv> projectKO_opt"
 
 abbreviation tcbs_of' :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> tcb option" where
   "tcbs_of' s \<equiv> ksPSpace s |> tcb_of'"
@@ -263,29 +262,11 @@ abbreviation tcb_scs_of' :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> ob
 abbreviation scTCBs_of :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> obj_ref option" where
   "scTCBs_of s \<equiv> scs_of' s |> scTCB"
 
-(* 
-  sym_heapd is a definition version of sym_heap (abbreviation).
-  This is temporary for now, it should be combined with sym_heap properly,
-  either within the current PR, or later.
-*)
+abbreviation scTCB_sym_refs where
+  "scTCB_sym_refs s \<equiv> sym_heap (tcb_scs_of' s) (scTCBs_of s)"
 
-definition sym_heapd :: "('a \<rightharpoonup> 'b) \<Rightarrow> ('b \<rightharpoonup> 'a) \<Rightarrow> bool" where
-  "sym_heapd h1 h2 \<equiv> \<forall>p q. pred_map_eq q h1 p \<longleftrightarrow> pred_map_eq p h2 q"
-
-lemma sym_heapd_def2:
-  "sym_heapd h1 h2 = 
-  ((\<forall>p q. pred_map_eq q h1 p \<longrightarrow> pred_map_eq p h2 q) \<and> (\<forall>p q. pred_map_eq q h2 p \<longrightarrow> pred_map_eq p h1 q))"
-  unfolding sym_heapd_def by fastforce
-
-lemma sym_heapd_sym:
-  "sym_heapd h1 h2 = sym_heapd h2 h1"
-  unfolding sym_heapd_def by fastforce
-
-abbreviation tcbs_scs_sym_refs where
-  "tcbs_scs_sym_refs s \<equiv> sym_heapd (tcb_scs_of' s) (scTCBs_of s)"
-
-abbreviation replies_scs_sym_refs where
-  "replies_scs_sym_refs s \<equiv> sym_heapd (scReplies_of s) (replySCs_of s)"
+abbreviation scReply_sym_refs where
+  "scReply_sym_refs s \<equiv> sym_heap (scReplies_of s) (replySCs_of s)"
 
 definition
   tcb_cte_cases :: "word32 \<rightharpoonup> ((tcb \<Rightarrow> cte) \<times> ((cte \<Rightarrow> cte) \<Rightarrow> tcb \<Rightarrow> tcb))" where
@@ -2018,7 +1999,7 @@ lemma valid_pspaceE' [elim]:
 lemma idle'_only_sc_refs:
   "valid_idle' s \<Longrightarrow> state_refs_of' s (ksIdleThread s) = {(idle_sc_ptr, TCBSchedContext)}"
   by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def tcb_ntfn_is_bound'_def
-                     projectKO_eq project_inject state_refs_of'_def idle_tcb'_def tcb_of'_def)
+                     projectKO_eq project_inject state_refs_of'_def idle_tcb'_def)
 
 lemma idle'_not_queued':
   "\<lbrakk>valid_idle' s; sym_refs (state_refs_of' s);
@@ -4133,7 +4114,7 @@ lemma sym_refs_replyNext_replyPrev_sym:
 
 lemma reply_sym_heap_Next_Prev:
   "sym_refs (list_refs_of_replies' s') \<Longrightarrow> sym_heap (replyNexts_of s') (replyPrevs_of s')"
-  using sym_refs_replyNext_replyPrev_sym by clarsimp
+  using sym_refs_replyNext_replyPrev_sym by (clarsimp simp: sym_heap_def)
 
 lemmas reply_sym_heap_Prev_Next
   = sym_heap_symmetric[THEN iffD1, OF reply_sym_heap_Next_Prev]

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -754,8 +754,8 @@ lemma replyRemoveTCB_corres:
               apply (drule sc_with_reply'_SomeD, clarsimp)
               apply (case_tac "hd xs = rp")
                apply (drule heap_path_head, clarsimp)
-               apply (drule (3) sym_refs_replySCs_of_scReplies_of[THEN iffD2, rotated])
-               apply (clarsimp simp: obj_at'_def projectKOs)
+               apply (drule (2) sym_refs_replies_scs)
+               apply (clarsimp simp: obj_at'_def projectKOs sym_heap_def)
 
               apply (frule (1) heap_path_takeWhile_lookup_next)
               apply (frule heap_path_head, clarsimp)
@@ -861,9 +861,9 @@ lemma replyRemoveTCB_corres:
                                             objBits_simps)
                      apply (erule sym_refs_replyNext_replyPrev_sym[THEN iffD2])
                      apply (clarsimp simp: opt_map_left_Some obj_at'_def projectKOs)
-                    apply (frule (2) sym_refs_replySCs_of_scReplies_of[THEN iffD2])
-                      apply (fastforce simp: hd_opt_def projectKOs opt_map_left_Some
-                                        del: opt_mapE split: list.split_asm)
+                    apply (frule (2) sym_refs_replies_scs)
+                    apply (clarsimp simp: hd_opt_def projectKOs opt_map_left_Some sym_heap_def
+                                   split: list.split_asm)
                     apply (clarsimp simp: opt_map_left_Some obj_at'_def projectKOs split: reply_next.splits)
 
                   (* rp is in the middle of the reply stack *)

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -4659,15 +4659,15 @@ lemma updateReply_reply_at'_wp:
   done
 
 crunches setThreadState
-  for tcb_scs_of'[wp]: "\<lambda>s. P (tcb_scs_of' s)"
-  (ignore: threadSet wp: threadSet_tcb_scs_of'_inv)
+  for tcbSCs_of'[wp]: "\<lambda>s. P (tcbSCs_of' s)"
+  (ignore: threadSet wp: threadSet_tcbSCs_of'_inv)
 
 crunches replyUnlink
-  for tcb_scs_of'[wp]: "\<lambda>s. P (tcb_scs_of' s)"
+  for tcbSCs_of'[wp]: "\<lambda>s. P (tcbSCs_of' s)"
   and scs_of'[wp]: "\<lambda>s. P (scs_of' s)"
 
 lemma replyUnlink_misc_heaps[wp]:
-  "replyUnlink rPtr tPtr \<lbrace>\<lambda>s. P (tcb_scs_of' s) (scTCBs_of s) (scReplies_of s) (replySCs_of s)\<rbrace>"
+  "replyUnlink rPtr tPtr \<lbrace>\<lambda>s. P (tcbSCs_of' s) (scTCBs_of s) (scReplies_of s) (replySCs_of s)\<rbrace>"
   by (rule hoare_weaken_pre, wps, wp, simp)
 
 lemma schedContextUpdateConsumed_scReplies_of[wp]:
@@ -4689,7 +4689,7 @@ lemma schedContextUpdateConsumed_sc_tcbs_of[wp]:
   done
 
 crunches schedContextUpdateConsumed
-  for tcb_scs_of'[wp]: "\<lambda>s. P (tcb_scs_of' s)"
+  for tcbSCs_of'[wp]: "\<lambda>s. P (tcbSCs_of' s)"
 
 crunches doIPCTransfer
   for replySCs_of[wp]: "\<lambda>s. P (replySCs_of s)"
@@ -4697,7 +4697,7 @@ crunches doIPCTransfer
 
 lemma schedContextUpdateConsumed_misc_heaps[wp]:
   "schedContextUpdateConsumed scPtr
-   \<lbrace>\<lambda>s. P (scReplies_of s) (replySCs_of s) (tcb_scs_of' s) (scTCBs_of s)\<rbrace>"
+   \<lbrace>\<lambda>s. P (scReplies_of s) (replySCs_of s) (tcbSCs_of' s) (scTCBs_of s)\<rbrace>"
   by (rule hoare_weaken_pre, wps, wp, simp)
 
 crunches doIPCTransfer
@@ -4705,11 +4705,11 @@ crunches doIPCTransfer
   (wp: crunch_wps ignore: setSchedContext simp: zipWithM_x_mapM)
 
 crunches doIPCTransfer
-  for scs_tcbs_of[wp]: "\<lambda>s. P (tcb_scs_of' s) (scTCBs_of s)"
-  (wp: crunch_wps threadSet_tcb_scs_of'_inv ignore: threadSet simp: zipWithM_x_mapM)
+  for scs_tcbs_of[wp]: "\<lambda>s. P (tcbSCs_of' s) (scTCBs_of s)"
+  (wp: crunch_wps threadSet_tcbSCs_of'_inv ignore: threadSet simp: zipWithM_x_mapM)
 
 crunches setEndpoint
-  for misc_heaps[wp]: "\<lambda>s. P (scReplies_of s) (replySCs_of s) (tcb_scs_of' s) (scTCBs_of s)"
+  for misc_heaps[wp]: "\<lambda>s. P (scReplies_of s) (replySCs_of s) (tcbSCs_of' s) (scTCBs_of s)"
   (wp: crunch_wps)
 
 lemma replyPush_sym_refs_list_refs_of_replies':
@@ -4779,7 +4779,7 @@ lemma replyPush_if_live_then_nonz_cap':
     apply (frule obj_at_ko_at'[where p=callerPtr], clarsimp)
     apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
     apply (clarsimp simp: valid_tcb'_def)
-   apply (subgoal_tac "(tcb_scs_of' s) callerPtr = Some scp")
+   apply (subgoal_tac "(tcbSCs_of' s) callerPtr = Some scp")
     apply (clarsimp simp: sym_heap_def)
    apply (clarsimp simp: opt_map_def obj_at'_real_def ko_wp_at'_def projectKOs)
   apply (clarsimp simp: valid_idle'_def)
@@ -4953,8 +4953,8 @@ lemma cancelIPC_notin_epQueue:
   by (wpsimp wp: blockedCancelIPC_notin_epQueue hoare_drop_imps threadSet_valid_objs')
 
 crunches rescheduleRequired
-  for scs_tcbs_of[wp]: "\<lambda>s. P (tcb_scs_of' s) (scTCBs_of s)"
-  (wp: crunch_wps threadSet_tcb_scs_of'_inv ignore: threadSet)
+  for scs_tcbs_of[wp]: "\<lambda>s. P (tcbSCs_of' s) (scTCBs_of s)"
+  (wp: crunch_wps threadSet_tcbSCs_of'_inv ignore: threadSet)
 
 lemma maybeReturnSc_scTCB_sym_refs[wp]:
   "\<lbrace>scTCB_sym_refs and valid_objs'\<rbrace>
@@ -4965,11 +4965,11 @@ lemma maybeReturnSc_scTCB_sym_refs[wp]:
   apply (simp add: liftM_def)
   apply (rule hoare_seq_ext[OF _ stateAssert_sp])
   apply (rule hoare_seq_ext[OF _ get_ntfn_sp'])
-  apply (wpsimp wp: setSchedContext_scTCBs_of threadSet_tcb_scs_of' | wps)+
+  apply (wpsimp wp: setSchedContext_scTCBs_of threadSet_tcbSCs_of' | wps)+
    apply (wpsimp wp: threadGet_wp)
   apply (clarsimp simp: tcb_at'_ex_eq_all)
   apply (drule sym, simp)
-  apply (subgoal_tac "(tcb_scs_of' s) t = Some (the (tcbSchedContext tcb))")
+  apply (subgoal_tac "(tcbSCs_of' s) t = Some (the (tcbSchedContext tcb))")
    apply (clarsimp simp: sym_heap_def)
    apply (subst (asm) sym_heap_symmetric[simplified sym_heap_def], simp)
   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def opt_map_def projectKOs)
@@ -4993,7 +4993,7 @@ lemma maybeReturnSc_scReply_sym_refs[wp]:
 
 crunches cleanReply
   for scTCBs_of[wp]: "\<lambda>s. P (scTCBs_of s)"
-  and tcb_scs_of'[wp]: "\<lambda>s. P (tcb_scs_of' s)"
+  and tcbSCs_of'[wp]: "\<lambda>s. P (tcbSCs_of' s)"
 
 lemma replyRemoveTCB_scTCBs_of[wp]:
   "replyRemoveTCB tptr \<lbrace>\<lambda>s. P (scTCBs_of s)\<rbrace>"
@@ -5002,8 +5002,8 @@ lemma replyRemoveTCB_scTCBs_of[wp]:
   apply (erule back_subst[where P=P], rule ext, clarsimp)
   by (clarsimp simp: opt_map_def obj_at'_real_def ko_wp_at'_def)
 
-lemma replyRemoveTCB_tcb_scs_of'[wp]:
-  "replyRemoveTCB tptr \<lbrace>\<lambda>s. P (tcb_scs_of' s)\<rbrace>"
+lemma replyRemoveTCB_tcbSCs_of'[wp]:
+  "replyRemoveTCB tptr \<lbrace>\<lambda>s. P (tcbSCs_of' s)\<rbrace>"
   unfolding replyRemoveTCB_def
   by (wpsimp wp: setSchedContext_scTCBs_of gts_wp')
 
@@ -5013,7 +5013,7 @@ lemma replyRemoveTCB_scTCB_sym_refs[wp]:
 
 crunches cancelIPC
   for scTCB_sym_refs[wp]: scTCB_sym_refs
-  (wp: crunch_wps threadSet_tcb_scs_of'_inv ignore: setSchedContext threadSet)
+  (wp: crunch_wps threadSet_tcbSCs_of'_inv ignore: setSchedContext threadSet)
 
 lemma cleanReply_scReply_sym_refs :
   "\<lbrace>\<lambda>s. sym_heap (scReplies_of s) (\<lambda>a. if a = rptr then None else replySCs_of s a)\<rbrace>

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -2081,7 +2081,6 @@ lemma replyPush_corres:
   apply (rule_tac Q="\<lambda>s. valid_replies'_sc_asrt reply_ptr s" in corres_cross_add_guard)
    apply (fastforce elim: valid_replies_sc_cross)
   apply (rule corres_stateAssert_implied[where P'=\<top>, simplified])
-   apply (rule corres_stateAssert_implied[where P'=\<top>, simplified])
     apply (rule stronger_corres_guard_imp)
       apply (simp add: get_tcb_obj_ref_def)
       apply (rule corres_split_deprecated [OF _ threadget_corres[where r="(=)"]])
@@ -2875,8 +2874,9 @@ lemma maybeDonateSc_corres:
      apply (erule if_live_then_nonz_capE')
      apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKO_sc live_sc'_def)
     apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
-   apply (frule ntfn_ko_at_valid_objs_valid_ntfn', clarsimp)
-   apply (clarsimp simp: valid_ntfn'_def)
+   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
+  apply (frule ntfn_ko_at_valid_objs_valid_ntfn', clarsimp)
+  apply (clarsimp simp: valid_ntfn'_def)
   apply (clarsimp simp: sym_refs_asrt_def)
   done
 
@@ -2900,8 +2900,7 @@ lemma setReleaseQueue_valid_queues[wp]:
 
 lemma getScTime_tcb_at'[wp]:
   "\<lbrace>\<top>\<rbrace> getScTime tptr \<lbrace>\<lambda>_. tcb_at' tptr\<rbrace>"
-  apply (wpsimp wp: getScTime_wp)
-  by (clarsimp simp: obj_at'_def)
+  by (wpsimp wp: getScTime_wp)
 
 lemma tcbReleaseEnqueue_vrq[wp]:
   "tcbReleaseEnqueue tcbPtr \<lbrace>valid_release_queue\<rbrace>"
@@ -4414,8 +4413,6 @@ lemma getSlotCap_cte_wp_at:
   apply (clarsimp simp: cte_wp_at_ctes_of)
   done
 
-crunch no_0_obj'[wp]: setThreadState no_0_obj'
-
 lemma cteInsert_cap_to':
   "\<lbrace>ex_nonz_cap_to' p and cte_wp_at' (\<lambda>c. cteCap c = NullCap) dest\<rbrace>
      cteInsert cap src dest
@@ -4653,78 +4650,139 @@ lemma valid_replies'_no_tcb_not_linked:
                         projectKO_reply)
   done
 
-lemma replyPush_sym_refs_list_refs_of_replies'[wp]:
-  "\<lbrace>(\<lambda>s. sym_refs (list_refs_of_replies' s)) and valid_replies'
-    and (\<lambda>s. replyTCBs_of s replyPtr = None)\<rbrace>
+lemma updateReply_reply_at'_wp:
+  "\<lbrace>\<lambda>s. P (if p = rptr then True else reply_at' p s)\<rbrace>
+   updateReply rptr f
+   \<lbrace>\<lambda>rv s. P (reply_at' p s)\<rbrace>"
+  apply (rule hoare_weaken_pre, rule updateReply_obj_at')
+  apply (clarsimp simp: obj_at'_real_def split: if_splits)
+  done
+
+crunches setThreadState
+  for tcb_scs_of'[wp]: "\<lambda>s. P (tcb_scs_of' s)"
+  (ignore: threadSet wp: threadSet_tcb_scs_of'_inv)
+
+crunches replyUnlink
+  for tcb_scs_of'[wp]: "\<lambda>s. P (tcb_scs_of' s)"
+  and scs_of'[wp]: "\<lambda>s. P (scs_of' s)"
+
+lemma replyUnlink_misc_heaps[wp]:
+  "replyUnlink rPtr tPtr \<lbrace>\<lambda>s. P (tcb_scs_of' s) (scTCBs_of s) (scReplies_of s) (replySCs_of s)\<rbrace>"
+  by (rule hoare_weaken_pre, wps, wp, simp)
+
+lemma schedContextUpdateConsumed_scReplies_of[wp]:
+  "schedContextUpdateConsumed scPtr \<lbrace>\<lambda>s. P (scReplies_of s) \<rbrace>"
+  unfolding schedContextUpdateConsumed_def
+  apply (wpsimp simp: setSchedContext_def)
+  apply (clarsimp simp: opt_map_def if_distrib)
+  apply (erule subst[where P=P, rotated], rule ext)
+  apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def split: option.splits)
+  done
+
+lemma schedContextUpdateConsumed_sc_tcbs_of[wp]:
+  "schedContextUpdateConsumed scPtr \<lbrace>\<lambda>s. P (scTCBs_of s)\<rbrace>"
+  unfolding schedContextUpdateConsumed_def
+  apply (wpsimp simp: setSchedContext_def)
+  apply (clarsimp simp: opt_map_def if_distrib)
+  apply (erule subst[where P=P, rotated], rule ext)
+  apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def split: option.splits)
+  done
+
+crunches schedContextUpdateConsumed
+  for tcb_scs_of'[wp]: "\<lambda>s. P (tcb_scs_of' s)"
+
+crunches doIPCTransfer
+  for replySCs_of[wp]: "\<lambda>s. P (replySCs_of s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma schedContextUpdateConsumed_misc_heaps[wp]:
+  "schedContextUpdateConsumed scPtr
+   \<lbrace>\<lambda>s. P (scReplies_of s) (replySCs_of s) (tcb_scs_of' s) (scTCBs_of s)\<rbrace>"
+  by (rule hoare_weaken_pre, wps, wp, simp)
+
+crunches doIPCTransfer
+  for scs_replies_of[wp]: "\<lambda>s. P (scReplies_of s) (replySCs_of s)"
+  (wp: crunch_wps ignore: setSchedContext simp: zipWithM_x_mapM)
+
+crunches doIPCTransfer
+  for scs_tcbs_of[wp]: "\<lambda>s. P (tcb_scs_of' s) (scTCBs_of s)"
+  (wp: crunch_wps threadSet_tcb_scs_of'_inv ignore: threadSet simp: zipWithM_x_mapM)
+
+crunches setEndpoint
+  for misc_heaps[wp]: "\<lambda>s. P (scReplies_of s) (replySCs_of s) (tcb_scs_of' s) (scTCBs_of s)"
+  (wp: crunch_wps)
+
+lemma replyPush_sym_refs_list_refs_of_replies':
+  "\<lbrace>(\<lambda>s. sym_refs (list_refs_of_replies' s))
+    and valid_replies'
+    and valid_objs'
+    and (\<lambda>s. replyTCBs_of s replyPtr = None) and replies_scs_sym_refs\<rbrace>
    replyPush callerPtr calleePtr replyPtr canDonate
    \<lbrace>\<lambda>_ s. sym_refs (list_refs_of_replies' s)\<rbrace>"
   supply if_split [split del]
   unfolding replyPush_def
   apply wpsimp
-         apply (wpsimp wp: bindScReply_sym_refs_list_refs_of_replies'
-                           hoare_vcg_if_lift hoare_vcg_imp_lift' hoare_vcg_all_lift)
-        apply (rule_tac Q="(\<lambda>_ s. sym_refs (list_refs_of_replies' s) \<and>
-                 (\<forall>rptr scp. obj_at' (\<lambda>ko. scReply ko = Some rptr) scp s
-                              \<longrightarrow> replySCs_of s rptr = Some scp) \<and>
-                 \<not> is_reply_linked replyPtr s \<and> replySCs_of s replyPtr = None)"
-               in hoare_strengthen_post[rotated])
-         apply (fastforce split: if_splits simp del: comp_apply)
+        apply (wpsimp wp: bindScReply_sym_refs_list_refs_of_replies'
+                          hoare_vcg_if_lift2 hoare_vcg_imp_lift' hoare_vcg_all_lift)
+       apply (rule_tac Q="(\<lambda>_ s. sym_refs (list_refs_of_replies' s) \<and>
+        (\<forall>rptr scp. (scReplies_of s) scp = Some rptr
+                     \<longrightarrow> replySCs_of s rptr = Some scp) \<and>
+        \<not> is_reply_linked replyPtr s \<and> replySCs_of s replyPtr = None)"
+      in hoare_strengthen_post[rotated])
+        apply (fastforce split: if_splits simp del: comp_apply)
 
-        apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift'
-                          updateReply_list_refs_of_replies'_inv threadGet_wp)+
+       apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift'
+                         updateReply_list_refs_of_replies'_inv threadGet_wp)+
   apply (frule valid_replies'_no_tcb_not_linked; clarsimp)
   apply (intro conjI)
     apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
    apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
-  apply (clarsimp simp: sym_refs_asrt_def)
-  apply (rename_tac s r scp)
-  apply (drule_tac p=scp in sym_refs_obj_atD', simp)
-  apply (clarsimp simp: ko_wp_at'_def refs_of_rev' opt_map_def)
+  apply (clarsimp simp: sym_heapd_def pred_map_eq)
   done
 
 lemma replyPush_if_live_then_nonz_cap':
-  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and> valid_objs' s \<and> valid_idle' s \<and> reply_at' replyPtr s \<and>
-        st_tcb_at' (\<lambda>st. st \<noteq> Inactive \<and> st \<noteq> IdleThreadState) callerPtr s \<and>
-        ex_nonz_cap_to' replyPtr s \<and> ex_nonz_cap_to' callerPtr s \<and> ex_nonz_cap_to' calleePtr s\<rbrace>
+  "\<lbrace> if_live_then_nonz_cap' and valid_objs' and valid_idle' and
+     ex_nonz_cap_to' replyPtr and ex_nonz_cap_to' callerPtr and ex_nonz_cap_to' calleePtr and
+     tcbs_scs_sym_refs and replies_scs_sym_refs and (\<lambda>s. callerPtr \<noteq> ksIdleThread s)\<rbrace>
    replyPush callerPtr calleePtr replyPtr canDonate
    \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
-  unfolding replyPush_def
-  apply (wp schedContextDonate_if_live_then_nonz_cap' bindScReply_if_live_then_nonz_cap')
-       apply (rule_tac Q="\<lambda>_ s. (\<forall>scp. scPtrOptDonated = Some scp \<longrightarrow> ex_nonz_cap_to' scp s \<and> sc_at' scp s) \<and>
-                                ex_nonz_cap_to' calleePtr s \<and> ex_nonz_cap_to' replyPtr s \<and>
-                                valid_objs' s \<and> if_live_then_nonz_cap' s \<and> reply_at' replyPtr s
-                                 \<and> (\<forall>rp. obj_at' (\<lambda>ko. scReply ko = Some rp) (fromJust scPtrOptDonated) s
-                                         \<longrightarrow> replySCs_of s rp = Some (fromJust scPtrOptDonated))"
-                    in hoare_strengthen_post[rotated], clarsimp)
-       apply (wp hoare_vcg_all_lift hoare_vcg_imp_lift')
-      apply (simp (no_asm_use) add: split del: if_split
-             | wp hoare_vcg_all_lift hoare_vcg_disj_lift hoare_vcg_imp_lift' updateReply_obj_at'
-                  hoare_vcg_if_lift set_reply'.obj_at' updateReply_iflive'_weak updateReply_valid_objs'
-             | rule threadGet_wp)+
+  supply if_split [split del]
+  unfolding replyPush_def  bind_assoc
+  apply (rule hoare_seq_ext[OF _ stateAssert_inv])
+  apply simp
+  apply (rule hoare_seq_ext[OF _ tg_sp'])
+  apply (rule hoare_seq_ext[OF _ tg_sp'])
+  apply (wpsimp wp: schedContextDonate_if_live_then_nonz_cap' bindScReply_if_live_then_nonz_cap')
+    apply (rule_tac Q="\<lambda>_. if_live_then_nonz_cap' and ex_nonz_cap_to' replyPtr and
+             valid_objs' and reply_at' replyPtr and ex_nonz_cap_to' calleePtr and
+             (if (\<exists>y. scPtrOptDonated = Some y) \<and> scPtrOptCallee = None \<and> canDonate
+             then \<lambda>s. ex_nonz_cap_to' (the scPtrOptDonated) s \<and>
+                       (\<forall>rp. (scReplies_of s) (the scPtrOptDonated) = Some rp \<longrightarrow>
+                             (replySCs_of s) rp  = Some (the scPtrOptDonated))
+             else \<top>)" in hoare_strengthen_post[rotated], clarsimp split: if_splits simp: pred_map_eq)
+    apply (wpsimp wp: hoare_vcg_if_lift2 hoare_vcg_imp_lift' hoare_vcg_all_lift)
+   apply (clarsimp cong: conj_cong)
+   apply (wpsimp wp_del: updateReply_reply_at'
+                     wp: updateReply_iflive'_weak updateReply_reply_at'_wp updateReply_valid_objs'
+                         hoare_vcg_all_lift hoare_vcg_imp_lift' updateReply_obj_at')
   apply clarsimp
-  apply (frule pred_tcb_at')
-  apply (rule context_conjI; clarsimp simp: sym_refs_asrt_def)
+  apply (intro conjI)
+   apply (clarsimp simp: valid_reply'_def obj_at'_def)
+  apply (intro allI impI, clarsimp)
+  apply (rename_tac s scp)
+  apply (subgoal_tac "sc_at' scp s \<and> (scTCBs_of s) scp = Some callerPtr \<and> callerPtr \<noteq> idle_thread_ptr")
    apply (intro conjI)
-    apply (clarsimp simp: obj_at'_def projectKO_eq projectKO_tcb projectKO_sc projectKO_reply)
     apply (erule if_live_then_nonz_capE')
-   apply (rename_tac s scp reply tcb)
-    apply (drule_tac ko=tcb in sym_refs_ko_atD'[rotated])
-     apply (fastforce simp: obj_at'_def projectKO_eq projectKO_tcb)
-    apply (fastforce simp: live_sc'_def idle_tcb'_def valid_idle'_def
-                           refs_of_rev' pred_tcb_at'_def ko_wp_at'_def obj_at'_def)
-   apply (frule obj_at_ko_at'[where p=callerPtr], clarsimp)
-   apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
-   apply (clarsimp simp: valid_tcb'_def)
-  apply (intro conjI allI)
-    apply (clarsimp simp: valid_tcb_state'_def)
-   apply (clarsimp simp: valid_reply'_def)
-  apply (subgoal_tac "\<forall>rp scPtr. obj_at' (\<lambda>ko. scReply ko = Some rp) scPtr s \<longrightarrow>
-                                 replySCs_of s rp = Some scPtr")
-   apply (clarsimp simp: obj_at'_def)
-  apply clarsimp
-  apply (rename_tac s r scp)
-  apply (drule_tac p=scp in sym_refs_obj_atD', simp)
-  apply (clarsimp simp: ko_wp_at'_def refs_of_rev' opt_map_def)
+    apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKO_sc pred_map_def pred_map_eq_def live_sc'_def)
+    apply (clarsimp simp: sym_heapd_def pred_map_eq)
+  apply (intro conjI)
+    apply (frule obj_at_ko_at'[where p=callerPtr], clarsimp)
+    apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
+    apply (clarsimp simp: valid_tcb'_def)
+   apply (subgoal_tac "(tcb_scs_of' s) callerPtr = Some scp")
+    apply (clarsimp simp: sym_heapd_def pred_map_eq)
+   apply (clarsimp simp: opt_map_def obj_at'_real_def ko_wp_at'_def projectKOs)
+  apply (clarsimp simp: valid_idle'_def)
   done
 
 lemma bindScReply_valid_idle':
@@ -4737,48 +4795,34 @@ lemma bindScReply_valid_idle':
 lemma replyPush_valid_idle':
   "\<lbrace>valid_idle'
     and valid_pspace'
-    and st_tcb_at' ((\<noteq>) IdleThreadState) callerPtr\<rbrace>
+    and (\<lambda>s. callerPtr \<noteq> ksIdleThread s)
+    and tcbs_scs_sym_refs\<rbrace>
    replyPush callerPtr calleePtr replyPtr canDonate
    \<lbrace>\<lambda>_. valid_idle'\<rbrace>"
   apply (simp only: replyPush_def)
   supply if_split [split del]
-  apply (wpsimp wp: threadGet_wp schedContextDonate_valid_idle' bindScReply_valid_idle'
-                    hoare_vcg_if_lift2 hoare_vcg_imp_lift' updateReply_valid_pspace'_strong)
-  unfolding sym_refs_asrt_def
-  apply (subgoal_tac "callerPtr \<noteq> ksIdleThread s")
-   apply (subgoal_tac "\<forall>kob. valid_reply' kob s \<longrightarrow> valid_reply' (replyTCB_update (\<lambda>_. Some callerPtr) kob) s")
-    apply (frule obj_at_ko_at'[where p=callerPtr], clarsimp)
-    apply (rule_tac x=ko in exI, clarsimp)
-    apply (frule obj_at_ko_at'[where p=calleePtr], clarsimp)
-    apply (rule_tac x=koa in exI, clarsimp)
-    apply (safe)
-      apply (erule notE)
-      apply (subgoal_tac "obj_at' idle_tcb' (ksIdleThread s) s")
-       apply (erule sym_refs_inj[where x=idle_sc_ptr and ref=TCBSchedContext])
-         apply clarsimp
-        apply (clarsimp simp: state_refs_of'_def ko_wp_at'_def obj_at'_real_def refs_of'_def
-                              projectKO_tcb)
-       apply (clarsimp simp: state_refs_of'_def ko_wp_at'_def obj_at'_real_def refs_of'_def
-                             projectKO_tcb valid_idle'_def idle_tcb'_def tcb_st_refs_of'_def)
-      apply (clarsimp simp: state_refs_of'_def ko_wp_at'_def obj_at'_real_def refs_of'_def
-                            projectKO_tcb valid_idle'_def idle_tcb'_def tcb_st_refs_of'_def)
-     apply (clarsimp simp: valid_idle'_def idle_tcb'_def obj_at'_real_def ko_wp_at'_def)
-    apply (subgoal_tac "valid_obj' (KOTCB ko) s")
-     apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def valid_obj'_def projectKO_tcb
-                           valid_tcb'_def)
-     apply (erule notE, rule sym)
-     apply (rule_tac y=y in sym_refs_inj2[where ref=SCTcb], assumption)
-       apply simp
-      apply (clarsimp simp: state_refs_of'_def refs_of'_def projectKO_sc get_refs_def valid_idle'_def
-                     split: option.splits)
-     apply (clarsimp simp: state_refs_of'_def refs_of'_def projectKO_sc get_refs_def split: option.splits)
-    apply (frule (1) valid_pspace_valid_objs'[THEN ko_at_valid_objs'_pre[rotated]], clarsimp)
-   apply (clarsimp simp: valid_reply'_def)
-  apply (clarsimp simp: valid_idle'_def idle_tcb'_def obj_at'_real_def ko_wp_at'_def
-                        pred_tcb_at'_def)
+  apply wpsimp
+         apply (wpsimp wp: schedContextDonate_valid_idle' bindScReply_valid_idle')+
+       apply (wpsimp wp: hoare_vcg_if_lift2 hoare_vcg_imp_lift')
+      apply (wpsimp wp: hoare_vcg_if_lift2 hoare_vcg_imp_lift' updateReply_valid_pspace'_strong)
+     apply (wpsimp wp: threadGet_wp)+
+  apply (clarsimp simp: tcb_at'_ex_eq_all valid_pspace'_def)
+  apply (subgoal_tac "\<forall>kob. valid_reply' kob s \<longrightarrow> valid_reply' (replyTCB_update (\<lambda>_. Some callerPtr) kob) s")
+   apply (clarsimp simp: tcb_at'_ex_eq_all)
+   apply (subgoal_tac "calleePtr \<noteq> idle_thread_ptr", simp)
+    apply (subgoal_tac "y \<noteq> idle_sc_ptr", simp)
+     apply (erule (3) not_idle_scTCB)
+     apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
+     apply (clarsimp simp: valid_tcb'_def)
+    apply (frule (2) not_idle_tcbSC[where p=callerPtr])
+      apply (clarsimp simp: valid_idle'_def)
+     apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
+    apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
+   apply (clarsimp simp: valid_idle'_def idle_tcb'_def obj_at'_real_def ko_wp_at'_def)
+  apply (clarsimp simp: valid_reply'_def)
   done
 
-lemma replyPush_valid_queues:
+lemma replyPush_valid_queues[wp]:
   "\<lbrace>valid_queues and valid_objs'\<rbrace>
    replyPush callerPtr calleePtr replyPtr canDonate
    \<lbrace>\<lambda>_. valid_queues\<rbrace>"
@@ -4786,16 +4830,14 @@ lemma replyPush_valid_queues:
   unfolding replyPush_def updateReply_def bind_assoc
   apply (rule hoare_seq_ext[OF _ stateAssert_inv])
   apply simp
-  apply (rule hoare_seq_ext[OF _ stateAssert_inv])
   apply (rule hoare_seq_ext[OF _ tg_sp'])
   apply (rule hoare_seq_ext[OF _ tg_sp'])
   apply (rule hoare_seq_ext[OF _ get_reply_sp'])
   apply (wpsimp wp: schedContextDonate_valid_queues
                     threadGet_wp hoare_vcg_if_lift2 hoare_vcg_imp_lift')
-  apply (clarsimp simp: valid_tcb'_def valid_tcb_state'_def)
   apply (clarsimp simp: ko_at_obj_at'[where P=\<top>])
   apply (clarsimp simp: valid_reply'_def dest!: reply_ko_at_valid_objs_valid_reply')
-  by (clarsimp simp: obj_at'_def projectKOs)
+  done
 
 lemma replyPush_untyped_ranges_zero'[wp]:
   "replyPush callerPtr calleePtr replyPtr canDonate \<lbrace>untyped_ranges_zero'\<rbrace>"
@@ -4812,17 +4854,21 @@ lemma replyPush_sch_act_wf:
   by (wpsimp wp: sts_sch_act' hoare_vcg_all_lift hoare_vcg_if_lift hoare_drop_imps)
 
 lemma replyPush_invs':
-  "\<lbrace>\<lambda>s. invs' s \<and> sch_act_not callerPtr s \<and> reply_at' replyPtr s \<and>
-        st_tcb_at' (\<lambda>st. st \<noteq> Inactive \<and> st \<noteq> IdleThreadState) callerPtr s \<and>
-        ex_nonz_cap_to' callerPtr s \<and> ex_nonz_cap_to' calleePtr s \<and> ex_nonz_cap_to' replyPtr s \<and>
-        replyTCBs_of s replyPtr = None\<rbrace>
+  "\<lbrace>invs' and tcbs_scs_sym_refs and replies_scs_sym_refs and
+    sch_act_not callerPtr and ex_nonz_cap_to' callerPtr and ex_nonz_cap_to' calleePtr and
+    ex_nonz_cap_to' replyPtr and (\<lambda>s. replyTCBs_of s replyPtr = None)\<rbrace>
    replyPush callerPtr calleePtr replyPtr canDonate
    \<lbrace>\<lambda>_. invs'\<rbrace>"
   unfolding invs'_def valid_state'_def valid_pspace'_def
   apply (wpsimp wp: replyPush_valid_objs' replyPush_sch_act_wf replyPush_valid_queues
-                    replyPush_if_live_then_nonz_cap' replyPush_valid_idle')
-  apply (fastforce simp: invs'_def valid_state'_def pred_tcb_at'_def obj_at'_def
-                  intro: invs_valid_replies')
+                    replyPush_if_live_then_nonz_cap' replyPush_valid_idle'
+                    replyPush_sym_refs_list_refs_of_replies'
+              simp: valid_pspace'_def)
+  apply (intro conjI)
+    apply (fastforce simp: invs'_def valid_state'_def valid_pspace'_def
+                    intro: invs_valid_replies')
+   apply (erule not_eqI[where P="\<lambda>x. ex_nonz_cap_to' x s" for s])
+   apply (rule global'_no_ex_cap; clarsimp simp: valid_pspace'_def)
   done
 
 lemma setEndpoint_invs':
@@ -4906,6 +4952,169 @@ lemma cancelIPC_notin_epQueue:
   unfolding cancelIPC_def
   by (wpsimp wp: blockedCancelIPC_notin_epQueue hoare_drop_imps threadSet_valid_objs')
 
+crunches rescheduleRequired
+  for scs_tcbs_of[wp]: "\<lambda>s. P (tcb_scs_of' s) (scTCBs_of s)"
+  (wp: crunch_wps threadSet_tcb_scs_of'_inv ignore: threadSet)
+
+lemma maybeReturnSc_tcbs_scs_sym_refs[wp]:
+  "\<lbrace>tcbs_scs_sym_refs and valid_objs'\<rbrace>
+   maybeReturnSc y t
+   \<lbrace>\<lambda>_. tcbs_scs_sym_refs\<rbrace>"
+  unfolding maybeReturnSc_def
+  apply (simp add: liftM_def)
+  apply (rule hoare_seq_ext[OF _ stateAssert_sp])
+  apply (rule hoare_seq_ext[OF _ get_ntfn_sp'])
+  apply (wpsimp wp: setSchedContext_scTCBs_of threadSet_tcb_scs_of' | wps)+
+   apply (wpsimp wp: threadGet_wp)
+  apply (clarsimp simp: tcb_at'_ex_eq_all)
+  apply (drule sym, simp)
+  apply (subgoal_tac "pred_map_eq (the (tcbSchedContext tcb)) (tcb_scs_of' s) t")
+   apply (clarsimp simp: sym_heapd_def pred_map_eq_upd)
+   apply (intro conjI; clarsimp)
+    using pred_map_eq_inj apply metis
+   using pred_map_eq_inj apply metis
+  apply (clarsimp simp: pred_map_eq_def pred_map_def obj_at'_real_def ko_wp_at'_def opt_map_def
+                        projectKOs)
+  done
+
+lemma maybeReturnSc_replies_scs_sym_refs[wp]:
+  "maybeReturnSc y t \<lbrace>replies_scs_sym_refs\<rbrace>"
+  unfolding maybeReturnSc_def
+  apply (simp add: liftM_def)
+  apply (rule hoare_seq_ext[OF _ stateAssert_sp])
+  apply (rule hoare_seq_ext[OF _ get_ntfn_sp'])
+  apply (wpsimp wp: setSchedContext_scReplies_of | wps)+
+   apply (wpsimp wp: threadGet_wp)
+  apply (clarsimp simp: tcb_at'_ex_eq_all)
+  apply (drule sym, simp)
+  apply (erule back_subst)
+  apply (rule arg_cong2[where f=sym_heapd, OF _ refl], rule ext)
+  apply (clarsimp simp: pred_map_eq_def pred_map_def obj_at'_real_def ko_wp_at'_def opt_map_def
+                        projectKOs)
+  done
+
+crunches cleanReply
+  for scTCBs_of[wp]: "\<lambda>s. P (scTCBs_of s)"
+  and tcb_scs_of'[wp]: "\<lambda>s. P (tcb_scs_of' s)"
+
+lemma replyRemoveTCB_scTCBs_of[wp]:
+  "replyRemoveTCB tptr \<lbrace>\<lambda>s. P (scTCBs_of s)\<rbrace>"
+  unfolding replyRemoveTCB_def
+  apply (wpsimp wp: setSchedContext_scTCBs_of gts_wp')
+  apply (erule back_subst[where P=P], rule ext, clarsimp)
+  by (clarsimp simp: opt_map_def obj_at'_real_def ko_wp_at'_def)
+
+lemma replyRemoveTCB_tcb_scs_of'[wp]:
+  "replyRemoveTCB tptr \<lbrace>\<lambda>s. P (tcb_scs_of' s)\<rbrace>"
+  unfolding replyRemoveTCB_def
+  by (wpsimp wp: setSchedContext_scTCBs_of gts_wp')
+
+lemma replyRemoveTCB_tcbs_scs_sym_refs[wp]:
+  "replyRemoveTCB tptr \<lbrace>tcbs_scs_sym_refs\<rbrace>"
+  by (rule hoare_weaken_pre, wps, wpsimp, simp)
+
+crunches cancelIPC
+  for tcbs_scs_sym_refs[wp]: tcbs_scs_sym_refs
+  (wp: crunch_wps threadSet_tcb_scs_of'_inv ignore: setSchedContext threadSet)
+
+lemma cleanReply_replies_scs_sym_refs :
+  "\<lbrace>\<lambda>s. sym_heapd (scReplies_of s) (\<lambda>a. if a = rptr then None else replySCs_of s a)\<rbrace>
+   cleanReply rptr
+   \<lbrace>\<lambda>_. replies_scs_sym_refs\<rbrace>"
+  unfolding cleanReply_def
+  apply (clarsimp simp: bind_assoc updateReply_def)
+  apply (wpsimp wp: hoare_drop_imp | wps)+
+  done
+
+lemma replyRemoveTCB_replies_scs_sym_refs [wp]:
+  "\<lbrace>replies_scs_sym_refs and (\<lambda>s. sym_refs (list_refs_of_replies' s))\<rbrace>
+   replyRemoveTCB t
+   \<lbrace>\<lambda>_. replies_scs_sym_refs\<rbrace>"
+  supply if_split [split del]
+  unfolding replyRemoveTCB_def
+  apply (clarsimp simp: bind_assoc updateReply_def)
+  apply wpsimp
+         apply (wpsimp wp: cleanReply_replies_scs_sym_refs)
+        apply wp
+         apply wps
+         apply wpsimp
+        apply (rule_tac Q="\<lambda>_ s. (replySCs_of s) (the (replyPrev reply)) = None \<and>
+                 sym_heapd (scReplies_of s) (\<lambda>a. if a = rptr then None else replySCs_of s a)"
+               in hoare_strengthen_post[rotated], clarsimp)
+        apply wpsimp
+       apply (rule_tac Q="\<lambda>_ s. (replyPrev reply \<noteq> None \<longrightarrow>
+                reply_at' (the (replyPrev reply)) s \<longrightarrow>
+                (replySCs_of s) (the (replyPrev reply)) = None) \<and>
+                sym_heapd (scReplies_of s) (\<lambda>a. if a = rptr then None else replySCs_of s a)"
+              in hoare_strengthen_post[rotated])
+        apply (clarsimp split: if_splits simp: obj_at'_def)
+       apply (wp hoare_vcg_if_lift2 hoare_vcg_imp_lift' hoare_vcg_all_lift)
+         apply wps
+         apply (wpsimp wp: setSchedContext_scReplies_of)
+        apply wpsimp
+       apply wp
+        apply wps
+        apply wpsimp
+       apply wpsimp
+      apply wpsimp
+     apply (rule_tac Q="\<lambda>replya s. replies_scs_sym_refs s \<and> sym_refs (list_refs_of_replies' s)"
+            in hoare_strengthen_post[rotated])
+      apply (clarsimp split: if_splits)
+      apply (intro conjI; intro allI impI)
+       apply clarsimp
+       apply (intro conjI; intro allI impI)
+         apply (clarsimp simp: isHead_to_head)
+         apply (intro conjI; intro allI impI)
+          apply clarsimp
+          apply (subgoal_tac "replyPrevs_of s r = Some ya")
+           apply (rule replyNexts_Some_replySCs_None)
+           apply (simp add: sym_refs_replyNext_replyPrev_sym[symmetric])
+          apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
+         apply (intro conjI; intro allI impI)
+          apply clarsimp
+          apply (drule ko_at'_inj, assumption, simp)
+          apply (clarsimp simp: isHead_to_head)
+          apply (subgoal_tac "replyPrevs_of s r = Some rPtr")
+           apply (insert replyNexts_Some_replySCs_None)
+           apply (simp add: sym_refs_replyNext_replyPrev_sym[symmetric])
+           apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
+          apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
+         apply clarsimp
+         apply (subgoal_tac "replyPrevs_of s r = Some ya")
+          apply (rule replyNexts_Some_replySCs_None)
+          apply (simp add: sym_refs_replyNext_replyPrev_sym[symmetric])
+         apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
+        apply (clarsimp simp: isHead_to_head)
+        apply (erule sym_heapd_remove_only)
+        apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def
+                              pred_map_eq_def pred_map_def)
+       apply (clarsimp simp: isHead_to_head)
+       apply (erule rsubst2[where P=sym_heapd, OF _ refl])
+       apply (rule ext, clarsimp split: if_split)
+       apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
+      apply (intro conjI, intro allI impI)
+       apply clarsimp
+       apply (subgoal_tac "replyPrevs_of s r = Some y")
+        apply (rule replyNexts_Some_replySCs_None)
+        apply (simp add: sym_refs_replyNext_replyPrev_sym[symmetric])
+       apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
+      apply (erule rsubst2[where P=sym_heapd, OF _ refl])
+      apply (rule ext, clarsimp split: if_split)
+      apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
+     apply (wpsimp wp: hoare_drop_imp)+
+  done
+
+crunches blockedCancelIPC, cancelSignal
+  for replies_scs_sym_refs[wp]: replies_scs_sym_refs
+  (wp: crunch_wps  ignore: setSchedContext setReply updateReply)
+
+lemma cancelIPC_replies_scs_sym_refs [wp]:
+  "\<lbrace>replies_scs_sym_refs and (\<lambda>s. sym_refs (list_refs_of_replies' s))\<rbrace>
+   cancelIPC t
+   \<lbrace>\<lambda>_. replies_scs_sym_refs\<rbrace>"
+  unfolding cancelIPC_def
+  by (wpsimp wp: gts_wp', simp add: comp_def)
+
 (* t = ksCurThread s *)
 lemma ri_invs' [wp]:
   "\<lbrace>invs' and sch_act_not t
@@ -4921,6 +5130,7 @@ lemma ri_invs' [wp]:
    apply (rule hoare_seq_ext)
     \<comment> \<open>After getEndpoint, the following holds regardless of the type of ep\<close>
     apply (rule_tac B="\<lambda>ep s. invs' s \<and> ex_nonz_cap_to' t s \<and> ex_nonz_cap_to' (capEPPtr cap) s \<and>
+                              tcbs_scs_sym_refs s \<and> replies_scs_sym_refs s \<and>
                               st_tcb_at' simple' t s \<and> sch_act_not t s \<and> t \<noteq> ksIdleThread s \<and>
                               (\<forall>x. replyOpt = Some x \<longrightarrow> ex_nonz_cap_to' x s \<and>
                                                          reply_at' x s \<and> replyTCBs_of s x = None) \<and>
@@ -4978,8 +5188,17 @@ lemma ri_invs' [wp]:
     apply (fastforce simp: obj_at'_def projectKOs)
    apply (fastforce simp: refs_of_rev' ko_wp_at'_def tcb_bound_refs'_def get_refs_def
                    split: option.splits)
-  apply (fastforce simp: invs'_def valid_state'_def valid_idle'_def idle_tcb'_def opt_map_def
-                         pred_tcb_at'_def obj_at'_def projectKOs isCap_simps isSend_def)
+  apply (clarsimp simp: comp_def invs'_def valid_state'_def valid_pspace'_def cong: conj_cong imp_cong)
+  apply (frule (3) invs'_tcbs_scs_sym_refs)
+  apply (frule (3) sym_refs_replies_scs)
+  apply (subgoal_tac "ex_nonz_cap_to' (capEPPtr cap) s \<and> st_tcb_at' simple' t s \<and>
+                      t \<noteq> ksIdleThread s \<and> (ep_at' (capEPPtr cap) s \<longrightarrow>
+                      obj_at' (\<lambda>ep. ep \<noteq> Structures_H.endpoint.IdleEP \<longrightarrow> t \<notin> set (epQueue ep))
+                      (capEPPtr cap) s)")
+   apply clarsimp
+   apply (fastforce simp: opt_map_def pred_tcb_at'_def obj_at'_def projectKOs)
+  apply (fastforce simp: valid_idle'_def idle_tcb'_def pred_tcb_at'_def obj_at'_def projectKOs
+                         isCap_simps isSend_def)
   done
 
 lemma replyUnlink_invs':
@@ -5003,6 +5222,42 @@ crunches doIPCTransfer
   for pred_tcb_at''[wp]: "\<lambda>s. P (pred_tcb_at' proj test t s)"
   (wp: setCTE_pred_tcb_at' getCTE_wp mapM_wp' simp: cte_wp_at'_def zipWithM_x_mapM)
 
+lemma si_invs'_helper2:
+  "\<lbrace>\<lambda>s. invs' s \<and> sch_act_not t s \<and> st_tcb_at' active' t s \<and> tcb_at' d s \<and>
+        ex_nonz_cap_to' t s \<and> ex_nonz_cap_to' d s \<and>
+        tcbs_scs_sym_refs s \<and> replies_scs_sym_refs s \<and>
+        (\<forall>reply. replyObject recvState = Some reply \<longrightarrow> ex_nonz_cap_to' reply s \<and> reply_at' reply s
+                 \<and> replyTCBs_of s reply = None) \<and>
+        (cd \<and> scOptDest = Nothing \<longrightarrow> bound_sc_tcb_at' ((=) None) d s \<and>
+        (\<exists>scptr. bound_sc_tcb_at' (\<lambda>scp. scp = (Some scptr)) t s \<and> ex_nonz_cap_to' scptr s))\<rbrace>
+   if call \<or> (\<exists>y. fault = Some y)
+   then if (cg \<or> cgr) \<and> (\<exists>y. replyObject recvState = Some y)
+        then replyPush t d (the (replyObject recvState)) cd
+        else setThreadState Structures_H.thread_state.Inactive t
+   else when (cd \<and> scOptDest = None) (do
+          scOptSrc <- threadGet tcbSchedContext t;
+          schedContextDonate (the scOptSrc) d
+        od)
+  \<lbrace>\<lambda>b s. invs' s \<and> tcb_at' d s \<and> ex_nonz_cap_to' d s\<rbrace>"
+  apply (wpsimp wp: ex_nonz_cap_to_pres' schedContextDonate_invs' replyPush_invs' sts_invs_minor'
+                    threadGet_wp)
+  apply (frule pred_tcb_at')
+  apply (frule invs_valid_objs')
+  apply (frule invs_valid_idle')
+  apply (subgoal_tac "t \<noteq> ksIdleThread s")
+   apply (clarsimp simp: tcb_at'_ex_eq_all)
+   apply (intro conjI)
+    apply (clarsimp simp: pred_tcb_at'_def obj_at'_real_def ko_wp_at'_def projectKO_tcb)
+   apply (rule not_idle_scTCB, clarsimp, clarsimp, clarsimp)
+    apply (frule not_idle_tcbSC[where p=t], clarsimp, clarsimp)
+      apply (clarsimp simp: valid_idle'_def)
+     apply (clarsimp simp: valid_state'_def pred_tcb_at'_def obj_at'_def valid_tcb_state'_def)
+    apply (clarsimp simp: pred_tcb_at'_def obj_at'_real_def ko_wp_at'_def projectKO_tcb)
+   apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
+   apply (clarsimp simp: valid_tcb'_def pred_tcb_at'_def obj_at'_real_def ko_wp_at'_def projectKO_tcb)
+  apply (fastforce simp: invs'_def valid_state'_def dest: global'_no_ex_cap)
+  done
+
 lemma replyUnlink_obj_at_tcb_none:
   "\<lbrace>K (rptr' = rptr)\<rbrace>
    replyUnlink rptr tptr
@@ -5011,7 +5266,8 @@ lemma replyUnlink_obj_at_tcb_none:
   apply (wpsimp wp: updateReply_wp_all gts_wp')
   by (auto simp: obj_at'_def projectKOs objBitsKO_def)
 
-lemma si_invs'[wp]:
+(* FIXME RT: si_invs' already exists, and should perhaps be renamed *)
+lemma si_invs'2[wp]:
   "\<lbrace>invs' and st_tcb_at' active' t
           and sch_act_not t
           and (\<lambda>s. cd \<longrightarrow> bound_sc_tcb_at' (\<lambda>a. a \<noteq> None) t s)
@@ -5027,33 +5283,46 @@ lemma si_invs'[wp]:
     \<comment> \<open>ep' = RecvEP\<close>
     apply (rename_tac list)
     apply (case_tac list; simp)
-    apply (wpsimp wp: threadGet_wp possibleSwitchTo_invs' setThreadState_Running_invs'
-                      setThreadState_st_tcb schedContextDonate_invs' replyPush_invs'
-                      replyUnlink_invs' replyUnlink_st_tcb_at' replyUnlink_obj_at_tcb_none
-                      ex_nonz_cap_to_pres' sts_invs_minor' hoare_vcg_const_imp_lift
-                simp: if_fun_split)
+    apply (wpsimp wp: possibleSwitchTo_invs')
+             apply (wpsimp wp: setThreadState_st_tcb setThreadState_Running_invs')
+            apply (wpsimp wp: si_invs'_helper2)
+           apply wpsimp
+          apply (wpsimp wp: threadGet_wp)
+         apply (rule_tac Q="\<lambda>_ s. invs' s \<and> st_tcb_at' active' t s \<and> sch_act_not t s \<and>
+                                  ex_nonz_cap_to' t s \<and> ex_nonz_cap_to' a s \<and>
+                                  (\<forall>x. replyObject recvState = Some x \<longrightarrow> ex_nonz_cap_to' x s \<and> reply_at' x s
+                                       \<and> replyTCBs_of s x = None) \<and>
+                                  tcbs_scs_sym_refs s \<and> replies_scs_sym_refs s \<and>
+                                  (cd \<longrightarrow> (\<exists>scptr. bound_sc_tcb_at' (\<lambda>scp. scp = Some scptr) t s \<and>
+                                                   ex_nonz_cap_to' scptr s))"
+                in hoare_strengthen_post[rotated])
+          apply (fastforce simp: obj_at'_def projectKO_eq projectKO_tcb
+                                 pred_tcb_at'_def invs'_def valid_state'_def
+                          dest!: global'_no_ex_cap)
+         apply (wpsimp wp: replyUnlink_invs' replyUnlink_st_tcb_at' replyUnlink_obj_at_tcb_none
+                           hoare_vcg_ex_lift hoare_vcg_imp_lift')
         apply (rule_tac Q="\<lambda>_ s. invs' s \<and> st_tcb_at' active' t s \<and> sch_act_not t s \<and>
-                                 ex_nonz_cap_to' t s \<and> ex_nonz_cap_to' a s \<and> t \<noteq> a \<and>
-                                 (\<forall>x. replyObject recvState = Some x \<longrightarrow>
-                                      ex_nonz_cap_to' x s \<and> reply_at' x s) \<and>
-                                 (cd \<and> bound_sc_tcb_at' ((=) None) a s \<longrightarrow>
-                                   (\<exists>sc. bound_sc_tcb_at' ((=) sc) t s \<and>
-                                         ex_nonz_cap_to' (the sc) s))"
-                     in hoare_strengthen_post[rotated])
+                                 ex_nonz_cap_to' t s \<and> ex_nonz_cap_to' a s \<and> a \<noteq> t \<and>
+                                 tcbs_scs_sym_refs s \<and> replies_scs_sym_refs s \<and>
+                                 (\<forall>x. replyObject recvState = Some x \<longrightarrow> ex_nonz_cap_to' x s \<and> reply_at' x s) \<and>
+                                 (cd \<longrightarrow> (\<exists>scptr. bound_sc_tcb_at' (\<lambda>scp. scp = Some scptr) t s \<and> ex_nonz_cap_to' scptr s))"
+               in hoare_strengthen_post[rotated])
          apply (fastforce simp: obj_at'_def projectKO_eq projectKO_tcb
                                 pred_tcb_at'_def invs'_def valid_state'_def
                          dest!: global'_no_ex_cap)
         apply (wpsimp simp: invs'_def valid_state'_def valid_pspace'_def comp_def sym_refs_asrt_def
                         wp: hoare_vcg_all_lift hoare_vcg_ex_lift hoare_vcg_imp_lift' gts_wp')+
     apply (intro conjI; clarsimp?)
-        apply (force simp: obj_at'_def projectKO_eq projectKO_ep valid_obj'_def valid_ep'_def
-                     elim: valid_objsE' split: list.splits)
-       apply (fastforce simp: pred_tcb_at'_def ko_wp_at'_def obj_at'_def
-                              projectKO_eq projectKO_tcb isReceive_def
-                        elim: if_live_then_nonz_capE' split: thread_state.splits)
-      apply (fastforce simp: pred_tcb_at'_def ko_wp_at'_def obj_at'_def
-                             projectKO_eq projectKO_tcb isReceive_def
-                      split: thread_state.splits)
+          apply (force simp: obj_at'_def projectKO_eq projectKO_ep valid_obj'_def valid_ep'_def
+                       elim: valid_objsE' split: list.splits)
+         apply (fastforce simp: pred_tcb_at'_def ko_wp_at'_def obj_at'_def
+                                projectKO_eq projectKO_tcb isReceive_def
+                          elim: if_live_then_nonz_capE' split: thread_state.splits)
+        apply (fastforce simp: pred_tcb_at'_def ko_wp_at'_def obj_at'_def
+                               projectKO_eq projectKO_tcb isReceive_def
+                        split: thread_state.splits)
+       apply (erule (3) invs'_tcbs_scs_sym_refs)
+      apply (erule (3) sym_refs_replies_scs)
      apply (subgoal_tac "ko_wp_at' live' xb s \<and> reply_at' xb s", clarsimp)
       apply (erule (1) if_live_then_nonz_capE')
      apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKO_eq projectKO_tcb)

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -4022,7 +4022,7 @@ lemma shows
   obj_at'_sc_tcbs_of_equiv:
     "obj_at' (\<lambda>x. scTCB x = Some t) p s = (sc_at' p s \<and> scTCBs_of s p = Some t)"
   and obj_at'_tcb_scs_of_equiv:
-    "obj_at' (\<lambda>x. tcbSchedContext x = Some sc) p s = (tcb_at' p s \<and> tcb_scs_of' s p = Some sc)"
+    "obj_at' (\<lambda>x. tcbSchedContext x = Some sc) p s = (tcb_at' p s \<and> tcbSCs_of' s p = Some sc)"
   and obj_at'_replySCs_of_equiv:
     "obj_at' (\<lambda>a. replyNext a = Some (Head sc)) p s = (reply_at' p s \<and> replySCs_of s p = Some sc)"
   and obj_at'_scReplies_of_equiv:
@@ -4061,13 +4061,13 @@ lemma setObject_other_tcbs_of'[wp]:
   "setObject c (sc::sched_context) \<lbrace>\<lambda>s. P' (tcbs_of' s)\<rbrace>"
   by setObject_easy_cases+
 
-lemma setObject_cte_tcb_scs_of'[wp]:
-  "setObject c (reply::cte) \<lbrace>\<lambda>s. P' (tcb_scs_of' s)\<rbrace>"
+lemma setObject_cte_tcbSCs_of'[wp]:
+  "setObject c (reply::cte) \<lbrace>\<lambda>s. P' (tcbSCs_of' s)\<rbrace>"
   by setObject_easy_cases
 
-lemma threadSet_tcb_scs_of'_inv:
+lemma threadSet_tcbSCs_of'_inv:
   "\<forall>x. tcbSchedContext (f x) = tcbSchedContext x \<Longrightarrow>
-  threadSet f t \<lbrace>\<lambda>s. P (tcb_scs_of' s)\<rbrace>"
+  threadSet f t \<lbrace>\<lambda>s. P (tcbSCs_of' s)\<rbrace>"
   unfolding threadSet_def
   apply (rule hoare_seq_ext[OF _ get_tcb_sp'])
   apply (wpsimp wp: setObject_tcb_tcbs_of')
@@ -4139,7 +4139,7 @@ lemma ReplySchedContext_state_refs_of':
   done
 
 lemma TCBSC_pred_map_state_refs_of':
-  "\<lbrakk>tcb_scs_of' s p = Some scp; pspace_aligned' s; pspace_distinct' s\<rbrakk>
+  "\<lbrakk>tcbSCs_of' s p = Some scp; pspace_aligned' s; pspace_distinct' s\<rbrakk>
    \<Longrightarrow> (scp, TCBSchedContext) \<in> state_refs_of' s p"
   apply (clarsimp simp: TCBSchedContext_state_refs_of' obj_at'_tcb_scs_of_equiv projectKOs
                         ksPSpace_obj_at')
@@ -4220,10 +4220,10 @@ lemma getObject_tcb_wp:
                      split_def objBits_simps' loadObject_default_def
                      projectKOs obj_at'_def in_magnitude_check)
 
-lemma threadSet_tcb_scs_of':
-  "\<lbrace>\<lambda>s. P (\<lambda>a. if a = t then tcbSchedContext (f (the (tcbs_of' s a))) else tcb_scs_of' s a)\<rbrace>
+lemma threadSet_tcbSCs_of':
+  "\<lbrace>\<lambda>s. P (\<lambda>a. if a = t then tcbSchedContext (f (the (tcbs_of' s a))) else tcbSCs_of' s a)\<rbrace>
    threadSet f t
-   \<lbrace>\<lambda>_ s. P (tcb_scs_of' s)\<rbrace>"
+   \<lbrace>\<lambda>_ s. P (tcbSCs_of' s)\<rbrace>"
   unfolding threadSet_def
   apply (wpsimp wp: setObject_tcb_wp getObject_tcb_wp)
   apply (clarsimp simp: tcb_at'_ex_eq_all)

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -880,17 +880,6 @@ lemma bindScReply_valid_objs'[wp]:
                        dest!: sc_ko_at_valid_objs_valid_sc')+)[5]
   done
 
-lemma sym_refs_replySCs_of_scReplies_of:
-  "\<lbrakk>sym_refs (state_refs_of' s'); pspace_aligned' s'; pspace_distinct' s'\<rbrakk>
-   \<Longrightarrow> replySCs_of s' rp = Some scp \<longleftrightarrow> scReplies_of s' scp = Some rp"
-  apply (rule iffI)
-   apply (drule_tac tp=SCReply and x=rp and y=scp in sym_refsE;
-          force simp: get_refs_def2 state_refs_of'_def projectKOs opt_map_left_Some refs_of_rev'
-                dest: pspace_alignedD' pspace_distinctD' split: if_split_asm option.split_asm)+
-  by (drule_tac tp=ReplySchedContext and x=scp and y=rp in sym_refsE;
-      force simp: get_refs_def2 state_refs_of'_def projectKOs opt_map_left_Some refs_of_rev'
-               dest: pspace_alignedD' pspace_distinctD' split: if_split_asm option.split_asm)+
-
 crunches bindScReply
   for valid_queues[wp]: valid_queues
   and valid_queues'[wp]: valid_queues'
@@ -912,7 +901,7 @@ lemma bindScReply_sym_refs_list_refs_of_replies':
   unfolding bindScReply_def
   apply (wpsimp wp: updateReply_list_refs_of_replies' updateReply_obj_at'
                     hoare_vcg_all_lift hoare_vcg_imp_lift')
-  by (auto simp: list_refs_of_replies'_def list_refs_of_reply'_def pred_map_eq
+  by (auto simp: list_refs_of_replies'_def list_refs_of_reply'_def
                  opt_map_Some_def obj_at'_def projectKO_eq
            elim: delta_sym_refs split: if_splits)
 
@@ -930,7 +919,7 @@ lemma bindScReply_if_live_then_nonz_cap':
          | rule threadGet_wp)+
   apply clarsimp
   apply (erule if_live_then_nonz_capE')
-  apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKO_eq live_reply'_def projectKOs opt_map_def)
+   apply (clarsimp simp: ko_wp_at'_def obj_at'_def live_reply'_def opt_map_def projectKOs)
   done
 
 lemma bindScReply_ex_nonz_cap_to'[wp]:
@@ -1111,13 +1100,6 @@ lemma sc_replies_relation_sc_with_reply_heap_path:
   apply (frule (1) heap_path_takeWhile_lookup_next)
   by (metis (mono_tags) option.sel sc_replies.Some)
 
-lemma shows
-  replyNexts_Some_replySCs_None:
-  "replyNexts_of s rp = Some nrp \<Longrightarrow> replySCs_of s rp = None" and
-  replySCs_Some_replyNexts_None:
-  "replySCs_of s rp = Some nrp \<Longrightarrow> replyNexts_of s rp = None"
-  by (clarsimp simp: opt_map_def projectKOs obj_at'_def split: option.splits reply_next.splits)+
-
 lemma next_reply_in_sc_replies:
   "\<lbrakk>sc_replies_relation s s'; sc_with_reply rp s = Some scp; sym_refs (list_refs_of_replies' s');
     sym_refs (state_refs_of' s'); replyNexts_of s' rp = Some nrp;
@@ -1133,7 +1115,7 @@ lemma next_reply_in_sc_replies:
   apply simp
   apply (frule (3) heap_ls_prev_cases[OF _ _ _ reply_sym_heap_Prev_Next])
   apply (drule (2) sym_refs_replySCs_of_None)
-   apply (erule replyNexts_Some_replySCs_None)
+   apply (rule replyNexts_Some_replySCs_None[where rp=rp], simp)
   apply (clarsimp simp: vs_heap_simps)
   apply (drule (1) heap_ls_next_takeWhile_append[rotated -1])
   apply (meson omonadE(1))
@@ -1154,7 +1136,7 @@ lemma prev_reply_in_sc_replies:
   apply simp
   apply (frule (2) heap_ls_next_in_list)
   apply (frule (2) sym_refs_replySCs_of_None[where rp=nrp])
-   apply (erule replyNexts_Some_replySCs_None)
+   apply (rule replyNexts_Some_replySCs_None, simp)
   apply (drule_tac x=scp in spec)
   apply (clarsimp simp: vs_heap_simps)
   apply (frule (2) heap_ls_next_takeWhile_append[where p=rp])
@@ -1219,8 +1201,8 @@ lemma sc_with_reply_replyNext_Some:
    apply (frule (2) heap_ls_prev_cases)
     apply (erule reply_sym_heap_Prev_Next)
    apply (erule disjE)
-    apply (frule (3) sym_refs_replySCs_of_scReplies_of[THEN iffD2])
-    apply (frule replySCs_Some_replyNexts_None)
+    apply (frule (2) sym_refs_replies_scs, clarsimp simp: sym_heap_def)
+    apply (frule replySCs_Some_replyNexts_None[OF option.discI])
     apply (drule (1) sym_refs_replyNext_None, clarsimp)
    apply clarsimp
   apply (clarsimp simp: sc_with_reply'_def the_pred_option_def the_equality split: if_split_asm)
@@ -1260,8 +1242,8 @@ lemma sc_with_reply_replyPrev_None:
   apply (frule (2) heap_ls_prev_cases)
    apply (erule reply_sym_heap_Prev_Next)
   apply (erule disjE)
-   apply (frule (3) sym_refs_replySCs_of_scReplies_of[THEN iffD2])
-   apply (frule replySCs_Some_replyNexts_None)
+   apply (frule (2) sym_refs_replies_scs, clarsimp simp: sym_heap_def)
+   apply (frule replySCs_Some_replyNexts_None[OF option.discI])
    apply (drule (1) sym_refs_replyNext_None, clarsimp)
   by (meson heap_ls_prev_not_in)
 

--- a/proof/refine/ARM/SchedContext_R.thy
+++ b/proof/refine/ARM/SchedContext_R.thy
@@ -589,7 +589,6 @@ lemma schedContextDonate_valid_objs':
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   (is "valid ?pre _ _")
   apply (clarsimp simp: schedContextDonate_def)
-  apply (rule hoare_seq_ext[OF _ stateAssert_sp])
   apply (rule hoare_seq_ext[OF _ get_sc_sp'], rename_tac sc)
   apply (rule_tac Q="?pre and valid_sched_context' sc and K (valid_sched_context_size' sc) and sc_at' scPtr"
                in hoare_weaken_pre[rotated])

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -1226,7 +1226,7 @@ lemma scheduleTCB_rct:
 lemma setThreadState_rct:
   "\<lbrace>\<lambda>s. (t = ksCurThread s \<longrightarrow> runnable' st
       \<and> pred_map (\<lambda>tcb. \<not>(tcbInReleaseQueue tcb)) (tcbs_of' s) t
-      \<and> pred_map (\<lambda>scPtr. isScActive scPtr s) (tcb_scs_of' s) t)
+      \<and> pred_map (\<lambda>scPtr. isScActive scPtr s) (tcbSCs_of' s) t)
         \<and> ksSchedulerAction s = ResumeCurrentThread\<rbrace>
    setThreadState st t
    \<lbrace>\<lambda>_ s. ksSchedulerAction s = ResumeCurrentThread\<rbrace>"
@@ -1571,7 +1571,7 @@ lemma tcbInReleaseQueue_cross_rel:
 
 lemma isScActive_cross_rel:
   "cross_rel (pspace_aligned and pspace_distinct and valid_objs and active_sc_tcb_at t)
-             (\<lambda>s'. pred_map ((\<lambda>scPtr. isScActive scPtr s')) (tcb_scs_of' s') t)"
+             (\<lambda>s'. pred_map ((\<lambda>scPtr. isScActive scPtr s')) (tcbSCs_of' s') t)"
   apply (rule cross_rel_imp[OF tcb_at'_cross_rel[where t=t]])
    apply (clarsimp simp: cross_rel_def)
    apply (subgoal_tac "pspace_relation (kheap s) (ksPSpace s')")

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -101,7 +101,7 @@ lemma tcbSchedAppend_corres:
           (tcb_sched_action (tcb_sched_append) t) (tcbSchedAppend t)"
   apply (rule corres_cross_back[where P="tcb_at t" and P'="tcb_at' t"])
     apply (fastforce dest: pspace_relation_tcb_at
-                     simp: state_relation_def tcb_of'_def opt_map_def obj_at'_def projectKOs
+                     simp: state_relation_def opt_map_def obj_at'_def projectKOs
                     split: option.splits)
    apply simp
   apply (simp only: tcbSchedAppend_def tcb_sched_action_def)
@@ -1540,7 +1540,7 @@ lemma runnable_cross_rel:
   apply (clarsimp simp: other_obj_relation_def split: option.splits)
   apply (case_tac "ko"; simp)
   apply (rule_tac x="x6" in exI)
-  apply (clarsimp simp: tcb_of'_def opt_map_def)
+  apply (clarsimp simp: opt_map_def)
   apply (clarsimp simp: tcb_relation_def thread_state_relation_def)
   apply (case_tac "tcb_state b"; simp add: runnable_def)
   apply clarsimp
@@ -1559,7 +1559,7 @@ lemma tcbInReleaseQueue_cross_rel:
   apply (clarsimp simp: other_obj_relation_def split: option.splits)
   apply (case_tac "koa"; simp)
   apply (rule_tac x="x6" in exI)
-  apply (clarsimp simp: tcb_of'_def opt_map_def)
+  apply (clarsimp simp: opt_map_def)
   apply (subgoal_tac "obj_at' tcbInReleaseQueue t s'")
   apply (subgoal_tac "release_queue_relation (release_queue s) (ksReleaseQueue s')")
   apply (clarsimp simp: release_queue_relation_def not_in_release_q_def valid_release_queue'_def)
@@ -1588,7 +1588,7 @@ lemma isScActive_cross_rel:
       apply (subgoal_tac "valid_sched_context_size n")
        apply (clarsimp simp: other_obj_relation_def split: option.splits)
        apply (clarsimp simp: obj_at'_def projectKO_eq Bits_R.projectKO_sc)
-       apply (clarsimp simp: tcb_of'_def opt_map_def tcb_relation_def)
+       apply (clarsimp simp: opt_map_def tcb_relation_def)
        apply (rule_tac x=scp in exI, simp)
        apply (clarsimp simp: isScActive_def active_sc_def)
        apply (clarsimp simp: obj_at'_def projectKO_eq Bits_R.projectKO_sc pred_map_def opt_map_def)
@@ -1644,7 +1644,7 @@ lemma guarded_switch_to_chooseThread_fragment_corres:
                          invs_valid_vs_lookup invs_unique_refs)
    apply (clarsimp simp: thread_get_def in_monad pred_tcb_at_def obj_at_def get_tcb_ko_at)
   apply (prop_tac "st_tcb_at' runnable' t s")
-   apply (clarsimp simp: pred_tcb_at'_def isSchedulable_bool_def pred_map_def obj_at'_def tcb_of'_def
+   apply (clarsimp simp: pred_tcb_at'_def isSchedulable_bool_def pred_map_def obj_at'_def
                          projectKO_eq Bits_R.projectKO_tcb
                   split: kernel_object.splits)
   by (auto elim!: pred_tcb'_weakenE split: thread_state.splits
@@ -2572,7 +2572,7 @@ lemma setSchedulerAction_ksSchedulerAction[wp]:
 lemma isSchedulable_bool_runnableE:
   "isSchedulable_bool t s \<Longrightarrow> tcb_at' t s \<Longrightarrow> st_tcb_at' runnable' t s"
   unfolding isSchedulable_bool_def
-  by (clarsimp simp: pred_tcb_at'_def obj_at'_def pred_map_def projectKO_eq projectKO_opt_tcb tcb_of'_Some)
+  by (clarsimp simp: pred_tcb_at'_def obj_at'_def pred_map_def projectKO_eq projectKO_opt_tcb)
 
 lemma rescheduleRequired_invs'[wp]:
   "rescheduleRequired \<lbrace>invs'\<rbrace>"

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -2914,7 +2914,6 @@ lemma schedContextDonate_valid_queues:
   "\<lbrace>valid_queues and valid_objs'\<rbrace> schedContextDonate scPtr tcbPtr \<lbrace>\<lambda>_. valid_queues\<rbrace>"
   (is "valid ?pre _ _")
   apply (clarsimp simp: schedContextDonate_def)
-  apply (rule hoare_seq_ext[OF _ stateAssert_sp])
   apply (rule hoare_seq_ext[OF _ get_sc_sp'])
   apply (rule_tac B="\<lambda>_. ?pre" in hoare_seq_ext[rotated])
    apply (rule hoare_when_cases, clarsimp)
@@ -2935,7 +2934,6 @@ lemma schedContextDonate_valid_queues:
 lemma schedContextDonate_valid_queues':
   "schedContextDonate sc t \<lbrace>valid_queues'\<rbrace>"
   apply (clarsimp simp: schedContextDonate_def)
-  apply (rule hoare_seq_ext_skip, solves wpsimp)
   apply (rule hoare_seq_ext_skip, solves wpsimp)
   apply (rule hoare_seq_ext_skip)
    apply (rule hoare_when_cases, simp)
@@ -3000,28 +2998,28 @@ lemma schedContextDonate_if_live_then_nonz_cap':
   by (wpsimp wp: threadSet_iflive'T setSchedContext_iflive' hoare_vcg_all_lift threadSet_cap_to'
            simp: conj_ac cong: conj_cong | wp hoare_drop_imps | fastforce simp: tcb_cte_cases_def)+
 
+(* `obj_at' (\<lambda>x. scTCB x \<noteq> Some idle_thread_ptr) scPtr s` is
+   needed because sometimes sym_refs doesn't hold in its entirety here. *)
 lemma schedContextDonate_invs':
   "\<lbrace>\<lambda>s. invs' s \<and> bound_sc_tcb_at' ((=) None) tcbPtr s \<and>
-        ex_nonz_cap_to' scPtr s \<and> ex_nonz_cap_to' tcbPtr s\<rbrace>
+        ex_nonz_cap_to' scPtr s \<and> ex_nonz_cap_to' tcbPtr s \<and>
+        obj_at' (\<lambda>x. scTCB x \<noteq> Some idle_thread_ptr) scPtr s\<rbrace>
    schedContextDonate scPtr tcbPtr
    \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (simp only: invs'_def valid_state'_def)
-  apply (rule_tac E="\<lambda>s. sc_at' scPtr s \<and> sym_refs (state_refs_of' s)"
-               in hoare_strengthen_pre_via_assert_backward)
+  apply (rule_tac E="\<lambda>s. sc_at' scPtr s" in hoare_strengthen_pre_via_assert_backward)
    apply (simp only: schedContextDonate_def)
-   apply (rule hoare_seq_ext[OF _ stateAssert_sp])
-   apply (rule hoare_K_bind)
    apply (rule hoare_seq_ext[OF _ get_sc_sp'])
    apply (rule_tac hoare_weaken_pre[OF hoare_pre_cont])
-   apply (clarsimp simp: obj_at'_def sym_refs_asrt_def)
-  apply (wp schedContextDonate_valid_pspace' schedContextDonate_vrq
+   apply (clarsimp simp: obj_at'_def)
+  apply (wp schedContextDonate_valid_pspace'
             schedContextDonate_valid_queues schedContextDonate_valid_queues'
             schedContextDonate_valid_idle' schedContextDonate_if_live_then_nonz_cap')
+  apply clarsimp
   apply (clarsimp simp: obj_at'_def projectKO_eq projectKO_sc)
-  apply (drule_tac ko=obj in sym_refs_ko_atD'[rotated, where p=scPtr])
-   apply (auto dest!: global'_sc_no_ex_cap
-               simp: ko_wp_at'_def obj_at'_def projectKO_eq projectKO_tcb
-                     pred_tcb_at'_def valid_idle'_def idle_tcb'_def refs_of_rev')
+  apply (auto dest!: global'_sc_no_ex_cap
+              simp: ko_wp_at'_def obj_at'_def projectKO_eq projectKO_tcb
+                    pred_tcb_at'_def valid_idle'_def idle_tcb'_def refs_of_rev')
   done
 
 lemma tcbSchedDequeue_notksQ:
@@ -3163,7 +3161,6 @@ lemma schedContextDonate_corres:
   apply add_sym_refs
   apply (simp add: test_reschedule_def get_sc_obj_ref_def set_tcb_obj_ref_thread_set
                    schedContextDonate_def sched_context_donate_def schedContextDonate_corres_helper)
-  apply (rule corres_stateAssert_assume)
    apply (rule stronger_corres_guard_imp)
      apply (rule corres_split_deprecated [OF _ get_sc_corres])
        apply (rule corres_split_deprecated [OF _ corres_when2])
@@ -3235,7 +3232,6 @@ lemma schedContextDonate_corres:
    apply (clarsimp simp: valid_obj'_def valid_sched_context'_def obj_at'_def projectKOs)
    apply (frule valid_objs'_valid_tcbs')
    apply (fastforce simp: valid_obj'_def valid_tcb'_def)
-  apply (clarsimp simp: sym_refs_asrt_def)
   done
 
 end

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -764,12 +764,6 @@ lemma setObject_tcb_valid_globals' [wp]:
    apply (wp | wp setObject_ksPSpace_only updateObject_default_inv | simp)+
   done
 
-lemma getObject_tcb_wp:
-  "\<lbrace>\<lambda>s. tcb_at' p s \<longrightarrow> (\<exists>t::tcb. ko_at' t p s \<and> Q t s)\<rbrace> getObject p \<lbrace>Q\<rbrace>"
-  by (clarsimp simp: getObject_def valid_def in_monad
-                     split_def objBits_simps' loadObject_default_def
-                     projectKOs obj_at'_def in_magnitude_check)
-
 lemma setObject_tcb_pspace_no_overlap':
   "\<lbrace>pspace_no_overlap' w s and tcb_at' t\<rbrace>
   setObject t (tcb::tcb)

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -598,7 +598,7 @@ proof -
         apply (rule corres_noop [where P=\<top> and P'=\<top>])
          apply wpsimp+
       apply (fastforce dest: pspace_relation_tcb_at
-                       simp: state_relation_def tcb_of'_def opt_map_def obj_at'_def projectKOs
+                       simp: state_relation_def opt_map_def obj_at'_def projectKOs
                       split: option.splits)
      apply clarsimp
     apply simp
@@ -2926,10 +2926,10 @@ lemma isSchedulable_wp:
   apply (wpsimp simp: hoare_vcg_if_lift2 obj_at_def is_tcb inReleaseQueue_def wp: threadGet_wp)
   apply (rule conjI)
    apply (fastforce simp: isSchedulable_bool_def isScActive_def obj_at'_def projectKOs
-                          pred_tcb_at'_def tcb_of'_def pred_map_simps in_opt_map_eq
+                          pred_tcb_at'_def pred_map_simps in_opt_map_eq
                    split: option.splits)
   apply (clarsimp simp: isSchedulable_bool_def isScActive_def obj_at'_def projectKOs
-                         pred_tcb_at'_def tcb_of'_def pred_map_simps in_opt_map_eq vs_all_heap_simps
+                         pred_tcb_at'_def pred_map_simps in_opt_map_eq vs_all_heap_simps
                  split: option.splits)
   by argo
 
@@ -2973,7 +2973,7 @@ lemma threadSet_isSchedulable_bool_nochange:
   unfolding isSchedulable_bool_def threadSet_def
   apply (rule hoare_seq_ext[OF _ getObject_tcb_sp])
   apply (wpsimp wp: setObject_tcb_wp simp: pred_map_def obj_at'_def opt_map_def projectKOs)
-  apply (fastforce simp: pred_map_def tcb_of'_def projectKOs isScActive_def)
+  apply (fastforce simp: pred_map_def projectKOs isScActive_def)
   done
 
 lemma threadSet_isSchedulable_bool:
@@ -2985,7 +2985,7 @@ lemma threadSet_isSchedulable_bool:
   unfolding isSchedulable_bool_def threadSet_def
   apply (rule hoare_seq_ext[OF _ getObject_tcb_sp])
   apply (wpsimp wp: setObject_tcb_wp simp: pred_map_def obj_at'_def opt_map_def projectKOs)
-  apply (fastforce simp: pred_map_def tcb_of'_def projectKOs isScActive_def)
+  apply (fastforce simp: pred_map_def projectKOs isScActive_def)
   done
 
 lemma setObject_queued_pred_tcb_at'[wp]:
@@ -3063,7 +3063,7 @@ lemma sts_sch_act':
                             (ksCurThread s \<noteq> t \<or> ksSchedulerAction s \<noteq> ResumeCurrentThread \<longrightarrow>
                                sch_act_wf (ksSchedulerAction s) s)"
            in hoare_post_imp)
-   apply (clarsimp simp: pred_tcb_at'_def tcb_of'_def obj_at'_def projectKOs pred_map_def)
+   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs pred_map_def)
   apply (simp only: imp_conv_disj)
   apply (wpsimp wp: threadSet_pred_tcb_at_state threadSet_sch_act_wf hoare_vcg_disj_lift)
   done
@@ -3083,7 +3083,7 @@ lemma sts_sch_act[wp]:
                             (ksCurThread s \<noteq> t \<or> ksSchedulerAction s \<noteq> ResumeCurrentThread \<longrightarrow>
                                sch_act_wf (ksSchedulerAction s) s)"
            in hoare_post_imp)
-   apply (clarsimp simp: pred_tcb_at'_def tcb_of'_def obj_at'_def projectKOs pred_map_def)
+   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs pred_map_def)
   apply (simp only: imp_conv_disj)
   apply (wpsimp wp: threadSet_pred_tcb_at_state threadSet_sch_act_wf hoare_vcg_disj_lift)
   apply (fastforce simp: sch_act_simple_def)
@@ -4738,7 +4738,7 @@ lemma rescheduleRequired_iflive'[wp]:
   apply (simp add: rescheduleRequired_def)
   apply (wpsimp wp: isSchedulable_wp)
   apply (erule if_live_then_nonz_capE')
-  apply (fastforce simp: isSchedulable_bool_def pred_map_def tcb_of'_def
+  apply (fastforce simp: isSchedulable_bool_def pred_map_def
                          ko_wp_at'_def obj_at'_def projectKO_eq projectKO_tcb)
   done
 

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -2910,14 +2910,14 @@ where
 abbreviation
   "ct_isSchedulable \<equiv> ct_active'
                        and (\<lambda>s. pred_map (\<lambda>tcb. \<not> tcbInReleaseQueue tcb) (tcbs_of' s) (ksCurThread s))
-                       and (\<lambda>s. pred_map (\<lambda>scPtr. isScActive scPtr s) (tcb_scs_of' s) (ksCurThread s))"
+                       and (\<lambda>s. pred_map (\<lambda>scPtr. isScActive scPtr s) (tcbSCs_of' s) (ksCurThread s))"
 
 definition
   isSchedulable_bool :: "machine_word \<Rightarrow> kernel_state \<Rightarrow> bool"
 where
   "isSchedulable_bool tcbPtr s'
     \<equiv> pred_map (\<lambda>tcb. runnable' (tcbState tcb) \<and> \<not>(tcbInReleaseQueue tcb)) (tcbs_of' s') tcbPtr
-      \<and> pred_map (\<lambda>scPtr. isScActive scPtr s') (tcb_scs_of' s') tcbPtr"
+      \<and> pred_map (\<lambda>scPtr. isScActive scPtr s') (tcbSCs_of' s') tcbPtr"
 
 lemma isSchedulable_wp:
   "\<lbrace>\<lambda>s. \<forall>t. isSchedulable_bool tcbPtr s = t \<and> tcb_at' tcbPtr s \<longrightarrow> P t s\<rbrace> isSchedulable tcbPtr \<lbrace>P\<rbrace>"
@@ -2979,7 +2979,7 @@ lemma threadSet_isSchedulable_bool_nochange:
 lemma threadSet_isSchedulable_bool:
   "\<lbrace>\<lambda>s. runnable' st
       \<and> pred_map (\<lambda>tcb. \<not>(tcbInReleaseQueue tcb)) (tcbs_of' s) t
-      \<and> pred_map (\<lambda>scPtr. isScActive scPtr s) (tcb_scs_of' s) t\<rbrace>
+      \<and> pred_map (\<lambda>scPtr. isScActive scPtr s) (tcbSCs_of' s) t\<rbrace>
    threadSet (tcbState_update (\<lambda>_. st)) t
    \<lbrace>\<lambda>_. isSchedulable_bool t\<rbrace>"
   unfolding isSchedulable_bool_def threadSet_def

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -254,7 +254,7 @@ lemma restart_invs':
               in hoare_strengthen_post[rotated])
         apply wpsimp
         apply (clarsimp simp: isSchedulable_bool_def pred_map_pred_conj[simplified pred_conj_def]
-                              projectKO_opt_tcb pred_map_def tcb_of'_Some pred_tcb_at'_def
+                              projectKO_opt_tcb pred_map_def pred_tcb_at'_def
                               obj_at'_real_def ko_wp_at'_def)
        apply (wpsimp wp: hoare_vcg_imp_lift')
       apply (rule_tac Q="\<lambda>_. invs' and

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -2446,7 +2446,8 @@ lemma tc_caps_invs':
   apply (wpsimp wp: hoare_vcg_all_lift hoare_weak_lift_imp setP_invs' setMCPriority_invs'
                     installTCBCap_invs' installThreadBuffer_invs' installTCBCap_sch_act_simple)
   apply (clarsimp cong: conj_cong)
-  apply (fastforce simp: isValidFaultHandler_def isCap_simps isValidVTableRoot_def)
+  apply (intro conjI; intro allI impI; clarsimp;
+         fastforce simp: isValidFaultHandler_def isCap_simps isValidVTableRoot_def)
   done
 
 lemma schedContextBindTCB_invs':
@@ -3011,9 +3012,6 @@ lemma get_sc_released_corres:
            apply (clarsimp simp: sc_relation_def active_sc_def)
           apply (clarsimp simp: state_relation_def)
          apply wpsimp+
-      apply (clarsimp simp: obj_at'_def)
-     apply (clarsimp simp: state_relation_def)
-     apply wpsimp+
    apply (fastforce simp: obj_at_def sc_at_pred_n_def is_obj_defs valid_obj_def)
   apply clarsimp
   done

--- a/spec/abstract/Ipc_A.thy
+++ b/spec/abstract/Ipc_A.thy
@@ -289,8 +289,8 @@ where
                 set_endpoint epptr $ (case queue of [] \<Rightarrow> IdleEP
                                                      | _ \<Rightarrow> RecvEP queue);
                 recv_state \<leftarrow> get_thread_state dest;
-                (reply, reply_can_grant) \<leftarrow> case recv_state
-                  of (BlockedOnReceive _ reply data) \<Rightarrow> return (reply, receiver_can_grant data)
+                reply \<leftarrow> case recv_state
+                  of (BlockedOnReceive _ reply data) \<Rightarrow> return reply
                   | _ \<Rightarrow> fail;
                 do_ipc_transfer thread (Some epptr) badge can_grant dest;
                 maybeM (reply_unlink_tcb dest) reply;
@@ -298,7 +298,7 @@ where
 
                 fault \<leftarrow> thread_get tcb_fault thread;
                 if call \<or> fault \<noteq> None then
-                  if (can_grant \<or> reply_can_grant) \<and> reply \<noteq> None then
+                  if (can_grant \<or> can_grant_reply) \<and> reply \<noteq> None then
                     reply_push thread dest (the reply) can_donate
                   else
                     set_thread_state thread Inactive

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -52,8 +52,6 @@ This module specifies the behavior of reply objects.
 
 > replyPush :: PPtr TCB -> PPtr TCB -> PPtr Reply -> Bool -> Kernel ()
 > replyPush callerPtr calleePtr replyPtr canDonate = do
->     stateAssert sym_refs_asrt
->         "replyPush: `sym_refs (state_refs_of' s)` must hold"
 >     stateAssert (valid_replies'_sc_asrt replyPtr)
 >         "replyPush: valid_replies'_sc holds for replyPtr"
 >     scPtrOptDonated <- threadGet tcbSchedContext callerPtr

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -580,8 +580,6 @@ This module uses the C preprocessor to select a target architecture.
 
 > schedContextDonate :: PPtr SchedContext -> PPtr TCB -> Kernel ()
 > schedContextDonate scPtr tcbPtr = do
->     stateAssert sym_refs_asrt
->         "Assert that `sym_refs (state_refs_of' s)` holds"
 >     sc <- getSchedContext scPtr
 >     fromOpt <- return $ scTCB sc
 >     when (fromOpt /= Nothing) $ do


### PR DESCRIPTION
**I recommend reviewing commit-by-commit.**

In this PR:

1. Update `send_ipc` (abstract) to match source. Fix AInvs.
2. Update `sendIPC` to be slightly easier for refinement.
3. Remove `sym_ref` assertions from `replyPush` and `schedContextDonate`
   a. These assertions can actually fail in executable code.
4. Fix up `refine` for these changes in Haskell
5. Some slight improvements to `replyPush` lemmas. 

As a side effect:
* 1 new heap
* many new `sym_refs` lemmas based on heaps.