### PR TITLE
A small improvement to `rec_del_termination`

### DIFF
--- a/proof/invariant-abstract/ARM/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchCNodeInv_AI.thy
@@ -229,15 +229,6 @@ lemma vs_cap_ref_update_cap_data[simp, CNodeInv_AI_assms]:
          split: cap.split)
 
 
-lemma in_preempt[simp, intro, CNodeInv_AI_assms]:
-  "(Inr rv, s') \<in> fst (preemption_point s) \<Longrightarrow>
-  (\<exists>f es. s' = s \<lparr> machine_state := machine_state s \<lparr> irq_state := f (irq_state (machine_state s)) \<rparr>, exst := es\<rparr>)"
-  apply (clarsimp simp: preemption_point_def in_monad do_machine_op_def
-                        return_def returnOk_def throwError_def o_def
-                        select_f_def select_def getActiveIRQ_def)
-  done
-
-
 lemma invs_irq_state_independent[intro!, simp, CNodeInv_AI_assms]:
   "invs (s\<lparr>machine_state := machine_state s\<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>)
    = invs s"

--- a/proof/invariant-abstract/ARM/ArchLevityCatch_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchLevityCatch_AI.thy
@@ -55,18 +55,6 @@ lemma asid_high_bits_of_add:
               simp: asid_low_bits_def word_bits_def nth_ucast)
   done
 
-lemma preemption_point_success [simp,intro]:
-  "((Inr (), s') \<in> fst (preemption_point s)) \<Longrightarrow>
-  \<exists>f es. s' = s \<lparr> machine_state := machine_state s \<lparr> irq_state := f (irq_state (machine_state s)) \<rparr>, exst := es \<rparr>"
-  apply (auto simp: in_monad preemption_point_def do_machine_op_def
-                    select_f_def select_def getActiveIRQ_def alternative_def
-                    do_extended_op_def OR_choiceE_def mk_ef_def
-             split: option.splits if_splits
-             intro: exI[where x=id])
-      apply (rule_tac x=Suc in exI, rule_tac x="exst bb" in exI, force)+
-    apply (rule_tac x=id in exI, rule_tac x="exst b" in exI, force)+
-    done
-
 lemma pageBits_less_word_bits [simp]:
   "pageBits < word_bits" by (simp add: pageBits_def word_bits_conv)
 

--- a/proof/invariant-abstract/ARM_HYP/ArchLevityCatch_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchLevityCatch_AI.thy
@@ -55,18 +55,6 @@ lemma asid_high_bits_of_add:
               simp: asid_low_bits_def word_bits_def nth_ucast)
   done
 
-lemma preemption_point_success [simp,intro]:
-  "((Inr (), s') \<in> fst (preemption_point s)) \<Longrightarrow>
-  \<exists>f es. s' = s \<lparr> machine_state := machine_state s \<lparr> irq_state := f (irq_state (machine_state s)) \<rparr>, exst := es \<rparr>"
-  apply (auto simp: in_monad preemption_point_def do_machine_op_def
-                    select_f_def select_def getActiveIRQ_def alternative_def
-                    do_extended_op_def OR_choiceE_def mk_ef_def
-             split: option.splits if_splits
-             intro: exI[where x=id])
-      apply (rule_tac x=Suc in exI, rule_tac x="exst bb" in exI, force)+
-    apply (rule_tac x=id in exI, rule_tac x="exst b" in exI, force)+
-    done
-
 lemma pageBits_less_word_bits [simp]:
   "pageBits < word_bits" by (simp add: pageBits_def word_bits_conv)
 

--- a/proof/invariant-abstract/RISCV64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchCNodeInv_AI.thy
@@ -235,15 +235,6 @@ lemma vs_cap_ref_update_cap_data[simp, CNodeInv_AI_assms]:
          split: arch_cap.splits cap.split if_splits)
 
 
