### PR TITLE
rt refine: sendIPC_corres

### DIFF
--- a/proof/invariant-abstract/DetSchedAux_AI.thy
+++ b/proof/invariant-abstract/DetSchedAux_AI.thy
@@ -1307,17 +1307,6 @@ lemma ball_filterM_scheme:
   shows "distinct xs \<Longrightarrow> \<lbrace> (\<lambda>s. \<forall>t\<in>set xs. Q t s) and P\<rbrace> filterM f xs \<lbrace>\<lambda>_. P\<rbrace>"
   by (subst filterM_mapM) (wpsimp wp: ball_mapM_scheme[where Q=Q] x y)
 
-(* FIXME: Move *)
-lemma st_tcb_reply_state_refs:
-  "\<lbrakk>st_tcb_at ((=) (Structures_A.thread_state.BlockedOnReply rp)) thread s; sym_refs (state_refs_of s)\<rbrakk>
-  \<Longrightarrow> \<exists>reply. (kheap s rp = Some (kernel_object.Reply reply) \<and> reply_tcb reply = Some thread)"
-  apply (clarsimp simp: pred_tcb_at_def)
-  apply (drule (1) sym_refs_obj_atD[where p=thread])
-  apply (clarsimp simp: state_refs_of_def obj_at_def tcb_st_refs_of_def
-                 split: Structures_A.thread_state.splits)
-  apply (rename_tac ko; case_tac ko; clarsimp simp: get_refs_def2)
-  done
-
 (* FIXME move *)
 lemma set_filter_all[simp]: "set (filter (\<lambda>x. P x) xs @ filter (\<lambda>x. \<not> P x) xs) = set xs" by auto
 

--- a/proof/invariant-abstract/Finalise_AI.thy
+++ b/proof/invariant-abstract/Finalise_AI.thy
@@ -655,14 +655,6 @@ lemma reply_tcb_state_refs:
                   split: thread_state.splits if_splits)
   done
 
