### PR TITLE
refill spec cleanup WIP

### DIFF
--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -7151,7 +7151,8 @@ lemma refill_update_is_active_sc[wp]:
    \<lbrace>\<lambda>rv s. Q (is_active_sc scp s)\<rbrace>"
   unfolding refill_update_def refill_add_tail_def
             update_sched_context_set_refills_rewrite update_refill_hd_rewrite
-  by (wpsimp wp: hoare_drop_imps simp: set_refills_def)
+  apply (wpsimp wp: set_refills_wp hoare_drop_imps get_refills_wp update_sched_context_wp)
+  by (clarsimp simp: obj_at_def vs_all_heap_simps)
 
 lemma refill_new_is_active_sc[wp]:
   "\<lbrace>\<lambda>s. if scp = sc_ptr
@@ -15510,8 +15511,8 @@ lemma refill_update_not_active_sc:
    \<lbrace>\<lambda>rv s.  \<not> pred_map active_scrc (sc_refill_cfgs_of s) scp\<rbrace>"
   unfolding refill_update_def refill_add_tail_def update_refill_tl_def
             update_refill_hd_def update_sched_context_set_refills_rewrite
-  apply (wpsimp wp: hoare_drop_imps simp: set_refills_def)
-  by (clarsimp simp: active_sc_def)
+  apply (wpsimp wp: set_refills_wp get_refills_wp update_sched_context_wp)
+  by (clarsimp simp: obj_at_def vs_all_heap_simps active_sc_def)
 
 lemma refill_update_bounded_release_time:
   "\<lbrace>bounded_release_time scp and current_time_bounded 2

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -7139,6 +7139,7 @@ lemma refill_unblock_check_is_active_sc_at[wp]:
   "refill_unblock_check sc_ptr \<lbrace>\<lambda>s. Q (is_active_sc scp s)\<rbrace>"
   apply (clarsimp simp: refill_unblock_check_defs)
   apply (wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
+              simp: update_sched_context_set_refills_rewrite
          | clarsimp simp: vs_all_heap_simps active_sc_def obj_at_kh_kheap_simps pred_map_simps)+
   done
 
@@ -7148,9 +7149,9 @@ lemma refill_update_is_active_sc[wp]:
         else Q (is_active_sc scp s)\<rbrace>
    refill_update sc_ptr period budget mrefills
    \<lbrace>\<lambda>rv s. Q (is_active_sc scp s)\<rbrace>"
-  unfolding refill_update_def set_refills_def refill_add_tail_def update_refill_tl_def
-            update_refill_hd_def
-  by (wpsimp wp: hoare_drop_imps)
+  unfolding refill_update_def refill_add_tail_def
+            update_sched_context_set_refills_rewrite update_refill_hd_rewrite
+  by (wpsimp wp: hoare_drop_imps simp: set_refills_def)
 
 lemma refill_new_is_active_sc[wp]:
   "\<lbrace>\<lambda>s. if scp = sc_ptr
@@ -7230,6 +7231,7 @@ lemma refill_head_overlapping_refills_not_overlapping:
 
 method merge_refills_simple
   = (clarsimp simp: merge_refills_def refill_pop_head_def merge_refill_def
+                    update_sched_context_set_refills_rewrite update_refill_hd_rewrite
      , wpsimp wp: set_refills_wp get_refills_wp
      , (clarsimp simp: vs_all_heap_simps obj_at_kh_kheap_simps pred_map_simps refills_sum_def)?)
 
@@ -7536,7 +7538,8 @@ lemma refill_head_overlapping_loop_ordered_disjoint_strong:
    apply (wpsimp wp: merge_refills_refills_unat_sum)
    apply (fastforce intro!: refill_head_overlapping_true_imp_length_at_least_two
                       simp: vs_all_heap_simps)
-  apply (wpsimp simp: merge_refills_def refill_pop_head_def
+  apply (wpsimp simp: merge_refills_def refill_pop_head_def update_refill_hd_rewrite
+                      update_sched_context_set_refills_rewrite
                   wp: set_refills_wp get_refills_wp)
   apply (clarsimp simp: vs_all_heap_simps obj_at_def)
   apply (blast dest: ordered_disjoint_sublist)
@@ -7606,6 +7609,7 @@ lemma head_insufficient_false_imp_sufficient:
 
 method non_overlapping_merge_refills_simple
   = (clarsimp simp: non_overlapping_merge_refills_def refill_pop_head_def merge_refill_def
+                    update_refill_hd_rewrite update_sched_context_set_refills_rewrite
      , wpsimp wp: set_refills_wp get_refills_wp
      , (clarsimp simp: vs_all_heap_simps obj_at_def)?)
 
@@ -7696,7 +7700,8 @@ lemma head_insufficient_loop_refills_sum:
     apply (fastforce dest: head_insufficient_length_at_least_two)
    apply (wpsimp wp: non_overlapping_merge_refills_refills_unat_sum)
    apply (fastforce dest: head_insufficient_length_at_least_two)
-  apply (clarsimp simp: non_overlapping_merge_refills_def refill_pop_head_def merge_refill_def)
+  apply (clarsimp simp: non_overlapping_merge_refills_def refill_pop_head_def merge_refill_def
+                        update_refill_hd_rewrite update_sched_context_set_refills_rewrite)
   apply (wpsimp wp: set_refills_wp get_refills_wp)
   apply (frule head_insufficient_length_at_least_two, clarsimp)
   apply (clarsimp simp: vs_all_heap_simps obj_at_kh_kheap_simps pred_map_simps)
@@ -7748,7 +7753,8 @@ lemma head_insufficient_loop_refills_unat_sum_equals_budget:
     apply (fastforce dest: head_insufficient_length_at_least_two)
    apply (wpsimp wp: non_overlapping_merge_refills_refills_unat_sum)
    apply (fastforce dest: head_insufficient_length_at_least_two)
-  apply (clarsimp simp: non_overlapping_merge_refills_def refill_pop_head_def merge_refill_def)
+  apply (clarsimp simp: non_overlapping_merge_refills_def refill_pop_head_def merge_refill_def
+                        update_sched_context_set_refills_rewrite update_refill_hd_rewrite)
   apply (wpsimp wp: set_refills_wp get_refills_wp)
   apply (frule head_insufficient_length_at_least_two, clarsimp)
   apply (clarsimp simp: vs_all_heap_simps obj_at_kh_kheap_simps pred_map_simps)
@@ -7799,7 +7805,7 @@ lemma non_overlapping_merge_refills_ordered_disjoint:
   apply (rename_tac list)
   apply (case_tac list; (solves simp)?)
   apply (fastforce dest: non_overlapping_merge_refills_ordered_disjoint_helper
-                   simp: add_ac)
+                   simp: add_ac cong: refill.ext_split)
   done
 
 lemma head_insufficient_loop_ordered_disjoint:
@@ -7873,7 +7879,7 @@ lemma non_overlapping_merge_refills_no_overflow:
   apply (rename_tac list)
   apply (case_tac list; (solves simp)?)
   apply (fastforce dest: non_overlapping_merge_refills_no_overflow_helper
-                   simp: add_ac)
+                   simp: add_ac cong: refill.ext_split)
   done
 
 lemma head_insufficient_loop_no_overflow:
@@ -7921,7 +7927,8 @@ lemma head_insufficient_loop_refills_window:
     apply (fastforce dest: head_insufficient_length_at_least_two)
    apply (wpsimp wp: non_overlapping_merge_refills_refills_unat_sum)
    apply (fastforce dest: head_insufficient_length_at_least_two)
-  apply (clarsimp simp: non_overlapping_merge_refills_def refill_pop_head_def merge_refill_def)
+  apply (clarsimp simp: non_overlapping_merge_refills_def refill_pop_head_def merge_refill_def
+                        update_sched_context_set_refills_rewrite update_refill_hd_rewrite)
   apply (wpsimp wp: set_refills_wp get_refills_wp)
   apply (frule head_insufficient_length_at_least_two, clarsimp)
   apply (clarsimp simp: vs_all_heap_simps refills_unat_sum_def obj_at_def window_def)
@@ -7979,7 +7986,8 @@ lemma head_insufficient_loop_hd_r_time:
                  in ordered_disjoint_no_overflow_implies_sorted
           ; fastforce?)
    apply (simp add: hd_conv_nth last_conv_nth unat_arith_simps(1))
-  apply (clarsimp simp: non_overlapping_merge_refills_def refill_pop_head_def merge_refill_def)
+  apply (clarsimp simp: non_overlapping_merge_refills_def refill_pop_head_def merge_refill_def
+                        update_sched_context_set_refills_rewrite update_refill_hd_rewrite)
   apply (wpsimp wp: set_refills_wp get_refills_wp)
   apply (frule head_insufficient_length_at_least_two, clarsimp)
   apply (clarsimp simp: vs_all_heap_simps obj_at_def)
@@ -8124,7 +8132,7 @@ lemma refill_unblock_check_is_refill_sufficient[wp]:
        \<lbrace>\<lambda>_. is_refill_sufficient usage sc_ptr'\<rbrace>"
   supply round_robin_def[simp add]
   apply (subst is_refill_sufficient_alt, simp)+
-  apply (clarsimp simp: refill_unblock_check_def set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: refill_unblock_check_def bind_assoc update_refill_hd_rewrite)
   apply (rule hoare_seq_ext[OF _ is_round_robin_sp])
   apply (rule hoare_seq_ext_skip, wpsimp)
   apply (rule hoare_when_cases, simp)
