### PR TITLE
trivial: fix c-parser link

### DIFF
--- a/tools/autocorres/README.md
+++ b/tools/autocorres/README.md
@@ -16,7 +16,7 @@ abstracts the result to produce a result that is (hopefully)
 more pleasant to reason about.
 
   [1]: https://www.cl.cam.ac.uk/research/hvg/Isabelle/
-  [2]: https://ts.data61.csiro.au/software/TS/c-parser.html
+  [2]: https://ts.data61.csiro.au/software/TS/c-parser/
 
 
 


### PR DESCRIPTION
This reverts commit 985ce0d28a87298427e9836055cfbad0751b13c5.