### PR TITLE
Haskell cleanup

### DIFF
--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -3325,7 +3325,7 @@ lemma getTCB_det:
   by (clarsimp simp: ko_wp_at'_def getObject_def split_def gets_the_def
                      bind_def gets_def return_def get_def fail_def assert_opt_def
                      no_ofailD[OF no_ofail_tcb_at'_readObject] obj_at'_def projectKOs
-              split: if_splits option.split)
+              split: if_splits option.split dest!: readObject_misc_ko_at')
 
 lemma threadSet_det:
   "tcb_at' ptr s

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -3018,7 +3018,7 @@ lemma refillUnblockCheck_corres:
 
 lemma updateRefillHd_valid_objs':
   "\<lbrace>valid_objs' and active_sc_at' scPtr\<rbrace> updateRefillHd scPtr f \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (clarsimp simp: updateRefillHd_def2 updateScPtr_def)
+  apply (clarsimp simp: updateRefillHd_def2 updateSchedContext_def)
   apply (wpsimp wp: )
   apply (frule (1) sc_ko_at_valid_objs_valid_sc')
   apply (clarsimp simp: valid_sched_context'_def active_sc_at'_def obj_at'_real_def ko_wp_at'_def
@@ -3249,12 +3249,12 @@ crunches schedContextResume
   for valid_queues'[wp]: valid_queues'
   (wp: crunch_wps)
 
-lemma updateScPtr_sc_obj_at':
+lemma updateSchedContext_sc_obj_at':
   "\<lbrace>if scPtr = scPtr' then (\<lambda>s. \<forall>ko. ko_at' ko scPtr' s \<longrightarrow> P (f ko)) else obj_at' P scPtr'\<rbrace>
-   updateScPtr scPtr f
+   updateSchedContext scPtr f
    \<lbrace>\<lambda>rv. obj_at' P scPtr'\<rbrace>"
   supply if_split [split del]
-  apply (simp add: updateScPtr_def)
+  apply (simp add: updateSchedContext_def)
   apply (wpsimp wp: set_sc'.obj_at')
   apply (clarsimp split: if_splits simp: obj_at'_real_def ko_wp_at'_def)
   done
@@ -3263,7 +3263,7 @@ lemma refillPopHead_bound_tcb_sc_at[wp]:
   "refillPopHead scPtr \<lbrace>obj_at' (\<lambda>a. \<exists>y. scTCB a = Some y) t\<rbrace>"
   supply if_split [split del]
   unfolding refillPopHead_def
-  apply (wpsimp wp: updateScPtr_sc_obj_at' getRefillNext_wp getMapScPtr_wp)
+  apply (wpsimp wp: updateSchedContext_sc_obj_at' getRefillNext_wp)
   by (clarsimp simp: obj_at'_real_def ko_wp_at'_def split: if_split)
 
 lemma updateRefillHd_bound_tcb_sc_at[wp]:

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -1938,60 +1938,28 @@ lemma no_ofail_threadRead[simp]:
                   split: option.split dest!: no_ofailD[OF no_ofail_obj_at'_readObject_tcb])
   done
 
-lemma no_ofail_readMapScPtr[simp]:
-  "no_ofail (obj_at' (P::sched_context \<Rightarrow> bool) p) (readMapScPtr p f)"
-  unfolding readMapScPtr_def oliftM_def no_ofail_def
-  apply clarsimp
-  apply (clarsimp simp: readMapScPtr_def readSchedContext_def obind_def oliftM_def oreturn_def
-                  split: option.split dest!: no_ofailD[OF no_ofail_obj_at'_readObject_sc])
-  done
-
 lemmas no_ofail_threadRead_tcb_at'[wp] = no_ofail_threadRead[where P=\<top>]
-lemmas no_ofail_readMapScPtr_sc_at'[wp] = no_ofail_readMapScPtr[where P=\<top>]
 
 lemma threadRead_tcb_at'':
   "bound (threadRead f t s) \<Longrightarrow> tcb_at' t s"
   by (clarsimp simp: threadRead_def oliftM_def elim!: obj_at'_weakenE)
 
-lemma readMapScPtr_sc_at'':
-  "bound (readMapScPtr t f s) \<Longrightarrow> sc_at' t s"
-  by (clarsimp simp: readMapScPtr_def readSchedContext_def oliftM_def elim!: obj_at'_weakenE)
-
 lemmas threadRead_tcb_at' = threadRead_tcb_at''[simplified]
-lemmas readMapScPtr_sc_at' = readMapScPtr_sc_at''[simplified]
 
 lemma ovalid_threadRead:
   "o\<lbrace>\<lambda>s. tcb_at' t s \<longrightarrow> (\<exists>tcb. ko_at' tcb t s \<and> P (f tcb) s)\<rbrace>
     threadRead f t \<lbrace>P\<rbrace>"
   by (clarsimp simp: threadRead_def oliftM_def obind_def obj_at'_def ovalid_def
-        split: option.split_asm dest!: readObject_misc_ko_at')
-
-lemma ovalid_readMapScPtr:
-  "o\<lbrace>\<lambda>s. sc_at' scPtr s \<longrightarrow> (\<exists>sc. ko_at' sc scPtr s \<and> P (f sc) s)\<rbrace> readMapScPtr scPtr f \<lbrace>P\<rbrace>"
-  apply (clarsimp simp: readMapScPtr_def oliftM_def obind_def obj_at'_def ovalid_def
-                        readSchedContext_def
-                 split: option.split_asm dest!: readObject_misc_ko_at')
-  done
+              dest!: readObject_misc_ko_at' split: option.split_asm)
 
 lemma ovalid_threadRead_sp:
   "o\<lbrace>P\<rbrace> threadRead f ptr \<lbrace>\<lambda>rv s. \<exists>tcb :: tcb. ko_at' tcb ptr s \<and> f tcb = rv \<and> P s\<rbrace>"
   by (clarsimp simp: threadRead_def oliftM_def obind_def obj_at'_def ovalid_def
-        split: option.split_asm dest!: readObject_misc_ko_at')
-
-lemma ovalid_readMapScPtr_sp:
-  "o\<lbrace>P\<rbrace> readMapScPtr ptr f \<lbrace>\<lambda>rv s. \<exists>sc :: sched_context. ko_at' sc ptr s \<and> f sc = rv \<and> P s\<rbrace>"
-  apply (clarsimp simp: readMapScPtr_def readSchedContext_def oliftM_def obind_def obj_at'_def
-                        ovalid_def
-                 split: option.split_asm dest!: readObject_misc_ko_at')
-  done
+              dest!: readObject_misc_ko_at' split: option.split_asm)
 
 lemma no_fail_threadGet [wp]:
   "no_fail (tcb_at' t) (threadGet f t)"
   by (wpsimp simp: threadGet_def wp: no_ofail_gets_the)
-
-lemma no_fail_readMapScPtr [wp]:
-  "no_fail (sc_at' t) (getMapScPtr t f)"
-  by (wpsimp simp: getMapScPtr_def wp: no_ofail_gets_the)
 
 lemma no_fail_getThreadState [wp]:
   "no_fail (tcb_at' t) (getThreadState t)"
@@ -3820,22 +3788,6 @@ lemma getObject_sc_wp:
                      projectKOs obj_at'_def in_magnitude_check
               dest!: readObject_misc_ko_at')
 
-lemma getMapScPtr_getObject:
-  "getMapScPtr t f = do x \<leftarrow> getObject t;
-                        return (f x)
-                     od"
-  apply (simp add: getMapScPtr_def readSchedContext_def readMapScPtr_def getObject_def[symmetric])
-  done
-
-lemma getMapScPtr_wp:
-  "\<lbrace>\<lambda>s. \<forall>sc. ko_at' sc scPtr s \<longrightarrow> P (f sc) s\<rbrace>
-   getMapScPtr scPtr f
-   \<lbrace>P\<rbrace>"
-  apply (simp add: getMapScPtr_getObject)
-  apply (wp getObject_sc_wp)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
 lemma getRefillNext_getSchedContext:
   "getRefillNext scPtr index = do sc \<leftarrow> getSchedContext scPtr;
                                   return $ if index = scRefillMax sc - 1 then 0 else index + 1
@@ -3852,15 +3804,15 @@ lemma getRefillNext_wp:
   apply (wpsimp wp: getObject_sc_wp)
   done
 
-lemma getRefillSize_getMapScPtr:
-  "getRefillSize scPtr = getMapScPtr scPtr scRefillCount"
-  apply (clarsimp simp: getRefillSize_def getMapScPtr_def readRefillSize_def)
+lemma getRefillSize_def2:
+  "getRefillSize scPtr = liftM scRefillCount (gets_the (readSchedContext scPtr))"
+  apply (clarsimp simp: getRefillSize_def readRefillSize_def liftM_def oliftM_def)
   done
 
 lemma getRefillSize_wp:
   "\<lbrace>\<lambda>s. \<forall>ko. ko_at' ko scp s \<longrightarrow> P (scRefillCount ko) s\<rbrace> getRefillSize scp \<lbrace>P\<rbrace>"
-  apply (clarsimp simp: getRefillSize_getMapScPtr)
-  apply (wpsimp wp: getMapScPtr_wp)
+  apply (clarsimp simp: getRefillSize_def2)
+  apply (wpsimp wp: simp: readSchedContext_def)
   done
 
 lemma refillEmpty_wp:

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -202,7 +202,7 @@ method readObject_obj_at'_method
                     obj_at'_def projectKOs objBits_simps' scBits_pos_power2
              split: option.splits if_split_asm
 
-lemma readObject_misc_ko_at'[simp, dest!]:
+lemma readObject_misc_ko_at'[simp]:
   shows
   readObject_ko_at'_tcb: "readObject p s = Some (tcb :: tcb) \<Longrightarrow> ko_at' tcb p s" and
   readObject_ko_at'_ep: "readObject p s = Some (ep :: endpoint) \<Longrightarrow> ko_at' ep p s" and
@@ -222,7 +222,7 @@ lemma readObject_misc_obj_at'[simplified, simp]:
 
 lemma getObject_tcb_at':
   "\<lbrace> \<top> \<rbrace> getObject t \<lbrace>\<lambda>r::tcb. tcb_at' t\<rbrace>"
-  unfolding getObject_def by wpsimp (clarsimp elim!: ko_at_obj_at')
+  unfolding getObject_def by wpsimp
 
 lemma koType_objBitsKO:
   "\<lbrakk>koTypeOf k' = koTypeOf k; koTypeOf k = SchedContextT \<longrightarrow> objBitsKO k' = objBitsKO k\<rbrakk>
@@ -303,7 +303,8 @@ lemma corres_get_tcb [corres]:
    apply wp
   apply (simp add: get_object_def get_tcb_def gets_def gets_the_def getObject_def)
   apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def
-                        assert_def fail_def obj_at_def is_tcb)
+                        assert_def fail_def obj_at_def is_tcb
+                 dest!: readObject_misc_ko_at')
   apply (clarsimp simp: state_relation_def pspace_relation_def obj_at'_def projectKOs)
   apply (drule bspec)
    apply blast
@@ -1156,7 +1157,8 @@ lemma get_ep_corres [corres]:
    apply wp
   apply (simp add: get_simple_ko_def getEndpoint_def get_object_def gets_the_def
                    getObject_def bind_assoc ep_at_def2)
-  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def)
+  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def
+                 dest!: readObject_misc_ko_at')
   apply (clarsimp simp: assert_def fail_def obj_at_def return_def is_ep partial_inv_def)
   apply (rename_tac ep' ep)
   apply (clarsimp simp: state_relation_def pspace_relation_def obj_at'_def projectKOs)
@@ -1680,7 +1682,8 @@ lemma get_ntfn_corres:
    apply wp
   apply (simp add: get_simple_ko_def getNotification_def get_object_def
                    getObject_def bind_assoc gets_the_def)
-  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def)
+  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def
+                 dest!: readObject_misc_ko_at')
   apply (clarsimp simp: assert_def fail_def obj_at_def return_def is_ntfn partial_inv_def)
   apply (clarsimp simp add: state_relation_def pspace_relation_def obj_at'_def projectKOs)
   apply (drule bspec)
@@ -1695,7 +1698,8 @@ lemma get_reply_corres:
    apply wp
   apply (simp add: get_simple_ko_def getReply_def get_object_def
                    getObject_def bind_assoc gets_the_def)
-  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def)
+  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def
+                 dest!: readObject_misc_ko_at')
   apply (clarsimp simp: assert_def fail_def obj_at_def return_def is_reply partial_inv_def)
   apply (clarsimp simp add: state_relation_def pspace_relation_def obj_at'_def projectKOs)
   apply (drule bspec)
@@ -1718,7 +1722,8 @@ lemma get_sc_corres:
    apply wp
   apply (simp add: get_sched_context_def getSchedContext_def get_object_def
                    getObject_def bind_assoc gets_the_def)
-  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def)
+  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def return_def
+                 dest!: readObject_misc_ko_at')
   apply (clarsimp simp: assert_def fail_def obj_at_def return_def is_sc_obj_def
                  split: Structures_A.kernel_object.splits)
   apply (clarsimp simp add: state_relation_def pspace_relation_def obj_at'_def projectKOs)
@@ -1737,7 +1742,8 @@ lemma get_sc_corres_size:
                    getObject_def bind_assoc gets_the_def)
   apply (clarsimp simp: in_monad split_def bind_def gets_def get_def)
   apply (clarsimp simp: assert_def fail_def obj_at_def return_def is_sc_obj
-                 split: Structures_A.kernel_object.splits)
+                 split: Structures_A.kernel_object.splits
+                 dest!: readObject_misc_ko_at')
   apply (clarsimp simp: state_relation_def pspace_relation_def obj_at'_def projectKOs)
   apply (drule bspec)
    apply blast
@@ -1958,25 +1964,25 @@ lemma ovalid_threadRead:
   "o\<lbrace>\<lambda>s. tcb_at' t s \<longrightarrow> (\<exists>tcb. ko_at' tcb t s \<and> P (f tcb) s)\<rbrace>
     threadRead f t \<lbrace>P\<rbrace>"
   by (clarsimp simp: threadRead_def oliftM_def obind_def obj_at'_def ovalid_def
-        split: option.split_asm)
+        split: option.split_asm dest!: readObject_misc_ko_at')
 
 lemma ovalid_readMapScPtr:
   "o\<lbrace>\<lambda>s. sc_at' scPtr s \<longrightarrow> (\<exists>sc. ko_at' sc scPtr s \<and> P (f sc) s)\<rbrace> readMapScPtr scPtr f \<lbrace>P\<rbrace>"
   apply (clarsimp simp: readMapScPtr_def oliftM_def obind_def obj_at'_def ovalid_def
                         readSchedContext_def
-                 split: option.split_asm)
+                 split: option.split_asm dest!: readObject_misc_ko_at')
   done
 
 lemma ovalid_threadRead_sp:
   "o\<lbrace>P\<rbrace> threadRead f ptr \<lbrace>\<lambda>rv s. \<exists>tcb :: tcb. ko_at' tcb ptr s \<and> f tcb = rv \<and> P s\<rbrace>"
   by (clarsimp simp: threadRead_def oliftM_def obind_def obj_at'_def ovalid_def
-        split: option.split_asm)
+        split: option.split_asm dest!: readObject_misc_ko_at')
 
 lemma ovalid_readMapScPtr_sp:
   "o\<lbrace>P\<rbrace> readMapScPtr ptr f \<lbrace>\<lambda>rv s. \<exists>sc :: sched_context. ko_at' sc ptr s \<and> f sc = rv \<and> P s\<rbrace>"
   apply (clarsimp simp: readMapScPtr_def readSchedContext_def oliftM_def obind_def obj_at'_def
                         ovalid_def
-                 split: option.split_asm)
+                 split: option.split_asm dest!: readObject_misc_ko_at')
   done
 
 lemma no_fail_threadGet [wp]:
@@ -3811,7 +3817,8 @@ lemma getObject_sc_wp:
   "\<lbrace>\<lambda>s. sc_at' p s \<longrightarrow> (\<exists>t::sched_context. ko_at' t p s \<and> Q t s)\<rbrace> getObject p \<lbrace>Q\<rbrace>"
   by (clarsimp simp: getObject_def valid_def in_monad
                      split_def objBits_simps' loadObject_default_def
-                     projectKOs obj_at'_def in_magnitude_check)
+                     projectKOs obj_at'_def in_magnitude_check
+              dest!: readObject_misc_ko_at')
 
 lemma getMapScPtr_getObject:
   "getMapScPtr t f = do x \<leftarrow> getObject t;
@@ -3879,7 +3886,9 @@ lemma ovalid_readRefillReady[rule_format, simp]:
               (readRefillReady scp) P"
   unfolding readRefillReady_def readSchedContext_def ovalid_def
   by (fastforce simp: obind_def split: option.split_asm
-                dest: use_ovalid[OF ovalid_readCurTime])
+                dest: use_ovalid[OF ovalid_readCurTime]
+               dest!: readObject_misc_ko_at')
+
 
 lemma refillReady_wp:
   "\<lbrace>\<lambda>s. \<forall>ko. ko_at' ko scp s \<longrightarrow> P (rTime (refillHd ko) \<le> ksCurTime s + kernelWCETTicks) s\<rbrace> refillReady scp \<lbrace>P\<rbrace>"
@@ -4220,7 +4229,9 @@ lemma getObject_tcb_wp:
   "\<lbrace>\<lambda>s. tcb_at' p s \<longrightarrow> (\<exists>t::tcb. ko_at' t p s \<and> Q t s)\<rbrace> getObject p \<lbrace>Q\<rbrace>"
   by (clarsimp simp: getObject_def valid_def in_monad
                      split_def objBits_simps' loadObject_default_def
-                     projectKOs obj_at'_def in_magnitude_check)
+                     projectKOs obj_at'_def in_magnitude_check
+              dest!: readObject_misc_ko_at')
+
 
 lemma threadSet_tcbSCs_of:
   "\<lbrace>\<lambda>s. P (\<lambda>a. if a = t then tcbSchedContext (f (the (tcbs_of' s a))) else tcbSCs_of s a)\<rbrace>

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -1333,7 +1333,7 @@ lemma updateReply_sr_inv:
   apply (clarsimp simp: setReply_def getReply_def getObject_def setObject_def projectKOs
                         updateObject_default_def loadObject_default_def split_def
                         in_monad return_def fail_def objBits_simps' in_magnitude_check
-                 split: if_split_asm option.split_asm)
+                 split: if_split_asm option.split_asm dest!: readObject_misc_ko_at')
   apply (rename_tac reply')
   apply (prop_tac "ko_at' reply' rp s'")
    apply (clarsimp simp: obj_at'_def objBits_simps' projectKOs)
@@ -1366,7 +1366,7 @@ lemma updateReply_sr_inv_next:
   apply (clarsimp simp: setReply_def getReply_def getObject_def setObject_def projectKOs
                         updateObject_default_def loadObject_default_def split_def
                         in_monad return_def fail_def objBits_simps' in_magnitude_check
-                 split: if_split_asm option.split_asm)
+                 split: if_split_asm option.split_asm dest!: readObject_misc_ko_at')
   apply (rename_tac reply')
   apply (frule (1) pspace_relation_reply_at[OF state_relation_pspace_relation])
   apply (clarsimp simp: obj_at_def is_reply obj_at'_def projectKOs)

--- a/proof/refine/ARM/SchedContext_R.thy
+++ b/proof/refine/ARM/SchedContext_R.thy
@@ -43,7 +43,8 @@ lemma valid_sched_context_size'_scConsumed_update[simp]:
 lemma readSchedContext_SomeD:
   "readSchedContext scp s = Some sc'
    \<Longrightarrow> ksPSpace s scp = Some (KOSchedContext sc')"
-  by (clarsimp simp: readSchedContext_def asks_def obj_at'_def projectKOs)
+  by (clarsimp simp: readSchedContext_def asks_def obj_at'_def projectKOs
+              dest!: readObject_misc_ko_at')
 
 lemma sym_refs_tcbSchedContext:
   "\<lbrakk>ko_at' tcb tcbPtr s; sym_refs (state_refs_of' s); tcbSchedContext tcb = Some scPtr\<rbrakk>

--- a/proof/refine/ARM/SchedContext_R.thy
+++ b/proof/refine/ARM/SchedContext_R.thy
@@ -88,15 +88,15 @@ lemma setSchedContext_active_sc_at':
   apply (clarsimp simp: ko_wp_at'_def obj_at'_real_def)
   done
 
-lemma updateScPtr_invs':
+lemma updateSchedContext_invs':
   "\<lbrace>invs'
     and (\<lambda>s. scPtr = idle_sc_ptr \<longrightarrow> (\<forall>ko. ko_at' ko scPtr s \<longrightarrow> idle_sc' (f ko)))
     and (\<lambda>s. \<forall>ko. ko_at' ko scPtr s \<longrightarrow> live_sc' (f ko) \<longrightarrow> ex_nonz_cap_to' scPtr s)
     and (\<lambda>s. \<forall>ko. ko_at' ko scPtr s \<longrightarrow> valid_sched_context' (f ko) s
                                         \<and> valid_sched_context_size' (f ko))\<rbrace>
-    updateScPtr scPtr f
+    updateSchedContext scPtr f
     \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: updateScPtr_def)
+  apply (simp add: updateSchedContext_def)
   by (wpsimp wp: setSchedContext_invs')
 
 lemma sym_refs_sc_trivial_update:
@@ -118,7 +118,7 @@ lemma live_sc'_ko_ex_nonz_cap_to':
   apply (erule if_live_then_nonz_capE')
   by (clarsimp simp: ko_wp_at'_def obj_at'_real_def projectKO_sc)
 
-lemma updateScPtr_refills_invs':
+lemma updateSchedContext_refills_invs':
   "\<lbrace>invs'
     and (\<lambda>s. scPtr = idle_sc_ptr \<longrightarrow> (\<forall>ko. ko_at' ko scPtr s \<longrightarrow> idle_sc' (f ko)))
     and (\<lambda>s. \<forall>ko. ko_at' ko scPtr s \<longrightarrow> valid_sched_context' (f ko) s \<and> valid_sched_context_size' (f ko))
@@ -126,9 +126,9 @@ lemma updateScPtr_refills_invs':
     and (\<lambda>_. \<forall>ko. scTCB (f ko) = scTCB ko)
     and (\<lambda>_. \<forall>ko. scYieldFrom (f ko) = scYieldFrom ko)
     and (\<lambda>_. \<forall>ko. scReply (f ko) = scReply ko)\<rbrace>
-    updateScPtr scPtr f
+    updateSchedContext scPtr f
     \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: updateScPtr_def)
+  apply (simp add: updateSchedContext_def)
   apply (wpsimp wp: setSchedContext_invs')
   apply (intro conjI)
    apply fastforce
@@ -137,12 +137,12 @@ lemma updateScPtr_refills_invs':
   apply (clarsimp simp: live_sc'_def)
   done
 
-lemma updateScPtr_active_sc_at':
+lemma updateSchedContext_active_sc_at':
   "\<lbrace>active_sc_at' scPtr'
     and (\<lambda>s. scPtr = scPtr' \<longrightarrow> (\<forall>ko. ko_at' ko scPtr s \<longrightarrow> 0 < scRefillMax ko \<longrightarrow> 0 < scRefillMax (f ko)))\<rbrace>
-    updateScPtr scPtr f
+    updateSchedContext scPtr f
     \<lbrace>\<lambda>rv. active_sc_at' scPtr'\<rbrace>"
-  apply (simp add: updateScPtr_def)
+  apply (simp add: updateSchedContext_def)
   apply (wpsimp wp: setSchedContext_active_sc_at')
   apply (clarsimp simp: active_sc_at'_def obj_at'_real_def ko_wp_at'_def projectKO_sc)
   done
@@ -153,7 +153,7 @@ lemma invs'_ko_at_valid_sched_context':
   apply (drule (1) sc_ko_at_valid_objs_valid_sc', simp)
   done
 
-lemma updateScPtr_invs'_indep:
+lemma updateSchedContext_invs'_indep:
   "\<lbrace>invs' and (\<lambda>s. scPtr = idle_sc_ptr \<longrightarrow> (\<forall>ko. ko_at' ko scPtr s \<longrightarrow> idle_sc' (f ko)))
     and (\<lambda>s. \<forall>ko. valid_sched_context' ko s \<longrightarrow> valid_sched_context' (f ko) s)
     and (\<lambda>_. \<forall>ko. valid_sched_context_size' ko \<longrightarrow> valid_sched_context_size' (f ko))
@@ -161,9 +161,9 @@ lemma updateScPtr_invs'_indep:
                   \<and> scTCB (f ko) = scTCB ko
                   \<and> scYieldFrom (f ko) = scYieldFrom ko
                   \<and> scReply (f ko) = scReply ko )\<rbrace>
-    updateScPtr scPtr f
+    updateSchedContext scPtr f
     \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (wpsimp wp: updateScPtr_invs')
+  apply (wpsimp wp: updateSchedContext_invs')
   apply (intro conjI; intro allI impI; (drule_tac x=ko in spec)+)
    apply (clarsimp simp: invs'_def valid_state'_def valid_objs'_def obj_at'_def)
    apply (erule if_live_then_nonz_capE')

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -2296,7 +2296,8 @@ lemma refillPopHead_valid_objs'[wp]:
   apply (clarsimp simp: readMapScPtr_def readRefillNext_def readSchedContext_def)
   apply (fastforce simp: obj_at'_def projectKOs vs_all_heap_simps pred_map_simps
                          valid_sched_context'_def valid_sched_context_size'_def objBits_simps'
-                         scBits_simps)
+                         scBits_simps
+                  dest!: readObject_misc_ko_at')
   done
 
 lemma refillPopHead_invs'[wp]:
@@ -3440,7 +3441,7 @@ lemma refillReady_corres:
   apply (drule_tac x=s and y=sc_ptr in meta_spec2, clarsimp)
   apply (clarsimp simp: read_sc_refill_ready_simp readRefillReady_simp readSchedContext_def
                         read_sched_context_def
-                 split: option.splits)
+                 split: option.splits dest!: readObject_misc_ko_at')
   apply (frule active_sc_valid_refillsE[rotated])
    apply (fastforce simp: is_sc_active_kh_simp)
   apply (rename_tac n sc' sc)

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -20,7 +20,8 @@ declare complement_def[simp]
 
 lemma threadRead_SomeD:
   "threadRead f t s = Some y \<Longrightarrow> \<exists>tcb. ko_at' tcb t s \<and> y = f tcb"
-  by (fastforce simp: threadRead_def oliftM_def)
+  by (fastforce simp: threadRead_def oliftM_def dest!: readObject_misc_ko_at')
+
 
 (* Auxiliaries and basic properties of priority bitmap functions *)
 
@@ -490,8 +491,8 @@ lemma tcb_update_corres:
   apply (rule corres_guard_imp)
     apply (erule (3) tcb_update_corres', force)
   apply (clarsimp simp: getObject_def in_monad split_def obj_at'_def
-                        loadObject_default_def projectKOs objBits_simps'
-                        in_magnitude_check)
+                        loadObject_default_def projectKOs objBits_simps' in_magnitude_check
+                 dest!: readObject_misc_ko_at')
   done
 
 lemma assert_get_tcb_corres:

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -2982,7 +2982,8 @@ lemma get_sc_released_corres:
   apply (rule corres_symb_exec_l[rotated 2, OF gets_sp]; (solves wpsimp)?)
   apply (rule corres_symb_exec_r[rotated, OF gets_the_sp]; (solves wpsimp)?)
    apply (wpsimp wp: no_ofail_gets_the readRefillReady_no_ofail)
-  apply (clarsimp simp: sc_released_def readRefillReady_def readSchedContext_def)
+  apply (clarsimp simp: sc_released_def readRefillReady_def readSchedContext_def
+                 dest!: readObject_misc_ko_at')
   apply normalise_obj_at'
   apply (subgoal_tac "sc_active sc = (0 < scRefillMax v')")
    apply (case_tac "sc_active sc"; clarsimp)

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -1007,7 +1007,7 @@ On some architectures, the thread context may include registers that may be modi
 >     ifM (isRoundRobin scPtr)
 >       (refillResetRR scPtr)
 >       (refillBudgetCheck consumed)
->     updateScPtr scPtr $ \sc -> sc { scConsumed = scConsumed sc + consumed }
+>     updateSchedContext scPtr $ \sc -> sc { scConsumed = scConsumed sc + consumed }
 >     setConsumedTime 0
 >     whenM ((return isCurCPU) `andM` (getCurThread >>= isSchedulable)) $ do
 >       endTimeslice canTimeoutFault


### PR DESCRIPTION
This is some cleanup, mainly on Haskell, that came up in Michael’s Overrun PR (and others).

I did this as part of the work to finish Refill corres PR, but the cleanup here also overlaps with the Schedule proofs that Mitch wants me to look at, in that both the PRs want `no_ofail` proof for ‘refillHeadOverlapping`. All things considered, I think it makes sense to have this change merged before working on that lemma and other related ones.

the changes included are:
- remove `readMapScPtr` (because this was an extra layer of definition that we could do without)
- cleanup for `updateSchedContext`
- remove dest! attribute for `readObject_misc_ko_at’`
  (we do need to add it quite often, but there are cases when we specifically don’t want it, and it is harder to figure out when the lemma is added by default that we need to remove it)