@@ -8135,7 +8143,7 @@ lemma refill_unblock_check_is_refill_sufficient[wp]:
    apply (wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
                simp: merge_refills_def refill_pop_head_def head_insufficient_loop_def
                      refill_head_overlapping_loop_def non_overlapping_merge_refills_def
-                     vs_all_heap_simps)
+                     vs_all_heap_simps update_refill_hd_rewrite update_sched_context_set_refills_rewrite)
 
   apply (rename_tac refills)
   apply (rule_tac Q="\<lambda>s. pred_map (\<lambda>cfg. refills_unat_sum (scrc_refills cfg) \<le> unat max_time)
@@ -8831,14 +8839,11 @@ lemma refill_budget_sched_schedule_used_r_time_helper:
         \<and> cur_sc s = sc_ptr
         \<and> (\<exists>n. ko_at (SchedContext sc n) sc_ptr s \<and> refills = sc_refills sc)
         \<and> pred_map (\<lambda>cfg. usage < r_amount (hd (scrc_refills cfg))) (sc_refill_cfgs_of s) sc_ptr\<rbrace>
-   set_refills sc_ptr
-               (schedule_used full (\<lparr>r_time = r_time (hd refills)
-                                              + usage,
-                                     r_amount = r_amount (hd refills)
-                                                - usage\<rparr>
-                                    # tl (refills))
-                                   \<lparr>r_time = r_time (hd refills) + sc_period sc,
-                                    r_amount = usage\<rparr>)
+           set_refills sc_ptr
+             (schedule_used (length (sc_refills sc) = sc_refill_max sc)
+               (r_time_update (\<lambda>t. t + usage)
+                 (r_amount_update (\<lambda>m. m - usage) (hd refills)) #l refills)
+               \<lparr>r_time = r_time (refill_hd sc) + sc_period sc, r_amount = usage\<rparr>) 
    \<lbrace>\<lambda>_ s. pred_map (\<lambda>cfg. unat (r_time (scrc_refill_hd cfg)) + n * unat MAX_PERIOD
                            \<le> unat max_time)
                    (sc_refill_cfgs_of s) sc_ptr\<rbrace>"
@@ -8956,15 +8961,15 @@ lemma refill_single_sp:
 method handle_overrun_loop_body_simple
   = ((clarsimp simp: handle_overrun_loop_body_def)?
      , wpsimp wp: whileLoop_wp' set_refills_wp get_refills_wp
-            simp: refill_pop_head_def vs_all_heap_simps obj_at_def set_refill_hd_def
-                  update_refill_hd_def refill_single_def refill_size_def)
+            simp: refill_pop_head_def vs_all_heap_simps obj_at_def refill_single_def refill_size_def
+                  update_sched_context_set_refills_rewrite update_refill_hd_rewrite)
 
 method handle_overrun_loop_simple
   = ((clarsimp simp: handle_overrun_loop_def)?
      , wpsimp wp: whileLoop_wp' set_refills_wp get_refills_wp
             simp: handle_overrun_loop_body_def merge_refills_def round_robin_def refill_pop_head_def
-                  sc_valid_refills_def vs_all_heap_simps obj_at_def set_refill_hd_def
-                  update_refill_hd_def refill_budget_check_defs)
+                  sc_valid_refills_def vs_all_heap_simps obj_at_def refill_budget_check_defs
+                  update_sched_context_set_refills_rewrite)
 
 lemma handle_overrun_loop_body_nonzero_refills:
   "handle_overrun_loop_body usage
@@ -8995,12 +9000,12 @@ lemma handle_overrun_loop_body_refills_unat_sum_equals_budget:
   apply (rule hoare_seq_ext[OF _ get_sched_context_sp])
   apply (rule_tac B="\<lambda>_ s. ?post s" in hoare_seq_ext; (solves wpsimp)?)
   apply (rule hoare_if)
-   apply (wpsimp simp: set_refill_hd_def update_refill_hd_def
+   apply (wpsimp simp: update_sched_context_set_refills_rewrite update_refill_hd_rewrite
                    wp: set_refills_wp get_refills_wp)
    apply (clarsimp simp: vs_all_heap_simps obj_at_def refills_unat_sum_def)
    apply (rename_tac sc n)
    apply (case_tac "sc_refills sc"; clarsimp)
-  apply (wpsimp simp: refill_pop_head_def set_refill_hd_def update_refill_hd_def
+  apply (wpsimp simp: refill_pop_head_def update_sched_context_set_refills_rewrite update_refill_hd_rewrite
                   wp: set_refills_wp get_refills_wp)
   apply (clarsimp simp: vs_all_heap_simps obj_at_def refills_unat_sum_def)
   apply (subst schedule_used_unat_sum)
@@ -9042,11 +9047,11 @@ lemma handle_overrun_loop_body_window:
   apply (rule hoare_seq_ext[OF _ get_sched_context_sp])
   apply (rule_tac B="\<lambda>_ s. ?post s" in hoare_seq_ext; (solves wpsimp)?)
   apply (rule hoare_if)
-   apply (wpsimp simp: set_refill_hd_def update_refill_hd_def
+   apply (wpsimp simp: update_sched_context_set_refills_rewrite update_refill_hd_rewrite
                    wp: set_refills_wp get_refills_wp)
    apply (clarsimp simp: vs_all_heap_simps obj_at_def window_def)
    apply (simp add: less_not_refl2 tail_nonempty_length)
-  apply (wpsimp simp: refill_pop_head_def set_refill_hd_def update_refill_hd_def
+  apply (wpsimp simp: refill_pop_head_def update_sched_context_set_refills_rewrite update_refill_hd_rewrite
                   wp: set_refills_wp get_refills_wp)
   apply (clarsimp simp: vs_all_heap_simps obj_at_def window_def)
   apply (rename_tac sc n)
@@ -9129,10 +9134,10 @@ lemma handle_overrun_loop_body_ordered_disjoint:
   apply (rule hoare_seq_ext[OF _ get_sched_context_sp])
   apply (rule_tac B="\<lambda>_ s. ?post s" in hoare_seq_ext; (solves wpsimp)?)
   apply (rule hoare_if)
-   apply (wpsimp simp: refill_pop_head_def set_refill_hd_def update_refill_hd_def
+   apply (wpsimp simp: update_sched_context_set_refills_rewrite update_refill_hd_rewrite
                    wp: set_refills_wp get_refills_wp)
    apply (clarsimp simp: vs_all_heap_simps ordered_disjoint_def obj_at_kh_kheap_simps)
-  apply (wpsimp simp: refill_pop_head_def set_refill_hd_def update_refill_hd_def
+  apply (wpsimp simp: refill_pop_head_def update_sched_context_set_refills_rewrite update_refill_hd_rewrite
                   wp: set_refills_wp get_refills_wp)
   apply (clarsimp simp: vs_all_heap_simps obj_at_kh_kheap_simps pred_map_simps)
   apply (rule schedule_used_ordered_disjoint)
@@ -9207,7 +9212,8 @@ lemma schedule_used_hd_r_time_same:
   by (cases list; fastforce simp: schedule_used_def)
 
 method schedule_used_simple
-  = (wpsimp wp: set_refills_wp
+  = (wpsimp wp: set_refills_wp get_refills_wp
+          simp: update_refill_hd_rewrite update_sched_context_set_refills_rewrite
      , clarsimp simp: round_robin_def vs_all_heap_simps obj_at_def sc_valid_refills_def)
 
 lemma handle_overrun_loop_head_bound:
@@ -9274,7 +9280,7 @@ lemma handle_overrun_loop_head_bound:
 
   apply (rule hoare_if)
 
-   apply (clarsimp simp: set_refill_hd_def update_refill_hd_def)
+   apply (clarsimp simp: update_sched_context_set_refills_rewrite update_refill_hd_rewrite)
    apply (wpsimp wp: get_refills_wp set_refills_wp)
    apply (frule head_time_buffer_true_imp_unat_buffer)
     apply (fastforce simp: vs_all_heap_simps obj_at_kh_kheap_simps)
@@ -9396,12 +9402,12 @@ lemma handle_overrun_loop_body_refills_sum:
   apply (rule hoare_seq_ext[OF _ get_sched_context_sp])
   apply (rule_tac B="\<lambda>_ s. ?post s" in hoare_seq_ext; (solves wpsimp)?)
   apply (rule hoare_if)
-   apply (wpsimp simp: refill_pop_head_def set_refill_hd_def update_refill_hd_def
+   apply (wpsimp simp: update_sched_context_set_refills_rewrite update_refill_hd_rewrite
                    wp: set_refills_wp get_refills_wp)
    apply (clarsimp simp: vs_all_heap_simps obj_at_kh_kheap_simps)
    apply (rename_tac sc n)
    apply (case_tac "sc_refills sc"; clarsimp)
-  apply (wpsimp simp: refill_pop_head_def set_refill_hd_def update_refill_hd_def
+  apply (wpsimp simp: refill_pop_head_def update_sched_context_set_refills_rewrite update_refill_hd_rewrite
                   wp: set_refills_wp get_refills_wp)
   apply (clarsimp simp: vs_all_heap_simps obj_at_kh_kheap_simps pred_map_simps)
   apply (rename_tac sc n)
@@ -9425,6 +9431,7 @@ method head_insufficient_loop_simple
   = ((clarsimp simp: head_insufficient_loop_def)?
      , wpsimp wp: whileLoop_wp' set_refills_wp get_refills_wp
             simp: non_overlapping_merge_refills_def refill_pop_head_def
+                  update_sched_context_set_refills_rewrite update_refill_hd_rewrite
      , clarsimp simp: vs_all_heap_simps obj_at_def sc_valid_refills_def round_robin_def
      , fastforce?)
 
@@ -9432,6 +9439,7 @@ method refill_head_overlapping_loop_simple
   = ((clarsimp simp: refill_head_overlapping_loop_def)?
      , wpsimp wp: whileLoop_wp' set_refills_wp get_refills_wp
             simp: merge_refills_def round_robin_def refill_pop_head_def sc_valid_refills_def
+                  update_sched_context_set_refills_rewrite update_refill_hd_rewrite
                   vs_all_heap_simps obj_at_def)
 
 lemma head_insufficient_loop_round_robin[wp]:
@@ -9456,10 +9464,10 @@ lemma handle_overrun_loop_body_length:
   apply (rule hoare_seq_ext[OF _ get_sched_context_sp])
   apply (rule_tac B="\<lambda>_ s. ?post s" in hoare_seq_ext; (solves wpsimp)?)
   apply (rule hoare_if)
-   apply (wpsimp simp: refill_pop_head_def set_refill_hd_def update_refill_hd_def
+   apply (wpsimp simp: update_sched_context_set_refills_rewrite update_refill_hd_rewrite
                    wp: set_refills_wp get_refills_wp)
    apply (clarsimp simp: vs_all_heap_simps obj_at_kh_kheap_simps)
-  apply (wpsimp simp: refill_pop_head_def set_refill_hd_def update_refill_hd_def
+  apply (wpsimp simp: refill_pop_head_def update_sched_context_set_refills_rewrite update_refill_hd_rewrite
                   wp: set_refills_wp get_refills_wp)
   apply (clarsimp simp: vs_all_heap_simps obj_at_kh_kheap_simps pred_map_simps)
   apply (rename_tac sc n)
@@ -9495,10 +9503,10 @@ lemma refill_budget_check_valid_refills[wp]:
                             \<and> cur_sc s = csc_ptr"
                 in hoare_seq_ext[rotated])
     apply ((wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
-                 simp: refill_budget_check_defs
+                 simp: refill_budget_check_defs update_sched_context_set_refills_rewrite
            | fastforce simp: obj_at_def vs_all_heap_simps )+)[1]
    apply ((wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
-                simp: refill_budget_check_defs
+                simp: refill_budget_check_defs update_sched_context_set_refills_rewrite
           | fastforce simp: obj_at_def vs_all_heap_simps)+)[1]
 
   apply (rule_tac R1="\<lambda>s. pred_map (\<lambda>cfg. refills_unat_sum (scrc_refills cfg)
@@ -9550,41 +9558,18 @@ lemma refill_budget_check_valid_refills[wp]:
                                               = unat (scrc_budget cfg))
                                        (sc_refill_cfgs_of s) sc_ptr"
                in hoare_seq_ext[rotated])
-
    apply (rule hoare_when_cases, clarsimp simp: vs_all_heap_simps)
-   apply (rule hoare_seq_ext[OF _ get_refills_sp])
    apply (rule hoare_seq_ext[OF _ get_sched_context_sp])
-   apply (rule hoare_seq_ext[OF _ refill_full_sp])
    apply (intro hoare_vcg_conj_lift_pre_fix
           ; (solves schedule_used_simple)?)
-         apply (wpsimp wp: set_refills_wp
-                     simp: vs_all_heap_simps)
-         apply (clarsimp simp: sc_valid_refills_def refills_sum_def obj_at_def)
-         apply (rename_tac sc n)
-         apply (case_tac "sc_refills sc"; clarsimp)
-        apply (wpsimp wp: set_refills_wp)
-        apply (fastforce intro: refill_budget_check_ordered_disjoint_helper
-                          simp: word_le_nat_alt obj_at_def vs_all_heap_simps)
-       apply (wpsimp wp: set_refills_wp)
-       apply (fastforce intro!: refill_budget_check_no_overflow_schedule_used_helper
-                          simp: sc_valid_refills_def obj_at_def vs_all_heap_simps)
-      apply (wpsimp wp: set_refills_wp)
-      apply (fastforce intro: schedule_used_window
-                        simp: obj_at_def vs_all_heap_simps)
-     apply (wpsimp wp: set_refills_wp)
-     apply (fastforce simp: schedule_used_non_nil vs_all_heap_simps)
-    apply (wpsimp wp: set_refills_wp)
-    apply (fastforce intro: refill_budget_check_schedule_used_length_at_most_sc_refill_max
-                      simp: obj_at_def vs_all_heap_simps)
-   apply (wpsimp wp: set_refills_wp)
-   apply (fastforce intro: refill_budget_check_unat_sum_helper
-                     simp: obj_at_def vs_all_heap_simps)
 
-  apply (rule_tac Q="\<lambda>_ s. \<not> round_robin sc_ptr s \<and> sp_valid_refills_unbundled sc_ptr s"
-               in hoare_strengthen_post[rotated])
-   apply (fastforce simp: valid_refills_def vs_all_heap_simps)
-   apply (intro hoare_vcg_conj_lift_pre_fix
-          ; (solves head_insufficient_loop_simple)?)
+         apply (find_goal \<open>match conclusion in "\<lbrace>_\<rbrace> head_insufficient_loop _ \<lbrace>\<lambda>_. _\<rbrace>" \<Rightarrow> \<open>-\<close>\<close>)
+         apply (rule_tac Q="\<lambda>_ s. \<not> round_robin sc_ptr s \<and> sp_valid_refills_unbundled sc_ptr s"
+                      in hoare_strengthen_post[rotated])
+          apply (fastforce simp: valid_refills_def vs_all_heap_simps)
+         apply (intro hoare_vcg_conj_lift_pre_fix
+                ; (solves head_insufficient_loop_simple)?)
+
        apply (wpsimp wp: head_insufficient_loop_refills_sum)
        apply (clarsimp simp: vs_all_heap_simps word_le_nat_alt)
       apply (wpsimp wp: head_insufficient_loop_ordered_disjoint)
@@ -9597,6 +9582,19 @@ lemma refill_budget_check_valid_refills[wp]:
    apply (clarsimp simp: vs_all_heap_simps word_le_nat_alt)
   apply (wpsimp wp: head_insufficient_loop_length_bounded)
   apply (clarsimp simp: vs_all_heap_simps word_le_nat_alt)
+        apply (all \<open>wpsimp wp: set_refills_wp get_refills_wp
+                         simp: vs_all_heap_simps update_sched_context_set_refills_rewrite
+                               update_refill_hd_rewrite\<close>)
+        apply (all \<open>clarsimp simp: sc_valid_refills_def obj_at_def\<close>)
+        apply (all \<open>rename_tac sc n, case_tac "refill_hd sc"; simp\<close>)
+        apply (case_tac "sc_refills sc"; clarsimp)
+       apply (fastforce dest: refill_budget_check_ordered_disjoint_helper simp: word_le_nat_alt)
+      apply (fastforce dest: refill_budget_check_no_overflow_schedule_used_helper)
+     apply (fastforce dest: schedule_used_window)
+    apply (clarsimp simp: schedule_used_non_nil)
+   apply (fastforce dest: refill_budget_check_schedule_used_length_at_most_sc_refill_max[rotated -1]
+                    simp: refills_sum_def vs_all_heap_simps)
+  apply (fastforce dest: refill_budget_check_unat_sum_helper)
   done
 
 lemma valid_refills_sc_update:
@@ -9628,7 +9626,8 @@ lemma refill_budget_check_round_robin_valid_refills[wp]:
     refill_budget_check_round_robin usage
     \<lbrace>\<lambda>_. valid_refills p\<rbrace>"
   supply if_split[split del]
-  apply (clarsimp simp: refill_budget_check_round_robin_def update_refill_tl_def update_refill_hd_def)
+  apply (clarsimp simp: refill_budget_check_round_robin_def
+                        update_refill_tl_rewrite update_refill_hd_rewrite)
   apply (wpsimp wp: set_refills_wp get_refills_wp)
   apply (case_tac "p \<noteq> cur_sc s"; simp?)
    apply (clarsimp simp: vs_all_heap_simps)
@@ -9770,7 +9769,7 @@ lemma refill_unblock_check_valid_refills[wp]:
     refill_unblock_check sc_ptr
     \<lbrace>\<lambda>_. valid_refills p\<rbrace>"
   supply map_map[simp del] round_robin_def[simp add]
-  apply (clarsimp simp: refill_unblock_check_def set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: refill_unblock_check_def update_refill_hd_rewrite)
   apply (rule hoare_seq_ext[OF _ is_round_robin_sp])
   apply (rule hoare_seq_ext[OF _ get_sc_refill_ready_sp])
   apply (rule hoare_when_cases, simp)
@@ -9781,7 +9780,7 @@ lemma refill_unblock_check_valid_refills[wp]:
    apply (wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
                simp: merge_refills_def refill_pop_head_def head_insufficient_loop_def
                      refill_head_overlapping_loop_def non_overlapping_merge_refills_def
-                     vs_all_heap_simps)
+                     vs_all_heap_simps update_refill_hd_rewrite update_sched_context_set_refills_rewrite)
 
   apply (rule_tac R1="\<lambda>s. pred_map (\<lambda>cfg. refills_unat_sum (scrc_refills cfg)
                                            = unat (scrc_budget cfg))
@@ -9840,12 +9839,11 @@ lemma refill_unblock_check_valid_refills[wp]:
 lemma refill_unblock_check_is_refill_ready[wp]:
   "refill_unblock_check sc_ptr' \<lbrace>is_refill_ready sc_ptr\<rbrace>"
   (is "valid _ _ ?post")
-  apply (clarsimp simp: refill_unblock_check_def set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: refill_unblock_check_def update_refill_hd_rewrite)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_when_cases, simp)
   apply (rule hoare_seq_ext_skip, solves wpsimp)
   apply (rule hoare_seq_ext[OF _ gets_sp])
-  apply (subst bind_assoc[symmetric])
   apply (rule_tac B="?post" in hoare_seq_ext[rotated])
    apply (wpsimp wp: set_refills_wp get_refills_wp)
    apply (fastforce simp: pred_tcb_at_def obj_at_def vs_all_heap_simps refill_ready_def)
@@ -9891,9 +9889,12 @@ lemma refill_unblock_check_budget_sufficient[wp]:
   apply (fastforce simp: active_sc_valid_refills_def vs_all_heap_simps obj_at_kh_kheap_simps)
   done
 
+lemmas update_sc_refills_active_sc_tcb_at2[wp]
+  = bound_sc_obj_tcb_at_update_sched_context_no_change[where P=active_scrc and f="sc_refills_update f" for f, simplified]
+
 crunches refill_unblock_check
   for active_sc_tcb_at[wp]: "\<lambda>s. P (active_sc_tcb_at tcb_ptr s)"
-  (wp: crunch_wps)
+  (wp: crunch_wps simp: update_refill_hd_rewrite ignore: update_sched_context)
 
 lemma refill_unblock_check_released_sc_tcb_at[wp]:
   "\<lbrace>released_sc_tcb_at x and active_sc_valid_refills\<rbrace>
@@ -10131,6 +10132,13 @@ lemma sc_consumed_update_sc_tcb_sc_at[wp]:
   apply (clarsimp simp: sc_tcb_sc_at_def obj_at_def)
   done
 
+lemma sc_refills_update_sc_tcb_sc_at[wp]:
+  "update_sched_context csc (sc_refills_update f)
+   \<lbrace>\<lambda>s. Q (sc_tcb_sc_at P sc_ptr s)\<rbrace>"
+  apply (wpsimp wp: update_sched_context_wp)
+  apply (clarsimp simp: sc_tcb_sc_at_def obj_at_def)
+  done
+
 crunches commit_domain_time, refill_budget_check, refill_budget_check_round_robin,
          refill_unblock_check
   for sc_tcb_sc_at[wp]: "\<lambda>s. Q (sc_tcb_sc_at P sc_ptr s)"
@@ -10139,7 +10147,7 @@ crunches commit_domain_time, refill_budget_check, refill_budget_check_round_robi
   and valid_idle_etcb[wp]: "valid_idle_etcb"
   and etcb_at[wp]: "etcb_at P t"
   (wp: crunch_wps set_refills_budget_ready
-   simp: crunch_simps refill_budget_check_defs update_refill_tl_def)
+   simp: crunch_simps refill_budget_check_defs update_refill_tl_rewrite ignore: update_sched_context)
 
 lemma commit_time_sc_tcb_sc_at[wp]:
   "commit_time \<lbrace>\<lambda>s. sc_tcb_sc_at P sc_ptr s\<rbrace>"
@@ -10225,7 +10233,8 @@ lemma refill_budget_check_valid_sched_action_act_not:
   apply (rule_tac B="\<lambda>_ s. valid_sched_action s \<and> sc_scheduler_act_not (cur_sc s) s
                            \<and> cur_sc s = csc_ptr"
                in hoare_seq_ext[rotated])
-   apply (wpsimp wp: set_refills_wp get_refills_wp)
+   apply (wpsimp wp: set_refills_wp get_refills_wp
+               simp: update_refill_hd_rewrite update_sched_context_set_refills_rewrite)
    apply (fastforce simp: valid_sched_action_def weak_valid_sched_action_def vs_all_heap_simps
                           obj_at_def scheduler_act_not_def is_activatable_def
                           switch_in_cur_domain_def in_cur_domain_def etcb_at'_def
@@ -10237,7 +10246,8 @@ lemma refill_budget_check_round_robin_valid_sched_action_act_not:
   "\<lbrace>valid_sched_action and (\<lambda>s. sc_scheduler_act_not (cur_sc s) s)\<rbrace>
    refill_budget_check_round_robin usage
    \<lbrace>\<lambda>_. valid_sched_action\<rbrace>"
-  unfolding refill_budget_check_round_robin_def update_refill_tl_def update_refill_hd_def
+  unfolding refill_budget_check_round_robin_def update_refill_hd_rewrite
+            update_refill_tl_rewrite update_sched_context_set_refills_rewrite
   by (wpsimp wp: set_refills_valid_sched_action_act_not is_round_robin_wp)
 
 lemma head_insufficient_loop_valid_ready_qs_not:
@@ -10303,9 +10313,10 @@ lemma refill_budget_check_valid_ready_qs_not_queued:
   apply (rule_tac B="\<lambda>_ s. valid_ready_qs s \<and> sc_not_in_ready_q (cur_sc s) s
                            \<and> cur_sc s = csc_ptr"
                in hoare_seq_ext[rotated])
-   apply (wpsimp wp: set_refills_wp get_refills_wp)
-   apply (fastforce simp: valid_ready_qs_def vs_all_heap_simps obj_at_def not_queued_def
-                   split: if_splits)
+   apply (wpsimp wp: set_refills_wp get_refills_wp
+               simp: update_refill_hd_rewrite update_sched_context_set_refills_rewrite)
+   apply (clarsimp simp: obj_at_def vs_all_heap_simps not_queued_def valid_ready_qs_def
+                  split: if_splits, fastforce)
   apply (wpsimp wp: head_insufficient_loop_valid_ready_qs_not)
   done
 
@@ -10333,7 +10344,7 @@ lemma refill_budget_check_refill_ready_offset_ready_and_sufficient:
    \<lbrace>\<lambda>_ s. is_refill_ready sc_ptr s\<rbrace>"
   supply map_map[simp del] round_robin_def[simp add]
   apply (subst is_refill_ready_alt)+
-  apply (clarsimp simp: refill_budget_check_def)
+  apply (clarsimp simp: refill_budget_check_def update_refill_hd_rewrite update_sched_context_set_refills_rewrite)
   apply (rule hoare_seq_ext[OF _ gets_sp], rename_tac csc_ptr)
   apply (rule hoare_seq_ext[OF _ is_round_robin_sp])
   apply (rule hoare_seq_ext[OF _ assert_sp])
@@ -10346,10 +10357,10 @@ lemma refill_budget_check_refill_ready_offset_ready_and_sufficient:
                             \<and> cur_sc s = csc_ptr"
                 in hoare_seq_ext[rotated])
     apply ((wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
-                 simp: refill_budget_check_defs
+                 simp: refill_budget_check_defs update_sched_context_set_refills_rewrite
            | fastforce simp: obj_at_def vs_all_heap_simps )+)[1]
    apply ((wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
-                simp: refill_budget_check_defs
+                simp: refill_budget_check_defs update_sched_context_set_refills_rewrite
           | fastforce simp: obj_at_def vs_all_heap_simps)+)[1]
 
   apply (rule_tac R1="\<lambda>s. pred_map (\<lambda>cfg. refills_unat_sum (scrc_refills cfg)
@@ -10436,10 +10447,10 @@ lemma refill_budget_check_is_refill_sufficient:
                             \<and> cur_sc s = csc_ptr"
                 in hoare_seq_ext[rotated])
     apply ((wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
-                 simp: refill_budget_check_defs
+                 simp: refill_budget_check_defs update_sched_context_set_refills_rewrite
            | fastforce simp: obj_at_def vs_all_heap_simps )+)[1]
    apply ((wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
-                simp: refill_budget_check_defs
+                simp: refill_budget_check_defs update_sched_context_set_refills_rewrite
           | fastforce simp: obj_at_def vs_all_heap_simps)+)[1]
 
   apply (rule_tac R1="\<lambda>s. pred_map (\<lambda>cfg. refills_unat_sum (scrc_refills cfg)
@@ -10470,16 +10481,19 @@ lemma refill_budget_check_is_refill_sufficient:
                in hoare_seq_ext)
    apply (subst is_refill_sufficient_0_alt)
    apply (wpsimp wp: head_insufficient_loop_MIN_BUDGET_in_head)
-   apply (fastforce simp: vs_all_heap_simps word_le_nat_alt)
-  apply (intro hoare_vcg_conj_lift_pre_fix)
-    apply (wpsimp wp: set_refills_wp get_refills_wp)
-    apply (fastforce intro: refill_budget_check_unat_sum_helper
-                      simp: sc_valid_refills_def vs_all_heap_simps obj_at_def)
-   apply (wpsimp wp: set_refills_wp get_refills_wp)
-   apply (fastforce simp: sc_valid_refills_def  vs_all_heap_simps obj_at_def)
-  apply (wpsimp wp: set_refills_wp get_refills_wp)
-  apply (fastforce simp: vs_all_heap_simps schedule_used_non_nil sc_valid_refills_def)
-  done
+    apply (fastforce simp: vs_all_heap_simps word_le_nat_alt)
+   apply (intro hoare_vcg_conj_lift_pre_fix)
+     apply (wpsimp wp: set_refills_wp get_refills_wp
+                 simp: update_sched_context_set_refills_rewrite update_refill_hd_rewrite)
+     apply (clarsimp simp:  vs_all_heap_simps obj_at_def sc_valid_refills_def)
+     apply (rename_tac sc n; case_tac "refill_hd sc"; simp)
+     apply (fastforce dest: refill_budget_check_unat_sum_helper)
+    apply (wpsimp wp: set_refills_wp get_refills_wp
+                simp: update_sched_context_set_refills_rewrite update_refill_hd_rewrite)
+    apply (fastforce simp: sc_valid_refills_def vs_all_heap_simps obj_at_def)
+   apply (wpsimp wp: set_refills_wp get_refills_wp  simp: update_sched_context_set_refills_rewrite update_refill_hd_rewrite)
+   apply (fastforce simp: vs_all_heap_simps schedule_used_non_nil sc_valid_refills_def)
+   done
 
 crunches refill_budget_check
   for etcb_eq[wp]: "etcb_eq p d t"
@@ -10493,7 +10507,7 @@ lemma refill_budget_check_round_robin_refill_ready_offset_ready_and_sufficient:
    refill_budget_check_round_robin usage
    \<lbrace>\<lambda>_ s. is_refill_ready sc_ptr s\<rbrace>"
   unfolding refill_budget_check_round_robin_def get_sc_refill_ready_def is_round_robin_def
-            update_refill_tl_def update_refill_hd_def
+            update_sched_context_set_refills_rewrite update_refill_tl_def update_refill_hd_def
   apply (wpsimp wp: set_refills_wp get_refills_wp)
   apply (clarsimp simp: vs_all_heap_simps refill_ready_no_overflow_def refill_ready_def obj_at_def)
   using cur_time_no_overflow word_le_nat_alt unat_plus_simple apply force
@@ -10507,7 +10521,7 @@ lemma refill_budget_check_round_robin_is_refill_sufficient:
    refill_budget_check_round_robin usage
    \<lbrace>\<lambda>_ s. is_refill_sufficient 0 sc_ptr s\<rbrace>"
   unfolding refill_budget_check_round_robin_def get_sc_refill_ready_def is_round_robin_def
-            update_refill_tl_def update_refill_hd_def
+            update_refill_tl_def update_refill_hd_def update_sched_context_set_refills_rewrite
   apply (wpsimp wp: set_refills_wp get_refills_wp)
   by (auto simp: pred_map_def obj_at_def vs_all_heap_simps refill_sufficient_def refill_capacity_def
                  refill_ready_no_overflow_def valid_refills_def rr_valid_refills_def
@@ -10518,6 +10532,7 @@ lemma refill_budget_check_round_robin_valid_ready_qs_not_queued:
    refill_budget_check_round_robin usage
    \<lbrace>\<lambda>_. valid_ready_qs\<rbrace>"
   unfolding refill_budget_check_round_robin_def update_refill_tl_def update_refill_hd_def
+            update_sched_context_set_refills_rewrite
   apply (wpsimp wp: set_refills_valid_ready_qs get_refills_wp is_round_robin_wp hoare_vcg_all_lift
                     hoare_vcg_imp_lift' set_refills_wp)
   apply (clarsimp simp: obj_at_def vs_all_heap_simps split: if_splits)
@@ -10531,6 +10546,34 @@ lemma precondition_cases:
   apply (rule hoare_vcg_disj_lift)
   by force+
 
+lemma update_refill_hd_valid_release_q:
+  "\<lbrace>\<lambda>s. valid_release_q s
+        \<and> (\<forall>t. pred_map_eq (Some sc_ptr) (tcb_scps_of s) t
+               \<longrightarrow> in_release_q t s
+               \<longrightarrow> (scs_of s ||> sc_refills |> hd_opt ||> f ||> r_time) sc_ptr = tcb_ready_times_of s t)\<rbrace>
+   update_refill_hd sc_ptr f
+   \<lbrace>\<lambda>_. valid_release_q\<rbrace>"
+  unfolding update_refill_hd_rewrite
+  apply (wpsimp wp: set_refills_valid_release_q get_refills_wp)
+  by (fastforce simp: tcb_ready_times_defs vs_all_heap_simps obj_at_def opt_map_left_Some
+                      sc_heap_of_state_def  map_project_def map_join_def sc_refill_cfgs_of_scs_def)
+
+lemma non_overlapping_merge_refills_cur_sc_not_in_release_q:
+  "non_overlapping_merge_refills csc_ptr \<lbrace>\<lambda>s. sc_not_in_release_q (cur_sc s) s\<rbrace>"
+  apply non_overlapping_merge_refills_simple
+  apply (fastforce split: if_splits)
+  done
+
+lemma update_refill_head_wp:
+  "\<lbrace>\<lambda>s. \<forall>sc n. obj_at ((=) (SchedContext sc n)) sc_ptr s
+               \<longrightarrow> P (s\<lparr>kheap := kheap s(sc_ptr \<mapsto> SchedContext (sc\<lparr>sc_refills := refills\<rparr>) n)\<rparr>)\<rbrace>
+     update_refill_hd sc_ptr f
+   \<lbrace>\<lambda>r. P\<rbrace>"
+  unfolding set_refills_def
+oops
+
+thm set_tcb_sched_context_valid_release_q_not_queued
+
 lemma head_insufficient_loop_valid_release_q:
   "\<lbrace>\<lambda>s. valid_release_q s \<and> sc_not_in_release_q (cur_sc s) s \<and> cur_sc s = csc_ptr\<rbrace>
    head_insufficient_loop csc_ptr
@@ -10542,7 +10585,8 @@ lemma head_insufficient_loop_valid_release_q:
   apply (intro hoare_vcg_conj_lift_pre_fix)
     apply (wpsimp wp: set_refills_valid_release_q get_refills_wp hoare_vcg_all_lift
                       hoare_vcg_imp_lift' set_refills_wp
-                simp: non_overlapping_merge_refills_def refill_pop_head_def)
+                simp: non_overlapping_merge_refills_def refill_pop_head_def
+                      update_refill_hd_rewrite update_sched_context_set_refills_rewrite)
     apply (fastforce simp: vs_all_heap_simps obj_at_def split: if_splits)
    apply non_overlapping_merge_refills_simple
    apply (fastforce split: if_splits)
@@ -10560,10 +10604,12 @@ lemma refill_head_overlapping_loop_valid_release_q:
   apply (intro hoare_vcg_conj_lift_pre_fix)
    apply (wpsimp wp: set_refills_valid_release_q get_refills_wp hoare_vcg_all_lift
                       hoare_vcg_imp_lift' set_refills_wp
-                simp: merge_refills_def refill_pop_head_def)
+                simp: merge_refills_def refill_pop_head_def
+                      update_refill_hd_def update_sched_context_set_refills_rewrite)
    apply (fastforce simp: vs_all_heap_simps obj_at_def split: if_splits)
   apply (wpsimp wp: set_refills_wp get_refills_wp
-              simp: merge_refills_def refill_pop_head_def)
+              simp: merge_refills_def refill_pop_head_def
+                    update_refill_hd_def update_sched_context_set_refills_rewrite)
   apply (fastforce simp: vs_all_heap_simps obj_at_def split: if_splits)
   done
 
@@ -10577,7 +10623,7 @@ lemma handle_overrun_loop_valid_release_q:
          ; fastforce?)
   apply (wpsimp wp: set_refills_valid_release_q get_refills_wp hoare_vcg_all_lift
                     hoare_vcg_imp_lift'
-              simp: refill_budget_check_defs
+              simp: refill_budget_check_defs update_sched_context_set_refills_rewrite
          | wpsimp wp: set_refills_wp)+
   done
 
@@ -10585,19 +10631,44 @@ crunches head_insufficient_loop, handle_overrun_loop
   for sc_not_in_release_q_cur_sc[wp]: "\<lambda>s. sc_not_in_release_q (cur_sc s) s"
   (wp: crunch_wps)
 
+lemma sorted_release_q_sc_not_in_sc_update:
+  "\<lbrakk>sc_not_in_release_q scp s;  \<forall>t\<in> set (release_queue s). tcb_at t s;
+    kheap s scp = Some (SchedContext sc' n)\<rbrakk> \<Longrightarrow>
+   sorted_release_q (s\<lparr> kheap := (kheap s(scp \<mapsto> SchedContext sc n)) \<rparr>) = sorted_release_q s"
+  apply (clarsimp simp: sorted_release_q_def not_in_release_q_def obj_at_def is_tcb)
+  apply (rule sorted_wrt_img_ord_eq_lift; simp?)
+  apply (rename_tac tp; drule_tac x=tp in bspec, simp)
+  apply (case_tac "tcb_ready_times_of s tp"; clarsimp)
+  by (fastforce simp: vs_all_heap_simps tcb_ready_times_defs map_project_def map_join_def opt_map_def
+               split: option.splits)+
+
+lemma valid_release_q_sc_not_in_sc_update:
+  "\<lbrakk>valid_release_q (s::('a::state_ext state)); sc_not_in_release_q scp s;
+    kheap s scp = Some (SchedContext sc' n)\<rbrakk> \<Longrightarrow>
+   valid_release_q (s\<lparr> kheap := (kheap s(scp \<mapsto> SchedContext sc n)) \<rparr>) "
+  apply (clarsimp simp: valid_release_q_def sorted_release_q_sc_not_in_sc_update)
+  apply (rule conjI)
+   apply (fastforce simp: not_in_release_q_def vs_all_heap_simps)
+  by (subst sorted_release_q_sc_not_in_sc_update[simplified];
+      fastforce simp: obj_at_def is_tcb vs_all_heap_simps)
+
 lemma refill_budget_check_valid_release_q:
   "\<lbrace>valid_release_q and (\<lambda>s. sc_not_in_release_q (cur_sc s) s)\<rbrace>
    refill_budget_check usage
    \<lbrace>\<lambda>_. valid_release_q\<rbrace>"
-  apply (clarsimp simp: refill_budget_check_def)
+  apply (clarsimp simp: refill_budget_check_def update_sched_context_set_refills_rewrite
+                        update_refill_hd_rewrite)
   apply (rule hoare_seq_ext[OF _ gets_sp], rename_tac csc_ptr)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_seq_ext_skip, wpsimp wp: handle_overrun_loop_valid_release_q)
-  apply (rule hoare_seq_ext_skip, solves wpsimp)
+  apply (rule hoare_seq_ext[OF _ get_refills_sp])
   apply (rule_tac B="\<lambda>_ s. valid_release_q s \<and> sc_not_in_release_q (cur_sc s) s
                            \<and> cur_sc s = csc_ptr"
                in hoare_seq_ext[rotated])
-   apply (wpsimp wp: set_refills_valid_release_q get_refills_wp)
+   apply (wpsimp wp: set_refills_valid_release_q get_refills_wp set_refills_wp)
+   apply (clarsimp simp: vs_all_heap_simps obj_at_def)
+   apply (drule_tac scp="cur_sc s" in valid_release_q_sc_not_in_sc_update; simp?)
+   apply (clarsimp simp: vs_all_heap_simps obj_at_def is_sc_obj valid_release_q_sc_not_in_sc_update)
   apply (wpsimp wp: head_insufficient_loop_valid_release_q)
   done
 
@@ -10606,6 +10677,7 @@ lemma refill_budget_check_round_robin_valid_release_q:
    refill_budget_check_round_robin usage
    \<lbrace>\<lambda>_. valid_release_q\<rbrace>"
   unfolding refill_budget_check_round_robin_def update_refill_tl_def update_refill_hd_def
+            update_sched_context_set_refills_rewrite
   apply (wpsimp wp: set_refills_valid_release_q is_round_robin_wp get_refills_wp hoare_vcg_all_lift
                     hoare_vcg_imp_lift' set_refills_wp)
   apply (clarsimp simp: obj_at_def vs_all_heap_simps split: if_splits)
@@ -10835,6 +10907,7 @@ lemma refill_budget_check_round_robin_sc_refills_update_unspecified:
    refill_budget_check_round_robin usage
    \<lbrace>\<lambda>_. valid_sched_pred_strong P\<rbrace>"
   unfolding refill_budget_check_round_robin_def update_refill_tl_def update_refill_hd_def
+            update_sched_context_set_refills_rewrite
   apply (clarsimp simp: bind_assoc)
   apply (wpsimp wp: set_refills_valid_sched_pred get_refills_wp hoare_vcg_imp_lift' hoare_vcg_all_lift
          | wpsimp wp: set_refills_wp)+
@@ -10885,12 +10958,13 @@ lemma commit_time_valid_sched_action:
    by (wpsimp wp: hoare_vcg_all_lift hoare_drop_imps set_refills_valid_sched_action_act_not
                   refill_budget_check_valid_sched_action_act_not
             simp: refill_budget_check_round_robin_def update_refill_tl_def update_refill_hd_def
+                  update_sched_context_set_refills_rewrite
        | strengthen simple_sched_act_not
        | intro conjI)+
 
 crunches commit_domain_time, refill_budget_check, refill_budget_check_round_robin
   for valid_blocked_except_set[wp]: "valid_blocked_except_set S"
-  (wp: crunch_wps simp: crunch_simps)
+  (wp: crunch_wps simp: crunch_simps update_sched_context_set_refills_rewrite ignore: update_sched_context)
 
 lemma refill_budget_check_round_robin_not_active_sc[wp]:
    "\<lbrace>(\<lambda>s. \<not> pred_map active_scrc (sc_refill_cfgs_of s) scp)\<rbrace>
@@ -10904,7 +10978,7 @@ lemma refill_budget_check_not_active_sc[wp]:
    "\<lbrace>(\<lambda>s. \<not> pred_map active_scrc (sc_refill_cfgs_of s) scp)\<rbrace>
     refill_budget_check usage
     \<lbrace>\<lambda>_ s. \<not> pred_map active_scrc (sc_refill_cfgs_of s) scp\<rbrace>"
-  unfolding refill_budget_check_def
+  unfolding refill_budget_check_def update_sched_context_set_refills_rewrite update_refill_hd_def
   apply (rule hoare_seq_ext_skip, solves wpsimp, clarsimp?)+
   apply (rule hoare_seq_ext_skip)
    apply handle_overrun_loop_simple
@@ -10959,10 +11033,10 @@ lemma refill_budget_check_bounded_release_time:
                             \<and> cur_sc s = csc_ptr"
                 in hoare_seq_ext[rotated])
     apply ((wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
-                 simp: refill_budget_check_defs
+                 simp: refill_budget_check_defs update_sched_context_set_refills_rewrite
            | fastforce simp: obj_at_def vs_all_heap_simps )+)[1]
    apply ((wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
-                simp: refill_budget_check_defs
+                simp: refill_budget_check_defs update_sched_context_set_refills_rewrite
           | fastforce simp: obj_at_def vs_all_heap_simps)+)[1]
 
   apply (rule_tac R1="\<lambda>s. pred_map (\<lambda>cfg. refills_unat_sum (scrc_refills cfg)
@@ -11001,7 +11075,6 @@ lemma refill_budget_check_bounded_release_time:
    apply (wpsimp wp: handle_overrun_loop_head_bound)
    apply (clarsimp simp: sc_valid_refills_def vs_all_heap_simps)
 
-
   apply (clarsimp simp: current_time_bounded_def)
   apply (rule_tac R1="\<lambda>s. pred_map (\<lambda>cfg. no_overflow (scrc_refills cfg)) (sc_refill_cfgs_of s) sc_ptr"
                in hoare_pre_add[THEN iffD2, simplified pred_conj_def])
@@ -11021,37 +11094,30 @@ lemma refill_budget_check_bounded_release_time:
                in hoare_seq_ext[rotated])
 
    apply (rule hoare_when_cases, clarsimp simp: vs_all_heap_simps)
-   apply (rule hoare_seq_ext[OF _ get_refills_sp])
    apply (rule hoare_seq_ext[OF _ get_sched_context_sp])
-   apply (rule hoare_seq_ext[OF _ refill_full_sp])
 
    apply (intro hoare_vcg_conj_lift_pre_fix
           ; (solves schedule_used_simple)?)
-          apply (wpsimp wp: set_refills_wp
-                      simp: vs_all_heap_simps)
-          apply (clarsimp simp: sc_valid_refills_def refills_sum_def obj_at_def)
-          apply (rename_tac sc n)
+
+          apply (all \<open>wpsimp wp: set_refills_wp get_refills_wp
+                         simp: vs_all_heap_simps update_sched_context_set_refills_rewrite
+                               update_refill_hd_rewrite\<close>)[7]
+          apply (all \<open>clarsimp simp: sc_valid_refills_def obj_at_def\<close>)[7]
+          apply (all \<open>rename_tac sc n, case_tac "refill_hd sc"; simp\<close>)[7]
           apply (case_tac "sc_refills sc"; clarsimp)
-         apply (wpsimp wp: set_refills_wp)
-         apply (fastforce intro: refill_budget_check_ordered_disjoint_helper
-                           simp: word_le_nat_alt obj_at_def vs_all_heap_simps)
-        apply (wpsimp wp: set_refills_wp)
-        apply (fastforce intro!: refill_budget_check_no_overflow_schedule_used_helper
-                           simp: sc_valid_refills_def obj_at_def vs_all_heap_simps)
-       apply (wpsimp wp: set_refills_wp)
-       apply (fastforce intro: schedule_used_window
-                         simp: obj_at_def vs_all_heap_simps)
-      apply (wpsimp wp: set_refills_wp)
-      apply (fastforce simp: schedule_used_non_nil vs_all_heap_simps)
-     apply (wpsimp wp: set_refills_wp)
-     apply (fastforce intro: refill_budget_check_schedule_used_length_at_most_sc_refill_max
-                       simp: obj_at_def vs_all_heap_simps)
-    apply (wpsimp wp: set_refills_wp)
-    apply (fastforce intro: refill_budget_check_unat_sum_helper
-                      simp: obj_at_def vs_all_heap_simps)
-   apply (wpsimp wp: refill_budget_sched_schedule_used_r_time_helper)
-   apply (fastforce intro: refill_budget_check_unat_sum_helper
-                     simp: obj_at_def vs_all_heap_simps)
+
+         apply (fastforce dest: refill_budget_check_ordered_disjoint_helper simp: word_le_nat_alt)
+        apply (fastforce dest: refill_budget_check_no_overflow_schedule_used_helper)
+       apply (fastforce dest: schedule_used_window)
+      apply (clarsimp simp: schedule_used_non_nil)
+     apply (fastforce dest: refill_budget_check_schedule_used_length_at_most_sc_refill_max[rotated -1]
+                      simp: refills_sum_def vs_all_heap_simps)
+    apply (fastforce dest: refill_budget_check_unat_sum_helper)
+   apply (unfold update_refill_hd_def)
+   apply (subst update_sched_context_decompose[symmetric, simplified])
+   apply (clarsimp simp: update_sched_context_set_refills_rewrite)
+   apply (wpsimp wp: refill_budget_sched_schedule_used_r_time_helper get_refills_wp)
+   apply (clarsimp simp: obj_at_def vs_all_heap_simps)
 
   apply (rule_tac Q="\<lambda>_ s. pred_map (\<lambda>cfg. unat (r_time (scrc_refill_hd cfg)) + 2 * unat MAX_PERIOD
                                            \<le> unat max_time) (sc_refill_cfgs_of s) sc_ptr"
@@ -11134,7 +11200,8 @@ lemma refill_budget_check_active_reply_scs[wp]:
   apply handle_overrun_loop_simple
     apply (fastforce simp: active_reply_scs_def active_if_reply_sc_at_def vs_all_heap_simps
                            active_sc_def obj_at_def)+
-  apply (rule hoare_seq_ext_skip, solves wpsimp)+
+  apply (rule hoare_seq_ext_skip,
+         solves \<open>wpsimp simp: update_refill_hd_rewrite update_sched_context_set_refills_rewrite\<close>)+
   apply head_insufficient_loop_simple
    apply (fastforce simp: active_reply_scs_def active_if_reply_sc_at_def vs_all_heap_simps
                           active_sc_def obj_at_def)
@@ -11190,7 +11257,7 @@ lemma refill_unblock_check_valid_release_q:
   "\<lbrace>valid_release_q and sc_not_in_release_q sc_ptr\<rbrace>
    refill_unblock_check sc_ptr
    \<lbrace>\<lambda>_. valid_release_q\<rbrace>"
-  apply (clarsimp simp: refill_unblock_check_def set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: refill_unblock_check_def update_refill_hd_rewrite)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_when_cases, simp)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
@@ -11205,13 +11272,12 @@ lemma refill_unblock_check_bounded_release_time:
    refill_unblock_check sc_ptr
    \<lbrace>\<lambda>_. bounded_release_time sc_ptr'\<rbrace>"
   (is "valid ?pre _ ?post")
-  apply (clarsimp simp: refill_unblock_check_def set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: refill_unblock_check_def update_refill_hd_rewrite)
   apply (rule hoare_seq_ext_skip, solves wpsimp)
   apply (rule hoare_seq_ext[OF _ get_sc_refill_ready_sp])
   apply (rule hoare_when_cases, simp)
   apply (rule hoare_seq_ext_skip, solves wpsimp)
   apply (rule hoare_seq_ext[OF _ gets_sp])
-  apply (subst bind_assoc[symmetric])
   apply (rule_tac B="\<lambda>_. ?pre" in hoare_seq_ext[rotated])
    apply (wpsimp wp: set_refills_wp get_refills_wp)
    apply (clarsimp simp: vs_all_heap_simps bounded_release_time_def unat_plus_gt_trans)
@@ -11239,7 +11305,7 @@ lemma refill_unblock_check_valid_blocked_except_set[wp]:
   "\<lbrace>valid_blocked_except_set S\<rbrace>
    refill_unblock_check sc_ptr
    \<lbrace>\<lambda>rv. valid_blocked_except_set S\<rbrace>"
-  unfolding refill_unblock_check_defs
+  unfolding refill_unblock_check_defs update_sched_context_set_refills_rewrite
   apply (wpsimp wp: set_refills_wp get_refills_wp is_round_robin_wp whileLoop_wp'
          | fastforce simp: vs_all_heap_simps valid_blocked_except_set_2_def valid_blocked_thread_def
                            obj_at_def)+
@@ -11256,7 +11322,8 @@ lemma ready_or_release_reprogram_timer_update[simp]:
 crunches refill_unblock_check
   for sc_at_period[wp]: "sc_at_period P p"
   and sc_at_period_sc[wp]: "\<lambda>s. sc_at_period P (cur_sc s) s"
-    (wp: crunch_wps simp: crunch_simps)
+    (wp: crunch_wps simp: crunch_simps update_sched_context_set_refills_rewrite
+     ignore: update_sched_context)
 
 lemma refill_unblock_check_valid_sched_action[wp]:
   "\<lbrace>valid_sched_action and active_sc_valid_refills\<rbrace>
@@ -11276,7 +11343,7 @@ lemma refill_unblock_check_released_ipc_queues[wp]:
 
 lemma refill_unblock_check_active_reply_scs[wp]:
   "refill_unblock_check scp \<lbrace>active_reply_scs\<rbrace>"
-  apply (clarsimp simp: refill_unblock_check_def set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: refill_unblock_check_def update_refill_hd_rewrite)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_when_cases, simp)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
@@ -11310,7 +11377,7 @@ lemma refill_unblock_check_cur_sc_budget_sufficient[wp]:
    refill_unblock_check sc_ptr
    \<lbrace>\<lambda>_ s. cur_sc_budget_sufficient s\<rbrace>"
   (is "valid ?pre _ _")
-  apply (clarsimp simp: refill_unblock_check_def set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: refill_unblock_check_def update_refill_hd_rewrite)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_when_cases, simp)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
@@ -11338,7 +11405,7 @@ lemma refill_unblock_check_refill_ready_no_overflow_sc:
    \<lbrace>\<lambda>_ s. pred_map (refill_ready_no_overflow_sc usage curtime) (sc_refill_cfgs_of s) sc_ptr'\<rbrace>"
   unfolding refill_unblock_check_defs refill_ready_no_overflow_def merge_refill_def
   apply (wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp' is_round_robin_wp
-              simp: vs_all_heap_simps obj_at_def)
+              simp: vs_all_heap_simps obj_at_def update_sched_context_set_refills_rewrite)
   done
 
 lemma ruc_is_refill_sufficient_indep:
@@ -11346,7 +11413,7 @@ lemma ruc_is_refill_sufficient_indep:
    refill_unblock_check sc_ptr
    \<lbrace>\<lambda>_ s. is_refill_sufficient usage sc_ptr' s\<rbrace>"
   (is "valid ?pre _ _")
-  apply (clarsimp simp: refill_unblock_check_def set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: refill_unblock_check_def update_refill_hd_rewrite)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_when_cases, simp)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
@@ -11361,7 +11428,7 @@ lemma ruc_is_refill_sufficient_indep:
 
 lemma refill_unblock_check_cur_sc_active[wp]:
   "refill_unblock_check a \<lbrace>cur_sc_active\<rbrace>"
-  apply (clarsimp simp: refill_unblock_check_def set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: refill_unblock_check_def update_refill_hd_rewrite)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_when_cases, simp)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
@@ -12309,7 +12376,7 @@ lemma not_queued_refill_unblock_check:
   "\<lbrace>\<lambda>s. \<forall>t. sc_tcb_sc_at (\<lambda>p. p = Some t) sc_ptr s \<longrightarrow> not_queued t s\<rbrace>
    refill_unblock_check sc_ptr
    \<lbrace>\<lambda>rv s. \<forall>t. sc_tcb_sc_at (\<lambda>p. p = Some t) sc_ptr s \<longrightarrow> not_queued t s\<rbrace>"
