### PR TITLE
Fixes to sendIPC (fresh PR)

### DIFF
--- a/lib/Heap_List.thy
+++ b/lib/Heap_List.thy
@@ -148,20 +148,21 @@ lemma heap_ls_last_None:
 
 (* sym_heap *)
 
-abbreviation sym_heap where
+definition sym_heap where
   "sym_heap hp hp' \<equiv> \<forall>p p'. hp p = Some p' \<longleftrightarrow> hp' p' = Some p"
 
 lemma sym_heap_symmetric:
-  "sym_heap hp hp' \<longleftrightarrow> sym_heap hp' hp" by blast
+  "sym_heap hp hp' \<longleftrightarrow> sym_heap hp' hp"
+  unfolding sym_heap_def by blast
 
 lemma sym_heap_None:
-  "\<lbrakk>sym_heap hp hp'; hp p = None\<rbrakk> \<Longrightarrow> \<forall>p'. hp' p' \<noteq> Some p" by force
+  "\<lbrakk>sym_heap hp hp'; hp p = None\<rbrakk> \<Longrightarrow> \<forall>p'. hp' p' \<noteq> Some p" unfolding sym_heap_def by force
 
 lemma sym_heap_path_reverse:
   "sym_heap hp hp' \<Longrightarrow>
       heap_path hp (Some p) (p#ps) (Some p')
           \<longleftrightarrow> heap_path hp' (Some p') (p'#(rev ps)) (Some p)"
-  by (induct ps arbitrary: p p' rule: rev_induct; force)
+  unfolding sym_heap_def by (induct ps arbitrary: p p' rule: rev_induct; force)
 
 lemma sym_heap_ls_rev_Cons:
   "\<lbrakk>sym_heap hp hp'; heap_ls hp (Some p) (p#ps)\<rbrakk>
@@ -229,13 +230,13 @@ lemma heap_path_distinct_sym_prev_cases:
   apply (cases xs; simp del: heap_path.simps)
   apply (frule heap_path_head, simp)
   apply (cases ed, clarsimp)
-   apply (drule sym_heap_ls_rev_Cons, fastforce)
-   apply (drule heap_path_distinct_next_cases[where hp=hp']; simp)
-   apply fastforce
+   apply (frule sym_heap_ls_rev_Cons, fastforce)
+   apply (drule heap_path_distinct_next_cases[where hp=hp']; simp add: sym_heap_def)
+   apply simp
   apply (simp del: heap_path.simps)
-  apply (drule (1) sym_heap_path_reverse[where hp'=hp', THEN iffD1])
+  apply (frule (1) sym_heap_path_reverse[where hp'=hp', THEN iffD1])
   apply simp
-  apply (frule heap_path_distinct_next_cases[where hp=hp']; simp)
+  apply (frule heap_path_distinct_next_cases[where hp=hp']; simp add: sym_heap_def)
   apply fastforce
   done
 

--- a/proof/invariant-abstract/IpcDet_AI.thy
+++ b/proof/invariant-abstract/IpcDet_AI.thy
@@ -1987,16 +1987,15 @@ lemma si_invs'_helper_fault:
         sym_refs (state_hyp_refs_of s)\<rbrace>
     do
       recv_state <- get_thread_state dest;
-      (reply, reply_can_grant) <- case recv_state of
-                                    BlockedOnReceive _ reply data \<Rightarrow>
-                                      return (reply, receiver_can_grant data)
+      reply <- case recv_state of BlockedOnReceive _ reply data \<Rightarrow>
+                                      return reply
                                   | _ \<Rightarrow> fail;
       y <- do_ipc_transfer tptr (Some epptr) ba cg dest;
       y <- maybeM (reply_unlink_tcb dest) reply;
       sc_opt <- get_tcb_obj_ref tcb_sched_context dest;
       fault <- thread_get tcb_fault tptr;
       y <- if call \<or> (\<exists>y. fault = Some y)
-           then if (cg \<or> reply_can_grant) \<and> (\<exists>y. reply = Some y)
+           then if (cg \<or> cgr) \<and> (\<exists>y. reply = Some y)
                 then reply_push tptr dest (the reply) can_donate
                 else set_thread_state tptr Inactive
            else when (can_donate \<and> sc_opt = None) (do thread_sc <- get_tcb_obj_ref tcb_sched_context tptr;
@@ -2103,16 +2102,16 @@ lemma si_invs'_helper:
         sym_refs (state_hyp_refs_of s)\<rbrace>
     do
       recv_state <- get_thread_state dest;
-      (reply, reply_can_grant) <- case recv_state of
+      reply <- case recv_state of
                                     BlockedOnReceive _ reply data \<Rightarrow>
-                                      return (reply, receiver_can_grant data)
+                                      return reply
                                   | _ \<Rightarrow> fail;
       y <- do_ipc_transfer tptr (Some epptr) ba cg dest;
       y <- maybeM (reply_unlink_tcb dest) reply;
       sc_opt <- get_tcb_obj_ref tcb_sched_context dest;
       fault <- thread_get tcb_fault tptr;
       y <- if call \<or> (\<exists>y. fault = Some y)
-           then if (cg \<or> reply_can_grant) \<and> (\<exists>y. reply = Some y)
+           then if (cg \<or> cgr) \<and> (\<exists>y. reply = Some y)
                 then reply_push tptr dest (the reply) can_donate
                 else set_thread_state tptr Inactive
            else when (can_donate \<and> sc_opt = None) (do thread_sc <- get_tcb_obj_ref tcb_sched_context tptr;

--- a/proof/refine/ARM/ArchAcc_R.thy
+++ b/proof/refine/ARM/ArchAcc_R.thy
@@ -356,7 +356,7 @@ lemma aligned_distinct_relation_asid_pool_atI'[elim]:
   apply (clarsimp simp: other_obj_relation_def)
   apply (simp split: Structures_H.kernel_object.split_asm
                      arch_kernel_object.split_asm)
-  apply (drule(2) aligned'_distinct'_obj_at'I[where 'a=asidpool], simp)
+  apply (drule(2) aligned'_distinct'_ko_at'I[where 'a=asidpool], simp)
   apply (clarsimp simp: obj_at'_def typ_at'_def ko_wp_at'_def
                         projectKOs)
   done
@@ -436,7 +436,7 @@ lemma get_pde_corres [corres]:
   done
 
 lemmas aligned_distinct_pde_atI'
-    = aligned'_distinct'_obj_at'I[where 'a=pde,
+    = aligned'_distinct'_ko_at'I[where 'a=pde,
                                 simplified, OF _ _ _ refl]
 
 lemma aligned_distinct_relation_pde_atI'[elim]:
@@ -682,7 +682,7 @@ lemma pte_relation_alignedD:
   done
 
 lemmas aligned_distinct_pte_atI'
-    = aligned'_distinct'_obj_at'I[where 'a=pte,
+    = aligned'_distinct'_ko_at'I[where 'a=pte,
                                 simplified, OF _ _ _ refl]
 
 lemma aligned_distinct_relation_pte_atI'[elim]:

--- a/proof/refine/ARM/Bits_R.thy
+++ b/proof/refine/ARM/Bits_R.thy
@@ -110,6 +110,10 @@ lemma sc_of'_Sched[simp]:
   "sc_of' (KOSchedContext sc) = Some sc"
   by (simp add: projectKO_sc)
 
+lemma tcb_of'_TCB[simp]:
+  "tcb_of' (KOTCB tcb) = Some tcb"
+  by (simp add: projectKO_tcb)
+
 lemma projectKO_ASID:
   "(projectKO_opt ko = Some t) = (ko = KOArch (KOASIDPool t))"
   by (cases ko)

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -218,7 +218,7 @@ lemma pspace_relation_cte_wp_at:
    apply (simp add: unpleasant_helper)
    apply (drule spec, drule mp, erule domI)
    apply (clarsimp simp: cte_relation_def)
-   apply (drule(2) aligned'_distinct'_obj_at'I[where 'a=cte])
+   apply (drule(2) aligned'_distinct'_ko_at'I[where 'a=cte])
     apply simp
    apply (drule ko_at_imp_cte_wp_at')
    apply (clarsimp elim!: cte_wp_at_weakenE')
@@ -226,7 +226,7 @@ lemma pspace_relation_cte_wp_at:
   apply (drule(1) pspace_relation_absD)
   apply (clarsimp simp: other_obj_relation_def)
   apply (simp split: kernel_object.split_asm)
-  apply (drule(2) aligned'_distinct'_obj_at'I[where 'a=tcb])
+  apply (drule(2) aligned'_distinct'_ko_at'I[where 'a=tcb])
    apply simp
   apply (drule tcb_cases_related)
   apply (clarsimp simp: obj_at'_def projectKOs objBits_simps)

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -1828,7 +1828,7 @@ lemma setObject_cte_scs_of'_use_valid_ksPSpace:
   assumes step: "(x, s\<lparr>ksPSpace := ps\<rparr>) \<in> fst (setObject p (cte :: cte) s)"
       and pre: "P (scs_of' s)"
   shows "P (ps |> sc_of')"
-  using use_valid[OF step setObject_cte_scs_of'] pre
+  using use_valid[OF step setObject_scs_of'(1)] pre
   by auto
 
 lemma updateCap_stuff:

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -4796,7 +4796,6 @@ lemma createTCBs_tcb_at':
     apply simp
    apply simp
   apply (clarsimp simp: retype_obj_at_disj')
-  apply (clarsimp simp: projectKO_opt_tcb)
   apply (clarsimp simp: new_cap_addrs_def image_def)
   apply (drule_tac x = "unat x" in bspec)
    apply (simp add:objBits_simps' shiftl_t2n)

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3901,11 +3901,12 @@ lemma schedContextUnbindReply_invs'[wp]:
   unfolding schedContextUnbindReply_def
   apply (wpsimp wp: setSchedContext_invs' updateReply_replyNext_Nothing_invs'
                     hoare_vcg_imp_lift typ_at_lifts)
-  apply (frule ko_at_valid_objs'; (fastforce simp: projectKOs)?)
+  apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def sym_refs_asrt_def)
+  apply (frule (1) ko_at_valid_objs', clarsimp simp: projectKOs)
+  apply (frule (2) sym_refs_scReplies)
   apply (intro conjI)
-     apply (subst sym_refs_replySCs_of_scReplies_of; (fastforce simp: sym_refs_asrt_def)?)
-     apply (fastforce simp: obj_at'_def opt_map_def projectKOs split: option.splits)
-    apply (fastforce elim: if_live_then_nonz_capE'[OF invs_iflive']
+     apply (fastforce simp: obj_at'_def opt_map_def projectKOs sym_heap_def split: option.splits)
+    apply (fastforce elim: if_live_then_nonz_capE'
                      simp: ko_wp_at'_def obj_at'_def projectKOs live_sc'_def)
    apply (auto simp: valid_obj'_def valid_sched_context'_def valid_sched_context_size'_def
                      objBits_simps')

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3717,7 +3717,6 @@ lemma schedContextDonate_valid_inQ_queues:
    \<lbrace>\<lambda>_. valid_inQ_queues\<rbrace>"
   (is "valid ?pre _ _")
   apply (clarsimp simp: schedContextDonate_def)
-  apply (rule hoare_seq_ext[OF _ stateAssert_sp])
   apply (rule hoare_seq_ext[OF _ get_sc_sp'], rename_tac sc)
   apply (rule_tac B="\<lambda>_. ?pre" in hoare_seq_ext[rotated])
    apply (rule hoare_when_cases, clarsimp)

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -260,6 +260,33 @@ abbreviation tcbs_of' :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> tcb o
 abbreviation tcb_scs_of' :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> obj_ref option" where
   "tcb_scs_of' s \<equiv> tcbs_of' s |> tcbSchedContext"
 
+abbreviation scTCBs_of :: "kernel_state \<Rightarrow> obj_ref \<Rightarrow> obj_ref option" where
+  "scTCBs_of s \<equiv> scs_of' s |> scTCB"
+
+(* 
+  sym_heapd is a definition version of sym_heap (abbreviation).
+  This is temporary for now, it should be combined with sym_heap properly,
+  either within the current PR, or later.
+*)
+
+definition sym_heapd :: "('a \<rightharpoonup> 'b) \<Rightarrow> ('b \<rightharpoonup> 'a) \<Rightarrow> bool" where
+  "sym_heapd h1 h2 \<equiv> \<forall>p q. pred_map_eq q h1 p \<longleftrightarrow> pred_map_eq p h2 q"
+
+lemma sym_heapd_def2:
+  "sym_heapd h1 h2 = 
+  ((\<forall>p q. pred_map_eq q h1 p \<longrightarrow> pred_map_eq p h2 q) \<and> (\<forall>p q. pred_map_eq q h2 p \<longrightarrow> pred_map_eq p h1 q))"
+  unfolding sym_heapd_def by fastforce
+
+lemma sym_heapd_sym:
+  "sym_heapd h1 h2 = sym_heapd h2 h1"
+  unfolding sym_heapd_def by fastforce
+
+abbreviation tcbs_scs_sym_refs where
+  "tcbs_scs_sym_refs s \<equiv> sym_heapd (tcb_scs_of' s) (scTCBs_of s)"
+
+abbreviation replies_scs_sym_refs where
+  "replies_scs_sym_refs s \<equiv> sym_heapd (scReplies_of s) (replySCs_of s)"
+
 definition
   tcb_cte_cases :: "word32 \<rightharpoonup> ((tcb \<Rightarrow> cte) \<times> ((cte \<Rightarrow> cte) \<Rightarrow> tcb \<Rightarrow> tcb))" where
  "tcb_cte_cases \<equiv> [    0 \<mapsto> (tcbCTable, tcbCTable_update),

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -754,8 +754,8 @@ lemma replyRemoveTCB_corres:
               apply (drule sc_with_reply'_SomeD, clarsimp)
               apply (case_tac "hd xs = rp")
                apply (drule heap_path_head, clarsimp)
-               apply (drule (3) sym_refs_replySCs_of_scReplies_of[THEN iffD2, rotated])
-               apply (clarsimp simp: obj_at'_def projectKOs)
+               apply (drule (2) sym_refs_scReplies)
+               apply (clarsimp simp: obj_at'_def projectKOs sym_heap_def)
 
               apply (frule (1) heap_path_takeWhile_lookup_next)
               apply (frule heap_path_head, clarsimp)
@@ -861,9 +861,9 @@ lemma replyRemoveTCB_corres:
                                             objBits_simps)
                      apply (erule sym_refs_replyNext_replyPrev_sym[THEN iffD2])
                      apply (clarsimp simp: opt_map_left_Some obj_at'_def projectKOs)
-                    apply (frule (2) sym_refs_replySCs_of_scReplies_of[THEN iffD2])
-                      apply (fastforce simp: hd_opt_def projectKOs opt_map_left_Some
-                                        del: opt_mapE split: list.split_asm)
+                    apply (frule (2) sym_refs_scReplies)
+                    apply (clarsimp simp: hd_opt_def projectKOs opt_map_left_Some sym_heap_def
+                                   split: list.split_asm)
                     apply (clarsimp simp: opt_map_left_Some obj_at'_def projectKOs split: reply_next.splits)
 
                   (* rp is in the middle of the reply stack *)

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -2058,7 +2058,7 @@ lemma replyPush_corres:
    corres dc (invs and tcb_at caller and tcb_at callee and reply_at reply_ptr
               and ex_nonz_cap_to reply_ptr
               and st_tcb_at active caller
-              and reply_sc_reply_at (\<lambda>tptr. tptr = None) reply_ptr
+              and reply_sc_reply_at (\<lambda>scp. scp = None) reply_ptr
               and reply_tcb_reply_at (\<lambda>tptr. tptr = None) reply_ptr
               and weak_valid_sched_action and scheduler_act_not caller)
              (valid_release_queue_iff and valid_objs' and valid_queues and valid_queues')
@@ -4579,15 +4579,15 @@ lemma updateReply_reply_at'_wp:
   done
 
 crunches setThreadState
-  for tcb_scs_of'[wp]: "\<lambda>s. P (tcb_scs_of' s)"
-  (ignore: threadSet wp: threadSet_tcb_scs_of'_inv)
+  for tcbSCs_of[wp]: "\<lambda>s. P (tcbSCs_of s)"
+  (ignore: threadSet wp: threadSet_tcbSCs_of_inv)
 
 crunches replyUnlink
-  for tcb_scs_of'[wp]: "\<lambda>s. P (tcb_scs_of' s)"
+  for tcbSCs_of[wp]: "\<lambda>s. P (tcbSCs_of s)"
   and scs_of'[wp]: "\<lambda>s. P (scs_of' s)"
 
 lemma replyUnlink_misc_heaps[wp]:
-  "replyUnlink rPtr tPtr \<lbrace>\<lambda>s. P (tcb_scs_of' s) (scTCBs_of s) (scReplies_of s) (replySCs_of s)\<rbrace>"
+  "replyUnlink rPtr tPtr \<lbrace>\<lambda>s. P (tcbSCs_of s) (scTCBs_of s) (scReplies_of s) (replySCs_of s)\<rbrace>"
   by (rule hoare_weaken_pre, wps, wp, simp)
 
 lemma schedContextUpdateConsumed_scReplies_of[wp]:
@@ -4609,7 +4609,7 @@ lemma schedContextUpdateConsumed_sc_tcbs_of[wp]:
   done
 
 crunches schedContextUpdateConsumed
-  for tcb_scs_of'[wp]: "\<lambda>s. P (tcb_scs_of' s)"
+  for tcbSCs_of[wp]: "\<lambda>s. P (tcbSCs_of s)"
 
 crunches doIPCTransfer
   for replySCs_of[wp]: "\<lambda>s. P (replySCs_of s)"
@@ -4617,7 +4617,7 @@ crunches doIPCTransfer
 
 lemma schedContextUpdateConsumed_misc_heaps[wp]:
   "schedContextUpdateConsumed scPtr
-   \<lbrace>\<lambda>s. P (scReplies_of s) (replySCs_of s) (tcb_scs_of' s) (scTCBs_of s)\<rbrace>"
+   \<lbrace>\<lambda>s. P (scReplies_of s) (replySCs_of s) (tcbSCs_of s) (scTCBs_of s)\<rbrace>"
   by (rule hoare_weaken_pre, wps, wp, simp)
 
 crunches doIPCTransfer
@@ -4625,24 +4625,24 @@ crunches doIPCTransfer
   (wp: crunch_wps ignore: setSchedContext simp: zipWithM_x_mapM)
 
 crunches doIPCTransfer
-  for scs_tcbs_of[wp]: "\<lambda>s. P (tcb_scs_of' s) (scTCBs_of s)"
-  (wp: crunch_wps threadSet_tcb_scs_of'_inv ignore: threadSet simp: zipWithM_x_mapM)
+  for scs_tcbs_of[wp]: "\<lambda>s. P (tcbSCs_of s) (scTCBs_of s)"
+  (wp: crunch_wps threadSet_tcbSCs_of_inv ignore: threadSet simp: zipWithM_x_mapM)
 
 crunches setEndpoint
-  for misc_heaps[wp]: "\<lambda>s. P (scReplies_of s) (replySCs_of s) (tcb_scs_of' s) (scTCBs_of s)"
+  for misc_heaps[wp]: "\<lambda>s. P (scReplies_of s) (replySCs_of s) (tcbSCs_of s) (scTCBs_of s)"
   (wp: crunch_wps)
 
 lemma replyPush_sym_refs_list_refs_of_replies':
   "\<lbrace>(\<lambda>s. sym_refs (list_refs_of_replies' s))
     and valid_replies'
     and valid_objs'
-    and (\<lambda>s. replyTCBs_of s replyPtr = None) and replies_scs_sym_refs\<rbrace>
+    and (\<lambda>s. replyTCBs_of s replyPtr = None) and sym_heap_scReplies\<rbrace>
    replyPush callerPtr calleePtr replyPtr canDonate
    \<lbrace>\<lambda>_ s. sym_refs (list_refs_of_replies' s)\<rbrace>"
   supply if_split [split del]
   unfolding replyPush_def
   apply wpsimp
-        apply (wpsimp wp: bindScReply_sym_refs_list_refs_of_replies'
+        apply (wpsimp wp: bindsym_heap_scReplies_list_refs_of_replies'
                           hoare_vcg_if_lift2 hoare_vcg_imp_lift' hoare_vcg_all_lift)
        apply (rule_tac Q="(\<lambda>_ s. sym_refs (list_refs_of_replies' s) \<and>
         (\<forall>rptr scp. (scReplies_of s) scp = Some rptr
@@ -4657,13 +4657,13 @@ lemma replyPush_sym_refs_list_refs_of_replies':
   apply (intro conjI)
     apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
    apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
-  apply (clarsimp simp: sym_heapd_def pred_map_eq)
+  apply (clarsimp simp: sym_heap_def pred_map_eq)
   done
 
 lemma replyPush_if_live_then_nonz_cap':
   "\<lbrace> if_live_then_nonz_cap' and valid_objs' and valid_idle' and
      ex_nonz_cap_to' replyPtr and ex_nonz_cap_to' callerPtr and ex_nonz_cap_to' calleePtr and
-     tcbs_scs_sym_refs and replies_scs_sym_refs and (\<lambda>s. callerPtr \<noteq> ksIdleThread s)\<rbrace>
+     sym_heap_tcbSCs and sym_heap_scReplies and (\<lambda>s. callerPtr \<noteq> ksIdleThread s)\<rbrace>
    replyPush callerPtr calleePtr replyPtr canDonate
    \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
   supply if_split [split del]
@@ -4694,13 +4694,13 @@ lemma replyPush_if_live_then_nonz_cap':
    apply (intro conjI)
     apply (erule if_live_then_nonz_capE')
     apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKO_sc pred_map_def pred_map_eq_def live_sc'_def)
-    apply (clarsimp simp: sym_heapd_def pred_map_eq)
+    apply (clarsimp simp: sym_heap_def)
   apply (intro conjI)
     apply (frule obj_at_ko_at'[where p=callerPtr], clarsimp)
     apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
     apply (clarsimp simp: valid_tcb'_def)
-   apply (subgoal_tac "(tcb_scs_of' s) callerPtr = Some scp")
-    apply (clarsimp simp: sym_heapd_def pred_map_eq)
+   apply (subgoal_tac "(tcbSCs_of s) callerPtr = Some scp")
+    apply (clarsimp simp: sym_heap_def)
    apply (clarsimp simp: opt_map_def obj_at'_real_def ko_wp_at'_def projectKOs)
   apply (clarsimp simp: valid_idle'_def)
   done
@@ -4716,7 +4716,7 @@ lemma replyPush_valid_idle':
   "\<lbrace>valid_idle'
     and valid_pspace'
     and (\<lambda>s. callerPtr \<noteq> ksIdleThread s)
-    and tcbs_scs_sym_refs\<rbrace>
+    and sym_heap_tcbSCs\<rbrace>
    replyPush callerPtr calleePtr replyPtr canDonate
    \<lbrace>\<lambda>_. valid_idle'\<rbrace>"
   apply (simp only: replyPush_def)
@@ -4774,7 +4774,7 @@ lemma replyPush_sch_act_wf:
   by (wpsimp wp: sts_sch_act' hoare_vcg_all_lift hoare_vcg_if_lift hoare_drop_imps)
 
 lemma replyPush_invs':
-  "\<lbrace>invs' and tcbs_scs_sym_refs and replies_scs_sym_refs and
+  "\<lbrace>invs' and sym_heap_tcbSCs and sym_heap_scReplies and
     sch_act_not callerPtr and ex_nonz_cap_to' callerPtr and ex_nonz_cap_to' calleePtr and
     ex_nonz_cap_to' replyPtr and (\<lambda>s. replyTCBs_of s replyPtr = None)\<rbrace>
    replyPush callerPtr calleePtr replyPtr canDonate
@@ -4873,32 +4873,30 @@ lemma cancelIPC_notin_epQueue:
   by (wpsimp wp: blockedCancelIPC_notin_epQueue hoare_drop_imps threadSet_valid_objs')
 
 crunches rescheduleRequired
-  for scs_tcbs_of[wp]: "\<lambda>s. P (tcb_scs_of' s) (scTCBs_of s)"
-  (wp: crunch_wps threadSet_tcb_scs_of'_inv ignore: threadSet)
+  for scs_tcbs_of[wp]: "\<lambda>s. P (tcbSCs_of s) (scTCBs_of s)"
+  (wp: crunch_wps threadSet_tcbSCs_of_inv ignore: threadSet)
 
-lemma maybeReturnSc_tcbs_scs_sym_refs[wp]:
-  "\<lbrace>tcbs_scs_sym_refs and valid_objs'\<rbrace>
+lemma maybeReturnSc_sym_heap_tcbSCs[wp]:
+  "\<lbrace>sym_heap_tcbSCs and valid_objs'\<rbrace>
    maybeReturnSc y t
-   \<lbrace>\<lambda>_. tcbs_scs_sym_refs\<rbrace>"
+   \<lbrace>\<lambda>_. sym_heap_tcbSCs\<rbrace>"
+  supply opt_mapE [rule del]
   unfolding maybeReturnSc_def
   apply (simp add: liftM_def)
   apply (rule hoare_seq_ext[OF _ stateAssert_sp])
   apply (rule hoare_seq_ext[OF _ get_ntfn_sp'])
-  apply (wpsimp wp: setSchedContext_scTCBs_of threadSet_tcb_scs_of' | wps)+
+  apply (wpsimp wp: setSchedContext_scTCBs_of threadSet_tcbSCs_of | wps)+
    apply (wpsimp wp: threadGet_wp)
   apply (clarsimp simp: tcb_at'_ex_eq_all)
   apply (drule sym, simp)
-  apply (subgoal_tac "pred_map_eq (the (tcbSchedContext tcb)) (tcb_scs_of' s) t")
-   apply (clarsimp simp: sym_heapd_def pred_map_eq_upd)
-   apply (intro conjI; clarsimp)
-    using pred_map_eq_inj apply metis
-   using pred_map_eq_inj apply metis
-  apply (clarsimp simp: pred_map_eq_def pred_map_def obj_at'_real_def ko_wp_at'_def opt_map_def
-                        projectKOs)
+  apply (subgoal_tac "(tcbSCs_of s) t = Some (the (tcbSchedContext tcb))")
+   apply (clarsimp simp: sym_heap_def)
+   apply (subst (asm) sym_heap_symmetric[simplified sym_heap_def], simp)
+  apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def opt_map_def projectKOs)
   done
 
-lemma maybeReturnSc_replies_scs_sym_refs[wp]:
-  "maybeReturnSc y t \<lbrace>replies_scs_sym_refs\<rbrace>"
+lemma maybeReturnSc_sym_heap_scReplies[wp]:
+  "maybeReturnSc y t \<lbrace>sym_heap_scReplies\<rbrace>"
   unfolding maybeReturnSc_def
   apply (simp add: liftM_def)
   apply (rule hoare_seq_ext[OF _ stateAssert_sp])
@@ -4908,14 +4906,14 @@ lemma maybeReturnSc_replies_scs_sym_refs[wp]:
   apply (clarsimp simp: tcb_at'_ex_eq_all)
   apply (drule sym, simp)
   apply (erule back_subst)
-  apply (rule arg_cong2[where f=sym_heapd, OF _ refl], rule ext)
+  apply (rule arg_cong2[where f=sym_heap, OF _ refl], rule ext)
   apply (clarsimp simp: pred_map_eq_def pred_map_def obj_at'_real_def ko_wp_at'_def opt_map_def
                         projectKOs)
   done
 
 crunches cleanReply
   for scTCBs_of[wp]: "\<lambda>s. P (scTCBs_of s)"
-  and tcb_scs_of'[wp]: "\<lambda>s. P (tcb_scs_of' s)"
+  and tcbSCs_of[wp]: "\<lambda>s. P (tcbSCs_of s)"
 
 lemma replyRemoveTCB_scTCBs_of[wp]:
   "replyRemoveTCB tptr \<lbrace>\<lambda>s. P (scTCBs_of s)\<rbrace>"
@@ -4924,48 +4922,48 @@ lemma replyRemoveTCB_scTCBs_of[wp]:
   apply (erule back_subst[where P=P], rule ext, clarsimp)
   by (clarsimp simp: opt_map_def obj_at'_real_def ko_wp_at'_def)
 
-lemma replyRemoveTCB_tcb_scs_of'[wp]:
-  "replyRemoveTCB tptr \<lbrace>\<lambda>s. P (tcb_scs_of' s)\<rbrace>"
+lemma replyRemoveTCB_tcbSCs_of[wp]:
+  "replyRemoveTCB tptr \<lbrace>\<lambda>s. P (tcbSCs_of s)\<rbrace>"
   unfolding replyRemoveTCB_def
   by (wpsimp wp: setSchedContext_scTCBs_of gts_wp')
 
-lemma replyRemoveTCB_tcbs_scs_sym_refs[wp]:
-  "replyRemoveTCB tptr \<lbrace>tcbs_scs_sym_refs\<rbrace>"
+lemma replyRemoveTCB_sym_heap_tcbSCs[wp]:
+  "replyRemoveTCB tptr \<lbrace>sym_heap_tcbSCs\<rbrace>"
   by (rule hoare_weaken_pre, wps, wpsimp, simp)
 
 crunches cancelIPC
-  for tcbs_scs_sym_refs[wp]: tcbs_scs_sym_refs
-  (wp: crunch_wps threadSet_tcb_scs_of'_inv ignore: setSchedContext threadSet)
+  for sym_heap_tcbSCs[wp]: sym_heap_tcbSCs
+  (wp: crunch_wps threadSet_tcbSCs_of_inv ignore: setSchedContext threadSet)
 
-lemma cleanReply_replies_scs_sym_refs :
-  "\<lbrace>\<lambda>s. sym_heapd (scReplies_of s) (\<lambda>a. if a = rptr then None else replySCs_of s a)\<rbrace>
+lemma cleanReply_sym_heap_scReplies :
+  "\<lbrace>\<lambda>s. sym_heap (scReplies_of s) (\<lambda>a. if a = rptr then None else replySCs_of s a)\<rbrace>
    cleanReply rptr
-   \<lbrace>\<lambda>_. replies_scs_sym_refs\<rbrace>"
+   \<lbrace>\<lambda>_. sym_heap_scReplies\<rbrace>"
   unfolding cleanReply_def
   apply (clarsimp simp: bind_assoc updateReply_def)
   apply (wpsimp wp: hoare_drop_imp | wps)+
   done
 
-lemma replyRemoveTCB_replies_scs_sym_refs [wp]:
-  "\<lbrace>replies_scs_sym_refs and (\<lambda>s. sym_refs (list_refs_of_replies' s))\<rbrace>
+lemma replyRemoveTCB_sym_heap_scReplies [wp]:
+  "\<lbrace>sym_heap_scReplies and (\<lambda>s. sym_refs (list_refs_of_replies' s))\<rbrace>
    replyRemoveTCB t
-   \<lbrace>\<lambda>_. replies_scs_sym_refs\<rbrace>"
+   \<lbrace>\<lambda>_. sym_heap_scReplies\<rbrace>"
   supply if_split [split del]
   unfolding replyRemoveTCB_def
   apply (clarsimp simp: bind_assoc updateReply_def)
   apply wpsimp
-         apply (wpsimp wp: cleanReply_replies_scs_sym_refs)
+         apply (wpsimp wp: cleanReply_sym_heap_scReplies)
         apply wp
          apply wps
          apply wpsimp
         apply (rule_tac Q="\<lambda>_ s. (replySCs_of s) (the (replyPrev reply)) = None \<and>
-                 sym_heapd (scReplies_of s) (\<lambda>a. if a = rptr then None else replySCs_of s a)"
+                 sym_heap (scReplies_of s) (\<lambda>a. if a = rptr then None else replySCs_of s a)"
                in hoare_strengthen_post[rotated], clarsimp)
         apply wpsimp
        apply (rule_tac Q="\<lambda>_ s. (replyPrev reply \<noteq> None \<longrightarrow>
                 reply_at' (the (replyPrev reply)) s \<longrightarrow>
                 (replySCs_of s) (the (replyPrev reply)) = None) \<and>
-                sym_heapd (scReplies_of s) (\<lambda>a. if a = rptr then None else replySCs_of s a)"
+                sym_heap (scReplies_of s) (\<lambda>a. if a = rptr then None else replySCs_of s a)"
               in hoare_strengthen_post[rotated])
         apply (clarsimp split: if_splits simp: obj_at'_def)
        apply (wp hoare_vcg_if_lift2 hoare_vcg_imp_lift' hoare_vcg_all_lift)
@@ -4977,7 +4975,7 @@ lemma replyRemoveTCB_replies_scs_sym_refs [wp]:
         apply wpsimp
        apply wpsimp
       apply wpsimp
-     apply (rule_tac Q="\<lambda>replya s. replies_scs_sym_refs s \<and> sym_refs (list_refs_of_replies' s)"
+     apply (rule_tac Q="\<lambda>replya s. sym_heap_scReplies s \<and> sym_refs (list_refs_of_replies' s)"
             in hoare_strengthen_post[rotated])
       apply (clarsimp split: if_splits)
       apply (intro conjI; intro allI impI)
@@ -5005,11 +5003,10 @@ lemma replyRemoveTCB_replies_scs_sym_refs [wp]:
           apply (simp add: sym_refs_replyNext_replyPrev_sym[symmetric])
          apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
         apply (clarsimp simp: isHead_to_head)
-        apply (erule sym_heapd_remove_only)
-        apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def
-                              pred_map_eq_def pred_map_def)
+        apply (erule sym_heap_remove_only)
+        apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def pred_map_eq)
        apply (clarsimp simp: isHead_to_head)
-       apply (erule rsubst2[where P=sym_heapd, OF _ refl])
+       apply (erule rsubst2[where P=sym_heap, OF _ refl])
        apply (rule ext, clarsimp split: if_split)
        apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
       apply (intro conjI, intro allI impI)
@@ -5018,20 +5015,20 @@ lemma replyRemoveTCB_replies_scs_sym_refs [wp]:
         apply (rule replyNexts_Some_replySCs_None)
         apply (simp add: sym_refs_replyNext_replyPrev_sym[symmetric])
        apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
-      apply (erule rsubst2[where P=sym_heapd, OF _ refl])
+      apply (erule rsubst2[where P=sym_heap, OF _ refl])
       apply (rule ext, clarsimp split: if_split)
       apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)
      apply (wpsimp wp: hoare_drop_imp)+
   done
 
 crunches blockedCancelIPC, cancelSignal
-  for replies_scs_sym_refs[wp]: replies_scs_sym_refs
+  for sym_heap_scReplies[wp]: sym_heap_scReplies
   (wp: crunch_wps  ignore: setSchedContext setReply updateReply)
 
-lemma cancelIPC_replies_scs_sym_refs [wp]:
-  "\<lbrace>replies_scs_sym_refs and (\<lambda>s. sym_refs (list_refs_of_replies' s))\<rbrace>
+lemma cancelIPC_sym_heap_scReplies [wp]:
+  "\<lbrace>sym_heap_scReplies and (\<lambda>s. sym_refs (list_refs_of_replies' s))\<rbrace>
    cancelIPC t
-   \<lbrace>\<lambda>_. replies_scs_sym_refs\<rbrace>"
+   \<lbrace>\<lambda>_. sym_heap_scReplies\<rbrace>"
   unfolding cancelIPC_def
   by (wpsimp wp: gts_wp', simp add: comp_def)
 
@@ -5050,7 +5047,7 @@ lemma ri_invs' [wp]:
    apply (rule hoare_seq_ext)
     \<comment> \<open>After getEndpoint, the following holds regardless of the type of ep\<close>
     apply (rule_tac B="\<lambda>ep s. invs' s \<and> ex_nonz_cap_to' t s \<and> ex_nonz_cap_to' (capEPPtr cap) s \<and>
-                              tcbs_scs_sym_refs s \<and> replies_scs_sym_refs s \<and>
+                              sym_heap_tcbSCs s \<and> sym_heap_scReplies s \<and>
                               st_tcb_at' simple' t s \<and> sch_act_not t s \<and> t \<noteq> ksIdleThread s \<and>
                               (\<forall>x. replyOpt = Some x \<longrightarrow> ex_nonz_cap_to' x s \<and>
                                                          reply_at' x s \<and> replyTCBs_of s x = None) \<and>
@@ -5109,8 +5106,8 @@ lemma ri_invs' [wp]:
    apply (fastforce simp: refs_of_rev' ko_wp_at'_def tcb_bound_refs'_def get_refs_def
                    split: option.splits)
   apply (clarsimp simp: comp_def invs'_def valid_state'_def valid_pspace'_def cong: conj_cong imp_cong)
-  apply (frule (3) invs'_tcbs_scs_sym_refs)
-  apply (frule (3) sym_refs_replies_scs)
+  apply (frule (2) sym_refs_tcbSCs)
+  apply (frule (2) sym_refs_scReplies)
   apply (subgoal_tac "ex_nonz_cap_to' (capEPPtr cap) s \<and> st_tcb_at' simple' t s \<and>
                       t \<noteq> ksIdleThread s \<and> (ep_at' (capEPPtr cap) s \<longrightarrow>
                       obj_at' (\<lambda>ep. ep \<noteq> Structures_H.endpoint.IdleEP \<longrightarrow> t \<notin> set (epQueue ep))
@@ -5145,7 +5142,7 @@ crunches doIPCTransfer
 lemma si_invs'_helper2:
   "\<lbrace>\<lambda>s. invs' s \<and> sch_act_not t s \<and> st_tcb_at' active' t s \<and> tcb_at' d s \<and>
         ex_nonz_cap_to' t s \<and> ex_nonz_cap_to' d s \<and>
-        tcbs_scs_sym_refs s \<and> replies_scs_sym_refs s \<and>
+        sym_heap_tcbSCs s \<and> sym_heap_scReplies s \<and>
         (\<forall>reply. replyObject recvState = Some reply \<longrightarrow> ex_nonz_cap_to' reply s \<and> reply_at' reply s
                  \<and> replyTCBs_of s reply = None) \<and>
         (cd \<and> scOptDest = Nothing \<longrightarrow> bound_sc_tcb_at' ((=) None) d s \<and>
@@ -5212,7 +5209,7 @@ lemma si_invs'2[wp]:
                                   ex_nonz_cap_to' t s \<and> ex_nonz_cap_to' a s \<and>
                                   (\<forall>x. replyObject recvState = Some x \<longrightarrow> ex_nonz_cap_to' x s \<and> reply_at' x s
                                        \<and> replyTCBs_of s x = None) \<and>
-                                  tcbs_scs_sym_refs s \<and> replies_scs_sym_refs s \<and>
+                                  sym_heap_tcbSCs s \<and> sym_heap_scReplies s \<and>
                                   (cd \<longrightarrow> (\<exists>scptr. bound_sc_tcb_at' (\<lambda>scp. scp = Some scptr) t s \<and>
                                                    ex_nonz_cap_to' scptr s))"
                 in hoare_strengthen_post[rotated])
@@ -5223,7 +5220,7 @@ lemma si_invs'2[wp]:
                            hoare_vcg_ex_lift hoare_vcg_imp_lift')
         apply (rule_tac Q="\<lambda>_ s. invs' s \<and> st_tcb_at' active' t s \<and> sch_act_not t s \<and>
                                  ex_nonz_cap_to' t s \<and> ex_nonz_cap_to' a s \<and> a \<noteq> t \<and>
-                                 tcbs_scs_sym_refs s \<and> replies_scs_sym_refs s \<and>
+                                 sym_heap_tcbSCs s \<and> sym_heap_scReplies s \<and>
                                  (\<forall>x. replyObject recvState = Some x \<longrightarrow> ex_nonz_cap_to' x s \<and> reply_at' x s) \<and>
                                  (cd \<longrightarrow> (\<exists>scptr. bound_sc_tcb_at' (\<lambda>scp. scp = Some scptr) t s \<and> ex_nonz_cap_to' scptr s))"
                in hoare_strengthen_post[rotated])
@@ -5241,8 +5238,8 @@ lemma si_invs'2[wp]:
         apply (fastforce simp: pred_tcb_at'_def ko_wp_at'_def obj_at'_def
                                projectKO_eq projectKO_tcb isReceive_def
                         split: thread_state.splits)
-       apply (erule (3) invs'_tcbs_scs_sym_refs)
-      apply (erule (3) sym_refs_replies_scs)
+       apply (erule (2) sym_refs_tcbSCs)
+      apply (erule (2) sym_refs_scReplies)
      apply (subgoal_tac "ko_wp_at' live' xb s \<and> reply_at' xb s", clarsimp)
       apply (erule (1) if_live_then_nonz_capE')
      apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKO_eq projectKO_tcb)

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -1959,6 +1959,197 @@ crunches cteDeleteOne
 crunches handleFaultReply
   for valid_objs'[wp]: valid_objs'
 
+lemma bind_sc_reply_weak_valid_sched_action[wp]:
+  "bind_sc_reply a b \<lbrace>weak_valid_sched_action\<rbrace>"
+  unfolding bind_sc_reply_def by wpsimp
+
+lemma bind_sc_reply_invs[wp]:
+  "\<lbrace> \<lambda>s. invs s
+         \<and> reply_at reply_ptr s
+         \<and> sc_at sc_ptr s
+         \<and> ex_nonz_cap_to reply_ptr s
+         \<and> ex_nonz_cap_to sc_ptr s
+         \<and> reply_sc_reply_at (\<lambda>sc_ptr'. sc_ptr' = None) reply_ptr s
+         \<and> reply_ptr \<in> fst ` replies_blocked s
+         \<and> reply_ptr \<notin> fst ` replies_with_sc s \<rbrace>
+    bind_sc_reply sc_ptr reply_ptr
+   \<lbrace> \<lambda>rv. invs \<rbrace>"
+  unfolding bind_sc_reply_def
+  supply if_weak_cong[cong del] if_split[split del]
+  apply (rule hoare_seq_ext[OF _ gscrpls_sp])
+  apply (rename_tac sc_replies')
+  apply (case_tac sc_replies'; simp)
+   apply (wpsimp wp: sched_context_donate_invs)
+     apply (wpsimp simp: invs_def valid_state_def valid_pspace_def
+                     wp: valid_irq_node_typ set_reply_sc_valid_replies_already_BlockedOnReply
+                         valid_ioports_lift)
+    apply (wpsimp wp: set_sc_replies_valid_replies update_sched_context_valid_idle)
+   apply clarsimp
+   apply (clarsimp simp: invs_def valid_state_def valid_pspace_def
+                          reply_sc_reply_at_def obj_at_def state_refs_of_def get_refs_def2
+                          sc_replies_sc_at_def pred_tcb_at_def is_tcb is_reply is_sc_obj_def
+                  split: if_splits
+                  elim!: delta_sym_refs)
+   apply safe
+        apply fastforce
+       apply fastforce
+      apply (clarsimp simp: valid_idle_def)
+     apply (rule replies_with_sc_upd_replies_new_valid_replies)
+       apply fastforce
+      apply (clarsimp simp: image_def)
+      apply (rule_tac x="(reply_ptr, b)" in bexI; fastforce)
+     apply (clarsimp simp: image_def)
+    apply (fastforce simp: invs_def valid_state_def valid_pspace_def
+                           reply_sc_reply_at_def obj_at_def state_refs_of_def get_refs_def2
+                           sc_replies_sc_at_def pred_tcb_at_def is_tcb is_reply is_sc_obj_def
+                    split: if_splits
+                    elim!: delta_sym_refs)
+   apply (clarsimp simp: idle_sc_no_ex_cap)
+  apply wpsimp
+     apply (wpsimp simp: invs_def valid_state_def valid_pspace_def
+                     wp: valid_irq_node_typ set_reply_sc_valid_replies_already_BlockedOnReply
+                         valid_ioports_lift valid_sc_typ_list_all_reply)
+    apply (wpsimp wp: set_sc_replies_valid_replies update_sched_context_valid_idle)
+   apply (wpsimp simp: get_simple_ko_def get_object_def
+                   wp: valid_sc_typ_list_all_reply valid_ioports_lift)
+  apply (subgoal_tac "list_all (\<lambda>r. reply_at r s) (a # list) \<and> reply_ptr \<notin> set (a # list) \<and> distinct (a # list)")
+   apply (clarsimp simp: invs_def valid_pspace_def valid_state_def)
+   apply (intro conjI)
+     apply (rule replies_with_sc_upd_replies_valid_replies_add_one, simp)
+       apply (clarsimp simp:replies_blocked_def image_def, fastforce)
+      apply simp
+     apply (clarsimp simp:sc_replies_sc_at_def obj_at_def)
+    apply (erule delta_sym_refs)
+     apply (clarsimp split: if_splits
+                     elim!: delta_sym_refs)
+    apply (clarsimp simp: reply_sc_reply_at_def obj_at_def state_refs_of_def get_refs_def2
+                          pred_tcb_at_def is_tcb is_reply is_sc_obj sc_at_pred_n_def
+                   split: if_splits
+                   elim!: delta_sym_refs)
+    apply (safe; clarsimp?)
+    apply (rename_tac rp1 tl s tptr scp sc r1 r2 n1)
+    apply (subgoal_tac "(rp1,scp) \<in> replies_with_sc s \<and> (rp1,sc_ptr) \<in> replies_with_sc s")
+     apply (clarsimp dest!: valid_replies_2_inj_onD )
+    apply (intro conjI)
+     apply (subgoal_tac "valid_reply r1 s")
+      apply (clarsimp simp: valid_reply_def refs_of_def obj_at_def is_sc_obj_def
+                     split: option.splits)
+      apply (rename_tac ko n2)
+      apply (case_tac ko; clarsimp simp: get_refs_def)
+      apply (erule disjE, clarsimp split: option.splits)+
+      apply (clarsimp simp: replies_with_sc_def sc_replies_sc_at_def obj_at_def split: option.splits)
+     apply (erule valid_objs_valid_reply, assumption)
+    apply(clarsimp simp: replies_with_sc_def sc_replies_sc_at_def obj_at_def)
+    apply (metis cons_set_intro)
+   apply (fastforce simp: idle_sc_no_ex_cap tcb_at_def is_tcb_def
+                    dest: pred_tcb_at_tcb_at get_tcb_SomeD)
+  apply (clarsimp simp del: distinct.simps list.pred_inject insert_iff)
+  apply (frule sc_replies_sc_at_subset_fst_replies_with_sc)
+  apply (frule invs_valid_objs)
+  apply (intro conjI)
+    apply (erule replies_blocked_list_all_reply_at)
+    apply (meson dual_order.trans invs_valid_replies valid_replies_defs(1))
+   apply fastforce
+  apply (erule (1) valid_objs_sc_replies_distinct)
+  done
+
+lemma replyPush_corres:
+  "can_donate = can_donate' \<Longrightarrow>
+   corres dc (invs and tcb_at caller and tcb_at callee and reply_at reply_ptr
+              and ex_nonz_cap_to reply_ptr
+              and st_tcb_at active caller
+              and reply_sc_reply_at (\<lambda>tptr. tptr = None) reply_ptr
+              and reply_tcb_reply_at (\<lambda>tptr. tptr = None) reply_ptr
+              and weak_valid_sched_action and scheduler_act_not caller)
+             (valid_release_queue_iff and valid_objs' and valid_queues and valid_queues')
+   (reply_push caller callee reply_ptr can_donate)
+   (replyPush caller callee reply_ptr can_donate')"
+  unfolding reply_push_def replyPush_def
+  apply clarsimp
+  apply add_sym_refs
+  apply (rule_tac Q="\<lambda>s. valid_replies'_sc_asrt reply_ptr s" in corres_cross_add_guard)
+   apply (fastforce elim: valid_replies_sc_cross)
+  apply (rule corres_stateAssert_implied[where P'=\<top>, simplified])
+   apply (rule corres_stateAssert_implied[where P'=\<top>, simplified])
+    apply (rule stronger_corres_guard_imp)
+      apply (simp add: get_tcb_obj_ref_def)
+      apply (rule corres_split_deprecated [OF _ threadget_corres[where r="(=)"]])
+         apply (rule corres_split_deprecated [OF _ threadget_corres[where r="(=)"]])
+            apply (rule corres_split_deprecated [OF _ replyTCB_update_corres])
+              apply (rule corres_split_deprecated[OF _ sts_corres])
+                 apply (rule corres_when2, clarsimp)
+                 apply simp
+                 apply (rule corres_split_deprecated [OF schedContextDonate_corres bindReplySc_corres])
+                  apply (wpsimp wp: sc_at_typ_at)
+                 apply wpsimp
+                apply simp
+               apply (wpsimp wp: set_thread_state_invs hoare_vcg_imp_lift'
+                                 hoare_vcg_all_lift sts_in_replies_blocked
+                                 set_thread_state_weak_valid_sched_action)
+              apply (wpsimp wp: hoare_vcg_imp_lift' sts_invs_minor')
+             apply clarsimp
+             apply (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift)
+            apply (clarsimp simp: valid_tcb_state'_def cong: conj_cong)
+            apply (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift updateReply_valid_objs')
+           apply (clarsimp simp: tcb_relation_def)
+          apply (wpsimp wp: thread_get_wp')
+          apply assumption
+         apply (wpsimp wp: threadGet_wp)
+        apply (clarsimp simp: tcb_relation_def)
+       apply (wpsimp wp: thread_get_wp')
+      apply (wpsimp wp: threadGet_wp)
+     apply (subgoal_tac "caller \<noteq> reply_ptr")
+      apply (subgoal_tac "caller \<noteq> idle_thread_ptr")
+       apply (clarsimp simp: invs_def valid_state_def
+                             valid_pspace_def cong: conj_cong)
+       apply (frule valid_objs_valid_tcbs, clarsimp)
+       apply (frule (1) valid_objs_ko_at[where ptr=caller])
+       apply (subgoal_tac "ex_nonz_cap_to caller s", clarsimp)
+        apply (frule (1) idle_no_ex_cap)
+        apply (frule (2) no_tcb_not_in_replies_with_sc, clarsimp)
+        apply (intro conjI)
+            apply (clarsimp simp: valid_obj_def valid_tcb_def)
+           apply clarsimp
+          apply (clarsimp simp: replies_blocked_def pred_tcb_at_def obj_at_def)
+         apply (erule delta_sym_refs_insert_only, simp)
+           apply (subst set_eq_subset, intro conjI)
+            apply (clarsimp simp: state_refs_of_def)
+           apply (clarsimp simp: state_refs_of_def obj_at_def is_tcb get_refs_def2)
+           apply (subgoal_tac "tcb_st_refs_of (tcb_state tcb) = {}", simp)
+            apply fastforce
+           apply (fastforce simp: tcb_st_refs_of_def pred_tcb_at_def obj_at_def)
+          apply (subst set_eq_subset, intro conjI)
+           apply (clarsimp simp: state_refs_of_def)
+          apply (clarsimp simp: state_refs_of_def obj_at_def is_reply get_refs_def2)
+          apply (clarsimp simp: obj_at_def sk_obj_at_pred_def)
+         apply simp
+        apply (subgoal_tac "sc_tcb_sc_at ((=) (Some caller)) y s")
+         apply (clarsimp simp: sc_at_pred_n_def)
+         apply (erule (1) if_live_then_nonz_capD)
+         apply (clarsimp simp: live_def live_sc_def, fastforce)
+        apply (subst sym_refs_bound_sc_tcb_iff_sc_tcb_sc_at[symmetric, OF refl eq_commute])
+         apply assumption
+        apply (clarsimp simp: pred_tcb_at_def obj_at_def)
+       apply (erule (1) if_live_then_nonz_capD)
+       apply (clarsimp simp: live_def  is_tcb obj_at_def)
+       apply (frule (1) bound_sc_tcb_at_idle_sc_idle_thread[where t=caller])
+        apply (clarsimp simp: pred_tcb_at_def obj_at_def)
+       apply simp
+      apply clarsimp
+      apply (frule invs_valid_idle)
+      apply (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def)
+     apply (clarsimp simp: obj_at_def is_tcb is_reply)
+    apply clarsimp
+    apply (frule valid_objs'_valid_tcbs')
+    apply (frule cross_relF[OF _ tcb_at'_cross_rel[where t=caller]], fastforce, clarsimp)
+    apply (frule cross_relF[OF _ tcb_at'_cross_rel[where t=callee]], fastforce, clarsimp)
+    apply (frule cross_relF[OF _ reply_at'_cross_rel[where t=reply_ptr]], fastforce, clarsimp)
+    apply (prop_tac "obj_at' (\<lambda>t. valid_bound_sc' (tcbSchedContext t) s') caller s'")
+     apply (erule valid_tcbs'_obj_at'[rotated])
+      apply (clarsimp simp: valid_tcb'_def)
+     apply (clarsimp simp: obj_at'_def sym_refs_asrt_def valid_reply'_def)+
+  done
+
 lemma do_reply_transfer_corres:
   "corres dc
      (einvs and reply_at reply and tcb_at sender)
@@ -3635,197 +3826,6 @@ lemma maybeReturnSc_corres:
     apply (clarsimp simp: valid_tcbs'_def obj_at'_real_def ko_wp_at'_def projectKO_tcb)
    apply (clarsimp simp: obj_at'_def)
   apply (clarsimp simp: sym_refs_asrt_def)
-  done
-
-lemma bind_sc_reply_weak_valid_sched_action[wp]:
-  "bind_sc_reply a b \<lbrace>weak_valid_sched_action\<rbrace>"
-  unfolding bind_sc_reply_def by wpsimp
-
-lemma bind_sc_reply_invs[wp]:
-  "\<lbrace> \<lambda>s. invs s
-         \<and> reply_at reply_ptr s
-         \<and> sc_at sc_ptr s
-         \<and> ex_nonz_cap_to reply_ptr s
-         \<and> ex_nonz_cap_to sc_ptr s
-         \<and> reply_sc_reply_at (\<lambda>sc_ptr'. sc_ptr' = None) reply_ptr s
-         \<and> reply_ptr \<in> fst ` replies_blocked s
-         \<and> reply_ptr \<notin> fst ` replies_with_sc s \<rbrace>
-    bind_sc_reply sc_ptr reply_ptr
-   \<lbrace> \<lambda>rv. invs \<rbrace>"
-  unfolding bind_sc_reply_def
-  supply if_weak_cong[cong del] if_split[split del]
-  apply (rule hoare_seq_ext[OF _ gscrpls_sp])
-  apply (rename_tac sc_replies')
-  apply (case_tac sc_replies'; simp)
-   apply (wpsimp wp: sched_context_donate_invs)
-     apply (wpsimp simp: invs_def valid_state_def valid_pspace_def
-                     wp: valid_irq_node_typ set_reply_sc_valid_replies_already_BlockedOnReply
-                         valid_ioports_lift)
-    apply (wpsimp wp: set_sc_replies_valid_replies update_sched_context_valid_idle)
-   apply clarsimp
-   apply (clarsimp simp: invs_def valid_state_def valid_pspace_def
-                          reply_sc_reply_at_def obj_at_def state_refs_of_def get_refs_def2
-                          sc_replies_sc_at_def pred_tcb_at_def is_tcb is_reply is_sc_obj_def
-                  split: if_splits
-                  elim!: delta_sym_refs)
-   apply safe
-        apply fastforce
-       apply fastforce
-      apply (clarsimp simp: valid_idle_def)
-     apply (rule replies_with_sc_upd_replies_new_valid_replies)
-       apply fastforce
-      apply (clarsimp simp: image_def)
-      apply (rule_tac x="(reply_ptr, b)" in bexI; fastforce)
-     apply (clarsimp simp: image_def)
-    apply (fastforce simp: invs_def valid_state_def valid_pspace_def
-                           reply_sc_reply_at_def obj_at_def state_refs_of_def get_refs_def2
-                           sc_replies_sc_at_def pred_tcb_at_def is_tcb is_reply is_sc_obj_def
-                    split: if_splits
-                    elim!: delta_sym_refs)
-   apply (clarsimp simp: idle_sc_no_ex_cap)
-  apply wpsimp
-     apply (wpsimp simp: invs_def valid_state_def valid_pspace_def
-                     wp: valid_irq_node_typ set_reply_sc_valid_replies_already_BlockedOnReply
-                         valid_ioports_lift valid_sc_typ_list_all_reply)
-    apply (wpsimp wp: set_sc_replies_valid_replies update_sched_context_valid_idle)
-   apply (wpsimp simp: get_simple_ko_def get_object_def
-                   wp: valid_sc_typ_list_all_reply valid_ioports_lift)
-  apply (subgoal_tac "list_all (\<lambda>r. reply_at r s) (a # list) \<and> reply_ptr \<notin> set (a # list) \<and> distinct (a # list)")
-   apply (clarsimp simp: invs_def valid_pspace_def valid_state_def)
-   apply (intro conjI)
-     apply (rule replies_with_sc_upd_replies_valid_replies_add_one, simp)
-       apply (clarsimp simp:replies_blocked_def image_def, fastforce)
-      apply simp
-     apply (clarsimp simp:sc_replies_sc_at_def obj_at_def)
-    apply (erule delta_sym_refs)
-     apply (clarsimp split: if_splits
-                     elim!: delta_sym_refs)
-    apply (clarsimp simp: reply_sc_reply_at_def obj_at_def state_refs_of_def get_refs_def2
-                          pred_tcb_at_def is_tcb is_reply is_sc_obj sc_at_pred_n_def
-                   split: if_splits
-                   elim!: delta_sym_refs)
-    apply (safe; clarsimp?)
-    apply (rename_tac rp1 tl s tptr scp sc r1 r2 n1)
-    apply (subgoal_tac "(rp1,scp) \<in> replies_with_sc s \<and> (rp1,sc_ptr) \<in> replies_with_sc s")
-     apply (clarsimp dest!: valid_replies_2_inj_onD )
-    apply (intro conjI)
-     apply (subgoal_tac "valid_reply r1 s")
-      apply (clarsimp simp: valid_reply_def refs_of_def obj_at_def is_sc_obj_def
-                     split: option.splits)
-      apply (rename_tac ko n2)
-      apply (case_tac ko; clarsimp simp: get_refs_def)
-      apply (erule disjE, clarsimp split: option.splits)+
-      apply (clarsimp simp: replies_with_sc_def sc_replies_sc_at_def obj_at_def split: option.splits)
-     apply (erule valid_objs_valid_reply, assumption)
-    apply(clarsimp simp: replies_with_sc_def sc_replies_sc_at_def obj_at_def)
-    apply (metis cons_set_intro)
-   apply (fastforce simp: idle_sc_no_ex_cap tcb_at_def is_tcb_def
-                    dest: pred_tcb_at_tcb_at get_tcb_SomeD)
-  apply (clarsimp simp del: distinct.simps list.pred_inject insert_iff)
-  apply (frule sc_replies_sc_at_subset_fst_replies_with_sc)
-  apply (frule invs_valid_objs)
-  apply (intro conjI)
-    apply (erule replies_blocked_list_all_reply_at)
-    apply (meson dual_order.trans invs_valid_replies valid_replies_defs(1))
-   apply fastforce
-  apply (erule (1) valid_objs_sc_replies_distinct)
-  done
-
-lemma replyPush_corres:
-  "can_donate = can_donate' \<Longrightarrow>
-   corres dc (invs and tcb_at caller and tcb_at callee and reply_at reply_ptr
-              and ex_nonz_cap_to reply_ptr
-              and st_tcb_at active caller
-              and reply_sc_reply_at (\<lambda>tptr. tptr = None) reply_ptr
-              and reply_tcb_reply_at (\<lambda>tptr. tptr = None) reply_ptr
-              and weak_valid_sched_action and scheduler_act_not caller)
-             (valid_release_queue_iff and valid_objs' and valid_queues and valid_queues')
-   (reply_push caller callee reply_ptr can_donate)
-   (replyPush caller callee reply_ptr can_donate')"
-  unfolding reply_push_def replyPush_def
-  apply clarsimp
-  apply add_sym_refs
-  apply (rule_tac Q="\<lambda>s. valid_replies'_sc_asrt reply_ptr s" in corres_cross_add_guard)
-   apply (fastforce elim: valid_replies_sc_cross)
-  apply (rule corres_stateAssert_implied[where P'=\<top>, simplified])
-   apply (rule corres_stateAssert_implied[where P'=\<top>, simplified])
-    apply (rule stronger_corres_guard_imp)
-      apply (simp add: get_tcb_obj_ref_def)
-      apply (rule corres_split_deprecated [OF _ threadget_corres[where r="(=)"]])
-         apply (rule corres_split_deprecated [OF _ threadget_corres[where r="(=)"]])
-            apply (rule corres_split_deprecated [OF _ replyTCB_update_corres])
-              apply (rule corres_split_deprecated[OF _ sts_corres])
-                 apply (rule corres_when2, clarsimp)
-                 apply simp
-                 apply (rule corres_split_deprecated [OF schedContextDonate_corres bindReplySc_corres])
-                  apply (wpsimp wp: sc_at_typ_at)
-                 apply wpsimp
-                apply simp
-               apply (wpsimp wp: set_thread_state_invs hoare_vcg_imp_lift'
-                                 hoare_vcg_all_lift sts_in_replies_blocked
-                                 set_thread_state_weak_valid_sched_action)
-              apply (wpsimp wp: hoare_vcg_imp_lift' sts_invs_minor')
-             apply clarsimp
-             apply (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift)
-            apply (clarsimp simp: valid_tcb_state'_def cong: conj_cong)
-            apply (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift updateReply_valid_objs')
-           apply (clarsimp simp: tcb_relation_def)
-          apply (wpsimp wp: thread_get_wp')
-          apply assumption
-         apply (wpsimp wp: threadGet_wp)
-        apply (clarsimp simp: tcb_relation_def)
-       apply (wpsimp wp: thread_get_wp')
-      apply (wpsimp wp: threadGet_wp)
-     apply (subgoal_tac "caller \<noteq> reply_ptr")
-      apply (subgoal_tac "caller \<noteq> idle_thread_ptr")
-       apply (clarsimp simp: invs_def valid_state_def
-                             valid_pspace_def cong: conj_cong)
-       apply (frule valid_objs_valid_tcbs, clarsimp)
-       apply (frule (1) valid_objs_ko_at[where ptr=caller])
-       apply (subgoal_tac "ex_nonz_cap_to caller s", clarsimp)
-        apply (frule (1) idle_no_ex_cap)
-        apply (frule (2) no_tcb_not_in_replies_with_sc, clarsimp)
-        apply (intro conjI)
-            apply (clarsimp simp: valid_obj_def valid_tcb_def)
-           apply clarsimp
-          apply (clarsimp simp: replies_blocked_def pred_tcb_at_def obj_at_def)
-         apply (erule delta_sym_refs_insert_only, simp)
-           apply (subst set_eq_subset, intro conjI)
-            apply (clarsimp simp: state_refs_of_def)
-           apply (clarsimp simp: state_refs_of_def obj_at_def is_tcb get_refs_def2)
-           apply (subgoal_tac "tcb_st_refs_of (tcb_state tcb) = {}", simp)
-            apply fastforce
-           apply (fastforce simp: tcb_st_refs_of_def pred_tcb_at_def obj_at_def)
-          apply (subst set_eq_subset, intro conjI)
-           apply (clarsimp simp: state_refs_of_def)
-          apply (clarsimp simp: state_refs_of_def obj_at_def is_reply get_refs_def2)
-          apply (clarsimp simp: obj_at_def sk_obj_at_pred_def)
-         apply simp
-        apply (subgoal_tac "sc_tcb_sc_at ((=) (Some caller)) y s")
-         apply (clarsimp simp: sc_at_pred_n_def)
-         apply (erule (1) if_live_then_nonz_capD)
-         apply (clarsimp simp: live_def live_sc_def, fastforce)
-        apply (subst sym_refs_bound_sc_tcb_iff_sc_tcb_sc_at[symmetric, OF refl eq_commute])
-         apply assumption
-        apply (clarsimp simp: pred_tcb_at_def obj_at_def)
-       apply (erule (1) if_live_then_nonz_capD)
-       apply (clarsimp simp: live_def  is_tcb obj_at_def)
-       apply (frule (1) bound_sc_tcb_at_idle_sc_idle_thread[where t=caller])
-        apply (clarsimp simp: pred_tcb_at_def obj_at_def)
-       apply simp
-      apply clarsimp
-      apply (frule invs_valid_idle)
-      apply (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def)
-     apply (clarsimp simp: obj_at_def is_tcb is_reply)
-    apply clarsimp
-    apply (frule valid_objs'_valid_tcbs')
-    apply (frule cross_relF[OF _ tcb_at'_cross_rel[where t=caller]], fastforce, clarsimp)
-    apply (frule cross_relF[OF _ tcb_at'_cross_rel[where t=callee]], fastforce, clarsimp)
-    apply (frule cross_relF[OF _ reply_at'_cross_rel[where t=reply_ptr]], fastforce, clarsimp)
-    apply (prop_tac "obj_at' (\<lambda>t. valid_bound_sc' (tcbSchedContext t) s') caller s'")
-     apply (erule valid_tcbs'_obj_at'[rotated])
-      apply (clarsimp simp: valid_tcb'_def)
-     apply (clarsimp simp: obj_at'_def sym_refs_asrt_def valid_reply'_def)+
   done
 
 lemma receive_ipc_corres:

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -284,7 +284,7 @@ lemma pspace_relation_tcb_at:
   assumes t: "tcbs_of' s' t \<noteq> None"
   shows "tcb_at t s" using assms
   by (fastforce elim!: pspace_dom_relatedE obj_relation_cutsE
-                 simp: other_obj_relation_def obj_at_def projectKOs is_tcb_def tcb_of'_def
+                 simp: other_obj_relation_def obj_at_def projectKOs is_tcb_def
                 split: Structures_A.kernel_object.split_asm if_split_asm
                        ARM_A.arch_kernel_obj.split_asm kernel_object.splits)
 
@@ -3442,7 +3442,7 @@ lemma pspace_distinct_cross:
   apply (erule (2) in_empty_interE)
   done
 
-lemma aligned'_distinct'_obj_at'I:
+lemma aligned'_distinct'_ko_at'I:
   "\<lbrakk>ksPSpace s' x = Some ko;  pspace_aligned' s'; pspace_distinct' s';
     ko = injectKO (v:: 'a :: pspace_storable)\<rbrakk>
       \<Longrightarrow> ko_at' v x s'"
@@ -3452,12 +3452,12 @@ lemma aligned'_distinct'_obj_at'I:
   apply simp
   done
 
-lemma aligned_distinct_obj_at'I:
+lemma aligned_distinct_ko_at'I:
   assumes p: "pspace_relation (kheap s) (ksPSpace s')"
   assumes ps: "pspace_aligned s" "pspace_distinct s"
   shows "\<lbrakk>ksPSpace s' x = Some ko; ko = injectKO (v:: 'a :: pspace_storable)\<rbrakk>
       \<Longrightarrow> ko_at' v x s'"
-  apply (rule aligned'_distinct'_obj_at'I[OF _ pspace_aligned_cross[OF ps(1) p]]; simp)
+  apply (rule aligned'_distinct'_ko_at'I[OF _ pspace_aligned_cross[OF ps(1) p]]; simp)
   using assms by (fastforce dest!: pspace_distinct_cross)
 
 lemma tcb_at_cross:
@@ -3469,7 +3469,7 @@ lemma tcb_at_cross:
   apply (clarsimp simp: obj_at_def is_tcb)
   apply (drule (1) pspace_relation_absD, clarsimp simp: other_obj_relation_def)
   apply (case_tac z; simp)
-  by (fastforce dest!: aligned_distinct_obj_at'I[where 'a=tcb] elim: obj_at'_weakenE)
+  by (fastforce dest!: aligned_distinct_ko_at'I[where 'a=tcb] elim: obj_at'_weakenE)
 
 lemma st_tcb_at_coerce_abstract:
   assumes t: "st_tcb_at' P t c"
@@ -3527,7 +3527,7 @@ lemma reply_at_cross:
   apply (clarsimp simp: obj_at_def is_reply)
   apply (drule (1) pspace_relation_absD, clarsimp)
   apply (case_tac z; simp)
-  by (fastforce dest!: aligned_distinct_obj_at'I[where 'a=reply] elim: obj_at'_weakenE)
+  by (fastforce dest!: aligned_distinct_ko_at'I[where 'a=reply] elim: obj_at'_weakenE)
 
 lemma ep_at_cross:
   assumes p: "pspace_relation (kheap s) (ksPSpace s')"
@@ -3538,7 +3538,7 @@ lemma ep_at_cross:
   apply (clarsimp simp: obj_at_def is_ep)
   apply (drule (1) pspace_relation_absD, clarsimp simp: other_obj_relation_def)
   apply (case_tac z; simp)
-  by (fastforce dest!: aligned_distinct_obj_at'I[where 'a=endpoint] elim: obj_at'_weakenE)
+  by (fastforce dest!: aligned_distinct_ko_at'I[where 'a=endpoint] elim: obj_at'_weakenE)
 
 lemma ntfn_at_cross:
   assumes p: "pspace_relation (kheap s) (ksPSpace s')"
@@ -3549,7 +3549,7 @@ lemma ntfn_at_cross:
   apply (clarsimp simp: obj_at_def is_ntfn)
   apply (drule (1) pspace_relation_absD, clarsimp simp: other_obj_relation_def)
   apply (case_tac z; simp)
-  by (fastforce dest!: aligned_distinct_obj_at'I[where 'a=notification] elim: obj_at'_weakenE)
+  by (fastforce dest!: aligned_distinct_ko_at'I[where 'a=notification] elim: obj_at'_weakenE)
 
 lemma sc_at_cross:
   assumes p: "pspace_relation (kheap s) (ksPSpace s')"
@@ -3560,7 +3560,7 @@ lemma sc_at_cross:
   apply (clarsimp simp: obj_at_def is_sc_obj)
   apply (drule (1) pspace_relation_absD, clarsimp)
   apply (case_tac z; simp)
-  by (fastforce dest!: aligned_distinct_obj_at'I[where 'a=sched_context] elim: obj_at'_weakenE)
+  by (fastforce dest!: aligned_distinct_ko_at'I[where 'a=sched_context] elim: obj_at'_weakenE)
 
 lemma sc_obj_at_cross:
   assumes p: "pspace_relation (kheap s) (ksPSpace s')"
@@ -3572,7 +3572,7 @@ lemma sc_obj_at_cross:
   apply (drule (1) pspace_relation_absD, clarsimp)
   apply (case_tac z; simp)
   apply (rename_tac sc')
-  apply (drule (3) aligned_distinct_obj_at'I[where 'a=sched_context], simp)
+  apply (drule (3) aligned_distinct_ko_at'I[where 'a=sched_context], simp)
   by (clarsimp simp: scBits_simps objBits_simps sc_relation_def obj_at'_def)
 
 lemma real_cte_at_cross:
@@ -3588,7 +3588,7 @@ lemma real_cte_at_cross:
     cte_relation (snd ptr) (CNode (length (snd ptr)) cs) z")
   apply fastforce
   apply (clarsimp split: kernel_object.split_asm simp: cte_relation_def)
-  by (fastforce dest!: aligned_distinct_obj_at'I[where 'a=cte] elim: obj_at'_weakenE)
+  by (fastforce dest!: aligned_distinct_ko_at'I[where 'a=cte] elim: obj_at'_weakenE)
 
 lemma valid_tcb_state_cross:
   assumes "pspace_relation (kheap s) (ksPSpace s')"
@@ -3725,10 +3725,6 @@ lemma valid_replies_sc_cross:
 method add_valid_replies for rptr uses simp =
   rule_tac Q="\<lambda>s. valid_replies'_sc_asrt rptr s" in corres_cross_add_guard
   , fastforce elim: valid_replies_sc_cross simp: simp
-
-lemma tcb_of'_Some:
-  "(tcb_of' ko = Some y) = (ko = KOTCB y)"
-  by (case_tac ko; simp add: tcb_of'_def)
 
 lemma getCurThread_sp:
   "\<lbrace>P\<rbrace> getCurThread \<lbrace>\<lambda>rv. P and (\<lambda>s. rv = ksCurThread s)\<rbrace>"
@@ -3993,18 +3989,6 @@ lemma cross_relF:
   "(s, s') \<in> state_relation \<Longrightarrow> cross_rel A B \<Longrightarrow> A s \<Longrightarrow> B s'"
   by (clarsimp simp: cross_rel_def)
 
-lemma tcb_of'_tcb[simp]:
-  "tcb_of' (KOTCB t) = Some t"
-  by (clarsimp simp: tcb_of'_def)+
-
-lemma tcb_of'_not_tcb[simp]:
-  "tcb_of' (KOEndpoint e) = None"
-  "tcb_of' (KONotification n) = None"
-  "tcb_of' (KOCTE c) = None"
-  "tcb_of' (KOSchedContext sc) = None"
-  "tcb_of' (KOReply r) = None"
-  by (clarsimp simp: tcb_of'_def)+
-
 lemma valid_tcb_state'_simps[simp]:
   "valid_tcb_state' Running = \<top>"
   "valid_tcb_state' Inactive = \<top>"
@@ -4041,65 +4025,34 @@ lemma obj_at'_typ_at'[elim!]:
    obj_at' (\<top> :: ('a :: pspace_storable) \<Rightarrow> bool) p s"
   by (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
 
-lemma sc_tcbs_of_pred_map_equiv:
-  "obj_at' (\<lambda>x. scTCB x = Some t) p s = 
-   (sc_at' p s \<and> pred_map_eq t (scTCBs_of s) p)"
-  by (intro iffI; clarsimp simp: obj_at'_real_def ko_wp_at'_def pred_map_eq
-                                 projectKOs opt_map_def)
-
-lemma tcb_scs_of_pred_map_equiv:
-  "obj_at' (\<lambda>x. tcbSchedContext x = Some sc) p s = 
-   (tcb_at' p s \<and> pred_map_eq sc (tcb_scs_of' s) p)"
-  by (intro iffI; clarsimp simp: obj_at'_real_def ko_wp_at'_def pred_map_eq
-                                 projectKOs opt_map_def)
-
-lemma replySCs_of_pred_map_equiv:
-  "obj_at' (\<lambda>a. replyNext a = Some (Head sc)) p s = 
-   (reply_at' p s \<and> pred_map_eq sc (replySCs_of s) p)"
-  by (intro iffI; clarsimp simp: obj_at'_real_def ko_wp_at'_def pred_map_eq
-                                 projectKOs opt_map_def)
-
-lemma scReplies_of_pred_map_equiv:
-  "obj_at' (\<lambda>a. scReply a = Some sc) p s = 
-   (sc_at' p s \<and> pred_map_eq sc (scReplies_of s) p)"
-  by (intro iffI; clarsimp simp: obj_at'_real_def ko_wp_at'_def pred_map_eq
-                                 projectKOs opt_map_def)
-
-lemma tcbs_scs_sym_refs_equiv:
-  "\<lbrakk>tcbs_scs_sym_refs s; valid_objs' s; sc_at' p s \<or> tcb_at' p s\<rbrakk> \<Longrightarrow>
-   obj_at' (\<lambda>x. scTCB x = Some t) p s = obj_at' (\<lambda>x. tcbSchedContext x = Some p) t s"
-  apply (rule iffI; subgoal_tac "sc_at' p s \<and> tcb_at' t s", clarsimp)
-     apply (clarsimp simp: sc_tcbs_of_pred_map_equiv tcb_scs_of_pred_map_equiv sym_heapd_def)
-    apply (frule obj_at'_typ_at', simp)
-    apply (frule obj_at_ko_at', clarsimp)
-    apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-    apply (clarsimp simp: valid_sched_context'_def)
-   apply (clarsimp simp: sc_tcbs_of_pred_map_equiv tcb_scs_of_pred_map_equiv sym_heapd_def)
-  apply (frule obj_at'_typ_at', simp)
-  apply (frule obj_at_ko_at', clarsimp)
-  apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
-  apply (clarsimp simp: valid_tcb'_def)
-  done
+lemma shows
+  obj_at'_sc_tcbs_of_equiv:
+    "obj_at' (\<lambda>x. scTCB x = Some t) p s = (sc_at' p s \<and> scTCBs_of s p = Some t)"
+  and obj_at'_tcb_scs_of_equiv:
+    "obj_at' (\<lambda>x. tcbSchedContext x = Some sc) p s = (tcb_at' p s \<and> tcbSCs_of s p = Some sc)"
+  and obj_at'_replySCs_of_equiv:
+    "obj_at' (\<lambda>a. replyNext a = Some (Head sc)) p s = (reply_at' p s \<and> replySCs_of s p = Some sc)"
+  and obj_at'_scReplies_of_equiv:
+    "obj_at' (\<lambda>a. scReply a = Some sc) p s = (sc_at' p s \<and> scReplies_of s p = Some sc)"
+  by (intro iffI; clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def)+
 
 lemma not_idle_scTCB:
-  "\<lbrakk>tcbs_scs_sym_refs s; valid_objs' s; valid_idle' s; p \<noteq> idle_sc_ptr; sc_at' p s\<rbrakk> \<Longrightarrow>
+  "\<lbrakk>sym_heap_tcbSCs s; valid_objs' s; valid_idle' s; p \<noteq> idle_sc_ptr; sc_at' p s\<rbrakk> \<Longrightarrow>
    obj_at' (\<lambda>x. scTCB x \<noteq> Some idle_thread_ptr) p s"
   apply (subgoal_tac "\<not>obj_at' (\<lambda>x. scTCB x = Some idle_thread_ptr) p s")
    apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
-  apply (subst (asm) sym_heapd_sym)
-  apply (clarsimp simp: sc_tcbs_of_pred_map_equiv sym_heapd_def)
-  apply (clarsimp simp: valid_idle'_def obj_at'_real_def ko_wp_at'_def idle_tcb'_def pred_map_eq
-                        projectKOs)
+  apply (subst (asm) sym_heap_symmetric)
+  apply (clarsimp simp: obj_at'_sc_tcbs_of_equiv sym_heap_def)
+  apply (clarsimp simp: valid_idle'_def obj_at'_real_def ko_wp_at'_def idle_tcb'_def projectKOs)
   done
 
 lemma not_idle_tcbSC:
-  "\<lbrakk>tcbs_scs_sym_refs s; valid_objs' s; valid_idle' s; p \<noteq> idle_thread_ptr; tcb_at' p s\<rbrakk> \<Longrightarrow>
+  "\<lbrakk>sym_heap_tcbSCs s; valid_objs' s; valid_idle' s; p \<noteq> idle_thread_ptr; tcb_at' p s\<rbrakk> \<Longrightarrow>
    obj_at' (\<lambda>x. tcbSchedContext x \<noteq> Some idle_sc_ptr) p s"
   apply (subgoal_tac "\<not>obj_at' (\<lambda>x. tcbSchedContext x = Some idle_sc_ptr) p s")
    apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
-  apply (clarsimp simp: tcb_scs_of_pred_map_equiv sym_heapd_def)
-  apply (clarsimp simp: valid_idle'_def obj_at'_real_def ko_wp_at'_def idle_tcb'_def pred_map_eq
-                        projectKOs)
+  apply (clarsimp simp: obj_at'_tcb_scs_of_equiv sym_heap_def)
+  apply (clarsimp simp: valid_idle'_def obj_at'_real_def ko_wp_at'_def idle_tcb'_def projectKOs)
   done
 
 lemma setObject_tcb_tcbs_of':
@@ -4115,13 +4068,13 @@ lemma setObject_other_tcbs_of'[wp]:
   "setObject c (sc::sched_context) \<lbrace>\<lambda>s. P' (tcbs_of' s)\<rbrace>"
   by setObject_easy_cases+
 
-lemma setObject_cte_tcb_scs_of'[wp]:
-  "setObject c (reply::cte) \<lbrace>\<lambda>s. P' (tcb_scs_of' s)\<rbrace>"
+lemma setObject_cte_tcbSCs_of[wp]:
+  "setObject c (reply::cte) \<lbrace>\<lambda>s. P' (tcbSCs_of s)\<rbrace>"
   by setObject_easy_cases
 
-lemma threadSet_tcb_scs_of'_inv:
+lemma threadSet_tcbSCs_of_inv:
   "\<forall>x. tcbSchedContext (f x) = tcbSchedContext x \<Longrightarrow>
-  threadSet f t \<lbrace>\<lambda>s. P (tcb_scs_of' s)\<rbrace>"
+  threadSet f t \<lbrace>\<lambda>s. P (tcbSCs_of s)\<rbrace>"
   unfolding threadSet_def
   apply (rule hoare_seq_ext[OF _ get_tcb_sp'])
   apply (wpsimp wp: setObject_tcb_tcbs_of')
@@ -4130,30 +4083,12 @@ lemma threadSet_tcb_scs_of'_inv:
                  split: option.splits)
   done
 
-lemma KOTCB_tcb_at':
-  "\<exists>v'. ksPSpace s p = Some (KOTCB v') \<Longrightarrow> pspace_aligned' s \<Longrightarrow> pspace_distinct' s \<Longrightarrow> tcb_at' p s"
-  apply (clarsimp simp: pred_map_def state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_tcb
-                        tcb_of'_Some)
-  apply (intro conjI)
-   apply (erule (1) pspace_alignedD')
-  apply (erule (1) pspace_distinctD')
-  done
-
-lemma KOSC_sc_at':
-  "\<exists>v'. ksPSpace s p = Some (KOSchedContext v') \<Longrightarrow> pspace_aligned' s \<Longrightarrow> pspace_distinct' s \<Longrightarrow> sc_at' p s"
-  apply (clarsimp simp: pred_map_def state_refs_of'_def obj_at'_real_def ko_wp_at'_def)
-  apply (intro conjI)
-   apply (erule (1) pspace_alignedD')
-  apply (erule (1) pspace_distinctD')
-  done
-
-lemma KOReply_reply_at':
-  "\<exists>v'. ksPSpace s p = Some (KOReply v') \<Longrightarrow> pspace_aligned' s \<Longrightarrow> pspace_distinct' s \<Longrightarrow> reply_at' p s"
-  apply (clarsimp simp: pred_map_def state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_reply
-                        tcb_of'_Some)
-  apply (intro conjI)
-   apply (erule (1) pspace_alignedD')
-  apply (erule (1) pspace_distinctD')
+lemma aligned'_distinct'_obj_at'I:
+  "\<lbrakk> \<exists>y. ksPSpace s p = Some (injectKO (y:: 'a::pspace_storable)); pspace_aligned' s; pspace_distinct' s\<rbrakk>
+   \<Longrightarrow> obj_at' (\<top> :: 'a::pspace_storable \<Rightarrow> bool) p s"
+  apply (clarsimp)
+  apply (frule (2) aligned'_distinct'_ko_at'I, simp)
+  apply (clarsimp simp: obj_at'_def)
   done
 
 (* FIXME RT: maybe move? *)
@@ -4168,107 +4103,29 @@ lemma prod_in_refsD:
   apply (clarsimp simp: tcb_bound_refs'_def get_refs_def2)
   done
 
-lemma SCTcb_state_refs_of':
-  "(p, SCTcb) \<in> state_refs_of' s scp = obj_at' (\<lambda>ko. scTCB ko = Some p) scp s"
+lemma sym_refs_tcbSCs:
+  "\<lbrakk>sym_refs (state_refs_of' s); pspace_aligned' s; pspace_distinct' s\<rbrakk>
+   \<Longrightarrow> sym_heap_tcbSCs s"
+  apply (clarsimp simp: sym_heap_def)
   apply (rule iffI)
-   apply (clarsimp simp: state_refs_of'_def split: option.splits if_splits)
-   apply (rename_tac ko, case_tac ko; simp add: get_refs_def2)
-      apply (fastforce dest: prod_in_refsD)+
-   apply (clarsimp simp: obj_at'_def projectKOs)
-  apply (clarsimp simp: obj_at'_def state_refs_of'_def projectKOs)
-  done
+   apply (drule_tac tp=SCTcb and x=p and y=p' in sym_refsE;
+          force simp: get_refs_def2 state_refs_of'_def projectKOs opt_map_left_Some refs_of_rev'
+                dest: pspace_alignedD' pspace_distinctD' split: if_split_asm option.split_asm)+
+  by (drule_tac tp=TCBSchedContext and x=p' and y=p in sym_refsE;
+      force simp: get_refs_def2 state_refs_of'_def projectKOs opt_map_left_Some refs_of_rev'
+               dest: pspace_alignedD' pspace_distinctD' split: if_split_asm option.split_asm)+
 
-lemma TCBSchedContext_state_refs_of':
-  "(scp, TCBSchedContext) \<in> state_refs_of' s p = obj_at' (\<lambda>ko. tcbSchedContext ko = Some scp) p s"
+lemma sym_refs_scReplies:
+  "\<lbrakk>sym_refs (state_refs_of' s); pspace_aligned' s; pspace_distinct' s\<rbrakk>
+   \<Longrightarrow> sym_heap_scReplies s"
+  apply (clarsimp simp: sym_heap_def)
   apply (rule iffI)
-   apply (clarsimp simp: state_refs_of'_def split: option.splits if_splits)
-   apply (rename_tac ko, case_tac ko; simp add: get_refs_def2)
-     apply (fastforce dest: prod_in_refsD)
-    apply (fastforce dest: prod_in_refsD)
-   apply (erule disjE, fastforce dest: prod_in_refsD)
-   apply (clarsimp simp: obj_at'_def projectKOs tcb_bound_refs'_def get_refs_def2)
-  apply (clarsimp simp: obj_at'_def state_refs_of'_def projectKOs)
-  done
-
-lemma SCReply_state_refs_of':
-  "(r, SCReply) \<in> state_refs_of' s p = obj_at' (\<lambda>ko. scReply ko = Some r) p s"
-  apply (rule iffI)
-   apply (clarsimp simp: state_refs_of'_def split: option.splits if_splits)
-   apply (rename_tac ko, case_tac ko; simp add: get_refs_def2)
-     apply (fastforce dest: prod_in_refsD)+
-   apply (clarsimp simp: obj_at'_def projectKOs tcb_bound_refs'_def get_refs_def2)
-  apply (clarsimp simp: obj_at'_def state_refs_of'_def projectKOs)
-  done
-
-lemma ReplySchedContext_state_refs_of':
-  "(scp, ReplySchedContext) \<in> state_refs_of' s p = obj_at' (\<lambda>ko. replyNext ko = Some (Head scp)) p s"
-  apply (rule iffI)
-   apply (clarsimp simp: state_refs_of'_def split: option.splits if_splits)
-   apply (rename_tac ko, case_tac ko; simp add: get_refs_def2)
-     apply (fastforce dest: prod_in_refsD)+
-   apply (clarsimp simp: obj_at'_def projectKOs tcb_bound_refs'_def get_refs_def2)
-  apply (clarsimp simp: obj_at'_def state_refs_of'_def projectKOs)
-  done
-
-lemma TCBSC_pred_map_state_refs_of':
-  "\<lbrakk>pred_map_eq scp (tcb_scs_of' s) p; pspace_aligned' s; pspace_distinct' s\<rbrakk>
-   \<Longrightarrow> (scp, TCBSchedContext) \<in> state_refs_of' s p"
-  apply (clarsimp simp: TCBSchedContext_state_refs_of' tcb_scs_of_pred_map_equiv)
-  apply (clarsimp simp: pred_map_eq tcb_of'_def)
-  apply (rule KOTCB_tcb_at'; simp)
-  apply (case_tac v'a; clarsimp)
-  done
-
-lemma SCTcb_pred_map_state_refs_of':
-  "\<lbrakk>pred_map_eq r (scTCBs_of s) scp; pspace_aligned' s; pspace_distinct' s\<rbrakk>
-   \<Longrightarrow> (r, SCTcb) \<in> state_refs_of' s scp"
-  apply (subgoal_tac "sc_at' scp s")
-   apply (clarsimp simp: pred_map_eq state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_sc
-                         tcb_of'_Some)
-  apply (erule (1) KOSC_sc_at'[rotated])
-  apply (clarsimp simp: pred_map_eq projectKO_sc)
-  done
-
-lemma SCReply_pred_map_state_refs_of':
-  "\<lbrakk>pred_map_eq r (scReplies_of s) p; pspace_aligned' s; pspace_distinct' s\<rbrakk>
-   \<Longrightarrow> (r, SCReply) \<in> state_refs_of' s p"
-  apply (subgoal_tac "sc_at' p s")
-   apply (clarsimp simp: pred_map_eq state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_sc
-                         tcb_of'_Some)
-  apply (erule (1) KOSC_sc_at'[rotated])
-  apply (clarsimp simp: pred_map_eq projectKO_sc)
-  done
-
-lemma ReplySC_pred_map_state_refs_of':
-  "\<lbrakk>pred_map_eq scp (replySCs_of s) r; pspace_aligned' s; pspace_distinct' s\<rbrakk>
-   \<Longrightarrow> (scp, ReplySchedContext) \<in> state_refs_of' s r"
-  apply (subgoal_tac "reply_at' r s")
-   apply (clarsimp simp: pred_map_eq state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_reply)
-  apply (erule (1) KOReply_reply_at'[rotated])
-  apply (clarsimp simp: pred_map_eq projectKO_reply)
-  done
-
-lemma invs'_tcbs_scs_sym_refs:
-  "\<lbrakk>sym_refs (state_refs_of' s); pspace_aligned' s; pspace_distinct' s; valid_objs' s\<rbrakk>
-   \<Longrightarrow> tcbs_scs_sym_refs s"
-  apply (clarsimp simp: sym_heapd_def2)
-  apply (intro conjI impI allI)
-   apply (frule (2) TCBSC_pred_map_state_refs_of')
-   apply (frule (1) sym_refsD, simp add: SCTcb_state_refs_of' sc_tcbs_of_pred_map_equiv)
-  apply (frule (2) SCTcb_pred_map_state_refs_of')
-   apply (frule (1) sym_refsD, simp add: TCBSchedContext_state_refs_of' tcb_scs_of_pred_map_equiv)
-  done
-
-lemma sym_refs_replies_scs:
-  "\<lbrakk>sym_refs (state_refs_of' s); pspace_aligned' s; pspace_distinct' s; valid_objs' s\<rbrakk>
-   \<Longrightarrow> replies_scs_sym_refs s"
-  apply (clarsimp simp: sym_heapd_def2)
-  apply (intro conjI impI allI)
-   apply (frule (2) SCReply_pred_map_state_refs_of')
-   apply (frule (1) sym_refsD, simp add: ReplySchedContext_state_refs_of' replySCs_of_pred_map_equiv)
-  apply (frule (2) ReplySC_pred_map_state_refs_of')
-   apply (frule (1) sym_refsD, simp add: SCReply_state_refs_of' scReplies_of_pred_map_equiv)
-  done
+   apply (drule_tac tp=ReplySchedContext and x=p and y=p' in sym_refsE;
+          force simp: get_refs_def2 state_refs_of'_def projectKOs opt_map_left_Some refs_of_rev'
+                dest: pspace_alignedD' pspace_distinctD' split: if_split_asm option.split_asm)+
+  by (drule_tac tp=SCReply and x=p' and y=p in sym_refsE;
+      force simp: get_refs_def2 state_refs_of'_def projectKOs opt_map_left_Some refs_of_rev'
+               dest: pspace_alignedD' pspace_distinctD' split: if_split_asm option.split_asm)+
 
 lemma setSchedContext_scTCBs_of:
   "\<lbrace>\<lambda>s. P (\<lambda>a. if a = scPtr then scTCB sc else scTCBs_of s a)\<rbrace>
@@ -4294,10 +4151,10 @@ lemma getObject_tcb_wp:
                      split_def objBits_simps' loadObject_default_def
                      projectKOs obj_at'_def in_magnitude_check)
 
-lemma threadSet_tcb_scs_of':
-  "\<lbrace>\<lambda>s. P (\<lambda>a. if a = t then tcbSchedContext (f (the (tcbs_of' s a))) else tcb_scs_of' s a)\<rbrace>
+lemma threadSet_tcbSCs_of:
+  "\<lbrace>\<lambda>s. P (\<lambda>a. if a = t then tcbSchedContext (f (the (tcbs_of' s a))) else tcbSCs_of s a)\<rbrace>
    threadSet f t
-   \<lbrace>\<lambda>_ s. P (tcb_scs_of' s)\<rbrace>"
+   \<lbrace>\<lambda>_ s. P (tcbSCs_of s)\<rbrace>"
   unfolding threadSet_def
   apply (wpsimp wp: setObject_tcb_wp getObject_tcb_wp)
   apply (clarsimp simp: tcb_at'_ex_eq_all)
@@ -4305,27 +4162,19 @@ lemma threadSet_tcb_scs_of':
   apply (clarsimp simp: opt_map_def obj_at'_real_def ko_wp_at'_def projectKOs)
   done
 
-lemma pred_map_eq_inj:
-  "pred_map_eq val1 h p \<Longrightarrow> pred_map_eq val2 h p \<Longrightarrow> val1 = val2"
-  by (clarsimp simp: pred_map_eq)
+lemma shows
+  replyNexts_Some_replySCs_None:
+  "replyNexts_of s rp \<noteq> None \<Longrightarrow> replySCs_of s rp = None" and
+  replySCs_Some_replyNexts_None:
+  "replySCs_of s rp \<noteq> None \<Longrightarrow> replyNexts_of s rp = None"
+  by (clarsimp simp: opt_map_def projectKOs split: option.splits reply_next.splits)+
 
-lemma replyNexts_Some_replySCs_None:
-  "replyNexts_of s rPtr \<noteq> None \<Longrightarrow> replySCs_of s rPtr = None"
-   by (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def split: option.split)
-
-lemma sym_heapd_remove_only:
-  "\<lbrakk> sym_heapd h1 h2; pred_map_eq x h2 y \<rbrakk> \<Longrightarrow>
-   sym_heapd (\<lambda>a. if a = x then None else h1 a) (\<lambda>a. if a = y then None else h2 a)"
-  apply (clarsimp simp: sym_heapd_def2 pred_map_eq_upd)
-  apply (intro conjI allI; rule contrapos_imp; intro impI)
-  apply (erule allE2)
-  apply (drule (1) mp)
-   apply (simp add: pred_map_eq_def pred_map_def )
-  apply (rule allE2[where P="\<lambda>a b. pred_map_eq b h2 a \<longrightarrow> R a b h1" for R], assumption)
-  apply (drule (1) mp[rotated])
-  apply (erule allE2[where P="\<lambda>a b. pred_map_eq b h2 a \<longrightarrow> R a b h1" for R])
-  apply (drule (1) mp[rotated])
-   apply (simp only: pred_map_eq_def pred_map_def, clarsimp)
+lemma sym_heap_remove_only:
+  "\<lbrakk> sym_heap h1 h2; h2 y = Some x \<rbrakk> \<Longrightarrow>
+   sym_heap (\<lambda>a. if a = x then None else h1 a) (\<lambda>a. if a = y then None else h2 a)"
+  supply opt_mapE [rule del]
+  apply (clarsimp simp: sym_heap_def)
+  apply (subst (asm) sym_heap_symmetric[simplified sym_heap_def], simp)
   done
 
 end

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -766,14 +766,6 @@ lemma setObject_reply_replies_of'[wp]:
   \<lbrace>\<lambda>_ s. P' (replies_of' s)\<rbrace>"
   by setObject_easy_cases
 
-lemma setObject_endpoint_scs_of'[wp]:
-  "setObject c (endpoint::endpoint) \<lbrace>\<lambda>s. P' (scs_of' s)\<rbrace>"
-  by setObject_easy_cases
-
-lemma setObject_notification_scs_of'[wp]:
-  "setObject c (notification::notification) \<lbrace>\<lambda>s. P' (scs_of' s)\<rbrace>"
-  by setObject_easy_cases
-
 \<comment>\<open>
   Warning: this may not be a weakest precondition. `setObject c`
   asserts that there's already a correctly-typed object at `c`,
@@ -787,13 +779,13 @@ lemma setObject_sched_context_scs_of'[wp]:
   \<lbrace>\<lambda>_ s. P' (scs_of' s)\<rbrace>"
   by setObject_easy_cases
 
-lemma setObject_cte_scs_of'[wp]:
+lemma setObject_scs_of'[wp]:
   "setObject c (cte::cte) \<lbrace>\<lambda>s. P' (scs_of' s)\<rbrace>"
-  by setObject_easy_cases
-
-lemma setObject_reply_scs_of'[wp]:
   "setObject c (reply::reply) \<lbrace>\<lambda>s. P' (scs_of' s)\<rbrace>"
-  by setObject_easy_cases
+  "setObject c (tcb::tcb) \<lbrace>\<lambda>s. P' (scs_of' s)\<rbrace>"
+  "setObject c (notification::notification) \<lbrace>\<lambda>s. P' (scs_of' s)\<rbrace>"
+  "setObject c (endpoint::endpoint) \<lbrace>\<lambda>s. P' (scs_of' s)\<rbrace>"
+  by setObject_easy_cases+
 
 lemmas setReply_replies_of' = setObject_reply_replies_of'[folded setReply_def]
 
@@ -4001,11 +3993,25 @@ lemma cross_relF:
   "(s, s') \<in> state_relation \<Longrightarrow> cross_rel A B \<Longrightarrow> A s \<Longrightarrow> B s'"
   by (clarsimp simp: cross_rel_def)
 
-lemma valid_simple'[simp]:
+lemma tcb_of'_tcb[simp]:
+  "tcb_of' (KOTCB t) = Some t"
+  by (clarsimp simp: tcb_of'_def)+
+
+lemma tcb_of'_not_tcb[simp]:
+  "tcb_of' (KOEndpoint e) = None"
+  "tcb_of' (KONotification n) = None"
+  "tcb_of' (KOCTE c) = None"
+  "tcb_of' (KOSchedContext sc) = None"
+  "tcb_of' (KOReply r) = None"
+  by (clarsimp simp: tcb_of'_def)+
+
+lemma valid_tcb_state'_simps[simp]:
   "valid_tcb_state' Running = \<top>"
   "valid_tcb_state' Inactive = \<top>"
   "valid_tcb_state' Restart = \<top>"
   "valid_tcb_state' IdleThreadState = \<top>"
+  "valid_tcb_state' (BlockedOnSend ref b c d e) = ep_at' ref"
+  "valid_tcb_state' (BlockedOnReply r) = valid_bound_reply' r"
   by (rule ext, simp add: valid_tcb_state'_def)+
 
 lemma tcb_at'_ex1_ko_at':
@@ -4028,6 +4034,298 @@ lemma threadGet_getObject:
                          return (f x)
                    od"
   apply (simp add: threadGet_def threadRead_def oliftM_def getObject_def[symmetric])
+  done
+
+lemma obj_at'_typ_at'[elim!]:
+  "obj_at' (P :: ('a :: pspace_storable) \<Rightarrow> bool) p s \<Longrightarrow>
+   obj_at' (\<top> :: ('a :: pspace_storable) \<Rightarrow> bool) p s"
+  by (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
+
+lemma sc_tcbs_of_pred_map_equiv:
+  "obj_at' (\<lambda>x. scTCB x = Some t) p s = 
+   (sc_at' p s \<and> pred_map_eq t (scTCBs_of s) p)"
+  by (intro iffI; clarsimp simp: obj_at'_real_def ko_wp_at'_def pred_map_eq
+                                 projectKOs opt_map_def)
+
+lemma tcb_scs_of_pred_map_equiv:
+  "obj_at' (\<lambda>x. tcbSchedContext x = Some sc) p s = 
+   (tcb_at' p s \<and> pred_map_eq sc (tcb_scs_of' s) p)"
+  by (intro iffI; clarsimp simp: obj_at'_real_def ko_wp_at'_def pred_map_eq
+                                 projectKOs opt_map_def)
+
+lemma replySCs_of_pred_map_equiv:
+  "obj_at' (\<lambda>a. replyNext a = Some (Head sc)) p s = 
+   (reply_at' p s \<and> pred_map_eq sc (replySCs_of s) p)"
+  by (intro iffI; clarsimp simp: obj_at'_real_def ko_wp_at'_def pred_map_eq
+                                 projectKOs opt_map_def)
+
+lemma scReplies_of_pred_map_equiv:
+  "obj_at' (\<lambda>a. scReply a = Some sc) p s = 
+   (sc_at' p s \<and> pred_map_eq sc (scReplies_of s) p)"
+  by (intro iffI; clarsimp simp: obj_at'_real_def ko_wp_at'_def pred_map_eq
+                                 projectKOs opt_map_def)
+
+lemma tcbs_scs_sym_refs_equiv:
+  "\<lbrakk>tcbs_scs_sym_refs s; valid_objs' s; sc_at' p s \<or> tcb_at' p s\<rbrakk> \<Longrightarrow>
+   obj_at' (\<lambda>x. scTCB x = Some t) p s = obj_at' (\<lambda>x. tcbSchedContext x = Some p) t s"
+  apply (rule iffI; subgoal_tac "sc_at' p s \<and> tcb_at' t s", clarsimp)
+     apply (clarsimp simp: sc_tcbs_of_pred_map_equiv tcb_scs_of_pred_map_equiv sym_heapd_def)
+    apply (frule obj_at'_typ_at', simp)
+    apply (frule obj_at_ko_at', clarsimp)
+    apply (frule (1) sc_ko_at_valid_objs_valid_sc')
+    apply (clarsimp simp: valid_sched_context'_def)
+   apply (clarsimp simp: sc_tcbs_of_pred_map_equiv tcb_scs_of_pred_map_equiv sym_heapd_def)
+  apply (frule obj_at'_typ_at', simp)
+  apply (frule obj_at_ko_at', clarsimp)
+  apply (frule (1) tcb_ko_at_valid_objs_valid_tcb')
+  apply (clarsimp simp: valid_tcb'_def)
+  done
+
+lemma not_idle_scTCB:
+  "\<lbrakk>tcbs_scs_sym_refs s; valid_objs' s; valid_idle' s; p \<noteq> idle_sc_ptr; sc_at' p s\<rbrakk> \<Longrightarrow>
+   obj_at' (\<lambda>x. scTCB x \<noteq> Some idle_thread_ptr) p s"
+  apply (subgoal_tac "\<not>obj_at' (\<lambda>x. scTCB x = Some idle_thread_ptr) p s")
+   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
+  apply (subst (asm) sym_heapd_sym)
+  apply (clarsimp simp: sc_tcbs_of_pred_map_equiv sym_heapd_def)
+  apply (clarsimp simp: valid_idle'_def obj_at'_real_def ko_wp_at'_def idle_tcb'_def pred_map_eq
+                        projectKOs)
+  done
+
+lemma not_idle_tcbSC:
+  "\<lbrakk>tcbs_scs_sym_refs s; valid_objs' s; valid_idle' s; p \<noteq> idle_thread_ptr; tcb_at' p s\<rbrakk> \<Longrightarrow>
+   obj_at' (\<lambda>x. tcbSchedContext x \<noteq> Some idle_sc_ptr) p s"
+  apply (subgoal_tac "\<not>obj_at' (\<lambda>x. tcbSchedContext x = Some idle_sc_ptr) p s")
+   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
+  apply (clarsimp simp: tcb_scs_of_pred_map_equiv sym_heapd_def)
+  apply (clarsimp simp: valid_idle'_def obj_at'_real_def ko_wp_at'_def idle_tcb'_def pred_map_eq
+                        projectKOs)
+  done
+
+lemma setObject_tcb_tcbs_of':
+  "\<lbrace>\<lambda>s. P' ((tcbs_of' s)(c \<mapsto> tcb))\<rbrace>
+  setObject c (tcb::tcb)
+  \<lbrace>\<lambda>_ s. P' (tcbs_of' s)\<rbrace>"
+  by (setObject_easy_cases, clarsimp simp: ARM_H.fromPPtr_def)
+
+lemma setObject_other_tcbs_of'[wp]:
+  "setObject c (r::reply) \<lbrace>\<lambda>s. P' (tcbs_of' s)\<rbrace>"
+  "setObject c (e::endpoint) \<lbrace>\<lambda>s. P' (tcbs_of' s)\<rbrace>"
+  "setObject c (n::notification) \<lbrace>\<lambda>s. P' (tcbs_of' s)\<rbrace>"
+  "setObject c (sc::sched_context) \<lbrace>\<lambda>s. P' (tcbs_of' s)\<rbrace>"
+  by setObject_easy_cases+
+
+lemma setObject_cte_tcb_scs_of'[wp]:
+  "setObject c (reply::cte) \<lbrace>\<lambda>s. P' (tcb_scs_of' s)\<rbrace>"
+  by setObject_easy_cases
+
+lemma threadSet_tcb_scs_of'_inv:
+  "\<forall>x. tcbSchedContext (f x) = tcbSchedContext x \<Longrightarrow>
+  threadSet f t \<lbrace>\<lambda>s. P (tcb_scs_of' s)\<rbrace>"
+  unfolding threadSet_def
+  apply (rule hoare_seq_ext[OF _ get_tcb_sp'])
+  apply (wpsimp wp: setObject_tcb_tcbs_of')
+  apply (erule subst[where P=P, rotated], rule ext)
+  apply (clarsimp simp: opt_map_def obj_at'_real_def ko_wp_at'_def projectKO_tcb
+                 split: option.splits)
+  done
+
+lemma KOTCB_tcb_at':
+  "\<exists>v'. ksPSpace s p = Some (KOTCB v') \<Longrightarrow> pspace_aligned' s \<Longrightarrow> pspace_distinct' s \<Longrightarrow> tcb_at' p s"
+  apply (clarsimp simp: pred_map_def state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_tcb
+                        tcb_of'_Some)
+  apply (intro conjI)
+   apply (erule (1) pspace_alignedD')
+  apply (erule (1) pspace_distinctD')
+  done
+
+lemma KOSC_sc_at':
+  "\<exists>v'. ksPSpace s p = Some (KOSchedContext v') \<Longrightarrow> pspace_aligned' s \<Longrightarrow> pspace_distinct' s \<Longrightarrow> sc_at' p s"
+  apply (clarsimp simp: pred_map_def state_refs_of'_def obj_at'_real_def ko_wp_at'_def)
+  apply (intro conjI)
+   apply (erule (1) pspace_alignedD')
+  apply (erule (1) pspace_distinctD')
+  done
+
+lemma KOReply_reply_at':
+  "\<exists>v'. ksPSpace s p = Some (KOReply v') \<Longrightarrow> pspace_aligned' s \<Longrightarrow> pspace_distinct' s \<Longrightarrow> reply_at' p s"
+  apply (clarsimp simp: pred_map_def state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_reply
+                        tcb_of'_Some)
+  apply (intro conjI)
+   apply (erule (1) pspace_alignedD')
+  apply (erule (1) pspace_distinctD')
+  done
+
+(* FIXME RT: maybe move? *)
+lemma prod_in_refsD:
+  "\<And>ref x y. (x, ref) \<in> ep_q_refs_of' y \<Longrightarrow> ref \<in> {EPRecv, EPSend}"
+  "\<And>ref x y. (x, ref) \<in> ntfn_q_refs_of' y \<Longrightarrow> ref \<in> {NTFNSignal}"
+  "\<And>ref x y. (x, ref) \<in> tcb_st_refs_of' y \<Longrightarrow> ref \<in> {TCBBlockedRecv, TCBReply, TCBSignal, TCBBlockedSend}"
+  "\<And>ref x a b c. (x, ref) \<in> tcb_bound_refs' a b c \<Longrightarrow> ref \<in> {TCBBound, TCBSchedContext, TCBYieldTo}"
+  apply (rename_tac ep; case_tac ep; simp)
+  apply (rename_tac ep; case_tac ep; simp)
+  apply (rename_tac ep; case_tac ep; clarsimp split: if_splits)
+  apply (clarsimp simp: tcb_bound_refs'_def get_refs_def2)
+  done
+
+lemma SCTcb_state_refs_of':
+  "(p, SCTcb) \<in> state_refs_of' s scp = obj_at' (\<lambda>ko. scTCB ko = Some p) scp s"
+  apply (rule iffI)
+   apply (clarsimp simp: state_refs_of'_def split: option.splits if_splits)
+   apply (rename_tac ko, case_tac ko; simp add: get_refs_def2)
+      apply (fastforce dest: prod_in_refsD)+
+   apply (clarsimp simp: obj_at'_def projectKOs)
+  apply (clarsimp simp: obj_at'_def state_refs_of'_def projectKOs)
+  done
+
+lemma TCBSchedContext_state_refs_of':
+  "(scp, TCBSchedContext) \<in> state_refs_of' s p = obj_at' (\<lambda>ko. tcbSchedContext ko = Some scp) p s"
+  apply (rule iffI)
+   apply (clarsimp simp: state_refs_of'_def split: option.splits if_splits)
+   apply (rename_tac ko, case_tac ko; simp add: get_refs_def2)
+     apply (fastforce dest: prod_in_refsD)
+    apply (fastforce dest: prod_in_refsD)
+   apply (erule disjE, fastforce dest: prod_in_refsD)
+   apply (clarsimp simp: obj_at'_def projectKOs tcb_bound_refs'_def get_refs_def2)
+  apply (clarsimp simp: obj_at'_def state_refs_of'_def projectKOs)
+  done
+
+lemma SCReply_state_refs_of':
+  "(r, SCReply) \<in> state_refs_of' s p = obj_at' (\<lambda>ko. scReply ko = Some r) p s"
+  apply (rule iffI)
+   apply (clarsimp simp: state_refs_of'_def split: option.splits if_splits)
+   apply (rename_tac ko, case_tac ko; simp add: get_refs_def2)
+     apply (fastforce dest: prod_in_refsD)+
+   apply (clarsimp simp: obj_at'_def projectKOs tcb_bound_refs'_def get_refs_def2)
+  apply (clarsimp simp: obj_at'_def state_refs_of'_def projectKOs)
+  done
+
+lemma ReplySchedContext_state_refs_of':
+  "(scp, ReplySchedContext) \<in> state_refs_of' s p = obj_at' (\<lambda>ko. replyNext ko = Some (Head scp)) p s"
+  apply (rule iffI)
+   apply (clarsimp simp: state_refs_of'_def split: option.splits if_splits)
+   apply (rename_tac ko, case_tac ko; simp add: get_refs_def2)
+     apply (fastforce dest: prod_in_refsD)+
+   apply (clarsimp simp: obj_at'_def projectKOs tcb_bound_refs'_def get_refs_def2)
+  apply (clarsimp simp: obj_at'_def state_refs_of'_def projectKOs)
+  done
+
+lemma TCBSC_pred_map_state_refs_of':
+  "\<lbrakk>pred_map_eq scp (tcb_scs_of' s) p; pspace_aligned' s; pspace_distinct' s\<rbrakk>
+   \<Longrightarrow> (scp, TCBSchedContext) \<in> state_refs_of' s p"
+  apply (clarsimp simp: TCBSchedContext_state_refs_of' tcb_scs_of_pred_map_equiv)
+  apply (clarsimp simp: pred_map_eq tcb_of'_def)
+  apply (rule KOTCB_tcb_at'; simp)
+  apply (case_tac v'a; clarsimp)
+  done
+
+lemma SCTcb_pred_map_state_refs_of':
+  "\<lbrakk>pred_map_eq r (scTCBs_of s) scp; pspace_aligned' s; pspace_distinct' s\<rbrakk>
+   \<Longrightarrow> (r, SCTcb) \<in> state_refs_of' s scp"
+  apply (subgoal_tac "sc_at' scp s")
+   apply (clarsimp simp: pred_map_eq state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_sc
+                         tcb_of'_Some)
+  apply (erule (1) KOSC_sc_at'[rotated])
+  apply (clarsimp simp: pred_map_eq projectKO_sc)
+  done
+
+lemma SCReply_pred_map_state_refs_of':
+  "\<lbrakk>pred_map_eq r (scReplies_of s) p; pspace_aligned' s; pspace_distinct' s\<rbrakk>
+   \<Longrightarrow> (r, SCReply) \<in> state_refs_of' s p"
+  apply (subgoal_tac "sc_at' p s")
+   apply (clarsimp simp: pred_map_eq state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_sc
+                         tcb_of'_Some)
+  apply (erule (1) KOSC_sc_at'[rotated])
+  apply (clarsimp simp: pred_map_eq projectKO_sc)
+  done
+
+lemma ReplySC_pred_map_state_refs_of':
+  "\<lbrakk>pred_map_eq scp (replySCs_of s) r; pspace_aligned' s; pspace_distinct' s\<rbrakk>
+   \<Longrightarrow> (scp, ReplySchedContext) \<in> state_refs_of' s r"
+  apply (subgoal_tac "reply_at' r s")
+   apply (clarsimp simp: pred_map_eq state_refs_of'_def obj_at'_real_def ko_wp_at'_def projectKO_reply)
+  apply (erule (1) KOReply_reply_at'[rotated])
+  apply (clarsimp simp: pred_map_eq projectKO_reply)
+  done
+
+lemma invs'_tcbs_scs_sym_refs:
+  "\<lbrakk>sym_refs (state_refs_of' s); pspace_aligned' s; pspace_distinct' s; valid_objs' s\<rbrakk>
+   \<Longrightarrow> tcbs_scs_sym_refs s"
+  apply (clarsimp simp: sym_heapd_def2)
+  apply (intro conjI impI allI)
+   apply (frule (2) TCBSC_pred_map_state_refs_of')
+   apply (frule (1) sym_refsD, simp add: SCTcb_state_refs_of' sc_tcbs_of_pred_map_equiv)
+  apply (frule (2) SCTcb_pred_map_state_refs_of')
+   apply (frule (1) sym_refsD, simp add: TCBSchedContext_state_refs_of' tcb_scs_of_pred_map_equiv)
+  done
+
+lemma sym_refs_replies_scs:
+  "\<lbrakk>sym_refs (state_refs_of' s); pspace_aligned' s; pspace_distinct' s; valid_objs' s\<rbrakk>
+   \<Longrightarrow> replies_scs_sym_refs s"
+  apply (clarsimp simp: sym_heapd_def2)
+  apply (intro conjI impI allI)
+   apply (frule (2) SCReply_pred_map_state_refs_of')
+   apply (frule (1) sym_refsD, simp add: ReplySchedContext_state_refs_of' replySCs_of_pred_map_equiv)
+  apply (frule (2) ReplySC_pred_map_state_refs_of')
+   apply (frule (1) sym_refsD, simp add: SCReply_state_refs_of' scReplies_of_pred_map_equiv)
+  done
+
+lemma setSchedContext_scTCBs_of:
+  "\<lbrace>\<lambda>s. P (\<lambda>a. if a = scPtr then scTCB sc else scTCBs_of s a)\<rbrace>
+   setSchedContext scPtr sc
+   \<lbrace>\<lambda>_ s. P (scTCBs_of s)\<rbrace>"
+  unfolding setSchedContext_def
+  apply (wpsimp wp: setObject_sc_wp)
+  apply (erule back_subst[where P=P], rule ext)
+  by (clarsimp simp: opt_map_def)
+
+lemma setSchedContext_scReplies_of:
+  "\<lbrace>\<lambda>s. P (\<lambda>a. if a = scPtr then scReply sc else scReplies_of s a)\<rbrace>
+   setSchedContext scPtr sc
+   \<lbrace>\<lambda>_ s. P (scReplies_of s)\<rbrace>"
+  unfolding setSchedContext_def
+  apply (wpsimp wp: setObject_sc_wp)
+  apply (erule back_subst[where P=P], rule ext)
+  by (clarsimp simp: opt_map_def)
+
+lemma getObject_tcb_wp:
+  "\<lbrace>\<lambda>s. tcb_at' p s \<longrightarrow> (\<exists>t::tcb. ko_at' t p s \<and> Q t s)\<rbrace> getObject p \<lbrace>Q\<rbrace>"
+  by (clarsimp simp: getObject_def valid_def in_monad
+                     split_def objBits_simps' loadObject_default_def
+                     projectKOs obj_at'_def in_magnitude_check)
+
+lemma threadSet_tcb_scs_of':
+  "\<lbrace>\<lambda>s. P (\<lambda>a. if a = t then tcbSchedContext (f (the (tcbs_of' s a))) else tcb_scs_of' s a)\<rbrace>
+   threadSet f t
+   \<lbrace>\<lambda>_ s. P (tcb_scs_of' s)\<rbrace>"
+  unfolding threadSet_def
+  apply (wpsimp wp: setObject_tcb_wp getObject_tcb_wp)
+  apply (clarsimp simp: tcb_at'_ex_eq_all)
+  apply (erule back_subst[where P=P], rule ext)
+  apply (clarsimp simp: opt_map_def obj_at'_real_def ko_wp_at'_def projectKOs)
+  done
+
+lemma pred_map_eq_inj:
+  "pred_map_eq val1 h p \<Longrightarrow> pred_map_eq val2 h p \<Longrightarrow> val1 = val2"
+  by (clarsimp simp: pred_map_eq)
+
+lemma replyNexts_Some_replySCs_None:
+  "replyNexts_of s rPtr \<noteq> None \<Longrightarrow> replySCs_of s rPtr = None"
+   by (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs opt_map_def split: option.split)
+
+lemma sym_heapd_remove_only:
+  "\<lbrakk> sym_heapd h1 h2; pred_map_eq x h2 y \<rbrakk> \<Longrightarrow>
+   sym_heapd (\<lambda>a. if a = x then None else h1 a) (\<lambda>a. if a = y then None else h2 a)"
+  apply (clarsimp simp: sym_heapd_def2 pred_map_eq_upd)
+  apply (intro conjI allI; rule contrapos_imp; intro impI)
+  apply (erule allE2)
+  apply (drule (1) mp)
+   apply (simp add: pred_map_eq_def pred_map_def )
+  apply (rule allE2[where P="\<lambda>a b. pred_map_eq b h2 a \<longrightarrow> R a b h1" for R], assumption)
+  apply (drule (1) mp[rotated])
+  apply (erule allE2[where P="\<lambda>a b. pred_map_eq b h2 a \<longrightarrow> R a b h1" for R])
+  apply (drule (1) mp[rotated])
+   apply (simp only: pred_map_eq_def pred_map_def, clarsimp)
   done
 
 end

--- a/proof/refine/ARM/SchedContext_R.thy
+++ b/proof/refine/ARM/SchedContext_R.thy
@@ -594,7 +594,6 @@ lemma schedContextDonate_valid_objs':
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   (is "valid ?pre _ _")
   apply (clarsimp simp: schedContextDonate_def)
-  apply (rule hoare_seq_ext[OF _ stateAssert_sp])
   apply (rule hoare_seq_ext[OF _ get_sc_sp'], rename_tac sc)
   apply (rule_tac Q="?pre and valid_sched_context' sc and K (valid_sched_context_size' sc) and sc_at' scPtr"
                in hoare_weaken_pre[rotated])

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -101,7 +101,7 @@ lemma tcbSchedAppend_corres:
           (tcb_sched_action (tcb_sched_append) t) (tcbSchedAppend t)"
   apply (rule corres_cross_back[where P="tcb_at t" and P'="tcb_at' t"])
     apply (fastforce dest: pspace_relation_tcb_at
-                     simp: state_relation_def tcb_of'_def opt_map_def obj_at'_def projectKOs
+                     simp: state_relation_def opt_map_def obj_at'_def projectKOs
                     split: option.splits)
    apply simp
   apply (simp only: tcbSchedAppend_def tcb_sched_action_def)
@@ -1226,7 +1226,7 @@ lemma scheduleTCB_rct:
 lemma setThreadState_rct:
   "\<lbrace>\<lambda>s. (t = ksCurThread s \<longrightarrow> runnable' st
       \<and> pred_map (\<lambda>tcb. \<not>(tcbInReleaseQueue tcb)) (tcbs_of' s) t
-      \<and> pred_map (\<lambda>scPtr. isScActive scPtr s) (tcb_scs_of' s) t)
+      \<and> pred_map (\<lambda>scPtr. isScActive scPtr s) (tcbSCs_of s) t)
         \<and> ksSchedulerAction s = ResumeCurrentThread\<rbrace>
    setThreadState st t
    \<lbrace>\<lambda>_ s. ksSchedulerAction s = ResumeCurrentThread\<rbrace>"
@@ -1540,7 +1540,7 @@ lemma runnable_cross_rel:
   apply (clarsimp simp: other_obj_relation_def split: option.splits)
   apply (case_tac "ko"; simp)
   apply (rule_tac x="x6" in exI)
-  apply (clarsimp simp: tcb_of'_def opt_map_def)
+  apply (clarsimp simp: opt_map_def)
   apply (clarsimp simp: tcb_relation_def thread_state_relation_def)
   apply (case_tac "tcb_state b"; simp add: runnable_def)
   apply clarsimp
@@ -1559,7 +1559,7 @@ lemma tcbInReleaseQueue_cross_rel:
   apply (clarsimp simp: other_obj_relation_def split: option.splits)
   apply (case_tac "koa"; simp)
   apply (rule_tac x="x6" in exI)
-  apply (clarsimp simp: tcb_of'_def opt_map_def)
+  apply (clarsimp simp: opt_map_def)
   apply (subgoal_tac "obj_at' tcbInReleaseQueue t s'")
   apply (subgoal_tac "release_queue_relation (release_queue s) (ksReleaseQueue s')")
   apply (clarsimp simp: release_queue_relation_def not_in_release_q_def valid_release_queue'_def)
@@ -1571,7 +1571,7 @@ lemma tcbInReleaseQueue_cross_rel:
 
 lemma isScActive_cross_rel:
   "cross_rel (pspace_aligned and pspace_distinct and valid_objs and active_sc_tcb_at t)
-             (\<lambda>s'. pred_map ((\<lambda>scPtr. isScActive scPtr s')) (tcb_scs_of' s') t)"
+             (\<lambda>s'. pred_map ((\<lambda>scPtr. isScActive scPtr s')) (tcbSCs_of s') t)"
   apply (rule cross_rel_imp[OF tcb_at'_cross_rel[where t=t]])
    apply (clarsimp simp: cross_rel_def)
    apply (subgoal_tac "pspace_relation (kheap s) (ksPSpace s')")
@@ -1588,7 +1588,7 @@ lemma isScActive_cross_rel:
       apply (subgoal_tac "valid_sched_context_size n")
        apply (clarsimp simp: other_obj_relation_def split: option.splits)
        apply (clarsimp simp: obj_at'_def projectKO_eq Bits_R.projectKO_sc)
-       apply (clarsimp simp: tcb_of'_def opt_map_def tcb_relation_def)
+       apply (clarsimp simp: opt_map_def tcb_relation_def)
        apply (rule_tac x=scp in exI, simp)
        apply (clarsimp simp: isScActive_def active_sc_def)
        apply (clarsimp simp: obj_at'_def projectKO_eq Bits_R.projectKO_sc pred_map_def opt_map_def)
@@ -1644,7 +1644,7 @@ lemma guarded_switch_to_chooseThread_fragment_corres:
                          invs_valid_vs_lookup invs_unique_refs)
    apply (clarsimp simp: thread_get_def in_monad pred_tcb_at_def obj_at_def get_tcb_ko_at)
   apply (prop_tac "st_tcb_at' runnable' t s")
-   apply (clarsimp simp: pred_tcb_at'_def isSchedulable_bool_def pred_map_def obj_at'_def tcb_of'_def
+   apply (clarsimp simp: pred_tcb_at'_def isSchedulable_bool_def pred_map_def obj_at'_def
                          projectKO_eq Bits_R.projectKO_tcb
                   split: kernel_object.splits)
   by (auto elim!: pred_tcb'_weakenE split: thread_state.splits
@@ -2438,7 +2438,7 @@ lemma setSchedulerAction_ksSchedulerAction[wp]:
 lemma isSchedulable_bool_runnableE:
   "isSchedulable_bool t s \<Longrightarrow> tcb_at' t s \<Longrightarrow> st_tcb_at' runnable' t s"
   unfolding isSchedulable_bool_def
-  by (clarsimp simp: pred_tcb_at'_def obj_at'_def pred_map_def projectKO_eq projectKO_opt_tcb tcb_of'_Some)
+  by (clarsimp simp: pred_tcb_at'_def obj_at'_def pred_map_def projectKO_eq projectKO_opt_tcb)
 
 lemma rescheduleRequired_invs'[wp]:
   "rescheduleRequired \<lbrace>invs'\<rbrace>"

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -768,12 +768,6 @@ lemma setObject_tcb_valid_globals' [wp]:
    apply (wp | wp setObject_ksPSpace_only updateObject_default_inv | simp)+
   done
 
-lemma getObject_tcb_wp:
-  "\<lbrace>\<lambda>s. tcb_at' p s \<longrightarrow> (\<exists>t::tcb. ko_at' t p s \<and> Q t s)\<rbrace> getObject p \<lbrace>Q\<rbrace>"
-  by (clarsimp simp: getObject_def valid_def in_monad
-                     split_def objBits_simps' loadObject_default_def
-                     projectKOs obj_at'_def in_magnitude_check)
-
 lemma setObject_tcb_pspace_no_overlap':
   "\<lbrace>pspace_no_overlap' w s and tcb_at' t\<rbrace>
   setObject t (tcb::tcb)

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -254,7 +254,7 @@ lemma restart_invs':
               in hoare_strengthen_post[rotated])
         apply wpsimp
         apply (clarsimp simp: isSchedulable_bool_def pred_map_pred_conj[simplified pred_conj_def]
-                              projectKO_opt_tcb pred_map_def tcb_of'_Some pred_tcb_at'_def
+                              projectKO_opt_tcb pred_map_def pred_tcb_at'_def
                               obj_at'_real_def ko_wp_at'_def)
        apply (wpsimp wp: hoare_vcg_imp_lift')
       apply (rule_tac Q="\<lambda>_. invs' and

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -2446,7 +2446,8 @@ lemma tc_caps_invs':
   apply (wpsimp wp: hoare_vcg_all_lift hoare_weak_lift_imp setP_invs' setMCPriority_invs'
                     installTCBCap_invs' installThreadBuffer_invs' installTCBCap_sch_act_simple)
   apply (clarsimp cong: conj_cong)
-  apply (fastforce simp: isValidFaultHandler_def isCap_simps isValidVTableRoot_def)
+  apply (intro conjI; intro allI impI; clarsimp;
+         fastforce simp: isValidFaultHandler_def isCap_simps isValidVTableRoot_def)
   done
 
 lemma schedContextBindTCB_invs':

--- a/spec/abstract/Ipc_A.thy
+++ b/spec/abstract/Ipc_A.thy
@@ -289,8 +289,8 @@ where
                 set_endpoint epptr $ (case queue of [] \<Rightarrow> IdleEP
                                                      | _ \<Rightarrow> RecvEP queue);
                 recv_state \<leftarrow> get_thread_state dest;
-                (reply, reply_can_grant) \<leftarrow> case recv_state
-                  of (BlockedOnReceive _ reply data) \<Rightarrow> return (reply, receiver_can_grant data)
+                reply \<leftarrow> case recv_state
+                  of (BlockedOnReceive _ reply data) \<Rightarrow> return reply
                   | _ \<Rightarrow> fail;
                 do_ipc_transfer thread (Some epptr) badge can_grant dest;
                 maybeM (reply_unlink_tcb dest) reply;
@@ -298,7 +298,7 @@ where
 
                 fault \<leftarrow> thread_get tcb_fault thread;
                 if call \<or> fault \<noteq> None then
-                  if (can_grant \<or> reply_can_grant) \<and> reply \<noteq> None then
+                  if (can_grant \<or> can_grant_reply) \<and> reply \<noteq> None then
                     reply_push thread dest (the reply) can_donate
                   else
                     set_thread_state thread Inactive

--- a/spec/haskell/src/SEL4/Object/Reply.lhs
+++ b/spec/haskell/src/SEL4/Object/Reply.lhs
@@ -52,8 +52,6 @@ This module specifies the behavior of reply objects.
 
 > replyPush :: PPtr TCB -> PPtr TCB -> PPtr Reply -> Bool -> Kernel ()
 > replyPush callerPtr calleePtr replyPtr canDonate = do
->     stateAssert sym_refs_asrt
->         "replyPush: `sym_refs (state_refs_of' s)` must hold"
 >     stateAssert (valid_replies'_sc_asrt replyPtr)
 >         "replyPush: valid_replies'_sc holds for replyPtr"
 >     scPtrOptDonated <- threadGet tcbSchedContext callerPtr

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -583,8 +583,6 @@ This module uses the C preprocessor to select a target architecture.
 
 > schedContextDonate :: PPtr SchedContext -> PPtr TCB -> Kernel ()
 > schedContextDonate scPtr tcbPtr = do
->     stateAssert sym_refs_asrt
->         "Assert that `sym_refs (state_refs_of' s)` holds"
 >     sc <- getSchedContext scPtr
 >     fromOpt <- return $ scTCB sc
 >     when (fromOpt /= Nothing) $ do


### PR DESCRIPTION
I recommend reviewing commit-by-commit.

This is the same as https://github.com/seL4/l4v/pull/234 but free of all the previous comments.

**In this PR:**
1. Update send_ipc (abstract) to match source. Fix AInvs.
2. Update sendIPC to be slightly easier for refinement.
3. Remove sym_ref assertions from replyPush and schedContextDonate
  a. These assertions can actually fail in executable code.
5. Fix up refine for these changes in Haskell
6. Some slight improvements to replyPush lemmas.

**As a side effect:**
- 1 new heap
- change `sym_heap` to a definition and some related cleanup