### PR TITLE
Overrun

### DIFF
--- a/lib/Monad_WP/WhileLoopRules.thy
+++ b/lib/Monad_WP/WhileLoopRules.thy
@@ -421,6 +421,17 @@ lemma whileLoop_wp':
   apply (fastforce intro: whileLoop_wp)
   done
 
+lemma valid_whileLoop_cond_fail:
+  assumes pre_implies_post: "\<And>s. P r s \<Longrightarrow> Q r s"
+      and pre_implies_fail: "\<And>s. P r s \<Longrightarrow> \<not> C r s"
+    shows "\<lbrace> P r \<rbrace> whileLoop C B r \<lbrace> Q \<rbrace>"
+  apply (insert assms)
+  apply (clarsimp simp: valid_def)
+  apply (subst (asm) whileLoop_cond_fail)
+   apply blast
+  apply (clarsimp simp: return_def)
+  done
+
 lemma whileLoop_wp_inv [wp]:
   "\<lbrakk> \<And>r. \<lbrace>\<lambda>s. I r s \<and> C r s\<rbrace> B r \<lbrace>I\<rbrace>; \<And>r s. \<lbrakk>I r s; \<not> C r s\<rbrakk> \<Longrightarrow> Q r s \<rbrakk>
       \<Longrightarrow> \<lbrace> I r \<rbrace> whileLoop_inv C B r I M \<lbrace> Q \<rbrace>"

--- a/proof/invariant-abstract/ARM/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedAux_AI.thy
@@ -73,7 +73,7 @@ lemma dmo_getCurrentTime_vmt_sp[wp, DetSchedAux_AI_assms]:
       apply (subst group_add_class.diff_conv_add_uminus)
       apply (subst minus_one_norm_num)
       apply clarsimp