-  apply (clarsimp simp: refill_unblock_check_def set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: refill_unblock_check_def update_refill_hd_def)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_when_cases, simp)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
@@ -15374,13 +15441,14 @@ lemma sc_ready_times_cong:
 
 lemma maybe_add_empty_tail_sc_tcb_sc_at[wp]:
   "maybe_add_empty_tail sc_ptr \<lbrace>sc_tcb_sc_at P sc_ptr\<rbrace>"
-  unfolding maybe_add_empty_tail_def refill_add_tail_def
+  unfolding maybe_add_empty_tail_def refill_add_tail_def update_sched_context_set_refills_rewrite
   apply (wpsimp wp: update_sched_context_wp hoare_drop_imp hoare_vcg_if_lift2)
   done
 
 lemma refill_update_sc_tcb_sc_at[wp]:
   "refill_update sc_ptr mrefills budget period \<lbrace>sc_tcb_sc_at P sc_ptr\<rbrace>"
   unfolding refill_update_def refill_add_tail_def update_refill_tl_def update_refill_hd_def
+             bind_assoc update_sched_context_set_refills_rewrite
   apply (wpsimp wp: update_sched_context_wp set_refills_wp get_refills_wp)
   by (clarsimp simp: sc_tcb_sc_at_def obj_at_def)
 
@@ -15440,9 +15508,9 @@ lemma refill_update_not_active_sc:
   "\<lbrace>\<lambda>s. if (scp = sc_ptr) then mrefills = 0 else \<not> pred_map active_scrc (sc_refill_cfgs_of s) scp\<rbrace>
    refill_update sc_ptr period budget mrefills
    \<lbrace>\<lambda>rv s.  \<not> pred_map active_scrc (sc_refill_cfgs_of s) scp\<rbrace>"
-  unfolding refill_update_def set_refills_def refill_add_tail_def update_refill_tl_def
-            update_refill_hd_def
-  apply (wpsimp wp: hoare_drop_imps)
+  unfolding refill_update_def refill_add_tail_def update_refill_tl_def
+            update_refill_hd_def update_sched_context_set_refills_rewrite
+  apply (wpsimp wp: hoare_drop_imps simp: set_refills_def)
   by (clarsimp simp: active_sc_def)
 
 lemma refill_update_bounded_release_time:
@@ -15777,8 +15845,8 @@ lemma refill_reset_rr_valid_sched_misc[wp]:
    \<lbrace>\<lambda>s. P (consumed_time s) (cur_sc s) (ep_send_qs_of s) (ep_recv_qs_of s)
           (sc_tcbs_of s) (sc_replies_of s) (cur_time s) (cur_domain s) (cur_thread s)
           (idle_thread s) (ready_queues s) (release_queue s) (scheduler_action s) (tcbs_of s)\<rbrace>"
-  unfolding refill_reset_rr_def update_refill_tl_def update_refill_hd_def set_refill_tl_def
-            set_refill_hd_def
+  unfolding refill_reset_rr_def update_refill_tl_def update_refill_hd_def
+            update_sched_context_set_refills_rewrite
   by wpsimp
 
 lemma check_budget_sc_tcb_sc_at[wp]:
@@ -15786,7 +15854,7 @@ lemma check_budget_sc_tcb_sc_at[wp]:
   supply if_split [split del]
   unfolding check_budget_def charge_budget_def end_timeslice_def
             handle_timeout_def refill_budget_check_defs refill_reset_rr_def update_refill_tl_def
-            set_refill_tl_def
+            update_sched_context_set_refills_rewrite
   apply clarsimp
   apply (wpsimp wp: hoare_drop_imps send_fault_ipc_sc_tcb_sc_at hoare_vcg_if_lift2  whileLoop_wp'
               simp: Let_def)
@@ -15883,7 +15951,8 @@ lemma head_insufficient_loop_weak_valid_sched_action_not:
          ; fastforce?)
   apply (intro hoare_vcg_conj_lift_pre_fix)
     apply (wpsimp wp: set_refills_wp get_refills_wp
-                simp: non_overlapping_merge_refills_def refill_pop_head_def)
+                simp: non_overlapping_merge_refills_def refill_pop_head_def update_refill_hd_rewrite
+                      update_sched_context_set_refills_rewrite)
     apply (fastforce simp: weak_valid_sched_action_def vs_all_heap_simps
                            obj_at_def scheduler_act_not_def)
    apply (wpsimp wp: set_refills_wp get_refills_wp
@@ -15902,16 +15971,12 @@ lemma refill_head_overlapping_loop_weak_valid_sched_action_not:
          ; fastforce?)
   apply (intro hoare_vcg_conj_lift_pre_fix)
     apply (wpsimp wp: set_refills_wp get_refills_wp
-                simp: merge_refills_def refill_pop_head_def)
+                simp: merge_refills_def refill_pop_head_def update_refill_hd_rewrite
+                      update_sched_context_set_refills_rewrite)
     apply (fastforce simp: weak_valid_sched_action_def vs_all_heap_simps
                            obj_at_def scheduler_act_not_def)
    apply (wpsimp wp: set_refills_wp get_refills_wp
-               simp: merge_refills_def refill_pop_head_def)
-   apply (fastforce simp: weak_valid_sched_action_def vs_all_heap_simps
-                          obj_at_def scheduler_act_not_def
-                   split: if_splits)
-  apply (wpsimp wp: set_refills_wp get_refills_wp
-              simp: merge_refills_def refill_pop_head_def)
+               simp: merge_refills_def refill_pop_head_def)+
   done
 
 lemma handle_overrun_loop_weak_valid_sched_action_not:
@@ -15945,7 +16010,8 @@ lemma refill_budget_check_weak_valid_sched_action_act_not:
   apply (rule_tac B="\<lambda>_ s. weak_valid_sched_action s \<and> sc_scheduler_act_not (cur_sc s) s
                            \<and> cur_sc s = csc_ptr"
                in hoare_seq_ext[rotated])
-   apply (wpsimp wp: set_refills_wp get_refills_wp)
+   apply (wpsimp wp: set_refills_wp get_refills_wp
+               simp: update_sched_context_set_refills_rewrite update_refill_hd_rewrite)
    apply (fastforce simp: valid_sched_action_def weak_valid_sched_action_def vs_all_heap_simps
                           obj_at_def scheduler_act_not_def
                    split: if_splits)
@@ -15957,6 +16023,7 @@ lemma refill_budget_check_round_robin_weak_valid_sched_action:
    refill_budget_check_round_robin consumed
    \<lbrace>\<lambda>_. weak_valid_sched_action\<rbrace>"
   unfolding refill_budget_check_round_robin_def update_refill_tl_def update_refill_hd_def
+            update_sched_context_set_refills_rewrite
   by (wpsimp wp: set_refills_weak_valid_sched_action_act_not is_round_robin_wp)
 
 lemma refill_budget_check_cur_sc_tcb[wp]:
@@ -16437,7 +16504,7 @@ lemma refill_budget_check_round_robin_released_ipc_queues:
    refill_budget_check_round_robin usage
    \<lbrace>\<lambda>_. released_ipc_queues\<rbrace>"
   apply (clarsimp simp: refill_budget_check_round_robin_def update_refill_tl_def
-                        update_refill_hd_def bind_assoc)
+                        update_refill_hd_def bind_assoc update_sched_context_set_refills_rewrite)
   apply (rule hoare_seq_ext[OF _ gets_sp])
   apply (rule hoare_seq_ext_skip, wpsimp)
   apply (rule hoare_seq_ext_skip, wpsimp wp: set_refills_released_ipc_queues)
@@ -16455,14 +16522,14 @@ lemma refill_pop_head_released_ipc_queues:
   "\<lbrace>\<lambda>s. released_ipc_queues s \<and> cur_sc_not_blocked s \<and> sc_ptr = cur_sc s\<rbrace>
    refill_pop_head sc_ptr
    \<lbrace>\<lambda>_. released_ipc_queues\<rbrace>"
-  apply (clarsimp simp: refill_pop_head_def)
+  apply (clarsimp simp: refill_pop_head_def update_sched_context_set_refills_rewrite)
   apply (wpsimp wp: set_refills_released_ipc_queues get_refills_wp)
   apply (clarsimp simp: pred_map_ipc_queued_thread_state_iff cur_sc_not_blocked_def)
   done
 
 lemma refill_pop_head_cur_sc_not_blocked:
   "refill_pop_head sc_ptr \<lbrace>cur_sc_not_blocked\<rbrace>"
-  apply (clarsimp simp: refill_pop_head_def)
+  apply (clarsimp simp: refill_pop_head_def update_sched_context_set_refills_rewrite)
   apply (wpsimp wp: set_refills_wp get_refills_wp)
   apply (clarsimp simp: cur_sc_not_blocked_def vs_all_heap_simps)
   done
@@ -16471,15 +16538,15 @@ lemma non_overlapping_merge_refills_released_ipc_queues:
   "\<lbrace>\<lambda>s. released_ipc_queues s \<and> cur_sc_not_blocked s \<and> sc_ptr = cur_sc s\<rbrace>
    non_overlapping_merge_refills sc_ptr
    \<lbrace>\<lambda>_. released_ipc_queues\<rbrace>"
-  apply (clarsimp simp: non_overlapping_merge_refills_def)
+  apply (clarsimp simp: non_overlapping_merge_refills_def update_refill_hd_rewrite bind_assoc)
   apply (rule hoare_seq_ext_skip)
    apply (intro hoare_vcg_conj_lift_pre_fix)
      apply (wpsimp wp: refill_pop_head_released_ipc_queues)
     apply (wpsimp wp: refill_pop_head_cur_sc_not_blocked)
-   apply (clarsimp simp: refill_pop_head_def)
+   apply (clarsimp simp: refill_pop_head_def update_sched_context_set_refills_rewrite bind_assoc)
    apply (wpsimp wp: set_refills_wp get_refills_wp)
-  apply (wpsimp wp: set_refills_released_ipc_queues get_refills_wp)
-  apply (clarsimp simp: pred_map_ipc_queued_thread_state_iff cur_sc_not_blocked_def)
+  apply (wpsimp wp: set_refills_released_ipc_queues get_refills_wp set_refills_wp)
+  apply (clarsimp simp: pred_map_ipc_queued_thread_state_iff cur_sc_not_blocked_def obj_at_def)
   done
 
 lemma head_insufficient_loop_released_ipc_queues:
@@ -16492,7 +16559,7 @@ lemma head_insufficient_loop_released_ipc_queues:
          ; fastforce?)
   apply (intro hoare_vcg_conj_lift_pre_fix)
     apply (wpsimp wp: non_overlapping_merge_refills_released_ipc_queues)
-   apply (clarsimp simp: non_overlapping_merge_refills_def refill_pop_head_def)
+   apply (clarsimp simp: non_overlapping_merge_refills_def refill_pop_head_def update_refill_hd_def)
    apply (wpsimp wp: set_refills_wp get_refills_wp)
    apply (clarsimp simp: cur_sc_not_blocked_def vs_all_heap_simps)
   apply (clarsimp simp: non_overlapping_merge_refills_def refill_pop_head_def)
@@ -16513,7 +16580,7 @@ lemma handle_overrun_loop_body_released_ipc_queues:
   apply (rule hoare_seq_ext_skip, wpsimp)
   apply (rule_tac B="\<lambda>_ s. ?post s" in hoare_seq_ext; (solves wpsimp)?)
   apply (rule hoare_if)
-   apply (wpsimp simp: set_refill_hd_def update_refill_hd_def
+   apply (wpsimp simp: update_refill_hd_rewrite
                    wp: set_refills_released_ipc_queues get_refills_wp)
   apply (clarsimp simp: pred_map_ipc_queued_thread_state_iff cur_sc_not_blocked_def)
   apply (rule hoare_seq_ext_skip)
@@ -16524,7 +16591,8 @@ lemma handle_overrun_loop_body_released_ipc_queues:
      apply (wpsimp wp: refill_pop_head_cur_sc_not_blocked)
     apply (wpsimp wp: set_refills_wp)
    apply (wpsimp wp: set_refills_wp)
-  apply (wpsimp wp: set_refills_released_ipc_queues get_refills_wp)
+  apply (wpsimp wp: set_refills_released_ipc_queues get_refills_wp
+              simp: update_sched_context_set_refills_rewrite)
   apply (clarsimp simp: pred_map_ipc_queued_thread_state_iff cur_sc_not_blocked_def)
   done
 
@@ -16546,14 +16614,14 @@ lemma merge_refills_released_ipc_queues:
   "\<lbrace>\<lambda>s. released_ipc_queues s \<and> cur_sc_not_blocked s \<and> sc_ptr = cur_sc s\<rbrace>
    merge_refills sc_ptr
    \<lbrace>\<lambda>_. released_ipc_queues\<rbrace>"
-  apply (clarsimp simp: merge_refills_def)
+  apply (clarsimp simp: merge_refills_def update_refill_hd_rewrite)
   apply (rule hoare_seq_ext_skip)
    apply (intro hoare_vcg_conj_lift_pre_fix)
      apply (wpsimp wp: refill_pop_head_released_ipc_queues)
     apply (clarsimp simp: refill_pop_head_def)
     apply (wpsimp wp: set_refills_wp get_refills_wp)
     apply (clarsimp simp: cur_sc_not_blocked_def vs_all_heap_simps)
-   apply (clarsimp simp: refill_pop_head_def)
+   apply (clarsimp simp: refill_pop_head_def update_sched_context_set_refills_rewrite)
    apply (wpsimp wp: set_refills_wp get_refills_wp)
   apply (wpsimp wp: set_refills_released_ipc_queues get_refills_wp)
   apply (clarsimp simp: pred_map_ipc_queued_thread_state_iff cur_sc_not_blocked_def)
@@ -16569,7 +16637,8 @@ lemma refill_head_overlapping_loop_released_ipc_queues:
          ; fastforce?)
   apply (intro hoare_vcg_conj_lift_pre_fix)
     apply (wpsimp wp: merge_refills_released_ipc_queues)
-   apply (clarsimp simp: merge_refills_def refill_pop_head_def)
+   apply (clarsimp simp: merge_refills_def refill_pop_head_def update_refill_hd_rewrite
+                         update_sched_context_set_refills_rewrite)
    apply (wpsimp wp: set_refills_wp get_refills_wp)
    apply (clarsimp simp: cur_sc_not_blocked_def vs_all_heap_simps)
   apply (clarsimp simp: merge_refills_def refill_pop_head_def)
@@ -16597,6 +16666,9 @@ lemma refill_budget_check_released_ipc_queues:
   apply (rule hoare_seq_ext_skip)
    apply (clarsimp simp: pred_conj_def)
    apply (intro hoare_vcg_conj_lift_pre_fix)
+     apply (unfold update_refill_hd_def)
+     apply (subst update_sched_context_decompose[symmetric, simplified])
+     apply (clarsimp simp: update_sched_context_set_refills_rewrite)
      apply (wpsimp wp: set_refills_released_ipc_queues get_refills_wp
                  simp: cur_sc_not_blocked_def merge_refills_def refill_pop_head_def obj_at_def)
      apply (fastforce simp: pred_map_ipc_queued_thread_state_iff)
@@ -16611,8 +16683,8 @@ lemma charge_budget_valid_blocked[wp]:
   "\<lbrace>valid_blocked_except_set S\<rbrace>
    charge_budget consumed canTimeout
    \<lbrace>\<lambda>_. valid_blocked_except_set S:: 'state_ext state \<Rightarrow> _\<rbrace>"
-  unfolding charge_budget_def refill_reset_rr_def set_refill_hd_def update_refill_hd_def
-            set_refill_tl_def update_refill_tl_def
+  unfolding charge_budget_def refill_reset_rr_def update_refill_hd_def
+            update_refill_tl_def update_sched_context_set_refills_rewrite
   by (wpsimp wp: reschedule_required_valid_blocked end_timeslice_valid_blocked
                  assert_inv gts_wp is_schedulable_wp')
 
@@ -16621,8 +16693,8 @@ lemma refill_reset_rr_valid_release_q[wp]:
    refill_reset_rr scp
    \<lbrace>\<lambda>_. valid_release_q :: 'state_ext state \<Rightarrow> _\<rbrace>"
   (is "valid ?pre _ _")
-  apply (clarsimp simp: refill_reset_rr_def set_refill_hd_def update_refill_hd_def
-                        set_refill_tl_def update_refill_tl_def bind_assoc)
+  apply (clarsimp simp: refill_reset_rr_def update_refill_hd_def update_refill_tl_def
+                        update_sched_context_set_refills_rewrite bind_assoc)
   apply (intro hoare_seq_ext[OF _ get_refills_sp])
   apply (rule_tac B="\<lambda>_. ?pre" in hoare_seq_ext[rotated])
    apply (wpsimp wp: set_refills_valid_release_q get_refills_wp hoare_vcg_imp_lift'
@@ -16673,8 +16745,8 @@ lemma refill_reset_rr_valid_sched_action:
   "\<lbrace>valid_sched_action and sc_scheduler_act_not scp\<rbrace>
    refill_reset_rr scp
    \<lbrace>\<lambda>_. valid_sched_action\<rbrace>"
-  unfolding refill_reset_rr_def set_refill_hd_def update_refill_hd_def set_refill_tl_def
-            update_refill_tl_def
+  unfolding refill_reset_rr_def update_refill_hd_def
+            update_refill_tl_def update_sched_context_set_refills_rewrite
   by (wpsimp wp: set_refills_valid_sched_action_act_not)
 
 lemma charge_budget_valid_sched_action:
@@ -16744,8 +16816,8 @@ lemma refill_reset_rr_released_sc_tcb_at[wp]:
     and (\<lambda>s. pred_map (\<lambda>cfg. scrc_period cfg = 0) (sc_refill_cfgs_of s) csc_ptr)\<rbrace>
    refill_reset_rr csc_ptr
    \<lbrace>\<lambda>_. released_sc_tcb_at tptr :: 'state_ext state \<Rightarrow> _\<rbrace>"
-  unfolding released_sc_tcb_at_def refill_reset_rr_def set_refill_hd_def update_refill_hd_def set_refill_tl_def
-            update_refill_tl_def
+  unfolding released_sc_tcb_at_def refill_reset_rr_def update_refill_hd_def
+            update_refill_tl_def update_sched_context_set_refills_rewrite bind_assoc
   apply (wpsimp simp: active_sc_tcb_at_def2 budget_ready_def2 budget_sufficient_def2
                   wp: hoare_vcg_ex_lift
          | wp set_refills_wp get_refills_wp)+
@@ -16755,7 +16827,6 @@ lemma refill_reset_rr_released_sc_tcb_at[wp]:
                  split: if_splits)
   apply (intro conjI impI allI; simp)
     apply (metis hd_last_length_2 list.distinct(1) list.sel(3))
-   apply (metis hd_last_length_2 list.distinct(1) list.sel(3))
   apply (erule order_trans, overflow_hammer, clarsimp simp: list_length_2)
   done
 
@@ -16774,7 +16845,8 @@ lemma refill_reset_rr_active_sc_valid_refills[wp]:
     and (\<lambda>s. pred_map (\<lambda>cfg. scrc_period cfg = 0) (sc_refill_cfgs_of s) csc_ptr)\<rbrace>
    refill_reset_rr csc_ptr
    \<lbrace>\<lambda>_. active_sc_valid_refills :: 'state_ext state \<Rightarrow> _\<rbrace>"
-  unfolding refill_reset_rr_def set_refill_hd_def update_refill_hd_def set_refill_tl_def update_refill_tl_def
+  unfolding refill_reset_rr_def update_refill_hd_def update_refill_tl_def
+            update_sched_context_set_refills_rewrite
   apply (wpsimp wp: set_refills_wp get_refills_wp)
   apply (clarsimp simp: active_sc_valid_refills_def)
   apply (drule_tac x=scp in spec)
@@ -16913,13 +16985,13 @@ lemma refill_budget_check_round_robin_cur_sc_active[wp]:
 
 lemma refill_budget_check_cur_sc_active[wp]:
   "refill_budget_check consumed \<lbrace>cur_sc_active\<rbrace>"
-  apply (clarsimp simp: refill_budget_check_def)
+  apply (clarsimp simp: refill_budget_check_def update_refill_hd_rewrite)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_seq_ext_skip)
    apply handle_overrun_loop_simple
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_seq_ext_skip)
-   apply (wpsimp wp: set_refills_wp get_refills_wp)
+   apply (wpsimp wp: set_refills_wp get_refills_wp simp: update_sched_context_set_refills_rewrite)
    apply (clarsimp simp: obj_at_def cur_sc_tcb_def sc_at_pred_n_def vs_all_heap_simps)
   apply head_insufficient_loop_simple
   done
