### PR TITLE
`bump` script for `verification-manifest`

### DIFF
--- a/misc/bump/README.md
+++ b/misc/bump/README.md
@@ -76,6 +76,8 @@ merged. As soon as possible after it is merged, follow the bump script recipe
 below. If you think a proof update is required, or if you bump and regression
 subsequently fails, then flag the need for a verification patch.
 
+[testboard]: https://github.com/seL4/gh-testboard
+
 ## Verification patches
 
 A proof update for an seL4 update requires merging pull requests for both `l4v`

--- a/misc/bump/README.md
+++ b/misc/bump/README.md
@@ -89,13 +89,15 @@ sure that everything is up to date, you can skip this step.
 
 Once you're happy that both PRs have been tested and reviewed appropriately,
 both can be merged. The seL4 PR should be merged first, followed without too
-much delay by the l4v PR. As soon as both PRs are merged, follow the bump script
-recipe below.
+much delay (see below) by the l4v PR. As soon as both PRs are merged, follow the
+bump script recipe below.
 
-Don't worry if it takes too long (Bamboo checks roughly every 5 min), the only
-adverse effect is a wasted test cycle that tests the seL4 PR without the l4v PR
-and/or a failure of the preprocess test. But do try to minimise the time the
-repositories are in an inconstent state with respect to each other.
+Timing: in between the three merges, the repos are in an inconsistent state with
+respect to each other. Don't worry if the merges take too long (Bamboo checks
+roughly every 5 min), the only adverse effect is a wasted test cycle that tests
+the seL4 PR without the l4v PR and/or a failure of the preprocess test. But do
+try to minimise the time the repositories are in an inconstent state with
+respect to each other, so that others can keep working.
 
 ## Using the bump script
 
@@ -124,3 +126,13 @@ To bump the manifest:
 
 6. In the root of the `repo` checkout (i.e. parent of `l4v` directory), run
    `./l4v/misc/bump/bump-ver-manifest` and follow the prompts.
+
+## Files in this directory
+
+* `bump-ver-manifest`: for interactive use, to update `verification-manifest`
+* `ver-bump.py`: python script that backs `bump-ver-manifest`
+* `bump-local-repos`: used in CI to update the branch `successful-decompile` in
+  [HOL4][] and [polyml][] repos. Not intended for manual or interactive use.
+
+[HOL4]: https://github.com/seL4/HOL/
+[polyml]: https://github.com/seL4/polyml/

