### PR TITLE
Proof updates to avoid passing large structs by value

### DIFF
--- a/lib/clib/Corres_UL_C.thy
+++ b/lib/clib/Corres_UL_C.thy
@@ -705,19 +705,18 @@ lemmas ceqvhD2 = ceqvhD1 [OF _ _ ceqv_sym]
 lemma ccorres_tmp_lift2:
   assumes rl: "\<And>t t'. ceqv \<Gamma> xf' rv' t t' c c'"
   and c: "ccorres_underlying srel \<Gamma> rrel xf arrel axf G (G'' rv') hs m c'"
-  and geq: "G'' rv' \<inter> {s. rv' = xf' s} = G' \<inter> {s. rv' = xf' s}"
+  and geq: "G' \<inter> {s. rv' = xf' s} \<subseteq> G'' rv'"
   shows "ccorres_underlying srel \<Gamma> rrel xf arrel axf G (G' \<inter> {s. xf' s = rv'}) hs m c"
   using c
   apply -
   apply (rule ccorresI')
-   apply (erule (2) ccorresE)
+  apply (erule (2) ccorresE)
      apply (subst (asm) Int_eq_symmetric)
-     apply (subst (asm) geq [symmetric])
-     apply fastforce
+     apply (drule set_mp[OF geq], clarsimp)
     apply assumption
    apply simp
    apply (erule conjE)+
-   apply (erule (1) ceqvhD1 [OF _ _ rl])
+   apply (erule (1) ceqvhD1[OF _ _ rl])
    apply simp
   apply fastforce
   done

--- a/lib/clib/SIMPL_Lemmas.thy
+++ b/lib/clib/SIMPL_Lemmas.thy
@@ -88,7 +88,7 @@ lemma Normal_resultE:
   done
 
 lemma Abrupt_result:
-  "\<Gamma> \<turnstile> \<langle>c, s\<rangle> \<Rightarrow> Abrupt t' \<Longrightarrow> \<exists>t. s = Normal t \<or> s = Abrupt t"
+  "\<Gamma> \<turnstile> \<langle>c, s\<rangle> \<Rightarrow> Abrupt t' \<Longrightarrow> (\<exists>t. s = Normal t) \<or> s = Abrupt t'"
 proof (induct c arbitrary: s)
   case While
   thus ?case
@@ -97,11 +97,11 @@ qed (fastforce elim: exec_elim_cases)+
 
 lemma Abrupt_resultE [consumes 1, case_names normal abrupt]:
   "\<lbrakk>\<Gamma> \<turnstile> \<langle>c, s\<rangle> \<Rightarrow> Abrupt t';
-  \<And>t. \<lbrakk>\<Gamma> \<turnstile> \<langle>c, Normal t\<rangle> \<Rightarrow> Abrupt t'; s = Normal t \<rbrakk> \<Longrightarrow> P;
-  \<And>t. \<lbrakk>\<Gamma> \<turnstile> \<langle>c, Abrupt t\<rangle> \<Rightarrow> Abrupt t'; s = Abrupt t \<rbrakk> \<Longrightarrow> P \<rbrakk> \<Longrightarrow> P"
+    \<And>t. \<lbrakk>\<Gamma> \<turnstile> \<langle>c, Normal t\<rangle> \<Rightarrow> Abrupt t'; s = Normal t\<rbrakk> \<Longrightarrow> P;
+    \<And>t. \<lbrakk>\<Gamma> \<turnstile> \<langle>c, Abrupt t\<rangle> \<Rightarrow> Abrupt t'; s = Abrupt t\<rbrakk> \<Longrightarrow> P\<rbrakk>
+   \<Longrightarrow> P"
   apply (frule Abrupt_result)
-  apply auto
-  done
+  by auto
 
 lemma Fault_result:
   assumes ex: "\<Gamma> \<turnstile> \<langle>a, s\<rangle> \<Rightarrow> t"

--- a/lib/clib/SIMPL_Lemmas.thy
+++ b/lib/clib/SIMPL_Lemmas.thy
@@ -10,6 +10,14 @@ imports
   "CTranslationNICTA"
 begin
 
+lemma hoarep_false_pre:
+  "\<Gamma>\<turnstile>\<^bsub>/F\<^esub> {} f Q,A"
+  by (clarsimp intro!: hoare_complete simp: HoarePartialDef.valid_def)
+
+lemma hoarep_false_pre_gen:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/F s\<^esub> {} f (Q s),(A s)"
+  by (rule allI, rule hoarep_false_pre)
+
 lemma Cond_true:
   "\<Gamma> \<turnstile>\<^bsub>/F\<^esub> P t Q, A \<Longrightarrow> \<Gamma> \<turnstile>\<^bsub>/F\<^esub> (P \<inter> b) Cond b t f Q, A"
   apply (rule hoare_complete)
@@ -270,34 +278,32 @@ lemma exec_Seq_Skip_simps:
   apply (case_tac s', auto intro: exec.intros)
   done
 
-lemma exec_normal:
-  assumes asms: "s' \<in> P'"
-  and     ce: "\<Gamma> \<turnstile> \<langle>c, Normal s'\<rangle> \<Rightarrow> Normal t'"
-  and valid': "\<Gamma> \<turnstile>\<^bsub>/F\<^esub> P' c Q', A'"
-  shows   "t' \<in> Q'"
-  using valid' ce asms
-  apply -
-  apply (drule hoare_sound)
-  apply (clarsimp elim: exec_Normal_elim_cases
-    simp: NonDetMonad.bind_def cvalid_def split_def HoarePartialDef.valid_def)
+lemma hoarep_exec:
+  assumes pre: "s \<in> P"
+  assumes exec: "\<Gamma>\<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> t"
+  assumes hoare: "\<Gamma>\<turnstile>\<^bsub>/F\<^esub> P c Q,A"
+  shows "(\<exists>f \<in> F. t = Fault f) \<or> (\<exists>t' \<in> Q. t = Normal t') \<or> (\<exists>t' \<in> A. t = Abrupt t')"
+  using pre hoare_sound[OF hoare] exec
+  apply (clarsimp simp: cvalid_def HoarePartialDef.valid_def image_def)
   apply (drule spec, drule spec, drule (1) mp)
-  apply auto
-  done
+  by auto
 
-lemma exec_abrupt:
-  assumes asms: "s' \<in> P'"
-  and     ce: "\<Gamma> \<turnstile> \<langle>c, Normal s'\<rangle> \<Rightarrow> Abrupt t'"
-  and valid': "\<Gamma> \<turnstile>\<^bsub>/F\<^esub> P' c Q', A'"
-  shows   "t' \<in> A'"
-  using valid' ce asms
-  apply -
-  apply (drule hoare_sound)
-  apply (clarsimp elim: exec_Normal_elim_cases
-    simp: NonDetMonad.bind_def cvalid_def split_def HoarePartialDef.valid_def)
-  apply (drule spec, drule spec, drule (1) mp)
-  apply auto
-  done
+lemmas hoarep_exec'
+  = hoarep_exec[where s=s' and P=P' and A=A' and Q=Q' for s' P' Q' A']
 
+lemmas exec_normal = hoarep_exec'[where t="Normal t'" for t', simplified]
+lemmas exec_abrupt = hoarep_exec'[where t="Abrupt t'" for t', simplified]
+lemmas exec_fault = hoarep_exec'[where t="Fault f" for f, simplified]
+lemmas exec_stuck = hoarep_exec[where t=Stuck, simplified]
+
+lemma hoarep_exec_gen:
+  assumes h: "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/F s\<^esub> (P s) c (Q s),(A s)"
+  assumes e: "\<Gamma>\<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> t"
+  shows "s \<in> P x \<longrightarrow> (\<exists>f \<in> F x. t = Fault f) \<or> (\<exists>t' \<in> Q x. t = Normal t') \<or> (\<exists>t' \<in> A x. t = Abrupt t')"
+  by (rule impI, erule hoarep_exec[OF _ e spec[OF h]])
+
+lemmas hoarep_exec_call_body
+  = hoarep_exec_gen[OF _ exec_Call_body_aux[THEN iffD2]]
 
 (* Used so we don't simp it in ctac *)
 definition

--- a/lib/clib/XPres.thy
+++ b/lib/clib/XPres.thy
@@ -8,258 +8,415 @@ theory XPres
 imports SIMPL_Lemmas
 begin
 
-(* We don't really care if the computation gets stuck or faults, only that xf isn't changed *)
-definition
-  xpres :: "('s \<Rightarrow> 'a) \<Rightarrow> 'a \<Rightarrow> ('i \<rightharpoonup> ('s, 'i, 'x) com) \<Rightarrow> ('s, 'i, 'x) com \<Rightarrow> bool"
-where
-  "xpres xf v \<Gamma> c \<equiv> \<forall>s t. \<Gamma> \<turnstile> \<langle>c, s\<rangle> \<Rightarrow> t
-  \<longrightarrow> s \<in> Normal ` {s. xf s = v}
-  \<longrightarrow> (\<forall>t'. t = Normal t' \<or> t = Abrupt t' \<longrightarrow> xf t' = v)"
+(* FIXME: move *)
+lemmas trivial = TrueE[OF TrueI]
+
+(* Intended to be used to calculate `z` from `b`, `x` and `y`. *)
+definition xpres_eq_If :: "bool \<Rightarrow> 'a \<Rightarrow> 'a \<Rightarrow> 'a \<Rightarrow> bool" where
+  "xpres_eq_If b x y z \<equiv> z = (if b then x else y)"
+
+lemma xpres_eq_If_False:
+  "xpres_eq_If False x y y"
+  by (simp add: xpres_eq_If_def)
+
+lemma xpres_eq_If_True:
+  "xpres_eq_If True x y x"
+  by (simp add: xpres_eq_If_def)
+
+lemmas xpres_eq_If_rules = xpres_eq_If_False xpres_eq_If_True
+
+(* Intended to be used to calculate `abnormal` by syntactic analysis of `c`. *)
+definition xpres_abnormal where
+  "xpres_abnormal \<Gamma> c abnormal \<equiv> \<forall>s t. abnormal \<longrightarrow> \<not> \<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal t"
+
+lemma xpres_abnormalD:
+  assumes "xpres_abnormal \<Gamma> c abnormal"
+  assumes "abnormal"
+  assumes "\<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal t"
+  shows False
+  using assms by (auto simp: xpres_abnormal_def)
+
+lemma xpres_abnormalI:
+  assumes "\<And>s t. \<lbrakk>abnormal; \<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal t\<rbrakk> \<Longrightarrow> False"
+  shows "xpres_abnormal \<Gamma> c abnormal"
+  using assms by (auto simp: xpres_abnormal_def)
+
+lemma xpres_abnormal_trivial:
+  "xpres_abnormal \<Gamma> c False"
+  by (auto simp: xpres_abnormal_def)
+
+lemma xpres_abnormal_throw:
+  "xpres_abnormal \<Gamma> Throw True"
+  by (auto simp: xpres_abnormal_def elim!: exec_elim_cases)
+
+lemma xpres_abnormal_creturn:
+  "xpres_abnormal \<Gamma> (creturn rtu xfu v) True"
+  by (auto simp: xpres_abnormal_def creturn_def elim!: exec_elim_cases)
+
+lemma xpres_abnormal_creturn_void:
+  "xpres_abnormal \<Gamma> (creturn_void rtu) True"
+  by (auto simp: xpres_abnormal_def creturn_void_def elim!: exec_elim_cases)
+
+lemma xpres_abnormal_cbreak:
+  "xpres_abnormal \<Gamma> (cbreak rtu) True"
+  by (auto simp: xpres_abnormal_def cbreak_def elim!: exec_elim_cases)
+
+lemma xpres_abnormal_guard:
+  assumes "xpres_abnormal \<Gamma> c abnormal"
+  shows "xpres_abnormal \<Gamma> (Guard f g c) abnormal"
+  apply (rule xpres_abnormalI)
+  apply (erule exec_elim_cases; clarsimp; erule (1) assms[THEN xpres_abnormalD])
+  done
+
+lemma xpres_abnormal_seq:
+  assumes C: "xpres_abnormal \<Gamma> c C"
+             "xpres_abnormal \<Gamma> d D"
+  assumes S: "xpres_eq_If C True D S"
+  shows "xpres_abnormal \<Gamma> (Seq c d) S"
+  apply (rule xpres_abnormalI)
+  apply (erule exec_elim_cases; clarsimp)
+  apply (frule Normal_result, clarsimp, rename_tac s s')
+  apply (clarsimp simp: S[unfolded xpres_eq_If_def] if_bool_simps)
+  apply (erule disjE; erule (1) C[THEN xpres_abnormalD])
+  done
+
+lemma xpres_abnormal_cond:
+  assumes C: "xpres_abnormal \<Gamma> c C"
+             "xpres_abnormal \<Gamma> d D"
+  assumes S: "xpres_eq_If C D False S" (* S = (C \<and> D) *)
+  shows "xpres_abnormal \<Gamma> (Cond b c d) S"
+  apply (rule xpres_abnormalI)
+  apply (clarsimp simp: S[unfolded xpres_eq_If_def] if_bool_simps)
+  apply (erule exec_elim_cases; clarsimp; erule (1) C[THEN xpres_abnormalD])
+  done
+
+lemma xpres_abnormal_call:
+  assumes "\<And>s t. xpres_abnormal \<Gamma> (ret s t) abnormal"
+  shows "xpres_abnormal \<Gamma> (call i f reset ret) abnormal"
+  using assms by (auto simp: xpres_abnormal_def elim: exec_call_Normal_elim)
+
+lemmas xpres_abnormal_rules
+  = xpres_abnormal_creturn xpres_abnormal_creturn_void xpres_abnormal_cbreak xpres_abnormal_guard
+    xpres_abnormal_seq xpres_abnormal_cond xpres_abnormal_call
+
+(* Intended to be used to calculate `pres_norm`, `pres_abr` and `abnormal`
+   by syntactic analysis of `c`. *)
+definition xpres_strong ::
+  "('s,'p,'f) body \<Rightarrow> ('s \<Rightarrow> 'v) \<Rightarrow> 'v \<Rightarrow> ('s,'p,'f) com \<Rightarrow> bool \<Rightarrow> bool \<Rightarrow> bool \<Rightarrow> bool"
+  where
+  "xpres_strong \<Gamma> xf v c pres_norm pres_abr abnormal
+   \<equiv> (\<forall>s t. (\<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal t \<longrightarrow> \<not> abnormal \<and> (pres_norm \<longrightarrow> xf s = v \<longrightarrow> xf t = v))
+          \<and> (\<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Abrupt t \<longrightarrow> pres_abr \<longrightarrow> xf s = v \<longrightarrow> xf t = v))
+      \<and> (abnormal \<longrightarrow> pres_norm)"
+
+(* For compatibility with older proofs. *)
+abbreviation "xpres \<Gamma> xf v c \<equiv> xpres_strong \<Gamma> xf v c True True False"
+
+lemma xpres_def:
+  "xpres \<Gamma> xf v c \<equiv> \<forall>s t. \<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> t
+                          \<longrightarrow> xf s = v \<longrightarrow> (\<forall>t'. t = Normal t' \<or> t = Abrupt t' \<longrightarrow> xf t' = v)"
+  by (auto simp: xpres_strong_def atomize_eq)
+
+lemma xpres_strongI:
+  assumes "\<And>s t. \<lbrakk>pres_norm; \<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal t; xf s = v\<rbrakk> \<Longrightarrow> xf t = v"
+  assumes "\<And>s t. \<lbrakk>pres_abr; \<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Abrupt t; xf s = v\<rbrakk> \<Longrightarrow> xf t = v"
+  assumes "\<And>s t. \<lbrakk>abnormal; \<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal t\<rbrakk> \<Longrightarrow> False"
+  assumes "abnormal \<Longrightarrow> pres_norm"
+  shows "xpres_strong \<Gamma> xf v c pres_norm pres_abr abnormal"
+  unfolding xpres_strong_def
+  by (intro allI impI conjI notI; erule assms)
+
+lemma xpres_strong_abnormalD:
+  "xpres_strong \<Gamma> xf v c pres_norm pres_abr abnormal \<Longrightarrow> abnormal \<Longrightarrow> pres_norm"
+  by (simp add: xpres_strong_def)
 
 lemma xpresI:
   "\<lbrakk>\<And>s t t'. \<lbrakk>\<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> t; xf s = v; t = Normal t' \<or> t = Abrupt t' \<rbrakk> \<Longrightarrow> xf t' = v\<rbrakk> \<Longrightarrow>
-  xpres xf v \<Gamma> c"
+  xpres \<Gamma> xf v c"
   unfolding xpres_def by auto
 
-(* Sometimes it's easier to reason syntactically --- the two are more or less equivalent, under the assumption
-  that c doesn't fault or get stuck *)
-lemma xpres_hoareI:
-  "\<Gamma> \<turnstile> {s. xf s = v } c {s. xf s = v} \<Longrightarrow> xpres xf v \<Gamma> c"
-  apply (rule xpresI)
-  apply (drule hoare_sound)
-  apply (simp add:HoarePartialDef.valid_def cvalid_def)
-  apply (drule spec, drule spec, drule (1) mp)
-  apply clarsimp
-  done
+lemma xpres_strong_abnormal_iff:
+  "xpres_strong \<Gamma> xf v c abnormal False abnormal \<longleftrightarrow> xpres_abnormal \<Gamma> c abnormal"
+  by (auto simp: xpres_strong_def xpres_abnormal_def)
 
 lemma xpres_skip:
-  "xpres xf v \<Gamma> Skip"
-  apply (rule xpres_hoareI)
-  apply rule
-  done
+  "xpres \<Gamma> xf v Skip"
+  by (rule xpresI; erule exec_Normal_elim_cases; simp)
 
-lemma xpres_basic:
-  assumes rl: "\<And>s. xf s = v \<Longrightarrow> xf (f s) = v"
-  shows "xpres xf v \<Gamma> (Basic f)"
-  apply (rule xpresI)
-  apply (drule rl)
-  apply (erule exec_Normal_elim_cases)
-  apply clarsimp
-  done
+lemma xpres_strong_basic':
+  assumes rl: "\<And>s. pres_norm \<Longrightarrow> xf s = v \<Longrightarrow> xf (f s) = v"
+  shows "xpres_strong \<Gamma> xf v (Basic f) pres_norm pres_abr False"
+  by (rule xpres_strongI; simp?; erule exec_Normal_elim_cases; clarsimp simp: rl)
 
-lemma xpres_exec0:
-  assumes xp: "xpres xf v \<Gamma> c"
-  and     ex: "\<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> y"
-  and     xy: "y = Normal s' \<or> y = Abrupt s'"
-  and     xf: "xf s = v"
-  shows   "xf s' = v"
-  using xp ex xy xf
-  unfolding xpres_def
+lemmas xpres_strong_basic = xpres_strong_basic'[where pres_abr=True]
+lemmas xpres_basic = xpres_strong_basic[where pres_norm=True, simplified]
+
+lemma xpres_basic_False:
+  "xpres_strong \<Gamma> xf v (Basic f) False True False"
+  by (rule xpres_strong_basic, simp)
+
+lemma xpres_exec_Normal:
+  assumes "xpres_strong \<Gamma> xf v c pres_norm pres_abr abnormal"
+  assumes pres_norm
+  assumes "\<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal t"
+  assumes "xf s = v"
+  shows "xf t = v"
+  using assms unfolding xpres_strong_def
   apply -
-  apply (drule spec, drule spec, drule (1) mp)
-  apply (erule disjE)
-   apply (drule mp, simp)
-   apply simp
-  apply (drule mp, simp)
-  apply simp
+  by (drule (1) mp | erule allE conjE trivial)+
+
+lemma xpres_exec_Abrupt:
+  assumes xp: "xpres_strong \<Gamma> xf v c pres_norm pres_abr abnormal"
+  assumes pa: pres_abr
+  assumes ex: "\<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Abrupt t"
+  assumes xf: "xf s = v"
+  shows   "xf t = v"
+  using assms unfolding xpres_strong_def
+  apply -
+  by (drule (1) mp | erule allE conjE trivial)+
+
+lemma xpres_exec_abnormal:
+  assumes "xpres_strong \<Gamma> xf v c pres_norm pres_abr abnormal"
+  assumes abnormal
+  assumes "\<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal t"
+  shows "False"
+  using assms unfolding xpres_strong_def
+  apply -
+  by (drule (1) mp | erule allE conjE notE)+
+
+lemmas xpres_execs = xpres_exec_Normal xpres_exec_Abrupt
+
+(* If `b` never produces a `Normal` result, then we vacuously have that whenever
+   the sequence results in a `Normal` state, then `xf` is preserved. Together with
+   the rule for `Cond`, this is useful in situations like this:
+     IF condition THEN
+       \<acute>xf := modified_value ;;
+       return
+     FI ;;
+     // here, `xf` is still preserved.  *)
+lemma xpres_strong_seq:
+  assumes xpa: "xpres_strong \<Gamma> xf v c c_pres_norm c_pres_abr c_abnormal"
+  assumes xpb: "xpres_strong \<Gamma> xf v d d_pres_norm d_pres_abr d_abnormal"
+  notes xps = xpa xpb
+  \<comment> \<open>abnormal \<longleftrightarrow> c_abnormal \<or> d_abnormal\<close>
+  \<comment> \<open>pres_norm \<longleftrightarrow> c_pres_norm \<and> d_pres_norm \<or> abnormal\<close>
+  \<comment> \<open>pres_abr \<longleftrightarrow> c_pres_abr \<and> c_pres_norm \<and> d_pres_abr \<or> c_abnormal \<and> c_pres_abr\<close>
+  assumes ifs: "xpres_eq_If c_abnormal True d_abnormal abnormal"
+               "xpres_eq_If c_pres_norm d_pres_norm False cd_pres_norm"
+               "xpres_eq_If cd_pres_norm True abnormal pres_norm"
+               "xpres_eq_If c_pres_norm d_pres_abr False c_norm_d_pres_abr"
+               "xpres_eq_If c_pres_abr c_norm_d_pres_abr False cd_pres_abr"
+               "xpres_eq_If c_abnormal c_pres_abr False c_abnormal_pres_abr"
+               "xpres_eq_If cd_pres_abr True c_abnormal_pres_abr pres_abr"
+  shows "xpres_strong \<Gamma> xf v (c ;; d) pres_norm pres_abr abnormal"
+  unfolding ifs[simplified xpres_eq_If_def if_bool_simps]
+  apply (rule xpres_strongI
+         ; simp?
+         ; erule exec_Normal_elim_cases
+         ; erule Normal_resultE Abrupt_resultE
+         ; simp
+         ; elim disjE conjE exec_elim_cases)
+          apply (all \<open>(drule (1) xps[THEN xpres_exec_abnormal], simp)?\<close>)
+     apply (all \<open>(drule (2) xpres_execs[OF xpa])\<close>, simp_all)
+   apply (all \<open>(erule (2) xpres_execs[OF xpb])\<close>)
   done
-
-lemma xpres_exec:
-  assumes xp: "xpres xf v \<Gamma> c"
-  and     ex: "\<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal s'"
-  and     xf: "xf s = v"
-  shows   "xf s' = v"
-  using xp ex xf by (auto intro: xpres_exec0)
-
-lemma xpresD:
-  assumes xf: "xf s = v"
-  and     xp: "xpres xf v \<Gamma> a"
-  and     ex: "\<Gamma> \<turnstile> \<langle>a, Normal s\<rangle> \<Rightarrow> Normal s'"
-  shows   "xf s' = v"
-  by (rule xpres_exec [OF xp ex]) fact+
-
-lemma xpres_abruptD:
-  assumes xf: "xf s = v"
-  and     xp: "xpres xf v \<Gamma> a"
-  and     ex: "\<Gamma> \<turnstile> \<langle>a, Normal s\<rangle> \<Rightarrow> Abrupt s'"
-  shows   "xf s' = v"
-  by (rule xpres_exec0 [OF xp ex], simp) fact+
 
 lemma xpres_seq:
-  assumes xa: "xpres xf v \<Gamma> a"
-  and     xb: "xpres xf v \<Gamma> b"
-  shows   "xpres xf v \<Gamma> (a ;; b)"
-  apply (rule xpresI)
-  apply (erule exec_Normal_elim_cases)
-  apply (erule disjE)
-   apply simp
-   apply (erule Normal_resultE)
-   apply simp
-   apply (drule (1) xpresD [OF _ xa])
-   apply (erule (1) xpresD [OF _ xb])
-  apply simp
-  apply (erule Abrupt_resultE)
-   apply simp
-   apply (drule (1) xpresD [OF _ xa])
-   apply (erule (1) xpres_abruptD [OF _ xb])
-  apply simp
-  apply (drule Abrupt_end, rule refl)
-  apply simp
-  apply (erule (1) xpres_abruptD [OF _ xa])
-  done
+  assumes xpa: "xpres \<Gamma> xf v a"
+  assumes xpb: "xpres \<Gamma> xf v b"
+  shows "xpres \<Gamma> xf v (a ;; b)"
+  by (rule xpres_strong_seq[OF xpa xpb] xpres_eq_If_rules)+
 
-lemma xpres_while0:
+lemma xpres_strong_while0:
   assumes ex: "\<Gamma>\<turnstile> \<langle>d,s\<rangle> \<Rightarrow> t"
-  and     xp: "xpres xf v \<Gamma> a"
+  and     xp: "xpres_strong \<Gamma> xf v a pres_norm pres_abr abnormal"
   and      d: "d = While b a"
   and      s: "s \<in> Normal ` {s. xf s = v} \<union> Abrupt ` {s. xf s = v}"
-  and      t: "t = Normal t' \<or> t = Abrupt t'"
+  and      t: "pres_norm \<and> t = Normal t' \<or> pres_norm \<and> pres_abr \<and> t = Abrupt t'"
   shows    "xf t' = v"
   using ex d s t
 proof (induct)
   case (WhileTrue s' b' c' t u)
   hence eqs: "b' = b" "c' = a" and xfs: "xf s' = v" by auto
-
   {
     fix w
-    assume tv: "t = Normal w" and "\<Gamma> \<turnstile> \<langle>a, Normal s'\<rangle> \<Rightarrow> Normal w"
+    assume tv: "t = Normal w" and "\<Gamma> \<turnstile> \<langle>a, Normal s'\<rangle> \<Rightarrow> Normal w" and pres_norm
 
     have ?thesis
     proof (rule WhileTrue.hyps(5))
-      have "xf w = v" using xfs xp by (rule xpresD) fact+
+      have "xf w = v" by (rule xpres_exec_Normal) fact+
       thus "t \<in> Normal ` {s. xf s = v} \<union> Abrupt ` {s. xf s = v}" using tv
         by simp
     qed fact+
   } moreover
   {
     fix w
-    assume tv: "t = Abrupt w" and "\<Gamma> \<turnstile> \<langle>a, Normal s'\<rangle> \<Rightarrow> Abrupt w"
+    assume tv: "t = Abrupt w" and "\<Gamma> \<turnstile> \<langle>a, Normal s'\<rangle> \<Rightarrow> Abrupt w" and pres_abr
     have ?thesis
     proof (rule WhileTrue.hyps(5))
-      have "xf w = v" using xfs xp by (rule xpres_abruptD) fact+
+      have "xf w = v" by (rule xpres_exec_Abrupt) fact+
       thus "t \<in> Normal ` {s. xf s = v} \<union> Abrupt ` {s. xf s = v}" using tv
         by simp
     qed fact+
   } ultimately
-  show ?thesis using WhileTrue.prems(3) WhileTrue.hyps(2) WhileTrue.hyps(4) eqs
+  show ?thesis using WhileTrue.prems(3) WhileTrue.hyps(2) WhileTrue.hyps(4) unfolding eqs
   apply -
-  apply (erule disjE)
-   apply simp
-   apply (erule Normal_resultE)
-   apply simp
-  apply simp
-  apply (erule Abrupt_resultE)
-  apply simp
-  apply simp
-  done
+  by (elim disjE conjE; simp; erule Normal_resultE Abrupt_resultE; simp)
 qed auto
 
-lemma xpres_while:
-  assumes xp: "xpres xf v \<Gamma> x"
-  shows   "xpres xf v \<Gamma> (While b x)"
-  apply (rule xpresI)
-  apply (erule xpres_while0 [OF _ xp refl])
-   apply simp
-  apply simp
-  done
+lemma xpres_strong_while:
+  assumes xp: "xpres_strong \<Gamma> xf v x pres_norm pres_abr abnormal"
+  assumes pa: "xpres_eq_If pres_norm pres_abr False pres_abr'"
+  shows   "xpres_strong \<Gamma> xf v (While b x) pres_norm pres_abr' False"
+  unfolding pa[simplified xpres_eq_If_def if_bool_simps]
+  apply (rule xpres_strongI)
+  apply (erule xpres_strong_while0[OF _ xp refl]; simp)+
+  by auto
 
-lemma xpres_call_hoarep_gen:
+lemmas xpres_while
+  = xpres_strong_while[OF _ xpres_eq_If_True, where pres_abr=True and abnormal=False, simplified]
+
+lemma xpres_strong_xpres_abnormalI:
+  assumes abn: "xpres_strong \<Gamma> xf v c' pres_norm pres_abr' abnormal"
+  assumes "\<And>s t. \<lbrakk>pres_norm; \<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal t; xf s = v\<rbrakk> \<Longrightarrow> xf t = v"
+  assumes "\<And>s t. \<lbrakk>pres_abr; \<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Abrupt t; xf s = v\<rbrakk> \<Longrightarrow> xf t = v"
+  assumes "\<And>s t. \<lbrakk>abnormal; \<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal t\<rbrakk> \<Longrightarrow> False"
+  shows "xpres_strong \<Gamma> xf v c pres_norm pres_abr abnormal"
+  by (rule xpres_strongI[OF _ _ _ xpres_strong_abnormalD[OF abn]]; erule assms trivial; assumption)
+
+lemma xpres_strong_call_hoarep_gen:
   assumes mod: "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/F s\<^esub> (P s) Call f (Q s),(A s)"
-  assumes ret: "\<And>s t. xf s = v \<Longrightarrow> i s \<in> P (x s) \<longrightarrow> t \<in> Q (x s) \<or> t \<in> A (x s) \<Longrightarrow> xf (r s t) = v"
-  assumes xpr: "\<And>s t. xpres xf v \<Gamma> (c s t)"
-  shows "xpres xf v \<Gamma> (call i f r c)"
-  apply (rule xpresI)
-  apply (erule exec_call_Normal_elim)
-      apply (erule (1) xpres_exec0[OF xpr])
-      apply (erule ret)
-      apply (frule (1) hoarep_exec_call_body[OF mod], fastforce)
-     apply simp
-     apply (erule subst, erule ret)
+  assumes ret: "\<And>s t. xf s = v \<Longrightarrow> i s \<in> P (x s) \<longrightarrow> t \<in> Q (x s) \<or> t \<in> A (x s) \<Longrightarrow> xf (reset s t) = v"
+  assumes xpr: "\<And>s t. xpres_strong \<Gamma> xf v (ret s t) pres_norm pres_abr abnormal"
+  shows "xpres_strong \<Gamma> xf v (call i f reset ret) pres_norm pres_abr abnormal"
+  apply (rule xpres_strong_xpres_abnormalI[OF xpr]; simp?; erule exec_call_Normal_elim; simp?)
+     apply (erule (1) xpres_execs[OF xpr])
+     apply (erule ret)
      apply (frule (1) hoarep_exec_call_body[OF mod], fastforce)
-    apply simp
-   apply simp
-  apply simp
+    apply (erule (1) xpres_execs[OF xpr])
+    apply (erule ret)
+    apply (frule (1) hoarep_exec_call_body[OF mod], fastforce)
+   apply (erule ret)
+   apply (frule (1) hoarep_exec_call_body[OF mod], fastforce)
+  apply (erule (1) xpres_exec_abnormal[OF xpr])
   done
 
-lemmas xpres_call = xpres_call_hoarep_gen[OF hoarep_false_pre_gen, simplified]
-lemmas xpres_call_hoarep = xpres_call_hoarep_gen[where P="\<lambda>s. {s}" and x=i and i=i for i, simplified]
+lemmas xpres_call = xpres_strong_call_hoarep_gen[OF hoarep_false_pre_gen, simplified]
+lemmas xpres_call_hoarep = xpres_strong_call_hoarep_gen[where P="\<lambda>s. {s}" and x=i and i=i for i, simplified]
+
+lemma xpres_strong_catch:
+  assumes xpc: "xpres_strong \<Gamma> xf v c c_pres_norm c_pres_abr c_abnormal"
+  assumes xpd: "xpres_strong \<Gamma> xf v d d_pres_norm d_pres_abr d_abnormal"
+  notes xps = xpc xpd
+  \<comment> \<open>abnormal \<longleftrightarrow> c_abnormal \<and> d_abnormal\<close>
+  \<comment> \<open>pres_norm \<longleftrightarrow> abnormal \<or> c_pres_norm \<and> c_pres_abr \<and> d_pres_norm\<close>
+  \<comment> \<open>pres_abr \<longleftrightarrow> c_pres_abr \<and> c_pres_abr\<close>
+  assumes rew: "xpres_eq_If c_abnormal d_abnormal False abnormal"
+               "xpres_eq_If c_pres_norm c_pres_abr False c_pres_norm_abr"
+               "xpres_eq_If c_pres_norm_abr d_pres_norm False cd_pres_norm"
+               "xpres_eq_If abnormal True cd_pres_norm pres_norm"
+               "xpres_eq_If c_pres_abr d_pres_abr False pres_abr"
+  shows "xpres_strong \<Gamma> xf v (Catch c d) pres_norm pres_abr abnormal"
+  unfolding rew[simplified xpres_eq_If_def if_bool_simps]
+  apply (rule xpres_strongI; simp?; erule exec_Normal_elim_cases; simp?; (elim disjE conjE)?)
+          apply (all \<open>(drule (1) xps[THEN xpres_exec_abnormal], simp)?\<close>)
+     apply (all \<open>drule (2) xpres_execs[OF xpc], assumption?\<close>)
+   apply (all \<open>drule (2) xpres_execs[OF xpd], assumption\<close>)
+  done
 
 lemma xpres_catch:
-  assumes xpb: "xpres xf v \<Gamma> b"
-  and     xpc: "xpres xf v \<Gamma> c"
-  shows    "xpres xf v \<Gamma> (Catch b c)"
-  apply (rule xpresI)
-  apply (erule exec_Normal_elim_cases)
-   apply (drule (1) xpres_abruptD [OF _ xpb])
-   apply (erule (2) xpres_exec0 [OF xpc])
-  apply (erule (2) xpres_exec0 [OF xpb])
+  assumes "xpres \<Gamma> xf v b"
+  assumes "xpres \<Gamma> xf v c"
+  shows "xpres \<Gamma> xf v (Catch b c)"
+  by (rule xpres_strong_catch[OF assms] xpres_eq_If_rules)+
+
+lemma xpres_strong_guard:
+  assumes "xpres_strong \<Gamma> xf v c pres_norm pres_abr abnormal"
+  shows "xpres_strong \<Gamma> xf v (Guard f g c) pres_norm pres_abr abnormal"
+  apply (rule xpres_strong_xpres_abnormalI[OF assms]; erule exec_Normal_elim_cases; simp?)
+     apply (all \<open>drule (1) xpres_execs[OF assms] assms[THEN xpres_exec_abnormal]; simp\<close>)
   done
 
-lemma xpres_guard:
-  assumes xp: "xpres xf v \<Gamma> c"
-  shows   "xpres xf v \<Gamma> (Guard f g c)"
-  apply (rule xpresI)
-  apply (erule exec_Normal_elim_cases)
-   apply (erule (2) xpres_exec0 [OF xp])
-  apply simp
+lemmas xpres_guard = xpres_strong_guard[where pres_norm=True and pres_abr=True and abnormal=False]
+
+lemma xpres_strong_cond:
+  assumes xpc: "xpres_strong \<Gamma> xf v c c_pres_norm c_pres_abr c_abnormal"
+  assumes xpd: "xpres_strong \<Gamma> xf v d d_pres_norm d_pres_abr d_abnormal"
+  notes xps = xpc xpd
+  \<comment> \<open>pres_norm \<longleftrightarrow> abnormal \<or> c_pres_norm \<and> d_pres_norm \<or> c_abnormal \<and> d_pres_norm \<or> c_pres_norm \<and> d_abnormal\<close>
+  \<comment> \<open>pres_abr \<longleftrightarrow> c_pres_abr \<and> d_pres_abr\<close>
+  \<comment> \<open>abnormal \<longleftrightarrow> c_abnormal \<and> d_abnormal\<close>
+  assumes rew: "xpres_eq_If c_abnormal d_abnormal False abnormal"
+               "xpres_eq_If c_pres_norm d_pres_norm False cd_pres_norm"
+               "xpres_eq_If c_abnormal d_pres_norm False ca_pres_norm"
+               "xpres_eq_If c_pres_norm d_abnormal False da_pres_norm"
+               "xpres_eq_If ca_pres_norm True da_pres_norm cda_pres_norm"
+               "xpres_eq_If cd_pres_norm True cda_pres_norm pres_norm'"
+               "xpres_eq_If abnormal True pres_norm' pres_norm"
+               "xpres_eq_If c_pres_abr d_pres_abr False pres_abr"
+  shows "xpres_strong \<Gamma> xf v (Cond x c d) pres_norm pres_abr abnormal"
+  unfolding rew[simplified xpres_eq_If_def if_bool_simps]
+  apply (rule xpres_strongI; simp?; erule exec_Normal_elim_cases; elim disjE conjE)
+             apply (all \<open>(drule (1) xps[THEN xpres_exec_abnormal], simp)?\<close>)
+       apply (all \<open>(erule (2) xpres_execs[OF xpc] xpres_execs[OF xpd])\<close>)
   done
 
 lemma xpres_cond:
-  assumes xpa: "xpres xf v \<Gamma> a"
-  and     xpb: "xpres xf v \<Gamma> b"
-  shows   "xpres xf v \<Gamma> (Cond x a b)"
-  apply (rule xpresI)
-  apply (erule exec_Normal_elim_cases)
-   apply (erule (2) xpres_exec0 [OF xpa])
-  apply (erule (2) xpres_exec0 [OF xpb])
-  done
+  assumes "xpres \<Gamma> xf v a"
+  assumes "xpres \<Gamma> xf v b"
+  shows "xpres \<Gamma> xf v (Cond x a b)"
+  by (rule xpres_strong_cond[OF assms] xpres_eq_If_rules)+
 
-lemma xpres_throw:
-  shows   "xpres xf v \<Gamma> Throw"
-  apply (rule xpresI)
-  apply (erule exec_Normal_elim_cases)
-  apply simp
-  done
+lemma xpres_strong_throw':
+  shows   "xpres_strong \<Gamma> xf v Throw True True abnormal"
+  by (rule xpres_strongI; simp?; erule exec_Normal_elim_cases; simp)
 
-lemma xpres_creturn:
-  assumes xfu: "\<And>s f. xf (xfu f s) = xf s"
-  and xfg: "\<And>s f. xf (exnu f s) = xf s"
-  shows   "xpres xf v \<Gamma> (creturn exnu xfu v')"
+lemmas xpres_strong_throw = xpres_strong_throw'[where abnormal=True]
+lemmas xpres_throw = xpres_strong_throw'[where abnormal=False]
+
+lemma xpres_strong_creturn':
+  assumes xfu: "\<And>s f. pres_abr \<Longrightarrow> xf (xfu f s) = xf s"
+  and xfg: "\<And>s f. pres_abr \<Longrightarrow> xf (exnu f s) = xf s"
+  shows   "xpres_strong \<Gamma> xf v (creturn exnu xfu v') True pres_abr abnormal"
   unfolding creturn_def
-  apply (rule xpresI)
-  apply (clarsimp elim!: exec_Normal_elim_cases simp add: xfg xfu)+
-  done
+  by (rule xpres_strongI; clarsimp elim!: exec_Normal_elim_cases simp: xfu xfg)
 
-lemma xpres_creturn_void:
-  assumes xfg: "\<And>s f. xf (exnu f s) = xf s"
-  shows   "xpres xf v \<Gamma> (creturn_void exnu)"
+lemmas xpres_strong_creturn = xpres_strong_creturn'[where pres_abr=True and abnormal=True, simplified]
+lemmas xpres_strong_creturn_False = xpres_strong_creturn'[where pres_abr=False and abnormal=True, simplified]
+lemmas xpres_creturn = xpres_strong_creturn'[where pres_abr=True and abnormal=False, simplified]
+
+lemma xpres_strong_creturn_void':
+  assumes xfg: "\<And>s f. pres_abr \<Longrightarrow> xf (exnu f s) = xf s"
+  shows   "xpres_strong \<Gamma> xf v (creturn_void exnu) True pres_abr abnormal"
   unfolding creturn_void_def
-  apply (rule xpresI)
-  apply (clarsimp elim!: exec_Normal_elim_cases simp add: xfg)
-  done
+  by (rule xpres_strongI; clarsimp elim!: exec_Normal_elim_cases simp: xfg)
 
-lemma xpres_cbreak:
-  assumes xfg: "\<And>s f. xf (exnu f s) = xf s"
-  shows   "xpres xf v \<Gamma> (cbreak exnu)"
+lemmas xpres_strong_creturn_void = xpres_strong_creturn_void'[where pres_abr=True and abnormal=True, simplified]
+lemmas xpres_strong_creturn_void_False = xpres_strong_creturn_void'[where pres_abr=False and abnormal=True, simplified]
+lemmas xpres_creturn_void = xpres_strong_creturn_void'[where pres_abr=True and abnormal=False, simplified]
+
+lemma xpres_strong_cbreak':
+  assumes xfg: "\<And>s f. pres_abr \<Longrightarrow> xf (exnu f s) = xf s"
+  shows   "xpres_strong \<Gamma> xf v (cbreak exnu) True pres_abr abnormal"
   unfolding cbreak_def
-  apply (rule xpresI)
-  apply (clarsimp elim!: exec_Normal_elim_cases simp add: xfg)
-  done
+  by (rule xpres_strongI; clarsimp elim!: exec_Normal_elim_cases simp add: xfg)
+
+lemmas xpres_strong_cbreak = xpres_strong_cbreak'[where pres_abr=True and abnormal=True, simplified]
+lemmas xpres_strong_cbreak_False = xpres_strong_cbreak'[where pres_abr=False and abnormal=True, simplified]
+lemmas xpres_cbreak = xpres_strong_cbreak'[where pres_abr=True and abnormal=False, simplified]
 
 lemma xpres_catchbrk_C:
-  shows   "xpres xf v \<Gamma> (ccatchbrk exnu)"
+  shows   "xpres \<Gamma> xf v (ccatchbrk exnu)"
   unfolding ccatchbrk_def
-  apply (rule xpresI)
-  apply (fastforce elim!: exec_Normal_elim_cases)
-  done
+  by (rule xpresI; fastforce elim!: exec_Normal_elim_cases)
 
-lemma xpres_lvar_nondet_init:
-  assumes xfg: "\<And>s f. xf (st f s) = xf s"
-  shows   "xpres xf v \<Gamma> (lvar_nondet_init gt st)"
-  apply (rule xpresI)
-  apply (simp add: lvar_nondet_init_def)
-  apply (auto elim!: exec_Normal_elim_cases simp add: xfg)
-  done
+lemma xpres_strong_lvar_nondet_init:
+  assumes xfg: "\<And>s f. pres_norm \<Longrightarrow> xf (st f s) = xf s"
+  shows   "xpres_strong \<Gamma> xf v (lvar_nondet_init gt st) pres_norm True False"
+  by (auto intro!: xpres_strongI elim!: exec_Normal_elim_cases simp: xfg lvar_nondet_init_def)
+
+lemmas xpres_lvar_nondet_init_False = xpres_strong_lvar_nondet_init[where pres_norm=False, simplified]
+lemmas xpres_lvar_nondet_init = xpres_strong_lvar_nondet_init[where pres_norm=True, simplified]
 
 (* We ignore DynCom and Call and (for now) Spec.  The first two are covered by xpres_call *)
 lemmas xpres_rules = xpres_skip xpres_basic xpres_seq xpres_while

--- a/lib/clib/XPres.thy
+++ b/lib/clib/XPres.thy
@@ -163,20 +163,26 @@ lemma xpres_while:
   apply simp
   done
 
-lemma xpres_call:
-  assumes ret: "\<And>s t. xf s = v \<Longrightarrow> xf (r s t) = v"
-  and      xp: "\<And>s t. xpres xf v \<Gamma> (c s t)"
-  shows    "xpres xf v \<Gamma> (call i f r c)"
+lemma xpres_call_hoarep_gen:
+  assumes mod: "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/F s\<^esub> (P s) Call f (Q s),(A s)"
+  assumes ret: "\<And>s t. xf s = v \<Longrightarrow> i s \<in> P (x s) \<longrightarrow> t \<in> Q (x s) \<or> t \<in> A (x s) \<Longrightarrow> xf (r s t) = v"
+  assumes xpr: "\<And>s t. xpres xf v \<Gamma> (c s t)"
+  shows "xpres xf v \<Gamma> (call i f r c)"
   apply (rule xpresI)
   apply (erule exec_call_Normal_elim)
-      apply (erule (1) xpres_exec0 [OF xp])
+      apply (erule (1) xpres_exec0[OF xpr])
       apply (erule ret)
+      apply (frule (1) hoarep_exec_call_body[OF mod], fastforce)
      apply simp
      apply (erule subst, erule ret)
+     apply (frule (1) hoarep_exec_call_body[OF mod], fastforce)
     apply simp
    apply simp
   apply simp
   done
+
+lemmas xpres_call = xpres_call_hoarep_gen[OF hoarep_false_pre_gen, simplified]
+lemmas xpres_call_hoarep = xpres_call_hoarep_gen[where P="\<lambda>s. {s}" and x=i and i=i for i, simplified]
 
 lemma xpres_catch:
   assumes xpb: "xpres xf v \<Gamma> b"

--- a/lib/clib/XPres.thy
+++ b/lib/clib/XPres.thy
@@ -25,7 +25,10 @@ lemma xpres_eq_If_True:
 
 lemmas xpres_eq_If_rules = xpres_eq_If_False xpres_eq_If_True
 
-(* Intended to be used to calculate `abnormal` by syntactic analysis of `c`. *)
+(* Intended to be used to calculate `abnormal` by syntactic analysis of `c`.
+   `abnormal` should be true if syntactic analysis of `c` shows that `c`
+   never terminates normally. Note that this does not imply that `c` necessarily
+   terminates abruptly. *)
 definition xpres_abnormal where
   "xpres_abnormal \<Gamma> c abnormal \<equiv> \<forall>s t. abnormal \<longrightarrow> \<not> \<Gamma> \<turnstile> \<langle>c, Normal s\<rangle> \<Rightarrow> Normal t"
 
@@ -100,7 +103,19 @@ lemmas xpres_abnormal_rules
     xpres_abnormal_seq xpres_abnormal_cond xpres_abnormal_call
 
 (* Intended to be used to calculate `pres_norm`, `pres_abr` and `abnormal`
-   by syntactic analysis of `c`. *)
+   by syntactic analysis of `c`.
+
+   Input parameters:
+   - c: the program under consideration.
+   - xf: a function that extracts the value of a particular variable from the state.
+   - v: the presumed value of the variable prior to executing `c`.
+
+   Ouptut parameters:
+   - pres_norm: true if syntactic analysis of `c` shows that the variable
+     still has the value `v` whenever `c` terminates normally.
+   - pres_abr: true if syntactic analysis of `c` shows that the variable
+     still has the value `v` whenever `c` terminates abruptly.
+   - abormal: true if syntactic analysis shows that `c` never terminates normally. *)
 definition xpres_strong ::
   "('s,'p,'f) body \<Rightarrow> ('s \<Rightarrow> 'v) \<Rightarrow> 'v \<Rightarrow> ('s,'p,'f) com \<Rightarrow> bool \<Rightarrow> bool \<Rightarrow> bool \<Rightarrow> bool"
   where

--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -1052,7 +1052,7 @@ lemma createSafeMappingEntries_PDE_ccorres:
       apply (simp add:ARMSuperSectionBits_def word_0_sle_from_less
          ARMSectionBits_def)
       apply (ccorres_remove_UNIV_guard)
-      apply csymbr
+      apply csymbr_legacy
       apply (rule ccorres_rhs_assoc2,rule ccorres_splitE)
           apply (simp only:whileAnno_def)
           apply (ccorres_remove_UNIV_guard)

--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -1049,13 +1049,13 @@ lemma createSafeMappingEntries_PDE_ccorres:
       apply (simp add:ARMSuperSectionBits_def word_0_sle_from_less
          ARMSectionBits_def)
       apply (ccorres_remove_UNIV_guard)
-      apply csymbr_legacy
+      apply csymbr
       apply (rule ccorres_rhs_assoc2,rule ccorres_splitE)
           apply (simp only:whileAnno_def)
           apply (ccorres_remove_UNIV_guard)
           apply (rule_tac r'=dc and xf'=xfdc and F="\<lambda>_. page_directory_at' pd"
                     and Q="{s. pde_range_C.base_C (pde_entries_C
-                                 (ret___struct_create_mappings_pde_return_C_' s))
+                                                   ret___struct_create_mappings_pde_return_C)
                                    = Ptr (lookup_pd_slot pd vaddr)}"
                      in ccorres_sequenceE_while)
                apply (simp add: liftE_bindE)
@@ -1064,7 +1064,7 @@ lemma createSafeMappingEntries_PDE_ccorres:
                            and xf'=ret__int_' in ccorres_split_nothrow_novcg)
                     apply (rule ccorres_add_return2, rule ccorres_pre_getObject_pde)
                     apply (rule_tac P'="{s. let ptr = (pde_range_C.base_C (pde_entries_C
-                                    (ret___struct_create_mappings_pde_return_C_' s)))
+                                                       ret___struct_create_mappings_pde_return_C))
                                   in \<exists>v. cslift s (CTypesDefs.ptr_add ptr (uint (i_' s))) = Some v
                                    \<and> cpde_relation x v
                                    \<and> (i_' s = 0 \<or> array_assertion ptr (Suc (unat (i_' s)))

--- a/proof/crefine/ARM/CSpace_RAB_C.thy
+++ b/proof/crefine/ARM/CSpace_RAB_C.thy
@@ -178,7 +178,7 @@ next
      apply (rule_tac P = "capptr = cptr' \<and> ccap_relation cap' nodeCap" in ccorres_gen_asm2)
      apply (erule conjE)
      apply (erule_tac t = capptr in ssubst)
-     apply csymbr+
+     apply csymbr_legacy+
      apply (simp add: cap_get_tag_isCap split del: if_split)
      apply (thin_tac "ret__unsigned = X" for X)
      apply (rule ccorres_split_throws [where P = "?P"])

--- a/proof/crefine/ARM/CSpace_RAB_C.thy
+++ b/proof/crefine/ARM/CSpace_RAB_C.thy
@@ -17,18 +17,14 @@ abbreviation
               ret__struct_resolveAddressBits_ret_C_')"
 
 lemma rab_failure_case_ccorres:
-  fixes v :: "word32" and ist :: "cstate \<Rightarrow> cstate" and f :: int
-  defines "call_part \<equiv> (call ist f (\<lambda>s t. s\<lparr>globals := globals t\<rparr>)
-             (\<lambda>ts s'. Basic (\<lambda>s.
-                  globals_update (current_lookup_fault_'_update
-                     (\<lambda>_. ret__struct_lookup_fault_C_' s')) s)))"
-  assumes spec: "\<Gamma>\<turnstile> G' call_part {s. v \<noteq> scast EXCEPTION_NONE \<and> lookup_failure_rel e v (errstate s)}"
-  and     mod:  "\<And>s. \<Gamma>\<turnstile> {s'. (s, s') \<in> rf_sr} call_part {s'. (s, s') \<in> rf_sr}"
+  assumes spec: "\<Gamma>\<turnstile> G' call_part {s. resolveAddressBits_ret_C.status_C v \<noteq> scast EXCEPTION_NONE
+                                      \<and> lookup_failure_rel e (resolveAddressBits_ret_C.status_C v)
+                                                           (errstate s)}"
+  assumes mod:  "\<And>s. \<Gamma>\<turnstile> {s'. (s, s') \<in> rf_sr} call_part {s'. (s, s') \<in> rf_sr}"
   shows "ccorres (lookup_failure_rel \<currency> r) rab_xf \<top> G' (SKIP # hs)
    (throwError e)
    (call_part ;;
-    \<acute>ret___struct_resolveAddressBits_ret_C :==
-      resolveAddressBits_ret_C.status_C_update (\<lambda>_. v) \<acute>ret___struct_resolveAddressBits_ret_C;;
+    \<acute>ret___struct_resolveAddressBits_ret_C :== v;;
     return_C ret__struct_resolveAddressBits_ret_C_'_update ret___struct_resolveAddressBits_ret_C_')"
   apply (rule ccorres_rhs_assoc)+
   apply (rule ccorres_symb_exec_r [where R=\<top>, OF _ spec])
@@ -178,7 +174,7 @@ next
      apply (rule_tac P = "capptr = cptr' \<and> ccap_relation cap' nodeCap" in ccorres_gen_asm2)
      apply (erule conjE)
      apply (erule_tac t = capptr in ssubst)
-     apply csymbr_legacy+
+     apply csymbr+
      apply (simp add: cap_get_tag_isCap split del: if_split)
      apply (thin_tac "ret__unsigned = X" for X)
      apply (rule ccorres_split_throws [where P = "?P"])
@@ -480,7 +476,6 @@ next
        apply (vcg strip_guards=true)
       apply (rule conjI)
       \<comment> \<open>Haskell guard\<close>
-       apply (thin_tac "unat n_bits = guard")
        apply (clarsimp simp del: imp_disjL) \<comment> \<open>take a while\<close>
        apply (intro impI conjI allI)
            apply fastforce

--- a/proof/crefine/ARM/Interrupt_C.thy
+++ b/proof/crefine/ARM/Interrupt_C.thy
@@ -144,11 +144,11 @@ lemma decodeIRQHandlerInvocation_ccorres:
        (UNIV
             \<inter> {s. invLabel_' s = label}
             \<inter> {s. irq_' s = ucast irq}
-            \<inter> {s. excaps_' s = extraCaps'}) []
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}) []
      (decodeIRQHandlerInvocation label irq extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeIRQHandler)
      (Call decodeIRQHandlerInvocation_'proc)"
-  apply (cinit' lift: invLabel_' irq_' excaps_'
+  apply (cinit' lift: invLabel_' irq_' current_extra_caps_'
            simp: decodeIRQHandlerInvocation_def invocation_eq_use_types)
    apply (rule ccorres_Cond_rhs)
     apply (simp add: returnOk_bind ccorres_invocationCatch_Inr)
@@ -455,12 +455,12 @@ lemma Arch_decodeIRQControlInvocation_ccorres:
        (UNIV
             \<inter> {s. invLabel_' s = label} \<inter> {s. srcSlot_' s = cte_Ptr slot}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (Arch.decodeIRQControlInvocation label args slot (map fst extraCaps)
         >>= invocationCatch thread isBlocking isCall (InvokeIRQControl o ArchIRQControl))
      (Call Arch_decodeIRQControlInvocation_'proc)"
-  apply (cinit' lift: invLabel_' srcSlot_' length___unsigned_long_' excaps_' buffer_')
+  apply (cinit' lift: invLabel_' srcSlot_' length___unsigned_long_' current_extra_caps_' buffer_')
    apply (simp add: ARM_H.decodeIRQControlInvocation_def invocation_eq_use_types
                del: Collect_const
                cong: StateSpace.state.fold_congs globals.fold_congs)
@@ -627,13 +627,13 @@ lemma decodeIRQControlInvocation_ccorres:
        (UNIV
             \<inter> {s. invLabel_' s = label} \<inter> {s. srcSlot_' s = cte_Ptr slot}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeIRQControlInvocation label args slot (map fst extraCaps)
             >>= invocationCatch thread isBlocking isCall InvokeIRQControl)
      (Call decodeIRQControlInvocation_'proc)"
   supply gen_invocation_type_eq[simp]
-  apply (cinit' lift: invLabel_' srcSlot_' length___unsigned_long_' excaps_' buffer_')
+  apply (cinit' lift: invLabel_' srcSlot_' length___unsigned_long_' current_extra_caps_' buffer_')
    apply (simp add: decodeIRQControlInvocation_def invocation_eq_use_types
                del: Collect_const
               cong: StateSpace.state.fold_congs globals.fold_congs)
@@ -780,6 +780,7 @@ lemma decodeIRQControlInvocation_ccorres:
   apply (clarsimp simp: mask_def[where n=4] "StrictC'_thread_state_defs"
                         rf_sr_ksCurThread ccap_rights_relation_def
                         rightsFromWord_wordFromRights)
+
   apply (simp cong: conj_cong)
   apply (clarsimp simp: Kernel_C.maxIRQ_def word_le_nat_alt
                         ucast_nat_def ucast_ucast_mask mask_eq_ucast_eq unat_ucast_mask

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -108,7 +108,7 @@ lemma decodeDomainInvocation_ccorres:
               and sysargs_rel args buffer)
        (UNIV
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. call_' s = from_bool isCall}
              \<inter> {s. invLabel_' s = lab}
              \<inter> {s. buffer_' s = option_to_ptr buffer}) []
@@ -116,7 +116,7 @@ lemma decodeDomainInvocation_ccorres:
            >>= invocationCatch thread isBlocking isCall (uncurry InvokeDomain))
   (Call decodeDomainInvocation_'proc)"
   supply gen_invocation_type_eq[simp]
-  apply (cinit' lift: length___unsigned_long_' excaps_' call_' invLabel_' buffer_'
+  apply (cinit' lift: length___unsigned_long_' current_extra_caps_' call_' invLabel_' buffer_'
                 simp: decodeDomainInvocation_def list_case_If2 whenE_def)
    apply (rule ccorres_Cond_rhs_Seq)
     apply (simp add: throwError_bind invocationCatch_def invocation_eq_use_types
@@ -561,7 +561,7 @@ lemma decodeCNodeInvocation_ccorres:
        (UNIV
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. ccap_relation cp (cap_' s)}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. call_' s = from_bool isCall}
              \<inter> {s. invLabel_' s = lab}
              \<inter> {s. buffer_' s = option_to_ptr buffer}) []
@@ -573,7 +573,7 @@ lemma decodeCNodeInvocation_ccorres:
    apply (simp add: decodeCNodeInvocation_def
               cong: conj_cong)
    apply (rule ccorres_fail')
-  apply (cinit' (no_subst_asm) lift: length___unsigned_long_' cap_' excaps_'
+  apply (cinit' (no_subst_asm) lift: length___unsigned_long_' cap_' current_extra_caps_'
                                      call_' invLabel_' buffer_')
    apply (clarsimp simp: word_less_nat_alt decodeCNodeInvocation_def
                          list_case_If2 invocation_eq_use_types
@@ -2110,19 +2110,16 @@ lemma invokeUntyped_Retype_ccorres:
           | Some n \<Rightarrow> length destSlots + unat start \<le> 2 ^ n)
        and valid_untyped_inv' (Retype cref reset ptr_base ptr newType us destSlots isdev)
        and K (isdev \<longrightarrow> (newType = APIObjectType ArchTypes_H.apiobject_type.Untyped
-                \<or> isFrameType newType))
-     )
+                \<or> isFrameType newType)))
      (UNIV \<inter>  {s. retypeBase_' s = Ptr ptr}
            \<inter>  {s. srcSlot_' s = Ptr cref}
            \<inter>  {s. reset_' s = from_bool reset}
            \<inter>  {s. newType_' s = object_type_from_H newType }
            \<inter>  {s. unat (userSize_' s) = us }
            \<inter>  {s. deviceMemory_' s = from_bool isdev}
-           \<inter>  \<lbrace>\<acute>destSlots = slot_range_C (cte_Ptr cnodeptr) start
-                                          (of_nat (length destSlots)) \<and>
-                (\<forall>n<length destSlots.
-                    destSlots ! n = cnodeptr + (start + of_nat n) * 2^cteSizeBits)\<rbrace>
-            )
+           \<inter>  {s. destCNode_' s = cte_Ptr cnodeptr}
+           \<inter>  {s. destOffset_' s = start \<and> (\<forall>n < length destSlots. destSlots ! n = cnodeptr + (start + of_nat n) * 2^cteSizeBits)}
+           \<inter>  {s. destLength_' s = of_nat (length destSlots)})
      []
      (invokeUntyped (Retype cref reset ptr_base ptr newType us destSlots isdev))
      (Call invokeUntyped_Retype_'proc)"
@@ -2223,7 +2220,7 @@ lemma invokeUntyped_Retype_ccorres:
          [] (invokeUntyped (Retype cref reset ptr_base ptr newType us destSlots isdev))
             (Call invokeUntyped_Retype_'proc)"
       apply (cinit lift: retypeBase_' srcSlot_' reset_' newType_'
-                          userSize_' deviceMemory_' destSlots_'
+                          userSize_' deviceMemory_' destCNode_' destOffset_' destLength_'
                     simp: when_def)
        apply (rule ccorres_move_c_guard_cte)
        apply csymbr
@@ -2639,7 +2636,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. ccap_relation cp (cap_' s)}
              \<inter> {s. slot_' s = cte_Ptr slot}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. call_' s = from_bool isCall}
              \<inter> {s. buffer_' s = option_to_ptr buffer})
        []
@@ -2649,7 +2646,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
   (Call decodeUntypedInvocation_'proc)"
   supply if_cong[cong] option.case_cong[cong]
   apply (rule ccorres_name_pre)
-  apply (cinit' lift: invLabel_' length___unsigned_long_' cap_' slot_' excaps_' call_' buffer_'
+  apply (cinit' lift: invLabel_' length___unsigned_long_' cap_' slot_' current_extra_caps_' call_' buffer_'
                 simp: decodeUntypedInvocation_def list_case_If2
                       invocation_eq_use_types)
    apply (rule ccorres_Cond_rhs_Seq)
@@ -2875,14 +2872,12 @@ lemma decodeUntypedInvocation_ccorres_helper:
                  apply csymbr
                  apply csymbr
                  apply csymbr
-                 apply csymbr
                  apply (simp add: mapM_locate_eq liftE_bindE
                                   injection_handler_sequenceE mapME_x_sequenceE
                                   whileAnno_def injection_bindE[OF refl refl]
                                   bindE_assoc injection_handler_returnOk)
                  (* gsCNodes assertion *)
                  apply (rule ccorres_stateAssert)
-                 apply csymbr
                  apply (simp add: liftE_bindE[symmetric])
                  apply (rule_tac P="capAligned rv" in ccorres_gen_asm)
                  apply (subgoal_tac "args ! 5 \<le> args ! 4 + args ! 5")
@@ -3031,8 +3026,6 @@ lemma decodeUntypedInvocation_ccorres_helper:
                               apply (frule iffD2[OF olen_add_eqv])
                               apply (frule(1) isUntypedCap_ccap_relation_helper)
                               apply (clarsimp simp: unat_plus_simple[THEN iffD1])
-                              apply (case_tac slots,simp)
-                              apply clarsimp
                               apply (subst upto_enum_word)
                               apply (subst nth_map_upt)
                                apply (clarsimp simp: field_simps Suc_unat_diff_1 unat_plus_simple[THEN iffD1])
@@ -3233,7 +3226,7 @@ shows
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. ccap_relation cp (cap_' s)}
              \<inter> {s. slot_' s = cte_Ptr slot}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. call_' s = from_bool isCall}
              \<inter> {s. buffer_' s = option_to_ptr buffer})
        []

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -2756,7 +2756,7 @@ lemma transferCaps_ccorres [corres]:
      and K (ep \<noteq> Some 0)
      and K (receiveBuffer \<noteq> Some 0)
      and K (unat (msgExtraCaps mi) \<le> 3))
-    (UNIV \<inter> \<lbrace>interpret_excaps (\<acute>caps) = excaps_map caps\<rbrace>
+    (UNIV \<inter> \<lbrace>interpret_excaps \<acute>current_extra_caps = excaps_map caps\<rbrace>
           \<inter> \<lbrace>\<acute>receiver = tcb_ptr_to_ctcb_ptr receiver\<rbrace>
           \<inter> \<lbrace> mi = message_info_to_H \<acute>info\<rbrace>
           \<inter> \<lbrace>\<acute>receiveBuffer = Ptr (option_to_0 receiveBuffer)\<rbrace>
@@ -2764,7 +2764,7 @@ lemma transferCaps_ccorres [corres]:
     (transferCaps mi caps ep receiver receiveBuffer)
     (Call transferCaps_'proc)" (is "ccorres _ _ ?P _ _ _ _")
   apply (unfold K_def, intro ccorres_gen_asm)
-  apply (cinit lift: caps_' receiver_' info_' receiveBuffer_' endpoint_'
+  apply (cinit lift: current_extra_caps_' receiver_' info_' receiveBuffer_' endpoint_'
     simp: getThreadCSpaceRoot_def locateSlot_conv whileAnno_def)
    apply csymbr+
    apply (rule_tac P="?P" and P'="{s. info_' s = info}" in ccorres_inst)
@@ -2804,7 +2804,7 @@ lemma transferCaps_ccorres [corres]:
         apply (rule ccorres_add_return2)
         apply (rule ccorres_split_nothrow_novcg)
             apply (rule ccorres_Catch)
-            apply (rule_tac caps=caps and caps'=capsa in transferCapsLoop_ccorres, simp+)
+            apply (rule_tac caps=caps and caps'=current_extra_caps in transferCapsLoop_ccorres, simp+)
             apply (simp add: excaps_map_def)
            apply ceqv
           apply csymbr
@@ -3154,21 +3154,18 @@ proof -
                  cong: call_ignore_cong)
      apply (clarsimp cong: call_ignore_cong simp del: dc_simp)
      apply (ctac(c_lines 2, no_vcg) add: getMessageInfo_ccorres')
-       apply (rule_tac xf'=caps_' and r'="\<lambda>c c'. interpret_excaps c' = excaps_map c"
-                  in ccorres_split_nothrow_novcg)
+       apply (rule_tac xf'="\<lambda>s. current_extra_caps_' (globals s)"
+                   and r'="\<lambda>c c'. interpret_excaps c' = excaps_map c"
+              in ccorres_split_nothrow_novcg)
            apply (rule ccorres_if_lhs)
             apply (simp add: catch_def to_bool_def ccorres_cond_iffs)
-            apply (rule ccorres_rhs_assoc)+
-            apply (rule_tac xf'="\<lambda>s. (status_' s,
-                                current_extra_caps_' (globals s))"
-                             and ef'=fst and vf'=snd and es=errstate
-                        in ccorres_split_nothrow_case_sum)
+            apply (rule_tac xf'="\<lambda>s. (status_' s, current_extra_caps_' (globals s))"
+                        and ef'=fst and vf'=snd and es=errstate and R'=UNIV
+                   in ccorres_split_nothrow_case_sum)
                  apply (rule ccorres_call, rule lookupExtraCaps_ccorres, simp+)
                 apply (rule ceqv_tuple2, ceqv, ceqv)
                apply (simp add: ccorres_cond_iffs)
-               apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
-               apply (rule allI, rule conseqPre, vcg)
-               apply (clarsimp simp: return_def)
+               apply (rule ccorres_return_Skip')
               apply (simp add: ccorres_cond_iffs)
               apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
               apply (rule allI, rule conseqPre, vcg)
@@ -3176,38 +3173,37 @@ proof -
                                     word_sless_def word_sle_def)
              apply wp
             apply simp
-            apply (vcg exspec=lookupExtraCaps_modifies)
+            apply (vcg exspec=lookupExtraCaps_modifies, simp)
            apply (simp add: to_bool_def ccorres_cond_iffs)
-           apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
-           apply (rule allI, rule conseqPre, vcg)
-           apply (clarsimp simp: return_def excaps_map_def interpret_excaps_empty
-                                 word_sle_def word_sless_def)
+           apply (rule ccorres_return[where R=\<top> and R'=UNIV], vcg)
+           apply (clarsimp simp: excaps_map_def interpret_excaps_empty)
           apply ceqv
          apply csymbr
-         apply (ctac(no_vcg) add: copyMRs_ccorres)
-          apply (ctac(no_vcg) add: transferCaps_ccorres)
-           apply csymbr
-           apply (ctac(c_lines 2, no_vcg) add: setMessageInfo_ccorres)
-             apply ctac
+         apply (ctac add: copyMRs_ccorres)
+           apply (ctac add: transferCaps_ccorres)
+             apply csymbr
+             apply (ctac(c_lines 2, no_vcg) add: setMessageInfo_ccorres)
+               apply ctac
+              apply wp
+             apply (clarsimp simp: Kernel_C.badgeRegister_def ARM_H.badgeRegister_def
+                                ARM.badgeRegister_def Kernel_C.R0_def)
             apply wp
-           apply (clarsimp simp: Kernel_C.badgeRegister_def ARM_H.badgeRegister_def
-                              ARM.badgeRegister_def Kernel_C.R0_def)
-          apply wp
-         apply simp
-         apply (wp hoare_case_option_wp getMessageInfo_le3
-                   getMessageInfo_msgLength lookupExtraCaps_excaps_in_mem
-                   lookupExtraCaps_length
-                    | simp)+
+           apply (simp add: seL4_MessageInfo_lift_def message_info_to_H_def msgLengthBits_def)
+           apply (vcg exspec=transferCaps_modifies)
+          apply (wpsimp wp: hoare_case_option_wp)
+         apply clarsimp
+         apply (vcg exspec=copyMRs_modifies)
+        apply (wpsimp wp: lookupExtraCaps_length)
        apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem)
        apply (clarsimp simp: seL4_MessageInfo_lift_def message_info_to_H_def mask_def
                              msgLengthBits_def word_bw_assocs)
       apply (wp getMessageInfo_le3 getMessageInfo_msgLength[unfolded K_def] static_imp_wp
                   | simp)+
      apply (simp add: Collect_const_mem)
-    apply (auto simp: excaps_in_mem_def valid_ipc_buffer_ptr'_def
-                      option_to_0_def option_to_ptr_def
-                      seL4_MessageInfo_lift_def mi_from_H_def message_info_to_H_def
-               split: option.split)
+     apply (auto simp: excaps_in_mem_def valid_ipc_buffer_ptr'_def
+                       option_to_0_def option_to_ptr_def
+                       seL4_MessageInfo_lift_def mi_from_H_def message_info_to_H_def
+                split: option.split)
     done
 qed
 

--- a/proof/crefine/ARM/Recycle_C.thy
+++ b/proof/crefine/ARM/Recycle_C.thy
@@ -643,7 +643,7 @@ lemma cancelBadgedSends_ccorres:
           apply (induct_tac list)
            apply (rule allI)
            apply (rule iffD1 [OF ccorres_expand_while_iff_Seq])
-           apply (rule ccorres_tmp_lift2 [OF _ _ refl])
+           apply (rule ccorres_tmp_lift2 [OF _ _ Int_lower1])
             apply ceqv
            apply (simp add: ccorres_cond_iffs)
            apply (rule ccorres_rhs_assoc2)

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -6820,10 +6820,9 @@ shows  "ccorres dc xfdc
             (length destSlots * 2 ^ APIType_capBits newType userSize) s)}
            \<inter> {s. t_' s = object_type_from_H newType}
            \<inter> {s. parent_' s = cte_Ptr srcSlot}
-           \<inter> {s. slots_' s = slot_range_C (cte_Ptr cnodeptr) start num
-                     \<and> unat num \<noteq> 0
-                     \<and> (\<forall>n. n < length destSlots \<longrightarrow> destSlots ! n = cnodeptr + ((start + of_nat n) * 0x10))
-                     }
+           \<inter> {s. destCNode_' s = cte_Ptr cnodeptr}
+           \<inter> {s. destOffset_' s = start \<and> (\<forall>n. n < length destSlots \<longrightarrow> destSlots ! n = cnodeptr + ((start + of_nat n) * 0x10))}
+           \<inter> {s. destLength_' s = num \<and> unat num \<noteq> 0}
            \<inter> {s. regionBase_' s = Ptr ptr }
            \<inter> {s. unat_eq (userSize_' s) userSize}
            \<inter> {s. to_bool (deviceMemory_' s) = isdev}
@@ -6838,7 +6837,7 @@ shows  "ccorres dc xfdc
    apply (subst unat_of_nat32)
     apply (rule less_le_trans [OF getObjectSize_max_size], auto simp: word_bits_def untypedBits_defs)[1]
    apply simp
-  apply (cinit lift: t_' parent_' slots_' regionBase_' userSize_' deviceMemory_')
+  apply (cinit lift: t_' parent_' destCNode_' destOffset_' destLength_' regionBase_' userSize_' deviceMemory_')
    apply (rule ccorres_rhs_assoc2)+
    apply (rule ccorres_rhs_assoc)
    apply (rule_tac Q' = "Q'

--- a/proof/crefine/ARM/Syscall_C.thy
+++ b/proof/crefine/ARM/Syscall_C.thy
@@ -122,21 +122,21 @@ lemma decodeInvocation_ccorres:
               and (\<lambda>s. \<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p))
               and sysargs_rel args buffer)
        (UNIV \<inter> {s. call_' s = from_bool isCall}
-                   \<inter> {s. block_' s = from_bool isBlocking}
-                   \<inter> {s. call_' s = from_bool isCall}
-                   \<inter> {s. block_' s = from_bool isBlocking}
-                   \<inter> {s. invLabel_' s = label}
-                   \<inter> {s. unat (length___unsigned_long_' s) = length args}
-                   \<inter> {s. capIndex_' s = cptr}
-                   \<inter> {s. slot_' s = cte_Ptr slot}
-                   \<inter> {s. excaps_' s = extraCaps'}
-                   \<inter> {s. ccap_relation cp (cap_' s)}
-                   \<inter> {s. buffer_' s = option_to_ptr buffer}) []
+             \<inter> {s. block_' s = from_bool isBlocking}
+             \<inter> {s. call_' s = from_bool isCall}
+             \<inter> {s. block_' s = from_bool isBlocking}
+             \<inter> {s. invLabel_' s = label}
+             \<inter> {s. unat (length___unsigned_long_' s) = length args}
+             \<inter> {s. capIndex_' s = cptr}
+             \<inter> {s. slot_' s = cte_Ptr slot}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
+             \<inter> {s. ccap_relation cp (cap_' s)}
+             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
        (decodeInvocation label args cptr slot cp extraCaps
               >>= invocationCatch thread isBlocking isCall id)
        (Call decodeInvocation_'proc)"
   apply (cinit' lift: call_' block_' invLabel_' length___unsigned_long_'
-                      capIndex_' slot_' excaps_' cap_' buffer_')
+                      capIndex_' slot_' current_extra_caps_' cap_' buffer_')
    apply csymbr
    apply (simp add: cap_get_tag_isCap decodeInvocation_def
               cong: if_cong StateSpace.state.fold_congs

--- a/proof/crefine/ARM/Tcb_C.thy
+++ b/proof/crefine/ARM/Tcb_C.thy
@@ -2373,12 +2373,12 @@ lemma decodeCopyRegisters_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeCopyRegisters args cp (map fst extraCaps)
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeCopyRegisters_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeCopyRegisters_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeCopyRegisters_def)
    apply csymbr
    apply wpc
     apply (simp add: if_1_0_0 unat_eq_0)
@@ -2770,12 +2770,13 @@ lemma decodeTCBConfigure_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. rootCaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeTCBConfigure args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeTCBConfigure_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' slot_' rootCaps_' buffer_' simp: decodeTCBConfigure_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' slot_' current_extra_caps_' buffer_'
+                simp: decodeTCBConfigure_def)
    apply csymbr
    apply (clarsimp cong: StateSpace.state.fold_congs globals.fold_congs
                simp del: Collect_const
@@ -3168,14 +3169,14 @@ lemma decodeSetMCPriority_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetMCPriority args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetMCPriority_'proc)"
   supply Collect_const[simp del]
   supply dc_simp[simp del]
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeSetMCPriority_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetMCPriority_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
    apply (rule_tac xf'=ret__int_' and R'=UNIV and R=\<top> and
@@ -3304,13 +3305,13 @@ lemma decodeSetPriority_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetPriority args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetPriority_'proc)"
   supply Collect_const[simp del] dc_simp[simp del]
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeSetPriority_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetPriority_def)
      apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
    apply (rule_tac xf'=ret__int_' and R'=UNIV and R=\<top> and
@@ -3453,13 +3454,13 @@ lemma decodeSetSchedParams_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetSchedParams args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetSchedParams_'proc)"
   supply Collect_const[simp del] dc_simp[simp del]
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeSetSchedParams_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetSchedParams_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
    apply (rule_tac xf'=ret__int_' and R'=UNIV and R=\<top> and
@@ -3603,12 +3604,12 @@ lemma decodeSetIPCBuffer_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetIPCBuffer args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetIPCBuffer_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' slot_' excaps_' buffer_'
+  apply (cinit' lift: cap_' length___unsigned_long_' slot_' current_extra_caps_' buffer_'
                 simp: decodeSetIPCBuffer_def)
    apply wpc
     apply (simp add: unat_eq_0)
@@ -3903,11 +3904,11 @@ lemma decodeBindNotification_ccorres:
               and (excaps_in_mem extraCaps o ctes_of)
               and K (isThreadCap cp))
        (UNIV \<inter> {s. ccap_relation cp (cap_' s)}
-             \<inter> {s. excaps_' s = extraCaps'}) []
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}) []
      (decodeBindNotification cp extraCaps >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeBindNotification_'proc)"
   apply (simp, rule ccorres_gen_asm)
-  apply (cinit' lift: cap_' excaps_' simp: decodeBindNotification_def)
+  apply (cinit' lift: cap_' current_extra_caps_' simp: decodeBindNotification_def)
    apply (simp add: bind_assoc whenE_def bind_bindE_assoc interpret_excaps_test_null
                del: Collect_const cong: call_ignore_cong)
    apply (rule ccorres_Cond_rhs_Seq)
@@ -4102,12 +4103,12 @@ lemma decodeSetSpace_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetSpace args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetSpace_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' slot_' excaps_' buffer_'
+  apply (cinit' lift: cap_' length___unsigned_long_' slot_' current_extra_caps_' buffer_'
                 simp: decodeSetSpace_def)
    apply csymbr
    apply (rule ccorres_Cond_rhs_Seq)
@@ -4475,13 +4476,13 @@ lemma decodeTCBInvocation_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. call_' s = from_bool isCall}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeTCBInvocation label args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeTCBInvocation_'proc)"
-  apply (cinit' lift: invLabel_' cap_' length___unsigned_long_' slot_' excaps_' call_' buffer_')
+  apply (cinit' lift: invLabel_' cap_' length___unsigned_long_' slot_' current_extra_caps_' call_' buffer_')
    apply (simp add: decodeTCBInvocation_def invocation_eq_use_types gen_invocation_type_eq
                del: Collect_const)
    apply (rule ccorres_Cond_rhs)

--- a/proof/crefine/ARM_HYP/Arch_C.thy
+++ b/proof/crefine/ARM_HYP/Arch_C.thy
@@ -1073,7 +1073,7 @@ lemma createSafeMappingEntries_PDE_ccorres:
       apply (simp add:ARMSuperSectionBits_def word_0_sle_from_less
          ARMSectionBits_def)
       apply (ccorres_remove_UNIV_guard)
-      apply csymbr
+      apply csymbr_legacy
       apply (rule ccorres_rhs_assoc2,rule ccorres_splitE)
           apply (simp only:whileAnno_def)
           apply (ccorres_remove_UNIV_guard)

--- a/proof/crefine/ARM_HYP/Arch_C.thy
+++ b/proof/crefine/ARM_HYP/Arch_C.thy
@@ -1070,13 +1070,13 @@ lemma createSafeMappingEntries_PDE_ccorres:
       apply (simp add:ARMSuperSectionBits_def word_0_sle_from_less
          ARMSectionBits_def)
       apply (ccorres_remove_UNIV_guard)
-      apply csymbr_legacy
+      apply csymbr
       apply (rule ccorres_rhs_assoc2,rule ccorres_splitE)
           apply (simp only:whileAnno_def)
           apply (ccorres_remove_UNIV_guard)
           apply (rule_tac r'=dc and xf'=xfdc and F="\<lambda>_. page_directory_at' pd"
                     and Q="{s. pde_range_C.base_C (pde_entries_C
-                                 (ret___struct_create_mappings_pde_return_C_' s))
+                                                   ret___struct_create_mappings_pde_return_C)
                                    = Ptr (lookup_pd_slot pd vaddr)}"
                      in ccorres_sequenceE_while)
                apply (simp add: liftE_bindE)
@@ -1085,7 +1085,7 @@ lemma createSafeMappingEntries_PDE_ccorres:
                            and xf'=ret__int_' in ccorres_split_nothrow_novcg)
                     apply (rule ccorres_add_return2, rule ccorres_pre_getObject_pde)
                     apply (rule_tac P'="{s. let ptr = (pde_range_C.base_C (pde_entries_C
-                                    (ret___struct_create_mappings_pde_return_C_' s)))
+                                                       ret___struct_create_mappings_pde_return_C))
                                   in \<exists>v. cslift s (CTypesDefs.ptr_add ptr (uint (i_' s))) = Some v
                                    \<and> cpde_relation x v
                                    \<and> (i_' s = 0 \<or> array_assertion ptr (Suc (unat (i_' s)))

--- a/proof/crefine/ARM_HYP/CSpace_RAB_C.thy
+++ b/proof/crefine/ARM_HYP/CSpace_RAB_C.thy
@@ -214,7 +214,7 @@ next
      apply (rule_tac P = "capptr = cptr' \<and> ccap_relation cap' nodeCap" in ccorres_gen_asm2)
      apply (erule conjE)
      apply (erule_tac t = capptr in ssubst)
-     apply csymbr+
+     apply csymbr_legacy+
      apply (simp add: cap_get_tag_isCap split del: if_split)
      apply (thin_tac "ret__unsigned = X" for X)
      apply (rule ccorres_split_throws [where P = "?P"])

--- a/proof/crefine/ARM_HYP/CSpace_RAB_C.thy
+++ b/proof/crefine/ARM_HYP/CSpace_RAB_C.thy
@@ -17,18 +17,14 @@ abbreviation
               ret__struct_resolveAddressBits_ret_C_')"
 
 lemma rab_failure_case_ccorres:
-  fixes v :: "word32" and ist :: "cstate \<Rightarrow> cstate" and f :: int
-  defines "call_part \<equiv> (call ist f (\<lambda>s t. s\<lparr>globals := globals t\<rparr>)
-             (\<lambda>ts s'. Basic (\<lambda>s.
-                  globals_update (current_lookup_fault_'_update
-                     (\<lambda>_. ret__struct_lookup_fault_C_' s')) s)))"
-  assumes spec: "\<Gamma>\<turnstile> G' call_part {s. v \<noteq> scast EXCEPTION_NONE \<and> lookup_failure_rel e v (errstate s)}"
-  and     mod:  "\<And>s. \<Gamma>\<turnstile> {s'. (s, s') \<in> rf_sr} call_part {s'. (s, s') \<in> rf_sr}"
+  assumes spec: "\<Gamma>\<turnstile> G' call_part {s. resolveAddressBits_ret_C.status_C v \<noteq> scast EXCEPTION_NONE
+                                      \<and> lookup_failure_rel e (resolveAddressBits_ret_C.status_C v)
+                                                           (errstate s)}"
+  assumes mod:  "\<And>s. \<Gamma>\<turnstile> {s'. (s, s') \<in> rf_sr} call_part {s'. (s, s') \<in> rf_sr}"
   shows "ccorres (lookup_failure_rel \<currency> r) rab_xf \<top> G' (SKIP # hs)
    (throwError e)
    (call_part ;;
-    \<acute>ret___struct_resolveAddressBits_ret_C :==
-      resolveAddressBits_ret_C.status_C_update (\<lambda>_. v) \<acute>ret___struct_resolveAddressBits_ret_C;;
+    \<acute>ret___struct_resolveAddressBits_ret_C :== v;;
     return_C ret__struct_resolveAddressBits_ret_C_'_update ret___struct_resolveAddressBits_ret_C_')"
   apply (rule ccorres_rhs_assoc)+
   apply (rule ccorres_symb_exec_r [where R=\<top>, OF _ spec])
@@ -214,7 +210,7 @@ next
      apply (rule_tac P = "capptr = cptr' \<and> ccap_relation cap' nodeCap" in ccorres_gen_asm2)
      apply (erule conjE)
      apply (erule_tac t = capptr in ssubst)
-     apply csymbr_legacy+
+     apply csymbr+
      apply (simp add: cap_get_tag_isCap split del: if_split)
      apply (thin_tac "ret__unsigned = X" for X)
      apply (rule ccorres_split_throws [where P = "?P"])
@@ -515,7 +511,6 @@ next
        apply (vcg strip_guards=true)
       apply (rule conjI)
       \<comment> \<open>Haskell guard\<close>
-       apply (thin_tac "unat n_bits = guard")
        apply (clarsimp simp del: imp_disjL) \<comment> \<open>take a while\<close>
        apply (intro impI conjI allI)
            apply fastforce

--- a/proof/crefine/ARM_HYP/Interrupt_C.thy
+++ b/proof/crefine/ARM_HYP/Interrupt_C.thy
@@ -151,11 +151,11 @@ lemma decodeIRQHandlerInvocation_ccorres:
        (UNIV
             \<inter> {s. invLabel_' s = label}
             \<inter> {s. irq_' s = ucast irq}
-            \<inter> {s. excaps_' s = extraCaps'}) []
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}) []
      (decodeIRQHandlerInvocation label irq extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeIRQHandler)
      (Call decodeIRQHandlerInvocation_'proc)"
-  apply (cinit' lift: invLabel_' irq_' excaps_'
+  apply (cinit' lift: invLabel_' irq_' current_extra_caps_'
            simp: decodeIRQHandlerInvocation_def invocation_eq_use_types)
    apply (rule ccorres_Cond_rhs)
     apply (simp add: returnOk_bind ccorres_invocationCatch_Inr)
@@ -426,12 +426,12 @@ lemma Arch_decodeIRQControlInvocation_ccorres:
        (UNIV
             \<inter> {s. invLabel_' s = label} \<inter> {s. srcSlot_' s = cte_Ptr slot}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (Arch.decodeIRQControlInvocation label args slot (map fst extraCaps)
         >>= invocationCatch thread isBlocking isCall (InvokeIRQControl o ArchIRQControl))
      (Call Arch_decodeIRQControlInvocation_'proc)"
-  apply (cinit' lift: invLabel_' srcSlot_' length___unsigned_long_' excaps_' buffer_')
+  apply (cinit' lift: invLabel_' srcSlot_' length___unsigned_long_' current_extra_caps_' buffer_')
    apply (simp add: ARM_HYP_H.decodeIRQControlInvocation_def invocation_eq_use_types
                del: Collect_const
                cong: StateSpace.state.fold_congs globals.fold_congs)
@@ -599,13 +599,13 @@ lemma decodeIRQControlInvocation_ccorres:
        (UNIV
             \<inter> {s. invLabel_' s = label} \<inter> {s. srcSlot_' s = cte_Ptr slot}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeIRQControlInvocation label args slot (map fst extraCaps)
             >>= invocationCatch thread isBlocking isCall InvokeIRQControl)
      (Call decodeIRQControlInvocation_'proc)"
   supply gen_invocation_type_eq[simp]
-  apply (cinit' lift: invLabel_' srcSlot_' length___unsigned_long_' excaps_' buffer_')
+  apply (cinit' lift: invLabel_' srcSlot_' length___unsigned_long_' current_extra_caps_' buffer_')
    apply (simp add: decodeIRQControlInvocation_def invocation_eq_use_types
                del: Collect_const
               cong: StateSpace.state.fold_congs globals.fold_congs)

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -108,7 +108,7 @@ lemma decodeDomainInvocation_ccorres:
               and sysargs_rel args buffer)
        (UNIV
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. call_' s = from_bool isCall}
              \<inter> {s. invLabel_' s = lab}
              \<inter> {s. buffer_' s = option_to_ptr buffer}) []
@@ -116,7 +116,7 @@ lemma decodeDomainInvocation_ccorres:
            >>= invocationCatch thread isBlocking isCall (uncurry InvokeDomain))
   (Call decodeDomainInvocation_'proc)"
   supply gen_invocation_type_eq[simp]
-  apply (cinit' lift: length___unsigned_long_' excaps_' call_' invLabel_' buffer_'
+  apply (cinit' lift: length___unsigned_long_' current_extra_caps_' call_' invLabel_' buffer_'
                 simp: decodeDomainInvocation_def list_case_If2 whenE_def)
    apply (rule ccorres_Cond_rhs_Seq)
     apply (simp add: throwError_bind invocationCatch_def invocation_eq_use_types
@@ -580,7 +580,7 @@ lemma decodeCNodeInvocation_ccorres:
        (UNIV
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. ccap_relation cp (cap_' s)}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. call_' s = from_bool isCall}
              \<inter> {s. invLabel_' s = lab}
              \<inter> {s. buffer_' s = option_to_ptr buffer}) []
@@ -592,7 +592,7 @@ lemma decodeCNodeInvocation_ccorres:
    apply (simp add: decodeCNodeInvocation_def
               cong: conj_cong)
    apply (rule ccorres_fail')
-  apply (cinit' (no_subst_asm) lift: length___unsigned_long_' cap_' excaps_'
+  apply (cinit' (no_subst_asm) lift: length___unsigned_long_' cap_' current_extra_caps_'
                                      call_' invLabel_' buffer_')
    apply (clarsimp simp: word_less_nat_alt decodeCNodeInvocation_def
                          list_case_If2 invocation_eq_use_types
@@ -2273,11 +2273,9 @@ lemma invokeUntyped_Retype_ccorres:
            \<inter>  {s. newType_' s = object_type_from_H newType }
            \<inter>  {s. unat (userSize_' s) = us }
            \<inter>  {s. deviceMemory_' s = from_bool isdev}
-           \<inter>  \<lbrace>\<acute>destSlots = slot_range_C (cte_Ptr cnodeptr) start
-                                          (of_nat (length destSlots)) \<and>
-                (\<forall>n<length destSlots.
-                    destSlots ! n = cnodeptr + (start + of_nat n) * 2^cteSizeBits)\<rbrace>
-            )
+           \<inter>  {s. destCNode_' s = cte_Ptr cnodeptr}
+           \<inter>  {s. destOffset_' s = start \<and> (\<forall>n < length destSlots. destSlots ! n = cnodeptr + (start + of_nat n) * 2^cteSizeBits)}
+           \<inter>  {s. destLength_' s = of_nat (length destSlots)})
      []
      (invokeUntyped (Retype cref reset ptr_base ptr newType us destSlots isdev))
      (Call invokeUntyped_Retype_'proc)"
@@ -2378,7 +2376,7 @@ lemma invokeUntyped_Retype_ccorres:
          [] (invokeUntyped (Retype cref reset ptr_base ptr newType us destSlots isdev))
             (Call invokeUntyped_Retype_'proc)"
       apply (cinit lift: retypeBase_' srcSlot_' reset_' newType_'
-                          userSize_' deviceMemory_' destSlots_'
+                          userSize_' deviceMemory_' destCNode_' destOffset_' destLength_'
                     simp: when_def)
        apply (rule ccorres_move_c_guard_cte)
        apply csymbr
@@ -2837,7 +2835,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. ccap_relation cp (cap_' s)}
              \<inter> {s. slot_' s = cte_Ptr slot}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. call_' s = from_bool isCall}
              \<inter> {s. buffer_' s = option_to_ptr buffer})
        []
@@ -2847,7 +2845,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
   (Call decodeUntypedInvocation_'proc)"
   supply if_cong[cong] option.case_cong[cong]
   apply (rule ccorres_name_pre)
-  apply (cinit' lift: invLabel_' length___unsigned_long_' cap_' slot_' excaps_' call_' buffer_'
+  apply (cinit' lift: invLabel_' length___unsigned_long_' cap_' slot_' current_extra_caps_' call_' buffer_'
                 simp: decodeUntypedInvocation_def list_case_If2
                       invocation_eq_use_types)
    apply (rule ccorres_Cond_rhs_Seq)
@@ -3074,14 +3072,12 @@ lemma decodeUntypedInvocation_ccorres_helper:
                  apply csymbr
                  apply csymbr
                  apply csymbr
-                 apply csymbr
                  apply (simp add: mapM_locate_eq liftE_bindE
                                   injection_handler_sequenceE mapME_x_sequenceE
                                   whileAnno_def injection_bindE[OF refl refl]
                                   bindE_assoc injection_handler_returnOk)
                  (* gsCNodes assertion *)
                  apply (rule ccorres_stateAssert)
-                 apply csymbr
                  apply (simp add: liftE_bindE[symmetric])
                  apply (rule_tac P="capAligned rv" in ccorres_gen_asm)
                  apply (subgoal_tac "args ! 5 \<le> args ! 4 + args ! 5")
@@ -3235,8 +3231,6 @@ lemma decodeUntypedInvocation_ccorres_helper:
                               apply (frule iffD2[OF olen_add_eqv])
                               apply (frule(1) isUntypedCap_ccap_relation_helper)
                               apply (clarsimp simp: unat_plus_simple[THEN iffD1])
-                              apply (case_tac slots,simp)
-                              apply clarsimp
                               apply (subst upto_enum_word)
                               apply (subst nth_map_upt)
                                apply (clarsimp simp: field_simps Suc_unat_diff_1 unat_plus_simple[THEN iffD1])
@@ -3438,7 +3432,7 @@ shows
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. ccap_relation cp (cap_' s)}
              \<inter> {s. slot_' s = cte_Ptr slot}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. call_' s = from_bool isCall}
              \<inter> {s. buffer_' s = option_to_ptr buffer})
        []

--- a/proof/crefine/ARM_HYP/Recycle_C.thy
+++ b/proof/crefine/ARM_HYP/Recycle_C.thy
@@ -983,7 +983,7 @@ lemma cancelBadgedSends_ccorres:
           apply (induct_tac list)
            apply (rule allI)
            apply (rule iffD1 [OF ccorres_expand_while_iff_Seq])
-           apply (rule ccorres_tmp_lift2 [OF _ _ refl])
+           apply (rule ccorres_tmp_lift2 [OF _ _ Int_lower1])
             apply ceqv
            apply (simp add: ccorres_cond_iffs)
            apply (rule ccorres_rhs_assoc2)

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -8211,10 +8211,9 @@ shows  "ccorres dc xfdc
             (length destSlots * 2 ^ APIType_capBits newType userSize) s)}
            \<inter> {s. t_' s = object_type_from_H newType}
            \<inter> {s. parent_' s = cte_Ptr srcSlot}
-           \<inter> {s. slots_' s = slot_range_C (cte_Ptr cnodeptr) start num
-                     \<and> unat num \<noteq> 0
-                     \<and> (\<forall>n. n < length destSlots \<longrightarrow> destSlots ! n = cnodeptr + ((start + of_nat n) * 0x10))
-                     }
+           \<inter> {s. destCNode_' s = cte_Ptr cnodeptr}
+           \<inter> {s. destOffset_' s = start \<and> (\<forall>n. n < length destSlots \<longrightarrow> destSlots ! n = cnodeptr + ((start + of_nat n) * 0x10))}
+           \<inter> {s. destLength_' s = num \<and> unat num \<noteq> 0}
            \<inter> {s. regionBase_' s = Ptr ptr }
            \<inter> {s. unat_eq (userSize_' s) userSize}
            \<inter> {s. to_bool (deviceMemory_' s) = isdev}
@@ -8229,7 +8228,7 @@ shows  "ccorres dc xfdc
    apply (subst unat_of_nat32)
     apply (rule less_le_trans [OF getObjectSize_max_size], auto simp: word_bits_def untypedBits_defs)[1]
    apply simp
-  apply (cinit lift: t_' parent_' slots_' regionBase_' userSize_' deviceMemory_')
+  apply (cinit lift: t_' parent_' destCNode_' destOffset_' destLength_' regionBase_' userSize_' deviceMemory_')
    apply (rule ccorres_rhs_assoc2)+
    apply (rule ccorres_rhs_assoc)
    apply (rule_tac Q' = "Q'

--- a/proof/crefine/ARM_HYP/Syscall_C.thy
+++ b/proof/crefine/ARM_HYP/Syscall_C.thy
@@ -128,21 +128,21 @@ lemma decodeInvocation_ccorres:
               and (\<lambda>s. \<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p))
               and sysargs_rel args buffer)
        (UNIV \<inter> {s. call_' s = from_bool isCall}
-                   \<inter> {s. block_' s = from_bool isBlocking}
-                   \<inter> {s. call_' s = from_bool isCall}
-                   \<inter> {s. block_' s = from_bool isBlocking}
-                   \<inter> {s. invLabel_' s = label}
-                   \<inter> {s. unat (length___unsigned_long_' s) = length args}
-                   \<inter> {s. capIndex_' s = cptr}
-                   \<inter> {s. slot_' s = cte_Ptr slot}
-                   \<inter> {s. excaps_' s = extraCaps'}
-                   \<inter> {s. ccap_relation cp (cap_' s)}
-                   \<inter> {s. buffer_' s = option_to_ptr buffer}) []
+             \<inter> {s. block_' s = from_bool isBlocking}
+             \<inter> {s. call_' s = from_bool isCall}
+             \<inter> {s. block_' s = from_bool isBlocking}
+             \<inter> {s. invLabel_' s = label}
+             \<inter> {s. unat (length___unsigned_long_' s) = length args}
+             \<inter> {s. capIndex_' s = cptr}
+             \<inter> {s. slot_' s = cte_Ptr slot}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
+             \<inter> {s. ccap_relation cp (cap_' s)}
+             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
        (decodeInvocation label args cptr slot cp extraCaps
               >>= invocationCatch thread isBlocking isCall id)
        (Call decodeInvocation_'proc)"
   apply (cinit' lift: call_' block_' invLabel_' length___unsigned_long_'
-                      capIndex_' slot_' excaps_' cap_' buffer_')
+                      capIndex_' slot_' current_extra_caps_' cap_' buffer_')
    apply csymbr
    apply (simp add: cap_get_tag_isCap decodeInvocation_def
               cong: if_cong StateSpace.state.fold_congs

--- a/proof/crefine/ARM_HYP/Tcb_C.thy
+++ b/proof/crefine/ARM_HYP/Tcb_C.thy
@@ -2444,12 +2444,12 @@ lemma decodeCopyRegisters_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeCopyRegisters args cp (map fst extraCaps)
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeCopyRegisters_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeCopyRegisters_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeCopyRegisters_def)
    apply csymbr
    apply wpc
     apply (simp add: if_1_0_0 unat_eq_0)
@@ -2864,12 +2864,13 @@ lemma decodeTCBConfigure_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. rootCaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeTCBConfigure args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeTCBConfigure_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' slot_' rootCaps_' buffer_' simp: decodeTCBConfigure_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' slot_' current_extra_caps_' buffer_'
+                simp: decodeTCBConfigure_def)
    apply csymbr
    apply (clarsimp cong: StateSpace.state.fold_congs globals.fold_congs
                simp del: Collect_const
@@ -3261,14 +3262,14 @@ lemma decodeSetMCPriority_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetMCPriority args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetMCPriority_'proc)"
   supply Collect_const[simp del]
   supply dc_simp[simp del]
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeSetMCPriority_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetMCPriority_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
    apply (rule_tac xf'=ret__int_' and R'=UNIV and R=\<top> and
@@ -3397,13 +3398,13 @@ lemma decodeSetPriority_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetPriority args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetPriority_'proc)"
   supply Collect_const[simp del] dc_simp[simp del]
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeSetPriority_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetPriority_def)
      apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
    apply (rule_tac xf'=ret__int_' and R'=UNIV and R=\<top> and
@@ -3539,13 +3540,13 @@ lemma decodeSetSchedParams_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetSchedParams args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetSchedParams_'proc)"
   supply Collect_const[simp del] dc_simp[simp del]
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeSetSchedParams_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetSchedParams_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
    apply (rule_tac xf'=ret__int_' and R'=UNIV and R=\<top> and
@@ -3689,12 +3690,12 @@ lemma decodeSetIPCBuffer_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetIPCBuffer args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetIPCBuffer_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' slot_' excaps_' buffer_'
+  apply (cinit' lift: cap_' length___unsigned_long_' slot_' current_extra_caps_' buffer_'
                 simp: decodeSetIPCBuffer_def)
    apply wpc
     apply (simp add: unat_eq_0)
@@ -3992,12 +3993,12 @@ lemma decodeBindNotification_ccorres:
               and (excaps_in_mem extraCaps o ctes_of)
               and K (isThreadCap cp))
        (UNIV \<inter> {s. ccap_relation cp (cap_' s)}
-             \<inter> {s. excaps_' s = extraCaps'}) []
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}) []
      (decodeBindNotification cp extraCaps >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeBindNotification_'proc)"
   using [[goals_limit=1]]
   apply (simp, rule ccorres_gen_asm)
-  apply (cinit' lift: cap_' excaps_' simp: decodeBindNotification_def)
+  apply (cinit' lift: cap_' current_extra_caps_' simp: decodeBindNotification_def)
    apply (simp add: bind_assoc whenE_def bind_bindE_assoc interpret_excaps_test_null
                del: Collect_const cong: call_ignore_cong)
    apply (rule ccorres_Cond_rhs_Seq)
@@ -4192,12 +4193,12 @@ lemma decodeSetSpace_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetSpace args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetSpace_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' slot_' excaps_' buffer_'
+  apply (cinit' lift: cap_' length___unsigned_long_' slot_' current_extra_caps_' buffer_'
                 simp: decodeSetSpace_def)
    apply csymbr
    apply (rule ccorres_Cond_rhs_Seq)
@@ -4565,13 +4566,13 @@ lemma decodeTCBInvocation_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. call_' s = from_bool isCall}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeTCBInvocation label args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeTCBInvocation_'proc)"
-  apply (cinit' lift: invLabel_' cap_' length___unsigned_long_' slot_' excaps_' call_' buffer_')
+  apply (cinit' lift: invLabel_' cap_' length___unsigned_long_' slot_' current_extra_caps_' call_' buffer_')
    apply (simp add: decodeTCBInvocation_def invocation_eq_use_types gen_invocation_type_eq
                del: Collect_const)
    apply (rule ccorres_Cond_rhs)

--- a/proof/crefine/ARM_HYP/VSpace_C.thy
+++ b/proof/crefine/ARM_HYP/VSpace_C.thy
@@ -1983,7 +1983,7 @@ lemma vcpuUpdate_vTimer_pcount_ccorres:
                             cmachine_state_relation_def update_vcpu_map_to_vcpu
                             typ_heap_simps' cpspace_relation_def update_vcpu_map_tos)
       apply (erule (1) cmap_relation_updI
-             ; clarsimp simp: cvcpu_relation_regs_def cvgic_relation_def                              cvcpu_vppi_masked_relation_def
+             ; clarsimp simp: cvcpu_relation_regs_def cvgic_relation_def cvcpu_vppi_masked_relation_def
              ; (rule refl)?)
   apply (simp add: objBits_simps archObjSize_def machine_bits_defs)+
   done

--- a/proof/crefine/RISCV64/Arch_C.thy
+++ b/proof/crefine/RISCV64/Arch_C.thy
@@ -755,7 +755,7 @@ lemma decodeRISCVPageTableInvocation_ccorres:
        (UNIV \<inter> {s. label___unsigned_long_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. cte_' s = cte_Ptr slot}
-             \<inter> {s. extraCaps___struct_extra_caps_C_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer})
        hs
@@ -766,7 +766,7 @@ lemma decodeRISCVPageTableInvocation_ccorres:
   supply Collect_const[simp del] if_cong[cong] option.case_cong[cong]
   apply (clarsimp simp only: isCap_simps)
   apply (cinit' lift: label___unsigned_long_' length___unsigned_long_' cte_'
-                      extraCaps___struct_extra_caps_C_' cap_' buffer_'
+                      current_extra_caps_' cap_' buffer_'
                 simp: decodeRISCVMMUInvocation_def invocation_eq_use_types
                       decodeRISCVPageTableInvocation_def)
    apply (simp add: Let_def isCap_simps if_to_top_of_bind
@@ -1567,7 +1567,7 @@ lemma decodeRISCVFrameInvocation_ccorres:
        (UNIV \<inter> {s. label___unsigned_long_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. cte_' s = cte_Ptr slot}
-             \<inter> {s. extraCaps___struct_extra_caps_C_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer}) []
        (decodeRISCVMMUInvocation label args cptr slot cp extraCaps
@@ -1575,7 +1575,7 @@ lemma decodeRISCVFrameInvocation_ccorres:
        (Call decodeRISCVFrameInvocation_'proc)"
   apply (clarsimp simp only: isCap_simps)
   apply (cinit' lift: label___unsigned_long_' length___unsigned_long_' cte_'
-                      extraCaps___struct_extra_caps_C_' cap_' buffer_'
+                      current_extra_caps_' cap_' buffer_'
                 simp: decodeRISCVMMUInvocation_def)
    apply (simp add: Let_def isCap_simps invocation_eq_use_types split_def decodeRISCVFrameInvocation_def
                del: Collect_const
@@ -2235,7 +2235,7 @@ lemma decodeRISCVMMUInvocation_ccorres:
        (UNIV \<inter> {s. label___unsigned_long_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. cte_' s = cte_Ptr slot}
-             \<inter> {s. extraCaps___struct_extra_caps_C_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer}) []
        (decodeRISCVMMUInvocation label args cptr slot cp extraCaps
@@ -2243,7 +2243,7 @@ lemma decodeRISCVMMUInvocation_ccorres:
        (Call decodeRISCVMMUInvocation_'proc)"
   supply ccorres_prog_only_cong[cong]
   apply (cinit' lift: label___unsigned_long_' length___unsigned_long_' cte_'
-                      extraCaps___struct_extra_caps_C_' cap_' buffer_')
+                      current_extra_caps_' cap_' buffer_')
    apply csymbr
    apply (simp add: cap_get_tag_isCap_ArchObject
                     RISCV64_H.decodeInvocation_def
@@ -2934,7 +2934,7 @@ lemma Arch_decodeInvocation_ccorres:
        (UNIV \<inter> {s. label___unsigned_long_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. slot_' s = cte_Ptr slot}
-             \<inter> {s. extraCaps___struct_extra_caps_C_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer}
              \<inter> {s. call_' s = from_bool isCall }) []
@@ -2946,7 +2946,7 @@ proof -
   note trim_call = ccorres_trim_returnE[rotated 2, OF ccorres_call]
   from assms show ?thesis
     apply (cinit' lift: label___unsigned_long_' length___unsigned_long_' slot_'
-                        extraCaps___struct_extra_caps_C_' cap_' buffer_' call_')
+                        current_extra_caps_' cap_' buffer_' call_')
      apply (simp only: cap_get_tag_isCap_ArchObject RISCV64_H.decodeInvocation_def)
        apply (rule trim_call[OF decodeRISCVMMUInvocation_ccorres], simp+)[1]
     apply (clarsimp simp: o_def excaps_in_mem_def slotcap_in_mem_def)

--- a/proof/crefine/RISCV64/CSpace_RAB_C.thy
+++ b/proof/crefine/RISCV64/CSpace_RAB_C.thy
@@ -222,7 +222,7 @@ next
      apply (rule_tac P = "capptr = cptr' \<and> ccap_relation cap' nodeCap" in ccorres_gen_asm2)
      apply (erule conjE)
      apply (erule_tac t = capptr in ssubst)
-     apply csymbr+
+     apply csymbr_legacy+
      apply (simp add: cap_get_tag_isCap split del: if_split)
      apply (thin_tac "ret__unsigned_longlong = X" for X)
      apply (rule ccorres_split_throws [where P = "?P"])

--- a/proof/crefine/RISCV64/CSpace_RAB_C.thy
+++ b/proof/crefine/RISCV64/CSpace_RAB_C.thy
@@ -17,18 +17,14 @@ abbreviation
               ret__struct_resolveAddressBits_ret_C_')"
 
 lemma rab_failure_case_ccorres:
-  fixes v :: "machine_word" and ist :: "cstate \<Rightarrow> cstate" and f :: int
-  defines "call_part \<equiv> (call ist f (\<lambda>s t. s\<lparr>globals := globals t\<rparr>)
-             (\<lambda>ts s'. Basic (\<lambda>s.
-                  globals_update (current_lookup_fault_'_update
-                     (\<lambda>_. ret__struct_lookup_fault_C_' s')) s)))"
-  assumes spec: "\<Gamma>\<turnstile> G' call_part {s. v \<noteq> scast EXCEPTION_NONE \<and> lookup_failure_rel e v (errstate s)}"
-  and     mod:  "\<And>s. \<Gamma>\<turnstile> {s'. (s, s') \<in> rf_sr} call_part {s'. (s, s') \<in> rf_sr}"
+  assumes spec: "\<Gamma>\<turnstile> G' call_part {s. resolveAddressBits_ret_C.status_C v \<noteq> scast EXCEPTION_NONE
+                                      \<and> lookup_failure_rel e (resolveAddressBits_ret_C.status_C v)
+                                                           (errstate s)}"
+  assumes mod:  "\<And>s. \<Gamma>\<turnstile> {s'. (s, s') \<in> rf_sr} call_part {s'. (s, s') \<in> rf_sr}"
   shows "ccorres (lookup_failure_rel \<currency> r) rab_xf \<top> G' (SKIP # hs)
    (throwError e)
    (call_part ;;
-   \<acute>ret___struct_resolveAddressBits_ret_C :==
-		       resolveAddressBits_ret_C.status_C_update (\<lambda>_. v) \<acute>ret___struct_resolveAddressBits_ret_C;;
+    \<acute>ret___struct_resolveAddressBits_ret_C :== v;;
     return_C ret__struct_resolveAddressBits_ret_C_'_update ret___struct_resolveAddressBits_ret_C_')"
   apply (rule ccorres_rhs_assoc)+
   apply (rule ccorres_symb_exec_r [where R=\<top>, OF _ spec])
@@ -222,7 +218,7 @@ next
      apply (rule_tac P = "capptr = cptr' \<and> ccap_relation cap' nodeCap" in ccorres_gen_asm2)
      apply (erule conjE)
      apply (erule_tac t = capptr in ssubst)
-     apply csymbr_legacy+
+     apply csymbr+
      apply (simp add: cap_get_tag_isCap split del: if_split)
      apply (thin_tac "ret__unsigned_longlong = X" for X)
      apply (rule ccorres_split_throws [where P = "?P"])
@@ -524,7 +520,6 @@ next
        apply (vcg strip_guards=true)
       apply (rule conjI)
       \<comment> \<open>Haskell guard\<close>
-       apply (thin_tac "unat n_bits = guard")
        apply (clarsimp simp del: imp_disjL) \<comment> \<open>take a while\<close>
        apply (intro impI conjI allI)
            apply fastforce

--- a/proof/crefine/RISCV64/Interrupt_C.thy
+++ b/proof/crefine/RISCV64/Interrupt_C.thy
@@ -151,11 +151,11 @@ lemma decodeIRQHandlerInvocation_ccorres:
        (UNIV
             \<inter> {s. invLabel_' s = label}
             \<inter> {s. irq_' s = ucast irq}
-            \<inter> {s. excaps_' s = extraCaps'}) []
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}) []
      (decodeIRQHandlerInvocation label irq extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeIRQHandler)
      (Call decodeIRQHandlerInvocation_'proc)"
-  apply (cinit' lift: invLabel_' irq_' excaps_'
+  apply (cinit' lift: invLabel_' irq_' current_extra_caps_'
            simp: decodeIRQHandlerInvocation_def invocation_eq_use_types)
    apply (rule ccorres_Cond_rhs)
     apply (simp add: returnOk_bind ccorres_invocationCatch_Inr)
@@ -490,7 +490,7 @@ lemma Arch_decodeIRQControlInvocation_ccorres:
      (UNIV \<inter> {s. invLabel_' s = label}
            \<inter> {s. unat (length___unsigned_long_' s) = length args}
            \<inter> {s. srcSlot_' s = cte_Ptr srcSlot}
-           \<inter> {s. excaps_' s = extraCaps'}
+           \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
            \<inter> {s. buffer_' s = option_to_ptr buffer})
      []
      (Arch.decodeIRQControlInvocation label args srcSlot (map fst extraCaps)
@@ -498,7 +498,7 @@ lemma Arch_decodeIRQControlInvocation_ccorres:
      (Call Arch_decodeIRQControlInvocation_'proc)"
   supply maxIRQ_casts[simp]
   supply gen_invocation_type_eq[simp] if_cong[cong] Collect_const[simp del]
-  apply (cinit' lift: invLabel_' length___unsigned_long_' srcSlot_' excaps_' buffer_'
+  apply (cinit' lift: invLabel_' length___unsigned_long_' srcSlot_' current_extra_caps_' buffer_'
                 simp: ArchInterrupt_H.RISCV64_H.decodeIRQControlInvocation_def)
    apply (simp add: invocation_eq_use_types
               cong: StateSpace.state.fold_congs globals.fold_congs)
@@ -663,7 +663,7 @@ lemma decodeIRQControlInvocation_ccorres:
        (UNIV
             \<inter> {s. invLabel_' s = label} \<inter> {s. srcSlot_' s = cte_Ptr slot}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeIRQControlInvocation label args slot (map fst extraCaps)
             >>= invocationCatch thread isBlocking isCall InvokeIRQControl)
@@ -671,7 +671,7 @@ lemma decodeIRQControlInvocation_ccorres:
   supply gen_invocation_type_eq[simp] if_cong[cong] Collect_const[simp del]
   supply maxIRQ_ucast_toEnum_eq[simp] maxIRQ_ucast_toEnum_irq_t[simp] maxIRQ_irqInvalid[simp]
   supply maxIRQ_ucast_toEnum_irq_t2[simp]
-  apply (cinit' lift: invLabel_' srcSlot_' length___unsigned_long_' excaps_' buffer_')
+  apply (cinit' lift: invLabel_' srcSlot_' length___unsigned_long_' current_extra_caps_' buffer_')
    apply (simp add: decodeIRQControlInvocation_def invocation_eq_use_types
               cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_Cond_rhs)

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -3000,7 +3000,7 @@ lemma transferCaps_ccorres [corres]:
      and K (ep \<noteq> Some 0)
      and K (receiveBuffer \<noteq> Some 0)
      and K (unat (msgExtraCaps mi) \<le> 3))
-    (UNIV \<inter> \<lbrace>interpret_excaps (\<acute>caps) = excaps_map caps\<rbrace>
+    (UNIV \<inter> \<lbrace>interpret_excaps (\<acute>current_extra_caps) = excaps_map caps\<rbrace>
           \<inter> \<lbrace>\<acute>receiver = tcb_ptr_to_ctcb_ptr receiver\<rbrace>
           \<inter> \<lbrace> mi = message_info_to_H \<acute>info\<rbrace>
           \<inter> \<lbrace>\<acute>receiveBuffer = Ptr (option_to_0 receiveBuffer)\<rbrace>
@@ -3008,7 +3008,7 @@ lemma transferCaps_ccorres [corres]:
     (transferCaps mi caps ep receiver receiveBuffer)
     (Call transferCaps_'proc)" (is "ccorres _ _ ?P _ _ _ _")
   apply (unfold K_def, intro ccorres_gen_asm)
-  apply (cinit lift: caps_' receiver_' info_' receiveBuffer_' endpoint_'
+  apply (cinit lift: current_extra_caps_' receiver_' info_' receiveBuffer_' endpoint_'
     simp: getThreadCSpaceRoot_def locateSlot_conv whileAnno_def)
    apply csymbr+
    apply (rule_tac P="?P" and P'="{s. info_' s = info}" in ccorres_inst)
@@ -3048,7 +3048,7 @@ lemma transferCaps_ccorres [corres]:
         apply (rule ccorres_add_return2)
         apply (rule ccorres_split_nothrow_novcg)
             apply (rule ccorres_Catch)
-            apply (rule_tac caps=caps and caps'=capsa in transferCapsLoop_ccorres, simp+)
+            apply (rule_tac caps=caps and caps'=current_extra_caps in transferCapsLoop_ccorres, simp+)
             apply (simp add: excaps_map_def)
            apply ceqv
           apply csymbr
@@ -3395,21 +3395,18 @@ proof -
                  cong: call_ignore_cong)
      apply (clarsimp cong: call_ignore_cong simp del: dc_simp)
      apply (ctac(c_lines 2, no_vcg) add: getMessageInfo_ccorres')
-       apply (rule_tac xf'=caps_' and r'="\<lambda>c c'. interpret_excaps c' = excaps_map c"
-                  in ccorres_split_nothrow_novcg)
+       apply (rule_tac xf'="\<lambda>s. current_extra_caps_' (globals s)"
+                   and r'="\<lambda>c c'. interpret_excaps c' = excaps_map c"
+              in ccorres_split_nothrow_novcg)
            apply (rule ccorres_if_lhs)
             apply (simp add: catch_def to_bool_def ccorres_cond_iffs)
-            apply (rule ccorres_rhs_assoc)+
-            apply (rule_tac xf'="\<lambda>s. (status_' s,
-                                current_extra_caps_' (globals s))"
-                             and ef'=fst and vf'=snd and es=errstate
-                        in ccorres_split_nothrow_case_sum)
+            apply (rule_tac xf'="\<lambda>s. (status_' s, current_extra_caps_' (globals s))"
+                        and ef'=fst and vf'=snd and es=errstate
+                   in ccorres_split_nothrow_case_sum)
                  apply (rule ccorres_call, rule lookupExtraCaps_ccorres, simp+)
                 apply (rule ceqv_tuple2, ceqv, ceqv)
                apply (simp add: ccorres_cond_iffs)
-               apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
-               apply (rule allI, rule conseqPre, vcg)
-               apply (clarsimp simp: return_def)
+               apply (rule ccorres_return_Skip')
               apply (simp add: ccorres_cond_iffs)
               apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
               apply (rule allI, rule conseqPre, vcg)
@@ -3419,35 +3416,34 @@ proof -
             apply simp
             apply (vcg exspec=lookupExtraCaps_modifies)
            apply (simp add: to_bool_def ccorres_cond_iffs)
-           apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
-           apply (rule allI, rule conseqPre, vcg)
-           apply (clarsimp simp: return_def excaps_map_def interpret_excaps_empty
-                                 word_sle_def word_sless_def)
+           apply (rule ccorres_return[where R=\<top> and R'=UNIV], vcg)
+           apply (clarsimp simp: excaps_map_def interpret_excaps_empty)
           apply ceqv
          apply csymbr
-         apply (ctac(no_vcg) add: copyMRs_ccorres)
-          apply (ctac(no_vcg) add: transferCaps_ccorres)
-           apply csymbr
-           apply (ctac(c_lines 2, no_vcg) add: setMessageInfo_ccorres)
-             apply ctac
+         apply (ctac add: copyMRs_ccorres)
+           apply (ctac add: transferCaps_ccorres)
+             apply csymbr
+             apply (ctac(c_lines 2, no_vcg) add: setMessageInfo_ccorres)
+               apply ctac
+              apply wp
+             apply (clarsimp simp: Kernel_C.badgeRegister_def RISCV64_H.badgeRegister_def
+                                   RISCV64.badgeRegister_def a0_def)
             apply wp
-           apply (clarsimp simp: Kernel_C.badgeRegister_def RISCV64_H.badgeRegister_def
-                              RISCV64.badgeRegister_def RISCV64.capRegister_def C_register_defs)
-          apply wp
-         apply simp
-         apply (wp hoare_case_option_wp getMessageInfo_le3
-                   getMessageInfo_msgLength lookupExtraCaps_excaps_in_mem
-                   lookupExtraCaps_length
-                    | simp)+
+           apply (simp add: seL4_MessageInfo_lift_def message_info_to_H_def msgLengthBits_def)
+           apply (vcg exspec=transferCaps_modifies)
+          apply (wpsimp wp: hoare_case_option_wp)
+         apply clarsimp
+         apply (vcg exspec=copyMRs_modifies)
+        apply (wpsimp wp: lookupExtraCaps_length)
        apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem)
        apply (clarsimp simp: seL4_MessageInfo_lift_def message_info_to_H_def mask_def
                              msgLengthBits_def word_bw_assocs)
       apply (wp getMessageInfo_le3 getMessageInfo_msgLength[unfolded K_def] static_imp_wp
                   | simp)+
-    apply (auto simp: excaps_in_mem_def valid_ipc_buffer_ptr'_def
-                      option_to_0_def option_to_ptr_def
-                      seL4_MessageInfo_lift_def mi_from_H_def message_info_to_H_def
-               split: option.split)
+     apply (auto simp: excaps_in_mem_def valid_ipc_buffer_ptr'_def
+                       option_to_0_def option_to_ptr_def
+                       seL4_MessageInfo_lift_def mi_from_H_def message_info_to_H_def
+                split: option.split)
     done
 qed
 

--- a/proof/crefine/RISCV64/Recycle_C.thy
+++ b/proof/crefine/RISCV64/Recycle_C.thy
@@ -871,7 +871,7 @@ lemma cancelBadgedSends_ccorres:
           apply (induct_tac list)
            apply (rule allI)
            apply (rule iffD1 [OF ccorres_expand_while_iff_Seq])
-           apply (rule ccorres_tmp_lift2 [OF _ _ refl])
+           apply (rule ccorres_tmp_lift2 [OF _ _ Int_lower1])
             apply ceqv
            apply (simp add: ccorres_cond_iffs)
            apply (rule ccorres_rhs_assoc2)

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -7323,10 +7323,9 @@ shows  "ccorres dc xfdc
             (length destSlots * 2 ^ APIType_capBits newType userSize) s)}
            \<inter> {s. t_' s = object_type_from_H newType}
            \<inter> {s. parent_' s = cte_Ptr srcSlot}
-           \<inter> {s. slots_' s = slot_range_C (cte_Ptr cnodeptr) start num
-                     \<and> unat num \<noteq> 0
-                     \<and> (\<forall>n. n < length destSlots \<longrightarrow> destSlots ! n = cnodeptr + ((start + of_nat n) * 0x20))
-                     }
+           \<inter> {s. destCNode_' s = cte_Ptr cnodeptr}
+           \<inter> {s. destOffset_' s = start \<and> (\<forall>n. n < length destSlots \<longrightarrow> destSlots ! n = cnodeptr + ((start + of_nat n) * 0x20))}
+           \<inter> {s. destLength_' s = num \<and> unat num \<noteq> 0}
            \<inter> {s. regionBase_' s = Ptr ptr }
            \<inter> {s. unat_eq (userSize_' s) userSize}
            \<inter> {s. deviceMemory_' s = from_bool isdev}
@@ -7343,7 +7342,7 @@ shows  "ccorres dc xfdc
    apply (rule less_le_trans[OF getObjectSize_max_size]; clarsimp simp: word_bits_def untypedBits_defs)
   apply (subgoal_tac "\<forall>n < length destSlots. canonical_address (ptr + (of_nat n << APIType_capBits newType userSize))")
    prefer 2 subgoal by (simp add: shiftl_t2n field_simps range_cover_canonical_address)
-  apply (cinit lift: t_' parent_' slots_' regionBase_' userSize_' deviceMemory_')
+  apply (cinit lift: t_' parent_' destCNode_' destOffset_' destLength_' regionBase_' userSize_' deviceMemory_')
    apply (rule ccorres_rhs_assoc2)+
    apply (rule ccorres_rhs_assoc)
    apply (rule_tac Q' = "Q'

--- a/proof/crefine/RISCV64/Syscall_C.thy
+++ b/proof/crefine/RISCV64/Syscall_C.thy
@@ -127,22 +127,23 @@ lemma decodeInvocation_ccorres:
               and (\<lambda>s. \<forall>v \<in> set extraCaps. \<forall>y \<in> zobj_refs' (fst v). ex_nonz_cap_to' y s)
               and (\<lambda>s. \<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p))
               and sysargs_rel args buffer)
-       (UNIV \<inter> {s. call_' s = from_bool isCall}
-                   \<inter> {s. block_' s = from_bool isBlocking}
-                   \<inter> {s. call_' s = from_bool isCall}
-                   \<inter> {s. block_' s = from_bool isBlocking}
-                   \<inter> {s. invLabel_' s = label}
-                   \<inter> {s. unat (length___unsigned_long_' s) = length args}
-                   \<inter> {s. capIndex_' s = cptr}
-                   \<inter> {s. slot_' s = cte_Ptr slot}
-                   \<inter> {s. excaps_' s = extraCaps'}
-                   \<inter> {s. ccap_relation cp (cap_' s)}
-                   \<inter> {s. buffer_' s = option_to_ptr buffer}) []
+       (UNIV \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
+             \<inter> {s. call_' s = from_bool isCall}
+             \<inter> {s. block_' s = from_bool isBlocking}
+             \<inter> {s. call_' s = from_bool isCall}
+             \<inter> {s. block_' s = from_bool isBlocking}
+             \<inter> {s. invLabel_' s = label}
+             \<inter> {s. unat (length___unsigned_long_' s) = length args}
+             \<inter> {s. capIndex_' s = cptr}
+             \<inter> {s. slot_' s = cte_Ptr slot}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
+             \<inter> {s. ccap_relation cp (cap_' s)}
+             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
        (decodeInvocation label args cptr slot cp extraCaps
               >>= invocationCatch thread isBlocking isCall id)
        (Call decodeInvocation_'proc)"
   apply (cinit' lift: call_' block_' invLabel_' length___unsigned_long_'
-                      capIndex_' slot_' excaps_' cap_' buffer_')
+                      capIndex_' slot_' current_extra_caps_' cap_' buffer_')
    apply csymbr
    apply (simp add: cap_get_tag_isCap decodeInvocation_def
               cong: if_cong StateSpace.state.fold_congs

--- a/proof/crefine/RISCV64/Tcb_C.thy
+++ b/proof/crefine/RISCV64/Tcb_C.thy
@@ -2461,12 +2461,12 @@ lemma decodeCopyRegisters_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeCopyRegisters args cp (map fst extraCaps)
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeCopyRegisters_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeCopyRegisters_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeCopyRegisters_def)
    apply csymbr
    apply wpc
     apply (simp add: if_1_0_0 unat_eq_0)
@@ -2821,12 +2821,13 @@ lemma decodeTCBConfigure_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. rootCaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeTCBConfigure args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeTCBConfigure_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' slot_' rootCaps_' buffer_' simp: decodeTCBConfigure_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' slot_' current_extra_caps_' buffer_'
+                simp: decodeTCBConfigure_def)
    apply csymbr
    apply (clarsimp cong: StateSpace.state.fold_congs globals.fold_congs
                simp del: Collect_const
@@ -3218,14 +3219,14 @@ lemma decodeSetMCPriority_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetMCPriority args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetMCPriority_'proc)"
   supply Collect_const[simp del]
   supply dc_simp[simp del]
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeSetMCPriority_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetMCPriority_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
    apply (rule_tac xf'=ret__int_' and R'=UNIV and R=\<top> and
@@ -3354,13 +3355,13 @@ lemma decodeSetPriority_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetPriority args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetPriority_'proc)"
   supply Collect_const[simp del] dc_simp[simp del]
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeSetPriority_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetPriority_def)
      apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
    apply (rule_tac xf'=ret__int_' and R'=UNIV and R=\<top> and
@@ -3503,13 +3504,13 @@ lemma decodeSetSchedParams_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetSchedParams args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetSchedParams_'proc)"
   supply Collect_const[simp del] dc_simp[simp del]
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeSetSchedParams_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetSchedParams_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
    apply (rule_tac xf'=ret__int_' and R'=UNIV and R=\<top> and
@@ -3673,12 +3674,12 @@ lemma decodeSetIPCBuffer_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetIPCBuffer args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetIPCBuffer_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' slot_' excaps_' buffer_'
+  apply (cinit' lift: cap_' length___unsigned_long_' slot_' current_extra_caps_' buffer_'
                 simp: decodeSetIPCBuffer_def)
    apply wpc
     apply (simp add: unat_eq_0)
@@ -3987,12 +3988,12 @@ lemma decodeBindNotification_ccorres:
               and (excaps_in_mem extraCaps o ctes_of)
               and K (isThreadCap cp))
        (UNIV \<inter> {s. ccap_relation cp (cap_' s)}
-             \<inter> {s. excaps_' s = extraCaps'}) []
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}) []
      (decodeBindNotification cp extraCaps >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeBindNotification_'proc)"
   using [[goals_limit=1]]
   apply (simp, rule ccorres_gen_asm)
-  apply (cinit' lift: cap_' excaps_' simp: decodeBindNotification_def)
+  apply (cinit' lift: cap_' current_extra_caps_' simp: decodeBindNotification_def)
    apply (simp add: bind_assoc whenE_def bind_bindE_assoc interpret_excaps_test_null
                del: Collect_const cong: call_ignore_cong)
    apply (rule ccorres_Cond_rhs_Seq)
@@ -4188,12 +4189,12 @@ lemma decodeSetSpace_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetSpace args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetSpace_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' slot_' excaps_' buffer_'
+  apply (cinit' lift: cap_' length___unsigned_long_' slot_' current_extra_caps_' buffer_'
                 simp: decodeSetSpace_def)
    apply csymbr
    apply (rule ccorres_Cond_rhs_Seq)
@@ -4561,13 +4562,13 @@ lemma decodeTCBInvocation_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. call_' s = from_bool isCall}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeTCBInvocation label args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeTCBInvocation_'proc)"
-  apply (cinit' lift: invLabel_' cap_' length___unsigned_long_' slot_' excaps_' call_' buffer_')
+  apply (cinit' lift: invLabel_' cap_' length___unsigned_long_' slot_' current_extra_caps_' call_' buffer_')
    apply (simp add: decodeTCBInvocation_def invocation_eq_use_types gen_invocation_type_eq
                del: Collect_const)
    apply (rule ccorres_Cond_rhs)

--- a/proof/crefine/X64/Arch_C.thy
+++ b/proof/crefine/X64/Arch_C.thy
@@ -1006,7 +1006,7 @@ lemma decodeX64PageTableInvocation_ccorres:
        (UNIV \<inter> {s. invLabel_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. cte_' s = cte_Ptr slot}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer})
        hs
@@ -1016,7 +1016,7 @@ lemma decodeX64PageTableInvocation_ccorres:
    (is "_ \<Longrightarrow> _ \<Longrightarrow> ccorres _ _ ?pre _ _ _ _")
   supply Collect_const[simp del] if_cong[cong]
   apply (clarsimp simp only: isCap_simps)
-  apply (cinit' lift: invLabel_' length___unsigned_long_' cte_' excaps_' cap_' buffer_'
+  apply (cinit' lift: invLabel_' length___unsigned_long_' cte_' current_extra_caps_' cap_' buffer_'
                 simp: decodeX64MMUInvocation_def invocation_eq_use_types decodeX64PageTableInvocation_def)
    apply (simp add: Let_def isCap_simps if_to_top_of_bind
                cong: StateSpace.state.fold_congs globals.fold_congs)
@@ -2311,14 +2311,14 @@ lemma decodeX64FrameInvocation_ccorres:
        (UNIV \<inter> {s. invLabel_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. cte_' s = cte_Ptr slot}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer}) []
        (decodeX64MMUInvocation label args cptr slot cp extraCaps
               >>= invocationCatch thread isBlocking isCall InvokeArchObject)
        (Call decodeX86FrameInvocation_'proc)"
   apply (clarsimp simp only: isCap_simps)
-  apply (cinit' lift: invLabel_' length___unsigned_long_' cte_' excaps_' cap_' buffer_'
+  apply (cinit' lift: invLabel_' length___unsigned_long_' cte_' current_extra_caps_' cap_' buffer_'
                 simp: decodeX64MMUInvocation_def )
    apply (simp add: Let_def isCap_simps invocation_eq_use_types split_def decodeX64FrameInvocation_def
                del: Collect_const
@@ -2935,7 +2935,7 @@ lemma decodeX64PageDirectoryInvocation_ccorres:
        (UNIV \<inter> {s. label___unsigned_long_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. cte_' s = cte_Ptr slot}
-             \<inter> {s. extraCaps___struct_extra_caps_C_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer})
        hs
@@ -2945,7 +2945,7 @@ lemma decodeX64PageDirectoryInvocation_ccorres:
    (is "_ \<Longrightarrow> _ \<Longrightarrow> ccorres _ _ ?pre _ _ _ _")
   supply Collect_const[simp del] if_cong[cong]
   apply (clarsimp simp only: isCap_simps)
-  apply (cinit' lift: label___unsigned_long_' length___unsigned_long_' cte_' extraCaps___struct_extra_caps_C_' cap_' buffer_'
+  apply (cinit' lift: label___unsigned_long_' length___unsigned_long_' cte_' current_extra_caps_' cap_' buffer_'
                 simp: decodeX64MMUInvocation_def invocation_eq_use_types decodeX64PageDirectoryInvocation_def)
    apply (simp add: Let_def isCap_simps if_to_top_of_bind
                cong: StateSpace.state.fold_congs globals.fold_congs)
@@ -3411,7 +3411,7 @@ lemma decodeX64PDPTInvocation_ccorres:
        (UNIV \<inter> {s. label___unsigned_long_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. cte_' s = cte_Ptr slot}
-             \<inter> {s. extraCaps___struct_extra_caps_C_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer})
        hs
@@ -3422,7 +3422,7 @@ lemma decodeX64PDPTInvocation_ccorres:
   supply Collect_const[simp del] if_cong[cong] dc_simp[simp del]
          from_bool_eq_if[simp] from_bool_eq_if'[simp] from_bool_0[simp] ccorres_IF_True[simp]
   apply (clarsimp simp only: isCap_simps)
-  apply (cinit' lift: label___unsigned_long_' length___unsigned_long_' cte_' extraCaps___struct_extra_caps_C_' cap_' buffer_'
+  apply (cinit' lift: label___unsigned_long_' length___unsigned_long_' cte_' current_extra_caps_' cap_' buffer_'
                 simp: decodeX64MMUInvocation_def invocation_eq_use_types decodeX64PDPointerTableInvocation_def)
    apply (simp add: Let_def isCap_simps if_to_top_of_bind
                cong: StateSpace.state.fold_congs globals.fold_congs)
@@ -3718,7 +3718,7 @@ lemma decodeX64ModeMMUInvocation_ccorres:
        (UNIV \<inter> {s. label___unsigned_long_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. cte_' s = cte_Ptr slot}
-             \<inter> {s. extraCaps___struct_extra_caps_C_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer})
        hs
@@ -3727,7 +3727,7 @@ lemma decodeX64ModeMMUInvocation_ccorres:
        (Call decodeX86ModeMMUInvocation_'proc)"
   supply Collect_const[simp del] if_cong[cong]
   apply (cinit' lift: label___unsigned_long_' length___unsigned_long_' cte_'
-                      extraCaps___struct_extra_caps_C_' cap_' buffer_')
+                      current_extra_caps_' cap_' buffer_')
    apply csymbr
    apply (clarsimp simp: cap_get_tag_isCap_ArchObject
                    cong: StateSpace.state.fold_congs globals.fold_congs)
@@ -3763,14 +3763,14 @@ lemma decodeX64MMUInvocation_ccorres:
        (UNIV \<inter> {s. invLabel_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. cte_' s = cte_Ptr slot}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer}) []
        (decodeX64MMUInvocation label args cptr slot cp extraCaps
               >>= invocationCatch thread isBlocking isCall InvokeArchObject)
        (Call decodeX86MMUInvocation_'proc)"
   apply (cinit' lift: invLabel_' length___unsigned_long_' cte_'
-                      excaps_' cap_' buffer_')
+                      current_extra_caps_' cap_' buffer_')
    apply csymbr
    apply (simp add: cap_get_tag_isCap_ArchObject
                     X64_H.decodeInvocation_def
@@ -5134,7 +5134,7 @@ lemma decodeIOPortControlInvocation_ccorres:
        (UNIV \<inter> {s. invLabel_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. slot_' s = cte_Ptr slot}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer}) []
        (decodeX64PortInvocation label args slot cp (map fst extraCaps)
@@ -5144,7 +5144,7 @@ lemma decodeIOPortControlInvocation_ccorres:
 proof -
   from assms show ?thesis
     apply (clarsimp simp: isCap_simps decodeX64PortInvocation_def Let_def)
-    apply (cinit' lift: invLabel_' length___unsigned_long_' slot_' excaps_' cap_' buffer_')
+    apply (cinit' lift: invLabel_' length___unsigned_long_' slot_' current_extra_caps_' cap_' buffer_')
      apply (clarsimp cong: StateSpace.state.fold_congs globals.fold_congs)
      apply (rule ccorres_Cond_rhs_Seq, clarsimp simp: invocation_eq_use_types, ccorres_rewrite)
       apply (rule ccorres_equals_throwError)
@@ -5306,7 +5306,7 @@ lemma decodeIOPortInvocation_ccorres:
        (UNIV \<inter> {s. invLabel_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. slot_' s = cte_Ptr slot}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer}
              \<inter> {s. call_' s = from_bool isCall}) []
@@ -5317,7 +5317,7 @@ proof -
   from assms show ?thesis
   supply Collect_const[simp del]
   apply (clarsimp simp: isCap_simps decodeX64PortInvocation_def Let_def)
-  apply (cinit' lift: invLabel_' length___unsigned_long_' slot_' excaps_' cap_' buffer_' call_')
+  apply (cinit' lift: invLabel_' length___unsigned_long_' slot_' current_extra_caps_' cap_' buffer_' call_')
    apply (clarsimp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_Cond_rhs) (* IN invocations *)
     apply (erule ccorres_disj_division)
@@ -5631,7 +5631,7 @@ lemma Mode_decodeInvocation_ccorres:
        (UNIV \<inter> {s. label___unsigned_long_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. slot_' s = cte_Ptr slot}
-             \<inter> {s. extraCaps___struct_extra_caps_C_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer}) []
        (decodeX64MMUInvocation label args cptr slot cp extraCaps
@@ -5639,7 +5639,7 @@ lemma Mode_decodeInvocation_ccorres:
        (Call Mode_decodeInvocation_'proc)"
   using assms
   apply (cinit' lift: label___unsigned_long_' length___unsigned_long_' slot_'
-                      extraCaps___struct_extra_caps_C_' cap_' buffer_')
+                      current_extra_caps_' cap_' buffer_')
    apply csymbr
    apply (simp only: cap_get_tag_isCap_ArchObject X64_H.decodeInvocation_def)
    apply (rule ccorres_cond_true)
@@ -5660,7 +5660,7 @@ lemma Arch_decodeInvocation_ccorres:
        (UNIV \<inter> {s. invLabel_' s = label}
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. slot_' s = cte_Ptr slot}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. ccap_relation (ArchObjectCap cp) (cap_' s)}
              \<inter> {s. buffer_' s = option_to_ptr buffer}
              \<inter> {s. call_' s = from_bool isCall }) []
@@ -5671,7 +5671,7 @@ lemma Arch_decodeInvocation_ccorres:
 proof -
   note trim_call = ccorres_trim_returnE[rotated 2, OF ccorres_call]
   from assms show ?thesis
-    apply (cinit' lift: invLabel_' length___unsigned_long_' slot_' excaps_' cap_' buffer_' call_')
+    apply (cinit' lift: invLabel_' length___unsigned_long_' slot_' current_extra_caps_' cap_' buffer_' call_')
      apply csymbr
      apply (simp only: cap_get_tag_isCap_ArchObject X64_H.decodeInvocation_def)
      apply (rule ccorres_Cond_rhs)

--- a/proof/crefine/X64/CSpace_RAB_C.thy
+++ b/proof/crefine/X64/CSpace_RAB_C.thy
@@ -222,7 +222,7 @@ next
      apply (rule_tac P = "capptr = cptr' \<and> ccap_relation cap' nodeCap" in ccorres_gen_asm2)
      apply (erule conjE)
      apply (erule_tac t = capptr in ssubst)
-     apply csymbr+
+     apply csymbr_legacy+
      apply (simp add: cap_get_tag_isCap split del: if_split)
      apply (thin_tac "ret__unsigned_longlong = X" for X)
      apply (rule ccorres_split_throws [where P = "?P"])

--- a/proof/crefine/X64/CSpace_RAB_C.thy
+++ b/proof/crefine/X64/CSpace_RAB_C.thy
@@ -17,18 +17,14 @@ abbreviation
               ret__struct_resolveAddressBits_ret_C_')"
 
 lemma rab_failure_case_ccorres:
-  fixes v :: "machine_word" and ist :: "cstate \<Rightarrow> cstate" and f :: int
-  defines "call_part \<equiv> (call ist f (\<lambda>s t. s\<lparr>globals := globals t\<rparr>)
-             (\<lambda>ts s'. Basic (\<lambda>s.
-                  globals_update (current_lookup_fault_'_update
-                     (\<lambda>_. ret__struct_lookup_fault_C_' s')) s)))"
-  assumes spec: "\<Gamma>\<turnstile> G' call_part {s. v \<noteq> scast EXCEPTION_NONE \<and> lookup_failure_rel e v (errstate s)}"
-  and     mod:  "\<And>s. \<Gamma>\<turnstile> {s'. (s, s') \<in> rf_sr} call_part {s'. (s, s') \<in> rf_sr}"
+  assumes spec: "\<Gamma>\<turnstile> G' call_part {s. resolveAddressBits_ret_C.status_C v \<noteq> scast EXCEPTION_NONE
+                                      \<and> lookup_failure_rel e (resolveAddressBits_ret_C.status_C v)
+                                                           (errstate s)}"
+  assumes mod:  "\<And>s. \<Gamma>\<turnstile> {s'. (s, s') \<in> rf_sr} call_part {s'. (s, s') \<in> rf_sr}"
   shows "ccorres (lookup_failure_rel \<currency> r) rab_xf \<top> G' (SKIP # hs)
    (throwError e)
    (call_part ;;
-   \<acute>ret___struct_resolveAddressBits_ret_C :==
-		       resolveAddressBits_ret_C.status_C_update (\<lambda>_. v) \<acute>ret___struct_resolveAddressBits_ret_C;;
+    \<acute>ret___struct_resolveAddressBits_ret_C :== v;;
     return_C ret__struct_resolveAddressBits_ret_C_'_update ret___struct_resolveAddressBits_ret_C_')"
   apply (rule ccorres_rhs_assoc)+
   apply (rule ccorres_symb_exec_r [where R=\<top>, OF _ spec])
@@ -222,7 +218,7 @@ next
      apply (rule_tac P = "capptr = cptr' \<and> ccap_relation cap' nodeCap" in ccorres_gen_asm2)
      apply (erule conjE)
      apply (erule_tac t = capptr in ssubst)
-     apply csymbr_legacy+
+     apply csymbr+
      apply (simp add: cap_get_tag_isCap split del: if_split)
      apply (thin_tac "ret__unsigned_longlong = X" for X)
      apply (rule ccorres_split_throws [where P = "?P"])
@@ -523,7 +519,6 @@ next
        apply (vcg strip_guards=true)
       apply (rule conjI)
       \<comment> \<open>Haskell guard\<close>
-       apply (thin_tac "unat n_bits = guard")
        apply (clarsimp simp del: imp_disjL) \<comment> \<open>take a while\<close>
        apply (intro impI conjI allI)
            apply fastforce

--- a/proof/crefine/X64/Interrupt_C.thy
+++ b/proof/crefine/X64/Interrupt_C.thy
@@ -151,11 +151,11 @@ lemma decodeIRQHandlerInvocation_ccorres:
        (UNIV
             \<inter> {s. invLabel_' s = label}
             \<inter> {s. irq_' s = ucast irq}
-            \<inter> {s. excaps_' s = extraCaps'}) []
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}) []
      (decodeIRQHandlerInvocation label irq extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeIRQHandler)
      (Call decodeIRQHandlerInvocation_'proc)"
-  apply (cinit' lift: invLabel_' irq_' excaps_'
+  apply (cinit' lift: invLabel_' irq_' current_extra_caps_'
            simp: decodeIRQHandlerInvocation_def invocation_eq_use_types)
    apply (rule ccorres_Cond_rhs)
     apply (simp add: returnOk_bind ccorres_invocationCatch_Inr)
@@ -611,7 +611,7 @@ lemma Arch_decodeIRQControlInvocation_ccorres:
      (UNIV \<inter> {s. invLabel_' s = label}
            \<inter> {s. unat (length___unsigned_long_' s) = length args}
            \<inter> {s. srcSlot_' s = cte_Ptr srcSlot}
-           \<inter> {s. excaps_' s = extraCaps'}
+           \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
            \<inter> {s. buffer_' s = option_to_ptr buffer})
      []
      (Arch.decodeIRQControlInvocation label args srcSlot (map fst extraCaps)
@@ -709,7 +709,7 @@ lemma Arch_decodeIRQControlInvocation_ccorres:
     done
 from assms show ?thesis
   supply Collect_const[simp del]
-  apply (cinit' lift: invLabel_' length___unsigned_long_' srcSlot_' excaps_' buffer_'
+  apply (cinit' lift: invLabel_' length___unsigned_long_' srcSlot_' current_extra_caps_' buffer_'
                 simp: ArchInterrupt_H.X64_H.decodeIRQControlInvocation_def)
    apply (simp add: throwError_bind
               cong: StateSpace.state.fold_congs globals.fold_congs)
@@ -1063,13 +1063,13 @@ lemma decodeIRQControlInvocation_ccorres:
        (UNIV
             \<inter> {s. invLabel_' s = label} \<inter> {s. srcSlot_' s = cte_Ptr slot}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeIRQControlInvocation label args slot (map fst extraCaps)
             >>= invocationCatch thread isBlocking isCall InvokeIRQControl)
      (Call decodeIRQControlInvocation_'proc)"
   supply gen_invocation_type_eq[simp]
-  apply (cinit' lift: invLabel_' srcSlot_' length___unsigned_long_' excaps_' buffer_')
+  apply (cinit' lift: invLabel_' srcSlot_' length___unsigned_long_' current_extra_caps_' buffer_')
    apply (simp add: decodeIRQControlInvocation_def invocation_eq_use_types
                del: Collect_const
               cong: StateSpace.state.fold_congs globals.fold_congs)

--- a/proof/crefine/X64/Invoke_C.thy
+++ b/proof/crefine/X64/Invoke_C.thy
@@ -108,7 +108,7 @@ lemma decodeDomainInvocation_ccorres:
               and sysargs_rel args buffer)
        (UNIV
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. call_' s = from_bool isCall}
              \<inter> {s. invLabel_' s = lab}
              \<inter> {s. buffer_' s = option_to_ptr buffer}) []
@@ -116,7 +116,7 @@ lemma decodeDomainInvocation_ccorres:
            >>= invocationCatch thread isBlocking isCall (uncurry InvokeDomain))
   (Call decodeDomainInvocation_'proc)"
   supply gen_invocation_type_eq[simp]
-  apply (cinit' lift: length___unsigned_long_' excaps_' call_' invLabel_' buffer_'
+  apply (cinit' lift: length___unsigned_long_' current_extra_caps_' call_' invLabel_' buffer_'
                 simp: decodeDomainInvocation_def list_case_If2 whenE_def)
    apply (rule ccorres_Cond_rhs_Seq)
     apply (simp add: throwError_bind invocationCatch_def invocation_eq_use_types
@@ -570,7 +570,7 @@ lemma decodeCNodeInvocation_ccorres:
        (UNIV
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. ccap_relation cp (cap_' s)}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. call_' s = from_bool isCall}
              \<inter> {s. invLabel_' s = lab}
              \<inter> {s. buffer_' s = option_to_ptr buffer}) []
@@ -581,7 +581,7 @@ lemma decodeCNodeInvocation_ccorres:
    apply (simp add: decodeCNodeInvocation_def
               cong: conj_cong)
    apply (rule ccorres_fail')
-  apply (cinit' (no_subst_asm) lift: length___unsigned_long_' cap_' excaps_'
+  apply (cinit' (no_subst_asm) lift: length___unsigned_long_' cap_' current_extra_caps_'
                                      call_' invLabel_' buffer_')
    apply (clarsimp simp: word_less_nat_alt decodeCNodeInvocation_def
                          list_case_If2 invocation_eq_use_types
@@ -2250,11 +2250,9 @@ lemma invokeUntyped_Retype_ccorres:
            \<inter>  {s. newType_' s = object_type_from_H newType }
            \<inter>  {s. unat (userSize_' s) = us }
            \<inter>  {s. deviceMemory_' s = from_bool isdev}
-           \<inter>  \<lbrace>\<acute>destSlots = slot_range_C (cte_Ptr cnodeptr) start
-                                          (of_nat (length destSlots)) \<and>
-                (\<forall>n<length destSlots.
-                    destSlots ! n = cnodeptr + (start + of_nat n) * 2^cteSizeBits)\<rbrace>
-            )
+           \<inter>  {s. destCNode_' s = cte_Ptr cnodeptr}
+           \<inter>  {s. destOffset_' s = start \<and> (\<forall>n < length destSlots. destSlots ! n = cnodeptr + (start + of_nat n) * 2^cteSizeBits)}
+           \<inter>  {s. destLength_' s = of_nat (length destSlots)})
      []
      (invokeUntyped (Retype cref reset ptr_base ptr newType us destSlots isdev))
      (Call invokeUntyped_Retype_'proc)"
@@ -2375,7 +2373,7 @@ lemma invokeUntyped_Retype_ccorres:
          [] (invokeUntyped (Retype cref reset ptr_base ptr newType us destSlots isdev))
             (Call invokeUntyped_Retype_'proc)"
       apply (cinit lift: retypeBase_' srcSlot_' reset_' newType_'
-                          userSize_' deviceMemory_' destSlots_'
+                          userSize_' deviceMemory_' destCNode_' destOffset_' destLength_'
                     simp: when_def)
        apply (rule ccorres_move_c_guard_cte)
        apply csymbr
@@ -2851,7 +2849,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. ccap_relation cp (cap_' s)}
              \<inter> {s. slot_' s = cte_Ptr slot}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. call_' s = from_bool isCall}
              \<inter> {s. buffer_' s = option_to_ptr buffer})
        []
@@ -2861,7 +2859,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
   (Call decodeUntypedInvocation_'proc)"
   supply if_cong[cong] option.case_cong[cong]
   apply (rule ccorres_name_pre)
-  apply (cinit' lift: invLabel_' length___unsigned_long_' cap_' slot_' excaps_' call_' buffer_'
+  apply (cinit' lift: invLabel_' length___unsigned_long_' cap_' slot_' current_extra_caps_' call_' buffer_'
                 simp: decodeUntypedInvocation_def list_case_If2
                       invocation_eq_use_types)
    apply (rule ccorres_Cond_rhs_Seq)
@@ -3097,14 +3095,12 @@ lemma decodeUntypedInvocation_ccorres_helper:
                  apply csymbr
                  apply csymbr
                  apply csymbr
-                 apply csymbr
                  apply (simp add: mapM_locate_eq liftE_bindE
                                   injection_handler_sequenceE mapME_x_sequenceE
                                   whileAnno_def injection_bindE[OF refl refl]
                                   bindE_assoc injection_handler_returnOk)
                  (* gsCNodes assertion *)
                  apply (rule ccorres_stateAssert)
-                 apply csymbr
                  apply (simp add: liftE_bindE[symmetric])
                  apply (rule_tac P="capAligned rv" in ccorres_gen_asm)
                  apply (subgoal_tac "args ! 5 \<le> args ! 4 + args ! 5")
@@ -3263,8 +3259,6 @@ lemma decodeUntypedInvocation_ccorres_helper:
                               apply (frule iffD2[OF olen_add_eqv])
                               apply (frule(1) isUntypedCap_ccap_relation_helper)
                               apply (clarsimp simp: unat_plus_simple[THEN iffD1])
-                              apply (case_tac slots,simp)
-                              apply clarsimp
                               apply (subst upto_enum_word)
                               apply (subst nth_map_upt)
                                apply (clarsimp simp: field_simps Suc_unat_diff_1 unat_plus_simple[THEN iffD1])
@@ -3471,7 +3465,7 @@ shows
              \<inter> {s. unat (length___unsigned_long_' s) = length args}
              \<inter> {s. ccap_relation cp (cap_' s)}
              \<inter> {s. slot_' s = cte_Ptr slot}
-             \<inter> {s. excaps_' s = extraCaps'}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
              \<inter> {s. call_' s = from_bool isCall}
              \<inter> {s. buffer_' s = option_to_ptr buffer})
        []

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -3008,7 +3008,7 @@ lemma transferCaps_ccorres [corres]:
      and K (ep \<noteq> Some 0)
      and K (receiveBuffer \<noteq> Some 0)
      and K (unat (msgExtraCaps mi) \<le> 3))
-    (UNIV \<inter> \<lbrace>interpret_excaps (\<acute>caps) = excaps_map caps\<rbrace>
+    (UNIV \<inter> \<lbrace>interpret_excaps (\<acute>current_extra_caps) = excaps_map caps\<rbrace>
           \<inter> \<lbrace>\<acute>receiver = tcb_ptr_to_ctcb_ptr receiver\<rbrace>
           \<inter> \<lbrace> mi = message_info_to_H \<acute>info\<rbrace>
           \<inter> \<lbrace>\<acute>receiveBuffer = Ptr (option_to_0 receiveBuffer)\<rbrace>
@@ -3016,7 +3016,7 @@ lemma transferCaps_ccorres [corres]:
     (transferCaps mi caps ep receiver receiveBuffer)
     (Call transferCaps_'proc)" (is "ccorres _ _ ?P _ _ _ _")
   apply (unfold K_def, intro ccorres_gen_asm)
-  apply (cinit lift: caps_' receiver_' info_' receiveBuffer_' endpoint_'
+  apply (cinit lift: current_extra_caps_' receiver_' info_' receiveBuffer_' endpoint_'
     simp: getThreadCSpaceRoot_def locateSlot_conv whileAnno_def)
    apply csymbr+
    apply (rule_tac P="?P" and P'="{s. info_' s = info}" in ccorres_inst)
@@ -3056,7 +3056,7 @@ lemma transferCaps_ccorres [corres]:
         apply (rule ccorres_add_return2)
         apply (rule ccorres_split_nothrow_novcg)
             apply (rule ccorres_Catch)
-            apply (rule_tac caps=caps and caps'=capsa in transferCapsLoop_ccorres, simp+)
+            apply (rule_tac caps=caps and caps'=current_extra_caps in transferCapsLoop_ccorres, simp+)
             apply (simp add: excaps_map_def)
            apply ceqv
           apply csymbr
@@ -3403,11 +3403,11 @@ proof -
                  cong: call_ignore_cong)
      apply (clarsimp cong: call_ignore_cong simp del: dc_simp)
      apply (ctac(c_lines 2, no_vcg) add: getMessageInfo_ccorres')
-       apply (rule_tac xf'=caps_' and r'="\<lambda>c c'. interpret_excaps c' = excaps_map c"
-                  in ccorres_split_nothrow_novcg)
+       apply (rule_tac xf'="\<lambda>s. current_extra_caps_' (globals s)"
+                   and r'="\<lambda>c c'. interpret_excaps c' = excaps_map c"
+              in ccorres_split_nothrow_novcg)
            apply (rule ccorres_if_lhs)
             apply (simp add: catch_def to_bool_def ccorres_cond_iffs)
-            apply (rule ccorres_rhs_assoc)+
             apply (rule_tac xf'="\<lambda>s. (status_' s,
                                 current_extra_caps_' (globals s))"
                              and ef'=fst and vf'=snd and es=errstate
@@ -3415,9 +3415,7 @@ proof -
                  apply (rule ccorres_call, rule lookupExtraCaps_ccorres, simp+)
                 apply (rule ceqv_tuple2, ceqv, ceqv)
                apply (simp add: ccorres_cond_iffs)
-               apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
-               apply (rule allI, rule conseqPre, vcg)
-               apply (clarsimp simp: return_def)
+               apply (rule ccorres_return_Skip')
               apply (simp add: ccorres_cond_iffs)
               apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
               apply (rule allI, rule conseqPre, vcg)
@@ -3427,35 +3425,34 @@ proof -
             apply simp
             apply (vcg exspec=lookupExtraCaps_modifies)
            apply (simp add: to_bool_def ccorres_cond_iffs)
-           apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
-           apply (rule allI, rule conseqPre, vcg)
-           apply (clarsimp simp: return_def excaps_map_def interpret_excaps_empty
-                                 word_sle_def word_sless_def)
+           apply (rule ccorres_return[where R=\<top> and R'=UNIV], vcg)
+           apply (clarsimp simp: excaps_map_def interpret_excaps_empty)
           apply ceqv
          apply csymbr
-         apply (ctac(no_vcg) add: copyMRs_ccorres)
-          apply (ctac(no_vcg) add: transferCaps_ccorres)
-           apply csymbr
-           apply (ctac(c_lines 2, no_vcg) add: setMessageInfo_ccorres)
-             apply ctac
+         apply (ctac add: copyMRs_ccorres)
+           apply (ctac add: transferCaps_ccorres)
+             apply csymbr
+             apply (ctac(c_lines 2, no_vcg) add: setMessageInfo_ccorres)
+               apply ctac
+              apply wp
+             apply (clarsimp simp: Kernel_C.badgeRegister_def X64_H.badgeRegister_def
+                                X64.badgeRegister_def X64.capRegister_def Kernel_C.RDI_def)
             apply wp
-           apply (clarsimp simp: Kernel_C.badgeRegister_def X64_H.badgeRegister_def
-                              X64.badgeRegister_def X64.capRegister_def Kernel_C.RDI_def)
-          apply wp
-         apply simp
-         apply (wp hoare_case_option_wp getMessageInfo_le3
-                   getMessageInfo_msgLength lookupExtraCaps_excaps_in_mem
-                   lookupExtraCaps_length
-                    | simp)+
+           apply (simp add: seL4_MessageInfo_lift_def message_info_to_H_def msgLengthBits_def)
+           apply (vcg exspec=transferCaps_modifies)
+          apply (wpsimp wp: hoare_case_option_wp)
+         apply clarsimp
+         apply (vcg exspec=copyMRs_modifies)
+        apply (wpsimp wp: lookupExtraCaps_length)
        apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem)
        apply (clarsimp simp: seL4_MessageInfo_lift_def message_info_to_H_def mask_def
                              msgLengthBits_def word_bw_assocs)
       apply (wp getMessageInfo_le3 getMessageInfo_msgLength[unfolded K_def] static_imp_wp
                   | simp)+
-    apply (auto simp: excaps_in_mem_def valid_ipc_buffer_ptr'_def
-                      option_to_0_def option_to_ptr_def
-                      seL4_MessageInfo_lift_def mi_from_H_def message_info_to_H_def
-               split: option.split)
+     apply (auto simp: excaps_in_mem_def valid_ipc_buffer_ptr'_def
+                       option_to_0_def option_to_ptr_def
+                       seL4_MessageInfo_lift_def mi_from_H_def message_info_to_H_def
+                split: option.split)
     done
 qed
 

--- a/proof/crefine/X64/Recycle_C.thy
+++ b/proof/crefine/X64/Recycle_C.thy
@@ -990,7 +990,7 @@ lemma cancelBadgedSends_ccorres:
           apply (induct_tac list)
            apply (rule allI)
            apply (rule iffD1 [OF ccorres_expand_while_iff_Seq])
-           apply (rule ccorres_tmp_lift2 [OF _ _ refl])
+           apply (rule ccorres_tmp_lift2 [OF _ _ Int_lower1])
             apply ceqv
            apply (simp add: ccorres_cond_iffs)
            apply (rule ccorres_rhs_assoc2)

--- a/proof/crefine/X64/Retype_C.thy
+++ b/proof/crefine/X64/Retype_C.thy
@@ -8452,10 +8452,9 @@ shows  "ccorres dc xfdc
             (length destSlots * 2 ^ APIType_capBits newType userSize) s)}
            \<inter> {s. t_' s = object_type_from_H newType}
            \<inter> {s. parent_' s = cte_Ptr srcSlot}
-           \<inter> {s. slots_' s = slot_range_C (cte_Ptr cnodeptr) start num
-                     \<and> unat num \<noteq> 0
-                     \<and> (\<forall>n. n < length destSlots \<longrightarrow> destSlots ! n = cnodeptr + ((start + of_nat n) * 0x20))
-                     }
+           \<inter> {s. destCNode_' s = cte_Ptr cnodeptr}
+           \<inter> {s. destOffset_' s = start \<and> (\<forall>n. n < length destSlots \<longrightarrow> destSlots ! n = cnodeptr + ((start + of_nat n) * 0x20))}
+           \<inter> {s. destLength_' s = num \<and> unat num \<noteq> 0}
            \<inter> {s. regionBase_' s = Ptr ptr }
            \<inter> {s. unat_eq (userSize_' s) userSize}
            \<inter> {s. deviceMemory_' s = from_bool isdev}
@@ -8472,7 +8471,7 @@ shows  "ccorres dc xfdc
    apply (rule less_le_trans[OF getObjectSize_max_size]; clarsimp simp: word_bits_def untypedBits_defs)
   apply (subgoal_tac "\<forall>n < length destSlots. canonical_address (ptr + (of_nat n << APIType_capBits newType userSize))")
    prefer 2 subgoal by (simp add: shiftl_t2n field_simps range_cover_canonical_address)
-  apply (cinit lift: t_' parent_' slots_' regionBase_' userSize_' deviceMemory_')
+  apply (cinit lift: t_' parent_' destCNode_' destOffset_' destLength_' regionBase_' userSize_' deviceMemory_')
    apply (rule ccorres_rhs_assoc2)+
    apply (rule ccorres_rhs_assoc)
    apply (rule_tac Q' = "Q'

--- a/proof/crefine/X64/Syscall_C.thy
+++ b/proof/crefine/X64/Syscall_C.thy
@@ -127,21 +127,21 @@ lemma decodeInvocation_ccorres:
               and (\<lambda>s. \<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p))
               and sysargs_rel args buffer)
        (UNIV \<inter> {s. call_' s = from_bool isCall}
-                   \<inter> {s. block_' s = from_bool isBlocking}
-                   \<inter> {s. call_' s = from_bool isCall}
-                   \<inter> {s. block_' s = from_bool isBlocking}
-                   \<inter> {s. invLabel_' s = label}
-                   \<inter> {s. unat (length___unsigned_long_' s) = length args}
-                   \<inter> {s. capIndex_' s = cptr}
-                   \<inter> {s. slot_' s = cte_Ptr slot}
-                   \<inter> {s. excaps_' s = extraCaps'}
-                   \<inter> {s. ccap_relation cp (cap_' s)}
-                   \<inter> {s. buffer_' s = option_to_ptr buffer}) []
+             \<inter> {s. block_' s = from_bool isBlocking}
+             \<inter> {s. call_' s = from_bool isCall}
+             \<inter> {s. block_' s = from_bool isBlocking}
+             \<inter> {s. invLabel_' s = label}
+             \<inter> {s. unat (length___unsigned_long_' s) = length args}
+             \<inter> {s. capIndex_' s = cptr}
+             \<inter> {s. slot_' s = cte_Ptr slot}
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
+             \<inter> {s. ccap_relation cp (cap_' s)}
+             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
        (decodeInvocation label args cptr slot cp extraCaps
               >>= invocationCatch thread isBlocking isCall id)
        (Call decodeInvocation_'proc)"
   apply (cinit' lift: call_' block_' invLabel_' length___unsigned_long_'
-                      capIndex_' slot_' excaps_' cap_' buffer_')
+                      capIndex_' slot_' current_extra_caps_' cap_' buffer_')
    apply csymbr
    apply (simp add: cap_get_tag_isCap decodeInvocation_def
               cong: if_cong StateSpace.state.fold_congs

--- a/proof/crefine/X64/Tcb_C.thy
+++ b/proof/crefine/X64/Tcb_C.thy
@@ -2455,12 +2455,12 @@ lemma decodeCopyRegisters_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeCopyRegisters args cp (map fst extraCaps)
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeCopyRegisters_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeCopyRegisters_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeCopyRegisters_def)
    apply csymbr
    apply wpc
     apply (simp add: if_1_0_0 unat_eq_0)
@@ -2814,12 +2814,13 @@ lemma decodeTCBConfigure_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. rootCaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeTCBConfigure args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeTCBConfigure_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' slot_' rootCaps_' buffer_' simp: decodeTCBConfigure_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' slot_' current_extra_caps_' buffer_'
+                simp: decodeTCBConfigure_def)
    apply csymbr
    apply (clarsimp cong: StateSpace.state.fold_congs globals.fold_congs
                simp del: Collect_const
@@ -3211,14 +3212,14 @@ lemma decodeSetMCPriority_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetMCPriority args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetMCPriority_'proc)"
   supply Collect_const[simp del]
   supply dc_simp[simp del]
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeSetMCPriority_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetMCPriority_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
    apply (rule_tac xf'=ret__int_' and R'=UNIV and R=\<top> and
@@ -3347,13 +3348,13 @@ lemma decodeSetPriority_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetPriority args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetPriority_'proc)"
   supply Collect_const[simp del] dc_simp[simp del]
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeSetPriority_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetPriority_def)
      apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
    apply (rule_tac xf'=ret__int_' and R'=UNIV and R=\<top> and
@@ -3496,13 +3497,13 @@ lemma decodeSetSchedParams_ccorres:
        (UNIV
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetSchedParams args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetSchedParams_'proc)"
   supply Collect_const[simp del] dc_simp[simp del]
-  apply (cinit' lift: cap_' length___unsigned_long_' excaps_' buffer_' simp: decodeSetSchedParams_def)
+  apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetSchedParams_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
    apply (rule_tac xf'=ret__int_' and R'=UNIV and R=\<top> and
@@ -3666,12 +3667,12 @@ lemma decodeSetIPCBuffer_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetIPCBuffer args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetIPCBuffer_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' slot_' excaps_' buffer_'
+  apply (cinit' lift: cap_' length___unsigned_long_' slot_' current_extra_caps_' buffer_'
                 simp: decodeSetIPCBuffer_def)
    apply wpc
     apply (simp add: unat_eq_0)
@@ -3980,12 +3981,12 @@ lemma decodeBindNotification_ccorres:
               and (excaps_in_mem extraCaps o ctes_of)
               and K (isThreadCap cp))
        (UNIV \<inter> {s. ccap_relation cp (cap_' s)}
-             \<inter> {s. excaps_' s = extraCaps'}) []
+             \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}) []
      (decodeBindNotification cp extraCaps >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeBindNotification_'proc)"
   using [[goals_limit=1]]
   apply (simp, rule ccorres_gen_asm)
-  apply (cinit' lift: cap_' excaps_' simp: decodeBindNotification_def)
+  apply (cinit' lift: cap_' current_extra_caps_' simp: decodeBindNotification_def)
    apply (simp add: bind_assoc whenE_def bind_bindE_assoc interpret_excaps_test_null
                del: Collect_const cong: call_ignore_cong)
    apply (rule ccorres_Cond_rhs_Seq)
@@ -4181,12 +4182,12 @@ lemma decodeSetSpace_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeSetSpace args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetSpace_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' slot_' excaps_' buffer_'
+  apply (cinit' lift: cap_' length___unsigned_long_' slot_' current_extra_caps_' buffer_'
                 simp: decodeSetSpace_def)
    apply csymbr
    apply (rule ccorres_Cond_rhs_Seq)
@@ -4554,13 +4555,13 @@ lemma decodeTCBInvocation_ccorres:
             \<inter> {s. ccap_relation cp (cap_' s)}
             \<inter> {s. unat (length___unsigned_long_' s) = length args}
             \<inter> {s. slot_' s = cte_Ptr slot}
-            \<inter> {s. excaps_' s = extraCaps'}
+            \<inter> {s. current_extra_caps_' (globals s) = extraCaps'}
             \<inter> {s. call_' s = from_bool isCall}
             \<inter> {s. buffer_' s = option_to_ptr buffer}) []
      (decodeTCBInvocation label args cp slot extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeTCBInvocation_'proc)"
-  apply (cinit' lift: invLabel_' cap_' length___unsigned_long_' slot_' excaps_' call_' buffer_')
+  apply (cinit' lift: invLabel_' cap_' length___unsigned_long_' slot_' current_extra_caps_' call_' buffer_')
    apply (simp add: decodeTCBInvocation_def invocation_eq_use_types gen_invocation_type_eq
                del: Collect_const)
    apply (rule ccorres_Cond_rhs)

--- a/proof/crefine/lib/Ctac.thy
+++ b/proof/crefine/lib/Ctac.thy
@@ -1452,17 +1452,10 @@ lemma ceqv_xpres_lvar_nondet_init:
   done
 
 \<comment> \<open>
-Some ceqv_xpres rules as stated above are too general for the automation.
-Here, we build two instantiations of the rules for use in the tactics.
-
-ceqv_xpres_rules_legacy:
-  - Rules that matches the behaviour of an older version of the
-    ceqv_xpres framework, for compatibility with older proofs.
-  - Currently used in all methods except `cinit` and `cinit'`.
-
-ceqv_xpres_rules_new:
-  - A rule set that better understands exceptional control flow.
-  - Currently used in `cinit` and `cinit'`
+Some ceqv_xpres rules as stated above are too general for the automation, and need to
+be instantiated to ensure that output parameters are fully determined by input parameters.
+The instantiations we use in `ceqv_xpres_rules` allow us to take advantage of exceptional
+control flow.
 \<close>
 
 lemmas ceqv_xpres_returns
@@ -1471,24 +1464,13 @@ lemmas ceqv_xpres_returns
 lemmas ceqv_xpres_basics
   = ceqv_xpres_Basic ceqv_xpres_lvar_nondet_init
 
-lemmas ceqv_xpres_special_legacy =
-  ceqv_xpres_abnormalI[OF xpres_abnormal_trivial]
-  ceqv_xpres_Throw[where abnormal=False]
-  ceqv_xpres_returns[where pres_norm=pres and pres=pres and abnormal=False for pres, simplified]
-  ceqv_xpres_basics[where pres_abr=pres and pres=pres for pres]
-
-lemmas ceqv_xpres_special_new =
+lemmas ceqv_xpres_rules =
+  ceqv_xpres_xfdc ceqv_xpres_whileAnno ceqv_xpres_While ceqv_xpres_Cond ceqv_xpres_Guard
+  ceqv_xpres_Seq ceqv_xpres_call_ceqv_xpres ceqv_xpres_Skip ceqv_xpres_Catch ceqv_xpres_ccatchbrk
   ceqv_xpres_abnormalI
   ceqv_xpres_Throw[where abnormal=True]
   ceqv_xpres_returns[where pres_norm=True and abnormal=True, simplified]
   ceqv_xpres_basics[where pres_abr=True]
-
-lemmas ceqv_xpres_rules_common =
-  ceqv_xpres_xfdc ceqv_xpres_whileAnno ceqv_xpres_While ceqv_xpres_Cond ceqv_xpres_Guard
-  ceqv_xpres_Seq ceqv_xpres_call_ceqv_xpres ceqv_xpres_Skip ceqv_xpres_Catch ceqv_xpres_ccatchbrk
-
-lemmas ceqv_xpres_rules_legacy = ceqv_xpres_rules_common ceqv_xpres_special_legacy
-lemmas ceqv_xpres_rules_new = ceqv_xpres_rules_common ceqv_xpres_special_new
 
 lemma ceqv_xpres_FalseI:
   "ceqv_xpres \<Gamma> xf v pres c False False False c"
@@ -1858,10 +1840,7 @@ method_setup clift = \<open>CtacImpl.corres_abstract_args\<close>
 method_setup cinitlift = \<open>CtacImpl.corres_abstract_init_args\<close>
   "Abstract a list of local variables into HOL variable without touching the remaining guards"
 
-method_setup csymbr = \<open>CtacImpl.corres_symb_rhs_new\<close>
-  "Symbolically execute the call on the right hand side of corres (see ccorres_lift_rhss). Arguments simp (add|del|only)."
-
-method_setup csymbr_legacy = \<open>CtacImpl.corres_symb_rhs_legacy\<close>
+method_setup csymbr = \<open>CtacImpl.corres_symb_rhs\<close>
   "Symbolically execute the call on the right hand side of corres (see ccorres_lift_rhss). Arguments simp (add|del|only)."
 
 method_setup ceqv = \<open>CtacImpl.corres_ceqv\<close>

--- a/proof/crefine/lib/Ctac.thy
+++ b/proof/crefine/lib/Ctac.thy
@@ -1103,6 +1103,29 @@ lemmas ceqv_rules = ceqv_refl [where xf' = xfdc] \<comment> \<open>Any ceqv with
   ceqv_refl [where c = return_void_C] ceqv_refl [where c = break_C]
   ceqv_refl [where c = catchbrk_C]
 
+\<comment> \<open>
+Equivalence of SIMPL commands under the assumption that a variable contains a specified value.
+Intended to be used to calculate output parameters from input parameters.
+Stronger than `ceqv`, since it can also calculate the conditions under which the variable's
+value is preserved.
+
+Input parameters:
+- c: The SIMPL command under consideration.
+- pres_cont: false if execution of a previous command terminates normally
+  without preserving the value of the variable.
+- xf: a function that extracts the value of a particular variable from the state.
+- v: if `pres_cont` is true, the presumed value of the variable prior to executing `c`.
+
+Output parameters:
+- pres_norm: true if syntactic analysis shows that the variable still has
+  the value `v` whenever `c` terminates normally.
+- pres_abr: true if syntactic analysis shows that the variable still has
+  the value `v` whenever `c` terminates abruptly.
+- abnormal: true if syntactic analysis shows that `c` never terminates normally.
+- c': a command that is equivalent to `c`, with the intention that occurrences of the
+  variable have been replaced with the value `v` in any context where that value is
+  known to have been preserved.
+\<close>
 definition
   ceqv_xpres :: "(('s,'p,'f) body) \<Rightarrow> ('s \<Rightarrow> 'v) \<Rightarrow> 'v \<Rightarrow> bool \<Rightarrow> ('s,'p,'f) com
                  \<Rightarrow> bool \<Rightarrow> bool \<Rightarrow> bool \<Rightarrow> ('s,'p,'f) com \<Rightarrow> bool"

--- a/proof/crefine/lib/Ctac.thy
+++ b/proof/crefine/lib/Ctac.thy
@@ -1780,10 +1780,10 @@ method_setup clift = \<open>CtacImpl.corres_abstract_args\<close>
 method_setup cinitlift = \<open>CtacImpl.corres_abstract_init_args\<close>
   "Abstract a list of local variables into HOL variable without touching the remaining guards"
 
-method_setup csymbr_new = \<open>CtacImpl.corres_symb_rhs_new\<close>
+method_setup csymbr = \<open>CtacImpl.corres_symb_rhs_new\<close>
   "Symbolically execute the call on the right hand side of corres (see ccorres_lift_rhss). Arguments simp (add|del|only)."
 
-method_setup csymbr = \<open>CtacImpl.corres_symb_rhs_legacy\<close>
+method_setup csymbr_legacy = \<open>CtacImpl.corres_symb_rhs_legacy\<close>
   "Symbolically execute the call on the right hand side of corres (see ccorres_lift_rhss). Arguments simp (add|del|only)."
 
 method_setup ceqv = \<open>CtacImpl.corres_ceqv\<close>

--- a/proof/crefine/lib/ctac-method.ML
+++ b/proof/crefine/lib/ctac-method.ML
@@ -316,8 +316,9 @@ fun corres_solve_ceqv_old (trace : trace_opts) (depth : int) ctxt =
     EVERY' [REPEAT_DETERM' (Rule_Insts.thin_tac ctxt "_" []),
             SOLVE' (corres_ceqv_tac trace depth ctxt)]
 
-val ceqv_xpres_ceqvI = @{thm ceqv_xpres_ceqvI};
-val ceqv_xpres_rules = @{thms ceqv_xpres_rules};
+val ceqv_xpres_ceqvI = @{thm ceqv_xpres_ceqvD};
+val ceqv_xpres_rules_legacy = @{thms ceqv_xpres_rules_legacy};
+val ceqv_xpres_rules_new = @{thms ceqv_xpres_rules_new};
 val ceqv_xpres_FalseI = @{thm ceqv_xpres_FalseI};
 val ceqv_xpres_rewrite_basic_left_cong = @{thm ceqv_xpres_rewrite_basic_left_cong};
 val ceqv_xpres_rewrite_basic_refl = @{thm ceqv_xpres_rewrite_basic_refl};
@@ -326,7 +327,7 @@ val ceqv_xpres_basic_preserves_FalseI = @{thm ceqv_xpres_basic_preserves_FalseI}
 val ceqv_xpres_lvar_nondet_init_TrueI = @{thm ceqv_xpres_lvar_nondet_init_TrueI};
 val ceqv_xpres_lvar_nondet_init_FalseI = @{thm ceqv_xpres_lvar_nondet_init_FalseI};
 val ceqv_xpres_rewrite_set_rules = @{thms ceqv_xpres_rewrite_set_rules};
-val ceqv_xpres_eq_If_rules = @{thms ceqv_xpres_eq_If_rules};
+val xpres_eq_If_rules = @{thms xpres_eq_If_rules};
 
 val apply_ceqv_xpres_rules_trace = ref @{term True};
 
@@ -338,7 +339,7 @@ fun apply_ceqv_xpres_rules1 ctxt rules _ n = DETERM
              apply_ceqv_xpres_rules_trace := t;
              resolve_tac ctxt [ceqv_xpres_FalseI] n)) n));
 
-fun apply_ceqv_xpres_rules ctxt = let
+fun apply_ceqv_xpres_rules ceqv_xpres_rules ctxt = let
     val seq = ceqv_simpl_seq ctxt
     val ex_rules = if seq then [@{thm ceqv_xpres_While_simpl_sequence}]
         else []
@@ -351,15 +352,23 @@ fun solve_ceqv_xpres_rewrite_basic ctxt n = DETERM
   (safe_simp_tac (addcongs [ceqv_xpres_rewrite_basic_left_cong] (put_simpset HOL_basic_ss ctxt)) n
       THEN resolve_tac ctxt [ceqv_xpres_rewrite_basic_refl] n);
 
-fun solve_ceqv_xpres_basic_preserves ctxt n = DETERM
-  ((resolve_tac ctxt [ceqv_xpres_basic_preserves_TrueI] n
-       THEN SOLVE' (clarsimp_tac ctxt) n)
-     ORELSE resolve_tac ctxt [ceqv_xpres_basic_preserves_FalseI] n);
+fun solve_ceqv_xpres_basic_preserves ctxt (t, n) = let
+    val true_tac = resolve_tac ctxt [ceqv_xpres_basic_preserves_TrueI] n
+                   THEN SOLVE' (clarsimp_tac ctxt) n
+    fun false_tac st = let
+        val t_concl = Envir.beta_eta_contract (Logic.strip_assums_concl t)
+        val (context, xf) = case t_concl of
+            @{term_pat "Trueprop (ceqv_xpres_basic_preserves ?context ?xf _ _ _ _)"} => (context, xf)
+          | _ => (@{term unknown}, @{term unknown})
+        val _ = tracing ("failed to show preservation for variable: " ^ Syntax.string_of_term ctxt xf
+                         ^ "\nin context: " ^ Syntax.string_of_term ctxt context)
+      in resolve_tac ctxt [ceqv_xpres_basic_preserves_FalseI] n st end
+  in DETERM (true_tac ORELSE false_tac) end;
 
 fun ceqv_xpres_call_tac ctxt (t, n) = let
     val t_concl = Envir.beta_eta_contract (Logic.strip_assums_concl t);
     fun f_name () = case t_concl of
-        @{term Trueprop} $ (@{term_pat "ceqv_xpres_call _ _ _"} $ Const p $ _ $ _ $ _ $ _ $ _ $ _) => fst p
+        @{term Trueprop} $ (@{term_pat "ceqv_xpres_call _ _ _"} $ Const p $ _ $ _ $ _ $ _ $ _ $ _ $ _ $ _) => fst p
       | _ => raise TERM ("unexpected conclusion", [t_concl]);
     fun modifies_thm () = f_name ()
         |> Long_Name.base_name
@@ -371,9 +380,12 @@ fun ceqv_xpres_call_tac ctxt (t, n) = let
         resolve_tac ctxt [modifies_thm ()] 1 @{thm ceq_xpres_call_hoarep} |> Seq.hd;
     fun ceqv_xpres_call_default s =
         (warning ("ceqv_xpres_call_tac: " ^ s); @{thm ceqv_xpres_call});
+    (* FIXME: does something like this already exist? *)
+    fun string_of_terms ts =
+        if null ts then "" else (List.foldl (fn (t,s) => s ^ Syntax.string_of_term ctxt t ^ "\n") ":\n" ts)
     val ceqv_xpres_callI = ceqv_xpres_call_modifies ()
         handle ERROR s => ceqv_xpres_call_default s
-        handle TERM (s, _) => ceqv_xpres_call_default s
+        handle TERM (s, t) => ceqv_xpres_call_default (s ^ string_of_terms t)
         handle Option => ceqv_xpres_call_default "ceqv_xpres_call_modifies";
   in resolve_tac ctxt [ceqv_xpres_callI] n end;
 
@@ -422,35 +434,41 @@ fun ceqv_restore_args_tac ctxt = SUBGOAL (fn (t, n) => case
               (("g",0), g)]
           @{thm ceqv_xpres_call_restore_argsI}
           |> Drule.generalize ([], map (dest_Free #> fst) xs)
-    in resolve_tac ctxt [thm] n THEN simp_tac ctxt n end)
+    in resolve_tac ctxt [thm] n THEN simp_tac ctxt n end
+  | _ => raise TERM("ceqv_restore_args_tac", [t]))
 
-fun ceqv2_consts_and_tacs ctxt = map (apfst (fst o dest_Const)) [
-  (@{term ceqv_xpres}, apply_ceqv_xpres_rules ctxt),
+fun xpres_abnormal_tac ctxt =
+    resolve_tac ctxt @{thms xpres_abnormal_rules}
+    ORELSE' resolve_tac ctxt @{thms xpres_abnormal_trivial}
+
+fun ceqv2_consts_and_tacs ceqv_xpres_rules ctxt = map (apfst (fst o dest_Const)) [
+  (@{term ceqv_xpres}, apply_ceqv_xpres_rules ceqv_xpres_rules ctxt),
   (@{term ceqv_xpres_rewrite_basic}, solve_ceqv_xpres_rewrite_basic),
   (@{term ceqv_xpres_rewrite_set}, K (resolve_tac ctxt ceqv_xpres_rewrite_set_rules)),
-  (@{term ceqv_xpres_basic_preserves}, solve_ceqv_xpres_basic_preserves),
+  (@{term ceqv_xpres_basic_preserves}, SUBGOAL o solve_ceqv_xpres_basic_preserves),
   (@{term ceqv_xpres_lvar_nondet_init}, solve_ceqv_xpres_lvar),
-  (@{term ceqv_xpres_eq_If}, K (resolve_tac ctxt ceqv_xpres_eq_If_rules)),
   (@{term ceqv_xpres_call_restore_args}, ceqv_restore_args_tac),
-  (@{term ceqv_xpres_call}, SUBGOAL o ceqv_xpres_call_tac)
+  (@{term ceqv_xpres_call}, SUBGOAL o ceqv_xpres_call_tac),
+  (@{term xpres_eq_If}, K (resolve_tac ctxt xpres_eq_If_rules)),
+  (@{term xpres_abnormal}, K (xpres_abnormal_tac ctxt))
 ];
 
-fun ceqv2_all_tacs ctxt = SUBGOAL (fn (t, n) =>
+fun ceqv2_all_tacs ceqv_xpres_rules ctxt = SUBGOAL (fn (t, n) =>
   case head_of (HOLogic.dest_Trueprop (Logic.strip_assums_concl t)) of
-    Const (s, T) => (case (filter (fn v => fst v = s) (ceqv2_consts_and_tacs ctxt)) of
+    Const (s, T) => (case (filter (fn v => fst v = s) (ceqv2_consts_and_tacs ceqv_xpres_rules ctxt)) of
         (v :: _) => (snd v) ctxt n
       | [] => raise TERM ("ceqv2_all_tacs: unknown head const " ^ s, [Const (s, T), t]))
   | _ => raise TERM ("ceqv2_all_tacs: unknown form", [t]));
 
-fun ceqv2_tac ctxt n = let
+fun ceqv2_tac ceqv_xpres_rules ctxt n = let
 in
   resolve_tac ctxt [ceqv_xpres_ceqvI] n THEN
     SELECT_GOAL (REPEAT_DETERM (eresolve_tac ctxt [thin_rl] 1)
-       THEN REPEAT_DETERM (ceqv2_all_tacs ctxt 1)) n
+       THEN REPEAT_DETERM (ceqv2_all_tacs ceqv_xpres_rules ctxt 1)) n
 end;
 
-fun corres_solve_ceqv (_ (*trace*) : trace_opts) (_ (*depth*) : int) =
-    ceqv2_tac;
+fun corres_solve_ceqv ceqv_xpres_rules (_ (*trace*) : trace_opts) (_ (*depth*) : int) =
+    ceqv2_tac ceqv_xpres_rules;
 
 fun rename_fresh_tac nm i thm = let
     (* FIXME: proper name context handling *)
@@ -469,10 +487,8 @@ fun corres_pre_lift_tac lift_thm trace depth ctxt xf =
              res_inst xf ORELSE' res_inst ("\<lambda>s. " ^ xf ^ " (globals s)"),
              rename_fresh_tac var_name,
              resolve_tac ctxt [my_thm ctxt lift_thm],
-             corres_solve_ceqv trace depth ctxt]
+             corres_solve_ceqv ceqv_xpres_rules_new trace depth ctxt]
   end;
-
-val corres_lift_tac = corres_pre_lift_tac "ccorres_tmp_lift2";
 
 fun extract_lhs_xf (ct as (Const ("Language.com.Basic", _) $ _)) = extract_basic_xf ct
   | extract_lhs_xf (Const ("Language.call", _) $ _ $ _ $ _ $ (Abs (_, _, (Abs (_, _, c)))))
@@ -514,37 +530,42 @@ end;
 
 val guard_is_UNIVI  = @{thms "guard_is_UNIVI"}
 
-fun ccorres_cleanup_rest (trace : trace_opts)
+fun ccorres_cleanup_rest (ceqv_xpres_rules : thm list)
+                         (trace : trace_opts)
                          (depth : int)
                          (ctxt : Proof.context)
                          (n : int) = let
     val match_ceqv      = Proof_Context.get_thms ctxt "match_ceqv"
     val my_clarsimp_tac = prim_trace_tac' (#trace_this trace) depth "my_clarsimp_tac" ctxt (SOLVE' (clarsimp_tac ctxt))
 in
-    (FIRST_COMMIT' [(resolve_tac ctxt match_ceqv, corres_solve_ceqv trace depth ctxt),
+    (FIRST_COMMIT' [(resolve_tac ctxt match_ceqv, corres_solve_ceqv ceqv_xpres_rules trace depth ctxt),
                     (resolve_tac ctxt guard_is_UNIVI, fn _ => all_tac), (* maybe we should try simp? *)
                     (fn _ => all_tac, my_clarsimp_tac)]) n
 end;
 
 
-fun ccorres_norename_cleanup (trace : trace_opts)
+fun ccorres_norename_cleanup (ceqv_xpres_rules : thm list)
+                             (trace : trace_opts)
                              (depth : int)
                              (ctxt : Proof.context)
                              (n : int) = let
     val match_cc        = Proof_Context.get_thms ctxt "match_ccorres"
 in
     prim_trace_tac (#trace_this trace) depth "CLEANUP (no rename)" ctxt
-                   ((resolve_tac ctxt match_cc n) THEN_ELSE (all_tac, ccorres_cleanup_rest trace (depth + 1) ctxt n))
+                   (resolve_tac ctxt match_cc n
+                    THEN_ELSE (all_tac, ccorres_cleanup_rest ceqv_xpres_rules trace (depth + 1) ctxt n))
 end;
 
-fun ccorres_rename_cleanup trace depth xf ctxt n = let
+fun ccorres_rename_cleanup ceqv_xpres_rules trace depth xf ctxt n = let
     val match_cc  = Proof_Context.get_thms ctxt "match_ccorres"
 
     val base_xf   = Long_Name.base_name xf
     val var_name  = (unsuffix "_'" base_xf handle Fail _ => base_xf)
 in
     prim_trace_tac (#trace_this trace) depth "CLEANUP" ctxt
-                   (resolve_tac ctxt match_cc n THEN_ELSE (rename_fresh_tac var_name n, ccorres_cleanup_rest trace (depth + 1) ctxt n))
+                   (resolve_tac ctxt match_cc n
+                    THEN_ELSE (rename_fresh_tac var_name n,
+                               ccorres_cleanup_rest ceqv_xpres_rules trace (depth + 1) ctxt n))
 end;
 
 fun abstract_record_xf_if_required trace depth ctxt xf o_xfr = let
@@ -554,7 +575,7 @@ in
     case o_xfr of
         SOME (_, true) => prim_trace_tac' (#trace_this trace) depth "ccorres_abstract" ctxt
                                           (Rule_Insts.res_inst_tac ctxt [((("xf'", 0), Position.none), xf)] [] abstract_thm
-                                                        THEN_ALL_NEW ccorres_rename_cleanup trace (depth + 1) xf ctxt)
+                                           THEN_ALL_NEW ccorres_rename_cleanup ceqv_xpres_rules_new trace (depth + 1) xf ctxt)
       | _              => fn _ => all_tac
 end;
 
@@ -698,7 +719,7 @@ fun ccorres_doit (opts : ctac_opts)
         (* solve the remaining subgoals *)
         val resttac = (resolve_tac ctxt skips) (* Ignore any valids etc. *)
                           ORELSE'
-                          ccorres_rename_cleanup trace depth' xf ctxt
+                          ccorres_rename_cleanup ceqv_xpres_rules_new trace depth' xf ctxt
     in
         (abstract_record_xf_if_required trace depth ctxt xf o_xfru)
             THEN'
@@ -747,7 +768,9 @@ in
     (REPEAT_DETERM (resolve_tac ctxt ctac_pre_rules n))
         THEN (REPEAT_DETERM_N (#c_lines opts - 1) (resolve_tac ctxt rhs_assoc2 n))
         THEN
-        ((resolve_tac ctxt match_seq n) THEN_ELSE (corres_split_tac opts ctxt n, corres_nosplit_tac opts ctxt n))
+        (resolve_tac ctxt match_seq n
+         THEN_ELSE (corres_split_tac opts ctxt n,
+                    corres_nosplit_tac opts ctxt n))
         THEN REPEAT_DETERM (resolve_tac ctxt ctac_post_rules n)
 end;
 
@@ -768,7 +791,8 @@ in
     map inst_type_vars thms
 end handle Bind => raise TACTIC ("Exception Bind in instantiate_xf_type: check order of assumptions to rhss lemmas in Corres_C and function corres_symb_rhs_tac");
 
-fun corres_symb_rhs_exec_tac (trace : trace_opts)
+fun corres_symb_rhs_exec_tac (ceqv_xpres_rules : thm list)
+                             (trace : trace_opts)
                              (depth : int)
                              (ctxt : Proof.context)
                              (lhs : term)
@@ -795,7 +819,8 @@ fun corres_symb_rhs_exec_tac (trace : trace_opts)
                                                  @[@{thm TrueI}] @ xs)
 in
     prim_trace_tac' (#trace_this trace) depth ("CSYMBR (" ^ proc_name ^ ")") ctxt
-                    (Rule_Insts.res_inst_tac ctxt insts [] rule THEN_ALL_NEW ccorres_rename_cleanup trace depth' xf ctxt) n t
+                    (Rule_Insts.res_inst_tac ctxt insts [] rule
+                     THEN_ALL_NEW ccorres_rename_cleanup ceqv_xpres_rules trace depth' xf ctxt) n t
 end; (* handle TERM  e => no_tac
             | ERROR e => no_tac *)
 
@@ -809,14 +834,14 @@ fun corres_trim_lvar_nondet_init_tac trace depth ctxt known_guard = let
                                                      else "ccorres_lift_rhs_remove_lvar_init_unknown_guard")
     in
               prim_trace_tac' (#trace_this trace) depth "LVAR_INIT" ctxt
-                                          ((resolve_tac ctxt [remove_lvar_init])
-                                                     THEN_ALL_NEW (ccorres_norename_cleanup trace depth ctxt)) i
+                                          (resolve_tac ctxt [remove_lvar_init]
+                                           THEN_ALL_NEW (ccorres_norename_cleanup ceqv_xpres_rules_new trace depth ctxt)) i
     end;
 in
     resolve_tac ctxt match_seq THEN' SUBGOAL tac
 end;
 
-fun corres_symb_rhs_tac (opts : ceqv_opts) ctxt =
+fun corres_symb_rhs_tac ceqv_xpres_rules (opts : ceqv_opts) ctxt =
 let
     val ctxt      = Context_Position.set_visible false ctxt
     val trace     = #trace opts
@@ -864,13 +889,14 @@ let
         (* The Basic_record lemmas don't seem to require xfr and xfru to be instantiated *)
         val basic_tac =
             prim_trace_tac' (#trace_this trace) depth "CSYMBR (Basic)" ctxt
-                            ((Rule_Insts.res_inst_tac ctxt xf_inst [] basic_thm) THEN_ALL_NEW (ccorres_norename_cleanup trace depth' ctxt))
+                            (Rule_Insts.res_inst_tac ctxt xf_inst [] basic_thm
+                             THEN_ALL_NEW (ccorres_norename_cleanup ceqv_xpres_rules trace depth' ctxt))
 
         val call_thms' = Proof_Context.get_thms ctxt ("ccorres_lift_rhss" ^ record_suffix)
         val call_thms = inst_tp call_thms'
         val _ = forall (fn (t, t') => Thm.concl_of t <> Thm.concl_of t') (call_thms ~~ call_thms')
             orelse raise THM ("corres_symb_rhs_tac: failed to inst_tp", 1, call_thms @ call_thms')
-        val call_tac  = EVERY' [corres_symb_rhs_exec_tac trace depth ctxt lhs (xf_inst @ xfr_inst) call_thms new_xf_name,
+        val call_tac  = EVERY' [corres_symb_rhs_exec_tac ceqv_xpres_rules trace depth ctxt lhs (xf_inst @ xfr_inst) call_thms new_xf_name,
                                 (* Yes, simp should ignore assumptions -- this simplifies away the state dep. on i *)
                                     TRY' (simp_tac ss),
                                 TRY' (resolve_tac ctxt gen_asm)]
@@ -918,7 +944,8 @@ fun corres_boilerplate_tac opts unfold_haskell_p xfs ctxt = let
         val call_ignore_cong = @{thms "call_ignore_cong"}
 
         val ccorres_trim_redundant_throw = Proof_Context.get_thms ctxt "ccorres_trim_redundant_throw"
-        val trim_redundant_throw_tac = resolve_tac ctxt ccorres_trim_redundant_throw THEN_ALL_NEW ccorres_norename_cleanup trace depth' ctxt
+        val trim_redundant_throw_tac = resolve_tac ctxt ccorres_trim_redundant_throw
+                                       THEN_ALL_NEW ccorres_norename_cleanup ceqv_xpres_rules_new trace depth' ctxt
 
         val ccorres_trim_DontReach = Proof_Context.get_thms ctxt "ccorres_special_trim_guard_DontReach_pis"
         val pis_thms = Proof_Context.get_thms ctxt "push_in_stmt_rules"
@@ -1092,8 +1119,8 @@ fun corres_pre_abstract_args lift_fn =
 val corres_abstract_args = corres_pre_abstract_args (corres_pre_lift_tac "ccorres_tmp_lift2" default_trace_opts 0);
 val corres_abstract_init_args = corres_pre_abstract_args (corres_pre_lift_tac "ccorres_init_tmp_lift2" default_trace_opts 0);
 
-val corres_symb_rhs = let
-    fun tac upds ctxt = Method.SIMPLE_METHOD' (corres_symb_rhs_tac (apply upds default_csymbr_opts) ctxt);
+fun corres_symb_rhs ceqv_xpres_rules = let
+    fun tac upds ctxt = Method.SIMPLE_METHOD' (corres_symb_rhs_tac ceqv_xpres_rules (apply upds default_csymbr_opts) ctxt);
 
     val option_args = Args.parens (P.list (Scan.first csymbr_options))
     val opt_option_args = Scan.lift (Scan.optional option_args [])
@@ -1102,8 +1129,11 @@ in
     |> shorten_names
 end;
 
+val corres_symb_rhs_legacy = corres_symb_rhs ceqv_xpres_rules_legacy
+val corres_symb_rhs_new = corres_symb_rhs ceqv_xpres_rules_new
+
 val corres_ceqv = let
-    fun tac upds ctxt = Method.SIMPLE_METHOD' (corres_solve_ceqv (#trace (apply upds default_ceqv_opts)) 0 ctxt);
+    fun tac upds ctxt = Method.SIMPLE_METHOD' (corres_solve_ceqv ceqv_xpres_rules_new (#trace (apply upds default_ceqv_opts)) 0 ctxt);
 
     val option_args = Args.parens (P.list (Scan.first ceqv_options))
     val opt_option_args = Scan.lift (Scan.optional option_args [])

--- a/proof/crefine/lib/ctac-method.ML
+++ b/proof/crefine/lib/ctac-method.ML
@@ -329,6 +329,16 @@ val ceqv_xpres_lvar_nondet_init_FalseI = @{thm ceqv_xpres_lvar_nondet_init_False
 val ceqv_xpres_rewrite_set_rules = @{thms ceqv_xpres_rewrite_set_rules};
 val xpres_eq_If_rules = @{thms xpres_eq_If_rules};
 
+val cinit_lift_thms = (@{thm ccorres_save_pre_UNIV_Int}
+                       , @{thm ccorres_save_pre_lift1}
+                       , @{thm ccorres_save_pre_lift1_save_global}
+                       , @{thm ccorres_save_pre_init_lift2})
+
+val clift_thms = (@{thm ccorres_introduce_UNIV_Int_when_needed}
+                  , @{thm ccorres_tmp_lift1}
+                  , @{thm ccorres_tmp_lift1_global}
+                  , @{thm ccorres_tmp_lift2})
+
 val apply_ceqv_xpres_rules_trace = ref @{term True};
 
 fun apply_ceqv_xpres_rules1 ctxt rules _ n = DETERM
@@ -477,16 +487,16 @@ in
     rename_tac [#1 (Name.variant nm frees)] i thm
 end;
 
-fun corres_pre_lift_tac lift_thm trace depth ctxt xf =
+fun corres_pre_lift_tac lift_thms trace depth ctxt xf =
   prim_trace_tac' (#trace_this trace) depth ("PRE_LIFT_TAC " ^ xf) ctxt
-  let val base_xf = Long_Name.base_name xf;
+  let val (univ_thm, lift1_local_thm, lift1_global_thm, lift2_thm) = lift_thms
+      val base_xf = Long_Name.base_name xf;
       val var_name = (unsuffix "_'" base_xf handle Fail _ => "rv");
-      fun res_inst xf = Rule_Insts.res_inst_tac ctxt [((("xf'", 0), Position.none), xf)] []
-                                                (my_thm ctxt "ccorres_tmp_lift1");
-  in EVERY' [TRY o resolve_tac ctxt [my_thm ctxt "ccorres_introduce_UNIV_Int_when_needed"],
-             res_inst xf ORELSE' res_inst ("\<lambda>s. " ^ xf ^ " (globals s)"),
+      fun inst lift xf = Rule_Insts.res_inst_tac ctxt [((("xf'", 0), Position.none), xf)] [] lift;
+  in EVERY' [TRY o resolve_tac ctxt [univ_thm],
+             inst lift1_local_thm xf ORELSE' inst lift1_global_thm xf,
              rename_fresh_tac var_name,
-             resolve_tac ctxt [my_thm ctxt lift_thm],
+             resolve_tac ctxt [lift2_thm],
              corres_solve_ceqv ceqv_xpres_rules_new trace depth ctxt]
   end;
 
@@ -925,6 +935,14 @@ end;
 fun MY_REPEAT_ALL_NEW tac =
   tac THEN_ALL_NEW (fn i => MY_REPEAT_ALL_NEW tac i);
 
+fun corres_pre_lift_tacs ctxt lift_thms pre_tac post_tac trace depth xfs =
+    EVERY' (pre_tac :: rev (post_tac :: map (corres_pre_lift_tac lift_thms trace depth ctxt) xfs))
+
+fun corres_pre_lift_tac_cinit ctxt =
+    corres_pre_lift_tacs ctxt cinit_lift_thms
+                         (resolve_tac ctxt [@{thm ccorres_save_pre_start}])
+                         (REPEAT_ALL_NEW (resolve_tac ctxt @{thms ccorres_save_pre_finish}))
+
 fun corres_boilerplate_tac opts unfold_haskell_p xfs ctxt = let
     val ctxt = Context_Position.set_visible false ctxt
     val trace = #trace opts
@@ -988,7 +1006,7 @@ fun corres_boilerplate_tac opts unfold_haskell_p xfs ctxt = let
                          (* Simplify, using ccorres_rewrite *)
                          TRY' (fn _ => if #ccorres_rewrite opts then ccorres_rewrite_tac else all_tac),
                          (* Lift any variables *)
-                         EVERY' (map (corres_pre_lift_tac "ccorres_init_tmp_lift2" trace depth' ctxt) (rev xfs)),
+                         corres_pre_lift_tac_cinit ctxt trace depth' xfs,
                          (* Substitute any lifted variable equalities.  The option is the predicate to use on assumptions *)
                          substutite_asm_eqs ctxt (#subst_asms opts),
                          (* Remove local variable initialisers *)
@@ -1106,18 +1124,21 @@ in
       >> tac) |> shorten_names
 end;
 
+fun corres_pre_lift_tac_clift ctxt =
+    corres_pre_lift_tacs ctxt clift_thms (fn _ => all_tac) (fn _ => all_tac)
+
 fun corres_pre_abstract_args lift_fn =
     let
         fun tac (xfs : string list) (ctxt : Proof.context)
-          = Method.SIMPLE_METHOD' (EVERY' (map (lift_fn ctxt) (rev xfs)))
+          = Method.SIMPLE_METHOD' (lift_fn ctxt default_trace_opts 0 xfs)
     in
         (Args.context |-- Scan.lift (Scan.repeat1 Args.name) >> tac)
         |> shorten_names
     end;
 
 (* These differ only in the behaviour wrt the concrete guards --- the first abstracts the new variable, the second just drops it *)
-val corres_abstract_args = corres_pre_abstract_args (corres_pre_lift_tac "ccorres_tmp_lift2" default_trace_opts 0);
-val corres_abstract_init_args = corres_pre_abstract_args (corres_pre_lift_tac "ccorres_init_tmp_lift2" default_trace_opts 0);
+val corres_abstract_args = corres_pre_abstract_args corres_pre_lift_tac_clift;
+val corres_abstract_init_args = corres_pre_abstract_args corres_pre_lift_tac_cinit;
 
 fun corres_symb_rhs ceqv_xpres_rules = let
     fun tac upds ctxt = Method.SIMPLE_METHOD' (corres_symb_rhs_tac ceqv_xpres_rules (apply upds default_csymbr_opts) ctxt);

--- a/proof/crefine/lib/ctac-method.ML
+++ b/proof/crefine/lib/ctac-method.ML
@@ -261,7 +261,7 @@ fun nothrows (Const ("Language.com.Skip", _)) = true
   | nothrows (Const ("Language.com.Throw", _)) = false
   | nothrows (Const ("Language.com.Catch", _) $ a $ b) =
     nothrows a orelse nothrows b
-  | nothrows (Const ("Language.call", _) $ i $ f $ r $ (Abs (_, _, (Abs (_, _, c)))))
+  | nothrows (Const ("Language.call", _) $ _ $ _ $ _ $ (Abs (_, _, (Abs (_, _, c)))))
     = nothrows c
   | nothrows _ = false (* who knows *)
 
@@ -353,8 +353,29 @@ fun solve_ceqv_xpres_rewrite_basic ctxt n = DETERM
 
 fun solve_ceqv_xpres_basic_preserves ctxt n = DETERM
   ((resolve_tac ctxt [ceqv_xpres_basic_preserves_TrueI] n
-       THEN SOLVE' (safe_simp_tac ctxt) n)
+       THEN SOLVE' (clarsimp_tac ctxt) n)
      ORELSE resolve_tac ctxt [ceqv_xpres_basic_preserves_FalseI] n);
+
+fun ceqv_xpres_call_tac ctxt (t, n) = let
+    val t_concl = Envir.beta_eta_contract (Logic.strip_assums_concl t);
+    fun f_name () = case t_concl of
+        @{term Trueprop} $ (@{term_pat "ceqv_xpres_call _ _ _"} $ Const p $ _ $ _ $ _ $ _ $ _ $ _) => fst p
+      | _ => raise TERM ("unexpected conclusion", [t_concl]);
+    fun modifies_thm () = f_name ()
+        |> Long_Name.base_name
+        |> unsuffix Hoare.proc_deco
+        |> suffix "_modifies"
+        |> my_thm ctxt
+        |> Local_Defs.unfold ctxt @{thms mex_def meq_def};
+    fun ceqv_xpres_call_modifies () =
+        resolve_tac ctxt [modifies_thm ()] 1 @{thm ceq_xpres_call_hoarep} |> Seq.hd;
+    fun ceqv_xpres_call_default s =
+        (warning ("ceqv_xpres_call_tac: " ^ s); @{thm ceqv_xpres_call});
+    val ceqv_xpres_callI = ceqv_xpres_call_modifies ()
+        handle ERROR s => ceqv_xpres_call_default s
+        handle TERM (s, _) => ceqv_xpres_call_default s
+        handle Option => ceqv_xpres_call_default "ceqv_xpres_call_modifies";
+  in resolve_tac ctxt [ceqv_xpres_callI] n end;
 
 fun solve_ceqv_xpres_lvar ctxt n = DETERM
   ((resolve_tac ctxt [ceqv_xpres_lvar_nondet_init_TrueI] n
@@ -363,7 +384,7 @@ fun solve_ceqv_xpres_lvar ctxt n = DETERM
 
 fun abstract_upds ctxt t = let
     val sT = domain_type (fastype_of t)
-    fun inner (upd $ updf $ t) = upd :: inner t
+    fun inner (upd $ _ $ t) = upd :: inner t
       | inner (Bound 0) = []
       | inner t = raise TERM ("strip_upds", [t])
     val upds = inner (betapply (t, Bound 0)) |> List.rev
@@ -410,7 +431,8 @@ fun ceqv2_consts_and_tacs ctxt = map (apfst (fst o dest_Const)) [
   (@{term ceqv_xpres_basic_preserves}, solve_ceqv_xpres_basic_preserves),
   (@{term ceqv_xpres_lvar_nondet_init}, solve_ceqv_xpres_lvar),
   (@{term ceqv_xpres_eq_If}, K (resolve_tac ctxt ceqv_xpres_eq_If_rules)),
-  (@{term ceqv_xpres_call_restore_args}, ceqv_restore_args_tac)
+  (@{term ceqv_xpres_call_restore_args}, ceqv_restore_args_tac),
+  (@{term ceqv_xpres_call}, SUBGOAL o ceqv_xpres_call_tac)
 ];
 
 fun ceqv2_all_tacs ctxt = SUBGOAL (fn (t, n) =>
@@ -427,10 +449,8 @@ in
        THEN REPEAT_DETERM (ceqv2_all_tacs ctxt 1)) n
 end;
 
-fun corres_solve_ceqv (trace : trace_opts) (depth : int)
-      ctxt = ceqv2_tac ctxt;
-
-
+fun corres_solve_ceqv (_ (*trace*) : trace_opts) (_ (*depth*) : int) =
+    ceqv2_tac;
 
 fun rename_fresh_tac nm i thm = let
     (* FIXME: proper name context handling *)
@@ -439,27 +459,25 @@ in
     rename_tac [#1 (Name.variant nm frees)] i thm
 end;
 
-(* If we are updating globals, we just ignore the new variable *)
 fun corres_pre_lift_tac lift_thm trace depth ctxt xf =
   prim_trace_tac' (#trace_this trace) depth ("PRE_LIFT_TAC " ^ xf) ctxt
-  let
-    val base_xf = Long_Name.base_name xf
-    val var_name = (unsuffix "_'" base_xf handle Fail _ => "rv")
-in if base_xf = "globals"
-   then resolve_tac ctxt [my_thm ctxt "ccorres_special_trim_Int"]
-   else EVERY' [TRY o resolve_tac ctxt [my_thm ctxt "ccorres_introduce_UNIV_Int_when_needed"],
-                Rule_Insts.res_inst_tac ctxt [((("xf'", 0), Position.none), xf)] [] (my_thm ctxt "ccorres_tmp_lift1"),
-                rename_fresh_tac var_name,
-                resolve_tac ctxt [my_thm ctxt lift_thm],
-                corres_solve_ceqv trace depth ctxt]
-end;
+  let val base_xf = Long_Name.base_name xf;
+      val var_name = (unsuffix "_'" base_xf handle Fail _ => "rv");
+      fun res_inst xf = Rule_Insts.res_inst_tac ctxt [((("xf'", 0), Position.none), xf)] []
+                                                (my_thm ctxt "ccorres_tmp_lift1");
+  in EVERY' [TRY o resolve_tac ctxt [my_thm ctxt "ccorres_introduce_UNIV_Int_when_needed"],
+             res_inst xf ORELSE' res_inst ("\<lambda>s. " ^ xf ^ " (globals s)"),
+             rename_fresh_tac var_name,
+             resolve_tac ctxt [my_thm ctxt lift_thm],
+             corres_solve_ceqv trace depth ctxt]
+  end;
 
 val corres_lift_tac = corres_pre_lift_tac "ccorres_tmp_lift2";
 
 fun extract_lhs_xf (ct as (Const ("Language.com.Basic", _) $ _)) = extract_basic_xf ct
-  | extract_lhs_xf (Const ("Language.call", _) $ i $ f $ r $ (Abs (_, _, (Abs (_, _, c)))))
+  | extract_lhs_xf (Const ("Language.call", _) $ _ $ _ $ _ $ (Abs (_, _, (Abs (_, _, c)))))
     = extract_basic_xf c
-  | extract_lhs_xf t = (NONE, NONE) (* raise TERM ("extract_lhs_xf", [t]) *)
+  | extract_lhs_xf _ = (NONE, NONE) (* raise TERM ("extract_lhs_xf", [t]) *)
 
 fun Call_name (Const ("Language.com.Call", _) $ (Const (name, _))) = name
   | Call_name t = raise TERM ("Call_name", [t])
@@ -544,7 +562,7 @@ end;
 fun normalise_xf (o_xf, o_xfru) =
     case o_xf of
         NONE                     => (false, xfdc, NONE)
-      | SOME (xf_tp as (xf, tp)) => if (Long_Name.base_name xf) = "globals" then (false, xfdc, NONE) else (true, xf_tp, o_xfru)
+      | SOME (xf_tp as (xf, _)) => if (Long_Name.base_name xf) = "globals" then (false, xfdc, NONE) else (true, xf_tp, o_xfru)
 
 (* Options *)
 
@@ -692,7 +710,7 @@ fun corres_split_tac opts ctxt =
                 let
                     val trace          = #trace opts
                     val cc             = concl_dest_ccorres prem;
-                    val (lhs, rhs)     = extract_Seq (#conc cc)
+                    val (lhs, _)     = extract_Seq (#conc cc)
                     val vcg_suffix     = #vcg_suffix opts
                     val record_splits     = Proof_Context.get_thms ctxt ("ctac_splits_record" ^ vcg_suffix)
                     val call_splits       = Proof_Context.get_thms ctxt ("ctac_splits_call" ^ vcg_suffix)
@@ -784,7 +802,7 @@ end; (* handle TERM  e => no_tac
 fun corres_trim_lvar_nondet_init_tac trace depth ctxt known_guard = let
     val match_seq = Proof_Context.get_thms ctxt "match_ccorres_Seq";
 
-    fun tac (prem, i) = let
+    fun tac (_, i) = let
               val remove_lvar_init = Proof_Context.get_thm ctxt
                                                     (if known_guard
                                                      then "ccorres_lift_rhs_remove_lvar_init"
@@ -816,7 +834,7 @@ let
 
         (* xf and friends *)
         val cc         = concl_dest_ccorres prem;
-        val (lhs, rhs) = extract_Seq (#conc cc)
+        val (lhs, _) = extract_Seq (#conc cc)
         val (_, (xf, tp), o_xfru) = normalise_xf (extract_lhs_xf lhs)
 
         val xfN   = "xf'" (* _should_ be OK here *)
@@ -1112,9 +1130,9 @@ end;
 (* Debugging *)
 
 val corres_print_xf = let
-    fun tac (ctxt : Proof.context) (prem, i) = let
+    fun tac (_ : Proof.context) (prem, _) = let
         val cc         = concl_dest_ccorres prem;
-        val (lhs, rhs) = extract_Seq (#conc cc)
+        val (lhs, _) = extract_Seq (#conc cc)
         val (is_concr, (xf, _), o_xfru)  = normalise_xf (extract_lhs_xf lhs)
 
         fun b_to_s b = if b then "true" else "false"

--- a/proof/crefine/lib/ctac-method.ML
+++ b/proof/crefine/lib/ctac-method.ML
@@ -317,8 +317,7 @@ fun corres_solve_ceqv_old (trace : trace_opts) (depth : int) ctxt =
             SOLVE' (corres_ceqv_tac trace depth ctxt)]
 
 val ceqv_xpres_ceqvI = @{thm ceqv_xpres_ceqvD};
-val ceqv_xpres_rules_legacy = @{thms ceqv_xpres_rules_legacy};
-val ceqv_xpres_rules_new = @{thms ceqv_xpres_rules_new};
+val ceqv_xpres_rules = @{thms ceqv_xpres_rules};
 val ceqv_xpres_FalseI = @{thm ceqv_xpres_FalseI};
 val ceqv_xpres_rewrite_basic_left_cong = @{thm ceqv_xpres_rewrite_basic_left_cong};
 val ceqv_xpres_rewrite_basic_refl = @{thm ceqv_xpres_rewrite_basic_refl};
@@ -349,7 +348,7 @@ fun apply_ceqv_xpres_rules1 ctxt rules _ n = DETERM
              apply_ceqv_xpres_rules_trace := t;
              resolve_tac ctxt [ceqv_xpres_FalseI] n)) n));
 
-fun apply_ceqv_xpres_rules ceqv_xpres_rules ctxt = let
+fun apply_ceqv_xpres_rules ctxt = let
     val seq = ceqv_simpl_seq ctxt
     val ex_rules = if seq then [@{thm ceqv_xpres_While_simpl_sequence}]
         else []
@@ -451,8 +450,8 @@ fun xpres_abnormal_tac ctxt =
     resolve_tac ctxt @{thms xpres_abnormal_rules}
     ORELSE' resolve_tac ctxt @{thms xpres_abnormal_trivial}
 
-fun ceqv2_consts_and_tacs ceqv_xpres_rules ctxt = map (apfst (fst o dest_Const)) [
-  (@{term ceqv_xpres}, apply_ceqv_xpres_rules ceqv_xpres_rules ctxt),
+fun ceqv2_consts_and_tacs ctxt = map (apfst (fst o dest_Const)) [
+  (@{term ceqv_xpres}, apply_ceqv_xpres_rules ctxt),
   (@{term ceqv_xpres_rewrite_basic}, solve_ceqv_xpres_rewrite_basic),
   (@{term ceqv_xpres_rewrite_set}, K (resolve_tac ctxt ceqv_xpres_rewrite_set_rules)),
   (@{term ceqv_xpres_basic_preserves}, SUBGOAL o solve_ceqv_xpres_basic_preserves),
@@ -463,22 +462,21 @@ fun ceqv2_consts_and_tacs ceqv_xpres_rules ctxt = map (apfst (fst o dest_Const))
   (@{term xpres_abnormal}, K (xpres_abnormal_tac ctxt))
 ];
 
-fun ceqv2_all_tacs ceqv_xpres_rules ctxt = SUBGOAL (fn (t, n) =>
+fun ceqv2_all_tacs ctxt = SUBGOAL (fn (t, n) =>
   case head_of (HOLogic.dest_Trueprop (Logic.strip_assums_concl t)) of
-    Const (s, T) => (case (filter (fn v => fst v = s) (ceqv2_consts_and_tacs ceqv_xpres_rules ctxt)) of
+    Const (s, T) => (case (filter (fn v => fst v = s) (ceqv2_consts_and_tacs ctxt)) of
         (v :: _) => (snd v) ctxt n
       | [] => raise TERM ("ceqv2_all_tacs: unknown head const " ^ s, [Const (s, T), t]))
   | _ => raise TERM ("ceqv2_all_tacs: unknown form", [t]));
 
-fun ceqv2_tac ceqv_xpres_rules ctxt n = let
+fun ceqv2_tac ctxt n = let
 in
   resolve_tac ctxt [ceqv_xpres_ceqvI] n THEN
     SELECT_GOAL (REPEAT_DETERM (eresolve_tac ctxt [thin_rl] 1)
-       THEN REPEAT_DETERM (ceqv2_all_tacs ceqv_xpres_rules ctxt 1)) n
+       THEN REPEAT_DETERM (ceqv2_all_tacs ctxt 1)) n
 end;
 
-fun corres_solve_ceqv ceqv_xpres_rules (_ (*trace*) : trace_opts) (_ (*depth*) : int) =
-    ceqv2_tac ceqv_xpres_rules;
+fun corres_solve_ceqv (_ (*trace*) : trace_opts) (_ (*depth*) : int) = ceqv2_tac;
 
 fun rename_fresh_tac nm i thm = let
     (* FIXME: proper name context handling *)
@@ -497,7 +495,7 @@ fun corres_pre_lift_tac lift_thms trace depth ctxt xf =
              inst lift1_local_thm xf ORELSE' inst lift1_global_thm xf,
              rename_fresh_tac var_name,
              resolve_tac ctxt [lift2_thm],
-             corres_solve_ceqv ceqv_xpres_rules_new trace depth ctxt]
+             corres_solve_ceqv trace depth ctxt]
   end;
 
 fun extract_lhs_xf (ct as (Const ("Language.com.Basic", _) $ _)) = extract_basic_xf ct
@@ -540,22 +538,20 @@ end;
 
 val guard_is_UNIVI  = @{thms "guard_is_UNIVI"}
 
-fun ccorres_cleanup_rest (ceqv_xpres_rules : thm list)
-                         (trace : trace_opts)
+fun ccorres_cleanup_rest (trace : trace_opts)
                          (depth : int)
                          (ctxt : Proof.context)
                          (n : int) = let
     val match_ceqv      = Proof_Context.get_thms ctxt "match_ceqv"
     val my_clarsimp_tac = prim_trace_tac' (#trace_this trace) depth "my_clarsimp_tac" ctxt (SOLVE' (clarsimp_tac ctxt))
 in
-    (FIRST_COMMIT' [(resolve_tac ctxt match_ceqv, corres_solve_ceqv ceqv_xpres_rules trace depth ctxt),
+    (FIRST_COMMIT' [(resolve_tac ctxt match_ceqv, corres_solve_ceqv trace depth ctxt),
                     (resolve_tac ctxt guard_is_UNIVI, fn _ => all_tac), (* maybe we should try simp? *)
                     (fn _ => all_tac, my_clarsimp_tac)]) n
 end;
 
 
-fun ccorres_norename_cleanup (ceqv_xpres_rules : thm list)
-                             (trace : trace_opts)
+fun ccorres_norename_cleanup (trace : trace_opts)
                              (depth : int)
                              (ctxt : Proof.context)
                              (n : int) = let
@@ -563,10 +559,10 @@ fun ccorres_norename_cleanup (ceqv_xpres_rules : thm list)
 in
     prim_trace_tac (#trace_this trace) depth "CLEANUP (no rename)" ctxt
                    (resolve_tac ctxt match_cc n
-                    THEN_ELSE (all_tac, ccorres_cleanup_rest ceqv_xpres_rules trace (depth + 1) ctxt n))
+                    THEN_ELSE (all_tac, ccorres_cleanup_rest trace (depth + 1) ctxt n))
 end;
 
-fun ccorres_rename_cleanup ceqv_xpres_rules trace depth xf ctxt n = let
+fun ccorres_rename_cleanup trace depth xf ctxt n = let
     val match_cc  = Proof_Context.get_thms ctxt "match_ccorres"
 
     val base_xf   = Long_Name.base_name xf
@@ -575,7 +571,7 @@ in
     prim_trace_tac (#trace_this trace) depth "CLEANUP" ctxt
                    (resolve_tac ctxt match_cc n
                     THEN_ELSE (rename_fresh_tac var_name n,
-                               ccorres_cleanup_rest ceqv_xpres_rules trace (depth + 1) ctxt n))
+                               ccorres_cleanup_rest trace (depth + 1) ctxt n))
 end;
 
 fun abstract_record_xf_if_required trace depth ctxt xf o_xfr = let
@@ -585,7 +581,7 @@ in
     case o_xfr of
         SOME (_, true) => prim_trace_tac' (#trace_this trace) depth "ccorres_abstract" ctxt
                                           (Rule_Insts.res_inst_tac ctxt [((("xf'", 0), Position.none), xf)] [] abstract_thm
-                                           THEN_ALL_NEW ccorres_rename_cleanup ceqv_xpres_rules_new trace (depth + 1) xf ctxt)
+                                           THEN_ALL_NEW ccorres_rename_cleanup trace (depth + 1) xf ctxt)
       | _              => fn _ => all_tac
 end;
 
@@ -729,7 +725,7 @@ fun ccorres_doit (opts : ctac_opts)
         (* solve the remaining subgoals *)
         val resttac = (resolve_tac ctxt skips) (* Ignore any valids etc. *)
                           ORELSE'
-                          ccorres_rename_cleanup ceqv_xpres_rules_new trace depth' xf ctxt
+                          ccorres_rename_cleanup trace depth' xf ctxt
     in
         (abstract_record_xf_if_required trace depth ctxt xf o_xfru)
             THEN'
@@ -801,8 +797,7 @@ in
     map inst_type_vars thms
 end handle Bind => raise TACTIC ("Exception Bind in instantiate_xf_type: check order of assumptions to rhss lemmas in Corres_C and function corres_symb_rhs_tac");
 
-fun corres_symb_rhs_exec_tac (ceqv_xpres_rules : thm list)
-                             (trace : trace_opts)
+fun corres_symb_rhs_exec_tac (trace : trace_opts)
                              (depth : int)
                              (ctxt : Proof.context)
                              (lhs : term)
@@ -830,7 +825,7 @@ fun corres_symb_rhs_exec_tac (ceqv_xpres_rules : thm list)
 in
     prim_trace_tac' (#trace_this trace) depth ("CSYMBR (" ^ proc_name ^ ")") ctxt
                     (Rule_Insts.res_inst_tac ctxt insts [] rule
-                     THEN_ALL_NEW ccorres_rename_cleanup ceqv_xpres_rules trace depth' xf ctxt) n t
+                     THEN_ALL_NEW ccorres_rename_cleanup trace depth' xf ctxt) n t
 end; (* handle TERM  e => no_tac
             | ERROR e => no_tac *)
 
@@ -845,13 +840,13 @@ fun corres_trim_lvar_nondet_init_tac trace depth ctxt known_guard = let
     in
               prim_trace_tac' (#trace_this trace) depth "LVAR_INIT" ctxt
                                           (resolve_tac ctxt [remove_lvar_init]
-                                           THEN_ALL_NEW (ccorres_norename_cleanup ceqv_xpres_rules_new trace depth ctxt)) i
+                                           THEN_ALL_NEW (ccorres_norename_cleanup trace depth ctxt)) i
     end;
 in
     resolve_tac ctxt match_seq THEN' SUBGOAL tac
 end;
 
-fun corres_symb_rhs_tac ceqv_xpres_rules (opts : ceqv_opts) ctxt =
+fun corres_symb_rhs_tac (opts : ceqv_opts) ctxt =
 let
     val ctxt      = Context_Position.set_visible false ctxt
     val trace     = #trace opts
@@ -900,13 +895,13 @@ let
         val basic_tac =
             prim_trace_tac' (#trace_this trace) depth "CSYMBR (Basic)" ctxt
                             (Rule_Insts.res_inst_tac ctxt xf_inst [] basic_thm
-                             THEN_ALL_NEW (ccorres_norename_cleanup ceqv_xpres_rules trace depth' ctxt))
+                             THEN_ALL_NEW (ccorres_norename_cleanup trace depth' ctxt))
 
         val call_thms' = Proof_Context.get_thms ctxt ("ccorres_lift_rhss" ^ record_suffix)
         val call_thms = inst_tp call_thms'
         val _ = forall (fn (t, t') => Thm.concl_of t <> Thm.concl_of t') (call_thms ~~ call_thms')
             orelse raise THM ("corres_symb_rhs_tac: failed to inst_tp", 1, call_thms @ call_thms')
-        val call_tac  = EVERY' [corres_symb_rhs_exec_tac ceqv_xpres_rules trace depth ctxt lhs (xf_inst @ xfr_inst) call_thms new_xf_name,
+        val call_tac  = EVERY' [corres_symb_rhs_exec_tac trace depth ctxt lhs (xf_inst @ xfr_inst) call_thms new_xf_name,
                                 (* Yes, simp should ignore assumptions -- this simplifies away the state dep. on i *)
                                     TRY' (simp_tac ss),
                                 TRY' (resolve_tac ctxt gen_asm)]
@@ -963,7 +958,7 @@ fun corres_boilerplate_tac opts unfold_haskell_p xfs ctxt = let
 
         val ccorres_trim_redundant_throw = Proof_Context.get_thms ctxt "ccorres_trim_redundant_throw"
         val trim_redundant_throw_tac = resolve_tac ctxt ccorres_trim_redundant_throw
-                                       THEN_ALL_NEW ccorres_norename_cleanup ceqv_xpres_rules_new trace depth' ctxt
+                                       THEN_ALL_NEW ccorres_norename_cleanup trace depth' ctxt
 
         val ccorres_trim_DontReach = Proof_Context.get_thms ctxt "ccorres_special_trim_guard_DontReach_pis"
         val pis_thms = Proof_Context.get_thms ctxt "push_in_stmt_rules"
@@ -1140,8 +1135,8 @@ fun corres_pre_abstract_args lift_fn =
 val corres_abstract_args = corres_pre_abstract_args corres_pre_lift_tac_clift;
 val corres_abstract_init_args = corres_pre_abstract_args corres_pre_lift_tac_cinit;
 
-fun corres_symb_rhs ceqv_xpres_rules = let
-    fun tac upds ctxt = Method.SIMPLE_METHOD' (corres_symb_rhs_tac ceqv_xpres_rules (apply upds default_csymbr_opts) ctxt);
+val corres_symb_rhs = let
+    fun tac upds ctxt = Method.SIMPLE_METHOD' (corres_symb_rhs_tac (apply upds default_csymbr_opts) ctxt);
 
     val option_args = Args.parens (P.list (Scan.first csymbr_options))
     val opt_option_args = Scan.lift (Scan.optional option_args [])
@@ -1150,11 +1145,8 @@ in
     |> shorten_names
 end;
 
-val corres_symb_rhs_legacy = corres_symb_rhs ceqv_xpres_rules_legacy
-val corres_symb_rhs_new = corres_symb_rhs ceqv_xpres_rules_new
-
 val corres_ceqv = let
-    fun tac upds ctxt = Method.SIMPLE_METHOD' (corres_solve_ceqv ceqv_xpres_rules_new (#trace (apply upds default_ceqv_opts)) 0 ctxt);
+    fun tac upds ctxt = Method.SIMPLE_METHOD' (corres_solve_ceqv (#trace (apply upds default_ceqv_opts)) 0 ctxt);
 
     val option_args = Args.parens (P.list (Scan.first ceqv_options))
     val opt_option_args = Scan.lift (Scan.optional option_args [])


### PR DESCRIPTION
This contains proof and tool updates for the C patch:
https://bitbucket.ts.data61.csiro.au/projects/SEL4/repos/sel4/pull-requests/1751/overview
(Also https://github.com/mbrcknl/seL4/tree/mbrcknl/no-large-structs-by-value)

The main purpose of that patch is to avoid passing structs by value when those structs are larger than the calling convention allows passing by registers. The allows us to avoid part of the RISC-V calling convention in binary verification.

This has previously appeared as the Data61-internal PR:
https://bitbucket.ts.data61.csiro.au/projects/SEL4/repos/l4v/pull-requests/810/overview

While I had intended to improve documentation of the tool improvements, that hasn't happened yet. If reviewers are agreeable, I'd like to merge this as is now, so I can also merge the C patch, and then hope that I can find some time for documentation in the future.