### PR TITLE
Access Control: Arch Split

### DIFF
--- a/camkes/cdl-refine/Eval_CAMKES_CDL.thy
+++ b/camkes/cdl-refine/Eval_CAMKES_CDL.thy
@@ -479,7 +479,7 @@ lemma cdl_state_asids_to_policy__eval:
                      \<and> (case obj_label_spec (cap_object asid_pool_cap) of
                            Some asid_pool_l \<Rightarrow>
                              generic_tag ''asid pool policy'' (asid_high, asid_pool_cap)
-                                 ((asid_pool_l, ASIDPoolMapsASID, asidl) \<in> policy_spec)
+                                 ((asid_pool_l, AAuth ASIDPoolMapsASID, asidl) \<in> policy_spec)
                          | _ \<Rightarrow> False)
                 | _ \<Rightarrow> False)"
 

--- a/proof/ROOT
+++ b/proof/ROOT
@@ -140,8 +140,10 @@ session DPolicy in "dpolicy" = DRefine +
  *)
 
 session Access in "access-control" = AInvs +
+  directories
+    "$L4V_ARCH"
   theories
-    "ADT_AC"
+    "ArchADT_AC"
     "ExampleSystem"
 
 session InfoFlow in "infoflow" = Access +

--- a/proof/access-control/ADT_AC.thy
+++ b/proof/access-control/ADT_AC.thy
@@ -5,241 +5,32 @@
  *)
 
 theory ADT_AC
-imports Syscall_AC
+imports ArchSyscall_AC
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma pd_of_thread_same_agent:
-  "\<lbrakk> pas_refined aag s; is_subject aag tcb_ptr;
-     get_pd_of_thread (kheap s) (arch_state s) tcb_ptr = pd;
-     pd \<noteq> arm_global_pd (arch_state s) \<rbrakk>
-   \<Longrightarrow> pasObjectAbs aag tcb_ptr = pasObjectAbs aag pd"
-  apply (rule_tac aag="pasPolicy aag" in aag_wellformed_Control[rotated])
-   apply (fastforce simp: pas_refined_def)
-  apply (rule pas_refined_mem[rotated], simp)
-  apply (clarsimp simp: get_pd_of_thread_eq)
-  apply (cut_tac ptr="(tcb_ptr, tcb_cnode_index 1)" in sbta_caps)
-     prefer 4
-     apply (simp add: state_objs_to_policy_def)
-    apply (subst caps_of_state_tcb_cap_cases)
-      apply (simp add: get_tcb_def)
-     apply (simp add: dom_tcb_cap_cases[simplified])
-    apply simp
-   apply (simp add: obj_refs_def)
-  apply (simp add: cap_auth_conferred_def is_page_cap_def)
-  done
-
-lemma invs_valid_global_pd_mappings:
-  "invs s \<Longrightarrow> valid_global_vspace_mappings s"
-  apply (simp add: invs_def valid_state_def)
-  done
-
-lemma objs_valid_tcb_vtable:
-  "\<lbrakk>valid_objs s; get_tcb t s = Some tcb\<rbrakk> \<Longrightarrow> s \<turnstile> tcb_vtable tcb"
-  apply (clarsimp simp: get_tcb_def split: option.splits Structures_A.kernel_object.splits)
-  apply (erule cte_wp_valid_cap[rotated])
-  apply (rule cte_wp_at_tcbI[where t="(a, b)" for a b, where b3="tcb_cnode_index 1"])
-    apply fastforce+
-  done
-
-lemma pd_of_thread_page_directory_at:
-  "\<lbrakk> invs s; get_pd_of_thread (kheap s) (arch_state s) tcb \<noteq> arm_global_pd (arch_state s) \<rbrakk>
-    \<Longrightarrow> page_directory_at ((get_pd_of_thread (kheap s) (arch_state s) tcb)) s"
-  apply (clarsimp simp: get_pd_of_thread_def
-                 split: option.splits kernel_object.splits cap.splits arch_cap.splits if_splits)
-  apply (frule_tac t=tcb in objs_valid_tcb_vtable[OF invs_valid_objs])
-   apply (simp add: get_tcb_def)
-  apply (fastforce simp: valid_cap_def2 valid_cap_ref_def valid_arch_cap_ref_simps)
-  done
-
-lemma ptr_offset_in_ptr_range:
-  "\<lbrakk> invs s; get_page_info (\<lambda>obj. get_arch_obj (kheap s obj))
-           (get_pd_of_thread (kheap s) (arch_state s) tcb) x =
-          Some (base, sz, attr, r); x \<notin> kernel_mappings;
-     get_pd_of_thread (kheap s) (arch_state s) tcb \<noteq> arm_global_pd (arch_state s) \<rbrakk>
-   \<Longrightarrow> ptrFromPAddr base + (x && mask sz) \<in> ptr_range (ptrFromPAddr base) sz"
-  apply (simp add: ptr_range_def mask_def)
-  apply (rule conjI)
-   apply (rule_tac b="2 ^ sz - 1" in word_plus_mono_right2)
-    apply (frule some_get_page_info_umapsD)
-          apply (clarsimp simp: get_pd_of_thread_reachable invs_vspace_objs
-                                invs_psp_aligned invs_valid_asid_table invs_valid_objs)+
-    apply (drule is_aligned_ptrFromPAddr_n)
-     apply (simp add: pageBitsForSize_def split: vmpage_size.splits)
-    apply (clarsimp simp: is_aligned_no_overflow' word_and_le1)+
-
-  apply (subst p_assoc_help)
-  apply (rule word_plus_mono_right)
-   apply (rule word_and_le1)
-  apply (frule some_get_page_info_umapsD)
-        apply (clarsimp simp: get_pd_of_thread_reachable invs_vspace_objs
-                              invs_psp_aligned invs_valid_asid_table invs_valid_objs)+
-  apply (drule is_aligned_ptrFromPAddr_n)
-   apply (simp add: pageBitsForSize_def split: vmpage_size.splits)
-  apply (clarsimp simp: is_aligned_no_overflow')
-  done
-
-lemma kernel_mappings_kernel_mapping_slots:
-  "x \<notin> kernel_mappings \<Longrightarrow> ucast (x >> 20) \<notin> kernel_mapping_slots"
-  apply (rule kernel_base_kernel_mapping_slots)
-  apply (simp add: kernel_mappings_def)
-  done
-
-lemmas kernel_mappings_kernel_mapping_slots' =
-       kernel_mappings_kernel_mapping_slots[simplified kernel_mapping_slots_def, simplified]
-
-lemma ptable_state_objs_to_policy:
-  "\<lbrakk> invs s; ptable_lift tcb s x = Some ptr;
-     auth \<in> vspace_cap_rights_to_auth (ptable_rights tcb s x);
-     get_pd_of_thread (kheap s) (arch_state s) tcb \<noteq> arm_global_pd (arch_state s);
-     \<forall>word1 set1 word2. get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj))
-        (get_pd_of_thread (kheap s) (arch_state s) tcb) x \<noteq>
-        Some (PageTablePDE word1 set1 word2); x \<notin> kernel_mappings \<rbrakk>
-  \<Longrightarrow> (get_pd_of_thread (kheap s) (arch_state s) tcb, auth, ptrFromPAddr ptr)
-          \<in> state_objs_to_policy s"
-  apply (simp add: state_objs_to_policy_def)
-  apply (rule sbta_vref)
-  apply (clarsimp simp: ptable_lift_def ptable_rights_def state_vrefs_def
-                  split: option.splits)
-  apply (frule pd_of_thread_page_directory_at, simp)
-  apply (clarsimp simp: typ_at_eq_kheap_obj)
-
-  apply (clarsimp simp: vs_refs_no_global_pts_def)
-  apply (rule_tac x="(ucast (x >> 20), ptrFromPAddr a, aa,
-                      vspace_cap_rights_to_auth b)" in bexI)
-   apply clarsimp
-   apply (rule_tac x="(ptrFromPAddr a + (x && mask aa), auth)" in image_eqI)
-    apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def physBase_def)
-   apply (simp add: ptr_offset_in_ptr_range)
-
-  apply (simp add: kernel_mappings_kernel_mapping_slots')
-  apply (clarsimp simp: graph_of_def)
-  apply (clarsimp simp: get_page_info_def get_pd_entry_def pde_ref2_def
-                  split: option.splits pde.splits arch_kernel_obj.splits)
-   apply (clarsimp simp: get_arch_obj_def
-                   split: option.splits kernel_object.splits arch_kernel_obj.splits)+
-  done
-
-lemma pt_in_pd_same_agent:
-  "\<lbrakk> pas_refined aag s; is_subject aag pd_ptr; vptr \<notin> kernel_mappings;
-     get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj)) pd_ptr vptr = Some (PageTablePDE p x xa) \<rbrakk>
-   \<Longrightarrow> pasObjectAbs aag pd_ptr = pasObjectAbs aag (ptrFromPAddr p)"
-  apply (rule_tac aag="pasPolicy aag" in aag_wellformed_Control[rotated])
-   apply (fastforce simp: pas_refined_def)
-  apply (rule pas_refined_mem[rotated], simp)
-  apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
-                  split: option.splits kernel_object.splits arch_kernel_obj.splits)
-  apply (simp add: state_objs_to_policy_def)
-  apply (rule sbta_vref)
-  apply (simp add: state_vrefs_def split: option.splits)
-
-  apply (clarsimp simp: vs_refs_no_global_pts_def)
-  apply (rule_tac x="(ucast (vptr >> 20), ptrFromPAddr p, 0, {Control})" in bexI)
-   apply simp
-
-  apply (simp add: kernel_mappings_kernel_mapping_slots' graph_of_def pde_ref2_def)
-  done
-
-lemma pt_in_pd_page_table_at:
-  "\<lbrakk> invs s; get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj)) pd_ptr x =
-     Some (PageTablePDE word1 set1 word2); (\<exists>\<rhd> pd_ptr) s; x \<notin> kernel_mappings \<rbrakk>
-    \<Longrightarrow> page_table_at (ptrFromPAddr word1) s"
-  apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
-                  split: option.splits kernel_object.splits arch_kernel_obj.splits)
-  apply (rename_tac "fun")
-  apply (subgoal_tac "valid_vspace_obj (PageDirectory fun) s")
-   apply (simp add: kernel_mappings_slots_eq)
-   apply (drule bspec)
-    apply simp+
-  apply (drule invs_vspace_objs)
-  apply (auto simp: obj_at_def invs_vspace_objs valid_vspace_objs_def)
-  done
-
-lemma get_page_info_state_objs_to_policy:
-  "\<lbrakk> invs s; auth \<in> vspace_cap_rights_to_auth r;
-     get_page_info (\<lambda>obj. get_arch_obj (kheap s obj))
-           (get_pd_of_thread (kheap s) (arch_state s) tcb) x = Some (base, sz, attr, r);
-     get_pd_of_thread (kheap s) (arch_state s) tcb \<noteq> arm_global_pd (arch_state s);
-     get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj))
-         (get_pd_of_thread (kheap s) (arch_state s) tcb) x =
-        Some (PageTablePDE word1 set1 word2); x \<notin> kernel_mappings \<rbrakk>
-  \<Longrightarrow> (ptrFromPAddr word1, auth, ptrFromPAddr (base + (x && mask sz))) \<in> state_objs_to_policy s"
-  apply (simp add: state_objs_to_policy_def)
-  apply (rule sbta_vref)
-  apply (clarsimp simp: state_vrefs_def split: option.splits)
-  apply (frule pt_in_pd_page_table_at)
-     apply (simp add: get_pd_of_thread_reachable)+
-  apply (clarsimp simp: typ_at_eq_kheap_obj)
-
-  apply (clarsimp simp: vs_refs_no_global_pts_def)
-  apply (rule_tac x="(ucast ((x >> 12) && mask 8),  ptrFromPAddr base, sz,
-                      vspace_cap_rights_to_auth r)" in bexI)
-   apply clarsimp
-   apply (rule_tac x="(ptrFromPAddr base + (x && mask sz), auth)" in image_eqI)
-    apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def physBase_def)
-   apply (simp add: ptr_offset_in_ptr_range)
-
-  apply (clarsimp simp: graph_of_def)
-  apply (clarsimp simp: get_page_info_def get_pd_entry_def get_pt_info_def
-                        get_pt_entry_def pte_ref_def
-                  split: option.splits pte.splits pde.splits arch_kernel_obj.splits)
-   apply (clarsimp simp: get_arch_obj_def
-                   split: option.splits kernel_object.splits arch_kernel_obj.splits)+
-  done
-
-lemma user_op_access:
-  "\<lbrakk> invs s; pas_refined aag s; is_subject aag tcb;
-     ptable_lift tcb s x = Some ptr;
-     auth \<in> vspace_cap_rights_to_auth (ptable_rights tcb s x) \<rbrakk>
-   \<Longrightarrow> (pasObjectAbs aag tcb, auth, pasObjectAbs aag (ptrFromPAddr ptr)) \<in> pasPolicy aag"
-  apply (case_tac "x \<in> kernel_mappings")
-   apply (clarsimp simp: ptable_lift_def ptable_rights_def split: option.splits)
-   apply (frule some_get_page_info_kmapsD)
-      apply (fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
-                             vspace_cap_rights_to_auth_def)+
-
-  apply (case_tac "get_pd_of_thread (kheap s) (arch_state s) tcb
-                 = arm_global_pd (arch_state s)")
-   apply (clarsimp simp: ptable_lift_def ptable_rights_def split: option.splits)
-   apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-     apply (fastforce simp: invs_valid_global_objs invs_arch_state)+
-
-  apply (subst pd_of_thread_same_agent)
-      apply fastforce+
-
-  apply (case_tac "\<exists>word1 set1 word2. get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj))
-                          (get_pd_of_thread (kheap s) (arch_state s) tcb) x =
-                          Some (PageTablePDE word1 set1 word2)")
-   apply (clarsimp simp: ptable_lift_def ptable_rights_def split: option.splits)
-   apply (frule pd_of_thread_same_agent)
-      apply fastforce+
-   apply (subst pt_in_pd_same_agent)
-       apply fastforce+
-   apply (rule pas_refined_mem[rotated], simp)
-   apply (rule get_page_info_state_objs_to_policy)
-        apply fastforce+
-
-  apply (rule pas_refined_mem[rotated], simp)
-  apply (rule ptable_state_objs_to_policy)
-       apply simp+
-  done
+locale ADT_AC_1 =
+  fixes aag :: "'a PAS"
+  assumes user_op_access:
+    "\<lbrakk> invs s; pas_refined aag s; is_subject aag tcb;
+       ptable_lift tcb s x = Some ptr; auth \<in> vspace_cap_rights_to_auth (ptable_rights tcb s x) \<rbrakk>
+       \<Longrightarrow> abs_has_auth_to aag auth tcb (ptrFromPAddr ptr)"
+  and write_in_vspace_cap_rights:
+    "AllowWrite \<in> ptable_rights (cur_thread s) s va
+     \<Longrightarrow> Write \<in> vspace_cap_rights_to_auth (ptable_rights (cur_thread s) s va)"
+begin
 
 lemma user_op_access':
   "\<lbrakk> invs s; pas_refined aag s; is_subject aag tcb;
      ptable_lift tcb s x = Some (addrFromPPtr ptr);
      auth \<in> vspace_cap_rights_to_auth (ptable_rights tcb s x) \<rbrakk>
-   \<Longrightarrow> (pasObjectAbs aag tcb, auth, pasObjectAbs aag ptr) \<in> pasPolicy aag"
-  apply (drule user_op_access)
-        apply auto
-  done
+     \<Longrightarrow> abs_has_auth_to aag auth tcb ptr"
+  by (auto dest: user_op_access simp: ptrFormPAddr_addFromPPtr)
 
 lemma integrity_underlying_mem_update:
-  "\<lbrakk> integrity aag X st s;
-     \<forall>x\<in>xs. (pasSubject aag, Write, pasObjectAbs aag x) \<in> pasPolicy aag;
-     \<forall>x\<in>-xs. um' x = underlying_memory (machine_state s) x\<rbrakk>
-    \<Longrightarrow> integrity aag X st
-          (machine_state_update (\<lambda>ms. underlying_memory_update (\<lambda>_. um') ms) s)"
+  "\<lbrakk> integrity aag X st s; \<forall>x\<in>xs. aag_has_auth_to aag Write x;
+     \<forall>x\<in>-xs. um' x = underlying_memory (machine_state s) x \<rbrakk>
+     \<Longrightarrow> integrity aag X st (machine_state_update (\<lambda>ms. underlying_memory_update (\<lambda>_. um') ms) s)"
   apply (clarsimp simp: integrity_def)
   apply (case_tac "x \<in> xs")
    apply (erule_tac x=x in ballE)
@@ -249,8 +40,8 @@ lemma integrity_underlying_mem_update:
 
 lemma dmo_user_memory_update_respects_Write:
   "\<lbrace>integrity aag X st and K (\<forall>p \<in> dom um. aag_has_auth_to aag Write p)\<rbrace>
-  do_machine_op (user_memory_update um)
-  \<lbrace>\<lambda>a. integrity aag X st\<rbrace>"
+   do_machine_op (user_memory_update um)
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   unfolding user_memory_update_def
   apply (wp dmo_wp)
   apply clarsimp
@@ -261,10 +52,8 @@ lemma dmo_user_memory_update_respects_Write:
   done
 
 lemma integrity_device_state_update:
-  "\<lbrakk>integrity aag X st s;
-    \<forall>x\<in>xs. (pasSubject aag, Write, pasObjectAbs aag x) \<in> pasPolicy aag;
-    \<forall>x\<in>-xs. um' x = None
-    \<rbrakk> \<Longrightarrow>  integrity aag X st (machine_state_update (\<lambda>v. v\<lparr>device_state := device_state v ++ um'\<rparr>) s)"
+  "\<lbrakk> integrity aag X st s; \<forall>x\<in>xs. aag_has_auth_to aag Write x; \<forall>x\<in>-xs. um' x = None \<rbrakk>
+     \<Longrightarrow> integrity aag X st (machine_state_update (\<lambda>v. v\<lparr>device_state := device_state v ++ um'\<rparr>) s)"
   apply (clarsimp simp: integrity_def)
   apply (case_tac "x \<in> xs")
    apply (erule_tac x=x in ballE)
@@ -279,9 +68,9 @@ lemma integrity_device_state_update:
 
 lemma dmo_device_update_respects_Write:
   "\<lbrace>integrity aag X st and (\<lambda>s. device_state (machine_state s) = um)
-    and K (\<forall>p \<in> dom um'. aag_has_auth_to aag Write p)\<rbrace>
-    do_machine_op (device_memory_update um')
-  \<lbrace>\<lambda>a. integrity aag X st\<rbrace>"
+                       and K (\<forall>p \<in> dom um'. aag_has_auth_to aag Write p)\<rbrace>
+   do_machine_op (device_memory_update um')
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: device_memory_update_def)
   apply (rule hoare_pre)
    apply (wp dmo_wp)
@@ -296,34 +85,30 @@ lemma dmo_device_update_respects_Write:
   done
 
 lemma dmo_um_upd_machine_state:
-  "\<lbrace>\<lambda>s. P (device_state (machine_state s))\<rbrace>
-       do_machine_op (user_memory_update ms)
-   \<lbrace>\<lambda>_ s. P (device_state (machine_state s))\<rbrace>"
-  including no_pre
-  apply (wp dmo_wp)
-  by (simp add:user_memory_update_def simpler_modify_def valid_def)
+  "do_machine_op (user_memory_update ms) \<lbrace>\<lambda>s. P (device_state (machine_state s))\<rbrace>"
+  by (rule dmo_wp) (simp add: user_memory_update_def simpler_modify_def valid_def)
 
 lemma do_user_op_respects:
- "\<lbrace> invs and integrity aag X st and is_subject aag \<circ> cur_thread and pas_refined aag \<rbrace>
-    do_user_op uop tc
+ "\<lbrace>invs and integrity aag X st and is_subject aag \<circ> cur_thread and pas_refined aag\<rbrace>
+  do_user_op uop tc
   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
   apply (simp add: do_user_op_def)
-  apply (wp | simp | wpc)+
+  apply wpsimp+
            apply (rule dmo_device_update_respects_Write)
-          apply (wp dmo_um_upd_machine_state
-                    dmo_user_memory_update_respects_Write hoare_vcg_all_lift hoare_vcg_imp_lift
-                  | wpc | clarsimp)+
+          apply (wpsimp wp: dmo_um_upd_machine_state
+                            dmo_user_memory_update_respects_Write
+                            hoare_vcg_all_lift hoare_vcg_imp_lift)+
           apply (rule hoare_pre_cont)
-         apply (wp   select_wp | wpc | clarsimp)+
-  apply (simp add: restrict_map_def split:if_splits)
+         apply (wpsimp wp: select_wp)+
+  apply (simp add: restrict_map_def split: if_splits)
   apply (rule conjI)
    apply (clarsimp split: if_splits)
    apply (drule_tac auth=Write in user_op_access')
-       apply (simp add: vspace_cap_rights_to_auth_def)+
-  apply (rule conjI,simp)
+       apply (simp add: write_in_vspace_cap_rights)+
+  apply (rule conjI, simp)
   apply (clarsimp split: if_splits)
   apply (drule_tac auth=Write in user_op_access')
-      apply (simp add: vspace_cap_rights_to_auth_def)+
+      apply (simp add: write_in_vspace_cap_rights)+
   done
 
 end

--- a/proof/access-control/ARM/ArchADT_AC.thy
+++ b/proof/access-control/ARM/ArchADT_AC.thy
@@ -1,0 +1,230 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchADT_AC
+imports ADT_AC
+begin
+
+context Arch begin global_naming ARM_A
+
+named_theorems ADT_AC_assms
+
+lemma invs_valid_global_pd_mappings:
+  "invs s \<Longrightarrow> valid_global_vspace_mappings s"
+  apply (simp add: invs_def valid_state_def)
+  done
+
+lemma objs_valid_tcb_vtable:
+  "\<lbrakk> valid_objs s; get_tcb t s = Some tcb \<rbrakk> \<Longrightarrow> s \<turnstile> tcb_vtable tcb"
+  apply (clarsimp simp: get_tcb_def split: option.splits Structures_A.kernel_object.splits)
+  apply (erule cte_wp_valid_cap[rotated])
+  apply (rule cte_wp_at_tcbI[where t="(a, b)" for a b, where b3="tcb_cnode_index 1"])
+    apply fastforce+
+  done
+
+lemma pd_of_thread_same_agent:
+  "\<lbrakk> pas_refined aag s; is_subject aag tcb_ptr;
+     get_pd_of_thread (kheap s) (arch_state s) tcb_ptr = pd; pd \<noteq> arm_global_pd (arch_state s) \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag tcb_ptr = pasObjectAbs aag pd"
+  apply (rule_tac aag="pasPolicy aag" in aag_wellformed_Control[rotated])
+   apply (fastforce simp: pas_refined_def)
+  apply (rule pas_refined_mem[rotated], simp)
+  apply (clarsimp simp: get_pd_of_thread_eq)
+  apply (cut_tac ptr="(tcb_ptr, tcb_cnode_index 1)" in sbta_caps)
+     prefer 4
+     apply (simp add: state_objs_to_policy_def)
+    apply (subst caps_of_state_tcb_cap_cases)
+      apply (simp add: get_tcb_def)
+     apply (simp add: dom_tcb_cap_cases[simplified])
+    apply simp
+   apply (simp add: obj_refs_def)
+  apply (simp add: cap_auth_conferred_def arch_cap_auth_conferred_def is_page_cap_def)
+  done
+
+lemma pd_of_thread_page_directory_at:
+  "\<lbrakk> invs s; get_pd_of_thread (kheap s) (arch_state s) tcb \<noteq> arm_global_pd (arch_state s) \<rbrakk>
+     \<Longrightarrow> page_directory_at ((get_pd_of_thread (kheap s) (arch_state s) tcb)) s"
+  apply (clarsimp simp: get_pd_of_thread_def
+                 split: option.splits kernel_object.splits cap.splits arch_cap.splits if_splits)
+  apply (frule_tac t=tcb in objs_valid_tcb_vtable[OF invs_valid_objs])
+   apply (simp add: get_tcb_def)
+  apply (fastforce simp: valid_cap_def2 valid_cap_ref_def valid_arch_cap_ref_simps)
+  done
+
+lemma ptr_offset_in_ptr_range:
+  "\<lbrakk> invs s; x \<notin> kernel_mappings;
+     get_pd_of_thread (kheap s) (arch_state s) tcb \<noteq> arm_global_pd (arch_state s);
+     get_page_info (\<lambda>obj. get_arch_obj (kheap s obj))
+                   (get_pd_of_thread (kheap s) (arch_state s) tcb) x = Some (base, sz, attr, r) \<rbrakk>
+     \<Longrightarrow> ptrFromPAddr base + (x && mask sz) \<in> ptr_range (ptrFromPAddr base) sz"
+  apply (simp add: ptr_range_def mask_def)
+  apply (rule conjI)
+   apply (rule_tac b="2 ^ sz - 1" in word_plus_mono_right2)
+    apply (frule some_get_page_info_umapsD)
+          apply (clarsimp simp: get_pd_of_thread_reachable invs_vspace_objs
+                                invs_psp_aligned invs_valid_asid_table invs_valid_objs)+
+    apply (drule is_aligned_ptrFromPAddr_n)
+     apply (simp add: pageBitsForSize_def split: vmpage_size.splits)
+    apply (clarsimp simp: is_aligned_no_overflow' word_and_le1)+
+  apply (subst p_assoc_help)
+  apply (rule word_plus_mono_right)
+   apply (rule word_and_le1)
+  apply (frule some_get_page_info_umapsD)
+        apply (clarsimp simp: get_pd_of_thread_reachable invs_vspace_objs
+                              invs_psp_aligned invs_valid_asid_table invs_valid_objs)+
+  apply (drule is_aligned_ptrFromPAddr_n)
+   apply (simp add: pageBitsForSize_def split: vmpage_size.splits)
+  apply (clarsimp simp: is_aligned_no_overflow')
+  done
+
+lemma kernel_mappings_kernel_mapping_slots:
+  "x \<notin> kernel_mappings \<Longrightarrow> ucast (x >> 20) \<notin> kernel_mapping_slots"
+  apply (rule kernel_base_kernel_mapping_slots)
+  apply (simp add: kernel_mappings_def)
+  done
+
+lemmas kernel_mappings_kernel_mapping_slots' =
+  kernel_mappings_kernel_mapping_slots[simplified kernel_mapping_slots_def, simplified]
+
+lemma ptable_state_objs_to_policy:
+  "\<lbrakk> invs s; ptable_lift tcb s x = Some ptr;
+     auth \<in> vspace_cap_rights_to_auth (ptable_rights tcb s x);
+     get_pd_of_thread (kheap s) (arch_state s) tcb \<noteq> arm_global_pd (arch_state s);
+     \<forall>word1 set1 word2. get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj))
+                                     (get_pd_of_thread (kheap s) (arch_state s) tcb) x \<noteq>
+                        Some (PageTablePDE word1 set1 word2); x \<notin> kernel_mappings \<rbrakk>
+     \<Longrightarrow> (get_pd_of_thread (kheap s) (arch_state s) tcb, auth, ptrFromPAddr ptr) \<in>
+           state_objs_to_policy s"
+  apply (simp add: state_objs_to_policy_def)
+  apply (rule sbta_vref)
+  apply (clarsimp simp: ptable_lift_def ptable_rights_def state_vrefs_def
+                  split: option.splits)
+  apply (frule pd_of_thread_page_directory_at, simp)
+  apply (clarsimp simp: typ_at_eq_kheap_obj)
+  apply (clarsimp simp: vs_refs_no_global_pts_def)
+  apply (rule_tac x="(ucast (x >> 20), ptrFromPAddr a, aa,
+                      vspace_cap_rights_to_auth b)" in bexI)
+   apply clarsimp
+   apply (rule_tac x="(ptrFromPAddr a + (x && mask aa), auth)" in image_eqI)
+    apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def physBase_def)
+   apply (simp add: ptr_offset_in_ptr_range)
+  apply (simp add: kernel_mappings_kernel_mapping_slots')
+  apply (clarsimp simp: graph_of_def)
+  apply (clarsimp simp: get_page_info_def get_pd_entry_def pde_ref2_def
+                  split: option.splits pde.splits arch_kernel_obj.splits)
+   apply (clarsimp simp: get_arch_obj_def
+                   split: option.splits kernel_object.splits arch_kernel_obj.splits)+
+  done
+
+lemma pt_in_pd_same_agent:
+  "\<lbrakk> pas_refined aag s; is_subject aag pd_ptr; vptr \<notin> kernel_mappings;
+     get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj)) pd_ptr vptr = Some (PageTablePDE p x xa) \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag pd_ptr = pasObjectAbs aag (ptrFromPAddr p)"
+  apply (rule_tac aag="pasPolicy aag" in aag_wellformed_Control[rotated])
+   apply (fastforce simp: pas_refined_def)
+  apply (rule pas_refined_mem[rotated], simp)
+  apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
+                 split: option.splits kernel_object.splits arch_kernel_obj.splits)
+  apply (simp add: state_objs_to_policy_def)
+  apply (rule sbta_vref)
+  apply (simp add: state_vrefs_def split: option.splits)
+  apply (clarsimp simp: vs_refs_no_global_pts_def)
+  apply (rule_tac x="(ucast (vptr >> 20), ptrFromPAddr p, 0, {Control})" in bexI)
+   apply simp
+  apply (simp add: kernel_mappings_kernel_mapping_slots' graph_of_def pde_ref2_def)
+  done
+
+lemma pt_in_pd_page_table_at:
+  "\<lbrakk> invs s; get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj)) pd_ptr x =
+     Some (PageTablePDE word1 set1 word2); (\<exists>\<rhd> pd_ptr) s; x \<notin> kernel_mappings \<rbrakk>
+     \<Longrightarrow> page_table_at (ptrFromPAddr word1) s"
+  apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
+                  split: option.splits kernel_object.splits arch_kernel_obj.splits)
+  apply (rename_tac "fun")
+  apply (subgoal_tac "valid_vspace_obj (PageDirectory fun) s")
+   apply (simp add: kernel_mappings_slots_eq)
+   apply (drule bspec)
+    apply simp+
+  apply (drule invs_vspace_objs)
+  apply (auto simp: obj_at_def invs_vspace_objs valid_vspace_objs_def)
+  done
+
+lemma get_page_info_state_objs_to_policy:
+  "\<lbrakk> invs s; auth \<in> vspace_cap_rights_to_auth r;
+     get_page_info (\<lambda>obj. get_arch_obj (kheap s obj))
+                   (get_pd_of_thread (kheap s) (arch_state s) tcb) x =
+     Some (base, sz, attr, r);
+     get_pd_of_thread (kheap s) (arch_state s) tcb \<noteq> arm_global_pd (arch_state s);
+     get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj))
+                  (get_pd_of_thread (kheap s) (arch_state s) tcb) x =
+     Some (PageTablePDE word1 set1 word2); x \<notin> kernel_mappings \<rbrakk>
+     \<Longrightarrow> (ptrFromPAddr word1, auth, ptrFromPAddr (base + (x && mask sz))) \<in> state_objs_to_policy s"
+  apply (simp add: state_objs_to_policy_def)
+  apply (rule sbta_vref)
+  apply (clarsimp simp: state_vrefs_def split: option.splits)
+  apply (frule pt_in_pd_page_table_at)
+     apply (simp add: get_pd_of_thread_reachable)+
+  apply (clarsimp simp: typ_at_eq_kheap_obj)
+  apply (clarsimp simp: vs_refs_no_global_pts_def)
+  apply (rule_tac x="(ucast ((x >> 12) && mask 8),  ptrFromPAddr base, sz,
+                      vspace_cap_rights_to_auth r)" in bexI)
+   apply clarsimp
+   apply (rule_tac x="(ptrFromPAddr base + (x && mask sz), auth)" in image_eqI)
+    apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def physBase_def)
+   apply (simp add: ptr_offset_in_ptr_range)
+  apply (clarsimp simp: get_page_info_def get_pd_entry_def get_pt_info_def
+                        get_pt_entry_def get_arch_obj_def pte_ref_def graph_of_def
+                 split: option.splits pte.splits pde.splits arch_kernel_obj.splits)
+  done
+
+lemma user_op_access[ADT_AC_assms]:
+  "\<lbrakk> invs s; pas_refined aag s; is_subject aag tcb; ptable_lift tcb s x = Some ptr;
+     auth \<in> vspace_cap_rights_to_auth (ptable_rights tcb s x) \<rbrakk>
+     \<Longrightarrow> abs_has_auth_to aag auth tcb (ptrFromPAddr ptr)"
+  apply (case_tac "x \<in> kernel_mappings")
+   apply (fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
+                          ptable_lift_def ptable_rights_def vspace_cap_rights_to_auth_def
+                    dest: some_get_page_info_kmapsD split: option.splits)
+  apply (case_tac "get_pd_of_thread (kheap s) (arch_state s) tcb =
+                   arm_global_pd (arch_state s)")
+   apply (fastforce simp: invs_valid_global_objs invs_arch_state
+                          ptable_lift_def ptable_rights_def
+                   split: option.splits
+                    dest: get_page_info_gpd_kmaps[rotated 2])
+  apply (subst pd_of_thread_same_agent)
+      apply fastforce+
+  apply (cases "\<exists>word1 set1 word2. get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj))
+                                                (get_pd_of_thread (kheap s) (arch_state s) tcb) x =
+                                   Some (PageTablePDE word1 set1 word2)")
+   apply (clarsimp simp: ptable_lift_def ptable_rights_def split: option.splits)
+   apply (frule pd_of_thread_same_agent)
+      apply fastforce+
+   apply (subst pt_in_pd_same_agent)
+       apply fastforce+
+   apply (rule pas_refined_mem[rotated], simp)
+   apply (rule get_page_info_state_objs_to_policy)
+        apply fastforce+
+  apply (rule pas_refined_mem[rotated], simp)
+  apply (rule ptable_state_objs_to_policy)
+       apply simp+
+  done
+
+lemma write_in_vspace_cap_rights[ADT_AC_assms]:
+  "AllowWrite \<in> ptable_rights (cur_thread s) s va
+   \<Longrightarrow> Write \<in> vspace_cap_rights_to_auth (ptable_rights (cur_thread s) s va)"
+  by (clarsimp simp: vspace_cap_rights_to_auth_def)
+
+end
+
+
+global_interpretation ADT_AC_1?: ADT_AC_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact ADT_AC_assms)
+qed
+
+end

--- a/proof/access-control/ARM/ArchAccess.thy
+++ b/proof/access-control/ARM/ArchAccess.thy
@@ -1,0 +1,287 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchAccess
+imports Types
+begin
+
+context Arch begin global_naming ARM_A
+
+subsection \<open>Arch-specific transformation of caps into authorities\<close>
+
+definition vspace_cap_rights_to_auth :: "cap_rights \<Rightarrow> auth set" where
+  "vspace_cap_rights_to_auth r \<equiv>
+     (if AllowWrite \<in> r then {Write} else {})
+   \<union> (if AllowRead \<in> r then {Read} else {})"
+
+definition arch_cap_auth_conferred where
+  "arch_cap_auth_conferred arch_cap \<equiv>
+     (if is_page_cap arch_cap then vspace_cap_rights_to_auth (acap_rights arch_cap) else {Control})"
+
+subsection \<open>Generating a policy from the current ASID distribution\<close>
+
+definition pte_ref where
+  "pte_ref pte \<equiv> case pte of
+     SmallPagePTE addr atts rights
+       \<Rightarrow> Some (ptrFromPAddr addr, pageBitsForSize ARMSmallPage, vspace_cap_rights_to_auth rights)
+   | LargePagePTE addr atts rights
+       \<Rightarrow> Some (ptrFromPAddr addr, pageBitsForSize ARMLargePage, vspace_cap_rights_to_auth rights)
+   | _ \<Rightarrow> None"
+
+definition pde_ref2 where
+  "pde_ref2 pde \<equiv> case pde of
+     SectionPDE addr atts domain rights
+       \<Rightarrow> Some (ptrFromPAddr addr, pageBitsForSize ARMSection, vspace_cap_rights_to_auth rights)
+   | SuperSectionPDE addr atts rights
+       \<Rightarrow> Some (ptrFromPAddr addr, pageBitsForSize ARMSuperSection, vspace_cap_rights_to_auth rights)
+   | PageTablePDE addr atts domain
+       \<comment> \<open>The 0 is a hack, saying that we own only addr, although 12 would also be OK\<close>
+       \<Rightarrow> Some (ptrFromPAddr addr, 0, {Control})
+   | _ \<Rightarrow> None"
+
+\<comment> \<open>We exclude the global page tables from the authority graph. Alternatively, we could include them
+    and add a wellformedness constraint to policies that requires that every label has the necessary
+    authority to whichever label owns the global page tables, so that when a new page directory is
+    created and references to the global page tables are added to it, no new authority is gained.
+    Note: excluding the references to global page tables in this way brings in some ARM
+          arch-specific VM knowledge here\<close>
+definition vs_refs_no_global_pts :: "kernel_object \<Rightarrow> (obj_ref \<times> obj_ref \<times> aa_type \<times> auth) set"
+  where
+  "vs_refs_no_global_pts \<equiv> \<lambda>ko. case ko of
+     ArchObj (ASIDPool pool) \<Rightarrow> (\<lambda>(r,p). (p, ucast r, AASIDPool, Control)) ` graph_of pool
+   | ArchObj (PageDirectory pd) \<Rightarrow>
+       \<Union>(r,(p, sz, auth)) \<in> graph_of (pde_ref2 o pd) - {(x,y). (ucast (kernel_base >> 20) \<le> x)}.
+         (\<lambda>(p, a). (p, ucast r, APageDirectory, a)) ` (ptr_range p sz \<times> auth)
+   | ArchObj (PageTable pt) \<Rightarrow>
+       \<Union>(r,(p, sz, auth)) \<in> graph_of (pte_ref o pt).
+         (\<lambda>(p, a). (p, ucast r, APageTable, a)) ` (ptr_range p sz \<times> auth)
+   | _ \<Rightarrow> {}"
+
+definition state_vrefs where
+  "state_vrefs s = case_option {} vs_refs_no_global_pts o kheap s"
+
+end
+
+
+context pspace_update_eq begin interpretation Arch .
+
+lemma state_vrefs[iff]: "state_vrefs (f s) = state_vrefs s"
+  by (simp add: state_vrefs_def pspace)
+
+end
+
+
+context Arch begin
+
+primrec aobj_ref' where
+  "aobj_ref' (ASIDPoolCap p as) = {p}"
+| "aobj_ref' ASIDControlCap = {}"
+| "aobj_ref' (PageCap isdev x rs sz as4) = ptr_range x (pageBitsForSize sz)"
+| "aobj_ref' (PageDirectoryCap x as2) = {x}"
+| "aobj_ref' (PageTableCap x as3) = {x}"
+
+fun acap_asid' :: "arch_cap \<Rightarrow> asid set" where
+  "acap_asid' (PageCap _ _ _ _ mapping) = fst ` set_option mapping"
+| "acap_asid' (PageTableCap _ mapping) = fst ` set_option mapping"
+| "acap_asid' (PageDirectoryCap _ asid_opt) = set_option asid_opt"
+| "acap_asid' (ASIDPoolCap _ asid)
+     = {x. asid_high_bits_of x = asid_high_bits_of asid \<and> x \<noteq> 0}"
+| "acap_asid' ASIDControlCap = UNIV"
+
+inductive_set state_asids_to_policy_aux for aag caps asid_tab vrefs where
+  sata_asid:
+    "\<lbrakk> caps ptr = Some (ArchObjectCap acap); asid \<in> acap_asid' acap \<rbrakk>
+       \<Longrightarrow> (pasObjectAbs aag (fst ptr), Control, pasASIDAbs aag asid)
+             \<in> state_asids_to_policy_aux aag caps asid_tab vrefs"
+| sata_asid_lookup:
+    "\<lbrakk> asid_tab (asid_high_bits_of asid) = Some poolptr;
+       (pdptr, asid && mask asid_low_bits, AASIDPool, a) \<in> vrefs poolptr \<rbrakk>
+       \<Longrightarrow> (pasASIDAbs aag asid, a, pasObjectAbs aag pdptr)
+             \<in> state_asids_to_policy_aux aag caps asid_tab vrefs"
+| sata_asidpool:
+    "\<lbrakk> asid_tab (asid_high_bits_of asid) = Some poolptr; asid \<noteq> 0 \<rbrakk>
+       \<Longrightarrow> (pasObjectAbs aag poolptr, AAuth ASIDPoolMapsASID, pasASIDAbs aag asid)
+             \<in> state_asids_to_policy_aux aag caps asid_tab vrefs"
+
+definition
+  "state_asids_to_policy_arch aag caps astate vrefs \<equiv>
+     state_asids_to_policy_aux aag caps (arm_asid_table astate) vrefs"
+declare state_asids_to_policy_arch_def[simp]
+
+section \<open>Arch-specific integrity definition\<close>
+
+subsection \<open>How ASIDs can change\<close>
+
+abbreviation integrity_asids_aux ::
+  "'a PAS \<Rightarrow> 'a set \<Rightarrow> asid \<Rightarrow> obj_ref option \<Rightarrow> obj_ref option \<Rightarrow> bool" where
+  "integrity_asids_aux aag subjects asid pp_opt pp_opt' \<equiv>
+     pp_opt = pp_opt' \<or> (\<forall>asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of asid
+                                 \<longrightarrow> pasASIDAbs aag asid' \<in> subjects)"
+
+definition integrity_asids ::
+  "'a PAS \<Rightarrow> 'a set \<Rightarrow> asid \<Rightarrow> 'y::state_ext state \<Rightarrow> 'z:: state_ext state  \<Rightarrow> bool" where
+  "integrity_asids aag subjects x s s' \<equiv>
+   integrity_asids_aux aag subjects x (asid_table s  (asid_high_bits_of x))
+                                      (asid_table s' (asid_high_bits_of x))"
+
+declare integrity_asids_def[simp]
+
+lemma integrity_asids_trans_state_l[simp]:
+  "integrity_asids aag subjects x (trans_state f st) s =
+   integrity_asids aag subjects x st s"
+  by simp
+
+lemma integrity_asids_trans_state_r[simp]:
+  "integrity_asids aag subjects x st (trans_state f s) =
+   integrity_asids aag subjects x st s"
+  by simp
+
+lemma integrity_asids_cur_thread_update_l[simp]:
+  "integrity_asids aag subjects x (cur_thread_update f st) s =
+   integrity_asids aag subjects x st s"
+  by simp
+
+lemma integrity_asids_cur_thread_update_r[simp]:
+  "integrity_asids aag subjects x st (cur_thread_update f s) =
+   integrity_asids aag subjects x st s"
+  by simp
+
+lemma integrity_asids_kheap_update_l[simp]:
+  "integrity_asids aag subjects x (kheap_update f st) s =
+   integrity_asids aag subjects x st s"
+  by simp
+
+lemma integrity_asids_kheap_update_r[simp]:
+  "integrity_asids aag subjects x st (kheap_update f s) =
+   integrity_asids aag subjects x st s"
+  by simp
+
+lemma integrity_asids_machine_state_update_l[simp]:
+  "integrity_asids aag subjects x (machine_state_update f st) s =
+   integrity_asids aag subjects x st s"
+  by simp
+
+lemma integrity_asids_machine_state_update_r[simp]:
+  "integrity_asids aag subjects x st (machine_state_update f s) =
+   integrity_asids aag subjects x st s"
+  by simp
+
+lemma integrity_asids_cdt_update_l[simp]:
+  "integrity_asids aag subjects x (cdt_update f st) s =
+   integrity_asids aag subjects x st s"
+  by simp
+
+lemma integrity_asids_cdt_update_r[simp]:
+  "integrity_asids aag subjects x st (cdt_update f s) =
+   integrity_asids aag subjects x st s"
+  by simp
+
+lemma integrity_asids_is_original_cap_update_l[simp]:
+  "integrity_asids aag subjects x (is_original_cap_update f st) s =
+   integrity_asids aag subjects x st s"
+  by simp
+
+lemma integrity_asids_is_original_cap_update_r[simp]:
+  "integrity_asids aag subjects x st (is_original_cap_update f s) =
+   integrity_asids aag subjects x st s"
+  by simp
+
+lemma integrity_asids_interrupt_states_update_l[simp]:
+  "integrity_asids aag subjects x (interrupt_states_update f st) s =
+   integrity_asids aag subjects x st s"
+  by simp
+
+lemma integrity_asids_interrupt_states_update_r[simp]:
+  "integrity_asids aag subjects x st (interrupt_states_update f s) =
+   integrity_asids aag subjects x st s"
+  by simp
+
+(* FIXME AC: locale? *)
+lemmas integrity_asids_updates =
+  integrity_asids_trans_state_l
+  integrity_asids_trans_state_r
+  integrity_asids_cur_thread_update_l
+  integrity_asids_cur_thread_update_r
+  integrity_asids_kheap_update_l
+  integrity_asids_kheap_update_r
+  integrity_asids_machine_state_update_l
+  integrity_asids_machine_state_update_r
+  integrity_asids_cdt_update_l
+  integrity_asids_cdt_update_r
+  integrity_asids_is_original_cap_update_l
+  integrity_asids_is_original_cap_update_r
+  integrity_asids_interrupt_states_update_l
+  integrity_asids_interrupt_states_update_r
+
+
+subsection \<open>Misc definitions\<close>
+
+definition ctxt_IP_update where
+  "ctxt_IP_update ctxt \<equiv> ctxt(NextIP := ctxt FaultIP)"
+
+abbreviation arch_IP_update where
+  "arch_IP_update arch \<equiv> arch_tcb_context_set (ctxt_IP_update (arch_tcb_context_get arch)) arch"
+
+definition asid_pool_integrity ::
+  "'a set \<Rightarrow> 'a PAS \<Rightarrow> (asid_low_index \<rightharpoonup> obj_ref) \<Rightarrow> (asid_low_index \<rightharpoonup> obj_ref) \<Rightarrow> bool" where
+  "asid_pool_integrity subjects aag pool pool' \<equiv>
+     \<forall>x. pool' x \<noteq> pool x
+         \<longrightarrow> pool' x = None \<and> aag_subjects_have_auth_to subjects aag Control (the (pool x))"
+
+inductive arch_integrity_obj_atomic ::
+   "'a PAS \<Rightarrow> 'a set \<Rightarrow> 'a \<Rightarrow> arch_kernel_obj \<Rightarrow> arch_kernel_obj \<Rightarrow> bool"
+  for aag subjects l ao ao' where
+  arch_troa_asidpool_clear:
+    "\<lbrakk> ao = ASIDPool pool; ao' = ASIDPool pool';
+       asid_pool_integrity subjects aag pool pool' \<rbrakk>
+       \<Longrightarrow> arch_integrity_obj_atomic aag subjects l ao ao'"
+
+inductive arch_integrity_obj_alt ::
+   "'a PAS \<Rightarrow> 'a set \<Rightarrow> 'a \<Rightarrow> arch_kernel_obj \<Rightarrow> arch_kernel_obj \<Rightarrow> bool"
+  for aag subjects l' ao ao' where
+  arch_tro_alt_asidpool_clear:
+    "\<lbrakk> ao = ASIDPool pool; ao' = ASIDPool pool';
+       asid_pool_integrity subjects aag pool pool'\<rbrakk>
+       \<Longrightarrow> arch_integrity_obj_alt aag subjects l' ao ao'"
+
+definition auth_ipc_buffers :: "'z::state_ext state \<Rightarrow> obj_ref \<Rightarrow> obj_ref set" where
+  "auth_ipc_buffers s \<equiv> \<lambda>p. case (get_tcb p s) of
+     None \<Rightarrow> {}
+   | Some tcb \<Rightarrow>
+     (case tcb_ipcframe tcb of
+        ArchObjectCap (PageCap False p' R vms _) \<Rightarrow>
+          if AllowWrite \<in> R
+          then (ptr_range (p' + (tcb_ipc_buffer tcb && mask (pageBitsForSize vms))) msg_align_bits)
+          else {}
+      | _ \<Rightarrow> {})"
+
+end
+
+
+context begin interpretation Arch .
+
+requalify_consts
+  vspace_cap_rights_to_auth
+  aobj_ref'
+  acap_asid'
+  state_vrefs
+  state_asids_to_policy_arch
+  integrity_asids
+  ctxt_IP_update
+  arch_IP_update
+  arch_cap_auth_conferred
+  arch_integrity_obj_atomic
+  arch_integrity_obj_alt
+  auth_ipc_buffers
+
+requalify_facts
+  integrity_asids_updates
+
+end
+
+declare integrity_asids_updates[simp]
+
+end

--- a/proof/access-control/ARM/ArchAccess_AC.thy
+++ b/proof/access-control/ARM/ArchAccess_AC.thy
@@ -1,0 +1,187 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchAccess_AC
+imports Access_AC
+begin
+
+section\<open>Arch-specific AC proofs\<close>
+
+context Arch begin global_naming ARM_A
+
+named_theorems Access_AC_assms
+
+lemma acap_class_reply[Access_AC_assms]:
+  "acap_class acap \<noteq> ReplyClass t"
+  by (cases acap; simp)
+
+lemma arch_troa_tro_alt[Access_AC_assms, elim!]:
+  "arch_integrity_obj_atomic aag subjects l ko ko'
+   \<Longrightarrow> arch_integrity_obj_alt aag subjects l ko ko'"
+  by (fastforce elim: arch_integrity_obj_atomic.cases intro: arch_integrity_obj_alt.intros)
+
+lemma clear_asidpool_trans[elim]:
+  "\<lbrakk> asid_pool_integrity subjects aag pool pool';
+     asid_pool_integrity subjects aag pool' pool'' \<rbrakk>
+     \<Longrightarrow> asid_pool_integrity subjects aag pool pool''"
+  unfolding asid_pool_integrity_def by metis
+
+lemma cap_asid'_member[simp]:
+  "asid \<in> cap_asid' cap = (\<exists>acap. cap = ArchObjectCap acap \<and> asid \<in> acap_asid' acap)"
+  by (cases cap; clarsimp)
+
+lemma clas_caps_of_state[Access_AC_assms]:
+  "\<lbrakk> caps_of_state s slot = Some cap; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> cap_links_asid_slot aag (pasObjectAbs aag (fst slot)) cap"
+  apply (clarsimp simp: cap_links_asid_slot_def label_owns_asid_slot_def pas_refined_def)
+  apply (drule state_asids_to_policy_aux.intros)
+   apply assumption
+  apply (blast dest: state_asids_to_policy_aux.intros)
+  done
+
+lemma arch_tro_alt_trans_spec[Access_AC_assms]:
+  "\<lbrakk> arch_integrity_obj_alt aag subjects l ko ko';
+     arch_integrity_obj_alt aag subjects l ko' ko'' \<rbrakk>
+     \<Longrightarrow> arch_integrity_obj_alt aag subjects l ko ko''"
+  by (fastforce simp: arch_integrity_obj_alt.simps)
+
+lemma integrity_asids_update_autarch[Access_AC_assms]:
+  "\<lbrakk> integrity_asids aag subjects x st s; is_subject aag ptr \<rbrakk>
+     \<Longrightarrow> integrity_asids aag subjects x st (s\<lparr>kheap := kheap s(ptr \<mapsto> obj)\<rparr>)"
+  by simp
+
+lemma as_user_state_vrefs[Access_AC_assms, wp]:
+  "as_user t f \<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace>"
+  apply (simp add: as_user_def)
+  apply (wpsimp wp: set_object_wp)
+  apply (clarsimp simp: state_vrefs_def vs_refs_no_global_pts_def get_tcb_def
+                 elim!: rsubst[where P=P, OF _ ext]
+                 split: option.split_asm Structures_A.kernel_object.split)
+  done
+
+end
+
+
+global_interpretation Access_AC_1?: Access_AC_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact Access_AC_assms)
+qed
+
+
+context Arch begin global_naming ARM_A
+
+lemma auth_ipc_buffers_tro[Access_AC_assms]:
+  "\<lbrakk> integrity_obj_state aag activate subjects s s';
+     x \<in> auth_ipc_buffers s' p; pasObjectAbs aag p \<notin> subjects \<rbrakk>
+     \<Longrightarrow> x \<in> auth_ipc_buffers s p "
+  by (drule_tac x = p in spec)
+     (erule integrity_objE;
+      fastforce simp: tcb_states_of_state_def get_tcb_def auth_ipc_buffers_def
+               split: cap.split_asm arch_cap.split_asm if_split_asm bool.splits)
+
+lemma trasids_trans[Access_AC_assms]:
+  "\<lbrakk> (\<forall>x. integrity_asids aag subjects x s s');
+     (\<forall>x. integrity_asids aag subjects x  s' s'') \<rbrakk>
+     \<Longrightarrow> (\<forall>x. integrity_asids aag subjects x s s'')"
+  apply clarsimp
+  apply (drule_tac x=x in spec)+
+  apply fastforce
+  done
+
+lemma integrity_asids_refl[Access_AC_assms, simp]:
+  "integrity_asids aag subjects x s s"
+  by simp
+
+end
+
+
+global_interpretation Access_AC_2?: Access_AC_2
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact Access_AC_assms)
+qed
+
+
+context Arch begin global_naming ARM_A
+
+lemma ipcframe_subset_page:
+  "\<lbrakk> valid_objs s; get_tcb p s = Some tcb;
+     tcb_ipcframe tcb = ArchObjectCap (PageCap d p' R vms xx);
+     x \<in> ptr_range (p' + (tcb_ipc_buffer tcb && mask (pageBitsForSize vms))) msg_align_bits \<rbrakk>
+     \<Longrightarrow> x \<in> ptr_range p' (pageBitsForSize vms)"
+   apply (frule (1) valid_tcb_objs)
+   apply (clarsimp simp add: valid_tcb_def ran_tcb_cap_cases)
+   apply (erule set_mp[rotated])
+   apply (rule ptr_range_subset)
+     apply (simp add: valid_cap_def cap_aligned_def)
+    apply (simp add: valid_tcb_def valid_ipc_buffer_cap_def is_aligned_andI1 split:bool.splits)
+   apply (rule order_trans [OF _ pbfs_atleast_pageBits])
+   apply (simp add: msg_align_bits pageBits_def)
+  apply (rule and_mask_less')
+  apply (simp add: pbfs_less_wb' [unfolded word_bits_conv])
+  done
+
+lemma auth_ipc_buffers_member_def:
+  "x \<in> auth_ipc_buffers s p =
+   (\<exists>tcb p' R vms xx. get_tcb p s = Some tcb
+                   \<and> tcb_ipcframe tcb = (ArchObjectCap (PageCap False p' R vms xx))
+                   \<and> caps_of_state s (p, tcb_cnode_index 4) =
+                      Some (ArchObjectCap (PageCap False p' R vms xx))
+                   \<and> AllowWrite \<in> R
+                   \<and> x \<in> ptr_range (p' + (tcb_ipc_buffer tcb && mask (pageBitsForSize vms)))
+                                    msg_align_bits)"
+  unfolding auth_ipc_buffers_def
+  by (clarsimp simp: caps_of_state_tcb' split: option.splits cap.splits arch_cap.splits bool.splits)
+
+lemma auth_ipc_buffers_member[Access_AC_assms]:
+  "\<lbrakk> x \<in> auth_ipc_buffers s p; valid_objs s \<rbrakk>
+     \<Longrightarrow> \<exists>tcb acap. get_tcb p s = Some tcb
+                  \<and> tcb_ipcframe tcb = (ArchObjectCap acap)
+                  \<and> caps_of_state s (p, tcb_cnode_index 4) = Some (ArchObjectCap acap)
+                  \<and> Write \<in> arch_cap_auth_conferred acap
+                  \<and> x \<in> aobj_ref' acap"
+  by (fastforce simp: auth_ipc_buffers_def caps_of_state_tcb' arch_cap_auth_conferred_def
+                      vspace_cap_rights_to_auth_def ipcframe_subset_page
+               split: option.splits cap.splits arch_cap.splits bool.splits if_splits)
+
+lemma asid_pool_integrity_mono[Access_AC_assms]:
+  "\<lbrakk> asid_pool_integrity S aag cont cont'; S \<subseteq> T \<rbrakk> \<Longrightarrow> asid_pool_integrity T aag cont cont'"
+  unfolding asid_pool_integrity_def by fastforce
+
+lemma integrity_asids_mono[Access_AC_assms]:
+    "\<lbrakk> integrity_asids aag S x s s'; S \<subseteq> T; pas_refined aag s; valid_objs s \<rbrakk>
+       \<Longrightarrow> integrity_asids aag T x s s'"
+  by fastforce
+
+lemma arch_integrity_obj_atomic_mono[Access_AC_assms]:
+  "\<lbrakk> arch_integrity_obj_atomic aag S l ao ao'; S \<subseteq> T; pas_refined aag s; valid_objs s \<rbrakk>
+     \<Longrightarrow> arch_integrity_obj_atomic aag T l ao ao'"
+  by (clarsimp simp: arch_integrity_obj_atomic.simps asid_pool_integrity_mono)
+
+end
+
+
+global_interpretation Access_AC_3?: Access_AC_3
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact Access_AC_assms)
+qed
+
+
+context Arch begin global_naming ARM_A
+
+lemma pas_refined_irq_state_independent[intro!, simp]:
+  "pas_refined x (s\<lparr>machine_state := machine_state s\<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>) =
+   pas_refined x s"
+  by (simp add: pas_refined_def)
+
+end
+
+end

--- a/proof/access-control/ARM/ArchArch_AC.thy
+++ b/proof/access-control/ARM/ArchArch_AC.thy
@@ -1,0 +1,1002 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchArch_AC
+imports Arch_AC
+begin
+
+text\<open>
+
+Arch-specific access control.
+
+\<close>
+
+context Arch begin global_naming ARM_A
+
+named_theorems Arch_AC_assms
+
+lemma set_mrs_state_vrefs[Arch_AC_assms, wp]:
+  "set_mrs thread buf msgs \<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace>"
+  apply (simp add: set_mrs_def split_def set_object_def get_object_def split del: if_split)
+  apply (wpsimp wp: gets_the_wp get_wp put_wp mapM_x_wp'
+              simp: zipWithM_x_mapM_x split_def store_word_offs_def
+         split_del: if_split)
+  apply (auto simp: obj_at_def state_vrefs_def get_tcb_ko_at
+             elim!: rsubst[where P=P, OF _ ext]
+             split: if_split_asm simp: vs_refs_no_global_pts_def)
+  done
+
+lemma mul_add_word_size_lt_msg_align_bits_ofnat[Arch_AC_assms]:
+  "\<lbrakk> p < 2 ^ (msg_align_bits - word_size_bits); k < 4 \<rbrakk>
+     \<Longrightarrow> of_nat p * of_nat word_size + k < (2 :: obj_ref) ^ msg_align_bits"
+  apply (rule is_aligned_add_less_t2n[where n=word_size_bits])
+     apply (simp_all add: msg_align_bits' word_size_word_size_bits is_aligned_mult_triv2)
+   apply (simp_all add: word_size_word_size_bits word_size_bits_def)
+  apply (erule word_less_power_trans_ofnat[where k=2 and m=9, simplified], simp)
+  done
+
+end
+
+
+global_interpretation Arch_AC_1?: Arch_AC_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact Arch_AC_assms)
+qed
+
+
+context Arch begin global_naming ARM_A
+
+lemma store_pte_respects:
+  "\<lbrace>integrity aag X st and K (is_subject aag (p && ~~ mask pt_bits))\<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: store_pte_def set_pt_def)
+  apply (wp get_object_wp set_object_integrity_autarch)
+  apply simp
+  done
+
+lemma integrity_arch_state [iff]:
+  "arm_asid_table v = arm_asid_table (arch_state s)
+   \<Longrightarrow> integrity aag X st (s\<lparr>arch_state := v\<rparr>) = integrity aag X st s"
+  unfolding integrity_def by simp
+
+lemma integrity_arm_asid_map[iff]:
+  "integrity aag X st (s\<lparr>arch_state := ((arch_state s)\<lparr>arm_asid_map := v\<rparr>)\<rparr>) =
+   integrity aag X st s"
+  unfolding integrity_def by simp
+
+lemma integrity_arm_hwasid_table[iff]:
+  "integrity aag X st (s\<lparr>arch_state := ((arch_state s)\<lparr>arm_hwasid_table := v\<rparr>)\<rparr>) =
+   integrity aag X st s"
+  unfolding integrity_def by simp
+
+lemma integrity_arm_next_asid[iff]:
+  "integrity aag X st (s\<lparr>arch_state := ((arch_state s)\<lparr>arm_next_asid := v\<rparr>)\<rparr>) =
+   integrity aag X st s"
+  unfolding integrity_def by simp
+
+crunch respects[wp]: arm_context_switch "integrity X aag st"
+  (simp: dmo_bind_valid dsb_def isb_def writeTTBR0_def invalidateLocalTLB_ASID_def
+         setHardwareASID_def set_current_pd_def ignore: do_machine_op)
+
+crunch respects[wp]: set_vm_root "integrity X aag st"
+  (simp: set_current_pd_def isb_def dsb_def writeTTBR0_def dmo_bind_valid crunch_simps
+     wp: crunch_wps ignore: do_machine_op)
+
+crunch respects[wp]: set_vm_root_for_flush "integrity X aag st"
+  (wp: crunch_wps simp: set_current_pd_def crunch_simps ignore: do_machine_op)
+
+crunch respects[wp]: flush_table "integrity X aag st"
+  (wp: crunch_wps simp: invalidateLocalTLB_ASID_def crunch_simps ignore: do_machine_op)
+
+crunch respects[wp]: page_table_mapped "integrity X aag st"
+
+lemma kheap_eq_state_vrefsD:
+  "kheap s p = Some ko \<Longrightarrow> state_vrefs s p = vs_refs_no_global_pts ko"
+  by (simp add: state_vrefs_def)
+
+lemma kheap_eq_state_vrefs_pas_refinedD:
+  "\<lbrakk> kheap s p = Some ko; (p', r, t, a) \<in> vs_refs_no_global_pts ko; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> abs_has_auth_to aag a p p'"
+  apply (drule kheap_eq_state_vrefsD)
+  apply (erule pas_refined_mem[OF sta_vref, rotated])
+  apply simp
+  done
+
+lemma find_pd_for_asid_authority1:
+  "\<lbrace>pas_refined aag\<rbrace>
+   find_pd_for_asid asid
+   \<lbrace>\<lambda>pd _. (pasASIDAbs aag asid, Control, pasObjectAbs aag pd) \<in> pasPolicy aag\<rbrace>,-"
+  apply (rule hoare_pre)
+   apply (simp add: find_pd_for_asid_def)
+   apply (wp | wpc)+
+  apply (clarsimp simp: obj_at_def pas_refined_def)
+  apply (erule subsetD, erule sata_asid_lookup)
+  apply (simp add: state_vrefs_def vs_refs_no_global_pts_def image_def)
+  apply (rule rev_bexI, erule graph_ofI)
+  apply (simp add: mask_asid_low_bits_ucast_ucast)
+  done
+
+lemma find_pd_for_asid_authority2:
+  "\<lbrace>\<lambda>s. \<forall>pd. (\<forall>aag. pas_refined aag s
+                    \<longrightarrow> (pasASIDAbs aag asid, Control, pasObjectAbs aag pd) \<in> pasPolicy aag) \<and>
+             (pspace_aligned s \<and> valid_vspace_objs s \<longrightarrow> is_aligned pd pd_bits) \<and>
+             (\<exists>\<rhd> pd) s
+             \<longrightarrow> Q pd s\<rbrace>
+   find_pd_for_asid asid
+   \<lbrace>Q\<rbrace>, -" (is "\<lbrace>?P\<rbrace> ?f \<lbrace>Q\<rbrace>,-")
+  apply (clarsimp simp: validE_R_def validE_def valid_def imp_conjL[symmetric])
+  apply (frule in_inv_by_hoareD[OF find_pd_for_asid_inv], clarsimp)
+  apply (drule spec, erule mp)
+  apply (simp add: use_validE_R[OF _ find_pd_for_asid_authority1]
+                   use_validE_R[OF _ find_pd_for_asid_aligned_pd_bits]
+                   use_validE_R[OF _ find_pd_for_asid_lookup])
+  done
+
+lemma find_pd_for_asid_pd_slot_authorised [wp]:
+  "\<lbrace>pas_refined aag and K (is_subject_asid aag asid) and pspace_aligned and valid_vspace_objs\<rbrace>
+   find_pd_for_asid asid
+   \<lbrace>\<lambda>rv _. is_subject aag (lookup_pd_slot rv vptr && ~~ mask pd_bits)\<rbrace>, -"
+  apply (wp find_pd_for_asid_authority2)
+  apply (clarsimp simp: lookup_pd_slot_pd)
+  apply (fastforce dest: pas_refined_Control)
+  done
+
+lemma unmap_page_table_respects:
+  "\<lbrace>integrity aag X st and pas_refined aag and invs
+                       and K (is_subject_asid aag asid \<and> vaddr < kernel_base)\<rbrace>
+   unmap_page_table asid vaddr pt
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (simp add: unmap_page_table_def page_table_mapped_def )
+  apply (rule hoare_pre)
+   apply (wpsimp wp: store_pde_respects page_table_mapped_wp_weak get_pde_wp hoare_vcg_all_lift_R
+               simp: cleanByVA_PoU_def
+          | wp (once) hoare_drop_imps)+
+  apply auto
+  done
+
+definition authorised_page_table_inv :: "'a PAS \<Rightarrow> page_table_invocation \<Rightarrow> bool" where
+  "authorised_page_table_inv aag pti \<equiv>
+   case pti of PageTableMap cap cslot_ptr pde obj_ref \<Rightarrow>
+                 is_subject aag (fst cslot_ptr) \<and> is_subject aag (obj_ref && ~~ mask pd_bits) \<and>
+                 (case_option True (is_subject aag o fst) (pde_ref2 pde)) \<and>
+                 pas_cap_cur_auth aag cap
+             | PageTableUnmap cap cslot_ptr \<Rightarrow>
+                 is_subject aag (fst cslot_ptr) \<and> aag_cap_auth aag (pasSubject aag) cap  \<and>
+                 (\<forall>p asid vspace_ref. cap = ArchObjectCap (PageTableCap p (Some (asid, vspace_ref)))
+                                      \<longrightarrow> is_subject_asid aag asid \<and>
+                                          (\<forall>x \<in> set [p , p + 4 .e. p + 2 ^ pt_bits - 1].
+                                                   is_subject aag (x && ~~ mask pt_bits)))"
+
+lemma perform_page_table_invocation_respects:
+  "\<lbrace>integrity aag X st and pas_refined aag and invs and valid_pti page_table_invocation
+                       and K (authorised_page_table_inv aag page_table_invocation)\<rbrace>
+   perform_page_table_invocation page_table_invocation
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (simp add: perform_page_table_invocation_def
+             cong: page_table_invocation.case_cong option.case_cong prod.case_cong
+                   cap.case_cong arch_cap.case_cong)
+  apply (wpsimp wp: store_pde_respects set_cap_integrity_autarch
+                    store_pte_respects unmap_page_table_respects mapM_wp'
+              simp: mapM_x_mapM authorised_page_table_inv_def cleanByVA_PoU_def)
+  apply (auto simp: valid_pti_def valid_cap_simps)
+  done
+
+crunch arm_asid_table_inv [wp]: unmap_page_table "\<lambda>s. P (arm_asid_table (arch_state s))"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma clas_update_map_data_strg:
+  "(is_pg_cap cap \<or> is_pt_cap cap)
+   \<longrightarrow> cap_links_asid_slot aag p (ArchObjectCap (update_map_data (the_arch_cap cap) None))"
+  unfolding cap_links_asid_slot_def
+  by (fastforce simp: is_cap_simps update_map_data_def)
+
+lemmas pte_ref_simps = pte_ref_def[split_simps pte.split]
+
+lemmas store_pde_pas_refined_simple =
+  store_pde_pas_refined[where pde=InvalidPDE, simplified pde_ref_simps, simplified]
+
+crunch pas_refined[wp]: unmap_page_table "pas_refined aag"
+  (wp: crunch_wps store_pde_pas_refined_simple simp: crunch_simps pde_ref_simps)
+
+lemma pde_ref_pde_ref2:
+  "\<lbrakk> pde_ref x = Some v; pde_ref2 x = Some v' \<rbrakk>
+     \<Longrightarrow> v' = (v, 0, {Control})"
+  unfolding pde_ref_def pde_ref2_def
+  by (cases x, simp_all)
+
+lemma mask_PTCap_eq:
+  "(ArchObjectCap (PageTableCap a b) = mask_cap R cap) = (cap = ArchObjectCap (PageTableCap a b))"
+  by (auto simp: mask_cap_def cap_rights_update_def acap_rights_update_def
+          split: arch_cap.splits cap.splits bool.splits)
+
+(* FIXME MOVE *)
+crunch cdt[wp]: unmap_page_table "\<lambda>s. P (cdt s)"
+  (simp: crunch_simps wp: crunch_wps)
+
+lemma is_transferable_is_arch_update:
+  "is_arch_update cap cap' \<Longrightarrow> is_transferable (Some cap) = is_transferable (Some cap')"
+  using is_transferable.simps is_arch_cap_def is_arch_update_def cap_master_cap_def
+  by (simp split: cap.splits arch_cap.splits)
+
+lemma perform_page_table_invocation_pas_refined [wp]:
+  "\<lbrace>pas_refined aag and valid_pti iv and K (authorised_page_table_inv aag iv)\<rbrace>
+   perform_page_table_invocation iv
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (simp add: perform_page_table_invocation_def
+             cong: page_table_invocation.case_cong option.case_cong prod.case_cong
+                   cap.case_cong arch_cap.case_cong)
+  apply (rule hoare_pre)
+  apply (wp get_cap_wp mapM_wp' store_pte_cte_wp_at do_machine_op_cte_wp_at
+            hoare_vcg_all_lift set_cap_pas_refined_not_transferable
+         | (wp hoare_vcg_imp_lift, unfold disj_not1)
+         | simp add: mapM_x_mapM authorised_page_table_inv_def imp_conjR pte_ref_simps
+         | wpc | wps| blast)+
+  apply (cases iv)
+   apply (fastforce simp: cte_wp_at_caps_of_state Option.is_none_def
+                          is_transferable_is_arch_update[symmetric]
+                          valid_pti_def is_cap_simps pas_refined_refl auth_graph_map_def2
+                    dest: pde_ref_pde_ref2)
+  apply (rename_tac s pt_cap page_cslot)
+  apply (case_tac page_cslot)
+  apply (rename_tac page_ptr page_slot)
+  apply (case_tac "\<exists>pt_ptr mapping. pt_cap = ArchObjectCap (PageTableCap pt_ptr mapping)")
+   prefer 2
+   apply fastforce
+  apply (elim exE)
+  apply clarsimp
+  apply (rename_tac page_cap)
+  apply (subgoal_tac
+            "cte_wp_at ((=) page_cap) (page_ptr, page_slot) s \<longrightarrow>
+             cte_wp_at (\<lambda>c. \<not> is_transferable (Some c)) (page_ptr, page_slot) s \<and>
+             pas_cap_cur_auth aag (ArchObjectCap (update_map_data (the_arch_cap page_cap) None))")
+   apply simp
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (frule (1) cap_cur_auth_caps_of_state)
+   apply simp
+  apply (clarsimp simp: valid_pti_def cte_wp_at_caps_of_state mask_PTCap_eq)
+  apply (clarsimp simp: cap_auth_conferred_def arch_cap_auth_conferred_def update_map_data_def
+                        is_page_cap_def cap_links_asid_slot_def cap_links_irq_def aag_cap_auth_def)
+  done
+
+definition authorised_slots :: "'a PAS \<Rightarrow> pte \<times> obj_ref list + pde \<times> obj_ref list \<Rightarrow> bool" where
+ "authorised_slots aag m \<equiv> case m of
+    Inl (pte, slots) \<Rightarrow>
+      (\<forall>x. pte_ref pte = Some x
+           \<longrightarrow> (\<forall>a \<in> snd (snd x). \<forall>p \<in> ptr_range (fst x) (fst (snd x)). aag_has_auth_to aag a p)) \<and>
+      (\<forall>x \<in> set slots. is_subject aag (x && ~~ mask pt_bits))
+  | Inr (pde, slots) \<Rightarrow>
+      (\<forall>x. pde_ref2 pde = Some x
+           \<longrightarrow> (\<forall>a \<in> snd (snd x). \<forall>p \<in> ptr_range (fst x) (fst (snd x)). aag_has_auth_to aag a p)) \<and>
+      (\<forall>x \<in> set slots. is_subject aag (x && ~~ mask pd_bits))"
+
+definition authorised_page_inv :: "'a PAS \<Rightarrow> page_invocation \<Rightarrow> bool" where
+  "authorised_page_inv aag pgi \<equiv> case pgi of
+     PageMap asid cap ptr slots \<Rightarrow>
+       pas_cap_cur_auth aag cap \<and> is_subject aag (fst ptr) \<and> authorised_slots aag slots
+   | PageUnmap cap ptr \<Rightarrow> pas_cap_cur_auth aag (ArchObjectCap cap) \<and> is_subject aag (fst ptr)
+   | PageFlush typ start end pstart pd asid \<Rightarrow> True
+   | PageGetAddr ptr \<Rightarrow> True"
+
+crunch respects[wp]: lookup_pt_slot "integrity X aag st"
+
+lemma vs_refs_no_global_pts_pdI:
+  "\<lbrakk> pd (ucast r) = PageTablePDE x a b; (ucast r :: 12 word) < ucast (kernel_base >> 20) \<rbrakk>
+     \<Longrightarrow> (ptrFromPAddr x, r && mask 12, APageDirectory, Control) \<in>
+           vs_refs_no_global_pts (ArchObj (PageDirectory pd))"
+  apply (clarsimp simp: vs_refs_no_global_pts_def)
+  apply (drule_tac f=pde_ref2 in arg_cong, simp add: pde_ref_simps o_def)
+  apply (rule rev_bexI, rule DiffI, erule graph_ofI)
+   apply simp
+  apply (clarsimp simp: ucast_ucast_mask)
+  done
+
+lemma lookup_pt_slot_authorised:
+  "\<lbrace>\<exists>\<rhd> pd and valid_vspace_objs and pspace_aligned and pas_refined aag
+          and K (is_subject aag pd) and K (is_aligned pd 14 \<and> vptr < kernel_base)\<rbrace>
+   lookup_pt_slot pd vptr
+   \<lbrace>\<lambda>rv _. is_subject aag (rv && ~~ mask pt_bits)\<rbrace>, -"
+  apply (simp add: lookup_pt_slot_def)
+  apply (wp get_pde_wp | wpc)+
+  apply (subgoal_tac "is_aligned pd pd_bits")
+   apply (clarsimp simp: lookup_pd_slot_pd)
+   apply (drule(2) valid_vspace_objsD)
+   apply (clarsimp simp: obj_at_def)
+   apply (drule kheap_eq_state_vrefs_pas_refinedD)
+     apply (erule vs_refs_no_global_pts_pdI)
+     apply (drule(1) less_kernel_base_mapping_slots)
+     apply (simp add: kernel_mapping_slots_def)
+    apply assumption
+   apply (simp add: aag_has_Control_iff_owns)
+   apply (drule_tac f="\<lambda>pde. valid_pde pde s" in arg_cong, simp)
+   apply (clarsimp simp: obj_at_def less_kernel_base_mapping_slots)
+   apply (erule pspace_alignedE, erule domI)
+   apply (simp add: pt_bits_def pageBits_def)
+   apply (subst is_aligned_add_helper, assumption)
+    apply (rule shiftl_less_t2n)
+     apply (rule order_le_less_trans, rule word_and_le1, simp)
+    apply simp
+   apply simp
+  apply (simp add: pd_bits_def pageBits_def)
+  done
+
+lemma is_aligned_6_masks:
+  "\<lbrakk> is_aligned (p :: obj_ref) 6; bits = pt_bits \<or> bits = pd_bits \<rbrakk>
+     \<Longrightarrow> \<forall>x \<in> set [0, 4 .e. 0x3C]. x + p && ~~ mask bits = p && ~~ mask bits"
+  apply clarsimp
+  apply (drule subsetD[OF upto_enum_step_subset])
+  apply (subst mask_lower_twice[symmetric, where n=6])
+   apply (auto simp add: pt_bits_def pageBits_def pd_bits_def)[1]
+  apply (subst add.commute, subst is_aligned_add_helper, assumption)
+   apply (simp add: order_le_less_trans)
+  apply simp
+  done
+
+lemma lookup_pt_slot_authorised2:
+  "\<lbrace>\<exists>\<rhd> pd and K (is_subject aag pd) and
+    K (is_aligned pd 14 \<and> is_aligned vptr 16 \<and> vptr < kernel_base) and
+    valid_vspace_objs and valid_arch_state and equal_kernel_mappings and
+    valid_global_objs and pspace_aligned and pas_refined aag\<rbrace>
+   lookup_pt_slot pd vptr
+   \<lbrace>\<lambda>rv _. \<forall>x\<in>set [0 , 4 .e. 0x3C]. is_subject aag (x + rv && ~~ mask pt_bits)\<rbrace>, -"
+  apply (clarsimp simp: validE_R_def valid_def validE_def
+                 split: sum.split)
+  apply (frule use_validE_R[OF _ lookup_pt_slot_authorised])
+   apply fastforce
+  apply (frule use_validE_R[OF _ lookup_pt_slot_is_aligned_6])
+   apply (fastforce simp add: vmsz_aligned_def pd_bits_def pageBits_def)
+  apply (simp add: is_aligned_6_masks)
+  done
+
+lemma lookup_pt_slot_authorised3:
+  "\<lbrace>\<exists>\<rhd> pd and K (is_subject aag pd) and
+    K (is_aligned pd 14 \<and> is_aligned vptr 16 \<and> vptr < kernel_base) and
+    valid_vspace_objs and valid_arch_state and equal_kernel_mappings and
+    valid_global_objs and pspace_aligned and pas_refined aag\<rbrace>
+   lookup_pt_slot pd vptr
+   \<lbrace>\<lambda>rv _.  \<forall>x\<in>set [rv, rv + 4 .e. rv + 0x3C]. is_subject aag (x && ~~ mask pt_bits)\<rbrace>, -"
+  apply (rule_tac Q'="\<lambda>rv s. is_aligned rv 6 \<and> (\<forall>x\<in>set [0, 4 .e. 0x3C].
+                                                  is_subject aag (x + rv && ~~ mask pt_bits))"
+               in hoare_post_imp_R)
+  apply (rule hoare_pre)
+  apply (wp lookup_pt_slot_is_aligned_6 lookup_pt_slot_authorised2)
+   apply (fastforce simp: vmsz_aligned_def pd_bits_def pageBits_def)
+  apply simp
+  apply (simp add: p_0x3C_shift)
+  done
+
+crunch respects[wp]: flush_page "integrity aag X st"
+  (simp: invalidateLocalTLB_VAASID_def ignore: do_machine_op)
+
+lemma find_pd_for_asid_pd_owned[wp]:
+  "\<lbrace>pas_refined aag and K (is_subject_asid aag asid)\<rbrace>
+   find_pd_for_asid asid
+   \<lbrace>\<lambda>rv _. is_subject aag rv\<rbrace>,-"
+  apply (wp find_pd_for_asid_authority2)
+  apply (auto simp: aag_has_Control_iff_owns)
+  done
+
+lemmas store_pte_pas_refined_simple =
+  store_pte_pas_refined[where pte=InvalidPTE, simplified pte_ref_simps, simplified]
+
+crunch pas_refined[wp]: unmap_page "pas_refined aag"
+  (wp: crunch_wps store_pde_pas_refined_simple store_pte_pas_refined_simple simp: crunch_simps)
+
+lemma unmap_page_respects:
+  "\<lbrace>integrity aag X st and pspace_aligned and valid_vspace_objs
+                       and K (is_subject_asid aag asid) and pas_refined aag
+                       and K (vmsz_aligned vptr sz \<and> vptr < kernel_base)\<rbrace>
+   unmap_page sz asid vptr pptr
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (simp add: unmap_page_def swp_def cong: vmpage_size.case_cong)
+  apply (rule hoare_pre)
+   apply (wpsimp wp: store_pte_respects store_pde_respects lookup_pt_slot_authorised
+                     hoare_drop_imps[where Q="\<lambda>rv. integrity aag X st"]
+               simp: is_aligned_6_masks is_aligned_mask[symmetric] cleanByVA_PoU_def
+          | wp (once) hoare_drop_imps
+                      mapM_set''[where f="(\<lambda>a. store_pte a InvalidPTE)"
+                                   and I="\<lambda>x s. is_subject aag (x && ~~ mask pt_bits)"
+                                   and Q="integrity aag X st"]
+                      mapM_set''[where f="(\<lambda>a. store_pde a InvalidPDE)"
+                                   and I="\<lambda>x s. is_subject aag (x && ~~ mask pd_bits)"
+                                   and Q="integrity aag X st"]
+          | wp (once) hoare_drop_imps[where R="\<lambda>rv s. rv"])+
+  done
+
+(* FIXME: CLAG *)
+lemmas do_machine_op_bind =
+  submonad_bind [OF submonad_do_machine_op submonad_do_machine_op submonad_do_machine_op]
+
+lemmas do_flush_defs =
+  cleanCacheRange_RAM_def cleanCacheRange_PoC_def cleanCacheRange_PoU_def branchFlushRange_def
+  invalidateCacheRange_RAM_def invalidateCacheRange_I_def cleanInvalidateCacheRange_RAM_def
+
+lemma do_flush_respects[wp]:
+  "do_machine_op (do_flush typ start end pstart) \<lbrace>integrity aag X st\<rbrace>"
+  by (cases "typ"; wpsimp wp: dmo_no_mem_respects simp: do_flush_def cache_machine_op_defs do_flush_defs)
+
+lemma invalidate_tlb_by_asid_respects[wp]:
+  "invalidate_tlb_by_asid asid \<lbrace>integrity aag X st\<rbrace>"
+  unfolding invalidate_tlb_by_asid_def
+  by (wpsimp wp: dmo_no_mem_respects simp: invalidateLocalTLB_ASID_def)
+
+lemma invalidate_tlb_by_asid_pas_refined[wp]:
+  "invalidate_tlb_by_asid asid \<lbrace>pas_refined aag\<rbrace>"
+  by (wpsimp wp: dmo_no_mem_respects simp: invalidate_tlb_by_asid_def invalidateLocalTLB_ASID_def)
+
+lemma perform_page_invocation_respects:
+  "\<lbrace>integrity aag X st and pas_refined aag and K (authorised_page_inv aag pgi)
+                       and valid_page_inv pgi and valid_vspace_objs
+                       and pspace_aligned and is_subject aag  \<circ> cur_thread\<rbrace>
+   perform_page_invocation pgi
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+proof -
+  (* does not work as elim rule with clarsimp, which hammers Ball in concl. *)
+  have set_tl_subset_mp: "\<And>xs a. a \<in> set (tl xs) \<Longrightarrow> a \<in> set xs" by (case_tac xs; clarsimp)
+  have hd_valid_slots:
+    "\<And>a xs s. valid_slots (Inl (a, xs)) s \<Longrightarrow> hd xs \<in> set xs"
+    "\<And>a xs s. valid_slots (Inr (a, xs)) s \<Longrightarrow> hd xs \<in> set xs"
+    by (simp_all add: valid_slots_def)
+  show ?thesis
+  apply (simp add: perform_page_invocation_def mapM_discarded swp_def
+                   valid_page_inv_def valid_unmap_def
+                   authorised_page_inv_def authorised_slots_def
+            split: page_invocation.split sum.split
+                   arch_cap.split option.split,
+         safe)
+        apply (wp set_cap_integrity_autarch unmap_page_respects
+                  mapM_x_and_const_wp[OF store_pte_respects] store_pte_respects
+                  mapM_x_and_const_wp[OF store_pde_respects] store_pde_respects
+               | elim conjE hd_valid_slots[THEN bspec[rotated]]
+               | clarsimp dest!: set_tl_subset_mp
+               | wpc )+
+   apply (clarsimp simp: cte_wp_at_caps_of_state cap_rights_update_def
+                         acap_rights_update_def update_map_data_def is_pg_cap_def
+                         valid_page_inv_def valid_cap_simps
+                  dest!: cap_master_cap_eqDs)
+   apply (drule (1) clas_caps_of_state)
+   apply (simp add: cap_links_asid_slot_def label_owns_asid_slot_def)
+   apply (auto dest: pas_refined_Control)[1]
+     apply (wpsimp wp: set_mrs_integrity_autarch set_message_info_integrity_autarch
+                 simp: ipc_buffer_has_auth_def)+
+  done
+qed
+
+(* FIXME MOVE *)
+crunch cdt[wp]: unmap_page "\<lambda>s. P (cdt s)"
+  (simp: crunch_simps wp: crunch_wps)
+
+lemma perform_page_invocation_pas_refined [wp]:
+  "\<lbrace>pas_refined aag and K (authorised_page_inv aag pgi) and valid_page_inv pgi\<rbrace>
+   perform_page_invocation pgi
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (simp add: perform_page_invocation_def mapM_discarded valid_page_inv_def valid_unmap_def
+                   swp_def authorised_page_inv_def authorised_slots_def
+             cong: page_invocation.case_cong sum.case_cong)
+  apply (rule hoare_pre)
+   apply wpc
+      apply (wp set_cap_pas_refined unmap_page_pas_refined case_sum_wp case_prod_wp get_cap_wp
+                mapM_x_and_const_wp[OF store_pte_pas_refined] hoare_vcg_all_lift
+                mapM_x_and_const_wp[OF store_pde_pas_refined] hoare_vcg_const_imp_lift
+             | (wp hoare_vcg_imp_lift, unfold disj_not1)
+             | strengthen clas_update_map_data_strg
+             | wpc | wps | simp)+
+  apply (case_tac pgi)
+      apply ((force simp: valid_slots_def pte_ref_def cte_wp_at_caps_of_state
+                          is_transferable_is_arch_update[symmetric]
+                          pde_ref2_def auth_graph_map_mem pas_refined_refl
+                   split: sum.splits)+)[2]
+    apply (clarsimp simp: cte_wp_at_caps_of_state is_transferable_is_arch_update[symmetric]
+                          pte_ref_def pde_ref2_def is_cap_simps is_pg_cap_def)
+    apply (frule(1) cap_cur_auth_caps_of_state, simp)
+    apply (intro impI conjI;
+           clarsimp; (* NB: for speed *)
+           clarsimp simp: update_map_data_def clas_no_asid aag_cap_auth_def
+                          cap_auth_conferred_def arch_cap_auth_conferred_def
+                          vspace_cap_rights_to_auth_def cli_no_irqs is_pg_cap_def
+                          pte_ref_def[simplified aag_cap_auth_def])+
+  done
+
+definition authorised_asid_control_inv :: "'a PAS \<Rightarrow> asid_control_invocation \<Rightarrow> bool" where
+ "authorised_asid_control_inv aag aci \<equiv>
+  case aci of MakePool frame slot parent base \<Rightarrow>
+    is_subject aag (fst slot) \<and> is_aligned frame pageBits \<and>
+    (\<forall>asid. is_subject_asid aag asid) \<and> is_subject aag (fst parent) \<and>
+            (\<forall>x \<in> {frame..frame + 2 ^ pageBits - 1}. is_subject aag x)"
+
+
+lemma integrity_arm_asid_table_entry_update':
+  "\<lbrakk> integrity aag X st s; atable = arm_asid_table (arch_state s);
+     (\<forall>asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of asid
+             \<longrightarrow> is_subject_asid aag asid') \<rbrakk>
+     \<Longrightarrow> integrity aag X st (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table :=
+                                                          \<lambda>a. if a = asid_high_bits_of asid
+                                                              then v
+                                                              else atable a\<rparr>\<rparr>)"
+  by (clarsimp simp: integrity_def)
+
+lemma arm_asid_table_entry_update_integrity[wp]:
+ "\<lbrace>integrity aag X st and (\<lambda> s. atable = arm_asid_table (arch_state s)) and
+   K (\<forall>asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of asid
+              \<longrightarrow> is_subject_asid aag asid')\<rbrace>
+  modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := atable(asid_high_bits_of asid := v)\<rparr>\<rparr>)
+  \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (wp | simp)+
+  apply (blast intro: integrity_arm_asid_table_entry_update')
+  done
+
+lemma perform_asid_control_invocation_respects:
+  "\<lbrace>integrity aag X st and K (authorised_asid_control_inv aag aci)\<rbrace>
+   perform_asid_control_invocation aci
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: perform_asid_control_invocation_def)
+  apply (rule hoare_pre)
+   apply (wpc, simp)
+   apply (wpsimp wp: set_cap_integrity_autarch cap_insert_integrity_autarch
+                     retype_region_integrity[where sz=12] static_imp_wp)
+  apply (clarsimp simp: authorised_asid_control_inv_def
+                        ptr_range_def page_bits_def add.commute
+                        range_cover_def obj_bits_api_def default_arch_object_def
+                        pageBits_def word_bits_def)
+  apply (subst is_aligned_neg_mask_eq[THEN sym], assumption)
+  apply (simp add: and_mask_eq_iff_shiftr_0 mask_zero)
+  done
+
+lemma pas_refined_set_asid_strg:
+  "pas_refined aag s \<and> is_subject aag pool \<and>
+   (\<forall>asid. asid_high_bits_of asid = base \<longrightarrow> is_subject_asid aag asid)
+   \<longrightarrow> pas_refined aag (s\<lparr>arch_state :=
+                          arch_state s\<lparr>arm_asid_table := (arm_asid_table (arch_state s))(base \<mapsto> pool)\<rparr>\<rparr>)"
+  apply (clarsimp simp: pas_refined_def state_objs_to_policy_def)
+  apply (erule state_asids_to_policy_aux.cases, simp_all split: if_split_asm)
+      apply (auto intro: state_asids_to_policy_aux.intros auth_graph_map_memI[OF sbta_vref]
+                 intro!: pas_refined_refl[simplified pas_refined_def state_objs_to_policy_def])
+  done
+
+lemma perform_asid_control_invocation_pas_refined [wp]:
+  "\<lbrace>pas_refined aag and pas_cur_domain aag and invs and valid_aci aci and ct_active
+                    and K (authorised_asid_control_inv aag aci)\<rbrace>
+   perform_asid_control_invocation aci
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (simp add: perform_asid_control_invocation_def)
+  apply (rule hoare_pre)
+   apply (wp cap_insert_pas_refined' static_imp_wp
+          | strengthen pas_refined_set_asid_strg
+          | wpc
+          | simp add: delete_objects_def2 fun_upd_def[symmetric])+
+      apply (wp retype_region_pas_refined'[where sz=pageBits]
+                hoare_vcg_ex_lift hoare_vcg_all_lift static_imp_wp hoare_wp_combs hoare_drop_imp
+                retype_region_invs_extras(4)[where sz = pageBits]
+             | simp add: do_machine_op_def split_def cte_wp_at_neg2)+
+      apply (wp retype_region_cte_at_other'[where sz=pageBits]
+                max_index_upd_invs_simple max_index_upd_caps_overlap_reserved
+                hoare_vcg_ex_lift set_cap_cte_wp_at hoare_vcg_disj_lift set_free_index_valid_pspace
+                set_cap_descendants_range_in set_cap_no_overlap get_cap_wp set_cap_caps_no_overlap
+                hoare_vcg_all_lift static_imp_wp retype_region_invs_extras
+                set_cap_pas_refined_not_transferable
+             | simp add: do_machine_op_def split_def cte_wp_at_neg2 region_in_kernel_window_def)+
+   apply (rename_tac frame slot parent base cap)
+   apply (case_tac slot, rename_tac slot_ptr slot_idx)
+   apply (case_tac parent, rename_tac parent_ptr parent_idx)
+   apply (rule_tac Q="\<lambda>rv s.
+             (\<exists>idx. cte_wp_at ((=) (UntypedCap False frame pageBits idx)) parent s) \<and>
+             (\<forall>x\<in>ptr_range frame pageBits. is_subject aag x) \<and>
+             pas_refined aag s \<and>
+             pas_cur_domain aag s \<and>
+             pspace_no_overlap_range_cover frame pageBits s \<and>
+             invs s \<and>
+             descendants_range_in
+               {frame..(frame && ~~ mask pageBits) + 2 ^ pageBits - 1} parent s \<and>
+             range_cover frame pageBits
+               (obj_bits_api (ArchObject ASIDPoolObj) 0) (Suc 0) \<and>
+             is_subject aag slot_ptr \<and>
+             is_subject aag parent_ptr \<and>
+             pas_cap_cur_auth aag (ArchObjectCap (ASIDPoolCap frame base)) \<and>
+             is_subject aag frame \<and>
+             (\<forall>x. asid_high_bits_of x = asid_high_bits_of base \<longrightarrow>
+                 is_subject_asid aag x)"
+             in hoare_strengthen_post)
+    apply (simp add: page_bits_def)
+    apply (wp add: delete_objects_pspace_no_overlap hoare_vcg_ex_lift
+                   delete_objects_descendants_range_in delete_objects_invs_ex
+                   delete_objects_pas_refined
+              del: Untyped_AI.delete_objects_pspace_no_overlap
+           | simp add: page_bits_def)+
+   apply clarsimp
+   apply (rename_tac s idx)
+   apply (frule untyped_cap_aligned, simp add: invs_valid_objs)
+   apply (clarsimp simp: cte_wp_at_def aag_cap_auth_def ptr_range_def pas_refined_refl
+                         cap_links_asid_slot_def cap_links_irq_def
+                         obj_bits_api_def default_arch_object_def retype_addrs_def)
+   apply (rule conjI, force intro: descendants_range_caps_no_overlapI
+                             simp: cte_wp_at_def)
+   apply (rule conjI)
+    apply (cut_tac s=s and ptr="(parent_ptr, parent_idx)" in cap_refs_in_kernel_windowD)
+      apply ((fastforce simp add: caps_of_state_def cap_range_def)+)[3]
+   apply (rule conjI, force simp: field_simps)
+   apply (rule conjI, fastforce)
+   apply (fastforce dest: caps_of_state_valid
+                    simp: caps_of_state_def free_index_of_def max_free_index_def valid_cap_def)
+  apply (clarsimp simp: valid_aci_def authorised_asid_control_inv_def)
+  apply (rename_tac frame slot_ptr slot_idx parent_ptr parent_idx base)
+  apply (subgoal_tac "is_aligned frame pageBits")
+   apply (clarsimp simp: cte_wp_at_caps_of_state)
+   apply (rule conjI)
+    apply (drule untyped_slots_not_in_untyped_range)
+         apply (erule empty_descendants_range_in)
+        apply (simp add: cte_wp_at_caps_of_state)
+       apply simp
+      apply (rule refl)
+     apply (rule subset_refl)
+    apply (simp add: page_bits_def)
+   apply (clarsimp simp: ptr_range_def invs_psp_aligned invs_valid_objs
+                         descendants_range_def2 empty_descendants_range_in page_bits_def)
+   apply ((strengthen refl | simp)+)?
+   apply (rule conjI, fastforce)
+   apply (rule conjI, fastforce intro: empty_descendants_range_in)
+   apply (rule conjI)
+    apply (clarsimp simp: range_cover_def obj_bits_api_def default_arch_object_def)
+    apply (subst is_aligned_neg_mask_eq[THEN sym], assumption)
+    apply (simp add: and_mask_eq_iff_shiftr_0 pageBits_def mask_zero)
+   apply (clarsimp simp: aag_cap_auth_def pas_refined_refl)
+   apply (drule_tac x=frame in bspec)
+    apply (simp add: is_aligned_no_overflow)
+   apply (clarsimp simp: pas_refined_refl cap_links_asid_slot_def
+                         label_owns_asid_slot_def cap_links_irq_def)
+  apply (fastforce dest: cte_wp_at_valid_objs_valid_cap simp: valid_cap_def cap_aligned_def)
+  done
+
+definition authorised_asid_pool_inv :: "'a PAS \<Rightarrow> asid_pool_invocation \<Rightarrow> bool" where
+ "authorised_asid_pool_inv aag api \<equiv>
+  case api of Assign asid pool_ptr ct_slot \<Rightarrow>
+    is_subject aag pool_ptr \<and> is_subject aag (fst ct_slot) \<and> asid \<noteq> 0 \<and>
+    (\<forall>asid'. asid_high_bits_of asid' = asid_high_bits_of asid \<and> asid' \<noteq> 0
+             \<longrightarrow> is_subject_asid aag asid')"
+
+lemma perform_asid_pool_invocation_respects:
+  "\<lbrace>integrity aag X st and K (authorised_asid_pool_inv aag api)\<rbrace>
+   perform_asid_pool_invocation api
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: perform_asid_pool_invocation_def)
+  apply (wpsimp wp: set_asid_pool_integrity_autarch get_cap_wp set_cap_integrity_autarch)
+  apply (auto iff: authorised_asid_pool_inv_def)
+  done
+
+lemma asid_pool_into_aag:
+  "\<lbrakk> kheap s p = Some (ArchObj (ASIDPool pool)); pool r = Some p'; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> abs_has_auth_to aag Control p p'"
+  apply (rule pas_refined_mem [rotated], assumption)
+  apply (rule sta_vref)
+  apply (fastforce simp: state_vrefs_def vs_refs_no_global_pts_def intro!: graph_ofI)
+  done
+
+lemma asid_pool_uniqueness:
+  "\<lbrakk> ([VSRef (ucast (asid_high_bits_of asid)) None] \<rhd> p) s;
+     arm_asid_table (arch_state s) (asid_high_bits_of asid') = Some p;
+     invs s; \<forall>pt. \<not> ko_at (ArchObj (PageTable pt)) p s \<rbrakk>
+     \<Longrightarrow> asid_high_bits_of asid' = asid_high_bits_of asid"
+  apply (drule valid_vs_lookupD[OF vs_lookup_pages_vs_lookupI], clarsimp)
+  apply (drule vs_lookup_atI, drule valid_vs_lookupD[OF vs_lookup_pages_vs_lookupI], clarsimp)
+  apply (clarsimp dest!: obj_ref_elemD)
+  apply (drule(1) unique_table_refsD[where cps="caps_of_state s", rotated])
+    apply simp
+   apply (clarsimp simp: vs_cap_ref_def table_cap_ref_def up_ucast_inj_eq
+                  split: vmpage_size.splits option.splits cap.splits arch_cap.splits)+
+  done
+
+lemma perform_asid_pool_invocation_pas_refined [wp]:
+  "\<lbrace>pas_refined aag and invs and valid_apinv api and K (authorised_asid_pool_inv aag api)\<rbrace>
+   perform_asid_pool_invocation api
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (simp add: perform_asid_pool_invocation_def)
+  apply (rule hoare_pre)
+  apply (wp get_cap_auth_wp[where aag = aag] set_cap_pas_refined_not_transferable | wpc)+
+  apply (clarsimp simp: authorised_asid_pool_inv_def cap_links_asid_slot_def
+                        is_subject_asid_into_loas aag_cap_auth_def)
+  apply (clarsimp simp: cap_auth_conferred_def arch_cap_auth_conferred_def
+                        is_cap_simps is_page_cap_def auth_graph_map_mem
+                        pas_refined_all_auth_is_owns pas_refined_refl cli_no_irqs
+                        cte_wp_at_caps_of_state
+                 dest!: graph_ofD)
+  apply (clarsimp split: if_split_asm)
+   apply (clarsimp simp add: pas_refined_refl auth_graph_map_def2
+                             mask_asid_low_bits_ucast_ucast[symmetric]
+                             valid_apinv_def obj_at_def)
+   apply (drule(2) asid_pool_uniqueness)
+    apply (simp add: obj_at_def)
+   apply (case_tac "asid = 0"; simp add: pas_refined_refl)
+   apply (simp add: asid_low_high_bits[rotated, OF arg_cong[where f=ucast]])
+  apply (clarsimp simp: obj_at_def)
+  apply (frule (2) asid_pool_into_aag)
+  apply (drule kheap_eq_state_vrefsD)
+  apply (clarsimp simp: auth_graph_map_def2 pas_refined_refl)
+  apply (clarsimp simp: pas_refined_def vs_refs_no_global_pts_def)
+  apply (erule subsetD, erule state_asids_to_policy_aux.intros,
+         simp add: split_def, rule image_eqI[rotated], erule graph_ofI)
+  apply simp
+  done
+
+definition authorised_page_directory_inv :: "'a PAS \<Rightarrow> page_directory_invocation \<Rightarrow> bool" where
+  "authorised_page_directory_inv aag pdi \<equiv> True"
+
+definition authorised_arch_inv :: "'a PAS \<Rightarrow> arch_invocation \<Rightarrow> bool" where
+ "authorised_arch_inv aag ai \<equiv> case ai of
+     InvokePageTable pti \<Rightarrow> authorised_page_table_inv aag pti
+   | InvokePageDirectory pdi \<Rightarrow> authorised_page_directory_inv aag pdi
+   | InvokePage pgi \<Rightarrow> authorised_page_inv aag pgi
+   | InvokeASIDControl aci \<Rightarrow> authorised_asid_control_inv aag aci
+   | InvokeASIDPool api \<Rightarrow> authorised_asid_pool_inv aag api"
+
+crunch respects [wp]: perform_page_directory_invocation "integrity aag X st"
+  (ignore: do_machine_op)
+
+crunch pas_refined [wp]: perform_page_directory_invocation "pas_refined aag"
+
+lemma invoke_arch_respects:
+  "\<lbrace>integrity aag X st and K (authorised_arch_inv aag ai) and
+    pas_refined aag and invs and valid_arch_inv ai and is_subject aag \<circ> cur_thread\<rbrace>
+   arch_perform_invocation ai
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: arch_perform_invocation_def)
+  apply (wpsimp wp: perform_page_table_invocation_respects perform_page_invocation_respects
+                    perform_asid_control_invocation_respects perform_asid_pool_invocation_respects)
+  apply (auto simp: authorised_arch_inv_def valid_arch_inv_def)
+  done
+
+lemma invoke_arch_pas_refined:
+  "\<lbrace>pas_refined aag and pas_cur_domain aag and invs and ct_active
+                    and valid_arch_inv ai and K (authorised_arch_inv aag ai)\<rbrace>
+   arch_perform_invocation ai
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (simp add: arch_perform_invocation_def valid_arch_inv_def)
+  apply (rule hoare_pre)
+  apply (wp | wpc)+
+  apply (fastforce simp add: authorised_arch_inv_def)
+  done
+
+lemma create_mapping_entries_authorised_slots [wp]:
+  "\<lbrace>\<exists>\<rhd> pd and invs and pas_refined aag and
+    K (is_subject aag pd \<and> is_aligned pd pd_bits \<and>
+       vmsz_aligned vptr vmpage_size \<and> vptr < kernel_base \<and>
+       (\<forall>a\<in>vspace_cap_rights_to_auth rights.
+          \<forall>p\<in>ptr_range (ptrFromPAddr base) (pageBitsForSize vmpage_size). aag_has_auth_to aag a p))\<rbrace>
+   create_mapping_entries base vptr vmpage_size rights attrib pd
+   \<lbrace>\<lambda>rv _. authorised_slots aag rv\<rbrace>, -"
+  unfolding authorised_slots_def
+  apply (rule hoare_gen_asmE)
+  apply (cases vmpage_size)
+     apply (wp lookup_pt_slot_authorised | simp add: pte_ref_simps | fold validE_R_def)+
+     apply (auto simp: pd_bits_def pageBits_def)[1]
+    apply (wp lookup_pt_slot_authorised2
+           | simp add: pte_ref_simps largePagePTE_offsets_def
+           | fold validE_R_def)+
+    apply (auto simp: pd_bits_def pageBits_def vmsz_aligned_def)[1]
+   apply (wp | simp)+
+   apply (auto simp: pde_ref2_def lookup_pd_slot_pd)[1]
+  apply (wp | simp add: superSectionPDE_offsets_def)+
+  apply (auto simp: pde_ref2_def vmsz_aligned_def lookup_pd_slot_add_eq)
+  done
+
+lemma pageBitsForSize_le_t29:
+  "pageBitsForSize sz \<le> 29"
+  by (cases sz, simp_all)
+
+lemma x_t2n_sub_1_neg_mask:
+  "\<lbrakk> is_aligned x n; n \<le> m \<rbrakk>
+     \<Longrightarrow> x + 2 ^ n - 1 && ~~ mask m = x && ~~ mask m"
+  apply (erule is_aligned_get_word_bits)
+   apply (rule trans, rule mask_lower_twice[symmetric], assumption)
+   apply (subst add_diff_eq[symmetric], subst is_aligned_add_helper, assumption)
+    apply simp+
+  apply (simp add: mask_def power_overflow)
+  done
+
+lemmas vmsz_aligned_t2n_neg_mask =
+  x_t2n_sub_1_neg_mask[OF _ pageBitsForSize_le_t29, folded vmsz_aligned_def]
+
+lemma decode_arch_invocation_authorised:
+  "\<lbrace>invs and pas_refined aag and cte_wp_at ((=) (ArchObjectCap cap)) slot
+         and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)
+         and K (\<forall>(cap, slot) \<in> {(ArchObjectCap cap, slot)} \<union> set excaps.
+                  aag_cap_auth aag (pasObjectAbs aag (fst slot)) cap \<and>
+                  is_subject aag (fst slot) \<and>
+                  (\<forall>v \<in> cap_asid' cap. is_subject_asid aag v))\<rbrace>
+   arch_decode_invocation label msg x_slot slot cap excaps
+   \<lbrace>\<lambda>rv _. authorised_arch_inv aag rv\<rbrace>,-"
+  unfolding arch_decode_invocation_def authorised_arch_inv_def aag_cap_auth_def
+  apply (rule hoare_pre)
+   apply (simp add: split_def Let_def split del: if_split
+              cong: cap.case_cong arch_cap.case_cong if_cong option.case_cong)
+   apply (wp select_wp whenE_throwError_wp check_vp_wpR
+             find_pd_for_asid_authority2
+          | wpc
+          | simp add: authorised_asid_control_inv_def authorised_page_inv_def
+                      authorised_page_directory_inv_def
+                 del: hoare_True_E_R
+                 split del: if_split)+
+  apply (clarsimp simp: authorised_asid_pool_inv_def authorised_page_table_inv_def
+                        neq_Nil_conv invs_psp_aligned invs_vspace_objs cli_no_irqs)
+  apply (drule cte_wp_valid_cap, clarsimp+)
+  apply (cases cap; simp)
+      \<comment> \<open>asid pool\<close>
+     apply (find_goal \<open>match premises in "cap = ASIDPoolCap _ _" \<Rightarrow> succeed\<close>)
+     subgoal for s obj_ref asid
+       by (clarsimp simp: cap_auth_conferred_def arch_cap_auth_conferred_def is_page_cap_def
+                          pas_refined_all_auth_is_owns asid_high_bits_of_add_ucast valid_cap_simps)
+     \<comment> \<open>ControlCap\<close>
+    apply (find_goal \<open>match premises in "cap = ASIDControlCap" \<Rightarrow> succeed\<close>)
+    subgoal
+      apply (clarsimp simp: neq_Nil_conv split_def valid_cap_simps)
+      apply (cases excaps, solves simp)
+      apply (clarsimp simp: neq_Nil_conv aag_has_Control_iff_owns)
+      apply (drule cte_wp_at_valid_objs_valid_cap, clarsimp)
+      apply (clarsimp simp: valid_cap_def cap_aligned_def)
+      apply (clarsimp simp: is_cap_simps cap_auth_conferred_def
+                            pas_refined_all_auth_is_owns aag_cap_auth_def)
+      done
+   \<comment> \<open>PageCap\<close>
+   apply (find_goal \<open>match premises in "cap = PageCap _ _ _ _ _" \<Rightarrow> succeed\<close>)
+   subgoal for s is_dev obj_ref cap_rights vmpage_size mapping
+     apply (clarsimp simp: valid_cap_simps cli_no_irqs)
+     apply (cases "invocation_type label"; (solves \<open>simp\<close>)?)
+     apply (find_goal \<open>match premises in "_ = ArchInvocationLabel _" \<Rightarrow> succeed\<close>)
+     apply (rename_tac archlabel)
+     apply (case_tac archlabel; (solves \<open>simp\<close>)?)
+       \<comment> \<open>Map\<close>
+      apply (find_goal \<open>match premises in "_ = ARMPageMap" \<Rightarrow> succeed\<close>)
+      subgoal
+       apply (clarsimp simp: cap_auth_conferred_def arch_cap_auth_conferred_def is_cap_simps is_page_cap_def
+                             pas_refined_all_auth_is_owns)
+       apply (rule conjI)
+        apply (clarsimp simp: is_page_cap_def pas_refined_all_auth_is_owns
+                              aag_cap_auth_def cli_no_irqs cap_links_asid_slot_def)
+        apply (simp only: linorder_not_le kernel_base_less_observation
+                          vmsz_aligned_t2n_neg_mask simp_thms)
+         apply (clarsimp simp: cap_auth_conferred_def arch_cap_auth_conferred_def
+                               vspace_cap_rights_to_auth_def mask_vm_rights_def
+                               validate_vm_rights_def vm_read_only_def vm_kernel_only_def)
+        apply clarsimp
+        apply (clarsimp simp: cap_auth_conferred_def arch_cap_auth_conferred_def aag_cap_auth_def
+                               cli_no_irqs vspace_cap_rights_to_auth_def mask_vm_rights_def
+                              validate_vm_rights_def vm_read_only_def vm_kernel_only_def)
+       done
+     \<comment> \<open>Unmap\<close>
+     subgoal by (simp add: aag_cap_auth_def cli_no_irqs)
+     done
+  \<comment> \<open>PageTableCap\<close>
+  apply (find_goal \<open>match premises in "cap = PageTableCap _ _" \<Rightarrow> succeed\<close>)
+  subgoal for s word option
+    apply (cases "invocation_type label"; (solves \<open>simp\<close>)?)
+    apply (find_goal \<open>match premises in "_ = ArchInvocationLabel _" \<Rightarrow> succeed\<close>)
+    apply (rename_tac archlabel)
+    apply (case_tac archlabel; (solves \<open>simp\<close>)?)
+     \<comment> \<open>PTMap\<close>
+     apply (find_goal \<open>match premises in "_ = ARMPageTableMap" \<Rightarrow> succeed\<close>)
+     apply (clarsimp simp: aag_cap_auth_def cli_no_irqs cap_links_asid_slot_def
+                           cap_auth_conferred_def arch_cap_auth_conferred_def is_page_cap_def
+                           pde_ref2_def pas_refined_all_auth_is_owns pas_refined_refl
+                           pd_shifting[folded pd_bits_14])
+    \<comment> \<open>Unmap\<close>
+    apply (find_goal \<open>match premises in "_ = ARMPageTableUnmap" \<Rightarrow> succeed\<close>)
+    subgoal
+      apply (clarsimp simp: aag_cap_auth_def cli_no_irqs cap_links_asid_slot_def
+                            cap_auth_conferred_def arch_cap_auth_conferred_def is_page_cap_def
+                            pde_ref2_def pas_refined_all_auth_is_owns pas_refined_refl)
+      apply (subgoal_tac "x && ~~ mask pt_bits = word")
+       apply simp
+      apply (clarsimp simp: valid_cap_simps cap_aligned_def split: if_split_asm)
+      apply (subst (asm) upto_enum_step_subtract)
+      apply (subgoal_tac "is_aligned word pt_bits")
+       apply (simp add: is_aligned_no_overflow)
+      apply (simp add: pt_bits_def pageBits_def)
+      apply simp
+      apply (subst (asm) upto_enum_step_red [where us = 2, simplified])
+      apply (simp add: pt_bits_def pageBits_def word_bits_conv)
+      apply (simp add: pt_bits_def pageBits_def word_bits_conv)
+      apply clarsimp
+      apply (subst is_aligned_add_helper)
+      apply (simp add: pt_bits_def pageBits_def)
+      apply (erule word_less_power_trans_ofnat [where k = 2, simplified])
+        apply (simp add: pt_bits_def pageBits_def)
+       apply (simp add: pt_bits_def pageBits_def word_bits_conv)
+      apply simp
+      done
+    done
+  done
+
+crunch pas_refined[wp]: invalidate_asid_entry "pas_refined aag"
+  (wp: crunch_wps simp: crunch_simps)
+
+crunch pas_refined[wp]: flush_space "pas_refined aag"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma delete_asid_pas_refined[wp]:
+  "delete_asid asid pd \<lbrace>pas_refined aag\<rbrace>"
+  apply (simp add: delete_asid_def)
+  apply (wp | wpc)+
+  apply (clarsimp simp add: split_def Ball_def obj_at_def)
+  apply (rule conjI)
+   apply (clarsimp dest!: auth_graph_map_memD graph_ofD)
+   apply (erule pas_refined_mem[OF sta_vref, rotated])
+   apply (fastforce simp: state_vrefs_def vs_refs_no_global_pts_def
+                         image_def graph_of_def split: if_split_asm)
+  apply (clarsimp simp: pas_refined_def dest!: graph_ofD)
+  apply (erule subsetD, erule state_asids_to_policy_aux.intros)
+  apply (fastforce simp: state_vrefs_def vs_refs_no_global_pts_def
+                        graph_of_def image_def split: if_split_asm)
+  done
+
+lemma delete_asid_pool_pas_refined [wp]:
+  "delete_asid_pool param_a param_b \<lbrace>pas_refined aag\<rbrace>"
+  unfolding delete_asid_pool_def
+  apply (wp | wpc | simp)+
+      apply (rule_tac Q = "\<lambda>_ s. pas_refined aag s \<and>
+                                 asid_table = arm_asid_table (arch_state s)" in hoare_post_imp)
+       apply clarsimp
+       apply (erule pas_refined_clear_asid)
+      apply (wp mapM_wp' | simp)+
+  done
+
+crunch respects[wp]: invalidate_asid_entry "integrity aag X st"
+
+crunch respects[wp]: flush_space "integrity aag X st"
+  (ignore: do_machine_op simp: invalidateLocalTLB_ASID_def cleanCaches_PoU_def
+           dsb_def clean_D_PoU_def invalidate_I_PoU_def do_machine_op_bind)
+
+lemma delete_asid_pool_respects[wp]:
+  "\<lbrace>integrity aag X st and
+    K (\<forall>asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of x
+               \<longrightarrow> is_subject_asid aag asid')\<rbrace>
+   delete_asid_pool x y
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  unfolding delete_asid_pool_def
+  apply simp
+  apply (wp mapM_wp[OF _ subset_refl] | simp)+
+  done
+
+lemma set_asid_pool_respects_clear:
+  "\<lbrace>integrity aag X st and (\<lambda>s. \<forall>pool'. ko_at (ArchObj (arch_kernel_obj.ASIDPool pool')) ptr s
+                                        \<longrightarrow> asid_pool_integrity {pasSubject aag} aag pool' pool)\<rbrace>
+   set_asid_pool ptr pool
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  apply (wpsimp wp: set_object_wp_strong
+              simp: obj_at_def a_type_def
+             split: Structures_A.kernel_object.split_asm arch_kernel_obj.split_asm if_splits)
+  apply (erule integrity_trans)
+  apply (clarsimp simp: integrity_def)
+  apply (rule tro_arch; fastforce simp: arch_integrity_obj_atomic.simps)
+  done
+
+lemma delete_asid_respects:
+  "\<lbrace>integrity aag X st and pas_refined aag and invs and K (is_subject aag pd)\<rbrace>
+   delete_asid asid pd
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  by (wpsimp wp: set_asid_pool_respects_clear hoare_vcg_all_lift
+           simp: obj_at_def pas_refined_refl delete_asid_def asid_pool_integrity_def)
+
+end
+
+
+context begin interpretation Arch .
+
+requalify_facts
+  invoke_arch_pas_refined
+  invoke_arch_respects
+  decode_arch_invocation_authorised
+
+requalify_consts
+  authorised_arch_inv
+
+end
+
+end

--- a/proof/access-control/ARM/ArchCNode_AC.thy
+++ b/proof/access-control/ARM/ArchCNode_AC.thy
@@ -1,0 +1,545 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchCNode_AC
+imports CNode_AC
+begin
+
+section\<open>Arch-specific CNode AC.\<close>
+
+context Arch begin global_naming ARM_A
+
+declare arch_post_modify_registers_def[simp]
+declare arch_post_cap_deletion_def[simp]
+declare arch_cap_cleanup_opt_def[simp]
+declare arch_mask_irq_signal_def[simp]
+
+named_theorems CNode_AC_assms
+
+lemma sata_cdt_update[CNode_AC_assms, simp]:
+  "state_asids_to_policy aag (cdt_update f s) = state_asids_to_policy aag s"
+  by simp
+
+lemma sata_is_original_cap_update[CNode_AC_assms, simp]:
+  "state_asids_to_policy aag (is_original_cap_update f s) = state_asids_to_policy aag s"
+  by simp
+
+lemma sata_interrupt_states_update[CNode_AC_assms, simp]:
+  "state_asids_to_policy aag (interrupt_states_update f s) = state_asids_to_policy aag s"
+  by simp
+
+lemma sata_machine_state_update[CNode_AC_assms, simp]:
+  "state_asids_to_policy aag (machine_state_update f s) = state_asids_to_policy aag s"
+  by simp
+
+lemma sata_update[CNode_AC_assms]:
+  "\<lbrakk> pas_wellformed aag;
+     cap_links_asid_slot aag (pasObjectAbs aag (fst ptr)) cap;
+     state_asids_to_policy_arch aag caps as vrefs \<subseteq> pasPolicy aag \<rbrakk>
+     \<Longrightarrow> state_asids_to_policy_arch aag (caps(ptr \<mapsto> cap)) as vrefs \<subseteq> pasPolicy aag"
+  by (fastforce intro: state_asids_to_policy_aux.intros
+                 elim!: state_asids_to_policy_aux.cases
+                 simp: cap_links_asid_slot_def label_owns_asid_slot_def
+                split: if_split_asm)
+
+lemma sata_update2[CNode_AC_assms]:
+  "\<lbrakk> pas_wellformed aag;
+     cap_links_asid_slot aag (pasObjectAbs aag (fst ptr)) cap;
+     cap_links_asid_slot aag (pasObjectAbs aag (fst ptr')) cap';
+     state_asids_to_policy_arch aag caps as vrefs \<subseteq> pasPolicy aag \<rbrakk>
+     \<Longrightarrow> state_asids_to_policy_arch aag (caps(ptr \<mapsto> cap, ptr' \<mapsto> cap')) as vrefs \<subseteq> pasPolicy aag"
+  by (fastforce intro: state_asids_to_policy_aux.intros
+                elim!: state_asids_to_policy_aux.cases
+                 simp: cap_links_asid_slot_def label_owns_asid_slot_def
+                split: if_split_asm)
+
+lemma set_cap_state_vrefs[CNode_AC_assms, wp]:
+  "set_cap cap ptr \<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace>"
+  apply (wpsimp wp: get_object_wp simp: set_cap_def split_def set_object_def)
+  apply (auto simp: obj_at_def state_vrefs_def
+             elim!: rsubst[where P=P, OF _ ext]
+             split: if_split_asm simp: vs_refs_no_global_pts_def)
+  done
+
+crunches maskInterrupt
+  for underlying_memory[CNode_AC_assms, wp]: "\<lambda>s. P (underlying_memory s)"
+  and device_state[CNode_AC_assms, wp]: "\<lambda>s. P (device_state s)"
+  (simp: maskInterrupt_def)
+
+crunches set_cdt
+  for state_vrefs[CNode_AC_assms, wp]: "\<lambda>s. P (state_vrefs s)"
+  and state_asids_to_policy[CNode_AC_assms, wp]: "\<lambda>s. P (state_asids_to_policy aag s)"
+
+crunches prepare_thread_delete, arch_finalise_cap
+  for cur_domain[CNode_AC_assms, wp]:"\<lambda>s. P (cur_domain s)"
+  (wp: crunch_wps select_wp hoare_vcg_if_lift2 simp: unless_def)
+
+lemma state_vrefs_tcb_upd[CNode_AC_assms]:
+  "get_tcb t s = Some y \<Longrightarrow> state_vrefs (s\<lparr>kheap := kheap s(t \<mapsto> TCB tcb)\<rparr>) = state_vrefs s"
+  apply (rule ext)
+  apply (auto simp: state_vrefs_def vs_refs_no_global_pts_def dest!: get_tcb_SomeD)
+  done
+
+lemma state_vrefs_simple_type_upd[CNode_AC_assms]:
+  "\<lbrakk> ko_at ko ptr s; is_simple_type ko; a_type ko = a_type (f val) \<rbrakk>
+     \<Longrightarrow> state_vrefs (s\<lparr>kheap := kheap s(ptr \<mapsto> f val)\<rparr>) = state_vrefs s"
+  apply (rule ext)
+  apply (auto simp: state_vrefs_def vs_refs_no_global_pts_def obj_at_def partial_inv_def a_type_def
+             split: kernel_object.splits arch_kernel_obj.splits if_splits)
+  done
+
+(* FIXME: move *)
+lemma a_type_arch_object_not_tcb[CNode_AC_assms, simp]:
+  "a_type (ArchObj arch_kernel_obj) \<noteq> ATCB"
+  by auto
+
+lemma arch_post_cap_deletion_cur_domain[CNode_AC_assms, wp]:
+  "arch_post_cap_deletion acap \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  by wpsimp
+
+lemma arch_post_cap_deletion_integrity[CNode_AC_assms]:
+  "arch_post_cap_deletion acap \<lbrace>integrity aag X st\<rbrace>"
+  by wpsimp
+
+end
+
+
+context is_extended begin interpretation Arch .
+
+lemma list_integ_lift[CNode_AC_assms]:
+  assumes li:
+    "\<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
+     f
+     \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag}  (cdt st) (tcb_states_of_state st)) st\<rbrace>"
+  assumes ekh: "\<And>P. f \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
+  assumes rq: "\<And>P. f \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace>"
+  shows "\<lbrace>integrity aag X st and Q\<rbrace> f \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (rule hoare_pre)
+   apply (unfold integrity_def[abs_def] integrity_asids_def)
+   apply (simp only: integrity_cdt_list_as_list_integ)
+   apply (rule hoare_lift_Pf2[where f="ekheap"])
+    apply (simp add: tcb_states_of_state_def get_tcb_def)
+    apply (wp li[simplified tcb_states_of_state_def get_tcb_def] ekh rq)+
+  apply (simp only: integrity_cdt_list_as_list_integ)
+  apply (simp add: tcb_states_of_state_def get_tcb_def)
+  done
+
+end
+
+
+global_interpretation CNode_AC_1?: CNode_AC_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact CNode_AC_assms)
+qed
+
+
+context Arch begin global_naming ARM_A
+
+lemma integrity_asids_set_cap_Nullcap[CNode_AC_assms]:
+  "\<lbrace>(=) s\<rbrace> set_cap NullCap slot \<lbrace>\<lambda>_. integrity_asids aag subjects x s\<rbrace>"
+  unfolding integrity_asids_def by wpsimp
+
+crunches set_original
+  for state_asids_to_policy[CNode_AC_assms, wp]: "\<lambda>s. P (state_asids_to_policy aag s)"
+  and state_objs_to_policy[CNode_AC_assms, wp]: "\<lambda>s. P (state_objs_to_policy s)"
+  (simp: state_objs_to_policy_def)
+
+crunches set_cdt_list, update_cdt_list
+  for state_vrefs[CNode_AC_assms, wp]: "\<lambda>s. P (state_vrefs s)"
+  and state_asids_to_policy[CNode_AC_assms, wp]: "\<lambda>s. P (state_asids_to_policy aag s)"
+  (simp: set_cdt_list_def)
+
+end
+
+
+global_interpretation CNode_AC_2?: CNode_AC_2
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact CNode_AC_assms)
+qed
+
+
+context Arch begin global_naming ARM_A
+
+lemma arch_post_cap_deletion_pas_refined[CNode_AC_assms, wp]:
+  "arch_post_cap_deletion irqopt \<lbrace>pas_refined aag\<rbrace>"
+  by (wpsimp simp: post_cap_deletion_def)
+
+lemma aobj_ref'_same_aobject[CNode_AC_assms]:
+  "same_aobject_as ao' ao \<Longrightarrow> aobj_ref' ao = aobj_ref' ao'"
+  by (cases ao; clarsimp split: arch_cap.splits)
+
+end
+
+
+context is_extended begin interpretation Arch .
+
+lemma pas_refined_tcb_domain_map_wellformed[CNode_AC_assms, wp]:
+  assumes tdmw: "f \<lbrace>tcb_domain_map_wellformed aag\<rbrace>"
+  shows "f \<lbrace>pas_refined aag\<rbrace>"
+  apply (simp add: pas_refined_def)
+  apply (wp tdmw)
+   apply (wp lift_inv)
+   apply simp+
+  done
+
+end
+
+
+global_interpretation CNode_AC_3?: CNode_AC_3
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact CNode_AC_assms)
+qed
+
+
+context Arch begin global_naming ARM_A
+
+lemma arch_derive_cap_auth_derived[CNode_AC_assms]:
+  "\<lbrace>\<lambda>s. cte_wp_at (auth_derived (ArchObjectCap cap)) src_slot s\<rbrace>
+   arch_derive_cap cap
+   \<lbrace>\<lambda>rv s. cte_wp_at (auth_derived rv) src_slot s\<rbrace>, -"
+  apply (rule hoare_pre)
+   apply (wp | wpc | simp add: arch_derive_cap_def)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (safe)
+  apply (clarsimp simp: auth_derived_def arch_cap_auth_conferred_def cap_auth_conferred_def)
+  done
+
+lemma cap_asid'_cap_rights_update[CNode_AC_assms, simp]:
+  "acap_asid' (acap_rights_update rights ao) = acap_asid' ao"
+  by (cases ao; clarsimp simp: cap_rights_update_def acap_rights_update_def)
+
+lemma untyped_range_cap_rights_update[CNode_AC_assms, simp]:
+  "untyped_range (cap_rights_update rights (ArchObjectCap ao)) = untyped_range (ArchObjectCap ao)"
+  by (cases ao; clarsimp simp: cap_rights_update_def)
+
+lemma obj_refs_cap_rights_update[CNode_AC_assms, simp]:
+  "aobj_ref' (acap_rights_update rights ao) = aobj_ref' ao"
+  by (cases ao; clarsimp simp: cap_rights_update_def acap_rights_update_def)
+
+lemma auth_derived_arch_update_cap_data[CNode_AC_assms]:
+  "auth_derived (ArchObjectCap ao) cap' \<Longrightarrow> auth_derived (arch_update_cap_data pres w ao) cap'"
+  by (simp add: update_cap_data_def is_cap_simps arch_update_cap_data_def
+                  split del: if_split cong: if_cong)
+
+lemma acap_auth_conferred_acap_rights_update[CNode_AC_assms]:
+  "arch_cap_auth_conferred (acap_rights_update (acap_rights acap \<inter> R) acap)
+   \<subseteq> arch_cap_auth_conferred acap"
+  by (auto simp: arch_cap_auth_conferred_def vspace_cap_rights_to_auth_def acap_rights_update_def
+                 validate_vm_rights_def vm_kernel_only_def vm_read_only_def
+          split: arch_cap.splits)
+
+lemma arch_derive_cap_clas[CNode_AC_assms]:
+  "\<lbrace>\<lambda>s. cap_links_asid_slot aag p (ArchObjectCap acap)\<rbrace>
+   arch_derive_cap acap
+   \<lbrace>\<lambda>rv s. cap_links_asid_slot aag p rv\<rbrace>, -"
+  apply (simp add: arch_derive_cap_def cong: cap.case_cong)
+  apply (rule hoare_pre)
+  apply (wp | wpc)+
+  apply (auto simp: is_cap_simps cap_links_asid_slot_def)
+  done
+
+lemma arch_derive_cap_obj_refs_auth[CNode_AC_assms]:
+  "\<lbrace>K (\<forall>r\<in>obj_refs (ArchObjectCap cap).
+       \<forall>auth\<in>cap_auth_conferred (ArchObjectCap cap). aag_has_auth_to aag auth r)\<rbrace>
+   arch_derive_cap cap
+   \<lbrace>(\<lambda>x s. \<forall>r\<in>obj_refs x. \<forall>auth\<in>cap_auth_conferred x. aag_has_auth_to aag auth r)\<rbrace>, -"
+  unfolding arch_derive_cap_def
+  apply (rule hoare_pre)
+   apply (wp | wpc)+
+  apply (clarsimp simp: cap_auth_conferred_def arch_cap_auth_conferred_def)
+  done
+
+(* FIXME: move *)
+lemma arch_derive_cap_obj_refs_subset[CNode_AC_assms]:
+  "\<lbrace>\<lambda>s. (\<forall>x \<in> aobj_ref' acap. P x s)\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv s. \<forall>x \<in> obj_refs rv. P x s\<rbrace>, -"
+  by (wpsimp simp: arch_derive_cap_def) fastforce
+
+lemma arch_derive_cap_clip[CNode_AC_assms]:
+  "\<lbrace>K (cap_links_irq aag l (ArchObjectCap ac))\<rbrace>
+   arch_derive_cap ac
+   \<lbrace>\<lambda>x s. cap_links_irq aag l x\<rbrace>, -"
+  by (wpsimp simp: arch_derive_cap_def comp_def cli_no_irqs)
+
+(* FIXME: move *)
+lemma arch_derive_cap_untyped_range_subset[CNode_AC_assms]:
+  "\<lbrace>\<lambda>s. \<forall>x \<in> untyped_range (ArchObjectCap acap). P x s\<rbrace>
+   arch_derive_cap acap
+   \<lbrace>\<lambda>rv s. \<forall>x \<in> untyped_range rv. P x s\<rbrace>, -"
+  by (wpsimp simp: arch_derive_cap_def)
+
+lemma arch_update_cap_obj_refs_subset[CNode_AC_assms]:
+  "\<lbrakk> x \<in> obj_refs (arch_update_cap_data pres data cap) \<rbrakk> \<Longrightarrow> x \<in> aobj_ref' cap"
+  by (simp add: arch_update_cap_data_def)
+
+lemma arch_update_cap_untyped_range_empty[CNode_AC_assms, simp]:
+  "untyped_range (arch_update_cap_data pres data cap) = {}"
+  by (simp add: arch_update_cap_data_def)
+
+lemma arch_update_cap_irqs_controlled_empty[CNode_AC_assms, simp]:
+  "cap_irqs_controlled (arch_update_cap_data pres data cap) = {}"
+  by (simp add: arch_update_cap_data_def)
+
+lemma arch_update_cap_links_asid_slot[CNode_AC_assms]:
+  "cap_links_asid_slot aag p (arch_update_cap_data pres w acap) =
+   cap_links_asid_slot aag p (ArchObjectCap acap)"
+  by (simp add: arch_update_cap_data_def)
+
+lemma arch_update_cap_cap_auth_conferred_subset[CNode_AC_assms]:
+  "y \<in> cap_auth_conferred (arch_update_cap_data b w acap) \<Longrightarrow> y \<in> arch_cap_auth_conferred acap"
+  by (simp add: arch_update_cap_data_def cap_auth_conferred_def)
+
+end
+
+
+global_interpretation CNode_AC_4?: CNode_AC_4
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact CNode_AC_assms)?)
+qed
+
+
+context Arch begin global_naming ARM_A
+
+lemma pas_refined_arch_state_update_not_asids[simp]:
+ "arm_asid_table (f (arch_state s)) = arm_asid_table (arch_state s)
+  \<Longrightarrow> pas_refined aag (arch_state_update f s) = pas_refined aag s"
+  by (simp add: pas_refined_def state_objs_to_policy_def)
+
+crunch cdt[wp]: store_pte "\<lambda>s. P (cdt s)"
+
+lemma store_pte_state_refs[wp]:
+  "store_pte p pte \<lbrace>\<lambda>s. P (state_refs_of s)\<rbrace>"
+  apply (simp add: store_pte_def set_pt_def set_object_def)
+  apply (wp get_object_wp)
+  apply (clarsimp simp: obj_at_def state_refs_of_def
+                 elim!: rsubst[where P=P, OF _ ext])
+  done
+
+lemma all_rsubst:
+  "\<lbrakk> \<forall>v. P (f v); \<exists>v. f v = r \<rbrakk> \<Longrightarrow> P r"
+  by clarsimp
+
+lemma store_pte_st_vrefs[wp]:
+  "\<lbrace>\<lambda>s. \<forall>S. P ((state_vrefs s) (p && ~~ mask pt_bits :=
+                                  (state_vrefs s (p && ~~ mask pt_bits) - S) \<union>
+                                  (\<Union>(p', sz, auth)\<in>set_option (pte_ref pte).
+                                     (\<lambda>(p'', a). (p'', (p && mask pt_bits) >> 2, APageTable, a)) `
+                                                                       (ptr_range p' sz \<times> auth))))\<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>rv s. P (state_vrefs s)\<rbrace>"
+  apply (simp add: store_pte_def set_pt_def set_object_def)
+  apply (wp get_object_wp)
+  apply (clarsimp simp: state_vrefs_def vs_refs_no_global_pts_def obj_at_def)
+  apply (simp add: fun_upd_def[symmetric] fun_upd_comp)
+  apply (erule all_rsubst[where P=P])
+  apply (subst fun_eq_iff, clarsimp simp: split_def)
+  apply (cases "pte_ref pte")
+   apply (auto simp: ucast_ucast_mask shiftr_over_and_dist
+                     word_bw_assocs mask_def pt_bits_def pageBits_def)
+  done
+
+lemma store_pte_thread_states[wp]:
+  "store_pte p pte \<lbrace>\<lambda>s. P (thread_states s)\<rbrace>"
+  apply (simp add: store_pte_def set_pt_def set_object_def)
+  apply (wp get_object_wp)
+  apply (clarsimp simp: thread_states_def obj_at_def get_tcb_def tcb_states_of_state_def
+                 elim!: rsubst[where P=P, OF _ ext]
+                 split: kernel_object.split_asm option.split)
+  done
+
+lemma store_pte_thread_bound_ntfns[wp]:
+  "store_pte p pte \<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace>"
+  apply (simp add: store_pte_def set_pt_def set_object_def)
+  apply (wp get_object_wp)
+  apply (clarsimp simp: thread_bound_ntfns_def obj_at_def get_tcb_def tcb_states_of_state_def
+                 elim!: rsubst[where P=P, OF _ ext]
+                 split: kernel_object.split_asm option.split)
+  done
+
+lemma auth_graph_map_def2:
+  "auth_graph_map f S = (\<lambda>(x, auth, y). (f x, auth, f y)) ` S"
+  by (auto simp add: auth_graph_map_def image_def intro: rev_bexI)
+
+(* FIXME move to AInvs *)
+lemma store_pte_ekheap[wp]:
+  "store_pte p pte \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
+  apply (simp add: store_pte_def set_pt_def)
+  apply (wp get_object_wp)
+  apply simp
+  done
+
+crunch asid_table_inv [wp]: store_pte "\<lambda>s. P (asid_table s)"
+
+lemma store_pte_pas_refined[wp]:
+  "\<lbrace>pas_refined aag and
+    K (\<forall>x. pte_ref pte = Some x
+           \<longrightarrow> (\<forall>a \<in> snd (snd x). \<forall>p' \<in> (ptr_range (fst x) (fst (snd x))).
+                auth_graph_map (pasObjectAbs aag) {(p && ~~ mask pt_bits, a, p')} \<subseteq> pasPolicy aag))\<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  apply (simp add: auth_graph_map_def2)
+  apply (simp add: pas_refined_def state_objs_to_policy_def)
+  apply (rule hoare_pre)
+   apply (wp tcb_domain_map_wellformed_lift | wps)+
+  apply clarsimp
+  apply (rule conjI)
+   apply (clarsimp dest!: auth_graph_map_memD split del: if_split)
+   apply (erule state_bits_to_policy.cases,
+          auto intro: state_bits_to_policy.intros auth_graph_map_memI
+               split: if_split_asm)[1]
+  apply (erule_tac B="state_asids_to_policy_aux _ _ _ _" in subset_trans[rotated])
+  apply (auto intro: state_asids_to_policy_aux.intros
+              elim!: state_asids_to_policy_aux.cases
+               elim: subset_trans[rotated]
+              split: if_split_asm)
+  done
+
+lemma store_pde_st_vrefs[wp]:
+  "\<lbrace>\<lambda>s. \<forall>S. P ((state_vrefs s) (p && ~~ mask pd_bits :=
+                                  (state_vrefs s (p && ~~ mask pd_bits) - S) \<union>
+                                  (if ucast (kernel_base >> 20) \<le> (ucast (p && mask pd_bits >> 2)::12 word)
+                                   then {}
+                                   else (\<Union>(p', sz, auth)\<in>set_option (pde_ref2 pde).
+                                        (\<lambda>(p'', a). (p'', (p && mask pd_bits) >> 2, APageDirectory, a)) `
+                                                                             (ptr_range p' sz \<times> auth)))))\<rbrace>
+   store_pde p pde
+   \<lbrace>\<lambda>rv s. P (state_vrefs s)\<rbrace>"
+  apply (simp add: store_pde_def set_pd_def set_object_def split del: if_split)
+  apply (wp get_object_wp)
+  apply (clarsimp simp: obj_at_def)
+  apply (erule all_rsubst[where P=P], subst fun_eq_iff)
+  apply (clarsimp simp add: state_vrefs_def vs_refs_no_global_pts_def
+                            fun_upd_def[symmetric] fun_upd_comp)
+  apply (cases "pde_ref2 pde")
+  by (auto simp: split_def insert_Diff_if Un_ac ucast_ucast_mask_shift_helper)
+
+lemma store_pde_thread_states[wp]:
+  "store_pde p pde \<lbrace>\<lambda>s. P (thread_states s)\<rbrace>"
+  apply (simp add: store_pde_def set_pd_def set_object_def)
+  apply (wp get_object_wp)
+  apply (clarsimp simp: thread_states_def obj_at_def get_tcb_def tcb_states_of_state_def
+                 elim!: rsubst[where P=P, OF _ ext]
+                 split: kernel_object.split_asm option.split)
+  done
+
+lemma store_pde_thread_bound_ntfns[wp]:
+  "store_pde p pde \<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace>"
+  apply (simp add: store_pde_def set_pd_def set_object_def)
+  apply (wp get_object_wp)
+  apply (clarsimp simp: thread_bound_ntfns_def obj_at_def get_tcb_def tcb_states_of_state_def
+                 elim!: rsubst[where P=P, OF _ ext]
+                 split: kernel_object.split_asm option.split)
+  done
+
+lemma store_pde_pas_refined[wp]:
+  "\<lbrace>pas_refined aag and
+    K ((ucast (p && mask pd_bits >> 2)::12 word) < (ucast (kernel_base >> 20))
+       \<longrightarrow> (\<forall>x. pde_ref2 pde = Some x \<longrightarrow>  (\<forall>a \<in> snd (snd x). \<forall>p' \<in> ptr_range (fst x) (fst (snd x)).
+            auth_graph_map (pasObjectAbs aag) {(p && ~~ mask pd_bits, a, p')} \<subseteq> pasPolicy aag)))\<rbrace>
+   store_pde p pde
+   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  apply (simp add: auth_graph_map_def2)
+  apply (simp add: pas_refined_def state_objs_to_policy_def)
+  apply (rule hoare_pre)
+   apply (wp tcb_domain_map_wellformed_lift | wps)+
+  apply (clarsimp split del: if_split)
+  apply (rule conjI)
+   apply (clarsimp dest!: auth_graph_map_memD split del: if_split)
+   apply (erule state_bits_to_policy.cases,
+          auto intro: state_bits_to_policy.intros auth_graph_map_memI
+               split: if_split_asm)[1]
+  apply (erule_tac B="state_asids_to_policy_aux _ _ _ _" in subset_trans[rotated])
+  apply (auto intro: state_asids_to_policy_aux.intros
+              elim!: state_asids_to_policy_aux.cases
+              split: if_split_asm)
+  done
+
+lemmas pde_ref_simps = pde_ref_def[split_simps pde.split] pde_ref2_def[split_simps pde.split]
+
+lemma set_asid_pool_st_vrefs[wp]:
+  "\<lbrace>\<lambda>s. P ((state_vrefs s) (p := (\<lambda>(r, p). (p, ucast r, AASIDPool, Control)) ` graph_of pool))\<rbrace>
+   set_asid_pool p pool
+   \<lbrace>\<lambda>rv s. P (state_vrefs s)\<rbrace>"
+  apply (simp add: set_asid_pool_def set_object_def)
+  apply (wp get_object_wp)
+  apply (clarsimp simp: state_vrefs_def fun_upd_def[symmetric] fun_upd_comp obj_at_def
+                        vs_refs_no_global_pts_def
+                 split: kernel_object.split_asm arch_kernel_obj.split_asm
+                 elim!: rsubst[where P=P, OF _ ext])
+  done
+
+lemma set_asid_pool_thread_states[wp]:
+  "set_asid_pool p pool \<lbrace>\<lambda>s. P (thread_states s)\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  apply (wpsimp wp: set_object_wp_strong)
+  apply (clarsimp simp: thread_states_def obj_at_def get_tcb_def tcb_states_of_state_def
+                 elim!: rsubst[where P=P, OF _ ext]
+                 split: kernel_object.split_asm option.split)
+  done
+
+lemma set_asid_pool_thread_bound_ntfns[wp]:
+  "set_asid_pool p pool \<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  apply (wpsimp wp: set_object_wp_strong)
+  apply (clarsimp simp: thread_bound_ntfns_def obj_at_def get_tcb_def tcb_states_of_state_def
+                 elim!: rsubst[where P=P, OF _ ext]
+                 split: kernel_object.split_asm option.split)
+  done
+
+(* FIXME move to AInvs *)
+lemma set_asid_pool_ekheap[wp]:
+  "set_asid_pool p pool \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  apply (wp get_object_wp | simp)+
+  done
+
+lemma set_asid_pool_pas_refined[wp]:
+  "\<lbrace>pas_refined aag and
+    (\<lambda>s. \<forall>(x, y) \<in> graph_of pool.
+           auth_graph_map (pasObjectAbs aag) {(p, Control, y)} \<subseteq> pasPolicy aag \<and>
+           (\<forall>asid. asid_table s (asid_high_bits_of asid) = Some p \<and>
+                   asid && mask asid_low_bits = ucast x
+                   \<longrightarrow> (pasASIDAbs aag asid, Control, pasObjectAbs aag y) \<in> pasPolicy aag))\<rbrace>
+         set_asid_pool p pool \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  apply (simp add: auth_graph_map_def2 image_UN split_def)
+  apply (simp add: pas_refined_def state_objs_to_policy_def)
+  apply (rule hoare_pre)
+   apply (wp tcb_domain_map_wellformed_lift | wps)+
+  apply clarsimp
+  apply (rule conjI)
+   apply (clarsimp dest!: auth_graph_map_memD)
+   apply (erule state_bits_to_policy.cases,
+          auto intro: state_bits_to_policy.intros auth_graph_map_memI
+               split: if_split_asm)[1]
+  apply (auto intro: state_asids_to_policy_aux.intros
+               simp: subsetD[OF _ state_asids_to_policy_aux.intros(2)]
+              elim!: state_asids_to_policy_aux.cases
+              split: if_split_asm)
+  apply fastforce+
+  done
+
+lemma pas_refined_clear_asid:
+  "pas_refined aag s
+   \<Longrightarrow> pas_refined aag (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := \<lambda>a. if a = asid then None
+                                                                           else asid_table s a\<rparr>\<rparr>)"
+  by (fastforce simp: pas_refined_def state_objs_to_policy_def
+               intro: state_asids_to_policy_aux.intros
+               elim!: state_asids_to_policy_aux.cases
+               split: if_split_asm)
+
+crunch integrity_autarch: set_asid_pool "integrity aag X st"
+  (wp: crunch_wps)
+
+end
+
+end

--- a/proof/access-control/ARM/ArchDomainSepInv.thy
+++ b/proof/access-control/ARM/ArchDomainSepInv.thy
@@ -1,0 +1,141 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchDomainSepInv
+imports
+  "DomainSepInv"
+begin
+
+context Arch begin global_naming ARM_A
+
+named_theorems DomainSepInv_assms
+
+crunches arch_post_cap_deletion, set_pd, set_pt, set_asid_pool, prepare_thread_delete, init_arch_objects
+  for domain_sep_inv[DomainSepInv_assms, wp]: "domain_sep_inv irqs st"
+  (wp: domain_sep_inv_triv crunch_wps set_asid_pool_cte_wp_at set_pd_cte_wp_at set_pt_cte_wp_at)
+
+crunch domain_sep_inv[DomainSepInv_assms, wp]: arch_finalise_cap "domain_sep_inv irqs st"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma arch_finalise_cap_rv[DomainSepInv_assms]:
+  "\<lbrace>\<lambda>_. P (NullCap,NullCap)\<rbrace> arch_finalise_cap c x \<lbrace>\<lambda>rv _. P rv\<rbrace>"
+  unfolding arch_finalise_cap_def by wpsimp
+
+end
+
+
+global_interpretation DomainSepInv_1?: DomainSepInv_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact DomainSepInv_assms)
+qed
+
+
+context Arch begin global_naming ARM_A
+
+crunches
+  invalidate_tlb_by_asid, handle_reserved_irq, handle_vm_fault,
+  handle_hypervisor_fault, handle_arch_fault_reply, arch_mask_irq_signal,
+  arch_switch_to_thread, arch_switch_to_idle_thread, arch_activate_idle_thread
+  for domain_sep_inv[DomainSepInv_assms, wp]: "domain_sep_inv irqs st"
+
+lemma perform_page_invocation_domain_sep_inv:
+  "\<lbrace>domain_sep_inv irqs st and valid_page_inv pgi\<rbrace>
+   perform_page_invocation pgi
+   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  apply (rule hoare_pre)
+   apply (wp mapM_wp[OF _ subset_refl] set_cap_domain_sep_inv mapM_x_wp[OF _ subset_refl]
+             perform_page_invocation_domain_sep_inv_get_cap_helper static_imp_wp
+          | simp add: perform_page_invocation_def o_def | wpc)+
+  apply (clarsimp simp: valid_page_inv_def)
+  apply (case_tac xa, simp_all add: domain_sep_inv_cap_def is_pg_cap_def)
+  done
+
+lemma perform_page_table_invocation_domain_sep_inv:
+  "\<lbrace>domain_sep_inv irqs st and valid_pti pgi\<rbrace>
+   perform_page_table_invocation pgi
+   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  apply (rule hoare_pre)
+   apply (simp add: perform_page_table_invocation_def)
+   apply (wpsimp wp: perform_page_invocation_domain_sep_inv_get_cap_helper
+                     crunch_wps set_cap_domain_sep_inv)
+  apply (clarsimp simp: valid_pti_def)
+  apply (case_tac x, simp_all add: domain_sep_inv_cap_def is_pt_cap_def)
+  done
+
+lemma perform_page_directory_invocation_domain_sep_inv:
+  "perform_page_directory_invocation pti \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  apply (simp add: perform_page_directory_invocation_def)
+  apply (cases pti)
+   apply (simp | wp)+
+  done
+
+lemma perform_asid_control_invocation_domain_sep_inv:
+  "perform_asid_control_invocation iv \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  unfolding perform_asid_control_invocation_def
+  apply (rule hoare_pre)
+  apply (wp modify_wp cap_insert_domain_sep_inv' set_cap_domain_sep_inv
+            get_cap_domain_sep_inv_cap[where st=st] static_imp_wp
+         | wpc | simp )+
+  done
+
+lemma perform_asid_pool_invocation_domain_sep_inv:
+  "perform_asid_pool_invocation iv \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  apply (simp add: perform_asid_pool_invocation_def)
+  apply (rule hoare_pre)
+  apply (wp set_cap_domain_sep_inv get_cap_wp | wpc | simp)+
+  done
+
+lemma arch_perform_invocation_domain_sep_inv[DomainSepInv_assms]:
+  "\<lbrace>domain_sep_inv irqs st and valid_arch_inv ai\<rbrace>
+   arch_perform_invocation ai
+   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  unfolding arch_perform_invocation_def
+  apply (wpsimp wp: perform_page_table_invocation_domain_sep_inv
+                    perform_page_directory_invocation_domain_sep_inv
+                    perform_page_invocation_domain_sep_inv
+                    perform_asid_control_invocation_domain_sep_inv
+                    perform_asid_pool_invocation_domain_sep_inv)
+  apply (clarsimp simp: valid_arch_inv_def split: arch_invocation.splits)
+  done
+
+lemma arch_invoke_irq_handler_domain_sep_inv[DomainSepInv_assms, wp]:
+  "arch_invoke_irq_handler ihi \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  by (cases ihi; wpsimp)
+
+lemma arch_invoke_irq_control_domain_sep_inv[DomainSepInv_assms]:
+  "\<lbrace>domain_sep_inv irqs st and arch_irq_control_inv_valid ivk\<rbrace>
+   arch_invoke_irq_control ivk
+   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  apply (cases ivk)
+  apply (wpsimp wp: cap_insert_domain_sep_inv' simp: set_irq_state_def)
+   apply (rule_tac Q="\<lambda>_. domain_sep_inv irqs st and arch_irq_control_inv_valid ivk"
+                in hoare_strengthen_post[rotated])
+    apply (fastforce simp: domain_sep_inv_def domain_sep_inv_cap_def arch_irq_control_inv_valid_def)
+   apply (wpsimp wp: do_machine_op_domain_sep_inv simp: arch_irq_control_inv_valid_def)+
+  done
+
+lemma arch_derive_cap_domain_sep_inv[DomainSepInv_assms, wp]:
+  "\<lbrace>\<top>\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv _. domain_sep_inv_cap irqs rv\<rbrace>,-"
+  unfolding arch_derive_cap_def
+  by wpsimp
+
+lemma arch_post_modify_registers_domain_sep_inv[DomainSepInv_assms, wp]:
+  "arch_post_modify_registers cur x31 \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  unfolding arch_post_modify_registers_def by wpsimp
+
+end
+
+
+global_interpretation DomainSepInv_2?: DomainSepInv_2
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact DomainSepInv_assms)
+qed
+
+end

--- a/proof/access-control/ARM/ArchFinalise_AC.thy
+++ b/proof/access-control/ARM/ArchFinalise_AC.thy
@@ -1,0 +1,127 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchFinalise_AC
+imports Finalise_AC
+begin
+
+context Arch begin global_naming ARM_A
+
+named_theorems Finalise_AC_assms
+
+crunch pas_refined[wp]: arch_finalise_cap, prepare_thread_delete "pas_refined aag"
+
+crunch respects[Finalise_AC_assms, wp]: prepare_thread_delete "integrity aag X st"
+
+lemma sbn_st_vrefs[Finalise_AC_assms, wp]:
+  "set_bound_notification t st \<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace>"
+  apply (simp add: set_bound_notification_def)
+  apply (wpsimp wp: set_object_wp dxo_wp_weak)
+  apply (clarsimp simp: state_vrefs_def vs_refs_no_global_pts_def
+                 elim!: rsubst[where P=P, OF _ ext]
+                 dest!: get_tcb_SomeD)
+  done
+
+lemma arch_finalise_cap_auth'[Finalise_AC_assms]:
+   "\<lbrace>pas_refined aag\<rbrace> arch_finalise_cap x12 final \<lbrace>\<lambda>rv s. pas_cap_cur_auth aag (fst rv)\<rbrace>"
+  unfolding arch_finalise_cap_def
+  by (wp | wpc | simp add: comp_def hoare_post_taut[where P = \<top>] split del: if_split)+
+
+lemma arch_finalise_cap_obj_refs[Finalise_AC_assms]:
+  "\<lbrace>\<lambda>s. \<forall>x \<in> aobj_ref' acap. P x\<rbrace>
+   arch_finalise_cap acap slot
+   \<lbrace>\<lambda>rv s. \<forall>x \<in> obj_refs (fst rv). P x\<rbrace>"
+  by (wpsimp simp: arch_finalise_cap_def)
+
+lemma arch_finalise_cap_makes_halted[Finalise_AC_assms]:
+  "\<lbrace>\<top>\<rbrace> arch_finalise_cap arch_cap ex \<lbrace>\<lambda>rv s. \<forall>t\<in>Access.obj_refs (fst rv). halted_if_tcb t s\<rbrace>"
+  apply (case_tac arch_cap, simp_all add: arch_finalise_cap_def)
+  by (wpsimp simp: valid_cap_def split: option.split bool.split)+
+
+lemma arch_cap_cleanup_wf[Finalise_AC_assms]:
+  "\<lbrakk> arch_cap_cleanup_opt acap \<noteq> NullCap; \<not> is_arch_cap (arch_cap_cleanup_opt acap) \<rbrakk>
+     \<Longrightarrow> (\<exists>irq. arch_cap_cleanup_opt acap = IRQHandlerCap irq \<and> is_subject_irq aag irq)"
+  by simp
+
+lemma arch_finalise_cap_respects[wp]:
+  "\<lbrace>integrity aag X st and invs and pas_refined aag and valid_cap (ArchObjectCap cap)
+                       and K (pas_cap_cur_auth aag (ArchObjectCap cap))\<rbrace>
+   arch_finalise_cap cap final
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: arch_finalise_cap_def)
+  apply (wpsimp wp: unmap_page_respects unmap_page_table_respects delete_asid_respects)
+  apply (auto simp: cap_auth_conferred_def arch_cap_auth_conferred_def is_page_cap_def
+                    aag_cap_auth_def pas_refined_all_auth_is_owns valid_cap_simps
+                    cap_links_asid_slot_def label_owns_asid_slot_def
+             intro: pas_refined_Control_into_is_subject_asid)
+  done
+
+end
+
+
+global_interpretation Finalise_AC_1?: Finalise_AC_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Finalise_AC_assms | wp finalise_cap_replaceable))
+qed
+
+
+context Arch begin global_naming ARM_A
+
+lemma cap_revoke_respects'[Finalise_AC_assms]:
+  "s \<turnstile> \<lbrace>(\<lambda>s. trp \<longrightarrow> integrity aag X st s) and K (is_subject aag (fst slot))
+                                           and pas_refined aag and einvs and simple_sched_action\<rbrace>
+       cap_revoke slot
+       \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>,
+       \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
+proof (induct rule: cap_revoke.induct[where ?a1.0=s])
+  case (1 slot s)
+  show ?case
+    apply (subst cap_revoke.simps)
+    apply (rule hoare_pre_spec_validE)
+     apply (wp "1.hyps")
+            apply ((wp preemption_point_inv' | simp add: integrity_subjects_def pas_refined_def)+)[1]
+           apply (wp select_ext_weak_wp cap_delete_respects cap_delete_pas_refined
+                  | simp split del: if_split | wp (once) hoare_vcg_const_imp_lift hoare_drop_imps)+
+    by (auto simp: emptyable_def descendants_of_def
+             dest: reply_slot_not_descendant
+            intro: cca_owned)
+qed
+
+lemma finalise_cap_caps_of_state_nullinv[Finalise_AC_assms]:
+  "\<lbrace>\<lambda>s. P (caps_of_state s) \<and> (\<forall>p. P (caps_of_state s(p \<mapsto> NullCap)))\<rbrace>
+   finalise_cap cap final
+   \<lbrace>\<lambda>_ s. P (caps_of_state s)\<rbrace>"
+  by (cases cap;
+      wpsimp wp: suspend_caps_of_state unbind_notification_caps_of_state
+                 unbind_notification_cte_wp_at
+                 hoare_vcg_all_lift hoare_drop_imps
+                 deleting_irq_handler_caps_of_state_nullinv
+           simp: fun_upd_def[symmetric] if_apply_def2 split_del: if_split)
+
+lemma finalise_cap_fst_ret[Finalise_AC_assms]:
+  "\<lbrace>\<lambda>_. P NullCap \<and> (\<forall>a b c. P (Zombie a b c))\<rbrace>
+   finalise_cap cap is_final
+   \<lbrace>\<lambda>rv _. P (fst rv)\<rbrace>"
+  including no_pre
+  apply (cases cap, simp_all add: arch_finalise_cap_def split del: if_split)
+  apply (wp | simp add: comp_def split del: if_split | fastforce)+
+  apply (rule hoare_pre)
+  apply (wp | simp | (rule hoare_pre, wpc))+
+  done
+
+end
+
+
+global_interpretation Finalise_AC_2?: Finalise_AC_2
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact Finalise_AC_assms)
+qed
+
+end

--- a/proof/access-control/ARM/ArchInterrupt_AC.thy
+++ b/proof/access-control/ARM/ArchInterrupt_AC.thy
@@ -1,0 +1,110 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchInterrupt_AC
+imports
+  Interrupt_AC
+begin
+
+context Arch begin global_naming ARM_A
+
+named_theorems Interrupt_AC_assms
+
+definition arch_authorised_irq_ctl_inv ::
+  "'a PAS \<Rightarrow> Invocations_A.arch_irq_control_invocation \<Rightarrow> bool" where
+  "arch_authorised_irq_ctl_inv aag cinv \<equiv>
+     case cinv of (ArchIRQControlIssue irq x1 x2 trigger) \<Rightarrow>
+       is_subject aag (fst x1) \<and> is_subject aag (fst x2) \<and>
+       (pasSubject aag, Control, pasIRQAbs aag irq) \<in> pasPolicy aag"
+
+lemma arch_invoke_irq_control_pas_refined[Interrupt_AC_assms]:
+  "\<lbrace>pas_refined aag and valid_mdb and arch_irq_control_inv_valid irq_ctl_inv
+                    and K (arch_authorised_irq_ctl_inv aag irq_ctl_inv)\<rbrace>
+   arch_invoke_irq_control irq_ctl_inv
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (cases irq_ctl_inv; simp)
+  apply (wpsimp wp: cap_insert_pas_refined_not_transferable)
+  apply (clarsimp simp: cte_wp_at_caps_of_state clas_no_asid cap_links_irq_def
+                        arch_authorised_irq_ctl_inv_def aag_cap_auth_def
+                        arch_irq_control_inv_valid_def)
+  done
+
+lemma arch_invoke_irq_handler_pas_refined[Interrupt_AC_assms]:
+  "\<lbrace>pas_refined aag and invs and (\<lambda>s. interrupt_states s x1 \<noteq> IRQInactive)\<rbrace>
+   arch_invoke_irq_handler (ACKIrq x1)
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  by wpsimp
+
+lemma arch_invoke_irq_control_respects[Interrupt_AC_assms]:
+  "\<lbrace>integrity aag X st and pas_refined aag and K (arch_authorised_irq_ctl_inv aag acinv)\<rbrace>
+   arch_invoke_irq_control acinv
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (case_tac acinv, clarsimp simp add: setIRQTrigger_def arch_authorised_irq_ctl_inv_def)
+  apply (wpsimp wp: cap_insert_integrity_autarch aag_Control_into_owns_irq
+                    dmo_mol_respects do_machine_op_pas_refined)
+  done
+
+lemma integrity_irq_masks [iff]:
+  "integrity aag X st (s\<lparr>machine_state := machine_state s \<lparr>irq_masks := v \<rparr>\<rparr>) =
+   integrity aag X st s"
+  unfolding integrity_def by simp
+
+lemma arch_invoke_irq_handler_respects[Interrupt_AC_assms]:
+  "\<lbrace>integrity aag X st and pas_refined aag and einvs\<rbrace>
+   arch_invoke_irq_handler (ACKIrq x1)
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  by (wpsimp wp: dmo_wp simp: maskInterrupt_def)
+
+crunches arch_check_irq for inv[Interrupt_AC_assms, wp]: P
+
+end
+
+requalify_consts ARM_A.arch_authorised_irq_ctl_inv
+
+
+global_interpretation Interrupt_AC_1?: Interrupt_AC_1 "arch_authorised_irq_ctl_inv"
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Interrupt_AC_assms)?)
+qed
+
+
+context Arch begin global_naming ARM_A
+
+lemma arch_decode_irq_control_invocation_authorised[Interrupt_AC_assms]:
+  "\<lbrace>pas_refined aag and
+    K (is_subject aag (fst slot) \<and> (\<forall>cap \<in> set caps. pas_cap_cur_auth aag cap) \<and>
+       (args \<noteq> [] \<longrightarrow> (pasSubject aag, Control, pasIRQAbs aag (ucast (args ! 0))) \<in> pasPolicy aag))\<rbrace>
+   arch_decode_irq_control_invocation info_label args slot caps
+   \<lbrace>\<lambda>x _. arch_authorised_irq_ctl_inv aag x\<rbrace>, -"
+  unfolding decode_irq_control_invocation_def arch_decode_irq_control_invocation_def
+            authorised_irq_ctl_inv_def arch_authorised_irq_ctl_inv_def arch_check_irq_def
+  apply (rule hoare_gen_asmE)
+  apply (rule hoare_pre)
+   apply (simp add: Let_def split del: if_split cong: if_cong)
+   apply (wp whenE_throwError_wp hoare_vcg_imp_lift hoare_drop_imps
+          | strengthen  aag_Control_owns_strg
+          | simp add: o_def del: hoare_True_E_R)+
+  apply (cases args, simp_all)
+  apply (cases caps, simp_all)
+  apply (simp add: ucast_mask_drop)
+  apply (auto simp: is_cap_simps cap_auth_conferred_def
+                    pas_refined_wellformed
+                    pas_refined_all_auth_is_owns aag_cap_auth_def)
+  done
+
+end
+
+
+global_interpretation Interrupt_AC_2?: Interrupt_AC_2 "arch_authorised_irq_ctl_inv"
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Interrupt_AC_assms)?)
+qed
+
+end

--- a/proof/access-control/ARM/ArchIpc_AC.thy
+++ b/proof/access-control/ARM/ArchIpc_AC.thy
@@ -1,0 +1,231 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchIpc_AC
+imports Ipc_AC
+begin
+
+context Arch begin global_naming ARM_A
+
+named_theorems Ipc_AC_assms
+
+declare make_fault_message_inv[Ipc_AC_assms]
+declare handle_arch_fault_reply_typ_at[Ipc_AC_assms]
+
+crunches deleted_irq_handler, send_signal
+  for state_vrefs[Ipc_AC_assms, wp]: "\<lambda>s. P (state_vrefs (s :: det_ext state))"
+  (wp: crunch_wps hoare_unless_wp select_wp dxo_wp_weak simp: crunch_simps)
+
+crunches deleted_irq_handler, send_signal
+  for arch_state[Ipc_AC_assms, wp]: "\<lambda>s. P (arch_state (s :: det_ext state))"
+  (wp: crunch_wps hoare_unless_wp select_wp dxo_wp_weak simp: crunch_simps)
+
+crunch integrity_asids[Ipc_AC_assms, wp]: cap_insert_ext "integrity_asids aag subjects x st"
+
+lemma arch_derive_cap_auth_derived[Ipc_AC_assms]:
+  "\<lbrace>\<top>\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv _. rv \<noteq> NullCap \<longrightarrow> auth_derived rv (ArchObjectCap acap)\<rbrace>, -"
+  by (case_tac acap;
+      simp add: derive_cap_def arch_derive_cap_def;
+      wpc?;
+      wp?;
+      simp add: auth_derived_def cap_auth_conferred_def arch_cap_auth_conferred_def)
+
+lemma lookup_ipc_buffer_has_auth[Ipc_AC_assms, wp]:
+  "\<lbrace>pas_refined aag and valid_objs\<rbrace>
+   lookup_ipc_buffer True receiver
+   \<lbrace>\<lambda>rv _. ipc_buffer_has_auth aag receiver rv\<rbrace>"
+  apply (rule hoare_pre)
+   apply (simp add: lookup_ipc_buffer_def)
+   apply (wp get_cap_wp thread_get_wp'
+        | wpc)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state ipc_buffer_has_auth_def get_tcb_ko_at[symmetric])
+  apply (frule caps_of_state_tcb_cap_cases [where idx="tcb_cnode_index 4"])
+   apply (simp add: dom_tcb_cap_cases)
+  apply (frule (1) caps_of_state_valid_cap)
+  apply (rule conjI)
+   apply (clarsimp simp: valid_cap_simps cap_aligned_def)
+   apply (erule aligned_add_aligned)
+    apply (rule is_aligned_andI1)
+    apply (drule (1) valid_tcb_objs)
+    apply (clarsimp simp: valid_obj_def valid_tcb_def valid_ipc_buffer_cap_def
+                   split: if_splits)
+   apply (rule order_trans [OF _ pbfs_atleast_pageBits])
+   apply (simp add: msg_align_bits pageBits_def)
+  apply simp
+  apply (drule (1) cap_auth_caps_of_state)
+  apply (clarsimp simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def
+                        vspace_cap_rights_to_auth_def vm_read_write_def is_page_cap_def)
+  apply (drule bspec)
+   apply (erule (3) ipcframe_subset_page)
+  apply simp
+  done
+
+lemma tcb_context_no_change[Ipc_AC_assms]:
+  "\<exists>ctxt. tcb = tcb\<lparr>tcb_arch := arch_tcb_context_set ctxt (tcb_arch tcb)\<rparr>"
+  apply (cases tcb, clarsimp)
+  apply (case_tac tcb_arch)
+  apply (auto simp: arch_tcb_context_set_def)
+  done
+
+end
+
+
+global_interpretation Ipc_AC_1?: Ipc_AC_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact Ipc_AC_assms)
+qed
+
+
+context Arch begin global_naming ARM_A
+
+lemma store_word_offs_respects_in_ipc[Ipc_AC_assms]:
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
+    K ((\<not> is_subject aag receiver \<longrightarrow> auth_ipc_buffers st receiver = ptr_range buf msg_align_bits)
+        \<and> is_aligned buf msg_align_bits \<and> r < 2 ^ (msg_align_bits - word_size_bits))\<rbrace>
+   store_word_offs buf r v
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+  apply (simp add: store_word_offs_def storeWord_def pred_conj_def)
+  apply (rule hoare_pre)
+   apply (wp dmo_wp)
+  apply (unfold integrity_tcb_in_ipc_def)
+  apply (elim conjE)
+  apply (intro impI conjI)
+     apply assumption+
+   apply (erule integrity_trans)
+   apply (clarsimp simp: ptr_range_off_off_mems integrity_def is_aligned_mask[symmetric])
+  apply simp
+  done
+
+crunches set_extra_badge
+  for respects_in_ipc[Ipc_AC_assms, wp]: "integrity_tcb_in_ipc aag X receiver epptr TRContext st"
+  (wp: store_word_offs_respects_in_ipc)
+
+crunch inv[Ipc_AC_assms, wp]: arch_get_sanitise_register_info P
+crunch pas_refined[Ipc_AC_assms, wp]: handle_arch_fault_reply "pas_refined aag"
+
+lemma set_mrs_respects_in_ipc[Ipc_AC_assms]:
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
+    K ((\<not> is_subject aag receiver \<longrightarrow>
+        (case recv_buf of None \<Rightarrow> True | Some buf' \<Rightarrow> auth_ipc_buffers st receiver =
+                                                     ptr_range buf' msg_align_bits)) \<and>
+       (case recv_buf of None \<Rightarrow> True | Some buf' \<Rightarrow> is_aligned buf' msg_align_bits))\<rbrace>
+     set_mrs receiver recv_buf msgs
+   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+  unfolding set_mrs_def set_object_def get_object_def
+  apply (rule hoare_gen_asm)
+  apply (wp mapM_x_wp' store_word_offs_respects_in_ipc
+         | wpc
+         | simp split del: if_split add: zipWithM_x_mapM_x split_def)+
+   apply (clarsimp simp add: set_zip nth_append simp: msg_align_bits' msg_max_length_def
+                   split: if_split_asm)
+   apply (simp add: msg_registers_def msgRegisters_def upto_enum_def fromEnum_def enum_register)
+   apply arith
+   apply simp
+   apply wp+
+  apply (clarsimp simp: arch_tcb_set_registers_def)
+  by (rule update_tcb_context_in_ipc [unfolded fun_upd_def]; fastforce)
+
+lemma lookup_ipc_buffer_ptr_range_in_ipc[Ipc_AC_assms]:
+  "\<lbrace>valid_objs and integrity_tcb_in_ipc aag X thread epptr tst st\<rbrace>
+   lookup_ipc_buffer True thread
+   \<lbrace>\<lambda>rv _. \<not> is_subject aag thread \<longrightarrow>
+           (case rv of None \<Rightarrow> True | Some buf' \<Rightarrow> auth_ipc_buffers st thread =
+                                                   ptr_range buf' msg_align_bits)\<rbrace>"
+  unfolding lookup_ipc_buffer_def
+  apply (rule hoare_pre)
+  apply (wp get_cap_wp thread_get_wp' | wpc)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state ipc_buffer_has_auth_def get_tcb_ko_at [symmetric])
+  apply (frule caps_of_state_tcb_cap_cases [where idx = "tcb_cnode_index 4"])
+   apply (simp add: dom_tcb_cap_cases)
+  apply (clarsimp simp: auth_ipc_buffers_def get_tcb_ko_at [symmetric] integrity_tcb_in_ipc_def)
+  apply (drule get_tcb_SomeD)
+  apply (erule(1) valid_objsE)
+  apply (clarsimp simp: valid_obj_def valid_tcb_def valid_ipc_buffer_cap_def case_bool_if
+                 split: if_split_asm)
+  apply (erule tcb_in_ipc.cases; clarsimp simp: get_tcb_def vm_read_write_def)
+  done
+
+lemma lookup_ipc_buffer_aligned[Ipc_AC_assms]:
+  "\<lbrace>valid_objs\<rbrace>
+   lookup_ipc_buffer True thread
+   \<lbrace>\<lambda>rv _. (case rv of None \<Rightarrow> True | Some buf' \<Rightarrow> is_aligned buf' msg_align_bits)\<rbrace>"
+  unfolding lookup_ipc_buffer_def
+  apply (rule hoare_pre)
+   apply (wp get_cap_wp thread_get_wp' | wpc)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state get_tcb_ko_at [symmetric])
+  apply (frule caps_of_state_tcb_cap_cases [where idx = "tcb_cnode_index 4"])
+   apply (simp add: dom_tcb_cap_cases)
+  apply (frule (1) caps_of_state_valid_cap)
+  apply (clarsimp simp: valid_cap_simps cap_aligned_def)
+  apply (erule aligned_add_aligned)
+    apply (rule is_aligned_andI1)
+    apply (drule (1) valid_tcb_objs)
+    apply (clarsimp simp: valid_obj_def valid_tcb_def valid_ipc_buffer_cap_def
+                   split: if_splits)
+  apply (rule order_trans [OF _ pbfs_atleast_pageBits])
+  apply (simp add: msg_align_bits pageBits_def)
+  done
+
+lemma handle_arch_fault_reply_respects[Ipc_AC_assms]:
+  "\<lbrace>integrity aag X st and K (is_subject aag thread)\<rbrace>
+   handle_arch_fault_reply fault thread x y
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  by (wpsimp simp: handle_arch_fault_reply_def)
+
+lemma auth_ipc_buffers_kheap_update[Ipc_AC_assms]:
+  "\<lbrakk> x \<in> auth_ipc_buffers st thread; kheap st thread = Some (TCB tcb);
+     kheap s thread = Some (TCB tcb'); tcb_ipcframe tcb = tcb_ipcframe tcb' \<rbrakk>
+     \<Longrightarrow> x \<in> auth_ipc_buffers (s\<lparr>kheap := kheap s(thread \<mapsto> TCB tcb)\<rparr>) thread"
+  by (clarsimp simp: auth_ipc_buffers_member_def get_tcb_def caps_of_state_tcb)
+
+lemma auth_ipc_buffers_machine_state_update[Ipc_AC_assms, simp]:
+  "auth_ipc_buffers (machine_state_update f s) = auth_ipc_buffers s"
+  by (clarsimp simp: auth_ipc_buffers_def get_tcb_def)
+
+(* FIXME AC: handle_arch_fault_reply_typ_at is likely malformed, it actually proves invariance *)
+lemma handle_arch_fault_reply_integrity_tcb_in_fault_reply_TRFContext[Ipc_AC_assms, wp]:
+  "handle_arch_fault_reply vmf thread x y \<lbrace>integrity_tcb_in_fault_reply aag X thread TRFContext st\<rbrace>"
+  by (wp handle_arch_fault_reply_typ_at)
+
+end
+
+
+context is_extended begin interpretation Arch . (*FIXME: arch_split*)
+
+lemma list_integ_lift_in_ipc[Ipc_AC_assms]:
+  assumes li:
+   "\<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
+    f
+    \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace>"
+  assumes ekh: "\<And>P. \<lbrace>\<lambda>s. P (ekheap s)\<rbrace> f \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
+  assumes rq: "\<And>P. \<lbrace> \<lambda>s. P (ready_queues s) \<rbrace> f \<lbrace> \<lambda>rv s. P (ready_queues s) \<rbrace>"
+  shows "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and Q\<rbrace>
+         f
+         \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
+  apply (unfold integrity_tcb_in_ipc_def integrity_def[abs_def])
+  apply (simp del:split_paired_All)
+  apply (rule hoare_pre)
+   apply (simp only: integrity_cdt_list_as_list_integ)
+   apply (rule hoare_lift_Pf2[where f="ekheap"])
+    apply (simp add: tcb_states_of_state_def get_tcb_def)
+    apply (wp li[simplified tcb_states_of_state_def get_tcb_def] ekh rq)+
+  apply (simp only: integrity_cdt_list_as_list_integ)
+  apply (simp add: tcb_states_of_state_def get_tcb_def)
+  done
+
+end
+
+
+global_interpretation Ipc_AC_2?: Ipc_AC_2
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact Ipc_AC_assms)
+qed
+
+end

--- a/proof/access-control/ARM/ArchRetype_AC.thy
+++ b/proof/access-control/ARM/ArchRetype_AC.thy
@@ -1,0 +1,427 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchRetype_AC
+imports Retype_AC
+begin
+
+
+lemma invs_mdb_cte':
+  "invs s \<Longrightarrow> mdb_cte_at (\<lambda>p. \<exists>c. caps_of_state s p = Some c \<and> NullCap \<noteq> c) (cdt s)"
+  by (drule invs_mdb) (simp add: valid_mdb_def2)
+
+
+context retype_region_proofs begin interpretation Arch .
+
+lemma vs_refs_no_global_pts_default[simp]:
+  "vs_refs_no_global_pts (default_object ty dev us) = {}"
+  by (simp add: default_object_def default_arch_object_def tyunt
+                vs_refs_no_global_pts_def pde_ref2_def pte_ref_def
+                o_def
+         split: apiobject_type.splits aobject_type.splits)
+
+lemma vrefs_eq: "state_vrefs s' = state_vrefs s"
+  apply (rule ext)
+  apply (simp add: s'_def state_vrefs_def ps_def orthr split: option.split)
+  done
+
+end
+
+
+context retype_region_proofs' begin interpretation Arch .
+
+lemma pas_refined:
+  "\<lbrakk> invs s; pas_refined aag s \<rbrakk> \<Longrightarrow> pas_refined aag s'"
+  apply (erule pas_refined_state_objs_to_policy_subset)
+     apply (simp add: state_objs_to_policy_def refs_eq vrefs_eq mdb_and_revokable)
+     apply (rule subsetI, rename_tac x, case_tac x, simp)
+     apply (erule state_bits_to_policy.cases)
+            apply (solves \<open>auto intro!: sbta_caps intro: caps_retype split: cap.split\<close>)
+           apply (solves \<open>auto intro!: sbta_untyped intro: caps_retype split: cap.split\<close>)
+          apply (blast intro: state_bits_to_policy.intros)
+         apply (blast intro: state_bits_to_policy.intros)
+        apply (force intro!: sbta_cdt
+                       dest: caps_of_state_pres invs_mdb_cte'[THEN mdb_cte_atD[rotated]])
+       apply (force intro!: sbta_cdt_transferable
+                      dest: caps_of_state_pres invs_mdb_cte'[THEN mdb_cte_atD[rotated]])
+      apply (simp add: vrefs_eq)
+      apply (blast intro: state_bits_to_policy.intros)
+     apply (simp add: vrefs_eq)
+     apply (force elim!: state_asids_to_policy_aux.cases
+                 intro: state_asids_to_policy_aux.intros caps_retype
+                 split: cap.split
+                 dest: sata_asid[OF caps_retype, rotated])
+    apply clarsimp
+    apply (erule state_irqs_to_policy_aux.cases)
+    apply (solves\<open>auto intro!: sita_controlled intro: caps_retype split: cap.split\<close>)
+   apply (rule domains_of_state)
+  apply simp
+  done
+
+end
+
+
+context Arch begin global_naming ARM_A
+
+named_theorems Retype_AC_assms
+
+declare retype_region_proofs.vrefs_eq[Retype_AC_assms]
+declare retype_region_proofs'.pas_refined[Retype_AC_assms]
+
+crunch integrity_autarch: set_pd "integrity aag X st"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma store_pde_respects:
+  "\<lbrace>integrity aag X st and K (is_subject aag (p && ~~ mask pd_bits))\<rbrace>
+   store_pde p pde
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  by (wpsimp simp: store_pde_def wp: set_pd_integrity_autarch)
+
+(* Borrowed from part of copy_global_mappings_nonempty_table in Untyped_R.thy *)
+lemma copy_global_mappings_index_subset:
+  "set [kernel_base >> 20.e.2 ^ (pd_bits - 2) - 1] \<subseteq> {x. \<exists>y. x = y >> 20}"
+  apply clarsimp
+  apply (rule_tac x="x << 20" in exI)
+  apply (subst shiftl_shiftr1, simp)
+  apply (simp add: word_size)
+  apply (rule sym, rule less_mask_eq)
+  apply (simp add: word_leq_minus_one_le pd_bits_def pageBits_def)
+  done
+
+lemma copy_global_mappings_integrity:
+  "is_aligned x pd_bits
+   \<Longrightarrow> \<lbrace>integrity aag X st and K (is_subject aag x)\<rbrace>
+       copy_global_mappings x
+       \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (simp add: copy_global_mappings_def)
+  apply (wp mapM_x_wp[OF _ subset_refl] store_pde_respects)
+    apply (drule subsetD[OF copy_global_mappings_index_subset])
+    apply (fastforce simp: pd_shifting')
+   apply wpsimp+
+  done
+
+lemma state_vrefs_detype[Retype_AC_assms,simp]:
+  "state_vrefs (detype R s) = (\<lambda>x. if x \<in> R then {} else state_vrefs s x)"
+  unfolding state_vrefs_def
+  apply (rule ext)
+  apply (clarsimp simp: detype_def)
+  done
+
+lemma sata_detype[Retype_AC_assms]:
+  "state_asids_to_policy aag (detype R s) \<subseteq> state_asids_to_policy aag s"
+  apply (clarsimp)
+  apply (erule state_asids_to_policy_aux.induct)
+  apply (auto intro: state_asids_to_policy_aux.intros split: if_split_asm)
+  done
+
+lemma untyped_min_bits_ge_2[Retype_AC_assms]: "2 \<le> untyped_min_bits"
+  by (simp add: untyped_min_bits_def)
+
+lemma clas_default_cap[Retype_AC_assms]:
+  "tp \<noteq> ArchObject ASIDPoolObj \<Longrightarrow> cap_links_asid_slot aag p (default_cap tp p' sz dev)"
+  unfolding cap_links_asid_slot_def
+  apply (cases tp, simp_all)
+  apply (rename_tac aobject_type)
+  apply (case_tac aobject_type, simp_all add: arch_default_cap_def)
+  done
+
+lemma cli_default_cap[Retype_AC_assms]:
+  "tp \<noteq> ArchObject ASIDPoolObj \<Longrightarrow> cap_links_irq aag p (default_cap tp p' sz dev)"
+  unfolding cap_links_irq_def
+  apply (cases tp, simp_all)
+  done
+
+lemma aobj_refs'_default'[Retype_AC_assms]:
+  "is_aligned oref (obj_bits_api (ArchObject tp) sz)
+   \<Longrightarrow> aobj_ref' (arch_default_cap tp oref sz dev) \<subseteq> ptr_range oref (obj_bits_api (ArchObject tp) sz)"
+  by (cases tp; simp add: arch_default_cap_def ptr_range_memI obj_bits_api_def default_arch_object_def)
+
+lemma pd_shifting_dual':
+  "is_aligned (pd::word32) pd_bits
+   \<Longrightarrow> pd + (vptr >> 20 << 2) && mask pd_bits = vptr >> 20 << 2"
+  apply (subst (asm) pd_bits_def)
+  apply (subst (asm) pageBits_def)
+  apply (simp add: pd_shifting_dual)
+  done
+
+lemma empty_table_update_from_arm_global_pts:
+  "\<lbrakk>valid_global_objs s; kernel_base >> 20 \<le> y >> 20; y >> 20 \<le> 2 ^ (pd_bits - 2) - 1;
+    is_aligned pd pd_bits; obj_at (empty_table (set (second_level_tables (arch_state s)))) pd s;
+    kheap s (arm_global_pd (arch_state s)) = Some (ArchObj (PageDirectory pda)) \<rbrakk>
+    \<Longrightarrow> (\<forall>pdb. ko_at (ArchObj (PageDirectory pdb)) pd s
+               \<longrightarrow> empty_table (set (second_level_tables (arch_state s)))
+                               (ArchObj (PageDirectory (pdb(ucast (y >> 20) := pda (ucast (y >> 20)))))))"
+  by (clarsimp simp: obj_at_def valid_global_objs_def empty_table_def)
+
+lemma copy_global_mappings_pas_refined:
+  "is_aligned pd pd_bits
+   \<Longrightarrow> \<lbrace>pas_refined aag and valid_kernel_mappings and valid_arch_state
+                        and valid_global_objs and valid_global_refs and pspace_aligned\<rbrace>
+       copy_global_mappings pd
+       \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (simp add: copy_global_mappings_def)
+  apply (rule hoare_weaken_pre)
+  apply wp
+  (* Use \<circ> to avoid wp filtering out the global_pd condition here
+     TODO: see if we can clean this up *)
+    apply (rule_tac Q="\<lambda>rv s. is_aligned global_pd pd_bits \<and>
+                              (global_pd = (arm_global_pd \<circ> arch_state) s \<and>
+                               valid_kernel_mappings s \<and> valid_arch_state s \<and>
+                               valid_global_objs s \<and> valid_global_refs s \<and> pas_refined aag s)"
+                 in hoare_strengthen_post)
+  apply (rule mapM_x_wp[OF _ subset_refl])
+    apply (rule hoare_seq_ext)
+     apply (unfold o_def)
+     (* Use [1] so wp doesn't filter out the global_pd condition *)
+     apply (wp store_pde_pas_refined store_pde_valid_kernel_mappings_map_global)[1]
+     apply (frule subsetD[OF copy_global_mappings_index_subset])
+     apply (rule hoare_gen_asm[simplified K_def pred_conj_def conj_commute])
+     apply (simp add: get_pde_def)
+     apply (subst kernel_vsrefs_kernel_mapping_slots[symmetric])
+     apply wp
+     apply (clarsimp simp: get_pde_def pd_shifting' pd_shifting_dual' triple_shift_fun)
+     apply (subst (asm) obj_at_def, erule exE, erule conjE)
+     apply (rotate_tac -1, drule sym, simp)
+     apply (frule (1) valid_kernel_mappingsD[folded obj_at_def])
+     apply (clarsimp simp: kernel_mapping_slots_def shiftr_20_less pde_ref_def
+                           global_refs_def empty_table_update_from_arm_global_pts)
+     apply fastforce
+    apply fastforce
+   apply (rule gets_wp)
+  apply (simp, blast intro: invs_aligned_pdD)
+  done
+
+lemma copy_global_invs_mappings_restricted':
+  "pd \<in> S
+   \<Longrightarrow> \<lbrace>all_invs_but_equal_kernel_mappings_restricted S and (\<lambda>s. S \<inter> global_refs s = {})
+                                                        and K (is_aligned pd pd_bits)\<rbrace>
+       copy_global_mappings pd
+       \<lbrace>\<lambda>_. all_invs_but_equal_kernel_mappings_restricted S\<rbrace>"
+  apply (rule hoare_weaken_pre)
+  apply (rule copy_global_invs_mappings_restricted)
+  apply (simp add: insert_absorb)
+  done
+
+lemma init_arch_objects_pas_refined[Retype_AC_assms]:
+  "\<lbrace>pas_refined aag and post_retype_invs tp refs and (\<lambda>s. \<forall> x\<in>set refs. x \<notin> global_refs s)
+                    and K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api tp obj_sz))\<rbrace>
+   init_arch_objects tp ptr bits obj_sz refs
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (cases tp)
+       apply (simp_all add: init_arch_objects_def)
+       apply (wp | simp)+
+  apply (rename_tac aobject_type)
+  apply (case_tac aobject_type, simp_all)
+        apply ((simp | wp)+)[5]
+   apply wp
+    apply (rule_tac Q="\<lambda>rv. pas_refined aag and
+                            all_invs_but_equal_kernel_mappings_restricted (set refs) and
+                            (\<lambda>s. \<forall>x \<in> set refs. x \<notin> global_refs s)" in hoare_strengthen_post)
+     apply (wp mapM_x_wp[OF _ subset_refl])
+     apply ((wp copy_global_mappings_pas_refined copy_global_invs_mappings_restricted'
+                copy_global_mappings_global_refs_inv copy_global_invs_mappings_restricted'
+             | fastforce simp: obj_bits_api_def default_arch_object_def pd_bits_def pageBits_def)+)[2]
+   apply (wp dmo_invs hoare_vcg_const_Ball_lift valid_irq_node_typ
+         | fastforce simp: post_retype_invs_def)+
+  done
+
+lemma region_in_kernel_window_preserved:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows "\<And>S. f \<lbrace>region_in_kernel_window S\<rbrace>"
+  apply (clarsimp simp: valid_def region_in_kernel_window_def)
+  apply (erule use_valid)
+  apply (rule assms)
+  apply simp
+  done
+
+(* proof clagged from Retype_AI.clearMemory_vms *)
+lemma freeMemory_vms:
+  "valid_machine_state s \<Longrightarrow>
+   \<forall>x\<in>fst (freeMemory ptr bits (machine_state s)). valid_machine_state (s\<lparr>machine_state := snd x\<rparr>)"
+  apply (clarsimp simp: valid_machine_state_def disj_commute[of "in_user_frame p s" for p s])
+  apply (drule_tac x=p in spec, simp)
+  apply (drule_tac P4="\<lambda>m'. underlying_memory m' p = 0"
+                in use_valid[where P=P and Q="\<lambda>_. P" for P], simp_all)
+  apply (simp add: freeMemory_def machine_op_lift_def machine_rest_lift_def split_def)
+  apply (wp hoare_drop_imps | simp | wp mapM_x_wp_inv)+
+   apply (simp add: storeWord_def | wp)+
+   apply (simp add: word_rsplit_0)+
+  done
+
+lemma dmo_freeMemory_vms:
+  "do_machine_op (freeMemory ptr bits) \<lbrace>valid_machine_state\<rbrace>"
+  apply (unfold do_machine_op_def)
+  apply (wp modify_wp freeMemory_vms | simp add: split_def)+
+  done
+
+lemma freeMemory_valid_irq_states:
+  "freeMemory ptr bits \<lbrace>\<lambda>ms. valid_irq_states (s\<lparr>machine_state := ms\<rparr>)\<rbrace>"
+  unfolding freeMemory_def
+  by (wp mapM_x_wp[OF _ subset_refl] storeWord_valid_irq_states)
+
+crunch pspace_respects_device_region[wp]: freeMemory "\<lambda>ms. P (device_state ms)"
+  (wp: crunch_wps)
+
+lemma dmo_freeMemory_invs[Retype_AC_assms]:
+  "do_machine_op (freeMemory ptr bits) \<lbrace>invs\<rbrace>"
+  apply (simp add: do_machine_op_def invs_def valid_state_def cur_tcb_def | wp | wpc)+
+  apply (clarsimp)
+  apply (frule_tac P1="(=) (device_state (machine_state s))"
+                in use_valid[OF _ freeMemory_pspace_respects_device_region])
+   apply simp
+  apply simp
+  apply (rule conjI)
+   apply (erule use_valid[OF _ freeMemory_valid_irq_states], simp)
+  apply (drule freeMemory_vms)
+  apply auto
+  done
+
+crunch global_refs[wp]: delete_objects "\<lambda>s. P (global_refs s)"
+  (ignore: do_machine_op freeMemory)
+
+lemma init_arch_objects_pas_cur_domain[Retype_AC_assms, wp]:
+  "init_arch_objects tp ptr n us refs \<lbrace>pas_cur_domain aag\<rbrace>"
+  by wp
+
+lemma retype_region_pas_cur_domain[Retype_AC_assms, wp]:
+  "retype_region ptr n us tp dev \<lbrace>pas_cur_domain aag\<rbrace>"
+  by wp
+
+lemma reset_untyped_cap_pas_cur_domain[Retype_AC_assms, wp]:
+  "reset_untyped_cap src_slot \<lbrace>pas_cur_domain aag\<rbrace>"
+  by wp
+
+lemma arch_data_to_obj_type_not_ASIDPoolObj[Retype_AC_assms, simp]:
+  "arch_data_to_obj_type v \<noteq> Some ASIDPoolObj"
+  by (clarsimp simp: arch_data_to_obj_type_def)
+
+lemma data_to_nat_of_nat[Retype_AC_assms, simp]:
+  "of_nat (data_to_nat x) = x"
+  by simp
+
+lemma nonzero_data_to_nat_simp[Retype_AC_assms]:
+  "0 < data_to_nat x \<Longrightarrow> 0 < x"
+  by (auto dest: word_of_nat_less)
+
+lemma storeWord_integrity_autarch:
+  "\<lbrace>\<lambda>ms. integrity aag X st (s\<lparr>machine_state := ms\<rparr>) \<and>
+         (is_aligned p 2 \<longrightarrow> (\<forall>p' \<in> ptr_range p 2. is_subject aag p'))\<rbrace>
+   storeWord p v
+   \<lbrace>\<lambda>_ ms. integrity aag X st (s\<lparr>machine_state := ms\<rparr>)\<rbrace>"
+  unfolding storeWord_def
+  apply wp
+  apply (auto simp: integrity_def is_aligned_mask [symmetric]
+            intro!: trm_lrefl ptr_range_memI ptr_range_add_memI)
+  done
+
+(* TODO: proof has mainly been copied from dmo_clearMemory_respects *)
+lemma dmo_freeMemory_respects[Retype_AC_assms]:
+  "\<lbrace>integrity aag X st and K (is_aligned ptr bits \<and> bits < word_bits \<and> 2 \<le> bits \<and>
+                              (\<forall>p \<in> ptr_range ptr bits. is_subject aag p))\<rbrace>
+   do_machine_op (freeMemory ptr bits)
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  unfolding do_machine_op_def freeMemory_def
+  apply (simp add: split_def)
+  apply wp
+  apply clarsimp
+  apply (erule use_valid)
+   apply (wp mol_respects mapM_x_wp' storeWord_integrity_autarch)
+   apply simp
+   apply (clarsimp simp: word_size_def word_bits_def
+                         upto_enum_step_shift_red[where us=2, simplified])
+   apply (erule bspec)
+   apply (erule set_mp [rotated])
+   apply (rule ptr_range_subset)
+      apply simp
+     apply (simp add: is_aligned_mult_triv2 [where n = 2, simplified])
+    apply assumption
+   apply (erule word_less_power_trans_ofnat [where k = 2, simplified])
+    apply assumption
+   apply simp
+  apply simp
+  done
+
+lemma storeWord_respects:
+  "\<lbrace>\<lambda>ms. integrity aag X st (s\<lparr>machine_state := ms\<rparr>) \<and>
+         (\<forall>p' \<in> ptr_range p word_size_bits. aag_has_auth_to aag Write p')\<rbrace>
+   storeWord p v
+   \<lbrace>\<lambda>_ ms. integrity aag X st (s\<lparr>machine_state := ms\<rparr>)\<rbrace>"
+  unfolding storeWord_def word_size_bits_def
+  apply wp
+  apply (auto simp: integrity_def is_aligned_mask [symmetric]
+            intro!: trm_write ptr_range_memI ptr_range_add_memI)
+  done
+
+lemma dmo_clearMemory_respects'[Retype_AC_assms]:
+  "\<lbrace>integrity aag X st and
+    K (is_aligned ptr bits \<and> bits < word_bits \<and> 2 \<le> bits \<and>
+       (\<forall>p \<in> ptr_range ptr bits. aag_has_auth_to aag Write p))\<rbrace>
+   do_machine_op (clearMemory ptr (2 ^ bits))
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  unfolding do_machine_op_def clearMemory_def
+  apply (simp add: split_def cleanCacheRange_PoU_def)
+  apply wp
+  apply clarsimp
+  apply (erule use_valid)
+   apply wp
+    apply (simp add: cleanByVA_PoU_def)
+    apply (wp mol_respects mapM_x_wp' storeWord_respects)+
+   apply (simp add: word_size_bits_def)
+   apply (clarsimp simp: word_size_def word_bits_def upto_enum_step_shift_red[where us=2, simplified])
+   apply (erule bspec)
+   apply (erule set_mp [rotated])
+   apply (rule ptr_range_subset)
+      apply simp
+     apply (simp add: is_aligned_mult_triv2 [where n = 2, simplified])
+    apply assumption
+   apply (erule word_less_power_trans_ofnat [where k = 2, simplified])
+    apply assumption
+   apply simp
+  apply simp
+  done
+
+lemma dmo_cacheRangeOp_lift:
+  "(\<And>a b. do_machine_op (oper a b) \<lbrace>P\<rbrace>)
+   \<Longrightarrow> do_machine_op (cacheRangeOp oper x y z) \<lbrace>P\<rbrace>"
+  by (wpsimp wp: dmo_mapM_x_wp_inv simp: cacheRangeOp_def)
+
+lemma dmo_cleanCacheRange_PoU_respects [wp]:
+  "do_machine_op (cleanCacheRange_PoU vstart vend pstart) \<lbrace>integrity aag X st\<rbrace>"
+  by (wpsimp wp: dmo_cacheRangeOp_lift simp: cleanCacheRange_PoU_def cleanByVA_PoU_def)
+
+lemma dmo_mapM_x_cleanCacheRange_PoU_integrity:
+  "do_machine_op (mapM_x (\<lambda>x. cleanCacheRange_PoU (f x) (g x) (h x)) refs) \<lbrace>integrity aag X st\<rbrace>"
+  by (wp dmo_mapM_x_wp_inv)
+
+lemma init_arch_objects_integrity[Retype_AC_assms]:
+  "\<lbrace>integrity aag X st and K (\<forall>x\<in>set refs. is_subject aag x)
+                       and K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api new_type obj_sz))\<rbrace>
+   init_arch_objects new_type ptr num_objects obj_sz refs
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (rule hoare_gen_asm)+
+  apply (cases new_type; simp add: init_arch_objects_def split del: if_split)
+  apply (wpsimp wp: mapM_x_wp[OF _ subset_refl] copy_global_mappings_integrity
+                    dmo_mapM_x_cleanCacheRange_PoU_integrity
+              simp: obj_bits_api_def default_arch_object_def pd_bits_def pageBits_def)
+  done
+
+end
+
+
+global_interpretation Retype_AC_1?: Retype_AC_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact Retype_AC_assms)
+qed
+
+
+requalify_facts
+  ARM_A.storeWord_respects
+
+end

--- a/proof/access-control/ARM/ArchSyscall_AC.thy
+++ b/proof/access-control/ARM/ArchSyscall_AC.thy
@@ -1,0 +1,183 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchSyscall_AC
+imports
+  Syscall_AC
+begin
+
+context Arch begin global_naming ARM_A
+
+named_theorems Syscall_AC_assms
+
+declare prepare_thread_delete_idle_thread[Syscall_AC_assms]
+declare arch_finalise_cap_idle_thread[Syscall_AC_assms]
+declare cap_move_idle_thread[Syscall_AC_assms]
+declare cancel_badged_sends_idle_thread[Syscall_AC_assms]
+
+lemma invs_irq_state_update[Syscall_AC_assms, simp]:
+  "invs (s\<lparr>machine_state := irq_state_update f sa\<rparr>) = invs (s\<lparr>machine_state := sa\<rparr>)"
+  apply (rule iffI)
+   apply (subst invs_irq_state_independent[symmetric])
+   apply (subst ARM.fold_congs(2); fastforce)
+  apply (subst (asm) invs_irq_state_independent[symmetric])
+  apply (subst ARM.fold_congs(2); fastforce)
+  done
+
+crunches prepare_thread_delete, arch_finalise_cap
+  for cur_thread[Syscall_AC_assms, wp]: "\<lambda>s. P (cur_thread s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+crunches set_original
+  for idle_thread[wp]: "\<lambda>s. P (idle_thread s)"
+  and cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
+
+lemma cap_move_cur_thread[Syscall_AC_assms, wp]:
+  "cap_move new_cap src_slot dest_slot \<lbrace>\<lambda>s. P (cur_thread s)\<rbrace>"
+  unfolding cap_move_def
+  by (wpsimp wp: dxo_wp_weak)
+
+lemma cancel_badged_sends_cur_thread[Syscall_AC_assms, wp]:
+  "cancel_badged_sends epptr badge \<lbrace>\<lambda>s. P (cur_thread s)\<rbrace>"
+  unfolding cancel_badged_sends_def
+  by (wpsimp wp: dxo_wp_weak filterM_preserved crunch_wps)
+
+lemma state_vrefs_cur_thread_update[Syscall_AC_assms, simp]:
+  "state_vrefs (cur_thread_update f s) = state_vrefs s"
+  by (simp add: state_vrefs_def)
+
+crunches arch_mask_irq_signal, handle_reserved_irq
+  for pas_refined[Syscall_AC_assms, wp]: "pas_refined aag"
+
+crunches handle_hypervisor_fault
+  for pas_refined[Syscall_AC_assms, wp]: "pas_refined aag"
+  and cur_thread[Syscall_AC_assms, wp]: "\<lambda>s. P (cur_thread s)"
+  and integrity[Syscall_AC_assms, wp]: "integrity aag X st"
+
+crunches handle_vm_fault
+  for pas_refined[Syscall_AC_assms, wp]: "pas_refined aag"
+  and cur_thread[Syscall_AC_assms, wp]: "\<lambda>s. P (cur_thread s)"
+  and state_refs_of[Syscall_AC_assms, wp]: "\<lambda>s. P (state_refs_of s)"
+
+lemma handle_vm_fault_integrity[Syscall_AC_assms]:
+  "\<lbrace>integrity aag X st and K (is_subject aag thread)\<rbrace>
+   handle_vm_fault thread vmfault_type
+   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  apply (cases vmfault_type, simp_all)
+  apply (rule hoare_pre)
+  apply (wp as_user_integrity_autarch dmo_wp | simp add: getDFSR_def getFAR_def getIFSR_def)+
+  done
+
+crunches ackInterrupt, resetTimer
+  for underlying_memory_inv[Syscall_AC_assms, wp]: "\<lambda>s. P (underlying_memory s)"
+  (simp: maskInterrupt_def)
+
+(* FIXME AC: will probably break on ARM_HYP.handle_reserved_irq *)
+crunches arch_mask_irq_signal, handle_reserved_irq
+  for integrity[Syscall_AC_assms, wp]: "integrity aag X st"
+  (wp: dmo_no_mem_respects)
+
+lemma set_thread_state_restart_to_running_respects[Syscall_AC_assms]:
+  "\<lbrace>integrity aag X st and st_tcb_at ((=) Restart) thread and K (pasMayActivate aag)\<rbrace>
+   do pc \<leftarrow> as_user thread getRestartPC;
+            as_user thread $ setNextPC pc;
+            set_thread_state thread Structures_A.thread_state.Running
+   od
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: set_thread_state_def as_user_def split_def setNextPC_def
+                   getRestartPC_def setRegister_def bind_assoc getRegister_def)
+  apply (wpsimp wp: set_object_wp)
+  apply (clarsimp simp: in_monad fun_upd_def[symmetric] cong: if_cong)
+  apply (cases "is_subject aag thread")
+   apply (cut_tac aag=aag in integrity_update_autarch, simp+)
+  apply (erule integrity_trans)
+  apply (clarsimp simp: integrity_def obj_at_def st_tcb_at_def)
+  apply (clarsimp dest!: get_tcb_SomeD)
+  apply (rule_tac tro_tcb_activate[OF refl refl])
+    apply (simp add: tcb_bound_notification_reset_integrity_def ctxt_IP_update_def)+
+  done
+
+lemma getActiveIRQ_inv[Syscall_AC_assms]:
+  "\<forall>f s. P s \<longrightarrow> P (irq_state_update f s) \<Longrightarrow>
+   \<lbrace>P\<rbrace> getActiveIRQ irq \<lbrace>\<lambda>rv. P\<rbrace>"
+  by (wpsimp simp: irq_state_independent_def)
+
+lemma getActiveIRQ_rv_None[Syscall_AC_assms]:
+  "\<lbrace>\<top>\<rbrace> getActiveIRQ True \<lbrace>\<lambda>rv ms. (rv \<noteq> None \<longrightarrow> the rv \<notin> non_kernel_IRQs)\<rbrace>"
+  by (wpsimp simp: getActiveIRQ_def)
+
+lemma arch_activate_idle_thread_respects[Syscall_AC_assms, wp]:
+  "arch_activate_idle_thread t \<lbrace>integrity aag X st\<rbrace>"
+  unfolding arch_activate_idle_thread_def by wpsimp
+
+lemma arch_activate_idle_thread_pas_refined[Syscall_AC_assms, wp]:
+  "arch_activate_idle_thread t \<lbrace>pas_refined aag\<rbrace>"
+  unfolding arch_activate_idle_thread_def by wpsimp
+
+lemma integrity_exclusive_state_update[Syscall_AC_assms, simp]:
+  "integrity aag X st (s\<lparr>machine_state := exclusive_state_update f (machine_state s)\<rparr>) =
+   integrity aag X st s"
+  unfolding integrity_def by simp
+
+lemma dmo_clearExMonitor_respects_globals[Syscall_AC_assms, wp]:
+  "do_machine_op clearExMonitor \<lbrace>integrity aag X st\<rbrace>"
+  by (wpsimp wp: dmo_wp simp: clearExMonitor_def)
+
+lemma arch_switch_to_thread_respects[Syscall_AC_assms, wp]:
+  "arch_switch_to_thread t \<lbrace>integrity aag X st\<rbrace>"
+  unfolding arch_switch_to_thread_def by wpsimp
+
+lemma arch_switch_to_thread_pas_refined[Syscall_AC_assms, wp]:
+  "arch_switch_to_thread t \<lbrace>pas_refined aag\<rbrace>"
+  unfolding arch_switch_to_thread_def by wpsimp
+
+lemma arch_switch_to_idle_thread_respects[Syscall_AC_assms, wp]:
+  "arch_switch_to_idle_thread \<lbrace>integrity aag X st\<rbrace>"
+  unfolding arch_switch_to_idle_thread_def by wpsimp
+
+lemma arch_switch_to_idle_thread_pas_refined[Syscall_AC_assms, wp]:
+  "arch_switch_to_idle_thread \<lbrace>pas_refined aag\<rbrace>"
+  unfolding arch_switch_to_idle_thread_def by wpsimp
+
+lemma arch_mask_irq_signal_arch_state[Syscall_AC_assms, wp]:
+  "arch_mask_irq_signal irq \<lbrace>\<lambda>s :: det_ext state. P (arch_state s)\<rbrace>"
+  by wpsimp
+
+lemma handle_reserved_irq_arch_state[Syscall_AC_assms, wp]:
+  "handle_reserved_irq irq \<lbrace>\<lambda>s :: det_ext state. P (arch_state s)\<rbrace>"
+  unfolding handle_reserved_irq_def by wpsimp
+
+crunch arch_state[Syscall_AC_assms, wp]: init_arch_objects "\<lambda>s. P (arch_state s)"
+  (wp: crunch_wps)
+
+crunch ct_active [Syscall_AC_assms, wp]: arch_post_cap_deletion "ct_active"
+  (wp: crunch_wps filterM_preserved hoare_unless_wp
+   simp: crunch_simps ignore: do_extended_op)
+
+crunches
+  arch_post_modify_registers, arch_invoke_irq_control,
+  arch_invoke_irq_handler, arch_perform_invocation, arch_mask_irq_signal,
+  handle_reserved_irq, handle_vm_fault, handle_hypervisor_fault, handle_arch_fault_reply
+  for cur_thread[Syscall_AC_assms, wp]: "\<lambda>s. P (cur_thread s)"
+  and idle_thread[Syscall_AC_assms, wp]: "\<lambda>s. P (idle_thread s)"
+  and cur_domain[Syscall_AC_assms, wp]:  "\<lambda>s. P (cur_domain s)"
+  (wp: crunch_wps)
+
+\<comment> \<open>These aren't proved in the previous crunch, and hence need to be declared\<close>
+declare handle_arch_fault_reply_cur_thread[Syscall_AC_assms]
+declare handle_arch_fault_reply_it[Syscall_AC_assms]
+
+end
+
+
+global_interpretation Syscall_AC_1?: Syscall_AC_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact Syscall_AC_assms)
+qed
+
+end

--- a/proof/access-control/ARM/ArchTcb_AC.thy
+++ b/proof/access-control/ARM/ArchTcb_AC.thy
@@ -1,0 +1,103 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchTcb_AC
+imports Tcb_AC
+begin
+
+context Arch begin global_naming ARM_A
+
+named_theorems Tcb_AC_assms
+
+crunches arch_post_modify_registers
+  for pas_refined[Tcb_AC_assms, wp]: "pas_refined aag"
+
+crunches arch_get_sanitise_register_info
+  for inv[Tcb_AC_assms, wp]: P
+
+lemma arch_post_modify_registers_respects[Tcb_AC_assms]:
+  "\<lbrace>integrity aag X st and K (is_subject aag t)\<rbrace>
+   arch_post_modify_registers cur t
+   \<lbrace>\<lambda>_ s. integrity aag X st s\<rbrace>"
+  by wpsimp
+
+lemma invoke_tcb_tc_respects_aag[Tcb_AC_assms]:
+  "\<lbrace>integrity aag X st and pas_refined aag and einvs and simple_sched_action
+                       and tcb_inv_wf (ThreadControl t sl ep mcp priority croot vroot buf)
+                       and K (authorised_tcb_inv aag (ThreadControl t sl ep mcp priority croot vroot buf))\<rbrace>
+   invoke_tcb (ThreadControl t sl ep mcp priority croot vroot buf)
+   \<lbrace>\<lambda>_. integrity aag X st and pas_refined aag\<rbrace>"
+  apply (rule hoare_gen_asm)+
+  apply (subst invoke_tcb.simps)
+  apply (subst set_priority_extended.dxo_eq)
+  apply (rule hoare_vcg_precond_imp)
+   apply (rule_tac P="case ep of Some v \<Rightarrow> length v = word_bits | _ \<Rightarrow> True"
+                 in hoare_gen_asm)
+   apply (simp only: split_def)
+  apply ((simp add: conj_comms del: hoare_True_E_R,
+          strengthen imp_consequent[where Q="x = None" for x], simp cong: conj_cong)
+         | rule wp_split_const_if wp_split_const_if_R hoare_vcg_all_lift_R
+                hoare_vcg_E_elim hoare_vcg_const_imp_lift_R hoare_vcg_R_conj
+         | wp restart_integrity_autarch set_mcpriority_integrity_autarch
+              as_user_integrity_autarch thread_set_integrity_autarch
+              option_update_thread_integrity_autarch
+              opt_update_thread_valid_sched static_imp_wp
+              cap_insert_integrity_autarch checked_insert_pas_refined
+              cap_delete_respects' cap_delete_pas_refined'
+              check_cap_inv2[where Q="\<lambda>_. integrity aag X st"]
+              as_user_pas_refined restart_pas_refined
+              thread_set_pas_refined
+              option_update_thread_pas_refined
+              out_invs_trivial case_option_wpE cap_delete_deletes
+              cap_delete_valid_cap cap_insert_valid_cap out_cte_at
+              cap_insert_cte_at cap_delete_cte_at out_valid_cap out_tcb_valid
+              hoare_vcg_const_imp_lift_R hoare_vcg_all_lift_R
+              thread_set_tcb_ipc_buffer_cap_cleared_invs
+              thread_set_invs_trivial[OF ball_tcb_cap_casesI]
+              hoare_vcg_all_lift thread_set_valid_cap out_emptyable
+              check_cap_inv[where P="valid_cap c" for c]
+              check_cap_inv[where P="tcb_cap_valid c p" for c p]
+              check_cap_inv[where P="cte_at p0" for p0]
+              check_cap_inv[where P="tcb_at p0" for p0]
+              check_cap_inv[where P="simple_sched_action"]
+              check_cap_inv[where P="valid_list"]
+              check_cap_inv[where P="valid_sched"]
+              thread_set_cte_at
+              thread_set_cte_wp_at_trivial[where Q="\<lambda>x. x", OF ball_tcb_cap_casesI]
+              thread_set_no_cap_to_trivial[OF ball_tcb_cap_casesI]
+              checked_insert_no_cap_to
+              out_no_cap_to_trivial[OF ball_tcb_cap_casesI]
+              thread_set_ipc_tcb_cap_valid
+              cap_delete_pas_refined'[THEN valid_validE_E] thread_set_cte_wp_at_trivial
+         | simp add: ran_tcb_cap_cases dom_tcb_cap_cases[simplified]
+                     emptyable_def a_type_def partial_inv_def
+                del: hoare_True_E_R
+         | wpc
+         | strengthen invs_mdb use_no_cap_to_obj_asid_strg
+                      tcb_cap_always_valid_strg[where p="tcb_cnode_index 0"]
+                      tcb_cap_always_valid_strg[where p="tcb_cnode_index (Suc 0)"])+
+  apply (clarsimp simp: authorised_tcb_inv_def)
+  apply (clarsimp simp: tcb_at_cte_at_0 tcb_at_cte_at_1[simplified]
+                        is_cap_simps is_valid_vtable_root_def
+                        is_cnode_or_valid_arch_def tcb_cap_valid_def
+                        tcb_at_st_tcb_at[symmetric] invs_valid_objs
+                        cap_asid_def vs_cap_ref_def
+                        clas_no_asid cli_no_irqs
+                        emptyable_def
+         | rule conjI | erule pas_refined_refl)+
+  done
+
+end
+
+
+global_interpretation Tcb_AC_1?: Tcb_AC_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; fact Tcb_AC_assms)
+qed
+
+end

--- a/proof/access-control/ARM/ArchTypes.thy
+++ b/proof/access-control/ARM/ArchTypes.thy
@@ -1,0 +1,17 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchTypes
+imports Deterministic_AC
+begin
+
+section \<open>Policy and policy refinement\<close>
+
+subsection \<open>Arch-specific definitions\<close>
+
+datatype arch_auth = ASIDPoolMapsASID
+
+end

--- a/proof/access-control/ARM/ExampleSystem.thy
+++ b/proof/access-control/ARM/ExampleSystem.thy
@@ -5,7 +5,7 @@
  *)
 
 theory ExampleSystem
-imports Access
+imports ArchAccess_AC
 begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)
@@ -550,11 +550,11 @@ declare AllowSend_def[simp] AllowRecv_def[simp]
 
 lemma domains_of_state_s1[simp]:
   "domains_of_state s1 = {}"
-  apply(rule equalityI)
-   apply(rule subsetI)
+  apply (rule equalityI)
+   apply (rule subsetI)
    apply clarsimp
-   apply(erule domains_of_state_aux.induct)
-   apply(simp add: s1_def exst1_def)
+   apply (erule domains_of_state_aux.induct)
+   apply (simp add: s1_def exst1_def)
   apply simp
   done
 
@@ -1054,11 +1054,11 @@ lemma Sys2AgentMap_simps:
 
 lemma domains_of_state_s2[simp]:
   "domains_of_state s2 = {}"
-  apply(rule equalityI)
-   apply(rule subsetI)
+  apply (rule equalityI)
+   apply (rule subsetI)
    apply clarsimp
-   apply(erule domains_of_state_aux.induct)
-   apply(simp add: s2_def exst1_def)
+   apply (erule domains_of_state_aux.induct)
+   apply (simp add: s2_def exst1_def)
   apply simp
   done
 

--- a/proof/access-control/Access.thy
+++ b/proof/access-control/Access.thy
@@ -38,7 +38,7 @@ the grant bit set.
 
 type_synonym 'a agent_map = "obj_ref \<Rightarrow> 'a"
 type_synonym 'a agent_asid_map = "asid \<Rightarrow> 'a"
-type_synonym 'a agent_irq_map = "10 word \<Rightarrow> 'a"
+type_synonym 'a agent_irq_map = "irq \<Rightarrow> 'a"
 type_synonym 'a agent_domain_map = "domain \<Rightarrow> 'a set"
 
 text\<open>
@@ -122,7 +122,7 @@ given pointer.
 
 \<close>
 
-abbreviation is_subject :: "'a PAS \<Rightarrow> word32 \<Rightarrow> bool"
+abbreviation is_subject :: "'a PAS \<Rightarrow> obj_ref \<Rightarrow> bool"
 where
   "is_subject aag ptr \<equiv> pasObjectAbs aag ptr = pasSubject aag"
 
@@ -133,7 +133,7 @@ pointer that he doesn't own but has some authority to.
 
 \<close>
 
-abbreviation(input) aag_has_auth_to :: "'a PAS \<Rightarrow> auth \<Rightarrow> word32 \<Rightarrow> bool"
+abbreviation(input) aag_has_auth_to :: "'a PAS \<Rightarrow> auth \<Rightarrow> obj_ref \<Rightarrow> bool"
 where
   "aag_has_auth_to aag auth ptr \<equiv> (pasSubject aag, auth, pasObjectAbs aag ptr) \<in> pasPolicy aag"
 
@@ -1054,7 +1054,7 @@ lemma cnode_integrityE:
   using hyp cnode_integrityD by blast
 
 definition asid_pool_integrity ::
-  "'a set \<Rightarrow> 'a PAS \<Rightarrow> (10 word \<rightharpoonup> obj_ref) \<Rightarrow> (10 word \<rightharpoonup> obj_ref) \<Rightarrow> bool"
+  "'a set \<Rightarrow> 'a PAS \<Rightarrow> (asid_low_index \<rightharpoonup> obj_ref) \<Rightarrow> (asid_low_index \<rightharpoonup> obj_ref) \<Rightarrow> bool"
   where
   "asid_pool_integrity subjects aag pool pool' \<equiv>
    \<forall>x. pool' x \<noteq> pool x \<longrightarrow> pool' x = None
@@ -1515,7 +1515,7 @@ where
 
 subsection \<open>auth_ipc_buffer\<close>
 
-definition auth_ipc_buffers :: "'z::state_ext state \<Rightarrow> word32 \<Rightarrow> word32 set"
+definition auth_ipc_buffers :: "'z::state_ext state \<Rightarrow> obj_ref \<Rightarrow> obj_ref set"
 where
   "auth_ipc_buffers s \<equiv>
      \<lambda>p. case (get_tcb p s) of
@@ -1688,7 +1688,7 @@ text\<open>
   v' = (final parent of ptr, final "originality" of ptr)
 \<close>
 definition integrity_cdt
-  :: "'a PAS \<Rightarrow> 'a set \<Rightarrow> cdt \<Rightarrow> (32 word \<Rightarrow> thread_state option)
+  :: "'a PAS \<Rightarrow> 'a set \<Rightarrow> cdt \<Rightarrow> (obj_ref \<Rightarrow> thread_state option)
        \<Rightarrow> cslot_ptr \<Rightarrow> (cslot_ptr option \<times> bool) \<Rightarrow> (cslot_ptr option \<times> bool) \<Rightarrow> bool"
 where
   "integrity_cdt aag subjects m tcbsts ptr v v'
@@ -1735,7 +1735,7 @@ text\<open>
   l and l' are the initial and final list of children of ptr
 \<close>
 definition integrity_cdt_list
-  :: "'a PAS \<Rightarrow> 'a set \<Rightarrow> cdt \<Rightarrow> (32 word \<Rightarrow> thread_state option) \<Rightarrow> cslot_ptr \<Rightarrow>
+  :: "'a PAS \<Rightarrow> 'a set \<Rightarrow> cdt \<Rightarrow> (obj_ref \<Rightarrow> thread_state option) \<Rightarrow> cslot_ptr \<Rightarrow>
       (cslot_ptr list) \<Rightarrow> (cslot_ptr list) \<Rightarrow> bool"
 where
   "integrity_cdt_list aag subjects m tcbsts ptr l l'
@@ -1788,7 +1788,7 @@ where
 lemma integrity_interrupts_refl[simp]: "integrity_interrupts aag subjects ptr v v"
   by (simp add: integrity_interrupts_def)
 
-definition integrity_asids :: "'a PAS \<Rightarrow> 'a set \<Rightarrow> asid \<Rightarrow> word32 option \<Rightarrow> word32 option \<Rightarrow> bool"
+definition integrity_asids :: "'a PAS \<Rightarrow> 'a set \<Rightarrow> asid \<Rightarrow> obj_ref option \<Rightarrow> obj_ref option \<Rightarrow> bool"
 where
   "integrity_asids aag subjects asid pp_opt pp_opt'
      \<equiv> pp_opt = pp_opt' \<or> (\<forall> asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of asid \<longrightarrow> pasASIDAbs aag asid' \<in> subjects)"

--- a/proof/access-control/Access.thy
+++ b/proof/access-control/Access.thy
@@ -5,150 +5,8 @@
  *)
 
 theory Access
-imports Deterministic_AC
+imports ArchAccess
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-section \<open>Policy and policy refinement\<close>
-
-subsection \<open>Policy definition\<close>
-
-text\<open>
-
-The goal is to place limits on what untrusted agents can do while the
-trusted agents are not running. This supports a framing constraint in
-the descriptions (Hoare triples) of syscalls. Roughly the existing
-proofs show the effect of the syscall, and this proof summarises what
-doesn't (or isn't allowed to) change.
-
-The basic intuition is to map all object references to the agent they
-belong to and show that changes to the object reference graph are
-allowed by the policy specified by the user. The policy is a labelled
-graph amongst agents independent of the current state, i.e. a static
-external summary of what should be talking to what and how.
-
-The interesting cases occur between trusted and untrusted components:
-e.g. we assume that it is unsafe for untrusted components (UT)
-to send capabilities to trusted components (T), and so T must ensure
-that all endpoints it shares with UT that it receives on do not have
-the grant bit set.
-
-\<close>
-
-type_synonym 'a agent_map = "obj_ref \<Rightarrow> 'a"
-type_synonym 'a agent_asid_map = "asid \<Rightarrow> 'a"
-type_synonym 'a agent_irq_map = "irq \<Rightarrow> 'a"
-type_synonym 'a agent_domain_map = "domain \<Rightarrow> 'a set"
-
-text\<open>
-
-What one agent can do to another. We allow multiple edges between
-agents in the graph.
-
-Control is special. It implies the ability to do pretty much anything,
-including get access the other rights, create, remove, etc.
-
-DeleteDerived allows you to delete a cap derived from a cap you own
-\<close>
-
-datatype auth = Control | Receive | SyncSend | Notify
-                    | Reset | Grant | Call | Reply | Write | Read
-                    | ASIDPoolMapsASID | DeleteDerived
-
-text\<open>
-
-The interesting case is for endpoints.
-
-Consider an EP between T and UT (across a trust boundary). We want to
-be able to say that all EPs and tcbs that T does not expose to UT do
-not change when it is not running. If UT had a direct Send right to T
-then integrity (see below) could not guarantee this, as it doesn't
-know which EP can be changed by UT. Thus we set things up like this
-(all distinct labels):
-
-T -Receive-> EP <-Send- UT
-
-Now UT can interfere with EP and all of T's tcbs blocked for receive on EP,
-but not endpoints internal to T, or tcbs blocked on other (suitably
-labelled) EPs, etc.
-
-\<close>
-
-type_synonym 'a auth_graph = "('a \<times> auth \<times> 'a) set"
-
-text \<open>
-
-Each global namespace will need a labeling function.
-
-We map each scheduling domain to a single label; concretely, each tcb
-in a scheduling domain has to have the same label. We will want to
-weaken this in the future.
-
-The booleans @{text pasMayActivate} and @{text pasMayEditReadyQueues}
-are used to weaken the integrity property. When @{const True},
-@{text pasMayActivate} causes the integrity property to permit
-activation of newly-scheduled threads. Likewise, @{text pasMayEditReadyQueues}
-has the integrity property permit the removal of threads from ready queues,
-as occurs when scheduling a new domain for instance. By setting each of these
-@{const False} we get a more constrained integrity property that is useful for
-establishing some of the proof obligations for the infoflow proofs, particularly
-those over @{const handle_event} that neither activates new threads nor schedules
-new domains.
-
-The @{text pasDomainAbs} relation describes which labels may run in
-a given scheduler domain. This relation is not relevant to integrity
-but will be used in the information flow theory (with additional
-constraints on its structure).
-\<close>
-
-end
-
-record 'a PAS =
-  pasObjectAbs :: "'a agent_map"
-  pasASIDAbs :: "'a agent_asid_map"
-  pasIRQAbs :: "'a agent_irq_map"
-  pasPolicy :: "'a auth_graph"
-  pasSubject :: "'a"                \<comment> \<open>The active label\<close>
-  pasMayActivate :: "bool"
-  pasMayEditReadyQueues :: "bool"
-  pasMaySendIrqs :: "bool"
-  pasDomainAbs :: "'a agent_domain_map"
-
-text\<open>
-
-Very often we want to say that the agent currently running owns a
-given pointer.
-
-\<close>
-
-abbreviation is_subject :: "'a PAS \<Rightarrow> obj_ref \<Rightarrow> bool"
-where
-  "is_subject aag ptr \<equiv> pasObjectAbs aag ptr = pasSubject aag"
-
-text\<open>
-
-Also we often want to say the current agent can do something to a
-pointer that he doesn't own but has some authority to.
-
-\<close>
-
-abbreviation(input) aag_has_auth_to :: "'a PAS \<Rightarrow> auth \<Rightarrow> obj_ref \<Rightarrow> bool"
-where
-  "aag_has_auth_to aag auth ptr \<equiv> (pasSubject aag, auth, pasObjectAbs aag ptr) \<in> pasPolicy aag"
-
-abbreviation aag_subjects_have_auth_to_label :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> auth \<Rightarrow> 'a \<Rightarrow> bool"
-where
- "aag_subjects_have_auth_to_label subs aag auth label
-    \<equiv> \<exists>s \<in> subs. (s, auth, label) \<in> pasPolicy aag"
-
-abbreviation aag_subjects_have_auth_to :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> auth \<Rightarrow> obj_ref \<Rightarrow> bool"
-where
- "aag_subjects_have_auth_to subs aag auth oref
-    \<equiv> aag_subjects_have_auth_to_label subs aag auth (pasObjectAbs aag oref)"
-
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 subsection \<open>Policy wellformedness\<close>
 
@@ -186,83 +44,25 @@ Wellformedness of the agent authority function with respect to a label
 
 \<close>
 
-definition policy_wellformed
-where
+definition policy_wellformed where
   "policy_wellformed aag maySendIrqs irqs agent \<equiv>
      (\<forall>agent'. (agent, Control, agent') \<in> aag \<longrightarrow> agent = agent')
    \<and> (\<forall>a. (agent, a, agent) \<in> aag)
    \<and> (\<forall>s r ep. (s, Grant, ep) \<in> aag \<and> (r, Receive, ep) \<in> aag
-              \<longrightarrow> (s, Control, r) \<in> aag \<and> (r, Control, s) \<in> aag)
+                \<longrightarrow> (s, Control, r) \<in> aag \<and> (r, Control, s) \<in> aag)
    \<and> (maySendIrqs \<longrightarrow> (\<forall>irq ntfn. irq \<in> irqs \<and> (irq, Notify, ntfn) \<in> aag
-                  \<longrightarrow> (agent, Notify, ntfn) \<in> aag))
+                                  \<longrightarrow> (agent, Notify, ntfn) \<in> aag))
    \<and> (\<forall>s ep. (s, Call, ep) \<in> aag \<longrightarrow> (s, SyncSend, ep) \<in> aag)
    \<and> (\<forall>s r ep. (s, Call, ep) \<in> aag \<and> (r, Receive, ep) \<in> aag \<longrightarrow> (r, Reply, s) \<in> aag)
    \<and> (\<forall>s r. (s, Reply, r) \<in> aag \<longrightarrow> (r, DeleteDerived, s) \<in> aag)
    \<and> (\<forall>l1 l2 l3. (l1, DeleteDerived, l2) \<in> aag \<longrightarrow> (l2, DeleteDerived, l3) \<in> aag
-             \<longrightarrow> (l1, DeleteDerived, l3) \<in> aag)
+                  \<longrightarrow> (l1, DeleteDerived, l3) \<in> aag)
    \<and> (\<forall>s r ep. (s, Call, ep) \<in> aag \<and> (r, Receive, ep) \<in> aag \<and> (r, Grant, ep) \<in> aag
-              \<longrightarrow> (s, Control, r) \<in> aag \<and> (r, Control, s) \<in> aag)"
+                \<longrightarrow> (s, Control, r) \<in> aag \<and> (r, Control, s) \<in> aag)"
 
-abbreviation pas_wellformed
-where
+abbreviation pas_wellformed where
   "pas_wellformed aag \<equiv>
-    policy_wellformed (pasPolicy aag) (pasMaySendIrqs aag) (range (pasIRQAbs aag)) (pasSubject aag)"
-
-lemma aag_wellformed_Control:
-  "\<lbrakk>  (x, Control, y) \<in> aag; policy_wellformed aag mirqs irqs x \<rbrakk> \<Longrightarrow> x = y"
-  unfolding policy_wellformed_def by metis
-
-lemma aag_wellformed_refl:
-  "\<lbrakk> policy_wellformed aag mirqs irqs x \<rbrakk> \<Longrightarrow> (x, a, x) \<in> aag"
-  unfolding policy_wellformed_def by blast
-
-lemma aag_wellformed_grant_Control_to_recv:
-  "\<lbrakk> (s, Grant, ep) \<in> aag; (r, Receive, ep) \<in> aag; policy_wellformed aag mirqs irqs l\<rbrakk>
-        \<Longrightarrow> (s, Control, r) \<in> aag"
-  unfolding policy_wellformed_def by blast
-
-lemma aag_wellformed_grant_Control_to_send:
-  "\<lbrakk> (s, Grant, ep) \<in> aag; (r, Receive, ep) \<in> aag; policy_wellformed aag mirqs irqs l\<rbrakk>
-        \<Longrightarrow> (r, Control, s) \<in> aag"
-  unfolding policy_wellformed_def by blast
-
-lemma aag_wellformed_reply:
-  "\<lbrakk> (s, Call, ep) \<in> aag; (r, Receive, ep) \<in> aag; policy_wellformed aag mirqs irqs l\<rbrakk>
-        \<Longrightarrow> (r, Reply, s) \<in> aag"
-  unfolding policy_wellformed_def by blast
-
-lemma aag_wellformed_delete_derived':
-  "\<lbrakk>  (s, Call, ep) \<in> aag; (r, Receive, ep) \<in> aag; policy_wellformed aag mirqs irqs l\<rbrakk>
-        \<Longrightarrow> (s, DeleteDerived, r) \<in> aag"
-  unfolding policy_wellformed_def by blast
-
-lemma aag_wellformed_delete_derived:
-  "\<lbrakk> (s, Reply, r) \<in> aag; policy_wellformed aag mirqs irqs l\<rbrakk>
-        \<Longrightarrow> (r, DeleteDerived, s) \<in> aag"
-  unfolding policy_wellformed_def by blast
-
-lemma aag_wellformed_delete_derived_trans:
-  "\<lbrakk> (l1, DeleteDerived, l2) \<in> aag; (l2, DeleteDerived, l3) \<in> aag;
-     policy_wellformed aag mirqs irqs l\<rbrakk>
-        \<Longrightarrow> (l1, DeleteDerived, l3) \<in> aag"
-  unfolding policy_wellformed_def by blast
-
-lemma aag_wellformed_call_to_syncsend:
-  "\<lbrakk> (s, Call, ep) \<in> aag; policy_wellformed aag mirqs irqs l\<rbrakk>
-        \<Longrightarrow> (s, SyncSend, ep) \<in> aag"
-  unfolding policy_wellformed_def by blast
-
-lemma aag_wellformed_grant_Control_to_send_by_reply:
-  "\<lbrakk> (s, Call, ep) \<in> aag; (r, Receive, ep) \<in> aag; (r, Grant, ep) \<in> aag;
-   policy_wellformed aag mirqs irqs l\<rbrakk>
-        \<Longrightarrow> (r, Control, s) \<in> aag"
-  unfolding policy_wellformed_def by blast
-
-lemma aag_wellformed_grant_Control_to_recv_by_reply:
-  "\<lbrakk> (s, Call, ep) \<in> aag; (r, Receive, ep) \<in> aag; (r, Grant, ep) \<in> aag;
-   policy_wellformed aag mirqs irqs l\<rbrakk>
-        \<Longrightarrow> (s, Control, r) \<in> aag"
-  unfolding policy_wellformed_def by blast
+     policy_wellformed (pasPolicy aag) (pasMaySendIrqs aag) (range (pasIRQAbs aag)) (pasSubject aag)"
 
 
 subsection \<open>auth_graph_map\<close>
@@ -274,31 +74,8 @@ collapse (and not create) distinctions.
 
 \<close>
 
-definition
-  auth_graph_map :: "('a \<Rightarrow> 'b) \<Rightarrow> 'a auth_graph \<Rightarrow> 'b auth_graph"
-where
+definition auth_graph_map :: "('a \<Rightarrow> 'b) \<Rightarrow> 'a auth_graph \<Rightarrow> 'b auth_graph" where
   "auth_graph_map f aag \<equiv> {(f x, auth, f y) | x auth y. (x, auth, y) \<in> aag}"
-
-lemma auth_graph_map_mem:
-  "(x, auth, y) \<in> auth_graph_map f S
-     = (\<exists>x' y'. x = f x' \<and> y = f y' \<and> (x', auth, y') \<in> S)"
-  by (simp add: auth_graph_map_def)
-
-lemmas auth_graph_map_memD = auth_graph_map_mem[THEN iffD1]
-lemma auth_graph_map_memE:
-  assumes hyp:"(x, auth, y) \<in> auth_graph_map f S"
-  obtains x' and y' where "x = f x'" and "y = f y'" and "(x', auth, y') \<in> S"
-  using hyp[THEN auth_graph_map_mem[THEN iffD1]] by fastforce
-
-lemma auth_graph_map_memI:
-  "\<lbrakk> (x', auth, y') \<in> S; x = f x'; y = f y' \<rbrakk>
-      \<Longrightarrow> (x, auth, y) \<in> auth_graph_map f S"
-  by (fastforce simp add: auth_graph_map_mem)
-
-lemma auth_graph_map_mono:
-  "S \<subseteq> S' \<Longrightarrow> auth_graph_map G S \<subseteq> auth_graph_map G S'"
-  unfolding auth_graph_map_def by auto
-
 
 
 subsection \<open>Transform caps and tcb states into authority\<close>
@@ -311,8 +88,7 @@ in it.
 
 \<close>
 
-definition cap_rights_to_auth :: "cap_rights \<Rightarrow> bool \<Rightarrow> auth set"
-where
+definition cap_rights_to_auth :: "cap_rights \<Rightarrow> bool \<Rightarrow> auth set" where
   "cap_rights_to_auth r sync \<equiv>
      {Reset}
    \<union> (if AllowRead \<in> r then {Receive} else {})
@@ -320,94 +96,33 @@ where
    \<union> (if AllowGrant \<in> r then UNIV else {})
    \<union> (if AllowGrantReply \<in> r \<and> AllowWrite \<in> r then {Call} else {})"
 
-definition vspace_cap_rights_to_auth :: "cap_rights \<Rightarrow> auth set"
-where
-  "vspace_cap_rights_to_auth r \<equiv>
-      (if AllowWrite \<in> r then {Write} else {})
-    \<union> (if AllowRead \<in> r then {Read} else {})"
-
-definition reply_cap_rights_to_auth :: "bool \<Rightarrow> cap_rights \<Rightarrow> auth set"
-where
+definition reply_cap_rights_to_auth :: "bool \<Rightarrow> cap_rights \<Rightarrow> auth set" where
   "reply_cap_rights_to_auth master r \<equiv> if AllowGrant \<in> r \<or> master then UNIV else {Reply}"
 
-definition cap_auth_conferred :: "cap \<Rightarrow> auth set"
-where
- "cap_auth_conferred cap \<equiv>
-    case cap of
-      Structures_A.NullCap \<Rightarrow> {}
-    | Structures_A.UntypedCap isdev oref bits freeIndex \<Rightarrow> {Control}
-    | Structures_A.EndpointCap oref badge r \<Rightarrow>
-         cap_rights_to_auth r True
-    | Structures_A.NotificationCap oref badge r \<Rightarrow>
-         cap_rights_to_auth (r - {AllowGrant, AllowGrantReply}) False
-    | Structures_A.ReplyCap oref m r \<Rightarrow> reply_cap_rights_to_auth m r
-    | Structures_A.CNodeCap oref bits guard \<Rightarrow> {Control}
-    | Structures_A.ThreadCap obj_ref \<Rightarrow> {Control}
-    | Structures_A.DomainCap \<Rightarrow> {Control}
-    | Structures_A.IRQControlCap \<Rightarrow> {Control}
-    | Structures_A.IRQHandlerCap irq \<Rightarrow> {Control}
-    | Structures_A.Zombie ptr b n \<Rightarrow> {Control}
-    | Structures_A.ArchObjectCap arch_cap \<Rightarrow>
-         (if is_page_cap (the_arch_cap cap)
-         then vspace_cap_rights_to_auth (acap_rights arch_cap)
-             else {Control})"
+definition cap_auth_conferred :: "cap \<Rightarrow> auth set" where
+ "cap_auth_conferred cap \<equiv> case cap of
+    NullCap \<Rightarrow> {}
+  | UntypedCap isdev oref bits freeIndex \<Rightarrow> {Control}
+  | EndpointCap oref badge r \<Rightarrow> cap_rights_to_auth r True
+  | NotificationCap oref badge r \<Rightarrow> cap_rights_to_auth (r - {AllowGrant, AllowGrantReply}) False
+  | ReplyCap oref m r \<Rightarrow> reply_cap_rights_to_auth m r
+  | CNodeCap oref bits guard \<Rightarrow> {Control}
+  | ThreadCap obj_ref \<Rightarrow> {Control}
+  | DomainCap \<Rightarrow> {Control}
+  | IRQControlCap \<Rightarrow> {Control}
+  | IRQHandlerCap irq \<Rightarrow> {Control}
+  | Zombie ptr b n \<Rightarrow> {Control}
+  | ArchObjectCap arch_cap \<Rightarrow> arch_cap_auth_conferred arch_cap"
 
-fun tcb_st_to_auth :: "Structures_A.thread_state \<Rightarrow> (obj_ref \<times> auth) set"
-where
-  "tcb_st_to_auth (Structures_A.BlockedOnNotification ntfn) = {(ntfn, Receive)}"
-| "tcb_st_to_auth (Structures_A.BlockedOnSend ep payl)
-     = {(ep, SyncSend)} \<union> (if sender_can_grant payl then {(ep, Grant),(ep, Call)} else {})
-       \<union> (if sender_can_grant_reply payl then {(ep, Call)} else {})"
-| "tcb_st_to_auth (Structures_A.BlockedOnReceive ep payl)
-     = {(ep, Receive)} \<union> (if receiver_can_grant payl then {(ep, Grant)} else {})"
+fun tcb_st_to_auth :: "thread_state \<Rightarrow> (obj_ref \<times> auth) set" where
+  "tcb_st_to_auth (BlockedOnNotification ntfn) = {(ntfn, Receive)}"
+| "tcb_st_to_auth (BlockedOnSend ep payl) =
+     {(ep, SyncSend)} \<union> (if sender_can_grant payl then {(ep, Grant),(ep, Call)} else {})
+   \<union> (if sender_can_grant_reply payl then {(ep, Call)} else {})"
+| "tcb_st_to_auth (BlockedOnReceive ep payl) =
+     {(ep, Receive)} \<union> (if receiver_can_grant payl then {(ep, Grant)} else {})"
 | "tcb_st_to_auth _ = {}"
 
-subsection \<open>FIXME MOVE\<close>
-
-definition pte_ref
-where
-  "pte_ref pte \<equiv> case pte of
-    SmallPagePTE addr atts rights
-       \<Rightarrow> Some (ptrFromPAddr addr, pageBitsForSize ARMSmallPage, vspace_cap_rights_to_auth rights)
-  | LargePagePTE addr atts rights
-       \<Rightarrow> Some (ptrFromPAddr addr, pageBitsForSize ARMLargePage, vspace_cap_rights_to_auth rights)
-  | _ \<Rightarrow> None"
-
-definition pde_ref2
-where
-  "pde_ref2 pde \<equiv> case pde of
-    SectionPDE addr atts domain rights
-       \<Rightarrow> Some (ptrFromPAddr addr, pageBitsForSize ARMSection, vspace_cap_rights_to_auth rights)
-  | SuperSectionPDE addr atts rights
-       \<Rightarrow> Some (ptrFromPAddr addr, pageBitsForSize ARMSuperSection, vspace_cap_rights_to_auth rights)
-  | PageTablePDE addr atts domain
-    \<comment> \<open>The 0 is a hack, saying that we own only addr, although 12 would also be OK\<close>
-       \<Rightarrow> Some (ptrFromPAddr addr, 0, {Control})
-  | _ \<Rightarrow> None"
-
-definition ptr_range
-where
-  "ptr_range p sz \<equiv> {p .. p + 2 ^ sz - 1}"
-
-(* We exclude the global page tables from the authority graph. Alternatively,
-   we could include them and add a wellformedness constraint to policies that
-   requires that every label has the necessary authority to whichever label owns
-   the global page tables, so that when a new page directory is created and
-   references to the global page tables are added to it, no new authority is gained.
-   Note: excluding the references to global page tables in this way
-         brings in some ARM arch-specific VM knowledge here *)
-definition vs_refs_no_global_pts :: "Structures_A.kernel_object \<Rightarrow> (obj_ref \<times> vs_ref \<times> auth) set"
-where
-  "vs_refs_no_global_pts \<equiv> \<lambda>ko. case ko of
-    ArchObj (ASIDPool pool) \<Rightarrow>
-       (\<lambda>(r,p). (p, VSRef (ucast r) (Some AASIDPool), Control)) ` graph_of pool
-  | ArchObj (PageDirectory pd) \<Rightarrow>
-      \<Union>(r,(p, sz, auth)) \<in> graph_of (pde_ref2 o pd) - {(x,y). (ucast (kernel_base >> 20) \<le> x)}.
-          (\<lambda>(p, a). (p, VSRef (ucast r) (Some APageDirectory), a)) ` (ptr_range p sz \<times> auth)
-  | ArchObj (PageTable pt) \<Rightarrow>
-      \<Union>(r,(p, sz, auth)) \<in> graph_of (pte_ref o pt).
-          (\<lambda>(p, a). (p, VSRef (ucast r) (Some APageTable), a)) ` (ptr_range p sz \<times> auth)
-  | _ \<Rightarrow> {}"
 
 subsection \<open>Transferability: Moving caps between agents\<close>
 
@@ -415,10 +130,10 @@ text \<open>
   Tells if cap can move/be derived between agents without grant
   due to the inner workings of the system (Calling and replying for now)
 \<close>
-(* FIXME is_transferable should garantee directly that a non-NullCap cap is owned by its CDT
+
+(* FIXME is_transferable should guarantee directly that a non-NullCap cap is owned by its CDT
    parents without using directly the CDT so that we can use it in integrity *)
-inductive is_transferable for opt_cap
-where
+inductive is_transferable for opt_cap where
   it_None: "opt_cap = None \<Longrightarrow> is_transferable opt_cap" |
   it_Null: "opt_cap = Some NullCap \<Longrightarrow> is_transferable opt_cap" |
   it_Reply: "opt_cap = Some (ReplyCap t False R) \<Longrightarrow> is_transferable opt_cap"
@@ -426,103 +141,13 @@ where
 abbreviation "is_transferable_cap cap \<equiv> is_transferable (Some cap)"
 abbreviation "is_transferable_in slot s \<equiv> is_transferable (caps_of_state s slot)"
 
-lemma is_transferable_capE:
-  assumes hyp:"is_transferable_cap cap"
-  obtains "cap = NullCap" | t R where "cap = ReplyCap t False R"
-  by (rule is_transferable.cases[OF hyp]) auto
-
-lemma is_transferable_None[simp]: "is_transferable None"
-  using is_transferable.simps by simp
-lemma is_transferable_Null[simp]: "is_transferable_cap NullCap"
-  using is_transferable.simps by simp
-lemma is_transferable_Reply[simp]: "is_transferable_cap (ReplyCap t False R)"
-  using is_transferable.simps by simp
-
-lemma is_transferable_NoneE:
-  assumes hyp: "is_transferable opt_cap"
-  obtains "opt_cap = None" | cap where "opt_cap = Some cap" and "is_transferable_cap cap"
-  by (rule is_transferable.cases[OF hyp];simp)
-
-lemma is_transferable_Untyped[simp]: "\<not> is_transferable (Some (UntypedCap dev ptr sz freeIndex))"
-  by (blast elim: is_transferable.cases)
-lemma is_transferable_IRQ[simp]: "\<not> is_transferable_cap IRQControlCap"
-  by (blast elim: is_transferable.cases)
-lemma is_transferable_Zombie[simp]: "\<not> is_transferable (Some (Zombie ptr sz n))"
-  by (blast elim: is_transferable.cases)
-lemma is_transferable_Ntfn[simp]: "\<not> is_transferable (Some (NotificationCap ntfn badge R))"
-  by (blast elim: is_transferable.cases)
-lemma is_transferable_Endpoint[simp]: "\<not> is_transferable (Some (EndpointCap ntfn badge R))"
-  by (blast elim: is_transferable.cases)
-
-(*FIXME MOVE *)
-lemmas descendants_incD
-    = descendants_inc_def[THEN meta_eq_to_obj_eq, THEN iffD1, rule_format]
-
-lemma acap_class_reply:
-  "(acap_class acap \<noteq> ReplyClass t)"
-  (* warning: arch split *)
-  by (cases acap; simp)
-
-lemma cap_class_reply:
-  "(cap_class cap = ReplyClass t) = (\<exists>r m. cap = ReplyCap t m r)"
-  by (cases cap; simp add: acap_class_reply)
-
-lemma reply_cap_no_children:
-  "\<lbrakk> valid_mdb s; caps_of_state s p = Some (ReplyCap t False r) \<rbrakk> \<Longrightarrow> cdt s p' \<noteq> Some p"
-  apply (clarsimp simp: valid_mdb_def)
-  apply (frule descendants_incD[where p=p' and p'=p])
-   apply (rule child_descendant)
-   apply (fastforce)
-  apply clarsimp
-  apply (subgoal_tac "caps_of_state s p' \<noteq> None")
-   apply (clarsimp simp: cap_class_reply)
-   apply (simp only: reply_mdb_def reply_caps_mdb_def reply_masters_mdb_def)
-   apply (elim conjE allE[where x=p'])
-   apply simp
-  apply (drule(1) mdb_cte_atD)
-  apply (fastforce simp add: cte_wp_at_def caps_of_state_def)
-  done
-
-(*FIXME MOVE *)
-lemmas all_childrenI = all_children_def[THEN meta_eq_to_obj_eq, THEN iffD2, rule_format]
-lemmas all_childrenD = all_children_def[THEN meta_eq_to_obj_eq, THEN iffD1, rule_format]
-
-(*FIXME MOVE *)
-lemma valid_mdb_descendants_inc[elim!]:
-  "valid_mdb s \<Longrightarrow> descendants_inc (cdt s) (caps_of_state s)"
-  by (simp add:valid_mdb_def)
-
-(*FIXME MOVE *)
-lemma valid_mdb_mdb_cte_at [elim!]:
-  "valid_mdb s \<Longrightarrow> mdb_cte_at (swp (cte_wp_at ((\<noteq>) NullCap)) s) (cdt s)"
-  by (simp add:valid_mdb_def)
-
-(*FIXME MOVE *)
-lemma descendants_inc_cap_classD:
-  "\<lbrakk> descendants_inc m caps; p \<in> descendants_of p' m; caps p = Some cap ; caps p' = Some cap'\<rbrakk>
-   \<Longrightarrow> cap_class cap = cap_class cap'"
-  by (fastforce dest:descendants_incD)
-
-lemma is_transferable_all_children:
-  "valid_mdb s \<Longrightarrow> all_children (\<lambda>slot . is_transferable (caps_of_state s slot)) (cdt s)"
-  apply (rule all_childrenI)
-  apply (erule is_transferable.cases)
-    apply (fastforce dest: mdb_cte_atD valid_mdb_mdb_cte_at
-                     simp: mdb_cte_at_def cte_wp_at_def caps_of_state_def)
-   apply (fastforce dest: mdb_cte_atD valid_mdb_mdb_cte_at
-                    simp: mdb_cte_at_def cte_wp_at_def caps_of_state_def)
-  apply (blast dest:reply_cap_no_children)
-done
-
-
-
 
 subsection \<open>Generating a policy from the current cap, ASID and IRQs distribution\<close>
 
-(* TODO split that section between stba sata and sita and move a maximun
+(* TODO split that section between sbta sata and sita and move a maximum
    of accesor functions back to AInvs *)
 
-
+(* FIXME: update comment *)
 text \<open>
   sbta_caps/sbta_asid imply that a thread and it's vspace are labelled
   the same -- caps_of_state (tcb, vspace_index) will be the PD cap.
@@ -542,224 +167,75 @@ text \<open>
 
 \<close>
 
-primrec aobj_ref' :: "arch_cap \<Rightarrow> obj_ref set"
-where
-  "aobj_ref' (arch_cap.ASIDPoolCap p as) = {p}"
-| "aobj_ref' arch_cap.ASIDControlCap = {}"
-| "aobj_ref' (arch_cap.PageCap isdev x rs sz as4) = ptr_range x (pageBitsForSize sz)"
-| "aobj_ref' (arch_cap.PageDirectoryCap x as2) = {x}"
-| "aobj_ref' (arch_cap.PageTableCap x as3) = {x}"
+primrec obj_refs :: "cap \<Rightarrow> obj_ref set" where
+  "obj_refs NullCap = {}"
+| "obj_refs (ReplyCap r m cr) = {r}"
+| "obj_refs IRQControlCap = {}"
+| "obj_refs (IRQHandlerCap irq) = {}"
+| "obj_refs (UntypedCap d r s f) = {}"
+| "obj_refs (CNodeCap r bits guard) = {r}"
+| "obj_refs (EndpointCap r b cr) = {r}"
+| "obj_refs (NotificationCap r b cr) = {r}"
+| "obj_refs (ThreadCap r) = {r}"
+| "obj_refs (Zombie ptr b n) = {ptr}"
+| "obj_refs (ArchObjectCap x) = aobj_ref' x"
+| "obj_refs DomainCap = UNIV" (* hack, see above *)
 
-primrec obj_refs :: "cap \<Rightarrow> obj_ref set"
-where
-  "obj_refs cap.NullCap = {}"
-| "obj_refs (cap.ReplyCap r m cr) = {r}"
-| "obj_refs cap.IRQControlCap = {}"
-| "obj_refs (cap.IRQHandlerCap irq) = {}"
-| "obj_refs (cap.UntypedCap d r s f) = {}"
-| "obj_refs (cap.CNodeCap r bits guard) = {r}"
-| "obj_refs (cap.EndpointCap r b cr) = {r}"
-| "obj_refs (cap.NotificationCap r b cr) = {r}"
-| "obj_refs (cap.ThreadCap r) = {r}"
-| "obj_refs (cap.Zombie ptr b n) = {ptr}"
-| "obj_refs (cap.ArchObjectCap x) = aobj_ref' x"
-| "obj_refs cap.DomainCap = UNIV" (* hack, see above *)
+fun cap_irqs_controlled :: "cap \<Rightarrow> irq set" where
+  "cap_irqs_controlled IRQControlCap = UNIV"
+| "cap_irqs_controlled (IRQHandlerCap irq) = {irq}"
+| "cap_irqs_controlled _ = {}"
 
-inductive_set state_bits_to_policy for caps thread_sts thread_bas cdt vrefs
-where
-  sbta_caps: "\<lbrakk> caps ptr = Some cap; oref \<in> obj_refs cap;
-                auth \<in> cap_auth_conferred cap \<rbrakk>
-           \<Longrightarrow> (fst ptr, auth, oref) \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
-| sbta_untyped: "\<lbrakk> caps ptr = Some cap; oref \<in> untyped_range cap \<rbrakk>
-           \<Longrightarrow> (fst ptr, Control, oref) \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
-| sbta_ts: "\<lbrakk> (oref', auth) \<in> thread_sts oref \<rbrakk>
-           \<Longrightarrow> (oref, auth, oref') \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
-| sbta_bounds: "\<lbrakk>thread_bas oref = Some oref'; auth \<in> {Receive, Reset} \<rbrakk>
-           \<Longrightarrow> (oref, auth, oref') \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
-| sbta_cdt: "\<lbrakk> cdt slot' = Some slot ; \<not>is_transferable (caps slot') \<rbrakk>
-           \<Longrightarrow> (fst slot, Control, fst slot')
-                                   \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
-| sbta_cdt_transferable: "\<lbrakk>cdt slot' = Some slot\<rbrakk>
-           \<Longrightarrow> (fst slot, DeleteDerived, fst slot')
-                                   \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
-| sbta_vref: "\<lbrakk> (ptr', ref, auth) \<in> vrefs ptr \<rbrakk>
-           \<Longrightarrow> (ptr, auth, ptr') \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
+inductive_set state_irqs_to_policy_aux for aag caps where
+  sita_controlled:
+    "\<lbrakk> caps ptr = Some cap; irq \<in> cap_irqs_controlled cap \<rbrakk>
+       \<Longrightarrow> (pasObjectAbs aag (fst ptr), Control, pasIRQAbs aag irq) \<in> state_irqs_to_policy_aux aag caps"
 
-fun cap_asid' :: "cap \<Rightarrow> asid set"
-where
-  "cap_asid' (ArchObjectCap (PageCap _ _ _ _ mapping))
-      = fst ` set_option mapping"
-  | "cap_asid' (ArchObjectCap (PageTableCap _ mapping))
-      = fst ` set_option mapping"
-  | "cap_asid' (ArchObjectCap (PageDirectoryCap _ asid_opt))
-      = set_option asid_opt"
-  | "cap_asid' (ArchObjectCap (ASIDPoolCap _ asid))
-          = {x. asid_high_bits_of x = asid_high_bits_of asid \<and> x \<noteq> 0}"
-  | "cap_asid' (ArchObjectCap ASIDControlCap) = UNIV"
-  | "cap_asid' _ = {}"
-
-inductive_set state_asids_to_policy_aux for aag caps asid_tab vrefs
-where
-    sata_asid: "\<lbrakk> caps ptr = Some cap; asid \<in> cap_asid' cap \<rbrakk>
-              \<Longrightarrow> ( pasObjectAbs aag (fst ptr), Control, pasASIDAbs aag asid)
-                        \<in> state_asids_to_policy_aux aag caps asid_tab vrefs"
-  | sata_asid_lookup: "\<lbrakk> asid_tab (asid_high_bits_of asid) = Some poolptr;
-                           (pdptr, VSRef (asid && mask asid_low_bits)
-                                         (Some AASIDPool), a) \<in> vrefs poolptr \<rbrakk>
-                       \<Longrightarrow> (pasASIDAbs aag asid, a, pasObjectAbs aag pdptr)
-                              \<in> state_asids_to_policy_aux aag caps asid_tab vrefs"
-  | sata_asidpool:    "\<lbrakk> asid_tab (asid_high_bits_of asid) = Some poolptr; asid \<noteq> 0 \<rbrakk> \<Longrightarrow>
-                        (pasObjectAbs aag poolptr, ASIDPoolMapsASID, pasASIDAbs aag asid)
-                                             \<in> state_asids_to_policy_aux aag caps asid_tab vrefs"
-
-fun cap_irqs_controlled :: "cap \<Rightarrow> irq set"
-where
-  "cap_irqs_controlled cap.IRQControlCap = UNIV"
-  | "cap_irqs_controlled (cap.IRQHandlerCap irq) = {irq}"
-  | "cap_irqs_controlled _ = {}"
-
-inductive_set state_irqs_to_policy_aux for aag caps
-where
-  sita_controlled: "\<lbrakk> caps ptr = Some cap; irq \<in> cap_irqs_controlled cap \<rbrakk>
-  \<Longrightarrow> (pasObjectAbs aag (fst ptr), Control, pasIRQAbs aag irq) \<in> state_irqs_to_policy_aux aag caps"
-
-abbreviation state_irqs_to_policy
-where
+abbreviation state_irqs_to_policy where
   "state_irqs_to_policy aag s \<equiv> state_irqs_to_policy_aux aag (caps_of_state s)"
 
-definition irq_map_wellformed_aux
-where
+definition irq_map_wellformed_aux where
   "irq_map_wellformed_aux aag irqs \<equiv> \<forall>irq. pasObjectAbs aag (irqs irq) = pasIRQAbs aag irq"
 
-abbreviation irq_map_wellformed
-where
+abbreviation irq_map_wellformed where
   "irq_map_wellformed aag s \<equiv> irq_map_wellformed_aux aag (interrupt_irq_node s)"
 
-definition state_vrefs
-where
-  "state_vrefs s = case_option {} vs_refs_no_global_pts o kheap s"
-
-abbreviation state_asids_to_policy
-where
-  "state_asids_to_policy aag s \<equiv> state_asids_to_policy_aux aag (caps_of_state s)
-        (arm_asid_table (arch_state s)) (state_vrefs s)"
-
-definition tcb_states_of_state
-where
-  "tcb_states_of_state s \<equiv> \<lambda>p. option_map tcb_state (get_tcb p s)"
-
-(* FIXME: RENAME: should be named something thread_st_auth. thread_states is confusing as
-   it outputs autorities *)
-definition thread_states
-where
+(* FIXME: rename to thread_st_auth or similar since it outputs authorities *)
+definition thread_states where
   "thread_states s \<equiv> case_option {} tcb_st_to_auth \<circ> tcb_states_of_state s"
 
-definition thread_bound_ntfns
-where
-  "thread_bound_ntfns s \<equiv> \<lambda>p. case (get_tcb p s) of None \<Rightarrow> None
-                                                  | Some tcb \<Rightarrow> tcb_bound_notification tcb"
+definition thread_bound_ntfns where
+  "thread_bound_ntfns s \<equiv> \<lambda>p. case_option None tcb_bound_notification (get_tcb p s)"
 
-definition state_objs_to_policy
-where
-  "state_objs_to_policy s =
-      state_bits_to_policy (caps_of_state s) (thread_states s) (thread_bound_ntfns s)
-                           (cdt s) (state_vrefs s)"
+inductive_set state_bits_to_policy for caps thread_sts thread_bas cdt vrefs where
+  sbta_caps:
+    "\<lbrakk> caps ptr = Some cap; oref \<in> obj_refs cap; auth \<in> cap_auth_conferred cap \<rbrakk>
+       \<Longrightarrow> (fst ptr, auth, oref) \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
+| sbta_untyped:
+    "\<lbrakk> caps ptr = Some cap; oref \<in> untyped_range cap \<rbrakk>
+       \<Longrightarrow> (fst ptr, Control, oref) \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
+| sbta_ts:
+    "(oref', auth) \<in> thread_sts oref
+     \<Longrightarrow> (oref, auth, oref') \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
+| sbta_bounds:
+    "\<lbrakk> thread_bas oref = Some oref'; auth \<in> {Receive, Reset} \<rbrakk>
+       \<Longrightarrow> (oref, auth, oref') \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
+| sbta_cdt:
+    "\<lbrakk> cdt slot' = Some slot ; \<not>is_transferable (caps slot') \<rbrakk>
+       \<Longrightarrow> (fst slot, Control, fst slot') \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
+| sbta_cdt_transferable:
+    "cdt slot' = Some slot
+     \<Longrightarrow> (fst slot, DeleteDerived, fst slot') \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
+| sbta_vref:
+    "(ptr', _, _, auth) \<in> vrefs ptr
+     \<Longrightarrow> (ptr, auth, ptr') \<in> state_bits_to_policy caps thread_sts thread_bas cdt vrefs"
 
-lemmas state_objs_to_policy_mem = eqset_imp_iff[OF state_objs_to_policy_def]
+definition state_objs_to_policy :: "det_ext state \<Rightarrow> (obj_ref \<times> auth \<times> obj_ref) set" where
+  "state_objs_to_policy s = state_bits_to_policy (caps_of_state s) (thread_states s)
+                                                 (thread_bound_ntfns s) (cdt s) (state_vrefs s)"
 
-lemmas state_objs_to_policy_intros
-    = state_bits_to_policy.intros[THEN state_objs_to_policy_mem[THEN iffD2]]
-
-(* FIXME this is non resilient at all to adding or removing rules to or from state_bits_to_policy *)
-lemmas sta_caps = state_objs_to_policy_intros(1)
-  and sta_untyped = state_objs_to_policy_intros(2)
-  and sta_ts = state_objs_to_policy_intros(3)
-  and sta_bas = state_objs_to_policy_intros(4)
-  and sta_cdt = state_objs_to_policy_intros(5)
-  and sta_cdt_transferable = state_objs_to_policy_intros(6)
-  and sta_vref = state_objs_to_policy_intros(7)
-
-lemmas state_objs_to_policy_cases
-    = state_bits_to_policy.cases[OF state_objs_to_policy_mem[THEN iffD1]]
-
-end
-
-context pspace_update_eq begin
-
-interpretation Arch . (*FIXME: arch_split*)
-
-lemma state_vrefs[iff]: "state_vrefs (f s) = state_vrefs s"
-  by (simp add: state_vrefs_def pspace)
-
-lemma thread_states[iff]: "thread_states (f s) = thread_states s"
-  by (simp add: thread_states_def pspace get_tcb_def swp_def tcb_states_of_state_def)
-
-lemma thread_bound_ntfns[iff]: "thread_bound_ntfns (f s) = thread_bound_ntfns s"
-  by (simp add: thread_bound_ntfns_def pspace get_tcb_def swp_def split: option.splits)
-
-(*
-  lemma ipc_buffers_of_state[iff]: "ipc_buffers_of_state (f s) = ipc_buffers_of_state s"
-  by (simp add: ipc_buffers_of_state_def pspace get_tcb_def swp_def)
-*)
-
-end
-
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-lemma tcb_states_of_state_preserved:
-  "\<lbrakk> get_tcb thread s = Some tcb; tcb_state tcb' = tcb_state tcb \<rbrakk>
-     \<Longrightarrow> tcb_states_of_state (s\<lparr>kheap := kheap s(thread \<mapsto> TCB tcb')\<rparr>) = tcb_states_of_state s"
-  apply rule
-  apply (auto split: option.splits simp: tcb_states_of_state_def get_tcb_def)
-  done
-
-lemma thread_states_preserved:
-  "\<lbrakk> get_tcb thread s = Some tcb; tcb_state tcb' = tcb_state tcb \<rbrakk>
-     \<Longrightarrow> thread_states (s\<lparr>kheap := kheap s(thread \<mapsto> TCB tcb')\<rparr>) = thread_states s"
-  by (simp add: tcb_states_of_state_preserved thread_states_def)
-
-lemma thread_bound_ntfns_preserved:
-  "\<lbrakk> get_tcb thread s = Some tcb; tcb_bound_notification tcb' = tcb_bound_notification tcb \<rbrakk>
-     \<Longrightarrow> thread_bound_ntfns (s\<lparr>kheap := kheap s(thread \<mapsto> TCB tcb')\<rparr>) = thread_bound_ntfns s"
-  by (auto simp:  thread_bound_ntfns_def get_tcb_def split: option.splits)
-
-(* FIXME: move all three *)
-lemma null_filterI:
-  "\<lbrakk> cs p = Some cap; cap \<noteq> cap.NullCap \<rbrakk> \<Longrightarrow> null_filter cs p = Some cap"
-  unfolding null_filter_def by auto
-lemma null_filterI2:
-  "\<lbrakk> cs p = None \<rbrakk> \<Longrightarrow> null_filter cs p = None"
-  unfolding null_filter_def by auto
-
-lemma null_filterE2:
-  "\<lbrakk> null_filter cps x = None;
-      \<lbrakk> cps x = Some NullCap \<rbrakk> \<Longrightarrow> R ; \<lbrakk> cps x = None \<rbrakk> \<Longrightarrow> R  \<rbrakk>
-     \<Longrightarrow> R"
-  by (simp add: null_filter_def split: if_split_asm)
-
-lemma is_transferable_null_filter[simp]:
-  "is_transferable (null_filter caps ptr) = is_transferable (caps ptr)"
-  by (auto simp: is_transferable.simps null_filter_def)
-
-lemma sbta_null_filter:
-  "state_bits_to_policy (null_filter cs) sr bar cd vr = state_bits_to_policy cs sr bar cd vr"
-  apply (rule subset_antisym)
-  apply clarsimp
-  apply (erule state_bits_to_policy.induct,
-        (fastforce intro: state_bits_to_policy.intros
-                   elim: null_filterE null_filterE2 split: option.splits)+)[1]
-  apply clarsimp
-  apply (erule state_bits_to_policy.induct)
-  by (fastforce intro: state_bits_to_policy.intros null_filterI split:option.splits)+
-
-lemma sata_null_filter:
-  "state_asids_to_policy_aux aag (null_filter cs) asid_tab vrefs
-        = state_asids_to_policy_aux aag cs asid_tab vrefs"
-  by (auto elim!: state_asids_to_policy_aux.induct null_filterE
-           intro: state_asids_to_policy_aux.intros sata_asid[OF null_filterI])
 
 subsection \<open>Policy Refinement\<close>
-
 
 text\<open>
 
@@ -771,27 +247,18 @@ unauthorised subjects (see integrity_ready_queues).
 
 \<close>
 
-inductive_set domains_of_state_aux for ekheap
-where
-  domtcbs: "\<lbrakk> ekheap ptr = Some etcb; d = tcb_domain etcb \<rbrakk>
-  \<Longrightarrow> (ptr, d) \<in> domains_of_state_aux ekheap"
+inductive_set domains_of_state_aux for ekheap where
+  domtcbs:
+    "\<lbrakk> ekheap ptr = Some etcb; d = tcb_domain etcb \<rbrakk> \<Longrightarrow> (ptr, d) \<in> domains_of_state_aux ekheap"
 
-abbreviation domains_of_state
-where
-  "domains_of_state s \<equiv> domains_of_state_aux (ekheap s)"
+abbreviation "domains_of_state s \<equiv> domains_of_state_aux (ekheap s)"
 
-definition tcb_domain_map_wellformed_aux
-where
+definition tcb_domain_map_wellformed_aux where
   "tcb_domain_map_wellformed_aux aag etcbs_doms \<equiv>
      \<forall>(ptr, d) \<in> etcbs_doms. pasObjectAbs aag ptr \<in> pasDomainAbs aag d"
 
-abbreviation tcb_domain_map_wellformed
-where
+abbreviation tcb_domain_map_wellformed where
   "tcb_domain_map_wellformed aag s \<equiv> tcb_domain_map_wellformed_aux aag (domains_of_state s)"
-
-lemma tcb_domain_map_wellformed_mono:
-  "\<lbrakk> domains_of_state s' \<subseteq> domains_of_state s; tcb_domain_map_wellformed pas s \<rbrakk> \<Longrightarrow> tcb_domain_map_wellformed pas s'"
-by (auto simp: tcb_domain_map_wellformed_aux_def get_etcb_def)
 
 text\<open>
 
@@ -799,8 +266,7 @@ We sometimes need to know that our current subject may run in the current domain
 
 \<close>
 
-abbreviation
-  "pas_cur_domain aag s \<equiv> pasSubject aag \<in> pasDomainAbs aag (cur_domain s)"
+abbreviation "pas_cur_domain aag s \<equiv> pasSubject aag \<in> pasDomainAbs aag (cur_domain s)"
 
 text\<open>
 
@@ -815,15 +281,17 @@ the policy:
 \end{itemize}
 
 \<close>
-abbreviation state_objs_in_policy :: "'a PAS \<Rightarrow> det_ext state \<Rightarrow> bool"
-where
+
+abbreviation state_objs_in_policy :: "'a PAS \<Rightarrow> det_ext state \<Rightarrow> bool" where
   "state_objs_in_policy aag s \<equiv>
                 auth_graph_map (pasObjectAbs aag) (state_objs_to_policy s) \<subseteq> pasPolicy aag"
 
+abbreviation state_asids_to_policy :: "'a PAS \<Rightarrow> det_ext state \<Rightarrow> ('a \<times> auth \<times> 'a) set" where
+  "state_asids_to_policy aag s \<equiv>
+     state_asids_to_policy_arch aag (caps_of_state s) (arch_state s) (state_vrefs s)"
 
-definition pas_refined :: "'a PAS \<Rightarrow> det_ext state \<Rightarrow> bool"
-where
- "pas_refined aag \<equiv> \<lambda>s.
+definition pas_refined :: "'a PAS \<Rightarrow> det_ext state \<Rightarrow> bool" where
+  "pas_refined aag \<equiv> \<lambda>s.
      pas_wellformed aag
    \<and> irq_map_wellformed aag s
    \<and> tcb_domain_map_wellformed aag s
@@ -831,237 +299,89 @@ where
    \<and> state_asids_to_policy aag s \<subseteq> pasPolicy aag
    \<and> state_irqs_to_policy aag s \<subseteq> pasPolicy aag"
 
-lemma pas_refined_mem:
-  "\<lbrakk> (x, auth, y) \<in> state_objs_to_policy s; pas_refined aag s \<rbrakk>
-       \<Longrightarrow> (pasObjectAbs aag x, auth, pasObjectAbs aag y) \<in> pasPolicy aag"
-  by (auto simp: pas_refined_def intro: auth_graph_map_memI)
-
-lemma pas_refined_wellformed[elim!]:
-  "pas_refined aag s \<Longrightarrow> pas_wellformed aag"
-  unfolding pas_refined_def by simp
-
-lemmas pas_refined_Control
-    = aag_wellformed_Control[OF _ pas_refined_wellformed]
-  and pas_refined_refl = aag_wellformed_refl [OF pas_refined_wellformed]
-
-lemma caps_of_state_pasObjectAbs_eq:
-  "\<lbrakk> caps_of_state s p = Some cap; Control \<in> cap_auth_conferred cap;
-     is_subject aag (fst p); pas_refined aag s;
-     x \<in> obj_refs cap \<rbrakk>
-       \<Longrightarrow> is_subject aag x"
-  apply (frule sta_caps, simp+)
-  apply (drule pas_refined_mem, simp+)
-  apply (drule pas_refined_Control, simp+)
-  done
-
-lemma pas_refined_state_objs_to_policy_subset:
-  "\<lbrakk> pas_refined aag s;
-     state_objs_to_policy s' \<subseteq> state_objs_to_policy s;
-     state_asids_to_policy aag s' \<subseteq> state_asids_to_policy aag s;
-     state_irqs_to_policy aag s' \<subseteq> state_irqs_to_policy aag s;
-     domains_of_state s' \<subseteq> domains_of_state s;
-     interrupt_irq_node s' = interrupt_irq_node s
-    \<rbrakk>
-    \<Longrightarrow> pas_refined aag s'"
-by (simp add: pas_refined_def) (blast dest: tcb_domain_map_wellformed_mono dest: auth_graph_map_mono[where G="pasObjectAbs aag"])
-
-lemma aag_wellformed_all_auth_is_owns':
-  "\<lbrakk> Control \<in> S; pas_wellformed aag \<rbrakk> \<Longrightarrow> (\<forall>auth \<in> S. aag_has_auth_to aag auth x) = (is_subject aag x)"
-  apply (rule iffI)
-   apply (drule (1) bspec)
-   apply (frule (1) aag_wellformed_Control )
-   apply fastforce
-  apply (clarsimp simp: aag_wellformed_refl)
-  done
-
-lemmas aag_wellformed_all_auth_is_owns
-   = aag_wellformed_all_auth_is_owns'[where S=UNIV, simplified]
-     aag_wellformed_all_auth_is_owns'[where S="{Control}", simplified]
-
-lemmas aag_wellformed_control_is_owns
-   = aag_wellformed_all_auth_is_owns'[where S="{Control}", simplified]
-
-lemmas pas_refined_all_auth_is_owns = aag_wellformed_all_auth_is_owns[OF pas_refined_wellformed]
-
-lemma pas_refined_sita_mem:
-  "\<lbrakk> (x, auth, y) \<in> state_irqs_to_policy aag s; pas_refined aag s \<rbrakk>
-       \<Longrightarrow> (x, auth, y) \<in> pasPolicy aag"
-  by (auto simp: pas_refined_def)
-
-
-
 
 section \<open>Integrity definition\<close>
 
 subsection \<open>How kernel objects can change\<close>
 
-fun blocked_on :: "obj_ref \<Rightarrow> Structures_A.thread_state \<Rightarrow> bool"
-where
-    "blocked_on ref (Structures_A.BlockedOnReceive ref' _)     = (ref = ref')"
-  | "blocked_on ref (Structures_A.BlockedOnSend    ref' _)     = (ref = ref')"
-  | "blocked_on ref (Structures_A.BlockedOnNotification ref')  = (ref = ref')"
-  | "blocked_on _ _ = False"
+fun blocked_on :: "obj_ref \<Rightarrow> thread_state \<Rightarrow> bool" where
+  "blocked_on ref (BlockedOnReceive ref' _)    = (ref = ref')"
+| "blocked_on ref (BlockedOnSend    ref' _)    = (ref = ref')"
+| "blocked_on ref (BlockedOnNotification ref') = (ref = ref')"
+| "blocked_on _ _ = False"
 
-lemma blocked_on_def2:
-  "blocked_on ref ts = (ref \<in> fst ` tcb_st_to_auth ts)"
-  by (cases ts, simp_all)
-
-fun receive_blocked_on :: "obj_ref \<Rightarrow> Structures_A.thread_state \<Rightarrow> bool"
-where
-   "receive_blocked_on ref (Structures_A.BlockedOnReceive ref' _)     = (ref = ref')"
-  | "receive_blocked_on ref (Structures_A.BlockedOnNotification ref') = (ref = ref')"
-  | "receive_blocked_on _ _ = False"
+fun receive_blocked_on :: "obj_ref \<Rightarrow> thread_state \<Rightarrow> bool" where
+  "receive_blocked_on ref (BlockedOnReceive ref' _)    = (ref = ref')"
+| "receive_blocked_on ref (BlockedOnNotification ref') = (ref = ref')"
+| "receive_blocked_on _ _ = False"
 
 lemma receive_blocked_on_def2:
   "receive_blocked_on ref ts = ((ref, Receive) \<in> tcb_st_to_auth ts)"
   by (cases ts, simp_all)
 
-fun can_receive_ipc :: "Structures_A.thread_state \<Rightarrow> bool"
-where
-   "can_receive_ipc (Structures_A.BlockedOnReceive _ _)     = True"
-  | "can_receive_ipc (Structures_A.BlockedOnSend _ pl)     =
-         (sender_is_call pl \<and> (sender_can_grant pl \<or> sender_can_grant_reply pl))"
-  | "can_receive_ipc (Structures_A.BlockedOnNotification _) = True"
-  | "can_receive_ipc Structures_A.BlockedOnReply = True"
-  | "can_receive_ipc _ = False"
-
-lemma receive_blocked_on_can_receive_ipc[elim!,simp]:
-  "receive_blocked_on ref ts \<Longrightarrow>can_receive_ipc ts"
-  by (cases ts;simp)
-
-lemma receive_blocked_on_can_receive_ipc'[elim!,simp]:
-  "case_option False (receive_blocked_on ref) tsopt \<Longrightarrow> case_option False can_receive_ipc tsopt"
-  by (cases tsopt;simp)
-
-
-fun send_blocked_on :: "obj_ref \<Rightarrow> Structures_A.thread_state \<Rightarrow> bool"
-where
-  "send_blocked_on ref (Structures_A.BlockedOnSend ref' _)     = (ref = ref')"
-  | "send_blocked_on _ _ = False"
+fun send_blocked_on :: "obj_ref \<Rightarrow> thread_state \<Rightarrow> bool" where
+  "send_blocked_on ref (BlockedOnSend ref' _) = (ref = ref')"
+| "send_blocked_on _ _ = False"
 
 lemma send_blocked_on_def2:
   "send_blocked_on ref ts = ((ref, SyncSend) \<in> tcb_st_to_auth ts)"
   by (cases ts, simp_all)
 
-lemma send_blocked_on_def3:
-  "send_blocked_on ref ts = (\<exists> pl. ts = BlockedOnSend ref pl)"
-  by (cases ts; force)
-
-fun send_is_call :: "Structures_A.thread_state \<Rightarrow> bool"
-where
-  "send_is_call (Structures_A.BlockedOnSend _ payl) = sender_is_call payl"
+fun send_is_call :: "thread_state \<Rightarrow> bool" where
+  "send_is_call (BlockedOnSend _ payl) = sender_is_call payl"
 | "send_is_call _ = False"
 
+definition tcb_bound_notification_reset_integrity ::
+  "obj_ref option \<Rightarrow> obj_ref option \<Rightarrow> 'a set \<Rightarrow> 'a PAS \<Rightarrow> bool" where
+  "tcb_bound_notification_reset_integrity ntfn ntfn' subjects aag \<equiv>
+     (ntfn = ntfn') \<comment> \<open>no change to bound ntfn\<close>
+   \<or> (ntfn' = None \<and> aag_subjects_have_auth_to subjects aag Reset (the ntfn)) \<comment> \<open>ntfn is unbound\<close>"
 
-
-definition tcb_bound_notification_reset_integrity
-  :: "obj_ref option \<Rightarrow> obj_ref option \<Rightarrow> 'a set \<Rightarrow> 'a PAS \<Rightarrow> bool"
-where
-  "tcb_bound_notification_reset_integrity ntfn ntfn' subjects aag
-    = ((ntfn = ntfn') \<comment> \<open>no change to bound ntfn\<close>
-       \<or> (ntfn' = None \<and> aag_subjects_have_auth_to subjects aag Reset (the ntfn))
-         \<comment> \<open>ntfn is unbound\<close>)"
-
-lemma tcb_bound_notification_reset_integrity_refl[simp]:
-  "tcb_bound_notification_reset_integrity ntfn ntfn subjects aag"
-  by (simp add: tcb_bound_notification_reset_integrity_def)
-
-
-definition direct_send :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> obj_ref \<Rightarrow> tcb \<Rightarrow> bool"
-where
+definition direct_send :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> obj_ref \<Rightarrow> tcb \<Rightarrow> bool" where
   "direct_send subjects aag ep tcb \<equiv> receive_blocked_on ep (tcb_state tcb) \<and>
-                                   (aag_subjects_have_auth_to subjects aag SyncSend ep
-                                     \<or> aag_subjects_have_auth_to subjects aag Notify ep)"
+                                     (aag_subjects_have_auth_to subjects aag SyncSend ep \<or>
+                                      aag_subjects_have_auth_to subjects aag Notify ep)"
 
-abbreviation ep_recv_blocked :: "obj_ref \<Rightarrow> thread_state \<Rightarrow> bool"
-where
-  "ep_recv_blocked ep ts \<equiv> case ts of BlockedOnReceive w _ \<Rightarrow> w = ep
-                             | _ \<Rightarrow> False"
+abbreviation ep_recv_blocked :: "obj_ref \<Rightarrow> thread_state \<Rightarrow> bool" where
+  "ep_recv_blocked ep ts \<equiv> case ts of BlockedOnReceive w _ \<Rightarrow> w = ep | _ \<Rightarrow> False"
 
-definition direct_call :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> obj_ref \<Rightarrow> thread_state \<Rightarrow> bool"
-where
+definition direct_call :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> obj_ref \<Rightarrow> thread_state \<Rightarrow> bool" where
   "direct_call subjects aag ep tcbst \<equiv> ep_recv_blocked ep (tcbst) \<and>
-                                   aag_subjects_have_auth_to subjects aag Call ep"
+                                        aag_subjects_have_auth_to subjects aag Call ep"
 
-definition indirect_send :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> obj_ref \<Rightarrow> obj_ref \<Rightarrow> tcb \<Rightarrow> bool"
-where
-  "indirect_send subjects aag ntfn recv_ep tcb \<equiv> ep_recv_blocked recv_ep (tcb_state tcb)
-                                                    \<comment> \<open>tcb is blocked on sync ep\<close>
-                                         \<and> (tcb_bound_notification tcb = Some ntfn)
-                                         \<and> aag_subjects_have_auth_to subjects aag Notify ntfn"
+definition indirect_send :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> obj_ref \<Rightarrow> obj_ref \<Rightarrow> tcb \<Rightarrow> bool" where
+  "indirect_send subjects aag ntfn recv_ep tcb \<equiv>
+     ep_recv_blocked recv_ep (tcb_state tcb) \<and> aag_subjects_have_auth_to subjects aag Notify ntfn
+              \<comment> \<open>tcb is blocked on sync ep\<close> \<and> (tcb_bound_notification tcb = Some ntfn)"
 
+definition call_blocked :: "obj_ref \<Rightarrow> thread_state \<Rightarrow> bool" where
+  "call_blocked ep tst \<equiv> \<exists>pl. tst = BlockedOnSend ep pl \<and> sender_is_call pl"
 
-definition call_blocked :: "obj_ref \<Rightarrow> thread_state \<Rightarrow> bool"
-where
-  "call_blocked ep tst \<equiv> \<exists> pl. tst = BlockedOnSend ep pl \<and> sender_is_call pl"
-
-definition allowed_call_blocked :: "obj_ref \<Rightarrow> thread_state \<Rightarrow> bool"
-where
-  "allowed_call_blocked ep tst \<equiv> \<exists> pl. tst = BlockedOnSend ep pl \<and> sender_is_call pl \<and>
+definition allowed_call_blocked :: "obj_ref \<Rightarrow> thread_state \<Rightarrow> bool" where
+  "allowed_call_blocked ep tst \<equiv> \<exists>pl. tst = BlockedOnSend ep pl \<and> sender_is_call pl \<and>
                                               (sender_can_grant pl \<or> sender_can_grant_reply pl)"
 
-lemma allowed_call_blocked_call_blocked[elim!]:
-  "allowed_call_blocked ep tst \<Longrightarrow> call_blocked ep tst"
-  unfolding allowed_call_blocked_def call_blocked_def by fastforce
-
-definition direct_reply :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> 'a \<Rightarrow> tcb \<Rightarrow> bool"
-where
+definition direct_reply :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> 'a \<Rightarrow> tcb \<Rightarrow> bool" where
   "direct_reply subjects aag tcb_owner tcb \<equiv>
      (awaiting_reply (tcb_state tcb)
         \<or> (\<exists>ep. allowed_call_blocked ep (tcb_state tcb)
             \<and> aag_subjects_have_auth_to subjects aag Receive ep))
      \<and> aag_subjects_have_auth_to_label subjects aag Reply tcb_owner"
 
-definition reply_cap_deletion_integrity :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> cap \<Rightarrow> cap \<Rightarrow> bool"
-where
+definition reply_cap_deletion_integrity :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> cap \<Rightarrow> cap \<Rightarrow> bool" where
   "reply_cap_deletion_integrity subjects aag cap cap' \<equiv>
-   (cap = cap') \<or> (\<exists> caller R. cap = ReplyCap caller False R \<and>
-                               cap' = NullCap \<and>
-                               pasObjectAbs aag caller \<in> subjects)"
+   (cap = cap') \<or> (\<exists>caller R. cap = ReplyCap caller False R \<and> cap' = NullCap \<and>
+                              pasObjectAbs aag caller \<in> subjects)"
 
-lemmas reply_cap_deletion_integrityI1 =
-       reply_cap_deletion_integrity_def[THEN meta_eq_to_obj_eq,THEN iffD2,OF disjI1]
-lemmas reply_cap_deletion_integrityI2 =
-       reply_cap_deletion_integrity_def[THEN meta_eq_to_obj_eq,THEN iffD2, OF disjI2, OF exI,
-                                        OF exI, OF conjI [OF _ conjI], rule_format]
-lemmas reply_cap_deletion_integrity_intros =
-       reply_cap_deletion_integrityI1 reply_cap_deletion_integrityI2
-
-lemma reply_cap_deletion_integrityE:
-  assumes hyp:"reply_cap_deletion_integrity subjects aag cap cap'"
-  obtains "cap = cap'" | caller R where "cap = ReplyCap caller False R"
-  and "cap' = NullCap" and "pasObjectAbs aag caller \<in> subjects"
-  using hyp reply_cap_deletion_integrity_def by blast
-
-lemma reply_cap_deletion_integrity_refl[simp]:
-  "reply_cap_deletion_integrity subjects aag cap cap"
-  by (rule reply_cap_deletion_integrityI1) simp
-
-
-(* WARNING if some one want to add a cap to is_transferable, it must appear here *)
-definition cnode_integrity :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> cnode_contents \<Rightarrow> cnode_contents \<Rightarrow> bool"
-  where
+(* WARNING: if some one want to add a cap to is_transferable, it must appear here *)
+definition cnode_integrity :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> cnode_contents \<Rightarrow> cnode_contents \<Rightarrow> bool" where
   "cnode_integrity subjects aag content content' \<equiv>
-   \<forall> l. content l = content' l \<or> (\<exists> cap cap'. content l = Some cap \<and> content' l = Some cap' \<and>
-                                         reply_cap_deletion_integrity subjects aag cap cap')"
-
-lemmas cnode_integrityI = cnode_integrity_def[THEN meta_eq_to_obj_eq,THEN iffD2,rule_format]
-lemmas cnode_integrityD = cnode_integrity_def[THEN meta_eq_to_obj_eq,THEN iffD1,rule_format]
-lemma cnode_integrityE:
-  assumes hyp:"cnode_integrity subjects aag content content'"
-  obtains "content l = content' l" | cap cap' where "content l = Some cap"
-  and "content' l = Some cap'" and "reply_cap_deletion_integrity subjects aag cap cap'"
-  using hyp cnode_integrityD by blast
-
-definition asid_pool_integrity ::
-  "'a set \<Rightarrow> 'a PAS \<Rightarrow> (asid_low_index \<rightharpoonup> obj_ref) \<Rightarrow> (asid_low_index \<rightharpoonup> obj_ref) \<Rightarrow> bool"
-  where
-  "asid_pool_integrity subjects aag pool pool' \<equiv>
-   \<forall>x. pool' x \<noteq> pool x \<longrightarrow> pool' x = None
-       \<and> aag_subjects_have_auth_to subjects aag Control (the (pool x))"
+   \<forall>l. content l = content' l \<or> (\<exists>cap cap'. content l = Some cap \<and> content' l = Some cap' \<and>
+                                            reply_cap_deletion_integrity subjects aag cap cap')"
 
 
 subsubsection \<open>Definition of object integrity\<close>
+
 text \<open>
   The object integrity relation describes which modification to kernel objects are allowed by the
   policy aag when the system is controlled by subjects.
@@ -1074,223 +394,129 @@ text \<open>
 
   Creation and destruction or retyping of kernel objects are not allowed unless l \<in> subjects
 \<close>
+
 (* FIXME it would be nice if there was an arch_tcb_context_update with all the required lemmas*)
-inductive integrity_obj_atomic for aag activate subjects l ko ko'
-  where
+inductive integrity_obj_atomic for aag activate subjects l ko ko' where
   (* l can modify any object it owns *)
   troa_lrefl:
-    "\<lbrakk>l \<in> subjects \<rbrakk> \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
-  (* l can modify an Notification object state if it has rights to interact with it *)
+    "l \<in> subjects \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+  (* l can modify a Notification object state if it has rights to interact with it *)
 | troa_ntfn:
-    "\<lbrakk>ko = Some (Notification ntfn); ko' = Some (Notification ntfn');
-      auth \<in> {Receive, Notify, Reset}; s \<in> subjects;
-      (s, auth, l) \<in> pasPolicy aag\<rbrakk>
-     \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+    "\<lbrakk> ko = Some (Notification ntfn); ko' = Some (Notification ntfn');
+       auth \<in> {Receive, Notify, Reset}; s \<in> subjects; (s, auth, l) \<in> pasPolicy aag \<rbrakk>
+       \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
   (* l can modify an Endpoint object state if it has rights to interact with it *)
 | troa_ep:
     "\<lbrakk> ko = Some (Endpoint ep); ko' = Some (Endpoint ep');
-      auth \<in> {Receive, SyncSend, Reset}; s \<in> subjects;
-      (s, auth, l) \<in> pasPolicy aag\<rbrakk>
-     \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+       auth \<in> {Receive, SyncSend, Reset}; s \<in> subjects; (s, auth, l) \<in> pasPolicy aag \<rbrakk>
+       \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
   (* If a tcb is waiting on receiving on an Endpoint but could be bound to a notification ntfn.
      Then if we can Notify ntfn, we could modify the endpoint *)
 | troa_ep_unblock:
-    "\<lbrakk>ko = Some (Endpoint ep); ko' = Some (Endpoint ep');
-      (tcb, Receive, pasObjectAbs aag ntfn) \<in> pasPolicy aag;
-      (tcb, Receive, l) \<in> pasPolicy aag;
-      aag_subjects_have_auth_to subjects aag Notify ntfn\<rbrakk>
-     \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+    "\<lbrakk> ko = Some (Endpoint ep); ko' = Some (Endpoint ep');
+       (tcb, Receive, pasObjectAbs aag ntfn) \<in> pasPolicy aag;
+       (tcb, Receive, l) \<in> pasPolicy aag;
+       aag_subjects_have_auth_to subjects aag Notify ntfn \<rbrakk>
+       \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
   (* If the subjects can send to an Endpoint or its bound notification, they can also
      modify any thread that is waiting on it *)
 | troa_tcb_send:
-    "\<lbrakk>ko = Some (TCB tcb); ko' = Some (TCB tcb');
-      tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb), tcb_state := Running\<rparr>;
-      direct_send subjects aag ep tcb
-       \<or> indirect_send subjects aag (the (tcb_bound_notification tcb)) ep tcb\<rbrakk>
-     \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+    "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb), tcb_state := Running\<rparr>;
+       direct_send subjects aag ep tcb
+       \<or> indirect_send subjects aag (the (tcb_bound_notification tcb)) ep tcb \<rbrakk>
+       \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
   (* If a tcb is waiting on an Endpoint that the subjects can Call, they are allowed
      to do that call, and insert a ReplyCap back towards a subject*)
 | troa_tcb_call:
-    "\<lbrakk>ko = Some (TCB tcb); ko' = Some (TCB tcb');
-      tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb), tcb_state := Running,
-                  tcb_caller := ReplyCap caller False R\<rparr>;
-      pasObjectAbs aag caller \<in> subjects;
-      direct_call subjects aag ep (tcb_state tcb)\<rbrakk>
-     \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+    "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb), tcb_state := Running,
+                   tcb_caller := ReplyCap caller False R\<rparr>;
+       pasObjectAbs aag caller \<in> subjects;
+       direct_call subjects aag ep (tcb_state tcb) \<rbrakk>
+       \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
   (* Subjects can reply to a tcb waiting for a Reply, if they have authority to do that Reply
      In case of a fault Reply, the new state of the thread can be Restart or Inactive depending on
      the fault handler*)
 | troa_tcb_reply:
-    "\<lbrakk>ko = Some (TCB tcb); ko' = Some (TCB tcb');
-      tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
-                  tcb_state := new_st, tcb_fault := None\<rparr>;
-      new_st = Running \<or> (tcb_fault tcb \<noteq> None \<and> (new_st = Restart \<or> new_st = Inactive));
-      awaiting_reply (tcb_state tcb);
-      aag_subjects_have_auth_to_label subjects aag Reply l\<rbrakk>
-     \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+    "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
+                   tcb_state := new_st, tcb_fault := None\<rparr>;
+       new_st = Running \<or> (tcb_fault tcb \<noteq> None \<and> (new_st = Restart \<or> new_st = Inactive));
+       awaiting_reply (tcb_state tcb); aag_subjects_have_auth_to_label subjects aag Reply l \<rbrakk>
+       \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
   (* Subjects can receive a message from an Endpoint. The sender state will then be set to
      Running if it is a normal send and to Inactive or BlockedOnReply if it is a call.
      TODO split that rule *)
 | troa_tcb_receive:
-    "\<lbrakk>ko = Some (TCB tcb); ko' = Some (TCB tcb');
-      tcb' = tcb \<lparr>tcb_state := new_st\<rparr>;
-      new_st = Running
+    "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       tcb' = tcb \<lparr>tcb_state := new_st\<rparr>;
+       new_st = Running
        \<or> (inactive new_st \<and> call_blocked ep (tcb_state tcb))
        \<or> (awaiting_reply new_st \<and> allowed_call_blocked ep (tcb_state tcb));
-      send_blocked_on ep (tcb_state tcb);
-      aag_subjects_have_auth_to subjects aag Receive ep \<rbrakk>
-     \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+       send_blocked_on ep (tcb_state tcb);
+       aag_subjects_have_auth_to subjects aag Receive ep \<rbrakk>
+       \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
   (* Subjects can Reset an Endpoint/Notification they have Reset authority to, and thus
      all TCBs blocked on it need to be restarted *)
 | troa_tcb_restart:
-    "\<lbrakk>ko = Some (TCB tcb); ko' = Some (TCB tcb');
-      tcb' = tcb\<lparr>tcb_state := Restart\<rparr>;
-      blocked_on ep (tcb_state tcb);
-      aag_subjects_have_auth_to subjects aag Reset ep\<rbrakk>
-    \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+    "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       tcb' = tcb\<lparr>tcb_state := Restart\<rparr>;
+       blocked_on ep (tcb_state tcb);
+       aag_subjects_have_auth_to subjects aag Reset ep \<rbrakk>
+       \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
   (* Subjects can Reset a bound Notification which then need to be unbound*)
 | troa_tcb_unbind:
-    "\<lbrakk>ko = Some (TCB tcb); ko' = Some (TCB tcb');
-      tcb' = tcb\<lparr>tcb_bound_notification := None\<rparr>;
-      aag_subjects_have_auth_to subjects aag Reset (the (tcb_bound_notification tcb))\<rbrakk>
-    \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+    "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       tcb' = tcb\<lparr>tcb_bound_notification := None\<rparr>;
+       aag_subjects_have_auth_to subjects aag Reset (the (tcb_bound_notification tcb)) \<rbrakk>
+       \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
   (* Allow subjects to delete their reply caps in other subjects' threads.
    * Note that we need to account for the reply cap being in tcb_ctable,
    * because recursive deletion of the root CNode may temporarily place any
    * contained cap (in particular, a copied reply cap) in that location. *)
 | troa_tcb_empty_ctable:
-    "\<lbrakk>ko = Some (TCB tcb); ko' = Some (TCB tcb');
-      tcb' = tcb\<lparr>tcb_ctable := cap'\<rparr>;
-      reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) cap'\<rbrakk>
-    \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+    "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       tcb' = tcb\<lparr>tcb_ctable := cap'\<rparr>;
+       reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) cap' \<rbrakk>
+       \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
 | troa_tcb_empty_caller:
-    "\<lbrakk>ko = Some (TCB tcb); ko' = Some (TCB tcb');
-      tcb' = tcb\<lparr>tcb_caller := cap'\<rparr>;
-      reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap'\<rbrakk>
-    \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+    "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       tcb' = tcb\<lparr>tcb_caller := cap'\<rparr>;
+       reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap' \<rbrakk>
+       \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
   (* If the activate flag is on, any thread in Restart state can be restarted *)
 | troa_tcb_activate:
-    "\<lbrakk>ko = Some (TCB tcb); ko' = Some (TCB tcb');
-      tcb' = tcb\<lparr>tcb_arch := arch_tcb_context_set
-                        ((arch_tcb_context_get (tcb_arch tcb))(NextIP :=
-                                          (arch_tcb_context_get (tcb_arch tcb)) FaultIP)
-                        ) (tcb_arch tcb),
-                   tcb_state := Running\<rparr>;
-      tcb_state tcb = Restart;
-      activate\<rbrakk> \<comment> \<open>Anyone can do this\<close>
-     \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
-  (* Subjects can clear ASIDs that they control *)
-| troa_asidpool_clear:
-    "\<lbrakk>ko = Some (ArchObj (ASIDPool pool)); ko' = Some (ArchObj (ASIDPool pool'));
-      asid_pool_integrity subjects aag pool pool' \<rbrakk>
-    \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+    "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       tcb' = tcb\<lparr>tcb_arch := arch_IP_update (tcb_arch tcb),
+                  tcb_state := Running\<rparr>;
+       tcb_state tcb = Restart; activate \<rbrakk> \<comment> \<open>Anyone can do this\<close>
+       \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
   (* If there is a deletable_cap in a CNode, it must be allowed to be deleted *)
 | troa_cnode:
-      "\<lbrakk>ko = Some (CNode n content); ko' = Some (CNode n content');
+      "\<lbrakk> ko = Some (CNode n content); ko' = Some (CNode n content');
          cnode_integrity subjects aag content content' \<rbrakk>
-       \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+         \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
+  (* Arch-specific rules *)
+| troa_arch:
+      "\<lbrakk> ko = Some (ArchObj ao); ko' = Some (ArchObj ao');
+         arch_integrity_obj_atomic aag subjects l ao ao' \<rbrakk>
+         \<Longrightarrow> integrity_obj_atomic aag activate subjects l ko ko'"
 
-definition integrity_obj
-  where
+definition integrity_obj where
   "integrity_obj aag activate subjects l \<equiv> (integrity_obj_atomic aag activate subjects l)\<^sup>*\<^sup>*"
 
-subsubsection \<open>Introduction rules for object integrity\<close>
-
-lemma troa_tro:
-  "integrity_obj_atomic aag activate subjects l ko ko'
-    \<Longrightarrow> integrity_obj aag activate subjects l ko ko'"
-  unfolding integrity_obj_def by (rule r_into_rtranclp)
-
-lemmas tro_lrefl = troa_lrefl[THEN troa_tro]
-lemma tro_orefl:
-  "\<lbrakk> ko = ko' \<rbrakk> \<Longrightarrow> integrity_obj aag activate subjects l' ko ko'"
-  unfolding integrity_obj_def by simp
-lemmas tro_ntfn = troa_ntfn[THEN troa_tro]
-lemmas tro_ep = troa_ep[THEN troa_tro]
-lemmas tro_ep_unblock = troa_ep_unblock[THEN troa_tro]
-lemmas tro_tcb_send = troa_tcb_send[THEN troa_tro]
-lemmas tro_tcb_call = troa_tcb_call[THEN troa_tro]
-lemmas tro_tcb_reply = troa_tcb_reply[THEN troa_tro]
-lemmas tro_tcb_receive = troa_tcb_receive[THEN troa_tro]
-lemmas tro_tcb_restart = troa_tcb_restart[THEN troa_tro]
-lemmas tro_tcb_unbind = troa_tcb_unbind[THEN troa_tro]
-lemmas tro_tcb_empty_ctable = troa_tcb_empty_ctable[THEN troa_tro]
-lemmas tro_tcb_empty_caller = troa_tcb_empty_caller[THEN troa_tro]
-lemmas tro_tcb_activate = troa_tcb_activate[THEN troa_tro]
-lemmas tro_asidpool_clear = troa_asidpool_clear[THEN troa_tro]
-lemmas tro_cnode = troa_cnode[THEN troa_tro]
-
-lemmas tro_intros = tro_lrefl tro_orefl tro_ntfn tro_ep tro_ep_unblock tro_tcb_send tro_tcb_call
-           tro_tcb_reply tro_tcb_receive tro_tcb_restart tro_tcb_unbind tro_tcb_empty_ctable
-           tro_tcb_empty_caller tro_tcb_activate tro_asidpool_clear tro_cnode
-
-lemma tro_tcb_unbind':
-  "\<lbrakk> ko  = Some (TCB tcb); ko' = Some (TCB tcb');
-     tcb' = tcb\<lparr>tcb_bound_notification := ntfn'\<rparr>;
-     tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag\<rbrakk>
-                 \<Longrightarrow> integrity_obj aag activate subjects l' ko ko'"
-  apply (clarsimp simp:tcb_bound_notification_reset_integrity_def)
-  apply (elim disjE)
-   apply (rule tro_orefl;fastforce)
-  apply (rule tro_tcb_unbind;fastforce)
-  done
-
-lemmas rtranclp_transp[intro!] = transp_rtranclp
-
-lemma tro_transp[intro!]:
-  "transp (integrity_obj aag activate es subjects)"
-  unfolding integrity_obj_def by simp
-
-lemmas tro_trans_spec = tro_transp[THEN transpD]
-
-lemma tro_tcb_generic':
-  "\<lbrakk>ko = Some (TCB tcb); ko' = Some (TCB tcb');
-    tcb' = tcb \<lparr>tcb_bound_notification := ntfn', tcb_caller := cap', tcb_ctable := ccap'\<rparr>;
-    tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag ;
-    reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
-    reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap' \<rbrakk>
-   \<Longrightarrow> integrity_obj aag activate subjects l' ko ko'"
-  apply clarsimp
-  apply (rule tro_trans_spec)
-   apply (rule tro_tcb_empty_caller[OF refl refl refl];simp)
-  apply (rule tro_trans_spec)
-   apply (rule tro_tcb_empty_ctable[OF refl refl refl];simp)
-  apply (rule tro_trans_spec)
-   apply (rule tro_tcb_unbind'[OF refl refl refl];simp)
-  apply (fastforce intro!: tro_orefl tcb.equality)
-  done
-
-lemma tro_tcb_reply':
-  "\<lbrakk>ko = Some (TCB tcb); ko' = Some (TCB tcb');
-    tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
-                        tcb_state := new_st, tcb_fault := None\<rparr>;
-    new_st = Running \<or> (tcb_fault tcb \<noteq> None \<and> (new_st = Restart \<or> new_st = Inactive));
-    direct_reply subjects aag l' tcb \<rbrakk>
-   \<Longrightarrow> integrity_obj aag activate subjects l' ko ko'"
-  apply (clarsimp simp:direct_reply_def simp del:not_None_eq)
-  apply (erule disjE, (rule tro_tcb_reply[OF refl refl], force; force)) (* Warning: schematics *)
-  apply (clarsimp simp del:not_None_eq)
-  apply (rule tro_trans_spec)
-   apply (frule allowed_call_blocked_def[THEN meta_eq_to_obj_eq,THEN iffD1],clarsimp)
-   apply (rule tro_tcb_receive[OF refl refl refl, where new_st=BlockedOnReply];force)
-  apply (rule tro_trans_spec)
-   apply (rule tro_tcb_reply[OF refl refl refl, where new_st=new_st];force)
-  by (fastforce intro!: tro_orefl tcb.equality)
-
-abbreviation integrity_obj_state
-where
+abbreviation integrity_obj_state where
   "integrity_obj_state aag activate subjects s s' \<equiv>
-       (\<forall>x. integrity_obj aag activate subjects (pasObjectAbs aag x) (kheap s x) (kheap s' x))"
-
+     (\<forall>x. integrity_obj aag activate subjects (pasObjectAbs aag x) (kheap s x) (kheap s' x))"
 
 
 subsubsection \<open>Alternative tagged formulation of object integrity\<close>
 
-datatype Tro_rules = LRefl | ORefl | RNtfn | REp | EpUnblock | TCBSend | TCBCall |
-  TCBReply | TCBReceive | TCBRestart | TCBGeneric | RASID | TCBActivate | RCNode
+datatype Tro_rules = LRefl | ORefl | RNtfn | REp | EpUnblock | TCBSend | TCBCall | TCBReply
+                           | TCBReceive | TCBRestart | TCBGeneric | RArch | TCBActivate | RCNode
 
-definition tro_tag :: "Tro_rules \<Rightarrow> bool"
-where
+definition tro_tag :: "Tro_rules \<Rightarrow> bool" where
   "tro_tag t \<equiv> True"
 
 (* do not put that one in the simpset unless you know what you are doing *)
@@ -1298,8 +524,7 @@ lemma tro_tagI[intro!]:
   "tro_tag t"
   unfolding tro_tag_def ..
 
-definition tro_tag' :: "Tro_rules \<Rightarrow> bool"
-where
+definition tro_tag' :: "Tro_rules \<Rightarrow> bool" where
   "tro_tag' t \<equiv> True"
 
 (* do not put that one in the simpset unless you know what you are doing *)
@@ -1329,145 +554,111 @@ text \<open>
       implying @{const integrity_obj}. It is not quite true, and we
       do not need it in any case.
 \<close>
-inductive integrity_obj_alt for aag activate subjects l' ko ko'
-where
+
+inductive integrity_obj_alt for aag activate subjects l' ko ko' where
   tro_alt_lrefl:
-      "\<lbrakk> tro_tag LRefl ; l' \<in> subjects  \<rbrakk> \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
+    "\<lbrakk> tro_tag LRefl; l' \<in> subjects \<rbrakk> \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
 | tro_alt_orefl:
-      "\<lbrakk> tro_tag ORefl; ko = ko' \<rbrakk> \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
+    "\<lbrakk> tro_tag ORefl; ko = ko' \<rbrakk> \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
 | tro_alt_ntfn:
-      "\<lbrakk>tro_tag RNtfn; ko = Some (Notification ntfn); ko' = Some (Notification ntfn');
-        auth \<in> {Receive, Notify, Reset};
-        \<exists>s \<in> subjects. (s, auth, l') \<in> pasPolicy aag \<rbrakk>
+    "\<lbrakk> tro_tag RNtfn; ko = Some (Notification ntfn); ko' = Some (Notification ntfn');
+       auth \<in> {Receive, Notify, Reset};
+       \<exists>s \<in> subjects. (s, auth, l') \<in> pasPolicy aag \<rbrakk>
        \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
 | tro_alt_ep:
-      "\<lbrakk>tro_tag REp; ko = Some (Endpoint ep); ko' = Some (Endpoint ep');
-             auth \<in> {Receive, SyncSend, Reset};
-             (\<exists>s \<in> subjects. (s, auth, l') \<in> pasPolicy aag) \<rbrakk>
-           \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
-| tro_alt_ep_unblock:
-      "\<lbrakk>tro_tag EpUnblock; ko = Some (Endpoint ep); ko' = Some (Endpoint ep');
-        \<exists>tcb ntfn. (tcb, Receive, pasObjectAbs aag ntfn) \<in> pasPolicy aag \<and>
-                   (tcb, Receive, l') \<in> pasPolicy aag \<and>
-        aag_subjects_have_auth_to subjects aag Notify ntfn \<rbrakk>
+    "\<lbrakk> tro_tag REp; ko = Some (Endpoint ep); ko' = Some (Endpoint ep');
+       auth \<in> {Receive, SyncSend, Reset}; (\<exists>s \<in> subjects. (s, auth, l') \<in> pasPolicy aag) \<rbrakk>
        \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
-
+| tro_alt_ep_unblock:
+    "\<lbrakk> tro_tag EpUnblock; ko = Some (Endpoint ep); ko' = Some (Endpoint ep');
+       \<exists>tcb ntfn. (tcb, Receive, pasObjectAbs aag ntfn) \<in> pasPolicy aag \<and>
+                  (tcb, Receive, l') \<in> pasPolicy aag \<and>
+                  aag_subjects_have_auth_to subjects aag Notify ntfn \<rbrakk>
+       \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
 | tro_alt_tcb_send:
-      "\<lbrakk>tro_tag TCBSend; ko = Some (TCB tcb); ko' = Some (TCB tcb');
-        \<exists>ctxt'. tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
-                            tcb_state := Running,
-                            tcb_bound_notification := ntfn', tcb_caller := cap',
-                            tcb_ctable := ccap'\<rparr>;
-        tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag;
-        reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
-        reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap';
-        direct_send subjects aag ep tcb \<or> indirect_send subjects aag (the (tcb_bound_notification tcb)) ep tcb \<rbrakk>
+    "\<lbrakk> tro_tag TCBSend; ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       \<exists>ctxt'. tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
+                           tcb_state := Running, tcb_bound_notification := ntfn',
+                           tcb_caller := cap', tcb_ctable := ccap'\<rparr>;
+       tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag;
+       reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
+       reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap';
+       direct_send subjects aag ep tcb
+       \<or> indirect_send subjects aag (the (tcb_bound_notification tcb)) ep tcb \<rbrakk>
        \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
 | tro_alt_tcb_call:
-      "\<lbrakk>tro_tag TCBCall; ko = Some (TCB tcb); ko' = Some (TCB tcb');
-        \<exists>ctxt'. tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
-                            tcb_state := Running,
-                            tcb_bound_notification := ntfn', tcb_caller := cap',
-                            tcb_ctable := ccap'\<rparr>;
-        pasObjectAbs aag caller \<in> subjects;
-        tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag;
-        reply_cap_deletion_integrity subjects aag (ReplyCap caller False R) cap';
-        reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap';
-        direct_call subjects aag ep (tcb_state tcb) \<rbrakk>
+    "\<lbrakk> tro_tag TCBCall; ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       \<exists>ctxt'. tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
+                           tcb_state := Running, tcb_bound_notification := ntfn',
+                            tcb_caller := cap', tcb_ctable := ccap'\<rparr>;
+       pasObjectAbs aag caller \<in> subjects;
+       tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag;
+       reply_cap_deletion_integrity subjects aag (ReplyCap caller False R) cap';
+       reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap';
+       direct_call subjects aag ep (tcb_state tcb) \<rbrakk>
        \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
 | tro_alt_tcb_reply:
-      "\<lbrakk>tro_tag TCBReply; ko = Some (TCB tcb); ko' = Some (TCB tcb');
-        \<exists>ctxt'. tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
-                            tcb_state := new_st, tcb_fault := None,
-                            tcb_bound_notification := ntfn', tcb_caller := cap',
-                            tcb_ctable := ccap'\<rparr>;
-        new_st = Running \<or> (tcb_fault tcb \<noteq> None \<and> (new_st = Restart \<or> new_st = Inactive));
-        tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag;
-        reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
-        reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap';
-        direct_reply subjects aag l' tcb \<rbrakk>
+    "\<lbrakk> tro_tag TCBReply; ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       \<exists>ctxt'. tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
+                           tcb_state := new_st, tcb_fault := None,
+                           tcb_bound_notification := ntfn',
+                           tcb_caller := cap', tcb_ctable := ccap'\<rparr>;
+       new_st = Running \<or> (tcb_fault tcb \<noteq> None \<and> (new_st = Restart \<or> new_st = Inactive));
+       tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag;
+       reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
+       reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap';
+       direct_reply subjects aag l' tcb \<rbrakk>
        \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
 | tro_alt_tcb_receive:
-      "\<lbrakk>tro_tag TCBReceive; ko = Some (TCB tcb); ko' = Some (TCB tcb');
-        tcb' = tcb \<lparr>tcb_state := new_st, tcb_bound_notification := ntfn', tcb_caller := cap',
-                    tcb_ctable := ccap'\<rparr>;
-        new_st = Running \<or> (((new_st = Inactive \<and> call_blocked ep (tcb_state tcb)) \<or> (new_st = BlockedOnReply \<and> (allowed_call_blocked ep (tcb_state tcb)))));
-        tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag;
-        reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
-        reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap';
-        send_blocked_on ep (tcb_state tcb);
-        aag_subjects_have_auth_to subjects aag Receive ep \<rbrakk>
+    "\<lbrakk> tro_tag TCBReceive; ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       tcb' = tcb \<lparr>tcb_state := new_st, tcb_bound_notification := ntfn',
+                   tcb_caller := cap', tcb_ctable := ccap'\<rparr>;
+       new_st = Running \<or> ((new_st = Inactive \<and> call_blocked ep (tcb_state tcb)) \<or>
+       (new_st = BlockedOnReply \<and> (allowed_call_blocked ep (tcb_state tcb))));
+       tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag;
+       reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
+       reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap';
+       send_blocked_on ep (tcb_state tcb);
+       aag_subjects_have_auth_to subjects aag Receive ep \<rbrakk>
        \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
 | tro_alt_tcb_restart:
-      "\<lbrakk>tro_tag TCBRestart; ko  = Some (TCB tcb); ko' = Some (TCB tcb');
-        tcb' = tcb\<lparr> tcb_arch := arch_tcb_context_set
-                                         (arch_tcb_context_get (tcb_arch tcb')) (tcb_arch tcb),
-                    tcb_state := tcb_state tcb', tcb_bound_notification := ntfn',
-                    tcb_caller := cap',tcb_ctable := ccap'\<rparr>;
-        (tcb_state tcb' = Restart \<and>
-               arch_tcb_context_get (tcb_arch tcb') = arch_tcb_context_get (tcb_arch tcb)) \<or>
-        (tcb_state tcb' = Running \<and>
-        arch_tcb_context_get (tcb_arch tcb')
-             = (arch_tcb_context_get (tcb_arch tcb))
-                   (NextIP := arch_tcb_context_get (tcb_arch tcb) FaultIP));
-        tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag;
-        reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
-        reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap';
-        blocked_on ep (tcb_state tcb);
-        aag_subjects_have_auth_to subjects aag Reset ep \<rbrakk>
+    "\<lbrakk> tro_tag TCBRestart; ko  = Some (TCB tcb); ko' = Some (TCB tcb');
+       tcb' = tcb\<lparr>tcb_arch := new_arch, tcb_state := tcb_state tcb',
+                  tcb_bound_notification := ntfn', tcb_caller := cap', tcb_ctable := ccap'\<rparr>;
+       (tcb_state tcb' = Restart \<and> new_arch = tcb_arch tcb) \<or>
+       (tcb_state tcb' = Running \<and> new_arch = arch_IP_update (tcb_arch tcb));
+       tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag;
+       reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
+       reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap';
+       blocked_on ep (tcb_state tcb);
+       aag_subjects_have_auth_to subjects aag Reset ep \<rbrakk>
        \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
 | tro_alt_tcb_generic:
-      "\<lbrakk>tro_tag TCBGeneric; ko = Some (TCB tcb); ko' = Some (TCB tcb');
-        tcb' = tcb \<lparr>tcb_bound_notification := ntfn', tcb_caller := cap', tcb_ctable := ccap'\<rparr>;
-        tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag ;
-        reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
-        reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap' \<rbrakk>
-       \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
-| tro_alt_asidpool_clear:
-      "\<lbrakk>tro_tag RASID; ko = Some (ArchObj (ASIDPool pool)); ko' = Some (ArchObj (ASIDPool pool'));
-        asid_pool_integrity subjects aag pool pool'\<rbrakk>
+    "\<lbrakk> tro_tag TCBGeneric; ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       tcb' = tcb \<lparr>tcb_bound_notification := ntfn', tcb_caller := cap', tcb_ctable := ccap'\<rparr>;
+       tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag ;
+       reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
+       reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap' \<rbrakk>
        \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
 | tro_alt_tcb_activate:
-      "\<lbrakk>tro_tag TCBActivate; ko  = Some (TCB tcb); ko' = Some (TCB tcb');
-        tcb' = tcb \<lparr> tcb_arch := arch_tcb_context_set
-                              ((arch_tcb_context_get (tcb_arch tcb))(NextIP :=
-                                           (arch_tcb_context_get (tcb_arch tcb)) FaultIP)
-                               ) (tcb_arch tcb),
-                     tcb_caller := cap', tcb_ctable := ccap',
-                     tcb_state := Running, tcb_bound_notification := ntfn'\<rparr>;
-        tcb_state tcb = Restart;
-        reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
-        reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap';
-        tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag;
-        activate \<rbrakk> \<comment> \<open>Anyone can do this\<close>
+    "\<lbrakk> tro_tag TCBActivate; ko  = Some (TCB tcb); ko' = Some (TCB tcb');
+       tcb' = tcb \<lparr>tcb_arch := arch_IP_update (tcb_arch tcb),
+                   tcb_caller := cap', tcb_ctable := ccap',
+                   tcb_state := Running, tcb_bound_notification := ntfn'\<rparr>;
+       tcb_state tcb = Restart;
+       reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
+       reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap';
+       tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag;
+       activate \<rbrakk> \<comment> \<open>Anyone can do this\<close>
        \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
 | tro_alt_cnode:
-      "\<lbrakk>tro_tag RCNode; ko  = Some (CNode n content); ko' = Some (CNode n content');
-        cnode_integrity subjects aag content content' \<rbrakk>
+    "\<lbrakk> tro_tag RCNode; ko  = Some (CNode n content); ko' = Some (CNode n content');
+       cnode_integrity subjects aag content content' \<rbrakk>
        \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
-
-lemmas disj_cong' = arg_cong2[where f="(\<or>)"]
-
-
-lemma troa_tro_alt[elim!]:
-  "integrity_obj_atomic aag activate subjects l ko ko'
-   \<Longrightarrow> integrity_obj_alt aag activate subjects l ko ko'"
-  apply (erule integrity_obj_atomic.cases)
-
-  text \<open>Single out TCB cases for special handling. We manually simplify
-        the TCB updates in the tro_alt rules using @{thm tcb.equality}.\<close>
-  (* somewhat slow 10s *)
-  apply (find_goal \<open>match premises in "ko = Some (TCB _)" \<Rightarrow> succeed\<close>,
-         ((erule(1) integrity_obj_alt.intros[OF tro_tagI],
-                  (intro exI tcb.equality; solves \<open>simp\<close>));
-          fastforce simp: reply_cap_deletion_integrity_def
-                          tcb_bound_notification_reset_integrity_def
-                          direct_reply_def))+
-
-  text \<open>Remaining cases.\<close>
-  apply (fastforce intro: integrity_obj_alt.intros[OF tro_tagI])+
-  done
-
+| tro_alt_arch:
+    "\<lbrakk> tro_tag RArch; ko = Some (ArchObj ao); ko' = Some (ArchObj ao');
+       arch_integrity_obj_alt aag subjects l' ao ao'\<rbrakk>
+       \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
 
 
 subsubsection \<open>ekheap and ready queues\<close>
@@ -1485,81 +676,105 @@ text\<open>
 
 \<close>
 
-definition integrity_ready_queues
-where
+definition integrity_ready_queues where
   "integrity_ready_queues aag subjects queue_labels rq rq' \<equiv>
      pasMayEditReadyQueues aag \<or> (queue_labels \<inter> subjects = {} \<longrightarrow> (\<exists>threads. threads @ rq = rq'))"
 
-lemma integrity_ready_queues_refl[simp]: "integrity_ready_queues aag subjects ptr s s"
-unfolding integrity_ready_queues_def by simp
+inductive integrity_eobj for aag subjects l' eko eko' where
+  tre_lrefl: "l' \<in> subjects \<Longrightarrow> integrity_eobj aag subjects l' eko eko'"
+| tre_orefl: "eko = eko' \<Longrightarrow> integrity_eobj aag subjects l' eko eko'"
 
-inductive integrity_eobj for aag subjects l' eko eko'
-where
-  tre_lrefl: "\<lbrakk> l' \<in> subjects \<rbrakk> \<Longrightarrow> integrity_eobj aag subjects l' eko eko'"
-| tre_orefl: "\<lbrakk> eko = eko' \<rbrakk> \<Longrightarrow> integrity_eobj aag subjects l' eko eko'"
 
-subsubsection \<open>generic stuff : FIXME MOVE\<close>
-
-lemma integrity_obj_activate:
-  "integrity_obj aag False subjects l' ko ko' \<Longrightarrow>
-   integrity_obj aag activate subjects l' ko ko'"
-  unfolding integrity_obj_def
-  apply (erule rtranclp_mono[THEN predicate2D, rotated])
-  apply (rule predicate2I)
-  by (erule integrity_obj_atomic.cases; (intro integrity_obj_atomic.intros; assumption | simp))
-
-abbreviation object_integrity
-where
+abbreviation object_integrity where
   "object_integrity aag \<equiv> integrity_obj (aag :: 'a PAS) (pasMayActivate aag) {pasSubject aag}"
 
 
-subsection \<open>auth_ipc_buffer\<close>
+subsection \<open>How the CDT can change\<close>
 
-definition auth_ipc_buffers :: "'z::state_ext state \<Rightarrow> obj_ref \<Rightarrow> obj_ref set"
-where
-  "auth_ipc_buffers s \<equiv>
-     \<lambda>p. case (get_tcb p s) of
-         None \<Rightarrow> {}
-       | Some tcb \<Rightarrow>
-           (case tcb_ipcframe tcb of
-              cap.ArchObjectCap (arch_cap.PageCap False p' R vms _) \<Rightarrow>
-                if AllowWrite \<in> R
-                then (ptr_range (p' + (tcb_ipc_buffer tcb && mask (pageBitsForSize vms)))
-                                msg_align_bits)
-                else {}
-            | _ \<Rightarrow> {})"
+text \<open>
+  The CDT and CDT_list integrity relations describe which modification to the CDT (@{term cdt})
+  , @{term is_original_cap} and @{term cdt_list})
+  are allowed by the policy aag when the system is controlled by subjects.
 
-(* MOVE *)
-lemma caps_of_state_tcb':
-  "\<lbrakk> get_tcb p s = Some tcb; option_map fst (tcb_cap_cases idx) = Some getF \<rbrakk> \<Longrightarrow> caps_of_state s (p, idx) = Some (getF tcb)"
-  apply (drule get_tcb_SomeD)
-  apply clarsimp
-  apply (drule (1) cte_wp_at_tcbI [where t = "(p, idx)" and P = "(=) (getF tcb)", simplified])
-  apply simp
-  apply (clarsimp simp: cte_wp_at_caps_of_state)
-  done
+  A modification to the CDT at a specific slot can happen for different reasons :
+  \begin{itemize}
+  \item we own directly or indirectly the slot. The "indirectly" means that
+        if an ancestor of a slot is owned by the subject, the slot is indirectly own by the subject
+  \item we are allowed explicitly to take ownership of the slot, for now this only happens when
+        we call someone: we are allowed to put a reply cap in its caller slot (slot number 3)
+\<close>
 
-(* MOVE *)
-lemma caps_of_state_tcb_cap_cases:
-  "\<lbrakk> get_tcb p s = Some tcb; idx \<in> dom tcb_cap_cases \<rbrakk> \<Longrightarrow> caps_of_state s (p, idx) = Some ((the (option_map fst (tcb_cap_cases idx))) tcb)"
-  apply (clarsimp simp: dom_def)
-  apply (erule caps_of_state_tcb')
-  apply simp
-  done
+(* FIXME MOVE *)
+notation parent_of_rtrancl ("_ \<Turnstile> _ \<rightarrow>* _" [60,0,60] 60)
 
-lemma auth_ipc_buffers_member_def:
-  "x \<in> auth_ipc_buffers s p =
-      (\<exists>tcb p' R vms xx. get_tcb p s = Some tcb
-                       \<and> tcb_ipcframe tcb = (cap.ArchObjectCap (arch_cap.PageCap False p' R vms xx))
-                       \<and> caps_of_state s (p, tcb_cnode_index 4) =
-                                    Some (cap.ArchObjectCap (arch_cap.PageCap False p' R vms xx))
-                       \<and> AllowWrite \<in> R
-                       \<and> x \<in> ptr_range (p' + (tcb_ipc_buffer tcb && mask (pageBitsForSize vms)))
-                                       msg_align_bits)"
-  unfolding auth_ipc_buffers_def
-  by (clarsimp simp: caps_of_state_tcb' split: option.splits cap.splits arch_cap.splits bool.splits)
+inductive cdt_direct_change_allowed for aag subjects tcbsts ptr where
+  cdca_owned:
+    "pasObjectAbs aag (fst ptr) \<in> subjects \<Longrightarrow> cdt_direct_change_allowed aag subjects tcbsts ptr"
+| cdca_reply:
+    "\<lbrakk> tcbsts (fst ptr) = Some tcbst; direct_call subjects aag ep tcbst; (snd ptr) = tcb_cnode_index 3 \<rbrakk>
+       \<Longrightarrow> cdt_direct_change_allowed aag subjects tcbsts ptr"
 
-subsection \<open>How User and device memory can change\<close>
+(* for the moment the only caps that can be affected by that indirect control are reply caps *)
+definition cdt_change_allowed where
+  "cdt_change_allowed aag subjects m tcbsts ptr \<equiv>
+     \<exists>pptr. m \<Turnstile> pptr \<rightarrow>* ptr \<and> cdt_direct_change_allowed aag subjects tcbsts pptr"
+
+(* FIXME get a coherent naming scheme *)
+abbreviation cdt_change_allowed' where
+  "cdt_change_allowed' aag ptr s \<equiv>
+     cdt_change_allowed aag {pasSubject aag} (cdt s) (tcb_states_of_state s) ptr"
+
+text\<open>
+  ptr is the slot we currently looking at
+  s is the initial state (v should be coherent with s)
+  v = (initial parent of ptr, initial "originality" of ptr)
+  v' = (final parent of ptr, final "originality" of ptr)
+\<close>
+definition integrity_cdt ::
+   "'a PAS \<Rightarrow> 'a set \<Rightarrow> cdt \<Rightarrow> (obj_ref \<Rightarrow> thread_state option) \<Rightarrow> cslot_ptr
+           \<Rightarrow> (cslot_ptr option \<times> bool) \<Rightarrow> (cslot_ptr option \<times> bool) \<Rightarrow> bool" where
+  "integrity_cdt aag subjects m tcbsts ptr v v' \<equiv>
+     v = v' \<or> cdt_change_allowed aag subjects m tcbsts ptr"
+
+abbreviation integrity_cdt_state where
+  "integrity_cdt_state aag subjects s s' \<equiv>
+     (\<forall>x. integrity_cdt aag subjects (cdt s) (tcb_states_of_state s) x
+                        (cdt s x,is_original_cap s x) (cdt s' x, is_original_cap s' x))"
+
+abbreviation "cdt_integrity aag \<equiv> integrity_cdt (aag :: 'a PAS) {pasSubject aag} "
+
+abbreviation cdt_integrity_state where
+  "cdt_integrity_state aag s s' \<equiv>
+     (\<forall>x. integrity_cdt (aag :: 'a PAS) {pasSubject aag} (cdt s) (tcb_states_of_state s) x
+                        (cdt s x,is_original_cap s x) (cdt s' x, is_original_cap s' x))"
+
+text\<open>
+  m is the cdt of the initial state
+  tcbsts are tcb_states_of_state of the initial state
+  ptr is the slot we currently looking at
+  l and l' are the initial and final list of children of ptr
+\<close>
+definition integrity_cdt_list ::
+   "'a PAS \<Rightarrow> 'a set \<Rightarrow> cdt \<Rightarrow> (obj_ref \<Rightarrow> thread_state option)
+           \<Rightarrow> cslot_ptr \<Rightarrow> (cslot_ptr list) \<Rightarrow> (cslot_ptr list) \<Rightarrow> bool" where
+  "integrity_cdt_list aag subjects m tcbsts ptr l l' \<equiv>
+     filtered_eq (cdt_change_allowed aag subjects m tcbsts) l l'
+   \<or> cdt_change_allowed aag subjects m tcbsts ptr"
+
+abbreviation integrity_cdt_list_state where
+  "integrity_cdt_list_state aag subjects s s' \<equiv>
+     (\<forall>x. integrity_cdt_list aag subjects (cdt s) (tcb_states_of_state s)
+                             x (cdt_list s x) (cdt_list s' x))"
+
+abbreviation "cdt_list_integrity aag \<equiv> integrity_cdt_list (aag :: 'a PAS) {pasSubject aag}"
+
+abbreviation cdt_list_integrity_state where
+  "cdt_list_integrity_state aag  s s' \<equiv>
+     (\<forall>x. integrity_cdt_list (aag :: 'a PAS) {pasSubject aag} (cdt s) (tcb_states_of_state s) x
+                             (cdt_list s x) (cdt_list s' x))"
+
+
+subsection \<open>How user and device memory can change\<close>
 
 text \<open>
   The memory integrity relation describes which modification to user memory are allowed by the
@@ -1584,217 +799,39 @@ text \<open>
   Inductive for now, we should add something about user memory/transitions.
 \<close>
 
-inductive integrity_mem for aag subjects p ts ts' ipcbufs globals w w'
-where
-  trm_lrefl: "\<lbrakk> pasObjectAbs aag p \<in> subjects \<rbrakk>
-     \<Longrightarrow> integrity_mem aag subjects p ts ts' ipcbufs globals w w'" (* implied by wf and write *)
-  | trm_orefl: "\<lbrakk> w = w' \<rbrakk> \<Longrightarrow> integrity_mem aag subjects p ts ts' ipcbufs globals w w'"
-  | trm_write: "\<lbrakk> aag_subjects_have_auth_to subjects aag Write p \<rbrakk> \<Longrightarrow> integrity_mem aag subjects p ts ts' ipcbufs globals w w'"
-  | trm_globals: "\<lbrakk> p \<in> globals \<rbrakk> \<Longrightarrow> integrity_mem aag subjects p ts ts' ipcbufs globals w w'"
-  | trm_ipc: "\<lbrakk> case_option False can_receive_ipc (ts p'); ts' p' = Some Structures_A.Running;
-                p \<in> ipcbufs p'; pasObjectAbs aag p' \<notin> subjects
-        \<rbrakk> \<Longrightarrow> integrity_mem aag subjects p ts ts' ipcbufs globals w w'"
+inductive integrity_mem for aag subjects p ts ts' ipcbufs globals w w' where
+  trm_lrefl:
+    "pasObjectAbs aag p \<in> subjects \<Longrightarrow> integrity_mem aag subjects p ts ts' ipcbufs globals w w'"
+| trm_orefl:
+    "w = w' \<Longrightarrow> integrity_mem aag subjects p ts ts' ipcbufs globals w w'"
+| trm_write:
+    "aag_subjects_have_auth_to subjects aag Write p
+     \<Longrightarrow> integrity_mem aag subjects p ts ts' ipcbufs globals w w'"
+| trm_globals:
+    "p \<in> globals \<Longrightarrow> integrity_mem aag subjects p ts ts' ipcbufs globals w w'"
+| trm_ipc:
+    "\<lbrakk> case_option False can_receive_ipc (ts p');
+       ts' p' = Some Running; p \<in> ipcbufs p'; pasObjectAbs aag p' \<notin> subjects \<rbrakk>
+       \<Longrightarrow> integrity_mem aag subjects p ts ts' ipcbufs globals w w'"
 
+abbreviation
+  "memory_integrity X aag x t1 t2 ipc \<equiv> integrity_mem (aag :: 'a PAS) {pasSubject aag} x t1 t2 ipc X"
 
-abbreviation memory_integrity
-where
-  "memory_integrity X aag x t1 t2 ipc == integrity_mem (aag :: 'a PAS) {pasSubject aag} x t1 t2 ipc X"
-
-inductive integrity_device for aag subjects p ts ts' w w'
-where
-  trd_lrefl: "\<lbrakk> pasObjectAbs aag p \<in> subjects \<rbrakk>
-     \<Longrightarrow> integrity_device aag subjects p ts ts' w w'" (* implied by wf and write *)
-  | trd_orefl: "\<lbrakk> w = w' \<rbrakk> \<Longrightarrow> integrity_device aag subjects p ts ts' w w'"
-  | trd_write: "\<lbrakk> aag_subjects_have_auth_to subjects aag Write p \<rbrakk> \<Longrightarrow> integrity_device aag subjects p ts ts' w w'"
-
-lemmas integrity_obj_simps [simp] = tro_orefl[OF refl]
-    tro_lrefl[OF singletonI]
-    trm_orefl[OF refl]
-    trd_orefl[OF refl]
-    tre_lrefl[OF singletonI]
-    tre_orefl[OF refl]
-
-
-
-
-subsection \<open>How the CDT can change\<close>
-
-text \<open>
-  The CDT and CDT_list integrity relations describe which modification to the CDT (@{term cdt})
-  , @{term is_original_cap} and @{term cdt_list})
-  are allowed by the policy aag when the system is controlled by subjects.
-
-  A modification to the CDT at a specific slot can happen for different reasons :
-  \begin{itemize}
-  \item we own directly or indirectly the slot. The "indirectly" means that
-        if an ancestor of a slot is owned by the subject, the slot is indirectly own by the subject
-  \item we are allowed explicitly to take ownership of the slot, for now this only happens when
-        we call someone: we are allowed to put a reply cap in its caller slot (slot number 3)
-\<close>
-
-(* FIXME MOVE*)
-notation parent_of_rtrancl ("_ \<Turnstile> _ \<rightarrow>* _" [60,0,60] 60)
-
-inductive cdt_direct_change_allowed for aag subjects tcbsts ptr
-  where
-  cdca_owned:
-  "pasObjectAbs aag (fst ptr) \<in> subjects \<Longrightarrow> cdt_direct_change_allowed aag subjects tcbsts ptr"
-| cdca_reply:
-  "\<lbrakk>tcbsts (fst ptr) = Some tcbst; direct_call subjects aag ep tcbst; (snd ptr) = tcb_cnode_index 3\<rbrakk>
-   \<Longrightarrow> cdt_direct_change_allowed aag subjects tcbsts ptr"
-
-(* for the moment the only caps that can be affected by that indirect control are reply caps *)
-definition cdt_change_allowed
-  where
-  "cdt_change_allowed aag subjects m tcbsts ptr \<equiv>
-   \<exists> pptr. m \<Turnstile> pptr \<rightarrow>* ptr \<and> cdt_direct_change_allowed aag subjects tcbsts pptr"
-
-lemma cdt_change_allowedI:
-  "\<lbrakk>m \<Turnstile> pptr \<rightarrow>* ptr; cdt_direct_change_allowed aag subjects tcbsts pptr\<rbrakk>
-   \<Longrightarrow> cdt_change_allowed aag subjects m tcbsts ptr"
-  by (fastforce simp: cdt_change_allowed_def simp del: split_paired_Ex)
-
-lemma cdt_change_allowedE:
-  assumes "cdt_change_allowed aag subjects m tcbsts ptr"
-  obtains pptr where "m \<Turnstile> pptr \<rightarrow>* ptr" "cdt_direct_change_allowed aag subjects tcbsts pptr"
-  using assms by (fastforce simp: cdt_change_allowed_def simp del: split_paired_Ex)
-
-lemma cdca_ccaI:
-  "\<lbrakk>cdt_direct_change_allowed aag subjects tcbsts ptr\<rbrakk>
-   \<Longrightarrow> cdt_change_allowed aag subjects m tcbsts ptr"
-  by (fastforce simp: cdt_change_allowed_def simp del: split_paired_Ex)
-
-lemmas cca_owned = cdt_change_allowedI[OF _ cdca_owned]
-lemmas cca_reply' = cdt_change_allowedI[OF _ cdca_owned]
-lemmas cca_direct[intro] = cdca_ccaI[OF cdca_owned]
-lemmas cca_reply = cdca_ccaI[OF cdca_reply]
-
-lemma cca_direct_single[intro]:
-  "is_subject aag (fst ptr) \<Longrightarrow> cdt_change_allowed aag {pasSubject aag} m kh ptr"
-  apply (rule cca_direct) by blast
-
-(* FIXME get a coherent naming scheme *)
-abbreviation cdt_change_allowed'
-where
-  "cdt_change_allowed' aag ptr s \<equiv> cdt_change_allowed aag {pasSubject aag} (cdt s)
-(tcb_states_of_state s) ptr"
-
-
-
-text\<open>
-  ptr is the slot we currently looking at
-  s is the initial state (v should be coherent with s)
-  v = (initial parent of ptr, initial "originality" of ptr)
-  v' = (final parent of ptr, final "originality" of ptr)
-\<close>
-definition integrity_cdt
-  :: "'a PAS \<Rightarrow> 'a set \<Rightarrow> cdt \<Rightarrow> (obj_ref \<Rightarrow> thread_state option)
-       \<Rightarrow> cslot_ptr \<Rightarrow> (cslot_ptr option \<times> bool) \<Rightarrow> (cslot_ptr option \<times> bool) \<Rightarrow> bool"
-where
-  "integrity_cdt aag subjects m tcbsts ptr v v'
-     \<equiv> v = v' \<or> cdt_change_allowed aag subjects m tcbsts ptr"
-
-lemma integrity_cdtE:
-  assumes hyp:"integrity_cdt aag subjects m tcbsts ptr v v'"
-  obtains "v = v'" | "cdt_change_allowed aag subjects m tcbsts ptr"
-  using hyp integrity_cdt_def by blast
-
-abbreviation integrity_cdt_state
-where
-  "integrity_cdt_state aag subjects s s' \<equiv>
-   (\<forall>x. integrity_cdt aag subjects (cdt s) (tcb_states_of_state s) x
-                      (cdt s x,is_original_cap s x) (cdt s' x, is_original_cap s' x))"
-
-abbreviation cdt_integrity
-where
-  "cdt_integrity aag \<equiv> integrity_cdt (aag :: 'a PAS) {pasSubject aag} "
-
-abbreviation cdt_integrity_state
-where
-  "cdt_integrity_state aag s s' \<equiv>
-   (\<forall>x. integrity_cdt (aag :: 'a PAS) {pasSubject aag} (cdt s) (tcb_states_of_state s) x
-                      (cdt s x,is_original_cap s x) (cdt s' x, is_original_cap s' x))"
-
-lemma integrity_cdt_refl[simp]: "integrity_cdt aag subjects m kh ptr v v"
-  by (simp add: integrity_cdt_def)
-
-lemma integrity_cdt_change_allowed[simp,intro]:
-  "cdt_change_allowed aag subjects m kh ptr \<Longrightarrow> integrity_cdt aag subjects m kh ptr v v'"
-  by (simp add: integrity_cdt_def)
-
-lemmas integrity_cdt_intros = integrity_cdt_refl integrity_cdt_change_allowed
-
-lemmas integrity_cdt_direct = cca_direct[THEN  integrity_cdt_change_allowed]
-
-
-
-text\<open>
-  m is the cdt of the initial state
-  tcbsts are tcb_states_of_state of the initial state
-  ptr is the slot we currently looking at
-  l and l' are the initial and final list of children of ptr
-\<close>
-definition integrity_cdt_list
-  :: "'a PAS \<Rightarrow> 'a set \<Rightarrow> cdt \<Rightarrow> (obj_ref \<Rightarrow> thread_state option) \<Rightarrow> cslot_ptr \<Rightarrow>
-      (cslot_ptr list) \<Rightarrow> (cslot_ptr list) \<Rightarrow> bool"
-where
-  "integrity_cdt_list aag subjects m tcbsts ptr l l'
-     \<equiv> (filtered_eq (cdt_change_allowed aag subjects m tcbsts) l l') \<or>
-        cdt_change_allowed aag subjects m tcbsts ptr"
-
-abbreviation integrity_cdt_list_state
-where
-  "integrity_cdt_list_state aag subjects s s' \<equiv>
-     (\<forall>x. integrity_cdt_list aag subjects (cdt s) (tcb_states_of_state s) x (cdt_list s x) (cdt_list s' x))"
-
-abbreviation cdt_list_integrity
-where
-  "cdt_list_integrity aag == integrity_cdt_list (aag :: 'a PAS) {pasSubject aag}"
-
-abbreviation cdt_list_integrity_state
-where
-  "cdt_list_integrity_state aag  s s' \<equiv>
-     (\<forall>x. integrity_cdt_list (aag :: 'a PAS) {pasSubject aag} (cdt s) (tcb_states_of_state s) x
-                             (cdt_list s x) (cdt_list s' x))"
-
-lemma integrity_cdt_list_refl[simp]: "integrity_cdt_list aag subjects m kh ptr v v"
-  by (simp add: integrity_cdt_list_def)
-
-lemma integrity_cdt_list_filt:
-  "filtered_eq (cdt_change_allowed aag subjects m kh) l l' \<Longrightarrow> integrity_cdt_list aag subjects m kh ptr l l'"
-  by (simp add: integrity_cdt_list_def)
-lemma integrity_cdt_list_change_allowed:
-  "cdt_change_allowed aag subjects m kh ptr \<Longrightarrow> integrity_cdt_list aag subjects m kh ptr l l'"
-  by (simp add: integrity_cdt_list_def)
-
-lemmas integrity_cdt_list_intros = integrity_cdt_list_filt integrity_cdt_list_change_allowed
-
-lemma integrity_cdt_listE:
-  assumes hyp:"integrity_cdt_list aag subjects m kh ptr l l'"
-  obtains "filtered_eq (cdt_change_allowed aag subjects m kh) l l'" |
-          "cdt_change_allowed aag subjects m kh ptr"
-  using hyp integrity_cdt_list_def by blast
-
+inductive integrity_device for aag subjects p ts ts' w w' where
+  trd_lrefl:
+    "pasObjectAbs aag p \<in> subjects \<Longrightarrow> integrity_device aag subjects p ts ts' w w'"
+| trd_orefl:
+    "w = w' \<Longrightarrow> integrity_device aag subjects p ts ts' w w'"
+| trd_write:
+    "aag_subjects_have_auth_to subjects aag Write p \<Longrightarrow> integrity_device aag subjects p ts ts' w w'"
 
 
 subsection \<open>How other stuff can change\<close>
 
-definition integrity_interrupts
-  :: "'a PAS \<Rightarrow> 'a set \<Rightarrow> irq \<Rightarrow> (obj_ref \<times> irq_state) \<Rightarrow> (obj_ref \<times> irq_state) \<Rightarrow> bool"
-where
-  "integrity_interrupts aag subjects irq v v'
-     \<equiv> v = v' \<or> pasIRQAbs aag irq \<in> subjects"
+definition integrity_interrupts ::
+  "'a PAS \<Rightarrow> 'a set \<Rightarrow> irq \<Rightarrow> (obj_ref \<times> irq_state) \<Rightarrow> (obj_ref \<times> irq_state) \<Rightarrow> bool" where
+  "integrity_interrupts aag subjects irq v v' \<equiv> v = v' \<or> pasIRQAbs aag irq \<in> subjects"
 
-lemma integrity_interrupts_refl[simp]: "integrity_interrupts aag subjects ptr v v"
-  by (simp add: integrity_interrupts_def)
-
-definition integrity_asids :: "'a PAS \<Rightarrow> 'a set \<Rightarrow> asid \<Rightarrow> obj_ref option \<Rightarrow> obj_ref option \<Rightarrow> bool"
-where
-  "integrity_asids aag subjects asid pp_opt pp_opt'
-     \<equiv> pp_opt = pp_opt' \<or> (\<forall> asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of asid \<longrightarrow> pasASIDAbs aag asid' \<in> subjects)"
-
-lemma integrity_asids_refl[simp]: "integrity_asids aag subjects ptr s s"
-  by (simp add: integrity_asids_def)
 
 subsection \<open>General integrity\<close>
 
@@ -1809,1226 +846,58 @@ policy. See @{term "state_objs_to_policy s"} and @{term "pas_refined aag s"}.
 
 \<close>
 
-definition integrity_subjects
-  :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> bool \<Rightarrow> obj_ref set \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool"
-where
+definition integrity_subjects ::
+  "'a set \<Rightarrow> 'a PAS \<Rightarrow> bool \<Rightarrow> obj_ref set \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool" where
   "integrity_subjects subjects aag activate X s s' \<equiv>
-         (\<forall>x. integrity_obj aag activate subjects (pasObjectAbs aag x) (kheap s x) (kheap s' x)) \<and>
-         (\<forall>x. integrity_eobj aag subjects (pasObjectAbs aag x) (ekheap s x) (ekheap s' x)) \<and>
-         (\<forall>x. integrity_mem aag subjects x (tcb_states_of_state s) (tcb_states_of_state s')
-                       (auth_ipc_buffers s) X
-                       (underlying_memory (machine_state s) x)
-                       (underlying_memory (machine_state s') x)) \<and>
-         (\<forall>x. integrity_device aag subjects x (tcb_states_of_state s) (tcb_states_of_state s')
-                       (device_state (machine_state s) x)
-                       (device_state (machine_state s') x)) \<and>
-         integrity_cdt_state aag subjects s s'\<and>
-         integrity_cdt_list_state aag subjects s s' \<and>
-         (\<forall>x. integrity_interrupts aag subjects x (interrupt_irq_node s x, interrupt_states s x)
-                                   (interrupt_irq_node s' x, interrupt_states s' x)) \<and>
-         (\<forall>x. integrity_asids aag subjects x (arm_asid_table (arch_state s) (asid_high_bits_of x))
-                              (arm_asid_table (arch_state s') (asid_high_bits_of x))) \<and>
-         (\<forall>d p. integrity_ready_queues aag subjects (pasDomainAbs aag d) (ready_queues s d p)
-                                       (ready_queues s' d p))"
-
-abbreviation integrity
-where
-  "integrity pas \<equiv> integrity_subjects {pasSubject pas} pas (pasMayActivate pas)"
-
-
-
-section \<open>Integrity transitivity\<close>
-
-subsection \<open>Object integrity transitivity\<close>
-
-lemma clear_asidpool_trans[elim]:
-  "\<lbrakk>asid_pool_integrity subjects aag pool pool';
-    asid_pool_integrity subjects aag pool' pool''\<rbrakk>
-   \<Longrightarrow> asid_pool_integrity subjects aag pool pool''"
-  unfolding asid_pool_integrity_def
-  apply clarsimp
-  apply (drule_tac x=x in spec)+
-  apply auto
-  done
-
-lemma tcb_bound_notification_reset_integrity_trans[elim]:
-  "\<lbrakk> tcb_bound_notification_reset_integrity ntfn ntfn' subjects aag;
-    tcb_bound_notification_reset_integrity ntfn' ntfn'' subjects aag \<rbrakk>
-    \<Longrightarrow> tcb_bound_notification_reset_integrity ntfn ntfn'' subjects aag"
-  by (auto simp: tcb_bound_notification_reset_integrity_def)
-
-lemma reply_cap_deletion_integrity_trans[elim]:
-  "\<lbrakk> reply_cap_deletion_integrity subjects aag cap cap';
-    reply_cap_deletion_integrity subjects aag cap' cap'' \<rbrakk>
-    \<Longrightarrow> reply_cap_deletion_integrity subjects aag cap cap''"
-  by (auto simp: reply_cap_deletion_integrity_def)
-
-
-lemma cnode_integrity_trans[elim]:
-  "\<lbrakk> cnode_integrity subjects aag cont cont';
-    cnode_integrity subjects aag cont' cont'' \<rbrakk>
-    \<Longrightarrow> cnode_integrity subjects aag cont cont''"
-   unfolding cnode_integrity_def
-   apply (intro allI)
-   apply (drule_tac x=l in spec)+
-   by fastforce
-
-lemma tcb_bound_notification_reset_eq_or_none:
-  "tcb_bound_notification_reset_integrity ntfn ntfn' subjects aag \<Longrightarrow> ntfn = ntfn' \<or> ntfn' = None"
-  by (auto simp: tcb_bound_notification_reset_integrity_def)
-
-
-lemma tro_alt_trans_spec: (* this takes a long time to process *)
-  "\<lbrakk>integrity_obj_alt aag activate es subjects ko ko';
-    integrity_obj_alt aag activate es subjects ko' ko'' \<rbrakk> \<Longrightarrow>
-    integrity_obj_alt aag activate es subjects ko ko''"
-  (* We need to consider nearly 200 cases, one for each possible pair
-     of integrity steps. We use the tro_tags to select subsets of goals
-     that can be solved by the same method. *)
-
-  (* Expand the first integrity step *)
-  apply (erule integrity_obj_alt.cases[where ko=ko and ko'=ko'])
-
-  (* LRefl and ORefl trivially collapse into the second integrity step *)
-  apply (find_goal \<open>match premises in "tro_tag LRefl" \<Rightarrow> -\<close>)
-  subgoal by (rule tro_alt_lrefl, simp)
-
-  apply (find_goal \<open>match premises in "tro_tag ORefl" \<Rightarrow> -\<close>)
-  subgoal by simp
-
-  (* Now re-tag the first step with tro_tag' *)
-  apply (all \<open>simp only:tro_tag_to_prime\<close>)
-  (* Expand the second integrity step, which will be tagged with tro_tag *)
-  apply (all \<open>erule integrity_obj_alt.cases\<close>)
-
-  (* There are some special cases that would be too slow or unsolvable by the bulk tactics.
-     We move them up here and solve manually *)
-  apply (find_goal \<open>match premises in "tro_tag' TCBReply" and "tro_tag TCBActivate" \<Rightarrow> -\<close>)
-  apply (clarsimp, rule tro_alt_tcb_reply[OF tro_tagI refl refl],
-         (rule exI; rule tcb.equality; simp add: arch_tcb_context_set_def); fastforce)
-
-  apply (find_goal \<open>match premises in "tro_tag' TCBReceive" and "tro_tag TCBReply" \<Rightarrow> -\<close>)
-  apply (clarsimp, rule tro_alt_tcb_reply[OF tro_tagI refl refl],
-         (rule exI; rule tcb.equality;
-          simp add: arch_tcb_context_set_def);
-         fastforce simp: indirect_send_def direct_send_def direct_reply_def
-                         allowed_call_blocked_def)
-
-  apply (find_goal \<open>match premises in "tro_tag TCBGeneric" and "tro_tag' TCBRestart" \<Rightarrow> -\<close>)
-  subgoal
-    apply (erule integrity_obj_alt.intros[simplified tro_tag_to_prime])
-            apply (rule refl | assumption
-                  | fastforce intro: tcb.equality
-                  | (erule tcb_bound_notification_reset_integrity_trans
-                           reply_cap_deletion_integrity_trans;
-                     fastforce))+
-    done
-
-  apply (find_goal \<open>match premises in "tro_tag TCBActivate" and "tro_tag' TCBRestart" \<Rightarrow> -\<close>)
-  apply (rule tro_alt_tcb_restart[OF tro_tagI],
-                 rule refl,
-                assumption,
-               (* somehow works better than tcb.equality *)
-               (simp only: tcb.splits; simp),
-              force+)[1]
-
-  apply (find_goal \<open>match premises in "tro_tag REp" and "tro_tag' REp" \<Rightarrow> -\<close>)
-  subgoal by (erule integrity_obj_alt.intros, (rule refl | assumption)+)
-
-  (* Select groups of subgoals by tag, then solve with the given methods *)
-  apply (all \<open>fails \<open>erule thin_rl[of "tro_tag LRefl"]\<close>
-             | time_methods \<open>solves \<open>
-                   fastforce intro: tro_alt_lrefl\<close>\<close>\<close>)
-
-  apply (all \<open>fails \<open>erule thin_rl[of "tro_tag ORefl"]\<close>
-             | time_methods \<open>solves \<open>
-                   drule sym[where t="ko''"];
-                   erule integrity_obj_alt.intros[simplified tro_tag_to_prime];
-                   solves \<open>simp\<close>\<close>\<close>\<close>)
-
-  apply (all \<open>fails \<open>erule thin_rl[of "tro_tag RNtfn"] thin_rl[of "tro_tag' RNtfn"]\<close>
-             | time_methods \<open>solves \<open>
-                   fastforce intro: tro_alt_ntfn\<close>\<close>\<close>)
-
-  apply (all \<open>fails \<open>erule thin_rl[of "tro_tag REp"]
-                    | erule thin_rl[of "tro_tag' REp"]
-                    | erule thin_rl[of "tro_tag RASID"]
-                    | erule thin_rl[of "tro_tag' RASID"]
-                    | erule thin_rl[of "tro_tag EpUnblock"]
-                    | erule thin_rl[of "tro_tag' EpUnblock"]
-                    | erule thin_rl[of "tro_tag RCNode"]
-                    | erule thin_rl[of "tro_tag' RCNode"]\<close>
-             | time_methods \<open>solves \<open>
-                   fastforce intro: integrity_obj_alt.intros tcb.equality
-                             simp: indirect_send_def direct_send_def\<close>\<close>\<close>)
-
-  (* TCB-TCB steps, somewhat slow *)
-  apply (all \<open>fails \<open>erule thin_rl[of "tro_tag TCBGeneric"]\<close>
-             | time_methods \<open>solves \<open>
-                    erule integrity_obj_alt.intros[simplified tro_tag_to_prime],
-                    (assumption | rule refl
-                    | ((erule exE)+)?, (rule exI)?, force intro: tcb.equality)+\<close>\<close>\<close>)
-
-  apply (all \<open>fails \<open>erule thin_rl[of "tro_tag' TCBGeneric"]\<close>
-             | time_methods \<open>solves \<open>
-                    erule integrity_obj_alt.intros,
-                    (assumption | rule refl
-                    | (elim exE)?, (intro exI)?, fastforce intro: tcb.equality
-                    | fastforce simp: indirect_send_def direct_send_def direct_call_def direct_reply_def
-                                dest: tcb_bound_notification_reset_eq_or_none)+\<close>\<close>\<close>)
-
-  apply (time_methods \<open>
-           succeeds \<open>match premises in T: "tro_tag _" and T': "tro_tag' _" \<Rightarrow>
-                                       \<open>print_fact T, print_fact T'\<close>\<close>,
-           fastforce intro: integrity_obj_alt.intros tcb.equality
-                     simp: indirect_send_def direct_send_def direct_call_def direct_reply_def
-                           send_blocked_on_def3 call_blocked_def allowed_call_blocked_def\<close>)+
-  done
-
-lemma tro_alt_reflp[intro!]:
-  "reflp (integrity_obj_alt aag activate es subjects)"
-  by (rule reflpI) (rule tro_alt_orefl; blast)
-
-lemma tro_alt_transp[intro!]:
-  "transp (integrity_obj_alt aag activate es subjects)"
-  by (rule transpI) (rule tro_alt_trans_spec)
-
-
-
-lemma tro_tro_alt[elim!]:
-  "integrity_obj aag activate es subjects ko ko'
-  \<Longrightarrow> integrity_obj_alt aag activate es subjects ko ko'"
-  unfolding integrity_obj_def
-  by (subst rtranclp_id[symmetric]; fastforce elim: rtranclp_mono[THEN predicate2D,rotated])
-
-lemmas integrity_objE = tro_tro_alt[THEN integrity_obj_alt.cases
-                                          [simplified tro_tag_def True_implies_equals]]
-
-
-
-lemma tro_trans:
-  "\<lbrakk>integrity_obj_state aag activate es s s'; integrity_obj_state aag activate es s' s''\<rbrakk>
-    \<Longrightarrow> integrity_obj_state aag activate es s s''"
-   unfolding integrity_obj_def
-  apply clarsimp
-  apply (drule_tac x = x in spec)+
-  by force
-
-lemma tre_trans:
-  "\<lbrakk>(\<forall>x. integrity_eobj aag es (pasObjectAbs aag x) (ekh x) (ekh' x));
-    (\<forall>x. integrity_eobj aag es (pasObjectAbs aag x) (ekh' x) (ekh'' x)) \<rbrakk> \<Longrightarrow>
-    (\<forall>x. integrity_eobj aag es (pasObjectAbs aag x) (ekh x) (ekh'' x))"
-by (fastforce elim!: integrity_eobj.cases
-              intro: integrity_eobj.intros)
-
-
-
-subsection \<open>CDT integrity transitivity\<close>
-
-lemma tcb_caller_slot_empty_on_recieve:
-  "\<lbrakk> valid_mdb s ; valid_objs s; kheap s tcb_ptr = Some (TCB tcb); ep_recv_blocked ep (tcb_state tcb) \<rbrakk> \<Longrightarrow>
-   tcb_caller tcb = NullCap \<and> cdt s (tcb_ptr,(tcb_cnode_index 3)) = None \<and>
-   descendants_of (tcb_ptr,(tcb_cnode_index 3)) (cdt s) = {}"
-   apply (simp only:valid_objs_def)
-   apply (drule bspec,fastforce)
-   apply (simp add:valid_obj_def)
-   apply (simp only:valid_tcb_def)
-   apply (drule conjunct1)
-   apply (drule_tac x="the (tcb_cap_cases (tcb_cnode_index 3))" in  bspec)
-    apply (fastforce simp:tcb_cap_cases_def)
-   apply (simp add:tcb_cap_cases_def split: thread_state.splits)
-  apply (subgoal_tac "caps_of_state s (tcb_ptr, tcb_cnode_index 3) = Some NullCap")
-   apply (simp only: valid_mdb_def2, drule conjunct1)
-   apply (intro conjI)
-    apply (simp add: mdb_cte_at_def)
-    apply (rule classical)
-    apply fastforce
-   apply (rule mdb_cte_at_no_descendants, fastforce+)[1]
-  apply (fastforce simp add: tcb_cnode_map_def caps_of_state_tcb_index_trans[OF get_tcb_rev])
-done
-
-
-(* FIXME MOVE next to tcb_states_of_state definition *)
-lemma tcb_states_of_state_kheap:
-   "\<lbrakk>kheap s slot = Some (TCB tcb)\<rbrakk>
-    \<Longrightarrow> tcb_states_of_state s slot = Some (tcb_state tcb)"
-  by (simp add:tcb_states_of_state_def get_tcb_def split: option.splits kernel_object.splits)
-
-lemma tcb_states_of_state_kheapI:
-   "\<lbrakk>kheap s slot = Some (TCB tcb); tcb_state tcb = tcbst\<rbrakk>
-    \<Longrightarrow> tcb_states_of_state s slot = Some tcbst"
-  by (simp add:tcb_states_of_state_def get_tcb_def split: option.splits kernel_object.splits)
-
-lemma tcb_states_of_state_kheapD:
-   "tcb_states_of_state s slot = Some tcbst \<Longrightarrow>
-    \<exists> tcb. kheap s slot = Some (TCB tcb) \<and> tcb_state tcb = tcbst"
-  by (simp add:tcb_states_of_state_def get_tcb_def split: option.splits kernel_object.splits)
-
-lemma tcb_states_of_state_kheapE:
-   assumes "tcb_states_of_state s slot = Some tcbst"
-   obtains tcb where "kheap s slot = Some (TCB tcb)" "tcb_state tcb = tcbst"
-  using assms tcb_states_of_state_kheapD by blast
-
-lemma cdt_direct_change_allowed_backward:
-  "\<lbrakk>integrity_obj_state aag activate subjects s s';
-    cdt_direct_change_allowed aag subjects (tcb_states_of_state s') ptr\<rbrakk> \<Longrightarrow>
-    cdt_direct_change_allowed aag subjects (tcb_states_of_state s) ptr"
-  apply (erule cdt_direct_change_allowed.cases)
-   subgoal by (rule cdca_owned)
-  apply (erule tcb_states_of_state_kheapE)
-  by (drule spec,
-      erule integrity_objE, erule cdca_owned;
-      (elim exE)?;
-      simp;
-      rule cdca_reply[rotated], assumption, assumption,
-        fastforce elim:tcb_states_of_state_kheapI simp:direct_call_def)
-
-lemma cdt_change_allowed_to_child:
-  "cdt_change_allowed aag subjects m tcbsts pptr \<Longrightarrow> m ptr = Some pptr
-   \<Longrightarrow> cdt_change_allowed aag subjects m tcbsts ptr"
-  apply (elim cdt_change_allowedE)
-  apply (erule cdt_change_allowedI[rotated])
-  by(fastforce intro: rtrancl_into_rtrancl simp: cdt_parent_of_def)
-
-lemma cdt_change_allowed_backward:
-  "\<lbrakk>integrity_obj_state aag activate subjects s s';
-    integrity_cdt_state aag subjects s s';
-    cdt_change_allowed aag subjects (cdt s') (tcb_states_of_state s') ptr\<rbrakk> \<Longrightarrow>
-    cdt_change_allowed aag subjects (cdt s) (tcb_states_of_state s) ptr"
-  apply (elim cdt_change_allowedE)
-  apply (drule(1) cdt_direct_change_allowed_backward)
-  apply (erule rtrancl_induct)
-  subgoal by (rule cdca_ccaI)
-  apply (rename_tac pptr0 ptr)
-  apply (frule_tac x=ptr in spec)
-  apply (elim integrity_cdtE; simp; elim conjE)
-  apply (erule cdt_change_allowed_to_child)
-  by(simp add: cdt_parent_of_def)
-
-lemma trcdt_trans:
-  "\<lbrakk>integrity_cdt_state aag subjects s s' ;
-    integrity_obj_state aag activate subjects s s' ;
-    integrity_cdt_state aag subjects s' s'' \<rbrakk>
-   \<Longrightarrow> integrity_cdt_state aag subjects s s''"
-  apply (intro allI)
-  apply (frule_tac x=x in spec)
-  apply (frule_tac x=x in spec[where P = "\<lambda>x. integrity_cdt _ _ (cdt s') _ x (_ x) (_ x)"])
-  apply (erule integrity_cdtE)+
-  apply simp
-  by (blast dest: cdt_change_allowed_backward)+
-
-lemma trcdtlist_trans:
-  "\<lbrakk>integrity_cdt_list_state aag subjects s s' ;
-    integrity_obj_state aag activate subjects s s' ;
-    integrity_cdt_state aag subjects s s' ;
-    integrity_cdt_list_state aag subjects s' s'' \<rbrakk>
-   \<Longrightarrow> integrity_cdt_list_state aag subjects s s''"
-  apply (intro allI)
-  apply (drule_tac x=x in spec [where P="\<lambda>ptr. integrity_cdt_list _ _ _ _ ptr (_ ptr) (_ ptr)"] )+
-  apply (erule integrity_cdt_listE)+
-      apply (rule integrity_cdt_list_filt)
-      apply (simp del: split_paired_All split_paired_Ex)
-      apply (erule weaken_filter_eq')
-  by (blast intro: integrity_cdt_list_intros dest: cdt_change_allowed_backward)+
-
-
-subsection \<open>Main integrity transitivity\<close>
-
-
-lemma trinterrupts_trans:
-  "\<lbrakk> (\<forall>x. integrity_interrupts aag subjects x (interrupt_irq_node s x, interrupt_states s x) (interrupt_irq_node s' x, interrupt_states s' x));
-    (\<forall>x. integrity_interrupts aag subjects x (interrupt_irq_node s' x, interrupt_states s' x) (interrupt_irq_node s'' x, interrupt_states s'' x)) \<rbrakk>
-   \<Longrightarrow> (\<forall>x. integrity_interrupts aag subjects x (interrupt_irq_node s x, interrupt_states s x) (interrupt_irq_node s'' x, interrupt_states s'' x))"
-  apply (simp add: integrity_interrupts_def
-                  del: split_paired_All)
-  apply metis
-  done
-
-lemma trasids_trans:
-  "\<lbrakk> (\<forall>x. integrity_asids aag subjects x (arm_asid_table (arch_state s) (asid_high_bits_of x)) (arm_asid_table (arch_state s') (asid_high_bits_of x)));
-     (\<forall>x. integrity_asids aag subjects x (arm_asid_table (arch_state s') (asid_high_bits_of x)) (arm_asid_table (arch_state s'') (asid_high_bits_of x)))\<rbrakk>
-   \<Longrightarrow>
-     (\<forall>x. integrity_asids aag subjects x (arm_asid_table (arch_state s) (asid_high_bits_of x)) (arm_asid_table (arch_state s'') (asid_high_bits_of x)))"
-  apply (clarsimp simp: integrity_asids_def)
-  apply metis
-  done
-
-lemma trrqs_trans:
-  "\<lbrakk> (\<forall>d p. integrity_ready_queues aag subjects (pasDomainAbs aag d) (ready_queues s d p) (ready_queues s' d p));
-     (\<forall>d p. integrity_ready_queues aag subjects (pasDomainAbs aag d) (ready_queues s' d p) (ready_queues s'' d p)) \<rbrakk>
-   \<Longrightarrow> (\<forall>d p. integrity_ready_queues aag subjects (pasDomainAbs aag d) (ready_queues s d p) (ready_queues s'' d p))"
-apply (clarsimp simp: integrity_ready_queues_def)
-apply (metis append_assoc)
-done
-
-(* FIXME RENAME *)
-lemma tsos_tro:
-  "\<lbrakk>integrity_obj_state aag activate subjects s s'; tcb_states_of_state s' p = Some a;
-    receive_blocked_on ep a; pasObjectAbs aag p \<notin> subjects \<rbrakk> \<Longrightarrow> tcb_states_of_state s p = Some a"
-  apply (drule_tac x = p in spec)
-  apply (erule integrity_objE, simp_all add: tcb_states_of_state_def get_tcb_def)
-  by fastforce+
-
-lemma can_receive_ipc_backward:
-  "\<lbrakk>integrity_obj_state aag activate subjects s s'; tcb_states_of_state s' p = Some a;
-    can_receive_ipc a; pasObjectAbs aag p \<notin> subjects \<rbrakk>
-   \<Longrightarrow> case tcb_states_of_state s p of None \<Rightarrow> False | Some x \<Rightarrow> can_receive_ipc x"
-  apply (drule_tac x = p in spec)
-  apply (erule integrity_objE;
-         (fastforce simp: tcb_states_of_state_def get_tcb_def
-                         call_blocked_def allowed_call_blocked_def
-                   split: option.splits kernel_object.splits
-         | cases a \<comment> \<open>only split when needed\<close>)+)
-  done
-
-
-
-lemma auth_ipc_buffers_tro:
-  "\<lbrakk>integrity_obj_state aag activate subjects s s'; x \<in> auth_ipc_buffers s' p;
-          pasObjectAbs aag p \<notin> subjects \<rbrakk>
-  \<Longrightarrow> x \<in> auth_ipc_buffers s p "
-  by (drule_tac x = p in spec)
-     (erule integrity_objE;
-      fastforce simp: tcb_states_of_state_def get_tcb_def auth_ipc_buffers_def
-               split: cap.split_asm arch_cap.split_asm if_split_asm bool.splits)
-
-
-lemma auth_ipc_buffers_tro_fwd:
-  "\<lbrakk>integrity_obj_state aag activate subjects s s'; x \<in> auth_ipc_buffers s p;
-          pasObjectAbs aag p \<notin> subjects \<rbrakk>
-  \<Longrightarrow> x \<in> auth_ipc_buffers s' p "
-  by (drule_tac x = p in spec)
-     (erule integrity_objE;
-      fastforce simp: tcb_states_of_state_def get_tcb_def auth_ipc_buffers_def
-               split: cap.split_asm arch_cap.split_asm if_split_asm bool.splits)
-
-
-lemma tsos_tro_running:
-  "\<lbrakk>\<forall>x. integrity_obj aag activate subjects (pasObjectAbs aag x) (kheap s x) (kheap s' x);
-       tcb_states_of_state s p = Some Structures_A.Running;
-          pasObjectAbs aag p \<notin> subjects \<rbrakk>
-     \<Longrightarrow> tcb_states_of_state s' p = Some Structures_A.Running"
-  by (drule_tac x = p in spec)
-     (erule integrity_objE,
-         simp_all add: tcb_states_of_state_def get_tcb_def indirect_send_def
-                       direct_send_def direct_call_def direct_reply_def call_blocked_def allowed_call_blocked_def)
-
-
-lemma integrity_trans:
-  assumes t1: "integrity_subjects subjects aag activate X s s'"
-  and     t2: "integrity_subjects subjects aag activate X s' s''"
-  shows  "integrity_subjects subjects aag activate X s s''"
-proof -
-  from t1 have tro1: "integrity_obj_state aag activate subjects s s'"
-    unfolding integrity_subjects_def by simp
-  from t2 have tro2: "integrity_obj_state aag activate subjects s' s''"
-    unfolding integrity_subjects_def by simp
-
-  have intm: "\<forall>x. integrity_mem aag subjects x
-                  (tcb_states_of_state s) (tcb_states_of_state s'') (auth_ipc_buffers s) X
-                  (underlying_memory (machine_state s) x)
-                  (underlying_memory (machine_state s'') x)" (is "\<forall>x. ?P x s s''")
-  proof
-    fix x
-    from t1 t2 have m1: "?P x s s'" and m2: "?P x s' s''" unfolding integrity_subjects_def by auto
-
-    from m1 show "?P x s s''"
-    proof cases
-      case trm_lrefl thus ?thesis by (rule integrity_mem.intros)
-    next
-      case trm_globals thus ?thesis by (rule integrity_mem.intros)
-    next
-      case trm_orefl
-      from m2 show ?thesis
-      proof cases
-        case (trm_ipc p')
-
-        show ?thesis
-        proof (rule integrity_mem.trm_ipc)
-          from trm_ipc show "case_option False can_receive_ipc (tcb_states_of_state s p')"
-            by (fastforce split: option.splits dest: can_receive_ipc_backward [OF tro1])
-
-          from trm_ipc show "x \<in> auth_ipc_buffers s p'"
-            by (fastforce split: option.splits intro: auth_ipc_buffers_tro [OF tro1])
-        qed (simp_all add: trm_ipc)
-      qed (auto simp add: trm_orefl intro: integrity_mem.intros)
-    next
-      case trm_write thus ?thesis by (rule integrity_mem.intros)
-    next
-      case (trm_ipc p')
-      note trm_ipc1 = trm_ipc
-
-      from m2 show ?thesis
-      proof cases
-        case trm_orefl
-        thus ?thesis using trm_ipc1
-          by (auto intro!: integrity_mem.trm_ipc simp add: restrict_map_Some_iff elim!: tsos_tro_running [OF tro2, rotated])
-      next
-        case (trm_ipc p'')
-        show ?thesis
-        proof (cases "p' = p''")
-          case True thus ?thesis using trm_ipc trm_ipc1 by (simp add: restrict_map_Some_iff)
-        next
-          (* 2 tcbs sharing same IPC buffer, we can appeal to either t1 or t2 *)
-          case False
-          thus ?thesis using trm_ipc1
-            by (auto intro!: integrity_mem.trm_ipc simp add: restrict_map_Some_iff elim!: tsos_tro_running [OF tro2, rotated])
-        qed
-      qed (auto simp add: trm_ipc intro: integrity_mem.intros)
-    qed
-  qed
-
-  moreover have "\<forall>x. integrity_device aag subjects x
-                  (tcb_states_of_state s) (tcb_states_of_state s'')
-                  (device_state (machine_state s) x)
-                  (device_state (machine_state s'') x)" (is "\<forall>x. ?P x s s''")
-  proof
-    fix x
-    from t1 t2 have m1: "?P x s s'" and m2: "?P x s' s''" unfolding integrity_subjects_def by auto
-
-    from m1 show "?P x s s''"
-    proof cases
-      case trd_lrefl thus ?thesis by (rule integrity_device.intros)
-    next
-      case torel1: trd_orefl
-      from m2 show ?thesis
-      proof cases
-        case (trd_lrefl) thus ?thesis by (rule integrity_device.trd_lrefl)
-      next
-        case trd_orefl thus ?thesis
-          by (simp add:torel1)
-      next
-        case trd_write thus ?thesis by (rule integrity_device.trd_write)
-      qed
-    next
-      case trd_write thus ?thesis by (rule integrity_device.intros)
-    qed
-  qed
-  thus ?thesis using tro_trans[OF tro1 tro2] t1 t2 intm
-    apply (clarsimp simp add: integrity_subjects_def simp del:  split_paired_All)
-    apply (frule(2) trcdt_trans)
-    apply (frule(3) trcdtlist_trans)
-    apply (frule(1) trinterrupts_trans[simplified])
-    apply (frule(1) trasids_trans[simplified])
-    apply (frule(1) tre_trans[simplified])
-    apply (frule(1) trrqs_trans[simplified])
-    by blast
-qed
-
-lemma integrity_refl [simp]:
-  "integrity_subjects S aag activate X s s"
-unfolding integrity_subjects_def
-by simp
-
-section \<open>Generic AC stuff\<close>
-
-subsection \<open>Basic integrity lemmas\<close>
-
-(* Tom says that Gene Wolfe says that autarchy \<equiv> self authority. *)
-
-lemma integrity_update_autarch:
-  "\<lbrakk> integrity aag X st s; is_subject aag ptr \<rbrakk>
-   \<Longrightarrow> integrity aag X st (s\<lparr>kheap := kheap s(ptr \<mapsto> obj)\<rparr>)"
-  unfolding integrity_subjects_def
-  apply (intro conjI,simp_all)
-   apply clarsimp
-   apply (drule_tac x = x in spec, erule integrity_mem.cases)
-   apply ((auto intro: integrity_mem.intros)+)[4]
-   apply (erule trm_ipc, simp_all)
-   apply (clarsimp simp: restrict_map_Some_iff tcb_states_of_state_def get_tcb_def)
-  apply clarsimp
-  apply (drule_tac x = x in spec, erule integrity_device.cases)
-    apply (erule integrity_device.trd_lrefl)
-   apply (erule integrity_device.trd_orefl)
-  apply (erule integrity_device.trd_write)
-  done
-
-lemma set_object_integrity_autarch:
-  "\<lbrace>integrity aag X st and K (is_subject aag ptr)\<rbrace>
-     set_object ptr obj
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (wpsimp wp: set_object_wp)
-  apply (rule integrity_update_autarch, simp_all)
-  done
-
-lemma tcb_states_of_state_trans_state[simp]:
-  "tcb_states_of_state (trans_state f s) = tcb_states_of_state s"
-  by (simp add: tcb_states_of_state_def get_tcb_exst_update)
-
-lemma eintegrity_sa_update[simp]:
-  "integrity aag X st (scheduler_action_update f s) = integrity aag X st s"
-  by (simp add: integrity_subjects_def trans_state_update'[symmetric])
-
-lemma trans_state_back[simp]:
-  "trans_state (\<lambda>_. exst s) s = s"
-  by simp
-
-declare wrap_ext_op_det_ext_ext_def[simp]
-
-crunch integrity[wp]: set_thread_state_ext "integrity aag X st"
-
-crunch integrity_autarch: set_thread_state "integrity aag X st"
-
-lemmas integrity_def = integrity_subjects_def
-
-subsection \<open>Out of subject cap manipulation\<close>
-
-(* FIXME MOVE *)
-lemma all_children_descendants_of:
-  "\<lbrakk> all_children P m ; p \<in> descendants_of q m ; P q \<rbrakk> \<Longrightarrow> P p "
-  apply (simp add: descendants_of_def)
-  apply (erule trancl_induct[where P=P])
-  unfolding cdt_parent_of_def
-   apply (erule(2) all_childrenD)+
-  done
-
-lemmas all_children_parent_of_trancl =
-                    all_children_descendants_of[simplified descendants_of_def,simplified]
-
-lemma all_children_parent_of_rtrancl:
-  "\<lbrakk> all_children P m ; m \<Turnstile> q \<rightarrow>* p ; P q \<rbrakk> \<Longrightarrow> P p "
-  by (drule rtranclD,elim conjE disjE; blast dest:all_children_parent_of_trancl)
-
-lemma pas_refined_all_children':
-  "\<lbrakk>valid_mdb s ; pas_refined aag s ; m = (cdt s) \<rbrakk> \<Longrightarrow>
-   all_children (\<lambda>x. is_subject aag (fst x) \<or> is_transferable (caps_of_state s x)) m"
-  apply (rule all_childrenI)
-  apply (erule disjE)
-   apply (simp add: pas_refined_def,elim conjE)
-   apply (rule disjCI)
-   apply (subgoal_tac
-               "(pasObjectAbs aag (fst p), Control, pasObjectAbs aag (fst c)) \<in> pasPolicy aag")
-    apply (fastforce elim: aag_wellformed_control_is_owns[THEN iffD1])
-   apply (simp add: state_objs_to_policy_def auth_graph_map_def)
-   apply (erule set_mp)
-   apply (frule(1) sbta_cdt)
-   apply force
-  apply (rule disjI2)
-  by (rule is_transferable_all_children[THEN all_childrenD]; solves \<open>simp\<close>)
-
-lemmas pas_refined_all_children = pas_refined_all_children'[OF _ _ refl]
-
-(* FIXME MOVE just after cte_wp_at_cases2 *)
-lemma caps_of_state_def':
-  "caps_of_state s slot =
-    (case kheap s (fst slot) of
-       Some (TCB tcb) \<Rightarrow> tcb_cnode_map tcb (snd slot)
-     | Some (CNode sz content) \<Rightarrow> (if well_formed_cnode_n sz content then content (snd slot) else None)
-     | _ \<Rightarrow> None)"
-  by (fastforce simp: caps_of_state_cte_wp_at cte_wp_at_cases2
-                split: option.splits kernel_object.splits)
-
-lemma caps_of_state_cnode:
-  "\<lbrakk>kheap s pos = Some (CNode sz content); well_formed_cnode_n sz content\<rbrakk> \<Longrightarrow>
-   caps_of_state s (pos,addr) = content addr"
-  by (simp add:caps_of_state_def')
-
-lemma caps_of_state_tcb:
-  "\<lbrakk>kheap s pos = Some (TCB tcb)\<rbrakk> \<Longrightarrow>
-   caps_of_state s (pos,addr) = tcb_cnode_map tcb addr"
-  by (simp add:caps_of_state_def')
-
-(* FIXME MOVE next to tcb_cnode_cases_simps *)
-lemma tcb_cnode_map_simps[simp]:
-  "tcb_cnode_map tcb (tcb_cnode_index 0) = Some (tcb_ctable tcb)"
-  "tcb_cnode_map tcb (tcb_cnode_index (Suc 0)) = Some (tcb_vtable tcb)"
-  "tcb_cnode_map tcb (tcb_cnode_index 2) = Some (tcb_reply tcb)"
-  "tcb_cnode_map tcb (tcb_cnode_index 3) = Some (tcb_caller tcb)"
-  "tcb_cnode_map tcb (tcb_cnode_index 4) = Some (tcb_ipcframe tcb)"
-  by (simp_all add: tcb_cnode_map_def)
-
-(* FIXME MOVE *)
-lemma valid_mdb_reply_mdb[elim!]:
-  "valid_mdb s \<Longrightarrow> reply_mdb (cdt s) (caps_of_state s)"
-  by (simp add:valid_mdb_def)
-
-(* FIXME MOVE *)
-lemma invs_reply_mdb[elim!]: "invs s \<Longrightarrow> reply_mdb (cdt s) (caps_of_state s)"
-  by (simp add:invs_def valid_state_def valid_mdb_def)
-
-lemma parent_of_rtrancl_no_descendant:
-  "\<lbrakk>m \<Turnstile> pptr \<rightarrow>* ptr; descendants_of pptr m = {}\<rbrakk> \<Longrightarrow> pptr = ptr"
-  by (fastforce simp add:rtrancl_eq_or_trancl descendants_of_def)
-
-(* FIXME MOVE *)
-lemma tcb_atD:
-  "tcb_at ptr s \<Longrightarrow> \<exists>tcb. kheap s ptr = Some (TCB tcb)"
-   by (cases "the (kheap s ptr)";fastforce simp:obj_at_def is_tcb_def)
-
-(* FIXME MOVE *)
-lemma tcb_atE:
-  assumes hyp: "tcb_at ptr s"
-  obtains tcb where "kheap s ptr = Some (TCB tcb)"
-   using hyp[THEN tcb_atD] by blast
-
-(*FIXME MOVE *)
-lemma tcb_atI:
-  "kheap s ptr = Some (TCB tcb) \<Longrightarrow> tcb_at ptr s"
-  by (simp add:obj_at_def is_tcb_def)
-
-
-
-lemma descendant_of_caller_slot:
-  "\<lbrakk>valid_mdb s; valid_objs s; tcb_at t s\<rbrakk> \<Longrightarrow> descendants_of (t, tcb_cnode_index 3) (cdt s) = {}"
-  apply (frule(1) tcb_caller_cap)
-  apply (clarsimp simp add:cte_wp_at_caps_of_state is_cap_simps; elim disjE ;clarsimp)
-  subgoal by (intro allI no_children_empty_desc[THEN iffD1] reply_cap_no_children)
-  apply (drule valid_mdb_mdb_cte_at)
-  apply (erule mdb_cte_at_no_descendants)
-  apply (simp add:cte_wp_at_caps_of_state)
-  done
-
-lemma cca_to_transferable_or_subject:
-  "\<lbrakk>valid_objs s; valid_mdb s; pas_refined aag s; cdt_change_allowed' aag ptr s \<rbrakk>
-  \<Longrightarrow> is_subject aag (fst ptr) \<or> is_transferable (caps_of_state s ptr)"
-  apply (elim cdt_change_allowedE cdt_direct_change_allowed.cases)
-   apply (rule all_children_parent_of_rtrancl[OF pas_refined_all_children]; blast)
-  apply (simp add:rtrancl_eq_or_trancl,elim disjE conjE)
-   apply (simp add:direct_call_def, elim conjE)
-   apply (drule tcb_states_of_state_kheapD, elim exE conjE)
-   apply (frule(2) tcb_caller_slot_empty_on_recieve ,simp)
-   apply (cases ptr,simp)
-   apply (simp add:caps_of_state_tcb)
-  apply (elim tcb_states_of_state_kheapE)
-  apply (drule(2) descendant_of_caller_slot[OF _ _ tcb_atI])
-  by (force simp add: descendants_of_def simp del:split_paired_All)
-
-lemma is_transferable_weak_derived:
-  "weak_derived cap cap' \<Longrightarrow> is_transferable_cap cap = is_transferable_cap cap'"
-  unfolding is_transferable.simps weak_derived_def copy_of_def same_object_as_def
-  by (fastforce simp: is_cap_simps split:cap.splits)
-
-lemma aag_cdt_link_Control:
-  "\<lbrakk> cdt s x = Some y; \<not> is_transferable(caps_of_state s x); pas_refined aag s \<rbrakk>
-    \<Longrightarrow> (pasObjectAbs aag (fst y), Control, pasObjectAbs aag (fst x)) \<in> pasPolicy aag"
-  by (fastforce elim: pas_refined_mem[rotated] sta_cdt)
-
-lemma aag_cdt_link_DeleteDerived:
-  "\<lbrakk> cdt s x = Some y; pas_refined aag s \<rbrakk>
-    \<Longrightarrow> (pasObjectAbs aag (fst y), DeleteDerived, pasObjectAbs aag (fst x)) \<in> pasPolicy aag"
-  by (fastforce elim: pas_refined_mem[rotated] sta_cdt_transferable)
-
-lemma tcb_states_of_state_to_auth:
-  "\<lbrakk>tcb_states_of_state s thread = Some tcbst; pas_refined aag s \<rbrakk>
-   \<Longrightarrow> \<forall> (obj,auth) \<in> tcb_st_to_auth tcbst.
-                  (pasObjectAbs aag thread, auth, pasObjectAbs aag obj) \<in> pasPolicy aag"
-
-   apply clarsimp
-   apply (erule pas_refined_mem[rotated])
-   apply (rule sta_ts)
-   apply (simp add:thread_states_def)
-   done
-
-lemma tcb_states_of_state_to_auth':
-  "\<lbrakk>tcb_states_of_state s thread = Some tcbst; pas_refined aag s;
-    (obj,auth) \<in> tcb_st_to_auth tcbst \<rbrakk>
-   \<Longrightarrow> (pasObjectAbs aag thread, auth, pasObjectAbs aag obj) \<in> pasPolicy aag"
-   using tcb_states_of_state_to_auth by blast
-
-lemma ep_recv_blocked_def:
-  "ep_recv_blocked ep st \<longleftrightarrow> (\<exists>pl. st = BlockedOnReceive ep pl)"
-  by (simp split: thread_state.split)
-
-lemma cdt_change_allowed_delete_derived:
-  "valid_objs s \<Longrightarrow> valid_mdb s \<Longrightarrow> pas_refined aag s \<Longrightarrow> cdt_change_allowed' aag slot s
-   \<Longrightarrow> aag_has_auth_to aag DeleteDerived (fst slot)"
-  apply (elim cdt_change_allowedE cdt_direct_change_allowed.cases)
-   apply (erule rtrancl_induct)
-    apply (solves\<open>simp add: pas_refined_refl\<close>)
-   apply (fastforce simp: cdt_parent_of_def
-                    dest: aag_cdt_link_DeleteDerived
-                   intro: aag_wellformed_delete_derived_trans)
-  apply (clarsimp simp: direct_call_def ep_recv_blocked_def)
-  apply (frule(1)tcb_states_of_state_to_auth)
-  apply (elim tcb_states_of_state_kheapE)
-  apply (frule(2) descendant_of_caller_slot[OF _ _ tcb_atI])
-  apply (frule(1) parent_of_rtrancl_no_descendant)
-  apply clarsimp
-  by (rule aag_wellformed_delete_derived'[OF _ _ pas_refined_wellformed])
-
-end
-
-context pspace_update_eq begin
-
-interpretation Arch . (*FIXME: arch_split*)
-
-lemma integrity_update_eq[iff]:
-  "tcb_states_of_state (f s) = tcb_states_of_state s"
-  by (simp add: pspace tcb_states_of_state_def get_tcb_def)
-
-end
-
-subsection \<open>Various abbreviations\<close>
-
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-definition label_owns_asid_slot :: "'a PAS \<Rightarrow> 'a \<Rightarrow> asid \<Rightarrow> bool"
-where
+     (\<forall>x. integrity_obj aag activate subjects (pasObjectAbs aag x) (kheap s x) (kheap s' x))
+   \<and> (\<forall>x. integrity_eobj aag subjects (pasObjectAbs aag x) (ekheap s x) (ekheap s' x))
+   \<and> integrity_cdt_state aag subjects s s'
+   \<and> integrity_cdt_list_state aag subjects s s'
+   \<and> (\<forall>x. integrity_interrupts aag subjects x (interrupt_irq_node s x, interrupt_states s x)
+                               (interrupt_irq_node s' x, interrupt_states s' x))
+   \<and> (\<forall>d p. integrity_ready_queues aag subjects (pasDomainAbs aag d) (ready_queues s d p)
+                                   (ready_queues s' d p))
+   \<and> (\<forall>x. integrity_mem aag subjects x (tcb_states_of_state s) (tcb_states_of_state s')
+                        (auth_ipc_buffers s) X
+                        (underlying_memory (machine_state s) x)
+                        (underlying_memory (machine_state s') x))
+   \<and> (\<forall>x. integrity_device aag subjects x (tcb_states_of_state s) (tcb_states_of_state s')
+                           (device_state (machine_state s) x)
+                           (device_state (machine_state s') x))
+   \<and> (\<forall>x. integrity_asids aag subjects x s s')"
+
+abbreviation "integrity pas \<equiv> integrity_subjects {pasSubject pas} pas (pasMayActivate pas)"
+
+subsection \<open>Various definitions and abbreviations\<close>
+
+definition label_owns_asid_slot :: "'a PAS \<Rightarrow> 'a \<Rightarrow> asid \<Rightarrow> bool" where
   "label_owns_asid_slot aag l asid \<equiv>
      (l, Control, pasASIDAbs aag asid) \<in> pasPolicy aag"
 
-definition cap_links_asid_slot :: "'a PAS \<Rightarrow> 'a \<Rightarrow> cap \<Rightarrow> bool"
-where
-  "cap_links_asid_slot aag l cap \<equiv> (\<forall>asid \<in> cap_asid' cap.
-      label_owns_asid_slot aag l asid)"
+fun cap_asid' :: "cap \<Rightarrow> asid set" where
+  "cap_asid' (ArchObjectCap acap) = acap_asid' acap"
+| "cap_asid' _ = {}"
 
-abbreviation is_subject_asid :: "'a PAS \<Rightarrow> asid \<Rightarrow> bool"
-where
+definition cap_links_asid_slot :: "'a PAS \<Rightarrow> 'a \<Rightarrow> cap \<Rightarrow> bool" where
+  "cap_links_asid_slot aag l cap \<equiv> (\<forall>asid \<in> cap_asid' cap. label_owns_asid_slot aag l asid)"
+
+abbreviation is_subject_asid :: "'a PAS \<Rightarrow> asid \<Rightarrow> bool" where
   "is_subject_asid aag asid \<equiv> pasASIDAbs aag asid = pasSubject aag"
 
-lemma clas_no_asid:
-  "cap_asid' cap = {} \<Longrightarrow> cap_links_asid_slot aag l cap"
-  unfolding cap_links_asid_slot_def by simp
-
-definition cap_links_irq
-where
+definition cap_links_irq :: "'a PAS \<Rightarrow> 'a \<Rightarrow> cap \<Rightarrow> bool" where
   "cap_links_irq aag l cap \<equiv>
-       \<forall>irq \<in> cap_irqs_controlled cap. (l, Control, pasIRQAbs aag irq) \<in> pasPolicy aag"
+     \<forall>irq \<in> cap_irqs_controlled cap. (l, Control, pasIRQAbs aag irq) \<in> pasPolicy aag"
 
-lemma cli_no_irqs:
-  "cap_irqs_controlled cap = {} \<Longrightarrow> cap_links_irq aag l cap"
-  unfolding cap_links_irq_def by simp
-
-abbreviation is_subject_irq :: "'a PAS \<Rightarrow> irq \<Rightarrow> bool"
-where
+abbreviation is_subject_irq :: "'a PAS \<Rightarrow> irq \<Rightarrow> bool" where
   "is_subject_irq aag irq \<equiv> pasIRQAbs aag irq = pasSubject aag"
 
-definition aag_cap_auth :: "'a PAS \<Rightarrow> 'a \<Rightarrow> cap \<Rightarrow> bool"
-where
+definition aag_cap_auth :: "'a PAS \<Rightarrow> 'a \<Rightarrow> cap \<Rightarrow> bool" where
   "aag_cap_auth aag l cap \<equiv>
-      (\<forall>x \<in> obj_refs cap. \<forall>auth \<in> cap_auth_conferred cap. (l, auth, pasObjectAbs aag x) \<in> pasPolicy aag)
-    \<and> (\<forall>x \<in> untyped_range cap. (l, Control, pasObjectAbs aag x) \<in> pasPolicy aag)
-    \<and> cap_links_asid_slot aag l cap \<and> cap_links_irq aag l cap"
+     (\<forall>x \<in> obj_refs cap. \<forall>auth \<in> cap_auth_conferred cap. (l, auth, pasObjectAbs aag x) \<in> pasPolicy aag)
+   \<and> (\<forall>x \<in> untyped_range cap. (l, Control, pasObjectAbs aag x) \<in> pasPolicy aag)
+   \<and> cap_links_asid_slot aag l cap \<and> cap_links_irq aag l cap"
 
-abbreviation pas_cap_cur_auth :: "'a PAS \<Rightarrow> cap \<Rightarrow> bool"
-where
+abbreviation pas_cap_cur_auth :: "'a PAS \<Rightarrow> cap \<Rightarrow> bool" where
   "pas_cap_cur_auth aag cap \<equiv> aag_cap_auth aag (pasSubject aag) cap"
-
-subsection \<open>Random lemmas that belong here\<close>
-
-crunch integrity_autarch: as_user "integrity aag X st"
-
-lemma owns_thread_owns_cspace:
-  "\<lbrakk> is_subject aag thread; pas_refined aag s; get_tcb thread s = Some tcb; is_cnode_cap (tcb_ctable tcb); x \<in> obj_refs (tcb_ctable tcb)\<rbrakk>
-    \<Longrightarrow> is_subject aag x"
-  apply (drule get_tcb_SomeD)
-  apply (drule cte_wp_at_tcbI[where t="(thread, tcb_cnode_index 0)" and P="\<lambda>cap. cap = tcb_ctable tcb", simplified])
-  apply (auto simp: cte_wp_at_caps_of_state is_cap_simps cap_auth_conferred_def
-              elim: caps_of_state_pasObjectAbs_eq [where p = "(thread, tcb_cnode_index 0)"])
-  done
-
-
-
-lemma is_subject_into_is_subject_asid:
-  "\<lbrakk> cap_links_asid_slot aag (pasObjectAbs aag p) cap; is_subject aag p; pas_refined aag s;
-         asid \<in> cap_asid' cap \<rbrakk>
-     \<Longrightarrow> is_subject_asid aag asid"
-  apply (clarsimp simp add: cap_links_asid_slot_def label_owns_asid_slot_def)
-  apply (drule (1) bspec)
-  apply (drule (1) pas_refined_Control)
-  apply simp
-  done
-
-(* MOVE *)
-lemma clas_caps_of_state:
-  "\<lbrakk> caps_of_state s slot = Some cap; pas_refined aag s \<rbrakk> \<Longrightarrow> cap_links_asid_slot aag (pasObjectAbs aag (fst slot)) cap"
-apply (clarsimp simp add: cap_links_asid_slot_def label_owns_asid_slot_def pas_refined_def)
-apply (blast dest: state_asids_to_policy_aux.intros)
-done
-
-lemma as_user_state_vrefs[wp]:
-  "\<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace> as_user t f \<lbrace>\<lambda>rv s. P (state_vrefs s)\<rbrace>"
-  apply (simp add: as_user_def)
-  apply (wpsimp wp: set_object_wp)
-  apply (clarsimp simp: state_vrefs_def vs_refs_no_global_pts_def get_tcb_def
-                 elim!: rsubst[where P=P, OF _ ext]
-                 split: option.split_asm Structures_A.kernel_object.split)
-  done
-
-lemma as_user_tcb_states[wp]:
-  "\<lbrace>\<lambda>s. P (tcb_states_of_state s)\<rbrace> as_user t f \<lbrace>\<lambda>rv s. P (tcb_states_of_state s)\<rbrace>"
-  apply (simp add: as_user_def)
-  apply (wpsimp wp: set_object_wp)
-  apply (clarsimp simp: thread_states_def get_tcb_def tcb_states_of_state_def
-                 elim!: rsubst[where P=P, OF _ ext] split: option.split)
-  done
-
-lemma as_user_thread_state[wp]:
-  "\<lbrace>\<lambda>s. P (thread_states s)\<rbrace> as_user t f \<lbrace>\<lambda>rv s. P (thread_states s)\<rbrace>"
-  apply (simp add: thread_states_def)
-  apply wp
-  done
-
-lemma as_user_thread_bound_ntfn[wp]:
-  "\<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace> as_user t f \<lbrace>\<lambda>rv s. P (thread_bound_ntfns s)\<rbrace>"
-  apply (simp add: as_user_def set_object_def split_def thread_bound_ntfns_def)
-  apply (wp get_object_wp)
-  apply (clarsimp simp: thread_states_def get_tcb_def
-                 elim!: rsubst[where P=P, OF _ ext] split: option.split)
-  done
-
-lemma tcb_domain_map_wellformed_lift:
-  assumes 1: "\<And>P. \<lbrace>\<lambda>s. P (ekheap s)\<rbrace> f \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
-  shows "\<lbrace>tcb_domain_map_wellformed aag\<rbrace> f \<lbrace>\<lambda>rv. tcb_domain_map_wellformed aag\<rbrace>"
-  by (rule 1)
-
-lemma as_user_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace> as_user t f \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-apply (simp add: pas_refined_def state_objs_to_policy_def)
-apply (rule hoare_pre)
- apply wps
- apply wp
-apply simp
-done
-
-(* **************************************** *)
-
-subsection\<open>Random lemmas that belong elsewhere.\<close>
-
-(* FIXME: move *)
-lemma bang_0_in_set:
-  "xs \<noteq> [] \<Longrightarrow> xs ! 0 \<in> set xs"
-  apply(fastforce simp: in_set_conv_nth)
-  done
-
-(* FIXME: move *)
-lemma update_one_strg:
-  "((b \<longrightarrow> P c v) \<and> (\<not> b \<longrightarrow> (\<forall>v'. f c' = Some v' \<longrightarrow> P c v')))
-  \<longrightarrow>
-  ((f(c := if b then Some v else f c')) x = Some y \<and> f x \<noteq> Some y \<longrightarrow> P x y)"
-  by auto
-
-(* FIXME: move *)
-lemma hoare_gen_asm2:
-  assumes a: "P \<Longrightarrow> \<lbrace>\<top>\<rbrace> f \<lbrace>Q\<rbrace>"
-  shows "\<lbrace>K P\<rbrace> f \<lbrace>Q\<rbrace>"
-  using a by (fastforce simp: valid_def)
-
-(* FIXME: move *)
-lemma hoare_vcg_all_liftE:
-  "(\<And>x. \<lbrace>P x\<rbrace> f \<lbrace>Q x\<rbrace>, \<lbrace>Q' x\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x. P x s\<rbrace> f \<lbrace>\<lambda>rv s. \<forall>x. Q x rv s\<rbrace>, \<lbrace>\<lambda>rv s. \<forall>x. Q' x rv s\<rbrace>"
-  unfolding validE_def
-  apply (rule hoare_post_imp [where Q = "\<lambda>v s. \<forall>x. case v of Inl e \<Rightarrow> Q' x e s | Inr r \<Rightarrow> Q x r s"])
-   apply (clarsimp split: sum.splits)
-  apply (erule hoare_vcg_all_lift)
-  done
-
-(* FIXME: eliminate *)
-lemma hoare_weak_lift_impE:
-  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>Q'\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>s. R \<longrightarrow> P s\<rbrace> f \<lbrace>\<lambda>rv s. R \<longrightarrow> Q rv s\<rbrace>, \<lbrace>\<lambda>rv s. R \<longrightarrow> Q' rv s\<rbrace>"
-  by (rule wp_throw_const_impE)
-
-(* FIXME: move *)
-lemma hoare_use_ex_R:
-  "(\<And>x. \<lbrace>P x and Q \<rbrace> f \<lbrace>R\<rbrace>, -) \<Longrightarrow> \<lbrace>\<lambda>s. (\<exists>x. P x s) \<and> Q s \<rbrace> f \<lbrace>R\<rbrace>, -"
-  unfolding validE_R_def validE_def valid_def by fastforce
-
-(* FIXME: move *)
-lemma mapM_x_and_const_wp:
-  assumes f: "\<And>v. \<lbrace>P and K (Q v)\<rbrace> f v \<lbrace>\<lambda>rv. P\<rbrace>"
-  shows "\<lbrace>P and K (\<forall>v \<in> set vs. Q v)\<rbrace> mapM_x f vs \<lbrace>\<lambda>rv. P\<rbrace>"
-  apply (induct vs)
-   apply (simp add: mapM_x_Nil)
-  apply (simp add: mapM_x_Cons)
-  apply (wp f | assumption | simp)+
-  done
-
-(* stronger *)
-(* FIXME: MOVE *)
-lemma ep_queued_st_tcb_at':
-  "\<And>P. \<lbrakk>ko_at (Endpoint ep) ptr s; (t, rt) \<in> ep_q_refs_of ep;
-         valid_objs s; sym_refs (state_refs_of s);
-         \<And>pl pl'. P (Structures_A.BlockedOnSend ptr pl) \<and> P (Structures_A.BlockedOnReceive ptr pl') \<rbrakk>
-    \<Longrightarrow> st_tcb_at P t s"
-  apply (case_tac ep, simp_all)
-  apply (frule(1) sym_refs_ko_atD, clarsimp, erule (1) my_BallE,
-         clarsimp simp: st_tcb_at_def refs_of_rev elim!: obj_at_weakenE)+
-  done
-
-(* Sometimes we only care about one of the queues. *)
-(* FIXME: move *)
-lemma ep_rcv_queued_st_tcb_at:
-  "\<And>P. \<lbrakk>ko_at (Endpoint ep) epptr s; (t, EPRecv) \<in> ep_q_refs_of ep;
-         valid_objs s; sym_refs (state_refs_of s);
-         \<And>pl. P (Structures_A.BlockedOnReceive epptr pl);
-         kheap s' t = kheap s t\<rbrakk>
-    \<Longrightarrow> st_tcb_at P t s'"
-  apply (case_tac ep, simp_all)
-  apply (subgoal_tac "st_tcb_at P t s")
-   apply (simp add: st_tcb_at_def obj_at_def)
-  apply (frule(1) sym_refs_ko_atD, clarsimp, erule (1) my_BallE,
-         clarsimp simp: st_tcb_at_def refs_of_rev elim!: obj_at_weakenE)+
-  done
-
-(* FIXME: move. *)
-lemma ntfn_queued_st_tcb_at':
-  "\<And>P. \<lbrakk>ko_at (Notification ntfn) ntfnptr s; (t, rt) \<in> ntfn_q_refs_of (ntfn_obj ntfn);
-         valid_objs s; sym_refs (state_refs_of s);
-         P (Structures_A.BlockedOnNotification ntfnptr) \<rbrakk>
-   \<Longrightarrow> st_tcb_at P t s"
-  apply (case_tac "ntfn_obj ntfn", simp_all)
-  apply (frule(1) sym_refs_ko_atD)
-  apply (clarsimp)
-  apply (erule_tac y="(t, NTFNSignal)" in my_BallE, clarsimp)
-  apply (clarsimp simp: pred_tcb_at_def refs_of_rev elim!: obj_at_weakenE)+
-  done
-
-(* FIXME: move *)
-lemma case_prod_wp:
-  "(\<And>a b. x = (a, b) \<Longrightarrow> \<lbrace>P a b\<rbrace> f a b \<lbrace>Q\<rbrace>)
-  \<Longrightarrow> \<lbrace>P (fst x) (snd x)\<rbrace> case_prod f x \<lbrace>Q\<rbrace>"
- by (cases x, simp)
-
-(* FIXME: move *)
-lemma case_sum_wp:
-  "\<lbrakk> (\<And>a. x = Inl a \<Longrightarrow> \<lbrace>P a\<rbrace> f a \<lbrace>Q\<rbrace>);
-     (\<And>a. x = Inr a \<Longrightarrow> \<lbrace>P' a\<rbrace> g a \<lbrace>Q\<rbrace>) \<rbrakk>
-  \<Longrightarrow> \<lbrace>\<lambda>s. (\<forall>a. x = Inl a \<longrightarrow> P a s) \<and> (\<forall>a. x = Inr a \<longrightarrow> P' a s)\<rbrace> case_sum f g x \<lbrace>Q\<rbrace>"
-  by (cases x, simp_all)
-
-(* MOVE *)
-crunch arm_asid_table_inv [wp]: store_pte "\<lambda>s. P (arm_asid_table (arch_state s))"
-
-lemma st_tcb_at_to_thread_states:
-  "st_tcb_at P t s \<Longrightarrow> \<exists>st. P st \<and> thread_states s t = tcb_st_to_auth st"
-  by (fastforce simp: st_tcb_def2 thread_states_def tcb_states_of_state_def)
-
-lemma aag_Control_into_owns:
-  "\<lbrakk> aag_has_auth_to aag Control p; pas_refined aag s \<rbrakk> \<Longrightarrow> is_subject aag p"
-  apply (drule (1) pas_refined_Control)
-  apply simp
-  done
-
-lemma aag_has_Control_iff_owns:
-  "pas_refined aag s \<Longrightarrow> (aag_has_auth_to aag Control x) = (is_subject aag x)"
-  apply (rule iffI)
-  apply (erule (1) aag_Control_into_owns)
-  apply (simp add: pas_refined_refl)
-  done
-
-lemma aag_Control_owns_strg:
-  "pas_wellformed aag \<and> is_subject aag v \<longrightarrow> aag_has_auth_to aag Control v"
-  by (clarsimp simp: aag_wellformed_refl)
-
-(* **************************************** *)
-
-subsection \<open>Policy entailments\<close>
-
-lemma owns_ep_owns_receivers:
-  "\<lbrakk>\<forall>auth. aag_has_auth_to aag auth epptr; pas_refined aag s; invs s;
-    ko_at (Endpoint ep) epptr s; (t, EPRecv) \<in> ep_q_refs_of ep\<rbrakk>
-  \<Longrightarrow> is_subject aag t"
-  apply (drule (1) ep_rcv_queued_st_tcb_at [where P = "receive_blocked_on epptr"])
-      apply clarsimp
-     apply clarsimp
-    apply clarsimp
-   apply (rule refl)
-  apply (drule st_tcb_at_to_thread_states)
-  apply (clarsimp simp: receive_blocked_on_def2)
-  apply (drule spec [where x = Grant])
-  apply (frule aag_wellformed_grant_Control_to_recv
-           [OF _ _ pas_refined_wellformed])
-    apply (rule pas_refined_mem [OF sta_ts])
-     apply fastforce
-    apply assumption+
-  apply (erule (1) aag_Control_into_owns)
-  done
-
-(* MOVE *)
-lemma cli_caps_of_state:
-  "\<lbrakk> caps_of_state s slot = Some cap; pas_refined aag s \<rbrakk> \<Longrightarrow> cap_links_irq aag (pasObjectAbs aag (fst slot)) cap"
-apply (clarsimp simp add: cap_links_irq_def pas_refined_def)
-apply (blast dest: state_irqs_to_policy_aux.intros)
-done
-
-(* MOVE *)
-lemma cap_auth_caps_of_state:
-  "\<lbrakk> caps_of_state s p = Some cap; pas_refined aag s \<rbrakk>
-  \<Longrightarrow> aag_cap_auth aag (pasObjectAbs aag (fst p)) cap"
-  unfolding aag_cap_auth_def
-  apply (intro conjI)
-    apply clarsimp
-    apply (drule (2) sta_caps)
-    apply (drule_tac f="pasObjectAbs aag" in auth_graph_map_memI[OF _ refl refl])
-    apply (fastforce simp: pas_refined_def)
-   apply clarsimp
-   apply (drule (2) sta_untyped [THEN pas_refined_mem] )
-   apply simp
-  apply (drule (1) clas_caps_of_state)
-  apply simp
-  apply (drule (1) cli_caps_of_state)
-  apply simp
-  done
-
-lemma cap_cur_auth_caps_of_state:
-  "\<lbrakk> caps_of_state s p = Some cap; pas_refined aag s; is_subject aag (fst p) \<rbrakk>
-  \<Longrightarrow> pas_cap_cur_auth aag cap"
-  by (metis cap_auth_caps_of_state)
-
-subsection \<open>Integrity monotony over subjects\<close>
-
-lemmas new_range_subset' = aligned_range_offset_subset
-lemmas ptr_range_subset = new_range_subset' [folded ptr_range_def]
-
-lemma pbfs_less_wb:
-  "pageBitsForSize x < word_bits"
-  by (cases x, simp_all add: word_bits_def)
-
-lemma ipcframe_subset_page:
-  "\<lbrakk>valid_objs s; get_tcb p s = Some tcb;
-    tcb_ipcframe tcb = cap.ArchObjectCap (arch_cap.PageCap d p' R vms xx);
-    x \<in> ptr_range (p' + (tcb_ipc_buffer tcb && mask (pageBitsForSize vms))) msg_align_bits \<rbrakk>
-  \<Longrightarrow> x \<in> ptr_range p' (pageBitsForSize vms)"
-   apply (frule (1) valid_tcb_objs)
-   apply (clarsimp simp add: valid_tcb_def ran_tcb_cap_cases)
-   apply (erule set_mp[rotated])
-   apply (rule ptr_range_subset)
-     apply (simp add: valid_cap_def cap_aligned_def)
-    apply (simp add: valid_tcb_def valid_ipc_buffer_cap_def is_aligned_andI1 split:bool.splits)
-   apply (rule order_trans [OF _ pbfs_atleast_pageBits])
-   apply (simp add: msg_align_bits pageBits_def)
-  apply (rule and_mask_less')
-  apply (simp add: pbfs_less_wb [unfolded word_bits_conv])
-  done
-
-lemma trm_ipc':
-  "\<lbrakk> pas_refined aag s; valid_objs s; case_option False can_receive_ipc (tcb_states_of_state s p');
-     (tcb_states_of_state s' p') = Some Structures_A.Running;
-     p \<in> auth_ipc_buffers s p' \<rbrakk> \<Longrightarrow>
-    integrity_mem aag subjects p
-          (tcb_states_of_state s) (tcb_states_of_state s') (auth_ipc_buffers s) X
-          (underlying_memory (machine_state s) p)
-          (underlying_memory (machine_state s') p)"
-  apply (cases "pasObjectAbs aag p' \<in> subjects")
-   apply (rule trm_write)
-   apply (clarsimp simp: auth_ipc_buffers_member_def)
-   apply (frule pas_refined_mem[rotated])
-    apply (erule sta_caps, simp)
-     apply (erule(3) ipcframe_subset_page)
-    apply (simp add: cap_auth_conferred_def vspace_cap_rights_to_auth_def
-                     is_page_cap_def)
-    apply fastforce
-   apply fastforce
-  by (rule trm_ipc)
-
-
-lemma tcb_bound_notification_reset_integrity_mono:
-  "\<lbrakk> tcb_bound_notification_reset_integrity ntfn ntfn' S aag ; S \<subseteq> T\<rbrakk>
-   \<Longrightarrow> tcb_bound_notification_reset_integrity ntfn ntfn' T aag"
-  unfolding tcb_bound_notification_reset_integrity_def by blast
-
-lemma reply_cap_deletion_integrity_mono:
-  "\<lbrakk> reply_cap_deletion_integrity S aag cap cap' ; S \<subseteq> T\<rbrakk> \<Longrightarrow> reply_cap_deletion_integrity T aag cap cap'"
-  by (blast intro: reply_cap_deletion_integrity_intros elim: reply_cap_deletion_integrityE)
-
-lemma cnode_integrity_mono:
-  "\<lbrakk> cnode_integrity S aag cont cont' ; S \<subseteq> T\<rbrakk> \<Longrightarrow> cnode_integrity T aag cont cont'"
-  by (blast intro!: cnode_integrityI elim: cnode_integrityE dest:reply_cap_deletion_integrity_mono)
-
-lemma asid_pool_integrity_mono:
-  "\<lbrakk> asid_pool_integrity S aag cont cont' ; S \<subseteq> T\<rbrakk> \<Longrightarrow> asid_pool_integrity T aag cont cont'"
-  unfolding asid_pool_integrity_def by fastforce
-
-lemma cdt_change_allowed_mono:
-  "\<lbrakk>cdt_change_allowed aag S (cdt s) (tcb_states_of_state s) ptr; S \<subseteq> T \<rbrakk> \<Longrightarrow>
-    cdt_change_allowed aag T (cdt s) (tcb_states_of_state s) ptr"
-  unfolding cdt_change_allowed_def cdt_direct_change_allowed.simps direct_call_def by blast
-
-
-
-lemmas rtranclp_monoE = rtranclp_mono[THEN predicate2D,rotated,OF _ predicate2I]
-
-lemma integrity_mono:
-  "\<lbrakk> integrity_subjects S aag activate X s s'; S \<subseteq> T;
-           pas_refined aag s; valid_objs s \<rbrakk>
-     \<Longrightarrow> integrity_subjects T aag activate X s s'"
-  apply (clarsimp simp: integrity_subjects_def simp del:split_paired_All)
-  apply (rule conjI)
-   apply clarsimp
-   apply (drule_tac x=x in spec)+
-   apply (simp only: integrity_obj_def)
-   apply (erule rtranclp_monoE)
-   apply (erule integrity_obj_atomic.cases[OF _ integrity_obj_atomic.intros];
-          auto simp: indirect_send_def direct_send_def direct_call_def direct_reply_def
-               elim: asid_pool_integrity_mono reply_cap_deletion_integrity_mono
-                     cnode_integrity_mono)
-  apply (rule conjI)
-   apply clarsimp
-   apply (drule_tac x=x in spec)+
-   apply (erule integrity_eobj.cases; auto intro: integrity_eobj.intros)
-  apply (rule conjI)
-   apply clarsimp
-   apply (drule_tac x=x in spec, erule integrity_mem.cases;
-          blast intro: integrity_mem.intros trm_ipc')
-  apply (rule conjI)
-   apply clarsimp
-   apply (drule_tac x=x in spec, erule integrity_device.cases;
-          blast intro: integrity_device.intros)
-  apply (rule conjI)
-  apply (intro allI)
-  apply (drule_tac x=x in spec)+
-   apply (erule integrity_cdtE; auto elim: cdt_change_allowed_mono)
-  apply (rule conjI)
-   apply (intro allI)
-   apply (drule_tac x=x in spec)+
-   apply (erule integrity_cdt_listE;
-          auto elim!: weaken_filter_eq' intro: integrity_cdt_list_intros
-               elim: cdt_change_allowed_mono)
-  apply (rule conjI)
-   apply (fastforce simp: integrity_interrupts_def)
-  apply (rule conjI)
-   apply (fastforce simp: integrity_asids_def)
-  apply (clarsimp simp: integrity_ready_queues_def)
-  apply blast
-  done
-
-subsection\<open>Access control do not care about machine_state\<close>
-
-lemma integrity_irq_state_independent[intro!, simp]:
-  "integrity x y z (s\<lparr>machine_state :=
-                              machine_state s\<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>)
-   = integrity x y z s"
-  by (simp add: integrity_def)
-
-lemma state_objs_to_policy_irq_state_independent[intro!, simp]:
-  "state_objs_to_policy (s\<lparr>machine_state :=
-                                   machine_state s\<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>)
-   = state_objs_to_policy s"
-  by (simp add: state_objs_to_policy_def)
-
-lemma tcb_domain_map_wellformed_independent[intro!, simp]:
-  "tcb_domain_map_wellformed aag (s\<lparr>machine_state :=
-                                  machine_state s\<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
-   = tcb_domain_map_wellformed aag s"
-  by (simp add: tcb_domain_map_wellformed_aux_def get_etcb_def)
-
-lemma pas_refined_irq_state_independent[intro!, simp]:
-  "pas_refined x (s\<lparr>machine_state := machine_state s\<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>)
-   = pas_refined x s"
-  by (simp add: pas_refined_def)
-
-
-subsection\<open>Transitivity of integrity lemmas and tactics\<close>
-
-lemma integrity_trans_start:
-  "(\<And> s. P s \<Longrightarrow> \<lbrace>(=) s\<rbrace> f \<lbrace>\<lambda>_. integrity aag X s\<rbrace>)
-    \<Longrightarrow> \<lbrace>integrity aag X st and P\<rbrace> f \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  unfolding spec_valid_def valid_def using integrity_trans
-  by simp blast
-
-method integrity_trans_start
-    = ((simp only: and_assoc[symmetric])?, rule integrity_trans_start[rotated])
-
-(* Q should be explicitly supplied, if not, use wp_integrity_clean' *)
-lemma wp_integrity_clean:
-  "\<lbrakk>\<And>s. Q s \<Longrightarrow> integrity aag X s (g s);
-    \<lbrace> P \<rbrace> f \<lbrace>\<lambda>_. integrity aag X st and Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> f \<lbrace>\<lambda>_ s. integrity aag X st (g s) \<rbrace> "
-   by (rule hoare_post_imp[of "\<lambda>_. integrity aag X st and Q"])
-      (fastforce elim: integrity_trans)
-
-lemmas wp_integrity_clean'= wp_integrity_clean[of \<top>, simplified]
-
-
-end
 
 end

--- a/proof/access-control/Access_AC.thy
+++ b/proof/access-control/Access_AC.thy
@@ -1,0 +1,1596 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory Access_AC
+imports Access
+begin
+
+section\<open>Generic AC proofs\<close>
+
+lemma aag_wellformed_Control:
+  "\<lbrakk> (x, Control, y) \<in> aag; policy_wellformed aag mirqs irqs x \<rbrakk> \<Longrightarrow> x = y"
+  unfolding policy_wellformed_def by metis
+
+lemma aag_wellformed_refl:
+  "\<lbrakk> policy_wellformed aag mirqs irqs x \<rbrakk> \<Longrightarrow> (x, a, x) \<in> aag"
+  unfolding policy_wellformed_def by blast
+
+lemma aag_wellformed_grant_Control_to_recv:
+  "\<lbrakk> (s, Grant, ep) \<in> aag; (r, Receive, ep) \<in> aag; policy_wellformed aag mirqs irqs l \<rbrakk>
+     \<Longrightarrow> (s, Control, r) \<in> aag"
+  unfolding policy_wellformed_def by blast
+
+lemma aag_wellformed_grant_Control_to_send:
+  "\<lbrakk> (s, Grant, ep) \<in> aag; (r, Receive, ep) \<in> aag; policy_wellformed aag mirqs irqs l \<rbrakk>
+     \<Longrightarrow> (r, Control, s) \<in> aag"
+  unfolding policy_wellformed_def by blast
+
+lemma aag_wellformed_reply:
+  "\<lbrakk> (s, Call, ep) \<in> aag; (r, Receive, ep) \<in> aag; policy_wellformed aag mirqs irqs l \<rbrakk>
+     \<Longrightarrow> (r, Reply, s) \<in> aag"
+  unfolding policy_wellformed_def by blast
+
+lemma aag_wellformed_delete_derived':
+  "\<lbrakk> (s, Call, ep) \<in> aag; (r, Receive, ep) \<in> aag; policy_wellformed aag mirqs irqs l \<rbrakk>
+     \<Longrightarrow> (s, DeleteDerived, r) \<in> aag"
+  unfolding policy_wellformed_def by blast
+
+lemma aag_wellformed_delete_derived:
+  "\<lbrakk> (s, Reply, r) \<in> aag; policy_wellformed aag mirqs irqs l \<rbrakk>
+     \<Longrightarrow> (r, DeleteDerived, s) \<in> aag"
+  unfolding policy_wellformed_def by blast
+
+lemma aag_wellformed_delete_derived_trans:
+  "\<lbrakk> (l1, DeleteDerived, l2) \<in> aag; (l2, DeleteDerived, l3) \<in> aag;
+     policy_wellformed aag mirqs irqs l\<rbrakk>
+     \<Longrightarrow> (l1, DeleteDerived, l3) \<in> aag"
+  unfolding policy_wellformed_def by blast
+
+lemma aag_wellformed_call_to_syncsend:
+  "\<lbrakk> (s, Call, ep) \<in> aag; policy_wellformed aag mirqs irqs l \<rbrakk>
+     \<Longrightarrow> (s, SyncSend, ep) \<in> aag"
+  unfolding policy_wellformed_def by blast
+
+lemma aag_wellformed_grant_Control_to_send_by_reply:
+  "\<lbrakk> (s, Call, ep) \<in> aag; (r, Receive, ep) \<in> aag;
+     (r, Grant, ep) \<in> aag; policy_wellformed aag mirqs irqs l \<rbrakk>
+     \<Longrightarrow> (r, Control, s) \<in> aag"
+  unfolding policy_wellformed_def by blast
+
+lemma aag_wellformed_grant_Control_to_recv_by_reply:
+  "\<lbrakk> (s, Call, ep) \<in> aag; (r, Receive, ep) \<in> aag;
+     (r, Grant, ep) \<in> aag; policy_wellformed aag mirqs irqs l \<rbrakk>
+     \<Longrightarrow> (s, Control, r) \<in> aag"
+  unfolding policy_wellformed_def by blast
+
+lemma auth_graph_map_mem:
+  "(x, auth, y) \<in> auth_graph_map f S = (\<exists>x' y'. x = f x' \<and> y = f y' \<and> (x', auth, y') \<in> S)"
+  by (simp add: auth_graph_map_def)
+
+lemmas auth_graph_map_memD = auth_graph_map_mem[THEN iffD1]
+
+lemma auth_graph_map_memE:
+  assumes hyp: "(x, auth, y) \<in> auth_graph_map f S"
+  obtains x' and y' where "x = f x'" and "y = f y'" and "(x', auth, y') \<in> S"
+  using hyp[THEN auth_graph_map_mem[THEN iffD1]] by fastforce
+
+lemma auth_graph_map_memI:
+  "\<lbrakk> (x', auth, y') \<in> S; x = f x'; y = f y' \<rbrakk>
+     \<Longrightarrow> (x, auth, y) \<in> auth_graph_map f S"
+  by (fastforce simp add: auth_graph_map_mem)
+
+lemma auth_graph_map_mono:
+  "S \<subseteq> S' \<Longrightarrow> auth_graph_map G S \<subseteq> auth_graph_map G S'"
+  unfolding auth_graph_map_def by auto
+
+lemma is_transferable_capE:
+  assumes hyp:"is_transferable_cap cap"
+  obtains "cap = NullCap" | t R where "cap = ReplyCap t False R"
+  by (rule is_transferable.cases[OF hyp]) auto
+
+lemma is_transferable_None[simp]: "is_transferable None"
+  using is_transferable.simps by simp
+lemma is_transferable_Null[simp]: "is_transferable_cap NullCap"
+  using is_transferable.simps by simp
+lemma is_transferable_Reply[simp]: "is_transferable_cap (ReplyCap t False R)"
+  using is_transferable.simps by simp
+
+lemma is_transferable_NoneE:
+  assumes hyp: "is_transferable opt_cap"
+  obtains "opt_cap = None" | cap where "opt_cap = Some cap" and "is_transferable_cap cap"
+  by (rule is_transferable.cases[OF hyp];simp)
+
+lemma is_transferable_Untyped[simp]: "\<not> is_transferable (Some (UntypedCap dev ptr sz freeIndex))"
+  by (blast elim: is_transferable.cases)
+lemma is_transferable_IRQ[simp]: "\<not> is_transferable_cap IRQControlCap"
+  by (blast elim: is_transferable.cases)
+lemma is_transferable_Zombie[simp]: "\<not> is_transferable (Some (Zombie ptr sz n))"
+  by (blast elim: is_transferable.cases)
+lemma is_transferable_Ntfn[simp]: "\<not> is_transferable (Some (NotificationCap ntfn badge R))"
+  by (blast elim: is_transferable.cases)
+lemma is_transferable_Endpoint[simp]: "\<not> is_transferable (Some (EndpointCap ntfn badge R))"
+  by (blast elim: is_transferable.cases)
+
+(* FIXME MOVE *)
+lemmas descendants_incD = descendants_inc_def[THEN meta_eq_to_obj_eq, THEN iffD1, rule_format]
+
+(* FIXME MOVE *)
+lemmas all_childrenI = all_children_def[THEN meta_eq_to_obj_eq, THEN iffD2, rule_format]
+lemmas all_childrenD = all_children_def[THEN meta_eq_to_obj_eq, THEN iffD1, rule_format]
+
+(* FIXME MOVE *)
+lemma valid_mdb_descendants_inc[elim!]:
+  "valid_mdb s \<Longrightarrow> descendants_inc (cdt s) (caps_of_state s)"
+  by (simp add:valid_mdb_def)
+
+(* FIXME MOVE *)
+lemma valid_mdb_mdb_cte_at [elim!]:
+  "valid_mdb s \<Longrightarrow> mdb_cte_at (swp (cte_wp_at ((\<noteq>) NullCap)) s) (cdt s)"
+  by (simp add:valid_mdb_def)
+
+(* FIXME MOVE *)
+lemma descendants_inc_cap_classD:
+  "\<lbrakk> descendants_inc m caps; p \<in> descendants_of p' m; caps p = Some cap ; caps p' = Some cap' \<rbrakk>
+     \<Longrightarrow> cap_class cap = cap_class cap'"
+  by (fastforce dest:descendants_incD)
+
+
+locale Access_AC_1 =
+  fixes aag :: "'a PAS"
+  and user_monad_t :: "'b user_monad"
+  assumes acap_class_reply:
+    "acap_class acap \<noteq> ReplyClass t"
+  and arch_troa_tro_alt[elim!]:
+    "arch_integrity_obj_atomic aag subjects l ko ko'
+     \<Longrightarrow> arch_integrity_obj_alt aag subjects l ko ko'"
+  and arch_tro_alt_trans_spec:
+    "\<lbrakk> arch_integrity_obj_alt aag subjects l ko ko';
+       arch_integrity_obj_alt aag subjects l ko' ko'' \<rbrakk>
+       \<Longrightarrow> arch_integrity_obj_alt aag subjects l ko ko''"
+  and clas_caps_of_state:
+    "\<lbrakk> caps_of_state s slot = Some cap; pas_refined aag s \<rbrakk>
+       \<Longrightarrow> cap_links_asid_slot aag (pasObjectAbs aag (fst slot)) cap"
+  and as_user_state_vrefs[wp]:
+    "as_user t (f' :: 'b user_monad) \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
+begin
+
+lemma cap_class_reply:
+  "(cap_class cap = ReplyClass t) = (\<exists>r m. cap = ReplyCap t m r)"
+  by (cases cap; simp add: acap_class_reply)
+
+lemma reply_cap_no_children:
+  "\<lbrakk> valid_mdb s; caps_of_state s p = Some (ReplyCap t False r) \<rbrakk> \<Longrightarrow> cdt s p' \<noteq> Some p"
+  apply (clarsimp simp: valid_mdb_def)
+  apply (frule descendants_incD[where p=p' and p'=p])
+   apply (rule child_descendant)
+   apply (fastforce)
+  apply clarsimp
+  apply (subgoal_tac "caps_of_state s p' \<noteq> None")
+   apply (clarsimp simp: cap_class_reply)
+   apply (simp only: reply_mdb_def reply_caps_mdb_def reply_masters_mdb_def)
+   apply (elim conjE allE[where x=p'])
+   apply simp
+  apply (drule(1) mdb_cte_atD)
+  apply (fastforce simp add: cte_wp_at_def caps_of_state_def)
+  done
+
+lemma is_transferable_all_children:
+  "valid_mdb s \<Longrightarrow> all_children (\<lambda>slot . is_transferable (caps_of_state s slot)) (cdt s)"
+  apply (rule all_childrenI)
+  apply (erule is_transferable.cases)
+    apply (fastforce dest: mdb_cte_atD valid_mdb_mdb_cte_at
+                     simp: mdb_cte_at_def cte_wp_at_def caps_of_state_def)
+   apply (fastforce dest: mdb_cte_atD valid_mdb_mdb_cte_at
+                    simp: mdb_cte_at_def cte_wp_at_def caps_of_state_def)
+  apply (blast dest: reply_cap_no_children)
+  done
+
+end
+
+
+lemmas state_objs_to_policy_mem = eqset_imp_iff[OF state_objs_to_policy_def]
+
+lemmas state_objs_to_policy_intros
+    = state_bits_to_policy.intros[THEN state_objs_to_policy_mem[THEN iffD2]]
+
+(* FIXME: brittle when adding rules to or removing rules from state_bits_to_policy *)
+lemmas sta_caps = state_objs_to_policy_intros(1)
+  and sta_untyped = state_objs_to_policy_intros(2)
+  and sta_ts = state_objs_to_policy_intros(3)
+  and sta_bas = state_objs_to_policy_intros(4)
+  and sta_cdt = state_objs_to_policy_intros(5)
+  and sta_cdt_transferable = state_objs_to_policy_intros(6)
+  and sta_vref = state_objs_to_policy_intros(7)
+
+lemmas state_objs_to_policy_cases
+    = state_bits_to_policy.cases[OF state_objs_to_policy_mem[THEN iffD1]]
+
+lemma tcb_states_of_state_preserved:
+  "\<lbrakk> get_tcb thread s = Some tcb; tcb_state tcb' = tcb_state tcb \<rbrakk>
+     \<Longrightarrow> tcb_states_of_state (s\<lparr>kheap := kheap s(thread \<mapsto> TCB tcb')\<rparr>) = tcb_states_of_state s"
+  by (auto split: option.splits simp: tcb_states_of_state_def get_tcb_def)
+
+lemma thread_states_preserved:
+  "\<lbrakk> get_tcb thread s = Some tcb; tcb_state tcb' = tcb_state tcb \<rbrakk>
+     \<Longrightarrow> thread_states (s\<lparr>kheap := kheap s(thread \<mapsto> TCB tcb')\<rparr>) = thread_states s"
+  by (simp add: tcb_states_of_state_preserved thread_states_def)
+
+lemma thread_bound_ntfns_preserved:
+  "\<lbrakk> get_tcb thread s = Some tcb; tcb_bound_notification tcb' = tcb_bound_notification tcb \<rbrakk>
+     \<Longrightarrow> thread_bound_ntfns (s\<lparr>kheap := kheap s(thread \<mapsto> TCB tcb')\<rparr>) = thread_bound_ntfns s"
+  by (auto simp: thread_bound_ntfns_def get_tcb_def split: option.splits)
+
+lemma is_transferable_null_filter[simp]:
+  "is_transferable (null_filter caps ptr) = is_transferable (caps ptr)"
+  by (auto simp: is_transferable.simps null_filter_def)
+
+lemma tcb_domain_map_wellformed_mono:
+  "\<lbrakk> domains_of_state s' \<subseteq> domains_of_state s; tcb_domain_map_wellformed pas s \<rbrakk>
+     \<Longrightarrow> tcb_domain_map_wellformed pas s'"
+  by (auto simp: tcb_domain_map_wellformed_aux_def get_etcb_def)
+
+lemma pas_refined_mem:
+  "\<lbrakk> (x, auth, y) \<in> state_objs_to_policy s; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> abs_has_auth_to aag auth x y"
+  by (auto simp: pas_refined_def intro: auth_graph_map_memI)
+
+lemma pas_refined_wellformed[elim!]:
+  "pas_refined aag s \<Longrightarrow> pas_wellformed aag"
+  unfolding pas_refined_def by simp
+
+lemmas pas_refined_Control
+    = aag_wellformed_Control[OF _ pas_refined_wellformed]
+  and pas_refined_refl = aag_wellformed_refl [OF pas_refined_wellformed]
+
+lemma caps_of_state_pasObjectAbs_eq:
+  "\<lbrakk> caps_of_state s p = Some cap; Control \<in> cap_auth_conferred cap;
+     is_subject aag (fst p); pas_refined aag s; x \<in> obj_refs cap \<rbrakk>
+     \<Longrightarrow> is_subject aag x"
+  apply (frule sta_caps, simp+)
+  apply (drule pas_refined_mem, simp+)
+  apply (drule pas_refined_Control, simp+)
+  done
+
+lemma pas_refined_state_objs_to_policy_subset:
+  "\<lbrakk> pas_refined aag s;
+     state_objs_to_policy s' \<subseteq> state_objs_to_policy s;
+     state_asids_to_policy aag s' \<subseteq> state_asids_to_policy aag s;
+     state_irqs_to_policy aag s' \<subseteq> state_irqs_to_policy aag s;
+     domains_of_state s' \<subseteq> domains_of_state s;
+     interrupt_irq_node s' = interrupt_irq_node s \<rbrakk>
+     \<Longrightarrow> pas_refined aag s'"
+  by (simp add: pas_refined_def)
+     (blast dest: tcb_domain_map_wellformed_mono auth_graph_map_mono[where G="pasObjectAbs aag"])
+
+lemma aag_wellformed_all_auth_is_owns':
+  "\<lbrakk> Control \<in> S; pas_wellformed aag \<rbrakk>
+     \<Longrightarrow> (\<forall>auth \<in> S. aag_has_auth_to aag auth x) = (is_subject aag x)"
+  by (fastforce simp: aag_wellformed_refl dest: aag_wellformed_Control)
+
+lemmas aag_wellformed_all_auth_is_owns
+   = aag_wellformed_all_auth_is_owns'[where S=UNIV, simplified]
+     aag_wellformed_all_auth_is_owns'[where S="{Control}", simplified]
+
+lemmas aag_wellformed_control_is_owns
+   = aag_wellformed_all_auth_is_owns'[where S="{Control}", simplified]
+
+lemmas pas_refined_all_auth_is_owns = aag_wellformed_all_auth_is_owns[OF pas_refined_wellformed]
+
+lemma pas_refined_sita_mem:
+  "\<lbrakk> (x, auth, y) \<in> state_irqs_to_policy aag s; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> (x, auth, y) \<in> pasPolicy aag"
+  by (auto simp: pas_refined_def)
+
+lemma receive_blocked_on_can_receive_ipc[elim!,simp]:
+  "receive_blocked_on ref ts \<Longrightarrow> can_receive_ipc ts"
+  by (cases ts; simp)
+
+lemma receive_blocked_on_can_receive_ipc'[elim!,simp]:
+  "case_option False (receive_blocked_on ref) tsopt \<Longrightarrow> case_option False can_receive_ipc tsopt"
+  by (cases tsopt;simp)
+
+lemma tcb_bound_notification_reset_integrity_refl[simp]:
+  "tcb_bound_notification_reset_integrity ntfn ntfn subjects aag"
+  by (simp add: tcb_bound_notification_reset_integrity_def)
+
+lemma allowed_call_blocked_call_blocked[elim!]:
+  "allowed_call_blocked ep tst \<Longrightarrow> call_blocked ep tst"
+  unfolding allowed_call_blocked_def call_blocked_def by fastforce
+
+lemmas reply_cap_deletion_integrityI1 =
+       reply_cap_deletion_integrity_def[THEN meta_eq_to_obj_eq,THEN iffD2,OF disjI1]
+lemmas reply_cap_deletion_integrityI2 =
+       reply_cap_deletion_integrity_def[THEN meta_eq_to_obj_eq,THEN iffD2, OF disjI2, OF exI,
+                                        OF exI, OF conjI [OF _ conjI], rule_format]
+lemmas reply_cap_deletion_integrity_intros =
+       reply_cap_deletion_integrityI1 reply_cap_deletion_integrityI2
+
+lemma reply_cap_deletion_integrityE:
+  assumes hyp: "reply_cap_deletion_integrity subjects aag cap cap'"
+  obtains "cap = cap'" | caller R where "cap = ReplyCap caller False R"
+  and "cap' = NullCap" and "pasObjectAbs aag caller \<in> subjects"
+  using hyp reply_cap_deletion_integrity_def by blast
+
+lemma reply_cap_deletion_integrity_refl[simp]:
+  "reply_cap_deletion_integrity subjects aag cap cap"
+  by (rule reply_cap_deletion_integrityI1) simp
+
+lemmas cnode_integrityI = cnode_integrity_def[THEN meta_eq_to_obj_eq,THEN iffD2,rule_format]
+lemmas cnode_integrityD = cnode_integrity_def[THEN meta_eq_to_obj_eq,THEN iffD1,rule_format]
+lemma cnode_integrityE:
+  assumes hyp:"cnode_integrity subjects aag content content'"
+  obtains "content l = content' l" | cap cap' where "content l = Some cap"
+  and "content' l = Some cap'" and "reply_cap_deletion_integrity subjects aag cap cap'"
+  using hyp cnode_integrityD by blast
+
+subsubsection \<open>Introduction rules for object integrity\<close>
+
+lemma troa_tro:
+  "integrity_obj_atomic aag activate subjects l ko ko'
+    \<Longrightarrow> integrity_obj aag activate subjects l ko ko'"
+  unfolding integrity_obj_def by (rule r_into_rtranclp)
+
+lemmas tro_lrefl = troa_lrefl[THEN troa_tro]
+lemma tro_orefl:
+  "ko = ko' \<Longrightarrow> integrity_obj aag activate subjects l' ko ko'"
+  unfolding integrity_obj_def by simp
+lemmas tro_ntfn = troa_ntfn[THEN troa_tro]
+lemmas tro_ep = troa_ep[THEN troa_tro]
+lemmas tro_ep_unblock = troa_ep_unblock[THEN troa_tro]
+lemmas tro_tcb_send = troa_tcb_send[THEN troa_tro]
+lemmas tro_tcb_call = troa_tcb_call[THEN troa_tro]
+lemmas tro_tcb_reply = troa_tcb_reply[THEN troa_tro]
+lemmas tro_tcb_receive = troa_tcb_receive[THEN troa_tro]
+lemmas tro_tcb_restart = troa_tcb_restart[THEN troa_tro]
+lemmas tro_tcb_unbind = troa_tcb_unbind[THEN troa_tro]
+lemmas tro_tcb_empty_ctable = troa_tcb_empty_ctable[THEN troa_tro]
+lemmas tro_tcb_empty_caller = troa_tcb_empty_caller[THEN troa_tro]
+lemmas tro_tcb_activate = troa_tcb_activate[THEN troa_tro]
+lemmas tro_arch = troa_arch[THEN troa_tro]
+lemmas tro_cnode = troa_cnode[THEN troa_tro]
+
+lemmas tro_intros = tro_lrefl tro_orefl tro_ntfn tro_ep tro_ep_unblock tro_tcb_send tro_tcb_call
+           tro_tcb_reply tro_tcb_receive tro_tcb_restart tro_tcb_unbind tro_tcb_empty_ctable
+           tro_tcb_empty_caller tro_tcb_activate tro_arch tro_cnode
+
+lemma tro_tcb_unbind':
+  "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+     tcb' = tcb\<lparr>tcb_bound_notification := ntfn'\<rparr>;
+     tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag \<rbrakk>
+     \<Longrightarrow> integrity_obj aag activate subjects l' ko ko'"
+  apply (clarsimp simp:tcb_bound_notification_reset_integrity_def)
+  apply (elim disjE)
+   apply (rule tro_orefl;fastforce)
+  apply (rule tro_tcb_unbind;fastforce)
+  done
+
+lemmas rtranclp_transp[intro!] = transp_rtranclp
+
+lemma tro_transp[intro!]:
+  "transp (integrity_obj aag activate es subjects)"
+  unfolding integrity_obj_def by simp
+
+lemmas tro_trans_spec = tro_transp[THEN transpD]
+
+lemma tro_tcb_generic':
+  "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+     tcb' = tcb \<lparr>tcb_bound_notification := ntfn', tcb_caller := cap', tcb_ctable := ccap'\<rparr>;
+     tcb_bound_notification_reset_integrity (tcb_bound_notification tcb) ntfn' subjects aag;
+     reply_cap_deletion_integrity subjects aag (tcb_caller tcb) cap';
+     reply_cap_deletion_integrity subjects aag (tcb_ctable tcb) ccap' \<rbrakk>
+     \<Longrightarrow> integrity_obj aag activate subjects l' ko ko'"
+  apply clarsimp
+  apply (rule tro_trans_spec)
+   apply (rule tro_tcb_empty_caller[OF refl refl refl];simp)
+  apply (rule tro_trans_spec)
+   apply (rule tro_tcb_empty_ctable[OF refl refl refl];simp)
+  apply (rule tro_trans_spec)
+   apply (rule tro_tcb_unbind'[OF refl refl refl];simp)
+  apply (fastforce intro!: tro_orefl tcb.equality)
+  done
+
+lemma tro_tcb_reply':
+  "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+     tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
+                 tcb_state := new_st, tcb_fault := None\<rparr>;
+     new_st = Running \<or> (tcb_fault tcb \<noteq> None \<and> (new_st = Restart \<or> new_st = Inactive));
+     direct_reply subjects aag l' tcb \<rbrakk>
+     \<Longrightarrow> integrity_obj aag activate subjects l' ko ko'"
+  apply (clarsimp simp:direct_reply_def simp del:not_None_eq)
+  apply (erule disjE, (rule tro_tcb_reply[OF refl refl], force; force)) (* Warning: schematics *)
+  apply (clarsimp simp del:not_None_eq)
+  apply (rule tro_trans_spec)
+   apply (frule allowed_call_blocked_def[THEN meta_eq_to_obj_eq,THEN iffD1],clarsimp)
+   apply (rule tro_tcb_receive[OF refl refl refl, where new_st=BlockedOnReply];force)
+  apply (rule tro_trans_spec)
+   apply (rule tro_tcb_reply[OF refl refl refl, where new_st=new_st];force)
+  by (fastforce intro!: tro_orefl tcb.equality)
+
+
+context Access_AC_1 begin
+
+lemma troa_tro_alt[elim!]:
+  "integrity_obj_atomic aag activate subjects l ko ko'
+   \<Longrightarrow> integrity_obj_alt aag activate subjects l ko ko'"
+  apply (erule integrity_obj_atomic.cases)
+
+  text \<open>Single out TCB cases for special handling. We manually simplify
+        the TCB updates in the tro_alt rules using @{thm tcb.equality}.\<close>
+    (* somewhat slow 10s *)
+                apply (find_goal \<open>match premises in "ko = Some (TCB _)" \<Rightarrow> succeed\<close>,
+                       ((erule(1) integrity_obj_alt.intros[OF tro_tagI],
+                         (intro exI tcb.equality; solves \<open>simp\<close>));
+                        fastforce simp: reply_cap_deletion_integrity_def direct_reply_def
+                                        tcb_bound_notification_reset_integrity_def))+
+
+       text \<open>Remaining cases.\<close>
+       apply (fastforce intro: integrity_obj_alt.intros[OF tro_tagI])+
+
+  done
+
+end
+
+
+lemma integrity_ready_queues_refl[simp]: "integrity_ready_queues aag subjects ptr s s"
+  unfolding integrity_ready_queues_def by simp
+
+(* FIXME MOVE *)
+lemma caps_of_state_tcb':
+  "\<lbrakk> get_tcb p s = Some tcb; option_map fst (tcb_cap_cases idx) = Some getF \<rbrakk>
+     \<Longrightarrow> caps_of_state s (p, idx) = Some (getF tcb)"
+  apply (drule get_tcb_SomeD)
+  apply clarsimp
+  apply (drule (1) cte_wp_at_tcbI [where t = "(p, idx)" and P = "(=) (getF tcb)", simplified])
+  apply simp
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  done
+
+(* FIXME MOVE *)
+lemma caps_of_state_tcb_cap_cases:
+  "\<lbrakk> get_tcb p s = Some tcb; idx \<in> dom tcb_cap_cases \<rbrakk>
+     \<Longrightarrow> caps_of_state s (p, idx) = Some ((the (option_map fst (tcb_cap_cases idx))) tcb)"
+  apply (clarsimp simp: dom_def)
+  apply (erule caps_of_state_tcb')
+  apply simp
+  done
+
+lemmas integrity_obj_simps [simp] =
+  tro_orefl[OF refl]
+  tro_lrefl[OF singletonI]
+  trm_orefl[OF refl]
+  trd_orefl[OF refl]
+  tre_lrefl[OF singletonI]
+  tre_orefl[OF refl]
+
+lemma cdt_change_allowedI:
+  "\<lbrakk> m \<Turnstile> pptr \<rightarrow>* ptr; cdt_direct_change_allowed aag subjects tcbsts pptr \<rbrakk>
+     \<Longrightarrow> cdt_change_allowed aag subjects m tcbsts ptr"
+  by (fastforce simp: cdt_change_allowed_def simp del: split_paired_Ex)
+
+lemma cdt_change_allowedE:
+  assumes "cdt_change_allowed aag subjects m tcbsts ptr"
+  obtains pptr where "m \<Turnstile> pptr \<rightarrow>* ptr" "cdt_direct_change_allowed aag subjects tcbsts pptr"
+  using assms by (fastforce simp: cdt_change_allowed_def simp del: split_paired_Ex)
+
+lemma cdca_ccaI:
+  "\<lbrakk> cdt_direct_change_allowed aag subjects tcbsts ptr \<rbrakk>
+     \<Longrightarrow> cdt_change_allowed aag subjects m tcbsts ptr"
+  by (fastforce simp: cdt_change_allowed_def simp del: split_paired_Ex)
+
+lemmas cca_owned = cdt_change_allowedI[OF _ cdca_owned]
+lemmas cca_reply' = cdt_change_allowedI[OF _ cdca_owned]
+lemmas cca_direct[intro] = cdca_ccaI[OF cdca_owned]
+lemmas cca_reply = cdca_ccaI[OF cdca_reply]
+
+lemma cca_direct_single[intro]:
+  "is_subject aag (fst ptr) \<Longrightarrow> cdt_change_allowed aag {pasSubject aag} m kh ptr"
+  by (rule cca_direct) blast
+
+lemma integrity_cdtE:
+  assumes hyp:"integrity_cdt aag subjects m tcbsts ptr v v'"
+  obtains "v = v'" | "cdt_change_allowed aag subjects m tcbsts ptr"
+  using hyp integrity_cdt_def by blast
+
+lemma integrity_cdt_refl[simp]: "integrity_cdt aag subjects m kh ptr v v"
+  by (simp add: integrity_cdt_def)
+
+lemma integrity_cdt_change_allowed[simp,intro]:
+  "cdt_change_allowed aag subjects m kh ptr \<Longrightarrow> integrity_cdt aag subjects m kh ptr v v'"
+  by (simp add: integrity_cdt_def)
+
+lemmas integrity_cdt_intros = integrity_cdt_refl integrity_cdt_change_allowed
+
+lemmas integrity_cdt_direct = cca_direct[THEN  integrity_cdt_change_allowed]
+
+lemma integrity_cdt_list_refl[simp]: "integrity_cdt_list aag subjects m kh ptr v v"
+  by (simp add: integrity_cdt_list_def)
+
+lemma integrity_cdt_list_filt:
+  "filtered_eq (cdt_change_allowed aag subjects m kh) l l'
+   \<Longrightarrow> integrity_cdt_list aag subjects m kh ptr l l'"
+  by (simp add: integrity_cdt_list_def)
+
+lemma integrity_cdt_list_change_allowed:
+  "cdt_change_allowed aag subjects m kh ptr \<Longrightarrow> integrity_cdt_list aag subjects m kh ptr l l'"
+  by (simp add: integrity_cdt_list_def)
+
+lemmas integrity_cdt_list_intros = integrity_cdt_list_filt integrity_cdt_list_change_allowed
+
+lemma integrity_cdt_listE:
+  assumes hyp:"integrity_cdt_list aag subjects m kh ptr l l'"
+  obtains "filtered_eq (cdt_change_allowed aag subjects m kh) l l'" |
+          "cdt_change_allowed aag subjects m kh ptr"
+  using hyp integrity_cdt_list_def by blast
+
+lemma integrity_interrupts_refl[simp]: "integrity_interrupts aag subjects ptr v v"
+  by (simp add: integrity_interrupts_def)
+
+section \<open>Integrity transitivity\<close>
+
+subsection \<open>Object integrity transitivity\<close>
+
+lemma tcb_bound_notification_reset_integrity_trans[elim]:
+  "\<lbrakk> tcb_bound_notification_reset_integrity ntfn ntfn' subjects aag;
+     tcb_bound_notification_reset_integrity ntfn' ntfn'' subjects aag \<rbrakk>
+     \<Longrightarrow> tcb_bound_notification_reset_integrity ntfn ntfn'' subjects aag"
+  by (auto simp: tcb_bound_notification_reset_integrity_def)
+
+lemma reply_cap_deletion_integrity_trans[elim]:
+  "\<lbrakk> reply_cap_deletion_integrity subjects aag cap cap';
+     reply_cap_deletion_integrity subjects aag cap' cap'' \<rbrakk>
+     \<Longrightarrow> reply_cap_deletion_integrity subjects aag cap cap''"
+  by (auto simp: reply_cap_deletion_integrity_def)
+
+
+lemma cnode_integrity_trans[elim]:
+  "\<lbrakk> cnode_integrity subjects aag cont cont';
+     cnode_integrity subjects aag cont' cont'' \<rbrakk>
+     \<Longrightarrow> cnode_integrity subjects aag cont cont''"
+   unfolding cnode_integrity_def
+   apply (intro allI)
+   apply (drule_tac x=l in spec)+
+   by fastforce
+
+lemma tcb_bound_notification_reset_eq_or_none:
+  "tcb_bound_notification_reset_integrity ntfn ntfn' subjects aag \<Longrightarrow> ntfn = ntfn' \<or> ntfn' = None"
+  by (auto simp: tcb_bound_notification_reset_integrity_def)
+
+
+context Access_AC_1 begin
+
+lemma tro_alt_trans_spec: (* this takes a long time to process *)
+  "\<lbrakk> integrity_obj_alt aag activate es subjects ko ko';
+     integrity_obj_alt aag activate es subjects ko' ko'' \<rbrakk>
+     \<Longrightarrow> integrity_obj_alt aag activate es subjects ko ko''"
+  (* We need to consider nearly 200 cases, one for each possible pair
+     of integrity steps. We use the tro_tags to select subsets of goals
+     that can be solved by the same method. *)
+
+  (* Expand the first integrity step *)
+  apply (erule integrity_obj_alt.cases[where ko=ko and ko'=ko'])
+
+  (* LRefl and ORefl trivially collapse into the second integrity step *)
+  apply (find_goal \<open>match premises in "tro_tag LRefl" \<Rightarrow> -\<close>)
+  subgoal by (rule tro_alt_lrefl, simp)
+
+  apply (find_goal \<open>match premises in "tro_tag ORefl" \<Rightarrow> -\<close>)
+  subgoal by simp
+
+  (* Now re-tag the first step with tro_tag' *)
+  apply (all \<open>simp only:tro_tag_to_prime\<close>)
+  (* Expand the second integrity step, which will be tagged with tro_tag *)
+  apply (all \<open>erule integrity_obj_alt.cases\<close>)
+
+  (* There are some special cases that would be too slow or unsolvable by the bulk tactics.
+     We move them up here and solve manually *)
+  apply (find_goal \<open>match premises in "tro_tag' TCBReply" and "tro_tag TCBActivate" \<Rightarrow> -\<close>)
+  apply (clarsimp, rule tro_alt_tcb_reply[OF tro_tagI refl refl],
+         (rule exI; rule tcb.equality; simp); fastforce)
+
+  apply (find_goal \<open>match premises in "tro_tag' TCBReceive" and "tro_tag TCBReply" \<Rightarrow> -\<close>)
+  apply (clarsimp, rule tro_alt_tcb_reply[OF tro_tagI refl refl],
+         (rule exI; rule tcb.equality; simp);
+          fastforce simp: direct_reply_def allowed_call_blocked_def)
+
+  apply (find_goal \<open>match premises in "tro_tag TCBGeneric" and "tro_tag' TCBRestart" \<Rightarrow> -\<close>)
+  subgoal
+    apply (erule integrity_obj_alt.intros[simplified tro_tag_to_prime])
+            apply (simp | rule tcb.equality | fastforce)+
+    done
+
+  apply (find_goal \<open>match premises in "tro_tag TCBActivate" and "tro_tag' TCBRestart" \<Rightarrow> -\<close>)
+  apply (rule tro_alt_tcb_restart[OF tro_tagI], (fastforce simp: tcb.splits fun_upd_def)+)[1]
+
+  apply (find_goal \<open>match premises in "tro_tag REp" and "tro_tag' REp" \<Rightarrow> -\<close>)
+  subgoal by (erule integrity_obj_alt.intros, (rule refl | assumption)+)
+
+  (* Select groups of subgoals by tag, then solve with the given methods *)
+  apply (all \<open>fails \<open>erule thin_rl[of "tro_tag LRefl"]\<close>
+             | time_methods \<open>fastforce intro: tro_alt_lrefl\<close>\<close>)
+
+  apply (all \<open>fails \<open>erule thin_rl[of "tro_tag ORefl"]\<close>
+             | time_methods \<open>solves \<open>
+                   drule sym[where t="ko''"];
+                   erule integrity_obj_alt.intros[simplified tro_tag_to_prime];
+                   solves \<open>simp\<close>\<close>\<close>\<close>)
+
+  apply (all \<open>fails \<open>erule thin_rl[of "tro_tag RNtfn"] thin_rl[of "tro_tag' RNtfn"]\<close>
+             | time_methods \<open>fastforce intro: tro_alt_ntfn\<close>\<close>)
+
+  apply (all \<open>fails \<open>erule thin_rl[of "tro_tag REp"]
+                    | erule thin_rl[of "tro_tag' REp"]
+                    | erule thin_rl[of "tro_tag RArch"]
+                    | erule thin_rl[of "tro_tag' RArch"]
+                    | erule thin_rl[of "tro_tag EpUnblock"]
+                    | erule thin_rl[of "tro_tag' EpUnblock"]
+                    | erule thin_rl[of "tro_tag RCNode"]
+                    | erule thin_rl[of "tro_tag' RCNode"]\<close>
+             | time_methods \<open>fastforce intro: integrity_obj_alt.intros
+                                        simp: arch_tro_alt_trans_spec\<close>\<close>)
+
+  (* TCB-TCB steps, somewhat slow *)
+  apply (all \<open>fails \<open>erule thin_rl[of "tro_tag TCBGeneric"]\<close>
+             | time_methods \<open>solves \<open>
+                    erule integrity_obj_alt.intros[simplified tro_tag_to_prime],
+                    (assumption | rule refl
+                    | ((erule exE)+)?, (rule exI)?, force intro: tcb.equality)+\<close>\<close>\<close>)
+
+  apply (all \<open>fails \<open>erule thin_rl[of "tro_tag' TCBGeneric"]\<close>
+             | time_methods \<open>solves \<open>
+                    erule integrity_obj_alt.intros,
+                    (assumption | rule refl
+                    | (elim exE)?, (intro exI)?, fastforce intro: tcb.equality
+                    | fastforce simp: indirect_send_def direct_send_def direct_call_def direct_reply_def
+                                dest: tcb_bound_notification_reset_eq_or_none)+\<close>\<close>\<close>)
+
+  apply (time_methods \<open>
+           succeeds \<open>match premises in T: "tro_tag _" and T': "tro_tag' _" \<Rightarrow>
+                                       \<open>print_fact T, print_fact T'\<close>\<close>,
+           fastforce intro: integrity_obj_alt.intros tcb.equality
+                     simp: indirect_send_def direct_send_def direct_call_def direct_reply_def
+                           call_blocked_def allowed_call_blocked_def\<close>)+
+
+  done
+
+lemma tro_alt_transp[intro!]:
+  "transp (integrity_obj_alt (aag :: 'a PAS) activate es subjects)"
+  by (rule transpI) (rule tro_alt_trans_spec)
+
+lemma tro_alt_reflp[intro!]:
+  "reflp (integrity_obj_alt aag activate es subjects)"
+  by (rule reflpI) (rule tro_alt_orefl; blast)
+
+lemma tro_tro_alt[elim!]:
+  "integrity_obj aag activate es subjects ko ko'
+  \<Longrightarrow> integrity_obj_alt aag activate es subjects ko ko'"
+  unfolding integrity_obj_def
+  by (subst rtranclp_id[symmetric]; fastforce elim: rtranclp_mono[THEN predicate2D,rotated])
+
+lemmas integrity_objE = tro_tro_alt[THEN integrity_obj_alt.cases
+                                          [simplified tro_tag_def True_implies_equals]]
+
+end
+
+
+lemma tro_trans:
+  "\<lbrakk> integrity_obj_state aag activate es s s'; integrity_obj_state aag activate es s' s'' \<rbrakk>
+     \<Longrightarrow> integrity_obj_state aag activate es s s''"
+  unfolding integrity_obj_def
+  apply clarsimp
+  apply (drule_tac x = x in spec)+
+  by force
+
+lemma tre_trans:
+  "\<lbrakk> (\<forall>x. integrity_eobj aag es (pasObjectAbs aag x) (ekh x) (ekh' x));
+     (\<forall>x. integrity_eobj aag es (pasObjectAbs aag x) (ekh' x) (ekh'' x)) \<rbrakk>
+     \<Longrightarrow> (\<forall>x. integrity_eobj aag es (pasObjectAbs aag x) (ekh x) (ekh'' x))"
+  by (fastforce elim!: integrity_eobj.cases intro: integrity_eobj.intros)
+
+
+subsection \<open>Integrity transitivity\<close>
+
+lemma tcb_caller_slot_empty_on_recieve:
+  "\<lbrakk> valid_mdb s; valid_objs s; kheap s tcb_ptr = Some (TCB tcb); ep_recv_blocked ep (tcb_state tcb) \<rbrakk>
+     \<Longrightarrow> tcb_caller tcb = NullCap \<and> cdt s (tcb_ptr,(tcb_cnode_index 3)) = None \<and>
+         descendants_of (tcb_ptr,(tcb_cnode_index 3)) (cdt s) = {}"
+  apply (simp only:valid_objs_def)
+  apply (drule bspec,fastforce)
+  apply (simp add:valid_obj_def)
+  apply (simp only:valid_tcb_def)
+  apply (drule conjunct1)
+  apply (drule_tac x="the (tcb_cap_cases (tcb_cnode_index 3))" in  bspec)
+   apply (fastforce simp:tcb_cap_cases_def)
+  apply (simp add:tcb_cap_cases_def split: thread_state.splits)
+  apply (subgoal_tac "caps_of_state s (tcb_ptr, tcb_cnode_index 3) = Some NullCap")
+   apply (simp only: valid_mdb_def2, drule conjunct1)
+   apply (intro conjI)
+    apply (simp add: mdb_cte_at_def)
+    apply (rule classical)
+    apply fastforce
+   apply (rule mdb_cte_at_no_descendants, fastforce+)[1]
+  apply (fastforce simp add: tcb_cnode_map_def caps_of_state_tcb_index_trans[OF get_tcb_rev])
+  done
+
+(* FIXME MOVE next to tcb_states_of_state definition *)
+lemma tcb_states_of_state_kheap:
+   "\<lbrakk> kheap s slot = Some (TCB tcb)\<rbrakk>
+      \<Longrightarrow> tcb_states_of_state s slot = Some (tcb_state tcb)"
+  by (simp add:tcb_states_of_state_def get_tcb_def split: option.splits kernel_object.splits)
+
+lemma tcb_states_of_state_kheapI:
+   "\<lbrakk> kheap s slot = Some (TCB tcb); tcb_state tcb = tcbst \<rbrakk>
+      \<Longrightarrow> tcb_states_of_state s slot = Some tcbst"
+  by (simp add: tcb_states_of_state_def get_tcb_def split: option.splits kernel_object.splits)
+
+lemma tcb_states_of_state_kheapD:
+  "tcb_states_of_state s slot = Some tcbst \<Longrightarrow>
+   \<exists>tcb. kheap s slot = Some (TCB tcb) \<and> tcb_state tcb = tcbst"
+  by (simp add:tcb_states_of_state_def get_tcb_def split: option.splits kernel_object.splits)
+
+lemma tcb_states_of_state_kheapE:
+  assumes "tcb_states_of_state s slot = Some tcbst"
+  obtains tcb where "kheap s slot = Some (TCB tcb)" "tcb_state tcb = tcbst"
+  using assms tcb_states_of_state_kheapD by blast
+
+lemma cdt_change_allowed_to_child:
+  "\<lbrakk> cdt_change_allowed aag subjects m tcbsts pptr; m ptr = Some pptr \<rbrakk>
+     \<Longrightarrow> cdt_change_allowed aag subjects m tcbsts ptr"
+  apply (elim cdt_change_allowedE)
+  apply (erule cdt_change_allowedI[rotated])
+  by (fastforce intro: rtrancl_into_rtrancl simp: cdt_parent_of_def)
+
+lemma trinterrupts_trans:
+  "\<lbrakk> (\<forall>x. integrity_interrupts aag subjects x (interrupt_irq_node s x, interrupt_states s x)
+                                              (interrupt_irq_node s' x, interrupt_states s' x));
+     (\<forall>x. integrity_interrupts aag subjects x (interrupt_irq_node s' x, interrupt_states s' x)
+                                              (interrupt_irq_node s'' x, interrupt_states s'' x)) \<rbrakk>
+     \<Longrightarrow> (\<forall>x. integrity_interrupts aag subjects x (interrupt_irq_node s x, interrupt_states s x)
+                                                  (interrupt_irq_node s'' x, interrupt_states s'' x))"
+  apply (simp add: integrity_interrupts_def del: split_paired_All)
+  apply metis
+  done
+
+lemma trrqs_trans:
+  "\<lbrakk> (\<forall>d p. integrity_ready_queues aag subjects (pasDomainAbs aag d)
+                                  (ready_queues s d p) (ready_queues s' d p));
+     (\<forall>d p. integrity_ready_queues aag subjects (pasDomainAbs aag d)
+                                   (ready_queues s' d p) (ready_queues s'' d p)) \<rbrakk>
+     \<Longrightarrow> (\<forall>d p. integrity_ready_queues aag subjects (pasDomainAbs aag d)
+                                       (ready_queues s d p) (ready_queues s'' d p))"
+  apply (clarsimp simp: integrity_ready_queues_def)
+  apply (metis append_assoc)
+  done
+
+
+context Access_AC_1 begin
+
+lemma cdt_direct_change_allowed_backward:
+  "\<lbrakk> integrity_obj_state aag activate subjects s s';
+     cdt_direct_change_allowed aag subjects (tcb_states_of_state s') ptr \<rbrakk>
+     \<Longrightarrow> cdt_direct_change_allowed aag subjects (tcb_states_of_state s) ptr"
+  apply (erule cdt_direct_change_allowed.cases)
+   subgoal by (rule cdca_owned)
+  apply (erule tcb_states_of_state_kheapE)
+  by (drule spec,
+      erule integrity_objE, erule cdca_owned;
+      (elim exE)?;
+      simp;
+      rule cdca_reply[rotated], assumption, assumption,
+      fastforce elim:tcb_states_of_state_kheapI simp:direct_call_def)
+
+lemma cdt_change_allowed_backward:
+  "\<lbrakk> integrity_obj_state aag activate subjects s s';
+     integrity_cdt_state aag subjects s s';
+     cdt_change_allowed aag subjects (cdt s') (tcb_states_of_state s') ptr \<rbrakk>
+     \<Longrightarrow> cdt_change_allowed aag subjects (cdt s) (tcb_states_of_state s) ptr"
+  apply (elim cdt_change_allowedE)
+  apply (drule(1) cdt_direct_change_allowed_backward)
+  apply (erule rtrancl_induct)
+   subgoal by (rule cdca_ccaI)
+  apply (rename_tac pptr0 ptr)
+  apply (frule_tac x=ptr in spec)
+  apply (elim integrity_cdtE; simp; elim conjE)
+  apply (erule cdt_change_allowed_to_child)
+  by (simp add: cdt_parent_of_def)
+
+lemma trcdt_trans:
+  "\<lbrakk> integrity_cdt_state aag subjects s s' ;
+     integrity_obj_state aag activate subjects s s' ;
+     integrity_cdt_state aag subjects s' s'' \<rbrakk>
+     \<Longrightarrow> integrity_cdt_state aag subjects s s''"
+  apply (intro allI)
+  apply (frule_tac x=x in spec)
+  apply (frule_tac x=x in spec[where P = "\<lambda>x. integrity_cdt _ _ (cdt s') _ x (_ x) (_ x)"])
+  apply (erule integrity_cdtE)+
+    apply simp
+  by (blast dest: cdt_change_allowed_backward)+
+
+lemma trcdtlist_trans:
+  "\<lbrakk> integrity_cdt_list_state aag subjects s s' ;
+     integrity_obj_state aag activate subjects s s' ;
+     integrity_cdt_state aag subjects s s' ;
+     integrity_cdt_list_state aag subjects s' s'' \<rbrakk>
+     \<Longrightarrow> integrity_cdt_list_state aag subjects s s''"
+  apply (intro allI)
+  apply (drule_tac x=x in spec [where P="\<lambda>ptr. integrity_cdt_list _ _ _ _ ptr (_ ptr) (_ ptr)"] )+
+  apply (erule integrity_cdt_listE)+
+    apply (rule integrity_cdt_list_filt)
+    apply (simp del: split_paired_All split_paired_Ex)
+    apply (erule weaken_filter_eq')
+  by (blast intro: integrity_cdt_list_intros dest: cdt_change_allowed_backward)+
+
+(* FIXME RENAME *)
+lemma tsos_tro:
+  "\<lbrakk> integrity_obj_state aag activate subjects s s'; tcb_states_of_state s' p = Some a;
+     receive_blocked_on ep a; pasObjectAbs aag p \<notin> subjects \<rbrakk>
+     \<Longrightarrow> tcb_states_of_state s p = Some a"
+  apply (drule_tac x = p in spec)
+  apply (erule integrity_objE, simp_all add: tcb_states_of_state_def get_tcb_def)
+  by fastforce+
+
+lemma can_receive_ipc_backward:
+  "\<lbrakk> integrity_obj_state aag activate subjects s s'; tcb_states_of_state s' p = Some a;
+     can_receive_ipc a; pasObjectAbs aag p \<notin> subjects \<rbrakk>
+     \<Longrightarrow> case tcb_states_of_state s p of None \<Rightarrow> False | Some x \<Rightarrow> can_receive_ipc x"
+  apply (drule_tac x = p in spec)
+  apply (erule integrity_objE;
+         (fastforce simp: tcb_states_of_state_def get_tcb_def
+                         call_blocked_def allowed_call_blocked_def
+                   split: option.splits kernel_object.splits
+         | cases a \<comment> \<open>only split when needed\<close>)+)
+  done
+
+lemma tsos_tro_running:
+  "\<lbrakk> \<forall>x. integrity_obj aag activate subjects (pasObjectAbs aag x) (kheap s x) (kheap s' x);
+     tcb_states_of_state s p = Some Running; pasObjectAbs aag p \<notin> subjects \<rbrakk>
+     \<Longrightarrow> tcb_states_of_state s' p = Some Running"
+  by (drule_tac x=p in spec, erule integrity_objE,
+      simp_all add: tcb_states_of_state_def get_tcb_def indirect_send_def direct_send_def
+                    direct_call_def direct_reply_def call_blocked_def allowed_call_blocked_def)
+
+end
+
+
+locale Access_AC_2 = Access_AC_1 +
+  assumes auth_ipc_buffers_tro:
+    "\<And>x. \<lbrakk> integrity_obj_state aag activate subjects s s';
+            x \<in> auth_ipc_buffers s' p; pasObjectAbs aag p \<notin> subjects \<rbrakk>
+            \<Longrightarrow> x \<in> auth_ipc_buffers s p "
+  and integrity_asids_refl[simp]:
+    "\<And>x. integrity_asids aag subjects x (s :: det_ext state) s"
+  and trasids_trans:
+    "\<lbrakk> (\<forall>x. integrity_asids aag subjects x s (s' :: det_ext state));
+       (\<forall>x. integrity_asids aag subjects x  s' (s'' :: det_ext state))\<rbrakk>
+       \<Longrightarrow> (\<forall>x. integrity_asids aag subjects x s s'')"
+begin
+
+section \<open>Generic AC stuff\<close>
+
+subsection \<open>Basic integrity lemmas\<close>
+
+lemma integrity_trans:
+  assumes t1: "integrity_subjects subjects aag activate X s s'"
+  and     t2: "integrity_subjects subjects aag activate X s' s''"
+  shows  "integrity_subjects subjects aag activate X s s''"
+proof -
+  from t1 have tro1: "integrity_obj_state aag activate subjects s s'"
+    unfolding integrity_subjects_def by simp
+  from t2 have tro2: "integrity_obj_state aag activate subjects s' s''"
+    unfolding integrity_subjects_def by simp
+
+  have intm: "\<forall>x. integrity_mem aag subjects x
+                  (tcb_states_of_state s) (tcb_states_of_state s'') (auth_ipc_buffers s) X
+                  (underlying_memory (machine_state s) x)
+                  (underlying_memory (machine_state s'') x)" (is "\<forall>x. ?P x s s''")
+  proof
+    fix x
+    from t1 t2 have m1: "?P x s s'" and m2: "?P x s' s''" unfolding integrity_subjects_def by auto
+
+    from m1 show "?P x s s''"
+    proof cases
+      case trm_lrefl thus ?thesis by (rule integrity_mem.intros)
+    next
+      case trm_globals thus ?thesis by (rule integrity_mem.intros)
+    next
+      case trm_orefl
+      from m2 show ?thesis
+      proof cases
+        case (trm_ipc p')
+
+        show ?thesis
+        proof (rule integrity_mem.trm_ipc)
+          from trm_ipc show "case_option False can_receive_ipc (tcb_states_of_state s p')"
+            by (fastforce split: option.splits dest: can_receive_ipc_backward [OF tro1])
+
+          from trm_ipc show "x \<in> auth_ipc_buffers s p'"
+            by (fastforce split: option.splits intro: auth_ipc_buffers_tro [OF tro1])
+        qed (simp_all add: trm_ipc)
+      qed (auto simp add: trm_orefl intro: integrity_mem.intros)
+    next
+      case trm_write thus ?thesis by (rule integrity_mem.intros)
+    next
+      case (trm_ipc p')
+      note trm_ipc1 = trm_ipc
+
+      from m2 show ?thesis
+      proof cases
+        case trm_orefl
+        thus ?thesis using trm_ipc1
+          by (auto intro!: integrity_mem.trm_ipc simp add: restrict_map_Some_iff elim!: tsos_tro_running [OF tro2, rotated])
+      next
+        case (trm_ipc p'')
+        show ?thesis
+        proof (cases "p' = p''")
+          case True thus ?thesis using trm_ipc trm_ipc1 by (simp add: restrict_map_Some_iff)
+        next
+          (* 2 tcbs sharing same IPC buffer, we can appeal to either t1 or t2 *)
+          case False
+          thus ?thesis using trm_ipc1
+            by (auto intro!: integrity_mem.trm_ipc simp add: restrict_map_Some_iff elim!: tsos_tro_running [OF tro2, rotated])
+        qed
+      qed (auto simp add: trm_ipc intro: integrity_mem.intros)
+    qed
+  qed
+
+  moreover have "\<forall>x. integrity_device aag subjects x
+                  (tcb_states_of_state s) (tcb_states_of_state s'')
+                  (device_state (machine_state s) x)
+                  (device_state (machine_state s'') x)" (is "\<forall>x. ?P x s s''")
+  proof
+    fix x
+    from t1 t2 have m1: "?P x s s'" and m2: "?P x s' s''" unfolding integrity_subjects_def by auto
+
+    from m1 show "?P x s s''"
+    proof cases
+      case trd_lrefl thus ?thesis by (rule integrity_device.intros)
+    next
+      case torel1: trd_orefl
+      from m2 show ?thesis
+      proof cases
+        case (trd_lrefl) thus ?thesis by (rule integrity_device.trd_lrefl)
+      next
+        case trd_orefl thus ?thesis
+          by (simp add: torel1)
+      next
+        case trd_write thus ?thesis by (rule integrity_device.trd_write)
+      qed
+    next
+      case trd_write thus ?thesis by (rule integrity_device.intros)
+    qed
+  qed
+  thus ?thesis using tro_trans[OF tro1 tro2] t1 t2 intm
+    apply (clarsimp simp add: integrity_subjects_def simp del:  split_paired_All)
+    apply (frule(2) trcdt_trans)
+    apply (frule(3) trcdtlist_trans)
+    apply (frule(1) trinterrupts_trans[simplified])
+    apply (frule(1) trasids_trans[simplified])
+    apply (frule(1) tre_trans[simplified])
+    apply (frule(1) trrqs_trans[simplified])
+    by blast
+qed
+
+lemma integrity_refl [simp]:
+  "integrity_subjects S aag activate X s s"
+  unfolding integrity_subjects_def
+  by simp
+
+lemma integrity_update_autarch:
+  "\<lbrakk> integrity aag X st s; is_subject aag ptr \<rbrakk>
+   \<Longrightarrow> integrity aag X st (s\<lparr>kheap := kheap s(ptr \<mapsto> obj)\<rparr>)"
+  unfolding integrity_subjects_def
+  apply (intro conjI,simp_all)
+   apply clarsimp
+   apply (drule_tac x = x in spec, erule integrity_mem.cases)
+   apply ((auto intro: integrity_mem.intros)+)[4]
+   apply (erule trm_ipc, simp_all)
+   apply (clarsimp simp: restrict_map_Some_iff tcb_states_of_state_def get_tcb_def)
+  apply clarsimp
+  apply (drule_tac x = x in spec, erule integrity_device.cases)
+    apply (erule integrity_device.trd_lrefl)
+   apply (erule integrity_device.trd_orefl)
+  apply (erule integrity_device.trd_write)
+  done
+
+lemma set_object_integrity_autarch:
+  "\<lbrace>integrity aag X st and K (is_subject aag ptr)\<rbrace> set_object ptr obj \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  apply (wpsimp wp: set_object_wp)
+  apply (rule integrity_update_autarch, simp_all)
+  done
+
+end
+
+context pspace_update_eq begin
+
+lemma thread_states[iff]: "thread_states (f s) = thread_states s"
+  by (simp add: thread_states_def pspace get_tcb_def swp_def tcb_states_of_state_def)
+
+lemma thread_bound_ntfns[iff]: "thread_bound_ntfns (f s) = thread_bound_ntfns s"
+  by (simp add: thread_bound_ntfns_def pspace get_tcb_def swp_def split: option.splits)
+
+lemma integrity_update_eq[iff]:
+  "tcb_states_of_state (f s) = tcb_states_of_state s"
+  by (simp add: pspace tcb_states_of_state_def get_tcb_def)
+
+end
+
+context Access_AC_2 begin
+
+lemma eintegrity_sa_update[simp]:
+  "integrity aag X st (scheduler_action_update f s) = integrity aag X st s"
+  by (simp add: integrity_subjects_def)
+
+lemma trans_state_back[simp]:
+  "trans_state (\<lambda>_. exst s) s = s"
+  by simp
+
+declare wrap_ext_op_det_ext_ext_def[simp]
+
+crunch integrity[wp]: set_thread_state_ext "integrity aag X st"
+
+crunch integrity_autarch: set_thread_state "integrity aag X st"
+
+lemmas integrity_def = integrity_subjects_def
+
+subsection \<open>Out of subject cap manipulation\<close>
+
+(* FIXME MOVE *)
+lemma all_children_descendants_of:
+  "\<lbrakk> all_children P m; p \<in> descendants_of q m; P q \<rbrakk> \<Longrightarrow> P p"
+  apply (simp add: descendants_of_def)
+  apply (erule trancl_induct[where P=P])
+   apply (unfold cdt_parent_of_def)
+   apply (erule(2) all_childrenD)+
+  done
+
+lemmas all_children_parent_of_trancl =
+  all_children_descendants_of[simplified descendants_of_def,simplified]
+
+lemma all_children_parent_of_rtrancl:
+  "\<lbrakk> all_children P m; m \<Turnstile> q \<rightarrow>* p; P q \<rbrakk> \<Longrightarrow> P p"
+  by (drule rtranclD, elim conjE disjE; blast dest: all_children_parent_of_trancl)
+
+lemma pas_refined_all_children':
+  "\<lbrakk> valid_mdb s; pas_refined aag s; m = (cdt s) \<rbrakk>
+     \<Longrightarrow> all_children (\<lambda>x. is_subject aag (fst x) \<or> is_transferable (caps_of_state s x)) m"
+  apply (rule all_childrenI)
+  apply (erule disjE)
+   apply (simp add: pas_refined_def,elim conjE)
+   apply (rule disjCI)
+   apply (subgoal_tac "abs_has_auth_to aag Control (fst p) (fst c)")
+    apply (fastforce elim: aag_wellformed_control_is_owns[THEN iffD1])
+   apply (simp add: state_objs_to_policy_def auth_graph_map_def)
+   apply (erule set_mp)
+   apply (frule(1) sbta_cdt)
+   apply force
+  apply (rule disjI2)
+  by (rule is_transferable_all_children[THEN all_childrenD]; solves \<open>simp\<close>)
+
+lemmas pas_refined_all_children = pas_refined_all_children'[OF _ _ refl]
+
+(* FIXME MOVE just after cte_wp_at_cases2 *)
+lemma caps_of_state_def':
+  "caps_of_state s slot =
+   (case kheap s (fst slot) of
+      Some (TCB tcb) \<Rightarrow> tcb_cnode_map tcb (snd slot)
+    | Some (CNode sz content) \<Rightarrow> (if well_formed_cnode_n sz content then content (snd slot) else None)
+    | _ \<Rightarrow> None)"
+  by (fastforce simp: caps_of_state_cte_wp_at cte_wp_at_cases2
+               split: option.splits kernel_object.splits)
+
+lemma caps_of_state_cnode:
+  "\<lbrakk> kheap s pos = Some (CNode sz content); well_formed_cnode_n sz content\<rbrakk>
+     \<Longrightarrow> caps_of_state s (pos,addr) = content addr"
+  by (simp add:caps_of_state_def')
+
+lemma caps_of_state_tcb:
+  "kheap s pos = Some (TCB tcb) \<Longrightarrow> caps_of_state s (pos,addr) = tcb_cnode_map tcb addr"
+  by (simp add:caps_of_state_def')
+
+end
+
+
+(* FIXME MOVE next to tcb_cnode_cases_simps *)
+lemma tcb_cnode_map_simps[simp]:
+  "tcb_cnode_map tcb (tcb_cnode_index 0) = Some (tcb_ctable tcb)"
+  "tcb_cnode_map tcb (tcb_cnode_index (Suc 0)) = Some (tcb_vtable tcb)"
+  "tcb_cnode_map tcb (tcb_cnode_index 2) = Some (tcb_reply tcb)"
+  "tcb_cnode_map tcb (tcb_cnode_index 3) = Some (tcb_caller tcb)"
+  "tcb_cnode_map tcb (tcb_cnode_index 4) = Some (tcb_ipcframe tcb)"
+  by (simp_all add: tcb_cnode_map_def)
+
+(* FIXME MOVE *)
+lemma valid_mdb_reply_mdb[elim!]:
+  "valid_mdb s \<Longrightarrow> reply_mdb (cdt s) (caps_of_state s)"
+  by (simp add:valid_mdb_def)
+
+(* FIXME MOVE *)
+lemma invs_reply_mdb[elim!]:
+  "invs s \<Longrightarrow> reply_mdb (cdt s) (caps_of_state s)"
+  by (simp add:invs_def valid_state_def valid_mdb_def)
+
+lemma parent_of_rtrancl_no_descendant:
+  "\<lbrakk> m \<Turnstile> pptr \<rightarrow>* ptr; descendants_of pptr m = {} \<rbrakk> \<Longrightarrow> pptr = ptr"
+  by (fastforce simp add:rtrancl_eq_or_trancl descendants_of_def)
+
+(* FIXME MOVE *)
+lemma tcb_atD:
+  "tcb_at ptr s \<Longrightarrow> \<exists>tcb. kheap s ptr = Some (TCB tcb)"
+  by (cases "the (kheap s ptr)";fastforce simp:obj_at_def is_tcb_def)
+
+(* FIXME MOVE *)
+lemma tcb_atE:
+  assumes hyp: "tcb_at ptr s"
+  obtains tcb where "kheap s ptr = Some (TCB tcb)"
+  using hyp[THEN tcb_atD] by blast
+
+(*FIXME MOVE *)
+lemma tcb_atI:
+  "kheap s ptr = Some (TCB tcb) \<Longrightarrow> tcb_at ptr s"
+  by (simp add:obj_at_def is_tcb_def)
+
+
+context Access_AC_2 begin
+
+lemma descendant_of_caller_slot:
+  "\<lbrakk> valid_mdb s; valid_objs s; tcb_at t s \<rbrakk> \<Longrightarrow> descendants_of (t, tcb_cnode_index 3) (cdt s) = {}"
+  apply (frule(1) tcb_caller_cap)
+  apply (clarsimp simp add:cte_wp_at_caps_of_state is_cap_simps; elim disjE ;clarsimp)
+  subgoal by (intro allI no_children_empty_desc[THEN iffD1] reply_cap_no_children)
+  apply (drule valid_mdb_mdb_cte_at)
+  apply (erule mdb_cte_at_no_descendants)
+  apply (simp add:cte_wp_at_caps_of_state)
+  done
+
+lemma cca_to_transferable_or_subject:
+  "\<lbrakk> valid_objs s; valid_mdb s; pas_refined aag s; cdt_change_allowed' aag ptr s \<rbrakk>
+     \<Longrightarrow> is_subject aag (fst ptr) \<or> is_transferable (caps_of_state s ptr)"
+  apply (elim cdt_change_allowedE cdt_direct_change_allowed.cases)
+   apply (rule all_children_parent_of_rtrancl[OF pas_refined_all_children]; blast)
+  apply (simp add:rtrancl_eq_or_trancl,elim disjE conjE)
+   apply (simp add:direct_call_def, elim conjE)
+   apply (drule tcb_states_of_state_kheapD, elim exE conjE)
+   apply (frule(2) tcb_caller_slot_empty_on_recieve ,simp)
+   apply (cases ptr,simp)
+   apply (simp add:caps_of_state_tcb)
+  apply (elim tcb_states_of_state_kheapE)
+  apply (drule(2) descendant_of_caller_slot[OF _ _ tcb_atI])
+  by (force simp add: descendants_of_def simp del:split_paired_All)
+
+lemma is_transferable_weak_derived:
+  "weak_derived cap cap' \<Longrightarrow> is_transferable_cap cap = is_transferable_cap cap'"
+  unfolding is_transferable.simps weak_derived_def copy_of_def same_object_as_def
+  by (fastforce simp: is_cap_simps split: cap.splits)
+
+lemma aag_cdt_link_Control:
+  "\<lbrakk> cdt s x = Some y; \<not> is_transferable(caps_of_state s x); pas_refined aag s \<rbrakk>
+     \<Longrightarrow> abs_has_auth_to aag Control (fst y) (fst x)"
+  by (fastforce elim: pas_refined_mem[rotated] sta_cdt)
+
+lemma aag_cdt_link_DeleteDerived:
+  "\<lbrakk> cdt s x = Some y; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> abs_has_auth_to aag  DeleteDerived (fst y) (fst x)"
+  by (fastforce elim: pas_refined_mem[rotated] sta_cdt_transferable)
+
+lemma tcb_states_of_state_to_auth:
+  "\<lbrakk> tcb_states_of_state s thread = Some tcbst; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> \<forall>(obj,auth) \<in> tcb_st_to_auth tcbst. abs_has_auth_to aag auth thread obj"
+   apply clarsimp
+   apply (erule pas_refined_mem[rotated])
+   apply (rule sta_ts)
+   apply (simp add:thread_states_def)
+   done
+
+lemma tcb_states_of_state_to_auth':
+  "\<lbrakk> tcb_states_of_state s thread = Some tcbst;
+     pas_refined aag s; (obj,auth) \<in> tcb_st_to_auth tcbst \<rbrakk>
+     \<Longrightarrow> abs_has_auth_to aag auth thread obj"
+   using tcb_states_of_state_to_auth by blast
+
+lemma ep_recv_blocked_def:
+  "ep_recv_blocked ep st \<longleftrightarrow> (\<exists>pl. st = BlockedOnReceive ep pl)"
+  by (simp split: thread_state.split)
+
+lemma cdt_change_allowed_delete_derived:
+  "\<lbrakk> valid_objs s; valid_mdb s; pas_refined aag s; cdt_change_allowed' aag slot s \<rbrakk>
+     \<Longrightarrow> aag_has_auth_to aag DeleteDerived (fst slot)"
+  apply (elim cdt_change_allowedE cdt_direct_change_allowed.cases)
+   apply (erule rtrancl_induct)
+    apply (solves\<open>simp add: pas_refined_refl\<close>)
+   apply (fastforce simp: cdt_parent_of_def
+                    dest: aag_cdt_link_DeleteDerived
+                   intro: aag_wellformed_delete_derived_trans)
+  apply (clarsimp simp: direct_call_def ep_recv_blocked_def)
+  apply (frule(1)tcb_states_of_state_to_auth)
+  apply (elim tcb_states_of_state_kheapE)
+  apply (frule(2) descendant_of_caller_slot[OF _ _ tcb_atI])
+  apply (frule(1) parent_of_rtrancl_no_descendant)
+  apply clarsimp
+  by (rule aag_wellformed_delete_derived'[OF _ _ pas_refined_wellformed])
+
+end
+
+
+lemma owns_thread_owns_cspace:
+  "\<lbrakk> is_subject aag thread; pas_refined aag s; get_tcb thread s = Some tcb;
+     is_cnode_cap (tcb_ctable tcb); x \<in> obj_refs (tcb_ctable tcb) \<rbrakk>
+     \<Longrightarrow> is_subject aag x"
+  apply (drule get_tcb_SomeD)
+  apply (drule cte_wp_at_tcbI[where t="(thread, tcb_cnode_index 0)"
+                                and P="\<lambda>cap. cap = tcb_ctable tcb", simplified])
+  apply (auto simp: cte_wp_at_caps_of_state is_cap_simps cap_auth_conferred_def
+              elim: caps_of_state_pasObjectAbs_eq[where p = "(thread, tcb_cnode_index 0)"])
+  done
+
+lemma is_subject_into_is_subject_asid:
+  "\<lbrakk> cap_links_asid_slot aag (pasObjectAbs aag p) cap;
+     is_subject aag p; pas_refined aag s; asid \<in> cap_asid' cap \<rbrakk>
+     \<Longrightarrow> is_subject_asid aag asid"
+  apply (clarsimp simp add: cap_links_asid_slot_def label_owns_asid_slot_def)
+  apply (drule (1) bspec)
+  apply (drule (1) pas_refined_Control)
+  apply simp
+  done
+
+lemma clas_no_asid:
+  "cap_asid' cap = {} \<Longrightarrow> cap_links_asid_slot aag l cap"
+  unfolding cap_links_asid_slot_def by simp
+
+lemma cli_no_irqs:
+  "cap_irqs_controlled cap = {} \<Longrightarrow> cap_links_irq aag l cap"
+  unfolding cap_links_irq_def by simp
+
+lemma as_user_tcb_states[wp]:
+  "as_user t f \<lbrace>\<lambda>s. P (tcb_states_of_state s)\<rbrace>"
+  apply (simp add: as_user_def)
+  apply (wpsimp wp: set_object_wp)
+  apply (clarsimp simp: thread_states_def get_tcb_def tcb_states_of_state_def
+                 elim!: rsubst[where P=P, OF _ ext] split: option.split)
+  done
+
+lemma as_user_thread_state[wp]:
+  "as_user t f \<lbrace>\<lambda>s. P (thread_states s)\<rbrace>"
+  apply (simp add: thread_states_def)
+  apply wp
+  done
+
+lemma as_user_thread_bound_ntfn[wp]:
+  "as_user t f \<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace>"
+  apply (simp add: as_user_def set_object_def split_def thread_bound_ntfns_def)
+  apply (wp get_object_wp)
+  apply (clarsimp simp: thread_states_def get_tcb_def
+                 elim!: rsubst[where P=P, OF _ ext] split: option.split)
+  done
+
+lemma tcb_domain_map_wellformed_lift:
+  assumes 1: "\<And>P. f \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
+  shows "f \<lbrace>tcb_domain_map_wellformed aag\<rbrace>"
+  by (rule 1)
+
+
+(* **************************************** *)
+
+subsection\<open>Random lemmas that belong elsewhere.\<close>
+
+(* FIXME: move *)
+lemma bang_0_in_set:
+  "xs \<noteq> [] \<Longrightarrow> xs ! 0 \<in> set xs"
+  by (fastforce simp: in_set_conv_nth)
+
+(* FIXME: move *)
+lemma update_one_strg:
+  "(b \<longrightarrow> P c v) \<and> (\<not> b \<longrightarrow> (\<forall>v'. f c' = Some v' \<longrightarrow> P c v'))
+   \<longrightarrow> ((f(c := if b then Some v else f c')) x = Some y \<and> f x \<noteq> Some y \<longrightarrow> P x y)"
+  by auto
+
+(* FIXME: move *)
+lemma hoare_gen_asm2:
+  assumes a: "P \<Longrightarrow> \<lbrace>\<top>\<rbrace> f \<lbrace>Q\<rbrace>"
+  shows "\<lbrace>K P\<rbrace> f \<lbrace>Q\<rbrace>"
+  using a by (fastforce simp: valid_def)
+
+(* FIXME: move *)
+lemma hoare_vcg_all_liftE:
+  "(\<And>x. \<lbrace>P x\<rbrace> f \<lbrace>Q x\<rbrace>, \<lbrace>Q' x\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x. P x s\<rbrace> f \<lbrace>\<lambda>rv s. \<forall>x. Q x rv s\<rbrace>, \<lbrace>\<lambda>rv s. \<forall>x. Q' x rv s\<rbrace>"
+  unfolding validE_def
+  apply (rule hoare_post_imp [where Q = "\<lambda>v s. \<forall>x. case v of Inl e \<Rightarrow> Q' x e s | Inr r \<Rightarrow> Q x r s"])
+   apply (clarsimp split: sum.splits)
+  apply (erule hoare_vcg_all_lift)
+  done
+
+(* FIXME: move *)
+lemma hoare_use_ex_R:
+  "(\<And>x. \<lbrace>P x and Q \<rbrace> f \<lbrace>R\<rbrace>, -) \<Longrightarrow> \<lbrace>\<lambda>s. (\<exists>x. P x s) \<and> Q s \<rbrace> f \<lbrace>R\<rbrace>, -"
+  unfolding validE_R_def validE_def valid_def by fastforce
+
+(* FIXME: move *)
+lemma mapM_x_and_const_wp:
+  assumes f: "\<And>v. \<lbrace>P and K (Q v)\<rbrace> f v \<lbrace>\<lambda>rv. P\<rbrace>"
+  shows "\<lbrace>P and K (\<forall>v \<in> set vs. Q v)\<rbrace> mapM_x f vs \<lbrace>\<lambda>rv. P\<rbrace>"
+  apply (induct vs)
+   apply (simp add: mapM_x_Nil)
+  apply (simp add: mapM_x_Cons)
+  apply (wp f | assumption | simp)+
+  done
+
+(* stronger *)
+(* FIXME: MOVE *)
+lemma ep_queued_st_tcb_at':
+  "\<And>P. \<lbrakk> ko_at (Endpoint ep) ptr s; (t, rt) \<in> ep_q_refs_of ep;
+         valid_objs s; sym_refs (state_refs_of s);
+         \<And>pl pl'. P (BlockedOnSend ptr pl) \<and> P (BlockedOnReceive ptr pl') \<rbrakk>
+         \<Longrightarrow> st_tcb_at P t s"
+  apply (case_tac ep, simp_all)
+  apply (frule(1) sym_refs_ko_atD, clarsimp, erule (1) my_BallE,
+         clarsimp simp: st_tcb_at_def refs_of_rev elim!: obj_at_weakenE)+
+  done
+
+(* Sometimes we only care about one of the queues. *)
+(* FIXME: move *)
+lemma ep_rcv_queued_st_tcb_at:
+  "\<And>P. \<lbrakk> ko_at (Endpoint ep) epptr s; (t, EPRecv) \<in> ep_q_refs_of ep;
+         valid_objs s; sym_refs (state_refs_of s);
+         \<And>pl. P (BlockedOnReceive epptr pl); kheap s' t = kheap s t\<rbrakk>
+         \<Longrightarrow> st_tcb_at P t s'"
+  apply (case_tac ep, simp_all)
+  apply (subgoal_tac "st_tcb_at P t s")
+   apply (simp add: st_tcb_at_def obj_at_def)
+  apply (frule(1) sym_refs_ko_atD, clarsimp, erule (1) my_BallE,
+         clarsimp simp: st_tcb_at_def refs_of_rev elim!: obj_at_weakenE)+
+  done
+
+(* FIXME: move. *)
+lemma ntfn_queued_st_tcb_at':
+  "\<And>P. \<lbrakk> ko_at (Notification ntfn) ntfnptr s; (t, rt) \<in> ntfn_q_refs_of (ntfn_obj ntfn);
+         valid_objs s; sym_refs (state_refs_of s); P (BlockedOnNotification ntfnptr) \<rbrakk>
+         \<Longrightarrow> st_tcb_at P t s"
+  apply (case_tac "ntfn_obj ntfn", simp_all)
+  apply (frule(1) sym_refs_ko_atD)
+  apply (clarsimp)
+  apply (erule_tac y="(t, NTFNSignal)" in my_BallE, clarsimp)
+  apply (clarsimp simp: pred_tcb_at_def refs_of_rev elim!: obj_at_weakenE)+
+  done
+
+(* FIXME: move *)
+lemma case_prod_wp:
+  "(\<And>a b. x = (a, b) \<Longrightarrow> \<lbrace>P a b\<rbrace> f a b \<lbrace>Q\<rbrace>)
+   \<Longrightarrow> \<lbrace>P (fst x) (snd x)\<rbrace> case_prod f x \<lbrace>Q\<rbrace>"
+  by (cases x, simp)
+
+(* FIXME: move *)
+lemma case_sum_wp:
+  "\<lbrakk> (\<And>a. x = Inl a \<Longrightarrow> \<lbrace>P a\<rbrace> f a \<lbrace>Q\<rbrace>); (\<And>a. x = Inr a \<Longrightarrow> \<lbrace>P' a\<rbrace> g a \<lbrace>Q\<rbrace>) \<rbrakk>
+     \<Longrightarrow> \<lbrace>\<lambda>s. (\<forall>a. x = Inl a \<longrightarrow> P a s) \<and> (\<forall>a. x = Inr a \<longrightarrow> P' a s)\<rbrace> case_sum f g x \<lbrace>Q\<rbrace>"
+  by (cases x, simp_all)
+
+lemma st_tcb_at_to_thread_states:
+  "st_tcb_at P t s \<Longrightarrow> \<exists>st. P st \<and> thread_states s t = tcb_st_to_auth st"
+  by (fastforce simp: st_tcb_def2 thread_states_def tcb_states_of_state_def)
+
+lemma aag_Control_into_owns:
+  "\<lbrakk> aag_has_auth_to aag Control p; pas_refined aag s \<rbrakk> \<Longrightarrow> is_subject aag p"
+  apply (drule (1) pas_refined_Control)
+  apply simp
+  done
+
+lemma aag_has_Control_iff_owns:
+  "pas_refined aag s \<Longrightarrow> (aag_has_auth_to aag Control x) = (is_subject aag x)"
+  apply (rule iffI)
+  apply (erule (1) aag_Control_into_owns)
+  apply (simp add: pas_refined_refl)
+  done
+
+lemma aag_Control_owns_strg:
+  "pas_wellformed aag \<and> is_subject aag v \<longrightarrow> aag_has_auth_to aag Control v"
+  by (clarsimp simp: aag_wellformed_refl)
+
+(* **************************************** *)
+
+subsection \<open>Policy entailments\<close>
+
+lemma owns_ep_owns_receivers:
+  "\<lbrakk> \<forall>auth. aag_has_auth_to aag auth epptr; pas_refined aag s; invs s;
+     ko_at (Endpoint ep) epptr s; (t, EPRecv) \<in> ep_q_refs_of ep \<rbrakk>
+     \<Longrightarrow> is_subject aag t"
+  apply (drule (1) ep_rcv_queued_st_tcb_at[where P = "receive_blocked_on epptr"])
+      apply clarsimp
+     apply clarsimp
+    apply clarsimp
+   apply (rule refl)
+  apply (drule st_tcb_at_to_thread_states)
+  apply (clarsimp simp: receive_blocked_on_def2)
+  apply (drule spec[where x = Grant])
+  apply (frule aag_wellformed_grant_Control_to_recv[OF _ _ pas_refined_wellformed])
+    apply (rule pas_refined_mem[OF sta_ts])
+     apply (case_tac st; fastforce)
+    apply assumption+
+  apply (erule (1) aag_Control_into_owns)
+  done
+
+(* MOVE *)
+lemma cli_caps_of_state:
+  "\<lbrakk> caps_of_state s slot = Some cap; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> cap_links_irq aag (pasObjectAbs aag (fst slot)) cap"
+  apply (clarsimp simp add: cap_links_irq_def pas_refined_def)
+  apply (blast dest: state_irqs_to_policy_aux.intros)
+  done
+
+
+context Access_AC_2 begin
+
+(* MOVE *)
+lemma cap_auth_caps_of_state:
+  "\<lbrakk> caps_of_state s p = Some cap; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> aag_cap_auth aag (pasObjectAbs aag (fst p)) cap"
+  unfolding aag_cap_auth_def
+  apply (intro conjI)
+    apply clarsimp
+    apply (drule (2) sta_caps)
+    apply (drule_tac f="pasObjectAbs aag" in auth_graph_map_memI[OF _ refl refl])
+    apply (fastforce simp: pas_refined_def)
+   apply clarsimp
+   apply (drule (2) sta_untyped [THEN pas_refined_mem] )
+   apply simp
+  apply (drule (1) clas_caps_of_state)
+  apply simp
+  apply (drule (1) cli_caps_of_state)
+  apply simp
+  done
+
+lemma cap_cur_auth_caps_of_state:
+  "\<lbrakk> caps_of_state s p = Some cap; pas_refined aag s; is_subject aag (fst p) \<rbrakk>
+     \<Longrightarrow> pas_cap_cur_auth aag cap"
+  by (metis cap_auth_caps_of_state)
+
+end
+
+
+subsection \<open>Integrity monotony over subjects\<close>
+
+
+lemma tcb_bound_notification_reset_integrity_mono:
+  "\<lbrakk> tcb_bound_notification_reset_integrity ntfn ntfn' S aag; S \<subseteq> T\<rbrakk>
+     \<Longrightarrow> tcb_bound_notification_reset_integrity ntfn ntfn' T aag"
+  unfolding tcb_bound_notification_reset_integrity_def by blast
+
+lemma reply_cap_deletion_integrity_mono:
+  "\<lbrakk> reply_cap_deletion_integrity S aag cap cap'; S \<subseteq> T \<rbrakk>
+     \<Longrightarrow> reply_cap_deletion_integrity T aag cap cap'"
+  by (blast intro: reply_cap_deletion_integrity_intros elim: reply_cap_deletion_integrityE)
+
+lemma cnode_integrity_mono:
+  "\<lbrakk> cnode_integrity S aag cont cont'; S \<subseteq> T\<rbrakk> \<Longrightarrow> cnode_integrity T aag cont cont'"
+  by (blast intro!: cnode_integrityI elim: cnode_integrityE dest: reply_cap_deletion_integrity_mono)
+
+lemmas new_range_subset' = aligned_range_offset_subset
+lemmas ptr_range_subset = new_range_subset' [folded ptr_range_def]
+
+lemma cdt_change_allowed_mono:
+  "\<lbrakk> cdt_change_allowed aag S (cdt s) (tcb_states_of_state s) ptr; S \<subseteq> T \<rbrakk>
+     \<Longrightarrow> cdt_change_allowed aag T (cdt s) (tcb_states_of_state s) ptr"
+  unfolding cdt_change_allowed_def cdt_direct_change_allowed.simps direct_call_def by blast
+
+lemmas rtranclp_monoE = rtranclp_mono[THEN predicate2D,rotated,OF _ predicate2I]
+
+
+locale Access_AC_3 = Access_AC_2 +
+  assumes arch_integrity_obj_atomic_mono:
+    "\<lbrakk> arch_integrity_obj_atomic aag S l ao ao'; S \<subseteq> T; pas_refined aag s; valid_objs s \<rbrakk>
+       \<Longrightarrow> arch_integrity_obj_atomic aag T l ao ao'"
+  and integrity_asids_mono:
+    "\<And>x. \<lbrakk> integrity_asids aag S x s s'; S \<subseteq> T; pas_refined aag s; valid_objs s \<rbrakk>
+            \<Longrightarrow> integrity_asids aag T x s (s' :: det_ext state)"
+  and auth_ipc_buffers_member:
+    "\<And>x. \<lbrakk> x \<in> auth_ipc_buffers s p; valid_objs s \<rbrakk>
+            \<Longrightarrow> \<exists>tcb acap. get_tcb p s = Some tcb
+                         \<and> tcb_ipcframe tcb = (ArchObjectCap acap)
+                         \<and> caps_of_state s (p, tcb_cnode_index 4) = Some (ArchObjectCap acap)
+                         \<and> Write \<in> arch_cap_auth_conferred acap
+                         \<and> x \<in> aobj_ref' acap"
+begin
+
+lemma trm_ipc':
+  "\<lbrakk> pas_refined aag s; valid_objs s; case_option False can_receive_ipc (tcb_states_of_state s p');
+     (tcb_states_of_state s' p') = Some Structures_A.Running; p \<in> auth_ipc_buffers s p' \<rbrakk>
+     \<Longrightarrow> integrity_mem aag subjects p (tcb_states_of_state s) (tcb_states_of_state s')
+                      (auth_ipc_buffers s) X
+                      (underlying_memory (machine_state s) p)
+                      (underlying_memory (machine_state s') p)"
+  apply (cases "pasObjectAbs aag p' \<in> subjects")
+   apply (rule trm_write)
+   apply (clarsimp simp: )
+   apply (frule pas_refined_mem[rotated])
+    prefer 3
+    apply (rule trm_ipc; fastforce)
+   prefer 2
+   apply (rule bexI)
+    apply assumption
+   apply assumption
+  apply (drule (1) auth_ipc_buffers_member)
+  apply clarsimp
+  apply (drule (1) sta_caps[where cap="ArchObjectCap acap" for acap, simplified])
+   apply (auto simp: cap_auth_conferred_def)
+  done
+
+lemma integrity_mono:
+  "\<lbrakk> integrity_subjects S aag activate X s s'; S \<subseteq> T; pas_refined aag s; valid_objs s \<rbrakk>
+     \<Longrightarrow> integrity_subjects T aag activate X s s'"
+  apply (clarsimp simp: integrity_subjects_def simp del: split_paired_All)
+  apply (rule conjI)
+   apply clarsimp
+   apply (drule_tac x=x in spec)+
+   apply (simp only: integrity_obj_def)
+   apply (erule rtranclp_monoE)
+   apply (erule integrity_obj_atomic.cases[OF _ integrity_obj_atomic.intros];
+          auto simp: indirect_send_def direct_send_def direct_call_def direct_reply_def
+               elim: reply_cap_deletion_integrity_mono cnode_integrity_mono
+                     arch_integrity_obj_atomic_mono)
+  apply (rule conjI)
+   apply clarsimp
+   apply (drule_tac x=x in spec)+
+   apply (erule integrity_eobj.cases; auto intro: integrity_eobj.intros)
+  apply (rule conjI)
+   apply (intro allI)
+   apply (drule_tac x=x in spec)+
+   apply (erule integrity_cdtE; auto elim: cdt_change_allowed_mono)
+  apply (rule conjI)
+   apply (intro allI)
+   apply (drule_tac x=x in spec)+
+   apply (erule integrity_cdt_listE;
+          auto elim!: weaken_filter_eq' intro: integrity_cdt_list_intros
+               elim: cdt_change_allowed_mono)
+  apply (rule conjI)
+   apply (fastforce simp: integrity_interrupts_def)
+  apply (rule conjI)
+   apply (clarsimp simp: integrity_ready_queues_def)
+   apply blast
+  apply (rule conjI)
+   apply clarsimp
+   apply (drule_tac x=x in spec, erule integrity_mem.cases;
+          blast intro: integrity_mem.intros trm_ipc')
+  apply (rule conjI)
+   apply clarsimp
+   apply (drule_tac x=x in spec, erule integrity_device.cases;
+          blast intro: integrity_device.intros)
+  apply (fastforce elim: integrity_asids_mono)
+  done
+
+
+subsection\<open>Access control do not care about machine_state\<close>
+
+lemma state_objs_to_policy_irq_state_independent[intro!, simp]:
+  "state_objs_to_policy (s\<lparr>machine_state :=
+                           machine_state s\<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>) =
+   state_objs_to_policy s"
+  by (simp add: state_objs_to_policy_def)
+
+lemma tcb_domain_map_wellformed_independent[intro!, simp]:
+  "tcb_domain_map_wellformed aag (s\<lparr>machine_state :=
+                                    machine_state s\<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>) =
+   tcb_domain_map_wellformed aag s"
+  by (simp add: tcb_domain_map_wellformed_aux_def get_etcb_def)
+
+subsection\<open>Transitivity of integrity lemmas and tactics\<close>
+
+lemma integrity_trans_start:
+  "(\<And>s. P s \<Longrightarrow> \<lbrace>(=) s\<rbrace> f \<lbrace>\<lambda>_. integrity aag X s\<rbrace>)
+   \<Longrightarrow> \<lbrace>integrity aag X st and P\<rbrace> f \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  unfolding spec_valid_def valid_def using integrity_trans by simp blast
+
+method integrity_trans_start =
+  ((simp only: and_assoc[symmetric])?, rule integrity_trans_start[rotated])
+
+(* Q should be explicitly supplied, if not, use wp_integrity_clean' *)
+lemma wp_integrity_clean:
+  "\<lbrakk> \<And>s. Q s \<Longrightarrow> integrity aag X s (g s); \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. integrity aag X st and Q\<rbrace> \<rbrakk>
+     \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ s. integrity aag X st (g s)\<rbrace> "
+   by (rule hoare_post_imp[of "\<lambda>_. integrity aag X st and Q"])
+      (fastforce elim: integrity_trans)
+
+lemmas wp_integrity_clean'= wp_integrity_clean[of \<top>, simplified]
+
+end
+
+end

--- a/proof/access-control/Arch_AC.thy
+++ b/proof/access-control/Arch_AC.thy
@@ -757,7 +757,7 @@ lemma perform_asid_control_invocation_respects:
                         range_cover_def obj_bits_api_def default_arch_object_def
                         pageBits_def word_bits_def)
   apply(subst is_aligned_neg_mask_eq[THEN sym], assumption)
-  apply(simp add: mask_neg_mask_is_zero mask_zero)
+  apply(simp add: and_mask_eq_iff_shiftr_0 mask_zero)
   done
 
 lemma pas_refined_set_asid_strg:
@@ -925,7 +925,7 @@ lemma perform_asid_control_invocation_pas_refined [wp]:
    apply (rule conjI)
     apply (clarsimp simp: range_cover_def obj_bits_api_def default_arch_object_def)
     apply (subst is_aligned_neg_mask_eq[THEN sym], assumption)
-    apply (simp add: mask_neg_mask_is_zero pageBits_def mask_zero)
+    apply (simp add: and_mask_eq_iff_shiftr_0 pageBits_def mask_zero)
    apply (clarsimp simp: aag_cap_auth_def pas_refined_refl)
    apply (drule_tac x=frame in bspec)
     apply (simp add: is_aligned_no_overflow)
@@ -1114,7 +1114,6 @@ lemma pageBitsForSize_le_t29:
 lemmas vmsz_aligned_t2n_neg_mask
     = x_t2n_sub_1_neg_mask[OF _ pageBitsForSize_le_t29, folded vmsz_aligned_def]
 
-
 lemma decode_arch_invocation_authorised:
   "\<lbrace>invs and pas_refined aag
         and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot
@@ -1216,7 +1215,7 @@ lemma decode_arch_invocation_authorised:
       apply (subgoal_tac "is_aligned word pt_bits")
        apply (simp add: is_aligned_no_overflow)
       apply (simp add: pt_bits_def pageBits_def)
-      apply (simp add: word_minus_1 minus_one_norm)
+      apply simp
       apply (subst (asm) upto_enum_step_red [where us = 2, simplified])
       apply (simp add: pt_bits_def pageBits_def word_bits_conv)
       apply (simp add: pt_bits_def pageBits_def word_bits_conv)

--- a/proof/access-control/Arch_AC.thy
+++ b/proof/access-control/Arch_AC.thy
@@ -5,389 +5,37 @@
  *)
 
 theory Arch_AC
-imports Retype_AC
+imports ArchRetype_AC
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 text\<open>
 
-Arch-specific access control.
+Setup for arch-specific access control.
 
 \<close>
 
-lemma store_pde_respects:
-  "\<lbrace>integrity aag X st and K (is_subject aag (p && ~~ mask pd_bits)) \<rbrace>
-     store_pde p pde
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: store_pde_def set_pd_def)
-  apply (wp get_object_wp set_object_integrity_autarch)
-  apply simp
-  done
+(* c.f.  auth_ipc_buffers *)
+definition ipc_buffer_has_auth :: "'a PAS \<Rightarrow> obj_ref \<Rightarrow> obj_ref option \<Rightarrow> bool" where
+   "ipc_buffer_has_auth aag thread \<equiv>
+    case_option True (\<lambda>p. is_aligned p msg_align_bits \<and>
+                          (\<forall>x \<in> ptr_range p msg_align_bits. abs_has_auth_to aag Write thread x))"
 
-lemma store_pte_respects:
-  "\<lbrace>integrity aag X st and K (is_subject aag (p && ~~ mask pt_bits)) \<rbrace>
-     store_pte p pte
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: store_pte_def set_pt_def)
-  apply (wp get_object_wp set_object_integrity_autarch)
-  apply simp
-  done
+lemma ipc_buffer_has_auth_wordE:
+  "\<lbrakk> ipc_buffer_has_auth aag thread (Some buf); p \<in> ptr_range (buf + off) sz;
+     is_aligned off sz; sz \<le> msg_align_bits; off < 2 ^ msg_align_bits \<rbrakk>
+     \<Longrightarrow> abs_has_auth_to aag Write thread p"
+  unfolding ipc_buffer_has_auth_def
+  by (fastforce elim: bspec set_mp[OF ptr_range_subset])
 
-lemma integrity_arch_state [iff]:
-  "\<lbrakk>arm_asid_table v = arm_asid_table (arch_state s)\<rbrakk> \<Longrightarrow>
-   integrity aag X st (s\<lparr>arch_state := v\<rparr>) = integrity aag X st s"
-  unfolding integrity_def
-  by (simp )
-
-lemma integrity_arm_asid_map [iff]:
-  "integrity aag X st (s\<lparr>arch_state := ((arch_state s)\<lparr>arm_asid_map := v\<rparr>)\<rparr>) = integrity aag X st s"
-  unfolding integrity_def
-  by (simp )
-
-lemma integrity_arm_hwasid_table [iff]:
-  "integrity aag X st (s\<lparr>arch_state := ((arch_state s)\<lparr>arm_hwasid_table := v\<rparr>)\<rparr>) = integrity aag X st s"
-  unfolding integrity_def
-  by (simp )
-
-lemma integrity_arm_next_asid [iff]:
-  "integrity aag X st (s\<lparr>arch_state := ((arch_state s)\<lparr>arm_next_asid := v\<rparr>)\<rparr>) = integrity aag X st s"
-  unfolding integrity_def
-  by (simp )
-
-declare dmo_mol_respects [wp]
-
-crunch respects[wp]: arm_context_switch "integrity X aag st"
-  (simp: dmo_bind_valid dsb_def isb_def writeTTBR0_def invalidateLocalTLB_ASID_def
-         setHardwareASID_def set_current_pd_def
- ignore: do_machine_op)
-
-crunch respects[wp]: set_vm_root "integrity X aag st"
-    (wp: crunch_wps
-   simp: set_current_pd_def isb_def dsb_def writeTTBR0_def dmo_bind_valid crunch_simps
- ignore: do_machine_op)
-
-crunch respects[wp]: set_vm_root_for_flush "integrity X aag st"
-  (wp: crunch_wps simp: set_current_pd_def crunch_simps ignore: do_machine_op)
-
-crunch respects[wp]: flush_table "integrity X aag st"
-  (wp: crunch_wps simp: invalidateLocalTLB_ASID_def crunch_simps ignore: do_machine_op)
-
-crunch respects[wp]: page_table_mapped "integrity X aag st"
-
-lemma kheap_eq_state_vrefsD:
-  "kheap s p = Some ko \<Longrightarrow> state_vrefs s p = vs_refs_no_global_pts ko"
-  by (simp add: state_vrefs_def)
-
-lemma kheap_eq_state_vrefs_pas_refinedD:
-  "\<lbrakk> kheap s p = Some ko;
-       (p', r, a) \<in> vs_refs_no_global_pts ko; pas_refined aag s \<rbrakk>
-    \<Longrightarrow> (pasObjectAbs aag p, a, pasObjectAbs aag p') \<in> pasPolicy aag"
-  apply (drule kheap_eq_state_vrefsD)
-  apply (erule pas_refined_mem[OF sta_vref, rotated])
-  apply simp
-  done
-
-lemma find_pd_for_asid_authority1:
-  "\<lbrace>pas_refined aag\<rbrace>
-      find_pd_for_asid asid
-   \<lbrace>\<lambda>pd s. (pasASIDAbs aag asid, Control, pasObjectAbs aag pd) \<in> pasPolicy aag\<rbrace>,-"
-  apply (rule hoare_pre)
-   apply (simp add: find_pd_for_asid_def)
-   apply (wp | wpc)+
-  apply (clarsimp simp: obj_at_def pas_refined_def)
-  apply (erule subsetD, erule sata_asid_lookup)
-  apply (simp add: state_vrefs_def vs_refs_no_global_pts_def image_def)
-  apply (rule rev_bexI, erule graph_ofI)
-  apply (simp add: mask_asid_low_bits_ucast_ucast)
-  done
-
-lemma find_pd_for_asid_authority2:
-  "\<lbrace>\<lambda>s. \<forall>pd. (\<forall>aag. pas_refined aag s \<longrightarrow> (pasASIDAbs aag asid, Control, pasObjectAbs aag pd) \<in> pasPolicy aag)
-           \<and> (pspace_aligned s \<and> valid_vspace_objs s \<longrightarrow> is_aligned pd pd_bits)
-           \<and> (\<exists>\<rhd> pd) s
-           \<longrightarrow> Q pd s\<rbrace> find_pd_for_asid asid \<lbrace>Q\<rbrace>, -"
-  (is "\<lbrace>?P\<rbrace> ?f \<lbrace>Q\<rbrace>,-")
-  apply (clarsimp simp: validE_R_def validE_def valid_def imp_conjL[symmetric])
-  apply (frule in_inv_by_hoareD[OF find_pd_for_asid_inv], clarsimp)
-  apply (drule spec, erule mp)
-  apply (simp add: use_validE_R[OF _ find_pd_for_asid_authority1]
-                   use_validE_R[OF _ find_pd_for_asid_aligned_pd_bits]
-                   use_validE_R[OF _ find_pd_for_asid_lookup])
-  done
-
-lemma find_pd_for_asid_pd_slot_authorised [wp]:
-  "\<lbrace>pas_refined aag and K (is_subject_asid aag asid) and pspace_aligned and valid_vspace_objs\<rbrace>
-  find_pd_for_asid asid
-  \<lbrace>\<lambda>rv s. is_subject aag (lookup_pd_slot rv vptr && ~~ mask pd_bits) \<rbrace>, -"
-  apply (wp find_pd_for_asid_authority2)
-  apply (clarsimp simp: lookup_pd_slot_pd)
-  apply (fastforce dest: pas_refined_Control)
-  done
-
-lemma unmap_page_table_respects:
-  "\<lbrace>integrity aag X st and pas_refined aag and invs
-         and K (is_subject_asid aag asid \<and> vaddr < kernel_base)\<rbrace>
-     unmap_page_table asid vaddr pt
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: unmap_page_table_def page_table_mapped_def )
-  apply (rule hoare_pre)
-   apply (wp store_pde_respects page_table_mapped_wp_weak get_pde_wp
-             hoare_vcg_all_lift_R dmo_mol_respects
-        | wpc
-        | simp add: cleanByVA_PoU_def
-        | wp (once) hoare_drop_imps)+
-  apply auto
-  done
-
-definition
-  authorised_page_table_inv :: "'a PAS \<Rightarrow> page_table_invocation \<Rightarrow> bool"
-where
-  "authorised_page_table_inv aag pti \<equiv> case pti of
-     page_table_invocation.PageTableMap cap cslot_ptr pde obj_ref \<Rightarrow>
-         is_subject aag (fst cslot_ptr) \<and> is_subject aag (obj_ref && ~~ mask pd_bits)
-       \<and> (case_option True (is_subject aag o fst) (pde_ref2 pde))
-       \<and> pas_cap_cur_auth aag cap
-   | page_table_invocation.PageTableUnmap cap cslot_ptr \<Rightarrow>
-       is_subject aag (fst cslot_ptr) \<and> aag_cap_auth aag (pasSubject aag) cap
-         \<and> (\<forall>p asid vspace_ref. cap = cap.ArchObjectCap (arch_cap.PageTableCap p (Some (asid, vspace_ref)))
-                \<longrightarrow> is_subject_asid aag asid
-                \<and> (\<forall>x \<in> set [p , p + 4 .e. p + 2 ^ pt_bits - 1]. is_subject aag (x && ~~ mask pt_bits)))"
-
-lemma perform_page_table_invocation_respects:
-  "\<lbrace>integrity aag X st and pas_refined aag and invs
-          and valid_pti page_table_invocation
-          and K (authorised_page_table_inv aag page_table_invocation)\<rbrace>
-     perform_page_table_invocation page_table_invocation
-   \<lbrace>\<lambda>s. integrity aag X st\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: perform_page_table_invocation_def
-             cong: page_table_invocation.case_cong option.case_cong prod.case_cong
-                   cap.case_cong arch_cap.case_cong)
-  apply (rule hoare_pre)
-  apply (wp store_pde_respects set_cap_integrity_autarch store_pte_respects unmap_page_table_respects mapM_wp'
-       | wpc
-       | simp add: mapM_x_mapM authorised_page_table_inv_def cleanByVA_PoU_def)+
-  apply (auto simp: cap_auth_conferred_def is_page_cap_def
-                    pas_refined_all_auth_is_owns
-                    valid_pti_def valid_cap_simps)
-  done
-
-crunch arm_asid_table_inv [wp]: unmap_page_table "\<lambda>s. P (arm_asid_table (arch_state s))"
- (wp: crunch_wps simp: crunch_simps)
-
-lemma clas_update_map_data_strg:
-  "(is_pg_cap cap \<or> is_pt_cap cap) \<longrightarrow> cap_links_asid_slot aag p (cap.ArchObjectCap (update_map_data (the_arch_cap cap) None))"
-  unfolding cap_links_asid_slot_def
-  by (fastforce simp: is_cap_simps update_map_data_def)
-
-lemmas pte_ref_simps = pte_ref_def[split_simps pte.split]
-
-lemmas store_pde_pas_refined_simple
-    = store_pde_pas_refined[where pde=InvalidPDE, simplified pde_ref_simps, simplified]
-
-crunch pas_refined[wp]: unmap_page_table "pas_refined aag"
-  (wp: crunch_wps store_pde_pas_refined_simple
-      simp: crunch_simps pde_ref_simps)
-
-lemma pde_ref_pde_ref2:
-  "\<lbrakk> pde_ref x = Some v; pde_ref2 x = Some v' \<rbrakk> \<Longrightarrow> v' = (v, 0, {Control})"
-  unfolding pde_ref_def pde_ref2_def
-  by (cases x, simp_all)
-
-lemma ptr_range_0 [simp]: "ptr_range (p :: word32) 0 = {p}"
-  unfolding ptr_range_def by simp
-
-lemma mask_PTCap_eq:
-  "(ArchObjectCap (PageTableCap a b) = mask_cap R cap) = (cap = ArchObjectCap (PageTableCap a b))"
-  by (auto simp: mask_cap_def cap_rights_update_def acap_rights_update_def
-           split: arch_cap.splits cap.splits bool.splits)
-
-
-(* FIXME MOVE *)
-crunch cdt[wp]: unmap_page_table "\<lambda>s. P (cdt s)"
-  (simp: crunch_simps wp: crunch_wps)
-
-(* FIXME MOVE *)
 lemma is_transferable_ArchCap[simp]:
-  "\<not> is_transferable
-        (Some (ArchObjectCap cap))"
+  "\<not> is_transferable (Some (ArchObjectCap cap))"
   using is_transferable.simps by simp
-
-
-
-lemma is_transferable_is_arch_update:
-  "is_arch_update cap cap' \<Longrightarrow> is_transferable (Some cap) = is_transferable (Some cap')"
-  using is_transferable.simps is_arch_cap_def is_arch_update_def cap_master_cap_def
-  by (simp split: cap.splits arch_cap.splits)
-
-lemma perform_page_table_invocation_pas_refined [wp]:
-  "\<lbrace> pas_refined aag and valid_pti page_table_invocation
-     and K (authorised_page_table_inv aag page_table_invocation)\<rbrace>
-     perform_page_table_invocation page_table_invocation
-   \<lbrace>\<lambda>s. pas_refined aag\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: perform_page_table_invocation_def
-             cong: page_table_invocation.case_cong option.case_cong prod.case_cong
-                   cap.case_cong arch_cap.case_cong)
-  apply (rule hoare_pre)
-  apply (wp get_cap_wp mapM_wp' store_pte_cte_wp_at do_machine_op_cte_wp_at
-            hoare_vcg_all_lift set_cap_pas_refined_not_transferable
-        | (wp hoare_vcg_imp_lift, unfold disj_not1)
-        | wpc
-        | simp add: mapM_x_mapM authorised_page_table_inv_def imp_conjR
-                    pte_ref_simps
-        | wps
-        | blast)+
-  apply (cases page_table_invocation)
-   apply (fastforce simp: cte_wp_at_caps_of_state Option.is_none_def
-                          is_transferable_is_arch_update[symmetric]
-                          valid_pti_def is_cap_simps pas_refined_refl auth_graph_map_def2
-                    dest: pde_ref_pde_ref2)
-  apply (rename_tac s pt_cap page_cslot)
-  apply (case_tac page_cslot)
-  apply (rename_tac page_ptr page_slot)
-  apply (case_tac "\<exists>pt_ptr mapping. pt_cap = ArchObjectCap (PageTableCap pt_ptr mapping)")
-   prefer 2
-   apply fastforce
-  apply (elim exE)
-  apply clarsimp
-  apply (rename_tac page_cap)
-  apply (subgoal_tac
-            "cte_wp_at ((=) page_cap) (page_ptr, page_slot) s \<longrightarrow>
-             cte_wp_at (\<lambda>c. \<not> is_transferable (Some c)) (page_ptr, page_slot) s \<and>
-             pas_cap_cur_auth aag
-                (cap.ArchObjectCap (update_map_data (the_arch_cap page_cap) None))")
-   apply simp
-  apply (clarsimp simp: cte_wp_at_caps_of_state)
-  apply (frule (1) cap_cur_auth_caps_of_state)
-   apply simp
-  apply (clarsimp simp: valid_pti_def cte_wp_at_caps_of_state mask_PTCap_eq)
-  apply (clarsimp simp: cap_auth_conferred_def update_map_data_def is_page_cap_def
-                        cap_links_asid_slot_def cap_links_irq_def aag_cap_auth_def)
-  done
-
-definition
-  authorised_slots :: "'a PAS \<Rightarrow> pte \<times> (obj_ref list) + pde \<times> (obj_ref list) \<Rightarrow> bool"
-where
- "authorised_slots aag m \<equiv> case m of
-    Inl (pte, slots) \<Rightarrow> (\<forall>x. pte_ref pte = Some x \<longrightarrow> (\<forall>a \<in> (snd (snd x)). \<forall>p \<in> ptr_range (fst x) (fst (snd x)).(aag_has_auth_to aag a p)))
-           \<and> (\<forall>x \<in> set slots. is_subject aag (x && ~~ mask pt_bits))
-  | Inr (pde, slots) \<Rightarrow> (\<forall>x. pde_ref2 pde = Some x \<longrightarrow> (\<forall>a \<in> (snd (snd x)). \<forall>p \<in> ptr_range (fst x) (fst (snd x)). (aag_has_auth_to aag a p)))
-           \<and> (\<forall>x \<in> set slots. is_subject aag (x && ~~ mask pd_bits))"
-
-definition
-  authorised_page_inv :: "'a PAS \<Rightarrow> page_invocation \<Rightarrow> bool"
-where
-  "authorised_page_inv aag pgi \<equiv> case pgi of
-     PageMap asid cap ptr slots \<Rightarrow>
-       pas_cap_cur_auth aag cap \<and> is_subject aag (fst ptr) \<and> authorised_slots aag slots
-   | PageUnmap cap ptr \<Rightarrow> pas_cap_cur_auth aag (Structures_A.ArchObjectCap cap) \<and> is_subject aag (fst ptr)
-   | PageFlush typ start end pstart pd asid \<Rightarrow> True
-   | PageGetAddr ptr \<Rightarrow> True"
-
-crunch respects[wp]: lookup_pt_slot "integrity X aag st"
-
-lemma ptrFromPAddr_inj: "inj ptrFromPAddr"
-  by (auto intro: injI simp: ptrFromPAddr_def)
-
-lemma vs_refs_no_global_pts_pdI:
-  "\<lbrakk>pd (ucast r) = PageTablePDE x a b;
-    ((ucast r)::12 word) < ucast (kernel_base >> 20) \<rbrakk> \<Longrightarrow>
-        (ptrFromPAddr x, VSRef (r && mask 12)
-                  (Some APageDirectory), Control)
-          \<in> vs_refs_no_global_pts (ArchObj (PageDirectory pd))"
-  apply(clarsimp simp: vs_refs_no_global_pts_def)
-  apply (drule_tac f=pde_ref2 in arg_cong, simp add: pde_ref_simps o_def)
-  apply (rule rev_bexI, rule DiffI, erule graph_ofI)
-   apply simp
-  apply (clarsimp simp: ucast_ucast_mask )
-  done
-
-lemma aag_has_auth_to_Control_eq_owns:
-  "pas_refined aag s \<Longrightarrow> aag_has_auth_to aag Control p = is_subject aag p"
-  by (auto simp: pas_refined_refl elim: aag_Control_into_owns)
-
-lemma lookup_pt_slot_authorised:
-  "\<lbrace>\<exists>\<rhd> pd and valid_vspace_objs and pspace_aligned and pas_refined aag
-            and K (is_subject aag pd) and K (is_aligned pd 14 \<and> vptr < kernel_base)\<rbrace>
-    lookup_pt_slot pd vptr
-  \<lbrace>\<lambda>rv s. is_subject aag (rv && ~~ mask pt_bits)\<rbrace>, -"
-  apply (simp add: lookup_pt_slot_def)
-  apply (wp get_pde_wp | wpc)+
-  apply (subgoal_tac "is_aligned pd pd_bits")
-   apply (clarsimp simp: lookup_pd_slot_pd)
-   apply (drule(2) valid_vspace_objsD)
-   apply (clarsimp simp: obj_at_def)
-   apply (drule kheap_eq_state_vrefs_pas_refinedD)
-     apply (erule vs_refs_no_global_pts_pdI)
-     apply (drule(1) less_kernel_base_mapping_slots)
-     apply (simp add: kernel_mapping_slots_def)
-    apply assumption
-   apply (simp add: aag_has_auth_to_Control_eq_owns)
-   apply (drule_tac f="\<lambda>pde. valid_pde pde s" in arg_cong, simp)
-   apply (clarsimp simp: obj_at_def less_kernel_base_mapping_slots)
-   apply (erule pspace_alignedE, erule domI)
-   apply (simp add: pt_bits_def pageBits_def)
-   apply (subst is_aligned_add_helper, assumption)
-    apply (rule shiftl_less_t2n)
-     apply (rule order_le_less_trans, rule word_and_le1, simp)
-    apply simp
-   apply simp
-  apply (simp add: pd_bits_def pageBits_def)
-  done
-
-lemma is_aligned_6_masks:
-  fixes p :: word32
-  shows
-  "\<lbrakk> is_aligned p 6; bits = pt_bits \<or> bits = pd_bits \<rbrakk>
-        \<Longrightarrow> \<forall>x \<in> set [0, 4 .e. 0x3C]. x + p && ~~ mask bits = p && ~~ mask bits"
-  apply clarsimp
-  apply (drule subsetD[OF upto_enum_step_subset])
-  apply (subst mask_lower_twice[symmetric, where n=6])
-   apply (auto simp add: pt_bits_def pageBits_def pd_bits_def)[1]
-  apply (subst add.commute, subst is_aligned_add_helper, assumption)
-   apply (simp add: order_le_less_trans)
-  apply simp
-  done
-
-lemma lookup_pt_slot_authorised2:
-  "\<lbrace>\<exists>\<rhd> pd and K (is_subject aag pd) and
-    K (is_aligned pd 14 \<and> is_aligned vptr 16 \<and> vptr < kernel_base) and
-    valid_vspace_objs and valid_arch_state and equal_kernel_mappings and
-    valid_global_objs and pspace_aligned and pas_refined aag\<rbrace>
-    lookup_pt_slot pd vptr
-  \<lbrace>\<lambda>rv s.  \<forall>x\<in>set [0 , 4 .e. 0x3C]. is_subject aag (x + rv && ~~ mask pt_bits)\<rbrace>, -"
-  apply (clarsimp simp: validE_R_def valid_def validE_def
-                 split: sum.split)
-  apply (frule use_validE_R[OF _ lookup_pt_slot_authorised])
-   apply fastforce
-  apply (frule use_validE_R[OF _ lookup_pt_slot_is_aligned_6])
-   apply (fastforce simp add: vmsz_aligned_def pd_bits_def pageBits_def)
-  apply (simp add: is_aligned_6_masks)
-  done
-
-lemma lookup_pt_slot_authorised3:
-  "\<lbrace>\<exists>\<rhd> pd and K (is_subject aag pd) and
-    K (is_aligned pd 14 \<and> is_aligned vptr 16 \<and> vptr < kernel_base) and
-    valid_vspace_objs and valid_arch_state and equal_kernel_mappings and
-    valid_global_objs and pspace_aligned and pas_refined aag\<rbrace>
-    lookup_pt_slot pd vptr
-  \<lbrace>\<lambda>rv s.  \<forall>x\<in>set [rv , rv + 4 .e. rv + 0x3C]. is_subject aag (x && ~~ mask pt_bits)\<rbrace>, -"
-  apply (rule hoare_post_imp_R [where Q' = "\<lambda>rv s. is_aligned rv 6 \<and> (\<forall>x\<in>set [0 , 4 .e. 0x3C]. is_subject aag (x + rv && ~~ mask pt_bits))"])
-  apply (rule hoare_pre)
-  apply (wp lookup_pt_slot_is_aligned_6 lookup_pt_slot_authorised2)
-   apply (fastforce simp: vmsz_aligned_def pd_bits_def pageBits_def)
-  apply simp
-  apply (simp add: p_0x3C_shift)
-  done
 
 lemma mapM_set':
   assumes ip: "\<And>x y. \<lbrakk> x \<in> set xs; y \<in> set xs \<rbrakk> \<Longrightarrow> \<lbrace>I x and I y\<rbrace> f x \<lbrace>\<lambda>_. I y\<rbrace>"
-  and   rl: "\<And>s. (\<forall>x \<in> set xs. I x s) \<Longrightarrow> P s"
+  and rl: "\<And>s. (\<forall>x \<in> set xs. I x s) \<Longrightarrow> P s"
   shows "\<lbrace>\<lambda>s. (\<forall>x \<in> set xs. I x s)\<rbrace> mapM f xs \<lbrace>\<lambda>_. P\<rbrace>"
-  apply (rule hoare_post_imp [OF rl])
+  apply (rule hoare_post_imp[OF rl])
    apply assumption
   apply (rule mapM_set)
     apply (rule hoare_pre)
@@ -406,905 +54,166 @@ lemma mapM_set':
 
 lemma mapM_set'':
   assumes ip: "\<And>x y. \<lbrakk> x \<in> set xs; y \<in> set xs \<rbrakk> \<Longrightarrow> \<lbrace>I x and I y and Q\<rbrace> f x \<lbrace>\<lambda>_. I y and Q\<rbrace>"
-  and   rl: "\<And>s. (\<forall>x \<in> set xs. I x s) \<and> Q s \<Longrightarrow> P s"
+  and rl: "\<And>s. (\<forall>x \<in> set xs. I x s) \<and> Q s \<Longrightarrow> P s"
   shows "\<lbrace>\<lambda>s. (\<forall>x \<in> set xs. I x s) \<and> Q s\<rbrace> mapM f xs \<lbrace>\<lambda>_. P\<rbrace>"
-  apply (rule hoare_post_imp [OF rl])
+  apply (rule hoare_post_imp[OF rl])
    apply assumption
   apply (cases "xs = []")
    apply (simp add: mapM_Nil)
   apply (rule hoare_pre)
-   apply (rule mapM_set' [where I = "\<lambda>x s. I x s \<and> Q s"])
+   apply (rule mapM_set'[where I = "\<lambda>x s. I x s \<and> Q s"])
     apply (rule hoare_pre)
-     apply (rule ip [simplified pred_conj_def])
-      apply simp_all
-  apply (clarsimp simp add: neq_Nil_conv)
+     apply (rule ip[simplified pred_conj_def])
+      apply (auto simp: neq_Nil_conv)
   done
 
-crunch respects [wp]: flush_page "integrity aag X st"
-  (simp: invalidateLocalTLB_VAASID_def ignore: do_machine_op)
-
-lemma find_pd_for_asid_pd_owned[wp]:
-  "\<lbrace>pas_refined aag and K (is_subject_asid aag asid)\<rbrace>
-  find_pd_for_asid asid
-  \<lbrace>\<lambda>rv s. is_subject aag rv\<rbrace>,-"
-  apply (wp find_pd_for_asid_authority2)
-  apply (auto simp: aag_has_auth_to_Control_eq_owns)
-  done
-
-lemmas store_pte_pas_refined_simple
-   = store_pte_pas_refined[where pte=InvalidPTE, simplified pte_ref_simps, simplified]
-
-crunch pas_refined[wp]: unmap_page "pas_refined aag"
-  (wp: crunch_wps store_pde_pas_refined_simple store_pte_pas_refined_simple
-       simp: crunch_simps)
-
-lemma unmap_page_respects:
-  "\<lbrace>integrity aag X st and K (is_subject_asid aag asid) and pas_refined aag and pspace_aligned and valid_vspace_objs
-        and K (vmsz_aligned vptr sz \<and> vptr < kernel_base)\<rbrace>
-    unmap_page sz asid vptr pptr
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: unmap_page_def swp_def cong: vmpage_size.case_cong)
+lemma as_user_pas_refined[wp]:
+  "as_user t f \<lbrace>pas_refined aag\<rbrace>"
+  apply (simp add: pas_refined_def state_objs_to_policy_def)
   apply (rule hoare_pre)
-   apply (wp store_pte_respects store_pde_respects
-             hoare_drop_imps[where Q="\<lambda>rv. integrity aag X st"]
-             lookup_pt_slot_authorised
-                   | wpc
-                   | simp add: is_aligned_6_masks is_aligned_mask[symmetric] cleanByVA_PoU_def
-                   | wp (once) hoare_drop_imps
-                     mapM_set'' [where f = "(\<lambda>a. store_pte a InvalidPTE)" and I = "\<lambda>x s. is_subject aag (x && ~~ mask pt_bits)" and Q = "integrity aag X st"]
-                     mapM_set'' [where f = "(\<lambda>a. store_pde a InvalidPDE)" and I = "\<lambda>x s. is_subject aag (x && ~~ mask pd_bits)" and Q = "integrity aag X st"]
-                   | wp (once) hoare_drop_imps[where R="\<lambda>rv s. rv"])+
-  done
-
-(* FIXME: MOVE *)
-lemma less_shiftr:
-  shows "\<lbrakk> x < y; is_aligned y n \<rbrakk> \<Longrightarrow> x >> n < y >> n"
-  apply (simp add: word_less_nat_alt shiftr_div_2n')
-  apply (subst td_gal_lt[symmetric])
-   apply simp
-  apply (subst dvd_div_mult_self)
-   apply (simp add: is_aligned_def)
+   apply wps
+   apply wp
   apply simp
   done
 
-lemma kernel_base_aligned_20:
-  "is_aligned kernel_base 20"
-  apply(simp add: kernel_base_def is_aligned_def)
-  done
+crunches set_message_info
+  for pas_refined[wp]: "pas_refined aag"
+  and cdt[wp]: "\<lambda>s. P (cdt s)"
 
-(* FIXME: CLAG *)
-lemmas do_machine_op_bind =
-    submonad_bind [OF submonad_do_machine_op submonad_do_machine_op
-                      submonad_do_machine_op]
+crunches do_machine_op
+  for thread_states[wp]: "\<lambda>s. P (thread_states s)"
+  and state_vrefs[wp]: "\<lambda>s :: 'a :: state_ext state. P (state_vrefs s)"
 
-lemma mol_mem[wp]:
-  "\<lbrace>\<lambda>ms. P (underlying_memory ms)\<rbrace> machine_op_lift mop \<lbrace>\<lambda>rv ms. P (underlying_memory ms)\<rbrace>"
-  by (simp add: machine_op_lift_def machine_rest_lift_def split_def | wp)+
-
-lemma mol_dvs[wp]:
-  "\<lbrace>\<lambda>ms. P (device_state ms)\<rbrace> machine_op_lift mop \<lbrace>\<lambda>rv ms. P (device_state ms)\<rbrace>"
-  by (simp add: machine_op_lift_def machine_rest_lift_def split_def | wp)+
-
-lemmas do_flush_defs = cleanCacheRange_RAM_def cleanCacheRange_PoC_def cleanCacheRange_PoU_def invalidateCacheRange_RAM_def cleanInvalidateCacheRange_RAM_def branchFlushRange_def invalidateCacheRange_I_def
-
-lemma do_flush_respects[wp]:
-  "\<lbrace>integrity aag X st\<rbrace> do_machine_op (do_flush typ start end pstart)
-    \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (cases "typ")
-     apply (wp dmo_no_mem_respects | simp add: do_flush_def cache_machine_op_defs do_flush_defs)+
-     done
-
-lemma invalidate_tlb_by_asid_respects[wp]:
-  "\<lbrace>integrity aag X st\<rbrace> invalidate_tlb_by_asid asid
-    \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: invalidate_tlb_by_asid_def)
-  apply (wp dmo_no_mem_respects | wpc | simp add: invalidateLocalTLB_ASID_def )+
-  done
-
-lemma invalidate_tlb_by_asid_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace> invalidate_tlb_by_asid asid \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  by (wp dmo_no_mem_respects | wpc | simp add: invalidate_tlb_by_asid_def invalidateLocalTLB_ASID_def)+
-
-crunch pas_refined[wp]: set_message_info "pas_refined aag"
-
-(* FIXME: move *)
-lemma set_message_info_mdb[wp]:
-  "\<lbrace>\<lambda>s. P (cdt s)\<rbrace> set_message_info thread info \<lbrace>\<lambda>rv s. P (cdt s)\<rbrace>"
-  unfolding set_message_info_def by wp
-
-crunch state_vrefs[wp]: do_machine_op "\<lambda>s::'z::state_ext state. P (state_vrefs s)"
-
-crunch thread_states[wp]: do_machine_op "\<lambda>s. P (thread_states s)"
-
-(* FIXME: move *)
-lemma set_mrs_state_vrefs[wp]:
-  "\<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace> set_mrs thread buf msgs \<lbrace>\<lambda>rv s. P (state_vrefs s)\<rbrace>"
-  apply (simp add: set_mrs_def split_def set_object_def get_object_def split del: if_split)
-  apply (wp gets_the_wp get_wp put_wp mapM_x_wp'
-       | wpc
-       | simp split del: if_split add: zipWithM_x_mapM_x split_def store_word_offs_def)+
-  apply (auto simp: obj_at_def state_vrefs_def get_tcb_ko_at
-             elim!: rsubst[where P=P, OF _ ext]
-             split: if_split_asm simp: vs_refs_no_global_pts_def)
-  done
+crunch integrity_autarch: set_message_info "integrity aag X st"
 
 (* FIXME: move *)
 lemma set_mrs_thread_states[wp]:
-  "\<lbrace>\<lambda>s. P (thread_states s)\<rbrace> set_mrs thread buf msgs \<lbrace>\<lambda>rv s. P (thread_states s)\<rbrace>"
-  apply (simp add: set_mrs_def split_def set_object_def get_object_def split del: if_split)
-  apply (wp gets_the_wp get_wp put_wp mapM_x_wp'
-       | wpc
-       | simp split del: if_split add: zipWithM_x_mapM_x split_def store_word_offs_def)+
+  "set_mrs thread buf msgs \<lbrace>\<lambda>s. P (thread_states s)\<rbrace>"
+  supply if_split[split del]
+  apply (simp add: set_mrs_def split_def set_object_def get_object_def)
+  apply (wpsimp wp: gets_the_wp get_wp put_wp mapM_x_wp'
+              simp: zipWithM_x_mapM_x split_def store_word_offs_def)
   apply (clarsimp simp: fun_upd_def[symmetric] thread_states_preserved)
   done
 
 lemma set_mrs_thread_bound_ntfns[wp]:
-  "\<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace> set_mrs thread buf msgs \<lbrace>\<lambda>rv s. P (thread_bound_ntfns s)\<rbrace>"
-  apply (simp add: set_mrs_def split_def set_object_def get_object_def split del: if_split)
-  apply (wp gets_the_wp get_wp put_wp mapM_x_wp' dmo_wp
-       | wpc
-       | simp split del: if_split add: zipWithM_x_mapM_x split_def store_word_offs_def no_irq_storeWord)+
-  apply (clarsimp simp: fun_upd_def[symmetric] thread_bound_ntfns_preserved )
+  "set_mrs thread buf msgs \<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace>"
+  supply if_split[split del]
+  apply (simp add: set_mrs_def split_def set_object_def get_object_def )
+  apply (wpsimp wp: gets_the_wp get_wp put_wp mapM_x_wp' dmo_wp
+              simp: zipWithM_x_mapM_x split_def store_word_offs_def no_irq_storeWord)
+  apply (clarsimp simp: fun_upd_def[symmetric] thread_bound_ntfns_preserved)
+  done
+
+lemma delete_objects_pspace_no_overlap:
+  "\<lbrace>pspace_aligned and valid_objs and (\<lambda>s. \<exists>idx. cte_wp_at ((=) (UntypedCap dev ptr sz idx)) slot s)\<rbrace>
+   delete_objects ptr sz
+   \<lbrace>\<lambda>_. pspace_no_overlap_range_cover ptr sz\<rbrace>"
+  unfolding delete_objects_def do_machine_op_def
+  apply (wp | simp add: split_def detype_machine_state_update_comm)+
+  apply (clarsimp)
+  apply (rule pspace_no_overlap_detype)
+    apply (auto dest: cte_wp_at_valid_objs_valid_cap)
+  done
+
+lemma delete_objects_invs_ex:
+  "\<lbrace>invs and ct_active and
+    (\<lambda>s. \<exists>slot dev f. cte_wp_at ((=) (UntypedCap dev ptr bits f)) slot s \<and>
+                      descendants_range (UntypedCap dev ptr bits f) slot s)\<rbrace>
+   delete_objects ptr bits
+   \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (erule use_valid)
+   apply wp
+  apply auto
+  done
+
+lemma is_subject_asid_into_loas:
+  "\<lbrakk> is_subject_asid aag asid; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> label_owns_asid_slot aag (pasSubject aag) asid"
+  unfolding label_owns_asid_slot_def
+  by (clarsimp simp: pas_refined_refl)
+
+
+locale Arch_AC_1 =
+  assumes set_mrs_state_vrefs[wp]:
+    "set_mrs thread buf msgs \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
+  and mul_add_word_size_lt_msg_align_bits_ofnat:
+    "\<lbrakk> p < 2 ^ (msg_align_bits - word_size_bits); k < 4 \<rbrakk>
+       \<Longrightarrow> of_nat p * of_nat word_size + k < (2 :: obj_ref) ^ msg_align_bits"
+begin
+
+lemmas mul_word_size_lt_msg_align_bits_ofnat =
+  mul_add_word_size_lt_msg_align_bits_ofnat[where k=0, simplified]
+
+lemmas ptr_range_off_off_mems =
+  ptr_range_add_memI[OF _ mul_word_size_lt_msg_align_bits_ofnat]
+  ptr_range_add_memI[OF _ mul_add_word_size_lt_msg_align_bits_ofnat, simplified add.assoc[symmetric]]
+
+lemma dmo_storeWord_respects_Write:
+  "\<lbrace>integrity aag X st and K (\<forall>p' \<in> ptr_range p word_size_bits. aag_has_auth_to aag Write p')\<rbrace>
+   do_machine_op (storeWord p v)
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (rule hoare_pre)
+  apply (wp dmo_wp storeWord_respects)
+  apply simp
+  done
+
+lemma store_word_offs_integrity_autarch:
+  "\<lbrace>\<lambda>s. integrity aag X st s \<and> is_subject aag thread \<and>
+        ipc_buffer_has_auth aag thread (Some buf) \<and>
+        r < 2 ^ (msg_align_bits - word_size_bits)\<rbrace>
+   store_word_offs buf r v
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: store_word_offs_def)
+  apply (rule hoare_pre)
+   apply (wp dmo_storeWord_respects_Write)
+  apply clarsimp
+  apply (drule (1) ipc_buffer_has_auth_wordE)
+     apply (simp add: word_size_word_size_bits is_aligned_mult_triv2)
+    apply (simp add: msg_align_bits')
+   apply (erule mul_word_size_lt_msg_align_bits_ofnat)
+  apply simp
   done
 
 lemma set_mrs_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace> set_mrs thread buf msgs \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "set_mrs thread buf msgs \<lbrace>pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def)
   apply (rule hoare_pre)
    apply (wp | wps)+
   apply (clarsimp dest!: auth_graph_map_memD)
   done
 
-crunch integrity_autarch: set_message_info "integrity aag X st"
-
-lemma dmo_storeWord_respects_Write:
-  "\<lbrace>integrity aag X st and K (\<forall>p' \<in> ptr_range p 2. aag_has_auth_to aag Write p')\<rbrace>
-  do_machine_op (storeWord p v)
-  \<lbrace>\<lambda>a. integrity aag X st\<rbrace>"
-  apply (rule hoare_pre)
-  apply (wp dmo_wp storeWord_respects)
-  apply simp
-  done
-
-(* c.f.  auth_ipc_buffers *)
-definition
-  ipc_buffer_has_auth :: "'a PAS \<Rightarrow> word32 \<Rightarrow> word32 option \<Rightarrow> bool"
-where
-   "ipc_buffer_has_auth aag thread \<equiv>
-    case_option True (\<lambda>buf'. is_aligned buf' msg_align_bits \<and> (\<forall>x \<in> ptr_range buf' msg_align_bits. (pasObjectAbs aag thread, Write, pasObjectAbs aag x) \<in> pasPolicy aag))"
-
-lemma ipc_buffer_has_auth_wordE:
-  "\<lbrakk> ipc_buffer_has_auth aag thread (Some buf); p \<in> ptr_range (buf + off) sz; is_aligned off sz; sz \<le> msg_align_bits; off < 2 ^ msg_align_bits \<rbrakk>
-  \<Longrightarrow> (pasObjectAbs aag thread, Write, pasObjectAbs aag p) \<in> pasPolicy aag"
-  unfolding ipc_buffer_has_auth_def
-  apply clarsimp
-  apply (erule bspec)
-  apply (erule (4) set_mp [OF ptr_range_subset])
-  done
-
-
-lemma is_aligned_word_size_2 [simp]:
-  "is_aligned (p * of_nat word_size) 2"
-  unfolding word_size_def
-  by (simp add: is_aligned_mult_triv2 [where n = 2, simplified] word_bits_conv)
-
-
-
-lemma mul_word_size_lt_msg_align_bits_ofnat:
-  "p < 2 ^ (msg_align_bits - 2) \<Longrightarrow> of_nat p * of_nat word_size < (2 :: word32) ^ msg_align_bits"
-  unfolding word_size_def
-  apply simp
-  apply (rule word_less_power_trans_ofnat [where k = 2, simplified])
-  apply (simp_all add: msg_align_bits word_bits_conv)
-  done
-
-lemma store_word_offs_integrity_autarch:
-  "\<lbrace>integrity aag X st and K (is_subject aag thread \<and> ipc_buffer_has_auth aag thread (Some buf) \<and> r < 2 ^ (msg_align_bits - 2))\<rbrace>
-   store_word_offs buf r v
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: store_word_offs_def)
-  apply (rule hoare_pre)
-   apply (wp dmo_storeWord_respects_Write)
-  apply clarsimp
-  apply (drule (1) ipc_buffer_has_auth_wordE)
-     apply simp
-    apply (simp add: msg_align_bits)
-   apply (erule mul_word_size_lt_msg_align_bits_ofnat)
-  apply simp
+lemma copy_mrs_integrity_autarch:
+  "\<lbrace>pas_refined aag and integrity aag X st and
+    K (is_subject aag receiver \<and> ipc_buffer_has_auth aag receiver rbuf \<and>
+       unat n < 2 ^ (msg_align_bits - word_size_bits))\<rbrace>
+   copy_mrs sender sbuf receiver rbuf n
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (simp add: copy_mrs_def cong: if_cong split del: if_split)
+  apply (wpsimp wp: mapM_wp' as_user_integrity_autarch
+                    store_word_offs_integrity_autarch[where thread=receiver]
+         | fastforce)+
   done
 
 lemma set_mrs_integrity_autarch:
-  "\<lbrace>integrity aag X st and K (is_subject aag thread \<and>  ipc_buffer_has_auth aag thread buf)\<rbrace>
-     set_mrs thread buf msgs
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and K (is_subject aag thread \<and> ipc_buffer_has_auth aag thread buf)\<rbrace>
+   set_mrs thread buf msgs
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: set_mrs_def split del: if_split)
-  apply (wp gets_the_wp get_wp put_wp mapM_x_wp' store_word_offs_integrity_autarch [where aag = aag and thread = thread]
-       | wpc
-       | simp split del: if_split add: split_def zipWithM_x_mapM_x )+
-    apply (clarsimp elim!: in_set_zipE split: if_split_asm)
-    apply (rule order_le_less_trans [where y = msg_max_length])
-     apply (fastforce simp add: le_eq_less_or_eq)
-    apply (simp add: msg_max_length_def msg_align_bits)
-   apply simp
-   apply (wp set_object_integrity_autarch hoare_drop_imps hoare_vcg_all_lift)+
-  apply simp
-  done
-
-lemma perform_page_invocation_respects:
-  "\<lbrace>integrity aag X st and pas_refined aag and K (authorised_page_inv aag pgi) and valid_page_inv pgi and valid_vspace_objs and pspace_aligned and is_subject aag  \<circ> cur_thread\<rbrace>
-     perform_page_invocation pgi
-   \<lbrace>\<lambda>s. integrity aag X st\<rbrace>"
-proof -
-  (* does not work as elim rule with clarsimp, which hammers Ball in concl. *)
-  have set_tl_subset_mp: "\<And>xs a. a \<in> set (tl xs) \<Longrightarrow> a \<in> set xs" by (case_tac xs,clarsimp+)
-  have hd_valid_slots:
-    "\<And>a xs s. valid_slots (Inl (a, xs)) s \<Longrightarrow> hd xs \<in> set xs"
-    "\<And>a xs s. valid_slots (Inr (a, xs)) s \<Longrightarrow> hd xs \<in> set xs"
-    by (simp_all add: valid_slots_def)
-
-  show ?thesis
-  apply (simp add: perform_page_invocation_def mapM_discarded swp_def
-                   valid_page_inv_def valid_unmap_def
-                   authorised_page_inv_def authorised_slots_def
-            split: page_invocation.split sum.split
-                   arch_cap.split option.split,
-         safe)
-        apply (wp set_cap_integrity_autarch unmap_page_respects
-                  mapM_x_and_const_wp[OF store_pte_respects] store_pte_respects
-                  mapM_x_and_const_wp[OF store_pde_respects] store_pde_respects
-             | elim conjE hd_valid_slots[THEN bspec[rotated]]
-             | clarsimp dest!:set_tl_subset_mp
-             | wpc )+
-   apply (clarsimp simp: cte_wp_at_caps_of_state cap_auth_conferred_def cap_rights_update_def
-                         acap_rights_update_def update_map_data_def is_pg_cap_def
-                         valid_page_inv_def valid_cap_simps
-                  dest!: cap_master_cap_eqDs)
-   apply (drule (1) clas_caps_of_state)
-   apply (simp add: cap_links_asid_slot_def label_owns_asid_slot_def)
-   apply (auto dest: pas_refined_Control)[1]
-  apply (wp set_mrs_integrity_autarch set_message_info_integrity_autarch | simp add: ipc_buffer_has_auth_def)+
-  done
-qed
-
-(* FIXME MOVE *)
-crunch cdt[wp]: unmap_page "\<lambda>s. P (cdt s)"
-  (simp: crunch_simps wp: crunch_wps)
-
-
-lemma perform_page_invocation_pas_refined [wp]:
-  "\<lbrace>pas_refined aag and K (authorised_page_inv aag pgi) and valid_page_inv pgi\<rbrace>
-     perform_page_invocation pgi
-   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  apply (simp add: perform_page_invocation_def mapM_discarded
-    valid_page_inv_def valid_unmap_def swp_def
-    authorised_page_inv_def authorised_slots_def
-    cong: page_invocation.case_cong sum.case_cong)
-  apply (rule hoare_pre)
-   apply wpc
-      apply (wp set_cap_pas_refined unmap_page_pas_refined case_sum_wp  case_prod_wp
-                mapM_x_and_const_wp [OF store_pte_pas_refined] mapM_x_and_const_wp [OF store_pde_pas_refined]
-             hoare_vcg_all_lift hoare_vcg_const_imp_lift get_cap_wp
-            | (wp hoare_vcg_imp_lift, unfold disj_not1)
-            | strengthen clas_update_map_data_strg
-            | wpc
-            | wps
-            | simp)+
-  apply (case_tac pgi)
-      apply ((force simp: valid_slots_def pte_ref_def cte_wp_at_caps_of_state
-                          is_transferable_is_arch_update[symmetric]
-                          pde_ref2_def auth_graph_map_mem pas_refined_refl
-                   split: sum.splits)+)[2]
-    apply (clarsimp simp: cte_wp_at_caps_of_state is_transferable_is_arch_update[symmetric]
-                          pte_ref_def pde_ref2_def is_cap_simps is_pg_cap_def cap_auth_conferred_def)
-    apply (frule(1) cap_cur_auth_caps_of_state, simp)
-    apply (intro impI conjI;
-           clarsimp; (* NB: for speed *)
-           clarsimp simp: update_map_data_def clas_no_asid aag_cap_auth_def
-                          cap_auth_conferred_def vspace_cap_rights_to_auth_def
-                          cli_no_irqs is_pg_cap_def
-                          pte_ref_def[simplified aag_cap_auth_def])+
-  done
-
-definition
-  authorised_asid_control_inv :: "'a PAS \<Rightarrow> asid_control_invocation \<Rightarrow> bool"
-where
- "authorised_asid_control_inv aag aci \<equiv> case aci of
-     asid_control_invocation.MakePool frame slot parent base \<Rightarrow>
-       is_subject aag (fst slot) \<and> is_aligned frame pageBits \<and> (\<forall>asid. is_subject_asid aag asid) \<and> is_subject aag (fst parent) \<and>
-       (\<forall>x \<in> {frame..frame + 2 ^ pageBits - 1}. is_subject aag x)"
-
-
-lemma integrity_arm_asid_table_entry_update':
-  "\<lbrakk>integrity aag X st s;  asid_table = arm_asid_table (arch_state s);
-       (\<forall>asid'.
-                    asid' \<noteq> 0 \<and>
-                    asid_high_bits_of asid' = asid_high_bits_of asid \<longrightarrow>
-                    is_subject_asid aag asid')\<rbrakk> \<Longrightarrow>
-       integrity aag X st
-           (s\<lparr>arch_state := arch_state s
-                \<lparr>arm_asid_table :=
-                   \<lambda>a. if a = asid_high_bits_of asid then v
-                       else asid_table a\<rparr>\<rparr>)"
-  apply(clarsimp simp: integrity_def integrity_asids_def)
-  done
-
-lemma arm_asid_table_entry_update_integrity[wp]:
- "\<lbrace>integrity aag X st and (\<lambda> s. asid_table = arm_asid_table (arch_state s)) and K (\<forall>asid'.
-                    asid' \<noteq> 0 \<and>
-                    asid_high_bits_of asid' = asid_high_bits_of asid \<longrightarrow>
-                    is_subject_asid aag asid')\<rbrace>
- modify
-        (\<lambda>s. s\<lparr>arch_state := arch_state s
-                 \<lparr>arm_asid_table := asid_table
-                    (asid_high_bits_of asid := v)\<rparr>\<rparr>)
-  \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  apply (wp| simp)+
-  apply (blast intro: integrity_arm_asid_table_entry_update')
-  done
-
-lemma perform_asid_control_invocation_respects:
-  "\<lbrace>integrity aag X st and K (authorised_asid_control_inv aag aci)\<rbrace>
-     perform_asid_control_invocation aci
-   \<lbrace>\<lambda>s. integrity aag X st\<rbrace>"
-  apply (simp add: perform_asid_control_invocation_def)
-  apply (rule hoare_pre)
-   apply (wpc, simp)
-   apply (wp set_cap_integrity_autarch cap_insert_integrity_autarch retype_region_integrity[where sz=12] static_imp_wp | simp)+
-  apply (clarsimp simp: authorised_asid_control_inv_def
-                        ptr_range_def page_bits_def add.commute
-                        range_cover_def obj_bits_api_def default_arch_object_def
-                        pageBits_def word_bits_def)
-  apply(subst is_aligned_neg_mask_eq[THEN sym], assumption)
-  apply(simp add: and_mask_eq_iff_shiftr_0 mask_zero)
-  done
-
-lemma pas_refined_set_asid_strg:
-  "pas_refined aag s \<and> is_subject aag pool \<and> (\<forall>asid. asid_high_bits_of asid = base \<longrightarrow> is_subject_asid aag asid)
-    \<longrightarrow>
-  pas_refined aag (s\<lparr>arch_state := arch_state s \<lparr>arm_asid_table := (arm_asid_table (arch_state s))(base \<mapsto> pool)\<rparr>\<rparr>)"
-  apply (clarsimp simp: pas_refined_def state_objs_to_policy_def)
-  apply (erule state_asids_to_policy_aux.cases, simp_all split: if_split_asm)
-    apply (auto intro: state_asids_to_policy_aux.intros auth_graph_map_memI[OF sbta_vref] pas_refined_refl[simplified pas_refined_def state_objs_to_policy_def])
-  done
-
-
-(* FIXME: copied from Detype_R. *)
-lemma gets_modify_comm2:
-  "\<forall>s. g (f s) = g s \<Longrightarrow>
-   (do x \<leftarrow> modify f; y \<leftarrow> gets g; m x y od) =
-   (do y \<leftarrow> gets g; x \<leftarrow> modify f; m x y od)"
-  apply (rule ext)
-  apply (drule spec)
-  by (rule gets_modify_comm)
-lemma dmo_detype_comm:
-  assumes "empty_fail f"
-  shows "do_machine_op f >>= (\<lambda>s. modify (detype S)) =
-         modify (detype S) >>= (\<lambda>s. do_machine_op f)"
-proof -
-  have machine_state_detype: "\<forall>s. machine_state (detype S s) = machine_state s"
-    by (simp add: detype_def)
-  have detype_msu_independent:
-    "\<And>f. detype S \<circ> machine_state_update f = machine_state_update f \<circ> detype S"
-    by (simp add: detype_def ext)
-  from assms
-  show ?thesis
-    apply (simp add: do_machine_op_def split_def bind_assoc)
-    apply (simp add: gets_modify_comm2[OF machine_state_detype])
-    apply (rule arg_cong_bind1)
-    apply (simp add: empty_fail_def select_f_walk[OF empty_fail_modify]
-                     modify_modify detype_msu_independent)
-    done
-qed
-
-(* FIXME: copied from Detype_R. *)
-lemma empty_fail_freeMemory: "empty_fail (freeMemory ptr bits)"
-  by (simp add: freeMemory_def mapM_x_mapM ef_storeWord)
-
-(* FIXME: copied from Detype_R. *)
-lemma delete_objects_def2:
-  "delete_objects ptr bits \<equiv>
-   do modify (detype {ptr..ptr + 2 ^ bits - 1});
-      do_machine_op (freeMemory ptr bits)
-   od"
-  by (rule eq_reflection)
-     (simp add: delete_objects_def dmo_detype_comm[OF empty_fail_freeMemory])
-
-lemma delete_objects_pspace_no_overlap:
-  "\<lbrace> pspace_aligned and valid_objs and
-     (\<lambda> s. \<exists> idx. cte_wp_at ((=) (UntypedCap dev ptr sz idx)) slot s)\<rbrace>
-    delete_objects ptr sz
-   \<lbrace>\<lambda>rv. pspace_no_overlap_range_cover ptr sz\<rbrace>"
-  unfolding delete_objects_def do_machine_op_def
-  apply(wp | simp add: split_def detype_machine_state_update_comm)+
-  apply(clarsimp)
-  apply(rule pspace_no_overlap_detype)
-   apply(auto dest: cte_wp_at_valid_objs_valid_cap)
-  done
-
-
-lemma delete_objects_invs_ex:
-  "\<lbrace>(\<lambda>s. \<exists>slot dev f.
-         cte_wp_at ((=) (UntypedCap dev ptr bits f)) slot s \<and>
-         descendants_range (UntypedCap dev ptr bits f) slot s) and
-   invs and
-   ct_active\<rbrace>
-  delete_objects ptr bits \<lbrace>\<lambda>_. invs\<rbrace>"
-  apply(clarsimp simp: valid_def)
-  apply(erule use_valid)
-  apply wp
-  apply auto
-  done
-
-
-lemma perform_asid_control_invocation_pas_refined [wp]:
-  notes delete_objects_invs[wp del]
-  shows
-  "\<lbrace>pas_refined aag and pas_cur_domain aag and invs and valid_aci aci and ct_active and
-    K (authorised_asid_control_inv aag aci)\<rbrace>
-   perform_asid_control_invocation aci
-   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  apply (simp add: perform_asid_control_invocation_def)
-  apply (rule hoare_pre)
-   apply (wp cap_insert_pas_refined' static_imp_wp
-        | strengthen pas_refined_set_asid_strg
-        | wpc
-        | simp add: delete_objects_def2 fun_upd_def[symmetric])+
-      apply (wp retype_region_pas_refined'[where sz=pageBits]
-                hoare_vcg_ex_lift hoare_vcg_all_lift static_imp_wp hoare_wp_combs hoare_drop_imp
-                retype_region_invs_extras(4)[where sz = pageBits]
-            | simp add: do_machine_op_def split_def cte_wp_at_neg2)+
-      apply (wp retype_region_cte_at_other'[where sz=pageBits]
-                max_index_upd_invs_simple max_index_upd_caps_overlap_reserved
-                hoare_vcg_ex_lift set_cap_cte_wp_at hoare_vcg_disj_lift set_free_index_valid_pspace
-                set_cap_descendants_range_in set_cap_no_overlap get_cap_wp set_cap_caps_no_overlap
-                hoare_vcg_all_lift static_imp_wp retype_region_invs_extras
-                set_cap_pas_refined_not_transferable
-            | simp add: do_machine_op_def split_def cte_wp_at_neg2 region_in_kernel_window_def)+
-   apply (rename_tac frame slot parent base cap)
-   apply (case_tac slot, rename_tac slot_ptr slot_idx)
-   apply (case_tac parent, rename_tac parent_ptr parent_idx)
-   apply (rule_tac Q="\<lambda>rv s.
-             (\<exists>idx. cte_wp_at ((=) (UntypedCap False frame pageBits idx)) parent s) \<and>
-             (\<forall>x\<in>ptr_range frame pageBits. is_subject aag x) \<and>
-             pas_refined aag s \<and>
-             pas_cur_domain aag s \<and>
-             pspace_no_overlap_range_cover frame pageBits s \<and>
-             invs s \<and>
-             descendants_range_in
-               {frame..(frame && ~~ mask pageBits) + 2 ^ pageBits - 1} parent s \<and>
-             range_cover frame pageBits
-               (obj_bits_api (ArchObject ASIDPoolObj) 0) (Suc 0) \<and>
-             is_subject aag slot_ptr \<and>
-             is_subject aag parent_ptr \<and>
-             pas_cap_cur_auth aag (ArchObjectCap (ASIDPoolCap frame base)) \<and>
-             is_subject aag frame \<and>
-             (\<forall>x. asid_high_bits_of x = asid_high_bits_of base \<longrightarrow>
-                 is_subject_asid aag x)"
-             in hoare_strengthen_post)
-    apply (simp add: page_bits_def)
-    apply (wp add: delete_objects_pspace_no_overlap hoare_vcg_ex_lift
-                   delete_objects_descendants_range_in delete_objects_invs_ex
-                   delete_objects_pas_refined
-              del: Untyped_AI.delete_objects_pspace_no_overlap
-          | simp add: page_bits_def)+
-   apply clarsimp
-   apply (rename_tac s idx)
-   apply (frule untyped_cap_aligned, simp add: invs_valid_objs)
-   apply (clarsimp simp: cte_wp_at_def aag_cap_auth_def ptr_range_def pas_refined_refl
-                         cap_links_asid_slot_def cap_links_irq_def
-                         obj_bits_api_def default_arch_object_def retype_addrs_def)
-   apply (rule conjI, force intro: descendants_range_caps_no_overlapI
-                             simp: cte_wp_at_def)
-   apply (rule conjI)
-    apply (cut_tac s=s and ptr="(parent_ptr, parent_idx)" in cap_refs_in_kernel_windowD)
-      apply ((fastforce simp add: caps_of_state_def cap_range_def)+)[3]
-   apply (rule conjI, force simp: field_simps)
-   apply (rule conjI, fastforce)
-   apply (fastforce dest: caps_of_state_valid
-                    simp: caps_of_state_def free_index_of_def
-                          max_free_index_def valid_cap_def)
-  apply (clarsimp simp: valid_aci_def authorised_asid_control_inv_def)
-  apply (rename_tac frame slot_ptr slot_idx parent_ptr parent_idx base)
-  apply (subgoal_tac "is_aligned frame pageBits")
-   apply (clarsimp simp: cte_wp_at_caps_of_state)
-   apply (rule conjI)
-    apply (drule untyped_slots_not_in_untyped_range)
-         apply (erule empty_descendants_range_in)
-        apply (simp add: cte_wp_at_caps_of_state)
-       apply simp
-      apply (rule refl)
-     apply (rule subset_refl)
-    apply (simp add: page_bits_def)
-   apply (clarsimp simp: ptr_range_def invs_psp_aligned invs_valid_objs
-                         descendants_range_def2 empty_descendants_range_in page_bits_def)
-   apply ((strengthen refl | simp)+)?
-   apply (rule conjI, fastforce)
-   apply (rule conjI, fastforce intro: empty_descendants_range_in)
-   apply (rule conjI)
-    apply (clarsimp simp: range_cover_def obj_bits_api_def default_arch_object_def)
-    apply (subst is_aligned_neg_mask_eq[THEN sym], assumption)
-    apply (simp add: and_mask_eq_iff_shiftr_0 pageBits_def mask_zero)
-   apply (clarsimp simp: aag_cap_auth_def pas_refined_refl)
-   apply (drule_tac x=frame in bspec)
-    apply (simp add: is_aligned_no_overflow)
-   apply (clarsimp simp: pas_refined_refl cap_links_asid_slot_def
-                         label_owns_asid_slot_def cap_links_irq_def)
-  apply (fastforce dest: cte_wp_at_valid_objs_valid_cap simp: valid_cap_def cap_aligned_def)
-  done
-
-lemma set_asid_pool_respects:
-  "\<lbrace>integrity aag X st and K (is_subject aag ptr)\<rbrace>
-     set_asid_pool ptr pool
-   \<lbrace>\<lambda>s. integrity aag X st\<rbrace>"
-  apply (simp add: set_asid_pool_def)
-  apply (wp get_object_wp set_object_integrity_autarch)
-  apply simp
-  done
-
-definition
-  authorised_asid_pool_inv :: "'a PAS \<Rightarrow> asid_pool_invocation \<Rightarrow> bool"
-where
- "authorised_asid_pool_inv aag api \<equiv> case api of
-     asid_pool_invocation.Assign asid pool_ptr ct_slot \<Rightarrow>
-       is_subject aag pool_ptr \<and> is_subject aag (fst ct_slot)
-          \<and> asid \<noteq> 0
-          \<and> (\<forall>asid'. asid_high_bits_of asid' = asid_high_bits_of asid \<and> asid' \<noteq> 0
-                     \<longrightarrow> is_subject_asid aag asid')"
-
-lemma perform_asid_pool_invocation_respects:
-  "\<lbrace>integrity aag X st and K (authorised_asid_pool_inv aag api)\<rbrace>
-     perform_asid_pool_invocation api
-   \<lbrace>\<lambda>s. integrity aag X st\<rbrace>"
-  apply (simp add: perform_asid_pool_invocation_def)
-  apply (rule hoare_pre)
-  apply (wp set_asid_pool_respects get_cap_wp set_cap_integrity_autarch
-       | wpc
-       | simp)+
-  apply (auto iff: authorised_asid_pool_inv_def)
-  done
-
-lemma is_subject_asid_into_loas:
-  "\<lbrakk> is_subject_asid aag asid; pas_refined aag s \<rbrakk> \<Longrightarrow> label_owns_asid_slot aag (pasSubject aag) asid"
-  unfolding label_owns_asid_slot_def
-  by (clarsimp simp: pas_refined_refl)
-
-lemma asid_pool_into_aag:
-  "\<lbrakk>kheap s p = Some (ArchObj (arch_kernel_obj.ASIDPool pool)); pool r = Some p'; pas_refined aag s \<rbrakk>
-  \<Longrightarrow> (pasObjectAbs aag p, Control, pasObjectAbs aag p') \<in> pasPolicy aag"
-  apply (rule pas_refined_mem [rotated], assumption)
-  apply (rule sta_vref)
-  apply (fastforce simp add: state_vrefs_def vs_refs_no_global_pts_def intro!: graph_ofI)
-  done
-
-lemma asid_pool_uniqueness:
-  "\<lbrakk> ([VSRef (ucast (asid_high_bits_of asid)) None] \<rhd> p) s;
-      arm_asid_table (arch_state s) (asid_high_bits_of asid') = Some p;
-       invs s; \<forall>pt. \<not> ko_at (ArchObj (PageTable pt)) p s \<rbrakk>
-      \<Longrightarrow> asid_high_bits_of asid' = asid_high_bits_of asid"
-  apply (drule valid_vs_lookupD[OF vs_lookup_pages_vs_lookupI], clarsimp)
-  apply (drule vs_lookup_atI, drule valid_vs_lookupD[OF vs_lookup_pages_vs_lookupI], clarsimp)
-  apply (clarsimp dest!: obj_ref_elemD)
-  apply (drule(1) unique_table_refsD[where cps="caps_of_state s", rotated])
+  apply (wpsimp wp: gets_the_wp get_wp put_wp mapM_x_wp'
+                    store_word_offs_integrity_autarch[where thread=thread]
+              simp: split_def zipWithM_x_mapM_x split_del: if_split)+
+     apply (clarsimp elim!: in_set_zipE split: if_split_asm)
+     apply (rule order_le_less_trans[where y=msg_max_length])
+      apply (fastforce simp add: le_eq_less_or_eq)
+     apply (simp add: msg_max_length_def msg_align_bits' word_size_bits_def)
     apply simp
-   apply (clarsimp simp: vs_cap_ref_def table_cap_ref_def up_ucast_inj_eq
-                  split: vmpage_size.splits option.splits cap.splits arch_cap.splits)+
-  done
-
-lemma perform_asid_pool_invocation_pas_refined [wp]:
-  "\<lbrace>pas_refined aag and invs and valid_apinv api and K (authorised_asid_pool_inv aag api)\<rbrace>
-     perform_asid_pool_invocation api
-   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  apply (simp add: perform_asid_pool_invocation_def)
-  apply (rule hoare_pre)
-  apply (wp get_cap_auth_wp[where aag = aag] set_cap_pas_refined_not_transferable | wpc)+
-  apply (clarsimp simp: authorised_asid_pool_inv_def cap_links_asid_slot_def
-                        is_subject_asid_into_loas aag_cap_auth_def)
-  apply (clarsimp simp: cap_auth_conferred_def is_cap_simps is_page_cap_def auth_graph_map_mem
-                        pas_refined_all_auth_is_owns pas_refined_refl cli_no_irqs
-                        cte_wp_at_caps_of_state
-                 dest!: graph_ofD)
-  apply (clarsimp split: if_split_asm)
-   apply (clarsimp simp add: pas_refined_refl auth_graph_map_def2
-                             mask_asid_low_bits_ucast_ucast[symmetric]
-                             valid_apinv_def obj_at_def)
-   apply (drule(2) asid_pool_uniqueness)
-    apply (simp add: obj_at_def)
-   apply (case_tac "asid = 0"; simp add: pas_refined_refl)
-   apply (simp add: asid_low_high_bits[rotated, OF arg_cong[where f=ucast]])
-  apply (clarsimp simp: obj_at_def)
-  apply (frule (2) asid_pool_into_aag)
-  apply (drule kheap_eq_state_vrefsD)
-  apply (clarsimp simp: auth_graph_map_def2 pas_refined_refl)
-  apply (clarsimp simp: pas_refined_def vs_refs_no_global_pts_def)
-  apply (erule subsetD, erule state_asids_to_policy_aux.intros,
-         simp add: split_def, rule image_eqI[rotated], erule graph_ofI)
+    apply (wp set_object_integrity_autarch hoare_drop_imps hoare_vcg_all_lift)+
   apply simp
   done
-
-definition
-  authorised_page_directory_inv :: "'a PAS \<Rightarrow> page_directory_invocation \<Rightarrow> bool"
-where
-  "authorised_page_directory_inv aag pdi \<equiv> True"
-
-definition
-  authorised_arch_inv :: "'a PAS \<Rightarrow> arch_invocation \<Rightarrow> bool"
-where
- "authorised_arch_inv aag ai \<equiv> case ai of
-     InvokePageTable pti \<Rightarrow> authorised_page_table_inv aag pti
-   | InvokePageDirectory pdi \<Rightarrow> authorised_page_directory_inv aag pdi
-   | InvokePage pgi \<Rightarrow> authorised_page_inv aag pgi
-   | InvokeASIDControl aci \<Rightarrow> authorised_asid_control_inv aag aci
-   | InvokeASIDPool api \<Rightarrow> authorised_asid_pool_inv aag api"
-
-crunch respects [wp]: perform_page_directory_invocation "integrity aag X st"
-  (ignore: do_machine_op)
-
-lemma invoke_arch_respects:
-  "\<lbrace>integrity aag X st and K (authorised_arch_inv aag ai) and
-    pas_refined aag and invs and valid_arch_inv ai and is_subject aag \<circ> cur_thread\<rbrace>
-     arch_perform_invocation ai
-   \<lbrace>\<lambda>s. integrity aag X st\<rbrace>"
-  apply (simp add: arch_perform_invocation_def)
-  apply (rule hoare_pre)
-  apply (wp perform_page_table_invocation_respects perform_page_invocation_respects
-           perform_asid_control_invocation_respects perform_asid_pool_invocation_respects
-       | wpc)+
-  apply (auto simp: authorised_arch_inv_def valid_arch_inv_def)
-  done
-
-crunch pas_refined [wp]: perform_page_directory_invocation "pas_refined aag"
-
-lemma invoke_arch_pas_refined:
-  "\<lbrace>pas_refined aag and pas_cur_domain aag and invs and ct_active and valid_arch_inv ai and K (authorised_arch_inv aag ai)\<rbrace>
-     arch_perform_invocation ai
-   \<lbrace>\<lambda>s. pas_refined aag\<rbrace>"
-  apply (simp add: arch_perform_invocation_def valid_arch_inv_def)
-  apply (rule hoare_pre)
-  apply (wp | wpc)+
-  apply (fastforce simp add: authorised_arch_inv_def)
-  done
-
-lemma create_mapping_entries_authorised_slots [wp]:
-  "\<lbrace>\<exists>\<rhd> pd and invs and pas_refined aag
-    and K (is_subject aag pd
-           \<and> is_aligned pd pd_bits
-           \<and> vmsz_aligned vptr vmpage_size
-           \<and> vptr < kernel_base
-           \<and> (\<forall>a\<in>vspace_cap_rights_to_auth rights.
-                  \<forall>p\<in>ptr_range (ptrFromPAddr base) (pageBitsForSize vmpage_size).
-                      aag_has_auth_to aag a p))\<rbrace>
-    create_mapping_entries base vptr vmpage_size rights attrib pd
-  \<lbrace>\<lambda>rv s. authorised_slots aag rv\<rbrace>, -"
-  unfolding authorised_slots_def
-  apply (rule hoare_gen_asmE)
-  apply (cases vmpage_size)
-     apply (wp lookup_pt_slot_authorised
-                 | simp add: pte_ref_simps | fold validE_R_def)+
-     apply (auto simp: pd_bits_def pageBits_def)[1]
-    apply (wp lookup_pt_slot_authorised2
-          | simp add: pte_ref_simps largePagePTE_offsets_def
-          | fold validE_R_def)+
-    apply (auto simp: pd_bits_def pageBits_def vmsz_aligned_def)[1]
-   apply (wp | simp)+
-   apply (auto simp: pde_ref2_def lookup_pd_slot_pd)[1]
-  apply (wp | simp add: superSectionPDE_offsets_def)+
-  apply (auto simp: pde_ref2_def vmsz_aligned_def lookup_pd_slot_add_eq)
-  done
-
-lemma x_t2n_sub_1_neg_mask:
-  "\<lbrakk> is_aligned x n; n \<le> m \<rbrakk>
-     \<Longrightarrow> x + 2 ^ n - 1 && ~~ mask m = x && ~~ mask m"
-  apply (erule is_aligned_get_word_bits)
-   apply (rule trans, rule mask_lower_twice[symmetric], assumption)
-   apply (subst add_diff_eq[symmetric], subst is_aligned_add_helper, assumption)
-    apply simp+
-  apply (simp add: mask_def power_overflow)
-  done
-
-lemma pageBitsForSize_le_t28:
-  "pageBitsForSize sz \<le> 28"
-  by (cases sz, simp_all)
-
-lemma pageBitsForSize_le_t29:
-  "pageBitsForSize sz \<le> 29"
-  by (cases sz, simp_all)
-
-lemmas vmsz_aligned_t2n_neg_mask
-    = x_t2n_sub_1_neg_mask[OF _ pageBitsForSize_le_t29, folded vmsz_aligned_def]
-
-lemma decode_arch_invocation_authorised:
-  "\<lbrace>invs and pas_refined aag
-        and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot
-        and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)
-        and K (\<forall>(cap, slot) \<in> {(cap.ArchObjectCap cap, slot)} \<union> set excaps.
-                      aag_cap_auth aag (pasObjectAbs aag (fst slot)) cap \<and> is_subject aag (fst slot)
-                   \<and> (\<forall>v \<in> cap_asid' cap. is_subject_asid aag v))\<rbrace>
-     arch_decode_invocation label msg x_slot slot cap excaps
-   \<lbrace>\<lambda>rv s. authorised_arch_inv aag rv\<rbrace>,-"
-  unfolding arch_decode_invocation_def authorised_arch_inv_def aag_cap_auth_def
-  apply (rule hoare_pre)
-   apply (simp add: split_def Let_def
-     cong: cap.case_cong arch_cap.case_cong if_cong option.case_cong split del: if_split)
-
-   apply (wp select_wp whenE_throwError_wp check_vp_wpR
-             find_pd_for_asid_authority2
-           | wpc
-           | simp add: authorised_asid_control_inv_def authorised_page_inv_def
-                       authorised_page_directory_inv_def
-                  del: hoare_True_E_R
-                  split del: if_split)+
-  apply (clarsimp simp: authorised_asid_pool_inv_def authorised_page_table_inv_def
-                        neq_Nil_conv invs_psp_aligned invs_vspace_objs cli_no_irqs)
-  apply (drule cte_wp_valid_cap, clarsimp+)
-  apply (cases cap; simp)
-      \<comment> \<open>asid pool\<close>
-     apply (find_goal \<open>match premises in "cap = ASIDPoolCap _ _" \<Rightarrow> succeed\<close>)
-     subgoal for s obj_ref asid
-       by (clarsimp simp: cap_auth_conferred_def is_page_cap_def
-                          pas_refined_all_auth_is_owns asid_high_bits_of_add_ucast
-                          valid_cap_simps)
-     \<comment> \<open>ControlCap\<close>
-    apply (find_goal \<open>match premises in "cap = ASIDControlCap" \<Rightarrow> succeed\<close>)
-    subgoal
-      apply (clarsimp simp: neq_Nil_conv split_def valid_cap_simps)
-      apply (cases excaps, solves simp)
-      apply (clarsimp simp: neq_Nil_conv aag_has_auth_to_Control_eq_owns)
-      apply (drule cte_wp_at_valid_objs_valid_cap, clarsimp)
-      apply (clarsimp simp: valid_cap_def cap_aligned_def)
-      apply (clarsimp simp: is_cap_simps cap_auth_conferred_def
-                            pas_refined_all_auth_is_owns aag_cap_auth_def)
-      done
-   \<comment> \<open>PageCap\<close>
-   apply (find_goal \<open>match premises in "cap = PageCap _ _ _ _ _" \<Rightarrow> succeed\<close>)
-   subgoal for s is_dev obj_ref cap_rights vmpage_size mapping
-     apply (clarsimp simp: valid_cap_simps cli_no_irqs)
-     apply (cases "invocation_type label"; (solves \<open>simp\<close>)?)
-     apply (find_goal \<open>match premises in "_ = ArchInvocationLabel _" \<Rightarrow> succeed\<close>)
-     apply (rename_tac archlabel)
-     apply (case_tac archlabel; (solves \<open>simp\<close>)?)
-       \<comment> \<open>Map\<close>
-      apply (find_goal \<open>match premises in "_ = ARMPageMap" \<Rightarrow> succeed\<close>)
-      subgoal
-       apply (clarsimp simp: cap_auth_conferred_def is_cap_simps is_page_cap_def
-                             pas_refined_all_auth_is_owns)
-       apply (rule conjI)
-        apply (clarsimp simp: cap_auth_conferred_def is_page_cap_def pas_refined_all_auth_is_owns
-                              aag_cap_auth_def cli_no_irqs cap_links_asid_slot_def)
-        apply (simp only: linorder_not_le kernel_base_less_observation
-                          vmsz_aligned_t2n_neg_mask simp_thms)
-        apply (clarsimp simp: cap_auth_conferred_def vspace_cap_rights_to_auth_def
-                              mask_vm_rights_def validate_vm_rights_def vm_read_only_def
-                              vm_kernel_only_def)
-       apply (clarsimp simp: cap_auth_conferred_def is_cap_simps is_page_cap_def
-                             pas_refined_all_auth_is_owns)
-       apply (rule conjI)
-        apply (clarsimp simp: cap_auth_conferred_def is_page_cap_def pas_refined_all_auth_is_owns
-                              aag_cap_auth_def cli_no_irqs cap_links_asid_slot_def)
-       apply (clarsimp simp: cap_auth_conferred_def vspace_cap_rights_to_auth_def
-                             mask_vm_rights_def validate_vm_rights_def vm_read_only_def
-                             vm_kernel_only_def)
-       done
-     \<comment> \<open>Unmap\<close>
-     subgoal by (simp add: aag_cap_auth_def cli_no_irqs)
-     done
-  \<comment> \<open>PageTableCap\<close>
-  apply (find_goal \<open>match premises in "cap = PageTableCap _ _" \<Rightarrow> succeed\<close>)
-  subgoal for s word option
-    apply (cases "invocation_type label"; (solves \<open>simp\<close>)?)
-    apply (find_goal \<open>match premises in "_ = ArchInvocationLabel _" \<Rightarrow> succeed\<close>)
-    apply (rename_tac archlabel)
-    apply (case_tac archlabel; (solves \<open>simp\<close>)?)
-     \<comment> \<open>PTMap\<close>
-     apply (find_goal \<open>match premises in "_ = ARMPageTableMap" \<Rightarrow> succeed\<close>)
-     apply (clarsimp simp: aag_cap_auth_def cli_no_irqs cap_links_asid_slot_def
-                           cap_auth_conferred_def is_page_cap_def
-                           pde_ref2_def pas_refined_all_auth_is_owns pas_refined_refl
-                           pd_shifting[folded pd_bits_14])
-    \<comment> \<open>Unmap\<close>
-    apply (find_goal \<open>match premises in "_ = ARMPageTableUnmap" \<Rightarrow> succeed\<close>)
-    subgoal
-      apply (clarsimp simp: aag_cap_auth_def cli_no_irqs cap_links_asid_slot_def
-                            cap_auth_conferred_def is_page_cap_def
-                            pde_ref2_def pas_refined_all_auth_is_owns pas_refined_refl)
-      apply (subgoal_tac "x && ~~ mask pt_bits = word")
-       apply simp
-      apply (clarsimp simp: valid_cap_simps cap_aligned_def split: if_split_asm)
-      apply (subst (asm) upto_enum_step_subtract)
-      apply (subgoal_tac "is_aligned word pt_bits")
-       apply (simp add: is_aligned_no_overflow)
-      apply (simp add: pt_bits_def pageBits_def)
-      apply simp
-      apply (subst (asm) upto_enum_step_red [where us = 2, simplified])
-      apply (simp add: pt_bits_def pageBits_def word_bits_conv)
-      apply (simp add: pt_bits_def pageBits_def word_bits_conv)
-      apply clarsimp
-      apply (subst is_aligned_add_helper)
-      apply (simp add: pt_bits_def pageBits_def)
-      apply (erule word_less_power_trans_ofnat [where k = 2, simplified])
-        apply (simp add: pt_bits_def pageBits_def)
-       apply (simp add: pt_bits_def pageBits_def word_bits_conv)
-      apply simp
-      done
-    done
-  done
-
-crunch pas_refined[wp]: invalidate_asid_entry "pas_refined aag"
-  (wp: crunch_wps simp: crunch_simps)
-
-crunch pas_refined[wp]: flush_space "pas_refined aag"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma delete_asid_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace> delete_asid asid pd \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (simp add: delete_asid_def)
-  apply (wp | wpc)+
-  apply (clarsimp simp add: split_def Ball_def obj_at_def)
-  apply (rule conjI)
-   apply (clarsimp dest!: auth_graph_map_memD graph_ofD)
-   apply (erule pas_refined_mem[OF sta_vref, rotated])
-   apply (fastforce simp: state_vrefs_def vs_refs_no_global_pts_def
-                         image_def graph_of_def split: if_split_asm)
-  apply (clarsimp simp: pas_refined_def dest!: graph_ofD)
-  apply (erule subsetD, erule state_asids_to_policy_aux.intros)
-  apply (fastforce simp: state_vrefs_def vs_refs_no_global_pts_def
-                        graph_of_def image_def split: if_split_asm)
-  done
-
-lemma delete_asid_pool_pas_refined [wp]:
-  "\<lbrace>pas_refined aag\<rbrace> delete_asid_pool param_a param_b \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  unfolding delete_asid_pool_def
-  apply (wp | wpc | simp)+
-  apply (rule_tac Q = "\<lambda>_ s. pas_refined aag s \<and> asid_table = arm_asid_table (arch_state s)" in hoare_post_imp)
-  apply clarsimp
-  apply (erule pas_refined_clear_asid)
-  apply (wp mapM_wp' | simp)+
-  done
-
-crunch respects[wp]: invalidate_asid_entry "integrity aag X st"
-
-crunch respects[wp]: flush_space "integrity aag X st"
-  (ignore: do_machine_op simp: invalidateLocalTLB_ASID_def cleanCaches_PoU_def dsb_def clean_D_PoU_def invalidate_I_PoU_def do_machine_op_bind)
-
-lemma delete_asid_pool_respects[wp]:
-  "\<lbrace> integrity aag X st and K (\<forall>asid'.
-            asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of x \<longrightarrow>
-            is_subject_asid aag asid')\<rbrace>
-   delete_asid_pool x y
-   \<lbrace> \<lambda>_. integrity aag X st \<rbrace>"
-  unfolding delete_asid_pool_def
-  apply simp
-  apply (wp mapM_wp[OF _ subset_refl] | simp)+
-  done
-
-
-lemma pas_refined_asid_mem:
-  "\<lbrakk> v \<in> state_asids_to_policy aag s; pas_refined aag s \<rbrakk>
-         \<Longrightarrow> v \<in> pasPolicy aag"
-  by (auto simp add: pas_refined_def)
-
-
-lemma set_asid_pool_respects_clear:
-  "\<lbrace>(\<lambda>s. \<forall>pool'. ko_at (ArchObj (arch_kernel_obj.ASIDPool pool')) ptr s
-              \<longrightarrow> asid_pool_integrity {pasSubject aag} aag pool' pool)
-            and integrity aag X st\<rbrace>
-     set_asid_pool ptr pool \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: set_asid_pool_def)
-  apply (wpsimp wp: set_object_wp_strong
-              simp: obj_at_def a_type_def
-             split: Structures_A.kernel_object.split_asm arch_kernel_obj.split_asm if_splits)
-  apply (erule integrity_trans)
-  apply (clarsimp simp: integrity_def)
-  apply (rule tro_asidpool_clear; simp add: asid_pool_integrity_def)
-  done
-
-lemma delete_asid_respects:
-  "\<lbrace>integrity aag X st and pas_refined aag and invs and K (is_subject aag pd)\<rbrace>
-     delete_asid asid pd
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  by (wpsimp wp: set_asid_pool_respects_clear hoare_vcg_all_lift
-           simp: obj_at_def pas_refined_refl delete_asid_def asid_pool_integrity_def)
 
 end
 

--- a/proof/access-control/CNode_AC.thy
+++ b/proof/access-control/CNode_AC.thy
@@ -1452,14 +1452,6 @@ lemma all_rsubst:
   "\<lbrakk> \<forall>v. P (f v); \<exists>v. f v = r \<rbrakk> \<Longrightarrow> P r"
   by clarsimp
 
-lemma ucast_ucast_mask_pt_bits:
-  "ucast (ucast (p && mask pt_bits >> 2) :: word8)
-     = (p :: word32) && mask pt_bits >> 2"
-  apply (simp add: ucast_ucast_mask shiftr_over_and_dist
-                   word_bw_assocs)
-  apply (simp add: mask_def pt_bits_def pageBits_def)
-  done
-
 lemma store_pte_st_vrefs[wp]:
   "\<lbrace>\<lambda>s. \<forall>S. P ((state_vrefs s) (p && ~~ mask pt_bits :=
           (state_vrefs s (p && ~~ mask pt_bits) - S) \<union>
@@ -1472,7 +1464,9 @@ lemma store_pte_st_vrefs[wp]:
   apply (simp add: fun_upd_def[symmetric] fun_upd_comp)
   apply (erule all_rsubst[where P=P])
   apply (subst fun_eq_iff, clarsimp simp: split_def)
-  apply (cases "pte_ref pte", auto simp: ucast_ucast_mask_pt_bits)
+  apply (cases "pte_ref pte")
+   apply (auto simp: ucast_ucast_mask shiftr_over_and_dist
+                     word_bw_assocs mask_def pt_bits_def pageBits_def)
   done
 
 lemma store_pte_thread_states[wp]:

--- a/proof/access-control/CNode_AC.thy
+++ b/proof/access-control/CNode_AC.thy
@@ -5,118 +5,147 @@
  *)
 
 theory CNode_AC
-imports Access
+imports ArchAccess_AC
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+section\<open>CNode-specific AC.\<close>
 
-declare arch_post_modify_registers_def[simp]
-declare arch_post_cap_deletion_def[simp]
-declare arch_cap_cleanup_opt_def[simp]
-declare arch_mask_irq_signal_def[simp]
-
-(* FIXME: arch-split *)
-lemmas post_cap_deletion_simps[simp] = post_cap_deletion_def[simplified arch_post_cap_deletion_def]
-                                       cap_cleanup_opt_def[simplified arch_cap_cleanup_opt_def]
 
 (* FIXME: Move. *)
 lemma tcb_domain_map_wellformed_ekheap[intro!, simp]:
   "ekheap (P s) = ekheap s \<Longrightarrow> tcb_domain_map_wellformed aag (P s) = tcb_domain_map_wellformed aag s"
-by (simp add: tcb_domain_map_wellformed_aux_def get_etcb_def)
-
-
-section\<open>CNode-specific AC.\<close>
-
-lemma set_original_integrity_autarch:
-  "\<lbrace>integrity aag X st and K (is_subject aag (fst slot))\<rbrace>
-      set_original slot orig \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: set_original_def)
-  apply wp
-  apply (simp add: integrity_def)
-  apply (clarsimp intro!: integrity_cdt_direct)
-  done
-
-lemma set_original_integrity:
-  "\<lbrace>integrity aag X st and cdt_change_allowed' aag slot\<rbrace>
-      set_original slot orig
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  by integrity_trans_start (wpsimp simp: set_original_def integrity_def)
-
-
-lemma update_cdt_fun_upd_integrity_autarch:
-  "\<lbrace>integrity aag X st and K (is_subject aag (fst slot))\<rbrace>
-      update_cdt (\<lambda>cdt. cdt (slot := v cdt)) \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: update_cdt_def set_cdt_def)
-  apply wp
-  apply (simp add: integrity_def)
-  apply (clarsimp intro!: integrity_cdt_direct)
-  done
+  by (simp add: tcb_domain_map_wellformed_aux_def get_etcb_def)
 
 (* FIXME: for some reason crunch does not discover the right precondition *)
 lemma set_cap_integrity_autarch:
   "\<lbrace>integrity aag X st and K (is_subject aag (fst slot))\<rbrace> set_cap cap slot \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  unfolding set_cap_def
-  apply (rule hoare_pre)
-   apply (wp set_object_integrity_autarch get_object_wp | wpc)+
-  apply clarsimp
-  done
+  by (wpsimp simp: set_cap_def wp: set_object_integrity_autarch get_object_wp)
 
 lemma integrity_cdt_list_as_list_integ:
   "cdt_list_integrity_state aag st s =
-       (list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st s)"
-  apply (rule iffI)
-  apply (fastforce elim!: integrity_cdt_listE  intro: list_integI)
-  apply (fastforce elim!:list_integE  intro: integrity_cdt_list_intros)
+   list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st s"
+  by (fastforce elim: integrity_cdt_listE list_integE intro: list_integI integrity_cdt_list_intros)
+
+crunches cap_swap_ext,cap_move_ext,empty_slot_ext
+  for ekheap[wp]: "\<lambda>s. P (ekheap s)"
+  and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
+
+crunches set_untyped_cap_as_full
+  for integrity_autarch: "integrity aag X st"
+
+
+locale CNode_AC_1 =
+  fixes aag :: "'a PAS"
+  and val_t :: "'b"
+  assumes sata_cdt_update[simp]:
+    "\<And>f. state_asids_to_policy aag (cdt_update f s) = state_asids_to_policy aag s"
+  and sata_is_original_cap_update[simp]:
+    "\<And>f. state_asids_to_policy aag (is_original_cap_update f s) = state_asids_to_policy aag s"
+  and sata_interrupt_states_update[simp]:
+    "\<And>f. state_asids_to_policy aag (interrupt_states_update f s) = state_asids_to_policy aag s"
+  and sata_machine_state_update[simp]:
+    "\<And>f. state_asids_to_policy aag (machine_state_update f s) = state_asids_to_policy aag s"
+  and sata_update:
+    "\<lbrakk> pas_wellformed aag; cap_links_asid_slot aag (pasObjectAbs aag (fst ptr)) cap;
+       state_asids_to_policy_arch aag (caps :: cslot_ptr \<Rightarrow> cap option) as vrefs \<subseteq> pasPolicy aag \<rbrakk>
+       \<Longrightarrow> state_asids_to_policy_arch aag (caps(ptr \<mapsto> cap)) as vrefs \<subseteq> pasPolicy aag"
+  and sata_update2:
+    "\<lbrakk> pas_wellformed aag; cap_links_asid_slot aag (pasObjectAbs aag (fst ptr)) cap;
+       cap_links_asid_slot aag (pasObjectAbs aag (fst ptr')) cap';
+       state_asids_to_policy_arch aag caps (as :: arch_state) vrefs \<subseteq> pasPolicy aag \<rbrakk>
+       \<Longrightarrow> state_asids_to_policy_arch aag (caps(ptr \<mapsto> cap, ptr' \<mapsto> cap')) as vrefs \<subseteq> pasPolicy aag"
+  and state_vrefs_tcb_upd:
+    "get_tcb tptr s = Some y \<Longrightarrow> state_vrefs (s\<lparr>kheap := kheap s(tptr \<mapsto> TCB tcb)\<rparr>) = state_vrefs s"
+  and state_vrefs_simple_type_upd:
+    "\<lbrakk> ko_at ko p s; is_simple_type ko; a_type ko = a_type (f (val :: 'b)) \<rbrakk>
+       \<Longrightarrow> state_vrefs (s\<lparr>kheap := kheap s(p \<mapsto> f val)\<rparr>) = state_vrefs s"
+  and a_type_arch_object_not_tcb[simp]:
+    "a_type (ArchObj arch_kernel_obj) \<noteq> ATCB"
+  and set_cap_state_vrefs[wp]:
+    "\<And>P. set_cap cap slot \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
+  and set_cdt_state_vrefs[wp]:
+    "\<And>P. set_cdt t \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
+  and set_cdt_state_asids_to_policy[wp]:
+    "\<And>P. set_cdt t \<lbrace>\<lambda>s. P (state_asids_to_policy aag s)\<rbrace>"
+  and arch_post_cap_deletion_integrity[wp]:
+    "arch_post_cap_deletion acap \<lbrace>integrity aag X st\<rbrace>"
+  and arch_post_cap_deletion_cur_domain[wp]:
+    "\<And>P. arch_post_cap_deletion acap \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  and arch_finalise_cap_cur_domain:
+    "\<And>P. arch_finalise_cap acap final \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  and prepare_thread_delete_cur_domain:
+    "\<And>P. prepare_thread_delete p \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  and maskInterrupt_underlying_memory[wp]:
+    "\<And>P. maskInterrupt m irq \<lbrace>\<lambda>s. P (underlying_memory s)\<rbrace>"
+  and maskInterrupt_device_state[wp]:
+    "\<And>P. maskInterrupt m irq \<lbrace>\<lambda>s. P (device_state s)\<rbrace>"
+  and cap_insert_ext_extended_list_integ_lift:
+    "\<And>Q a b c d e.
+     \<lbrakk> \<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
+       cap_insert_ext a b c d e
+       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace>;
+       \<And>P. cap_insert_ext a b c d e \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>; \<And>P. cap_insert_ext a b c d e \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace> \<rbrakk>
+       \<Longrightarrow> \<lbrace>integrity aag X st and Q\<rbrace> cap_insert_ext a b c d e \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  and cap_move_ext_list_integ_lift:
+    "\<And>Q a b c d.
+     \<lbrakk> \<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
+       cap_move_ext a b c d
+       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace>;
+       \<And>P. cap_move_ext a b c d \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>; \<And>P. cap_move_ext a b c d \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace> \<rbrakk>
+       \<Longrightarrow> \<lbrace>integrity aag X st and Q\<rbrace> cap_move_ext a b c d \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  and cap_swap_ext_extended_list_integ_lift:
+    "\<And>Q a b c d.
+     \<lbrakk> \<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
+       cap_swap_ext a b c d
+       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace>;
+       \<And>P. cap_swap_ext a b c d \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>; \<And>P. cap_swap_ext a b c d \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace> \<rbrakk>
+       \<Longrightarrow> \<lbrace>integrity aag X st and Q\<rbrace> cap_swap_ext a b c d \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  and empty_slot_extended_list_integ_lift:
+    "\<And>Q a b.
+     \<lbrakk> \<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
+       empty_slot_ext a b
+       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace>;
+       \<And>P. empty_slot_ext a b \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>; \<And>P. empty_slot_ext a b \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace> \<rbrakk>
+       \<Longrightarrow> \<lbrace>integrity aag X st and Q\<rbrace> empty_slot_ext a b \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+begin
+
+lemma set_original_integrity_autarch:
+  "\<lbrace>integrity aag X st and K (is_subject aag (fst slot))\<rbrace>
+   set_original slot orig
+   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  apply (wpsimp simp: set_original_def)
+  apply (clarsimp simp: integrity_def intro!: integrity_cdt_direct)
   done
 
-end
-
-context is_extended begin
-
-interpretation Arch . (*FIXME: arch_split*)
-
-lemma list_integ_lift:
-  assumes li:
-   "\<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
-       f
-    \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag}  (cdt st) (tcb_states_of_state st)) st\<rbrace>"
-  assumes ekh: "\<And>P. \<lbrace>\<lambda>s. P (ekheap s)\<rbrace> f \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
-  assumes rq: "\<And>P. \<lbrace> \<lambda>s. P (ready_queues s) \<rbrace> f \<lbrace> \<lambda>rv s. P (ready_queues s) \<rbrace>"
-  shows "\<lbrace>integrity aag X st and Q\<rbrace> f \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  apply (rule hoare_pre)
-   apply (unfold integrity_def[abs_def])
-   apply (simp only: integrity_cdt_list_as_list_integ)
-   apply (rule hoare_lift_Pf2[where f="ekheap"])
-    apply (simp add: tcb_states_of_state_def get_tcb_def)
-    apply (wp li[simplified tcb_states_of_state_def get_tcb_def] ekh rq)+
-  apply (simp only: integrity_cdt_list_as_list_integ)
-  apply (simp add: tcb_states_of_state_def get_tcb_def)
+lemma set_original_integrity:
+  "\<lbrace>integrity aag X st and cdt_change_allowed' aag slot\<rbrace>
+   set_original slot orig
+   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  apply integrity_trans_start
+  apply (wpsimp simp: set_original_def integrity_def)
   done
 
-end
-
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-crunch ekheap[wp]: cap_swap_ext,cap_move_ext,empty_slot_ext "\<lambda>s. P (ekheap s)"
-
-crunch ready_queues[wp]: cap_swap_ext,cap_move_ext,empty_slot_ext "\<lambda>s. P (ready_queues s)"
-
-crunch integrity_autarch: set_untyped_cap_as_full "integrity aag X st"
-  (simp: crunch_simps wp: crunch_wps update_cdt_fun_upd_integrity_autarch
-         cap_insert_ext_extended.list_integ_lift cap_insert_list_integrity
-   ignore:update_cdt)
+lemma update_cdt_fun_upd_integrity_autarch:
+  "\<lbrace>integrity aag X st and K (is_subject aag (fst slot))\<rbrace>
+   update_cdt (\<lambda>cdt. cdt (slot := v cdt))
+   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  apply (wpsimp simp: update_cdt_def set_cdt_def)
+  apply (clarsimp simp: integrity_def intro!: integrity_cdt_direct)
+  done
 
 lemma cap_insert_integrity_autarch:
-  "\<lbrace>integrity aag X st and
-     K (is_subject aag (fst src_slot) \<and> is_subject aag (fst dest_slot))\<rbrace>
+  "\<lbrace>integrity aag X st and K (is_subject aag (fst src_slot) \<and> is_subject aag (fst dest_slot))\<rbrace>
    cap_insert cap src_slot dest_slot
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  apply (simp add:cap_insert_def)
-  apply (wp set_original_integrity_autarch cap_insert_ext_extended.list_integ_lift
+  apply (simp add: cap_insert_def)
+  apply (wp set_original_integrity_autarch cap_insert_ext_extended_list_integ_lift
             cap_insert_list_integrity update_cdt_fun_upd_integrity_autarch gets_inv
             set_cap_integrity_autarch set_untyped_cap_as_full_integrity_autarch assert_inv)
   apply fastforce
   done
+
+end
+
 
 text\<open>
 
@@ -128,23 +157,22 @@ rewriting (the equivalent equalities) in the wp proofs.
 
 \<close>
 
-definition
-  authorised_cnode_inv :: "'a PAS \<Rightarrow> Invocations_A.cnode_invocation \<Rightarrow> 'z::state_ext state \<Rightarrow> bool"
-where
- "authorised_cnode_inv aag ci \<equiv> K (case ci of
-    InsertCall cap ptr ptr' \<Rightarrow> pasObjectAbs aag ` {fst ptr, fst ptr'} \<subseteq> {pasSubject aag}
-  | MoveCall cap ptr ptr' \<Rightarrow> pasObjectAbs aag ` {fst ptr, fst ptr'} \<subseteq> {pasSubject aag}
-  | RotateCall s_cap p_cap src pivot dest \<Rightarrow>
-                           pasObjectAbs aag ` {fst src, fst pivot, fst dest} \<subseteq> {pasSubject aag}
-  | SaveCall ptr \<Rightarrow> is_subject aag (fst ptr)
-  | DeleteCall ptr \<Rightarrow> is_subject aag (fst ptr)
-  | CancelBadgedSendsCall cap \<Rightarrow> pas_cap_cur_auth aag cap
-  | RevokeCall ptr \<Rightarrow> is_subject aag (fst ptr))"
+definition authorised_cnode_inv ::
+  "'a PAS \<Rightarrow> Invocations_A.cnode_invocation \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
+  "authorised_cnode_inv aag ci \<equiv> K (case ci of
+     InsertCall cap ptr ptr' \<Rightarrow> pasObjectAbs aag ` {fst ptr, fst ptr'} \<subseteq> {pasSubject aag}
+   | MoveCall cap ptr ptr' \<Rightarrow> pasObjectAbs aag ` {fst ptr, fst ptr'} \<subseteq> {pasSubject aag}
+   | RotateCall s_cap p_cap src pivot dest \<Rightarrow>
+       pasObjectAbs aag ` {fst src, fst pivot, fst dest} \<subseteq> {pasSubject aag}
+   | SaveCall ptr \<Rightarrow> is_subject aag (fst ptr)
+   | DeleteCall ptr \<Rightarrow> is_subject aag (fst ptr)
+   | CancelBadgedSendsCall cap \<Rightarrow> pas_cap_cur_auth aag cap
+   | RevokeCall ptr \<Rightarrow> is_subject aag (fst ptr))"
 
 lemma resolve_address_bits_authorised_aux:
   "s \<turnstile> \<lbrace>pas_refined aag and K (is_cnode_cap (fst (cap, cref))
                                \<longrightarrow> (\<forall>x \<in> obj_refs (fst (cap, cref)). is_subject aag x))\<rbrace>
-         resolve_address_bits (cap, cref)
+       resolve_address_bits (cap, cref)
        \<lbrace>\<lambda>rv s. is_subject aag (fst (fst rv))\<rbrace>, \<lbrace>\<lambda>rv. \<top>\<rbrace>"
 unfolding resolve_address_bits_def
 proof (induct arbitrary: s rule: resolve_address_bits'.induct)
@@ -156,7 +184,7 @@ proof (induct arbitrary: s rule: resolve_address_bits'.induct)
     apply (cases cap', simp_all add: P split del: if_split)
     apply (rule hoare_pre_spec_validE)
      apply (wp "1.hyps", (assumption | simp add: in_monad | rule conjI)+)
-          apply (wp get_cap_wp)+
+        apply (wp get_cap_wp)+
     apply (auto simp: cte_wp_at_caps_of_state is_cap_simps cap_auth_conferred_def
                 dest: caps_of_state_pasObjectAbs_eq)
     done
@@ -164,211 +192,136 @@ qed
 
 lemma resolve_address_bits_authorised[wp]:
   "\<lbrace>pas_refined aag and K (is_cnode_cap cap \<longrightarrow> (\<forall>x \<in> obj_refs cap. is_subject aag x))\<rbrace>
-    resolve_address_bits (cap, cref)
+   resolve_address_bits (cap, cref)
    \<lbrace>\<lambda>rv s. is_subject aag (fst (fst rv))\<rbrace>, -"
   apply (unfold validE_R_def)
   apply (rule hoare_pre)
-  apply (rule use_spec(2)[OF resolve_address_bits_authorised_aux])
+   apply (rule use_spec(2)[OF resolve_address_bits_authorised_aux])
   apply simp
   done
 
 lemma lookup_slot_for_cnode_op_authorised[wp]:
   "\<lbrace>pas_refined aag and K (is_cnode_cap croot \<longrightarrow> (\<forall>x \<in> obj_refs croot. is_subject aag x))\<rbrace>
-    lookup_slot_for_cnode_op is_source croot ptr depth
+   lookup_slot_for_cnode_op is_source croot ptr depth
    \<lbrace>\<lambda>rv s. is_subject aag (fst rv)\<rbrace>, -"
   apply (simp add: lookup_slot_for_cnode_op_def split del: if_split)
-  apply (rule hoare_pre)
   apply (wp whenE_throwError_wp hoare_drop_imps
-            resolve_address_bits_authorised[THEN hoare_post_imp_R[where Q'="\<lambda>x s. is_subject aag (fst (fst x))"]]
-       | wpc
-       | simp add: split_def authorised_cnode_inv_def split del: if_split
-              del: split_paired_All | clarsimp)+
+            resolve_address_bits_authorised
+              [THEN hoare_post_imp_R[where Q'="\<lambda>x s. is_subject aag (fst (fst x))"]]
+         | wpc | fastforce)+
   done
 
-(* MOVE *)
+(* FIXME MOVE *)
 lemma is_cnode_into_is_subject:
-  "\<lbrakk> pas_cap_cur_auth aag cap; pas_refined aag s \<rbrakk> \<Longrightarrow> is_cnode_cap cap \<longrightarrow> (\<forall>x\<in>obj_refs cap. is_subject aag x)"
+  "\<lbrakk> pas_cap_cur_auth aag cap; pas_refined aag s; is_cnode_cap cap \<rbrakk>
+     \<Longrightarrow> \<forall>x\<in>obj_refs cap. is_subject aag x"
   by (clarsimp simp: is_cap_simps cap_auth_conferred_def
                      pas_refined_all_auth_is_owns aag_cap_auth_def)
 
 lemma get_cap_prop_imp:
-  "\<lbrace>cte_wp_at (\<lambda>cap. P cap \<longrightarrow> Q cap) slot\<rbrace>
-       get_cap slot \<lbrace>\<lambda>rv s. P rv \<longrightarrow> cte_wp_at Q slot s\<rbrace>"
-  apply (wp get_cap_wp)
-  apply (clarsimp simp: cte_wp_at_caps_of_state)
-  done
+  "\<lbrace>cte_wp_at (\<lambda>cap. P cap \<longrightarrow> Q cap) slot\<rbrace> get_cap slot \<lbrace>\<lambda>rv s. P rv \<longrightarrow> cte_wp_at Q slot s\<rbrace>"
+  by (wpsimp wp: get_cap_wp simp: cte_wp_at_caps_of_state)
 
 lemma get_cap_prop_imp2:
   "\<lbrace>cte_wp_at (\<lambda>cap. P cap) slot\<rbrace> get_cap slot \<lbrace>\<lambda>rv s. P rv\<rbrace>"
-  apply (rule hoare_pre)
-   apply (wp get_cap_wp)
-  apply (clarsimp simp: cte_wp_at_def)
-  done
+  by (wpsimp wp: get_cap_wp simp: cte_wp_at_def)
 
 lemma get_cap_cur_auth:
-  "\<lbrace>pas_refined aag and cte_wp_at (\<lambda>_. True) slot and K (is_subject aag (fst slot))\<rbrace> get_cap slot \<lbrace>\<lambda>rv s. pas_cap_cur_auth aag rv\<rbrace>"
-  apply (rule hoare_pre)
-   apply (wp get_cap_wp)
+  "\<lbrace>pas_refined aag and cte_wp_at (\<lambda>_. True) slot and K (is_subject aag (fst slot))\<rbrace>
+   get_cap slot
+   \<lbrace>\<lambda>rv s. pas_cap_cur_auth aag rv\<rbrace>"
+  apply (wp get_cap_wp)
   apply (clarsimp simp: cte_wp_at_caps_of_state cap_cur_auth_caps_of_state)
   done
 
 lemma decode_cnode_inv_authorised:
-  "\<lbrace>pas_refined aag and invs and valid_cap cap and K (\<forall>c \<in> {cap} \<union> set excaps. pas_cap_cur_auth aag c)\<rbrace>
-     decode_cnode_invocation label args cap excaps
+  "\<lbrace>pas_refined aag and invs and valid_cap cap
+                    and K (\<forall>c \<in> {cap} \<union> set excaps. pas_cap_cur_auth aag c)\<rbrace>
+   decode_cnode_invocation label args cap excaps
    \<lbrace>\<lambda>rv s. authorised_cnode_inv aag rv s\<rbrace>,-"
-  apply (simp add: authorised_cnode_inv_def decode_cnode_invocation_def split_def whenE_def unlessE_def set_eq_iff
-                 cong: if_cong Invocations_A.cnode_invocation.case_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp hoare_vcg_all_lift hoare_vcg_const_imp_lift_R hoare_vcg_all_lift_R
-              lsfco_cte_at
-        | simp only: simp_thms if_simps fst_conv snd_conv Invocations_A.cnode_invocation.simps K_def
-        | wpc
-        | wp (once) get_cap_cur_auth)+
-  apply clarsimp
-  apply (frule is_cnode_into_is_subject [rotated], fastforce)
-  apply simp
-  apply (subgoal_tac "\<forall>n. n < length excaps \<longrightarrow> (is_cnode_cap (excaps ! n) \<longrightarrow> (\<forall>x\<in>obj_refs (excaps ! n). is_subject aag x))")
-   apply (frule spec [where x = 0])
-   apply (drule spec [where x = 1])
-   apply (clarsimp simp: invs_valid_objs)
-   apply (drule (1) mp [OF _ length_ineq_not_Nil(1)], erule (1) bspec) (* yuck *)
-  apply (rule allI, rule impI)
-  apply (rule is_cnode_into_is_subject)
-   apply fastforce
-  apply assumption
-  done
-
-lemma set_cap_state_vrefs[wp]:
-  "\<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace> set_cap cap ptr \<lbrace>\<lambda>rv s. P (state_vrefs s)\<rbrace>"
-  apply (simp add: set_cap_def split_def set_object_def)
-  apply (wp get_object_wp | wpc)+
-  apply (auto simp: obj_at_def state_vrefs_def
-             elim!: rsubst[where P=P, OF _ ext]
-             split: if_split_asm simp: vs_refs_no_global_pts_def)
+  apply (simp add: authorised_cnode_inv_def decode_cnode_invocation_def
+                   split_def whenE_def unlessE_def set_eq_iff
+             cong: if_cong Invocations_A.cnode_invocation.case_cong split del: if_split)
+   apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_const_imp_lift_R hoare_vcg_all_lift_R lsfco_cte_at
+               simp: simp_thms if_simps fst_conv snd_conv Invocations_A.cnode_invocation.simps K_def
+          | wp (once) get_cap_cur_auth)+
+  apply (subgoal_tac "\<forall>n. n < length excaps
+                          \<longrightarrow> (is_cnode_cap (excaps ! n)
+                               \<longrightarrow> (\<forall>x\<in>obj_refs (excaps ! n). is_subject aag x))")
+   apply (fastforce simp: invs_valid_objs is_cnode_into_is_subject)
+  apply (intro allI impI is_cnode_into_is_subject; fastforce)
   done
 
 lemma set_cap_thread_states[wp]:
-  "\<lbrace>\<lambda>s. P (thread_states s)\<rbrace> set_cap cap ptr \<lbrace>\<lambda>rv s. P (thread_states s)\<rbrace>"
-  apply (simp add: set_cap_def split_def set_object_def)
-  apply (wp get_object_wp | wpc)+
-  apply (clarsimp simp: obj_at_def | rule conjI
-           | erule rsubst[where P=P, OF _ ext]
-           | clarsimp simp: thread_states_def get_tcb_def tcb_states_of_state_def)+
+  "set_cap cap ptr \<lbrace>\<lambda>s. P (thread_states s)\<rbrace>"
+  apply (wpsimp wp: get_object_wp simp: set_cap_def split_def set_object_def)
+  apply (fastforce simp: obj_at_def get_tcb_def tcb_states_of_state_def
+                         thread_states_def rsubst[where P=P, OF _ ext])
   done
 
 lemma set_cap_tcb_states_of_state[wp]:
-  "\<lbrace> \<lambda>s. P (tcb_states_of_state s) \<rbrace> set_cap cap ptr \<lbrace> \<lambda>rv s. P (tcb_states_of_state s)\<rbrace>"
+  "set_cap cap ptr \<lbrace>\<lambda>s. P (tcb_states_of_state s)\<rbrace>"
   apply (simp add: set_cap_def split_def set_object_def)
-  apply (wp get_object_wp | wpc)+
-  apply (clarsimp simp: obj_at_def get_tcb_def tcb_states_of_state_def | rule conjI
-           | erule rsubst[where P=P, OF _ ext])+
+  apply (wpsimp wp: get_object_wp)
+  apply (fastforce simp: obj_at_def get_tcb_def tcb_states_of_state_def rsubst[where P=P, OF _ ext])
   done
 
 lemma set_cap_thread_bound_ntfns[wp]:
-  "\<lbrace> \<lambda>s. P (thread_bound_ntfns s) \<rbrace> set_cap cap ptr \<lbrace> \<lambda>rv s. P (thread_bound_ntfns s)\<rbrace>"
-  apply (simp add: set_cap_def split_def set_object_def)
-  apply (wp get_object_wp | wpc)+
-  apply (clarsimp simp: obj_at_def get_tcb_def thread_bound_ntfns_def | rule conjI
-           | erule rsubst[where P=P, OF _ ext])+
+  "set_cap cap ptr \<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace>"
+  apply (wpsimp wp: get_object_wp simp: set_cap_def split_def set_object_def)
+  apply (fastforce simp: obj_at_def get_tcb_def thread_bound_ntfns_def rsubst[where P=P, OF _ ext])
   done
 
 lemma sita_caps_update:
-  "\<lbrakk> pas_wellformed aag;
-    state_irqs_to_policy_aux aag caps \<subseteq> pasPolicy aag;
-    cap_links_irq aag (pasObjectAbs aag (fst ptr)) cap \<rbrakk> \<Longrightarrow>
-    state_irqs_to_policy_aux aag (caps(ptr \<mapsto> cap))  \<subseteq> pasPolicy aag"
-  apply clarsimp
-  apply (erule state_irqs_to_policy_aux.cases)
-  apply (fastforce intro: state_irqs_to_policy_aux.intros simp: cap_links_irq_def split: if_split_asm)+
-  done
+  "\<lbrakk> pas_wellformed aag; state_irqs_to_policy_aux aag caps \<subseteq> pasPolicy aag;
+     cap_links_irq aag (pasObjectAbs aag (fst ptr)) cap \<rbrakk>
+     \<Longrightarrow> state_irqs_to_policy_aux aag (caps(ptr \<mapsto> cap)) \<subseteq> pasPolicy aag"
+  by (fastforce intro: state_irqs_to_policy_aux.intros
+                 elim: state_irqs_to_policy_aux.cases
+                 simp: cap_links_irq_def split: if_splits)
 
 lemma sita_caps_update2:
-  "\<lbrakk> pas_wellformed aag;
-    state_irqs_to_policy_aux aag caps \<subseteq> pasPolicy aag;
-    cap_links_irq aag (pasObjectAbs aag (fst ptr')) cap';
-    cap_links_irq aag (pasObjectAbs aag (fst ptr)) cap \<rbrakk> \<Longrightarrow>
-    state_irqs_to_policy_aux aag (caps(ptr \<mapsto> cap, ptr' \<mapsto> cap'))  \<subseteq> pasPolicy aag"
-  apply clarsimp
-  apply (erule state_irqs_to_policy_aux.cases)
-  apply (fastforce intro: state_irqs_to_policy_aux.intros simp: cap_links_irq_def split: if_split_asm)+
-  done
+  "\<lbrakk> pas_wellformed aag; state_irqs_to_policy_aux aag caps \<subseteq> pasPolicy aag;
+     cap_links_irq aag (pasObjectAbs aag (fst ptr')) cap';
+     cap_links_irq aag (pasObjectAbs aag (fst ptr)) cap \<rbrakk>
+     \<Longrightarrow> state_irqs_to_policy_aux aag (caps(ptr \<mapsto> cap, ptr' \<mapsto> cap')) \<subseteq> pasPolicy aag"
+  by (fastforce intro: state_irqs_to_policy_aux.intros
+                 elim: state_irqs_to_policy_aux.cases
+                 simp: cap_links_irq_def split: if_splits)
 
-lemma sata_update:
-  "\<lbrakk> pas_wellformed aag;
-     state_asids_to_policy_aux aag (caps_of_state s) asid_tab vrefs \<subseteq> pasPolicy aag;
-     cap_links_asid_slot aag (pasObjectAbs aag (fst ptr)) cap \<rbrakk> \<Longrightarrow>
-     state_asids_to_policy_aux aag ((caps_of_state s) (ptr \<mapsto> cap)) asid_tab vrefs \<subseteq> pasPolicy aag"
-  apply clarsimp
-  apply (erule state_asids_to_policy_aux.cases)
-  apply (fastforce intro: state_asids_to_policy_aux.intros simp: cap_links_asid_slot_def label_owns_asid_slot_def split: if_split_asm)+
-  done
 
-lemma sata_update2:
-  "\<lbrakk> pas_wellformed aag;
-     state_asids_to_policy_aux aag (caps_of_state s) asid_tab vrefs \<subseteq> pasPolicy aag;
-     cap_links_asid_slot aag (pasObjectAbs aag (fst ptr)) cap ;
-     cap_links_asid_slot aag (pasObjectAbs aag (fst ptr')) cap' \<rbrakk> \<Longrightarrow>
-     state_asids_to_policy_aux aag ((caps_of_state s) (ptr \<mapsto> cap,ptr' \<mapsto> cap')) asid_tab vrefs \<subseteq> pasPolicy aag"
-  apply clarsimp
-  apply (erule state_asids_to_policy_aux.cases)
-  apply (fastforce intro: state_asids_to_policy_aux.intros simp: cap_links_asid_slot_def label_owns_asid_slot_def split: if_split_asm)+
-  done
-
-lemma cli_caps_of_state:
-  "\<lbrakk> caps_of_state s slot = Some cap; pas_refined aag s \<rbrakk> \<Longrightarrow> cap_links_irq aag (pasObjectAbs aag (fst slot)) cap"
-apply (clarsimp simp add: cap_links_irq_def pas_refined_def)
-apply (blast dest: state_irqs_to_policy_aux.intros)
-done
-
-lemma set_object_caps_of_state:
-  "\<lbrace>(\<lambda>s. \<not>(tcb_at p s) \<and> \<not>(\<exists>n. cap_table_at n p s)) and
-    K ((\<forall>x y. obj \<noteq> CNode x y) \<and> (\<forall>x. obj \<noteq> TCB x)) and
-    (\<lambda>s. P (caps_of_state s))\<rbrace>
-   set_object p obj
-   \<lbrace>\<lambda>_ s. P (caps_of_state s)\<rbrace>"
-  apply (wpsimp wp: set_object_wp)
-  apply (erule rsubst[where P=P])
-  apply (rule ext)
-  apply (simp add: caps_of_state_cte_wp_at obj_at_def is_cap_table_def
-                   is_tcb_def)
-  apply (auto simp: cte_wp_at_cases)
-  done
-
-lemma set_object_domains_of_state[wp]:
-  "\<lbrace> \<lambda>s. P (domains_of_state s) \<rbrace> set_object a b \<lbrace> \<lambda>_ s. P (domains_of_state s) \<rbrace>"
-  by (wpsimp wp: set_object_wp)
+context CNode_AC_1 begin
 
 lemma set_cap_pas_refined:
-  "\<lbrace>pas_refined aag and (\<lambda>s. (is_transferable_in ptr s \<and> (\<not> Option.is_none (cdt s ptr)))
-          \<longrightarrow> is_transferable_cap cap
-            \<or> (pasObjectAbs aag (fst $ the $ cdt s ptr), Control, pasObjectAbs aag (fst ptr))
-                                                                                    \<in> pasPolicy aag)
-         and K (aag_cap_auth aag (pasObjectAbs aag (fst ptr)) cap)\<rbrace>
-      set_cap cap ptr
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and
+    (\<lambda>s. (is_transferable_in ptr s \<and> (\<not> Option.is_none (cdt s ptr)))
+          \<longrightarrow> is_transferable_cap cap \<or>
+              abs_has_auth_to aag Control (fst $ the $ cdt s ptr) (fst ptr)) and
+    K (aag_cap_auth aag (pasObjectAbs aag (fst ptr)) cap)\<rbrace>
+   set_cap cap ptr
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def aag_cap_auth_def)
   apply (rule hoare_pre)
-   apply (wp set_cap_caps_of_state| wps)+
+   apply (wp set_cap_caps_of_state  | wps)+
   apply clarsimp
   apply (intro conjI)  \<comment> \<open>auth_graph_map\<close>
-   apply (clarsimp dest!: auth_graph_map_memD)
-   apply (erule state_bits_to_policy.cases;
-          solves\<open>auto simp: cap_links_asid_slot_def label_owns_asid_slot_def
-                     intro: auth_graph_map_memI state_bits_to_policy.intros
-                     split: if_split_asm\<close>)
-  apply (erule (2) sata_update[unfolded fun_upd_def])
+    apply (clarsimp dest!: auth_graph_map_memD)
+    apply (erule state_bits_to_policy.cases;
+           solves\<open>auto simp: cap_links_asid_slot_def label_owns_asid_slot_def
+                      intro: auth_graph_map_memI state_bits_to_policy.intros
+                      split: if_split_asm\<close>)
+   apply (erule (2) sata_update[unfolded fun_upd_def])
   apply (erule (2) sita_caps_update[unfolded fun_upd_def])
   done
 
 lemma set_cap_pas_refined_not_transferable:
   "\<lbrace>pas_refined aag and cte_wp_at (\<lambda>c. \<not>is_transferable (Some c)) ptr
-       and K (aag_cap_auth aag (pasObjectAbs aag (fst ptr)) cap)\<rbrace>
-      set_cap cap ptr
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (rule hoare_pre)
-  apply (rule set_cap_pas_refined)
-  by (fastforce simp: cte_wp_at_caps_of_state)
+                    and K (aag_cap_auth aag (pasObjectAbs aag (fst ptr)) cap)\<rbrace>
+   set_cap cap ptr
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  by (wpsimp wp: set_cap_pas_refined simp: cte_wp_at_caps_of_state)
 
+end
 
 
 (* FIXME MOVE *)
@@ -377,62 +330,57 @@ lemma parent_ofI[intro!]: "m x = Some src \<Longrightarrow> m \<Turnstile> src \
 
 declare set_original_wp[wp del]
 
+
+context CNode_AC_1 begin
+
 lemma cap_move_respects[wp]:
-  "\<lbrace>integrity aag X st and pas_refined aag and  K (is_subject aag (fst dest) \<and> is_subject aag (fst src))\<rbrace>
-       cap_move cap src dest \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (rule hoare_gen_asm) apply (elim conjE)
-  apply (simp add: cap_move_def)
-  apply (rule hoare_pre)
-   apply (wp add: get_cap_wp set_cap_integrity_autarch set_original_integrity_autarch
-             cap_move_ext.list_integ_lift[where Q="\<top>"] cap_move_list_integrity
-             | simp add: set_cdt_def split del: if_split | blast)+
+  "\<lbrace>integrity aag X st and pas_refined aag
+                       and K (is_subject aag (fst dest) \<and> is_subject aag (fst src))\<rbrace>
+   cap_move cap src dest
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (clarsimp simp: cap_move_def)
+   apply (wpsimp wp: get_cap_wp set_cap_integrity_autarch set_original_integrity_autarch
+                     cap_move_ext_list_integ_lift[where Q="\<top>"] cap_move_list_integrity
+               simp: set_cdt_def | blast)+
     apply (rule wp_integrity_clean')
-     apply (simp add: integrity_def del:split_paired_All)
-     apply (simp add:integrity_cdt_def) apply (blast intro: cca_owned)
-    apply (wp set_cap_integrity_autarch| simp)+
+     apply (simp add: integrity_def integrity_cdt_def)
+     apply (blast intro: cca_owned)
+    apply (wpsimp wp: set_cap_integrity_autarch)+
   done
 
-lemma integrity_cdt_fun_upd:
-  "\<lbrakk> integrity aag X st (cdt_update f s); is_subject aag (fst slot) \<rbrakk>
-       \<Longrightarrow> integrity aag X st (cdt_update (\<lambda>cdt. (f cdt) (slot := v cdt)) s)"
-  apply (simp add: integrity_def integrity_cdt_def del:split_paired_All)
-  oops
-
 lemma cap_swap_respects[wp]:
-  "\<lbrace>integrity aag X st and pas_refined aag and
-               K (is_subject aag (fst slot) \<and> is_subject aag (fst slot'))\<rbrace>
-       cap_swap cap slot cap' slot' \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag
+                       and K (is_subject aag (fst slot) \<and> is_subject aag (fst slot'))\<rbrace>
+   cap_swap cap slot cap' slot'
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
-  apply (simp add: cap_swap_def)
-  apply (wp get_cap_wp set_cap_integrity_autarch
-            cap_swap_ext_extended.list_integ_lift[where Q="\<top>"] cap_swap_list_integrity
+  apply (clarsimp simp: cap_swap_def)
+  apply (wp get_cap_wp set_cap_integrity_autarch cap_swap_list_integrity
+            cap_swap_ext_extended_list_integ_lift[where Q="\<top>"]
             set_original_integrity_autarch[unfolded pred_conj_def K_def]
          | simp add: set_cdt_def split del: if_split | blast)+
     apply (rule wp_integrity_clean')
-     (* 5s clarsimp *)
-     apply (clarsimp simp add: integrity_def)
+     apply (simp add: integrity_def)
      apply (blast intro: cca_owned)
-    apply (wp set_cap_integrity_autarch set_cap_pas_refined
-           | simp | simp_all)+
+    apply (wpsimp wp: set_cap_integrity_autarch set_cap_pas_refined)+
   done
 
 lemma cap_swap_for_delete_respects[wp]:
   "\<lbrace>integrity aag X st and pas_refined aag
-            and K (is_subject aag (fst slot) \<and> is_subject aag (fst slot'))\<rbrace>
-      cap_swap_for_delete slot slot'
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: cap_swap_for_delete_def)
-  apply (wp | simp)+
-  done
+                       and K (is_subject aag (fst slot) \<and> is_subject aag (fst slot'))\<rbrace>
+   cap_swap_for_delete slot slot'
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  by (wpsimp simp: cap_swap_for_delete_def)
 
 lemma dmo_no_mem_respects:
-  assumes p: "\<And>P. \<lbrace>\<lambda>ms. P (underlying_memory ms)\<rbrace> mop \<lbrace>\<lambda>_ ms. P (underlying_memory ms)\<rbrace>"
-  assumes q: "\<And>P. \<lbrace>\<lambda>ms. P (device_state ms)\<rbrace> mop \<lbrace>\<lambda>_ ms. P (device_state ms)\<rbrace>"
-  shows "\<lbrace>integrity aag X st\<rbrace> do_machine_op mop \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  assumes p: "\<And>P. mop \<lbrace>\<lambda>ms. P (underlying_memory ms)\<rbrace>"
+  assumes q: "\<And>P. mop \<lbrace>\<lambda>ms. P (device_state ms)\<rbrace>"
+  shows "do_machine_op mop \<lbrace>integrity aag X st\<rbrace>"
   unfolding do_machine_op_def
   apply (rule hoare_pre)
-  apply (simp add: split_def)
-  apply (wp )
+   apply (simp add: split_def)
+   apply wp
   apply (clarsimp simp: integrity_def)
   apply (rule conjI)
    apply clarsimp
@@ -443,120 +391,163 @@ lemma dmo_no_mem_respects:
   apply (erule (1) use_valid [OF _ q])
   done
 
+lemma set_irq_state_respects[wp]:
+  "\<lbrace>integrity aag X st and K (is_subject_irq aag irq)\<rbrace>
+   set_irq_state irqst irq
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  unfolding set_irq_state_def
+  by (wpsimp wp: dmo_no_mem_respects simp: integrity_subjects_def integrity_interrupts_def)
+
+end
+
+
 (* FIXME: MOVE *)
 (* Only works after a hoare_pre! *)
 lemma dmo_wp:
   assumes mopv: "\<And>s. \<lbrace>P s\<rbrace> mop \<lbrace>\<lambda>a b. R a (s\<lparr>machine_state := b\<rparr>)\<rbrace>"
   shows "\<lbrace>\<lambda>s. P s (machine_state s)\<rbrace> do_machine_op mop \<lbrace>R\<rbrace>"
-  unfolding do_machine_op_def
-  apply (simp add: split_def)
-  apply (wp)
-  apply clarsimp
-  apply (erule use_valid [OF _ mopv])
-  apply simp
-  done
+  by (wpsimp simp: do_machine_op_def use_valid[OF _ mopv])
 
-lemma set_irq_state_respects[wp]:
-  "\<lbrace> integrity aag X st and K (is_subject_irq aag irq) \<rbrace>
-   set_irq_state irqst irq
-   \<lbrace> \<lambda>_. integrity aag X st \<rbrace>"
-  unfolding set_irq_state_def
-  apply (wp dmo_no_mem_respects | simp add: maskInterrupt_def)+
-  apply (clarsimp simp: integrity_subjects_def integrity_interrupts_def)
-  done
-
-crunch respects[wp]: deleted_irq_handler "integrity aag X st"
-
-lemmas cases_simp_options
-    = cases_simp_option cases_simp_option[where 'a="'b \<times> 'c", simplified]
+lemmas cases_simp_options = cases_simp_option cases_simp_option[where 'a="'b \<times> 'c", simplified]
 
 (* FIXME MOVE *)
 lemma cdt_change_allowed_all_children:
- "all_children (cdt_change_allowed aag subject (cdt s) (tcb_states_of_state s)) (cdt s)"
+  "all_children (cdt_change_allowed aag subject (cdt s) (tcb_states_of_state s)) (cdt s)"
   by (rule all_childrenI) (erule cdt_change_allowed_to_child)
 
-
-abbreviation cleanup_info_wf :: "cap \<Rightarrow> 'a PAS \<Rightarrow> bool"
-where
-  "cleanup_info_wf c aag \<equiv> c \<noteq> NullCap \<longrightarrow> (\<exists>irq. c = (IRQHandlerCap irq) \<and> is_subject_irq aag irq)"
+abbreviation cleanup_info_wf :: "cap \<Rightarrow> 'a PAS \<Rightarrow> bool" where
+  "cleanup_info_wf c aag \<equiv> c \<noteq> NullCap \<and> \<not>is_arch_cap c
+                           \<longrightarrow> (\<exists>irq. c = (IRQHandlerCap irq) \<and> is_subject_irq aag irq)"
 
 (* FIXME: MOVE *)
 named_theorems wp_transferable
 named_theorems wp_not_transferable
 
+
+context CNode_AC_1 begin
+
+crunch respects[wp]: deleted_irq_handler "integrity aag X st"
+
+lemma post_cap_deletion_integrity[wp]:
+ "\<lbrace>integrity aag X s and K (cleanup_info_wf cleanup_info aag)\<rbrace>
+  post_cap_deletion cleanup_info
+  \<lbrace>\<lambda>_. integrity aag X s\<rbrace>"
+  by (wpsimp simp: post_cap_deletion_def is_cap_simps wp: arch_post_cap_deletion_integrity)
+
 lemma empty_slot_integrity_spec:
   notes split_paired_All[simp del]
   shows
-  "s \<turnstile> \<lbrace>valid_list and valid_mdb and valid_objs and pas_refined aag and
-            K (is_subject aag (fst slot) \<and> cleanup_info_wf cleanup_info aag)\<rbrace>
-          empty_slot slot cleanup_info
-       \<lbrace>\<lambda>rv. integrity aag X s\<rbrace>"
-   apply (simp add: spec_valid_def)
+  "s \<turnstile> \<lbrace>valid_list and valid_mdb and valid_objs and pas_refined aag
+                   and K (is_subject aag (fst slot) \<and> cleanup_info_wf cleanup_info aag)\<rbrace>
+       empty_slot slot cleanup_info
+       \<lbrace>\<lambda>_. integrity aag X s\<rbrace>"
+  apply (simp add: spec_valid_def)
   apply (simp add: empty_slot_def)
-  apply (wp add:get_cap_wp set_cap_integrity_autarch set_original_integrity_autarch
-            hoare_vcg_all_lift static_imp_wp
-            empty_slot_extended.list_integ_lift empty_slot_list_integrity[where m="cdt s"] |
-         simp add: set_cdt_def |
-         wpc)+
+  apply (wp add: get_cap_wp set_cap_integrity_autarch set_original_integrity_autarch
+                 empty_slot_extended_list_integ_lift empty_slot_list_integrity[where m="cdt s"]
+         | simp add: set_cdt_def | wpc)+
   apply (safe; \<comment> \<open>for speedup\<close>
          clarsimp simp add: integrity_def,
          blast intro: cca_owned cdt_change_allowed_all_children)
   done
 
 lemma empty_slot_integrity[wp,wp_not_transferable]:
-  "\<lbrace>integrity aag X st and valid_list and valid_objs and valid_mdb and pas_refined aag and
-    K (is_subject aag (fst slot) \<and> cleanup_info_wf c aag)\<rbrace>
-       empty_slot slot c \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and valid_list and valid_objs and valid_mdb and pas_refined aag
+                       and K (is_subject aag (fst slot) \<and> cleanup_info_wf c aag)\<rbrace>
+   empty_slot slot c
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (integrity_trans_start)
   apply (rule hoare_pre)
-  apply (wp empty_slot_integrity_spec[simplified spec_valid_def])
+   apply (wp empty_slot_integrity_spec[simplified spec_valid_def])
   by force
+
+end
+
 
 (* FIXME MOVE next to obj_atE *)
 lemma ko_atD:
   "ko_at obj pos s \<Longrightarrow> kheap s pos = Some obj"
   by (blast elim: obj_atE)
 
-
-lemma reply_cap_mdbE:
-  assumes hyp:"reply_caps_mdb m cs"
-  assumes side_hyp: "cs slot = Some (ReplyCap t False R)"
-  obtains ptr R' where "m slot = Some ptr" and "cs ptr = Some (ReplyCap t True R')"
-  using side_hyp hyp by (fastforce simp:reply_caps_mdb_def)
-
 lemma reply_masters_mdbD1:
- "\<lbrakk>reply_masters_mdb m cs ; cs slot = Some (ReplyCap t True R)\<rbrakk> \<Longrightarrow> m slot = None"
+ "\<lbrakk> reply_masters_mdb m cs ; cs slot = Some (ReplyCap t True R) \<rbrakk>
+    \<Longrightarrow> m slot = None"
   by (fastforce simp:reply_masters_mdb_def simp del:split_paired_All)
 
 lemma reply_cap_no_grand_parent:
-  "\<lbrakk>m \<Turnstile> pptr \<rightarrow>* slot ; reply_mdb m cs ; cs slot = Some (ReplyCap t False R)\<rbrakk>
-    \<Longrightarrow> pptr = slot \<or> (m \<Turnstile> pptr \<leadsto> slot \<and> (\<exists> R'. cs pptr = Some (ReplyCap t True R')))"
+  "\<lbrakk> m \<Turnstile> pptr \<rightarrow>* slot ; reply_mdb m cs ; cs slot = Some (ReplyCap t False R) \<rbrakk>
+     \<Longrightarrow> pptr = slot \<or> (m \<Turnstile> pptr \<leadsto> slot \<and> (\<exists> R'. cs pptr = Some (ReplyCap t True R')))"
   apply (clarsimp simp add:reply_mdb_def del:disjCI)
-  apply (erule(1) reply_cap_mdbE)
+  apply (erule(1) reply_caps_mdbE)
   apply (drule(1) reply_masters_mdbD1)
   apply (erule rtrancl.cases,blast)
   apply (erule rtrancl.cases, simp add: cdt_parent_of_def)
   apply (simp add: cdt_parent_of_def)
   done
 
+(* FIXME MOVE to lib*)
+lemma pred_neg_simp[simp]:
+  "(not P) s \<longleftrightarrow> \<not> (P s)"
+  by (simp add:pred_neg_def)
+
+(* FIXME MOVE ? *)
+crunches set_cdt_list, update_cdt_list
+  for cdt[wp]: "\<lambda>s. P (cdt s)"
+  and kheap[wp]: "\<lambda>s. P (kheap s)"
+  and valid_mdb[wp]: "\<lambda>s. P (valid_mdb s)"
+  and valid_objs[wp]: "\<lambda>s. P (valid_objs s)"
+  and arch_state[wp]: "\<lambda>s. P (arch_state s)"
+  and thread_states[wp]: "\<lambda>s. P (thread_states s)"
+  and caps_of_state[wp]: "\<lambda>s. P (caps_of_state s)"
+  and is_original_cap[wp]: "\<lambda>s. P (is_original_cap s)"
+  and interrupt_irq_node[wp]: "\<lambda>s. P (interrupt_irq_node s)"
+  and thread_bound_ntfns[wp]: "\<lambda>s. P (thread_bound_ntfns s)"
+
+
+locale CNode_AC_2 = CNode_AC_1 +
+  assumes integrity_asids_set_cap_Nullcap:
+    "\<lbrace>(=) s\<rbrace> set_cap NullCap slot \<lbrace>\<lambda>_. integrity_asids aag subjects x (s :: det_ext state)\<rbrace>"
+  and set_original_state_asids_to_policy[wp]:
+    "\<And>P. set_original slot v \<lbrace>\<lambda>s. P (state_asids_to_policy aag s)\<rbrace>"
+  and set_original_state_objs_to_policy[wp]:
+    "\<And>P. set_original slot v \<lbrace>\<lambda>s. P (state_objs_to_policy s)\<rbrace>"
+  and set_cdt_list_state_vrefs[wp]:
+    "\<And>P. set_cdt_list t \<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace>"
+  and set_cdt_list_state_asids_to_policy[wp]:
+    "\<And>P. set_cdt_list t \<lbrace>\<lambda>s. P (state_asids_to_policy aag s)\<rbrace>"
+  and update_cdt_list_state_vrefs[wp]:
+    "\<And>P. update_cdt_list f \<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace>"
+  and update_cdt_list_state_asids_to_policy[wp]:
+    "\<And>P. update_cdt_list f \<lbrace>\<lambda>s. P (state_asids_to_policy aag s)\<rbrace>"
+begin
+
+crunches set_original
+  for tcb_domain_map_wellformed[wp]: "\<lambda>s. P (tcb_domain_map_wellformed aag s)"
+  and state_irqs_to_policy[wp]: "\<lambda>s. P (state_irqs_to_policy aag s)"
+  and cdt_change_allowed[wp]: "\<lambda>s. P (cdt_change_allowed' aag slot s)"
+  and irq_map_wellformed[wp]: "\<lambda>s. P (irq_map_wellformed aag s)"
+  and pas_refined[wp]: "\<lambda>s. P (pas_refined aag s)"
+  and valid_objs[wp]: "\<lambda>s. P (valid_objs s)"
+  and cte_wp_at[wp]: "cte_wp_at P slot"
+  (simp: state_objs_to_policy_def pas_refined_def)
 
 lemma set_cap_integrity_deletion_aux:
-  "\<lbrace>integrity aag X st and valid_mdb and valid_objs and pas_refined aag and is_transferable_in slot and
-     cdt_change_allowed' aag slot and K(\<not> is_subject aag (fst slot))\<rbrace>
-      set_cap NullCap slot
+  "\<lbrace>integrity aag X st and valid_mdb and valid_objs and pas_refined aag and is_transferable_in slot
+                       and cdt_change_allowed' aag slot and K(\<not> is_subject aag (fst slot))\<rbrace>
+   set_cap NullCap slot
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (integrity_trans_start)
   apply (rule hoare_pre)
-   apply(unfold integrity_subjects_def)[1]
+   apply (unfold integrity_subjects_def)[1]
    apply (wp hoare_wp_combs)
     apply (unfold set_cap_def)[1]
     apply (wpc)
     apply (wp set_object_wp)
      apply wpc
          apply wp+
-   apply (wp get_object_wp)
+    apply (wp get_object_wp)
    apply wps
-   apply wp
+   apply (wp integrity_asids_set_cap_Nullcap hoare_vcg_all_lift)
   apply (safe ; clarsimp simp add: cte_wp_at_caps_of_state dest!: ko_atD)
        (* cnode *)
        subgoal for s obj addr cnode_size content cap'
@@ -577,7 +568,7 @@ lemma set_cap_integrity_deletion_aux:
          apply (fastforce dest: tcb_states_of_state_kheapD descendant_of_caller_slot[OF _ _ tcb_atI]
                                 parent_of_rtrancl_no_descendant)
          done
-           (* tcb_ctable *)
+       (* tcb_ctable *)
        subgoal for s obj tcb
          apply (rule_tac tro_tcb_empty_ctable, simp, simp, simp)
          apply (frule_tac addr="tcb_cnode_index 0" in caps_of_state_tcb)
@@ -620,7 +611,7 @@ lemma set_cap_integrity_deletion_aux:
                       dest: tcb_caller_slot_empty_on_recieve parent_of_rtrancl_no_descendant
                             descendant_of_caller_slot[OF _ _ tcb_atI] tcb_states_of_state_kheapD)
      done
-    (* tcb_ipcframe*)
+  (* tcb_ipcframe*)
   apply (rename_tac s obj tcb)
   apply (rule tro_orefl)
   apply (fastforce simp: is_nondevice_page_cap_simps caps_of_state_tcb
@@ -628,47 +619,22 @@ lemma set_cap_integrity_deletion_aux:
                    elim: pspace_valid_objsE[OF _ invs_valid_objs] elim!:is_transferable.cases)
   done
 
-
-(* FIXME MOVE to lib*)
-lemma pred_neg_simp[simp]:
-  "(not P) s \<longleftrightarrow> \<not> (P s)"
-  by (simp add:pred_neg_def)
-
 lemma set_cap_integrity_deletion[wp_transferable]:
-  "\<lbrace>integrity aag X st and valid_mdb and valid_objs and pas_refined aag and
-     cdt_change_allowed' aag slot\<rbrace>
-      set_cap NullCap slot
+  "\<lbrace>integrity aag X st and valid_mdb and valid_objs
+                       and pas_refined aag and cdt_change_allowed' aag slot\<rbrace>
+   set_cap NullCap slot
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (cases "is_subject aag (fst slot)")
    apply (wpsimp wp: set_cap_integrity_autarch)
   apply (wpsimp wp: set_cap_integrity_deletion_aux)
-  by (fastforce dest:cca_to_transferable_or_subject simp:cte_wp_at_caps_of_state)
-
-
-crunches set_original
-  for pas_refined[wp]: "pas_refined aag"
-  and valid_objs[wp]: "valid_objs"
-  and cte_wp_at[wp]: "cte_wp_at P slot"
-  and cdt_change_allowed[wp]: "cdt_change_allowed' aag slot"
-  (simp:pas_refined_def state_objs_to_policy_def)
-
-(* FIXME MOVE ?*)
-crunches set_cdt_list, update_cdt_list
-  for cdt[wp]: "\<lambda>s. P (cdt s)"
-  and caps_of_state[wp]: "\<lambda>s. P (caps_of_state s)"
-  and is_original_cap[wp]: "\<lambda>s. P (is_original_cap s)"
-  and interrupt_irq_node[wp]: "\<lambda>s. P (interrupt_irq_node s)"
-  and kheap[wp]: "\<lambda>s. P (kheap s)"
-  and thread_states[wp]: "\<lambda>s. P (thread_states s)"
-  and thread_bound_ntfns[wp]: "\<lambda>s. P (thread_bound_ntfns s)"
-  and state_vrefs[wp]: "\<lambda>s. P (state_vrefs s)"
-  and arch_state[wp]: "\<lambda>s. P (arch_state s)"
-  and valid_mdb[wp]: "valid_mdb"
-  and valid_objs[wp]: "valid_objs"
+  by (fastforce dest: cca_to_transferable_or_subject simp: cte_wp_at_caps_of_state)
 
 lemma update_cdt_list_pas_refined[wp]:
-   "\<lbrace> pas_refined aag \<rbrace> update_cdt_list f \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  by (wpsimp simp:pas_refined_def state_objs_to_policy_def | wps)+
+  "update_cdt_list f \<lbrace>pas_refined aag\<rbrace>"
+  by (wpsimp simp: pas_refined_def state_objs_to_policy_def | wps)+
+
+end
+
 
 text \<open>
   For the @{const empty_slot} proof, we need to rearrange the operations
@@ -698,9 +664,9 @@ lemma set_eq_iff_imp:
   by blast
 
 lemma modify_get_commute:
-  "(\<And>s0. \<lbrace>(=) s0\<rbrace> g \<lbrace>\<lambda>r t. s0 = t\<rbrace>) \<Longrightarrow>
-   monad_commute (\<lambda>s. fst ` fst (g (f s)) = fst ` fst (g s)
-                      \<and> snd (g (f s)) = snd (g s)) (modify f) g"
+  "(\<And>s0. \<lbrace>(=) s0\<rbrace> g \<lbrace>\<lambda>r t. s0 = t\<rbrace>)
+   \<Longrightarrow> monad_commute (\<lambda>s. fst ` fst (g (f s)) = fst ` fst (g s) \<and>
+                          snd (g (f s)) = snd (g s)) (modify f) g"
   (* FIXME: proof cleanup *)
   apply (monad_eq simp: monad_commute_def valid_def
                         set_eq_iff_imp[where A="fst ` fst _"] image_iff)
@@ -747,13 +713,12 @@ lemma gets_gets_commute:
 lemma gets_get_commute:
   "(\<And>s0. \<lbrace>(=) s0\<rbrace> g \<lbrace>\<lambda>r t. s0 = t\<rbrace>) \<Longrightarrow>
    monad_commute \<top> (gets f) g"
-  apply (monad_eq simp: monad_commute_def valid_def)
-  by fastforce
+  by (monad_eq simp: monad_commute_def valid_def) fastforce
 
 lemma assert_commute':
   "empty_fail f \<Longrightarrow> monad_commute \<top> (assert G) f"
-  apply (monad_eq simp: monad_commute_def empty_fail_def)
-  by fastforce
+  by (monad_eq simp: monad_commute_def empty_fail_def) fastforce
+
 
 named_theorems monad_commute_wp
 
@@ -771,6 +736,7 @@ lemmas[monad_commute_wp] =
 lemma wpc_helper_monad_commute:
   "monad_commute P f g \<Longrightarrow> wpc_helper (P, P') (Q, Q') (monad_commute P f g)"
   by (clarsimp simp: wpc_helper_def)
+
 wpc_setup "\<lambda>m. monad_commute P f m" wpc_helper_monad_commute
 
 method monad_commute_wpc =
@@ -839,7 +805,7 @@ lemma set_cdt_set_original_comm:
 
 lemma set_cdt_empty_slot_ext_comm:
   "(do set_cdt c; empty_slot_ext slot slot_p od) =
-   ((do empty_slot_ext slot slot_p; set_cdt c od) :: (det_ext state \<Rightarrow> _))"
+   (do empty_slot_ext slot slot_p; set_cdt c od)"
   supply K_bind_def[simp del]
   apply (clarsimp simp: set_cdt_def empty_slot_ext_def
                         update_cdt_list_def set_cdt_list_def)
@@ -851,7 +817,7 @@ lemma set_cdt_empty_slot_ext_comm:
 
 lemma set_cap_empty_slot_ext_comm:
   "(do set_cap cap slot; empty_slot_ext slot' slot_p od) =
-   (do empty_slot_ext slot' slot_p; set_cap cap slot od :: (det_ext state \<Rightarrow> _))"
+   (do empty_slot_ext slot' slot_p; set_cap cap slot od)"
   apply (rule ext)
   apply (clarsimp simp: bind_def split_def set_cap_def empty_slot_ext_def
                         update_cdt_list_def set_cdt_list_def
@@ -870,29 +836,38 @@ lemma K_bind_assoc:
 lemmas K_bind_eqI = arg_cong2[where f="\<lambda>f g. do f; g od"]
 lemmas K_bind_eqI' = K_bind_eqI[OF _ refl]
 
+lemma aag_cap_auth_max_free_index_update[simp]:
+  "aag_cap_auth aag (pasObjectAbs aag x) (max_free_index_update y) =
+   aag_cap_auth aag (pasObjectAbs aag x) y"
+  by (clarsimp simp: aag_cap_auth_def free_index_update_def cap_links_asid_slot_def cap_links_irq_def
+              split: cap.splits)
+
+
+context CNode_AC_2 begin
+
 (* Putting it all together *)
 lemma empty_slot_shuffle:
   "(do set_cdt c;
        empty_slot_ext slot slot_p;
        set_original slot False;
-       set_cap NullCap slot od)
-    =
+       set_cap NullCap slot;
+       post_cap_deletion NullCap od) =
    (do set_cap NullCap slot;
        empty_slot_ext slot slot_p;
        set_original slot False;
-       set_cdt c od :: (det_ext state \<Rightarrow> _))"
-  by (simp only:
-            set_cdt_empty_slot_ext_comm[THEN K_bind_eqI', simplified K_bind_assoc]
-            set_cdt_set_original_comm[THEN K_bind_eqI', simplified K_bind_assoc]
-            set_cdt_set_cap_comm
-            set_original_set_cap_comm[THEN K_bind_eqI', simplified K_bind_assoc]
-            set_cap_empty_slot_ext_comm[THEN K_bind_eqI', simplified K_bind_assoc])
+       set_cdt c;
+       post_cap_deletion NullCap od :: (det_ext state \<Rightarrow> _))"
+  by (simp only: set_cdt_empty_slot_ext_comm[THEN K_bind_eqI', simplified K_bind_assoc]
+                 set_cdt_set_original_comm[THEN K_bind_eqI', simplified K_bind_assoc]
+                 set_cdt_set_cap_comm[THEN K_bind_eqI', simplified K_bind_assoc]
+                 set_original_set_cap_comm[THEN K_bind_eqI', simplified K_bind_assoc]
+                 set_cap_empty_slot_ext_comm[THEN K_bind_eqI', simplified K_bind_assoc])
 
 lemma empty_slot_integrity_transferable[wp_transferable]:
-  "\<lbrace>integrity aag X st and valid_list and valid_objs and valid_mdb and pas_refined aag and
-        cdt_change_allowed' aag slot and
-        K (c = NullCap)\<rbrace>
-       empty_slot slot c \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and valid_list and valid_objs and valid_mdb and pas_refined aag
+                       and cdt_change_allowed' aag slot and K (c = NullCap)\<rbrace>
+   empty_slot slot c
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply integrity_trans_start
   apply (rule hoare_pre)
    apply (simp add: empty_slot_def)
@@ -905,7 +880,7 @@ lemma empty_slot_integrity_transferable[wp_transferable]:
                        in hoare_post_imp)
         apply (clarsimp simp add: integrity_def)
         apply (frule all_childrenD[OF cdt_change_allowed_all_children];fastforce)
-       apply (wp empty_slot_extended.list_integ_lift)
+       apply (wp empty_slot_extended_list_integ_lift)
           apply (rule hoare_pre)
            apply (rule_tac m = "cdt s" in empty_slot_list_integrity)
           apply simp
@@ -913,23 +888,21 @@ lemma empty_slot_integrity_transferable[wp_transferable]:
       apply (wp set_cap_integrity_deletion gets_wp get_cap_wp)+
   by (fastforce intro: cdt_change_allowed_all_children)
 
-
-
 lemma set_cdt_pas_refined:
   notes split_paired_All[simp del] split_paired_Ex[simp del]
   shows "\<lbrace>pas_refined aag and (\<lambda>s. \<forall>x y. c x = Some y \<and> cdt s x \<noteq> Some y
            \<longrightarrow> (is_transferable (caps_of_state s x) \<or>
-               (pasObjectAbs aag (fst y), Control, pasObjectAbs aag (fst x)) \<in> pasPolicy aag)
-             \<and> (pasObjectAbs aag (fst y), DeleteDerived, pasObjectAbs aag (fst x)) \<in> pasPolicy aag)\<rbrace>
-      set_cdt c \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+                abs_has_auth_to aag Control (fst y) (fst x)) \<and>
+               abs_has_auth_to aag DeleteDerived (fst y) (fst x))\<rbrace>
+         set_cdt c
+         \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def set_cdt_def)
   apply (wp | simp | simp_all)+
   apply (clarsimp dest!: auth_graph_map_memD)
   apply (subgoal_tac
           "\<forall>x y. c x = Some y \<longrightarrow>
-            (is_transferable (caps_of_state s x)
-              \<or> (pasObjectAbs aag (fst y), Control, pasObjectAbs aag (fst x)) \<in> pasPolicy aag)
-            \<and> (pasObjectAbs aag (fst y), DeleteDerived, pasObjectAbs aag (fst x)) \<in> pasPolicy aag")
+            (is_transferable (caps_of_state s x) \<or> abs_has_auth_to aag Control (fst y) (fst x))
+          \<and> abs_has_auth_to  aag DeleteDerived (fst y) (fst x)")
    defer
    apply (intro allI, case_tac "cdt s x = Some y")
     apply (solves\<open>auto intro: auth_graph_map_memI state_bits_to_policy.intros\<close>)
@@ -951,41 +924,24 @@ lemma pas_refined_interrupt_states_update[simp]:
   "pas_refined aag (interrupt_states_update f s) = pas_refined aag s"
   by (simp add: pas_refined_def state_objs_to_policy_def state_refs_of_def)
 
+crunches deleted_irq_handler
+  for pas_refined[wp]: "pas_refined aag"
 
-crunch pas_refined[wp]: deleted_irq_handler "pas_refined aag"
-
-lemma update_cdt_pas_refined:
-  "\<lbrace>pas_refined aag and (\<lambda>s. \<forall>x y. c (cdt s) x = Some y \<and> cdt s x \<noteq> Some y
-           \<longrightarrow> (is_transferable (caps_of_state s x) \<or>
-               (pasObjectAbs aag (fst y), Control, pasObjectAbs aag (fst x)) \<in> pasPolicy aag)
-             \<and> (pasObjectAbs aag (fst y), DeleteDerived, pasObjectAbs aag (fst x)) \<in> pasPolicy aag)\<rbrace>
-     update_cdt c
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (simp add: update_cdt_def)
-  apply (wp set_cdt_pas_refined)
-  apply simp
-  done
-
-lemma aag_cap_auth_max_free_index_update[simp]:
-  "aag_cap_auth aag (pasObjectAbs aag x)
-     (max_free_index_update y) =
-      aag_cap_auth aag (pasObjectAbs aag x) y"
-  by (clarsimp simp: aag_cap_auth_def free_index_update_def split: cap.splits
-               simp: cap_links_asid_slot_def cap_links_irq_def)
-
-crunch pas_refined: set_untyped_cap_as_full "pas_refined aag"
+crunches set_untyped_cap_as_full
+  for pas_refined: "pas_refined aag"
 
 lemmas set_untyped_cap_as_full_pas_refined'[wp] = set_untyped_cap_as_full_pas_refined[simplified]
 
-
-lemma set_untyped_cap_as_full_cdt_is_original_cap:
-  "\<lbrace> \<lambda> s. P (cdt s) (is_original_cap s) \<rbrace>
-     set_untyped_cap_as_full src_cap new_cap src_slot
-   \<lbrace> \<lambda> rv s. P (cdt s) (is_original_cap s) \<rbrace>"
-  unfolding set_untyped_cap_as_full_def
-  apply(rule hoare_pre)
-  apply (wp set_cap_caps_of_state2)
-  apply clarsimp
+lemma update_cdt_pas_refined:
+  "\<lbrace>pas_refined aag and (\<lambda>s. \<forall>x y. c (cdt s) x = Some y \<and> cdt s x \<noteq> Some y
+                                   \<longrightarrow> (is_transferable (caps_of_state s x) \<or>
+                                        abs_has_auth_to aag Control (fst y) (fst x))
+                                     \<and> abs_has_auth_to aag DeleteDerived (fst y) (fst x))\<rbrace>
+   update_cdt c
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (simp add: update_cdt_def)
+  apply (wp set_cdt_pas_refined)
+  apply simp
   done
 
 lemma state_objs_to_policy_more_update[simp]:
@@ -995,22 +951,16 @@ lemma state_objs_to_policy_more_update[simp]:
 
 end
 
-context is_extended begin
 
-interpretation Arch . (*FIXME: arch_split*)
-
-lemma pas_refined_tcb_domain_map_wellformed[wp]:
-  assumes tdmw: "\<lbrace>tcb_domain_map_wellformed aag\<rbrace> f \<lbrace>\<lambda>_. tcb_domain_map_wellformed aag\<rbrace>"
-  shows "\<lbrace>pas_refined aag\<rbrace> f \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  apply (simp add: pas_refined_def)
-  apply (wp tdmw)
-   apply (wp lift_inv)
-   apply simp+
+lemma set_untyped_cap_as_full_cdt_is_original_cap:
+  "\<lbrace>\<lambda>s. P (cdt s) (is_original_cap s)\<rbrace>
+   set_untyped_cap_as_full src_cap new_cap src_slot
+   \<lbrace>\<lambda>_ s. P (cdt s) (is_original_cap s)\<rbrace>"
+  unfolding set_untyped_cap_as_full_def
+  apply (rule hoare_pre)
+  apply (wp set_cap_caps_of_state2)
+  apply clarsimp
   done
-
-end
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 (* FIXME MOVE *)
 lemma untyped_not_transferable:
@@ -1023,30 +973,59 @@ lemma is_transferable_max_free_index_update[simp]:
   by (simp add: is_transferable.simps free_index_update_def split: cap.splits)
 
 lemma set_untyped_cap_as_full_is_transferable[wp]:
-  "\<lbrace>\<lambda>s.\<not> is_transferable (caps_of_state s other_slot)\<rbrace>
-     set_untyped_cap_as_full src_cap new_cap slot
-   \<lbrace>\<lambda>rv s. \<not> is_transferable (caps_of_state s other_slot)\<rbrace>"
+  "set_untyped_cap_as_full src_cap new_cap slot \<lbrace>\<lambda>s. \<not> is_transferable (caps_of_state s other_slot)\<rbrace>"
   apply (clarsimp simp: set_untyped_cap_as_full_def)
   apply wp
   using untyped_not_transferable max_free_index_update_preserve_untyped by simp
 
 lemma set_untyped_cap_as_full_is_transferable':
-  "\<lbrace>\<lambda>s. is_transferable ((caps_of_state s(slot2 \<mapsto> new_cap)) slot3) \<and> Some src_cap = (caps_of_state s slot)\<rbrace>
-     set_untyped_cap_as_full src_cap new_cap slot
-   \<lbrace>\<lambda>rv s. is_transferable ((caps_of_state s(slot2 \<mapsto> new_cap)) slot3)\<rbrace>"
+  "\<lbrace>\<lambda>s. is_transferable ((caps_of_state s(slot2 \<mapsto> new_cap)) slot3) \<and>
+        Some src_cap = (caps_of_state s slot)\<rbrace>
+   set_untyped_cap_as_full src_cap new_cap slot
+   \<lbrace>\<lambda>_ s. is_transferable ((caps_of_state s(slot2 \<mapsto> new_cap)) slot3)\<rbrace>"
   apply (clarsimp simp: set_untyped_cap_as_full_def)
   apply safe
   apply (wp,fastforce)+
   done
 
+lemma cap_links_irq_Nullcap [simp]:
+  "cap_links_irq aag l NullCap" unfolding cap_links_irq_def by simp
+
+lemma aag_cap_auth_NullCap [simp]:
+  "aag_cap_auth aag l NullCap"
+  unfolding aag_cap_auth_def
+  by (simp add: clas_no_asid)
+
+crunch thread_states[wp]: set_cdt "\<lambda>s. P (thread_states s)"
+crunch thread_bound_ntfns[wp]: set_cdt "\<lambda>s. P (thread_bound_ntfns s)"
+
+
+locale CNode_AC_3 = CNode_AC_2 +
+  assumes cap_move_ext_pas_refined_tcb_domain_map_wellformed[wp]:
+    "\<And>a b c d. cap_move_ext a b c d \<lbrace>tcb_domain_map_wellformed aag\<rbrace>
+                \<Longrightarrow> cap_move_ext a b c d \<lbrace>pas_refined aag\<rbrace>"
+  and cap_insert_ext_pas_refined_tcb_domain_map_wellformed[wp]:
+    "\<And>a b c d e. cap_insert_ext a b c d e \<lbrace>tcb_domain_map_wellformed aag\<rbrace>
+                  \<Longrightarrow> cap_insert_ext a b c d e \<lbrace>pas_refined aag\<rbrace>"
+  and cap_swap_ext_extended_pas_refined_tcb_domain_map_wellformed[wp]:
+    "\<And>a b c d. cap_swap_ext a b c d \<lbrace>tcb_domain_map_wellformed aag\<rbrace>
+                \<Longrightarrow> cap_swap_ext a b c d \<lbrace>pas_refined aag\<rbrace>"
+  and empty_slot_ext_pas_refined_tcb_domain_map_wellformed[wp]:
+    "\<And>a b. empty_slot_ext a b \<lbrace>tcb_domain_map_wellformed aag\<rbrace>
+            \<Longrightarrow> empty_slot_ext a b \<lbrace>pas_refined aag\<rbrace>"
+  and arch_ost_cap_deletion_pas_refined[wp]:
+    "arch_post_cap_deletion irqopt \<lbrace>pas_refined aag\<rbrace>"
+  and aobj_ref'_same_aobject:
+    "same_aobject_as ao' ao \<Longrightarrow> aobj_ref' ao = aobj_ref' ao'"
+begin
+
 lemma cap_insert_pas_refined:
   "\<lbrace>pas_refined aag and valid_mdb and
-    (\<lambda> s. (is_transferable_in src_slot s \<and> (\<not> Option.is_none (cdt s src_slot)))
-    \<longrightarrow> is_transferable_cap new_cap)
-     and K (is_subject aag (fst dest_slot)
-                                 \<and> is_subject aag (fst src_slot)
-                                 \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
-     cap_insert new_cap src_slot dest_slot
+    (\<lambda>s. (is_transferable_in src_slot s \<and> (\<not> Option.is_none (cdt s src_slot)))
+         \<longrightarrow> is_transferable_cap new_cap) and
+    K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot)
+                                      \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
+   cap_insert new_cap src_slot dest_slot
    \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: cap_insert_def)
@@ -1056,74 +1035,55 @@ lemma cap_insert_pas_refined:
             set_untyped_cap_as_full_cdt_is_original_cap get_cap_wp
             tcb_domain_map_wellformed_lift hoare_vcg_disj_lift
             set_untyped_cap_as_full_is_transferable'
-       | simp split del: if_split del: split_paired_All fun_upd_apply
-       | strengthen update_one_strg)+
+         | simp split del: if_split del: split_paired_All fun_upd_apply
+         | strengthen update_one_strg)+
   by (fastforce split: if_split_asm
-                simp: cte_wp_at_caps_of_state pas_refined_refl F[symmetric] valid_mdb_def2
-                      mdb_cte_at_def Option.is_none_def
-                simp del:split_paired_All
-                dest: aag_cdt_link_Control aag_cdt_link_DeleteDerived cap_auth_caps_of_state)
+                 simp: cte_wp_at_caps_of_state pas_refined_refl F[symmetric]
+                       valid_mdb_def2 mdb_cte_at_def Option.is_none_def
+             simp del: split_paired_All
+                 dest: aag_cdt_link_Control aag_cdt_link_DeleteDerived cap_auth_caps_of_state)
 
 lemma cap_insert_pas_refined':
   "\<lbrace>pas_refined aag and valid_mdb and
-    (\<lambda> s. cte_wp_at is_transferable_cap src_slot s \<longrightarrow> is_transferable_cap new_cap)
-     and K (is_subject aag (fst dest_slot)
-                                 \<and> is_subject aag (fst src_slot)
-                                 \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
-     cap_insert new_cap src_slot dest_slot
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+    (\<lambda>s. cte_wp_at is_transferable_cap src_slot s \<longrightarrow> is_transferable_cap new_cap) and
+    K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot)
+                                      \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
+   cap_insert new_cap src_slot dest_slot
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   by (wp cap_insert_pas_refined)
      (fastforce dest: valid_mdb_mdb_cte_at[THEN mdb_cte_atD[rotated]]
                 simp: cte_wp_at_caps_of_state Option.is_none_def)
 
 lemma cap_insert_pas_refined_not_transferable:
-   "\<lbrace>pas_refined aag and valid_mdb and
-     not cte_wp_at is_transferable_cap src_slot
-     and K (is_subject aag (fst dest_slot)
-                                 \<and> is_subject aag (fst src_slot)
-                                 \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
-     cap_insert new_cap src_slot dest_slot
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and valid_mdb and not cte_wp_at is_transferable_cap src_slot
+                    and K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot)
+                                                          \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
+   cap_insert new_cap src_slot dest_slot
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
    by (wpsimp wp: cap_insert_pas_refined')
 
 lemma cap_insert_pas_refined_same_object_as:
-   "\<lbrace>pas_refined aag and valid_mdb and
-     cte_wp_at (same_object_as new_cap) src_slot
-     and K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot)
-           \<and> (\<not> is_master_reply_cap new_cap)
-                                 \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
-     cap_insert new_cap src_slot dest_slot
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and valid_mdb and cte_wp_at (same_object_as new_cap) src_slot
+                     and K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot) \<and>
+                            (\<not> is_master_reply_cap new_cap) \<and> pas_cap_cur_auth aag new_cap)\<rbrace>
+   cap_insert new_cap src_slot dest_slot
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (wp cap_insert_pas_refined)
   apply (clarsimp simp: Option.is_none_def cte_wp_at_caps_of_state)
-  by (elim is_transferable_capE;
-      fastforce simp: same_object_as_commute is_master_reply_cap_def same_object_as_def
-               split: cap.splits)
-
-
-
-
-lemma cap_links_irq_Nullcap [simp]:
-  "cap_links_irq aag l cap.NullCap" unfolding cap_links_irq_def by simp
-
-lemma aag_cap_auth_NullCap [simp]:
-  "aag_cap_auth aag l cap.NullCap"
-  unfolding aag_cap_auth_def
-  by (simp add: clas_no_asid)
+  by (fastforce simp: same_object_as_commute is_master_reply_cap_def same_object_as_def
+                elim: is_transferable_capE split: cap.splits)
 
 lemma cap_move_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and valid_mdb and
-    cte_wp_at (weak_derived new_cap) src_slot and
-    cte_wp_at ((=) NullCap) dest_slot
-    and K (is_subject aag (fst dest_slot)
-                       \<and> is_subject aag (fst src_slot)
-                       \<and> pas_cap_cur_auth aag new_cap)\<rbrace>
-     cap_move new_cap src_slot dest_slot
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and valid_mdb and cte_wp_at (weak_derived new_cap) src_slot
+                    and cte_wp_at ((=) NullCap) dest_slot
+                    and K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot)
+                                                          \<and> pas_cap_cur_auth aag new_cap)\<rbrace>
+   cap_move new_cap src_slot dest_slot
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: cap_move_def)
   apply (rule hoare_pre)
-   apply (wpsimp wp: set_cap_pas_refined set_cdt_pas_refined tcb_domain_map_wellformed_lift
-             set_cap_caps_of_state2)
+   apply (wpsimp wp: set_cap_caps_of_state2 set_cap_pas_refined set_cdt_pas_refined
+                     tcb_domain_map_wellformed_lift)
   by (fastforce simp: is_transferable_weak_derived valid_mdb_def2 mdb_cte_at_def
                       Option.is_none_def cte_wp_at_caps_of_state
             simp del: split_paired_All
@@ -1131,58 +1091,42 @@ lemma cap_move_pas_refined[wp]:
                 dest: invs_mdb pas_refined_mem[OF sta_cdt]
                       pas_refined_mem[OF sta_cdt_transferable])
 
-
-
-
 lemma empty_slot_pas_refined[wp, wp_not_transferable]:
   "\<lbrace>pas_refined aag and valid_mdb and K (is_subject aag (fst slot))\<rbrace>
-      empty_slot slot irqopt
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (simp add: empty_slot_def)
+   empty_slot slot irqopt
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (simp add: empty_slot_def post_cap_deletion_def)
   apply (wpsimp wp: set_cap_pas_refined get_cap_wp set_cdt_pas_refined
                     tcb_domain_map_wellformed_lift hoare_drop_imps)
-  apply (strengthen aag_wellformed_delete_derived_trans[OF _ _ pas_refined_wellformed,
-                                                            mk_strg I _ _ A])
+  apply (strengthen aag_wellformed_delete_derived_trans[OF _ _ pas_refined_wellformed, mk_strg I _ _ A])
   by (fastforce dest: all_childrenD is_transferable_all_children
                       pas_refined_mem[OF sta_cdt] pas_refined_mem[OF sta_cdt_transferable]
                       pas_refined_Control)
 
 lemma empty_slot_pas_refined_transferable[wp_transferable]:
   "\<lbrace>pas_refined aag and valid_mdb and (\<lambda>s. is_transferable (caps_of_state s slot))\<rbrace>
-     empty_slot slot irqopt
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (simp add: empty_slot_def)
-  apply (wp set_cap_pas_refined get_cap_wp set_cdt_pas_refined tcb_domain_map_wellformed_lift
-            hoare_drop_imps
-        | simp | wpc)+
-  apply clarsimp
-  apply (strengthen aag_wellformed_delete_derived_trans[OF _ _ pas_refined_wellformed,
-                                                            mk_strg I _ _ A])
+   empty_slot slot irqopt
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (simp add: empty_slot_def post_cap_deletion_def)
+  apply (wpsimp wp: set_cap_pas_refined get_cap_wp set_cdt_pas_refined
+                    tcb_domain_map_wellformed_lift hoare_drop_imps)
+  apply (strengthen aag_wellformed_delete_derived_trans[OF _ _ pas_refined_wellformed, mk_strg I _ _ A])
   by (fastforce simp: cte_wp_at_caps_of_state
                 dest: all_childrenD is_transferable_all_children
                       pas_refined_mem[OF sta_cdt] pas_refined_mem[OF sta_cdt_transferable])
 
 lemma obj_ref_weak_derived:
   "weak_derived cap cap' \<Longrightarrow> obj_refs cap = obj_refs cap'"
-  unfolding obj_refs_def aobj_ref'_def weak_derived_def copy_of_def same_object_as_def
-  by (cases cap;
-      (* also split arch caps *)
-      (match premises in "cap = ArchObjectCap acap" for acap \<Rightarrow> \<open>cases acap\<close>)?;
-      fastforce simp: is_cap_simps split: cap.splits arch_cap.splits)
-
-
-crunch thread_states[wp]: set_cdt "\<lambda>s. P (thread_states s)"
-crunch thread_bound_ntfns[wp]: set_cdt "\<lambda>s. P (thread_bound_ntfns s)"
-crunch state_vrefs[wp]: set_cdt "\<lambda>s. P (state_vrefs s)"
+  unfolding obj_refs_def weak_derived_def copy_of_def same_object_as_def
+  by (cases cap; fastforce simp: is_cap_simps aobj_ref'_same_aobject split: cap.splits)
 
 lemma cap_swap_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and invs and
-    cte_wp_at (weak_derived cap) slot and
-     cte_wp_at (weak_derived cap') slot' and
-     K (is_subject aag (fst slot) \<and> is_subject aag (fst slot')
-             \<and> pas_cap_cur_auth aag cap \<and> pas_cap_cur_auth aag cap')\<rbrace>
-      cap_swap cap slot cap' slot'
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and invs and cte_wp_at (weak_derived cap) slot
+                    and cte_wp_at (weak_derived cap') slot'
+                    and K (is_subject aag (fst slot) \<and> is_subject aag (fst slot') \<and>
+                           pas_cap_cur_auth aag cap \<and> pas_cap_cur_auth aag cap')\<rbrace>
+   cap_swap cap slot cap' slot'
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: cap_swap_def)
   apply (rule hoare_pre)
    apply (wp add: tcb_domain_map_wellformed_lift | simp split del: if_split)+
@@ -1190,12 +1134,11 @@ lemma cap_swap_pas_refined[wp]:
         apply (wps | wp set_cdt_cdt_ct_ms_rvk set_cap_caps_of_state)+
   apply (clarsimp simp: pas_refined_def aag_cap_auth_def state_objs_to_policy_def
                         cte_wp_at_caps_of_state
-                 split: if_split_asm
-             split del: if_split)
+                 split: if_split_asm split del: if_split)
   apply (rename_tac old_cap old_cap')
   apply (intro conjI)
-    apply (find_goal \<open>match conclusion in "state_asids_to_policy_aux _ _ _ _ \<subseteq> _" \<Rightarrow> succeed\<close>)
-    apply (erule(1) sata_update2[unfolded fun_upd_def]; fastforce)
+    apply (find_goal \<open>match conclusion in "state_asids_to_policy_arch _ _ _ _ \<subseteq> _" \<Rightarrow> succeed\<close>)
+    apply (erule sata_update2[unfolded fun_upd_def]; fastforce)
    apply (find_goal \<open>match conclusion in "state_irqs_to_policy_aux _ _ \<subseteq> _" \<Rightarrow> succeed\<close>)
    apply (erule sita_caps_update2[unfolded fun_upd_def]; fastforce)
   apply (find_goal \<open>match conclusion in "auth_graph_map _ _ \<subseteq> _" \<Rightarrow> succeed\<close>)
@@ -1220,11 +1163,10 @@ lemma cap_swap_pas_refined[wp]:
          force simp: is_transferable_weak_derived intro!: sbta_cdt_transferable auth_graph_map_memI)+
   by (blast intro: state_bits_to_policy.intros auth_graph_map_memI)
 
-
 lemma cap_swap_for_delete_pas_refined[wp]:
   "\<lbrace>pas_refined aag and invs and K (is_subject aag (fst slot) \<and> is_subject aag (fst slot'))\<rbrace>
-      cap_swap_for_delete slot slot'
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+   cap_swap_for_delete slot slot'
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: cap_swap_for_delete_def)
   apply (wp get_cap_wp | simp)+
   apply (clarsimp simp: cte_wp_at_caps_of_state )
@@ -1232,9 +1174,9 @@ lemma cap_swap_for_delete_pas_refined[wp]:
   done
 
 lemma sts_respects_restart_ep:
-  "\<lbrace>integrity aag X st
-     and (\<lambda>s. \<exists>ep. aag_has_auth_to aag Reset ep \<and> st_tcb_at (blocked_on ep) thread s)\<rbrace>
-        set_thread_state thread Structures_A.Restart
+  "\<lbrace>integrity aag X st and
+    (\<lambda>s. \<exists>ep. aag_has_auth_to aag Reset ep \<and> st_tcb_at (blocked_on ep) thread s)\<rbrace>
+   set_thread_state thread Restart
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: set_thread_state_def)
   apply (wpsimp wp: set_object_wp)
@@ -1246,12 +1188,11 @@ lemma sts_respects_restart_ep:
   apply simp
   done
 
-lemma set_endpoinintegrity:
-  "\<lbrace>integrity aag X st
-          and ep_at epptr
-          and K (\<exists>auth. aag_has_auth_to aag auth epptr \<and> auth \<in> {Receive, SyncSend, Reset})\<rbrace>
-     set_endpoint epptr ep'
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+lemma set_endpoint_respects:
+  "\<lbrace>integrity aag X st and ep_at epptr and
+    K (\<exists>auth. aag_has_auth_to aag auth epptr \<and> auth \<in> {Receive, SyncSend, Reset})\<rbrace>
+   set_endpoint epptr ep'
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: set_simple_ko_def set_object_def)
   apply (wp get_object_wp)
   apply (clarsimp simp: obj_at_def partial_inv_def a_type_def)
@@ -1259,21 +1200,16 @@ lemma set_endpoinintegrity:
   apply (clarsimp simp: integrity_def tro_ep)
   done
 
+end
+
+
 lemma mapM_mapM_x_valid:
   "\<lbrace>P\<rbrace> mapM_x f xs \<lbrace>\<lambda>rv. Q\<rbrace> = \<lbrace>P\<rbrace> mapM f xs \<lbrace>\<lambda>rv. Q\<rbrace>"
   by (simp add: mapM_x_mapM liftM_def[symmetric] hoare_liftM_subst)
 
-lemma sts_st_vrefs[wp]:
-  "\<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace> set_thread_state t st \<lbrace>\<lambda>rv s. P (state_vrefs s)\<rbrace>"
-  apply (simp add: set_thread_state_def)
-  apply (wpsimp wp: set_object_wp dxo_wp_weak)
-  apply (clarsimp simp: state_vrefs_def vs_refs_no_global_pts_def
-                 elim!: rsubst[where P=P, OF _ ext]
-                 dest!: get_tcb_SomeD)
-  done
 
 lemma sts_thread_bound_ntfns[wp]:
-  "\<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace> set_thread_state t st \<lbrace>\<lambda>rv s. P (thread_bound_ntfns s)\<rbrace>"
+  "set_thread_state t st \<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace>"
   apply (simp add: set_thread_state_def)
   apply (wpsimp wp: set_object_wp dxo_wp_weak)
   apply (clarsimp simp: thread_bound_ntfns_def get_tcb_def
@@ -1282,7 +1218,9 @@ lemma sts_thread_bound_ntfns[wp]:
   done
 
 lemma sts_thread_states[wp]:
-  "\<lbrace>\<lambda>s. P ((thread_states s)(t := tcb_st_to_auth st))\<rbrace> set_thread_state t st \<lbrace>\<lambda>rv s. P (thread_states s)\<rbrace>"
+  "\<lbrace>\<lambda>s. P ((thread_states s)(t := tcb_st_to_auth st))\<rbrace>
+   set_thread_state t st
+   \<lbrace>\<lambda>_ s. P (thread_states s)\<rbrace>"
   apply (simp add: set_thread_state_def)
   apply (wpsimp wp: set_object_wp dxo_wp_weak)
   apply (clarsimp simp: get_tcb_def thread_states_def tcb_states_of_state_def
@@ -1291,8 +1229,8 @@ lemma sts_thread_states[wp]:
 
 lemma sbn_thread_bound_ntfns[wp]:
   "\<lbrace>\<lambda>s. P ((thread_bound_ntfns s)(t := ntfn))\<rbrace>
-     set_bound_notification t ntfn
-   \<lbrace>\<lambda>rv s. P (thread_bound_ntfns s)\<rbrace>"
+   set_bound_notification t ntfn
+   \<lbrace>\<lambda>_ s. P (thread_bound_ntfns s)\<rbrace>"
   apply (simp add: set_bound_notification_def)
   apply (wpsimp wp: set_object_wp dxo_wp_weak)
   apply (clarsimp simp: get_tcb_def thread_bound_ntfns_def
@@ -1301,16 +1239,68 @@ lemma sbn_thread_bound_ntfns[wp]:
 
 (* FIXME move to AInvs *)
 lemma set_thread_state_ekheap[wp]:
-  "\<lbrace>\<lambda>s. P (ekheap s)\<rbrace> set_thread_state t st \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
+  "set_thread_state t st \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
   apply (simp add: set_thread_state_def)
   apply (wpsimp wp: set_scheduler_action_wp simp: set_thread_state_ext_def)
   done
 
+lemma set_simple_ko_tcb_states_of_state[wp]:
+  "set_simple_ko f ptr val \<lbrace>\<lambda>s. P (tcb_states_of_state s)\<rbrace>"
+  apply (simp add: set_simple_ko_def set_object_def)
+  apply (wp get_object_wp)
+  apply clarify
+  apply (clarsimp simp: thread_states_def obj_at_def get_tcb_def tcb_states_of_state_def
+                        partial_inv_def a_type_def
+                 elim!: rsubst[where P=P, OF _ ext]
+                 split: kernel_object.split_asm if_splits)
+  done
+
+lemma set_simple_ko_thread_states[wp]:
+  "set_simple_ko f ptr val \<lbrace>\<lambda>s. P (thread_states s)\<rbrace>"
+  apply (simp add: set_simple_ko_def set_object_def)
+  apply (wp get_object_wp)
+  apply clarify
+  apply (clarsimp simp: thread_states_def obj_at_def get_tcb_def tcb_states_of_state_def
+                        partial_inv_def a_type_def
+                 elim!: rsubst[where P=P, OF _ ext]
+                 split: kernel_object.split_asm if_splits)
+  done
+
+lemma set_simple_ko_thread_bound_ntfns[wp]:
+  "set_simple_ko f ptr val \<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace>"
+  apply (simp add: set_simple_ko_def set_object_def)
+  apply (wp get_object_wp)
+  apply clarify
+  apply (clarsimp simp: thread_bound_ntfns_def obj_at_def get_tcb_def tcb_states_of_state_def
+                        partial_inv_def a_type_def
+                 elim!: rsubst[where P=P, OF _ ext]
+                 split: kernel_object.split_asm if_splits)
+  done
+
+(* FIXME move to AInvs *)
+lemma set_simple_ko_ekheap[wp]:
+  "set_simple_ko f ptr ep \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
+  apply (simp add: set_simple_ko_def)
+  apply (wpsimp wp: get_object_wp)
+  done
+
+
+context CNode_AC_3 begin
+
+lemma sts_st_vrefs[wp]:
+  "set_thread_state t st \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
+  apply (simp add: set_thread_state_def del: set_thread_state_ext_extended.dxo_eq)
+  apply (wpsimp wp: set_object_wp dxo_wp_weak)
+  apply (clarsimp simp: state_vrefs_tcb_upd
+                 elim!: rsubst[where P=P, OF _ ext]
+                 dest!: get_tcb_SomeD)
+  done
+
 lemma set_thread_state_pas_refined:
   "\<lbrace>pas_refined aag and
-        K (\<forall>r \<in> tcb_st_to_auth st. (pasObjectAbs aag t, snd r, pasObjectAbs aag (fst r)) \<in> pasPolicy aag)\<rbrace>
-      set_thread_state t st
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+    K (\<forall>r \<in> tcb_st_to_auth st. abs_has_auth_to aag (snd r) t (fst r))\<rbrace>
+   set_thread_state t st
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def)
   apply (rule hoare_pre)
    apply (wp tcb_domain_map_wellformed_lift | wps)+
@@ -1321,58 +1311,14 @@ lemma set_thread_state_pas_refined:
   done
 
 lemma set_simple_ko_vrefs[wp]:
-  "\<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace> set_simple_ko f ptr val \<lbrace>\<lambda>rv s. P (state_vrefs s)\<rbrace>"
+  "set_simple_ko f ptr (val :: 'b) \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
   apply (simp add: set_simple_ko_def set_object_def)
   apply (wp get_object_wp)
-  apply clarify
-  apply (clarsimp simp: state_vrefs_def vs_refs_no_global_pts_def obj_at_def
-                        partial_inv_def a_type_def
-                 elim!: rsubst[where P=P, OF _ ext]
-                 split: Structures_A.kernel_object.split_asm if_splits)
-  done
-
-lemma set_simple_ko_tcb_states_of_state[wp]:
-  "\<lbrace>\<lambda>s. P (tcb_states_of_state s)\<rbrace> set_simple_ko f ptr val \<lbrace>\<lambda>rv s. P (tcb_states_of_state s)\<rbrace>"
-  apply (simp add: set_simple_ko_def set_object_def)
-  apply (wp get_object_wp)
-  apply clarify
-  apply (clarsimp simp: thread_states_def obj_at_def get_tcb_def tcb_states_of_state_def
-                        partial_inv_def a_type_def
-                 elim!: rsubst[where P=P, OF _ ext]
-                 split: Structures_A.kernel_object.split_asm if_splits)
-  done
-
-lemma set_simple_ko_thread_states[wp]:
-  "\<lbrace>\<lambda>s. P (thread_states s)\<rbrace> set_simple_ko f ptr val \<lbrace>\<lambda>rv s. P (thread_states s)\<rbrace>"
-  apply (simp add: set_simple_ko_def set_object_def)
-  apply (wp get_object_wp)
-  apply clarify
-  apply (clarsimp simp: thread_states_def obj_at_def get_tcb_def tcb_states_of_state_def
-                        partial_inv_def a_type_def
-                 elim!: rsubst[where P=P, OF _ ext]
-                 split: Structures_A.kernel_object.split_asm if_splits)
-  done
-
-lemma set_simple_ko_thread_bound_ntfns[wp]:
-  "\<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace> set_simple_ko f ptr val \<lbrace>\<lambda>rv s. P (thread_bound_ntfns s)\<rbrace>"
-  apply (simp add: set_simple_ko_def set_object_def)
-  apply (wp get_object_wp)
-  apply clarify
-  apply (clarsimp simp: thread_bound_ntfns_def obj_at_def get_tcb_def tcb_states_of_state_def
-                        partial_inv_def a_type_def
-                 elim!: rsubst[where P=P, OF _ ext]
-                 split: Structures_A.kernel_object.split_asm if_splits)
-  done
-
-(* FIXME move to AInvs *)
-lemma set_simple_ko_ekheap[wp]:
-  "\<lbrace>\<lambda>s. P (ekheap s)\<rbrace> set_simple_ko f ptr ep \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
-  apply (simp add: set_simple_ko_def)
-  apply (wpsimp wp: get_object_wp)
+  apply (fastforce simp: state_vrefs_simple_type_upd obj_at_def elim!: rsubst[where P=P, OF _ ext])
   done
 
 lemma set_simple_ko_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace> set_simple_ko f ptr ep \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "set_simple_ko f ptr (ep :: 'b) \<lbrace>pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def)
   apply (rule hoare_pre)
    apply (wp tcb_domain_map_wellformed_lift | wps)+
@@ -1380,284 +1326,74 @@ lemma set_simple_ko_pas_refined[wp]:
   done
 
 lemma thread_set_st_vrefs[wp]:
-  "\<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace> thread_set f t \<lbrace>\<lambda>rv s. P (state_vrefs s)\<rbrace>"
+  "thread_set f t \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
   apply (simp add: thread_set_def)
   apply (wpsimp wp: set_object_wp)
-  apply (clarsimp simp: state_vrefs_def vs_refs_no_global_pts_def
+  apply (clarsimp simp: state_vrefs_tcb_upd
                  elim!: rsubst[where P=P, OF _ ext] dest!: get_tcb_SomeD)
   done
 
+end
+
+
 lemma thread_set_thread_states_trivT:
   assumes st: "\<And>tcb. tcb_state (f tcb) = tcb_state tcb"
-  shows "\<lbrace>\<lambda>s. P (thread_states s)\<rbrace> thread_set f t \<lbrace>\<lambda>rv s. P (thread_states s)\<rbrace>"
+  shows "thread_set f t \<lbrace>\<lambda>s. P (thread_states s)\<rbrace>"
   apply (simp add: thread_set_def)
   apply (wpsimp wp: set_object_wp)
   apply (clarsimp simp: st get_tcb_def thread_states_def tcb_states_of_state_def
                  elim!: rsubst[where P=P, OF _ ext]
-                 split: Structures_A.kernel_object.split_asm)
+                 split: kernel_object.split_asm)
   done
 
 lemma thread_set_thread_bound_ntfns_trivT:
   assumes ntfn: "\<And>tcb. tcb_bound_notification (f tcb) = tcb_bound_notification tcb"
-  shows "\<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace> thread_set f t \<lbrace>\<lambda>rv s. P (thread_bound_ntfns s)\<rbrace>"
+  shows "thread_set f t \<lbrace>\<lambda>s :: det_ext state. P (thread_bound_ntfns s)\<rbrace>"
   apply (simp add: thread_set_def)
   apply (wpsimp wp: set_object_wp)
   apply (clarsimp simp: ntfn get_tcb_def thread_bound_ntfns_def tcb_states_of_state_def
                  elim!: rsubst[where P=P, OF _ ext]
-                 split: Structures_A.kernel_object.split_asm)
+                 split: kernel_object.split_asm)
   done
+
+
+context CNode_AC_3 begin
 
 lemma thread_set_pas_refined_triv:
   assumes cps: "\<And>tcb. \<forall>(getF, v)\<in>ran tcb_cap_cases. getF (f tcb) = getF tcb"
        and st: "\<And>tcb. tcb_state (f tcb) = tcb_state tcb"
       and ntfn: "\<And>tcb. tcb_bound_notification (f tcb) = tcb_bound_notification tcb"
-     shows "\<lbrace>pas_refined aag\<rbrace> thread_set f t \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (simp add: pas_refined_def state_objs_to_policy_def)
-  apply (rule hoare_pre)
-   apply (wp tcb_domain_map_wellformed_lift
-        | wps thread_set_caps_of_state_trivial[OF cps]
-              thread_set_thread_states_trivT[OF st]
-              thread_set_thread_bound_ntfns_trivT[OF ntfn]
-        | simp)+
-  done
+     shows "thread_set f t \<lbrace>pas_refined aag\<rbrace>"
+  by (wpsimp wp: tcb_domain_map_wellformed_lift simp: pas_refined_def state_objs_to_policy_def
+      | wps thread_set_caps_of_state_trivial[OF cps]
+            thread_set_thread_states_trivT[OF st]
+            thread_set_thread_bound_ntfns_trivT[OF ntfn])+
 
 lemmas thread_set_pas_refined = thread_set_pas_refined_triv[OF ball_tcb_cap_casesI]
 
+end
+
+
 lemma aag_owned_cdt_link:
-  "\<lbrakk> cdt s x = Some y; is_subject aag (fst y); pas_refined aag s ;
-     \<not> is_transferable (caps_of_state s x) \<rbrakk> \<Longrightarrow> is_subject aag (fst x)"
+  "\<lbrakk> cdt s x = Some y; is_subject aag (fst y);
+     pas_refined aag s; \<not> is_transferable (caps_of_state s x) \<rbrakk>
+     \<Longrightarrow> is_subject aag (fst x)"
   by (fastforce dest: sta_cdt pas_refined_mem pas_refined_Control)
 
 (* FIXME: MOVE *)
 lemma descendants_of_owned_or_transferable:
   "\<lbrakk> valid_mdb s; pas_refined aag s; p \<in> descendants_of q (cdt s); is_subject aag (fst q) \<rbrakk>
-       \<Longrightarrow> is_subject aag (fst p) \<or> is_transferable (caps_of_state s p)"
+     \<Longrightarrow> is_subject aag (fst p) \<or> is_transferable (caps_of_state s p)"
    using all_children_descendants_of pas_refined_all_children by blast
 
-lemma pas_refined_arch_state_update_not_asids[simp]:
- "(arm_asid_table (f (arch_state s)) = arm_asid_table (arch_state s)) \<Longrightarrow> pas_refined aag (arch_state_update f s) = pas_refined aag s"
-  by (simp add: pas_refined_def state_objs_to_policy_def)
 
-crunch cdt[wp]: store_pte "\<lambda>s. P (cdt s)"
-
-lemma store_pte_state_refs[wp]:
-  "\<lbrace>\<lambda>s. P (state_refs_of s)\<rbrace> store_pte p pte \<lbrace>\<lambda>rv s. P (state_refs_of s)\<rbrace>"
-  apply (simp add: store_pte_def set_pt_def set_object_def)
-  apply (wp get_object_wp)
-  apply (clarsimp simp: obj_at_def state_refs_of_def
-                 elim!: rsubst[where P=P, OF _ ext])
-  done
-
-lemma all_rsubst:
-  "\<lbrakk> \<forall>v. P (f v); \<exists>v. f v = r \<rbrakk> \<Longrightarrow> P r"
-  by clarsimp
-
-lemma store_pte_st_vrefs[wp]:
-  "\<lbrace>\<lambda>s. \<forall>S. P ((state_vrefs s) (p && ~~ mask pt_bits :=
-          (state_vrefs s (p && ~~ mask pt_bits) - S) \<union>
-             (\<Union>(p', sz, auth)\<in>set_option (pte_ref pte).
-                   (\<lambda>(p'', a). (p'', VSRef ((p && mask pt_bits) >> 2) (Some APageTable), a)) ` (ptr_range p' sz \<times> auth))))\<rbrace>
-      store_pte p pte \<lbrace>\<lambda>rv s. P (state_vrefs s)\<rbrace>"
-  apply (simp add: store_pte_def set_pt_def set_object_def)
-  apply (wp get_object_wp)
-  apply (clarsimp simp: state_vrefs_def vs_refs_no_global_pts_def obj_at_def)
-  apply (simp add: fun_upd_def[symmetric] fun_upd_comp)
-  apply (erule all_rsubst[where P=P])
-  apply (subst fun_eq_iff, clarsimp simp: split_def)
-  apply (cases "pte_ref pte")
-   apply (auto simp: ucast_ucast_mask shiftr_over_and_dist
-                     word_bw_assocs mask_def pt_bits_def pageBits_def)
-  done
-
-lemma store_pte_thread_states[wp]:
-  "\<lbrace>\<lambda>s. P (thread_states s)\<rbrace> store_pte p pte \<lbrace>\<lambda>rv s. P (thread_states s)\<rbrace>"
-  apply (simp add: store_pte_def set_pt_def set_object_def)
-  apply (wp get_object_wp)
-  apply (clarsimp simp: thread_states_def obj_at_def get_tcb_def tcb_states_of_state_def
-                 elim!: rsubst[where P=P, OF _ ext]
-                 split: Structures_A.kernel_object.split_asm option.split)
-  done
-
-lemma store_pte_thread_bound_ntfns[wp]:
-  "\<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace> store_pte p pte \<lbrace>\<lambda>rv s. P (thread_bound_ntfns s)\<rbrace>"
-  apply (simp add: store_pte_def set_pt_def set_object_def)
-  apply (wp get_object_wp)
-  apply (clarsimp simp: thread_bound_ntfns_def obj_at_def get_tcb_def tcb_states_of_state_def
-                 elim!: rsubst[where P=P, OF _ ext]
-                 split: Structures_A.kernel_object.split_asm option.split)
-  done
-
-lemma auth_graph_map_def2:
-  "auth_graph_map f S = (\<lambda>(x, auth, y). (f x, auth, f y)) ` S"
-  by (auto simp add: auth_graph_map_def image_def intro: rev_bexI)
-
-(* FIXME move to AInvs *)
-lemma store_pte_ekheap[wp]:
-  "\<lbrace>\<lambda>s. P (ekheap s)\<rbrace> store_pte p pte \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
-apply (simp add: store_pte_def set_pt_def)
-apply (wp get_object_wp)
-apply simp
-done
-
-lemma store_pte_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and K (\<forall>x. pte_ref pte = Some x \<longrightarrow> (\<forall>a \<in> snd (snd x).
-         \<forall>p' \<in> (ptr_range (fst x) (fst (snd x))). auth_graph_map (pasObjectAbs aag) {(p && ~~ mask pt_bits, a, p')} \<subseteq> pasPolicy aag))\<rbrace>
-        store_pte p pte \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (simp add: auth_graph_map_def2)
-  apply (simp add: pas_refined_def state_objs_to_policy_def)
-  apply (rule hoare_pre)
-   apply (wp tcb_domain_map_wellformed_lift | wps)+
-  apply clarsimp
-  apply (rule conjI)
-   apply (clarsimp dest!: auth_graph_map_memD split del: if_split)
-   apply (erule state_bits_to_policy.cases,
-          auto intro: state_bits_to_policy.intros auth_graph_map_memI
-               split: if_split_asm)[1]
-  apply (erule_tac B="state_asids_to_policy aag s" for s in subset_trans[rotated])
-  apply (auto intro: state_asids_to_policy_aux.intros
-              elim!: state_asids_to_policy_aux.cases
-              split: if_split_asm)
-  done
-
-lemma store_pde_st_vrefs[wp]:
-  "\<lbrace>\<lambda>s. \<forall>S. P ((state_vrefs s) (p && ~~ mask pd_bits :=
-          (state_vrefs s (p && ~~ mask pd_bits) - S) \<union>
-           (if ucast (kernel_base >> 20) \<le> (ucast (p && mask pd_bits >> 2)::12 word) then {}
-            else
-               (\<Union>(p', sz, auth)\<in>set_option (pde_ref2 pde).
-                   (\<lambda>(p'', a). (p'', VSRef ((p && mask pd_bits) >> 2) (Some APageDirectory), a)) ` (ptr_range p' sz \<times> auth)))))\<rbrace>
-      store_pde p pde \<lbrace>\<lambda>rv s. P (state_vrefs s)\<rbrace>"
-  apply (simp add: store_pde_def set_pd_def set_object_def split del: if_split)
-  apply (wp get_object_wp)
-  apply (clarsimp simp: obj_at_def)
-  apply (erule all_rsubst[where P=P], subst fun_eq_iff)
-  apply (clarsimp simp add: state_vrefs_def vs_refs_no_global_pts_def
-                            fun_upd_def[symmetric] fun_upd_comp)
-  apply (cases "pde_ref2 pde",
-         simp_all add: split_def insert_Diff_if Un_ac ucast_ucast_mask_shift_helper)
-  apply auto
-  done
-
-lemma store_pde_thread_states[wp]:
-  "\<lbrace>\<lambda>s. P (thread_states s)\<rbrace> store_pde p pde \<lbrace>\<lambda>rv s. P (thread_states s)\<rbrace>"
-  apply (simp add: store_pde_def set_pd_def set_object_def)
-  apply (wp get_object_wp)
-  apply (clarsimp simp: thread_states_def obj_at_def get_tcb_def tcb_states_of_state_def
-                 elim!: rsubst[where P=P, OF _ ext]
-                 split: Structures_A.kernel_object.split_asm option.split)
-  done
-
-lemma store_pde_thread_bound_ntfns[wp]:
-  "\<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace> store_pde p pde \<lbrace>\<lambda>rv s. P (thread_bound_ntfns s)\<rbrace>"
-  apply (simp add: store_pde_def set_pd_def set_object_def)
-  apply (wp get_object_wp)
-  apply (clarsimp simp: thread_bound_ntfns_def obj_at_def get_tcb_def tcb_states_of_state_def
-                 elim!: rsubst[where P=P, OF _ ext]
-                 split: Structures_A.kernel_object.split_asm option.split)
-  done
-
-lemma store_pde_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and K ((ucast (p && mask pd_bits >> 2)::12 word) < (ucast (kernel_base >> 20))
-           \<longrightarrow> (\<forall>x. pde_ref2 pde = Some x \<longrightarrow>  (\<forall>a \<in> snd (snd x).
-         \<forall>p' \<in> ptr_range (fst x) (fst (snd x)). auth_graph_map (pasObjectAbs aag) {(p && ~~ mask pd_bits, a, p')} \<subseteq> pasPolicy aag)))\<rbrace>
-      store_pde p pde \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (simp add: auth_graph_map_def2)
-  apply (simp add: pas_refined_def state_objs_to_policy_def)
-  apply (rule hoare_pre)
-   apply (wp tcb_domain_map_wellformed_lift | wps)+
-  apply (clarsimp split del: if_split)
-  apply (rule conjI)
-   apply (clarsimp dest!: auth_graph_map_memD split del: if_split)
-   apply (erule state_bits_to_policy.cases,
-          auto intro: state_bits_to_policy.intros auth_graph_map_memI
-               split: if_split_asm)[1]
-  apply (erule_tac B="state_asids_to_policy aag s" for s in subset_trans[rotated])
-  apply (auto intro: state_asids_to_policy_aux.intros
-              elim!: state_asids_to_policy_aux.cases
-              split: if_split_asm)
-  done
-
-lemmas pde_ref_simps = pde_ref_def[split_simps pde.split]
-    pde_ref2_def[split_simps pde.split]
-
-lemma set_asid_pool_st_vrefs[wp]:
-  "\<lbrace>\<lambda>s. P ((state_vrefs s) (p := (\<lambda>(r, p). (p, VSRef (ucast r)
-               (Some AASIDPool), Control)) ` graph_of pool))\<rbrace>
-      set_asid_pool p pool \<lbrace>\<lambda>rv s. P (state_vrefs s)\<rbrace>"
-  apply (simp add: set_asid_pool_def set_object_def)
-  apply (wp get_object_wp)
-  apply (clarsimp simp: state_vrefs_def fun_upd_def[symmetric] fun_upd_comp obj_at_def
-                        vs_refs_no_global_pts_def
-                 split: Structures_A.kernel_object.split_asm arch_kernel_obj.split_asm
-                 elim!: rsubst[where P=P, OF _ ext])
-  done
-
-lemma set_asid_pool_thread_states[wp]:
-  "\<lbrace>\<lambda>s. P (thread_states s)\<rbrace> set_asid_pool p pool \<lbrace>\<lambda>rv s. P (thread_states s)\<rbrace>"
-  apply (simp add: set_asid_pool_def)
-  apply (wpsimp wp: set_object_wp_strong)
-  apply (clarsimp simp: thread_states_def obj_at_def get_tcb_def tcb_states_of_state_def
-                 elim!: rsubst[where P=P, OF _ ext]
-                 split: Structures_A.kernel_object.split_asm option.split)
-  done
-
-lemma set_asid_pool_thread_bound_ntfns[wp]:
-  "\<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace> set_asid_pool p pool \<lbrace>\<lambda>rv s. P (thread_bound_ntfns s)\<rbrace>"
-  apply (simp add: set_asid_pool_def)
-  apply (wpsimp wp: set_object_wp_strong)
-  apply (clarsimp simp: thread_bound_ntfns_def obj_at_def get_tcb_def tcb_states_of_state_def
-                 elim!: rsubst[where P=P, OF _ ext]
-                 split: Structures_A.kernel_object.split_asm option.split)
-  done
-
-(* FIXME move to AInvs *)
-lemma set_asid_pool_ekheap[wp]:
-  "\<lbrace>\<lambda>s. P (ekheap s)\<rbrace> set_asid_pool p pool \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
-apply (simp add: set_asid_pool_def)
-apply (wp get_object_wp | simp)+
-done
-
-lemma set_asid_pool_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and (\<lambda>s. \<forall>(x, y) \<in> graph_of pool.
-                  auth_graph_map (pasObjectAbs aag) {(p, Control, y)} \<subseteq> pasPolicy aag
-               \<and> (\<forall>asid. arm_asid_table (arch_state s) (asid_high_bits_of asid) = Some p
-                       \<and> asid && mask asid_low_bits = ucast x
-                       \<longrightarrow> (pasASIDAbs aag asid, Control, pasObjectAbs aag y) \<in> pasPolicy aag))\<rbrace>
-         set_asid_pool p pool \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (simp add: auth_graph_map_def2 image_UN split_def)
-  apply (simp add: pas_refined_def state_objs_to_policy_def)
-  apply (rule hoare_pre)
-   apply (wp tcb_domain_map_wellformed_lift | wps)+
-  apply clarsimp
-  apply (rule conjI)
-   apply (clarsimp dest!: auth_graph_map_memD)
-   apply (erule state_bits_to_policy.cases,
-          auto intro: state_bits_to_policy.intros auth_graph_map_memI
-               split: if_split_asm)[1]
-  apply (auto intro: state_asids_to_policy_aux.intros
-               simp: subsetD[OF _ state_asids_to_policy_aux.intros(2)]
-              elim!: state_asids_to_policy_aux.cases
-              split: if_split_asm)
-  apply fastforce+
-  done
-
-lemma auth_graph_map_mem_imageI:
-  "(x, a, y) \<in> g \<Longrightarrow> (f x, a, f y) \<in> auth_graph_map f g"
-  unfolding auth_graph_map_def by auto
-
-lemma pas_refined_clear_asid:
-  "pas_refined aag s \<Longrightarrow> pas_refined aag (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := \<lambda>a. if a = asid then None else arm_asid_table (arch_state s) a\<rparr>\<rparr>)"
-  unfolding pas_refined_def
-  apply (auto simp: state_objs_to_policy_def elim!: state_asids_to_policy_aux.cases
-             split: if_split_asm intro: state_asids_to_policy_aux.intros)
-  apply (fastforce elim: state_asids_to_policy_aux.intros)+
-  done
+context CNode_AC_3 begin
 
 lemma set_ntfn_respects:
-  "\<lbrace>integrity aag X st
-          and K (\<exists>auth. aag_has_auth_to aag auth epptr \<and> auth \<in> {Receive, Notify, Reset})\<rbrace>
-     set_notification epptr ep'
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and
+    K (\<exists>auth. aag_has_auth_to aag auth epptr \<and> auth \<in> {Receive, Notify, Reset})\<rbrace>
+   set_notification epptr ep'
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: set_simple_ko_def set_object_def)
   apply (wp get_object_wp)
   apply (clarsimp simp: obj_at_def partial_inv_def a_type_def)
@@ -1667,16 +1403,17 @@ lemma set_ntfn_respects:
 
 crunch integrity_autarch: thread_set "integrity aag X st"
 
+end
+
+
 lemma sta_ts_mem:
-  "\<lbrakk> thread_states s x = S; r \<in> S \<rbrakk>
-      \<Longrightarrow> (x, snd r, fst r) \<in> state_objs_to_policy s"
+  "\<lbrakk> thread_states s x = S; r \<in> S \<rbrakk> \<Longrightarrow> (x, snd r, fst r) \<in> state_objs_to_policy s"
   using sta_ts by force
 
 lemma get_cap_auth_wp:
-  "\<lbrace>\<lambda>s. pas_refined aag s \<and> is_subject aag (fst p)
-       \<and> (\<forall>cap. caps_of_state s p = Some cap \<and> pas_cap_cur_auth aag cap \<longrightarrow> Q cap s)\<rbrace>
-     get_cap p
-   \<lbrace>Q\<rbrace>"
+  "\<lbrace>\<lambda>s. pas_refined aag s \<and> is_subject aag (fst p) \<and>
+        (\<forall>cap. caps_of_state s p = Some cap \<and> pas_cap_cur_auth aag cap \<longrightarrow> Q cap s)\<rbrace>
+   get_cap p \<lbrace>Q\<rbrace>"
   apply (wp get_cap_wp)
   apply clarsimp
   apply (drule spec, erule mp)
@@ -1685,7 +1422,7 @@ lemma get_cap_auth_wp:
 
 lemma get_cap_auth_conferred:
   "\<lbrace>pas_refined aag and K (is_subject aag (fst slot))\<rbrace>
-     get_cap slot
+   get_cap slot
    \<lbrace>\<lambda>rv s. \<forall>x\<in>obj_refs rv. \<forall>a \<in> cap_auth_conferred rv. aag_has_auth_to aag a x\<rbrace>"
   apply (wp get_cap_wp)
   apply (clarsimp simp: cte_wp_at_caps_of_state)
@@ -1700,109 +1437,154 @@ lemma cap_auth_conferred_cnode_cap:
 
 lemma get_cap_ret_is_subject:
   "\<lbrace>pas_refined aag and K (is_subject aag (fst slot))\<rbrace>
-     get_cap slot
+   get_cap slot
    \<lbrace>\<lambda>rv s. is_cnode_cap rv \<longrightarrow> is_subject aag (obj_ref_of rv)\<rbrace>"
-  apply(clarsimp simp: valid_def)
-  apply(frule get_cap_det)
-  apply(drule_tac f=fst in arg_cong)
-  apply(subst (asm) fst_conv)
+  apply (clarsimp simp: valid_def)
+  apply (frule get_cap_det)
+  apply (drule_tac f=fst in arg_cong)
+  apply (subst (asm) fst_conv)
   apply (drule in_get_cap_cte_wp_at[THEN iffD1])
   apply (clarsimp simp: cte_wp_at_caps_of_state)
-  apply(rule caps_of_state_pasObjectAbs_eq)
-      apply(blast intro: sym)
-     apply(blast intro: cap_auth_conferred_cnode_cap)
+  apply (rule caps_of_state_pasObjectAbs_eq)
+      apply (blast intro: sym)
+     apply (blast intro: cap_auth_conferred_cnode_cap)
     apply assumption+
-  apply(case_tac a, simp_all)
+  apply (case_tac a, simp_all)
   done
 
-definition
-  auth_derived :: "cap \<Rightarrow> cap \<Rightarrow> bool"
-where
- "auth_derived cap cap'
-    \<equiv> (cap_asid' cap \<subseteq> cap_asid' cap')
-    \<and> (untyped_range cap = untyped_range cap')
-    \<and> (obj_refs cap = obj_refs cap')
-    \<and> (cap_auth_conferred cap \<subseteq> cap_auth_conferred cap')
-    \<and> (cap_irqs_controlled cap = cap_irqs_controlled cap')"
+definition auth_derived :: "cap \<Rightarrow> cap \<Rightarrow> bool" where
+ "auth_derived cap cap' \<equiv>
+    (cap_asid' cap \<subseteq> cap_asid' cap')
+  \<and> (untyped_range cap = untyped_range cap')
+  \<and> (obj_refs cap = obj_refs cap')
+  \<and> (cap_auth_conferred cap \<subseteq> cap_auth_conferred cap')
+  \<and> (cap_irqs_controlled cap = cap_irqs_controlled cap')"
 
-definition
-  cnode_inv_auth_derivations :: "Invocations_A.cnode_invocation \<Rightarrow> 'z::state_ext state \<Rightarrow> bool"
-where
- "cnode_inv_auth_derivations ci \<equiv> case ci of
-    InsertCall cap ptr ptr' \<Rightarrow> cte_wp_at (auth_derived cap) ptr
-  | MoveCall cap ptr ptr' \<Rightarrow> cte_wp_at (auth_derived cap) ptr
-  | RotateCall s_cap p_cap src pivot dest
-      \<Rightarrow> cte_wp_at (auth_derived s_cap) src and cte_wp_at (auth_derived p_cap) pivot
-  | _ \<Rightarrow> \<top>"
+definition cnode_inv_auth_derivations ::
+  "Invocations_A.cnode_invocation \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
+  "cnode_inv_auth_derivations ci \<equiv> case ci of
+     InsertCall cap ptr ptr' \<Rightarrow> cte_wp_at (auth_derived cap) ptr
+   | MoveCall cap ptr ptr' \<Rightarrow> cte_wp_at (auth_derived cap) ptr
+   | RotateCall s_cap p_cap src pivot dest \<Rightarrow>
+       cte_wp_at (auth_derived s_cap) src and cte_wp_at (auth_derived p_cap) pivot
+   | _ \<Rightarrow> \<top>"
 
 lemma UNIV_eq_single_card:
   "(UNIV = {x :: 'a}) \<Longrightarrow> (card (UNIV :: 'a set) = 1)"
-  apply (erule ssubst)
-  apply simp
-  done
+  by (erule ssubst) simp
 
 lemma cli_cap_irqs_controlled:
   "(cap_irqs_controlled cap = cap_irqs_controlled cap') \<Longrightarrow>
     cap_links_irq aag (pasSubject aag) cap = cap_links_irq aag (pasSubject aag) cap'"
-  by (auto simp add: card_word cap_links_irq_def split: cap.splits dest!: UNIV_eq_single_card UNIV_eq_single_card [OF sym])
+  by (auto simp: card_word cap_links_irq_def split: cap.splits
+          dest!: UNIV_eq_single_card UNIV_eq_single_card [OF sym])
 
 lemma auth_derived_caps_of_state_impls:
-  "\<lbrakk> auth_derived cap cap'; caps_of_state s ptr = Some cap'; pas_refined aag s;
-     is_subject aag (fst ptr) \<rbrakk>
+  "\<lbrakk> auth_derived cap cap'; caps_of_state s ptr = Some cap';
+     pas_refined aag s; is_subject aag (fst ptr) \<rbrakk>
      \<Longrightarrow> pas_cap_cur_auth aag cap"
   unfolding aag_cap_auth_def
   apply (frule (1) clas_caps_of_state)
   apply (frule (1) cli_caps_of_state)
-  apply (clarsimp simp: auth_derived_def cap_links_asid_slot_def)
-  apply (auto dest: pas_refined_mem[OF sta_untyped] pas_refined_mem[OF sta_caps] cong: cli_cap_irqs_controlled)
+  apply (clarsimp simp: auth_derived_def cap_links_asid_slot_def cong: cli_cap_irqs_controlled)
+  apply (auto dest: pas_refined_mem[OF sta_untyped] pas_refined_mem[OF sta_caps])
   done
-
-crunch integrity_autarch: set_asid_pool "integrity aag X st"
-  (wp: crunch_wps)
-
-(* FIXME: move *)
-lemma a_type_arch_object_not_tcb[simp]:
-  "a_type (ArchObj arch_kernel_obj) \<noteq> ATCB"
-  by auto
 
 crunch cur_domain[wp]: deleted_irq_handler "\<lambda>s. P (cur_domain s)"
 
-lemma post_cap_deletion_cur_domain[wp]:
-  "\<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> post_cap_deletion c \<lbrace>\<lambda>rv s. P (cur_domain s)\<rbrace>"
-  by (wpsimp)
-
-crunch cur_domain[wp]: cap_swap_for_delete, empty_slot, finalise_cap  "\<lambda>s. P (cur_domain s)"
-  (wp: crunch_wps select_wp hoare_vcg_if_lift2 simp: unless_def)
-
 lemma preemption_point_cur_domain[wp]:
-  "\<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> preemption_point \<lbrace>\<lambda>_ s. P (cur_domain s)\<rbrace>"
+  "preemption_point \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
   by (wp preemption_point_inv', simp+)
 
+lemma cnode_inv_auth_derivations_If_Insert_Move:
+  "cnode_inv_auth_derivations ((if P then MoveCall else InsertCall) cap src_slot dest_slot) =
+   cnode_inv_auth_derivations (MoveCall cap src_slot dest_slot)"
+  by (simp add: cnode_inv_auth_derivations_def)
+
+
+context CNode_AC_3 begin
+
+lemma post_cap_deletion_cur_domain[wp]:
+  "post_cap_deletion c \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  by (wpsimp simp: post_cap_deletion_def)
+
+crunch cur_domain[wp]: cap_swap_for_delete, empty_slot "\<lambda>s. P (cur_domain s)"
+  (wp: crunch_wps select_wp hoare_vcg_if_lift2 simp: unless_def)
+
+crunch cur_domain[wp]: finalise_cap "\<lambda>s. P (cur_domain s)"
+  (wp: crunch_wps select_wp hoare_vcg_if_lift2 simp: unless_def)
+
 lemma rec_del_cur_domain[wp]:
-  "\<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> rec_del call \<lbrace>\<lambda>_ s. P (cur_domain s)\<rbrace>"
+  "rec_del call \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
   by (rule rec_del_preservation; wp)
 
 crunch cur_domain[wp]: cap_delete  "\<lambda>s. P (cur_domain s)"
 
 lemma cap_revoke_cur_domain[wp]:
-  "\<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> cap_revoke slot \<lbrace>\<lambda>_ s. P (cur_domain s)\<rbrace>"
+  "cap_revoke slot \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
   by (rule cap_revoke_preservation2; wp)
 
-lemma cnode_inv_auth_derivations_If_Insert_Move:
-  "cnode_inv_auth_derivations ((if P then MoveCall else InsertCall) cap src_slot dest_slot)
-      = cnode_inv_auth_derivations (MoveCall cap src_slot dest_slot)"
-  by (simp add: cnode_inv_auth_derivations_def)
+end
+
+
+locale CNode_AC_4 = CNode_AC_3 +
+  assumes cap_asid'_cap_rights_update[simp]:
+    "acap_asid' (acap_rights_update rights ao) = acap_asid' ao"
+  and untyped_range_cap_rights_update[simp]:
+    "untyped_range (cap_rights_update rights (ArchObjectCap ao)) = untyped_range (ArchObjectCap ao)"
+  and obj_refs_cap_rights_update[simp]:
+    "aobj_ref' (acap_rights_update rights ao) = aobj_ref' ao"
+  and auth_derived_arch_update_cap_data:
+    "auth_derived (ArchObjectCap ao) cap' \<Longrightarrow> auth_derived (arch_update_cap_data pres w ao) cap'"
+  and acap_auth_conferred_acap_rights_update:
+    "arch_cap_auth_conferred (acap_rights_update (acap_rights acap \<inter> R) acap)
+     \<subseteq> arch_cap_auth_conferred acap"
+  and arch_derive_cap_auth_derived:
+    "\<lbrace>\<lambda>s :: det_ext state. cte_wp_at (auth_derived (ArchObjectCap cap)) src_slot s\<rbrace>
+     arch_derive_cap cap
+     \<lbrace>\<lambda>rv s. cte_wp_at (auth_derived rv) src_slot s\<rbrace>, -"
+  and arch_derive_cap_clas:
+    "\<lbrace>\<lambda>s :: det_ext state. cap_links_asid_slot aag p (ArchObjectCap acap) \<rbrace>
+     arch_derive_cap acap
+     \<lbrace>\<lambda>rv s. cap_links_asid_slot aag p rv\<rbrace>, -"
+  and arch_derive_cap_obj_refs_auth:
+    "\<lbrace>K (\<forall>r\<in>obj_refs (ArchObjectCap cap).
+         \<forall>auth\<in>cap_auth_conferred (ArchObjectCap cap). aag_has_auth_to aag auth r)\<rbrace>
+     arch_derive_cap cap
+     \<lbrace>\<lambda>x s :: det_ext state. \<forall>r\<in>obj_refs x.
+                             \<forall>auth \<in> cap_auth_conferred x. aag_has_auth_to aag auth r\<rbrace>, -"
+  and arch_derive_cap_obj_refs_subset:
+    "\<lbrace>\<lambda>s :: det_ext state. (\<forall>x \<in> aobj_ref' acap. P x s)\<rbrace>
+     arch_derive_cap acap
+     \<lbrace>\<lambda>rv s. \<forall>x \<in> obj_refs rv. P x s\<rbrace>, -"
+  and arch_derive_cap_cli:
+    "\<lbrace>K (cap_links_irq aag l (ArchObjectCap ac))\<rbrace>
+     arch_derive_cap ac
+     \<lbrace>\<lambda>x (s :: det_ext state). cap_links_irq aag l x\<rbrace>, -"
+  and arch_derive_cap_untyped_range_subset:
+    "\<lbrace>\<lambda>s. \<forall>x \<in> untyped_range (ArchObjectCap acap). P x s\<rbrace>
+     arch_derive_cap acap
+     \<lbrace>\<lambda>rv s. \<forall>x \<in> untyped_range rv. P x s\<rbrace>, -"
+  and arch_update_cap_obj_refs_subset:
+    "\<lbrakk> x \<in> obj_refs (arch_update_cap_data pres data cap) \<rbrakk> \<Longrightarrow> x \<in> aobj_ref' cap"
+  and arch_update_cap_untyped_range_empty[simp]:
+    "untyped_range (arch_update_cap_data pres data cap) = {}"
+  and arch_update_cap_irqs_controlled_empty[simp]:
+    "cap_irqs_controlled (arch_update_cap_data pres data cap) = {}"
+  and arch_update_cap_links_asid_slot:
+    "cap_links_asid_slot aag p (arch_update_cap_data pres w acap) =
+     cap_links_asid_slot aag p (ArchObjectCap acap)"
+  and arch_update_cap_cap_auth_conferred_subset:
+    "y \<in> cap_auth_conferred (arch_update_cap_data b w acap)
+     \<Longrightarrow> y \<in> arch_cap_auth_conferred acap"
+begin
 
 lemma derive_cap_auth_derived:
-  "\<lbrace>\<lambda>s. cap \<noteq> cap.NullCap \<longrightarrow> cte_wp_at (auth_derived cap) src_slot s\<rbrace>
-      derive_cap src_slot cap
-   \<lbrace>\<lambda>rv s. rv \<noteq> cap.NullCap \<longrightarrow> cte_wp_at (auth_derived rv) src_slot s\<rbrace>, -"
-  apply (simp add: derive_cap_def)
-  apply (rule hoare_pre)
-   apply (wp | wpc | simp add: arch_derive_cap_def)+
-  apply (clarsimp simp: cte_wp_at_caps_of_state)
-  apply (safe, simp_all)
-  apply (clarsimp simp: auth_derived_def cap_auth_conferred_def is_page_cap_def)
+  "\<lbrace>\<lambda>s :: det_ext state. cap \<noteq> NullCap \<longrightarrow> cte_wp_at (auth_derived cap) src_slot s\<rbrace>
+   derive_cap src_slot cap
+   \<lbrace>\<lambda>rv s. rv \<noteq> NullCap \<longrightarrow> cte_wp_at (auth_derived rv) src_slot s\<rbrace>, -"
+  apply (wpsimp wp: arch_derive_cap_auth_derived simp: derive_cap_def | wp hoare_drop_imps)+
+  apply (auto simp: cte_wp_at_caps_of_state)
   done
 
 lemma cap_rights_to_auth_mono:
@@ -1811,39 +1593,29 @@ lemma cap_rights_to_auth_mono:
 
 lemma auth_derived_mask_cap:
   "auth_derived cap cap' \<Longrightarrow> auth_derived (mask_cap R cap) cap'"
-  apply (simp add: auth_derived_def mask_cap_def cap_rights_update_def
-                   is_cap_simps acap_rights_update_def
-                   validate_vm_rights_def vm_kernel_only_def
-                   vm_read_only_def
-            split: cap.split arch_cap.split bool.splits)
-  apply (rule conjI | clarsimp
-              | erule subsetD
-              | simp add: cap_auth_conferred_def vspace_cap_rights_to_auth_def
-                          reply_cap_rights_to_auth_def cap_rights_to_auth_def
-                          is_page_cap_def split: if_split_asm)+
-  done
+  using cap_rights_update_def acap_auth_conferred_acap_rights_update
+  by (simp add: mask_cap_def split: cap.splits)
+     (fastforce simp: cap_auth_conferred_def auth_derived_def
+                      cap_rights_to_auth_def reply_cap_rights_to_auth_def
+               split: if_splits)
 
 lemma auth_derived_update_cap_data:
-  "\<lbrakk> auth_derived cap cap'; update_cap_data pres w cap \<noteq> cap.NullCap  \<rbrakk>
-           \<Longrightarrow> auth_derived (update_cap_data pres w cap) cap'"
-  apply (simp add: update_cap_data_def is_cap_simps arch_update_cap_data_def
-                  split del: if_split cong: if_cong)
-  apply (clarsimp simp: badge_update_def Let_def split_def is_cap_simps
-                        is_page_cap_def
-                  split: if_split_asm
-              split del: if_split)
-  apply (simp_all add: auth_derived_def the_cnode_cap_def)
-  apply (simp_all add: cap_auth_conferred_def)
+  "\<lbrakk> auth_derived cap cap'; update_cap_data pres w cap \<noteq> NullCap \<rbrakk>
+     \<Longrightarrow> auth_derived (update_cap_data pres w cap) cap'"
+  apply (clarsimp simp: update_cap_data_def badge_update_def Let_def split_def
+                        is_cap_simps auth_derived_arch_update_cap_data
+                 split: if_split_asm)
+  apply (simp_all add: auth_derived_def cap_auth_conferred_def the_cnode_cap_def)
   done
 
 lemma cte_wp_at_auth_derived_mask_cap_strg:
   "cte_wp_at (auth_derived cap) p s
-      \<longrightarrow> cte_wp_at (auth_derived (mask_cap R cap)) p s"
+   \<longrightarrow> cte_wp_at (auth_derived (mask_cap R cap)) p s"
   by (clarsimp simp: cte_wp_at_caps_of_state auth_derived_mask_cap)
 
 lemma cte_wp_at_auth_derived_update_cap_data_strg:
-  "cte_wp_at (auth_derived cap) p s \<and> update_cap_data pres w cap \<noteq> cap.NullCap
-      \<longrightarrow> cte_wp_at (auth_derived (update_cap_data pres w cap)) p s"
+  "cte_wp_at (auth_derived cap) p s \<and> update_cap_data pres w cap \<noteq> NullCap
+   \<longrightarrow> cte_wp_at (auth_derived (update_cap_data pres w cap)) p s"
   by (clarsimp simp: cte_wp_at_caps_of_state auth_derived_update_cap_data)
 
 lemma get_cap_auth_derived:
@@ -1853,62 +1625,37 @@ lemma get_cap_auth_derived:
   done
 
 lemma decode_cnode_invocation_auth_derived:
-  "\<lbrace>\<top>\<rbrace> decode_cnode_invocation label args cap excaps
+  "\<lbrace>\<top> :: det_ext state \<Rightarrow> bool\<rbrace>
+   decode_cnode_invocation label args cap excaps
    \<lbrace>cnode_inv_auth_derivations\<rbrace>,-"
-  apply (simp add: decode_cnode_invocation_def split_def whenE_def unlessE_def
-                 split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp derive_cap_auth_derived get_cap_auth_derived
-             hoare_vcg_all_lift
-            | wpc
-            | simp add: cnode_inv_auth_derivations_If_Insert_Move[unfolded cnode_inv_auth_derivations_def]
-                        cnode_inv_auth_derivations_def split_def whenE_def
-                    split del: if_split
-            | strengthen cte_wp_at_auth_derived_mask_cap_strg
-                         cte_wp_at_auth_derived_update_cap_data_strg
-            | wp (once) hoare_drop_imps)+
+  apply (simp add: decode_cnode_invocation_def split_def whenE_def unlessE_def split del: if_split)
+  apply (wpsimp wp: derive_cap_auth_derived get_cap_auth_derived hoare_vcg_all_lift
+              simp: cnode_inv_auth_derivations_If_Insert_Move[unfolded cnode_inv_auth_derivations_def]
+                    cnode_inv_auth_derivations_def split_def whenE_def split_del: if_split
+         | strengthen cte_wp_at_auth_derived_mask_cap_strg cte_wp_at_auth_derived_update_cap_data_strg
+         | wp (once) hoare_drop_imps)+
   done
 
-
 lemma derive_cap_clas:
-  "\<lbrace>\<lambda>s. (\<not> is_pg_cap b) \<longrightarrow> cap_links_asid_slot aag p b \<rbrace>
-     derive_cap a b
+  "\<lbrace>\<lambda>s :: det_ext state. cap_links_asid_slot aag p b \<rbrace>
+   derive_cap a b
    \<lbrace>\<lambda>rv s. cap_links_asid_slot aag p rv\<rbrace>, -"
-  apply (simp add: derive_cap_def arch_derive_cap_def  cong: cap.case_cong)
+  apply (simp add: derive_cap_def  cong: cap.case_cong)
   apply (rule hoare_pre)
-  apply (wp | wpc)+
+  apply (wp arch_derive_cap_clas | wpc)+
   apply (auto simp: is_cap_simps cap_links_asid_slot_def)
   done
 
-lemma arch_derive_cap_obj_refs_auth:
-  "\<lbrace>K (\<forall>r\<in>obj_refs (cap.ArchObjectCap cap). \<forall>auth\<in>cap_auth_conferred (cap.ArchObjectCap cap). aag_has_auth_to aag auth r)\<rbrace>
-  arch_derive_cap cap
-  \<lbrace>(\<lambda>x s. \<forall>r\<in>obj_refs x. \<forall>auth\<in>cap_auth_conferred x. aag_has_auth_to aag auth r)\<rbrace>, -"
-  unfolding arch_derive_cap_def
-  apply (rule hoare_pre)
-   apply (wp | wpc)+
-  apply (clarsimp simp: cap_auth_conferred_def is_page_cap_def)
-  done
-
 lemma derive_cap_obj_refs_auth:
-  "\<lbrace>K (\<forall>r\<in>obj_refs cap. \<forall>auth\<in>cap_auth_conferred cap. aag_has_auth_to aag auth r)\<rbrace>
-  derive_cap slot cap
-  \<lbrace>\<lambda>x s. (\<forall>r\<in>obj_refs x. \<forall>auth\<in>cap_auth_conferred x. aag_has_auth_to aag auth r) \<rbrace>, -"
-  unfolding derive_cap_def
-  apply (rule hoare_pre)
-   apply (wp arch_derive_cap_obj_refs_auth | wpc | simp)+
-  done
-
-lemma arch_derive_cap_cli:
-  "\<lbrace>K (cap_links_irq aag l (ArchObjectCap ac))\<rbrace>
-   arch_derive_cap ac
-   \<lbrace>\<lambda>x s. cap_links_irq aag l x\<rbrace>, -"
-  by (wpsimp simp: arch_derive_cap_def comp_def cli_no_irqs)
+  "\<lbrace>\<lambda>s :: det_ext state. (\<forall>r\<in>obj_refs cap. \<forall>auth\<in>cap_auth_conferred cap. aag_has_auth_to aag auth r)\<rbrace>
+   derive_cap slot cap
+   \<lbrace>\<lambda>x s. (\<forall>r\<in>obj_refs x. \<forall>auth\<in>cap_auth_conferred x. aag_has_auth_to aag auth r) \<rbrace>, -"
+  by (wpsimp wp: arch_derive_cap_obj_refs_auth simp: derive_cap_def)
 
 lemma derive_cap_cli:
   "\<lbrace>K (cap_links_irq aag l cap)\<rbrace>
-  derive_cap slot cap
-  \<lbrace>\<lambda>x s. cap_links_irq aag l x \<rbrace>, -"
+   derive_cap slot cap
+   \<lbrace>\<lambda>x s :: det_ext state. cap_links_irq aag l x\<rbrace>, -"
   unfolding derive_cap_def
   apply (rule hoare_pre)
   apply (wp arch_derive_cap_cli | wpc | simp add: comp_def cli_no_irqs)+
@@ -1917,38 +1664,26 @@ lemma derive_cap_cli:
 
 (* FIXME: move *)
 lemma derive_cap_obj_refs_subset:
-  "\<lbrace>\<lambda>s. \<forall>x \<in> obj_refs cap. P x s\<rbrace> derive_cap slot cap \<lbrace>\<lambda>rv s. \<forall>x \<in> obj_refs rv. P x s\<rbrace>, -"
-  unfolding derive_cap_def arch_derive_cap_def
+  "\<lbrace>\<lambda>s :: det_ext state. \<forall>x \<in> obj_refs cap. P x s\<rbrace>
+   derive_cap slot cap
+   \<lbrace>\<lambda>rv s. \<forall>x \<in> obj_refs rv. P x s\<rbrace>, -"
+  unfolding derive_cap_def
   apply (rule hoare_pre)
   apply (simp cong: cap.case_cong)
-  apply (wp | wpc)+
+  apply (wp arch_derive_cap_obj_refs_subset | wpc)+
   apply fastforce
   done
 
 (* FIXME: move *)
 lemma derive_cap_untyped_range_subset:
-  "\<lbrace>\<lambda>s. \<forall>x \<in> untyped_range cap. P x s\<rbrace> derive_cap slot cap \<lbrace>\<lambda>rv s. \<forall>x \<in> untyped_range rv. P x s\<rbrace>, -"
-  unfolding derive_cap_def arch_derive_cap_def
+  "\<lbrace>\<lambda>s :: det_ext state. \<forall>x \<in> untyped_range cap. P x s\<rbrace>
+   derive_cap slot cap
+   \<lbrace>\<lambda>rv s. \<forall>x \<in> untyped_range rv. P x s\<rbrace>, -"
+  unfolding derive_cap_def
   apply (rule hoare_pre)
-  apply (simp cong: cap.case_cong)
-  apply (wp | wpc)+
+   apply (simp cong: cap.case_cong)
+   apply (wp arch_derive_cap_untyped_range_subset | wpc)+
   apply fastforce
-  done
-
-(* FIXME: move *)
-lemma update_cap_obj_refs_subset:
-  "x \<in> obj_refs (update_cap_data P dt cap) \<Longrightarrow> x \<in> obj_refs cap"
-  apply (case_tac cap,
-         simp_all add: update_cap_data_closedform
-                split: if_split_asm)
-  done
-
-(* FIXME: move *)
-lemma update_cap_untyped_range_subset:
-  "x \<in> untyped_range (update_cap_data P dt cap) \<Longrightarrow> x \<in> untyped_range cap"
-  apply (case_tac cap,
-         simp_all add: update_cap_data_closedform
-                split: if_split_asm)
   done
 
 lemmas derive_cap_aag_caps =
@@ -1958,12 +1693,54 @@ lemmas derive_cap_aag_caps =
   derive_cap_cli
 
 lemma derive_cap_cap_cur_auth [wp]:
-  "\<lbrace>\<lambda>s. pas_cap_cur_auth aag cap\<rbrace> derive_cap slot cap \<lbrace>\<lambda>rv s. pas_cap_cur_auth aag rv\<rbrace>, -"
+  "\<lbrace>\<lambda>s :: det_ext state. pas_cap_cur_auth aag cap\<rbrace>
+   derive_cap slot cap
+   \<lbrace>\<lambda>rv s. pas_cap_cur_auth aag rv\<rbrace>, -"
   unfolding aag_cap_auth_def
   apply (rule hoare_pre)
   apply (wp derive_cap_aag_caps)
   apply simp
   done
+
+(* FIXME AC: replace ArchIpc_AI.update_cap_data_closedform with the following *)
+lemma update_cap_data_closedform:
+  "update_cap_data pres w cap =
+   (case cap of
+      EndpointCap r badge rights \<Rightarrow>
+        if badge = 0 \<and> \<not> pres then (EndpointCap r (w && mask badge_bits) rights) else NullCap
+    | NotificationCap r badge rights \<Rightarrow>
+        if badge = 0 \<and> \<not> pres then (NotificationCap r (w && mask badge_bits) rights) else NullCap
+    | CNodeCap r bits guard \<Rightarrow>
+        if word_bits < fst (update_cnode_cap_data w) + bits
+        then NullCap
+        else CNodeCap r bits ((\<lambda>g''. drop (size g'' - fst (update_cnode_cap_data w)) (to_bl g''))
+                             (snd (update_cnode_cap_data w)))
+    | ThreadCap r \<Rightarrow> ThreadCap r
+    | DomainCap \<Rightarrow> DomainCap
+    | UntypedCap d p n idx \<Rightarrow> UntypedCap d p n idx
+    | NullCap \<Rightarrow> NullCap
+    | ReplyCap t m rights \<Rightarrow> ReplyCap t m rights
+    | IRQControlCap \<Rightarrow> IRQControlCap
+    | IRQHandlerCap irq \<Rightarrow> IRQHandlerCap irq
+    | Zombie r b n \<Rightarrow> Zombie r b n
+    | ArchObjectCap cap \<Rightarrow> arch_update_cap_data pres w cap)"
+  by (cases cap,
+         simp_all only: cap.simps update_cap_data_def is_ep_cap.simps if_False if_True
+                        is_ntfn_cap.simps is_cnode_cap.simps is_arch_cap_def word_size
+                        cap_ep_badge.simps badge_update_def o_def cap_rights_update_def
+                        simp_thms cap_rights.simps Let_def split_def
+                        the_cnode_cap_def fst_conv snd_conv fun_app_def the_arch_cap_def
+                  cong: if_cong)
+
+(* FIXME: move *)
+lemma update_cap_obj_refs_subset:
+  "x \<in> obj_refs (update_cap_data P dt cap) \<Longrightarrow> x \<in> obj_refs cap"
+  by (cases cap; simp add: update_cap_data_closedform arch_update_cap_obj_refs_subset split: if_splits)
+
+(* FIXME: move *)
+lemma update_cap_untyped_range_subset:
+  "x \<in> untyped_range (update_cap_data P dt cap) \<Longrightarrow> x \<in> untyped_range cap"
+  by (cases cap; simp add: update_cap_data_closedform split: if_split_asm)
 
 lemma P_0_1_spec:
   "\<lbrakk> (\<forall>x < length xs. P x); 2 \<le> length xs \<rbrakk> \<Longrightarrow> P 0 \<and> P 1"
@@ -1971,27 +1748,24 @@ lemma P_0_1_spec:
 
 lemma clas_update_cap_data [simp]:
   "cap_links_asid_slot aag p (update_cap_data pres w cap) = cap_links_asid_slot aag p cap"
-  unfolding cap_links_asid_slot_def update_cap_data_closedform arch_update_cap_data_def
-  apply (cases cap)
-  apply simp_all
-  done
+  unfolding cap_links_asid_slot_def update_cap_data_closedform
+  by (cases cap) (auto simp: arch_update_cap_links_asid_slot[simplified cap_links_asid_slot_def])
 
 lemma update_cap_cap_auth_conferred_subset:
   "x \<in> cap_auth_conferred (update_cap_data b w cap) \<Longrightarrow> x \<in> cap_auth_conferred cap"
   unfolding update_cap_data_def
-  apply (clarsimp split: if_split_asm simp: is_cap_simps cap_auth_conferred_def cap_rights_to_auth_def badge_update_def the_cnode_cap_def
-    Let_def vspace_cap_rights_to_auth_def arch_update_cap_data_def)
-  done
+  by (auto simp: is_cap_simps cap_auth_conferred_def cap_rights_to_auth_def badge_update_def
+                 the_cnode_cap_def Let_def arch_update_cap_cap_auth_conferred_subset
+          split: if_split_asm)
 
 lemma update_cap_cli:
   "cap_links_irq aag l (update_cap_data b w cap) = cap_links_irq aag l cap"
-  unfolding update_cap_data_def arch_update_cap_data_def
-  apply (cases cap, simp_all add: is_cap_simps cli_no_irqs badge_update_def the_cnode_cap_def Let_def)
-  done
+  unfolding update_cap_data_def
+  by (cases cap, simp_all add: is_cap_simps cli_no_irqs badge_update_def the_cnode_cap_def Let_def)
 
 lemma untyped_range_update_cap_data [simp]:
   "untyped_range (update_cap_data b w c) = untyped_range c"
-  unfolding update_cap_data_def arch_update_cap_data_def
+  unfolding update_cap_data_def
   by (cases c, simp_all add: is_cap_simps badge_update_def Let_def the_cnode_cap_def)
 
 end

--- a/proof/access-control/DomainSepInv.thy
+++ b/proof/access-control/DomainSepInv.thy
@@ -6,11 +6,9 @@
 
 theory DomainSepInv
 imports
-  "Ipc_AC" (* for transfer_caps_loop_pres_dest lec_valid_cap' set_simple_ko_get_tcb thread_set_tcb_fault_update_valid_mdb *)
+  "ArchIpc_AC" (* for transfer_caps_loop_pres_dest lec_valid_cap' set_simple_ko_get_tcb thread_set_tcb_fault_update_valid_mdb *)
   "Lib.WPBang"
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 text \<open>
   We define and prove an invariant that is necessary to achieve domain
@@ -25,197 +23,209 @@ text \<open>
 text \<open>
   When @{term irqs} is @{term False} we require that non-timer IRQs are off permanently.
 \<close>
-definition domain_sep_inv where
+definition domain_sep_inv :: "bool \<Rightarrow> 'a :: state_ext state \<Rightarrow> 'b :: state_ext state \<Rightarrow> bool" where
   "domain_sep_inv irqs st s \<equiv>
-    (\<forall> slot. \<not> cte_wp_at ((=) DomainCap) slot s) \<and>
-    (irqs \<or> (\<forall> irq slot. \<not> cte_wp_at ((=) IRQControlCap) slot s
-      \<and> \<not> cte_wp_at ((=) (IRQHandlerCap irq)) slot s
-      \<and> interrupt_states s irq \<noteq> IRQSignal
-      \<and> interrupt_states s irq \<noteq> IRQReserved
-      \<and> interrupt_states s = interrupt_states st))"
+    (\<forall>slot. \<not> cte_wp_at ((=) DomainCap) slot s) \<and>
+    (irqs \<or> (\<forall>irq slot. \<not> cte_wp_at ((=) IRQControlCap) slot s
+                      \<and> \<not> cte_wp_at ((=) (IRQHandlerCap irq)) slot s
+                      \<and> interrupt_states s irq \<noteq> IRQSignal
+                      \<and> interrupt_states s irq \<noteq> IRQReserved
+                      \<and> interrupt_states s = interrupt_states st))"
 
 definition domain_sep_inv_cap where
   "domain_sep_inv_cap irqs cap \<equiv> case cap of
-    IRQControlCap \<Rightarrow> irqs
-  | IRQHandlerCap irq \<Rightarrow> irqs
-  | DomainCap \<Rightarrow> False
-  | _ \<Rightarrow> True"
-
+     IRQControlCap \<Rightarrow> irqs
+   | IRQHandlerCap irq \<Rightarrow> irqs
+   | DomainCap \<Rightarrow> False
+   | _ \<Rightarrow> True"
 
 lemma cte_wp_at_not_domain_sep_inv_cap:
   "cte_wp_at (not domain_sep_inv_cap irqs) slot s \<longleftrightarrow>
    ((irqs \<longrightarrow> False) \<and>
     (\<not> irqs \<longrightarrow> (cte_wp_at ((=) IRQControlCap) slot s \<or>
-                    (\<exists> irq. cte_wp_at ((=) (IRQHandlerCap irq)) slot s)))
-   )
-   \<or> cte_wp_at ((=) DomainCap) slot s"
-  apply(rule iffI)
-   apply(drule cte_wp_at_eqD)
+                 (\<exists> irq. cte_wp_at ((=) (IRQHandlerCap irq)) slot s)))) \<or>
+   cte_wp_at ((=) DomainCap) slot s"
+  apply (rule iffI)
+   apply (drule cte_wp_at_eqD)
    apply clarsimp
-   apply(case_tac c, simp_all add: domain_sep_inv_cap_def pred_neg_def)
-   apply(auto elim: cte_wp_at_weakenE split: if_splits)
+   apply (case_tac c, simp_all add: domain_sep_inv_cap_def pred_neg_def)
+   apply (auto elim: cte_wp_at_weakenE split: if_splits)
   done
 
 lemma domain_sep_inv_def2:
   "domain_sep_inv irqs st s =
-    ((\<forall> slot. \<not> cte_wp_at ((=) DomainCap) slot s) \<and>
-    (irqs \<or> (\<forall> irq slot. \<not> cte_wp_at ((=) IRQControlCap) slot s
-                            \<and> \<not> cte_wp_at ((=) (IRQHandlerCap irq)) slot s)) \<and>
-    (irqs \<or> (\<forall> irq.
-        interrupt_states s irq \<noteq> IRQSignal
-        \<and> interrupt_states s irq \<noteq> IRQReserved
-        \<and> interrupt_states s = interrupt_states st)))"
-  apply(fastforce simp: domain_sep_inv_def)
-  done
+    ((\<forall>slot. \<not> cte_wp_at ((=) DomainCap) slot s) \<and>
+     (irqs \<or> (\<forall>irq slot. \<not> cte_wp_at ((=) IRQControlCap) slot s
+                       \<and> \<not> cte_wp_at ((=) (IRQHandlerCap irq)) slot s)) \<and>
+     (irqs \<or> (\<forall>irq. interrupt_states s irq \<noteq> IRQSignal
+                  \<and> interrupt_states s irq \<noteq> IRQReserved
+                  \<and> interrupt_states s = interrupt_states st)))"
+  by (fastforce simp: domain_sep_inv_def)
 
 lemma domain_sep_inv_wp:
-  assumes nctrl: "\<And>slot. \<lbrace>(\<lambda>s. \<not> cte_wp_at (not domain_sep_inv_cap irqs) slot s) and P\<rbrace> f \<lbrace>\<lambda>_ s. \<not> cte_wp_at (not domain_sep_inv_cap irqs) slot s\<rbrace>"
-  assumes irq_pres: "\<And>P. \<not> irqs \<Longrightarrow> \<lbrace>(\<lambda>s. P (interrupt_states s)) and R\<rbrace> f \<lbrace>\<lambda>_ s. P (interrupt_states s)\<rbrace>"
-  shows "\<lbrace>domain_sep_inv irqs st and P and (\<lambda>s. irqs \<or> R s)\<rbrace> f \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  assumes nctrl:
+    "\<And>slot. \<lbrace>(\<lambda>s. \<not> cte_wp_at (not domain_sep_inv_cap irqs) slot s) and P\<rbrace>
+             f
+             \<lbrace>\<lambda>_ s. \<not> cte_wp_at (not domain_sep_inv_cap irqs) slot s\<rbrace>"
+  assumes irq_pres:
+    "\<And>P. \<not> irqs \<Longrightarrow> \<lbrace>(\<lambda>s. P (interrupt_states s)) and R\<rbrace>
+                     f
+                     \<lbrace>\<lambda>_ s. P (interrupt_states s)\<rbrace>"
+  shows
+    "\<lbrace>domain_sep_inv irqs st and P and (\<lambda>s. irqs \<or> R s)\<rbrace>
+     f
+     \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
   apply (clarsimp simp: domain_sep_inv_def2 valid_def)
   apply (subst conj_assoc[symmetric])
   apply (rule conjI)
    apply (rule conjI)
-    apply(intro allI)
-    apply(erule use_valid[OF _ hoare_strengthen_post[OF nctrl]])
-     apply(fastforce simp: cte_wp_at_not_domain_sep_inv_cap)
-    apply(fastforce simp: cte_wp_at_not_domain_sep_inv_cap)
-   apply(fastforce elim!: use_valid[OF _ hoare_strengthen_post[OF nctrl]] simp: cte_wp_at_not_domain_sep_inv_cap)
-  apply(case_tac "irqs")
+    apply (intro allI)
+    apply (erule use_valid[OF _ hoare_strengthen_post[OF nctrl]])
+     apply (fastforce simp: cte_wp_at_not_domain_sep_inv_cap)
+    apply (fastforce simp: cte_wp_at_not_domain_sep_inv_cap)
+   apply (fastforce elim!: use_valid[OF _ hoare_strengthen_post[OF nctrl]]
+                     simp: cte_wp_at_not_domain_sep_inv_cap)
+  apply (case_tac "irqs")
    apply blast
-  apply(rule disjI2)
+  apply (rule disjI2)
   apply simp
-  apply(intro allI conjI)
-    apply(erule_tac P1="\<lambda>x. x irq \<noteq> IRQSignal" in use_valid[OF _ irq_pres], assumption)
+  apply (intro allI conjI)
+    apply (erule_tac P1="\<lambda>x. x irq \<noteq> IRQSignal" in use_valid[OF _ irq_pres], assumption)
     apply blast
-   apply(erule use_valid[OF _ irq_pres], assumption)
+   apply (erule use_valid[OF _ irq_pres], assumption)
    apply blast
-  apply(erule use_valid[OF _ irq_pres], assumption)
+  apply (erule use_valid[OF _ irq_pres], assumption)
   apply blast
   done
 
 lemma domain_sep_inv_triv:
   assumes cte_pres: "\<And>P slot. \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace> f \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
   assumes irq_pres: "\<And>P. \<lbrace>\<lambda>s. P (interrupt_states s)\<rbrace> f \<lbrace>\<lambda>_ s. P (interrupt_states s)\<rbrace>"
-  shows
-  "\<lbrace>domain_sep_inv irqs st\<rbrace> f \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(rule domain_sep_inv_wp[where P="\<top>" and R="\<top>", simplified])
-  apply(rule cte_pres, rule irq_pres)
+  shows "\<lbrace>domain_sep_inv irqs st\<rbrace> f \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  apply (rule domain_sep_inv_wp[where P="\<top>" and R="\<top>", simplified])
+  apply (rule cte_pres, rule irq_pres)
   done
 
-(* FIXME: clagged from FinalCaps *)
-lemma set_object_wp:
-  "\<lbrace> \<lambda> s. P (s\<lparr>kheap := kheap s(ptr \<mapsto> obj)\<rparr>) \<rbrace>
-   set_object ptr obj
-   \<lbrace> \<lambda>_. P \<rbrace>"
-  by (wpsimp wp: set_object_wp)
+lemma domain_sep_inv_arch_state_update[simp]:
+  "domain_sep_inv irqs st (s\<lparr>arch_state := blah\<rparr>) = domain_sep_inv irqs st s"
+  by (simp add: domain_sep_inv_def)
+
+lemma domain_sep_inv_machine_state_update[simp]:
+  "domain_sep_inv irqs st (s\<lparr>machine_state := X\<rparr>) = domain_sep_inv irqs st s"
+  by (simp add: domain_sep_inv_def)
+
+lemma detype_interrupts_states[simp]:
+  "interrupt_states (detype S s) = interrupt_states s"
+  by (simp add: detype_def)
+
+lemma detype_domain_sep_inv[simp]:
+  "domain_sep_inv irqs st s \<longrightarrow> domain_sep_inv irqs st (detype S s)"
+  by (fastforce simp: domain_sep_inv_def)
+
+lemma domain_sep_inv_detype_lift:
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. domain_sep_inv irqs st\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. domain_sep_inv irqs st (detype S s)\<rbrace>"
+  by (strengthen detype_domain_sep_inv, assumption)
+
+crunch domain_sep_inv[wp]: set_extra_badge "domain_sep_inv irqs st"
 
 (* FIXME: following 3 lemmas clagged from FinalCaps *)
 lemma set_cap_neg_cte_wp_at_other_helper':
-  "\<lbrakk>oslot \<noteq> slot;
-    ko_at (TCB x) (fst oslot) s;
-    tcb_cap_cases (snd oslot) = Some (ogetF, osetF, orestr);
-        kheap
-         (s\<lparr>kheap := kheap s(fst oslot \<mapsto>
-              TCB (osetF (\<lambda> x. cap) x))\<rparr>)
-         (fst slot) =
-        Some (TCB tcb);
-        tcb_cap_cases (snd slot) = Some (getF, setF, restr);
-        P (getF tcb)\<rbrakk> \<Longrightarrow>
-   cte_wp_at P slot s"
-  apply(case_tac "fst oslot = fst slot")
-   apply(rule cte_wp_at_tcbI)
-     apply(fastforce split: if_splits simp: obj_at_def)
+  "\<lbrakk> oslot \<noteq> slot; ko_at (TCB x) (fst oslot) s;
+     tcb_cap_cases (snd oslot) = Some (ogetF, osetF, orestr);
+     kheap (s\<lparr>kheap := kheap s(fst oslot \<mapsto> TCB (osetF (\<lambda> x. cap) x))\<rparr>) (fst slot) = Some (TCB tcb);
+     tcb_cap_cases (snd slot) = Some (getF, setF, restr); P (getF tcb) \<rbrakk>
+     \<Longrightarrow> cte_wp_at P slot s"
+  apply (case_tac "fst oslot = fst slot")
+   apply (rule cte_wp_at_tcbI)
+     apply (fastforce split: if_splits simp: obj_at_def)
     apply assumption
-   apply(fastforce split: if_splits simp: tcb_cap_cases_def dest: prod_eqI)
-  apply(rule cte_wp_at_tcbI)
-    apply(fastforce split: if_splits simp: obj_at_def)
+   apply (fastforce split: if_splits simp: tcb_cap_cases_def dest: prod_eqI)
+  apply (rule cte_wp_at_tcbI)
+    apply (fastforce split: if_splits simp: obj_at_def)
    apply assumption
   apply assumption
   done
 
 lemma set_cap_neg_cte_wp_at_other_helper:
-  "\<lbrakk>\<not> cte_wp_at P slot s; oslot \<noteq> slot; ko_at (TCB x) (fst oslot) s;
-     tcb_cap_cases (snd oslot) = Some (getF, setF, restr)\<rbrakk>  \<Longrightarrow>
-   \<not> cte_wp_at P slot (s\<lparr>kheap := kheap s(fst oslot \<mapsto> TCB (setF (\<lambda> x. cap) x))\<rparr>)"
-  apply(rule notI)
-  apply(erule cte_wp_atE)
-   apply(fastforce elim: notE intro: cte_wp_at_cteI split: if_splits)
-  apply(fastforce elim: notE intro: set_cap_neg_cte_wp_at_other_helper')
+  "\<lbrakk> \<not> cte_wp_at P slot s; oslot \<noteq> slot; ko_at (TCB x) (fst oslot) s;
+     tcb_cap_cases (snd oslot) = Some (getF, setF, restr) \<rbrakk>
+     \<Longrightarrow> \<not> cte_wp_at P slot (s\<lparr>kheap := kheap s(fst oslot \<mapsto> TCB (setF (\<lambda> x. cap) x))\<rparr>)"
+  apply (rule notI)
+  apply (erule cte_wp_atE)
+   apply (fastforce elim: notE intro: cte_wp_at_cteI split: if_splits)
+  apply (fastforce elim: notE intro: set_cap_neg_cte_wp_at_other_helper')
   done
 
-
 lemma set_cap_neg_cte_wp_at_other:
-  "oslot \<noteq> slot \<Longrightarrow> \<lbrace> \<lambda> s. \<not> (cte_wp_at P slot s)\<rbrace> set_cap cap oslot \<lbrace> \<lambda>rv s. \<not>  (cte_wp_at P slot s) \<rbrace>"
-  apply(rule hoare_pre)
+  "oslot \<noteq> slot \<Longrightarrow> set_cap cap oslot \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
   unfolding set_cap_def
-  apply(wp set_object_wp get_object_wp | wpc | simp add: split_def)+
-  apply(intro allI impI conjI)
-       apply(rule notI)
-       apply(erule cte_wp_atE)
+  apply (wp set_object_wp get_object_wp | wpc | simp add: split_def)+
+  apply (intro allI impI conjI)
+       apply (rule notI)
+       apply (erule cte_wp_atE)
         apply (fastforce split: if_splits dest: prod_eqI elim: notE intro: cte_wp_at_cteI simp: obj_at_def)
-       apply(fastforce split: if_splits elim: notE intro: cte_wp_at_tcbI)
-      apply(auto dest: set_cap_neg_cte_wp_at_other_helper)
+       apply (fastforce split: if_splits elim: notE intro: cte_wp_at_tcbI)
+      apply (auto dest: set_cap_neg_cte_wp_at_other_helper)
   done
 
 lemma set_cap_neg_cte_wp_at:
-  "\<lbrace>(\<lambda>s. \<not> cte_wp_at P slot s) and K (\<not> P capa)\<rbrace>
+  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s \<and> \<not> P capa\<rbrace>
    set_cap capa slota
-    \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
-  apply(case_tac "slot = slota")
+   \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
+  apply (case_tac "slot = slota")
    apply simp
-   apply(simp add: set_cap_def set_object_def)
-   apply(rule hoare_pre)
-    apply(wp get_object_wp | wpc)+
-   apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  apply(rule hoare_pre)
-   apply(rule set_cap_neg_cte_wp_at_other, simp+)
+   apply (simp add: set_cap_def set_object_def)
+   apply (rule hoare_pre)
+    apply (wp get_object_wp | wpc)+
+   apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  apply (rule hoare_pre)
+   apply (rule set_cap_neg_cte_wp_at_other, simp+)
   done
 
 lemma domain_sep_inv_cap_IRQControlCap:
-  "\<lbrakk>domain_sep_inv_cap irqs cap; \<not> irqs\<rbrakk> \<Longrightarrow> cap \<noteq> IRQControlCap"
-  apply(auto simp: domain_sep_inv_cap_def)
-  done
+  "\<lbrakk> domain_sep_inv_cap irqs cap; \<not> irqs \<rbrakk> \<Longrightarrow> cap \<noteq> IRQControlCap"
+  by (auto simp: domain_sep_inv_cap_def)
 
 lemma domain_sep_inv_cap_IRQHandlerCap:
-  "\<lbrakk>domain_sep_inv_cap irqs cap; \<not> irqs\<rbrakk> \<Longrightarrow> cap \<noteq> IRQHandlerCap irq"
-  apply(auto simp: domain_sep_inv_cap_def)
-  done
+  "\<lbrakk> domain_sep_inv_cap irqs cap; \<not> irqs \<rbrakk> \<Longrightarrow> cap \<noteq> IRQHandlerCap irq"
+  by (auto simp: domain_sep_inv_cap_def)
 
 lemma set_cap_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and K (domain_sep_inv_cap irqs cap)\<rbrace>
    set_cap cap slot
    \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(rule hoare_gen_asm)
-  apply(rule hoare_pre)
-   apply(rule domain_sep_inv_wp)
-   apply(wp set_cap_neg_cte_wp_at | simp add: pred_neg_def | blast)+
+  apply (rule hoare_gen_asm)
+  apply (rule hoare_pre)
+   apply (rule domain_sep_inv_wp)
+   apply (wp set_cap_neg_cte_wp_at | simp add: pred_neg_def | blast)+
   done
 
 lemma cte_wp_at_domain_sep_inv_cap:
-  "\<lbrakk>domain_sep_inv irqs st s; cte_wp_at ((=) cap) slot s\<rbrakk> \<Longrightarrow> domain_sep_inv_cap irqs cap"
-  apply(case_tac slot)
-  apply(auto simp: domain_sep_inv_def domain_sep_inv_cap_def split: cap.splits)
+  "\<lbrakk> domain_sep_inv irqs st s; cte_wp_at ((=) cap) slot s \<rbrakk>
+     \<Longrightarrow> domain_sep_inv_cap irqs cap"
+  apply (case_tac slot)
+  apply (auto simp: domain_sep_inv_def domain_sep_inv_cap_def split: cap.splits)
   done
 
 lemma weak_derived_irq_handler:
   "weak_derived (IRQHandlerCap irq) cap \<Longrightarrow> cap = (IRQHandlerCap irq)"
-  apply(auto simp: weak_derived_def copy_of_def same_object_as_def split: cap.splits if_splits arch_cap.splits)
-  done
+  by (auto simp: weak_derived_def copy_of_def same_object_as_def split: cap.splits if_splits)
 
 (* FIXME: move to CSpace_AI *)
 lemma weak_derived_DomainCap:
-  "weak_derived c' c \<Longrightarrow> (c' = cap.DomainCap) = (c = cap.DomainCap)"
+  "weak_derived c' c \<Longrightarrow> (c' = DomainCap) = (c = DomainCap)"
   apply (clarsimp simp: weak_derived_def)
   apply (erule disjE)
    apply (clarsimp simp: copy_of_def split: if_split_asm)
    apply (auto simp: is_cap_simps same_object_as_def
-              split: cap.splits arch_cap.splits)[1]
+              split: cap.splits)[1]
   apply simp
   done
 
 lemma cte_wp_at_weak_derived_domain_sep_inv_cap:
-  "\<lbrakk>domain_sep_inv irqs st s; cte_wp_at (weak_derived cap) slot s\<rbrakk> \<Longrightarrow> domain_sep_inv_cap irqs cap"
+  "\<lbrakk> domain_sep_inv irqs st s; cte_wp_at (weak_derived cap) slot s \<rbrakk>
+     \<Longrightarrow> domain_sep_inv_cap irqs cap"
   apply (cases slot)
   apply (force simp: domain_sep_inv_def domain_sep_inv_cap_def
               split: cap.splits
@@ -224,735 +234,592 @@ lemma cte_wp_at_weak_derived_domain_sep_inv_cap:
 
 lemma is_derived_IRQHandlerCap:
   "is_derived m src (IRQHandlerCap irq) cap \<Longrightarrow> (cap = IRQHandlerCap irq)"
-  apply(clarsimp simp: is_derived_def)
-  apply(case_tac cap, simp_all add: is_cap_simps cap_master_cap_def)
+  apply (clarsimp simp: is_derived_def)
+  apply (case_tac cap, simp_all add: is_cap_simps cap_master_cap_def)
   done
 
 (* FIXME: move to CSpace_AI *)
 lemma DomainCap_is_derived:
-  "is_derived m src cap.DomainCap cap \<Longrightarrow> cap = DomainCap"
-by (auto simp: is_derived_def is_reply_cap_def is_pg_cap_def is_master_reply_cap_def cap_master_cap_def split: cap.splits)
+  "is_derived m src DomainCap cap \<Longrightarrow> cap = DomainCap"
+  by (auto simp: is_derived_def is_reply_cap_def is_master_reply_cap_def cap_master_cap_def
+          split: cap.splits)
 
 lemma cte_wp_at_is_derived_domain_sep_inv_cap:
-  "\<lbrakk>domain_sep_inv irqs st s; cte_wp_at (is_derived (cdt s) slot cap) slot s\<rbrakk> \<Longrightarrow> domain_sep_inv_cap irqs cap"
-apply (cases slot)
-apply (fastforce simp: domain_sep_inv_def domain_sep_inv_cap_def
-                split: cap.splits
-                 dest: cte_wp_at_eqD DomainCap_is_derived is_derived_IRQHandlerCap)
-done
+  "\<lbrakk> domain_sep_inv irqs st s; cte_wp_at (is_derived (cdt s) slot cap) slot s \<rbrakk>
+     \<Longrightarrow> domain_sep_inv_cap irqs cap"
+  apply (cases slot)
+  apply (fastforce simp: domain_sep_inv_def domain_sep_inv_cap_def
+                  split: cap.splits
+                   dest: cte_wp_at_eqD DomainCap_is_derived is_derived_IRQHandlerCap)
+  done
 
 lemma domain_sep_inv_exst_update[simp]:
   "domain_sep_inv irqs st (trans_state f s) = domain_sep_inv irqs st s"
-  apply(simp add: domain_sep_inv_def)
-  done
+  by (simp add: domain_sep_inv_def)
 
 lemma domain_sep_inv_is_original_cap_update[simp]:
   "domain_sep_inv irqs st (s\<lparr>is_original_cap := X\<rparr>) = domain_sep_inv irqs st s"
-  apply(simp add: domain_sep_inv_def)
-  done
+  by (simp add: domain_sep_inv_def)
 
 lemma domain_sep_inv_cdt_update[simp]:
   "domain_sep_inv irqs st (s\<lparr>cdt := X\<rparr>) = domain_sep_inv irqs st s"
-  apply(simp add: domain_sep_inv_def)
-  done
+  by (simp add: domain_sep_inv_def)
 
 crunch domain_sep_inv[wp]: update_cdt "domain_sep_inv irqs st"
 
 lemma set_untyped_cap_as_full_domain_sep_inv[wp]:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace> set_untyped_cap_as_full a b c \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(clarsimp simp: set_untyped_cap_as_full_def)
-  apply(rule hoare_pre)
-   apply(rule set_cap_domain_sep_inv)
-  apply(case_tac a, simp_all add: domain_sep_inv_cap_def)
+  "set_untyped_cap_as_full a b c \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  apply (clarsimp simp: set_untyped_cap_as_full_def)
+  apply (rule hoare_pre)
+   apply (rule set_cap_domain_sep_inv)
+  apply (case_tac a, simp_all add: domain_sep_inv_cap_def)
   done
 
 lemma cap_insert_domain_sep_inv:
-  "\<lbrace> domain_sep_inv irqs st and (\<lambda>s. cte_wp_at (is_derived (cdt s) slot cap) slot s) \<rbrace>
-  cap_insert cap slot dest_slot
-   \<lbrace> \<lambda>_. domain_sep_inv irqs st \<rbrace>"
-  apply(simp add: cap_insert_def)
-  apply(wp set_cap_domain_sep_inv get_cap_wp set_original_wp dxo_wp_weak | simp split del: if_split)+
-  apply(blast dest: cte_wp_at_is_derived_domain_sep_inv_cap)
+  "\<lbrace>domain_sep_inv irqs st and (\<lambda>s. cte_wp_at (is_derived (cdt s) slot cap) slot s)\<rbrace>
+   cap_insert cap slot dest_slot
+   \<lbrace>\<lambda>_. domain_sep_inv irqs st \<rbrace>"
+  apply (simp add: cap_insert_def)
+  apply (wpsimp wp: set_cap_domain_sep_inv get_cap_wp set_original_wp dxo_wp_weak)
+  apply (blast dest: cte_wp_at_is_derived_domain_sep_inv_cap)
   done
 
 lemma domain_sep_inv_cap_NullCap[simp]:
   "domain_sep_inv_cap irqs NullCap"
-  apply(simp add: domain_sep_inv_cap_def)
-  done
+  by (simp add: domain_sep_inv_cap_def)
 
 lemma cap_move_domain_sep_inv:
-  "\<lbrace> domain_sep_inv irqs st and (\<lambda>s. cte_wp_at (weak_derived cap) slot s) \<rbrace>
-  cap_move cap slot dest_slot
-   \<lbrace> \<lambda>_. domain_sep_inv irqs st \<rbrace>"
-  apply(simp add: cap_move_def)
-  apply(wp set_cap_domain_sep_inv get_cap_wp set_original_wp dxo_wp_weak | simp split del: if_split | blast dest: cte_wp_at_weak_derived_domain_sep_inv_cap)+
-  done
-
-lemma domain_sep_inv_machine_state_update[simp]:
-  "domain_sep_inv irqs st (s\<lparr>machine_state := X\<rparr>) = domain_sep_inv irqs st s"
-  apply(simp add: domain_sep_inv_def)
+  "\<lbrace>domain_sep_inv irqs st and (\<lambda>s. cte_wp_at (weak_derived cap) slot s)\<rbrace>
+   cap_move cap slot dest_slot
+   \<lbrace>\<lambda>_. domain_sep_inv irqs st \<rbrace>"
+  apply (simp add: cap_move_def)
+  apply (wpsimp wp: set_cap_domain_sep_inv get_cap_wp set_original_wp dxo_wp_weak)
+  apply (blast dest: cte_wp_at_weak_derived_domain_sep_inv_cap)
   done
 
 lemma set_irq_state_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and (\<lambda>s. stt = interrupt_states s irq)\<rbrace>
    set_irq_state stt irq
    \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(simp add: set_irq_state_def)
-  apply(wp | simp add: do_machine_op_def | wpc)+
+  apply (simp add: set_irq_state_def)
+  apply (wp | simp add: do_machine_op_def | wpc)+
   done
 
+
+locale DomainSepInv_1 =
+  fixes state_ext_t :: "'state_ext :: state_ext itself"
+  assumes arch_finalise_cap_domain_sep_inv[wp]:
+    "arch_finalise_cap c x \<lbrace>\<lambda>s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
+  and arch_post_cap_deletion_domain_sep_inv[wp]:
+    "arch_post_cap_deletion acap \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and init_arch_objects_domain_sep_inv[wp]:
+    "init_arch_objects typ ptr n sz refs \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and prepare_thread_delete_domain_sep_inv[wp]:
+    "prepare_thread_delete t \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and arch_finalise_cap_rv:
+    "\<lbrace>\<lambda>_. P (NullCap,NullCap)\<rbrace> arch_finalise_cap c x \<lbrace>\<lambda>rv s :: det_ext state. P rv\<rbrace>"
+begin
+
 lemma deleted_irq_handler_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st and K irqs\<rbrace> deleted_irq_handler a \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(rule hoare_gen_asm)
-  apply(simp add: deleted_irq_handler_def)
-  apply(simp add: set_irq_state_def)
+  "\<lbrace>domain_sep_inv irqs st and K irqs\<rbrace>
+   deleted_irq_handler irq
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (simp add: deleted_irq_handler_def set_irq_state_def)
   apply wp
-    apply(rule domain_sep_inv_triv, wp+)
-  apply(simp add: domain_sep_inv_def)
+  apply (simp add: domain_sep_inv_def)
   done
 
 lemma empty_slot_domain_sep_inv:
   "\<lbrace>\<lambda>s. domain_sep_inv irqs st s \<and> (\<not> irqs \<longrightarrow> b = NullCap)\<rbrace>
    empty_slot a b
-   \<lbrace>\<lambda>_ s. domain_sep_inv irqs st s\<rbrace>"
-  unfolding empty_slot_def
-  by (wpsimp wp: get_cap_wp set_cap_domain_sep_inv set_original_wp dxo_wp_weak static_imp_wp
-                 deleted_irq_handler_domain_sep_inv)
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
+  unfolding empty_slot_def post_cap_deletion_def
+  by (wpsimp wp: get_cap_wp set_cap_domain_sep_inv set_original_wp dxo_wp_weak
+                 static_imp_wp deleted_irq_handler_domain_sep_inv)
+
+end
+
 
 lemma set_simple_ko_neg_cte_wp_at[wp]:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace> set_simple_ko f a b \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
-  apply(simp add: set_simple_ko_def)
-  apply(wp set_object_wp_strong get_object_wp
-     | simp add: partial_inv_def a_type_def split: kernel_object.splits)+
-  apply(case_tac "a = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(fastforce elim: cte_wp_atE simp: obj_at_def)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  "set_simple_ko f a b \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
+  apply (simp add: set_simple_ko_def)
+  apply (wp set_object_wp_strong get_object_wp
+         | simp add: partial_inv_def a_type_def split: kernel_object.splits)+
+  apply (case_tac "a = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (fastforce elim: cte_wp_atE simp: obj_at_def)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
 crunch domain_sep_inv[wp]: set_simple_ko "domain_sep_inv irqs st"
   (wp: domain_sep_inv_triv)
 
 lemma set_thread_state_neg_cte_wp_at[wp]:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace> set_thread_state a b \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
-  apply(simp add: set_thread_state_def)
-  apply(wp set_object_wp get_object_wp dxo_wp_weak| simp)+
-  apply(case_tac "a = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(erule notE)
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(drule get_tcb_SomeD)
-   apply(rule cte_wp_at_tcbI)
-     apply(simp)
+  "set_thread_state a b \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
+  apply (simp add: set_thread_state_def)
+  apply (wp set_object_wp get_object_wp dxo_wp_weak| simp)+
+  apply (case_tac "a = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (erule notE)
+   apply (erule cte_wp_atE)
+    apply (fastforce simp: obj_at_def)
+   apply (drule get_tcb_SomeD)
+   apply (rule cte_wp_at_tcbI)
+     apply simp
     apply assumption
    apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
 lemma set_bound_notification_neg_cte_wp_at[wp]:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace> set_bound_notification a b \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
-  apply(simp add: set_bound_notification_def)
-  apply(wp set_object_wp get_object_wp dxo_wp_weak| simp)+
-  apply(case_tac "a = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(erule notE)
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(drule get_tcb_SomeD)
-   apply(rule cte_wp_at_tcbI)
-     apply(simp)
+  "set_bound_notification a b \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
+  apply (simp add: set_bound_notification_def)
+  apply (wp set_object_wp get_object_wp dxo_wp_weak| simp)+
+  apply (case_tac "a = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (erule notE)
+   apply (erule cte_wp_atE)
+    apply (fastforce simp: obj_at_def)
+   apply (drule get_tcb_SomeD)
+   apply (rule cte_wp_at_tcbI)
+     apply simp
     apply assumption
    apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
 crunch domain_sep_inv[wp]: set_thread_state, set_bound_notification, get_bound_notification "domain_sep_inv irqs st"
   (wp: domain_sep_inv_triv)
 
 lemma thread_set_tcb_fault_update_neg_cte_wp_at[wp]:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>
-   thread_set (tcb_fault_update blah) param_a
-   \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
-  apply(simp add: thread_set_def)
-  apply(wp set_object_wp get_object_wp | simp)+
-  apply(case_tac "param_a = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(erule notE)
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(drule get_tcb_SomeD)
-   apply(rule cte_wp_at_tcbI)
-     apply(simp)
+  "thread_set (tcb_fault_update blah) t \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
+  apply (simp add: thread_set_def)
+  apply (wp set_object_wp get_object_wp | simp)+
+  apply (case_tac "t = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (erule notE)
+   apply (erule cte_wp_atE)
+    apply (fastforce simp: obj_at_def)
+   apply (drule get_tcb_SomeD)
+   apply (rule cte_wp_at_tcbI)
+     apply simp
     apply assumption
    apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
 lemma thread_set_tcb_fault_update_domain_sep_inv[wp]:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-   thread_set (tcb_fault_update blah) param_a
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(wp domain_sep_inv_triv)
-  done
+  "thread_set (tcb_fault_update blah) t \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  by (wp domain_sep_inv_triv)
 
-crunch domain_sep_inv[wp]: cap_delete_one "domain_sep_inv irqs st"
-  (wp: mapM_x_wp' hoare_unless_wp dxo_wp_weak ignore: tcb_sched_action reschedule_required simp: crunch_simps)
-
-lemma reply_cancel_ipc_domain_sep_inv[wp]:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-   reply_cancel_ipc t
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(simp add: reply_cancel_ipc_def)
-  apply (wp select_wp)
-  apply(rule hoare_strengthen_post[OF thread_set_tcb_fault_update_domain_sep_inv])
-  apply auto
-  done
-
-lemma domain_sep_inv_arch_state_update[simp]:
-  "domain_sep_inv irqs st (s\<lparr>arch_state := blah\<rparr>) = domain_sep_inv irqs st s"
-  apply(simp add: domain_sep_inv_def)
-  done
-
-lemma set_pt_neg_cte_wp_at[wp]:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>
-   set_pt ptr pt
-   \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
-  unfolding set_pt_def
-  apply(wp set_object_wp get_object_wp | simp)+
-  apply(case_tac "ptr = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(fastforce elim: cte_wp_atE simp: obj_at_def)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  done
-
-crunch domain_sep_inv[wp]: set_pt "domain_sep_inv irqs st"
+crunch domain_sep_inv[wp]: as_user "domain_sep_inv irqs st"
   (wp: domain_sep_inv_triv)
-
-lemma set_pd_neg_cte_wp_at[wp]:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>
-   set_pd ptr pt
-   \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
-  unfolding set_pd_def
-  apply(wp set_object_wp get_object_wp | simp)+
-  apply(case_tac "ptr = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(fastforce elim: cte_wp_atE simp: obj_at_def)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  done
-
-crunch domain_sep_inv[wp]: set_pd "domain_sep_inv irqs st"
-  (wp: domain_sep_inv_triv)
-
-lemma set_asid_pool_neg_cte_wp_at[wp]:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>
-   set_asid_pool ptr pt
-   \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
-  unfolding set_asid_pool_def
-  apply(wp set_object_wp get_object_wp | simp)+
-  apply(case_tac "ptr = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(fastforce elim: cte_wp_atE simp: obj_at_def)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  done
-
-crunch domain_sep_inv[wp]: set_asid_pool "domain_sep_inv irqs st"
-  (wp: domain_sep_inv_triv)
-
-lemma as_user_domain_sep_inv[wp]:
-  "\<lbrace>\<lambda>s. domain_sep_inv irqs st s\<rbrace> as_user a b \<lbrace>\<lambda>_ s. domain_sep_inv irqs st s\<rbrace>"
-  by (wpsimp simp: domain_sep_inv_def
-               wp: as_user_cte_wp_at as_user_interrupt_states hoare_vcg_conj_lift
-                   hoare_vcg_all_lift hoare_vcg_disj_lift)
-
-crunch domain_sep_inv[wp]: finalise_cap "domain_sep_inv irqs st"
-  (wp: crunch_wps dxo_wp_weak simp: crunch_simps ignore: set_object tcb_sched_action)
-
-lemma finalise_cap_domain_sep_inv_cap:
-  "\<lbrace>\<lambda>s. domain_sep_inv_cap irqs cap\<rbrace> finalise_cap cap b \<lbrace>\<lambda>rv s. domain_sep_inv_cap irqs (fst rv)\<rbrace>"
-  including no_pre
-  apply(case_tac cap)
-            apply(wp | simp add: o_def split del: if_split  split: cap.splits arch_cap.splits | fastforce split: if_splits simp: domain_sep_inv_cap_def)+
-      apply(rule hoare_pre, wp, fastforce)
-     apply(rule hoare_pre, simp, wp, fastforce simp: domain_sep_inv_cap_def)
-  apply(simp add: arch_finalise_cap_def)
-  apply(rule hoare_pre)
-   apply(wpc | wp | simp)+
-  done
 
 lemma get_cap_domain_sep_inv_cap:
   "\<lbrace>domain_sep_inv irqs st\<rbrace> get_cap cap \<lbrace>\<lambda>rv s. domain_sep_inv_cap irqs rv\<rbrace>"
-  apply(wp get_cap_wp)
-  apply(blast dest: cte_wp_at_domain_sep_inv_cap)
-  done
+  by (wpsimp wp: get_cap_wp simp: cte_wp_at_domain_sep_inv_cap)
 
 crunch domain_sep_inv[wp]: cap_swap_for_delete "domain_sep_inv irqs st"
   (wp: get_cap_domain_sep_inv_cap dxo_wp_weak simp: crunch_simps ignore: cap_swap_ext)
 
+lemma preemption_point_domain_sep_inv[wp]:
+  "preemption_point \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  by (wp preemption_point_inv | simp)+
+
+
+context DomainSepInv_1 begin
+
+crunches cap_delete_one
+  for domain_sep_inv[wp]: "\<lambda>s. domain_sep_inv irqs  (st :: 'state_ext state) (s :: det_ext state)"
+  (wp: mapM_x_wp' hoare_unless_wp dxo_wp_weak simp: crunch_simps)
+
+lemma reply_cancel_ipc_domain_sep_inv[wp]:
+  "\<lbrace>domain_sep_inv irqs st\<rbrace>
+   reply_cancel_ipc t
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs  (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
+  apply (simp add: reply_cancel_ipc_def)
+  apply (wp select_wp)
+  apply (rule hoare_strengthen_post[OF thread_set_tcb_fault_update_domain_sep_inv])
+  apply auto
+  done
+
+crunches finalise_cap
+  for domain_sep_inv[wp]: "\<lambda>s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)"
+  (wp: dxo_wp_weak)
+
+lemma finalise_cap_domain_sep_inv_cap:
+  "\<lbrace>\<lambda>s. domain_sep_inv_cap irqs cap\<rbrace>
+   finalise_cap cap b
+   \<lbrace>\<lambda>rv s :: det_ext state. domain_sep_inv_cap irqs (fst rv)\<rbrace>"
+  including no_pre
+  apply (case_tac cap)
+             apply (wp | simp add: o_def split del: if_split  split: cap.splits
+                       | fastforce split: if_splits simp: domain_sep_inv_cap_def)+
+    apply (rule hoare_pre, wp, fastforce)
+   apply (rule hoare_pre, simp, wp, fastforce simp: domain_sep_inv_cap_def)
+  apply (wpc | wp arch_finalise_cap_rv | simp)+
+  done
+
 lemma finalise_cap_returns_NullCap:
   "\<lbrace>\<lambda>s. domain_sep_inv_cap irqs cap\<rbrace>
    finalise_cap cap b
-   \<lbrace>\<lambda>rv s. \<not> irqs \<longrightarrow> snd rv = NullCap\<rbrace>"
-  apply(case_tac cap)
-  by (wpsimp simp: o_def split_del: if_split | clarsimp simp: domain_sep_inv_cap_def arch_finalise_cap_def)+
+   \<lbrace>\<lambda>rv s :: det_ext state. \<not> irqs \<longrightarrow> snd rv = NullCap\<rbrace>"
+  apply (case_tac cap)
+  by (wpsimp wp: arch_finalise_cap_rv simp: o_def domain_sep_inv_cap_def split_del: if_split)+
 
 lemma rec_del_domain_sep_inv':
   notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del]
          rec_del.simps[simp del]
   shows
-  "s \<turnstile> \<lbrace> domain_sep_inv irqs st\<rbrace>
-     (rec_del call)
-   \<lbrace>\<lambda> a s. (case call of (FinaliseSlotCall x y) \<Rightarrow> (y \<or> fst a) \<longrightarrow> \<not> irqs \<longrightarrow> snd a = NullCap | _ \<Rightarrow> True) \<and> domain_sep_inv irqs st s\<rbrace>,\<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  "s \<turnstile> \<lbrace>domain_sep_inv irqs st\<rbrace>
+       rec_del call
+       \<lbrace>\<lambda>rv s. (case call of (FinaliseSlotCall x y) \<Rightarrow> (y \<or> fst rv) \<longrightarrow> \<not> irqs \<longrightarrow> snd rv = NullCap
+                                                | _ \<Rightarrow> True) \<and>
+               domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>,
+       \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
   proof (induct s arbitrary: rule: rec_del.induct, simp_all only: rec_del_fails hoare_fail_any)
   case (1 slot exposed s) show ?case
-    apply(simp add: split_def rec_del.simps)
-    apply(wp empty_slot_domain_sep_inv drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] | simp)+
-    apply(rule spec_strengthen_postE[OF "1.hyps"])
+    apply (simp add: split_def rec_del.simps)
+    apply (wpsimp wp: empty_slot_domain_sep_inv
+                      drop_spec_validE[OF returnOk_wp]
+                      drop_spec_validE[OF liftE_wp])
+    apply (rule spec_strengthen_postE[OF "1.hyps"])
     apply fastforce
     done
   next
   case (2 slot exposed s) show ?case
-    apply(simp add: rec_del.simps split del: if_split)
-    apply(rule hoare_pre_spec_validE)
-     apply(wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
-          |simp add: split_def split del: if_split)+
-           apply(rule spec_strengthen_postE)
-            apply(rule "2.hyps", fastforce+)
-          apply(rule drop_spec_validE, (wp preemption_point_inv| simp)+)[1]
+    apply (simp add: rec_del.simps split del: if_split)
+    apply (rule hoare_pre_spec_validE)
+     apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
+            | simp add: split_def split del: if_split)+
+           apply (rule spec_strengthen_postE)
+            apply (rule "2.hyps", fastforce+)
+          apply (rule drop_spec_validE, (wp preemption_point_inv| simp)+)[1]
          apply simp
-         apply(rule spec_strengthen_postE)
-          apply(rule "2.hyps", fastforce+)
-         apply(wp  finalise_cap_domain_sep_inv_cap get_cap_wp
+         apply (rule spec_strengthen_postE)
+          apply (rule "2.hyps", fastforce+)
+         apply (wp  finalise_cap_domain_sep_inv_cap get_cap_wp
                    finalise_cap_returns_NullCap
                    drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
                |simp split del: if_split
                |wp (once) hoare_drop_imps)+
-    apply(blast dest: cte_wp_at_domain_sep_inv_cap)
+    apply (blast dest: cte_wp_at_domain_sep_inv_cap)
     done
   next
   case (3 ptr bits n slot s) show ?case
-    apply(simp add: rec_del.simps)
+    apply (simp add: rec_del.simps)
     apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp])
-    apply(rule hoare_pre_spec_validE)
+    apply (rule hoare_pre_spec_validE)
     apply (wp drop_spec_validE[OF assertE_wp])
-    apply(fastforce)
+    apply (fastforce)
     done
   next
   case (4 ptr bits n slot s) show ?case
-    apply(simp add: rec_del.simps)
+    apply (simp add: rec_del.simps)
     apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
               drop_spec_validE[OF assertE_wp] get_cap_wp | simp)+
     apply (rule spec_strengthen_postE[OF "4.hyps"])
-     apply(simp add: returnOk_def return_def)
-    apply(clarsimp simp: domain_sep_inv_cap_def)
+     apply (simp add: returnOk_def return_def)
+    apply (clarsimp simp: domain_sep_inv_cap_def)
     done
   qed
 
 lemma rec_del_domain_sep_inv:
-  "\<lbrace> domain_sep_inv irqs st\<rbrace>
-     (rec_del call)
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  "\<lbrace>domain_sep_inv irqs st\<rbrace>
+   rec_del call
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
   apply (rule validE_valid)
   apply (rule use_spec)
   apply (rule spec_strengthen_postE[OF rec_del_domain_sep_inv'])
   by fastforce
 
-crunch domain_sep_inv[wp]: cap_delete "domain_sep_inv irqs st"
-
-lemma preemption_point_domain_sep_inv[wp]:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace> preemption_point \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  by (wp preemption_point_inv | simp)+
+crunches cap_delete
+  for domain_sep_inv[wp]: "\<lambda>s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)"
 
 lemma cap_revoke_domain_sep_inv':
   notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del]
   shows
   "s \<turnstile> \<lbrace> domain_sep_inv irqs st\<rbrace>
    cap_revoke slot
-   \<lbrace> \<lambda>_. domain_sep_inv irqs st\<rbrace>, \<lbrace> \<lambda>_. domain_sep_inv irqs st\<rbrace>"
+   \<lbrace> \<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>, \<lbrace> \<lambda>_. domain_sep_inv irqs st\<rbrace>"
   proof(induct rule: cap_revoke.induct[where ?a1.0=s])
   case (1 slot s)
   show ?case
-  apply(subst cap_revoke.simps)
-  apply(rule hoare_pre_spec_validE)
+  apply (subst cap_revoke.simps)
+  apply (rule hoare_pre_spec_validE)
    apply (wp "1.hyps")
-           apply(wp spec_valid_conj_liftE2 | simp)+
-           apply(wp drop_spec_validE[OF valid_validE[OF preemption_point_domain_sep_inv]]
+           apply (wp spec_valid_conj_liftE2 | simp)+
+           apply (wp drop_spec_validE[OF valid_validE[OF preemption_point_domain_sep_inv]]
                     drop_spec_validE[OF valid_validE[OF cap_delete_domain_sep_inv]]
                     drop_spec_validE[OF assertE_wp] drop_spec_validE[OF returnOk_wp]
                     drop_spec_validE[OF liftE_wp] select_wp
                 | simp | wp (once) hoare_drop_imps)+
   done
-  qed
+qed
 
 lemmas cap_revoke_domain_sep_inv[wp] = use_spec(2)[OF cap_revoke_domain_sep_inv']
 
+end
+
+
 lemma cap_move_cte_wp_at_other:
-  "\<lbrace> cte_wp_at P slot and K (slot \<noteq> dest_slot \<and> slot \<noteq> src_slot) \<rbrace>
+  "\<lbrace>cte_wp_at P slot and K (slot \<noteq> dest_slot \<and> slot \<noteq> src_slot)\<rbrace>
    cap_move cap src_slot dest_slot
-   \<lbrace> \<lambda>_. cte_wp_at P slot \<rbrace>"
+   \<lbrace>\<lambda>_. cte_wp_at P slot\<rbrace>"
   unfolding cap_move_def
-  apply (rule hoare_pre)
-   apply (wp set_cdt_cte_wp_at set_cap_cte_wp_at' dxo_wp_weak static_imp_wp
-             set_original_wp | simp)+
-  done
+  by (wpsimp wp: set_cdt_cte_wp_at set_cap_cte_wp_at' dxo_wp_weak static_imp_wp set_original_wp)
 
 lemma cte_wp_at_weak_derived_ReplyCap:
   "cte_wp_at ((=) (ReplyCap x False R)) slot s
-       \<Longrightarrow> cte_wp_at (weak_derived (ReplyCap x False R)) slot s"
-  apply(erule cte_wp_atE)
-   apply(rule cte_wp_at_cteI)
+   \<Longrightarrow> cte_wp_at (weak_derived (ReplyCap x False R)) slot s"
+  apply (erule cte_wp_atE)
+   apply (rule cte_wp_at_cteI)
       apply assumption
      apply assumption
     apply assumption
    apply simp
-  apply(rule cte_wp_at_tcbI)
+  apply (rule cte_wp_at_tcbI)
   apply auto
   done
 
 lemma thread_set_tcb_registers_caps_merge_default_tcb_neg_cte_wp_at[wp]:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>
-   thread_set (tcb_registers_caps_merge default_tcb) word
-   \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
+  "thread_set (tcb_registers_caps_merge default_tcb) word \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
   unfolding thread_set_def
-  apply(wp set_object_wp | simp)+
-  apply(case_tac "word = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(erule notE)
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(drule get_tcb_SomeD)
-   apply(rule cte_wp_at_tcbI)
-     apply(simp)
+  apply (wp set_object_wp | simp)+
+  apply (case_tac "word = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (erule notE)
+   apply (erule cte_wp_atE)
+    apply (fastforce simp: obj_at_def)
+   apply (drule get_tcb_SomeD)
+   apply (rule cte_wp_at_tcbI)
+     apply simp
     apply assumption
    apply (clarsimp simp: tcb_cap_cases_def tcb_registers_caps_merge_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
 lemma thread_set_tcb_registers_caps_merge_default_tcb_domain_sep_inv[wp]:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-   thread_set (tcb_registers_caps_merge default_tcb) word
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(wp domain_sep_inv_triv)
-  done
+  "thread_set (tcb_registers_caps_merge default_tcb) word \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  by (wp domain_sep_inv_triv)
 
 lemma cancel_badged_sends_domain_sep_inv[wp]:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-   cancel_badged_sends epptr badge
-   \<lbrace>\<lambda>rv. domain_sep_inv irqs st\<rbrace>"
-  apply(simp add: cancel_badged_sends_def)
-  apply(rule hoare_pre)
-   apply(wp dxo_wp_weak mapM_wp | wpc | simp add: filterM_mapM | rule subset_refl | wp (once) hoare_drop_imps)+
-   done
-
-crunch domain_sep_inv[wp]: finalise_slot "domain_sep_inv irqs st"
-
-lemma invoke_cnode_domain_sep_inv:
-  "\<lbrace> domain_sep_inv irqs st and valid_cnode_inv ci\<rbrace>
-   invoke_cnode ci
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  unfolding invoke_cnode_def
-  apply(case_tac ci)
-        apply(wp cap_insert_domain_sep_inv cap_move_domain_sep_inv | simp split del: if_split)+
-     apply(rule hoare_pre)
-      apply (wpsimp wp: cap_move_domain_sep_inv cap_move_cte_wp_at_other get_cap_wp,
-            blast dest: cte_wp_at_weak_derived_domain_sep_inv_cap)+
-   apply (wpsimp wp: cap_move_domain_sep_inv get_cap_wp)
-   apply(fastforce dest:  cte_wp_at_weak_derived_ReplyCap)
-  apply(wp | simp | wpc | rule hoare_pre)+
+  "cancel_badged_sends epptr badge \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  apply (simp add: cancel_badged_sends_def)
+  apply (wpsimp wp: dxo_wp_weak mapM_wp | simp add: filterM_mapM | wp (once) hoare_drop_imps)+
   done
 
 lemma create_cap_domain_sep_inv[wp]:
-  "\<lbrace> domain_sep_inv irqs st\<rbrace>
-   create_cap tp sz p dev slot
-   \<lbrace> \<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(simp add: create_cap_def)
-  apply(rule hoare_pre)
-  apply(wp set_cap_domain_sep_inv dxo_wp_weak | wpc | simp)+
+  "create_cap tp sz p dev slot \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  apply (simp add: create_cap_def)
+  apply (rule hoare_pre)
+  apply (wp set_cap_domain_sep_inv dxo_wp_weak | wpc | simp)+
   apply clarsimp
-  apply(case_tac tp, simp_all add: domain_sep_inv_cap_def)
-  done
-
-lemma detype_interrupts_states[simp]:
-  "interrupt_states (detype S s) = interrupt_states s"
-  apply(simp add: detype_def)
-  done
-
-lemma detype_domain_sep_inv[simp]:
-  "domain_sep_inv irqs st s \<longrightarrow> domain_sep_inv irqs st (detype S s)"
-  apply(fastforce simp: domain_sep_inv_def)
-  done
-
-lemma domain_sep_inv_detype_lift:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. domain_sep_inv irqs st\<rbrace> \<Longrightarrow>
-   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. domain_sep_inv irqs st (detype S s)\<rbrace>"
-  apply(strengthen detype_domain_sep_inv, assumption)
+  apply (case_tac tp, simp_all add: domain_sep_inv_cap_def)
   done
 
 lemma retype_region_neg_cte_wp_at_not_domain_sep_inv_cap:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at (not domain_sep_inv_cap irqs) slot s \<rbrace>
-   retype_region  base n sz ty dev
-   \<lbrace>\<lambda>rv s. \<not> cte_wp_at (not domain_sep_inv_cap irqs) slot s\<rbrace>"
-  apply(rule hoare_pre)
-   apply(simp only: retype_region_def retype_addrs_def
-
-                    foldr_upd_app_if fun_app_def K_bind_def)
-   apply(wp dxo_wp_weak |simp)+
+  "retype_region  base n sz ty dev \<lbrace>\<lambda>s. \<not> cte_wp_at (not domain_sep_inv_cap irqs) slot s\<rbrace>"
+  apply (rule hoare_pre)
+   apply (simp only: retype_region_def retype_addrs_def foldr_upd_app_if fun_app_def K_bind_def)
+   apply (wp dxo_wp_weak | simp)+
   apply clarsimp
-  apply(case_tac "fst slot \<in> (\<lambda>p. ptr_add base (p * 2 ^ obj_bits_api ty sz)) `
-                              {0..<n}")
+  apply (case_tac "fst slot \<in> (\<lambda>p. ptr_add base (p * 2 ^ obj_bits_api ty sz)) ` {0..<n}")
    apply clarsimp
-   apply(erule cte_wp_atE)
-    apply(clarsimp simp: default_object_def empty_cnode_def split: apiobject_type.splits if_splits simp: pred_neg_def)
-   apply(clarsimp simp: default_object_def default_tcb_def tcb_cap_cases_def split: apiobject_type.splits if_splits simp: pred_neg_def)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_tcbI cte_wp_at_cteI)
+   apply (erule cte_wp_atE)
+    apply (clarsimp simp: default_object_def empty_cnode_def
+                   split: apiobject_type.splits if_splits)
+   apply (clarsimp simp: default_object_def default_tcb_def tcb_cap_cases_def
+                  split: apiobject_type.splits if_splits)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_tcbI cte_wp_at_cteI)
   done
 
-
 lemma retype_region_domain_sep_inv[wp]:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-   retype_region base n sz tp dev
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(rule domain_sep_inv_wp[where P="\<top>" and R="\<top>", simplified])
-   apply(rule retype_region_neg_cte_wp_at_not_domain_sep_inv_cap)
+  "retype_region base n sz tp dev \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  apply (rule domain_sep_inv_wp[where P="\<top>" and R="\<top>", simplified])
+   apply (rule retype_region_neg_cte_wp_at_not_domain_sep_inv_cap)
   apply wp
   done
 
 lemma domain_sep_inv_cap_UntypedCap[simp]:
   "domain_sep_inv_cap irqs (UntypedCap dev base sz n)"
-  apply(simp add: domain_sep_inv_cap_def)
+  by (simp add: domain_sep_inv_cap_def)
+
+crunch domain_sep_inv[wp]: delete_objects "domain_sep_inv irqs st"
+  (wp: domain_sep_inv_detype_lift)
+
+
+context DomainSepInv_1 begin
+
+crunches finalise_slot, invoke_untyped, send_signal
+  for domain_sep_inv[wp]: "\<lambda>s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)"
+  (wp: crunch_wps mapME_x_inv_wp simp: crunch_simps mapM_x_def_bak)
+
+lemma invoke_cnode_domain_sep_inv:
+  "\<lbrace>domain_sep_inv irqs st and valid_cnode_inv ci\<rbrace>
+   invoke_cnode ci
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
+  unfolding invoke_cnode_def
+  apply (case_tac ci)
+        apply (wp cap_insert_domain_sep_inv cap_move_domain_sep_inv | simp split del: if_split)+
+     apply (rule hoare_pre)
+      apply (wpsimp wp: cap_move_domain_sep_inv cap_move_cte_wp_at_other get_cap_wp,
+             blast dest: cte_wp_at_weak_derived_domain_sep_inv_cap)+
+   apply (wpsimp wp: cap_move_domain_sep_inv get_cap_wp)
+   apply (fastforce dest:  cte_wp_at_weak_derived_ReplyCap)
+  apply (wp | simp | wpc | rule hoare_pre)+
   done
 
-crunch domain_sep_inv[wp]: invoke_untyped "domain_sep_inv irqs st"
-  (ignore: freeMemory retype_region wp: crunch_wps domain_sep_inv_detype_lift
-   get_cap_wp mapME_x_inv_wp
-   simp: crunch_simps mapM_x_def_bak unless_def)
+end
+
 
 lemma perform_page_invocation_domain_sep_inv_get_cap_helper:
-  "\<lbrace>\<top>\<rbrace>
-   get_cap blah
-   \<lbrace>\<lambda>rv s.
-     domain_sep_inv_cap irqs
-       (ArchObjectCap (F rv))\<rbrace>"
-  apply(simp add: domain_sep_inv_cap_def)
-  apply(rule wp_post_taut)
+  "\<lbrace>\<top>\<rbrace> get_cap blah \<lbrace>\<lambda>rv s. domain_sep_inv_cap irqs (ArchObjectCap (F rv))\<rbrace>"
+  apply (simp add: domain_sep_inv_cap_def)
+  apply (rule wp_post_taut)
   done
-
 
 lemma set_object_tcb_context_update_neg_cte_wp_at:
   "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s \<and> obj_at ((=) (TCB tcb)) ptr s\<rbrace>
    set_object ptr (TCB (tcb\<lparr>tcb_arch := arch_tcb_context_set X (arch_tcb tcb)\<rparr>))
    \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
-  apply(wp set_object_wp)
+  apply (wp set_object_wp)
   apply clarsimp
-  apply(case_tac "ptr = fst slot")
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(erule notE)
-   apply(clarsimp simp: obj_at_def)
-   apply(rule cte_wp_at_tcbI)
-      apply(simp)
-     apply(fastforce)
-    apply(fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  apply (case_tac "ptr = fst slot")
+   apply (erule cte_wp_atE)
+    apply (fastforce simp: obj_at_def)
+   apply (erule notE)
+   apply (clarsimp simp: obj_at_def)
+   apply (rule cte_wp_at_tcbI)
+      apply simp
+     apply (fastforce)
+    apply (fastforce simp: tcb_cap_cases_def split: if_splits)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
-lemma as_user_neg_cte_wp_at[wp]:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>
-   as_user t f
-   \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
-  unfolding as_user_def
-  apply(wp set_object_tcb_context_update_neg_cte_wp_at | simp add: split_def)+
-  apply(fastforce simp: obj_at_def)
-  done
-
-crunch domain_sep_inv[wp]: as_user "domain_sep_inv irqs st"
-  (wp: domain_sep_inv_triv)
-
-lemma set_object_tcb_context_update_domain_sep_inv:
-  "\<lbrace>\<lambda>s. domain_sep_inv irqs st s \<and> obj_at ((=) (TCB tcb)) ptr s\<rbrace>
-   set_object ptr (TCB (tcb\<lparr>tcb_arch := arch_tcb_context_set X (tcb_arch tcb)\<rparr>))
+lemma set_object_tcb_arch_update_domain_sep_inv:
+  "\<lbrace>domain_sep_inv irqs st and obj_at ((=) (TCB tcb)) ptr\<rbrace>
+   set_object ptr (TCB (tcb\<lparr>tcb_arch := arch\<rparr>))
    \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(rule hoare_pre)
-   apply(rule domain_sep_inv_wp)
-    apply(rule hoare_pre)
-     apply(rule set_object_tcb_context_update_neg_cte_wp_at)
-    apply(fastforce)
-   apply(wp | simp | elim conjE | assumption)+
-  apply blast
+  apply (wp set_object_wp)
+  apply (simp add: domain_sep_inv_def fun_upd_def cte_wp_at_caps_of_state)
+  apply (fastforce simp: caps_of_state_after_update obj_at_def tcb_cap_cases_def)
   done
 
-crunch domain_sep_inv[wp]: set_mrs "domain_sep_inv irqs st"
-  (ignore: set_object
-   wp: crunch_wps set_object_tcb_context_update_domain_sep_inv
-   simp: crunch_simps arch_tcb_set_registers_def)
+lemma dxo_domain_sep_inv[wp]:
+  "do_extended_op eop \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  by (simp | wp dxo_wp_weak)+
 
-
-crunch domain_sep_inv[wp]: send_signal "domain_sep_inv irqs st" (wp: dxo_wp_weak ignore: possible_switch_to)
-
-crunch domain_sep_inv[wp]: copy_mrs, set_message_info, invalidate_tlb_by_asid "domain_sep_inv irqs st"
-  (wp: crunch_wps)
-
-lemma perform_page_invocation_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st and valid_page_inv pgi\<rbrace>
-  perform_page_invocation pgi
-  \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(rule hoare_pre)
-   apply(wp mapM_wp[OF _ subset_refl] set_cap_domain_sep_inv
-            mapM_x_wp[OF _ subset_refl]
-            perform_page_invocation_domain_sep_inv_get_cap_helper static_imp_wp
-        | simp add: perform_page_invocation_def o_def | wpc)+
-  apply(clarsimp simp: valid_page_inv_def)
-  apply(case_tac xa, simp_all add: domain_sep_inv_cap_def is_pg_cap_def)
-  done
-
-lemma perform_page_table_invocation_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st and valid_pti pgi\<rbrace>
-  perform_page_table_invocation pgi
-  \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(rule hoare_pre)
-   apply(simp add: perform_page_table_invocation_def)
-   apply(wp crunch_wps perform_page_invocation_domain_sep_inv_get_cap_helper
-            set_cap_domain_sep_inv
-        | wpc
-        | simp add: o_def)+
-  apply(clarsimp simp: valid_pti_def)
-  apply(case_tac x, simp_all add: domain_sep_inv_cap_def is_pt_cap_def)
-  done
-
-lemma perform_page_directory_invocation_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-  perform_page_directory_invocation pti
-  \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply (simp add: perform_page_directory_invocation_def)
-  apply (cases pti)
-   apply (simp | wp)+
-   done
+crunch domain_sep_inv[wp]: copy_mrs, set_message_info, set_mrs "domain_sep_inv irqs st"
+  (wp: crunch_wps set_object_tcb_arch_update_domain_sep_inv simp: crunch_simps ignore: set_object)
 
 lemma cap_insert_domain_sep_inv':
-  "\<lbrace> domain_sep_inv irqs st and K (domain_sep_inv_cap irqs cap) \<rbrace>
-  cap_insert cap slot dest_slot
-   \<lbrace> \<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(simp add: cap_insert_def)
-  apply(wp set_cap_domain_sep_inv get_cap_wp dxo_wp_weak | simp split del: if_split)+
+  "\<lbrace>domain_sep_inv irqs st and K (domain_sep_inv_cap irqs cap)\<rbrace>
+   cap_insert cap slot dest_slot
+   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  apply (simp add: cap_insert_def)
+  apply (wp set_cap_domain_sep_inv get_cap_wp dxo_wp_weak | simp split del: if_split)+
   done
 
 lemma domain_sep_inv_cap_max_free_index_update[simp]:
   "domain_sep_inv_cap irqs (max_free_index_update cap) =
    domain_sep_inv_cap irqs cap"
-  apply(simp add: max_free_index_def free_index_update_def split: cap.splits)
-  done
+  by (simp add: max_free_index_def free_index_update_def split: cap.splits)
 
 lemma domain_sep_inv_cap_ArchObjectCap[simp]:
   "domain_sep_inv_cap irqs (ArchObjectCap arch_cap)"
-  by(simp add: domain_sep_inv_cap_def)
+  by (simp add: domain_sep_inv_cap_def)
 
-lemma perform_asid_control_invocation_domain_sep_inv:
-  notes blah[simp del] =  atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
-  shows
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-   perform_asid_control_invocation blah
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  unfolding perform_asid_control_invocation_def
-  apply(rule hoare_pre)
-  apply (wp modify_wp cap_insert_domain_sep_inv' set_cap_domain_sep_inv
-            get_cap_domain_sep_inv_cap[where st=st] static_imp_wp
-        | wpc | simp )+
-  done
 
-lemma perform_asid_pool_invocation_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-   perform_asid_pool_invocation blah
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(simp add: perform_asid_pool_invocation_def)
-  apply(rule hoare_pre)
-  apply(wp set_cap_domain_sep_inv get_cap_wp | wpc | simp)+
-  done
+locale DomainSepInv_2 = DomainSepInv_1 state_ext_t
+  for state_ext_t :: "'state_ext :: state_ext itself" +
+  assumes arch_switch_to_thread_domain_sep_inv[wp]:
+    "arch_switch_to_thread t \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs (st :: 'state_ext state) s\<rbrace>"
+  and arch_switch_to_idle_thread_domain_sep_inv[wp]:
+    "arch_switch_to_idle_thread \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and arch_activate_idle_thread_domain_sep_inv[wp]:
+    "arch_activate_idle_thread t \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and arch_mask_irq_signal_domain_sep_inv[wp]:
+    "arch_mask_irq_signal irq \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and arch_derive_cap_domain_sep_inv[wp]:
+    "\<lbrace>\<top>\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv s :: det_ext state. domain_sep_inv_cap irqs rv\<rbrace>,-"
+  and arch_post_modify_registers_domain_sep_inv[wp]:
+    "arch_post_modify_registers cur x31 \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and arch_perform_invocation_domain_sep_inv[wp]:
+    "\<lbrace>domain_sep_inv irqs st and valid_arch_inv ai\<rbrace>
+     arch_perform_invocation ai
+     \<lbrace>\<lambda>_ s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and arch_invoke_irq_handler_domain_sep_inv[wp]:
+    "arch_invoke_irq_handler ihi \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and arch_invoke_irq_control_domain_sep_inv:
+    "\<lbrace>domain_sep_inv irqs st and arch_irq_control_inv_valid ivk\<rbrace>
+     arch_invoke_irq_control ivk
+     \<lbrace>\<lambda>_ s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and handle_arch_fault_reply_domain_sep_inv[wp]:
+    "handle_arch_fault_reply vmf thread x y \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and handle_hypervisor_fault_domain_sep_inv[wp]:
+    "handle_hypervisor_fault t hf_t \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and handle_vm_fault_domain_sep_inv[wp]:
+    "handle_vm_fault t vmf_t \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and handle_reserved_irq_domain_sep_inv[wp]:
+    "handle_reserved_irq irq \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+begin
 
-lemma arch_perform_invocation_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st and valid_arch_inv ai\<rbrace>
-   arch_perform_invocation ai
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  unfolding arch_perform_invocation_def
-  apply(rule hoare_pre)
-  apply(wp perform_page_table_invocation_domain_sep_inv
-           perform_page_directory_invocation_domain_sep_inv
-           perform_page_invocation_domain_sep_inv
-           perform_asid_control_invocation_domain_sep_inv
-           perform_asid_pool_invocation_domain_sep_inv
-       | wpc)+
-  apply(clarsimp simp: valid_arch_inv_def split: arch_invocation.splits)
-  done
-
-(* when blah is AckIRQ the preconditions here contradict each other, which
+(* when i is AckIRQ the preconditions here contradict each other, which
    is why this lemma is true *)
 lemma invoke_irq_handler_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st and irq_handler_inv_valid blah\<rbrace>
-    invoke_irq_handler blah
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(case_tac blah)
-    apply(wp cap_insert_domain_sep_inv' | simp)+
-    apply(rename_tac irq cap cslot_ptr s)
-    apply(case_tac cap, simp_all add: domain_sep_inv_cap_def)[1]
-   apply(wp | auto simp: domain_sep_inv_def)+
+  "\<lbrace>domain_sep_inv irqs st and irq_handler_inv_valid i\<rbrace>
+   invoke_irq_handler i
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
+  apply (case_tac i)
+    apply (wp cap_insert_domain_sep_inv' | simp)+
+   apply (rename_tac irq cap cslot_ptr s)
+   apply (case_tac cap, simp_all add: domain_sep_inv_cap_def)[1]
+  apply (wp | clarsimp)+
   done
-
 
 (* similarly, the preconditions here tend to contradict one another *)
 lemma invoke_control_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st and irq_control_inv_valid blah\<rbrace>
-    invoke_irq_control blah
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  "\<lbrace>domain_sep_inv irqs st and irq_control_inv_valid i\<rbrace>
+    invoke_irq_control i
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
   including no_pre
-  apply (case_tac blah)
+  apply (case_tac i)
    apply (case_tac irqs)
     apply (wp cap_insert_domain_sep_inv' | simp )+
     apply (simp add: set_irq_state_def, wp, simp)
     apply (fastforce simp: domain_sep_inv_def domain_sep_inv_cap_def)
    apply (fastforce simp: valid_def domain_sep_inv_def)
-  apply (wp | simp)+
-  apply (case_tac x2)
-  apply (simp)
-  apply (rule hoare_seq_ext[where B="\<lambda>_. domain_sep_inv irqs st and irq_control_inv_valid blah"])
-   apply simp
-   apply (case_tac irqs)
-    prefer 2
-    apply (fastforce simp: valid_def domain_sep_inv_def arch_irq_control_inv_valid_def)
-   apply (wp cap_insert_domain_sep_inv' | simp )+
-   apply (simp add: set_irq_state_def, wp, simp)
-   apply (fastforce simp: domain_sep_inv_def domain_sep_inv_cap_def)
-  apply wpsimp
-  apply (simp add: arch_irq_control_inv_valid_def)
-  apply (rule hoare_pre)
-   apply (wpsimp wp: do_machine_op_domain_sep_inv)
-  apply clarsimp
+  apply simp
+  apply (wp arch_invoke_irq_control_domain_sep_inv)
   done
 
+lemma derive_cap_domain_sep_inv_cap:
+  "\<lbrace>\<lambda>s. domain_sep_inv_cap irqs cap\<rbrace>
+   derive_cap slot cap
+   \<lbrace>\<lambda>rv s :: det_ext state. domain_sep_inv_cap irqs rv\<rbrace>,-"
+  apply (simp add: derive_cap_def)
+  apply (rule hoare_pre)
+  apply (wp | wpc | simp add: )+
+  apply auto
+  done
+
+end
 
 
-crunch domain_sep_inv[wp]: receive_signal "domain_sep_inv irqs st"
+crunch domain_sep_inv[wp]: receive_signal, complete_signal "domain_sep_inv irqs st"
 
 lemma domain_sep_inv_cap_ReplyCap[simp]:
   "domain_sep_inv_cap irqs (ReplyCap param_a param_b param_c)"
-  by(simp add: domain_sep_inv_cap_def)
+  by (simp add: domain_sep_inv_cap_def)
 
 lemma setup_caller_cap_domain_sep_inv[wp]:
   "\<lbrace>domain_sep_inv irqs st\<rbrace>
    setup_caller_cap a b c
    \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(simp add: setup_caller_cap_def split del:if_split)
-  apply(wp cap_insert_domain_sep_inv' | simp)+
-  done
-
-crunch domain_sep_inv[wp]: set_extra_badge "domain_sep_inv irqs st"
-
-lemma derive_cap_domain_sep_inv_cap:
-  "\<lbrace>\<lambda>s. domain_sep_inv_cap irqs cap\<rbrace>
-   derive_cap slot cap
-   \<lbrace>\<lambda>rv s. domain_sep_inv_cap irqs rv\<rbrace>,-"
-  apply(simp add: derive_cap_def)
-  apply(rule hoare_pre)
-  apply(wp | wpc | simp add: arch_derive_cap_def)+
-  apply auto
+  apply (simp add: setup_caller_cap_def split del:if_split)
+  apply (wp cap_insert_domain_sep_inv' | simp)+
   done
 
 lemma transfer_caps_domain_sep_inv:
@@ -968,356 +835,293 @@ lemma transfer_caps_domain_sep_inv:
   transfer_caps mi caps endpoint receiver receive_buffer
   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
   unfolding transfer_caps_def
-  apply (wpsimp wp: transfer_caps_loop_pres_dest cap_insert_domain_sep_inv hoare_vcg_all_lift hoare_vcg_imp_lift)
+  apply (wpsimp wp: transfer_caps_loop_pres_dest cap_insert_domain_sep_inv
+                    hoare_vcg_all_lift hoare_vcg_imp_lift)
   apply (fastforce elim: cte_wp_at_weakenE)
   done
 
 
+context DomainSepInv_2 begin
+
 lemma do_normal_transfer_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and valid_objs and valid_mdb\<rbrace>
    do_normal_transfer sender send_buffer ep badge grant receiver recv_buffer
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
   unfolding do_normal_transfer_def
-  apply (wp transfer_caps_domain_sep_inv hoare_vcg_ball_lift lec_valid_cap' | simp)+
-  done
+  by (wp transfer_caps_domain_sep_inv hoare_vcg_ball_lift lec_valid_cap' | simp)+
 
-crunch domain_sep_inv[wp]: do_fault_transfer "domain_sep_inv irqs st"
+crunches do_fault_transfer
+  for domain_sep_inv[wp]: "\<lambda>s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)"
 
 lemma do_ipc_transfer_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and valid_objs and valid_mdb\<rbrace>
    do_ipc_transfer sender ep badge grant receiver
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
   unfolding do_ipc_transfer_def
   apply (wp do_normal_transfer_domain_sep_inv hoare_vcg_all_lift | wpc | wp (once) hoare_drop_imps)+
   apply clarsimp
-  done
-
-(* FIXME: clagged from FinalCaps *)
-lemma valid_ep_recv_dequeue':
-  "\<lbrakk> ko_at (Endpoint (Structures_A.endpoint.RecvEP (t # ts))) epptr s;
-     valid_objs s\<rbrakk>
-     \<Longrightarrow> valid_ep (case ts of [] \<Rightarrow> Structures_A.endpoint.IdleEP
-                            | b # bs \<Rightarrow> Structures_A.endpoint.RecvEP ts) s"
-  unfolding valid_objs_def valid_obj_def valid_ep_def obj_at_def
-  apply (drule bspec)
-  apply (auto split: list.splits)
   done
 
 lemma send_ipc_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and valid_objs and valid_mdb and
     sym_refs \<circ> state_refs_of\<rbrace>
    send_ipc block call badge can_grant can_grant_reply thread epptr
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
   unfolding send_ipc_def
   apply (wp setup_caller_cap_domain_sep_inv hoare_vcg_if_lift | wpc | simp split del:if_split)+
-        apply(rule_tac Q="\<lambda> r s. domain_sep_inv irqs st s" in hoare_strengthen_post)
-         apply(wp do_ipc_transfer_domain_sep_inv dxo_wp_weak | wpc | simp)+
-    apply (wp (once) hoare_drop_imps)
-    apply (wp get_simple_ko_wp)+
+        apply (rule_tac Q="\<lambda> r s. domain_sep_inv irqs st s" in hoare_strengthen_post)
+         apply (wp do_ipc_transfer_domain_sep_inv dxo_wp_weak | wpc | simp)+
+     apply (wp (once) hoare_drop_imps)
+     apply (wp get_simple_ko_wp)+
   apply clarsimp
   apply (fastforce simp: valid_objs_def valid_obj_def obj_at_def ep_q_refs_of_def
-                         a_type_def ep_redux_simps neq_Nil_conv valid_ep_def case_list_cons_cong
-                   elim: ep_queued_st_tcb_at)
+                         a_type_def ep_redux_simps neq_Nil_conv valid_ep_def
+                   elim: ep_queued_st_tcb_at split: list.splits)
   done
-
-(* FIXME: following 2 clagged from FinalCaps *)
-lemma hd_tl_in_set:
-  "tl xs = (x # xs') \<Longrightarrow> x \<in> set xs"
-  apply(case_tac xs, auto)
-  done
-
-lemma set_tl_subset:
-  "list \<noteq> [] \<Longrightarrow> set (tl list) \<subseteq> set list"
-  apply(case_tac list)
-   apply auto
-  done
-
-crunch domain_sep_inv[wp]: complete_signal "domain_sep_inv irqs st"
 
 lemma receive_ipc_base_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and valid_objs and valid_mdb and
     sym_refs \<circ> state_refs_of and ko_at (Endpoint ep) epptr \<rbrace>
    receive_ipc_base aag receiver ep epptr rights is_blocking
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
   apply (clarsimp cong: endpoint.case_cong thread_get_def get_thread_state_def)
-  apply (rule hoare_pre)
-  apply (wp setup_caller_cap_domain_sep_inv dxo_wp_weak
-        | wpc | simp split del: if_split)+
-          apply(rule_tac Q="\<lambda> r s. domain_sep_inv irqs st s" in hoare_strengthen_post)
-          apply(wp do_ipc_transfer_domain_sep_inv hoare_vcg_all_lift | wpc | simp)+
-     apply(wp hoare_vcg_imp_lift [OF set_simple_ko_get_tcb, unfolded disj_not1] hoare_vcg_all_lift get_simple_ko_wp
-         | wpc | simp add: a_type_def do_nbrecv_failed_transfer_def)+
-  apply (clarsimp simp: conj_comms)
+  apply (wp setup_caller_cap_domain_sep_inv dxo_wp_weak | wpc | simp split del: if_split)+
+        apply (rule_tac Q="\<lambda> r s. domain_sep_inv irqs st s" in hoare_strengthen_post)
+         apply (wp do_ipc_transfer_domain_sep_inv hoare_vcg_all_lift | wpc | simp)+
+     apply (wpsimp wp: hoare_vcg_imp_lift[OF set_simple_ko_get_tcb, unfolded disj_not1]
+                       hoare_vcg_all_lift get_simple_ko_wp
+                 simp: a_type_def do_nbrecv_failed_transfer_def)+
   apply (fastforce simp: valid_objs_def valid_obj_def obj_at_def
-                         ep_redux_simps neq_Nil_conv valid_ep_def case_list_cons_cong)
+                         ep_redux_simps neq_Nil_conv valid_ep_def
+                  split: list.splits)
   done
 
 lemma receive_ipc_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st and valid_objs and valid_mdb and
-    sym_refs \<circ> state_refs_of \<rbrace>
+  "\<lbrace>domain_sep_inv irqs st and valid_objs and valid_mdb and sym_refs \<circ> state_refs_of\<rbrace>
    receive_ipc receiver cap is_blocking
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
   unfolding receive_ipc_def
   apply (simp add: receive_ipc_def split: cap.splits, clarsimp)
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
   apply (rule hoare_seq_ext[OF _ gbn_sp])
   apply (case_tac ntfnptr, simp)
-  apply (wp receive_ipc_base_domain_sep_inv get_simple_ko_wp | simp split: if_split option.splits)+
+   apply (wp receive_ipc_base_domain_sep_inv get_simple_ko_wp | simp split: if_split option.splits)+
   done
 
 lemma send_fault_ipc_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st and valid_objs and sym_refs \<circ> state_refs_of and valid_mdb and
-     K (valid_fault fault)\<rbrace>
-    send_fault_ipc thread fault
-    \<lbrace>\<lambda>rv. domain_sep_inv irqs st\<rbrace>"
-  apply(rule hoare_gen_asm)+
+  "\<lbrace>domain_sep_inv irqs st and valid_objs and sym_refs \<circ> state_refs_of
+                           and valid_mdb and K (valid_fault fault)\<rbrace>
+   send_fault_ipc thread fault
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
   unfolding send_fault_ipc_def
-  apply(wp send_ipc_domain_sep_inv thread_set_valid_objs thread_set_tcb_fault_update_valid_mdb
-           thread_set_refs_trivial thread_set_obj_at_impossible
-           hoare_vcg_ex_lift
-       | wpc| simp add: Let_def split_def lookup_cap_def valid_tcb_fault_update split del: if_split)+
-    apply (wpe get_cap_inv[where P="domain_sep_inv irqs st and valid_objs and valid_mdb
-                            and sym_refs o state_refs_of"])
-    apply (wp | simp)+
+  apply (rule hoare_gen_asm)+
+  apply (wp send_ipc_domain_sep_inv thread_set_valid_objs thread_set_tcb_fault_update_valid_mdb
+            thread_set_refs_trivial thread_set_obj_at_impossible hoare_vcg_ex_lift
+         | wpc | simp add: Let_def split_def lookup_cap_def valid_tcb_fault_update)+
+     apply (wpe get_cap_inv[where P="domain_sep_inv irqs st and valid_objs and valid_mdb
+                                                            and sym_refs o state_refs_of"])
+     apply (wp | simp)+
   done
 
-crunch domain_sep_inv[wp]: handle_fault "domain_sep_inv irqs st"
+crunches do_reply_transfer, handle_fault, reply_from_kernel, restart
+  for domain_sep_inv[wp]: "\<lambda>s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)"
+  (wp: handle_arch_fault_reply_domain_sep_inv dxo_wp_weak crunch_wps ignore: thread_set)
 
-crunch domain_sep_inv[wp]: do_reply_transfer "domain_sep_inv irqs st"
-  (wp:  dxo_wp_weak crunch_wps  ignore: set_object thread_set possible_switch_to)
-
-crunch domain_sep_inv[wp]: reply_from_kernel "domain_sep_inv irqs st"
-  (wp: crunch_wps simp: crunch_simps)
+end
 
 crunch domain_sep_inv[wp]: setup_reply_master "domain_sep_inv irqs st"
   (wp: crunch_wps simp: crunch_simps)
 
-crunch domain_sep_inv[wp]: restart "domain_sep_inv irqs st"
-  (wp: crunch_wps dxo_wp_weak simp: crunch_simps ignore: tcb_sched_action possible_switch_to)
-
 lemma thread_set_tcb_ipc_buffer_update_neg_cte_wp_at[wp]:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>
-    thread_set (tcb_ipc_buffer_update f) t
-   \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
+  "thread_set (tcb_ipc_buffer_update f) t \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
   unfolding thread_set_def
-  apply(wp set_object_wp | simp)+
-  apply(case_tac "t = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(erule notE)
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(drule get_tcb_SomeD)
-   apply(rule cte_wp_at_tcbI)
-     apply(simp)
+  apply (wp set_object_wp | simp)+
+  apply (case_tac "t = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (erule notE)
+   apply (erule cte_wp_atE)
+    apply (fastforce simp: obj_at_def)
+   apply (drule get_tcb_SomeD)
+   apply (rule cte_wp_at_tcbI)
+     apply simp
     apply assumption
    apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
 lemma thread_set_tcb_ipc_buffer_update_domain_sep_inv[wp]:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-   thread_set (tcb_ipc_buffer_update f) t
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  "thread_set (tcb_ipc_buffer_update f) t \<lbrace>domain_sep_inv irqs st\<rbrace>"
   by (rule domain_sep_inv_triv; wp)
 
 lemma thread_set_tcb_fault_handler_update_neg_cte_wp_at[wp]:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>
-   thread_set (tcb_fault_handler_update blah) t
-   \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
+  "thread_set (tcb_fault_handler_update f) t \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
   unfolding thread_set_def
-  apply(wp set_object_wp | simp)+
-  apply(case_tac "t = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(erule notE)
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(drule get_tcb_SomeD)
-   apply(rule cte_wp_at_tcbI)
-     apply(simp)
+  apply (wp set_object_wp | simp)+
+  apply (case_tac "t = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (erule notE)
+   apply (erule cte_wp_atE)
+    apply (fastforce simp: obj_at_def)
+   apply (drule get_tcb_SomeD)
+   apply (rule cte_wp_at_tcbI)
+     apply simp
     apply assumption
    apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
 lemma thread_set_tcb_fault_handler_update_domain_sep_inv[wp]:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-   thread_set (tcb_fault_handler_update blah) t
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  "thread_set (tcb_fault_handler_update f) t \<lbrace>domain_sep_inv irqs st\<rbrace>"
   by (rule domain_sep_inv_triv; wp)
 
 lemma thread_set_tcb_tcb_mcpriority_update_neg_cte_wp_at[wp]:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>
-   thread_set (tcb_mcpriority_update blah) t
-   \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
+  "thread_set (tcb_mcpriority_update f) t \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
   unfolding thread_set_def
-  apply(wp set_object_wp | simp)+
-  apply(case_tac "t = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(erule notE)
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(drule get_tcb_SomeD)
-   apply(rule cte_wp_at_tcbI)
-     apply(simp)
+  apply (wp set_object_wp | simp)+
+  apply (case_tac "t = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (erule notE)
+   apply (erule cte_wp_atE)
+    apply (fastforce simp: obj_at_def)
+   apply (drule get_tcb_SomeD)
+   apply (rule cte_wp_at_tcbI)
+     apply simp
     apply assumption
    apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
 lemma thread_set_tcb_tcp_mcpriority_update_domain_sep_inv[wp]:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-   thread_set (tcb_mcpriority_update blah) t
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  "thread_set (tcb_mcpriority_update f) t \<lbrace>domain_sep_inv irqs st\<rbrace>"
   by (rule domain_sep_inv_triv; wp)
 
 lemma same_object_as_domain_sep_inv_cap:
-  "\<lbrakk>same_object_as a cap; domain_sep_inv_cap irqs cap\<rbrakk>
-   \<Longrightarrow> domain_sep_inv_cap irqs a"
-  apply(case_tac a, simp_all add: same_object_as_def domain_sep_inv_cap_def)
-  apply(case_tac cap, simp_all)
+  "\<lbrakk> same_object_as a cap; domain_sep_inv_cap irqs cap \<rbrakk>
+     \<Longrightarrow> domain_sep_inv_cap irqs a"
+  apply (case_tac a, simp_all add: same_object_as_def domain_sep_inv_cap_def)
+  apply (case_tac cap, simp_all)
   done
 
 lemma checked_cap_insert_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-   check_cap_at a b (check_cap_at c d (cap_insert a b e))
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(wp get_cap_wp cap_insert_domain_sep_inv' | simp add: check_cap_at_def)+
+  "check_cap_at a b (check_cap_at c d (cap_insert a b e)) \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  apply (wp get_cap_wp cap_insert_domain_sep_inv' | simp add: check_cap_at_def)+
   apply clarsimp
-  apply(drule_tac cap=cap in cte_wp_at_domain_sep_inv_cap)
+  apply (drule_tac cap=cap in cte_wp_at_domain_sep_inv_cap)
    apply assumption
-  apply(erule (1) same_object_as_domain_sep_inv_cap)
+  apply (erule (1) same_object_as_domain_sep_inv_cap)
   done
 
 crunch domain_sep_inv[wp]: bind_notification,reschedule_required "domain_sep_inv irqs st"
 
-lemma dxo_domain_sep_inv[wp]:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace> do_extended_op eop  \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  by (simp | wp dxo_wp_weak)+
-
-
 lemma set_mcpriority_domain_sep_inv[wp]:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace> set_mcpriority tcb_ref mcp \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  "set_mcpriority tcb_ref mcp \<lbrace>domain_sep_inv irqs st\<rbrace>"
   unfolding set_mcpriority_def by wp
 
-lemma invoke_tcb_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st and
-    Tcb_AI.tcb_inv_wf tinv\<rbrace>
-   invoke_tcb tinv
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(case_tac tinv)
-       apply((wp restart_domain_sep_inv hoare_vcg_if_lift  mapM_x_wp[OF _ subset_refl]
-            | wpc
-            | simp split del: if_split add: check_cap_at_def
-            | clarsimp)+)[3]
-    defer
-    apply((wp | simp )+)[2]
-  (* just NotificationControl and ThreadControl left *)
-  apply (rename_tac option)
-  apply (case_tac option)
-  apply  ((wp | simp)+)[1]
-  apply (simp add: split_def cong: option.case_cong)
-  apply (wp checked_cap_insert_domain_sep_inv hoare_vcg_all_lift_R
-            hoare_vcg_all_lift hoare_vcg_const_imp_lift_R
-            cap_delete_domain_sep_inv
-            cap_delete_deletes
-            dxo_wp_weak
-            cap_delete_valid_cap cap_delete_cte_at static_imp_wp
-        |wpc
-        |simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
-                  tcb_at_st_tcb_at
-        |strengthen use_no_cap_to_obj_asid_strg)+
-  apply(rule hoare_pre)
-  apply(simp add: option_update_thread_def tcb_cap_cases_def
-       | wp hoare_vcg_all_lift
-            thread_set_emptyable
-            thread_set_valid_cap static_imp_wp
-            thread_set_cte_at  thread_set_no_cap_to_trivial
-       | wpc)+
-  done
-
 lemma invoke_domain_domain_set_inv:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-     invoke_domain word1 word2
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  "invoke_domain word1 word2 \<lbrace>domain_sep_inv irqs st\<rbrace>"
   apply (simp add: invoke_domain_def)
   apply (wp dxo_wp_weak | simp)+
   done
 
 
+context DomainSepInv_2 begin
+
+lemma invoke_tcb_domain_sep_inv:
+  "\<lbrace>domain_sep_inv irqs st and tcb_inv_wf tinv\<rbrace>
+   invoke_tcb tinv
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
+  apply (case_tac tinv)
+         apply ((wp restart_domain_sep_inv hoare_vcg_if_lift mapM_x_wp[OF _ subset_refl]
+                 | wpc | simp split del: if_split add: check_cap_at_def | clarsimp)+)[3]
+      defer
+      apply ((wp | simp)+)[2]
+    (* just NotificationControl and ThreadControl left *)
+    apply (rename_tac option)
+    apply (case_tac option)
+     apply  ((wp | simp)+)[1]
+    apply (simp add: split_def cong: option.case_cong)
+    apply (wp checked_cap_insert_domain_sep_inv hoare_vcg_all_lift_R hoare_vcg_all_lift
+              hoare_vcg_const_imp_lift_R cap_delete_domain_sep_inv cap_delete_deletes
+              dxo_wp_weak cap_delete_valid_cap cap_delete_cte_at static_imp_wp
+           | wpc | strengthen
+           | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def tcb_at_st_tcb_at
+                  del: set_priority_extended.dxo_eq)+
+        apply (rule hoare_pre)
+         apply (simp add: option_update_thread_def tcb_cap_cases_def
+                | wpsimp wp: hoare_vcg_all_lift thread_set_emptyable thread_set_valid_cap
+                             static_imp_wp thread_set_cte_at  thread_set_no_cap_to_trivial)+
+  done
 
 lemma perform_invocation_domain_sep_inv':
-  "\<lbrace>domain_sep_inv irqs st and valid_invocation iv and valid_objs and valid_mdb and sym_refs \<circ> state_refs_of\<rbrace>
-     perform_invocation block call iv
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(case_tac iv)
-          apply(wp send_ipc_domain_sep_inv invoke_tcb_domain_sep_inv
-                   invoke_cnode_domain_sep_inv invoke_control_domain_sep_inv
-                   invoke_irq_handler_domain_sep_inv arch_perform_invocation_domain_sep_inv
-                   invoke_domain_domain_set_inv
-               | simp add: split_def
-               | blast)+
+  "\<lbrace>domain_sep_inv irqs st and valid_invocation iv and valid_objs
+                           and valid_mdb and sym_refs \<circ> state_refs_of\<rbrace>
+   perform_invocation block call iv
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
+  apply (case_tac iv)
+           apply (wp send_ipc_domain_sep_inv invoke_tcb_domain_sep_inv
+                     invoke_cnode_domain_sep_inv invoke_control_domain_sep_inv
+                     invoke_irq_handler_domain_sep_inv arch_perform_invocation_domain_sep_inv
+                     invoke_domain_domain_set_inv
+                  | simp add: split_def | blast)+
   done
 
 lemma perform_invocation_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and valid_invocation iv and invs\<rbrace>
-     perform_invocation block call iv
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+   perform_invocation block call iv
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
   apply (rule hoare_weaken_pre[OF perform_invocation_domain_sep_inv'])
   apply auto
   done
 
 lemma handle_invocation_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and invs and ct_active\<rbrace>
-     handle_invocation calling blocking
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply (simp add: handle_invocation_def ts_Restart_case_helper split_def
-                   liftE_liftM_liftME liftME_def bindE_assoc
-              split del: if_split)
-  apply(wp syscall_valid perform_invocation_domain_sep_inv
-           set_thread_state_runnable_valid_sched
-       | simp split del: if_split)+
-       apply(rule_tac E="\<lambda>ft. domain_sep_inv irqs st and
-                  valid_objs and
-                  sym_refs \<circ> state_refs_of and
-                  valid_mdb and
-                  (\<lambda>y. valid_fault ft)" and R="Q" and Q=Q for Q in hoare_post_impErr)
-         apply(wp
-              | simp | clarsimp)+
-     apply(rule_tac E="\<lambda>ft. domain_sep_inv irqs st and
-                            valid_objs and
-                            sym_refs \<circ> state_refs_of and
-                            valid_mdb and
-                            (\<lambda>y. valid_fault (CapFault x False ft))" and R="Q" and Q=Q
-                  for Q in hoare_post_impErr)
-       apply (wp lcs_ex_cap_to2
-             | clarsimp)+
+   handle_invocation calling blocking
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
+  apply (simp add: handle_invocation_def ts_Restart_case_helper
+                   split_def liftE_liftM_liftME liftME_def bindE_assoc)
+  apply (wp syscall_valid perform_invocation_domain_sep_inv set_thread_state_runnable_valid_sched
+         | simp split del: if_split)+
+        apply (rule_tac E="\<lambda>ft. domain_sep_inv irqs st and valid_objs and sym_refs \<circ> state_refs_of
+                                                       and valid_mdb and (\<lambda>y. valid_fault ft)"
+                    and R="Q" and Q=Q for Q in hoare_post_impErr)
+         apply (wp | simp | clarsimp)+
+      apply (rule_tac E="\<lambda>ft. domain_sep_inv irqs st and valid_objs and sym_refs \<circ> state_refs_of and
+                              valid_mdb and (\<lambda>y. valid_fault (CapFault x False ft))"
+                  and R="Q" and Q=Q for Q in hoare_post_impErr)
+        apply (wp lcs_ex_cap_to2 | clarsimp)+
   apply (auto intro: st_tcb_ex_cap simp: ct_in_state_def)
   done
 
 lemma handle_send_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and invs and ct_active\<rbrace>
-     handle_send a
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(simp add: handle_send_def)
-  apply(wp handle_invocation_domain_sep_inv)
+   handle_send a
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
+  apply (simp add: handle_send_def)
+  apply (wp handle_invocation_domain_sep_inv)
   done
 
 lemma handle_call_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and invs and ct_active\<rbrace>
-     handle_call
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(simp add: handle_call_def)
-  apply(wp handle_invocation_domain_sep_inv)
+   handle_call
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
+  apply (simp add: handle_call_def)
+  apply (wp handle_invocation_domain_sep_inv)
   done
 
 lemma handle_reply_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st and invs\<rbrace> handle_reply \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(simp add: handle_reply_def)
-  apply(wp get_cap_wp | wpc)+
+  "\<lbrace>domain_sep_inv irqs st and invs\<rbrace>
+   handle_reply
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
+  apply (simp add: handle_reply_def)
+  apply (wp get_cap_wp | wpc)+
   apply auto
   done
 
-crunch domain_sep_inv[wp]: delete_caller_cap "domain_sep_inv irqs st"
+crunches delete_caller_cap
+  for domain_sep_inv[wp]: "\<lambda>s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)"
+
+end
+
 
 (* FIXME: clagged from Syscall_AC *)
 lemma lookup_slot_for_thread_cap_fault:
@@ -1328,68 +1132,57 @@ lemma lookup_slot_for_thread_cap_fault:
   apply (erule (1) invs_valid_tcb_ctable)
   done
 
+lemma domain_sep_inv_cur_thread_update[simp]:
+  "domain_sep_inv irqs st (s\<lparr>cur_thread := X\<rparr>) = domain_sep_inv irqs st s"
+  apply (simp add: domain_sep_inv_def)
+  done
+
+lemma (in is_extended') domain_sep_inv[wp]: "I (domain_sep_inv irqs st)" by (rule lift_inv, simp)
+
+
+context DomainSepInv_2 begin
 
 lemma handle_recv_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and invs\<rbrace>
    handle_recv is_blocking
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
   apply (simp add: handle_recv_def Let_def lookup_cap_def split_def)
-  apply (wp hoare_vcg_all_lift lookup_slot_for_thread_cap_fault
-            receive_ipc_domain_sep_inv delete_caller_cap_domain_sep_inv
-            get_cap_wp get_simple_ko_wp
-        | wpc | simp
-        | rule_tac Q="\<lambda>rv. invs and (\<lambda>s. cur_thread s = thread)" in hoare_strengthen_post, wp,
-          clarsimp simp: invs_valid_objs invs_sym_refs)+
-    apply (rule_tac Q'="\<lambda>r s. domain_sep_inv irqs st s \<and> invs s \<and> tcb_at thread s \<and> thread = cur_thread s" in hoare_post_imp_R)
+  apply (wp hoare_vcg_all_lift lookup_slot_for_thread_cap_fault receive_ipc_domain_sep_inv
+            delete_caller_cap_domain_sep_inv get_cap_wp get_simple_ko_wp
+         | wpc | simp
+         | (rule_tac Q="\<lambda>rv. invs and (\<lambda>s. cur_thread s = thread)" in hoare_strengthen_post, wp,
+            clarsimp simp: invs_valid_objs invs_sym_refs))+
+     apply (rule_tac Q'="\<lambda>r s. domain_sep_inv irqs st s \<and> invs s \<and>
+                               tcb_at thread s \<and> thread = cur_thread s" in hoare_post_imp_R)
       apply wp
      apply ((clarsimp simp add: invs_valid_objs invs_sym_refs
-           | intro impI allI conjI
-           | rule cte_wp_valid_cap caps_of_state_cteD
-           | fastforce simp:  valid_fault_def
-           )+)[1]
+             | intro impI allI conjI
+             | rule cte_wp_valid_cap caps_of_state_cteD
+             | fastforce simp:  valid_fault_def)+)[1]
     apply (wp delete_caller_cap_domain_sep_inv | simp add: split_def cong: conj_cong)+
-    apply(wp | simp add: invs_valid_objs invs_mdb invs_sym_refs tcb_at_invs)+
+    apply (wp | simp add: invs_valid_objs invs_mdb invs_sym_refs tcb_at_invs)+
   done
 
-crunch domain_sep_inv[wp]: handle_interrupt "domain_sep_inv irqs st"
-  (wp: dxo_wp_weak ignore: getActiveIRQ resetTimer ackInterrupt ignore: timer_tick)
-
-crunch domain_sep_inv[wp]: handle_vm_fault, handle_hypervisor_fault "domain_sep_inv irqs st"
-  (ignore: getFAR getDFSR getIFSR)
+crunches handle_interrupt, activate_thread, choose_thread
+  for domain_sep_inv[wp]: "\<lambda>s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)"
+  (wp: dxo_wp_weak crunch_wps)
 
 lemma handle_event_domain_sep_inv:
-  "\<lbrace> domain_sep_inv irqs st and invs and
-      (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) \<rbrace>
+  "\<lbrace>domain_sep_inv irqs st and invs and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
    handle_event ev
-   \<lbrace> \<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(case_tac ev, simp_all)
-      apply(rule hoare_pre)
-       apply(wpc
-            | wp handle_send_domain_sep_inv handle_call_domain_sep_inv
-                 handle_recv_domain_sep_inv handle_reply_domain_sep_inv
-                 hy_inv
-            | simp add: invs_valid_objs invs_mdb invs_sym_refs valid_fault_def)+
-     apply(rule_tac E="\<lambda>rv s. domain_sep_inv irqs st s \<and> invs s \<and> valid_fault rv" and R="Q" and Q=Q for Q in hoare_post_impErr)
-     apply(wp handle_vm_fault_domain_sep_inv | simp add: invs_valid_objs invs_mdb invs_sym_refs valid_fault_def | auto)+
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
+  apply (case_tac ev, simp_all)
+      apply (rule hoare_pre)
+       apply (wpsimp wp: handle_send_domain_sep_inv handle_call_domain_sep_inv
+                         handle_recv_domain_sep_inv handle_reply_domain_sep_inv hy_inv
+              | simp add: invs_valid_objs invs_mdb invs_sym_refs valid_fault_def)+
+     apply (rule_tac E="\<lambda>rv s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state) \<and>
+                               invs s \<and> valid_fault rv" and R="Q" and Q=Q for Q in hoare_post_impErr)
+     apply (wp | simp add: invs_valid_objs invs_mdb invs_sym_refs valid_fault_def | auto)+
   done
 
-crunch domain_sep_inv[wp]: activate_thread "domain_sep_inv irqs st"
-
-lemma domain_sep_inv_cur_thread_update[simp]:
-  "domain_sep_inv irqs st (s\<lparr>cur_thread := X\<rparr>) = domain_sep_inv irqs st s"
-  apply(simp add: domain_sep_inv_def)
-  done
-
-crunch domain_sep_inv[wp]: choose_thread "domain_sep_inv irqs st"
-  (wp: crunch_wps dxo_wp_weak ignore: tcb_sched_action ARM.clearExMonitor)
-
-end
-
-lemma (in is_extended') domain_sep_inv[wp]: "I (domain_sep_inv irqs st)" by (rule lift_inv, simp)
-
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-lemma schedule_domain_sep_inv: "\<lbrace>domain_sep_inv irqs st\<rbrace> (schedule :: (unit,det_ext) s_monad) \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+lemma schedule_domain_sep_inv:
+  "(schedule :: (unit,det_ext) s_monad) \<lbrace>domain_sep_inv irqs (st :: 'state_ext state)\<rbrace>"
   apply (simp add: schedule_def allActiveTCBs_def)
   apply (wp add: alternative_wp select_wp  guarded_switch_to_lift hoare_drop_imps
             del: ethread_get_wp
@@ -1398,14 +1191,13 @@ lemma schedule_domain_sep_inv: "\<lbrace>domain_sep_inv irqs st\<rbrace> (schedu
   done
 
 lemma call_kernel_domain_sep_inv:
-  "\<lbrace> domain_sep_inv irqs st and invs and
-      (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) \<rbrace>
+  "\<lbrace>domain_sep_inv irqs st and invs and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
    call_kernel ev :: (unit,det_ext) s_monad
-   \<lbrace> \<lambda>_. domain_sep_inv irqs st\<rbrace>"
-apply (simp add: call_kernel_def getActiveIRQ_def)
-apply (wp handle_interrupt_domain_sep_inv handle_event_domain_sep_inv schedule_domain_sep_inv
-     | simp)+
-done
+   \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) s\<rbrace>"
+  apply (simp add: call_kernel_def)
+  apply (wp handle_interrupt_domain_sep_inv handle_event_domain_sep_inv schedule_domain_sep_inv
+         | simp)+
+  done
 
 end
 

--- a/proof/access-control/Finalise_AC.thy
+++ b/proof/access-control/Finalise_AC.thy
@@ -5,10 +5,8 @@
  *)
 
 theory Finalise_AC
-imports Arch_AC
+imports ArchArch_AC
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 text \<open>
 NB: the @{term is_subject} assumption is not appropriate for some of
@@ -21,21 +19,61 @@ NB: the @{term is_subject} assumption is not appropriate for some of
     the current subject's domains.
 \<close>
 
+
+locale Finalise_AC_1 =
+  fixes aag :: "'a PAS"
+  assumes sbn_st_vrefs[wp]:
+    "\<And>P. set_bound_notification ref ntfn \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
+  and arch_finalise_cap_auth':
+    "\<lbrace>pas_refined aag\<rbrace> arch_finalise_cap acap final \<lbrace>\<lambda>rv _. pas_cap_cur_auth aag (fst rv)\<rbrace>"
+  and arch_finalise_cap_obj_refs:
+    "\<And>P. \<lbrace>\<lambda>_ :: det_ext state. \<forall>x \<in> aobj_ref' acap. P x\<rbrace>
+          arch_finalise_cap acap slot
+          \<lbrace>\<lambda>rv _. \<forall>x \<in> obj_refs (fst rv). P x\<rbrace>"
+  and prepare_thread_delete_st_tcb_at_halted[wp]:
+    "prepare_thread_delete t \<lbrace>\<lambda>s :: det_ext state. st_tcb_at halted t s\<rbrace>"
+  and arch_finalise_cap_makes_halted:
+    "\<lbrace>\<top>\<rbrace> arch_finalise_cap acap ex \<lbrace>\<lambda>rv s :: det_ext state. \<forall>t\<in>obj_refs (fst rv). halted_if_tcb t s\<rbrace>"
+  and arch_cap_cleanup_wf:
+    "\<lbrakk> arch_cap_cleanup_opt acap \<noteq> NullCap; \<not> is_arch_cap (arch_cap_cleanup_opt acap) \<rbrakk>
+       \<Longrightarrow> (\<exists>irq. arch_cap_cleanup_opt acap = IRQHandlerCap irq \<and> is_subject_irq aag irq)"
+  and finalise_cap_valid_list[wp]:
+    "finalise_cap param_a param_b \<lbrace>valid_list\<rbrace>"
+  and arch_finalise_cap_pas_refined[wp]:
+    "arch_finalise_cap acap ex \<lbrace>pas_refined aag\<rbrace>"
+  and prepare_thread_delete_pas_refined[wp]:
+    "prepare_thread_delete p \<lbrace>pas_refined aag\<rbrace>"
+  and prepare_thread_delete_respects[wp]:
+    "prepare_thread_delete p \<lbrace>integrity aag X st\<rbrace>"
+  and finalise_cap_replaceable:
+    "\<lbrace>\<lambda>s :: det_ext state. s \<turnstile> cap \<and> x = is_final_cap' cap s \<and> valid_mdb s \<and>
+                           cte_wp_at ((=) cap) sl s \<and> valid_objs s \<and> sym_refs (state_refs_of s) \<and>
+                           (cap_irqs cap \<noteq> {} \<longrightarrow> if_unsafe_then_cap s \<and> valid_global_refs s) \<and>
+                           (is_arch_cap cap \<longrightarrow> pspace_aligned s \<and> valid_vspace_objs s \<and>
+                                                valid_arch_state s \<and> valid_arch_caps s)\<rbrace>
+     finalise_cap cap x
+     \<lbrace>\<lambda>rv s. replaceable s sl (fst rv) cap\<rbrace>"
+  and arch_finalise_cap_respects[wp]:
+    "\<lbrace>integrity aag X st and invs and pas_refined aag and valid_cap (ArchObjectCap acap)
+                                  and K (pas_cap_cur_auth aag (ArchObjectCap acap))\<rbrace>
+     arch_finalise_cap acap final
+     \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+begin
+
 lemma tcb_sched_action_dequeue_integrity':
   "\<lbrace>integrity aag X st and pas_refined aag and
     (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag (tcb_domain (the (ekheap s thread))))\<rbrace>
-    tcb_sched_action tcb_sched_dequeue thread
+   tcb_sched_action tcb_sched_dequeue thread
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  apply (simp add: tcb_sched_action_def)
-  apply wp
+  apply (wpsimp simp: tcb_sched_action_def)
   apply (clarsimp simp: integrity_def integrity_ready_queues_def pas_refined_def
                         tcb_domain_map_wellformed_aux_def etcb_at_def get_etcb_def
-                  split: option.splits)
+                 split: option.splits)
   done
 
 lemma tcb_sched_action_dequeue_integrity[wp]:
   "\<lbrace>integrity aag X st and pas_refined aag and K (is_subject aag thread)\<rbrace>
-    tcb_sched_action tcb_sched_dequeue thread
+   tcb_sched_action tcb_sched_dequeue thread
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: tcb_sched_action_def)
   apply wp
@@ -47,9 +85,7 @@ lemma tcb_sched_action_dequeue_integrity[wp]:
   done
 
 lemma tcb_sched_action_enqueue_integrity[wp]:
-  "\<lbrace>integrity aag X st\<rbrace>
-    tcb_sched_action tcb_sched_enqueue thread
-   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  "tcb_sched_action tcb_sched_enqueue thread \<lbrace>integrity aag X st\<rbrace>"
   apply (simp add: tcb_sched_action_def)
   apply wp
   apply (clarsimp simp: integrity_def integrity_ready_queues_def pas_refined_def
@@ -63,7 +99,7 @@ text \<open>See comment for @{thm tcb_sched_action_dequeue_integrity'}\<close>
 lemma tcb_sched_action_append_integrity':
   "\<lbrace>integrity aag X st and
     (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag (tcb_domain (the (ekheap s thread))))\<rbrace>
-    tcb_sched_action tcb_sched_append thread
+   tcb_sched_action tcb_sched_append thread
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: tcb_sched_action_def)
   apply wp
@@ -73,7 +109,7 @@ lemma tcb_sched_action_append_integrity':
 
 lemma tcb_sched_action_append_integrity[wp]:
   "\<lbrace>integrity aag X st and pas_refined aag and K (is_subject aag thread)\<rbrace>
-    tcb_sched_action tcb_sched_append thread
+   tcb_sched_action tcb_sched_append thread
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: tcb_sched_action_def)
   apply wp
@@ -86,7 +122,7 @@ lemma tcb_sched_action_append_integrity[wp]:
 
 lemma tcb_sched_action_append_integrity_pasMayEditReadyQueues:
   "\<lbrace>integrity aag X st and pas_refined aag and K (pasMayEditReadyQueues aag)\<rbrace>
-    tcb_sched_action tcb_sched_append thread
+   tcb_sched_action tcb_sched_append thread
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: tcb_sched_action_def)
   apply wp
@@ -94,27 +130,27 @@ lemma tcb_sched_action_append_integrity_pasMayEditReadyQueues:
   done
 
 lemma reschedule_required_integrity[wp]:
-  "\<lbrace>integrity aag X st\<rbrace> reschedule_required \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  "reschedule_required \<lbrace>integrity aag X st\<rbrace>"
   apply (simp add: integrity_def reschedule_required_def)
   apply (wp | wpc)+
   apply simp
   done
 
 lemma cancel_badged_sends_respects[wp]:
-  "\<lbrace>integrity aag X st and einvs
-           and valid_objs and (sym_refs \<circ> state_refs_of)
-           and K (aag_has_auth_to aag Reset epptr)\<rbrace>
-    cancel_badged_sends epptr badge
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and einvs and valid_objs
+                       and (sym_refs \<circ> state_refs_of)
+                       and K (aag_has_auth_to aag Reset epptr)\<rbrace>
+   cancel_badged_sends epptr badge
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: cancel_badged_sends_def filterM_mapM
-             cong: Structures_A.endpoint.case_cong)
-  apply (wp set_endpoinintegrity | wpc | simp)+
+             cong: endpoint.case_cong)
+  apply (wp set_endpoint_respects | wpc | simp)+
      apply (rule mapM_mapM_x_valid[THEN iffD1])
      apply (simp add: exI[where x=Reset])
-     apply (rule mapM_x_inv_wp2[where Q="P" and I="P" and
-               V = "\<lambda>q s. distinct q \<and> (\<forall>x \<in> set q. st_tcb_at (blocked_on epptr) x s)"
-               for P] )
+      apply (rule mapM_x_inv_wp2
+                  [where V="\<lambda>q s. distinct q \<and> (\<forall>x \<in> set q. st_tcb_at (blocked_on epptr) x s)"
+                     and Q="P" and I="P" for P])
       apply simp
      apply (simp add: bind_assoc)
      apply (rule hoare_seq_ext[OF _ gts_sp])
@@ -122,7 +158,7 @@ lemma cancel_badged_sends_respects[wp]:
       apply (wp sts_respects_restart_ep hoare_vcg_const_Ball_lift sts_st_tcb_at_neq)
      apply clarsimp
      apply fastforce
-    apply (wp set_endpoinintegrity hoare_vcg_const_Ball_lift get_simple_ko_wp)+
+    apply (wp set_endpoint_respects hoare_vcg_const_Ball_lift get_simple_ko_wp)+
   apply clarsimp
   apply (frule(1) sym_refs_ko_atD)
   apply (frule ko_at_state_refs_ofD)
@@ -133,112 +169,97 @@ lemma cancel_badged_sends_respects[wp]:
   done
 
 lemma cancel_all_ipc_respects [wp]:
-  "\<lbrace>integrity aag X st
-           and valid_objs and (sym_refs \<circ> state_refs_of)
-           and K (\<exists>auth. aag_has_auth_to aag Reset epptr)\<rbrace>
-    cancel_all_ipc epptr
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and valid_objs and (sym_refs \<circ> state_refs_of)
+                       and K (\<exists>auth. aag_has_auth_to aag Reset epptr)\<rbrace>
+   cancel_all_ipc epptr
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
-  apply (clarsimp simp: cancel_all_ipc_def get_ep_queue_def cong: Structures_A.endpoint.case_cong)
-  apply (wp mapM_x_inv_wp2[
-                  where I = "integrity aag X st"
-                    and V = "\<lambda>q s. distinct q \<and> (\<forall>x \<in> set q. st_tcb_at (blocked_on epptr) x s)"]
-            sts_respects_restart_ep sts_st_tcb_at_neq hoare_vcg_ball_lift set_endpoinintegrity
-            get_simple_ko_wp
-        | wpc
-        | clarsimp
-        | blast)+
+  apply (clarsimp simp: cancel_all_ipc_def get_ep_queue_def cong: endpoint.case_cong)
+  apply (wp mapM_x_inv_wp2
+            [where I="integrity aag X st"
+               and V="\<lambda>q s. distinct q \<and> (\<forall>x \<in> set q. st_tcb_at (blocked_on epptr) x s)"]
+            sts_respects_restart_ep sts_st_tcb_at_neq hoare_vcg_ball_lift
+            set_endpoint_respects get_simple_ko_wp
+         | wpc | clarsimp | blast)+
   apply (frule ko_at_state_refs_ofD)
   apply (rule obj_at_valid_objsE, assumption, assumption)
   apply (rename_tac ep ko)
   apply (subgoal_tac "\<forall>x \<in> ep_q_refs_of ep. st_tcb_at (blocked_on epptr) (fst x) s")
    apply (fastforce simp: valid_obj_def valid_ep_def obj_at_def is_ep_def
-                   split: Structures_A.endpoint.splits)
+                   split: endpoint.splits)
   apply clarsimp
   apply (erule (1) ep_queued_st_tcb_at')
     apply simp_all
   done
 
+end
+
+
 crunch pas_refined[wp]: blocked_cancel_ipc, cancel_signal "pas_refined aag"
+
+crunch tcb_domain_map_wellformed[wp]: reschedule_required "tcb_domain_map_wellformed aag"
 
 (* FIXME move to AInvs *)
 lemma tcb_sched_action_ekheap[wp]:
-  "\<lbrace>\<lambda>s. P (ekheap s)\<rbrace> tcb_sched_action p1 p2 \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
-apply (simp add: tcb_sched_action_def)
-apply wp
-apply (simp add: etcb_at_def)
-done
+  "tcb_sched_action p1 p2 \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
+  apply (simp add: tcb_sched_action_def)
+  apply wp
+  apply (simp add: etcb_at_def)
+  done
 
 (* FIXME move to CNode *)
 lemma scheduler_action_update_pas_refined[simp]:
   "pas_refined aag (scheduler_action_update (\<lambda>_. param_a) s) = pas_refined aag s"
-by (simp add: pas_refined_def)
-
-(* FIXME move to CNode *)
-lemma tcb_sched_action_tcb_domain_map_wellformed[wp]:
-  "\<lbrace>tcb_domain_map_wellformed aag\<rbrace> tcb_sched_action p1 p2 \<lbrace>\<lambda>_. tcb_domain_map_wellformed aag\<rbrace>"
-by (wp tcb_domain_map_wellformed_lift)
-
-lemma gbn_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace> get_bound_notification t \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  by (wp get_bound_notification_inv)
+  by (simp add: pas_refined_def)
 
 lemma set_bound_notification_ekheap[wp]:
-  "\<lbrace>\<lambda>s. P (ekheap s)\<rbrace> set_bound_notification t st \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
+  "set_bound_notification t st \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
   apply (simp add: set_bound_notification_def)
   apply (wp set_scheduler_action_wp | simp)+
   done
 
 lemma sbn_thread_states[wp]:
-  "\<lbrace>\<lambda>s. P (thread_states s)\<rbrace> set_bound_notification t ntfn \<lbrace>\<lambda>rv s. P (thread_states s)\<rbrace>"
+  "set_bound_notification t ntfn \<lbrace>\<lambda>s. P (thread_states s)\<rbrace>"
   apply (simp add: set_bound_notification_def)
   apply (wpsimp wp: set_object_wp dxo_wp_weak)
   apply (clarsimp simp: get_tcb_def thread_states_def tcb_states_of_state_def
                  elim!: rsubst[where P=P, OF _ ext])
   done
 
-lemma sbn_st_vrefs[wp]:
-  "\<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace> set_bound_notification t st \<lbrace>\<lambda>rv s. P (state_vrefs s)\<rbrace>"
-  apply (simp add: set_bound_notification_def)
-  apply (wpsimp wp: set_object_wp dxo_wp_weak)
-  apply (clarsimp simp: state_vrefs_def vs_refs_no_global_pts_def
-                 elim!: rsubst[where P=P, OF _ ext]
-                 dest!: get_tcb_SomeD)
-  done
+
+context Finalise_AC_1 begin
 
 lemma sbn_pas_refined[wp]:
   "\<lbrace>pas_refined aag and
-       K(case ntfn of None \<Rightarrow> True
-                    | Some ntfn' \<Rightarrow> \<forall>auth \<in> {Receive, Reset}.
-                         (pasObjectAbs aag t, auth, pasObjectAbs aag ntfn') \<in> pasPolicy aag )\<rbrace>
-      set_bound_notification t ntfn
+    K (case ntfn of None \<Rightarrow> True
+                  | Some ntfn' \<Rightarrow> \<forall>auth \<in> {Receive, Reset}. abs_has_auth_to aag auth t ntfn')\<rbrace>
+   set_bound_notification t ntfn
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def)
   apply (rule hoare_pre)
    apply (wp tcb_domain_map_wellformed_lift | wps)+
   apply (clarsimp dest!: auth_graph_map_memD)
   apply (erule state_bits_to_policy.cases)
-  apply (auto intro: state_bits_to_policy.intros auth_graph_map_memI
-              split: if_split_asm)
-  done
+  by (auto intro: state_bits_to_policy.intros auth_graph_map_memI
+           split: if_split_asm)
 
 lemma unbind_notification_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace> unbind_notification t \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  "unbind_notification tptr \<lbrace>pas_refined aag\<rbrace>"
   apply (clarsimp simp: unbind_notification_def)
   apply (wp set_simple_ko_pas_refined | wpc | simp)+
   done
 
 lemma unbind_maybe_notification_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace> unbind_maybe_notification a \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  "unbind_maybe_notification nptr \<lbrace>pas_refined aag\<rbrace>"
   apply (clarsimp simp: unbind_maybe_notification_def)
   apply (wp set_simple_ko_pas_refined | wpc | simp)+
   done
 
-crunch tcb_domain_map_wellformed[wp]: reschedule_required "tcb_domain_map_wellformed aag"
-
-
 crunch pas_refined[wp]: fast_finalise "pas_refined aag"
   (wp: crunch_wps simp: crunch_simps)
+
+end
+
 
 crunch valid_mdb[wp]: fast_finalise "valid_mdb :: det_ext state \<Rightarrow> bool"
   (wp: crunch_wps simp: crunch_simps)
@@ -246,26 +267,28 @@ crunch valid_mdb[wp]: fast_finalise "valid_mdb :: det_ext state \<Rightarrow> bo
 crunch valid_objs[wp]: fast_finalise "valid_objs :: det_ext state \<Rightarrow> bool"
   (wp: crunch_wps simp: crunch_simps)
 
-crunch pas_refined_transferable[wp_transferable]: cap_delete_one "pas_refined aag"
+
+context Finalise_AC_1 begin
+
+crunches cap_delete_one
+  for pas_refined_transferable[wp_transferable]: "pas_refined aag"
+  and pas_refined[wp, wp_not_transferable]: "pas_refined aag"
   (wp: crunch_wps simp: crunch_simps)
 
-crunch pas_refined[wp, wp_not_transferable]: cap_delete_one, set_vm_root "pas_refined aag"
-  (wp: crunch_wps simp: crunch_simps)
+end
+
 
 (* FIXME MOVE next to thread_set_tcb_fault_set_invs in DetSchedSchedule *)
 lemma thread_set_tcb_fault_reset_invs:
-  "\<lbrace>invs\<rbrace>
-     thread_set (tcb_fault_update (\<lambda>_. None)) t
-   \<lbrace>\<lambda>rv. invs\<rbrace>"
+  "thread_set (tcb_fault_update (\<lambda>_. None)) t \<lbrace>invs\<rbrace>"
   by (rule thread_set_invs_trivial) (clarsimp simp: ran_tcb_cap_cases)+
 
 (* FIXME MOVE next to IpcCancel_AI.reply_cap_descends_from_master *)
 lemma reply_cap_descends_from_master0:
-  "\<lbrakk> invs s; tcb_at t s \<rbrakk> \<Longrightarrow>
-   \<forall>sl\<in>descendants_of (t, tcb_cnode_index 2) (cdt s).
-      \<exists> R. caps_of_state s sl = Some (cap.ReplyCap t False R)"
-  apply (subgoal_tac "cte_wp_at (\<lambda>c. (is_master_reply_cap c \<and> obj_ref_of c = t)
-                                     \<or> c = cap.NullCap)
+  "\<lbrakk> invs s; tcb_at t s \<rbrakk>
+     \<Longrightarrow> \<forall>sl\<in>descendants_of (t, tcb_cnode_index 2) (cdt s).
+           \<exists>R. caps_of_state s sl = Some (ReplyCap t False R)"
+  apply (subgoal_tac "cte_wp_at (\<lambda>c. (is_master_reply_cap c \<and> obj_ref_of c = t) \<or> c = NullCap)
                                 (t, tcb_cnode_index 2) s")
    apply (clarsimp simp: invs_def valid_state_def valid_mdb_def2 is_cap_simps
                          valid_reply_caps_def cte_wp_at_caps_of_state)
@@ -281,58 +304,56 @@ lemma reply_cap_descends_from_master0:
   done
 
 
+context Finalise_AC_1 begin
+
 lemma reply_cancel_ipc_pas_refined[wp]:
   "\<lbrace>pas_refined aag and invs and tcb_at t and K (is_subject aag t)\<rbrace>
-     reply_cancel_ipc t
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+   reply_cancel_ipc t
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: reply_cancel_ipc_def)
   apply (wp add: select_wp wp_transferable del: wp_not_transferable)
-   apply (rule hoare_strengthen_post[where Q="\<lambda>_.invs and tcb_at t and pas_refined aag"])
+   apply (rule hoare_strengthen_post[where Q="\<lambda>_. invs and tcb_at t and pas_refined aag"])
     apply (wpsimp wp: hoare_wp_combs thread_set_tcb_fault_reset_invs thread_set_pas_refined)+
    apply (frule(1) reply_cap_descends_from_master0)
    apply (fastforce simp: cte_wp_at_caps_of_state intro:it_Reply)
-  by fastforce
+  apply fastforce
+  done
 
 lemma deleting_irq_handler_pas_refined[wp]:
   "\<lbrace>pas_refined aag and invs and K (is_subject_irq aag irq)\<rbrace>
-      deleting_irq_handler irq
+   deleting_irq_handler irq
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: deleting_irq_handler_def get_irq_slot_def)
   apply wp
   apply (clarsimp simp: pas_refined_def irq_map_wellformed_aux_def)
   done
 
-crunch pas_refined[wp]: "suspend", arch_finalise_cap,prepare_thread_delete "pas_refined aag"
+crunch pas_refined[wp]: suspend "pas_refined aag"
 
 lemma finalise_cap_pas_refined[wp]:
   "\<lbrace>pas_refined aag and invs and valid_cap cap and K (pas_cap_cur_auth aag cap)\<rbrace>
-     finalise_cap cap fin
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+   finalise_cap cap fin
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (cases cap; simp only: finalise_cap.simps)
-  (* 12 subgoals *)
-  apply (wp unbind_notification_invs
-        | clarsimp simp: aag_cap_auth_def cap_auth_conferred_def valid_cap_simps
-                         cap_links_irq_def pas_refined_Control[symmetric])+
-  done
+  by (wpsimp wp: unbind_notification_invs
+           simp: aag_cap_auth_def cap_auth_conferred_def valid_cap_simps
+                 cap_links_irq_def pas_refined_Control[symmetric])+
 
 lemma cancel_all_signals_respects [wp]:
-  "\<lbrace>integrity aag X st
-           and valid_objs and (sym_refs \<circ> state_refs_of)
-           and K (aag_has_auth_to aag Reset epptr)\<rbrace>
-    cancel_all_signals epptr
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and valid_objs and (sym_refs \<circ> state_refs_of)
+                       and K (aag_has_auth_to aag Reset epptr)\<rbrace>
+   cancel_all_signals epptr
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (clarsimp simp add: cancel_all_signals_def)
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp], rule hoare_pre)
-   apply (wp mapM_x_inv_wp2[
-              where I = "integrity aag X st"
-                and V = "\<lambda>q s. distinct q \<and> (\<forall>x \<in> set q. st_tcb_at (blocked_on epptr) x s)"]
+   apply (wp mapM_x_inv_wp2
+             [where I="integrity aag X st"
+                and V="\<lambda>q s. distinct q \<and> (\<forall>x \<in> set q. st_tcb_at (blocked_on epptr) x s)"]
             sts_respects_restart_ep sts_st_tcb_at_neq hoare_vcg_ball_lift set_ntfn_respects
-        | wpc
-        | clarsimp
-        | blast)+
+          | wpc | clarsimp | blast)+
   apply (frule sym_refs_ko_atD, clarsimp+)
   apply (rule obj_at_valid_objsE, assumption, assumption)
   apply (clarsimp simp: valid_obj_def valid_ntfn_def st_tcb_at_refs_of_rev st_tcb_def2
@@ -340,15 +361,12 @@ lemma cancel_all_signals_respects [wp]:
   apply fastforce+
   done
 
-lemma gbn_respects[wp]:
-  "\<lbrace>integrity aag X st\<rbrace> get_bound_notification t \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  by (wp get_bound_notification_inv)
+end
 
 lemma sbn_unbind_respects[wp]:
   "\<lbrace>integrity aag X st and
-       (\<lambda>s. (\<exists>ntfn. bound_tcb_at (\<lambda>a. a = Some ntfn) t s \<and>
-           (pasSubject aag, Reset, pasObjectAbs aag ntfn) \<in> pasPolicy aag))\<rbrace>
-     set_bound_notification t None
+    (\<lambda>s. (\<exists>ntfn. bound_tcb_at (\<lambda>a. a = Some ntfn) t s \<and> aag_has_auth_to aag Reset ntfn))\<rbrace>
+   set_bound_notification t None
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: set_bound_notification_def)
   apply (wpsimp wp: set_object_wp)
@@ -366,48 +384,24 @@ lemma bound_tcb_at_thread_bound_ntfns:
   by (clarsimp simp: thread_bound_ntfns_def pred_tcb_at_def obj_at_def get_tcb_def
               split: option.splits)
 
-
 lemma bound_tcb_at_implies_receive:
-  "\<lbrakk>pas_refined aag s; bound_tcb_at ((=) (Some x)) t s\<rbrakk>
-          \<Longrightarrow> (pasObjectAbs aag t, Receive, pasObjectAbs aag x) \<in> pasPolicy aag"
+  "\<lbrakk> pas_refined aag s; bound_tcb_at ((=) (Some x)) t s \<rbrakk>
+     \<Longrightarrow> abs_has_auth_to aag Receive t x"
   by (fastforce dest!: bound_tcb_at_thread_bound_ntfns sta_bas pas_refined_mem)
 
 lemma bound_tcb_at_implies_reset:
-  "\<lbrakk>pas_refined aag s; bound_tcb_at ((=) (Some x)) t s\<rbrakk>
-          \<Longrightarrow> (pasObjectAbs aag t, Reset, pasObjectAbs aag x) \<in> pasPolicy aag"
+  "\<lbrakk> pas_refined aag s; bound_tcb_at ((=) (Some x)) t s \<rbrakk>
+     \<Longrightarrow> abs_has_auth_to aag Reset t x"
   by (fastforce dest!: bound_tcb_at_thread_bound_ntfns sta_bas pas_refined_mem)
 
-lemma unbind_notification_bound_respects:
-  "\<lbrace>integrity aag X st and pas_refined aag and (\<lambda>s. bound_tcb_at (\<lambda>a. a = Some ntfn) t s \<and>
-     (pasSubject aag, Reset, pasObjectAbs aag ntfn) \<in> pasPolicy aag)\<rbrace>
-      unbind_notification t
-   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  apply (clarsimp simp: unbind_notification_def)
-  apply (wp set_ntfn_respects hoare_vcg_imp_lift hoare_vcg_ex_lift gbn_wp
-        | wpc
-        | simp)+
-   apply clarsimp
-   apply (fastforce simp: pred_tcb_at_def obj_at_def)+
-  done
-
-lemma unbind_notification_noop_respects:
-  "\<lbrace>integrity aag X st and bound_tcb_at (\<lambda>a. a = None) t\<rbrace>
-      unbind_notification t
-   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  apply (clarsimp simp: unbind_notification_def)
-  apply (wp set_ntfn_respects hoare_vcg_ex_lift gbn_wp | wpc | simp)+
-  apply (clarsimp simp: pred_tcb_at_def obj_at_def)
-  done
 
 lemma unbind_notification_respects:
   "\<lbrace>integrity aag X st and pas_refined aag and
-      bound_tcb_at (\<lambda>a. case a of
-        None \<Rightarrow> True |
-        Some ntfn \<Rightarrow> (pasSubject aag, Reset, pasObjectAbs aag ntfn) \<in> pasPolicy aag) t\<rbrace>
-     unbind_notification t \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+    bound_tcb_at (\<lambda>a. case a of None \<Rightarrow> True | Some ntfn \<Rightarrow> aag_has_auth_to aag Reset ntfn) t\<rbrace>
+   unbind_notification t
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (clarsimp simp: unbind_notification_def)
   apply (rule hoare_seq_ext[OF _ gbn_sp])
-  apply (rule hoare_pre)
   apply (wp set_ntfn_respects hoare_vcg_ex_lift gbn_wp | wpc | simp)+
   apply (clarsimp simp: pred_tcb_at_def obj_at_def split: option.splits)
   apply blast
@@ -415,11 +409,11 @@ lemma unbind_notification_respects:
 
 lemma unbind_maybe_notification_respects:
   "\<lbrace>integrity aag X st and invs and pas_refined aag and
-      obj_at (\<lambda>ko. \<exists>ntfn. ko = (Notification ntfn) \<and>
-        (case (ntfn_bound_tcb ntfn) of
-          None \<Rightarrow> True |
-          Some t \<Rightarrow> (pasSubject aag, Reset, pasObjectAbs aag a) \<in> pasPolicy aag)) a \<rbrace>
-     unbind_maybe_notification a \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+    obj_at (\<lambda>ko. \<exists>ntfn. ko = (Notification ntfn) \<and>
+                        (case (ntfn_bound_tcb ntfn) of None \<Rightarrow> True
+                                                     | Some t \<Rightarrow> aag_has_auth_to aag Reset a)) a\<rbrace>
+   unbind_maybe_notification a
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (clarsimp simp: unbind_maybe_notification_def)
   apply (rule hoare_pre)
    apply (wp set_ntfn_respects get_simple_ko_wp hoare_vcg_ex_lift gbn_wp | wpc | simp)+
@@ -429,54 +423,56 @@ lemma unbind_maybe_notification_respects:
   apply (auto simp: pred_tcb_at_def obj_at_def split: option.splits)
   done
 
+
+context Finalise_AC_1 begin
+
 lemma fast_finalise_respects[wp]:
-  "\<lbrace>integrity aag X st and invs and pas_refined aag and valid_cap cap and
-     K (pas_cap_cur_auth aag cap)\<rbrace>
-      fast_finalise cap fin
+  "\<lbrace>integrity aag X st and invs and pas_refined aag and valid_cap cap
+                                and K (pas_cap_cur_auth aag cap)\<rbrace>
+   fast_finalise cap fin
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (cases cap; simp)
-     apply (wp unbind_maybe_notification_valid_objs get_simple_ko_wp
-               unbind_maybe_notification_respects
-           | wpc
-           | simp add: cap_auth_conferred_def cap_rights_to_auth_def aag_cap_auth_def when_def
-                split: if_split_asm
-           | fastforce)+
-      apply (clarsimp simp: obj_at_def valid_cap_def is_ntfn invs_def valid_state_def
-                            valid_pspace_def
-                     split: option.splits)+
+     apply (wpsimp wp: unbind_maybe_notification_valid_objs get_simple_ko_wp
+                       unbind_maybe_notification_respects
+                 simp: cap_auth_conferred_def cap_rights_to_auth_def aag_cap_auth_def when_def
+            | fastforce)+
+   apply (clarsimp simp: obj_at_def valid_cap_def is_ntfn invs_def valid_state_def valid_pspace_def
+                  split: option.splits)+
   apply (wp, simp)
   done
 
 lemma cap_delete_one_respects[wp,wp_not_transferable]:
   "\<lbrace>integrity aag X st and pas_refined aag and einvs and K (is_subject aag (fst slot))\<rbrace>
-     cap_delete_one slot
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+   cap_delete_one slot
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: cap_delete_one_def unless_def bind_assoc)
-  apply (wp hoare_drop_imps get_cap_auth_wp [where aag = aag]
-        | simp)+
+  apply (wpsimp wp: hoare_drop_imps get_cap_auth_wp [where aag = aag])
   apply (fastforce simp: caps_of_state_valid)
   done
 
+end
+
+
 lemma fast_finalise_is_transferable[wp_transferable]:
-  "\<lbrace> P and K(is_transferable (Some cap)) \<rbrace>
-     fast_finalise cap final
-   \<lbrace>\<lambda>_. P \<rbrace>"
+  "\<lbrace>P and K (is_transferable (Some cap))\<rbrace>
+   fast_finalise cap final
+   \<lbrace>\<lambda>_. P\<rbrace>"
   by (rule hoare_gen_asm) (erule is_transferable.cases; simp)
 
 lemma cap_delete_one_respects_transferable[wp_transferable]:
-  "\<lbrace>integrity aag X st and pas_refined aag and einvs and
-    cte_wp_at(\<lambda>c. is_transferable (Some c)) slot and cdt_change_allowed' aag slot\<rbrace>
-      cap_delete_one slot
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and einvs
+                       and cte_wp_at (\<lambda>c. is_transferable (Some c)) slot
+                       and cdt_change_allowed' aag slot\<rbrace>
+   cap_delete_one slot
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: cap_delete_one_def unless_def bind_assoc)
-  apply (wp add: hoare_drop_imps get_cap_wp wp_transferable del:wp_not_transferable
-        | simp)+
+  apply (wp add: hoare_drop_imps get_cap_wp wp_transferable del: wp_not_transferable | simp)+
   apply (fastforce simp: caps_of_state_valid cte_wp_at_caps_of_state)
   done
 
 lemma thread_set_tcb_state_trivial:
-  "(\<And> tcb. tcb_state (f tcb) = tcb_state tcb) \<Longrightarrow>
-   \<lbrace>\<lambda>s. P (tcb_states_of_state s)\<rbrace> thread_set f t \<lbrace>\<lambda>_ s. P (tcb_states_of_state s)\<rbrace>"
+  "(\<And>tcb. tcb_state (f tcb) = tcb_state tcb)
+   \<Longrightarrow> thread_set f t \<lbrace>\<lambda>s. P (tcb_states_of_state s)\<rbrace>"
   apply (simp add: thread_set_def)
   apply (wpsimp wp: set_object_wp)
   apply (clarsimp elim!: rsubst[where P=P] dest!: get_tcb_SomeD)
@@ -484,11 +480,9 @@ lemma thread_set_tcb_state_trivial:
 
 
 lemma reply_cancel_ipc_respects[wp]:
-  "\<lbrace>integrity aag X st and einvs and tcb_at t and
-        K (is_subject aag t) and
-        pas_refined aag\<rbrace>
-     reply_cancel_ipc t
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and einvs and tcb_at t and K (is_subject aag t) and pas_refined aag\<rbrace>
+   reply_cancel_ipc t
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: reply_cancel_ipc_def)
   apply (rule hoare_pre)
    apply (wp add: select_wp wp_transferable del:wp_not_transferable)
@@ -502,51 +496,50 @@ lemma reply_cancel_ipc_respects[wp]:
   apply (rule conjI)
    apply (fastforce simp: cte_wp_at_caps_of_state intro:is_transferable.intros
                    dest!: reply_cap_descends_from_master0)
-  apply (rule cdt_change_allowed_all_children
-                [where aag=aag, THEN all_children_descendants_of])
-   by fastforce+
+  apply (rule cdt_change_allowed_all_children[where aag=aag, THEN all_children_descendants_of])
+  by fastforce+
 
 lemma cancel_signal_respects[wp]:
-  "\<lbrace>integrity aag X st and K (is_subject aag t \<and>
-        (\<exists>auth. aag_has_auth_to aag auth ntfnptr \<and> (auth = Receive \<or> auth = Notify)))\<rbrace>
-     cancel_signal t ntfnptr
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>\<lambda>s. integrity aag X st s \<and> is_subject aag t \<and>
+        (\<exists>auth. aag_has_auth_to aag auth ntfnptr \<and> (auth = Receive \<or> auth = Notify))\<rbrace>
+   cancel_signal t ntfnptr
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: cancel_signal_def)
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
   apply (rule hoare_pre)
-   apply (wp set_thread_state_integrity_autarch set_ntfn_respects
-             | wpc | fastforce)+
+   apply (wp set_thread_state_integrity_autarch set_ntfn_respects | wpc | fastforce)+
   done
 
 lemma cancel_ipc_respects[wp]:
-  "\<lbrace>integrity aag X st and einvs and tcb_at t and
-    K (is_subject aag t) and pas_refined aag\<rbrace>
-     cancel_ipc t
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and einvs and tcb_at t and K (is_subject aag t) and pas_refined aag\<rbrace>
+   cancel_ipc t
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: cancel_ipc_def)
   apply (rule hoare_seq_ext[OF _ gts_sp])
   apply (rule hoare_pre)
-   apply (wp set_thread_state_integrity_autarch set_endpoinintegrity get_simple_ko_wp
-         | wpc
-         | simp(no_asm) add: blocked_cancel_ipc_def get_ep_queue_def get_blocking_object_def)+
+   apply (wp set_thread_state_integrity_autarch set_endpoint_respects get_simple_ko_wp
+          | wpc
+          | simp (no_asm) add: blocked_cancel_ipc_def get_ep_queue_def get_blocking_object_def)+
   apply clarsimp
   apply (frule st_tcb_at_to_thread_states, clarsimp+)
   apply (fastforce simp: obj_at_def is_ep_def dest: pas_refined_mem[OF sta_ts_mem])
   done
 
 lemma update_restart_pc_integrity_autarch[wp]:
-  "\<lbrace>integrity aag X st and K (is_subject aag t)\<rbrace> update_restart_pc t
-                                      \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  apply (simp add: get_thread_state_def thread_get_def)
-  unfolding update_restart_pc_def
-  apply (wp as_user_integrity_autarch)
-  apply simp
+  "\<lbrace>integrity aag X st and K (is_subject aag t)\<rbrace>
+   update_restart_pc t
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: get_thread_state_def thread_get_def update_restart_pc_def)
+  apply (wpsimp wp: as_user_integrity_autarch)
   done
 
+
+context Finalise_AC_1 begin
+
 lemma suspend_respects[wp]:
-  "\<lbrace>integrity aag X st and pas_refined aag and einvs and tcb_at t and
-    K (is_subject aag t)\<rbrace>
-    suspend t \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and einvs and tcb_at t and K (is_subject aag t)\<rbrace>
+   suspend t
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: suspend_def)
   apply (wp set_thread_state_integrity_autarch set_thread_state_pas_refined)
     apply (rule hoare_conjI)
@@ -554,14 +547,17 @@ lemma suspend_respects[wp]:
     apply wpsimp+
   done
 
+end
+
+
 lemma finalise_is_fast_finalise:
-  "can_fast_finalise cap \<Longrightarrow>
-    finalise_cap cap fin = do fast_finalise cap fin; return (cap.NullCap, cap.NullCap) od"
+  "can_fast_finalise cap
+   \<Longrightarrow> finalise_cap cap fin = do fast_finalise cap fin; return (NullCap, NullCap) od"
   by (cases cap, simp_all add: can_fast_finalise_def liftM_def)
 
-lemma get_irq_slot_owns [wp]:
+lemma get_irq_slot_owns[wp]:
   "\<lbrace>pas_refined aag and K (is_subject_irq aag irq)\<rbrace>
-      get_irq_slot irq
+   get_irq_slot irq
    \<lbrace>\<lambda>rv _. is_subject aag (fst rv)\<rbrace>"
   unfolding get_irq_slot_def
   apply wp
@@ -571,59 +567,43 @@ lemma get_irq_slot_owns [wp]:
   done
 
 lemma pas_refined_Control_into_is_subject_asid:
-  "\<lbrakk>pas_refined aag s; (pasSubject aag, Control, pasASIDAbs aag asid) \<in> pasPolicy aag\<rbrakk> \<Longrightarrow>
-  is_subject_asid aag asid"
-  apply(drule (1) pas_refined_Control)
-  apply(blast intro: sym)
+  "\<lbrakk> pas_refined aag s; (pasSubject aag, Control, pasASIDAbs aag asid) \<in> pasPolicy aag \<rbrakk>
+     \<Longrightarrow> is_subject_asid aag asid"
+  apply (drule (1) pas_refined_Control)
+  apply (blast intro: sym)
   done
 
-lemma arch_finalise_cap_respects[wp]:
-  "\<lbrace>integrity aag X st and invs and pas_refined aag
-             and valid_cap (cap.ArchObjectCap cap)
-             and K (pas_cap_cur_auth aag (cap.ArchObjectCap cap))\<rbrace>
-       arch_finalise_cap cap final \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: arch_finalise_cap_def)
-  apply (rule hoare_pre)
-   apply (wp unmap_page_respects unmap_page_table_respects delete_asid_respects
-              | wpc | simp)+
-  apply clarsimp
-  apply (auto simp: cap_auth_conferred_def is_page_cap_def aag_cap_auth_def
-                    pas_refined_all_auth_is_owns valid_cap_simps
-                    cap_links_asid_slot_def label_owns_asid_slot_def
-             dest!: pas_refined_Control intro: pas_refined_Control_into_is_subject_asid)
-  done
 
-crunch respects[wp]: prepare_thread_delete "integrity aag X st"
+context Finalise_AC_1 begin
 
 lemma finalise_cap_respects[wp]:
   "\<lbrace>integrity aag X st and pas_refined aag and einvs and valid_cap cap
-    and K (pas_cap_cur_auth aag cap)\<rbrace>
-       finalise_cap cap final \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+                                           and K (pas_cap_cur_auth aag cap)\<rbrace>
+   finalise_cap cap final
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (cases cap; simp; safe?;
-     (solves \<open>(wp | simp add: if_apply_def2 split del: if_split
-                  | clarsimp simp: cap_auth_conferred_def cap_rights_to_auth_def is_cap_simps
-                                   pas_refined_all_auth_is_owns aag_cap_auth_def
-                                   deleting_irq_handler_def cap_links_irq_def invs_valid_objs
-                        split del: if_split
-                            elim!: pas_refined_Control [symmetric])+\<close>)?
-  )
-
+         (solves \<open>(wp | simp add: if_apply_def2 split del: if_split
+                      | clarsimp simp: cap_auth_conferred_def cap_rights_to_auth_def is_cap_simps
+                                       pas_refined_all_auth_is_owns aag_cap_auth_def
+                                       deleting_irq_handler_def cap_links_irq_def invs_valid_objs
+                            split del: if_split
+                                elim!: pas_refined_Control [symmetric])+\<close>)?)
    (*NTFN Cap*)
    apply ((wp unbind_maybe_notification_valid_objs get_simple_ko_wp
               unbind_maybe_notification_respects
-          | wpc
-          | simp add: cap_auth_conferred_def cap_rights_to_auth_def aag_cap_auth_def
-               split: if_split_asm
-          | fastforce)+;
+           | wpc
+           | simp add: cap_auth_conferred_def cap_rights_to_auth_def aag_cap_auth_def
+                split: if_split_asm
+           | fastforce)+;
           clarsimp simp: obj_at_def valid_cap_def is_ntfn invs_def
                          valid_state_def valid_pspace_def
                   split: option.splits)
   (* tcb cap *)
   apply (wp unbind_notification_respects unbind_notification_invs
-          | clarsimp simp: cap_auth_conferred_def cap_rights_to_auth_def aag_cap_auth_def
-                           unbind_maybe_notification_def
-                    elim!: pas_refined_Control[symmetric]
-          | simp add: if_apply_def2 split del: if_split )+
+         | clarsimp simp: cap_auth_conferred_def cap_rights_to_auth_def aag_cap_auth_def
+                          unbind_maybe_notification_def
+                   elim!: pas_refined_Control[symmetric]
+         | simp add: if_apply_def2 split del: if_split )+
   apply (clarsimp simp: valid_cap_def pred_tcb_at_def obj_at_def is_tcb
                  dest!: tcb_at_ko_at)
   apply (clarsimp split: option.splits elim!: pas_refined_Control[symmetric])
@@ -633,11 +613,9 @@ lemma finalise_cap_respects[wp]:
   done
 
 lemma finalise_cap_auth:
-  "\<lbrace>(\<lambda>s. final \<longrightarrow> is_final_cap' cap s \<and> cte_wp_at ((=) cap) slot s)
-             and K (pas_cap_cur_auth aag cap)\<rbrace>
-      finalise_cap cap final
-   \<lbrace>\<lambda>rv s. \<forall>x\<in>obj_refs (fst rv). \<forall>a \<in> cap_auth_conferred (fst rv).
-                                         (pasSubject aag, a, pasObjectAbs aag x) \<in> pasPolicy aag\<rbrace>"
+  "\<lbrace>(\<lambda>s. final \<longrightarrow> is_final_cap' cap s \<and> cte_wp_at ((=) cap) slot s) and K (pas_cap_cur_auth aag cap)\<rbrace>
+   finalise_cap cap final
+   \<lbrace>\<lambda>rv _. \<forall>x \<in> obj_refs (fst rv). \<forall>a \<in> cap_auth_conferred (fst rv). aag_has_auth_to aag a x\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (rule hoare_strengthen_post, rule finalise_cap_cases)
   apply (elim disjE, clarsimp+)
@@ -645,119 +623,122 @@ lemma finalise_cap_auth:
   apply (simp add: fst_cte_ptrs_def split: cap.split_asm)
   done
 
+end
+
+
 lemma aag_cap_auth_Zombie:
-  "pas_refined aag s \<Longrightarrow> pas_cap_cur_auth aag (cap.Zombie word a b) = is_subject aag word"
+  "pas_refined aag s \<Longrightarrow> pas_cap_cur_auth aag (Zombie word a b) = is_subject aag word"
   unfolding aag_cap_auth_def
   by (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def pas_refined_all_auth_is_owns)
 
 lemma aag_cap_auth_CNode:
-  "pas_refined aag s \<Longrightarrow> pas_cap_cur_auth aag (cap.CNodeCap word a b) = is_subject aag word"
+  "pas_refined aag s \<Longrightarrow> pas_cap_cur_auth aag (CNodeCap word a b) = is_subject aag word"
   unfolding aag_cap_auth_def
   by (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def pas_refined_all_auth_is_owns)
 
 lemma aag_cap_auth_Thread:
-  "pas_refined aag s \<Longrightarrow> pas_cap_cur_auth aag (cap.ThreadCap word) = is_subject aag word"
+  "pas_refined aag s \<Longrightarrow> pas_cap_cur_auth aag (ThreadCap word) = is_subject aag word"
   unfolding aag_cap_auth_def
   by (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def pas_refined_all_auth_is_owns)
 
+
+context Finalise_AC_1 begin
+
 lemma finalise_cap_auth':
   "\<lbrace>pas_refined aag and K (pas_cap_cur_auth aag cap)\<rbrace>
-      finalise_cap cap final
-   \<lbrace>\<lambda>rv s. pas_cap_cur_auth aag (fst rv)\<rbrace>"
+   finalise_cap cap final
+   \<lbrace>\<lambda>rv _. pas_cap_cur_auth aag (fst rv)\<rbrace>"
   including no_pre
   apply (rule hoare_gen_asm)
-  apply (cases cap, simp_all add: arch_finalise_cap_def split del: if_split)
-  apply (wp
-    | simp add: comp_def hoare_post_taut [where P = \<top>] split del: if_split
-    | fastforce simp:  aag_cap_auth_Zombie aag_cap_auth_CNode aag_cap_auth_Thread
-    )+
-  apply (rule hoare_pre)
-  apply (wp | simp)+
-  apply (rule hoare_pre)
-  apply (wp | wpc
-    | simp add: comp_def hoare_post_taut [where P = \<top>] split del: if_split)+
+  apply (cases cap, simp_all split del: if_split)
+             apply (wp | simp add: comp_def hoare_post_taut[where P = \<top>] split del: if_split
+                       | fastforce simp: aag_cap_auth_Zombie aag_cap_auth_CNode aag_cap_auth_Thread)+
+    apply (rule hoare_pre)
+     apply (wp | simp)+
+  apply (wp arch_finalise_cap_auth')
   done
 
 lemma finalise_cap_obj_refs:
-  "\<lbrace>\<lambda>s. \<forall>x \<in> obj_refs cap. P x\<rbrace> finalise_cap cap slot \<lbrace>\<lambda>rv s. \<forall>x \<in> obj_refs (fst rv). P x\<rbrace>"
-  apply (cases cap)
-             apply (wpsimp simp: arch_finalise_cap_def o_def|rule conjI)+
-  done
+  "\<lbrace>\<lambda>_ :: det_ext state. \<forall>x \<in> obj_refs cap. P x\<rbrace>
+   finalise_cap cap slot
+   \<lbrace>\<lambda>rv _. \<forall>x \<in> obj_refs (fst rv). P x\<rbrace>"
+  by (cases cap) (wpsimp wp: arch_finalise_cap_obj_refs simp: o_def | rule conjI)+
+
+end
+
 
 lemma zombie_ptr_emptyable:
-  "\<lbrakk> caps_of_state s cref = Some (cap.Zombie ptr zbits n); invs s \<rbrakk>
+  "\<lbrakk> caps_of_state s cref = Some (Zombie ptr zbits n); invs s \<rbrakk>
      \<Longrightarrow> emptyable (ptr, cref_half) s"
   apply (clarsimp simp: emptyable_def tcb_at_def st_tcb_def2)
   apply (rule ccontr)
   apply (clarsimp simp: get_tcb_ko_at)
   apply (drule if_live_then_nonz_capD[rotated])
-    apply (auto simp: live_def hyp_live_def)[2]
+    apply (auto simp: live_def)[2]
   apply (clarsimp simp: ex_nonz_cap_to_def cte_wp_at_caps_of_state
                         zobj_refs_to_obj_refs)
   apply (drule(2) zombies_final_helperE, clarsimp, simp+)
   apply (simp add: is_cap_simps)
   done
 
+
+context Finalise_AC_1 begin
+
 lemma finalise_cap_makes_halted:
-  "\<lbrace>invs and valid_cap cap and (\<lambda>s. ex = is_final_cap' cap s)
-         and cte_wp_at ((=) cap) slot\<rbrace>
-    finalise_cap cap ex
-   \<lbrace>\<lambda>rv s. \<forall>t \<in> obj_refs (fst rv). halted_if_tcb t s\<rbrace>"
+  "\<lbrace>invs and valid_cap cap and (\<lambda>s. ex = is_final_cap' cap s) and cte_wp_at ((=) cap) slot\<rbrace>
+   finalise_cap cap ex
+   \<lbrace>\<lambda>rv s :: det_ext state. \<forall>t \<in> Access.obj_refs (fst rv). halted_if_tcb t s\<rbrace>"
   apply (case_tac cap, simp_all)
-            apply (wp unbind_notification_valid_objs
-                 | clarsimp simp: o_def valid_cap_def cap_table_at_typ
-                                  is_tcb obj_at_def
-                 | clarsimp simp: halted_if_tcb_def
-                           split: option.split
-                 | intro impI conjI
-                 | rule hoare_drop_imp)+
+             apply (wp unbind_notification_valid_objs
+                    | clarsimp simp: o_def valid_cap_def cap_table_at_typ is_tcb
+                                     obj_at_def halted_if_tcb_def
+                              split: option.split
+                    | intro impI conjI
+                    | rule hoare_drop_imp)+
    apply (fastforce simp: st_tcb_at_def obj_at_def is_tcb live_def
-                  dest!: final_zombie_not_live)
-  apply (rename_tac arch_cap)
-  apply (case_tac arch_cap, simp_all add: arch_finalise_cap_def)
-      apply (wp
-           | clarsimp simp: valid_cap_def split: option.split bool.split
-           | intro impI conjI)+
+                   dest!: final_zombie_not_live)
+  apply (wp arch_finalise_cap_makes_halted)
   done
+
+end
 
 
 lemma aag_Control_into_owns_irq:
-  "\<lbrakk>(pasSubject aag, Control, pasIRQAbs aag irq) \<in> pasPolicy aag; pas_refined aag s\<rbrakk>
-    \<Longrightarrow> is_subject_irq aag irq"
+  "\<lbrakk> (pasSubject aag, Control, pasIRQAbs aag irq) \<in> pasPolicy aag; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> is_subject_irq aag irq"
   apply (drule (1) pas_refined_Control)
   apply simp
   done
 
 lemma owns_slot_owns_irq:
-  "\<lbrakk>is_subject aag (fst slot); caps_of_state s slot = Some rv;
-    pas_refined aag s; cap_irq_opt rv = Some irq\<rbrakk>
-    \<Longrightarrow> is_subject_irq aag irq"
-  apply(rule aag_Control_into_owns_irq[rotated], assumption)
-  apply(drule (1) cli_caps_of_state)
-  apply(clarsimp simp: cap_links_irq_def cap_irq_opt_def split: cap.splits)
+  "\<lbrakk> is_subject aag (fst slot); pas_refined aag s;
+     caps_of_state s slot = Some rv; cap_irq_opt rv = Some irq \<rbrakk>
+     \<Longrightarrow> is_subject_irq aag irq"
+  apply (rule aag_Control_into_owns_irq[rotated], assumption)
+  apply (drule (1) cli_caps_of_state)
+  apply (clarsimp simp: cap_links_irq_def cap_irq_opt_def split: cap.splits)
   done
 
 lemma replaceable_zombie_not_transferable:
   "replaceable s slot (Zombie ref sz n) cap \<Longrightarrow> \<not> is_transferable (Some cap)"
   by (intro notI) (erule is_transferable.cases; simp add:replaceable_def)
 
+declare finalise_cap_valid_list[wp]
+
+
+context Finalise_AC_1 begin
 
 lemma rec_del_respects'_pre':
-  "s \<turnstile> \<lbrace>(\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag
-                  and einvs and simple_sched_action and valid_rec_del_call call
-                  and emptyable (slot_rdcall call)
-                  and (\<lambda>s. \<not> exposed_rdcall call \<longrightarrow>
-                                  ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) (slot_rdcall call) s)
-                  and K (is_subject aag (fst (slot_rdcall call)))
-                  and K (case call of ReduceZombieCall cap sl _ \<Rightarrow>
-                                          \<forall>x \<in> obj_refs cap. is_subject aag x
-                                    | _ \<Rightarrow> True)\<rbrace>
-     rec_del call
-   \<lbrace>\<lambda>rv. (\<lambda>s. trp \<longrightarrow> (case call of FinaliseSlotCall sl _ \<Rightarrow>
-                                          (cleanup_info_wf (snd rv) aag)
-                                  | _ \<Rightarrow> True) \<and> integrity aag X st s)
-                  and pas_refined aag\<rbrace>,
-   \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
+  "s \<turnstile>
+  \<lbrace>(\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag and einvs and
+   simple_sched_action and valid_rec_del_call call and emptyable (slot_rdcall call) and
+   (\<lambda>s. \<not> exposed_rdcall call \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) (slot_rdcall call) s) and
+   K (is_subject aag (fst (slot_rdcall call))) and
+   K (case call of ReduceZombieCall cap sl _ \<Rightarrow> \<forall>x \<in> obj_refs cap. is_subject aag x | _ \<Rightarrow> True)\<rbrace>
+  rec_del call
+  \<lbrace>\<lambda>rv. (\<lambda>s. trp \<longrightarrow> (case call of FinaliseSlotCall sl _ \<Rightarrow> (cleanup_info_wf (snd rv) aag)
+                                 | _ \<Rightarrow> True) \<and> integrity aag X st s) and pas_refined aag\<rbrace>,
+  \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
 proof (induct arbitrary: st rule: rec_del.induct, simp_all only: rec_del_fails)
   case (1 slot exposed s)
   show ?case
@@ -775,8 +756,7 @@ proof (induct arbitrary: st rule: rec_del.induct, simp_all only: rec_del_fails)
        apply (rule valid_validE_R, rule rec_del_invs)
       apply (rule "1.hyps"[simplified rec_del_call.simps slot_rdcall.simps])
      apply auto
-  done
-
+    done
 next
   case (2 slot exposed s)
   show ?case
@@ -785,8 +765,7 @@ next
     apply (simp only: split_def)
     apply (rule hoare_pre_spec_validE)
      apply (wp set_cap_integrity_autarch set_cap_pas_refined_not_transferable "2.hyps" static_imp_wp)
-          apply ((wp preemption_point_inv'
-                 | simp add: integrity_subjects_def pas_refined_def)+)[1]
+          apply ((wp preemption_point_inv' | simp add: integrity_subjects_def pas_refined_def)+)[1]
          apply (simp(no_asm))
          apply (rule spec_strengthen_postE)
           apply (rule spec_valid_conj_liftE1, rule valid_validE_R, rule rec_del_invs)
@@ -807,12 +786,12 @@ next
                        | simp add: in_monad)+
        apply (rule hoare_strengthen_post)
         apply (rule_tac Q="\<lambda>fin s. einvs s \<and> simple_sched_action s \<and> replaceable s slot (fst fin) rv
-                                  \<and> cte_wp_at ((=) rv) slot s \<and> s \<turnstile> (fst fin)
-                                  \<and> ex_cte_cap_wp_to (appropriate_cte_cap rv) slot s
-                                  \<and> emptyable slot s
-                                  \<and> (\<forall>t\<in>obj_refs (fst fin). halted_if_tcb t s)
-                                  \<and> pas_refined aag s \<and> (trp \<longrightarrow> integrity aag X st s)
-                                  \<and> pas_cap_cur_auth aag (fst fin)"
+                                 \<and> cte_wp_at ((=) rv) slot s \<and> s \<turnstile> (fst fin)
+                                 \<and> ex_cte_cap_wp_to (appropriate_cte_cap rv) slot s
+                                 \<and> emptyable slot s
+                                 \<and> (\<forall>t\<in>obj_refs (fst fin). halted_if_tcb t s)
+                                 \<and> pas_refined aag s \<and> (trp \<longrightarrow> integrity aag X st s)
+                                 \<and> pas_cap_cur_auth aag (fst fin)"
                    in hoare_vcg_conj_lift)
          apply (wp finalise_cap_invs[where slot=slot]
                    finalise_cap_replaceable[where sl=slot]
@@ -821,8 +800,8 @@ next
         apply (rule finalise_cap_cases[where slot=slot])
        apply (clarsimp simp: cte_wp_at_caps_of_state)
        apply (erule disjE)
-        apply (clarsimp split: cap.split_asm)
-        apply(fastforce intro: owns_slot_owns_irq)
+        apply (clarsimp simp: cap_cleanup_opt_def arch_cap_cleanup_wf split: cap.split_asm)
+        apply (fastforce intro: owns_slot_owns_irq)
        apply (clarsimp simp: is_cap_simps cap_auth_conferred_def clas_no_asid aag_cap_auth_def
                              pas_refined_all_auth_is_owns cli_no_irqs)
        apply (drule appropriate_Zombie[symmetric, THEN trans, symmetric])
@@ -843,7 +822,6 @@ next
     apply (wp static_imp_wp)
     apply clarsimp
     done
-
 next
   case (4 ptr bits n slot s)
   show ?case
@@ -853,9 +831,8 @@ next
      apply (rule split_spec_bindE)
       apply (rule split_spec_bindE[rotated])
        apply (rule "4.hyps", assumption+)
-      apply (wp set_cap_integrity_autarch set_cap_pas_refined_not_transferable get_cap_wp
-                static_imp_wp
-            | simp)+
+      apply (wpsimp wp: set_cap_integrity_autarch set_cap_pas_refined_not_transferable
+                        get_cap_wp static_imp_wp)+
       apply (clarsimp simp: cte_wp_at_caps_of_state clas_no_asid cli_no_irqs aag_cap_auth_def)
       apply (drule_tac auth=auth in sta_caps, simp+)
        apply (simp add: cap_auth_conferred_def aag_cap_auth_def)
@@ -868,35 +845,36 @@ next
 qed
 
 lemma rec_del_respects'_pre:
-  "s \<turnstile> \<lbrace>(\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag
-                  and einvs and simple_sched_action and valid_rec_del_call call
-                  and emptyable (slot_rdcall call)
-                  and (\<lambda>s. \<not> exposed_rdcall call \<longrightarrow>
-                                   ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) (slot_rdcall call) s)
-                  and K (is_subject aag (fst (slot_rdcall call)))
-                  and K (case call of ReduceZombieCall cap sl _ \<Rightarrow>
-                                         \<forall>x \<in> obj_refs cap. is_subject aag x
-                                    | _ \<Rightarrow> True)\<rbrace>
-     rec_del call
-   \<lbrace>\<lambda>rv. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>,
-   \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
+  "s \<turnstile>
+  \<lbrace>(\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag and einvs and
+   simple_sched_action and valid_rec_del_call call and emptyable (slot_rdcall call) and
+   (\<lambda>s. \<not> exposed_rdcall call \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) (slot_rdcall call) s) and
+   K (is_subject aag (fst (slot_rdcall call))) and
+   K (case call of ReduceZombieCall cap sl _ \<Rightarrow> \<forall>x \<in> obj_refs cap. is_subject aag x | _ \<Rightarrow> True)\<rbrace>
+  rec_del call
+  \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>,
+  \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
   apply (rule spec_strengthen_postE[OF rec_del_respects'_pre'])
   by simp
 
 lemmas rec_del_respects'' = rec_del_respects'_pre[THEN use_spec(2), THEN validE_valid]
-lemmas rec_del_respects
-    = rec_del_respects''[of True, THEN hoare_conjD1, simplified]
-      rec_del_respects''[of False, THEN hoare_conjD2, simplified]
+lemmas rec_del_respects =
+  rec_del_respects''[of True, THEN hoare_conjD1, simplified]
+  rec_del_respects''[of False, THEN hoare_conjD2, simplified]
+
+end
+
 
 lemma finalise_cap_transferable:
-  "\<lbrace>P and K(is_transferable_cap cap)\<rbrace> finalise_cap cap final \<lbrace>\<lambda>rv s . rv =(NullCap, NullCap) \<and> P s\<rbrace>"
+  "\<lbrace>P and K (is_transferable_cap cap)\<rbrace>
+   finalise_cap cap final
+   \<lbrace>\<lambda>rv s. rv = (NullCap, NullCap) \<and> P s\<rbrace>"
   by (rule hoare_gen_asm) (erule is_transferable_capE; wpsimp+)
-
 
 lemma rec_del_Finalise_transferable:
   "\<lbrace>(\<lambda>s. is_transferable (caps_of_state s slot)) and P\<rbrace>
-     rec_del (FinaliseSlotCall slot exposed)
-   \<lbrace>\<lambda>rv. K(rv = (True,NullCap)) and  P \<rbrace>, \<lbrace>\<lambda>_.P\<rbrace>"
+   rec_del (FinaliseSlotCall slot exposed)
+   \<lbrace>\<lambda>rv. K (rv = (True,NullCap)) and P\<rbrace>, \<lbrace>\<lambda>_. P\<rbrace>"
   apply (subst rec_del.simps[abs_def])
   apply (wp hoare_K_bind | wpc )+
         apply ((simp only: validE_R_def validE_E_def)?, rule hoare_FalseE)
@@ -908,12 +886,14 @@ lemma rec_del_Finalise_transferable:
      apply (wp finalise_cap_transferable without_preemption_wp get_cap_wp)+
   by (fastforce simp:cte_wp_at_caps_of_state)
 
+
+context Finalise_AC_1 begin
+
 lemma rec_del_respects_CTEDelete_transferable':
-  "\<lbrace>(\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag
-                  and einvs and simple_sched_action and emptyable slot
-                  and (\<lambda>s. \<not> exposed \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) slot s)
-                  and cdt_change_allowed' aag slot\<rbrace>
-     rec_del (CTEDeleteCall slot exposed)
+  "\<lbrace>(\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag and einvs and
+    simple_sched_action and emptyable slot and  cdt_change_allowed' aag slot and
+    (\<lambda>s. \<not> exposed \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) slot s)\<rbrace>
+   rec_del (CTEDeleteCall slot exposed)
    \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>,
    \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
   apply (cases "is_subject aag (fst slot)")
@@ -923,13 +903,13 @@ lemma rec_del_respects_CTEDelete_transferable':
   apply (wp add: hoare_K_bind without_preemption_wp static_imp_wp wp_transferable
                  rec_del_Finalise_transferable
             del: wp_not_transferable
-        | wpc)+
+         | wpc)+
     apply (rule hoare_post_impErr,rule rec_del_Finalise_transferable)
      apply simp apply (elim conjE) apply simp apply simp
    apply (wp add: hoare_K_bind without_preemption_wp static_imp_wp wp_transferable
                   rec_del_Finalise_transferable
              del: wp_not_transferable
-         | wpc)+
+          | wpc)+
    apply (rule hoare_post_impErr,rule rec_del_Finalise_transferable)
     apply simp apply (elim conjE) apply simp apply simp
   apply (clarsimp)
@@ -940,44 +920,44 @@ lemmas rec_del_respects_CTEDelete_transferable =
   rec_del_respects_CTEDelete_transferable'[of True,THEN validE_valid,THEN hoare_conjD1,simplified]
   rec_del_respects_CTEDelete_transferable'[of False,THEN validE_valid,THEN hoare_conjD2,simplified]
 
+end
 
 
 (* TODO section change *)
 
-
 (* FIXME: CLAG *)
-lemmas dmo_valid_cap[wp] = valid_cap_typ [OF do_machine_op_obj_at]
+lemmas dmo_valid_cap[wp] = valid_cap_typ[OF do_machine_op_obj_at]
 
-lemma integrity_eupdate_autarch:
-  "\<lbrakk> integrity aag X st s; is_subject aag ptr \<rbrakk>
-    \<Longrightarrow> integrity aag X st (s\<lparr>ekheap := ekheap s(ptr \<mapsto> obj)\<rparr>)"
-  unfolding integrity_subjects_def by auto
+
+context Finalise_AC_1 begin
 
 lemma set_eobject_integrity_autarch:
   "\<lbrace>integrity aag X st and K (is_subject aag ptr)\<rbrace>
-     set_eobject ptr obj
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+   set_eobject ptr obj
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: set_eobject_def)
   apply wp
-  apply (rule integrity_eupdate_autarch, simp_all)
+  apply (simp add: integrity_subjects_def)
   done
 
 crunch pas_refined[wp]: cancel_badged_sends "pas_refined aag"
   (wp: crunch_wps simp: filterM_mapM crunch_simps ignore: filterM)
 
+end
+
+
 lemma rsubst':
-  "\<lbrakk>P s s'; s=t; s'=t'\<rbrakk> \<Longrightarrow> P t t'"
+  "\<lbrakk> P s s'; s=t; s'=t' \<rbrakk> \<Longrightarrow> P t t'"
   by auto
 
 lemma thread_set_pas_refined_triv_idleT:
   assumes cps: "\<And>tcb. \<forall>(getF, v)\<in>ran tcb_cap_cases. getF (f tcb) = getF tcb"
-       and st: "\<And>tcb. P (tcb_state tcb) \<longrightarrow> tcb_state (f tcb) = tcb_state tcb"
-       and ba: "\<And>tcb. Q (tcb_bound_notification tcb) \<longrightarrow>
-                             tcb_bound_notification (f tcb) = tcb_bound_notification tcb"
-  shows
-    "\<lbrace>pas_refined aag and idle_tcb_at (\<lambda>(st, ntfn, arch). P st \<and> Q ntfn \<and> R arch) t\<rbrace>
-        thread_set f t
-     \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  and st: "\<And>tcb. P (tcb_state tcb) \<longrightarrow> tcb_state (f tcb) = tcb_state tcb"
+  and ba: "\<And>tcb. Q (tcb_bound_notification tcb)
+                  \<longrightarrow> tcb_bound_notification (f tcb) = tcb_bound_notification tcb"
+  shows "\<lbrace>pas_refined aag and idle_tcb_at (\<lambda>(st, ntfn, arch). P st \<and> Q ntfn \<and> R arch) t\<rbrace>
+         thread_set f t
+         \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def)
   apply (rule hoare_pre)
    apply (wps thread_set_caps_of_state_trivial[OF cps])
@@ -993,124 +973,52 @@ lemma thread_set_pas_refined_triv_idleT:
   apply (rule ext, clarsimp simp: thread_bound_ntfns_def get_tcb_def ba)
   done
 
-lemma copy_global_mappings_pas_refined2:
-  "\<lbrace>invs and pas_refined aag and K (is_aligned pd pd_bits)\<rbrace>
-      copy_global_mappings pd
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (rule hoare_gen_asm, wp copy_global_mappings_pas_refined)
-  apply (auto simp: invs_def valid_state_def valid_pspace_def)
-  done
 
-lemma pas_refined_set_asid_table_empty_strg:
-  "pas_refined aag s \<and> is_subject aag pool
-   \<and> (\<forall> asid. asid \<noteq> 0 \<and> asid_high_bits_of asid = base \<longrightarrow> is_subject_asid aag asid)
-   \<and> ko_at (ArchObj (arch_kernel_obj.ASIDPool Map.empty)) pool s
-   \<longrightarrow> pas_refined aag (s\<lparr>arch_state :=
-                          arch_state s \<lparr>arm_asid_table :=
-                                        (arm_asid_table (arch_state s))(base \<mapsto> pool)\<rparr>\<rparr>)"
-  apply (clarsimp simp: pas_refined_def state_objs_to_policy_def)
-  apply (erule state_asids_to_policy_aux.cases)
-    apply(simp_all split: if_split_asm)
-      prefer 2
-      apply (clarsimp simp: state_vrefs_def obj_at_def vs_refs_no_global_pts_def)
-     apply (auto intro: state_asids_to_policy_aux.intros auth_graph_map_memI[OF sbta_vref]
-                        pas_refined_refl[simplified pas_refined_def state_objs_to_policy_def])[3]
-  apply(rule pas_refined_asid_mem)
-   apply(drule_tac t="pasSubject aag" in sym)
-   apply(simp, rule sata_asidpool)
-    apply simp
-   apply assumption
-  apply(simp add: pas_refined_def state_objs_to_policy_def)
-  done
-
-lemma set_asid_pool_ko_at[wp]:
-  "\<lbrace>\<top>\<rbrace> set_asid_pool ptr pool \<lbrace>\<lambda>rv. ko_at (ArchObj (arch_kernel_obj.ASIDPool pool)) ptr\<rbrace>"
-  by (wpsimp simp: obj_at_def set_asid_pool_def set_object_def)
-
-(* The contents of the delete_access_control locale *)
-
-
+context Finalise_AC_1 begin
 
 lemma cap_delete_respects:
   "\<lbrace>integrity aag X st and cdt_change_allowed' aag slot and pas_refined aag
-            and einvs and simple_sched_action and emptyable slot\<rbrace>
-       cap_delete slot
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+                       and einvs and simple_sched_action and emptyable slot\<rbrace>
+   cap_delete slot
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   by (simp add: cap_delete_def) (wpsimp wp: rec_del_respects_CTEDelete_transferable)
 
 lemma cap_delete_respects':
-  "\<lbrace>integrity aag X st and K (is_subject aag (fst slot))
-            and pas_refined aag
-            and einvs and simple_sched_action and emptyable slot\<rbrace>
-       cap_delete slot
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and K (is_subject aag (fst slot)) and pas_refined aag
+                       and einvs and simple_sched_action and emptyable slot\<rbrace>
+   cap_delete slot
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   by (wp cap_delete_respects) fastforce
 
 lemma cap_delete_pas_refined:
-  "\<lbrace>cdt_change_allowed' aag slot and pas_refined aag and einvs and simple_sched_action
-          and emptyable slot\<rbrace>
-       cap_delete slot
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>cdt_change_allowed' aag slot and pas_refined aag and einvs
+                                 and simple_sched_action and emptyable slot\<rbrace>
+   cap_delete slot
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   by (simp add: cap_delete_def) (wpsimp wp: rec_del_respects_CTEDelete_transferable)
 
 lemma cap_delete_pas_refined':
-  "\<lbrace>pas_refined aag and einvs and simple_sched_action and emptyable slot
-          and K(is_subject aag (fst slot))\<rbrace>
-       cap_delete slot
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and einvs and simple_sched_action
+                    and emptyable slot and K(is_subject aag (fst slot))\<rbrace>
+   cap_delete slot
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   by (wp cap_delete_pas_refined) fastforce
 
-lemma cap_revoke_respects':
-  "s \<turnstile> \<lbrace> (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and K (is_subject aag (fst slot))
-         and pas_refined aag and einvs and simple_sched_action\<rbrace>
-       (cap_revoke slot)
-   \<lbrace>\<lambda>rv. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>,
-   \<lbrace>\<lambda>rv. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
-proof (induct rule: cap_revoke.induct[where ?a1.0=s])
-  case (1 slot s)
-  show ?case
-    apply (subst cap_revoke.simps)
+end
 
-    apply (rule hoare_pre_spec_validE)
-     apply (wp "1.hyps")
-            apply ((wp preemption_point_inv' | simp add: integrity_subjects_def pas_refined_def)+)[1]
-           apply (wp select_ext_weak_wp cap_delete_respects cap_delete_pas_refined
-                 | simp split del: if_split | wp (once) hoare_vcg_const_imp_lift hoare_drop_imps)+
-    by (auto simp: emptyable_def descendants_of_def
-             dest: reply_slot_not_descendant
-            intro: cca_owned)
-qed
-
-lemmas cap_revoke_respects[wp]
-    = cap_revoke_respects'[of _ True, THEN use_spec(2), THEN validE_valid,
-                           THEN hoare_conjD1, simplified]
-
-lemmas cap_revoke_pas_refined[wp]
-    = cap_revoke_respects'[of _ False, THEN use_spec(2), THEN validE_valid,
-                           THEN hoare_conjD2, simplified]
 
 (* MOVE *)
 lemma empty_slot_cte_wp_at:
-  "\<lbrace>\<lambda>s. (p = slot \<longrightarrow> P cap.NullCap) \<and> (p \<noteq> slot \<longrightarrow> cte_wp_at P p s)\<rbrace>
-      empty_slot slot free_irq
-   \<lbrace>\<lambda>_ s. cte_wp_at P p s\<rbrace>"
-  apply (rule hoare_pre)
-  apply (simp add: cte_wp_at_caps_of_state)
-  apply (wp empty_slot_caps_of_state)
-  apply (simp add: cte_wp_at_caps_of_state)
-  done
-
-lemma valid_specE_validE:
-  "s \<turnstile> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>R\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>s'. s = s' \<and> P s'\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>R\<rbrace>"
-  unfolding spec_validE_def
-  apply (erule hoare_pre)
-  apply simp
-  done
+  "\<lbrace>\<lambda>s. (p = slot \<longrightarrow> P NullCap) \<and> (p \<noteq> slot \<longrightarrow> cte_wp_at P p s)\<rbrace>
+   empty_slot slot free_irq
+   \<lbrace>\<lambda>_. cte_wp_at P p\<rbrace>"
+  unfolding cte_wp_at_caps_of_state
+  by (wpsimp wp: empty_slot_caps_of_state)
 
 lemma deleting_irq_handler_caps_of_state_nullinv:
-  "\<lbrace>\<lambda>s. \<forall>p. P (caps_of_state s(p \<mapsto> cap.NullCap))\<rbrace>
+  "\<lbrace>\<lambda>s. \<forall>p. P (caps_of_state s(p \<mapsto> NullCap))\<rbrace>
      deleting_irq_handler irq
-   \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
+   \<lbrace>\<lambda>_ s. P (caps_of_state s)\<rbrace>"
   unfolding deleting_irq_handler_def
   including no_pre
   apply (wp cap_delete_one_caps_of_state hoare_drop_imps)
@@ -1118,50 +1026,51 @@ lemma deleting_irq_handler_caps_of_state_nullinv:
   apply fastforce
   done
 
-lemma finalise_cap_caps_of_state_nullinv:
-  "\<lbrace>\<lambda>s. P (caps_of_state s) \<and> (\<forall>p. P (caps_of_state s(p \<mapsto> cap.NullCap)))\<rbrace>
-     finalise_cap cap final
-   \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
-  by (cases cap;
-      wpsimp wp: suspend_caps_of_state unbind_notification_caps_of_state
-                 unbind_notification_cte_wp_at
-                 hoare_vcg_all_lift hoare_drop_imps
-                 deleting_irq_handler_caps_of_state_nullinv
-           simp: fun_upd_def[symmetric] if_apply_def2 split_del: if_split)
+
+locale Finalise_AC_2 = Finalise_AC_1 +
+  assumes cap_revoke_respects':
+  "s \<turnstile> \<lbrace>(\<lambda>s. trp \<longrightarrow> integrity aag X st s) and K (is_subject aag (fst slot))
+                                           and pas_refined aag and einvs and simple_sched_action\<rbrace>
+       (cap_revoke slot)
+       \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>,
+       \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
+  and finalise_cap_caps_of_state_nullinv:
+    "\<And>P. \<lbrace>\<lambda>s :: det_ext state. P (caps_of_state s) \<and> (\<forall>p. P (caps_of_state s(p \<mapsto> NullCap)))\<rbrace>
+          finalise_cap cap final
+          \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
+  and finalise_cap_fst_ret:
+    "\<And>P. \<lbrace>\<lambda>_ :: det_ext state. P NullCap \<and> (\<forall>a b c. P (Zombie a b c)) \<rbrace>
+          finalise_cap cap is_final
+          \<lbrace>\<lambda>rv _. P (fst rv)\<rbrace>"
+begin
+
+lemmas cap_revoke_respects[wp] =
+  cap_revoke_respects'[of _ True, THEN use_spec(2), THEN validE_valid, THEN hoare_conjD1, simplified]
+
+lemmas cap_revoke_pas_refined[wp] =
+  cap_revoke_respects'[of _ False, THEN use_spec(2), THEN validE_valid, THEN hoare_conjD2, simplified]
 
 lemma finalise_cap_cte_wp_at_nullinv:
-  "\<lbrace>\<lambda>s. P cap.NullCap \<and> cte_wp_at P p s\<rbrace>
-     finalise_cap cap final
-   \<lbrace>\<lambda>rv s. cte_wp_at P p s\<rbrace>"
+  "\<lbrace>\<lambda>s :: det_ext state. P NullCap \<and> cte_wp_at P p s\<rbrace>
+   finalise_cap cap final
+   \<lbrace>\<lambda>_ s. cte_wp_at P p s\<rbrace>"
   apply (simp add: cte_wp_at_caps_of_state)
   apply (wp finalise_cap_caps_of_state_nullinv)
   apply simp
   done
 
-lemma finalise_cap_fst_ret:
-  "\<lbrace>\<lambda>s. P cap.NullCap \<and> (\<forall>a b c. P (cap.Zombie a b c)) \<rbrace>
-     finalise_cap cap is_final
-   \<lbrace>\<lambda>rv s. P (fst rv)\<rbrace>"
-  including no_pre
-  apply (cases cap, simp_all add: arch_finalise_cap_def split del: if_split)
-  apply (wp | simp add: comp_def split del: if_split | fastforce)+
-  apply (rule hoare_pre)
-  apply (wp | simp | (rule hoare_pre, wpc))+
-  done
-
 lemma rec_del_preserves_cte_zombie_null:
   assumes P_Null: "P (NullCap)"
   assumes P_Zombie: "\<And>word x y. P (Zombie word x y)"
-  shows "s \<turnstile> \<lbrace>\<lambda>s. ((slot_rdcall call \<noteq> p \<or> exposed_rdcall call)
-                         \<longrightarrow> cte_wp_at P p s)
-                    \<and> (case call of ReduceZombieCall remove slot _
-                        \<Rightarrow> cte_wp_at ((=) remove) slot s | _ \<Rightarrow> True)\<rbrace>
-              rec_del call
-             \<lbrace>\<lambda>_ s. (slot_rdcall call \<noteq> p \<or> exposed_rdcall call)
-                         \<longrightarrow> cte_wp_at P p s\<rbrace>, \<lbrace>\<lambda>_. \<top>\<rbrace>"
+  shows
+    "s \<turnstile> \<lbrace>\<lambda>s. ((slot_rdcall call \<noteq> p \<or> exposed_rdcall call) \<longrightarrow> cte_wp_at P p s) \<and>
+              (case call of ReduceZombieCall remove slot _ \<Rightarrow> cte_wp_at ((=) remove) slot s
+                                                       | _ \<Rightarrow> True)\<rbrace>
+         rec_del call
+         \<lbrace>\<lambda>_ s :: det_ext state. (slot_rdcall call \<noteq> p \<or> exposed_rdcall call) \<longrightarrow> cte_wp_at P p s\<rbrace>,
+         \<lbrace>\<lambda>_. \<top>\<rbrace>"
 proof (induct rule: rec_del.induct, simp_all only: rec_del_fails)
   case (1 slot exposed s)
-
   show ?case
     apply (insert P_Null)
     apply (subst rec_del.simps)
@@ -1194,8 +1103,9 @@ next
       apply (rule_tac Q = "\<lambda>rv' s. (slot \<noteq> p \<or> exposed \<longrightarrow> cte_wp_at P p s) \<and> P (fst rv')
                              \<and> cte_at slot s" in hoare_post_imp)
        apply (clarsimp simp: cte_wp_at_caps_of_state)
-      apply (wp static_imp_wp set_cap_cte_wp_at' finalise_cap_cte_wp_at_nullinv finalise_cap_fst_ret get_cap_wp
-         | simp add: is_final_cap_def)+
+      apply (wp static_imp_wp set_cap_cte_wp_at' finalise_cap_cte_wp_at_nullinv
+                finalise_cap_fst_ret get_cap_wp
+             | simp add: is_final_cap_def)+
     apply (clarsimp simp add: P_Zombie is_cap_simps cte_wp_at_caps_of_state)+
     done
 next
@@ -1227,41 +1137,25 @@ next
     done
 qed
 
-lemma nullcap_not_pg_cap:
-  "is_pg_cap NullCap \<longrightarrow> has_cancel_send_rights NullCap"
-  by (clarsimp simp: is_pg_cap_def)
-
-lemma zombie_not_pg_cap:
-  "is_pg_cap (Zombie word x y) \<longrightarrow> has_cancel_send_rights (Zombie word x y)"
-  by (clarsimp simp: is_pg_cap_def)
-
-lemmas rec_del_has_cancel_send_rights' =
-           rec_del_preserves_cte_zombie_null[where P="\<lambda>cap. is_pg_cap cap
-                                                        \<longrightarrow> has_cancel_send_rights cap",
-                                             OF nullcap_not_pg_cap zombie_not_pg_cap]
 
 lemma rec_del_preserves_cte_zombie_null_insts:
   assumes P_Null: "P (NullCap)"
   assumes P_Zombie: "\<And>word x y. P (Zombie word x y)"
-  shows "\<lbrace>cte_wp_at P p\<rbrace> rec_del (FinaliseSlotCall slot True) \<lbrace>\<lambda>_. cte_wp_at P p\<rbrace>,-"
-        "\<lbrace>cte_wp_at P p\<rbrace> cap_delete slot \<lbrace>\<lambda>_. cte_wp_at P p\<rbrace>,-"
-  apply (simp add: validE_R_def P_Null P_Zombie cap_delete_def
-        | rule use_spec spec_strengthen_postE[OF hoare_pre_spec_validE
+  shows "\<lbrace>\<lambda>s :: det_ext state. cte_wp_at P p s\<rbrace>
+         rec_del (FinaliseSlotCall slot True)
+         \<lbrace>\<lambda>_. cte_wp_at P p\<rbrace>,-"
+  and "\<lbrace>\<lambda>s :: det_ext state. cte_wp_at P p s\<rbrace> cap_delete slot \<lbrace>\<lambda>_. cte_wp_at P p\<rbrace>,-"
+  by (simp add: validE_R_def P_Null P_Zombie cap_delete_def
+      | rule use_spec spec_strengthen_postE[OF hoare_pre_spec_validE
                             [OF rec_del_preserves_cte_zombie_null[where P=P]]]
-        | wp)+
-done
-
-lemmas rec_del_has_cancel_send_rights_insts =
-           rec_del_preserves_cte_zombie_null_insts[where P="\<lambda>cap. is_pg_cap cap
-                                                              \<longrightarrow> has_cancel_send_rights cap",
-                                                   OF nullcap_not_pg_cap zombie_not_pg_cap]
+      | wp)+
 
 lemma cap_revoke_preserves_cte_zombie_null:
   fixes p
   assumes Q_Null: "Q (NullCap)"
   assumes Q_Zombie: "\<And>word x y. Q (Zombie word x y)"
   defines "P \<equiv> cte_wp_at (\<lambda>cap. Q cap) p"
-  shows "s \<turnstile> \<lbrace>P\<rbrace> cap_revoke ptr \<lbrace>\<lambda>rv. P\<rbrace>, \<lbrace>\<lambda>rv. \<top>\<rbrace>"
+  shows "s \<turnstile> \<lbrace>\<lambda>s :: det_ext state. P s\<rbrace> cap_revoke ptr \<lbrace>\<lambda>rv. P\<rbrace>, \<lbrace>\<lambda>rv. \<top>\<rbrace>"
 proof (induct rule: cap_revoke.induct)
   case (1 slot)
   show ?case
@@ -1274,73 +1168,64 @@ proof (induct rule: cap_revoke.induct)
     done
 qed
 
-lemmas cap_revoke_has_cancel_send_rights' =
-                  cap_revoke_preserves_cte_zombie_null[where Q="\<lambda>cap. is_pg_cap cap
-                                                                  \<longrightarrow> has_cancel_send_rights cap",
-                                                       OF nullcap_not_pg_cap zombie_not_pg_cap]
-
-lemmas cap_revoke_has_cancel_send_rights
-    = cap_revoke_has_cancel_send_rights'[THEN use_spec(2), folded validE_R_def]
-
 lemma invoke_cnode_respects:
-  "\<lbrace>integrity aag X st and authorised_cnode_inv aag ci
-          and (\<lambda>s. is_subject aag (cur_thread s)) and pas_refined aag
-          and einvs and simple_sched_action and valid_cnode_inv ci
-          and cnode_inv_auth_derivations ci\<rbrace>
-     invoke_cnode ci \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: invoke_cnode_def authorised_cnode_inv_def
-            split: Invocations_A.cnode_invocation.split,
-         safe)
-  apply (wp get_cap_wp cap_insert_integrity_autarch
-            cap_revoke_respects cap_delete_respects
-            | wpc | simp add: real_cte_emptyable_strg is_transferable_weak_derived
-            | clarsimp simp: cte_wp_at_caps_of_state invs_valid_objs invs_sym_refs
-                             cnode_inv_auth_derivations_def
-            | drule(2) auth_derived_caps_of_state_impls
-            | rule hoare_pre | rule cca_direct)+
+  "\<lbrace>integrity aag X st and authorised_cnode_inv aag ci and (\<lambda>s. is_subject aag (cur_thread s))
+                       and pas_refined aag and einvs and simple_sched_action
+                       and valid_cnode_inv ci and cnode_inv_auth_derivations ci\<rbrace>
+   invoke_cnode ci
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: invoke_cnode_def authorised_cnode_inv_def split: cnode_invocation.split, safe)
+  apply (wpsimp wp: get_cap_wp cap_insert_integrity_autarch
+                    cap_revoke_respects cap_delete_respects
+              simp: real_cte_emptyable_strg is_transferable_weak_derived
+         | clarsimp simp: cte_wp_at_caps_of_state invs_valid_objs invs_sym_refs
+                          cnode_inv_auth_derivations_def
+         | drule(2) auth_derived_caps_of_state_impls
+         | rule hoare_pre | rule cca_direct)+
   apply (auto simp: cap_auth_conferred_def cap_rights_to_auth_def aag_cap_auth_def)
   done
 
+end
+
 lemma set_cap_cte_wp_at_separation:
-  "\<lbrace> cte_wp_at P slot and K(slot \<noteq> slot') \<rbrace>
-     set_cap cap slot'
+  "\<lbrace>cte_wp_at P slot and K (slot \<noteq> slot')\<rbrace>
+   set_cap cap slot'
    \<lbrace>\<lambda>_. cte_wp_at P slot \<rbrace>"
   by (wpsimp simp: cte_wp_at_caps_of_state[abs_def])
 
 (* FIXME MOVE*)
 lemma cap_move_cte_wp_at_separation:
-  "\<lbrace> cte_wp_at P slot and K(slot \<noteq> src \<and> slot \<noteq> dest) \<rbrace>
-     cap_move cap src dest
-   \<lbrace>\<lambda>_. cte_wp_at P slot \<rbrace>"
+  "\<lbrace>cte_wp_at P slot and K(slot \<noteq> src \<and> slot \<noteq> dest)\<rbrace>
+   cap_move cap src dest
+   \<lbrace>\<lambda>_. cte_wp_at P slot\<rbrace>"
   by (wpsimp wp: dxo_wp_weak set_cdt_cte_wp_at set_cap_cte_wp_at_separation
            simp: cap_move_def cte_wp_at_caps_of_state)
 
 (* FIXME MOVE *)
 lemma cap_move_empty_src_slot:
-  "\<lbrace> K(src \<noteq> dest) \<rbrace>
-     cap_move cap src dest
+  "\<lbrace>K (src \<noteq> dest)\<rbrace>
+   cap_move cap src dest
    \<lbrace>\<lambda>_. cte_wp_at ((=) NullCap) src \<rbrace>"
-  apply (simp add:cap_move_def)
-  apply (wp dxo_wp_weak set_cdt_cte_wp_at set_cap_cte_wp_at_separation)
-         apply simp
-        apply (wp dxo_wp_weak set_cdt_cte_wp_at set_cap_sets_wp)+
-  apply simp
-  done
+  unfolding cap_move_def
+  by (wpsimp wp: dxo_wp_weak set_cdt_cte_wp_at set_cap_sets_wp)
 
 lemma is_derived_is_transferable:
-  "\<lbrakk> is_derived m slot child_cap parent_cap; is_transferable_cap parent_cap \<rbrakk> \<Longrightarrow>
-   is_transferable_cap child_cap"
+  "\<lbrakk> is_derived m slot child_cap parent_cap; is_transferable_cap parent_cap \<rbrakk>
+     \<Longrightarrow> is_transferable_cap child_cap"
   apply (erule is_transferable_capE)
   apply simp
-  apply (simp add:is_derived_def is_cap_simps)
+  apply (simp add: is_derived_def is_cap_simps)
   done
+
+
+context Finalise_AC_2 begin
 
 lemma invoke_cnode_pas_refined:
   "\<lbrace>pas_refined aag and pas_cur_domain aag and einvs and simple_sched_action
-          and valid_cnode_inv ci and (\<lambda>s. is_subject aag (cur_thread s))
-          and cnode_inv_auth_derivations ci and authorised_cnode_inv aag ci\<rbrace>
-     invoke_cnode ci
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+                    and valid_cnode_inv ci and (\<lambda>s. is_subject aag (cur_thread s))
+                    and cnode_inv_auth_derivations ci and authorised_cnode_inv aag ci\<rbrace>
+   invoke_cnode ci
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: invoke_cnode_def)
   apply (rule hoare_pre)
    apply (wp add:cap_insert_pas_refined cap_delete_pas_refined cap_revoke_pas_refined
@@ -1353,8 +1238,8 @@ lemma invoke_cnode_pas_refined:
                 cnode_inv_auth_derivations_def integrity_def;
       (clarsimp simp: cte_wp_at_caps_of_state pas_refined_refl cap_links_irq_def
                       real_cte_emptyable_strg
-      | drule auth_derived_caps_of_state_impls
-      | fastforce intro: cap_cur_auth_caps_of_state dest: is_derived_is_transferable)+)
+       | drule auth_derived_caps_of_state_impls
+       | fastforce intro: cap_cur_auth_caps_of_state dest: is_derived_is_transferable)+)
 
 end
 

--- a/proof/access-control/Interrupt_AC.thy
+++ b/proof/access-control/Interrupt_AC.thy
@@ -6,58 +6,11 @@
 
 theory Interrupt_AC
 imports
-  Finalise_AC
+  ArchFinalise_AC
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
 
-definition
-  arch_authorised_irq_ctl_inv :: "'a PAS \<Rightarrow> Invocations_A.arch_irq_control_invocation \<Rightarrow> bool"
-where
-  "arch_authorised_irq_ctl_inv aag cinv \<equiv>
-     case cinv of
-         (ArchIRQControlIssue irq x1 x2 trigger) \<Rightarrow>
-                                 is_subject aag (fst x1) \<and> is_subject aag (fst x2) \<and>
-                                 (pasSubject aag, Control, pasIRQAbs aag irq) \<in> pasPolicy aag"
-
-definition
-  authorised_irq_ctl_inv :: "'a PAS \<Rightarrow> Invocations_A.irq_control_invocation \<Rightarrow> bool"
-where
-  "authorised_irq_ctl_inv aag cinv \<equiv>
-     case cinv of
-         IRQControl irq x1 x2 \<Rightarrow> is_subject aag (fst x1) \<and> is_subject aag (fst x2) \<and>
-                                  (pasSubject aag, Control, pasIRQAbs aag irq) \<in> pasPolicy aag
-        | ArchIRQControl acinv \<Rightarrow> arch_authorised_irq_ctl_inv aag acinv"
-
-lemma arch_invoke_irq_control_pas_refined:
-  "\<lbrace>pas_refined aag and valid_mdb and arch_irq_control_inv_valid irq_ctl_inv and
-     K (arch_authorised_irq_ctl_inv aag irq_ctl_inv)\<rbrace>
-     arch_invoke_irq_control irq_ctl_inv
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (cases irq_ctl_inv; simp)
-  apply (wpsimp wp: cap_insert_pas_refined_not_transferable)
-  apply (clarsimp simp: cte_wp_at_caps_of_state clas_no_asid cap_links_irq_def
-                        arch_authorised_irq_ctl_inv_def aag_cap_auth_def
-                        arch_irq_control_inv_valid_def)
-  done
-
-lemma invoke_irq_control_pas_refined:
-  "\<lbrace>pas_refined aag and valid_mdb and irq_control_inv_valid irq_ctl_inv
-      and K (authorised_irq_ctl_inv aag irq_ctl_inv)\<rbrace>
-     invoke_irq_control irq_ctl_inv
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (cases irq_ctl_inv; simp)
-  apply (wpsimp wp: cap_insert_pas_refined_not_transferable)
-   apply (clarsimp simp: cte_wp_at_caps_of_state clas_no_asid cap_links_irq_def
-                         authorised_irq_ctl_inv_def aag_cap_auth_def)
-  apply (wp arch_invoke_irq_control_pas_refined)
-  apply (clarsimp simp: cte_wp_at_caps_of_state clas_no_asid cap_links_irq_def
-                        authorised_irq_ctl_inv_def aag_cap_auth_def)
-  done
-
-definition
-  authorised_irq_hdl_inv :: "'a PAS \<Rightarrow> Invocations_A.irq_handler_invocation \<Rightarrow> bool"
-where
+definition authorised_irq_hdl_inv :: "'a PAS \<Rightarrow> Invocations_A.irq_handler_invocation \<Rightarrow> bool" where
   "authorised_irq_hdl_inv aag hinv \<equiv>
      case hinv of
          irq_handler_invocation.SetIRQHandler word cap x \<Rightarrow>
@@ -70,19 +23,64 @@ lemma emptyable_irq_node:
   by (simp add:emptyable_def tcb_cnode_index_def)
 
 lemma pas_refined_is_subject_irqD:
-  "\<lbrakk>is_subject_irq aag irq ; pas_refined aag s \<rbrakk> \<Longrightarrow> is_subject aag (interrupt_irq_node s irq)"
+  "\<lbrakk> is_subject_irq aag irq; pas_refined aag s \<rbrakk> \<Longrightarrow> is_subject aag (interrupt_irq_node s irq)"
   by (simp add:pas_refined_def irq_map_wellformed_aux_def)
 
+
+locale Interrupt_AC_1 =
+  fixes arch_authorised_irq_ctl_inv :: "'a PAS \<Rightarrow> arch_irq_control_invocation \<Rightarrow> bool"
+  assumes arch_invoke_irq_control_pas_refined:
+    "\<lbrace>pas_refined (aag :: 'a PAS) and valid_mdb and arch_irq_control_inv_valid irq_ctl_inv
+                                  and K (arch_authorised_irq_ctl_inv aag irq_ctl_inv)\<rbrace>
+     arch_invoke_irq_control irq_ctl_inv
+     \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  and arch_invoke_irq_handler_pas_refined:
+    "\<lbrace>pas_refined aag and invs and (\<lambda>s. interrupt_states s x1 \<noteq> IRQInactive)\<rbrace>
+     arch_invoke_irq_handler (ACKIrq x1)
+     \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  and arch_invoke_irq_control_respects:
+    "\<lbrace>integrity aag X st and pas_refined aag and K (arch_authorised_irq_ctl_inv aag acinv)\<rbrace>
+     arch_invoke_irq_control acinv
+     \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  and arch_invoke_irq_handler_respects:
+    "\<lbrace>integrity aag X st and pas_refined aag and einvs\<rbrace>
+     arch_invoke_irq_handler (ACKIrq x1)
+     \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  and arch_check_irq_inv[wp]:
+    "arch_check_irq irq \<lbrace>\<lambda>s :: det_ext state. P s\<rbrace>"
+begin
+
+definition authorised_irq_ctl_inv :: "'a PAS \<Rightarrow> Invocations_A.irq_control_invocation \<Rightarrow> bool" where
+  "authorised_irq_ctl_inv aag cinv \<equiv>
+     case cinv of
+       IRQControl irq x1 x2 \<Rightarrow> is_subject aag (fst x1) \<and> is_subject aag (fst x2) \<and>
+                               (pasSubject aag, Control, pasIRQAbs aag irq) \<in> pasPolicy aag
+     | ArchIRQControl acinv \<Rightarrow> arch_authorised_irq_ctl_inv aag acinv"
+
+lemma invoke_irq_control_pas_refined:
+  "\<lbrace>pas_refined aag and valid_mdb and irq_control_inv_valid irq_ctl_inv
+                    and K (authorised_irq_ctl_inv aag irq_ctl_inv)\<rbrace>
+   invoke_irq_control irq_ctl_inv
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (cases irq_ctl_inv; simp)
+  apply (wpsimp wp: cap_insert_pas_refined_not_transferable)
+   apply (clarsimp simp: cte_wp_at_caps_of_state clas_no_asid cap_links_irq_def
+                         authorised_irq_ctl_inv_def aag_cap_auth_def)
+  apply (wp arch_invoke_irq_control_pas_refined)
+  apply (clarsimp simp: cte_wp_at_caps_of_state clas_no_asid cap_links_irq_def
+                        authorised_irq_ctl_inv_def aag_cap_auth_def)
+  done
+
 lemma invoke_irq_handler_pas_refined:
-  "\<lbrace>pas_refined aag and invs and irq_handler_inv_valid irq_inv
-       and K (authorised_irq_hdl_inv aag irq_inv)\<rbrace>
-     invoke_irq_handler irq_inv
-   \<lbrace>\<lambda>rv (s::det_ext state). pas_refined aag s\<rbrace>"
+  "\<lbrace>pas_refined (aag :: 'a PAS) and invs and irq_handler_inv_valid irq_inv
+                                and K (authorised_irq_hdl_inv aag irq_inv)\<rbrace>
+   invoke_irq_handler irq_inv
+   \<lbrace>\<lambda>_ s. pas_refined aag s\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (cases irq_inv, simp_all add: authorised_irq_hdl_inv_def)
-    apply (wp cap_insert_pas_refined_not_transferable delete_one_caps_of_state
-          | strengthen invs_mdb aag_Control_owns_strg
-          | simp add: pas_refined_wellformed cte_wp_at_caps_of_state)+
+    apply (wp arch_invoke_irq_handler_pas_refined)
+   apply (wp cap_insert_pas_refined_not_transferable delete_one_caps_of_state
+          | strengthen invs_mdb | simp add: cte_wp_at_caps_of_state)+
     apply (rename_tac irq cap slot)
     apply (rule_tac Q =
             "\<lambda> irq_slot. K(irq_slot \<noteq> slot) and invs and emptyable irq_slot
@@ -92,18 +90,16 @@ lemma invoke_irq_handler_pas_refined:
      apply (force simp: cte_wp_at_caps_of_state)
     apply simp
     apply (wp get_irq_slot_different)
-
    apply (clarsimp simp: emptyable_irq_node cte_wp_at_caps_of_state)
    apply (fastforce simp: interrupt_derived_def is_cap_simps cap_master_cap_def split: cap.splits)
   apply (wp delete_one_caps_of_state | simp add: get_irq_slot_def)+
   apply (fastforce dest: pas_refined_is_subject_irqD)
   done
 
-
 lemma invoke_irq_control_respects:
   "\<lbrace>integrity aag X st and pas_refined aag and K (authorised_irq_ctl_inv aag irq_ctl_inv)\<rbrace>
-     invoke_irq_control irq_ctl_inv
-   \<lbrace>\<lambda>y. integrity aag X st\<rbrace>"
+   invoke_irq_control irq_ctl_inv
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (cases irq_ctl_inv)
   subgoal \<comment>\<open>generic case\<close>
@@ -111,63 +107,63 @@ lemma invoke_irq_control_respects:
     apply (wp cap_insert_integrity_autarch aag_Control_into_owns_irq | simp | blast)+
     done
   subgoal for arch_irq_ctl_inv \<comment>\<open>arch case\<close>
-    apply (simp add: arch_authorised_irq_ctl_inv_def authorised_irq_ctl_inv_def)
-    apply (case_tac arch_irq_ctl_inv, clarsimp simp add: setIRQTrigger_def)
-    apply (wp cap_insert_integrity_autarch aag_Control_into_owns_irq dmo_mol_respects do_machine_op_pas_refined | simp)+
-    apply auto
+    apply (wpsimp wp: arch_invoke_irq_control_respects simp: authorised_irq_ctl_inv_def)
     done
   done
 
-lemma integrity_irq_masks [iff]:
-  "integrity aag X st (s\<lparr>machine_state := machine_state s \<lparr>irq_masks := v \<rparr>\<rparr>) = integrity aag X st s"
-  unfolding integrity_def
-  by simp
-
 lemma invoke_irq_handler_respects:
-  "\<lbrace>integrity aag X st and pas_refined aag and einvs and
-       K (authorised_irq_hdl_inv aag irq_inv)\<rbrace>
-     invoke_irq_handler irq_inv
-   \<lbrace>\<lambda>y. integrity aag X st\<rbrace>"
-  apply (rule hoare_gen_asm)
+  "\<lbrace>integrity (aag :: 'a PAS) X st and pas_refined aag and einvs
+                                   and K (authorised_irq_hdl_inv aag irq_inv)\<rbrace>
+   invoke_irq_handler irq_inv
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (cases irq_inv, simp_all add: authorised_irq_hdl_inv_def)
+  by (wpsimp wp: arch_invoke_irq_handler_respects cap_insert_integrity_autarch)+
+
+end
+
+
+lemma decode_irq_handler_invocation_authorised [wp]:
+  "\<lbrace>K (is_subject_irq aag irq \<and> (\<forall>cap_slot \<in> set caps. pas_cap_cur_auth aag (fst cap_slot)
+                              \<and> is_subject aag (fst (snd cap_slot))))\<rbrace>
+   decode_irq_handler_invocation info_label irq caps
+   \<lbrace>\<lambda>x s. authorised_irq_hdl_inv aag x\<rbrace>, -"
+  unfolding decode_irq_handler_invocation_def authorised_irq_hdl_inv_def
   apply (rule hoare_pre)
-  apply (wp cap_insert_integrity_autarch get_irq_slot_owns dmo_wp | simp add: maskInterrupt_def )+
+   apply (simp add: Let_def split_def split del: if_split cong: if_cong)
+   apply wp
+  apply (auto dest!: hd_in_set)
   done
 
+
+locale Interrupt_AC_2 = Interrupt_AC_1 +
+  assumes arch_decode_irq_control_invocation_authorised:
+    "\<lbrace>pas_refined aag and
+      K (is_subject aag (fst slot) \<and> (\<forall>cap \<in> set caps. pas_cap_cur_auth aag cap) \<and>
+         (args \<noteq> [] \<longrightarrow> (pasSubject aag, Control, pasIRQAbs aag (ucast (args ! 0))) \<in> pasPolicy aag))\<rbrace>
+     arch_decode_irq_control_invocation info_label args slot caps
+     \<lbrace>\<lambda>x s. arch_authorised_irq_ctl_inv aag x\<rbrace>, -"
+begin
+
 lemma decode_irq_control_invocation_authorised [wp]:
-  "\<lbrace>pas_refined aag
-      and K (is_subject aag (fst slot)
-              \<and> (\<forall>cap \<in> set caps. pas_cap_cur_auth aag cap)
-              \<and> (args \<noteq> [] \<longrightarrow>
-                  (pasSubject aag, Control, pasIRQAbs aag (ucast (args ! 0))) \<in> pasPolicy aag))\<rbrace>
-    decode_irq_control_invocation info_label args slot caps
-  \<lbrace>\<lambda>x s. authorised_irq_ctl_inv aag x\<rbrace>, -"
-  unfolding decode_irq_control_invocation_def arch_decode_irq_control_invocation_def authorised_irq_ctl_inv_def arch_authorised_irq_ctl_inv_def arch_check_irq_def
+  "\<lbrace>pas_refined aag and
+    K (is_subject aag (fst slot) \<and> (\<forall>cap \<in> set caps. pas_cap_cur_auth aag cap) \<and>
+       (args \<noteq> [] \<longrightarrow> (pasSubject aag, Control, pasIRQAbs aag (ucast (args ! 0))) \<in> pasPolicy aag))\<rbrace>
+   decode_irq_control_invocation info_label args slot caps
+   \<lbrace>\<lambda>x s. authorised_irq_ctl_inv aag x\<rbrace>, -"
+  unfolding decode_irq_control_invocation_def authorised_irq_ctl_inv_def
   apply (rule hoare_gen_asmE)
   apply (rule hoare_pre)
    apply (simp add: Let_def split del: if_split cong: if_cong)
-   apply (wp whenE_throwError_wp hoare_vcg_imp_lift hoare_drop_imps
-         | strengthen  aag_Control_owns_strg
-         | simp add: o_def del: hoare_True_E_R)+
+   apply (wp arch_decode_irq_control_invocation_authorised
+             whenE_throwError_wp hoare_vcg_imp_lift hoare_drop_imps
+          | strengthen  aag_Control_owns_strg
+          | simp add: o_def del: hoare_True_E_R)+
   apply (cases args, simp_all)
   apply (cases caps, simp_all)
   apply (simp add: ucast_mask_drop)
   apply (auto simp: is_cap_simps cap_auth_conferred_def
                     pas_refined_wellformed
                     pas_refined_all_auth_is_owns aag_cap_auth_def)
-  done
-
-lemma decode_irq_handler_invocation_authorised [wp]:
-  "\<lbrace>K (is_subject_irq aag irq
-         \<and> (\<forall>cap_slot \<in> set caps. pas_cap_cur_auth aag (fst cap_slot)
-                                \<and> is_subject aag (fst (snd cap_slot))))\<rbrace>
-    decode_irq_handler_invocation info_label irq caps
-  \<lbrace>\<lambda>x s. authorised_irq_hdl_inv aag x\<rbrace>, -"
-  unfolding decode_irq_handler_invocation_def authorised_irq_hdl_inv_def
-  apply (rule hoare_pre)
-   apply (simp add: Let_def split_def split del: if_split cong: if_cong)
-   apply wp
-  apply (auto dest!: hd_in_set)
   done
 
 end

--- a/proof/access-control/Ipc_AC.thy
+++ b/proof/access-control/Ipc_AC.thy
@@ -288,12 +288,6 @@ lemma receive_signal_integrity_autarch:
 
 subsubsection\<open>Non-autarchy: the sender is running\<close>
 
-
-lemma length_msg_registers:
-  "length msg_registers = 4"
-  unfolding msg_registers_def
-  by (simp add: msgRegisters_def upto_enum_def fromEnum_def enum_register)
-
 lemma send_upd_ctxintegrity:
   "\<lbrakk> direct_send {pasSubject aag} aag ep tcb
       \<or> indirect_send {pasSubject aag} aag (the (tcb_bound_notification tcb)) ep tcb;
@@ -1554,7 +1548,7 @@ lemma copy_mrs_integrity_autarch:
             store_word_offs_integrity_autarch [where aag = aag and thread = receiver]
        | wpc
        | simp
-       | fastforce simp: length_msg_registers msg_align_bits split: if_split_asm)+
+       | fastforce simp: msg_align_bits split: if_split_asm)+
   done
 
 (* FIXME: Why was the [wp] attribute clobbered by interpretation of the Arch locale? *)
@@ -2023,7 +2017,7 @@ lemma set_message_info_respects_in_ipc:
 
 lemma mul_add_word_size_lt_msg_align_bits_ofnat:
   "\<lbrakk> p < 2 ^ (msg_align_bits - 2); k < 4 \<rbrakk>
-   \<Longrightarrow> of_nat p * of_nat word_size + k < (2 :: word32) ^ msg_align_bits"
+   \<Longrightarrow> of_nat p * of_nat word_size + k < (2 :: obj_ref) ^ msg_align_bits"
   unfolding word_size_def
   apply simp
   apply (rule is_aligned_add_less_t2n[where n=2])
@@ -2031,7 +2025,6 @@ lemma mul_add_word_size_lt_msg_align_bits_ofnat:
                           is_aligned_word_size_2[simplified word_size_def, simplified])
   apply (erule word_less_power_trans_ofnat [where k = 2 and m=9, simplified], simp)
   done
-
 
 lemmas ptr_range_off_off_mems =
     ptr_range_add_memI [OF _ mul_word_size_lt_msg_align_bits_ofnat]
@@ -2229,7 +2222,7 @@ lemma copy_mrs_respects_in_ipc:
             mapM_wp'
             hoare_vcg_const_imp_lift hoare_vcg_all_lift
        | wpc
-       | fastforce split: if_split_asm simp: length_msg_registers)+
+       | fastforce split: if_split_asm)+
   done
 
 lemma do_normal_transfer_respects_in_ipc:
@@ -2272,7 +2265,7 @@ lemma set_mrs_respects_in_ipc:
        | simp split del: if_split add: zipWithM_x_mapM_x split_def)+
    apply (clarsimp simp add: set_zip nth_append simp: msg_align_bits msg_max_length_def
                    split: if_split_asm)
-   apply (simp add: length_msg_registers)
+   apply (simp add: msg_registers_def msgRegisters_def upto_enum_def fromEnum_def enum_register)
    apply arith
    apply simp
    apply wp+

--- a/proof/access-control/Ipc_AC.thy
+++ b/proof/access-control/Ipc_AC.thy
@@ -5,10 +5,8 @@
  *)
 
 theory Ipc_AC
-imports Finalise_AC "Lib.MonadicRewrite"
+imports ArchFinalise_AC "Lib.MonadicRewrite"
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 section\<open>Notifications\<close>
 
@@ -16,49 +14,46 @@ subsection\<open>@{term "pas_refined"}\<close>
 
 crunch thread_bound_ntfns[wp]: do_machine_op "\<lambda>s. P (thread_bound_ntfns s)"
 
-crunches deleted_irq_handler, send_signal
-  for state_vrefs[wp]: "\<lambda>s. P (state_vrefs (s :: det_ext state))"
-  (wp: crunch_wps hoare_unless_wp select_wp dxo_wp_weak simp: crunch_simps)
-
 lemma cancel_ipc_receive_blocked_caps_of_state:
-  "\<lbrace>\<lambda>s. P (caps_of_state (s :: det_ext state)) \<and> st_tcb_at receive_blocked t s\<rbrace> cancel_ipc t \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
+  "\<lbrace>\<lambda>s. P (caps_of_state s) \<and> st_tcb_at receive_blocked t s\<rbrace>
+   cancel_ipc t
+   \<lbrace>\<lambda>_ s. P (caps_of_state s)\<rbrace>"
   apply (clarsimp simp: cancel_ipc_def)
   apply (rule hoare_seq_ext[OF _ gts_sp])
   apply (rule hoare_pre)
-  apply (wp gts_wp | wpc | simp)+
+   apply (wp gts_wp | wpc | simp)+
      apply (rule hoare_pre_cont)+
   apply (clarsimp simp: st_tcb_def2 receive_blocked_def)
   apply (clarsimp split: thread_state.splits)
   done
 
 lemma send_signal_caps_of_state[wp]:
-  "\<lbrace>\<lambda>s :: det_ext state. P (caps_of_state s) \<rbrace> send_signal ntfnptr badge \<lbrace>\<lambda>_ s. P (caps_of_state s)\<rbrace>"
+  "send_signal ntfnptr badge \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace>"
   apply (clarsimp simp: send_signal_def)
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
-  apply (rule hoare_pre)
-   apply (wp dxo_wp_weak cancel_ipc_receive_blocked_caps_of_state gts_wp static_imp_wp | wpc | simp add: update_waiting_ntfn_def)+
+   apply (wpsimp wp: dxo_wp_weak cancel_ipc_receive_blocked_caps_of_state gts_wp static_imp_wp
+               simp: update_waiting_ntfn_def)
   apply (clarsimp simp: fun_upd_def[symmetric] st_tcb_def2)
   done
 
-crunches deleted_irq_handler, send_signal
-  for arch_state[wp]: "\<lambda>s. P (arch_state (s :: det_ext state))"
+crunch mdb[wp]: blocked_cancel_ipc, update_waiting_ntfn "\<lambda>s. P (cdt (s :: det_ext state))"
   (wp: crunch_wps hoare_unless_wp select_wp dxo_wp_weak simp: crunch_simps)
 
-crunch mdb[wp]: blocked_cancel_ipc, update_waiting_ntfn "\<lambda>s. P (cdt (s :: det_ext state))" (wp: crunch_wps hoare_unless_wp select_wp dxo_wp_weak simp: crunch_simps)
-
 lemma cancel_ipc_receive_blocked_mdb:
-  "\<lbrace>\<lambda>s. P (cdt (s :: det_ext state)) \<and> st_tcb_at receive_blocked t s\<rbrace> cancel_ipc t \<lbrace>\<lambda>rv s. P (cdt s)\<rbrace>"
+  "\<lbrace>\<lambda>s :: det_ext state. P (cdt s) \<and> st_tcb_at receive_blocked t s\<rbrace>
+   cancel_ipc t
+   \<lbrace>\<lambda>_ s. P (cdt s)\<rbrace>"
   apply (clarsimp simp: cancel_ipc_def)
   apply (rule hoare_seq_ext[OF _ gts_sp])
   apply (rule hoare_pre)
-  apply (wp gts_wp | wpc | simp)+
+   apply (wp gts_wp | wpc | simp)+
      apply (rule hoare_pre_cont)+
   apply (clarsimp simp: st_tcb_def2 receive_blocked_def)
   apply (clarsimp split: thread_state.splits)
   done
 
 lemma send_signal_mdb[wp]:
-  "\<lbrace>\<lambda>s. P (cdt (s :: det_ext state))\<rbrace> send_signal ntfnptr badge \<lbrace>\<lambda>rv s. P (cdt s)\<rbrace>"
+  "send_signal ntfnptr badge \<lbrace>\<lambda>s :: det_ext state. P (cdt s)\<rbrace>"
   apply (clarsimp simp: send_signal_def)
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
   apply (rule hoare_pre)
@@ -71,14 +66,12 @@ crunches possible_switch_to
 
 lemma update_waiting_ntfn_pas_refined:
   "\<lbrace>pas_refined aag and ko_at (Notification ntfn) ntfnptr and K (ntfn_obj ntfn = WaitingNtfn queue)\<rbrace>
-     update_waiting_ntfn ntfnptr queue badge val
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (simp add: update_waiting_ntfn_def)
-  apply (wp set_thread_state_pas_refined set_simple_ko_pas_refined | simp)+
-  done
+   update_waiting_ntfn ntfnptr queue badge val
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  by (wpsimp wp: set_thread_state_pas_refined set_simple_ko_pas_refined simp: update_waiting_ntfn_def)
 
 lemma cancel_ipc_receive_blocked_pas_refined:
-  "\<lbrace>pas_refined aag and st_tcb_at receive_blocked t\<rbrace> cancel_ipc t \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and st_tcb_at receive_blocked t\<rbrace> cancel_ipc t \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (clarsimp simp: cancel_ipc_def)
   apply (rule hoare_seq_ext[OF _ gts_sp])
   apply (rule hoare_pre)
@@ -87,29 +80,24 @@ lemma cancel_ipc_receive_blocked_pas_refined:
   done
 
 lemma send_signal_pas_refined:
-  "\<lbrace>\<lambda>s. pas_refined aag s\<rbrace> send_signal ntfnptr badge \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "send_signal ntfnptr badge \<lbrace>pas_refined aag\<rbrace>"
   apply (simp add: send_signal_def)
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
-  apply (rule hoare_pre)
-  apply (wp set_simple_ko_pas_refined update_waiting_ntfn_pas_refined gts_wp set_thread_state_pas_refined
-            cancel_ipc_receive_blocked_pas_refined
-       | wpc
-       | simp)+
-  apply clarsimp
+  apply (wpsimp wp: set_simple_ko_pas_refined update_waiting_ntfn_pas_refined gts_wp
+                    set_thread_state_pas_refined cancel_ipc_receive_blocked_pas_refined)
   apply (fastforce simp: st_tcb_def2)
   done
 
 lemma receive_signal_pas_refined:
-  "\<lbrace>pas_refined aag and K (\<forall>ntfnptr \<in> obj_refs cap. (pasObjectAbs aag thread, Receive, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag)\<rbrace>
-     receive_signal thread cap is_blocking
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and K (\<forall>ntfnptr \<in> obj_refs cap. abs_has_auth_to aag Receive thread ntfnptr)\<rbrace>
+   receive_signal thread cap is_blocking
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: receive_signal_def)
   apply (cases cap, simp_all)
   apply (rule hoare_seq_ext [OF _ get_simple_ko_sp])
-  apply (rule hoare_pre)
-  by (wp set_simple_ko_pas_refined set_thread_state_pas_refined
-       | wpc | simp add: do_nbrecv_failed_transfer_def)+
-
+  apply (wpsimp wp: set_simple_ko_pas_refined set_thread_state_pas_refined
+              simp: do_nbrecv_failed_transfer_def)
+  done
 
 subsection\<open>integrity\<close>
 
@@ -129,141 +117,14 @@ lemma st_tcb_at_tcb_states_of_state_eq:
   "(st_tcb_at ((=) st) p s) = (tcb_states_of_state s p = Some st)"
   unfolding tcb_states_of_state_def st_tcb_def2 by auto
 
-lemma kheap_auth_ipc_buffer_same:
-  "kheap st thread = kheap s thread \<Longrightarrow> auth_ipc_buffers st thread = auth_ipc_buffers s thread"
-  unfolding auth_ipc_buffers_def get_tcb_def by simp
-
-lemma tcb_ipc_buffer_not_device:
-  "\<lbrakk>kheap s thread = Some (TCB tcb);valid_objs s\<rbrakk>
-  \<Longrightarrow> \<not> cap_is_device (tcb_ipcframe tcb)"
-  apply (erule(1) valid_objsE)
-  apply (clarsimp simp: valid_obj_def valid_tcb_def valid_ipc_buffer_cap_def
-                 split: cap.split_asm arch_cap.split_asm)
-  done
-
-lemma tro_auth_ipc_buffer_idem:
-  "\<lbrakk> \<forall>x. integrity_obj aag activate subjects (pasObjectAbs aag x) (kheap st x) (kheap s x);
-        pasObjectAbs aag thread \<notin> subjects; valid_objs s \<rbrakk>
-   \<Longrightarrow> auth_ipc_buffers st thread = auth_ipc_buffers s thread"
-  apply (drule spec [where x = thread])
-  by (erule integrity_objE;
-      simp add: auth_ipc_buffers_def get_tcb_def;
-      fastforce cong: cap.case_cong arch_cap.case_cong if_cong
-                simp: case_bool_if
-               dest!: tcb_ipc_buffer_not_device split:arch_cap.splits cap.splits
-               split: if_splits)
-
-
-lemma dmo_storeWord_respects_ipc:
-  "\<lbrace>integrity aag X st and st_tcb_at ((=) Structures_A.Running) thread and
-    K ((\<not> is_subject aag thread \<longrightarrow> st_tcb_at (receive_blocked_on ep) thread st \<and> auth_ipc_buffers st thread = ptr_range buf msg_align_bits) \<and>
-      ipc_buffer_has_auth aag thread (Some buf) \<and> p < 2 ^ (msg_align_bits - 2)) \<rbrace>
-    do_machine_op (storeWord (buf + of_nat p * of_nat word_size) v)
-   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (elim conjE)
-  apply (cases "is_subject aag thread")
-   apply (rule hoare_pre)
-   apply (rule dmo_storeWord_respects_Write)
-    apply clarsimp
-    apply (drule (1) ipc_buffer_has_auth_wordE)
-       apply simp
-      apply (simp add: msg_align_bits)
-     apply (erule mul_word_size_lt_msg_align_bits_ofnat)
-    apply simp
-   \<comment> \<open>non auth case\<close>
-  apply (rule hoare_pre)
-  apply (simp add: storeWord_def)
-  apply (wp dmo_wp)
-  apply clarsimp
-  apply (simp add: integrity_def split del: if_split)
-  apply (clarsimp split del: if_split)
-  apply (case_tac "x \<in> ptr_range (buf + of_nat p * of_nat word_size) 2")
-   apply (clarsimp simp add: st_tcb_at_tcb_states_of_state split del: if_split)
-   apply (rule trm_ipc [where p' = thread])
-      apply simp
-     apply assumption
-    apply (clarsimp simp: ipc_buffer_has_auth_def)
-    apply (erule (1) set_mp [OF ptr_range_subset, rotated -1])
-      apply simp
-     apply (simp add: msg_align_bits)
-    apply (erule mul_word_size_lt_msg_align_bits_ofnat)
-   apply simp
-  \<comment> \<open>otherwise\<close>
-  apply (auto simp: is_aligned_mask [symmetric] intro!: trm_lrefl ptr_range_memI ptr_range_add_memI)
-  done
-
-lemma store_word_offs_respects:
-  "\<lbrace>integrity aag X st and st_tcb_at ((=) Structures_A.Running) thread and
-    K ((\<not> is_subject aag thread \<longrightarrow> st_tcb_at (receive_blocked_on ep) thread st \<and> auth_ipc_buffers st thread = ptr_range buf msg_align_bits) \<and>
-      ipc_buffer_has_auth aag thread (Some buf) \<and> p < 2 ^ (msg_align_bits - 2)) \<rbrace>
-   store_word_offs buf p v
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: store_word_offs_def)
-  apply (rule hoare_pre)
-   apply (wp dmo_storeWord_respects_ipc [where thread = thread])
-  apply fastforce
-  done
-
-
 lemma ipc_buffer_has_auth_None [simp]:
   "ipc_buffer_has_auth aag receiver None"
   unfolding ipc_buffer_has_auth_def by simp
 
-(* FIXME: MOVE *)
-lemma cap_auth_caps_of_state:
-  "\<lbrakk> caps_of_state s p = Some cap; pas_refined aag s\<rbrakk>
-  \<Longrightarrow> aag_cap_auth aag (pasObjectAbs aag (fst p)) cap"
-  unfolding aag_cap_auth_def
-  apply (intro conjI)
-    apply clarsimp
-    apply (drule (2) sta_caps)
-    apply (drule auth_graph_map_memI [where x = "pasObjectAbs aag (fst p)", OF _ sym refl])
-    apply (rule refl)
-    apply (fastforce simp: pas_refined_def)
-   apply clarsimp
-   apply (drule (2) sta_untyped [THEN pas_refined_mem] )
-   apply simp
-  apply (drule (1) clas_caps_of_state)
-  apply simp
-  apply (drule (1) cli_caps_of_state)
-  apply simp
-  done
-
-lemma lookup_ipc_buffer_has_auth [wp]:
-  "\<lbrace>pas_refined aag and valid_objs\<rbrace>
-    lookup_ipc_buffer True receiver
-   \<lbrace>\<lambda>rv s. ipc_buffer_has_auth aag receiver rv\<rbrace>"
-  apply (rule hoare_pre)
-   apply (simp add: lookup_ipc_buffer_def)
-   apply (wp get_cap_wp thread_get_wp'
-        | wpc)+
-  apply (clarsimp simp: cte_wp_at_caps_of_state ipc_buffer_has_auth_def get_tcb_ko_at [symmetric])
-  apply (frule caps_of_state_tcb_cap_cases [where idx = "tcb_cnode_index 4"])
-   apply (simp add: dom_tcb_cap_cases)
-  apply (frule (1) caps_of_state_valid_cap)
-  apply (rule conjI)
-   apply (clarsimp simp: valid_cap_simps cap_aligned_def)
-   apply (erule aligned_add_aligned)
-    apply (rule is_aligned_andI1)
-    apply (drule (1) valid_tcb_objs)
-    apply (clarsimp simp: valid_obj_def valid_tcb_def valid_ipc_buffer_cap_def
-                   split: if_splits)
-   apply (rule order_trans [OF _ pbfs_atleast_pageBits])
-   apply (simp add: msg_align_bits pageBits_def)
-  apply simp
-  apply (drule (1) cap_auth_caps_of_state)
-  apply (clarsimp simp: aag_cap_auth_def cap_auth_conferred_def vspace_cap_rights_to_auth_def
-                        vm_read_write_def is_page_cap_def split: if_split_asm)
-  apply (drule bspec)
-   apply (erule (3) ipcframe_subset_page)
-  apply simp
-  done
-
 lemma set_notification_respects:
   "\<lbrace>integrity aag X st and K (aag_has_auth_to aag auth epptr \<and> auth \<in> {Receive, Notify, Reset})\<rbrace>
-     set_notification epptr ntfn'
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+   set_notification epptr ntfn'
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: set_simple_ko_def set_object_def)
   apply (wp get_object_wp)
   apply (clarsimp simp: obj_at_def partial_inv_def a_type_def)
@@ -272,94 +133,77 @@ lemma set_notification_respects:
   done
 
 lemma receive_signal_integrity_autarch:
-  "\<lbrace>integrity aag X st and pas_refined aag and valid_objs
-           and K ((\<forall>ntfnptr \<in> obj_refs cap. aag_has_auth_to aag Receive ntfnptr)
-                 \<and> is_subject aag thread)\<rbrace>
-     receive_signal thread cap is_blocking
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and valid_objs and
+    K ((\<forall>ntfnptr \<in> obj_refs cap. aag_has_auth_to aag Receive ntfnptr) \<and> is_subject aag thread)\<rbrace>
+   receive_signal thread cap is_blocking
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: receive_signal_def)
   apply (cases cap, simp_all)
   apply (rule hoare_seq_ext [OF _ get_simple_ko_sp])
-  apply (rule hoare_pre)
-  apply (wp set_notification_respects[where auth=Receive] set_thread_state_integrity_autarch as_user_integrity_autarch
-       | wpc
-       | simp add: do_nbrecv_failed_transfer_def)+
+  apply (wpsimp wp: set_notification_respects[where auth=Receive]
+                    set_thread_state_integrity_autarch as_user_integrity_autarch
+              simp: do_nbrecv_failed_transfer_def)
   done
+
 
 subsubsection\<open>Non-autarchy: the sender is running\<close>
 
+locale Ipc_AC_1 =
+  fixes aag :: "'a PAS"
+  assumes arch_derive_cap_auth_derived:
+    "\<lbrace>\<top>\<rbrace>
+     arch_derive_cap acap
+     \<lbrace>\<lambda>rv _ :: det_ext state. rv \<noteq> NullCap \<longrightarrow> auth_derived rv (ArchObjectCap acap)\<rbrace>, -"
+  and lookup_ipc_buffer_has_auth[wp]:
+    "\<lbrace>pas_refined aag and valid_objs\<rbrace>
+     lookup_ipc_buffer True receiver
+     \<lbrace>\<lambda>rv _. ipc_buffer_has_auth aag receiver rv\<rbrace>"
+  and cap_insert_ext_integrity_asids[wp]:
+    "cap_insert_ext a b c d e \<lbrace>integrity_asids aag subjects x (st :: det_ext state)\<rbrace>"
+  and make_fault_message_inv[wp]: (* FIXME AC: requalify *)
+    "\<And>P. make_fault_msg ft t \<lbrace>\<lambda>s :: det_ext state. P s\<rbrace>"
+  and tcb_context_no_change:
+    "\<exists>ctxt. (tcb :: tcb) = tcb\<lparr>tcb_arch := arch_tcb_context_set ctxt (tcb_arch tcb)\<rparr>"
+begin
+
 lemma send_upd_ctxintegrity:
   "\<lbrakk> direct_send {pasSubject aag} aag ep tcb
-      \<or> indirect_send {pasSubject aag} aag (the (tcb_bound_notification tcb)) ep tcb;
-     integrity aag X st s; st_tcb_at ((=) Structures_A.thread_state.Running) thread s;
+     \<or> indirect_send {pasSubject aag} aag (the (tcb_bound_notification tcb)) ep tcb;
+     integrity aag X st s; st_tcb_at ((=) Running) thread s;
      get_tcb thread st = Some tcb; get_tcb thread s = Some tcb'\<rbrakk>
-     \<Longrightarrow> integrity aag X st (s\<lparr>kheap :=
-                               kheap s(thread \<mapsto> TCB (tcb'\<lparr>tcb_arch :=
-                                                           arch_tcb_context_set c' (tcb_arch tcb')
-                                                          \<rparr>))
-                              \<rparr>)"
- apply (clarsimp simp: integrity_def tcb_states_of_state_preserved st_tcb_def2)
+     \<Longrightarrow> integrity aag X st
+                   (s\<lparr>kheap := kheap s(thread \<mapsto>
+                                       TCB (tcb'\<lparr>tcb_arch := arch_tcb_context_set c' (tcb_arch tcb')\<rparr>))\<rparr>)"
+  apply (clarsimp simp: integrity_def tcb_states_of_state_preserved st_tcb_def2)
   apply (drule get_tcb_SomeD)+
   apply (drule spec[where x=thread], simp)
   apply (cases "is_subject aag thread")
    apply (rule tro_lrefl, solves\<open>simp\<close>)
-
   (* slow 5s *)
   by (erule integrity_objE;
       (* eliminate all TCB unrelated cases and simplifies the other *)
       clarsimp;
         (* deal with the orefl case *)
-      ( solves\<open>simp add:direct_send_def indirect_send_def\<close>
-        (* deal with the other case by applying either the reply, call or send rules and then
-           the generic rule *)
+      (solves \<open>simp add:direct_send_def indirect_send_def\<close>
+      (* deal with the other case by applying either the reply,
+         call or send rules and then the generic rule *)
       | rule tro_trans_spec,
         (rule tro_tcb_reply'[OF refl refl refl] tro_tcb_call[OF refl refl refl]
               tro_tcb_send[OF refl refl refl];
           blast),
         rule tro_trans_spec,
         (rule tro_tcb_generic'[OF refl refl refl]; simp),
-        rule tro_orefl, simp, rule tcb.equality; solves\<open>simp add:arch_tcb_context_set_def\<close>))
-
-lemma set_mrs_respects_in_signalling':
-  "\<lbrace>integrity aag X st and st_tcb_at ((=) Structures_A.Running) thread and
-    K ((\<not> is_subject aag thread \<longrightarrow> st_tcb_at (receive_blocked_on ep) thread st
-        \<and> case_option True (\<lambda>buf'. auth_ipc_buffers st thread = ptr_range buf' msg_align_bits) buf)
-        \<and> aag_has_auth_to aag Notify ep \<and> ipc_buffer_has_auth aag thread buf) \<rbrace>
-     set_mrs thread buf msgs
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: set_mrs_def split_def set_object_def get_object_def split del: if_split)
-  apply (wp gets_the_wp get_wp put_wp
-       | wpc
-       | simp split del: if_split
-                    add: zipWithM_x_mapM_x split_def store_word_offs_def fun_upd_def[symmetric])+
-     apply (rule hoare_post_imp [where Q = "\<lambda>rv. st_tcb_at ((=) Structures_A.Running) thread and integrity aag X st"])
-      apply simp
-     apply (wp mapM_x_wp' dmo_storeWord_respects_ipc [where thread = thread and ep = ep])
-     apply (fastforce simp add: set_zip nth_append simp: msg_align_bits msg_max_length_def
-                         split: if_split_asm)
-    apply wp+
-  apply (rule impI)
-  apply (subgoal_tac "\<forall>c'. integrity aag X st
-          (s\<lparr>kheap := kheap s(thread \<mapsto>
-               TCB ((the (get_tcb thread s))\<lparr>tcb_arch :=  arch_tcb_set_registers c' (tcb_arch (the (get_tcb thread s))) \<rparr>))\<rparr>)")
-   apply (clarsimp simp: fun_upd_def st_tcb_at_nostate_upd [unfolded fun_upd_def])
-  apply (rule allI)
-  apply clarsimp
-  apply (cases "is_subject aag thread")
-   apply (erule (1) integrity_update_autarch)
-  apply (clarsimp simp: st_tcb_def2 arch_tcb_set_registers_def)
-  apply (rule send_upd_ctxintegrity[OF disjI1], auto simp: st_tcb_def2 direct_send_def)
-  done
+        rule tro_orefl, simp, rule tcb.equality; solves simp))
 
 lemma as_user_set_register_respects:
-  "\<lbrace>integrity aag X st and st_tcb_at ((=) Structures_A.Running) thread and
-    K ((\<not> is_subject aag thread \<longrightarrow> st_tcb_at (receive_blocked_on ep) thread st) \<and> (aag_has_auth_to aag SyncSend ep \<or> aag_has_auth_to aag Notify ep)) \<rbrace>
+  "\<lbrace>integrity aag X st and st_tcb_at ((=) Running) thread and
+    K ((\<not> is_subject aag thread \<longrightarrow> st_tcb_at (receive_blocked_on ep) thread st) \<and>
+       (aag_has_auth_to aag SyncSend ep \<or> aag_has_auth_to aag Notify ep))\<rbrace>
    as_user thread (set_register r v)
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: as_user_def split_def set_object_def get_object_def)
   apply wp
-  apply (clarsimp simp: in_monad setRegister_def)
+  apply (clarsimp simp: in_monad)
   apply (cases "is_subject aag thread")
    apply (erule (1) integrity_update_autarch [unfolded fun_upd_def])
   apply (clarsimp simp: st_tcb_def2)
@@ -367,32 +211,14 @@ lemma as_user_set_register_respects:
       apply (auto simp: direct_send_def st_tcb_def2)
   done
 
-lemma lookup_ipc_buffer_ptr_range:
-  "\<lbrace>valid_objs and integrity aag X st\<rbrace>
-  lookup_ipc_buffer True thread
-  \<lbrace>\<lambda>rv s. \<not> is_subject aag thread \<longrightarrow> (case rv of None \<Rightarrow> True | Some buf' \<Rightarrow> auth_ipc_buffers st thread = ptr_range buf' msg_align_bits) \<rbrace>"
-  unfolding lookup_ipc_buffer_def
-  apply (rule hoare_pre)
-  apply (wp get_cap_wp thread_get_wp' | wpc)+
-  apply (clarsimp simp: cte_wp_at_caps_of_state ipc_buffer_has_auth_def get_tcb_ko_at [symmetric])
-  apply (frule caps_of_state_tcb_cap_cases [where idx = "tcb_cnode_index 4"])
-   apply (simp add: dom_tcb_cap_cases)
-  apply (clarsimp simp: auth_ipc_buffers_def get_tcb_ko_at [symmetric] integrity_def)
-  apply (drule spec [where x = thread])+
-  apply (drule get_tcb_SomeD)+
-  apply (erule(1) valid_objsE)
-  apply (clarsimp simp: valid_obj_def valid_tcb_def valid_ipc_buffer_cap_def case_bool_if
-                 split: if_split_asm)
-  apply (erule integrity_objE, simp_all add: get_tcb_def vm_read_write_def)
-  apply auto
-  done
+end
+
 
 lemma set_thread_state_respects_in_signalling:
-  "\<lbrace>integrity aag X st
-             and (\<lambda>s. \<not> is_subject aag thread \<longrightarrow> st_tcb_at (receive_blocked_on ntfnptr) thread s)
-             and K (aag_has_auth_to aag Notify ntfnptr)\<rbrace>
-     set_thread_state thread Structures_A.thread_state.Running
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>\<lambda>s. integrity aag X st s \<and> aag_has_auth_to aag Notify ntfnptr \<and>
+        (is_subject aag thread \<or> st_tcb_at (receive_blocked_on ntfnptr) thread s)\<rbrace>
+   set_thread_state thread Running
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: set_thread_state_def set_object_def get_object_def)
   apply wp
   apply (clarsimp)
@@ -403,38 +229,29 @@ lemma set_thread_state_respects_in_signalling:
   apply (clarsimp simp: integrity_def st_tcb_def2)
   apply (clarsimp dest!: get_tcb_SomeD)
   apply (rule tro_tcb_send [OF refl refl])
-  apply (rule tcb.equality;simp; rule arch_tcb_context_set_eq[symmetric])
+   apply (rule tcb.equality; simp; rule arch_tcb_context_set_eq[symmetric])
   apply (auto simp: indirect_send_def direct_send_def)
   done
 
 lemma set_notification_obj_at:
   "\<lbrace>obj_at P ptr and K (ptr \<noteq> ntfnptr)\<rbrace>
-     set_notification ntfnptr queue
-   \<lbrace>\<lambda>rv. obj_at P ptr\<rbrace>"
+   set_notification ntfnptr queue
+   \<lbrace>\<lambda>_. obj_at P ptr\<rbrace>"
   apply (simp add: set_simple_ko_def set_object_def)
   apply (wp get_object_wp)
   apply (auto simp: obj_at_def)
   done
 
 lemma set_ntfn_valid_objs_at:
-  "\<lbrace>valid_objs and (\<lambda>s. ntfn_at p s \<longrightarrow> valid_ntfn ntfn s)\<rbrace> set_notification p ntfn \<lbrace>\<lambda>rv. valid_objs\<rbrace>"
+  "\<lbrace>valid_objs and (\<lambda>s. ntfn_at p s \<longrightarrow> valid_ntfn ntfn s)\<rbrace>
+   set_notification p ntfn
+   \<lbrace>\<lambda>rv. valid_objs\<rbrace>"
   unfolding set_simple_ko_def
   apply (rule hoare_pre)
   apply (wp set_object_valid_objs get_object_wp)
   apply (clarsimp simp: valid_obj_def obj_at_def is_ntfn partial_inv_def
-              split: Structures_A.kernel_object.splits)
+                 split: kernel_object.splits)
   done
-
-lemma drop_Suc0_iff:
-  "xs \<noteq> [] \<Longrightarrow> (drop (Suc 0) xs = ys) = (\<exists>x. xs = x # ys)"
-  by (auto simp: neq_Nil_conv)
-
-lemma receive_blocked_on_def3:
-  "receive_blocked_on ref ts =
-     ((\<exists>pl. ts = Structures_A.BlockedOnReceive ref pl)
-      \<or> ts = Structures_A.BlockedOnNotification ref)"
-  by (cases ts, auto)
-
 
 lemma integrity_receive_blocked_chain:
   "\<lbrakk> st_tcb_at (receive_blocked_on ep) p s; integrity aag X st s; \<not> is_subject aag p \<rbrakk> \<Longrightarrow> st_tcb_at (receive_blocked_on ep) p st"
@@ -449,12 +266,11 @@ crunch integrity[wp]: possible_switch_to "integrity aag X st"
   (ignore: tcb_sched_action)
 
 abbreviation
-  "integrity_once_ts_upd t ts aag X st s
-    == integrity aag X st (s \<lparr> kheap := (kheap s) ( t := Some (TCB ((the (get_tcb t s)) \<lparr>tcb_state := ts\<rparr>)))\<rparr>)"
+  "integrity_once_ts_upd t ts aag X st s \<equiv>
+   integrity aag X st (s\<lparr>kheap := (kheap s)(t := Some (TCB ((the (get_tcb t s))\<lparr>tcb_state := ts\<rparr>)))\<rparr>)"
 
 lemma set_scheduler_action_integrity_once_ts_upd:
-  "\<lbrace>integrity_once_ts_upd t ts aag X st\<rbrace>
-    set_scheduler_action sa \<lbrace>\<lambda>_. integrity_once_ts_upd t ts aag X st\<rbrace>"
+  "set_scheduler_action sa \<lbrace>integrity_once_ts_upd t ts aag X st\<rbrace>"
   apply (simp add: set_scheduler_action_def, wp)
   apply clarsimp
   apply (erule rsubst[where P="\<lambda>x. x"])
@@ -466,8 +282,7 @@ lemma set_scheduler_action_integrity_once_ts_upd:
 crunch integrity_once_ts_upd: set_thread_state_ext "integrity_once_ts_upd t ts aag X st"
 
 lemma set_thread_state_integrity_once_ts_upd:
-  "\<lbrace>integrity_once_ts_upd t ts aag X st\<rbrace>
-    set_thread_state t ts' \<lbrace>\<lambda>_. integrity_once_ts_upd t ts aag X st\<rbrace>"
+  "set_thread_state t ts' \<lbrace>integrity_once_ts_upd t ts aag X st\<rbrace>"
   apply (simp add: set_thread_state_def)
   apply (wpsimp wp: set_object_wp set_thread_state_ext_integrity_once_ts_upd)
   apply (clarsimp simp: fun_upd_def dest!: get_tcb_SomeD)
@@ -475,8 +290,8 @@ lemma set_thread_state_integrity_once_ts_upd:
   done
 
 lemma get_tcb_recv_blocked_implies_receive:
-  "\<lbrakk>pas_refined aag s; get_tcb t s = Some tcb; ep_recv_blocked ep (tcb_state tcb) \<rbrakk>
-          \<Longrightarrow> (pasObjectAbs aag t, Receive, pasObjectAbs aag ep) \<in> pasPolicy aag"
+  "\<lbrakk> pas_refined aag s; get_tcb t s = Some tcb; ep_recv_blocked ep (tcb_state tcb) \<rbrakk>
+     \<Longrightarrow> abs_has_auth_to aag Receive t ep"
   apply (erule pas_refined_mem[rotated])
   apply (rule sta_ts)
   apply (simp add: thread_states_def tcb_states_of_state_def)
@@ -485,11 +300,10 @@ lemma get_tcb_recv_blocked_implies_receive:
 
 lemma cancel_ipc_receive_blocked_respects:
   "\<lbrace>integrity aag X st and pas_refined aag and st_tcb_at (receive_blocked) t and
-       (sym_refs o state_refs_of) and
-       bound_tcb_at (\<lambda>ntfn. ntfn = Some ntfnptr) t and
-       K ((pasObjectAbs aag t, Receive, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag \<and>
-             (pasSubject aag, Notify, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag)\<rbrace>
-    cancel_ipc t \<lbrace>\<lambda>_. integrity_once_ts_upd t Running aag X st\<rbrace>"
+    (sym_refs o state_refs_of) and bound_tcb_at (\<lambda>ntfn. ntfn = Some ntfnptr) t and
+    K (abs_has_auth_to aag Receive t ntfnptr \<and> aag_has_auth_to aag Notify ntfnptr)\<rbrace>
+   cancel_ipc t
+   \<lbrace>\<lambda>_. integrity_once_ts_upd t Running aag X st\<rbrace>"
   apply (clarsimp simp: cancel_ipc_def bind_assoc)
   apply (rule hoare_seq_ext[OF _ gts_sp])
   apply (rule hoare_name_pre_state)
@@ -526,26 +340,32 @@ lemma set_thread_state_integrity':
   apply (simp add: set_thread_state_def)
   by (wpsimp wp: set_object_wp)
 
+
+context Ipc_AC_1 begin
+
 lemma as_user_set_register_respects_indirect:
-  "\<lbrace>integrity aag X st and st_tcb_at ((=) Structures_A.Running) thread and
+  "\<lbrace>integrity aag X st and st_tcb_at ((=) Running) thread and
     K ((\<not> is_subject aag thread \<longrightarrow> st_tcb_at receive_blocked thread st
-           \<and> bound_tcb_at ((=) (Some ntfnptr)) thread st)
-        \<and> (aag_has_auth_to aag Notify ntfnptr)) \<rbrace>
+                                  \<and> bound_tcb_at ((=) (Some ntfnptr)) thread st) \<and>
+       (aag_has_auth_to aag Notify ntfnptr))\<rbrace>
    as_user thread (set_register r v)
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: as_user_def split_def set_object_def get_object_def)
   apply wp
-  apply (clarsimp simp: in_monad setRegister_def)
+  apply (clarsimp simp: in_monad )
   apply (cases "is_subject aag thread")
    apply (erule (1) integrity_update_autarch [unfolded fun_upd_def])
   apply (clarsimp simp: st_tcb_def2 receive_blocked_def)
   apply (simp split: thread_state.split_asm)
-  apply (rule send_upd_ctxintegrity [OF disjI2, unfolded fun_upd_def],
-         auto simp: st_tcb_def2 indirect_send_def pred_tcb_def2 dest: sym)
-  done
+  apply (rule send_upd_ctxintegrity [OF disjI2, unfolded fun_upd_def])
+  by (auto simp: st_tcb_def2 indirect_send_def pred_tcb_def2 dest: sym)
+
+end
+
 
 lemma integrity_receive_blocked_chain':
-  "\<lbrakk> st_tcb_at receive_blocked p s; integrity aag X st s; \<not> is_subject aag p \<rbrakk> \<Longrightarrow> st_tcb_at receive_blocked p st"
+  "\<lbrakk> st_tcb_at receive_blocked p s; integrity aag X st s; \<not> is_subject aag p \<rbrakk>
+     \<Longrightarrow> st_tcb_at receive_blocked p st"
   apply (clarsimp simp: integrity_def st_tcb_at_tcb_states_of_state receive_blocked_def)
   apply (simp split: thread_state.split_asm)
   apply (rename_tac word pl)
@@ -557,11 +377,10 @@ lemma tba_Some:
   by (clarsimp simp: thread_bound_ntfns_def pred_tcb_at_def obj_at_def get_tcb_def
               split: option.splits kernel_object.splits)
 
-
 lemma tsos_tro':
-  "\<lbrakk>\<forall>x. integrity_obj aag activate subjects (pasObjectAbs aag x) (kheap s x) (kheap s' x);
-    thread_bound_ntfns s' p = Some a; pasObjectAbs aag p \<notin> subjects \<rbrakk>
-   \<Longrightarrow> thread_bound_ntfns s p = Some a"
+  "\<lbrakk> \<forall>x. integrity_obj aag activate subjects (pasObjectAbs aag x) (kheap s x) (kheap s' x);
+     thread_bound_ntfns s' p = Some a; pasObjectAbs aag p \<notin> subjects \<rbrakk>
+     \<Longrightarrow> thread_bound_ntfns s p = Some a"
   apply (drule_tac x=p in spec)
   apply (erule integrity_objE;
          simp?;
@@ -570,21 +389,22 @@ lemma tsos_tro':
   done
 
 lemma integrity_receive_blocked_chain_bound:
-  "\<lbrakk>bound_tcb_at ((=) (Some ntfnptr)) p s; integrity aag X st s; \<not> is_subject aag p\<rbrakk>
-   \<Longrightarrow> bound_tcb_at ((=) (Some ntfnptr)) p st"
+  "\<lbrakk> bound_tcb_at ((=) (Some ntfnptr)) p s; integrity aag X st s; \<not> is_subject aag p \<rbrakk>
+     \<Longrightarrow> bound_tcb_at ((=) (Some ntfnptr)) p st"
   apply (clarsimp simp: integrity_def)
   apply (drule bound_tcb_at_thread_bound_ntfns)
   apply (drule tsos_tro' [where p = p], simp+ )
   apply (clarsimp simp:tba_Some)
   done
 
+
+context Ipc_AC_1 begin
+
 lemma send_signal_respects:
-  "\<lbrace>integrity aag X st and pas_refined aag
-         and valid_objs
-         and sym_refs \<circ> state_refs_of
-         and K (aag_has_auth_to aag Notify ntfnptr)\<rbrace>
-     send_signal ntfnptr badge
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and valid_objs and sym_refs \<circ> state_refs_of
+                       and K (aag_has_auth_to aag Notify ntfnptr)\<rbrace>
+   send_signal ntfnptr badge
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: send_signal_def)
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
   apply (rule hoare_name_pre_state)
@@ -633,10 +453,13 @@ lemma send_signal_respects:
    apply simp
   apply simp
   apply (intro impI conjI)
-     \<comment> \<open>st_tcb_at receive_blocked st\<close>
+   \<comment> \<open>st_tcb_at receive_blocked st\<close>
    apply (erule (2) integrity_receive_blocked_chain)
   apply clarsimp
   done
+
+end
+
 
 section\<open>Sync IPC\<close>
 
@@ -652,41 +475,34 @@ etc.
 
 subsection\<open>auxiliary\<close>
 
-
 lemma cap_master_cap_masked_as_full:
   "cap_master_cap (masked_as_full a a) = cap_master_cap a "
-  apply(clarsimp simp: cap_master_cap_def split: cap.splits simp: masked_as_full_def)
-  done
+  by (clarsimp simp: cap_master_cap_def masked_as_full_def split: cap.splits)
 
 lemma cap_badge_masked_as_full:
   "(cap_badge (masked_as_full a a), cap_badge a) \<in> capBadge_ordering False"
-  apply(case_tac a, simp_all add: masked_as_full_def)
-  done
-
-
+  by (cases a, simp_all add: masked_as_full_def)
 
 lemma masked_as_full_double:
   "masked_as_full (masked_as_full ab ab) cap' = masked_as_full ab ab"
-  apply(case_tac ab, simp_all add: masked_as_full_def)
-  done
+  by (cases ab, simp_all add: masked_as_full_def)
 
 lemma transfer_caps_loop_pres_dest_aux:
   assumes x: "\<And>cap src dest.
-              \<lbrace>\<lambda>s. P s \<and> dest \<in> slots' \<and> src \<in> snd ` caps'
-                                   \<and> (valid_objs s \<and> real_cte_at dest s \<and> s \<turnstile> cap \<and> tcb_cap_valid cap dest s
-                                   \<and> real_cte_at src s
-                                   \<and> cte_wp_at (is_derived (cdt s) src cap) src s \<and> cap \<noteq> cap.NullCap) \<rbrace>
-                 cap_insert cap src dest \<lbrace>\<lambda>rv. P\<rbrace>"
-  assumes eb: "\<And>b n'. n' \<le> N \<Longrightarrow> \<lbrace>P\<rbrace> set_extra_badge buffer b n' \<lbrace>\<lambda>_. P\<rbrace>"
-  shows      "n + length caps \<le> N \<Longrightarrow>
-                 \<lbrace>\<lambda>s. P s \<and> set slots \<subseteq> slots' \<and> set caps \<subseteq> caps' \<and>
-                     (valid_objs s \<and> valid_mdb s \<and> distinct slots \<and>
-                     (\<forall>x \<in> set slots. real_cte_at x s) \<and>
-                     (\<forall>x \<in> set caps. s \<turnstile> fst x \<and>
-                                     cte_wp_at (\<lambda>cp. fst x \<noteq> cap.NullCap \<longrightarrow> cp \<noteq> fst x \<longrightarrow> cp = masked_as_full (fst x) (fst x)) (snd x) s
-                                           \<and> real_cte_at (snd x) s))\<rbrace>
-                  transfer_caps_loop ep buffer n caps slots mi
-              \<lbrace>\<lambda>rv. P\<rbrace>" (is "?L \<Longrightarrow> ?P n caps slots mi")
+              \<lbrace>\<lambda>s. P s \<and> dest \<in> slots' \<and> src \<in> snd ` caps' \<and> valid_objs s \<and> real_cte_at dest s \<and>
+                   s \<turnstile> cap \<and> tcb_cap_valid cap dest s \<and> real_cte_at src s \<and>
+                   cte_wp_at (is_derived (cdt s) src cap) src s \<and> cap \<noteq> NullCap\<rbrace>
+              cap_insert cap src dest
+              \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes eb: "\<And>b n'. n' \<le> N \<Longrightarrow> set_extra_badge buffer b n' \<lbrace>P\<rbrace>"
+  shows "n + length caps \<le> N \<Longrightarrow>
+         \<lbrace>\<lambda>s. P s \<and> set slots \<subseteq> slots' \<and> set caps \<subseteq> caps' \<and> valid_objs s \<and>
+              valid_mdb s \<and> distinct slots \<and> (\<forall>x \<in> set slots. real_cte_at x s) \<and>
+              (\<forall>x \<in> set caps. s \<turnstile> fst x \<and> real_cte_at (snd x) s \<and>
+                              cte_wp_at (\<lambda>cp. fst x \<noteq> NullCap \<and> cp \<noteq> fst x
+                                              \<longrightarrow> cp = masked_as_full (fst x) (fst x)) (snd x) s)\<rbrace>
+         transfer_caps_loop ep buffer n caps slots mi
+         \<lbrace>\<lambda>_. P\<rbrace>" (is "?L \<Longrightarrow> ?P n caps slots mi")
 proof (induct caps arbitrary: slots n mi)
   case Nil
   thus ?case by (simp, wp, simp)
@@ -715,7 +531,7 @@ next
      prefer 2
      apply clarsimp
      apply assumption
-    apply(wp derive_cap_is_derived_foo)+
+    apply (wp derive_cap_is_derived_foo)+
   apply (simp only: tl_drop_1[symmetric])
   apply (clarsimp simp: cte_wp_at_caps_of_state
                         ex_cte_cap_to_cnode_always_appropriate_strg
@@ -726,7 +542,7 @@ next
                         imp_conjR[symmetric] cap_master_cap_masked_as_full
                         cap_badge_masked_as_full
                  split del: if_split)
-  apply(intro conjI)
+  apply (intro conjI)
    apply clarsimp
    apply (case_tac "cap = a",clarsimp simp: remove_rights_def)
    apply (clarsimp simp:masked_as_full_def is_cap_simps)
@@ -746,22 +562,21 @@ next
   done
 qed
 
-
 (* FIXME: move *)
 lemma transfer_caps_loop_pres_dest:
   assumes x: "\<And>cap src dest.
-              \<lbrace>\<lambda>s. P s \<and> dest \<in> set slots \<and> src \<in> snd ` set caps
-                                   \<and> (valid_objs s \<and> real_cte_at dest s \<and> s \<turnstile> cap \<and> tcb_cap_valid cap dest s
-                                   \<and> real_cte_at src s
-                                   \<and> cte_wp_at (is_derived (cdt s) src cap) src s \<and> cap \<noteq> cap.NullCap) \<rbrace>
-                 cap_insert cap src dest \<lbrace>\<lambda>rv. P\<rbrace>"
+              \<lbrace>\<lambda>s. P s \<and> dest \<in> set slots \<and> src \<in> snd ` set caps \<and> valid_objs s \<and>
+                   real_cte_at dest s \<and> s \<turnstile> cap \<and> tcb_cap_valid cap dest s \<and> real_cte_at src s \<and>
+                   cte_wp_at (is_derived (cdt s) src cap) src s \<and> cap \<noteq> NullCap \<rbrace>
+              cap_insert cap src dest
+              \<lbrace>\<lambda>_. P\<rbrace>"
   assumes eb: "\<And>b n'. n' \<le> n + length caps \<Longrightarrow> \<lbrace>P\<rbrace> set_extra_badge buffer b n' \<lbrace>\<lambda>_. P\<rbrace>"
-  shows      "\<lbrace>\<lambda>s. P s \<and> (valid_objs s \<and> valid_mdb s \<and> distinct slots \<and>
-                                 (\<forall>x \<in> set slots. real_cte_at x s) \<and>
-                                 (\<forall>x \<in> set caps. s \<turnstile> fst x \<and> cte_wp_at (\<lambda>cp. fst x \<noteq> cap.NullCap \<longrightarrow> cp \<noteq> fst x \<longrightarrow> cp = masked_as_full (fst x) (fst x)) (snd x) s
-                                           \<and> real_cte_at (snd x) s))\<rbrace>
-                  transfer_caps_loop ep buffer n caps slots mi
-              \<lbrace>\<lambda>rv. P\<rbrace>"
+  shows "\<lbrace>\<lambda>s. P s \<and> valid_objs s \<and> valid_mdb s \<and> distinct slots \<and> (\<forall>x \<in> set slots. real_cte_at x s) \<and>
+              (\<forall>x \<in> set caps. s \<turnstile> fst x \<and> real_cte_at (snd x) s \<and>
+                              cte_wp_at (\<lambda>cp. fst x \<noteq> NullCap \<and> cp \<noteq> fst x
+                                              \<longrightarrow> cp = masked_as_full (fst x) (fst x)) (snd x) s)\<rbrace>
+              transfer_caps_loop ep buffer n caps slots mi
+              \<lbrace>\<lambda>_. P\<rbrace>"
   apply (rule hoare_pre)
   apply (rule transfer_caps_loop_pres_dest_aux [OF x eb])
   apply assumption
@@ -769,74 +584,76 @@ lemma transfer_caps_loop_pres_dest:
   apply simp
   done
 
+
 subsection\<open>pas_refined\<close>
 
 lemma lookup_slot_for_thread_authorised:
   "\<lbrace>pas_refined aag and K (is_subject aag thread)\<rbrace>
-    lookup_slot_for_thread thread cref
-   \<lbrace>\<lambda>rv s. is_subject aag (fst (fst rv))\<rbrace>,-"
+   lookup_slot_for_thread thread cref
+   \<lbrace>\<lambda>rv _. is_subject aag (fst (fst rv))\<rbrace>,-"
   unfolding lookup_slot_for_thread_def
   apply wp
   apply (clarsimp simp: owns_thread_owns_cspace)
   done
 
 lemma cnode_cap_all_auth_owns:
-  "(\<exists>s. is_cnode_cap cap \<and> (\<forall>x\<in>obj_refs cap.
-          \<forall>auth\<in>cap_auth_conferred cap. aag_has_auth_to aag auth x)
-            \<and> pas_refined aag s)
-          \<longrightarrow> (\<forall>x\<in>obj_refs cap. is_subject aag x)"
+  "(\<exists>s. is_cnode_cap cap \<and> pas_refined aag s \<and>
+        (\<forall>x\<in>obj_refs cap. \<forall>auth\<in>cap_auth_conferred cap. aag_has_auth_to aag auth x))
+   \<longrightarrow> (\<forall>x\<in>obj_refs cap. is_subject aag x)"
   apply (clarsimp simp: is_cap_simps)
   apply (clarsimp simp: cap_auth_conferred_def pas_refined_all_auth_is_owns)
   done
 
 lemma get_receive_slots_authorised:
   "\<lbrace>pas_refined aag and K (\<forall>rbuf. recv_buf = Some rbuf \<longrightarrow> is_subject aag receiver)\<rbrace>
-     get_receive_slots receiver recv_buf
-  \<lbrace>\<lambda>rv s. \<forall>slot \<in> set rv. is_subject aag (fst slot)\<rbrace>"
+   get_receive_slots receiver recv_buf
+   \<lbrace>\<lambda>rv _. \<forall>slot \<in> set rv. is_subject aag (fst slot)\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (cases recv_buf)
    apply (simp, wp, simp)
   apply clarsimp
   apply (wp get_cap_auth_wp[where aag=aag] lookup_slot_for_thread_authorised
-       | rule hoare_drop_imps
-       | simp add: add: lookup_cap_def split_def)+
-   apply (strengthen cnode_cap_all_auth_owns, simp add: aag_cap_auth_def)
-   apply (wp hoare_vcg_all_lift_R hoare_drop_imps)+
+         | rule hoare_drop_imps
+         | simp add: lookup_cap_def split_def)+
+    apply (strengthen cnode_cap_all_auth_owns, simp add: aag_cap_auth_def)
+    apply (wp hoare_vcg_all_lift_R hoare_drop_imps)+
   apply clarsimp
   apply (fastforce simp: is_cap_simps)
   done
 
 crunch pas_refined[wp]: set_extra_badge "pas_refined aag"
 
-lemma remove_rights_clas [simp]:
+lemma remove_rights_clas[simp]:
   "cap_links_asid_slot aag p (remove_rights R cap) = cap_links_asid_slot aag p cap"
-  unfolding cap_links_asid_slot_def remove_rights_def cap_rights_update_def acap_rights_update_def
-  by (clarsimp split: cap.splits arch_cap.splits bool.splits)
+  unfolding cap_links_asid_slot_def remove_rights_def cap_rights_update_def
+  by (clarsimp split: cap.splits)
 
 lemma remove_rights_cap_auth_conferred_subset:
   "x \<in> cap_auth_conferred (remove_rights R cap) \<Longrightarrow> x \<in> cap_auth_conferred cap"
   unfolding remove_rights_def cap_rights_update_def
-  apply (clarsimp split: if_split_asm cap.splits arch_cap.splits bool.splits
-    simp: cap_auth_conferred_def vspace_cap_rights_to_auth_def acap_rights_update_def
-          validate_vm_rights_def vm_read_only_def vm_kernel_only_def)
+  apply (clarsimp split: if_split_asm cap.splits bool.splits
+                   simp: cap_auth_conferred_def
+                         validate_vm_rights_def vm_read_only_def vm_kernel_only_def)
   apply (erule set_mp [OF cap_rights_to_auth_mono, rotated], clarsimp)+
-  apply (auto simp: is_page_cap_def cap_rights_to_auth_def reply_cap_rights_to_auth_def split:if_splits)
+   apply (fastforce simp: cap_rights_to_auth_def reply_cap_rights_to_auth_def)
+  apply (simp add: Diff_eq)
+  apply (erule set_rev_mp[OF _ acap_auth_conferred_acap_rights_update])
   done
 
-lemma remove_rights_cli [simp]:
+lemma remove_rights_cli[simp]:
   "cap_links_irq aag l (remove_rights R cap) = cap_links_irq aag l cap"
   unfolding remove_rights_def cap_rights_update_def
-  by (clarsimp split: cap.splits arch_cap.splits bool.splits simp: cap_links_irq_def)
+  by (clarsimp split: cap.splits simp: cap_links_irq_def)
 
-lemma remove_rights_untyped_range [simp]:
+lemma remove_rights_untyped_range[simp]:
   "untyped_range (remove_rights R c) = untyped_range c"
   unfolding remove_rights_def cap_rights_update_def
-  by (clarsimp split: cap.splits arch_cap.splits bool.splits simp: )
+  by (clarsimp split: cap.splits simp: cap_links_irq_def)
 
-lemma obj_refs_remove_rights [simp]:
+lemma obj_refs_remove_rights[simp]:
   "obj_refs (remove_rights rs cap) = obj_refs cap"
   unfolding remove_rights_def
-  by (cases cap, simp_all add: cap_rights_update_def acap_rights_update_def split: arch_cap.splits bool.splits)
+  by (cases cap, simp_all add: cap_rights_update_def)
 
 lemma remove_rights_cur_auth:
   "pas_cap_cur_auth aag cap \<Longrightarrow> pas_cap_cur_auth aag (remove_rights R cap)"
@@ -846,54 +663,52 @@ lemma remove_rights_cur_auth:
 (* FIXME MOVE *)
 lemmas hoare_gen_asmE2 = hoare_gen_asmE[where P'=\<top>,simplified pred_and_true_var]
 
-
 lemma derive_cap_is_transferable:
-  "\<lbrace>K(is_transferable_cap cap) \<rbrace> derive_cap slot cap \<lbrace>\<lambda>r s. is_transferable_cap r\<rbrace>, -"
+  "\<lbrace>K (is_transferable_cap cap)\<rbrace> derive_cap slot cap \<lbrace>\<lambda>rv _. is_transferable_cap rv\<rbrace>, -"
   apply (rule hoare_gen_asmE2)
   by (erule is_transferable_capE; wpsimp simp: derive_cap_def)
 
 lemma auth_derived_refl[simp]:
-  " auth_derived cap cap"
-  by (simp add:auth_derived_def)
+  "auth_derived cap cap"
+  by (simp add: auth_derived_def)
+
+
+context Ipc_AC_1 begin
 
 lemma derive_cap_auth_derived:
-  "\<lbrace>\<top>\<rbrace> derive_cap slot cap \<lbrace>\<lambda>rv _. rv \<noteq> NullCap \<longrightarrow> auth_derived rv cap \<rbrace>,-"
-  apply (cases cap ; (wpsimp simp:derive_cap_def)?)
-  apply (case_tac x12 ;
-         simp add:derive_cap_def arch_derive_cap_def;
-         wpc?;
-         wp?;
-         simp add:auth_derived_def cap_auth_conferred_def)
-  done
+  "\<lbrace>\<top>\<rbrace> derive_cap slot cap \<lbrace>\<lambda>rv s :: det_ext state. rv \<noteq> NullCap \<longrightarrow> auth_derived rv cap\<rbrace>, -"
+  by (cases cap; wpsimp wp: arch_derive_cap_auth_derived simp: derive_cap_def)
 
 (* FIXME MOVE *)
 lemma auth_derived_pas_cur_auth:
-  "auth_derived cap cap' \<Longrightarrow> pas_cap_cur_auth aag cap' \<Longrightarrow> pas_cap_cur_auth aag cap"
-  by (force simp:aag_cap_auth_def auth_derived_def cap_links_asid_slot_def cap_links_irq_def)
+  "\<lbrakk> auth_derived cap cap'; pas_cap_cur_auth aag cap' \<rbrakk>
+     \<Longrightarrow> pas_cap_cur_auth aag cap"
+  by (force simp: aag_cap_auth_def auth_derived_def cap_links_asid_slot_def cap_links_irq_def)
 
 lemma derive_cap_is_derived_foo':
-  "\<lbrace>\<lambda>s. \<forall>cap'. (cte_wp_at (\<lambda>capa.
-                 cap_master_cap capa = cap_master_cap cap \<and>
-                 (cap_badge capa, cap_badge cap) \<in> capBadge_ordering False \<and>
-                 cap_asid capa = cap_asid cap \<and> vs_cap_ref capa = vs_cap_ref cap)
-      slot s \<and> valid_objs s \<and> cap' \<noteq> NullCap
-          \<longrightarrow> cte_at slot s )
-            \<and> (s \<turnstile> cap \<longrightarrow> s \<turnstile> cap')
-            \<and> (cap' \<noteq> NullCap \<longrightarrow> auth_derived cap' cap \<and> cap \<noteq> NullCap \<and> \<not> is_zombie cap \<and> cap \<noteq> IRQControlCap)
-          \<longrightarrow> Q cap' s \<rbrace>
-      derive_cap slot cap \<lbrace>Q\<rbrace>,-"
-  apply (clarsimp simp add: validE_R_def validE_def valid_def
-                     split: sum.splits)
+  "\<lbrace>\<lambda>s :: det_ext state.
+    \<forall>cap'. (valid_objs s \<and> cap' \<noteq> NullCap \<and>
+            cte_wp_at (\<lambda>capa. cap_master_cap capa = cap_master_cap cap \<and>
+                              (cap_badge capa, cap_badge cap) \<in> capBadge_ordering False \<and>
+                              cap_asid capa = cap_asid cap \<and> vs_cap_ref capa = vs_cap_ref cap) slot s
+            \<longrightarrow> cte_at slot s) \<and>
+           (s \<turnstile> cap \<longrightarrow> s \<turnstile> cap') \<and>
+           (cap' \<noteq> NullCap \<longrightarrow> auth_derived cap' cap \<and> cap \<noteq> NullCap \<and>
+                                \<not> is_zombie cap \<and> cap \<noteq> IRQControlCap)
+           \<longrightarrow> Q cap' s\<rbrace>
+   derive_cap slot cap
+   \<lbrace>Q\<rbrace>, -"
+  apply (clarsimp simp: validE_R_def validE_def valid_def split: sum.splits)
   apply (frule in_inv_by_hoareD[OF derive_cap_inv], clarsimp)
   apply (erule allE)
   apply (erule impEM)
    apply (frule use_validE_R[OF _ cap_derive_not_null_helper, OF _ _ imp_refl])
     apply (rule derive_cap_inv[THEN valid_validE_R])
-    apply (intro conjI)
-     apply (clarsimp simp:cte_wp_at_caps_of_state)+
-     apply (erule(1) use_validE_R[OF _ derive_cap_valid_cap])
-    apply simp
-    apply (erule use_validE_R[OF _ derive_cap_auth_derived],simp)
+   apply (intro conjI)
+     apply (clarsimp simp: cte_wp_at_caps_of_state)+
+    apply (erule(1) use_validE_R[OF _ derive_cap_valid_cap])
+   apply simp
+   apply (erule use_validE_R[OF _ derive_cap_auth_derived],simp)
   apply simp
   done
 
@@ -901,45 +716,41 @@ lemma derive_cap_is_derived_foo':
 lemma transfer_caps_loop_presM_extended:
   fixes P vo em ex buffer slots caps n mi
   assumes x: "\<And>cap src dest.
-              \<lbrace>\<lambda>s::('state_ext :: state_ext) state .
-                               P s \<and> (vo \<longrightarrow> valid_objs s \<and> valid_mdb s \<and> real_cte_at dest s \<and>
-                                             s \<turnstile> cap \<and> Psrc src \<and> Pdest dest \<and> Pcap cap \<and>
-                                             tcb_cap_valid cap dest s
-                                   \<and> real_cte_at src s
-                                   \<and> cte_wp_at (is_derived (cdt s) src cap) src s \<and>
-                                                cap \<noteq> cap.NullCap)
-                       \<and> (em \<longrightarrow> cte_wp_at ((=) cap.NullCap) dest s)
-                       \<and> (ex \<longrightarrow> ex_cte_cap_wp_to (appropriate_cte_cap cap) dest s)\<rbrace>
-                 cap_insert cap src dest \<lbrace>\<lambda>rv. P\<rbrace>"
-  assumes eb: "\<And>b n. \<lbrace>P\<rbrace> set_extra_badge buffer b n \<lbrace>\<lambda>_. P\<rbrace>"
-  assumes pcap_auth_derived :
-    "\<And>cap cap'. \<lbrakk>auth_derived cap cap'; Pcap cap'\<rbrakk> \<Longrightarrow> Pcap cap"
-  shows "\<lbrace>\<lambda>s. P s \<and>
-             (vo \<longrightarrow> valid_objs s \<and> valid_mdb s \<and> distinct slots \<and>
-                     (\<forall>x \<in> set slots. cte_wp_at (\<lambda>cap. cap = cap.NullCap) x s \<and>
-                                             real_cte_at x s \<and> Pdest x) \<and>
-                     (\<forall>x \<in> set caps. valid_cap (fst x) s \<and> Psrc (snd x) \<and> Pcap (fst x) \<and>
-                                     cte_wp_at (\<lambda>cp. fst x \<noteq> cap.NullCap \<longrightarrow> cp \<noteq> fst x
-                                                     \<longrightarrow> cp = masked_as_full (fst x) (fst x)) (snd x) s
-                     \<and> real_cte_at (snd x) s))
-             \<and> (ex \<longrightarrow> (\<forall>x \<in> set slots. ex_cte_cap_wp_to is_cnode_cap x s))\<rbrace>
-          transfer_caps_loop ep buffer n caps slots mi
-        \<lbrace>\<lambda>rv. P\<rbrace>"
+              \<lbrace>\<lambda>s :: det_ext state . P s \<and> (vo \<longrightarrow> valid_objs s \<and> valid_mdb s \<and> real_cte_at dest s
+                                                 \<and> s \<turnstile> cap \<and> Psrc src \<and> Pdest dest \<and> Pcap cap
+                                                 \<and> tcb_cap_valid cap dest s \<and> real_cte_at src s
+                                                 \<and> cte_wp_at (is_derived (cdt s) src cap) src s
+                                                 \<and> cap \<noteq> NullCap)
+                                         \<and> (em \<longrightarrow> cte_wp_at ((=) NullCap) dest s)
+                                         \<and> (ex \<longrightarrow> ex_cte_cap_wp_to (appropriate_cte_cap cap) dest s)\<rbrace>
+              cap_insert cap src dest
+              \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes eb: "\<And>b n. set_extra_badge buffer b n \<lbrace>P\<rbrace>"
+  assumes pcap_auth_derived: "\<And>cap cap'. \<lbrakk> auth_derived cap cap'; Pcap cap' \<rbrakk> \<Longrightarrow> Pcap cap"
+  shows "\<lbrace>\<lambda>s. P s \<and> (vo \<longrightarrow> valid_objs s \<and> valid_mdb s \<and> distinct slots
+                          \<and> (\<forall>x \<in> set slots. cte_wp_at (\<lambda>cap. cap = NullCap) x s
+                                           \<and> real_cte_at x s \<and> Pdest x)
+                          \<and> (\<forall>x \<in> set caps. valid_cap (fst x) s \<and> Psrc (snd x) \<and> Pcap (fst x)
+                          \<and> cte_wp_at (\<lambda>cp. fst x \<noteq> NullCap \<longrightarrow> cp \<noteq> fst x
+                                             \<longrightarrow> cp = masked_as_full (fst x) (fst x)) (snd x) s
+                          \<and> real_cte_at (snd x) s))
+                  \<and> (ex \<longrightarrow> (\<forall>x \<in> set slots. ex_cte_cap_wp_to is_cnode_cap x s))\<rbrace>
+         transfer_caps_loop ep buffer n caps slots mi
+         \<lbrace>\<lambda>_. P\<rbrace>"
   apply (induct caps arbitrary: slots n mi)
    apply (simp, wp, simp)
   apply (clarsimp simp add: Let_def split_def whenE_def
                       cong: if_cong list.case_cong split del: if_split)
   apply (rule hoare_pre)
    apply (wp eb hoare_vcg_const_imp_lift hoare_vcg_const_Ball_lift static_imp_wp
-           | assumption | simp split del: if_split)+
+          | assumption | simp split del: if_split)+
       apply (rule cap_insert_assume_null)
       apply (wp x hoare_vcg_const_Ball_lift cap_insert_cte_wp_at static_imp_wp)+
     apply (rule hoare_vcg_conj_liftE_R)
      apply (rule derive_cap_is_derived_foo')
-    apply (rule_tac Q' ="\<lambda>cap' s. (vo \<longrightarrow> cap'\<noteq> cap.NullCap \<longrightarrow>
-                            cte_wp_at (is_derived (cdt s) (aa, b) cap') (aa, b) s)
-                            \<and> (cap'\<noteq> cap.NullCap \<longrightarrow> QM s cap')" for QM
-                    in hoare_post_imp_R)
+    apply (rule_tac Q' ="\<lambda>cap' s. (vo \<longrightarrow> cap'\<noteq> NullCap \<longrightarrow>
+                                   cte_wp_at (is_derived (cdt s) (aa, b) cap') (aa, b) s) \<and>
+                                   (cap'\<noteq> NullCap \<longrightarrow> QM s cap')" for QM in hoare_post_imp_R)
      prefer 2
      apply clarsimp
      apply assumption
@@ -974,16 +785,15 @@ lemma transfer_caps_loop_presM_extended:
   by (clarsimp simp: masked_as_full_def is_cap_simps split: if_splits)+
 
 lemma transfer_caps_loop_pas_refined:
-  "\<lbrace>pas_refined aag and valid_objs and valid_mdb
-            and (\<lambda>s. (\<forall>x \<in> set caps. valid_cap (fst x) s \<and>
-                                      cte_wp_at (\<lambda>cp. fst x \<noteq> cap.NullCap \<longrightarrow> cp = fst x) (snd x) s
-                     \<and> real_cte_at (snd x) s) \<and>
-                     (\<forall>x\<in>set slots. real_cte_at x s \<and> cte_wp_at (\<lambda>cap. cap = NullCap) x s))
-            and K ((\<forall>slot \<in> set slots. is_subject aag (fst slot)) \<and>
-                   (\<forall>x \<in> set caps. is_subject aag (fst (snd x)) \<and>
-                   pas_cap_cur_auth aag (fst x)) \<and> distinct slots)\<rbrace>
-    transfer_caps_loop ep buffer n caps slots mi
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>\<lambda>s. pas_refined aag s \<and> valid_objs s \<and> valid_mdb s \<and>
+        (\<forall>x \<in> set caps. valid_cap (fst x) s \<and> real_cte_at (snd x) s
+                      \<and> cte_wp_at (\<lambda>cp. fst x \<noteq> NullCap \<longrightarrow> cp = fst x) (snd x) s) \<and>
+        (\<forall>x\<in>set slots. real_cte_at x s \<and> cte_wp_at (\<lambda>cap. cap = NullCap) x s) \<and>
+        (\<forall>slot \<in> set slots. is_subject aag (fst slot)) \<and>
+        (\<forall>x \<in> set caps. is_subject aag (fst (snd x)) \<and>
+        pas_cap_cur_auth aag (fst x)) \<and> distinct slots\<rbrace>
+   transfer_caps_loop ep buffer n caps slots mi
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_pre)
   apply (rule transfer_caps_loop_presM_extended
               [where vo=True and em=True and ex=False and
@@ -997,21 +807,20 @@ lemma transfer_caps_loop_pas_refined:
   apply (fastforce elim: cte_wp_at_weakenE)
   done
 
-
 lemma transfer_caps_pas_refined:
   "\<lbrace>pas_refined aag and valid_objs and valid_mdb
     and (\<lambda>s. (\<forall>x \<in> set caps. valid_cap (fst x) s \<and> valid_cap (fst x) s \<and>
-                                      cte_wp_at (\<lambda>cp. fst x \<noteq> cap.NullCap \<longrightarrow> cp = fst x) (snd x) s
+                                      cte_wp_at (\<lambda>cp. fst x \<noteq> NullCap \<longrightarrow> cp = fst x) (snd x) s
                      \<and> real_cte_at (snd x) s))
     and K (is_subject aag receiver \<and> (\<forall>x \<in> set caps. is_subject aag (fst (snd x))) \<and> (\<forall>x \<in> set caps. pas_cap_cur_auth aag (fst x))) \<rbrace>
      transfer_caps info caps endpoint receiver recv_buf
    \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
   unfolding transfer_caps_def
-  apply (rule hoare_pre)
   by (wp transfer_caps_loop_pas_refined get_receive_slots_authorised get_recv_slot_inv
          hoare_vcg_const_imp_lift hoare_vcg_all_lift grs_distinct
-     | wpc | simp del: get_receive_slots.simps add: ball_conj_distrib)+
+      | wpc | simp del: get_receive_slots.simps add: ball_conj_distrib)+
 
+end
 
 
 crunch pas_refined[wp]: copy_mrs "pas_refined aag"
@@ -1019,55 +828,39 @@ crunch pas_refined[wp]: copy_mrs "pas_refined aag"
 
 lemma lookup_cap_and_slot_authorised:
   "\<lbrace>pas_refined aag and K (is_subject aag thread)\<rbrace>
-     lookup_cap_and_slot thread xs
-   \<lbrace>\<lambda>rv s. is_subject aag (fst (snd rv))\<rbrace>, -"
+   lookup_cap_and_slot thread xs
+   \<lbrace>\<lambda>rv _. is_subject aag (fst (snd rv))\<rbrace>, -"
   unfolding lookup_cap_and_slot_def
-  apply (rule hoare_pre)
-   apply (wp lookup_slot_for_thread_authorised
-        | simp add: split_def)+
-  done
+  by (wp lookup_slot_for_thread_authorised | simp add: split_def)+
 
 lemma lookup_extra_caps_authorised:
   "\<lbrace>pas_refined aag and K (is_subject aag thread)\<rbrace>
-    lookup_extra_caps thread buffer mi
-   \<lbrace>\<lambda>rv s. \<forall>cap \<in> set rv. is_subject aag (fst (snd cap))\<rbrace>, -"
-  apply (simp add: lookup_extra_caps_def)
-  apply (wp mapME_set lookup_cap_and_slot_authorised
-       | simp)+
-  done
+   lookup_extra_caps thread buffer mi
+   \<lbrace>\<lambda>rv _. \<forall>cap \<in> set rv. is_subject aag (fst (snd cap))\<rbrace>, -"
+  unfolding lookup_extra_caps_def
+  by (wpsimp wp: mapME_set lookup_cap_and_slot_authorised)
 
 lemma lookup_cap_and_slot_cur_auth:
    "\<lbrace>pas_refined aag and K (is_subject aag thread)\<rbrace>
-     lookup_cap_and_slot thread xs
-   \<lbrace>\<lambda>rv s. pas_cap_cur_auth aag (fst rv)\<rbrace>, -"
+    lookup_cap_and_slot thread xs
+    \<lbrace>\<lambda>rv _. pas_cap_cur_auth aag (fst rv)\<rbrace>, -"
   unfolding lookup_cap_and_slot_def
-  apply (rule hoare_pre)
-   apply (wp get_cap_auth_wp [where aag = aag] lookup_slot_for_thread_authorised
-        | simp add: split_def)+
-  done
+  by (wp get_cap_auth_wp [where aag = aag] lookup_slot_for_thread_authorised | simp add: split_def)+
 
 lemma lookup_extra_caps_auth:
   "\<lbrace>pas_refined aag and K (is_subject aag thread)\<rbrace>
-    lookup_extra_caps thread buffer mi
-   \<lbrace>\<lambda>rv s. \<forall>cap \<in> set rv. pas_cap_cur_auth aag (fst cap)\<rbrace>, -"
-  apply (simp add: lookup_extra_caps_def)
-  apply (wp mapME_set lookup_cap_and_slot_cur_auth
-       | simp)+
-  done
+   lookup_extra_caps thread buffer mi
+   \<lbrace>\<lambda>rv _. \<forall>cap \<in> set rv. pas_cap_cur_auth aag (fst cap)\<rbrace>, -"
+  unfolding lookup_extra_caps_def
+  by (wpsimp wp: mapME_set lookup_cap_and_slot_cur_auth)
 
 lemma transfer_caps_empty_inv:
-  "\<lbrace>P\<rbrace>  transfer_caps mi [] endpoint receiver rbuf \<lbrace>\<lambda>_. P\<rbrace>"
-  unfolding transfer_caps_def
-  by (wp | wpc | simp) +
+  "transfer_caps mi [] endpoint receiver rbuf \<lbrace>P\<rbrace>"
+  unfolding transfer_caps_def by wpsimp
 
 lemma lcs_valid':
   "\<lbrace>valid_objs\<rbrace> lookup_cap_and_slot thread xs \<lbrace>\<lambda>x s. s \<turnstile> fst x\<rbrace>, -"
-  unfolding lookup_cap_and_slot_def
-  apply (rule hoare_pre)
-  apply wp
-   apply (simp add: split_def)
-   apply (wp lookup_slot_for_thread_inv | simp)+
-  done
+  unfolding lookup_cap_and_slot_def by wpsimp
 
 lemma lec_valid_cap':
   "\<lbrace>valid_objs\<rbrace> lookup_extra_caps thread xa mi \<lbrace>\<lambda>rv s. (\<forall>x\<in>set rv. s \<turnstile> fst x)\<rbrace>, -"
@@ -1076,69 +869,61 @@ lemma lec_valid_cap':
 
 (* FIXME: MOVE *)
 lemma hoare_conjDR1:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> R rv s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> R rv s\<rbrace>, - \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, -"
   by (simp add:validE_def validE_R_def valid_def) blast
 
 lemma hoare_conjDR2:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> R rv s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>,-"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> R rv s\<rbrace>, - \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>, -"
   by (simp add:validE_def validE_R_def valid_def) blast
 
+
+context Ipc_AC_1 begin
+
+crunches do_fault_transfer
+  for pas_refined[wp]: "\<lambda>s :: det_ext state. pas_refined aag s"
+
 lemma do_normal_transfer_pas_refined:
-  "\<lbrace>pas_refined aag
-        and valid_objs and valid_mdb
-        and K (grant \<longrightarrow> is_subject aag sender)
-        and K (grant \<longrightarrow> is_subject aag receiver)\<rbrace>
-     do_normal_transfer sender sbuf endpoint badge grant receiver rbuf
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and valid_objs and valid_mdb
+                    and K (grant \<longrightarrow> is_subject aag sender)
+                    and K (grant \<longrightarrow> is_subject aag receiver)\<rbrace>
+   do_normal_transfer sender sbuf endpoint badge grant receiver rbuf
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
 proof(cases grant)
   case True thus ?thesis
     apply -
     apply (rule hoare_gen_asm)
     apply (simp add: do_normal_transfer_def)
-    by (simp
-         | wp copy_mrs_pas_refined transfer_caps_pas_refined lec_valid_cap'
-           copy_mrs_cte_wp_at
-           hoare_vcg_ball_lift
-           lookup_extra_caps_srcs[simplified ball_conj_distrib,THEN hoare_conjDR1]
-           lookup_extra_caps_srcs[simplified ball_conj_distrib,THEN hoare_conjDR2]
-           lookup_extra_caps_authorised lookup_extra_caps_auth lec_valid_cap'
-         | wpc | simp add:ball_conj_distrib)+
+    by (wpsimp wp: copy_mrs_pas_refined transfer_caps_pas_refined
+                   lec_valid_cap' copy_mrs_cte_wp_at hoare_vcg_ball_lift
+                   lookup_extra_caps_srcs[simplified ball_conj_distrib,THEN hoare_conjDR1]
+                   lookup_extra_caps_srcs[simplified ball_conj_distrib,THEN hoare_conjDR2]
+                   lookup_extra_caps_authorised lookup_extra_caps_auth
+             simp: ball_conj_distrib)
 next
   case False thus ?thesis
     apply (simp add: do_normal_transfer_def)
-    by (simp
-          | wp copy_mrs_pas_refined transfer_caps_empty_inv
-               copy_mrs_cte_wp_at
-              hoare_vcg_const_imp_lift hoare_vcg_all_lift
-         | wpc)+
+    by (wpsimp wp: copy_mrs_pas_refined copy_mrs_cte_wp_at transfer_caps_empty_inv)
 qed
 
-crunch pas_refined[wp]: do_fault_transfer "pas_refined aag"
-
 lemma do_ipc_transfer_pas_refined:
-  "\<lbrace>pas_refined aag
-        and valid_objs and valid_mdb
-        and K (grant \<longrightarrow> is_subject aag sender)
-        and K (grant \<longrightarrow> is_subject aag receiver)\<rbrace>
-     do_ipc_transfer sender ep badge grant receiver
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (simp add: do_ipc_transfer_def)
-  apply (wp do_normal_transfer_pas_refined
-            hoare_vcg_conj_lift hoare_vcg_all_lift
-       | rule hoare_drop_imps
-       | wpc)+
-  by simp
+  "\<lbrace>pas_refined aag and valid_objs and valid_mdb
+                    and K (grant \<longrightarrow> is_subject aag sender)
+                    and K (grant \<longrightarrow> is_subject aag receiver)\<rbrace>
+   do_ipc_transfer sender ep badge grant receiver
+   \<lbrace>\<lambda>_ s :: det_ext state. pas_refined aag s\<rbrace>"
+  unfolding do_ipc_transfer_def
+  by (wpsimp wp: do_normal_transfer_pas_refined hoare_vcg_all_lift hoare_drop_imps)
+
+end
 
 
 (* FIXME MOVE*)
 lemma cap_insert_pas_refined_transferable:
-  "\<lbrace>pas_refined aag and valid_mdb
-     and K (is_transferable_cap new_cap
-            \<and> aag_cap_auth aag (pasObjectAbs aag (fst dest_slot)) new_cap
-            \<and> (pasObjectAbs aag (fst src_slot), DeleteDerived, pasObjectAbs aag (fst dest_slot))
-                           \<in> pasPolicy aag) \<rbrace>
-     cap_insert new_cap src_slot dest_slot
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and valid_mdb and
+    K (is_transferable_cap new_cap \<and> aag_cap_auth aag (pasObjectAbs aag (fst dest_slot)) new_cap \<and>
+       abs_has_auth_to aag DeleteDerived (fst src_slot) (fst dest_slot))\<rbrace>
+   cap_insert new_cap src_slot dest_slot
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: cap_insert_def)
   apply (rule hoare_pre)
@@ -1147,8 +932,8 @@ lemma cap_insert_pas_refined_transferable:
             set_untyped_cap_as_full_cdt_is_original_cap get_cap_wp
             tcb_domain_map_wellformed_lift hoare_vcg_disj_lift
             set_untyped_cap_as_full_is_transferable'
-        | simp split del: if_split del: split_paired_All fun_upd_apply
-        | strengthen update_one_strg)+
+         | simp split del: if_split del: split_paired_All fun_upd_apply
+         | strengthen update_one_strg)+
   by (fastforce split: if_split_asm
                  simp: cte_wp_at_caps_of_state pas_refined_refl valid_mdb_def2
                        mdb_cte_at_def Option.is_none_def
@@ -1156,25 +941,21 @@ lemma cap_insert_pas_refined_transferable:
                  dest: aag_cdt_link_Control aag_cdt_link_DeleteDerived cap_auth_caps_of_state
                 intro: aag_wellformed_delete_derived_trans[OF _ _ pas_refined_wellformed])
 
-
 lemma setup_caller_cap_pas_refined:
-  "\<lbrace>pas_refined aag
-         and valid_mdb
-         and K((grant \<longrightarrow> is_subject aag sender \<and> is_subject aag receiver) \<and>
-             (pasObjectAbs aag receiver, Reply, pasObjectAbs aag sender) \<in> pasPolicy aag )\<rbrace>
-     setup_caller_cap sender receiver grant
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and valid_mdb and
+    K ((grant \<longrightarrow> is_subject aag sender \<and> is_subject aag receiver) \<and>
+       abs_has_auth_to aag Reply receiver sender)\<rbrace>
+   setup_caller_cap sender receiver grant
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: setup_caller_cap_def)
   apply (rule conjI)
    (* if grant *)
    apply clarsimp
-   apply (rule hoare_pre)
-    apply (wpsimp wp: cap_insert_pas_refined set_thread_state_pas_refined)
+   apply (wpsimp wp: cap_insert_pas_refined set_thread_state_pas_refined)
    apply (fastforce simp: aag_cap_auth_def clas_no_asid cli_no_irqs pas_refined_refl)
-   (* if not grant *)
+  (* if not grant *)
   apply clarsimp
-  apply (rule hoare_pre)
-   apply (wp cap_insert_pas_refined_transferable set_thread_state_pas_refined)
+  apply (wp cap_insert_pas_refined_transferable set_thread_state_pas_refined)
   by (fastforce simp: aag_cap_auth_def cap_links_irq_def cap_links_asid_slot_def
                       cap_auth_conferred_def reply_cap_rights_to_auth_def
                intro: aag_wellformed_delete_derived[OF _ pas_refined_wellformed])
@@ -1184,7 +965,7 @@ lemma sym_ref_endpoint_recvD:
   assumes sym: "sym_refs (state_refs_of s)"
   and ep: "ko_at (Endpoint (RecvEP l)) epptr s"
   and inl: "t \<in> set l"
-  shows "\<exists> pl. st_tcb_at ((=) (BlockedOnReceive epptr pl)) t s"
+  shows "\<exists>pl. st_tcb_at ((=) (BlockedOnReceive epptr pl)) t s"
 proof -
   have "(t, EPRecv) \<in> state_refs_of s epptr"
     using ep inl by (force simp: state_refs_of_def dest:ko_atD)
@@ -1203,7 +984,7 @@ lemma pas_refined_ep_recv:
   and invs: "invs s"
   and ep: "ko_at (Endpoint (RecvEP l)) epptr s"
   and inl: "t \<in> set l"
-  shows "(pasObjectAbs aag t, Receive, pasObjectAbs aag epptr) \<in> pasPolicy aag"
+  shows "abs_has_auth_to aag Receive t epptr"
   apply (insert sym_ref_endpoint_recvD[OF invs_sym_refs[OF invs] ep inl])
   apply clarsimp
   apply (clarsimp simp:st_tcb_at_tcb_states_of_state_eq)
@@ -1213,8 +994,8 @@ lemma pas_refined_ep_recv:
   done
 
 lemma send_ipc_valid_ep_helper:
-  "\<lbrakk>invs s ; ko_at (Endpoint (RecvEP (h # t))) epptr s \<rbrakk> \<Longrightarrow>
-   valid_ep (case t of [] \<Rightarrow> IdleEP | h' # t'  \<Rightarrow> RecvEP t) s"
+  "\<lbrakk> invs s; ko_at (Endpoint (RecvEP (h # t))) epptr s \<rbrakk>
+     \<Longrightarrow> valid_ep (case t of [] \<Rightarrow> IdleEP | h' # t'  \<Rightarrow> RecvEP t) s"
   apply (drule invs_valid_objs)
   apply (drule ko_atD)
   apply (erule(1) valid_objsE)
@@ -1223,15 +1004,16 @@ lemma send_ipc_valid_ep_helper:
 lemmas head_in_set = list.set_intros(1)[of h t for h t]
 
 
+context Ipc_AC_1 begin
+
 lemma send_ipc_pas_refined:
-  "\<lbrace>pas_refined aag
-       and invs
-       and K (is_subject aag thread
-              \<and> aag_has_auth_to aag SyncSend epptr
-              \<and> (can_grant_reply \<longrightarrow> aag_has_auth_to aag Call epptr)
-              \<and> (can_grant \<longrightarrow> aag_has_auth_to aag Grant epptr \<and> aag_has_auth_to aag Call epptr))\<rbrace>
-     send_ipc block call badge can_grant can_grant_reply thread epptr
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and invs and
+    K (is_subject aag thread \<and> aag_has_auth_to aag SyncSend epptr
+                             \<and> (can_grant_reply \<longrightarrow> aag_has_auth_to aag Call epptr)
+                             \<and> (can_grant \<longrightarrow> aag_has_auth_to aag Grant epptr
+                                            \<and> aag_has_auth_to aag Call epptr))\<rbrace>
+   send_ipc block call badge can_grant can_grant_reply thread epptr
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: send_ipc_def)
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
@@ -1253,11 +1035,10 @@ lemma send_ipc_pas_refined:
   subgoal for ep s (* post-wp proof *)
     apply (intro conjI impI; clarsimp;
            frule(2) pas_refined_ep_recv[OF _ _ _ head_in_set])
-
     subgoal (* can_grant *)
       apply (frule(2) aag_wellformed_grant_Control_to_recv[OF _ _ pas_refined_wellformed])
       apply (frule(2) aag_wellformed_reply[OF _ _ pas_refined_wellformed])
-      apply (force elim: send_ipc_valid_ep_helper simp:aag_has_auth_to_Control_eq_owns)
+      apply (force elim: send_ipc_valid_ep_helper simp:aag_has_Control_iff_owns)
       done
     subgoal (* can_grant_reply and not can_grant*)
       apply (frule(2) aag_wellformed_reply[OF _ _ pas_refined_wellformed])
@@ -1266,7 +1047,7 @@ lemma send_ipc_pas_refined:
       apply (frule(1) sym_ref_endpoint_recvD[OF invs_sym_refs _ head_in_set],
              clarsimp simp:st_tcb_at_tcb_states_of_state_eq)
       apply (fastforce elim: send_ipc_valid_ep_helper
-                       simp: aag_has_auth_to_Control_eq_owns
+                       simp: aag_has_Control_iff_owns
                        dest: aag_wellformed_grant_Control_to_recv_by_reply
                                [OF _ _ _ pas_refined_wellformed])
       done
@@ -1275,36 +1056,27 @@ lemma send_ipc_pas_refined:
     done
   done
 
+end
+
+
 lemma set_simple_ko_get_tcb:
-  "\<lbrace>\<lambda>s. P (get_tcb p s)\<rbrace> set_simple_ko f ep epptr \<lbrace>\<lambda>_ s. P (get_tcb p s) \<rbrace>"
+  "set_simple_ko f ep epptr \<lbrace>\<lambda>s. P (get_tcb p s)\<rbrace>"
   unfolding set_simple_ko_def set_object_def
   apply (wp get_object_wp)
   apply (auto simp: partial_inv_def a_type_def get_tcb_def obj_at_def the_equality
-                 split: Structures_A.kernel_object.splits option.splits)
+             split: kernel_object.splits option.splits)
   done
-
-lemma get_tcb_is_Some_iff_typ_at:
-  "(\<exists>y. get_tcb p s = Some y) = typ_at ATCB p s"
-  by (simp add: tcb_at_typ [symmetric] tcb_at_def)
-
-lemma case_list_cons_cong:
-  "(case xxs of [] \<Rightarrow> f | x # xs \<Rightarrow> g xxs)
- = (case xxs of [] \<Rightarrow> f | x # xs \<Rightarrow> g (x # xs))"
-  by (simp split: list.split)
 
 lemma complete_signal_integrity:
   "\<lbrace>integrity aag X st and pas_refined aag and valid_objs
-           and bound_tcb_at ((=) (Some ntfnptr)) thread
-           and K (is_subject aag thread)\<rbrace>
-     complete_signal ntfnptr thread
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+                       and bound_tcb_at ((=) (Some ntfnptr)) thread
+                       and K (is_subject aag thread)\<rbrace>
+   complete_signal ntfnptr thread
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: complete_signal_def)
   apply (rule hoare_seq_ext [OF _ get_simple_ko_sp])
-  apply (rule hoare_pre)
-  apply ((wp set_notification_respects[where auth=Receive] set_thread_state_integrity_autarch as_user_integrity_autarch
-       | wpc
-       | simp)+)[1]
-  apply clarsimp
+  apply (wpsimp wp: set_notification_respects[where auth=Receive]
+                    set_thread_state_integrity_autarch as_user_integrity_autarch)
   apply (drule_tac t="pasSubject aag" in sym)
   apply (fastforce intro!: bound_tcb_at_implies_receive)
   done
@@ -1314,8 +1086,7 @@ match_abbreviation (input) receive_ipc_base2
   in concl receive_ipc_def
   select "case_endpoint X Y Z A" (for X Y Z A)
 
-abbreviation (input) receive_ipc_base
-where
+abbreviation (input) receive_ipc_base where
   "receive_ipc_base aag thread ep epptr rights is_blocking
     \<equiv> receive_ipc_base2 thread is_blocking epptr rights ep"
 
@@ -1324,7 +1095,7 @@ lemma sym_ref_endpoint_sendD:
   assumes sym: "sym_refs (state_refs_of s)"
   and ep: "ko_at (Endpoint (SendEP l)) epptr s"
   and inl: "t \<in> set l"
-  shows "\<exists> pl. st_tcb_at ((=) (BlockedOnSend epptr pl)) t s"
+  shows "\<exists>pl. st_tcb_at ((=) (BlockedOnSend epptr pl)) t s"
 proof -
   have "(t, EPSend) \<in> state_refs_of s epptr"
     using ep inl by (force simp: state_refs_of_def dest:ko_atD)
@@ -1339,8 +1110,8 @@ proof -
 qed
 
 lemma receive_ipc_valid_ep_helper:
-  "\<lbrakk> invs s; ko_at (Endpoint (SendEP list)) epptr s \<rbrakk> \<Longrightarrow>
-   valid_ep (case tl list of [] \<Rightarrow> IdleEP | a # t \<Rightarrow> SendEP (tl list)) s"
+  "\<lbrakk> invs s; ko_at (Endpoint (SendEP list)) epptr s \<rbrakk>
+     \<Longrightarrow> valid_ep (case tl list of [] \<Rightarrow> IdleEP | a # t \<Rightarrow> SendEP (tl list)) s"
   apply (drule_tac invs_valid_objs)
   apply (drule ko_atD)
   apply (erule(1) valid_objsE)
@@ -1348,33 +1119,45 @@ lemma receive_ipc_valid_ep_helper:
   by (cases "tl list"; clarsimp simp:valid_obj_def valid_ep_def)
 
 lemma receive_ipc_sender_helper:
-  "\<lbrakk>pas_refined aag s ; kheap s thread = Some (TCB tcb) ; tcb_state tcb = BlockedOnSend ep pl\<rbrakk>
-   \<Longrightarrow> (pasObjectAbs aag thread, SyncSend, pasObjectAbs aag ep) \<in> pasPolicy aag"
+  "\<lbrakk> pas_refined aag s; kheap s thread = Some (TCB tcb); tcb_state tcb = BlockedOnSend ep pl \<rbrakk>
+     \<Longrightarrow> abs_has_auth_to aag SyncSend thread ep"
   apply (erule pas_refined_mem[rotated])
   apply (rule sta_ts)
   apply (simp add: thread_states_def tcb_states_of_state_def get_tcb_def)
   done
 
 lemma receive_ipc_sender_can_grant_helper:
-  "\<lbrakk>invs s; pas_refined aag s ; kheap s thread = Some (TCB tcb) ; tcb_state tcb = BlockedOnSend ep pl;
-    sender_can_grant pl ; aag_has_auth_to aag Receive ep\<rbrakk>
-   \<Longrightarrow> is_subject aag thread"
+  "\<lbrakk> invs s; pas_refined aag s; kheap s thread = Some (TCB tcb);
+     tcb_state tcb = BlockedOnSend ep pl; sender_can_grant pl; aag_has_auth_to aag Receive ep \<rbrakk>
+     \<Longrightarrow> is_subject aag thread"
   apply (frule pas_refined_mem[rotated,where x = "thread" and auth=Grant])
    apply (rule sta_ts)
    apply (simp add:thread_states_def tcb_states_of_state_def get_tcb_def)
   apply (frule(2) aag_wellformed_grant_Control_to_send[OF _ _ pas_refined_wellformed])
-  apply (simp add:aag_has_auth_to_Control_eq_owns)
+  apply (simp add:aag_has_Control_iff_owns)
+  done
+
+lemma complete_signal_pas_refined:
+  "\<lbrace>pas_refined aag and bound_tcb_at ((=) (Some ntfnptr)) thread\<rbrace>
+   complete_signal ntfnptr thread
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (simp add: complete_signal_def)
+  apply (rule hoare_seq_ext [OF _ get_simple_ko_sp])
+  apply (rule hoare_pre)
+  apply (wp set_simple_ko_pas_refined set_thread_state_pas_refined
+       | wpc)+
+  apply clarsimp
   done
 
 
+context Ipc_AC_1 begin
+
 lemma receive_ipc_base_pas_refined:
-  "\<lbrace>pas_refined aag and invs
-           and ko_at (Endpoint ep) epptr
-           and K (is_subject aag thread
-               \<and> (pasSubject aag, Receive, pasObjectAbs aag epptr) \<in> pasPolicy aag \<and>
-               (\<forall> auth \<in> cap_rights_to_auth rights True . aag_has_auth_to aag auth epptr))\<rbrace>
-    receive_ipc_base aag thread ep epptr rights is_blocking
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and invs and ko_at (Endpoint ep) epptr and
+    K (is_subject aag thread \<and> aag_has_auth_to aag Receive epptr \<and>
+       (\<forall>auth \<in> cap_rights_to_auth rights True . aag_has_auth_to aag auth epptr))\<rbrace>
+   receive_ipc_base aag thread ep epptr rights is_blocking
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   (* FIXME: proof structure *)
   apply (rule hoare_gen_asm)
   apply (clarsimp simp: thread_get_def cong: endpoint.case_cong)
@@ -1383,13 +1166,12 @@ lemma receive_ipc_base_pas_refined:
         | wpc | simp add: thread_get_def do_nbrecv_failed_transfer_def split del: if_split)+
         apply (rename_tac list sss data)
         apply (rule_tac Q="\<lambda>rv s. pas_refined aag s \<and> valid_mdb s \<and>
-                             (sender_can_grant data \<longrightarrow> is_subject aag (hd list)) \<and>
-                             (sender_can_grant_reply data \<longrightarrow>
-                             (AllowGrant \<in> rights \<longrightarrow> is_subject aag (hd list)) \<and>
-                             (pasSubject aag, Reply, pasObjectAbs aag (hd list)) \<in> pasPolicy aag)"
+                                  (sender_can_grant data \<longrightarrow> is_subject aag (hd list)) \<and>
+                                  (sender_can_grant_reply data \<longrightarrow>
+                                  (AllowGrant \<in> rights \<longrightarrow> is_subject aag (hd list)) \<and>
+                                  aag_has_auth_to aag Reply (hd list))"
                      in hoare_strengthen_post[rotated])
-         apply (fastforce simp: cap_auth_conferred_def pas_refined_all_auth_is_owns
-                                pas_refined_refl)
+         apply (fastforce simp: pas_refined_refl)
         apply (wp static_imp_wp do_ipc_transfer_pas_refined set_simple_ko_pas_refined
                   set_thread_state_pas_refined get_simple_ko_wp hoare_vcg_all_lift
                   hoare_vcg_imp_lift [OF set_simple_ko_get_tcb, unfolded disj_not1]
@@ -1412,8 +1194,7 @@ lemma receive_ipc_base_pas_refined:
           apply (clarsimp simp:st_tcb_at_def elim!:obj_atE)
           by (rule receive_ipc_sender_can_grant_helper)
         moreover have
-          "sender_can_grant_reply pl \<Longrightarrow>
-              (pasSubject aag, Reply, pasObjectAbs aag (hd list)) \<in> pasPolicy aag"
+          "sender_can_grant_reply pl \<Longrightarrow> aag_has_auth_to aag Reply (hd list)"
           using prems
           apply (clarsimp elim!: tcb_atE simp:tcb_at_st_tcb_at[symmetric] get_tcb_def)
           apply (frule(1) sym_ref_endpoint_sendD[OF invs_sym_refs,where t= "hd list"],force)
@@ -1436,29 +1217,15 @@ lemma receive_ipc_base_pas_refined:
        apply (rule sta_ts)
        apply (simp add:thread_states_def tcb_states_of_state_def get_tcb_def)
       apply (frule aag_wellformed_grant_Control_to_send_by_reply[OF _ _ _ pas_refined_wellformed])
-      by (force simp:aag_has_auth_to_Control_eq_owns)+
+      by (force simp:aag_has_Control_iff_owns)+
   qed
   done
 
-lemma complete_signal_pas_refined:
-  "\<lbrace>pas_refined aag and bound_tcb_at ((=) (Some ntfnptr)) thread\<rbrace>
-     complete_signal ntfnptr thread
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (simp add: complete_signal_def)
-  apply (rule hoare_seq_ext [OF _ get_simple_ko_sp])
-  apply (rule hoare_pre)
-  apply (wp set_simple_ko_pas_refined set_thread_state_pas_refined
-       | wpc)+
-  apply clarsimp
-  done
-
 lemma receive_ipc_pas_refined:
-  "\<lbrace>pas_refined aag
-         and invs
-         and K (is_subject aag thread
-              \<and> pas_cap_cur_auth aag ep_cap \<and> AllowRead \<in> cap_rights ep_cap)\<rbrace>
-     receive_ipc thread ep_cap is_blocking
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and invs and
+    K (is_subject aag thread \<and> pas_cap_cur_auth aag ep_cap \<and> AllowRead \<in> cap_rights ep_cap)\<rbrace>
+   receive_ipc thread ep_cap is_blocking
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: receive_ipc_def thread_get_def  split: cap.split)
   apply clarsimp
@@ -1479,6 +1246,8 @@ lemma receive_ipc_pas_refined:
   apply (fastforce simp: aag_cap_auth_def cap_auth_conferred_def cap_rights_to_auth_def)
   done
 
+end
+
 
 subsection \<open>@{term "integrity"}\<close>
 
@@ -1490,66 +1259,6 @@ text\<open>
   (i.e. receiver last to the IPC rendezvous or sender owns receiver).
 
 \<close>
-
-
-lemma set_extra_badge_integrity_autarch:
-  "\<lbrace>(integrity aag X st and
-         K (is_subject aag thread \<and>
-            ipc_buffer_has_auth aag thread (Some buf) \<and>
-            buffer_cptr_index + n < 2 ^ (msg_align_bits - 2)))\<rbrace>
-  set_extra_badge buf badge n
-  \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  unfolding set_extra_badge_def
-  by (wp store_word_offs_integrity_autarch)
-
-lemma transfer_caps_integrity_autarch:
-  "\<lbrace>pas_refined aag
-        and integrity aag X st
-        and valid_objs and valid_mdb
-        and (\<lambda> s. (\<forall>x\<in>set caps.
-               s \<turnstile> fst x) \<and>
-              (\<forall>x\<in>set caps.
-               cte_wp_at
-                (\<lambda>cp. fst x \<noteq> NullCap \<longrightarrow>
-                      cp = fst x)
-                (snd x) s \<and>
-               real_cte_at (snd x) s))
-        and K (is_subject aag receiver \<and> ipc_buffer_has_auth aag receiver receive_buffer \<and>
-               (\<forall>x\<in>set caps. is_subject aag (fst (snd x))) \<and> length caps < 6)\<rbrace>
-    transfer_caps mi caps endpoint receiver receive_buffer
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: transfer_caps_def)
-  apply (wpc | wp)+
-  apply (rule_tac P = "\<forall>x \<in> set dest_slots. is_subject aag (fst x)" in hoare_gen_asm)
-  apply (wp transfer_caps_loop_pres_dest cap_insert_integrity_autarch set_extra_badge_integrity_autarch [where aag = aag and thread = receiver]
-            get_receive_slots_authorised hoare_vcg_all_lift hoare_vcg_imp_lift
-       | simp add: msg_align_bits buffer_cptr_index_def msg_max_length_def cte_wp_at_caps_of_state
-       | blast)+
-  done
-
-(* FIXME: duplicate somehow *)
-lemma load_word_offs_inv[wp]:
-  "\<lbrace>P\<rbrace> load_word_offs buf off \<lbrace>\<lambda>rv. P\<rbrace>"
-  apply (simp add: load_word_offs_def do_machine_op_def split_def)
-  apply wp
-  apply clarsimp
-  apply (drule in_inv_by_hoareD[OF loadWord_inv])
-  apply simp
-  done
-
-lemma copy_mrs_integrity_autarch:
-  "\<lbrace>pas_refined aag and integrity aag X st and K (is_subject aag receiver \<and> ipc_buffer_has_auth aag receiver rbuf \<and> unat n < 2 ^ (msg_align_bits - 2))\<rbrace>
-     copy_mrs sender sbuf receiver rbuf n
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: copy_mrs_def cong: if_cong split del: if_split)
-  apply (wp mapM_wp' as_user_integrity_autarch
-            store_word_offs_integrity_autarch [where aag = aag and thread = receiver]
-       | wpc
-       | simp
-       | fastforce simp: msg_align_bits split: if_split_asm)+
-  done
 
 (* FIXME: Why was the [wp] attribute clobbered by interpretation of the Arch locale? *)
 declare as_user_thread_bound_ntfn[wp]
@@ -1565,66 +1274,92 @@ lemma lookup_extra_caps_length:
   "\<lbrace>K (valid_message_info mi)\<rbrace> lookup_extra_caps thread buf mi \<lbrace>\<lambda>rv s. length rv < 6\<rbrace>, -"
   unfolding lookup_extra_caps_def
   apply (cases buf, simp_all)
-   apply (wp mapME_length | simp add: comp_def  valid_message_info_def msg_max_extra_caps_def word_le_nat_alt)+
+   apply (wp mapME_length
+          | simp add: comp_def valid_message_info_def msg_max_extra_caps_def word_le_nat_alt)+
   done
 
 lemma get_mi_length:
-  "\<lbrace>\<top>\<rbrace> get_message_info sender \<lbrace>\<lambda>rv s. unat (mi_length rv) < 2 ^ (msg_align_bits - 2)\<rbrace>"
+  "\<lbrace>\<top>\<rbrace> get_message_info sender \<lbrace>\<lambda>rv s. unat (mi_length rv) < 2 ^ (msg_align_bits - word_size_bits)\<rbrace>"
   apply (rule hoare_post_imp [OF _ get_mi_valid'])
-  apply (clarsimp simp: valid_message_info_def msg_align_bits msg_max_length_def word_le_nat_alt)
+  apply (clarsimp simp: valid_message_info_def msg_align_bits' msg_max_length_def word_le_nat_alt)
+  done
+
+
+context Ipc_AC_1 begin
+
+lemma set_extra_badge_integrity_autarch:
+  "\<lbrace>\<lambda>s. integrity aag X st s \<and> is_subject aag thread \<and> ipc_buffer_has_auth aag thread (Some buf)
+                             \<and> buffer_cptr_index + n < 2 ^ (msg_align_bits - word_size_bits)\<rbrace>
+   set_extra_badge buf badge n
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  unfolding set_extra_badge_def
+  by (wp store_word_offs_integrity_autarch)
+
+lemma transfer_caps_integrity_autarch:
+  "\<lbrace>pas_refined aag and integrity aag X st and valid_objs and valid_mdb and
+    (\<lambda>s. (\<forall>x\<in>set caps. s \<turnstile> fst x) \<and>
+         (\<forall>x\<in>set caps. cte_wp_at (\<lambda>cp. fst x \<noteq> NullCap \<longrightarrow> cp = fst x) (snd x) s \<and>
+                       real_cte_at (snd x) s)) and
+    K (is_subject aag receiver \<and> ipc_buffer_has_auth aag receiver receive_buffer \<and>
+       (\<forall>x\<in>set caps. is_subject aag (fst (snd x))) \<and> length caps < 6)\<rbrace>
+   transfer_caps mi caps endpoint receiver receive_buffer
+   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (simp add: transfer_caps_def)
+  apply (wpc | wp)+
+    apply (rule_tac P = "\<forall>x \<in> set dest_slots. is_subject aag (fst x)" in hoare_gen_asm)
+    apply (wp transfer_caps_loop_pres_dest cap_insert_integrity_autarch
+              set_extra_badge_integrity_autarch[where thread=receiver]
+              get_receive_slots_authorised hoare_vcg_all_lift hoare_vcg_imp_lift
+           | simp add: msg_align_bits' buffer_cptr_index_def
+                       msg_max_length_def cte_wp_at_caps_of_state
+           | blast)+
   done
 
 lemma do_normal_transfer_send_integrity_autarch:
   notes lec_valid_cap[wp del]
   shows
-  "\<lbrace>pas_refined aag
-        and integrity aag X st
-        and valid_objs and valid_mdb
-        and K (is_subject aag receiver \<and>
-               ipc_buffer_has_auth aag receiver rbuf \<and>
-               (grant \<longrightarrow> is_subject aag sender))\<rbrace>
-     do_normal_transfer sender sbuf endpoint badge grant receiver rbuf
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: do_normal_transfer_def)
-  apply (wp as_user_integrity_autarch set_message_info_integrity_autarch transfer_caps_integrity_autarch
-            copy_mrs_integrity_autarch
-            copy_mrs_tcb copy_mrs_cte_wp_at lookup_extra_caps_authorised
-            lookup_extra_caps_length get_mi_length get_mi_valid'
-            hoare_vcg_conj_lift hoare_vcg_ball_lift lec_valid_cap' static_imp_wp
-       | wpc
-       | simp)+
-  done
+  "\<lbrace>pas_refined aag and integrity aag X st and valid_objs and valid_mdb and
+    K (is_subject aag receiver \<and> ipc_buffer_has_auth aag receiver rbuf
+                               \<and> (grant \<longrightarrow> is_subject aag sender))\<rbrace>
+   do_normal_transfer sender sbuf endpoint badge grant receiver rbuf
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  unfolding do_normal_transfer_def
+  by (wpsimp wp: as_user_integrity_autarch set_message_info_integrity_autarch
+                 transfer_caps_integrity_autarch copy_mrs_integrity_autarch
+                 copy_mrs_tcb copy_mrs_cte_wp_at lookup_extra_caps_authorised
+                 lookup_extra_caps_length get_mi_length get_mi_valid' static_imp_wp
+                 hoare_vcg_conj_lift hoare_vcg_ball_lift lec_valid_cap')
+
 
 crunch integrity_autarch: setup_caller_cap "integrity aag X st"
 
 lemma do_fault_transfer_integrity_autarch:
-  "\<lbrace>integrity aag X st and K (is_subject aag receiver \<and> ipc_buffer_has_auth aag receiver recv_buf) \<rbrace>
-    do_fault_transfer badge sender receiver recv_buf
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: do_fault_transfer_def split_def)
-  apply (wp as_user_integrity_autarch set_message_info_integrity_autarch set_mrs_integrity_autarch
-            thread_get_wp'
-       | wpc | simp)+
-  done
+  "\<lbrace>integrity aag X st and K (is_subject aag receiver \<and> ipc_buffer_has_auth aag receiver recv_buf)\<rbrace>
+   do_fault_transfer badge sender receiver recv_buf
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  unfolding do_fault_transfer_def split_def
+  by (wpsimp wp: as_user_integrity_autarch set_message_info_integrity_autarch
+                 set_mrs_integrity_autarch thread_get_wp')
 
 lemma do_ipc_transfer_integrity_autarch:
-  "\<lbrace>pas_refined aag
-        and integrity aag X st
-        and valid_objs and valid_mdb
-        and K (is_subject aag receiver \<and> (grant \<longrightarrow> is_subject aag sender))\<rbrace>
-     do_ipc_transfer sender ep badge grant receiver
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>pas_refined aag and integrity aag X st and valid_objs and valid_mdb and
+    K (is_subject aag receiver \<and> (grant \<longrightarrow> is_subject aag sender))\<rbrace>
+   do_ipc_transfer sender ep badge grant receiver
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: do_ipc_transfer_def)
-  apply (wp do_normal_transfer_send_integrity_autarch do_fault_transfer_integrity_autarch
-            thread_get_wp' lookup_ipc_buffer_has_auth hoare_vcg_all_lift
-       | wpc | simp | wp (once) hoare_drop_imps)+
+  apply (wpsimp wp: do_normal_transfer_send_integrity_autarch thread_get_wp'
+                    do_fault_transfer_integrity_autarch hoare_vcg_all_lift
+         | wp (once) hoare_drop_imps)+
   done
 
+end
+
+
 lemma set_thread_state_running_respects:
-  "\<lbrace>integrity aag X st
-        and (\<lambda>s. \<exists>ep. aag_has_auth_to aag Receive ep
-                   \<and> st_tcb_at (send_blocked_on ep) sender s)\<rbrace>
-     set_thread_state sender Structures_A.Running
+  "\<lbrace>integrity aag X st and
+    (\<lambda>s. \<exists>ep. aag_has_auth_to aag Receive ep \<and> st_tcb_at (send_blocked_on ep) sender s)\<rbrace>
+   set_thread_state sender Running
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: set_thread_state_def)
   apply (wpsimp wp: set_object_wp)
@@ -1632,14 +1367,13 @@ lemma set_thread_state_running_respects:
   apply (clarsimp simp: integrity_def obj_at_def st_tcb_at_def)
   apply (clarsimp dest!: get_tcb_SomeD)
   apply (rule_tac new_st=Running in tro_tcb_receive)
-  apply (auto simp: tcb_bound_notification_reset_integrity_def)
-  done
+  by (auto simp: tcb_bound_notification_reset_integrity_def)
 
 (* FIXME move *)
 lemma set_simple_ko_obj_at:
   "\<lbrace>obj_at P ptr and K (ptr \<noteq> epptr)\<rbrace>
-     set_simple_ko f epptr ep
-   \<lbrace>\<lambda>rv. obj_at P ptr\<rbrace>"
+   set_simple_ko f epptr ep
+   \<lbrace>\<lambda>_. obj_at P ptr\<rbrace>"
   apply (simp add: set_simple_ko_def set_object_def)
   apply (wp get_object_wp)
   apply (auto simp: obj_at_def)
@@ -1647,10 +1381,10 @@ lemma set_simple_ko_obj_at:
 
 (* ep is free here *)
 lemma sts_receive_Inactive_respects:
-  "\<lbrace>integrity aag X st and st_tcb_at (send_blocked_on ep) thread
-    and (\<lambda>s. \<forall>tcb. get_tcb thread s = Some tcb \<longrightarrow> call_blocked ep (tcb_state tcb))
-    and K (aag_has_auth_to aag Receive ep)\<rbrace>
-    set_thread_state thread Structures_A.thread_state.Inactive
+  "\<lbrace>integrity aag X st and st_tcb_at (send_blocked_on ep) thread and
+    (\<lambda>s. \<forall>tcb. get_tcb thread s = Some tcb \<longrightarrow> call_blocked ep (tcb_state tcb)) and
+    K (aag_has_auth_to aag Receive ep)\<rbrace>
+   set_thread_state thread Inactive
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: set_thread_state_def set_object_def get_object_def)
   apply wp
@@ -1659,29 +1393,24 @@ lemma sts_receive_Inactive_respects:
   apply (clarsimp simp: integrity_def)
   apply (drule get_tcb_SomeD)
   apply (rule_tac new_st=Inactive in tro_tcb_receive, simp_all)
-  apply (fastforce simp add: st_tcb_at_def obj_at_def)
+  apply (fastforce simp: st_tcb_at_def obj_at_def)
   done
 
-crunch pred_tcb: do_ipc_transfer "pred_tcb_at proj P t"
-  (wp: crunch_wps transfer_caps_loop_pres make_fault_message_inv simp: zipWithM_x_mapM)
-
 lemma set_untyped_cap_as_full_not_untyped:
-  "\<lbrace> P and K(\<not> is_untyped_cap cap') \<rbrace>
+  "\<lbrace>P and K (\<not> is_untyped_cap cap')\<rbrace>
    set_untyped_cap_as_full cap cap' slot
-   \<lbrace> \<lambda>rv. P\<rbrace>"
+   \<lbrace>\<lambda>_. P\<rbrace>"
   unfolding set_untyped_cap_as_full_def
   apply wp
-  apply (rule hoare_pre_cont)
+    apply (rule hoare_pre_cont)
    apply wpsimp+
   done
 
-
 lemma cap_insert_integrity_autarch_not_untyped:
-  "\<lbrace>integrity aag X st and
-     K (\<not> is_untyped_cap cap \<and> is_subject aag (fst dest_slot))\<rbrace>
+  "\<lbrace>integrity aag X st and K (\<not> is_untyped_cap cap \<and> is_subject aag (fst dest_slot))\<rbrace>
    cap_insert cap src_slot dest_slot
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  apply (simp add:cap_insert_def)
+  apply (simp add: cap_insert_def)
   apply (wp set_original_integrity_autarch cap_insert_ext_extended.list_integ_lift
             cap_insert_list_integrity update_cdt_fun_upd_integrity_autarch gets_inv
             set_cap_integrity_autarch set_untyped_cap_as_full_not_untyped assert_inv)
@@ -1692,34 +1421,31 @@ lemma cap_insert_integrity_autarch_not_untyped:
 lemma pred_tcb_atE:
   assumes hyp: "pred_tcb_at proj pred t s"
   obtains tcb where "kheap s t = Some (TCB tcb)" and " pred (proj (tcb_to_itcb tcb))"
-  using hyp by (fastforce elim:obj_atE simp:pred_tcb_at_def)
+  using hyp by (fastforce elim: obj_atE simp: pred_tcb_at_def)
 
 
 lemma set_thread_state_blocked_on_reply_respects:
-  "\<lbrace> integrity aag X st and
-       st_tcb_at (send_blocked_on ep) thread and
-       pred_tcb_at id (\<lambda>itcb. allowed_call_blocked ep (itcb_state itcb)) thread
-       and K(aag_has_auth_to aag Receive ep)\<rbrace>
-     set_thread_state thread BlockedOnReply
+  "\<lbrace>integrity aag X st and st_tcb_at (send_blocked_on ep) thread and
+    pred_tcb_at id (\<lambda>itcb. allowed_call_blocked ep (itcb_state itcb)) thread and
+    K (aag_has_auth_to aag Receive ep)\<rbrace>
+   set_thread_state thread BlockedOnReply
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (rule hoare_pre)
-  apply (simp add: set_thread_state_def set_object_def get_object_def)
-  apply wp
+   apply (simp add: set_thread_state_def set_object_def get_object_def)
+   apply wp
   apply clarsimp
   apply (erule integrity_trans)
-  apply (clarsimp simp:integrity_def dest!:get_tcb_SomeD elim!: pred_tcb_atE)
+  apply (clarsimp simp: integrity_def dest!:get_tcb_SomeD elim!: pred_tcb_atE)
   apply (rule tro_tcb_receive[where new_st=BlockedOnReply])
   by fastforce+
 
 lemma setup_caller_cap_integrity_recv:
-  "\<lbrace>integrity aag X st and valid_mdb
-       and st_tcb_at (send_blocked_on ep) sender and
-       pred_tcb_at id (\<lambda>itcb. allowed_call_blocked ep (itcb_state itcb)) sender
-      and K (aag_has_auth_to aag Receive ep \<and> is_subject aag receiver
-             \<and> (grant \<longrightarrow> is_subject aag sender))\<rbrace>
-     setup_caller_cap sender receiver grant
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and valid_mdb and st_tcb_at (send_blocked_on ep) sender and
+    pred_tcb_at id (\<lambda>itcb. allowed_call_blocked ep (itcb_state itcb)) sender and
+    K (aag_has_auth_to aag Receive ep \<and> is_subject aag receiver \<and> (grant \<longrightarrow> is_subject aag sender))\<rbrace>
+   setup_caller_cap sender receiver grant
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (rule hoare_pre)
   apply (unfold setup_caller_cap_def)
@@ -1727,34 +1453,36 @@ lemma setup_caller_cap_integrity_recv:
   by fastforce
 
 lemma pred_tcb_atI:
-  "\<lbrakk>kheap s t = Some (TCB tcb) ;pred (proj (tcb_to_itcb tcb))\<rbrakk> \<Longrightarrow> pred_tcb_at proj pred t s"
+  "\<lbrakk> kheap s t = Some (TCB tcb); pred (proj (tcb_to_itcb tcb)) \<rbrakk>
+     \<Longrightarrow> pred_tcb_at proj pred t s"
   by (fastforce simp:pred_tcb_at_def obj_at_def)
 
 (* FIXME MOVE *)
-abbreviation
-  sender_can_call :: "sender_payload \<Rightarrow> bool"
-where
+abbreviation sender_can_call :: "sender_payload \<Rightarrow> bool" where
   "sender_can_call pl \<equiv> sender_can_grant pl \<or> sender_can_grant_reply pl"
+
+
+context Ipc_AC_1 begin
+
+crunch pred_tcb: do_ipc_transfer "\<lambda>s :: det_ext state. pred_tcb_at proj P t s"
+  (wp: crunch_wps transfer_caps_loop_pres make_fault_message_inv simp: zipWithM_x_mapM)
 
 lemma receive_ipc_base_integrity:
   notes do_nbrecv_failed_transfer_def[simp]
-  shows "\<lbrace>pas_refined aag and integrity aag X st and invs
-          and ko_at (Endpoint ep) epptr
-          and K (is_subject aag receiver
-                \<and> (pasSubject aag, Receive, pasObjectAbs aag epptr) \<in> pasPolicy aag
-                \<and> (\<forall>auth \<in> cap_rights_to_auth rights True. aag_has_auth_to aag auth epptr))\<rbrace>
-          receive_ipc_base aag receiver ep epptr rights is_blocking
-         \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  shows "\<lbrace>pas_refined aag and integrity aag X st and invs and ko_at (Endpoint ep) epptr and
+          K (is_subject aag receiver \<and> aag_has_auth_to aag Receive epptr \<and>
+             (\<forall>auth \<in> cap_rights_to_auth rights True. aag_has_auth_to aag auth epptr))\<rbrace>
+         receive_ipc_base aag receiver ep epptr rights is_blocking
+         \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (clarsimp simp: thread_get_def get_thread_state_def cong: endpoint.case_cong)
   apply (rule hoare_pre)
-   apply (wp set_endpoinintegrity set_thread_state_running_respects
+   apply (wpsimp wp: set_endpoint_respects set_thread_state_running_respects
              setup_caller_cap_integrity_recv[where ep = epptr]
              do_ipc_transfer_integrity_autarch
              set_thread_state_integrity_autarch[where param_a=receiver]
              sts_receive_Inactive_respects[where ep = epptr]
-             as_user_integrity_autarch
-       | wpc | simp)+
+             as_user_integrity_autarch)
         apply (rename_tac list tcb data)
         apply (rule_tac Q="\<lambda>rv s. integrity aag X st s
                            \<and> valid_mdb s
@@ -1769,13 +1497,11 @@ lemma receive_ipc_base_integrity:
                                 allowed_call_blocked_def
                          dest!: get_tcb_SomeD
                          elim: pred_tcb_atI)
-        apply (wp do_ipc_transfer_integrity_autarch do_ipc_transfer_pred_tcb set_endpoinintegrity
-                  get_simple_ko_wp
-                  set_thread_state_integrity_autarch[where param_a=receiver]
-                  hoare_vcg_imp_lift [OF set_simple_ko_get_tcb, unfolded disj_not1]
-                  hoare_vcg_all_lift as_user_integrity_autarch
-              | wpc | simp)+
-  apply clarsimp
+        apply (wpsimp wp: do_ipc_transfer_integrity_autarch do_ipc_transfer_pred_tcb
+                          set_endpoint_respects get_simple_ko_wp
+                          set_thread_state_integrity_autarch[where param_a=receiver]
+                          hoare_vcg_imp_lift [OF set_simple_ko_get_tcb, unfolded disj_not1]
+                          hoare_vcg_all_lift as_user_integrity_autarch)+
   apply (subgoal_tac "ep_at epptr s \<and> (\<exists>auth. aag_has_auth_to aag auth epptr
                                     \<and> (auth = Receive \<or> auth = SyncSend \<or> auth = Reset))")
    prefer 2
@@ -1786,40 +1512,41 @@ lemma receive_ipc_base_integrity:
   apply (clarsimp simp: st_tcb_def2 a_type_def)
   apply (frule_tac t="hd x" in sym_ref_endpoint_sendD[OF invs_sym_refs],assumption,force)
   apply (clarsimp simp: get_tcb_def elim!: pred_tcb_atE)
-  apply (intro conjI;
-         (force elim: receive_ipc_valid_ep_helper receive_ipc_sender_can_grant_helper)?)
+  apply (intro conjI; (force elim: receive_ipc_valid_ep_helper receive_ipc_sender_can_grant_helper)?)
   apply (intro impI)
   apply (frule_tac x= "hd x" in pas_refined_mem[rotated,where auth=Call])
    apply (rule sta_ts)
    apply (simp add: thread_states_def tcb_states_of_state_def get_tcb_def)
   apply (simp add: cap_rights_to_auth_def)
-  apply (rule aag_has_auth_to_Control_eq_owns[THEN iffD1],assumption)
-  apply (erule aag_wellformed_grant_Control_to_send_by_reply[OF _ _ _ pas_refined_wellformed];force)
+  apply (rule aag_has_Control_iff_owns[THEN iffD1], assumption)
+  apply (erule aag_wellformed_grant_Control_to_send_by_reply[OF _ _ _ pas_refined_wellformed]; force)
   done
 
 lemma receive_ipc_integrity_autarch:
-  "\<lbrace>pas_refined aag and integrity aag X st and invs
-        and K (is_subject aag receiver
-            \<and> pas_cap_cur_auth aag cap \<and> AllowRead \<in> cap_rights cap)\<rbrace>
-    receive_ipc receiver cap is_blocking
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>pas_refined aag and integrity aag X st and invs and
+    K (is_subject aag receiver \<and> pas_cap_cur_auth aag cap \<and> AllowRead \<in> cap_rights cap)\<rbrace>
+   receive_ipc receiver cap is_blocking
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: receive_ipc_def split: cap.splits)
   apply clarsimp
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
   apply (rule hoare_seq_ext[OF _ gbn_sp])
   apply (case_tac ntfnptr, simp_all)
-  (* old receive case, not bound *)
+   (* old receive case, not bound *)
    apply (rule hoare_pre, wp receive_ipc_base_integrity)
-   apply (fastforce simp:aag_cap_auth_def cap_auth_conferred_def cap_rights_to_auth_def)
+   apply (fastforce simp: aag_cap_auth_def cap_auth_conferred_def cap_rights_to_auth_def)
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
   apply (case_tac "isActive ntfn", simp_all)
-  (* new ntfn-binding case *)
+   (* new ntfn-binding case *)
    apply (rule hoare_pre, wp complete_signal_integrity, clarsimp)
-   (* old receive case, bound ntfn not active *)
+  (* old receive case, bound ntfn not active *)
   apply (rule hoare_pre, wp receive_ipc_base_integrity)
-  apply (fastforce simp:aag_cap_auth_def cap_auth_conferred_def cap_rights_to_auth_def)
+  apply (fastforce simp: aag_cap_auth_def cap_auth_conferred_def cap_rights_to_auth_def)
   done
+
+end
+
 
 subsubsection\<open>Non-autarchy: the sender is running\<close>
 
@@ -1838,83 +1565,220 @@ text\<open>
 
 datatype tcb_respects_state = TRContext | TRFinal | TRFinalOrCall | TRReplyContext
 
-inductive
-  tcb_in_ipc for aag tst l' epptr ko ko'
-where
-  tii_lrefl: "\<lbrakk> l' = pasSubject aag \<rbrakk> \<Longrightarrow> tcb_in_ipc aag tst l' epptr ko ko'"
-| tii_context: "\<lbrakk> ko  = Some (TCB tcb);
-                  ko' = Some (TCB tcb');
-                  can_receive_ipc (tcb_state tcb);
-                  \<exists>ctxt'. tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb)\<rparr>;
-                  tst = TRContext\<rbrakk>
-        \<Longrightarrow> tcb_in_ipc aag tst l' epptr ko ko'"
-| tii_final: "\<lbrakk> ko  = Some (TCB tcb);
-                ko' = Some (TCB tcb');
-                receive_blocked_on epptr (tcb_state tcb);
-                \<exists>ctxt'. tcb' = tcb \<lparr> tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb)
-                                   , tcb_state := Structures_A.Running\<rparr>;
-                aag_has_auth_to aag SyncSend epptr;
-                tst = TRFinal \<or> tst = TRFinalOrCall\<rbrakk>
-         \<Longrightarrow> tcb_in_ipc aag tst l' epptr ko ko'"
-| tii_call:  "\<lbrakk> ko  = Some (TCB tcb);
-                ko' = Some (TCB tcb');
-                ep_recv_blocked epptr (tcb_state tcb);
-                \<exists>ctxt'. tcb' = tcb \<lparr> tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
-                                     tcb_state := Structures_A.Running,
-                                     tcb_caller := ReplyCap caller False R\<rparr>;
-                is_subject aag caller;
-                aag_has_auth_to aag Call epptr;
-                tst = TRFinal\<rbrakk>
-         \<Longrightarrow> tcb_in_ipc aag tst l' epptr ko ko'"
-| tii_reply:  "\<lbrakk> ko  = Some (TCB tcb);
-                ko' = Some (TCB tcb');
-                \<exists>ctxt'. tcb' = tcb \<lparr> tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
-                                     tcb_fault := None,
-                                     tcb_state := Structures_A.Running\<rparr>;
-                (pasSubject aag, Reply, l') \<in> pasPolicy aag;
-                tcb_state tcb = BlockedOnReply;
-                tst = TRFinal\<rbrakk>
-         \<Longrightarrow> tcb_in_ipc aag tst l' epptr ko ko'"
+inductive tcb_in_ipc for aag tst l' epptr ko ko' where
+  tii_lrefl:
+    "l' = pasSubject aag \<Longrightarrow> tcb_in_ipc aag tst l' epptr ko ko'"
+| tii_context:
+    "\<lbrakk> ko  = Some (TCB tcb); ko' = Some (TCB tcb'); can_receive_ipc (tcb_state tcb);
+       \<exists>ctxt'. tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb)\<rparr>; tst = TRContext \<rbrakk>
+       \<Longrightarrow> tcb_in_ipc aag tst l' epptr ko ko'"
+| tii_final:
+    "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb'); receive_blocked_on epptr (tcb_state tcb);
+       \<exists>ctxt'. tcb' = tcb\<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb), tcb_state := Running\<rparr>;
+       aag_has_auth_to aag SyncSend epptr; tst = TRFinal \<or> tst = TRFinalOrCall \<rbrakk>
+       \<Longrightarrow> tcb_in_ipc aag tst l' epptr ko ko'"
+| tii_call:
+    "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb'); ep_recv_blocked epptr (tcb_state tcb);
+       \<exists>ctxt'. tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
+                           tcb_state := Running, tcb_caller := ReplyCap caller False R\<rparr>;
+       is_subject aag caller; aag_has_auth_to aag Call epptr; tst = TRFinal \<rbrakk>
+       \<Longrightarrow> tcb_in_ipc aag tst l' epptr ko ko'"
+| tii_reply:
+    "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       \<exists>ctxt'. tcb' = tcb\<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
+                          tcb_fault := None, tcb_state := Running\<rparr>;
+       (pasSubject aag, Reply, l') \<in> pasPolicy aag; tcb_state tcb = BlockedOnReply; tst = TRFinal \<rbrakk>
+       \<Longrightarrow> tcb_in_ipc aag tst l' epptr ko ko'"
 
-lemmas tii_subject[simp] = tii_lrefl [OF refl]
+lemmas tii_subject[simp] = tii_lrefl[OF refl]
 
-definition integrity_tcb_in_ipc
-  :: "'a PAS \<Rightarrow> obj_ref set \<Rightarrow> obj_ref \<Rightarrow> obj_ref \<Rightarrow> tcb_respects_state \<Rightarrow>
-      det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool"
-where
-  "integrity_tcb_in_ipc aag X thread epptr tst st \<equiv> \<lambda>s.
-     \<not> is_subject aag thread \<and> pas_refined aag st \<and>
-     (integrity aag X st (s\<lparr>kheap := (kheap s)(thread := kheap st thread),
-                            machine_state :=
-                               (machine_state s)\<lparr>underlying_memory :=
-                                    (\<lambda>p. if p \<in> auth_ipc_buffers st thread then
-                                         underlying_memory (machine_state st) p
-                                         else underlying_memory (machine_state s) p) \<rparr>\<rparr>)
-   \<and> (tcb_in_ipc aag tst (pasObjectAbs aag thread) epptr (kheap st thread) (kheap s thread)))"
+definition integrity_tcb_in_ipc ::
+  "'a PAS \<Rightarrow> obj_ref set \<Rightarrow> obj_ref \<Rightarrow> obj_ref \<Rightarrow>
+   tcb_respects_state \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool" where
+  "integrity_tcb_in_ipc aag X thread epptr tst st \<equiv>
+   \<lambda>s. \<not> is_subject aag thread \<and> pas_refined aag st \<and>
+       integrity aag X st (s\<lparr>kheap := (kheap s)(thread := kheap st thread),
+                              machine_state :=
+                              (machine_state s)\<lparr>underlying_memory :=
+                                                (\<lambda>p. if p \<in> auth_ipc_buffers st thread
+                                                     then underlying_memory (machine_state st) p
+                                                     else underlying_memory (machine_state s) p)\<rparr>\<rparr>) \<and>
+       (tcb_in_ipc aag tst (pasObjectAbs aag thread) epptr (kheap st thread) (kheap s thread))"
 
-lemma tcb_context_no_change:
-  "\<exists>ctxt. tcb = tcb\<lparr> tcb_arch :=  arch_tcb_context_set ctxt (tcb_arch tcb)\<rparr>"
-  apply (cases tcb, clarsimp)
-  apply (case_tac tcb_arch)
-  apply (auto simp: arch_tcb_context_set_def)
+
+text \<open>The special case of fault reply need a different machinery than *_in_ipc stuff because,
+        there is no @{term underlying_memory} modification\<close>
+
+datatype tcb_respects_fault_state = TRFContext | TRFRemoveFault | TRFFinal
+
+inductive tcb_in_fault_reply for aag tst l' ko ko' where
+  tifr_lrefl: "l' = pasSubject aag \<Longrightarrow> tcb_in_fault_reply aag tst l' ko ko'"
+| tifr_context:
+    "\<lbrakk> ko = Some (TCB tcb); ko' = Some (TCB tcb');
+       \<exists>ctxt'. tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb)\<rparr>;
+       (pasSubject aag, Reply, l') \<in> pasPolicy aag;
+       tcb_state tcb = BlockedOnReply; tcb_fault tcb = Some fault; tst = TRFContext \<rbrakk>
+       \<Longrightarrow> tcb_in_fault_reply aag tst l' ko ko'"
+| tifr_remove_fault:
+    "\<lbrakk> ko  = Some (TCB tcb); ko' = Some (TCB tcb');
+       \<exists>ctxt'. tcb' = tcb \<lparr> tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb), tcb_fault := None\<rparr>;
+       (pasSubject aag, Reply, l') \<in> pasPolicy aag;
+       tcb_state tcb = BlockedOnReply; tcb_fault tcb = Some fault; tst = TRFRemoveFault \<rbrakk>
+         \<Longrightarrow> tcb_in_fault_reply aag tst l' ko ko'"
+| tifr_reply:
+    "\<lbrakk> ko  = Some (TCB tcb); ko' = Some (TCB tcb');
+       \<exists>ctxt'. tcb' = tcb \<lparr> tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
+                            tcb_fault := None, tcb_state := new_st\<rparr>;
+       new_st = Restart \<or> new_st = Inactive; (pasSubject aag, Reply, l') \<in> pasPolicy aag;
+       tcb_state tcb = BlockedOnReply; tcb_fault tcb = Some fault; tst = TRFFinal \<rbrakk>
+       \<Longrightarrow> tcb_in_fault_reply aag tst l' ko ko'"
+
+definition integrity_tcb_in_fault_reply ::
+  "'a PAS \<Rightarrow> obj_ref set \<Rightarrow> obj_ref \<Rightarrow> tcb_respects_fault_state \<Rightarrow>
+   det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool" where
+  "integrity_tcb_in_fault_reply aag X thread tst st \<equiv>
+   \<lambda>s. \<not> is_subject aag thread \<and> pas_refined aag st \<and> \<comment> \<open>more or less convenience\<close>
+       integrity aag X st (s\<lparr>kheap := (kheap s)(thread := kheap st thread)\<rparr>) \<and>
+       (tcb_in_fault_reply aag tst (pasObjectAbs aag thread) (kheap st thread) (kheap s thread))"
+
+
+
+lemma update_tcb_context_in_ipc:
+  "\<lbrakk> integrity_tcb_in_ipc aag X thread epptr TRContext st s; get_tcb thread s = Some tcb;
+     tcb' = tcb\<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb)\<rparr> \<rbrakk>
+     \<Longrightarrow> integrity_tcb_in_ipc aag X thread epptr TRContext st
+                              (s\<lparr>kheap := (kheap s)(thread \<mapsto> TCB tcb')\<rparr>)"
+  unfolding integrity_tcb_in_ipc_def
+  apply (elim conjE)
+  apply (intro conjI)
+     apply assumption+
+   apply (erule integrity_trans)
+   apply (simp cong: if_cong)
+  apply clarsimp
+  apply (erule tcb_in_ipc.cases, simp_all)
+  apply (auto intro!: tii_context[OF refl refl] dest!: get_tcb_SomeD)
   done
 
-lemma auth_ipc_buffers_mem_Write:
-  "\<lbrakk> x \<in> auth_ipc_buffers s thread; pas_refined aag s; valid_objs s; is_subject aag thread \<rbrakk>
-  \<Longrightarrow> aag_has_auth_to aag Write x"
-  apply (clarsimp simp add: auth_ipc_buffers_member_def)
-  apply (drule (1) cap_cur_auth_caps_of_state)
+
+locale Ipc_AC_2 = Ipc_AC_1 +
+  assumes store_word_offs_respects_in_ipc:
+    "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
+      K ((\<not> is_subject aag receiver \<longrightarrow> auth_ipc_buffers st receiver = ptr_range buf msg_align_bits)
+          \<and> is_aligned buf msg_align_bits \<and> r < 2 ^ (msg_align_bits - word_size_bits))\<rbrace>
+     store_word_offs buf r v
+     \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+  and set_extra_badge_respects_in_ipc[wp]:
+    "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
+      K ((pasObjectAbs aag receiver \<noteq> pasSubject aag
+          \<longrightarrow> auth_ipc_buffers st receiver = ptr_range buffer msg_align_bits) \<and>
+         is_aligned buffer msg_align_bits \<and>
+         buffer_cptr_index + n < 2 ^ (msg_align_bits - word_size_bits))\<rbrace>
+     set_extra_badge buffer badge n
+     \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+  and arch_get_sanitise_register_info_inv[wp]:
+    "arch_get_sanitise_register_info t \<lbrace>\<lambda>s :: det_ext state. P s\<rbrace>"
+  and handle_arch_fault_reply_pas_refined[wp]:
+    "handle_arch_fault_reply vmf thread x y \<lbrace>pas_refined aag\<rbrace>"
+  and set_mrs_respects_in_ipc:
+    "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
+      K ((\<not> is_subject aag receiver \<longrightarrow>
+          (case recv_buf of None \<Rightarrow> True | Some buf' \<Rightarrow> auth_ipc_buffers st receiver =
+                                                        ptr_range buf' msg_align_bits)) \<and>
+         (case recv_buf of None \<Rightarrow> True | Some buf' \<Rightarrow> is_aligned buf' msg_align_bits))\<rbrace>
+     set_mrs receiver recv_buf msgs
+     \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+  and lookup_ipc_buffer_ptr_range_in_ipc:
+    "\<lbrace>valid_objs and integrity_tcb_in_ipc aag X thread epptr tst st\<rbrace>
+     lookup_ipc_buffer True thread
+     \<lbrace>\<lambda>rv _. \<not> is_subject aag thread \<longrightarrow>
+             (case rv of None \<Rightarrow> True | Some buf' \<Rightarrow> auth_ipc_buffers st thread =
+                                                     ptr_range buf' msg_align_bits)\<rbrace>"
+  and lookup_ipc_buffer_aligned:
+    "\<lbrace>valid_objs\<rbrace>
+     lookup_ipc_buffer True thread
+     \<lbrace>\<lambda>rv _ :: det_ext state. case rv of None \<Rightarrow> True | Some buf' \<Rightarrow> is_aligned buf' msg_align_bits\<rbrace>"
+  and handle_arch_fault_reply_respects:
+    "\<lbrace>integrity aag X st and K (is_subject aag thread)\<rbrace>
+     handle_arch_fault_reply fault thread x y
+     \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  and auth_ipc_buffers_kheap_update:
+    "\<lbrakk> x \<in> auth_ipc_buffers st thread; kheap st thread = Some (TCB tcb);
+       kheap s thread = Some (TCB tcb'); tcb_ipcframe tcb = tcb_ipcframe tcb' \<rbrakk>
+       \<Longrightarrow> x \<in> auth_ipc_buffers (s\<lparr>kheap := kheap s(thread \<mapsto> TCB tcb)\<rparr>) thread"
+  and auth_ipc_buffers_machine_state_update[simp]:
+    "auth_ipc_buffers (machine_state_update f s) = auth_ipc_buffers (s :: det_ext state)"
+  and empty_slot_extended_list_integ_lift_in_ipc:
+    "\<lbrakk> \<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
+       empty_slot_ext a b
+       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace>;
+       \<And>P. empty_slot_ext a b \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>; \<And>P. empty_slot_ext a b \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace> \<rbrakk>
+       \<Longrightarrow> \<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and Q\<rbrace>
+           empty_slot_ext a b
+           \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
+  and handle_arch_fault_reply_integrity_tcb_in_fault_reply_TRFContext[wp]:
+    "handle_arch_fault_reply vmf thread x y
+     \<lbrace>integrity_tcb_in_fault_reply aag X thread TRFContext st\<rbrace>"
+begin
+
+lemma cap_insert_ext_integrity_in_ipc_autarch:
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and K (is_subject aag (fst src_slot))
+                                                      and K (is_subject aag (fst dest_slot))\<rbrace>
+   cap_insert_ext src_parent src_slot dest_slot src_p dest_p
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
+  apply (rule hoare_gen_asm)+
+  apply (simp add: integrity_tcb_in_ipc_def split del: if_split)
+  apply (unfold integrity_def)
+  apply (simp only: integrity_cdt_list_as_list_integ)
+  apply (rule hoare_lift_Pf[where f="ekheap"])
+   apply (clarsimp simp: integrity_tcb_in_ipc_def integrity_def
+                         tcb_states_of_state_def get_tcb_def
+              split del: if_split cong: if_cong)
+   including no_pre
+   apply wp
+   apply (rule hoare_vcg_conj_lift)
+    apply (simp add: list_integ_def del: split_paired_All)
+    apply (fold list_integ_def)
+    apply (wp cap_insert_list_integrity hoare_vcg_all_lift | simp | force)+
+  done
+
+lemma cap_insert_ext_integrity_in_ipc_reply:
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and
+    K (is_subject aag (fst src_slot) \<and>
+       st_tcb_at (\<lambda>st. direct_call {pasSubject aag} aag epptr st) receiver st)\<rbrace>
+   cap_insert_ext src_parent src_slot (receiver, tcb_cnode_index 3) src_p dest_p
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
+  apply (rule hoare_gen_asm)+
+  apply (simp add: integrity_tcb_in_ipc_def split del: if_split)
+  apply (unfold integrity_def)
+  apply (simp only: integrity_cdt_list_as_list_integ)
+  apply (clarsimp simp: integrity_tcb_in_ipc_def integrity_def
+                        tcb_states_of_state_def get_tcb_def
+             split del: if_split cong: if_cong)
+  apply wp
+   apply (simp add: list_integ_def del: split_paired_All)
+   apply (fold list_integ_def get_tcb_def tcb_states_of_state_def)
+   apply (wp cap_insert_list_integrity hoare_vcg_all_lift)
    apply simp
-  apply (clarsimp simp: aag_cap_auth_def cap_auth_conferred_def
-                        vspace_cap_rights_to_auth_def vm_read_write_def
-                        is_page_cap_def
-                 split: if_split_asm)
-  apply (auto dest: ipcframe_subset_page)
+   apply (simp add: list_integ_def del: split_paired_All)
+   apply (fold list_integ_def get_tcb_def tcb_states_of_state_def)
+  apply (clarsimp simp: st_tcb_at_tcb_states_of_state)
+  apply (rule conjI)
+   apply (rule cca_reply; force)
+  apply clarsimp
+  apply (erule_tac x=x in allE)+
+  apply fastforce
   done
 
+crunch pas_refined[wp]: handle_fault_reply "pas_refined aag"
+
+lemma handle_fault_reply_respects:
+  "\<lbrace>integrity aag X st and K (is_subject aag thread)\<rbrace>
+   handle_fault_reply fault thread x y
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  by (cases fault; wpsimp wp: as_user_integrity_autarch handle_arch_fault_reply_respects)
 
 lemma integrity_tcb_in_ipc_final:
-  "\<lbrakk> integrity_tcb_in_ipc aag X thread epptr TRFinal st s \<rbrakk> \<Longrightarrow> integrity aag X st s"
+  "integrity_tcb_in_ipc aag X thread epptr TRFinal st s \<Longrightarrow> integrity aag X st s"
   unfolding integrity_tcb_in_ipc_def
   apply clarsimp
   apply (erule integrity_trans)
@@ -1922,62 +1786,43 @@ lemma integrity_tcb_in_ipc_final:
   apply (rule conjI)
    apply (erule tcb_in_ipc.cases; simp)
      apply (fastforce intro!: tro_tcb_send simp: direct_send_def)
-    apply (fastforce intro!: tro_tcb_call  simp: direct_call_def)
-    apply clarsimp
+    apply (fastforce intro!: tro_tcb_call simp: direct_call_def)
+   apply clarsimp
    apply (fastforce intro!: tro_tcb_reply tcb.equality simp: direct_reply_def)
     \<comment> \<open>rm\<close>
   apply clarsimp
   apply (cases "is_subject aag thread")
    apply (rule trm_write)
    apply (solves\<open>simp\<close>)
-  \<comment> \<open>doesn't own\<close>
+    \<comment> \<open>doesn't own\<close>
   apply (erule tcb_in_ipc.cases, simp_all)[1]
     apply clarsimp
     apply (rule trm_ipc [where p' = thread])
        apply (simp add: tcb_states_of_state_def get_tcb_def)
       apply (simp add: tcb_states_of_state_def get_tcb_def)
-     apply (simp add: auth_ipc_buffers_def get_tcb_def
-      split: option.split_asm cap.split_asm arch_cap.split_asm if_split_asm  split del: if_split)
+     apply (fastforce elim: auth_ipc_buffers_kheap_update)
     apply simp
    apply clarsimp
    apply (rule trm_ipc [where p' = thread])
-      apply (simp add: tcb_states_of_state_def get_tcb_def split:thread_state.splits)
+      apply (simp add: tcb_states_of_state_def get_tcb_def split: thread_state.splits)
      apply (simp add: tcb_states_of_state_def get_tcb_def)
-    apply (simp add: auth_ipc_buffers_def get_tcb_def
-      split: option.split_asm cap.split_asm arch_cap.split_asm if_split_asm  split del: if_split)
+    apply (fastforce elim: auth_ipc_buffers_kheap_update)
    apply simp
   apply clarsimp
   apply (rule trm_ipc [where p' = thread])
-     apply (simp add: tcb_states_of_state_def get_tcb_def split:thread_state.splits)
+     apply (simp add: tcb_states_of_state_def get_tcb_def split: thread_state.splits)
     apply (simp add: tcb_states_of_state_def get_tcb_def)
-   apply (simp add: auth_ipc_buffers_def get_tcb_def
-     split: option.split_asm cap.split_asm arch_cap.split_asm if_split_asm  split del: if_split)
+   apply (fastforce elim: auth_ipc_buffers_kheap_update)
   apply simp
   done
 
-lemma update_tcb_context_in_ipc:
-  "\<lbrakk> integrity_tcb_in_ipc aag X thread epptr TRContext st s;
-     get_tcb thread s = Some tcb;
-     tcb' = tcb\<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb)\<rparr>\<rbrakk>
-     \<Longrightarrow> integrity_tcb_in_ipc aag X thread epptr TRContext st
-                              (s\<lparr>kheap := (kheap s)(thread \<mapsto> TCB tcb')\<rparr>)"
-  unfolding integrity_tcb_in_ipc_def
-  apply (elim conjE)
-  apply (intro conjI)
-    apply assumption+
-   apply (erule integrity_trans)
-   apply (simp cong: if_cong)
-  apply clarsimp
-  apply (erule tcb_in_ipc.cases, simp_all)
-   apply (auto intro!: tii_context[OF refl refl] tii_lrefl[OF refl]  tcb_context_no_change
-                dest!: get_tcb_SomeD simp: arch_tcb_context_set_def)
-  done
+end
 
 
 lemma update_tcb_state_in_ipc:
   "\<lbrakk> integrity_tcb_in_ipc aag X thread epptr TRContext st s;
-      receive_blocked_on epptr (tcb_state tcb); aag_has_auth_to aag SyncSend epptr;
-     get_tcb thread s = Some tcb; tcb' = tcb\<lparr>tcb_state := Structures_A.thread_state.Running\<rparr> \<rbrakk>
+     receive_blocked_on epptr (tcb_state tcb); aag_has_auth_to aag SyncSend epptr;
+     get_tcb thread s = Some tcb; tcb' = tcb\<lparr>tcb_state := Running\<rparr> \<rbrakk>
      \<Longrightarrow> integrity_tcb_in_ipc aag X thread epptr TRFinalOrCall st
                               (s\<lparr>kheap := (kheap s)(thread \<mapsto> TCB tcb')\<rparr>)"
   unfolding integrity_tcb_in_ipc_def
@@ -1998,8 +1843,8 @@ lemma update_tcb_state_in_ipc:
 
 lemma as_user_respects_in_ipc:
   "\<lbrace>integrity_tcb_in_ipc aag X thread epptr TRContext st\<rbrace>
-     as_user thread m
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X thread epptr TRContext st\<rbrace>"
+   as_user thread m
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X thread epptr TRContext st\<rbrace>"
   apply (simp add: as_user_def set_object_def get_object_def)
   apply (wp gets_the_wp get_wp put_wp mapM_x_wp'
        | wpc
@@ -2010,54 +1855,18 @@ lemma as_user_respects_in_ipc:
 
 lemma set_message_info_respects_in_ipc:
   "\<lbrace>integrity_tcb_in_ipc aag X thread epptr TRContext st\<rbrace>
-     set_message_info thread m
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X thread epptr TRContext st\<rbrace>"
+   set_message_info thread m
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X thread epptr TRContext st\<rbrace>"
   unfolding set_message_info_def
   by (wp as_user_respects_in_ipc)
 
-lemma mul_add_word_size_lt_msg_align_bits_ofnat:
-  "\<lbrakk> p < 2 ^ (msg_align_bits - 2); k < 4 \<rbrakk>
-   \<Longrightarrow> of_nat p * of_nat word_size + k < (2 :: obj_ref) ^ msg_align_bits"
-  unfolding word_size_def
-  apply simp
-  apply (rule is_aligned_add_less_t2n[where n=2])
-     apply (simp_all add: msg_align_bits word_bits_conv
-                          is_aligned_word_size_2[simplified word_size_def, simplified])
-  apply (erule word_less_power_trans_ofnat [where k = 2 and m=9, simplified], simp)
-  done
 
-lemmas ptr_range_off_off_mems =
-    ptr_range_add_memI [OF _ mul_word_size_lt_msg_align_bits_ofnat]
-    ptr_range_add_memI [OF _ mul_add_word_size_lt_msg_align_bits_ofnat,
-                        simplified add.assoc [symmetric]]
-
-lemma store_word_offs_respects_in_ipc:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
-     K ((\<not> is_subject aag receiver \<longrightarrow> auth_ipc_buffers st receiver = ptr_range buf msg_align_bits)
-        \<and> is_aligned buf msg_align_bits \<and> r < 2 ^ (msg_align_bits - 2))\<rbrace>
-    store_word_offs buf r v
-  \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
-  apply (simp add: store_word_offs_def storeWord_def pred_conj_def)
-  apply (rule hoare_pre)
-  apply (wp dmo_wp)
-  apply (unfold integrity_tcb_in_ipc_def)
-  apply (elim conjE)
-  apply (intro impI conjI)
-    apply assumption+
-   apply (erule integrity_trans)
-   apply (clarsimp simp:  ptr_range_off_off_mems integrity_def is_aligned_mask [symmetric]
-     cong: imp_cong )
- apply simp
- done
-
-crunch respects_in_ipc: set_extra_badge "integrity_tcb_in_ipc aag X receiver epptr TRContext st"
-  (wp: store_word_offs_respects_in_ipc)
+context Ipc_AC_2 begin
 
 lemma set_object_respects_in_ipc_autarch:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st
-          and K (is_subject aag ptr)\<rbrace>
-     set_object ptr obj
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and K (is_subject aag ptr)\<rbrace>
+   set_object ptr obj
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
   apply (simp add: integrity_tcb_in_ipc_def)
   apply (rule hoare_pre, wp)
    apply (wpsimp wp: set_object_wp)
@@ -2069,311 +1878,196 @@ lemma set_object_respects_in_ipc_autarch:
   done
 
 lemma set_cap_respects_in_ipc_autarch:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st
-          and K (is_subject aag (fst ptr))\<rbrace>
-     set_cap cap ptr
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and K (is_subject aag (fst ptr))\<rbrace>
+   set_cap cap ptr
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
   apply (simp add: set_cap_def split_def)
-  apply (wp set_object_respects_in_ipc_autarch get_object_wp
-       | wpc)+
-  apply simp
+  apply (wpsimp wp: set_object_respects_in_ipc_autarch get_object_wp)
   done
 
 lemma set_original_respects_in_ipc_autarch:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st
-          and K (is_subject aag (fst slot))\<rbrace>
-     set_original slot orig
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and K (is_subject aag (fst slot))\<rbrace>
+   set_original slot orig
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
   apply (wp set_original_wp)
   apply (clarsimp simp: integrity_tcb_in_ipc_def)
   apply (simp add: integrity_def
                    tcb_states_of_state_def get_tcb_def map_option_def
-                 split del: if_split cong: if_cong)
-  by (fastforce intro :integrity_cdt_direct)
+              split del: if_split cong: if_cong)
+  by (fastforce intro: integrity_cdt_direct)
 
 lemma update_cdt_fun_upd_respects_in_ipc_autarch:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st
-           and K (is_subject aag (fst slot))\<rbrace>
-      update_cdt (\<lambda>cdt. cdt (slot := v cdt))
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and K (is_subject aag (fst slot))\<rbrace>
+   update_cdt (\<lambda>cdt. cdt (slot := v cdt))
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
   apply (simp add: update_cdt_def set_cdt_def)
   apply wp
-  apply (clarsimp simp: integrity_tcb_in_ipc_def integrity_def
-                        tcb_states_of_state_def get_tcb_def
-             split del: if_split cong: if_cong)
-  by (fastforce intro :integrity_cdt_direct)
+  apply (simp add: integrity_tcb_in_ipc_def integrity_def tcb_states_of_state_def get_tcb_def
+             cong: if_cong split del: if_split)
+  by (fastforce intro: integrity_cdt_direct)
 
 lemma set_untyped_cap_as_full_integrity_tcb_in_ipc_autarch:
   "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
     K (is_subject aag (fst src_slot))\<rbrace>
    set_untyped_cap_as_full src_cap new_cap src_slot
-   \<lbrace>\<lambda>ya. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
-  apply(rule hoare_pre)
-  apply(clarsimp simp: set_untyped_cap_as_full_def)
-  apply(intro conjI impI)
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+  apply (rule hoare_pre)
+  apply (clarsimp simp: set_untyped_cap_as_full_def)
+  apply (intro conjI impI)
   apply (wp set_cap_respects_in_ipc_autarch | simp)+
   done
 
-
-lemma cap_insert_ext_integrity_in_ipc_autarch:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and K(is_subject aag (fst src_slot))
-        and K(is_subject aag (fst dest_slot))\<rbrace>
-      cap_insert_ext src_parent src_slot dest_slot src_p dest_p
-   \<lbrace>\<lambda>yd. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
-  apply (rule hoare_gen_asm)+
-  apply (simp add: integrity_tcb_in_ipc_def split del: if_split)
-  apply (unfold integrity_def)
-  apply (simp only: integrity_cdt_list_as_list_integ)
-  apply (rule hoare_lift_Pf[where f="ekheap"])
-   apply (clarsimp simp: integrity_tcb_in_ipc_def integrity_def
-                         tcb_states_of_state_def get_tcb_def
-              split del: if_split cong: if_cong)
-   including no_pre
-   apply wp
-   apply (rule hoare_vcg_conj_lift)
-    apply (simp add: list_integ_def del: split_paired_All)
-    apply (fold list_integ_def)
-    apply (wp cap_insert_list_integrity | simp | force)+
-  done
-
 lemma cap_inserintegrity_in_ipc_autarch:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st
-         and K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot))\<rbrace>
-     cap_insert new_cap src_slot dest_slot
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
+    K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot))\<rbrace>
+   cap_insert new_cap src_slot dest_slot
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: cap_insert_def cong: if_cong)
-  apply (rule hoare_pre)
-   apply (wp set_original_respects_in_ipc_autarch
-             set_untyped_cap_as_full_integrity_tcb_in_ipc_autarch
-             update_cdt_fun_upd_respects_in_ipc_autarch
-             set_cap_respects_in_ipc_autarch get_cap_wp
-             cap_insert_ext_integrity_in_ipc_autarch
-              | simp split del: if_split)+
+  apply (wpsimp wp: set_original_respects_in_ipc_autarch
+                    set_untyped_cap_as_full_integrity_tcb_in_ipc_autarch
+                    update_cdt_fun_upd_respects_in_ipc_autarch
+                    set_cap_respects_in_ipc_autarch get_cap_wp
+                    cap_insert_ext_integrity_in_ipc_autarch)
   done
 
 lemma transfer_caps_loop_respects_in_ipc_autarch:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st
-         and valid_objs and valid_mdb
-         and (\<lambda>s. (\<forall>slot \<in> set slots. real_cte_at slot s)
-                \<and> (\<forall>x \<in> set caps. s \<turnstile> fst x
-                                \<and> cte_wp_at (\<lambda>cp. fst x \<noteq> cap.NullCap \<longrightarrow> cp = fst x) (snd x) s
-                                \<and> real_cte_at (snd x) s))
-         and K ((\<forall>cap \<in> set caps. is_subject aag (fst (snd cap)))
-              \<and> (\<forall>slot \<in> set slots. is_subject aag (fst slot))
-              \<and> (\<not> is_subject aag receiver \<longrightarrow>
-                           auth_ipc_buffers st receiver = ptr_range buffer msg_align_bits)
-              \<and> is_aligned buffer msg_align_bits
-              \<and> n + length caps < 6 \<and> distinct slots)\<rbrace>
-     transfer_caps_loop ep buffer n caps slots mi
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and valid_objs and valid_mdb and
+    (\<lambda>s. (\<forall>slot \<in> set slots. real_cte_at slot s) \<and>
+         (\<forall>x \<in> set caps. s \<turnstile> fst x \<and> real_cte_at (snd x) s \<and>
+                         cte_wp_at (\<lambda>cp. fst x \<noteq> NullCap \<longrightarrow> cp = fst x) (snd x) s)) and
+    K ((\<forall>cap \<in> set caps. is_subject aag (fst (snd cap))) \<and>
+       (\<forall>slot \<in> set slots. is_subject aag (fst slot)) \<and>
+       (\<not> is_subject aag receiver
+        \<longrightarrow> auth_ipc_buffers st receiver = ptr_range buffer msg_align_bits) \<and>
+            is_aligned buffer msg_align_bits \<and> n + length caps < 6 \<and> distinct slots)\<rbrace>
+   transfer_caps_loop ep buffer n caps slots mi
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (wp transfer_caps_loop_pres_dest cap_inserintegrity_in_ipc_autarch
-            set_extra_badge_respects_in_ipc
-       | simp
-       | simp add: msg_align_bits buffer_cptr_index_def msg_max_length_def
-       | blast)+
+         | simp add: msg_align_bits' buffer_cptr_index_def msg_max_length_def
+         | blast)+
   apply (auto simp: cte_wp_at_caps_of_state)
   done
 
 lemma transfer_caps_respects_in_ipc:
-  "\<lbrace>pas_refined aag
-         and integrity_tcb_in_ipc aag X receiver epptr TRContext st
-         and valid_objs and valid_mdb
-         and tcb_at receiver
-         and (\<lambda>s. (\<forall>x \<in> set caps. s \<turnstile> fst x)
-                \<and> (\<forall>x \<in> set caps. cte_wp_at (\<lambda>cp. fst x \<noteq> cap.NullCap \<longrightarrow> cp = fst x) (snd x) s
-                                \<and> real_cte_at (snd x) s))
-         and K ((\<not> null caps \<longrightarrow> is_subject aag receiver)
-              \<and> (\<forall>cap \<in> set caps. is_subject aag (fst (snd cap)))
-              \<and> (\<not> is_subject aag receiver \<longrightarrow>
-                      case_option True (\<lambda>buf'. auth_ipc_buffers st receiver
-                                             = ptr_range buf' msg_align_bits) recv_buf)
-              \<and> (case_option True (\<lambda>buf'. is_aligned buf' msg_align_bits) recv_buf)
-              \<and> length caps < 6)\<rbrace>
-     transfer_caps mi caps endpoint receiver recv_buf
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
+    pas_refined aag and valid_objs and valid_mdb and tcb_at receiver and
+    (\<lambda>s. (\<forall>x \<in> set caps. s \<turnstile> fst x) \<and>
+         (\<forall>x \<in> set caps. cte_wp_at (\<lambda>cp. fst x \<noteq> NullCap \<longrightarrow> cp = fst x) (snd x) s
+                       \<and> real_cte_at (snd x) s)) and
+    K ((\<not> null caps \<longrightarrow> is_subject aag receiver) \<and> length caps < 6 \<and>
+                        (\<forall>cap \<in> set caps. is_subject aag (fst (snd cap))) \<and>
+                        (\<not> is_subject aag receiver \<longrightarrow>
+                         case_option True (\<lambda>buf'. auth_ipc_buffers st receiver =
+                                                  ptr_range buf' msg_align_bits) recv_buf) \<and>
+                        (case_option True (\<lambda>buf'. is_aligned buf' msg_align_bits) recv_buf))\<rbrace>
+   transfer_caps mi caps endpoint receiver recv_buf
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (cases recv_buf)
    apply (simp add: transfer_caps_def, wp, simp)
   apply (cases caps)
    apply (simp add: transfer_caps_def del: get_receive_slots.simps, wp, simp)
   apply (simp add: transfer_caps_def del: get_receive_slots.simps)
-  apply (wp transfer_caps_loop_respects_in_ipc_autarch
-            get_receive_slots_authorised
-            hoare_vcg_all_lift
-       | wpc
-       | rule hoare_drop_imps
-       | simp add: null_def del: get_receive_slots.simps)+
+  apply (wp transfer_caps_loop_respects_in_ipc_autarch get_receive_slots_authorised
+         | wpc | rule hoare_drop_imps | simp add: null_def del: get_receive_slots.simps)+
   done
 
 lemma copy_mrs_respects_in_ipc:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st
-        and K ((\<not> is_subject aag receiver \<longrightarrow>
-                      case_option True (\<lambda>buf'. auth_ipc_buffers st receiver
-                                             = ptr_range buf' msg_align_bits) rbuf)
-              \<and> (case_option True (\<lambda>buf'. is_aligned buf' msg_align_bits) rbuf)
-              \<and> unat n < 2 ^ (msg_align_bits - 2))\<rbrace>
-     copy_mrs sender sbuf receiver rbuf n
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
+    K ((\<not> is_subject aag receiver \<longrightarrow> case_option True (\<lambda>buf'. auth_ipc_buffers st receiver =
+                                                                ptr_range buf' msg_align_bits) rbuf) \<and>
+       (case_option True (\<lambda>buf'. is_aligned buf' msg_align_bits) rbuf) \<and>
+       unat n < 2 ^ (msg_align_bits - word_size_bits))\<rbrace>
+   copy_mrs sender sbuf receiver rbuf n
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
   unfolding copy_mrs_def
   apply (rule hoare_gen_asm)
   apply (wp as_user_respects_in_ipc store_word_offs_respects_in_ipc
-            mapM_wp'
-            hoare_vcg_const_imp_lift hoare_vcg_all_lift
-       | wpc
-       | fastforce split: if_split_asm)+
+            mapM_wp' hoare_vcg_const_imp_lift hoare_vcg_all_lift
+         | wpc | fastforce split: if_split_asm)+
   done
 
 lemma do_normal_transfer_respects_in_ipc:
   notes lec_valid_cap[wp del]
   shows
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st
-         and pas_refined aag
-         and valid_objs and valid_mdb
-         and st_tcb_at can_receive_ipc receiver
-         and (\<lambda>s. grant \<longrightarrow> is_subject aag sender
-                         \<and> is_subject aag receiver)
-         and K ((\<not> is_subject aag receiver \<longrightarrow>
-                      (case recv_buf of None \<Rightarrow> True
-                                      | Some buf' \<Rightarrow> auth_ipc_buffers st receiver
-                                                   = ptr_range buf' msg_align_bits)) \<and>
-                (case recv_buf of None \<Rightarrow> True | Some buf' \<Rightarrow> is_aligned buf' msg_align_bits))\<rbrace>
-     do_normal_transfer sender sbuf epopt badge grant receiver recv_buf
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and pas_refined aag and
+    valid_objs and valid_mdb and st_tcb_at can_receive_ipc receiver and
+    (\<lambda>s. grant \<longrightarrow> is_subject aag sender \<and> is_subject aag receiver) and
+    K ((\<not> is_subject aag receiver \<longrightarrow>
+        (case recv_buf of None \<Rightarrow> True | Some buf' \<Rightarrow> auth_ipc_buffers st receiver =
+                                                      ptr_range buf' msg_align_bits)) \<and>
+       (case recv_buf of None \<Rightarrow> True | Some buf' \<Rightarrow> is_aligned buf' msg_align_bits))\<rbrace>
+   do_normal_transfer sender sbuf epopt badge grant receiver recv_buf
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
   apply (simp add: do_normal_transfer_def)
-  apply (wp as_user_respects_in_ipc set_message_info_respects_in_ipc
-            transfer_caps_respects_in_ipc copy_mrs_respects_in_ipc get_mi_valid'
-            lookup_extra_caps_authorised lookup_extra_caps_length get_mi_length
-            hoare_vcg_const_Ball_lift hoare_vcg_conj_lift_R hoare_vcg_const_imp_lift
-            lec_valid_cap'
-       | rule hoare_drop_imps
-       | simp)+
+  apply (wpsimp wp: as_user_respects_in_ipc set_message_info_respects_in_ipc
+            transfer_caps_respects_in_ipc copy_mrs_respects_in_ipc get_mi_valid' get_mi_length
+            lookup_extra_caps_authorised lookup_extra_caps_length hoare_vcg_const_Ball_lift
+            hoare_vcg_conj_lift_R hoare_vcg_const_imp_lift lec_valid_cap'
+         | rule hoare_drop_imps)+
   apply (auto simp: null_def intro: st_tcb_at_tcb_at)
   done
 
-lemma set_mrs_respects_in_ipc:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
-    K ((\<not> is_subject aag receiver \<longrightarrow> (case recv_buf of None \<Rightarrow> True | Some buf' \<Rightarrow> auth_ipc_buffers st receiver = ptr_range buf' msg_align_bits)) \<and>
-       (case recv_buf of None \<Rightarrow> True | Some buf' \<Rightarrow> is_aligned buf' msg_align_bits))\<rbrace>
-     set_mrs receiver recv_buf msgs
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
-  unfolding set_mrs_def set_object_def get_object_def
-  apply (rule hoare_gen_asm)
-  apply (wp mapM_x_wp' store_word_offs_respects_in_ipc
-       | wpc
-       | simp split del: if_split add: zipWithM_x_mapM_x split_def)+
-   apply (clarsimp simp add: set_zip nth_append simp: msg_align_bits msg_max_length_def
-                   split: if_split_asm)
-   apply (simp add: msg_registers_def msgRegisters_def upto_enum_def fromEnum_def enum_register)
-   apply arith
-   apply simp
-   apply wp+
-  apply (clarsimp simp: arch_tcb_set_registers_def)
-  by (rule update_tcb_context_in_ipc [unfolded fun_upd_def]; fastforce)
-
 lemma do_fault_transfer_respects_in_ipc:
   "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
-    K ((\<not> is_subject aag receiver \<longrightarrow> (case recv_buf of None \<Rightarrow> True | Some buf' \<Rightarrow> auth_ipc_buffers st receiver = ptr_range buf' msg_align_bits)) \<and>
+    K ((\<not> is_subject aag receiver \<longrightarrow>
+        (case recv_buf of None \<Rightarrow> True | Some buf' \<Rightarrow> auth_ipc_buffers st receiver =
+                                                      ptr_range buf' msg_align_bits)) \<and>
        (case recv_buf of None \<Rightarrow> True | Some buf' \<Rightarrow> is_aligned buf' msg_align_bits))\<rbrace>
-    do_fault_transfer badge sender receiver recv_buf
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+   do_fault_transfer badge sender receiver recv_buf
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
   apply (simp add: do_fault_transfer_def split_def)
   apply (wp as_user_respects_in_ipc set_message_info_respects_in_ipc set_mrs_respects_in_ipc
-       | wpc
-       | simp
-       | rule hoare_drop_imps)+
-  done
-
-lemma lookup_ipc_buffer_ptr_range_in_ipc:
-  "\<lbrace>valid_objs and integrity_tcb_in_ipc aag X thread epptr tst st\<rbrace>
-  lookup_ipc_buffer True thread
-  \<lbrace>\<lambda>rv s. \<not> is_subject aag thread \<longrightarrow>
-         (case rv of None \<Rightarrow> True
-                   | Some buf' \<Rightarrow> auth_ipc_buffers st thread = ptr_range buf' msg_align_bits) \<rbrace>"
-  unfolding lookup_ipc_buffer_def
-  apply (rule hoare_pre)
-  apply (wp get_cap_wp thread_get_wp' | wpc)+
-  apply (clarsimp simp: cte_wp_at_caps_of_state ipc_buffer_has_auth_def get_tcb_ko_at [symmetric])
-  apply (frule caps_of_state_tcb_cap_cases [where idx = "tcb_cnode_index 4"])
-   apply (simp add: dom_tcb_cap_cases)
-  apply (clarsimp simp: auth_ipc_buffers_def get_tcb_ko_at [symmetric] integrity_tcb_in_ipc_def)
-  apply (drule get_tcb_SomeD)
-  apply (erule(1) valid_objsE)
-  apply (clarsimp simp: valid_obj_def valid_tcb_def valid_ipc_buffer_cap_def case_bool_if
-                 split: if_split_asm)
-  apply (erule tcb_in_ipc.cases; clarsimp simp: get_tcb_def vm_read_write_def)
-  done
-
-lemma lookup_ipc_buffer_aligned:
-  "\<lbrace>valid_objs\<rbrace>
-  lookup_ipc_buffer True thread
-  \<lbrace>\<lambda>rv s. (case rv of None \<Rightarrow> True | Some buf' \<Rightarrow> is_aligned buf' msg_align_bits) \<rbrace>"
-  unfolding lookup_ipc_buffer_def
-  apply (rule hoare_pre)
-   apply (wp get_cap_wp thread_get_wp' | wpc)+
-  apply (clarsimp simp: cte_wp_at_caps_of_state get_tcb_ko_at [symmetric])
-  apply (frule caps_of_state_tcb_cap_cases [where idx = "tcb_cnode_index 4"])
-   apply (simp add: dom_tcb_cap_cases)
-  apply (frule (1) caps_of_state_valid_cap)
-  apply (clarsimp simp: valid_cap_simps cap_aligned_def)
-  apply (erule aligned_add_aligned)
-    apply (rule is_aligned_andI1)
-    apply (drule (1) valid_tcb_objs)
-    apply (clarsimp simp: valid_obj_def valid_tcb_def valid_ipc_buffer_cap_def
-                   split: if_splits)
-  apply (rule order_trans [OF _ pbfs_atleast_pageBits])
-  apply (simp add: msg_align_bits pageBits_def)
+         | wpc | simp | rule hoare_drop_imps)+
   done
 
 lemma do_ipc_transfer_respects_in_ipc:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st
-         and pas_refined aag
-         and valid_objs and valid_mdb
-         and st_tcb_at can_receive_ipc receiver
-         and (\<lambda>s. grant \<longrightarrow> is_subject aag sender
-                         \<and> is_subject aag receiver)
-         \<rbrace>
-     do_ipc_transfer sender epopt badge grant receiver
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and pas_refined aag and
+    valid_objs and valid_mdb and st_tcb_at can_receive_ipc receiver and
+    (\<lambda>s. grant \<longrightarrow> is_subject aag sender \<and> is_subject aag receiver)\<rbrace>
+   do_ipc_transfer sender epopt badge grant receiver
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
   apply (simp add: do_ipc_transfer_def)
   apply (wp do_normal_transfer_respects_in_ipc do_fault_transfer_respects_in_ipc
-            lookup_ipc_buffer_ptr_range_in_ipc lookup_ipc_buffer_aligned
-            hoare_vcg_conj_lift
-       | wpc
-       | simp
-       | rule hoare_drop_imps)+
+            lookup_ipc_buffer_ptr_range_in_ipc lookup_ipc_buffer_aligned hoare_vcg_conj_lift
+         | wpc | simp | rule hoare_drop_imps)+
   apply (auto intro: st_tcb_at_tcb_at)
   done
+
+end
 
 
 lemma sts_ext_running_noop:
   "\<lbrace>P and st_tcb_at (runnable) receiver\<rbrace> set_thread_state_ext receiver \<lbrace>\<lambda>_. P\<rbrace>"
   apply (simp add: set_thread_state_ext_def get_thread_state_def thread_get_def
-        | wp set_scheduler_action_wp)+
+         | wp set_scheduler_action_wp)+
   apply (clarsimp simp add: st_tcb_at_def obj_at_def get_tcb_def)
   done
 
 lemma set_thread_state_running_respects_in_ipc:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and st_tcb_at(receive_blocked_on epptr) receiver and K(aag_has_auth_to aag SyncSend epptr)\<rbrace>
-     set_thread_state receiver Structures_A.thread_state.Running
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRFinalOrCall st\<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
+    st_tcb_at(receive_blocked_on epptr) receiver and K (aag_has_auth_to aag SyncSend epptr)\<rbrace>
+   set_thread_state receiver Running
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRFinalOrCall st\<rbrace>"
   apply (simp add: set_thread_state_def)
   apply (wpsimp wp: set_object_wp sts_ext_running_noop)
   apply (auto simp: st_tcb_at_def obj_at_def get_tcb_def
                     get_tcb_rev update_tcb_state_in_ipc
-              cong: if_cong
-              elim: update_tcb_state_in_ipc[unfolded fun_upd_def])
+              cong: if_cong elim: update_tcb_state_in_ipc[unfolded fun_upd_def])
   done
 
-lemma set_endpoinintegrity_in_ipc:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st
-          and K (aag_has_auth_to aag SyncSend epptr)\<rbrace>
-    set_endpoint epptr ep'
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
+
+context Ipc_AC_2 begin
+
+lemma set_endpoint_integrity_in_ipc:
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and K (aag_has_auth_to aag SyncSend epptr)\<rbrace>
+   set_endpoint epptr ep'
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRContext st\<rbrace>"
   apply (simp add: set_simple_ko_def set_object_def)
   apply (wp get_object_wp)
-  apply (clarsimp split: Structures_A.kernel_object.splits
+  apply (clarsimp split: kernel_object.splits
                   simp: obj_at_def is_tcb is_ep integrity_tcb_in_ipc_def
                         partial_inv_def a_type_def)
   apply (intro impI conjI)
@@ -2386,20 +2080,9 @@ lemma set_endpoinintegrity_in_ipc:
   apply (fastforce intro: tro_ep)
   done
 
-(* FIXME: move *)
-lemma valid_ep_recv_dequeue:
-  "\<lbrakk> ko_at (Endpoint (Structures_A.endpoint.RecvEP (t # ts))) epptr s;
-     valid_objs s; sym_refs (state_refs_of s) \<rbrakk>
-     \<Longrightarrow> valid_ep (case ts of [] \<Rightarrow> Structures_A.endpoint.IdleEP
-                            | b # bs \<Rightarrow> Structures_A.endpoint.RecvEP ts) s"
-  unfolding valid_objs_def valid_obj_def valid_ep_def obj_at_def
-  apply (drule bspec)
-  apply (auto split: list.splits)
-  done
-
 lemma integrity_tcb_in_ipc_refl:
-  "\<lbrakk> st_tcb_at can_receive_ipc receiver s; \<not> is_subject aag receiver; pas_refined aag s\<rbrakk>
-  \<Longrightarrow> integrity_tcb_in_ipc aag X receiver epptr TRContext s s"
+  "\<lbrakk> st_tcb_at can_receive_ipc receiver s; \<not> is_subject aag receiver; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> integrity_tcb_in_ipc aag X receiver epptr TRContext s s"
   unfolding integrity_tcb_in_ipc_def
   apply (clarsimp simp: st_tcb_def2)
   apply (rule tii_context [OF get_tcb_SomeD get_tcb_SomeD], assumption+)
@@ -2407,17 +2090,8 @@ lemma integrity_tcb_in_ipc_refl:
    apply simp
   done
 
-(* stronger *)
-(* MOVE *)
-lemma ep_queued_st_tcb_at'':
-  "\<And>P. \<lbrakk>ko_at (Endpoint ep) ptr s; (t, rt) \<in> ep_q_refs_of ep;
-         valid_objs s; sym_refs (state_refs_of s);
-         \<And>pl pl'. (rt = EPSend \<and> P (Structures_A.BlockedOnSend ptr pl)) \<or>
-                  (rt = EPRecv \<and> P (Structures_A.BlockedOnReceive ptr pl')) \<rbrakk>
-    \<Longrightarrow> st_tcb_at P t s"
-  apply (case_tac ep, simp_all)
-  apply (frule (1) sym_refs_ko_atD, fastforce simp: st_tcb_at_def obj_at_def refs_of_rev)+
-  done
+end
+
 
 subsubsection \<open>Inserting the reply cap\<close>
 
@@ -2426,55 +2100,37 @@ lemma integrity_tcb_in_ipc_no_call:
    \<Longrightarrow> integrity_tcb_in_ipc aag X receiver epptr TRFinal st s"
   unfolding integrity_tcb_in_ipc_def tcb_in_ipc.simps by clarsimp
 
+
+context Ipc_AC_2 begin
+
 lemma set_original_respects_in_ipc_reply:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st
-          and K(st_tcb_at (\<lambda>st. direct_call {pasSubject aag} aag epptr st) receiver st)\<rbrace>
-     set_original (receiver, tcb_cnode_index 3) orig
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and
+    K (st_tcb_at (\<lambda>st. direct_call {pasSubject aag} aag epptr st) receiver st)\<rbrace>
+   set_original (receiver, tcb_cnode_index 3) orig
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
   apply (wp set_original_wp)
   apply (clarsimp simp: integrity_tcb_in_ipc_def)
-  apply (simp add: integrity_def tcb_states_of_state_def get_tcb_def
-              split del: if_split cong: if_cong)
+  apply (simp add: integrity_def tcb_states_of_state_def get_tcb_def)
   apply (fold get_tcb_def tcb_states_of_state_def)
-  apply (clarsimp simp:st_tcb_at_tcb_states_of_state)
+  apply (clarsimp simp: st_tcb_at_tcb_states_of_state)
   apply (rule integrity_cdt_change_allowed)
   apply (rule cca_reply; force)
   done
 
-lemma cap_insert_ext_integrity_in_ipc_reply:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st
-       and K(is_subject aag (fst src_slot)
-           \<and> st_tcb_at (\<lambda>st. direct_call {pasSubject aag} aag epptr st) receiver st)\<rbrace>
-    cap_insert_ext src_parent src_slot (receiver, tcb_cnode_index 3) src_p dest_p
-   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
-  apply (rule hoare_gen_asm)+
-  apply (simp add: integrity_tcb_in_ipc_def split del: if_split)
-  apply (unfold integrity_def)
-  apply (simp only: integrity_cdt_list_as_list_integ)
-  apply (clarsimp simp: integrity_tcb_in_ipc_def integrity_def
-                        tcb_states_of_state_def get_tcb_def
-             split del: if_split cong: if_cong)
-  apply wp
-   apply (simp add: list_integ_def del: split_paired_All)
-   apply (fold list_integ_def get_tcb_def tcb_states_of_state_def)
-   apply (wp cap_insert_list_integrity)
-   apply simp
-   apply (simp add: list_integ_def del: split_paired_All)
-   apply (fold list_integ_def get_tcb_def tcb_states_of_state_def)
-   apply (clarsimp simp: st_tcb_at_tcb_states_of_state)
-   apply (rule cca_reply; force)
-  done
+end
+
 
 lemma update_cdt_wp:
-  "\<lbrace>\<lambda>s.  P (s\<lparr> cdt := f (cdt s) \<rparr>)\<rbrace>
-     update_cdt f
-   \<lbrace>\<lambda>_. P \<rbrace>"
+  "\<lbrace>\<lambda>s. P (s\<lparr>cdt := f (cdt s)\<rparr>)\<rbrace> update_cdt f \<lbrace>\<lambda>_. P\<rbrace>"
   by (wpsimp simp: update_cdt_def set_cdt_def)
 
+
+context Ipc_AC_2 begin
+
 lemma update_cdt_reply_in_ipc:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st
-       and K(st_tcb_at (\<lambda>st. direct_call {pasSubject aag} aag epptr st) receiver st)\<rbrace>
-    update_cdt (\<lambda>cdt. cdt ((receiver, tcb_cnode_index 3) := val cdt))
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and
+    K(st_tcb_at (\<lambda>st. direct_call {pasSubject aag} aag epptr st) receiver st)\<rbrace>
+   update_cdt (\<lambda>cdt. cdt ((receiver, tcb_cnode_index 3) := val cdt))
    \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
   apply (wp update_cdt_wp)
   apply (clarsimp simp: integrity_tcb_in_ipc_def)
@@ -2486,17 +2142,19 @@ lemma update_cdt_reply_in_ipc:
   apply (rule cca_reply; force)
   done
 
+end
+
+
 (* FIXME: move to NondetMonad *)
 lemma spec_valid_direct:
-  "\<lbrakk> P s \<Longrightarrow> s \<turnstile> \<lbrace> \<top> \<rbrace> f \<lbrace> Q \<rbrace> \<rbrakk> \<Longrightarrow> s \<turnstile> \<lbrace>P\<rbrace> f \<lbrace> Q \<rbrace>"
+  "(P s \<Longrightarrow> s \<turnstile> \<lbrace>\<top>\<rbrace> f \<lbrace> Q \<rbrace>) \<Longrightarrow> s \<turnstile> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   by (simp add: spec_valid_def valid_def)
 
 lemma set_cap_respects_in_ipc_reply:
-   "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRFinalOrCall st
-     and K(st_tcb_at (\<lambda>st. direct_call {pasSubject aag} aag epptr st) receiver st
-           \<and> is_subject aag caller)\<rbrace>
-      set_cap (ReplyCap caller False R) (receiver, tcb_cnode_index 3)
-    \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRFinal st\<rbrace>"
+   "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRFinalOrCall st and
+     K (st_tcb_at (direct_call {pasSubject aag} aag epptr) receiver st \<and> is_subject aag caller)\<rbrace>
+    set_cap (ReplyCap caller False R) (receiver, tcb_cnode_index 3)
+    \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRFinal st\<rbrace>"
   unfolding set_cap_def
   apply simp
   apply (rule hoare_seq_ext[OF _ get_object_sp])
@@ -2512,36 +2170,39 @@ lemma set_cap_respects_in_ipc_reply:
   by (erule tcb_in_ipc.cases; (force intro:tii_call))
 
 
+context Ipc_AC_2 begin
+
 lemma cap_insert_reply_cap_respects_in_ipc:
-  "\<lbrace> integrity_tcb_in_ipc aag X receiver epptr TRFinalOrCall st and
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRFinalOrCall st and
     K (st_tcb_at (direct_call {pasSubject aag} aag epptr) receiver st \<and>
        is_subject aag caller \<and> is_subject aag (fst master_slot))\<rbrace>
-    cap_insert
-          (ReplyCap caller False R)
-          master_slot (receiver, tcb_cnode_index 3)
+   cap_insert (ReplyCap caller False R) master_slot (receiver, tcb_cnode_index 3)
    \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRFinal st\<rbrace>"
   unfolding cap_insert_def
-  apply (rule hoare_pre)
-  apply (wp add:set_original_respects_in_ipc_reply)
-  apply simp
-  apply (wp cap_insert_ext_integrity_in_ipc_reply update_cdt_reply_in_ipc
-            set_cap_respects_in_ipc_reply set_untyped_cap_as_full_not_untyped get_cap_wp)+
-  by fastforce
+  by (wpsimp wp: set_original_respects_in_ipc_reply cap_insert_ext_integrity_in_ipc_reply
+                 update_cdt_reply_in_ipc set_cap_respects_in_ipc_reply
+                 set_untyped_cap_as_full_not_untyped get_cap_wp)
 
 lemma set_scheduler_action_respects_in_ipc_autarch:
   "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>
-    set_scheduler_action action
+   set_scheduler_action action
    \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
    unfolding set_scheduler_action_def
    by (wpsimp simp: integrity_tcb_in_ipc_def integrity_def tcb_states_of_state_def get_tcb_def)
+
+end
+
 
 lemma exists_cons_append:
   "\<exists>xs. xs @ ys = zs \<Longrightarrow> \<exists>xs. xs @ ys = z # zs"
   by auto
 
+
+context Ipc_AC_2 begin
+
 lemma tcb_sched_action_respects_in_ipc_autarch:
   "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>
-      tcb_sched_action tcb_sched_enqueue target
+   tcb_sched_action tcb_sched_enqueue target
    \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
   apply (simp add: tcb_sched_action_def)
   apply wp
@@ -2552,28 +2213,25 @@ lemma tcb_sched_action_respects_in_ipc_autarch:
   apply (fastforce intro: exists_cons_append)
   done
 
-
-crunches possible_switch_to, set_thread_state for respects_in_ipc_autarch: "integrity_tcb_in_ipc aag X receiver epptr ctxt st"
-  (wp: tcb_sched_action_respects_in_ipc_autarch ignore:tcb_sched_action )
+crunches possible_switch_to, set_thread_state
+  for respects_in_ipc_autarch: "integrity_tcb_in_ipc aag X receiver epptr ctxt st"
+  (wp: tcb_sched_action_respects_in_ipc_autarch ignore: tcb_sched_action)
 
 lemma setup_caller_cap_respects_in_ipc_reply:
-  "\<lbrace> integrity_tcb_in_ipc aag X receiver epptr TRFinalOrCall st
-      and K (is_subject aag sender \<and> st_tcb_at (direct_call {pasSubject aag} aag epptr) receiver st) \<rbrace>
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRFinalOrCall st and
+    K (is_subject aag sender \<and> st_tcb_at (direct_call {pasSubject aag} aag epptr) receiver st)\<rbrace>
    setup_caller_cap sender receiver grant
-   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRFinal st \<rbrace>"
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRFinal st\<rbrace>"
   unfolding setup_caller_cap_def
   by (wpsimp wp: cap_insert_reply_cap_respects_in_ipc set_thread_state_respects_in_ipc_autarch)
 
-
 lemma send_ipc_integrity_autarch:
-  "\<lbrace>integrity aag X st and pas_refined aag
-          and invs
-          and is_subject aag \<circ> cur_thread
-          and obj_at (\<lambda>ep. can_grant \<longrightarrow> (\<forall>r \<in> refs_of ep. snd r = EPRecv \<longrightarrow> is_subject aag (fst r))) epptr
-          and K (is_subject aag sender \<and> aag_has_auth_to aag SyncSend epptr \<and>
-                (can_grant_reply \<longrightarrow> aag_has_auth_to aag Call epptr))\<rbrace>
-     send_ipc block call badge can_grant can_grant_reply sender epptr
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and invs and is_subject aag \<circ> cur_thread and
+    obj_at (\<lambda>ep. can_grant \<longrightarrow> (\<forall>r \<in> refs_of ep. snd r = EPRecv \<longrightarrow> is_subject aag (fst r))) epptr and
+    K (is_subject aag sender \<and> aag_has_auth_to aag SyncSend epptr \<and>
+       (can_grant_reply \<longrightarrow> aag_has_auth_to aag Call epptr))\<rbrace>
+   send_ipc block call badge can_grant can_grant_reply sender epptr
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: send_ipc_def)
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
@@ -2581,14 +2239,12 @@ lemma send_ipc_integrity_autarch:
     \<comment> \<open>IdleEP\<close>
     apply simp
     apply (rule hoare_pre)
-     apply (wp set_endpoinintegrity  set_thread_state_integrity_autarch
-                 | wpc | simp)+
+     apply (wp set_endpoint_respects  set_thread_state_integrity_autarch | wpc | simp)+
     apply (fastforce simp: obj_at_def is_ep) \<comment> \<open>ep_at and has_auth\<close>
    \<comment> \<open>SendEP\<close>
    apply simp
    apply (rule hoare_pre)
-    apply (wp set_endpoinintegrity  set_thread_state_integrity_autarch
-               | wpc | simp)+
+    apply (wp set_endpoint_respects  set_thread_state_integrity_autarch | wpc | simp)+
    apply (fastforce simp: obj_at_def is_ep) \<comment> \<open>ep_at and has_auth\<close>
   \<comment> \<open>WaitingEP\<close>
   apply (rename_tac list)
@@ -2597,15 +2253,14 @@ lemma send_ipc_integrity_autarch:
    apply clarsimp
    apply (rule hoare_pre)
     apply (wp setup_caller_cap_integrity_autarch set_thread_state_integrity_autarch thread_get_wp'
-                  | wpc)+
-          apply (rule_tac Q="\<lambda>rv s. integrity aag X st s\<and> (can_grant \<longrightarrow> is_subject aag (hd list))"
+           | wpc)+
+          apply (rule_tac Q="\<lambda>rv s. integrity aag X st s \<and> (can_grant \<longrightarrow> is_subject aag (hd list))"
                        in hoare_strengthen_post[rotated])
           apply simp+
           apply (wp set_thread_state_integrity_autarch thread_get_wp'
                     do_ipc_transfer_integrity_autarch
-                    hoare_vcg_all_lift hoare_drop_imps set_endpoinintegrity
-                   | wpc | simp add: get_thread_state_def split del: if_split
-                                del: hoare_True_E_R)+
+                    hoare_vcg_all_lift hoare_drop_imps set_endpoint_respects
+                 | wpc | simp add: get_thread_state_def split del: if_split del: hoare_True_E_R)+
    apply (fastforce simp: a_type_def obj_at_def is_ep elim: send_ipc_valid_ep_helper)
   \<comment> \<open>we don't own head of queue\<close>
   apply clarsimp
@@ -2614,28 +2269,30 @@ lemma send_ipc_integrity_autarch:
   apply (rule hoare_pre)
    apply (wpc, wp)
    apply (rename_tac list s receiver queue)
-   apply (rule_tac Q =  "\<lambda>_ s'. integrity aag X st s \<and>
-                         integrity_tcb_in_ipc aag X receiver epptr TRFinal s s'" in hoare_post_imp)
+   apply (rule_tac Q="\<lambda>_ s'. integrity aag X st s \<and>
+                             integrity_tcb_in_ipc aag X receiver epptr TRFinal s s'" in hoare_post_imp)
     apply (fastforce dest!: integrity_tcb_in_ipc_final elim!: integrity_trans)
    apply (wp setup_caller_cap_respects_in_ipc_reply
              set_thread_state_respects_in_ipc_autarch[where param_b = Inactive]
              hoare_vcg_if_lift static_imp_wp possible_switch_to_respects_in_ipc_autarch
              set_thread_state_running_respects_in_ipc do_ipc_transfer_respects_in_ipc thread_get_inv
-             set_endpoinintegrity_in_ipc
+             set_endpoint_integrity_in_ipc
           | wpc
           | strengthen integrity_tcb_in_ipc_no_call
           | wp hoare_drop_imps
           | simp add:get_thread_state_def)+
-
-  apply (clarsimp intro:integrity_tcb_in_ipc_refl)
+  apply (clarsimp intro: integrity_tcb_in_ipc_refl)
   apply (frule_tac t=x in sym_ref_endpoint_recvD[OF invs_sym_refs],assumption,simp)
-  apply (clarsimp simp:st_tcb_at_tcb_states_of_state_eq st_tcb_at_tcb_states_of_state direct_call_def)
+  apply (clarsimp simp: st_tcb_at_tcb_states_of_state_eq st_tcb_at_tcb_states_of_state direct_call_def)
   apply (subgoal_tac "\<not> can_grant")
    apply (force intro!: integrity_tcb_in_ipc_refl
                   simp: st_tcb_at_tcb_states_of_state
                   elim: send_ipc_valid_ep_helper)
-  apply (force elim:obj_at_ko_atE)
+  apply (force elim: obj_at_ko_atE)
   done
+
+end
+
 
 section\<open>Faults\<close>
 
@@ -2644,121 +2301,80 @@ lemma valid_tcb_fault_update:
   "\<lbrakk> valid_tcb p t s; valid_fault fault \<rbrakk> \<Longrightarrow> valid_tcb p (t\<lparr>tcb_fault := Some fault\<rparr>) s"
   by (simp add: valid_tcb_def ran_tcb_cap_cases)
 
-lemma thread_set_fault_pas_refined:
-  "\<lbrace>pas_refined aag\<rbrace>
-     thread_set (tcb_fault_update (\<lambda>_. Some fault)) thread
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (wp send_ipc_pas_refined thread_set_pas_refined
-            thread_set_refs_trivial thread_set_obj_at_impossible
-       | simp)+
-  done
 
-lemma owns_ep_owns_receivers':
-  "\<lbrakk> (\<forall>auth. aag_has_auth_to aag auth epptr); pas_refined aag s; valid_objs s;
-     sym_refs (state_refs_of s); ko_at (Endpoint ep) epptr s; (t, EPRecv) \<in> ep_q_refs_of ep\<rbrakk>
-  \<Longrightarrow> is_subject aag t"
-  apply (drule (1) ep_rcv_queued_st_tcb_at [where P = "receive_blocked_on epptr"])
-      apply clarsimp
-     apply clarsimp
-    apply clarsimp
-   apply (rule refl)
-  apply (drule st_tcb_at_to_thread_states)
-  apply (clarsimp simp: receive_blocked_on_def2)
-  apply (drule spec [where x = Grant])
-  apply (frule aag_wellformed_grant_Control_to_recv [OF _ _ pas_refined_wellformed])
-    apply (rule pas_refined_mem [OF sta_ts])
-     apply fastforce
-    apply assumption
-   apply assumption
-  apply (erule (1) aag_Control_into_owns)
-  done
+context Ipc_AC_2 begin
+
+lemma thread_set_fault_pas_refined:
+  "thread_set (tcb_fault_update (\<lambda>_. Some fault)) thread \<lbrace>pas_refined aag\<rbrace>"
+  by (wpsimp wp: send_ipc_pas_refined thread_set_pas_refined
+                 thread_set_refs_trivial thread_set_obj_at_impossible)
 
 lemma send_fault_ipc_pas_refined:
-  "\<lbrace>pas_refined aag
-         and invs
-         and is_subject aag \<circ> cur_thread
-         and K (valid_fault fault)
-         and K (is_subject aag thread)\<rbrace>
-     send_fault_ipc thread fault
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and invs and is_subject aag \<circ> cur_thread
+                    and K (valid_fault fault) and K (is_subject aag thread)\<rbrace>
+   send_fault_ipc thread fault
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)+
   apply (simp add: send_fault_ipc_def Let_def lookup_cap_def split_def)
-  apply (wp send_ipc_pas_refined thread_set_fault_pas_refined thread_set_tcb_fault_set_invs
-            thread_set_refs_trivial thread_set_obj_at_impossible
-            get_cap_wp thread_set_valid_objs''
-            hoare_vcg_conj_lift hoare_vcg_ex_lift hoare_vcg_all_lift
-       | wpc
-       | rule hoare_drop_imps
-       | simp add: split_def split del: if_split)+
-    apply (rule_tac Q'="\<lambda>rv s. pas_refined aag s
-                            \<and> is_subject aag (cur_thread s)
-                            \<and> invs s
-                            \<and> valid_fault fault
-                            \<and> is_subject aag (fst (fst rv))"
+  apply (wpsimp wp: send_ipc_pas_refined thread_set_fault_pas_refined thread_set_tcb_fault_set_invs
+                    thread_set_refs_trivial thread_set_obj_at_impossible get_cap_wp
+                    thread_set_valid_objs'' hoare_vcg_conj_lift hoare_vcg_ex_lift hoare_vcg_all_lift
+              simp: split_def)
+    apply (rule_tac Q'="\<lambda>rv s. pas_refined aag s \<and> is_subject aag (cur_thread s) \<and>
+                               invs s \<and> valid_fault fault \<and> is_subject aag (fst (fst rv))"
                  in hoare_post_imp_R[rotated])
      apply (fastforce dest!: cap_auth_caps_of_state
                        simp: invs_valid_objs invs_sym_refs cte_wp_at_caps_of_state aag_cap_auth_def
                              cap_auth_conferred_def cap_rights_to_auth_def AllowSend_def)
     apply (wp get_cap_auth_wp[where aag=aag] lookup_slot_for_thread_authorised
-          | simp add: lookup_cap_def split_def)+
+           | simp add: lookup_cap_def split_def)+
   done
 
 lemma handle_fault_pas_refined:
-  "\<lbrace>pas_refined aag
-          and invs
-          and is_subject aag \<circ> cur_thread
-          and K (valid_fault fault)
-          and K (is_subject aag thread)\<rbrace>
-     handle_fault thread fault
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (simp add: handle_fault_def)
-  apply (wp set_thread_state_pas_refined send_fault_ipc_pas_refined
-        | simp add: handle_double_fault_def)+
-  done
+  "\<lbrace>pas_refined aag and invs and is_subject aag \<circ> cur_thread
+                    and K (valid_fault fault) and K (is_subject aag thread)\<rbrace>
+   handle_fault thread fault
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  by (wpsimp wp: set_thread_state_pas_refined send_fault_ipc_pas_refined
+           simp: handle_fault_def handle_double_fault_def)
 
+end
 
 
 lemma thread_set_tcb_fault_update_valid_mdb:
-  "\<lbrace>valid_mdb\<rbrace>
-     thread_set (tcb_fault_update (\<lambda>_. Some fault)) thread
-          \<lbrace>\<lambda>rv. valid_mdb\<rbrace>"
-  apply(rule thread_set_mdb)
-  apply(clarsimp simp: tcb_cap_cases_def)
+  "thread_set (tcb_fault_update (\<lambda>_. Some fault)) thread \<lbrace>valid_mdb\<rbrace>"
+  apply (rule thread_set_mdb)
+  apply (clarsimp simp: tcb_cap_cases_def)
   apply auto
   done
-
 
 (* FIXME: MOVE *)
 lemma obj_at_conj_distrib:
   "obj_at (\<lambda>ko. P ko \<and> Q ko) p s = (obj_at (\<lambda>ko. P ko) p s \<and> obj_at (\<lambda>ko. Q ko) p s)"
   by (auto simp: obj_at_def)
 
+
+context Ipc_AC_2 begin
+
 lemma send_fault_ipc_integrity_autarch:
-  "\<lbrace>pas_refined aag
-          and invs
-          and integrity aag X st
-          and is_subject aag \<circ> cur_thread
-          and K (valid_fault fault)
-          and K (is_subject aag thread)\<rbrace>
-     send_fault_ipc thread fault
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>pas_refined aag and invs and integrity aag X st and is_subject aag \<circ> cur_thread
+                    and K (valid_fault fault) and K (is_subject aag thread)\<rbrace>
+   send_fault_ipc thread fault
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)+
   apply (simp add: send_fault_ipc_def Let_def)
-  apply (wp send_ipc_integrity_autarch
-            thread_set_integrity_autarch thread_set_fault_pas_refined
-            thread_set_valid_objs'' thread_set_refs_trivial
-            thread_set_tcb_fault_update_valid_mdb
+  apply (wp send_ipc_integrity_autarch thread_set_integrity_autarch thread_set_fault_pas_refined
+            thread_set_valid_objs'' thread_set_refs_trivial thread_set_tcb_fault_update_valid_mdb
             thread_set_tcb_fault_set_invs
-        | wpc
-        | simp add: is_obj_defs)+
+         | wpc | simp add: is_obj_defs)+
   (* 14 subgoals *)
   apply (rename_tac word1 word2 set)
   apply (rule_tac R="\<lambda>rv s. ep_at word1 s" in hoare_post_add)
   apply (simp only: obj_at_conj_distrib[symmetric] flip: conj_assoc)
   apply (wp thread_set_obj_at_impossible thread_set_tcb_fault_set_invs
             get_cap_auth_wp[where aag=aag]
-        | simp add: lookup_cap_def is_obj_defs split_def)+
-  (* down to 3 : normal indentation *)
+         | simp add: lookup_cap_def is_obj_defs split_def)+
+    (* down to 3 : normal indentation *)
     apply (rule_tac Q'="\<lambda>rv s. integrity aag X st s \<and> pas_refined aag s
                           \<and> invs s
                           \<and> valid_fault fault
@@ -2771,62 +2387,48 @@ lemma send_fault_ipc_integrity_autarch:
      apply (clarsimp simp: valid_cap_def  is_ep aag_cap_auth_def cap_auth_conferred_def
                            cap_rights_to_auth_def AllowSend_def
                     elim!: obj_atE)
-
-     apply (intro conjI ; fastforce ?)
-     apply (clarsimp simp:ep_q_refs_of_def split:endpoint.splits)
-     apply (frule(1) pas_refined_ep_recv, simp add:obj_at_def,assumption)
+     apply (intro conjI; fastforce ?)
+     apply (clarsimp simp: ep_q_refs_of_def split: endpoint.splits)
+     apply (frule(1) pas_refined_ep_recv, simp add: obj_at_def,assumption)
      apply (frule(1) aag_wellformed_grant_Control_to_recv[OF _ _ pas_refined_wellformed,rotated],
             blast)
-     apply (simp add:aag_has_auth_to_Control_eq_owns)
-
+     apply (simp add: aag_has_Control_iff_owns)
     apply (wp lookup_slot_for_thread_authorised)+
   apply simp
   done
 
 lemma handle_fault_integrity_autarch:
-  "\<lbrace>pas_refined aag
-         and integrity aag X st
-         and is_subject aag \<circ> cur_thread
-         and invs
-         and K (valid_fault fault)
-         and K (is_subject aag thread)\<rbrace>
-     handle_fault thread fault
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>pas_refined aag and integrity aag X st and is_subject aag \<circ> cur_thread and invs
+                    and K (valid_fault fault) and K (is_subject aag thread)\<rbrace>
+   handle_fault thread fault
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: handle_fault_def)
   apply (wp set_thread_state_integrity_autarch send_fault_ipc_integrity_autarch
-       | simp add: handle_double_fault_def)+
+         | simp add: handle_double_fault_def)+
   done
+
+end
+
 
 section\<open>Replies\<close>
-
-crunch pas_refined[wp]: handle_fault_reply "pas_refined aag"
-
-lemma handle_fault_reply_respects:
-  "\<lbrace>integrity aag X st and K (is_subject aag thread)\<rbrace>
-     handle_fault_reply fault thread x y
-    \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (cases fault, simp_all)
-  apply (wp as_user_integrity_autarch
-        | simp add: handle_arch_fault_reply_def arch_get_sanitise_register_info_def)+
-  done
 
 lemma tcb_st_to_auth_Restart_Inactive [simp]:
   "tcb_st_to_auth (if P then Restart else Inactive) = {}"
   by simp
 
 
+context Ipc_AC_2 begin
+
 lemma do_reply_transfer_pas_refined:
-  "\<lbrace>pas_refined aag
-         and invs and K (is_subject aag sender)
-         and K ((grant \<longrightarrow> is_subject aag receiver) \<and> is_subject aag (fst slot))\<rbrace>
-     do_reply_transfer sender receiver slot grant
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and invs and K (is_subject aag sender)
+                    and K ((grant \<longrightarrow> is_subject aag receiver) \<and> is_subject aag (fst slot))\<rbrace>
+   do_reply_transfer sender receiver slot grant
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: do_reply_transfer_def)
   apply (rule hoare_pre)
   apply (wp set_thread_state_pas_refined do_ipc_transfer_pas_refined
             thread_set_pas_refined K_valid
-       | wpc
-       | simp add: thread_get_def split del: if_split)+
+         | wpc | simp add: thread_get_def split del: if_split)+
   (* otherwise simp does too much *)
   apply (rule hoare_strengthen_post, rule gts_inv)
    apply (rule impI)
@@ -2834,13 +2436,15 @@ lemma do_reply_transfer_pas_refined:
   apply auto
   done
 
+end
+
+
 lemma update_tcb_state_in_ipc_reply:
   "\<lbrakk> integrity_tcb_in_ipc aag X thread epptr TRContext st s;
      tcb_state tcb = BlockedOnReply; aag_has_auth_to aag Reply thread; tcb_fault tcb = None;
-     get_tcb thread s = Some tcb; tcb' = tcb\<lparr>tcb_state := Structures_A.thread_state.Running\<rparr>
-   \<rbrakk> \<Longrightarrow>
-   integrity_tcb_in_ipc aag X thread epptr TRFinal st
-                        (s \<lparr> kheap := (kheap s)(thread \<mapsto> TCB tcb') \<rparr>)"
+     get_tcb thread s = Some tcb; tcb' = tcb\<lparr>tcb_state := Running\<rparr> \<rbrakk>
+     \<Longrightarrow> integrity_tcb_in_ipc aag X thread epptr TRFinal st
+                              (s\<lparr>kheap := (kheap s)(thread \<mapsto> TCB tcb')\<rparr>)"
   unfolding integrity_tcb_in_ipc_def
   apply (elim conjE)
   apply (intro conjI)
@@ -2855,7 +2459,6 @@ lemma update_tcb_state_in_ipc_reply:
     apply auto
   done
 
-
 abbreviation "fault_tcb_at \<equiv> pred_tcb_at itcb_fault"
 
 lemma fault_tcb_atI:
@@ -2863,104 +2466,84 @@ lemma fault_tcb_atI:
   by (fastforce simp:pred_tcb_at_def obj_at_def)
 
 lemma fault_tcb_atE:
-  assumes hyp:"fault_tcb_at P ptr s"
+  assumes hyp: "fault_tcb_at P ptr s"
   obtains tcb where "kheap s ptr = Some (TCB tcb)" and "P (tcb_fault tcb)"
-  using hyp by (fastforce simp:pred_tcb_at_def elim: obj_atE)
+  using hyp by (fastforce simp: pred_tcb_at_def elim: obj_atE)
 
 lemma set_thread_state_running_respects_in_ipc_reply:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st
-      and st_tcb_at awaiting_reply receiver
-      and fault_tcb_at ((=) None) receiver
-      and K (aag_has_auth_to aag Reply receiver)\<rbrace>
-     set_thread_state receiver Structures_A.thread_state.Running
-   \<lbrace>\<lambda>rv. integrity_tcb_in_ipc aag X receiver epptr TRFinal st\<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr TRContext st and
+    st_tcb_at awaiting_reply receiver and fault_tcb_at ((=) None) receiver and
+    K (aag_has_auth_to aag Reply receiver)\<rbrace>
+   set_thread_state receiver Running
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRFinal st\<rbrace>"
   apply (simp add: set_thread_state_def set_object_def get_object_def)
   apply (wp sts_ext_running_noop)
   apply (auto simp: st_tcb_at_def obj_at_def get_tcb_def
               cong: if_cong
-              elim!: fault_tcb_atE elim: update_tcb_state_in_ipc_reply[unfolded fun_upd_def])
+             elim!: fault_tcb_atE elim: update_tcb_state_in_ipc_reply[unfolded fun_upd_def])
   done
-
-end
-
-context is_extended begin
-
-interpretation Arch . (*FIXME: arch_split*)
-
-lemma list_integ_lift_in_ipc:
-  assumes li:
-   "\<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
-       f
-    \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag}  (cdt st) (tcb_states_of_state st)) st\<rbrace>"
-  assumes ekh: "\<And>P. \<lbrace>\<lambda>s. P (ekheap s)\<rbrace> f \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
-  assumes rq: "\<And>P. \<lbrace> \<lambda>s. P (ready_queues s) \<rbrace> f \<lbrace> \<lambda>rv s. P (ready_queues s) \<rbrace>"
-  shows "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and Q\<rbrace> f \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
-  apply (unfold integrity_tcb_in_ipc_def integrity_def[abs_def])
-  apply (simp del:split_paired_All)
-  apply (rule hoare_pre)
-   apply (simp only: integrity_cdt_list_as_list_integ)
-   apply (rule hoare_lift_Pf2[where f="ekheap"])
-    apply (simp add: tcb_states_of_state_def get_tcb_def)
-    apply (wp li[simplified tcb_states_of_state_def get_tcb_def] ekh rq)+
-  apply (simp only: integrity_cdt_list_as_list_integ)
-  apply (simp add: tcb_states_of_state_def get_tcb_def)
-  done
-
-end
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma fast_finalise_reply_respects_in_ipc_autarch:
-  "\<lbrace> integrity_tcb_in_ipc aag X receiver epptr ctxt st  and K (is_reply_cap cap) \<rbrace>
-     fast_finalise cap final
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and K (is_reply_cap cap)\<rbrace>
+   fast_finalise cap final
    \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st \<rbrace>"
   by (rule hoare_gen_asm) (fastforce simp: is_cap_simps)
 
 lemma empty_slot_list_integrity':
   notes split_paired_All[simp del]
-  shows
-  "\<lbrace>list_integ P st and (\<lambda>s . cdt_list s slot = []) and K(P slot)\<rbrace> empty_slot_ext slot slot_p \<lbrace>\<lambda>_. list_integ P st\<rbrace>"
+  shows "\<lbrace>list_integ P st and (\<lambda>s . cdt_list s slot = []) and K (P slot)\<rbrace>
+         empty_slot_ext slot slot_p
+         \<lbrace>\<lambda>_. list_integ P st\<rbrace>"
   apply (simp add: empty_slot_ext_def split del: if_split)
   apply (wp update_cdt_list_wp)
-  apply (intro impI conjI allI | simp add: list_filter_replace_list list_filter_remove split: option.splits | elim conjE  | simp add: list_integ_def)+
+  apply (fastforce simp: list_filter_replace_list list_integ_def split: option.splits)
   done
-
 
 lemma tcb_state_of_states_cdt_update_behind_kheap[simp]:
   "tcb_states_of_state (kheap_update g (cdt_update f s)) = tcb_states_of_state (kheap_update g s)"
-  by (simp add:tcb_states_of_state_def get_tcb_def)
+  by (simp add: tcb_states_of_state_def get_tcb_def)
+
+
+context Ipc_AC_2 begin
 
 lemma set_cdt_empty_slot_respects_in_ipc_autarch:
-  "\<lbrace> integrity_tcb_in_ipc aag X receiver epptr ctxt st and (\<lambda>s. m =cdt s)
-     and (\<lambda>s. descendants_of slot m = {}) and K(is_subject aag (fst slot))\<rbrace>
-      set_cdt ((\<lambda>p. if m p = Some slot then m slot else m p)(slot := None))
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and (\<lambda>s. m = cdt s) and
+    (\<lambda>s. descendants_of slot m = {}) and K (is_subject aag (fst slot))\<rbrace>
+   set_cdt ((\<lambda>p. if m p = Some slot then m slot else m p)(slot := None))
    \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st \<rbrace>"
   unfolding set_cdt_def
   apply wp
-  apply (simp add: integrity_tcb_in_ipc_def integrity_def)
-  apply (force simp:no_children_empty_desc[symmetric])
+  apply (force simp: integrity_tcb_in_ipc_def integrity_def no_children_empty_desc[symmetric])
   done
 
+end
+
+
 lemma reply_cap_no_children':
-  "\<lbrakk> valid_mdb s; caps_of_state s p = Some (ReplyCap t False r) \<rbrakk> \<Longrightarrow> \<forall>p' .cdt s p' \<noteq> Some p"
+  "\<lbrakk> valid_mdb s; caps_of_state s p = Some (ReplyCap t False r) \<rbrakk>
+     \<Longrightarrow> \<forall>p'. cdt s p' \<noteq> Some p"
   using reply_cap_no_children ..
 
 lemma valid_list_empty:
-  "\<lbrakk> valid_list_2 list m; descendants_of slot m = {}\<rbrakk> \<Longrightarrow> list slot = []"
+  "\<lbrakk> valid_list_2 list m; descendants_of slot m = {}\<rbrakk>
+     \<Longrightarrow> list slot = []"
   unfolding valid_list_2_def
   apply (drule no_children_empty_desc[THEN iffD2])
   apply (rule classical)
-  by (fastforce simp del:split_paired_All split_paired_Ex simp add:neq_Nil_conv)
+  by (fastforce simp del: split_paired_All split_paired_Ex simp add: neq_Nil_conv)
 
+
+context Ipc_AC_2 begin
 
 lemma empty_slot_respects_in_ipc_autarch:
-  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and valid_mdb and valid_list
-    and cte_wp_at is_reply_cap slot and K (is_subject aag (fst slot))\<rbrace>
-     empty_slot slot NullCap
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and valid_mdb and
+    valid_list and cte_wp_at is_reply_cap slot and K (is_subject aag (fst slot))\<rbrace>
+   empty_slot slot NullCap
    \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
-  unfolding empty_slot_def apply simp
+  unfolding empty_slot_def post_cap_deletion_def
+  apply simp
   apply (wp add: set_cap_respects_in_ipc_autarch set_original_respects_in_ipc_autarch)
-       apply (wp empty_slot_extended.list_integ_lift_in_ipc empty_slot_list_integrity')
+       apply (wp empty_slot_extended_list_integ_lift_in_ipc empty_slot_list_integrity')
           apply simp
          apply wp+
       apply (wp set_cdt_empty_slot_respects_in_ipc_autarch)
@@ -2974,103 +2557,55 @@ lemma empty_slot_respects_in_ipc_autarch:
   by (force dest: valid_list_empty simp: no_children_empty_desc simp del: split_paired_All)
 
 lemma cte_delete_one_respects_in_ipc_autharch:
-  "\<lbrace> integrity_tcb_in_ipc aag X receiver epptr ctxt st and valid_mdb and valid_list and
-       cte_wp_at is_reply_cap slot and K (is_subject aag (fst slot)) \<rbrace>
-     cap_delete_one slot
-   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st \<rbrace>"
+  "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and valid_mdb and
+    valid_list and cte_wp_at is_reply_cap slot and K (is_subject aag (fst slot))\<rbrace>
+   cap_delete_one slot
+   \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
   unfolding cap_delete_one_def
-  apply (wp empty_slot_respects_in_ipc_autarch
-            fast_finalise_reply_respects_in_ipc_autarch get_cap_wp)
+  apply (wp empty_slot_respects_in_ipc_autarch fast_finalise_reply_respects_in_ipc_autarch get_cap_wp)
   by (fastforce simp:cte_wp_at_caps_of_state is_cap_simps)
 
+end
 
 
-text \<open>The special case of fault reply need a different machinery than *_in_ipc stuff because,
-        there is no @{term underlying_memory} modification\<close>
-
-datatype tcb_respects_fault_state = TRFContext | TRFRemoveFault | TRFFinal
-
-inductive tcb_in_fault_reply for aag tst l' ko ko'
-where
-  tifr_lrefl: "\<lbrakk> l' = pasSubject aag \<rbrakk> \<Longrightarrow> tcb_in_fault_reply aag tst l' ko ko'"
-| tifr_context: "\<lbrakk> ko  = Some (TCB tcb);
-                  ko' = Some (TCB tcb');
-                  \<exists>ctxt'. tcb' = tcb \<lparr>tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb)\<rparr>;
-                  (pasSubject aag, Reply, l') \<in> pasPolicy aag;
-                  tcb_state tcb = BlockedOnReply;
-                  tcb_fault tcb = Some fault;
-                  tst = TRFContext\<rbrakk>
-        \<Longrightarrow> tcb_in_fault_reply aag tst l' ko ko'"
-| tifr_remove_fault: "\<lbrakk> ko  = Some (TCB tcb);
-                   ko' = Some (TCB tcb');
-                   \<exists>ctxt'. tcb' = tcb \<lparr> tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb)
-                                   , tcb_fault := None\<rparr>;
-                   (pasSubject aag, Reply, l') \<in> pasPolicy aag;
-                   tcb_state tcb = BlockedOnReply;
-                   tcb_fault tcb = Some fault;
-                   tst = TRFRemoveFault\<rbrakk>
-         \<Longrightarrow> tcb_in_fault_reply aag tst l' ko ko'"
-| tifr_reply:  "\<lbrakk> ko  = Some (TCB tcb);
-                ko' = Some (TCB tcb');
-                \<exists>ctxt'. tcb' = tcb \<lparr> tcb_arch := arch_tcb_context_set ctxt' (tcb_arch tcb),
-                                     tcb_fault := None,
-                                     tcb_state := new_st\<rparr>;
-                new_st = Structures_A.Restart \<or> new_st = Structures_A.Inactive;
-                (pasSubject aag, Reply, l') \<in> pasPolicy aag;
-                tcb_state tcb = BlockedOnReply;
-                tcb_fault tcb = Some fault;
-                tst = TRFFinal\<rbrakk>
-         \<Longrightarrow> tcb_in_fault_reply aag tst l' ko ko'"
-
-definition integrity_tcb_in_fault_reply ::
-  "'a PAS \<Rightarrow> obj_ref set \<Rightarrow> obj_ref \<Rightarrow> tcb_respects_fault_state \<Rightarrow> det_ext state
-    \<Rightarrow> det_ext state \<Rightarrow> bool"
-where
-  "integrity_tcb_in_fault_reply aag X thread tst st \<equiv> \<lambda>s.
-     \<not> is_subject aag thread \<and> pas_refined aag st \<and> \<comment> \<open>more or less convenience\<close>
-     (integrity aag X st (s\<lparr>kheap := (kheap s)(thread := kheap st thread)\<rparr>)
-   \<and> (tcb_in_fault_reply aag tst (pasObjectAbs aag thread) (kheap st thread) (kheap s thread)))"
+context Ipc_AC_2 begin
 
 lemma integrity_tcb_in_fault_reply_final:
-  "\<lbrakk> integrity_tcb_in_fault_reply aag X thread TRFFinal st s \<rbrakk> \<Longrightarrow> integrity aag X st s"
+  "integrity_tcb_in_fault_reply aag X thread TRFFinal st s \<Longrightarrow> integrity aag X st s"
   unfolding integrity_tcb_in_fault_reply_def
   apply clarsimp
   apply (erule integrity_trans)
   apply (clarsimp simp: integrity_def)
   apply (erule tcb_in_fault_reply.cases; clarsimp)
-  apply (fastforce intro!:tcb.equality tro_tcb_reply)
+  apply (fastforce intro!: tcb.equality tro_tcb_reply)
   done
 
-lemma set_scheduler_action_respects_in_fault_reply:
-  "\<lbrace>integrity_tcb_in_fault_reply aag X receiver ctxt st\<rbrace>
-    set_scheduler_action action
-   \<lbrace>\<lambda>_. integrity_tcb_in_fault_reply aag X receiver ctxt st\<rbrace>"
-  unfolding set_scheduler_action_def
-  by (wpsimp simp: integrity_tcb_in_fault_reply_def integrity_def
-                   tcb_states_of_state_def get_tcb_def)
+end
 
-crunches set_thread_state_ext
-  for respects_in_fault_reply:"integrity_tcb_in_fault_reply aag X receiver ctxt st"
 
 lemma as_user_respects_in_fault_reply:
-  "\<lbrace>integrity_tcb_in_fault_reply aag X thread TRFContext st\<rbrace>
-     as_user thread m
-   \<lbrace>\<lambda>rv. integrity_tcb_in_fault_reply aag X thread TRFContext st\<rbrace>"
+  "as_user thread m \<lbrace>integrity_tcb_in_fault_reply aag X thread TRFContext st\<rbrace>"
   apply (simp add: as_user_def)
   apply (wpsimp wp: set_object_wp)
   apply (clarsimp simp: integrity_tcb_in_fault_reply_def)
   apply (erule tcb_in_fault_reply.cases; clarsimp dest!: get_tcb_SomeD)
   apply (rule tifr_context[OF refl refl])
-      apply (intro exI tcb.equality; simp add: arch_tcb_context_set_def)
   by fastforce+
 
+
+context Ipc_AC_2 begin
+
+lemma set_scheduler_action_respects_in_fault_reply:
+  "set_scheduler_action action \<lbrace>integrity_tcb_in_fault_reply aag X receiver ctxt st\<rbrace>"
+  unfolding set_scheduler_action_def
+  by (wpsimp simp: integrity_tcb_in_fault_reply_def integrity_def tcb_states_of_state_def get_tcb_def)
+
 lemma handle_fault_reply_respects_in_fault_reply:
-  "\<lbrace>integrity_tcb_in_fault_reply aag X thread TRFContext st\<rbrace>
-   handle_fault_reply f thread label mrs
-   \<lbrace>\<lambda>_. integrity_tcb_in_fault_reply aag X thread TRFContext st\<rbrace>"
-  by (cases f;
-      wpsimp simp: handle_arch_fault_reply_def arch_get_sanitise_register_info_def
-               wp: as_user_respects_in_fault_reply)
+  "handle_fault_reply f thread label mrs \<lbrace>integrity_tcb_in_fault_reply aag X thread TRFContext st\<rbrace>"
+  by (cases f; wpsimp wp: as_user_respects_in_fault_reply handle_arch_fault_reply_typ_at)
+
+crunches set_thread_state_ext
+  for respects_in_fault_reply: "integrity_tcb_in_fault_reply aag X receiver ctxt st"
 
 lemma thread_set_no_fault_respects_in_fault_reply:
   "\<lbrace>integrity_tcb_in_fault_reply aag X thread TRFContext st\<rbrace>
@@ -3081,7 +2616,6 @@ lemma thread_set_no_fault_respects_in_fault_reply:
   apply (clarsimp simp: integrity_tcb_in_fault_reply_def)
   apply (erule tcb_in_fault_reply.cases; clarsimp dest!: get_tcb_SomeD)
   apply (rule tifr_remove_fault[OF refl refl])
-      apply (intro exI tcb.equality ; simp add: arch_tcb_context_set_def)
   by fastforce+
 
 lemma set_thread_state_respects_in_fault_reply:
@@ -3094,14 +2628,13 @@ lemma set_thread_state_respects_in_fault_reply:
   apply (clarsimp simp: integrity_tcb_in_fault_reply_def)
   apply (erule tcb_in_fault_reply.cases; clarsimp dest!: get_tcb_SomeD)
   apply (rule tifr_reply[OF refl refl])
-       apply (intro exI tcb.equality; simp add: arch_tcb_context_set_def)
+       apply (intro exI tcb.equality; simp)
   by fastforce+
 
 lemma integrity_tcb_in_fault_reply_refl:
   "\<lbrakk> st_tcb_at awaiting_reply receiver s; fault_tcb_at (flip (\<noteq>) None) receiver s;
-     aag_has_auth_to aag Reply receiver;
-     \<not> is_subject aag receiver; pas_refined aag s \<rbrakk>
-  \<Longrightarrow> integrity_tcb_in_fault_reply aag X receiver TRFContext s s"
+     aag_has_auth_to aag Reply receiver; \<not> is_subject aag receiver; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> integrity_tcb_in_fault_reply aag X receiver TRFContext s s"
   unfolding integrity_tcb_in_fault_reply_def
   apply (clarsimp elim!: pred_tcb_atE)
   apply (rule tifr_context[OF refl refl])
@@ -3109,24 +2642,31 @@ lemma integrity_tcb_in_fault_reply_refl:
      apply fastforce+
   done
 
+end
+
+
 lemma emptyable_not_master:
-  "\<lbrakk> valid_objs s; caps_of_state s slot = Some cap; \<not> is_master_reply_cap cap\<rbrakk>
-   \<Longrightarrow> emptyable slot s"
+  "\<lbrakk> valid_objs s; caps_of_state s slot = Some cap; \<not> is_master_reply_cap cap \<rbrakk>
+     \<Longrightarrow> emptyable slot s"
   apply (rule emptyable_cte_wp_atD[rotated 2])
     apply (intro allI impI, assumption)
    by (fastforce simp:is_cap_simps cte_wp_at_caps_of_state)+
 
+
+context Ipc_AC_2 begin
+
+crunches do_ipc_transfer
+  for valid_list[wp]: valid_list
+  (wp: crunch_wps simp: crunch_simps)
+
 lemma do_reply_transfer_respects:
-  "\<lbrace>pas_refined aag
-        and integrity aag X st
-        and einvs \<comment> \<open>cap_delete_one\<close>
-        and tcb_at sender
-        and cte_wp_at (is_reply_cap_to receiver) slot
-        and K (is_subject aag sender)
-        and K (aag_has_auth_to aag Reply receiver)
-        and K (is_subject aag (fst slot) \<and> (grant \<longrightarrow> is_subject aag receiver))\<rbrace>
-     do_reply_transfer sender receiver slot grant
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>pas_refined aag and integrity aag X st and einvs \<comment> \<open>cap_delete_one\<close> and tcb_at sender
+                    and cte_wp_at (is_reply_cap_to receiver) slot
+                    and K (is_subject aag sender)
+                    and K (aag_has_auth_to aag Reply receiver)
+                    and K (is_subject aag (fst slot) \<and> (grant \<longrightarrow> is_subject aag receiver))\<rbrace>
+   do_reply_transfer sender receiver slot grant
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)+
   apply (simp add: do_reply_transfer_def thread_get_def get_thread_state_def)
   apply (rule hoare_seq_ext[OF _ assert_get_tcb_sp];force?)
@@ -3145,9 +2685,8 @@ lemma do_reply_transfer_respects:
     \<comment> \<open>receiver is not a subject\<close>
     apply (rule use_spec') \<comment> \<open>Name initial state\<close>
     apply (simp add: spec_valid_def) \<comment> \<open>no imp rule?\<close>
-
-    apply (rule_tac Q =  "\<lambda>_ s'. integrity aag X st s \<and>
-                         integrity_tcb_in_ipc aag X receiver _ TRFinal s s'" in hoare_post_imp)
+    apply (rule_tac Q="\<lambda>_ s'. integrity aag X st s \<and>
+                              integrity_tcb_in_ipc aag X receiver _ TRFinal s s'" in hoare_post_imp)
      apply (fastforce dest!: integrity_tcb_in_ipc_final elim!: integrity_trans)
     apply ((wp possible_switch_to_respects_in_ipc_autarch
                set_thread_state_running_respects_in_ipc_reply
@@ -3169,7 +2708,7 @@ lemma do_reply_transfer_respects:
     apply (rule use_spec') \<comment> \<open>Name initial state\<close>
     apply (simp add: spec_valid_def) \<comment> \<open>no imp rule?\<close>
     apply wp
-          apply (rule_tac Q = "\<lambda>_ s'. integrity aag X st s \<and>
+          apply (rule_tac Q="\<lambda>_ s'. integrity aag X st s \<and>
                                       integrity_tcb_in_fault_reply aag X receiver TRFFinal s s'"
                        in hoare_post_imp)
      apply (fastforce dest!: integrity_tcb_in_fault_reply_final elim!: integrity_trans)
@@ -3180,7 +2719,6 @@ lemma do_reply_transfer_respects:
    apply force
    apply (strengthen integrity_tcb_in_fault_reply_refl)+
    apply (wp cap_delete_one_reply_st_tcb_at)
-
   \<comment> \<open>the end\<close>
   by (force simp: st_tcb_at_tcb_states_of_state cte_wp_at_caps_of_state is_cap_simps
                   is_reply_cap_to_def
@@ -3189,13 +2727,13 @@ lemma do_reply_transfer_respects:
           intro!: integrity_tcb_in_ipc_refl tcb_states_of_state_kheapI
            elim!: fault_tcb_atE)
 
-
 lemma reply_from_kernel_integrity_autarch:
   "\<lbrace>integrity aag X st and pas_refined aag and valid_objs and K (is_subject aag thread)\<rbrace>
-    reply_from_kernel thread x
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+   reply_from_kernel thread x
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: reply_from_kernel_def split_def)
-  apply (wp set_message_info_integrity_autarch set_mrs_integrity_autarch as_user_integrity_autarch | simp)+
+  apply (wpsimp wp: set_message_info_integrity_autarch
+                    set_mrs_integrity_autarch as_user_integrity_autarch)+
   done
 
 end

--- a/proof/access-control/Retype_AC.thy
+++ b/proof/access-control/Retype_AC.thy
@@ -5,49 +5,21 @@
  *)
 
 theory Retype_AC
-imports CNode_AC
+imports ArchCNode_AC
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-(* put in here that we own the region mentioned in the invocation *)
-definition
-  authorised_untyped_inv :: "'a PAS \<Rightarrow> Invocations_A.untyped_invocation \<Rightarrow> bool"
-where
- "authorised_untyped_inv aag ui \<equiv> case ui of
-     Invocations_A.untyped_invocation.Retype src_slot reset base aligned_free_ref new_type obj_sz slots dev \<Rightarrow>
-       is_subject aag (fst src_slot) \<and> (0 :: obj_ref) < of_nat (length slots) \<and>
-       (\<forall>x\<in>set (retype_addrs aligned_free_ref new_type (length slots) obj_sz). is_subject aag x) \<and>
-       (\<forall>x\<in>{aligned_free_ref..aligned_free_ref + of_nat (length slots)*2^(obj_bits_api new_type obj_sz) - 1}. is_subject aag x) \<and>
-       new_type \<noteq> ArchObject ASIDPoolObj \<and>
-       (\<forall>x\<in>set slots. is_subject aag (fst x))"
 
 subsection\<open>invoke\<close>
 
-lemma create_cap_integrity:
-  "\<lbrace>integrity aag X st and K (is_subject aag (fst (fst ref)))\<rbrace>
-     create_cap typ sz untyped_ptr is_device ref
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: create_cap_def split_def)
-  apply (wp set_cap_integrity_autarch[unfolded pred_conj_def K_def]
-            create_cap_extended.list_integ_lift
-            create_cap_list_integrity
-            set_original_integrity_autarch
-              | simp add: set_cdt_def)+
-  by (auto simp: integrity_def)
-
-
-crunch inv[wp]: reserve_region P
-
-lemma mol_respects:
-  "\<lbrace>\<lambda>ms. integrity aag X st (s\<lparr>machine_state := ms\<rparr>)\<rbrace>
-     machine_op_lift mop
-   \<lbrace>\<lambda>a b. integrity aag X st (s\<lparr>machine_state := b\<rparr>)\<rbrace>"
-  unfolding machine_op_lift_def
-  apply (simp add: machine_rest_lift_def split_def)
-  apply wp
-  apply (clarsimp simp: integrity_def)
-  done
+(* put in here that we own the region mentioned in the invocation *)
+definition authorised_untyped_inv :: "'a PAS \<Rightarrow> Invocations_A.untyped_invocation \<Rightarrow> bool" where
+ "authorised_untyped_inv aag ui \<equiv> case ui of
+    Retype src_slot reset base afr new_type obj_sz slots dev \<Rightarrow>
+      is_subject aag (fst src_slot)
+    \<and> (0 :: obj_ref) < of_nat (length slots)
+    \<and> (\<forall>x\<in>set (retype_addrs afr new_type (length slots) obj_sz). is_subject aag x)
+    \<and> (\<forall>x\<in>{afr..afr + of_nat (length slots)*2^(obj_bits_api new_type obj_sz) - 1}. is_subject aag x)
+    \<and> new_type \<noteq> ArchObject ASIDPoolObj
+    \<and> (\<forall>x\<in>set slots. is_subject aag (fst x))"
 
 lemma ptr_range_memI:
   "is_aligned p n \<Longrightarrow> p \<in> ptr_range p n"
@@ -73,103 +45,50 @@ lemma ptr_range_add_memI:
   apply (simp add: word_bits_conv)
   done
 
-lemma storeWord_integrity_autarch:
-  "\<lbrace>\<lambda>ms. integrity aag X st (s\<lparr>machine_state := ms\<rparr>) \<and> (is_aligned p 2 \<longrightarrow> (\<forall>p' \<in> ptr_range p 2. is_subject aag p'))\<rbrace> storeWord p v \<lbrace>\<lambda>a b. integrity aag X st (s\<lparr>machine_state := b\<rparr>)\<rbrace>"
-  unfolding storeWord_def
+lemma create_cap_integrity:
+  "\<lbrace>integrity aag X st and K (is_subject aag (fst (fst ref)))\<rbrace>
+   create_cap typ sz untyped_ptr is_device ref
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: create_cap_def split_def)
+  apply (wp set_cap_integrity_autarch[unfolded pred_conj_def K_def]
+            create_cap_extended.list_integ_lift
+            create_cap_list_integrity
+            set_original_integrity_autarch
+              | simp add: set_cdt_def)+
+  by (auto simp: integrity_def)
+
+lemma mol_respects:
+  "machine_op_lift mop \<lbrace>\<lambda>ms. integrity aag X st (s\<lparr>machine_state := ms\<rparr>)\<rbrace>"
+  unfolding machine_op_lift_def
+  apply (simp add: machine_rest_lift_def split_def)
   apply wp
-  apply (auto simp: integrity_def is_aligned_mask [symmetric] intro!: trm_lrefl ptr_range_memI ptr_range_add_memI)
+  apply (clarsimp simp: integrity_def)
   done
 
-lemma Suc_0_lt_cases:
-  "\<lbrakk>(x = 0 \<Longrightarrow> False); (x = 1 \<Longrightarrow> False)\<rbrakk> \<Longrightarrow> Suc 0 < x"
-  apply (rule classical)
-  apply (auto simp add: not_less le_Suc_eq)
-  done
-
-lemma clearMemory_respects:
-  "\<lbrace>\<lambda> a. integrity aag X st (s\<lparr>machine_state := a\<rparr>) \<and>
-         is_aligned ptr sz \<and> sz < word_bits \<and> 2 \<le> sz \<and>
-         (\<forall> y\<in>ptr_range ptr sz. is_subject aag y)\<rbrace>
-    clearMemory ptr (2 ^ sz)
-   \<lbrace>\<lambda>rv a. integrity aag X st (s\<lparr>machine_state := a\<rparr>)\<rbrace>"
-  unfolding clearMemory_def
-  apply (rule hoare_pre)
-   apply (simp add: split_def cleanCacheRange_PoU_def)
-   apply wp
-   apply (simp add: cleanByVA_PoU_def)
-   apply (wp mol_respects)
-   apply (rule_tac Q="\<lambda> x ms. integrity aag X st (s\<lparr>machine_state := ms\<rparr>) \<and> (\<forall> y\<in> set [ptr , ptr + 4 .e. ptr + of_nat (2 ^ sz) - 1]. (is_aligned y 2 \<longrightarrow> (\<forall> z \<in> ptr_range y 2. is_subject aag z)))" in  hoare_strengthen_post)
-    apply(wp mapM_x_wp' storeWord_integrity_autarch | simp add: no_irq_storeWord word_size_def)+
-  apply(clarsimp simp: upto_enum_step_shift_red[where us=2, simplified] word_bits_def)
-  apply(erule bspec)
-  apply(erule subsetD[rotated])
-  apply(rule ptr_range_subset)
-     apply assumption
-    apply(rule is_aligned_mult_triv2[where n=2, simplified])
-   apply assumption
-  apply (auto simp: word_bits_def
-             intro: word_less_power_trans_ofnat[where k=2, simplified])
-  done
-
-crunch integrity_autarch: set_pd "integrity aag X st"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma store_pde_integrity:
-  "\<lbrace>integrity aag X st and K (is_subject aag (p && ~~ mask pd_bits))\<rbrace>
-     store_pde p pde
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply(simp add: store_pde_def)
-  apply(wp set_pd_integrity_autarch)
-  apply(auto)
-  done
-
-(* Borrowed from part of copy_global_mappings_nonempty_table in Untyped_R.thy *)
-lemma copy_global_mappings_index_subset:
-  "set [kernel_base >> 20.e.2 ^ (pd_bits - 2) - 1] \<subseteq> {x. \<exists>y. x = y >> 20}"
-  apply clarsimp
-  apply (rule_tac x="x << 20" in exI)
-  apply (subst shiftl_shiftr1, simp)
-  apply (simp add: word_size)
-  apply (rule sym, rule less_mask_eq)
-  apply (simp add: word_leq_minus_one_le pd_bits_def pageBits_def)
-  done
-
-lemma copy_global_mappings_integrity:
-  "is_aligned x pd_bits \<Longrightarrow>
-   \<lbrace>integrity aag X st and K (is_subject aag x)\<rbrace>
-     copy_global_mappings x
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: copy_global_mappings_def)
-  apply (wp mapM_x_wp[OF _ subset_refl] store_pde_integrity)
-    apply (drule subsetD[OF copy_global_mappings_index_subset])
-    apply (fastforce simp: pd_shifting')
-   apply wpsimp+
-  done
-
-lemma dmo_mol_respects:
-  "\<lbrace>integrity aag X st\<rbrace> do_machine_op (machine_op_lift mop) \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+lemma dmo_mol_respects[wp]:
+  "do_machine_op (machine_op_lift mop) \<lbrace>integrity aag X st\<rbrace>"
   unfolding do_machine_op_def
-  apply (simp add: split_def)
-  apply wp
-  apply clarsimp
+  apply wpsimp
   apply (erule use_valid)
    apply (wp mol_respects)
   apply simp
   done
 
 lemma dmo_bind_valid:
-  "\<lbrace>P\<rbrace> do_machine_op (a >>= b) \<lbrace>Q\<rbrace> = \<lbrace>P\<rbrace> do_machine_op a >>= (\<lambda>rv. do_machine_op (b rv)) \<lbrace>Q\<rbrace>"
-  by (fastforce simp: do_machine_op_def gets_def get_def select_f_def modify_def put_def return_def bind_def valid_def)
+  "\<lbrace>P\<rbrace> do_machine_op (a >>= b) \<lbrace>Q\<rbrace> =
+   \<lbrace>P\<rbrace> do_machine_op a >>= (\<lambda>rv. do_machine_op (b rv)) \<lbrace>Q\<rbrace>"
+  by (fastforce simp: do_machine_op_def gets_def get_def select_f_def
+                      modify_def put_def return_def bind_def valid_def)
 
 lemma dmo_bind_valid':
-  "\<lbrace>P\<rbrace> a >>= (\<lambda>rv. do_machine_op (b rv >>= c rv)) \<lbrace>Q\<rbrace>
-    = \<lbrace>P\<rbrace> a >>= (\<lambda>rv. do_machine_op (b rv) >>= (\<lambda>rv'. do_machine_op (c rv rv'))) \<lbrace>Q\<rbrace>"
-  by (fastforce simp: do_machine_op_def gets_def get_def select_f_def modify_def put_def return_def bind_def valid_def)
+  "\<lbrace>P\<rbrace> a >>= (\<lambda>rv. do_machine_op (b rv >>= c rv)) \<lbrace>Q\<rbrace> =
+   \<lbrace>P\<rbrace> a >>= (\<lambda>rv. do_machine_op (b rv) >>= (\<lambda>rv'. do_machine_op (c rv rv'))) \<lbrace>Q\<rbrace>"
+  by (fastforce simp: do_machine_op_def gets_def get_def select_f_def
+                      modify_def put_def return_def bind_def valid_def)
 
 lemma dmo_mapM_wp:
   assumes x: "\<And>x. x \<in> S \<Longrightarrow> \<lbrace>P\<rbrace> do_machine_op (f x) \<lbrace>\<lambda>rv. P\<rbrace>"
-  shows      "set xs \<subseteq> S \<Longrightarrow> \<lbrace>P\<rbrace> do_machine_op (mapM f xs) \<lbrace>\<lambda>rv. P\<rbrace>"
+  shows "set xs \<subseteq> S \<Longrightarrow> \<lbrace>P\<rbrace> do_machine_op (mapM f xs) \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (induct xs)
    apply (simp add: mapM_def sequence_def)
   apply (simp add: mapM_Cons dmo_bind_valid dmo_bind_valid')
@@ -178,53 +97,19 @@ lemma dmo_mapM_wp:
 
 lemma dmo_mapM_x_wp:
   assumes x: "\<And>x. x \<in> S \<Longrightarrow> \<lbrace>P\<rbrace> do_machine_op (f x) \<lbrace>\<lambda>rv. P\<rbrace>"
-  shows      "set xs \<subseteq> S \<Longrightarrow> \<lbrace>P\<rbrace> do_machine_op (mapM_x f xs) \<lbrace>\<lambda>rv. P\<rbrace>"
+  shows "set xs \<subseteq> S \<Longrightarrow> \<lbrace>P\<rbrace> do_machine_op (mapM_x f xs) \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (subst mapM_x_mapM)
   apply (simp add: do_machine_op_return_foo)
   apply wp
-  apply (rule dmo_mapM_wp)
-   apply (rule x)
-   apply assumption+
+   apply (rule dmo_mapM_wp)
+    apply (rule x)
+    apply assumption+
   done
 
 lemmas dmo_mapM_x_wp_inv = dmo_mapM_x_wp[where S=UNIV, simplified]
 
-lemma dmo_cacheRangeOp_lift:
-  "(\<And>a b. \<lbrace>P\<rbrace> do_machine_op (oper a b) \<lbrace>\<lambda>_. P\<rbrace>)
-    \<Longrightarrow> \<lbrace>P\<rbrace> do_machine_op (cacheRangeOp oper x y z) \<lbrace>\<lambda>_. P\<rbrace>"
-  apply (simp add: cacheRangeOp_def)
-  apply (wp dmo_mapM_x_wp_inv)
-   apply (simp add: split_def)+
-  done
-
-lemma dmo_cleanCacheRange_PoU_respects [wp]:
-  "\<lbrace>integrity aag X st\<rbrace> do_machine_op (cleanCacheRange_PoU vstart vend pstart) \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  by (simp add: cleanCacheRange_PoU_def cleanByVA_PoU_def | wp dmo_cacheRangeOp_lift dmo_mol_respects)+
-
-lemma dmo_mapM_x_cleanCacheRange_PoU_integrity:
-     "\<lbrace>integrity aag X st\<rbrace>
-      do_machine_op
-           (mapM_x (\<lambda>x. cleanCacheRange_PoU (f x) (g x) (h x)) refs)
-       \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  by (wp dmo_mapM_x_wp_inv)
-
-lemma init_arch_objects_integrity:
-  "\<lbrace>integrity aag X st and
-    K (\<forall> x\<in>set refs. is_subject aag x) and
-    K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api new_type obj_sz))\<rbrace>
-     init_arch_objects new_type ptr num_objects obj_sz refs
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply(rule hoare_gen_asm)+
-  apply(cases new_type)
-  apply(simp_all add: init_arch_objects_def split del: if_split)
-  apply(rule hoare_pre)
-   apply(wpc
-        | wp  mapM_x_wp[OF _ subset_refl]
-             copy_global_mappings_integrity dmo_mapM_x_cleanCacheRange_PoU_integrity
-        | simp add: obj_bits_api_def default_arch_object_def pd_bits_def pageBits_def)+
-  done
-
-lemma foldr_upd_app_if': "foldr (\<lambda>p ps. ps(p := f p)) as g = (\<lambda>x. if x \<in> set as then (f x) else g x)"
+lemma foldr_upd_app_if':
+  "foldr (\<lambda>p ps. ps(p := f p)) as g = (\<lambda>x. if x \<in> set as then (f x) else g x)"
   apply (induct as)
    apply simp
   apply simp
@@ -232,88 +117,33 @@ lemma foldr_upd_app_if': "foldr (\<lambda>p ps. ps(p := f p)) as g = (\<lambda>x
   apply simp
   done
 
-
-lemma retype_region_integrity:
-  "\<lbrace>integrity aag X st and
-       K (range_cover ptr sz (obj_bits_api type o_bits) num_objects \<and>
-          (\<forall>x\<in>{ptr..(ptr && ~~ mask sz) + (2 ^ sz - 1)}. is_subject aag x))\<rbrace>
-     retype_region ptr num_objects o_bits type dev
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (rule hoare_gen_asm)+
-  apply (simp only: retype_region_def retype_region_ext_extended.dxo_eq)
-  apply (simp only: retype_addrs_def  retype_region_ext_def
-                    foldr_upd_app_if' fun_app_def K_bind_def)
-  apply wp
-  apply (clarsimp simp: not_less)
-  apply (erule integrity_trans)
-  apply (clarsimp simp add: integrity_def)
-  apply(fastforce intro: tro_lrefl tre_lrefl
-                   dest: retype_addrs_subset_ptr_bits[simplified retype_addrs_def]
-                   simp: image_def p_assoc_help power_sub integrity_def)
-  done
-
 lemma retype_region_ret_is_subject:
   "\<lbrace>K (range_cover ptr sz (obj_bits_api tp us) num_objects \<and>
        (\<forall>x\<in>{ptr..(ptr && ~~ mask sz) + (2 ^ sz - 1)}. is_subject aag x))\<rbrace>
    retype_region ptr num_objects us tp dev
-   \<lbrace>\<lambda>rv. K (\<forall> ref \<in> set rv. is_subject aag ref)\<rbrace>"
-  apply(rule hoare_gen_asm2 | rule hoare_gen_asm)+
-  apply(rule hoare_strengthen_post)
-   apply(rule retype_region_ret)
-  apply(simp only: K_def)
-  apply(rule ballI)
-  apply(elim conjE)
-  apply(erule bspec)
-  apply(rule rev_subsetD, assumption)
-  apply(simp add: p_assoc_help del: set_map)
-  apply(rule retype_addrs_subset_ptr_bits[simplified retype_addrs_def])
+   \<lbrace>\<lambda>rv. K (\<forall>ref \<in> set rv. is_subject aag ref)\<rbrace>"
+  apply (rule hoare_gen_asm2 | rule hoare_gen_asm)+
+  apply (rule hoare_strengthen_post)
+   apply (rule retype_region_ret)
+  apply (simp only: K_def)
+  apply (rule ballI)
+  apply (elim conjE)
+  apply (erule bspec)
+  apply (rule rev_subsetD, assumption)
+  apply (simp add: p_assoc_help del: set_map)
+  apply (rule retype_addrs_subset_ptr_bits[simplified retype_addrs_def])
   apply simp
-  done
-
-lemma retype_region_ret_pd_aligned:
-  "\<lbrace>K (range_cover ptr sz (obj_bits_api tp us) num_objects)\<rbrace>
-   retype_region ptr num_objects us tp dev
-   \<lbrace>\<lambda>rv. K (\<forall> ref \<in> set rv. tp = ArchObject PageDirectoryObj \<longrightarrow> is_aligned ref pd_bits)\<rbrace>"
-  apply(rule hoare_strengthen_post)
-  apply(rule hoare_weaken_pre)
-  apply(rule retype_region_aligned_for_init)
-   apply simp
-  apply (clarsimp simp: obj_bits_api_def default_arch_object_def pd_bits_def pageBits_def)
   done
 
 declare wrap_ext_det_ext_ext_def[simp]
 
-lemma detype_integrity:
-  "\<lbrakk>integrity aag X st s; (\<forall> r\<in>refs. is_subject aag r)\<rbrakk> \<Longrightarrow>
-    integrity aag X st (detype refs s)"
-  apply (erule integrity_trans)
-  by (auto simp: detype_def detype_ext_def integrity_def)
-
-lemma state_vrefs_detype [simp]:
-  "state_vrefs (detype R s) = (\<lambda>x. if x \<in> R then {} else state_vrefs s x)"
-  unfolding state_vrefs_def
-  apply (rule ext)
-  apply (clarsimp simp: detype_def)
-  done
-
-lemma global_refs_detype [simp]:
-  "global_refs (detype R s) = global_refs s"
-  by(simp add: detype_def)
-
 lemma thread_states_detype[simp]:
   "thread_states (detype S s) = (\<lambda>x. if x \<in> S then {} else thread_states s x)"
-  by (rule ext, simp add: thread_states_def get_tcb_def  o_def detype_def tcb_states_of_state_def)
+  by (rule ext, simp add: thread_states_def get_tcb_def detype_def tcb_states_of_state_def)
 
 lemma thread_bound_ntfns_detype[simp]:
   "thread_bound_ntfns (detype S s) = (\<lambda>x. if x \<in> S then None else thread_bound_ntfns s x)"
-  by (rule ext, simp add: thread_bound_ntfns_def get_tcb_def  o_def detype_def tcb_states_of_state_def)
-
-lemma sta_detype:
-  "state_objs_to_policy (detype R s) \<subseteq> state_objs_to_policy s"
-  apply (clarsimp simp add: state_objs_to_policy_def state_refs_of_detype)
-  apply (erule state_bits_to_policy.induct)
-  apply (auto intro: state_bits_to_policy.intros split: if_split_asm)
-  done
+  by (rule ext, simp add: thread_bound_ntfns_def get_tcb_def detype_def tcb_states_of_state_def)
 
 lemma sita_detype:
   "state_irqs_to_policy aag (detype R s) \<subseteq> state_irqs_to_policy aag s"
@@ -322,125 +152,140 @@ lemma sita_detype:
   apply (auto simp: detype_def  intro: state_irqs_to_policy_aux.intros split: if_split_asm)
   done
 
-lemma sata_detype:
-  "state_asids_to_policy aag (detype R s) \<subseteq> state_asids_to_policy aag s"
-  apply (clarsimp)
-  apply (erule state_asids_to_policy_aux.induct)
-  apply (auto intro: state_asids_to_policy_aux.intros split: if_split_asm)
-  done
-
 (* FIXME: move *)
 lemmas pas_refined_by_subsets = pas_refined_state_objs_to_policy_subset
 
-
-lemma detype_irqs [simp]:
-  "interrupt_irq_node (detype R s) = interrupt_irq_node s"
-  unfolding detype_def by simp
-
 lemma dtsa_detype: "domains_of_state (detype R s) \<subseteq> domains_of_state s"
-by (auto simp: detype_def detype_ext_def
-        intro: domtcbs
-        elim!: domains_of_state_aux.cases
-        split: if_splits)
+  by (auto simp: detype_def detype_ext_def
+          intro: domtcbs
+          elim!: domains_of_state_aux.cases
+          split: if_splits)
+
+
+locale retype_region_proofs' = retype_region_proofs +
+  constrains s :: "det_ext state"
+  and s' :: "det_ext state"
+
+locale Retype_AC_1 =
+  fixes aag :: "'a PAS"
+  assumes state_vrefs_detype[simp]:
+    "state_vrefs (detype R s) = (\<lambda>x. if x \<in> R then {} else state_vrefs s x)"
+  and sata_detype:
+    "state_asids_to_policy aag (detype R s) \<subseteq> state_asids_to_policy aag s"
+  and untyped_min_bits_ge_2:
+    "2 \<le> untyped_min_bits"
+  and clas_default_cap:
+    "\<And>tp. tp \<noteq> ArchObject ASIDPoolObj \<Longrightarrow> cap_links_asid_slot aag l (default_cap tp p sz dev)"
+  and cli_default_cap:
+    "\<And>tp. tp \<noteq> ArchObject ASIDPoolObj \<Longrightarrow> cap_links_irq aag l (default_cap tp p sz dev)"
+  and aobj_refs'_default':
+    "\<And>tp. is_aligned p (obj_bits_api (ArchObject tp) n)
+           \<Longrightarrow> aobj_ref' (arch_default_cap tp p n dev) \<subseteq> ptr_range p (obj_bits_api (ArchObject tp) n)"
+  and init_arch_objects_pas_refined:
+    "\<And>tp. \<lbrace>pas_refined aag and post_retype_invs tp refs
+                            and (\<lambda>s. \<forall>x\<in>set refs. x \<notin> global_refs s)
+                            and K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api tp obj_sz))\<rbrace>
+           init_arch_objects tp ptr bits obj_sz refs
+           \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  and dmo_freeMemory_invs:
+    "do_machine_op (freeMemory ptr bits) \<lbrace>\<lambda>s :: det_ext state. invs s\<rbrace>"
+  and init_arch_objects_pas_cur_domain[wp]:
+    "\<And>tp. init_arch_objects tp ptr n us refs \<lbrace>pas_cur_domain aag\<rbrace>"
+  and retype_region_pas_cur_domain[wp]:
+    "\<And>tp. retype_region ptr n us tp dev \<lbrace>pas_cur_domain aag\<rbrace>"
+  and reset_untyped_cap_pas_cur_domain[wp]:
+    "reset_untyped_cap src_slot \<lbrace>pas_cur_domain aag\<rbrace>"
+  and arch_data_to_obj_type_not_ASIDPoolObj[simp]:
+    "arch_data_to_obj_type v \<noteq> Some ASIDPoolObj"
+  and data_to_nat_of_nat[simp]:
+    "\<And>x. of_nat (data_to_nat x) = x"
+  and nonzero_data_to_nat_simp:
+    "\<And>x. 0 < data_to_nat x \<Longrightarrow> 0 < x"
+  and retype_region_proofs_vrefs_eq:
+    "retype_region_proofs s ty us ptr sz n dev
+     \<Longrightarrow> state_vrefs (s\<lparr>kheap := \<lambda>x. if x \<in> set (retype_addrs ptr ty n us)
+                                   then Some (default_object ty dev us)
+                                   else kheap s x\<rparr>) =
+         state_vrefs s"
+  and retype_region_proofs'_pas_refined:
+    "\<lbrakk> retype_region_proofs' s ty us ptr sz n dev; invs s; pas_refined aag s \<rbrakk>
+       \<Longrightarrow> pas_refined aag (s\<lparr>kheap := \<lambda>x. if x \<in> set (retype_addrs ptr ty n us)
+                                           then Some (default_object ty dev us)
+                                           else kheap s x\<rparr>)"
+  and dmo_freeMemory_respects:
+    "\<lbrace>integrity aag X st and K (is_aligned ptr bits \<and> bits < word_bits \<and> 2 \<le> bits
+                                   \<and> (\<forall>p \<in> ptr_range ptr bits. is_subject aag p))\<rbrace>
+     do_machine_op (freeMemory ptr bits)
+     \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  and dmo_clearMemory_respects':
+    "\<lbrace>integrity aag X st and
+      K (is_aligned ptr bits \<and> bits < word_bits \<and> 2 \<le> bits \<and>
+         (\<forall>p \<in> ptr_range ptr bits. aag_has_auth_to aag Write p))\<rbrace>
+     do_machine_op (clearMemory ptr (2 ^ bits))
+     \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  and init_arch_objects_integrity:
+    "\<lbrace>integrity aag X st and K (\<forall>x\<in>set refs. is_subject aag x)
+                         and K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api new_type obj_sz))\<rbrace>
+     init_arch_objects new_type ptr num_objects obj_sz refs
+     \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+begin
+
+lemma detype_integrity:
+  "\<lbrakk> integrity aag X st s; \<forall>r\<in>refs. is_subject aag r \<rbrakk>
+     \<Longrightarrow> integrity aag X st (detype refs s)"
+  apply (erule integrity_trans)
+  apply (clarsimp simp: integrity_def)
+  apply (clarsimp simp: detype_def detype_ext_def integrity_def)
+  done
+
+lemma sta_detype:
+  "state_objs_to_policy (detype R s) \<subseteq> state_objs_to_policy s"
+  apply (clarsimp simp add: state_objs_to_policy_def state_refs_of_detype)
+  apply (erule state_bits_to_policy.induct)
+  apply (auto intro: state_bits_to_policy.intros split: if_split_asm)
+  done
 
 lemma pas_refined_detype:
   "pas_refined aag s \<Longrightarrow> pas_refined aag (detype R s)"
   apply (rule pas_refined_by_subsets)
-  apply (blast intro!: sta_detype sata_detype sita_detype detype_irqs dtsa_detype)+
-  done
-
-(* TODO: proof has mainly been copied from dmo_clearMemory_respects *)
-lemma dmo_freeMemory_respects:
-  "\<lbrace>integrity aag X st and
-     K (is_aligned ptr bits \<and> bits < word_bits \<and> 2 \<le> bits \<and>
-          (\<forall>p \<in> ptr_range ptr bits. is_subject aag p))\<rbrace>
-   do_machine_op (freeMemory ptr bits) \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  unfolding do_machine_op_def freeMemory_def
-  apply (simp add: split_def)
-  apply wp
-  apply clarsimp
-  apply (erule use_valid)
-   apply (wp mol_respects mapM_x_wp' storeWord_integrity_autarch)
-   apply simp
-   apply (clarsimp simp: word_size_def word_bits_def upto_enum_step_shift_red [where us=2, simplified])
-   apply (erule bspec)
-   apply (erule set_mp [rotated])
-   apply (rule ptr_range_subset)
-      apply simp
-     apply (simp add: is_aligned_mult_triv2 [where n = 2, simplified])
-    apply assumption
-   apply (erule word_less_power_trans_ofnat [where k = 2, simplified])
-    apply assumption
-   apply simp
-  apply simp
+  apply (blast intro!: sta_detype sata_detype sita_detype interrupt_irq_node_detype dtsa_detype)+
   done
 
 lemma delete_objects_respects[wp]:
-  "\<lbrace>integrity aag X st and
-    K (is_aligned ptr bits \<and> bits < word_bits \<and>
-       2 \<le> bits \<and> (\<forall>p\<in>ptr_range ptr bits. is_subject aag p))\<rbrace>
+  "\<lbrace>integrity aag X st and K (is_aligned ptr bits \<and> bits < word_bits \<and> 2 \<le> bits \<and>
+                              (\<forall>p\<in>ptr_range ptr bits. is_subject aag p))\<rbrace>
    delete_objects ptr bits
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
    apply (simp add: delete_objects_def)
    apply (rule_tac seq_ext)
    apply (rule hoare_triv[of P _ "%_. P" for P])
    apply (wp dmo_freeMemory_respects | simp)+
    by (fastforce simp: ptr_range_def intro!: detype_integrity)
 
-lemma storeWord_respects:
-  "\<lbrace>\<lambda>ms. integrity aag X st (s\<lparr>machine_state := ms\<rparr>)
-    \<and> (\<forall>p' \<in> ptr_range p 2. aag_has_auth_to aag Write p')\<rbrace>
-     storeWord p v
-   \<lbrace>\<lambda>a b. integrity aag X st (s\<lparr>machine_state := b\<rparr>)\<rbrace>"
-  unfolding storeWord_def
-  apply wp
-  apply (auto simp: integrity_def is_aligned_mask [symmetric]
-            intro!: trm_write ptr_range_memI ptr_range_add_memI)
-  done
-
-lemma dmo_clearMemory_respects':
-  "\<lbrace>integrity aag X st and K (is_aligned ptr bits \<and> bits < word_bits \<and> 2 \<le> bits \<and> (\<forall>p \<in> ptr_range ptr bits. aag_has_auth_to aag Write p))\<rbrace>
-  do_machine_op (clearMemory ptr (2 ^ bits))
-  \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  unfolding do_machine_op_def clearMemory_def
-  apply (simp add: split_def cleanCacheRange_PoU_def)
-  apply wp
-  apply clarsimp
-  apply (erule use_valid)
-   apply wp
-    apply (simp add: cleanByVA_PoU_def)
-    apply (wp mol_respects mapM_x_wp' storeWord_respects)+
-   apply simp
-   apply (clarsimp simp add: word_size_def word_bits_def upto_enum_step_shift_red[where us=2, simplified])
-   apply (erule bspec)
-   apply (erule set_mp [rotated])
-   apply (rule ptr_range_subset)
-      apply simp
-     apply (simp add: is_aligned_mult_triv2 [where n = 2, simplified])
-    apply assumption
-   apply (erule word_less_power_trans_ofnat [where k = 2, simplified])
-    apply assumption
-   apply simp
-  apply simp
-  done
-
 lemma integrity_work_units_completed_update[simp]:
   "integrity aag X st (work_units_completed_update f s) = integrity aag X st s"
   by (simp add: integrity_def)
 
+lemma integrity_irq_state_independent[intro!, simp]:
+  "integrity x y z (s\<lparr>machine_state :=
+                      machine_state s\<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>) =
+   integrity x y z s"
+  by (simp add: integrity_def)
+
 lemma reset_untyped_cap_integrity:
-  "\<lbrace>integrity aag X st and pas_refined aag
-      and valid_objs and cte_wp_at is_untyped_cap slot
-      and K (is_subject aag (fst slot))\<rbrace>
-     reset_untyped_cap slot
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and valid_objs
+                       and cte_wp_at is_untyped_cap slot
+                       and K (is_subject aag (fst slot))\<rbrace>
+   reset_untyped_cap slot
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: reset_untyped_cap_def)
   apply (rule hoare_pre)
    apply (wp set_cap_integrity_autarch dmo_clearMemory_respects'
          | simp add: unless_def)+
-     apply (rule valid_validE, rule_tac P="cap_aligned cap \<and> is_untyped_cap cap
-           \<and> (\<forall>r \<in> cap_range cap. aag_has_auth_to aag Write r)" in hoare_gen_asm)
+     apply (rule valid_validE)
+     apply (rule_tac P="cap_aligned cap \<and> is_untyped_cap cap \<and>
+                        (\<forall>r \<in> cap_range cap. aag_has_auth_to aag Write r)" in hoare_gen_asm)
      apply (rule validE_valid, rule mapME_x_wp')
      apply (rule hoare_pre)
       apply (wp mapME_x_inv_wp[OF hoare_pre(2)]  preemption_point_inv'
@@ -460,22 +305,36 @@ lemma reset_untyped_cap_integrity:
     apply (wp hoare_vcg_const_imp_lift get_cap_wp)+
   apply (clarsimp simp: cte_wp_at_caps_of_state)
   apply (frule caps_of_state_valid_cap, clarsimp+)
-  apply (clarsimp simp: cap_aligned_def is_cap_simps valid_cap_simps bits_of_def
-                        untyped_min_bits_def)
+  apply (clarsimp simp: cap_aligned_def is_cap_simps valid_cap_simps bits_of_def)
   apply (frule(2) cap_cur_auth_caps_of_state)
   apply (clarsimp simp: aag_cap_auth_def ptr_range_def aag_has_Control_iff_owns
-                        pas_refined_refl)
+                        pas_refined_refl le_trans[OF untyped_min_bits_ge_2])
   done
 
-lemma bool_enum[simp]: "(\<forall>x. d = (\<not> x)) = False" "(\<forall>x. d = x) = False"
-  by blast+
+lemma retype_region_integrity:
+  "\<lbrace>integrity aag X st and K (range_cover ptr sz (obj_bits_api type o_bits) num_objects \<and>
+                              (\<forall>x\<in>{ptr..(ptr && ~~ mask sz) + (2 ^ sz - 1)}. is_subject aag x))\<rbrace>
+   retype_region ptr num_objects o_bits type dev
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (rule hoare_gen_asm)+
+  apply (simp only: retype_region_def retype_region_ext_extended.dxo_eq)
+  apply (simp only: retype_addrs_def  retype_region_ext_def
+                    foldr_upd_app_if' fun_app_def K_bind_def)
+  apply wp
+  apply (clarsimp simp: not_less)
+  apply (erule integrity_trans)
+  apply (clarsimp simp add: integrity_def)
+  apply (fastforce intro: tro_lrefl tre_lrefl
+                    dest: retype_addrs_subset_ptr_bits[simplified retype_addrs_def]
+                    simp: image_def p_assoc_help power_sub)
+  done
 
 lemma invoke_untyped_integrity:
-  "\<lbrace>integrity aag X st and pas_refined aag
-        and valid_objs
-        and valid_untyped_inv ui and K (authorised_untyped_inv aag ui)\<rbrace>
-     invoke_untyped ui
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and valid_objs
+                       and valid_untyped_inv ui
+                       and K (authorised_untyped_inv aag ui)\<rbrace>
+   invoke_untyped ui
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_name_pre_state)
   apply (clarsimp simp only: valid_untyped_inv_wcap)
   apply (cases ui)
@@ -484,182 +343,50 @@ lemma invoke_untyped_integrity:
   apply (rule hoare_pre)
    apply (wp mapM_x_wp[OF _ subset_refl] create_cap_integrity
              init_arch_objects_integrity retype_region_integrity
-             retype_region_ret_is_subject retype_region_ret_pd_aligned
+             retype_region_ret_is_subject
              set_cap_integrity_autarch hoare_vcg_if_lift
              hoare_whenE_wp reset_untyped_cap_integrity
-         | clarsimp simp: split_paired_Ball
-         | erule in_set_zipE
-         | blast)+
+          | clarsimp simp: split_paired_Ball
+          | erule in_set_zipE
+          | blast)+
   apply (clarsimp simp: ptr_range_def p_assoc_help bits_of_def
                         cte_wp_at_caps_of_state)
   apply (frule(1) cap_cur_auth_caps_of_state, simp+)
   apply (clarsimp simp: aag_cap_auth_def pas_refined_all_auth_is_owns)
   apply (simp add: word_and_le2 field_simps
-        | erule ball_subset[where A="{a && c .. b}" for a b c]
-        | rule conjI impI)+
+         | erule ball_subset[where A="{a && c .. b}" for a b c]
+         | rule conjI impI)+
   done
-
-lemma clas_default_cap:
-  "tp \<noteq> ArchObject ASIDPoolObj \<Longrightarrow> cap_links_asid_slot aag p (default_cap tp p' sz dev)"
-  unfolding cap_links_asid_slot_def
-  apply (cases tp, simp_all)
-  apply (rename_tac aobject_type)
-  apply (case_tac aobject_type, simp_all add: arch_default_cap_def)
-  done
-
-lemma cli_default_cap:
-  "tp \<noteq> ArchObject ASIDPoolObj \<Longrightarrow> cap_links_irq aag p (default_cap tp p' sz dev)"
-  unfolding cap_links_irq_def
-  apply (cases tp, simp_all)
-  done
-
-lemma obj_refs_default_nut:
-  "\<lbrakk> tp \<noteq> Untyped; \<forall>atp. tp \<noteq> ArchObject atp \<rbrakk> \<Longrightarrow>
-  obj_refs (default_cap tp oref sz dev) = {oref}"
-  by (cases tp, simp_all add: arch_default_cap_def  split: aobject_type.splits)
 
 lemma obj_refs_default':
-  "is_aligned oref (obj_bits_api tp sz) \<Longrightarrow> obj_refs (default_cap tp oref sz dev) \<subseteq> ptr_range oref (obj_bits_api tp sz)"
-  by (cases tp, simp_all add: arch_default_cap_def ptr_range_memI obj_bits_api_def default_arch_object_def split: aobject_type.splits)
+  "is_aligned oref (obj_bits_api tp sz)
+   \<Longrightarrow> obj_refs (default_cap tp oref sz dev) \<subseteq> ptr_range oref (obj_bits_api tp sz)"
+  by (cases tp; auto simp: ptr_range_memI obj_bits_api_def dest: rev_subsetD[OF _ aobj_refs'_default'])
 
 lemma create_cap_pas_refined:
-  "\<lbrace>pas_refined aag and K (tp \<noteq> ArchObject ASIDPoolObj \<and> is_subject aag (fst p) \<and> is_subject aag (fst (fst ref)) \<and>
-    (\<forall>x \<in> ptr_range (snd ref) (obj_bits_api tp sz). is_subject aag x)
-    \<and> is_aligned (snd ref)  (obj_bits_api tp sz))\<rbrace>
-     create_cap tp sz p dev ref
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and
+    K (tp \<noteq> ArchObject ASIDPoolObj \<and> is_subject aag (fst p) \<and> is_subject aag (fst (fst ref)) \<and>
+       (\<forall>x \<in> ptr_range (snd ref) (obj_bits_api tp sz). is_subject aag x) \<and>
+       is_aligned (snd ref) (obj_bits_api tp sz))\<rbrace>
+   create_cap tp sz p dev ref
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: create_cap_def split_def)
   apply (wps | wp set_cdt_pas_refined set_cap_pas_refined set_original_wp | clarsimp)+
   apply (rule conjI)
    apply (cases "fst ref", clarsimp simp: pas_refined_refl)
   apply (cases "tp = Untyped")
-   apply (simp add: cap_links_asid_slot_def pas_refined_refl cap_links_irq_def aag_cap_auth_def ptr_range_def obj_bits_api_def)
-  apply (clarsimp simp add:  obj_refs_default_nut clas_default_cap pas_refined_refl cli_default_cap aag_cap_auth_def)
+   apply (simp add: cap_links_asid_slot_def pas_refined_refl cap_links_irq_def
+                    aag_cap_auth_def ptr_range_def obj_bits_api_def)
+  apply (clarsimp simp: clas_default_cap pas_refined_refl cli_default_cap aag_cap_auth_def)
   apply (drule obj_refs_default')
   apply (case_tac tp, simp_all)
   apply (auto intro: pas_refined_refl dest!: subsetD)
   done
 
-lemma pd_shifting_dual':
-  "is_aligned (pd::word32) pd_bits \<Longrightarrow>
-  pd + (vptr >> 20 << 2) && mask pd_bits = vptr >> 20 << 2"
-  apply (subst (asm) pd_bits_def)
-  apply (subst (asm) pageBits_def)
-  apply (simp add: pd_shifting_dual)
-  done
-
-lemma empty_table_update_from_arm_global_pts:
-  "\<lbrakk>valid_global_objs s;
-    kernel_base >> 20 \<le> y >> 20; y >> 20 \<le> 2 ^ (pd_bits - 2) - 1;
-    is_aligned pd pd_bits;
-    kheap s (arm_global_pd (arch_state s)) = Some (ArchObj (PageDirectory pda));
-    obj_at (empty_table (set (second_level_tables (arch_state s)))) pd s\<rbrakk>
-   \<Longrightarrow>
-   (\<forall>pdb. ko_at (ArchObj (PageDirectory pdb)) pd s \<longrightarrow>
-       empty_table (set (second_level_tables (arch_state s)))
-                   (ArchObj
-                     (PageDirectory
-                       (pdb(ucast (y >> 20) := pda (ucast (y >> 20)))))))"
-  apply(clarsimp simp: empty_table_def obj_at_def)
-  apply(clarsimp simp: valid_global_objs_def obj_at_def empty_table_def)
-  done
-
-lemma copy_global_mappings_pas_refined:
-  "is_aligned pd pd_bits \<Longrightarrow>
-   \<lbrace>pas_refined aag and valid_kernel_mappings and
-     valid_arch_state and valid_global_objs and valid_global_refs and
-     pspace_aligned\<rbrace>
-     copy_global_mappings pd
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply(simp add: copy_global_mappings_def)
-  apply(rule hoare_weaken_pre)
-  apply(wp)
-  (* Use \<circ> to avoid wp filtering out the global_pd condition here
-     TODO: see if we can clean this up *)
-  apply(rule_tac Q="\<lambda> rv s. is_aligned global_pd pd_bits \<and> (global_pd = (arm_global_pd \<circ> arch_state) s \<and> valid_kernel_mappings s \<and> valid_arch_state s \<and> valid_global_objs s \<and> valid_global_refs s \<and> pas_refined aag s)" in hoare_strengthen_post)
-  apply(rule mapM_x_wp[OF _ subset_refl])
-    apply (rule hoare_seq_ext)
-     apply(unfold o_def)
-     (* Use [1] so wp doesn't filter out the global_pd condition *)
-     apply(wp store_pde_pas_refined store_pde_valid_kernel_mappings_map_global)[1]
-     apply(frule subsetD[OF copy_global_mappings_index_subset])
-     apply(rule hoare_gen_asm[simplified K_def pred_conj_def conj_commute])
-     apply(simp add: get_pde_def)
-     apply(subst kernel_vsrefs_kernel_mapping_slots[symmetric])
-     apply(wp)
-     apply(clarsimp simp: get_pde_def pd_shifting' pd_shifting_dual' triple_shift_fun)
-     apply(subst (asm) obj_at_def, erule exE, erule conjE)
-     apply(rotate_tac -1, drule sym, simp)
-     apply(frule (1) valid_kernel_mappingsD[folded obj_at_def])
-     apply(clarsimp simp: kernel_mapping_slots_def shiftr_20_less
-                          empty_table_update_from_arm_global_pts
-                          global_refs_def pde_ref_def)
-     apply(fastforce)
-    apply fastforce
-   apply(rule gets_wp)
-  apply(simp, blast intro: invs_aligned_pdD)
-  done
-
-lemma copy_global_invs_mappings_restricted':
-  "pd \<in> S \<Longrightarrow>
-   \<lbrace>all_invs_but_equal_kernel_mappings_restricted S
-    and (\<lambda>s. S \<inter> global_refs s = {})
-    and K (is_aligned pd pd_bits)\<rbrace>
-    copy_global_mappings pd
-   \<lbrace>\<lambda>rv. all_invs_but_equal_kernel_mappings_restricted S\<rbrace>"
-  apply(rule hoare_weaken_pre)
-  apply(rule copy_global_invs_mappings_restricted)
-  apply(simp add: insert_absorb)
-  done
-
-lemma init_arch_objects_pas_refined:
-  "\<lbrace>pas_refined aag and
-    post_retype_invs tp refs and
-    (\<lambda> s. \<forall> x\<in>set refs. x \<notin> global_refs s) and
-    K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api tp obj_sz))\<rbrace>
-     init_arch_objects tp ptr bits obj_sz refs
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply(rule hoare_gen_asm)
-  apply(cases tp)
-       apply(simp_all add: init_arch_objects_def)
-       apply(wp | simp)+
-  apply(rename_tac aobject_type)
-  apply(case_tac aobject_type, simp_all)
-        apply((simp | wp)+)[5]
-   apply(wp)
-    apply(rule_tac Q="\<lambda> rv. pas_refined aag and all_invs_but_equal_kernel_mappings_restricted (set refs) and (\<lambda> s. \<forall> x\<in>set refs. x \<notin> global_refs s)" in hoare_strengthen_post)
-     apply(wp mapM_x_wp[OF _ subset_refl])
-     apply((wp copy_global_mappings_pas_refined
-               copy_global_invs_mappings_restricted'
-               copy_global_mappings_global_refs_inv
-               copy_global_invs_mappings_restricted' |
-            fastforce simp: obj_bits_api_def default_arch_object_def
-                            pd_bits_def pageBits_def)+)[2]
-   apply(wp dmo_invs hoare_vcg_const_Ball_lift
-            valid_irq_node_typ |
-         fastforce simp: post_retype_invs_def)+
-  done
-
 end
 
-locale retype_region_proofs' = retype_region_proofs + constrains s ::"det_ext state" and s' :: "det_ext state"
 
-context retype_region_proofs
-begin
-
-interpretation Arch . (*FIXME; arch_split*)
-
-lemma vs_refs_no_global_pts_default [simp]:
-  "vs_refs_no_global_pts (default_object ty dev us) = {}"
-  by (simp add: default_object_def default_arch_object_def tyunt
-                vs_refs_no_global_pts_def pde_ref2_def pte_ref_def
-                o_def
-           split: Structures_A.apiobject_type.splits aobject_type.splits)
-
-lemma vrefs_eq: "state_vrefs s' = state_vrefs s"
-  apply(rule ext)
-  apply(simp add: s'_def state_vrefs_def ps_def orthr split: option.split)
-  done
+context retype_region_proofs begin
 
 lemma ts_eq[simp]: "thread_states s' = thread_states s"
   apply (rule ext)
@@ -676,16 +403,11 @@ lemma bas_eq[simp]: "thread_bound_ntfns s' = thread_bound_ntfns s"
   apply (simp add: default_object_def default_tcb_def tyunt
             split: Structures_A.apiobject_type.split)
   done
+
 end
 
-lemma invs_mdb_cte':
-  "invs s \<Longrightarrow> mdb_cte_at (\<lambda>p. \<exists>c. caps_of_state s p = Some c \<and> NullCap \<noteq> c) (cdt s)"
-  by (drule invs_mdb) (simp add: valid_mdb_def2)
 
-context retype_region_proofs'
-begin
-
-interpretation Arch . (*FIXME; arch_split*)
+context retype_region_proofs' begin
 
 lemma domains_of_state: "domains_of_state s' \<subseteq> domains_of_state s"
   unfolding s'_def by simp
@@ -703,40 +425,14 @@ lemma caps_of_state_pres:
   "caps_of_state s p = Some cap \<Longrightarrow> caps_of_state s' p = Some cap"
   using cte_wp_at_pres by (simp add: F)
 
-lemma pas_refined: "invs s \<Longrightarrow> pas_refined aag s \<Longrightarrow> pas_refined aag s'"
-  apply(erule pas_refined_state_objs_to_policy_subset)
-     apply(simp add: state_objs_to_policy_def refs_eq vrefs_eq mdb_and_revokable)
-     apply(rule subsetI, rename_tac x, case_tac x, simp)
-     apply(erule state_bits_to_policy.cases)
-            apply (solves \<open>auto intro!: sbta_caps intro: caps_retype split: cap.split\<close>)
-           apply (solves \<open>auto intro!: sbta_untyped intro: caps_retype split: cap.split\<close>)
-          apply (blast intro: state_bits_to_policy.intros)
-         apply (blast intro: state_bits_to_policy.intros)
-        apply (force intro!: sbta_cdt
-                       dest: caps_of_state_pres invs_mdb_cte'[THEN mdb_cte_atD[rotated]])
-       apply (force intro!: sbta_cdt_transferable
-                      dest: caps_of_state_pres invs_mdb_cte'[THEN mdb_cte_atD[rotated]])
-      apply (simp add: vrefs_eq)
-      apply (blast intro: state_bits_to_policy.intros)
-     apply (simp add: vrefs_eq)
-     apply (force elim!: state_asids_to_policy_aux.cases
-                 intro: state_asids_to_policy_aux.intros caps_retype
-                 split: cap.split
-                 dest: sata_asid[OF caps_retype, rotated])
-    apply clarsimp
-    apply (erule state_irqs_to_policy_aux.cases)
-    apply (solves\<open>auto intro!: sita_controlled intro: caps_retype split: cap.split\<close>)
-   apply (rule domains_of_state)
-  apply simp
-  done
-
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma retype_region_ext_kheap_update:
   "\<lbrace>Q xs and R xs\<rbrace> retype_region_ext xs ty \<lbrace>\<lambda>_. Q xs\<rbrace>
-  \<Longrightarrow> \<lbrace>\<lambda>s. Q xs (kheap_update f s) \<and> R xs (kheap_update f s)\<rbrace> retype_region_ext xs ty \<lbrace>\<lambda>_ s. Q xs (kheap_update f s)\<rbrace>"
+   \<Longrightarrow> \<lbrace>\<lambda>s. Q xs (kheap_update f s) \<and> R xs (kheap_update f s)\<rbrace>
+       retype_region_ext xs ty
+       \<lbrace>\<lambda>_ s. Q xs (kheap_update f s)\<rbrace>"
   apply (clarsimp simp: valid_def retype_region_ext_def)
   apply (erule_tac x="kheap_update f s" in allE)
   apply (clarsimp simp: split_def bind_def gets_def get_def return_def modify_def put_def)
@@ -744,51 +440,54 @@ lemma retype_region_ext_kheap_update:
 
 lemma use_retype_region_proofs_ext':
   assumes x: "\<And>(s::det_ext state). \<lbrakk> retype_region_proofs s ty us ptr sz n dev; P s \<rbrakk>
-   \<Longrightarrow> Q (retype_addrs ptr ty n us) (s\<lparr>kheap :=
-           \<lambda>x. if x \<in> set (retype_addrs ptr ty n us)
-             then Some (default_object ty dev us )
-             else kheap s x\<rparr>)"
+                                      \<Longrightarrow> Q (retype_addrs ptr ty n us)
+                                            (s\<lparr>kheap := \<lambda>x. if x \<in> set (retype_addrs ptr ty n us)
+                                                            then Some (default_object ty dev us )
+                                                            else kheap s x\<rparr>)"
   assumes y: "\<And>xs. \<lbrace>Q xs and R xs\<rbrace> retype_region_ext xs ty \<lbrace>\<lambda>_. Q xs\<rbrace>"
   assumes z: "\<And>f xs s. R xs (kheap_update f s) = R xs s"
   shows
-    "\<lbrakk> ty = CapTableObject \<Longrightarrow> 0 < us;
-         \<And>s. P s \<Longrightarrow> Q (retype_addrs ptr ty n us) s \<rbrakk> \<Longrightarrow>
-    \<lbrace>\<lambda>s. valid_pspace s \<and> valid_mdb s \<and> range_cover ptr sz (obj_bits_api ty us) n
-        \<and> caps_overlap_reserved {ptr..ptr + of_nat n * 2 ^ obj_bits_api ty us - 1} s
-        \<and> caps_no_overlap ptr sz s \<and> pspace_no_overlap_range_cover ptr sz s
-        \<and> (\<exists>slot. cte_wp_at (\<lambda>c. up_aligned_area ptr sz \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s) \<and>
-        P s \<and> R (retype_addrs ptr ty n us) s\<rbrace> retype_region ptr n us ty dev \<lbrace>Q\<rbrace>"
+    "\<lbrakk> ty = CapTableObject \<Longrightarrow> 0 < us; \<And>s. P s \<Longrightarrow> Q (retype_addrs ptr ty n us) s \<rbrakk>
+       \<Longrightarrow> \<lbrace>\<lambda>s. valid_pspace s \<and> valid_mdb s \<and> range_cover ptr sz (obj_bits_api ty us) n \<and>
+                caps_overlap_reserved {ptr..ptr + of_nat n * 2 ^ obj_bits_api ty us - 1} s \<and>
+                caps_no_overlap ptr sz s \<and> pspace_no_overlap_range_cover ptr sz s \<and>
+                (\<exists>slot. cte_wp_at (\<lambda>c. up_aligned_area ptr sz \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s) \<and>
+                P s \<and> R (retype_addrs ptr ty n us) s\<rbrace>
+           retype_region ptr n us ty dev \<lbrace>Q\<rbrace>"
   apply (simp add: retype_region_def split del: if_split)
-  apply (rule hoare_pre, (wp|simp)+)
+  apply (rule hoare_pre, (wp | simp)+)
     apply (rule retype_region_ext_kheap_update[OF y])
-   apply (wp|simp)+
+   apply (wp | simp)+
   apply (clarsimp simp: retype_addrs_fold
                         foldr_upd_app_if fun_upd_def[symmetric])
   apply safe
   apply (rule x)
-   apply (rule retype_region_proofs.intro, simp_all)[1]
-   apply (fastforce simp add: range_cover_def obj_bits_api_def z
-     slot_bits_def word_bits_def cte_level_bits_def)+
-   done
+     apply (rule retype_region_proofs.intro, simp_all)[1]
+      apply (fastforce simp: range_cover_def obj_bits_api_def z slot_bits_def2 word_bits_def)+
+  done
 
-lemmas use_retype_region_proofs_ext
-    = use_retype_region_proofs_ext'[where Q="\<lambda>_. Q" and P=Q, simplified] for Q
+lemmas use_retype_region_proofs_ext =
+  use_retype_region_proofs_ext'[where Q="\<lambda>_. Q" and P=Q, simplified] for Q
+
+
+context is_extended begin
+
+lemma pas_refined_tcb_domain_map_wellformed':
+  assumes tdmw: "\<lbrace>tcb_domain_map_wellformed aag and P\<rbrace> f \<lbrace>\<lambda>_. tcb_domain_map_wellformed aag\<rbrace>"
+  shows "\<lbrace>pas_refined aag and P\<rbrace> f \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (simp add: pas_refined_def)
+  apply (wp tdmw)
+   apply (wp lift_inv)
+   apply simp+
+  done
 
 end
 
-lemma (in is_extended) pas_refined_tcb_domain_map_wellformed':
-  assumes tdmw: "\<lbrace>tcb_domain_map_wellformed aag and P\<rbrace> f \<lbrace>\<lambda>_. tcb_domain_map_wellformed aag\<rbrace>"
-  shows "\<lbrace>pas_refined aag and P\<rbrace> f \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-apply (simp add: pas_refined_def)
-apply (wp tdmw)
-apply (wp lift_inv)
-apply simp+
-done
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma retype_region_ext_pas_refined:
-  "\<lbrace>pas_refined aag and pas_cur_domain aag and K (\<forall>x\<in> set xs. is_subject aag x)\<rbrace> retype_region_ext xs ty \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and pas_cur_domain aag and K (\<forall>x\<in> set xs. is_subject aag x)\<rbrace>
+   retype_region_ext xs ty
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   including no_pre
   apply (subst and_assoc[symmetric])
   apply (wp retype_region_ext_extended.pas_refined_tcb_domain_map_wellformed')
@@ -801,23 +500,24 @@ lemma retype_region_ext_pas_refined:
   apply (force intro: domtcbs)
   done
 
+
+context Retype_AC_1 begin
+
 lemma retype_region_pas_refined:
   "\<lbrace>pas_refined aag and invs and pas_cur_domain aag and
-    caps_overlap_reserved
-            {ptr..ptr + of_nat num_objects * 2 ^ obj_bits_api type o_bits -
-                  1} and
+    caps_overlap_reserved {ptr..ptr + of_nat num_objects * 2 ^ obj_bits_api type o_bits - 1} and
     caps_no_overlap ptr sz and pspace_no_overlap_range_cover ptr sz and
-    (\<lambda>s. \<exists>slot. cte_wp_at (\<lambda>c. up_aligned_area ptr sz \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s) and
+    (\<lambda>s. \<exists>sl. cte_wp_at (\<lambda>c. up_aligned_area ptr sz \<subseteq> cap_range c \<and> cap_is_device c = dev) sl s) and
     K (range_cover ptr sz (obj_bits_api type o_bits) num_objects) and
     K (\<forall>x\<in>set (retype_addrs ptr type num_objects o_bits). is_subject aag x) and
     K ((type = CapTableObject \<longrightarrow> 0 < o_bits))\<rbrace>
-     retype_region ptr num_objects o_bits type dev
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+   retype_region ptr num_objects o_bits type dev
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (rule hoare_pre)
    apply (rule use_retype_region_proofs_ext'[where P = "invs and pas_refined aag"])
        apply clarsimp
-       apply (erule (2) retype_region_proofs'.pas_refined[OF retype_region_proofs'.intro])
+       apply (erule (2) retype_region_proofs'_pas_refined[OF retype_region_proofs'.intro])
       apply (wp retype_region_ext_pas_refined)
       apply simp
      apply auto
@@ -825,22 +525,21 @@ lemma retype_region_pas_refined:
 
 (* FIXME MOVE *)
 lemma retype_region_aag_bits:
-  "\<lbrace>\<lambda>s. P (null_filter (caps_of_state s)) (state_refs_of s) (cdt s) (state_vrefs s)
-       \<and> valid_pspace s \<and> valid_mdb s \<and>
-           caps_overlap_reserved
-            {ptr..ptr + of_nat num_objects * 2 ^ obj_bits_api tp us - 1} s \<and>
-           caps_no_overlap ptr sz s \<and> pspace_no_overlap_range_cover ptr sz s \<and>
-           (\<exists>slot. cte_wp_at (\<lambda>c. up_aligned_area ptr sz \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s)
-       \<and> ((tp = CapTableObject \<longrightarrow> 0 < us) \<and> range_cover ptr sz (obj_bits_api tp us) num_objects)\<rbrace>
-  retype_region ptr num_objects us tp dev
-  \<lbrace>\<lambda>_ s. P (null_filter (caps_of_state s)) (state_refs_of s) (cdt s) (state_vrefs s)\<rbrace>"
+  "\<lbrace>\<lambda>s :: det_ext state. P (null_filter (caps_of_state s)) (state_refs_of s) (cdt s) (state_vrefs s)
+        \<and> valid_pspace s \<and> valid_mdb s
+        \<and> caps_overlap_reserved {ptr..ptr + of_nat num_objects * 2 ^ obj_bits_api tp us - 1} s
+        \<and> caps_no_overlap ptr sz s \<and> pspace_no_overlap_range_cover ptr sz s
+        \<and> (\<exists>slot. cte_wp_at (\<lambda>c. up_aligned_area ptr sz \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s)
+        \<and> ((tp = CapTableObject \<longrightarrow> 0 < us) \<and> range_cover ptr sz (obj_bits_api tp us) num_objects)\<rbrace>
+   retype_region ptr num_objects us tp dev
+   \<lbrace>\<lambda>_ s. P (null_filter (caps_of_state s)) (state_refs_of s) (cdt s) (state_vrefs s)\<rbrace>"
   apply (subst conj_assoc [symmetric])+
   apply (rule hoare_gen_asm [unfolded pred_conj_def K_def])+
   apply (rule hoare_pre)
    apply (rule use_retype_region_proofs)
       apply (frule retype_region_proofs.null_filter, erule ssubst)
       apply (frule retype_region_proofs.refs_eq, erule ssubst)
-      apply (frule retype_region_proofs.vrefs_eq, erule ssubst)
+      apply (frule retype_region_proofs_vrefs_eq, erule ssubst)
       apply (frule retype_region_proofs.mdb_and_revokable, erule ssubst)
       apply assumption
      apply simp
@@ -849,10 +548,14 @@ lemma retype_region_aag_bits:
   apply blast
   done
 
+end
+
+
 lemma retype_region_ranges'':
   "\<lbrace>K (range_cover ptr sz (obj_bits_api tp us) num_objects \<and> num_objects \<noteq> 0)\<rbrace>
-  retype_region ptr num_objects us tp dev
-   \<lbrace>\<lambda>rv s. \<forall>y\<in>set rv. ptr_range y (obj_bits_api tp us) \<subseteq> {ptr..ptr + of_nat num_objects * 2 ^ (obj_bits_api tp us) - 1}\<rbrace>"
+   retype_region ptr num_objects us tp dev
+   \<lbrace>\<lambda>rv _. \<forall>y\<in>set rv. ptr_range y (obj_bits_api tp us) \<subseteq>
+                        {ptr..ptr + of_nat num_objects * 2 ^ (obj_bits_api tp us) - 1}\<rbrace>"
   apply simp
   apply (rule hoare_gen_asm[where P'="\<top>", simplified])
   apply (rule hoare_strengthen_post [OF retype_region_ret])
@@ -860,114 +563,39 @@ lemma retype_region_ranges'':
   apply (frule_tac p=y in range_cover_subset)
     apply assumption
    apply simp
-  apply(rule conjI)
+  apply (rule conjI)
    apply (fastforce simp: ptr_range_def ptr_add_def)
-  apply(clarsimp simp: ptr_range_def ptr_add_def intro: order_trans)
-  apply(erule order_trans)
-  apply(erule impE)
-   apply(simp add: p_assoc_help)
-   apply(rule is_aligned_no_wrap')
-    apply(rule is_aligned_add)
-     apply(fastforce simp: range_cover_def)
-    apply(simp add: is_aligned_mult_triv2)
-   apply(rule word_leq_le_minus_one, simp)
-   apply(rule power_not_zero)
-   apply(simp add: range_cover_def)
-  apply simp
-  done
-
-lemma region_in_kernel_window_preserved:
-  assumes "\<And> P. \<lbrace>\<lambda> s. P (arch_state s) \<rbrace> f \<lbrace>\<lambda> rv s. P (arch_state s) \<rbrace>"
-  shows "\<And> S. \<lbrace> region_in_kernel_window S \<rbrace> f \<lbrace> \<lambda>_. region_in_kernel_window S \<rbrace>"
-  apply(clarsimp simp: valid_def region_in_kernel_window_def)
-  apply(erule use_valid)
-  apply(rule assms)
+  apply (clarsimp simp: ptr_range_def ptr_add_def intro: order_trans)
+  apply (erule order_trans)
+  apply (erule impE)
+   apply (simp add: p_assoc_help)
+   apply (rule is_aligned_no_wrap')
+    apply (rule is_aligned_add)
+     apply (fastforce simp: range_cover_def)
+    apply (simp add: is_aligned_mult_triv2)
+   apply (rule word_leq_le_minus_one, simp)
+   apply (rule power_not_zero)
+   apply (simp add: range_cover_def)
   apply simp
   done
 
 lemma pspace_no_overlap_msu[simp]:
   "pspace_no_overlap S (machine_state_update f s) = pspace_no_overlap S s"
-  apply(clarsimp simp: pspace_no_overlap_def)
-  done
+  by (clarsimp simp: pspace_no_overlap_def)
 
 lemma descendants_range_in_msu[simp]:
   "descendants_range_in S slot (machine_state_update f s) = descendants_range_in S slot s"
-  apply(clarsimp simp: descendants_range_in_def)
-  done
-
-(* proof clagged from Retype_AI.clearMemory_vms *)
-lemma freeMemory_vms:
-  "valid_machine_state s \<Longrightarrow>
-   \<forall>x\<in>fst (freeMemory ptr bits (machine_state s)).
-   valid_machine_state (s\<lparr>machine_state := snd x\<rparr>)"
-  apply (clarsimp simp: valid_machine_state_def
-                        disj_commute[of "in_user_frame p s" for p s])
-  apply (drule_tac x=p in spec, simp)
-  apply (drule_tac P4="\<lambda>m'. underlying_memory m' p = 0"
-         in use_valid[where P=P and Q="\<lambda>_. P" for P], simp_all)
-  apply (simp add: freeMemory_def machine_op_lift_def
-                   machine_rest_lift_def split_def)
-  apply (wp hoare_drop_imps | simp | wp mapM_x_wp_inv)+
-   apply (simp add: storeWord_def | wp)+
-   apply (simp add: word_rsplit_0)+
-  done
-
-
-lemma dmo_freeMemory_vms:
-  "\<lbrace>valid_machine_state\<rbrace>
-     do_machine_op (freeMemory ptr bits)
-   \<lbrace>\<lambda>_. valid_machine_state\<rbrace>"
-  apply(unfold do_machine_op_def)
-  apply (wp modify_wp freeMemory_vms | simp add: split_def)+
-  done
-
-lemma freeMemory_valid_irq_states:
-  "\<lbrace>\<lambda>m. valid_irq_states (s\<lparr>machine_state := m\<rparr>) \<rbrace>
-   freeMemory ptr bits
-   \<lbrace>\<lambda>a b. valid_irq_states (s\<lparr>machine_state := b\<rparr>)\<rbrace>"
-  unfolding freeMemory_def
-  apply(wp mapM_x_wp[OF _ subset_refl] storeWord_valid_irq_states)
-  done
-
-crunch pspace_respects_device_region[wp]: freeMemory "\<lambda>ms. P (device_state ms)"
- (wp: crunch_wps)
-
-lemma dmo_freeMemory_invs:
-  "\<lbrace> invs \<rbrace>
-     do_machine_op (freeMemory ptr bits)
-   \<lbrace>\<lambda>_. invs\<rbrace>"
-  apply (simp add: do_machine_op_def invs_def valid_state_def cur_tcb_def | wp | wpc)+
-  apply (clarsimp)
-  apply (frule_tac P1="(=) (device_state (machine_state s))" in
-    use_valid[OF _ freeMemory_pspace_respects_device_region])
-   apply simp
-  apply simp
-  apply(rule conjI)
-   apply(erule use_valid[OF _ freeMemory_valid_irq_states], simp)
-  apply(drule freeMemory_vms)
-  by auto
-
-
-lemma delete_objects_pas_refined:
-  "\<lbrace>pas_refined aag\<rbrace> delete_objects ptr sz \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  apply(simp add: delete_objects_def do_machine_op_def)
-  apply (wp modify_wp | simp add: split_def)+
-  apply clarsimp
-  apply(rule pas_refined_detype)
-  apply simp
-  done
-
+  by (clarsimp simp: descendants_range_in_def)
 
 lemma cte_wp_at_sym:
   "cte_wp_at (\<lambda> c. c = cap) slot s = cte_wp_at ((=) cap) slot s"
-  apply(simp add: cte_wp_at_def)
-  done
+  by (simp add: cte_wp_at_def)
 
 lemma untyped_slots_not_in_untyped_range:
-  "\<lbrakk>invs s; descendants_range_in S slot s; cte_wp_at ((=) cap) slot s;
-    is_untyped_cap cap; S = untyped_range cap; T \<subseteq> S\<rbrakk> \<Longrightarrow>
-   fst slot \<notin> T"
-  apply(erule contra_subsetD)
+  "\<lbrakk> invs s; descendants_range_in S slot s; cte_wp_at ((=) cap) slot s;
+     is_untyped_cap cap; S = untyped_range cap; T \<subseteq> S\<rbrakk>
+     \<Longrightarrow> fst slot \<notin> T"
+  apply (erule contra_subsetD)
   proof -
   assume i: "invs s" and
          dr: "descendants_range_in S slot s" and
@@ -975,7 +603,7 @@ lemma untyped_slots_not_in_untyped_range:
          ut: "is_untyped_cap cap" and
           r: "S = untyped_range cap"
   hence dt: "detype_locale cap slot s"
-   by(simp add: detype_locale_def descendants_range_def2 invs_untyped_children)
+   by (simp add: detype_locale_def descendants_range_def2 invs_untyped_children)
   show "fst slot \<notin> S"
   apply -
   apply (insert r)
@@ -987,10 +615,10 @@ lemma untyped_slots_not_in_untyped_range:
   qed
 
 lemma descendants_range_in_detype:
-  "\<lbrakk>invs s; descendants_range_in S slot s; cte_wp_at ((=) cap) slot s;
-    is_untyped_cap cap; S = untyped_range cap; T \<subseteq> S\<rbrakk> \<Longrightarrow>
-   descendants_range_in T slot (detype S s)"
-  apply(erule descendants_range_in_subseteq[rotated])
+  "\<lbrakk> invs s; descendants_range_in S slot s; cte_wp_at ((=) cap) slot s;
+     is_untyped_cap cap; S = untyped_range cap; T \<subseteq> S \<rbrakk>
+     \<Longrightarrow> descendants_range_in T slot (detype S s)"
+  apply (erule descendants_range_in_subseteq[rotated])
   proof -
   assume i: "invs s" and
          dr: "descendants_range_in S slot s" and
@@ -998,144 +626,135 @@ lemma descendants_range_in_detype:
          ut: "is_untyped_cap cap" and
           r: "S = untyped_range cap"
   hence dt: "detype_locale cap slot s"
-   by(simp add: detype_locale_def descendants_range_def2 invs_untyped_children)
+   by (simp add: detype_locale_def descendants_range_def2 invs_untyped_children)
   show "descendants_range_in S slot (detype S s)"
   apply -
-  apply(insert i dr ct ut r)
-  apply(simp add: valid_mdb_descendants_range_in[OF invs_mdb])
-  apply(simp add: descendants_range_in_def)
-  apply(rule ballI)
-  apply(drule_tac x=p' in bspec, assumption)
-  apply(clarsimp simp: null_filter_def split: if_split_asm)
-  apply(rule conjI)
-   apply(simp add: cte_wp_at_caps_of_state)
-  apply(rule_tac t=a in ssubst[OF fst_conv[symmetric]])
-  apply(rule_tac ptr=slot and s=s in detype_locale.non_null_present)
-   apply(rule dt)
-  apply(simp add: cte_wp_at_caps_of_state)
+  apply (insert i dr ct ut r)
+  apply (simp add: valid_mdb_descendants_range_in[OF invs_mdb])
+  apply (simp add: descendants_range_in_def)
+  apply (rule ballI)
+  apply (drule_tac x=p' in bspec, assumption)
+  apply (clarsimp simp: null_filter_def split: if_split_asm)
+  apply (rule conjI)
+   apply (simp add: cte_wp_at_caps_of_state)
+  apply (rule_tac t=a in ssubst[OF fst_conv[symmetric]])
+  apply (rule_tac ptr=slot and s=s in detype_locale.non_null_present)
+   apply (rule dt)
+  apply (simp add: cte_wp_at_caps_of_state)
   apply fastforce
   done
   qed
 
 lemma descendants_range_in_detype_ex:
-  "\<lbrakk>invs s; descendants_range_in S slot s; \<exists> cap. cte_wp_at ((=) cap) slot s \<and>
-    is_untyped_cap cap \<and> S = untyped_range cap; T \<subseteq> S\<rbrakk> \<Longrightarrow>
-   descendants_range_in T slot (detype S s)"
+  "\<lbrakk> invs s; descendants_range_in S slot s; \<exists> cap. cte_wp_at ((=) cap) slot s \<and>
+     is_untyped_cap cap \<and> S = untyped_range cap; T \<subseteq> S \<rbrakk>
+     \<Longrightarrow> descendants_range_in T slot (detype S s)"
   apply clarsimp
-  apply(blast intro: descendants_range_in_detype)
+  apply (blast intro: descendants_range_in_detype)
   done
 
 lemma descendants_range_in_detype_ex_strengthen:
-  "(invs s \<and> descendants_range_in S slot s \<and> (\<exists> cap. cte_wp_at ((=) cap) slot s \<and>
-    is_untyped_cap cap \<and> S = untyped_range cap) \<and> T \<subseteq> S) \<longrightarrow>
-   descendants_range_in T slot (detype S s)"
-  apply(blast intro: descendants_range_in_detype_ex)
-  done
-
-lemma delete_objects_descendants_range_in':
-  notes modify_wp[wp del]
-  shows
-    "\<lbrace>invs and (\<lambda> s. \<exists> idx. cte_wp_at ((=) (UntypedCap dev word2 sz idx)) slot s) and
-     descendants_range_in {word2..word2 + 2 ^ sz - 1} slot\<rbrace>
-     (delete_objects word2 sz)
-     \<lbrace>\<lambda>_. descendants_range_in {word2..word2 + 2 ^ sz - 1} slot\<rbrace>"
-  apply(rule hoare_pre)
-   unfolding delete_objects_def
-   apply (wp modify_wp dmo_freeMemory_invs
-         | strengthen descendants_range_in_detype_ex_strengthen)+
-   apply (wp descendants_range_in_lift hoare_vcg_ex_lift | elim conjE | simp)+
-  apply clarsimp
-  apply(fastforce)
-  done
+  "(invs s \<and> descendants_range_in S slot s \<and> T \<subseteq> S \<and>
+    (\<exists>cap. cte_wp_at ((=) cap) slot s \<and> is_untyped_cap cap \<and> S = untyped_range cap))
+   \<longrightarrow> descendants_range_in T slot (detype S s)"
+  by (blast intro: descendants_range_in_detype_ex)
 
 lemma untyped_cap_aligned:
-  "\<lbrakk>cte_wp_at ((=) (UntypedCap dev word sz idx)) slot s; valid_objs s\<rbrakk> \<Longrightarrow>
-   is_aligned word sz"
-  apply(fastforce dest: cte_wp_at_valid_objs_valid_cap simp: valid_cap_def cap_aligned_def)
-  done
-
-lemma delete_objects_descendants_range_in'':
-  shows
-    "\<lbrace>invs and (\<lambda> s. \<exists> idx. cte_wp_at ((=) (UntypedCap dev word2 sz idx)) slot s) and
-     descendants_range_in {word2..word2 + 2 ^ sz - 1} slot\<rbrace>
-     (delete_objects word2 sz)
-     \<lbrace>\<lambda>_. descendants_range_in {word2..(word2 && ~~ mask sz) + 2 ^ sz - 1} slot\<rbrace>"
-  apply(clarsimp simp: valid_def)
-  apply(frule untyped_cap_aligned, fastforce)
-  apply(clarsimp)
-  apply(erule use_valid)
-   apply(wp delete_objects_descendants_range_in' | clarsimp | blast)+
-  done
-
-lemma delete_objects_descendants_range_in''':
-  shows
-    "\<lbrace>invs and (\<lambda> s. \<exists> idx. cte_wp_at ((=) (UntypedCap dev word2 sz idx)) slot s) and
-     descendants_range_in {word2..word2 + 2 ^ sz - 1} slot\<rbrace>
-     (delete_objects word2 sz)
-     \<lbrace>\<lambda>_. descendants_range_in {word2 && ~~ mask sz..(word2 && ~~ mask sz) + 2 ^ sz - 1} slot\<rbrace>"
-  apply(clarsimp simp: valid_def)
-  apply(frule untyped_cap_aligned, fastforce)
-  apply(clarsimp)
-  apply(erule use_valid)
-   apply(wp delete_objects_descendants_range_in' | clarsimp | blast)+
-  done
+  "\<lbrakk> cte_wp_at ((=) (UntypedCap dev word sz idx)) slot s; valid_objs s \<rbrakk>
+     \<Longrightarrow> is_aligned word sz"
+  by (fastforce dest: cte_wp_at_valid_objs_valid_cap simp: valid_cap_def cap_aligned_def)
 
 lemma range_cover_subset'':
-  "\<lbrakk>range_cover ptr sz sbit n; n \<noteq> 0\<rbrakk>
-  \<Longrightarrow> {ptr ..ptr + of_nat n * 2 ^ sbit - 1} \<subseteq> {ptr && ~~ mask sz..(ptr && ~~ mask sz) + 2^ sz - 1}"
+  "\<lbrakk> range_cover ptr sz sbit n; n \<noteq> 0 \<rbrakk>
+     \<Longrightarrow> {ptr ..ptr + of_nat n * 2 ^ sbit - 1} \<subseteq> {ptr && ~~ mask sz..(ptr && ~~ mask sz) + 2^ sz - 1}"
   apply (rule order_trans, erule(1) range_cover_subset')
   apply (simp add: word_and_le2)
   done
 
+
+context Retype_AC_1 begin
+
+lemma delete_objects_descendants_range_in':
+  "\<lbrace>invs and (\<lambda>s :: det_ext state. \<exists>idx. cte_wp_at ((=) (UntypedCap dev word2 sz idx)) slot s)
+         and descendants_range_in {word2..word2 + 2 ^ sz - 1} slot\<rbrace>
+   delete_objects word2 sz
+   \<lbrace>\<lambda>_. descendants_range_in {word2..word2 + 2 ^ sz - 1} slot\<rbrace>"
+  unfolding delete_objects_def
+  apply (wp modify_wp dmo_freeMemory_invs | strengthen descendants_range_in_detype_ex_strengthen)+
+   apply (wp descendants_range_in_lift hoare_vcg_ex_lift | elim conjE | simp)+
+  apply fastforce
+  done
+
+lemma delete_objects_descendants_range_in'':
+  "\<lbrace>invs and (\<lambda> s :: det_ext state. \<exists>idx. cte_wp_at ((=) (UntypedCap dev word2 sz idx)) slot s)
+         and descendants_range_in {word2..word2 + 2 ^ sz - 1} slot\<rbrace>
+   delete_objects word2 sz
+   \<lbrace>\<lambda>_. descendants_range_in {word2..(word2 && ~~ mask sz) + 2 ^ sz - 1} slot\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (frule untyped_cap_aligned, fastforce)
+  apply (clarsimp)
+  apply (erule use_valid)
+   apply (wp delete_objects_descendants_range_in' | clarsimp | blast)+
+  done
+
+lemma delete_objects_descendants_range_in''':
+  "\<lbrace>invs and (\<lambda>s :: det_ext state. \<exists>idx. cte_wp_at ((=) (UntypedCap dev word2 sz idx)) slot s)
+         and descendants_range_in {word2..word2 + 2 ^ sz - 1} slot\<rbrace>
+   delete_objects word2 sz
+   \<lbrace>\<lambda>_. descendants_range_in {word2 && ~~ mask sz..(word2 && ~~ mask sz) + 2 ^ sz - 1} slot\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (frule untyped_cap_aligned, fastforce)
+  apply (clarsimp)
+  apply (erule use_valid)
+   apply (wp delete_objects_descendants_range_in' | clarsimp | blast)+
+  done
+
 lemma delete_objects_descendants_range_in'''':
-  shows
-   "\<lbrace>invs and (\<lambda> s. \<exists> idx. cte_wp_at ((=) (UntypedCap dev word2 sz idx)) slot s) and
+  "\<lbrace>invs and (\<lambda> s :: det_ext state. \<exists>idx. cte_wp_at ((=) (UntypedCap dev word2 sz idx)) slot s) and
     ct_active and descendants_range_in {word2..word2 + 2 ^ sz - 1} slot and
-     K (range_cover word2 sz bits n \<and>
-        n \<noteq> 0)\<rbrace>
-          (delete_objects word2 sz)
-    \<lbrace>\<lambda>_. descendants_range_in {word2..word2 + of_nat n * 2 ^ bits - 1} slot\<rbrace>"
-  apply(clarsimp simp: valid_def)
-  apply(rule descendants_range_in_subseteq)
-  apply(erule use_valid)
-   apply(wp delete_objects_descendants_range_in' | clarsimp | blast)+
-  apply(drule range_cover_subset'', simp)
-  apply(fastforce dest: untyped_cap_aligned)
+    K (range_cover word2 sz bits n \<and> n \<noteq> 0)\<rbrace>
+   delete_objects word2 sz
+   \<lbrace>\<lambda>_. descendants_range_in {word2..word2 + of_nat n * 2 ^ bits - 1} slot\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (rule descendants_range_in_subseteq)
+   apply (erule use_valid)
+    apply (wp delete_objects_descendants_range_in' | clarsimp | blast)+
+  apply (drule range_cover_subset'', simp)
+  apply (fastforce dest: untyped_cap_aligned)
   done
 
 lemmas delete_objects_descendants_range_in =
-   delete_objects_descendants_range_in'
-   delete_objects_descendants_range_in''
-   delete_objects_descendants_range_in'''
-   delete_objects_descendants_range_in''''
+  delete_objects_descendants_range_in'
+  delete_objects_descendants_range_in''
+  delete_objects_descendants_range_in'''
+  delete_objects_descendants_range_in''''
 
-crunch global_refs[wp]: delete_objects "\<lambda> s. P (global_refs s)"
+end
+
+
+crunch arch_state[wp]: delete_objects "\<lambda>s. P (arch_state s)"
   (ignore: do_machine_op freeMemory)
 
-crunch arch_state[wp]: delete_objects "\<lambda> s. P (arch_state s)"
-  (ignore: do_machine_op freeMemory)
-
-
-
-lemma  bits_of_UntypedCap:
+lemma bits_of_UntypedCap:
   "bits_of (UntypedCap dev ptr sz free) = sz"
-  apply(simp add: bits_of_def split: cap.splits)
-  done
+  by (simp add: bits_of_def split: cap.splits)
 
 (* clagged from Untyped_R.invoke_untyped_proofs.usable_range_disjoint *)
 lemma usable_range_disjoint:
-  assumes cte_wp_at: "cte_wp_at ((=) (cap.UntypedCap dev (ptr && ~~ mask sz) sz idx)) cref s"
-  assumes  misc     : "distinct slots" "idx \<le> unat (ptr && mask sz) \<or> ptr = ptr && ~~ mask sz"
-  "invs s" "slots \<noteq> []" "ct_active s"
-  "\<forall>slot\<in>set slots. cte_wp_at ((=) cap.NullCap) slot s"
-  "\<forall>x\<in>set slots. ex_cte_cap_wp_to (\<lambda>_. True) x s"
+  assumes cte_wp_at: "cte_wp_at ((=) (UntypedCap dev (ptr && ~~ mask sz) sz idx)) cref s"
+  assumes misc: "distinct slots" "idx \<le> unat (ptr && mask sz) \<or> ptr = ptr && ~~ mask sz"
+                "invs s" "slots \<noteq> []" "ct_active s"
+                "\<forall>slot\<in>set slots. cte_wp_at ((=) NullCap) slot s"
+                "\<forall>x\<in>set slots. ex_cte_cap_wp_to (\<lambda>_. True) x s"
   assumes cover: "range_cover ptr sz (obj_bits_api tp us) (length slots)"
-  notes blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
-          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
+  notes blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff
+                         atLeastatMost_subset_iff atLeastLessThan_iff
+                         Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
   shows
-       "usable_untyped_range (cap.UntypedCap dev (ptr && ~~ mask sz) sz
-       (unat ((ptr && mask sz) + of_nat (length slots) * 2 ^ obj_bits_api tp us))) \<inter>
-       {ptr..ptr + of_nat (length slots) * 2 ^ obj_bits_api tp us - 1} = {}"
+       "usable_untyped_range (UntypedCap dev (ptr && ~~ mask sz) sz
+                                         (unat ((ptr && mask sz) +
+                                          of_nat (length slots) * 2 ^ obj_bits_api tp us))) \<inter>
+        {ptr..ptr + of_nat (length slots) * 2 ^ obj_bits_api tp us - 1} = {}"
       proof -
       have not_0_ptr[simp]: "ptr\<noteq> 0"
       using misc cte_wp_at
@@ -1163,81 +782,140 @@ lemma usable_range_disjoint:
      qed
 
 lemma set_free_index_invs':
-  "\<lbrace> (\<lambda>s. invs s \<and>
-         cte_wp_at ((=) cap) slot s \<and>
+  "\<lbrace>(\<lambda>s. invs s \<and> cte_wp_at ((=) cap) slot s \<and>
          (free_index_of cap \<le> idx' \<or>
           (descendants_range_in {word1..word1 + 2 ^ (bits_of cap) - 1} slot s \<and>
-           pspace_no_overlap_range_cover word1 (bits_of cap) s)) \<and>
-         idx' \<le> 2 ^ cap_bits cap \<and>
-         is_untyped_cap cap) and K(word1 = obj_ref_of cap \<and> dev = (cap_is_device cap))\<rbrace>
-       set_cap
-           (UntypedCap dev word1 (bits_of cap) idx')
-            slot
-       \<lbrace>\<lambda>_. invs \<rbrace>"
-  apply(rule hoare_gen_asm)
-  apply(case_tac cap, simp_all add: bits_of_def)
-  apply(case_tac "free_index_of cap \<le> idx'")
+          pspace_no_overlap_range_cover word1 (bits_of cap) s)) \<and>
+         idx' \<le> 2 ^ cap_bits cap \<and> is_untyped_cap cap) and
+    K (word1 = obj_ref_of cap \<and> dev = (cap_is_device cap))\<rbrace>
+   set_cap (UntypedCap dev word1 (bits_of cap) idx') slot
+   \<lbrace>\<lambda>_. invs \<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (case_tac cap, simp_all add: bits_of_def)
+  apply (case_tac "free_index_of cap \<le> idx'")
    apply simp
-    apply(cut_tac cap=cap and cref=slot and idx="idx'" in set_free_index_invs)
-    apply(simp add: free_index_update_def conj_comms is_cap_simps)
+    apply (cut_tac cap=cap and cref=slot and idx="idx'" in set_free_index_invs)
+   apply (simp add: free_index_of_def)
+   apply (rule hoare_weaken_pre, assumption, fastforce elim: cte_wp_at_weakenE)
    apply simp
-   apply(wp set_untyped_cap_invs_simple | simp)+
-   apply(fastforce simp: cte_wp_at_def)
-   done
+   apply (wp set_untyped_cap_invs_simple | simp)+
+   apply (fastforce simp: cte_wp_at_def)
+  done
 
 lemma delete_objects_pspace_no_overlap:
-  "\<lbrace> pspace_aligned and valid_objs and
-     cte_wp_at ((=) (UntypedCap dev ptr sz idx)) slot\<rbrace>
-    delete_objects ptr sz
-   \<lbrace>\<lambda>rv. pspace_no_overlap_range_cover ptr sz\<rbrace>"
+  "\<lbrace>pspace_aligned and valid_objs and cte_wp_at ((=) (UntypedCap dev ptr sz idx)) slot\<rbrace>
+   delete_objects ptr sz
+   \<lbrace>\<lambda>_. pspace_no_overlap_range_cover ptr sz\<rbrace>"
   unfolding delete_objects_def do_machine_op_def
-  apply(wp | simp add: split_def detype_machine_state_update_comm)+
+  apply (wp | simp add: split_def detype_machine_state_update_comm)+
   apply clarsimp
-  apply(rule pspace_no_overlap_detype)
-   apply(auto dest: cte_wp_at_valid_objs_valid_cap)
+  apply (rule pspace_no_overlap_detype)
+   apply (auto dest: cte_wp_at_valid_objs_valid_cap)
   done
 
 lemma delete_objects_pspace_no_overlap':
-  "\<lbrace> pspace_aligned and valid_objs and
-     cte_wp_at ((=) (UntypedCap dev ptr sz idx)) slot\<rbrace>
-    delete_objects ptr sz
-   \<lbrace>\<lambda>rv. pspace_no_overlap_range_cover (ptr && ~~ mask sz) sz\<rbrace>"
-  apply(clarsimp simp: valid_def)
-  apply(frule untyped_cap_aligned, simp)
-  apply(clarsimp)
-  apply(frule(1) cte_wp_at_valid_objs_valid_cap)
-  apply(erule use_valid, wp delete_objects_pspace_no_overlap, auto)
+  "\<lbrace>pspace_aligned and valid_objs and cte_wp_at ((=) (UntypedCap dev ptr sz idx)) slot\<rbrace>
+   delete_objects ptr sz
+   \<lbrace>\<lambda>_. pspace_no_overlap_range_cover (ptr && ~~ mask sz) sz\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (frule untyped_cap_aligned, simp)
+  apply (clarsimp)
+  apply (frule(1) cte_wp_at_valid_objs_valid_cap)
+  apply (erule use_valid, wp delete_objects_pspace_no_overlap, auto)
   done
 
 (* FIXME: move *)
 lemma valid_cap_range_untyped:
-  "\<lbrakk> valid_objs s; cte_wp_at ((=) (UntypedCap dev (ptr && ~~ mask sz) sz idx)) slot s\<rbrakk>
-  \<Longrightarrow> cte_wp_at (\<lambda>c. up_aligned_area ptr sz \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s"
+  "\<lbrakk> valid_objs s; cte_wp_at ((=) (UntypedCap dev (ptr && ~~ mask sz) sz idx)) slot s \<rbrakk>
+     \<Longrightarrow> cte_wp_at (\<lambda>c. up_aligned_area ptr sz \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s"
   apply (rule cte_wp_at_weakenE)
    apply simp
   apply (clarsimp simp: word_and_le2 p_assoc_help)
   done
 
+fun slot_of_untyped_inv where "slot_of_untyped_inv (Retype slot _ _ _ _ _ _ _) = slot"
+
+lemma aag_cap_auth_UntypedCap_idx_dev:
+  "aag_cap_auth aag l (UntypedCap dev base sz idx)
+   \<Longrightarrow> aag_cap_auth aag l (UntypedCap dev' base sz idx')"
+  by (clarsimp simp: aag_cap_auth_def cap_links_asid_slot_def
+                     cap_links_irq_def)
+
+lemma cte_wp_at_pas_cap_cur_auth_UntypedCap_idx_dev:
+  "\<lbrakk> cte_wp_at ((=) (UntypedCap dev base sz idx)) slot s;
+     is_subject aag (fst slot); pas_refined aag s\<rbrakk>
+     \<Longrightarrow> pas_cap_cur_auth aag (UntypedCap dev' base sz idx')"
+  apply (rule aag_cap_auth_UntypedCap_idx_dev)
+  apply (auto intro: cap_cur_auth_caps_of_state simp: cte_wp_at_caps_of_state)
+  done
+
+lemmas caps_pas_cap_cur_auth_UntypedCap_idx_dev =
+  cte_wp_at_pas_cap_cur_auth_UntypedCap_idx_dev[OF caps_of_state_cteD]
+
+lemma retype_addrs_aligned_range_cover:
+  assumes xin: "x \<in> set (retype_addrs ptr ty n us)"
+  and co: "range_cover ptr sz (obj_bits_api ty us) n"
+  shows "is_aligned x (obj_bits_api ty us)"
+  using co
+  apply (clarsimp simp: range_cover_def)
+  apply (rule retype_addrs_aligned[OF xin, where sz=sz], simp_all)
+  apply (simp add: word_bits_def)
+  done
+
+lemma pas_refined_work_units_complete[simp]:
+  "pas_refined aag (work_units_completed_update f s) = pas_refined aag s"
+  by (simp add: pas_refined_def)
+
+(*FIXME MOVE *)
+lemma set_cap_sets_direct:
+  "P cap \<Longrightarrow> \<lbrace>\<top>\<rbrace> set_cap cap slot \<lbrace>\<lambda>_. cte_wp_at P slot\<rbrace>"
+  apply (rule hoare_strengthen_post)
+   apply (rule set_cap_sets)
+  apply (erule cte_wp_at_lift)
+  by blast
+
+(*FIXME MOVE *)
+lemma set_cap_sets_wp:
+  "\<lbrace>\<lambda>_. P cap\<rbrace> set_cap cap slot \<lbrace>\<lambda>_. cte_wp_at P slot\<rbrace>"
+  by (rule hoare_gen_asm2[simplified]) (erule set_cap_sets_direct)
+
+lemma retype_region_post_retype_invs_spec:
+  "\<lbrace>invs and caps_no_overlap ptr sz and pspace_no_overlap_range_cover ptr sz
+         and caps_overlap_reserved {ptr..ptr + of_nat n * 2 ^ obj_bits_api ty us - 1}
+         and region_in_kernel_window {ptr .. (ptr && ~~ mask sz) + 2 ^ sz - 1}
+         and (\<lambda>s. \<exists>idx. cte_wp_at ((=) (UntypedCap dev (ptr && ~~ mask sz) sz idx)) slot s)
+         and K (ty = Structures_A.CapTableObject \<longrightarrow> 0 < us)
+         and K (range_cover ptr sz (obj_bits_api ty us) n) \<rbrace>
+   retype_region ptr n us ty dev
+   \<lbrace>\<lambda>rv. post_retype_invs ty rv\<rbrace>"
+  apply (rule hoare_pre)
+  apply (wp retype_region_post_retype_invs)
+  apply (clarsimp simp del: split_paired_Ex)
+  apply (frule valid_cap_range_untyped[OF invs_valid_objs],simp)
+  apply fastforce
+  done
+
+
+context Retype_AC_1 begin
+
 lemma retype_region_pas_refined':
   "\<lbrace>pas_refined aag and pas_cur_domain aag and invs and
-    caps_overlap_reserved
-            {ptr..ptr + of_nat num_objects * 2 ^ obj_bits_api type o_bits -
-                  1} and
-    (\<lambda> s. \<exists> idx. cte_wp_at (\<lambda> c. c = (UntypedCap dev (ptr && ~~ mask sz) sz idx)) slot s \<and>
-                 (idx \<le> unat (ptr && mask sz) \<or>
-                  (descendants_range_in {ptr..(ptr && ~~ mask sz) + 2 ^ sz - 1} slot s) \<and>
-                    pspace_no_overlap_range_cover ptr sz s)) and
+    caps_overlap_reserved {ptr..ptr + of_nat num_objects * 2 ^ obj_bits_api type o_bits - 1} and
+    (\<lambda>s. \<exists>idx. cte_wp_at (\<lambda> c. c = (UntypedCap dev (ptr && ~~ mask sz) sz idx)) slot s \<and>
+               (idx \<le> unat (ptr && mask sz) \<or>
+                (descendants_range_in {ptr..(ptr && ~~ mask sz) + 2 ^ sz - 1} slot s) \<and>
+                pspace_no_overlap_range_cover ptr sz s)) and
     K (sz < word_bits) and
     K (range_cover ptr sz (obj_bits_api type o_bits) num_objects) and
     K (\<forall>x\<in>set (retype_addrs ptr type num_objects o_bits). is_subject aag x) and
     K ((type = CapTableObject \<longrightarrow> 0 < o_bits))\<rbrace>
-     retype_region ptr num_objects o_bits type dev
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+   retype_region ptr num_objects o_bits type dev
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)+
   apply (rule hoare_weaken_pre)
    apply (rule use_retype_region_proofs_ext'[where P="invs and pas_refined aag"])
        apply clarsimp
-       apply (erule (2) retype_region_proofs'.pas_refined[OF retype_region_proofs'.intro])
+       apply (erule (2) retype_region_proofs'_pas_refined[OF retype_region_proofs'.intro])
       apply (wp retype_region_ext_pas_refined)
       apply simp
      apply fastforce
@@ -1252,83 +930,29 @@ lemma retype_region_pas_refined':
                simp: cte_wp_at_sym)
   done
 
-
-lemma free_index_of_UntypedCap:
-  "free_index_of (UntypedCap dev ptr sz idx) = idx"
-  apply(simp add: free_index_of_def)
+lemma delete_objects_pas_refined:
+  "delete_objects ptr sz \<lbrace>pas_refined aag\<rbrace>"
+  apply (simp add: delete_objects_def do_machine_op_def)
+  apply (wp modify_wp | simp add: split_def)+
+  apply clarsimp
+  apply (rule pas_refined_detype)
+  apply simp
   done
-
-fun slot_of_untyped_inv where "slot_of_untyped_inv (Retype slot _ _ _ _ _ _ _) = slot"
-
-lemma region_in_kernel_window_subseteq:
-  "\<lbrakk> region_in_kernel_window S s; T \<subseteq> S\<rbrakk> \<Longrightarrow>
-     region_in_kernel_window T s"
-  apply(fastforce simp: region_in_kernel_window_def)
-  done
-
-lemma aag_cap_auth_UntypedCap_idx_dev:
-   "aag_cap_auth aag l (UntypedCap dev base sz idx) \<Longrightarrow>
-    aag_cap_auth aag l (UntypedCap dev' base sz idx')"
-  by (clarsimp simp: aag_cap_auth_def cap_links_asid_slot_def
-                     cap_links_irq_def)
-
-lemma cte_wp_at_pas_cap_cur_auth_UntypedCap_idx_dev:
-  "\<lbrakk>cte_wp_at ((=) (UntypedCap dev base sz idx)) slot s; is_subject aag (fst slot);
-    pas_refined aag s\<rbrakk> \<Longrightarrow>
-  pas_cap_cur_auth aag (UntypedCap dev' base sz idx')"
-  apply(rule aag_cap_auth_UntypedCap_idx_dev)
-  apply(auto intro: cap_cur_auth_caps_of_state simp: cte_wp_at_caps_of_state)
-  done
-
-lemmas caps_pas_cap_cur_auth_UntypedCap_idx_dev
-    = cte_wp_at_pas_cap_cur_auth_UntypedCap_idx_dev[OF caps_of_state_cteD]
-
-lemma retype_addrs_aligned_range_cover:
-  assumes xin: "x \<in> set (retype_addrs ptr ty n us)"
-  and co: "range_cover ptr sz (obj_bits_api ty us) n"
-  shows   "is_aligned x (obj_bits_api ty us)"
-  using co
-  apply (clarsimp simp: range_cover_def)
-  apply (rule retype_addrs_aligned[OF xin, where sz=sz], simp_all)
-  apply (simp add: word_bits_def)
-  done
-
-lemma pas_refined_work_units_complete[simp]:
-  "pas_refined aag (work_units_completed_update f s) = pas_refined aag s"
-  by (simp add: pas_refined_def)
-
-(*FIXME MOVE *)
-lemma set_cap_sets_direct:
-  "P cap \<Longrightarrow>
-   \<lbrace>\<top>\<rbrace>
-     set_cap cap slot
-   \<lbrace>\<lambda>rv. cte_wp_at P slot\<rbrace>"
-  apply (rule hoare_strengthen_post)
-   apply (rule set_cap_sets)
-  apply (erule cte_wp_at_lift)
-  by blast
-
-(*FIXME MOVE *)
-lemma set_cap_sets_wp:
-  "\<lbrace>\<lambda>_. P cap\<rbrace>
-     set_cap cap slot
-   \<lbrace>\<lambda>rv. cte_wp_at P slot\<rbrace>"
-  by (rule hoare_gen_asm2[simplified]) (erule set_cap_sets_direct)
 
 lemma reset_untyped_cap_pas_refined[wp]:
   "\<lbrace>pas_refined aag and cte_wp_at is_untyped_cap slot
-      and cte_wp_at (\<lambda>c. fst slot \<notin> untyped_range c) slot
-      and K (is_subject aag (fst slot))\<rbrace>
-    reset_untyped_cap slot
-  \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+                    and cte_wp_at (\<lambda>c. fst slot \<notin> untyped_range c) slot
+                    and K (is_subject aag (fst slot))\<rbrace>
+   reset_untyped_cap slot
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (clarsimp simp: reset_untyped_cap_def)
   apply (rule hoare_pre)
    apply (wps | wp set_cap_pas_refined_not_transferable | simp add: unless_def)+
      apply (rule valid_validE)
      apply (rule_tac P="is_untyped_cap cap \<and> pas_cap_cur_auth aag cap" in hoare_gen_asm)
-     apply (rule_tac Q= "\<lambda>_.cte_wp_at (\<lambda> c. \<not> is_transferable (Some c)) slot and pas_refined aag"
-                     in hoare_strengthen_post)
+     apply (rule_tac Q="\<lambda>_.cte_wp_at (\<lambda> c. \<not> is_transferable (Some c)) slot and pas_refined aag"
+                  in hoare_strengthen_post)
       apply (rule validE_valid, rule mapME_x_inv_wp)
       apply (rule hoare_pre)
        apply (wps
@@ -1337,36 +961,18 @@ lemma reset_untyped_cap_pas_refined[wp]:
       apply (fastforce simp: is_cap_simps aag_cap_auth_UntypedCap_idx_dev bits_of_def)
      apply blast
     apply (wps
-          | wp hoare_vcg_const_imp_lift get_cap_wp delete_objects_pas_refined hoare_drop_imp
-          | simp)+
+           | wp hoare_vcg_const_imp_lift get_cap_wp delete_objects_pas_refined hoare_drop_imp
+           | simp)+
   apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps bits_of_def)
   apply (auto elim: caps_pas_cap_cur_auth_UntypedCap_idx_dev)
   done
 
-lemma retype_region_post_retype_invs_spec:
-  "\<lbrace>invs and caps_no_overlap ptr sz and pspace_no_overlap_range_cover ptr sz
-      and caps_overlap_reserved {ptr..ptr + of_nat n * 2 ^ obj_bits_api ty us - 1}
-      and region_in_kernel_window {ptr .. (ptr && ~~ mask sz) + 2 ^ sz - 1}
-      and (\<lambda>s. \<exists>idx. cte_wp_at ((=) (UntypedCap dev (ptr && ~~ mask sz) sz idx)) slot s)
-      and K (ty = Structures_A.CapTableObject \<longrightarrow> 0 < us)
-      and K (range_cover ptr sz (obj_bits_api ty us) n) \<rbrace>
-      retype_region ptr n us ty dev\<lbrace>\<lambda>rv. post_retype_invs ty rv\<rbrace>"
-  apply (rule hoare_pre)
-  apply (wp retype_region_post_retype_invs)
-  apply (clarsimp simp del: split_paired_Ex)
-  apply (frule valid_cap_range_untyped[OF invs_valid_objs],simp)
-  apply fastforce
-  done
-
 lemma invoke_untyped_pas_refined:
-  notes modify_wp[wp del]
-  notes usable_untyped_range.simps[simp del]
-  shows
   "\<lbrace>pas_refined aag and pas_cur_domain aag and invs and valid_untyped_inv ui
-      and ct_active and K (authorised_untyped_inv aag ui)\<rbrace>
-     invoke_untyped ui
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply(rule hoare_gen_asm)
+                    and ct_active and K (authorised_untyped_inv aag ui)\<rbrace>
+   invoke_untyped ui
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (rule hoare_gen_asm)
   apply (rule hoare_pre)
    apply (rule_tac Q="\<lambda>_. pas_refined aag and pas_cur_domain aag" in hoare_strengthen_post)
    apply (rule invoke_untyped_Q)
@@ -1376,12 +982,12 @@ lemma invoke_untyped_pas_refined:
                               retype_addrs_aligned_range_cover)
         apply (clarsimp simp: cte_wp_at_caps_of_state
                               is_cap_simps ptr_range_def[symmetric])
-        apply (frule cap_cur_auth_caps_of_state[where
-            cap="cap.UntypedCap dev p sz idx" for dev p sz idx], simp+)
+        apply (frule cap_cur_auth_caps_of_state
+                     [where cap="UntypedCap dev p sz idx" for dev p sz idx], simp+)
         apply (clarsimp simp add: aag_cap_auth_def ptr_range_def[symmetric]
                                   pas_refined_all_auth_is_owns)
         apply blast
-       apply (rule hoare_pre, wp init_arch_objects_pas_refined)
+       apply (wp init_arch_objects_pas_refined)
        apply (clarsimp simp: retype_addrs_aligned_range_cover
                              cte_wp_at_caps_of_state)
        apply (drule valid_global_refsD[rotated 2])
@@ -1417,31 +1023,24 @@ lemma invoke_untyped_pas_refined:
                            cte_wp_at_caps_of_state authorised_untyped_inv_def)+
   done
 
-subsection\<open>decode\<close>
+end
 
-lemma data_to_obj_type_ret_not_asid_pool:
-  "\<lbrace> \<top> \<rbrace> data_to_obj_type v \<lbrace> \<lambda>r s. r \<noteq> ArchObject ASIDPoolObj \<rbrace>,-"
-  apply(clarsimp simp: validE_R_def validE_def valid_def)
-  apply(auto simp: data_to_obj_type_def arch_data_to_obj_type_def throwError_def simp: returnOk_def bindE_def return_def bind_def lift_def split: if_split_asm)
-  done
+
+subsection\<open>decode\<close>
 
 definition authorised_untyped_inv' where
  "authorised_untyped_inv' aag ui \<equiv> case ui of
-     Invocations_A.untyped_invocation.Retype src_slot reset base aligned_free_ref new_type obj_sz slots dev \<Rightarrow>
+     Retype src_slot reset base aligned_free_ref new_type obj_sz slots dev \<Rightarrow>
        is_subject aag (fst src_slot) \<and> (0 :: obj_ref) < of_nat (length slots) \<and>
-       new_type \<noteq> ArchObject ASIDPoolObj \<and>
-       (\<forall>x\<in>set slots. is_subject aag (fst x))"
+       new_type \<noteq> ArchObject ASIDPoolObj \<and> (\<forall>x\<in>set slots. is_subject aag (fst x))"
 
 lemma authorised_untyped_invI:
   notes blah[simp del] = atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
-          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
-
-  shows
-  "\<lbrakk>valid_untyped_inv ui s; pas_refined aag s;
-        authorised_untyped_inv' aag ui\<rbrakk> \<Longrightarrow>
-   authorised_untyped_inv aag ui"
-  apply(case_tac ui)
-  apply(clarsimp simp: cte_wp_at_caps_of_state
+                         Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
+  shows "\<lbrakk> valid_untyped_inv ui s; pas_refined aag s; authorised_untyped_inv' aag ui \<rbrakk>
+           \<Longrightarrow> authorised_untyped_inv aag ui"
+  apply (case_tac ui)
+  apply (clarsimp simp: cte_wp_at_caps_of_state
                        authorised_untyped_inv_def authorised_untyped_inv'_def
                   del: ballI)
   apply (frule(1) cap_cur_auth_caps_of_state, simp)
@@ -1449,75 +1048,73 @@ lemma authorised_untyped_invI:
   apply (frule range_cover_subset'', simp)
   apply (frule retype_addrs_subset_ptr_bits)
   apply (subgoal_tac "case ui of Retype src r base aligned_free_ref new_type obj_sz slots dev \<Rightarrow>
-    {aligned_free_ref .. base + 2 ^ sz - 1} \<subseteq> {base .. base + 2 ^ sz - 1}")
+                        {aligned_free_ref .. base + 2 ^ sz - 1} \<subseteq> {base .. base + 2 ^ sz - 1}")
    apply (simp add: field_simps)
    apply blast
   apply (simp add: blah word_and_le2)
   done
 
-lemma nonzero_unat_simp:
-  "0 < unat (x::obj_ref) \<Longrightarrow> 0 < x"
-  apply(auto dest: word_of_nat_less)
+
+context Retype_AC_1 begin
+
+lemma data_to_obj_type_ret_not_asid_pool:
+  "\<lbrace>\<top>\<rbrace> data_to_obj_type v \<lbrace>\<lambda>r s. r \<noteq> ArchObject ASIDPoolObj\<rbrace>, -"
+  apply (clarsimp simp: validE_R_def validE_def valid_def)
+  apply (auto simp: data_to_obj_type_def throwError_def returnOk_def
+                    bindE_def return_def bind_def lift_def
+             split: if_splits option.splits)
   done
 
 lemma decode_untyped_invocation_authorised:
-   "\<lbrace>invs and pas_refined aag and valid_cap cap
-        and cte_wp_at ((=) cap) slot
-        and (\<lambda>s. \<forall>cap\<in>set excaps.
-                  is_cnode_cap cap \<longrightarrow>
-                   (\<forall>r\<in>cte_refs cap (interrupt_irq_node s).
-                       ex_cte_cap_wp_to is_cnode_cap r s))
-        and (\<lambda>s. \<forall>x\<in>set excaps. s \<turnstile> x)
-        and K (cap = cap.UntypedCap dev base sz idx
-               \<and> is_subject aag (fst slot)
-               \<and> (\<forall>c \<in> set excaps. pas_cap_cur_auth aag c)
-               \<and> (\<forall> ref \<in> untyped_range cap. is_subject aag ref))\<rbrace>
-     decode_untyped_invocation label args slot cap excaps
-   \<lbrace>\<lambda>rv s. authorised_untyped_inv aag rv\<rbrace>,-"
-  apply(rule hoare_gen_asmE)
-  apply(rule hoare_pre)
+  "\<lbrace>invs and pas_refined aag and valid_cap cap and cte_wp_at ((=) cap) slot
+         and (\<lambda>s. \<forall>cap\<in>set excaps. is_cnode_cap cap
+                  \<longrightarrow> (\<forall>r\<in>cte_refs cap (interrupt_irq_node s). ex_cte_cap_wp_to is_cnode_cap r s))
+         and (\<lambda>s. \<forall>x\<in>set excaps. s \<turnstile> x)
+         and K (cap = UntypedCap dev base sz idx \<and> is_subject aag (fst slot) \<and>
+                (\<forall>c \<in> set excaps. pas_cap_cur_auth aag c) \<and>
+                (\<forall> ref \<in> untyped_range cap. is_subject aag ref))\<rbrace>
+   decode_untyped_invocation label args slot cap excaps
+   \<lbrace>\<lambda>rv _. authorised_untyped_inv aag rv\<rbrace>,-"
+  apply (rule hoare_gen_asmE)
+  apply (rule hoare_pre)
    apply (strengthen authorised_untyped_invI[mk_strg I])
-   apply(wp dui_inv_wf | simp)+
+   apply (wp dui_inv_wf | simp)+
    apply (clarsimp simp: decode_untyped_invocation_def split_def
                          authorised_untyped_inv'_def
                    split del: if_split split: untyped_invocation.splits)
    (* need to hoist the is_cnode_cap assumption into postcondition later on *)
-   apply (simp add: unlessE_def[symmetric] whenE_def[symmetric] unlessE_whenE
-            split del: if_split)
+   apply (simp add: unlessE_def[symmetric] whenE_def[symmetric] unlessE_whenE split del: if_split)
    apply (wp whenE_throwError_wp  hoare_vcg_all_lift mapME_x_inv_wp
-         | simp split: untyped_invocation.splits
-         | (auto)[1])+
+          | simp split: untyped_invocation.splits
+          | (auto)[1])+
            apply (rule_tac Q="\<lambda>node_cap s.
-             (is_cnode_cap node_cap \<longrightarrow> is_subject aag (obj_ref_of node_cap)) \<and>
-             is_subject aag (fst slot) \<and>
-             new_type \<noteq> ArchObject ASIDPoolObj \<and>
-             (\<forall> cap. cte_wp_at ((=) cap) slot s \<longrightarrow>
-                (\<forall>ref\<in>ptr_range base (bits_of cap). is_subject aag ref))"
-                       in hoare_strengthen_post)
+                              (is_cnode_cap node_cap \<longrightarrow> is_subject aag (obj_ref_of node_cap)) \<and>
+                              is_subject aag (fst slot) \<and> new_type \<noteq> ArchObject ASIDPoolObj \<and>
+                              (\<forall>cap. cte_wp_at ((=) cap) slot s
+                                     \<longrightarrow> (\<forall>ref \<in> ptr_range base (bits_of cap). is_subject aag ref))"
+                        in hoare_strengthen_post)
             apply (wp get_cap_inv get_cap_ret_is_subject)
-           apply (fastforce simp: nonzero_unat_simp)
+           apply (fastforce simp: nonzero_data_to_nat_simp)
           apply clarsimp
-          apply(wp lookup_slot_for_cnode_op_authorised
-                   lookup_slot_for_cnode_op_inv whenE_throwError_wp)+
-      apply(rule hoare_drop_imps)+
-      apply(clarsimp)
-      apply(rule_tac Q'="\<lambda>rv s. rv \<noteq> ArchObject ASIDPoolObj \<and>
-                                (\<forall> cap. cte_wp_at ((=) cap) slot s \<longrightarrow>
-                                  (\<forall>ref\<in>ptr_range base (bits_of cap). is_subject aag ref)) \<and>
-                               is_subject aag (fst slot) \<and>
-                           pas_refined aag s \<and> 2 \<le> sz \<and>
-                           sz < word_bits \<and> is_aligned base sz \<and>
-                           (is_cnode_cap (excaps ! 0) \<longrightarrow>
-                             (\<forall> x\<in>obj_refs (excaps ! 0). is_subject aag x))"
-                  in hoare_post_imp_R)
-       apply(wp data_to_obj_type_ret_not_asid_pool data_to_obj_type_inv2)
-      apply(case_tac "excaps ! 0", simp_all, fastforce simp: nonzero_unat_simp)[1]
-     apply(wp whenE_throwError_wp)+
-  apply(auto dest!: bang_0_in_set
-              simp: valid_cap_def cap_aligned_def obj_ref_of_def is_cap_simps
-                    cap_auth_conferred_def pas_refined_all_auth_is_owns
-                    aag_cap_auth_def ptr_range_def untyped_min_bits_def
-             dest: cte_wp_at_eqD2 simp: bits_of_UntypedCap)
+          apply (wp lookup_slot_for_cnode_op_authorised
+                    lookup_slot_for_cnode_op_inv whenE_throwError_wp)+
+      apply (rule hoare_drop_imps)+
+      apply clarsimp
+      apply (rule_tac Q'=
+               "\<lambda>rv s. rv \<noteq> ArchObject ASIDPoolObj \<and>
+                       (\<forall>cap. cte_wp_at ((=) cap) slot s
+                              \<longrightarrow> (\<forall>ref \<in> ptr_range base (bits_of cap). is_subject aag ref)) \<and>
+                       is_subject aag (fst slot) \<and> pas_refined aag s \<and> 2 \<le> sz \<and>
+                       sz < word_bits \<and> is_aligned base sz \<and>
+                       (is_cnode_cap (excaps ! 0) \<longrightarrow> (\<forall>x\<in>obj_refs (excaps ! 0). is_subject aag x))"
+                   in hoare_post_imp_R)
+       apply (wp data_to_obj_type_ret_not_asid_pool data_to_obj_type_inv2)
+      apply (case_tac "excaps ! 0", simp_all, fastforce simp: nonzero_data_to_nat_simp)[1]
+     apply (wp whenE_throwError_wp)+
+  apply (auto dest!: bang_0_in_set dest: cte_wp_at_eqD2
+               simp: valid_cap_def cap_aligned_def obj_ref_of_def is_cap_simps
+                     cap_auth_conferred_def pas_refined_all_auth_is_owns bits_of_UntypedCap
+                     aag_cap_auth_def ptr_range_def le_trans[OF untyped_min_bits_ge_2])
   done
 
 end

--- a/proof/access-control/Syscall_AC.thy
+++ b/proof/access-control/Syscall_AC.thy
@@ -6,56 +6,53 @@
 
 theory Syscall_AC
 imports
-  Ipc_AC
-  Tcb_AC
-  Interrupt_AC
-  DomainSepInv
+  ArchIpc_AC
+  ArchTcb_AC
+  ArchInterrupt_AC
+  ArchDomainSepInv
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-definition
-  authorised_invocation :: "'a PAS \<Rightarrow> Invocations_A.invocation \<Rightarrow> 'z::state_ext state \<Rightarrow> bool"
-where
- "authorised_invocation aag i \<equiv> \<lambda>s. case i of
-     Invocations_A.InvokeUntyped i' \<Rightarrow> valid_untyped_inv i' s \<and> (authorised_untyped_inv aag i') \<and> ct_active s
-   | Invocations_A.InvokeEndpoint epptr badge can_grant can_grant_reply \<Rightarrow>
-               \<exists>ep. ko_at (Endpoint ep) epptr s \<and>
-                    (can_grant \<longrightarrow>  (\<forall>r \<in> ep_q_refs_of ep. snd r = EPRecv \<longrightarrow> is_subject aag (fst r))
-                                  \<and> aag_has_auth_to aag Grant epptr \<and> aag_has_auth_to aag Call epptr) \<and>
-                    (can_grant_reply \<longrightarrow> aag_has_auth_to aag Call epptr)
-             \<and> aag_has_auth_to aag SyncSend epptr
-   | Invocations_A.InvokeNotification ep badge \<Rightarrow> aag_has_auth_to aag Notify ep
-   | Invocations_A.InvokeReply thread slot grant \<Rightarrow>
-       (grant \<longrightarrow> is_subject aag thread) \<and> is_subject aag (fst slot) \<and> aag_has_auth_to aag Reply thread
-   | Invocations_A.InvokeTCB i' \<Rightarrow> Tcb_AI.tcb_inv_wf i' s \<and> authorised_tcb_inv aag i'
-   | Invocations_A.InvokeDomain thread slot \<Rightarrow> False
-   | Invocations_A.InvokeCNode i' \<Rightarrow> authorised_cnode_inv aag i' s \<and> is_subject aag (cur_thread s)
-           \<and> cnode_inv_auth_derivations i' s
-   | Invocations_A.InvokeIRQControl i' \<Rightarrow> authorised_irq_ctl_inv aag i'
-   | Invocations_A.InvokeIRQHandler i' \<Rightarrow> authorised_irq_hdl_inv aag i'
-   | Invocations_A.InvokeArchObject i' \<Rightarrow> valid_arch_inv i' s \<and> authorised_arch_inv aag i' \<and> ct_active s"
+definition authorised_invocation ::
+  "'a PAS \<Rightarrow> invocation \<Rightarrow> 'z :: state_ext state \<Rightarrow> bool" where
+  "authorised_invocation aag i \<equiv> \<lambda>s. case i of
+     InvokeUntyped i' \<Rightarrow> valid_untyped_inv i' s \<and> (authorised_untyped_inv aag i') \<and> ct_active s
+   | InvokeEndpoint epptr badge can_grant can_grant_reply \<Rightarrow>
+       \<exists>ep. ko_at (Endpoint ep) epptr s \<and>
+            (can_grant \<longrightarrow>  (\<forall>r \<in> ep_q_refs_of ep. snd r = EPRecv \<longrightarrow> is_subject aag (fst r)) \<and>
+                            aag_has_auth_to aag Grant epptr \<and> aag_has_auth_to aag Call epptr) \<and>
+            (can_grant_reply \<longrightarrow> aag_has_auth_to aag Call epptr) \<and>
+            aag_has_auth_to aag SyncSend epptr
+   | InvokeNotification ep badge \<Rightarrow> aag_has_auth_to aag Notify ep
+   | InvokeReply thread slot grant \<Rightarrow>
+       (grant \<longrightarrow> is_subject aag thread) \<and> is_subject aag (fst slot)
+                                         \<and> aag_has_auth_to aag Reply thread
+   | InvokeTCB i' \<Rightarrow> tcb_inv_wf i' s \<and> authorised_tcb_inv aag i'
+   | InvokeDomain thread slot \<Rightarrow> False
+   | InvokeCNode i' \<Rightarrow> authorised_cnode_inv aag i' s \<and> is_subject aag (cur_thread s)
+                                                     \<and> cnode_inv_auth_derivations i' s
+   | InvokeIRQControl i' \<Rightarrow> authorised_irq_ctl_inv aag i'
+   | InvokeIRQHandler i' \<Rightarrow> authorised_irq_hdl_inv aag i'
+   | InvokeArchObject i' \<Rightarrow> valid_arch_inv i' s \<and> authorised_arch_inv aag i' \<and> ct_active s"
 
 lemma perform_invocation_pas_refined:
-  "\<lbrace>pas_refined aag and pas_cur_domain aag
-          and einvs and simple_sched_action and valid_invocation oper
-          and is_subject aag \<circ> cur_thread
-          and authorised_invocation aag oper\<rbrace>
-    perform_invocation blocking calling oper
+  "\<lbrace>pas_refined aag and pas_cur_domain aag and einvs and simple_sched_action
+                    and valid_invocation oper and is_subject aag \<circ> cur_thread
+                    and authorised_invocation aag oper\<rbrace>
+   perform_invocation blocking calling oper
    \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
   apply (cases oper, simp_all)
-  apply (simp add: authorised_invocation_def validE_R_def[symmetric] invs_valid_objs
-       | wp invoke_untyped_pas_refined send_ipc_pas_refined send_signal_pas_refined
-            do_reply_transfer_pas_refined invoke_tcb_pas_refined invoke_cnode_pas_refined
-            invoke_irq_control_pas_refined invoke_irq_handler_pas_refined
-            invoke_arch_pas_refined decode_cnode_invocation_auth_derived
-       | fastforce)+
+           apply (simp add: authorised_invocation_def validE_R_def[symmetric] invs_valid_objs
+                  | wp invoke_untyped_pas_refined send_ipc_pas_refined send_signal_pas_refined
+                       do_reply_transfer_pas_refined invoke_tcb_pas_refined invoke_cnode_pas_refined
+                       invoke_irq_control_pas_refined invoke_irq_handler_pas_refined
+                       invoke_arch_pas_refined decode_cnode_invocation_auth_derived
+                  | fastforce)+
   done
 
 lemma ntfn_gives_obj_at:
-  "invs s \<Longrightarrow>
-   (\<exists>ntfn. ko_at (Notification ntfn) ntfnptr s
-           \<and> (\<forall>x\<in>ntfn_q_refs_of (ntfn_obj ntfn).
+  "invs s
+   \<Longrightarrow> (\<exists>ntfn. ko_at (Notification ntfn) ntfnptr s
+             \<and> (\<forall>x\<in>ntfn_q_refs_of (ntfn_obj ntfn).
                   (\<lambda>(t, rt). obj_at (\<lambda>tcb. ko_at tcb t s) t s) x)) = ntfn_at ntfnptr s"
   apply (rule iffI)
    apply (clarsimp simp: obj_at_def is_ntfn)
@@ -68,13 +65,12 @@ lemma ntfn_gives_obj_at:
 
 (* ((=) st) -- too strong, the thread state of the calling thread changes. *)
 lemma perform_invocation_respects:
-  "\<lbrace>pas_refined aag and integrity aag X st
-          and einvs and simple_sched_action and valid_invocation oper
-          and authorised_invocation aag oper
-          and is_subject aag \<circ> cur_thread
-          and (\<lambda>s. \<forall>p ko. kheap s p = Some ko \<longrightarrow> \<not> (is_tcb ko \<and> p = cur_thread st)  \<longrightarrow> kheap st p = Some ko)
-          \<rbrace>
-    perform_invocation blocking calling oper
+  "\<lbrace>pas_refined aag and integrity aag X st and einvs and simple_sched_action
+                    and valid_invocation oper and authorised_invocation aag oper
+                    and is_subject aag \<circ> cur_thread
+                    and (\<lambda>s. \<forall>p ko. kheap s p = Some ko
+                                    \<longrightarrow> \<not> (is_tcb ko \<and> p = cur_thread st)  \<longrightarrow> kheap st p = Some ko)\<rbrace>
+   perform_invocation blocking calling oper
    \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
   supply [wp] = invoke_untyped_integrity send_ipc_integrity_autarch send_signal_respects
                 do_reply_transfer_respects invoke_tcb_respects invoke_cnode_respects
@@ -109,46 +105,37 @@ lemma perform_invocation_respects:
 
 declare AllowSend_def[simp] AllowRecv_def[simp]
 
-lemma hoare_conjunct1_R:
-  "\<lbrace> P \<rbrace> f \<lbrace> \<lambda> r s. Q r s \<and> Q' r s\<rbrace>,- \<Longrightarrow> \<lbrace> P \<rbrace> f \<lbrace> Q \<rbrace>,-"
-  apply(auto intro: hoare_post_imp_R)
-  done
-
-lemma hoare_conjunct2_R:
-  "\<lbrace> P \<rbrace> f \<lbrace> \<lambda> r s. Q r s \<and> Q' r s\<rbrace>,- \<Longrightarrow> \<lbrace> P \<rbrace> f \<lbrace> Q' \<rbrace>,-"
-  apply(auto intro: hoare_post_imp_R)
-  done
-
+(* FIXME AC: breaks for RISCV unless "real_cte_at slot" is assumed. This term appears in the RISCV
+             variant of arch_decode_inv_wf, but not in the ARM variant. We should avoid requalifying
+             it and instead have a wp rule for valid_arch_inv as part of a locale. *)
 lemma decode_invocation_authorised:
-  "\<lbrace>pas_refined aag and valid_cap cap and invs and ct_active and cte_wp_at ((=) cap) slot
-           and ex_cte_cap_to slot
-           and (\<lambda>s. \<forall>r\<in>zobj_refs cap. ex_nonz_cap_to r s)
-           and (\<lambda>s. \<forall>r\<in>cte_refs cap (interrupt_irq_node s). ex_cte_cap_to r s)
-           and (\<lambda>s. \<forall>cap \<in> set excaps. \<forall>r\<in>cte_refs (fst cap) (interrupt_irq_node s). ex_cte_cap_to r s)
-           and (\<lambda>s. \<forall>x \<in> set excaps. s \<turnstile> (fst x))
-           and (\<lambda>s. \<forall>x \<in> set excaps. \<forall>r\<in>zobj_refs (fst x). ex_nonz_cap_to r s)
-           and (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at ((=) (fst x)) (snd x) s)
-           and (\<lambda>s. \<forall>x \<in> set excaps. real_cte_at (snd x) s)
-           and (\<lambda>s. \<forall>x \<in> set excaps. ex_cte_cap_wp_to is_cnode_cap (snd x) s)
-           and (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at (interrupt_derived (fst x)) (snd x) s)
-           and (is_subject aag \<circ> cur_thread) and
-              K (is_subject aag (fst slot) \<and> pas_cap_cur_auth aag cap
-                \<and> (\<forall>slot \<in> set excaps. is_subject aag (fst (snd slot)))
-                \<and> (\<forall>slot \<in> set excaps. pas_cap_cur_auth aag (fst slot)))
-           and domain_sep_inv (pasMaySendIrqs aag) st'\<rbrace>
-    decode_invocation info_label args ptr slot cap excaps
+  "\<lbrace>pas_refined aag and valid_cap cap and invs and ct_active and (is_subject aag \<circ> cur_thread) and
+    cte_wp_at ((=) cap) slot and ex_cte_cap_to slot and domain_sep_inv (pasMaySendIrqs aag) st' and
+    (\<lambda>s. \<forall>r\<in>zobj_refs cap. ex_nonz_cap_to r s) and
+    (\<lambda>s. \<forall>r\<in>cte_refs cap (interrupt_irq_node s). ex_cte_cap_to r s) and
+    (\<lambda>s. \<forall>cap \<in> set excaps. \<forall>r\<in>cte_refs (fst cap) (interrupt_irq_node s). ex_cte_cap_to r s) and
+    (\<lambda>s. \<forall>x \<in> set excaps. s \<turnstile> (fst x)) and
+    (\<lambda>s. \<forall>x \<in> set excaps. \<forall>r\<in>zobj_refs (fst x). ex_nonz_cap_to r s) and
+    (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at ((=) (fst x)) (snd x) s) and
+    (\<lambda>s. \<forall>x \<in> set excaps. real_cte_at (snd x) s) and
+    (\<lambda>s. \<forall>x \<in> set excaps. ex_cte_cap_wp_to is_cnode_cap (snd x) s) and
+    (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at (interrupt_derived (fst x)) (snd x) s) and
+    K (is_subject aag (fst slot) \<and> pas_cap_cur_auth aag cap \<and>
+       (\<forall>slot \<in> set excaps. is_subject aag (fst (snd slot))) \<and>
+       (\<forall>slot \<in> set excaps. pas_cap_cur_auth aag (fst slot)))\<rbrace>
+   decode_invocation info_label args ptr slot cap excaps
    \<lbrace>\<lambda>rv. authorised_invocation aag rv\<rbrace>, -"
   unfolding decode_invocation_def
   apply (rule hoare_pre)
    apply (wp decode_untyped_invocation_authorised
-              decode_cnode_invocation_auth_derived
-              decode_cnode_inv_authorised
-              decode_tcb_invocation_authorised decode_tcb_inv_wf
-              decode_arch_invocation_authorised
-              | strengthen cnode_eq_strg
-              | wpc | simp add: comp_def authorised_invocation_def decode_invocation_def
-                        split del: if_split del: hoare_True_E_R
-              | wp (once) hoare_FalseE_R)+
+             decode_cnode_invocation_auth_derived
+             decode_cnode_inv_authorised
+             decode_tcb_invocation_authorised decode_tcb_inv_wf
+             decode_arch_invocation_authorised
+          | strengthen cnode_eq_strg
+          | wpc | simp add: comp_def authorised_invocation_def decode_invocation_def
+                       split del: if_split del: hoare_True_E_R
+          | wp (once) hoare_FalseE_R)+
 
   apply (clarsimp simp: aag_has_Control_iff_owns split_def aag_cap_auth_def)
   apply (cases cap, simp_all)
@@ -165,10 +152,10 @@ lemma decode_invocation_authorised:
       apply ((clarsimp simp: valid_cap_def is_cap_simps pas_refined_all_auth_is_owns
                             ex_cte_cap_wp_to_weakenE[OF _ TrueI]
                             cap_auth_conferred_def cap_rights_to_auth_def
-               | rule conjI | (subst split_paired_Ex[symmetric], erule exI)
-               | erule cte_wp_at_weakenE
-               | drule(1) bspec
-               | erule eq_no_cap_to_obj_with_diff_ref)+)[1]
+              | rule conjI | (subst split_paired_Ex[symmetric], erule exI)
+              | erule cte_wp_at_weakenE
+              | drule(1) bspec
+              | erule eq_no_cap_to_obj_with_diff_ref)+)[1]
      apply (simp only: domain_sep_inv_def)
     apply (rule impI, erule subst, rule pas_refined_sita_mem [OF sita_controlled],
            auto simp: cte_wp_at_caps_of_state)[1]
@@ -181,39 +168,22 @@ lemma decode_invocation_authorised:
   done
 
 lemma in_extended: "(u,a) \<in> fst (do_extended_op f s) \<Longrightarrow> \<exists>e. a = (trans_state (\<lambda>_. e) s)"
-   apply (clarsimp simp add: do_extended_op_def bind_def gets_def return_def get_def
-                   mk_ef_def modify_def select_f_def put_def trans_state_update')
-   apply force
-   done
+  by (fastforce simp: do_extended_op_def bind_def gets_def return_def get_def
+                      mk_ef_def modify_def select_f_def put_def trans_state_update')
 
 lemma set_thread_state_authorised[wp]:
   "\<lbrace>authorised_invocation aag i and (\<lambda>s. thread = cur_thread s) and valid_objs\<rbrace>
-     set_thread_state thread Structures_A.thread_state.Restart
+   set_thread_state thread Restart
    \<lbrace>\<lambda>rv. authorised_invocation aag i\<rbrace>"
-  apply (cases i)
-           apply (simp_all add: authorised_invocation_def)
-          apply (wp sts_valid_untyped_inv ct_in_state_set
-                    hoare_vcg_ex_lift sts_obj_at_impossible
-                  | simp)+
+  apply (cases i; simp add: authorised_invocation_def)
+          apply (wpsimp wp: sts_valid_untyped_inv ct_in_state_set
+                            hoare_vcg_ex_lift sts_obj_at_impossible)+
      apply (rename_tac cnode_invocation)
-     apply (case_tac cnode_invocation,
-            simp_all add: cnode_inv_auth_derivations_def authorised_cnode_inv_def)[1]
+     apply (case_tac cnode_invocation;
+            simp add: cnode_inv_auth_derivations_def authorised_cnode_inv_def)[1]
            apply (wp set_thread_state_cte_wp_at | simp)+
   apply (rename_tac arch_invocation)
-  apply (case_tac arch_invocation, simp_all add: valid_arch_inv_def)[1]
-      apply (rename_tac page_table_invocation)
-      apply (case_tac page_table_invocation, simp_all add: valid_pti_def)[1]
-       apply (wp sts_typ_ats sts_obj_at_impossible ct_in_state_set
-                 hoare_vcg_ex_lift hoare_vcg_conj_lift
-               | simp add: valid_pdi_def)+
-     apply (rename_tac asid_control_invocation)
-     apply (case_tac asid_control_invocation, simp_all add: valid_aci_def)
-    apply (wp ct_in_state_set | simp)+
-  apply (rename_tac asid_pool_invocation)
-  apply (case_tac asid_pool_invocation; simp add: valid_apinv_def)
-  apply (wp sts_obj_at_impossible ct_in_state_set
-            hoare_vcg_ex_lift
-          | simp)+
+  apply (wpsimp wp: sts_valid_arch_inv ct_in_state_set)
   done
 
 lemma sts_first_restart:
@@ -226,8 +196,8 @@ lemma sts_first_restart:
 
 lemma lcs_reply_owns:
   "\<lbrace>pas_refined aag and K (is_subject aag thread)\<rbrace>
-    lookup_cap_and_slot thread ptr
-   \<lbrace>\<lambda>rv s. \<forall>ep. (\<exists>m R. fst rv = cap.ReplyCap ep m R \<and> AllowGrant \<in> R) \<longrightarrow> is_subject aag ep\<rbrace>, -"
+   lookup_cap_and_slot thread ptr
+   \<lbrace>\<lambda>rv _. \<forall>ep. (\<exists>m R. fst rv = ReplyCap ep m R \<and> AllowGrant \<in> R) \<longrightarrow> is_subject aag ep\<rbrace>, -"
   apply (rule hoare_post_imp_R)
    apply (rule hoare_pre)
     apply (rule hoare_vcg_conj_lift_R [where S = "K (pas_refined aag)"])
@@ -241,21 +211,27 @@ crunch pas_refined[wp]: reply_from_kernel "pas_refined aag"
   (simp: split_def)
 
 lemma lookup_cap_and_slot_valid_fault3:
-  "\<lbrace>valid_objs\<rbrace> lookup_cap_and_slot thread cptr
-   -,
-   \<lbrace>\<lambda>ft s. valid_fault (ExceptionTypes_A.CapFault (of_bl cptr) rp ft)\<rbrace>"
+  "\<lbrace>valid_objs\<rbrace>
+   lookup_cap_and_slot thread cptr
+   -, \<lbrace>\<lambda>ft _. valid_fault (CapFault (of_bl cptr) rp ft)\<rbrace>"
   apply (unfold validE_E_def)
   apply (rule hoare_post_impErr)
     apply (rule lookup_cap_and_slot_valid_fault)
    apply auto
   done
 
-definition guarded_pas_domain
-where
+definition guarded_pas_domain where
   "guarded_pas_domain aag \<equiv>
-     \<lambda>s. cur_thread s \<noteq> idle_thread s \<longrightarrow>
-         pasObjectAbs aag (cur_thread s) \<in> pasDomainAbs aag (cur_domain s)"
+   \<lambda>s. cur_thread s \<noteq> idle_thread s
+       \<longrightarrow> pasObjectAbs aag (cur_thread s) \<in> pasDomainAbs aag (cur_domain s)"
 
+locale gpd_wps' =
+  fixes f :: "(det_ext state, 'z) nondet_monad"
+  assumes idle_thread[wp]: "\<And>P. f \<lbrace>\<lambda>s. P (idle_thread s)\<rbrace>"
+  and cur_thread[wp]: "\<And>P. f \<lbrace>\<lambda>s. P (cur_thread s)\<rbrace>"
+
+locale gpd_wps = gpd_wps' +
+  assumes cur_domain[wp]: "\<And>P. f \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
 
 lemma guarded_pas_domain_lift:
   assumes a: "\<And>P. \<lbrace>\<lambda>s. P (cur_thread s)\<rbrace> f \<lbrace>\<lambda>r s. P (cur_thread s)\<rbrace>"
@@ -270,49 +246,46 @@ lemma guarded_pas_domain_lift:
   done
 
 lemma guarded_to_cur_domain:
-  "\<lbrakk>invs s; ct_in_state x s; \<not> x IdleThreadState; guarded_pas_domain aag s;
-    is_subject aag (cur_thread s)\<rbrakk>
-   \<Longrightarrow> pas_cur_domain aag s"
-  by (auto simp: invs_def valid_state_def valid_idle_def pred_tcb_at_def obj_at_def
-                 ct_in_state_def guarded_pas_domain_def)
-
+  "\<lbrakk> invs s; ct_in_state x s; \<not> x IdleThreadState;
+     guarded_pas_domain aag s; is_subject aag (cur_thread s) \<rbrakk>
+     \<Longrightarrow> pas_cur_domain aag s"
+  by (auto simp: invs_def valid_state_def valid_idle_def pred_tcb_at_def
+                 obj_at_def ct_in_state_def guarded_pas_domain_def)
 
 lemma handle_invocation_pas_refined:
-  shows "\<lbrace>pas_refined aag and guarded_pas_domain aag and domain_sep_inv (pasMaySendIrqs aag) st'
-          and einvs and ct_active and schact_is_rct
-          and is_subject aag \<circ> cur_thread\<rbrace>
-     handle_invocation calling blocking
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and guarded_pas_domain aag and domain_sep_inv (pasMaySendIrqs aag) st'
+                    and einvs and ct_active and schact_is_rct and is_subject aag \<circ> cur_thread\<rbrace>
+   handle_invocation calling blocking
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: handle_invocation_def split_def)
   apply (cases blocking, simp)
-   apply (rule hoare_pre)
-    by (((wp syscall_valid without_preemption_wp
-              handle_fault_pas_refined set_thread_state_pas_refined
-              set_thread_state_runnable_valid_sched
-              perform_invocation_pas_refined
-              hoare_vcg_conj_lift hoare_vcg_all_lift
-         | wpc
-         | rule hoare_drop_imps
-         | simp add: if_apply_def2 conj_comms split del: if_split
+  by (((wp syscall_valid without_preemption_wp
+           handle_fault_pas_refined set_thread_state_pas_refined
+           set_thread_state_runnable_valid_sched
+           perform_invocation_pas_refined
+           hoare_vcg_conj_lift hoare_vcg_all_lift
+        | wpc
+        | rule hoare_drop_imps
+        | simp add: if_apply_def2 conj_comms split del: if_split
                del: hoare_True_E_R)+),
-        ((wp lookup_extra_caps_auth lookup_extra_caps_authorised
-              decode_invocation_authorised
-              lookup_cap_and_slot_authorised
-              lookup_cap_and_slot_cur_auth
-              as_user_pas_refined
-              lookup_cap_and_slot_valid_fault3
+       ((wp lookup_extra_caps_auth lookup_extra_caps_authorised
+            decode_invocation_authorised
+            lookup_cap_and_slot_authorised
+            lookup_cap_and_slot_cur_auth
+            as_user_pas_refined
+            lookup_cap_and_slot_valid_fault3
          | simp add: comp_def runnable_eq_active)+),
-         (auto intro: guarded_to_cur_domain
-               simp: ct_in_state_def st_tcb_at_def live_def hyp_live_def
-               intro: if_live_then_nonz_capD)[1])+
+       (auto intro: guarded_to_cur_domain
+              simp: ct_in_state_def st_tcb_at_def live_def
+             intro: if_live_then_nonz_capD)[1])+
 
 lemma handle_invocation_respects:
-  "\<lbrace>integrity aag X st and pas_refined aag and guarded_pas_domain aag and domain_sep_inv (pasMaySendIrqs aag) st'
-          and einvs and ct_active and schact_is_rct
-          and is_subject aag \<circ> cur_thread
-          and ((=) st)\<rbrace>
-     handle_invocation calling blocking
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and guarded_pas_domain aag
+                       and domain_sep_inv (pasMaySendIrqs aag) st'
+                       and einvs and ct_active and schact_is_rct
+                       and is_subject aag \<circ> cur_thread and ((=) st)\<rbrace>
+   handle_invocation calling blocking
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: handle_invocation_def split_def)
   apply (wp syscall_valid without_preemption_wp handle_fault_integrity_autarch
             reply_from_kernel_integrity_autarch
@@ -324,85 +297,74 @@ lemma handle_invocation_respects:
          | simp add: if_apply_def2
                 split del: if_split)+
          apply (simp add: conj_comms pred_conj_def comp_def if_apply_def2 split del: if_split
-               | wp perform_invocation_respects set_thread_state_pas_refined
-                  set_thread_state_authorised
-                  set_thread_state_runnable_valid_sched
-                  set_thread_state_integrity_autarch
-                  sts_first_restart
-                  decode_invocation_authorised
-                  lookup_extra_caps_auth lookup_extra_caps_authorised
-                  set_thread_state_integrity_autarch
-                  lookup_cap_and_slot_cur_auth lookup_cap_and_slot_authorised
-                  hoare_vcg_const_imp_lift perform_invocation_pas_refined
-                  set_thread_state_ct_st      hoare_vcg_const_imp_lift_R
-                  lookup_cap_and_slot_valid_fault3
-               | (rule valid_validE, strengthen invs_vobjs_strgs))+
+                | wp perform_invocation_respects set_thread_state_pas_refined
+                   set_thread_state_authorised
+                   set_thread_state_runnable_valid_sched
+                   set_thread_state_integrity_autarch
+                   sts_first_restart
+                   decode_invocation_authorised
+                   lookup_extra_caps_auth lookup_extra_caps_authorised
+                   set_thread_state_integrity_autarch
+                   lookup_cap_and_slot_cur_auth lookup_cap_and_slot_authorised
+                   hoare_vcg_const_imp_lift perform_invocation_pas_refined
+                   set_thread_state_ct_st hoare_vcg_const_imp_lift_R
+                   lookup_cap_and_slot_valid_fault3
+                | (rule valid_validE, strengthen invs_vobjs_strgs))+
   by (fastforce intro: st_tcb_ex_cap' guarded_to_cur_domain
                  simp: ct_in_state_def runnable_eq_active)
 
 crunch pas_refined[wp]: delete_caller_cap "pas_refined aag"
 
-lemma invs_sym_refs_strg:
-  "invs s \<longrightarrow> sym_refs (state_refs_of s)" by clarsimp
-
 lemma handle_recv_pas_refined:
   "\<lbrace>pas_refined aag and invs and is_subject aag \<circ> cur_thread\<rbrace>
      handle_recv is_blocking
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: handle_recv_def Let_def lookup_cap_def split_def)
   apply (wp handle_fault_pas_refined receive_ipc_pas_refined receive_signal_pas_refined
             get_cap_auth_wp [where aag=aag] lookup_slot_for_cnode_op_authorised
             lookup_slot_for_thread_authorised lookup_slot_for_thread_cap_fault
             hoare_vcg_all_lift_R get_simple_ko_wp
-       | wpc | simp
-       | (rule_tac Q="\<lambda>rv s. invs s \<and> is_subject aag thread
-                             \<and> (pasSubject aag, Receive, pasObjectAbs aag thread) \<in> pasPolicy aag"
-                in hoare_strengthen_post,
-          wp, clarsimp simp: invs_valid_objs invs_sym_refs))+
-     apply (rule_tac Q' = "\<lambda>rv s. pas_refined aag s \<and> invs s \<and> tcb_at thread s
-                                   \<and> cur_thread s = thread \<and> is_subject aag (cur_thread s)
-                                   \<and> is_subject aag thread" in hoare_post_imp_R [rotated])
+         | wpc | simp
+         | (rule_tac Q="\<lambda>rv s. invs s \<and> is_subject aag thread \<and> aag_has_auth_to aag Receive thread"
+                  in hoare_strengthen_post,
+            wp, clarsimp simp: invs_valid_objs invs_sym_refs))+
+     apply (rule_tac Q'="\<lambda>rv s. pas_refined aag s \<and> invs s \<and> tcb_at thread s
+                              \<and> cur_thread s = thread \<and> is_subject aag (cur_thread s)
+                              \<and> is_subject aag thread" in hoare_post_imp_R [rotated])
       apply (fastforce simp: aag_cap_auth_def cap_auth_conferred_def
                              cap_rights_to_auth_def valid_fault_def)
-     apply (wp user_getreg_inv | strengthen invs_vobjs_strgs invs_sym_refs_strg | simp)+
+     apply (wp user_getreg_inv | strengthen invs_vobjs_strgs | simp)+
   apply clarsimp
   done
 
 crunch respects[wp]: delete_caller_cap "integrity aag X st"
 
-lemma invs_mdb_strgs: "invs s \<longrightarrow> valid_mdb s"
-  by auto
-
 lemma handle_recv_integrity:
   "\<lbrace>integrity aag X st and pas_refined aag and einvs and is_subject aag \<circ> cur_thread
-      and K(valid_mdb st \<and> valid_objs st)\<rbrace>
-     handle_recv is_blocking
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+                       and K (valid_mdb st \<and> valid_objs st)\<rbrace>
+   handle_recv is_blocking
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: handle_recv_def Let_def lookup_cap_def split_def)
   apply (wp handle_fault_integrity_autarch receive_ipc_integrity_autarch
             receive_signal_integrity_autarch lookup_slot_for_thread_authorised
             lookup_slot_for_thread_cap_fault get_cap_auth_wp [where aag=aag] get_simple_ko_wp
-        | wpc
-        | simp
-        | rule_tac Q="\<lambda>rv s. invs s \<and> is_subject aag thread
-                           \<and> (pasSubject aag, Receive, pasObjectAbs aag thread) \<in> pasPolicy aag"
-                in hoare_strengthen_post, wp, clarsimp simp: invs_valid_objs invs_sym_refs)+
-     apply (rule_tac Q' = "\<lambda>rv s. pas_refined aag s \<and> einvs s \<and> is_subject aag (cur_thread s)
-                         \<and> tcb_at thread s \<and> cur_thread s = thread
-            \<and> is_subject aag thread \<and> integrity aag X st s" in hoare_post_imp_R [rotated])
+         | wpc
+         | simp
+         | rule_tac Q="\<lambda>rv s. invs s \<and> is_subject aag thread \<and> aag_has_auth_to aag Receive thread"
+                 in hoare_strengthen_post, wp, clarsimp simp: invs_valid_objs invs_sym_refs)+
+     apply (rule_tac Q'="\<lambda>rv s. pas_refined aag s \<and> einvs s \<and> is_subject aag (cur_thread s)
+                              \<and> tcb_at thread s \<and> cur_thread s = thread \<and> is_subject aag thread
+                              \<and> integrity aag X st s" in hoare_post_imp_R [rotated])
       apply (fastforce simp: aag_cap_auth_def cap_auth_conferred_def
                              cap_rights_to_auth_def valid_fault_def)
-     apply (wp user_getreg_inv
-           | strengthen invs_vobjs_strgs invs_sym_refs_strg invs_mdb_strgs
-           | simp)+
-  apply clarsimp
+     apply wpsimp+
   done
 
 lemma handle_reply_pas_refined[wp]:
-  "\<lbrace> pas_refined aag and invs and is_subject aag \<circ> cur_thread\<rbrace>
-     handle_reply
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and invs and is_subject aag \<circ> cur_thread\<rbrace>
+   handle_reply
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   unfolding handle_reply_def
   apply (rule hoare_pre)
    apply (wp do_reply_transfer_pas_refined get_cap_auth_wp [where aag = aag]| wpc)+
@@ -410,11 +372,9 @@ lemma handle_reply_pas_refined[wp]:
            intro: aag_Control_into_owns)
 
 lemma handle_reply_respects:
-  "\<lbrace>integrity aag X st and pas_refined aag
-          and einvs
-          and is_subject aag \<circ> cur_thread\<rbrace>
-     handle_reply
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and einvs and is_subject aag \<circ> cur_thread\<rbrace>
+   handle_reply
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   unfolding handle_reply_def
   apply (rule hoare_pre)
   apply (wp do_reply_transfer_respects get_cap_auth_wp [where aag = aag]| wpc)+
@@ -425,9 +385,7 @@ lemma handle_reply_respects:
   done
 
 lemma ethread_set_time_slice_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace>
-     ethread_set (tcb_time_slice_update f) thread
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "ethread_set (tcb_time_slice_update f) thread \<lbrace>pas_refined aag\<rbrace>"
   apply (simp add: ethread_set_def set_eobject_def | wp)+
   apply (clarsimp simp: pas_refined_def tcb_domain_map_wellformed_aux_def)
   apply (erule_tac x="(a, b)" in ballE)
@@ -438,16 +396,11 @@ lemma ethread_set_time_slice_pas_refined[wp]:
   done
 
 lemma thread_set_time_slice_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace>
-     thread_set_time_slice tptr time
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (simp add: thread_set_time_slice_def | wp)+
-  done
+  "thread_set_time_slice tptr time \<lbrace>pas_refined aag\<rbrace>"
+  by (simp add: thread_set_time_slice_def | wp)+
 
 lemma dec_domain_time_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace>
-     dec_domain_time
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "dec_domain_time \<lbrace>pas_refined aag\<rbrace>"
   apply (simp add: dec_domain_time_def | wp)+
   apply (clarsimp simp: pas_refined_def tcb_domain_map_wellformed_aux_def)
   done
@@ -455,57 +408,189 @@ lemma dec_domain_time_pas_refined[wp]:
 crunch pas_refined[wp]: timer_tick "pas_refined aag"
   (wp_del: timer_tick_extended.pas_refined_tcb_domain_map_wellformed)
 
+
+locale Syscall_AC_wps =
+  fixes f :: "(det_ext state, 'z) nondet_monad"
+  and aag :: "'a PAS"
+  assumes respects[wp]: "f \<lbrace>integrity aag X st\<rbrace>"
+  and pas_refined[wp]: "f \<lbrace>pas_refined aag\<rbrace>"
+
+locale Syscall_AC_1 =
+  fixes aag :: "'a PAS"
+  assumes invs_irq_state_update[simp]:
+    "invs ((s :: det_ext state)\<lparr>machine_state := irq_state_update f s'\<rparr>) =
+     invs (s\<lparr>machine_state := s'\<rparr>)"
+  and prepare_thread_delete_Syscall_AC_wps''[simp]:
+    "gpd_wps' (prepare_thread_delete p)"
+  and arch_finalise_cap_Syscall_AC_wps''[simp]:
+    "gpd_wps' (arch_finalise_cap acap final)"
+  and cap_move_Syscall_AC_wps''[simp]:
+    "gpd_wps' (cap_move new_cap src_slot dest_slot)"
+  and cancel_badged_sends_Syscall_AC_wps''[simp]:
+    "gpd_wps' (cancel_badged_sends epptr badge)"
+  and arch_post_modify_registers_Syscall_AC_wps[simp]:
+    "gpd_wps (arch_post_modify_registers cur t)"
+  and arch_perform_invocation_Syscall_AC_wps[simp]:
+    "gpd_wps (arch_perform_invocation ai)"
+  and arch_invoke_irq_control_Syscall_AC_wps[simp]:
+    "gpd_wps (arch_invoke_irq_control ivk)"
+  and arch_invoke_irq_handler_Syscall_AC_wps[simp]:
+    "gpd_wps (arch_invoke_irq_handler ihi)"
+  and arch_mask_irq_signal_Syscall_AC_wps[simp]:
+    "gpd_wps (arch_mask_irq_signal irq)"
+  and handle_reserved_irq_Syscall_AC_wps[simp]:
+    "gpd_wps (handle_reserved_irq irq)"
+  and handle_arch_fault_reply_Syscall_AC_wps[simp]:
+    "gpd_wps (handle_arch_fault_reply vmf thread x y)"
+  and handle_hypervisor_fault_Syscall_AC_wps[simp]:
+    "gpd_wps (handle_hypervisor_fault t hf_t)"
+  and handle_vm_fault_Syscall_AC_wps[simp]:
+    "gpd_wps (handle_vm_fault t vmf_t)"
+  and arch_switch_to_thread_Syscall_AC_wps'[simp]:
+    "Syscall_AC_wps (arch_switch_to_thread t) aag"
+  and arch_switch_to_idle_thread_respects[simp]:
+    "Syscall_AC_wps (arch_switch_to_idle_thread) aag"
+  and arch_activate_idle_thread_respects[simp]:
+    "Syscall_AC_wps (arch_activate_idle_thread t) aag"
+  and arch_mask_irq_signal_integrity[simp]:
+    "Syscall_AC_wps (arch_mask_irq_signal irq) aag"
+  and handle_reserved_irq_integrity[simp]:
+    "Syscall_AC_wps (handle_reserved_irq irq) aag"
+  and handle_hypervisor_fault_integrity[simp]:
+    "Syscall_AC_wps (handle_hypervisor_fault t hf_t) aag"
+  and arch_switch_to_idle_thread_pas_refined[wp]:
+    "arch_switch_to_idle_thread \<lbrace>pas_refined aag\<rbrace>"
+  and arch_activate_idle_thread_pas_refined[wp]:
+    "arch_activate_idle_thread t \<lbrace>pas_refined aag\<rbrace>"
+  and arch_mask_irq_signal_pas_refined[wp]:
+    "arch_mask_irq_signal irq \<lbrace>pas_refined aag\<rbrace>"
+  and handle_reserved_irq_pas_refined[wp]:
+    "handle_reserved_irq irq \<lbrace>pas_refined aag\<rbrace>"
+  and handle_hypervisor_fault_pas_refined[wp]:
+    "handle_hypervisor_fault t hf_t \<lbrace>pas_refined aag\<rbrace>"
+  and handle_vm_fault_integrity:
+    "\<lbrace>integrity aag X st and K (is_subject aag thread)\<rbrace>
+     handle_vm_fault thread vmfault_type
+     \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  and handle_vm_fault_pas_refined[wp]:
+    "handle_vm_fault t vmf_t \<lbrace>pas_refined aag\<rbrace>"
+  and arch_mask_irq_signal_pas_cur_domain:
+    "arch_mask_irq_signal irq \<lbrace>pas_cur_domain aag\<rbrace>"
+  and handle_reserved_irq_pas_cur_domain:
+    "handle_reserved_irq irq \<lbrace>pas_cur_domain aag\<rbrace>"
+  and ackInterrupt_underlying_memory_inv[wp]:
+    "\<And>P. ackInterrupt irq \<lbrace>\<lambda>s. P (underlying_memory s)\<rbrace>"
+  and resetTimer_underlying_memory_inv[wp]:
+    "\<And>P. resetTimer \<lbrace>\<lambda>s. P (underlying_memory s)\<rbrace>"
+  and arch_post_cap_deletion_ct_active[wp]:
+    "arch_post_cap_deletion acap \<lbrace>\<lambda>s :: det_ext state. ct_active s\<rbrace>"
+  and arch_mask_irq_signal_arch_state[wp]:
+    "\<And>P. arch_mask_irq_signal irq \<lbrace>\<lambda>s :: det_ext state. P (arch_state s)\<rbrace>"
+  and handle_reserved_irq_arch_state[wp]:
+    "\<And>P. handle_reserved_irq irq \<lbrace>\<lambda>s :: det_ext state. P (arch_state s)\<rbrace>"
+  and init_arch_objects_arch_state[wp]:
+    "\<And>P. init_arch_objects new_type ptr n sz refs \<lbrace>\<lambda>s :: det_ext state. P (arch_state s)\<rbrace>"
+  and getActiveIRQ_inv:
+    "\<And>P. \<forall>f s. P s \<longrightarrow> P (irq_state_update f s)
+          \<Longrightarrow> \<lbrace>P\<rbrace> getActiveIRQ in_kernel \<lbrace>\<lambda>rv. P\<rbrace>"
+  and getActiveIRQ_rv_None:
+    "\<lbrace>\<top>\<rbrace> getActiveIRQ True \<lbrace>\<lambda>rv ms. (rv \<noteq> None \<longrightarrow> the rv \<notin> non_kernel_IRQs)\<rbrace>"
+  and set_thread_state_restart_to_running_respects:
+    "\<lbrace>integrity aag X st and st_tcb_at ((=) Restart) thread and K (pasMayActivate aag)\<rbrace>
+     do pc \<leftarrow> as_user thread getRestartPC;
+              as_user thread $ setNextPC pc;
+              set_thread_state thread Structures_A.thread_state.Running
+     od
+     \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+begin
+
+interpretation prepare_thread_delete: gpd_wps' "prepare_thread_delete p"
+  by simp
+interpretation arch_finalise_cap: gpd_wps' "arch_finalise_cap acap final"
+  by simp
+interpretation cap_move: gpd_wps' "cap_move new_cap src_slot dest_slot"
+  by simp
+interpretation cancel_badged_sends: gpd_wps' "cancel_badged_sends epptr badge"
+  by simp
+
+interpretation arch_post_modify_registers: gpd_wps "arch_post_modify_registers cur t"
+  by simp
+interpretation arch_perform_invocation: gpd_wps "arch_perform_invocation ai"
+  by simp
+interpretation arch_invoke_irq_control: gpd_wps "arch_invoke_irq_control ivk"
+  by simp
+interpretation arch_invoke_irq_handler: gpd_wps "arch_invoke_irq_handler ihi"
+  by simp
+interpretation arch_mask_irq_signal: gpd_wps "arch_mask_irq_signal irq"
+  by simp
+interpretation handle_reserved_irq: gpd_wps "handle_reserved_irq irq"
+  by simp
+interpretation handle_arch_fault_reply: gpd_wps "handle_arch_fault_reply vmf thread x y"
+  by simp
+interpretation handle_hypervisor_fault: gpd_wps "handle_hypervisor_fault t hf_t"
+  by simp
+interpretation handle_vm_fault: gpd_wps "handle_vm_fault t vmf_t"
+  by simp
+
+interpretation arch_switch_to_thread: Syscall_AC_wps "arch_switch_to_thread t" aag
+  by simp
+interpretation arch_switch_to_idle_thread: Syscall_AC_wps "arch_switch_to_idle_thread" aag
+  by simp
+interpretation arch_activate_idle_thread: Syscall_AC_wps "arch_activate_idle_thread t" aag
+  by simp
+interpretation arch_mask_irq_signal: Syscall_AC_wps "arch_mask_irq_signal irq" aag
+  by simp
+interpretation handle_reserved_irq: Syscall_AC_wps "handle_reserved_irq irq" aag
+  by simp
+interpretation handle_hypervisor_fault: Syscall_AC_wps "handle_hypervisor_fault t hf_t" aag
+  by simp
+
 lemma handle_interrupt_pas_refined:
-  "\<lbrace>pas_refined aag\<rbrace>
-     handle_interrupt irq
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "handle_interrupt irq \<lbrace>pas_refined aag\<rbrace>"
   apply (simp add: handle_interrupt_def)
   apply (rule conjI; rule impI;rule hoare_pre)
   apply (wp send_signal_pas_refined get_cap_wp
-       | wpc
-       | simp add: get_irq_slot_def get_irq_state_def handle_reserved_irq_def)+
+         | wpc
+         | simp add: get_irq_slot_def get_irq_state_def )+
   done
 
 lemma dec_domain_time_integrity[wp]:
-  "\<lbrace>integrity aag X st\<rbrace>
-        dec_domain_time
-       \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  "dec_domain_time \<lbrace>integrity aag X st\<rbrace>"
   apply (simp add: dec_domain_time_def | wp)+
   apply (clarsimp simp: integrity_subjects_def)
   done
 
 lemma timer_tick_integrity[wp]:
   "\<lbrace>integrity aag X st and pas_refined aag and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))\<rbrace>
-        timer_tick
-       \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+   timer_tick
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: timer_tick_def)
   apply (wp ethread_set_integrity_autarch gts_wp
-           | wpc | simp add: thread_set_time_slice_def split del: if_split)+
+         | wpc | simp add: thread_set_time_slice_def split del: if_split)+
   apply (clarsimp simp: ct_in_state_def st_tcb_at_def obj_at_def)
   done
 
 lemma handle_interrupt_integrity_autarch:
-  "\<lbrace>integrity aag X st and pas_refined aag
-          and invs and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))
-          and K (is_subject_irq aag irq)\<rbrace>
-     handle_interrupt irq
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: handle_interrupt_def  cong: irq_state.case_cong maskInterrupt_def
-                   ackInterrupt_def resetTimer_def )
+  "\<lbrace>integrity aag X st and pas_refined aag and invs
+                       and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))
+                       and K (is_subject_irq aag irq)\<rbrace>
+   handle_interrupt irq
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: handle_interrupt_def  cong: irq_state.case_cong)
   apply (rule conjI; rule impI; rule hoare_pre)
-  apply (wp (once) send_signal_respects get_cap_auth_wp [where aag = aag] dmo_mol_respects
-       | simp add: get_irq_slot_def get_irq_state_def ackInterrupt_def resetTimer_def
-                   handle_reserved_irq_def
-       | wp dmo_no_mem_respects
-       | wpc)+
+     apply (wp (once) send_signal_respects get_cap_auth_wp [where aag = aag] dmo_mol_respects
+                      ackInterrupt_device_state_inv resetTimer_device_state_inv
+            | simp add: get_irq_slot_def get_irq_state_def
+            | wp dmo_no_mem_respects
+            | wpc)+
   apply (fastforce simp: is_cap_simps aag_cap_auth_def cap_auth_conferred_def
                          cap_rights_to_auth_def)
   done
 
 lemma hacky_ipc_Send:
-  "\<lbrakk> (pasObjectAbs aag (interrupt_irq_node s irq), Notify, pasObjectAbs aag p) \<in> pasPolicy aag;
+  "\<lbrakk> abs_has_auth_to aag Notify (interrupt_irq_node s irq) p;
      pas_refined aag s; pasMaySendIrqs aag \<rbrakk>
-   \<Longrightarrow> aag_has_auth_to aag Notify p"
+     \<Longrightarrow> aag_has_auth_to aag Notify p"
   unfolding pas_refined_def
   apply (clarsimp simp: policy_wellformed_def irq_map_wellformed_aux_def)
   apply (drule spec [where x = "pasIRQAbs aag irq"], drule spec [where x = "pasObjectAbs aag p"],
@@ -513,20 +598,19 @@ lemma hacky_ipc_Send:
   apply simp
   done
 
-
 lemma handle_interrupt_integrity:
   "\<lbrace>integrity aag X st and pas_refined aag and invs
-       and (\<lambda>s. pasMaySendIrqs aag \<or> interrupt_states s irq \<noteq> IRQSignal)
-       and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))\<rbrace>
-     handle_interrupt irq
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: handle_interrupt_def maskInterrupt_def ackInterrupt_def resetTimer_def
+                       and (\<lambda>s. pasMaySendIrqs aag \<or> interrupt_states s irq \<noteq> IRQSignal)
+                       and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))\<rbrace>
+   handle_interrupt irq
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: handle_interrupt_def
              cong: irq_state.case_cong bind_cong)
   apply (rule conjI; rule impI; rule hoare_pre)
-  apply (wp (once) send_signal_respects get_cap_wp dmo_mol_respects dmo_no_mem_respects
-       | wpc
-       | simp add: get_irq_slot_def get_irq_state_def ackInterrupt_def resetTimer_def
-                   handle_reserved_irq_def)+
+     apply (wp (once) send_signal_respects get_cap_wp dmo_mol_respects dmo_no_mem_respects
+                      ackInterrupt_device_state_inv resetTimer_device_state_inv
+            | wpc
+            | simp add: get_irq_slot_def get_irq_state_def)+
   apply clarsimp
   apply (rule conjI, fastforce)+ \<comment> \<open>valid_objs etc.\<close>
   apply (clarsimp simp: cte_wp_at_caps_of_state)
@@ -537,243 +621,132 @@ lemma handle_interrupt_integrity:
   apply assumption+
   done
 
-lemma handle_vm_fault_integrity:
-  "\<lbrace>integrity aag X st and K (is_subject aag thread)\<rbrace>
-    handle_vm_fault thread vmfault_type
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (cases vmfault_type, simp_all)
-  apply (rule hoare_pre)
-  apply (wp as_user_integrity_autarch dmo_wp | simp add: getDFSR_def getFAR_def getIFSR_def)+
-  done
-
-lemma handle_vm_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace>
-    handle_vm_fault thread vmfault_type
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  apply (cases vmfault_type, simp_all)
-  apply (wp | simp)+
-  done
-
-crunch pas_refined[wp]: handle_hypervisor_fault "pas_refined aag"
-crunch cur_thread[wp]: handle_hypervisor_fault "\<lambda>s. P (cur_thread s)"
-crunch integrity[wp]: handle_hypervisor_fault "integrity aag X st"
-
-lemma handle_vm_cur_thread [wp]:
-  "\<lbrace>\<lambda>s. P (cur_thread s)\<rbrace>
-    handle_vm_fault thread vmfault_type
-   \<lbrace>\<lambda>rv s. P (cur_thread s)\<rbrace>"
-  apply (cases vmfault_type, simp_all)
-  apply (wp | simp)+
-  done
-
-lemma handle_vm_state_refs_of [wp]:
-  "\<lbrace>\<lambda>s. P (state_refs_of s)\<rbrace>
-    handle_vm_fault thread vmfault_type
-   \<lbrace>\<lambda>rv s. P (state_refs_of s)\<rbrace>"
-  apply (cases vmfault_type, simp_all)
-  apply (wp | simp)+
-  done
-
 lemma handle_yield_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace>
-    handle_yield
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "handle_yield \<lbrace>pas_refined aag\<rbrace>"
   by (simp add: handle_yield_def | wp)+
-
-
 
 lemma handle_event_pas_refined:
   "\<lbrace>pas_refined aag and guarded_pas_domain aag and domain_sep_inv (pasMaySendIrqs aag) st'
-          and einvs and schact_is_rct
-          and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> is_subject aag (cur_thread s))
-          and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) \<rbrace>
-    handle_event ev
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+                    and einvs and schact_is_rct
+                    and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> is_subject aag (cur_thread s))
+                    and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) \<rbrace>
+   handle_event ev
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (case_tac ev; simp)
       apply (rename_tac syscall)
       apply (case_tac syscall; simp add: handle_send_def handle_call_def)
             apply ((wp handle_invocation_pas_refined handle_recv_pas_refined
                        handle_fault_pas_refined
-                     | simp | clarsimp)+)
+                    | simp | clarsimp)+)
      apply (fastforce simp: valid_fault_def)
-    apply (wp handle_fault_pas_refined
-            | simp)+
+    apply (wp handle_fault_pas_refined | simp)+
     apply (fastforce simp: valid_fault_def)
    apply (wp handle_interrupt_pas_refined handle_fault_pas_refined
              hoare_vcg_conj_lift hoare_vcg_all_lift
-           | wpc
-           | rule hoare_drop_imps
-           | strengthen invs_vobjs_strgs
-           | simp)+
+          | wpc
+          | rule hoare_drop_imps
+          | strengthen invs_vobjs_strgs
+          | simp)+
   done
 
-lemma valid_fault_Unknown [simp]:
+lemma valid_fault_Unknown[simp]:
   "valid_fault (UnknownSyscallException x)"
   by (simp add: valid_fault_def)
 
-lemma valid_fault_User [simp]:
+lemma valid_fault_User[simp]:
   "valid_fault (UserException word1 word2)"
   by (simp add: valid_fault_def)
-
 
 declare hy_inv[wp del]
 
 lemma handle_yield_integrity[wp]:
   "\<lbrace>integrity aag X st and pas_refined aag and is_subject aag \<circ> cur_thread\<rbrace>
-    handle_yield
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+   handle_yield
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   by (simp add: handle_yield_def | wp)+
 
-lemma ct_in_state_machine_state_update[simp]: "ct_in_state s (st\<lparr>machine_state := x\<rparr>) = ct_in_state s st"
-  apply (simp add: ct_in_state_def)
-  done
-
+lemma ct_in_state_machine_state_update[simp]:
+  "ct_in_state s (st\<lparr>machine_state := x\<rparr>) = ct_in_state s st"
+  by (simp add: ct_in_state_def)
 
 lemma handle_event_integrity:
-  "\<lbrace>integrity aag X st and pas_refined aag and guarded_pas_domain aag and domain_sep_inv (pasMaySendIrqs aag) st'
-          and einvs and schact_is_rct
-          and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s)) and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) and ((=) st)\<rbrace>
-    handle_event ev
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (case_tac "ev \<noteq> Interrupt")
-  apply (case_tac ev; simp)
-      apply (rename_tac syscall)
-      apply (case_tac syscall, simp_all add: handle_send_def handle_call_def)
-      apply (wp handle_recv_integrity handle_invocation_respects
-                handle_reply_respects handle_fault_integrity_autarch
-                handle_interrupt_integrity handle_vm_fault_integrity
-                handle_reply_pas_refined handle_vm_fault_valid_fault
-                handle_reply_valid_sched
-                hoare_vcg_conj_lift hoare_vcg_all_lift alternative_wp select_wp
-           | rule dmo_wp
-           | wpc
-           | simp add: getActiveIRQ_def domain_sep_inv_def
-           | clarsimp
-           | rule conjI hoare_vcg_E_elim
-           | strengthen invs_vobjs_strgs invs_mdb_strgs
-           | fastforce)+
-   done
-
-lemma set_thread_state_restart_to_running_respects:
-  "\<lbrace>integrity aag X st and st_tcb_at ((=) Structures_A.Restart) thread
-          and K (pasMayActivate aag)\<rbrace>
-              do pc \<leftarrow> as_user thread getRestartPC;
-                 as_user thread $ setNextPC pc;
-                 set_thread_state thread Structures_A.thread_state.Running
-              od
+  "\<lbrace>integrity aag X st and pas_refined aag and guarded_pas_domain aag
+                       and domain_sep_inv (pasMaySendIrqs aag) st'
+                       and einvs and schact_is_rct
+                       and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))
+                       and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) and ((=) st)\<rbrace>
+   handle_event ev
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  apply (simp add: set_thread_state_def as_user_def split_def setNextPC_def
-                   getRestartPC_def setRegister_def bind_assoc getRegister_def)
-  apply (wpsimp wp: set_object_wp)
-  apply (clarsimp simp: in_monad fun_upd_def[symmetric] cong: if_cong)
-  apply (cases "is_subject aag thread")
-   apply (cut_tac aag=aag in integrity_update_autarch, simp+)
-  apply (erule integrity_trans)
-  apply (clarsimp simp: integrity_def obj_at_def st_tcb_at_def)
-  apply (clarsimp dest!: get_tcb_SomeD)
-  apply (rule_tac tro_tcb_activate[OF refl refl])
-    apply (simp add: tcb_bound_notification_reset_integrity_def)+
-  done
+  apply (cases ev; simp)
+       apply (unfold handle_send_def handle_call_def)
+  by (wpsimp wp: handle_recv_integrity handle_invocation_respects
+                  handle_reply_respects handle_fault_integrity_autarch
+                  handle_interrupt_integrity handle_vm_fault_integrity
+                  handle_reply_pas_refined handle_vm_fault_valid_fault
+                  handle_reply_valid_sched alternative_wp select_wp
+                  hoare_vcg_conj_lift hoare_vcg_all_lift hoare_drop_imps
+            simp: domain_sep_inv_def
+      | rule dmo_wp hoare_vcg_E_elim
+      | fastforce
+      | (rule hoare_vcg_conj_lift)?, wpsimp wp: getActiveIRQ_inv)+
 
 lemma activate_thread_respects:
   "\<lbrace>integrity aag X st and K (pasMayActivate aag)\<rbrace>
-    activate_thread
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: activate_thread_def arch_activate_idle_thread_def)
-  apply (rule hoare_pre)
-  apply (wp set_thread_state_restart_to_running_respects thread_get_wp'
-    | wpc | simp add: arch_activate_idle_thread_def get_thread_state_def)+
+   activate_thread
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: activate_thread_def get_thread_state_def)
+  apply (wpsimp wp: set_thread_state_restart_to_running_respects thread_get_wp')
   apply (clarsimp simp: st_tcb_at_def obj_at_def)
   done
 
 lemma activate_thread_integrity:
-  "\<lbrace>integrity aag X st and (\<lambda>s. cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject aag (cur_thread s)) and valid_idle\<rbrace>
-    activate_thread
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: activate_thread_def arch_activate_idle_thread_def)
+  "\<lbrace>integrity aag X st and valid_idle and
+    (\<lambda>s. cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject aag (cur_thread s))\<rbrace>
+   activate_thread
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: activate_thread_def )
   apply (rule hoare_pre)
-  apply (wp gts_wp set_thread_state_integrity_autarch as_user_integrity_autarch | wpc |  simp add: arch_activate_idle_thread_def)+
-  apply(clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def)
+  apply (wpsimp wp: gts_wp set_thread_state_integrity_autarch as_user_integrity_autarch)+
+  apply (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def)
   done
 
 lemma activate_thread_pas_refined:
-  "\<lbrace> pas_refined aag \<rbrace>
-    activate_thread
-   \<lbrace>\<lambda>rv. pas_refined aag \<rbrace>"
-  unfolding activate_thread_def arch_activate_idle_thread_def
-            get_thread_state_def thread_get_def
-  apply (rule hoare_pre)
-  apply (wp set_thread_state_pas_refined hoare_drop_imps
-             | wpc | simp)+
+  "activate_thread \<lbrace>pas_refined aag\<rbrace>"
+  unfolding activate_thread_def get_thread_state_def thread_get_def
+  apply (wpsimp wp: set_thread_state_pas_refined hoare_drop_imps)
   done
 
-lemma integrity_exclusive_state [iff]:
-  "integrity aag X st (s\<lparr>machine_state := machine_state s \<lparr>exclusive_state := es \<rparr>\<rparr>)
-   = integrity aag X st s"
-  unfolding integrity_def
-  by simp
-
-lemma dmo_clearExMonitor_respects_globals[wp]:
-  "\<lbrace>integrity aag X st\<rbrace>
-    do_machine_op clearExMonitor
-   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  apply (rule hoare_pre)
-  apply (simp add: clearExMonitor_def | wp dmo_wp)+
-  done
-
-lemma integrity_cur_thread [iff]:
+lemma integrity_cur_thread[iff]:
   "integrity aag X st (s\<lparr>cur_thread := v\<rparr>) = integrity aag X st s"
   unfolding integrity_def by simp
 
 lemma tcb_sched_action_dequeue_integrity_pasMayEditReadyQueues:
   "\<lbrace>integrity aag X st and pas_refined aag and K (pasMayEditReadyQueues aag)\<rbrace>
-    tcb_sched_action tcb_sched_dequeue thread
+   tcb_sched_action tcb_sched_dequeue thread
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: tcb_sched_action_def)
   apply wp
-  apply (clarsimp simp: integrity_def integrity_ready_queues_def pas_refined_def tcb_domain_map_wellformed_aux_def etcb_at_def get_etcb_def
-                  split: option.splits)
-  done
-
-lemma as_user_set_register_respects_indirect:
-  "\<lbrace>integrity aag X st and st_tcb_at ((=) Structures_A.Running) thread and
-    K ((\<not> is_subject aag thread \<longrightarrow> st_tcb_at receive_blocked thread st
-           \<and> bound_tcb_at ((=) (Some ntfnptr)) thread st)
-        \<and> (aag_has_auth_to aag Notify ntfnptr)) \<rbrace>
-   as_user thread (setRegister r v)
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: as_user_def split_def set_object_def get_object_def)
-  apply wp
-  apply (clarsimp simp: in_monad setRegister_def)
-  apply (cases "is_subject aag thread")
-   apply (erule (1) integrity_update_autarch [unfolded fun_upd_def])
-  apply (clarsimp simp: st_tcb_def2 receive_blocked_def)
-  apply (simp split: thread_state.split_asm)
-  apply (rule send_upd_ctxintegrity [OF disjI2, unfolded fun_upd_def],
-         auto simp: st_tcb_def2 indirect_send_def pred_tcb_def2 dest: sym)
+  apply (clarsimp simp: integrity_def integrity_ready_queues_def pas_refined_def
+                        tcb_domain_map_wellformed_aux_def etcb_at_def get_etcb_def
+                 split: option.splits)
   done
 
 lemma switch_to_thread_respects_pasMayEditReadyQueues:
-  notes tcb_sched_action_dequeue_integrity[wp del]
-  shows
-  "\<lbrace>integrity aag X st and pas_refined aag
-    and K (pasMayEditReadyQueues aag)\<rbrace>
-  switch_to_thread t
-  \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  unfolding switch_to_thread_def arch_switch_to_thread_def
+  "\<lbrace>integrity aag X st and pas_refined aag and K (pasMayEditReadyQueues aag)\<rbrace>
+   switch_to_thread t
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  unfolding switch_to_thread_def
   apply (simp add: spec_valid_def)
-  apply (wp tcb_sched_action_dequeue_integrity_pasMayEditReadyQueues
-                | simp add: clearExMonitor_def)+
+  apply (wpsimp wp: tcb_sched_action_dequeue_integrity_pasMayEditReadyQueues)
   done
 
 lemma switch_to_thread_respects:
-  "\<lbrace>integrity aag X st and pas_refined aag
-    and K (is_subject aag t) \<rbrace>
-  switch_to_thread t
-  \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  unfolding switch_to_thread_def arch_switch_to_thread_def
+  "\<lbrace>integrity aag X st and pas_refined aag and K (is_subject aag t) \<rbrace>
+   switch_to_thread t
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  unfolding switch_to_thread_def
   apply (simp add: spec_valid_def)
-  apply (wp | simp add: clearExMonitor_def)+
+  apply wpsimp
   done
 
 text \<open>
@@ -782,26 +755,23 @@ See comment for @{thm tcb_sched_action_dequeue_integrity'}
 \<close>
 lemma switch_to_thread_respects':
   "\<lbrace>integrity aag X st and pas_refined aag
-    and (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag (tcb_domain (the (ekheap s t)))) \<rbrace>
-  switch_to_thread t
-  \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  unfolding switch_to_thread_def arch_switch_to_thread_def
+                       and (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag (tcb_domain (the (ekheap s t))))\<rbrace>
+   switch_to_thread t
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  unfolding switch_to_thread_def
   apply (simp add: spec_valid_def)
-  apply (wp tcb_sched_action_dequeue_integrity'
-        | simp add: clearExMonitor_def)+
+  apply (wpsimp wp: tcb_sched_action_dequeue_integrity')
   done
 
 lemma switch_to_idle_thread_respects:
-  "\<lbrace>integrity aag X st\<rbrace>
-    switch_to_idle_thread
-  \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  unfolding switch_to_idle_thread_def arch_switch_to_idle_thread_def
-  by (wp | simp)+
+  "switch_to_idle_thread \<lbrace>integrity aag X st\<rbrace>"
+  unfolding switch_to_idle_thread_def by wpsimp
 
 lemma choose_thread_respects_pasMayEditReadyQueues:
-  "\<lbrace>integrity aag X st and pas_refined aag and einvs and valid_queues and K (pasMayEditReadyQueues aag ) \<rbrace>
-  choose_thread
-  \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and einvs and valid_queues
+                       and K (pasMayEditReadyQueues aag)\<rbrace>
+   choose_thread
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   by (simp add: choose_thread_def guarded_switch_to_def
       | wp switch_to_thread_respects_pasMayEditReadyQueues switch_to_idle_thread_respects gts_wp)+
 
@@ -809,9 +779,9 @@ text \<open>integrity for @{const choose_thread} without @{const pasMayEditReady
 lemma choose_thread_respects:
   "\<lbrace>integrity aag X st and pas_refined aag and pas_cur_domain aag and einvs and valid_queues\<rbrace>
    choose_thread
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: choose_thread_def guarded_switch_to_def
-        | wp switch_to_thread_respects' switch_to_idle_thread_respects gts_wp)+
+         | wp switch_to_thread_respects' switch_to_idle_thread_respects gts_wp)+
   apply (clarsimp simp: pas_refined_def)
   apply (clarsimp simp: tcb_domain_map_wellformed_aux_def)
   apply (clarsimp simp: valid_queues_def is_etcb_at_def)
@@ -832,29 +802,15 @@ lemma choose_thread_respects:
   done
 
 lemma guarded_switch_to_respects:
-  "\<lbrace> integrity aag X st
-     and pas_refined aag and (\<lambda>s. is_subject aag x)\<rbrace>
+  "\<lbrace>integrity aag X st and pas_refined aag and (\<lambda>s. is_subject aag x)\<rbrace>
    guarded_switch_to x
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-   apply (simp add: guarded_switch_to_def)
-   apply (simp add: choose_thread_def guarded_switch_to_def
-               | wp switch_to_thread_respects switch_to_idle_thread_respects gts_wp)+
-   done
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+   by (wpsimp simp: guarded_switch_to_def choose_thread_def
+                wp: switch_to_thread_respects switch_to_idle_thread_respects gts_wp)
 
-lemma next_domain_integrity [wp]:
-  "\<lbrace>integrity aag X st\<rbrace>
-  next_domain
-  \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: next_domain_def thread_set_domain_def ethread_set_def set_eobject_def Let_def | wp)+
-  apply (clarsimp simp: get_etcb_def integrity_subjects_def lfp_def)
-  done
-
-lemma next_domain_tcb_domain_map_wellformed [wp]:
-  "\<lbrace>tcb_domain_map_wellformed aag\<rbrace>
-  next_domain
-  \<lbrace>\<lambda>rv. tcb_domain_map_wellformed aag\<rbrace>"
-  by (simp add: next_domain_def thread_set_domain_def ethread_set_def set_eobject_def Let_def | wp)+
-
+lemma next_domain_tcb_domain_map_wellformed[wp]:
+  "next_domain \<lbrace>tcb_domain_map_wellformed aag\<rbrace>"
+  by (wpsimp simp: next_domain_def thread_set_domain_def ethread_set_def set_eobject_def Let_def)
 
 lemma valid_blocked_2_valid_blocked_except[simp]:
   "valid_blocked_2 queues kh sa ct \<Longrightarrow> valid_blocked_except_2 t queues kh sa ct"
@@ -862,7 +818,7 @@ lemma valid_blocked_2_valid_blocked_except[simp]:
 
 (* clagged from Schedule_R *)
 lemma next_domain_valid_sched:
-  "\<lbrace> valid_sched and (\<lambda>s. scheduler_action s  = choose_new_thread)\<rbrace> next_domain \<lbrace> \<lambda>_. valid_sched \<rbrace>"
+  "\<lbrace>valid_sched and (\<lambda>s. scheduler_action s = choose_new_thread)\<rbrace> next_domain \<lbrace>\<lambda>_. valid_sched\<rbrace>"
   apply (simp add: next_domain_def Let_def)
   apply (wp, simp add: valid_sched_def valid_sched_action_2_def ct_not_in_q_2_def)
   apply (simp add:valid_blocked_2_def)
@@ -874,10 +830,10 @@ because t's domain may contain multiple labels. See the comment for
 @{thm tcb_sched_action_dequeue_integrity'}
 \<close>
 lemma valid_sched_action_switch_subject_thread:
-   "\<lbrakk> scheduler_action s = switch_thread t ; valid_sched_action s ;
-      valid_etcbs s ; pas_refined aag s ; pas_cur_domain aag s \<rbrakk>
-    \<Longrightarrow> pasObjectAbs aag t \<in> pasDomainAbs aag (tcb_domain (the (ekheap s t))) \<and>
-        pasSubject aag \<in> pasDomainAbs aag (tcb_domain (the (ekheap s t)))"
+   "\<lbrakk> scheduler_action s = switch_thread t; valid_sched_action s;
+      valid_etcbs s; pas_refined aag s; pas_cur_domain aag s \<rbrakk>
+      \<Longrightarrow> pasObjectAbs aag t \<in> pasDomainAbs aag (tcb_domain (the (ekheap s t))) \<and>
+          pasSubject aag \<in> pasDomainAbs aag (tcb_domain (the (ekheap s t)))"
   apply (clarsimp simp: valid_sched_action_def weak_valid_sched_action_2_def
                         switch_in_cur_domain_2_def in_cur_domain_2_def valid_etcbs_def
                         etcb_at_def st_tcb_at_def obj_at_def is_etcb_at_def)
@@ -887,13 +843,33 @@ lemma valid_sched_action_switch_subject_thread:
   apply force
   done
 
+lemma next_domain_integrity[wp]:
+  "next_domain \<lbrace>integrity aag X st\<rbrace>"
+  apply (wpsimp simp: next_domain_def thread_set_domain_def ethread_set_def set_eobject_def Let_def)
+  apply (clarsimp simp: get_etcb_def integrity_subjects_def lfp_def)
+  done
+
+lemma pas_refined_cur_thread[iff]:
+  "pas_refined aag (s\<lparr>cur_thread := v\<rparr>) = pas_refined aag s"
+  unfolding pas_refined_def
+  by (simp add: state_objs_to_policy_def)
+
+lemma switch_to_thread_pas_refined:
+  "switch_to_thread t \<lbrace>pas_refined aag\<rbrace>"
+  unfolding switch_to_thread_def
+  by (wpsimp wp: do_machine_op_pas_refined)
+
+lemma switch_to_idle_thread_pas_refined:
+  "switch_to_idle_thread \<lbrace>pas_refined aag\<rbrace>"
+  unfolding switch_to_idle_thread_def
+  by (wpsimp wp: do_machine_op_pas_refined)
 
 lemma schedule_choose_new_thread_integrity:
-  "\<lbrace> invs and valid_sched and valid_list and integrity aag X st and pas_refined aag
-     and K (pasMayEditReadyQueues aag)
-     and (\<lambda>s. scheduler_action s = choose_new_thread) \<rbrace>
+  "\<lbrace>invs and valid_sched and valid_list and integrity aag X st and pas_refined aag
+         and K (pasMayEditReadyQueues aag)
+         and (\<lambda>s. scheduler_action s = choose_new_thread)\<rbrace>
    schedule_choose_new_thread
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   unfolding schedule_choose_new_thread_def
   by (wpsimp wp: choose_thread_respects_pasMayEditReadyQueues
                  next_domain_valid_sched next_domain_valid_queues
@@ -902,24 +878,18 @@ lemma schedule_choose_new_thread_integrity:
 lemma schedule_integrity:
   "\<lbrace>einvs and integrity aag X st and pas_refined aag and pas_cur_domain aag
           and (\<lambda>s. domain_time s \<noteq> 0) \<rbrace>
-      schedule
-    \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+   schedule
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: schedule_def)
-  apply (rule hoare_pre)
-  supply ethread_get_wp[wp del]
-  apply (wp|wpc|simp only: schedule_choose_new_thread_def)+
-  apply (wpsimp wp: alternative_wp switch_to_thread_respects' select_wp switch_to_idle_thread_respects
-                 guarded_switch_to_lift choose_thread_respects gts_wp hoare_drop_imps
-                 set_scheduler_action_cnt_valid_sched append_thread_queued enqueue_thread_queued
-                 tcb_sched_action_enqueue_valid_blocked_except
-                 tcb_sched_action_append_integrity'
-            wp_del: ethread_get_wp
-    | wpc
-    | simp add: allActiveTCBs_def schedule_choose_new_thread_def
-    | rule hoare_pre_cont[where a=next_domain])+
+  apply (wpsimp wp: alternative_wp switch_to_thread_respects' select_wp guarded_switch_to_lift
+                    switch_to_idle_thread_respects choose_thread_respects gts_wp hoare_drop_imps
+                    set_scheduler_action_cnt_valid_sched append_thread_queued enqueue_thread_queued
+                    tcb_sched_action_enqueue_valid_blocked_except tcb_sched_action_append_integrity'
+         | simp add: allActiveTCBs_def schedule_choose_new_thread_def
+         | rule hoare_pre_cont[where a=next_domain])+
   apply (auto simp: obj_at_def st_tcb_at_def not_cur_thread_2_def valid_sched_def
-              valid_sched_action_def weak_valid_sched_action_def
-              valid_sched_action_switch_subject_thread schedule_choose_new_thread_def)
+                    valid_sched_action_def weak_valid_sched_action_def
+                    valid_sched_action_switch_subject_thread)
   done
 
 lemma  valid_sched_valid_sched_action:
@@ -927,10 +897,10 @@ lemma  valid_sched_valid_sched_action:
   by (simp add: valid_sched_def)
 
 lemma schedule_integrity_pasMayEditReadyQueues:
-  "\<lbrace>einvs and integrity aag X st and pas_refined aag and guarded_pas_domain aag
-          and K (pasMayEditReadyQueues aag) \<rbrace>
-     schedule
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>einvs and integrity aag X st and pas_refined aag
+          and guarded_pas_domain aag and K (pasMayEditReadyQueues aag)\<rbrace>
+   schedule
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   supply ethread_get_wp[wp del]
   supply schedule_choose_new_thread_integrity[wp]
   supply if_split[split del]
@@ -942,46 +912,24 @@ lemma schedule_integrity_pasMayEditReadyQueues:
        (* choose thread *)
        apply wp
       (* switch_to *)
-      apply (wpsimp wp: set_scheduler_action_cnt_valid_sched enqueue_thread_queued append_thread_queued
-                        tcb_sched_action_append_integrity_pasMayEditReadyQueues
+      apply (wpsimp wp: set_scheduler_action_cnt_valid_sched enqueue_thread_queued
+                        append_thread_queued tcb_sched_action_append_integrity_pasMayEditReadyQueues
                         guarded_switch_to_lift switch_to_thread_respects_pasMayEditReadyQueues)+
             (* is_highest_prio *)
             apply (simp add: wrap_is_highest_prio_def)
             apply ((wp (once) hoare_drop_imp)+)[1]
            apply (wpsimp wp: tcb_sched_action_enqueue_valid_blocked_except hoare_vcg_imp_lift' gts_wp)+
   apply (clarsimp simp: if_apply_def2 cong: imp_cong conj_cong)
-
-  apply (safe ; ((solves \<open>clarsimp simp: valid_sched_def not_cur_thread_def valid_sched_action_def
-                                         weak_valid_sched_action_def\<close>
-                )?))
+  apply (safe; ((solves \<open>clarsimp simp: valid_sched_def not_cur_thread_def
+                                        valid_sched_action_def weak_valid_sched_action_def\<close>)?))
    apply (clarsimp simp: obj_at_def pred_tcb_at_def)+
   done
 
-lemma pas_refined_cur_thread [iff]:
-  "pas_refined aag (s\<lparr>cur_thread := v\<rparr>) = pas_refined aag s"
-  unfolding pas_refined_def
-  by (simp add:  state_objs_to_policy_def)
-
-lemma switch_to_thread_pas_refined:
-  "\<lbrace>pas_refined aag\<rbrace>
-    switch_to_thread t
-  \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  unfolding switch_to_thread_def arch_switch_to_thread_def
-  by (wp do_machine_op_pas_refined | simp)+
-
-lemma switch_to_idle_thread_pas_refined:
-  "\<lbrace>pas_refined aag\<rbrace>
-    switch_to_idle_thread
-  \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  unfolding switch_to_idle_thread_def arch_switch_to_idle_thread_def
-  by (wp do_machine_op_pas_refined | simp)+
-
-crunch pas_refined[wp]: choose_thread "pas_refined aag" (wp: switch_to_thread_pas_refined switch_to_idle_thread_pas_refined crunch_wps)
+crunch pas_refined[wp]: choose_thread "pas_refined aag"
+  (wp: switch_to_thread_pas_refined switch_to_idle_thread_pas_refined crunch_wps)
 
 lemma schedule_pas_refined:
-  "\<lbrace>pas_refined aag\<rbrace>
-  schedule
-  \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "schedule \<lbrace>pas_refined aag\<rbrace>"
   apply (simp add: schedule_def allActiveTCBs_def)
   apply (wp add: alternative_wp guarded_switch_to_lift switch_to_thread_pas_refined select_wp
                   switch_to_idle_thread_pas_refined gts_wp
@@ -994,40 +942,18 @@ lemma schedule_pas_refined:
          | wpc | simp add: schedule_choose_new_thread_def)+
   done
 
-lemma handle_interrupt_arch_state [wp]:
-  "\<lbrace>\<lambda>s :: det_ext state. P (arch_state s)\<rbrace> handle_interrupt irq \<lbrace>\<lambda>_ s. P (arch_state s)\<rbrace>"
-  unfolding handle_interrupt_def
-  apply (rule hoare_if)
-  apply (rule hoare_pre)
-  apply clarsimp
-  apply (wp get_cap_inv dxo_wp_weak send_signal_arch_state
-        | wpc
-        | simp add: get_irq_state_def handle_reserved_irq_def)+
-  done
-
 lemmas sequence_x_mapM_x = mapM_x_def [symmetric]
 
-crunch arch_state [wp]: invoke_untyped "\<lambda>s. P (arch_state s)"
-   (wp: crunch_wps without_preemption_wp syscall_valid do_machine_op_arch hoare_unless_wp
-        preemption_point_inv mapME_x_inv_wp
-     simp: crunch_simps sequence_x_mapM_x
-     ignore: do_machine_op freeMemory clearMemory)
+crunch arch_state [wp]: invoke_untyped "\<lambda>s :: det_ext state. P (arch_state s)"
+  (wp: crunch_wps preemption_point_inv mapME_x_inv_wp simp: crunch_simps sequence_x_mapM_x)
 
-end
-
-crunch_ignore (add:
-  cap_swap_ext cap_move_ext cap_insert_ext empty_slot_ext create_cap_ext tcb_sched_action ethread_set
-  reschedule_required set_thread_state_ext possible_switch_to next_domain
-  set_domain
-  timer_tick set_priority retype_region_ext)
-
-context begin interpretation Arch . (*FIXME: arch_split*)
+crunch_ignore (add: cap_swap_ext cap_move_ext cap_insert_ext create_cap_ext set_thread_state_ext
+                    empty_slot_ext retype_region_ext set_priority ethread_set tcb_sched_action
+                    reschedule_required possible_switch_to next_domain set_domain timer_tick)
 
 lemma zet_zip_contrapos:
   "fst t \<notin> set xs  \<Longrightarrow> t \<notin> set (zip xs ys)"
-  apply (rule ccontr)
-  apply (simp add: set_zip_helper)
-  done
+  by (auto simp: set_zip_helper)
 
 lemma ct_active_update[simp]:
   "ct_active (s\<lparr>cdt := b\<rparr>) = ct_active s"
@@ -1037,63 +963,43 @@ lemma ct_active_update[simp]:
   by (auto simp: st_tcb_at_def ct_in_state_def)
 
 lemma set_cap_ct_active[wp]:
-  "\<lbrace>ct_active\<rbrace>
-    set_cap ptr c
-   \<lbrace>\<lambda>_. ct_active \<rbrace>"
+  "set_cap ptr c \<lbrace>ct_active \<rbrace>"
   apply (rule hoare_pre)
-  apply (wp select_wp sts_st_tcb_at_cases thread_set_no_change_tcb_state
-          | simp add: crunch_simps ct_in_state_def | wps)+
+  apply (wps | wpsimp wp: select_wp sts_st_tcb_at_cases thread_set_no_change_tcb_state
+                    simp: crunch_simps ct_in_state_def)+
   done
 
 lemma do_extended_op_ct_active[wp]:
-  "\<lbrace>ct_active\<rbrace>
-    do_extended_op ch
-   \<lbrace>\<lambda>_. ct_active \<rbrace>"
+  "do_extended_op ch \<lbrace>ct_active \<rbrace>"
   apply (rule hoare_pre)
   apply (wp | simp add: crunch_simps ct_in_state_def do_extended_op_def | wps)+
   apply (auto simp: st_tcb_at_def obj_at_def)
   done
 
-crunch ct_active [wp]: set_original "ct_active"
-  ( wp: crunch_wps
-    simp: crunch_simps ct_in_state_def)
-
-crunch ct_active [wp]: set_cdt "ct_active"
-  ( wp: crunch_wps
-    simp: crunch_simps ct_in_state_def)
+crunches set_original, set_cdt
+  for ct_active [wp]: "ct_active"
+  (wp: crunch_wps simp: crunch_simps ct_in_state_def)
 
 lemma cap_swap_ct_active[wp]:
-  "\<lbrace>ct_active\<rbrace>
-    cap_swap a b c d
-   \<lbrace>\<lambda>_. ct_active \<rbrace>"
+  "cap_swap a b c d \<lbrace>ct_active\<rbrace>"
   by (wp | simp add: cap_swap_def | wps)+
 
 lemma unbind_maybe_notification_ct_active[wp]:
-  "\<lbrace>ct_active\<rbrace>
-    unbind_maybe_notification ptr
-   \<lbrace>\<lambda>_. ct_active \<rbrace>"
-  apply (rule hoare_pre)
-  apply (wp | wps | simp add: unbind_maybe_notification_def ct_in_state_def | wpc)+
-  done
+  "unbind_maybe_notification ptr \<lbrace>ct_active\<rbrace>"
+  by (wps | wpsimp simp: unbind_maybe_notification_def ct_in_state_def)+
 
 lemma unbind_notification_ct_active[wp]:
-  "\<lbrace>ct_active\<rbrace>
-    unbind_notification ptr
-   \<lbrace>\<lambda>_. ct_active \<rbrace>"
-  apply (rule hoare_pre)
-  apply (wp | wps | simp add: unbind_notification_def ct_in_state_def | wpc)+
-  done
+  "unbind_notification ptr \<lbrace>ct_active\<rbrace>"
+  by (wps | wpsimp simp: unbind_notification_def ct_in_state_def)+
 
 lemma sts_Restart_ct_active[wp]:
-  "\<lbrace>ct_active\<rbrace> set_thread_state xa Restart \<lbrace>\<lambda>xb. ct_active\<rbrace>"
+  "set_thread_state xa Restart \<lbrace>ct_active\<rbrace>"
   apply (wp set_object_wp | simp add: set_thread_state_def)+
   apply (clarsimp simp: ct_in_state_def st_tcb_at_def obj_at_def)
   done
 
 lemma cancel_all_ipc_ct_active[wp]:
-  "\<lbrace>ct_active\<rbrace>
-    cancel_all_ipc ptr
-   \<lbrace>\<lambda>_. ct_active \<rbrace>"
+  "cancel_all_ipc ptr \<lbrace>ct_active\<rbrace>"
   apply (wp mapM_x_wp set_simple_ko_ct_active | wps | simp add: cancel_all_ipc_def | wpc)+
        apply force
       apply (wp mapM_x_wp set_simple_ko_ct_active)+
@@ -1102,46 +1008,46 @@ lemma cancel_all_ipc_ct_active[wp]:
   apply simp
   done
 
-crunch ct_active [wp]: cap_swap_for_delete "ct_active"
-  ( wp: crunch_wps filterM_preserved hoare_unless_wp
-    simp: crunch_simps ignore: do_extended_op)
+crunch ct_active[wp]: cap_swap_for_delete "ct_active"
+  (wp: crunch_wps filterM_preserved hoare_unless_wp simp: crunch_simps ignore: do_extended_op)
 
-crunch ct_active [wp]: post_cap_deletion, empty_slot "ct_active"
-  ( wp: crunch_wps filterM_preserved hoare_unless_wp
-    simp: crunch_simps ignore: do_extended_op)
+crunch ct_active[wp]: post_cap_deletion, empty_slot "\<lambda>s :: det_ext state. ct_active s"
+  (simp: crunch_simps empty_slot_ext_def ignore: do_extended_op
+     wp: crunch_wps filterM_preserved hoare_unless_wp)
 
-crunch cur_thread[wp]: cap_swap_for_delete,finalise_cap "\<lambda>s. P (cur_thread s)" (wp: select_wp dxo_wp_weak crunch_wps simp: crunch_simps )
+crunch cur_thread[wp]: cap_swap_for_delete, finalise_cap "\<lambda>s :: det_ext state. P (cur_thread s)"
+  (wp: select_wp dxo_wp_weak crunch_wps simp: crunch_simps)
 
-lemma irq_state_indepenedent_cur_thread[simp]: "irq_state_independent_A (\<lambda>s. P (cur_thread s))"
-  by (simp add: irq_state_independent_def)
-
-lemma rec_del_cur_thread[wp]:"\<lbrace>\<lambda>s. P (cur_thread s)\<rbrace> rec_del a \<lbrace>\<lambda>r s. P (cur_thread s)\<rbrace>"
+lemma rec_del_cur_thread[wp]:
+  "rec_del a \<lbrace>\<lambda>s :: det_ext state. P (cur_thread s)\<rbrace>"
   apply (rule rec_del_preservation)
   apply (wp preemption_point_inv|simp)+
   done
 
-crunch cur_thread[wp]: cap_delete,cap_move "\<lambda>s. P (cur_thread s)" (wp: cap_revoke_preservation2 mapM_wp mapM_x_wp crunch_wps dxo_wp_weak simp: filterM_mapM unless_def ignore: without_preemption filterM)
+crunch cur_thread[wp]: cap_delete, cap_move "\<lambda>s :: det_ext state. P (cur_thread s)"
 
-lemma cap_revoke_cur_thread[wp]: "\<lbrace>\<lambda>s. P (cur_thread s)\<rbrace> cap_revoke a \<lbrace>\<lambda>r s. P (cur_thread s)\<rbrace>"
+lemma cap_revoke_cur_thread[wp]:
+  "cap_revoke a \<lbrace>\<lambda>s :: det_ext state. P (cur_thread s)\<rbrace>"
   apply (rule cap_revoke_preservation2)
   apply (wp preemption_point_inv|simp)+
   done
 
-crunch cur_thread[wp]: cancel_badged_sends "\<lambda>s. P (cur_thread s)" (wp: crunch_wps mapM_wp mapM_x_wp dxo_wp_weak simp: filterM_mapM unless_def ignore: without_preemption filterM)
+crunch cur_thread[wp]: cancel_badged_sends "\<lambda>s. P (cur_thread s)"
+  (wp: mapM_wp dxo_wp_weak simp: filterM_mapM)
 
-lemma invoke_cnode_cur_thread[wp]: "\<lbrace>\<lambda>s. P (cur_thread s)\<rbrace> invoke_cnode a \<lbrace>\<lambda>r s. P (cur_thread s)\<rbrace>"
+lemma invoke_cnode_cur_thread[wp]:
+ "invoke_cnode a \<lbrace>\<lambda>s :: det_ext state. P (cur_thread s)\<rbrace>"
   apply (simp add: invoke_cnode_def)
   apply (rule hoare_pre)
   apply (wp hoare_drop_imps hoare_vcg_all_lift | wpc | simp split del: if_split)+
   done
 
-crunch cur_thread[wp]: handle_event "\<lambda>s. P (cur_thread s)"
+crunch cur_thread[wp]: handle_event "\<lambda>s :: det_ext state. P (cur_thread s)"
   (wp: syscall_valid crunch_wps check_cap_inv dxo_wp_weak
-   simp: crunch_simps filterM_mapM
-   ignore: syscall)
+   simp: crunch_simps ignore: syscall)
 
 crunches ethread_set, timer_tick, possible_switch_to, handle_interrupt
-  for pas_cur_domain[wp]: "pas_cur_domain pas"
+  for pas_cur_domain[wp]: "pas_cur_domain aag"
   (wp: crunch_wps simp: crunch_simps ignore_del: ethread_set timer_tick possible_switch_to)
 
 lemma dxo_idle_thread[wp]:
@@ -1151,36 +1057,33 @@ lemma dxo_idle_thread[wp]:
 crunch idle_thread[wp]: throwError "\<lambda>s. P (idle_thread s)"
 
 lemma preemption_point_idle_thread[wp]:
-  "\<lbrace>\<lambda>s. P (idle_thread s) \<rbrace> preemption_point \<lbrace>\<lambda>_ s. P (idle_thread s)\<rbrace>"
-  apply (clarsimp simp: preemption_point_def)
-  by (wpsimp wp: OR_choiceE_weak_wp simp: irq_state_independent_def)
+  "preemption_point \<lbrace>\<lambda>s. P (idle_thread s)\<rbrace>"
+  by (wpsimp wp: OR_choiceE_weak_wp simp: preemption_point_def)
 
-(* following idle_thread and cur_domain proofs clagged from infoflow/PasUpdates.thy *)
-crunch idle_thread'[wp]: cap_delete "\<lambda>s. P (idle_thread s)"
-
-lemma cap_revoke_idle_thread[wp]:"\<lbrace>\<lambda>s. P (idle_thread s)\<rbrace> cap_revoke a \<lbrace>\<lambda>r s. P (idle_thread s)\<rbrace>"
+lemma cap_revoke_idle_thread[wp]:
+  "cap_revoke a \<lbrace>\<lambda>s :: det_ext state. P (idle_thread s)\<rbrace>"
   by (rule cap_revoke_preservation2; wp)
 
-lemma invoke_cnode_idle_thread[wp]: "\<lbrace>\<lambda>s. P (idle_thread s)\<rbrace> invoke_cnode a \<lbrace>\<lambda>r s. P (idle_thread s)\<rbrace>"
+lemma invoke_cnode_idle_thread[wp]:
+  "invoke_cnode a \<lbrace>\<lambda>s :: det_ext state. P (idle_thread s)\<rbrace>"
   apply (simp add: invoke_cnode_def)
   apply (rule hoare_pre)
-    apply (wp hoare_drop_imps hoare_vcg_all_lift | wpc | simp split del: if_split)+
+   apply (wp hoare_drop_imps hoare_vcg_all_lift | wpc | simp split del: if_split)+
   done
 
-crunch idle_thread[wp]: handle_event "\<lambda>s::det_state. P (idle_thread s)"
-  (wp: syscall_valid crunch_wps
-   simp: crunch_simps check_cap_at_def
-   ignore: check_cap_at syscall)
+crunch idle_thread[wp]: handle_event "\<lambda>s :: det_state. P (idle_thread s)"
+  (wp: syscall_valid crunch_wps simp: check_cap_at_def ignore: check_cap_at syscall)
 
 crunch cur_domain[wp]:
-  transfer_caps_loop, ethread_set, possible_switch_to, thread_set_priority, set_priority,
-  set_domain, invoke_domain, cap_move_ext, timer_tick,
+  transfer_caps_loop, ethread_set, possible_switch_to, thread_set_priority,
+  set_priority, set_domain, invoke_domain, cap_move_ext, timer_tick,
   cap_move, cancel_badged_sends, possible_switch_to
   "\<lambda>s. P (cur_domain s)"
-  (wp: crunch_wps simp: crunch_simps filterM_mapM rule: transfer_caps_loop_pres
+  (wp: crunch_wps simp: filterM_mapM rule: transfer_caps_loop_pres
    ignore_del: ethread_set set_priority set_domain cap_move_ext timer_tick possible_switch_to)
 
-lemma invoke_cnode_cur_domain[wp]: "\<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> invoke_cnode a \<lbrace>\<lambda>r s. P (cur_domain s)\<rbrace>"
+lemma invoke_cnode_cur_domain[wp]:
+ "invoke_cnode a \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
   apply (simp add: invoke_cnode_def)
   apply (rule hoare_pre)
    apply (wp hoare_drop_imps hoare_vcg_all_lift | wpc | simp split del: if_split)+
@@ -1192,45 +1095,61 @@ crunch cur_domain[wp]: handle_event "\<lambda>s. P (cur_domain s)"
    ignore: check_cap_at syscall)
 
 lemma handle_event_guarded_pas_domain[wp]:
-  "\<lbrace>guarded_pas_domain aag\<rbrace> handle_event e \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
-  by (wp guarded_pas_domain_lift)
+  "handle_event e \<lbrace>guarded_pas_domain aag\<rbrace>"
+  by (wpsimp wp: guarded_pas_domain_lift)
 
 lemma handle_interrupt_guarded_pas_domain[wp]:
-  "\<lbrace>guarded_pas_domain aag\<rbrace> handle_interrupt blah \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
-  by (wp guarded_pas_domain_lift)
+  "handle_interrupt blah \<lbrace>guarded_pas_domain aag\<rbrace>"
+  by (wpsimp wp: guarded_pas_domain_lift)
+
+lemma integrity_irq_state_independent[simp]:
+  "integrity_subjects subjects aag activate X st (s\<lparr>machine_state := irq_state_update f ms\<rparr>) =
+   integrity_subjects subjects aag activate X st (s\<lparr>machine_state := ms\<rparr>)"
+  by (clarsimp simp: integrity_def)
+
+lemma guarded_pas_domain_machine_state_update[simp]:
+  "guarded_pas_domain aag (machine_state_update f s) = guarded_pas_domain aag s"
+  by (simp add: guarded_pas_domain_def)
 
 lemma call_kernel_integrity':
   "st \<turnstile> \<lbrace>einvs and pas_refined aag and is_subject aag \<circ> cur_thread and schact_is_rct and guarded_pas_domain aag
-                    and domain_sep_inv (pasMaySendIrqs aag) st'
-                    and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) and (ct_active or ct_idle)
-                    and K (pasMayActivate aag \<and> pasMayEditReadyQueues aag)\<rbrace>
-               call_kernel ev
-             \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  apply (simp add: call_kernel_def getActiveIRQ_def )
+               and domain_sep_inv (pasMaySendIrqs aag) st'
+               and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) and (ct_active or ct_idle)
+               and K (pasMayActivate aag \<and> pasMayEditReadyQueues aag)\<rbrace>
+        call_kernel ev
+        \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: call_kernel_def)
   apply (simp only: spec_valid_def)
-  apply (wp activate_thread_respects schedule_integrity_pasMayEditReadyQueues
-            handle_interrupt_integrity
-            dmo_wp alternative_wp select_wp handle_interrupt_pas_refined
-         | simp )+
+  apply (wpsimp wp: activate_thread_respects schedule_integrity_pasMayEditReadyQueues
+                    handle_interrupt_integrity dmo_wp alternative_wp
+                    select_wp handle_interrupt_pas_refined)
+    apply (clarsimp simp: if_fun_split)
+    apply (rule_tac Q="\<lambda>rv ms. (rv \<noteq> None \<longrightarrow> the rv \<notin> non_kernel_IRQs) \<and>
+                                R True (domain_sep_inv (pasMaySendIrqs aag) st' s) rv ms"
+                and R="\<lambda>rv ms. R (the rv \<in> non_kernel_IRQs \<longrightarrow> scheduler_act_sane s \<and> ct_not_queued s)
+                                 (pasMaySendIrqs aag \<or> interrupt_states s (the rv) \<noteq> IRQSignal) rv ms"
+                for R in hoare_strengthen_post[rotated], fastforce simp: domain_sep_inv_def)
+    apply (wpsimp wp: getActiveIRQ_rv_None hoare_drop_imps getActiveIRQ_inv)
    apply (rule hoare_post_impErr,
-          rule_tac Q = "integrity aag X st and pas_refined aag and einvs and guarded_pas_domain aag and domain_sep_inv (pasMaySendIrqs aag) st'
-                        and is_subject aag \<circ> cur_thread
-                        and (\<lambda>_. pasMayActivate aag \<and> pasMayEditReadyQueues aag)" in valid_validE)
-     apply (wp handle_event_integrity he_invs handle_event_pas_refined
-              handle_event_cur_thread handle_event_cur_domain
-              handle_event_domain_sep_inv handle_event_valid_sched | simp)+
-    apply(fastforce simp: domain_sep_inv_def guarded_pas_domain_def)+
+      rule_tac Q="integrity aag X st and pas_refined aag and einvs and guarded_pas_domain aag
+                                     and domain_sep_inv (pasMaySendIrqs aag) st'
+                                     and is_subject aag \<circ> cur_thread
+                                     and K (pasMayActivate aag \<and> pasMayEditReadyQueues aag)"
+            in valid_validE)
+     apply (wpsimp wp: handle_event_integrity he_invs handle_event_pas_refined
+                       handle_event_cur_thread handle_event_cur_domain
+                       handle_event_domain_sep_inv handle_event_valid_sched)+
+    apply (fastforce simp: domain_sep_inv_def guarded_pas_domain_def)+
   done
 
 lemma call_kernel_integrity:
-  "\<lbrace>pas_refined pas and einvs
-    and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) and (ct_active or ct_idle)
-    and domain_sep_inv (pasMaySendIrqs pas) st'
-    and schact_is_rct and guarded_pas_domain pas
-    and is_subject pas o cur_thread and K (pasMayActivate pas \<and> pasMayEditReadyQueues pas) and (\<lambda>s. s = st)\<rbrace>
+  "\<lbrace>pas_refined aag and einvs and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) and (ct_active or ct_idle)
+                    and domain_sep_inv (pasMaySendIrqs aag) st' and schact_is_rct
+                    and guarded_pas_domain aag and is_subject aag o cur_thread
+                    and K (pasMayActivate aag \<and> pasMayEditReadyQueues aag) and (\<lambda>s. s = st)\<rbrace>
    call_kernel ev
-   \<lbrace>\<lambda>_. integrity pas X st\<rbrace>"
-  using call_kernel_integrity' [of st pas st' ev X]
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  using call_kernel_integrity' [of st st' ev X]
   apply (simp add: spec_valid_def)
   apply (erule hoare_chain)
    apply clarsimp
@@ -1239,17 +1158,16 @@ lemma call_kernel_integrity:
 
 lemma call_kernel_pas_refined:
   "\<lbrace>einvs and pas_refined aag and is_subject aag \<circ> cur_thread and guarded_pas_domain aag
-    and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) and (ct_active or ct_idle)
-    and schact_is_rct and pas_cur_domain aag and domain_sep_inv (pasMaySendIrqs aag) st'\<rbrace>
-  call_kernel ev
-  \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  apply (simp add: call_kernel_def getActiveIRQ_def)
+          and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) and (ct_active or ct_idle)
+          and schact_is_rct and pas_cur_domain aag and domain_sep_inv (pasMaySendIrqs aag) st'\<rbrace>
+   call_kernel ev
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (simp add: call_kernel_def )
   apply (wp activate_thread_pas_refined schedule_pas_refined handle_interrupt_pas_refined
             do_machine_op_pas_refined dmo_wp alternative_wp select_wp)
-   apply simp
-   apply (rule hoare_post_impErr [OF valid_validE [where Q = "pas_refined aag and invs"]])
-     apply (wp he_invs handle_event_pas_refined)
-    apply auto
+    apply (wpsimp wp: getActiveIRQ_inv)
+   apply (wp he_invs handle_event_pas_refined)
+  apply auto
   done
 
 end

--- a/proof/access-control/Tcb_AC.thy
+++ b/proof/access-control/Tcb_AC.thy
@@ -5,39 +5,34 @@
  *)
 
 theory Tcb_AC
-imports Finalise_AC
+imports ArchFinalise_AC
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 (* FIXME-NTFN: The 'NotificationControl' case of the following definition needs to be changed. *)
 
-definition
-  authorised_tcb_inv :: "'a PAS \<Rightarrow> Invocations_A.tcb_invocation \<Rightarrow>  bool"
-where
+definition authorised_tcb_inv :: "'a PAS \<Rightarrow> tcb_invocation \<Rightarrow>  bool" where
  "authorised_tcb_inv aag ti \<equiv> case ti of
-     tcb_invocation.Suspend t \<Rightarrow> is_subject aag t
-   | tcb_invocation.Resume t \<Rightarrow> is_subject aag t
-   | tcb_invocation.ThreadControl t sl ep mcp priority croot vroot buf
-          \<Rightarrow> is_subject aag t \<and>
-            (\<forall>(cap, slot) \<in> (set_option croot \<union> set_option vroot \<union>
-                            (case_option {} (set_option \<circ> snd) buf)).
-                      pas_cap_cur_auth aag cap \<and> is_subject aag (fst slot))
-   | tcb_invocation.NotificationControl t ntfn \<Rightarrow> is_subject aag t \<and>
-         case_option True (\<lambda>a. \<forall>auth \<in> {Receive, Reset}.
-                                 (pasSubject aag, auth, pasObjectAbs aag a) \<in> pasPolicy aag) ntfn
-   | tcb_invocation.ReadRegisters src susp n arch \<Rightarrow> is_subject aag src
-   | tcb_invocation.WriteRegisters dest res values arch \<Rightarrow> is_subject aag dest
-   | tcb_invocation.CopyRegisters dest src susp res frame int_regs arch \<Rightarrow>
-         is_subject aag src \<and> is_subject aag dest
-   | tcb_invocation.SetTLSBase tcb tls_base \<Rightarrow> is_subject aag tcb"
+    Suspend t \<Rightarrow> is_subject aag t
+  | Resume t \<Rightarrow> is_subject aag t
+  | ThreadControl t sl ep mcp priority croot vroot buf \<Rightarrow>
+      is_subject aag t \<and>
+      (\<forall>(cap, slot) \<in> set_option croot \<union> set_option vroot \<union>
+                      (case_option {} (set_option \<circ> snd) buf). pas_cap_cur_auth aag cap \<and>
+                                                               is_subject aag (fst slot))
+  | NotificationControl t ntfn \<Rightarrow>
+      is_subject aag t \<and>
+      case_option True (\<lambda>a. \<forall>auth \<in> {Receive, Reset}. aag_has_auth_to aag auth a) ntfn
+  | ReadRegisters src susp n arch \<Rightarrow> is_subject aag src
+  | WriteRegisters dest res values arch \<Rightarrow> is_subject aag dest
+  | CopyRegisters dest src susp res frame int_regs arch \<Rightarrow> is_subject aag src \<and> is_subject aag dest
+  | SetTLSBase tcb tls_base \<Rightarrow> is_subject aag tcb"
 
 subsection\<open>invoke\<close>
 
 lemma setup_reply_master_respects:
   "\<lbrace>integrity aag X st and K (is_subject aag t)\<rbrace>
-     setup_reply_master t
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+   setup_reply_master t
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: setup_reply_master_def)
   apply (wp get_cap_wp set_cap_integrity_autarch[unfolded K_def pred_conj_def]
             set_original_integrity_autarch)+
@@ -48,96 +43,70 @@ crunch eintegrity[wp]: possible_switch_to "integrity aag X st"
   (ignore: tcb_sched_action)
 
 lemma restart_integrity_autarch:
-  "\<lbrace>integrity aag X st and K (is_subject aag t) and einvs
-           and tcb_at t
-           and pas_refined aag\<rbrace>
-     restart t
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and K (is_subject aag t) and einvs and tcb_at t and pas_refined aag\<rbrace>
+   restart t
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: restart_def)
   apply (wp set_thread_state_integrity_autarch setup_reply_master_respects
             hoare_drop_imps
-        | simp add: if_apply_def2)+
+         | simp add: if_apply_def2)+
   done
 
 crunch integrity_autarch: option_update_thread "integrity aag X st"
 
 crunch arch_state [wp]: cap_swap_for_delete "\<lambda>s. P (arch_state s)"
 
-lemma schematic_lift_tuple3_l:
-  "P (fst (a, b, c)) (fst (snd (a, b, c))) (snd (snd (a, b, c))) \<and> Q \<Longrightarrow> P a b c" by simp
-
-lemma schematic_lift_tuple3_r:
-  "Q \<and> P (fst (a, b, c)) (fst (snd (a, b, c))) (snd (snd (a, b, c))) \<Longrightarrow> P a b c" by simp
-
-(* FIXME: MOVE *)
-lemma invoke_tcb_cases:
-  "invoke_tcb ti = (case ti of
-     tcb_invocation.Suspend t \<Rightarrow> invoke_tcb (tcb_invocation.Suspend t)
-   | tcb_invocation.Resume t \<Rightarrow> invoke_tcb (tcb_invocation.Resume t)
-   | tcb_invocation.ThreadControl t sl ep mcp priority croot vroot buf \<Rightarrow>
-         invoke_tcb (tcb_invocation.ThreadControl t sl ep mcp priority croot vroot buf)
-   | tcb_invocation.NotificationControl t ntfn \<Rightarrow>
-         invoke_tcb (tcb_invocation.NotificationControl t ntfn)
-   | tcb_invocation.ReadRegisters src susp n arch \<Rightarrow>
-         invoke_tcb (tcb_invocation.ReadRegisters src susp n arch)
-   | tcb_invocation.WriteRegisters dest res values arch \<Rightarrow>
-         invoke_tcb (tcb_invocation.WriteRegisters dest res values arch)
-   | tcb_invocation.CopyRegisters dest src susp res frame int_regs arch \<Rightarrow>
-         invoke_tcb (tcb_invocation.CopyRegisters dest src susp res frame int_regs arch)
-   | tcb_invocation.SetTLSBase tcb tls_base \<Rightarrow> invoke_tcb (tcb_invocation.SetTLSBase tcb tls_base))"
-  by (cases ti, simp_all)
-
-lemmas itr_wps = restart_integrity_autarch as_user_integrity_autarch thread_set_integrity_autarch
-              option_update_thread_integrity_autarch thread_set_pas_refined
-              cap_insert_integrity_autarch cap_insert_pas_refined
-              hoare_vcg_all_liftE hoare_weak_lift_impE hoare_weak_lift_imp hoare_vcg_all_lift
-              check_cap_inv[where P="valid_cap c" for c]
-              check_cap_inv[where P="tcb_cap_valid c p" for c p]
-              check_cap_inv[where P="cte_at p0" for p0]
-              check_cap_inv[where P="tcb_at p0" for p0]
-              check_cap_inv[where P="ex_cte_cap_wp_to P p" for P p]
-              check_cap_inv[where P="ex_nonz_cap_to p" for p]
-              check_cap_inv2[where Q="\<lambda>_. integrity aag X st" for aag X st]
-              check_cap_inv2[where Q="\<lambda>_. pas_refined aag" for aag]
-              checked_insert_no_cap_to cap_insert_ex_cap
-              cap_delete_valid_cap cap_delete_deletes
-              hoare_case_option_wp thread_set_valid_cap
-              thread_set_tcb_ipc_buffer_cap_cleared_invs
-              thread_set_invs_trivial[OF ball_tcb_cap_casesI]
-              thread_set_cte_wp_at_trivial[where Q="\<lambda>x. x", OF ball_tcb_cap_casesI]
-              thread_set_no_cap_to_trivial[OF ball_tcb_cap_casesI]
+lemmas itr_wps =
+  restart_integrity_autarch as_user_integrity_autarch thread_set_integrity_autarch
+  option_update_thread_integrity_autarch thread_set_pas_refined
+  cap_insert_integrity_autarch cap_insert_pas_refined
+  hoare_vcg_all_liftE wp_throw_const_impE hoare_weak_lift_imp hoare_vcg_all_lift
+  check_cap_inv[where P="valid_cap c" for c]
+  check_cap_inv[where P="tcb_cap_valid c p" for c p]
+  check_cap_inv[where P="cte_at p0" for p0]
+  check_cap_inv[where P="tcb_at p0" for p0]
+  check_cap_inv[where P="ex_cte_cap_wp_to P p" for P p]
+  check_cap_inv[where P="ex_nonz_cap_to p" for p]
+  check_cap_inv2[where Q="\<lambda>_. integrity aag X st" for aag X st]
+  check_cap_inv2[where Q="\<lambda>_. pas_refined aag" for aag]
+  checked_insert_no_cap_to cap_insert_ex_cap
+  cap_delete_valid_cap cap_delete_deletes
+  hoare_case_option_wp thread_set_valid_cap
+  thread_set_tcb_ipc_buffer_cap_cleared_invs
+  thread_set_invs_trivial[OF ball_tcb_cap_casesI]
+  thread_set_cte_wp_at_trivial[where Q="\<lambda>x. x", OF ball_tcb_cap_casesI]
+  thread_set_no_cap_to_trivial[OF ball_tcb_cap_casesI]
 
 (*FIXME MOVE *)
-
 lemma aag_cap_auth_master_Reply:
-  "\<lbrakk>pas_refined aag s ; AllowGrant \<in> R\<rbrakk>
-     \<Longrightarrow>  pas_cap_cur_auth aag (cap.ReplyCap tcb True R) = is_subject aag tcb"
+  "\<lbrakk> pas_refined aag s ; AllowGrant \<in> R \<rbrakk>
+     \<Longrightarrow>  pas_cap_cur_auth aag (ReplyCap tcb True R) = is_subject aag tcb"
   unfolding aag_cap_auth_def
   by (fastforce intro: aag_wellformed_refl aag_wellformed_control_is_owns[THEN iffD1]
                  simp: pas_refined_def cli_no_irqs clas_no_asid cap_auth_conferred_def
                        reply_cap_rights_to_auth_def)
 
-
-
 (* FIXME MOVE *)
 lemma cdt_NullCap:
-  "valid_mdb s \<Longrightarrow> caps_of_state s src = Some NullCap \<Longrightarrow> cdt s src = None"
+  "\<lbrakk> valid_mdb s; caps_of_state s src = Some NullCap \<rbrakk>
+     \<Longrightarrow> cdt s src = None"
   by (rule ccontr) (force dest: mdb_cte_atD simp: valid_mdb_def2)
-
 
 lemma setup_reply_master_pas_refined:
   "\<lbrace>pas_refined aag and valid_mdb and K (is_subject aag t)\<rbrace>
-     setup_reply_master t
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+   setup_reply_master t
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: setup_reply_master_def)
   apply (wp get_cap_wp set_cap_pas_refined set_original_wp)+
   by (force dest: cdt_NullCap simp: aag_cap_auth_master_Reply cte_wp_at_caps_of_state)
 
 crunches possible_switch_to
-  for tcb_domain_map_wellformed[wp]: " tcb_domain_map_wellformed aag"
+  for tcb_domain_map_wellformed[wp]: "tcb_domain_map_wellformed aag"
 
 lemma restart_pas_refined:
-  "\<lbrace>pas_refined aag and invs and tcb_at t and K (is_subject aag t)\<rbrace> restart t \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and invs and tcb_at t and K (is_subject aag t)\<rbrace>
+   restart t
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: restart_def get_thread_state_def)
   apply (wp set_thread_state_pas_refined setup_reply_master_pas_refined thread_get_wp'
          | strengthen invs_mdb
@@ -149,21 +118,24 @@ lemma option_update_thread_set_safe_lift:
      \<Longrightarrow> \<lbrace>P\<rbrace> option_update_thread t f v \<lbrace>\<lambda>rv. P\<rbrace>"
   by (simp add: option_update_thread_def split: option.split)
 
-lemmas option_update_thread_pas_refined
-    = option_update_thread_set_safe_lift [OF thread_set_pas_refined]
+lemmas option_update_thread_pas_refined =
+  option_update_thread_set_safe_lift [OF thread_set_pas_refined]
 
 crunch integrity_autarch[wp]: thread_set_priority "integrity aag X st"
   (ignore: tcb_sched_action)
 
 lemma set_priority_integrity_autarch[wp]:
  "\<lbrace>integrity aag X st and pas_refined aag and K (is_subject aag tptr)\<rbrace>
-    set_priority tptr prio \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  set_priority tptr prio
+  \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   by (simp add: set_priority_def | wp)+
 
 lemma set_priority_pas_refined[wp]:
   "\<lbrace>pas_refined aag\<rbrace>
-    set_priority tptr prio \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  apply (simp add: set_priority_def thread_set_priority_def ethread_set_def set_eobject_def get_etcb_def
+   set_priority tptr prio
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  apply (simp add: set_priority_def thread_set_priority_def
+                   ethread_set_def set_eobject_def get_etcb_def
          | wp hoare_vcg_imp_lift')+
    apply (simp add: tcb_sched_action_def | wp)+
   apply (clarsimp simp: etcb_at_def pas_refined_def tcb_domain_map_wellformed_aux_def
@@ -174,7 +146,8 @@ lemma set_priority_pas_refined[wp]:
   apply (force intro: domtcbs split: if_split_asm)
   done
 
-lemma gts_test[wp]: "\<lbrace>\<top>\<rbrace> get_thread_state t \<lbrace>\<lambda>rv s. test rv = st_tcb_at test t s\<rbrace>"
+lemma gts_test[wp]:
+   "\<lbrace>\<top>\<rbrace> get_thread_state t \<lbrace>\<lambda>rv s. test rv = st_tcb_at test t s\<rbrace>"
   apply (simp add: get_thread_state_def thread_get_def)
   apply wp
   apply (clarsimp simp add: st_tcb_def2)
@@ -182,52 +155,30 @@ lemma gts_test[wp]: "\<lbrace>\<top>\<rbrace> get_thread_state t \<lbrace>\<lamb
 
 crunch exst[wp]: option_update_thread "\<lambda>s. P (exst s)"
 
-lemma out_valid_sched: "(\<And>x a. tcb_state (f a x) = tcb_state x) \<Longrightarrow>
-  \<lbrace>valid_sched\<rbrace> option_update_thread tptr f v \<lbrace>\<lambda>rv. valid_sched\<rbrace>"
-  apply (simp add: option_update_thread_def)
-  apply (rule hoare_pre)
-  apply (wp thread_set_not_state_valid_sched | wpc | simp)+
-  done
-
-
-definition "safe_id x \<equiv> x"
-
-lemma use_safe_id: "safe_id x \<Longrightarrow> x"
-  by (simp add: safe_id_def)
-
-lemma simplify_post:
-  "\<lbrakk>\<And>r s. x r s \<Longrightarrow> safe_id (Q' r s) \<Longrightarrow> Q r s; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. x r s \<and> Q' r s\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk>
-    \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
-  apply (rule hoare_post_impErr)
-  apply assumption
-  apply (clarsimp simp add: safe_id_def)+
-  done
-
-end
-
-lemma (in is_extended') valid_cap_syn[wp]: "I (\<lambda>s. valid_cap_syn s a)" by (rule lift_inv,simp)
-
-lemma (in is_extended') no_cap_to_obj_dr_emp[wp]: "I (no_cap_to_obj_dr_emp a)" by (rule lift_inv,simp)
-
-lemma (in is_extended') cte_wp_at[wp]: "I (cte_wp_at P a)" by (rule lift_inv,simp)
-
 crunch pas_refined[wp]: set_mcpriority "pas_refined aag"
 
 crunch integrity_autarch: set_mcpriority "integrity aag X st"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+lemma (in is_extended') valid_cap_syn[wp]: "I (\<lambda>s. valid_cap_syn s a)"
+  by (rule lift_inv, simp)
+
+lemma (in is_extended') no_cap_to_obj_dr_emp[wp]: "I (no_cap_to_obj_dr_emp a)"
+  by (rule lift_inv, simp)
+
+lemma (in is_extended') cte_wp_at[wp]: "I (cte_wp_at P a)"
+  by (rule lift_inv, simp)
 
 lemma checked_insert_pas_refined:
   "\<lbrace>pas_refined aag and valid_mdb and
-       K(\<not> is_master_reply_cap new_cap \<and> is_subject aag target \<and>
-       is_subject aag (fst src_slot) \<and> pas_cap_cur_auth aag new_cap)\<rbrace>
-     check_cap_at new_cap src_slot (
-     check_cap_at (ThreadCap target) slot(
-     cap_insert new_cap src_slot (target, ref)))
+    K(\<not> is_master_reply_cap new_cap \<and> is_subject aag target \<and>
+      is_subject aag (fst src_slot) \<and> pas_cap_cur_auth aag new_cap)\<rbrace>
+   check_cap_at new_cap src_slot
+     (check_cap_at (ThreadCap target) slot
+        (cap_insert new_cap src_slot (target, ref)))
    \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
   apply (unfold check_cap_at_def)
   apply (wp cap_insert_pas_refined_same_object_as get_cap_wp)
-  by (fastforce simp:cte_wp_at_caps_of_state)
+  by (fastforce simp: cte_wp_at_caps_of_state)
 
 (* FIXME MOVE *)
 lemma update_cdt_wp:
@@ -238,9 +189,7 @@ lemma update_cdt_wp:
 lemma parent_ofD: "m \<Turnstile> src \<leadsto> x \<Longrightarrow> m x = Some src"
   by (simp add: cdt_parent_of_def)
 
-
 crunch tcb_states_of_state[wp]: set_untyped_cap_as_full "\<lambda>s. P (tcb_states_of_state s)"
-
 
 (* FIXME MOVE *)
 lemma map_le_to_rtrancl:
@@ -257,15 +206,15 @@ lemma map_le_to_cca:
   by (rule map_le_to_rtrancl)
 
 lemma cap_insert_cdt_change_allowed[wp]:
-  "\<lbrace> valid_mdb and cdt_change_allowed' aag slot\<rbrace>
-     cap_insert new_cap src_slot dest_slot
-  \<lbrace>\<lambda>_. cdt_change_allowed' aag slot \<rbrace>"
+  "\<lbrace>valid_mdb and cdt_change_allowed' aag slot\<rbrace>
+   cap_insert new_cap src_slot dest_slot
+   \<lbrace>\<lambda>_. cdt_change_allowed' aag slot\<rbrace>"
   apply (rule hoare_pre, unfold cap_insert_def)
    apply (wp add: dxo_wp_weak update_cdt_wp | simp)+
         apply (rule hoare_post_imp[of
         "\<lambda>_. cdt_change_allowed' aag slot and (\<lambda>s. cdt s dest_slot = None)"])
          apply (fastforce elim: map_le_to_cca[rotated] simp:map_le_def dom_def)
-        apply (wps|wp get_cap_wp)+
+        apply (wps | wp get_cap_wp)+
   apply (clarsimp)
   apply (drule valid_mdb_mdb_cte_at)
   apply (subst not_Some_eq[symmetric])
@@ -274,84 +223,12 @@ lemma cap_insert_cdt_change_allowed[wp]:
   apply (simp add:cte_wp_at_caps_of_state)
   done
 
-
-lemma invoke_tcb_tc_respects_aag:
-  "\<lbrace> integrity aag X st and pas_refined aag
-         and einvs and simple_sched_action
-         and tcb_inv_wf (ThreadControl t sl ep mcp priority croot vroot buf)
-         and K (authorised_tcb_inv aag (ThreadControl t sl ep mcp priority croot vroot buf))\<rbrace>
-     invoke_tcb (ThreadControl t sl ep mcp priority croot vroot buf)
-   \<lbrace>\<lambda>rv. integrity aag X st and pas_refined aag\<rbrace>"
-  apply (rule hoare_gen_asm)+
-  apply (subst invoke_tcb.simps)
-  apply (subst set_priority_extended.dxo_eq)
-  apply (rule hoare_vcg_precond_imp)
-   apply (rule_tac P="case ep of Some v \<Rightarrow> length v = word_bits | _ \<Rightarrow> True"
-                 in hoare_gen_asm)
-   apply (simp only: split_def)
-  apply ((simp add: conj_comms del: hoare_True_E_R,
-                  strengthen imp_consequent[where Q="x = None" for x], simp cong: conj_cong)
-        | rule wp_split_const_if wp_split_const_if_R
-                   hoare_vcg_all_lift_R
-                   hoare_vcg_E_elim hoare_vcg_const_imp_lift_R
-                   hoare_vcg_R_conj
-        | wp
-             restart_integrity_autarch set_mcpriority_integrity_autarch
-             as_user_integrity_autarch thread_set_integrity_autarch
-             option_update_thread_integrity_autarch
-             out_valid_sched static_imp_wp
-             cap_insert_integrity_autarch checked_insert_pas_refined
-             cap_delete_respects' cap_delete_pas_refined'
-             check_cap_inv2[where Q="\<lambda>_. integrity aag X st"]
-             as_user_pas_refined restart_pas_refined
-             thread_set_pas_refined
-             option_update_thread_pas_refined
-             out_invs_trivial case_option_wpE cap_delete_deletes
-             cap_delete_valid_cap cap_insert_valid_cap out_cte_at
-             cap_insert_cte_at cap_delete_cte_at out_valid_cap out_tcb_valid
-             hoare_vcg_const_imp_lift_R hoare_vcg_all_lift_R
-             thread_set_tcb_ipc_buffer_cap_cleared_invs
-             thread_set_invs_trivial[OF ball_tcb_cap_casesI]
-             hoare_vcg_all_lift thread_set_valid_cap out_emptyable
-             check_cap_inv[where P="valid_cap c" for c]
-             check_cap_inv[where P="tcb_cap_valid c p" for c p]
-             check_cap_inv[where P="cte_at p0" for p0]
-             check_cap_inv[where P="tcb_at p0" for p0]
-             check_cap_inv[where P="simple_sched_action"]
-             check_cap_inv[where P="valid_list"]
-             check_cap_inv[where P="valid_sched"]
-             thread_set_cte_at
-             thread_set_cte_wp_at_trivial[where Q="\<lambda>x. x", OF ball_tcb_cap_casesI]
-             thread_set_no_cap_to_trivial[OF ball_tcb_cap_casesI]
-             checked_insert_no_cap_to
-             out_no_cap_to_trivial[OF ball_tcb_cap_casesI]
-             thread_set_ipc_tcb_cap_valid
-             cap_delete_pas_refined'[THEN valid_validE_E] thread_set_cte_wp_at_trivial
-        | simp add: ran_tcb_cap_cases dom_tcb_cap_cases[simplified]
-                    emptyable_def a_type_def partial_inv_def
-               del: hoare_True_E_R
-        | wpc
-        | strengthen invs_mdb use_no_cap_to_obj_asid_strg
-                     tcb_cap_always_valid_strg[where p="tcb_cnode_index 0"]
-                     tcb_cap_always_valid_strg[where p="tcb_cnode_index (Suc 0)"]
-        )+
-  apply (clarsimp simp: authorised_tcb_inv_def)
-  apply (clarsimp simp: tcb_at_cte_at_0 tcb_at_cte_at_1[simplified]
-                        is_cap_simps is_valid_vtable_root_def
-                        is_cnode_or_valid_arch_def tcb_cap_valid_def
-                        tcb_at_st_tcb_at[symmetric] invs_valid_objs
-                        cap_asid_def vs_cap_ref_def
-                        clas_no_asid cli_no_irqs
-                        emptyable_def
-       | rule conjI | erule pas_refined_refl)+
-  done
-
 lemma invoke_tcb_unbind_notification_respects:
-  "\<lbrace>integrity aag X st and pas_refined aag and simple_sched_action
-       and einvs and Tcb_AI.tcb_inv_wf (tcb_invocation.NotificationControl t None)
-       and K (authorised_tcb_inv aag (tcb_invocation.NotificationControl t None))\<rbrace>
-     invoke_tcb (tcb_invocation.NotificationControl t None)
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and simple_sched_action and einvs
+                       and tcb_inv_wf (NotificationControl t None)
+                       and K (authorised_tcb_inv aag (NotificationControl t None))\<rbrace>
+   invoke_tcb (tcb_invocation.NotificationControl t None)
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (clarsimp)
   apply (wp unbind_notification_respects)
   apply (clarsimp simp: authorised_tcb_inv_def tcb_at_def pred_tcb_def2)
@@ -362,10 +239,10 @@ lemma invoke_tcb_unbind_notification_respects:
   done
 
 lemma sbn_bind_respects:
-  "\<lbrace>integrity aag X st and bound_tcb_at ((=) None) t
-    and K ((pasSubject aag, Receive, pasObjectAbs aag ntfn) \<in> pasPolicy aag \<and> is_subject aag t)\<rbrace>
-       set_bound_notification t (Some ntfn)
-   \<lbrace>\<lambda>rv. integrity aag X st \<rbrace>"
+  "\<lbrace>integrity aag X st and bound_tcb_at ((=) None) t and
+    K (aag_has_auth_to aag Receive ntfn \<and> is_subject aag t)\<rbrace>
+   set_bound_notification t (Some ntfn)
+   \<lbrace>\<lambda>_. integrity aag X st \<rbrace>"
   apply (simp add: set_bound_notification_def)
   apply (wpsimp wp: set_object_wp)
   apply (erule integrity_trans)
@@ -375,10 +252,9 @@ lemma sbn_bind_respects:
 
 lemma bind_notification_respects:
   "\<lbrace>integrity aag X st and pas_refined aag and bound_tcb_at ((=) None) t
-      and K ((pasSubject aag, Receive, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag \<and>
-             is_subject aag t)\<rbrace>
-     bind_notification t ntfnptr
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+                       and K (aag_has_auth_to aag Receive ntfn \<and> is_subject aag t)\<rbrace>
+   bind_notification t ntfn
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (clarsimp simp: bind_notification_def)
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
@@ -387,12 +263,11 @@ lemma bind_notification_respects:
   done
 
 lemma invoke_tcb_bind_notification_respects:
-  "\<lbrace>integrity aag X st and pas_refined aag
-      and einvs and Tcb_AI.tcb_inv_wf (tcb_invocation.NotificationControl t (Some ntfn))
-      and simple_sched_action
-      and K (authorised_tcb_inv aag (tcb_invocation.NotificationControl t (Some ntfn)))\<rbrace>
-     invoke_tcb (tcb_invocation.NotificationControl t (Some ntfn))
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and einvs and simple_sched_action
+                       and tcb_inv_wf (NotificationControl t (Some ntfn))
+                       and K (authorised_tcb_inv aag (NotificationControl t (Some ntfn)))\<rbrace>
+   invoke_tcb (NotificationControl t (Some ntfn))
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (clarsimp)
   apply (wp bind_notification_respects)
@@ -400,71 +275,90 @@ lemma invoke_tcb_bind_notification_respects:
   done
 
 lemma invoke_tcb_ntfn_control_respects[wp]:
-  "\<lbrace>integrity aag X st and pas_refined aag
-      and einvs and Tcb_AI.tcb_inv_wf (tcb_invocation.NotificationControl t ntfn)
-      and simple_sched_action
-      and K (authorised_tcb_inv aag (tcb_invocation.NotificationControl t ntfn))\<rbrace>
-     invoke_tcb (tcb_invocation.NotificationControl t ntfn)
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and einvs and simple_sched_action
+                       and tcb_inv_wf (NotificationControl t ntfn)
+                       and K (authorised_tcb_inv aag (NotificationControl t ntfn))\<rbrace>
+   invoke_tcb (NotificationControl t ntfn)
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (case_tac ntfn, simp_all del: invoke_tcb.simps Tcb_AI.tcb_inv_wf.simps K_def)
    apply (wp invoke_tcb_bind_notification_respects invoke_tcb_unbind_notification_respects | simp)+
   done
 
+
+locale Tcb_AC_1 =
+  fixes aag :: "'a PAS"
+  assumes arch_post_modify_registers_invs[wp]:
+    "arch_post_modify_registers cur t \<lbrace>pas_refined aag\<rbrace>"
+  and arch_post_modify_registers_respects:
+    "\<lbrace>integrity aag X st and K (is_subject aag t)\<rbrace>
+     arch_post_modify_registers cur t
+     \<lbrace>\<lambda>_ s. integrity aag X st s\<rbrace>"
+  and arch_get_sanitise_register_info_inv[wp]:
+    "arch_get_sanitise_register_info t \<lbrace>\<lambda>s :: det_ext state. P s\<rbrace>"
+  and invoke_tcb_tc_respects_aag:
+    "\<lbrace>integrity aag X st and pas_refined aag and einvs and simple_sched_action
+                         and tcb_inv_wf (ThreadControl t sl ep mcp priority croot vroot buf)
+                         and K (authorised_tcb_inv aag (ThreadControl t sl ep mcp priority croot vroot buf))\<rbrace>
+     invoke_tcb (ThreadControl t sl ep mcp priority croot vroot buf)
+     \<lbrace>\<lambda>rv. integrity aag X st and pas_refined aag\<rbrace>"
+begin
+
 lemma invoke_tcb_respects:
-  "\<lbrace>integrity aag X st and pas_refined aag
-         and einvs and simple_sched_action and Tcb_AI.tcb_inv_wf ti
-         and K (authorised_tcb_inv aag ti)\<rbrace>
-     invoke_tcb ti
-   \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
+  "\<lbrace>integrity aag X st and pas_refined aag and einvs and simple_sched_action
+                       and tcb_inv_wf ti and K (authorised_tcb_inv aag ti)\<rbrace>
+   invoke_tcb ti
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (cases ti, simp_all add: hoare_conjD1 [OF invoke_tcb_tc_respects_aag [simplified simp_thms]]
                             del: invoke_tcb.simps Tcb_AI.tcb_inv_wf.simps K_def)
   apply (safe intro!: hoare_gen_asm)
-  apply ((wp itr_wps mapM_x_wp' | simp add: if_apply_def2 split del: if_split
-            | wpc | clarsimp simp: authorised_tcb_inv_def arch_get_sanitise_register_info_def
-            | rule conjI | subst(asm) idle_no_ex_cap)+)
-  done
+  by ((wp itr_wps mapM_x_wp' arch_post_modify_registers_respects
+       | wpc | clarsimp simp: authorised_tcb_inv_def if_apply_def2
+       | rule conjI | subst (asm) idle_no_ex_cap)+)
+
+end
+
 
 subsubsection\<open>@{term "pas_refined"}\<close>
 
 lemmas ita_wps = as_user_pas_refined restart_pas_refined cap_insert_pas_refined
                  thread_set_pas_refined cap_delete_pas_refined' check_cap_inv2 hoare_vcg_all_liftE
-                 hoare_weak_lift_impE hoare_weak_lift_imp hoare_vcg_all_lift
+                 wp_throw_const_impE hoare_weak_lift_imp hoare_vcg_all_lift
 
 lemma hoare_st_refl:
-  "\<lbrakk>\<And>st. \<lbrace>P st\<rbrace> f \<lbrace>Q st\<rbrace>; \<And>r s st. Q st r s \<Longrightarrow> Q' r s\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P s s\<rbrace> f \<lbrace>Q'\<rbrace>"
+  "\<lbrakk> \<And>st. \<lbrace>P st\<rbrace> f \<lbrace>Q st\<rbrace>; \<And>r s st. Q st r s \<Longrightarrow> Q' r s \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P s s\<rbrace> f \<lbrace>Q'\<rbrace>"
   apply (clarsimp simp add: valid_def)
   apply (drule_tac x=s in meta_spec)
   apply force
   done
 
 lemma bind_notification_pas_refined[wp]:
-  "\<lbrace>pas_refined aag
-      and K (\<forall>auth \<in> {Receive, Reset}.
-                   (pasObjectAbs aag t, auth, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag)\<rbrace>
-     bind_notification t ntfnptr
+  "\<lbrace>pas_refined aag and K (\<forall>auth \<in> {Receive, Reset}. abs_has_auth_to aag auth t ntfn)\<rbrace>
+   bind_notification t ntfn
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (clarsimp simp: bind_notification_def)
   apply (wp set_simple_ko_pas_refined | wpc | simp)+
   done
 
 lemma invoke_tcb_ntfn_control_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and Tcb_AI.tcb_inv_wf (tcb_invocation.NotificationControl t ntfn)
-     and einvs  and simple_sched_action
-     and K (authorised_tcb_inv aag (tcb_invocation.NotificationControl t ntfn))\<rbrace>
-     invoke_tcb (tcb_invocation.NotificationControl t ntfn)
+  "\<lbrace>pas_refined aag and tcb_inv_wf (NotificationControl t ntfn) and einvs and simple_sched_action
+                    and K (authorised_tcb_inv aag (NotificationControl t ntfn))\<rbrace>
+   invoke_tcb (NotificationControl t ntfn)
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (case_tac ntfn, simp_all del: K_def)
    apply (safe intro!: hoare_gen_asm)
    apply (wp | simp add: authorised_tcb_inv_def)+
   done
 
+
+context Tcb_AC_1 begin
+
 lemma invoke_tcb_pas_refined:
-  "\<lbrace>pas_refined aag and Tcb_AI.tcb_inv_wf ti and einvs and simple_sched_action
-       and K (authorised_tcb_inv aag ti)\<rbrace>
-     invoke_tcb ti
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "\<lbrace>pas_refined aag and tcb_inv_wf ti and einvs and simple_sched_action
+                    and K (authorised_tcb_inv aag ti)\<rbrace>
+   invoke_tcb ti
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (cases "\<exists>t sl ep mcp priority croot vroot buf.
-              ti = tcb_invocation.ThreadControl t sl ep mcp priority croot vroot buf")
+                ti = tcb_invocation.ThreadControl t sl ep mcp priority croot vroot buf")
    apply safe
    apply (rule hoare_chain, rule_tac Q'="\<lambda>_. pas_refined aag" and st1="\<lambda>x. x" in
                                      hoare_st_refl[OF invoke_tcb_tc_respects_aag])
@@ -475,72 +369,77 @@ lemma invoke_tcb_pas_refined:
   apply (cases ti, simp_all add: authorised_tcb_inv_def)
         apply (wp ita_wps hoare_drop_imps mapM_x_wp'
               | simp add: emptyable_def if_apply_def2 authorised_tcb_inv_def
-                          arch_get_sanitise_register_info_def
               | rule ball_tcb_cap_casesI
               | wpc
               | fastforce intro: notE[rotated,OF idle_no_ex_cap,simplified]
                            simp: invs_valid_global_refs invs_valid_objs)+
   done
 
+end
+
+
 subsection\<open>TCB / decode\<close>
 
 lemma decode_registers_authorised:
-  "\<lbrace>K (is_subject aag t)\<rbrace> decode_read_registers msg (cap.ThreadCap t) \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
-  "\<lbrace>K (is_subject aag t)\<rbrace> decode_write_registers msg (cap.ThreadCap t) \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
-  "\<lbrace>pas_refined aag and K (is_subject aag t \<and> (\<forall>(cap, slot) \<in> set excaps. pas_cap_cur_auth aag cap \<and> is_subject aag (fst slot)))\<rbrace>
-     decode_copy_registers msg (cap.ThreadCap t) (map fst excaps)
-   \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
-  unfolding decode_read_registers_def decode_write_registers_def decode_copy_registers_def authorised_tcb_inv_def
-  by (rule hoare_pre, simp cong: list.case_cong, (wp | wpc)+, clarsimp simp: cap_auth_conferred_def pas_refined_all_auth_is_owns aag_cap_auth_def)+
-
-
-lemma stupid_strg:
-  "cap_links_asid_slot aag (pasObjectAbs aag (fst y)) x \<longrightarrow>
-  (x = cap \<and> (\<exists>b. y = (a, b)) \<longrightarrow> cap_links_asid_slot aag (pasObjectAbs aag a) cap)"
-  by auto
+  "\<lbrace>K (is_subject aag t)\<rbrace> decode_read_registers msg (ThreadCap t) \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
+  "\<lbrace>K (is_subject aag t)\<rbrace> decode_write_registers msg (ThreadCap t) \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
+  "\<lbrace>pas_refined aag and K (is_subject aag t \<and> (\<forall>(cap, slot) \<in> set excaps. pas_cap_cur_auth aag cap
+                                                                        \<and> is_subject aag (fst slot)))\<rbrace>
+   decode_copy_registers msg (ThreadCap t) (map fst excaps)
+   \<lbrace>\<lambda>rv _. authorised_tcb_inv aag rv\<rbrace>, -"
+  unfolding decode_read_registers_def decode_write_registers_def
+            decode_copy_registers_def authorised_tcb_inv_def
+    apply (simp_all cong: list.case_cong)
+    apply wpsimp+
+  apply (clarsimp simp: cap_auth_conferred_def pas_refined_all_auth_is_owns aag_cap_auth_def)
+  done
 
 lemma decode_set_ipc_buffer_authorised:
   "\<lbrace>K (is_subject aag t \<and> (\<forall>x \<in> set excaps. is_subject aag (fst (snd x)))
-                      \<and> (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x))) \<rbrace>
-    decode_set_ipc_buffer msg (cap.ThreadCap t) slot excaps
-   \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
+                        \<and> (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x)))\<rbrace>
+   decode_set_ipc_buffer msg (ThreadCap t) slot excaps
+   \<lbrace>\<lambda>rv _ :: det_ext state. authorised_tcb_inv aag rv\<rbrace>, -"
   unfolding decode_set_ipc_buffer_def authorised_tcb_inv_def
   apply (cases "excaps ! 0")
   apply (clarsimp cong: list.case_cong split del: if_split)
   apply (rule hoare_pre)
   apply (clarsimp simp: ball_Un aag_cap_auth_def split del: if_split split: prod.split
-       | strengthen stupid_strg
-       | wp (once) derive_cap_obj_refs_auth derive_cap_untyped_range_subset derive_cap_clas derive_cap_cli
-                 hoare_vcg_all_lift_R whenE_throwError_wp slot_long_running_inv
-       | wpc)+
+         | wp (once) derive_cap_obj_refs_auth derive_cap_untyped_range_subset derive_cap_clas
+                     derive_cap_cli hoare_vcg_all_lift_R whenE_throwError_wp slot_long_running_inv
+         | wpc)+
   apply (cases excaps, simp)
   apply fastforce
   done
 
 lemma decode_set_space_authorised:
   "\<lbrace>K (is_subject aag t \<and> (\<forall>x \<in> set excaps. is_subject aag (fst (snd x)))
-                      \<and> (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x))) \<rbrace>
-     decode_set_space ws (cap.ThreadCap t) slot excaps
-   \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
+                        \<and> (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x)))\<rbrace>
+   decode_set_space ws (ThreadCap t) slot excaps
+   \<lbrace>\<lambda>rv _ :: det_ext state. authorised_tcb_inv aag rv\<rbrace>, -"
   unfolding decode_set_space_def authorised_tcb_inv_def
   apply (rule hoare_pre)
   apply (simp cong: list.case_cong split del: if_split)
   apply (clarsimp simp: ball_Un split del: if_split
-       | wp (once) derive_cap_obj_refs_auth derive_cap_untyped_range_subset derive_cap_clas derive_cap_cli
-                 hoare_vcg_const_imp_lift_R hoare_vcg_all_lift_R whenE_throwError_wp slot_long_running_inv)+
+         | wp (once) derive_cap_obj_refs_auth derive_cap_untyped_range_subset derive_cap_clas
+                     derive_cap_cli hoare_vcg_const_imp_lift_R hoare_vcg_all_lift_R
+                     whenE_throwError_wp slot_long_running_inv)+
   apply (clarsimp simp: not_less all_set_conv_all_nth dest!: P_0_1_spec)
-  apply (auto simp: aag_cap_auth_def update_cap_cli intro: update_cap_obj_refs_subset dest!: update_cap_untyped_range_subset update_cap_cap_auth_conferred_subset)
+  apply (auto simp: aag_cap_auth_def update_cap_cli
+             intro: update_cap_obj_refs_subset
+             dest!: update_cap_cap_auth_conferred_subset)
   done
 
 (* grot: this is from the bowels of decode_tcb_configure_authorised. *)
 lemma decode_tcb_configure_authorised_helper:
   "\<lbrace>K True and K (is_subject aag t \<and> (\<forall>x \<in> set excaps. is_subject aag (fst (snd x)))
-                      \<and> (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x))
-                      \<and> authorised_tcb_inv aag set_param \<and> is_thread_control set_param)\<rbrace>
-     decode_set_space ws (cap.ThreadCap t) slot excaps
-   \<lbrace>\<lambda>rv s. authorised_tcb_inv aag (tcb_invocation.ThreadControl t slot (tc_new_fault_ep rv)
-                                    None None (tc_new_croot rv)
-                                    (tc_new_vroot rv) (tc_new_buffer set_param))\<rbrace>, -"
+                                   \<and> (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x))
+                                   \<and> authorised_tcb_inv aag set_param
+                                   \<and> is_thread_control set_param)\<rbrace>
+   decode_set_space ws (ThreadCap t) slot excaps
+   \<lbrace>\<lambda>rv _ :: det_ext state. authorised_tcb_inv aag (ThreadControl t slot (tc_new_fault_ep rv)
+                                                                  None None (tc_new_croot rv)
+                                                                  (tc_new_vroot rv)
+                                                                  (tc_new_buffer set_param))\<rbrace>, -"
   apply (rule hoare_gen_asmE)
   apply (cases set_param)
   apply (simp_all add: is_thread_control_def decode_set_space_def authorised_tcb_inv_def
@@ -550,19 +449,20 @@ lemma decode_tcb_configure_authorised_helper:
   apply (cases "excaps!Suc 0")
   apply (rule hoare_pre)
    apply (clarsimp simp: ball_Un split del: if_split split: prod.split
-        | strengthen stupid_strg
         | wp (once) derive_cap_obj_refs_auth derive_cap_untyped_range_subset derive_cap_clas derive_cap_cli
                   hoare_vcg_all_lift_R whenE_throwError_wp slot_long_running_inv)+
   apply (clarsimp cong: list.case_cong option.case_cong prod.case_cong split: prod.split_asm)
   apply (clarsimp simp: not_less all_set_conv_all_nth dest!: P_0_1_spec)
-  apply (auto simp: aag_cap_auth_def update_cap_cli intro: update_cap_untyped_range_subset update_cap_obj_refs_subset dest!: update_cap_cap_auth_conferred_subset elim: bspec)
+  apply (auto simp: aag_cap_auth_def update_cap_cli
+             intro: update_cap_obj_refs_subset
+             dest!: update_cap_cap_auth_conferred_subset)
   done
 
 lemma decode_tcb_configure_authorised:
   "\<lbrace>K (is_subject aag t \<and> (\<forall>x \<in> set excaps. is_subject aag (fst (snd x)))
-                      \<and> (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x))) \<rbrace>
-    decode_tcb_configure msg (cap.ThreadCap t) slot excaps
-   \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
+                        \<and> (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x)))\<rbrace>
+   decode_tcb_configure msg (ThreadCap t) slot excaps
+   \<lbrace>\<lambda>rv _ :: det_ext state. authorised_tcb_inv aag rv\<rbrace>, -"
   apply (wpsimp simp: decode_tcb_configure_def
                 wp: whenE_throwError_wp decode_tcb_configure_authorised_helper
                     decode_set_ipc_buffer_authorised)
@@ -571,26 +471,26 @@ lemma decode_tcb_configure_authorised:
 
 lemma decode_set_priority_authorised:
   "\<lbrace>K (is_subject aag t)\<rbrace>
-    decode_set_priority msg (ThreadCap t) slot excs
-   \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
+   decode_set_priority msg (ThreadCap t) slot excs
+   \<lbrace>\<lambda>rv _. authorised_tcb_inv aag rv\<rbrace>, -"
   by (wpsimp simp: decode_set_priority_def check_prio_def authorised_tcb_inv_def)
 
 lemma decode_set_mcpriority_authorised:
   "\<lbrace>K (is_subject aag t)\<rbrace>
-    decode_set_mcpriority msg (ThreadCap t) slot excs
-   \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
+   decode_set_mcpriority msg (ThreadCap t) slot excs
+   \<lbrace>\<lambda>rv _. authorised_tcb_inv aag rv\<rbrace>, -"
   by (wpsimp simp: decode_set_mcpriority_def check_prio_def authorised_tcb_inv_def)
 
 lemma decode_set_sched_params_authorised:
   "\<lbrace>K (is_subject aag t)\<rbrace>
-    decode_set_sched_params msg (ThreadCap t) slot excs
-   \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
+   decode_set_sched_params msg (ThreadCap t) slot excs
+   \<lbrace>\<lambda>rv _. authorised_tcb_inv aag rv\<rbrace>, -"
   by (wpsimp simp: decode_set_sched_params_def check_prio_def authorised_tcb_inv_def)
 
 lemma decode_unbind_notification_authorised:
   "\<lbrace>K (is_subject aag t)\<rbrace>
-    decode_unbind_notification (cap.ThreadCap t)
-   \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
+   decode_unbind_notification (ThreadCap t)
+   \<lbrace>\<lambda>rv _. authorised_tcb_inv aag rv\<rbrace>, -"
   unfolding decode_unbind_notification_def authorised_tcb_inv_def
   apply clarsimp
   apply (wp gbn_wp, clarsimp)
@@ -598,9 +498,9 @@ lemma decode_unbind_notification_authorised:
 
 lemma decode_bind_notification_authorised:
   "\<lbrace>K (is_subject aag t \<and> (\<forall>x \<in> set excaps. is_subject aag (fst (snd x)))
-                      \<and> (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x)) )\<rbrace>
-    decode_bind_notification (cap.ThreadCap t) excaps
-   \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
+                        \<and> (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x)) )\<rbrace>
+   decode_bind_notification (ThreadCap t) excaps
+   \<lbrace>\<lambda>rv _. authorised_tcb_inv aag rv\<rbrace>, -"
   unfolding decode_bind_notification_def authorised_tcb_inv_def
   apply clarsimp
   apply (wp gbn_wp get_simple_ko_wp whenE_throwError_wp | wpc | simp add:)+
@@ -611,18 +511,19 @@ lemma decode_bind_notification_authorised:
 
 lemma decode_set_tls_base_authorised:
   "\<lbrace>K (is_subject aag t)\<rbrace>
-    decode_set_tls_base msg (cap.ThreadCap t)
-   \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>, -"
+   decode_set_tls_base msg (ThreadCap t)
+   \<lbrace>\<lambda>rv _. authorised_tcb_inv aag rv\<rbrace>, -"
   unfolding decode_set_tls_base_def authorised_tcb_inv_def
   apply clarsimp
   apply (wpsimp wp: gbn_wp)
   done
 
 lemma decode_tcb_invocation_authorised:
-  "\<lbrace>invs and pas_refined aag and K (is_subject aag t \<and> (\<forall>x \<in> set excaps. is_subject aag (fst (snd x)))
-                                  \<and> (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x)))\<rbrace>
-     decode_tcb_invocation label msg (cap.ThreadCap t) slot excaps
-   \<lbrace>\<lambda>rv s. authorised_tcb_inv aag rv\<rbrace>,-"
+  "\<lbrace>invs and pas_refined aag
+         and K (is_subject aag t \<and> (\<forall>x \<in> set excaps. is_subject aag (fst (snd x)))
+                                 \<and> (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x)))\<rbrace>
+   decode_tcb_invocation label msg (ThreadCap t) slot excaps
+   \<lbrace>\<lambda>rv _. authorised_tcb_inv aag rv\<rbrace>, -"
   unfolding decode_tcb_invocation_def
   apply (rule hoare_pre)
    apply wpc
@@ -641,7 +542,5 @@ text\<open>
 to show @{term "integrity"} or @{term "pas_refined"}.
 
 \<close>
-
-end
 
 end

--- a/proof/access-control/Types.thy
+++ b/proof/access-control/Types.thy
@@ -1,0 +1,162 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory Types
+imports ArchTypes
+begin
+
+subsection \<open>Policy definition\<close>
+
+text\<open>
+
+The goal is to place limits on what untrusted agents can do while the
+trusted agents are not running. This supports a framing constraint in
+the descriptions (Hoare triples) of syscalls. Roughly the existing
+proofs show the effect of the syscall, and this proof summarises what
+doesn't (or isn't allowed to) change.
+
+The basic intuition is to map all object references to the agent they
+belong to and show that changes to the object reference graph are
+allowed by the policy specified by the user. The policy is a labelled
+graph amongst agents independent of the current state, i.e. a static
+external summary of what should be talking to what and how.
+
+The interesting cases occur between trusted and untrusted components:
+e.g. we assume that it is unsafe for untrusted components (UT)
+to send capabilities to trusted components (T), and so T must ensure
+that all endpoints it shares with UT that it receives on do not have
+the grant bit set.
+
+\<close>
+
+type_synonym 'a agent_map = "obj_ref \<Rightarrow> 'a"
+type_synonym 'a agent_asid_map = "asid \<Rightarrow> 'a"
+type_synonym 'a agent_irq_map = "irq \<Rightarrow> 'a"
+type_synonym 'a agent_domain_map = "domain \<Rightarrow> 'a set"
+
+text\<open>
+
+What one agent can do to another. We allow multiple edges between
+agents in the graph.
+
+Control is special. It implies the ability to do pretty much anything,
+including get access the other rights, create, remove, etc.
+
+DeleteDerived allows you to delete a cap derived from a cap you own
+\<close>
+
+datatype auth = Control | Receive | SyncSend | Notify | Reset | Grant | Call
+                        | Reply | Write | Read | DeleteDerived | AAuth arch_auth
+
+text\<open>
+
+The interesting case is for endpoints.
+
+Consider an EP between T and UT (across a trust boundary). We want to
+be able to say that all EPs and tcbs that T does not expose to UT do
+not change when it is not running. If UT had a direct Send right to T
+then integrity (see below) could not guarantee this, as it doesn't
+know which EP can be changed by UT. Thus we set things up like this
+(all distinct labels):
+
+T -Receive-> EP <-Send- UT
+
+Now UT can interfere with EP and all of T's tcbs blocked for receive on EP,
+but not endpoints internal to T, or tcbs blocked on other (suitably
+labelled) EPs, etc.
+
+\<close>
+
+type_synonym 'a auth_graph = "('a \<times> auth \<times> 'a) set"
+
+text \<open>
+
+Each global namespace will need a labeling function.
+
+We map each scheduling domain to a single label; concretely, each tcb
+in a scheduling domain has to have the same label. We will want to
+weaken this in the future.
+
+The booleans @{text pasMayActivate} and @{text pasMayEditReadyQueues}
+are used to weaken the integrity property. When @{const True},
+@{text pasMayActivate} causes the integrity property to permit
+activation of newly-scheduled threads. Likewise, @{text pasMayEditReadyQueues}
+has the integrity property permit the removal of threads from ready queues,
+as occurs when scheduling a new domain for instance. By setting each of these
+@{const False} we get a more constrained integrity property that is useful for
+establishing some of the proof obligations for the infoflow proofs, particularly
+those over @{const handle_event} that neither activates new threads nor schedules
+new domains.
+
+The @{text pasDomainAbs} relation describes which labels may run in
+a given scheduler domain. This relation is not relevant to integrity
+but will be used in the information flow theory (with additional
+constraints on its structure).
+\<close>
+
+record 'a PAS =
+  pasObjectAbs :: "'a agent_map"
+  pasASIDAbs :: "'a agent_asid_map"
+  pasIRQAbs :: "'a agent_irq_map"
+  pasPolicy :: "'a auth_graph"
+  pasSubject :: "'a"                \<comment> \<open>The active label\<close>
+  pasMayActivate :: "bool"
+  pasMayEditReadyQueues :: "bool"
+  pasMaySendIrqs :: "bool"
+  pasDomainAbs :: "'a agent_domain_map"
+
+text\<open>
+
+Very often we want to say that the agent currently running owns a
+given pointer.
+
+\<close>
+
+abbreviation is_subject :: "'a PAS \<Rightarrow> obj_ref \<Rightarrow> bool" where
+  "is_subject aag ptr \<equiv> pasObjectAbs aag ptr = pasSubject aag"
+
+text\<open>
+
+Also we often want to say the current agent can do something to a
+pointer that he doesn't own but has some authority to.
+
+\<close>
+
+abbreviation(input) abs_has_auth_to :: "'a PAS \<Rightarrow> auth \<Rightarrow> obj_ref \<Rightarrow> obj_ref \<Rightarrow> bool" where
+  "abs_has_auth_to aag auth ptr ptr' \<equiv>
+     (pasObjectAbs aag ptr, auth, pasObjectAbs aag ptr') \<in> pasPolicy aag"
+
+abbreviation(input) aag_has_auth_to :: "'a PAS \<Rightarrow> auth \<Rightarrow> obj_ref \<Rightarrow> bool" where
+  "aag_has_auth_to aag auth ptr \<equiv> (pasSubject aag, auth, pasObjectAbs aag ptr) \<in> pasPolicy aag"
+
+abbreviation aag_subjects_have_auth_to_label :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> auth \<Rightarrow> 'a \<Rightarrow> bool" where
+  "aag_subjects_have_auth_to_label subs aag auth label \<equiv>
+     \<exists>s \<in> subs. (s, auth, label) \<in> pasPolicy aag"
+
+abbreviation aag_subjects_have_auth_to :: "'a set \<Rightarrow> 'a PAS \<Rightarrow> auth \<Rightarrow> obj_ref \<Rightarrow> bool" where
+ "aag_subjects_have_auth_to subs aag auth oref \<equiv>
+    aag_subjects_have_auth_to_label subs aag auth (pasObjectAbs aag oref)"
+
+subsection \<open>Misc. definitions\<close>
+
+definition ptr_range where
+  "ptr_range p sz \<equiv> {p .. p + 2 ^ sz - 1}"
+
+lemma ptr_range_0[simp]: "ptr_range (p :: obj_ref) 0 = {p}"
+  unfolding ptr_range_def by simp
+
+definition tcb_states_of_state where
+  "tcb_states_of_state s \<equiv> \<lambda>p. option_map tcb_state (get_tcb p s)"
+
+fun can_receive_ipc :: "thread_state \<Rightarrow> bool" where
+  "can_receive_ipc (BlockedOnReceive _ _) = True"
+| "can_receive_ipc (BlockedOnSend _ pl)
+     = (sender_is_call pl \<and> (sender_can_grant pl \<or> sender_can_grant_reply pl))"
+| "can_receive_ipc (BlockedOnNotification _) = True"
+| "can_receive_ipc BlockedOnReply = True"
+| "can_receive_ipc _ = False"
+
+end

--- a/proof/infoflow/ADT_IF.thy
+++ b/proof/infoflow/ADT_IF.thy
@@ -14,8 +14,8 @@ text \<open>
 theory ADT_IF
 imports
     Noninterference_Base
-    "Access.Syscall_AC"
-    "Access.ADT_AC"
+    "Access.ArchSyscall_AC"
+    "Access.ArchADT_AC"
     IRQMasks_IF FinalCaps Scheduler_IF UserOp_IF
 begin
 
@@ -923,7 +923,7 @@ where
 
 crunch cur_domain[wp]: kernel_entry_if "\<lambda>s. P (cur_domain s)"
 crunch idle_thread[wp]: kernel_entry_if "\<lambda>s::det_state. P (idle_thread s)"
-crunch cur_thread [wp]: kernel_entry_if "\<lambda>s. P (cur_thread s)"
+crunch cur_thread [wp]: kernel_entry_if "\<lambda>s::det_state. P (cur_thread s)"
 
 lemma thread_set_tcb_context_update_ct_active[wp]:
   "\<lbrace>ct_active\<rbrace>
@@ -1199,7 +1199,7 @@ lemma handle_preemption_if_pas_refined[wp]:
   apply (wp handle_interrupt_pas_refined | simp)+
   done
 
-crunch cur_thread[wp]: handle_preemption_if "\<lambda>s. P (cur_thread s)"
+crunch cur_thread[wp]: handle_preemption_if "\<lambda>s::det_state. P (cur_thread s)"
 crunch cur_domain[wp]: handle_preemption_if " \<lambda>s. P (cur_domain s)"
 crunch idle_thread[wp]: handle_preemption_if "\<lambda>s::det_state. P (idle_thread s)"
 
@@ -1799,7 +1799,7 @@ lemma next_domain_domain_time_nonzero:
 
 lemma nonzero_gt_zero[simp]:
   "x \<noteq> (0::word32) \<Longrightarrow> x > 0"
-  apply(rule nonzero_unat_simp)
+  apply(rule nonzero_data_to_nat_simp)
   apply(simp add: unat_gt_0)
   done
 
@@ -3400,9 +3400,8 @@ lemma ADT_A_if_sub_big_steps_measuref_if:
   apply(erule sub_big_steps.induct)
    apply(clarsimp simp: big_step_R_def measuref_if_def)
   apply(clarsimp simp: big_step_R_def measuref_if_def split: if_splits)
-   apply(case_tac ba, simp_all, case_tac bc, simp_all add: Step_ADT_A_if')
-       apply(simp_all add: ADT_A_if_def global_automaton_if_def)
-  done
+  apply(case_tac ba, simp_all, case_tac bc)
+  by(fastforce simp: Step_ADT_A_if' ADT_A_if_def global_automaton_if_def)+
 
 lemma rah_simp:
   "(\<forall>b. b) = False"

--- a/proof/infoflow/Arch_IF.thy
+++ b/proof/infoflow/Arch_IF.thy
@@ -1931,6 +1931,11 @@ lemma store_word_offs_globals_equiv:
   done
 
 
+lemma length_msg_registers:
+  "length msg_registers = 4"
+  unfolding msg_registers_def
+  by (simp add: msgRegisters_def upto_enum_def fromEnum_def enum_register)
+
 lemma length_msg_lt_msg_max:
   "length msg_registers < msg_max_length"
   apply(simp add: length_msg_registers msg_max_length_def)
@@ -2066,8 +2071,6 @@ lemma delete_objects_valid_ko_at_arm:
   apply(wp detype_valid_ko_at_arm do_machine_op_valid_ko_at_arm | simp add: ptr_range_def)+
   done
 
-
-
 lemma perform_asid_control_invocation_globals_equiv:
   notes delete_objects_invs[wp del]
   notes blah[simp del] =  atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
@@ -2117,7 +2120,7 @@ lemma perform_asid_control_invocation_globals_equiv:
      apply(simp add: empty_descendants_range_in)
     apply(clarsimp simp: range_cover_def)
     apply(subst is_aligned_neg_mask_eq[THEN sym], assumption)
-    apply(simp add: mask_neg_mask_is_zero pageBits_def mask_zero)
+    apply(simp add: word_bw_assocs pageBits_def mask_zero)
    apply(wp add: delete_objects_invs_ex delete_objects_pspace_no_overlap[where dev=False]
             delete_objects_globals_equiv delete_objects_valid_ko_at_arm
             hoare_vcg_ex_lift
@@ -2231,7 +2234,7 @@ lemma decode_arch_invocation_authorised_for_globals:
             apply(simp add: valid_cap_def)
            apply(simp add: vmsz_aligned_def)
            apply(drule_tac ptr="msg ! 0" and off="2 ^ pageBitsForSize vmpage_size - 1" in is_aligned_no_wrap')
-            apply(insert pbfs_less_wb)
+            apply(insert pbfs_less_wb')
             apply(clarsimp)
            apply(fastforce simp: x_power_minus_1)
           apply(clarsimp)

--- a/proof/infoflow/CNode_IF.thy
+++ b/proof/infoflow/CNode_IF.thy
@@ -432,17 +432,17 @@ lemma aag_cap_auth_ASIDPoolCap:
   "pas_cap_cur_auth aag (ArchObjectCap (ASIDPoolCap r asid)) \<Longrightarrow>
    pas_refined aag s \<Longrightarrow> is_subject aag r"
 unfolding aag_cap_auth_def
-  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def pas_refined_all_auth_is_owns
-                   is_page_cap_def)
-done
+  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
+                   pas_refined_all_auth_is_owns is_page_cap_def)
+  done
 
 lemma aag_cap_auth_PageDirectory:
   "pas_cap_cur_auth aag (ArchObjectCap (PageDirectoryCap word (Some a))) \<Longrightarrow>
     pas_refined aag s \<Longrightarrow> is_subject aag word"
   unfolding aag_cap_auth_def
-  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def pas_refined_all_auth_is_owns
-                   is_page_cap_def)
-done
+  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
+                   pas_refined_all_auth_is_owns is_page_cap_def)
+  done
 
 lemma aag_cap_auth_ASIDPoolCap_asid:
   "pas_cap_cur_auth aag (ArchObjectCap (ASIDPoolCap r asid)) \<Longrightarrow>
@@ -453,7 +453,7 @@ lemma aag_cap_auth_ASIDPoolCap_asid:
   unfolding aag_cap_auth_def
   apply (rule is_subject_into_is_subject_asid)
   apply auto
-done
+  done
 
 lemma aag_cap_auth_PageCap_asid:
   "pas_cap_cur_auth aag (ArchObjectCap (PageCap dev word fun vmpage_size (Some (a, b))))
@@ -462,27 +462,27 @@ lemma aag_cap_auth_PageCap_asid:
   apply (auto simp add: aag_cap_auth_def cap_auth_conferred_def
                         cap_links_asid_slot_def label_owns_asid_slot_def
                  intro: pas_refined_Control_into_is_subject_asid)
-done
+  done
 
 lemma aag_cap_auth_PageTableCap:
   "pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word option)) \<Longrightarrow>
    pas_refined aag s \<Longrightarrow> is_subject aag word"
   unfolding aag_cap_auth_def
-  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def pas_refined_all_auth_is_owns
-                   is_page_cap_def)
-done
+  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
+                   pas_refined_all_auth_is_owns is_page_cap_def)
+  done
 
 lemma aag_cap_auth_PageTableCap_asid: "pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word (Some (a, b)))) \<Longrightarrow> pas_refined aag s \<Longrightarrow> is_subject_asid aag a"
   apply (auto simp add: aag_cap_auth_def cap_auth_conferred_def
                    cap_links_asid_slot_def label_owns_asid_slot_def
                    intro: pas_refined_Control_into_is_subject_asid)
-done
+  done
 
 lemma aag_cap_auth_PageDirectoryCap:"pas_cap_cur_auth aag (ArchObjectCap (PageDirectoryCap word option)) \<Longrightarrow> pas_refined aag s \<Longrightarrow>
   is_subject aag word"
   unfolding aag_cap_auth_def
-  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def   pas_refined_all_auth_is_owns is_page_cap_def)
-done
+  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def   pas_refined_all_auth_is_owns is_page_cap_def)
+  done
 
 
 lemma aag_cap_auth_PageDirectoryCap_asid:"pas_cap_cur_auth aag (ArchObjectCap (PageDirectoryCap word (Some a))) \<Longrightarrow> pas_refined aag s \<Longrightarrow>

--- a/proof/infoflow/Decode_IF.thy
+++ b/proof/infoflow/Decode_IF.thy
@@ -58,15 +58,7 @@ lemma decode_untyped_invocation_rev:
                         | simp
                         | wp (once) hoare_drop_imps)+
   apply(clarify, drule_tac x="excaps ! 0" in bspec, fastforce intro: bang_0_in_set)
-  apply safe
-     apply(drule (1) is_cnode_into_is_subject)
-     apply(erule (1) impE)
-     apply(fastforce elim: prop_of_obj_ref_of_cnode_cap)
-    apply(fastforce dest: is_cnode_into_is_subject)
-   apply(drule (1) is_cnode_into_is_subject)
-   apply(erule (1) impE)
-   apply(fastforce elim: prop_of_obj_ref_of_cnode_cap)
-  apply(fastforce dest: is_cnode_into_is_subject)
+  apply(auto dest: is_cnode_into_is_subject elim: prop_of_obj_ref_of_cnode_cap)
   done
 
 lemma derive_cap_rev':
@@ -119,9 +111,12 @@ lemma decode_cnode_invocation_rev:
         | wpc
         | (wp (once) hoare_drop_imps, wp (once) lookup_slot_for_cnode_op_authorised)
         | strengthen aag_can_read_self)+)
-   apply(auto dest: bspec[where x="excaps ! 0"] bspec[where x="excaps ! Suc 0"]
-              intro: nth_mem elim: prop_of_obj_ref_of_cnode_cap
-              dest!: is_cnode_into_is_subject simp: expand_len_gr_Suc_0)
+  apply clarsimp
+  apply (cases excaps; cases "tl excaps"; clarsimp)
+    apply (auto dest: bspec[where x="excaps ! 0"] bspec[where x="excaps ! Suc 0"]
+                      is_cnode_into_is_subject
+               intro: nth_mem elim: prop_of_obj_ref_of_cnode_cap
+               simp: expand_len_gr_Suc_0)
   done
 
 lemma range_check_ev:
@@ -309,9 +304,7 @@ lemma arch_decode_irq_control_invocation_rev:
     apply(blast intro: aag_Control_into_owns_irq )
    apply(drule_tac x="caps ! 0" in bspec)
     apply(fastforce intro: bang_0_in_set)
-   apply(drule (1) is_cnode_into_is_subject)
-   apply(erule (1) impE)
-   apply(blast dest: prop_of_obj_ref_of_cnode_cap)
+   apply(drule (1) is_cnode_into_is_subject; blast dest: prop_of_obj_ref_of_cnode_cap)
   apply(fastforce dest: is_cnode_into_is_subject intro: bang_0_in_set)
   done
 
@@ -332,9 +325,7 @@ lemma decode_irq_control_invocation_rev:
     apply(blast intro: aag_Control_into_owns_irq )
    apply(drule_tac x="caps ! 0" in bspec)
     apply(fastforce intro: bang_0_in_set)
-   apply(drule (1) is_cnode_into_is_subject)
-   apply(erule (1) impE)
-   apply(blast dest: prop_of_obj_ref_of_cnode_cap)
+   apply(drule (1) is_cnode_into_is_subject; blast dest: prop_of_obj_ref_of_cnode_cap)
   apply(fastforce dest: is_cnode_into_is_subject intro: bang_0_in_set)
   done
 
@@ -516,7 +507,7 @@ lemma lookup_pt_slot_no_fail_is_subject:
     apply (drule(1) less_kernel_base_mapping_slots)
     apply (simp add: kernel_mapping_slots_def lookup_pd_slot_def pd_shifting_dual' triple_shift_fun)
    apply assumption
-  apply (simp add: aag_has_auth_to_Control_eq_owns)
+  apply (simp add: aag_has_Control_iff_owns)
   apply (drule_tac f="\<lambda>pde. valid_pde pde s" in arg_cong, simp)
   apply (clarsimp simp: obj_at_def kernel_base_kernel_mapping_slots)
   apply (erule pspace_alignedE, erule domI)
@@ -626,7 +617,7 @@ lemma arch_decode_invocation_reads_respects_f:
                    apply simp
                   apply(case_tac xc, simp_all)[1]
                  apply(rule ball_subset[OF _ vspace_cap_rights_to_auth_mask_vm_rights])
-                 apply(fastforce simp: aag_cap_auth_def cap_auth_conferred_def)
+                 apply(fastforce simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def)
                 apply(simp add: lookup_pd_slot_def)
                 apply(subgoal_tac "excaps ! 0 \<in> set excaps")
                  apply(subst vaddr_segment_nonsense)
@@ -648,7 +639,7 @@ lemma arch_decode_invocation_reads_respects_f:
             apply fastforce
            apply(fastforce dest: cte_wp_valid_cap simp: valid_cap_simps)
           apply(rule ball_subset[OF _ vspace_cap_rights_to_auth_mask_vm_rights])
-          apply(fastforce simp: aag_cap_auth_def cap_auth_conferred_def)
+          apply(fastforce simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def)
          apply(subgoal_tac "excaps ! 0 \<in> set excaps")
           apply(fastforce intro: aag_cap_auth_PageDirectoryCap_asid)
          apply fastforce

--- a/proof/infoflow/FinalCaps.thy
+++ b/proof/infoflow/FinalCaps.thy
@@ -1235,7 +1235,7 @@ lemma empty_slot_silc_inv:
   "\<lbrace>silc_inv aag st and K (pasObjectAbs aag (fst slot) \<noteq> SilcLabel)\<rbrace>
    empty_slot slot free_irq
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding empty_slot_def
+  unfolding empty_slot_def post_cap_deletion_def
   apply(wp set_cap_silc_inv hoare_vcg_all_lift hoare_vcg_ex_lift
            slots_holding_overlapping_caps_lift get_cap_wp
            set_cdt_silc_inv dxo_wp_weak hoare_drop_imps
@@ -2830,7 +2830,6 @@ lemma do_ipc_transfer_silc_inv:
   apply clarsimp
   done
 
-
 lemma send_ipc_silc_inv:
   "\<lbrace>silc_inv aag st and invs and pas_refined aag
        and K (is_subject aag thread \<and> aag_has_auth_to aag SyncSend epptr \<and>
@@ -2861,7 +2860,7 @@ lemma send_ipc_silc_inv:
       apply (frule(1) sym_ref_endpoint_recvD[OF invs_sym_refs _ head_in_set],
              clarsimp simp: st_tcb_at_tcb_states_of_state_eq)
       apply (frule(2) aag_wellformed_grant_Control_to_recv[OF _ _ pas_refined_wellformed])
-      by (simp add: aag_has_auth_to_Control_eq_owns)
+      by (simp add: aag_has_Control_iff_owns)
     apply clarsimp
     apply (intro conjI[rotated] impI)
     subgoal (* no grant or grant reply case *)
@@ -2873,7 +2872,7 @@ lemma send_ipc_silc_inv:
              clarsimp simp: st_tcb_at_tcb_states_of_state_eq)
       apply (frule(1) tcb_states_of_state_to_auth)
       by (auto elim: send_ipc_valid_ep_helper
-          simp: aag_has_auth_to_Control_eq_owns
+          simp: aag_has_Control_iff_owns
           dest: tcb_states_of_state_to_auth
           aag_wellformed_grant_Control_to_recv_by_reply[OF _ _ _ pas_refined_wellformed];
           force dest: tcb_states_of_state_kheapD
@@ -2917,9 +2916,9 @@ lemma receive_ipc_base_silc_inv:
        (erule(1) receive_ipc_valid_ep_helper
        | (erule(1) silc_inv_cnode_onlyE,simp add: obj_at_def is_cap_table)
        | (drule(2) aag_wellformed_grant_Control_to_send[OF _ _ pas_refined_wellformed],
-          (simp add: aag_has_auth_to_Control_eq_owns | force dest: pas_refined_Control))
+          (simp add: aag_has_Control_iff_owns | force dest: pas_refined_Control))
        | (drule aag_wellformed_grant_Control_to_send_by_reply[OF _ _ _ pas_refined_wellformed],
-          blast, blast, blast, simp add: aag_has_auth_to_Control_eq_owns)))
+          blast, blast, blast, simp add: aag_has_Control_iff_owns)))
 
 
 lemma receive_ipc_silc_inv:

--- a/proof/infoflow/IRQMasks_IF.thy
+++ b/proof/infoflow/IRQMasks_IF.thy
@@ -5,7 +5,7 @@
  *)
 
 theory IRQMasks_IF
-imports "Access.DomainSepInv"
+imports "Access.ArchDomainSepInv"
 begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)
@@ -65,7 +65,7 @@ lemma empty_slot_irq_masks:
    empty_slot slot irq_opt
    \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
   apply(rule hoare_gen_asm)
-  apply(simp add: empty_slot_def | wp)+
+  apply(simp add: empty_slot_def post_cap_deletion_def | wp)+
   done
 
 crunch irq_masks[wp]: do_reply_transfer "\<lambda>s. P (irq_masks_of_state s)"

--- a/proof/infoflow/InfoFlow.thy
+++ b/proof/infoflow/InfoFlow.thy
@@ -17,7 +17,7 @@ text \<open>
 
 theory InfoFlow
 imports
-  "Access.Syscall_AC"
+  "Access.ArchSyscall_AC"
   "Lib.EquivValid"
 begin
 
@@ -816,10 +816,11 @@ text \<open>
   through the actions of l, this state can be modified, then we say that the
   label l' can be affected by l. This is, of course, just a more coarse
   statement of the integrity property from the access proofs.
-
+\<close>
+(* FIXME: theorem no longer exists
   The case in which @{thm tro_asidpool_clear} is covered when the graph is wellformed
   since, in this case, the subject has Control rights to the asid.
-\<close>
+*)
 inductive_set subjectAffects :: "'a auth_graph \<Rightarrow> 'a \<Rightarrow> 'a set"
   for g :: "'a auth_graph" and l :: "'a"
 where
@@ -864,7 +865,7 @@ where
      l'' \<in> subjectAffects g l" |
   (* if you alter an asid mapping, you affect the domain who owns that asid *)
   affects_asidpool_map:
-    "(l,ASIDPoolMapsASID,l') \<in> g \<Longrightarrow> l' \<in> subjectAffects g l" |
+    "(l,AAuth ASIDPoolMapsASID,l') \<in> g \<Longrightarrow> l' \<in> subjectAffects g l" |
   (* if you are sending to an ntfn, which is bound to a tcb that is
      receive blocked on an ep, then you can affect that ep *)
   affects_ep_bound_trans:
@@ -1693,9 +1694,8 @@ lemma auth_ipc_buffers_mem_Write':
   apply (clarsimp simp add: auth_ipc_buffers_member_def)
   apply (drule (1) cap_auth_caps_of_state)
     apply simp
-  apply (clarsimp simp: aag_cap_auth_def cap_auth_conferred_def
-                        vspace_cap_rights_to_auth_def vm_read_write_def
-                        is_page_cap_def
+  apply (clarsimp simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def
+                        vspace_cap_rights_to_auth_def vm_read_write_def is_page_cap_def
                  split: if_split_asm)
    apply (auto dest: ipcframe_subset_page)
   done

--- a/proof/infoflow/PasUpdates.thy
+++ b/proof/infoflow/PasUpdates.thy
@@ -148,7 +148,7 @@ lemma pas_refined_pasSubject_update':
       apply (simp add: irq_map_wellformed_pasSubject_update pas_refined_def)
      apply (simp add: tcb_domain_map_wellformed_pasSubject_update pas_refined_def)
     apply (clarsimp simp: pas_refined_def)
-   apply(fastforce intro: pas_refined_asid_mem simp: state_asids_to_policy_pasSubject_update)
+   apply(fastforce simp: pas_refined_def state_asids_to_policy_pasSubject_update)
   apply(fastforce simp: pas_refined_def state_irqs_to_policy_pasSubject_update)
   done
 
@@ -229,7 +229,7 @@ lemma pas_refined_pasMayActivate_update:
   "pas_refined aag s \<Longrightarrow>
    pas_refined (aag\<lparr> pasMayActivate := x \<rparr>) s"
   apply(simp add: pas_refined_def)
-  apply(clarsimp simp: irq_map_wellformed_aux_def state_asids_to_policy_pasMayActivate_update
+  apply(clarsimp simp: irq_map_wellformed_aux_def state_asids_to_policy_pasMayActivate_update[simplified]
                        state_irqs_to_policy_pasMayActivate_update tcb_domain_map_wellformed_aux_def)
   done
 
@@ -297,7 +297,7 @@ lemma pas_refined_pasMayEditReadyQueues_update:
    pas_refined (aag\<lparr> pasMayEditReadyQueues := x \<rparr>) s"
   apply(simp add: pas_refined_def)
   apply(clarsimp simp: irq_map_wellformed_aux_def
-                       state_asids_to_policy_pasMayEditReadyQueues_update
+                       state_asids_to_policy_pasMayEditReadyQueues_update[simplified]
                        state_irqs_to_policy_pasMayEditReadyQueues_update
                        tcb_domain_map_wellformed_aux_def)
   done

--- a/proof/infoflow/Syscall_IF.thy
+++ b/proof/infoflow/Syscall_IF.thy
@@ -198,13 +198,6 @@ lemma cancel_badged_sends_reads_respects_f:
   apply (simp add: invs_valid_objs invs_sym_refs)
   done
 
-lemma rec_del_subject_cur_thread:
-  "\<lbrace>is_subject aag \<circ> cur_thread\<rbrace> rec_del call \<lbrace>\<lambda>_. is_subject aag \<circ> cur_thread\<rbrace>"
-  apply (rule rec_del_preservation)
-  apply (simp add: comp_def | wp preemption_point_inv)+
-  done
-
-
 lemma cap_revoke_only_timer_irq_inv:
   "\<lbrace>only_timer_irq_inv irq (st::det_ext state)\<rbrace>
    cap_revoke slot \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"

--- a/proof/infoflow/Tcb_IF.thy
+++ b/proof/infoflow/Tcb_IF.thy
@@ -202,7 +202,7 @@ next
                    in hoare_vcg_conj_lift)
          apply (wp finalise_cap_invs[where slot=slot]
                    finalise_cap_replaceable[where sl=slot]
-                   Finalise_AC.finalise_cap_makes_halted[where slot=slot]
+                   Finalise_IF.finalise_cap_makes_halted[where slot=slot]
                    finalise_cap_P)[1]
 
          apply (rule finalise_cap_cases[where slot=slot])
@@ -506,10 +506,6 @@ lemma restart_reads_respects_f:
   apply (rule requiv_get_tcb_eq, simp+ |
          rule conjI | assumption | clarsimp simp: reads_equiv_f_def)+
   done
-
-crunch cur_thread: cancel_ipc "\<lambda> s. P (cur_thread s)"
-  (wp: crunch_wps select_wp simp: crunch_simps)
-
 
 lemma det_zipWithM:
   assumes "\<And> x y. \<lbrakk>x \<in> set xs; y \<in> set ys\<rbrakk> \<Longrightarrow> det (f x y)"

--- a/proof/infoflow/UserOp_IF.thy
+++ b/proof/infoflow/UserOp_IF.thy
@@ -5,7 +5,7 @@
  *)
 
 theory UserOp_IF
-imports Syscall_IF "Access.ADT_AC"
+imports Syscall_IF "Access.ArchADT_AC"
 begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)
@@ -473,7 +473,7 @@ lemma data_at_same_size:
    apply (drule is_aligned_ptrFromPAddrD[OF _ pageBitsForSize_le_t24])
      apply (subst neg_mask_add_aligned[OF _ and_mask_less'])
       apply simp
-     apply (fastforce simp: pbfs_less_wb[unfolded word_bits_def,simplified])
+     apply (fastforce simp: pbfs_less_wb'[unfolded word_bits_def,simplified])
    apply (simp add: is_aligned_neg_mask_eq)
   apply (drule not_sym)
   apply (erule(5) data_at_disjoint_equiv)
@@ -491,7 +491,7 @@ lemma data_at_same_size:
   apply (rule arg_cong[where f = "\<lambda>x. x && ~~ mask z" for z])
   apply (subst neg_mask_add_aligned[OF _ and_mask_less'])
     apply simp
-   apply (fastforce simp: pbfs_less_wb[unfolded word_bits_def,simplified])
+   apply (fastforce simp: pbfs_less_wb'[unfolded word_bits_def,simplified])
   apply simp
   done
 qed

--- a/proof/invariant-abstract/LevityCatch_AI.thy
+++ b/proof/invariant-abstract/LevityCatch_AI.thy
@@ -10,7 +10,11 @@ imports
 begin
 
 context begin interpretation Arch .
+
+requalify_consts
+  ptrFromPAddr addrFromPPtr
 requalify_facts
+  ptrFormPAddr_addFromPPtr
   aobj_ref_arch_cap
 
 end

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -24,6 +24,7 @@ requalify_facts
   arch_post_cap_deletion_cur_thread
   arch_post_cap_deletion_state_refs_of
   arch_invoke_irq_handler_typ_at
+  resetTimer_device_state_inv
 end
 
 lemmas [wp] =

--- a/proof/invariant-abstract/VSpace_AI.thy
+++ b/proof/invariant-abstract/VSpace_AI.thy
@@ -16,6 +16,7 @@ context begin interpretation Arch .
 requalify_facts
    pspace_respects_device_region_dmo
    cap_refs_respects_device_region_dmo
+   ackInterrupt_device_state_inv
 
 end
 

--- a/spec/abstract/ARM/ArchVSpaceAcc_A.thy
+++ b/spec/abstract/ARM/ArchVSpaceAcc_A.thy
@@ -30,6 +30,9 @@ definition
   asid_high_bits_of :: "asid \<Rightarrow> 7 word" where
   "asid_high_bits_of asid \<equiv> ucast (asid >> asid_low_bits)"
 
+locale_abbrev
+  "asid_table \<equiv> \<lambda>s. arm_asid_table (arch_state s)"
+
 
 section "Kernel Heap Accessors"
 


### PR DESCRIPTION
Split the access control proofs into generic and arch-specific theories. Commits have been structured according to the files that were split. New FIXMEs have been annotated "FIXME AC".