-      apply (insert cur_time_bound_no_overflow')
+      apply (insert getCurrentTime_buffer_no_overflow')
       done
    subgoal for s
      apply (subst (asm) linorder_class.not_le)
@@ -92,7 +92,7 @@ lemma dmo_getCurrentTime_vmt_sp[wp, DetSchedAux_AI_assms]:
      apply (subst group_add_class.diff_conv_add_uminus)
      apply (subst minus_one_norm_num)
      apply clarsimp
-     apply (insert cur_time_bound_no_overflow')
+     apply (insert getCurrentTime_buffer_no_overflow')
      done
   subgoal for s
     apply (subst (asm) linorder_class.not_le)
@@ -110,9 +110,9 @@ lemma dmo_getCurrentTime_vmt_sp[wp, DetSchedAux_AI_assms]:
       apply simp
      apply simp
      apply (subst unat_minus_plus_one)
-      apply (insert cur_time_bound_no_overflow cur_time_bound_no_overflow')
+      apply (insert getCurrentTime_buffer_no_overflow getCurrentTime_buffer_no_overflow')
       apply (clarsimp simp: kernelWCET_ticks_def MAX_PERIOD_def)
-     apply (insert cur_time_bound_no_overflow'_stronger)
+     apply (insert getCurrentTime_buffer_no_overflow'_stronger)
      apply (subst unat_add_lem')
       apply (clarsimp simp: kernelWCET_ticks_def MAX_PERIOD_def max_word_def)
      apply fastforce

--- a/proof/invariant-abstract/DetSchedAux_AI.thy
+++ b/proof/invariant-abstract/DetSchedAux_AI.thy
@@ -599,7 +599,7 @@ lemma non_empty_sc_replies_nonz_cap:
 lemma valid_machine_time_refill_ready_buffer:
   "valid_machine_time s \<Longrightarrow> cur_time s \<le> cur_time s + kernelWCET_ticks"
   apply (clarsimp simp: valid_machine_time_def)
-  apply (insert cur_time_bound_minus)
+  apply (insert getCurrentTime_buffer_minus)
   by (metis (no_types, hide_lams) Groups.add_ac(2) olen_add_eqv plus_minus_no_overflow_ab
                                   uminus_add_conv_diff word_n1_ge word_plus_mono_right2)
 
@@ -806,14 +806,14 @@ lemma valid_sched_tcb_state_preservation_gen:
   apply (prop_tac "active_sc_valid_refills s'")
    subgoal for s rv s'
    unfolding active_sc_valid_refills_def
-   apply (frule use_valid[OF _ sc_refill_cfg2[where P="cfg_valid_refills and cfg_bounded_release_time (cur_time s)"]], intro conjI)
+   apply (frule use_valid[OF _ sc_refill_cfg2[where P="cfg_valid_refills and cfg_bounded_release_time"]], intro conjI)
      apply (clarsimp simp: pred_map_pred_conj)
     apply simp
    apply (frule use_valid[OF _ cur_time_nondecreasing], simp)
    apply clarsimp
    apply (drule_tac x=scp
                 and P="\<lambda>p. is_active_sc p s'
-                           \<longrightarrow> pred_map (cfg_valid_refills and cfg_bounded_release_time (cur_time s))
+                           \<longrightarrow> pred_map (cfg_valid_refills and cfg_bounded_release_time)
                                         (sc_refill_cfgs_of s') p"
                  in spec)
    apply (clarsimp simp: bounded_release_time_def  word_le_nat_alt vs_all_heap_simps pred_conj_def)
@@ -1049,7 +1049,7 @@ lemma update_time_stamp_is_refill_ready[wp]:
     apply (subst olen_add_eqv)
     apply (subst add.commute)
     apply (rule no_plus_overflow_neg)
-    apply (insert cur_time_bound_minus')
+    apply (insert getCurrentTime_buffer_minus')
     apply fastforce
    apply wpsimp
   by simp

--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -176,7 +176,8 @@ crunches awaken
   (wp: crunch_wps)
 
 crunch domain_list_inv[wp]: commit_time "\<lambda>s. P (domain_list s)"
-  (simp: Let_def wp: get_sched_context_wp get_refills_wp crunch_wps)
+  (simp: Let_def
+   wp: get_sched_context_wp get_refills_wp crunch_wps hoare_vcg_all_lift hoare_vcg_if_lift2)
 
 crunch domain_list_inv[wp]: refill_new "\<lambda>s. P (domain_list s)"
   (simp: Let_def crunch_simps wp: get_sched_context_wp get_refills_wp wp: crunch_wps)

--- a/proof/invariant-abstract/Ipc_AI.thy
+++ b/proof/invariant-abstract/Ipc_AI.thy
@@ -2075,14 +2075,6 @@ crunches sched_context_resume
   for valid_irq_node[wp]: valid_irq_node
   (wp: crunch_wps)
 
-lemma set_refills_wp:
-  "\<lbrace>\<lambda>s. \<forall>sc n. obj_at ((=) (SchedContext sc n)) sc_ptr s
-               \<longrightarrow> P (s\<lparr>kheap := kheap s(sc_ptr \<mapsto> SchedContext (sc\<lparr>sc_refills := refills\<rparr>) n)\<rparr>)\<rbrace>
-     set_refills sc_ptr refills
-   \<lbrace>\<lambda>r. P\<rbrace>"
-  unfolding set_refills_def
-  by (wpsimp wp: update_sched_context_wp)
-
 crunches maybe_donate_sc
   for equal_kernel_mappings[wp]: equal_kernel_mappings
   and pspace_in_kernel_window[wp]: pspace_in_kernel_window

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedAux_AI.thy
@@ -84,7 +84,7 @@ lemma dmo_getCurrentTime_vmt_sp[wp, DetSchedAux_AI_assms]:
      apply (subst group_add_class.diff_conv_add_uminus)
      apply (subst minus_one_norm_num)
      apply clarsimp
-     apply (insert cur_time_bound_no_overflow')
+     apply (insert getCurrentTime_buffer_no_overflow')
      done
   subgoal for s
     apply (subst (asm) linorder_class.not_le)
@@ -102,9 +102,9 @@ lemma dmo_getCurrentTime_vmt_sp[wp, DetSchedAux_AI_assms]:
       apply simp
      apply simp
      apply (subst unat_minus_plus_one)
-      apply (insert cur_time_bound_no_overflow cur_time_bound_no_overflow')
+      apply (insert getCurrentTime_buffer_no_overflow getCurrentTime_buffer_no_overflow')
       apply (clarsimp simp: kernelWCET_ticks_def MAX_PERIOD_def)
-     apply (insert cur_time_bound_no_overflow'_stronger)
+     apply (insert getCurrentTime_buffer_no_overflow'_stronger)
      apply (subst unat_add_lem')
       apply (clarsimp simp: kernelWCET_ticks_def MAX_PERIOD_def max_word_def)
      apply fastforce

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -795,6 +795,14 @@ definition
 where
   "refills_unat_sum refills = sum_list (map unat (map r_amount refills))"
 
+lemma refills_unat_sum_member_bound:
+  "\<lbrakk>refills_unat_sum refills \<le> amount; refill \<in> set refills\<rbrakk> \<Longrightarrow> unat (r_amount refill) \<le> amount"
+  apply (clarsimp simp: refills_unat_sum_def)
+  apply (prop_tac "unat (r_amount refill) \<in> set (map unat (map r_amount refills))")
+   apply fastforce
+  apply (fastforce dest!: member_le_sum_list)
+  done
+
 fun
   refill_list_to_intervals :: "refill list \<Rightarrow> (nat set) list"
 where
@@ -1288,7 +1296,7 @@ lemma schedule_used_ordered_disjoint:
 lemma schedule_used_no_overflow:
   "\<lbrakk>no_overflow list; no_overflow [new];
     list \<noteq> [] \<longrightarrow> unat (r_time (last list)) + unat (r_amount (last list)) + unat (r_amount new)
-                   \<le> unat (max_word :: time)\<rbrakk>
+                   \<le> unat max_time\<rbrakk>
    \<Longrightarrow> no_overflow (schedule_used full list new)"
   apply (cases list)
    apply (clarsimp simp: schedule_used_def Let_def ordered_disjoint_def)
@@ -1653,19 +1661,6 @@ lemma refill_update_invs:
   unfolding refill_update_def
   apply (wpsimp wp: set_sc_obj_ref_invs_no_change hoare_vcg_all_lift hoare_vcg_imp_lift'
                     hoare_vcg_disj_lift)
-  done
-
-lemma set_refills_bound_sc:
-  "\<lbrace>\<lambda>s. bound_sc_tcb_at P (cur_thread s) s\<rbrace>
-   set_refills sc_ptr refills
-   \<lbrace>\<lambda>rv s. bound_sc_tcb_at P (cur_thread s) s\<rbrace>"
-  by (wpsimp simp: set_refills_def)
-
-lemma refill_budget_check_bound_sc:
-  "refill_budget_check usage \<lbrace>\<lambda>s. bound_sc_tcb_at P (cur_thread s) s\<rbrace>"
-  apply (wpsimp simp: refill_budget_check_defs is_round_robin_def merge_refills_def
-                  wp: whileLoop_wp' get_refills_wp set_refills_wp
-         | clarsimp simp: pred_tcb_at_def obj_at_def)+
   done
 
 lemma refill_reset_rr_invs[wp]:

--- a/proof/refine/ARM/Interrupt_R.thy
+++ b/proof/refine/ARM/Interrupt_R.thy
@@ -650,7 +650,7 @@ lemma doMachineOp_ackDeadlineIRQ_invs'[wp]:
 
 lemma handle_interrupt_corres:
   "corres dc
-     (einvs and current_time_bounded 1) (invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive))
+     (einvs and current_time_bounded 2) (invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive))
      (handle_interrupt irq) (handleInterrupt irq)"
   (is "corres dc ?Q ?P' ?f ?g")
   apply (simp add: handle_interrupt_def handleInterrupt_def )

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -3053,7 +3053,7 @@ lemma cteInsert_ct'[wp]:
 lemma maybeDonateSc_corres:
   "corres dc (tcb_at tcb_ptr and ntfn_at ntfn_ptr and invs and weak_valid_sched_action
               and valid_ready_qs and active_sc_valid_refills and valid_release_q
-              and current_time_bounded 1 and ex_nonz_cap_to tcb_ptr)
+              and current_time_bounded 2 and ex_nonz_cap_to tcb_ptr)
              (tcb_at' tcb_ptr and ntfn_at' ntfn_ptr and invs' and ex_nonz_cap_to' tcb_ptr)
              (maybe_donate_sc tcb_ptr ntfn_ptr)
              (maybeDonateSc tcb_ptr ntfn_ptr)"
@@ -3086,7 +3086,7 @@ lemma maybeDonateSc_corres:
              apply (rule_tac Q="\<lambda>_. invs and valid_ready_qs and
                        active_sc_valid_refills and valid_release_q and
                        sc_not_in_release_q xa and active_sc_valid_refills and
-                       current_time_bounded 1 and sc_tcb_sc_at ((=) (Some tcb_ptr)) xa"
+                       current_time_bounded 2 and sc_tcb_sc_at ((=) (Some tcb_ptr)) xa"
                     in hoare_strengthen_post[rotated])
               apply (fastforce simp: sc_at_pred_n_def obj_at_def)
              apply (wpsimp wp: sched_context_donate_invs
@@ -3352,7 +3352,7 @@ lemma thread_state_tcb_in_WaitingNtfn'_q:
   done
 
 lemma sendSignal_corres:
-  "corres dc (einvs and ntfn_at ep and current_time_bounded 1) (invs' and ntfn_at' ep)
+  "corres dc (einvs and ntfn_at ep and current_time_bounded 2) (invs' and ntfn_at' ep)
              (send_signal ep bg) (sendSignal ep bg)"
   apply (simp add: send_signal_def sendSignal_def Let_def)
   apply add_sym_refs
@@ -3362,7 +3362,7 @@ lemma sendSignal_corres:
                  where
                  R  = "\<lambda>rv. einvs and ntfn_at ep and valid_ntfn rv and
                             ko_at (Structures_A.Notification rv) ep
-                            and current_time_bounded 1" and
+                            and current_time_bounded 2" and
                  R' = "\<lambda>rv'. invs' and ntfn_at' ep and
                              valid_ntfn' rv' and ko_at' rv' ep"])
        defer
@@ -3412,7 +3412,7 @@ lemma sendSignal_corres:
                       (=) Structures_A.thread_state.IdleThreadState) tptr and
                    ex_nonz_cap_to tptr and fault_tcb_at ((=) None) tptr and
                    valid_sched and scheduler_act_not tptr and active_sc_valid_refills
-                   and current_time_bounded 1"
+                   and current_time_bounded 2"
                  in hoare_strengthen_post[rotated])
            apply (clarsimp simp: invs_def valid_state_def valid_pspace_def valid_sched_def pred_disj_def)
           apply (wpsimp wp: cancel_ipc_simple_except_awaiting_reply cancel_ipc_ex_nonz_cap_to_tcb)
@@ -4655,7 +4655,7 @@ lemma receiveSignal_corres:
  "\<lbrakk> is_ntfn_cap cap; cap_relation cap cap' \<rbrakk> \<Longrightarrow>
   corres dc ((invs and weak_valid_sched_action and scheduler_act_not thread and valid_ready_qs
                    and st_tcb_at active thread and active_sc_valid_refills and valid_release_q
-                   and current_time_bounded 1 and (\<lambda>s. thread = cur_thread s) and not_queued thread
+                   and current_time_bounded 2 and (\<lambda>s. thread = cur_thread s) and not_queued thread
                    and not_in_release_q thread and ex_nonz_cap_to thread) and valid_cap cap)
             (invs' and tcb_at' thread and ex_nonz_cap_to' thread and valid_cap' cap')
             (receive_signal thread cap isBlocking) (receiveSignal thread cap' isBlocking)"

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -388,7 +388,7 @@ lemma pinv_corres:
    corres (dc \<oplus> (=))
      (einvs and valid_machine_time and valid_invocation i
             and schact_is_rct
-            and current_time_bounded 1
+            and current_time_bounded 2
             and ct_active
             and ct_released
             and ct_not_in_release_q
@@ -445,7 +445,7 @@ lemma pinv_corres:
          apply (clarsimp simp: liftME_def)
          apply (rule corres_guard_imp)
            apply (erule tcbinv_corres)
-          apply fastforce+
+          apply (fastforce simp: current_time_bounded_def)+
         \<comment> \<open>domain cap\<close>
         apply (clarsimp simp: invoke_domain_def)
         apply (rule corres_guard_imp)
@@ -1156,7 +1156,7 @@ lemma hinv_corres:
    corres (dc \<oplus> dc)
           (einvs and valid_machine_time and schact_is_rct and ct_active and ct_released
            and (\<lambda>s. active_sc_tcb_at (cur_thread s) s) and ct_not_in_release_q
-           and current_time_bounded 1)
+           and current_time_bounded 2)
           (invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
           (handle_invocation call blocking can_donate first_phase cptr)
           (handleInvocation call blocking can_donate first_phase cptr')"
@@ -1204,7 +1204,7 @@ lemma hinv_corres:
                                  and (\<lambda>s. thread = cur_thread s)
                                  and st_tcb_at active thread
                                  and ct_not_in_release_q and ct_released
-                                 and current_time_bounded 1"
+                                 and current_time_bounded 2"
                         in hoare_post_imp)
               apply (clarsimp simp: simple_from_active ct_in_state_def schact_is_rct_def
                              elim!: st_tcb_weakenE)
@@ -1336,7 +1336,7 @@ lemma hs_corres:
   "corres (dc \<oplus> dc)
           (einvs and valid_machine_time and schact_is_rct and ct_active and
            ct_released and (\<lambda>s. active_sc_tcb_at (cur_thread s) s) and
-           ct_not_in_release_q and current_time_bounded 1)
+           ct_not_in_release_q and current_time_bounded 2)
           (invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
            (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_active')
           (handle_send blocking) (handleSend blocking)"
@@ -1591,7 +1591,7 @@ lemmas cteDeleteOne_st_tcb_at_simple'[wp] =
 lemma hc_corres:
   "corres (dc \<oplus> dc) (einvs and valid_machine_time and schact_is_rct and ct_active and
                       ct_released and (\<lambda>s. active_sc_tcb_at (cur_thread s) s) and
-                      ct_not_in_release_q and current_time_bounded 1)
+                      ct_not_in_release_q and current_time_bounded 2)
               (invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
                 (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
                 ct_active')

--- a/spec/haskell/src/SEL4/Model/StateData.lhs
+++ b/spec/haskell/src/SEL4/Model/StateData.lhs
@@ -220,6 +220,9 @@ Similarly, these functions access the idle thread pointer, the ready queue for a
 > getCurSc :: Kernel (PPtr SchedContext)
 > getCurSc = gets ksCurSc
 
+> readCurSc :: KernelR (PPtr SchedContext)
+> readCurSc = asks ksCurSc
+
 > setCurSc :: PPtr SchedContext -> Kernel ()
 > setCurSc scptr = modify (\ks -> ks { ksCurSc = scptr })
 

--- a/spec/machine/MachineExports.thy
+++ b/spec/machine/MachineExports.thy
@@ -76,16 +76,17 @@ requalify_facts
   MAX_PERIOD_US_def
   MAX_PERIOD_def
   us_to_ticks_mult
-  cur_time_bound_no_overflow
+  getCurrentTime_buffer_no_overflow
   kernelWCET_ticks_def
   replicate_no_overflow
-  cur_time_bound_nonzero
-  cur_time_bound_nonzero'
-  cur_time_bound_no_overflow'
-  cur_time_bound_minus
-  cur_time_bound_minus'
-  cur_time_bound_no_overflow'_stronger
+  getCurrentTime_buffer_nonzero
+  getCurrentTime_buffer_nonzero'
+  getCurrentTime_buffer_no_overflow'
+  getCurrentTime_buffer_no_overflow'_stronger
+  getCurrentTime_buffer_minus
+  getCurrentTime_buffer_minus'
   MAX_PERIOD_mult
+  MAX_PERIOD_mult'
 
 (* HERE IS THE PLACE FOR GENERIC WORD LEMMAS FOR ALL ARCHITECTURES *)
 

--- a/spec/machine/RISCV64/MachineOps.thy
+++ b/spec/machine/RISCV64/MachineOps.thy
@@ -120,13 +120,14 @@ and
 and
   kernelWCET_ticks_no_overflow: "4 * unat (us_to_ticks kernelWCET_us) \<le> unat max_time"
 and
-  cur_time_bound_no_overflow: "3 * unat (us_to_ticks MAX_PERIOD_US) + unat (us_to_ticks kernelWCET_us)
-                               < unat max_time"
+  getCurrentTime_buffer_no_overflow:
+    "unat (us_to_ticks kernelWCET_us) + 5 * unat (us_to_ticks MAX_PERIOD_US)
+     < unat max_time"
 and
   us_to_ticks_mult: "unat n * unat (us_to_ticks a) \<le> unat max_time
                      \<Longrightarrow> n * us_to_ticks a = us_to_ticks (n * a)"
 and
-  cur_time_bound_nonzero: "0 < us_to_ticks kernelWCET_us + 3 * (us_to_ticks MAX_PERIOD_US)"
+  getCurrentTime_buffer_nonzero: "0 < us_to_ticks kernelWCET_us + 5 * (us_to_ticks MAX_PERIOD_US)"
 
 definition "MAX_PERIOD = us_to_ticks MAX_PERIOD_US"
 
@@ -139,6 +140,9 @@ context Arch begin global_naming RISCV64
 
 definition
   "kernelWCET_ticks = us_to_ticks (kernelWCET_us)"
+
+abbreviation (input) getCurrentTime_buffer where
+  "getCurrentTime_buffer \<equiv> kernelWCET_ticks + 5 * MAX_PERIOD"
 
 lemma replicate_no_overflow:
   "n * unat (a :: ticks) \<le> unat (upper_bound :: ticks)
@@ -153,19 +157,19 @@ lemma kernelWCET_ticks_pos2: "0 < 2 * kernelWCET_ticks"
    using replicate_no_overflow apply fastforce
   using kernelWCET_ticks_no_overflow by force
 
-lemma cur_time_bound_nonzero':
-  "0 < kernelWCET_ticks + 3 * MAX_PERIOD"
-  apply (insert cur_time_bound_nonzero)
+lemma getCurrentTime_buffer_nonzero':
+  "0 < getCurrentTime_buffer"
+  apply (insert getCurrentTime_buffer_nonzero)
   apply (clarsimp simp: kernelWCET_ticks_def MAX_PERIOD_def)
   done
 
-lemma cur_time_bound_no_overflow':
-  "unat kernelWCET_ticks + 3 * unat MAX_PERIOD = unat (kernelWCET_ticks + 3 * MAX_PERIOD)"
-  apply (prop_tac "3 * unat (us_to_ticks MAX_PERIOD_US) = unat (3 * us_to_ticks MAX_PERIOD_US)")
-   apply (prop_tac "3 * unat (us_to_ticks MAX_PERIOD_US) \<le> unat (max_word :: 64 word)")
-    using cur_time_bound_no_overflow apply linarith
-   apply (fastforce dest: replicate_no_overflow[where a="us_to_ticks MAX_PERIOD_US" and n=3])
-  apply (insert cur_time_bound_no_overflow)
+lemma getCurrentTime_buffer_no_overflow':
+  "unat kernelWCET_ticks + 5 * unat MAX_PERIOD = unat (kernelWCET_ticks + 5 * MAX_PERIOD)"
+  apply (prop_tac "5 * unat (us_to_ticks MAX_PERIOD_US) = unat (5 * us_to_ticks MAX_PERIOD_US)")
+   apply (prop_tac "5 * unat (us_to_ticks MAX_PERIOD_US) \<le> unat (max_word :: 64 word)")
+    using getCurrentTime_buffer_no_overflow apply linarith
+   apply (fastforce dest: replicate_no_overflow[where a="us_to_ticks MAX_PERIOD_US" and n=5])
+  apply (insert getCurrentTime_buffer_no_overflow)
   apply (clarsimp simp: kernelWCET_ticks_def MAX_PERIOD_def)
   apply (subst unat_add_lem')
    apply (clarsimp simp: max_word_def)
@@ -173,40 +177,45 @@ lemma cur_time_bound_no_overflow':
   done
 
 lemma MAX_PERIOD_mult:
-  "unat (3 * MAX_PERIOD) = 3 * unat MAX_PERIOD"
-  apply (insert cur_time_bound_no_overflow')
-  apply (metis (mono_tags, hide_lams) add_diff_cancel_left' add_leE order_refl unat_sub
-                                      word_le_nat_alt)
-  done
+  "unat (5 * MAX_PERIOD) = 5 * unat MAX_PERIOD"
+  apply (insert getCurrentTime_buffer_no_overflow')
+  apply (insert replicate_no_overflow[where n=5 and a=MAX_PERIOD and upper_bound=max_time, atomized])
+  using MAX_PERIOD_def getCurrentTime_buffer_no_overflow by auto
 
-lemma cur_time_bound_no_overflow'_stronger:
-  "unat (kernelWCET_ticks + 3 * MAX_PERIOD + 1) = unat kernelWCET_ticks + unat (3 * MAX_PERIOD) + 1"
+lemma MAX_PERIOD_mult':
+  "(n :: 64 word) \<le> 5 \<Longrightarrow> unat (n * MAX_PERIOD) = unat n * unat MAX_PERIOD"
+  apply (insert getCurrentTime_buffer_no_overflow')
+  apply (insert replicate_no_overflow[where n="unat n" and a=MAX_PERIOD and upper_bound=max_time])
+  apply (prop_tac "word_of_int (int (unat n)) = n")
+   apply (metis word_of_nat word_unat.Rep_inverse)
+  by (metis (mono_tags, hide_lams) MAX_PERIOD_mult le_trans max_word_max mult_le_mono1
+                                   of_nat_numeral unat_le_helper word_le_nat_alt)
+
+lemma getCurrentTime_buffer_no_overflow'_stronger:
+  "unat (kernelWCET_ticks + 5 * MAX_PERIOD + 1) = unat kernelWCET_ticks + unat (5 * MAX_PERIOD) + 1"
   apply (subst unat_add_lem')
-   apply (insert cur_time_bound_no_overflow' cur_time_bound_no_overflow)
+   apply (insert getCurrentTime_buffer_no_overflow' getCurrentTime_buffer_no_overflow)
    apply (clarsimp simp: kernelWCET_ticks_def MAX_PERIOD_def max_word_def)
   apply (fastforce simp: MAX_PERIOD_mult)
   done
 
-lemma cur_time_bound_minus:
-  "- kernelWCET_ticks - 3 * MAX_PERIOD - 1 \<le> - kernelWCET_ticks - 1"
-  apply (prop_tac "kernelWCET_ticks \<le> kernelWCET_ticks + 3 * MAX_PERIOD")
+lemma getCurrentTime_buffer_minus:
+  "- kernelWCET_ticks - 5 * MAX_PERIOD - 1 \<le> - kernelWCET_ticks - 1"
+  apply (prop_tac "kernelWCET_ticks \<le> kernelWCET_ticks + 5 * MAX_PERIOD")
    apply (clarsimp simp: word_le_nat_alt)
-   using cur_time_bound_no_overflow' apply force
-  apply (prop_tac "MAX_PERIOD * 3 \<le> - 1 - kernelWCET_ticks")
+   using getCurrentTime_buffer_no_overflow' apply force
+  apply (prop_tac "MAX_PERIOD * 5 \<le> - 1 - kernelWCET_ticks")
    apply (metis le_minus mult.commute word_n1_ge)
   apply (metis (no_types, hide_lams) ab_group_add_class.ab_diff_conv_add_uminus add.assoc
                add.commute mult.commute word_sub_le)
   done
 
-lemma cur_time_bound_minus':
-  "- kernelWCET_ticks - 3 * MAX_PERIOD - 1 < - kernelWCET_ticks"
-  apply (insert cur_time_bound_minus)
+lemma getCurrentTime_buffer_minus':
+  "- kernelWCET_ticks - 5 * MAX_PERIOD - 1 < - kernelWCET_ticks"
+  apply (insert getCurrentTime_buffer_minus)
   apply (prop_tac "kernelWCET_ticks \<noteq> 0")
    using us_to_ticks_nonzero kernelWCET_ticks_def kernelWCET_us_pos apply fastforce
   by (simp add: word_leq_minus_one_le)
-
-abbreviation (input) getCurrentTime_buffer where
-  "getCurrentTime_buffer \<equiv> kernelWCET_ticks + 3 * MAX_PERIOD"
 
 text \<open>
 This encodes the following assumptions:


### PR DESCRIPTION
This adds handling of overrun to `refill_budget_check/refillBudgetCheck`.

As far as I understand, the most stringent real time guarantees are applicable only in systems which respect a worst case execution time for threads running in user space, as well as the kernel itself. However, we would like to be able to properly handle the case where the WCET of a thread in user space is violated - that is, we'd still like to prove functional correctness for a kernel which handles this. `handle_overrun_loop/handleOverrunLoop` has been added to `refill_budget_check/refillBudgetCheck` to achieve this.

Our current approach does not wish to statically establish an upper bound on the release time of a scheduling context on which `refill_budget_check` is called. Instead, we check throughout `handle_overrun_loop` to see whether an operation would result in overflow. 

Because of this, we can no longer work with the formulation of `bounded_release_time` that we had (which said that the release time of a scheduling context was within a certain distance of the current time). `bounded_release_time` was only being used to show that `refill_update` preserves `valid_refills` (in particular, performing `refill_update` on some scheduling context would not result in overflow). The check in `handle_overrun_loop` allows us to show another property which suffices, namely that there is no scheduling context with release time within `2 * MAX_PERIOD` of `max_time`. Since `bounded_release_time` was used in fairly few places before, and the name is still reasonable for this new property, I've decided to stick with it (but happy to change it if it's confusing)