-lemma in_preempt[simp, intro, CNodeInv_AI_assms]:
-  "(Inr rv, s') \<in> fst (preemption_point s) \<Longrightarrow>
-  (\<exists>f es. s' = s \<lparr> machine_state := machine_state s \<lparr> irq_state := f (irq_state (machine_state s)) \<rparr>, exst := es\<rparr>)"
-  apply (clarsimp simp: preemption_point_def in_monad do_machine_op_def
-                        return_def returnOk_def throwError_def o_def
-                        select_f_def select_def getActiveIRQ_def)
-  done
-
-
 lemmas [CNodeInv_AI_assms] = invs_irq_state_independent
 
 lemma cte_at_nat_to_cref_zbits [CNodeInv_AI_assms]:

--- a/proof/invariant-abstract/RISCV64/ArchLevityCatch_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchLevityCatch_AI.thy
@@ -56,18 +56,6 @@ lemma asid_high_bits_of_add:
               simp: asid_low_bits_def nth_ucast)
   done
 
-lemma preemption_point_success [simp,intro]:
-  "((Inr (), s') \<in> fst (preemption_point s)) \<Longrightarrow>
-  \<exists>f es. s' = s \<lparr> machine_state := machine_state s \<lparr> irq_state := f (irq_state (machine_state s)) \<rparr>, exst := es \<rparr>"
-  apply (auto simp: in_monad preemption_point_def do_machine_op_def
-                    select_f_def select_def getActiveIRQ_def alternative_def
-                    do_extended_op_def OR_choiceE_def mk_ef_def
-             split: option.splits if_splits
-             intro: exI[where x=id])
-      apply (rule_tac x=Suc in exI, rule_tac x="exst bb" in exI, force)+
-    apply (rule_tac x=id in exI, rule_tac x="exst b" in exI, force)+
-    done
-
 lemma pageBits_less_word_bits [simp]:
   "pageBits < word_bits" by (simp add: pageBits_def word_bits_conv)
 

--- a/proof/invariant-abstract/X64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/X64/ArchCNodeInv_AI.thy
@@ -236,15 +236,6 @@ lemma vs_cap_ref_update_cap_data[simp, CNodeInv_AI_assms]:
          split: arch_cap.splits cap.split if_splits)
 
 
-lemma in_preempt[simp, intro, CNodeInv_AI_assms]:
-  "(Inr rv, s') \<in> fst (preemption_point s) \<Longrightarrow>
-  (\<exists>f es. s' = s \<lparr> machine_state := machine_state s \<lparr> irq_state := f (irq_state (machine_state s)) \<rparr>, exst := es\<rparr>)"
-  apply (clarsimp simp: preemption_point_def in_monad do_machine_op_def
-                        return_def returnOk_def throwError_def o_def
-                        select_f_def select_def getActiveIRQ_def)
-  done
-
-
 lemma invs_irq_state_independent[intro!, simp, CNodeInv_AI_assms]:
   "invs (s\<lparr>machine_state := machine_state s\<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>)
    = invs s"

--- a/proof/invariant-abstract/X64/ArchLevityCatch_AI.thy
+++ b/proof/invariant-abstract/X64/ArchLevityCatch_AI.thy
@@ -56,18 +56,6 @@ lemma asid_high_bits_of_add:
               simp: asid_low_bits_def nth_ucast)
   done
 
-lemma preemption_point_success [simp,intro]:
-  "((Inr (), s') \<in> fst (preemption_point s)) \<Longrightarrow>
-  \<exists>f es. s' = s \<lparr> machine_state := machine_state s \<lparr> irq_state := f (irq_state (machine_state s)) \<rparr>, exst := es \<rparr>"
-  apply (auto simp: in_monad preemption_point_def do_machine_op_def
-                    select_f_def select_def getActiveIRQ_def alternative_def
-                    do_extended_op_def OR_choiceE_def mk_ef_def
-             split: option.splits if_splits
-             intro: exI[where x=id])
-      apply (rule_tac x=Suc in exI, rule_tac x="exst bb" in exI, force)+
-    apply (rule_tac x=id in exI, rule_tac x="exst b" in exI, force)+
-    done
-
 lemma pageBits_less_word_bits [simp]:
   "pageBits < word_bits" by (simp add: pageBits_def word_bits_conv)
 


### PR DESCRIPTION
The improvements are:
* add comments into proof
* unwind some automation to clarify how each subgoal is solved.
* Remove some awkward "in monad" lemmas about `premption_point`