@@ -16934,7 +17006,7 @@ lemma charge_budget_active_reply_scs:
                     get_tcb_obj_ref_wp is_schedulable_wp)
       apply (rule_tac Q="\<lambda>_. active_reply_scs" in hoare_strengthen_post[rotated],
              clarsimp split: if_splits simp: is_schedulable_bool_def2)
-  by (wpsimp simp: refill_reset_rr_def set_refill_hd_def update_refill_hd_def set_refill_tl_def
+  by (wpsimp simp: refill_reset_rr_def update_refill_hd_def update_sched_context_set_refills_rewrite
                    update_refill_tl_def)+
 
 lemma charge_budget_ready_or_release:
@@ -17212,7 +17284,8 @@ lemma refill_budget_check_sc_refill_max_sc_at:
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_seq_ext_skip)
   apply (wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
-              simp: obj_at_def merge_refills_def refill_pop_head_def sc_at_pred_n_def)
+              simp: obj_at_def merge_refills_def refill_pop_head_def sc_at_pred_n_def
+                    update_sched_context_set_refills_rewrite update_refill_hd_rewrite)
    apply (head_insufficient_loop_simple
           ; clarsimp simp: sc_at_pred_n_def obj_at_def)
   done
@@ -17293,7 +17366,8 @@ lemma refill_budget_check_is_active_sc[wp]:
    apply handle_overrun_loop_simple
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_seq_ext_skip)
-   apply (wpsimp wp: set_refills_wp get_refills_wp)
+   apply (wpsimp wp: set_refills_wp get_refills_wp
+               simp: update_sched_context_set_refills_rewrite update_refill_hd_rewrite)
    apply (clarsimp simp: obj_at_def cur_sc_tcb_def sc_at_pred_n_def vs_all_heap_simps)
    apply head_insufficient_loop_simple
   done
@@ -20656,16 +20730,16 @@ crunches send_ipc, end_timeslice
 
 lemma refill_reset_rr_is_active_sc[wp]:
   "refill_reset_rr csc_ptr \<lbrace>is_active_sc sc_ptr :: 'state_ext state \<Rightarrow> _\<rbrace>"
-  apply (clarsimp simp: refill_reset_rr_def set_refill_tl_def update_refill_tl_def
-                        set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: refill_reset_rr_def update_refill_tl_def
+                        update_sched_context_set_refills_rewrite update_refill_hd_def)
   apply (wpsimp wp: set_refills_wp get_refills_wp)
   apply (clarsimp simp: vs_all_heap_simps active_sc_def obj_at_kh_kheap_simps pred_map_simps)
   done
 
 lemma charge_budget_is_active_sc:
   "charge_budget consumed canTimeout \<lbrace>is_active_sc sc_ptr :: 'state_ext state \<Rightarrow> _\<rbrace>"
-  apply (clarsimp simp: charge_budget_def refill_reset_rr_def set_refill_tl_def update_refill_tl_def
-                        set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: charge_budget_def refill_reset_rr_def update_refill_tl_def
+                        update_sched_context_set_refills_rewrite update_refill_hd_def)
   apply (wpsimp wp: hoare_drop_imps set_refills_wp get_refills_wp)
   apply (clarsimp simp: vs_all_heap_simps active_sc_def obj_at_kh_kheap_simps pred_map_simps)
   done
@@ -20753,7 +20827,6 @@ lemma maybe_add_empty_tail_cur_sc_more_than_ready[wp]:
    \<lbrace>\<lambda>yb. cur_sc_more_than_ready\<rbrace>"
   unfolding maybe_add_empty_tail_def refill_add_tail_def get_refills_def
   apply (wpsimp wp: update_sched_context_cur_sc_more_than_ready is_round_robin_wp set_refills_wp)
-  apply (clarsimp simp: cur_sc_more_than_ready_def vs_all_heap_simps)
   done
 
 lemma refill_update_cur_sc_more_than_ready[wp]:
@@ -22027,7 +22100,7 @@ lemma refill_unblock_check_cur_sc_offset_ready_consumed_time[wp]:
    refill_unblock_check scp
    \<lbrace>\<lambda>_ s. cur_sc_offset_ready (consumed_time s) s\<rbrace>"
   (is "valid ?pre _ _")
-  apply (clarsimp simp: refill_unblock_check_def set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: refill_unblock_check_def update_refill_hd_rewrite)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_when_cases, simp)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
@@ -22045,7 +22118,7 @@ lemma refill_unblock_check_cur_sc_offset_sufficient_consumed_time[wp]:
    refill_unblock_check scp
    \<lbrace>\<lambda>_ s. cur_sc_offset_sufficient (consumed_time s) s\<rbrace>"
   (is "valid ?pre _ _")
-  apply (clarsimp simp: refill_unblock_check_def set_refill_hd_def update_refill_hd_def)
+  apply (clarsimp simp: refill_unblock_check_def update_refill_hd_rewrite)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+
   apply (rule hoare_when_cases, simp)
   apply (rule hoare_seq_ext_skip, solves wpsimp)+

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -10565,16 +10565,6 @@ lemma non_overlapping_merge_refills_cur_sc_not_in_release_q:
   apply (fastforce split: if_splits)
   done
 
-lemma update_refill_head_wp:
-  "\<lbrace>\<lambda>s. \<forall>sc n. obj_at ((=) (SchedContext sc n)) sc_ptr s
-               \<longrightarrow> P (s\<lparr>kheap := kheap s(sc_ptr \<mapsto> SchedContext (sc\<lparr>sc_refills := refills\<rparr>) n)\<rparr>)\<rbrace>
-     update_refill_hd sc_ptr f
-   \<lbrace>\<lambda>r. P\<rbrace>"
-  unfolding set_refills_def
-oops
-
-thm set_tcb_sched_context_valid_release_q_not_queued
-
 lemma head_insufficient_loop_valid_release_q:
   "\<lbrace>\<lambda>s. valid_release_q s \<and> sc_not_in_release_q (cur_sc s) s \<and> cur_sc s = csc_ptr\<rbrace>
    head_insufficient_loop csc_ptr

--- a/proof/invariant-abstract/RealTime_AI.thy
+++ b/proof/invariant-abstract/RealTime_AI.thy
@@ -56,6 +56,10 @@ lemma update_sched_context_valid_objs_same:
   apply (auto simp: valid_obj_def valid_sched_context_def a_type_def obj_at_def)
   done
 
+lemmas sc_refills_update_valid_objs[wp]
+  = update_sched_context_valid_objs_same[where f="sc_refills_update f" for f,
+                                         simplified valid_sched_context_def, simplified]
+
 lemmas sc_consumed_update_valid_objs[wp]
   = update_sched_context_valid_objs_same[where f="sc_consumed_update f" for f,
                                          simplified valid_sched_context_def, simplified]

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -1641,7 +1641,7 @@ abbreviation active_sc_at :: "obj_ref \<Rightarrow> 'z::state_ext state \<Righta
 lemmas active_sc_at_def = obj_at_def
 
 lemma set_refills_active_sc_at[wp]:
-  "set_refills sc_ptr refills \<lbrace>active_sc_at sc_ptr\<rbrace>"
+  "set_refills sc_ptr refills \<lbrace>\<lambda>s. P (active_sc_at sc_ptr s)\<rbrace>"
   apply (clarsimp simp: set_refills_def)
   apply (wpsimp wp: update_sched_context_wp)
   apply (clarsimp simp: active_sc_at_def)
@@ -1649,9 +1649,9 @@ lemma set_refills_active_sc_at[wp]:
 
 lemma refill_unblock_check_active_sc_at[wp]:
   "refill_unblock_check sc_ptr \<lbrace>\<lambda>s. Q (active_sc_at sc_ptr s)\<rbrace>"
-  apply (clarsimp simp: refill_unblock_check_defs)
+  apply (clarsimp simp: refill_unblock_check_defs simp del: update_refill_hd_def)
   apply (wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
-              simp: active_sc_at_def)
+              simp: update_refill_hd_rewrite update_sched_context_set_refills_rewrite active_sc_at_def)
   done
 
 lemma refill_update_invs:

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3473,7 +3473,7 @@ crunches schedContextCompleteYieldTo, unbindNotification, unbindMaybeNotificatio
 lemma schedContextZeroRefillMax_unlive[wp]:
   "schedContextZeroRefillMax scPtr \<lbrace>\<lambda>s. P (ko_wp_at' (Not \<circ> live') p s)\<rbrace>"
   unfolding schedContextZeroRefillMax_def
