### PR TITLE
rt replyRemoveTCB_corres

### DIFF
--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -1632,6 +1632,18 @@ lemma corres_noop_sr:
   apply (drule_tac x=b in spec, clarsimp)
   done
 
+lemma corres_noop_sr2:
+  assumes x: "\<And>s. P s  \<Longrightarrow> \<lbrace>(=) s\<rbrace> f \<exists>\<lbrace>\<lambda>r. (=) s\<rbrace>"
+  assumes sr: "sr_inv_ul sr P P' g"
+  assumes nf': "\<And>s. \<lbrakk> P s; nf' \<rbrakk> \<Longrightarrow> no_fail (\<lambda>s'. (s, s') \<in> sr \<and> P' s') g"
+  assumes nf : "nf \<Longrightarrow> no_fail P f"
+  shows "corres_underlying sr nf nf' dc P P' f g"
+  using sr x
+  apply (clarsimp simp: sr_inv_ul_def corres_underlying_def return_def)
+  apply (clarsimp simp: no_failD[OF nf'[simplified]] valid_def exs_valid_def)
+  apply (drule_tac x=a in meta_spec, fastforce)
+  done
+
 (* corres_symb_exec_r_sr basically combines the two lemmas corres_split_noop_rhs and corres_noop
    in one and separates out the sr_inv part *)
 lemma corres_symb_exec_r_sr:

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -172,7 +172,7 @@ lemma set_simple_ko_not_tcb_at[wp]:
   done
 
 lemma set_reply_obj_ref_not_tcb_at[wp]:
-  "set_reply_obj_ref f rp opt \<lbrace>\<lambda>s. \<not> ko_at (TCB tcb) t s\<rbrace>"
+  "set_reply_obj_ref f rp opt \<lbrace>\<lambda>s. P (ko_at (TCB tcb) t s)\<rbrace>"
   apply (clarsimp simp: update_sk_obj_ref_def)
   apply (wpsimp wp: set_simple_ko_wp get_simple_ko_wp)
   apply (clarsimp simp: obj_at_def sk_obj_at_pred_def pred_neg_def split: if_splits)


### PR DESCRIPTION
This PR contains the final cleaned-up version of the `replyRemoveTCB_corres` proof. Most part of it might have been reviewed elsewhere. The most notable thing perhaps is a simpler version of `sc_with_reply’` as suggested by Corey in #180 , but there isn’t so much change in the proof for that.

This also cleans up various corres rules for `setSchedContext`. A more (most?) generic version of `setSchedContext_corres` is added, and other existing versions are consolidated and derived from it.