--- a/misc/bump/README.md
+++ b/misc/bump/README.md
@@ -1,0 +1,126 @@
+<!--
+     Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Verification manifest updater
+
+Herein are scripts to manually update [verification-manifest][] whenever there
+is a change to [seL4][] that cannot be automatically handled by the "preprocess"
+CI job.
+
+A manual manifest update is commonly called a *preprocess bump*.
+
+[verification-manifest]: https://github.com/seL4/verification-manifest/
+[seL4]: https://github.com/seL4/seL4/
+
+## Rationale
+
+The `devel.xml` file in the [verification-manifest][actual-manifest] tracks
+`master` for [l4v][], but is pinned to specific commits for [seL4][]. This
+allows us to freely make improvements to l4v, while keeping track of exactly
+which versions of seL4 are believed to be verified.
+
+[actual-manifest]: https://github.com/seL4/verification-manifest/blob/master/devel.xml
+[l4v]: https://github.com/seL4/l4v/
+
+However, this means that whenever seL4 is updated,
+[`devel.xml`][actual-manifest] must also be updated. There is a CI job that
+automatically performs the manifest update whenever the seL4 update does *not*
+modify what the C parser sees for the verified kernel configurations. It uses
+the [preprocess][] script to detect that case.
+
+When the seL4 update *does* make changes to the verified configurations, the
+[preprocess][] job will fail. In that case, a *bump* (manual manifest update) is
+required.
+
+[preprocess]: https://github.com/seL4/ci-actions/tree/master/preprocess
+
+## When is a bump required?
+
+There are typically two situations in which a bump is required:
+
+1. A [seL4][] pull request requires a *bump* for a change to seL4 which affects
+   the verified configurations, but which is believed not to require a proof
+   update.
+
+2. There is a proof update for an seL4 patch (usually with corresponding seL4
+   pull request), and we want to merge both the seL4 change and the proof update.
+
+## Bump requests from seL4 pull requests
+
+Some changes to verified configurations do not require proof updates. This
+includes most changes to boot code, and superficial changes which can be
+absorbed by `ccorres_rewrite`. In these cases, the preprocess test on the seL4
+pull request will fail, but the `diff` it shows in its output contains only
+proof-irrelevant changes. Usually someone on the seL4 pull request will ask for
+help from someone with verification experience.
+
+An experienced proof engineer should inspect the `diff` in the [preprocess][]
+logs for the test failure, and make a judgement about whether a proof update
+will be required. If unsure, you can run a full proof [testboard][] on the PR.
+But unless the PR is a release candidate, there is some room for error. You
+should balance the desire for quick turnaround on kernel updates against the
+desire to avoid broken verification regression and unplanned proof updates.
+
+Note that changes to boot code can cause `SimplExportAndRefine` to fail,
+particularly if the changes involve complex loops, or complex memory access
+patterns (combinations of array access with either constant index offsets or
+struct fields). In those cases, it might be worth obtaining an opinion from
+someone with `SimplExportAndRefine` experience. Otherwise, don't worry about it
+until it fails.
+
+If you think no proof update is required, approve the seL4 pull request to be
+merged. As soon as possible after it is merged, follow the bump script recipe
+below. If you think a proof update is required, or if you bump and regression
+subsequently fails, then flag the need for a verification patch.
+
+## Verification patches
+
+A proof update for an seL4 update requires merging pull requests for both `l4v`
+and `seL4`, and a manifest bump. The proof engineer who prepared the patch
+should already have made sure the seL4 pull request is rebased and tested the
+proof update against the rebased version of the seL4.
+
+It doesn't hurt to double check that the manifest displayed in the proof test
+log contains the commit hashes of the branches you want to merge, but if you are
+sure that everything is up to date, you can skip this step.
+
+Once you're happy that both PRs have been tested and reviewed appropriately,
+both can be merged. The seL4 PR should be merged first, followed without too
+much delay by the l4v PR. As soon as both PRs are merged, follow the bump script
+recipe below.
+
+Don't worry if it takes too long (Bamboo checks roughly every 5 min), the only
+adverse effect is a wasted test cycle that tests the seL4 PR without the l4v PR
+and/or a failure of the preprocess test. But do try to minimise the time the
+repositories are in an inconstent state with respect to each other.
+
+## Using the bump script
+
+The [bump script][] can be found at `l4v/misc/bump/bump-ver-manifest` in any
+checkout of [l4v][]. Unless you know `repo` well, it is advisable to keep a
+separate `repo` checkout of [verification-manifest][] that you only use for
+manifest bumps.
+
+[bump script]: https://github.com/seL4/l4v/tree/master/misc/bump/
+
+To bump the manifest:
+
+1. `repo sync` your [verification-manifest][] checkout.
+
+2. Ensure that for `l4v`, `HEAD` corresponds to current master, and that this is
+   the `l4v` commit that verifies the new `seL4` version.
+
+3. Note that for `seL4`, new commits will have been fetched from the remote, but
+   `HEAD` will still correspond to the `seL4` commit in the *current* manifest.
+
+4. In the `seL4` directory, look at `git log ^HEAD verification/master`. Check
+   that it shows exactly the commits in the `seL4` PR for which the bump is
+   required.
+
+5. In the `seL4` directory, perform `git checkout verification/master`.
+
+6. In the root of the `repo` checkout (i.e. parent of `l4v` directory), run
+   `./l4v/misc/bump/bump-ver-manifest` and follow the prompts.

--- a/misc/bump/bump-local-repos
+++ b/misc/bump/bump-local-repos
@@ -1,0 +1,87 @@
+#! /bin/bash
+#
+# Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# bumping some locally cloned repos
+
+# repos HOL4 and polyml exist as forks in the seL4 github org so that we can add
+# the branch "successful-decompile" which CI will bump on success.
+
+# three kinds of bump needed:
+#  - copy upstream master to master in clone in seL4 org
+#  - checkout master (= master in seL4 org, to begin a test)
+#  - push master to successful-decompile
+
+echo repos: ${BUMP_REPOS:=HOL4 HOL4/polyml}
+
+HOL=ssh://git@github.com/hol-theorem-prover/HOL
+POLY=ssh://git@github.com/polyml/polyml
+
+if [[ $1 == --checkout ]]
+then
+  BUMP_REMOTES=no
+  BUMP_PUSH_REMOTE=no
+  CHECKOUT=yes
+  CHECKOUT_BRANCH=$2
+  echo will checkout: ${CHECKOUT_BRANCH:=master}
+elif [[ $1 == --push ]]
+then
+  BUMP_REMOTES=no
+  BUMP_PUSH_BRANCH=$2
+fi
+
+echo remotes to fetch: ${BUMP_REMOTES:=$HOL $POLY}
+
+echo remote to push: ${BUMP_PUSH_REMOTE:=projects}
+
+if [[ $BUMP_PUSH_REMOTE != no ]]
+then
+  echo branch to push: ${BUMP_PUSH_BRANCH:=master}
+fi
+
+set -x
+
+for REPO in $BUMP_REPOS
+do
+  pushd $REPO
+
+  # repo may have left a detached git with no master
+  # creating branches will safely fail if they exist already
+
+  FIRST_KNOWN_REMOTE=$(git remote | head -n 1)
+  git fetch $FIRST_KNOWN_REMOTE
+  git branch master $FIRST_KNOWN_REMOTE/master
+  git branch recv-master master
+
+  if [[ $CHECKOUT == yes ]]
+  then
+    git checkout master
+  fi
+
+  if [[ $BUMP_REMOTES != no ]]
+  then
+    for REMOTE in $BUMP_REMOTES
+    do
+      # fetch remote master to here
+      # will fail safely if incompatible
+      if git fetch -n --dry-run $REMOTE master:recv-master
+      then
+        git fetch -n $REMOTE master:recv-master
+        git fetch . recv-master:master
+      fi
+    done
+  fi
+
+  echo 'Current status having fetched.'
+  git branch -v | cat
+
+  if [[ $BUMP_PUSH_REMOTE != no ]]
+  then
+    # push out again
+    git push $BUMP_PUSH_REMOTE master:$BUMP_PUSH_BRANCH
+  fi
+  popd
+done

