### PR TITLE
Refine cleanup

### DIFF
--- a/proof/crefine/ARM/Interrupt_C.thy
+++ b/proof/crefine/ARM/Interrupt_C.thy
@@ -47,12 +47,11 @@ lemma ptr_add_assertion_irq_guard:
                 (hrs_htd \<acute>t_hrs)\<rbrace> c ;; m)"
   by (simp add: ptr_add_assertion_def sint_ucast_eq_uint is_down)
 
-
 lemma cte_at_irq_node':
   "invs' s \<Longrightarrow>
     cte_at' (irq_node' s + 2 ^ cte_level_bits * ucast (irq :: 10 word)) s"
   by (clarsimp simp: invs'_def valid_state'_def valid_irq_node'_def
-                     cte_level_bits_def real_cte_at')
+                     cte_level_bits_def real_cte_at' cteSizeBits_def shiftl_t2n)
 
 lemma invokeIRQHandler_SetIRQHandler_ccorres:
   "ccorres dc xfdc

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -7123,7 +7123,7 @@ shows  "ccorres dc xfdc
                apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def
                dest!:invs_valid_idle' elim!: obj_atE')
              apply (drule(1) pspace_no_overlapD')
-             apply (erule_tac x = "ksIdleThread s" in in_empty_interE[rotated])
+             apply (rule_tac x = "ksIdleThread s" in in_empty_interE[rotated], simp)
               prefer 2
               apply (simp add:Int_ac)
              subgoal by (clarsimp simp: blah)

--- a/proof/crefine/ARM_HYP/Interrupt_C.thy
+++ b/proof/crefine/ARM_HYP/Interrupt_C.thy
@@ -52,7 +52,7 @@ lemma cte_at_irq_node':
   "invs' s \<Longrightarrow>
     cte_at' (irq_node' s + 2 ^ cte_level_bits * ucast (irq :: 10 word)) s"
   by (clarsimp simp: invs'_def valid_state'_def valid_irq_node'_def
-                     cte_level_bits_def real_cte_at')
+                     cte_level_bits_def real_cte_at' cteSizeBits_def shiftl_t2n)
 
 lemma invokeIRQHandler_SetIRQHandler_ccorres:
   "ccorres dc xfdc

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -8514,7 +8514,7 @@ shows  "ccorres dc xfdc
                apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def
                dest!:invs_valid_idle' elim!: obj_atE')
              apply (drule(1) pspace_no_overlapD')
-             apply (erule_tac x = "ksIdleThread s" in in_empty_interE[rotated])
+             apply (rule_tac x = "ksIdleThread s" in in_empty_interE[rotated], simp)
               prefer 2
               apply (simp add:Int_ac)
              subgoal by (clarsimp simp: blah)

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -7630,7 +7630,7 @@ shows  "ccorres dc xfdc
                apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def
                dest!:invs_valid_idle' elim!: obj_atE')
              apply (drule(1) pspace_no_overlapD')
-             apply (erule_tac x = "ksIdleThread s" in in_empty_interE[rotated])
+             apply (rule_tac x = "ksIdleThread s" in in_empty_interE[rotated], simp)
               prefer 2
               apply (simp add:Int_ac)
              subgoal by (clarsimp simp: blah)

--- a/proof/crefine/X64/Arch_C.thy
+++ b/proof/crefine/X64/Arch_C.thy
@@ -5254,7 +5254,7 @@ proof -
                              split: thread_state.splits)
               apply (case_tac "tcbState obj"; clarsimp)
                apply (drule invs_valid_idle',
-                           clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs)+
+                      clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs idle_tcb'_def)+
              apply (simp add: all_ex_eq_helper)
              apply vcg
             apply wp

--- a/proof/crefine/X64/Interrupt_C.thy
+++ b/proof/crefine/X64/Interrupt_C.thy
@@ -52,7 +52,7 @@ lemma cte_at_irq_node':
   "invs' s \<Longrightarrow>
     cte_at' (irq_node' s + 2 ^ cte_level_bits * ucast (irq :: 8 word)) s"
   by (clarsimp simp: invs'_def valid_state'_def valid_irq_node'_def
-                     cte_level_bits_def real_cte_at')
+                     cte_level_bits_def real_cte_at' cteSizeBits_def shiftl_t2n)
 
 lemma invokeIRQHandler_SetIRQHandler_ccorres:
   "ccorres dc xfdc

--- a/proof/crefine/X64/Retype_C.thy
+++ b/proof/crefine/X64/Retype_C.thy
@@ -8759,7 +8759,7 @@ shows  "ccorres dc xfdc
                apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def
                dest!:invs_valid_idle' elim!: obj_atE')
              apply (drule(1) pspace_no_overlapD')
-             apply (erule_tac x = "ksIdleThread s" in in_empty_interE[rotated])
+             apply (rule_tac x = "ksIdleThread s" in in_empty_interE[rotated], simp)
               prefer 2
               apply (simp add:Int_ac)
              subgoal by (clarsimp simp: blah)

--- a/proof/infoflow/refine/Example_Valid_StateH.thy
+++ b/proof/infoflow/refine/Example_Valid_StateH.thy
@@ -2935,10 +2935,13 @@ lemma s0H_invs:
     apply simp
    apply simp
   apply (rule conjI)
-   apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKO_eq project_inject objBitsKO_def)
+   apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKO_eq project_inject
+                         objBitsKO_def idle_tcb'_def)
    apply (clarsimp simp: s0H_internal_def s0_ptrs_aligned idle_tcbH_def)