-lemma st_tcb_recv_reply_state_refs:
-  "\<lbrakk>sym_refs (state_refs_of s); st_tcb_at ((=) (BlockedOnReceive ep (Some reply) pl)) thread s\<rbrakk>
-  \<Longrightarrow> \<exists>rep. (kheap s reply = Some (Reply rep) \<and> reply_tcb rep = Some thread)"
-  apply (drule (1) sym_refs_st_tcb_atD[rotated])
-  apply (clarsimp simp: get_refs_def2 obj_at_def valid_tcb_state_def is_reply refs_of_def
-                 split: thread_state.splits if_splits kernel_object.splits)
-  done
-
 lemma sym_refs_reply_sc_reply_at:
   "sym_refs (state_refs_of s) \<Longrightarrow>
    sc_replies_sc_at ((=) (reply_ptr # list)) sc_ptr s \<Longrightarrow>

--- a/proof/invariant-abstract/KHeap_AI.thy
+++ b/proof/invariant-abstract/KHeap_AI.thy
@@ -525,10 +525,12 @@ lemma get_ntfn_valid_ntfn[wp]:
   done
 
 lemma get_ep_valid_ep[wp]:
-  "\<lbrace> invs and ep_at ep \<rbrace>
+  "\<lbrace> valid_objs \<rbrace>
    get_endpoint ep
    \<lbrace> valid_ep \<rbrace>"
-  by (wpsimp simp: ep_at_def2 valid_ep_def2 simp_del: valid_simple_obj_def)
+  apply (wpsimp simp: get_simple_ko_def get_object_def)
+  apply (auto simp: valid_obj_def)
+  done
 
 lemma get_sc_valid_sc:
   "\<lbrace> invs and sc_at sc \<rbrace>
@@ -2599,5 +2601,24 @@ lemma valid_replies_tcb_fault_update:
   by (auto simp: get_refs_def2 refs_of_def obj_at_def sc_replies_sc_at_def
                  replies_with_sc_tcb_fault_update
                  replies_blocked_tcb_fault_update)
+
+lemma st_tcb_reply_state_refs:
+  "\<lbrakk>st_tcb_at ((=) (BlockedOnReply rp)) thread s; sym_refs (state_refs_of s)\<rbrakk>
+  \<Longrightarrow> reply_tcb_reply_at (\<lambda>x. x = Some thread) rp s"
+  apply (clarsimp simp: pred_tcb_at_def)
+  apply (drule (1) sym_refs_obj_atD[where p=thread])
+  apply (clarsimp simp: state_refs_of_def obj_at_def tcb_st_refs_of_def reply_tcb_reply_at_def
+                 split: Structures_A.thread_state.splits)
+  apply (rename_tac ko; case_tac ko; clarsimp simp: get_refs_def2)
+  done
+
+lemma st_tcb_recv_reply_state_refs:
+  "\<lbrakk>st_tcb_at ((=) (BlockedOnReceive ep (Some reply) pl)) thread s; sym_refs (state_refs_of s)\<rbrakk>
+  \<Longrightarrow> reply_tcb_reply_at (\<lambda>x. x = Some thread) reply s"
+  apply (drule (1) sym_refs_st_tcb_atD[rotated])
+  apply (clarsimp simp: get_refs_def2 obj_at_def valid_tcb_state_def is_reply refs_of_def
+                        reply_tcb_reply_at_def
+                 split: thread_state.splits if_splits kernel_object.splits)
+  done
 
 end

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -4151,6 +4151,11 @@ lemmas sym_refs_replyPrev_heap_ls
 
 (* end: sym_heap *)
 
+lemma no_replySC_valid_replies'_sc_asrt:
+  "replySCs_of s r = None \<Longrightarrow> valid_replies'_sc_asrt r s"
+  unfolding valid_replies'_sc_asrt_def
+  by (simp)
+
 (** sc_with_reply' **)
 
 definition sc_with_reply' where

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -3721,7 +3721,6 @@ lemma valid_replies_sc_cross:
   apply (drule subsetD, force)
   apply (clarsimp simp: pred_tcb_at_eq_commute[symmetric])
   apply (frule (1) st_tcb_reply_state_refs)
-  apply clarsimp
   apply (drule (3) st_tcb_at_coerce_concrete)
   apply (drule replyTCBs_of_cross[where P="\<lambda>rtcb. rtcb = (Some tptr)" for tptr])
    apply (fastforce simp: sk_obj_at_pred_def2)

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -415,7 +415,7 @@ lemma pinv_corres:
             apply (rule corres_guard_imp)
               apply (rule corres_split_deprecated [OF _ gct_corres])
                 apply simp
-                apply (rule corres_split_deprecated [OF _ send_ipc_corres])
+                apply (rule corres_split_deprecated [OF _ sendIPC_corres])
                    apply (rule corres_trivial)
                    apply simp
                   apply simp
@@ -424,8 +424,9 @@ lemma pinv_corres:
                                    fault_tcbs_valid_states_to_except_set schact_is_rct_sane
                                    ct_in_state_def released_sc_tcb_at_def active_sc_tcb_at_def2)
              apply (intro conjI)
-              apply (fastforce elim: st_tcb_ex_cap)
-             apply (clarsimp simp: pred_tcb_at_def obj_at_def)
+               apply (fastforce elim: st_tcb_ex_cap)
+              apply fastforce
+             apply (fastforce simp: pred_tcb_at_def obj_at_def dest: invs_cur_sc_tcb_symref)
             apply (clarsimp simp: pred_conj_def invs'_def cur_tcb'_def simple_sane_strg
                                   sch_act_simple_def)
            apply (rule corres_guard_imp)

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -1522,6 +1522,18 @@ lemma getObject_tcb_sp:
   "\<lbrace>P\<rbrace> getObject r \<lbrace>\<lambda>t::tcb. P and ko_at' t r\<rbrace>"
   by (wp getObject_obj_at'; simp)
 
+lemma threadGet_sp':
+  "\<lbrace>P\<rbrace> threadGet f p \<lbrace>\<lambda>t. obj_at' (\<lambda>t'. f t' = t) p and P\<rbrace>"
+  including no_pre
+  apply (simp add: threadGet_getObject)
+  apply wp
+  apply (rule hoare_strengthen_post)
+   apply (rule getObject_tcb_sp)
+  apply clarsimp
+  apply (erule obj_at'_weakenE)
+  apply simp
+  done
+
 lemma threadSet_valid_objs':
   "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. valid_tcb' tcb s \<longrightarrow> valid_tcb' (f tcb) s)\<rbrace>
   threadSet f t
@@ -1770,6 +1782,13 @@ lemma asUser_valid_queues[wp]:
   apply (simp add: asUser_def split_def)
   apply (wp hoare_drop_imps | simp)+
   apply (wp threadSet_valid_queues hoare_drop_imps | simp)+
+  done
+
+lemma asUser_valid_release_queue[wp]:
+  "asUser t m \<lbrace>valid_release_queue\<rbrace>"
+  apply (simp add: asUser_def split_def)
+  apply (wp hoare_drop_imps | simp)+
+  apply (wp threadSet_valid_release_queue hoare_drop_imps | simp)+
   done
 
 lemma asUser_ifunsafe'[wp]:

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -417,21 +417,6 @@ lemma asUser_valid_tcbs' [wp]:
              | simp add: valid_tcb'_def tcb_cte_cases_def)+
   done
 
-lemma asUser_valid_release_queue[wp]:
-  "asUser t m \<lbrace>valid_release_queue\<rbrace>"
-  apply (simp add: asUser_def split_def)
-  apply (wp hoare_drop_imps | simp)+
-  apply (wp threadSet_valid_release_queue hoare_drop_imps | simp)+
-  done
-
-lemma asUser_valid_release_queue'[wp]:
-  "asUser t m \<lbrace>valid_release_queue'\<rbrace>"
-  apply (simp add: asUser_def split_def)
-  apply (wp hoare_drop_imps | simp)+
-  apply (wp threadSet_valid_release_queue' threadGet_wp | simp)+
-  apply (clarsimp simp: valid_release_queue'_def obj_at'_real_def ko_wp_at'_def)
-  done
-
 lemma copyreg_corres:
   "corres (dc \<oplus> (=))
         (einvs and simple_sched_action and tcb_at dest and tcb_at src and ex_nonz_cap_to src and
@@ -604,7 +589,7 @@ lemma tcbSchedDequeue_not_queued:
   apply (rule_tac Q="\<lambda>rv. obj_at' (\<lambda>obj. tcbQueued obj = rv) t"
                in hoare_post_imp)
    apply (clarsimp simp: obj_at'_def)
-  apply (wp tg_sp' [where P=\<top>, simplified] | simp)+
+  apply (wp threadGet_sp' [where P=\<top>, simplified] | simp)+
   done
 
 lemma threadSet_ct_in_state':
@@ -961,7 +946,7 @@ lemma threadSetPriority_onRunning_corres:
   apply (rule corres_symb_exec_l[OF _ _ thread_get_sp])
     apply (rule corres_symb_exec_l[OF _ _ thread_get_sp])
       apply (rule corres_symb_exec_l[OF _ _ gets_sp])
-        apply (rule corres_symb_exec_r[OF _ tg_sp'])
+        apply (rule corres_symb_exec_r[OF _ threadGet_sp'])
           apply (rule stronger_corres_guard_imp)
             apply (rule_tac F="t \<in> set (queues d p) = queued" in corres_gen_asm)
             apply (rule_tac r'="(=)" in corres_split_deprecated)

--- a/proof/refine/Move_R.thy
+++ b/proof/refine/Move_R.thy
@@ -468,4 +468,9 @@ lemma lookup_cap_and_slot_valid_fault3[wp]:
   apply (drule invs_valid_objs, fastforce)
   done
 
+(* An "excluded middle" lemma for sc_at_ppred *)
+lemma sc_at_ppred_exm:
+  "sc_at_ppred p P scp s = (obj_at (\<lambda>ko. \<exists>sc n. ko = SchedContext sc n) scp s \<and> \<not> sc_at_ppred p (\<lambda>x. \<not> P x) scp s)"
+  by (fastforce simp: sc_at_pred_n_def obj_at_def is_sc_obj pred_neg_def)
+
 end


### PR DESCRIPTION
This proves `sendIPC_corres` and attempts to do so with minimal other impact on proofs, aside from some strengthening of lemmas for `replyPush` and `schedContextDonate`.