### PR TITLE
Incremental progress towards `schedule_corres`

### DIFF
--- a/lib/LemmaBucket.thy
+++ b/lib/LemmaBucket.thy
@@ -11,9 +11,14 @@ imports
   SubMonadLib
 begin
 
+lemma corres_underlying_trivial_gen:
+  "\<lbrakk> nf' \<Longrightarrow> no_fail P' f; \<forall>x. rr x x \<rbrakk> \<Longrightarrow>
+  corres_underlying Id nf nf' rr P P' f f"
+  by (auto simp add: corres_underlying_def Id_def no_fail_def)
+
 lemma corres_underlying_trivial:
   "\<lbrakk> nf' \<Longrightarrow> no_fail P' f \<rbrakk> \<Longrightarrow> corres_underlying Id nf nf' (=) \<top> P' f f"
-  by (auto simp add: corres_underlying_def Id_def no_fail_def)
+  by (erule corres_underlying_trivial_gen, simp)
 
 lemma hoare_spec_gen_asm:
   "\<lbrakk> F \<Longrightarrow> s \<turnstile> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> s \<turnstile> \<lbrace>P and K F\<rbrace> f \<lbrace>Q\<rbrace>"

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -3213,6 +3213,7 @@ lemma schedule_invs':
   apply (rule_tac hoare_seq_ext, rename_tac t)
    apply (rule_tac Q="invs'" in hoare_weaken_pre)
     apply (rule_tac hoare_seq_ext[OF _ getCurThread_sp])
+    apply (rule_tac hoare_seq_ext[OF _ isSchedulable_sp])
     apply (rule_tac hoare_seq_ext[OF _ getSchedulerAction_sp])
     apply (rule hoare_seq_ext)
      apply (wpsimp wp: switchSchedContext_invs')
@@ -3227,7 +3228,7 @@ lemma schedule_invs':
             apply (wpsimp simp: isHighestPrio_def')
            apply (wpsimp wp: curDomain_wp)
           apply (wpsimp simp: scheduleSwitchThreadFastfail_def)
-         apply (rename_tac tPtr isSchedulable x idleThread targetPrio)
+         apply (rename_tac tPtr x idleThread targetPrio)
          apply (rule_tac Q="\<lambda>_. invs' and st_tcb_at' runnable' tPtr and (\<lambda>s. action = ksSchedulerAction s)
                                 and tcb_in_cur_domain' tPtr" in hoare_strengthen_post[rotated])
           apply (prop_tac "st_tcb_at' runnable' tPtr s \<Longrightarrow> obj_at' (\<lambda>a. activatable' (tcbState a)) tPtr s")
@@ -3236,13 +3237,13 @@ lemma schedule_invs':
            apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def invs'_def valid_state'_def)
           apply fastforce
          apply (wpsimp wp: threadGet_wp hoare_drop_imp hoare_vcg_ex_lift)
-        apply (rename_tac tPtr isSchedulable x idleThread)
+        apply (rename_tac tPtr x idleThread)
         apply (rule_tac Q="\<lambda>_. invs'
                                and st_tcb_at' runnable' tPtr and (\<lambda>s. action = ksSchedulerAction s)
                                and tcb_in_cur_domain' tPtr" in hoare_strengthen_post[rotated])
          apply (subst obj_at_ko_at'_eq[symmetric], simp)
         apply (wpsimp wp: threadGet_wp hoare_drop_imp hoare_vcg_ex_lift)
-       apply (rename_tac tPtr isSchedulable x)
+       apply (rename_tac tPtr x)
        apply (rule_tac Q="\<lambda>_. invs'
                               and st_tcb_at' runnable' tPtr and (\<lambda>s. action = ksSchedulerAction s)
                               and tcb_in_cur_domain' tPtr" in hoare_strengthen_post[rotated])

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -252,6 +252,23 @@ definition sc_relation ::
      sc_badge sc = scBadge sc' \<and>
      sc_yield_from sc = scYieldFrom sc'"
 
+
+(* Most sched contexts should satisfy these conditions. The lemma below (valid_refills'_common_usage)
+   illustrates a common situation where these conditions hold.
+
+   It seems clear that an abbreviation of this kind is useful, but it's not clear exactly which
+   conditions it should contain. For instance, it does not contain "0 < scRefillMax sc" which one
+   may argue is equally standard.
+*)
+abbreviation (input) valid_refills' where
+  "valid_refills' sc \<equiv> scRefillMax sc \<le> length (scRefills sc) \<and> scRefillHead sc < scRefillMax sc \<and>
+                    scRefillCount sc \<le> scRefillMax sc \<and> 0 < scRefillCount sc"
+
+lemma valid_refills'_common_usage:
+  "\<exists>n. sc_relation sc n sc' \<Longrightarrow> sc_active sc \<Longrightarrow> sc_valid_refills sc \<Longrightarrow> valid_sched_context' sc' s'
+   \<Longrightarrow> valid_refills' sc'"
+  by (clarsimp simp: sc_valid_refills_def valid_sched_context'_def active_sc_def sc_relation_def)
+
 definition reply_relation :: "Structures_A.reply \<Rightarrow> Structures_H.reply \<Rightarrow> bool" where
   "reply_relation \<equiv> \<lambda>reply reply'.
      reply_sc reply = replySC reply' \<and> reply_tcb reply = replyTCB reply'"


### PR DESCRIPTION
This is incremental progress towards `schedule_corres`. The main contributions are:
* `setNextInterrupt_corres`
* `getReprogramTimer_corres`
* `setDomainTime_corres`
* `setConsumedTime_corres`
* `setCurSc_corres`
* `machine_op_lift_corres_trivial`
* `refillSingle_corres`

This also introduces `standard_sc` which might be useful, I'd appreciate some feedback on that.