-   apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct', simplified s0H_internal_def])
-   apply (simp add: objBitsKO_def)
+   apply (rule conjI)
+    apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct', simplified s0H_internal_def])
+    apply (simp add: objBitsKO_def)
+   apply (clarsimp simp: idle_tcb_ptr_def idle_thread_ptr_def)
   apply (rule conjI)
    apply (clarsimp simp: kdr_valid_global_refs') (* use axiomatization for now *)
   apply (rule conjI)
@@ -2965,7 +2968,7 @@ lemma s0H_invs:
   apply (rule conjI)
    apply (clarsimp simp: valid_irq_node'_def)
    apply (rule conjI)
-    apply (clarsimp simp: s0H_internal_def is_aligned_def s0_ptr_defs)
+    apply (clarsimp simp: s0H_internal_def is_aligned_def s0_ptr_defs word_size)
    apply (clarsimp simp: obj_at'_def projectKO_eq project_inject objBitsKO_def s0H_internal_def
                          shiftl_t2n[where n=4, simplified, symmetric]
                           kh0H_simps(1)[simplified cte_level_bits_def])

--- a/proof/refine/ARM/CSpace_R.thy
+++ b/proof/refine/ARM/CSpace_R.thy
@@ -2786,7 +2786,10 @@ lemma setCTE_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> setCTE p cte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: valid_idle'_def)
   apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (wp setCTE_pred_tcb_at')+
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (clarsimp simp: setCTE_def)
+   apply (rule setObject_cte_obj_at_tcb'[where P="idle_tcb'", simplified])
+  apply wpsimp
   done
 
 crunch it[wp]: getCTE "\<lambda>s. P (ksIdleThread s)"
@@ -2796,7 +2799,7 @@ lemma updateMDB_idle'[wp]:
   apply (clarsimp simp add: updateMDB_def)
   apply (rule hoare_pre)
   apply (wp | simp add: valid_idle'_def)+
-  done
+  by fastforce
 
 lemma updateCap_idle':
  "\<lbrace>valid_idle'\<rbrace> updateCap p c \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -1026,7 +1026,7 @@ lemma st_tcb:
 
 lemma irq_nodes_global:
     "\<forall>irq :: 10 word. irq_node' s + (ucast irq) * 16 \<in> global_refs' s"
-    by (simp add: global_refs'_def mult.commute mult.left_commute)
+    by (simp add: global_refs'_def mult.commute mult.left_commute cteSizeBits_def shiftl_t2n)
 
 lemma global_refs:
   "global_refs' s \<inter> base_bits = {}"
@@ -1393,7 +1393,8 @@ proof (simp add: invs'_def valid_state'_def valid_pspace'_def
 
   show "valid_irq_node' (irq_node' s) ?s"
     using virq irq_nodes_range
-    by (simp add: valid_irq_node'_def mult.commute mult.left_commute ucast_ucast_mask_8)
+    by (simp add: valid_irq_node'_def mult.commute mult.left_commute ucast_ucast_mask_8
+                  cteSizeBits_def shiftl_t2n)
 
   show "valid_irq_handlers' ?s" using virqh
     apply (simp add: valid_irq_handlers'_def irq_issued'_def

--- a/proof/refine/ARM/InterruptAcc_R.thy
+++ b/proof/refine/ARM/InterruptAcc_R.thy
@@ -72,7 +72,7 @@ lemma getIRQSlot_real_cte[wp]:
   apply (simp add: getIRQSlot_def getInterruptState_def locateSlot_conv)
   apply wp
   apply (clarsimp simp: invs'_def valid_state'_def valid_irq_node'_def
-                        cte_level_bits_def ucast_nat_def)
+                        cte_level_bits_def ucast_nat_def cteSizeBits_def shiftl_t2n)
   done
 
 lemma getIRQSlot_cte_at[wp]:

--- a/proof/refine/ARM/Interrupt_R.thy
+++ b/proof/refine/ARM/Interrupt_R.thy
@@ -356,7 +356,7 @@ lemma valid_globals_ex_cte_cap_irq:
   apply (subgoal_tac "irq_node' s + 2 ^ cte_level_bits * ucast irq \<in> global_refs' s")
    apply blast
   apply (simp add: global_refs'_def cte_level_bits_def
-    mult.commute mult.left_commute)
+                   mult.commute mult.left_commute cteSizeBits_def shiftl_t2n)
   done
 
 lemma arch_invokeIRQHandler_corres:

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -965,10 +965,7 @@ where
 abbreviation
   "sch_act_not t \<equiv> \<lambda>s. ksSchedulerAction s \<noteq> SwitchToThread t"
 
-definition
-  idle_tcb'_2 :: "Structures_H.thread_state \<times> machine_word option
-                  \<Rightarrow> bool"
-where
+definition idle_tcb'_2 :: "Structures_H.thread_state \<times> machine_word option \<Rightarrow> bool" where
   "idle_tcb'_2 \<equiv> \<lambda>(st, ntfn_opt). (idle' st \<and> ntfn_opt = None)"
 
 abbreviation
@@ -976,23 +973,16 @@ abbreviation
 
 lemmas idle_tcb'_def = idle_tcb'_2_def
 
-definition
-  valid_idle' :: "kernel_state \<Rightarrow> bool"
-where
-  "valid_idle' \<equiv>
-     \<lambda>s. obj_at' idle_tcb' (ksIdleThread s) s
-         \<and> idle_thread_ptr = ksIdleThread s"
+definition valid_idle' :: "kernel_state \<Rightarrow> bool" where
+  "valid_idle' \<equiv> \<lambda>s. obj_at' idle_tcb' (ksIdleThread s) s \<and> idle_thread_ptr = ksIdleThread s"
 
 lemma valid_idle'_tcb_at':
   "valid_idle' s \<Longrightarrow> obj_at' idle_tcb' (ksIdleThread s) s"
   by (clarsimp simp: valid_idle'_def)
 
-definition
-  valid_irq_node' :: "word32 \<Rightarrow> kernel_state \<Rightarrow> bool"
-where
- "valid_irq_node' x \<equiv>
-  \<lambda>s. is_aligned x (size (0::irq) + cteSizeBits)
-      \<and> (\<forall>irq :: irq. real_cte_at' (x + (ucast irq << cteSizeBits)) s)"
+definition valid_irq_node' :: "word32 \<Rightarrow> kernel_state \<Rightarrow> bool" where
+ "valid_irq_node' x \<equiv> \<lambda>s. is_aligned x (size (0::irq) + cteSizeBits)
+                          \<and> (\<forall>irq :: irq. real_cte_at' (x + (ucast irq << cteSizeBits)) s)"
 
 definition
   valid_refs' :: "word32 set \<Rightarrow> cte_heap \<Rightarrow> bool"

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -965,12 +965,27 @@ where
 abbreviation
   "sch_act_not t \<equiv> \<lambda>s. ksSchedulerAction s \<noteq> SwitchToThread t"
 
-abbreviation "idle_tcb_at' \<equiv> pred_tcb_at' (\<lambda>t. (itcbState t, itcbBoundNotification t))"
+definition
+  idle_tcb'_2 :: "Structures_H.thread_state \<times> machine_word option
+                  \<Rightarrow> bool"
+where
+  "idle_tcb'_2 \<equiv> \<lambda>(st, ntfn_opt). (idle' st \<and> ntfn_opt = None)"
+
+abbreviation
+  "idle_tcb' tcb \<equiv> idle_tcb'_2 (tcbState tcb, tcbBoundNotification tcb)"
+
+lemmas idle_tcb'_def = idle_tcb'_2_def
 
 definition
   valid_idle' :: "kernel_state \<Rightarrow> bool"
 where
-  "valid_idle' \<equiv> \<lambda>s. idle_tcb_at' (\<lambda>p. idle' (fst p) \<and> snd p = None) (ksIdleThread s) s"
+  "valid_idle' \<equiv>
+     \<lambda>s. obj_at' idle_tcb' (ksIdleThread s) s
+         \<and> idle_thread_ptr = ksIdleThread s"
+
+lemma valid_idle'_tcb_at':
+  "valid_idle' s \<Longrightarrow> obj_at' idle_tcb' (ksIdleThread s) s"
+  by (clarsimp simp: valid_idle'_def)
 
 definition
   valid_irq_node' :: "word32 \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -1692,7 +1707,7 @@ lemma valid_pspaceE' [elim]:
 lemma idle'_no_refs:
   "valid_idle' s \<Longrightarrow> state_refs_of' s (ksIdleThread s) = {}"
   by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def tcb_ntfn_is_bound'_def
-                     projectKO_eq project_inject state_refs_of'_def)
+                     projectKO_eq project_inject state_refs_of'_def idle_tcb'_def)
 
 lemma idle'_not_queued':
   "\<lbrakk>valid_idle' s; sym_refs (state_refs_of' s);
@@ -1817,7 +1832,7 @@ lemma valid_idle'_pspace_itI[elim]:
   "\<lbrakk> valid_idle' s; ksPSpace s = ksPSpace s'; ksIdleThread s = ksIdleThread s' \<rbrakk>
       \<Longrightarrow> valid_idle' s'"
   apply (clarsimp simp: valid_idle'_def ex_nonz_cap_to'_def)
-  apply (erule pred_tcb_at'_pspaceI, assumption)
+  apply (erule obj_at'_pspaceI, assumption)
   done
 
 lemma obj_at'_weaken:
@@ -3128,10 +3143,6 @@ lemma not_obj_at'_strengthen:
 lemma not_pred_tcb_at'_strengthen:
   "pred_tcb_at' f (Not \<circ> P) p s \<Longrightarrow> \<not> pred_tcb_at' f P p s"
   by (clarsimp simp: pred_tcb_at'_def obj_at'_def)
-
-lemma idle_tcb_at'_split:
-  "idle_tcb_at' (\<lambda>p. P (fst p) \<and> Q (snd p)) t s \<Longrightarrow> st_tcb_at' P t s \<and> bound_tcb_at' Q t s"
-  by (clarsimp simp: pred_tcb_at'_def dest!: obj_at'_conj_distrib)
 
 lemma valid_queues_no_bitmap_def':
   "valid_queues_no_bitmap =

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -976,7 +976,8 @@ definition
   valid_irq_node' :: "word32 \<Rightarrow> kernel_state \<Rightarrow> bool"
 where
  "valid_irq_node' x \<equiv>
-  \<lambda>s. is_aligned x 12 \<and> (\<forall>irq :: irq. real_cte_at' (x + 16 * (ucast irq)) s)"
+  \<lambda>s. is_aligned x (size (0::irq) + cteSizeBits)
+      \<and> (\<forall>irq :: irq. real_cte_at' (x + (ucast irq << cteSizeBits)) s)"
 
 definition
   valid_refs' :: "word32 set \<Rightarrow> cte_heap \<Rightarrow> bool"
@@ -1000,7 +1001,7 @@ where
   {ksIdleThread s} \<union>
    page_directory_refs' (armKSGlobalPD (ksArchState s)) \<union>
    (\<Union>pt \<in> set (armKSGlobalPTs (ksArchState s)). page_table_refs' pt) \<union>
-   range (\<lambda>irq :: irq. irq_node' s + 16 * ucast irq)"
+   range (\<lambda>irq :: irq. irq_node' s + (ucast irq << cteSizeBits))"
 
 definition
   valid_cap_sizes' :: "nat \<Rightarrow> cte_heap \<Rightarrow> bool"

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -859,7 +859,7 @@ proof -
     apply (rule hoare_strengthen_post [OF get_ep_sp'])
     apply (clarsimp simp: pred_tcb_at' fun_upd_def[symmetric] conj_comms
                split del: if_split cong: if_cong)
-    apply (rule conjI, clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs)
+    apply (rule conjI, clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
     apply (frule obj_at_valid_objs', clarsimp)
     apply (clarsimp simp: projectKOs valid_obj'_def)
     apply (rule conjI)
@@ -2546,7 +2546,7 @@ lemma cancelBadgedSends_filterM_helper':
   apply (intro conjI)
       apply (clarsimp simp: valid_pspace'_def valid_tcb'_def elim!: valid_objs_valid_tcbE dest!: st_tcb_ex_cap'')
      apply (fastforce dest!: st_tcb_ex_cap'')
-    apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def)
+    apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
    apply (erule delta_sym_refs)
     apply (fastforce elim!: obj_atE'
                       simp: state_refs_of'_def projectKOs tcb_bound_refs'_def

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -2977,7 +2977,7 @@ lemma sai_invs'[wp]:
           apply (clarsimp simp: valid_obj'_def valid_ntfn'_def
                          split: list.splits)
          apply (clarsimp simp: invs'_def valid_state'_def)
-         apply (clarsimp simp: st_tcb_at_refs_of_rev' valid_idle'_def pred_tcb_at'_def
+         apply (clarsimp simp: st_tcb_at_refs_of_rev' valid_idle'_def pred_tcb_at'_def idle_tcb'_def
                         dest!: sym_refs_ko_atD' sym_refs_st_tcb_atD' sym_refs_obj_atD'
                         split: list.splits)
         apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
@@ -3575,7 +3575,7 @@ crunch cap_to'[wp]: doIPCTransfer "ex_nonz_cap_to' p"
 lemma st_tcb_idle':
   "\<lbrakk>valid_idle' s; st_tcb_at' P t s\<rbrakk> \<Longrightarrow>
    (t = ksIdleThread s) \<longrightarrow> P IdleThreadState"
-  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def)
+  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
 
 crunch idle'[wp]: getThreadCallerSlot "valid_idle'"
 crunch idle'[wp]: getThreadReplySlot "valid_idle'"

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -1160,6 +1160,13 @@ lemma setObject_it[wp]:
   apply (wp x | simp)+
   done
 
+\<comment>\<open>
+  `idle_tcb_ps val` asserts that `val` is a pspace_storable value
+  which corresponds to an idle TCB.
+\<close>
+definition idle_tcb_ps :: "('a :: pspace_storable) \<Rightarrow> bool" where
+  "idle_tcb_ps val \<equiv> (\<exists>tcb. projectKO_opt (injectKO val) = Some tcb \<and> idle_tcb' tcb)"
+
 lemma setObject_idle':
   fixes v :: "'a :: pspace_storable"
   assumes R: "\<And>ko s x y n. (updateObject v ko ptr y n s)
@@ -1170,12 +1177,9 @@ lemma setObject_idle':
        \<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace> updateObject v p q n ko
        \<lbrace>\<lambda>rv s. P (ksIdleThread s)\<rbrace>"
   shows      "\<lbrace>\<lambda>s. valid_idle' s \<and>
-                   (ptr = ksIdleThread s \<longrightarrow>
-                    (\<exists>obj (val :: 'a). projectKO_opt (injectKO val) = Some obj
-                                      \<and> idle' (tcbState obj) \<and> tcbBoundNotification obj = None)
-                    \<longrightarrow> (\<exists>obj. projectKO_opt (injectKO v) = Some obj \<and>
-                          idle' (tcbState obj) \<and> tcbBoundNotification obj = None)) \<and>
-                   P s\<rbrace>
+                   (ptr = ksIdleThread s
+                        \<longrightarrow> (\<exists>val :: 'a. idle_tcb_ps val)
+                        \<longrightarrow> idle_tcb_ps v)\<rbrace>
                 setObject ptr v
               \<lbrace>\<lambda>rv s. valid_idle' s\<rbrace>"
   apply (simp add: valid_idle'_def pred_tcb_at'_def o_def)
@@ -1184,8 +1188,7 @@ lemma setObject_idle':
     apply (simp add: pred_tcb_at'_def obj_at'_real_def)
     apply (rule setObject_ko_wp_at [OF R n m])
    apply (wp z)
-  apply (clarsimp simp add: pred_tcb_at'_def obj_at'_real_def ko_wp_at'_def)
-  apply (drule_tac x=obj in spec, simp)
+  apply (clarsimp simp add: pred_tcb_at'_def obj_at'_real_def ko_wp_at'_def idle_tcb_ps_def)
   apply (clarsimp simp add: project_inject)
   apply (drule_tac x=obja in spec, simp)
   done
@@ -1717,9 +1720,9 @@ lemma setEndpoint_idle'[wp]:
    setEndpoint p v
    \<lbrace>\<lambda>_. valid_idle'\<rbrace>"
   unfolding setEndpoint_def
-  apply (wp setObject_idle'[where P="\<top>"])
+  apply (wp setObject_idle')
        apply (simp add: objBits_simps' updateObject_default_inv)+
-  apply (clarsimp simp: projectKOs)
+  apply (clarsimp simp: projectKOs idle_tcb_ps_def)
   done
 
 crunch it[wp]: setEndpoint "\<lambda>s. P (ksIdleThread s)"
@@ -1855,9 +1858,9 @@ lemma setNotification_ifunsafe'[wp]:
 lemma setNotification_idle'[wp]:
   "\<lbrace>\<lambda>s. valid_idle' s\<rbrace> setNotification p v \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   unfolding setNotification_def
-  apply (wp setObject_idle'[where P="\<top>"])
+  apply (wp setObject_idle')
         apply (simp add: objBits_simps' updateObject_default_inv)+
-  apply (clarsimp simp: projectKOs)
+  apply (clarsimp simp: projectKOs idle_tcb_ps_def)
   done
 
 crunch it[wp]: setNotification "\<lambda>s. P (ksIdleThread s)"

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -4090,6 +4090,7 @@ lemma createObjects_idle':
   apply (rule hoare_gen_asm)
   apply (rule hoare_pre)
    apply (clarsimp simp add: valid_idle'_def pred_tcb_at'_def)
+   apply (rule hoare_vcg_conj_lift)
    apply (rule hoare_as_subst [OF createObjects'_it])
    apply (wp createObjects_orig_obj_at'
              createObjects_orig_cte_wp_at2'

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -4091,10 +4091,10 @@ lemma createObjects_idle':
   apply (rule hoare_pre)
    apply (clarsimp simp add: valid_idle'_def pred_tcb_at'_def)
    apply (rule hoare_vcg_conj_lift)
-   apply (rule hoare_as_subst [OF createObjects'_it])
-   apply (wp createObjects_orig_obj_at'
-             createObjects_orig_cte_wp_at2'
-             hoare_vcg_all_lift | simp)+
+    apply (rule hoare_as_subst [OF createObjects'_it])
+    apply (wp createObjects_orig_obj_at'
+              createObjects_orig_cte_wp_at2'
+              hoare_vcg_all_lift | simp)+
   apply (clarsimp simp: valid_idle'_def projectKOs o_def
                         pred_tcb_at'_def valid_pspace'_def
                   cong: option.case_cong)

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -764,7 +764,7 @@ lemma arch_switchToIdleThread_corres:
   apply (simp add: arch_switch_to_idle_thread_def
                 ARM_H.switchToIdleThread_def)
   apply (corressimp corres: getIdleThread_corres setVMRoot_corres[@lift_corres_args])
-  apply (clarsimp simp: valid_idle_def valid_idle'_def pred_tcb_at_def obj_at_def is_tcb)
+  apply (clarsimp simp: valid_idle_def valid_idle'_def pred_tcb_at_def obj_at_def is_tcb obj_at'_def)
   done
 
 lemma switchToIdleThread_corres:
@@ -893,7 +893,7 @@ lemma idle'_not_tcbQueued':
  shows "obj_at' (Not \<circ> tcbQueued) (ksIdleThread s) s"
  proof -
    from idle have stidle: "st_tcb_at' (Not \<circ> runnable') (ksIdleThread s) s"
-     by (clarsimp simp add: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs)
+     by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs idle_tcb'_def)
 
    with vq vq' show ?thesis
      by (rule valid_queues_not_runnable_not_queued)
@@ -911,15 +911,17 @@ proof -
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (clarsimp simp add: ct_not_inQ_ct idle'_activatable' idle'_not_tcbQueued'[simplified o_def]
+    apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def)
+    apply (frule (2) idle'_not_tcbQueued'[simplified o_def])
+    apply (clarsimp simp add: ct_not_inQ_ct idle'_activatable'
                               invs'_def cur_tcb'_def valid_state'_def valid_idle'_def
                               sch_act_wf ct_in_state'_def state_refs_of'_def
                               ps_clear_def valid_irq_node'_def
                               ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
                               valid_queues_def bitmapQ_defs valid_queues_no_bitmap_def valid_queues'_def
-                              all_invs_but_ct_idle_or_in_cur_domain'_def pred_tcb_at'_def
+                              pred_tcb_at'_def
                         cong: option.case_cong)
-    apply (clarsimp simp: obj_at'_def projectKOs)
+    apply (clarsimp simp: obj_at'_def projectKOs idle_tcb'_def)
     done
 qed
 
@@ -1988,7 +1990,7 @@ lemma switchToIdleThread_activatable_2[wp]:
                    ARM_H.switchToIdleThread_def)
   apply (wp setCurThread_ct_in_state)
   apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def valid_idle'_def
-                        pred_tcb_at'_def obj_at'_def)
+                        pred_tcb_at'_def obj_at'_def idle_tcb'_def)
   done
 
 lemma switchToThread_tcb_in_cur_domain':

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -821,18 +821,17 @@ lemma doReply_invs[wp]:
                    in hoare_strengthen_post [rotated])
             apply (clarsimp)
             apply (rule conjI)
-             apply (clarsimp simp add: invs'_def valid_state'_def valid_idle'_def)
+             apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def)
              apply (rule conjI)
               apply clarsimp
-             apply clarsimp
-             apply (drule idle_tcb_at'_split, clarsimp, drule (1) st_tcb_at'_eqD, simp)
+             apply (clarsimp simp: obj_at'_def idle_tcb'_def pred_tcb_at'_def)
             apply clarsimp
             apply (rule conjI)
-             apply (clarsimp simp add: invs'_def valid_state'_def valid_idle'_def)
+             apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def)
              apply (erule pred_tcb'_weakenE, clarsimp)
             apply (rule conjI)
-             apply (clarsimp simp add: invs'_def valid_state'_def valid_idle'_def pred_tcb_at'_def
-                                      obj_at'_def)
+             apply (clarsimp simp : invs'_def valid_state'_def valid_idle'_def pred_tcb_at'_def
+                                    obj_at'_def idle_tcb'_def)
             apply (rule conjI)
              apply clarsimp
              apply (frule invs'_not_runnable_not_queued)
@@ -1142,7 +1141,7 @@ lemma get_mrs_length_rv[wp]:
 lemma st_tcb_at_idle_thread':
   "\<lbrakk> st_tcb_at' P (ksIdleThread s) s; valid_idle' s \<rbrakk>
         \<Longrightarrow> P IdleThreadState"
-  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def)
+  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
 
 crunch tcb_at'[wp]: replyFromKernel "tcb_at' t"
 
@@ -1338,7 +1337,7 @@ lemma hinv_invs'[wp]:
          apply (subgoal_tac "thread \<noteq> ksIdleThread s", simp_all)[1]
           apply (fastforce elim!: pred_tcb'_weakenE st_tcb_ex_cap'')
          apply (clarsimp simp: valid_idle'_def valid_state'_def
-                               invs'_def pred_tcb_at'_def obj_at'_def)
+                               invs'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
         apply wp+
        apply (rule_tac Q="\<lambda>rv'. invs' and valid_invocation' rv
                                 and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
@@ -2115,7 +2114,7 @@ proof
   assume "ksCurThread s = ksIdleThread s"
   with vi have "ct_in_state' idle' s"
     unfolding ct_in_state'_def valid_idle'_def
-    by (clarsimp simp: pred_tcb_at'_def obj_at'_def)
+    by (clarsimp simp: pred_tcb_at'_def obj_at'_def idle_tcb'_def)
 
   with cts show False
     unfolding ct_in_state'_def

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -528,10 +528,10 @@ lemma setObject_tcb_idle':
      (t = ksIdleThread s \<longrightarrow> idle' (tcbState v) \<and> tcbBoundNotification v = None)\<rbrace>
      setObject t (v :: tcb) \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (rule hoare_pre)
-  apply (rule_tac P="\<top>" in setObject_idle')
+  apply (rule setObject_idle')
       apply (simp add: objBits_simps')+
    apply (simp add: updateObject_default_inv)
-  apply (simp add: projectKOs)
+  apply (simp add: projectKOs idle_tcb_ps_def idle_tcb'_def)
   done
 
 lemma setObject_tcb_irq_node'[wp]:
@@ -798,14 +798,13 @@ lemma threadSet_idle'T:
   shows
   "\<lbrace>\<lambda>s. valid_idle' s
       \<and> (t = ksIdleThread s \<longrightarrow>
-          (\<forall>tcb. ko_at' tcb t s \<and> idle' (tcbState tcb) \<longrightarrow> idle' (tcbState (F tcb)))
-        \<and> (\<forall>tcb. ko_at' tcb t s \<and> tcbBoundNotification tcb = None \<longrightarrow> tcbBoundNotification (F tcb) = None))\<rbrace>
+          (\<forall>tcb. ko_at' tcb t s \<and> idle_tcb' tcb \<longrightarrow> idle_tcb' (F tcb)))\<rbrace>
      threadSet F t
    \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: threadSet_def)
   apply (wp setObject_tcb_idle' getObject_tcb_wp)
   apply (clarsimp simp: obj_at'_def projectKOs)
-  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs)
+  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs idle_tcb'_def)
   done
 
 lemmas threadSet_idle' =
@@ -3646,7 +3645,7 @@ lemma sts_valid_idle'[wp]:
    setThreadState ts t
    \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: setThreadState_def)
-  apply (wp threadSet_idle', simp+)+
+  apply (wpsimp wp: threadSet_idle' simp: idle_tcb'_def)
   done
 
 lemma sbn_valid_idle'[wp]:
@@ -3655,7 +3654,7 @@ lemma sbn_valid_idle'[wp]:
    setBoundNotification ntfn t
    \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: setBoundNotification_def)
-  apply (wp threadSet_idle', simp+)+
+  apply (wpsimp wp: threadSet_idle' simp: idle_tcb'_def)
   done
 
 lemma gts_sp':

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -120,7 +120,7 @@ lemma activate_invs':
                in hoare_post_imp, clarsimp)
       apply (wp sch_act_simple_lift)+
     apply (clarsimp simp: valid_idle'_def invs'_def valid_state'_def
-                          pred_tcb_at'_def obj_at'_def
+                          pred_tcb_at'_def obj_at'_def idle_tcb'_def
                    elim!: pred_tcb'_weakenE)
    apply (wp gts_st_tcb')+
   apply (clarsimp simp: tcb_at_invs' ct_in_state'_def

--- a/proof/refine/ARM/Untyped_R.thy
+++ b/proof/refine/ARM/Untyped_R.thy
@@ -690,7 +690,7 @@ lemma map_ensure_empty':
 
 lemma irq_nodes_global:
   "irq_node' s + (ucast (irq :: 10 word)) * 16 \<in> global_refs' s"
-  by (simp add: global_refs'_def mult.commute mult.left_commute)
+  by (simp add: global_refs'_def mult.commute mult.left_commute cteSizeBits_def shiftl_t2n)
 
 lemma valid_global_refsD2':
   "\<lbrakk>ctes_of s p = Some cte; valid_global_refs' s\<rbrakk> \<Longrightarrow>
@@ -3767,7 +3767,7 @@ lemma descendants_range_ex_cte':
    apply (case_tac "\<exists>irq. cteCap ctea = IRQHandlerCap irq")
      apply clarsimp
    apply (erule(1) in_empty_interE[OF _ _ subsetD,rotated -1])
-     apply (clarsimp simp:global_refs'_def)
+     apply (clarsimp simp:global_refs'_def cteSizeBits_def shiftl_t2n)
      apply (erule_tac A = "range P" for P in subsetD)
      apply (simp add:range_eqI field_simps)
    apply (case_tac ctea)

--- a/proof/refine/ARM/VSpace_R.thy
+++ b/proof/refine/ARM/VSpace_R.thy
@@ -2831,16 +2831,14 @@ lemma storePDE_ifunsafe [wp]:
   apply simp
   done
 
+method valid_idle'_setObject uses simp =
+  simp add: valid_idle'_def, rule hoare_lift_Pf [where f="ksIdleThread"]; wpsimp?;
+  (wpsimp wp: obj_at_setObject2[where P="idle_tcb'", simplified] hoare_drop_imp
+        simp: simp
+   | clarsimp dest!: updateObject_default_result)+
+
 lemma storePDE_idle [wp]:
-  "\<lbrace>valid_idle'\<rbrace> storePDE p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  apply (simp add: valid_idle'_def)
-  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
-   apply (clarsimp simp: storePDE_def)
-   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
-   apply (clarsimp dest!: updateObject_default_result)
-   apply wpsimp
-  done
+  "\<lbrace>valid_idle'\<rbrace> storePDE p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>" by (valid_idle'_setObject simp: storePDE_def)
 
 crunches storePDE
   for arch'[wp]: "\<lambda>s. P (ksArchState s)"
@@ -3025,15 +3023,7 @@ lemma storePTE_ifunsafe [wp]:
   done
 
 lemma storePTE_idle [wp]:
-  "\<lbrace>valid_idle'\<rbrace> storePTE p pte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  apply (simp add: valid_idle'_def)
-  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
-   apply (clarsimp simp: storePTE_def)
-   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
-   apply (clarsimp dest!: updateObject_default_result)
-  apply wpsimp
-  done
+  "\<lbrace>valid_idle'\<rbrace> storePTE p pte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>" by (valid_idle'_setObject simp: storePTE_def)
 
 crunches storePTE
   for arch'[wp]: "\<lambda>s. P (ksArchState s)"
@@ -3222,14 +3212,7 @@ lemma setASIDPool_it' [wp]:
   by (wp setObject_it updateObject_default_inv|simp)+
 
 lemma setASIDPool_idle [wp]:
-  "\<lbrace>valid_idle'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  apply (simp add: valid_idle'_def)
-  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
-   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
-   apply (clarsimp dest!: updateObject_default_result)
-   apply wpsimp
-  done
+  "\<lbrace>valid_idle'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>rv. valid_idle'\<rbrace>" by valid_idle'_setObject
 
 lemma setASIDPool_irq_states' [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>_. valid_irq_states'\<rbrace>"

--- a/proof/refine/ARM/VSpace_R.thy
+++ b/proof/refine/ARM/VSpace_R.thy
@@ -2833,8 +2833,14 @@ lemma storePDE_ifunsafe [wp]:
 
 lemma storePDE_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> storePDE p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  unfolding valid_idle'_def
-  by (rule hoare_lift_Pf [where f="ksIdleThread"]; wp)
+  apply (simp add: valid_idle'_def)
+  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (clarsimp simp: storePDE_def)
+   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
+   apply (clarsimp dest!: updateObject_default_result)
+   apply wpsimp
+  done
 
 crunches storePDE
   for arch'[wp]: "\<lambda>s. P (ksArchState s)"
@@ -3020,8 +3026,14 @@ lemma storePTE_ifunsafe [wp]:
 
 lemma storePTE_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> storePTE p pte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  unfolding valid_idle'_def
-  by (rule hoare_lift_Pf [where f="ksIdleThread"]; wp)
+  apply (simp add: valid_idle'_def)
+  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (clarsimp simp: storePTE_def)
+   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
+   apply (clarsimp dest!: updateObject_default_result)
+  apply wpsimp
+  done
 
 crunches storePTE
   for arch'[wp]: "\<lambda>s. P (ksArchState s)"
@@ -3211,8 +3223,13 @@ lemma setASIDPool_it' [wp]:
 
 lemma setASIDPool_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  unfolding valid_idle'_def
-  by (rule hoare_lift_Pf [where f="ksIdleThread"]; wp)
+  apply (simp add: valid_idle'_def)
+  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
+   apply (clarsimp dest!: updateObject_default_result)
+   apply wpsimp
+  done
 
 lemma setASIDPool_irq_states' [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>_. valid_irq_states'\<rbrace>"

--- a/proof/refine/ARM_HYP/CSpace_R.thy
+++ b/proof/refine/ARM_HYP/CSpace_R.thy
@@ -2797,7 +2797,10 @@ lemma setCTE_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> setCTE p cte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: valid_idle'_def)
   apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (wp setCTE_pred_tcb_at')+
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (clarsimp simp: setCTE_def)
+   apply (rule setObject_cte_obj_at_tcb'[where P="idle_tcb'", simplified])
+  apply wpsimp
   done
 
 crunch it[wp]: getCTE "\<lambda>s. P (ksIdleThread s)"
@@ -2816,7 +2819,7 @@ lemma updateMDB_idle'[wp]:
   apply (clarsimp simp add: updateMDB_def)
   apply (rule hoare_pre)
   apply (wp | simp add: valid_idle'_def)+
-  done
+  by fastforce
 
 lemma updateCap_idle':
  "\<lbrace>valid_idle'\<rbrace> updateCap p c \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"

--- a/proof/refine/ARM_HYP/Finalise_R.thy
+++ b/proof/refine/ARM_HYP/Finalise_R.thy
@@ -2544,8 +2544,7 @@ lemma archThreadSet_valid_idle'[wp]:
   "archThreadSet f t \<lbrace>valid_idle'\<rbrace>"
   unfolding archThreadSet_def
   apply (wpsimp wp: setObject_tcb_idle' getObject_tcb_wp)
-  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def)
-  apply normalise_obj_at'
+  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
   done
 
 lemma archThreadSet_ko_wp_at_no_vcpu[wp]:

--- a/proof/refine/ARM_HYP/Interrupt_R.thy
+++ b/proof/refine/ARM_HYP/Interrupt_R.thy
@@ -1185,7 +1185,6 @@ lemma vgicMaintenance_invs'[wp]:
              apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def obj_at'_def idle_tcb'_def)
             apply wps
             apply (wpsimp simp: if_apply_def2 wp: hoare_vcg_const_imp_lift hoare_drop_imps
-hoare_vcg_ex_lift hoare_vcg_conj_lift
                    | wps)+
   apply (clarsimp cong: conj_cong imp_cong split: if_split)
   apply (strengthen st_tcb_ex_cap''[where P=active'])

--- a/proof/refine/ARM_HYP/Interrupt_R.thy
+++ b/proof/refine/ARM_HYP/Interrupt_R.thy
@@ -1182,10 +1182,10 @@ lemma vgicMaintenance_invs'[wp]:
              apply (clarsimp simp: st_tcb_at'_def obj_at'_def runnable'_eq)
              apply (rule conjI)
               apply (fastforce elim!: st_tcb_ex_cap'' simp: valid_state'_def valid_pspace'_def)
-             apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def)
-             apply (clarsimp simp: st_tcb_at'_def obj_at'_def runnable'_eq pred_tcb_at'_def)
+             apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def obj_at'_def idle_tcb'_def)
             apply wps
             apply (wpsimp simp: if_apply_def2 wp: hoare_vcg_const_imp_lift hoare_drop_imps
+hoare_vcg_ex_lift hoare_vcg_conj_lift
                    | wps)+
   apply (clarsimp cong: conj_cong imp_cong split: if_split)
   apply (strengthen st_tcb_ex_cap''[where P=active'])
@@ -1195,8 +1195,7 @@ lemma vgicMaintenance_invs'[wp]:
    apply (clarsimp simp: st_tcb_at'_def obj_at'_def runnable'_eq)
    apply (rule conjI)
     apply (fastforce elim!: st_tcb_ex_cap'' simp: valid_state'_def valid_pspace'_def)
-   apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def)
-   apply (clarsimp simp: st_tcb_at'_def obj_at'_def runnable'_eq pred_tcb_at'_def)
+   apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def obj_at'_def idle_tcb'_def)
   apply clarsimp
   done
 
@@ -1218,8 +1217,7 @@ lemma vppiEvent_invs'[wp]:
              apply (clarsimp simp: st_tcb_at'_def obj_at'_def runnable'_eq)
              apply (rule conjI)
               apply (fastforce elim!: st_tcb_ex_cap'' simp: valid_state'_def valid_pspace'_def)
-             apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def)
-             apply (clarsimp simp: st_tcb_at'_def obj_at'_def runnable'_eq pred_tcb_at'_def)
+             apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def obj_at'_def idle_tcb'_def)
             apply wps
             apply (wpsimp simp: if_apply_def2 vcpuUpdate_def
                           wp: hoare_vcg_const_imp_lift hoare_drop_imps

--- a/proof/refine/ARM_HYP/Invariants_H.thy
+++ b/proof/refine/ARM_HYP/Invariants_H.thy
@@ -1110,10 +1110,7 @@ where
 abbreviation
   "sch_act_not t \<equiv> \<lambda>s. ksSchedulerAction s \<noteq> SwitchToThread t"
 
-definition
-  idle_tcb'_2 :: "Structures_H.thread_state \<times> machine_word option
-                  \<Rightarrow> bool"
-where
+definition idle_tcb'_2 :: "Structures_H.thread_state \<times> machine_word option \<Rightarrow> bool" where
   "idle_tcb'_2 \<equiv> \<lambda>(st, ntfn_opt). (idle' st \<and> ntfn_opt = None)"
 
 abbreviation
@@ -1121,12 +1118,8 @@ abbreviation
 
 lemmas idle_tcb'_def = idle_tcb'_2_def
 
-definition
-  valid_idle' :: "kernel_state \<Rightarrow> bool"
-where
-  "valid_idle' \<equiv>
-     \<lambda>s. obj_at' idle_tcb' (ksIdleThread s) s
-         \<and> idle_thread_ptr = ksIdleThread s"
+definition valid_idle' :: "kernel_state \<Rightarrow> bool" where
+  "valid_idle' \<equiv> \<lambda>s. obj_at' idle_tcb' (ksIdleThread s) s \<and> idle_thread_ptr = ksIdleThread s"
 
 lemma valid_idle'_tcb_at':
   "valid_idle' s \<Longrightarrow> obj_at' idle_tcb' (ksIdleThread s) s"

--- a/proof/refine/ARM_HYP/IpcCancel_R.thy
+++ b/proof/refine/ARM_HYP/IpcCancel_R.thy
@@ -867,7 +867,7 @@ proof -
               | wpc)+
     apply (clarsimp simp: pred_tcb_at' fun_upd_def[symmetric] conj_comms
                split del: if_split cong: if_cong)
-    apply (rule conjI, clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs)
+    apply (rule conjI, clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
     apply (frule obj_at_valid_objs', clarsimp)
     apply (clarsimp simp: projectKOs valid_obj'_def)
     apply (rule conjI)
@@ -2723,7 +2723,7 @@ lemma cancelBadgedSends_filterM_helper':
   apply (intro conjI)
       apply (clarsimp simp: valid_pspace'_def valid_tcb'_def elim!: valid_objs_valid_tcbE dest!: st_tcb_ex_cap'')
      apply (fastforce dest!: st_tcb_ex_cap'')
-    apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def)
+    apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
    apply (erule delta_sym_refs)
     apply (fastforce elim!: obj_atE'
                       simp: state_refs_of'_def projectKOs tcb_bound_refs'_def

--- a/proof/refine/ARM_HYP/Ipc_R.thy
+++ b/proof/refine/ARM_HYP/Ipc_R.thy
@@ -3116,7 +3116,7 @@ lemma sai_invs'[wp]:
           apply (clarsimp simp: valid_obj'_def valid_ntfn'_def
                          split: list.splits)
          apply (clarsimp simp: invs'_def valid_state'_def)
-         apply (clarsimp simp: st_tcb_at_refs_of_rev' valid_idle'_def pred_tcb_at'_def
+         apply (clarsimp simp: st_tcb_at_refs_of_rev' valid_idle'_def pred_tcb_at'_def idle_tcb'_def
                         dest!: sym_refs_ko_atD' sym_refs_st_tcb_atD' sym_refs_obj_atD'
                         split: list.splits)
         apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
@@ -3723,7 +3723,7 @@ crunch cap_to'[wp]: doIPCTransfer "ex_nonz_cap_to' p"
 lemma st_tcb_idle':
   "\<lbrakk>valid_idle' s; st_tcb_at' P t s\<rbrakk> \<Longrightarrow>
    (t = ksIdleThread s) \<longrightarrow> P IdleThreadState"
-  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def)
+  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
 
 crunch idle'[wp]: getThreadCallerSlot "valid_idle'"
 crunch idle'[wp]: getThreadReplySlot "valid_idle'"

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -4160,6 +4160,7 @@ lemma createObjects_idle':
   apply (rule hoare_gen_asm)
   apply (rule hoare_pre)
    apply (clarsimp simp add: valid_idle'_def pred_tcb_at'_def)
+   apply (rule hoare_vcg_conj_lift)
    apply (rule hoare_as_subst [OF createObjects'_it])
    apply (wp createObjects_orig_obj_at'
              createObjects_orig_cte_wp_at2'

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -4161,10 +4161,10 @@ lemma createObjects_idle':
   apply (rule hoare_pre)
    apply (clarsimp simp add: valid_idle'_def pred_tcb_at'_def)
    apply (rule hoare_vcg_conj_lift)
-   apply (rule hoare_as_subst [OF createObjects'_it])
-   apply (wp createObjects_orig_obj_at'
-             createObjects_orig_cte_wp_at2'
-             hoare_vcg_all_lift | simp)+
+    apply (rule hoare_as_subst [OF createObjects'_it])
+    apply (wp createObjects_orig_obj_at'
+              createObjects_orig_cte_wp_at2'
+              hoare_vcg_all_lift | simp)+
   apply (clarsimp simp: valid_idle'_def projectKOs o_def
                         pred_tcb_at'_def valid_pspace'_def
                   cong: option.case_cong)

--- a/proof/refine/ARM_HYP/Schedule_R.thy
+++ b/proof/refine/ARM_HYP/Schedule_R.thy
@@ -967,7 +967,7 @@ lemma idle'_not_tcbQueued':
  shows "obj_at' (Not \<circ> tcbQueued) (ksIdleThread s) s"
  proof -
    from idle have stidle: "st_tcb_at' (Not \<circ> runnable') (ksIdleThread s) s"
-     by (clarsimp simp add: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs)
+     by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs idle_tcb'_def)
 
    with vq vq' show ?thesis
      by (rule valid_queues_not_runnable_not_queued)
@@ -985,15 +985,17 @@ proof -
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (clarsimp simp add: ct_not_inQ_ct idle'_activatable' idle'_not_tcbQueued'[simplified o_def]
+    apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def)
+    apply (frule (2) idle'_not_tcbQueued'[simplified o_def])
+    apply (clarsimp simp add: ct_not_inQ_ct idle'_activatable'
                               invs'_def cur_tcb'_def valid_state'_def valid_idle'_def
                               sch_act_wf ct_in_state'_def state_refs_of'_def
                               ps_clear_def valid_irq_node'_def
                               ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
                               valid_queues_def bitmapQ_defs valid_queues_no_bitmap_def valid_queues'_def
-                              all_invs_but_ct_idle_or_in_cur_domain'_def pred_tcb_at'_def
+                              pred_tcb_at'_def
                         cong: option.case_cong)
-    apply (clarsimp simp: obj_at'_def projectKOs)
+    apply (clarsimp simp: obj_at'_def projectKOs idle_tcb'_def)
     done
 qed
 
@@ -2164,7 +2166,7 @@ lemma switchToIdleThread_activatable_2[wp]:
                    ARM_HYP_H.switchToIdleThread_def)
   apply (wp setCurThread_ct_in_state)
   apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def valid_idle'_def
-                        pred_tcb_at'_def obj_at'_def)
+                        pred_tcb_at'_def obj_at'_def idle_tcb'_def)
   done
 
 lemma switchToThread_tcb_in_cur_domain':

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -834,18 +834,17 @@ lemma doReply_invs[wp]:
                    in hoare_strengthen_post [rotated])
             apply (clarsimp)
             apply (rule conjI)
-             apply (clarsimp simp add: invs'_def valid_state'_def valid_idle'_def)
+             apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def)
              apply (rule conjI)
               apply clarsimp
-             apply clarsimp
-             apply (drule idle_tcb_at'_split, clarsimp, drule (1) st_tcb_at'_eqD, simp)
+             apply (clarsimp simp: obj_at'_def idle_tcb'_def pred_tcb_at'_def)
             apply clarsimp
             apply (rule conjI)
-             apply (clarsimp simp add: invs'_def valid_state'_def valid_idle'_def)
+             apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def)
              apply (erule pred_tcb'_weakenE, clarsimp)
             apply (rule conjI)
-             apply (clarsimp simp add: invs'_def valid_state'_def valid_idle'_def pred_tcb_at'_def
-                                      obj_at'_def)
+             apply (clarsimp simp : invs'_def valid_state'_def valid_idle'_def pred_tcb_at'_def
+                                    obj_at'_def idle_tcb'_def)
             apply (rule conjI)
              apply clarsimp
              apply (frule invs'_not_runnable_not_queued)
@@ -1159,7 +1158,7 @@ lemma get_mrs_length_rv[wp]:
 lemma st_tcb_at_idle_thread':
   "\<lbrakk> st_tcb_at' P (ksIdleThread s) s; valid_idle' s \<rbrakk>
         \<Longrightarrow> P IdleThreadState"
-  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def)
+  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
 
 crunch tcb_at'[wp]: replyFromKernel "tcb_at' t"
 
@@ -1354,7 +1353,7 @@ lemma hinv_invs'[wp]:
          apply (subgoal_tac "thread \<noteq> ksIdleThread s", simp_all)[1]
           apply (fastforce elim!: pred_tcb'_weakenE st_tcb_ex_cap'')
          apply (clarsimp simp: valid_idle'_def valid_state'_def
-                               invs'_def pred_tcb_at'_def obj_at'_def)
+                               invs'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
         apply wp+
        apply (wp sts_invs_minor' setThreadState_st_tcb setThreadState_rct
                  ct_in_state_thread_state_lift' sts_st_tcb_at'_cases
@@ -2147,7 +2146,7 @@ proof
   assume "ksCurThread s = ksIdleThread s"
   with vi have "ct_in_state' idle' s"
     unfolding ct_in_state'_def valid_idle'_def
-    by (clarsimp simp: pred_tcb_at'_def obj_at'_def)
+    by (clarsimp simp: pred_tcb_at'_def obj_at'_def idle_tcb'_def)
 
   with cts show False
     unfolding ct_in_state'_def

--- a/proof/refine/ARM_HYP/TcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/TcbAcc_R.thy
@@ -541,10 +541,10 @@ lemma setObject_tcb_idle':
      (t = ksIdleThread s \<longrightarrow> idle' (tcbState v) \<and> tcbBoundNotification v = None)\<rbrace>
      setObject t (v :: tcb) \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (rule hoare_pre)
-  apply (rule_tac P="\<top>" in setObject_idle')
+  apply (rule setObject_idle')
       apply (simp add: objBits_simps')+
    apply (simp add: updateObject_default_inv)
-  apply (simp add: projectKOs)
+  apply (simp add: projectKOs idle_tcb_ps_def idle_tcb'_def)
   done
 
 lemma setObject_tcb_irq_node'[wp]:
@@ -826,14 +826,13 @@ lemma threadSet_idle'T:
   shows
   "\<lbrace>\<lambda>s. valid_idle' s
       \<and> (t = ksIdleThread s \<longrightarrow>
-          (\<forall>tcb. ko_at' tcb t s \<and> idle' (tcbState tcb) \<longrightarrow> idle' (tcbState (F tcb)))
-        \<and> (\<forall>tcb. ko_at' tcb t s \<and> tcbBoundNotification tcb = None \<longrightarrow> tcbBoundNotification (F tcb) = None))\<rbrace>
+          (\<forall>tcb. ko_at' tcb t s \<and> idle_tcb' tcb \<longrightarrow> idle_tcb' (F tcb)))\<rbrace>
      threadSet F t
    \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: threadSet_def)
   apply (wp setObject_tcb_idle' getObject_tcb_wp)
   apply (clarsimp simp: obj_at'_def projectKOs)
-  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs)
+  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs idle_tcb'_def)
   done
 
 lemmas threadSet_idle' =
@@ -3730,7 +3729,7 @@ lemma sts_valid_idle'[wp]:
    setThreadState ts t
    \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: setThreadState_def)
-  apply (wp threadSet_idle', simp+)+
+  apply (wpsimp wp: threadSet_idle' simp: idle_tcb'_def)
   done
 
 lemma sbn_valid_idle'[wp]:
@@ -3739,7 +3738,7 @@ lemma sbn_valid_idle'[wp]:
    setBoundNotification ntfn t
    \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: setBoundNotification_def)
-  apply (wp threadSet_idle', simp+)+
+  apply (wpsimp wp: threadSet_idle' simp: idle_tcb'_def)
   done
 
 lemma gts_sp':

--- a/proof/refine/ARM_HYP/Tcb_R.thy
+++ b/proof/refine/ARM_HYP/Tcb_R.thy
@@ -120,7 +120,7 @@ lemma activate_invs':
                in hoare_post_imp, clarsimp)
       apply (wp sch_act_simple_lift)+
     apply (clarsimp simp: valid_idle'_def invs'_def valid_state'_def
-                          pred_tcb_at'_def obj_at'_def
+                          pred_tcb_at'_def obj_at'_def idle_tcb'_def
                    elim!: pred_tcb'_weakenE)
    apply (wp gts_st_tcb')+
   apply (clarsimp simp: tcb_at_invs' ct_in_state'_def

--- a/proof/refine/ARM_HYP/VSpace_R.thy
+++ b/proof/refine/ARM_HYP/VSpace_R.thy
@@ -4513,8 +4513,15 @@ lemma storePDE_ifunsafe [wp]:
 
 lemma storePDE_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> storePDE p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  unfolding valid_idle'_def
-  by (rule hoare_lift_Pf [where f="ksIdleThread"]; wp)
+  apply (simp add: valid_idle'_def)
+  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (clarsimp simp: storePDE_def)
+   apply (wpsimp wp: obj_at_setObject2[where P="idle_tcb'", simplified] hoare_drop_imp)
+    apply (clarsimp dest!: updateObject_default_result)
+   apply simp
+   apply wpsimp
+  done
 
 lemma storePDE_arch'[wp]:
   "\<lbrace>\<lambda>s. P (ksArchState s)\<rbrace> storePDE param_a param_b \<lbrace>\<lambda>_ s. P (ksArchState s)\<rbrace>"
@@ -4715,8 +4722,15 @@ lemma storePTE_ifunsafe [wp]:
 
 lemma storePTE_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> storePTE p pte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  unfolding valid_idle'_def
-  by (rule hoare_lift_Pf [where f="ksIdleThread"]; wp)
+  apply (simp add: valid_idle'_def)
+  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (clarsimp simp: storePTE_def)
+   apply (wpsimp wp: obj_at_setObject2[where P="idle_tcb'", simplified] hoare_drop_imp)
+    apply (clarsimp dest!: updateObject_default_result)
+   apply simp
+  apply wpsimp
+  done
 
 lemma storePTE_arch'[wp]:
   "\<lbrace>\<lambda>s. P (ksArchState s)\<rbrace> storePTE param_a param_b \<lbrace>\<lambda>_ s. P (ksArchState s)\<rbrace>"
@@ -4919,8 +4933,13 @@ lemma setASIDPool_it' [wp]:
 
 lemma setASIDPool_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  unfolding valid_idle'_def
-  by (rule hoare_lift_Pf [where f="ksIdleThread"]; wp)
+  apply (simp add: valid_idle'_def)
+  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
+   apply (clarsimp dest!: updateObject_default_result)
+   apply wpsimp
+  done
 
 lemma setASIDPool_irq_states' [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>_. valid_irq_states'\<rbrace>"

--- a/proof/refine/ARM_HYP/VSpace_R.thy
+++ b/proof/refine/ARM_HYP/VSpace_R.thy
@@ -4511,17 +4511,14 @@ lemma storePDE_ifunsafe [wp]:
   apply simp
   done
 
+method valid_idle'_setObject uses simp =
+  simp add: valid_idle'_def, rule hoare_lift_Pf [where f="ksIdleThread"]; wpsimp?;
+  (wpsimp wp: obj_at_setObject2[where P="idle_tcb'", simplified] hoare_drop_imp
+        simp: simp
+   | clarsimp dest!: updateObject_default_result)+
+
 lemma storePDE_idle [wp]:
-  "\<lbrace>valid_idle'\<rbrace> storePDE p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  apply (simp add: valid_idle'_def)
-  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
-   apply (clarsimp simp: storePDE_def)
-   apply (wpsimp wp: obj_at_setObject2[where P="idle_tcb'", simplified] hoare_drop_imp)
-    apply (clarsimp dest!: updateObject_default_result)
-   apply simp
-   apply wpsimp
-  done
+  "\<lbrace>valid_idle'\<rbrace> storePDE p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>" by (valid_idle'_setObject simp: storePDE_def)
 
 lemma storePDE_arch'[wp]:
   "\<lbrace>\<lambda>s. P (ksArchState s)\<rbrace> storePDE param_a param_b \<lbrace>\<lambda>_ s. P (ksArchState s)\<rbrace>"
@@ -4721,16 +4718,7 @@ lemma storePTE_ifunsafe [wp]:
   done
 
 lemma storePTE_idle [wp]:
-  "\<lbrace>valid_idle'\<rbrace> storePTE p pte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  apply (simp add: valid_idle'_def)
-  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
-   apply (clarsimp simp: storePTE_def)
-   apply (wpsimp wp: obj_at_setObject2[where P="idle_tcb'", simplified] hoare_drop_imp)
-    apply (clarsimp dest!: updateObject_default_result)
-   apply simp
-  apply wpsimp
-  done
+  "\<lbrace>valid_idle'\<rbrace> storePTE p pte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>" by (valid_idle'_setObject simp: storePTE_def)
 
 lemma storePTE_arch'[wp]:
   "\<lbrace>\<lambda>s. P (ksArchState s)\<rbrace> storePTE param_a param_b \<lbrace>\<lambda>_ s. P (ksArchState s)\<rbrace>"
@@ -4932,14 +4920,7 @@ lemma setASIDPool_it' [wp]:
   by (wp setObject_it updateObject_default_inv|simp)+
 
 lemma setASIDPool_idle [wp]:
-  "\<lbrace>valid_idle'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  apply (simp add: valid_idle'_def)
-  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
-   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
-   apply (clarsimp dest!: updateObject_default_result)
-   apply wpsimp
-  done
+  "\<lbrace>valid_idle'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>rv. valid_idle'\<rbrace>" by valid_idle'_setObject
 
 lemma setASIDPool_irq_states' [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>_. valid_irq_states'\<rbrace>"

--- a/proof/refine/RISCV64/CSpace_R.thy
+++ b/proof/refine/RISCV64/CSpace_R.thy
@@ -2778,7 +2778,10 @@ lemma setCTE_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> setCTE p cte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: valid_idle'_def)
   apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (wp setCTE_pred_tcb_at')+
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (clarsimp simp: setCTE_def)
+   apply (rule setObject_cte_obj_at_tcb'[where P="idle_tcb'", simplified])
+  apply wpsimp
   done
 
 lemma getCTE_no_idle_cap:
@@ -2795,7 +2798,7 @@ lemma updateMDB_idle'[wp]:
   apply (clarsimp simp add: updateMDB_def)
   apply (rule hoare_pre)
   apply (wp | simp add: valid_idle'_def)+
-  done
+  by fastforce
 
 lemma updateCap_idle':
  "\<lbrace>valid_idle'\<rbrace> updateCap p c \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"

--- a/proof/refine/RISCV64/Invariants_H.thy
+++ b/proof/refine/RISCV64/Invariants_H.thy
@@ -842,11 +842,28 @@ definition sch_act_sane :: "kernel_state \<Rightarrow> bool" where
 abbreviation
   "sch_act_not t \<equiv> \<lambda>s. ksSchedulerAction s \<noteq> SwitchToThread t"
 
-abbreviation
-  "idle_tcb_at' \<equiv> pred_tcb_at' (\<lambda>t. (itcbState t, itcbBoundNotification t))"
+definition
+  idle_tcb'_2 :: "Structures_H.thread_state \<times> machine_word option \<Rightarrow> bool"
+where
+  "idle_tcb'_2 \<equiv> \<lambda>(st, ntfn_opt).
+                    (idle' st \<and> ntfn_opt = None)"
 
-definition valid_idle' :: "kernel_state \<Rightarrow> bool" where
-  "valid_idle' \<equiv> \<lambda>s. idle_tcb_at' (\<lambda>p. idle' (fst p) \<and> snd p = None) (ksIdleThread s) s"
+abbreviation
+  "idle_tcb' tcb \<equiv>
+      idle_tcb'_2 (tcbState tcb, tcbBoundNotification tcb)"
+
+lemmas idle_tcb'_def = idle_tcb'_2_def
+
+definition
+  valid_idle' :: "kernel_state \<Rightarrow> bool"
+where
+  "valid_idle' \<equiv>
+     \<lambda>s. obj_at' idle_tcb' (ksIdleThread s) s
+         \<and> idle_thread_ptr = ksIdleThread s"
+
+lemma valid_idle'_tcb_at':
+  "valid_idle' s \<Longrightarrow> obj_at' idle_tcb' (ksIdleThread s) s"
+  by (clarsimp simp: valid_idle'_def)
 
 definition valid_irq_node' :: "machine_word \<Rightarrow> kernel_state \<Rightarrow> bool" where
   "valid_irq_node' x \<equiv>
@@ -1492,7 +1509,7 @@ lemma valid_pspaceE' [elim]:
 lemma idle'_no_refs:
   "valid_idle' s \<Longrightarrow> state_refs_of' s (ksIdleThread s) = {}"
   by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def tcb_ntfn_is_bound'_def
-                     projectKO_eq project_inject state_refs_of'_def)
+                     projectKO_eq project_inject state_refs_of'_def idle_tcb'_def)
 
 lemma idle'_not_queued':
   "\<lbrakk>valid_idle' s; sym_refs (state_refs_of' s);
@@ -1613,7 +1630,7 @@ lemma valid_idle'_pspace_itI[elim]:
   "\<lbrakk> valid_idle' s; ksPSpace s = ksPSpace s'; ksIdleThread s = ksIdleThread s' \<rbrakk>
       \<Longrightarrow> valid_idle' s'"
   apply (clarsimp simp: valid_idle'_def ex_nonz_cap_to'_def)
-  apply (erule pred_tcb_at'_pspaceI, assumption)
+  apply (erule obj_at'_pspaceI, assumption)
   done
 
 lemma obj_at'_weaken:
@@ -2913,10 +2930,6 @@ lemma not_pred_tcb_at'_strengthen:
 lemma obj_at'_ko_at'_prop:
   "ko_at' ko t s \<Longrightarrow> obj_at' P t s = P ko"
   by (drule obj_at_ko_at', clarsimp simp: obj_at'_def)
-
-lemma idle_tcb_at'_split:
-  "idle_tcb_at' (\<lambda>p. P (fst p) \<and> Q (snd p)) t s \<Longrightarrow> st_tcb_at' P t s \<and> bound_tcb_at' Q t s"
-  by (clarsimp simp: pred_tcb_at'_def dest!: obj_at'_conj_distrib)
 
 lemma valid_queues_no_bitmap_def':
   "valid_queues_no_bitmap =

--- a/proof/refine/RISCV64/Invariants_H.thy
+++ b/proof/refine/RISCV64/Invariants_H.thy
@@ -842,24 +842,16 @@ definition sch_act_sane :: "kernel_state \<Rightarrow> bool" where
 abbreviation
   "sch_act_not t \<equiv> \<lambda>s. ksSchedulerAction s \<noteq> SwitchToThread t"
 
-definition
-  idle_tcb'_2 :: "Structures_H.thread_state \<times> machine_word option \<Rightarrow> bool"
-where
-  "idle_tcb'_2 \<equiv> \<lambda>(st, ntfn_opt).
-                    (idle' st \<and> ntfn_opt = None)"
+definition idle_tcb'_2 :: "Structures_H.thread_state \<times> machine_word option \<Rightarrow> bool" where
+  "idle_tcb'_2 \<equiv> \<lambda>(st, ntfn_opt). (idle' st \<and> ntfn_opt = None)"
 
 abbreviation
-  "idle_tcb' tcb \<equiv>
-      idle_tcb'_2 (tcbState tcb, tcbBoundNotification tcb)"
+  "idle_tcb' tcb \<equiv> idle_tcb'_2 (tcbState tcb, tcbBoundNotification tcb)"
 
 lemmas idle_tcb'_def = idle_tcb'_2_def
 
-definition
-  valid_idle' :: "kernel_state \<Rightarrow> bool"
-where
-  "valid_idle' \<equiv>
-     \<lambda>s. obj_at' idle_tcb' (ksIdleThread s) s
-         \<and> idle_thread_ptr = ksIdleThread s"
+definition valid_idle' :: "kernel_state \<Rightarrow> bool" where
+  "valid_idle' \<equiv> \<lambda>s. obj_at' idle_tcb' (ksIdleThread s) s \<and> idle_thread_ptr = ksIdleThread s"
 
 lemma valid_idle'_tcb_at':
   "valid_idle' s \<Longrightarrow> obj_at' idle_tcb' (ksIdleThread s) s"

--- a/proof/refine/RISCV64/IpcCancel_R.thy
+++ b/proof/refine/RISCV64/IpcCancel_R.thy
@@ -841,7 +841,7 @@ proof -
     apply (rule hoare_strengthen_post [OF get_ep_sp'])
     apply (clarsimp simp: pred_tcb_at' fun_upd_def[symmetric] conj_comms
                split del: if_split cong: if_cong)
-    apply (rule conjI, clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs)
+    apply (rule conjI, clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
     apply (frule obj_at_valid_objs', clarsimp)
     apply (clarsimp simp: projectKOs valid_obj'_def)
     apply (rule conjI)
@@ -2512,7 +2512,7 @@ lemma cancelBadgedSends_filterM_helper':
   apply (intro conjI)
       apply (clarsimp simp: valid_pspace'_def valid_tcb'_def elim!: valid_objs_valid_tcbE dest!: st_tcb_ex_cap'')
      apply (fastforce dest!: st_tcb_ex_cap'')
-    apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def)
+    apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
    apply (erule delta_sym_refs)
     apply (fastforce elim!: obj_atE'
                       simp: state_refs_of'_def tcb_bound_refs'_def

--- a/proof/refine/RISCV64/Ipc_R.thy
+++ b/proof/refine/RISCV64/Ipc_R.thy
@@ -3037,7 +3037,7 @@ lemma sai_invs'[wp]:
           apply (clarsimp simp: valid_obj'_def valid_ntfn'_def
                          split: list.splits)
          apply (clarsimp simp: invs'_def valid_state'_def)
-         apply (clarsimp simp: st_tcb_at_refs_of_rev' valid_idle'_def pred_tcb_at'_def
+         apply (clarsimp simp: st_tcb_at_refs_of_rev' valid_idle'_def pred_tcb_at'_def idle_tcb'_def
                         dest!: sym_refs_ko_atD' sym_refs_st_tcb_atD' sym_refs_obj_atD'
                         split: list.splits)
         apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
@@ -3629,7 +3629,7 @@ crunch cap_to'[wp]: doIPCTransfer "ex_nonz_cap_to' p"
 lemma st_tcb_idle':
   "\<lbrakk>valid_idle' s; st_tcb_at' P t s\<rbrakk> \<Longrightarrow>
    (t = ksIdleThread s) \<longrightarrow> P IdleThreadState"
-  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def)
+  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
 
 crunch idle'[wp]: getThreadCallerSlot "valid_idle'"
 crunch idle'[wp]: getThreadReplySlot "valid_idle'"

--- a/proof/refine/RISCV64/KHeap_R.thy
+++ b/proof/refine/RISCV64/KHeap_R.thy
@@ -1178,6 +1178,13 @@ lemma setObject_it[wp]:
   apply (wp x | simp)+
   done
 
+\<comment>\<open>
+  `idle_tcb_ps val` asserts that `val` is a pspace_storable value
+  which corresponds to an idle TCB.
+\<close>
+definition idle_tcb_ps :: "('a :: pspace_storable) \<Rightarrow> bool" where
+  "idle_tcb_ps val \<equiv> (\<exists>tcb. projectKO_opt (injectKO val) = Some tcb \<and> idle_tcb' tcb)"
+
 lemma setObject_idle':
   fixes v :: "'a :: pspace_storable"
   assumes R: "\<And>ko s y n. (updateObject v ko ptr y n s)
@@ -1188,12 +1195,9 @@ lemma setObject_idle':
        \<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace> updateObject v p q n ko
        \<lbrace>\<lambda>rv s. P (ksIdleThread s)\<rbrace>"
   shows      "\<lbrace>\<lambda>s. valid_idle' s \<and>
-                   (ptr = ksIdleThread s \<longrightarrow>
-                    (\<exists>obj (val :: 'a). projectKO_opt (injectKO val) = Some obj
-                                      \<and> idle' (tcbState obj) \<and> tcbBoundNotification obj = None)
-                    \<longrightarrow> (\<exists>obj. projectKO_opt (injectKO v) = Some obj \<and>
-                          idle' (tcbState obj) \<and> tcbBoundNotification obj = None)) \<and>
-                   P s\<rbrace>
+                   (ptr = ksIdleThread s
+                        \<longrightarrow> (\<exists>val :: 'a. idle_tcb_ps val)
+                        \<longrightarrow> idle_tcb_ps v)\<rbrace>
                 setObject ptr v
               \<lbrace>\<lambda>rv s. valid_idle' s\<rbrace>"
   apply (simp add: valid_idle'_def pred_tcb_at'_def o_def)
@@ -1202,8 +1206,7 @@ lemma setObject_idle':
     apply (simp add: pred_tcb_at'_def obj_at'_real_def)
     apply (rule setObject_ko_wp_at [OF R n m])
    apply (wp z)
-  apply (clarsimp simp add: pred_tcb_at'_def obj_at'_real_def ko_wp_at'_def)
-  apply (drule_tac x=obj in spec, simp)
+  apply (clarsimp simp add: pred_tcb_at'_def obj_at'_real_def ko_wp_at'_def idle_tcb_ps_def)
   apply (clarsimp simp add: project_inject)
   done
 
@@ -1727,8 +1730,8 @@ lemma setEndpoint_idle'[wp]:
    setEndpoint p v
    \<lbrace>\<lambda>_. valid_idle'\<rbrace>"
   unfolding setEndpoint_def
-  apply (wp setObject_idle'[where P="\<top>"])
-       apply (simp add: objBits_simps' updateObject_default_inv)+
+  apply (wp setObject_idle')
+       apply (simp add: objBits_simps' updateObject_default_inv idle_tcb_ps_def)+
   done
 
 crunch it[wp]: setEndpoint "\<lambda>s. P (ksIdleThread s)"
@@ -1860,8 +1863,8 @@ lemma setNotification_ifunsafe'[wp]:
 lemma setNotification_idle'[wp]:
   "\<lbrace>\<lambda>s. valid_idle' s\<rbrace> setNotification p v \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   unfolding setNotification_def
-  apply (wp setObject_idle'[where P="\<top>"])
-        apply (simp add: objBits_simps' updateObject_default_inv)+
+  apply (wp setObject_idle')
+        apply (simp add: objBits_simps' updateObject_default_inv idle_tcb_ps_def)+
   done
 
 crunch it[wp]: setNotification "\<lambda>s. P (ksIdleThread s)"

--- a/proof/refine/RISCV64/Retype_R.thy
+++ b/proof/refine/RISCV64/Retype_R.thy
@@ -4034,11 +4034,12 @@ lemma createObjects_idle':
   apply (rule hoare_gen_asm)
   apply (rule hoare_pre)
    apply (clarsimp simp add: valid_idle'_def pred_tcb_at'_def)
+   apply (rule hoare_vcg_conj_lift)
    apply (rule hoare_as_subst [OF createObjects'_it])
    apply (wp createObjects_orig_obj_at'
              createObjects_orig_cte_wp_at2'
              hoare_vcg_all_lift | simp)+
-  apply (clarsimp simp: valid_idle'_def o_def
+  apply (clarsimp simp: valid_idle'_def projectKOs o_def
                         pred_tcb_at'_def valid_pspace'_def
                   cong: option.case_cong)
   apply auto

--- a/proof/refine/RISCV64/Schedule_R.thy
+++ b/proof/refine/RISCV64/Schedule_R.thy
@@ -783,7 +783,7 @@ lemma idle'_not_tcbQueued':
  shows "obj_at' (Not \<circ> tcbQueued) (ksIdleThread s) s"
 proof -
   from idle have stidle: "st_tcb_at' (Not \<circ> runnable') (ksIdleThread s) s"
-    by (clarsimp simp add: valid_idle'_def pred_tcb_at'_def obj_at'_def)
+    by (clarsimp simp add: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
   with vq vq' show ?thesis
     by (rule valid_queues_not_runnable_not_queued)
 qed
@@ -800,15 +800,17 @@ proof -
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (clarsimp simp add: ct_not_inQ_ct idle'_activatable' idle'_not_tcbQueued'[simplified o_def]
+    apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def)
+    apply (frule (2) idle'_not_tcbQueued'[simplified o_def])
+    apply (clarsimp simp add: ct_not_inQ_ct idle'_activatable'
                               invs'_def cur_tcb'_def valid_state'_def valid_idle'_def
                               sch_act_wf ct_in_state'_def state_refs_of'_def
                               ps_clear_def valid_irq_node'_def
                               ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
                               valid_queues_def bitmapQ_defs valid_queues_no_bitmap_def valid_queues'_def
-                              all_invs_but_ct_idle_or_in_cur_domain'_def pred_tcb_at'_def
+                              pred_tcb_at'_def
                         cong: option.case_cong)
-    apply (clarsimp simp: obj_at'_def)
+    apply (clarsimp simp: obj_at'_def idle_tcb'_def )
     done
 qed
 
@@ -1971,7 +1973,7 @@ lemma switchToIdleThread_activatable_2[wp]:
                    RISCV64_H.switchToIdleThread_def)
   apply (wp setCurThread_ct_in_state)
   apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def valid_idle'_def
-                        pred_tcb_at'_def obj_at'_def)
+                        pred_tcb_at'_def obj_at'_def idle_tcb'_def)
   done
 
 lemma switchToThread_tcb_in_cur_domain':

--- a/proof/refine/RISCV64/Syscall_R.thy
+++ b/proof/refine/RISCV64/Syscall_R.thy
@@ -827,18 +827,17 @@ lemma doReply_invs[wp]:
                    in hoare_strengthen_post [rotated])
             apply (clarsimp)
             apply (rule conjI)
-             apply (clarsimp simp add: invs'_def valid_state'_def valid_idle'_def)
+             apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def)
              apply (rule conjI)
               apply clarsimp
-             apply clarsimp
-             apply (drule idle_tcb_at'_split, clarsimp, drule (1) st_tcb_at'_eqD, simp)
+             apply (clarsimp simp: obj_at'_def idle_tcb'_def pred_tcb_at'_def)
             apply clarsimp
             apply (rule conjI)
-             apply (clarsimp simp add: invs'_def valid_state'_def valid_idle'_def)
+             apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def)
              apply (erule pred_tcb'_weakenE, clarsimp)
             apply (rule conjI)
-             apply (clarsimp simp add: invs'_def valid_state'_def valid_idle'_def pred_tcb_at'_def
-                                      obj_at'_def)
+             apply (clarsimp simp : invs'_def valid_state'_def valid_idle'_def pred_tcb_at'_def
+                                    obj_at'_def idle_tcb'_def)
             apply (rule conjI)
              apply clarsimp
              apply (frule invs'_not_runnable_not_queued)
@@ -1148,7 +1147,7 @@ lemma get_mrs_length_rv[wp]:
 lemma st_tcb_at_idle_thread':
   "\<lbrakk> st_tcb_at' P (ksIdleThread s) s; valid_idle' s \<rbrakk>
         \<Longrightarrow> P IdleThreadState"
-  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def)
+  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
 
 crunch tcb_at'[wp]: replyFromKernel "tcb_at' t"
 
@@ -1311,7 +1310,7 @@ lemma hinv_invs'[wp]:
          apply (subgoal_tac "thread \<noteq> ksIdleThread s", simp_all)[1]
           apply (fastforce elim!: pred_tcb'_weakenE st_tcb_ex_cap'')
          apply (clarsimp simp: valid_idle'_def valid_state'_def
-                               invs'_def pred_tcb_at'_def obj_at'_def)
+                               invs'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
         apply wp+
        apply (rule_tac Q="\<lambda>rv'. invs' and valid_invocation' rv
                                 and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
@@ -2076,7 +2075,7 @@ proof
   assume "ksCurThread s = ksIdleThread s"
   with vi have "ct_in_state' idle' s"
     unfolding ct_in_state'_def valid_idle'_def
-    by (clarsimp simp: pred_tcb_at'_def obj_at'_def)
+    by (clarsimp simp: pred_tcb_at'_def obj_at'_def idle_tcb'_def)
 
   with cts show False
     unfolding ct_in_state'_def

--- a/proof/refine/RISCV64/TcbAcc_R.thy
+++ b/proof/refine/RISCV64/TcbAcc_R.thy
@@ -570,13 +570,13 @@ lemma setObject_tcb_iflive':
 
 lemma setObject_tcb_idle':
   "\<lbrace>\<lambda>s. valid_idle' s \<and>
-     (t = ksIdleThread s \<longrightarrow> idle' (tcbState v) \<and> tcbBoundNotification v = None)\<rbrace>
+     (t = ksIdleThread s \<longrightarrow> idle_tcb' v)\<rbrace>
      setObject t (v :: tcb) \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (rule hoare_pre)
-  apply (rule_tac P="\<top>" in setObject_idle')
+  apply (rule setObject_idle')
       apply (simp add: objBits_simps')+
    apply (simp add: updateObject_default_inv)
-  apply simp
+  apply (simp add: idle_tcb_ps_def)
   done
 
 lemma setObject_tcb_irq_node'[wp]:
@@ -838,8 +838,7 @@ lemma threadSet_idle'T:
   shows
   "\<lbrace>\<lambda>s. valid_idle' s
       \<and> (t = ksIdleThread s \<longrightarrow>
-          (\<forall>tcb. ko_at' tcb t s \<and> idle' (tcbState tcb) \<longrightarrow> idle' (tcbState (F tcb)))
-        \<and> (\<forall>tcb. ko_at' tcb t s \<and> tcbBoundNotification tcb = None \<longrightarrow> tcbBoundNotification (F tcb) = None))\<rbrace>
+          (\<forall>tcb. ko_at' tcb t s \<and> idle_tcb' tcb \<longrightarrow> idle_tcb' (F tcb)))\<rbrace>
      threadSet F t
    \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: threadSet_def)
@@ -3719,7 +3718,7 @@ lemma sts_valid_idle'[wp]:
    setThreadState ts t
    \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: setThreadState_def)
-  apply (wp threadSet_idle', simp+)+
+  apply (wpsimp wp: threadSet_idle' simp: idle_tcb'_def)
   done
 
 lemma sbn_valid_idle'[wp]:
@@ -3728,7 +3727,7 @@ lemma sbn_valid_idle'[wp]:
    setBoundNotification ntfn t
    \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: setBoundNotification_def)
-  apply (wp threadSet_idle', simp+)+
+  apply (wpsimp wp: threadSet_idle' simp: idle_tcb'_def)
   done
 
 lemma gts_sp':

--- a/proof/refine/RISCV64/Tcb_R.thy
+++ b/proof/refine/RISCV64/Tcb_R.thy
@@ -119,7 +119,7 @@ lemma activate_invs':
                in hoare_post_imp, clarsimp)
       apply (wp sch_act_simple_lift)+
     apply (clarsimp simp: valid_idle'_def invs'_def valid_state'_def
-                          pred_tcb_at'_def obj_at'_def
+                          pred_tcb_at'_def obj_at'_def idle_tcb'_def
                    elim!: pred_tcb'_weakenE)
    apply (wp gts_st_tcb')+
   apply (clarsimp simp: tcb_at_invs' ct_in_state'_def

--- a/proof/refine/RISCV64/VSpace_R.thy
+++ b/proof/refine/RISCV64/VSpace_R.thy
@@ -925,16 +925,15 @@ lemma storePTE_ifunsafe [wp]:
   apply simp
   done
 
+method valid_idle'_setObject uses simp =
+  simp add: valid_idle'_def, rule hoare_lift_Pf [where f="ksIdleThread"]; wpsimp?;
+  (wpsimp wp: obj_at_setObject2[where P="idle_tcb'", simplified] hoare_drop_imp
+        simp: simp
+   | clarsimp dest!: updateObject_default_result)+
+
+
 lemma storePTE_idle [wp]:
-  "\<lbrace>valid_idle'\<rbrace> storePTE p pte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  apply (simp add: valid_idle'_def)
-  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
-   apply (clarsimp simp: storePTE_def)
-   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
-   apply (clarsimp dest!: updateObject_default_result)
-  apply wpsimp
-  done
+  "\<lbrace>valid_idle'\<rbrace> storePTE p pte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>" by (valid_idle'_setObject simp: storePTE_def)
 
 crunch arch' [wp]: storePTE "\<lambda>s. P (ksArchState s)"
 

--- a/proof/refine/RISCV64/VSpace_R.thy
+++ b/proof/refine/RISCV64/VSpace_R.thy
@@ -927,8 +927,14 @@ lemma storePTE_ifunsafe [wp]:
 
 lemma storePTE_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> storePTE p pte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  unfolding valid_idle'_def
-  by (rule hoare_lift_Pf [where f="ksIdleThread"]; wp)
+  apply (simp add: valid_idle'_def)
+  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (clarsimp simp: storePTE_def)
+   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
+   apply (clarsimp dest!: updateObject_default_result)
+  apply wpsimp
+  done
 
 crunch arch' [wp]: storePTE "\<lambda>s. P (ksArchState s)"
 

--- a/proof/refine/X64/CSpace_R.thy
+++ b/proof/refine/X64/CSpace_R.thy
@@ -2884,7 +2884,10 @@ lemma setCTE_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> setCTE p cte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: valid_idle'_def)
   apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (wp setCTE_pred_tcb_at')+
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (clarsimp simp: setCTE_def)
+   apply (rule setObject_cte_obj_at_tcb'[where P="idle_tcb'", simplified])
+  apply wpsimp
   done
 
 crunch it[wp]: getCTE "\<lambda>s. P (ksIdleThread s)"
@@ -2903,7 +2906,7 @@ lemma updateMDB_idle'[wp]:
   apply (clarsimp simp add: updateMDB_def)
   apply (rule hoare_pre)
   apply (wp | simp add: valid_idle'_def)+
-  done
+  by fastforce
 
 lemma updateCap_idle':
  "\<lbrace>valid_idle'\<rbrace> updateCap p c \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"

--- a/proof/refine/X64/Invariants_H.thy
+++ b/proof/refine/X64/Invariants_H.thy
@@ -1020,10 +1020,7 @@ where
 abbreviation
   "sch_act_not t \<equiv> \<lambda>s. ksSchedulerAction s \<noteq> SwitchToThread t"
 
-definition
-  idle_tcb'_2 :: "Structures_H.thread_state \<times> machine_word option
-                  \<Rightarrow> bool"
-where
+definition idle_tcb'_2 :: "Structures_H.thread_state \<times> machine_word option \<Rightarrow> bool" where
   "idle_tcb'_2 \<equiv> \<lambda>(st, ntfn_opt). (idle' st \<and> ntfn_opt = None)"
 
 abbreviation
@@ -1031,12 +1028,8 @@ abbreviation
 
 lemmas idle_tcb'_def = idle_tcb'_2_def
 
-definition
-  valid_idle' :: "kernel_state \<Rightarrow> bool"
-where
-  "valid_idle' \<equiv>
-     \<lambda>s. obj_at' idle_tcb' (ksIdleThread s) s
-         \<and> idle_thread_ptr = ksIdleThread s"
+definition valid_idle' :: "kernel_state \<Rightarrow> bool" where
+  "valid_idle' \<equiv> \<lambda>s. obj_at' idle_tcb' (ksIdleThread s) s \<and> idle_thread_ptr = ksIdleThread s"
 
 lemma valid_idle'_tcb_at':
   "valid_idle' s \<Longrightarrow> obj_at' idle_tcb' (ksIdleThread s) s"

--- a/proof/refine/X64/Invariants_H.thy
+++ b/proof/refine/X64/Invariants_H.thy
@@ -1020,12 +1020,27 @@ where
 abbreviation
   "sch_act_not t \<equiv> \<lambda>s. ksSchedulerAction s \<noteq> SwitchToThread t"
 
-abbreviation "idle_tcb_at' \<equiv> pred_tcb_at' (\<lambda>t. (itcbState t, itcbBoundNotification t))"
+definition
+  idle_tcb'_2 :: "Structures_H.thread_state \<times> machine_word option
+                  \<Rightarrow> bool"
+where
+  "idle_tcb'_2 \<equiv> \<lambda>(st, ntfn_opt). (idle' st \<and> ntfn_opt = None)"
+
+abbreviation
+  "idle_tcb' tcb \<equiv> idle_tcb'_2 (tcbState tcb, tcbBoundNotification tcb)"
+
+lemmas idle_tcb'_def = idle_tcb'_2_def
 
 definition
   valid_idle' :: "kernel_state \<Rightarrow> bool"
 where
-  "valid_idle' \<equiv> \<lambda>s. idle_tcb_at' (\<lambda>p. idle' (fst p) \<and> snd p = None) (ksIdleThread s) s"
+  "valid_idle' \<equiv>
+     \<lambda>s. obj_at' idle_tcb' (ksIdleThread s) s
+         \<and> idle_thread_ptr = ksIdleThread s"
+
+lemma valid_idle'_tcb_at':
+  "valid_idle' s \<Longrightarrow> obj_at' idle_tcb' (ksIdleThread s) s"
+  by (clarsimp simp: valid_idle'_def)
 
 definition
   valid_irq_node' :: "machine_word \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -1761,7 +1776,7 @@ lemma valid_pspaceE' [elim]:
 lemma idle'_no_refs:
   "valid_idle' s \<Longrightarrow> state_refs_of' s (ksIdleThread s) = {}"
   by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def tcb_ntfn_is_bound'_def
-                     projectKO_eq project_inject state_refs_of'_def)
+                     projectKO_eq project_inject state_refs_of'_def idle_tcb'_def)
 
 lemma idle'_not_queued':
   "\<lbrakk>valid_idle' s; sym_refs (state_refs_of' s);
@@ -1896,7 +1911,7 @@ lemma valid_idle'_pspace_itI[elim]:
   "\<lbrakk> valid_idle' s; ksPSpace s = ksPSpace s'; ksIdleThread s = ksIdleThread s' \<rbrakk>
       \<Longrightarrow> valid_idle' s'"
   apply (clarsimp simp: valid_idle'_def ex_nonz_cap_to'_def)
-  apply (erule pred_tcb_at'_pspaceI, assumption)
+  apply (erule obj_at'_pspaceI, assumption)
   done
 
 lemma obj_at'_weaken:
@@ -3286,10 +3301,6 @@ lemma not_pred_tcb_at'_strengthen:
 lemma obj_at'_ko_at'_prop:
   "ko_at' ko t s \<Longrightarrow> obj_at' P t s = P ko"
   by (drule obj_at_ko_at', clarsimp simp: obj_at'_def)
-
-lemma idle_tcb_at'_split:
-  "idle_tcb_at' (\<lambda>p. P (fst p) \<and> Q (snd p)) t s \<Longrightarrow> st_tcb_at' P t s \<and> bound_tcb_at' Q t s"
-  by (clarsimp simp: pred_tcb_at'_def dest!: obj_at'_conj_distrib)
 
 lemma valid_queues_no_bitmap_def':
   "valid_queues_no_bitmap =

--- a/proof/refine/X64/IpcCancel_R.thy
+++ b/proof/refine/X64/IpcCancel_R.thy
@@ -851,7 +851,7 @@ proof -
     apply (rule hoare_strengthen_post [OF get_ep_sp'])
     apply (clarsimp simp: pred_tcb_at' fun_upd_def[symmetric] conj_comms
                split del: if_split cong: if_cong)
-    apply (rule conjI, clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs)
+    apply (rule conjI, clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
     apply (frule obj_at_valid_objs', clarsimp)
     apply (clarsimp simp: projectKOs valid_obj'_def)
     apply (rule conjI)
@@ -2597,7 +2597,7 @@ lemma cancelBadgedSends_filterM_helper':
   apply (intro conjI)
       apply (clarsimp simp: valid_pspace'_def valid_tcb'_def elim!: valid_objs_valid_tcbE dest!: st_tcb_ex_cap'')
      apply (fastforce dest!: st_tcb_ex_cap'')
-    apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def)
+    apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
    apply (erule delta_sym_refs)
     apply (fastforce elim!: obj_atE'
                       simp: state_refs_of'_def projectKOs tcb_bound_refs'_def

--- a/proof/refine/X64/Ipc_R.thy
+++ b/proof/refine/X64/Ipc_R.thy
@@ -3083,7 +3083,7 @@ lemma sai_invs'[wp]:
           apply (clarsimp simp: valid_obj'_def valid_ntfn'_def
                          split: list.splits)
          apply (clarsimp simp: invs'_def valid_state'_def)
-         apply (clarsimp simp: st_tcb_at_refs_of_rev' valid_idle'_def pred_tcb_at'_def
+         apply (clarsimp simp: st_tcb_at_refs_of_rev' valid_idle'_def pred_tcb_at'_def idle_tcb'_def
                         dest!: sym_refs_ko_atD' sym_refs_st_tcb_atD' sym_refs_obj_atD'
                         split: list.splits)
         apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
@@ -3689,7 +3689,7 @@ crunch cap_to'[wp]: doIPCTransfer "ex_nonz_cap_to' p"
 lemma st_tcb_idle':
   "\<lbrakk>valid_idle' s; st_tcb_at' P t s\<rbrakk> \<Longrightarrow>
    (t = ksIdleThread s) \<longrightarrow> P IdleThreadState"
-  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def)
+  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
 
 crunch idle'[wp]: getThreadCallerSlot "valid_idle'"
 crunch idle'[wp]: getThreadReplySlot "valid_idle'"

--- a/proof/refine/X64/KHeap_R.thy
+++ b/proof/refine/X64/KHeap_R.thy
@@ -1213,6 +1213,13 @@ lemma setObject_it[wp]:
   apply (wp x | simp)+
   done
 
+\<comment>\<open>
+  `idle_tcb_ps val` asserts that `val` is a pspace_storable value
+  which corresponds to an idle TCB.
+\<close>
+definition idle_tcb_ps :: "('a :: pspace_storable) \<Rightarrow> bool" where
+  "idle_tcb_ps val \<equiv> (\<exists>tcb. projectKO_opt (injectKO val) = Some tcb \<and> idle_tcb' tcb)"
+
 lemma setObject_idle':
   fixes v :: "'a :: pspace_storable"
   assumes R: "\<And>ko s x y n. (updateObject v ko ptr y n s)
@@ -1223,12 +1230,9 @@ lemma setObject_idle':
        \<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace> updateObject v p q n ko
        \<lbrace>\<lambda>rv s. P (ksIdleThread s)\<rbrace>"
   shows      "\<lbrace>\<lambda>s. valid_idle' s \<and>
-                   (ptr = ksIdleThread s \<longrightarrow>
-                    (\<exists>obj (val :: 'a). projectKO_opt (injectKO val) = Some obj
-                                      \<and> idle' (tcbState obj) \<and> tcbBoundNotification obj = None)
-                    \<longrightarrow> (\<exists>obj. projectKO_opt (injectKO v) = Some obj \<and>
-                          idle' (tcbState obj) \<and> tcbBoundNotification obj = None)) \<and>
-                   P s\<rbrace>
+                   (ptr = ksIdleThread s
+                        \<longrightarrow> (\<exists>val :: 'a. idle_tcb_ps val)
+                        \<longrightarrow> idle_tcb_ps v)\<rbrace>
                 setObject ptr v
               \<lbrace>\<lambda>rv s. valid_idle' s\<rbrace>"
   apply (simp add: valid_idle'_def pred_tcb_at'_def o_def)
@@ -1237,8 +1241,7 @@ lemma setObject_idle':
     apply (simp add: pred_tcb_at'_def obj_at'_real_def)
     apply (rule setObject_ko_wp_at [OF R n m])
    apply (wp z)
-  apply (clarsimp simp add: pred_tcb_at'_def obj_at'_real_def ko_wp_at'_def)
-  apply (drule_tac x=obj in spec, simp)
+  apply (clarsimp simp add: pred_tcb_at'_def obj_at'_real_def ko_wp_at'_def idle_tcb_ps_def)
   apply (clarsimp simp add: project_inject)
   apply (drule_tac x=obja in spec, simp)
   done
@@ -1771,9 +1774,9 @@ lemma setEndpoint_idle'[wp]:
    setEndpoint p v
    \<lbrace>\<lambda>_. valid_idle'\<rbrace>"
   unfolding setEndpoint_def
-  apply (wp setObject_idle'[where P="\<top>"])
+  apply (wp setObject_idle')
        apply (simp add: objBits_simps' updateObject_default_inv)+
-  apply (clarsimp simp: projectKOs)
+  apply (clarsimp simp: projectKOs idle_tcb_ps_def)
   done
 
 crunch it[wp]: setEndpoint "\<lambda>s. P (ksIdleThread s)"
@@ -1912,9 +1915,9 @@ lemma setNotification_ifunsafe'[wp]:
 lemma setNotification_idle'[wp]:
   "\<lbrace>\<lambda>s. valid_idle' s\<rbrace> setNotification p v \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   unfolding setNotification_def
-  apply (wp setObject_idle'[where P="\<top>"])
+  apply (wp setObject_idle')
         apply (simp add: objBits_simps' updateObject_default_inv)+
-  apply (clarsimp simp: projectKOs)
+  apply (clarsimp simp: projectKOs idle_tcb_ps_def)
   done
 
 crunch it[wp]: setNotification "\<lambda>s. P (ksIdleThread s)"

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -4203,10 +4203,10 @@ lemma createObjects_idle':
   apply (rule hoare_pre)
    apply (clarsimp simp add: valid_idle'_def pred_tcb_at'_def)
    apply (rule hoare_vcg_conj_lift)
-   apply (rule hoare_as_subst [OF createObjects'_it])
-   apply (wp createObjects_orig_obj_at'
-             createObjects_orig_cte_wp_at2'
-             hoare_vcg_all_lift | simp)+
+    apply (rule hoare_as_subst [OF createObjects'_it])
+    apply (wp createObjects_orig_obj_at'
+              createObjects_orig_cte_wp_at2'
+              hoare_vcg_all_lift | simp)+
   apply (clarsimp simp: valid_idle'_def projectKOs o_def
                         pred_tcb_at'_def valid_pspace'_def
                   cong: option.case_cong)

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -4202,6 +4202,7 @@ lemma createObjects_idle':
   apply (rule hoare_gen_asm)
   apply (rule hoare_pre)
    apply (clarsimp simp add: valid_idle'_def pred_tcb_at'_def)
+   apply (rule hoare_vcg_conj_lift)
    apply (rule hoare_as_subst [OF createObjects'_it])
    apply (wp createObjects_orig_obj_at'
              createObjects_orig_cte_wp_at2'

--- a/proof/refine/X64/Schedule_R.thy
+++ b/proof/refine/X64/Schedule_R.thy
@@ -724,7 +724,7 @@ lemma arch_switchToIdleThread_corres:
   apply (simp add: arch_switch_to_idle_thread_def
                 X64_H.switchToIdleThread_def)
   apply (corressimp corres: getIdleThread_corres setVMRoot_corres)
-  apply (clarsimp simp: valid_idle_def valid_idle'_def pred_tcb_at_def obj_at_def is_tcb)
+  apply (clarsimp simp: valid_idle_def valid_idle'_def pred_tcb_at_def obj_at_def is_tcb obj_at'_def)
   done
 
 lemma switchToIdleThread_corres:
@@ -853,7 +853,7 @@ lemma idle'_not_tcbQueued':
  shows "obj_at' (Not \<circ> tcbQueued) (ksIdleThread s) s"
  proof -
    from idle have stidle: "st_tcb_at' (Not \<circ> runnable') (ksIdleThread s) s"
-     by (clarsimp simp add: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs)
+     by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs idle_tcb'_def)
 
    with vq vq' show ?thesis
      by (rule valid_queues_not_runnable_not_queued)
@@ -871,15 +871,17 @@ proof -
   show ?thesis
     apply (simp add: setCurThread_def)
     apply wp
-    apply (clarsimp simp add: ct_not_inQ_ct idle'_activatable' idle'_not_tcbQueued'[simplified o_def]
+    apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def)
+    apply (frule (2) idle'_not_tcbQueued'[simplified o_def])
+    apply (clarsimp simp add: ct_not_inQ_ct idle'_activatable'
                               invs'_def cur_tcb'_def valid_state'_def valid_idle'_def
                               sch_act_wf ct_in_state'_def state_refs_of'_def
                               ps_clear_def valid_irq_node'_def
                               ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
                               valid_queues_def bitmapQ_defs valid_queues_no_bitmap_def valid_queues'_def
-                              all_invs_but_ct_idle_or_in_cur_domain'_def pred_tcb_at'_def
+                              pred_tcb_at'_def
                         cong: option.case_cong)
-    apply (clarsimp simp: obj_at'_def projectKOs)
+    apply (clarsimp simp: obj_at'_def projectKOs idle_tcb'_def)
     done
 qed
 
@@ -1995,7 +1997,7 @@ lemma switchToIdleThread_activatable_2[wp]:
                    X64_H.switchToIdleThread_def)
   apply (wp setCurThread_ct_in_state)
   apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def valid_idle'_def
-                        pred_tcb_at'_def obj_at'_def)
+                        pred_tcb_at'_def obj_at'_def idle_tcb'_def)
   done
 
 lemma switchToThread_tcb_in_cur_domain':

--- a/proof/refine/X64/Syscall_R.thy
+++ b/proof/refine/X64/Syscall_R.thy
@@ -830,18 +830,17 @@ lemma doReply_invs[wp]:
                    in hoare_strengthen_post [rotated])
             apply (clarsimp)
             apply (rule conjI)
-             apply (clarsimp simp add: invs'_def valid_state'_def valid_idle'_def)
+             apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def)
              apply (rule conjI)
               apply clarsimp
-             apply clarsimp
-             apply (drule idle_tcb_at'_split, clarsimp, drule (1) st_tcb_at'_eqD, simp)
+             apply (clarsimp simp: obj_at'_def idle_tcb'_def pred_tcb_at'_def)
             apply clarsimp
             apply (rule conjI)
-             apply (clarsimp simp add: invs'_def valid_state'_def valid_idle'_def)
+             apply (clarsimp simp: invs'_def valid_state'_def valid_idle'_def)
              apply (erule pred_tcb'_weakenE, clarsimp)
             apply (rule conjI)
-             apply (clarsimp simp add: invs'_def valid_state'_def valid_idle'_def pred_tcb_at'_def
-                                      obj_at'_def)
+             apply (clarsimp simp : invs'_def valid_state'_def valid_idle'_def pred_tcb_at'_def
+                                    obj_at'_def idle_tcb'_def)
             apply (rule conjI)
              apply clarsimp
              apply (frule invs'_not_runnable_not_queued)
@@ -1154,7 +1153,7 @@ lemma get_mrs_length_rv[wp]:
 lemma st_tcb_at_idle_thread':
   "\<lbrakk> st_tcb_at' P (ksIdleThread s) s; valid_idle' s \<rbrakk>
         \<Longrightarrow> P IdleThreadState"
-  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def)
+  by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
 
 crunch tcb_at'[wp]: replyFromKernel "tcb_at' t"
 
@@ -1317,7 +1316,7 @@ lemma hinv_invs'[wp]:
          apply (subgoal_tac "thread \<noteq> ksIdleThread s", simp_all)[1]
           apply (fastforce elim!: pred_tcb'_weakenE st_tcb_ex_cap'')
          apply (clarsimp simp: valid_idle'_def valid_state'_def
-                               invs'_def pred_tcb_at'_def obj_at'_def)
+                               invs'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
         apply wp+
        apply (rule_tac Q="\<lambda>rv'. invs' and valid_invocation' rv
                                 and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
@@ -2083,7 +2082,7 @@ proof
   assume "ksCurThread s = ksIdleThread s"
   with vi have "ct_in_state' idle' s"
     unfolding ct_in_state'_def valid_idle'_def
-    by (clarsimp simp: pred_tcb_at'_def obj_at'_def)
+    by (clarsimp simp: pred_tcb_at'_def obj_at'_def idle_tcb'_def)
 
   with cts show False
     unfolding ct_in_state'_def

--- a/proof/refine/X64/TcbAcc_R.thy
+++ b/proof/refine/X64/TcbAcc_R.thy
@@ -559,10 +559,10 @@ lemma setObject_tcb_idle':
      (t = ksIdleThread s \<longrightarrow> idle' (tcbState v) \<and> tcbBoundNotification v = None)\<rbrace>
      setObject t (v :: tcb) \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (rule hoare_pre)
-  apply (rule_tac P="\<top>" in setObject_idle')
+  apply (rule setObject_idle')
       apply (simp add: objBits_simps')+
    apply (simp add: updateObject_default_inv)
-  apply (simp add: projectKOs)
+  apply (simp add: projectKOs idle_tcb_ps_def idle_tcb'_def)
   done
 
 lemma setObject_tcb_irq_node'[wp]:
@@ -829,14 +829,13 @@ lemma threadSet_idle'T:
   shows
   "\<lbrace>\<lambda>s. valid_idle' s
       \<and> (t = ksIdleThread s \<longrightarrow>
-          (\<forall>tcb. ko_at' tcb t s \<and> idle' (tcbState tcb) \<longrightarrow> idle' (tcbState (F tcb)))
-        \<and> (\<forall>tcb. ko_at' tcb t s \<and> tcbBoundNotification tcb = None \<longrightarrow> tcbBoundNotification (F tcb) = None))\<rbrace>
+          (\<forall>tcb. ko_at' tcb t s \<and> idle_tcb' tcb \<longrightarrow> idle_tcb' (F tcb)))\<rbrace>
      threadSet F t
    \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: threadSet_def)
   apply (wp setObject_tcb_idle' getObject_tcb_wp)
   apply (clarsimp simp: obj_at'_def projectKOs)
-  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs)
+  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs idle_tcb'_def)
   done
 
 lemmas threadSet_idle' =
@@ -3711,7 +3710,7 @@ lemma sts_valid_idle'[wp]:
    setThreadState ts t
    \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: setThreadState_def)
-  apply (wp threadSet_idle', simp+)+
+  apply (wpsimp wp: threadSet_idle' simp: idle_tcb'_def)
   done
 
 lemma sbn_valid_idle'[wp]:
@@ -3720,7 +3719,7 @@ lemma sbn_valid_idle'[wp]:
    setBoundNotification ntfn t
    \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
   apply (simp add: setBoundNotification_def)
-  apply (wp threadSet_idle', simp+)+
+  apply (wpsimp wp: threadSet_idle' simp: idle_tcb'_def)
   done
 
 lemma gts_sp':

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -120,7 +120,7 @@ lemma activate_invs':
                in hoare_post_imp, clarsimp)
       apply (wp sch_act_simple_lift)+
     apply (clarsimp simp: valid_idle'_def invs'_def valid_state'_def
-                          pred_tcb_at'_def obj_at'_def
+                          pred_tcb_at'_def obj_at'_def idle_tcb'_def
                    elim!: pred_tcb'_weakenE)
    apply (wp gts_st_tcb')+
   apply (clarsimp simp: tcb_at_invs' ct_in_state'_def

--- a/proof/refine/X64/VSpace_R.thy
+++ b/proof/refine/X64/VSpace_R.thy
@@ -1835,8 +1835,14 @@ lemma storePDE_ifunsafe [wp]:
 
 lemma storePDE_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> storePDE p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  unfolding valid_idle'_def
-  by (rule hoare_lift_Pf [where f="ksIdleThread"]; wp)
+  apply (simp add: valid_idle'_def)
+  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (clarsimp simp: storePDE_def)
+   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
+   apply (clarsimp dest!: updateObject_default_result)
+   apply wpsimp
+  done
 
 lemma storePDPTE_ifunsafe [wp]:
   "\<lbrace>if_unsafe_then_cap'\<rbrace> storePDPTE p pde \<lbrace>\<lambda>rv. if_unsafe_then_cap'\<rbrace>"
@@ -1850,8 +1856,14 @@ lemma storePDPTE_ifunsafe [wp]:
 
 lemma storePDPTE_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> storePDPTE p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  unfolding valid_idle'_def
-  by (rule hoare_lift_Pf [where f="ksIdleThread"]; wp)
+  apply (simp add: valid_idle'_def)
+  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (clarsimp simp: storePDPTE_def)
+   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
+   apply (clarsimp dest!: updateObject_default_result)
+   apply wpsimp
+  done
 
 lemma storePML4E_ifunsafe [wp]:
   "\<lbrace>if_unsafe_then_cap'\<rbrace> storePML4E p pde \<lbrace>\<lambda>rv. if_unsafe_then_cap'\<rbrace>"
@@ -1865,8 +1877,14 @@ lemma storePML4E_ifunsafe [wp]:
 
 lemma storePML4E_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> storePML4E p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  unfolding valid_idle'_def
-  by (rule hoare_lift_Pf [where f="ksIdleThread"]; wp)
+  apply (simp add: valid_idle'_def)
+  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (clarsimp simp: storePML4E_def)
+   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
+   apply (clarsimp dest!: updateObject_default_result)
+   apply wpsimp
+  done
 
 crunches storePDE, storePDPTE, storePML4E
   for arch'[wp]: "\<lambda>s. P (ksArchState s)"
@@ -2187,8 +2205,14 @@ lemma storePTE_ifunsafe [wp]:
 
 lemma storePTE_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> storePTE p pte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  unfolding valid_idle'_def
-  by (rule hoare_lift_Pf [where f="ksIdleThread"]; wp)
+  apply (simp add: valid_idle'_def)
+  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (clarsimp simp: storePTE_def)
+   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
+   apply (clarsimp dest!: updateObject_default_result)
+  apply wpsimp
+  done
 
 crunch arch' [wp]: storePTE "\<lambda>s. P (ksArchState s)"
 
@@ -2369,8 +2393,13 @@ lemma setASIDPool_it' [wp]:
 
 lemma setASIDPool_idle [wp]:
   "\<lbrace>valid_idle'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  unfolding valid_idle'_def
-  by (rule hoare_lift_Pf [where f="ksIdleThread"]; wp)
+  apply (simp add: valid_idle'_def)
+  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
+   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
+   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
+   apply (clarsimp dest!: updateObject_default_result)
+   apply wpsimp
+  done
 
 lemma setASIDPool_irq_states' [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>_. valid_irq_states'\<rbrace>"

--- a/proof/refine/X64/VSpace_R.thy
+++ b/proof/refine/X64/VSpace_R.thy
@@ -1833,16 +1833,14 @@ lemma storePDE_ifunsafe [wp]:
   apply simp
   done
 
+method valid_idle'_setObject uses simp =
+  simp add: valid_idle'_def, rule hoare_lift_Pf [where f="ksIdleThread"]; wpsimp?;
+  (wpsimp wp: obj_at_setObject2[where P="idle_tcb'", simplified] hoare_drop_imp
+        simp: simp
+   | clarsimp dest!: updateObject_default_result)+
+
 lemma storePDE_idle [wp]:
-  "\<lbrace>valid_idle'\<rbrace> storePDE p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  apply (simp add: valid_idle'_def)
-  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
-   apply (clarsimp simp: storePDE_def)
-   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
-   apply (clarsimp dest!: updateObject_default_result)
-   apply wpsimp
-  done
+  "\<lbrace>valid_idle'\<rbrace> storePDE p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>" by (valid_idle'_setObject simp: storePDE_def)
 
 lemma storePDPTE_ifunsafe [wp]:
   "\<lbrace>if_unsafe_then_cap'\<rbrace> storePDPTE p pde \<lbrace>\<lambda>rv. if_unsafe_then_cap'\<rbrace>"
@@ -1855,15 +1853,7 @@ lemma storePDPTE_ifunsafe [wp]:
   done
 
 lemma storePDPTE_idle [wp]:
-  "\<lbrace>valid_idle'\<rbrace> storePDPTE p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  apply (simp add: valid_idle'_def)
-  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
-   apply (clarsimp simp: storePDPTE_def)
-   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
-   apply (clarsimp dest!: updateObject_default_result)
-   apply wpsimp
-  done
+  "\<lbrace>valid_idle'\<rbrace> storePDPTE p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>" by (valid_idle'_setObject simp: storePDPTE_def)
 
 lemma storePML4E_ifunsafe [wp]:
   "\<lbrace>if_unsafe_then_cap'\<rbrace> storePML4E p pde \<lbrace>\<lambda>rv. if_unsafe_then_cap'\<rbrace>"
@@ -1876,15 +1866,7 @@ lemma storePML4E_ifunsafe [wp]:
   done
 
 lemma storePML4E_idle [wp]:
-  "\<lbrace>valid_idle'\<rbrace> storePML4E p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  apply (simp add: valid_idle'_def)
-  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
-   apply (clarsimp simp: storePML4E_def)
-   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
-   apply (clarsimp dest!: updateObject_default_result)
-   apply wpsimp
-  done
+  "\<lbrace>valid_idle'\<rbrace> storePML4E p pde \<lbrace>\<lambda>rv. valid_idle'\<rbrace>" by (valid_idle'_setObject simp: storePML4E_def)
 
 crunches storePDE, storePDPTE, storePML4E
   for arch'[wp]: "\<lambda>s. P (ksArchState s)"
@@ -2204,15 +2186,7 @@ lemma storePTE_ifunsafe [wp]:
   done
 
 lemma storePTE_idle [wp]:
-  "\<lbrace>valid_idle'\<rbrace> storePTE p pte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  apply (simp add: valid_idle'_def)
-  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
-   apply (clarsimp simp: storePTE_def)
-   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
-   apply (clarsimp dest!: updateObject_default_result)
-  apply wpsimp
-  done
+  "\<lbrace>valid_idle'\<rbrace> storePTE p pte \<lbrace>\<lambda>rv. valid_idle'\<rbrace>" by (valid_idle'_setObject simp: storePTE_def)
 
 crunch arch' [wp]: storePTE "\<lambda>s. P (ksArchState s)"
 
@@ -2392,14 +2366,7 @@ lemma setASIDPool_it' [wp]:
   by (wp setObject_it updateObject_default_inv|simp)+
 
 lemma setASIDPool_idle [wp]:
-  "\<lbrace>valid_idle'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
-  apply (simp add: valid_idle'_def)
-  apply (rule hoare_lift_Pf [where f="ksIdleThread"])
-   apply (intro hoare_vcg_conj_lift; (solves \<open>wpsimp\<close>)?)
-   apply (rule obj_at_setObject2[where P="idle_tcb'", simplified])
-   apply (clarsimp dest!: updateObject_default_result)
-   apply wpsimp
-  done
+  "\<lbrace>valid_idle'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>rv. valid_idle'\<rbrace>" by valid_idle'_setObject
 
 lemma setASIDPool_irq_states' [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>_. valid_irq_states'\<rbrace>"


### PR DESCRIPTION
This is a small byproduct of ARM-RISCV syncing for MCS Refine verification. The hope is that doing this on master will get the CRefine in a better state for later when we start on it.

I updated ARM_HYP and X64 as well this time to see what it’s like, but, for the remaining changes, I will be updating only ARM and RISCV whenever possible.

[Testboard](https://bamboo.ts.data61.csiro.au/browse/L4V-GHTESTBOARD31)