-  apply (wpsimp wp: set_sc'.set_wp)
+  apply (wpsimp wp: set_sc'.set_wp simp: updateSchedContext_def)
   apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKOs live_sc'_def
                         ps_clear_upd objBits_simps)
   done
@@ -4227,7 +4227,7 @@ lemma schedContextZeroRefillMax_invs'[wp]:
    schedContextZeroRefillMax scPtr
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (clarsimp simp: schedContextZeroRefillMax_def)
-  apply (wpsimp wp: setSchedContext_invs')
+  apply (wpsimp wp: setSchedContext_invs' simp: updateSchedContext_def)
   apply (frule (1) invs'_ko_at_valid_sched_context')
   apply (fastforce intro!: if_live_then_nonz_capE'
                      simp: ko_wp_at'_def obj_at'_def projectKOs live_sc'_def
@@ -4909,7 +4909,7 @@ lemma schedContextZeroRefillMax_corres:
   "corres dc (\<lambda>s. sc_at scPtr s) (sc_at' scPtr)
           (sched_context_zero_refill_max scPtr) (schedContextZeroRefillMax scPtr)"
   apply (clarsimp simp: sched_context_zero_refill_max_def schedContextZeroRefillMax_def
-                        set_refills_def sc_at_sc_obj_at)
+                        set_refills_def sc_at_sc_obj_at updateSchedContext_def)
   apply (rule corres_underlying_lift_ex1')
   apply (rule corres_guard_imp)
     apply (subst bind_dummy_ret_val, subst update_sched_context_decompose[symmetric])

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -3024,12 +3024,12 @@ lemma refillUnblockCheck_corres:
 
 lemma updateRefillHd_valid_objs':
   "\<lbrace>valid_objs' and active_sc_at' scPtr\<rbrace> updateRefillHd scPtr f \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (clarsimp simp: updateRefillHd_def2 updateSchedContext_def)
-  apply (wpsimp wp: )
+  apply (clarsimp simp: updateRefillHd_def updateSchedContext_def)
+  apply wpsimp
   apply (frule (1) sc_ko_at_valid_objs_valid_sc')
   apply (clarsimp simp: valid_sched_context'_def active_sc_at'_def obj_at'_real_def ko_wp_at'_def
                         valid_sched_context_size'_def objBits_def objBitsKO_def projectKO_sc
-                        length_replaceAt)
+                        length_updateAt)
   done
 
 lemma getCTE_cap_to_refs[wp]:
@@ -3276,7 +3276,7 @@ lemma updateRefillHd_bound_tcb_sc_at[wp]:
   "updateRefillHd scPtr f \<lbrace>obj_at' (\<lambda>a. \<exists>y. scTCB a = Some y) t\<rbrace>"
   supply if_split [split del]
   unfolding updateRefillHd_def
-  apply (wpsimp wp: set_sc'.obj_at')
+  apply (wpsimp wp: set_sc'.obj_at' simp: updateSchedContext_def)
   by (clarsimp simp: obj_at'_real_def ko_wp_at'_def split: if_split)
 
 crunches refillUnblockCheck

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -3981,6 +3981,7 @@ lemma get_sched_context_no_fail:
                      gets_def obj_at_def is_sc_obj_def gets_the_def
               split: Structures_A.kernel_object.splits)
 
+(* FIXME RT: rename *)
 (* this let us cross the sc size information from concrete to abstract *)
 lemma ko_at'_cross:
   assumes p: "pspace_relation (kheap s) (ksPSpace s')"

--- a/proof/refine/ARM/SchedContextInv_R.thy
+++ b/proof/refine/ARM/SchedContextInv_R.thy
@@ -384,15 +384,214 @@ lemma valid_sc_size_sc_relation:
   "\<lbrakk>valid_sched_context_size n; sc_relation sc n sc'\<rbrakk> \<Longrightarrow> n = objBits sc' - minSchedContextBits"
   by (clarsimp simp: sc_relation_def objBits_simps valid_sched_context_size_def scBits_simps)
 
-lemma state_relation_sc_update:
+(* FIXME RT: Move to Lib *)
+lemma last_take:
+  "\<lbrakk>ls \<noteq> []; 0 < n; n \<le>  length ls\<rbrakk> \<Longrightarrow>last (take n ls) = ls ! (n - 1)"
+  by (induct ls arbitrary: n; fastforce simp: take_Cons nth_Cons split: nat.splits)
+
+lemma take_drop_nth:
+  "\<lbrakk> 0 < n; n < length ls\<rbrakk> \<Longrightarrow> take 1 (drop n ls) = [ls ! n]"
+  apply (induct ls arbitrary: n; clarsimp simp: drop_Cons nth_Cons)
+  by (case_tac n; simp add: drop_Suc_nth)
+
+(* wrap_slice *)
+lemma wrap_slice_start_0:
+  "\<lbrakk>0 < count; mx \<le> length ls; count \<le> mx\<rbrakk> \<Longrightarrow> wrap_slice 0 count mx ls = take count ls"
+  by (clarsimp simp: wrap_slice_def)
+
+lemma butlast_wrap_slice:
+  "\<lbrakk>0 < count; start < mx; count \<le> mx; mx \<le> length list\<rbrakk> \<Longrightarrow>
+   butlast (wrap_slice start count mx list) =  wrap_slice start (count -1) mx list"
+  by (case_tac "start + count - 1 < mx"; clarsimp simp: wrap_slice_def butlast_conv_take add_ac)
+
+lemma last_wrap_slice:
+  "\<lbrakk>0 < count; start < mx; count \<le> mx; mx \<le> length list\<rbrakk>
+   \<Longrightarrow> last (wrap_slice start count mx list)
+           = list ! (if start + count - 1 < mx then start + count - 1 else start + count - mx -1)"
+  by (fastforce simp: wrap_slice_def last_take last_append not_le)
+
+lemma tl_wrap_slice:
+  "\<lbrakk>0 < count; mx \<le> length list; start < mx\<rbrakk> \<Longrightarrow>
+   tl (wrap_slice start count mx list) = wrap_slice (start + 1) (count - 1) mx list"
+  by (fastforce simp: wrap_slice_def tl_take tl_drop drop_Suc)
+
+lemma wrap_slice_max[simp]:
+  "wrap_slice start count start list = take count list"
+  by (clarsimp simp: wrap_slice_def)
+
+lemma length_refills_map[simp]:
+  "\<lbrakk> mx \<le> length list; count \<le> mx \<rbrakk> \<Longrightarrow> length (refills_map start count mx list) = count"
+  by (clarsimp simp: refills_map_def)
+
+(* updateAt *)
+(* FIXME RT: add [simp] *)
+declare length_updateAt[simp]
+declare length_replaceAt[simp]
+
+lemma updateAt_index:
+  "\<lbrakk>xs \<noteq> []; i < length xs; j < length xs\<rbrakk>
+   \<Longrightarrow> (updateAt i xs f) ! j = (if i = j then f (xs ! i) else (xs ! j))"
+  by (fastforce simp: updateAt_def null_def nth_append)
+
+lemma wrap_slice_updateAt_eq:
+  "\<lbrakk>if start + count \<le> mx
+       then (i < start \<or> start + count \<le> i)
+       else (start + count - mx \<le> i \<and> i < start);
+    count \<le> mx; start < mx; mx \<le> length xs; xs \<noteq> []; i < mx\<rbrakk>
+   \<Longrightarrow> wrap_slice start count mx xs = wrap_slice start count mx (updateAt i xs new)"
+  apply (rule nth_equalityI)
+   apply clarsimp
+  by (subst wrap_slice_index; clarsimp simp: updateAt_index split: if_split_asm)+
+
+lemma take_updateAt_eq[simp]:
+  "n \<le> i \<Longrightarrow> take n (updateAt i ls f) = take n ls" 
+  by (clarsimp simp: updateAt_def)
+
+lemma valid_obj'_scPeriod_update[simp]:
+  "valid_obj' (KOSchedContext (scPeriod_update (\<lambda>_. period) sc')) = valid_obj' (KOSchedContext sc')"
+  by (fastforce simp: valid_obj'_def valid_sched_context'_def valid_sched_context_size'_def objBits_simps)
+
+(* should all wp rules for valid_objs/valid_objs' be in this form? *)
+lemma updateSchedContext_valid_objs'[wp]:
+  "\<lbrace>valid_objs' and
+    (\<lambda>s. ((\<lambda>sc'. valid_obj' (injectKOS sc') s \<longrightarrow> valid_obj' (injectKOS (f' sc')) s)
+              |< scs_of' s) scp)\<rbrace>
+    updateSchedContext scp f'
+   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  apply (wpsimp simp: updateSchedContext_def wp: set_sc'.valid_objs')
+  by (fastforce simp: valid_obj'_def valid_sched_context'_def valid_sched_context_size'_def
+                      obj_at'_def projectKOs scBits_simps objBits_simps opt_map_left_Some)
+
+lemma updateSchedContext_obj_at'[wp]:
+  "\<forall>sc'. objBits sc' = objBits (f' sc'::sched_context) \<Longrightarrow>
+   updateSchedContext scp f' \<lbrace>\<lambda>s. P (sc_at' p s)\<rbrace>"
+  apply (wpsimp simp: updateSchedContext_def wp: set_sc'.set_wp)
+  apply (clarsimp simp: obj_at'_def ps_clear_upd projectKOs objBits_simps)
+  done
+
+(* it would be good to rewrite all update wp rules in this form *)
+lemma updateSchedContext_wp:
+  "\<lbrace> \<lambda>s. sc_at' sc_ptr s \<longrightarrow>
+       Q (s\<lparr>ksPSpace := ksPSpace s(sc_ptr \<mapsto> KOSchedContext (f' (the (scs_of' s sc_ptr))))\<rparr>) \<rbrace>
+   updateSchedContext sc_ptr f'
+   \<lbrace> \<lambda>rv. Q \<rbrace>"
+  by (wpsimp simp: updateSchedContext_def wp: set_sc'.set_wp)
+     (clarsimp simp: obj_at'_def projectKOs opt_map_left_Some elim!: rsubst[where P=Q])
+
+lemma no_fail_setSchedContext[wp]:
+  "no_fail (sc_at' ptr and (\<lambda>s'. pred_map (\<lambda>k::sched_context. objBits k = objBits new) (scs_of' s') ptr)) (setSchedContext ptr new)"
+  unfolding setSchedContext_def by (wpsimp simp: pred_map_simps obj_at'_def projectKOs)
+
+lemma no_fail_updateSchedContext[wp]:
+  "no_fail (sc_at' ptr and (\<lambda>s'. pred_map (\<lambda>k::sched_context. objBits k = objBits (f k)) (scs_of' s') ptr))
+         (updateSchedContext ptr f)"
+  by (wpsimp simp: updateSchedContext_def obj_at'_def projectKOs pred_map_simps opt_map_Some)
+
+(* rewrite rules for updateSchedCOntext *)
+lemma updateSchedContext_decompose:
+   "monadic_rewrite False True
+     (sc_at' scPtr and K (\<forall>sc. objBits (f sc) = objBits sc) and K (\<forall>sc. objBits (g sc) = objBits sc))
+     (updateSchedContext scPtr (g o f))
+     (do updateSchedContext scPtr f;
+         updateSchedContext scPtr g
+      od)"
+  unfolding updateSchedContext_def bind_assoc o_def
+  using getSchedContext_setSchedContext_decompose by blast
+
+lemma updateSchedContext_decompose_twice:
+  "\<lbrakk>\<forall>sc. objBits (f sc) = objBits sc; \<forall>sc. objBits (g sc) = objBits sc;
+    \<forall>sc. objBits (h sc) = objBits sc\<rbrakk> \<Longrightarrow>
+    monadic_rewrite False True
+     (sc_at' scPtr)
+     (updateSchedContext scPtr (h o g o f))
+     (do updateSchedContext scPtr f;
+         updateSchedContext scPtr g;
+         updateSchedContext scPtr h
+      od)"
+  apply (rule monadic_rewrite_imp)
+   apply (rule monadic_rewrite_trans)
+    apply (rule updateSchedContext_decompose)
+   apply (rule monadic_rewrite_bind_tail)
+    apply simp
+    apply (rule updateSchedContext_decompose[simplified])
+   apply (wpsimp wp: updateSchedContext_wp)
+  apply (clarsimp simp: obj_at_simps opt_map_def ps_clear_upd)
+  done
+
+lemma updateSchedContext_decompose_thrice:
+  "\<lbrakk>\<forall>sc. objBits (f sc) = objBits sc; \<forall>sc. objBits (g sc) = objBits sc;
+    \<forall>sc. objBits (h sc) = objBits sc;  \<forall>sc. objBits (k sc) = objBits sc\<rbrakk> \<Longrightarrow>
+    monadic_rewrite False True
+     (sc_at' scPtr)
+     (updateSchedContext scPtr (k o h o g o f))
+     (do updateSchedContext scPtr f;
+         updateSchedContext scPtr g;
+         updateSchedContext scPtr h;
+         updateSchedContext scPtr k
+      od)"
+  apply (rule monadic_rewrite_imp)
+   apply (rule monadic_rewrite_trans)
+    apply (rule updateSchedContext_decompose)
+   apply (rule monadic_rewrite_bind_tail)
+    apply simp
+    apply (rule updateSchedContext_decompose_twice[simplified]; simp)
+   apply (wpsimp wp: updateSchedContext_wp)
+  apply (clarsimp simp: obj_at_simps ps_clear_upd opt_map_def)
+  done
+
+(* projection project *)
+
+(* it would be good to rewrite all getting wp rules in this form *)
+lemma getSchedContext_wp':
+  "\<lbrace>\<lambda>s. sc_at' p s  \<longrightarrow> P (the (scs_of' s p)) s\<rbrace> getSchedContext p \<lbrace>P\<rbrace>"
+  by (wpsimp simp: obj_at'_def projectKOs opt_map_left_Some)
+
+lemma is_active_sc'_cross:
+  assumes p: "pspace_relation (kheap s) (ksPSpace s')"
+  assumes t: "is_active_sc2 ptr s"
+  shows "is_active_sc' ptr s'"
+  using assms
+  supply projection_rewrites[simp]
+  apply (clarsimp simp: projectKOs is_active_sc2_def is_active_sc'_def
+                 split: option.split_asm Structures_A.kernel_object.split_asm)
+  apply (drule (1) pspace_relation_absD, clarsimp split: if_split_asm)
+  by (case_tac z; simp add: sc_relation_def)
+
+lemma set_refills_is_active_sc2[wp]:
+  "set_refills ptr new \<lbrace>is_active_sc2 ptr'\<rbrace>"
+  apply (wpsimp simp: is_active_sc2_def wp: set_refills_wp)
+  by (clarsimp simp: obj_at_def opt_map_def)
+
+lemma ovalid_readRefillReady'[rule_format, simp]:
+  "ovalid (\<lambda>s. sc_at' scp s \<longrightarrow> P (((\<lambda>sc'. rTime (refillHd sc') \<le> ksCurTime s + kernelWCETTicks) |< scs_of' s) scp) s)
+              (readRefillReady scp) P"
+  unfolding readRefillReady_def readSchedContext_def ovalid_def
+  by (fastforce simp: obind_def opt_map_left_Some obj_at'_def projectKOs
+                dest: use_ovalid[OF ovalid_readCurTime]
+               dest!: readObject_misc_ko_at'
+               split: option.split_asm)+
+
+lemma refillReady_wp':
+  "\<lbrace>\<lambda>s. sc_at' scp s \<longrightarrow> P (((\<lambda>sc'. rTime (refillHd sc') \<le> ksCurTime s + kernelWCETTicks) |< scs_of' s) scp) s\<rbrace>
+    refillReady scp \<lbrace>P\<rbrace>"
+  unfolding refillReady_def
+  by wpsimp (drule use_ovalid[OF ovalid_readRefillReady'])
+
+(* end : projection project *)
+
+lemma state_relation_sc_update':
   assumes
-      R1: "\<forall>sc n sc'. P sc \<longrightarrow> P' sc' \<longrightarrow> sc_relation sc n sc' \<longrightarrow> sc_relation (f sc) n (f' sc')"
-  and R2: "\<forall>sc sc' s'. P sc \<longrightarrow> P' sc' \<longrightarrow> heap_ls (replyPrevs_of s') (scReply sc') (sc_replies sc)
-                         \<longrightarrow> heap_ls (replyPrevs_of s') (scReply (f' sc')) (sc_replies (f sc))"
+      R1: "\<forall>s s'. (s, s') \<in> state_relation \<longrightarrow>
+         P s \<longrightarrow> P' s' \<longrightarrow> sc_at ptr s \<longrightarrow> sc_at' ptr s' \<longrightarrow>
+           (\<forall>n. (((\<lambda>ko. obj_bits ko = min_sched_context_bits + n) |< kheap s) ptr) \<longrightarrow>
+           sc_relation (the ((scs_of2 s ||> f) ptr)) n (the ((scs_of' s' ||> f') ptr)))"
+  and R2: "\<forall>s s'. (s, s') \<in> state_relation \<longrightarrow>                
+         P s \<longrightarrow> P' s' \<longrightarrow> sc_at ptr s \<longrightarrow> sc_at' ptr s' \<longrightarrow>
+           heap_ls (replyPrevs_of s')  (scReply (the ((scs_of' s' ||> f') ptr)))
+             (sc_replies (the ((scs_of2 s ||> f) ptr)))"
   and sz: "\<forall>sc'::sched_context. objBits sc' = objBits (f' sc')"
   shows
-  "\<lbrakk>(s, s') \<in> state_relation; sc_at ptr s; sc_at' ptr s';
-    P (the ((kheap s |> sc_of) ptr)); P' (the (scs_of' s' ptr))\<rbrakk> \<Longrightarrow>
+  "\<lbrakk>(s, s') \<in> state_relation; P s; P' s'; sc_at ptr s; sc_at' ptr s'\<rbrakk> \<Longrightarrow>
      (kheap_update (\<lambda>hp p. if p = ptr
                            then
                              case hp ptr of
@@ -406,6 +605,7 @@ lemma state_relation_sc_update:
                                      \<Rightarrow> Some (KOSchedContext (f' sc'))
                                  | _ \<Rightarrow> hp' ptr
                                 else hp' p)) s') \<in> state_relation"
+  supply projection_rewrites[simp]
   proof -
   have z': "\<And>s. sc_at' ptr s
                \<Longrightarrow> \<forall>sc'::sched_context. map_to_ctes ((\<lambda>hp' p. if p = ptr then case hp' ptr of
@@ -418,15 +618,17 @@ lemma state_relation_sc_update:
   have S: "\<And>(v::'a::pspace_storable). (1 :: word32) < 2 ^ (objBits v)"
     by (clarsimp simp: obj_at_simps objBits_defs pteBits_def pdeBits_def scBits_pos_power2
                 split: kernel_object.splits arch_kernel_object.splits)
-  assume H: "(s, s') \<in> state_relation" "sc_at ptr s" "sc_at' ptr s'"
-  and   H': "P (the ((kheap s |> sc_of) ptr))"
-            "P' (the (scs_of' s' ptr))"
+  assume H: "(s, s') \<in> state_relation" "P s" "P' s'" "sc_at ptr s" "sc_at' ptr s'"
   show ?thesis
-    using H H' S assms
+    using H S sz
+  apply -
+    apply (insert R1[rule_format, OF H(1) H(2) H(3) H(4) H(5)]
+                  R2[rule_format, OF H(1) H(2) H(3) H(4) H(5)])
     apply (clarsimp simp: state_relation_def)
     apply (clarsimp simp: obj_at_def is_sc_obj)
+    apply (drule_tac x=n in meta_spec, clarsimp)
     apply (prop_tac "obj_at (same_caps (kernel_object.SchedContext _ n)) ptr s")
-     apply (clarsimp simp: obj_at_def)
+     apply (clarsimp simp: obj_at_def obj_bits_def)
     apply (clarsimp simp: obj_at'_def projectKOs fun_upd_def[symmetric]
                           z[simplified obj_at'_def projectKO_eq projectKO_opts_defs])
     apply (rename_tac n sc sc')
@@ -441,22 +643,18 @@ lemma state_relation_sc_update:
      apply (frule bspec, erule domI)
      apply (rule ballI, drule(1) bspec)
      apply (drule domD)
-     apply (clarsimp simp: project_inject opt_map_left_Some sc_of_def
+     apply (clarsimp simp: project_inject  
                     split: if_split_asm kernel_object.split_asm)
-     apply (drule_tac x=sc in spec)+
-     apply clarsimp
-    apply (drule_tac x=n and y=sc' in spec2)
-     apply (drule_tac x=sc' in spec)+
-     apply clarsimp
+     apply (drule_tac x=sc' in spec)
      apply (rename_tac bb aa ba)
      apply (drule_tac x="(aa, ba)" in bspec, simp)
      apply (clarsimp simp: objBits_def)
      apply (frule_tac ko'="kernel_object.SchedContext sc n" and x'=ptr in obj_relation_cut_same_type)
         apply simp+
      apply (erule obj_relation_cutsE)
-            apply (simp split: if_split_asm)+
+            apply ((simp split: if_split_asm)+)[8]
     (* sc_replies_relation *)
-    apply (frule (1) sc_replies_relation_prevs_list')
+    apply (frule (1) sc_replies_relation_prevs_list'[simplified])
     apply (subst replyPrevs_of_non_reply_update[simplified]; (simp add: typ_at'_def ko_wp_at'_def)?)
     apply (simp add: sc_replies_relation_def)
     apply (clarsimp simp: vs_all_heap_simps sc_replies_of_scs_def map_project_def opt_map_left_Some)
@@ -485,41 +683,20 @@ lemma state_relation_sc_update:
     done
 qed
 
-lemma updateSchedContext_decompose:
-   "monadic_rewrite False True
-     (sc_at' scPtr and K (\<forall>sc. objBits (f sc) = objBits sc) and K (\<forall>sc. objBits (g sc) = objBits sc))
-     (updateSchedContext scPtr (g o f))
-     (do updateSchedContext scPtr f;
-         updateSchedContext scPtr g
-      od)"
-  unfolding updateSchedContext_def bind_assoc o_def
-  using getSchedContext_setSchedContext_decompose by blast
-
-lemma updateSchedContext_wp:
-  "\<lbrace> \<lambda>s. \<forall>sc'::sched_context. ko_at' sc' sc_ptr s
-                \<longrightarrow> Q (s\<lparr>ksPSpace := ksPSpace s(sc_ptr \<mapsto> KOSchedContext (f' sc'))\<rparr>) \<rbrace>
-   updateSchedContext sc_ptr f'
-   \<lbrace> \<lambda>rv. Q \<rbrace>"
-  by (wpsimp simp: updateSchedContext_def wp: set_sc'.set_wp)
-
-lemma no_fail_setSchedContext[wp]:
-  "no_fail (sc_at' ptr and (\<lambda>s'. pred_map (\<lambda>k::sched_context. objBits k = objBits new) (scs_of' s') ptr)) (setSchedContext ptr new)"
-  unfolding setSchedContext_def by (wpsimp simp: pred_map_simps obj_at'_def projectKOs)
-
-lemma no_fail_updateSchedContext[wp]:
-  "no_fail (sc_at' ptr and (\<lambda>s'. pred_map (\<lambda>k::sched_context. objBits k = objBits (f k)) (scs_of' s') ptr))
-         (updateSchedContext ptr f)"
-  by (wpsimp simp: updateSchedContext_def obj_at'_def projectKOs pred_map_simps opt_map_Some)
-
-lemma updateSchedContext_corres_gen:
+lemma updateSchedContext_corres_gen':
   assumes
-      R1: "\<forall>sc n sc'. P sc \<longrightarrow> P' sc' \<longrightarrow> sc_relation sc n sc' \<longrightarrow> sc_relation (f sc) n (f' sc')"
-  and R2: "\<forall>sc sc' s'. P sc \<longrightarrow> P' sc' \<longrightarrow> heap_ls (replyPrevs_of s') (scReply sc') (sc_replies sc)
-                         \<longrightarrow> heap_ls (replyPrevs_of s') (scReply (f' sc')) (sc_replies (f sc))"
+      R1: "\<forall>s s'. (s, s') \<in> state_relation \<longrightarrow>
+           P s \<longrightarrow> P' s' \<longrightarrow> sc_at ptr s \<longrightarrow> sc_at' ptr s' \<longrightarrow>
+           (\<forall>n. (((\<lambda>ko. obj_bits ko = min_sched_context_bits + n) |< kheap s) ptr)\<longrightarrow>
+           sc_relation (the ((scs_of2 s ||> f) ptr)) n (the ((scs_of' s' ||> f') ptr)))"
+  and R2: "\<forall>s s'. (s, s') \<in> state_relation \<longrightarrow>                
+          P s \<longrightarrow> P' s' \<longrightarrow> sc_at ptr s \<longrightarrow> sc_at' ptr s' \<longrightarrow>
+           heap_ls (replyPrevs_of s')  (scReply (the ((scs_of' s' ||> f') ptr)))
+             (sc_replies (the ((scs_of2 s ||> f) ptr)))"
   and sz: "\<forall>sc'::sched_context. objBits sc' = objBits (f' sc')"
   shows "corres dc
-         (sc_at ptr and (\<lambda>s. P (the ((kheap s |> sc_of) ptr))))
-         (sc_at' ptr and (\<lambda>s'. P' (the (scs_of' s' ptr))))
+         (sc_at ptr and P)
+         (sc_at' ptr and P')
             (update_sched_context ptr f)
             (updateSchedContext ptr f')"
   unfolding corres_underlying_def using sz
@@ -535,9 +712,9 @@ lemma updateSchedContext_corres_gen:
    apply (rule_tac x="((), s\<lparr>kheap := kheap s(ptr \<mapsto>
                   kernel_object.SchedContext (f sc) n)\<rparr>)" in bexI)
     apply clarsimp
-    apply (drule state_relation_sc_update[OF R1 R2 sz, simplified])
+    apply (drule state_relation_sc_update'[OF R1 R2 sz, simplified])
       apply ((fastforce simp: obj_at_def is_sc_obj obj_at'_def projectKOs)+)[4]
-    apply (clarsimp simp: obj_at_def obj_at'_def projectKOs fun_upd_def
+    apply (clarsimp simp: obj_at_def obj_at'_def projectKOs fun_upd_def opt_map_left_Some
                     cong: abstract_state.ext_split)
     apply (clarsimp cong: kernel_state.ext_split)
    apply (clarsimp simp: update_sched_context_def obj_at_def in_monad
@@ -546,44 +723,39 @@ lemma updateSchedContext_corres_gen:
                     simp: obj_at'_def pred_map_simps projectKOs opt_map_simps)
   done
 
-lemmas updateSchedContext_corres = updateSchedContext_corres_gen[where P=\<top> and P'=\<top>, simplified]
+lemmas updateSchedContext_corres = updateSchedContext_corres_gen'[where P=\<top> and P'=\<top>, simplified]
 
 lemma refillAddTail_corres:
   "time = time' \<and> amount = amount'
    \<Longrightarrow> corres dc (sc_at sc_ptr)
-                 (obj_at' (\<lambda>sc'. scRefillHead sc' < scRefillMax sc' \<and> 0 < scRefillCount sc'
-                                 \<and> scRefills sc' \<noteq> [] \<and> scRefillCount sc' < scRefillMax sc'
-                                 \<and> scRefillMax sc' \<le> length (scRefills sc')) sc_ptr)
+                 (sc_at' sc_ptr and
+                  (\<lambda>s'. ((\<lambda>sc'. scRefillCount sc' < scRefillMax sc' \<and> std_sc' sc') |< scs_of' s') sc_ptr))
                  (refill_add_tail sc_ptr \<lparr>r_time = time, r_amount = amount\<rparr>)
                  (refillAddTail sc_ptr (Refill time' amount'))"
+  supply projection_rewrites[simp]
   apply (clarsimp simp: refill_add_tail_def refillAddTail_def getRefillNext_getSchedContext
                         getRefillSize_def2 liftM_def get_refills_def)
   apply (rule corres_symb_exec_r[OF _ get_sc_sp', rotated]; (solves wpsimp)?)+
   apply (rename_tac sc')
   apply (rule corres_guard_imp)
     apply (rule corres_assert_assume_r)
-    apply (rule updateSchedContext_corres_gen[where P=\<top> and P'="\<lambda>sc'. scRefillHead sc' < scRefillMax sc' \<and>
-                             0 < scRefillCount sc' \<and>
-                             scRefills sc' \<noteq> [] \<and>
-                             scRefillCount sc' < scRefillMax sc' \<and>
-                             scRefillMax sc' \<le> length (scRefills sc')"])
-      apply (clarsimp simp: sc_relation_def length_replaceAt)
+    apply (rule updateSchedContext_corres_gen'[where P=\<top>
+                and P'="(\<lambda>s'. ((\<lambda>sc'. scRefillCount sc' < scRefillMax sc' \<and> std_sc' sc') |< scs_of' s') sc_ptr)"])
+      apply (clarsimp, drule (3) state_relation_sc_relation)
+      apply (clarsimp simp: obj_at_simps is_sc_obj)
+      apply (rename_tac sc')
+      apply (clarsimp simp: sc_relation_def neq_Nil_lengthI)
+      apply (prop_tac "scRefills sc' \<noteq> []")
+       apply (clarsimp simp: neq_Nil_lengthI)
       apply (clarsimp simp: refills_map_def)
-      apply (subst wrap_slice_append)
-         apply simp
-        apply simp
-       apply (simp add: length_replaceAt)
+      apply (subst wrap_slice_append; simp)
       apply (insert less_linear)[1]
       apply (drule_tac x="scRefillMax sc'" and y="scRefillHead sc' + scRefillCount sc' + Suc 0" in meta_spec2)
       apply (erule disjE)
        apply (simp add: refillNextIndex_def refillTailIndex_def Let_def)
-       apply (intro conjI impI; clarsimp simp: Suc_diff_Suc wrap_slice_replaceAt_eq)
-          apply (clarsimp simp: nat_le_Suc_less)
-          apply (metis add_less_mono add_less_mono1 le_refl le_simps(1) mult_is_add.mult_commute nat_diff_less wrap_slice_replaceAt_eq)
-         apply (clarsimp simp: replaceAt_index refill_map_def)
-        apply (clarsimp simp: eq_diff_iff not_le)
-        apply (metis add.commute add_gr_0 less_add_same_cancel1 less_or_eq_imp_le wrap_slice_replaceAt_eq)
-       apply (clarsimp simp: replaceAt_index refill_map_def)
+       apply (intro conjI impI;
+              clarsimp simp: Suc_diff_Suc wrap_slice_replaceAt_eq[symmetric] neq_Nil_lengthI
+                             nat_le_Suc_less refill_map_def replaceAt_index)
       apply (erule disjE)
        apply clarsimp
        apply (rule conjI)
@@ -596,13 +768,14 @@ lemma refillAddTail_corres:
       apply (rule conjI)
        apply (clarsimp simp: refillNextIndex_def refillTailIndex_def Let_def)
        apply (intro conjI impI; (clarsimp simp: not_le wrap_slice_replaceAt_eq)?)
-       apply (metis add_leE le_refl le_simps(1) less_SucI mult_is_add.mult_commute nat_neq_iff not_less_eq trans_less_add2 wrap_slice_replaceAt_eq)
+       apply (metis add_leE le_refl le_simps(1) less_SucI mult_is_add.mult_commute nat_neq_iff
+                    not_less_eq trans_less_add2 wrap_slice_replaceAt_eq)
       apply (clarsimp simp: refillNextIndex_def refillTailIndex_def Let_def not_le)
       apply (clarsimp simp: replaceAt_index refill_map_def)
-     apply fastforce
-    apply (clarsimp simp: objBits_simps length_replaceAt)
+     apply (fastforce simp: obj_at_simps is_sc_obj dest!: state_relation_sc_replies_relation_sc)
+    apply (clarsimp simp: objBits_simps)
    apply (clarsimp simp: obj_at_def is_sc_obj)
-  apply (clarsimp simp: obj_at'_def projectKOs opt_map_def)
+  apply (clarsimp simp: obj_at'_def projectKOs)
   done
 
 lemma isRoundRobin_sp:
@@ -618,30 +791,28 @@ lemma isRoundRobin_sp:
 
 lemma maybeAddEmptyTail_corres:
   "corres dc
-          (is_active_sc sc_ptr)
-          (\<lambda>s'. obj_at' (\<lambda>sc'. scRefillHead sc' < scRefillMax sc' \<and> 0 < scRefillCount sc'
-                                \<and> scRefills sc' \<noteq> [] \<and> scRefillCount sc' < scRefillMax sc'
-                                \<and> scRefillMax sc' \<le> length (scRefills sc')) sc_ptr s')
+          (is_active_sc2 sc_ptr)
+                 (sc_at' sc_ptr and
+                  (\<lambda>s'. ((\<lambda>sc'. scRefillCount sc' < scRefillMax sc' \<and> std_sc' sc') |< scs_of' s') sc_ptr))
           (maybe_add_empty_tail sc_ptr)
           (maybeAddEmptyTail sc_ptr)" (is "corres _ ?abs ?conc _ _")
-  apply (rule corres_guard_imp[where Q="?abs" and Q'="?conc and sc_at' sc_ptr", rotated];
-         clarsimp simp add: obj_at'_def projectKOs)
+  supply projection_rewrites[simp]
   apply (rule corres_cross_add_abs_guard[where Q="sc_at sc_ptr"])
-   apply (fastforce simp: dest!: sc_at'_cross[OF state_relation_pspace_relation])
+   apply (fastforce dest!: sc_at'_cross[OF state_relation_pspace_relation])
   apply (clarsimp simp: maybe_add_empty_tail_def maybeAddEmptyTail_def get_refills_def)
   apply (rule corres_split'[rotated 2, OF is_round_robin_sp isRoundRobin_sp])
    apply (corressimp corres: isRoundRobin_corres)
-  apply (clarsimp simp: obj_at_def is_sc_obj vs_all_heap_simps)
+  apply (clarsimp simp: obj_at_def is_sc_obj)
   apply (clarsimp simp: when_def)
   apply (rule corres_split'[rotated 2, OF get_sched_context_sp get_sc_sp'])
    apply (corressimp corres: get_sc_corres)
    apply (fastforce intro: valid_objs_valid_sched_context_size
-                     simp: obj_at_def is_sc_obj_def vs_all_heap_simps)
+                     simp: obj_at_def is_sc_obj_def)
   apply (rename_tac sc')
   apply (corressimp corres: refillAddTail_corres)
   apply (frule refill_hd_relation; clarsimp simp: obj_at'_def projectKOs)
   apply (fastforce dest: valid_objs_valid_sched_context_size
-                   simp: obj_at_def is_sc_obj_def vs_all_heap_simps refill_map_def)
+                   simp: obj_at_def is_sc_obj_def refill_map_def)
   done
 
 lemma getRefills_sp:
@@ -655,54 +826,9 @@ lemma getRefills_sp:
   apply (clarsimp simp: obj_at'_def projectKOs)
   done
 
-lemma updateAt_index:
-  "\<lbrakk>xs \<noteq> []; i < length xs; j < length xs\<rbrakk>
-   \<Longrightarrow> (updateAt i xs f) ! j = (if i = j then f (xs ! i) else (xs ! j))"
-  by (fastforce simp: updateAt_def null_def nth_append)
-
-(* FIXME RT: move *)
-lemma active_sc_at_cross:
-  assumes p: "pspace_relation (kheap s) (ksPSpace s')"
-  assumes ps: "pspace_aligned s" "pspace_distinct s"
-  assumes t: "active_sc_at ptr s"
-  shows "active_sc_at' ptr s'"
-  using assms
-  apply (clarsimp simp: active_sc_at_def active_sc_at'_def projectKOs active_sc_def)
-  apply (drule (1) pspace_relation_absD, clarsimp split: if_split_asm)
-  apply (case_tac z; simp add: sc_relation_def)
-  by (fastforce dest!: aligned_distinct_ko_at'I[where 'a=sched_context] elim: obj_at'_weakenE)
-
-(* FIXME RT: add [simp] *)
-declare length_updateAt[simp]
-
-lemma wrap_slice_updateAt_eq:
-  "\<lbrakk>if start + count \<le> mx
-       then (i < start \<or> start + count \<le> i)
-       else (start + count - mx \<le> i \<and> i < start);
-    count \<le> mx; start < mx; mx \<le> length xs; xs \<noteq> []; i < mx\<rbrakk>
-   \<Longrightarrow> wrap_slice start count mx xs = wrap_slice start count mx (updateAt i xs new)"
-  apply (rule nth_equalityI)
-   apply clarsimp
-  by (subst wrap_slice_index; clarsimp simp: updateAt_index split: if_split_asm)+
-
-lemma take_updateAt_eq[simp]:
-  "n \<le> i \<Longrightarrow> take n (updateAt i ls f) = take n ls" 
-  by (clarsimp simp: updateAt_def)
-
-lemma tl_wrap_slice:
-  "\<lbrakk>0 < count; mx \<le> length list; start < mx\<rbrakk> \<Longrightarrow>
-   tl (wrap_slice start count mx list) = wrap_slice (start + 1) (count - 1) mx list"
-  by (fastforce simp: wrap_slice_def tl_take tl_drop drop_Suc)
-
-lemma wrap_slice_max[simp]:
-  "wrap_slice start count start list = take count list"
-  by (clarsimp simp: wrap_slice_def)
-
-thm valid_sched_context'_def active_sc_at_equiv
-
 lemma sc_relation_updateRefillHd:
   "\<lbrakk>sc_relation sc n sc'; \<forall>refill'. f (refill_map refill') = refill_map (f' refill');
-        scRefills sc' \<noteq> []; scRefillMax sc' \<le> length (scRefills sc');
+        scRefillMax sc' \<le> length (scRefills sc');
         scRefillHead sc' < scRefillMax sc'; scRefillCount sc' \<le> scRefillMax sc';
         0 < scRefillCount sc'\<rbrakk>
        \<Longrightarrow> sc_relation (sc_refills_update (\<lambda>refills. f (hd refills) # tl refills) sc) n
@@ -713,54 +839,34 @@ lemma sc_relation_updateRefillHd:
   apply (subst hd_Cons_tl[where xs="wrap_slice _ _ _ (updateAt _ _ _)", symmetric])
    apply (clarsimp intro!: neq_Nil_lengthI)
   apply simp
-  apply (subst hd_wrap_slice; (simp add: updateAt_index tl_wrap_slice)?)+
+  apply (subst hd_wrap_slice; (simp add: updateAt_index tl_wrap_slice neq_Nil_lengthI)?)+
   apply (case_tac "Suc (scRefillHead sc') < scRefillMax sc'")
    apply (prop_tac "wrap_slice (Suc (scRefillHead sc')) (scRefillCount sc' - Suc 0)
                  (scRefillMax sc') (updateAt (scRefillHead sc') (scRefills sc') f')
           = wrap_slice (Suc (scRefillHead sc')) (scRefillCount sc' - Suc 0) (scRefillMax sc') (scRefills sc')")
     apply (subst wrap_slice_updateAt_eq[symmetric]; clarsimp)
-     apply fastforce+
+     apply (fastforce simp: neq_Nil_lengthI)+
   apply (clarsimp simp: not_less le_eq_less_or_eq[where m="scRefillMax sc'" for sc'])
   done
 
 lemma updateRefillHd_corres:
-  "\<lbrakk>sc_ptr = scPtr;
-    \<forall>refill refill'. refill = refill_map refill' \<longrightarrow> f refill = (refill_map (f' refill'))\<rbrakk>
+  "\<lbrakk>sc_ptr = scPtr; \<forall>refill refill'. refill = refill_map refill' \<longrightarrow> f refill = (refill_map (f' refill'))\<rbrakk>
    \<Longrightarrow> corres dc
-        (pspace_aligned and pspace_distinct and sc_at sc_ptr and is_active_sc sc_ptr)
-        valid_objs'
+        (sc_at sc_ptr and is_active_sc2 sc_ptr)
+        ((\<lambda>s'. ((\<lambda>sc'. scRefillCount sc' \<le> scRefillMax sc' \<and> std_sc' sc') |< scs_of' s') sc_ptr) and sc_at' sc_ptr)
         (update_refill_hd sc_ptr f)
         (updateRefillHd scPtr f')"
-  apply (rule_tac Q="active_sc_at' sc_ptr" in corres_cross_add_guard)
-   apply (clarsimp simp: active_sc_at_equiv[symmetric])
-   apply (fastforce elim!: active_sc_at_cross[OF state_relation_pspace_relation])
+  supply projection_rewrites[simp]
+  apply (rule_tac Q="is_active_sc' scPtr" in corres_cross_add_guard)
+   apply (fastforce dest!: is_active_sc'_cross[OF state_relation_pspace_relation])
   apply (clarsimp simp: update_refill_hd_def updateRefillHd_def)
   apply (rule corres_guard_imp)
-    apply (rule updateSchedContext_corres_gen[where P=\<top> and P'="\<lambda>sc'. scRefills sc' \<noteq> []
-                      \<and> scRefillMax sc' \<le> length (scRefills sc') \<and>
-                      (scRefillHead sc' < scRefillMax sc' \<and>
-                       scRefillCount sc' \<le> scRefillMax sc' \<and> 0 < scRefillCount sc')"])
-      apply (clarsimp simp: sc_relation_updateRefillHd)
-     apply (clarsimp simp: objBits_simps)+
-  apply (clarsimp simp: active_sc_at'_def)
-  apply (drule obj_at_ko_at', clarsimp)
-  apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-  by (clarsimp simp: obj_at'_def projectKOs opt_map_left_Some valid_sched_context'_def MIN_REFILLS_def)
-
-lemma last_take:
-  "\<lbrakk>ls \<noteq> []; 0 < n; n \<le>  length ls\<rbrakk> \<Longrightarrow>last (take n ls) = ls ! (n - 1)"
-  by (induct ls arbitrary: n; fastforce simp: take_Cons nth_Cons split: nat.splits)
-
-lemma butlast_wrap_slice:
-  "\<lbrakk>0 < count; start < mx; count \<le> mx; mx \<le> length list\<rbrakk> \<Longrightarrow>
-   butlast (wrap_slice start count mx list) =  wrap_slice start (count -1) mx list"
-  by (case_tac "start + count - 1 < mx"; clarsimp simp: wrap_slice_def butlast_conv_take add_ac)
-
-lemma last_wrap_slice:
-  "\<lbrakk>0 < count; start < mx; count \<le> mx; mx \<le> length list\<rbrakk>
-   \<Longrightarrow> last (wrap_slice start count mx list)
-           = list ! (if start + count - 1 < mx then start + count - 1 else start + count - mx -1)"
-  by (fastforce simp: wrap_slice_def last_take last_append not_le)
+    apply (rule updateSchedContext_corres_gen'[where P=\<top>
+      and P'="(\<lambda>s'. ((\<lambda>sc'. scRefillCount sc' \<le> scRefillMax sc' \<and> std_sc' sc') |< scs_of' s') sc_ptr) and is_active_sc' scPtr"])
+      apply (clarsimp, drule (3) state_relation_sc_relation)
+      apply (fastforce simp: is_sc_obj obj_at_simps is_active_sc'_def elim!: sc_relation_updateRefillHd)
+     apply (fastforce simp: obj_at_simps is_sc_obj dest!: state_relation_sc_replies_relation_sc)
+  by (clarsimp simp: objBits_simps)+
 
 lemma sc_relation_updateRefillTl:
   "\<lbrakk> sc_relation sc n sc'; \<forall>refill'. f (refill_map refill') = refill_map (f' refill');
@@ -770,10 +876,8 @@ lemma sc_relation_updateRefillTl:
        \<Longrightarrow> sc_relation
             (sc_refills_update (\<lambda>refills. butlast refills @ [f (last refills)]) sc) n
             (scRefills_update (\<lambda>_. updateAt (refillTailIndex sc') (scRefills sc') f') sc')"
-apply (prop_tac "scRefills sc' \<noteq> []")
-apply fastforce
-
-
+  apply (prop_tac "scRefills sc' \<noteq> []")
+   apply fastforce
   apply (clarsimp simp: sc_relation_def refills_map_def)
   apply (simp add: snoc_eq_iff_butlast)
   apply (prop_tac "wrap_slice (scRefillHead sc') (scRefillCount sc') (scRefillMax sc')
@@ -783,7 +887,6 @@ apply fastforce
               (updateAt (refillTailIndex sc') (scRefills sc') f') \<noteq> []")
    apply (clarsimp intro!: neq_Nil_lengthI)
   apply clarsimp
-
   apply (prop_tac "wrap_slice (scRefillHead sc') (scRefillCount sc' - Suc 0)
              (scRefillMax sc')
              (updateAt (refillTailIndex sc') (scRefills sc') f') = wrap_slice (scRefillHead sc') (scRefillCount sc' - Suc 0)
@@ -802,24 +905,22 @@ lemma updateRefillTl_corres:
   "\<lbrakk>sc_ptr = scPtr;
     \<forall>refill refill'. refill = refill_map refill' \<longrightarrow> f refill = (refill_map (f' refill'))\<rbrakk>
    \<Longrightarrow> corres dc
-              (pspace_aligned and pspace_distinct and sc_at sc_ptr and active_sc_at sc_ptr)
-              valid_objs'
+              (sc_at sc_ptr and is_active_sc2 sc_ptr)
+              (sc_at' scPtr and valid_objs')
               (update_refill_tl sc_ptr f)
               (updateRefillTl scPtr f')"
-  apply (rule_tac Q="active_sc_at' sc_ptr" in corres_cross_add_guard)
-   apply (fastforce simp: active_sc_at_equiv[symmetric] elim!: active_sc_at_cross[OF state_relation_pspace_relation])
+  supply projection_rewrites[simp]
+  apply (rule_tac Q="is_active_sc' scPtr" in corres_cross_add_guard)
+   apply (fastforce dest!: is_active_sc'_cross[OF state_relation_pspace_relation])
   apply (clarsimp simp: update_refill_tl_def updateRefillTl_def)
   apply (rule corres_guard_imp)
-    apply (rule updateSchedContext_corres_gen[where P=\<top> and P'="\<lambda>sc'.
-     scRefillMax sc' \<le> length (scRefills sc') \<and>
-    (scRefillHead sc' < scRefillMax sc' \<and>
-     scRefillCount sc' \<le> scRefillMax sc' \<and> 0 < scRefillCount sc')"])
+    apply (rule updateSchedContext_corres_gen'[where P=\<top> and P'="valid_objs' and is_active_sc' scPtr"])
+      apply (clarsimp, drule (3) state_relation_sc_relation)
+      apply (clarsimp simp: is_sc_obj obj_at_simps is_active_sc'_def)
+      apply (erule (1) valid_objsE', clarsimp simp: valid_obj'_def valid_sched_context'_def)
       apply (clarsimp simp: sc_relation_updateRefillTl)
-     apply (clarsimp simp: objBits_simps)+
-  apply (clarsimp simp: active_sc_at'_def)
-  apply (drule obj_at_ko_at', clarsimp)
-  apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-  by (clarsimp simp: obj_at'_def projectKOs opt_map_left_Some valid_sched_context'_def MIN_REFILLS_def)
+     apply (fastforce simp: obj_at_simps is_sc_obj dest!: state_relation_sc_replies_relation_sc)
+  by (clarsimp simp: objBits_simps)+
 
 lemma getCurSc_sp:
   "\<lbrace>P\<rbrace>
@@ -843,88 +944,36 @@ lemma active_sc_at'_cross:
 
 lemma refillBudgetCheckRoundRobin_corres:
   "corres dc
-          (\<lambda>s. pspace_aligned s \<and> pspace_distinct s \<and> active_sc_valid_refills s \<and> cur_sc_active s
-               \<and> valid_objs s)
-          valid_objs'
+          (cur_sc_active and (\<lambda>s. sc_at (cur_sc s) s))
+          (valid_objs' and (\<lambda>s'. sc_at' (ksCurSc s') s'))
           (refill_budget_check_round_robin usage) (refillBudgetCheckRoundRobin usage)"
+  supply projection_rewrites[simp]
+  apply (subst is_active_sc_rewrite)
   apply (clarsimp simp: refill_budget_check_round_robin_def refillBudgetCheckRoundRobin_def)
   apply (rule corres_split'[rotated 2, OF gets_sp getCurSc_sp])
    apply (corressimp corres: getCurSc_corres)
-
-  apply (rule_tac Q="\<lambda>s. active_sc_at' (ksCurSc s) s" in corres_cross_add_guard)
-   apply (rule_tac sc_ptr="ksCurSc s'" in active_sc_at'_cross, simp+)
-    apply (fastforce dest: valid_objs_valid_sched_context_size )
-   apply (fastforce dest: valid_objs_valid_sched_context_size
-                    simp: vs_all_heap_simps obj_at_def is_sc_obj_def)
-
-  apply (rule_tac Q="\<lambda>_ s. pspace_aligned s \<and> pspace_distinct s \<and> cur_sc_active s \<and> sc_at scPtr s
-                           \<and> cur_sc s = scPtr \<and> sc_refills_sc_at (\<lambda>refills. refills \<noteq> []) scPtr s"
-              and Q'="\<lambda>_ s. valid_objs' s"
-               in corres_split'[rotated 2])
-     apply ((wpsimp wp: get_refills_wp simp: update_refill_hd_rewrite | wpsimp wp: set_refills_wp)+)[1]
-     apply (fastforce intro: valid_objs_valid_sched_context_size
-                       simp: obj_at_def is_sc_obj_def sc_at_pred_n_def vs_all_heap_simps)
-
-    apply (wpsimp wp: updateRefillHd_valid_objs')
-   apply (rule corres_guard_imp)
-     apply (rule_tac f="\<lambda>refill. refill\<lparr>r_amount := r_amount refill - usage\<rparr>"
-                 and f'="\<lambda>r. rAmount_update (\<lambda>_. rAmount r - usage) r"
-                  in updateRefillHd_corres)
-      apply simp
-     apply (clarsimp simp: refill_map_def)
-    apply (fastforce intro: valid_objs_valid_sched_context_size
-                      simp: active_sc_valid_refills_def valid_refills_def vs_all_heap_simps
-                            rr_valid_refills_def obj_at_kh_kheap_simps is_sc_obj_def)
-   apply simp
+  apply (rule_tac Q="\<lambda>s. is_active_sc' (ksCurSc s) s" in corres_cross_add_guard)
+   apply (rule_tac ptr="ksCurSc s'" in is_active_sc'_cross[OF state_relation_pspace_relation]; simp)
+   apply clarsimp
   apply (rule corres_guard_imp)
-    apply (rule_tac f="\<lambda>refill. refill\<lparr>r_amount := r_amount refill + usage\<rparr>"
-                and f'="\<lambda>r. rAmount_update (\<lambda>_. rAmount r + usage) r"
-                 in updateRefillTl_corres)
-     apply simp
-    apply (clarsimp simp: refill_map_def)
-   apply (clarsimp simp: vs_all_heap_simps obj_at_kh_kheap_simps is_sc_obj_def)
-  apply simp
-  done
-
-lemma valid_tcb_state'_sc_update:
-  "\<lbrakk> valid_objs' s; valid_sched_context' sc' s; sc_at' scPtr s;  ksPSpace s x = Some (KOTCB obj) \<rbrakk>
-     \<Longrightarrow> valid_tcb_state' (tcbState obj) (s\<lparr>ksPSpace := ksPSpace s(scPtr \<mapsto> KOSchedContext sc')\<rparr>)"
-  apply (rule valid_objsE', simp, simp)
-  by (fastforce simp: typ_at'_same_type ps_clear_upd objBits_simps valid_obj'_def projectKOs
-                      valid_tcb_state'_def valid_bound_obj'_def valid_tcb'_def obj_at'_def
-               split: option.splits thread_state.splits)
-
-lemma valid_cap'_sc_update:
-  "\<lbrakk> valid_cap' cap s; valid_objs' s; valid_sched_context' sc' s; obj_at' (\<lambda>sc::sched_context. objBits sc = objBits sc') scPtr s \<rbrakk>
-     \<Longrightarrow> valid_cap' cap (s\<lparr>ksPSpace := ksPSpace s(scPtr \<mapsto> KOSchedContext sc')\<rparr>)"
-  supply ps_clear_upd[simp]
-  apply (clarsimp simp: typ_at'_same_type ko_wp_at'_def cte_at'_same_type
-                        valid_cap'_def obj_at'_def projectKOs objBits_simps
-                 split: capability.splits)
-         apply fastforce+
-       apply (clarsimp split: zombie_type.splits simp: projectKOs obj_at'_def typ_at'_same_type)
-       apply (intro conjI impI; clarsimp)
-        apply (drule_tac x=addr in spec, clarsimp)
-       apply (drule_tac x=addr in spec, clarsimp)
-      apply (clarsimp simp: ko_wp_at'_def valid_cap'_def obj_at'_def projectKOs objBits_simps
-                            page_directory_at'_def page_table_at'_def scBits_simps
-                     split: ARM_H.arch_capability.splits option.splits if_split_asm
-           | rule_tac ko="KOSchedContext obj" in typ_at'_same_type[where p'=scPtr]
-           | simp)+
-     apply fastforce
-    apply (clarsimp simp: valid_untyped'_def ko_wp_at'_def obj_range'_def split: if_split_asm)
-     apply (drule_tac x=scPtr in spec, fastforce simp: objBits_simps)+
-   apply (drule_tac x=addr in spec, fastforce)
-  apply fastforce
+    apply (rule corres_split[OF updateRefillHd_corres], simp)
+       apply (clarsimp simp: refill_map_def)
+      apply (rule updateRefillTl_corres, simp)
+      apply (clarsimp simp: refill_map_def)
+     apply (wpsimp simp: update_refill_hd_rewrite wp: set_refills_wp get_refills_wp)
+    apply (wpsimp wp: hoare_vcg_conj_lift)
+     apply (wpsimp simp: updateRefillHd_def wp: updateSchedContext_wp)
+    apply (wpsimp wp: updateRefillHd_valid_objs')
+   apply (clarsimp simp: obj_at_def is_active_sc2_def is_sc_obj
+                  split: option.split_asm Structures_A.kernel_object.split_asm)
+  apply (clarsimp simp: obj_at_simps fun_upd_def[symmetric] scBits_simps ps_clear_upd)
+  apply (erule (1) valid_objsE')
+  apply (clarsimp simp: is_active_sc'_def valid_obj'_def valid_sched_context'_def
+                 split: option.split_asm)
   done
 
 lemmas sc_relation_refillResetRR1 =
   sc_relation_updateRefillTl[where f="r_amount_update (\<lambda>_. 0)" and f'="rAmount_update (\<lambda>_. 0)"]
-
-lemma take_drop_nth:
-  "\<lbrakk> 0 < n; n < length ls\<rbrakk> \<Longrightarrow> take 1 (drop n ls) = [ls ! n]"
-  apply (induct ls arbitrary: n; clarsimp simp: drop_Cons nth_Cons)
-  by (case_tac n; simp add: drop_Suc_nth)
 
 lemma sc_relation_refillResetRR2:
   "\<lbrakk>sc_relation sc n sc'; length (sc_refills sc) = 2; sc_refill_max sc = MIN_REFILLS;
@@ -976,52 +1025,39 @@ lemma sc_relation_refillResetRR:
   apply (drule sc_relation_refillResetRR2; fastforce?)
   by (drule sc_relation_refillResetRR1; clarsimp simp: refill_map_def)
 
-lemma length_refills_map[simp]:
-  "\<lbrakk> mx \<le> length list; count \<le> mx \<rbrakk> \<Longrightarrow> length (refills_map start count mx list) = count"
-  by (clarsimp simp: refills_map_def)
-
 lemma refillResetRR_corres:
-  "corres dc (pspace_aligned and pspace_distinct and sc_at csc_ptr and is_active_sc csc_ptr
+  "corres dc (sc_at csc_ptr and is_active_sc csc_ptr
                   and round_robin csc_ptr and valid_refills csc_ptr)
-             valid_objs'
+             (valid_objs' and sc_at' csc_ptr)
              (refill_reset_rr csc_ptr) (refillResetRR csc_ptr)"
   (is "corres dc ?abs ?conc _ _")
-  apply (rule_tac Q="active_sc_at' csc_ptr" in corres_cross_add_guard)
-   apply (simp add: active_sc_at_equiv[symmetric])
-   apply (fastforce elim: active_sc_at_cross[OF state_relation_pspace_relation])
-  apply (rule_tac Q="obj_at' (\<lambda>sc'. length (refills_map (scRefillHead sc') (scRefillCount sc')
-                                                    (scRefillMax sc') (scRefills sc')) = 2) csc_ptr"
+  supply projection_rewrites[simp]
+  apply (subst is_active_sc_rewrite)
+  apply (subst valid_refills_rewrite)
+  apply (rule_tac Q="is_active_sc' csc_ptr" in corres_cross_add_guard)
+   apply (fastforce dest!: is_active_sc'_cross[OF state_relation_pspace_relation])
+  apply (rule_tac Q="\<lambda>s'. ((\<lambda>sc'. scRefillCount sc' = 2) |< scs_of' s') csc_ptr"
          in corres_cross_add_guard)
-   apply (clarsimp simp: active_sc_at'_def valid_refills_def rr_valid_refills_def vs_all_heap_simps
-                         round_robin_def obj_at'_def projectKOs obj_relation_cuts_def
-                  dest!: pspace_relation_absD[where x=csc_ptr, OF _ state_relation_pspace_relation])
+   apply (clarsimp simp: obj_at'_def projectKOs round_robin2_def obj_at_def is_sc_obj
+                         rr_valid_refills_def is_active_sc2_def is_active_sc'_def)
    apply (drule (1) pspace_relation_absD[where x=csc_ptr, OF _ state_relation_pspace_relation])
-   apply (clarsimp simp: sc_relation_def opt_map_left_Some MIN_REFILLS_def split: if_split_asm)
-
-  apply (clarsimp simp: sc_at_pred_n_def obj_at_def is_sc_obj_def)
+   apply (erule (1) valid_objsE')
+   apply (clarsimp simp: sc_relation_def refills_map_def valid_sched_context'_def valid_obj'_def)
   apply (clarsimp simp: refill_reset_rr_def refillResetRR_def get_refills_def updateRefillTl_def
                         update_sched_context_decompose[symmetric, simplified] update_refill_tl_def)
   apply (rule corres_guard_imp)
     apply (rule monadic_rewrite_corres'[OF _ monadic_rewrite_sym[OF updateSchedContext_decompose[simplified]]])
-    apply (rule updateSchedContext_corres_gen[where
-                P="\<lambda>sc. length (sc_refills sc) = 2 \<and> sc_refill_max sc = MIN_REFILLS"
-            and P'="\<lambda>sc'. scRefillMax sc' \<le> length (scRefills sc')
-                        \<and> scRefillHead sc' < scRefillMax sc'
-                        \<and> scRefillCount sc' \<le> scRefillMax sc' \<and> 1 < scRefillCount sc'"])
-      apply (intro allI impI)
-      apply (rule sc_relation_refillResetRR; simp)
-     apply clarsimp
-    apply (clarsimp simp: objBits_simps)
-   apply (clarsimp simp: vs_all_heap_simps obj_at_def is_sc_obj sc_of_def opt_map_def
-                         round_robin_def valid_refills_def rr_valid_refills_def)
-  apply (clarsimp simp: active_sc_at'_def)
-  apply (drule obj_at_ko_at', clarsimp)
-  apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-  by (clarsimp simp: obj_at'_def projectKOs opt_map_left_Some valid_sched_context'_def objBits_simps)
-
-lemma wrap_slice_start_0:
-  "\<lbrakk>0 < count; mx \<le> length ls; count \<le> mx\<rbrakk> \<Longrightarrow> wrap_slice 0 count mx ls = take count ls"
-  by (clarsimp simp: wrap_slice_def)
+    apply (rule updateSchedContext_corres_gen'[where
+                 P="(\<lambda>s. ((\<lambda>sc. length (sc_refills sc) = 2 \<and> sc_refill_max sc = MIN_REFILLS) |< scs_of2 s) csc_ptr)"
+            and P'="valid_objs' and is_active_sc' csc_ptr and (\<lambda>s'. ((\<lambda>sc'. scRefillCount sc' = 2) |< scs_of' s') csc_ptr)"])
+      apply (clarsimp, drule (3) state_relation_sc_relation)
+      apply (clarsimp simp: is_sc_obj obj_at_simps is_active_sc'_def)
+      apply (erule (1) valid_objsE', clarsimp simp: valid_obj'_def valid_sched_context'_def)
+      apply (fastforce elim!: sc_relation_refillResetRR[simplified])
+     apply (fastforce simp: obj_at_simps is_sc_obj dest!: state_relation_sc_replies_relation_sc)
+     apply (clarsimp simp: objBits_simps)+
+   apply (clarsimp simp: round_robin2_def obj_at_def is_sc_obj rr_valid_refills_def)
+  by (clarsimp simp: objBits_simps)
 
 lemma refillPopHead_corres:
   "corres (\<lambda>refill refill'. refill = refill_map refill')
@@ -1031,67 +1067,42 @@ lemma refillPopHead_corres:
               (refill_pop_head sc_ptr) (refillPopHead sc_ptr)"
   (is "corres _ ?abs ?conc _ _")
   supply if_split[split del]
+  supply projection_rewrites[simp]
+  apply (subst is_active_sc_rewrite)
   apply (rule corres_cross[where Q' = "sc_at' sc_ptr", OF sc_at'_cross_rel], fastforce)
+  apply (rule_tac Q="is_active_sc' sc_ptr" in corres_cross_add_guard)
+   apply (fastforce dest!: is_active_sc'_cross[OF state_relation_pspace_relation])
   apply (clarsimp simp: refill_pop_head_def refillPopHead_def)
   apply (clarsimp simp: getRefillNext_getSchedContext get_refills_def liftM_def)
   apply (rule corres_split'[rotated 2, OF get_sched_context_sp get_sc_sp'])
    apply (rule corres_guard_imp)
      apply (rule get_sc_corres)
     apply simp
-   apply (clarsimp simp: active_sc_at'_def elim: obj_at'_weakenE)
+   apply simp
   apply (rename_tac sc')
-  apply (rule_tac F="scRefillMax sc' \<le> length (scRefills sc') \<and> (scRefillHead sc' < scRefillMax sc'
-                     \<and> scRefillCount sc' \<le> scRefillMax sc' \<and> 0 < scRefillCount sc')" in corres_req)
-   apply clarsimp
-   apply (drule sc_ko_at_valid_objs_valid_sc'; clarsimp simp: valid_sched_context'_def)
-   apply (clarsimp simp: projectKOs active_sc_at'_def obj_at'_def sc_relation_def vs_all_heap_simps
-                         active_sc_def obj_at_def)
+  apply (rule_tac F="refill_hd sc = refill_map (refillHd sc')" in corres_req)
+   apply (clarsimp simp: obj_at_def is_sc_obj obj_at'_def projectKOs)
+   apply (frule (1) pspace_relation_absD[OF _ state_relation_pspace_relation])
+   apply (clarsimp elim!: refill_hd_relation)
+   apply (erule (1) valid_objsE', clarsimp simp: valid_obj'_def valid_sched_context'_def is_active_sc'_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split'[OF updateSchedContext_corres_gen[where
-                                    P="\<lambda>sc. 1 < length (sc_refills sc)"
-                                and P'="\<lambda>sc'. scRefillMax sc' \<le> length (scRefills sc')
-                                              \<and> (scRefillHead sc' < scRefillMax sc'
-                                              \<and> scRefillCount sc' \<le> scRefillMax sc'
-                                              \<and> 0 < scRefillCount sc')"]])
-         apply (clarsimp simp: sc_relation_def refills_map_def tl_map)
+    apply (rule corres_split'[OF updateSchedContext_corres_gen'[where
+                                    P="(\<lambda>s. ((\<lambda>sc. 1 < length (sc_refills sc)) |< scs_of2 s) sc_ptr)"
+                                and P'="valid_objs' and is_active_sc' sc_ptr"]])
+         apply (clarsimp, drule (3) state_relation_sc_relation)
+         apply (clarsimp simp: sc_relation_def refills_map_def tl_map obj_at_simps is_sc_obj)
+         apply (erule (1) valid_objsE', clarsimp simp: valid_obj'_def valid_sched_context'_def)
          apply (subst tl_wrap_slice; clarsimp simp: min_def split: if_split)
          apply (rule conjI impI; clarsimp simp: refillNextIndex_def wrap_slice_start_0 split: if_splits)
+        apply (fastforce simp: obj_at_simps is_sc_obj dest!: state_relation_sc_replies_relation_sc)
         apply clarsimp
        apply (clarsimp simp: objBits_simps)
       apply simp
-      apply (prop_tac "refills_map (scRefillHead sc') (scRefillCount sc')
-                       (scRefillMax sc') (scRefills sc') \<noteq> []")
-       apply (clarsimp intro!: neq_Nil_lengthI simp: refills_map_def)
-      apply (clarsimp simp: sc_relation_def refills_map_def hd_map refillHd_def hd_wrap_slice)
      apply (wpsimp wp: update_sched_context_wp)
     apply (wpsimp wp: updateSchedContext_wp)
-   apply (clarsimp simp: sc_refills_sc_at_def obj_at_def sc_of_def opt_map_def)
-  apply (clarsimp simp: obj_at'_def projectKOs opt_map_left_Some)
+   apply (clarsimp simp: sc_refills_sc_at_def obj_at_def)
+  apply simp
   done
-
-lemma updateSchedContext_decompose_twice:
-  "\<lbrakk>\<forall>sc. objBits (f sc) = objBits sc; \<forall>sc. objBits (g sc) = objBits sc;
-     \<forall>sc. objBits (h sc) = objBits sc\<rbrakk> \<Longrightarrow>
-    monadic_rewrite False True
-     (sc_at' scPtr)
-     (updateSchedContext scPtr (h o g o f))
-     (do updateSchedContext scPtr f;
-         updateSchedContext scPtr g;
-         updateSchedContext scPtr h
-      od)"
-  apply (rule monadic_rewrite_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule updateSchedContext_decompose)
-   apply (rule monadic_rewrite_bind_tail)
-    apply simp
-    apply (rule updateSchedContext_decompose[simplified])
-   apply (wpsimp wp: updateSchedContext_wp)
-  apply (clarsimp simp: obj_at'_def projectKOs ps_clear_upd objBits_def)
-  done
-
-abbreviation
-  opt_pred :: "('a \<Rightarrow> bool) \<Rightarrow> 'a option \<Rightarrow> bool" (infixl "|P" 50) where
-  "P |P opt \<equiv> case_option False P opt"
 
 lemma refillNew_corres:
   "\<lbrakk>1 < max_refills; valid_refills_number' max_refills (min_sched_context_bits + n)\<rbrakk>
@@ -1099,369 +1110,242 @@ lemma refillNew_corres:
          (pspace_aligned and pspace_distinct and sc_obj_at n sc_ptr) \<top>
             (refill_new sc_ptr max_refills budget period)
             (refillNew sc_ptr max_refills budget period)"
+  supply projection_rewrites[simp]
+  supply getSchedContext_wp[wp del] set_sc'.get_wp[wp del]
   apply (rule corres_cross_add_guard[where
-      Q = "sc_at' sc_ptr and (\<lambda>s'. (\<lambda>sc. objBits sc = minSchedContextBits + n) |P scs_of' s' sc_ptr)"])
+      Q = "sc_at' sc_ptr and (\<lambda>s'. ((\<lambda>sc. objBits sc = minSchedContextBits + n) |< scs_of' s') sc_ptr)"])
    apply (fastforce dest!: sc_obj_at_cross[OF state_relation_pspace_relation]
-                     simp: obj_at'_def pred_map_simps projectKOs opt_map_def)
+                     simp: obj_at'_def projectKOs)
   apply (unfold refillNew_def refill_new_def setRefillHd_def updateRefillHd_def)
-  apply (rule corres_split'[OF _ _ gets_sp getCurTime_sp])
-   apply (rule corres_guard_imp)
-     apply (rule getCurTime_corres)
-    apply simp+
-  apply (rule stronger_corres_guard_imp)
-    (* period *)
-    apply (rule corres_split[OF updateSchedContext_corres]; (clarsimp simp: sc_relation_def objBits_simps)?)
-      (* budget *)
-      apply (rule corres_split[OF updateSchedContext_corres]; (clarsimp simp: sc_relation_def objBits_simps)?)
-        (* max_refills, sc_refills update *)
-        (* rewrite into one step updateSchedContext corres *)
-        apply (subst bind_assoc[symmetric])
-        apply (subst update_sched_context_decompose[symmetric, simplified])
-        apply (subst bind_assoc[symmetric])
-        apply (subst bind_assoc[symmetric])
-        apply (subst bind_assoc)
-        apply (rule corres_split[OF  monadic_rewrite_corres'
-                                       [OF _ monadic_rewrite_sym
-                                               [OF updateSchedContext_decompose_twice[simplified]]]])
-              (* use setSchedContext_corres *)
-              apply (rule monadic_rewrite_corres[OF _ update_sched_context_rewrite[where n=n]])
-              apply (simp add: updateSchedContext_def)
-              apply (rule corres_split[OF get_sc_corres])
-                apply (rename_tac sc')
-                apply (rule_tac P="ko_at (kernel_object.SchedContext sc n) sc_ptr"
-                            and P'="ko_at' sc' sc_ptr
-                                    and (\<lambda>s'. (\<lambda>sc. objBits sc = minSchedContextBits + n) |P scs_of' s' sc_ptr)"
-                       in corres_inst)
-                apply (rule_tac F="length (scRefills sc') = max_num_refills (min_sched_context_bits + n)"
-                       in corres_req)
-                 apply (clarsimp simp: obj_at'_def projectKOs opt_map_left_Some objBits_simps scBits_simps)
-                using scBits_inverse_sc apply fastforce
-                apply (rule stronger_corres_guard_imp)
-                  apply (rule_tac sc'="sc'\<lparr> scRefillMax := max_refills,
-                                            scRefillHead := 0,
-                                            scRefillCount := Suc 0,
-                                            scRefills := updateAt 0 (scRefills sc') (\<lambda>r. Refill curTime budget)\<rparr>"
-                         in setSchedContext_corres)
-                   apply (clarsimp simp: sc_relation_def refill_map_def refills_map_def
-                                         wrap_slice_start_0 valid_refills_number'_def
-                                         max_num_refills_eq_refillAbsoluteMax')
-                   apply (case_tac "scRefills sc'"; simp add: updateAt_def null_def refill_map_def)
-                  apply (clarsimp simp: objBits_simps scBits_simps)
-                 apply simp
-                apply (clarsimp simp: objBits_simps scBits_simps obj_at'_def projectKOs obj_at_def is_sc_obj
-                               dest!: state_relation_sc_replies_relation)
-                apply (fastforce elim!: sc_replies_relation_prevs_list)
-               apply wpsimp+
-             apply (clarsimp simp: objBits_simps)+
-          (* last step : add tail *)
-          apply (rule maybeAddEmptyTail_corres[simplified dc_def])
+  apply (rule corres_guard_imp)
+    apply (rule corres_split_eqr[OF _ getCurTime_corres])
+      (* period *)
+      apply (rule corres_split[OF updateSchedContext_corres]; clarsimp simp: objBits_simps)
+     apply (fastforce simp: obj_at_simps is_sc_obj sc_relation_def
+                     dest!: state_relation_sc_relation)
+     apply (fastforce simp: obj_at_simps is_sc_obj dest!: state_relation_sc_replies_relation_sc)
+        (* budget *)
+        apply (rule corres_split[OF updateSchedContext_corres]; (clarsimp simp: objBits_simps)?)
+     apply (fastforce simp: obj_at_simps is_sc_obj sc_relation_def
+                     dest!: state_relation_sc_relation)
+           apply (fastforce simp: obj_at_simps is_sc_obj dest!: state_relation_sc_replies_relation_sc)
+          (* max_refills, sc_refills update *)
+          (* rewrite into one step updateSchedContext corres *)
+          apply (rename_tac ctime)
+          apply (rule_tac P="sc_obj_at n sc_ptr and (\<lambda>s. ctime = cur_time s)"
+                      and P'="sc_at' sc_ptr and (\<lambda>s'. ctime = ksCurTime s')
+                              and (\<lambda>s'. ((\<lambda>sc'. objBits sc' = minSchedContextBits + n) |< scs_of' s') sc_ptr)"
+                 in corres_inst)
+          apply (subst bind_assoc[symmetric])
+          apply (subst update_sched_context_decompose[symmetric, simplified])
+          apply (subst bind_assoc[symmetric])
+          apply (subst bind_assoc[symmetric])
+          apply (subst bind_assoc)
+          apply (rule corres_guard_imp)
+            apply (rule corres_split[OF  monadic_rewrite_corres'
+                                           [OF _ monadic_rewrite_sym
+                                                   [OF updateSchedContext_decompose_twice[simplified]]]])
+                  (* use setSchedContext_corres *)
+                  apply (rule monadic_rewrite_corres[OF _ update_sched_context_rewrite[where n=n]])
+                  apply (simp add: updateSchedContext_def)
+                  apply (rule corres_split[OF get_sc_corres])
+                    apply (rename_tac sc')
+                    apply (rule_tac P="ko_at (kernel_object.SchedContext sc n) sc_ptr"
+                                and P'="ko_at' sc' sc_ptr
+                                        and (\<lambda>s'. ((\<lambda>sc'. objBits sc' = minSchedContextBits + n) |< scs_of' s') sc_ptr)"
+                           in corres_inst)
+                    apply (rule_tac F="length (scRefills sc') = max_num_refills (min_sched_context_bits + n)"
+                           in corres_req)
+                     apply (clarsimp simp: obj_at'_def projectKOs objBits_simps scBits_simps)
+                    using scBits_inverse_sc apply fastforce
+                    apply (rule stronger_corres_guard_imp)
+                      apply (rule_tac sc'="sc'\<lparr> scRefillMax := max_refills,
+                                                scRefillHead := 0,
+                                                scRefillCount := Suc 0,
+                                                scRefills := updateAt 0 (scRefills sc') (\<lambda>r. Refill ctime budget)\<rparr>"
+                             in setSchedContext_corres)
+                       apply (clarsimp simp: sc_relation_def refills_map_def valid_refills_number'_def
+                                             wrap_slice_start_0 max_num_refills_eq_refillAbsoluteMax')
+                       apply (case_tac "scRefills sc'"; simp add: updateAt_def null_def refill_map_def)
+                      apply (clarsimp simp: objBits_simps scBits_simps)
+                     apply simp
+                    apply (fastforce simp: obj_at_simps is_sc_obj
+                                    dest!: sc_replies_relation_prevs_list'[OF state_relation_sc_replies_relation])
+                   apply (wpsimp wp: getSchedContext_wp')+
+                 apply (clarsimp simp: objBits_simps)+
+              (* last step : add tail *)
+              apply (rule_tac P="sc_obj_at n sc_ptr and is_active_sc2 sc_ptr"
+                          and P'="sc_at' sc_ptr
+                                  and (\<lambda>s'. ((\<lambda>sc'. objBits sc' = minSchedContextBits + n
+                                             \<and> scRefillHead sc' = 0 \<and> scRefillCount sc' = 1
+                                             \<and> scRefillMax sc' = max_refills) |< scs_of' s') sc_ptr)"
+                     in corres_inst)
+              apply (rule stronger_corres_guard_imp)
+                apply (rule maybeAddEmptyTail_corres[simplified dc_def])
+               apply simp
+              apply (clarsimp simp: obj_at_simps is_sc_obj objBits_simps scBits_simps
+                                    valid_refills_number'_def)
+              apply (drule (1) pspace_relation_absD[OF _ state_relation_pspace_relation, rotated])
+              using scBits_inverse_sc apply fastforce
+             apply (wpsimp wp: update_sched_context_wp updateSchedContext_wp)+
+           apply (clarsimp simp:  obj_at_def is_sc_obj is_active_sc2_def)
+          apply (clarsimp simp: obj_at_simps fun_upd_def[symmetric] valid_objs'_def ps_clear_upd)
          apply (wpsimp wp: update_sched_context_wp updateSchedContext_wp)+
-   apply (clarsimp simp: vs_all_heap_simps obj_at_def is_sc_obj active_sc_def sc_of_def)
-  apply (clarsimp simp: obj_at'_def projectKOs ps_clear_upd objBits_simps scBits_simps obj_at_def
-                        opt_map_left_Some fun_upd_def[symmetric] valid_refills_number'_def is_sc_obj)
-  apply (drule (1) pspace_relation_absD[OF _ state_relation_pspace_relation])
-  apply (clarsimp dest!: scBits_inverse_sc simp: updateAt_def null_def)
+   apply (clarsimp simp:  obj_at_def is_sc_obj is_active_sc2_def)
+  apply (clarsimp simp: obj_at_simps fun_upd_def[symmetric] valid_objs'_def ps_clear_upd)
   done
 
-lemma refill_update_bundled:
-  "refill_update sc_ptr period budget max_refills
-   = (do sc \<leftarrow> get_sched_context sc_ptr;
-         head \<leftarrow> return (refill_hd sc);
-         update_sched_context sc_ptr (\<lambda>sc. sc\<lparr>sc_refill_max := max_refills,
-                                              sc_refills := [head]\<rparr>);
-         set_sc_obj_ref sc_period_update sc_ptr period;
-         set_sc_obj_ref sc_budget_update sc_ptr budget;
-         ready \<leftarrow> get_sc_refill_ready sc_ptr;
-         when ready $ do cur_time \<leftarrow> gets cur_time;
-                         update_refill_hd sc_ptr (r_time_update (\<lambda>_. cur_time))
-                      od;
-         sc \<leftarrow> get_sched_context sc_ptr;
-         refill_hd \<leftarrow> return (refill_hd sc);
-         if budget \<le> r_amount refill_hd
-            then do update_refill_hd sc_ptr (r_amount_update (\<lambda>_. budget));
-                    maybe_add_empty_tail sc_ptr
-                 od
-            else do unused \<leftarrow> return $ budget - r_amount refill_hd;
-                    new \<leftarrow> return \<lparr>r_time = r_time refill_hd + period, r_amount = unused\<rparr>;
-                    refill_add_tail sc_ptr new
-                 od
-      od)"
-  apply (rule monadic_rewrite_to_eq)
-  apply (clarsimp simp: refill_update_def)
-  apply (simp flip: bind_assoc)
-  apply (rule monadic_rewrite_bind_head)+
-  apply (rule monadic_rewrite_bind_tail)
-  apply (clarsimp simp: monadic_rewrite_def set_refills_def)
-  apply (simp add: update_sched_context_decompose_ext2
-                       [where f=sc_refills_update and g=sc_refill_max_update]
-                   bind_assoc)
-  apply wpsimp
-  oops
-
-lemma refillUpdate_bundled:
-  "monadic_rewrite False True (sc_at' scPtr)
-     (refillUpdate scPtr newPeriod newBudget newMaxRefills)
-     (do sc \<leftarrow> getSchedContext scPtr;
-         do sca \<leftarrow> getSchedContext scPtr;
-            setSchedContext scPtr
-             (scRefills_update (\<lambda>_. replaceAt 0 (scRefills sca) (refillHd sc))
-              (scRefillMax_update (\<lambda>_. newMaxRefills)
-               (scRefillCount_update (\<lambda>_. 1)
-                (scRefillHead_update (\<lambda>_. 0) sca))))
-         od;
-         sc \<leftarrow> getSchedContext scPtr;
-         setSchedContext scPtr (scPeriod_update (\<lambda>_. newPeriod) sc);
-         sc \<leftarrow> getSchedContext scPtr;
-         setSchedContext scPtr (scBudget_update (\<lambda>_. newBudget) sc);
-         whenM (refillReady scPtr) $ do curTime \<leftarrow> getCurTime;
-                                        updateRefillHd scPtr (rTime_update (\<lambda>_. curTime))
-                                     od;
-         head \<leftarrow> liftM refillHd $ getSchedContext scPtr;
-         if newBudget \<le> rAmount head then do updateRefillHd scPtr (rAmount_update (\<lambda>_. newBudget));
-                                             maybeAddEmptyTail scPtr
-                                          od
-         else do unused \<leftarrow> return (newBudget - rAmount head);
-                 new \<leftarrow> return ( Refill_ \<lparr> rTime= rTime head + newPeriod, rAmount= unused \<rparr>);
-                 refillAddTail scPtr new
-        od
-      od)"
-  apply (clarsimp simp: refillUpdate_def setRefillIndex_def)
-  apply (simp flip: bind_assoc)
-  apply (rule monadic_rewrite_bind_head)+
-  apply (simp add: bind_assoc)
-  apply (rule monadic_rewrite_bind_tail[rotated, OF get_sc_inv'])
-  apply (subst bind_assoc_group4)
-  apply (rule monadic_rewrite_rewrite_head)
-   apply (rule monadic_rewrite_imp)
-    apply (rule monadic_rewrite_sym)
-    apply (rule getSchedContext_setSchedContext_decompose_decompose_ext2[unfolded K_bind_def])
-   apply (clarsimp simp: objBits_simps)
-  apply (simp only: bind_assoc)
-  apply (subst bind_assoc_group4)
-  apply (rule monadic_rewrite_rewrite_head)
-   apply (rule monadic_rewrite_imp)
-    apply (rule monadic_rewrite_sym)
-    apply (rule getSchedContext_setSchedContext_decompose_decompose_ext2[unfolded K_bind_def])
-   apply (clarsimp simp: objBits_simps)
-  apply (simp only: bind_assoc)
-  apply (rule monadic_rewrite_imp)
-   apply (rule monadic_rewrite_trans_dup)
-    apply (rule monadic_rewrite_sym)
-    apply (rule getSchedContext_setSchedContext_decompose[unfolded K_bind_def])
-   apply (rule monadic_rewrite_refl3)
-   apply clarsimp
-  apply (fastforce simp: objBits_simps length_replaceAt)
-  oops
-
 lemma refillUpdate_corres:
-  "1 < max_refills
+  "\<lbrakk>1 < max_refills; valid_refills_number' max_refills (min_sched_context_bits + n)\<rbrakk>
    \<Longrightarrow> corres dc
-              ((valid_objs and pspace_aligned and pspace_distinct and is_active_sc sc_ptr
-                and sc_at sc_ptr) and active_sc_valid_refills)
-              (\<lambda>s'. \<exists>n. sc_at'_n n sc_ptr s' \<and> valid_refills_number' max_refills n \<and> valid_objs' s')
-              (refill_update sc_ptr period budget max_refills )
+              ((is_active_sc2 sc_ptr and sc_obj_at n sc_ptr) and (pspace_aligned and pspace_distinct))
+              (\<lambda>s'. ((\<lambda>sc'. std_sc' sc') |< scs_of' s') sc_ptr)
+              (refill_update sc_ptr period budget max_refills)
               (refillUpdate sc_ptr period budget max_refills)"
-  (is "_ \<Longrightarrow> corres _ (?pred and _) ?conc _ _")
-  apply (rule corres_cross[where Q' = "sc_at' sc_ptr", OF sc_at'_cross_rel], fastforce)
-  apply (rule_tac Q="active_sc_at' sc_ptr" in corres_cross_add_guard)
-   apply (rule active_sc_at'_cross, simp+)
-
-
-
-
-
-
-
-
-  apply (subst refill_update_bundled)
-  apply (rule monadic_rewrite_corres'
-               [where P'=P' and Q=P' for P', simplified pred_conj_def, simplified, rotated])
-   apply (rule monadic_rewrite_imp)
-    apply (rule refillUpdate_bundled)
-apply (fold updateSchedContext_def)+
-   apply simp
-
-  apply (rule corres_split'[rotated 2, OF get_sched_context_sp get_sc_sp'])
-   apply (corressimp corres: get_sc_corres)
-  apply (rename_tac sc')
-  apply clarsimp
-  apply (subst update_sched_context_def)
-  apply (clarsimp simp: bind_assoc)
-  apply (rule corres_symb_exec_r[OF _ get_sc_sp', rotated]; (solves wpsimp)?)
-  apply (rename_tac sc'')
-  apply (rule_tac F="sc'' = sc'" in corres_req)
-   apply (clarsimp simp: obj_at'_def)
-  apply (clarsimp simp: pred_conj_def cong: conj_cong)
-  apply (rule corres_symb_exec_l[OF _ _ get_object_sp, rotated]; (solves wpsimp)?)
-    apply (fastforce intro: get_object_exs_valid simp: obj_at_def)
-   apply (wpsimp simp: obj_at_def)
-  apply (rename_tac obj)
-  apply (case_tac obj
-         ; clarsimp; (solves \<open>corressimp corres: corres_False simp: obj_at_def is_sc_obj_def\<close>)?)
-  apply (rename_tac abs_sc abs_n)
-  apply (rule_tac F="abs_sc = sc" in corres_req)
-   apply (clarsimp simp: obj_at_def)
-  apply clarsimp
-  apply (rule_tac Q="sc_obj_at (objBits sc' - minSchedContextBits) sc_ptr"
-               in corres_cross_add_abs_guard)
-   apply (fastforce dest!: state_relationD ko_at'_cross)
-
-  apply (rule_tac Q="\<lambda>_. ?pred and sc_refills_sc_at (\<lambda>refills. length refills = 1) sc_ptr"
-              and Q'="\<lambda>_. ?conc and sc_at' sc_ptr
-                          and obj_at' (\<lambda>sc. scRefillHead sc = 0 \<and> scRefillCount sc = 1
-                                            \<and> scRefillMax sc = max_refills) sc_ptr"
-               in corres_split'[rotated 2])
-     apply ((wpsimp wp: update_sched_context_valid_objs_update | wpsimp wp: set_object_wp)+)[1]
-     apply (fastforce dest!: active_sc_valid_refillsE
-                       simp: valid_refills_def vs_all_heap_simps rr_valid_refills_def
-                             valid_obj_def valid_sched_context_def active_sc_def sc_at_pred_n_def
-                             obj_at_def is_sc_obj_def)
-    apply ((wpsimp wp: hoare_vcg_ex_lift hoare_vcg_conj_lift | wpsimp wp: set_sc'.set_wp)+)[1]
-    apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-    apply (fastforce simp: valid_sched_context'_def length_replaceAt valid_refills_number'_def
-                           obj_at'_def projectKOs objBits_simps' ko_wp_at'_def scBits_inverse_sc
-                           valid_sched_context_size'_def)
-
-   apply (rule corres_assume_pre)
-   apply (rule corres_guard_imp)
-     apply (rule_tac f="\<lambda>sc. sc\<lparr>sc_refill_max := max_refills, sc_refills := [refill_hd sc]\<rparr>"
-                 and f'="\<lambda>sc'. scRefills_update (\<lambda>_. replaceAt 0 (scRefills sc') (refillHd sc'))
-                                (scRefillMax_update (\<lambda>_. max_refills)
-                                 (scRefillCount_update (\<lambda>_. Suc 0)
-                                  (scRefillHead_update (\<lambda>_. 0) sc')))"
-                  in setSchedContext_no_stack_update_corres)
-        apply (clarsimp simp: sc_relation_def)
-        apply (prop_tac "max_refills \<le> length (replaceAt 0 (scRefills sc') (refillHd sc'))")
-         apply (clarsimp simp: valid_refills_number'_def obj_at'_def projectKOs objBitsKO_def
-                               ko_wp_at'_def scBits_simps length_replaceAt)
-        apply (prop_tac "0 < scRefillCount sc' \<and> scRefillHead sc' < scRefillMax sc'
-                         \<and> scRefillMax sc' \<le> length (scRefills sc') \<and> 0 < length (scRefills sc')")
-         apply (prop_tac "sc_relation sc n sc'")
-          apply (fastforce simp: sc_relation_def)
-         apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-         apply (fastforce dest: sc_ko_at_valid_objs_valid_sc'
-                          simp: valid_sched_context'_def active_sc_at'_def obj_at'_def)
-        apply (intro conjI impI)
-         apply (clarsimp simp: refills_map_def)
-         apply (rule nth_equalityI; clarsimp)
-         apply (subst hd_conv_nth)
-          apply (rule length_greater_0_conv[THEN iffD1])
-          apply (subst length_map)
-          apply (subst length_wrap_slice; simp)
-         apply (subst nth_map)
-          apply (subst length_wrap_slice; simp)
-         apply (subst wrap_slice_index; simp)+
-         apply (subst replaceAt_index; fastforce simp: refillHd_def)
-        apply (fastforce simp: length_replaceAt)
-       apply fastforce
-      apply (fastforce simp: length_replaceAt objBits_simps)
-     apply simp
-    apply (clarsimp simp: obj_at_def)
-   apply (clarsimp simp: obj_at'_def)
-
-  apply (rule corres_symb_exec_r[OF _ get_sc_sp', rotated]; (solves wpsimp)?)
-  apply (rule_tac Q="\<lambda>_. ?pred and sc_refills_sc_at (\<lambda>refills. length refills = 1) sc_ptr"
-              and Q'="\<lambda>_. ?conc and sc_at' sc_ptr
-                          and obj_at' (\<lambda>sc. scRefillHead sc = 0 \<and> scRefillCount sc = 1
-                                            \<and> scRefillMax sc = max_refills) sc_ptr"
-               in corres_split'[rotated 2])
-     apply ((wpsimp wp: update_sched_context_valid_objs_update
-             | wpsimp wp: update_sched_context_wp)+)[1]
-     apply (fastforce dest!: valid_objs_ko_at
-                       simp: valid_obj_def valid_sched_context_def obj_at_def is_sc_obj_def
-                             sc_at_pred_n_def)
-    apply ((wpsimp wp: hoare_vcg_ex_lift hoare_vcg_conj_lift | wpsimp wp: set_sc'.set_wp)+)[1]
-    apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-    apply (fastforce simp: valid_sched_context'_def length_replaceAt valid_refills_number'_def
-                           obj_at'_def projectKOs objBits_simps' valid_sched_context_size'_def
-                           ps_clear_def)
-   apply (corressimp corres: update_sc_no_reply_stack_update_ko_at'_corres
-                               [where f'="scPeriod_update (\<lambda>_. period)"]
-                       simp: sc_relation_def objBits_simps)
-
-  apply (rule corres_symb_exec_r[OF _ get_sc_sp', rotated]; (solves wpsimp)?)
-  apply (rule_tac Q="\<lambda>_. ?pred and sc_refills_sc_at (\<lambda>refills. length refills = 1) sc_ptr"
-              and Q'="\<lambda>_. ?conc and sc_at' sc_ptr
-                          and obj_at' (\<lambda>sc. scRefillHead sc = 0 \<and> scRefillCount sc = 1
-                                            \<and> scRefillMax sc = max_refills) sc_ptr"
-               in corres_split'[rotated 2])
-     apply ((wpsimp wp: update_sched_context_valid_objs_update
-             | wpsimp wp: update_sched_context_wp)+)[1]
-     apply (fastforce dest!: valid_objs_ko_at
-                       simp: valid_obj_def valid_sched_context_def obj_at_def is_sc_obj_def
-                             sc_at_pred_n_def)
-    apply ((wpsimp wp: hoare_vcg_ex_lift hoare_vcg_conj_lift | wpsimp wp: set_sc'.set_wp)+)[1]
-    apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-    apply (fastforce simp: valid_sched_context'_def length_replaceAt valid_refills_number'_def
-                          obj_at'_def projectKOs objBits_simps' ko_wp_at'_def scBits_inverse_sc
-                          valid_sched_context_size'_def ps_clear_def)
-   apply (corressimp corres: update_sc_no_reply_stack_update_ko_at'_corres
-                               [where f'="scBudget_update (\<lambda>_. budget)"]
-                       simp: sc_relation_def objBits_simps)
-
-  apply (clarsimp simp: whenM_def ifM_def bind_assoc when_def getRefillNext_getSchedContext
-                        getRefillSize_def2 liftM_def)
-  apply (rule corres_split'[rotated 2, OF get_sc_refill_ready_inv refillReady_inv])
-   apply (corressimp corres: refillReady_corres)
-   apply (clarsimp simp: sc_at_pred_n_def obj_at_def)
-  apply (rule_tac Q="\<lambda>_. ?pred and sc_refills_sc_at (\<lambda>refills. length refills = 1) sc_ptr"
-              and Q'="\<lambda>_. valid_objs' and obj_at' (\<lambda>sc. scRefillHead sc = 0 \<and> scRefillCount sc = 1
-                                                         \<and> scRefillMax sc = max_refills) sc_ptr"
-              and r'=dc
-               in corres_split'[rotated 2])
-     apply (simp add: update_refill_hd_def set_refills_def)
-     apply ((wpsimp wp: update_sched_context_valid_objs_update get_refills_wp
-             | wpsimp wp: update_sched_context_wp get_refills_wp)+)[1]
-     apply (intro conjI impI allI)
-      apply (clarsimp simp: valid_sched_context_def)
-     apply (clarsimp simp: sc_at_pred_n_def obj_at_def)
-    apply ((wpsimp simp: updateRefillHd_def
-                     wp: set_sc'.valid_objs'
-            | wpsimp wp: set_sc'.set_wp)+)[1]
-    apply (fastforce dest: sc_ko_at_valid_objs_valid_sc'
-                     simp: valid_sched_context'_def valid_sched_context_size'_def objBits_simps
-                           valid_obj'_def length_replaceAt
-                           obj_at'_def projectKOs ps_clear_def)
-   apply (corressimp corres: getCurTime_corres updateRefillHd_corres
-                       simp: refill_map_def obj_at_kh_kheap_simps vs_all_heap_simps)
-   apply fastforce
-
-  apply clarsimp
-  apply (rule corres_split'[rotated 2, OF get_sched_context_sp get_sc_sp'])
-   apply (corressimp corres: get_sc_corres)
-  apply (rename_tac abs_sc conc_sc)
-  apply (rule_tac F="0 < scRefillCount conc_sc \<and> scRefillCount conc_sc \<le> scRefillMax conc_sc
-                     \<and> scRefillHead conc_sc < scRefillMax conc_sc
-                     \<and> scRefillMax conc_sc \<le> length (scRefills conc_sc)
-                     \<and> length (sc_refills abs_sc) = 1"
-               in corres_req)
-   apply (fastforce dest: sc_ko_at_valid_objs_valid_sc'
-                    simp: valid_sched_context'_def sc_relation_def sc_at_pred_n_def obj_at_def
-                          refills_map_def)
-  apply (clarsimp split del: if_split)
-  apply (frule_tac sc=abs_sc and sc'=conc_sc in refill_hd_relation; (solves simp)?)
-  apply (clarsimp simp: refill_map_def)
-  apply (intro conjI impI allI)
-   apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated[OF _ updateRefillHd_corres])
-         apply (rule maybeAddEmptyTail_corres)
-        apply simp
-       apply (clarsimp simp: refill_map_def)
-      apply (simp add: update_refill_hd_def set_refills_def)
-      apply ((wpsimp wp: update_sched_context_valid_objs_update get_refills_wp
-              | wpsimp wp: update_sched_context_wp get_refills_wp)+)[1]
-     apply (clarsimp simp: updateRefillHd_def)
-     apply (rule hoare_vcg_conj_lift
-            , (wpsimp wp: set_sc'.valid_objs'
-               | wpsimp wp: set_sc'.set_wp)+)[1]
-    apply (fastforce simp: obj_at_def active_sc_def vs_all_heap_simps sc_at_pred_n_def
-                           valid_sched_context_def)
-   apply (fastforce dest: sc_ko_at_valid_objs_valid_sc'
-                    simp: updateRefillHd_def valid_obj'_def valid_sched_context'_def
-                          valid_sched_context_size'_def length_replaceAt objBits_simps
-                          obj_at'_def projectKOs length_ineq_not_Nil(2))
-  apply (corressimp corres: refillAddTail_corres
-                      simp: obj_at'_def projectKOs refill_map_def obj_at_def is_sc_obj_def)
+  (is "_ \<Longrightarrow> _ \<Longrightarrow> corres _ (?pred and _) ?conc _ _")
+  supply getSchedContext_wp[wp del] set_sc'.get_wp[wp del] projection_rewrites[simp]
+  apply (rule corres_cross_add_guard[where
+      Q = "sc_at' sc_ptr and (\<lambda>s'. ((\<lambda>sc. objBits sc = minSchedContextBits + n) |< scs_of' s') sc_ptr)"])
+   apply (fastforce dest!: sc_obj_at_cross[OF state_relation_pspace_relation]
+                     simp: obj_at'_def projectKOs)
+  apply (rule_tac Q="is_active_sc' sc_ptr" in corres_cross_add_guard)
+   apply (rule is_active_sc'_cross, fastforce+)
+  apply (rule corres_guard_imp)
+    apply (rule_tac P="?pred" and P'="?conc and sc_at' sc_ptr" in corres_inst)
+    apply (unfold refillUpdate_def refill_update_def)
+    apply simp
+    (* rewrite the refill list update steps into one step updateSchedContext corres *)
+    apply (subst bind_assoc[where m="update_sched_context _ _", symmetric])
+    apply (subst update_sched_context_decompose[symmetric, simplified])
+    apply (subst bind_assoc[where m="updateSchedContext _ _", symmetric])
+    apply (subst bind_assoc[where m="do _ \<leftarrow> updateSchedContext _ _; updateSchedContext _ _ od", symmetric])
+    apply (subst bind_assoc[where m="do _ \<leftarrow> (do _ \<leftarrow> updateSchedContext _ _; updateSchedContext _ _ od);
+                                     updateSchedContext _ _ od", symmetric])
+    apply (subst bind_assoc[where m="updateSchedContext _ _"])
+    apply (subst bind_assoc[where m="updateSchedContext _ _"])
+    apply (subst bind_assoc[where m="updateSchedContext _ _"])
+    apply (rule stronger_corres_guard_imp)
+      apply (rule corres_split[OF  monadic_rewrite_corres'
+                                     [OF _ monadic_rewrite_sym
+                                             [OF updateSchedContext_decompose_thrice[simplified]]]])
+             (* now use setSchedContext_corres *)
+             apply (rule corres_inst[where P="?pred and sc_obj_at n sc_ptr" and P'="?conc and sc_at' sc_ptr"])
+             (* one of the sc_obj_at n sc_ptr will be consumed by the next line *)
+             apply (rule monadic_rewrite_corres[OF _ update_sched_context_rewrite[where n=n]])
+             apply (simp add: updateSchedContext_def)
+             apply (rule stronger_corres_guard_imp)
+               apply (rule corres_split[OF get_sc_corres])
+                 apply (rename_tac sc sc')
+                 apply (rule_tac P="?pred and ko_at (kernel_object.SchedContext sc n) sc_ptr"
+                             and P'="ko_at' sc' sc_ptr
+                                     and (\<lambda>s'. objBits sc' = minSchedContextBits + n
+                                                \<and> 0 < scRefillMax sc' \<and> std_sc' sc')"
+                        in corres_inst)
+                apply (rule_tac F="0 < scRefillMax sc' \<and> std_sc' sc'
+                                    \<and> length (scRefills sc') = max_num_refills (min_sched_context_bits + n)"
+                        in corres_req)
+                  apply clarsimp
+                  apply (clarsimp simp: obj_at'_def projectKOs objBits_simps scBits_simps)
+                  using scBits_inverse_sc apply fastforce
+                 apply (rule stronger_corres_guard_imp)
+                   apply (rule setSchedContext_corres)
+                    apply (unfold sc_relation_def; elim conjE exE; intro conjI; fastforce?)
+                    apply (clarsimp simp: refills_map_def wrap_slice_start_0 hd_map neq_Nil_lengthI
+                                          refill_map_def replaceAt_def null_def refillHd_def hd_wrap_slice
+                                          valid_refills_number'_def max_num_refills_eq_refillAbsoluteMax')
+                   apply (clarsimp simp: objBits_simps scBits_simps)
+                  apply simp
+                 apply (clarsimp simp: obj_at_simps scBits_simps is_sc_obj)
+                 apply (fastforce elim!: sc_replies_relation_prevs_list[OF state_relation_sc_replies_relation])
+                apply wpsimp
+               apply (wpsimp wp: getSchedContext_wp')
+              apply (clarsimp simp: obj_at_def is_sc_obj)
+             apply (drule state_relation_sc_relation[where ptr=sc_ptr and n=n];
+                   (fastforce simp: obj_at_simps is_sc_obj obj_bits_def)?)
+             apply (clarsimp simp: obj_at_simps is_sc_obj valid_refills_number'_def scBits_simps
+                            dest!: scRefills_length)
+            apply ((clarsimp simp: objBits_simps)+)[4]
+        (* sc_period *)
+        apply (rule corres_split[OF updateSchedContext_corres])
+             apply (fastforce dest!: state_relation_sc_relation simp: obj_at_simps is_sc_obj sc_relation_def)
+            apply (fastforce dest!: state_relation_sc_replies_relation_sc simp: obj_at_simps is_sc_obj sc_relation_def)
+           apply (simp add: objBits_simps)
+          (* sc_budget *)
+          apply (rule corres_split[OF updateSchedContext_corres])
+               apply (fastforce dest!: state_relation_sc_relation simp: obj_at_simps is_sc_obj sc_relation_def)
+              apply (fastforce dest!: state_relation_sc_replies_relation_sc simp: obj_at_simps is_sc_obj sc_relation_def)
+             apply (simp add: objBits_simps)
+            (* the rest *)
+            apply (rule_tac P="sc_obj_at n sc_ptr and
+                              (\<lambda>s. ((\<lambda>sc. sc_refills sc\<noteq> [] \<and> 0 < sc_refill_max sc) |< scs_of s) sc_ptr)"
+                       and P'="sc_at' sc_ptr and
+                              (\<lambda>s'. ((\<lambda>ko. 1 < scRefillMax ko \<and> scRefillCount ko = 1 \<and> std_sc' ko)
+                                            |< scs_of' s') sc_ptr)"
+                   in corres_inst)
+            apply (simp add: when_def[symmetric] whenM_def ifM_def bind_assoc split del: if_split)
+            apply (rule corres_guard_imp)
+              apply (rule corres_split[OF refillReady_corres]) (* projection version *)
+                (* when-block *)
+                apply (rule corres_split[OF corres_when], simp)
+                   apply (rule corres_split[OF getCurTime_corres])
+                     apply (rule corres_guard_imp)
+                       apply (rule updateRefillHd_corres, simp)
+                       apply (simp add: refill_map_def)
+                      apply (simp+)[2]
+                    apply (wpsimp+)[2]
+                  apply (simp add: liftM_def bind_assoc)
+                  apply (rule corres_split[OF get_sc_corres])
+                    (* if-block *)
+                    apply (rename_tac sc sc')
+                    apply (rule_tac P="ko_at (kernel_object.SchedContext sc n) sc_ptr
+                                        and K (0 < sc_refill_max sc) and K (sc_refills sc \<noteq> [])
+                                        and K (valid_sched_context_size n)"
+                                and P'="ko_at' sc' sc_ptr
+                                        and K (1 < scRefillMax sc' \<and> scRefillCount sc' = 1 \<and> std_sc' sc')"
+                           in corres_inst)
+                    apply (rule_tac F="refill_hd sc = refill_map (refillHd sc')" in corres_req)
+                     apply (fastforce dest!: refill_hd_relation)
+                    apply (rule corres_guard_imp)
+                      apply (rule corres_if)
+                        apply (clarsimp simp: refill_map_def)
+                       apply (rule corres_split[OF updateRefillHd_corres], simp)
+                          apply (clarsimp simp: refill_map_def)
+                         apply (rule maybeAddEmptyTail_corres)
+                        apply (wpsimp simp: update_refill_hd_rewrite)
+                       apply (wpsimp simp: updateRefillHd_def wp: updateSchedContext_wp)
+                      apply (rule refillAddTail_corres)
+                      apply (clarsimp simp: refill_map_def)
+                     apply (clarsimp simp: obj_at_def is_sc_obj is_active_sc2_def)
+                    apply (clarsimp simp: obj_at_simps  
+                                          is_sc_obj ps_clear_upd
+                                          scBits_simps fun_upd_def[symmetric])
+                   apply (clarsimp simp: obj_at'_def projectKOs objBits_simps)
+                   apply (clarsimp simp: valid_sched_context'_def valid_refills_number'_def neq_Nil_lengthI)
+                   apply wpsimp
+                  apply (wpsimp wp: getSchedContext_wp')
+                 apply (wpsimp simp: update_refill_hd_def wp: update_sched_context_wp)
+                apply (wpsimp simp: updateRefillHd_def objBits_simps
+                                wp: updateSchedContext_wp)
+               apply (wpsimp wp: get_sc_refill_ready_wp)
+              apply (wpsimp wp: refillReady_wp')
+             apply (fastforce simp: obj_at_def is_sc_obj is_active_sc2_def)
+            apply (fastforce simp: obj_at_simps ps_clear_upd fun_upd_def[symmetric])
+           apply (wpsimp wp: update_sched_context_wp)
+          apply (wpsimp wp: updateSchedContext_wp simp: objBits_simps)
+         apply (wpsimp wp: update_sched_context_wp)
+        apply (wpsimp wp: updateSchedContext_wp simp: objBits_simps)
+       apply (wpsimp wp: update_sched_context_wp)
+      apply (rule monadic_rewrite_refine_valid[where P''=\<top>, OF updateSchedContext_decompose_thrice, simplified])
+          apply ((clarsimp simp: objBits_simps)+)[4]
+      apply (wpsimp wp: updateSchedContext_wp simp: objBits_simps)
+     apply (clarsimp simp: obj_at_def is_sc_obj is_active_sc2_def)
+    apply (clarsimp simp: obj_at_simps scBits_simps ps_clear_upd fun_upd_def[symmetric]
+                          valid_refills_number'_def is_sc_obj)
+    apply (drule (1) pspace_relation_absD[OF _ state_relation_pspace_relation])
+    apply (fastforce simp: valid_sched_context'_def valid_obj'_def valid_refills_number'_def
+                           valid_sched_context_size'_def scBits_simps objBits_simps
+                    dest!: scRefills_length)
+   apply clarsimp+
   done
 
 (* FIXME RT: preconditions can be reduced, this is what is available at the call site: *)

--- a/spec/abstract/Ipc_A.thy
+++ b/spec/abstract/Ipc_A.thy
@@ -659,10 +659,10 @@ definition
   refill_reset_rr :: "obj_ref \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
   "refill_reset_rr csc_ptr = do
-     refills \<leftarrow> get_refills csc_ptr;
-     set_refill_hd csc_ptr \<lparr>r_time = r_time (hd refills),
-                            r_amount = r_amount (hd refills) + r_amount (hd (tl refills))\<rparr>;
-     set_refill_tl csc_ptr \<lparr>r_time = r_time (hd (tl refills)), r_amount = 0\<rparr>
+     update_sched_context csc_ptr
+         (sc_refills_update (\<lambda>refills. (r_amount_update
+                                           (\<lambda>m. m + r_amount (hd (tl refills)))) (hd refills) # (tl refills)));
+     update_refill_tl csc_ptr (r_amount_update (\<lambda>_. 0))
    od"
 
 definition

--- a/spec/abstract/SchedContext_A.thy
+++ b/spec/abstract/SchedContext_A.thy
@@ -327,10 +327,8 @@ definition
   refill_update :: "obj_ref \<Rightarrow> ticks \<Rightarrow> ticks \<Rightarrow> nat \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
   "refill_update sc_ptr new_period new_budget new_max_refills = do
-     sc \<leftarrow> get_sched_context sc_ptr;
-     refill_hd \<leftarrow> return (hd (sc_refills sc));
+     update_sched_context sc_ptr (sc_refills_update (\<lambda>rfs. [hd rfs]));
      set_sc_obj_ref sc_refill_max_update sc_ptr new_max_refills;
-     set_refills sc_ptr [refill_hd];
      set_sc_obj_ref sc_period_update sc_ptr new_period;
      set_sc_obj_ref sc_budget_update sc_ptr new_budget;
 

--- a/spec/abstract/SchedContext_A.thy
+++ b/spec/abstract/SchedContext_A.thy
@@ -104,10 +104,7 @@ where
 definition
   update_refill_hd :: "obj_ref \<Rightarrow> (refill \<Rightarrow> refill) \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
-  "update_refill_hd sc_ptr f = do
-     refills \<leftarrow> get_refills sc_ptr;
-     set_refills sc_ptr (f (hd refills) # (tl refills))
-   od"
+  "update_refill_hd sc_ptr f = update_sched_context sc_ptr (sc_refills_update (\<lambda>refills. f (hd refills) # (tl refills)))"
 
 definition
   set_refill_hd :: "obj_ref \<Rightarrow> refill \<Rightarrow> (unit, 'z::state_ext) s_monad"
@@ -117,10 +114,7 @@ where
 definition
   update_refill_tl :: "obj_ref \<Rightarrow> (refill \<Rightarrow> refill) \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
-  "update_refill_tl sc_ptr f = do
-     refills \<leftarrow> get_refills sc_ptr;
-     set_refills sc_ptr (butlast refills @ [f (last refills)])
-   od"
+  "update_refill_tl sc_ptr f = update_sched_context sc_ptr (sc_refills_update (\<lambda>refills. butlast refills @ [f (last refills)]))"
 
 definition
   set_refill_tl :: "obj_ref \<Rightarrow> refill \<Rightarrow> (unit, 'z::state_ext) s_monad"
@@ -130,10 +124,8 @@ where
 definition
   refill_add_tail :: "obj_ref \<Rightarrow> refill \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
-  "refill_add_tail sc_ptr new_refill = do
-     refills \<leftarrow> get_refills sc_ptr;
-     set_refills sc_ptr (refills @ [new_refill])
-   od"
+  "refill_add_tail sc_ptr new_refill =
+     update_sched_context sc_ptr (sc_refills_update (\<lambda>refills. refills @ [new_refill]))"
 
 definition
   maybe_add_empty_tail :: "obj_ref \<Rightarrow> (unit, 'z::state_ext) s_monad"
@@ -189,7 +181,7 @@ definition
 where
   "refill_pop_head sc_ptr \<equiv> do
      refills \<leftarrow> get_refills sc_ptr;
-     set_refills sc_ptr (tl refills);
+     update_sched_context sc_ptr (sc_refills_update tl);
      return (hd refills)
    od"
 
@@ -207,8 +199,7 @@ definition
 where
   "merge_refills sc_ptr \<equiv> do
      head \<leftarrow> refill_pop_head sc_ptr;
-     refills' \<leftarrow> get_refills sc_ptr;
-     set_refills sc_ptr (merge_refill head (hd refills') # (tl refills'))
+     update_refill_hd sc_ptr (merge_refill head)
    od"
 
 definition
@@ -226,8 +217,7 @@ where
     when (ready \<and> \<not>robin) $ do
       modify (\<lambda>s. s\<lparr> reprogram_timer := True \<rparr>);
       ct \<leftarrow> gets cur_time;
-      refills \<leftarrow> get_refills sc_ptr;
-      set_refill_hd sc_ptr ((hd refills)\<lparr>r_time := ct + kernelWCET_ticks\<rparr>);
+      update_refill_hd sc_ptr (r_time_update (\<lambda>_. ct + kernelWCET_ticks));
       refill_head_overlapping_loop sc_ptr
     od
   od"
@@ -254,10 +244,8 @@ definition
 where
   "non_overlapping_merge_refills sc_ptr \<equiv> do
      old_head \<leftarrow> refill_pop_head sc_ptr;
-     refills' \<leftarrow> get_refills sc_ptr;
-     set_refills sc_ptr (\<lparr>r_time = r_time (hd refills') - r_amount old_head,
-                          r_amount = r_amount (hd refills') + r_amount old_head\<rparr>
-                        # tl refills')
+     update_refill_hd sc_ptr (r_amount_update (\<lambda>m. m + r_amount old_head));
+     update_refill_hd sc_ptr (r_time_update (\<lambda>t. t - r_amount old_head))
    od"
 
 definition
@@ -288,12 +276,19 @@ where
      usage' \<leftarrow> return (usage - r_amount (refill_hd sc));
 
      if single
-        then set_refill_hd sc_ptr ((refill_hd sc)\<lparr>r_time := r_time (refill_hd sc) + sc_period sc\<rparr>)
+
+        then update_sched_context sc_ptr
+                         (\<lambda>sc. sc_refills_update (\<lambda>refills. (r_time_update (\<lambda>t. t + sc_period sc))
+                                                                    (hd refills) # (tl refills)) sc)
+\<comment>\<open>        then set_refill_hd sc_ptr ((refill_hd sc)\<lparr>r_time := r_time (refill_hd sc) + sc_period sc\<rparr>)\<close>
         else do old_head \<leftarrow> refill_pop_head sc_ptr;
                 full \<leftarrow> refill_full sc_ptr;
-                refills' \<leftarrow> get_refills sc_ptr;
+                update_sched_context sc_ptr (\<lambda>sc. sc_refills_update
+                                                  (\<lambda>refills. schedule_used full refills
+                                                   (old_head\<lparr>r_time := r_time old_head + sc_period sc\<rparr>)) sc)
+\<comment>\<open>                refills' \<leftarrow> get_refills sc_ptr;
                 set_refills sc_ptr $ schedule_used full refills'
-                                                   (old_head\<lparr>r_time := r_time old_head + sc_period sc\<rparr>)
+                                                   (old_head\<lparr>r_time := r_time old_head + sc_period sc\<rparr>)\<close>
              od;
      return usage'
    od"
@@ -320,14 +315,13 @@ where
      new_head_amount \<leftarrow> return (r_amount (hd refills));
 
      when (usage' > 0 \<and> usage' < new_head_amount) $ do
-       refills \<leftarrow> get_refills sc_ptr;
        sc \<leftarrow> get_sched_context sc_ptr;
        period \<leftarrow> return (sc_period sc);
-       used \<leftarrow> return \<lparr>r_time = r_time (hd refills) + period, r_amount = usage'\<rparr>;
-       adjusted_hd \<leftarrow> return \<lparr>r_time = r_time (hd refills) + usage',
-                              r_amount = r_amount (hd refills) - usage'\<rparr>;
-       full \<leftarrow> refill_full sc_ptr;
-       set_refills sc_ptr $ schedule_used full (adjusted_hd # (tl refills)) used
+       used \<leftarrow> return \<lparr>r_time = r_time (hd (sc_refills sc)) + period, r_amount = usage'\<rparr>;
+       update_refill_hd sc_ptr (r_amount_update (\<lambda>m. m + usage'));
+       update_refill_hd sc_ptr (r_time_update (\<lambda>t. t - usage'));
+       full \<leftarrow> return (size (sc_refills sc) = sc_refill_max sc);
+       update_sched_context sc_ptr (sc_refills_update (\<lambda>refills. schedule_used full refills used))
      od;
 
      head_insufficient_loop sc_ptr

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -49,7 +49,7 @@ This module uses the C preprocessor to select a target architecture.
 > import {-# SOURCE #-} SEL4.Object.Notification
 > import {-# SOURCE #-} SEL4.Object.Reply
 > import SEL4.Object.Structures
-> import {-# SOURCE #-} SEL4.Object.TCB(threadGet, threadSet, checkBudget, chargeBudget, replaceAt, setTimeArg, setMessageInfo, setMRs)
+> import {-# SOURCE #-} SEL4.Object.TCB(threadGet, threadSet, checkBudget, chargeBudget, replaceAt, updateAt, setTimeArg, setMessageInfo, setMRs)
 > import {-# SOURCE #-} SEL4.Kernel.Thread
 > import SEL4.API.Invocation(SchedContextInvocation(..), SchedControlInvocation(..))
 
@@ -82,14 +82,11 @@ This module uses the C preprocessor to select a target architecture.
 > refillHd :: SchedContext -> Refill
 > refillHd sc = scRefills sc !! scRefillHead sc
 
+> updateRefillIndex :: PPtr SchedContext -> (Refill -> Refill) -> Int -> Kernel ()
+> updateRefillIndex scPtr f idx = updateSchedContext scPtr (\sc -> sc { scRefills = updateAt idx (scRefills sc) f})
+
 > updateRefillHd :: PPtr SchedContext -> (Refill -> Refill) -> Kernel ()
-> updateRefillHd scPtr f = do
->     sc <- getSchedContext scPtr
->     let refills = scRefills sc
->     let idx = scRefillHead sc
->     let head = refillHd sc
->     let sc' = sc { scRefills = replaceAt idx refills (f head) }
->     setSchedContext scPtr sc'
+> updateRefillHd scPtr f = updateSchedContext scPtr (\sc -> sc { scRefills = updateAt (scRefillHead sc) (scRefills sc) f})
 
 > setRefillHd :: PPtr SchedContext -> Refill -> Kernel ()
 > setRefillHd scPtr new = updateRefillHd scPtr (\r -> new)
@@ -116,13 +113,7 @@ This module uses the C preprocessor to select a target architecture.
 > refillTl sc = scRefills sc !! refillTailIndex sc
 
 > updateRefillTl :: PPtr SchedContext -> (Refill -> Refill) -> Kernel ()
-> updateRefillTl scPtr f = do
->     sc <- getSchedContext scPtr
->     let refills = scRefills sc
->     let idx = refillTailIndex sc
->     let tail = refillTl sc
->     let sc' = sc { scRefills = replaceAt idx refills (f tail) }
->     setSchedContext scPtr sc'
+> updateRefillTl scPtr f = updateSchedContext scPtr (\sc -> sc { scRefills = updateAt (refillTailIndex sc) (scRefills sc) f})
 
 > setRefillTl :: PPtr SchedContext -> Refill -> Kernel ()
 > setRefillTl scPtr new = updateRefillTl scPtr (\r -> new)
@@ -165,8 +156,15 @@ This module uses the C preprocessor to select a target architecture.
 > getRefillNext :: PPtr SchedContext -> Int -> Kernel Int
 > getRefillNext scPtr index = getsJust (readRefillNext scPtr index)
 
+> updateRefillNext :: PPtr SchedContext -> (Refill -> Refill) -> Int -> Kernel ()
+> updateRefillNext scPtr f index = do
+>     updateSchedContext scPtr (\sc -> sc { scRefills = updateAt (refillNextIndex index sc) (scRefills sc) f})
+
 > refillIndex :: Int -> SchedContext -> Refill
 > refillIndex index sc = scRefills sc !! index
+
+> refillNextIndex :: Int -> SchedContext -> Int
+> refillNextIndex index sc = if (index == scRefillMax sc - 1) then 0 else index + 1
 
 > -- Odd argument order plays well with `updateSchedContext`.
 > setRefillIndex :: Int -> Refill -> SchedContext -> SchedContext
@@ -203,20 +201,16 @@ This module uses the C preprocessor to select a target architecture.
 > refillPopHead :: PPtr SchedContext -> Kernel Refill
 > refillPopHead scPtr = do
 >     refill <- liftM refillHd $ getSchedContext scPtr
->     oldHead <- liftM scRefillHead $ getSchedContext scPtr
->     nextHead <- getRefillNext scPtr oldHead
->     updateSchedContext scPtr $ \sc -> sc { scRefillHead = nextHead,
+>     updateSchedContext scPtr $ \sc -> sc { scRefillHead = refillNextIndex (scRefillHead sc) sc,
 >                                     scRefillCount = scRefillCount sc - 1 }
 >     return refill
 
 > refillAddTail :: PPtr SchedContext -> Refill -> Kernel ()
 > refillAddTail scPtr refill = do
 >     sc <- getSchedContext scPtr
->     sz <- getRefillSize scPtr
->     assert (sz < scRefillMax sc) "cannot add beyond queue size"
->     newTail <- getRefillNext scPtr (refillTailIndex sc)
->     refills <- return $ replaceAt newTail (scRefills sc) refill
->     setSchedContext scPtr (sc { scRefills = refills, scRefillCount = sz + 1 })
+>     assert (scRefillCount sc < scRefillMax sc) "cannot add beyond queue size"
+>     newTail <- return $ refillNextIndex (refillTailIndex sc) sc
+>     updateSchedContext scPtr (\sc -> sc { scRefills = replaceAt newTail (scRefills sc) refill, scRefillCount = scRefillCount sc + 1})
 
 > maybeAddEmptyTail :: PPtr SchedContext -> Kernel ()
 > maybeAddEmptyTail scPtr = do
@@ -304,9 +298,8 @@ This module uses the C preprocessor to select a target architecture.
 
 > refillResetRR :: PPtr SchedContext -> Kernel ()
 > refillResetRR scPtr = do
->     sc <- getSchedContext scPtr
->     setRefillHd scPtr (Refill { rTime = rTime (refillHd sc), rAmount = rAmount (refillHd sc) + rAmount (refillTl sc)})
->     setRefillTl scPtr (Refill { rTime = rTime (refillTl sc), rAmount = 0})
+>     updateSchedContext scPtr (\sc -> sc { scRefills = updateAt (scRefillHead sc) (scRefills sc) (\hd -> hd { rAmount = rAmount hd + rAmount (refillTl sc)})})
+>     updateRefillTl scPtr (\last -> last { rAmount = 0})
 
 > refillHdInsufficient :: PPtr SchedContext -> KernelR Bool
 > refillHdInsufficient scPtr = do
@@ -318,8 +311,8 @@ This module uses the C preprocessor to select a target architecture.
 >     sc <- getSchedContext scPtr
 >     assert (1 < scRefillCount sc) "if head is insufficient, there must be at least 2 refills"
 >     old_head <- refillPopHead scPtr
->     updateRefillHd scPtr $ \head -> head { rTime = rTime head - rAmount old_head,
->                                            rAmount = rAmount head + rAmount old_head }
+>     updateRefillHd scPtr $ \head -> head { rAmount = rAmount head + rAmount old_head }
+>     updateRefillHd scPtr $ \head -> head { rTime = rTime head - rAmount old_head}
 
 > headInsufficientLoop :: PPtr SchedContext -> Kernel ()
 > headInsufficientLoop scPtr = whileLoop (const (fromJust . runReaderT (refillHdInsufficient scPtr))) (const (nonOverlappingMergeRefills scPtr)) ()

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -241,8 +241,6 @@ This module uses the C preprocessor to select a target architecture.
 
 > refillUpdate :: PPtr SchedContext -> Ticks -> Ticks -> Int -> Kernel ()
 > refillUpdate scPtr newPeriod newBudget newMaxRefills = do
->     sc <- getSchedContext scPtr
->     let head = refillHd sc
 >     updateSchedContext scPtr $ \sc -> sc { scRefills = replaceAt 0 (scRefills sc) (refillHd sc) }
 >     updateSchedContext scPtr (\sc -> sc { scRefillHead = 0 })
 >     updateSchedContext scPtr (\sc -> sc { scRefillCount = 1 })

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -223,16 +223,10 @@ This module uses the C preprocessor to select a target architecture.
 > refillNew :: PPtr SchedContext -> Int -> Ticks -> Ticks -> Kernel ()
 > refillNew scPtr maxRefills budget period = do
 >     curTime <- getCurTime
->     sc <- getSchedContext scPtr
->     setSchedContext scPtr (sc { scPeriod = period })
->     sc <- getSchedContext scPtr
->     setSchedContext scPtr (sc { scBudget = budget })
->     sc <- getSchedContext scPtr
->     setSchedContext scPtr (sc { scRefillHead = 0 })
->     sc <- getSchedContext scPtr
->     setSchedContext scPtr (sc { scRefillCount = 1 })
->     sc <- getSchedContext scPtr
->     setSchedContext scPtr (sc { scRefillMax = maxRefills })
+>     updateSchedContext scPtr (\sc -> sc { scPeriod = period })
+>     updateSchedContext scPtr (\sc -> sc { scBudget = budget })
+>     updateSchedContext scPtr (\sc -> sc { scRefillMax = maxRefills })
+>     updateSchedContext scPtr (\sc -> sc { scRefillHead = 0, scRefillCount = 1 })
 >     setRefillHd scPtr (Refill { rTime = curTime, rAmount = budget })
 >     maybeAddEmptyTail scPtr
 
@@ -249,18 +243,12 @@ This module uses the C preprocessor to select a target architecture.
 > refillUpdate scPtr newPeriod newBudget newMaxRefills = do
 >     sc <- getSchedContext scPtr
 >     let head = refillHd sc
->     sc <- getSchedContext scPtr
->     setSchedContext scPtr (sc { scRefillHead = 0 })
->     sc <- getSchedContext scPtr
->     setSchedContext scPtr (sc { scRefillCount = 1 })
->     sc <- getSchedContext scPtr
->     setSchedContext scPtr (sc { scRefillMax = newMaxRefills })
->     sc <- getSchedContext scPtr
->     setSchedContext scPtr $ setRefillIndex 0 head sc
->     sc <- getSchedContext scPtr
->     setSchedContext scPtr (sc { scPeriod = newPeriod })
->     sc <- getSchedContext scPtr
->     setSchedContext scPtr (sc { scBudget = newBudget })
+>     updateSchedContext scPtr $ \sc -> sc { scRefills = replaceAt 0 (scRefills sc) (refillHd sc) }
+>     updateSchedContext scPtr (\sc -> sc { scRefillHead = 0 })
+>     updateSchedContext scPtr (\sc -> sc { scRefillCount = 1 })
+>     updateSchedContext scPtr (\sc -> sc { scRefillMax = newMaxRefills })
+>     updateSchedContext scPtr (\sc -> sc { scPeriod = newPeriod })
+>     updateSchedContext scPtr (\sc -> sc { scBudget = newBudget })
 >     whenM (refillReady scPtr) $ do
 >         curTime <- getCurTime
 >         updateRefillHd scPtr $ \r -> r { rTime = curTime }

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -523,8 +523,7 @@ This module uses the C preprocessor to select a target architecture.
 
 > schedContextZeroRefillMax :: PPtr SchedContext -> Kernel ()
 > schedContextZeroRefillMax scPtr = do
->     sc <- getSchedContext scPtr
->     setSchedContext scPtr $ sc { scRefillMax = 0 }
+>     updateSchedContext scPtr $ (\sc -> sc { scRefillMax = 0 })
 
 > unbindFromSC :: PPtr TCB -> Kernel ()
 > unbindFromSC tptr = do

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -210,7 +210,7 @@ This module uses the C preprocessor to select a target architecture.
 >     sc <- getSchedContext scPtr
 >     assert (scRefillCount sc < scRefillMax sc) "cannot add beyond queue size"
 >     newTail <- return $ refillNextIndex (refillTailIndex sc) sc
->     updateSchedContext scPtr (\sc -> sc { scRefills = replaceAt newTail (scRefills sc) refill, scRefillCount = scRefillCount sc + 1})
+>     updateSchedContext scPtr (\sc -> sc { scRefills = replaceAt (refillNextIndex (refillTailIndex sc) sc) (scRefills sc) refill, scRefillCount = scRefillCount sc + 1})
 
 > maybeAddEmptyTail :: PPtr SchedContext -> Kernel ()
 > maybeAddEmptyTail scPtr = do

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -1006,7 +1006,7 @@ On some architectures, the thread context may include registers that may be modi
 > updateAt :: Int -> [a] -> (a -> a) -> [a]
 > updateAt i lst f =
 >     let x = take i lst;
->         u = lst !! (i + 1)
+>         u = lst !! (i + 1);
 >         y = drop (i + 1) lst
 >     in if (null lst || length lst <= i)
 >           then lst

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -1006,7 +1006,7 @@ On some architectures, the thread context may include registers that may be modi
 > updateAt :: Int -> [a] -> (a -> a) -> [a]
 > updateAt i lst f =
 >     let x = take i lst;
->         u = lst !! (i + 1);
+>         u = lst !! i;
 >         y = drop (i + 1) lst
 >     in if (null lst || length lst <= i)
 >           then lst

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -26,13 +26,13 @@ This module uses the C preprocessor to select a target architecture.
 >         archThreadSet, archThreadGet,
 >         decodeSchedContextInvocation, decodeSchedControlInvocation,
 >         checkBudget, chargeBudget, checkBudgetRestart, mcsIRQ, commitTime, awaken, switchSchedContext,
->         replaceAt, tcbEPAppend, tcbEPDequeue, setTimeArg, isBlocked, isStopped
+>         replaceAt, updateAt, tcbEPAppend, tcbEPDequeue, setTimeArg, isBlocked, isStopped
 >     ) where
 
 \begin{impdetails}
 
 % {-# BOOT-IMPORTS: SEL4.API.Types SEL4.API.Failures SEL4.Machine SEL4.Model SEL4.Object.Structures SEL4.API.Invocation #-}
-% {-# BOOT-EXPORTS: threadGet threadSet asUser setMRs setMessageInfo getThreadCSpaceRoot getThreadVSpaceRoot decodeTCBInvocation invokeTCB getThreadBufferSlot decodeDomainInvocation archThreadSet archThreadGet sanitiseRegister decodeSchedContextInvocation decodeSchedControlInvocation checkBudget chargeBudget replaceAt tcbEPAppend tcbEPDequeue setTimeArg #-}
+% {-# BOOT-EXPORTS: threadGet threadSet asUser setMRs setMessageInfo getThreadCSpaceRoot getThreadVSpaceRoot decodeTCBInvocation invokeTCB getThreadBufferSlot decodeDomainInvocation archThreadSet archThreadGet sanitiseRegister decodeSchedContextInvocation decodeSchedControlInvocation checkBudget chargeBudget replaceAt updateAt tcbEPAppend tcbEPDequeue setTimeArg #-}
 
 > import Prelude hiding (Word)
 > import SEL4.Config
@@ -1002,6 +1002,15 @@ On some architectures, the thread context may include registers that may be modi
 >     in if (null lst || length lst <= i)
 >           then lst
 >           else x ++ [v] ++ y
+
+> updateAt :: Int -> [a] -> (a -> a) -> [a]
+> updateAt i lst f =
+>     let x = take i lst;
+>         u = lst !! (i + 1)
+>         y = drop (i + 1) lst
+>     in if (null lst || length lst <= i)
+>           then lst
+>           else x ++ [f u] ++ y
 
 > chargeBudget :: Ticks -> Bool -> Bool -> Kernel ()
 > chargeBudget consumed canTimeoutFault isCurCPU = do


### PR DESCRIPTION
This draft PR contains some cleanup of refill related functions in both haskell and abstract specs, mainly trying to achieve:

- more systematic use of `updateSchedContext` and its derivatives
- more streamlined approach for indexing haskell `scRefills`
- better alignment with the C code


