### PR TITLE
Refill corres rules

### DIFF
--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -183,7 +183,8 @@ crunch domain_list_inv[wp]: refill_new "\<lambda>s. P (domain_list s)"
   (simp: Let_def crunch_simps wp: get_sched_context_wp get_refills_wp wp: crunch_wps)
 
 crunch domain_list_inv[wp]: refill_update "\<lambda>s. P (domain_list s)"
-  (simp: Let_def wp: get_sched_context_wp get_refills_wp wp: crunch_wps)
+  (simp: Let_def crunch_simps
+     wp: get_refills_wp update_sched_context_wp set_refills_wp crunch_wps)
 
 crunch domain_list_inv[wp]: set_next_interrupt, switch_sched_context
   "\<lambda>s::det_state. P (domain_list s)"

--- a/proof/invariant-abstract/Deterministic_AI.thy
+++ b/proof/invariant-abstract/Deterministic_AI.thy
@@ -4103,7 +4103,7 @@ lemma refill_budget_check_valid_list[wp]:
 
 lemma refill_budget_check_round_robin_valid_list[wp]:
   "\<lbrace>valid_list\<rbrace> refill_budget_check_round_robin usage \<lbrace>\<lambda>_.valid_list\<rbrace>"
-  unfolding refill_budget_check_round_robin_def
+  unfolding refill_budget_check_round_robin_def update_refill_tl_def update_refill_hd_def
   by (wpsimp wp: hoare_drop_imps)
 
 crunch valid_list[wp]: update_restart_pc "valid_list"
@@ -4117,7 +4117,8 @@ lemma end_timeslice_valid_list[wp]:
 lemma charge_budget_valid_list[wp]:
   "\<lbrace>valid_list\<rbrace> charge_budget consumed canTimeout \<lbrace>\<lambda>_.valid_list\<rbrace>"
   by (wpsimp simp: charge_budget_def Let_def set_refills_def is_round_robin_def
-                   refill_budget_check_round_robin_def refill_reset_rr_def
+                   refill_budget_check_round_robin_def refill_reset_rr_def update_refill_tl_def
+                   update_refill_hd_def set_refill_tl_def set_refill_hd_def
                wp: assert_inv
       | intro conjI)+
 

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -1658,14 +1658,17 @@ lemma refill_update_invs:
   "\<lbrace>\<lambda>s. invs s \<and> sc_ptr \<noteq> idle_sc_ptr \<and> active_sc_at sc_ptr s\<rbrace>
    refill_update sc_ptr new_period new_budget new_max_refills
    \<lbrace>\<lambda>rv. invs\<rbrace>"
-  unfolding refill_update_def
+  unfolding refill_update_def refill_add_tail_def set_refills_def update_refill_tl_def
+            update_refill_hd_def
   apply (wpsimp wp: set_sc_obj_ref_invs_no_change hoare_vcg_all_lift hoare_vcg_imp_lift'
-                    hoare_vcg_disj_lift)
+                    get_refills_wp hoare_vcg_disj_lift)
   done
 
 lemma refill_reset_rr_invs[wp]:
   "refill_reset_rr csc_ptr \<lbrace>invs\<rbrace>"
-  unfolding refill_reset_rr_def by wpsimp
+  unfolding refill_reset_rr_def update_refill_tl_def update_refill_hd_def set_refill_tl_def
+            set_refill_hd_def
+  by wpsimp
 
 lemma charge_budget_invs[wp]:
   "\<lbrace>invs\<rbrace>

--- a/proof/invariant-abstract/SchedContext_AI.thy
+++ b/proof/invariant-abstract/SchedContext_AI.thy
@@ -465,8 +465,8 @@ lemma refill_budget_check_refs_of[wp]:
   done
 
 lemma refill_budget_check_round_robin_invs[wp]:
-  "refill_budget_check_round_robin usage \<lbrace>invs\<rbrace>"
-  by (wpsimp simp: refill_budget_check_round_robin_def
+  "refill_budget_check_round_robin u \<lbrace>invs\<rbrace>"
+  by (wpsimp simp: refill_budget_check_round_robin_def update_refill_tl_def update_refill_hd_def
                wp: hoare_drop_imp)
 
 lemma refill_budget_check_invs[wp]:
@@ -709,7 +709,8 @@ lemma refill_budget_check_valid_replies[wp]:
 
 lemma commit_time_valid_replies[wp]:
   "commit_time \<lbrace> valid_replies_pred P \<rbrace>"
-  by (wpsimp simp: commit_time_def refill_budget_check_round_robin_def
+  by (wpsimp simp: commit_time_def refill_budget_check_round_robin_def update_refill_tl_def
+                   update_refill_hd_def
                wp: hoare_drop_imps cong: sched_context.fold_congs)
 
 lemma sc_consumed_update_eq:
@@ -750,7 +751,8 @@ lemma commit_time_invs:
    apply (rename_tac csc sc consumed)
    apply (case_tac "0 < consumed"; simp split del: if_split add: bind_assoc)
     apply (wpsimp wp: commit_times_invs_helper hoare_vcg_ex_lift
-                simp: refill_budget_check_round_robin_def is_round_robin_def)
+                simp: refill_budget_check_round_robin_def is_round_robin_def
+                      update_refill_tl_def update_refill_hd_def)
    apply (clarsimp simp: obj_at_def is_sc_obj_def)
    apply (wpsimp simp: invs_def valid_state_def valid_pspace_def
                        consumed_time_update_arch.state_refs_update
@@ -819,7 +821,7 @@ lemma commit_time_bound_sc_tcb_at [wp]:
    commit_time
    \<lbrace>\<lambda>_ s. bound_sc_tcb_at ((=) (Some sc)) (cur_thread s) s\<rbrace>"
   by (wpsimp simp: commit_time_def sc_consumed_update_eq[symmetric]
-                   refill_budget_check_round_robin_def
+                   refill_budget_check_round_robin_def update_refill_tl_def update_refill_hd_def
                wp: hoare_drop_imps)
 
 lemma refill_unblock_check_bound_sc_tcb_at [wp]:
@@ -860,17 +862,19 @@ lemma refill_budget_check_valid_state [wp]:
 lemma commit_time_valid_state [wp]:
   "\<lbrace>valid_state\<rbrace> commit_time \<lbrace>\<lambda>_. valid_state\<rbrace>"
   by (wpsimp simp: commit_time_def sc_consumed_update_eq[symmetric]
-                   refill_budget_check_round_robin_def
+                   refill_budget_check_round_robin_def update_refill_tl_def update_refill_hd_def
                wp: hoare_drop_imps)
 
 lemma commit_time_cur_tcb [wp]:
   "\<lbrace>cur_tcb\<rbrace> commit_time \<lbrace>\<lambda>_. cur_tcb\<rbrace>"
-  by (wpsimp simp: commit_time_def refill_budget_check_round_robin_def
+  by (wpsimp simp: commit_time_def refill_budget_check_round_robin_def update_refill_tl_def
+                   update_refill_hd_def
                wp: hoare_drop_imps)
 
 lemma commit_time_fault_tcbs_valid_states[wp]:
   "commit_time \<lbrace>fault_tcbs_valid_states\<rbrace>"
-  by (wpsimp simp: commit_time_def refill_budget_check_round_robin_def
+  by (wpsimp simp: commit_time_def refill_budget_check_round_robin_def update_refill_tl_def
+                   update_refill_hd_def
                wp: hoare_drop_imps)
 
 crunches switch_sched_context
@@ -1525,11 +1529,10 @@ lemma maybe_add_empty_tail_invs[wp]:
   "\<lbrace>invs and K (sc_ptr \<noteq> idle_sc_ptr)\<rbrace>
    maybe_add_empty_tail sc_ptr
    \<lbrace>\<lambda>_. invs\<rbrace>"
-  by (wpsimp simp: maybe_add_empty_tail_def is_round_robin_def
-        split_del: if_split
-               wp: set_sc_obj_ref_invs_no_change hoare_vcg_all_lift hoare_vcg_imp_lift'
-                   hoare_vcg_disj_lift )
-     (clarsimp)
+  apply (wpsimp simp: maybe_add_empty_tail_def refill_add_tail_def is_round_robin_def
+                  wp: set_sc_obj_ref_invs_no_change hoare_vcg_all_lift hoare_vcg_imp_lift'
+                      hoare_vcg_disj_lift )
+  done
 
 lemma refill_new_invs[wp]:
   "\<lbrace>invs and K (sc_ptr \<noteq> idle_sc_ptr)\<rbrace>

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -668,7 +668,9 @@ definition valid_sched_context' :: "sched_context \<Rightarrow> kernel_state \<R
      \<and> valid_bound_reply' (scReply sc) s
      \<and> MIN_REFILLS \<le> length (scRefills sc)
      \<and> scRefillMax sc \<le> length (scRefills sc)
-     \<and> (0 < scRefillMax sc \<longrightarrow> scRefillHead sc < scRefillMax sc \<and> scRefillCount sc \<le> scRefillMax sc)"
+     \<and> (0 < scRefillMax sc \<longrightarrow> scRefillHead sc < scRefillMax sc
+                               \<and> scRefillCount sc \<le> scRefillMax sc
+                               \<and> 0 < scRefillCount sc)"
 
 definition valid_reply' :: "reply \<Rightarrow> kernel_state \<Rightarrow> bool" where
   "valid_reply' reply s \<equiv>

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -3045,13 +3045,16 @@ lemma schedContextResume_corres:
    apply (subgoal_tac "sc_tcb_sc_at (\<lambda>t. bound_sc_tcb_at (\<lambda>sc. sc = Some ptr) (the t) s) ptr s ")
     apply (clarsimp simp: sc_at_ppred_def obj_at_def is_sc_obj_def bound_sc_tcb_at_def is_tcb_def)
     apply (intro conjI impI; (clarsimp simp: invs_def valid_state_def; fail)?)
-           apply (fastforce dest!: invs_valid_objs elim!: valid_sched_context_size_objsI)+
-         apply (fastforce simp: is_schedulable_bool_def get_tcb_def is_sc_active_def vs_all_heap_simps)+
-        apply (prop_tac "is_active_sc ptr s")
-         apply (fastforce simp: vs_all_heap_simps is_schedulable_bool_def get_tcb_def
-                                is_sc_active_def)
-        apply (fastforce dest: active_sc_valid_refillsE
-                         simp: vs_all_heap_simps valid_refills_def rr_valid_refills_def)
+          apply (fastforce simp: invs_def valid_state_def valid_pspace_def valid_obj_def)
+         apply (clarsimp simp: is_schedulable_bool_def get_tcb_def obj_at_kh_kheap_simps)
+         apply (fastforce dest!: active_sc_valid_refillsE
+                           simp: valid_refills_def vs_all_heap_simps rr_valid_refills_def
+                          split: if_splits)
+        apply (fastforce simp: is_schedulable_bool_def get_tcb_def is_sc_active_def
+                               vs_all_heap_simps)
+       apply (prop_tac "is_active_sc ptr s")
+        apply (fastforce simp: vs_all_heap_simps is_schedulable_bool_def get_tcb_def
+                               is_sc_active_def)
        apply (fastforce simp: vs_all_heap_simps valid_ready_qs_2_def
                               valid_ready_queued_thread_2_def in_ready_q_def)+
      apply (clarsimp simp: is_schedulable_bool_def get_tcb_def)

--- a/proof/refine/ARM/SchedContext_R.thy
+++ b/proof/refine/ARM/SchedContext_R.thy
@@ -46,6 +46,10 @@ lemma readSchedContext_SomeD:
   by (clarsimp simp: readSchedContext_def asks_def obj_at'_def projectKOs
               dest!: readObject_misc_ko_at')
 
+lemma no_ofail_readSchedContext:
+  "no_ofail (sc_at' p) (readSchedContext p)"
+  unfolding readSchedContext_def by wpsimp
+
 lemma sym_refs_tcbSchedContext:
   "\<lbrakk>ko_at' tcb tcbPtr s; sym_refs (state_refs_of' s); tcbSchedContext tcb = Some scPtr\<rbrakk>
    \<Longrightarrow> obj_at' (\<lambda>sc. scTCB sc = Some tcbPtr) scPtr s"
@@ -663,5 +667,136 @@ lemma schedContextDonate_bound_tcb_sc_at[wp]:
   "\<lbrace>\<top>\<rbrace> schedContextDonate scPtr tcbPtr \<lbrace>\<lambda>_. obj_at' (\<lambda>a. \<exists>y. scTCB a = Some y) scPtr\<rbrace>"
    unfolding schedContextDonate_def
    by (wpsimp wp: set_sc'.obj_at')
+
+(* FIXME RT: move *)
+lemmas sc_inv_state_eq' = getObject_sc_inv[THEN use_valid[rotated], rotated
+                                           , where s=s and P="(=) s" for s, OF _ refl]
+
+lemma sc_inv_state_eq:
+  "(a :: sched_context, s') \<in> fst (getSchedContext p s) \<Longrightarrow> s' = s"
+  apply (fastforce dest: sc_inv_state_eq' simp: getSchedContext_def)
+  done
+
+lemma getObject_idempotent:
+  "monadic_rewrite False True (sc_at' ptr)
+   (do rv \<leftarrow> (getObject ptr :: sched_context kernel);
+       getObject ptr
+    od)
+   (getObject ptr :: sched_context kernel)"
+  apply (clarsimp simp: monadic_rewrite_def)
+  apply (rule monad_state_eqI)
+    apply ((clarsimp simp: in_monad getObject_def split_def
+                           loadObject_default_def projectKOs scBits_pos_power2 objBits_simps'
+                           lookupAround2_known1 in_magnitude_check)+)[2]
+  apply (fastforce dest!: sc_inv_state_eq[simplified getSchedContext_def]
+                          no_fail_getObject_misc[simplified no_fail_def, rule_format]
+                    simp: snd_bind)
+  done
+
+lemma getSchedContext_setSchedContext_decompose:
+   "monadic_rewrite False True
+     (sc_at' scPtr and K (\<forall>sc. objBits (f sc) = objBits sc) and K (\<forall>sc. objBits (g sc) = objBits sc))
+     (do sc \<leftarrow> getSchedContext scPtr;
+         setSchedContext scPtr (g (f sc))
+      od)
+     (do sc \<leftarrow> getSchedContext scPtr;
+         setSchedContext scPtr (f sc);
+         sc \<leftarrow> getSchedContext scPtr;
+         setSchedContext scPtr (g sc)
+      od)"
+  apply (clarsimp simp: monadic_rewrite_def)
+  apply (rule monad_state_eqI)
+    apply (simp add: in_monad getSchedContext_def getObject_def)
+    apply (frule no_ofailD[OF no_ofail_sc_at'_readObject])
+    apply (clarsimp del: readObject_misc_ko_at' simp del: readObject_misc_obj_at')
+    apply (clarsimp simp: setSchedContext_def setObject_def obj_at'_def projectKOs objBits_simps'
+                          in_monad ARM_H.fromPPtr_def scBits_pos_power2 updateObject_default_def
+                          in_magnitude_check ps_clear_upd magnitudeCheck_assert split_def
+                     del: readObject_misc_ko_at'
+                   split: option.split_asm)
+     apply (rename_tac sc sc')
+     apply (rule_tac x="f sc" in exI)
+     apply (rule conjI;
+            fastforce simp: readObject_def obind_def omonad_defs split_def ARM_H.fromPPtr_def
+                            ps_clear_upd loadObject_default_def lookupAround2_known1 projectKOs
+                            objBits_simps' scBits_pos_power2 lookupAround2_None2 lookupAround2_char2
+                     split: option.splits if_split_asm dest!: readObject_misc_ko_at')
+    apply (rename_tac sc p sc')
+    apply (rule_tac x="f sc" in exI)
+    apply (rule conjI)
+     apply (thin_tac "scBitsFromRefillLength' _=_")
+     apply (clarsimp simp: readObject_def obind_def omonad_defs fun_upd_def split_def ARM_H.fromPPtr_def
+                           ps_clear_upd loadObject_default_def lookupAround2_known1 projectKOs
+                           objBits_simps' scBits_pos_power2 lookupAround2_None2 lookupAround2_char2
+                    split: option.splits if_split_asm)
+     apply (metis option.simps(3) word_le_less_eq word_le_not_less)
+    apply (clarsimp simp: split: option.splits)
+    apply (metis (no_types) array_rules(2) lookupAround2_char2 mcs(1) order.strict_trans2
+                            word_le_less_eq word_le_not_less)
+   apply (simp add: in_monad getSchedContext_def getObject_def)
+   apply (frule no_ofailD[OF no_ofail_sc_at'_readObject])
+   apply (clarsimp del: readObject_misc_ko_at' simp del: readObject_misc_obj_at')
+   apply (clarsimp simp: setSchedContext_def setObject_def projectKOs in_monad ps_clear_upd obj_at'_def
+                         split_def updateObject_default_def magnitudeCheck_assert ARM_H.fromPPtr_def
+                  dest!: readObject_misc_ko_at')
+
+   apply (frule no_failD[OF no_fail_getMiscObject(4)])
+  apply (simp add: snd_bind)
+  apply (rule iffI; clarsimp simp: snd_bind split_def setSchedContext_def; rename_tac sc s')
+   apply (frule sc_inv_state_eq, simp)
+   apply (rule_tac x="(sc, s)" in bexI[rotated], simp)
+   apply (rule disjI2)
+   apply (drule use_valid[OF _ get_sc_ko'], simp)
+   apply (clarsimp simp: obj_at'_def projectKOs)
+   apply (prop_tac "obj_at' (\<lambda>k. objBits k = objBits (g (f sc))) scPtr s")
+    apply (clarsimp simp: obj_at'_def projectKOs projectKO_opt_sc)
+    apply (rule_tac x=sc in exI, clarsimp simp: projectKO_opt_sc)
+   apply (drule_tac ob1="g (f sc)" in no_failD[OF no_fail_setObject_other, rotated])
+    apply simp
+   apply clarsimp
+  apply (frule sc_inv_state_eq, simp)
+  apply (rule_tac x="(sc, s)" in bexI[rotated], simp)
+  apply (drule use_valid[OF _ get_sc_ko'], simp)
+  apply (erule disjE; clarsimp)
+   apply (clarsimp simp: obj_at'_def projectKOs)
+   apply (prop_tac "obj_at' (\<lambda>k. objBits k = objBits (f sc)) scPtr s")
+    apply (clarsimp simp: obj_at'_def projectKOs projectKO_opt_sc)
+    apply (rule_tac x=sc in exI, clarsimp simp: projectKO_opt_sc)
+   apply (drule_tac ob1="(f sc)" in no_failD[OF no_fail_setObject_other, rotated])
+    apply simp+
+
+  apply (rename_tac s'; erule disjE; clarsimp?)
+   apply (drule_tac Q2="\<lambda>s'. s' = (s\<lparr>ksPSpace := ksPSpace s(scPtr \<mapsto> injectKO (f sc))\<rparr>)"
+                 in use_valid[OF _ setObject_sc_wp])
+    apply simp+
+
+   apply (prop_tac "sc_at' scPtr (s\<lparr>ksPSpace := ksPSpace s(scPtr \<mapsto> KOSchedContext (f sc))\<rparr>)")
+    apply (clarsimp simp: obj_at'_def projectKOs objBits_simps' ps_clear_upd)
+   apply (frule_tac s="s\<lparr>ksPSpace := ksPSpace s(scPtr \<mapsto> KOSchedContext (f sc))\<rparr>"
+                 in no_failD[OF no_fail_getMiscObject(4)])
+   apply clarsimp
+
+ apply (rename_tac s')
+   apply (drule_tac Q2="\<lambda>s'. s' = (s\<lparr>ksPSpace := ksPSpace s(scPtr \<mapsto> injectKO (f sc))\<rparr>)"
+                 in use_valid[OF _ setObject_sc_wp])
+    apply simp+
+
+  apply (frule sc_inv_state_eq, simp)
+  apply (drule use_valid[OF _ get_sc_ko'], simp)
+  apply (clarsimp simp: obj_at'_def projectKOs)
+  apply (prop_tac "obj_at' (\<lambda>k. objBits k = objBits (g (f sc))) scPtr
+                           (s\<lparr>ksPSpace := ksPSpace s(scPtr \<mapsto> KOSchedContext (f sc))\<rparr>)")
+   apply (clarsimp simp: obj_at'_def projectKOs projectKO_opt_sc)
+   apply (rule_tac x="f sc" in exI, clarsimp simp: projectKO_opt_sc)
+  apply (drule_tac ob1="g (f sc)" in no_failD[OF no_fail_setObject_other, rotated])
+   apply simp+
+  done
+
+lemmas getSchedContext_setSchedContext_decompose_decompose_ext
+  = getSchedContext_setSchedContext_decompose[where f="f x" and g="g y" for f g x y]
+lemmas getSchedContext_setSchedContext_decompose_decompose2
+  = getSchedContext_setSchedContext_decompose[where g="\<lambda>sc. g (h sc)" for g h]
+lemmas getSchedContext_setSchedContext_decompose_decompose_ext2
+  = getSchedContext_setSchedContext_decompose[where f="f x" and g="g y" for f g x y]
 
 end

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -22,7 +22,6 @@ lemma threadRead_SomeD:
   "threadRead f t s = Some y \<Longrightarrow> \<exists>tcb. ko_at' tcb t s \<and> y = f tcb"
   by (fastforce simp: threadRead_def oliftM_def dest!: readObject_misc_ko_at')
 
-
 (* Auxiliaries and basic properties of priority bitmap functions *)
 
 lemma countLeadingZeros_word_clz[simp]:

--- a/proof/refine/Move_R.thy
+++ b/proof/refine/Move_R.thy
@@ -483,4 +483,40 @@ lemma sc_at_ppred_exm:
   "sc_at_ppred p P scp s = (obj_at (\<lambda>ko. \<exists>sc n. ko = SchedContext sc n) scp s \<and> \<not> sc_at_ppred p (\<lambda>x. \<not> P x) scp s)"
   by (fastforce simp: sc_at_pred_n_def obj_at_def is_sc_obj pred_neg_def)
 
+lemma get_object_exs_valid:
+  "obj_at \<top> ptr s \<Longrightarrow> \<lbrace>(=) s\<rbrace> get_object ptr \<exists>\<lbrace>\<lambda>r. (=) s\<rbrace>"
+  apply (clarsimp simp: get_object_def assert_def return_def fail_def gets_def exs_valid_def get_def
+                        bind_def obj_at_def gets_the_def)
+  done
+
+lemma monadic_rewrite_rewrite_head:
+  "\<lbrakk>monadic_rewrite False True P f f'; monadic_rewrite False True P (f' >>= g) (h >>= j)\<rbrakk>
+   \<Longrightarrow> monadic_rewrite False True P (f >>= g) (h >>= j)"
+  apply (clarsimp simp: monadic_rewrite_def bind_def)
+  done
+
+lemma bind_assoc_group4:
+  "(do x \<leftarrow> a; y \<leftarrow> b x; z \<leftarrow> c y; w \<leftarrow> d z; f w od)
+   = (do w \<leftarrow> (do x \<leftarrow> a; y \<leftarrow> b x; z <- c y; d z od); f w od)"
+  apply (simp add: bind_assoc)
+  done
+
+(* FIXME RT: move *)
+lemmas update_sched_context_decompose_ext
+  = update_sched_context_decompose[where f="f x" and g="g y" for f g x y]
+lemmas update_sched_context_decompose2
+  = update_sched_context_decompose[where g="\<lambda>sc. g (h sc)" for g h]
+lemmas update_sched_context_decompose_ext2
+  = update_sched_context_decompose2[where f="f x" and g="g y" for f g x y]
+
+(* FIXME RT: move to ListLibLemmas.thy? *)
+lemma hd_drop_length_2_last:
+  "length list = 2 \<Longrightarrow> hd (tl list) = last list"
+  apply (prop_tac "\<exists>a b. list = [a,b]")
+   apply (cases list; simp)
+   apply (rename_tac a lista)
+   apply (case_tac lista; simp)
+  apply clarsimp
+  done
+
 end

--- a/spec/abstract/Ipc_A.thy
+++ b/spec/abstract/Ipc_A.thy
@@ -659,10 +659,10 @@ definition
   refill_reset_rr :: "obj_ref \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
   "refill_reset_rr csc_ptr = do
-     csc \<leftarrow> get_sched_context csc_ptr;
-     refills \<leftarrow> return (sc_refills csc);
-     set_refills csc_ptr [\<lparr>r_time = r_time (hd refills), r_amount = r_amount (hd refills) + r_amount (hd (tl refills))\<rparr>,
-                          \<lparr>r_time = r_time (hd (tl refills)), r_amount = 0\<rparr>]
+     refills \<leftarrow> get_refills csc_ptr;
+     set_refill_hd csc_ptr \<lparr>r_time = r_time (hd refills),
+                            r_amount = r_amount (hd refills) + r_amount (hd (tl refills))\<rparr>;
+     set_refill_tl csc_ptr \<lparr>r_time = r_time (hd (tl refills)), r_amount = 0\<rparr>
    od"
 
 definition

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -999,7 +999,9 @@ On some architectures, the thread context may include registers that may be modi
 > replaceAt i lst v =
 >     let x = take i lst;
 >         y = drop (i + 1) lst
->     in x ++ [v] ++ y
+>     in if (null lst || length lst <= i)
+>           then lst
+>           else x ++ [v] ++ y
 
 > chargeBudget :: Ticks -> Bool -> Bool -> Kernel ()
 > chargeBudget consumed canTimeoutFault isCurCPU = do


### PR DESCRIPTION
This proves `corres` rules for `refillUpdate`, `refillNew`, and (I think) all other functions which modify refills other than `refillBudgetCheck` and `refillUnblockCheck`. 

There are many lemmas which we may want to move