### PR TITLE
corres_whileLoop and awaken_corres (using reader monad)

### DIFF
--- a/lib/ExtraCorres.thy
+++ b/lib/ExtraCorres.thy
@@ -251,4 +251,87 @@ lemma wp_from_corres_unit:
   f' \<lbrace>\<lambda>_ s'. \<exists>s. (s,s') \<in> state_relation \<and> Q s \<and> Q' s'\<rbrace>"
   by (auto intro!: wp_from_corres_u_unit)
 
+lemma corres_whileLoop_results_helper:
+  assumes cond: "\<And>r r' s s'. \<lbrakk>rrel r r'; (s, s') \<in> srel; P s; P' s'\<rbrakk> \<Longrightarrow> C r s = C' r' s'"
+  assumes body_corres:
+           "\<And>r r'. rrel r r'
+                    \<Longrightarrow> corres_underlying srel False nf' rrel (P and C r) (P' and C' r') (B r) (B' r')"
+  assumes body_inv: "\<And>r. \<lbrace>P and C r\<rbrace> B r \<lbrace>\<lambda>_. P\<rbrace>" "\<And>r'. \<lbrace>P' and C' r'\<rbrace> B' r' \<lbrace>\<lambda>_. P'\<rbrace>"
+  shows "(rv', t') \<in> fst (whileLoop C' B' r' s')
+         \<Longrightarrow> \<forall>s r. (s,s') \<in> srel \<and> rrel r r' \<and> P s \<and> P' s'
+                   \<longrightarrow> (\<exists>rv t. (rv, t) \<in> fst (whileLoop C B r s) \<and> (t,t') \<in> srel \<and> rrel rv rv')"
+  apply (rule_tac r=r' and B=B' in in_whileLoop_induct)
+    apply simp
+   apply clarsimp
+   apply (rename_tac r_conc s_conc s_abs r_abs)
+   apply (prop_tac "\<not> C r_abs s_abs")
+    apply (fastforce simp: cond)
+   apply (force simp: whileLoop_def)
+  apply (thin_tac "_ \<in> fst _")
+  apply (rename_tac r s' r' t' r'' u')
+  apply clarsimp
+  apply (rename_tac s r_abs)
+  apply (insert body_corres)
+  apply (drule_tac x=r_abs in meta_spec)
+  apply (drule_tac x=r in meta_spec)
+  apply clarsimp
+  apply (prop_tac "C r_abs s")
+   apply (fastforce dest: cond)
+  apply (prop_tac "\<exists>rv t. (rv,t) \<in> fst (B r_abs s) \<and> rrel rv r' \<and> (t,t') \<in> srel")
+   apply (fastforce simp: corres_underlying_def)
+  apply clarsimp
+  apply (rename_tac rv t)
+  apply (clarsimp simp: pred_conj_def)
+  apply (prop_tac "P t \<and> P' t'")
+   apply (metis body_inv pred_andI use_valid)
+  apply (drule_tac x=t and y=rv in spec2)
+  apply clarsimp
+  apply (rename_tac rv' t'')
+  apply (rule_tac x=rv' in exI)
+  apply (rule_tac x=t'' in exI)
+  apply (simp add: cond whileLoop_def whileLoop_results.intros)
+  done
+
+lemma corres_whileLoop_no_fail_helper:
+  assumes body_guard: "\<And>r'. \<lbrace>P' and C' r'\<rbrace> B' r' \<lbrace>\<lambda>_. P'\<rbrace>"
+  assumes nf': "\<And>r'. no_fail (P' and C' r') (B' r')"
+  assumes termin: "\<And>r' s'. P' s' \<Longrightarrow> whileLoop_terminates C' B' r' s'"
+  shows "P' s \<Longrightarrow> \<not> snd (whileLoop C' B' r' s)"
+  apply (rule_tac I="\<lambda>_ s. P' s"
+              and R="{((r', s'), r, s). C' r s \<and> (r', s') \<in> fst (B' r s)
+                                        \<and> whileLoop_terminates C' B' r s}"
+               in not_snd_whileLoop)
+    apply simp
+   apply (clarsimp simp: validNF_def)
+   apply (intro conjI)
+    apply (intro hoare_vcg_conj_lift_pre_fix; (solves wpsimp)?)
+      apply (insert assms)
+      apply (fastforce simp: valid_def)
+     apply (clarsimp simp: valid_def)
+    apply wpsimp
+   apply (fastforce intro: no_fail_pre)
+  apply (fastforce intro: wf_subset[OF whileLoop_terminates_wf[where C=C' and B=B']])
+  done
+
+lemma corres_whileLoop:
+  assumes cond: "\<And>r r' s s'. \<lbrakk>rrel r r'; (s, s') \<in> srel; P s; P' s'\<rbrakk> \<Longrightarrow> C r s = C' r' s'"
+  assumes body_corres:
+           "\<And>r r'. rrel r r'
+                    \<Longrightarrow> corres_underlying srel False nf' rrel (P and C r) (P' and C' r') (B r) (B' r')"
+  assumes body_guard: "\<And>r. \<lbrace>P and C r\<rbrace> B r \<lbrace>\<lambda>_. P\<rbrace>" "\<And>r'. \<lbrace>P' and C' r'\<rbrace> B' r' \<lbrace>\<lambda>_. P'\<rbrace>"
+  assumes rel: "rrel r r'"
+  assumes nf': "\<And>r'. no_fail (P' and C' r') (B' r')"
+  assumes termin: "\<And>r' s'. P' s' \<Longrightarrow> whileLoop_terminates C' B' r' s'"
+  shows "corres_underlying srel False nf' rrel P P' (whileLoop C B r) (whileLoop C' B' r')"
+  apply (rule corres_no_failI)
+   apply (simp add: no_fail_def)
+   apply (intro allI impI)
+   apply (insert assms)
+   apply (rule corres_whileLoop_no_fail_helper; blast)
+  apply clarsimp
+  apply (frule_tac C=C and P=P and P'=P' and rrel=rrel and srel=srel
+                in corres_whileLoop_results_helper[rotated 4])
+      apply fastforce+
+  done
+
 end

--- a/lib/Monad_WP/NonDetMonadVCG.thy
+++ b/lib/Monad_WP/NonDetMonadVCG.thy
@@ -1210,6 +1210,10 @@ lemma hoare_vcg_conj_lift:
   apply (rule hoare_pre_imp [OF _ y], simp)
   done
 
+\<comment> \<open>A variant which works nicely with subgoals that do not contain schematics\<close>
+lemmas hoare_vcg_conj_lift_pre_fix
+  = hoare_vcg_conj_lift[where P=R and P'=R for R, simplified]
+
 lemma hoare_vcg_conj_liftE1:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow>
   \<lbrace>P and P'\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> Q' r s\<rbrace>,\<lbrace>E\<rbrace>"

--- a/lib/Monad_WP/OptionMonadWP.thy
+++ b/lib/Monad_WP/OptionMonadWP.thy
@@ -220,7 +220,7 @@ lemma no_ofailD:
 lemma no_ofail_obind2 [simp]:
   assumes f: "no_ofail P f"
   assumes v: "o\<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>"
-  assumes g: "\<forall>r. no_ofail (R r) (g r)"
+  assumes g: "\<And>r. no_ofail (R r) (g r)"
   shows "no_ofail (P and Q) (f |>> g)"
   using v g
   by (fastforce simp: no_ofail_def obind_def pred_conj_def ovalid_def dest: no_ofailD [OF f])

--- a/lib/Monad_WP/WhileLoopRules.thy
+++ b/lib/Monad_WP/WhileLoopRules.thy
@@ -416,6 +416,11 @@ lemma whileLoop_wp:
   \<lbrace> I r \<rbrace> whileLoop C B r \<lbrace> Q \<rbrace>"
   by (rule valid_whileLoop)
 
+lemma whileLoop_wp':
+  "(\<And>r. \<lbrace> \<lambda>s. I r s \<and> C r s \<rbrace> B r \<lbrace> I \<rbrace>) \<Longrightarrow> \<lbrace> I r \<rbrace> whileLoop C B r \<lbrace> I \<rbrace>"
+  apply (fastforce intro: whileLoop_wp)
+  done
+
 lemma whileLoop_wp_inv [wp]:
   "\<lbrakk> \<And>r. \<lbrace>\<lambda>s. I r s \<and> C r s\<rbrace> B r \<lbrace>I\<rbrace>; \<And>r s. \<lbrakk>I r s; \<not> C r s\<rbrakk> \<Longrightarrow> Q r s \<rbrakk>
       \<Longrightarrow> \<lbrace> I r \<rbrace> whileLoop_inv C B r I M \<lbrace> Q \<rbrace>"

--- a/lib/NonDetMonadLemmaBucket.thy
+++ b/lib/NonDetMonadLemmaBucket.thy
@@ -3030,6 +3030,12 @@ lemma monad_commute_simple:
   apply (simp add:bind_assoc)
   done
 
+lemma monad_commute_simple':
+  "monad_commute \<top> a b \<Longrightarrow> (do x \<leftarrow> a; y \<leftarrow> b; g x y od) = (do y \<leftarrow> b; x \<leftarrow> a; g x y od)"
+  apply (clarsimp simp: monad_commute_def)
+  apply (fastforce simp: bind_def' return_def)
+  done
+
 lemma commute_commute:
   "monad_commute P f h \<Longrightarrow> monad_commute P h f"
   apply (simp (no_asm) add: monad_commute_def)

--- a/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
@@ -1635,13 +1635,10 @@ crunch valid_pdpt[wp]: sc_and_timer "valid_pdpt_objs::det_state \<Rightarrow> _"
 crunch valid_pdpt[wp]: schedule_choose_new_thread "valid_pdpt_objs"
   (simp: Let_def wp: hoare_drop_imp)
 
-crunch valid_pdpt[wp]: activate_thread,switch_to_thread,
-       switch_to_idle_thread "valid_pdpt_objs"
+crunch valid_pdpt[wp]: activate_thread, switch_to_thread, switch_to_idle_thread,
+                       awaken "valid_pdpt_objs"
   (simp: crunch_simps
    wp: crunch_wps alternative_valid select_wp OR_choice_weak_wp select_ext_weak_wp)
-
-crunch valid_pdpt[wp]: awaken "valid_pdpt_objs"
-  (wp: hoare_drop_imp mapM_x_wp')
 
 crunch valid_pdpt[wp]: handle_call, handle_recv, handle_send, handle_yield,
  handle_interrupt, handle_vm_fault, handle_hypervisor_fault

--- a/proof/invariant-abstract/BCorres_AI.thy
+++ b/proof/invariant-abstract/BCorres_AI.thy
@@ -126,6 +126,12 @@ lemma read_object_truncate[simp]: "read_object a (truncate_state s) = read_objec
 lemma get_tcb_truncate[simp]: "get_tcb a (truncate_state s) = get_tcb a s"
   by (simp add: get_tcb_def)
 
+lemma read_sched_context_truncate[simp]: "read_sched_context a (truncate_state s) = read_sched_context a s"
+  by (simp add: read_sched_context_def obind_def omonad_defs split: kernel_object.splits option.splits)
+
+lemma read_sc_refill_ready_truncate[simp]: "read_sc_refill_ready a (truncate_state s) = read_sc_refill_ready a s"
+  by (simp add: read_sc_refill_ready_def obind_def omonad_defs split: option.splits)
+
 lemma in_release_queue_truncate[simp]:
   "in_release_queue t (truncate_state s) = in_release_queue t s"
   by (simp add: in_release_queue_def)
@@ -141,6 +147,10 @@ lemma set_tcb_queue_bcorres[wp]:
   apply (simp cong: if_cong)
   done
 
+lemma get_sc_refill_ready_bcorres[wp]:
+  "bcorres (get_sc_refill_ready scp) (get_sc_refill_ready scp)"
+  by (wpsimp simp: get_sc_refill_ready_def gets_the_def)
+
 crunch (bcorres)bcorres[wp]:
   cancel_all_ipc, bind_notification, cancel_all_signals
   truncate_state
@@ -155,8 +165,6 @@ lemma unbind_maybe_notification_bcorres[wp]:
 lemma unbind_notification_bcorres[wp]:
   "bcorres (unbind_notification a) (unbind_notification a)"
   by (wpsimp simp: unbind_notification_def maybeM_def)
-
-crunch (bcorres)bcorres[wp]: set_reply truncate_state (simp: gets_the_def ignore: gets_the)
 
 (*
 lemma fast_finalise_bcorres[wp]:

--- a/proof/invariant-abstract/Bits_AI.thy
+++ b/proof/invariant-abstract/Bits_AI.thy
@@ -8,7 +8,7 @@ theory Bits_AI
 imports "./$L4V_ARCH/ArchBits_AI"
 begin
 
-lemmas crunch_wps = hoare_drop_imps mapM_wp' mapM_x_wp'
+lemmas crunch_wps = hoare_drop_imps mapM_wp' mapM_x_wp' whileLoop_wp'
 
 lemmas crunch_simps = split_def whenE_def unlessE_def Let_def if_fun_split
                       assertE_def zipWithM_mapM zipWithM_x_mapM

--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -168,8 +168,12 @@ lemma rec_del_domain_list[wp]:
 crunch domain_list_inv[wp]: cap_delete, activate_thread "\<lambda>s::det_state. P (domain_list s)"
   (wp: hoare_drop_imp)
 
-crunch domain_list_inv[wp]: awaken "\<lambda>s. P (domain_list s)"
-  (wp: hoare_drop_imp dxo_wp_weak mapM_x_wp simp: Let_def)
+crunch domain_list_inv[wp]: possible_switch_to "\<lambda>s. P (domain_list s)"
+  (simp: get_tcb_obj_ref_def wp: hoare_vcg_if_lift2 hoare_drop_imp)
+
+crunches awaken
+  for domain_list_inv[wp]: "\<lambda>s. P (domain_list s)"
+  (wp: crunch_wps)
 
 crunch domain_list_inv[wp]: commit_time "\<lambda>s. P (domain_list s)"
   (simp: Let_def wp: get_sched_context_wp get_refills_wp wp: crunch_wps)

--- a/proof/invariant-abstract/EmptyFail_AI.thy
+++ b/proof/invariant-abstract/EmptyFail_AI.thy
@@ -444,6 +444,7 @@ crunch (empty_fail) empty_fail[wp]:
 
 crunch (empty_fail) empty_fail[wp, intro!, simp]:
   possible_switch_to, awaken, schedule_switch_thread_fastfail
+  (wp: empty_fail_whileLoop)
 
 crunch (empty_fail) empty_fail[wp, intro!, simp]: sc_and_timer
   (wp: empty_fail_setDeadline simp: Let_def)

--- a/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
@@ -330,14 +330,14 @@ lemma handle_invocation_valid_vspace_objs'[wp]:
 crunches activate_thread,switch_to_thread, handle_hypervisor_fault,
          switch_to_idle_thread, handle_call, handle_recv, handle_vm_fault,
          handle_send, handle_yield, handle_interrupt, check_budget_restart, update_time_stamp,
-         schedule_choose_new_thread, activate_thread, switch_to_thread, awaken
+         schedule_choose_new_thread, activate_thread, switch_to_thread
   for valid_vspace_objs'[wp]: "valid_vspace_objs'"
   (simp: crunch_simps wp: crunch_wps
    ignore: without_preemption getActiveIRQ resetTimer ackInterrupt update_sk_obj_ref)
 
-crunches sc_and_timer
+crunches awaken, sc_and_timer
   for valid_vspace_objs'[wp]: "valid_vspace_objs'"
-  (wp: hoare_drop_imps hoare_vcg_if_lift2)
+  (wp: hoare_drop_imps hoare_vcg_if_lift2 crunch_wps)
 
 lemma schedule_valid_vspace_objs'[wp]:
   "\<lbrace>valid_vspace_objs'\<rbrace> schedule :: (unit,unit) s_monad \<lbrace>\<lambda>_. valid_vspace_objs'\<rbrace>"

--- a/proof/invariant-abstract/RealTime_AI.thy
+++ b/proof/invariant-abstract/RealTime_AI.thy
@@ -1024,12 +1024,30 @@ lemma get_sc_refill_sufficient_wp[wp]:
    \<lbrace>Q\<rbrace>"
  by (wpsimp simp: get_sc_refill_sufficient_def)
 
+lemma read_sched_context_SomeD:
+  "read_sched_context scp s = Some sc \<Longrightarrow> \<exists>n. kheap s scp = Some (SchedContext sc n)"
+  by (clarsimp simp: read_sched_context_def split: kernel_object.split_asm)
+
+lemma read_sched_context_NoneD:
+  "read_sched_context scp s = None \<Longrightarrow> \<not>(\<exists>n sc. kheap s scp = Some (SchedContext sc n))"
+  by (clarsimp simp: read_sched_context_def obind_def split: kernel_object.split_asm)
+
+lemma read_sc_refill_ready_SomeD:
+  "read_sc_refill_ready scp s = Some b
+   \<Longrightarrow> \<exists>sc. read_sched_context scp s = Some sc \<and> sc_refill_ready (cur_time s) sc = b"
+  by (clarsimp simp: read_sc_refill_ready_def asks_def)
+
+lemma read_sc_refill_ready_NoneD:
+  "read_sc_refill_ready scp s = None \<Longrightarrow> read_sched_context scp s = None"
+  by (clarsimp simp: read_sc_refill_ready_def obind_def asks_def split: option.split_asm)
+
 lemma get_sc_refill_ready_wp[wp]:
   "\<lbrace>\<lambda>s. \<forall>sc n. ko_at (SchedContext sc n) scp s \<longrightarrow>
          Q (sc_refill_ready (cur_time s) sc) s\<rbrace>
    get_sc_refill_ready scp
    \<lbrace>Q\<rbrace>"
- by (wpsimp simp: get_sc_refill_ready_def)
+ by (wpsimp simp: get_sc_refill_ready_def obj_at_def)
+    (clarsimp dest!: read_sc_refill_ready_SomeD read_sched_context_SomeD)
 
 lemma get_sc_released_wp[wp]:
   "\<lbrace>\<lambda>s. \<forall> sc n. ko_at (SchedContext sc n) scp s \<longrightarrow>

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -50,9 +50,9 @@ lemma next_domain_scheduler_action[wp]:
   unfolding next_domain_def
   by (wpsimp simp: Let_def)
 
-lemma awaken_invs[wp]:
-  "awaken \<lbrace> invs \<rbrace>"
-  unfolding awaken_def by (wpsimp wp: mapM_x_wp' hoare_drop_imp)
+crunches awaken
+  for invs[wp]: invs
+  (wp: crunch_wps simp: tcb_release_dequeue_def)
 
 lemma set_scheduler_action_valid_state_cur_tcb [wp]:
   "\<lbrace>invs\<rbrace> set_scheduler_action action \<lbrace>\<lambda>_ s. valid_state s \<and> cur_tcb s\<rbrace>"
@@ -156,8 +156,10 @@ declare sc_and_timer_activatable[wp]
 
 lemma awaken_schact_not_rct[wp]:
   "awaken \<lbrace>\<lambda>s. scheduler_action s \<noteq> resume_cur_thread\<rbrace>"
-  unfolding awaken_def possible_switch_to_def
-  by (wpsimp wp: mapM_x_wp_inv hoare_drop_imp simp: set_scheduler_action_def)
+  unfolding awaken_def awaken_body_def tcb_release_dequeue_def possible_switch_to_def
+  apply (rule whileLoop_wp)
+   apply (wpsimp wp: hoare_drop_imps simp: set_scheduler_action_def)+
+  done
 
 crunches awaken
   for ct_in_state[wp]: "ct_in_state P"

--- a/proof/invariant-abstract/TcbAcc_AI.thy
+++ b/proof/invariant-abstract/TcbAcc_AI.thy
@@ -22,6 +22,20 @@ declare user_getreg_inv[wp]
 
 end
 
+lemma thread_read_SomeD:
+  "thread_read f tp s = Some p \<Longrightarrow> \<exists>tcb. kheap s tp = Some (TCB tcb) \<and> f tcb = p"
+  by (clarsimp simp: thread_read_def oliftM_def dest!: get_tcb_SomeD)
+
+lemma read_tcb_obj_ref_SomeD:
+  "read_tcb_obj_ref f tp s = Some p \<Longrightarrow> \<exists>tcb. kheap s tp = Some (TCB tcb) \<and> f tcb = p"
+  by (clarsimp simp: read_tcb_obj_ref_def dest!: thread_read_SomeD)
+
+lemma read_tcb_obj_ref_NoneD:
+  "read_tcb_obj_ref f tp s = None
+   \<Longrightarrow> \<not> (\<exists>tcb. kheap s tp = Some (TCB tcb))"
+  by (clarsimp simp: read_tcb_obj_ref_def oliftM_def obind_def thread_read_def get_tcb_def
+              split: option.split_asm)
+
 declare global_refs_kheap[simp]
 
 locale TcbAcc_AI_storeWord_invs =

--- a/proof/refine/ARM/EmptyFail_H.thy
+++ b/proof/refine/ARM/EmptyFail_H.thy
@@ -117,10 +117,6 @@ lemma empty_fail_getObject_reply [intro!, wp, simp]:
   "empty_fail (getObject p :: reply kernel)"
   by (simp add: empty_fail_getObject)
 
-lemma empty_fail_getObject_sc [intro!, wp, simp]:
-  "empty_fail (getObject p :: sched_context kernel)"
-  by (simp add: empty_fail_getObject)
-
 lemma getEndpoint_empty_fail [intro!, wp, simp]:
   "empty_fail (getEndpoint ep)"
   by (simp add: getEndpoint_def)
@@ -188,7 +184,12 @@ lemma ignoreFailure_empty_fail[intro!, wp, simp]:
   "empty_fail x \<Longrightarrow> empty_fail (ignoreFailure x)"
   by (simp add: ignoreFailure_def empty_fail_catch)
 
+lemma empty_fail_getObject_sc [intro!, wp, simp]:
+   "empty_fail (getObject p :: sched_context kernel)"
+   by (simp add: empty_fail_getObject)
+
 crunch (empty_fail) "_H_empty_fail"[intro!, wp, simp]: "SchedContextDecls_H.postpone"
+  (simp: getSchedContext_def)
 
 crunch (empty_fail) empty_fail[intro!, wp, simp]:
   cancelIPC, setThreadState, tcbSchedDequeue, isStopped, possibleSwitchTo, tcbSchedAppend,
@@ -285,8 +286,13 @@ crunch (empty_fail) empty_fail[intro!, wp, simp]:
   chooseThread, getDomainTime, nextDomain, isHighestPrio, switchSchedContext, setNextInterrupt
   (wp: empty_fail_catch empty_fail_setDeadline)
 
-crunch (empty_fail) "_H_empty_fail"[intro!, wp, simp]: "TCBDecls_H.awaken"
-  (ignore_del: ThreadDecls_H.suspend)
+crunch (empty_fail) empty_fail[intro!, wp, simp]: tcbReleaseDequeue
+
+lemma awaken_empty_fail[intro!, wp, simp]:
+  "empty_fail awaken"
+  apply (clarsimp simp: awaken_def awakenBody_def)
+  apply (wpsimp wp: empty_fail_whileLoop)
+  done
 
 lemma ThreadDecls_H_schedule_empty_fail[intro!, wp, simp]:
   "empty_fail schedule"

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -660,8 +660,7 @@ definition valid_sched_context' :: "sched_context \<Rightarrow> kernel_state \<R
      \<and> valid_bound_reply' (scReply sc) s
      \<and> MIN_REFILLS \<le> length (scRefills sc)
      \<and> scRefillMax sc \<le> length (scRefills sc)
-     \<and> (0 < scRefillMax sc \<longrightarrow>
-          scRefillHead sc < scRefillMax sc \<and> scRefillCount sc \<le> scRefillMax sc)"
+     \<and> (0 < scRefillMax sc \<longrightarrow> scRefillHead sc < scRefillMax sc \<and> scRefillCount sc \<le> scRefillMax sc)"
 
 definition valid_reply' :: "reply \<Rightarrow> kernel_state \<Rightarrow> bool" where
   "valid_reply' reply s \<equiv>

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -2136,103 +2136,6 @@ crunches inReleaseQueue
   and cur_tcb'[wp]: cur_tcb'
   and if_live_then_nonz_cap'[wp]: if_live_then_nonz_cap'
 
-crunches possibleSwitchTo
-  for valid_pspace'[wp]: valid_pspace'
-  and valid_queues[wp]: valid_queues
-  and valid_tcbs'[wp]: valid_tcbs'
-  and cap_to'[wp]: "ex_nonz_cap_to' p"
-  and ifunsafe'[wp]: "if_unsafe_then_cap'"
-  and global_refs'[wp]: valid_global_refs'
-  and valid_machine_state'[wp]: valid_machine_state'
-  and cur[wp]: cur_tcb'
-  and valid_queues'[wp]: valid_queues'
-  and valid_release_queue[wp]: valid_release_queue
-  and valid_release_queue'[wp]: valid_release_queue'
-  and refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-  and replies_of'[wp]: "\<lambda>s. P (replies_of' s)"
-  and idle'[wp]: "valid_idle'"
-  and valid_arch'[wp]: valid_arch_state'
-  and irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  and sc_at'_n[wp]: "\<lambda>s. P (sc_at'_n n p s)"
-  and ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  and ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
-  and irq_states' [wp]: valid_irq_states'
-  and pde_mappings' [wp]: valid_pde_mappings'
-  and pspace_domain_valid[wp]: "pspace_domain_valid"
-  and ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-  and ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
-  and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-  and gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-  and valid_objs'[wp]: valid_objs'
-  and ksArchState[wp]: "\<lambda>s. P (ksArchState s)"
-  and ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
-  and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
-  and valid_irq_handlers'[wp]: valid_irq_handlers'
-  (wp: crunch_wps cur_tcb_lift valid_irq_handlers_lift'' simp: crunch_simps)
-
-global_interpretation possibleSwitchTo: typ_at_all_props' "possibleSwitchTo target"
-  by typ_at_props'
-
-lemma possibleSwitchTo_sch_act[wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s \<and> st_tcb_at' runnable' t s\<rbrace>
-   possibleSwitchTo t
-   \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (wpsimp simp: possibleSwitchTo_def wp: inReleaseQueue_wp threadGet_wp)
-  by (fastforce simp: obj_at'_def tcb_in_cur_domain'_def)
-
-lemma possibleSwitchTo_weak_sch_act[wp]:
-  "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s \<and> st_tcb_at' runnable' t s\<rbrace>
-   possibleSwitchTo t
-   \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  unfolding possibleSwitchTo_def
-  apply (wpsimp wp: inReleaseQueue_wp threadGet_wp rescheduleRequired_weak_sch_act_wf)
-  by (auto simp: obj_at'_def weak_sch_act_wf_def tcb_in_cur_domain'_def
-                 projectKO_eq ps_clear_domE)
-
-lemma possibleSwitchTo_iflive'[wp]:
-  "\<lbrace>if_live_then_nonz_cap' and ex_nonz_cap_to' t
-      and (\<lambda>s. \<forall>t. ksSchedulerAction s = SwitchToThread t
-                   \<longrightarrow> st_tcb_at' runnable' t s)\<rbrace>
-   possibleSwitchTo t
-   \<lbrace>\<lambda>rv. if_live_then_nonz_cap'\<rbrace>"
-  by (wpsimp simp: possibleSwitchTo_def inReleaseQueue_def
-               wp: hoare_vcg_if_lift2 hoare_drop_imps)
-
-lemma possibleSwitchTo_ct_idle_or_in_cur_domain'[wp]:
-  "possibleSwitchTo t \<lbrace>ct_idle_or_in_cur_domain'\<rbrace>"
-  apply (wpsimp simp: possibleSwitchTo_def
-                  wp: threadGet_wp inReleaseQueue_wp)
-  apply (fastforce simp: obj_at'_def ct_idle_or_in_cur_domain'_def)
-  done
-
-lemma possibleSwitchTo_utr[wp]:
-  "possibleSwitchTo t \<lbrace>untyped_ranges_zero'\<rbrace>"
-  by (wpsimp simp: cteCaps_of_def o_def wp: untyped_ranges_zero_lift)
-
-lemma possibleSwitchTo_all_invs_but_ct_not_inQ':
-  "\<lbrace>\<lambda>s. all_invs_but_ct_not_inQ' s \<and> st_tcb_at' runnable' t s
-        \<and> valid_objs' s \<and> weak_sch_act_wf (ksSchedulerAction s) s
-        \<and> sch_act_simple s \<and> ex_nonz_cap_to' t s\<rbrace>
-   possibleSwitchTo t
-   \<lbrace>\<lambda>_. all_invs_but_ct_not_inQ'\<rbrace>"
-  apply wp
-   apply (rule hoare_use_eq_irq_node', wp)
-   apply (wpsimp wp: typ_at_lift_valid_irq_node' valid_irq_handlers_lift'
-                     cteCaps_of_ctes_of_lift irqs_masked_lift)
-  apply clarsimp
-  apply (intro conjI; fastforce?)
-  by (metis fold_list_refs_of_replies')
-
-lemma possibleSwitchTo_sch_act_not_other:
-  "\<lbrace>\<lambda>s. sch_act_not t' s \<and> t' \<noteq> t\<rbrace>
-   possibleSwitchTo t
-   \<lbrace>\<lambda>_. sch_act_not t'\<rbrace>"
-  apply (clarsimp simp: possibleSwitchTo_def)
-  apply (wpsimp wp: threadGet_wp inReleaseQueue_wp)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
 (* FIXME RT: move to AInvs *)
 lemma restart_thread_if_no_fault_reply_tcb_reply_at[wp]:
   "restart_thread_if_no_fault t \<lbrace>reply_tcb_reply_at ((=) (Some t')) r_opt\<rbrace>"
@@ -2387,7 +2290,7 @@ lemma cancel_all_ipc_corres_helper:
            apply (clarsimp simp: vs_all_heap_simps obj_at_def is_tcb_def)
           apply clarsimp
          apply (fold cancel_all_ipc_loop_body_def)
-         apply (intro hoare_vcg_conj_lift_left_fix
+         apply (intro hoare_vcg_conj_lift_pre_fix
                 ; (solves \<open>wpsimp wp: gts_wp simp: cancel_all_ipc_loop_body_def\<close>)?)
           apply (wpsimp wp: restart_thread_if_no_fault_tcb_sts_of_other
                             reply_unlink_tcb_tcb_sts_of_other gts_wp
@@ -2511,7 +2414,7 @@ proof -
           apply (rule_tac Q="?abs_guard list" in hoare_weaken_pre)
            apply (rule hoare_strengthen_post)
             apply (rule ball_mapM_x_scheme)
-              apply (intro hoare_vcg_conj_lift_left_fix
+              apply (intro hoare_vcg_conj_lift_pre_fix
                      ; (solves \<open>wpsimp wp: gts_wp simp: cancel_all_ipc_loop_body_def\<close>)?)
                apply (wpsimp wp: restart_thread_if_no_fault_tcb_sts_of_other
                                  reply_unlink_tcb_tcb_sts_of_other gts_wp

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -3811,14 +3811,21 @@ lemma no_ofail_readCurTime[simp]:
   "no_ofail \<top> readCurTime"
   unfolding readCurTime_def by clarsimp
 
-lemma ovalid_readCurTime:
+lemma ovalid_readCurTime[wp]:
   "o\<lbrace>\<lambda>s. P (ksCurTime s) s\<rbrace> readCurTime \<lbrace>\<lambda>r s. P r s \<and> r = ksCurTime s\<rbrace>"
   by (simp add: readCurTime_def asks_def obind_def ovalid_def)
+
+lemma ovalid_readRefillReady[rule_format, simp]:
+  "ovalid (\<lambda>s. \<forall>ko. ko_at' ko scp s \<longrightarrow> P (rTime (refillHd ko) \<le> ksCurTime s + kernelWCETTicks) s)
+              (readRefillReady scp) P"
+  unfolding readRefillReady_def readSchedContext_def ovalid_def
+  by (fastforce simp: obind_def split: option.split_asm
+                dest: use_ovalid[OF ovalid_readCurTime])
 
 lemma refillReady_wp:
   "\<lbrace>\<lambda>s. \<forall>ko. ko_at' ko scp s \<longrightarrow> P (rTime (refillHd ko) \<le> ksCurTime s + kernelWCETTicks) s\<rbrace> refillReady scp \<lbrace>P\<rbrace>"
   unfolding refillReady_def
-  by wp
+  by wpsimp (drule use_ovalid[OF ovalid_readRefillReady])
 
 lemma scActive_wp:
   "\<lbrace>\<lambda>s. \<forall>ko. ko_at' ko scp s \<longrightarrow> P (0 < scRefillMax ko) s\<rbrace> scActive scp \<lbrace>P\<rbrace>"

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -2174,10 +2174,14 @@ lemma handleInterrupt_valid_duplicates'[wp]:
           |wpc|simp add: handleReservedIRQ_def maskIrqSignal_def)+
   done
 
+crunches awaken
+  for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
+  (wp: crunch_wps)
+
 crunch valid_duplicates' [wp]:
   schedule "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
   (ignore: setNextPC clearExMonitor threadSet simp: crunch_simps
-   wp: whileM_inv findM_inv hoare_drop_imps)
+   wp: hoare_drop_imps)
 
 lemma activate_sch_valid_duplicates'[wp]:
   "\<lbrace>\<lambda>s. ct_in_state' activatable' s \<and> vs_valid_duplicates' (ksPSpace s)\<rbrace>

--- a/proof/refine/ARM/SchedContext_R.thy
+++ b/proof/refine/ARM/SchedContext_R.thy
@@ -40,6 +40,11 @@ lemma valid_sched_context_size'_scConsumed_update[simp]:
   "valid_sched_context_size' (scConsumed_update f sc') = valid_sched_context_size' sc'"
   by (clarsimp simp: valid_sched_context_size'_def objBits_simps)
 
+lemma readSchedContext_SomeD:
+  "readSchedContext scp s = Some sc'
+   \<Longrightarrow> ksPSpace s scp = Some (KOSchedContext sc')"
+  by (clarsimp simp: readSchedContext_def asks_def obj_at'_def projectKOs)
+
 lemma sym_refs_tcbSchedContext:
   "\<lbrakk>ko_at' tcb tcbPtr s; sym_refs (state_refs_of' s); tcbSchedContext tcb = Some scPtr\<rbrakk>
    \<Longrightarrow> obj_at' (\<lambda>sc. scTCB sc = Some tcbPtr) scPtr s"

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -18,6 +18,10 @@ declare empty_fail_sequence_x[simp]
 declare storeWordUser_typ_at' [wp]
 declare complement_def[simp]
 
+lemma threadRead_SomeD:
+  "threadRead f t s = Some y \<Longrightarrow> \<exists>tcb. ko_at' tcb t s \<and> y = f tcb"
+  by (fastforce simp: threadRead_def oliftM_def)
+
 (* Auxiliaries and basic properties of priority bitmap functions *)
 
 lemma countLeadingZeros_word_clz[simp]:
@@ -2369,6 +2373,27 @@ lemma weak_valid_sched_action_strg:
                       obj_at_kh_kheap_simps vs_all_heap_simps is_tcb_def
                split: Structures_A.kernel_object.splits)
 
+lemma gets_the_exs_valid:
+  "bound (m s) \<Longrightarrow> \<lbrace>(=) s\<rbrace> gets_the m \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
+  by (clarsimp simp: bind_def assert_opt_def fail_def
+                     gets_def get_def return_def exs_valid_def gets_the_def
+              split: option.splits)
+
+lemma no_ofail_get_tcb[wp]:
+  "no_ofail (tcb_at tp) (get_tcb tp)"
+  unfolding get_tcb_def no_ofail_def
+  by (clarsimp simp: obj_at_def is_tcb split: option.splits)
+
+lemma no_ofail_read_sched_context[wp]:
+  "no_ofail (\<lambda>s. \<exists>sc n. kheap s scp = Some (Structures_A.SchedContext sc n)) (read_sched_context scp)"
+  unfolding read_sched_context_def no_ofail_def
+  by (clarsimp simp: obj_at_def is_sc_obj obind_def)
+
+lemma no_ofail_read_sc_refill_ready:
+  "no_ofail (\<lambda>s. \<exists>sc n. kheap s scp = Some (Structures_A.SchedContext sc n)) (read_sc_refill_ready scp)"
+  unfolding read_sc_refill_ready_def no_ofail_def
+  by (clarsimp simp: omonad_defs obind_def dest!: no_ofailD[OF no_ofail_read_sched_context])
+
 lemma rescheduleRequired_corres_weak:
   "corres dc (valid_tcbs and weaker_valid_sched_action and pspace_aligned and pspace_distinct)
              (valid_tcbs' and Invariants_H.valid_queues and valid_queues' and valid_release_queue_iff)
@@ -2408,12 +2433,12 @@ lemma rescheduleRequired_corres_weak:
                    split: option.splits Structures_A.kernel_object.splits)
 
   apply (rule corres_symb_exec_l[OF _ _ get_sc_refill_ready_sp, rotated])
-    apply (wpsimp wp: get_sched_context_exs_valid
-                simp: get_sc_refill_ready_def obj_at_def)
+    apply (wpsimp wp: get_sched_context_exs_valid gets_the_exs_valid
+                simp: get_sc_refill_ready_def)
+     apply (clarsimp intro!: no_ofailD[OF no_ofail_read_sc_refill_ready] simp: obj_at_def is_sc_obj)
+    apply simp
    apply (wpsimp wp: get_sched_context_no_fail simp: get_sc_refill_ready_def)
-   apply (fastforce simp: valid_tcbs_def valid_tcb_def obj_at_def is_schedulable_opt_def get_tcb_def
-                          is_sc_active_def is_sc_obj_def
-                   split: option.splits Structures_A.kernel_object.splits)
+   apply (clarsimp intro!: no_ofailD[OF no_ofail_read_sc_refill_ready] simp: obj_at_def is_sc_obj)
 
   apply (rule corres_symb_exec_l[OF _ _ assert_sp, rotated])
     apply (clarsimp simp: exs_valid_def return_def vs_all_heap_simps

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -2987,35 +2987,26 @@ lemma is_blocked_corres:
 lemma get_sc_released_corres:
   "corres (=) (active_sc_valid_refills and sc_at sc_ptr) (valid_objs' and sc_at' sc_ptr)
           (get_sc_released sc_ptr) (scReleased sc_ptr)"
-  apply (simp add: get_sc_released_def sc_released_def scReleased_def
-                   scActive_def refillReady_def getCurTime_def bind_assoc)
-  apply (rule corres_split_deprecated[OF _ get_sc_corres, THEN corres_guard_imp])
-      apply clarsimp
-      apply (rule corres_symb_exec_r[OF _ get_sc_sp'])
-        apply (rule corres_split_deprecated[OF _ corres_gets_trivial, simplified])
-           apply (rename_tac sc sc' n sc2' cur_time cur_time')
-           apply (rule_tac P="active_sc_valid_refills and sc_at_pred ((=) sc) sc_ptr"
-                           and P'="valid_objs' and ko_at' sc' sc_ptr and ko_at' sc2' sc_ptr"
-                           in corres_return[THEN iffD2, rule_format])
-           apply normalise_obj_at'
-           apply (subgoal_tac "sc_active sc = (0 < scRefillMax sc')")
-            apply (case_tac "sc_active sc"; clarsimp)
-            apply (drule active_sc_valid_refillsE[where scp=sc_ptr, rotated])
-             apply (clarsimp simp: is_active_sc_def sc_at_ppred_def obj_at_def)
-            apply (drule_tac s'=s' in refills_heads_equal_active)
-               apply (fastforce simp: refill_ready_def refill_sufficient_def refill_capacity_def
-                                      kernelWCET_ticks_def kernelWCETTicks_def vs_all_heap_simps
-                                      cfg_valid_refills_def rr_valid_refills_def sp_valid_refills_def
-                                      sc_at_ppred_def obj_at_def valid_obj'_def obj_at'_def projectKOs
-                               split: if_splits)+
-           apply (clarsimp simp: sc_relation_def active_sc_def)
-          apply (clarsimp simp: state_relation_def)
-         apply wpsimp+
-      apply (clarsimp simp: obj_at'_def)
-     apply (clarsimp simp: state_relation_def)
-     apply wpsimp+
-   apply (fastforce simp: obj_at_def sc_at_pred_n_def is_obj_defs valid_obj_def)
-  apply clarsimp
+  apply (simp add: get_sc_released_def scReleased_def scActive_def refillReady_def)
+  apply (rule corres_split'[rotated 2, OF get_sched_context_sp get_sc_sp'])
+   apply (corressimp corres: get_sc_corres)
+  apply (rule corres_symb_exec_l[rotated 2, OF gets_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_r[rotated, OF gets_the_sp]; (solves wpsimp)?)
+   apply (wpsimp wp: no_ofail_gets_the readRefillReady_no_ofail)
+  apply (clarsimp simp: sc_released_def readRefillReady_def readSchedContext_def)
+  apply normalise_obj_at'
+  apply (subgoal_tac "sc_active sc = (0 < scRefillMax v')")
+   apply (case_tac "sc_active sc"; clarsimp)
+   apply (drule active_sc_valid_refillsE[where scp=sc_ptr, rotated])
+    apply (clarsimp simp: is_active_sc_def sc_at_ppred_def obj_at_def)
+   apply (drule_tac s'=s' in refills_heads_equal_valid_sched_context')
+      apply (fastforce simp: refill_ready_def refill_sufficient_def refill_capacity_def
+                             kernelWCETTicks_def vs_all_heap_simps cfg_valid_refills_def
+                             rr_valid_refills_def sp_valid_refills_def obj_at_def
+                             valid_obj'_def obj_at'_def projectKOs readCurTime_def ogets_def
+                             state_relation_def
+                      split: if_splits)+
+  apply (clarsimp simp: refill_ready_def readCurTime_def ogets_def sc_relation_def active_sc_def)
   done
 
 (* FIXME RT: move to...? *)

--- a/spec/abstract/KHeap_A.thy
+++ b/spec/abstract/KHeap_A.thy
@@ -94,9 +94,19 @@ where
    od"
 
 definition
+  read_thread_state :: "obj_ref \<Rightarrow> (thread_state,'z::state_ext) r_monad"
+where
+  "read_thread_state ref \<equiv> thread_read tcb_state ref"
+
+definition
   get_thread_state :: "obj_ref \<Rightarrow> (thread_state,'z::state_ext) s_monad"
 where
   "get_thread_state ref \<equiv> thread_get tcb_state ref"
+
+definition
+  read_tcb_obj_ref :: "(tcb => obj_ref option) \<Rightarrow> obj_ref \<Rightarrow> (obj_ref option,'z::state_ext) r_monad"
+where
+  "read_tcb_obj_ref f ref \<equiv> thread_read f ref"
 
 definition
   get_tcb_obj_ref :: "(tcb => obj_ref option) \<Rightarrow> obj_ref \<Rightarrow> (obj_ref option,'z::state_ext) s_monad"
@@ -403,13 +413,18 @@ abbreviation sc_refill_ready :: "time \<Rightarrow> sched_context \<Rightarrow> 
   "sc_refill_ready curtime sc \<equiv> refill_ready curtime (refill_hd sc)"
 
 definition
+  read_sc_refill_ready :: "obj_ref \<Rightarrow> (bool, 'z::state_ext) r_monad"
+where
+  "read_sc_refill_ready sc_ptr = do {
+    sc \<leftarrow> read_sched_context sc_ptr;
+    cur_time \<leftarrow> asks cur_time;
+    oreturn $ sc_refill_ready cur_time sc
+  }"
+
+definition
   get_sc_refill_ready :: "obj_ref \<Rightarrow> (bool, 'z::state_ext) s_monad"
 where
-  "get_sc_refill_ready sc_ptr = do
-    sc \<leftarrow> get_sched_context sc_ptr;
-    cur_time \<leftarrow> gets cur_time;
-    return $ sc_refill_ready cur_time sc
-  od"
+  "get_sc_refill_ready sc_ptr \<equiv> gets_the $ read_sc_refill_ready sc_ptr"
 
 (* end refill checks *)
 
@@ -468,12 +483,6 @@ definition
 definition
   tcb_sched_dequeue :: "obj_ref \<Rightarrow> obj_ref list \<Rightarrow> obj_ref list" where
   "tcb_sched_dequeue thread queue \<equiv> filter ((\<noteq>) thread) queue"
-
-definition
-  tcb_release_dequeue :: "(unit, 'z::state_ext) s_monad"
-where
-  "tcb_release_dequeue =
-    modify (\<lambda>s. s\<lparr> release_queue := tl (release_queue s), reprogram_timer := True \<rparr>)"
 
 definition
   tcb_release_remove :: "obj_ref \<Rightarrow> (unit, 'z::state_ext) s_monad"

--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -130,41 +130,42 @@ where
   od"
 
 definition
-  fun_of_m :: "('s, 'a) nondet_monad \<Rightarrow> 's \<Rightarrow> 'a option"
+  read_tcb_refill_ready :: "obj_ref \<Rightarrow> (bool, 'z::state_ext) r_monad"
 where
-  "fun_of_m m \<equiv> \<lambda>s. if \<exists>x s'. m s = ({(x,s')}, False)
-                    then Some (THE x. \<exists>s'. m s = ({(x,s')}, False))
-                    else None"
+  "read_tcb_refill_ready t = do {
+     sc_opt \<leftarrow> read_tcb_obj_ref tcb_sched_context t;
+     sc_ptr \<leftarrow> oassert_opt sc_opt;
+     ready \<leftarrow> read_sc_refill_ready sc_ptr;
+     oreturn ready
+  }"
 
-definition
-  get_tcb_refill_ready :: "obj_ref \<Rightarrow> (bool, 'z::state_ext) s_monad"
+definition read_release_q_non_empty_and_ready :: "(bool, 'z::state_ext) r_monad"
 where
-  "get_tcb_refill_ready t = do
-     sc_opt \<leftarrow> get_tcb_obj_ref tcb_sched_context t;
-     sc_ptr \<leftarrow> assert_opt sc_opt;
-     ready \<leftarrow> get_sc_refill_ready sc_ptr;
-     return ready
+  "read_release_q_non_empty_and_ready \<equiv> do {
+     rq \<leftarrow> asks release_queue;
+     if rq = []
+     then oreturn False
+     else read_tcb_refill_ready (hd rq)
+   }"
+
+definition tcb_release_dequeue :: "(obj_ref, 'z::state_ext) s_monad"
+where
+  "tcb_release_dequeue = do
+     rq \<leftarrow> gets release_queue;
+     tcb_release_remove (hd rq);
+     return (hd rq)
    od"
 
-definition
-  awaken :: "(unit, 'z::state_ext) s_monad"
+definition awaken_body :: "(unit, 'z::state_ext) s_monad"
 where
-  "awaken \<equiv> do
-    rq \<leftarrow> gets release_queue;
-    s \<leftarrow> get;
-    rq1 \<leftarrow> return $ takeWhile (\<lambda>t. the (fun_of_m (get_tcb_refill_ready t) s)) rq;
-    rq2 \<leftarrow> return $ drop (length rq1) rq;
-    modify $ release_queue_update (K rq2);
-    mapM_x (\<lambda>t. do
-      consumed \<leftarrow> gets consumed_time;
-      sc_opt \<leftarrow> thread_get tcb_sched_context t;
-      scp \<leftarrow> assert_opt sc_opt;
-      sufficient \<leftarrow> get_sc_refill_sufficient scp consumed;
-      assert sufficient;
-      possible_switch_to t;
-      modify (\<lambda>s. s\<lparr>reprogram_timer := True\<rparr>)
-    od) rq1
-  od"
+  "awaken_body = do
+     awakened \<leftarrow> tcb_release_dequeue;
+     possible_switch_to awakened
+   od"
+
+definition awaken :: "(unit, 'z::state_ext) s_monad"
+where
+  "awaken \<equiv> whileLoop (\<lambda>r s. the (read_release_q_non_empty_and_ready s)) (\<lambda>_. awaken_body) ()"
 
 definition max_non_empty_queue :: "(priority \<Rightarrow> ready_queue) \<Rightarrow> ready_queue" where
   "max_non_empty_queue queues \<equiv> queues (Max {prio. queues prio \<noteq> []})"

--- a/spec/haskell/src/SEL4/Model/StateData.lhs
+++ b/spec/haskell/src/SEL4/Model/StateData.lhs
@@ -351,6 +351,14 @@ The function "whileM" allows writing while loops where the loop body and the con
 > whileM :: Monad m => m Bool -> m () -> m ()
 > whileM test body = whenM test $ body >> whileM test body
 
+The function "whileLoop" emulates the definition whileLoop from NonDetMonad.thy in lib.
+
+> condition :: MonadState s m => (s -> Bool) -> m a -> m a -> m a
+> condition cond left right = get >>= \s -> if cond s then left else right
+
+> whileLoop :: MonadState s m => (a -> s -> Bool) -> (a -> m a) -> a -> m a
+> whileLoop cond body r = condition (cond r) (body r) (return r) >>= whileLoop cond body
+
 The functions "orM" and "andM" allow composing conditions that run in a monad. These are "short-circuiting", in that if a monad doesn't need to be evaluated to return a result, it won't be.
 
 > orM :: Monad m => m Bool -> m Bool -> m Bool

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -22,7 +22,7 @@ This module uses the C preprocessor to select a target architecture.
 >         refillHd, refillTl, minBudget, minBudgetUs, refillCapacity, refillBudgetCheck,
 >         refillBudgetCheckRoundRobin, updateScPtr, emptyRefill, scBitsFromRefillLength,
 >         isCurDomainExpired, refillUnblockCheck, mapScPtr,
->         refillReady, tcbReleaseEnqueue, tcbReleaseDequeue, refillSufficient, postpone,
+>         readRefillReady, refillReady, tcbReleaseEnqueue, tcbReleaseDequeue, refillSufficient, postpone,
 >         schedContextDonate, maybeDonateSc, maybeReturnSc, schedContextUnbindNtfn,
 >         schedContextMaybeUnbindNtfn, isRoundRobin, getRefills, setRefills, refillFull,
 >         schedContextCompleteYieldTo, schedContextUnbindYieldFrom,
@@ -233,11 +233,14 @@ This module uses the C preprocessor to select a target architecture.
 >     setRefillHd scPtr (Refill { rTime = curTime, rAmount = budget })
 >     maybeAddEmptyTail scPtr
 
-> refillReady :: PPtr SchedContext -> Kernel Bool
-> refillReady scPtr = do
->     sc <- getSchedContext scPtr
->     curTime <- getCurTime
+> readRefillReady :: PPtr SchedContext -> KernelR Bool
+> readRefillReady scPtr = do
+>     sc <- readSchedContext scPtr
+>     curTime <- readCurTime
 >     return $ rTime (refillHd sc) <= curTime + kernelWCETTicks
+
+> refillReady :: PPtr SchedContext -> Kernel Bool
+> refillReady scPtr = getsJust (readRefillReady scPtr)
 
 > refillUpdate :: PPtr SchedContext -> Ticks -> Ticks -> Int -> Kernel ()
 > refillUpdate scPtr newPeriod newBudget newMaxRefills = do


### PR DESCRIPTION
This adds `corres_whileLoop`, a `corres` rule for functions defined using `whileLoop`, and uses it to prove `awaken_corres`. 

I decided to close the earlier PR containing these results and open this new PR, given that much has changed, in particular, the reader monad is now used.