--- a/misc/bump/bump-ver-manifest
+++ b/misc/bump/bump-ver-manifest
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# execute this in the root repo folder
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SEL4_DIR=seL4
+MANIFEST_DIR=.repo/manifests
+
+set -eo pipefail
+
+current_hash=$(grep '<project name="seL4"' "$MANIFEST_DIR/devel.xml" | sed -re 's/^.*revision="([0-9a-fA-F]+)".*$/\1/' | head -n1)
+current=$(git -C "$SEL4_DIR" log --oneline -n 1 "$current_hash")
+commits=$(git -C "$SEL4_DIR" log --oneline "$current_hash"..)
+latest=$(git -C "$SEL4_DIR" log --oneline -n 1)
+latest_hash=$(git -C "$SEL4_DIR" log --pretty=format:'%H' -n 1)
+
+echo "Manifest currently at: $current"
+echo "New commits:"
+echo "----"
+echo "$commits"
+echo
+
+read -p "Update manifest to $latest? (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo >&2 "Exiting..."
+    exit 1
+fi
+
+echo "Generating new manifest..."
+python3 "$SCRIPT_DIR/ver-bump.py" -m "$MANIFEST_DIR/devel.xml" -r "$latest_hash"
+
+echo
+echo "Committing new manifest..."
+git -C "$MANIFEST_DIR" add devel.xml
+git -C "$MANIFEST_DIR" commit -m "Bump kernel revision to '$latest'"
+
+echo
+echo "Pushing new manifest..."
+git -C "$MANIFEST_DIR" push origin HEAD:master

--- a/misc/bump/ver-bump.py
+++ b/misc/bump/ver-bump.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+#
+# Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+""" Script for bumping seL4 revision in verification-manifest"""
+
+import sys
+import argparse
+import re
+
+def parseargs():
+    """Parse script args"""
+    parser = argparse.ArgumentParser(description="Bump the seL4 revision in the verification manifest")
+    parser.add_argument('-m', '--manifest', required=True,
+                        help='Path to the manifest file')
+    parser.add_argument('-r', '--revision', required=True,
+                        help='New kernel revision hash')
+
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = parseargs()
+
+    with open(args.manifest, 'r') as manifest:
+        lines = manifest.readlines()
+
+    with open(args.manifest, 'w') as manifest:
+        found = False
+        for line in lines:
+            if re.match('  \<project name="seL4" revision="[a-f0-9]{40}', line) and not found:
+                found = True
+                manifest.write(re.sub('revision="[a-f0-9]{40}',
+                        'revision="' + args.revision, line))
+            else:
+                manifest.write(line)
+
+    if not found:
+        print("Could not find seL4 project in manifest file")
+        print("Reverting to previous manifest.")
+
+        open(args.manifest, 'w').writelines(lines)
+        exit(1)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/misc/bump/ver-bump.py
+++ b/misc/bump/ver-bump.py
@@ -11,9 +11,11 @@ import sys
 import argparse
 import re
 
+
 def parseargs():
     """Parse script args"""
-    parser = argparse.ArgumentParser(description="Bump the seL4 revision in the verification manifest")
+    parser = argparse.ArgumentParser(
+        description="Bump the seL4 revision in the verification manifest")
     parser.add_argument('-m', '--manifest', required=True,
                         help='Path to the manifest file')
     parser.add_argument('-r', '--revision', required=True,
@@ -21,6 +23,7 @@ def parseargs():
 
     args = parser.parse_args()
     return args
+
 
 def main():
     args = parseargs()
@@ -34,7 +37,7 @@ def main():
             if re.match('  \<project name="seL4" revision="[a-f0-9]{40}', line) and not found:
                 found = True
                 manifest.write(re.sub('revision="[a-f0-9]{40}',
-                        'revision="' + args.revision, line))
+                                      'revision="' + args.revision, line))
             else:
                 manifest.write(line)
 
@@ -44,6 +47,7 @@ def main():
 
         open(args.manifest, 'w').writelines(lines)
         exit(1)
+
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
Use this to update revisions in `devel.xml` of `verification-manifest` at <https://github.com/seL4/verification-manifest>

The script assumes direct push access to `verification-manifest` without pull request requirement. This is currently not configured and ill only work for people with admin access (TSC members).

We could either make the script also raise a pull request on `verification-manifest` or we could relax the access rights on `verification-manifest` to not require pull requests from people with commit access. I'd be happy with the latter.