### PR TITLE
Corres rename

### DIFF
--- a/lib/test/Corres_Test.thy
+++ b/lib/test/Corres_Test.thy
@@ -178,15 +178,15 @@ context begin interpretation Arch .
 
 
 lemmas load_hw_asid_corres_args[corres] =
-  load_hw_asid_corres[@lift_corres_args]
+  loadHWASID_corres[@lift_corres_args]
 
 lemmas invalidate_asid_corres_args[corres] =
-  invalidate_asid_corres[@lift_corres_args]
+  invalidateASID_corres[@lift_corres_args]
 
 lemmas invalidate_hw_asid_entry_corres_args[corres] =
-  invalidate_hw_asid_entry_corres[@lift_corres_args]
+  invalidateHWASIDEntry_corres[@lift_corres_args]
 
-lemma invalidate_asid_entry_corres:
+lemma invalidateASIDEntry_corres:
   "corres dc (valid_vspace_objs and valid_asid_map
                 and K (asid \<le> mask asid_bits \<and> asid \<noteq> 0)
                 and vspace_at_asid asid pd and valid_vs_lookup
@@ -218,10 +218,10 @@ crunch ksCurThread[wp]: invalidateASIDEntry, flushSpace "\<lambda>s. P (ksCurThr
 crunch obj_at'[wp]: invalidateASIDEntry, flushSpace "obj_at' P p"
 
 lemmas flush_space_corres_args[corres] =
-  flush_space_corres[@lift_corres_args]
+  flushSpace_corres[@lift_corres_args]
 
 lemmas invalidate_asid_entry_corres_args[corres] =
-  invalidate_asid_entry_corres[@lift_corres_args]
+  invalidateASIDEntry_corres[@lift_corres_args]
 
 
 lemma corres_inst_eq_ext:
@@ -229,10 +229,10 @@ lemma corres_inst_eq_ext:
   by (auto simp add: corres_inst_eq_def)
 
 lemma delete_asid_corresb:
-  notes [corres] = corres_gets_asid gct_corres set_asid_pool_corres and
+  notes [corres] = corres_gets_asid getCurThread_corres setObject_ASIDPool_corres and
     [@lift_corres_args, corres] =  get_asid_pool_corres_inv'
-    invalidate_asid_entry_corres
-    set_vm_root_corres
+    invalidateASIDEntry_corres
+    setVMRoot_corres
   notes [wp] = set_asid_pool_asid_map_unmap set_asid_pool_vs_lookup_unmap'
     set_asid_pool_vspace_objs_unmap'
     invalidate_asid_entry_invalidates
@@ -260,11 +260,11 @@ lemma delete_asid_corresb:
          continue (* function application *)
          continue (* corresK_when *)
          continue (* split *)
-             continue (* flush_space_corres *)
+             continue (* flushSpace_corres *)
             continue (* K_bind *)
             continue (* K_bind *)
             continue (* split *)
-                continue (* invalidate_asid_entry_corres *)
+                continue (* invalidateASIDEntry_corres *)
                continue (* K_bind *)
                continue (* return bind *)
                continue (* K_bind *)
@@ -272,12 +272,12 @@ lemma delete_asid_corresb:
                    continue (* backtracking *)
                continue (* split *)
                    continue (* function application *)
-                   continue (* set_asid_pool_corres *)
+                   continue (* setObject_ASIDPool_corres *)
                   continue (* K_bind *)
                   continue (* K_bind *)
                   continue (* split *)
-                      continue (* gct_corres *)
-                     continue (* set_vm_root_corres *)
+                      continue (* getCurThread_corres *)
+                     continue (* setVMRoot_corres *)
                     finish (* backtracking? *)
                     apply (corressimp simp: mask_asid_low_bits_ucast_ucast
       | fold cur_tcb_def | wps)+
@@ -328,8 +328,8 @@ lemma cte_wp_at_ex:
   by (simp add: cte_wp_at_def)
 
 (* Sadly broken:
-lemma set_vm_root_for_flush_corres:
-  notes [corres] = gct_corres getSlotCap_corres
+lemma setVMRootForFlush_corres:
+  notes [corres] = getCurThread_corres getSlotCap_corres
   shows
   "corres (=)
           (cur_tcb and vspace_at_asid asid pd
@@ -344,7 +344,7 @@ lemma set_vm_root_for_flush_corres:
           (setVMRootForFlush pd asid)"
   apply (simp add: set_vm_root_for_flush_def setVMRootForFlush_def getThreadVSpaceRoot_def locateSlot_conv)
   apply corres
-         apply_debug (trace) (tags "corres_search") (corres_search search: arm_context_switch_corres)
+         apply_debug (trace) (tags "corres_search") (corres_search search: armv_contextSwitch_corres)
   continue (* step left *)
   continue (* if rule *)
   continue (* failed corres on first subgoal, trying next *)
@@ -371,8 +371,8 @@ lemma set_vm_root_for_flush_corres:
 
 text \<open>Note we can wrap it all up in corressimp\<close>
 
-lemma set_vm_root_for_flush_corres':
-  notes [corres] = gct_corres getSlotCap_corres
+lemma setVMRootForFlush_corres':
+  notes [corres] = getCurThread_corres getSlotCap_corres
   shows
   "corres (=)
           (cur_tcb and vspace_at_asid asid pd
@@ -386,7 +386,7 @@ lemma set_vm_root_for_flush_corres':
           (set_vm_root_for_flush pd asid)
           (setVMRootForFlush pd asid)"
   apply (simp add: set_vm_root_for_flush_def setVMRootForFlush_def getThreadVSpaceRoot_def locateSlot_conv)
-  apply (corressimp search: arm_context_switch_corres
+  apply (corressimp search: armv_contextSwitch_corres
                         wp: get_cap_wp getSlotCap_wp
                       simp: isCap_simps)
   apply (rule context_conjI)

--- a/misc/search-replace/README.md
+++ b/misc/search-replace/README.md
@@ -1,0 +1,18 @@
+<!--
+     Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# search-replace.sh
+
+This script takes an input file which is a list of text replacements and
+applies those replacements to all files in the current directory.
+
+Usage: `bash search-replace.sh renames.txt`
+
+where each line of `renames.txt` is of the form `renames mysearchtext to
+myreplacetext`.
+
+Caution: if `renames.txt` is in the current directory then this script will act
+on that file and make it useless for future invocations.

--- a/misc/search-replace/search-replace.sh
+++ b/misc/search-replace/search-replace.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+do_replace () {
+
+if ! grep -r -w -q $2 .;
+  # target string exists
+  then
+  if grep -r -w -q $1 .;
+    # source string exists
+    then
+    # search and replace
+    find . -type f -exec sed -i "s/\b$1\b/$2/g" {} +
+    echo "renamed: $1 --> $2"
+  else
+    # Error 1
+    echo "source not found: $1"
+  fi
+else
+  # Error 2
+  echo "target not found: $2"
+fi
+}
+
+echo "READING: " $1
+
+cat $1 | while read line
+do
+	if [[ $line =~ (rename )([^ ]*)( to )([^ ]*) ]]
+	then
+	old=${BASH_REMATCH[2]}
+	new=${BASH_REMATCH[4]}
+	do_replace $old $new
+	else
+	echo "CANNOT PARSE LINE: $line"
+	fi
+done
+
+echo "DONE"

--- a/proof/infoflow/refine/ADT_IF_Refine.thy
+++ b/proof/infoflow/refine/ADT_IF_Refine.thy
@@ -36,7 +36,7 @@ lemma kernel_entry_if_corres:
                       (kernel_entry_if event tc) (kernelEntry_if event tc)"
   apply (simp add: kernel_entry_if_def kernelEntry_if_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gct_corres])
+    apply (rule corres_split_deprecated [OF _ getCurThread_corres])
       apply (rule corres_split_deprecated)
          prefer 2
          apply simp
@@ -48,7 +48,7 @@ lemma kernel_entry_if_corres:
            apply (clarsimp simp: tcb_cap_cases_def)
           apply (clarsimp simp: tcb_cte_cases_def)
          apply (simp add: exst_same_def)
-        apply (rule corres_split_deprecated [OF _ he_corres])
+        apply (rule corres_split_deprecated [OF _ handleEvent_corres])
           apply (rule corres_stateAssert_assume_stronger[where Q=\<top> and
                         P="\<lambda>s. valid_domain_list s \<and>
                                (event \<noteq> Interrupt \<longrightarrow> 0 < domain_time s) \<and>
@@ -444,7 +444,7 @@ lemma corres_ex_abs_lift':
   apply fastforce
   done
 
-lemma gct_corres': "corres_underlying state_relation nf nf' (=) \<top> \<top> (gets cur_thread) getCurThread"
+lemma getCurThread_corres': "corres_underlying state_relation nf nf' (=) \<top> \<top> (gets cur_thread) getCurThread"
   by (simp add: getCurThread_def curthread_relation)
 
 lemma user_mem_corres':
@@ -666,7 +666,7 @@ lemma handle_preemption_if_corres:
          apply (rule corres_when)
           apply simp
          apply simp
-         apply (rule handle_interrupt_corres)
+         apply (rule handleInterrupt_corres)
         apply (wp handle_interrupt_valid_domain_time)+
       apply (rule dmo_getActiveIRQ_corres)
      apply (rule dmo_getActiveIRQ_wp)
@@ -744,7 +744,7 @@ lemma schedule_if_corres:
                         P="\<lambda>s. valid_domain_list s \<and> 0 < domain_time s"])
            apply simp
           apply (clarsimp simp: state_relation_def)
-         apply (rule activate_corres)
+         apply (rule activateThread_corres)
         apply wp+
       apply (rule schedule_corres)
      apply (wp schedule_invs' schedule_domain_time_left)+
@@ -840,10 +840,10 @@ lemma kernel_exit_if_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated[where r'="(=)"])
        apply simp
-       apply (rule threadget_corres)
+       apply (rule threadGet_corres)
        apply (clarsimp simp: tcb_relation_def arch_tcb_relation_def
                              arch_tcb_context_get_def atcbContextGet_def)
-      apply (rule gct_corres)
+      apply (rule getCurThread_corres)
      apply wp+
    apply clarsimp+
   done

--- a/proof/infoflow/refine/ADT_IF_Refine_C.thy
+++ b/proof/infoflow/refine/ADT_IF_Refine_C.thy
@@ -333,7 +333,7 @@ lemma kernelEntry_corres_C:
         apply (rule corres_split_deprecated[OF _ ccorres_corres_u_xf, simplified bind_assoc])
             prefer 3
             apply (rule corres_nofail)
-             apply (rule he_corres)
+             apply (rule handleEvent_corres)
             apply simp
            prefer 2
            apply (rule_tac Q'="UNIV" in ccorres_guard_imp)
@@ -642,7 +642,7 @@ lemma handlePreemption_if_def2:
 lemma handleInterrupt_no_fail: "no_fail (ex_abs (einvs) and invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) a \<noteq> irqstate.IRQInactive)) (handleInterrupt a)"
   apply (rule no_fail_pre)
   apply (rule corres_nofail)
-    apply (rule handle_interrupt_corres)
+    apply (rule handleInterrupt_corres)
    apply (erule FalseE)
   apply (fastforce simp: ex_abs_def)
   done
@@ -747,7 +747,7 @@ lemma schedule_if_corres_C:
          apply (rule ccorres_corres_u')
             apply (rule activateThread_ccorres)
            apply (rule corres_nofail)
-            apply (rule activate_corres)
+            apply (rule activateThread_corres)
            apply (erule FalseE)
           apply simp
          apply simp

--- a/proof/refine/ARM/ArchAcc_R.thy
+++ b/proof/refine/ARM/ArchAcc_R.thy
@@ -92,7 +92,7 @@ lemma asid_low_bits [simp]:
   "asidLowBits = asid_low_bits"
   by (simp add: asid_low_bits_def asidLowBits_def)
 
-lemma get_asid_pool_corres [corres]:
+lemma getObject_ASIDPool_corres [corres]:
   "p = p' \<Longrightarrow> corres (\<lambda>p p'. p = inv ASIDPool p' o ucast)
           (asid_pool_at p) (asid_pool_at' p')
           (get_asid_pool p) (getObject p')"
@@ -155,12 +155,12 @@ lemma aligned_distinct_relation_asid_pool_atI'[elim]:
                         projectKOs)
   done
 
-lemma get_asid_pool_corres':
+lemma getObject_ASIDPool_corres':
   "corres (\<lambda>p p'. p = inv ASIDPool p' o ucast)
           (asid_pool_at p) (pspace_aligned' and pspace_distinct')
           (get_asid_pool p) (getObject p)"
   apply (rule stronger_corres_guard_imp,
-         rule get_asid_pool_corres)
+         rule getObject_ASIDPool_corres)
    apply auto
   done
 
@@ -195,23 +195,23 @@ lemma storePTE_cte_wp_at'[wp]:
 crunch cte_wp_at'[wp]: setIRQState "\<lambda>s. P (cte_wp_at' P' p s)"
 crunch inv[wp]: getIRQSlot "P"
 
-lemma set_asid_pool_corres [corres]:
+lemma setObject_ASIDPool_corres [corres]:
   "p = p' \<Longrightarrow> a = inv ASIDPool a' o ucast \<Longrightarrow>
   corres dc (asid_pool_at p and valid_etcbs) (asid_pool_at' p')
             (set_asid_pool p a) (setObject p' a')"
   apply (simp add: set_asid_pool_def)
-  apply (corressimp search: set_other_obj_corres[where P="\<lambda>_. True"]
+  apply (corressimp search: setObject_other_corres[where P="\<lambda>_. True"]
                         wp: get_object_ret get_object_wp)
   apply (simp add: other_obj_relation_def asid_pool_relation_def)
   apply (clarsimp simp: obj_at_simps )
   by (auto simp: obj_at_simps typ_at_to_obj_at_arches
           split: Structures_A.kernel_object.splits if_splits arch_kernel_obj.splits)
 
-lemma set_asid_pool_corres':
+lemma setObject_ASIDPool_corres':
   "a = inv ASIDPool a' o ucast \<Longrightarrow>
   corres dc (asid_pool_at p and valid_etcbs) (pspace_aligned' and pspace_distinct')
             (set_asid_pool p a) (setObject p a')"
-  apply (rule stronger_corres_guard_imp[OF set_asid_pool_corres])
+  apply (rule stronger_corres_guard_imp[OF setObject_ASIDPool_corres])
    apply auto
   done
 
@@ -222,7 +222,7 @@ lemma pde_relation_aligned_simp:
   by (clarsimp simp: pde_relation_aligned_def
               split: ARM_H.pde.splits if_splits)
 
-lemma get_pde_corres [corres]:
+lemma getObject_PDE_corres [corres]:
   "p = p' \<Longrightarrow> corres (pde_relation_aligned (p >> 2)) (pde_at p) (pde_at' p')
      (get_pde p) (getObject p')"
   apply (simp add: getObject_def get_pde_def get_pd_def get_object_def split_def bind_assoc)
@@ -445,12 +445,12 @@ lemma get_master_pde_corres [@lift_corres_args, corres]:
     done
   qed
 
-lemma get_pde_corres' :
+lemma getObject_PDE_corres' :
   "corres (pde_relation_aligned (p >> 2)) (pde_at p)
      (pspace_aligned' and pspace_distinct')
      (get_pde p) (getObject p)"
   apply (rule stronger_corres_guard_imp,
-         rule get_pde_corres)
+         rule getObject_PDE_corres)
    apply auto[1]
   apply clarsimp
   apply (rule aligned_distinct_relation_pde_atI')
@@ -474,7 +474,7 @@ lemma pte_relation_aligned_simp:
   by (clarsimp simp: pte_relation_aligned_def
               split: ARM_H.pte.splits if_splits)
 
-lemma get_pte_corres [corres]:
+lemma getObject_PTE_corres [corres]:
   "p = p' \<Longrightarrow> corres (pte_relation_aligned (p >> 2)) (pte_at p) (pte_at' p')
      (get_pte p) (getObject p')"
   apply (simp add: getObject_def get_pte_def get_pt_def get_object_def split_def bind_assoc)
@@ -671,12 +671,12 @@ lemma get_master_pte_corres [@lift_corres_args, corres]:
    done
   qed
 
-lemma get_pte_corres':
+lemma getObject_PTE_corres':
   "corres (pte_relation_aligned (p >> 2)) (pte_at p)
      (pspace_aligned' and pspace_distinct')
      (get_pte p) (getObject p)"
   apply (rule stronger_corres_guard_imp,
-         rule get_pte_corres)
+         rule getObject_PTE_corres)
    apply auto[1]
   apply clarsimp
   apply (rule aligned_distinct_relation_pte_atI')
@@ -693,8 +693,8 @@ lemma get_master_pte_corres':
    apply auto
   done
 
-\<comment> \<open>set_other_obj_corres unfortunately doesn't work here\<close>
-lemma set_pd_corres [@lift_corres_args, corres]:
+\<comment> \<open>setObject_other_corres unfortunately doesn't work here\<close>
+lemma setObject_PD_corres [@lift_corres_args, corres]:
   "pde_relation_aligned (p>>2) pde pde' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PageDirectory pd)) (p && ~~ mask pd_bits)
                      and pspace_aligned and valid_etcbs)
@@ -774,7 +774,7 @@ lemma set_pd_corres [@lift_corres_args, corres]:
   done
 
 
-lemma set_pt_corres [@lift_corres_args, corres]:
+lemma setObject_PT_corres [@lift_corres_args, corres]:
   "pte_relation_aligned (p >> 2) pte pte' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PageTable pt)) (p && ~~ mask pt_bits)
                      and pspace_aligned and valid_etcbs)
@@ -852,12 +852,12 @@ lemma set_pt_corres [@lift_corres_args, corres]:
   done
 
 
-lemma store_pde_corres [@lift_corres_args, corres]:
+lemma storePDE_corres [@lift_corres_args, corres]:
   "pde_relation_aligned (p >> 2) pde pde' \<Longrightarrow>
   corres dc (pde_at p and pspace_aligned and valid_etcbs) (pde_at' p) (store_pde p pde) (storePDE p pde')"
   apply (simp add: store_pde_def storePDE_def)
   apply (rule corres_symb_exec_l)
-     apply (erule set_pd_corres[OF _ refl])
+     apply (erule setObject_PD_corres[OF _ refl])
     apply (clarsimp simp: exs_valid_def get_pd_def get_object_def exec_gets bind_assoc
                           obj_at_def pde_at_def)
     apply (clarsimp simp: a_type_def return_def
@@ -870,21 +870,21 @@ lemma store_pde_corres [@lift_corres_args, corres]:
                   split: Structures_A.kernel_object.splits arch_kernel_obj.splits if_split_asm)
   done
 
-lemma store_pde_corres':
+lemma storePDE_corres':
   "pde_relation_aligned (p >> 2) pde pde' \<Longrightarrow>
   corres dc
      (pde_at p and pspace_aligned and valid_etcbs) (pspace_aligned' and pspace_distinct')
      (store_pde p pde) (storePDE p pde')"
-  apply (rule stronger_corres_guard_imp, rule store_pde_corres)
+  apply (rule stronger_corres_guard_imp, rule storePDE_corres)
    apply auto
   done
 
-lemma store_pte_corres [@lift_corres_args, corres]:
+lemma storePTE_corres [@lift_corres_args, corres]:
   "pte_relation_aligned (p>>2) pte pte' \<Longrightarrow>
   corres dc (pte_at p and pspace_aligned and valid_etcbs) (pte_at' p) (store_pte p pte) (storePTE p pte')"
   apply (simp add: store_pte_def storePTE_def)
   apply (rule corres_symb_exec_l)
-     apply (erule set_pt_corres[OF _ refl])
+     apply (erule setObject_PT_corres[OF _ refl])
     apply (clarsimp simp: exs_valid_def get_pt_def get_object_def
                           exec_gets bind_assoc obj_at_def pte_at_def)
     apply (clarsimp simp: a_type_def return_def
@@ -897,16 +897,16 @@ lemma store_pte_corres [@lift_corres_args, corres]:
                   split: Structures_A.kernel_object.splits arch_kernel_obj.splits if_split_asm)
   done
 
-lemma store_pte_corres':
+lemma storePTE_corres':
   "pte_relation_aligned (p >> 2) pte pte' \<Longrightarrow>
   corres dc (pte_at p and pspace_aligned and valid_etcbs)
             (pspace_aligned' and pspace_distinct')
             (store_pte p pte) (storePTE p pte')"
-  apply (rule stronger_corres_guard_imp, rule store_pte_corres)
+  apply (rule stronger_corres_guard_imp, rule storePTE_corres)
    apply auto
   done
 
-lemma lookup_pd_slot_corres [simp]:
+lemma lookupPDSlot_corres [simp]:
   "lookupPDSlot pd vptr = lookup_pd_slot pd vptr"
   by (simp add: lookupPDSlot_def lookup_pd_slot_def pageBits_def ptBits_def pdeBits_def)
 
@@ -1028,7 +1028,7 @@ lemmas checkPTAt_corres [corresK] =
   corres_stateAssert_implied_frame[OF page_table_at_lift, folded checkPTAt_def]
 
 
-lemma lookup_pt_slot_corres [@lift_corres_args, corres]:
+lemma lookupPTSlot_corres [@lift_corres_args, corres]:
   "corres (lfr \<oplus> (=))
           (pde_at (lookup_pd_slot pd vptr) and pspace_aligned and valid_vspace_objs
           and (\<exists>\<rhd> (lookup_pd_slot pd vptr && ~~ mask pd_bits)) and
@@ -1105,7 +1105,7 @@ lemma arch_deriveCap_valid:
                    capUntypedPtr_def ARM_H.capUntypedPtr_def)
   done
 
-lemma arch_derive_corres [corres]:
+lemma arch_deriveCap_corres [corres]:
  "cap_relation (cap.ArchObjectCap c) (ArchObjectCap c') \<Longrightarrow>
   corres (ser \<oplus> (\<lambda>c c'. cap_relation c c'))
          \<top> \<top>
@@ -1125,7 +1125,7 @@ definition
 where
   "mapping_map \<equiv> pte_relation' \<otimes> (=) \<oplus> pde_relation' \<otimes> (=)"
 
-lemma create_mapping_entries_corres [corres]:
+lemma createMappingEntries_corres [corres]:
   "\<lbrakk> vm_rights' = vmrights_map vm_rights;
      attrib' = vmattributes_map attrib; base = base'; vptr = vptr'; pgsz = pgsz'; pd = pd' \<rbrakk>
   \<Longrightarrow> corres (ser \<oplus> mapping_map)
@@ -1164,7 +1164,7 @@ lemma createMappingEntries_valid_slots' [wp]:
   apply auto
   done
 
-lemma ensure_safe_mapping_corres [corres]:
+lemma ensureSafeMapping_corres [corres]:
   "mapping_map m m' \<Longrightarrow>
   corres (ser \<oplus> dc) (valid_mapping_entries m)
                     (pspace_aligned' and pspace_distinct'

--- a/proof/refine/ARM/Bits_R.thy
+++ b/proof/refine/ARM/Bits_R.thy
@@ -185,13 +185,13 @@ lemma tcb_in_valid_state':
   apply (fastforce simp add: valid_obj'_def valid_tcb'_def)
   done
 
-lemma gct_corres [corres]: "corres (=) \<top> \<top> (gets cur_thread) getCurThread"
+lemma getCurThread_corres [corres]: "corres (=) \<top> \<top> (gets cur_thread) getCurThread"
   by (simp add: getCurThread_def curthread_relation)
 
 lemma gct_wp [wp]: "\<lbrace>\<lambda>s. P (ksCurThread s) s\<rbrace> getCurThread \<lbrace>P\<rbrace>"
   by (unfold getCurThread_def, wp)
 
-lemma git_corres [corres]:
+lemma getIdleThread_corres [corres]:
   "corres (=) \<top> \<top> (gets idle_thread) getIdleThread"
   by (simp add: getIdleThread_def state_relation_def)
 

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -154,7 +154,7 @@ lemma cancelSendRightsEq:
                   split: cap.splits bool.splits if_splits |
          case_tac x)+
 
-lemma dec_cnode_inv_corres:
+lemma decodeCNodeInvocation_corres:
   "\<lbrakk> cap_relation (cap.CNodeCap w n list) cap'; list_all2 cap_relation cs cs';
      length list \<le> 32 \<rbrakk> \<Longrightarrow>
   corres
@@ -173,9 +173,9 @@ lemma dec_cnode_inv_corres:
                    split del: if_split
                         cong: if_cong list.case_cong)
         apply (rule corres_guard_imp)
-          apply (rule corres_splitEE [OF _ lsfc_corres])
-              apply (rule corres_splitEE [OF _ ensure_empty_corres])
-                 apply (rule corres_splitEE [OF _ lsfc_corres])
+          apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
+              apply (rule corres_splitEE [OF _ ensureEmptySlot_corres])
+                 apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
                      apply (simp(no_asm) add: liftE_bindE del: de_Morgan_conj split del: if_split)
                      apply (rule corres_split_deprecated [OF _ get_cap_corres'])
                         prefer 2
@@ -197,7 +197,7 @@ lemma dec_cnode_inv_corres:
                              prefer 2
                              apply (simp add: returnOk_def del: imp_disjL)
                              apply (rule conjI[rotated], rule impI)
-                              apply (rule derive_cap_corres)
+                              apply (rule deriveCap_corres)
                                apply (clarsimp simp: cap_relation_mask
                                                      cap_map_update_data
                                               split: option.split)
@@ -215,7 +215,7 @@ lemma dec_cnode_inv_corres:
        \<comment> \<open>Revoke\<close>
        apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                         isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
-       apply (rule corres_guard_imp, rule corres_splitEE [OF _ lsfc_corres])
+       apply (rule corres_guard_imp, rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
              apply (simp add: split_beta)
              apply (rule corres_returnOkTT)
              apply simp
@@ -228,7 +228,7 @@ lemma dec_cnode_inv_corres:
       apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                        isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
       apply (rule corres_guard_imp)
-        apply (rule corres_splitEE [OF _ lsfc_corres])
+        apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
             apply (simp add: split_beta)
             apply (rule corres_returnOkTT)
             apply simp
@@ -241,12 +241,12 @@ lemma dec_cnode_inv_corres:
      apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                       isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
      apply (rule corres_guard_imp)
-       apply (rule corres_splitEE [OF _ lsfc_corres])
+       apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
            apply (simp add: split_beta)
            apply (rule corres_split_norE)
               apply (rule corres_returnOkTT)
               apply simp
-             apply (rule ensure_empty_corres)
+             apply (rule ensureEmptySlot_corres)
              apply simp
             apply wp+
            apply simp
@@ -259,7 +259,7 @@ lemma dec_cnode_inv_corres:
     apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                      isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
     apply (rule corres_guard_imp)
-      apply (rule corres_splitEE [OF _ lsfc_corres])
+      apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
           apply (simp(no_asm) add: split_beta liftE_bindE)
           apply (rule corres_split_deprecated [OF _ get_cap_corres'])
              apply (rule corres_split_norE)
@@ -278,9 +278,9 @@ lemma dec_cnode_inv_corres:
    apply (simp add: le_diff_conv2 split_def decode_cnode_invocation_def decodeCNodeInvocation_def
                     isCap_simps Let_def unlessE_whenE whenE_whenE_body
                del: disj_not1 ser_def split del: if_split)
-   apply (rule corres_guard_imp, rule corres_splitEE [OF _ lsfc_corres])
+   apply (rule corres_guard_imp, rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
          apply (rename_tac dest_slot destSlot)
-         apply (rule corres_splitEE [OF _ lsfc_corres])+
+         apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])+
                  apply (rule_tac R = "\<lambda>s. cte_at pivot_slot s \<and> cte_at dest_slot s
                                         \<and> cte_at src_slot s \<and> invs s" in
                    whenE_throwError_corres' [where R' = \<top>])
@@ -320,7 +320,7 @@ lemma dec_cnode_inv_corres:
                     apply (drule (2) cte_map_inj_eq, clarsimp+)[1]
                    apply (rule corres_guard_imp)
                      apply (erule corres_whenE)
-                      apply (rule ensure_empty_corres)
+                      apply (rule ensureEmptySlot_corres)
                       apply clarsimp
                      apply simp
                     apply clarsimp
@@ -354,7 +354,7 @@ lemma dec_cnode_inv_corres:
                          cnode_invok_case_cleanup
               split del: if_split cong: if_cong)
    apply (rule corres_guard_imp)
-     apply (rule corres_splitEE[OF _ lsfc_corres])
+     apply (rule corres_splitEE[OF _ lookupSlotForCNodeOp_corres])
          apply (rule corres_trivial, clarsimp split: list.split_asm)
         apply simp+
       apply wp+
@@ -364,7 +364,7 @@ lemma dec_cnode_inv_corres:
                         isCNodeCap_CNodeCap split_def unlessE_whenE
              split del: if_split cong: if_cong)
   apply (rule corres_guard_imp)
-   apply (rule corres_splitEE [OF _ lsfc_corres wp_post_tautE wp_post_tautE])
+   apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres wp_post_tautE wp_post_tautE])
      apply (clarsimp simp: list_all2_Cons1 list_all2_Nil
                     split: list.split_asm split del: if_split)
      apply simp
@@ -6945,7 +6945,7 @@ proof (induct rule: rec_del.induct,
                                  whenE_liftE)
         apply (rule corres_when, simp)
         apply simp
-        apply (rule empty_slot_corres)
+        apply (rule emptySlot_corres)
        apply (wp rec_del_invs rec_del_valid_list rec_del_cte_at finaliseSlot_invs hoare_drop_imps
                  preemption_point_inv'
             | simp)+
@@ -6971,10 +6971,10 @@ next
                 simp add: returnOk_def)
         apply (rule spec_corres_splitE')
            apply simp
-           apply (rule final_cap_corres[where ptr=slot])
+           apply (rule isFinalCapability_corres[where ptr=slot])
           apply (rule spec_corres_splitE')
              apply simp
-             apply (rule finalise_cap_corres[where sl=slot])
+             apply (rule finaliseCap_corres[where sl=slot])
                apply simp
               apply simp
              apply simp
@@ -6992,13 +6992,13 @@ next
                apply (erule conjunct2)
               apply (rule drop_spec_corres,
                      simp add: liftME_def[symmetric] o_def dc_def[symmetric])
-              apply (rule cap_update_corres)
+              apply (rule updateCap_corres)
                apply simp
               apply (simp(no_asm_use) add: cap_cyclic_zombie_def split: cap.split_asm)
               apply (simp add: is_cap_simps)
              apply (rule spec_corres_splitE')
                 apply simp
-                apply (rule cap_update_corres, erule conjunct1)
+                apply (rule updateCap_corres, erule conjunct1)
                 apply (case_tac "fst rvb", auto simp: isCap_simps is_cap_simps)[1]
                apply (rule spec_corres_splitE)
                   apply (rule iffD1 [OF spec_corres_liftME2[where fn="\<lambda>v. (True, NullCap)"]])
@@ -7007,7 +7007,7 @@ next
                    apply (rename_tac nat)
                    apply (case_tac nat, simp_all)[1]
                   apply clarsimp
-                 apply (rule spec_corres_splitE'[OF preemption_corres])
+                 apply (rule spec_corres_splitE'[OF preemptionPoint_corres])
                    apply (rule "2.hyps"(2)[unfolded fun_app_def rec_del_concrete_unfold
                                                     finaliseSlot_def],
                           assumption+)
@@ -7134,7 +7134,7 @@ next
        apply (clarsimp simp: cte_wp_at_def)
        apply (drule(1) zombies_finalD2, clarsimp+)
       apply (fold dc_def)
-      apply (rule corres_guard_imp, rule cap_swap_for_delete_corres)
+      apply (rule corres_guard_imp, rule capSwapForDelete_corres)
          apply (simp add: cte_map_replicate)
         apply simp
        apply clarsimp
@@ -7217,7 +7217,7 @@ next
              apply (rule corres_symb_exec_r)
                 apply (rule_tac F="cteCap endCTE = capability.NullCap"
                             in corres_gen_asm2, simp)
-                apply (rule cap_update_corres)
+                apply (rule updateCap_corres)
                  apply simp
                 apply (simp add: is_cap_simps)
                apply (rule_tac Q="\<lambda>rv. cte_at' (cte_map ?target)" in valid_prove_more)
@@ -7313,7 +7313,7 @@ next
     done
 qed
 
-lemma cap_delete_corres:
+lemma cteDelete_corres:
   "corres (dc \<oplus> dc)
       (einvs and simple_sched_action and cte_at ptr and emptyable ptr)
       (invs' and sch_act_simple and cte_at' (cte_map ptr))
@@ -7552,7 +7552,7 @@ lemma cap_revoke_mdb_stuff4:
        apply(simp add: cte_wp_at_def)+
        done
 
-lemma cap_revoke_corres':
+lemma cteRevoke_corres':
   "spec_corres s (dc \<oplus> dc)
       (einvs and simple_sched_action and cte_at ptr)
       (invs' and sch_act_simple and cte_at' (cte_map ptr))
@@ -7674,8 +7674,8 @@ proof (induct rule: cap_revoke.induct)
      apply (rule cap_revoke_mdb_stuff4, (simp add: in_get_cap_cte_wp_at)+)
     apply (clarsimp simp: whenE_def)
     apply (rule spec_corres_guard_imp)
-      apply (rule spec_corres_splitE' [OF cap_delete_corres])
-        apply (rule spec_corres_splitE' [OF preemption_corres])
+      apply (rule spec_corres_splitE' [OF cteDelete_corres])
+        apply (rule spec_corres_splitE' [OF preemptionPoint_corres])
           apply (rule "1.hyps",
                    (simp add: cte_wp_at_def in_monad select_def next_revoke_cap_def select_ext_def
                      | assumption | rule conjI refl)+)[1]
@@ -7689,7 +7689,7 @@ proof (induct rule: cap_revoke.induct)
     done
 qed
 
-lemmas cap_revoke_corres = use_spec_corres [OF cap_revoke_corres']
+lemmas cteRevoke_corres = use_spec_corres [OF cteRevoke_corres']
 
 crunch typ_at'[wp]: invokeCNode "\<lambda>s. P (typ_at' T p s)"
   (ignore: filterM finaliseSlot
@@ -8582,7 +8582,7 @@ crunch ksDomainTime[wp]: updateCap "\<lambda>s. P (ksDomainTime s)"
 
 declare corres_False' [simp]
 
-lemma inv_cnode_corres:
+lemma invokeCNode_corres:
   "cnodeinv_relation ci ci' \<Longrightarrow>
    corres (dc \<oplus> dc)
      (einvs and simple_sched_action and valid_cnode_inv ci)
@@ -8592,18 +8592,18 @@ lemma inv_cnode_corres:
   apply (cases ci, simp_all)
         apply clarsimp
         apply (rule corres_guard_imp)
-          apply (rule cins_corres)
+          apply (rule cteInsert_corres)
             apply simp+
          apply (clarsimp simp: invs_def valid_state_def valid_pspace_def
                         elim!: cte_wp_at_cte_at)
         apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
        apply clarsimp
        apply (rule corres_guard_imp)
-         apply (erule cap_move_corres)
+         apply (erule cteMove_corres)
         apply (clarsimp simp: cte_wp_at_caps_of_state real_cte_tcb_valid)
        apply (clarsimp simp: cte_wp_at_ctes_of)
-       apply (rule cap_revoke_corres)
-     apply (rule corres_guard_imp [OF cap_delete_corres])
+       apply (rule cteRevoke_corres)
+     apply (rule corres_guard_imp [OF cteDelete_corres])
       apply (clarsimp simp: cte_at_typ cap_table_at_typ halted_emptyable)
      apply simp
     apply (rename_tac cap1 cap2 p1 p2 p3)
@@ -8613,7 +8613,7 @@ lemma inv_cnode_corres:
      apply (rule corres_guard_imp)
        apply (rule_tac F="wellformed_cap cap1 \<and> wellformed_cap cap2"
               in corres_gen_asm)
-       apply (erule (1) cap_swap_corres [OF refl refl], simp+)
+       apply (erule (1) cteSwap_corres [OF refl refl], simp+)
       apply (simp add: invs_def valid_state_def valid_pspace_def
                        real_cte_tcb_valid valid_cap_def2)
      apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
@@ -8628,9 +8628,9 @@ lemma inv_cnode_corres:
      apply simp
     apply simp
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF cap_move_corres])
+      apply (rule corres_split_deprecated [OF cteMove_corres])
          apply assumption
-        apply (erule cap_move_corres)
+        apply (erule cteMove_corres)
        apply wp
        apply (simp add: cte_wp_at_caps_of_state)
        apply (wp cap_move_caps_of_state cteMove_cte_wp_at [simplified o_def])+
@@ -8656,7 +8656,7 @@ lemma inv_cnode_corres:
    apply (rename_tac prod)
    apply (simp add: getThreadCallerSlot_def locateSlot_conv objBits_simps)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated [OF _ gct_corres])
+     apply (rule corres_split_deprecated [OF _ getCurThread_corres])
         apply (subgoal_tac "thread + 2^cte_level_bits * tcbCallerSlot = cte_map (thread, tcb_cnode_index 3)")
          prefer 2
          apply (simp add: cte_map_def tcb_cnode_index_def tcbCallerSlot_def cte_level_bits_def objBits_defs)
@@ -8676,7 +8676,7 @@ lemma inv_cnode_corres:
             apply (case_tac cap, simp_all add: isCap_simps is_cap_simps split: bool.split)[1]
             apply clarsimp
             apply (rule corres_guard_imp)
-              apply (rule cap_move_corres)
+              apply (rule cteMove_corres)
               apply (simp add: real_cte_tcb_valid)+
         apply (wp get_cap_wp)
        apply (simp add: getSlotCap_def)
@@ -8706,7 +8706,7 @@ lemma inv_cnode_corres:
                 simp add: is_cap_simps)
    apply (clarsimp simp: when_def unless_def isCap_simps)
    apply (rule corres_guard_imp)
-     apply (rule cancel_badged_sends_corres)
+     apply (rule cancelBadgedSends_corres)
     apply (simp add: valid_cap_def)
    apply (simp add: valid_cap'_def)
   apply (clarsimp)

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -687,7 +687,7 @@ lemma getSlotCap_tcb_corres:
   apply (simp add: o_def cte_map_def tcb_cnode_index_def)
   done
 
-lemma lookup_slot_corres:
+lemma lookupSlotForThread_corres:
   "corres (lfr \<oplus> (\<lambda>(cref, bits) cref'. cref' = cte_map cref))
         (valid_objs and pspace_aligned and tcb_at t)
         (valid_objs' and pspace_aligned' and pspace_distinct' and tcb_at' t)
@@ -746,7 +746,7 @@ lemma lookupSlot_inv[wp]:
   apply (wp | simp add: split_def)+
   done
 
-lemma lc_corres:
+lemma lookupCap_corres:
  "corres (lfr \<oplus> cap_relation)
          (valid_objs and pspace_aligned and tcb_at t)
          (valid_objs' and pspace_aligned' and pspace_distinct' and tcb_at' t)
@@ -754,7 +754,7 @@ lemma lc_corres:
   apply (simp add: lookup_cap_def lookupCap_def bindE_assoc
                    lookupCapAndSlot_def liftME_def split_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_splitEE[OF _ lookup_slot_corres])
+    apply (rule corres_splitEE[OF _ lookupSlotForThread_corres])
       apply (simp add: split_def getSlotCap_def liftM_def[symmetric] o_def)
       apply (rule get_cap_corres)
      apply (rule hoare_pre, wp lookup_slot_cte_at_wp|simp)+
@@ -2256,7 +2256,7 @@ lemma pspace_relationsD:
   "\<lbrakk>pspace_relation kh kh'; ekheap_relation ekh kh'\<rbrakk> \<Longrightarrow> pspace_relations ekh kh kh'"
   by (simp add: pspace_relations_def)
 
-lemma cap_update_corres:
+lemma updateCap_corres:
   "\<lbrakk>cap_relation cap cap';
     is_zombie cap \<or> is_cnode_cap cap \<or> is_thread_cap cap \<rbrakk>
    \<Longrightarrow> corres dc (\<lambda>s. invs s \<and>
@@ -3665,7 +3665,7 @@ lemma updateUntypedCap_descendants_of:
   apply (clarsimp simp:mdb_next_rel_def mdb_next_def split:if_splits)
   done
 
-lemma set_untyped_cap_corres:
+lemma setCTE_UntypedCap_corres:
   "\<lbrakk>cap_relation cap (cteCap cte); is_untyped_cap cap; idx' = idx\<rbrakk>
    \<Longrightarrow> corres dc (cte_wp_at ((=) cap) src and valid_objs and
                   pspace_aligned and pspace_distinct)
@@ -3758,7 +3758,7 @@ lemma getCTE_get:
   apply (clarsimp simp:cte_wp_at_ctes_of)
   done
 
-lemma set_untyped_cap_as_full_corres:
+lemma setUntypedCapAsFull_corres:
   "\<lbrakk>cap_relation c c'; src' = cte_map src; dest' = cte_map dest;
     cap_relation src_cap (cteCap srcCTE); rv = cap.NullCap;
     cteCap rv' = capability.NullCap; mdbPrev (cteMDBNode rv') = nullPointer \<and>
@@ -3777,7 +3777,7 @@ lemma set_untyped_cap_as_full_corres:
         apply (rule corres_symb_exec_r)
            apply (rule_tac F="cte = srcCTE" in corres_gen_asm2)
            apply (simp)
-           apply (rule set_untyped_cap_corres)
+           apply (rule setCTE_UntypedCap_corres)
              apply simp+
            apply (clarsimp simp:free_index_update_def isCap_simps is_cap_simps)
            apply (subst identity_eq)
@@ -4993,7 +4993,7 @@ lemma cte_map_inj_eq':
   done
 
 context begin interpretation Arch . (*FIXME: arch_split*)
-lemma cins_corres:
+lemma cteInsert_corres:
   notes split_paired_All[simp del] split_paired_Ex[simp del]
         trans_state_update'[symmetric,simp]
   assumes "cap_relation c c'" "src' = cte_map src" "dest' = cte_map dest"
@@ -5426,7 +5426,7 @@ lemma cins_corres:
               apply (erule (5) cte_map_inj)
 (* FIXME *)
 
-             apply (rule set_untyped_cap_as_full_corres)
+             apply (rule setUntypedCapAsFull_corres)
                    apply simp+
             apply (wp set_untyped_cap_full_valid_objs set_untyped_cap_as_full_valid_mdb
                set_untyped_cap_as_full_cte_wp_at setUntypedCapAsFull_valid_cap
@@ -6434,7 +6434,7 @@ corres_underlying srel nf rrel G G' (do do_extended_op (return ()); g od) (g')"
   done
 *)
 
-(* consider putting in AINVS or up above cins_corres *)
+(* consider putting in AINVS or up above cteInsert_corres *)
 lemma next_slot_eq:
   "\<lbrakk>next_slot p t' m' = x; t' = t; m' = m\<rbrakk> \<Longrightarrow> next_slot p t m = x"
   by simp
@@ -6443,7 +6443,7 @@ lemma inj_on_image_set_diff15 : (* for compatibility of assumptions *)
   "\<lbrakk>inj_on f C; A \<subseteq> C; B \<subseteq> C\<rbrakk> \<Longrightarrow> f ` (A - B) = f ` A - f ` B"
 by (rule inj_on_image_set_diff; auto)
 
-lemma cap_swap_corres:
+lemma cteSwap_corres:
   assumes srcdst: "src' = cte_map src" "dest' = cte_map dest"
   assumes scr: "cap_relation scap scap'"
   assumes dcr: "cap_relation dcap dcap'"
@@ -6896,7 +6896,7 @@ lemma cap_swap_corres:
      done
 
 
-lemma cap_swap_for_delete_corres:
+lemma capSwapForDelete_corres:
   assumes "src' = cte_map src" "dest' = cte_map dest"
   shows "corres dc
          (valid_objs and pspace_aligned and pspace_distinct and
@@ -6917,7 +6917,7 @@ lemma cap_swap_for_delete_corres:
   apply (rule corres_guard_imp)
     apply (rule_tac P1=wellformed_cap in corres_split_deprecated [OF _ get_cap_corres_P])
       apply (rule_tac P1=wellformed_cap in corres_split_deprecated [OF _ get_cap_corres_P])
-        apply (rule cap_swap_corres, rule refl, rule refl, clarsimp+)
+        apply (rule cteSwap_corres, rule refl, rule refl, clarsimp+)
        apply (wp get_cap_wp getCTE_wp')+
    apply (clarsimp simp: cte_wp_at_caps_of_state)
    apply (drule (1) caps_of_state_valid_cap)+
@@ -6951,7 +6951,7 @@ lemma subtree_no_parent:
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma ensure_no_children_corres:
+lemma ensureNoChildren_corres:
   "p' = cte_map p \<Longrightarrow>
   corres (ser \<oplus> dc) (cte_at p) (pspace_aligned' and pspace_distinct' and cte_at' p' and valid_mdb')
          (ensure_no_children p) (ensureNoChildren p')"

--- a/proof/refine/ARM/CSpace_R.thy
+++ b/proof/refine/ARM/CSpace_R.thy
@@ -750,7 +750,7 @@ lemma set_cap_not_quite_corres':
                 apply (fastforce simp: c p pspace_relations_def)+
                 done
 context begin interpretation Arch . (*FIXME: arch_split*)
-lemma cap_move_corres:
+lemma cteMove_corres:
   assumes cr: "cap_relation cap cap'"
   notes trans_state_update'[symmetric,simp]
   shows
@@ -3278,7 +3278,7 @@ lemma cteInsert_invs:
   apply (auto simp: invs'_def valid_state'_def valid_pspace'_def elim: valid_capAligned)
   done
 
-lemma derive_cap_corres:
+lemma deriveCap_corres:
  "\<lbrakk>cap_relation c c'; cte = cte_map slot \<rbrakk> \<Longrightarrow>
   corres (ser \<oplus> cap_relation)
          (cte_at slot)
@@ -3289,14 +3289,14 @@ lemma derive_cap_corres:
             apply (simp_all add: returnOk_def Let_def is_zombie_def isCap_simps
                           split: sum.splits)
    apply (rule_tac Q="\<lambda>_ _. True" and Q'="\<lambda>_ _. True" in
-               corres_initial_splitE [OF ensure_no_children_corres])
+               corres_initial_splitE [OF ensureNoChildren_corres])
       apply simp
      apply clarsimp
     apply wp+
   apply clarsimp
   apply (rule corres_rel_imp)
    apply (rule corres_guard_imp)
-     apply (rule arch_derive_corres)
+     apply (rule arch_deriveCap_corres)
      apply (clarsimp simp: o_def)+
   done
 
@@ -3378,7 +3378,7 @@ lemma lookup_cap_corres:
      (lookupCap thread epcptr')"
   apply (simp add: lookup_cap_def lookupCap_def lookupCapAndSlot_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_splitEE [OF _ lookup_slot_corres])
+    apply (rule corres_splitEE [OF _ lookupSlotForThread_corres])
       apply (simp add: split_def)
       apply (subst bindE_returnOk[symmetric])
       apply (rule corres_splitEE)
@@ -3391,7 +3391,7 @@ lemma lookup_cap_corres:
    apply auto
   done
 
-lemma ensure_empty_corres:
+lemma ensureEmptySlot_corres:
   "q = cte_map p \<Longrightarrow>
    corres (ser \<oplus> dc) (invs and cte_at p) invs'
                      (ensure_empty p) (ensureEmptySlot q)"
@@ -3409,7 +3409,7 @@ lemma ensureEmpty_inv[wp]:
   "\<lbrace>P\<rbrace> ensureEmptySlot p \<lbrace>\<lambda>rv. P\<rbrace>"
   by (simp add: ensureEmptySlot_def unlessE_whenE whenE_def | wp)+
 
-lemma lsfc_corres:
+lemma lookupSlotForCNodeOp_corres:
   "\<lbrakk>cap_relation c c'; ptr = to_bl ptr'\<rbrakk>
   \<Longrightarrow> corres (ser \<oplus> (\<lambda>cref cref'. cref' = cte_map cref))
             (valid_objs and pspace_aligned and valid_cap c)
@@ -3505,7 +3505,7 @@ lemma deriveCap_untyped_derived:
   apply (clarsimp simp: cte_wp_at_ctes_of isCap_simps untyped_derived_eq_def)
   done
 
-lemma set_cap_pspace_corres:
+lemma setCTE_corres:
   "cap_relation cap (cteCap cte) \<Longrightarrow>
    corres_underlying {(s, s'). pspace_relations (ekheap (s)) (kheap s) (ksPSpace s')} False True dc
       (pspace_distinct and pspace_aligned and valid_objs and cte_at p)
@@ -3826,7 +3826,7 @@ lemma create_reply_master_corres:
     apply (clarsimp elim!: state_relationE simp: ghost_relation_of_heap)+
   apply (rule corres_guard_imp)
     apply (rule corres_underlying_symb_exec_l [OF set_original_symb_exec_l'])
-     apply (rule set_cap_pspace_corres)
+     apply (rule setCTE_corres)
      apply simp
     apply wp
    apply (clarsimp simp: cte_wp_at_cte_at valid_pspace_def)
@@ -3920,7 +3920,7 @@ proof -
     by (simp add: noReplyCapsFor_def)
 qed
 
-lemma setup_reply_master_corres:
+lemma setupReplyMaster_corres:
   "corres dc (einvs and tcb_at t) (invs' and tcb_at' t)
        (setup_reply_master t) (setupReplyMaster t)"
   apply (simp add: setupReplyMaster_def setup_reply_master_def)
@@ -4672,7 +4672,7 @@ lemma maskedAsFull_revokable_safe_parent:
 done
 
 context begin interpretation Arch . (*FIXME: arch_split*)
-lemma cins_corres_simple:
+lemma cteInsert_simple_corres:
   assumes "cap_relation c c'" "src' = cte_map src" "dest' = cte_map dest"
   notes trans_state_update'[symmetric,simp]
   shows "corres dc
@@ -4819,7 +4819,7 @@ lemma cins_corres_simple:
          apply (subgoal_tac "cte_map (aa,bb) \<noteq> cte_map dest")
           subgoal by (clarsimp simp: modify_map_def split: if_split_asm)
          apply (erule (5) cte_map_inj)
-         apply (rule set_untyped_cap_as_full_corres)
+         apply (rule setUntypedCapAsFull_corres)
          apply simp+
           apply (wp set_untyped_cap_full_valid_objs set_untyped_cap_as_full_valid_mdb set_untyped_cap_as_full_valid_list
              set_untyped_cap_as_full_cte_wp_at setUntypedCapAsFull_valid_cap
@@ -4875,7 +4875,7 @@ lemma cins_corres_simple:
    apply clarsimp
    apply (drule (5) cte_map_inj)+
    apply simp
-  (* exact reproduction of proof in cins_corres,
+  (* exact reproduction of proof in cteInsert_corres,
      as it does not used is_derived *)
   apply(simp add: cdt_list_relation_def del: split_paired_All split_paired_Ex)
   apply(subgoal_tac "no_mloop (cdt a) \<and> finite_depth (cdt a)")

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -615,7 +615,7 @@ lemma sym_refs_hyp_refs_triv[simp]: "sym_refs (state_hyp_refs_of s)"
   apply (case_tac ko; clarsimp)
   done
 
-lemma detype_corres:
+lemma deleteObjects_corres:
   "is_aligned base magnitude \<Longrightarrow> magnitude \<ge> 2 \<Longrightarrow>
    corres dc
       (\<lambda>s. einvs s

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -1456,24 +1456,24 @@ lemma emptySlot_invs'[wp]:
   apply (clarsimp simp: cte_wp_at_ctes_of)
   done
 
-lemma deleted_irq_corres:
+lemma deletedIRQHandler_corres:
   "corres dc \<top> \<top>
     (deleted_irq_handler irq)
     (deletedIRQHandler irq)"
   apply (simp add: deleted_irq_handler_def deletedIRQHandler_def)
-  apply (rule set_irq_state_corres)
+  apply (rule setIRQState_corres)
   apply (simp add: irq_state_relation_def)
   done
 
-lemma arch_post_cap_deletion_corres:
+lemma arch_postCapDeletion_corres:
   "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (ARM_H.postCapDeletion cap')"
   by (corressimp simp: arch_post_cap_deletion_def ARM_H.postCapDeletion_def)
 
-lemma post_cap_deletion_corres:
+lemma postCapDeletion_corres:
   "cap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (post_cap_deletion cap) (postCapDeletion cap')"
   apply (cases cap; clarsimp simp: post_cap_deletion_def Retype_H.postCapDeletion_def)
-   apply (corressimp corres: deleted_irq_corres)
-  by (corressimp corres: arch_post_cap_deletion_corres)
+   apply (corressimp corres: deletedIRQHandler_corres)
+  by (corressimp corres: arch_postCapDeletion_corres)
 
 lemma set_cap_trans_state:
   "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),trans_state f s') \<in> fst (set_cap c p (trans_state f s))"
@@ -1483,7 +1483,7 @@ lemma set_cap_trans_state:
   apply (auto simp add: in_monad set_object_def split: if_split_asm)
   done
 
-lemma clearUntypedFreeIndex_corres_noop:
+lemma clearUntypedFreeIndex_noop_corres:
   "corres dc \<top> (cte_at' (cte_map slot))
     (return ()) (clearUntypedFreeIndex (cte_map slot))"
   apply (simp add: clearUntypedFreeIndex_def)
@@ -1506,13 +1506,13 @@ lemma clearUntypedFreeIndex_valid_pspace'[wp]:
    apply (wp | simp add: valid_mdb'_def)+
   done
 
-lemma empty_slot_corres:
+lemma emptySlot_corres:
   "cap_relation info info' \<Longrightarrow> corres dc (einvs and cte_at slot) (invs' and cte_at' (cte_map slot))
              (empty_slot slot info) (emptySlot (cte_map slot) info')"
   unfolding emptySlot_def empty_slot_def
   apply (simp add: case_Null_If)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_noop_rhs[OF _ clearUntypedFreeIndex_corres_noop])
+    apply (rule corres_split_noop_rhs[OF _ clearUntypedFreeIndex_noop_corres])
      apply (rule_tac R="\<lambda>cap. einvs and cte_wp_at ((=) cap) slot" and
                      R'="\<lambda>cte. valid_pspace' and cte_wp_at' ((=) cte) (cte_map slot)" in
                      corres_split_deprecated [OF _ get_cap_corres])
@@ -1529,7 +1529,7 @@ lemma empty_slot_corres:
   apply (rule conjI, clarsimp)
   apply clarsimp
   apply (simp only: bind_assoc[symmetric])
-  apply (rule corres_split'[where r'=dc, OF _ post_cap_deletion_corres])
+  apply (rule corres_split'[where r'=dc, OF _ postCapDeletion_corres])
     defer
     apply wpsimp+
   apply (rule corres_no_failI)
@@ -2038,7 +2038,7 @@ lemma obj_refs_Master:
   by (clarsimp simp: isCap_simps
               split: cap_relation_split_asm arch_cap.split_asm)
 
-lemma final_cap_corres':
+lemma isFinalCapability_corres':
   "final_matters' (cteCap cte) \<Longrightarrow>
    corres (=) (invs and cte_wp_at ((=) cap) ptr)
                (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
@@ -2123,14 +2123,14 @@ lemma final_cap_corres':
   by (clarsimp simp: cap_irqs_def cap_irq_opt_def sameObjectAs_def3 isCap_simps arch_gen_obj_refs_def
                  split: cap.split_asm)
 
-lemma final_cap_corres:
+lemma isFinalCapability_corres:
   "corres (\<lambda>rv rv'. final_matters' (cteCap cte) \<longrightarrow> rv = rv')
           (invs and cte_wp_at ((=) cap) ptr)
           (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
        (is_final_cap cap) (isFinalCapability cte)"
   apply (cases "final_matters' (cteCap cte)")
    apply simp
-   apply (erule final_cap_corres')
+   apply (erule isFinalCapability_corres')
   apply (subst bind_return[symmetric],
          rule corres_symb_exec_r)
      apply (rule corres_no_failI)
@@ -3369,12 +3369,12 @@ lemma interrupt_cap_null_or_ntfn:
                  split: cap.split_asm)
   done
 
-lemma (in delete_one) deleting_irq_corres:
+lemma (in delete_one) deletingIRQHandler_corres:
   "corres dc (einvs) (invs')
           (deleting_irq_handler irq) (deletingIRQHandler irq)"
   apply (simp add: deleting_irq_handler_def deletingIRQHandler_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_irq_slot_corres])
+    apply (rule corres_split_deprecated [OF _ getIRQSlot_corres])
       apply simp
       apply (rule_tac P'="cte_at' (cte_map slot)" in corres_symb_exec_r_conj)
          apply (rule_tac F="isNotificationCap rv \<or> rv = capability.NullCap"
@@ -3399,7 +3399,7 @@ lemma (in delete_one) deleting_irq_corres:
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma arch_finalise_cap_corres:
+lemma arch_finaliseCap_corres:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
            (\<lambda>s. invs s \<and> valid_etcbs s
@@ -3418,23 +3418,23 @@ lemma arch_finalise_cap_corres:
                        isPageTableCap_def
                        o_def dc_def[symmetric]
                 split: option.split)
-     apply (rule corres_guard_imp, rule delete_asid_pool_corres)
+     apply (rule corres_guard_imp, rule deleteASIDPool_corres)
       apply (clarsimp simp: valid_cap_def mask_def)
      apply (clarsimp simp: valid_cap'_def)
      apply auto[1]
-    apply (rule corres_guard_imp, rule unmap_page_corres)
+    apply (rule corres_guard_imp, rule unmapPage_corres)
       apply simp
      apply (clarsimp simp: valid_cap_def valid_unmap_def)
      apply (auto simp: vmsz_aligned_def pbfs_atleast_pageBits mask_def
                  elim: is_aligned_weaken invs_valid_asid_map)[2]
-   apply (rule corres_guard_imp, rule unmap_page_table_corres)
+   apply (rule corres_guard_imp, rule unmapPageTable_corres)
     apply (auto simp: valid_cap_def valid_cap'_def mask_def
                elim!: is_aligned_weaken invs_valid_asid_map)[2]
-  apply (rule corres_guard_imp, rule delete_asid_corres)
+  apply (rule corres_guard_imp, rule deleteASID_corres)
    apply (auto elim!: invs_valid_asid_map simp: mask_def valid_cap_def)[2]
   done
 
-lemma unbind_notification_corres:
+lemma unbindNotification_corres:
   "corres dc
       (invs and tcb_at t)
       (invs' and tcb_at' t)
@@ -3443,14 +3443,14 @@ lemma unbind_notification_corres:
   supply option.case_cong_weak[cong]
   apply (simp add: unbind_notification_def unbindNotification_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gbn_corres])
+    apply (rule corres_split_deprecated[OF _ getBoundNotification_corres])
       apply (rule corres_option_split)
         apply simp
        apply (rule corres_return_trivial)
-      apply (rule corres_split_deprecated[OF _ get_ntfn_corres])
+      apply (rule corres_split_deprecated[OF _ getNotification_corres])
         apply clarsimp
-        apply (rule corres_split_deprecated[OF _ set_ntfn_corres])
-           apply (rule sbn_corres)
+        apply (rule corres_split_deprecated[OF _ setNotification_corres])
+           apply (rule setBoundNotification_corres)
           apply (clarsimp simp: ntfn_relation_def split:Structures_A.ntfn.splits)
          apply (wp gbn_wp' gbn_wp)+
    apply (clarsimp elim!: obj_at_valid_objsE
@@ -3464,19 +3464,19 @@ lemma unbind_notification_corres:
                   split: option.splits)
   done
 
-lemma unbind_maybe_notification_corres:
+lemma unbindMaybeNotification_corres:
   "corres dc
       (invs and ntfn_at ntfnptr) (invs' and ntfn_at' ntfnptr)
       (unbind_maybe_notification ntfnptr)
       (unbindMaybeNotification ntfnptr)"
   apply (simp add: unbind_maybe_notification_def unbindMaybeNotification_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ get_ntfn_corres])
+    apply (rule corres_split_deprecated[OF _ getNotification_corres])
       apply (rule corres_option_split)
         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
        apply (rule corres_return_trivial)
-      apply (rule corres_split_deprecated[OF _ set_ntfn_corres])
-         apply (rule sbn_corres)
+      apply (rule corres_split_deprecated[OF _ setNotification_corres])
+         apply (rule setBoundNotification_corres)
         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
        apply (wp get_simple_ko_wp getNotification_wp)+
    apply (clarsimp elim!: obj_at_valid_objsE
@@ -3490,7 +3490,7 @@ lemma unbind_maybe_notification_corres:
                   split: option.splits)
   done
 
-lemma fast_finalise_corres:
+lemma fast_finaliseCap_corres:
   "\<lbrakk> final_matters' cap' \<longrightarrow> final = final'; cap_relation cap cap';
      can_fast_finalise cap \<rbrakk>
    \<Longrightarrow> corres dc
@@ -3516,8 +3516,8 @@ lemma fast_finalise_corres:
    apply (simp add: valid_cap'_def)
   apply (clarsimp simp: final_matters'_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ unbind_maybe_notification_corres])
-         apply (rule ntfn_cancel_corres)
+    apply (rule corres_split_deprecated[OF _ unbindMaybeNotification_corres])
+         apply (rule cancelAllSignals_corres)
        apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps getNotification_wp
             | wpc)+
    apply (clarsimp simp: valid_cap_def)
@@ -3536,10 +3536,10 @@ lemma cap_delete_one_corres:
       apply (rule_tac F="can_fast_finalise cap" in corres_gen_asm)
       apply (rule corres_if)
         apply fastforce
-       apply (rule corres_split_deprecated [OF _ final_cap_corres[where ptr=ptr]])
+       apply (rule corres_split_deprecated [OF _ isFinalCapability_corres[where ptr=ptr]])
          apply (simp add: split_def bind_assoc [THEN sym])
-         apply (rule corres_split_deprecated [OF _ fast_finalise_corres[where sl=ptr]])
-              apply (rule empty_slot_corres)
+         apply (rule corres_split_deprecated [OF _ fast_finaliseCap_corres[where sl=ptr]])
+              apply (rule emptySlot_corres)
              apply simp+
           apply (wp hoare_drop_imps)+
         apply (wp isFinalCapability_inv | wp (once) isFinal[where x="cte_map ptr"])+
@@ -3560,7 +3560,7 @@ global_interpretation delete_one
    apply auto
   done
 
-lemma finalise_cap_corres:
+lemma finaliseCap_corres:
   "\<lbrakk> final_matters' cap' \<Longrightarrow> final = final'; cap_relation cap cap';
           flag \<longrightarrow> can_fast_finalise cap \<rbrakk>
      \<Longrightarrow> corres (\<lambda>x y. cap_relation (fst x) (fst y) \<and> cap_relation (snd x) (snd y))
@@ -3582,8 +3582,8 @@ lemma finalise_cap_corres:
         apply (simp add: valid_cap'_def)
        apply (clarsimp simp add: final_matters'_def)
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated[OF _ unbind_maybe_notification_corres])
-           apply (rule ntfn_cancel_corres)
+         apply (rule corres_split_deprecated[OF _ unbindMaybeNotification_corres])
+           apply (rule cancelAllSignals_corres)
           apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps hoare_vcg_all_lift | wpc)+
         apply (clarsimp simp: valid_cap_def)
        apply (clarsimp simp: valid_cap'_def)
@@ -3592,7 +3592,7 @@ lemma finalise_cap_corres:
                                liftM_def[symmetric] o_def zbits_map_def
                                dc_def[symmetric])
      apply (rule corres_guard_imp)
-       apply (rule corres_split_deprecated[OF _ unbind_notification_corres])
+       apply (rule corres_split_deprecated[OF _ unbindNotification_corres])
          apply (rule corres_split_deprecated[OF _ suspend_corres])
             apply (clarsimp simp: liftM_def[symmetric] o_def dc_def[symmetric] zbits_map_def)
           apply (rule prepareThreadDelete_corres)
@@ -3602,7 +3602,7 @@ lemma finalise_cap_corres:
     apply (simp add: final_matters'_def liftM_def[symmetric]
                      o_def dc_def[symmetric])
     apply (intro impI, rule corres_guard_imp)
-      apply (rule deleting_irq_corres)
+      apply (rule deletingIRQHandler_corres)
      apply simp
     apply simp
    apply (clarsimp simp: final_matters'_def)
@@ -3612,7 +3612,7 @@ lemma finalise_cap_corres:
     apply (clarsimp simp: cte_wp_at_caps_of_state)
    apply simp
   apply (clarsimp split del: if_split simp: o_def)
-  apply (rule corres_guard_imp [OF arch_finalise_cap_corres], (fastforce simp: valid_sched_def)+)
+  apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
   done
 context begin interpretation Arch . (*FIXME: arch_split*)
 lemma arch_recycleCap_improve_cases:

--- a/proof/refine/ARM/InterruptAcc_R.thy
+++ b/proof/refine/ARM/InterruptAcc_R.thy
@@ -8,7 +8,7 @@ theory InterruptAcc_R
 imports TcbAcc_R
 begin
 
-lemma get_irq_slot_corres:
+lemma getIRQSlot_corres:
   "corres (\<lambda>sl sl'. sl' = cte_map sl) \<top> \<top> (get_irq_slot irq) (getIRQSlot irq)"
   apply (simp add: getIRQSlot_def get_irq_slot_def locateSlot_conv
                    liftM_def[symmetric])
@@ -23,7 +23,7 @@ crunch inv[wp]: getIRQSlot "P"
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma set_irq_state_corres:
+lemma setIRQState_corres:
   "irq_state_relation state state' \<Longrightarrow>
    corres dc \<top> \<top> (set_irq_state state irq) (setIRQState state' irq)"
   apply (simp add: set_irq_state_def setIRQState_def
@@ -94,7 +94,7 @@ lemma work_units_and_irq_state_state_relationI [intro!]:
    \<in> state_relation"
   by (simp add: state_relation_def swp_def)
 
-lemma preemption_corres:
+lemma preemptionPoint_corres:
   "corres (dc \<oplus> dc) \<top> \<top> preemption_point preemptionPoint"
   apply (simp add: preemption_point_def preemptionPoint_def)
   by (auto simp: preemption_point_def preemptionPoint_def o_def gets_def liftE_def whenE_def getActiveIRQ_def

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -169,7 +169,7 @@ lemma invs_weak_sch_act_wf[elim!]:
 crunch tcb_at[wp]: set_endpoint "tcb_at t"
 crunch tcb_at'[wp]: setEndpoint "tcb_at' t"
 
-lemma blocked_cancel_ipc_corres:
+lemma blocked_cancelIPC_corres:
   "\<lbrakk> st = Structures_A.BlockedOnReceive epPtr p' \<or>
      st = Structures_A.BlockedOnSend epPtr p; thread_state_relation st st' \<rbrakk> \<Longrightarrow>
    corres dc (invs and st_tcb_at ((=) st) t) (invs' and st_tcb_at' ((=) st') t)
@@ -185,7 +185,7 @@ lemma blocked_cancel_ipc_corres:
             od)"
   apply (simp add: blocked_cancel_ipc_def gbep_ret)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres])
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres])
       apply (rule_tac F="ep \<noteq> IdleEP" in corres_gen_asm2)
       apply (rule corres_assert_assume[rotated])
        apply (clarsimp split: endpoint.splits)
@@ -198,8 +198,8 @@ lemma blocked_cancel_ipc_corres:
        apply (case_tac "remove1 t list")
         apply simp
         apply (rule corres_guard_imp)
-          apply (rule corres_split_deprecated [OF _ set_ep_corres])
-             apply (rule sts_corres)
+          apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+             apply (rule setThreadState_corres)
              apply simp
             apply (simp add: ep_relation_def)
            apply (simp add: valid_tcb_state_def pred_conj_def)
@@ -221,8 +221,8 @@ lemma blocked_cancel_ipc_corres:
                               valid_tcb_state'_def)[1]
        apply clarsimp
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
-            apply (rule sts_corres)
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+            apply (rule setThreadState_corres)
             apply simp
            apply (simp add: ep_relation_def)
           apply (wp)+
@@ -246,8 +246,8 @@ lemma blocked_cancel_ipc_corres:
       apply (case_tac "remove1 t list")
        apply simp
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
-            apply (rule sts_corres)
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+            apply (rule setThreadState_corres)
             apply simp
            apply (simp add: ep_relation_def)
           apply (simp add: valid_tcb_state_def pred_conj_def)
@@ -269,8 +269,8 @@ lemma blocked_cancel_ipc_corres:
                              valid_tcb_state'_def)[1]
       apply clarsimp
       apply (rule corres_guard_imp)
-        apply (rule corres_split_deprecated [OF _ set_ep_corres])
-           apply (rule sts_corres)
+        apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+           apply (rule setThreadState_corres)
            apply simp
           apply (simp add: ep_relation_def)
          apply (wp)+
@@ -308,7 +308,7 @@ lemma blocked_cancel_ipc_corres:
   apply (fastforce simp: ko_wp_at'_def obj_at'_def projectKOs dest: sym_refs_st_tcb_atD')
   done
 
-lemma ac_corres:
+lemma cancelSignal_corres:
   "corres dc
           (invs and st_tcb_at ((=) (Structures_A.BlockedOnNotification ntfn)) t)
           (invs' and st_tcb_at' ((=) (BlockedOnNotification ntfn)) t)
@@ -316,7 +316,7 @@ lemma ac_corres:
           (cancelSignal t ntfn)"
   apply (simp add: cancel_signal_def cancelSignal_def Let_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ntfn_corres])
+    apply (rule corres_split_deprecated [OF _ getNotification_corres])
       apply (rule_tac F="isWaitingNtfn (ntfnObj ntfnaa)" in corres_gen_asm2)
       apply (case_tac "ntfn_obj ntfna")
         apply (simp add: ntfn_relation_def isWaitingNtfn_def)
@@ -324,14 +324,14 @@ lemma ac_corres:
        apply (rename_tac list)
        apply (rule_tac R="remove1 t list = []" in corres_cases)
         apply (simp del: dc_simp)
-        apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-           apply (rule sts_corres)
+        apply (rule corres_split_deprecated [OF _ setNotification_corres])
+           apply (rule setThreadState_corres)
            apply simp
           apply (simp add: ntfn_relation_def)
          apply (wp)+
        apply (simp add: list_case_If del: dc_simp)
-       apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-          apply (rule sts_corres)
+       apply (rule corres_split_deprecated [OF _ setNotification_corres])
+          apply (rule setThreadState_corres)
           apply simp
          apply (clarsimp simp add: ntfn_relation_def neq_Nil_conv)
         apply (wp)+
@@ -523,7 +523,7 @@ locale delete_one = delete_one_conc + delete_one_abs +
                (invs' and cte_at' (cte_map ptr))
           (cap_delete_one ptr) (cteDeleteOne (cte_map ptr))"
 
-lemma (in delete_one) reply_cancel_ipc_corres:
+lemma (in delete_one) cancelIPC_ReplyCap_corres:
   "corres dc (einvs  and st_tcb_at awaiting_reply t)
              (invs' and st_tcb_at' awaiting_reply' t)
       (reply_cancel_ipc t)
@@ -613,28 +613,28 @@ lemma (in delete_one) cancel_ipc_corres:
       (cancel_ipc t) (cancelIPC t)"
   apply (simp add: cancel_ipc_def cancelIPC_def Let_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gts_corres])
+    apply (rule corres_split_deprecated [OF _ getThreadState_corres])
       apply (rule_tac P="einvs and st_tcb_at ((=) state) t" and
                       P'="invs' and st_tcb_at' ((=) statea) t" in corres_inst)
       apply (case_tac state, simp_all add: isTS_defs list_case_If)[1]
          apply (rule corres_guard_imp)
-           apply (rule blocked_cancel_ipc_corres)
+           apply (rule blocked_cancelIPC_corres)
             apply fastforce
            apply fastforce
           apply simp
          apply simp
         apply (clarsimp simp add: isTS_defs list_case_If)
         apply (rule corres_guard_imp)
-          apply (rule blocked_cancel_ipc_corres)
+          apply (rule blocked_cancelIPC_corres)
            apply fastforce
           apply fastforce
          apply simp
         apply simp
        apply (rule corres_guard_imp)
-         apply (rule reply_cancel_ipc_corres)
+         apply (rule cancelIPC_ReplyCap_corres)
         apply (clarsimp elim!: st_tcb_weakenE)
        apply (clarsimp elim!: pred_tcb'_weakenE)
-      apply (rule corres_guard_imp [OF ac_corres], simp+)
+      apply (rule corres_guard_imp [OF cancelSignal_corres], simp+)
      apply (wp gts_sp[where P="\<top>",simplified])+
     apply (rule hoare_strengthen_post)
      apply (rule gts_sp'[where P="\<top>"])
@@ -1410,9 +1410,9 @@ lemma (in delete_one) suspend_corres:
   apply (simp add: IpcCancel_A.suspend_def Thread_H.suspend_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_nor [OF _ cancel_ipc_corres])
-      apply (rule corres_split_deprecated [OF _ gts_corres])
+      apply (rule corres_split_deprecated [OF _ getThreadState_corres])
         apply (rule corres_split_nor)
-           apply (rule corres_split_nor [OF _ sts_corres])
+           apply (rule corres_split_nor [OF _ setThreadState_corres])
               apply (rule tcbSchedDequeue_corres')
              apply wpsimp
             apply wp
@@ -1420,7 +1420,7 @@ lemma (in delete_one) suspend_corres:
           apply (rule corres_if)
             apply (case_tac state; simp)
            apply (simp add: update_restart_pc_def updateRestartPC_def)
-           apply (rule corres_as_user')
+           apply (rule asUser_corres')
            apply (simp add: ARM.nextInstructionRegister_def ARM.faultRegister_def
                             ARM_H.nextInstructionRegister_def ARM_H.faultRegister_def)
            apply (simp add: ARM_H.Register_def)
@@ -1906,7 +1906,7 @@ lemma ep_cancel_corres_helper:
       apply (rule corres_guard_imp)
         apply (subst bind_return_unit, rule corres_split_deprecated [OF tcbSchedEnqueue_corres])
           apply simp
-          apply (rule corres_guard_imp [OF sts_corres])
+          apply (rule corres_guard_imp [OF setThreadState_corres])
             apply simp
            apply (simp add: valid_tcb_state_def)
           apply simp
@@ -1948,7 +1948,7 @@ proof -
                    rescheduleRequired
                 od)"
     apply (rule corres_split')
-       apply (rule corres_guard_imp [OF set_ep_corres])
+       apply (rule corres_guard_imp [OF setEndpoint_corres])
          apply (simp add: ep_relation_def)+
       apply (rule corres_split_deprecated [OF rescheduleRequired_corres])
         apply (rule ep_cancel_corres_helper)
@@ -1971,7 +1971,7 @@ proof -
   show ?thesis
     apply (simp add: cancel_all_ipc_def cancelAllIPC_def)
     apply (rule corres_split' [OF _ _ get_simple_ko_sp get_ep_sp'])
-     apply (rule corres_guard_imp [OF get_ep_corres], simp+)
+     apply (rule corres_guard_imp [OF getEndpoint_corres], simp+)
     apply (case_tac epa, simp_all add: ep_relation_def
                                        get_ep_queue_def)
      apply (rule corres_guard_imp [OF P]
@@ -1993,16 +1993,16 @@ lemma set_ntfn_tcb_obj_at' [wp]:
 apply (clarsimp simp: setNotification_def, wp)
 done
 
-lemma ntfn_cancel_corres:
+lemma cancelAllSignals_corres:
   "corres dc (invs and valid_sched and ntfn_at ntfn) (invs' and ntfn_at' ntfn)
              (cancel_all_signals ntfn) (cancelAllSignals ntfn)"
   apply (simp add: cancel_all_signals_def cancelAllSignals_def)
   apply (rule corres_split' [OF _ _ get_simple_ko_sp get_ntfn_sp'])
-   apply (rule corres_guard_imp [OF get_ntfn_corres])
+   apply (rule corres_guard_imp [OF getNotification_corres])
     apply simp+
   apply (case_tac "ntfn_obj ntfna", simp_all add: ntfn_relation_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
+    apply (rule corres_split_deprecated [OF _ setNotification_corres])
        apply (rule corres_split_deprecated [OF rescheduleRequired_corres])
          apply (rule ep_cancel_corres_helper)
         apply (wp mapM_x_wp'[where 'b="det_ext state"]
@@ -2595,21 +2595,21 @@ lemma cancelBadgedSends_invs[wp]:
 crunch state_refs_of[wp]: tcb_sched_action "\<lambda>s. P (state_refs_of s)"
   (ignore_del: tcb_sched_action)
 
-lemma cancel_badged_sends_corres:
+lemma cancelBadgedSends_corres:
   "corres dc (invs and valid_sched and ep_at epptr) (invs' and ep_at' epptr)
          (cancel_badged_sends epptr bdg) (cancelBadgedSends epptr bdg)"
   apply (simp add: cancel_badged_sends_def cancelBadgedSends_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres get_simple_ko_sp get_ep_sp',
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres get_simple_ko_sp get_ep_sp',
                                  where Q="invs and valid_sched" and Q'=invs'])
     apply simp_all
   apply (case_tac ep, simp_all add: ep_relation_def)
   apply (simp add: filterM_mapM list_case_return cong: list.case_cong)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_nor [OF _ set_ep_corres])
+    apply (rule corres_split_nor [OF _ setEndpoint_corres])
        apply (rule corres_split_eqr[OF _ _ _ hoare_post_add[where R="\<lambda>_. valid_objs'"]])
           apply (rule corres_split_deprecated [OF rescheduleRequired_corres])
-            apply (rule set_ep_corres)
+            apply (rule setEndpoint_corres)
             apply (simp split: list.split add: ep_relation_def)
            apply (wp weak_sch_act_wf_lift_linear)+
          apply (rule_tac S="(=)"
@@ -2619,11 +2619,11 @@ lemma cancel_badged_sends_corres:
                 simp_all add: list_all2_refl)[1]
            apply (clarsimp simp: liftM_def[symmetric] o_def)
            apply (rule corres_guard_imp)
-             apply (rule corres_split_deprecated [OF _ gts_corres])
+             apply (rule corres_split_deprecated [OF _ getThreadState_corres])
                apply (rule_tac F="\<exists>pl. st = Structures_A.BlockedOnSend epptr pl"
                             in corres_gen_asm)
                apply (clarsimp simp: o_def dc_def[symmetric] liftM_def)
-               apply (rule corres_split_deprecated [OF _ sts_corres])
+               apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                   apply (rule corres_split_deprecated[OF _ tcbSchedEnqueue_corres])
                     apply (rule corres_trivial)
                     apply simp

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -13,14 +13,14 @@ context begin interpretation Arch . (*FIXME: arch_split*)
 lemmas lookup_slot_wrapper_defs'[simp] =
    lookupSourceSlot_def lookupTargetSlot_def lookupPivotSlot_def
 
-lemma get_mi_corres: "corres ((=) \<circ> message_info_map)
+lemma getMessageInfo_corres: "corres ((=) \<circ> message_info_map)
                       (tcb_at t) (tcb_at' t)
                       (get_message_info t) (getMessageInfo t)"
   apply (rule corres_guard_imp)
     apply (unfold get_message_info_def getMessageInfo_def fun_app_def)
     apply (simp add: ARM_H.msgInfoRegister_def
              ARM.msgInfoRegister_def ARM_A.msg_info_register_def)
-    apply (rule corres_split_eqr [OF _ user_getreg_corres])
+    apply (rule corres_split_eqr [OF _ asUser_getRegister_corres])
        apply (rule corres_trivial, simp add: message_info_from_data_eqv)
       apply (wp | simp)+
   done
@@ -100,7 +100,7 @@ lemma valid_ipc_buffer_ptr'D2:
   apply simp
   done
 
-lemma load_ct_corres:
+lemma loadCapTransfer_corres:
   "corres ct_relation \<top> (valid_ipc_buffer_ptr' buffer) (load_cap_transfer buffer) (loadCapTransfer buffer)"
   apply (simp add: load_cap_transfer_def loadCapTransfer_def
                    captransfer_from_words_def
@@ -123,7 +123,7 @@ lemma load_ct_corres:
     apply (erule valid_ipc_buffer_ptr'D2, simp add: max_ipc_words, simp add: is_aligned_def)+
   done
 
-lemma get_recv_slot_corres:
+lemma getReceiveSlots_corres:
   "corres (\<lambda>xs ys. ys = map cte_map xs)
     (tcb_at receiver and valid_objs and pspace_aligned)
     (tcb_at' receiver and valid_objs' and pspace_aligned' and pspace_distinct' and
@@ -134,7 +134,7 @@ lemma get_recv_slot_corres:
    apply (simp add: getReceiveSlots_def)
   apply (simp add: getReceiveSlots_def split_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ load_ct_corres])
+    apply (rule corres_split_deprecated [OF _ loadCapTransfer_corres])
       apply (rule corres_empty_on_failure)
       apply (rule corres_splitEE)
          prefer 2
@@ -146,7 +146,7 @@ lemma get_recv_slot_corres:
            prefer 2
            apply (rule corres_unify_failure)
             apply (simp add: ct_relation_def)
-            apply (erule lsfc_corres [OF _ refl])
+            apply (erule lookupSlotForCNodeOp_corres [OF _ refl])
            apply simp
           apply (simp add: split_def liftE_bindE unlessE_whenE)
           apply (rule corres_split_deprecated [OF _ get_cap_corres])
@@ -206,11 +206,11 @@ declare word_div_1 [simp]
 declare word_minus_one_le [simp]
 declare word32_minus_one_le [simp]
 
-lemma load_word_offs_corres':
+lemma loadWordUser_corres':
   "\<lbrakk> y < unat max_ipc_words; y' = of_nat y * 4 \<rbrakk> \<Longrightarrow>
   corres (=) \<top> (valid_ipc_buffer_ptr' a) (load_word_offs a y) (loadWordUser (a + y'))"
   apply simp
-  apply (erule load_word_offs_corres)
+  apply (erule loadWordUser_corres)
   done
 
 declare loadWordUser_inv [wp]
@@ -243,7 +243,7 @@ lemma corres_set_extra_badge:
           (\<lambda>_. msg_max_length + 2 + n < unat max_ipc_words))
          (set_extra_badge buffer b n) (setExtraBadge buffer b' n)"
   apply (rule corres_gen_asm2)
-  apply (drule store_word_offs_corres [where a=buffer and w=b])
+  apply (drule storeWordUser_corres [where a=buffer and w=b])
   apply (simp add: set_extra_badge_def setExtraBadge_def buffer_cptr_index_def
                    bufferCPtrOffset_def Let_def)
   apply (simp add: word_size word_size_def wordSize_def wordBits_def
@@ -379,7 +379,7 @@ lemma cte_refs'_maskedAsFull[simp]:
  done
 
 
-lemma tc_loop_corres:
+lemma transferCapsToSlots_corres:
   "\<lbrakk> list_all2 (\<lambda>(cap, slot) (cap', slot'). cap_relation cap cap'
              \<and> slot' = cte_map slot) caps caps';
       mi' = message_info_map mi \<rbrakk> \<Longrightarrow>
@@ -445,14 +445,14 @@ next
          prefer 2
          apply (rule unifyFailure_discard2)
           apply (case_tac mi, clarsimp)
-         apply (rule derive_cap_corres)
+         apply (rule deriveCap_corres)
           apply (simp add: remove_rights_def)
          apply clarsimp
         apply (rule corres_split_norE)
            apply (simp add: liftE_bindE)
            apply (rule corres_split_nor)
               prefer 2
-              apply (rule cins_corres, simp_all add: hd_map)[1]
+              apply (rule cteInsert_corres, simp_all add: hd_map)[1]
              apply (simp add: tl_map)
              apply (rule corres_rel_imp, rule Cons.hyps, simp_all)[1]
             apply (wp valid_case_option_post_wp hoare_vcg_const_Ball_lift
@@ -1005,7 +1005,7 @@ lemma grs_distinct'[wp]:
   apply simp
   done
 
-lemma tc_corres:
+lemma transferCaps_corres:
   "\<lbrakk> info' = message_info_map info;
     list_all2 (\<lambda>x y. cap_relation (fst x) (fst y) \<and> snd y = cte_map (snd x))
          caps caps' \<rbrakk>
@@ -1030,12 +1030,12 @@ lemma tc_corres:
                    getThreadCSpaceRoot)
   apply (rule corres_assume_pre)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_recv_slot_corres])
+    apply (rule corres_split_deprecated [OF _ getReceiveSlots_corres])
       apply (rule_tac x=recv_buf in option_corres)
        apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
        apply (case_tac info, simp)
       apply simp
-      apply (rule corres_rel_imp, rule tc_loop_corres,
+      apply (rule corres_rel_imp, rule transferCapsToSlots_corres,
              simp_all add: split_def)[1]
       apply (case_tac info, simp)
      apply (wp hoare_vcg_all_lift get_rs_cte_at static_imp_wp
@@ -1273,7 +1273,7 @@ lemma getMessageInfo_msgExtraCaps[wp]:
    apply wpsimp+
   done
 
-lemma lcs_corres:
+lemma lookupCapAndSlot_corres:
   "cptr = to_bl cptr' \<Longrightarrow>
   corres (lfr \<oplus> (\<lambda>a b. cap_relation (fst a) (fst b) \<and> snd b = cte_map (snd a)))
     (valid_objs and pspace_aligned and tcb_at thread)
@@ -1288,12 +1288,12 @@ lemma lcs_corres:
           apply (rule corres_returnOkTT, simp)
          apply simp
         apply wp+
-      apply (rule corres_rel_imp, rule lookup_slot_corres)
+      apply (rule corres_rel_imp, rule lookupSlotForThread_corres)
       apply (simp add: split_def)
      apply (wp | simp add: liftE_bindE[symmetric])+
   done
 
-lemma lec_corres:
+lemma lookupExtraCaps_corres:
   "\<lbrakk> info' = message_info_map info; buffer = buffer'\<rbrakk> \<Longrightarrow>
   corres (fr \<oplus> list_all2 (\<lambda>x y. cap_relation (fst x) (fst y) \<and> snd y = cte_map (snd x)))
    (valid_objs and pspace_aligned and tcb_at thread and (\<lambda>_. valid_message_info info))
@@ -1334,7 +1334,7 @@ lemma lec_corres:
            apply simp
           apply simp
           apply (rule corres_guard_imp)
-            apply (rule load_word_offs_corres')
+            apply (rule loadWordUser_corres')
              apply (clarsimp simp: buffer_cptr_index_def msg_max_length_def
                                    max_ipc_words valid_message_info_def
                                    msg_max_extra_caps_def word_le_nat_alt)
@@ -1350,7 +1350,7 @@ lemma lec_corres:
             apply simp
            apply simp
           apply simp
-          apply (rule corres_cap_fault [OF lcs_corres])
+          apply (rule corres_cap_fault [OF lookupCapAndSlot_corres])
           apply simp
          apply simp
          apply (wp | simp)+
@@ -1365,7 +1365,7 @@ lemma copyMRs_valid_mdb[wp]:
   "\<lbrace>valid_mdb'\<rbrace> copyMRs t buf t' buf' n \<lbrace>\<lambda>rv. valid_mdb'\<rbrace>"
   by (simp add: valid_mdb'_def copyMRs_ctes_of)
 
-lemma do_normal_transfer_corres:
+lemma doNormalTransfer_corres:
   "corres dc
   (tcb_at sender and tcb_at receiver and (pspace_aligned:: det_state \<Rightarrow> bool)
    and valid_objs and cur_tcb and valid_mdb and valid_list and pspace_distinct
@@ -1383,7 +1383,7 @@ lemma do_normal_transfer_corres:
   apply (simp add: do_normal_transfer_def doNormalTransfer_def)
   apply (rule corres_guard_imp)
 
-    apply (rule corres_split_mapr [OF _ get_mi_corres])
+    apply (rule corres_split_mapr [OF _ getMessageInfo_corres])
       apply (rule_tac F="valid_message_info mi" in corres_gen_asm)
       apply (rule_tac r'="list_all2 (\<lambda>x y. cap_relation (fst x) (fst y) \<and> snd y = cte_map (snd x))"
                   in corres_split_deprecated)
@@ -1391,19 +1391,19 @@ lemma do_normal_transfer_corres:
          apply (rule corres_if[OF refl])
           apply (rule corres_split_catch)
              apply (rule corres_trivial, simp)
-            apply (rule lec_corres, simp+)
+            apply (rule lookupExtraCaps_corres, simp+)
            apply wp+
          apply (rule corres_trivial, simp)
         apply simp
-        apply (rule corres_split_eqr [OF _ copy_mrs_corres])
-          apply (rule corres_split_deprecated [OF _ tc_corres])
+        apply (rule corres_split_eqr [OF _ copyMRs_corres])
+          apply (rule corres_split_deprecated [OF _ transferCaps_corres])
               apply (rename_tac mi' mi'')
               apply (rule_tac F="mi_label mi' = mi_label mi"
                         in corres_gen_asm)
-              apply (rule corres_split_nor [OF _ set_mi_corres])
+              apply (rule corres_split_nor [OF _ setMessageInfo_corres])
                  apply (simp add: badge_register_def badgeRegister_def)
                  apply (fold dc_def)
-                 apply (rule user_setreg_corres)
+                 apply (rule asUser_setRegister_corres)
                 apply (case_tac mi', clarsimp)
                apply wp
              apply simp+
@@ -1423,11 +1423,11 @@ lemma corres_liftE_lift:
   by simp
 
 lemmas corres_ipc_thread_helper =
-  corres_split_eqrE [OF _  corres_liftE_lift [OF gct_corres]]
+  corres_split_eqrE [OF _  corres_liftE_lift [OF getCurThread_corres]]
 
 lemmas corres_ipc_info_helper =
   corres_split_maprE [where f = message_info_map, OF _
-                                corres_liftE_lift [OF get_mi_corres]]
+                                corres_liftE_lift [OF getMessageInfo_corres]]
 
 crunch typ_at'[wp]: doNormalTransfer "\<lambda>s. P (typ_at' T p s)"
 
@@ -1472,55 +1472,55 @@ lemma msgFromLookupFailure_map[simp]:
      = msg_from_lookup_failure lf"
   by (cases lf, simp_all add: lookup_failure_map_def msgFromLookupFailure_def)
 
-lemma getRestartPCs_corres:
+lemma asUser_getRestartPC_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
                  (as_user t getRestartPC) (asUser t getRestartPC)"
-  apply (rule corres_as_user')
+  apply (rule asUser_corres')
   apply (rule corres_Id, simp, simp)
   apply (rule no_fail_getRestartPC)
   done
 
-lemma user_mapM_getRegister_corres:
+lemma asUser_mapM_getRegister_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
      (as_user t (mapM getRegister regs))
      (asUser t (mapM getRegister regs))"
-  apply (rule corres_as_user')
+  apply (rule asUser_corres')
   apply (rule corres_Id [OF refl refl])
   apply (rule no_fail_mapM)
   apply (simp add: getRegister_def)
   done
 
-lemma make_arch_fault_msg_corres:
+lemma makeArchFaultMessage_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
   (make_arch_fault_msg f t)
   (makeArchFaultMessage (arch_fault_map f) t)"
   apply (cases f, clarsimp simp: makeArchFaultMessage_def split: arch_fault.split)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr[OF _ getRestartPCs_corres])
+    apply (rule corres_split_eqr[OF _ asUser_getRestartPC_corres])
       apply (rule corres_trivial, simp add: arch_fault_map_def)
      apply (wp+, auto)
   done
 
-lemma mk_ft_msg_corres:
+lemma makeFaultMessage_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
      (make_fault_msg ft t)
      (makeFaultMessage (fault_map ft) t)"
   apply (cases ft, simp_all add: makeFaultMessage_def split del: if_split)
      apply (rule corres_guard_imp)
-       apply (rule corres_split_eqr [OF _ getRestartPCs_corres])
+       apply (rule corres_split_eqr [OF _ asUser_getRestartPC_corres])
          apply (rule corres_trivial, simp add: fromEnum_def enum_bool)
         apply (wp | simp)+
     apply (simp add: ARM_H.syscallMessage_def)
     apply (rule corres_guard_imp)
-      apply (rule corres_split_eqr [OF _ user_mapM_getRegister_corres])
+      apply (rule corres_split_eqr [OF _ asUser_mapM_getRegister_corres])
         apply (rule corres_trivial, simp)
        apply (wp | simp)+
    apply (simp add: ARM_H.exceptionMessage_def)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_eqr [OF _ user_mapM_getRegister_corres])
+     apply (rule corres_split_eqr [OF _ asUser_mapM_getRegister_corres])
        apply (rule corres_trivial, simp)
       apply (wp | simp)+
-  apply (rule make_arch_fault_msg_corres)
+  apply (rule makeArchFaultMessage_corres)
   done
 
 lemma makeFaultMessage_inv[wp]:
@@ -1533,11 +1533,11 @@ lemma makeFaultMessage_inv[wp]:
   done
 
 lemmas threadget_fault_corres =
-          threadget_corres [where r = fault_rel_optionation
+          threadGet_corres [where r = fault_rel_optionation
                               and f = tcb_fault and f' = tcbFault,
                             simplified tcb_relation_def, simplified]
 
-lemma do_fault_transfer_corres:
+lemma doFaultTransfer_corres:
   "corres dc
     (obj_at (\<lambda>ko. \<exists>tcb ft. ko = TCB tcb \<and> tcb_fault tcb = Some ft) sender
      and tcb_at receiver and case_option \<top> in_user_frame recv_buf)
@@ -1569,17 +1569,17 @@ lemma do_fault_transfer_corres:
     apply (clarsimp simp: obj_at_def is_tcb)
    apply wp
    apply (rule corres_guard_imp)
-      apply (rule corres_split_eqr [OF _ mk_ft_msg_corres])
-        apply (rule corres_split_eqr [OF _ set_mrs_corres [OF refl]])
-          apply (rule corres_split_nor [OF _ set_mi_corres])
-             apply (rule user_setreg_corres)
+      apply (rule corres_split_eqr [OF _ makeFaultMessage_corres])
+        apply (rule corres_split_eqr [OF _ setMRs_corres [OF refl]])
+          apply (rule corres_split_nor [OF _ setMessageInfo_corres])
+             apply (rule asUser_setRegister_corres)
             apply simp
            apply (wp | simp)+
    apply (rule corres_guard_imp)
-      apply (rule corres_split_eqr [OF _ mk_ft_msg_corres])
-        apply (rule corres_split_eqr [OF _ set_mrs_corres [OF refl]])
-          apply (rule corres_split_nor [OF _ set_mi_corres])
-             apply (rule user_setreg_corres)
+      apply (rule corres_split_eqr [OF _ makeFaultMessage_corres])
+        apply (rule corres_split_eqr [OF _ setMRs_corres [OF refl]])
+          apply (rule corres_split_nor [OF _ setMessageInfo_corres])
+             apply (rule asUser_setRegister_corres)
             apply simp
            apply (wp | simp)+
   done
@@ -1631,7 +1631,7 @@ lemma lookupIPCBuffer_valid_ipc_buffer [wp]:
   apply (simp add: word_bits_conv)
   done
 
-lemma dit_corres:
+lemma doIPCTransfer_corres:
   "corres dc
      (tcb_at s and tcb_at r and valid_objs and pspace_aligned
         and valid_list
@@ -1651,7 +1651,7 @@ lemma dit_corres:
                                     \<comment> \<open>\<exists>ft. tcb_fault tcb = Some ft\<close>) s sa"
                in corres_split')
      apply (rule corres_guard_imp)
-       apply (rule lipcb_corres')
+       apply (rule lookupIPCBuffer_corres')
       apply auto[2]
     apply (rule corres_split' [OF _ _ thread_get_sp threadGet_inv])
      apply (rule corres_guard_imp)
@@ -1662,12 +1662,12 @@ lemma dit_corres:
        apply (subst case_option_If)+
        apply (rule corres_if2)
          apply (simp add: fault_rel_optionation_def)
-        apply (rule corres_split_eqr [OF _ lipcb_corres'])
+        apply (rule corres_split_eqr [OF _ lookupIPCBuffer_corres'])
           apply (simp add: dc_def[symmetric])
-          apply (rule do_normal_transfer_corres)
+          apply (rule doNormalTransfer_corres)
          apply (wp | simp add: valid_pspace'_def)+
        apply (simp add: dc_def[symmetric])
-       apply (rule do_fault_transfer_corres)
+       apply (rule doFaultTransfer_corres)
       apply (clarsimp simp: obj_at_def)
      apply (erule ignore_if)
     apply (wp|simp add: obj_at_def is_tcb valid_pspace'_def)+
@@ -1785,7 +1785,7 @@ lemma handle_fault_reply_registers_corres:
     apply (clarsimp simp: arch_get_sanitise_register_info_def getSanitiseRegisterInfo_def)
        apply (rule corres_split_deprecated)
        apply (rule corres_trivial, simp)
-      apply (rule corres_as_user')
+      apply (rule asUser_corres')
       apply(simp add: setRegister_def sanitise_register_def
                       sanitiseRegister_def syscallMessage_def)
       apply(subst zipWithM_x_modify)+
@@ -1793,7 +1793,7 @@ lemma handle_fault_reply_registers_corres:
        apply (simp|wp)+
   done
 
-lemma handle_fault_reply_corres:
+lemma handleFaultReply_corres:
   "ft' = fault_map ft \<Longrightarrow>
    corres (=) (tcb_at t) (tcb_at' t)
      (handle_fault_reply ft t label msg)
@@ -2041,7 +2041,7 @@ lemma cte_wp_at_is_reply_cap_toI:
    \<Longrightarrow> cte_wp_at (is_reply_cap_to t) ptr s"
   by (fastforce simp: cte_wp_at_reply_cap_to_ex_rights)
 
-lemma do_reply_transfer_corres:
+lemma doReplyTransfer_corres:
   "corres dc
      (einvs and tcb_at receiver and tcb_at sender
            and cte_wp_at ((=) (cap.ReplyCap receiver False rights)) slot)
@@ -2052,7 +2052,7 @@ lemma do_reply_transfer_corres:
   apply (simp add: do_reply_transfer_def doReplyTransfer_def cong: option.case_cong)
   apply (rule corres_split' [OF _ _ gts_sp gts_sp'])
    apply (rule corres_guard_imp)
-     apply (rule gts_corres, (clarsimp simp add: st_tcb_at_tcb_at)+)
+     apply (rule getThreadState_corres, (clarsimp simp add: st_tcb_at_tcb_at)+)
   apply (rule_tac F = "awaiting_reply state" in corres_req)
    apply (clarsimp simp add: st_tcb_at_def obj_at_def is_tcb)
    apply (fastforce simp: invs_def valid_state_def intro: has_reply_cap_cte_wpD
@@ -2081,9 +2081,9 @@ lemma do_reply_transfer_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ threadget_fault_corres])
       apply (case_tac rv, simp_all add: fault_rel_optionation_def bind_assoc)[1]
-       apply (rule corres_split_deprecated [OF _ dit_corres])
+       apply (rule corres_split_deprecated [OF _ doIPCTransfer_corres])
          apply (rule corres_split_deprecated [OF _ cap_delete_one_corres])
-           apply (rule corres_split_deprecated [OF _ sts_corres])
+           apply (rule corres_split_deprecated [OF _ setThreadState_corres])
               apply (rule possibleSwitchTo_corres)
              apply simp
             apply (wp set_thread_state_runnable_valid_sched set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at' sts_st_tcb' sts_valid_queues sts_valid_objs' delete_one_tcbDomain_obj_at'
@@ -2115,11 +2115,11 @@ lemma do_reply_transfer_corres:
 
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ cap_delete_one_corres])
-      apply (rule corres_split_mapr [OF _ get_mi_corres])
-        apply (rule corres_split_eqr [OF _ lipcb_corres'])
-          apply (rule corres_split_eqr [OF _ get_mrs_corres])
+      apply (rule corres_split_mapr [OF _ getMessageInfo_corres])
+        apply (rule corres_split_eqr [OF _ lookupIPCBuffer_corres'])
+          apply (rule corres_split_eqr [OF _ getMRs_corres])
             apply (simp(no_asm) del: dc_simp)
-            apply (rule corres_split_eqr [OF _ handle_fault_reply_corres])
+            apply (rule corres_split_eqr [OF _ handleFaultReply_corres])
                apply (rule corres_split_deprecated [OF _ threadset_corresT])
                      apply (rule_tac Q="valid_sched and cur_tcb and tcb_at receiver"
                                  and Q'="tcb_at' receiver and cur_tcb'
@@ -2128,13 +2128,13 @@ lemma do_reply_transfer_corres:
                                    in corres_guard_imp)
                        apply (case_tac rvb, simp_all)[1]
                         apply (rule corres_guard_imp)
-                          apply (rule corres_split_deprecated [OF _ sts_corres])
+                          apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                       apply (fold dc_def, rule possibleSwitchTo_corres)
                                apply simp
                               apply (wp static_imp_wp static_imp_conj_wp set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at'
                                         sts_st_tcb' sts_valid_queues | simp | force simp: valid_sched_def valid_sched_action_def valid_tcb_state'_def)+
                        apply (rule corres_guard_imp)
-                      apply (rule sts_corres)
+                      apply (rule setThreadState_corres)
                       apply (simp_all)[20]
                    apply (clarsimp simp add: tcb_relation_def fault_rel_optionation_def
                                              tcb_cap_cases_def tcb_cte_cases_def exst_same_def)+
@@ -2168,7 +2168,7 @@ lemma do_reply_transfer_corres:
 
 (* when we cannot talk about reply cap rights explicitly (for instance, when a schematic ?rights
    would be generated too early *)
-lemma do_reply_transfer_corres':
+lemma doReplyTransfer_corres':
   "corres dc
      (einvs and tcb_at receiver and tcb_at sender
            and cte_wp_at (is_reply_cap_to receiver) slot)
@@ -2176,7 +2176,7 @@ lemma do_reply_transfer_corres':
             and valid_pspace' and cte_at' (cte_map slot))
      (do_reply_transfer sender receiver slot grant)
      (doReplyTransfer sender receiver (cte_map slot) grant)"
-  using do_reply_transfer_corres[of receiver sender _ slot]
+  using doReplyTransfer_corres[of receiver sender _ slot]
   by (fastforce simp add: cte_wp_at_reply_cap_to_ex_rights corres_underlying_def)
 
 lemma valid_pspace'_splits[elim!]:
@@ -2202,7 +2202,7 @@ lemma sts_valid_pspace_hangers:
 
 declare no_fail_getSlotCap [wp]
 
-lemma setup_caller_corres:
+lemma setupCallerCap_corres:
   "corres dc
      (st_tcb_at (Not \<circ> halted) sender and tcb_at receiver and
       st_tcb_at (Not \<circ> awaiting_reply) sender and valid_reply_caps and
@@ -2226,7 +2226,7 @@ lemma setup_caller_corres:
           apply (rule corres_symb_exec_r)
              apply (rule_tac F="rv = capability.NullCap"
                           in corres_gen_asm2, simp)
-             apply (rule cins_corres)
+             apply (rule cteInsert_corres)
                apply (simp split: if_splits)
               apply (simp add: cte_map_def tcbReplySlot_def
                                tcb_cnode_index_def cte_level_bits_def)
@@ -2245,7 +2245,7 @@ lemma setup_caller_corres:
         apply blast
        apply (rule no_fail_pre, wp)
        apply (clarsimp simp: cte_wp_at_ctes_of)
-      apply (rule sts_corres)
+      apply (rule setThreadState_corres)
       apply (simp split: option.split)
      apply (wp sts_valid_pspace_hangers
                  | simp add: cte_wp_at_ctes_of)+
@@ -2331,7 +2331,7 @@ crunches possibleSwitchTo
   and valid_pspace'[wp]: valid_pspace'
   (wp: crunch_wps)
 
-lemma send_ipc_corres:
+lemma sendIPC_corres:
 (* call is only true if called in handleSyscall SysCall, which
    is always blocking. *)
   assumes "call \<longrightarrow> bl"
@@ -2346,7 +2346,7 @@ proof -
   apply (case_tac bl)
    apply clarsimp
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated [OF _ get_ep_corres,
+     apply (rule corres_split_deprecated [OF _ getEndpoint_corres,
               where
               R="\<lambda>rv. einvs and st_tcb_at active t and ep_at ep and
                       valid_ep rv and obj_at (\<lambda>ob. ob = Endpoint rv) ep
@@ -2357,8 +2357,8 @@ proof -
        apply (case_tac rv)
          apply (simp add: ep_relation_def)
          apply (rule corres_guard_imp)
-           apply (rule corres_split_deprecated [OF _ sts_corres])
-              apply (rule set_ep_corres)
+           apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+              apply (rule setEndpoint_corres)
               apply (simp add: ep_relation_def)
              apply (simp add: fault_rel_optionation_def)
             apply wp+
@@ -2367,8 +2367,8 @@ proof -
          \<comment> \<open>concludes IdleEP if bl branch\<close>
         apply (simp add: ep_relation_def)
         apply (rule corres_guard_imp)
-          apply (rule corres_split_deprecated [OF _ sts_corres])
-             apply (rule set_ep_corres)
+          apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+             apply (rule setEndpoint_corres)
              apply (simp add: ep_relation_def)
             apply (simp add: fault_rel_optionation_def)
            apply wp+
@@ -2383,16 +2383,16 @@ proof -
         apply simp
        apply (clarsimp split del: if_split)
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
             apply (simp add: isReceive_def split del:if_split)
-            apply (rule corres_split_deprecated [OF _ gts_corres])
+            apply (rule corres_split_deprecated [OF _ getThreadState_corres])
               apply (rule_tac
                      F="\<exists>data. recv_state = Structures_A.BlockedOnReceive ep data"
                      in corres_gen_asm)
               apply (clarsimp simp: case_bool_If  case_option_If if3_fold
                           simp del: dc_simp split del: if_split cong: if_cong)
-              apply (rule corres_split_deprecated [OF _ dit_corres])
-                apply (rule corres_split_deprecated [OF _ sts_corres])
+              apply (rule corres_split_deprecated [OF _ doIPCTransfer_corres])
+                apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                    apply (rule corres_split_deprecated [OF _ possibleSwitchTo_corres])
                        apply (fold when_def)[1]
 
@@ -2400,8 +2400,8 @@ proof -
                                 in corres_symmetric_bool_cases, blast)
                         apply (simp add: when_def dc_def[symmetric] split del: if_split)
                         apply (rule corres_if2, simp)
-                         apply (rule setup_caller_corres)
-                        apply (rule sts_corres, simp)
+                         apply (rule setupCallerCap_corres)
+                        apply (rule setThreadState_corres, simp)
                        apply (rule corres_trivial)
                        apply (simp add: when_def dc_def[symmetric] split del: if_split)
                       apply (simp split del: if_split add: if_apply_def2)
@@ -2437,7 +2437,7 @@ proof -
       apply wp+
     apply (clarsimp simp: ep_at_def2)+
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres,
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres,
              where
              R="\<lambda>rv. einvs and st_tcb_at active t and ep_at ep and
                      valid_ep rv and obj_at (\<lambda>k. k = Endpoint rv) ep"
@@ -2464,15 +2464,15 @@ proof -
        apply fastforce
       apply (clarsimp split del: if_split)
       apply (rule corres_guard_imp)
-        apply (rule corres_split_deprecated [OF _ set_ep_corres])
-           apply (rule corres_split_deprecated [OF _ gts_corres])
+        apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+           apply (rule corres_split_deprecated [OF _ getThreadState_corres])
              apply (rule_tac
                 F="\<exists>data. recv_state = Structures_A.BlockedOnReceive ep data"
                     in corres_gen_asm)
              apply (clarsimp simp: isReceive_def case_bool_If
                         split del: if_split cong: if_cong)
-             apply (rule corres_split_deprecated [OF _ dit_corres])
-               apply (rule corres_split_deprecated [OF _ sts_corres])
+             apply (rule corres_split_deprecated [OF _ doIPCTransfer_corres])
+               apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                    apply (rule possibleSwitchTo_corres)
                   apply (simp add: if_apply_def2)
                   apply (wp hoare_drop_imps)
@@ -2529,12 +2529,12 @@ lemma valid_sched_weak_strg:
 crunch weak_valid_sched_action[wp]: as_user weak_valid_sched_action
   (wp: weak_valid_sched_action_lift)
 
-lemma send_signal_corres:
+lemma sendSignal_corres:
   "corres dc (einvs and ntfn_at ep) (invs' and ntfn_at' ep)
              (send_signal ep bg) (sendSignal ep bg)"
   apply (simp add: send_signal_def sendSignal_def Let_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ntfn_corres,
+    apply (rule corres_split_deprecated [OF _ getNotification_corres,
                 where
                 R  = "\<lambda>rv. einvs and ntfn_at ep and valid_ntfn rv and
                            ko_at (Structures_A.Notification rv) ep" and
@@ -2548,19 +2548,19 @@ lemma send_signal_corres:
     apply (clarsimp simp add: ntfn_relation_def)
     apply (case_tac "ntfnBoundTCB nTFN")
      apply clarsimp
-     apply (rule corres_guard_imp[OF set_ntfn_corres])
+     apply (rule corres_guard_imp[OF setNotification_corres])
        apply (clarsimp simp add: ntfn_relation_def)+
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated[OF _ gts_corres])
+      apply (rule corres_split_deprecated[OF _ getThreadState_corres])
         apply (rule corres_if)
           apply (fastforce simp: receive_blocked_def receiveBlocked_def
                                  thread_state_relation_def
                           split: Structures_A.thread_state.splits
                                  Structures_H.thread_state.splits)
          apply (rule corres_split_deprecated[OF _ cancel_ipc_corres])
-           apply (rule corres_split_deprecated[OF _ sts_corres])
+           apply (rule corres_split_deprecated[OF _ setThreadState_corres])
               apply (simp add: badgeRegister_def badge_register_def)
-              apply (rule corres_split_deprecated[OF _ user_setreg_corres])
+              apply (rule corres_split_deprecated[OF _ asUser_setRegister_corres])
                 apply (rule possibleSwitchTo_corres)
                apply wp
              apply (clarsimp simp: thread_state_relation_def)
@@ -2573,7 +2573,7 @@ lemma send_signal_corres:
           apply wp
          apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak
                                valid_tcb_state'_def)
-        apply (rule set_ntfn_corres)
+        apply (rule setNotification_corres)
         apply (clarsimp simp add: ntfn_relation_def)
        apply (wp gts_wp gts_wp' | clarsimp)+
      apply (auto simp: valid_ntfn_def receive_blocked_def valid_sched_def invs_cur
@@ -2590,10 +2590,10 @@ lemma send_signal_corres:
     apply (rule corres_guard_imp)
       apply (rule_tac F="list \<noteq> []" in corres_gen_asm)
       apply (simp add: list_case_helper split del: if_split)
-      apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-         apply (rule corres_split_deprecated [OF _ sts_corres])
+      apply (rule corres_split_deprecated [OF _ setNotification_corres])
+         apply (rule corres_split_deprecated [OF _ setThreadState_corres])
             apply (simp add: badgeRegister_def badge_register_def)
-            apply (rule corres_split_deprecated [OF _ user_setreg_corres])
+            apply (rule corres_split_deprecated [OF _ asUser_setRegister_corres])
               apply (rule possibleSwitchTo_corres)
              apply ((wp | simp)+)[1]
             apply (rule_tac Q="\<lambda>_. Invariants_H.valid_queues and valid_queues' and
@@ -2621,10 +2621,10 @@ lemma send_signal_corres:
    apply (rule corres_guard_imp)
      apply (rule_tac F="list \<noteq> []" in corres_gen_asm)
      apply (simp add: list_case_helper)
-     apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-        apply (rule corres_split_deprecated [OF _ sts_corres])
+     apply (rule corres_split_deprecated [OF _ setNotification_corres])
+        apply (rule corres_split_deprecated [OF _ setThreadState_corres])
            apply (simp add: badgeRegister_def badge_register_def)
-           apply (rule corres_split_deprecated [OF _ user_setreg_corres])
+           apply (rule corres_split_deprecated [OF _ asUser_setRegister_corres])
              apply (rule possibleSwitchTo_corres)
             apply (wp cur_tcb_lift | simp)+
          apply (wp sts_st_tcb_at' set_thread_state_runnable_weak_valid_sched_action
@@ -2646,7 +2646,7 @@ lemma send_signal_corres:
   \<comment> \<open>ActiveNtfn\<close>
   apply (clarsimp simp add: ntfn_relation_def)
   apply (rule corres_guard_imp)
-    apply (rule set_ntfn_corres)
+    apply (rule setNotification_corres)
     apply (simp add: ntfn_relation_def combine_ntfn_badges_def
                      combine_ntfn_msgs_def)
    apply (simp add: invs_def valid_state_def valid_ntfn_def)
@@ -3035,17 +3035,17 @@ lemma sai_invs'[wp]:
                    split: thread_state.splits
                    dest!: global'_no_ex_cap st_tcb_ex_cap'' ko_at_valid_objs')+
 
-lemma rfk_corres:
+lemma replyFromKernel_corres:
   "corres dc (tcb_at t and invs) (tcb_at' t and invs')
              (reply_from_kernel t r) (replyFromKernel t r)"
   apply (case_tac r)
   apply (clarsimp simp: replyFromKernel_def reply_from_kernel_def
                         badge_register_def badgeRegister_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ lipcb_corres])
-      apply (rule corres_split_deprecated [OF _ user_setreg_corres])
-        apply (rule corres_split_eqr [OF _ set_mrs_corres])
-           apply (rule set_mi_corres)
+    apply (rule corres_split_eqr [OF _ lookupIPCBuffer_corres])
+      apply (rule corres_split_deprecated [OF _ asUser_setRegister_corres])
+        apply (rule corres_split_eqr [OF _ setMRs_corres])
+           apply (rule setMessageInfo_corres)
            apply (wp hoare_case_option_wp hoare_valid_ipc_buffer_ptr_typ_at'
                   | clarsimp)+
   done
@@ -3059,7 +3059,7 @@ lemma rfk_invs':
 
 crunch nosch[wp]: replyFromKernel "\<lambda>s. P (ksSchedulerAction s)"
 
-lemma complete_signal_corres:
+lemma completeSignal_corres:
   "corres dc (ntfn_at ntfnptr and tcb_at tcb and pspace_aligned and valid_objs
              \<comment> \<open>and obj_at (\<lambda>ko. ko = Notification ntfn \<and> Ipc_A.isActive ntfn) ntfnptr*\<close> )
              (ntfn_at' ntfnptr and tcb_at' tcb and valid_pspace' and obj_at' isActive ntfnptr)
@@ -3068,14 +3068,14 @@ lemma complete_signal_corres:
   apply (rule corres_guard_imp)
     apply (rule_tac R'="\<lambda>ntfn. ntfn_at' ntfnptr and tcb_at' tcb and valid_pspace'
                          and valid_ntfn' ntfn and (\<lambda>_. isActive ntfn)"
-                                in corres_split_deprecated [OF _ get_ntfn_corres])
+                                in corres_split_deprecated [OF _ getNotification_corres])
       apply (rule corres_gen_asm2)
       apply (case_tac "ntfn_obj rv")
         apply (clarsimp simp: ntfn_relation_def isActive_def
                        split: ntfn.splits Structures_H.notification.splits)+
       apply (rule corres_guard2_imp)
        apply (simp add: badgeRegister_def badge_register_def)
-       apply (rule corres_split_deprecated[OF set_ntfn_corres user_setreg_corres])
+       apply (rule corres_split_deprecated[OF setNotification_corres asUser_setRegister_corres])
          apply (clarsimp simp: ntfn_relation_def)
         apply (wp set_simple_ko_valid_objs get_simple_ko_wp getNotification_wp | clarsimp simp: valid_ntfn'_def)+
   apply (clarsimp simp: valid_pspace'_def)
@@ -3084,15 +3084,15 @@ lemma complete_signal_corres:
   done
 
 
-lemma do_nbrecv_failed_transfer_corres:
+lemma doNBRecvFailedTransfer_corres:
   "corres dc (tcb_at thread)
             (tcb_at' thread)
             (do_nbrecv_failed_transfer thread)
             (doNBRecvFailedTransfer thread)"
   unfolding do_nbrecv_failed_transfer_def doNBRecvFailedTransfer_def
-  by (simp add: badgeRegister_def badge_register_def, rule user_setreg_corres)
+  by (simp add: badgeRegister_def badge_register_def, rule asUser_setRegister_corres)
 
-lemma receive_ipc_corres:
+lemma receiveIPC_corres:
   assumes "is_ep_cap cap" and "cap_relation cap cap'"
   shows "
    corres dc (einvs and valid_sched and tcb_at thread and valid_cap cap and ex_nonz_cap_to thread
@@ -3106,15 +3106,15 @@ lemma receive_ipc_corres:
   apply (rename_tac word1 word2 right)
   apply clarsimp
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres])
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres])
       apply (rule corres_guard_imp)
-        apply (rule corres_split_deprecated [OF _ gbn_corres])
+        apply (rule corres_split_deprecated [OF _ getBoundNotification_corres])
           apply (rule_tac r'="ntfn_relation" in corres_split_deprecated)
              apply (rule corres_if)
                apply (clarsimp simp: ntfn_relation_def Ipc_A.isActive_def Endpoint_H.isActive_def
                               split: Structures_A.ntfn.splits Structures_H.notification.splits)
               apply clarsimp
-              apply (rule complete_signal_corres)
+              apply (rule completeSignal_corres)
              apply (rule_tac P="einvs and valid_sched and tcb_at thread and
                                        ep_at word1 and valid_ep ep and
                                        obj_at (\<lambda>k. k = Endpoint ep) word1
@@ -3128,12 +3128,12 @@ lemma receive_ipc_corres:
                apply (simp add: ep_relation_def)
                apply (rule corres_guard_imp)
                  apply (case_tac isBlocking; simp)
-                  apply (rule corres_split_deprecated [OF _ sts_corres])
-                     apply (rule set_ep_corres)
+                  apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+                     apply (rule setEndpoint_corres)
                      apply (simp add: ep_relation_def)
                     apply simp
                    apply wp+
-                 apply (rule corres_guard_imp, rule do_nbrecv_failed_transfer_corres, simp)
+                 apply (rule corres_guard_imp, rule doNBRecvFailedTransfer_corres, simp)
                  apply simp
                 apply (clarsimp simp add: invs_def valid_state_def valid_pspace_def
                valid_tcb_state_def st_tcb_at_tcb_at)
@@ -3145,8 +3145,8 @@ lemma receive_ipc_corres:
         apply (clarsimp simp: valid_ep_def)
        apply (case_tac list, simp_all split del: if_split)[1]
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
-            apply (rule corres_split_deprecated [OF _ gts_corres])
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+            apply (rule corres_split_deprecated [OF _ getThreadState_corres])
               apply (rule_tac
                        F="\<exists>data.
                            sender_state =
@@ -3155,7 +3155,7 @@ lemma receive_ipc_corres:
               apply (clarsimp simp: isSend_def case_bool_If
                                     case_option_If if3_fold
                          split del: if_split cong: if_cong)
-              apply (rule corres_split_deprecated [OF _ dit_corres])
+              apply (rule corres_split_deprecated [OF _ doIPCTransfer_corres])
                 apply (simp split del: if_split cong: if_cong)
                 apply (fold dc_def)[1]
                 apply (rule_tac P="valid_objs and valid_mdb and valid_list
@@ -3176,10 +3176,10 @@ lemma receive_ipc_corres:
                                         and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)"
                              in corres_guard_imp [OF corres_if])
                     apply (simp add: fault_rel_optionation_def)
-                   apply (rule corres_if2 [OF _ setup_caller_corres sts_corres])
+                   apply (rule corres_if2 [OF _ setupCallerCap_corres setThreadState_corres])
                            apply simp
                           apply simp
-                         apply (rule corres_split_deprecated [OF _ sts_corres])
+                         apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                             apply (rule possibleSwitchTo_corres)
                            apply simp
                           apply (wp sts_st_tcb_at' set_thread_state_runnable_weak_valid_sched_action
@@ -3209,17 +3209,17 @@ lemma receive_ipc_corres:
              apply (simp add: ep_relation_def)
              apply (rule_tac corres_guard_imp)
                apply (case_tac isBlocking; simp)
-                apply (rule corres_split_deprecated [OF _ sts_corres])
-                   apply (rule set_ep_corres)
+                apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+                   apply (rule setEndpoint_corres)
                    apply (simp add: ep_relation_def)
                   apply simp
                  apply wp+
-               apply (rule corres_guard_imp, rule do_nbrecv_failed_transfer_corres, simp)
+               apply (rule corres_guard_imp, rule doNBRecvFailedTransfer_corres, simp)
                apply simp
               apply (clarsimp simp: valid_tcb_state_def)
              apply (clarsimp simp add: valid_tcb_state'_def)
             apply (rule corres_option_split[rotated 2])
-              apply (rule get_ntfn_corres)
+              apply (rule getNotification_corres)
              apply clarsimp
             apply (rule corres_trivial, simp add: ntfn_relation_def default_notification_def
                                                   default_ntfn_def)
@@ -3237,7 +3237,7 @@ lemma receive_ipc_corres:
              split: option.splits)
   done
 
-lemma receive_signal_corres:
+lemma receiveSignal_corres:
  "\<lbrakk> is_ntfn_cap cap; cap_relation cap cap' \<rbrakk> \<Longrightarrow>
   corres dc (invs and st_tcb_at active thread and valid_cap cap and ex_nonz_cap_to thread)
             (invs' and tcb_at' thread and valid_cap' cap')
@@ -3252,36 +3252,36 @@ lemma receive_signal_corres:
                             obj_at (\<lambda>k. k = Notification rv) word1" and
                             R'="\<lambda>rv'. invs' and tcb_at' thread and ntfn_at' word1 and
                             valid_ntfn' rv'"
-                         in corres_split_deprecated [OF _ get_ntfn_corres])
+                         in corres_split_deprecated [OF _ getNotification_corres])
       apply clarsimp
       apply (case_tac "ntfn_obj rv")
         \<comment> \<open>IdleNtfn\<close>
         apply (simp add: ntfn_relation_def)
         apply (rule corres_guard_imp)
           apply (case_tac isBlocking; simp)
-           apply (rule corres_split_deprecated [OF _ sts_corres])
-              apply (rule set_ntfn_corres)
+           apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+              apply (rule setNotification_corres)
               apply (simp add: ntfn_relation_def)
              apply simp
             apply wp+
-          apply (rule corres_guard_imp, rule do_nbrecv_failed_transfer_corres, simp+)
+          apply (rule corres_guard_imp, rule doNBRecvFailedTransfer_corres, simp+)
        \<comment> \<open>WaitingNtfn\<close>
        apply (simp add: ntfn_relation_def)
        apply (rule corres_guard_imp)
          apply (case_tac isBlocking; simp)
-          apply (rule corres_split_deprecated[OF _ sts_corres])
-             apply (rule set_ntfn_corres)
+          apply (rule corres_split_deprecated[OF _ setThreadState_corres])
+             apply (rule setNotification_corres)
              apply (simp add: ntfn_relation_def)
             apply simp
            apply wp+
          apply (rule corres_guard_imp)
-           apply (rule do_nbrecv_failed_transfer_corres, simp+)
+           apply (rule doNBRecvFailedTransfer_corres, simp+)
       \<comment> \<open>ActiveNtfn\<close>
       apply (simp add: ntfn_relation_def)
       apply (rule corres_guard_imp)
         apply (simp add: badgeRegister_def badge_register_def)
-        apply (rule corres_split_deprecated [OF _ user_setreg_corres])
-          apply (rule set_ntfn_corres)
+        apply (rule corres_split_deprecated [OF _ asUser_setRegister_corres])
+          apply (rule setNotification_corres)
           apply (simp add: ntfn_relation_def)
          apply wp+
        apply (fastforce simp: invs_def valid_state_def valid_pspace_def
@@ -3306,7 +3306,7 @@ lemma tg_sp':
 
 declare lookup_cap_valid' [wp]
 
-lemma send_fault_ipc_corres:
+lemma sendFaultIPC_corres:
   "valid_fault f \<Longrightarrow> fr f f' \<Longrightarrow>
   corres (fr \<oplus> dc)
          (einvs and st_tcb_at active thread and ex_nonz_cap_to thread)
@@ -3333,7 +3333,7 @@ lemma send_fault_ipc_corres:
           apply (rule corres_guard_imp)
             apply (rule corres_if2 [OF refl])
              apply (simp add: dc_def[symmetric])
-             apply (rule corres_split_deprecated [OF send_ipc_corres threadset_corres], simp_all)[1]
+             apply (rule corres_split_deprecated [OF sendIPC_corres threadset_corres], simp_all)[1]
                apply (simp add: tcb_relation_def fault_rel_optionation_def exst_same_def)+
               apply (wp thread_set_invs_trivial thread_set_no_change_tcb_state
                         thread_set_typ_at ep_at_typ_at ex_nonz_cap_to_pres
@@ -3349,7 +3349,7 @@ lemma send_fault_ipc_corres:
           apply auto[1]
          apply (clarsimp simp: lookup_failure_map_def)
         apply wp+
-      apply (rule threadget_corres)
+      apply (rule threadGet_corres)
       apply (simp add: tcb_relation_def)
      apply wp+
    apply (fastforce elim: st_tcb_at_tcb_at)
@@ -3364,7 +3364,7 @@ lemma gets_the_noop_corres:
   apply (clarsimp simp: assert_opt_def return_def dest!: P)
   done
 
-lemma hdf_corres:
+lemma handleDoubleFault_corres:
   "corres dc (tcb_at thread)
              (tcb_at' thread and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s))
              (handle_double_fault thread f ft)
@@ -3372,7 +3372,7 @@ lemma hdf_corres:
   apply (simp add: handle_double_fault_def handleDoubleFault_def)
   apply (rule corres_guard_imp)
     apply (subst bind_return [symmetric],
-           rule corres_split' [OF sts_corres])
+           rule corres_split' [OF setThreadState_corres])
        apply simp
       apply (rule corres_noop2)
          apply (simp add: exs_valid_def return_def)
@@ -4126,7 +4126,7 @@ lemma sfi_invs_plus':
   apply (subst(asm) global'_no_ex_cap, auto)
   done
 
-lemma hf_corres:
+lemma handleFault_corres:
   "fr f f' \<Longrightarrow>
    corres dc (einvs and  st_tcb_at active thread and ex_nonz_cap_to thread
                    and (%_. valid_fault f))
@@ -4140,9 +4140,9 @@ lemma hf_corres:
                rule corres_split_deprecated [where P="tcb_at thread",
                                   OF _ gets_the_noop_corres [where x="()"]])
        apply (rule corres_split_catch)
-          apply (rule hdf_corres)
+          apply (rule handleDoubleFault_corres)
           apply (rule_tac F="valid_fault f" in corres_gen_asm)
-         apply (rule send_fault_ipc_corres, assumption)
+         apply (rule sendFaultIPC_corres, assumption)
          apply simp
         apply wp+
        apply (rule hoare_post_impErr, rule sfi_invs_plus', simp_all)[1]

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -785,7 +785,7 @@ lemma no_fail_getEndpoint [wp]:
    apply (clarsimp split: option.split_asm simp: objBits_simps' archObjSize_def)
   done
 
-lemma get_ep_corres [corres]:
+lemma getEndpoint_corres [corres]:
   "corres ep_relation (ep_at ptr) (ep_at' ptr)
      (get_endpoint ptr) (getEndpoint ptr)"
   apply (rule corres_no_failI)
@@ -890,7 +890,7 @@ where
   "exst_same' (KOTCB tcb) (KOTCB tcb') = exst_same tcb tcb'" |
   "exst_same' _ _ = True"
 
-lemma set_other_obj_corres:
+lemma setObject_other_corres:
   fixes ob' :: "'a :: pspace_storable"
   assumes x: "updateObject ob' = updateObject_default ob'"
   assumes z: "\<And>s. obj_at' P ptr s
@@ -967,21 +967,21 @@ lemmas obj_at_simps = obj_at_def obj_at'_def projectKOs map_to_ctes_upd_other
                       a_type_def objBits_simps other_obj_relation_def
                       archObjSize_def pageBits_def
 
-lemma set_ep_corres [corres]:
+lemma setEndpoint_corres [corres]:
   "ep_relation e e' \<Longrightarrow>
   corres dc (ep_at ptr) (ep_at' ptr)
             (set_endpoint ptr e) (setEndpoint ptr e')"
   apply (simp add: set_simple_ko_def setEndpoint_def is_ep_def[symmetric])
-    apply (corres_search search: set_other_obj_corres[where P="\<lambda>_. True"])
+    apply (corres_search search: setObject_other_corres[where P="\<lambda>_. True"])
   apply (corressimp wp: get_object_ret get_object_wp)+
   by (fastforce simp: is_ep obj_at_simps objBits_defs partial_inv_def)
 
-lemma set_ntfn_corres [corres]:
+lemma setNotification_corres [corres]:
   "ntfn_relation ae ae' \<Longrightarrow>
   corres dc (ntfn_at ptr) (ntfn_at' ptr)
             (set_notification ptr ae) (setNotification ptr ae')"
   apply (simp add: set_simple_ko_def setNotification_def is_ntfn_def[symmetric])
-       apply (corres_search search: set_other_obj_corres[where P="\<lambda>_. True"])
+       apply (corres_search search: setObject_other_corres[where P="\<lambda>_. True"])
   apply (corressimp wp: get_object_ret get_object_wp)+
   by (fastforce simp: is_ntfn obj_at_simps objBits_defs partial_inv_def)
 
@@ -1001,7 +1001,7 @@ lemma no_fail_getNotification [wp]:
    apply (clarsimp split: option.split_asm simp: objBits_simps' archObjSize_def)
   done
 
-lemma get_ntfn_corres:
+lemma getNotification_corres:
   "corres ntfn_relation (ntfn_at ptr) (ntfn_at' ptr)
      (get_notification ptr) (getNotification ptr)"
   apply (rule corres_no_failI)

--- a/proof/refine/ARM/Refine.thy
+++ b/proof/refine/ARM/Refine.thy
@@ -540,7 +540,7 @@ lemma kernel_corres':
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated)
        prefer 2
-       apply (rule corres_split_handle [OF _ he_corres])
+       apply (rule corres_split_handle [OF _ handleEvent_corres])
          apply simp
          apply (rule corres_split_deprecated [OF _ corres_machine_op])
             prefer 2
@@ -552,7 +552,7 @@ lemma kernel_corres':
             apply (simp add: when_def)
            apply (rule corres_when[simplified dc_def], simp)
            apply simp
-           apply (rule handle_interrupt_corres[simplified dc_def])
+           apply (rule handleInterrupt_corres[simplified dc_def])
           apply simp
           apply (wp hoare_drop_imps hoare_vcg_all_lift)[1]
          apply simp
@@ -567,7 +567,7 @@ lemma kernel_corres':
          apply wpsimp+
        apply (simp add: invs'_def valid_state'_def)
       apply (rule corres_split_deprecated [OF _ schedule_corres])
-        apply (rule activate_corres)
+        apply (rule activateThread_corres)
        apply (wp handle_interrupt_valid_sched[unfolded non_kernel_IRQs_def, simplified]
                  schedule_invs' hoare_vcg_if_lift2 hoare_drop_imps |simp)+
      apply (rule_tac Q="\<lambda>_. valid_sched and invs and valid_list" and
@@ -627,7 +627,7 @@ lemma entry_corres:
           (kernel_entry event tc) (kernelEntry event tc)"
   apply (simp add: kernel_entry_def kernelEntry_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gct_corres])
+    apply (rule corres_split_deprecated [OF _ getCurThread_corres])
       apply (rule corres_split_deprecated)
          prefer 2
          apply simp
@@ -638,8 +638,8 @@ lemma entry_corres:
           apply (clarsimp simp: tcb_cte_cases_def)
          apply (simp add: exst_same_def)
         apply (rule corres_split_deprecated [OF _ kernel_corres])
-          apply (rule corres_split_eqr [OF _ gct_corres])
-            apply (rule threadget_corres)
+          apply (rule corres_split_eqr [OF _ getCurThread_corres])
+            apply (rule threadGet_corres)
             apply (simp add: tcb_relation_def arch_tcb_relation_def
                              arch_tcb_context_get_def atcbContextGet_def)
            apply wp+
@@ -667,7 +667,7 @@ lemma do_user_op_corres:
           (do_user_op f tc) (doUserOp f tc)"
   apply (simp add: do_user_op_def doUserOp_def split_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply (rule_tac r'="(=)" and P=einvs and P'=invs' in corres_split_deprecated)
          prefer 2
          apply (fastforce dest: absKState_correct [rotated])
@@ -760,7 +760,7 @@ lemma check_active_irq_corres:
     apply (rule check_active_irq_corres', auto)
   done
 
-lemma check_active_irq_corres_just_running:
+lemma checkActiveIRQ_just_running_corres:
   "corres (=)
     (invs and ct_running and einvs and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and (\<lambda>s. 0 < domain_time s) and valid_domain_list)
@@ -772,7 +772,7 @@ lemma check_active_irq_corres_just_running:
     apply (rule check_active_irq_corres', auto)
   done
 
-lemma check_active_irq_corres_just_idle:
+lemma checkActiveIRQ_just_idle_corres:
   "corres (=)
     (invs and ct_idle and einvs and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and (\<lambda>s. 0 < domain_time s)  and valid_domain_list)
@@ -897,7 +897,7 @@ lemma ckernel_invariant:
    apply (drule use_valid)
      apply (rule hoare_vcg_conj_lift)
       apply (rule checkActiveIRQ_valid_duplicates')
-     apply (rule valid_corres_combined[OF check_active_irq_invs_just_running check_active_irq_corres_just_running])
+     apply (rule valid_corres_combined[OF check_active_irq_invs_just_running checkActiveIRQ_just_running_corres])
      apply (rule checkActiveIRQ_invs'_just_running[THEN hoare_weaken_pre])
      apply (fastforce simp: ex_abs_def)
     apply (fastforce simp: ex_abs_def ct_running_related sched_act_rct_related)
@@ -908,7 +908,7 @@ lemma ckernel_invariant:
    apply (drule use_valid)
      apply (rule hoare_vcg_conj_lift)
       apply (rule checkActiveIRQ_valid_duplicates')
-     apply (rule valid_corres_combined[OF check_active_irq_invs_just_idle check_active_irq_corres_just_idle])
+     apply (rule valid_corres_combined[OF check_active_irq_invs_just_idle checkActiveIRQ_just_idle_corres])
      apply (rule checkActiveIRQ_invs'_just_idle[THEN hoare_weaken_pre])
      apply clarsimp
      apply (fastforce simp: ex_abs_def)

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -2523,7 +2523,7 @@ lemma pde_relation_aligned_eq:
   apply auto
   done
 
-lemma copy_global_corres:
+lemma copyGlobalMappings_corres:
   "corres dc (valid_arch_state and valid_etcbs and pspace_aligned and page_directory_at pd)
              (valid_arch_state' and page_directory_at' pd)
           (copy_global_mappings pd)
@@ -2544,9 +2544,9 @@ lemma copy_global_corres:
                                               \<and> pde_at' (pd + (x << 2)) s"
                           in corres_mapM_list_all2, (simp add: pdeBits_def)+)
           apply (rule corres_guard_imp, rule corres_split_deprecated)
-               apply (erule store_pde_corres[OF _ refl])
+               apply (erule storePDE_corres[OF _ refl])
               apply (rule corres_rel_imp)
-               apply (rule_tac get_pde_corres[OF refl])
+               apply (rule_tac getObject_PDE_corres[OF refl])
               apply clarsimp
               apply (drule(1) pde_relation_aligned_eq)
               apply fastforce
@@ -5455,7 +5455,7 @@ lemma corres_retype_region_createNewCaps:
                           and Q'="\<lambda>xs s. (\<forall>x \<in> set xs. page_directory_at' x s) \<and> valid_arch_state' s"
                           in corres_mapM_list_all2[where r'=dc and S="(=)"])
                   apply simp+
-                apply (rule corres_guard_imp, rule copy_global_corres)
+                apply (rule corres_guard_imp, rule copyGlobalMappings_corres)
                  apply simp+
                apply (wp hoare_vcg_const_Ball_lift | simp)+
              apply (simp add: list_all2_same)

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -66,7 +66,7 @@ lemmas findM_awesome = findM_awesome' [OF _ _ _ suffix_order.order.refl]
 (* Levity: added (20090721 10:56:29) *)
 declare objBitsT_koTypeOf [simp]
 
-lemma arch_switch_thread_corres:
+lemma arch_switchToThread_corres:
   "corres dc (valid_arch_state and valid_objs and valid_asid_map
               and valid_vspace_objs and pspace_aligned and pspace_distinct
               and valid_vs_lookup and valid_global_objs
@@ -76,7 +76,7 @@ lemma arch_switch_thread_corres:
              (arch_switch_to_thread t) (Arch.switchToThread t)"
   apply (simp add: arch_switch_to_thread_def ARM_H.switchToThread_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split' [OF set_vm_root_corres])
+    apply (rule corres_split' [OF setVMRoot_corres])
       apply (rule corres_machine_op[OF corres_rel_imp])
       apply (rule corres_underlying_trivial)
        apply (simp add: ARM.clearExMonitor_def | wp)+
@@ -124,7 +124,7 @@ lemma tcbSchedAppend_corres:
              apply (rule corres_split_noop_rhs2)
                 apply (rule corres_split_noop_rhs2)
                    apply (rule threadSet_corres_noop, simp_all add: tcb_relation_def exst_same_def)[1]
-                  apply (rule addToBitmap_if_null_corres_noop)
+                  apply (rule addToBitmap_if_null_noop_corres)
                  apply wp+
                apply (simp add: tcb_sched_append_def)
                apply (intro conjI impI)
@@ -669,7 +669,7 @@ lemma tcbSchedDequeue_invs'[wp]:
   apply (fastforce elim: valid_objs'_maxDomain valid_objs'_maxPriority simp: valid_pspace'_def)+
   done
 
-lemma cur_thread_update_corres:
+lemma setCurThread_corres:
   "corres dc \<top> \<top> (modify (cur_thread_update (\<lambda>_. t))) (setCurThread t)"
   apply (unfold setCurThread_def)
   apply (rule corres_modify)
@@ -716,7 +716,7 @@ lemma arch_switch_thread_ksQ[wp]:
 crunch valid_queues[wp]: "Arch.switchToThread" "Invariants_H.valid_queues"
 (wp: crunch_wps simp: crunch_simps ignore: clearExMonitor)
 
-lemma switch_thread_corres:
+lemma switchToThread_corres:
   "corres dc (valid_arch_state and valid_objs and valid_asid_map
                 and valid_vspace_objs and pspace_aligned and pspace_distinct
                 and valid_vs_lookup and valid_global_objs
@@ -738,8 +738,8 @@ proof -
          setCurThread t
       od)"
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF _ arch_switch_thread_corres])
-        apply (rule corres_split_deprecated[OF cur_thread_update_corres tcbSchedDequeue_corres])
+      apply (rule corres_split_deprecated [OF _ arch_switchToThread_corres])
+        apply (rule corres_split_deprecated[OF setCurThread_corres tcbSchedDequeue_corres])
          apply (wp|clarsimp simp: tcb_at_is_etcb_at st_tcb_at_tcb_at)+
     done
 
@@ -755,7 +755,7 @@ proof -
     done
 qed
 
-lemma arch_switch_idle_thread_corres:
+lemma arch_switchToIdleThread_corres:
   "corres dc (valid_arch_state and valid_objs and valid_asid_map and unique_table_refs \<circ> caps_of_state and
       valid_vs_lookup and valid_global_objs and pspace_aligned and pspace_distinct and valid_vspace_objs and valid_idle)
      (valid_arch_state' and pspace_aligned' and pspace_distinct' and no_0_obj' and valid_idle')
@@ -763,16 +763,16 @@ lemma arch_switch_idle_thread_corres:
         Arch.switchToIdleThread"
   apply (simp add: arch_switch_to_idle_thread_def
                 ARM_H.switchToIdleThread_def)
-  apply (corressimp corres: git_corres set_vm_root_corres[@lift_corres_args])
+  apply (corressimp corres: getIdleThread_corres setVMRoot_corres[@lift_corres_args])
   apply (clarsimp simp: valid_idle_def valid_idle'_def pred_tcb_at_def obj_at_def is_tcb)
   done
 
-lemma switch_idle_thread_corres:
+lemma switchToIdleThread_corres:
   "corres dc invs invs_no_cicd' switch_to_idle_thread switchToIdleThread"
   apply (simp add: switch_to_idle_thread_def Thread_H.switchToIdleThread_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ git_corres])
-      apply (rule corres_split_deprecated [OF _ arch_switch_idle_thread_corres])
+    apply (rule corres_split_deprecated [OF _ getIdleThread_corres])
+      apply (rule corres_split_deprecated [OF _ arch_switchToIdleThread_corres])
         apply (unfold setCurThread_def)
         apply (rule corres_trivial, rule corres_modify)
         apply (simp add: state_relation_def cdt_relation_def)
@@ -1490,7 +1490,7 @@ lemma guarded_switch_to_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_symb_exec_l'[OF _ gts_exs_valid])
       apply (rule corres_assert_assume_l)
-      apply (rule switch_thread_corres)
+      apply (rule switchToThread_corres)
      apply (force simp: st_tcb_at_tcb_at)
     apply (wp gts_st_tcb_at)
     apply (force simp: st_tcb_at_tcb_at)+
@@ -1527,10 +1527,10 @@ lemma guarded_switch_to_chooseThread_fragment_corres:
   unfolding guarded_switch_to_def isRunnable_def
   apply simp
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gts_corres])
+    apply (rule corres_split_deprecated[OF _ getThreadState_corres])
       apply (rule corres_assert_assume_l)
       apply (rule corres_assert_assume_r)
-      apply (rule switch_thread_corres)
+      apply (rule switchToThread_corres)
      apply (wp gts_st_tcb_at)+
    apply (clarsimp simp: st_tcb_at_tcb_at invs_def valid_state_def valid_pspace_def valid_sched_def
                           invs_valid_vs_lookup invs_unique_refs)
@@ -1582,7 +1582,7 @@ proof -
       apply clarsimp
       apply (rule corres_split_deprecated[OF _ corres_gets_queues_getReadyQueuesL1Bitmap])
         apply (erule corres_if2[OF sym])
-         apply (rule switch_idle_thread_corres)
+         apply (rule switchToIdleThread_corres)
         apply (rule corres_symb_exec_r)
            apply (rule corres_symb_exec_r)
               apply (rule_tac
@@ -1636,11 +1636,11 @@ lemma schact_bind_inside: "do x \<leftarrow> f; (case act of resume_cur_thread \
 interpretation tcb_sched_action_extended: is_extended' "tcb_sched_action f a"
   by (unfold_locales)
 
-lemma domain_time_corres:
+lemma getDomainTime_corres:
   "corres (=) \<top> \<top> (gets domain_time) getDomainTime"
   by (simp add: getDomainTime_def state_relation_def)
 
-lemma next_domain_corres:
+lemma nextDomain_corres:
   "corres dc \<top> \<top> next_domain nextDomain"
   apply (simp add: next_domain_def nextDomain_def)
   apply (rule corres_modify)
@@ -1669,7 +1669,7 @@ lemma bind_dummy_ret_val:
    od = do a; b od"
   by simp
 
-lemma schedule_ChooseNewThread_fragment_corres:
+lemma scheduleChooseNewThread_fragment_corres:
   "corres dc (invs and valid_sched and (\<lambda>s. scheduler_action s = choose_new_thread)) (invs' and (\<lambda>s. ksSchedulerAction s = ChooseNewThread))
      (do _ \<leftarrow> when (domainTime = 0) next_domain;
          choose_thread
@@ -1684,12 +1684,12 @@ lemma schedule_ChooseNewThread_fragment_corres:
         apply simp
         apply (rule chooseThread_corres)
        apply simp
-      apply (rule next_domain_corres)
+      apply (rule nextDomain_corres)
      apply (wp nextDomain_invs_no_cicd')+
    apply (clarsimp simp: valid_sched_def invs'_def valid_state'_def all_invs_but_ct_idle_or_in_cur_domain'_def)+
   done
 
-lemma schedule_switch_thread_fastfail_corres:
+lemma scheduleSwitchThreadFastfail_corres:
   "\<lbrakk> ct \<noteq> it \<longrightarrow> (tp = tp' \<and> cp = cp') ; ct = ct' ; it = it' \<rbrakk> \<Longrightarrow>
    corres ((=)) (is_etcb_at ct) (tcb_at' ct)
      (schedule_switch_thread_fastfail ct it cp tp)
@@ -1752,9 +1752,9 @@ lemma scheduleChooseNewThread_corres:
            schedule_choose_new_thread scheduleChooseNewThread"
   unfolding schedule_choose_new_thread_def scheduleChooseNewThread_def
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ domain_time_corres], clarsimp)
-      apply (rule corres_split_deprecated[OF _ schedule_ChooseNewThread_fragment_corres, simplified bind_assoc])
-        apply (rule set_sa_corres)
+    apply (rule corres_split_deprecated[OF _ getDomainTime_corres], clarsimp)
+      apply (rule corres_split_deprecated[OF _ scheduleChooseNewThread_fragment_corres, simplified bind_assoc])
+        apply (rule setSchedulerAction_corres)
         apply (wp | simp)+
     apply (wp | simp add: getDomainTime_def)+
    apply auto
@@ -1787,8 +1787,8 @@ lemma schedule_corres:
   apply (subst thread_get_comm)
   apply (subst schact_bind_inside)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres[THEN corres_rel_imp[where r="\<lambda>x y. y = x"],simplified]])
-        apply (rule corres_split_deprecated[OF _ get_sa_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres[THEN corres_rel_imp[where r="\<lambda>x y. y = x"],simplified]])
+        apply (rule corres_split_deprecated[OF _ getSchedulerAction_corres])
           apply (rule corres_split_sched_act,assumption)
             apply (rule_tac P="tcb_at ct" in corres_symb_exec_l')
               apply (rule_tac corres_symb_exec_l)
@@ -1808,19 +1808,19 @@ lemma schedule_corres:
         apply (rule corres_split_deprecated[OF _ thread_get_isRunnable_corres],
                 rename_tac was_running wasRunning)
           apply (rule corres_split_deprecated[OF _ corres_when])
-              apply (rule corres_split_deprecated[OF _ git_corres], rename_tac it it')
+              apply (rule corres_split_deprecated[OF _ getIdleThread_corres], rename_tac it it')
                 apply (rule_tac F="was_running \<longrightarrow> ct \<noteq> it" in corres_gen_asm)
                 apply (rule corres_split_deprecated[OF _ ethreadget_corres[where r="(=)"]],
                        rename_tac tp tp')
                    apply (rule corres_split_deprecated[OF _ ethread_get_when_corres[where r="(=)"]],
                            rename_tac cp cp')
-                      apply (rule corres_split_deprecated[OF _ schedule_switch_thread_fastfail_corres])
+                      apply (rule corres_split_deprecated[OF _ scheduleSwitchThreadFastfail_corres])
                            apply (rule corres_split_deprecated[OF _ curDomain_corres])
                              apply (rule corres_split_deprecated[OF _ isHighestPrio_corres]; simp only:)
                                apply (rule corres_if, simp)
                                 apply (rule corres_split_deprecated[OF _ tcbSchedEnqueue_corres])
                                   apply (simp, fold dc_def)
-                                  apply (rule corres_split_deprecated[OF _ set_sa_corres])
+                                  apply (rule corres_split_deprecated[OF _ setSchedulerAction_corres])
                                      apply (rule scheduleChooseNewThread_corres, simp)
 
                                    apply (wp | simp)+
@@ -1836,7 +1836,7 @@ lemma schedule_corres:
 
                                 apply (rule corres_split_deprecated[OF _ tcbSchedAppend_corres])
                                   apply (simp, fold dc_def)
-                                  apply (rule corres_split_deprecated[OF _ set_sa_corres])
+                                  apply (rule corres_split_deprecated[OF _ setSchedulerAction_corres])
                                      apply (rule scheduleChooseNewThread_corres, simp)
 
                                    apply (wp | simp)+
@@ -1849,7 +1849,7 @@ lemma schedule_corres:
                                 apply (wp tcbSchedAppend_invs'_not_ResumeCurrentThread)
 
                                apply (rule corres_split_deprecated[OF _ guarded_switch_to_corres], simp)
-                                 apply (rule set_sa_corres[simplified dc_def])
+                                 apply (rule setSchedulerAction_corres[simplified dc_def])
                                  apply (wp | simp)+
 
                              (* isHighestPrio *)
@@ -2236,7 +2236,7 @@ lemma possibleSwitchTo_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated[OF _ curDomain_corres], simp)
       apply (rule corres_split_deprecated[OF _ ethreadget_corres[where r="(=)"]])
-         apply (rule corres_split_deprecated[OF _ get_sa_corres])
+         apply (rule corres_split_deprecated[OF _ getSchedulerAction_corres])
            apply (rule corres_if, simp)
             apply (rule tcbSchedEnqueue_corres)
            apply (rule corres_if, simp)
@@ -2244,7 +2244,7 @@ lemma possibleSwitchTo_corres:
             apply (rule corres_split_deprecated[OF _ rescheduleRequired_corres])
               apply (rule tcbSchedEnqueue_corres)
              apply (wp rescheduleRequired_valid_queues'_weak)+
-           apply (rule set_sa_corres, simp)
+           apply (rule setSchedulerAction_corres, simp)
           apply (wpsimp simp: etcb_relation_def if_apply_def2
                         wp: hoare_drop_imp[where f="ethread_get a b" for a b])+
       apply (wp hoare_drop_imps)[1]

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -128,7 +128,7 @@ where
 
 
 (* FIXME: move *)
-lemma dec_domain_inv_corres:
+lemma decodeDomainInvocation_corres:
   shows "\<lbrakk> list_all2 cap_relation (map fst cs) (map fst cs');
            list_all2 (\<lambda>p pa. snd pa = cte_map (snd p)) cs cs' \<rbrakk> \<Longrightarrow>
         corres (ser \<oplus> ((\<lambda>x. inv_relation x \<circ> uncurry Invocations_H.invocation.InvokeDomain) \<circ> (\<lambda>(x,y). Invocations_A.invocation.InvokeDomain x y))) \<top> \<top>
@@ -158,7 +158,7 @@ lemma dec_domain_inv_corres:
      apply (wp | simp)+
 done
 
-lemma decode_invocation_corres:
+lemma decodeInvocation_corres:
   "\<lbrakk>cptr = to_bl cptr'; mi' = message_info_map mi;
     slot' = cte_map slot; cap_relation cap cap';
     args = args'; list_all2 cap_relation (map fst excaps) (map fst excaps');
@@ -182,7 +182,7 @@ lemma decode_invocation_corres:
              apply (simp add: isCap_defs)
             \<comment> \<open>Untyped\<close>
             apply (simp add: isCap_defs Let_def o_def split del: if_split)
-            apply (rule corres_guard_imp, rule dec_untyped_inv_corres)
+            apply (rule corres_guard_imp, rule decodeUntypedInvocation_corres)
               apply ((clarsimp simp:cte_wp_at_caps_of_state)+)[3]
            \<comment> \<open>(Async)Endpoint\<close>
            apply (simp add: isCap_defs returnOk_def)
@@ -197,7 +197,7 @@ lemma decode_invocation_corres:
         apply (clarsimp simp add: o_def)
         apply (rule corres_guard_imp)
           apply (rule_tac F="length list \<le> 32" in corres_gen_asm)
-          apply (rule dec_cnode_inv_corres, simp+)
+          apply (rule decodeCNodeInvocation_corres, simp+)
          apply (simp add: valid_cap_def word_bits_def)
         apply simp
        \<comment> \<open>ThreadCap\<close>
@@ -205,7 +205,7 @@ lemma decode_invocation_corres:
                    split del: if_split cong: if_cong)
        apply (clarsimp simp add: o_def)
        apply (rule corres_guard_imp)
-         apply (rule decode_tcb_inv_corres, rule refl,
+         apply (rule decodeTCBInvocation_corres, rule refl,
                 simp_all add: valid_cap_def valid_cap'_def)[3]
        apply (simp add: split_def)
        apply (rule list_all2_conj)
@@ -214,20 +214,20 @@ lemma decode_invocation_corres:
       \<comment> \<open>DomainCap\<close>
       apply (simp add: isCap_defs)
       apply (rule corres_guard_imp)
-      apply (rule dec_domain_inv_corres)
+      apply (rule decodeDomainInvocation_corres)
       apply (simp+)[4]
      \<comment> \<open>IRQControl\<close>
      apply (simp add: isCap_defs o_def)
-     apply (rule corres_guard_imp, rule decode_irq_control_corres, simp+)[1]
+     apply (rule corres_guard_imp, rule decodeIRQControlInvocation_corres, simp+)[1]
     \<comment> \<open>IRQHandler\<close>
     apply (simp add: isCap_defs o_def)
-    apply (rule corres_guard_imp, rule decode_irq_handler_corres, simp+)[1]
+    apply (rule corres_guard_imp, rule decodeIRQHandlerInvocation_corres, simp+)[1]
    \<comment> \<open>Zombie\<close>
    apply (simp add: isCap_defs)
   \<comment> \<open>Arch\<close>
   apply (clarsimp simp only: cap_relation.simps)
   apply (clarsimp simp add: isCap_defs Let_def o_def)
-  apply (rule corres_guard_imp [OF dec_arch_inv_corres])
+  apply (rule corres_guard_imp [OF arch_decodeInvocation_corres])
       apply (simp_all add: list_all2_map2 list_all2_map1)+
   done
 
@@ -265,9 +265,9 @@ lemma hinv_corres_assist:
     apply (rule corres_splitEE [OF _ corres_cap_fault])
        prefer 2
        \<comment> \<open>switched over to argument of corres_cap_fault\<close>
-       apply (rule lcs_corres, simp)
-      apply (rule corres_split_deprecated [OF _ lipcb_corres])
-        apply (rule corres_splitEE [OF _ lec_corres])
+       apply (rule lookupCapAndSlot_corres, simp)
+      apply (rule corres_split_deprecated [OF _ lookupIPCBuffer_corres])
+        apply (rule corres_splitEE [OF _ lookupExtraCaps_corres])
             apply (rule corres_returnOkTT)
             apply simp+
          apply (wp | simp)+
@@ -339,7 +339,7 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
    apply (auto simp: obj_at'_def)
   done
 
-lemma set_domain_setDomain_corres:
+lemma setDomain_corres:
   "corres dc
      (valid_etcbs and valid_sched and tcb_at tptr)
      (invs'  and sch_act_simple
@@ -349,10 +349,10 @@ lemma set_domain_setDomain_corres:
   apply (rule corres_gen_asm2)
   apply (simp add: set_domain_def setDomain_def thread_set_domain_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply (rule corres_split_deprecated[OF _ tcbSchedDequeue_corres])
         apply (rule corres_split_deprecated[OF _ ethread_set_corres])
-                 apply (rule corres_split_deprecated[OF _ gts_isRunnable_corres])
+                 apply (rule corres_split_deprecated[OF _ isRunnable_corres])
                    apply simp
                    apply (rule corres_split_deprecated[OF corres_when[OF refl]])
                       apply (rule rescheduleRequired_corres)
@@ -385,7 +385,7 @@ lemma set_domain_setDomain_corres:
                simp: valid_sched_def valid_sched_action_def)
   done
 
-lemma pinv_corres:
+lemma performInvocation_corres:
   "\<lbrakk> inv_relation i i'; call \<longrightarrow> block \<rbrakk> \<Longrightarrow>
    corres (dc \<oplus> (=))
      (einvs and valid_invocation i
@@ -406,9 +406,9 @@ lemma pinv_corres:
               apply wp+
             apply simp+
           apply (rule corres_guard_imp)
-           apply (rule corres_split_deprecated [OF _ gct_corres])
+           apply (rule corres_split_deprecated [OF _ getCurThread_corres])
              apply simp
-             apply (rule corres_split_deprecated [OF _ send_ipc_corres])
+             apply (rule corres_split_deprecated [OF _ sendIPC_corres])
                 apply (rule corres_trivial)
                 apply simp
                apply simp
@@ -419,15 +419,15 @@ lemma pinv_corres:
                                sch_act_simple_def)
         apply (rule corres_guard_imp)
           apply (simp add: liftE_bindE)
-          apply (rule corres_split_deprecated [OF _ send_signal_corres])
+          apply (rule corres_split_deprecated [OF _ sendSignal_corres])
             apply (rule corres_trivial)
             apply (simp add: returnOk_def)
            apply wp+
          apply (simp+)[2]
        apply simp
        apply (rule corres_guard_imp)
-         apply (rule corres_split_eqr [OF _ gct_corres])
-           apply (rule corres_split_nor [OF _ do_reply_transfer_corres'])
+         apply (rule corres_split_eqr [OF _ getCurThread_corres])
+           apply (rule corres_split_nor [OF _ doReplyTransfer_corres'])
              apply (rule corres_trivial, simp)
             apply wp+
         apply (clarsimp simp: tcb_at_invs)
@@ -437,30 +437,30 @@ lemma pinv_corres:
        apply (fastforce elim!: cte_wp_at_weakenE')
       apply (clarsimp simp: liftME_def)
       apply (rule corres_guard_imp)
-        apply (erule tcbinv_corres)
+        apply (erule invokeTCB_corres)
        apply (simp)+
       \<comment> \<open>domain cap\<close>
       apply (clarsimp simp: invoke_domain_def)
       apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF _ set_domain_setDomain_corres])
+      apply (rule corres_split_deprecated [OF _ setDomain_corres])
         apply (rule corres_trivial, simp)
        apply (wp)+
        apply (clarsimp+)[2]
      \<comment> \<open>CNodes\<close>
      apply clarsimp
      apply (rule corres_guard_imp)
-       apply (rule corres_splitEE [OF _ inv_cnode_corres])
+       apply (rule corres_splitEE [OF _ invokeCNode_corres])
           apply (rule corres_trivial, simp add: returnOk_def)
          apply assumption
         apply wp+
       apply (clarsimp+)[2]
     apply (clarsimp simp: liftME_def[symmetric] o_def dc_def[symmetric])
-    apply (rule corres_guard_imp, rule invoke_irq_control_corres, simp+)
+    apply (rule corres_guard_imp, rule performIRQControl_corres, simp+)
    apply (clarsimp simp: liftME_def[symmetric] o_def dc_def[symmetric])
-   apply (rule corres_guard_imp, rule invoke_irq_handler_corres, simp+)
+   apply (rule corres_guard_imp, rule invokeIRQHandler_corres, simp+)
   apply clarsimp
   apply (rule corres_guard_imp)
-    apply (rule inv_arch_corres, assumption)
+    apply (rule arch_performInvocation_corres, assumption)
    apply (clarsimp+)[2]
   done
 
@@ -1201,7 +1201,7 @@ crunch valid_duplicates'[wp]: rescheduleRequired "\<lambda>s. vs_valid_duplicate
 crunch valid_duplicates'[wp]: setThreadState "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
 
 (*FIXME: move to NonDetMonadVCG.valid_validE_R *)
-lemma hinv_corres:
+lemma handleInvocation_corres:
   "c \<longrightarrow> b \<Longrightarrow>
    corres (dc \<oplus> dc)
           (einvs and (\<lambda>s. scheduler_action s = resume_cur_thread) and ct_active)
@@ -1211,19 +1211,19 @@ lemma hinv_corres:
           (handleInvocation c b)"
   apply (simp add: handle_invocation_def handleInvocation_def liftE_bindE)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ gct_corres])
-      apply (rule corres_split_deprecated [OF _ get_mi_corres])
+    apply (rule corres_split_eqr [OF _ getCurThread_corres])
+      apply (rule corres_split_deprecated [OF _ getMessageInfo_corres])
         apply clarsimp
         apply (simp add: liftM_def cap_register_def capRegister_def)
-        apply (rule corres_split_eqr [OF _ user_getreg_corres])
+        apply (rule corres_split_eqr [OF _ asUser_getRegister_corres])
           apply (rule syscall_corres)
                   apply (rule hinv_corres_assist, simp)
                  apply (clarsimp simp add: when_def)
-                 apply (rule hf_corres)
+                 apply (rule handleFault_corres)
                  apply simp
                 apply (simp add: split_def)
-                apply (rule corres_split_deprecated [OF _ get_mrs_corres])
-                  apply (rule decode_invocation_corres, simp_all)[1]
+                apply (rule corres_split_deprecated [OF _ getMRs_corres])
+                  apply (rule decodeInvocation_corres, simp_all)[1]
                    apply (fastforce simp: list_all2_map2 list_all2_map1 elim:  list_all2_mono)
                   apply (fastforce simp: list_all2_map2 list_all2_map1 elim:  list_all2_mono)
                  apply wp[1]
@@ -1231,17 +1231,17 @@ lemma hinv_corres:
                 apply simp
                 apply wp[1]
                apply (clarsimp simp: when_def)
-               apply (rule rfk_corres)
-              apply (rule corres_split_deprecated [OF _ sts_corres])
-                 apply (rule corres_splitEE [OF _ pinv_corres])
+               apply (rule replyFromKernel_corres)
+              apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+                 apply (rule corres_splitEE [OF _ performInvocation_corres])
                      apply simp
-                     apply (rule corres_split_deprecated [OF _ gts_corres])
+                     apply (rule corres_split_deprecated [OF _ getThreadState_corres])
                        apply (rename_tac state state')
                        apply (case_tac state, simp_all)[1]
                        apply (fold dc_def)[1]
-                       apply (rule corres_split_deprecated [OF sts_corres])
+                       apply (rule corres_split_deprecated [OF setThreadState_corres])
                           apply simp
-                         apply (rule corres_when [OF refl rfk_corres])
+                         apply (rule corres_when [OF refl replyFromKernel_corres])
                         apply (simp add: when_def)
                         apply (rule conjI, rule impI)
                          apply (rule reply_from_kernel_tcb_at)
@@ -1362,13 +1362,13 @@ crunch typ_at'[wp]: handleFault "\<lambda>s. P (typ_at' T p s)"
 
 lemmas handleFault_typ_ats[wp] = typ_at_lifts [OF handleFault_typ_at']
 
-lemma hs_corres:
+lemma handleSend_corres:
   "corres (dc \<oplus> dc)
           (einvs and (\<lambda>s. scheduler_action s = resume_cur_thread) and ct_active)
           (invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
            (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_active')
           (handle_send blocking) (handleSend blocking)"
-  by (simp add: handle_send_def handleSend_def hinv_corres)
+  by (simp add: handle_send_def handleSend_def handleInvocation_corres)
 
 lemma hs_invs'[wp]:
   "\<lbrace>invs' and ct_active' and
@@ -1393,7 +1393,7 @@ lemma tcb_at_cte_at_map:
   apply (auto elim: cte_wp_at_tcbI')
   done
 
-lemma delete_caller_cap_corres:
+lemma deleteCallerCap_corres:
   "corres dc (einvs and tcb_at t) (invs' and tcb_at' t)
      (delete_caller_cap t)
      (deleteCallerCap t)"
@@ -1489,7 +1489,7 @@ lemma delete_caller_cap_valid_ep_cap:
    by (wp get_cap_wp fast_finalise_typ_at abs_typ_at_lifts(1)
        | simp add: unless_def valid_cap_def)+
 
-lemma hw_corres':
+lemma handleRecv_isBlocking_corres':
    "corres dc (einvs and ct_in_state active
                     and (\<lambda>s. ex_nonz_cap_to (cur_thread s) s))
               (invs' and ct_in_state' simple'
@@ -1502,12 +1502,12 @@ lemma hw_corres':
                    cap_register_def capRegister_def
              cong: if_cong cap.case_cong capability.case_cong bool.case_cong)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ gct_corres])
-      apply (rule corres_split_eqr [OF _ user_getreg_corres])
+    apply (rule corres_split_eqr [OF _ getCurThread_corres])
+      apply (rule corres_split_eqr [OF _ asUser_getRegister_corres])
         apply (rule corres_split_catch)
-           apply (erule hf_corres)
+           apply (erule handleFault_corres)
           apply (rule corres_cap_fault)
-          apply (rule corres_splitEE [OF _ lc_corres])
+          apply (rule corres_splitEE [OF _ lookupCap_corres])
             apply (rule_tac P="?pre1 and tcb_at thread
                                and (\<lambda>s. (cur_thread s) = thread  )
                                and valid_cap rv"
@@ -1517,8 +1517,8 @@ lemma hw_corres':
              apply (rule corres_guard_imp)
                apply (rename_tac rights)
                 apply (case_tac "AllowRead \<in> rights"; simp)
-                 apply (rule corres_split_nor[OF _ delete_caller_cap_corres])
-                   apply (rule receive_ipc_corres)
+                 apply (rule corres_split_nor[OF _ deleteCallerCap_corres])
+                   apply (rule receiveIPC_corres)
                     apply (clarsimp)+
                   apply (wp delete_caller_cap_nonz_cap delete_caller_cap_valid_ep_cap)+
                 apply (clarsimp)+
@@ -1530,11 +1530,11 @@ lemma hw_corres':
                apply (rule_tac r'=ntfn_relation in corres_splitEE)
                   apply (rule corres_if)
                     apply (clarsimp simp: ntfn_relation_def)
-                   apply (clarsimp, rule receive_signal_corres)
+                   apply (clarsimp, rule receiveSignal_corres)
                     prefer 3
                     apply (rule corres_trivial)
                     apply (clarsimp simp: lookup_failure_map_def)+
-                 apply (rule get_ntfn_corres)
+                 apply (rule getNotification_corres)
                 apply (wp get_simple_ko_wp getNotification_wp | wpcw | simp)+
               apply (clarsimp simp: lookup_failure_map_def)
              apply (clarsimp simp: valid_cap_def ct_in_state_def)
@@ -1552,13 +1552,13 @@ lemma hw_corres':
                         ct_in_state'_def sch_act_sane_not)
   done
 
-lemma hw_corres:
+lemma handleRecv_isBlocking_corres:
   "corres dc (einvs and ct_active)
              (invs' and ct_active' and sch_act_sane and
                     (\<lambda>s. \<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p)))
             (handle_recv isBlocking) (handleRecv isBlocking)"
   apply (rule corres_guard_imp)
-    apply (rule hw_corres')
+    apply (rule handleRecv_isBlocking_corres')
    apply (clarsimp simp: ct_in_state_def)
    apply (fastforce elim!: st_tcb_weakenE st_tcb_ex_cap)
   apply (clarsimp simp: ct_in_state'_def invs'_def valid_state'_def)
@@ -1628,11 +1628,11 @@ lemma setSchedulerAction_obj_at'[wp]:
   unfolding setSchedulerAction_def
   by (wp, clarsimp elim!: obj_at'_pspaceI)
 
-lemma hy_corres:
+lemma handleYield_corres:
   "corres dc einvs (invs' and ct_active' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)) handle_yield handleYield"
   apply (clarsimp simp: handle_yield_def handleYield_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply simp
       apply (rule corres_split_deprecated[OF _ tcbSchedDequeue_corres])
         apply (rule corres_split_deprecated[OF _ tcbSchedAppend_corres])
@@ -1703,14 +1703,14 @@ lemma simple_from_running':
   by (clarsimp elim!: pred_tcb'_weakenE
                simp: ct_in_state'_def)+
 
-lemma hr_corres:
+lemma handleReply_corres:
   "corres dc (einvs and ct_running) (invs' and ct_running')
          handle_reply handleReply"
   apply (simp add: handle_reply_def handleReply_def
                    getThreadCallerSlot_map
                    getSlotCap_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ gct_corres])
+    apply (rule corres_split_eqr [OF _ getCurThread_corres])
       apply (rule corres_split_deprecated [OF _ get_cap_corres])
         apply (rule_tac P="einvs and cte_wp_at ((=) caller_cap) (thread, tcb_cnode_index 3)
                                 and K (is_reply_cap caller_cap \<or> caller_cap = cap.NullCap)
@@ -1721,8 +1721,8 @@ lemma hr_corres:
                               and cte_at' (cte_map (thread, tcb_cnode_index 3))"
                     in corres_inst)
         apply (auto split: cap_relation_split_asm arch_cap.split_asm bool.split
-                   intro!: corres_guard_imp [OF delete_caller_cap_corres]
-                           corres_guard_imp [OF do_reply_transfer_corres]
+                   intro!: corres_guard_imp [OF deleteCallerCap_corres]
+                           corres_guard_imp [OF doReplyTransfer_corres]
                            corres_fail
                      simp: valid_cap_def valid_cap'_def is_cap_simps assert_def is_reply_cap_to_def)[1]
         apply (fastforce simp: invs_def valid_state_def
@@ -1797,13 +1797,13 @@ lemma hr_ct_active'[wp]:
                   dest: ctes_of_valid')
   done
 
-lemma hc_corres:
+lemma handleCall_corres:
   "corres (dc \<oplus> dc) (einvs and (\<lambda>s. scheduler_action s = resume_cur_thread) and ct_active)
               (invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
                 (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
                 ct_active')
          handle_call handleCall"
-  by (simp add: handle_call_def handleCall_def liftE_bindE hinv_corres)
+  by (simp add: handle_call_def handleCall_def liftE_bindE handleInvocation_corres)
 
 lemma hc_invs'[wp]:
   "\<lbrace>invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
@@ -1948,14 +1948,14 @@ crunches possible_switch_to, handle_recv
   for valid_etcbs[wp]: "valid_etcbs"
   (wp: crunch_wps simp: crunch_simps)
 
-lemma hrw_corres:
+lemma handleReply_handleRecv_corres:
   "corres dc (einvs and ct_running)
              (invs' and ct_running' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
          (do x \<leftarrow> handle_reply; handle_recv True od)
          (do x \<leftarrow> handleReply; handleRecv True od)"
   apply (rule corres_guard_imp)
-    apply (rule corres_split_nor [OF _ hr_corres])
-      apply (rule hw_corres')
+    apply (rule corres_split_nor [OF _ handleReply_corres])
+      apply (rule handleRecv_isBlocking_corres')
      apply (wp handle_reply_nonz_cap_to_ct handleReply_sane
                handleReply_nonz_cap_to_ct handleReply_ct_not_ksQ handle_reply_valid_sched)+
    apply (fastforce simp: ct_in_state_def ct_in_state'_def simple_sane_strg
@@ -1965,7 +1965,7 @@ lemma hrw_corres:
   apply (fastforce elim: pred_tcb'_weakenE)
   done
 
-lemma hh_corres:
+lemma handleHypervisorFault_corres:
   "corres dc (einvs and  st_tcb_at active thread and ex_nonz_cap_to thread
                    and (%_. valid_fault f))
              (invs' and sch_act_not thread
@@ -1977,21 +1977,21 @@ lemma hh_corres:
   done
 
 (* FIXME: move *)
-lemma he_corres:
+lemma handleEvent_corres:
   "corres (dc \<oplus> dc) (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and
                        (\<lambda>s. scheduler_action s = resume_cur_thread))
                       (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and
                        (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
                        (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
                       (handle_event event) (handleEvent event)"
-  (is "?he_corres")
+  (is "?handleEvent_corres")
 proof -
   have hw:
     "\<And>isBlocking. corres dc (einvs and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread))
                (invs' and ct_running'
                       and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
                (handle_recv isBlocking) (handleRecv isBlocking)"
-    apply (rule corres_guard_imp [OF hw_corres])
+    apply (rule corres_guard_imp [OF handleRecv_isBlocking_corres])
      apply (clarsimp simp: ct_in_state_def ct_in_state'_def
                      elim!: st_tcb_weakenE pred_tcb'_weakenE
                      dest!: ct_not_ksQ)+
@@ -2002,17 +2002,17 @@ proof -
 
           apply (rename_tac syscall)
           apply (case_tac syscall)
-          apply (auto intro: corres_guard_imp[OF hs_corres]
+          apply (auto intro: corres_guard_imp[OF handleSend_corres]
                              corres_guard_imp[OF hw]
-                             corres_guard_imp [OF hr_corres]
-                             corres_guard_imp[OF hrw_corres]
-                             corres_guard_imp[OF hc_corres]
-                             corres_guard_imp[OF hy_corres]
+                             corres_guard_imp [OF handleReply_corres]
+                             corres_guard_imp[OF handleReply_handleRecv_corres]
+                             corres_guard_imp[OF handleCall_corres]
+                             corres_guard_imp[OF handleYield_corres]
                              active_from_running active_from_running'
                       simp: simple_sane_strg)[8]
          apply (rule corres_split')
-            apply (rule corres_guard_imp[OF gct_corres], simp+)
-           apply (rule hf_corres)
+            apply (rule corres_guard_imp[OF getCurThread_corres], simp+)
+           apply (rule handleFault_corres)
            apply simp
           apply (simp add: valid_fault_def)
           apply wp
@@ -2025,8 +2025,8 @@ proof -
                            sch_act_sane_def
                      elim: pred_tcb'_weakenE st_tcb_ex_cap'')[1]
         apply (rule corres_split')
-           apply (rule corres_guard_imp, rule gct_corres, simp+)
-          apply (rule hf_corres)
+           apply (rule corres_guard_imp, rule getCurThread_corres, simp+)
+          apply (rule handleFault_corres)
           apply (simp add: valid_fault_def)
          apply wp
          apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE
@@ -2042,7 +2042,7 @@ proof -
                                       and R'="\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> R'' x s"
                                       for R''])
             apply (case_tac rv, simp_all add: doMachineOp_return)[1]
-            apply (rule handle_interrupt_corres)
+            apply (rule handleInterrupt_corres)
            apply (rule corres_machine_op)
            apply (rule corres_Id, simp+)
            apply (wp hoare_vcg_all_lift
@@ -2053,10 +2053,10 @@ proof -
        apply simp
        apply (simp add: invs'_def valid_state'_def)
       apply (rule_tac corres_split')
-         apply (rule corres_guard_imp, rule gct_corres, simp+)
+         apply (rule corres_guard_imp, rule getCurThread_corres, simp+)
         apply (rule corres_split_catch)
-           apply (erule hf_corres)
-          apply (rule hv_corres)
+           apply (erule handleFault_corres)
+          apply (rule handleVMFault_corres)
          apply (rule hoare_elim_pred_conjE2)
          apply (rule hoare_vcg_E_conj, rule valid_validE_E, wp)
          apply (wp handle_vm_fault_valid_fault)
@@ -2070,8 +2070,8 @@ proof -
       apply (fastforce simp: simple_sane_strg sch_act_simple_def ct_in_state'_def
                   elim: st_tcb_ex_cap'' pred_tcb'_weakenE)
          apply (rule corres_split')
-            apply (rule corres_guard_imp[OF gct_corres], simp+)
-           apply (rule hh_corres)
+            apply (rule corres_guard_imp[OF getCurThread_corres], simp+)
+           apply (rule handleHypervisorFault_corres)
           apply (simp add: valid_fault_def)
           apply wp
           apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -10,45 +10,45 @@ begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma setNextPCs_corres:
+lemma asUser_setNextPC_corres:
   "corres dc (tcb_at t and invs) (tcb_at' t and invs')
              (as_user t (setNextPC v)) (asUser t (setNextPC v))"
-  apply (rule corres_as_user)
+  apply (rule asUser_corres)
   apply (rule corres_Id, simp, simp)
   apply (rule no_fail_setNextPC)
   done
 
-lemma activate_idle_thread_corres:
+lemma activateIdleThread_corres:
  "corres dc (invs and st_tcb_at idle t)
             (invs' and st_tcb_at' idle' t)
     (arch_activate_idle_thread t) (activateIdleThread t)"
   by (simp add: arch_activate_idle_thread_def activateIdleThread_def)
 
-lemma activate_corres:
+lemma activateThread_corres:
  "corres dc (invs and ct_in_state activatable) (invs' and ct_in_state' activatable')
             activate_thread activateThread"
   apply (simp add: activate_thread_def activateThread_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ gct_corres])
+    apply (rule corres_split_eqr [OF _ getCurThread_corres])
       apply (rule_tac R="\<lambda>ts s. valid_tcb_state ts s \<and> (idle ts \<or> runnable ts)
                                 \<and> invs s \<and> st_tcb_at ((=) ts) thread s"
                   and R'="\<lambda>ts s. valid_tcb_state' ts s \<and> (idle' ts \<or> runnable' ts)
                                 \<and> invs' s \<and> st_tcb_at' (\<lambda>ts'. ts' = ts) thread s"
-                  in  corres_split_deprecated [OF _ gts_corres])
+                  in  corres_split_deprecated [OF _ getThreadState_corres])
         apply (rule_tac F="idle rv \<or> runnable rv" in corres_req, simp)
         apply (rule_tac F="idle' rv' \<or> runnable' rv'" in corres_req, simp)
         apply (case_tac rv, simp_all add:
                   isRunning_def isRestart_def,
                   safe, simp_all)[1]
          apply (rule corres_guard_imp)
-           apply (rule corres_split_eqr [OF _ getRestartPCs_corres])
-             apply (rule corres_split_nor [OF _ setNextPCs_corres])
-               apply (rule sts_corres)
+           apply (rule corres_split_eqr [OF _ asUser_getRestartPC_corres])
+             apply (rule corres_split_nor [OF _ asUser_setNextPC_corres])
+               apply (rule setThreadState_corres)
                apply (simp | wp weak_sch_act_wf_lift_linear)+
           apply (clarsimp simp: st_tcb_at_tcb_at)
          apply fastforce
         apply (rule corres_guard_imp)
-          apply (rule activate_idle_thread_corres)
+          apply (rule activateIdleThread_corres)
          apply (clarsimp elim!: st_tcb_weakenE)
         apply (clarsimp elim!: pred_tcb'_weakenE)
        apply (wp gts_st_tcb gts_st_tcb' gts_st_tcb_at)+
@@ -59,15 +59,15 @@ lemma activate_corres:
   done
 
 
-lemma bind_notification_corres:
+lemma bindNotification_corres:
   "corres dc
          (invs and tcb_at t and ntfn_at a) (invs' and tcb_at' t and ntfn_at' a)
          (bind_notification t a) (bindNotification t a)"
   apply (simp add: bind_notification_def bindNotification_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ get_ntfn_corres])
-      apply (rule corres_split_deprecated[OF _ set_ntfn_corres])
-         apply (rule sbn_corres)
+    apply (rule corres_split_deprecated[OF _ getNotification_corres])
+      apply (rule corres_split_deprecated[OF _ setNotification_corres])
+         apply (rule setBoundNotification_corres)
         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
        apply (wp)+
    apply auto
@@ -207,11 +207,11 @@ lemma restart_corres:
   apply (simp add: Tcb_A.restart_def Thread_H.restart_def)
   apply (simp add: isStopped_def2 liftM_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gts_corres])
+    apply (rule corres_split_deprecated [OF _ getThreadState_corres])
       apply (clarsimp simp add: runnable_tsr idle_tsr when_def)
       apply (rule corres_split_nor [OF _ cancel_ipc_corres])
-        apply (rule corres_split_nor [OF _ setup_reply_master_corres])
-          apply (rule corres_split_nor [OF _ sts_corres])
+        apply (rule corres_split_nor [OF _ setupReplyMaster_corres])
+          apply (rule corres_split_nor [OF _ setThreadState_corres])
              apply (rule corres_split_deprecated [OF possibleSwitchTo_corres tcbSchedEnqueue_corres])
               apply (wp set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at' sts_valid_queues sts_st_tcb'  | clarsimp simp: valid_tcb_state'_def)+
        apply (rule_tac Q="\<lambda>rv. valid_sched and cur_tcb" in hoare_strengthen_post)
@@ -277,7 +277,7 @@ lemma
   no_fail_getRegister[wp]: "no_fail \<top> (getRegister r)"
   by (simp add: getRegister_def)
 
-lemma readreg_corres:
+lemma invokeTCB_ReadRegisters_corres:
   "corres (dc \<oplus> (=))
         (einvs  and tcb_at src and ex_nonz_cap_to src)
         (invs' and sch_act_simple and tcb_at' src and ex_nonz_cap_to' src)
@@ -288,9 +288,9 @@ lemma readreg_corres:
                    frameRegisters_def gpRegisters_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_nor)
-       apply (rule corres_split_deprecated [OF _ gct_corres])
+       apply (rule corres_split_deprecated [OF _ getCurThread_corres])
          apply (simp add: liftM_def[symmetric])
-         apply (rule corres_as_user)
+         apply (rule asUser_corres)
          apply (rule corres_Id)
            apply simp
           apply simp
@@ -317,7 +317,7 @@ declare invs_valid_queues'[rule_format, elim!]
 lemma einvs_valid_etcbs: "einvs s \<longrightarrow> valid_etcbs s"
   by (clarsimp simp: valid_sched_def)
 
-lemma arch_post_modify_registers_corres:
+lemma asUser_postModifyRegisters_corres:
   "corres dc \<top> (tcb_at' t)
      (arch_post_modify_registers ct t)
      (asUser t $ postModifyRegisters ct t)"
@@ -326,7 +326,7 @@ lemma arch_post_modify_registers_corres:
   apply (rule corres_stateAssert_assume)
    by simp+
 
-lemma writereg_corres:
+lemma invokeTCB_WriteRegisters_corres:
   "corres (dc \<oplus> (=)) (einvs  and tcb_at dest and ex_nonz_cap_to dest)
         (invs' and sch_act_simple and tcb_at' dest and ex_nonz_cap_to' dest)
         (invoke_tcb (tcb_invocation.WriteRegisters dest resume values arch))
@@ -335,17 +335,17 @@ lemma writereg_corres:
                    frameRegisters_def gpRegisters_def getSanitiseRegisterInfo_def
                    sanitiseRegister_def sanitise_register_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gct_corres])
+    apply (rule corres_split_deprecated [OF _ getCurThread_corres])
       apply (rule corres_split_nor)
          prefer 2
-         apply (rule corres_as_user)
+         apply (rule asUser_corres)
          apply (simp add: zipWithM_mapM getRestartPC_def setNextPC_def)
          apply (rule corres_Id, simp+)
          apply (rule no_fail_pre, wp no_fail_mapM)
             apply clarsimp
             apply (wp no_fail_setRegister | simp)+
         apply clarsimp
-        apply (rule corres_split_nor[OF _ arch_post_modify_registers_corres[simplified]])
+        apply (rule corres_split_nor[OF _ asUser_postModifyRegisters_corres[simplified]])
           apply (rule corres_split_nor[OF _ corres_when[OF refl restart_corres]])
             apply (rule corres_split_nor[OF _ corres_when[OF refl rescheduleRequired_corres]])
               apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
@@ -386,7 +386,7 @@ lemma suspend_ResumeCurrentThread_imp_notct[wp]:
    \<lbrace>\<lambda>rv s. ksSchedulerAction s = ResumeCurrentThread \<longrightarrow> ksCurThread s \<noteq> t'\<rbrace>"
   by (wpsimp simp: suspend_def)
 
-lemma copyreg_corres:
+lemma invokeTCB_CopyRegisters_corres:
   "corres (dc \<oplus> (=))
         (einvs and simple_sched_action and tcb_at dest and tcb_at src and ex_nonz_cap_to src and
           ex_nonz_cap_to dest)
@@ -408,11 +408,11 @@ proof -
     apply (rule corres_guard_imp)
       apply (rule corres_split_eqr)
         apply (simp add: setRegister_def)
-        apply (rule corres_as_user)
+        apply (rule asUser_corres)
         apply (rule corres_modify')
          apply simp
         apply simp
-       apply (rule user_getreg_corres)
+       apply (rule asUser_getRegister_corres)
        apply (simp | wp)+
     done
   have R: "\<And>src src' des des' xs ys. \<lbrakk> src = src'; des = des'; xs = ys \<rbrakk> \<Longrightarrow>
@@ -433,8 +433,8 @@ proof -
                 (do pc \<leftarrow> as_user t getRestartPC; as_user t (setNextPC pc) od)
                 (do pc \<leftarrow> asUser t getRestartPC; asUser t (setNextPC pc) od)"
     apply (rule corres_guard_imp)
-      apply (rule corres_split_eqr [OF _ getRestartPCs_corres])
-        apply (rule setNextPCs_corres)
+      apply (rule corres_split_eqr [OF _ asUser_getRestartPC_corres])
+        apply (rule asUser_setNextPC_corres)
        apply wp+
      apply simp+
     done
@@ -445,8 +445,8 @@ proof -
         apply (rule corres_split_deprecated [OF _ corres_when [OF refl restart_corres]], simp)
           apply (rule corres_split_nor)
              apply (rule corres_split_nor)
-                apply (rule corres_split_eqr [OF _ gct_corres])
-                  apply (rule corres_split_nor[OF _ arch_post_modify_registers_corres[simplified]])
+                apply (rule corres_split_eqr [OF _ getCurThread_corres])
+                  apply (rule corres_split_nor[OF _ asUser_postModifyRegisters_corres[simplified]])
                     apply (rule corres_split_deprecated [OF _ corres_when[OF refl rescheduleRequired_corres]])
                       apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
                       apply simp
@@ -551,13 +551,13 @@ lemma threadSet_valid_queues'_no_state:
   apply (fastforce simp: projectKOs inQ_def split: if_split_asm)
   done
 
-lemma gts_isRunnable_corres:
+lemma isRunnable_corres:
   "corres (\<lambda>ts runn. runnable ts = runn) (tcb_at t) (tcb_at' t)
      (get_thread_state t) (isRunnable t)"
   apply (simp add: isRunnable_def)
   apply (subst bind_return[symmetric])
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gts_corres])
+    apply (rule corres_split_deprecated[OF _ getThreadState_corres])
       apply (case_tac rv, clarsimp+)
      apply (wp hoare_TrueI)+
    apply auto
@@ -636,9 +636,9 @@ lemma sp_corres2:
   apply (rule stronger_corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ tcbSchedDequeue_corres])
       apply (rule corres_split_deprecated [OF _ ethread_set_corres], simp_all)[1]
-         apply (rule corres_split_deprecated [OF _ gts_isRunnable_corres])
+         apply (rule corres_split_deprecated [OF _ isRunnable_corres])
            apply (erule corres_when)
-           apply(rule corres_split_deprecated [OF _ gct_corres])
+           apply(rule corres_split_deprecated [OF _ getCurThread_corres])
              apply (wp corres_if; clarsimp)
               apply (rule rescheduleRequired_corres)
              apply (rule possibleSwitchTo_corres)
@@ -661,7 +661,7 @@ lemma sp_corres2:
   apply (force simp: state_relation_def elim: valid_objs'_maxDomain valid_objs'_maxPriority)
   done
 
-lemma sp_corres: "corres dc (einvs and tcb_at t) (invs' and tcb_at' t and valid_objs' and (\<lambda>_. x \<le> maxPriority))
+lemma setPriority_corres: "corres dc (einvs and tcb_at t) (invs' and tcb_at' t and valid_objs' and (\<lambda>_. x \<le> maxPriority))
                      (set_priority t x) (setPriority t x)"
   apply (rule corres_guard_imp)
     apply (rule sp_corres2)
@@ -669,7 +669,7 @@ lemma sp_corres: "corres dc (einvs and tcb_at t) (invs' and tcb_at' t and valid_
   apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak)
   done
 
-lemma smcp_corres: "corres dc (tcb_at t) (tcb_at' t)
+lemma setMCPriority_corres: "corres dc (tcb_at t) (tcb_at' t)
                      (set_mcpriority t x) (setMCPriority t x)"
   apply (rule corres_guard_imp)
     apply (clarsimp simp: setMCPriority_def set_mcpriority_def)
@@ -874,7 +874,7 @@ lemma sameObject_corres2:
   apply (case_tac arch_capa; simp)
   done
 
-lemma check_cap_at_corres:
+lemma checkCapAt_corres:
   assumes r: "cap_relation cap cap'"
   assumes c: "corres dc Q Q' f f'"
   assumes Q: "\<And>s. P s \<and> cte_wp_at (same_object_as cap) slot s \<Longrightarrow> Q s"
@@ -894,13 +894,13 @@ lemma check_cap_at_corres:
   apply (fastforce elim: cte_wp_at_weakenE' intro: Q')
   done
 
-lemma check_cap_at_corres_weak:
+lemma checkCapAt_weak_corres:
   assumes r: "cap_relation cap cap'"
   assumes c: "corres dc P P' f f'"
   shows "corres dc (P and cte_at slot and invs) (P' and pspace_aligned' and pspace_distinct')
              (check_cap_at cap slot f)
              (checkCapAt cap' (cte_map slot) f')"
-  apply (rule check_cap_at_corres, rule r, rule c)
+  apply (rule checkCapAt_corres, rule r, rule c)
   apply auto
   done
 
@@ -909,7 +909,7 @@ defs
   "assertDerived src cap f \<equiv>
   do stateAssert (\<lambda>s. cte_wp_at' (is_derived' (ctes_of s) src cap o cteCap) src s) []; f od"
 
-lemma checked_insert_corres:
+lemma checkCapAt_cteInsert_corres:
   "cap_relation new_cap newCap \<Longrightarrow>
    corres dc (einvs and cte_wp_at (\<lambda>c. c = cap.NullCap) (target, ref)
                and cte_at slot and K (is_cnode_or_valid_arch new_cap
@@ -937,12 +937,12 @@ lemma checked_insert_corres:
                         and
                         P'="cte_wp_at' (\<lambda>c. cteCap c = NullCap) (cte_map (target, ref))
                             and invs' and valid_cap' newCap"
-                       in check_cap_at_corres, assumption)
-      apply (rule check_cap_at_corres_weak, simp)
+                       in checkCapAt_corres, assumption)
+      apply (rule checkCapAt_weak_corres, simp)
       apply (unfold assertDerived_def)[1]
       apply (rule corres_stateAssert_implied [where P'=\<top>])
        apply simp
-       apply (erule cins_corres [OF _ refl refl])
+       apply (erule cteInsert_corres [OF _ refl refl])
       apply clarsimp
       apply (drule cte_wp_at_norm [where p=src_slot])
       apply (case_tac src_slot)
@@ -1270,7 +1270,7 @@ lemma valid_tcb_ipc_buffer_update:
    \<Longrightarrow> (\<forall>tcb. valid_tcb' tcb s \<longrightarrow> valid_tcb' (tcbIPCBuffer_update (\<lambda>_. buf) tcb) s)"
   by (simp add: valid_tcb'_def tcb_cte_cases_def)
 
-lemma tc_corres:
+lemma transferCaps_corres:
   assumes x: "newroot_rel e e'"
   assumes y: "newroot_rel f f'"
   assumes z: "(case g of None \<Rightarrow> g' = None
@@ -1335,12 +1335,12 @@ proof -
   have S: "\<And>t x. corres dc (einvs and tcb_at t) (invs' and tcb_at' t and valid_objs' and K (valid_option_prio p_auth))
                    (case_option (return ()) (\<lambda>(p, auth). set_priority t p) p_auth)
                    (case_option (return ()) (\<lambda>p'. setPriority t (fst p')) p_auth)"
-    apply (case_tac p_auth; clarsimp simp: sp_corres)
+    apply (case_tac p_auth; clarsimp simp: setPriority_corres)
     done
   have S': "\<And>t x. corres dc (tcb_at t) (tcb_at' t)
                     (case_option (return ()) (\<lambda>(mcp, auth). set_mcpriority t mcp) mcp_auth)
                     (case_option (return ()) (\<lambda>mcp'. setMCPriority t (fst mcp')) mcp_auth)"
-    apply(case_tac mcp_auth; clarsimp simp: smcp_corres)
+    apply(case_tac mcp_auth; clarsimp simp: setMCPriority_corres)
     done
   have T: "\<And>x x' ref getfn target.
       \<lbrakk> newroot_rel x x'; getfn = return (cte_map (target, ref));
@@ -1377,9 +1377,9 @@ proof -
     apply (clarsimp simp add: newroot_rel_def returnOk_def split_def)
     apply (rule corres_gen_asm)
     apply (rule corres_guard_imp)
-      apply (rule corres_split_norE [OF _ cap_delete_corres])
+      apply (rule corres_split_norE [OF _ cteDelete_corres])
         apply (simp del: dc_simp)
-        apply (erule checked_insert_corres)
+        apply (erule checkCapAt_cteInsert_corres)
        apply (fold validE_R_def)
        apply (wp cap_delete_deletes cap_delete_cte_at cap_delete_valid_cap
                     | strengthen use_no_cap_to_obj_asid_strg)+
@@ -1455,7 +1455,7 @@ proof -
          apply (rule corres_split_norE)
             apply (rule_tac F="is_aligned aa msg_align_bits" in corres_gen_asm2)
             apply (rule corres_split_nor)
-               apply (rule corres_split_deprecated [OF _ gct_corres], clarsimp)
+               apply (rule corres_split_deprecated [OF _ getCurThread_corres], clarsimp)
                  apply (rule corres_when[OF refl rescheduleRequired_corres])
                 apply (wpsimp wp: gct_wp)+
               apply (rule threadset_corres,
@@ -1465,22 +1465,22 @@ proof -
             apply simp
             apply (wp hoare_drop_imp)
             apply (wp threadcontrol_corres_helper2 | wpc | simp)+
-           apply (rule cap_delete_corres)
+           apply (rule cteDelete_corres)
           apply wp
          apply (wpsimp wp: cteDelete_invs' hoare_vcg_conj_lift)
         apply (fastforce simp: emptyable_def)
        apply fastforce
       apply clarsimp
       apply (rule corres_guard_imp)
-        apply (rule corres_split_norE [OF _ cap_delete_corres])
+        apply (rule corres_split_norE [OF _ cteDelete_corres])
           apply (rule_tac F="is_aligned aa msg_align_bits" in corres_gen_asm)
           apply (rule_tac F="isArchObjectCap ac" in corres_gen_asm2)
           apply (rule corres_split_nor)
              apply (rule corres_split_nor)
-                apply (rule corres_split_deprecated [OF _ gct_corres], clarsimp)
+                apply (rule corres_split_deprecated [OF _ getCurThread_corres], clarsimp)
                   apply (rule corres_when[OF refl rescheduleRequired_corres])
                  apply (wp gct_wp)+
-               apply (erule checked_insert_corres)
+               apply (erule checkCapAt_cteInsert_corres)
               apply (wp hoare_drop_imp threadcontrol_corres_helper3)[1]
              apply (wp hoare_drop_imp threadcontrol_corres_helper4)[1]
             apply (rule threadset_corres,
@@ -1815,21 +1815,21 @@ where
 | "tcb_inv_wf' (tcbinvocation.SetTLSBase ref w)
              = (tcb_at' ref and ex_nonz_cap_to' ref)"
 
-lemma tcbinv_corres:
+lemma invokeTCB_corres:
  "tcbinv_relation ti ti' \<Longrightarrow>
   corres (dc \<oplus> (=))
          (einvs and simple_sched_action and Tcb_AI.tcb_inv_wf ti)
          (invs' and sch_act_simple and tcb_inv_wf' ti')
          (invoke_tcb ti) (invokeTCB ti')"
   apply (case_tac ti, simp_all only: tcbinv_relation.simps valid_tcb_invocation_def)
-         apply (rule corres_guard_imp [OF writereg_corres], simp+)[1]
-        apply (rule corres_guard_imp [OF readreg_corres], simp+)[1]
-       apply (rule corres_guard_imp [OF copyreg_corres], simp+)[1]
+         apply (rule corres_guard_imp [OF invokeTCB_WriteRegisters_corres], simp+)[1]
+        apply (rule corres_guard_imp [OF invokeTCB_ReadRegisters_corres], simp+)[1]
+       apply (rule corres_guard_imp [OF invokeTCB_CopyRegisters_corres], simp+)[1]
       apply (clarsimp simp del: invoke_tcb.simps)
       apply (rename_tac word one t2 mcp t3 t4 t5 t6 t7 t8 t9 t10 t11)
       apply (rule_tac F="is_aligned word 5" in corres_req)
        apply (clarsimp simp add: is_aligned_weaken [OF tcb_aligned])
-      apply (rule corres_guard_imp [OF tc_corres], clarsimp+)
+      apply (rule corres_guard_imp [OF transferCaps_corres], clarsimp+)
        apply (clarsimp simp: is_cnode_or_valid_arch_def
                       split: option.split option.split_asm)
       apply clarsimp
@@ -1845,14 +1845,14 @@ lemma tcbinv_corres:
    apply (case_tac option)
     apply simp
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated[OF _ unbind_notification_corres])
+      apply (rule corres_split_deprecated[OF _ unbindNotification_corres])
         apply (rule corres_trivial, simp)
        apply wp+
      apply (clarsimp)
     apply clarsimp
    apply simp
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated[OF _ bind_notification_corres])
+     apply (rule corres_split_deprecated[OF _ bindNotification_corres])
        apply (rule corres_trivial, simp)
       apply wp+
     apply clarsimp
@@ -1860,8 +1860,8 @@ lemma tcbinv_corres:
    apply (clarsimp simp: obj_at'_def projectKOs)
   apply (simp add: invokeTCB_def tlsBaseRegister_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ TcbAcc_R.user_setreg_corres])
-      apply (rule corres_split_deprecated[OF _ Bits_R.gct_corres])
+    apply (rule corres_split_deprecated[OF _ TcbAcc_R.asUser_setRegister_corres])
+      apply (rule corres_split_deprecated[OF _ Bits_R.getCurThread_corres])
         apply (rule corres_split_deprecated[OF _ Corres_UL.corres_when])
             apply (rule corres_trivial, simp)
            apply simp
@@ -1960,7 +1960,7 @@ lemma copyregsets_map_only[simp]:
   "copyregsets_map v = ARMNoExtraRegisters"
   by (cases "copyregsets_map v", simp)
 
-lemma decode_readreg_corres:
+lemma decodeReadRegisters_corres:
   "corres (ser \<oplus> tcbinv_relation) (invs and tcb_at t) (invs' and tcb_at' t)
      (decode_read_registers args (cap.ThreadCap t))
      (decodeReadRegisters args (ThreadCap t))"
@@ -1976,13 +1976,13 @@ lemma decode_readreg_corres:
        apply (rule corres_trivial)
        apply (fastforce simp: returnOk_def)
       apply (simp add: liftE_bindE)
-      apply (rule corres_split_deprecated[OF _ gct_corres])
+      apply (rule corres_split_deprecated[OF _ getCurThread_corres])
         apply (rule corres_trivial)
         apply (clarsimp simp: whenE_def)
        apply (wp|simp)+
   done
 
-lemma decode_writereg_corres:
+lemma decodeWriteRegisters_corres:
   notes if_cong [cong]
   shows
   "\<lbrakk> length args < 2 ^ word_bits \<rbrakk> \<Longrightarrow>
@@ -1999,7 +1999,7 @@ lemma decode_writereg_corres:
   apply clarsimp
   apply (rule corres_guard_imp)
     apply (simp add: liftE_bindE)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply (rule corres_split_norE)
          apply (rule corres_trivial, simp)
         apply (rule corres_trivial, simp)
@@ -2007,7 +2007,7 @@ lemma decode_writereg_corres:
    apply simp+
   done
 
-lemma decode_copyreg_corres:
+lemma decodeCopyRegisters_corres:
   "\<lbrakk> list_all2 cap_relation extras extras'; length args < 2 ^ word_bits \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation) (invs and tcb_at t) (invs' and tcb_at' t)
      (decode_copy_registers args (cap.ThreadCap t) extras)
@@ -2066,13 +2066,13 @@ lemma eq_ucast_word8[simp]:
                    source_size_def target_size_def word_size)
   done
 
-lemma check_prio_corres:
+lemma checkPrio_corres:
   "corres (ser \<oplus> dc) (tcb_at auth) (tcb_at' auth)
      (check_prio p auth) (checkPrio p auth)"
   apply (simp add: check_prio_def checkPrio_def)
   apply (rule corres_guard_imp)
     apply (simp add: liftE_bindE)
-    apply (rule corres_split_deprecated[OF _ threadget_corres])
+    apply (rule corres_split_deprecated[OF _ threadGet_corres])
        apply (rule_tac rvr = dc and
                          R = \<top> and
                         R' = \<top> in
@@ -2086,7 +2086,7 @@ lemma check_prio_corres:
    apply (simp add: cur_tcb_def cur_tcb'_def)+
   done
 
-lemma decode_set_priority_corres:
+lemma decodeSetPriority_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
@@ -2098,14 +2098,14 @@ lemma decode_set_priority_corres:
          clarsimp simp: decode_set_priority_def decodeSetPriority_def)
   apply (rename_tac auth_cap auth_slot auth_path rest auth_cap' rest')
   apply (rule corres_split_eqrE)
-     apply (rule corres_splitEE[OF _ check_prio_corres])
+     apply (rule corres_splitEE[OF _ checkPrio_corres])
        apply (rule corres_returnOkTT)
        apply (clarsimp simp: newroot_rel_def elim!: is_thread_cap.elims(2))
       apply wpsimp+
     apply (corressimp simp: valid_cap_def valid_cap'_def)+
   done
 
-lemma decode_set_mcpriority_corres:
+lemma decodeSetMCPriority_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
@@ -2117,7 +2117,7 @@ lemma decode_set_mcpriority_corres:
          clarsimp simp: decode_set_mcpriority_def decodeSetMCPriority_def)
   apply (rename_tac auth_cap auth_slot auth_path rest auth_cap' rest')
   apply (rule corres_split_eqrE)
-     apply (rule corres_splitEE[OF _ check_prio_corres])
+     apply (rule corres_splitEE[OF _ checkPrio_corres])
        apply (rule corres_returnOkTT)
        apply (clarsimp simp: newroot_rel_def elim!: is_thread_cap.elims(2))
       apply wpsimp+
@@ -2214,7 +2214,7 @@ lemma decodeSetSchedParams_wf[wp]:
          simp)
   done
 
-lemma decode_set_sched_params_corres:
+lemma decodeSetSchedParams_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
@@ -2229,15 +2229,15 @@ lemma decode_set_sched_params_corres:
    apply (clarsimp split: list.split simp: list_all2_Cons2)
   apply (clarsimp simp: list_all2_Cons1 neq_Nil_conv val_le_length_Cons linorder_not_less)
   apply (rule corres_split_eqrE)
-     apply (rule corres_split_norE[OF _ check_prio_corres])
-       apply (rule corres_splitEE[OF _ check_prio_corres])
+     apply (rule corres_split_norE[OF _ checkPrio_corres])
+       apply (rule corres_splitEE[OF _ checkPrio_corres])
          apply (rule corres_returnOkTT)
          apply (clarsimp simp: newroot_rel_def elim!: is_thread_cap.elims(2))
         apply (wpsimp wp: check_prio_inv checkPrio_inv)+
     apply (corressimp simp: valid_cap_def valid_cap'_def)+
   done
 
-lemma check_valid_ipc_corres:
+lemma checkValidIPCBuffer_corres:
   "cap_relation cap cap' \<Longrightarrow>
    corres (ser \<oplus> dc) \<top> \<top>
      (check_valid_ipc_buffer vptr cap)
@@ -2270,7 +2270,7 @@ lemma checkValidIPCBuffer_ArchObject_wp:
     | wpc | clarsimp simp: isCap_simps is_aligned_mask msg_align_bits msgAlignBits_def)+
   done
 
-lemma decode_set_ipc_corres:
+lemma decodeSetIPCBuffer_corres:
   notes if_cong [cong]
   shows
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
@@ -2290,9 +2290,9 @@ lemma decode_set_ipc_corres:
              split del: if_split)
   apply (clarsimp simp add: returnOk_def newroot_rel_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_splitEE [OF _ derive_cap_corres])
+    apply (rule corres_splitEE [OF _ deriveCap_corres])
         apply (simp add: o_def newroot_rel_def split_def dc_def[symmetric])
-        apply (erule check_valid_ipc_corres)
+        apply (erule checkValidIPCBuffer_corres)
        apply (wp hoareE_TrueI | simp)+
   apply fastforce
   done
@@ -2326,7 +2326,7 @@ lemma decodeSetIPCBuffer_is_tc[wp]:
 crunch inv[wp]: decodeSetIPCBuffer "P"
   (simp: crunch_simps)
 
-lemma slot_long_running_corres:
+lemma slotCapLongRunningDelete_corres:
   "cte_map ptr = ptr' \<Longrightarrow>
    corres (=) (cte_at ptr and invs) invs'
            (slot_cap_long_running_delete ptr)
@@ -2336,7 +2336,7 @@ lemma slot_long_running_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ get_cap_corres])
       apply (auto split: cap_relation_split_asm arch_cap.split_asm
-                 intro!: corres_rel_imp [OF final_cap_corres[where ptr=ptr]]
+                 intro!: corres_rel_imp [OF isFinalCapability_corres[where ptr=ptr]]
                    simp: liftM_def[symmetric] final_matters'_def
                          long_running_delete_def
                          longRunningDelete_def isCap_simps)[1]
@@ -2359,7 +2359,7 @@ lemma cap_CNode_case_throw:
      = (doE unlessE (isCNodeCap cap) (throw x); m odE)"
   by (cases cap, simp_all add: isCap_simps unlessE_def)
 
-lemma decode_set_space_corres:
+lemma decodeSetSpace_corres:
   notes if_cong [cong]
   shows
  "\<lbrakk> cap_relation cap cap'; list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras';
@@ -2379,15 +2379,15 @@ lemma decode_set_space_corres:
                     getThreadCSpaceRoot getThreadVSpaceRoot
                  split del: if_split)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated [OF _ slot_long_running_corres])
-        apply (rule corres_split_deprecated [OF _ slot_long_running_corres])
+     apply (rule corres_split_deprecated [OF _ slotCapLongRunningDelete_corres])
+        apply (rule corres_split_deprecated [OF _ slotCapLongRunningDelete_corres])
            apply (rule corres_split_norE)
               apply (simp(no_asm) add: split_def unlessE_throwError_returnOk
                                        bindE_assoc cap_CNode_case_throw
                             split del: if_split)
-              apply (rule corres_splitEE [OF _ derive_cap_corres])
+              apply (rule corres_splitEE [OF _ deriveCap_corres])
                   apply (rule corres_split_norE)
-                     apply (rule corres_splitEE [OF _ derive_cap_corres])
+                     apply (rule corres_splitEE [OF _ deriveCap_corres])
                          apply (rule corres_split_norE)
                             apply (rule corres_trivial)
                             apply (clarsimp simp: returnOk_def newroot_rel_def is_cap_simps
@@ -2497,7 +2497,7 @@ lemma decodeSetSpace_tc_slot[wp]:
   apply simp
   done
 
-lemma decode_tcb_conf_corres:
+lemma decodeTCBConfigure_corres:
   notes if_cong [cong] option.case_cong [cong]
   shows
  "\<lbrakk> cap_relation cap cap'; list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras';
@@ -2514,8 +2514,8 @@ lemma decode_tcb_conf_corres:
   apply (clarsimp simp: linorder_not_less val_le_length_Cons list_all2_Cons1
       priorityBits_def)
   apply (rule corres_guard_imp)
-  apply (rule corres_splitEE [OF _ decode_set_ipc_corres])
-         apply (rule corres_splitEE [OF _ decode_set_space_corres])
+  apply (rule corres_splitEE [OF _ decodeSetIPCBuffer_corres])
+         apply (rule corres_splitEE [OF _ decodeSetSpace_corres])
               apply (rule_tac F="is_thread_control set_params" in corres_gen_asm)
               apply (rule_tac F="is_thread_control set_space" in corres_gen_asm)
   apply (rule_tac F="tcThreadCapSlot setSpace = cte_map slot" in corres_gen_asm2)
@@ -2585,7 +2585,7 @@ lemma corres_splitEE':
    apply (clarsimp simp: lift_def y)+
   done
 
-lemma decode_bind_notification_corres:
+lemma decodeBindNotification_corres:
 notes if_cong[cong] shows
   "\<lbrakk> list_all2 (\<lambda>x y. cap_relation (fst x) (fst y)) extras extras' \<rbrakk> \<Longrightarrow>
     corres (ser \<oplus> tcbinv_relation)
@@ -2609,7 +2609,7 @@ notes if_cong[cong] shows
                                 split: Structures_A.ntfn.splits Structures_H.ntfn.splits
                                        option.splits)
                      apply simp
-                     apply (rule get_ntfn_corres)
+                     apply (rule getNotification_corres)
                     apply wp+
                   apply (rule corres_trivial, clarsimp simp: whenE_def returnOk_def)
                  apply (wp | simp add: whenE_def split del: if_split)+
@@ -2619,7 +2619,7 @@ notes if_cong[cong] shows
               apply (wp | wpc | simp)+
             apply (rule corres_trivial, simp split: option.splits add: returnOk_def)
            apply (wp | wpc | simp)+
-         apply (rule gbn_corres)
+         apply (rule getBoundNotification_corres)
         apply (simp | wp gbn_wp gbn_wp')+
       apply (rule corres_trivial)
       apply (auto simp: returnOk_def whenE_def)[1]
@@ -2627,7 +2627,7 @@ notes if_cong[cong] shows
    apply (fastforce simp: valid_cap_def valid_cap'_def dest: hd_in_set)+
   done
 
-lemma decode_unbind_notification_corres:
+lemma decodeUnbindNotification_corres:
   "corres (ser \<oplus> tcbinv_relation)
       (tcb_at t)
       (tcb_at' t)
@@ -2640,12 +2640,12 @@ lemma decode_unbind_notification_corres:
        apply (simp split: option.splits)
        apply (simp add: returnOk_def)
       apply simp
-      apply (rule gbn_corres)
+      apply (rule getBoundNotification_corres)
      apply wp+
    apply auto
   done
 
-lemma decode_set_tls_base_corres:
+lemma decodeSetTLSBase_corres:
   "corres (ser \<oplus> tcbinv_relation) (tcb_at t) (tcb_at' t)
           (decode_set_tls_base w (cap.ThreadCap t))
           (decodeSetTLSBase w (capability.ThreadCap t))"
@@ -2653,7 +2653,7 @@ lemma decode_set_tls_base_corres:
                  split: list.split)
   by (rule sym, rule ucast_id)
 
-lemma decode_tcb_inv_corres:
+lemma decodeTCBInvocation_corres:
  "\<lbrakk> c = Structures_A.ThreadCap t; cap_relation c c';
       list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras';
       length args < 2 ^ word_bits \<rbrakk> \<Longrightarrow>
@@ -2669,18 +2669,18 @@ lemma decode_tcb_inv_corres:
              split del: if_split split: gen_invocation_labels.split)
   apply (simp add: returnOk_def)
   apply (intro conjI impI
-             corres_guard_imp[OF decode_readreg_corres]
-             corres_guard_imp[OF decode_writereg_corres]
-             corres_guard_imp[OF decode_copyreg_corres]
-             corres_guard_imp[OF decode_tcb_conf_corres]
-             corres_guard_imp[OF decode_set_priority_corres]
-             corres_guard_imp[OF decode_set_mcpriority_corres]
-             corres_guard_imp[OF decode_set_sched_params_corres]
-             corres_guard_imp[OF decode_set_ipc_corres]
-             corres_guard_imp[OF decode_set_space_corres]
-             corres_guard_imp[OF decode_bind_notification_corres]
-             corres_guard_imp[OF decode_unbind_notification_corres]
-             corres_guard_imp[OF decode_set_tls_base_corres],
+             corres_guard_imp[OF decodeReadRegisters_corres]
+             corres_guard_imp[OF decodeWriteRegisters_corres]
+             corres_guard_imp[OF decodeCopyRegisters_corres]
+             corres_guard_imp[OF decodeTCBConfigure_corres]
+             corres_guard_imp[OF decodeSetPriority_corres]
+             corres_guard_imp[OF decodeSetMCPriority_corres]
+             corres_guard_imp[OF decodeSetSchedParams_corres]
+             corres_guard_imp[OF decodeSetIPCBuffer_corres]
+             corres_guard_imp[OF decodeSetSpace_corres]
+             corres_guard_imp[OF decodeBindNotification_corres]
+             corres_guard_imp[OF decodeUnbindNotification_corres]
+             corres_guard_imp[OF decodeSetTLSBase_corres],
          simp_all add: valid_cap_simps valid_cap_simps' invs_def valid_sched_def)
   apply (auto simp: list_all2_map1 list_all2_map2
              elim!: list_all2_mono)

--- a/proof/refine/ARM/Untyped_R.thy
+++ b/proof/refine/ARM/Untyped_R.thy
@@ -91,7 +91,7 @@ lemma corres_check_no_children:
      apply (rule corres_guard_imp[OF corres_splitEE])
          apply (rule corres_returnOkTT)
          apply simp
-        apply (rule ensure_no_children_corres)
+        apply (rule ensureNoChildren_corres)
         apply simp
        apply wp+
       apply simp+
@@ -139,7 +139,7 @@ lemma corres_whenE_throw_merge:
   \<Longrightarrow> corres r P P' f (doE _ \<leftarrow> whenE A (throwError e); _ \<leftarrow>  whenE B (throwError e); h odE)"
   by (auto simp: whenE_def split: if_splits)
 
-lemma dec_untyped_inv_corres:
+lemma decodeUntypedInvocation_corres:
   assumes cap_rel: "list_all2 cap_relation cs cs'"
   shows "corres
         (ser \<oplus> untypinv_relation)
@@ -367,7 +367,7 @@ next
                   apply (rule_tac P = "valid_cap (cap.CNodeCap r bits g) and invs" in corres_guard_imp [where P' = invs'])
                     apply (rule mapME_x_corres_inv [OF _ _ _ refl])
                       apply (simp del: ser_def)
-                      apply (rule ensure_empty_corres)
+                      apply (rule ensureEmptySlot_corres)
                       apply (clarsimp simp: is_cap_simps)
                      apply (simp, wp)
                     apply (simp, wp)
@@ -391,7 +391,7 @@ next
            apply (rule corres_returnOkTT)
            apply (rule crel)
           apply simp
-          apply (rule corres_splitEE[OF _ lsfc_corres])
+          apply (rule corres_splitEE[OF _ lookupSlotForCNodeOp_corres])
               apply simp
               apply (rule getSlotCap_corres,simp)
              apply (rule crel)
@@ -1386,7 +1386,7 @@ crunches create_cap_ext
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma clearUntypedFreeIndex_corres_noop_psp:
+lemma updateNewFreeIndex_noop_psp_corres:
   "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False True
     dc \<top> (cte_at' slot)
     (return ()) (updateNewFreeIndex slot)"
@@ -1399,7 +1399,7 @@ lemma clearUntypedFreeIndex_corres_noop_psp:
         | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
   done
 
-lemma create_cap_corres:
+lemma insertNewCap_corres:
 notes if_cong[cong del] if_weak_cong[cong]
 shows
   "\<lbrakk> cref' = cte_map (fst tup)
@@ -1518,7 +1518,7 @@ shows
          apply (rule corres_underlying_symb_exec_l [OF set_original_symb_exec_l])
           apply (rule corres_cong[OF refl refl _ refl refl, THEN iffD1])
            apply (rule bind_return[THEN fun_cong])
-          apply (rule corres_split_deprecated [OF _ set_cap_pspace_corres])
+          apply (rule corres_split_deprecated [OF _ setCTE_corres])
              apply (subst bind_return[symmetric],
                     rule corres_split_deprecated)
                 prefer 2
@@ -1526,7 +1526,7 @@ shows
                 apply (rule updateMDB_symb_exec_r)
                apply (simp add: dc_def[symmetric])
                apply (rule corres_split_noop_rhs[OF _ updateMDB_symb_exec_r])
-                apply (rule clearUntypedFreeIndex_corres_noop_psp)
+                apply (rule updateNewFreeIndex_noop_psp_corres)
                apply (wp getCTE_wp set_cdt_valid_objs set_cdt_cte_at
                          hoare_weak_lift_imp | simp add: o_def)+
     apply (clarsimp simp: cte_wp_at_cte_at)
@@ -2848,7 +2848,7 @@ lemma inv_untyped_corres_helper1:
   apply (fold mapM_x_def)
   apply (rule corres_list_all2_mapM_)
      apply (rule corres_guard_imp)
-       apply (erule create_cap_corres)
+       apply (erule insertNewCap_corres)
       apply (clarsimp simp: cte_wp_at_def is_cap_simps)
      apply (clarsimp simp: fun_upd_def cte_wp_at_ctes_of)
     apply clarsimp
@@ -3791,7 +3791,7 @@ lemma descendants_range_ex_cte':
   apply blast
   done
 
-lemma update_untyped_cap_corres:
+lemma updateCap_isUntypedCap_corres:
   "\<lbrakk>is_untyped_cap cap; isUntypedCap cap'; cap_relation cap cap'\<rbrakk>
    \<Longrightarrow> corres dc
          (cte_wp_at (\<lambda>c. is_untyped_cap c \<and> obj_ref_of c = obj_ref_of cap \<and>
@@ -3817,7 +3817,7 @@ lemma update_untyped_cap_corres:
        apply (rule_tac F = " (cap.UntypedCap dev r bits f) = free_index_update (\<lambda>_. f) c"
                       in corres_gen_asm)
        apply simp
-       apply (rule set_untyped_cap_corres)
+       apply (rule setCTE_UntypedCap_corres)
          apply ((clarsimp simp: cte_wp_at_caps_of_state cte_wp_at_ctes_of)+)[3]
       apply (subst identity_eq)
       apply (wp getCTE_sp getCTE_get no_fail_getCTE)+
@@ -3842,7 +3842,7 @@ lemma updateFreeIndex_corres:
           apply (rule_tac F="isUntypedCap capa
                  \<and> cap_relation cap (capFreeIndex_update (\<lambda>_. idx) capa)"
                in corres_gen_asm2)
-          apply (rule update_untyped_cap_corres, simp+)
+          apply (rule updateCap_isUntypedCap_corres, simp+)
            apply (clarsimp simp: isCap_simps)
           apply simp
          apply (wp getSlotCap_wp)+
@@ -4186,7 +4186,7 @@ lemma ex_tupI:
 context begin interpretation Arch . (*FIXME: arch_split*)
 (* mostly stuff about PPtr/fromPPtr, which seems pretty soft *)
 
-lemma reset_untyped_cap_corres:
+lemma resetUntypedCap_corres:
   "untypinv_relation ui ui'
     \<Longrightarrow> corres (dc \<oplus> dc)
     (invs and valid_untyped_inv_wcap ui
@@ -4209,7 +4209,7 @@ lemma reset_untyped_cap_corres:
        apply (rule corres_if[OF refl])
         apply (rule corres_returnOk[where P=\<top> and P'=\<top>], simp)
        apply (simp add: liftE_bindE bits_of_def split del: if_split)
-       apply (rule corres_split_deprecated[OF _ detype_corres])
+       apply (rule corres_split_deprecated[OF _ deleteObjects_corres])
            apply (rule corres_if)
              apply (simp add: reset_chunk_bits_def resetChunkBits_def)
             apply (simp add: bits_of_def shiftL_nat)
@@ -4239,7 +4239,7 @@ lemma reset_untyped_cap_corres:
               apply (rule corres_guard_imp)
                 apply (rule corres_split_nor)
                    apply (rule corres_split_nor[OF _ updateFreeIndex_corres])
-                       apply (rule preemption_corres)
+                       apply (rule preemptionPoint_corres)
                       apply simp
                      apply (simp add: getFreeRef_def getFreeIndex_def
                                       free_index_of_def)
@@ -4845,7 +4845,7 @@ lemma inv_untyped_corres':
         apply (rule corres_split_norE)
            prefer 2
            apply (rule corres_whenE, simp)
-            apply (rule reset_untyped_cap_corres[where ui=ui and ui'=ui'])
+            apply (rule resetUntypedCap_corres[where ui=ui and ui'=ui'])
             apply (simp add: ui ui')
            apply simp
           apply simp

--- a/proof/refine/ARM/VSpace_R.thy
+++ b/proof/refine/ARM/VSpace_R.thy
@@ -172,7 +172,7 @@ lemma asidBits_asid_bits[simp]:
   by (simp add: asid_bits_def asidBits_def
                 asidHighBits_def asid_low_bits_def)
 
-lemma find_pd_for_asid_assert_corres:
+lemma findPDForASIDAssert_corres:
   "corres (\<lambda>rv rv'. rv = pd \<and> rv' = pd)
            (K (asid \<noteq> 0 \<and> asid \<le> mask asid_bits)
                  and pspace_aligned and pspace_distinct
@@ -257,14 +257,14 @@ lemma findPDForASIDAssert_known_corres:
    apply clarsimp
    apply (erule(3) find_pd_for_asid_assert_eq[symmetric])
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ find_pd_for_asid_assert_corres[where pd=pd]])
+    apply (rule corres_split_deprecated [OF _ findPDForASIDAssert_corres[where pd=pd]])
       apply simp
      apply wp+
    apply clarsimp
   apply simp
   done
 
-lemma load_hw_asid_corres:
+lemma loadHWASID_corres:
   "corres (=)
           (valid_vspace_objs and pspace_distinct
                  and pspace_aligned and valid_asid_map
@@ -297,7 +297,7 @@ lemma load_hw_asid_corres:
 crunch inv[wp]: loadHWASID "P"
   (wp: crunch_wps)
 
-lemma store_hw_asid_corres:
+lemma storeHWASID_corres:
   "corres dc
           (vspace_at_asid a pd and pd_at_uniq a pd
                   and valid_vspace_objs and pspace_distinct
@@ -307,7 +307,7 @@ lemma store_hw_asid_corres:
           (store_hw_asid a h) (storeHWASID a h)"
   apply (simp add: store_hw_asid_def storeHWASID_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ find_pd_for_asid_assert_corres[where pd=pd]])
+    apply (rule corres_split_deprecated [OF _ findPDForASIDAssert_corres[where pd=pd]])
       apply (rule corres_split_eqr)
          apply (rule corres_split_deprecated)
             prefer 2
@@ -329,7 +329,7 @@ lemma store_hw_asid_corres:
        apply (wp | simp)+
   done
 
-lemma invalidate_asid_corres:
+lemma invalidateASID_corres:
   "corres dc
           (valid_asid_map and valid_vspace_objs
                and pspace_aligned and pspace_distinct
@@ -359,12 +359,12 @@ lemma invalidate_asid_ext_corres:
                \<and> a \<noteq> 0 \<and> a \<le> mask asid_bits)
           (pspace_aligned' and pspace_distinct' and no_0_obj')
      (invalidate_asid a) (invalidateASID a)"
-  apply (insert invalidate_asid_corres)
+  apply (insert invalidateASID_corres)
   apply (clarsimp simp: corres_underlying_def)
   apply fastforce
   done
 
-lemma invalidate_hw_asid_entry_corres:
+lemma invalidateHWASIDEntry_corres:
   "corres dc \<top> \<top> (invalidate_hw_asid_entry a) (invalidateHWASIDEntry a)"
   apply (simp add: invalidate_hw_asid_entry_def invalidateHWASIDEntry_def)
   apply (rule corres_guard_imp)
@@ -377,7 +377,7 @@ lemma invalidate_hw_asid_entry_corres:
   apply simp
   done
 
-lemma find_free_hw_asid_corres:
+lemma findFreeHWASID_corres:
   "corres (=)
           (valid_asid_map and valid_vspace_objs
               and pspace_aligned and pspace_distinct
@@ -406,7 +406,7 @@ lemma find_free_hw_asid_corres:
                  apply fastforce
                 apply (rule corres_split_deprecated)
                    prefer 2
-                   apply (rule invalidate_hw_asid_entry_corres)
+                   apply (rule invalidateHWASIDEntry_corres)
                   apply (rule corres_split_deprecated)
                      apply (rule corres_trivial)
                      apply simp
@@ -445,7 +445,7 @@ crunch distinct'[wp]: findFreeHWASID "pspace_distinct'"
 crunch no_0_obj'[wp]: getHWASID "no_0_obj'"
 
 
-lemma get_hw_asid_corres:
+lemma getHWASID_corres:
   "corres (=)
           (vspace_at_asid a pd and K (a \<noteq> 0 \<and> a \<le> mask asid_bits)
            and unique_table_refs o caps_of_state
@@ -457,11 +457,11 @@ lemma get_hw_asid_corres:
           (get_hw_asid a) (getHWASID a)"
   apply (simp add: get_hw_asid_def getHWASID_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ load_hw_asid_corres[where pd=pd]])
+    apply (rule corres_split_eqr [OF _ loadHWASID_corres[where pd=pd]])
       apply (case_tac maybe_hw_asid, simp_all)[1]
       apply clarsimp
-      apply (rule corres_split_eqr [OF _ find_free_hw_asid_corres])
-         apply (rule corres_split_deprecated [OF _ store_hw_asid_corres[where pd=pd]])
+      apply (rule corres_split_eqr [OF _ findFreeHWASID_corres])
+         apply (rule corres_split_deprecated [OF _ storeHWASID_corres[where pd=pd]])
            apply (rule corres_trivial, simp )
           apply (wpsimp wp: load_hw_asid_wp)+
    apply (simp add: pd_at_asid_uniq)
@@ -473,7 +473,7 @@ lemma setCurrentPD_to_abs:
   by (rule ext)
      (clarsimp simp: set_current_pd_def setCurrentPD_def writeTTBR0Ptr_def fromPAddr_def)
 
-lemma arm_context_switch_corres:
+lemma armv_contextSwitch_corres:
   "corres dc
           (vspace_at_asid a pd and K (a \<noteq> 0 \<and> a \<le> mask asid_bits)
            and unique_table_refs o caps_of_state
@@ -485,7 +485,7 @@ lemma arm_context_switch_corres:
           (arm_context_switch pd a) (armv_contextSwitch pd a)"
   apply (simp add: arm_context_switch_def armv_contextSwitch_def armv_contextSwitch_HWASID_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ get_hw_asid_corres[where pd=pd]])
+    apply (rule corres_split_eqr [OF _ getHWASID_corres[where pd=pd]])
       apply (rule corres_machine_op)
       apply (simp add: setCurrentPD_to_abs)
       apply (rule corres_rel_imp)
@@ -495,7 +495,7 @@ lemma arm_context_switch_corres:
                       simp: setCurrentPD_to_abs)+
   done
 
-lemma hv_corres:
+lemma handleVMFault_corres:
   "corres (fr \<oplus> dc) (tcb_at thread) (tcb_at' thread)
           (handle_vm_fault thread fault) (handleVMFault thread fault)"
   apply (simp add: ARM_H.handleVMFault_def)
@@ -521,7 +521,7 @@ lemma hv_corres:
     apply (rule corres_splitEE)
        prefer 2
        apply simp
-       apply (rule corres_as_user')
+       apply (rule asUser_corres')
        apply (rule corres_no_failI [where R="(=)"])
         apply (rule no_fail_getRestartPC)
        apply fastforce
@@ -536,7 +536,7 @@ lemma hv_corres:
    apply simp+
   done
 
-lemma flush_space_corres:
+lemma flushSpace_corres:
   "corres dc
           (K (asid \<le> mask asid_bits \<and> asid \<noteq> 0)
            and valid_asid_map and valid_vspace_objs
@@ -550,7 +550,7 @@ lemma flush_space_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated)
        prefer 2
-       apply (rule load_hw_asid_corres[where pd=pd])
+       apply (rule loadHWASID_corres[where pd=pd])
       apply (rule corres_split_deprecated [where R="\<lambda>_. \<top>" and R'="\<lambda>_. \<top>"])
          prefer 2
          apply (rule corres_machine_op [where r=dc])
@@ -568,7 +568,7 @@ lemma flush_space_corres:
   apply simp
   done
 
-lemma invalidate_tlb_by_asid_corres:
+lemma invalidateTLBByASID_corres:
   "corres dc
           (K (asid \<le> mask asid_bits \<and> asid \<noteq> 0)
            and valid_asid_map and valid_vspace_objs
@@ -582,7 +582,7 @@ lemma invalidate_tlb_by_asid_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated [where R="\<lambda>_. \<top>" and R'="\<lambda>_. \<top>"])
        prefer 2
-       apply (rule load_hw_asid_corres[where pd=pd])
+       apply (rule loadHWASID_corres[where pd=pd])
       apply (case_tac maybe_hw_asid)
        apply simp
       apply clarsimp
@@ -607,7 +607,7 @@ lemma invalidate_tlb_by_asid_corres_ex:
           (invalidate_tlb_by_asid asid) (invalidateTLBByASID asid)"
   apply (rule corres_name_pre, clarsimp)
   apply (rule corres_guard_imp)
-    apply (rule_tac pd=pd in invalidate_tlb_by_asid_corres)
+    apply (rule_tac pd=pd in invalidateTLBByASID_corres)
    apply simp+
   done
 
@@ -654,7 +654,7 @@ lemma setCurrentPD_corres:
                 | simp add: dc_def)+
   done
 
-lemma set_vm_root_corres:
+lemma setVMRoot_corres:
   "corres dc (tcb_at t and valid_arch_state and valid_objs and valid_asid_map
               and unique_table_refs o caps_of_state and valid_vs_lookup
               and valid_global_objs and pspace_aligned and pspace_distinct
@@ -739,7 +739,7 @@ proof -
                    apply (simp add: lookup_failure_map_def)
                   apply simp
                  apply simp
-                 apply (rule arm_context_switch_corres)
+                 apply (rule armv_contextSwitch_corres)
                 apply ((wp find_pd_for_asid_pd_at_asid_again
                   | simp add: if_apply_def2 | wp (once) hoare_drop_imps)+)
             apply clarsimp
@@ -776,7 +776,7 @@ lemma get_asid_pool_corres_inv':
           (asid_pool_at p) (pspace_aligned' and pspace_distinct')
           (get_asid_pool p) (getObject p)"
   apply (rule corres_rel_imp)
-   apply (rule get_asid_pool_corres')
+   apply (rule getObject_ASIDPool_corres')
   apply simp
   done
 
@@ -789,7 +789,7 @@ lemma loadHWASID_wp [wp]:
   apply (auto split: option.split)
   done
 
-lemma invalidate_asid_entry_corres:
+lemma invalidateASIDEntry_corres:
   "corres dc (valid_vspace_objs and valid_asid_map
                 and K (asid \<le> mask asid_bits \<and> asid \<noteq> 0)
                 and vspace_at_asid asid pd and valid_vs_lookup
@@ -800,12 +800,12 @@ lemma invalidate_asid_entry_corres:
              (invalidate_asid_entry asid) (invalidateASIDEntry asid)"
   apply (simp add: invalidate_asid_entry_def invalidateASIDEntry_def)
   apply (rule corres_guard_imp)
-   apply (rule corres_split_deprecated [OF _ load_hw_asid_corres[where pd=pd]])
+   apply (rule corres_split_deprecated [OF _ loadHWASID_corres[where pd=pd]])
      apply (rule corres_split_deprecated [OF _ corres_when])
-         apply (rule invalidate_asid_corres[where pd=pd])
+         apply (rule invalidateASID_corres[where pd=pd])
         apply simp
        apply simp
-       apply (rule invalidate_hw_asid_entry_corres)
+       apply (rule invalidateHWASIDEntry_corres)
       apply (wp load_hw_asid_wp
                | clarsimp cong: if_cong)+
    apply (simp add: pd_at_asid_uniq)
@@ -837,7 +837,7 @@ lemma invalidateASID_valid_arch_state [wp]:
 crunch no_0_obj'[wp]: deleteASID "no_0_obj'"
   (simp: crunch_simps wp: crunch_wps getObject_inv loadObject_default_inv)
 
-lemma delete_asid_corres:
+lemma deleteASID_corres:
   "corres dc
           (invs and valid_etcbs and K (asid \<le> mask asid_bits \<and> asid \<noteq> 0))
           (pspace_aligned' and pspace_distinct' and no_0_obj'
@@ -858,23 +858,23 @@ lemma delete_asid_corres:
          apply (simp add: dom_def)
          apply (rule get_asid_pool_corres_inv')
         apply (rule corres_when, simp add: mask_asid_low_bits_ucast_ucast)
-        apply (rule corres_split_deprecated [OF _ flush_space_corres[where pd=pd]])
-          apply (rule corres_split_deprecated [OF _ invalidate_asid_entry_corres[where pd=pd]])
+        apply (rule corres_split_deprecated [OF _ flushSpace_corres[where pd=pd]])
+          apply (rule corres_split_deprecated [OF _ invalidateASIDEntry_corres[where pd=pd]])
             apply (rule_tac P="asid_pool_at (the (asidTable (ucast (asid_high_bits_of asid))))
                                and valid_etcbs"
                         and P'="pspace_aligned' and pspace_distinct'"
                          in corres_split_deprecated)
                prefer 2
                apply (simp del: fun_upd_apply)
-               apply (rule set_asid_pool_corres')
+               apply (rule setObject_ASIDPool_corres')
                apply (simp add: inv_def mask_asid_low_bits_ucast_ucast)
                apply (rule ext)
                apply (clarsimp simp: o_def)
                apply (erule notE)
                apply (erule ucast_ucast_eq, simp, simp)
-              apply (rule corres_split_deprecated [OF _ gct_corres])
+              apply (rule corres_split_deprecated [OF _ getCurThread_corres])
                 apply simp
-                apply (rule set_vm_root_corres)
+                apply (rule setVMRoot_corres)
                apply wp+
              apply (simp del: fun_upd_apply)
              apply (fold cur_tcb_def)
@@ -927,7 +927,7 @@ crunch armKSASIDTable_inv[wp]: invalidateASIDEntry
 crunch armKSASIDTable_inv[wp]: flushSpace
     "\<lambda>s. P (armKSASIDTable (ksArchState s))"
 
-lemma delete_asid_pool_corres:
+lemma deleteASIDPool_corres:
   "corres dc
           (invs and K (is_aligned base asid_low_bits
                          \<and> base \<le> mask asid_bits)
@@ -944,7 +944,7 @@ lemma delete_asid_pool_corres:
       apply (rule corres_when)
        apply simp
       apply (simp add: liftM_def)
-      apply (rule corres_split_deprecated [OF _ get_asid_pool_corres'])
+      apply (rule corres_split_deprecated [OF _ getObject_ASIDPool_corres'])
         apply (rule corres_split_deprecated)
            prefer 2
            apply (rule corres_mapM [where r=dc and r'=dc], simp, simp)
@@ -962,9 +962,9 @@ lemma delete_asid_pool_corres:
                  apply (clarsimp simp: ucast_ucast_low_bits)
                 apply simp
                 apply (rule_tac pd1="the (pool (ucast xa))"
-                          in corres_split_deprecated [OF _ flush_space_corres])
+                          in corres_split_deprecated [OF _ flushSpace_corres])
                   apply (rule_tac pd="the (pool (ucast xa))"
-                             in invalidate_asid_entry_corres)
+                             in invalidateASIDEntry_corres)
                  apply wp
                  apply clarsimp
                  apply (wpsimp)+
@@ -1030,9 +1030,9 @@ lemma delete_asid_pool_corres:
              apply (simp add: word_size nth_ucast)
             apply (rule corres_split_deprecated)
                prefer 2
-               apply (rule gct_corres)
+               apply (rule getCurThread_corres)
               apply (simp only:)
-              apply (rule set_vm_root_corres)
+              apply (rule setVMRoot_corres)
              apply wp+
          apply (rule_tac R="\<lambda>_ s. rv = arm_asid_table (arch_state s)"
                     in hoare_post_add)
@@ -1067,7 +1067,7 @@ lemma delete_asid_pool_corres:
   apply clarsimp
   done
 
-lemma set_vm_root_for_flush_corres:
+lemma setVMRootForFlush_corres:
   "corres (=)
           (cur_tcb and vspace_at_asid asid pd
            and K (asid \<noteq> 0 \<and> asid \<le> mask asid_bits)
@@ -1094,14 +1094,14 @@ proof -
                return True
             od)"
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF _ arm_context_switch_corres])
+      apply (rule corres_split_deprecated [OF _ armv_contextSwitch_corres])
         apply (rule corres_trivial)
         apply (wp | simp)+
     done
   show ?thesis
   apply (simp add: set_vm_root_for_flush_def setVMRootForFlush_def getThreadVSpaceRoot_def locateSlot_conv)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gct_corres])
+    apply (rule corres_split_deprecated [OF _ getCurThread_corres])
       apply (rule corres_split_deprecated [where R="\<lambda>_. vspace_at_asid asid pd and K (asid \<noteq> 0 \<and> asid \<le> mask asid_bits)
                                                and valid_asid_map and valid_vs_lookup
                                                and valid_vspace_objs and valid_global_objs
@@ -1275,7 +1275,7 @@ lemma load_hw_asid_corres2:
      (pspace_aligned' and pspace_distinct' and no_0_obj')
     (load_hw_asid a) (loadHWASID a)"
   apply (rule stronger_corres_guard_imp)
-    apply (rule load_hw_asid_corres[where pd=pd])
+    apply (rule loadHWASID_corres[where pd=pd])
    apply (clarsimp simp: pd_at_asid_uniq)
   apply simp
   done
@@ -1283,7 +1283,7 @@ lemma load_hw_asid_corres2:
 crunch no_0_obj'[wp]: flushTable "no_0_obj'"
   (wp: crunch_wps simp: crunch_simps)
 
-lemma flush_table_corres:
+lemma flushTable_corres:
   "corres dc
           (pspace_aligned and valid_objs and valid_arch_state and
            cur_tcb and vspace_at_asid asid pd and valid_asid_map and valid_vspace_objs and
@@ -1299,14 +1299,14 @@ lemma flush_table_corres:
   apply (simp add: ptBits_def pt_bits_def pageBits_def is_aligned_mask cong: corres_weak_cong)
   apply (thin_tac "P" for P)+
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ set_vm_root_for_flush_corres])
+    apply (rule corres_split_deprecated [OF _ setVMRootForFlush_corres])
       apply (rule corres_split_deprecated [OF _ load_hw_asid_corres2[where pd=pd]])
         apply (clarsimp cong: corres_weak_cong)
         apply (rule corres_when, rule refl)
         apply (rule corres_split_deprecated[where r' = dc, OF corres_when corres_machine_op])
             apply simp
-           apply (rule corres_split_deprecated[OF _ gct_corres])
-             apply (simp, rule set_vm_root_corres)
+           apply (rule corres_split_deprecated[OF _ getCurThread_corres])
+             apply (simp, rule setVMRoot_corres)
             apply ((wp mapM_wp' hoare_vcg_const_imp_lift get_pte_wp getPTE_wp|
                     wpc|simp|fold cur_tcb_def cur_tcb'_def)+)[4]
           apply (rule corres_Id[OF refl])
@@ -1317,7 +1317,7 @@ lemma flush_table_corres:
                 simp add: cur_tcb'_def [symmetric] cur_tcb_def [symmetric] )+
   done
 
-lemma flush_page_corres:
+lemma flushPage_corres:
   "corres dc
           (K (is_aligned vptr pageBits \<and> asid \<le> mask asid_bits \<and> asid \<noteq> 0) and
            cur_tcb and valid_arch_state and valid_objs and
@@ -1334,15 +1334,15 @@ lemma flush_page_corres:
   apply (simp add: is_aligned_mask cong: corres_weak_cong)
   apply (thin_tac P for P)+
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ set_vm_root_for_flush_corres])
+    apply (rule corres_split_deprecated [OF _ setVMRootForFlush_corres])
       apply (rule corres_split_deprecated [OF _ load_hw_asid_corres2[where pd=pd]])
         apply (clarsimp cong: corres_weak_cong)
         apply (rule corres_when, rule refl)
         apply (rule corres_split_deprecated [OF _ corres_machine_op [where r=dc]])
            apply (rule corres_when, rule refl)
-           apply (rule corres_split_deprecated [OF _ gct_corres])
+           apply (rule corres_split_deprecated [OF _ getCurThread_corres])
              apply simp
-             apply (rule set_vm_root_corres)
+             apply (rule setVMRoot_corres)
             apply wp+
           apply (rule corres_Id, rule refl, simp)
           apply (rule no_fail_pre, wp no_fail_invalidateLocalTLB_VAASID)
@@ -1367,7 +1367,7 @@ crunch distinct'[wp]: unmapPageTable "pspace_distinct'"
   (simp: crunch_simps
    wp: crunch_wps getObject_inv loadObject_default_inv)
 
-lemma page_table_mapped_corres:
+lemma pageTableMapped_corres:
   "corres (=) (valid_arch_state and valid_vspace_objs and pspace_aligned
                        and K (asid \<noteq> 0 \<and> asid \<le> mask asid_bits))
                  (pspace_aligned' and pspace_distinct' and no_0_obj')
@@ -1379,7 +1379,7 @@ lemma page_table_mapped_corres:
       apply (rule corres_trivial, simp)
      apply (rule corres_split_eqrE [OF _ find_pd_for_asid_corres])
        apply (simp add: liftE_bindE)
-       apply (rule corres_split_deprecated [OF _ get_pde_corres'])
+       apply (rule corres_split_deprecated [OF _ getObject_PDE_corres'])
          apply (rule corres_trivial)
          apply (case_tac rv,
            simp_all add: returnOk_def pde_relation_aligned_def
@@ -1397,7 +1397,7 @@ crunches storePDE, storePTE
   and valid_arch'[wp]: valid_arch_state'
   and cur_tcb'[wp]: cur_tcb'
 
-lemma unmap_page_table_corres:
+lemma unmapPageTable_corres:
   "corres dc
           (invs and valid_etcbs and page_table_at pt and
            K (0 < asid \<and> is_aligned vptr 20 \<and> asid \<le> mask asid_bits))
@@ -1407,12 +1407,12 @@ lemma unmap_page_table_corres:
           (unmapPageTable asid vptr pt)"
   apply (clarsimp simp: unmapPageTable_def unmap_page_table_def ignoreFailure_def const_def cong: option.case_cong)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ page_table_mapped_corres])
+    apply (rule corres_split_eqr [OF _ pageTableMapped_corres])
       apply (simp add: case_option_If2 split del: if_split)
       apply (rule corres_if2[OF refl])
-       apply (rule corres_split_deprecated [OF _ store_pde_corres'])
+       apply (rule corres_split_deprecated [OF _ storePDE_corres'])
           apply (rule corres_split_deprecated[OF _ corres_machine_op])
-             apply (rule flush_table_corres)
+             apply (rule flushTable_corres)
             apply (rule corres_Id, rule refl, simp)
             apply (wp no_fail_cleanByVA_PoU)+
            apply (simp, wp+)
@@ -1461,7 +1461,7 @@ lemma corres_split_strengthen_ftE:
    apply (simp add: validE_R_def)+
   done
 
-lemma check_mapping_corres:
+lemma checkMappingPPtr_corres:
   "corres (dc \<oplus> dc)
             ((case slotptr of Inl ptr \<Rightarrow> pte_at ptr | Inr ptr \<Rightarrow> pde_at ptr) and
              (\<lambda>s. (case slotptr of Inl ptr \<Rightarrow> is_aligned ptr (pg_entry_align sz)
@@ -1474,7 +1474,7 @@ lemma check_mapping_corres:
                    checkMappingPPtr_def)
   apply (cases slotptr, simp_all add: liftE_bindE)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated[OF _ get_pte_corres'])
+     apply (rule corres_split_deprecated[OF _ getObject_PTE_corres'])
        apply (rule corres_trivial)
        subgoal by (cases sz,
          auto simp add: is_aligned_mask[symmetric]
@@ -1485,7 +1485,7 @@ lemma check_mapping_corres:
     apply simp
    apply (simp add:is_aligned_mask[symmetric] is_aligned_shiftr pg_entry_align_def)
   apply (rule corres_guard_imp)
-   apply (rule corres_split_deprecated[OF _ get_pde_corres'])
+   apply (rule corres_split_deprecated[OF _ getObject_PDE_corres'])
       apply (rule corres_trivial)
       subgoal by (cases sz,
          auto simp add: is_aligned_mask[symmetric]
@@ -1507,7 +1507,7 @@ lemma store_pte_pd_at_asid[wp]:
   apply clarsimp
   done
 
-lemma unmap_page_corres:
+lemma unmapPage_corres:
   "corres dc (invs and valid_etcbs and
               K (valid_unmap sz (asid,vptr) \<and> vptr < kernel_base \<and> asid \<le> mask asid_bits))
              (valid_objs' and valid_arch_state' and pspace_aligned' and
@@ -1521,7 +1521,7 @@ lemma unmap_page_corres:
              rule find_pd_for_asid_corres,simp)
         apply (rule corres_splitEE)
            apply clarsimp
-           apply (rule flush_page_corres)
+           apply (rule flushPage_corres)
           apply (rule_tac F = "vptr < kernel_base" in corres_gen_asm)
           apply (rule_tac P="\<exists>\<rhd> pd and page_directory_at pd and vspace_at_asid asid pd
                              and (\<exists>\<rhd> (lookup_pd_slot pd vptr && ~~ mask pd_bits))
@@ -1535,11 +1535,11 @@ lemma unmap_page_corres:
           apply (cases sz, simp_all)[1]
              apply (rule corres_guard_imp)
                apply (rule_tac F = "vptr < kernel_base" in corres_gen_asm)
-               apply (rule corres_split_strengthen_ftE[OF lookup_pt_slot_corres[OF refl refl]])
+               apply (rule corres_split_strengthen_ftE[OF lookupPTSlot_corres[OF refl refl]])
                  apply simp
-                 apply (rule corres_splitEE[OF _ check_mapping_corres])
+                 apply (rule corres_splitEE[OF _ checkMappingPPtr_corres])
                    apply simp
-                   apply (rule corres_split_deprecated [OF _ store_pte_corres'])
+                   apply (rule corres_split_deprecated [OF _ storePTE_corres'])
                       apply (rule corres_machine_op)
                       apply (rule corres_Id, rule refl, simp)
                       apply (rule no_fail_cleanByVA_PoU)
@@ -1553,10 +1553,10 @@ lemma unmap_page_corres:
               apply (simp add:page_directory_at_aligned_pd_bits)
              apply simp
             apply (rule corres_guard_imp)
-              apply (rule corres_split_strengthen_ftE[OF lookup_pt_slot_corres[OF refl refl]])
+              apply (rule corres_split_strengthen_ftE[OF lookupPTSlot_corres[OF refl refl]])
                 apply (rule_tac F="is_aligned p 6" in corres_gen_asm)
                 apply (simp add: is_aligned_mask[symmetric])
-                apply (rule corres_split_strengthen_ftE[OF check_mapping_corres])
+                apply (rule corres_split_strengthen_ftE[OF checkMappingPPtr_corres])
                   apply (simp add: largePagePTEOffsets_def pteBits_def)
                   apply (rule corres_split_deprecated [OF _ corres_mapM])
                            prefer 8
@@ -1571,7 +1571,7 @@ lemma unmap_page_corres:
                        apply (rule_tac P="(\<lambda>s. \<forall>x\<in>set [0, 4 .e. 0x3C]. pte_at (x + pa) s) and pspace_aligned and valid_etcbs"
                                    and P'="pspace_aligned' and pspace_distinct'"
                                     in corres_guard_imp)
-                         apply (rule store_pte_corres',  simp add:pte_relation_aligned_def)
+                         apply (rule storePTE_corres',  simp add:pte_relation_aligned_def)
                         apply clarsimp
                        apply clarsimp
                       apply (wp store_pte_typ_at hoare_vcg_const_Ball_lift | simp | wp (once) hoare_drop_imps)+
@@ -1584,9 +1584,9 @@ lemma unmap_page_corres:
              apply (simp add:pd_bits_def pageBits_def)
             apply (clarsimp simp: pd_aligned page_directory_pde_at_lookupI)
            apply (rule corres_guard_imp)
-             apply (rule corres_split_strengthen_ftE[OF check_mapping_corres])
+             apply (rule corres_split_strengthen_ftE[OF checkMappingPPtr_corres])
                apply simp
-               apply (rule corres_split_deprecated[OF _ store_pde_corres'])
+               apply (rule corres_split_deprecated[OF _ storePDE_corres'])
                   apply (rule corres_machine_op)
                   apply (rule corres_Id, rule refl, simp)
                   apply (rule no_fail_cleanByVA_PoU)
@@ -1600,7 +1600,7 @@ lemma unmap_page_corres:
             apply (simp add:pd_bits_def pageBits_def word_bits_conv)
            apply (simp add:pd_bits_def pageBits_def)
           apply (rule corres_guard_imp)
-            apply (rule corres_split_strengthen_ftE[OF check_mapping_corres])
+            apply (rule corres_split_strengthen_ftE[OF checkMappingPPtr_corres])
               apply (rule_tac F="is_aligned (lookup_pd_slot pd vptr) 6"
                             in corres_gen_asm)
               apply (simp add: is_aligned_mask[symmetric])
@@ -1616,7 +1616,7 @@ lemma unmap_page_corres:
                     prefer 5
                     apply (rule order_refl)
                    apply (clarsimp simp: superSectionPDEOffsets_def pdeBits_def)
-                   apply (rule corres_guard_imp, rule store_pde_corres')
+                   apply (rule corres_guard_imp, rule storePDE_corres')
                      apply (simp add:pde_relation_aligned_def)+
                     apply clarsimp
                     apply (erule (2) pde_at_aligned_vptr)
@@ -1654,7 +1654,7 @@ definition
    | ARM_A.flush_type.CleanInvalidate \<Rightarrow> ARM_H.flush_type.CleanInvalidate
    | ARM_A.flush_type.Unify \<Rightarrow> ARM_H.flush_type.Unify"
 
-lemma do_flush_corres:
+lemma doFlush_corres:
   "corres_underlying Id nf nf' dc \<top> \<top>
              (do_flush typ start end pstart) (doFlush (flush_type_map typ) start end pstart)"
   apply (simp add: do_flush_def doFlush_def)
@@ -1677,7 +1677,7 @@ definition
   | ARM_A.PageDirectoryFlush typ start end pstart pd asid \<Rightarrow>
       pdi' = PageDirectoryFlush (flush_type_map typ) start end pstart pd asid"
 
-lemma perform_page_directory_corres:
+lemma performPageDirectoryInvocation_corres:
   "page_directory_invocation_map pdi pdi' \<Longrightarrow>
    corres dc (invs and valid_pdi pdi)
              (valid_objs' and pspace_aligned' and pspace_distinct' and no_0_obj'
@@ -1688,14 +1688,14 @@ lemma perform_page_directory_corres:
    apply (clarsimp simp: page_directory_invocation_map_def)
    apply (rule corres_guard_imp)
      apply (rule corres_when, simp)
-     apply (rule corres_split_deprecated [OF _ set_vm_root_for_flush_corres])
+     apply (rule corres_split_deprecated [OF _ setVMRootForFlush_corres])
        apply (rule corres_split_deprecated [OF _ corres_machine_op])
           prefer 2
-          apply (rule do_flush_corres)
+          apply (rule doFlush_corres)
          apply (rule corres_when, simp)
-         apply (rule corres_split_deprecated [OF _ gct_corres])
+         apply (rule corres_split_deprecated [OF _ getCurThread_corres])
            apply clarsimp
-           apply (rule set_vm_root_corres)
+           apply (rule setVMRoot_corres)
           apply wp+
         apply (simp add: cur_tcb_def[symmetric])
         apply (wp hoare_drop_imps)
@@ -1899,7 +1899,7 @@ lemma corres_store_pde_with_invalid_tail:
       apply simp
      apply clarsimp
      apply (rule corres_guard_imp)
-       apply (rule store_pde_corres')
+       apply (rule storePDE_corres')
        apply (drule bspec)
         apply simp
        apply (simp add:pde_relation_aligned_def)
@@ -1922,7 +1922,7 @@ lemma corres_store_pte_with_invalid_tail:
       apply simp
      apply clarsimp
      apply (rule corres_guard_imp)
-       apply (rule store_pte_corres')
+       apply (rule storePTE_corres')
        apply (drule bspec)
         apply simp
        apply (simp add:pte_relation_aligned_def)
@@ -1942,7 +1942,7 @@ lemma updateCap_valid_slots'[wp]:
   apply (wp hoare_vcg_ball_lift)
   done
 
-lemma pte_check_if_mapped_corres:
+lemma pteCheckIfMapped_corres:
   "corres (=) (pte_at slot) ((\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and pspace_aligned' and pspace_distinct') (pte_check_if_mapped slot) (pteCheckIfMapped slot)"
   apply (simp add: pte_check_if_mapped_def pteCheckIfMapped_def)
     apply (rule corres_guard_imp)
@@ -1956,7 +1956,7 @@ lemma pte_check_if_mapped_corres:
   apply simp
   done
 
-lemma pde_check_if_mapped_corres:
+lemma pdeCheckIfMapped_corres:
   "corres (=) (pde_at slot) ((\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and pspace_aligned' and pspace_distinct') (pde_check_if_mapped slot) (pdeCheckIfMapped slot)"
   apply (simp add: pde_check_if_mapped_def pdeCheckIfMapped_def)
     apply (rule corres_guard_imp)
@@ -2065,14 +2065,14 @@ lemma message_info_from_data_eqv:
                  msgLengthBits_def msgExtraCapBits_def msgMaxExtraCaps_def mask_def
                  shiftL_nat msgMaxLength_def msgLabelBits_def)
 
-lemma set_mi_corres:
+lemma setMessageInfo_corres:
  "mi' = message_info_map mi \<Longrightarrow>
   corres dc (tcb_at t) (tcb_at' t)
          (set_message_info t mi) (setMessageInfo t mi')"
   apply (simp add: setMessageInfo_def set_message_info_def)
   apply (subgoal_tac "wordFromMessageInfo (message_info_map mi) =
                       message_info_to_data mi")
-   apply (simp add: user_setreg_corres msg_info_register_def
+   apply (simp add: asUser_setRegister_corres msg_info_register_def
                     msgInfoRegister_def)
   apply (simp add: message_info_to_data_eqv)
   done
@@ -2109,7 +2109,7 @@ lemma same_refs_vs_cap_ref_eq:
    apply (all \<open>rename_tac pte slots p; case_tac slots; clarsimp\<close>)
   done
 
-lemma perform_page_corres:
+lemma performPageInvocation_corres:
   assumes "page_invocation_map pgi pgi'"
   shows "corres dc (invs and valid_etcbs and valid_page_inv pgi)
             (invs' and valid_page_inv' pgi' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
@@ -2139,8 +2139,8 @@ proof -
           apply (rule corres_name_pre)
           apply (clarsimp simp: mapM_Cons bind_assoc split del: if_split)
           apply (rule corres_guard_imp)
-            apply (rule corres_split_deprecated[OF _ pte_check_if_mapped_corres])
-              apply (rule corres_split_deprecated[OF _ store_pte_corres'])
+            apply (rule corres_split_deprecated[OF _ pteCheckIfMapped_corres])
+              apply (rule corres_split_deprecated[OF _ storePTE_corres'])
                  apply (rule corres_split_deprecated[where r' = dc, OF _ corres_store_pte_with_invalid_tail])
                     apply (rule corres_split_deprecated[where r'=dc, OF _ corres_machine_op[OF corres_Id]])
                          apply (clarsimp simp add: when_def)
@@ -2187,8 +2187,8 @@ proof -
          apply (rule corres_name_pre)
          apply (clarsimp simp: mapM_Cons bind_assoc split del:if_split)
          apply (rule corres_guard_imp)
-           apply (rule corres_split_deprecated[OF _ pde_check_if_mapped_corres])
-             apply (rule corres_split_deprecated[OF _ store_pde_corres'])
+           apply (rule corres_split_deprecated[OF _ pdeCheckIfMapped_corres])
+             apply (rule corres_split_deprecated[OF _ storePDE_corres'])
                 apply (rule corres_split_deprecated[where r'=dc, OF _ corres_store_pde_with_invalid_tail])
                    apply (rule corres_split_deprecated[where r'=dc,OF _ corres_machine_op[OF corres_Id]])
                         apply (clarsimp simp: when_def)
@@ -2279,7 +2279,7 @@ proof -
     apply (rule corres_guard_imp)
       apply (rule corres_split_deprecated)
          prefer 2
-         apply (rule unmap_page_corres)
+         apply (rule unmapPage_corres)
         apply (rule corres_split_deprecated [where r'=acap_relation])
            prefer 2
            apply simp
@@ -2307,14 +2307,14 @@ proof -
                          page_invocation_map_def)
    apply (rule corres_guard_imp)
      apply (rule corres_when, simp)
-     apply (rule corres_split_deprecated [OF _ set_vm_root_for_flush_corres])
+     apply (rule corres_split_deprecated [OF _ setVMRootForFlush_corres])
        apply (rule corres_split_deprecated [OF _ corres_machine_op])
           prefer 2
-          apply (rule do_flush_corres)
+          apply (rule doFlush_corres)
          apply (rule corres_when, simp)
-         apply (rule corres_split_deprecated [OF _ gct_corres])
+         apply (rule corres_split_deprecated [OF _ getCurThread_corres])
            apply simp
-           apply (rule set_vm_root_corres)
+           apply (rule setVMRoot_corres)
           apply wp+
         apply (simp add: cur_tcb_def [symmetric] cur_tcb'_def [symmetric])
         apply (wp hoare_drop_imps)
@@ -2324,9 +2324,9 @@ proof -
   \<comment> \<open>PageGetAddr\<close>
   apply (clarsimp simp: perform_page_invocation_def performPageInvocation_def page_invocation_map_def fromPAddr_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply simp
-      apply (rule corres_split_deprecated[OF set_mi_corres set_mrs_corres])
+      apply (rule corres_split_deprecated[OF setMessageInfo_corres setMRs_corres])
          apply (simp add: message_info_map_def)
         apply clarsimp
        apply (wp)+
@@ -2379,7 +2379,7 @@ lemma clear_page_table_corres:
                and Q="\<lambda>xs s. \<forall>x \<in> set xs. pte_at x s \<and> pspace_aligned s \<and> valid_etcbs s"
                and Q'="\<lambda>xs. pspace_aligned' and pspace_distinct'"
                 in corres_mapM_list_all2, simp_all)
-      apply (rule corres_guard_imp, rule store_pte_corres')
+      apply (rule corres_guard_imp, rule storePTE_corres')
         apply (simp add:pte_relation_aligned_def)+
      apply (wp hoare_vcg_const_Ball_lift | simp)+
    apply (simp add: list_all2_refl)
@@ -2393,7 +2393,7 @@ lemma clear_page_table_corres:
 crunch typ_at'[wp]: unmapPageTable "\<lambda>s. P (typ_at' T p s)"
 lemmas unmapPageTable_typ_ats[wp] = typ_at_lifts[OF unmapPageTable_typ_at']
 
-lemma perform_page_table_corres:
+lemma performPageTableInvocation_corres:
   "page_table_invocation_map pti pti' \<Longrightarrow>
    corres dc
           (invs and valid_etcbs and valid_pti pti)
@@ -2408,7 +2408,7 @@ lemma perform_page_table_corres:
       apply (rule corres_split_deprecated [OF _ updateCap_same_master])
          prefer 2
          apply assumption
-        apply (rule corres_split_deprecated [OF _ store_pde_corres'])
+        apply (rule corres_split_deprecated [OF _ storePDE_corres'])
            apply (rule corres_machine_op)
            apply (rule corres_Id, rule refl, simp)
            apply (rule no_fail_cleanByVA_PoU)
@@ -2438,7 +2438,7 @@ lemma perform_page_table_corres:
          apply (clarsimp simp: is_pt_cap_def update_map_data_def)
         apply (wp get_cap_wp)+
       apply (rule corres_if[OF refl])
-       apply (rule corres_split_deprecated [OF _ unmap_page_table_corres])
+       apply (rule corres_split_deprecated [OF _ unmapPageTable_corres])
          apply (rule corres_split_nor)
             apply (rule corres_machine_op, rule corres_Id)
               apply (simp add: pteBits_def)+
@@ -2473,7 +2473,7 @@ definition
   asid_pool_at' p and cte_wp_at' (isPDCap o cteCap) slot and K
   (0 < asid \<and> asid \<le> 2^asid_bits - 1)"
 
-lemma pap_corres:
+lemma performASIDPoolInvocation_corres:
   "ap' = asid_pool_invocation_map ap \<Longrightarrow>
   corres dc
           (valid_objs and pspace_aligned and pspace_distinct and valid_apinv ap and valid_etcbs)
@@ -2500,7 +2500,7 @@ lemma pap_corres:
            apply simp
           apply (rule corres_rel_imp)
            apply simp
-           apply (rule set_asid_pool_corres[OF refl])
+           apply (rule setObject_ASIDPool_corres[OF refl])
            apply (simp add: inv_def)
            apply (rule ext)
            apply (clarsimp simp: mask_asid_low_bits_ucast_ucast)

--- a/proof/refine/ARM_HYP/ArchAcc_R.thy
+++ b/proof/refine/ARM_HYP/ArchAcc_R.thy
@@ -92,7 +92,7 @@ lemma asid_low_bits [simp]:
   "asidLowBits = asid_low_bits"
   by (simp add: asid_low_bits_def asidLowBits_def)
 
-lemma get_asid_pool_corres [@lift_corres_args, corres]:
+lemma getObject_ASIDPool_corres [@lift_corres_args, corres]:
   "corres (\<lambda>p p'. p = inv ASIDPool p' o ucast)
           (asid_pool_at p) (asid_pool_at' p)
           (get_asid_pool p) (getObject p)"
@@ -155,12 +155,12 @@ lemma aligned_distinct_relation_asid_pool_atI'[elim]:
                         projectKOs)
   done
 
-lemma get_asid_pool_corres':
+lemma getObject_ASIDPool_corres':
   "corres (\<lambda>p p'. p = inv ASIDPool p' o ucast)
           (asid_pool_at p) (pspace_aligned' and pspace_distinct')
           (get_asid_pool p) (getObject p)"
   apply (rule stronger_corres_guard_imp,
-         rule get_asid_pool_corres)
+         rule getObject_ASIDPool_corres)
    apply auto
   done
 
@@ -226,23 +226,23 @@ lemma storePTE_state_hyp_refs_of[wp]:
 crunch cte_wp_at'[wp]: setIRQState "\<lambda>s. P (cte_wp_at' P' p s)"
 crunch inv[wp]: getIRQSlot "P"
 
-lemma set_asid_pool_corres [corres]:
+lemma setObject_ASIDPool_corres [corres]:
   "a = inv ASIDPool a' o ucast \<Longrightarrow>
   corres dc (asid_pool_at p and valid_etcbs) (asid_pool_at' p)
             (set_asid_pool p a) (setObject p a')"
   apply (simp add: set_asid_pool_def)
-  apply (corressimp search: set_other_obj_corres[where P="\<lambda>_. True"]
+  apply (corressimp search: setObject_other_corres[where P="\<lambda>_. True"]
                         wp: get_object_ret get_object_wp)
   apply (simp add: other_obj_relation_def asid_pool_relation_def)
   apply (clarsimp simp: obj_at_simps )
   by (auto simp: obj_at_simps typ_at_to_obj_at_arches
           split: Structures_A.kernel_object.splits if_splits arch_kernel_obj.splits)
 
-lemma set_asid_pool_corres':
+lemma setObject_ASIDPool_corres':
   "a = inv ASIDPool a' o ucast \<Longrightarrow>
   corres dc (asid_pool_at p and valid_etcbs) (pspace_aligned' and pspace_distinct')
             (set_asid_pool p a) (setObject p a')"
-  apply (rule stronger_corres_guard_imp[OF set_asid_pool_corres])
+  apply (rule stronger_corres_guard_imp[OF setObject_ASIDPool_corres])
    apply auto
   done
 
@@ -253,7 +253,7 @@ lemma pde_relation_aligned_simp:
   by (clarsimp simp: pde_relation_aligned_def pde_bits_def
               split: ARM_HYP_H.pde.splits if_splits)
 
-lemma get_pde_corres [@lift_corres_args, corres]:
+lemma getObject_PDE_corres [@lift_corres_args, corres]:
   "corres (pde_relation_aligned (p >> pde_bits)) (pde_at p) (pde_at' p)
      (get_pde p) (getObject p)"
   apply (simp add: getObject_def get_pde_def get_pd_def get_object_def split_def bind_assoc)
@@ -533,7 +533,7 @@ lemma get_master_pde_corres [@lift_corres_args, corres]:
    apply (rule no_fail_pre, wp)
    apply clarsimp
   apply (clarsimp simp: in_monad)
-  using get_pde_corres [OF refl, of p]
+  using getObject_PDE_corres [OF refl, of p]
   apply (clarsimp simp: corres_underlying_def)
   apply (drule bspec, assumption, clarsimp)
   apply (drule (1) bspec, clarsimp)
@@ -582,12 +582,12 @@ lemma get_master_pde_corres [@lift_corres_args, corres]:
   apply (drule (1) bspec, clarsimp simp: addPDEOffset_def)
   done
 
-lemma get_pde_corres':
+lemma getObject_PDE_corres':
   "corres (pde_relation_aligned (p >> pde_bits)) (pde_at p)
      (pspace_aligned' and pspace_distinct')
      (get_pde p) (getObject p)"
   apply (rule stronger_corres_guard_imp,
-         rule get_pde_corres)
+         rule getObject_PDE_corres)
    apply auto[1]
   apply clarsimp
   apply (rule aligned_distinct_relation_pde_atI')
@@ -607,7 +607,7 @@ lemma pte_relation_aligned_simp:
   by (clarsimp simp: pte_relation_aligned_def pte_bits_def
               split: ARM_HYP_H.pte.splits if_splits)
 
-lemma get_pte_corres [@lift_corres_args, corres]:
+lemma getObject_PTE_corres [@lift_corres_args, corres]:
   "corres (pte_relation_aligned (p >> pte_bits)) (pte_at p) (pte_at' p)
      (get_pte p) (getObject p)"
   apply (simp add: getObject_def get_pte_def get_pt_def get_object_def split_def bind_assoc)
@@ -796,7 +796,7 @@ lemma get_master_pte_corres [corres]:
    apply (rule no_fail_pre, wp)
    apply clarsimp
   apply (clarsimp simp: in_monad)
-  using get_pte_corres [OF refl, of p]
+  using getObject_PTE_corres [OF refl, of p]
   apply (clarsimp simp: corres_underlying_def)
   apply (drule bspec, assumption, clarsimp)
   apply (drule (1) bspec, clarsimp)
@@ -845,12 +845,12 @@ lemma get_master_pte_corres [corres]:
   apply (drule (1) bspec, clarsimp simp: addPTEOffset_def)
   done
 
-lemma get_pte_corres':
+lemma getObject_PTE_corres':
   "corres (pte_relation_aligned (p >> pte_bits)) (pte_at p)
      (pspace_aligned' and pspace_distinct')
      (get_pte p) (getObject p)"
   apply (rule stronger_corres_guard_imp,
-         rule get_pte_corres)
+         rule getObject_PTE_corres)
    apply auto[1]
   apply clarsimp
   apply (rule aligned_distinct_relation_pte_atI')
@@ -864,7 +864,7 @@ lemma get_master_pte_corres':
      (get_master_pte p) (getObject p)"
   by (rule stronger_corres_guard_imp, rule get_master_pte_corres) auto
 
-lemma set_pd_corres [corres]:
+lemma setObject_PD_corres [corres]:
   "pde_relation_aligned (p>>pde_bits) pde pde' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PageDirectory pd)) (p && ~~ mask pd_bits)
                      and pspace_aligned and valid_etcbs)
@@ -944,7 +944,7 @@ lemma set_pd_corres [corres]:
   apply (simp add: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
   done
 
-lemma set_pt_corres [corres]:
+lemma setObject_PT_corres [corres]:
   "pte_relation_aligned (p >> pte_bits) pte pte' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PageTable pt)) (p && ~~ mask pt_bits)
                      and pspace_aligned and valid_etcbs)
@@ -1024,14 +1024,14 @@ lemma set_pt_corres [corres]:
 lemma wordsFromPDEis2: "\<exists>a b . wordsFromPDE pde = [a , b]"
   by (cases pde ; clarsimp simp: wordsFromPDE_def tailM_def headM_def)
 
-lemma store_pde_corres [corres]:
+lemma storePDE_corres [corres]:
   "pde_relation_aligned (p >> pde_bits) pde pde' \<Longrightarrow>
   corres dc (pde_at p and pspace_aligned and valid_etcbs) (pde_at' p) (store_pde p pde) (storePDE p pde')"
   apply (simp add: store_pde_def storePDE_def)
   apply (insert wordsFromPDEis2[of pde'])
   apply (clarsimp simp: tailM_def headM_def)
   apply (rule corres_symb_exec_l)
-     apply (erule set_pd_corres)
+     apply (erule setObject_PD_corres)
     apply (clarsimp simp: exs_valid_def get_pd_def get_object_def exec_gets bind_assoc
                           obj_at_def pde_at_def)
     apply (clarsimp simp: a_type_def return_def
@@ -1044,26 +1044,26 @@ lemma store_pde_corres [corres]:
                   split: Structures_A.kernel_object.splits arch_kernel_obj.splits if_split_asm)
   done
 
-lemma store_pde_corres':
+lemma storePDE_corres':
   "pde_relation_aligned (p >> pde_bits) pde pde' \<Longrightarrow>
   corres dc
      (pde_at p and pspace_aligned and valid_etcbs) (pspace_aligned' and pspace_distinct')
      (store_pde p pde) (storePDE p pde')"
-  apply (rule stronger_corres_guard_imp, rule store_pde_corres)
+  apply (rule stronger_corres_guard_imp, rule storePDE_corres)
    apply auto
   done
 
 lemma wordsFromPTEis2: "\<exists>a b . wordsFromPTE pte = [a , b]"
   by (cases pte ; clarsimp simp: wordsFromPTE_def tailM_def headM_def)
 
-lemma store_pte_corres [corres]:
+lemma storePTE_corres [corres]:
   "pte_relation_aligned (p>>pte_bits) pte pte' \<Longrightarrow>
   corres dc (pte_at p and pspace_aligned and valid_etcbs) (pte_at' p) (store_pte p pte) (storePTE p pte')"
   apply (simp add: store_pte_def storePTE_def)
   apply (insert wordsFromPTEis2[of pte'])
   apply (clarsimp simp: tailM_def headM_def)
   apply (rule corres_symb_exec_l)
-     apply (erule set_pt_corres)
+     apply (erule setObject_PT_corres)
     apply (clarsimp simp: exs_valid_def get_pt_def get_object_def
                           exec_gets bind_assoc obj_at_def pte_at_def)
     apply (clarsimp simp: a_type_def return_def
@@ -1076,16 +1076,16 @@ lemma store_pte_corres [corres]:
                   split: Structures_A.kernel_object.splits arch_kernel_obj.splits if_split_asm)
   done
 
-lemma store_pte_corres':
+lemma storePTE_corres':
   "pte_relation_aligned (p >> pte_bits) pte pte' \<Longrightarrow>
   corres dc (pte_at p and pspace_aligned and valid_etcbs)
             (pspace_aligned' and pspace_distinct')
             (store_pte p pte) (storePTE p pte')"
-  apply (rule stronger_corres_guard_imp, rule store_pte_corres)
+  apply (rule stronger_corres_guard_imp, rule storePTE_corres)
    apply auto
   done
 
-lemma lookup_pd_slot_corres [simp]:
+lemma lookupPDSlot_corres [simp]:
   "lookupPDSlot pd vptr = lookup_pd_slot pd vptr"
   by (simp add: lookupPDSlot_def lookup_pd_slot_def)
 
@@ -1208,7 +1208,7 @@ lemmas checkPTAt_corres [corresK] =
   corres_stateAssert_implied_frame[OF page_table_at_lift, folded checkPTAt_def]
 
 
-lemma lookup_pt_slot_corres [corres]:
+lemma lookupPTSlot_corres [corres]:
   "corres (lfr \<oplus> (=))
           (pde_at (lookup_pd_slot pd vptr) and pspace_aligned and valid_vspace_objs
           and (\<exists>\<rhd> (lookup_pd_slot pd vptr && ~~ mask pd_bits)) and
@@ -1290,7 +1290,7 @@ lemma arch_deriveCap_valid:
                    capUntypedPtr_def ARM_HYP_H.capUntypedPtr_def)
   done
 
-lemma arch_derive_corres [corres]:
+lemma arch_deriveCap_corres [corres]:
  "cap_relation (cap.ArchObjectCap c) (ArchObjectCap c') \<Longrightarrow>
   corres (ser \<oplus> (\<lambda>c c'. cap_relation c c'))
          \<top> \<top>
@@ -1310,7 +1310,7 @@ definition
 where
   "mapping_map \<equiv> pte_relation' \<otimes> (=) \<oplus> pde_relation' \<otimes> (=)"
 
-lemma create_mapping_entries_corres [corres]:
+lemma createMappingEntries_corres [corres]:
   "\<lbrakk> vm_rights' = vmrights_map vm_rights;
      attrib' = vmattributes_map attrib \<rbrakk>
   \<Longrightarrow> corres (ser \<oplus> mapping_map)
@@ -1356,7 +1356,7 @@ lemma createMappingEntries_valid_slots' [wp]:
 
 lemmas [corresc_simp] = master_pte_relation_def master_pde_relation_def
 
-lemma ensure_safe_mapping_corres [corres]:
+lemma ensureSafeMapping_corres [corres]:
   "mapping_map m m' \<Longrightarrow>
   corres (ser \<oplus> dc) (valid_mapping_entries m)
                     (pspace_aligned' and pspace_distinct'

--- a/proof/refine/ARM_HYP/Arch_R.thy
+++ b/proof/refine/ARM_HYP/Arch_R.thy
@@ -121,7 +121,7 @@ lemma set_cap_device_and_range_aligned:
   apply (wp set_cap_device_and_range)
   done
 
-lemma pac_corres:
+lemma performASIDControlInvocation_corres:
   "asid_ci_map i = i' \<Longrightarrow>
   corres dc
          (einvs and ct_active and valid_aci i)
@@ -149,7 +149,7 @@ lemma pac_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated)
        prefer 2
-       apply (erule detype_corres)
+       apply (erule deleteObjects_corres)
        apply (simp add:pageBits_def)
       apply (rule corres_split_deprecated[OF _ getSlotCap_corres])
          apply (rule_tac F = " pcap = (cap.UntypedCap False word1 pageBits idxa)" in corres_gen_asm)
@@ -172,7 +172,7 @@ lemma pac_corres:
                   apply (simp add:obj_bits_api_def arch_kobj_size_def default_arch_object_def)+
                apply (rule corres_split_deprecated)
                   prefer 2
-                  apply (rule cins_corres_simple, simp, rule refl, rule refl)
+                  apply (rule cteInsert_simple_corres, simp, rule refl, rule refl)
                  apply (rule_tac F="is_aligned word2 asid_low_bits" in corres_gen_asm)
                  apply (simp add: is_aligned_mask dc_def[symmetric])
                  apply (rule corres_split_deprecated [where P=\<top> and P'=\<top> and r'="\<lambda>t t'. t = t' o ucast"])
@@ -410,7 +410,7 @@ lemma vm_attributes_corres:
   by (clarsimp simp: attribsFromWord_def attribs_from_word_def
                      Let_def vmattributes_map_def parity_mask_def)
 
-lemma check_vp_corres:
+lemma checkVPAlignment_corres:
   "corres (ser \<oplus> dc) \<top> \<top>
           (check_vp_alignment sz w)
           (checkVPAlignment sz w)"
@@ -518,7 +518,7 @@ lemma flush_type_map:
                         ARM_HYP_H.isPageFlushLabel_def ARM_HYP_H.isPDFlushLabel_def
                  split: ARM_A.flush_type.splits invocation_label.splits arch_invocation_label.splits)
 
-lemma resolve_vaddr_corres:
+lemma resolveVAddr_corres:
   "\<lbrakk> is_aligned pd pd_bits; vaddr < kernel_base \<rbrakk> \<Longrightarrow>
   corres (=) (pspace_aligned and valid_vspace_objs and page_directory_at pd
                  and (\<exists>\<rhd> (lookup_pd_slot pd vaddr && ~~ mask pd_bits)))
@@ -550,7 +550,7 @@ lemma resolve_vaddr_corres:
   apply (clarsimp simp: page_directory_pde_at_lookupI' page_directory_at_state_relation)
   done
 
-lemma dec_arch_inv_page_flush_corres:
+lemma decodeARMPageFlush_corres:
   "ARM_HYP_H.isPageFlushLabel (invocation_type (mi_label mi)) \<Longrightarrow>
    corres (ser \<oplus> archinv_relation)
            (invs and
@@ -812,7 +812,7 @@ lemma get_vcpu_LR_corres[corres]:
   "corres (r \<oplus> (\<lambda>vcpu lr. vgic_lr (vcpu_vgic vcpu) = lr)) (vcpu_at v) (vcpu_at' v)
              (liftE (get_vcpu v)) (liftE (liftM (vgicLR \<circ> vcpuVGIC) (getObject v)))"
   apply simp
-  apply (rule corres_rel_imp, rule get_vcpu_corres)
+  apply (rule corres_rel_imp, rule getObject_vcpu_corres)
   apply (rename_tac vcpu', case_tac vcpu')
   apply (clarsimp simp: vcpu_relation_def vgic_map_def)
   done
@@ -822,7 +822,7 @@ lemma vgi_mask[simp]:
   "vgicIRQActive = vgic_irq_active"
   by (auto simp: vgicIRQMask_def vgic_irq_mask_def vgic_irq_active_def vgicIRQActive_def)
 
-lemma dec_vcpu_inv_corres:
+lemma decodeARMVCPUInvocation_corres:
   notes if_split [split del]
   shows
   "\<lbrakk>acap_relation arch_cap arch_cap'; list_all2 cap_relation (map fst excaps) (map fst excaps');
@@ -892,7 +892,7 @@ lemma corres_splitEE':
 lemmas vmsz_aligned_imp_aligned
     = vmsz_aligned_def[THEN meta_eq_to_obj_eq, THEN iffD1, THEN is_aligned_weaken]
 
-lemma dec_arch_inv_corres:
+lemma arch_decodeInvocation_corres:
 notes check_vp_inv[wp del] check_vp_wpR[wp] [[goals_limit = 1]]
   (* FIXME: check_vp_inv shadowed check_vp_wpR.  Instead,
      check_vp_wpR should probably be generalised to replace check_vp_inv. *)
@@ -1030,13 +1030,13 @@ shows
             apply (rule corres_splitEE)
                prefer 2
                apply (fold ser_def)
-               apply (rule ensure_no_children_corres, rule refl)
+               apply (rule ensureNoChildren_corres, rule refl)
               apply (rule corres_splitEE)
                  prefer 2
-                 apply (erule lsfc_corres, rule refl)
+                 apply (erule lookupSlotForCNodeOp_corres, rule refl)
                 apply (rule corres_splitEE)
                    prefer 2
-                   apply (rule ensure_empty_corres)
+                   apply (rule ensureEmptySlot_corres)
                    apply clarsimp
                   apply (rule corres_returnOk[where P="\<top>"])
                   apply (clarsimp simp add: archinv_relation_def asid_ci_map_def split_def)
@@ -1093,10 +1093,10 @@ shows
             apply (rule corres_splitEE'[
                           OF corres_lookup_error[OF find_pd_for_asid_corres[where pd=undefined, OF refl]]])
               apply (rule whenE_throwError_corres; simp)
-              apply (rule corres_splitEE'[where r'=dc, OF check_vp_corres])
-                apply (rule corres_splitEE'[OF create_mapping_entries_corres]
+              apply (rule corres_splitEE'[where r'=dc, OF checkVPAlignment_corres])
+                apply (rule corres_splitEE'[OF createMappingEntries_corres]
                        ; simp add: mask_vmrights_corres vm_attributes_corres)
-                  apply (rule corres_splitEE'[OF ensure_safe_mapping_corres], assumption)
+                  apply (rule corres_splitEE'[OF ensureSafeMapping_corres], assumption)
                     apply (rule corres_returnOkTT)
                     \<comment> \<open>program split done, now prove resulting preconditions and Hoare triples\<close>
                     apply (simp add: archinv_relation_def page_invocation_map_def)
@@ -1126,7 +1126,7 @@ shows
      apply (cases "ARM_HYP_H.isPageFlushLabel (invocation_type (mi_label mi))")
       apply (clarsimp simp: ARM_HYP_H.isPageFlushLabel_def split del: if_split)
       apply (clarsimp split: invocation_label.splits arch_invocation_label.splits split del: if_split)
-         apply (rule dec_arch_inv_page_flush_corres,
+         apply (rule decodeARMPageFlush_corres,
                 clarsimp simp: ARM_HYP_H.isPageFlushLabel_def)+
      apply (clarsimp simp: ARM_HYP_H.isPageFlushLabel_def split del: if_split)
      apply (cases "invocation_type (mi_label mi) = ArchInvocationLabel ARMPageGetAddress")
@@ -1179,7 +1179,7 @@ shows
       apply (rule corres_symb_exec_r_conj)
          apply (rule_tac F="isArchCap isPageTableCap (cteCap cteVal)"
                   in corres_gen_asm2)
-         apply (rule corres_split_deprecated[OF _ final_cap_corres[where ptr=slot]])
+         apply (rule corres_split_deprecated[OF _ isFinalCapability_corres[where ptr=slot]])
            apply (drule mp)
             apply (clarsimp simp: isCap_simps final_matters'_def)
            apply (rule whenE_throwError_corres)
@@ -1225,7 +1225,7 @@ shows
         apply (rule corres_split_deprecated[OF _ _ resolve_vaddr_valid_mapping_size])
           prefer 2
           apply clarsimp
-          apply (rule resolve_vaddr_corres[THEN corres_gen_asm])
+          apply (rule resolveVAddr_corres[THEN corres_gen_asm])
            apply simp
           apply (clarsimp simp: not_le)
          apply (case_tac rva)
@@ -1254,7 +1254,7 @@ shows
     apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
                    split: option.splits)
    apply clarsimp
-  apply (simp, rule corres_guard_imp[OF dec_vcpu_inv_corres]; simp)
+  apply (simp, rule corres_guard_imp[OF decodeARMVCPUInvocation_corres]; simp)
   done
 
 
@@ -1266,26 +1266,26 @@ lemma invokeVCPUInjectIRQ_corres:
         (invokeVCPUInjectIRQ v index virq)"
   unfolding invokeVCPUInjectIRQ_def invoke_vcpu_inject_irq_def
   apply (clarsimp simp: bind_assoc)
-  apply (corressimp corres: get_vcpu_corres set_vcpu_corres wp: get_vcpu_wp)
+  apply (corressimp corres: getObject_vcpu_corres setObject_VCPU_corres wp: get_vcpu_wp)
   apply clarsimp
   done
 
 lemma [wp]:"no_fail \<top> getSCTLR"
   by (clarsimp simp: getSCTLR_def)
 
-lemma invoke_vcpu_read_register_corres:
+lemma invokeVCPUReadReg_corres:
   "corres (=) (vcpu_at v) (vcpu_at' v and no_0_obj')
                  (invoke_vcpu_read_register v r)
                  (invokeVCPUReadReg v r)"
   unfolding invoke_vcpu_read_register_def invokeVCPUReadReg_def read_vcpu_register_def readVCPUReg_def
   apply (rule corres_discard_r)
-  apply (corressimp corres: get_vcpu_corres wp: get_vcpu_wp)
+  apply (corressimp corres: getObject_vcpu_corres wp: get_vcpu_wp)
   apply (clarsimp simp: vcpu_relation_def split: option.splits)
   apply (wpsimp simp: getCurThread_def)+
   done
 
 
-lemma invoke_vcpu_write_register_corres:
+lemma invokeVCPUWriteReg_corres:
   "corres (=) (vcpu_at vcpu) (vcpu_at' vcpu and no_0_obj')
         (do y \<leftarrow> invoke_vcpu_write_register vcpu r v;
                  return []
@@ -1294,19 +1294,19 @@ lemma invoke_vcpu_write_register_corres:
   unfolding invokeVCPUWriteReg_def invoke_vcpu_write_register_def write_vcpu_register_def
             writeVCPUReg_def
   apply (rule corres_discard_r)
-  apply (corressimp corres: set_vcpu_corres get_vcpu_corres wp: get_vcpu_wp)
+  apply (corressimp corres: setObject_VCPU_corres getObject_vcpu_corres wp: get_vcpu_wp)
   subgoal by (auto simp: vcpu_relation_def split: option.splits)
   apply (wpsimp simp: getCurThread_def)+
   done
 
-lemma archThreadSet_corres_vcpu_Some[corres]:
+lemma archThreadSet_VCPU_Some_corres[corres]:
   "corres dc (tcb_at t) (tcb_at' t)
     (arch_thread_set (tcb_vcpu_update (\<lambda>_. Some v)) t) (archThreadSet (atcbVCPUPtr_update (\<lambda>_. Some v)) t)"
   apply (rule archThreadSet_corres)
   apply (simp add: arch_tcb_relation_def)
   done
 
-lemma associate_vcpu_tcb_corres:
+lemma associateVCPUTCB_corres:
   "corres (=) (invs and vcpu_at v and tcb_at t)
                (invs' and vcpu_at' v and tcb_at' t)
                (do y \<leftarrow> associate_vcpu_tcb v t;
@@ -1315,7 +1315,7 @@ lemma associate_vcpu_tcb_corres:
                (associateVCPUTCB v t)"
   unfolding associate_vcpu_tcb_def associateVCPUTCB_def
   apply (clarsimp simp: bind_assoc)
-  apply (corressimp search: get_vcpu_corres set_vcpu_corres
+  apply (corressimp search: getObject_vcpu_corres setObject_VCPU_corres
                        wp: get_vcpu_wp getVCPU_wp
                      simp: vcpu_relation_def)
       apply (rule_tac Q="\<lambda>_. invs and tcb_at t" in hoare_strengthen_post)
@@ -1352,7 +1352,7 @@ lemma associate_vcpu_tcb_corres:
   apply (simp add: valid_vcpu'_def typ_at_tcb')
   done
 
-lemma invoke_vcpu_ack_vppi_corres:
+lemma invokeVCPUAckVPPI_corres:
   "corres (=) (vcpu_at vcpu) (vcpu_at' vcpu)
         (do y \<leftarrow> invoke_vcpu_ack_vppi vcpu vppi;
                  return []
@@ -1360,13 +1360,13 @@ lemma invoke_vcpu_ack_vppi_corres:
         (invokeVCPUAckVPPI vcpu vppi)"
   unfolding invokeVCPUAckVPPI_def invoke_vcpu_ack_vppi_def write_vcpu_register_def
             writeVCPUReg_def
-  by (corressimp corres: set_vcpu_corres get_vcpu_corres wp: get_vcpu_wp)
+  by (corressimp corres: setObject_VCPU_corres getObject_vcpu_corres wp: get_vcpu_wp)
      (auto simp: vcpu_relation_def split: option.splits)
 
-lemma perform_vcpu_invocation_corres:
-  notes inv_corres = invokeVCPUInjectIRQ_corres invoke_vcpu_read_register_corres
-                     invoke_vcpu_write_register_corres associate_vcpu_tcb_corres
-                     invoke_vcpu_ack_vppi_corres
+lemma performARMVCPUInvocation_corres:
+  notes inv_corres = invokeVCPUInjectIRQ_corres invokeVCPUReadReg_corres
+                     invokeVCPUWriteReg_corres associateVCPUTCB_corres
+                     invokeVCPUAckVPPI_corres
   shows "corres (=) (einvs and ct_active and valid_vcpu_invocation iv)
                        (invs' and ct_active' and valid_vcpuinv' (vcpu_invocation_map iv))
                 (perform_vcpu_invocation iv) (performARMVCPUInvocation (vcpu_invocation_map iv))"
@@ -1375,15 +1375,15 @@ lemma perform_vcpu_invocation_corres:
      apply (rule inv_corres [THEN corres_guard_imp]; simp add: invs_no_0_obj')+
   done
 
-lemma inv_arch_corres:
+lemma arch_performInvocation_corres:
   assumes "archinv_relation ai ai'"
   shows   "corres (dc \<oplus> (=))
                   (einvs and ct_active and valid_arch_inv ai)
                   (invs' and ct_active' and valid_arch_inv' ai' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
                   (arch_perform_invocation ai) (Arch.performInvocation ai')"
 proof -
-  note invocation_corres =  perform_page_table_corres perform_page_directory_corres
-                            pac_corres pap_corres perform_page_corres perform_vcpu_invocation_corres
+  note invocation_corres =  performPageTableInvocation_corres performPageDirectoryInvocation_corres
+                            performASIDControlInvocation_corres performASIDPoolInvocation_corres performPageInvocation_corres performARMVCPUInvocation_corres
   from assms show ?thesis
   unfolding arch_perform_invocation_def ARM_HYP_H.performInvocation_def performARMMMUInvocation_def
   apply clarsimp

--- a/proof/refine/ARM_HYP/Bits_R.thy
+++ b/proof/refine/ARM_HYP/Bits_R.thy
@@ -187,13 +187,13 @@ lemma tcb_in_valid_state':
   apply (fastforce simp add: valid_obj'_def valid_tcb'_def)
   done
 
-lemma gct_corres [corres]: "corres (=) \<top> \<top> (gets cur_thread) getCurThread"
+lemma getCurThread_corres [corres]: "corres (=) \<top> \<top> (gets cur_thread) getCurThread"
   by (simp add: getCurThread_def curthread_relation)
 
 lemma gct_wp [wp]: "\<lbrace>\<lambda>s. P (ksCurThread s) s\<rbrace> getCurThread \<lbrace>P\<rbrace>"
   by (unfold getCurThread_def, wp)
 
-lemma git_corres:
+lemma getIdleThread_corres:
   "corres (=) \<top> \<top> (gets idle_thread) getIdleThread"
   by (simp add: getIdleThread_def state_relation_def)
 

--- a/proof/refine/ARM_HYP/CNodeInv_R.thy
+++ b/proof/refine/ARM_HYP/CNodeInv_R.thy
@@ -154,7 +154,7 @@ lemma cancelSendRightsEq:
                   split: cap.splits bool.splits if_splits |
          case_tac x)+
 
-lemma dec_cnode_inv_corres:
+lemma decodeCNodeInvocation_corres:
   "\<lbrakk> cap_relation (cap.CNodeCap w n list) cap'; list_all2 cap_relation cs cs';
      length list \<le> 32 \<rbrakk> \<Longrightarrow>
   corres
@@ -173,9 +173,9 @@ lemma dec_cnode_inv_corres:
                    split del: if_split
                         cong: if_cong list.case_cong)
         apply (rule corres_guard_imp)
-          apply (rule corres_splitEE [OF _ lsfc_corres])
-              apply (rule corres_splitEE [OF _ ensure_empty_corres])
-                 apply (rule corres_splitEE [OF _ lsfc_corres])
+          apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
+              apply (rule corres_splitEE [OF _ ensureEmptySlot_corres])
+                 apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
                      apply (simp(no_asm) add: liftE_bindE del: de_Morgan_conj split del: if_split)
                      apply (rule corres_split_deprecated [OF _ get_cap_corres'])
                         prefer 2
@@ -197,7 +197,7 @@ lemma dec_cnode_inv_corres:
                              prefer 2
                              apply (simp add: returnOk_def del: imp_disjL)
                              apply (rule conjI[rotated], rule impI)
-                              apply (rule derive_cap_corres)
+                              apply (rule deriveCap_corres)
                                apply (clarsimp simp: cap_relation_mask
                                                      cap_map_update_data
                                               split: option.split)
@@ -215,7 +215,7 @@ lemma dec_cnode_inv_corres:
        \<comment> \<open>Revoke\<close>
        apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                         isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
-       apply (rule corres_guard_imp, rule corres_splitEE [OF _ lsfc_corres])
+       apply (rule corres_guard_imp, rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
              apply (simp add: split_beta)
              apply (rule corres_returnOkTT)
              apply simp
@@ -228,7 +228,7 @@ lemma dec_cnode_inv_corres:
       apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                        isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
       apply (rule corres_guard_imp)
-        apply (rule corres_splitEE [OF _ lsfc_corres])
+        apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
             apply (simp add: split_beta)
             apply (rule corres_returnOkTT)
             apply simp
@@ -241,12 +241,12 @@ lemma dec_cnode_inv_corres:
      apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                       isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
      apply (rule corres_guard_imp)
-       apply (rule corres_splitEE [OF _ lsfc_corres])
+       apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
            apply (simp add: split_beta)
            apply (rule corres_split_norE)
               apply (rule corres_returnOkTT)
               apply simp
-             apply (rule ensure_empty_corres)
+             apply (rule ensureEmptySlot_corres)
              apply simp
             apply wp+
            apply simp
@@ -259,7 +259,7 @@ lemma dec_cnode_inv_corres:
     apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                      isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
     apply (rule corres_guard_imp)
-      apply (rule corres_splitEE [OF _ lsfc_corres])
+      apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
           apply (simp(no_asm) add: split_beta liftE_bindE)
           apply (rule corres_split_deprecated [OF _ get_cap_corres'])
              apply (rule corres_split_norE)
@@ -278,9 +278,9 @@ lemma dec_cnode_inv_corres:
    apply (simp add: le_diff_conv2 split_def decode_cnode_invocation_def decodeCNodeInvocation_def
                     isCap_simps Let_def unlessE_whenE whenE_whenE_body
                del: disj_not1 ser_def split del: if_split)
-   apply (rule corres_guard_imp, rule corres_splitEE [OF _ lsfc_corres])
+   apply (rule corres_guard_imp, rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
          apply (rename_tac dest_slot destSlot)
-         apply (rule corres_splitEE [OF _ lsfc_corres])+
+         apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])+
                  apply (rule_tac R = "\<lambda>s. cte_at pivot_slot s \<and> cte_at dest_slot s
                                         \<and> cte_at src_slot s \<and> invs s" in
                    whenE_throwError_corres' [where R' = \<top>])
@@ -320,7 +320,7 @@ lemma dec_cnode_inv_corres:
                     apply (drule (2) cte_map_inj_eq, clarsimp+)[1]
                    apply (rule corres_guard_imp)
                      apply (erule corres_whenE)
-                      apply (rule ensure_empty_corres)
+                      apply (rule ensureEmptySlot_corres)
                       apply clarsimp
                      apply simp
                     apply clarsimp
@@ -354,7 +354,7 @@ lemma dec_cnode_inv_corres:
                          cnode_invok_case_cleanup
               split del: if_split cong: if_cong)
    apply (rule corres_guard_imp)
-     apply (rule corres_splitEE[OF _ lsfc_corres])
+     apply (rule corres_splitEE[OF _ lookupSlotForCNodeOp_corres])
          apply (rule corres_trivial, clarsimp split: list.split_asm)
         apply simp+
       apply wp+
@@ -364,7 +364,7 @@ lemma dec_cnode_inv_corres:
                         isCNodeCap_CNodeCap split_def unlessE_whenE
              split del: if_split cong: if_cong)
   apply (rule corres_guard_imp)
-   apply (rule corres_splitEE [OF _ lsfc_corres wp_post_tautE wp_post_tautE])
+   apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres wp_post_tautE wp_post_tautE])
      apply (clarsimp simp: list_all2_Cons1 list_all2_Nil
                     split: list.split_asm split del: if_split)
      apply simp
@@ -7023,7 +7023,7 @@ proof (induct rule: rec_del.induct,
                                  whenE_liftE)
         apply (rule corres_when, simp)
         apply simp
-        apply (rule empty_slot_corres)
+        apply (rule emptySlot_corres)
        apply (wp rec_del_invs rec_del_valid_list rec_del_cte_at finaliseSlot_invs hoare_drop_imps
                  preemption_point_inv'
             | simp)+
@@ -7049,10 +7049,10 @@ next
                 simp add: returnOk_def)
         apply (rule spec_corres_splitE')
            apply simp
-           apply (rule final_cap_corres[where ptr=slot])
+           apply (rule isFinalCapability_corres[where ptr=slot])
           apply (rule spec_corres_splitE')
              apply simp
-             apply (rule finalise_cap_corres[where sl=slot])
+             apply (rule finaliseCap_corres[where sl=slot])
                apply simp
               apply simp
              apply simp
@@ -7070,13 +7070,13 @@ next
                apply (erule conjunct2)
               apply (rule drop_spec_corres,
                      simp add: liftME_def[symmetric] o_def dc_def[symmetric])
-              apply (rule cap_update_corres)
+              apply (rule updateCap_corres)
                apply simp
               apply (simp(no_asm_use) add: cap_cyclic_zombie_def split: cap.split_asm)
               apply (simp add: is_cap_simps)
              apply (rule spec_corres_splitE')
                 apply simp
-                apply (rule cap_update_corres, erule conjunct1)
+                apply (rule updateCap_corres, erule conjunct1)
                 apply (case_tac "fst rvb", auto simp: isCap_simps is_cap_simps)[1]
                apply (rule spec_corres_splitE)
                   apply (rule iffD1 [OF spec_corres_liftME2[where fn="\<lambda>v. (True, NullCap)"]])
@@ -7085,7 +7085,7 @@ next
                    apply (rename_tac nat)
                    apply (case_tac nat, simp_all)[1]
                   apply clarsimp
-                 apply (rule spec_corres_splitE'[OF preemption_corres])
+                 apply (rule spec_corres_splitE'[OF preemptionPoint_corres])
                    apply (rule "2.hyps"(2)[unfolded fun_app_def rec_del_concrete_unfold
                                                     finaliseSlot_def],
                           assumption+)
@@ -7208,7 +7208,7 @@ next
        apply (clarsimp simp: cte_wp_at_def)
        apply (drule(1) zombies_finalD2, clarsimp+)
       apply (fold dc_def)
-      apply (rule corres_guard_imp, rule cap_swap_for_delete_corres)
+      apply (rule corres_guard_imp, rule capSwapForDelete_corres)
          apply (simp add: cte_map_replicate)
         apply simp
        apply clarsimp
@@ -7291,7 +7291,7 @@ next
              apply (rule corres_symb_exec_r)
                 apply (rule_tac F="cteCap endCTE = capability.NullCap"
                             in corres_gen_asm2, simp)
-                apply (rule cap_update_corres)
+                apply (rule updateCap_corres)
                  apply simp
                 apply (simp add: is_cap_simps)
                apply (rule_tac Q="\<lambda>rv. cte_at' (cte_map ?target)" in valid_prove_more)
@@ -7387,7 +7387,7 @@ next
     done
 qed
 
-lemma cap_delete_corres:
+lemma cteDelete_corres:
   "corres (dc \<oplus> dc)
       (einvs and simple_sched_action and cte_at ptr and emptyable ptr)
       (invs' and sch_act_simple and cte_at' (cte_map ptr))
@@ -7636,7 +7636,7 @@ lemma cap_revoke_mdb_stuff4:
        apply(simp add: cte_wp_at_def)+
        done
 
-lemma cap_revoke_corres':
+lemma cteRevoke_corres':
   "spec_corres s (dc \<oplus> dc)
       (einvs and simple_sched_action and cte_at ptr)
       (invs' and sch_act_simple and cte_at' (cte_map ptr))
@@ -7758,8 +7758,8 @@ proof (induct rule: cap_revoke.induct)
      apply (rule cap_revoke_mdb_stuff4, (simp add: in_get_cap_cte_wp_at)+)
     apply (clarsimp simp: whenE_def)
     apply (rule spec_corres_guard_imp)
-      apply (rule spec_corres_splitE' [OF cap_delete_corres])
-        apply (rule spec_corres_splitE' [OF preemption_corres])
+      apply (rule spec_corres_splitE' [OF cteDelete_corres])
+        apply (rule spec_corres_splitE' [OF preemptionPoint_corres])
           apply (rule "1.hyps",
                    (simp add: cte_wp_at_def in_monad select_def next_revoke_cap_def select_ext_def
                      | assumption | rule conjI refl)+)[1]
@@ -7773,7 +7773,7 @@ proof (induct rule: cap_revoke.induct)
     done
 qed
 
-lemmas cap_revoke_corres = use_spec_corres [OF cap_revoke_corres']
+lemmas cteRevoke_corres = use_spec_corres [OF cteRevoke_corres']
 
 crunch typ_at'[wp]: invokeCNode "\<lambda>s. P (typ_at' T p s)"
   (ignore: finaliseSlot
@@ -8715,7 +8715,7 @@ lemma corres_null_cap_update:
      apply (rule corres_guard_imp, rule getCTE_symb_exec_r, simp+)
     prefer 3
     apply clarsimp
-    apply (rule set_cap_pspace_corres)
+    apply (rule setCTE_corres)
     apply (wp | simp)+
    apply (fastforce elim!: cte_wp_at_weakenE)
   apply wp
@@ -8724,7 +8724,7 @@ lemma corres_null_cap_update:
 
 declare corres_False' [simp]
 
-lemma inv_cnode_corres:
+lemma invokeCNode_corres:
   "cnodeinv_relation ci ci' \<Longrightarrow>
    corres (dc \<oplus> dc)
      (einvs and simple_sched_action and valid_cnode_inv ci)
@@ -8734,18 +8734,18 @@ lemma inv_cnode_corres:
   apply (cases ci, simp_all)
         apply clarsimp
         apply (rule corres_guard_imp)
-          apply (rule cins_corres)
+          apply (rule cteInsert_corres)
             apply simp+
          apply (clarsimp simp: invs_def valid_state_def valid_pspace_def
                         elim!: cte_wp_at_cte_at)
         apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
        apply clarsimp
        apply (rule corres_guard_imp)
-         apply (erule cap_move_corres)
+         apply (erule cteMove_corres)
         apply (clarsimp simp: cte_wp_at_caps_of_state real_cte_tcb_valid)
        apply (clarsimp simp: cte_wp_at_ctes_of)
-       apply (rule cap_revoke_corres)
-     apply (rule corres_guard_imp [OF cap_delete_corres])
+       apply (rule cteRevoke_corres)
+     apply (rule corres_guard_imp [OF cteDelete_corres])
       apply (clarsimp simp: cte_at_typ cap_table_at_typ halted_emptyable)
      apply simp
     apply (rename_tac cap1 cap2 p1 p2 p3)
@@ -8755,7 +8755,7 @@ lemma inv_cnode_corres:
      apply (rule corres_guard_imp)
        apply (rule_tac F="wellformed_cap cap1 \<and> wellformed_cap cap2"
               in corres_gen_asm)
-       apply (erule (1) cap_swap_corres [OF refl refl], simp+)
+       apply (erule (1) cteSwap_corres [OF refl refl], simp+)
       apply (simp add: invs_def valid_state_def valid_pspace_def
                        real_cte_tcb_valid valid_cap_def2)
      apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
@@ -8770,9 +8770,9 @@ lemma inv_cnode_corres:
      apply simp
     apply simp
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF cap_move_corres])
+      apply (rule corres_split_deprecated [OF cteMove_corres])
          apply assumption
-        apply (erule cap_move_corres)
+        apply (erule cteMove_corres)
        apply wp
        apply (simp add: cte_wp_at_caps_of_state)
        apply (wp cap_move_caps_of_state cteMove_cte_wp_at [simplified o_def])+
@@ -8798,7 +8798,7 @@ lemma inv_cnode_corres:
    apply (rename_tac prod)
    apply (simp add: getThreadCallerSlot_def locateSlot_conv objBits_simps)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated [OF _ gct_corres])
+     apply (rule corres_split_deprecated [OF _ getCurThread_corres])
         apply (subgoal_tac "thread + 2^cte_level_bits * tcbCallerSlot = cte_map (thread, tcb_cnode_index 3)")
          prefer 2
          apply (simp add: cte_map_def tcb_cnode_index_def tcbCallerSlot_def)
@@ -8818,7 +8818,7 @@ lemma inv_cnode_corres:
             apply (case_tac cap, simp_all add: isCap_simps is_cap_simps split: bool.split)[1]
             apply clarsimp
             apply (rule corres_guard_imp)
-              apply (rule cap_move_corres)
+              apply (rule cteMove_corres)
               apply (simp add: real_cte_tcb_valid)+
         apply (wp get_cap_wp)
        apply (simp add: getSlotCap_def)
@@ -8848,7 +8848,7 @@ lemma inv_cnode_corres:
                 simp add: is_cap_simps)
    apply (clarsimp simp: when_def unless_def isCap_simps)
    apply (rule corres_guard_imp)
-     apply (rule cancel_badged_sends_corres)
+     apply (rule cancelBadgedSends_corres)
     apply (simp add: valid_cap_def)
    apply (simp add: valid_cap'_def)
   apply (clarsimp)

--- a/proof/refine/ARM_HYP/CSpace1_R.thy
+++ b/proof/refine/ARM_HYP/CSpace1_R.thy
@@ -692,7 +692,7 @@ lemma getSlotCap_tcb_corres:
   apply (simp add: o_def cte_map_def tcb_cnode_index_def)
   done
 
-lemma lookup_slot_corres:
+lemma lookupSlotForThread_corres:
   "corres (lfr \<oplus> (\<lambda>(cref, bits) cref'. cref' = cte_map cref))
         (valid_objs and pspace_aligned and tcb_at t)
         (valid_objs' and pspace_aligned' and pspace_distinct' and tcb_at' t)
@@ -751,7 +751,7 @@ lemma lookupSlot_inv[wp]:
   apply (wp | simp add: split_def)+
   done
 
-lemma lc_corres:
+lemma lookupCap_corres:
  "corres (lfr \<oplus> cap_relation)
          (valid_objs and pspace_aligned and tcb_at t)
          (valid_objs' and pspace_aligned' and pspace_distinct' and tcb_at' t)
@@ -759,7 +759,7 @@ lemma lc_corres:
   apply (simp add: lookup_cap_def lookupCap_def bindE_assoc
                    lookupCapAndSlot_def liftME_def split_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_splitEE[OF _ lookup_slot_corres])
+    apply (rule corres_splitEE[OF _ lookupSlotForThread_corres])
       apply (simp add: split_def getSlotCap_def liftM_def[symmetric] o_def)
       apply (rule get_cap_corres)
      apply (rule hoare_pre, wp lookup_slot_cte_at_wp|simp)+
@@ -2421,7 +2421,7 @@ lemma pspace_relationsD:
   "\<lbrakk>pspace_relation kh kh'; ekheap_relation ekh kh'\<rbrakk> \<Longrightarrow> pspace_relations ekh kh kh'"
   by (simp add: pspace_relations_def)
 
-lemma cap_update_corres:
+lemma updateCap_corres:
   "\<lbrakk>cap_relation cap cap';
     is_zombie cap \<or> is_cnode_cap cap \<or> is_thread_cap cap \<rbrakk>
    \<Longrightarrow> corres dc (\<lambda>s. invs s \<and>
@@ -3834,7 +3834,7 @@ lemma updateUntypedCap_descendants_of:
   apply (clarsimp simp:mdb_next_rel_def mdb_next_def split:if_splits)
   done
 
-lemma set_untyped_cap_corres:
+lemma setCTE_UntypedCap_corres:
   "\<lbrakk>cap_relation cap (cteCap cte); is_untyped_cap cap; idx' = idx\<rbrakk>
    \<Longrightarrow> corres dc (cte_wp_at ((=) cap) src and valid_objs and
                   pspace_aligned and pspace_distinct)
@@ -3927,7 +3927,7 @@ lemma getCTE_get:
   apply (clarsimp simp:cte_wp_at_ctes_of)
   done
 
-lemma set_untyped_cap_as_full_corres:
+lemma setUntypedCapAsFull_corres:
   "\<lbrakk>cap_relation c c'; src' = cte_map src; dest' = cte_map dest;
     cap_relation src_cap (cteCap srcCTE); rv = cap.NullCap;
     cteCap rv' = capability.NullCap; mdbPrev (cteMDBNode rv') = nullPointer \<and>
@@ -3946,7 +3946,7 @@ lemma set_untyped_cap_as_full_corres:
         apply (rule corres_symb_exec_r)
            apply (rule_tac F="cte = srcCTE" in corres_gen_asm2)
            apply (simp)
-           apply (rule set_untyped_cap_corres)
+           apply (rule setCTE_UntypedCap_corres)
              apply simp+
            apply (clarsimp simp:free_index_update_def isCap_simps is_cap_simps)
            apply (subst identity_eq)
@@ -5162,7 +5162,7 @@ lemma cte_map_inj_eq':
   done
 
 context begin interpretation Arch . (*FIXME: arch_split*)
-lemma cins_corres:
+lemma cteInsert_corres:
   notes split_paired_All[simp del] split_paired_Ex[simp del]
         trans_state_update'[symmetric,simp]
   assumes "cap_relation c c'" "src' = cte_map src" "dest' = cte_map dest"
@@ -5595,7 +5595,7 @@ lemma cins_corres:
               apply (erule (5) cte_map_inj)
 (* FIXME *)
 
-             apply (rule set_untyped_cap_as_full_corres)
+             apply (rule setUntypedCapAsFull_corres)
                    apply simp+
             apply (wp set_untyped_cap_full_valid_objs set_untyped_cap_as_full_valid_mdb
                set_untyped_cap_as_full_cte_wp_at setUntypedCapAsFull_valid_cap
@@ -6603,7 +6603,7 @@ corres_underlying srel nf rrel G G' (do do_extended_op (return ()); g od) (g')"
   done
 *)
 
-(* consider putting in AINVS or up above cins_corres *)
+(* consider putting in AINVS or up above cteInsert_corres *)
 lemma next_slot_eq:
   "\<lbrakk>next_slot p t' m' = x; t' = t; m' = m\<rbrakk> \<Longrightarrow> next_slot p t m = x"
   by simp
@@ -6612,7 +6612,7 @@ lemma inj_on_image_set_diff15 : (* for compatibility of assumptions *)
   "\<lbrakk>inj_on f C; A \<subseteq> C; B \<subseteq> C\<rbrakk> \<Longrightarrow> f ` (A - B) = f ` A - f ` B"
 by (rule inj_on_image_set_diff; auto)
 
-lemma cap_swap_corres:
+lemma cteSwap_corres:
   assumes srcdst: "src' = cte_map src" "dest' = cte_map dest"
   assumes scr: "cap_relation scap scap'"
   assumes dcr: "cap_relation dcap dcap'"
@@ -7065,7 +7065,7 @@ lemma cap_swap_corres:
      done
 
 
-lemma cap_swap_for_delete_corres:
+lemma capSwapForDelete_corres:
   assumes "src' = cte_map src" "dest' = cte_map dest"
   shows "corres dc
          (valid_objs and pspace_aligned and pspace_distinct and
@@ -7086,7 +7086,7 @@ lemma cap_swap_for_delete_corres:
   apply (rule corres_guard_imp)
     apply (rule_tac P1=wellformed_cap in corres_split_deprecated [OF _ get_cap_corres_P])
       apply (rule_tac P1=wellformed_cap in corres_split_deprecated [OF _ get_cap_corres_P])
-        apply (rule cap_swap_corres, rule refl, rule refl, clarsimp+)
+        apply (rule cteSwap_corres, rule refl, rule refl, clarsimp+)
        apply (wp get_cap_wp getCTE_wp')+
    apply (clarsimp simp: cte_wp_at_caps_of_state)
    apply (drule (1) caps_of_state_valid_cap)+
@@ -7120,7 +7120,7 @@ lemma subtree_no_parent:
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma ensure_no_children_corres:
+lemma ensureNoChildren_corres:
   "p' = cte_map p \<Longrightarrow>
   corres (ser \<oplus> dc) (cte_at p) (pspace_aligned' and pspace_distinct' and cte_at' p' and valid_mdb')
          (ensure_no_children p) (ensureNoChildren p')"

--- a/proof/refine/ARM_HYP/CSpace_R.thy
+++ b/proof/refine/ARM_HYP/CSpace_R.thy
@@ -750,7 +750,7 @@ lemma set_cap_not_quite_corres':
                 apply (fastforce simp: c p pspace_relations_def)+
                 done
 context begin interpretation Arch . (*FIXME: arch_split*)
-lemma cap_move_corres:
+lemma cteMove_corres:
   assumes cr: "cap_relation cap cap'"
   notes trans_state_update'[symmetric,simp]
   shows
@@ -3322,7 +3322,7 @@ lemma cteInsert_invs:
   apply (auto simp: invs'_def valid_state'_def valid_pspace'_def elim: valid_capAligned)
   done
 
-lemma derive_cap_corres:
+lemma deriveCap_corres:
  "\<lbrakk>cap_relation c c'; cte = cte_map slot \<rbrakk> \<Longrightarrow>
   corres (ser \<oplus> cap_relation)
          (cte_at slot)
@@ -3333,14 +3333,14 @@ lemma derive_cap_corres:
             apply (simp_all add: returnOk_def Let_def is_zombie_def isCap_simps
                           split: sum.splits)
    apply (rule_tac Q="\<lambda>_ _. True" and Q'="\<lambda>_ _. True" in
-               corres_initial_splitE [OF ensure_no_children_corres])
+               corres_initial_splitE [OF ensureNoChildren_corres])
       apply simp
      apply clarsimp
     apply wp+
   apply clarsimp
   apply (rule corres_rel_imp)
    apply (rule corres_guard_imp)
-     apply (rule arch_derive_corres)
+     apply (rule arch_deriveCap_corres)
      apply (clarsimp simp: o_def)+
   done
 
@@ -3430,7 +3430,7 @@ lemma lookup_cap_corres:
      (lookupCap thread epcptr')"
   apply (simp add: lookup_cap_def lookupCap_def lookupCapAndSlot_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_splitEE [OF _ lookup_slot_corres])
+    apply (rule corres_splitEE [OF _ lookupSlotForThread_corres])
       apply (simp add: split_def)
       apply (subst bindE_returnOk[symmetric])
       apply (rule corres_splitEE)
@@ -3443,7 +3443,7 @@ lemma lookup_cap_corres:
    apply auto
   done
 
-lemma ensure_empty_corres:
+lemma ensureEmptySlot_corres:
   "q = cte_map p \<Longrightarrow>
    corres (ser \<oplus> dc) (invs and cte_at p) invs'
                      (ensure_empty p) (ensureEmptySlot q)"
@@ -3461,7 +3461,7 @@ lemma ensureEmpty_inv[wp]:
   "\<lbrace>P\<rbrace> ensureEmptySlot p \<lbrace>\<lambda>rv. P\<rbrace>"
   by (simp add: ensureEmptySlot_def unlessE_whenE whenE_def | wp)+
 
-lemma lsfc_corres:
+lemma lookupSlotForCNodeOp_corres:
   "\<lbrakk>cap_relation c c'; ptr = to_bl ptr'\<rbrakk>
   \<Longrightarrow> corres (ser \<oplus> (\<lambda>cref cref'. cref' = cte_map cref))
             (valid_objs and pspace_aligned and valid_cap c)
@@ -3557,7 +3557,7 @@ lemma deriveCap_untyped_derived:
   apply (clarsimp simp: cte_wp_at_ctes_of isCap_simps untyped_derived_eq_def)
   done
 
-lemma set_cap_pspace_corres:
+lemma setCTE_corres:
   "cap_relation cap (cteCap cte) \<Longrightarrow>
    corres_underlying {(s, s'). pspace_relations (ekheap (s)) (kheap s) (ksPSpace s')} False True dc
       (pspace_distinct and pspace_aligned and valid_objs and cte_at p)
@@ -3878,7 +3878,7 @@ lemma create_reply_master_corres:
     apply (clarsimp elim!: state_relationE simp: ghost_relation_of_heap)+
   apply (rule corres_guard_imp)
     apply (rule corres_underlying_symb_exec_l [OF set_original_symb_exec_l'])
-     apply (rule set_cap_pspace_corres)
+     apply (rule setCTE_corres)
      apply simp
     apply wp
    apply (clarsimp simp: cte_wp_at_cte_at valid_pspace_def)
@@ -3972,7 +3972,7 @@ proof -
     by (simp add: noReplyCapsFor_def)
 qed
 
-lemma setup_reply_master_corres:
+lemma setupReplyMaster_corres:
   "corres dc (einvs and tcb_at t) (invs' and tcb_at' t)
        (setup_reply_master t) (setupReplyMaster t)"
   apply (simp add: setupReplyMaster_def setup_reply_master_def)
@@ -4729,7 +4729,7 @@ lemma maskedAsFull_revokable_safe_parent:
 done
 
 context begin interpretation Arch . (*FIXME: arch_split*)
-lemma cins_corres_simple:
+lemma cteInsert_simple_corres:
   assumes "cap_relation c c'" "src' = cte_map src" "dest' = cte_map dest"
   notes trans_state_update'[symmetric,simp]
   shows "corres dc
@@ -4876,7 +4876,7 @@ lemma cins_corres_simple:
          apply (subgoal_tac "cte_map (aa,bb) \<noteq> cte_map dest")
           subgoal by (clarsimp simp: modify_map_def split: if_split_asm)
          apply (erule (5) cte_map_inj)
-         apply (rule set_untyped_cap_as_full_corres)
+         apply (rule setUntypedCapAsFull_corres)
          apply simp+
           apply (wp set_untyped_cap_full_valid_objs set_untyped_cap_as_full_valid_mdb set_untyped_cap_as_full_valid_list
              set_untyped_cap_as_full_cte_wp_at setUntypedCapAsFull_valid_cap
@@ -4932,7 +4932,7 @@ lemma cins_corres_simple:
    apply clarsimp
    apply (drule (5) cte_map_inj)+
    apply simp
-  (* exact reproduction of proof in cins_corres,
+  (* exact reproduction of proof in cteInsert_corres,
      as it does not used is_derived *)
   apply(simp add: cdt_list_relation_def del: split_paired_All split_paired_Ex)
   apply(subgoal_tac "no_mloop (cdt a) \<and> finite_depth (cdt a)")

--- a/proof/refine/ARM_HYP/Detype_R.thy
+++ b/proof/refine/ARM_HYP/Detype_R.thy
@@ -609,7 +609,7 @@ lemma cNodeNoPartialOverlap:
 declare wrap_ext_det_ext_ext_def[simp]
 
 
-lemma detype_corres:
+lemma deleteObjects_corres:
   "is_aligned base magnitude \<Longrightarrow> magnitude \<ge> 2 \<Longrightarrow>
    corres dc
       (\<lambda>s. einvs s

--- a/proof/refine/ARM_HYP/Finalise_R.thy
+++ b/proof/refine/ARM_HYP/Finalise_R.thy
@@ -1462,24 +1462,24 @@ lemma emptySlot_invs'[wp]:
   apply (clarsimp simp: cte_wp_at_ctes_of)
   done
 
-lemma deleted_irq_corres:
+lemma deletedIRQHandler_corres:
   "corres dc \<top> \<top>
     (deleted_irq_handler irq)
     (deletedIRQHandler irq)"
   apply (simp add: deleted_irq_handler_def deletedIRQHandler_def)
-  apply (rule set_irq_state_corres)
+  apply (rule setIRQState_corres)
   apply (simp add: irq_state_relation_def)
   done
 
-lemma arch_post_cap_deletion_corres:
+lemma arch_postCapDeletion_corres:
   "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (ARM_HYP_H.postCapDeletion cap')"
   by (corressimp simp: arch_post_cap_deletion_def ARM_HYP_H.postCapDeletion_def)
 
-lemma post_cap_deletion_corres:
+lemma postCapDeletion_corres:
   "cap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (post_cap_deletion cap) (postCapDeletion cap')"
   apply (cases cap; clarsimp simp: post_cap_deletion_def Retype_H.postCapDeletion_def)
-   apply (corressimp corres: deleted_irq_corres)
-  by (corressimp corres: arch_post_cap_deletion_corres)
+   apply (corressimp corres: deletedIRQHandler_corres)
+  by (corressimp corres: arch_postCapDeletion_corres)
 
 lemma set_cap_trans_state:
   "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),trans_state f s') \<in> fst (set_cap c p (trans_state f s))"
@@ -1489,7 +1489,7 @@ lemma set_cap_trans_state:
       apply (auto simp: in_monad set_object_def get_object_def split: if_split_asm)
   done
 
-lemma clearUntypedFreeIndex_corres_noop:
+lemma clearUntypedFreeIndex_noop_corres:
   "corres dc \<top> (cte_at' (cte_map slot))
     (return ()) (clearUntypedFreeIndex (cte_map slot))"
   apply (simp add: clearUntypedFreeIndex_def)
@@ -1512,13 +1512,13 @@ lemma clearUntypedFreeIndex_valid_pspace'[wp]:
    apply (wp | simp add: valid_mdb'_def)+
   done
 
-lemma empty_slot_corres:
+lemma emptySlot_corres:
   "cap_relation info info' \<Longrightarrow> corres dc (einvs and cte_at slot) (invs' and cte_at' (cte_map slot))
              (empty_slot slot info) (emptySlot (cte_map slot) info')"
   unfolding emptySlot_def empty_slot_def
   apply (simp add: case_Null_If)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_noop_rhs[OF _ clearUntypedFreeIndex_corres_noop])
+    apply (rule corres_split_noop_rhs[OF _ clearUntypedFreeIndex_noop_corres])
      apply (rule_tac R="\<lambda>cap. einvs and cte_wp_at ((=) cap) slot" and
                      R'="\<lambda>cte. valid_pspace' and cte_wp_at' ((=) cte) (cte_map slot)" in
                      corres_split_deprecated [OF _ get_cap_corres])
@@ -1535,7 +1535,7 @@ lemma empty_slot_corres:
   apply (rule conjI, clarsimp)
   apply clarsimp
   apply (simp only: bind_assoc[symmetric])
-  apply (rule corres_split'[where r'=dc, OF _ post_cap_deletion_corres])
+  apply (rule corres_split'[where r'=dc, OF _ postCapDeletion_corres])
     defer
     apply wpsimp+
   apply (rule corres_no_failI)
@@ -2044,7 +2044,7 @@ lemma obj_refs_Master:
   by (clarsimp simp: isCap_simps
               split: cap_relation_split_asm arch_cap.split_asm)
 
-lemma final_cap_corres':
+lemma isFinalCapability_corres':
   "final_matters' (cteCap cte) \<Longrightarrow>
    corres (=) (invs and cte_wp_at ((=) cap) ptr)
                (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
@@ -2129,14 +2129,14 @@ lemma final_cap_corres':
   by (clarsimp simp: cap_irqs_def cap_irq_opt_def sameObjectAs_def3 isCap_simps arch_gen_obj_refs_def
                  split: cap.split_asm)
 
-lemma final_cap_corres:
+lemma isFinalCapability_corres:
   "corres (\<lambda>rv rv'. final_matters' (cteCap cte) \<longrightarrow> rv = rv')
           (invs and cte_wp_at ((=) cap) ptr)
           (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
        (is_final_cap cap) (isFinalCapability cte)"
   apply (cases "final_matters' (cteCap cte)")
    apply simp
-   apply (erule final_cap_corres')
+   apply (erule isFinalCapability_corres')
   apply (subst bind_return[symmetric],
          rule corres_symb_exec_r)
      apply (rule corres_no_failI)
@@ -3800,12 +3800,12 @@ lemma interrupt_cap_null_or_ntfn:
                  split: cap.split_asm)
   done
 
-lemma (in delete_one) deleting_irq_corres:
+lemma (in delete_one) deletingIRQHandler_corres:
   "corres dc (einvs) (invs')
           (deleting_irq_handler irq) (deletingIRQHandler irq)"
   apply (simp add: deleting_irq_handler_def deletingIRQHandler_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_irq_slot_corres])
+    apply (rule corres_split_deprecated [OF _ getIRQSlot_corres])
       apply simp
       apply (rule_tac P'="cte_at' (cte_map slot)" in corres_symb_exec_r_conj)
          apply (rule_tac F="isNotificationCap rv \<or> rv = capability.NullCap"
@@ -3844,7 +3844,7 @@ lemma sym_refs_vcpu_tcb:
 lemma vcpuFinalise_corres [corres]:
   "corres dc (invs and vcpu_at vcpu) (invs' and vcpu_at' vcpu) (vcpu_finalise vcpu) (vcpuFinalise vcpu)"
   unfolding vcpuFinalise_def vcpu_finalise_def
-  apply (corressimp corres: get_vcpu_corres simp: vcpu_relation_def)
+  apply (corressimp corres: getObject_vcpu_corres simp: vcpu_relation_def)
      apply (wpsimp wp: get_vcpu_wp getVCPU_wp)+
   apply (rule conjI)
    apply clarsimp
@@ -3857,7 +3857,7 @@ lemma vcpuFinalise_corres [corres]:
   apply (clarsimp simp: valid_obj'_def valid_vcpu'_def typ_at_tcb')
   done
 
-lemma arch_finalise_cap_corres:
+lemma arch_finaliseCap_corres:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
            (\<lambda>s. invs s \<and> valid_etcbs s
@@ -3874,25 +3874,25 @@ lemma arch_finalise_cap_corres:
                        final_matters'_def case_bool_If liftM_def[symmetric]
                        o_def dc_def[symmetric]
                 split: option.split, safe)
-     apply (rule corres_guard_imp, rule delete_asid_pool_corres)
+     apply (rule corres_guard_imp, rule deleteASIDPool_corres)
       apply (clarsimp simp: valid_cap_def mask_def)
      apply (clarsimp simp: valid_cap'_def)
      apply auto[1]
-    apply (rule corres_guard_imp, rule unmap_page_corres)
+    apply (rule corres_guard_imp, rule unmapPage_corres)
       apply simp
      apply (clarsimp simp: valid_cap_def valid_unmap_def)
      apply (auto simp: vmsz_aligned_def pbfs_atleast_pageBits mask_def
                  elim: is_aligned_weaken invs_valid_asid_map)[2]
-   apply (rule corres_guard_imp, rule unmap_page_table_corres)
+   apply (rule corres_guard_imp, rule unmapPageTable_corres)
     apply (auto simp: valid_cap_def valid_cap'_def mask_def
                elim!: is_aligned_weaken invs_valid_asid_map)[2]
-  apply (rule corres_guard_imp, rule delete_asid_corres)
+  apply (rule corres_guard_imp, rule deleteASID_corres)
    apply (auto elim!: invs_valid_asid_map simp: mask_def valid_cap_def)[2]
   apply corres
   apply (clarsimp simp: valid_cap_def valid_cap'_def)
   done
 
-lemma unbind_notification_corres:
+lemma unbindNotification_corres:
   "corres dc
       (invs and tcb_at t)
       (invs' and tcb_at' t)
@@ -3901,14 +3901,14 @@ lemma unbind_notification_corres:
   supply option.case_cong_weak[cong]
   apply (simp add: unbind_notification_def unbindNotification_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gbn_corres])
+    apply (rule corres_split_deprecated[OF _ getBoundNotification_corres])
       apply (rule corres_option_split)
         apply simp
        apply (rule corres_return_trivial)
-      apply (rule corres_split_deprecated[OF _ get_ntfn_corres])
+      apply (rule corres_split_deprecated[OF _ getNotification_corres])
         apply clarsimp
-        apply (rule corres_split_deprecated[OF _ set_ntfn_corres])
-           apply (rule sbn_corres)
+        apply (rule corres_split_deprecated[OF _ setNotification_corres])
+           apply (rule setBoundNotification_corres)
           apply (clarsimp simp: ntfn_relation_def split:Structures_A.ntfn.splits)
          apply (wp gbn_wp' gbn_wp)+
    apply (clarsimp elim!: obj_at_valid_objsE
@@ -3922,19 +3922,19 @@ lemma unbind_notification_corres:
                   split: option.splits)
   done
 
-lemma unbind_maybe_notification_corres:
+lemma unbindMaybeNotification_corres:
   "corres dc
       (invs and ntfn_at ntfnptr) (invs' and ntfn_at' ntfnptr)
       (unbind_maybe_notification ntfnptr)
       (unbindMaybeNotification ntfnptr)"
   apply (simp add: unbind_maybe_notification_def unbindMaybeNotification_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ get_ntfn_corres])
+    apply (rule corres_split_deprecated[OF _ getNotification_corres])
       apply (rule corres_option_split)
         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
        apply (rule corres_return_trivial)
-      apply (rule corres_split_deprecated[OF _ set_ntfn_corres])
-         apply (rule sbn_corres)
+      apply (rule corres_split_deprecated[OF _ setNotification_corres])
+         apply (rule setBoundNotification_corres)
         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
        apply (wp get_simple_ko_wp getNotification_wp)+
    apply (clarsimp elim!: obj_at_valid_objsE
@@ -3948,7 +3948,7 @@ lemma unbind_maybe_notification_corres:
                   split: option.splits)
   done
 
-lemma fast_finalise_corres:
+lemma fast_finaliseCap_corres:
   "\<lbrakk> final_matters' cap' \<longrightarrow> final = final'; cap_relation cap cap';
      can_fast_finalise cap \<rbrakk>
    \<Longrightarrow> corres dc
@@ -3974,8 +3974,8 @@ lemma fast_finalise_corres:
    apply (simp add: valid_cap'_def)
   apply (clarsimp simp: final_matters'_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ unbind_maybe_notification_corres])
-         apply (rule ntfn_cancel_corres)
+    apply (rule corres_split_deprecated[OF _ unbindMaybeNotification_corres])
+         apply (rule cancelAllSignals_corres)
        apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps getNotification_wp
             | wpc)+
    apply (clarsimp simp: valid_cap_def)
@@ -3994,10 +3994,10 @@ lemma cap_delete_one_corres:
       apply (rule_tac F="can_fast_finalise cap" in corres_gen_asm)
       apply (rule corres_if)
         apply fastforce
-       apply (rule corres_split_deprecated [OF _ final_cap_corres[where ptr=ptr]])
+       apply (rule corres_split_deprecated [OF _ isFinalCapability_corres[where ptr=ptr]])
          apply (simp add: split_def bind_assoc [THEN sym])
-         apply (rule corres_split_deprecated [OF _ fast_finalise_corres[where sl=ptr]])
-              apply (rule empty_slot_corres)
+         apply (rule corres_split_deprecated [OF _ fast_finaliseCap_corres[where sl=ptr]])
+              apply (rule emptySlot_corres)
              apply simp+
           apply (wp hoare_drop_imps)+
         apply (wp isFinalCapability_inv | wp (once) isFinal[where x="cte_map ptr"])+
@@ -4040,7 +4040,7 @@ crunches ThreadDecls_H.suspend, unbindNotification
 end
 end
 
-lemma finalise_cap_corres:
+lemma finaliseCap_corres:
   "\<lbrakk> final_matters' cap' \<Longrightarrow> final = final'; cap_relation cap cap';
           flag \<longrightarrow> can_fast_finalise cap \<rbrakk>
      \<Longrightarrow> corres (\<lambda>x y. cap_relation (fst x) (fst y) \<and> cap_relation (snd x) (snd y))
@@ -4063,8 +4063,8 @@ lemma finalise_cap_corres:
         apply (simp add: valid_cap'_def)
        apply (clarsimp simp add: final_matters'_def)
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated[OF _ unbind_maybe_notification_corres])
-           apply (rule ntfn_cancel_corres)
+         apply (rule corres_split_deprecated[OF _ unbindMaybeNotification_corres])
+           apply (rule cancelAllSignals_corres)
           apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps hoare_vcg_all_lift | wpc)+
         apply (clarsimp simp: valid_cap_def)
        apply (clarsimp simp: valid_cap'_def)
@@ -4079,7 +4079,7 @@ lemma finalise_cap_corres:
        apply (clarsimp dest!: no_idle_thread_cap)
       apply (clarsimp simp: state_relation_def)
      apply (rule corres_guard_imp)
-       apply (rule corres_split_deprecated[OF _ unbind_notification_corres])
+       apply (rule corres_split_deprecated[OF _ unbindNotification_corres])
          apply (rule corres_split_deprecated[OF _ suspend_corres])
             apply (clarsimp simp: liftM_def[symmetric] o_def dc_def[symmetric] zbits_map_def)
           apply (rule prepareThreadDelete_corres)
@@ -4089,7 +4089,7 @@ lemma finalise_cap_corres:
      apply (simp add: valid_cap'_def)
     apply (simp add: final_matters'_def liftM_def[symmetric] o_def dc_def[symmetric])
     apply (intro impI, rule corres_guard_imp)
-      apply (rule deleting_irq_corres)
+      apply (rule deletingIRQHandler_corres)
      apply simp
     apply simp
    apply (clarsimp simp: final_matters'_def)
@@ -4099,7 +4099,7 @@ lemma finalise_cap_corres:
     apply (clarsimp simp: cte_wp_at_caps_of_state)
    apply simp
   apply (clarsimp split del: if_split simp: o_def)
-  apply (rule corres_guard_imp [OF arch_finalise_cap_corres], (fastforce simp: valid_sched_def)+)
+  apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
   done
 
 context begin interpretation Arch . (*FIXME: arch_split*)

--- a/proof/refine/ARM_HYP/InterruptAcc_R.thy
+++ b/proof/refine/ARM_HYP/InterruptAcc_R.thy
@@ -8,7 +8,7 @@ theory InterruptAcc_R
 imports TcbAcc_R
 begin
 
-lemma get_irq_slot_corres:
+lemma getIRQSlot_corres:
   "corres (\<lambda>sl sl'. sl' = cte_map sl) \<top> \<top> (get_irq_slot irq) (getIRQSlot irq)"
   apply (simp add: getIRQSlot_def get_irq_slot_def locateSlot_conv
                    liftM_def[symmetric])
@@ -23,7 +23,7 @@ crunch inv[wp]: getIRQSlot "P"
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma set_irq_state_corres:
+lemma setIRQState_corres:
   "irq_state_relation state state' \<Longrightarrow>
    corres dc \<top> \<top> (set_irq_state state irq) (setIRQState state' irq)"
   apply (simp add: set_irq_state_def setIRQState_def
@@ -99,7 +99,7 @@ lemma work_units_and_irq_state_state_relationI [intro!]:
    \<in> state_relation"
   by (simp add: state_relation_def swp_def)
 
-lemma preemption_corres:
+lemma preemptionPoint_corres:
   "corres (dc \<oplus> dc) \<top> \<top> preemption_point preemptionPoint"
   apply (simp add: preemption_point_def preemptionPoint_def)
   by (auto simp: preemption_point_def preemptionPoint_def o_def gets_def liftE_def whenE_def getActiveIRQ_def

--- a/proof/refine/ARM_HYP/Interrupt_R.thy
+++ b/proof/refine/ARM_HYP/Interrupt_R.thy
@@ -92,7 +92,7 @@ where
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma decode_irq_handler_corres:
+lemma decodeIRQHandlerInvocation_corres:
   "\<lbrakk> list_all2 cap_relation (map fst caps) (map fst caps');
     list_all2 (\<lambda>p pa. snd pa = cte_map (snd p)) caps caps' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> irq_handler_inv_relation) invs invs'
@@ -152,7 +152,7 @@ lemma isIRQActive_wp:
   apply (clarsimp simp: irq_issued'_def)
   done
 
-lemma arch_check_irq_corres:
+lemma checkIRQ_corres:
   "corres (ser \<oplus> dc) \<top> \<top> (arch_check_irq irq) (checkIRQ irq)"
   unfolding arch_check_irq_def checkIRQ_def rangeCheck_def
   apply (rule corres_guard_imp)
@@ -193,7 +193,7 @@ lemma arch_check_irq_maxIRQ_valid':
   "\<lbrace>\<top>\<rbrace> arch_check_irq y \<lbrace>\<lambda>_ _. unat y \<le> unat maxIRQ\<rbrace>, \<lbrace>\<lambda>_. \<top>\<rbrace>"
   by (wp arch_check_irq_maxIRQ_valid)
 
-lemma arch_decode_irq_control_corres:
+lemma arch_decodeIRQControlInvocation_corres:
   "list_all2 cap_relation caps caps' \<Longrightarrow>
    corres (ser \<oplus> arch_irq_control_inv_relation)
      (invs and (\<lambda>s. \<forall>cp \<in> set caps. s \<turnstile> cp))
@@ -215,13 +215,13 @@ lemma arch_decode_irq_control_corres:
   \<comment> \<open> ARM_HYPIRQIssueIRQHandler \<close>
   apply (rule conjI, clarsimp)
    apply (rule corres_guard_imp)
-     apply (rule corres_splitEE[OF _ arch_check_irq_corres])
+     apply (rule corres_splitEE[OF _ checkIRQ_corres])
        apply (rule_tac F="unat y \<le> unat maxIRQ" in corres_gen_asm)
        apply (clarsimp simp add: minIRQ_def maxIRQ_def ucast_nat_def)
        apply (rule corres_split_eqr[OF _ is_irq_active_corres])
          apply (rule whenE_throwError_corres, clarsimp, clarsimp)
-         apply (rule corres_splitEE[OF _ lsfc_corres])
-             apply (rule corres_splitEE[OF _ ensure_empty_corres])
+         apply (rule corres_splitEE[OF _ lookupSlotForCNodeOp_corres])
+             apply (rule corres_splitEE[OF _ ensureEmptySlot_corres])
                 apply (rule corres_returnOkTT)
                 apply (clarsimp simp: arch_irq_control_inv_relation_def )
                apply ((wpsimp wp: isIRQActive_inv arch_check_irq_maxIRQ_valid' checkIRQ_inv
@@ -239,7 +239,7 @@ lemma irqhandler_simp[simp]:
 
 lemmas unat_le_mono = word_le_nat_alt [THEN iffD1]
 
-lemma decode_irq_control_corres:
+lemma decodeIRQControlInvocation_corres:
   "list_all2 cap_relation caps caps' \<Longrightarrow>
    corres (ser \<oplus> irq_control_inv_relation)
      (invs and (\<lambda>s. \<forall>cp \<in> set caps. s \<turnstile> cp)) (invs' and (\<lambda>s. \<forall>cp \<in> set caps'. s \<turnstile>' cp))
@@ -260,8 +260,8 @@ lemma decode_irq_control_corres:
      apply (subgoal_tac "length args \<le> 2", clarsimp split: list.split)
      apply arith
     apply (simp add: minIRQ_def o_def)
-    apply (auto intro!: corres_guard_imp[OF arch_decode_irq_control_corres])[1]
-   apply (auto intro!: corres_guard_imp[OF arch_decode_irq_control_corres]
+    apply (auto intro!: corres_guard_imp[OF arch_decodeIRQControlInvocation_corres])[1]
+   apply (auto intro!: corres_guard_imp[OF arch_decodeIRQControlInvocation_corres]
                dest!: not_le_imp_less
                simp: minIRQ_def o_def length_Suc_conv whenE_rangeCheck_eq ucast_nat_def
                split: list.splits)[1]
@@ -272,8 +272,8 @@ lemma decode_irq_control_corres:
     apply (clarsimp simp add: minIRQ_def maxIRQ_def ucast_nat_def)
     apply (rule corres_split_eqr[OF _ is_irq_active_corres])
       apply (rule whenE_throwError_corres, clarsimp, clarsimp)
-      apply (rule corres_splitEE[OF _ lsfc_corres])
-          apply (rule corres_splitEE[OF _ ensure_empty_corres])
+      apply (rule corres_splitEE[OF _ lookupSlotForCNodeOp_corres])
+          apply (rule corres_splitEE[OF _ ensureEmptySlot_corres])
              apply (rule corres_returnOkTT)
              apply (clarsimp simp: arch_irq_control_inv_relation_def )
             apply (wpsimp wp: isIRQActive_inv arch_check_irq_maxIRQ_valid' checkIRQ_inv
@@ -358,7 +358,7 @@ lemma valid_globals_ex_cte_cap_irq:
     mult.commute mult.left_commute)
   done
 
-lemma invoke_irq_handler_corres:
+lemma invokeIRQHandler_corres:
   "irq_handler_inv_relation i i' \<Longrightarrow>
    corres dc (einvs and irq_handler_inv_valid i)
              (invs' and irq_handler_inv_valid' i')
@@ -371,10 +371,10 @@ lemma invoke_irq_handler_corres:
    apply (rename_tac word cap prod)
    apply clarsimp
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated [OF _ get_irq_slot_corres])
+     apply (rule corres_split_deprecated [OF _ getIRQSlot_corres])
        apply simp
        apply (rule corres_split_nor [OF _ cap_delete_one_corres])
-         apply (rule cins_corres, simp+)
+         apply (rule cteInsert_corres, simp+)
         apply (rule_tac Q="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
                                   \<and> (a, b) \<noteq> irq_slot
                                   \<and> cte_wp_at (is_derived (cdt s) (a, b) cap) (a, b) s"
@@ -389,7 +389,7 @@ lemma invoke_irq_handler_corres:
     apply (erule cte_wp_at_weakenE, simp add: is_derived_use_interrupt)
    apply fastforce
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_irq_slot_corres])
+    apply (rule corres_split_deprecated [OF _ getIRQSlot_corres])
       apply simp
       apply (rule cap_delete_one_corres)
      apply wp+
@@ -469,7 +469,7 @@ lemma setIRQTrigger_corres:
             | simp add: dc_def)+
   done
 
-lemma arch_invoke_irq_control_corres:
+lemma arch_performIRQControl_corres:
   "arch_irq_control_inv_relation x2 ivk' \<Longrightarrow> corres (dc \<oplus> dc)
           (einvs and arch_irq_control_inv_valid x2)
           (invs' and arch_irq_control_inv_valid' ivk')
@@ -479,8 +479,8 @@ lemma arch_invoke_irq_control_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_nor)
        apply (rule corres_split_nor)
-          apply (rule cins_corres_simple; simp)
-         apply (rule set_irq_state_corres)
+          apply (rule cteInsert_simple_corres; simp)
+         apply (rule setIRQState_corres)
          apply (simp add: irq_state_relation_def)
         apply (wp | simp add: irq_state_relation_def IRQHandler_valid IRQHandler_valid')+
       apply (rule setIRQTrigger_corres)
@@ -496,7 +496,7 @@ lemma arch_invoke_irq_control_corres:
   apply (auto dest: valid_irq_handlers_ctes_ofD)[1]
   done
 
-lemma invoke_irq_control_corres:
+lemma performIRQControl_corres:
   "irq_control_inv_relation i i' \<Longrightarrow>
    corres (dc \<oplus> dc) (einvs and irq_control_inv_valid i)
              (invs' and irq_control_inv_valid' i')
@@ -504,8 +504,8 @@ lemma invoke_irq_control_corres:
      (performIRQControl i')"
   apply (cases i, simp_all add: performIRQControl_def)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_nor [OF _ set_irq_state_corres])
-        apply (rule cins_corres_simple)
+     apply (rule corres_split_nor [OF _ setIRQState_corres])
+        apply (rule cteInsert_simple_corres)
           apply (wp | simp add: irq_state_relation_def
                                 IRQHandler_valid IRQHandler_valid')+
     apply (clarsimp simp: invs_def valid_state_def valid_pspace_def
@@ -518,7 +518,7 @@ lemma invoke_irq_control_corres:
    apply (case_tac ctea)
    apply (clarsimp simp: isCap_simps sameRegionAs_def3)
    apply (auto dest: valid_irq_handlers_ctes_ofD)[1]
-  by (clarsimp simp: arch_invoke_irq_control_corres)
+  by (clarsimp simp: arch_performIRQControl_corres)
 
 crunch valid_cap'[wp]: setIRQState "valid_cap' cap"
 
@@ -576,7 +576,7 @@ lemma invoke_irq_control_invs'[wp]:
               simp: invs'_def valid_state'_def)
   done
 
-lemma get_irq_state_corres:
+lemma getIRQState_corres:
   "corres irq_state_relation \<top> \<top>
        (get_irq_state irq) (getIRQState irq)"
   apply (simp add: get_irq_state_def getIRQState_def getInterruptState_def)
@@ -597,7 +597,7 @@ lemma num_domains[simp]:
   apply(simp add: num_domains_def numDomains_def)
   done
 
-lemma dec_domain_time_corres:
+lemma decDomainTime_corres:
   "corres dc \<top> \<top> dec_domain_time decDomainTime"
   apply (simp add:dec_domain_time_def corres_underlying_def
     decDomainTime_def simpler_modify_def)
@@ -642,15 +642,15 @@ lemma timerTick_corres:
   apply (simp add:thread_state_case_if threadState_case_if)
   apply (rule_tac Q="\<top> and (cur_tcb and valid_sched)" and Q'="\<top> and invs'" in corres_guard_imp)
   apply (rule corres_guard_imp)
-  apply (rule corres_split_deprecated [OF _ gct_corres])
+  apply (rule corres_split_deprecated [OF _ getCurThread_corres])
       apply simp
-      apply (rule corres_split_deprecated [OF _ gts_corres])
+      apply (rule corres_split_deprecated [OF _ getThreadState_corres])
         apply (rename_tac state state')
         apply (rule corres_split_deprecated[where r' = dc ])
            apply simp
            apply (rule corres_when,simp)
-           apply (rule corres_split_deprecated[OF _ dec_domain_time_corres])
-             apply (rule corres_split_deprecated[OF _ domain_time_corres])
+           apply (rule corres_split_deprecated[OF _ decDomainTime_corres])
+             apply (rule corres_split_deprecated[OF _ getDomainTime_corres])
                apply (rule corres_when,simp)
                apply (rule rescheduleRequired_corres)
               apply (wp hoare_drop_imp)+
@@ -841,14 +841,14 @@ proof -
                  apply (rename_tac eisr0 eisr1 flags)
                  apply (rule corres_split_deprecated[OF _ corres_gets_numlistregs])
                    apply (rule corres_split_deprecated[where r'="\<lambda>rv rv'. rv' = arch_fault_map rv"])
-                      apply (rule corres_split_eqr[OF _ gct_corres])
-                        apply (rule corres_split_deprecated[OF _ gts_corres])
+                      apply (rule corres_split_eqr[OF _ getCurThread_corres])
+                        apply (rule corres_split_deprecated[OF _ getThreadState_corres])
                           apply (fold dc_def)
                           apply (rule corres_when)
                            apply clarsimp
                            apply (rename_tac threadState threadState')
                            apply (case_tac threadState; simp)
-                          apply (rule hf_corres)
+                          apply (rule handleFault_corres)
                           apply clarsimp
                          apply clarsimp
                          apply (wp gts_wp)
@@ -906,7 +906,7 @@ proof -
     done
 qed
 
-lemma vppi_event_corres:
+lemma vppiEvent_corres:
   "corres dc einvs
     (\<lambda>s. invs' s \<and> sch_act_not (ksCurThread s) s \<and> (\<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p)))
     (vppi_event irq) (vppiEvent irq)"
@@ -924,12 +924,12 @@ lemma vppi_event_corres:
 
       apply (rule corres_split_dc[OF _ corres_machine_op])
          apply (rule corres_split_dc[OF _ vcpuUpdate_corres])
-            apply (rule corres_split_eqr[OF _ gct_corres])
-              apply (rule corres_split_deprecated[OF _ gts_corres], rename_tac gts gts')
+            apply (rule corres_split_eqr[OF _ getCurThread_corres])
+              apply (rule corres_split_deprecated[OF _ getThreadState_corres], rename_tac gts gts')
                 apply (fold dc_def)
                 apply (rule corres_when)
                  apply (case_tac gts; fastforce)
-                apply (rule hf_corres, simp)
+                apply (rule handleFault_corres, simp)
                apply (wp gts_st_tcb_at hoare_vcg_imp_lift')
               apply (wp gts_st_tcb_at' hoare_vcg_imp_lift')
              (* on both sides, we check that the current thread is runnable, then have to know it
@@ -984,14 +984,14 @@ lemma handle_reserved_irq_corres[corres]:
                         irq_vppi_event_index_def non_kernel_IRQs_def IRQ_def irqVGICMaintenance_def
                         irqVTimerEvent_def)
   apply (rule conjI; clarsimp)
-   apply (rule corres_guard_imp, rule vppi_event_corres)
+   apply (rule corres_guard_imp, rule vppiEvent_corres)
      apply (fastforce intro: vgic_maintenance_corres simp: unat_arith_simps)+
   apply (rule conjI; clarsimp)
    apply (rule corres_guard_imp)
      apply (fastforce intro: vgic_maintenance_corres simp: unat_arith_simps)+
   done
 
-lemma handle_interrupt_corres:
+lemma handleInterrupt_corres:
   "corres dc
      (einvs)
      (invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive) and
@@ -1002,7 +1002,7 @@ lemma handle_interrupt_corres:
   apply (simp add: handle_interrupt_def handleInterrupt_def)
   apply (rule conjI[rotated]; rule impI)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated [OF _ get_irq_state_corres,
+     apply (rule corres_split_deprecated [OF _ getIRQState_corres,
                               where R="\<lambda>rv. einvs"
                                 and R'="\<lambda>rv. invs' and ?P' and (\<lambda>s. rv \<noteq> IRQInactive)"])
        defer
@@ -1016,7 +1016,7 @@ lemma handle_interrupt_corres:
   apply (case_tac st, simp_all add: irq_state_relation_def split: irqstate.split_asm)
     apply (simp add: getSlotCap_def bind_assoc)
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF _ get_irq_slot_corres])
+      apply (rule corres_split_deprecated [OF _ getIRQSlot_corres])
         apply simp
         apply (rule corres_split_deprecated [OF _ get_cap_corres,
                                  where R="\<lambda>rv. einvs and valid_cap rv"
@@ -1024,7 +1024,7 @@ lemma handle_interrupt_corres:
           apply (rule corres_split'[where r'=dc])
              apply (case_tac xb, simp_all add: doMachineOp_return)[1]
               apply (clarsimp simp add: when_def doMachineOp_return)
-              apply (rule corres_guard_imp, rule send_signal_corres)
+              apply (rule corres_guard_imp, rule sendSignal_corres)
                apply (clarsimp simp: valid_cap_def valid_cap'_def do_machine_op_bind doMachineOp_bind)+
             apply (clarsimp simp: arch_mask_irq_signal_def maskIrqSignal_def)
             apply (rule corres_split_deprecated)

--- a/proof/refine/ARM_HYP/IpcCancel_R.thy
+++ b/proof/refine/ARM_HYP/IpcCancel_R.thy
@@ -169,7 +169,7 @@ lemma invs_weak_sch_act_wf[elim!]:
 crunch tcb_at[wp]: set_endpoint "tcb_at t"
 crunch tcb_at'[wp]: setEndpoint "tcb_at' t"
 
-lemma blocked_cancel_ipc_corres:
+lemma blocked_cancelIPC_corres:
   "\<lbrakk> st = Structures_A.BlockedOnReceive epPtr p' \<or>
      st = Structures_A.BlockedOnSend epPtr p; thread_state_relation st st' \<rbrakk> \<Longrightarrow>
    corres dc (invs and st_tcb_at ((=) st) t) (invs' and st_tcb_at' ((=) st') t)
@@ -185,7 +185,7 @@ lemma blocked_cancel_ipc_corres:
             od)"
   apply (simp add: blocked_cancel_ipc_def gbep_ret)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres])
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres])
       apply (rule_tac F="ep \<noteq> IdleEP" in corres_gen_asm2)
       apply (rule corres_assert_assume[rotated])
        apply (clarsimp split: endpoint.splits)
@@ -198,8 +198,8 @@ lemma blocked_cancel_ipc_corres:
        apply (case_tac "remove1 t list")
         apply simp
         apply (rule corres_guard_imp)
-          apply (rule corres_split_deprecated [OF _ set_ep_corres])
-             apply (rule sts_corres)
+          apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+             apply (rule setThreadState_corres)
              apply simp
             apply (simp add: ep_relation_def)
            apply (simp add: valid_tcb_state_def pred_conj_def)
@@ -221,8 +221,8 @@ lemma blocked_cancel_ipc_corres:
                               valid_tcb_state'_def)[1]
        apply clarsimp
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
-            apply (rule sts_corres)
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+            apply (rule setThreadState_corres)
             apply simp
            apply (simp add: ep_relation_def)
           apply (wp)+
@@ -246,8 +246,8 @@ lemma blocked_cancel_ipc_corres:
       apply (case_tac "remove1 t list")
        apply simp
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
-            apply (rule sts_corres)
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+            apply (rule setThreadState_corres)
             apply simp
            apply (simp add: ep_relation_def)
           apply (simp add: valid_tcb_state_def pred_conj_def)
@@ -269,8 +269,8 @@ lemma blocked_cancel_ipc_corres:
                              valid_tcb_state'_def)[1]
       apply clarsimp
       apply (rule corres_guard_imp)
-        apply (rule corres_split_deprecated [OF _ set_ep_corres])
-           apply (rule sts_corres)
+        apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+           apply (rule setThreadState_corres)
            apply simp
           apply (simp add: ep_relation_def)
          apply (wp)+
@@ -308,7 +308,7 @@ lemma blocked_cancel_ipc_corres:
   apply (fastforce simp: ko_wp_at'_def obj_at'_def projectKOs dest: sym_refs_st_tcb_atD')
   done
 
-lemma ac_corres:
+lemma cancelSignal_corres:
   "corres dc
           (invs and st_tcb_at ((=) (Structures_A.BlockedOnNotification ntfn)) t)
           (invs' and st_tcb_at' ((=) (BlockedOnNotification ntfn)) t)
@@ -316,7 +316,7 @@ lemma ac_corres:
           (cancelSignal t ntfn)"
   apply (simp add: cancel_signal_def cancelSignal_def Let_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ntfn_corres])
+    apply (rule corres_split_deprecated [OF _ getNotification_corres])
       apply (rule_tac F="isWaitingNtfn (ntfnObj ntfnaa)" in corres_gen_asm2)
       apply (case_tac "ntfn_obj ntfna")
         apply (simp add: ntfn_relation_def isWaitingNtfn_def)
@@ -324,14 +324,14 @@ lemma ac_corres:
        apply (rename_tac list)
        apply (rule_tac R="remove1 t list = []" in corres_cases)
         apply (simp del: dc_simp)
-        apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-           apply (rule sts_corres)
+        apply (rule corres_split_deprecated [OF _ setNotification_corres])
+           apply (rule setThreadState_corres)
            apply simp
           apply (simp add: ntfn_relation_def)
          apply (wp)+
        apply (simp add: list_case_If del: dc_simp)
-       apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-          apply (rule sts_corres)
+       apply (rule corres_split_deprecated [OF _ setNotification_corres])
+          apply (rule setThreadState_corres)
           apply simp
          apply (clarsimp simp add: ntfn_relation_def neq_Nil_conv)
         apply (wp)+
@@ -523,7 +523,7 @@ locale delete_one = delete_one_conc + delete_one_abs +
                (invs' and cte_at' (cte_map ptr))
           (cap_delete_one ptr) (cteDeleteOne (cte_map ptr))"
 
-lemma (in delete_one) reply_cancel_ipc_corres:
+lemma (in delete_one) cancelIPC_ReplyCap_corres:
   "corres dc (einvs  and st_tcb_at awaiting_reply t)
              (invs' and st_tcb_at' awaiting_reply' t)
       (reply_cancel_ipc t)
@@ -613,28 +613,28 @@ lemma (in delete_one) cancel_ipc_corres:
       (cancel_ipc t) (cancelIPC t)"
   apply (simp add: cancel_ipc_def cancelIPC_def Let_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gts_corres])
+    apply (rule corres_split_deprecated [OF _ getThreadState_corres])
       apply (rule_tac P="einvs and st_tcb_at ((=) state) t" and
                       P'="invs' and st_tcb_at' ((=) statea) t" in corres_inst)
       apply (case_tac state, simp_all add: isTS_defs list_case_If)[1]
          apply (rule corres_guard_imp)
-           apply (rule blocked_cancel_ipc_corres)
+           apply (rule blocked_cancelIPC_corres)
             apply fastforce
            apply fastforce
           apply simp
          apply simp
         apply (clarsimp simp add: isTS_defs list_case_If)
         apply (rule corres_guard_imp)
-          apply (rule blocked_cancel_ipc_corres)
+          apply (rule blocked_cancelIPC_corres)
            apply fastforce
           apply fastforce
          apply simp
         apply simp
        apply (rule corres_guard_imp)
-         apply (rule reply_cancel_ipc_corres)
+         apply (rule cancelIPC_ReplyCap_corres)
         apply (clarsimp elim!: st_tcb_weakenE)
        apply (clarsimp elim!: pred_tcb'_weakenE)
-      apply (rule corres_guard_imp [OF ac_corres], simp+)
+      apply (rule corres_guard_imp [OF cancelSignal_corres], simp+)
      apply (wp gts_sp[where P="\<top>",simplified])+
     apply (rule hoare_strengthen_post)
      apply (rule gts_sp'[where P="\<top>"])
@@ -1422,9 +1422,9 @@ lemma (in delete_one) suspend_corres:
   apply (simp add: IpcCancel_A.suspend_def Thread_H.suspend_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_nor [OF _ cancel_ipc_corres])
-      apply (rule corres_split_deprecated [OF _ gts_corres])
+      apply (rule corres_split_deprecated [OF _ getThreadState_corres])
         apply (rule corres_split_nor)
-           apply (rule corres_split_nor [OF _ sts_corres])
+           apply (rule corres_split_nor [OF _ setThreadState_corres])
               apply (rule tcbSchedDequeue_corres')
              apply wpsimp
             apply wp
@@ -1432,7 +1432,7 @@ lemma (in delete_one) suspend_corres:
           apply (rule corres_if)
             apply (case_tac state; simp)
            apply (simp add: update_restart_pc_def updateRestartPC_def)
-           apply (rule corres_as_user')
+           apply (rule asUser_corres')
            apply (simp add: ARM_HYP.nextInstructionRegister_def ARM_HYP.faultRegister_def
                             ARM_HYP_H.nextInstructionRegister_def ARM_HYP_H.faultRegister_def)
            apply (simp add: ARM_HYP_H.Register_def)
@@ -1465,7 +1465,7 @@ lemma tcb_vcpu_relation:
   "arch_tcb_relation a a' \<Longrightarrow> tcb_vcpu a = atcbVCPUPtr a'"
   unfolding arch_tcb_relation_def by auto
 
-lemma archThreadGet_vcpu_corres[corres]:
+lemma archThreadGet_VCPU_corres[corres]:
   "corres (=) (tcb_at t) (tcb_at' t) (arch_thread_get tcb_vcpu t) (archThreadGet atcbVCPUPtr t)"
   by (rule archThreadGet_corres) (erule tcb_vcpu_relation)
 
@@ -1500,12 +1500,12 @@ lemma archThreadSet_corres:
   "(\<And>a a'. arch_tcb_relation a a' \<Longrightarrow> arch_tcb_relation (f a) (f' a')) \<Longrightarrow>
   corres dc (tcb_at t) (tcb_at' t) (arch_thread_set f t) (archThreadSet f' t)"
   apply (simp add: arch_thread_set_def archThreadSet_def)
-  apply (corres corres: get_tcb_corres tcb_update_corres')
+  apply (corres corres: get_tcb_corres setObject_update_TCB_corres')
   apply wpsimp+
   apply (auto simp add: tcb_relation_def tcb_cap_cases_def tcb_cte_cases_def exst_same_def)+
   done
 
-lemma archThreadSet_corres_vcpu_None[corres]:
+lemma archThreadSet_VCPU_None_corres[corres]:
   "t = t' \<Longrightarrow> corres dc (tcb_at t) (tcb_at' t')
     (arch_thread_set (tcb_vcpu_update Map.empty) t) (archThreadSet (atcbVCPUPtr_update Map.empty) t')"
   apply simp
@@ -1520,9 +1520,9 @@ lemma no_fail_setRegister[wp]: "no_fail \<top> (setRegister r v)"
   by (simp add: setRegister_def)
 
 lemmas corresK_as_user' =
-  corres_as_user'[atomized, THEN corresK_lift_rule, THEN mp]
+  asUser_corres'[atomized, THEN corresK_lift_rule, THEN mp]
 
-lemma asUser_sanitise_corres[corres]:
+lemma asUser_sanitiseRegister_corres[corres]:
   "b=b' \<Longrightarrow> t = t' \<Longrightarrow> corres dc (tcb_at t) (tcb_at' t')
             (as_user t (do cpsr \<leftarrow> getRegister CPSR;
                            setRegister CPSR (sanitise_register b CPSR cpsr)
@@ -1553,7 +1553,7 @@ lemma dissociateVCPUTCB_corres [@lift_corres_args, corres]:
              (dissociate_vcpu_tcb v t) (dissociateVCPUTCB v t)"
   unfolding dissociate_vcpu_tcb_def dissociateVCPUTCB_def
   apply (clarsimp simp:  bind_assoc when_fail_assert opt_case_when)
-  apply (corressimp corres: get_vcpu_corres set_vcpu_corres get_tcb_corres)
+  apply (corressimp corres: getObject_vcpu_corres setObject_VCPU_corres get_tcb_corres)
   apply (wpsimp wp: arch_thread_get_wp
       simp: archThreadSet_def tcb_ko_at' tcb_at_typ_at'
       | strengthen imp_drop_strg[where Q="tcb_at t s" for s]
@@ -2084,7 +2084,7 @@ lemma ep_cancel_corres_helper:
       apply (rule corres_guard_imp)
         apply (subst bind_return_unit, rule corres_split_deprecated [OF tcbSchedEnqueue_corres])
           apply simp
-          apply (rule corres_guard_imp [OF sts_corres])
+          apply (rule corres_guard_imp [OF setThreadState_corres])
             apply simp
            apply (simp add: valid_tcb_state_def)
           apply simp
@@ -2126,7 +2126,7 @@ proof -
                    rescheduleRequired
                 od)"
     apply (rule corres_split')
-       apply (rule corres_guard_imp [OF set_ep_corres])
+       apply (rule corres_guard_imp [OF setEndpoint_corres])
          apply (simp add: ep_relation_def)+
       apply (rule corres_split_deprecated [OF rescheduleRequired_corres])
         apply (rule ep_cancel_corres_helper)
@@ -2149,7 +2149,7 @@ proof -
   show ?thesis
     apply (simp add: cancel_all_ipc_def cancelAllIPC_def)
     apply (rule corres_split' [OF _ _ get_simple_ko_sp get_ep_sp'])
-     apply (rule corres_guard_imp [OF get_ep_corres], simp+)
+     apply (rule corres_guard_imp [OF getEndpoint_corres], simp+)
     apply (case_tac epa, simp_all add: ep_relation_def
                                        get_ep_queue_def)
      apply (rule corres_guard_imp [OF P]
@@ -2171,16 +2171,16 @@ lemma set_ntfn_tcb_obj_at' [wp]:
 apply (clarsimp simp: setNotification_def, wp)
 done
 
-lemma ntfn_cancel_corres:
+lemma cancelAllSignals_corres:
   "corres dc (invs and valid_sched and ntfn_at ntfn) (invs' and ntfn_at' ntfn)
              (cancel_all_signals ntfn) (cancelAllSignals ntfn)"
   apply (simp add: cancel_all_signals_def cancelAllSignals_def)
   apply (rule corres_split' [OF _ _ get_simple_ko_sp get_ntfn_sp'])
-   apply (rule corres_guard_imp [OF get_ntfn_corres])
+   apply (rule corres_guard_imp [OF getNotification_corres])
     apply simp+
   apply (case_tac "ntfn_obj ntfna", simp_all add: ntfn_relation_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
+    apply (rule corres_split_deprecated [OF _ setNotification_corres])
        apply (rule corres_split_deprecated [OF rescheduleRequired_corres])
          apply (rule ep_cancel_corres_helper)
         apply (wp mapM_x_wp'[where 'b="det_ext state"]
@@ -2773,21 +2773,21 @@ crunches tcb_sched_action
   and state_hyp_refs_of[wp]: "\<lambda>s. P (state_hyp_refs_of s)"
   (ignore_del: tcb_sched_action)
 
-lemma cancel_badged_sends_corres:
+lemma cancelBadgedSends_corres:
   "corres dc (invs and valid_sched and ep_at epptr) (invs' and ep_at' epptr)
          (cancel_badged_sends epptr bdg) (cancelBadgedSends epptr bdg)"
   apply (simp add: cancel_badged_sends_def cancelBadgedSends_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres get_simple_ko_sp get_ep_sp',
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres get_simple_ko_sp get_ep_sp',
                                  where Q="invs and valid_sched" and Q'=invs'])
     apply simp_all
   apply (case_tac ep, simp_all add: ep_relation_def)
   apply (simp add: filterM_mapM list_case_return cong: list.case_cong)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_nor [OF _ set_ep_corres])
+    apply (rule corres_split_nor [OF _ setEndpoint_corres])
        apply (rule corres_split_eqr[OF _ _ _ hoare_post_add[where R="\<lambda>_. valid_objs'"]])
           apply (rule corres_split_deprecated [OF rescheduleRequired_corres])
-            apply (rule set_ep_corres)
+            apply (rule setEndpoint_corres)
             apply (simp split: list.split add: ep_relation_def)
            apply (wp weak_sch_act_wf_lift_linear)+
          apply (rule_tac S="(=)"
@@ -2797,11 +2797,11 @@ lemma cancel_badged_sends_corres:
                 simp_all add: list_all2_refl)[1]
            apply (clarsimp simp: liftM_def[symmetric] o_def)
            apply (rule corres_guard_imp)
-             apply (rule corres_split_deprecated [OF _ gts_corres])
+             apply (rule corres_split_deprecated [OF _ getThreadState_corres])
                apply (rule_tac F="\<exists>pl. st = Structures_A.BlockedOnSend epptr pl"
                             in corres_gen_asm)
                apply (clarsimp simp: o_def dc_def[symmetric] liftM_def)
-               apply (rule corres_split_deprecated [OF _ sts_corres])
+               apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                   apply (rule corres_split_deprecated[OF _ tcbSchedEnqueue_corres])
                     apply (rule corres_trivial)
                     apply simp

--- a/proof/refine/ARM_HYP/Ipc_R.thy
+++ b/proof/refine/ARM_HYP/Ipc_R.thy
@@ -13,14 +13,14 @@ context begin interpretation Arch . (*FIXME: arch_split*)
 lemmas lookup_slot_wrapper_defs'[simp] =
    lookupSourceSlot_def lookupTargetSlot_def lookupPivotSlot_def
 
-lemma get_mi_corres: "corres ((=) \<circ> message_info_map)
+lemma getMessageInfo_corres: "corres ((=) \<circ> message_info_map)
                       (tcb_at t) (tcb_at' t)
                       (get_message_info t) (getMessageInfo t)"
   apply (rule corres_guard_imp)
     apply (unfold get_message_info_def getMessageInfo_def fun_app_def)
     apply (simp add: ARM_HYP_H.msgInfoRegister_def
              ARM_HYP.msgInfoRegister_def ARM_A.msg_info_register_def)
-    apply (rule corres_split_eqr [OF _ user_getreg_corres])
+    apply (rule corres_split_eqr [OF _ asUser_getRegister_corres])
        apply (rule corres_trivial, simp add: message_info_from_data_eqv)
       apply (wp | simp)+
   done
@@ -100,7 +100,7 @@ lemma valid_ipc_buffer_ptr'D2:
   apply simp
   done
 
-lemma load_ct_corres:
+lemma loadCapTransfer_corres:
   "corres ct_relation \<top> (valid_ipc_buffer_ptr' buffer) (load_cap_transfer buffer) (loadCapTransfer buffer)"
   apply (simp add: load_cap_transfer_def loadCapTransfer_def
                    captransfer_from_words_def
@@ -124,7 +124,7 @@ lemma load_ct_corres:
     apply (erule valid_ipc_buffer_ptr'D2, simp add: max_ipc_words, simp add: is_aligned_def)+
   done
 
-lemma get_recv_slot_corres:
+lemma getReceiveSlots_corres:
   "corres (\<lambda>xs ys. ys = map cte_map xs)
     (tcb_at receiver and valid_objs and pspace_aligned)
     (tcb_at' receiver and valid_objs' and pspace_aligned' and pspace_distinct' and
@@ -135,7 +135,7 @@ lemma get_recv_slot_corres:
    apply (simp add: getReceiveSlots_def)
   apply (simp add: getReceiveSlots_def split_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ load_ct_corres])
+    apply (rule corres_split_deprecated [OF _ loadCapTransfer_corres])
       apply (rule corres_empty_on_failure)
       apply (rule corres_splitEE)
          prefer 2
@@ -147,7 +147,7 @@ lemma get_recv_slot_corres:
            prefer 2
            apply (rule corres_unify_failure)
             apply (simp add: ct_relation_def)
-            apply (erule lsfc_corres [OF _ refl])
+            apply (erule lookupSlotForCNodeOp_corres [OF _ refl])
            apply simp
           apply (simp add: split_def liftE_bindE unlessE_whenE)
           apply (rule corres_split_deprecated [OF _ get_cap_corres])
@@ -207,11 +207,11 @@ declare word_div_1 [simp]
 declare word_minus_one_le [simp]
 declare word32_minus_one_le [simp]
 
-lemma load_word_offs_corres':
+lemma loadWordUser_corres':
   "\<lbrakk> y < unat max_ipc_words; y' = of_nat y * 4 \<rbrakk> \<Longrightarrow>
   corres (=) \<top> (valid_ipc_buffer_ptr' a) (load_word_offs a y) (loadWordUser (a + y'))"
   apply simp
-  apply (erule load_word_offs_corres)
+  apply (erule loadWordUser_corres)
   done
 
 declare loadWordUser_inv [wp]
@@ -253,7 +253,7 @@ lemma corres_set_extra_badge:
           (\<lambda>_. msg_max_length + 2 + n < unat max_ipc_words))
          (set_extra_badge buffer b n) (setExtraBadge buffer b' n)"
   apply (rule corres_gen_asm2)
-  apply (drule store_word_offs_corres [where a=buffer and w=b])
+  apply (drule storeWordUser_corres [where a=buffer and w=b])
   apply (simp add: set_extra_badge_def setExtraBadge_def buffer_cptr_index_def
                    bufferCPtrOffset_def Let_def)
   apply (simp add: word_size_def wordSize_def wordBits_def
@@ -390,7 +390,7 @@ lemma cte_refs'_maskedAsFull[simp]:
  done
 
 
-lemma tc_loop_corres:
+lemma transferCapsToSlots_corres:
   "\<lbrakk> list_all2 (\<lambda>(cap, slot) (cap', slot'). cap_relation cap cap'
              \<and> slot' = cte_map slot) caps caps';
       mi' = message_info_map mi \<rbrakk> \<Longrightarrow>
@@ -456,14 +456,14 @@ next
          prefer 2
          apply (rule unifyFailure_discard2)
           apply (case_tac mi, clarsimp)
-         apply (rule derive_cap_corres)
+         apply (rule deriveCap_corres)
           apply (simp add: remove_rights_def)
          apply clarsimp
         apply (rule corres_split_norE)
            apply (simp add: liftE_bindE)
            apply (rule corres_split_nor)
               prefer 2
-              apply (rule cins_corres, simp_all add: hd_map)[1]
+              apply (rule cteInsert_corres, simp_all add: hd_map)[1]
              apply (simp add: tl_map)
              apply (rule corres_rel_imp, rule Cons.hyps, simp_all)[1]
             apply (wp valid_case_option_post_wp hoare_vcg_const_Ball_lift
@@ -1024,7 +1024,7 @@ lemma grs_distinct'[wp]:
   apply simp
   done
 
-lemma tc_corres:
+lemma transferCaps_corres:
   "\<lbrakk> info' = message_info_map info;
     list_all2 (\<lambda>x y. cap_relation (fst x) (fst y) \<and> snd y = cte_map (snd x))
          caps caps' \<rbrakk>
@@ -1049,12 +1049,12 @@ lemma tc_corres:
                    getThreadCSpaceRoot)
   apply (rule corres_assume_pre)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_recv_slot_corres])
+    apply (rule corres_split_deprecated [OF _ getReceiveSlots_corres])
       apply (rule_tac x=recv_buf in option_corres)
        apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
        apply (case_tac info, simp)
       apply simp
-      apply (rule corres_rel_imp, rule tc_loop_corres,
+      apply (rule corres_rel_imp, rule transferCapsToSlots_corres,
              simp_all add: split_def)[1]
       apply (case_tac info, simp)
      apply (wp hoare_vcg_all_lift get_rs_cte_at static_imp_wp
@@ -1335,7 +1335,7 @@ lemma getMessageInfo_msgExtraCaps[wp]:
    apply wpsimp+
   done
 
-lemma lcs_corres:
+lemma lookupCapAndSlot_corres:
   "cptr = to_bl cptr' \<Longrightarrow>
   corres (lfr \<oplus> (\<lambda>a b. cap_relation (fst a) (fst b) \<and> snd b = cte_map (snd a)))
     (valid_objs and pspace_aligned and tcb_at thread)
@@ -1350,12 +1350,12 @@ lemma lcs_corres:
           apply (rule corres_returnOkTT, simp)
          apply simp
         apply wp+
-      apply (rule corres_rel_imp, rule lookup_slot_corres)
+      apply (rule corres_rel_imp, rule lookupSlotForThread_corres)
       apply (simp add: split_def)
      apply (wp | simp add: liftE_bindE[symmetric])+
   done
 
-lemma lec_corres:
+lemma lookupExtraCaps_corres:
   "\<lbrakk> info' = message_info_map info; buffer = buffer'\<rbrakk> \<Longrightarrow>
   corres (fr \<oplus> list_all2 (\<lambda>x y. cap_relation (fst x) (fst y) \<and> snd y = cte_map (snd x)))
    (valid_objs and pspace_aligned and tcb_at thread and (\<lambda>_. valid_message_info info))
@@ -1397,7 +1397,7 @@ lemma lec_corres:
            apply simp
           apply simp
           apply (rule corres_guard_imp)
-            apply (rule load_word_offs_corres')
+            apply (rule loadWordUser_corres')
              apply (clarsimp simp: buffer_cptr_index_def msg_max_length_def
                                    max_ipc_words valid_message_info_def
                                    msg_max_extra_caps_def word_le_nat_alt)
@@ -1413,7 +1413,7 @@ lemma lec_corres:
             apply simp
            apply simp
           apply simp
-          apply (rule corres_cap_fault [OF lcs_corres])
+          apply (rule corres_cap_fault [OF lookupCapAndSlot_corres])
           apply simp
          apply simp
          apply (wp | simp)+
@@ -1429,7 +1429,7 @@ lemma copyMRs_valid_mdb[wp]:
   "\<lbrace>valid_mdb'\<rbrace> copyMRs t buf t' buf' n \<lbrace>\<lambda>rv. valid_mdb'\<rbrace>"
   by (simp add: valid_mdb'_def copyMRs_ctes_of)
 
-lemma do_normal_transfer_corres:
+lemma doNormalTransfer_corres:
   "corres dc
   (tcb_at sender and tcb_at receiver and (pspace_aligned:: det_state \<Rightarrow> bool)
    and valid_objs and cur_tcb and valid_mdb and valid_list and pspace_distinct
@@ -1447,7 +1447,7 @@ lemma do_normal_transfer_corres:
   apply (simp add: do_normal_transfer_def doNormalTransfer_def)
   apply (rule corres_guard_imp)
 
-    apply (rule corres_split_mapr [OF _ get_mi_corres])
+    apply (rule corres_split_mapr [OF _ getMessageInfo_corres])
       apply (rule_tac F="valid_message_info mi" in corres_gen_asm)
       apply (rule_tac r'="list_all2 (\<lambda>x y. cap_relation (fst x) (fst y) \<and> snd y = cte_map (snd x))"
                   in corres_split_deprecated)
@@ -1455,19 +1455,19 @@ lemma do_normal_transfer_corres:
          apply (rule corres_if[OF refl])
           apply (rule corres_split_catch)
              apply (rule corres_trivial, simp)
-            apply (rule lec_corres, simp+)
+            apply (rule lookupExtraCaps_corres, simp+)
            apply wp+
          apply (rule corres_trivial, simp)
         apply simp
-        apply (rule corres_split_eqr [OF _ copy_mrs_corres])
-          apply (rule corres_split_deprecated [OF _ tc_corres])
+        apply (rule corres_split_eqr [OF _ copyMRs_corres])
+          apply (rule corres_split_deprecated [OF _ transferCaps_corres])
               apply (rename_tac mi' mi'')
               apply (rule_tac F="mi_label mi' = mi_label mi"
                         in corres_gen_asm)
-              apply (rule corres_split_nor [OF _ set_mi_corres])
+              apply (rule corres_split_nor [OF _ setMessageInfo_corres])
                  apply (simp add: badge_register_def badgeRegister_def)
                  apply (fold dc_def)
-                 apply (rule user_setreg_corres)
+                 apply (rule asUser_setRegister_corres)
                 apply (case_tac mi', clarsimp)
                apply wp
              apply simp+
@@ -1487,11 +1487,11 @@ lemma corres_liftE_lift:
   by simp
 
 lemmas corres_ipc_thread_helper =
-  corres_split_eqrE [OF _  corres_liftE_lift [OF gct_corres]]
+  corres_split_eqrE [OF _  corres_liftE_lift [OF getCurThread_corres]]
 
 lemmas corres_ipc_info_helper =
   corres_split_maprE [where f = message_info_map, OF _
-                                corres_liftE_lift [OF get_mi_corres]]
+                                corres_liftE_lift [OF getMessageInfo_corres]]
 
 crunch typ_at'[wp]: doNormalTransfer "\<lambda>s. P (typ_at' T p s)"
 
@@ -1536,57 +1536,57 @@ lemma msgFromLookupFailure_map[simp]:
      = msg_from_lookup_failure lf"
   by (cases lf, simp_all add: lookup_failure_map_def msgFromLookupFailure_def)
 
-lemma getRestartPCs_corres:
+lemma asUser_getRestartPC_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
                  (as_user t getRestartPC) (asUser t getRestartPC)"
-  apply (rule corres_as_user')
+  apply (rule asUser_corres')
   apply (rule corres_Id, simp, simp)
   apply (rule no_fail_getRestartPC)
   done
 
-lemma user_mapM_getRegister_corres:
+lemma asUser_mapM_getRegister_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
      (as_user t (mapM getRegister regs))
      (asUser t (mapM getRegister regs))"
-  apply (rule corres_as_user')
+  apply (rule asUser_corres')
   apply (rule corres_Id [OF refl refl])
   apply (rule no_fail_mapM)
   apply (simp add: getRegister_def)
   done
 
-lemma make_arch_fault_msg_corres:
+lemma makeArchFaultMessage_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
   (make_arch_fault_msg f t)
   (makeArchFaultMessage (arch_fault_map f) t)"
   apply (cases f; clarsimp simp: makeArchFaultMessage_def ucast_nat_def split: arch_fault.split)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr[OF _ getRestartPCs_corres])
+    apply (rule corres_split_eqr[OF _ asUser_getRestartPC_corres])
       apply (rule corres_split_eqr[OF _ corres_machine_op])
          apply (rule corres_trivial, simp)
         apply (rule corres_underlying_trivial[OF addressTranslateS1CPR_no_fail])
        apply (wp+, auto)
   done
 
-lemma mk_ft_msg_corres:
+lemma makeFaultMessage_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
      (make_fault_msg ft t)
      (makeFaultMessage (fault_map ft) t)"
   apply (cases ft, simp_all add: makeFaultMessage_def split del: if_split)
      apply (rule corres_guard_imp)
-       apply (rule corres_split_eqr [OF _ getRestartPCs_corres])
+       apply (rule corres_split_eqr [OF _ asUser_getRestartPC_corres])
          apply (rule corres_trivial, simp add: fromEnum_def enum_bool)
         apply (wp | simp)+
     apply (simp add: ARM_HYP_H.syscallMessage_def)
     apply (rule corres_guard_imp)
-      apply (rule corres_split_eqr [OF _ user_mapM_getRegister_corres])
+      apply (rule corres_split_eqr [OF _ asUser_mapM_getRegister_corres])
         apply (rule corres_trivial, simp)
        apply (wp | simp)+
    apply (simp add: ARM_HYP_H.exceptionMessage_def)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_eqr [OF _ user_mapM_getRegister_corres])
+     apply (rule corres_split_eqr [OF _ asUser_mapM_getRegister_corres])
        apply (rule corres_trivial, simp)
       apply (wp | simp)+
-  apply (rule make_arch_fault_msg_corres)
+  apply (rule makeArchFaultMessage_corres)
   done
 
 lemma dmo_addressTranslateS1CPR_invs'[wp]:
@@ -1633,11 +1633,11 @@ lemma makeFaultMessage_valid_ipc_buffer_ptr'[wp]:
   done
 
 lemmas threadget_fault_corres =
-          threadget_corres [where r = fault_rel_optionation
+          threadGet_corres [where r = fault_rel_optionation
                               and f = tcb_fault and f' = tcbFault,
                             simplified tcb_relation_def, simplified]
 
-lemma do_fault_transfer_corres:
+lemma doFaultTransfer_corres:
   "corres dc
     (obj_at (\<lambda>ko. \<exists>tcb ft. ko = TCB tcb \<and> tcb_fault tcb = Some ft) sender
      and tcb_at receiver and case_option \<top> in_user_frame recv_buf)
@@ -1669,17 +1669,17 @@ lemma do_fault_transfer_corres:
     apply (clarsimp simp: obj_at_def is_tcb)
    apply wp
    apply (rule corres_guard_imp)
-      apply (rule corres_split_eqr [OF _ mk_ft_msg_corres])
-        apply (rule corres_split_eqr [OF _ set_mrs_corres [OF refl]])
-          apply (rule corres_split_nor [OF _ set_mi_corres])
-             apply (rule user_setreg_corres)
+      apply (rule corres_split_eqr [OF _ makeFaultMessage_corres])
+        apply (rule corres_split_eqr [OF _ setMRs_corres [OF refl]])
+          apply (rule corres_split_nor [OF _ setMessageInfo_corres])
+             apply (rule asUser_setRegister_corres)
             apply simp
            apply (wp | simp)+
    apply (rule corres_guard_imp)
-      apply (rule corres_split_eqr [OF _ mk_ft_msg_corres])
-        apply (rule corres_split_eqr [OF _ set_mrs_corres [OF refl]])
-          apply (rule corres_split_nor [OF _ set_mi_corres])
-             apply (rule user_setreg_corres)
+      apply (rule corres_split_eqr [OF _ makeFaultMessage_corres])
+        apply (rule corres_split_eqr [OF _ setMRs_corres [OF refl]])
+          apply (rule corres_split_nor [OF _ setMessageInfo_corres])
+             apply (rule asUser_setRegister_corres)
             apply simp
            apply (wp | simp)+
   done
@@ -1731,7 +1731,7 @@ lemma lookupIPCBuffer_valid_ipc_buffer [wp]:
   apply (simp add: word_bits_conv)
   done
 
-lemma dit_corres:
+lemma doIPCTransfer_corres:
   "corres dc
      (tcb_at s and tcb_at r and valid_objs and pspace_aligned
         and valid_list
@@ -1751,7 +1751,7 @@ lemma dit_corres:
                                     \<comment> \<open>\<exists>ft. tcb_fault tcb = Some ft\<close>) s sa"
                in corres_split')
      apply (rule corres_guard_imp)
-       apply (rule lipcb_corres')
+       apply (rule lookupIPCBuffer_corres')
       apply auto[2]
     apply (rule corres_split' [OF _ _ thread_get_sp threadGet_inv])
      apply (rule corres_guard_imp)
@@ -1762,12 +1762,12 @@ lemma dit_corres:
        apply (subst case_option_If)+
        apply (rule corres_if2)
          apply (simp add: fault_rel_optionation_def)
-        apply (rule corres_split_eqr [OF _ lipcb_corres'])
+        apply (rule corres_split_eqr [OF _ lookupIPCBuffer_corres'])
           apply (simp add: dc_def[symmetric])
-          apply (rule do_normal_transfer_corres)
+          apply (rule doNormalTransfer_corres)
          apply (wp | simp add: valid_pspace'_def)+
        apply (simp add: dc_def[symmetric])
-       apply (rule do_fault_transfer_corres)
+       apply (rule doFaultTransfer_corres)
       apply (clarsimp simp: obj_at_def)
      apply (erule ignore_if)
     apply (wp|simp add: obj_at_def is_tcb valid_pspace'_def)+
@@ -1867,13 +1867,13 @@ crunch nosch[wp]: doIPCTransfer "\<lambda>s. P (ksSchedulerAction s)"
   (wp: hoare_drop_imps hoare_vcg_split_case_option mapM_wp'
    simp: split_def zipWithM_x_mapM)
 
-lemma arch_tcb_sanitise_corres:
+lemma arch_getSanitiseRegisterInfo_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
       (arch_get_sanitise_register_info t)
       (getSanitiseRegisterInfo t)"
   unfolding arch_get_sanitise_register_info_def getSanitiseRegisterInfo_def
   apply (fold archThreadGet_def)
-  by (corressimp corres: archThreadGet_vcpu_corres)
+  by (corressimp corres: archThreadGet_VCPU_corres)
 
 crunch tcb_at'[wp]: getSanitiseRegisterInfo "tcb_at' t"
 
@@ -1896,10 +1896,10 @@ lemma handle_fault_reply_registers_corres:
             od)"
 
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ arch_tcb_sanitise_corres])
+    apply (rule corres_split_deprecated [OF _ arch_getSanitiseRegisterInfo_corres])
        apply (rule corres_split_deprecated)
        apply (rule corres_trivial, simp)
-      apply (rule corres_as_user')
+      apply (rule asUser_corres')
       apply(simp add: setRegister_def sanitise_register_def
                       sanitiseRegister_def syscallMessage_def Let_def cong: register.case_cong)
       apply(subst zipWithM_x_modify)+
@@ -1907,7 +1907,7 @@ lemma handle_fault_reply_registers_corres:
        apply (simp|wp)+
   done
 
-lemma handle_fault_reply_corres:
+lemma handleFaultReply_corres:
   "ft' = fault_map ft \<Longrightarrow>
    corres (=) (tcb_at t) (tcb_at' t)
      (handle_fault_reply ft t label msg)
@@ -2169,7 +2169,7 @@ lemma cte_wp_at_is_reply_cap_toI:
    \<Longrightarrow> cte_wp_at (is_reply_cap_to t) ptr s"
   by (fastforce simp: cte_wp_at_reply_cap_to_ex_rights)
 
-lemma do_reply_transfer_corres:
+lemma doReplyTransfer_corres:
   "corres dc
      (einvs and tcb_at receiver and tcb_at sender
            and cte_wp_at ((=) (cap.ReplyCap receiver False rights)) slot)
@@ -2180,7 +2180,7 @@ lemma do_reply_transfer_corres:
   apply (simp add: do_reply_transfer_def doReplyTransfer_def cong: option.case_cong)
   apply (rule corres_split' [OF _ _ gts_sp gts_sp'])
    apply (rule corres_guard_imp)
-     apply (rule gts_corres, (clarsimp simp add: st_tcb_at_tcb_at)+)
+     apply (rule getThreadState_corres, (clarsimp simp add: st_tcb_at_tcb_at)+)
   apply (rule_tac F = "awaiting_reply state" in corres_req)
    apply (clarsimp simp add: st_tcb_at_def obj_at_def is_tcb)
    apply (fastforce simp: invs_def valid_state_def intro: has_reply_cap_cte_wpD
@@ -2209,9 +2209,9 @@ lemma do_reply_transfer_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ threadget_fault_corres])
       apply (case_tac rv, simp_all add: fault_rel_optionation_def bind_assoc)[1]
-       apply (rule corres_split_deprecated [OF _ dit_corres])
+       apply (rule corres_split_deprecated [OF _ doIPCTransfer_corres])
          apply (rule corres_split_deprecated [OF _ cap_delete_one_corres])
-           apply (rule corres_split_deprecated [OF _ sts_corres])
+           apply (rule corres_split_deprecated [OF _ setThreadState_corres])
               apply (rule possibleSwitchTo_corres)
              apply simp
             apply (wp set_thread_state_runnable_valid_sched set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at' sts_st_tcb' sts_valid_queues sts_valid_objs' delete_one_tcbDomain_obj_at'
@@ -2243,11 +2243,11 @@ lemma do_reply_transfer_corres:
 
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ cap_delete_one_corres])
-      apply (rule corres_split_mapr [OF _ get_mi_corres])
-        apply (rule corres_split_eqr [OF _ lipcb_corres'])
-          apply (rule corres_split_eqr [OF _ get_mrs_corres])
+      apply (rule corres_split_mapr [OF _ getMessageInfo_corres])
+        apply (rule corres_split_eqr [OF _ lookupIPCBuffer_corres'])
+          apply (rule corres_split_eqr [OF _ getMRs_corres])
             apply (simp(no_asm) del: dc_simp)
-            apply (rule corres_split_eqr [OF _ handle_fault_reply_corres])
+            apply (rule corres_split_eqr [OF _ handleFaultReply_corres])
                apply (rule corres_split_deprecated [OF _ threadset_corresT])
                      apply (rule_tac Q="valid_sched and cur_tcb and tcb_at receiver"
                                  and Q'="tcb_at' receiver and cur_tcb'
@@ -2256,13 +2256,13 @@ lemma do_reply_transfer_corres:
                                    in corres_guard_imp)
                        apply (case_tac rvb, simp_all)[1]
                         apply (rule corres_guard_imp)
-                          apply (rule corres_split_deprecated [OF _ sts_corres])
+                          apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                       apply (fold dc_def, rule possibleSwitchTo_corres)
                                apply simp
                               apply (wp static_imp_wp static_imp_conj_wp set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at'
                                         sts_st_tcb' sts_valid_queues | simp | force simp: valid_sched_def valid_sched_action_def valid_tcb_state'_def)+
                        apply (rule corres_guard_imp)
-                      apply (rule sts_corres)
+                      apply (rule setThreadState_corres)
                       apply (simp_all)[20]
                    apply (clarsimp simp add: tcb_relation_def fault_rel_optionation_def
                                              tcb_cap_cases_def tcb_cte_cases_def exst_same_def)+
@@ -2296,7 +2296,7 @@ lemma do_reply_transfer_corres:
 
 (* when we cannot talk about reply cap rights explicitly (for instance, when a schematic ?rights
    would be generated too early *)
-lemma do_reply_transfer_corres':
+lemma doReplyTransfer_corres':
   "corres dc
      (einvs and tcb_at receiver and tcb_at sender
            and cte_wp_at (is_reply_cap_to receiver) slot)
@@ -2304,7 +2304,7 @@ lemma do_reply_transfer_corres':
             and valid_pspace' and cte_at' (cte_map slot))
      (do_reply_transfer sender receiver slot grant)
      (doReplyTransfer sender receiver (cte_map slot) grant)"
-  using do_reply_transfer_corres[of receiver sender _ slot]
+  using doReplyTransfer_corres[of receiver sender _ slot]
   by (fastforce simp add: cte_wp_at_reply_cap_to_ex_rights corres_underlying_def)
 
 lemma valid_pspace'_splits[elim!]:
@@ -2330,7 +2330,7 @@ lemma sts_valid_pspace_hangers:
 
 declare no_fail_getSlotCap [wp]
 
-lemma setup_caller_corres:
+lemma setupCallerCap_corres:
   "corres dc
      (st_tcb_at (Not \<circ> halted) sender and tcb_at receiver and
       st_tcb_at (Not \<circ> awaiting_reply) sender and valid_reply_caps and
@@ -2354,7 +2354,7 @@ lemma setup_caller_corres:
           apply (rule corres_symb_exec_r)
              apply (rule_tac F="rv = capability.NullCap"
                           in corres_gen_asm2, simp)
-             apply (rule cins_corres)
+             apply (rule cteInsert_corres)
                apply (simp split: if_splits)
               apply (simp add: cte_map_def tcbReplySlot_def
                                tcb_cnode_index_def cte_level_bits_def)
@@ -2373,7 +2373,7 @@ lemma setup_caller_corres:
         apply blast
        apply (rule no_fail_pre, wp)
        apply (clarsimp simp: cte_wp_at_ctes_of)
-      apply (rule sts_corres)
+      apply (rule setThreadState_corres)
       apply (simp split: option.split)
      apply (wp sts_valid_pspace_hangers
                  | simp add: cte_wp_at_ctes_of)+
@@ -2460,7 +2460,7 @@ crunch tcb_at'[wp]: possibleSwitchTo "tcb_at' t"
 crunch valid_pspace'[wp]: possibleSwitchTo valid_pspace'
   (wp: crunch_wps)
 
-lemma send_ipc_corres:
+lemma sendIPC_corres:
 (* call is only true if called in handleSyscall SysCall, which
    is always blocking. *)
   assumes "call \<longrightarrow> bl"
@@ -2475,7 +2475,7 @@ proof -
   apply (case_tac bl)
    apply clarsimp
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated [OF _ get_ep_corres,
+     apply (rule corres_split_deprecated [OF _ getEndpoint_corres,
               where
               R="\<lambda>rv. einvs and st_tcb_at active t and ep_at ep and
                       valid_ep rv and obj_at (\<lambda>ob. ob = Endpoint rv) ep
@@ -2486,8 +2486,8 @@ proof -
        apply (case_tac rv)
          apply (simp add: ep_relation_def)
          apply (rule corres_guard_imp)
-           apply (rule corres_split_deprecated [OF _ sts_corres])
-              apply (rule set_ep_corres)
+           apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+              apply (rule setEndpoint_corres)
               apply (simp add: ep_relation_def)
              apply (simp add: fault_rel_optionation_def)
             apply wp+
@@ -2496,8 +2496,8 @@ proof -
          \<comment> \<open>concludes IdleEP if bl branch\<close>
         apply (simp add: ep_relation_def)
         apply (rule corres_guard_imp)
-          apply (rule corres_split_deprecated [OF _ sts_corres])
-             apply (rule set_ep_corres)
+          apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+             apply (rule setEndpoint_corres)
              apply (simp add: ep_relation_def)
             apply (simp add: fault_rel_optionation_def)
            apply wp+
@@ -2512,16 +2512,16 @@ proof -
         apply simp
        apply (clarsimp split del: if_split)
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
             apply (simp add: isReceive_def split del:if_split)
-            apply (rule corres_split_deprecated [OF _ gts_corres])
+            apply (rule corres_split_deprecated [OF _ getThreadState_corres])
               apply (rule_tac
                      F="\<exists>data. recv_state = Structures_A.BlockedOnReceive ep data"
                      in corres_gen_asm)
               apply (clarsimp simp: case_bool_If  case_option_If if3_fold
                           simp del: dc_simp split del: if_split cong: if_cong)
-              apply (rule corres_split_deprecated [OF _ dit_corres])
-                apply (rule corres_split_deprecated [OF _ sts_corres])
+              apply (rule corres_split_deprecated [OF _ doIPCTransfer_corres])
+                apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                    apply (rule corres_split_deprecated [OF _ possibleSwitchTo_corres])
                        apply (fold when_def)[1]
 
@@ -2529,8 +2529,8 @@ proof -
                                 in corres_symmetric_bool_cases, blast)
                         apply (simp add: when_def dc_def[symmetric] split del: if_split)
                         apply (rule corres_if2, simp)
-                         apply (rule setup_caller_corres)
-                        apply (rule sts_corres, simp)
+                         apply (rule setupCallerCap_corres)
+                        apply (rule setThreadState_corres, simp)
                        apply (rule corres_trivial)
                        apply (simp add: when_def dc_def[symmetric] split del: if_split)
                       apply (simp split del: if_split add: if_apply_def2)
@@ -2566,7 +2566,7 @@ proof -
       apply wp+
     apply (clarsimp simp: ep_at_def2)+
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres,
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres,
              where
              R="\<lambda>rv. einvs and st_tcb_at active t and ep_at ep and
                      valid_ep rv and obj_at (\<lambda>k. k = Endpoint rv) ep"
@@ -2593,15 +2593,15 @@ proof -
        apply fastforce
       apply (clarsimp split del: if_split)
       apply (rule corres_guard_imp)
-        apply (rule corres_split_deprecated [OF _ set_ep_corres])
-           apply (rule corres_split_deprecated [OF _ gts_corres])
+        apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+           apply (rule corres_split_deprecated [OF _ getThreadState_corres])
              apply (rule_tac
                 F="\<exists>data. recv_state = Structures_A.BlockedOnReceive ep data"
                     in corres_gen_asm)
              apply (clarsimp simp: isReceive_def case_bool_If
                         split del: if_split cong: if_cong)
-             apply (rule corres_split_deprecated [OF _ dit_corres])
-               apply (rule corres_split_deprecated [OF _ sts_corres])
+             apply (rule corres_split_deprecated [OF _ doIPCTransfer_corres])
+               apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                    apply (rule possibleSwitchTo_corres)
                   apply (simp add: if_apply_def2)
                   apply (wp hoare_drop_imps)
@@ -2658,12 +2658,12 @@ lemma valid_sched_weak_strg:
 crunch weak_valid_sched_action[wp]: as_user weak_valid_sched_action
   (wp: weak_valid_sched_action_lift)
 
-lemma send_signal_corres:
+lemma sendSignal_corres:
   "corres dc (einvs and ntfn_at ep) (invs' and ntfn_at' ep)
              (send_signal ep bg) (sendSignal ep bg)"
   apply (simp add: send_signal_def sendSignal_def Let_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ntfn_corres,
+    apply (rule corres_split_deprecated [OF _ getNotification_corres,
                 where
                 R  = "\<lambda>rv. einvs and ntfn_at ep and valid_ntfn rv and
                            ko_at (Structures_A.Notification rv) ep" and
@@ -2677,19 +2677,19 @@ lemma send_signal_corres:
     apply (clarsimp simp add: ntfn_relation_def)
     apply (case_tac "ntfnBoundTCB nTFN")
      apply clarsimp
-     apply (rule corres_guard_imp[OF set_ntfn_corres])
+     apply (rule corres_guard_imp[OF setNotification_corres])
        apply (clarsimp simp add: ntfn_relation_def)+
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated[OF _ gts_corres])
+      apply (rule corres_split_deprecated[OF _ getThreadState_corres])
         apply (rule corres_if)
           apply (fastforce simp: receive_blocked_def receiveBlocked_def
                                  thread_state_relation_def
                           split: Structures_A.thread_state.splits
                                  Structures_H.thread_state.splits)
          apply (rule corres_split_deprecated[OF _ cancel_ipc_corres])
-           apply (rule corres_split_deprecated[OF _ sts_corres])
+           apply (rule corres_split_deprecated[OF _ setThreadState_corres])
               apply (simp add: badgeRegister_def badge_register_def)
-              apply (rule corres_split_deprecated[OF _ user_setreg_corres])
+              apply (rule corres_split_deprecated[OF _ asUser_setRegister_corres])
                 apply (rule possibleSwitchTo_corres)
                apply wp
              apply (clarsimp simp: thread_state_relation_def)
@@ -2702,7 +2702,7 @@ lemma send_signal_corres:
           apply wp
          apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak
                                valid_tcb_state'_def)
-        apply (rule set_ntfn_corres)
+        apply (rule setNotification_corres)
         apply (clarsimp simp add: ntfn_relation_def)
        apply (wp gts_wp gts_wp' | clarsimp)+
      apply (auto simp: valid_ntfn_def receive_blocked_def valid_sched_def invs_cur
@@ -2719,10 +2719,10 @@ lemma send_signal_corres:
     apply (rule corres_guard_imp)
       apply (rule_tac F="list \<noteq> []" in corres_gen_asm)
       apply (simp add: list_case_helper split del: if_split)
-      apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-         apply (rule corres_split_deprecated [OF _ sts_corres])
+      apply (rule corres_split_deprecated [OF _ setNotification_corres])
+         apply (rule corres_split_deprecated [OF _ setThreadState_corres])
             apply (simp add: badgeRegister_def badge_register_def)
-            apply (rule corres_split_deprecated [OF _ user_setreg_corres])
+            apply (rule corres_split_deprecated [OF _ asUser_setRegister_corres])
               apply (rule possibleSwitchTo_corres)
              apply ((wp | simp)+)[1]
             apply (rule_tac Q="\<lambda>_. Invariants_H.valid_queues and valid_queues' and
@@ -2750,10 +2750,10 @@ lemma send_signal_corres:
    apply (rule corres_guard_imp)
      apply (rule_tac F="list \<noteq> []" in corres_gen_asm)
      apply (simp add: list_case_helper)
-     apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-        apply (rule corres_split_deprecated [OF _ sts_corres])
+     apply (rule corres_split_deprecated [OF _ setNotification_corres])
+        apply (rule corres_split_deprecated [OF _ setThreadState_corres])
            apply (simp add: badgeRegister_def badge_register_def)
-           apply (rule corres_split_deprecated [OF _ user_setreg_corres])
+           apply (rule corres_split_deprecated [OF _ asUser_setRegister_corres])
              apply (rule possibleSwitchTo_corres)
             apply (wp cur_tcb_lift | simp)+
          apply (wp sts_st_tcb_at' set_thread_state_runnable_weak_valid_sched_action
@@ -2775,7 +2775,7 @@ lemma send_signal_corres:
   \<comment> \<open>ActiveNtfn\<close>
   apply (clarsimp simp add: ntfn_relation_def)
   apply (rule corres_guard_imp)
-    apply (rule set_ntfn_corres)
+    apply (rule setNotification_corres)
     apply (simp add: ntfn_relation_def combine_ntfn_badges_def
                      combine_ntfn_msgs_def)
    apply (simp add: invs_def valid_state_def valid_ntfn_def)
@@ -3174,17 +3174,17 @@ lemma sai_invs'[wp]:
                    split: thread_state.splits
                    dest!: global'_no_ex_cap st_tcb_ex_cap'' ko_at_valid_objs')+
 
-lemma rfk_corres:
+lemma replyFromKernel_corres:
   "corres dc (tcb_at t and invs) (tcb_at' t and invs')
              (reply_from_kernel t r) (replyFromKernel t r)"
   apply (case_tac r)
   apply (clarsimp simp: replyFromKernel_def reply_from_kernel_def
                         badge_register_def badgeRegister_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ lipcb_corres])
-      apply (rule corres_split_deprecated [OF _ user_setreg_corres])
-        apply (rule corres_split_eqr [OF _ set_mrs_corres])
-           apply (rule set_mi_corres)
+    apply (rule corres_split_eqr [OF _ lookupIPCBuffer_corres])
+      apply (rule corres_split_deprecated [OF _ asUser_setRegister_corres])
+        apply (rule corres_split_eqr [OF _ setMRs_corres])
+           apply (rule setMessageInfo_corres)
            apply (wp hoare_case_option_wp hoare_valid_ipc_buffer_ptr_typ_at'
                   | clarsimp)+
   done
@@ -3198,7 +3198,7 @@ lemma rfk_invs':
 
 crunch nosch[wp]: replyFromKernel "\<lambda>s. P (ksSchedulerAction s)"
 
-lemma complete_signal_corres:
+lemma completeSignal_corres:
   "corres dc (ntfn_at ntfnptr and tcb_at tcb and pspace_aligned and valid_objs
             \<comment> \<open>and obj_at (\<lambda>ko. ko = Notification ntfn \<and> Ipc_A.isActive ntfn) ntfnptr\<close>)
              (ntfn_at' ntfnptr and tcb_at' tcb and valid_pspace' and obj_at' isActive ntfnptr)
@@ -3207,14 +3207,14 @@ lemma complete_signal_corres:
   apply (rule corres_guard_imp)
     apply (rule_tac R'="\<lambda>ntfn. ntfn_at' ntfnptr and tcb_at' tcb and valid_pspace'
                          and valid_ntfn' ntfn and (\<lambda>_. isActive ntfn)"
-                                in corres_split_deprecated [OF _ get_ntfn_corres])
+                                in corres_split_deprecated [OF _ getNotification_corres])
       apply (rule corres_gen_asm2)
       apply (case_tac "ntfn_obj rv")
         apply (clarsimp simp: ntfn_relation_def isActive_def
                        split: ntfn.splits Structures_H.notification.splits)+
       apply (rule corres_guard2_imp)
        apply (simp add: badgeRegister_def badge_register_def)
-       apply (rule corres_split_deprecated[OF set_ntfn_corres user_setreg_corres])
+       apply (rule corres_split_deprecated[OF setNotification_corres asUser_setRegister_corres])
          apply (clarsimp simp: ntfn_relation_def)
         apply (wp set_simple_ko_valid_objs get_simple_ko_wp getNotification_wp | clarsimp simp: valid_ntfn'_def)+
   apply (clarsimp simp: valid_pspace'_def)
@@ -3223,15 +3223,15 @@ lemma complete_signal_corres:
   done
 
 
-lemma do_nbrecv_failed_transfer_corres:
+lemma doNBRecvFailedTransfer_corres:
   "corres dc (tcb_at thread)
             (tcb_at' thread)
             (do_nbrecv_failed_transfer thread)
             (doNBRecvFailedTransfer thread)"
   unfolding do_nbrecv_failed_transfer_def doNBRecvFailedTransfer_def
-  by (simp add: badgeRegister_def badge_register_def, rule user_setreg_corres)
+  by (simp add: badgeRegister_def badge_register_def, rule asUser_setRegister_corres)
 
-lemma receive_ipc_corres:
+lemma receiveIPC_corres:
   assumes "is_ep_cap cap" and "cap_relation cap cap'"
   shows "
    corres dc (einvs and valid_sched and tcb_at thread and valid_cap cap and ex_nonz_cap_to thread
@@ -3245,15 +3245,15 @@ lemma receive_ipc_corres:
   apply (rename_tac word1 word2 right)
   apply clarsimp
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres])
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres])
       apply (rule corres_guard_imp)
-        apply (rule corres_split_deprecated [OF _ gbn_corres])
+        apply (rule corres_split_deprecated [OF _ getBoundNotification_corres])
           apply (rule_tac r'="ntfn_relation" in corres_split_deprecated)
              apply (rule corres_if)
                apply (clarsimp simp: ntfn_relation_def Ipc_A.isActive_def Endpoint_H.isActive_def
                               split: Structures_A.ntfn.splits Structures_H.notification.splits)
               apply clarsimp
-              apply (rule complete_signal_corres)
+              apply (rule completeSignal_corres)
              apply (rule_tac P="einvs and valid_sched and tcb_at thread and
                                        ep_at word1 and valid_ep ep and
                                        obj_at (\<lambda>k. k = Endpoint ep) word1
@@ -3267,12 +3267,12 @@ lemma receive_ipc_corres:
                apply (simp add: ep_relation_def)
                apply (rule corres_guard_imp)
                  apply (case_tac isBlocking; simp)
-                  apply (rule corres_split_deprecated [OF _ sts_corres])
-                     apply (rule set_ep_corres)
+                  apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+                     apply (rule setEndpoint_corres)
                      apply (simp add: ep_relation_def)
                     apply simp
                    apply wp+
-                 apply (rule corres_guard_imp, rule do_nbrecv_failed_transfer_corres, simp)
+                 apply (rule corres_guard_imp, rule doNBRecvFailedTransfer_corres, simp)
                  apply simp
                 apply (clarsimp simp add: invs_def valid_state_def valid_pspace_def
                valid_tcb_state_def st_tcb_at_tcb_at)
@@ -3284,8 +3284,8 @@ lemma receive_ipc_corres:
         apply (clarsimp simp: valid_ep_def)
        apply (case_tac list, simp_all split del: if_split)[1]
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
-            apply (rule corres_split_deprecated [OF _ gts_corres])
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+            apply (rule corres_split_deprecated [OF _ getThreadState_corres])
               apply (rule_tac
                        F="\<exists>data.
                            sender_state =
@@ -3294,7 +3294,7 @@ lemma receive_ipc_corres:
               apply (clarsimp simp: isSend_def case_bool_If
                                     case_option_If if3_fold
                          split del: if_split cong: if_cong)
-              apply (rule corres_split_deprecated [OF _ dit_corres])
+              apply (rule corres_split_deprecated [OF _ doIPCTransfer_corres])
                 apply (simp split del: if_split cong: if_cong)
                 apply (fold dc_def)[1]
                 apply (rule_tac P="valid_objs and valid_mdb and valid_list
@@ -3315,10 +3315,10 @@ lemma receive_ipc_corres:
                                         and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)"
                              in corres_guard_imp [OF corres_if])
                     apply (simp add: fault_rel_optionation_def)
-                   apply (rule corres_if2 [OF _ setup_caller_corres sts_corres])
+                   apply (rule corres_if2 [OF _ setupCallerCap_corres setThreadState_corres])
                            apply simp
                           apply simp
-                         apply (rule corres_split_deprecated [OF _ sts_corres])
+                         apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                             apply (rule possibleSwitchTo_corres)
                            apply simp
                           apply (wp sts_st_tcb_at' set_thread_state_runnable_weak_valid_sched_action
@@ -3348,17 +3348,17 @@ lemma receive_ipc_corres:
              apply (simp add: ep_relation_def)
              apply (rule_tac corres_guard_imp)
                apply (case_tac isBlocking; simp)
-                apply (rule corres_split_deprecated [OF _ sts_corres])
-                   apply (rule set_ep_corres)
+                apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+                   apply (rule setEndpoint_corres)
                    apply (simp add: ep_relation_def)
                   apply simp
                  apply wp+
-               apply (rule corres_guard_imp, rule do_nbrecv_failed_transfer_corres, simp)
+               apply (rule corres_guard_imp, rule doNBRecvFailedTransfer_corres, simp)
                apply simp
               apply (clarsimp simp: valid_tcb_state_def)
              apply (clarsimp simp add: valid_tcb_state'_def)
             apply (rule corres_option_split[rotated 2])
-              apply (rule get_ntfn_corres)
+              apply (rule getNotification_corres)
              apply clarsimp
             apply (rule corres_trivial, simp add: ntfn_relation_def default_notification_def
                                                   default_ntfn_def)
@@ -3376,7 +3376,7 @@ lemma receive_ipc_corres:
              split: option.splits)
   done
 
-lemma receive_signal_corres:
+lemma receiveSignal_corres:
  "\<lbrakk> is_ntfn_cap cap; cap_relation cap cap' \<rbrakk> \<Longrightarrow>
   corres dc (invs and st_tcb_at active thread and valid_cap cap and ex_nonz_cap_to thread)
             (invs' and tcb_at' thread and valid_cap' cap')
@@ -3391,36 +3391,36 @@ lemma receive_signal_corres:
                             obj_at (\<lambda>k. k = Notification rv) word1" and
                             R'="\<lambda>rv'. invs' and tcb_at' thread and ntfn_at' word1 and
                             valid_ntfn' rv'"
-                         in corres_split_deprecated [OF _ get_ntfn_corres])
+                         in corres_split_deprecated [OF _ getNotification_corres])
       apply clarsimp
       apply (case_tac "ntfn_obj rv")
         \<comment> \<open>IdleNtfn\<close>
         apply (simp add: ntfn_relation_def)
         apply (rule corres_guard_imp)
           apply (case_tac isBlocking; simp)
-           apply (rule corres_split_deprecated [OF _ sts_corres])
-              apply (rule set_ntfn_corres)
+           apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+              apply (rule setNotification_corres)
               apply (simp add: ntfn_relation_def)
              apply simp
             apply wp+
-          apply (rule corres_guard_imp, rule do_nbrecv_failed_transfer_corres, simp+)
+          apply (rule corres_guard_imp, rule doNBRecvFailedTransfer_corres, simp+)
        \<comment> \<open>WaitingNtfn\<close>
        apply (simp add: ntfn_relation_def)
        apply (rule corres_guard_imp)
          apply (case_tac isBlocking; simp)
-          apply (rule corres_split_deprecated[OF _ sts_corres])
-             apply (rule set_ntfn_corres)
+          apply (rule corres_split_deprecated[OF _ setThreadState_corres])
+             apply (rule setNotification_corres)
              apply (simp add: ntfn_relation_def)
             apply simp
            apply wp+
          apply (rule corres_guard_imp)
-           apply (rule do_nbrecv_failed_transfer_corres, simp+)
+           apply (rule doNBRecvFailedTransfer_corres, simp+)
       \<comment> \<open>ActiveNtfn\<close>
       apply (simp add: ntfn_relation_def)
       apply (rule corres_guard_imp)
         apply (simp add: badgeRegister_def badge_register_def)
-        apply (rule corres_split_deprecated [OF _ user_setreg_corres])
-          apply (rule set_ntfn_corres)
+        apply (rule corres_split_deprecated [OF _ asUser_setRegister_corres])
+          apply (rule setNotification_corres)
           apply (simp add: ntfn_relation_def)
          apply wp+
        apply (fastforce simp: invs_def valid_state_def valid_pspace_def
@@ -3445,7 +3445,7 @@ lemma tg_sp':
 
 declare lookup_cap_valid' [wp]
 
-lemma send_fault_ipc_corres:
+lemma sendFaultIPC_corres:
   "valid_fault f \<Longrightarrow> fr f f' \<Longrightarrow>
   corres (fr \<oplus> dc)
          (einvs and st_tcb_at active thread and ex_nonz_cap_to thread)
@@ -3472,7 +3472,7 @@ lemma send_fault_ipc_corres:
           apply (rule corres_guard_imp)
             apply (rule corres_if2 [OF refl])
              apply (simp add: dc_def[symmetric])
-             apply (rule corres_split_deprecated [OF send_ipc_corres threadset_corres], simp_all)[1]
+             apply (rule corres_split_deprecated [OF sendIPC_corres threadset_corres], simp_all)[1]
                apply (simp add: tcb_relation_def fault_rel_optionation_def exst_same_def)+
               apply (wp thread_set_invs_trivial thread_set_no_change_tcb_state
                         thread_set_typ_at ep_at_typ_at ex_nonz_cap_to_pres
@@ -3488,7 +3488,7 @@ lemma send_fault_ipc_corres:
           apply auto[1]
          apply (clarsimp simp: lookup_failure_map_def)
         apply wp+
-      apply (rule threadget_corres)
+      apply (rule threadGet_corres)
       apply (simp add: tcb_relation_def)
      apply wp+
    apply (fastforce elim: st_tcb_at_tcb_at)
@@ -3503,7 +3503,7 @@ lemma gets_the_noop_corres:
   apply (clarsimp simp: assert_opt_def return_def dest!: P)
   done
 
-lemma hdf_corres:
+lemma handleDoubleFault_corres:
   "corres dc (tcb_at thread)
              (tcb_at' thread and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s))
              (handle_double_fault thread f ft)
@@ -3511,7 +3511,7 @@ lemma hdf_corres:
   apply (simp add: handle_double_fault_def handleDoubleFault_def)
   apply (rule corres_guard_imp)
     apply (subst bind_return [symmetric],
-           rule corres_split' [OF sts_corres])
+           rule corres_split' [OF setThreadState_corres])
        apply simp
       apply (rule corres_noop2)
          apply (simp add: exs_valid_def return_def)
@@ -4295,7 +4295,7 @@ lemma sfi_invs_plus':
   apply (subst(asm) global'_no_ex_cap, auto)
   done
 
-lemma hf_corres:
+lemma handleFault_corres:
   "fr f f' \<Longrightarrow>
    corres dc (einvs and  st_tcb_at active thread and ex_nonz_cap_to thread
                    and (%_. valid_fault f))
@@ -4309,9 +4309,9 @@ lemma hf_corres:
                rule corres_split_deprecated [where P="tcb_at thread",
                                   OF _ gets_the_noop_corres [where x="()"]])
        apply (rule corres_split_catch)
-          apply (rule hdf_corres)
+          apply (rule handleDoubleFault_corres)
           apply (rule_tac F="valid_fault f" in corres_gen_asm)
-         apply (rule send_fault_ipc_corres, assumption)
+         apply (rule sendFaultIPC_corres, assumption)
          apply simp
         apply wp+
        apply (rule hoare_post_impErr, rule sfi_invs_plus', simp_all)[1]

--- a/proof/refine/ARM_HYP/KHeap_R.thy
+++ b/proof/refine/ARM_HYP/KHeap_R.thy
@@ -162,7 +162,7 @@ lemma lookupAround2_same1[simp]:
   apply (simp add: lookupAround2_known1)
   done
 
-lemma get_vcpu_corres:
+lemma getObject_vcpu_corres:
   "corres vcpu_relation (vcpu_at vcpu) (vcpu_at' vcpu)
                         (get_vcpu vcpu) (getObject vcpu)"
   apply (simp add: getObject_def get_vcpu_def get_object_def split_def)
@@ -866,7 +866,7 @@ lemma no_fail_getEndpoint [wp]:
    apply (clarsimp split: option.split_asm simp: objBits_simps' archObjSize_def)
   done
 
-lemma get_ep_corres [corres]:
+lemma getEndpoint_corres [corres]:
   "corres ep_relation (ep_at ptr) (ep_at' ptr)
      (get_endpoint ptr) (getEndpoint ptr)"
   apply (rule corres_no_failI)
@@ -978,7 +978,7 @@ where
   "exst_same' (KOTCB tcb) (KOTCB tcb') = exst_same tcb tcb'" |
   "exst_same' _ _ = True"
 
-lemma set_other_obj_corres:
+lemma setObject_other_corres:
   fixes ob' :: "'a :: pspace_storable"
   assumes x: "updateObject ob' = updateObject_default ob'"
   assumes z: "\<And>s. obj_at' P ptr s
@@ -1056,21 +1056,21 @@ lemmas obj_at_simps = obj_at_def obj_at'_def projectKOs map_to_ctes_upd_other
                       a_type_def objBits_simps other_obj_relation_def
                       archObjSize_def pageBits_def
 
-lemma set_ep_corres [corres]:
+lemma setEndpoint_corres [corres]:
   "ep_relation e e' \<Longrightarrow>
   corres dc (ep_at ptr) (ep_at' ptr)
             (set_endpoint ptr e) (setEndpoint ptr e')"
   apply (simp add: set_simple_ko_def setEndpoint_def is_ep_def[symmetric])
-    apply (corres_search search: set_other_obj_corres[where P="\<lambda>_. True"])
+    apply (corres_search search: setObject_other_corres[where P="\<lambda>_. True"])
   apply (corressimp wp: get_object_ret get_object_wp)+
   by (fastforce simp: is_ep obj_at_simps objBits_defs partial_inv_def)
 
-lemma set_ntfn_corres [corres]:
+lemma setNotification_corres [corres]:
   "ntfn_relation ae ae' \<Longrightarrow>
   corres dc (ntfn_at ptr) (ntfn_at' ptr)
             (set_notification ptr ae) (setNotification ptr ae')"
   apply (simp add: set_simple_ko_def setNotification_def is_ntfn_def[symmetric])
-       apply (corres_search search: set_other_obj_corres[where P="\<lambda>_. True"])
+       apply (corres_search search: setObject_other_corres[where P="\<lambda>_. True"])
   apply (corressimp wp: get_object_ret get_object_wp)+
   by (fastforce simp: is_ntfn obj_at_simps objBits_defs partial_inv_def)
 
@@ -1090,7 +1090,7 @@ lemma no_fail_getNotification [wp]:
    apply (clarsimp split: option.split_asm simp: objBits_simps' archObjSize_def)
   done
 
-lemma get_ntfn_corres:
+lemma getNotification_corres:
   "corres ntfn_relation (ntfn_at ptr) (ntfn_at' ptr)
      (get_notification ptr) (getNotification ptr)"
   apply (rule corres_no_failI)

--- a/proof/refine/ARM_HYP/Refine.thy
+++ b/proof/refine/ARM_HYP/Refine.thy
@@ -553,7 +553,7 @@ lemma kernel_corres':
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated)
        prefer 2
-       apply (rule corres_split_handle [OF _ he_corres])
+       apply (rule corres_split_handle [OF _ handleEvent_corres])
          apply simp
          apply (rule corres_split_deprecated [OF _ corres_machine_op])
             prefer 2
@@ -565,7 +565,7 @@ lemma kernel_corres':
             apply (simp add: when_def)
            apply (rule corres_when[simplified dc_def], simp)
            apply simp
-           apply (rule handle_interrupt_corres[simplified dc_def])
+           apply (rule handleInterrupt_corres[simplified dc_def])
           apply simp
           apply (wp hoare_drop_imps hoare_vcg_all_lift)[1]
          apply simp
@@ -579,7 +579,7 @@ lemma kernel_corres':
          apply wpsimp+
        apply (simp add: invs'_def valid_state'_def)
       apply (rule corres_split_deprecated [OF _ schedule_corres])
-        apply (rule activate_corres)
+        apply (rule activateThread_corres)
        apply (wp schedule_invs' hoare_vcg_if_lift2 dmo_getActiveIRQ_non_kernel
               | simp cong: rev_conj_cong | strengthen None_drop | subst Ex_Some_conv)+
      apply (rule_tac Q="\<lambda>_. valid_sched and invs and valid_list" and E="\<lambda>_. valid_sched and invs and valid_list"
@@ -640,7 +640,7 @@ lemma entry_corres:
           (kernel_entry event tc) (kernelEntry event tc)"
   apply (simp add: kernel_entry_def kernelEntry_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gct_corres])
+    apply (rule corres_split_deprecated [OF _ getCurThread_corres])
       apply (rule corres_split_deprecated)
          prefer 2
          apply simp
@@ -651,8 +651,8 @@ lemma entry_corres:
           apply (clarsimp simp: tcb_cte_cases_def)
          apply (simp add: exst_same_def)
         apply (rule corres_split_deprecated [OF _ kernel_corres])
-          apply (rule corres_split_eqr [OF _ gct_corres])
-            apply (rule threadget_corres)
+          apply (rule corres_split_eqr [OF _ getCurThread_corres])
+            apply (rule threadGet_corres)
             apply (simp add: tcb_relation_def arch_tcb_relation_def
                              arch_tcb_context_get_def atcbContextGet_def)
            apply wp+
@@ -683,7 +683,7 @@ lemma do_user_op_corres:
           (do_user_op f tc) (doUserOp f tc)"
   apply (simp add: do_user_op_def doUserOp_def split_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply (rule_tac r'="(=)" and P=einvs and P'=invs' in corres_split_deprecated)
          prefer 2
          apply (fastforce dest: absKState_correct [rotated])
@@ -776,7 +776,7 @@ lemma check_active_irq_corres:
     apply (rule check_active_irq_corres', auto)
   done
 
-lemma check_active_irq_corres_just_running:
+lemma checkActiveIRQ_just_running_corres:
   "corres (=)
     (invs and ct_running and einvs and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and (\<lambda>s. 0 < domain_time s) and valid_domain_list)
@@ -788,7 +788,7 @@ lemma check_active_irq_corres_just_running:
     apply (rule check_active_irq_corres', auto)
   done
 
-lemma check_active_irq_corres_just_idle:
+lemma checkActiveIRQ_just_idle_corres:
   "corres (=)
     (invs and ct_idle and einvs and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and (\<lambda>s. 0 < domain_time s)  and valid_domain_list)
@@ -913,7 +913,7 @@ lemma ckernel_invariant:
    apply (drule use_valid)
      apply (rule hoare_vcg_conj_lift)
       apply (rule checkActiveIRQ_valid_duplicates')
-     apply (rule valid_corres_combined[OF check_active_irq_invs_just_running check_active_irq_corres_just_running])
+     apply (rule valid_corres_combined[OF check_active_irq_invs_just_running checkActiveIRQ_just_running_corres])
      apply (rule checkActiveIRQ_invs'_just_running[THEN hoare_weaken_pre])
      apply (fastforce simp: ex_abs_def)
     apply (fastforce simp: ex_abs_def ct_running_related sched_act_rct_related)
@@ -924,7 +924,7 @@ lemma ckernel_invariant:
    apply (drule use_valid)
      apply (rule hoare_vcg_conj_lift)
       apply (rule checkActiveIRQ_valid_duplicates')
-     apply (rule valid_corres_combined[OF check_active_irq_invs_just_idle check_active_irq_corres_just_idle])
+     apply (rule valid_corres_combined[OF check_active_irq_invs_just_idle checkActiveIRQ_just_idle_corres])
      apply (rule checkActiveIRQ_invs'_just_idle[THEN hoare_weaken_pre])
      apply clarsimp
      apply (fastforce simp: ex_abs_def)

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -2536,7 +2536,7 @@ lemma init_arch_objects_APIType_map2:
             split: apiobject_type.split)
   done
 
-lemma copy_global_corres:
+lemma copyGlobalMappings_corres:
   "corres dc (valid_arch_state and valid_etcbs and pspace_aligned and page_directory_at pd)
              (valid_arch_state' and page_directory_at' pd)
           (copy_global_mappings pd)
@@ -5505,7 +5505,7 @@ lemma corres_retype_region_createNewCaps:
                           and Q'="\<lambda>xs s. (\<forall>x \<in> set xs. page_directory_at' x s) \<and> valid_arch_state' s"
                           in corres_mapM_list_all2[where r'=dc and S="(=)"])
                   apply simp+
-                apply (rule corres_guard_imp, rule copy_global_corres)
+                apply (rule corres_guard_imp, rule copyGlobalMappings_corres)
                  apply simp+
                apply (wp hoare_vcg_const_Ball_lift | simp)+
              apply (simp add: list_all2_same)

--- a/proof/refine/ARM_HYP/Schedule_R.thy
+++ b/proof/refine/ARM_HYP/Schedule_R.thy
@@ -129,7 +129,7 @@ crunches vcpu_switch
   for valid_vs_lookup[wp]: "\<lambda>s. P (valid_vs_lookup s)"
   (simp: crunch_simps valid_vs_lookup_current_vcpu wp: crunch_wps)
 
-lemma arch_switch_thread_corres:
+lemma arch_switchToThread_corres:
   "corres dc (valid_arch_state and valid_objs and valid_asid_map
               and valid_vspace_objs and pspace_aligned and pspace_distinct
               and valid_vs_lookup and valid_global_objs
@@ -143,7 +143,7 @@ lemma arch_switch_thread_corres:
     apply (rule corres_split_deprecated[OF _ get_tcb_corres])
       apply (rule corres_split_deprecated[OF _ vcpuSwitch_corres'])
          apply (simp add: tcb_relation_def arch_tcb_relation_def)
-         apply (rule corres_split_deprecated[OF _ set_vm_root_corres])
+         apply (rule corres_split_deprecated[OF _ setVMRoot_corres])
            apply (rule corres_machine_op[OF corres_rel_imp])
             apply (rule corres_underlying_trivial)
             apply wpsimp
@@ -207,7 +207,7 @@ lemma tcbSchedAppend_corres:
              apply (rule corres_split_noop_rhs2)
                 apply (rule corres_split_noop_rhs2)
                    apply (rule threadSet_corres_noop, simp_all add: tcb_relation_def exst_same_def)[1]
-                  apply (rule addToBitmap_if_null_corres_noop)
+                  apply (rule addToBitmap_if_null_noop_corres)
                  apply wp+
                apply (simp add: tcb_sched_append_def)
                apply (intro conjI impI)
@@ -726,7 +726,7 @@ lemma tcbSchedDequeue_invs'[wp]:
   apply (fastforce elim: valid_objs'_maxDomain valid_objs'_maxPriority simp: valid_pspace'_def)+
   done
 
-lemma cur_thread_update_corres:
+lemma setCurThread_corres:
   "corres dc \<top> \<top> (modify (cur_thread_update (\<lambda>_. t))) (setCurThread t)"
   apply (unfold setCurThread_def)
   apply (rule corres_modify)
@@ -755,7 +755,7 @@ crunches Arch.switchToThread
   for valid_queues[wp]: Invariants_H.valid_queues
   (wp: crunch_wps simp: crunch_simps ignore: clearExMonitor)
 
-lemma switch_thread_corres:
+lemma switchToThread_corres:
   "corres dc (valid_arch_state and valid_objs and valid_asid_map
                 and valid_vspace_objs and pspace_aligned and pspace_distinct
                 and valid_vs_lookup and valid_global_objs
@@ -777,8 +777,8 @@ proof -
          setCurThread t
       od)"
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF _ arch_switch_thread_corres])
-        apply (rule corres_split_deprecated[OF cur_thread_update_corres tcbSchedDequeue_corres])
+      apply (rule corres_split_deprecated [OF _ arch_switchToThread_corres])
+        apply (rule corres_split_deprecated[OF setCurThread_corres tcbSchedDequeue_corres])
          apply (wpsimp simp: tcb_at_is_etcb_at st_tcb_at_tcb_at)+
     done
 
@@ -827,14 +827,14 @@ lemma tcb_at'_ksIdleThread_lift:
   apply (rule hoare_lift_Pf[where f=ksIdleThread])
   by (wpsimp wp: T I)+
 
-lemma arch_switch_idle_thread_corres:
+lemma arch_switchToIdleThread_corres:
   "corres dc
          invs
          (valid_arch_state' and pspace_aligned' and pspace_distinct' and no_0_obj' and valid_idle')
           arch_switch_to_idle_thread
           Arch.switchToIdleThread"
   unfolding arch_switch_to_idle_thread_def ARM_HYP_H.switchToIdleThread_def
-  apply (corressimp corres: git_corres set_vm_root_corres[@lift_corres_args] vcpuSwitch_corres[where vcpu=None, simplified]
+  apply (corressimp corres: getIdleThread_corres setVMRoot_corres[@lift_corres_args] vcpuSwitch_corres[where vcpu=None, simplified]
                         wp: tcb_at_idle_thread_lift tcb_at'_ksIdleThread_lift vcpuSwitch_it')
   apply (clarsimp simp: invs_valid_objs invs_arch_state invs_valid_asid_map invs_valid_vs_lookup
                         invs_psp_aligned invs_distinct invs_unique_refs invs_vspace_objs)
@@ -844,12 +844,12 @@ lemma arch_switch_idle_thread_corres:
                          projectKOs typ_at'_def ko_wp_at'_def is_vcpu'_def)
   done
 
-lemma switch_idle_thread_corres:
+lemma switchToIdleThread_corres:
   "corres dc invs invs_no_cicd' switch_to_idle_thread switchToIdleThread"
   apply (simp add: switch_to_idle_thread_def Thread_H.switchToIdleThread_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ git_corres])
-      apply (rule corres_split_deprecated [OF _ arch_switch_idle_thread_corres])
+    apply (rule corres_split_deprecated [OF _ getIdleThread_corres])
+      apply (rule corres_split_deprecated [OF _ arch_switchToIdleThread_corres])
         apply (unfold setCurThread_def)
         apply (rule corres_trivial, rule corres_modify)
         apply (simp add: state_relation_def cdt_relation_def)
@@ -1636,7 +1636,7 @@ lemma guarded_switch_to_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_symb_exec_l'[OF _ gts_exs_valid])
       apply (rule corres_assert_assume_l)
-      apply (rule switch_thread_corres)
+      apply (rule switchToThread_corres)
      apply (force simp: st_tcb_at_tcb_at)
     apply (wp gts_st_tcb_at)
    apply (force simp: st_tcb_at_tcb_at valid_global_objs_def)+
@@ -1699,10 +1699,10 @@ lemma guarded_switch_to_chooseThread_fragment_corres:
   unfolding guarded_switch_to_def isRunnable_def
   apply simp
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gts_corres])
+    apply (rule corres_split_deprecated[OF _ getThreadState_corres])
       apply (rule corres_assert_assume_l)
       apply (rule corres_assert_assume_r)
-      apply (rule switch_thread_corres)
+      apply (rule switchToThread_corres)
      apply (wp gts_st_tcb_at)+
    apply (clarsimp simp: st_tcb_at_tcb_at invs_def valid_state_def valid_pspace_def valid_sched_def
                           invs_valid_vs_lookup invs_unique_refs)
@@ -1754,7 +1754,7 @@ proof -
       apply clarsimp
       apply (rule corres_split_deprecated[OF _ corres_gets_queues_getReadyQueuesL1Bitmap])
         apply (erule corres_if2[OF sym])
-         apply (rule switch_idle_thread_corres)
+         apply (rule switchToIdleThread_corres)
         apply (rule corres_symb_exec_r)
            apply (rule corres_symb_exec_r)
               apply (rule_tac
@@ -1808,11 +1808,11 @@ lemma schact_bind_inside: "do x \<leftarrow> f; (case act of resume_cur_thread \
 interpretation tcb_sched_action_extended: is_extended' "tcb_sched_action f a"
   by (unfold_locales)
 
-lemma domain_time_corres:
+lemma getDomainTime_corres:
   "corres (=) \<top> \<top> (gets domain_time) getDomainTime"
   by (simp add: getDomainTime_def state_relation_def)
 
-lemma next_domain_corres:
+lemma nextDomain_corres:
   "corres dc \<top> \<top> next_domain nextDomain"
   apply (simp add: next_domain_def nextDomain_def)
   apply (rule corres_modify)
@@ -1841,7 +1841,7 @@ lemma bind_dummy_ret_val:
    od = do a; b od"
   by simp
 
-lemma schedule_ChooseNewThread_fragment_corres:
+lemma scheduleChooseNewThread_fragment_corres:
   "corres dc (invs and valid_sched and (\<lambda>s. scheduler_action s = choose_new_thread)) (invs' and (\<lambda>s. ksSchedulerAction s = ChooseNewThread))
      (do _ \<leftarrow> when (domainTime = 0) next_domain;
          choose_thread
@@ -1856,12 +1856,12 @@ lemma schedule_ChooseNewThread_fragment_corres:
         apply simp
         apply (rule chooseThread_corres)
        apply simp
-      apply (rule next_domain_corres)
+      apply (rule nextDomain_corres)
      apply (wp nextDomain_invs_no_cicd')+
    apply (clarsimp simp: valid_sched_def invs'_def valid_state'_def all_invs_but_ct_idle_or_in_cur_domain'_def)+
   done
 
-lemma schedule_switch_thread_fastfail_corres:
+lemma scheduleSwitchThreadFastfail_corres:
   "\<lbrakk> ct \<noteq> it \<longrightarrow> (tp = tp' \<and> cp = cp') ; ct = ct' ; it = it' \<rbrakk> \<Longrightarrow>
    corres ((=)) (is_etcb_at ct) (tcb_at' ct)
      (schedule_switch_thread_fastfail ct it cp tp)
@@ -1924,9 +1924,9 @@ lemma scheduleChooseNewThread_corres:
            schedule_choose_new_thread scheduleChooseNewThread"
   unfolding schedule_choose_new_thread_def scheduleChooseNewThread_def
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ domain_time_corres], clarsimp)
-      apply (rule corres_split_deprecated[OF _ schedule_ChooseNewThread_fragment_corres, simplified bind_assoc])
-        apply (rule set_sa_corres)
+    apply (rule corres_split_deprecated[OF _ getDomainTime_corres], clarsimp)
+      apply (rule corres_split_deprecated[OF _ scheduleChooseNewThread_fragment_corres, simplified bind_assoc])
+        apply (rule setSchedulerAction_corres)
         apply (wp | simp)+
     apply (wp | simp add: getDomainTime_def)+
    apply auto
@@ -1963,8 +1963,8 @@ lemma schedule_corres:
   apply (subst thread_get_comm)
   apply (subst schact_bind_inside)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres[THEN corres_rel_imp[where r="\<lambda>x y. y = x"],simplified]])
-      apply (rule corres_split_deprecated[OF _ get_sa_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres[THEN corres_rel_imp[where r="\<lambda>x y. y = x"],simplified]])
+      apply (rule corres_split_deprecated[OF _ getSchedulerAction_corres])
         apply (rule corres_split_sched_act,assumption)
           apply (rule_tac P="tcb_at ct" in corres_symb_exec_l')
             apply (rule_tac corres_symb_exec_l)
@@ -1984,19 +1984,19 @@ lemma schedule_corres:
         apply (rule corres_split_deprecated[OF _ thread_get_isRunnable_corres],
                 rename_tac was_running wasRunning)
           apply (rule corres_split_deprecated[OF _ corres_when])
-              apply (rule corres_split_deprecated[OF _ git_corres], rename_tac it it')
+              apply (rule corres_split_deprecated[OF _ getIdleThread_corres], rename_tac it it')
                 apply (rule_tac F="was_running \<longrightarrow> ct \<noteq> it" in corres_gen_asm)
                 apply (rule corres_split_deprecated[OF _ ethreadget_corres[where r="(=)"]],
                        rename_tac tp tp')
                    apply (rule corres_split_deprecated[OF _ ethread_get_when_corres[where r="(=)"]],
                            rename_tac cp cp')
-                      apply (rule corres_split_deprecated[OF _ schedule_switch_thread_fastfail_corres])
+                      apply (rule corres_split_deprecated[OF _ scheduleSwitchThreadFastfail_corres])
                            apply (rule corres_split_deprecated[OF _ curDomain_corres])
                              apply (rule corres_split_deprecated[OF _ isHighestPrio_corres]; simp only:)
                                apply (rule corres_if, simp)
                                 apply (rule corres_split_deprecated[OF _ tcbSchedEnqueue_corres])
                                   apply (simp, fold dc_def)
-                                  apply (rule corres_split_deprecated[OF _ set_sa_corres])
+                                  apply (rule corres_split_deprecated[OF _ setSchedulerAction_corres])
                                      apply (rule scheduleChooseNewThread_corres, simp)
 
                                    apply (wp | simp)+
@@ -2012,7 +2012,7 @@ lemma schedule_corres:
 
                                 apply (rule corres_split_deprecated[OF _ tcbSchedAppend_corres])
                                   apply (simp, fold dc_def)
-                                  apply (rule corres_split_deprecated[OF _ set_sa_corres])
+                                  apply (rule corres_split_deprecated[OF _ setSchedulerAction_corres])
                                      apply (rule scheduleChooseNewThread_corres, simp)
 
                                    apply (wp | simp)+
@@ -2025,7 +2025,7 @@ lemma schedule_corres:
                                 apply (wp tcbSchedAppend_invs'_not_ResumeCurrentThread)
 
                                apply (rule corres_split_deprecated[OF _ guarded_switch_to_corres], simp)
-                                 apply (rule set_sa_corres[simplified dc_def])
+                                 apply (rule setSchedulerAction_corres[simplified dc_def])
                                  apply (wp | simp)+
 
                              (* isHighestPrio *)
@@ -2412,7 +2412,7 @@ lemma possibleSwitchTo_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated[OF _ curDomain_corres], simp)
       apply (rule corres_split_deprecated[OF _ ethreadget_corres[where r="(=)"]])
-         apply (rule corres_split_deprecated[OF _ get_sa_corres])
+         apply (rule corres_split_deprecated[OF _ getSchedulerAction_corres])
            apply (rule corres_if, simp)
             apply (rule tcbSchedEnqueue_corres)
            apply (rule corres_if, simp)
@@ -2420,7 +2420,7 @@ lemma possibleSwitchTo_corres:
             apply (rule corres_split_deprecated[OF _ rescheduleRequired_corres])
               apply (rule tcbSchedEnqueue_corres)
              apply (wp rescheduleRequired_valid_queues'_weak)+
-           apply (rule set_sa_corres, simp)
+           apply (rule setSchedulerAction_corres, simp)
           apply (wpsimp simp: etcb_relation_def if_apply_def2
                         wp: hoare_drop_imp[where f="ethread_get a b" for a b])+
       apply (wp hoare_drop_imps)[1]

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -128,7 +128,7 @@ where
 
 
 (* FIXME: move *)
-lemma dec_domain_inv_corres:
+lemma decodeDomainInvocation_corres:
   shows "\<lbrakk> list_all2 cap_relation (map fst cs) (map fst cs');
            list_all2 (\<lambda>p pa. snd pa = cte_map (snd p)) cs cs' \<rbrakk> \<Longrightarrow>
         corres (ser \<oplus> ((\<lambda>x. inv_relation x \<circ> uncurry Invocations_H.invocation.InvokeDomain) \<circ> (\<lambda>(x,y). Invocations_A.invocation.InvokeDomain x y))) \<top> \<top>
@@ -158,7 +158,7 @@ lemma dec_domain_inv_corres:
      apply (wp | simp)+
 done
 
-lemma decode_invocation_corres:
+lemma decodeInvocation_corres:
   "\<lbrakk>cptr = to_bl cptr'; mi' = message_info_map mi;
     slot' = cte_map slot; cap_relation cap cap';
     args = args'; list_all2 cap_relation (map fst excaps) (map fst excaps');
@@ -182,7 +182,7 @@ lemma decode_invocation_corres:
              apply (simp add: isCap_defs)
             \<comment> \<open>Untyped\<close>
             apply (simp add: isCap_defs Let_def o_def split del: if_split)
-            apply (rule corres_guard_imp, rule dec_untyped_inv_corres)
+            apply (rule corres_guard_imp, rule decodeUntypedInvocation_corres)
               apply ((clarsimp simp:cte_wp_at_caps_of_state)+)[3]
            \<comment> \<open>(Async)Endpoint\<close>
            apply (simp add: isCap_defs returnOk_def)
@@ -197,7 +197,7 @@ lemma decode_invocation_corres:
         apply (clarsimp simp add: o_def)
         apply (rule corres_guard_imp)
           apply (rule_tac F="length list \<le> 32" in corres_gen_asm)
-          apply (rule dec_cnode_inv_corres, simp+)
+          apply (rule decodeCNodeInvocation_corres, simp+)
          apply (simp add: valid_cap_def word_bits_def)
         apply simp
        \<comment> \<open>ThreadCap\<close>
@@ -205,7 +205,7 @@ lemma decode_invocation_corres:
                    split del: if_split cong: if_cong)
        apply (clarsimp simp add: o_def)
        apply (rule corres_guard_imp)
-         apply (rule decode_tcb_inv_corres, rule refl,
+         apply (rule decodeTCBInvocation_corres, rule refl,
                 simp_all add: valid_cap_def valid_cap'_def)[3]
        apply (simp add: split_def)
        apply (rule list_all2_conj)
@@ -214,20 +214,20 @@ lemma decode_invocation_corres:
       \<comment> \<open>DomainCap\<close>
       apply (simp add: isCap_defs)
       apply (rule corres_guard_imp)
-      apply (rule dec_domain_inv_corres)
+      apply (rule decodeDomainInvocation_corres)
       apply (simp+)[4]
      \<comment> \<open>IRQControl\<close>
      apply (simp add: isCap_defs o_def)
-     apply (rule corres_guard_imp, rule decode_irq_control_corres, simp+)[1]
+     apply (rule corres_guard_imp, rule decodeIRQControlInvocation_corres, simp+)[1]
     \<comment> \<open>IRQHandler\<close>
     apply (simp add: isCap_defs o_def)
-    apply (rule corres_guard_imp, rule decode_irq_handler_corres, simp+)[1]
+    apply (rule corres_guard_imp, rule decodeIRQHandlerInvocation_corres, simp+)[1]
    \<comment> \<open>Zombie\<close>
    apply (simp add: isCap_defs)
   \<comment> \<open>Arch\<close>
   apply (clarsimp simp only: cap_relation.simps)
   apply (clarsimp simp add: isCap_defs Let_def o_def)
-  apply (rule corres_guard_imp [OF dec_arch_inv_corres])
+  apply (rule corres_guard_imp [OF arch_decodeInvocation_corres])
       apply (simp_all add: list_all2_map2 list_all2_map1)+
   done
 
@@ -265,9 +265,9 @@ lemma hinv_corres_assist:
     apply (rule corres_splitEE [OF _ corres_cap_fault])
        prefer 2
        \<comment> \<open>switched over to argument of corres_cap_fault\<close>
-       apply (rule lcs_corres, simp)
-      apply (rule corres_split_deprecated [OF _ lipcb_corres])
-        apply (rule corres_splitEE [OF _ lec_corres])
+       apply (rule lookupCapAndSlot_corres, simp)
+      apply (rule corres_split_deprecated [OF _ lookupIPCBuffer_corres])
+        apply (rule corres_splitEE [OF _ lookupExtraCaps_corres])
             apply (rule corres_returnOkTT)
             apply simp+
          apply (wp | simp)+
@@ -349,7 +349,7 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
    apply (auto simp: obj_at'_def)
   done
 
-lemma set_domain_setDomain_corres:
+lemma setDomain_corres:
   "corres dc
      (valid_etcbs and valid_sched and tcb_at tptr)
      (invs'  and sch_act_simple
@@ -359,10 +359,10 @@ lemma set_domain_setDomain_corres:
   apply (rule corres_gen_asm2)
   apply (simp add: set_domain_def setDomain_def thread_set_domain_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply (rule corres_split_deprecated[OF _ tcbSchedDequeue_corres])
         apply (rule corres_split_deprecated[OF _ ethread_set_corres])
-                 apply (rule corres_split_deprecated[OF _ gts_isRunnable_corres])
+                 apply (rule corres_split_deprecated[OF _ isRunnable_corres])
                    apply simp
                    apply (rule corres_split_deprecated[OF corres_when[OF refl]])
                       apply (rule rescheduleRequired_corres)
@@ -395,7 +395,7 @@ lemma set_domain_setDomain_corres:
                simp: valid_sched_def valid_sched_action_def)
   done
 
-lemma pinv_corres:
+lemma performInvocation_corres:
   "\<lbrakk> inv_relation i i'; call \<longrightarrow> block \<rbrakk> \<Longrightarrow>
    corres (dc \<oplus> (=))
      (einvs and valid_invocation i
@@ -416,9 +416,9 @@ lemma pinv_corres:
               apply wp+
             apply simp+
           apply (rule corres_guard_imp)
-           apply (rule corres_split_deprecated [OF _ gct_corres])
+           apply (rule corres_split_deprecated [OF _ getCurThread_corres])
              apply simp
-             apply (rule corres_split_deprecated [OF _ send_ipc_corres])
+             apply (rule corres_split_deprecated [OF _ sendIPC_corres])
                 apply (rule corres_trivial)
                 apply simp
                apply simp
@@ -429,15 +429,15 @@ lemma pinv_corres:
                                sch_act_simple_def)
         apply (rule corres_guard_imp)
           apply (simp add: liftE_bindE)
-          apply (rule corres_split_deprecated [OF _ send_signal_corres])
+          apply (rule corres_split_deprecated [OF _ sendSignal_corres])
             apply (rule corres_trivial)
             apply (simp add: returnOk_def)
            apply wp+
          apply (simp+)[2]
        apply simp
        apply (rule corres_guard_imp)
-         apply (rule corres_split_eqr [OF _ gct_corres])
-           apply (rule corres_split_nor [OF _ do_reply_transfer_corres'])
+         apply (rule corres_split_eqr [OF _ getCurThread_corres])
+           apply (rule corres_split_nor [OF _ doReplyTransfer_corres'])
              apply (rule corres_trivial, simp)
             apply wp+
         apply (clarsimp simp: tcb_at_invs)
@@ -447,30 +447,30 @@ lemma pinv_corres:
        apply (fastforce elim!: cte_wp_at_weakenE')
       apply (clarsimp simp: liftME_def)
       apply (rule corres_guard_imp)
-        apply (erule tcbinv_corres)
+        apply (erule invokeTCB_corres)
        apply (simp)+
       \<comment> \<open>domain cap\<close>
       apply (clarsimp simp: invoke_domain_def)
       apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF _ set_domain_setDomain_corres])
+      apply (rule corres_split_deprecated [OF _ setDomain_corres])
         apply (rule corres_trivial, simp)
        apply (wp)+
        apply (clarsimp+)[2]
      \<comment> \<open>CNodes\<close>
      apply clarsimp
      apply (rule corres_guard_imp)
-       apply (rule corres_splitEE [OF _ inv_cnode_corres])
+       apply (rule corres_splitEE [OF _ invokeCNode_corres])
           apply (rule corres_trivial, simp add: returnOk_def)
          apply assumption
         apply wp+
       apply (clarsimp+)[2]
     apply (clarsimp simp: liftME_def[symmetric] o_def dc_def[symmetric])
-    apply (rule corres_guard_imp, rule invoke_irq_control_corres, simp+)
+    apply (rule corres_guard_imp, rule performIRQControl_corres, simp+)
    apply (clarsimp simp: liftME_def[symmetric] o_def dc_def[symmetric])
-   apply (rule corres_guard_imp, rule invoke_irq_handler_corres, simp+)
+   apply (rule corres_guard_imp, rule invokeIRQHandler_corres, simp+)
   apply clarsimp
   apply (rule corres_guard_imp)
-    apply (rule inv_arch_corres, assumption)
+    apply (rule arch_performInvocation_corres, assumption)
    apply (clarsimp+)[2]
   done
 
@@ -1218,7 +1218,7 @@ crunch valid_duplicates'[wp]: rescheduleRequired "\<lambda>s. vs_valid_duplicate
 crunch valid_duplicates'[wp]: setThreadState "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
 
 (*FIXME: move to NonDetMonadVCG.valid_validE_R *)
-lemma hinv_corres:
+lemma handleInvocation_corres:
   "c \<longrightarrow> b \<Longrightarrow>
    corres (dc \<oplus> dc)
           (einvs and (\<lambda>s. scheduler_action s = resume_cur_thread) and ct_active)
@@ -1228,19 +1228,19 @@ lemma hinv_corres:
           (handleInvocation c b)"
   apply (simp add: handle_invocation_def handleInvocation_def liftE_bindE)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ gct_corres])
-      apply (rule corres_split_deprecated [OF _ get_mi_corres])
+    apply (rule corres_split_eqr [OF _ getCurThread_corres])
+      apply (rule corres_split_deprecated [OF _ getMessageInfo_corres])
         apply clarsimp
         apply (simp add: liftM_def cap_register_def capRegister_def)
-        apply (rule corres_split_eqr [OF _ user_getreg_corres])
+        apply (rule corres_split_eqr [OF _ asUser_getRegister_corres])
           apply (rule syscall_corres)
                   apply (rule hinv_corres_assist, simp)
                  apply (clarsimp simp add: when_def)
-                 apply (rule hf_corres)
+                 apply (rule handleFault_corres)
                  apply simp
                 apply (simp add: split_def)
-                apply (rule corres_split_deprecated [OF _ get_mrs_corres])
-                  apply (rule decode_invocation_corres, simp_all)[1]
+                apply (rule corres_split_deprecated [OF _ getMRs_corres])
+                  apply (rule decodeInvocation_corres, simp_all)[1]
                    apply (fastforce simp: list_all2_map2 list_all2_map1 elim:  list_all2_mono)
                   apply (fastforce simp: list_all2_map2 list_all2_map1 elim:  list_all2_mono)
                  apply wp[1]
@@ -1248,17 +1248,17 @@ lemma hinv_corres:
                 apply simp
                 apply wp[1]
                apply (clarsimp simp: when_def)
-               apply (rule rfk_corres)
-              apply (rule corres_split_deprecated [OF _ sts_corres])
-                 apply (rule corres_splitEE [OF _ pinv_corres])
+               apply (rule replyFromKernel_corres)
+              apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+                 apply (rule corres_splitEE [OF _ performInvocation_corres])
                      apply simp
-                     apply (rule corres_split_deprecated [OF _ gts_corres])
+                     apply (rule corres_split_deprecated [OF _ getThreadState_corres])
                        apply (rename_tac state state')
                        apply (case_tac state, simp_all)[1]
                        apply (fold dc_def)[1]
-                       apply (rule corres_split_deprecated [OF sts_corres])
+                       apply (rule corres_split_deprecated [OF setThreadState_corres])
                           apply simp
-                         apply (rule corres_when [OF refl rfk_corres])
+                         apply (rule corres_when [OF refl replyFromKernel_corres])
                         apply (simp add: when_def)
                         apply (rule conjI, rule impI)
                          apply (rule reply_from_kernel_tcb_at)
@@ -1374,13 +1374,13 @@ crunch typ_at'[wp]: handleFault "\<lambda>s. P (typ_at' T p s)"
 
 lemmas handleFault_typ_ats[wp] = typ_at_lifts [OF handleFault_typ_at']
 
-lemma hs_corres:
+lemma handleSend_corres:
   "corres (dc \<oplus> dc)
           (einvs and (\<lambda>s. scheduler_action s = resume_cur_thread) and ct_active)
           (invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
            (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_active')
           (handle_send blocking) (handleSend blocking)"
-  by (simp add: handle_send_def handleSend_def hinv_corres)
+  by (simp add: handle_send_def handleSend_def handleInvocation_corres)
 
 lemma hs_invs'[wp]:
   "\<lbrace>invs' and ct_active' and
@@ -1405,7 +1405,7 @@ lemma tcb_at_cte_at_map:
   apply (auto elim: cte_wp_at_tcbI')
   done
 
-lemma delete_caller_cap_corres:
+lemma deleteCallerCap_corres:
   "corres dc (einvs and tcb_at t) (invs' and tcb_at' t)
      (delete_caller_cap t)
      (deleteCallerCap t)"
@@ -1504,7 +1504,7 @@ lemma delete_caller_cap_valid_ep_cap:
    by (wp get_cap_wp fast_finalise_typ_at abs_typ_at_lifts(1)
        | simp add: unless_def valid_cap_def)+
 
-lemma hw_corres':
+lemma handleRecv_isBlocking_corres':
    "corres dc (einvs and ct_in_state active
                     and (\<lambda>s. ex_nonz_cap_to (cur_thread s) s))
               (invs' and ct_in_state' simple'
@@ -1517,12 +1517,12 @@ lemma hw_corres':
                    cap_register_def capRegister_def
              cong: if_cong cap.case_cong capability.case_cong bool.case_cong)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ gct_corres])
-      apply (rule corres_split_eqr [OF _ user_getreg_corres])
+    apply (rule corres_split_eqr [OF _ getCurThread_corres])
+      apply (rule corres_split_eqr [OF _ asUser_getRegister_corres])
         apply (rule corres_split_catch)
-           apply (erule hf_corres)
+           apply (erule handleFault_corres)
           apply (rule corres_cap_fault)
-          apply (rule corres_splitEE [OF _ lc_corres])
+          apply (rule corres_splitEE [OF _ lookupCap_corres])
             apply (rule_tac P="?pre1 and tcb_at thread
                                and (\<lambda>s. (cur_thread s) = thread  )
                                and valid_cap rv"
@@ -1532,8 +1532,8 @@ lemma hw_corres':
              apply (rule corres_guard_imp)
                apply (rename_tac rights)
                 apply (case_tac "AllowRead \<in> rights"; simp)
-                 apply (rule corres_split_nor[OF _ delete_caller_cap_corres])
-                   apply (rule receive_ipc_corres)
+                 apply (rule corres_split_nor[OF _ deleteCallerCap_corres])
+                   apply (rule receiveIPC_corres)
                     apply (clarsimp)+
                   apply (wp delete_caller_cap_nonz_cap delete_caller_cap_valid_ep_cap)+
                 apply (clarsimp)+
@@ -1545,11 +1545,11 @@ lemma hw_corres':
                apply (rule_tac r'=ntfn_relation in corres_splitEE)
                   apply (rule corres_if)
                     apply (clarsimp simp: ntfn_relation_def)
-                   apply (clarsimp, rule receive_signal_corres)
+                   apply (clarsimp, rule receiveSignal_corres)
                     prefer 3
                     apply (rule corres_trivial)
                     apply (clarsimp simp: lookup_failure_map_def)+
-                 apply (rule get_ntfn_corres)
+                 apply (rule getNotification_corres)
                 apply (wp get_simple_ko_wp getNotification_wp | wpcw | simp)+
               apply (clarsimp simp: lookup_failure_map_def)
              apply (clarsimp simp: valid_cap_def ct_in_state_def)
@@ -1567,13 +1567,13 @@ lemma hw_corres':
                         ct_in_state'_def sch_act_sane_not)
   done
 
-lemma hw_corres:
+lemma handleRecv_isBlocking_corres:
   "corres dc (einvs and ct_active)
              (invs' and ct_active' and sch_act_sane and
                     (\<lambda>s. \<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p)))
             (handle_recv isBlocking) (handleRecv isBlocking)"
   apply (rule corres_guard_imp)
-    apply (rule hw_corres')
+    apply (rule handleRecv_isBlocking_corres')
    apply (clarsimp simp: ct_in_state_def)
    apply (fastforce elim!: st_tcb_weakenE st_tcb_ex_cap)
   apply (clarsimp simp: ct_in_state'_def invs'_def valid_state'_def)
@@ -1643,11 +1643,11 @@ lemma setSchedulerAction_obj_at'[wp]:
   unfolding setSchedulerAction_def
   by (wp, clarsimp elim!: obj_at'_pspaceI)
 
-lemma hy_corres:
+lemma handleYield_corres:
   "corres dc einvs (invs' and ct_active' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)) handle_yield handleYield"
   apply (clarsimp simp: handle_yield_def handleYield_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply simp
       apply (rule corres_split_deprecated[OF _ tcbSchedDequeue_corres])
         apply (rule corres_split_deprecated[OF _ tcbSchedAppend_corres])
@@ -1703,14 +1703,14 @@ lemma simple_from_running':
   by (clarsimp elim!: pred_tcb'_weakenE
                simp: ct_in_state'_def)+
 
-lemma hr_corres:
+lemma handleReply_corres:
   "corres dc (einvs and ct_running) (invs' and ct_running')
          handle_reply handleReply"
   apply (simp add: handle_reply_def handleReply_def
                    getThreadCallerSlot_map
                    getSlotCap_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ gct_corres])
+    apply (rule corres_split_eqr [OF _ getCurThread_corres])
       apply (rule corres_split_deprecated [OF _ get_cap_corres])
         apply (rule_tac P="einvs and cte_wp_at ((=) caller_cap) (thread, tcb_cnode_index 3)
                                 and K (is_reply_cap caller_cap \<or> caller_cap = cap.NullCap)
@@ -1721,8 +1721,8 @@ lemma hr_corres:
                               and cte_at' (cte_map (thread, tcb_cnode_index 3))"
                     in corres_inst)
         apply (auto split: cap_relation_split_asm arch_cap.split_asm bool.split
-                   intro!: corres_guard_imp [OF delete_caller_cap_corres]
-                           corres_guard_imp [OF do_reply_transfer_corres]
+                   intro!: corres_guard_imp [OF deleteCallerCap_corres]
+                           corres_guard_imp [OF doReplyTransfer_corres]
                            corres_fail
                      simp: valid_cap_def valid_cap'_def is_cap_simps assert_def is_reply_cap_to_def)[1]
         apply (fastforce simp: invs_def valid_state_def
@@ -1797,13 +1797,13 @@ lemma hr_ct_active'[wp]:
                   dest: ctes_of_valid')
   done
 
-lemma hc_corres:
+lemma handleCall_corres:
   "corres (dc \<oplus> dc) (einvs and (\<lambda>s. scheduler_action s = resume_cur_thread) and ct_active)
               (invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
                 (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
                 ct_active')
          handle_call handleCall"
-  by (simp add: handle_call_def handleCall_def liftE_bindE hinv_corres)
+  by (simp add: handle_call_def handleCall_def liftE_bindE handleInvocation_corres)
 
 lemma hc_invs'[wp]:
   "\<lbrace>invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
@@ -1948,14 +1948,14 @@ crunch valid_etcbs[wp]: possible_switch_to  "valid_etcbs"
 crunch valid_etcbs[wp]: handle_recv "valid_etcbs"
   (wp: crunch_wps simp: crunch_simps)
 
-lemma hrw_corres:
+lemma handleReply_handleRecv_corres:
   "corres dc (einvs and ct_running)
              (invs' and ct_running' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
          (do x \<leftarrow> handle_reply; handle_recv True od)
          (do x \<leftarrow> handleReply; handleRecv True od)"
   apply (rule corres_guard_imp)
-    apply (rule corres_split_nor [OF _ hr_corres])
-      apply (rule hw_corres')
+    apply (rule corres_split_nor [OF _ handleReply_corres])
+      apply (rule handleRecv_isBlocking_corres')
      apply (wp handle_reply_nonz_cap_to_ct handleReply_sane
                handleReply_nonz_cap_to_ct handleReply_ct_not_ksQ handle_reply_valid_sched)+
    apply (fastforce simp: ct_in_state_def ct_in_state'_def simple_sane_strg
@@ -1965,7 +1965,7 @@ lemma hrw_corres:
   apply (fastforce elim: pred_tcb'_weakenE)
   done
 
-lemma hh_corres:
+lemma handleHypervisorFault_corres:
   "corres dc (einvs and  st_tcb_at active thread and ex_nonz_cap_to thread)
              (invs' and sch_act_not thread
                     and (\<lambda>s. \<forall>p. thread \<notin> set(ksReadyQueues s p))
@@ -1973,7 +1973,7 @@ lemma hh_corres:
           (handle_hypervisor_fault thread fault)
           (handleHypervisorFault thread fault)"
   apply (cases fault; clarsimp simp add: handleHypervisorFault_def returnOk_def2)
-  apply (corres corres: hf_corres)
+  apply (corres corres: handleFault_corres)
    apply (simp add: ucast_id)
   apply (clarsimp simp: valid_fault_def)
   done
@@ -2004,21 +2004,21 @@ lemma hvmf_invs_etc:
   apply (clarsimp simp: invs'_def valid_state'_def valid_machine_state'_def)
   done
 
-lemma he_corres:
+lemma handleEvent_corres:
   "corres (dc \<oplus> dc) (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and
                        (\<lambda>s. scheduler_action s = resume_cur_thread))
                       (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and
                        (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
                        (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
                       (handle_event event) (handleEvent event)"
-  (is "?he_corres")
+  (is "?handleEvent_corres")
 proof -
   have hw:
     "\<And>isBlocking. corres dc (einvs and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread))
                (invs' and ct_running'
                       and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
                (handle_recv isBlocking) (handleRecv isBlocking)"
-    apply (rule corres_guard_imp [OF hw_corres])
+    apply (rule corres_guard_imp [OF handleRecv_isBlocking_corres])
      apply (clarsimp simp: ct_in_state_def ct_in_state'_def
                      elim!: st_tcb_weakenE pred_tcb'_weakenE
                      dest!: ct_not_ksQ)+
@@ -2029,17 +2029,17 @@ proof -
 
           apply (rename_tac syscall)
           apply (case_tac syscall)
-          apply (auto intro: corres_guard_imp[OF hs_corres]
+          apply (auto intro: corres_guard_imp[OF handleSend_corres]
                              corres_guard_imp[OF hw]
-                             corres_guard_imp [OF hr_corres]
-                             corres_guard_imp[OF hrw_corres]
-                             corres_guard_imp[OF hc_corres]
-                             corres_guard_imp[OF hy_corres]
+                             corres_guard_imp [OF handleReply_corres]
+                             corres_guard_imp[OF handleReply_handleRecv_corres]
+                             corres_guard_imp[OF handleCall_corres]
+                             corres_guard_imp[OF handleYield_corres]
                              active_from_running active_from_running'
                       simp: simple_sane_strg)[8]
          apply (rule corres_split')
-            apply (rule corres_guard_imp[OF gct_corres], simp+)
-           apply (rule hf_corres)
+            apply (rule corres_guard_imp[OF getCurThread_corres], simp+)
+           apply (rule handleFault_corres)
            apply simp
           apply (simp add: valid_fault_def)
           apply wp
@@ -2052,8 +2052,8 @@ proof -
                            sch_act_sane_def
                      elim: pred_tcb'_weakenE st_tcb_ex_cap'')[1]
         apply (rule corres_split')
-           apply (rule corres_guard_imp, rule gct_corres, simp+)
-          apply (rule hf_corres)
+           apply (rule corres_guard_imp, rule getCurThread_corres, simp+)
+          apply (rule handleFault_corres)
           apply (simp add: valid_fault_def)
          apply wp
          apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE
@@ -2069,7 +2069,7 @@ proof -
                                       and R'="\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> R'' x s"
                                       for R''])
             apply (case_tac rv, simp_all add: doMachineOp_return)[1]
-            apply (rule handle_interrupt_corres)
+            apply (rule handleInterrupt_corres)
            apply (rule corres_machine_op)
            apply (rule corres_Id, simp+)
            apply (wp hoare_vcg_all_lift
@@ -2084,10 +2084,10 @@ proof -
        apply (erule conjE, drule (1) bspec)
        apply (clarsimp simp: obj_at'_def inQ_def)
       apply (rule_tac corres_split')
-         apply (rule corres_guard_imp, rule gct_corres, simp+)
+         apply (rule corres_guard_imp, rule getCurThread_corres, simp+)
         apply (rule corres_split_catch)
-           apply (erule hf_corres)
-          apply (rule hv_corres)
+           apply (erule handleFault_corres)
+          apply (rule handleVMFault_corres)
          apply (wp handle_vm_fault_valid_fault)
         apply (wp hvmf_invs_etc)
        apply wp
@@ -2099,8 +2099,8 @@ proof -
       apply (fastforce simp: simple_sane_strg sch_act_simple_def ct_in_state'_def
                   elim: st_tcb_ex_cap'' pred_tcb'_weakenE)
          apply (rule corres_split')
-            apply (rule corres_guard_imp[OF gct_corres], simp+)
-           apply (rule hh_corres)
+            apply (rule corres_guard_imp[OF getCurThread_corres], simp+)
+           apply (rule handleHypervisorFault_corres)
           apply wp
           apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE
                            simp: ct_in_state_def)

--- a/proof/refine/ARM_HYP/TcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/TcbAcc_R.thy
@@ -247,7 +247,7 @@ lemma updateObject_tcb_inv:
   "\<lbrace>P\<rbrace> updateObject (obj::tcb) ko p q n \<lbrace>\<lambda>rv. P\<rbrace>"
   by simp (rule updateObject_default_inv)
 
-lemma tcb_update_corres':
+lemma setObject_update_TCB_corres':
   assumes tcbs: "tcb_relation tcb tcb' \<Longrightarrow> tcb_relation tcbu tcbu'"
   assumes tables: "\<forall>(getF, v) \<in> ran tcb_cap_cases. getF tcbu = getF tcb"
   assumes tables': "\<forall>(getF, v) \<in> ran tcb_cte_cases. getF tcbu' = getF tcb'"
@@ -262,7 +262,7 @@ lemma tcb_update_corres':
    apply (clarsimp simp: projectKOs other_obj_relation_def exst)
   apply (rule corres_guard_imp)
     apply (rule corres_rel_imp)
-     apply (rule set_other_obj_corres[where P="(=) tcb'"])
+     apply (rule setObject_other_corres[where P="(=) tcb'"])
            apply (rule ext)+
            apply simp
           defer
@@ -279,7 +279,7 @@ lemma tcb_update_corres':
   apply simp
   done
 
-lemma tcb_update_corres:
+lemma setObject_update_TCB_corres:
   "\<lbrakk> tcb_relation tcb tcb' \<Longrightarrow> tcb_relation tcbu tcbu';
      \<forall>(getF, v) \<in> ran tcb_cap_cases. getF tcbu = getF tcb;
      \<forall>(getF, v) \<in> ran tcb_cte_cases. getF tcbu' = getF tcb';
@@ -288,14 +288,14 @@ lemma tcb_update_corres:
                (\<lambda>s'. (tcb', s') \<in> fst (getObject add s'))
                (set_object add (TCB tcbu)) (setObject add tcbu')"
   apply (rule corres_guard_imp)
-    apply (erule (3) tcb_update_corres', force)
+    apply (erule (3) setObject_update_TCB_corres', force)
    apply fastforce
   apply (clarsimp simp: getObject_def in_monad split_def obj_at'_def
                         loadObject_default_def projectKOs objBits_simps'
                         in_magnitude_check)
   done
 
-lemma assert_get_tcb_corres:
+lemma getObject_TCB_corres:
   "corres tcb_relation (tcb_at t) (tcb_at' t)
           (gets_the (get_tcb t)) (getObject t)"
   apply (rule corres_guard_imp)
@@ -305,14 +305,14 @@ lemma assert_get_tcb_corres:
   apply assumption
   done
 
-lemma threadget_corres:
+lemma threadGet_corres:
   assumes x: "\<And>tcb tcb'. tcb_relation tcb tcb' \<Longrightarrow> r (f tcb) (f' tcb')"
   shows      "corres r (tcb_at t) (tcb_at' t) (thread_get f t) (threadGet f' t)"
   apply (simp add: thread_get_def threadGet_def)
   apply (fold liftM_def)
   apply simp
   apply (rule corres_rel_imp)
-   apply (rule assert_get_tcb_corres)
+   apply (rule getObject_TCB_corres)
   apply (simp add: x)
   done
 
@@ -344,8 +344,8 @@ lemma threadset_corresT:
                     (thread_set f t) (threadSet f' t)"
   apply (simp add: thread_set_def threadSet_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ assert_get_tcb_corres])
-      apply (rule tcb_update_corres')
+    apply (rule corres_split_deprecated [OF _ getObject_TCB_corres])
+      apply (rule setObject_update_TCB_corres')
           apply (erule x)
          apply (rule y)
         apply (clarsimp simp: bspec_split [OF spec [OF z]])
@@ -1346,7 +1346,7 @@ lemma threadSet_valid_objs':
   apply (clarsimp elim!: obj_at'_weakenE)
   done
 
-lemma corres_as_user':
+lemma asUser_corres':
   assumes y: "corres_underlying Id False True r \<top> \<top> f g"
   shows      "corres r (tcb_at t)
                        (tcb_at' t)
@@ -1375,7 +1375,7 @@ lemma corres_as_user':
                      (\<lambda>s'. (tcb', s') \<in> fst (getObject add s'))
                      (set_object add (TCB (tcb \<lparr> tcb_arch := arch_tcb_context_set con (tcb_arch tcb) \<rparr>)))
                      (setObject add (tcb' \<lparr> tcbArch := atcbContextSet con' (tcbArch tcb') \<rparr>))"
-    by (rule tcb_update_corres [OF L2],
+    by (rule setObject_update_TCB_corres [OF L2],
         (simp add: tcb_cte_cases_def tcb_cap_cases_def exst_same_def)+)
   have L4: "\<And>con con'. con = con' \<Longrightarrow>
             corres (\<lambda>(irv, nc) (irv', nc'). r irv irv' \<and> nc = nc')
@@ -1404,11 +1404,11 @@ lemma corres_as_user':
   done
 qed
 
-lemma corres_as_user:
+lemma asUser_corres:
   assumes y: "corres_underlying Id False True r \<top> \<top> f g"
   shows      "corres r (tcb_at t and invs) (tcb_at' t and invs') (as_user t f) (asUser t g)"
   apply (rule corres_guard_imp)
-    apply (rule corres_as_user' [OF y])
+    apply (rule asUser_corres' [OF y])
    apply (simp add: invs_def valid_state_def valid_pspace_def)
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
   done
@@ -1433,10 +1433,10 @@ proof -
     done
 qed
 
-lemma user_getreg_corres:
+lemma asUser_getRegister_corres:
  "corres (=) (tcb_at t) (tcb_at' t)
         (as_user t (getRegister r)) (asUser t (getRegister r))"
-  apply (rule corres_as_user')
+  apply (rule asUser_corres')
   apply (clarsimp simp: getRegister_def)
   done
 
@@ -1598,21 +1598,21 @@ lemma no_fail_asUser [wp]:
   apply simp
   done
 
-lemma user_setreg_corres:
+lemma asUser_setRegister_corres:
   "corres dc (tcb_at t)
              (tcb_at' t)
              (as_user t (setRegister r v))
              (asUser t (setRegister r v))"
   apply (simp add: setRegister_def)
-  apply (rule corres_as_user')
+  apply (rule asUser_corres')
   apply (rule corres_modify'; simp)
   done
 
-lemma gts_corres:
+lemma getThreadState_corres:
   "corres thread_state_relation (tcb_at t) (tcb_at' t)
           (get_thread_state t) (getThreadState t)"
   apply (simp add: get_thread_state_def getThreadState_def)
-  apply (rule threadget_corres)
+  apply (rule threadGet_corres)
   apply (simp add: tcb_relation_def)
   done
 
@@ -1639,11 +1639,11 @@ lemma gts_st_tcb_at'[wp]: "\<lbrace>st_tcb_at' P t\<rbrace> getThreadState t \<l
 lemma gts_inv'[wp]: "\<lbrace>P\<rbrace> getThreadState t \<lbrace>\<lambda>rv. P\<rbrace>"
   by (simp add: getThreadState_def) wp
 
-lemma gbn_corres:
+lemma getBoundNotification_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
           (get_bound_notification t) (getBoundNotification t)"
   apply (simp add: get_bound_notification_def getBoundNotification_def)
-  apply (rule threadget_corres)
+  apply (rule threadGet_corres)
   apply (simp add: tcb_relation_def)
   done
 
@@ -1832,16 +1832,16 @@ lemma no_fail_return:
   "no_fail x (return y)"
   by wp
 
-lemma addToBitmap_corres_noop:
+lemma addToBitmap_noop_corres:
   "corres dc \<top> \<top> (return ()) (addToBitmap d p)"
   unfolding addToBitmap_def modifyReadyQueuesL1Bitmap_def getReadyQueuesL1Bitmap_def
             modifyReadyQueuesL2Bitmap_def getReadyQueuesL2Bitmap_def
   by (rule corres_noop)
      (wp | simp add: state_relation_def | rule no_fail_pre)+
 
-lemma addToBitmap_if_null_corres_noop: (* used this way in Haskell code *)
+lemma addToBitmap_if_null_noop_corres: (* used this way in Haskell code *)
   "corres dc \<top> \<top> (return ()) (if null queue then addToBitmap d p else return ())"
-  by (cases "null queue", simp_all add: addToBitmap_corres_noop)
+  by (cases "null queue", simp_all add: addToBitmap_noop_corres)
 
 lemma removeFromBitmap_corres_noop:
   "corres dc \<top> \<top> (return ()) (removeFromBitmap tdom prioa)"
@@ -1890,7 +1890,7 @@ proof -
                apply (rule corres_split_noop_rhs2)
                    apply (rule corres_split_noop_rhs2)
                      apply (fastforce intro: threadSet_corres_noop simp: tcb_relation_def exst_same_def)
-                    apply (fastforce intro: addToBitmap_corres_noop)
+                    apply (fastforce intro: addToBitmap_noop_corres)
                    apply wp+
                  apply (simp add: tcb_sched_enqueue_def split del: if_split)
                  apply (rule_tac P=\<top> and Q="K (t \<notin> set queuea)" in corres_assume_pre)
@@ -1910,7 +1910,7 @@ lemma weak_sch_act_wf_updateDomainTime[simp]:
   "weak_sch_act_wf m (ksDomainTime_update f s) = weak_sch_act_wf m s"
   by (simp add:weak_sch_act_wf_def tcb_in_cur_domain'_def )
 
-lemma set_sa_corres:
+lemma setSchedulerAction_corres:
   "sched_act_relation sa sa'
     \<Longrightarrow> corres dc \<top> \<top> (set_scheduler_action sa) (setSchedulerAction sa')"
   apply (simp add: setSchedulerAction_def set_scheduler_action_def)
@@ -1919,7 +1919,7 @@ lemma set_sa_corres:
   apply (clarsimp simp: in_monad simpler_modify_def state_relation_def)
   done
 
-lemma get_sa_corres:
+lemma getSchedulerAction_corres:
   "corres sched_act_relation \<top> \<top> (gets scheduler_action) getSchedulerAction"
   apply (simp add: getSchedulerAction_def)
   apply (clarsimp simp: state_relation_def)
@@ -1930,10 +1930,10 @@ lemma rescheduleRequired_corres:
      (reschedule_required) rescheduleRequired"
   apply (simp add: rescheduleRequired_def reschedule_required_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ get_sa_corres])
+    apply (rule corres_split_deprecated[OF _ getSchedulerAction_corres])
       apply (rule_tac P="case action of switch_thread t \<Rightarrow> P t | _ \<Rightarrow> \<top>"
               and P'="case actiona of SwitchToThread t \<Rightarrow> P' t | _ \<Rightarrow> \<top>" for P P' in corres_split_deprecated[where r'=dc])
-         apply (rule set_sa_corres)
+         apply (rule setSchedulerAction_corres)
          apply simp
         apply (case_tac action)
           apply simp
@@ -1953,7 +1953,7 @@ lemma rescheduleRequired_corres_simple:
   apply (simp add: rescheduleRequired_def)
   apply (rule corres_symb_exec_r[where Q'="\<lambda>rv s. rv = ResumeCurrentThread \<or> rv = ChooseNewThread"])
      apply (rule corres_symb_exec_r)
-        apply (rule set_sa_corres, simp)
+        apply (rule setSchedulerAction_corres, simp)
        apply (wp | clarsimp split: scheduler_action.split)+
     apply (wp | clarsimp simp: sch_act_simple_def split: scheduler_action.split)+
   apply (simp add: getSchedulerAction_def)
@@ -2107,12 +2107,12 @@ lemma thread_get_isRunnable_corres: "corres (=) (tcb_at t) (tcb_at' t) (thread_g
   apply (fold liftM_def)
   apply simp
   apply (rule corres_rel_imp)
-   apply (rule assert_get_tcb_corres)
+   apply (rule getObject_TCB_corres)
   apply (clarsimp simp add: tcb_relation_def thread_state_relation_def)
   apply (case_tac "tcb_state x",simp_all)
   done
 
-lemma sts_corres:
+lemma setThreadState_corres:
   "thread_state_relation ts ts' \<Longrightarrow>
    corres dc
           (tcb_at t)
@@ -2127,8 +2127,8 @@ lemma sts_corres:
        apply simp
        apply (subst thread_get_test[where test="runnable"])
        apply (rule corres_split_deprecated[OF _ thread_get_isRunnable_corres])
-         apply (rule corres_split_deprecated[OF _ gct_corres])
-           apply (rule corres_split_deprecated[OF _ get_sa_corres])
+         apply (rule corres_split_deprecated[OF _ getCurThread_corres])
+           apply (rule corres_split_deprecated[OF _ getSchedulerAction_corres])
              apply (simp only: when_def)
              apply (rule corres_if[where Q=\<top> and Q'=\<top>])
                apply (rule iffI)
@@ -2139,7 +2139,7 @@ lemma sts_corres:
      apply (wp hoare_vcg_conj_lift[where Q'="\<top>\<top>"] | simp add: sch_act_simple_def)+
    done
 
-lemma sbn_corres:
+lemma setBoundNotification_corres:
   "corres dc
           (tcb_at t)
           (tcb_at' t)
@@ -3224,7 +3224,7 @@ proof -
   thus ?thesis by (simp add: in_user_frame_def)
 qed
 
-lemma load_word_offs_corres:
+lemma loadWordUser_corres:
   assumes y: "y < unat max_ipc_words"
   shows "corres (=) \<top> (valid_ipc_buffer_ptr' a) (load_word_offs a y) (loadWordUser (a + of_nat y * 4))"
   unfolding loadWordUser_def
@@ -3243,7 +3243,7 @@ lemma load_word_offs_corres:
   apply (simp add: valid_ipc_buffer_ptr'_def msg_align_bits)
   done
 
-lemma store_word_offs_corres:
+lemma storeWordUser_corres:
   assumes y: "y < unat max_ipc_words"
   shows "corres dc (in_user_frame a) (valid_ipc_buffer_ptr' a)
                    (store_word_offs a y w) (storeWordUser (a + of_nat y * 4) w)"
@@ -3301,7 +3301,7 @@ lemmas msgRegisters_unfold
          unfolded fromEnum_def enum_register, simplified,
          unfolded toEnum_def enum_register, simplified]
 
-lemma get_mrs_corres:
+lemma getMRs_corres:
   "corres (=) (tcb_at t)
               (tcb_at' t and case_option \<top> valid_ipc_buffer_ptr' buf)
               (get_mrs t buf mi) (getMRs t buf (message_info_map mi))"
@@ -3312,7 +3312,7 @@ lemma get_mrs_corres:
      (thread_get (arch_tcb_get_registers o tcb_arch) t) (asUser t (mapM getRegister ARM_HYP_H.msgRegisters))"
     unfolding arch_tcb_get_registers_def
     apply (subst thread_get_as_user)
-    apply (rule corres_as_user')
+    apply (rule asUser_corres')
     apply (subst mapM_gets)
      apply (simp add: getRegister_def)
     apply (simp add: S ARM_HYP_H.msgRegisters_def msg_registers_def)
@@ -3338,7 +3338,7 @@ lemma get_mrs_corres:
               apply simp
              apply simp
             apply (simp add: word_size wordSize_def wordBits_def)
-            apply (rule load_word_offs_corres)
+            apply (rule loadWordUser_corres)
             apply simp
            apply wp+
          apply simp
@@ -3390,7 +3390,7 @@ lemma storeWordUser_valid_ipc_buffer_ptr' [wp]:
   unfolding valid_ipc_buffer_ptr'_def2
   by (wp hoare_vcg_all_lift storeWordUser_typ_at')
 
-lemma set_mrs_corres:
+lemma setMRs_corres:
   assumes m: "mrs' = mrs"
   shows
   "corres (=) (tcb_at t and case_option \<top> in_user_frame buf)
@@ -3421,7 +3421,7 @@ proof -
      apply (clarsimp simp: msgRegisters_unfold setRegister_def2 zipWithM_x_Nil zipWithM_x_modify
                            take_min_len zip_take_triv2 min.commute)
      apply (rule corres_guard_imp)
-       apply (rule corres_split_nor [OF _ corres_as_user'], rule corres_trivial, simp)
+       apply (rule corres_split_nor [OF _ asUser_corres'], rule corres_trivial, simp)
          apply (rule corres_modify')
           apply (fastforce simp: fold_fun_upd[symmetric] msgRegisters_unfold
                            cong: if_cong simp del: the_index.simps)
@@ -3433,11 +3433,11 @@ proof -
                           msgMaxLength_def msgLengthBits_def)
     apply (simp add: msg_max_length_def)
     apply (rule corres_guard_imp)
-      apply (rule corres_split_nor [OF _ corres_as_user'])
+      apply (rule corres_split_nor [OF _ asUser_corres'])
          apply (rule corres_split_nor, rule corres_trivial, clarsimp simp: min.commute)
           apply (rule_tac S="{((x, y), (x', y')). y = y' \<and> x' = (a + (of_nat x * 4)) \<and> x < unat max_ipc_words}"
                         in zipWithM_x_corres)
-              apply (fastforce intro: store_word_offs_corres)
+              apply (fastforce intro: storeWordUser_corres)
              apply wp+
             apply (clarsimp simp add: S msgMaxLength_def msg_max_length_def set_zip)
             apply (simp add: wordSize_def wordBits_def word_size max_ipc_words
@@ -3451,7 +3451,7 @@ proof -
      done
 qed
 
-lemma copy_mrs_corres:
+lemma copyMRs_corres:
   "corres (=) (tcb_at s and tcb_at r
                and case_option \<top> in_user_frame sb
                and case_option \<top> in_user_frame rb
@@ -3481,7 +3481,7 @@ proof -
              (take (unat n) msgRegisters))"
     apply (rule corres_guard_imp)
     apply (rule_tac S=Id in corres_mapM, simp+)
-        apply (rule corres_split_eqr [OF user_setreg_corres user_getreg_corres])
+        apply (rule corres_split_eqr [OF asUser_setRegister_corres asUser_getRegister_corres])
         apply (wp | clarsimp simp: msg_registers_def msgRegisters_def)+
         done
 
@@ -3517,9 +3517,9 @@ proof -
            apply (rule corres_trivial, simp)
           apply (rule_tac S="{(x, y). y = of_nat x \<and> x < unat max_ipc_words}" in corres_mapM, simp+)
               apply (rule corres_split_eqr)
-               apply (rule store_word_offs_corres)
+               apply (rule storeWordUser_corres)
                apply simp
-               apply (rule load_word_offs_corres)
+               apply (rule loadWordUser_corres)
                apply simp
               apply (wp hoare_vcg_all_lift | simp)+
            apply (clarsimp simp: upto_enum_def)
@@ -3609,14 +3609,14 @@ qed
 
 lemmas valid_ipc_buffer_cap_simps = valid_ipc_buffer_cap_def [split_simps cap.split arch_cap.split]
 
-lemma lipcb_corres':
+lemma lookupIPCBuffer_corres':
   "corres (=) (tcb_at t and valid_objs and pspace_aligned)
                (tcb_at' t and valid_objs' and pspace_aligned'
                 and pspace_distinct' and no_0_obj')
                (lookup_ipc_buffer w t) (lookupIPCBuffer w t)"
   apply (simp add: lookup_ipc_buffer_def ARM_HYP_H.lookupIPCBuffer_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ threadget_corres])
+    apply (rule corres_split_eqr [OF _ threadGet_corres])
        apply (simp add: getThreadBufferSlot_def locateSlot_conv)
        apply (rule corres_split_deprecated [OF _ getSlotCap_corres])
           apply (rule_tac F="valid_ipc_buffer_cap rv buffer_ptr"
@@ -3655,11 +3655,11 @@ lemma lipcb_corres':
   apply clarsimp
   done
 
-lemma lipcb_corres:
+lemma lookupIPCBuffer_corres:
   "corres (=) (tcb_at t and invs)
                (tcb_at' t and invs')
                (lookup_ipc_buffer w t) (lookupIPCBuffer w t)"
-  using lipcb_corres'
+  using lookupIPCBuffer_corres'
   by (rule corres_guard_imp, auto simp: invs'_def valid_state'_def)
 
 
@@ -4563,7 +4563,7 @@ lemma asUser_irq_handlers':
   apply (wpsimp wp: threadSet_irq_handlers' [OF all_tcbI, OF ball_tcb_cte_casesI] select_f_inv)
   done
 
-(* the brave can try to move this up to near tcb_update_corres' *)
+(* the brave can try to move this up to near setObject_update_TCB_corres' *)
 
 definition non_exst_same :: "Structures_H.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
 where

--- a/proof/refine/ARM_HYP/Tcb_R.thy
+++ b/proof/refine/ARM_HYP/Tcb_R.thy
@@ -10,45 +10,45 @@ begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma setNextPCs_corres:
+lemma asUser_setNextPC_corres:
   "corres dc (tcb_at t and invs) (tcb_at' t and invs')
              (as_user t (setNextPC v)) (asUser t (setNextPC v))"
-  apply (rule corres_as_user)
+  apply (rule asUser_corres)
   apply (rule corres_Id, simp, simp)
   apply (rule no_fail_setNextPC)
   done
 
-lemma activate_idle_thread_corres:
+lemma activateIdleThread_corres:
  "corres dc (invs and st_tcb_at idle t)
             (invs' and st_tcb_at' idle' t)
     (arch_activate_idle_thread t) (activateIdleThread t)"
   by (simp add: arch_activate_idle_thread_def activateIdleThread_def)
 
-lemma activate_corres:
+lemma activateThread_corres:
  "corres dc (invs and ct_in_state activatable) (invs' and ct_in_state' activatable')
             activate_thread activateThread"
   apply (simp add: activate_thread_def activateThread_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ gct_corres])
+    apply (rule corres_split_eqr [OF _ getCurThread_corres])
       apply (rule_tac R="\<lambda>ts s. valid_tcb_state ts s \<and> (idle ts \<or> runnable ts)
                                 \<and> invs s \<and> st_tcb_at ((=) ts) thread s"
                   and R'="\<lambda>ts s. valid_tcb_state' ts s \<and> (idle' ts \<or> runnable' ts)
                                 \<and> invs' s \<and> st_tcb_at' (\<lambda>ts'. ts' = ts) thread s"
-                  in  corres_split_deprecated [OF _ gts_corres])
+                  in  corres_split_deprecated [OF _ getThreadState_corres])
         apply (rule_tac F="idle rv \<or> runnable rv" in corres_req, simp)
         apply (rule_tac F="idle' rv' \<or> runnable' rv'" in corres_req, simp)
         apply (case_tac rv, simp_all add:
                   isRunning_def isRestart_def,
                   safe, simp_all)[1]
          apply (rule corres_guard_imp)
-           apply (rule corres_split_eqr [OF _ getRestartPCs_corres])
-             apply (rule corres_split_nor [OF _ setNextPCs_corres])
-               apply (rule sts_corres)
+           apply (rule corres_split_eqr [OF _ asUser_getRestartPC_corres])
+             apply (rule corres_split_nor [OF _ asUser_setNextPC_corres])
+               apply (rule setThreadState_corres)
                apply (simp | wp weak_sch_act_wf_lift_linear)+
           apply (clarsimp simp: st_tcb_at_tcb_at)
          apply fastforce
         apply (rule corres_guard_imp)
-          apply (rule activate_idle_thread_corres)
+          apply (rule activateIdleThread_corres)
          apply (clarsimp elim!: st_tcb_weakenE)
         apply (clarsimp elim!: pred_tcb'_weakenE)
        apply (wp gts_st_tcb gts_st_tcb' gts_st_tcb_at)+
@@ -59,15 +59,15 @@ lemma activate_corres:
   done
 
 
-lemma bind_notification_corres:
+lemma bindNotification_corres:
   "corres dc
          (invs and tcb_at t and ntfn_at a) (invs' and tcb_at' t and ntfn_at' a)
          (bind_notification t a) (bindNotification t a)"
   apply (simp add: bind_notification_def bindNotification_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ get_ntfn_corres])
-      apply (rule corres_split_deprecated[OF _ set_ntfn_corres])
-         apply (rule sbn_corres)
+    apply (rule corres_split_deprecated[OF _ getNotification_corres])
+      apply (rule corres_split_deprecated[OF _ setNotification_corres])
+         apply (rule setBoundNotification_corres)
         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
        apply (wp)+
    apply auto
@@ -207,11 +207,11 @@ lemma restart_corres:
   apply (simp add: Tcb_A.restart_def Thread_H.restart_def)
   apply (simp add: isStopped_def2 liftM_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gts_corres])
+    apply (rule corres_split_deprecated [OF _ getThreadState_corres])
       apply (clarsimp simp add: runnable_tsr idle_tsr when_def)
       apply (rule corres_split_nor [OF _ cancel_ipc_corres])
-        apply (rule corres_split_nor [OF _ setup_reply_master_corres])
-          apply (rule corres_split_nor [OF _ sts_corres])
+        apply (rule corres_split_nor [OF _ setupReplyMaster_corres])
+          apply (rule corres_split_nor [OF _ setThreadState_corres])
              apply (rule corres_split_deprecated [OF possibleSwitchTo_corres tcbSchedEnqueue_corres])
               apply (wp set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at' sts_valid_queues sts_st_tcb'  | clarsimp simp: valid_tcb_state'_def)+
        apply (rule_tac Q="\<lambda>rv. valid_sched and cur_tcb" in hoare_strengthen_post)
@@ -270,7 +270,7 @@ lemma suspend_cap_to'[wp]:
 declare det_getRegister[simp]
 declare det_setRegister[simp]
 
-lemma readreg_corres:
+lemma invokeTCB_ReadRegisters_corres:
   "corres (dc \<oplus> (=))
         (einvs  and tcb_at src and ex_nonz_cap_to src)
         (invs' and sch_act_simple and tcb_at' src and ex_nonz_cap_to' src)
@@ -281,9 +281,9 @@ lemma readreg_corres:
                    frameRegisters_def gpRegisters_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_nor)
-       apply (rule corres_split_deprecated [OF _ gct_corres])
+       apply (rule corres_split_deprecated [OF _ getCurThread_corres])
          apply (simp add: liftM_def[symmetric])
-         apply (rule corres_as_user)
+         apply (rule asUser_corres)
          apply (rule corres_Id)
            apply simp
           apply simp
@@ -312,7 +312,7 @@ declare invs_valid_queues'[rule_format, elim!]
 lemma einvs_valid_etcbs: "einvs s \<longrightarrow> valid_etcbs s"
   by (clarsimp simp: valid_sched_def)
 
-lemma arch_post_modify_registers_corres:
+lemma asUser_postModifyRegisters_corres:
   "corres dc \<top> (tcb_at' t)
      (arch_post_modify_registers ct t)
      (asUser t $ postModifyRegisters ct t)"
@@ -321,7 +321,7 @@ lemma arch_post_modify_registers_corres:
   apply (rule corres_stateAssert_assume)
    by simp+
 
-lemma writereg_corres:
+lemma invokeTCB_WriteRegisters_corres:
   "corres (dc \<oplus> (=)) (einvs  and tcb_at dest and ex_nonz_cap_to dest)
         (invs' and sch_act_simple and tcb_at' dest and ex_nonz_cap_to' dest)
         (invoke_tcb (tcb_invocation.WriteRegisters dest resume values arch))
@@ -330,11 +330,11 @@ lemma writereg_corres:
                    frameRegisters_def gpRegisters_def
                    sanitiseRegister_def sanitise_register_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gct_corres])
-      apply (rule corres_split_deprecated [OF _ arch_tcb_sanitise_corres])
+    apply (rule corres_split_deprecated [OF _ getCurThread_corres])
+      apply (rule corres_split_deprecated [OF _ arch_getSanitiseRegisterInfo_corres])
          apply (rule corres_split_nor)
             prefer 2
-             apply (rule corres_as_user)
+             apply (rule asUser_corres)
              apply (simp add: zipWithM_mapM getRestartPC_def setNextPC_def
                         cong: register.case_cong)
              apply (rule corres_Id, simp+)
@@ -342,7 +342,7 @@ lemma writereg_corres:
                 apply (clarsimp split del: if_split)
                 apply (wp no_fail_setRegister | simp)+
             apply clarsimp
-            apply (rule corres_split_nor[OF _ arch_post_modify_registers_corres[simplified]])
+            apply (rule corres_split_nor[OF _ asUser_postModifyRegisters_corres[simplified]])
               apply (rule corres_split_nor[OF _ corres_when[OF refl restart_corres]])
                 apply (rule corres_split_nor[OF _ corres_when[OF refl rescheduleRequired_corres]])
                   apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
@@ -383,7 +383,7 @@ lemma suspend_ResumeCurrentThread_imp_notct[wp]:
    \<lbrace>\<lambda>rv s. ksSchedulerAction s = ResumeCurrentThread \<longrightarrow> ksCurThread s \<noteq> t'\<rbrace>"
   by (wpsimp simp: suspend_def)
 
-lemma copyreg_corres:
+lemma invokeTCB_CopyRegisters_corres:
   "corres (dc \<oplus> (=))
         (einvs and simple_sched_action and tcb_at dest and tcb_at src and ex_nonz_cap_to src and
           ex_nonz_cap_to dest)
@@ -405,11 +405,11 @@ proof -
     apply (rule corres_guard_imp)
       apply (rule corres_split_eqr)
         apply (simp add: setRegister_def)
-        apply (rule corres_as_user)
+        apply (rule asUser_corres)
         apply (rule corres_modify')
          apply simp
         apply simp
-       apply (rule user_getreg_corres)
+       apply (rule asUser_getRegister_corres)
        apply (simp | wp)+
     done
   have R: "\<And>src src' des des' xs ys. \<lbrakk> src = src'; des = des'; xs = ys \<rbrakk> \<Longrightarrow>
@@ -430,8 +430,8 @@ proof -
                 (do pc \<leftarrow> as_user t getRestartPC; as_user t (setNextPC pc) od)
                 (do pc \<leftarrow> asUser t getRestartPC; asUser t (setNextPC pc) od)"
     apply (rule corres_guard_imp)
-      apply (rule corres_split_eqr [OF _ getRestartPCs_corres])
-        apply (rule setNextPCs_corres)
+      apply (rule corres_split_eqr [OF _ asUser_getRestartPC_corres])
+        apply (rule asUser_setNextPC_corres)
        apply wp+
      apply simp+
     done
@@ -442,8 +442,8 @@ proof -
         apply (rule corres_split_deprecated [OF _ corres_when [OF refl restart_corres]], simp)
              apply (rule corres_split_nor)
              apply (rule corres_split_nor)
-                apply (rule corres_split_eqr [OF _ gct_corres])
-                  apply (rule corres_split_nor[OF _ arch_post_modify_registers_corres[simplified]])
+                apply (rule corres_split_eqr [OF _ getCurThread_corres])
+                  apply (rule corres_split_nor[OF _ asUser_postModifyRegisters_corres[simplified]])
                     apply (rule corres_split_deprecated [OF _ corres_when[OF refl rescheduleRequired_corres]])
                       apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
                       apply simp
@@ -542,13 +542,13 @@ lemma threadSet_valid_queues'_no_state:
   apply (fastforce simp: projectKOs inQ_def split: if_split_asm)
   done
 
-lemma gts_isRunnable_corres:
+lemma isRunnable_corres:
   "corres (\<lambda>ts runn. runnable ts = runn) (tcb_at t) (tcb_at' t)
      (get_thread_state t) (isRunnable t)"
   apply (simp add: isRunnable_def)
   apply (subst bind_return[symmetric])
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gts_corres])
+    apply (rule corres_split_deprecated[OF _ getThreadState_corres])
       apply (case_tac rv, clarsimp+)
      apply (wp hoare_TrueI)+
    apply auto
@@ -627,9 +627,9 @@ lemma sp_corres2:
   apply (rule stronger_corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ tcbSchedDequeue_corres])
       apply (rule corres_split_deprecated [OF _ ethread_set_corres], simp_all)[1]
-         apply (rule corres_split_deprecated [OF _ gts_isRunnable_corres])
+         apply (rule corres_split_deprecated [OF _ isRunnable_corres])
            apply (erule corres_when)
-           apply(rule corres_split_deprecated [OF _ gct_corres])
+           apply(rule corres_split_deprecated [OF _ getCurThread_corres])
              apply (wp corres_if; clarsimp)
               apply (rule rescheduleRequired_corres)
              apply (rule possibleSwitchTo_corres)
@@ -669,7 +669,7 @@ lemma sp_corres2:
   apply (force simp: state_relation_def elim: valid_objs'_maxDomain valid_objs'_maxPriority)
   done
 
-lemma sp_corres: "corres dc (einvs and tcb_at t) (invs' and tcb_at' t and valid_objs' and (\<lambda>_. x \<le> maxPriority))
+lemma setPriority_corres: "corres dc (einvs and tcb_at t) (invs' and tcb_at' t and valid_objs' and (\<lambda>_. x \<le> maxPriority))
                      (set_priority t x) (setPriority t x)"
  apply (rule corres_guard_imp)
     apply (rule sp_corres2)
@@ -677,7 +677,7 @@ lemma sp_corres: "corres dc (einvs and tcb_at t) (invs' and tcb_at' t and valid_
   apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak)
   done
 
-lemma smcp_corres: "corres dc (tcb_at t) (tcb_at' t)
+lemma setMCPriority_corres: "corres dc (tcb_at t) (tcb_at' t)
                      (set_mcpriority t x) (setMCPriority t x)"
   apply (rule corres_guard_imp)
     apply (clarsimp simp: setMCPriority_def set_mcpriority_def)
@@ -878,7 +878,7 @@ lemma sameObject_corres2:
   apply (case_tac arch_capa; simp)
   done
 
-lemma check_cap_at_corres:
+lemma checkCapAt_corres:
   assumes r: "cap_relation cap cap'"
   assumes c: "corres dc Q Q' f f'"
   assumes Q: "\<And>s. P s \<and> cte_wp_at (same_object_as cap) slot s \<Longrightarrow> Q s"
@@ -898,13 +898,13 @@ lemma check_cap_at_corres:
   apply (fastforce elim: cte_wp_at_weakenE' intro: Q')
   done
 
-lemma check_cap_at_corres_weak:
+lemma checkCapAt_weak_corres:
   assumes r: "cap_relation cap cap'"
   assumes c: "corres dc P P' f f'"
   shows "corres dc (P and cte_at slot and invs) (P' and pspace_aligned' and pspace_distinct')
              (check_cap_at cap slot f)
              (checkCapAt cap' (cte_map slot) f')"
-  apply (rule check_cap_at_corres, rule r, rule c)
+  apply (rule checkCapAt_corres, rule r, rule c)
   apply auto
   done
 
@@ -913,7 +913,7 @@ defs
   "assertDerived src cap f \<equiv>
   do stateAssert (\<lambda>s. cte_wp_at' (is_derived' (ctes_of s) src cap o cteCap) src s) []; f od"
 
-lemma checked_insert_corres:
+lemma checkCapAt_cteInsert_corres:
   "cap_relation new_cap newCap \<Longrightarrow>
    corres dc (einvs and cte_wp_at (\<lambda>c. c = cap.NullCap) (target, ref)
                and cte_at slot and K (is_cnode_or_valid_arch new_cap
@@ -941,12 +941,12 @@ lemma checked_insert_corres:
                         and
                         P'="cte_wp_at' (\<lambda>c. cteCap c = NullCap) (cte_map (target, ref))
                             and invs' and valid_cap' newCap"
-                       in check_cap_at_corres, assumption)
-      apply (rule check_cap_at_corres_weak, simp)
+                       in checkCapAt_corres, assumption)
+      apply (rule checkCapAt_weak_corres, simp)
       apply (unfold assertDerived_def)[1]
       apply (rule corres_stateAssert_implied [where P'=\<top>])
        apply simp
-       apply (erule cins_corres [OF _ refl refl])
+       apply (erule cteInsert_corres [OF _ refl refl])
       apply clarsimp
       apply (drule cte_wp_at_norm [where p=src_slot])
       apply (case_tac src_slot)
@@ -1246,7 +1246,7 @@ lemma valid_tcb_ipc_buffer_update:
    \<Longrightarrow> (\<forall>tcb. valid_tcb' tcb s \<longrightarrow> valid_tcb' (tcbIPCBuffer_update (\<lambda>_. buf) tcb) s)"
   by (simp add: valid_tcb'_def tcb_cte_cases_def)
 
-lemma tc_corres:
+lemma transferCaps_corres:
   assumes x: "newroot_rel e e'"
   assumes y: "newroot_rel f f'"
   assumes z: "(case g of None \<Rightarrow> g' = None
@@ -1311,12 +1311,12 @@ proof -
   have S: "\<And>t x. corres dc (einvs and tcb_at t) (invs' and tcb_at' t and valid_objs' and K (valid_option_prio p_auth))
                    (case_option (return ()) (\<lambda>(p, auth). set_priority t p) p_auth)
                    (case_option (return ()) (\<lambda>p'. setPriority t (fst p')) p_auth)"
-    apply (case_tac p_auth; clarsimp simp: sp_corres)
+    apply (case_tac p_auth; clarsimp simp: setPriority_corres)
     done
   have S': "\<And>t x. corres dc (tcb_at t) (tcb_at' t)
                     (case_option (return ()) (\<lambda>(mcp, auth). set_mcpriority t mcp) mcp_auth)
                     (case_option (return ()) (\<lambda>mcp'. setMCPriority t (fst mcp')) mcp_auth)"
-    apply(case_tac mcp_auth; clarsimp simp: smcp_corres)
+    apply(case_tac mcp_auth; clarsimp simp: setMCPriority_corres)
     done
   have T: "\<And>x x' ref getfn target.
      \<lbrakk> newroot_rel x x'; getfn = return (cte_map (target, ref));
@@ -1353,9 +1353,9 @@ proof -
     apply (clarsimp simp add: newroot_rel_def returnOk_def split_def)
     apply (rule corres_gen_asm)
     apply (rule corres_guard_imp)
-      apply (rule corres_split_norE [OF _ cap_delete_corres])
+      apply (rule corres_split_norE [OF _ cteDelete_corres])
         apply (simp del: dc_simp)
-        apply (erule checked_insert_corres)
+        apply (erule checkCapAt_cteInsert_corres)
        apply (fold validE_R_def)
        apply (wp cap_delete_deletes cap_delete_cte_at cap_delete_valid_cap
                     | strengthen use_no_cap_to_obj_asid_strg)+
@@ -1431,7 +1431,7 @@ proof -
          apply (rule corres_split_norE)
             apply (rule_tac F="is_aligned aa msg_align_bits" in corres_gen_asm2)
             apply (rule corres_split_nor)
-               apply (rule corres_split_deprecated [OF _ gct_corres], clarsimp)
+               apply (rule corres_split_deprecated [OF _ getCurThread_corres], clarsimp)
                  apply (rule corres_when[OF refl rescheduleRequired_corres])
                 apply (wpsimp wp: gct_wp)+
               apply (rule threadset_corres,
@@ -1440,22 +1440,22 @@ proof -
              apply (rule threadcontrol_corres_helper1[unfolded pred_conj_def])
             apply (wp hoare_drop_imp)
             apply (wp threadcontrol_corres_helper2 | wpc | simp)+
-           apply (rule cap_delete_corres)
+           apply (rule cteDelete_corres)
           apply wp
          apply (wpsimp wp: cteDelete_invs' hoare_vcg_conj_lift)
         apply (fastforce simp: emptyable_def)
        apply fastforce
       apply clarsimp
       apply (rule corres_guard_imp)
-        apply (rule corres_split_norE [OF _ cap_delete_corres])
+        apply (rule corres_split_norE [OF _ cteDelete_corres])
           apply (rule_tac F="is_aligned aa msg_align_bits" in corres_gen_asm)
           apply (rule_tac F="isArchObjectCap ac" in corres_gen_asm2)
           apply (rule corres_split_nor)
              apply (rule corres_split_nor)
-                apply (rule corres_split_deprecated [OF _ gct_corres], clarsimp)
+                apply (rule corres_split_deprecated [OF _ getCurThread_corres], clarsimp)
                   apply (rule corres_when[OF refl rescheduleRequired_corres])
                  apply (wp gct_wp)+
-               apply (erule checked_insert_corres)
+               apply (erule checkCapAt_cteInsert_corres)
               apply (wp hoare_drop_imp threadcontrol_corres_helper3)[1]
              apply (wp hoare_drop_imp threadcontrol_corres_helper4)[1]
             apply (rule threadset_corres,
@@ -1794,21 +1794,21 @@ where
 | "tcb_inv_wf' (tcbinvocation.SetTLSBase ref w)
              = (tcb_at' ref and ex_nonz_cap_to' ref)"
 
-lemma tcbinv_corres:
+lemma invokeTCB_corres:
  "tcbinv_relation ti ti' \<Longrightarrow>
   corres (dc \<oplus> (=))
          (einvs and simple_sched_action and Tcb_AI.tcb_inv_wf ti)
          (invs' and sch_act_simple and tcb_inv_wf' ti')
          (invoke_tcb ti) (invokeTCB ti')"
   apply (case_tac ti, simp_all only: tcbinv_relation.simps valid_tcb_invocation_def)
-         apply (rule corres_guard_imp [OF writereg_corres], simp+)[1]
-        apply (rule corres_guard_imp [OF readreg_corres], simp+)[1]
-       apply (rule corres_guard_imp [OF copyreg_corres], simp+)[1]
+         apply (rule corres_guard_imp [OF invokeTCB_WriteRegisters_corres], simp+)[1]
+        apply (rule corres_guard_imp [OF invokeTCB_ReadRegisters_corres], simp+)[1]
+       apply (rule corres_guard_imp [OF invokeTCB_CopyRegisters_corres], simp+)[1]
       apply (clarsimp simp del: invoke_tcb.simps)
       apply (rename_tac word one t2 mcp t3 t4 t5 t6 t7 t8 t9 t10 t11)
       apply (rule_tac F="is_aligned word 5" in corres_req)
        apply (clarsimp simp add: is_aligned_weaken [OF tcb_aligned])
-      apply (rule corres_guard_imp [OF tc_corres], clarsimp+)
+      apply (rule corres_guard_imp [OF transferCaps_corres], clarsimp+)
        subgoal
        by (clarsimp simp: is_cnode_or_valid_arch_def
                    split: option.split option.split_asm)
@@ -1825,14 +1825,14 @@ lemma tcbinv_corres:
    apply (case_tac option)
     apply simp
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated[OF _ unbind_notification_corres])
+      apply (rule corres_split_deprecated[OF _ unbindNotification_corres])
         apply (rule corres_trivial, simp)
        apply wp+
      apply clarsimp
     apply clarsimp
    apply simp
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated[OF _ bind_notification_corres])
+     apply (rule corres_split_deprecated[OF _ bindNotification_corres])
        apply (rule corres_trivial, simp)
       apply wp+
     apply clarsimp
@@ -1840,8 +1840,8 @@ lemma tcbinv_corres:
    apply (clarsimp simp: obj_at'_def projectKOs)
   apply (simp add: invokeTCB_def tlsBaseRegister_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ TcbAcc_R.user_setreg_corres])
-      apply (rule corres_split_deprecated[OF _ Bits_R.gct_corres])
+    apply (rule corres_split_deprecated[OF _ TcbAcc_R.asUser_setRegister_corres])
+      apply (rule corres_split_deprecated[OF _ Bits_R.getCurThread_corres])
         apply (rule corres_split_deprecated[OF _ Corres_UL.corres_when])
             apply (rule corres_trivial, simp)
            apply simp
@@ -1940,7 +1940,7 @@ lemma copyregsets_map_only[simp]:
   "copyregsets_map v = ARMNoExtraRegisters"
   by (cases "copyregsets_map v", simp)
 
-lemma decode_readreg_corres:
+lemma decodeReadRegisters_corres:
   "corres (ser \<oplus> tcbinv_relation) (invs and tcb_at t) (invs' and tcb_at' t)
      (decode_read_registers args (cap.ThreadCap t))
      (decodeReadRegisters args (ThreadCap t))"
@@ -1956,13 +1956,13 @@ lemma decode_readreg_corres:
        apply (rule corres_trivial)
        apply (fastforce simp: returnOk_def)
       apply (simp add: liftE_bindE)
-      apply (rule corres_split_deprecated[OF _ gct_corres])
+      apply (rule corres_split_deprecated[OF _ getCurThread_corres])
         apply (rule corres_trivial)
         apply (clarsimp simp: whenE_def)
        apply (wp|simp)+
   done
 
-lemma decode_writereg_corres:
+lemma decodeWriteRegisters_corres:
   notes if_cong [cong]
   shows
   "\<lbrakk> length args < 2 ^ word_bits \<rbrakk> \<Longrightarrow>
@@ -1979,7 +1979,7 @@ lemma decode_writereg_corres:
   apply clarsimp
   apply (rule corres_guard_imp)
     apply (simp add: liftE_bindE)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply (rule corres_split_norE)
          apply (rule corres_trivial, simp)
         apply (rule corres_trivial, simp)
@@ -1987,7 +1987,7 @@ lemma decode_writereg_corres:
    apply simp+
   done
 
-lemma decode_copyreg_corres:
+lemma decodeCopyRegisters_corres:
   "\<lbrakk> list_all2 cap_relation extras extras'; length args < 2 ^ word_bits \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation) (invs and tcb_at t) (invs' and tcb_at' t)
      (decode_copy_registers args (cap.ThreadCap t) extras)
@@ -2046,13 +2046,13 @@ lemma eq_ucast_word8[simp]:
                    source_size_def target_size_def word_size)
   done
 
-lemma check_prio_corres:
+lemma checkPrio_corres:
   "corres (ser \<oplus> dc) (tcb_at auth) (tcb_at' auth)
      (check_prio p auth) (checkPrio p auth)"
   apply (simp add: check_prio_def checkPrio_def)
   apply (rule corres_guard_imp)
     apply (simp add: liftE_bindE)
-    apply (rule corres_split_deprecated[OF _ threadget_corres])
+    apply (rule corres_split_deprecated[OF _ threadGet_corres])
        apply (rule_tac rvr = dc and
                          R = \<top> and
                         R' = \<top> in
@@ -2066,7 +2066,7 @@ lemma check_prio_corres:
    apply (simp add: cur_tcb_def cur_tcb'_def)+
   done
 
-lemma decode_set_priority_corres:
+lemma decodeSetPriority_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
@@ -2078,14 +2078,14 @@ lemma decode_set_priority_corres:
          clarsimp simp: decode_set_priority_def decodeSetPriority_def)
   apply (rename_tac auth_cap auth_slot auth_path rest auth_cap' rest')
   apply (rule corres_split_eqrE)
-     apply (rule corres_splitEE[OF _ check_prio_corres])
+     apply (rule corres_splitEE[OF _ checkPrio_corres])
        apply (rule corres_returnOkTT)
        apply (clarsimp simp: newroot_rel_def elim!: is_thread_cap.elims(2))
       apply wpsimp+
     apply (corressimp simp: valid_cap_def valid_cap'_def)+
   done
 
-lemma decode_set_mcpriority_corres:
+lemma decodeSetMCPriority_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
@@ -2097,7 +2097,7 @@ lemma decode_set_mcpriority_corres:
          clarsimp simp: decode_set_mcpriority_def decodeSetMCPriority_def)
   apply (rename_tac auth_cap auth_slot auth_path rest auth_cap' rest')
   apply (rule corres_split_eqrE)
-     apply (rule corres_splitEE[OF _ check_prio_corres])
+     apply (rule corres_splitEE[OF _ checkPrio_corres])
        apply (rule corres_returnOkTT)
        apply (clarsimp simp: newroot_rel_def elim!: is_thread_cap.elims(2))
       apply wpsimp+
@@ -2200,7 +2200,7 @@ lemma decodeSetSchedParams_wf[wp]:
          simp)
   done
 
-lemma decode_set_sched_params_corres:
+lemma decodeSetSchedParams_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
@@ -2215,15 +2215,15 @@ lemma decode_set_sched_params_corres:
    apply (clarsimp split: list.split simp: list_all2_Cons2)
   apply (clarsimp simp: list_all2_Cons1 neq_Nil_conv val_le_length_Cons linorder_not_less)
   apply (rule corres_split_eqrE)
-     apply (rule corres_split_norE[OF _ check_prio_corres])
-       apply (rule corres_splitEE[OF _ check_prio_corres])
+     apply (rule corres_split_norE[OF _ checkPrio_corres])
+       apply (rule corres_splitEE[OF _ checkPrio_corres])
          apply (rule corres_returnOkTT)
          apply (clarsimp simp: newroot_rel_def elim!: is_thread_cap.elims(2))
         apply (wpsimp wp: check_prio_inv checkPrio_inv)+
     apply (corressimp simp: valid_cap_def valid_cap'_def)+
   done
 
-lemma check_valid_ipc_corres:
+lemma checkValidIPCBuffer_corres:
   "cap_relation cap cap' \<Longrightarrow>
    corres (ser \<oplus> dc) \<top> \<top>
      (check_valid_ipc_buffer vptr cap)
@@ -2256,7 +2256,7 @@ lemma checkValidIPCBuffer_ArchObject_wp:
     | wpc | clarsimp simp: isCap_simps is_aligned_mask msg_align_bits msgAlignBits_def)+
   done
 
-lemma decode_set_ipc_corres:
+lemma decodeSetIPCBuffer_corres:
   notes if_cong [cong]
   shows
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
@@ -2276,9 +2276,9 @@ lemma decode_set_ipc_corres:
              split del: if_split)
   apply (clarsimp simp add: returnOk_def newroot_rel_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_splitEE [OF _ derive_cap_corres])
+    apply (rule corres_splitEE [OF _ deriveCap_corres])
         apply (simp add: o_def newroot_rel_def split_def dc_def[symmetric])
-        apply (erule check_valid_ipc_corres)
+        apply (erule checkValidIPCBuffer_corres)
        apply (wp hoareE_TrueI | simp)+
   apply fastforce
   done
@@ -2326,7 +2326,7 @@ lemma decodeSetMCPriority_is_tc[wp]:
 crunch inv[wp]: decodeSetIPCBuffer "P"
   (simp: crunch_simps)
 
-lemma slot_long_running_corres:
+lemma slotCapLongRunningDelete_corres:
   "cte_map ptr = ptr' \<Longrightarrow>
    corres (=) (cte_at ptr and invs) invs'
            (slot_cap_long_running_delete ptr)
@@ -2336,7 +2336,7 @@ lemma slot_long_running_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ get_cap_corres])
       apply (auto split: cap_relation_split_asm arch_cap.split_asm
-                 intro!: corres_rel_imp [OF final_cap_corres[where ptr=ptr]]
+                 intro!: corres_rel_imp [OF isFinalCapability_corres[where ptr=ptr]]
                    simp: liftM_def[symmetric] final_matters'_def
                          long_running_delete_def
                          longRunningDelete_def isCap_simps)[1]
@@ -2359,7 +2359,7 @@ lemma cap_CNode_case_throw:
      = (doE unlessE (isCNodeCap cap) (throw x); m odE)"
   by (cases cap, simp_all add: isCap_simps unlessE_def)
 
-lemma decode_set_space_corres:
+lemma decodeSetSpace_corres:
   notes if_cong [cong]
   shows
  "\<lbrakk> cap_relation cap cap'; list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras';
@@ -2379,15 +2379,15 @@ lemma decode_set_space_corres:
                     getThreadCSpaceRoot getThreadVSpaceRoot
                  split del: if_split)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated [OF _ slot_long_running_corres])
-        apply (rule corres_split_deprecated [OF _ slot_long_running_corres])
+     apply (rule corres_split_deprecated [OF _ slotCapLongRunningDelete_corres])
+        apply (rule corres_split_deprecated [OF _ slotCapLongRunningDelete_corres])
            apply (rule corres_split_norE)
               apply (simp(no_asm) add: split_def unlessE_throwError_returnOk
                                        bindE_assoc cap_CNode_case_throw
                             split del: if_split)
-              apply (rule corres_splitEE [OF _ derive_cap_corres])
+              apply (rule corres_splitEE [OF _ deriveCap_corres])
                   apply (rule corres_split_norE)
-                     apply (rule corres_splitEE [OF _ derive_cap_corres])
+                     apply (rule corres_splitEE [OF _ deriveCap_corres])
                          apply (rule corres_split_norE)
                             apply (rule corres_trivial)
                             apply (clarsimp simp: returnOk_def newroot_rel_def is_cap_simps
@@ -2497,7 +2497,7 @@ lemma decodeSetSpace_tc_slot[wp]:
   apply simp
   done
 
-lemma decode_tcb_conf_corres:
+lemma decodeTCBConfigure_corres:
   notes if_cong [cong] option.case_cong [cong]
   shows
  "\<lbrakk> cap_relation cap cap'; list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras';
@@ -2514,8 +2514,8 @@ lemma decode_tcb_conf_corres:
   apply (clarsimp simp: linorder_not_less val_le_length_Cons list_all2_Cons1
       priorityBits_def)
   apply (rule corres_guard_imp)
-  apply (rule corres_splitEE [OF _ decode_set_ipc_corres])
-         apply (rule corres_splitEE [OF _ decode_set_space_corres])
+  apply (rule corres_splitEE [OF _ decodeSetIPCBuffer_corres])
+         apply (rule corres_splitEE [OF _ decodeSetSpace_corres])
               apply (rule_tac F="is_thread_control set_params" in corres_gen_asm)
               apply (rule_tac F="is_thread_control set_space" in corres_gen_asm)
   apply (rule_tac F="tcThreadCapSlot setSpace = cte_map slot" in corres_gen_asm2)
@@ -2585,7 +2585,7 @@ lemma corres_splitEE':
    apply (clarsimp simp: lift_def y)+
   done
 
-lemma decode_bind_notification_corres:
+lemma decodeBindNotification_corres:
 notes if_cong[cong] shows
   "\<lbrakk> list_all2 (\<lambda>x y. cap_relation (fst x) (fst y)) extras extras' \<rbrakk> \<Longrightarrow>
     corres (ser \<oplus> tcbinv_relation)
@@ -2609,7 +2609,7 @@ notes if_cong[cong] shows
                                 split: Structures_A.ntfn.splits Structures_H.ntfn.splits
                                        option.splits)
                      apply simp
-                     apply (rule get_ntfn_corres)
+                     apply (rule getNotification_corres)
                     apply wp+
                   apply (rule corres_trivial, clarsimp simp: whenE_def returnOk_def)
                  apply (wp | simp add: whenE_def split del: if_split)+
@@ -2619,7 +2619,7 @@ notes if_cong[cong] shows
               apply (wp | wpc | simp)+
             apply (rule corres_trivial, simp split: option.splits add: returnOk_def)
            apply (wp | wpc | simp)+
-         apply (rule gbn_corres)
+         apply (rule getBoundNotification_corres)
         apply (simp | wp gbn_wp gbn_wp')+
       apply (rule corres_trivial)
       apply (auto simp: returnOk_def whenE_def)[1]
@@ -2627,7 +2627,7 @@ notes if_cong[cong] shows
    apply (fastforce simp: valid_cap_def valid_cap'_def dest: hd_in_set)+
   done
 
-lemma decode_unbind_notification_corres:
+lemma decodeUnbindNotification_corres:
   "corres (ser \<oplus> tcbinv_relation)
       (tcb_at t)
       (tcb_at' t)
@@ -2640,12 +2640,12 @@ lemma decode_unbind_notification_corres:
        apply (simp split: option.splits)
        apply (simp add: returnOk_def)
       apply simp
-      apply (rule gbn_corres)
+      apply (rule getBoundNotification_corres)
      apply wp+
    apply auto
   done
 
-lemma decode_set_tls_base_corres:
+lemma decodeSetTLSBase_corres:
   "corres (ser \<oplus> tcbinv_relation) (tcb_at t) (tcb_at' t)
           (decode_set_tls_base w (cap.ThreadCap t))
           (decodeSetTLSBase w (capability.ThreadCap t))"
@@ -2653,7 +2653,7 @@ lemma decode_set_tls_base_corres:
                  split: list.split)
   by (rule sym, rule ucast_id)
 
-lemma decode_tcb_inv_corres:
+lemma decodeTCBInvocation_corres:
  "\<lbrakk> c = Structures_A.ThreadCap t; cap_relation c c';
       list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras';
       length args < 2 ^ word_bits \<rbrakk> \<Longrightarrow>
@@ -2669,18 +2669,18 @@ lemma decode_tcb_inv_corres:
              split del: if_split split: gen_invocation_labels.split)
   apply (simp add: returnOk_def)
   apply (intro conjI impI
-             corres_guard_imp[OF decode_readreg_corres]
-             corres_guard_imp[OF decode_writereg_corres]
-             corres_guard_imp[OF decode_copyreg_corres]
-             corres_guard_imp[OF decode_tcb_conf_corres]
-             corres_guard_imp[OF decode_set_priority_corres]
-             corres_guard_imp[OF decode_set_mcpriority_corres]
-             corres_guard_imp[OF decode_set_sched_params_corres]
-             corres_guard_imp[OF decode_set_ipc_corres]
-             corres_guard_imp[OF decode_set_space_corres]
-             corres_guard_imp[OF decode_bind_notification_corres]
-             corres_guard_imp[OF decode_unbind_notification_corres]
-             corres_guard_imp[OF decode_set_tls_base_corres],
+             corres_guard_imp[OF decodeReadRegisters_corres]
+             corres_guard_imp[OF decodeWriteRegisters_corres]
+             corres_guard_imp[OF decodeCopyRegisters_corres]
+             corres_guard_imp[OF decodeTCBConfigure_corres]
+             corres_guard_imp[OF decodeSetPriority_corres]
+             corres_guard_imp[OF decodeSetMCPriority_corres]
+             corres_guard_imp[OF decodeSetSchedParams_corres]
+             corres_guard_imp[OF decodeSetIPCBuffer_corres]
+             corres_guard_imp[OF decodeSetSpace_corres]
+             corres_guard_imp[OF decodeBindNotification_corres]
+             corres_guard_imp[OF decodeUnbindNotification_corres]
+             corres_guard_imp[OF decodeSetTLSBase_corres],
          simp_all add: valid_cap_simps valid_cap_simps' invs_def valid_sched_def)
   apply (auto simp: list_all2_map1 list_all2_map2
              elim!: list_all2_mono)

--- a/proof/refine/ARM_HYP/Untyped_R.thy
+++ b/proof/refine/ARM_HYP/Untyped_R.thy
@@ -91,7 +91,7 @@ lemma corres_check_no_children:
      apply (rule corres_guard_imp[OF corres_splitEE])
          apply (rule corres_returnOkTT)
          apply simp
-        apply (rule ensure_no_children_corres)
+        apply (rule ensureNoChildren_corres)
         apply simp
        apply wp+
       apply simp+
@@ -139,7 +139,7 @@ lemma corres_whenE_throw_merge:
   \<Longrightarrow> corres r P P' f (doE _ \<leftarrow> whenE A (throwError e); _ \<leftarrow>  whenE B (throwError e); h odE)"
   by (auto simp: whenE_def split: if_splits)
 
-lemma dec_untyped_inv_corres:
+lemma decodeUntypedInvocation_corres:
   assumes cap_rel: "list_all2 cap_relation cs cs'"
   shows "corres
         (ser \<oplus> untypinv_relation)
@@ -368,7 +368,7 @@ next
                   apply (rule_tac P = "valid_cap (cap.CNodeCap r bits g) and invs" in corres_guard_imp [where P' = invs'])
                     apply (rule mapME_x_corres_inv [OF _ _ _ refl])
                       apply (simp del: ser_def)
-                      apply (rule ensure_empty_corres)
+                      apply (rule ensureEmptySlot_corres)
                       apply (clarsimp simp: is_cap_simps)
                      apply (simp, wp)
                     apply (simp, wp)
@@ -392,7 +392,7 @@ next
            apply (rule corres_returnOkTT)
            apply (rule crel)
           apply simp
-          apply (rule corres_splitEE[OF _ lsfc_corres])
+          apply (rule corres_splitEE[OF _ lookupSlotForCNodeOp_corres])
               apply simp
               apply (rule getSlotCap_corres,simp)
              apply (rule crel)
@@ -1403,7 +1403,7 @@ crunches create_cap_ext
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma clearUntypedFreeIndex_corres_noop_psp:
+lemma updateNewFreeIndex_noop_psp_corres:
   "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False True
     dc \<top> (cte_at' slot)
     (return ()) (updateNewFreeIndex slot)"
@@ -1416,7 +1416,7 @@ lemma clearUntypedFreeIndex_corres_noop_psp:
         | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
   done
 
-lemma create_cap_corres:
+lemma insertNewCap_corres:
 notes if_cong[cong del] if_weak_cong[cong]
 shows
   "\<lbrakk> cref' = cte_map (fst tup)
@@ -1535,7 +1535,7 @@ shows
          apply (rule corres_underlying_symb_exec_l [OF set_original_symb_exec_l])
           apply (rule corres_cong[OF refl refl _ refl refl, THEN iffD1])
            apply (rule bind_return[THEN fun_cong])
-          apply (rule corres_split_deprecated [OF _ set_cap_pspace_corres])
+          apply (rule corres_split_deprecated [OF _ setCTE_corres])
              apply (subst bind_return[symmetric],
                     rule corres_split_deprecated)
                 prefer 2
@@ -1543,7 +1543,7 @@ shows
                 apply (rule updateMDB_symb_exec_r)
                apply (simp add: dc_def[symmetric])
                apply (rule corres_split_noop_rhs[OF _ updateMDB_symb_exec_r])
-                apply (rule clearUntypedFreeIndex_corres_noop_psp)
+                apply (rule updateNewFreeIndex_noop_psp_corres)
                apply (wp getCTE_wp set_cdt_valid_objs set_cdt_cte_at
                          hoare_weak_lift_imp | simp add: o_def)+
     apply (clarsimp simp: cte_wp_at_cte_at)
@@ -2902,7 +2902,7 @@ lemma inv_untyped_corres_helper1:
   apply (fold mapM_x_def)
   apply (rule corres_list_all2_mapM_)
      apply (rule corres_guard_imp)
-       apply (erule create_cap_corres)
+       apply (erule insertNewCap_corres)
       apply (clarsimp simp: cte_wp_at_def is_cap_simps)
      apply (clarsimp simp: fun_upd_def cte_wp_at_ctes_of)
     apply clarsimp
@@ -3842,7 +3842,7 @@ lemma descendants_range_ex_cte':
   apply blast
   done
 
-lemma update_untyped_cap_corres:
+lemma updateCap_isUntypedCap_corres:
   "\<lbrakk>is_untyped_cap cap; isUntypedCap cap'; cap_relation cap cap'\<rbrakk>
    \<Longrightarrow> corres dc
          (cte_wp_at (\<lambda>c. is_untyped_cap c \<and> obj_ref_of c = obj_ref_of cap \<and>
@@ -3868,7 +3868,7 @@ lemma update_untyped_cap_corres:
        apply (rule_tac F = " (cap.UntypedCap dev r bits f) = free_index_update (\<lambda>_. f) c"
                       in corres_gen_asm)
        apply simp
-       apply (rule set_untyped_cap_corres)
+       apply (rule setCTE_UntypedCap_corres)
          apply ((clarsimp simp: cte_wp_at_caps_of_state cte_wp_at_ctes_of)+)[3]
       apply (subst identity_eq)
       apply (wp getCTE_sp getCTE_get no_fail_getCTE)+
@@ -3893,7 +3893,7 @@ lemma updateFreeIndex_corres:
           apply (rule_tac F="isUntypedCap capa
                  \<and> cap_relation cap (capFreeIndex_update (\<lambda>_. idx) capa)"
                in corres_gen_asm2)
-          apply (rule update_untyped_cap_corres, simp+)
+          apply (rule updateCap_isUntypedCap_corres, simp+)
            apply (clarsimp simp: isCap_simps)
           apply simp
          apply (wp getSlotCap_wp)+
@@ -4237,7 +4237,7 @@ lemma ex_tupI:
 context begin interpretation Arch . (*FIXME: arch_split*)
 (* mostly stuff about PPtr/fromPPtr, which seems pretty soft *)
 
-lemma reset_untyped_cap_corres:
+lemma resetUntypedCap_corres:
   "untypinv_relation ui ui'
     \<Longrightarrow> corres (dc \<oplus> dc)
     (invs and valid_untyped_inv_wcap ui
@@ -4260,7 +4260,7 @@ lemma reset_untyped_cap_corres:
        apply (rule corres_if[OF refl])
         apply (rule corres_returnOk[where P=\<top> and P'=\<top>], simp)
        apply (simp add: liftE_bindE bits_of_def split del: if_split)
-       apply (rule corres_split_deprecated[OF _ detype_corres])
+       apply (rule corres_split_deprecated[OF _ deleteObjects_corres])
            apply (rule corres_if)
              apply (simp add: reset_chunk_bits_def resetChunkBits_def)
             apply (simp add: bits_of_def shiftL_nat)
@@ -4290,7 +4290,7 @@ lemma reset_untyped_cap_corres:
               apply (rule corres_guard_imp)
                 apply (rule corres_split_nor)
                    apply (rule corres_split_nor[OF _ updateFreeIndex_corres])
-                       apply (rule preemption_corres)
+                       apply (rule preemptionPoint_corres)
                       apply simp
                      apply (simp add: getFreeRef_def getFreeIndex_def
                                       free_index_of_def)
@@ -4898,7 +4898,7 @@ lemma inv_untyped_corres':
         apply (rule corres_split_norE)
            prefer 2
            apply (rule corres_whenE, simp)
-            apply (rule reset_untyped_cap_corres[where ui=ui and ui'=ui'])
+            apply (rule resetUntypedCap_corres[where ui=ui and ui'=ui'])
             apply (simp add: ui ui')
            apply simp
           apply simp

--- a/proof/refine/ARM_HYP/VSpace_R.thy
+++ b/proof/refine/ARM_HYP/VSpace_R.thy
@@ -185,7 +185,7 @@ lemma asidBits_asid_bits[simp]:
   by (simp add: asid_bits_def asidBits_def
                 asidHighBits_def asid_low_bits_def)
 
-lemma find_pd_for_asid_assert_corres:
+lemma findPDForASIDAssert_corres:
   "corres (\<lambda>rv rv'. rv = pd \<and> rv' = pd)
            (K (asid \<noteq> 0 \<and> asid \<le> mask asid_bits)
                  and pspace_aligned and pspace_distinct
@@ -270,14 +270,14 @@ lemma findPDForASIDAssert_known_corres:
    apply clarsimp
    apply (erule(3) find_pd_for_asid_assert_eq[symmetric])
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ find_pd_for_asid_assert_corres[where pd=pd]])
+    apply (rule corres_split_deprecated [OF _ findPDForASIDAssert_corres[where pd=pd]])
       apply simp
      apply wp+
    apply clarsimp
   apply simp
   done
 
-lemma load_hw_asid_corres:
+lemma loadHWASID_corres:
   "corres (=)
           (valid_vspace_objs and pspace_distinct
                  and pspace_aligned and valid_asid_map
@@ -310,7 +310,7 @@ lemma load_hw_asid_corres:
 crunch inv[wp]: loadHWASID "P"
   (wp: crunch_wps)
 
-lemma store_hw_asid_corres:
+lemma storeHWASID_corres:
   "corres dc
           (vspace_at_asid a pd and pd_at_uniq a pd
                   and valid_vspace_objs and pspace_distinct
@@ -320,7 +320,7 @@ lemma store_hw_asid_corres:
           (store_hw_asid a h) (storeHWASID a h)"
   apply (simp add: store_hw_asid_def storeHWASID_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ find_pd_for_asid_assert_corres[where pd=pd]])
+    apply (rule corres_split_deprecated [OF _ findPDForASIDAssert_corres[where pd=pd]])
       apply (rule corres_split_eqr)
          apply (rule corres_split_deprecated)
             prefer 2
@@ -342,7 +342,7 @@ lemma store_hw_asid_corres:
        apply (wp | simp)+
   done
 
-lemma invalidate_asid_corres:
+lemma invalidateASID_corres:
   "corres dc
           (valid_asid_map and valid_vspace_objs
                and pspace_aligned and pspace_distinct
@@ -372,12 +372,12 @@ lemma invalidate_asid_ext_corres:
                \<and> a \<noteq> 0 \<and> a \<le> mask asid_bits)
           (pspace_aligned' and pspace_distinct' and no_0_obj')
      (invalidate_asid a) (invalidateASID a)"
-  apply (insert invalidate_asid_corres)
+  apply (insert invalidateASID_corres)
   apply (clarsimp simp: corres_underlying_def)
   apply fastforce
   done
 
-lemma invalidate_hw_asid_entry_corres:
+lemma invalidateHWASIDEntry_corres:
   "corres dc \<top> \<top> (invalidate_hw_asid_entry a) (invalidateHWASIDEntry a)"
   apply (simp add: invalidate_hw_asid_entry_def invalidateHWASIDEntry_def)
   apply (rule corres_guard_imp)
@@ -390,7 +390,7 @@ lemma invalidate_hw_asid_entry_corres:
   apply simp
   done
 
-lemma find_free_hw_asid_corres:
+lemma findFreeHWASID_corres:
   "corres (=)
           (valid_asid_map and valid_vspace_objs
               and pspace_aligned and pspace_distinct
@@ -419,7 +419,7 @@ lemma find_free_hw_asid_corres:
                  apply fastforce
                 apply (rule corres_split_deprecated)
                    prefer 2
-                   apply (rule invalidate_hw_asid_entry_corres)
+                   apply (rule invalidateHWASIDEntry_corres)
                   apply (rule corres_split_deprecated)
                      apply (rule corres_trivial)
                      apply simp
@@ -456,7 +456,7 @@ crunch distinct'[wp]: findFreeHWASID "pspace_distinct'"
 
 crunch no_0_obj'[wp]: getHWASID "no_0_obj'"
 
-lemma get_hw_asid_corres:
+lemma getHWASID_corres:
   "corres (=)
           (vspace_at_asid a pd and K (a \<noteq> 0 \<and> a \<le> mask asid_bits)
            and unique_table_refs o caps_of_state
@@ -468,18 +468,18 @@ lemma get_hw_asid_corres:
           (get_hw_asid a) (getHWASID a)"
   apply (simp add: get_hw_asid_def getHWASID_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ load_hw_asid_corres[where pd=pd]])
+    apply (rule corres_split_eqr [OF _ loadHWASID_corres[where pd=pd]])
       apply (case_tac maybe_hw_asid, simp_all)[1]
       apply clarsimp
-      apply (rule corres_split_eqr [OF _ find_free_hw_asid_corres])
-         apply (rule corres_split_deprecated [OF _ store_hw_asid_corres[where pd=pd]])
+      apply (rule corres_split_eqr [OF _ findFreeHWASID_corres])
+         apply (rule corres_split_deprecated [OF _ storeHWASID_corres[where pd=pd]])
            apply (rule corres_trivial, simp)
           apply (wp load_hw_asid_wp | simp)+
    apply (simp add: pd_at_asid_uniq valid_global_objs_def)
   apply simp
   done
 
-lemma arm_context_switch_corres:
+lemma armv_contextSwitch_corres:
   "corres dc
           (vspace_at_asid a pd and K (a \<noteq> 0 \<and> a \<le> mask asid_bits)
            and unique_table_refs o caps_of_state
@@ -491,7 +491,7 @@ lemma arm_context_switch_corres:
           (arm_context_switch pd a) (armv_contextSwitch pd a)"
   apply (simp add: arm_context_switch_def armv_contextSwitch_def armv_contextSwitch_HWASID_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ get_hw_asid_corres[where pd=pd]])
+    apply (rule corres_split_eqr [OF _ getHWASID_corres[where pd=pd]])
       apply (rule corres_machine_op)
       apply (rule corres_rel_imp)
        apply (rule corres_underlying_trivial)
@@ -630,7 +630,7 @@ lemma setVCPU_ct_not_inQ[wp]:
   apply assumption
   done
 
-lemma hv_corres:
+lemma handleVMFault_corres:
   "corres (fr \<oplus> dc) (tcb_at thread) (tcb_at' thread)
           (handle_vm_fault thread fault) (handleVMFault thread fault)"
   apply (simp add: ARM_HYP_H.handleVMFault_def)
@@ -645,7 +645,7 @@ lemma hv_corres:
     apply wpsimp+
   apply (rule corres_guard_imp)
     apply (rule corres_splitEE,prefer_next,simp)
-       apply (rule corres_as_user')
+       apply (rule asUser_corres')
        apply (rule corres_no_failI [where R="(=)"])
         apply (rule no_fail_getRestartPC)
        apply fastforce
@@ -656,7 +656,7 @@ lemma hv_corres:
          apply wpsimp+
   done
 
-lemma flush_space_corres:
+lemma flushSpace_corres:
   "corres dc
           (K (asid \<le> mask asid_bits \<and> asid \<noteq> 0)
            and valid_asid_map and valid_vspace_objs
@@ -670,7 +670,7 @@ lemma flush_space_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated)
        prefer 2
-       apply (rule load_hw_asid_corres[where pd=pd])
+       apply (rule loadHWASID_corres[where pd=pd])
       apply (rule corres_split_deprecated [where R="\<lambda>_. \<top>" and R'="\<lambda>_. \<top>"])
          prefer 2
          apply (rule corres_machine_op [where r=dc])
@@ -688,7 +688,7 @@ lemma flush_space_corres:
   apply simp
   done
 
-lemma invalidate_tlb_by_asid_corres:
+lemma invalidateTLBByASID_corres:
   "corres dc
           (K (asid \<le> mask asid_bits \<and> asid \<noteq> 0)
            and valid_asid_map and valid_vspace_objs
@@ -702,7 +702,7 @@ lemma invalidate_tlb_by_asid_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated [where R="\<lambda>_. \<top>" and R'="\<lambda>_. \<top>"])
        prefer 2
-       apply (rule load_hw_asid_corres[where pd=pd])
+       apply (rule loadHWASID_corres[where pd=pd])
       apply (case_tac maybe_hw_asid)
        apply simp
       apply clarsimp
@@ -727,7 +727,7 @@ lemma invalidate_tlb_by_asid_corres_ex:
           (invalidate_tlb_by_asid asid) (invalidateTLBByASID asid)"
   apply (rule corres_name_pre, clarsimp)
   apply (rule corres_guard_imp)
-    apply (rule_tac pd=pd in invalidate_tlb_by_asid_corres)
+    apply (rule_tac pd=pd in invalidateTLBByASID_corres)
    apply simp+
   done
 
@@ -775,7 +775,7 @@ lemma corres_gets_gicvcpu_numlistregs:
 
 lemmas corres_split_forward = corres_split'[rule_format, where Q="\<lambda>_. P" and P=P  and Q'="\<lambda>_. P'" and P'=P' for P P']
 
-lemma set_vcpu_corres:
+lemma setObject_VCPU_corres:
   "vcpu_relation vcpuObj vcpuObj'
    \<Longrightarrow>  corres dc (vcpu_at  vcpu)
                   (vcpu_at' vcpu)
@@ -783,7 +783,7 @@ lemma set_vcpu_corres:
                   (setObject vcpu vcpuObj')"
   apply (simp add: set_vcpu_def)
   apply (rule corres_guard_imp)
-    apply (rule set_other_obj_corres [where P="\<lambda>ko::vcpu. True"], simp)
+    apply (rule setObject_other_corres [where P="\<lambda>ko::vcpu. True"], simp)
          apply (clarsimp simp: obj_at'_def projectKOs)
          apply (erule map_to_ctes_upd_other, simp, simp)
         apply (simp add: a_type_def is_other_obj_relation_type_def)
@@ -809,7 +809,7 @@ lemma vcpuUpdate_corres[corres]:
   "\<forall>v1 v2. vcpu_relation v1 v2 \<longrightarrow> vcpu_relation (f v1) (f' v2) \<Longrightarrow>
     corres dc (vcpu_at v) (vcpu_at' v)
            (vcpu_update v f) (vcpuUpdate v f')"
-  by (corressimp corres: get_vcpu_corres set_vcpu_corres
+  by (corressimp corres: getObject_vcpu_corres setObject_VCPU_corres
                  simp: vcpu_update_def vcpuUpdate_def vcpu_relation_def)
 
 lemma vgicUpdate_corres[corres]:
@@ -828,7 +828,7 @@ lemma vcpuReadReg_corres[corres]:
   apply (simp add: vcpu_read_reg_def vcpuReadReg_def)
   apply (rule corres_guard_imp)
     apply (rule corres_assert_gen_asm2)
-    apply (rule corres_split'[OF get_vcpu_corres])
+    apply (rule corres_split'[OF getObject_vcpu_corres])
       apply (wpsimp simp: vcpu_relation_def)+
   done
 
@@ -867,7 +867,7 @@ lemma vcpuRestoreReg_corres[corres]:
   apply (clarsimp simp: vcpu_restore_reg_def vcpuRestoreReg_def)
   apply (rule corres_guard_imp)
     apply (rule corres_assert_gen_asm2)
-    apply (rule corres_split_deprecated[OF _ get_vcpu_corres])
+    apply (rule corres_split_deprecated[OF _ getObject_vcpu_corres])
       apply (rule corres_machine_op)
       apply (rule corres_Id)
         apply (fastforce simp: vcpu_relation_def)
@@ -916,7 +916,7 @@ lemma restoreVirtTimer_corres[corres]:
     apply (rule corres_split_eqr[OF _ vcpuReadReg_corres], simp)
       apply (rule corres_split_eqr[OF _ vcpuReadReg_corres])
         apply (rule corres_split_eqr[OF _ corres_machine_op], simp)+
-              apply (rule corres_split_deprecated[OF _ get_vcpu_corres])
+              apply (rule corres_split_deprecated[OF _ getObject_vcpu_corres])
                 apply (rule corres_split_eqr[OF _ vcpuReadReg_corres])
                   apply (rule corres_split_eqr[OF _ vcpuReadReg_corres])
                     apply (clarsimp simp: vcpu_relation_def)
@@ -1005,7 +1005,7 @@ lemma vcpuEnable_corres:
   apply (simp add: vcpu_enable_def vcpuEnable_def doMachineOp_bind do_machine_op_bind bind_assoc)
   apply (rule corres_guard_imp)
     apply (rule corres_split_dc[OF _ vcpuRestoreReg_corres])+
-      apply (rule corres_split_deprecated[OF _ get_vcpu_corres], rename_tac vcpu')
+      apply (rule corres_split_deprecated[OF _ getObject_vcpu_corres], rename_tac vcpu')
         apply (case_tac vcpu')
         apply (rule corres_split_dc[OF _ corres_machine_op]
                | rule corres_machine_op corres_Id restoreVirtTimer_corres
@@ -1023,7 +1023,7 @@ lemma vcpuRestore_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_dc[OF _ corres_machine_op]
            | rule corres_machine_op corres_Id)+
-          apply (rule corres_split_deprecated[OF _ get_vcpu_corres], rename_tac vcpu')
+          apply (rule corres_split_deprecated[OF _ getObject_vcpu_corres], rename_tac vcpu')
             apply (rule corres_split_deprecated[OF _ corres_gets_gicvcpu_numlistregs])
               apply (case_tac vcpu'
                      , clarsimp simp: comp_def vcpu_relation_def vgic_map_def mapM_x_mapM
@@ -1154,7 +1154,7 @@ lemma valid_objs_valid_tcb: "\<lbrakk> valid_objs s ; ko_at (TCB t) p s \<rbrakk
 lemma valid_objs_valid_tcb': "\<lbrakk> valid_objs' s ; ko_at' (t :: tcb) p s \<rbrakk> \<Longrightarrow> valid_tcb' t s"
   by (fastforce simp add: obj_at'_def ran_def valid_obj'_def projectKOs valid_objs'_def)
 
-lemma set_vm_root_corres:
+lemma setVMRoot_corres:
   "corres dc (tcb_at t and valid_arch_state and valid_objs and valid_asid_map
               and unique_table_refs o caps_of_state and valid_vs_lookup
               and pspace_aligned and pspace_distinct
@@ -1238,7 +1238,7 @@ proof -
                     apply (simp add: lookup_failure_map_def)
                    apply simp
                   apply simp
-                  apply (rule arm_context_switch_corres)
+                  apply (rule armv_contextSwitch_corres)
                  apply simp
                 apply simp
                 apply (wpsimp simp: armv_contextSwitch_def if_apply_def2 wp: assert_get_tcb_ko')+
@@ -1278,7 +1278,7 @@ lemma get_asid_pool_corres_inv':
           (asid_pool_at p) (pspace_aligned' and pspace_distinct')
           (get_asid_pool p) (getObject p)"
   apply (rule corres_rel_imp)
-   apply (rule get_asid_pool_corres')
+   apply (rule getObject_ASIDPool_corres')
   apply simp
   done
 
@@ -1291,7 +1291,7 @@ lemma loadHWASID_wp [wp]:
   apply (auto split: option.split)
   done
 
-lemma invalidate_asid_entry_corres:
+lemma invalidateASIDEntry_corres:
   "corres dc (valid_vspace_objs and valid_asid_map
                 and K (asid \<le> mask asid_bits \<and> asid \<noteq> 0)
                 and vspace_at_asid asid pd and valid_vs_lookup
@@ -1302,12 +1302,12 @@ lemma invalidate_asid_entry_corres:
              (invalidate_asid_entry asid) (invalidateASIDEntry asid)"
   apply (simp add: invalidate_asid_entry_def invalidateASIDEntry_def)
   apply (rule corres_guard_imp)
-   apply (rule corres_split_deprecated [OF _ load_hw_asid_corres[where pd=pd]])
+   apply (rule corres_split_deprecated [OF _ loadHWASID_corres[where pd=pd]])
      apply (rule corres_split_deprecated [OF _ corres_when])
-         apply (rule invalidate_asid_corres[where pd=pd])
+         apply (rule invalidateASID_corres[where pd=pd])
         apply simp
        apply simp
-       apply (rule invalidate_hw_asid_entry_corres)
+       apply (rule invalidateHWASIDEntry_corres)
       apply (wp load_hw_asid_wp
                | clarsimp cong: if_cong)+
    apply (simp add: pd_at_asid_uniq)
@@ -1349,7 +1349,7 @@ crunch no_0_obj'[wp]: deleteASID "no_0_obj'"
   (simp: crunch_simps
    wp: crunch_wps getObject_inv loadObject_default_inv)
 
-lemma delete_asid_corres:
+lemma deleteASID_corres:
   "corres dc
           (invs and valid_etcbs and K (asid \<le> mask asid_bits \<and> asid \<noteq> 0))
           (pspace_aligned' and pspace_distinct' and no_0_obj'
@@ -1370,23 +1370,23 @@ lemma delete_asid_corres:
          apply (simp add: dom_def)
          apply (rule get_asid_pool_corres_inv')
         apply (rule corres_when, simp add: mask_asid_low_bits_ucast_ucast)
-        apply (rule corres_split_deprecated [OF _ flush_space_corres[where pd=pd]])
-          apply (rule corres_split_deprecated [OF _ invalidate_asid_entry_corres[where pd=pd]])
+        apply (rule corres_split_deprecated [OF _ flushSpace_corres[where pd=pd]])
+          apply (rule corres_split_deprecated [OF _ invalidateASIDEntry_corres[where pd=pd]])
             apply (rule_tac P="asid_pool_at (the (asidTable (ucast (asid_high_bits_of asid))))
                                and valid_etcbs"
                         and P'="pspace_aligned' and pspace_distinct'"
                          in corres_split_deprecated)
                prefer 2
                apply (simp del: fun_upd_apply)
-               apply (rule set_asid_pool_corres')
+               apply (rule setObject_ASIDPool_corres')
                apply (simp add: inv_def mask_asid_low_bits_ucast_ucast)
                apply (rule ext)
                apply (clarsimp simp: o_def)
                apply (erule notE)
                apply (erule ucast_ucast_eq, simp, simp)
-              apply (rule corres_split_deprecated [OF _ gct_corres])
+              apply (rule corres_split_deprecated [OF _ getCurThread_corres])
                 apply simp
-                apply (rule set_vm_root_corres)
+                apply (rule setVMRoot_corres)
                apply wp+
              apply (simp del: fun_upd_apply)
              apply (fold cur_tcb_def)
@@ -1438,7 +1438,7 @@ crunch armKSASIDTable_inv[wp]: invalidateASIDEntry
 crunch armKSASIDTable_inv[wp]: flushSpace
     "\<lambda>s. P (armKSASIDTable (ksArchState s))"
 
-lemma delete_asid_pool_corres:
+lemma deleteASIDPool_corres:
   "corres dc
           (invs and K (is_aligned base asid_low_bits
                          \<and> base \<le> mask asid_bits)
@@ -1455,7 +1455,7 @@ lemma delete_asid_pool_corres:
       apply (rule corres_when)
        apply simp
       apply (simp add: liftM_def)
-      apply (rule corres_split_deprecated [OF _ get_asid_pool_corres'])
+      apply (rule corres_split_deprecated [OF _ getObject_ASIDPool_corres'])
         apply (rule corres_split_deprecated)
            prefer 2
            apply (rule corres_mapM [where r=dc and r'=dc], simp, simp)
@@ -1473,9 +1473,9 @@ lemma delete_asid_pool_corres:
                  apply (clarsimp simp: ucast_ucast_low_bits)
                 apply simp
                 apply (rule_tac pd1="the (pool (ucast xa))"
-                          in corres_split_deprecated [OF _ flush_space_corres])
+                          in corres_split_deprecated [OF _ flushSpace_corres])
                   apply (rule_tac pd="the (pool (ucast xa))"
-                             in invalidate_asid_entry_corres)
+                             in invalidateASIDEntry_corres)
                  apply wp
                  apply clarsimp
                  apply wp+
@@ -1541,9 +1541,9 @@ lemma delete_asid_pool_corres:
              apply (simp add: word_size nth_ucast)
             apply (rule corres_split_deprecated)
                prefer 2
-               apply (rule gct_corres)
+               apply (rule getCurThread_corres)
               apply (simp only:)
-              apply (rule set_vm_root_corres)
+              apply (rule setVMRoot_corres)
              apply wp+
          apply (rule_tac R="\<lambda>_ s. rv = arm_asid_table (arch_state s)"
                     in hoare_post_add)
@@ -1576,7 +1576,7 @@ lemma delete_asid_pool_corres:
   apply clarsimp
 done
 
-lemma set_vm_root_for_flush_corres:
+lemma setVMRootForFlush_corres:
   "corres (=)
           (cur_tcb and vspace_at_asid asid pd
            and K (asid \<noteq> 0 \<and> asid \<le> mask asid_bits)
@@ -1603,14 +1603,14 @@ proof -
                return True
             od)"
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF _ arm_context_switch_corres])
+      apply (rule corres_split_deprecated [OF _ armv_contextSwitch_corres])
         apply (rule corres_trivial)
         apply (wp | simp)+
     done
   show ?thesis
   apply (simp add: set_vm_root_for_flush_def setVMRootForFlush_def getThreadVSpaceRoot_def locateSlot_conv)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gct_corres])
+    apply (rule corres_split_deprecated [OF _ getCurThread_corres])
       apply (rule corres_split_deprecated [where R="\<lambda>_. vspace_at_asid asid pd and K (asid \<noteq> 0 \<and> asid \<le> mask asid_bits)
                                                and valid_asid_map and valid_vs_lookup
                                                and valid_vspace_objs
@@ -1799,7 +1799,7 @@ lemma load_hw_asid_corres2:
      (pspace_aligned' and pspace_distinct' and no_0_obj')
     (load_hw_asid a) (loadHWASID a)"
   apply (rule stronger_corres_guard_imp)
-    apply (rule load_hw_asid_corres[where pd=pd])
+    apply (rule loadHWASID_corres[where pd=pd])
    apply (clarsimp simp: pd_at_asid_uniq)
   apply simp
   done
@@ -1807,7 +1807,7 @@ lemma load_hw_asid_corres2:
 crunch no_0_obj'[wp]: flushTable "no_0_obj'"
   (wp: crunch_wps simp: crunch_simps)
 
-lemma flush_table_corres:
+lemma flushTable_corres:
   "corres dc
           (pspace_aligned and valid_objs and valid_arch_state and
            cur_tcb and vspace_at_asid asid pd and valid_asid_map and valid_vspace_objs and
@@ -1823,14 +1823,14 @@ lemma flush_table_corres:
   apply (simp add: ptBits_def pt_bits_def pageBits_def is_aligned_mask cong: corres_weak_cong)
   apply (thin_tac "P" for P)+
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ set_vm_root_for_flush_corres])
+    apply (rule corres_split_deprecated [OF _ setVMRootForFlush_corres])
       apply (rule corres_split_deprecated [OF _ load_hw_asid_corres2[where pd=pd]])
         apply (clarsimp cong: corres_weak_cong)
         apply (rule corres_when, rule refl)
         apply (rule corres_split_deprecated[where r' = dc, OF corres_when corres_machine_op])
             apply simp
-           apply (rule corres_split_deprecated[OF _ gct_corres])
-             apply (simp, rule set_vm_root_corres)
+           apply (rule corres_split_deprecated[OF _ getCurThread_corres])
+             apply (simp, rule setVMRoot_corres)
             apply ((wp mapM_wp' hoare_vcg_const_imp_lift get_pte_wp getPTE_wp|
                     wpc|simp|fold cur_tcb_def cur_tcb'_def)+)[4]
           apply (rule corres_Id[OF refl])
@@ -1841,7 +1841,7 @@ lemma flush_table_corres:
             | rule hoare_drop_imps)+
   done
 
-lemma flush_page_corres:
+lemma flushPage_corres:
   "corres dc
           (K (is_aligned vptr pageBits \<and> asid \<le> mask asid_bits \<and> asid \<noteq> 0) and
            cur_tcb and valid_arch_state and valid_objs and
@@ -1858,15 +1858,15 @@ lemma flush_page_corres:
   apply (simp add: is_aligned_mask cong: corres_weak_cong)
   apply (thin_tac P for P)+
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ set_vm_root_for_flush_corres])
+    apply (rule corres_split_deprecated [OF _ setVMRootForFlush_corres])
       apply (rule corres_split_deprecated [OF _ load_hw_asid_corres2[where pd=pd]])
         apply (clarsimp cong: corres_weak_cong)
         apply (rule corres_when, rule refl)
         apply (rule corres_split_deprecated [OF _ corres_machine_op [where r=dc]])
            apply (rule corres_when, rule refl)
-           apply (rule corres_split_deprecated [OF _ gct_corres])
+           apply (rule corres_split_deprecated [OF _ getCurThread_corres])
              apply simp
-             apply (rule set_vm_root_corres)
+             apply (rule setVMRoot_corres)
             apply wp+
           apply (rule corres_Id, rule refl, simp)
           apply (rule no_fail_pre, wp no_fail_invalidateLocalTLB_VAASID)
@@ -1909,7 +1909,7 @@ crunch distinct'[wp]: unmapPageTable "pspace_distinct'"
   (simp: crunch_simps
      wp: crunch_wps getObject_inv loadObject_default_inv)
 
-lemma page_table_mapped_corres:
+lemma pageTableMapped_corres:
   "corres (=) (valid_arch_state and valid_vspace_objs and pspace_aligned
                        and K (asid \<noteq> 0 \<and> asid \<le> mask asid_bits))
                  (pspace_aligned' and pspace_distinct' and no_0_obj')
@@ -1921,7 +1921,7 @@ lemma page_table_mapped_corres:
       apply (rule corres_trivial, simp)
      apply (rule corres_split_eqrE [OF _ find_pd_for_asid_corres])
        apply (simp add: liftE_bindE)
-       apply (rule corres_split_deprecated [OF _ get_pde_corres'])
+       apply (rule corres_split_deprecated [OF _ getObject_PDE_corres'])
          apply (rule corres_trivial)
          apply (case_tac rv,
            simp_all add: returnOk_def pde_relation_aligned_def
@@ -1972,7 +1972,7 @@ lemma storePDE_cur_tcb'[wp]: "\<lbrace>cur_tcb'\<rbrace> storePDE param_a param_
 lemma storePTE_cur_tcb'[wp]: "\<lbrace>cur_tcb'\<rbrace> storePTE param_a param_b \<lbrace>\<lambda>_. cur_tcb'\<rbrace>"
   by (wpsimp wp: setObject_cte_wp_at2' headM_inv hoare_drop_imp simp: storePTE_def)
 
-lemma unmap_page_table_corres:
+lemma unmapPageTable_corres:
   "corres dc
           (invs and valid_etcbs and page_table_at pt and
            K (0 < asid \<and> is_aligned vptr 21 \<and> asid \<le> mask asid_bits))
@@ -1982,12 +1982,12 @@ lemma unmap_page_table_corres:
           (unmapPageTable asid vptr pt)"
   apply (clarsimp simp: unmapPageTable_def unmap_page_table_def ignoreFailure_def const_def cong: option.case_cong)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ page_table_mapped_corres])
+    apply (rule corres_split_eqr [OF _ pageTableMapped_corres])
       apply (simp add: case_option_If2 split del: if_split)
       apply (rule corres_if2[OF refl])
-       apply (rule corres_split_deprecated [OF _ store_pde_corres'])
+       apply (rule corres_split_deprecated [OF _ storePDE_corres'])
           apply (rule corres_split_deprecated[OF _ corres_machine_op])
-             apply (rule flush_table_corres)
+             apply (rule flushTable_corres)
             apply (rule corres_Id, rule refl, simp)
             apply (wp no_fail_cleanByVA_PoU)+
            apply (simp, wp+)
@@ -2068,7 +2068,7 @@ lemma corres_split_strengthen_ftE:
    apply (simp add: validE_R_def)+
   done
 
-lemma check_mapping_corres:
+lemma checkMappingPPtr_corres:
   "corres (dc \<oplus> dc)
             ((case slotptr of Inl ptr \<Rightarrow> pte_at ptr | Inr ptr \<Rightarrow> pde_at ptr) and
              (\<lambda>s. (case slotptr of Inl ptr \<Rightarrow> is_aligned ptr (pg_entry_align sz)
@@ -2081,7 +2081,7 @@ lemma check_mapping_corres:
                    checkMappingPPtr_def)
   apply (cases slotptr, simp_all add: liftE_bindE)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated[OF _ get_pte_corres'])
+     apply (rule corres_split_deprecated[OF _ getObject_PTE_corres'])
        apply (rule corres_trivial)
        subgoal by (cases sz,
          auto simp add: is_aligned_mask[symmetric]
@@ -2092,7 +2092,7 @@ lemma check_mapping_corres:
     apply simp
    apply (simp add:is_aligned_mask[symmetric] is_aligned_shiftr pg_entry_align_def)
   apply (rule corres_guard_imp)
-   apply (rule corres_split_deprecated[OF _ get_pde_corres'])
+   apply (rule corres_split_deprecated[OF _ getObject_PDE_corres'])
       apply (rule corres_trivial)
       subgoal by (cases sz,
          auto simp add: is_aligned_mask[symmetric]
@@ -2121,7 +2121,7 @@ lemma is_aligned_dvd_k: "\<lbrakk>  2 ^ m  * (k :: nat) = 2 ^ n  ; is_aligned p 
   apply simp
   done
 
-lemma unmap_page_corres:
+lemma unmapPage_corres:
   "corres dc (invs and valid_etcbs and
               K (valid_unmap sz (asid,vptr) \<and> vptr < kernel_base \<and> asid \<le> mask asid_bits))
              (valid_objs' and valid_arch_state' and pspace_aligned' and
@@ -2135,7 +2135,7 @@ lemma unmap_page_corres:
              rule find_pd_for_asid_corres[OF refl])
         apply (rule corres_splitEE)
            apply clarsimp
-           apply (rule flush_page_corres)
+           apply (rule flushPage_corres)
           apply (rule_tac F = "vptr < kernel_base" in corres_gen_asm)
           apply (rule_tac P="\<exists>\<rhd> pd and page_directory_at pd and vspace_at_asid asid pd
                              and (\<exists>\<rhd> (lookup_pd_slot pd vptr && ~~ mask pd_bits))
@@ -2149,11 +2149,11 @@ lemma unmap_page_corres:
           apply (cases sz, simp_all)[1]
              apply (rule corres_guard_imp)
                apply (rule_tac F = "vptr < kernel_base" in corres_gen_asm)
-               apply (rule corres_split_strengthen_ftE[OF lookup_pt_slot_corres])
+               apply (rule corres_split_strengthen_ftE[OF lookupPTSlot_corres])
                  apply simp
-                 apply (rule corres_splitEE[OF _ check_mapping_corres])
+                 apply (rule corres_splitEE[OF _ checkMappingPPtr_corres])
                    apply simp
-                   apply (rule corres_split_deprecated [OF _ store_pte_corres'])
+                   apply (rule corres_split_deprecated [OF _ storePTE_corres'])
                       apply (rule corres_machine_op)
                       apply (rule corres_Id, rule refl, simp)
                       apply (rule no_fail_cleanByVA_PoU)
@@ -2164,10 +2164,10 @@ lemma unmap_page_corres:
                 page_directory_at_aligned_pd_bits vmsz_aligned_def)
               apply (simp add:valid_unmap_def pageBits_def)+
             apply (rule corres_guard_imp)
-              apply (rule corres_split_strengthen_ftE[OF lookup_pt_slot_corres])
+              apply (rule corres_split_strengthen_ftE[OF lookupPTSlot_corres])
                 apply (rule_tac F="is_aligned p 7" in corres_gen_asm)
                 apply (simp add: is_aligned_mask[symmetric])
-                apply (rule corres_split_strengthen_ftE[OF check_mapping_corres])
+                apply (rule corres_split_strengthen_ftE[OF checkMappingPPtr_corres])
                   apply simp
                   apply (rule corres_split_deprecated [OF _ corres_mapM])
                            prefer 8
@@ -2182,7 +2182,7 @@ lemma unmap_page_corres:
                       apply (rule_tac P="(\<lambda>s. \<forall>x\<in>set largePagePTEOffsets. pte_at (x + pa) s) and pspace_aligned and valid_etcbs"
                                      and P'="pspace_aligned' and pspace_distinct'"
                                      in corres_guard_imp)
-                      apply (rule store_pte_corres',  simp add:pte_relation_aligned_def)
+                      apply (rule storePTE_corres',  simp add:pte_relation_aligned_def)
                       apply clarsimp
                       apply clarsimp
                       apply (wp store_pte_typ_at hoare_vcg_const_Ball_lift | clarsimp | wp (once) hoare_drop_imps)+
@@ -2196,9 +2196,9 @@ lemma unmap_page_corres:
                                    page_directory_at_aligned_pd_bits pde_bits_def)
             apply (simp add:pd_bits_def pageBits_def)
            apply (rule corres_guard_imp)
-             apply (rule corres_split_strengthen_ftE[OF check_mapping_corres])
+             apply (rule corres_split_strengthen_ftE[OF checkMappingPPtr_corres])
                apply simp
-               apply (rule corres_split_deprecated[OF _ store_pde_corres'])
+               apply (rule corres_split_deprecated[OF _ storePDE_corres'])
                   apply (rule corres_machine_op)
                   apply (rule corres_Id, rule refl, simp)
                   apply (rule no_fail_cleanByVA_PoU)
@@ -2220,7 +2220,7 @@ lemma unmap_page_corres:
            apply clarsimp
           apply (simp add:pd_bits_def pageBits_def)
           apply (rule corres_guard_imp)
-            apply (rule corres_split_strengthen_ftE[OF check_mapping_corres])
+            apply (rule corres_split_strengthen_ftE[OF checkMappingPPtr_corres])
               apply (rule_tac F="is_aligned (lookup_pd_slot pd vptr) 7"
                             in corres_gen_asm)
               apply (simp add: is_aligned_mask[symmetric])
@@ -2235,7 +2235,7 @@ lemma unmap_page_corres:
                     prefer 5
                     apply (rule order_refl)
                    apply clarsimp
-                   apply (rule corres_guard_imp, rule store_pde_corres')
+                   apply (rule corres_guard_imp, rule storePDE_corres')
                      apply (simp add:pde_relation_aligned_def)+
                     apply clarsimp
                     apply (rule pde_at_aligned_vptr)
@@ -2276,7 +2276,7 @@ definition
    | ARM_A.flush_type.CleanInvalidate \<Rightarrow> ARM_HYP_H.flush_type.CleanInvalidate
    | ARM_A.flush_type.Unify \<Rightarrow> ARM_HYP_H.flush_type.Unify"
 
-lemma do_flush_corres:
+lemma doFlush_corres:
   "corres_underlying Id nf nf' dc \<top> \<top>
              (do_flush typ start end pstart) (doFlush (flush_type_map typ) start end pstart)"
   apply (simp add: do_flush_def doFlush_def)
@@ -2299,7 +2299,7 @@ definition
   | ARM_A.PageDirectoryFlush typ start end pstart pd asid \<Rightarrow>
       pdi' = PageDirectoryFlush (flush_type_map typ) start end pstart pd asid"
 
-lemma perform_page_directory_corres:
+lemma performPageDirectoryInvocation_corres:
   "page_directory_invocation_map pdi pdi' \<Longrightarrow>
    corres dc (invs and valid_pdi pdi)
              (valid_objs' and pspace_aligned' and pspace_distinct' and no_0_obj'
@@ -2310,14 +2310,14 @@ lemma perform_page_directory_corres:
    apply (clarsimp simp: page_directory_invocation_map_def)
    apply (rule corres_guard_imp)
      apply (rule corres_when, simp)
-     apply (rule corres_split_deprecated [OF _ set_vm_root_for_flush_corres])
+     apply (rule corres_split_deprecated [OF _ setVMRootForFlush_corres])
        apply (rule corres_split_deprecated [OF _ corres_machine_op])
           prefer 2
-          apply (rule do_flush_corres)
+          apply (rule doFlush_corres)
          apply (rule corres_when, simp)
-         apply (rule corres_split_deprecated [OF _ gct_corres])
+         apply (rule corres_split_deprecated [OF _ getCurThread_corres])
            apply clarsimp
-           apply (rule set_vm_root_corres)
+           apply (rule setVMRoot_corres)
           apply wp+
         apply (simp add: cur_tcb_def[symmetric])
         apply (wp hoare_drop_imps)
@@ -2549,7 +2549,7 @@ lemma corres_store_pde_with_invalid_tail:
        apply simp
       apply clarsimp
       apply (rule corres_guard_imp)
-        apply (rule store_pde_corres')
+        apply (rule storePDE_corres')
         apply (drule bspec)
          apply simp
         apply (simp add:pde_relation_aligned_def addPDEOffset_def)
@@ -2573,7 +2573,7 @@ lemma corres_store_pte_with_invalid_tail:
        apply simp
       apply clarsimp
       apply (rule corres_guard_imp)
-        apply (rule store_pte_corres')
+        apply (rule storePTE_corres')
         apply (drule bspec)
          apply simp
         apply (simp add:pte_relation_aligned_def addPTEOffset_def)
@@ -2595,7 +2595,7 @@ lemma updateCap_valid_slots'[wp]:
   apply (wp hoare_vcg_ball_lift)
   done
 
-lemma pte_check_if_mapped_corres:
+lemma pteCheckIfMapped_corres:
   "corres (=) (pte_at slot) ((\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and pspace_aligned' and pspace_distinct') (pte_check_if_mapped slot) (pteCheckIfMapped slot)"
   apply (simp add: pte_check_if_mapped_def pteCheckIfMapped_def)
     apply (rule corres_guard_imp)
@@ -2609,7 +2609,7 @@ lemma pte_check_if_mapped_corres:
   apply simp
   done
 
-lemma pde_check_if_mapped_corres:
+lemma pdeCheckIfMapped_corres:
   "corres (=) (pde_at slot) ((\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and pspace_aligned' and pspace_distinct') (pde_check_if_mapped slot) (pdeCheckIfMapped slot)"
   apply (simp add: pde_check_if_mapped_def pdeCheckIfMapped_def)
     apply (rule corres_guard_imp)
@@ -2695,14 +2695,14 @@ lemma message_info_from_data_eqv:
                  msgLengthBits_def msgExtraCapBits_def msgMaxExtraCaps_def mask_def
                  shiftL_nat msgMaxLength_def msgLabelBits_def)
 
-lemma set_mi_corres:
+lemma setMessageInfo_corres:
  "mi' = message_info_map mi \<Longrightarrow>
   corres dc (tcb_at t) (tcb_at' t)
          (set_message_info t mi) (setMessageInfo t mi')"
   apply (simp add: setMessageInfo_def set_message_info_def)
   apply (subgoal_tac "wordFromMessageInfo (message_info_map mi) =
                       message_info_to_data mi")
-   apply (simp add: user_setreg_corres msg_info_register_def
+   apply (simp add: asUser_setRegister_corres msg_info_register_def
                     msgInfoRegister_def)
   apply (simp add: message_info_to_data_eqv)
   done
@@ -2770,7 +2770,7 @@ lemma valid_slots_duplicated'_length_Inr:
            dest: is_aligned_no_overflow'
           split: pde.splits)
 
-lemma perform_page_corres:
+lemma performPageInvocation_corres:
   assumes "page_invocation_map pgi pgi'"
   shows "corres dc (invs and valid_etcbs and valid_page_inv pgi)
             (invs' and valid_page_inv' pgi' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
@@ -2804,8 +2804,8 @@ proof -
            apply (fastforce split: pte.splits)
           apply (clarsimp simp: mapM_Cons bind_assoc split del: if_split)
           apply (rule corres_guard_imp)
-            apply (rule corres_split_deprecated[OF _ pte_check_if_mapped_corres])
-              apply (rule corres_split_deprecated[OF _ store_pte_corres'])
+            apply (rule corres_split_deprecated[OF _ pteCheckIfMapped_corres])
+              apply (rule corres_split_deprecated[OF _ storePTE_corres'])
                  apply (rule corres_split_deprecated[where r' = dc, OF _ corres_store_pte_with_invalid_tail])
                      apply (rule corres_split_deprecated[where r'=dc, OF _ corres_machine_op[OF corres_Id]])
                           apply (clarsimp simp add: when_def)
@@ -2861,8 +2861,8 @@ proof -
           apply (fastforce split: pde.splits)
          apply (clarsimp simp:mapM_Cons bind_assoc split del:if_split)
          apply (rule corres_guard_imp)
-           apply (rule corres_split_deprecated[OF _ pde_check_if_mapped_corres])
-             apply (rule corres_split_deprecated[OF _ store_pde_corres'])
+           apply (rule corres_split_deprecated[OF _ pdeCheckIfMapped_corres])
+             apply (rule corres_split_deprecated[OF _ storePDE_corres'])
                 apply (rule corres_split_deprecated[where r'=dc, OF _ corres_store_pde_with_invalid_tail])
                     apply (rule corres_split_deprecated[where r'=dc,OF _ corres_machine_op[OF corres_Id]])
                          apply (clarsimp simp: when_def)
@@ -2955,7 +2955,7 @@ proof -
     apply (rule corres_guard_imp)
       apply (rule corres_split_deprecated)
          prefer 2
-         apply (rule unmap_page_corres)
+         apply (rule unmapPage_corres)
         apply (rule corres_split_deprecated [where r'=acap_relation])
            prefer 2
            apply simp
@@ -2982,14 +2982,14 @@ proof -
                          page_invocation_map_def)
    apply (rule corres_guard_imp)
      apply (rule corres_when, simp)
-     apply (rule corres_split_deprecated [OF _ set_vm_root_for_flush_corres])
+     apply (rule corres_split_deprecated [OF _ setVMRootForFlush_corres])
        apply (rule corres_split_deprecated [OF _ corres_machine_op])
           prefer 2
-          apply (rule do_flush_corres)
+          apply (rule doFlush_corres)
          apply (rule corres_when, simp)
-         apply (rule corres_split_deprecated [OF _ gct_corres])
+         apply (rule corres_split_deprecated [OF _ getCurThread_corres])
            apply simp
-           apply (rule set_vm_root_corres)
+           apply (rule setVMRoot_corres)
           apply wp+
         apply (simp add: cur_tcb_def [symmetric] cur_tcb'_def [symmetric])
         apply (wp hoare_drop_imps)
@@ -2999,9 +2999,9 @@ proof -
   \<comment> \<open>PageGetAddr\<close>
   apply (clarsimp simp: perform_page_invocation_def performPageInvocation_def page_invocation_map_def fromPAddr_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply simp
-      apply (rule corres_split_deprecated[OF set_mi_corres set_mrs_corres])
+      apply (rule corres_split_deprecated[OF setMessageInfo_corres setMRs_corres])
          apply (simp add: message_info_map_def)
         apply clarsimp
        apply (wp)+
@@ -3054,7 +3054,7 @@ lemma clear_page_table_corres:
                and Q="\<lambda>xs s. \<forall>x \<in> set xs. pte_at x s \<and> pspace_aligned s \<and> valid_etcbs s"
                and Q'="\<lambda>xs. pspace_aligned' and pspace_distinct'"
                 in corres_mapM_list_all2, simp_all)
-      apply (rule corres_guard_imp, rule store_pte_corres')
+      apply (rule corres_guard_imp, rule storePTE_corres')
         apply (simp add:pte_relation_aligned_def)+
      apply (wp hoare_vcg_const_Ball_lift | simp)+
    apply (simp add: list_all2_refl)
@@ -3067,7 +3067,7 @@ lemma clear_page_table_corres:
 crunch typ_at'[wp]: unmapPageTable "\<lambda>s. P (typ_at' T p s)"
 lemmas unmapPageTable_typ_ats[wp] = typ_at_lifts[OF unmapPageTable_typ_at']
 
-lemma perform_page_table_corres:
+lemma performPageTableInvocation_corres:
   "page_table_invocation_map pti pti' \<Longrightarrow>
    corres dc
           (invs and valid_etcbs and valid_pti pti)
@@ -3082,7 +3082,7 @@ lemma perform_page_table_corres:
       apply (rule corres_split_deprecated [OF _ updateCap_same_master])
          prefer 2
          apply assumption
-        apply (rule corres_split_deprecated [OF _ store_pde_corres'])
+        apply (rule corres_split_deprecated [OF _ storePDE_corres'])
            apply (rule corres_machine_op)
            apply (rule corres_Id, rule refl, simp)
            apply (rule no_fail_cleanByVA_PoU)
@@ -3112,7 +3112,7 @@ lemma perform_page_table_corres:
          apply (clarsimp simp: is_pt_cap_def update_map_data_def)
         apply (wp get_cap_wp)+
       apply (rule corres_if[OF refl])
-       apply (rule corres_split_deprecated [OF _ unmap_page_table_corres])
+       apply (rule corres_split_deprecated [OF _ unmapPageTable_corres])
          apply (rule corres_split_nor)
             apply (rule corres_machine_op, rule corres_Id)
               apply simp+
@@ -3155,7 +3155,7 @@ definition (* ARMHYP: need review *)
   | VCPUWriteRegister v _ _ \<Rightarrow> vcpu_at' v
   | VCPUAckVPPI v _ \<Rightarrow> vcpu_at' v"
 
-lemma pap_corres:
+lemma performASIDPoolInvocation_corres:
   "ap' = asid_pool_invocation_map ap \<Longrightarrow>
   corres dc
           (valid_objs and pspace_aligned and pspace_distinct and valid_apinv ap and valid_etcbs)
@@ -3182,7 +3182,7 @@ lemma pap_corres:
            apply simp
           apply (rule corres_rel_imp)
            apply simp
-           apply (rule set_asid_pool_corres)
+           apply (rule setObject_ASIDPool_corres)
            apply (simp add: inv_def)
            apply (rule ext)
            apply (clarsimp simp: mask_asid_low_bits_ucast_ucast)

--- a/proof/refine/RISCV64/Bits_R.thy
+++ b/proof/refine/RISCV64/Bits_R.thy
@@ -172,13 +172,13 @@ lemma tcb_in_valid_state':
   apply (fastforce simp add: valid_obj'_def valid_tcb'_def)
   done
 
-lemma gct_corres: "corres (=) \<top> \<top> (gets cur_thread) getCurThread"
+lemma getCurThread_corres: "corres (=) \<top> \<top> (gets cur_thread) getCurThread"
   by (simp add: getCurThread_def curthread_relation)
 
 lemma gct_wp [wp]: "\<lbrace>\<lambda>s. P (ksCurThread s) s\<rbrace> getCurThread \<lbrace>P\<rbrace>"
   by (unfold getCurThread_def, wp)
 
-lemma git_corres:
+lemma getIdleThread_corres:
   "corres (=) \<top> \<top> (gets idle_thread) getIdleThread"
   by (simp add: getIdleThread_def state_relation_def)
 

--- a/proof/refine/RISCV64/CNodeInv_R.thy
+++ b/proof/refine/RISCV64/CNodeInv_R.thy
@@ -155,7 +155,7 @@ lemma cancelSendRightsEq:
                   split: cap.splits bool.splits if_splits |
          case_tac x)+
 
-lemma dec_cnode_inv_corres:
+lemma decodeCNodeInvocation_corres:
   "\<lbrakk> cap_relation (cap.CNodeCap w n list) cap'; list_all2 cap_relation cs cs';
      length list \<le> 64 \<rbrakk> \<Longrightarrow>
   corres
@@ -174,9 +174,9 @@ lemma dec_cnode_inv_corres:
                    split del: if_split
                         cong: if_cong list.case_cong)
         apply (rule corres_guard_imp)
-          apply (rule corres_splitEE [OF _ lsfc_corres])
-              apply (rule corres_splitEE [OF _ ensure_empty_corres])
-                 apply (rule corres_splitEE [OF _ lsfc_corres])
+          apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
+              apply (rule corres_splitEE [OF _ ensureEmptySlot_corres])
+                 apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
                      apply (simp(no_asm) add: liftE_bindE del: de_Morgan_conj split del: if_split)
                      apply (rule corres_split_deprecated [OF _ get_cap_corres'])
                         prefer 2
@@ -198,7 +198,7 @@ lemma dec_cnode_inv_corres:
                              prefer 2
                              apply (simp add: returnOk_def del: imp_disjL)
                              apply (rule conjI[rotated], rule impI)
-                              apply (rule derive_cap_corres)
+                              apply (rule deriveCap_corres)
                                apply (clarsimp simp: cap_relation_mask
                                                      cap_map_update_data
                                               split: option.split)
@@ -216,7 +216,7 @@ lemma dec_cnode_inv_corres:
        \<comment> \<open>Revoke\<close>
        apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                         isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
-       apply (rule corres_guard_imp, rule corres_splitEE [OF _ lsfc_corres])
+       apply (rule corres_guard_imp, rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
              apply (simp add: split_beta)
              apply (rule corres_returnOkTT)
              apply simp
@@ -229,7 +229,7 @@ lemma dec_cnode_inv_corres:
       apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                        isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
       apply (rule corres_guard_imp)
-        apply (rule corres_splitEE [OF _ lsfc_corres])
+        apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
             apply (simp add: split_beta)
             apply (rule corres_returnOkTT)
             apply simp
@@ -242,12 +242,12 @@ lemma dec_cnode_inv_corres:
      apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                       isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
      apply (rule corres_guard_imp)
-       apply (rule corres_splitEE [OF _ lsfc_corres])
+       apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
            apply (simp add: split_beta)
            apply (rule corres_split_norE)
               apply (rule corres_returnOkTT)
               apply simp
-             apply (rule ensure_empty_corres)
+             apply (rule ensureEmptySlot_corres)
              apply simp
             apply wp+
            apply simp
@@ -260,7 +260,7 @@ lemma dec_cnode_inv_corres:
     apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                      isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
     apply (rule corres_guard_imp)
-      apply (rule corres_splitEE [OF _ lsfc_corres])
+      apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
           apply (simp(no_asm) add: split_beta liftE_bindE)
           apply (rule corres_split_deprecated [OF _ get_cap_corres'])
              apply (rule corres_split_norE)
@@ -279,9 +279,9 @@ lemma dec_cnode_inv_corres:
    apply (simp add: le_diff_conv2 split_def decode_cnode_invocation_def decodeCNodeInvocation_def
                     isCap_simps Let_def unlessE_whenE whenE_whenE_body
                del: disj_not1 ser_def split del: if_split)
-   apply (rule corres_guard_imp, rule corres_splitEE [OF _ lsfc_corres])
+   apply (rule corres_guard_imp, rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
          apply (rename_tac dest_slot destSlot)
-         apply (rule corres_splitEE [OF _ lsfc_corres])+
+         apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])+
                  apply (rule_tac R = "\<lambda>s. cte_at pivot_slot s \<and> cte_at dest_slot s
                                         \<and> cte_at src_slot s \<and> invs s" in
                    whenE_throwError_corres' [where R' = \<top>])
@@ -321,7 +321,7 @@ lemma dec_cnode_inv_corres:
                     apply (drule (2) cte_map_inj_eq, clarsimp+)[1]
                    apply (rule corres_guard_imp)
                      apply (erule corres_whenE)
-                      apply (rule ensure_empty_corres)
+                      apply (rule ensureEmptySlot_corres)
                       apply clarsimp
                      apply simp
                     apply clarsimp
@@ -355,7 +355,7 @@ lemma dec_cnode_inv_corres:
                          cnode_invok_case_cleanup
               split del: if_split cong: if_cong)
    apply (rule corres_guard_imp)
-     apply (rule corres_splitEE[OF _ lsfc_corres])
+     apply (rule corres_splitEE[OF _ lookupSlotForCNodeOp_corres])
          apply (rule corres_trivial, clarsimp split: list.split_asm)
         apply simp+
       apply wp+
@@ -365,7 +365,7 @@ lemma dec_cnode_inv_corres:
                         isCNodeCap_CNodeCap split_def unlessE_whenE
              split del: if_split cong: if_cong)
   apply (rule corres_guard_imp)
-   apply (rule corres_splitEE [OF _ lsfc_corres wp_post_tautE wp_post_tautE])
+   apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres wp_post_tautE wp_post_tautE])
      apply (clarsimp simp: list_all2_Cons1 list_all2_Nil
                     split: list.split_asm split del: if_split)
      apply simp
@@ -6954,7 +6954,7 @@ proof (induct rule: rec_del.induct,
                                  whenE_liftE)
         apply (rule corres_when, simp)
         apply simp
-        apply (rule empty_slot_corres)
+        apply (rule emptySlot_corres)
        apply (wp rec_del_invs rec_del_valid_list rec_del_cte_at finaliseSlot_invs hoare_drop_imps
                  preemption_point_inv'
             | simp)+
@@ -6980,10 +6980,10 @@ next
                 simp add: returnOk_def)
         apply (rule spec_corres_splitE')
            apply simp
-           apply (rule final_cap_corres[where ptr=slot])
+           apply (rule isFinalCapability_corres[where ptr=slot])
           apply (rule spec_corres_splitE')
              apply simp
-             apply (rule finalise_cap_corres[where sl=slot])
+             apply (rule finaliseCap_corres[where sl=slot])
                apply simp
               apply simp
              apply simp
@@ -7001,13 +7001,13 @@ next
                apply (erule conjunct2)
               apply (rule drop_spec_corres,
                      simp add: liftME_def[symmetric] o_def dc_def[symmetric])
-              apply (rule cap_update_corres)
+              apply (rule updateCap_corres)
                apply simp
               apply (simp(no_asm_use) add: cap_cyclic_zombie_def split: cap.split_asm)
               apply (simp add: is_cap_simps)
              apply (rule spec_corres_splitE')
                 apply simp
-                apply (rule cap_update_corres, erule conjunct1)
+                apply (rule updateCap_corres, erule conjunct1)
                 apply (case_tac "fst rvb", auto simp: isCap_simps is_cap_simps)[1]
                apply (rule spec_corres_splitE)
                   apply (rule iffD1 [OF spec_corres_liftME2[where fn="\<lambda>v. (True, NullCap)"]])
@@ -7016,7 +7016,7 @@ next
                    apply (rename_tac nat)
                    apply (case_tac nat, simp_all)[1]
                   apply clarsimp
-                 apply (rule spec_corres_splitE'[OF preemption_corres])
+                 apply (rule spec_corres_splitE'[OF preemptionPoint_corres])
                    apply (rule "2.hyps"(2)[unfolded fun_app_def rec_del_concrete_unfold
                                                     finaliseSlot_def],
                           assumption+)
@@ -7139,7 +7139,7 @@ next
        apply (clarsimp simp: cte_wp_at_def)
        apply (drule(1) zombies_finalD2, clarsimp+)
       apply (fold dc_def)
-      apply (rule corres_guard_imp, rule cap_swap_for_delete_corres)
+      apply (rule corres_guard_imp, rule capSwapForDelete_corres)
          apply (simp add: cte_map_replicate)
         apply simp
        apply clarsimp
@@ -7222,7 +7222,7 @@ next
              apply (rule corres_symb_exec_r)
                 apply (rule_tac F="cteCap endCTE = capability.NullCap"
                             in corres_gen_asm2, simp)
-                apply (rule cap_update_corres)
+                apply (rule updateCap_corres)
                  apply simp
                 apply (simp add: is_cap_simps)
                apply (rule_tac Q="\<lambda>rv. cte_at' (cte_map ?target)" in valid_prove_more)
@@ -7318,7 +7318,7 @@ next
     done
 qed
 
-lemma cap_delete_corres:
+lemma cteDelete_corres:
   "corres (dc \<oplus> dc)
       (einvs and simple_sched_action and cte_at ptr and emptyable ptr)
       (invs' and sch_act_simple and cte_at' (cte_map ptr))
@@ -7567,7 +7567,7 @@ lemma cap_revoke_mdb_stuff4:
        apply(simp add: cte_wp_at_def)+
        done
 
-lemma cap_revoke_corres':
+lemma cteRevoke_corres':
   "spec_corres s (dc \<oplus> dc)
       (einvs and simple_sched_action and cte_at ptr)
       (invs' and sch_act_simple and cte_at' (cte_map ptr))
@@ -7689,8 +7689,8 @@ proof (induct rule: cap_revoke.induct)
      apply (rule cap_revoke_mdb_stuff4, (simp add: in_get_cap_cte_wp_at)+)
     apply (clarsimp simp: whenE_def)
     apply (rule spec_corres_guard_imp)
-      apply (rule spec_corres_splitE' [OF cap_delete_corres])
-        apply (rule spec_corres_splitE' [OF preemption_corres])
+      apply (rule spec_corres_splitE' [OF cteDelete_corres])
+        apply (rule spec_corres_splitE' [OF preemptionPoint_corres])
           apply (rule "1.hyps",
                    (simp add: cte_wp_at_def in_monad select_def next_revoke_cap_def select_ext_def
                      | assumption | rule conjI refl)+)[1]
@@ -7704,7 +7704,7 @@ proof (induct rule: cap_revoke.induct)
     done
 qed
 
-lemmas cap_revoke_corres = use_spec_corres [OF cap_revoke_corres']
+lemmas cteRevoke_corres = use_spec_corres [OF cteRevoke_corres']
 
 lemma arch_recycleCap_improve_cases:
    "\<lbrakk> \<not> isFrameCap cap; \<not> isPageTableCap cap;
@@ -8653,7 +8653,7 @@ lemma corres_null_cap_update:
      apply (rule corres_guard_imp, rule getCTE_symb_exec_r, simp+)
     prefer 3
     apply clarsimp
-    apply (rule set_cap_pspace_corres)
+    apply (rule setCTE_corres)
     apply (wp | simp)+
    apply (fastforce elim!: cte_wp_at_weakenE)
   apply wp
@@ -8662,7 +8662,7 @@ lemma corres_null_cap_update:
 
 declare corres_False' [simp]
 
-lemma inv_cnode_corres:
+lemma invokeCNode_corres:
   "cnodeinv_relation ci ci' \<Longrightarrow>
    corres (dc \<oplus> dc)
      (einvs and simple_sched_action and valid_cnode_inv ci)
@@ -8672,18 +8672,18 @@ lemma inv_cnode_corres:
   apply (cases ci, simp_all)
         apply clarsimp
         apply (rule corres_guard_imp)
-          apply (rule cins_corres)
+          apply (rule cteInsert_corres)
             apply simp+
          apply (clarsimp simp: invs_def valid_state_def valid_pspace_def
                         elim!: cte_wp_at_cte_at)
         apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
        apply clarsimp
        apply (rule corres_guard_imp)
-         apply (erule cap_move_corres)
+         apply (erule cteMove_corres)
         apply (clarsimp simp: cte_wp_at_caps_of_state real_cte_tcb_valid)
        apply (clarsimp simp: cte_wp_at_ctes_of)
-       apply (rule cap_revoke_corres)
-     apply (rule corres_guard_imp [OF cap_delete_corres])
+       apply (rule cteRevoke_corres)
+     apply (rule corres_guard_imp [OF cteDelete_corres])
       apply (clarsimp simp: cte_at_typ cap_table_at_typ halted_emptyable)
      apply simp
     apply (rename_tac cap1 cap2 p1 p2 p3)
@@ -8693,7 +8693,7 @@ lemma inv_cnode_corres:
      apply (rule corres_guard_imp)
        apply (rule_tac F="wellformed_cap cap1 \<and> wellformed_cap cap2"
               in corres_gen_asm)
-       apply (erule (1) cap_swap_corres [OF refl refl], simp+)
+       apply (erule (1) cteSwap_corres [OF refl refl], simp+)
       apply (simp add: invs_def valid_state_def valid_pspace_def
                        real_cte_tcb_valid valid_cap_def2)
      apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
@@ -8708,9 +8708,9 @@ lemma inv_cnode_corres:
      apply simp
     apply simp
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF cap_move_corres])
+      apply (rule corres_split_deprecated [OF cteMove_corres])
          apply assumption
-        apply (erule cap_move_corres)
+        apply (erule cteMove_corres)
        apply wp
        apply (simp add: cte_wp_at_caps_of_state)
        apply (wp cap_move_caps_of_state cteMove_cte_wp_at [simplified o_def])+
@@ -8736,7 +8736,7 @@ lemma inv_cnode_corres:
    apply (rename_tac prod)
    apply (simp add: getThreadCallerSlot_def locateSlot_conv objBits_simps)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated [OF _ gct_corres])
+     apply (rule corres_split_deprecated [OF _ getCurThread_corres])
         apply (subgoal_tac "thread + 2^cte_level_bits * tcbCallerSlot = cte_map (thread, tcb_cnode_index 3)")
          prefer 2
          apply (simp add: cte_map_def tcb_cnode_index_def tcbCallerSlot_def cte_level_bits_def)
@@ -8756,7 +8756,7 @@ lemma inv_cnode_corres:
             apply (case_tac cap, simp_all add: isCap_simps is_cap_simps split: bool.split)[1]
             apply clarsimp
             apply (rule corres_guard_imp)
-              apply (rule cap_move_corres)
+              apply (rule cteMove_corres)
               apply (simp add: real_cte_tcb_valid)+
         apply (wp get_cap_wp)
        apply (simp add: getSlotCap_def)
@@ -8786,7 +8786,7 @@ lemma inv_cnode_corres:
                 simp add: is_cap_simps)
    apply (clarsimp simp: when_def unless_def isCap_simps)
    apply (rule corres_guard_imp)
-     apply (rule cancel_badged_sends_corres)
+     apply (rule cancelBadgedSends_corres)
     apply (simp add: valid_cap_def)
    apply (simp add: valid_cap'_def)
   apply (clarsimp)

--- a/proof/refine/RISCV64/CSpace1_R.thy
+++ b/proof/refine/RISCV64/CSpace1_R.thy
@@ -707,7 +707,7 @@ lemma getSlotCap_tcb_corres:
   apply (simp add: o_def cte_map_def tcb_cnode_index_def)
   done
 
-lemma lookup_slot_corres:
+lemma lookupSlotForThread_corres:
   "corres (lfr \<oplus> (\<lambda>(cref, bits) cref'. cref' = cte_map cref))
         (valid_objs and pspace_aligned and tcb_at t)
         (valid_objs' and pspace_aligned' and pspace_distinct' and tcb_at' t)
@@ -766,7 +766,7 @@ lemma lookupSlot_inv[wp]:
   apply (wp | simp add: split_def)+
   done
 
-lemma lc_corres:
+lemma lookupCap_corres:
  "corres (lfr \<oplus> cap_relation)
          (valid_objs and pspace_aligned and tcb_at t)
          (valid_objs' and pspace_aligned' and pspace_distinct' and tcb_at' t)
@@ -774,7 +774,7 @@ lemma lc_corres:
   apply (simp add: lookup_cap_def lookupCap_def bindE_assoc
                    lookupCapAndSlot_def liftME_def split_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_splitEE[OF _ lookup_slot_corres])
+    apply (rule corres_splitEE[OF _ lookupSlotForThread_corres])
       apply (simp add: split_def getSlotCap_def liftM_def[symmetric] o_def)
       apply (rule get_cap_corres)
      apply (rule hoare_pre, wp lookup_slot_cte_at_wp|simp)+
@@ -2413,7 +2413,7 @@ lemma pspace_relationsD:
   "\<lbrakk>pspace_relation kh kh'; ekheap_relation ekh kh'\<rbrakk> \<Longrightarrow> pspace_relations ekh kh kh'"
   by (simp add: pspace_relations_def)
 
-lemma cap_update_corres:
+lemma updateCap_corres:
   "\<lbrakk>cap_relation cap cap';
     is_zombie cap \<or> is_cnode_cap cap \<or> is_thread_cap cap \<rbrakk>
    \<Longrightarrow> corres dc (\<lambda>s. invs s \<and>
@@ -3792,7 +3792,7 @@ lemma updateUntypedCap_descendants_of:
   apply (clarsimp simp:mdb_next_rel_def mdb_next_def split:if_splits)
   done
 
-lemma set_untyped_cap_corres:
+lemma setCTE_UntypedCap_corres:
   "\<lbrakk>cap_relation cap (cteCap cte); is_untyped_cap cap; idx' = idx\<rbrakk>
    \<Longrightarrow> corres dc (cte_wp_at ((=) cap) src and valid_objs and
                   pspace_aligned and pspace_distinct)
@@ -3885,7 +3885,7 @@ lemma getCTE_get:
   apply (clarsimp simp:cte_wp_at_ctes_of)
   done
 
-lemma set_untyped_cap_as_full_corres:
+lemma setUntypedCapAsFull_corres:
   "\<lbrakk>cap_relation c c'; src' = cte_map src; dest' = cte_map dest;
     cap_relation src_cap (cteCap srcCTE); rv = cap.NullCap;
     cteCap rv' = capability.NullCap; mdbPrev (cteMDBNode rv') = nullPointer \<and>
@@ -3904,7 +3904,7 @@ lemma set_untyped_cap_as_full_corres:
         apply (rule corres_symb_exec_r)
            apply (rule_tac F="cte = srcCTE" in corres_gen_asm2)
            apply (simp)
-           apply (rule set_untyped_cap_corres)
+           apply (rule setCTE_UntypedCap_corres)
              apply simp+
            apply (clarsimp simp:free_index_update_def isCap_simps is_cap_simps)
            apply (subst identity_eq)
@@ -5122,7 +5122,7 @@ lemma cte_map_inj_eq':
   done
 
 context begin interpretation Arch . (*FIXME: arch_split*)
-lemma cins_corres:
+lemma cteInsert_corres:
   notes split_paired_All[simp del] split_paired_Ex[simp del]
         trans_state_update'[symmetric,simp]
   assumes "cap_relation c c'" "src' = cte_map src" "dest' = cte_map dest"
@@ -5555,7 +5555,7 @@ lemma cins_corres:
               apply (erule (5) cte_map_inj)
 (* FIXME *)
 
-             apply (rule set_untyped_cap_as_full_corres)
+             apply (rule setUntypedCapAsFull_corres)
                    apply simp+
             apply (wp set_untyped_cap_full_valid_objs set_untyped_cap_as_full_valid_mdb
                set_untyped_cap_as_full_cte_wp_at setUntypedCapAsFull_valid_cap
@@ -6563,7 +6563,7 @@ corres_underlying srel nf rrel G G' (do do_extended_op (return ()); g od) (g')"
   done
 *)
 
-(* consider putting in AINVS or up above cins_corres *)
+(* consider putting in AINVS or up above cteInsert_corres *)
 lemma next_slot_eq:
   "\<lbrakk>next_slot p t' m' = x; t' = t; m' = m\<rbrakk> \<Longrightarrow> next_slot p t m = x"
   by simp
@@ -6572,7 +6572,7 @@ lemma inj_on_image_set_diff15 : (* for compatibility of assumptions *)
   "\<lbrakk>inj_on f C; A \<subseteq> C; B \<subseteq> C\<rbrakk> \<Longrightarrow> f ` (A - B) = f ` A - f ` B"
 by (rule inj_on_image_set_diff; auto)
 
-lemma cap_swap_corres:
+lemma cteSwap_corres:
   assumes srcdst: "src' = cte_map src" "dest' = cte_map dest"
   assumes scr: "cap_relation scap scap'"
   assumes dcr: "cap_relation dcap dcap'"
@@ -7025,7 +7025,7 @@ lemma cap_swap_corres:
      done
 
 
-lemma cap_swap_for_delete_corres:
+lemma capSwapForDelete_corres:
   assumes "src' = cte_map src" "dest' = cte_map dest"
   shows "corres dc
          (valid_objs and pspace_aligned and pspace_distinct and
@@ -7046,7 +7046,7 @@ lemma cap_swap_for_delete_corres:
   apply (rule corres_guard_imp)
     apply (rule_tac P1=wellformed_cap in corres_split_deprecated [OF _ get_cap_corres_P])
       apply (rule_tac P1=wellformed_cap in corres_split_deprecated [OF _ get_cap_corres_P])
-        apply (rule cap_swap_corres, rule refl, rule refl, clarsimp+)
+        apply (rule cteSwap_corres, rule refl, rule refl, clarsimp+)
        apply (wp get_cap_wp getCTE_wp')+
    apply (clarsimp simp: cte_wp_at_caps_of_state)
    apply (drule (1) caps_of_state_valid_cap)+
@@ -7080,7 +7080,7 @@ lemma subtree_no_parent:
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma ensure_no_children_corres:
+lemma ensureNoChildren_corres:
   "p' = cte_map p \<Longrightarrow>
   corres (ser \<oplus> dc) (cte_at p) (pspace_aligned' and pspace_distinct' and cte_at' p' and valid_mdb')
          (ensure_no_children p) (ensureNoChildren p')"

--- a/proof/refine/RISCV64/CSpace_R.thy
+++ b/proof/refine/RISCV64/CSpace_R.thy
@@ -735,7 +735,7 @@ lemma set_cap_not_quite_corres':
                 done
 
 context begin interpretation Arch . (*FIXME: arch_split*)
-lemma cap_move_corres:
+lemma cteMove_corres:
   assumes cr: "cap_relation cap cap'"
   notes trans_state_update'[symmetric,simp]
   shows
@@ -3276,7 +3276,7 @@ lemma cteInsert_invs:
   apply (auto simp: invs'_def valid_state'_def valid_pspace'_def elim: valid_capAligned)
   done
 
-lemma derive_cap_corres:
+lemma deriveCap_corres:
  "\<lbrakk>cap_relation c c'; cte = cte_map slot \<rbrakk> \<Longrightarrow>
   corres (ser \<oplus> cap_relation)
          (cte_at slot)
@@ -3287,14 +3287,14 @@ lemma derive_cap_corres:
             apply (simp_all add: returnOk_def Let_def is_zombie_def isCap_simps
                           split: sum.splits)
    apply (rule_tac Q="\<lambda>_ _. True" and Q'="\<lambda>_ _. True" in
-               corres_initial_splitE [OF ensure_no_children_corres])
+               corres_initial_splitE [OF ensureNoChildren_corres])
       apply simp
      apply clarsimp
     apply wp+
   apply clarsimp
   apply (rule corres_rel_imp)
    apply (rule corres_guard_imp)
-     apply (rule arch_derive_corres)
+     apply (rule arch_deriveCap_corres)
      apply (clarsimp simp: o_def)+
   done
 
@@ -3380,7 +3380,7 @@ lemma lookup_cap_corres:
      (lookupCap thread epcptr')"
   apply (simp add: lookup_cap_def lookupCap_def lookupCapAndSlot_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_splitEE [OF _ lookup_slot_corres])
+    apply (rule corres_splitEE [OF _ lookupSlotForThread_corres])
       apply (simp add: split_def)
       apply (subst bindE_returnOk[symmetric])
       apply (rule corres_splitEE)
@@ -3393,7 +3393,7 @@ lemma lookup_cap_corres:
    apply auto
   done
 
-lemma ensure_empty_corres:
+lemma ensureEmptySlot_corres:
   "q = cte_map p \<Longrightarrow>
    corres (ser \<oplus> dc) (invs and cte_at p) invs'
                      (ensure_empty p) (ensureEmptySlot q)"
@@ -3411,7 +3411,7 @@ lemma ensureEmpty_inv[wp]:
   "\<lbrace>P\<rbrace> ensureEmptySlot p \<lbrace>\<lambda>rv. P\<rbrace>"
   by (simp add: ensureEmptySlot_def unlessE_whenE whenE_def | wp)+
 
-lemma lsfc_corres:
+lemma lookupSlotForCNodeOp_corres:
   "\<lbrakk>cap_relation c c'; ptr = to_bl ptr'\<rbrakk>
   \<Longrightarrow> corres (ser \<oplus> (\<lambda>cref cref'. cref' = cte_map cref))
             (valid_objs and pspace_aligned and valid_cap c)
@@ -3507,7 +3507,7 @@ lemma deriveCap_untyped_derived:
   apply (clarsimp simp: cte_wp_at_ctes_of isCap_simps untyped_derived_eq_def)
   done
 
-lemma set_cap_pspace_corres:
+lemma setCTE_corres:
   "cap_relation cap (cteCap cte) \<Longrightarrow>
    corres_underlying {(s, s'). pspace_relations (ekheap (s)) (kheap s) (ksPSpace s')} False True dc
       (pspace_distinct and pspace_aligned and valid_objs and cte_at p)
@@ -3821,7 +3821,7 @@ lemma create_reply_master_corres:
     apply (clarsimp elim!: state_relationE simp: ghost_relation_of_heap)+
   apply (rule corres_guard_imp)
     apply (rule corres_underlying_symb_exec_l [OF set_original_symb_exec_l'])
-     apply (rule set_cap_pspace_corres)
+     apply (rule setCTE_corres)
      apply simp
     apply wp
    apply (clarsimp simp: cte_wp_at_cte_at valid_pspace_def)
@@ -3914,7 +3914,7 @@ proof -
     by (simp add: noReplyCapsFor_def)
 qed
 
-lemma setup_reply_master_corres:
+lemma setupReplyMaster_corres:
   "corres dc (einvs and tcb_at t) (invs' and tcb_at' t)
        (setup_reply_master t) (setupReplyMaster t)"
   apply (simp add: setupReplyMaster_def setup_reply_master_def)
@@ -4681,7 +4681,7 @@ lemma maskedAsFull_revokable_safe_parent:
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma cins_corres_simple:
+lemma cteInsert_simple_corres:
   assumes "cap_relation c c'" "src' = cte_map src" "dest' = cte_map dest"
   notes trans_state_update'[symmetric,simp]
   shows "corres dc
@@ -4828,7 +4828,7 @@ lemma cins_corres_simple:
          apply (subgoal_tac "cte_map (aa,bb) \<noteq> cte_map dest")
           subgoal by (clarsimp simp: modify_map_def split: if_split_asm)
          apply (erule (5) cte_map_inj)
-         apply (rule set_untyped_cap_as_full_corres)
+         apply (rule setUntypedCapAsFull_corres)
          apply simp+
           apply (wp set_untyped_cap_full_valid_objs set_untyped_cap_as_full_valid_mdb set_untyped_cap_as_full_valid_list
              set_untyped_cap_as_full_cte_wp_at setUntypedCapAsFull_valid_cap
@@ -4884,7 +4884,7 @@ lemma cins_corres_simple:
    apply clarsimp
    apply (drule (5) cte_map_inj)+
    apply simp
-  (* exact reproduction of proof in cins_corres,
+  (* exact reproduction of proof in cteInsert_corres,
      as it does not used is_derived *)
   apply(simp add: cdt_list_relation_def del: split_paired_All split_paired_Ex)
   apply(subgoal_tac "no_mloop (cdt a) \<and> finite_depth (cdt a)")

--- a/proof/refine/RISCV64/Detype_R.thy
+++ b/proof/refine/RISCV64/Detype_R.thy
@@ -577,7 +577,7 @@ lemma sym_refs_hyp_refs_triv[simp]: "sym_refs (state_hyp_refs_of s)"
   apply (clarsimp simp: state_hyp_refs_of_def sym_refs_def)
   by (case_tac "kheap s x"; simp)
 
-lemma detype_corres:
+lemma deleteObjects_corres:
   "is_aligned base magnitude \<Longrightarrow> magnitude \<ge> 3 \<Longrightarrow>
    corres dc
       (\<lambda>s. einvs s

--- a/proof/refine/RISCV64/InterruptAcc_R.thy
+++ b/proof/refine/RISCV64/InterruptAcc_R.thy
@@ -8,7 +8,7 @@ theory InterruptAcc_R
 imports TcbAcc_R
 begin
 
-lemma get_irq_slot_corres:
+lemma getIRQSlot_corres:
   "corres (\<lambda>sl sl'. sl' = cte_map sl) \<top> \<top> (get_irq_slot irq) (getIRQSlot irq)"
   apply (simp add: getIRQSlot_def get_irq_slot_def locateSlot_conv
                    liftM_def[symmetric])
@@ -20,7 +20,7 @@ lemma get_irq_slot_corres:
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma set_irq_state_corres:
+lemma setIRQState_corres:
   "irq_state_relation state state' \<Longrightarrow>
    corres dc \<top> \<top> (set_irq_state state irq) (setIRQState state' irq)"
   apply (simp add: set_irq_state_def setIRQState_def
@@ -94,7 +94,7 @@ lemma work_units_and_irq_state_state_relationI [intro!]:
    \<in> state_relation"
   by (simp add: state_relation_def swp_def)
 
-lemma preemption_corres:
+lemma preemptionPoint_corres:
   "corres (dc \<oplus> dc) \<top> \<top> preemption_point preemptionPoint"
   apply (simp add: preemption_point_def preemptionPoint_def)
   by (auto simp: preemption_point_def preemptionPoint_def o_def gets_def liftE_def whenE_def getActiveIRQ_def

--- a/proof/refine/RISCV64/Interrupt_R.thy
+++ b/proof/refine/RISCV64/Interrupt_R.thy
@@ -97,7 +97,7 @@ where
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma decode_irq_handler_corres:
+lemma decodeIRQHandlerInvocation_corres:
   "\<lbrakk> list_all2 cap_relation (map fst caps) (map fst caps');
     list_all2 (\<lambda>p pa. snd pa = cte_map (snd p)) caps caps' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> irq_handler_inv_relation) invs invs'
@@ -158,7 +158,7 @@ lemma isIRQActive_wp:
   apply (clarsimp simp: irq_issued'_def)
   done
 
-lemma arch_check_irq_corres:
+lemma checkIRQ_corres:
   "corres (ser \<oplus> dc) \<top> \<top> (arch_check_irq irq) (checkIRQ irq)"
   unfolding arch_check_irq_def checkIRQ_def rangeCheck_def
   apply (rule corres_guard_imp)
@@ -194,7 +194,7 @@ lemma arch_check_irq_valid':
   "\<lbrace>\<top>\<rbrace> arch_check_irq y \<lbrace>\<lambda>_ _. unat y \<le> unat maxIRQ \<and> unat y \<noteq> unat irqInvalid\<rbrace>, \<lbrace>\<lambda>_. \<top>\<rbrace>"
   by (wp arch_check_irq_valid)
 
-lemma arch_decode_irq_control_corres:
+lemma arch_decodeIRQControlInvocation_corres:
   "list_all2 cap_relation caps caps' \<Longrightarrow>
    corres (ser \<oplus> arch_irq_control_inv_relation)
      (invs and (\<lambda>s. \<forall>cp \<in> set caps. s \<turnstile> cp))
@@ -215,13 +215,13 @@ lemma arch_decode_irq_control_corres:
   \<comment>\<open>ARMIRQIssueIRQHandler\<close>
   apply (rule conjI, clarsimp)
    apply (rule corres_guard_imp)
-     apply (rule corres_splitEE[OF _ arch_check_irq_corres])
+     apply (rule corres_splitEE[OF _ checkIRQ_corres])
        apply (rule_tac F="unat y \<le> unat maxIRQ \<and> unat y \<noteq> unat irqInvalid" in corres_gen_asm)
        apply (clarsimp simp add: minIRQ_def maxIRQ_def ucast_nat_def)
        apply (rule corres_split_eqr[OF _ is_irq_active_corres])
          apply (rule whenE_throwError_corres, clarsimp, clarsimp)
-         apply (rule corres_splitEE[OF _ lsfc_corres])
-             apply (rule corres_splitEE[OF _ ensure_empty_corres])
+         apply (rule corres_splitEE[OF _ lookupSlotForCNodeOp_corres])
+             apply (rule corres_splitEE[OF _ ensureEmptySlot_corres])
                 apply (rule corres_returnOkTT)
                 apply (clarsimp simp: arch_irq_control_inv_relation_def)
                apply (wpsimp wp: isIRQActive_inv arch_check_irq_valid' checkIRQ_inv
@@ -237,7 +237,7 @@ lemma irqhandler_simp[simp]:
    (case gen_invocation_type label of IRQIssueIRQHandler \<Rightarrow> b | _ \<Rightarrow> c) = c"
   by (clarsimp split: gen_invocation_labels.splits)
 
-lemma decode_irq_control_corres:
+lemma decodeIRQControlInvocation_corres:
   "list_all2 cap_relation caps caps' \<Longrightarrow>
    corres (ser \<oplus> irq_control_inv_relation)
      (invs and (\<lambda>s. \<forall>cp \<in> set caps. s \<turnstile> cp)) (invs' and (\<lambda>s. \<forall>cp \<in> set caps'. s \<turnstile>' cp))
@@ -257,8 +257,8 @@ lemma decode_irq_control_corres:
      apply (prop_tac "length args \<le> 2", arith)
      apply (clarsimp split: list.split)
     apply (simp add: minIRQ_def o_def)
-    apply (auto intro!: corres_guard_imp[OF arch_decode_irq_control_corres])[1]
-   apply (auto intro!: corres_guard_imp[OF arch_decode_irq_control_corres]
+    apply (auto intro!: corres_guard_imp[OF arch_decodeIRQControlInvocation_corres])[1]
+   apply (auto intro!: corres_guard_imp[OF arch_decodeIRQControlInvocation_corres]
                dest!: not_le_imp_less
                simp: minIRQ_def o_def length_Suc_conv whenE_rangeCheck_eq ucast_nat_def
                split: list.splits)[1]
@@ -269,8 +269,8 @@ lemma decode_irq_control_corres:
     apply (clarsimp simp add: minIRQ_def maxIRQ_def ucast_nat_def)
     apply (rule corres_split_eqr[OF _ is_irq_active_corres])
       apply (rule whenE_throwError_corres, clarsimp, clarsimp)
-      apply (rule corres_splitEE[OF _ lsfc_corres])
-          apply (rule corres_splitEE[OF _ ensure_empty_corres])
+      apply (rule corres_splitEE[OF _ lookupSlotForCNodeOp_corres])
+          apply (rule corres_splitEE[OF _ ensureEmptySlot_corres])
              apply (rule corres_returnOkTT)
              apply (clarsimp simp: arch_irq_control_inv_relation_def)
             apply (wpsimp wp: isIRQActive_inv arch_check_irq_valid' checkIRQ_inv
@@ -346,7 +346,7 @@ lemma no_fail_plic_complete_claim [simp, wp]:
   unfolding RISCV64.plic_complete_claim_def
   by (rule no_fail_machine_op_lift)
 
-lemma invoke_arch_irq_handler_corres:
+lemma arch_invokeIRQHandler_corres:
   "irq_handler_inv_relation i i' \<Longrightarrow>
    corres dc \<top> \<top> (arch_invoke_irq_handler i) (RISCV64_H.invokeIRQHandler i')"
   apply (cases i; clarsimp simp: RISCV64_H.invokeIRQHandler_def)
@@ -354,7 +354,7 @@ lemma invoke_arch_irq_handler_corres:
   done
 
 
-lemma invoke_irq_handler_corres:
+lemma invokeIRQHandler_corres:
   "irq_handler_inv_relation i i' \<Longrightarrow>
    corres dc (einvs and irq_handler_inv_valid i)
              (invs' and irq_handler_inv_valid' i')
@@ -362,14 +362,14 @@ lemma invoke_irq_handler_corres:
      (InterruptDecls_H.invokeIRQHandler i')"
   supply arch_invoke_irq_handler.simps[simp del]
   apply (cases i; simp add: Interrupt_H.invokeIRQHandler_def)
-    apply (rule corres_guard_imp, rule invoke_arch_irq_handler_corres; simp)
+    apply (rule corres_guard_imp, rule arch_invokeIRQHandler_corres; simp)
    apply (rename_tac word cap prod)
    apply clarsimp
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated[OF _ get_irq_slot_corres])
+     apply (rule corres_split_deprecated[OF _ getIRQSlot_corres])
        apply simp
        apply (rule corres_split_nor [OF _ cap_delete_one_corres])
-         apply (rule cins_corres, simp+)
+         apply (rule cteInsert_corres, simp+)
         apply (rule_tac Q="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
                                   \<and> (a, b) \<noteq> irq_slot
                                   \<and> cte_wp_at (is_derived (cdt s) (a, b) cap) (a, b) s"
@@ -384,7 +384,7 @@ lemma invoke_irq_handler_corres:
     apply (erule cte_wp_at_weakenE, simp add: is_derived_use_interrupt)
    apply fastforce
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_irq_slot_corres])
+    apply (rule corres_split_deprecated [OF _ getIRQSlot_corres])
       apply simp
       apply (rule cap_delete_one_corres)
      apply wp+
@@ -477,7 +477,7 @@ lemma setIRQTrigger_corres:
             | simp add: dc_def)+
   done
 
-lemma arch_invoke_irq_control_corres:
+lemma arch_performIRQControl_corres:
   "arch_irq_control_inv_relation x2 ivk' \<Longrightarrow> corres (dc \<oplus> dc)
           (einvs and arch_irq_control_inv_valid x2)
           (invs' and arch_irq_control_inv_valid' ivk')
@@ -487,8 +487,8 @@ lemma arch_invoke_irq_control_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_nor)
        apply (rule corres_split_nor)
-          apply (rule cins_corres_simple; simp)
-         apply (rule set_irq_state_corres)
+          apply (rule cteInsert_simple_corres; simp)
+         apply (rule setIRQState_corres)
          apply (simp add: irq_state_relation_def)
         apply (wp | simp add: irq_state_relation_def IRQHandler_valid IRQHandler_valid')+
       apply (rule setIRQTrigger_corres)
@@ -504,7 +504,7 @@ lemma arch_invoke_irq_control_corres:
   apply (auto dest: valid_irq_handlers_ctes_ofD)[1]
   done
 
-lemma invoke_irq_control_corres:
+lemma performIRQControl_corres:
   "irq_control_inv_relation i i' \<Longrightarrow>
    corres (dc \<oplus> dc) (einvs and irq_control_inv_valid i)
              (invs' and irq_control_inv_valid' i')
@@ -512,8 +512,8 @@ lemma invoke_irq_control_corres:
      (performIRQControl i')"
   apply (cases i, simp_all add: performIRQControl_def)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_nor [OF _ set_irq_state_corres])
-        apply (rule cins_corres_simple)
+     apply (rule corres_split_nor [OF _ setIRQState_corres])
+        apply (rule cteInsert_simple_corres)
           apply (wp | simp add: irq_state_relation_def
                                 IRQHandler_valid IRQHandler_valid')+
     apply (clarsimp simp: invs_def valid_state_def valid_pspace_def
@@ -526,7 +526,7 @@ lemma invoke_irq_control_corres:
    apply (case_tac ctea)
    apply (clarsimp simp: isCap_simps sameRegionAs_def3)
    apply (auto dest: valid_irq_handlers_ctes_ofD)[1]
-  by (clarsimp simp: arch_invoke_irq_control_corres)
+  by (clarsimp simp: arch_performIRQControl_corres)
 
 crunch valid_cap'[wp]: setIRQState "valid_cap' cap"
 
@@ -581,7 +581,7 @@ lemma invoke_irq_control_invs'[wp]:
               simp: invs'_def valid_state'_def)
   done
 
-lemma get_irq_state_corres:
+lemma getIRQState_corres:
   "corres irq_state_relation \<top> \<top>
        (get_irq_state irq) (getIRQState irq)"
   apply (simp add: get_irq_state_def getIRQState_def getInterruptState_def)
@@ -602,7 +602,7 @@ lemma num_domains[simp]:
   apply(simp add: num_domains_def numDomains_def)
   done
 
-lemma dec_domain_time_corres:
+lemma decDomainTime_corres:
   "corres dc \<top> \<top> dec_domain_time decDomainTime"
   apply (simp add:dec_domain_time_def corres_underlying_def decDomainTime_def simpler_modify_def)
   apply (clarsimp simp:state_relation_def)
@@ -646,15 +646,15 @@ lemma timerTick_corres:
   apply (rule_tac Q="\<top> and (cur_tcb and valid_sched and pspace_aligned and pspace_distinct)"
                   and Q'="\<top> and invs'" in corres_guard_imp)
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF _ gct_corres])
+      apply (rule corres_split_deprecated [OF _ getCurThread_corres])
         apply simp
-        apply (rule corres_split_deprecated [OF _ gts_corres])
+        apply (rule corres_split_deprecated [OF _ getThreadState_corres])
           apply (rename_tac state state')
           apply (rule corres_split_deprecated[where r' = dc ])
              apply simp
              apply (rule corres_when,simp)
-             apply (rule corres_split_deprecated[OF _ dec_domain_time_corres])
-               apply (rule corres_split_deprecated[OF _ domain_time_corres])
+             apply (rule corres_split_deprecated[OF _ decDomainTime_corres])
+               apply (rule corres_split_deprecated[OF _ getDomainTime_corres])
                  apply (rule corres_when,simp)
                  apply (rule rescheduleRequired_corres)
                 apply (wp hoare_drop_imp)+
@@ -707,7 +707,7 @@ lemma timerTick_corres:
 
 lemmas corres_eq_trivial = corres_Id[where f = h and g = h for h, simplified]
 
-lemma handle_interrupt_corres:
+lemma handleInterrupt_corres:
   "corres dc
      (einvs) (invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive))
      (handle_interrupt irq) (handleInterrupt irq)"
@@ -716,7 +716,7 @@ lemma handle_interrupt_corres:
   apply (rule conjI[rotated]; rule impI)
 
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_irq_state_corres,
+    apply (rule corres_split_deprecated [OF _ getIRQState_corres,
                               where R="\<lambda>rv. einvs"
                                 and R'="\<lambda>rv. invs' and (\<lambda>s. rv \<noteq> IRQInactive)"])
       defer
@@ -730,7 +730,7 @@ apply (rule corres_split_deprecated)
   apply (case_tac st, simp_all add: irq_state_relation_def split: irqstate.split_asm)
    apply (simp add: getSlotCap_def bind_assoc)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated [OF _ get_irq_slot_corres])
+     apply (rule corres_split_deprecated [OF _ getIRQSlot_corres])
        apply simp
        apply (rule corres_split_deprecated [OF _ get_cap_corres,
                                  where R="\<lambda>rv. einvs and valid_cap rv"
@@ -738,7 +738,7 @@ apply (rule corres_split_deprecated)
          apply (rule corres_split'[where r'=dc])
             apply (case_tac xb, simp_all add: doMachineOp_return)[1]
              apply (clarsimp simp add: when_def doMachineOp_return)
-             apply (rule corres_guard_imp, rule send_signal_corres)
+             apply (rule corres_guard_imp, rule sendSignal_corres)
               apply (clarsimp simp: valid_cap_def valid_cap'_def arch_mask_irq_signal_def
                                     maskIrqSignal_def do_machine_op_bind doMachineOp_bind)+
               apply (rule corres_machine_op, rule corres_eq_trivial;

--- a/proof/refine/RISCV64/IpcCancel_R.thy
+++ b/proof/refine/RISCV64/IpcCancel_R.thy
@@ -157,7 +157,7 @@ lemma invs_weak_sch_act_wf[elim!]:
   apply (clarsimp simp: weak_sch_act_wf_def)
   done
 
-lemma blocked_cancel_ipc_corres:
+lemma blocked_cancelIPC_corres:
   "\<lbrakk> st = Structures_A.BlockedOnReceive epPtr p' \<or>
      st = Structures_A.BlockedOnSend epPtr p; thread_state_relation st st' \<rbrakk> \<Longrightarrow>
    corres dc (invs and st_tcb_at ((=) st) t) (invs' and st_tcb_at' ((=) st') t)
@@ -173,7 +173,7 @@ lemma blocked_cancel_ipc_corres:
             od)"
   apply (simp add: blocked_cancel_ipc_def gbep_ret)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres])
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres])
       apply (rule_tac F="ep \<noteq> IdleEP" in corres_gen_asm2)
       apply (rule corres_assert_assume[rotated])
        apply (clarsimp split: endpoint.splits)
@@ -186,8 +186,8 @@ lemma blocked_cancel_ipc_corres:
        apply (case_tac "remove1 t list")
         apply simp
         apply (rule corres_guard_imp)
-          apply (rule corres_split_deprecated [OF _ set_ep_corres])
-             apply (rule sts_corres)
+          apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+             apply (rule setThreadState_corres)
              apply simp
             apply (simp add: ep_relation_def)
            apply (simp add: valid_tcb_state_def pred_conj_def)
@@ -209,8 +209,8 @@ lemma blocked_cancel_ipc_corres:
                               valid_tcb_state'_def)[1]
        apply clarsimp
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
-            apply (rule sts_corres)
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+            apply (rule setThreadState_corres)
             apply simp
            apply (simp add: ep_relation_def)
           apply (wp)+
@@ -234,8 +234,8 @@ lemma blocked_cancel_ipc_corres:
       apply (case_tac "remove1 t list")
        apply simp
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
-            apply (rule sts_corres)
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+            apply (rule setThreadState_corres)
             apply simp
            apply (simp add: ep_relation_def)
           apply (simp add: valid_tcb_state_def pred_conj_def)
@@ -257,8 +257,8 @@ lemma blocked_cancel_ipc_corres:
                              valid_tcb_state'_def)[1]
       apply clarsimp
       apply (rule corres_guard_imp)
-        apply (rule corres_split_deprecated [OF _ set_ep_corres])
-           apply (rule sts_corres)
+        apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+           apply (rule setThreadState_corres)
            apply simp
           apply (simp add: ep_relation_def)
          apply (wp)+
@@ -296,7 +296,7 @@ lemma blocked_cancel_ipc_corres:
   apply (fastforce simp: ko_wp_at'_def obj_at'_def dest: sym_refs_st_tcb_atD')
   done
 
-lemma ac_corres:
+lemma cancelSignal_corres:
   "corres dc
           (invs and st_tcb_at ((=) (Structures_A.BlockedOnNotification ntfn)) t)
           (invs' and st_tcb_at' ((=) (BlockedOnNotification ntfn)) t)
@@ -304,7 +304,7 @@ lemma ac_corres:
           (cancelSignal t ntfn)"
   apply (simp add: cancel_signal_def cancelSignal_def Let_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ntfn_corres])
+    apply (rule corres_split_deprecated [OF _ getNotification_corres])
       apply (rule_tac F="isWaitingNtfn (ntfnObj ntfnaa)" in corres_gen_asm2)
       apply (case_tac "ntfn_obj ntfna")
         apply (simp add: ntfn_relation_def isWaitingNtfn_def)
@@ -312,14 +312,14 @@ lemma ac_corres:
        apply (rename_tac list)
        apply (rule_tac R="remove1 t list = []" in corres_cases)
         apply (simp del: dc_simp)
-        apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-           apply (rule sts_corres)
+        apply (rule corres_split_deprecated [OF _ setNotification_corres])
+           apply (rule setThreadState_corres)
            apply simp
           apply (simp add: ntfn_relation_def)
          apply (wp)+
        apply (simp add: list_case_If del: dc_simp)
-       apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-          apply (rule sts_corres)
+       apply (rule corres_split_deprecated [OF _ setNotification_corres])
+          apply (rule setThreadState_corres)
           apply simp
          apply (clarsimp simp add: ntfn_relation_def neq_Nil_conv)
         apply (wp)+
@@ -513,7 +513,7 @@ locale delete_one = delete_one_conc + delete_one_abs +
                (invs' and cte_at' (cte_map ptr))
           (cap_delete_one ptr) (cteDeleteOne (cte_map ptr))"
 
-lemma (in delete_one) reply_cancel_ipc_corres:
+lemma (in delete_one) cancelIPC_ReplyCap_corres:
   "corres dc (einvs  and st_tcb_at awaiting_reply t)
              (invs' and st_tcb_at' awaiting_reply' t)
       (reply_cancel_ipc t)
@@ -603,28 +603,28 @@ lemma (in delete_one) cancel_ipc_corres:
       (cancel_ipc t) (cancelIPC t)"
   apply (simp add: cancel_ipc_def cancelIPC_def Let_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gts_corres])
+    apply (rule corres_split_deprecated [OF _ getThreadState_corres])
       apply (rule_tac P="einvs and st_tcb_at ((=) state) t" and
                       P'="invs' and st_tcb_at' ((=) statea) t" in corres_inst)
       apply (case_tac state, simp_all add: isTS_defs list_case_If)[1]
          apply (rule corres_guard_imp)
-           apply (rule blocked_cancel_ipc_corres)
+           apply (rule blocked_cancelIPC_corres)
             apply fastforce
            apply fastforce
           apply simp
          apply simp
         apply (clarsimp simp add: isTS_defs list_case_If)
         apply (rule corres_guard_imp)
-          apply (rule blocked_cancel_ipc_corres)
+          apply (rule blocked_cancelIPC_corres)
            apply fastforce
           apply fastforce
          apply simp
         apply simp
        apply (rule corres_guard_imp)
-         apply (rule reply_cancel_ipc_corres)
+         apply (rule cancelIPC_ReplyCap_corres)
         apply (clarsimp elim!: st_tcb_weakenE)
        apply (clarsimp elim!: pred_tcb'_weakenE)
-      apply (rule corres_guard_imp [OF ac_corres], simp+)
+      apply (rule corres_guard_imp [OF cancelSignal_corres], simp+)
      apply (wp gts_sp[where P="\<top>",simplified])+
     apply (rule hoare_strengthen_post)
      apply (rule gts_sp'[where P="\<top>"])
@@ -1377,9 +1377,9 @@ lemma (in delete_one) suspend_corres:
   apply (simp add: IpcCancel_A.suspend_def Thread_H.suspend_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_nor [OF _ cancel_ipc_corres])
-      apply (rule corres_split_deprecated [OF _ gts_corres])
+      apply (rule corres_split_deprecated [OF _ getThreadState_corres])
         apply (rule corres_split_nor)
-           apply (rule corres_split_nor [OF _ sts_corres])
+           apply (rule corres_split_nor [OF _ setThreadState_corres])
               apply (rule tcbSchedDequeue_corres')
              apply wpsimp
             apply wp
@@ -1387,7 +1387,7 @@ lemma (in delete_one) suspend_corres:
           apply (rule corres_if)
             apply (case_tac state; simp)
            apply (simp add: update_restart_pc_def updateRestartPC_def)
-           apply (rule corres_as_user')
+           apply (rule asUser_corres')
            apply (simp add: RISCV64.nextInstructionRegister_def RISCV64.faultRegister_def
                             RISCV64_H.nextInstructionRegister_def RISCV64_H.faultRegister_def)
            apply (simp add: RISCV64_H.Register_def)
@@ -1885,7 +1885,7 @@ lemma ep_cancel_corres_helper:
       apply (rule corres_guard_imp)
         apply (subst bind_return_unit, rule corres_split_deprecated [OF tcbSchedEnqueue_corres])
           apply simp
-          apply (rule corres_guard_imp [OF sts_corres])
+          apply (rule corres_guard_imp [OF setThreadState_corres])
             apply simp
            apply (simp add: valid_tcb_state_def)
           apply simp
@@ -1927,7 +1927,7 @@ proof -
                    rescheduleRequired
                 od)"
     apply (rule corres_split')
-       apply (rule corres_guard_imp [OF set_ep_corres])
+       apply (rule corres_guard_imp [OF setEndpoint_corres])
          apply (simp add: ep_relation_def)+
       apply (rule corres_split_deprecated [OF rescheduleRequired_corres])
         apply (rule ep_cancel_corres_helper)
@@ -1950,7 +1950,7 @@ proof -
   show ?thesis
     apply (simp add: cancel_all_ipc_def cancelAllIPC_def)
     apply (rule corres_split' [OF _ _ get_simple_ko_sp get_ep_sp'])
-     apply (rule corres_guard_imp [OF get_ep_corres], simp+)
+     apply (rule corres_guard_imp [OF getEndpoint_corres], simp+)
     apply (case_tac epa, simp_all add: ep_relation_def
                                        get_ep_queue_def)
      apply (rule corres_guard_imp [OF P]
@@ -1972,16 +1972,16 @@ lemma set_ntfn_tcb_obj_at' [wp]:
   apply (clarsimp simp: setNotification_def, wp)
   done
 
-lemma ntfn_cancel_corres:
+lemma cancelAllSignals_corres:
   "corres dc (invs and valid_sched and ntfn_at ntfn) (invs' and ntfn_at' ntfn)
              (cancel_all_signals ntfn) (cancelAllSignals ntfn)"
   apply (simp add: cancel_all_signals_def cancelAllSignals_def)
   apply (rule corres_split' [OF _ _ get_simple_ko_sp get_ntfn_sp'])
-   apply (rule corres_guard_imp [OF get_ntfn_corres])
+   apply (rule corres_guard_imp [OF getNotification_corres])
     apply simp+
   apply (case_tac "ntfn_obj ntfna", simp_all add: ntfn_relation_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
+    apply (rule corres_split_deprecated [OF _ setNotification_corres])
        apply (rule corres_split_deprecated [OF rescheduleRequired_corres])
          apply (rule ep_cancel_corres_helper)
         apply (wp mapM_x_wp'[where 'b="det_ext state"]
@@ -2561,21 +2561,21 @@ lemma cancelBadgedSends_invs[wp]:
 crunch state_refs_of[wp]: tcb_sched_action "\<lambda>s. P (state_refs_of s)"
 
 
-lemma cancel_badged_sends_corres:
+lemma cancelBadgedSends_corres:
   "corres dc (invs and valid_sched and ep_at epptr) (invs' and ep_at' epptr)
          (cancel_badged_sends epptr bdg) (cancelBadgedSends epptr bdg)"
   apply (simp add: cancel_badged_sends_def cancelBadgedSends_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres get_simple_ko_sp get_ep_sp',
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres get_simple_ko_sp get_ep_sp',
                                  where Q="invs and valid_sched" and Q'=invs'])
     apply simp_all
   apply (case_tac ep, simp_all add: ep_relation_def)
   apply (simp add: filterM_mapM list_case_return cong: list.case_cong)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_nor [OF _ set_ep_corres])
+    apply (rule corres_split_nor [OF _ setEndpoint_corres])
        apply (rule corres_split_eqr[OF _ _ _ hoare_post_add[where R="\<lambda>_. valid_objs'"]])
           apply (rule corres_split_deprecated [OF rescheduleRequired_corres])
-            apply (rule set_ep_corres)
+            apply (rule setEndpoint_corres)
             apply (simp split: list.split add: ep_relation_def)
            apply (wp weak_sch_act_wf_lift_linear)+
          apply (rule_tac S="(=)"
@@ -2586,11 +2586,11 @@ lemma cancel_badged_sends_corres:
                 simp_all add: list_all2_refl)[1]
            apply (clarsimp simp: liftM_def[symmetric] o_def)
            apply (rule corres_guard_imp)
-             apply (rule corres_split_deprecated [OF _ gts_corres])
+             apply (rule corres_split_deprecated [OF _ getThreadState_corres])
                apply (rule_tac F="\<exists>pl. st = Structures_A.BlockedOnSend epptr pl"
                             in corres_gen_asm)
                apply (clarsimp simp: o_def dc_def[symmetric] liftM_def)
-               apply (rule corres_split_deprecated [OF _ sts_corres])
+               apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                   apply (rule corres_split_deprecated[OF _ tcbSchedEnqueue_corres])
                     apply (rule corres_trivial)
                     apply simp

--- a/proof/refine/RISCV64/KHeap_R.thy
+++ b/proof/refine/RISCV64/KHeap_R.thy
@@ -811,7 +811,7 @@ lemma no_fail_getEndpoint [wp]:
   apply (clarsimp split: option.split_asm simp: objBits_simps')
   done
 
-lemma get_ep_corres:
+lemma getEndpoint_corres:
   "corres ep_relation (ep_at ptr) (ep_at' ptr)
      (get_endpoint ptr) (getEndpoint ptr)"
   apply (rule corres_no_failI)
@@ -913,7 +913,7 @@ where
   "exst_same' (KOTCB tcb) (KOTCB tcb') = exst_same tcb tcb'" |
   "exst_same' _ _ = True"
 
-lemma set_other_obj_corres:
+lemma setObject_other_corres:
   fixes ob' :: "'a :: pspace_storable"
   assumes x: "updateObject ob' = updateObject_default ob'"
   assumes z: "\<And>s. obj_at' P ptr s
@@ -990,21 +990,21 @@ lemmas obj_at_simps = obj_at_def obj_at'_def map_to_ctes_upd_other
                       is_other_obj_relation_type_def
                       a_type_def objBits_simps other_obj_relation_def pageBits_def
 
-lemma set_ep_corres:
+lemma setEndpoint_corres:
   "ep_relation e e' \<Longrightarrow>
   corres dc (ep_at ptr) (ep_at' ptr)
             (set_endpoint ptr e) (setEndpoint ptr e')"
   apply (simp add: set_simple_ko_def setEndpoint_def is_ep_def[symmetric])
-    apply (corres_search search: set_other_obj_corres[where P="\<lambda>_. True"])
+    apply (corres_search search: setObject_other_corres[where P="\<lambda>_. True"])
   apply (corressimp wp: get_object_ret get_object_wp)+
   by (fastforce simp: is_ep obj_at_simps objBits_defs partial_inv_def)
 
-lemma set_ntfn_corres:
+lemma setNotification_corres:
   "ntfn_relation ae ae' \<Longrightarrow>
   corres dc (ntfn_at ptr) (ntfn_at' ptr)
             (set_notification ptr ae) (setNotification ptr ae')"
   apply (simp add: set_simple_ko_def setNotification_def is_ntfn_def[symmetric])
-       apply (corres_search search: set_other_obj_corres[where P="\<lambda>_. True"])
+       apply (corres_search search: setObject_other_corres[where P="\<lambda>_. True"])
   apply (corressimp wp: get_object_ret get_object_wp)+
   by (fastforce simp: is_ntfn obj_at_simps objBits_defs partial_inv_def)
 
@@ -1022,7 +1022,7 @@ lemma no_fail_getNotification [wp]:
   apply (clarsimp split: option.split_asm simp: objBits_simps')
   done
 
-lemma get_ntfn_corres:
+lemma getNotification_corres:
   "corres ntfn_relation (ntfn_at ptr) (ntfn_at' ptr)
      (get_notification ptr) (getNotification ptr)"
   apply (rule corres_no_failI)

--- a/proof/refine/RISCV64/Refine.thy
+++ b/proof/refine/RISCV64/Refine.thy
@@ -530,7 +530,7 @@ lemma kernel_corres':
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated)
        prefer 2
-       apply (rule corres_split_handle [OF _ he_corres])
+       apply (rule corres_split_handle [OF _ handleEvent_corres])
          apply simp
          apply (rule corres_split_deprecated [OF _ corres_machine_op])
             prefer 2
@@ -542,7 +542,7 @@ lemma kernel_corres':
             apply (simp add: when_def)
            apply (rule corres_when[simplified dc_def], simp)
            apply simp
-           apply (rule handle_interrupt_corres[simplified dc_def])
+           apply (rule handleInterrupt_corres[simplified dc_def])
           apply simp
           apply (wp hoare_drop_imps hoare_vcg_all_lift)[1]
          apply simp
@@ -557,7 +557,7 @@ lemma kernel_corres':
          apply wpsimp+
        apply (simp add: invs'_def valid_state'_def)
       apply (rule corres_split_deprecated [OF _ schedule_corres])
-        apply (rule activate_corres)
+        apply (rule activateThread_corres)
        apply (wp handle_interrupt_valid_sched[unfolded non_kernel_IRQs_def, simplified]
                  schedule_invs' hoare_vcg_if_lift2 hoare_drop_imps |simp)+
      apply (rule_tac Q="\<lambda>_. valid_sched and invs and valid_list" and
@@ -615,7 +615,7 @@ lemma entry_corres:
           (kernel_entry event tc) (kernelEntry event tc)"
   apply (simp add: kernel_entry_def kernelEntry_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gct_corres])
+    apply (rule corres_split_deprecated [OF _ getCurThread_corres])
       apply (rule corres_split_deprecated)
          prefer 2
          apply simp
@@ -626,8 +626,8 @@ lemma entry_corres:
           apply (clarsimp simp: tcb_cte_cases_def cteSizeBits_def)
          apply (simp add: exst_same_def)
         apply (rule corres_split_deprecated [OF _ kernel_corres])
-          apply (rule corres_split_eqr [OF _ gct_corres])
-            apply (rule threadget_corres)
+          apply (rule corres_split_eqr [OF _ getCurThread_corres])
+            apply (rule threadGet_corres)
             apply (simp add: tcb_relation_def arch_tcb_relation_def
                              arch_tcb_context_get_def atcbContextGet_def)
            apply wp+
@@ -656,7 +656,7 @@ lemma do_user_op_corres:
           (do_user_op f tc) (doUserOp f tc)"
   apply (simp add: do_user_op_def doUserOp_def split_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply (rule_tac r'="(=)" and P=einvs and P'=invs' in corres_split_deprecated)
          prefer 2
          apply (fastforce dest: absKState_correct [rotated])
@@ -740,7 +740,7 @@ lemma check_active_irq_corres:
     apply (rule check_active_irq_corres', auto)
   done
 
-lemma check_active_irq_corres_just_running:
+lemma checkActiveIRQ_just_running_corres:
   "corres (=)
     (invs and ct_running and einvs and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and (\<lambda>s. 0 < domain_time s) and valid_domain_list)
@@ -752,7 +752,7 @@ lemma check_active_irq_corres_just_running:
     apply (rule check_active_irq_corres', auto)
   done
 
-lemma check_active_irq_corres_just_idle:
+lemma checkActiveIRQ_just_idle_corres:
   "corres (=)
     (invs and ct_idle and einvs and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and (\<lambda>s. 0 < domain_time s)  and valid_domain_list)
@@ -878,7 +878,7 @@ lemma ckernel_invariant:
    apply (drule use_valid)
      apply (rule hoare_vcg_conj_lift)
       apply (rule checkActiveIRQ_valid_objs')
-     apply (rule valid_corres_combined[OF check_active_irq_invs_just_running check_active_irq_corres_just_running])
+     apply (rule valid_corres_combined[OF check_active_irq_invs_just_running checkActiveIRQ_just_running_corres])
      apply (rule checkActiveIRQ_invs'_just_running[THEN hoare_weaken_pre])
      apply (fastforce simp: ex_abs_def)
     apply (fastforce simp: ex_abs_def ct_running_related sched_act_rct_related)
@@ -889,7 +889,7 @@ lemma ckernel_invariant:
    apply (drule use_valid)
      apply (rule hoare_vcg_conj_lift)
       apply (rule checkActiveIRQ_valid_objs')
-     apply (rule valid_corres_combined[OF check_active_irq_invs_just_idle check_active_irq_corres_just_idle])
+     apply (rule valid_corres_combined[OF check_active_irq_invs_just_idle checkActiveIRQ_just_idle_corres])
      apply (rule checkActiveIRQ_invs'_just_idle[THEN hoare_weaken_pre])
      apply clarsimp
      apply (fastforce simp: ex_abs_def)

--- a/proof/refine/RISCV64/Schedule_R.thy
+++ b/proof/refine/RISCV64/Schedule_R.thy
@@ -71,14 +71,14 @@ crunches set_vm_root
   and pspace_distinct[wp]: pspace_distinct
   (simp: crunch_simps)
 
-lemma arch_switch_thread_corres:
+lemma arch_switchToThread_corres:
   "corres dc (valid_arch_state and valid_objs and pspace_aligned and pspace_distinct
                 and valid_vspace_objs and st_tcb_at runnable t)
              (no_0_obj')
              (arch_switch_to_thread t) (Arch.switchToThread t)"
   apply (simp add: arch_switch_to_thread_def RISCV64_H.switchToThread_def)
   apply (rule corres_guard_imp)
-    apply (rule set_vm_root_corres[OF refl])
+    apply (rule setVMRoot_corres[OF refl])
    apply (clarsimp simp: st_tcb_at_tcb_at valid_arch_state_asid_table
                          valid_arch_state_global_arch_objs)
   apply simp
@@ -127,7 +127,7 @@ lemma tcbSchedAppend_corres:
              apply (rule corres_split_noop_rhs2)
                 apply (rule corres_split_noop_rhs2)
                    apply (rule threadSet_corres_noop, simp_all add: tcb_relation_def exst_same_def)[1]
-                  apply (rule addToBitmap_if_null_corres_noop)
+                  apply (rule addToBitmap_if_null_noop_corres)
                  apply wp+
                apply (simp add: tcb_sched_append_def)
                apply (intro conjI impI)
@@ -571,7 +571,7 @@ lemma tcbSchedDequeue_invs'[wp]:
   apply (fastforce elim: valid_objs'_maxDomain valid_objs'_maxPriority simp: valid_pspace'_def)+
   done
 
-lemma cur_thread_update_corres:
+lemma setCurThread_corres:
   "corres dc \<top> \<top> (modify (cur_thread_update (\<lambda>_. t))) (setCurThread t)"
   apply (unfold setCurThread_def)
   apply (rule corres_modify)
@@ -607,7 +607,7 @@ crunches arch_switch_to_thread
   for pspace_aligned[wp]: pspace_aligned
   and pspace_distinct[wp]: pspace_distinct
 
-lemma switch_thread_corres:
+lemma switchToThread_corres:
   "corres dc (valid_arch_state and valid_objs
                 and valid_vspace_objs and pspace_aligned and pspace_distinct
                 and valid_vs_lookup and valid_global_objs
@@ -627,8 +627,8 @@ proof -
          setCurThread t
       od)"
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF _ arch_switch_thread_corres])
-        apply (rule corres_split_deprecated[OF cur_thread_update_corres tcbSchedDequeue_corres])
+      apply (rule corres_split_deprecated [OF _ arch_switchToThread_corres])
+        apply (rule corres_split_deprecated[OF setCurThread_corres tcbSchedDequeue_corres])
          apply (wp|clarsimp simp: tcb_at_is_etcb_at st_tcb_at_tcb_at)+
     done
 
@@ -644,7 +644,7 @@ proof -
     done
 qed
 
-lemma arch_switch_idle_thread_corres:
+lemma arch_switchToIdleThread_corres:
   "corres dc
         (valid_arch_state and valid_objs and pspace_aligned and pspace_distinct
            and valid_vspace_objs and valid_idle)
@@ -652,17 +652,17 @@ lemma arch_switch_idle_thread_corres:
         arch_switch_to_idle_thread Arch.switchToIdleThread"
   apply (simp add: arch_switch_to_idle_thread_def
                 RISCV64_H.switchToIdleThread_def)
-  apply (corressimp corres: git_corres set_vm_root_corres)
+  apply (corressimp corres: getIdleThread_corres setVMRoot_corres)
   apply (clarsimp simp: valid_idle_def valid_idle'_def pred_tcb_at_def obj_at_def is_tcb
                         valid_arch_state_asid_table valid_arch_state_global_arch_objs)
   done
 
-lemma switch_idle_thread_corres:
+lemma switchToIdleThread_corres:
   "corres dc invs invs_no_cicd' switch_to_idle_thread switchToIdleThread"
   apply (simp add: switch_to_idle_thread_def Thread_H.switchToIdleThread_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ git_corres])
-      apply (rule corres_split_deprecated [OF _ arch_switch_idle_thread_corres])
+    apply (rule corres_split_deprecated [OF _ getIdleThread_corres])
+      apply (rule corres_split_deprecated [OF _ arch_switchToIdleThread_corres])
         apply (unfold setCurThread_def)
         apply (rule corres_trivial, rule corres_modify)
         apply (simp add: state_relation_def cdt_relation_def)
@@ -1449,7 +1449,7 @@ lemma guarded_switch_to_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_symb_exec_l'[OF _ gts_exs_valid])
       apply (rule corres_assert_assume_l)
-      apply (rule switch_thread_corres)
+      apply (rule switchToThread_corres)
      apply (force simp: st_tcb_at_tcb_at)
     apply (wp gts_st_tcb_at)
    apply (force simp: st_tcb_at_tcb_at)+
@@ -1512,10 +1512,10 @@ lemma guarded_switch_to_chooseThread_fragment_corres:
   unfolding guarded_switch_to_def isRunnable_def
   apply simp
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gts_corres])
+    apply (rule corres_split_deprecated[OF _ getThreadState_corres])
       apply (rule corres_assert_assume_l)
       apply (rule corres_assert_assume_r)
-      apply (rule switch_thread_corres)
+      apply (rule switchToThread_corres)
      apply (wp gts_st_tcb_at)+
    apply (clarsimp simp: st_tcb_at_tcb_at invs_def valid_state_def valid_pspace_def valid_sched_def
                           invs_valid_vs_lookup invs_unique_refs)
@@ -1567,7 +1567,7 @@ proof -
       apply clarsimp
       apply (rule corres_split_deprecated[OF _ corres_gets_queues_getReadyQueuesL1Bitmap])
         apply (erule corres_if2[OF sym])
-         apply (rule switch_idle_thread_corres)
+         apply (rule switchToIdleThread_corres)
         apply (rule corres_symb_exec_r)
            apply (rule corres_symb_exec_r)
               apply (rule_tac
@@ -1621,11 +1621,11 @@ lemma schact_bind_inside: "do x \<leftarrow> f; (case act of resume_cur_thread \
 interpretation tcb_sched_action_extended: is_extended' "tcb_sched_action f a"
   by (unfold_locales)
 
-lemma domain_time_corres:
+lemma getDomainTime_corres:
   "corres (=) \<top> \<top> (gets domain_time) getDomainTime"
   by (simp add: getDomainTime_def state_relation_def)
 
-lemma next_domain_corres:
+lemma nextDomain_corres:
   "corres dc \<top> \<top> next_domain nextDomain"
   apply (simp add: next_domain_def nextDomain_def)
   apply (rule corres_modify)
@@ -1654,7 +1654,7 @@ lemma bind_dummy_ret_val:
    od = do a; b od"
   by simp
 
-lemma schedule_ChooseNewThread_fragment_corres:
+lemma scheduleChooseNewThread_fragment_corres:
   "corres dc (invs and valid_sched and (\<lambda>s. scheduler_action s = choose_new_thread)) (invs' and (\<lambda>s. ksSchedulerAction s = ChooseNewThread))
      (do _ \<leftarrow> when (domainTime = 0) next_domain;
          choose_thread
@@ -1669,12 +1669,12 @@ lemma schedule_ChooseNewThread_fragment_corres:
         apply simp
         apply (rule chooseThread_corres)
        apply simp
-      apply (rule next_domain_corres)
+      apply (rule nextDomain_corres)
      apply (wp nextDomain_invs_no_cicd')+
    apply (clarsimp simp: valid_sched_def invs'_def valid_state'_def all_invs_but_ct_idle_or_in_cur_domain'_def)+
   done
 
-lemma schedule_switch_thread_fastfail_corres:
+lemma scheduleSwitchThreadFastfail_corres:
   "\<lbrakk> ct \<noteq> it \<longrightarrow> (tp = tp' \<and> cp = cp') ; ct = ct' ; it = it' \<rbrakk> \<Longrightarrow>
    corres ((=)) (is_etcb_at ct) (tcb_at' ct)
      (schedule_switch_thread_fastfail ct it cp tp)
@@ -1736,9 +1736,9 @@ lemma scheduleChooseNewThread_corres:
            schedule_choose_new_thread scheduleChooseNewThread"
   unfolding schedule_choose_new_thread_def scheduleChooseNewThread_def
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ domain_time_corres], clarsimp)
-      apply (rule corres_split_deprecated[OF _ schedule_ChooseNewThread_fragment_corres, simplified bind_assoc])
-        apply (rule set_sa_corres)
+    apply (rule corres_split_deprecated[OF _ getDomainTime_corres], clarsimp)
+      apply (rule corres_split_deprecated[OF _ scheduleChooseNewThread_fragment_corres, simplified bind_assoc])
+        apply (rule setSchedulerAction_corres)
         apply (wp | simp)+
     apply (wp | simp add: getDomainTime_def)+
    apply auto
@@ -1770,8 +1770,8 @@ lemma schedule_corres:
   apply (subst thread_get_comm)
   apply (subst schact_bind_inside)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres[THEN corres_rel_imp[where r="\<lambda>x y. y = x"],simplified]])
-        apply (rule corres_split_deprecated[OF _ get_sa_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres[THEN corres_rel_imp[where r="\<lambda>x y. y = x"],simplified]])
+        apply (rule corres_split_deprecated[OF _ getSchedulerAction_corres])
           apply (rule corres_split_sched_act,assumption)
             apply (rule_tac P="tcb_at ct" in corres_symb_exec_l')
               apply (rule_tac corres_symb_exec_l)
@@ -1791,19 +1791,19 @@ lemma schedule_corres:
         apply (rule corres_split_deprecated[OF _ thread_get_isRunnable_corres],
                 rename_tac was_running wasRunning)
           apply (rule corres_split_deprecated[OF _ corres_when])
-              apply (rule corres_split_deprecated[OF _ git_corres], rename_tac it it')
+              apply (rule corres_split_deprecated[OF _ getIdleThread_corres], rename_tac it it')
                 apply (rule_tac F="was_running \<longrightarrow> ct \<noteq> it" in corres_gen_asm)
                 apply (rule corres_split_deprecated[OF _ ethreadget_corres[where r="(=)"]],
                        rename_tac tp tp')
                    apply (rule corres_split_deprecated[OF _ ethread_get_when_corres[where r="(=)"]],
                            rename_tac cp cp')
-                      apply (rule corres_split_deprecated[OF _ schedule_switch_thread_fastfail_corres])
+                      apply (rule corres_split_deprecated[OF _ scheduleSwitchThreadFastfail_corres])
                            apply (rule corres_split_deprecated[OF _ curDomain_corres])
                              apply (rule corres_split_deprecated[OF _ isHighestPrio_corres]; simp only:)
                                apply (rule corres_if, simp)
                                 apply (rule corres_split_deprecated[OF _ tcbSchedEnqueue_corres])
                                   apply (simp, fold dc_def)
-                                  apply (rule corres_split_deprecated[OF _ set_sa_corres])
+                                  apply (rule corres_split_deprecated[OF _ setSchedulerAction_corres])
                                      apply (rule scheduleChooseNewThread_corres, simp)
 
                                    apply (wp | simp)+
@@ -1819,7 +1819,7 @@ lemma schedule_corres:
 
                                 apply (rule corres_split_deprecated[OF _ tcbSchedAppend_corres])
                                   apply (simp, fold dc_def)
-                                  apply (rule corres_split_deprecated[OF _ set_sa_corres])
+                                  apply (rule corres_split_deprecated[OF _ setSchedulerAction_corres])
                                      apply (rule scheduleChooseNewThread_corres, simp)
 
                                    apply (wp | simp)+
@@ -1832,7 +1832,7 @@ lemma schedule_corres:
                                 apply (wp tcbSchedAppend_invs'_not_ResumeCurrentThread)
 
                                apply (rule corres_split_deprecated[OF _ guarded_switch_to_corres], simp)
-                                 apply (rule set_sa_corres[simplified dc_def])
+                                 apply (rule setSchedulerAction_corres[simplified dc_def])
                                  apply (wp | simp)+
 
                              (* isHighestPrio *)
@@ -2224,7 +2224,7 @@ lemma possibleSwitchTo_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated[OF _ curDomain_corres], simp)
       apply (rule corres_split_deprecated[OF _ ethreadget_corres[where r="(=)"]])
-         apply (rule corres_split_deprecated[OF _ get_sa_corres])
+         apply (rule corres_split_deprecated[OF _ getSchedulerAction_corres])
            apply (rule corres_if, simp)
             apply (rule tcbSchedEnqueue_corres)
            apply (rule corres_if, simp)
@@ -2232,7 +2232,7 @@ lemma possibleSwitchTo_corres:
             apply (rule corres_split_deprecated[OF _ rescheduleRequired_corres])
               apply (rule tcbSchedEnqueue_corres)
              apply (wp rescheduleRequired_valid_queues'_weak)+
-           apply (rule set_sa_corres, simp)
+           apply (rule setSchedulerAction_corres, simp)
           apply (wpsimp simp: etcb_relation_def if_apply_def2
                         wp: hoare_drop_imp[where f="ethread_get a b" for a b])+
       apply (wp hoare_drop_imps)[1]

--- a/proof/refine/RISCV64/Syscall_R.thy
+++ b/proof/refine/RISCV64/Syscall_R.thy
@@ -128,7 +128,7 @@ where
 
 
 (* FIXME: move *)
-lemma dec_domain_inv_corres:
+lemma decodeDomainInvocation_corres:
   shows "\<lbrakk> list_all2 cap_relation (map fst cs) (map fst cs');
            list_all2 (\<lambda>p pa. snd pa = cte_map (snd p)) cs cs' \<rbrakk> \<Longrightarrow>
         corres (ser \<oplus> ((\<lambda>x. inv_relation x \<circ> uncurry Invocations_H.invocation.InvokeDomain) \<circ> (\<lambda>(x,y). Invocations_A.invocation.InvokeDomain x y))) \<top> \<top>
@@ -158,7 +158,7 @@ lemma dec_domain_inv_corres:
      apply (wp | simp)+
 done
 
-lemma decode_invocation_corres:
+lemma decodeInvocation_corres:
   "\<lbrakk>cptr = to_bl cptr'; mi' = message_info_map mi;
     slot' = cte_map slot; cap_relation cap cap';
     args = args'; list_all2 cap_relation (map fst excaps) (map fst excaps');
@@ -181,7 +181,7 @@ lemma decode_invocation_corres:
              apply (simp add: isCap_defs)
             \<comment> \<open>Untyped\<close>
             apply (simp add: isCap_defs Let_def o_def split del: if_split)
-            apply (rule corres_guard_imp, rule dec_untyped_inv_corres)
+            apply (rule corres_guard_imp, rule decodeUntypedInvocation_corres)
               apply ((clarsimp simp:cte_wp_at_caps_of_state)+)[3]
            \<comment> \<open>(Async)Endpoint\<close>
            apply (simp add: isCap_defs returnOk_def)
@@ -196,7 +196,7 @@ lemma decode_invocation_corres:
         apply (clarsimp simp add: o_def)
         apply (rule corres_guard_imp)
           apply (rule_tac F="length list \<le> 64" in corres_gen_asm)
-          apply (rule dec_cnode_inv_corres, simp+)
+          apply (rule decodeCNodeInvocation_corres, simp+)
          apply (simp add: valid_cap_def word_bits_def)
         apply simp
        \<comment> \<open>ThreadCap\<close>
@@ -204,7 +204,7 @@ lemma decode_invocation_corres:
                    split del: if_split cong: if_cong)
        apply (clarsimp simp add: o_def)
        apply (rule corres_guard_imp)
-         apply (rule decode_tcb_inv_corres, rule refl,
+         apply (rule decodeTCBInvocation_corres, rule refl,
                 simp_all add: valid_cap_def valid_cap'_def)[3]
        apply (simp add: split_def)
        apply (rule list_all2_conj)
@@ -213,20 +213,20 @@ lemma decode_invocation_corres:
       \<comment> \<open>DomainCap\<close>
       apply (simp add: isCap_defs)
       apply (rule corres_guard_imp)
-      apply (rule dec_domain_inv_corres)
+      apply (rule decodeDomainInvocation_corres)
       apply (simp+)[4]
      \<comment> \<open>IRQControl\<close>
      apply (simp add: isCap_defs o_def)
-     apply (rule corres_guard_imp, rule decode_irq_control_corres, simp+)[1]
+     apply (rule corres_guard_imp, rule decodeIRQControlInvocation_corres, simp+)[1]
     \<comment> \<open>IRQHandler\<close>
     apply (simp add: isCap_defs o_def)
-    apply (rule corres_guard_imp, rule decode_irq_handler_corres, simp+)[1]
+    apply (rule corres_guard_imp, rule decodeIRQHandlerInvocation_corres, simp+)[1]
    \<comment> \<open>Zombie\<close>
    apply (simp add: isCap_defs)
   \<comment> \<open>Arch\<close>
   apply (clarsimp simp only: cap_relation.simps)
   apply (clarsimp simp add: isCap_defs Let_def o_def)
-  apply (rule corres_guard_imp [OF dec_arch_inv_corres])
+  apply (rule corres_guard_imp [OF arch_decodeInvocation_corres])
       apply (simp_all add: list_all2_map2 list_all2_map1)+
   done
 
@@ -264,9 +264,9 @@ lemma hinv_corres_assist:
     apply (rule corres_splitEE [OF _ corres_cap_fault])
        prefer 2
        \<comment> \<open>switched over to argument of corres_cap_fault\<close>
-       apply (rule lcs_corres, simp)
-      apply (rule corres_split_deprecated [OF _ lipcb_corres])
-        apply (rule corres_splitEE [OF _ lec_corres])
+       apply (rule lookupCapAndSlot_corres, simp)
+      apply (rule corres_split_deprecated [OF _ lookupIPCBuffer_corres])
+        apply (rule corres_splitEE [OF _ lookupExtraCaps_corres])
             apply (rule corres_returnOkTT)
             apply simp+
          apply (wp | simp)+
@@ -348,7 +348,7 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
    apply (auto simp: obj_at'_def)
   done
 
-lemma set_domain_setDomain_corres:
+lemma setDomain_corres:
   "corres dc
      (valid_etcbs and valid_sched and tcb_at tptr and pspace_aligned and pspace_distinct)
      (invs'  and sch_act_simple
@@ -358,10 +358,10 @@ lemma set_domain_setDomain_corres:
   apply (rule corres_gen_asm2)
   apply (simp add: set_domain_def setDomain_def thread_set_domain_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply (rule corres_split_deprecated[OF _ tcbSchedDequeue_corres])
         apply (rule corres_split_deprecated[OF _ ethread_set_corres])
-                 apply (rule corres_split_deprecated[OF _ gts_isRunnable_corres])
+                 apply (rule corres_split_deprecated[OF _ isRunnable_corres])
                    apply simp
                    apply (rule corres_split_deprecated[OF corres_when[OF refl]])
                       apply (rule rescheduleRequired_corres)
@@ -395,7 +395,7 @@ lemma set_domain_setDomain_corres:
   done
 
 
-lemma pinv_corres:
+lemma performInvocation_corres:
   "\<lbrakk> inv_relation i i'; call \<longrightarrow> block \<rbrakk> \<Longrightarrow>
    corres (dc \<oplus> (=))
      (einvs and valid_invocation i
@@ -416,9 +416,9 @@ lemma pinv_corres:
               apply wp+
             apply simp+
           apply (rule corres_guard_imp)
-           apply (rule corres_split_deprecated [OF _ gct_corres])
+           apply (rule corres_split_deprecated [OF _ getCurThread_corres])
              apply simp
-             apply (rule corres_split_deprecated [OF _ send_ipc_corres])
+             apply (rule corres_split_deprecated [OF _ sendIPC_corres])
                 apply (rule corres_trivial)
                 apply simp
                apply simp
@@ -429,15 +429,15 @@ lemma pinv_corres:
                                sch_act_simple_def)
         apply (rule corres_guard_imp)
           apply (simp add: liftE_bindE)
-          apply (rule corres_split_deprecated [OF _ send_signal_corres])
+          apply (rule corres_split_deprecated [OF _ sendSignal_corres])
             apply (rule corres_trivial)
             apply (simp add: returnOk_def)
            apply wp+
          apply (simp+)[2]
        apply simp
        apply (rule corres_guard_imp)
-         apply (rule corres_split_eqr [OF _ gct_corres])
-           apply (rule corres_split_nor [OF _ do_reply_transfer_corres'])
+         apply (rule corres_split_eqr [OF _ getCurThread_corres])
+           apply (rule corres_split_nor [OF _ doReplyTransfer_corres'])
              apply (rule corres_trivial, simp)
             apply wp+
         apply (clarsimp simp: tcb_at_invs)
@@ -447,30 +447,30 @@ lemma pinv_corres:
        apply (fastforce elim!: cte_wp_at_weakenE')
       apply (clarsimp simp: liftME_def)
       apply (rule corres_guard_imp)
-        apply (erule tcbinv_corres)
+        apply (erule invokeTCB_corres)
        apply (simp)+
       \<comment> \<open>domain cap\<close>
       apply (clarsimp simp: invoke_domain_def)
       apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF _ set_domain_setDomain_corres])
+      apply (rule corres_split_deprecated [OF _ setDomain_corres])
         apply (rule corres_trivial, simp)
        apply (wp)+
        apply ((clarsimp simp: invs_psp_aligned invs_distinct)+)[2]
      \<comment> \<open>CNodes\<close>
      apply clarsimp
      apply (rule corres_guard_imp)
-       apply (rule corres_splitEE [OF _ inv_cnode_corres])
+       apply (rule corres_splitEE [OF _ invokeCNode_corres])
           apply (rule corres_trivial, simp add: returnOk_def)
          apply assumption
         apply wp+
       apply (clarsimp+)[2]
     apply (clarsimp simp: liftME_def[symmetric] o_def dc_def[symmetric])
-    apply (rule corres_guard_imp, rule invoke_irq_control_corres, simp+)
+    apply (rule corres_guard_imp, rule performIRQControl_corres, simp+)
    apply (clarsimp simp: liftME_def[symmetric] o_def dc_def[symmetric])
-   apply (rule corres_guard_imp, rule invoke_irq_handler_corres, simp+)
+   apply (rule corres_guard_imp, rule invokeIRQHandler_corres, simp+)
   apply clarsimp
   apply (rule corres_guard_imp)
-    apply (rule inv_arch_corres, assumption)
+    apply (rule arch_performInvocation_corres, assumption)
    apply (clarsimp+)[2]
   done
 
@@ -1179,7 +1179,7 @@ crunches reply_from_kernel
   for pspace_aligned[wp]: pspace_aligned
   and pspace_distinct[wp]: pspace_distinct
 
-lemma hinv_corres:
+lemma handleInvocation_corres:
   "c \<longrightarrow> b \<Longrightarrow>
    corres (dc \<oplus> dc)
           (einvs and (\<lambda>s. scheduler_action s = resume_cur_thread) and ct_active)
@@ -1189,19 +1189,19 @@ lemma hinv_corres:
           (handleInvocation c b)"
   apply (simp add: handle_invocation_def handleInvocation_def liftE_bindE)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ gct_corres])
-      apply (rule corres_split_deprecated [OF _ get_mi_corres])
+    apply (rule corres_split_eqr [OF _ getCurThread_corres])
+      apply (rule corres_split_deprecated [OF _ getMessageInfo_corres])
         apply clarsimp
         apply (simp add: liftM_def cap_register_def capRegister_def)
-        apply (rule corres_split_eqr [OF _ user_getreg_corres])
+        apply (rule corres_split_eqr [OF _ asUser_getRegister_corres])
           apply (rule syscall_corres)
                   apply (rule hinv_corres_assist, simp)
                  apply (clarsimp simp add: when_def)
-                 apply (rule hf_corres)
+                 apply (rule handleFault_corres)
                  apply simp
                 apply (simp add: split_def)
-                apply (rule corres_split_deprecated [OF _ get_mrs_corres])
-                  apply (rule decode_invocation_corres, simp_all)[1]
+                apply (rule corres_split_deprecated [OF _ getMRs_corres])
+                  apply (rule decodeInvocation_corres, simp_all)[1]
                    apply (fastforce simp: list_all2_map2 list_all2_map1 elim:  list_all2_mono)
                   apply (fastforce simp: list_all2_map2 list_all2_map1 elim:  list_all2_mono)
                  apply wp[1]
@@ -1209,17 +1209,17 @@ lemma hinv_corres:
                 apply simp
                 apply wp[1]
                apply (clarsimp simp: when_def)
-               apply (rule rfk_corres)
-              apply (rule corres_split_deprecated [OF _ sts_corres])
-                 apply (rule corres_splitEE [OF _ pinv_corres])
+               apply (rule replyFromKernel_corres)
+              apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+                 apply (rule corres_splitEE [OF _ performInvocation_corres])
                      apply simp
-                     apply (rule corres_split_deprecated [OF _ gts_corres])
+                     apply (rule corres_split_deprecated [OF _ getThreadState_corres])
                        apply (rename_tac state state')
                        apply (case_tac state, simp_all)[1]
                        apply (fold dc_def)[1]
-                       apply (rule corres_split_deprecated [OF sts_corres])
+                       apply (rule corres_split_deprecated [OF setThreadState_corres])
                           apply simp
-                         apply (rule corres_when [OF refl rfk_corres])
+                         apply (rule corres_when [OF refl replyFromKernel_corres])
                         apply (simp add: when_def)
                         apply (rule conjI, rule impI)
                          apply (wp reply_from_kernel_tcb_at)
@@ -1335,13 +1335,13 @@ crunch typ_at'[wp]: handleFault "\<lambda>s. P (typ_at' T p s)"
 
 lemmas handleFault_typ_ats[wp] = typ_at_lifts [OF handleFault_typ_at']
 
-lemma hs_corres:
+lemma handleSend_corres:
   "corres (dc \<oplus> dc)
           (einvs and (\<lambda>s. scheduler_action s = resume_cur_thread) and ct_active)
           (invs' and
            (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_active')
           (handle_send blocking) (handleSend blocking)"
-  by (simp add: handle_send_def handleSend_def hinv_corres)
+  by (simp add: handle_send_def handleSend_def handleInvocation_corres)
 
 lemma hs_invs'[wp]:
   "\<lbrace>invs' and ct_active' and
@@ -1365,7 +1365,7 @@ lemma tcb_at_cte_at_map:
   apply (auto elim: cte_wp_at_tcbI')
   done
 
-lemma delete_caller_cap_corres:
+lemma deleteCallerCap_corres:
   "corres dc (einvs and tcb_at t) (invs' and tcb_at' t)
      (delete_caller_cap t)
      (deleteCallerCap t)"
@@ -1461,7 +1461,7 @@ lemma delete_caller_cap_valid_ep_cap:
    by (wp get_cap_wp fast_finalise_typ_at abs_typ_at_lifts(1)
        | simp add: unless_def valid_cap_def)+
 
-lemma hw_corres':
+lemma handleRecv_isBlocking_corres':
    "corres dc (einvs and ct_in_state active
                     and (\<lambda>s. ex_nonz_cap_to (cur_thread s) s))
               (invs' and ct_in_state' simple'
@@ -1474,12 +1474,12 @@ lemma hw_corres':
                    cap_register_def capRegister_def
              cong: if_cong cap.case_cong capability.case_cong bool.case_cong)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ gct_corres])
-      apply (rule corres_split_eqr [OF _ user_getreg_corres])
+    apply (rule corres_split_eqr [OF _ getCurThread_corres])
+      apply (rule corres_split_eqr [OF _ asUser_getRegister_corres])
         apply (rule corres_split_catch)
-           apply (erule hf_corres)
+           apply (erule handleFault_corres)
           apply (rule corres_cap_fault)
-          apply (rule corres_splitEE [OF _ lc_corres])
+          apply (rule corres_splitEE [OF _ lookupCap_corres])
             apply (rule_tac P="?pre1 and tcb_at thread
                                and (\<lambda>s. (cur_thread s) = thread  )
                                and valid_cap rv"
@@ -1489,8 +1489,8 @@ lemma hw_corres':
              apply (rule corres_guard_imp)
                apply (rename_tac rights)
                 apply (case_tac "AllowRead \<in> rights"; simp)
-                 apply (rule corres_split_nor[OF _ delete_caller_cap_corres])
-                   apply (rule receive_ipc_corres)
+                 apply (rule corres_split_nor[OF _ deleteCallerCap_corres])
+                   apply (rule receiveIPC_corres)
                     apply (clarsimp)+
                   apply (wp delete_caller_cap_nonz_cap delete_caller_cap_valid_ep_cap)+
                 apply (clarsimp)+
@@ -1502,11 +1502,11 @@ lemma hw_corres':
                apply (rule_tac r'=ntfn_relation in corres_splitEE)
                   apply (rule corres_if)
                     apply (clarsimp simp: ntfn_relation_def)
-                   apply (clarsimp, rule receive_signal_corres)
+                   apply (clarsimp, rule receiveSignal_corres)
                     prefer 3
                     apply (rule corres_trivial)
                     apply (clarsimp simp: lookup_failure_map_def)+
-                 apply (rule get_ntfn_corres)
+                 apply (rule getNotification_corres)
                 apply (wp get_simple_ko_wp getNotification_wp | wpcw | simp)+
               apply (clarsimp simp: lookup_failure_map_def)
              apply (clarsimp simp: valid_cap_def ct_in_state_def)
@@ -1524,13 +1524,13 @@ lemma hw_corres':
                         ct_in_state'_def sch_act_sane_not)
   done
 
-lemma hw_corres:
+lemma handleRecv_isBlocking_corres:
   "corres dc (einvs and ct_active)
              (invs' and ct_active' and sch_act_sane and
                     (\<lambda>s. \<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p)))
             (handle_recv isBlocking) (handleRecv isBlocking)"
   apply (rule corres_guard_imp)
-    apply (rule hw_corres')
+    apply (rule handleRecv_isBlocking_corres')
    apply (clarsimp simp: ct_in_state_def)
    apply (fastforce elim!: st_tcb_weakenE st_tcb_ex_cap)
   apply (clarsimp simp: ct_in_state'_def invs'_def valid_state'_def)
@@ -1600,11 +1600,11 @@ lemma setSchedulerAction_obj_at'[wp]:
   unfolding setSchedulerAction_def
   by (wp, clarsimp elim!: obj_at'_pspaceI)
 
-lemma hy_corres:
+lemma handleYield_corres:
   "corres dc einvs (invs' and ct_active' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)) handle_yield handleYield"
   apply (clarsimp simp: handle_yield_def handleYield_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply simp
       apply (rule corres_split_deprecated[OF _ tcbSchedDequeue_corres])
         apply (rule corres_split_deprecated[OF _ tcbSchedAppend_corres])
@@ -1668,14 +1668,14 @@ lemma simple_from_running':
   by (clarsimp elim!: pred_tcb'_weakenE
                simp: ct_in_state'_def)+
 
-lemma hr_corres:
+lemma handleReply_corres:
   "corres dc (einvs and ct_running) (invs' and ct_running')
          handle_reply handleReply"
   apply (simp add: handle_reply_def handleReply_def
                    getThreadCallerSlot_map
                    getSlotCap_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ gct_corres])
+    apply (rule corres_split_eqr [OF _ getCurThread_corres])
       apply (rule corres_split_deprecated [OF _ get_cap_corres])
         apply (rule_tac P="einvs and cte_wp_at ((=) caller_cap) (thread, tcb_cnode_index 3)
                                 and K (is_reply_cap caller_cap \<or> caller_cap = cap.NullCap)
@@ -1686,8 +1686,8 @@ lemma hr_corres:
                               and cte_at' (cte_map (thread, tcb_cnode_index 3))"
                     in corres_inst)
         apply (auto split: cap_relation_split_asm arch_cap.split_asm bool.split
-                   intro!: corres_guard_imp [OF delete_caller_cap_corres]
-                           corres_guard_imp [OF do_reply_transfer_corres]
+                   intro!: corres_guard_imp [OF deleteCallerCap_corres]
+                           corres_guard_imp [OF doReplyTransfer_corres]
                            corres_fail
                      simp: valid_cap_def valid_cap'_def is_cap_simps assert_def is_reply_cap_to_def)[1]
         apply (fastforce simp: invs_def valid_state_def
@@ -1762,13 +1762,13 @@ lemma hr_ct_active'[wp]:
                   dest: ctes_of_valid')
   done
 
-lemma hc_corres:
+lemma handleCall_corres:
   "corres (dc \<oplus> dc) (einvs and (\<lambda>s. scheduler_action s = resume_cur_thread) and ct_active)
               (invs' and
                 (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
                 ct_active')
          handle_call handleCall"
-  by (simp add: handle_call_def handleCall_def liftE_bindE hinv_corres)
+  by (simp add: handle_call_def handleCall_def liftE_bindE handleInvocation_corres)
 
 lemma hc_invs'[wp]:
   "\<lbrace>invs' and
@@ -1912,14 +1912,14 @@ lemma handleReply_ct_not_ksQ:
 crunch valid_etcbs[wp]: handle_recv "valid_etcbs"
   (wp: crunch_wps simp: crunch_simps)
 
-lemma hrw_corres:
+lemma handleReply_handleRecv_corres:
   "corres dc (einvs and ct_running)
              (invs' and ct_running' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
          (do x \<leftarrow> handle_reply; handle_recv True od)
          (do x \<leftarrow> handleReply; handleRecv True od)"
   apply (rule corres_guard_imp)
-    apply (rule corres_split_nor [OF _ hr_corres])
-      apply (rule hw_corres')
+    apply (rule corres_split_nor [OF _ handleReply_corres])
+      apply (rule handleRecv_isBlocking_corres')
      apply (wp handle_reply_nonz_cap_to_ct handleReply_sane
                handleReply_nonz_cap_to_ct handleReply_ct_not_ksQ handle_reply_valid_sched)+
    apply (fastforce simp: ct_in_state_def ct_in_state'_def simple_sane_strg
@@ -1929,7 +1929,7 @@ lemma hrw_corres:
   apply (fastforce elim: pred_tcb'_weakenE)
   done
 
-lemma hh_corres:
+lemma handleHypervisorFault_corres:
   "corres dc (einvs and  st_tcb_at active thread and ex_nonz_cap_to thread
                    and (%_. valid_fault f))
              (invs' and sch_act_not thread
@@ -1940,20 +1940,20 @@ lemma hh_corres:
   done
 
 (* FIXME: move *)
-lemma he_corres:
+lemma handleEvent_corres:
   "corres (dc \<oplus> dc) (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and
                        (\<lambda>s. scheduler_action s = resume_cur_thread))
                       (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and
                        (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
                       (handle_event event) (handleEvent event)"
-  (is "?he_corres")
+  (is "?handleEvent_corres")
 proof -
   have hw:
     "\<And>isBlocking. corres dc (einvs and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread))
                (invs' and ct_running'
                       and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
                (handle_recv isBlocking) (handleRecv isBlocking)"
-    apply (rule corres_guard_imp [OF hw_corres])
+    apply (rule corres_guard_imp [OF handleRecv_isBlocking_corres])
      apply (clarsimp simp: ct_in_state_def ct_in_state'_def
                      elim!: st_tcb_weakenE pred_tcb'_weakenE
                      dest!: ct_not_ksQ)+
@@ -1964,17 +1964,17 @@ proof -
 
           apply (rename_tac syscall)
           apply (case_tac syscall)
-          apply (auto intro: corres_guard_imp[OF hs_corres]
+          apply (auto intro: corres_guard_imp[OF handleSend_corres]
                              corres_guard_imp[OF hw]
-                             corres_guard_imp [OF hr_corres]
-                             corres_guard_imp[OF hrw_corres]
-                             corres_guard_imp[OF hc_corres]
-                             corres_guard_imp[OF hy_corres]
+                             corres_guard_imp [OF handleReply_corres]
+                             corres_guard_imp[OF handleReply_handleRecv_corres]
+                             corres_guard_imp[OF handleCall_corres]
+                             corres_guard_imp[OF handleYield_corres]
                              active_from_running active_from_running'
                       simp: simple_sane_strg)[8]
          apply (rule corres_split')
-            apply (rule corres_guard_imp[OF gct_corres], simp+)
-           apply (rule hf_corres)
+            apply (rule corres_guard_imp[OF getCurThread_corres], simp+)
+           apply (rule handleFault_corres)
            apply simp
           apply (simp add: valid_fault_def)
           apply wp
@@ -1987,8 +1987,8 @@ proof -
                            sch_act_sane_def
                      elim: pred_tcb'_weakenE st_tcb_ex_cap'')[1]
         apply (rule corres_split')
-           apply (rule corres_guard_imp, rule gct_corres, simp+)
-          apply (rule hf_corres)
+           apply (rule corres_guard_imp, rule getCurThread_corres, simp+)
+          apply (rule handleFault_corres)
           apply (simp add: valid_fault_def)
          apply wp
          apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE
@@ -2004,7 +2004,7 @@ proof -
                                       and R'="\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> R'' x s"
                                       for R''])
             apply (case_tac rv, simp_all add: doMachineOp_return)[1]
-            apply (rule handle_interrupt_corres)
+            apply (rule handleInterrupt_corres)
            apply (rule corres_machine_op)
            apply (rule corres_Id, simp+)
            apply (wp hoare_vcg_all_lift
@@ -2015,10 +2015,10 @@ proof -
        apply simp
        apply (simp add: invs'_def valid_state'_def)
       apply (rule_tac corres_split')
-         apply (rule corres_guard_imp, rule gct_corres, simp+)
+         apply (rule corres_guard_imp, rule getCurThread_corres, simp+)
         apply (rule corres_split_catch)
-           apply (erule hf_corres)
-          apply (rule hv_corres)
+           apply (erule handleFault_corres)
+          apply (rule handleVMFault_corres)
          apply (rule hoare_elim_pred_conjE2)
          apply (rule hoare_vcg_E_conj, rule valid_validE_E, wp)
          apply (wp handle_vm_fault_valid_fault)
@@ -2032,8 +2032,8 @@ proof -
       apply (fastforce simp: simple_sane_strg sch_act_simple_def ct_in_state'_def
                   elim: st_tcb_ex_cap'' pred_tcb'_weakenE)
          apply (rule corres_split')
-            apply (rule corres_guard_imp[OF gct_corres], simp+)
-           apply (rule hh_corres)
+            apply (rule corres_guard_imp[OF getCurThread_corres], simp+)
+           apply (rule handleHypervisorFault_corres)
           apply (simp add: valid_fault_def)
           apply wp
           apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE

--- a/proof/refine/RISCV64/TcbAcc_R.thy
+++ b/proof/refine/RISCV64/TcbAcc_R.thy
@@ -283,7 +283,7 @@ lemma updateObject_tcb_inv:
   "\<lbrace>P\<rbrace> updateObject (obj::tcb) ko p q n \<lbrace>\<lambda>rv. P\<rbrace>"
   by simp (rule updateObject_default_inv)
 
-lemma tcb_update_corres':
+lemma setObject_update_TCB_corres':
   assumes tcbs: "tcb_relation tcb tcb' \<Longrightarrow> tcb_relation tcbu tcbu'"
   assumes tables: "\<forall>(getF, v) \<in> ran tcb_cap_cases. getF tcbu = getF tcb"
   assumes tables': "\<forall>(getF, v) \<in> ran tcb_cte_cases. getF tcbu' = getF tcb'"
@@ -298,7 +298,7 @@ lemma tcb_update_corres':
    apply (clarsimp simp: other_obj_relation_def exst)
   apply (rule corres_guard_imp)
     apply (rule corres_rel_imp)
-     apply (rule set_other_obj_corres[where P="(=) tcb'"])
+     apply (rule setObject_other_corres[where P="(=) tcb'"])
            apply (rule ext)+
            apply simp
           defer
@@ -314,7 +314,7 @@ lemma tcb_update_corres':
   apply simp
   done
 
-lemma tcb_update_corres:
+lemma setObject_update_TCB_corres:
   "\<lbrakk> tcb_relation tcb tcb' \<Longrightarrow> tcb_relation tcbu tcbu';
      \<forall>(getF, v) \<in> ran tcb_cap_cases. getF tcbu = getF tcb;
      \<forall>(getF, v) \<in> ran tcb_cte_cases. getF tcbu' = getF tcb';
@@ -323,13 +323,13 @@ lemma tcb_update_corres:
                (\<lambda>s'. (tcb', s') \<in> fst (getObject add s'))
                (set_object add (TCB tcbu)) (setObject add tcbu')"
   apply (rule corres_guard_imp)
-    apply (erule (3) tcb_update_corres', force)
+    apply (erule (3) setObject_update_TCB_corres', force)
    apply fastforce
   apply (clarsimp simp: getObject_def in_monad split_def obj_at'_def
                         loadObject_default_def objBits_simps' in_magnitude_check)
   done
 
-lemma assert_get_tcb_corres:
+lemma getObject_TCB_corres:
   "corres tcb_relation (tcb_at t and pspace_aligned and pspace_distinct) \<top>
           (gets_the (get_tcb t)) (getObject t)"
   apply (rule corres_cross_over_guard[where Q="tcb_at' t"])
@@ -341,7 +341,7 @@ lemma assert_get_tcb_corres:
   apply assumption
   done
 
-lemma threadget_corres:
+lemma threadGet_corres:
   assumes x: "\<And>tcb tcb'. tcb_relation tcb tcb' \<Longrightarrow> r (f tcb) (f' tcb')"
   shows      "corres r (tcb_at t and pspace_aligned and pspace_distinct) \<top>
                        (thread_get f t) (threadGet f' t)"
@@ -349,7 +349,7 @@ lemma threadget_corres:
   apply (fold liftM_def)
   apply simp
   apply (rule corres_rel_imp)
-   apply (rule assert_get_tcb_corres)
+   apply (rule getObject_TCB_corres)
   apply (simp add: x)
   done
 
@@ -381,8 +381,8 @@ lemma threadset_corresT:
                         (thread_set f t) (threadSet f' t)"
   apply (simp add: thread_set_def threadSet_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ assert_get_tcb_corres])
-      apply (rule tcb_update_corres')
+    apply (rule corres_split_deprecated [OF _ getObject_TCB_corres])
+      apply (rule setObject_update_TCB_corres')
           apply (erule x)
          apply (rule y)
         apply (clarsimp simp: bspec_split [OF spec [OF z]])
@@ -1338,7 +1338,7 @@ lemma threadSet_valid_objs':
   apply (clarsimp elim!: obj_at'_weakenE)
   done
 
-lemma corres_as_user':
+lemma asUser_corres':
   assumes y: "corres_underlying Id False True r \<top> \<top> f g"
   shows      "corres r (tcb_at t and pspace_aligned and pspace_distinct) \<top>
                        (as_user t f) (asUser t g)"
@@ -1368,7 +1368,7 @@ proof -
                      (\<lambda>s'. (tcb', s') \<in> fst (getObject add s'))
                      (set_object add (TCB (tcb \<lparr> tcb_arch := arch_tcb_context_set con (tcb_arch tcb) \<rparr>)))
                      (setObject add (tcb' \<lparr> tcbArch := atcbContextSet con' (tcbArch tcb') \<rparr>))"
-    by (rule tcb_update_corres [OF L2],
+    by (rule setObject_update_TCB_corres [OF L2],
         (simp add: tcb_cte_cases_def tcb_cap_cases_def cteSizeBits_def exst_same_def)+)
   have L4: "\<And>con con'. con = con' \<Longrightarrow>
             corres (\<lambda>(irv, nc) (irv', nc'). r irv irv' \<and> nc = nc')
@@ -1399,11 +1399,11 @@ proof -
     done
 qed
 
-lemma corres_as_user:
+lemma asUser_corres:
   assumes y: "corres_underlying Id False True r \<top> \<top> f g"
   shows      "corres r (tcb_at t and invs) (tcb_at' t and invs') (as_user t f) (asUser t g)"
   apply (rule corres_guard_imp)
-    apply (rule corres_as_user' [OF y])
+    apply (rule asUser_corres' [OF y])
    apply (simp add: invs_def valid_state_def valid_pspace_def)
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
   done
@@ -1428,10 +1428,10 @@ proof -
     done
 qed
 
-lemma user_getreg_corres:
+lemma asUser_getRegister_corres:
  "corres (=) (tcb_at t and pspace_aligned and pspace_distinct) \<top>
         (as_user t (getRegister r)) (asUser t (getRegister r))"
-  apply (rule corres_as_user')
+  apply (rule asUser_corres')
   apply (clarsimp simp: getRegister_def)
   done
 
@@ -1578,20 +1578,20 @@ lemma no_fail_asUser [wp]:
   apply simp
   done
 
-lemma user_setreg_corres:
+lemma asUser_setRegister_corres:
   "corres dc (tcb_at t and pspace_aligned and pspace_distinct) \<top>
              (as_user t (setRegister r v))
              (asUser t (setRegister r v))"
   apply (simp add: setRegister_def)
-  apply (rule corres_as_user')
+  apply (rule asUser_corres')
   apply (rule corres_modify'; simp)
   done
 
-lemma gts_corres:
+lemma getThreadState_corres:
   "corres thread_state_relation (tcb_at t and pspace_aligned and pspace_distinct) \<top>
           (get_thread_state t) (getThreadState t)"
   apply (simp add: get_thread_state_def getThreadState_def)
-  apply (rule threadget_corres)
+  apply (rule threadGet_corres)
   apply (simp add: tcb_relation_def)
   done
 
@@ -1618,11 +1618,11 @@ lemma gts_st_tcb_at'[wp]: "\<lbrace>st_tcb_at' P t\<rbrace> getThreadState t \<l
 lemma gts_inv'[wp]: "\<lbrace>P\<rbrace> getThreadState t \<lbrace>\<lambda>rv. P\<rbrace>"
   by (simp add: getThreadState_def) wp
 
-lemma gbn_corres:
+lemma getBoundNotification_corres:
   "corres (=) (tcb_at t and pspace_aligned and pspace_distinct) \<top>
           (get_bound_notification t) (getBoundNotification t)"
   apply (simp add: get_bound_notification_def getBoundNotification_def)
-  apply (rule threadget_corres)
+  apply (rule threadGet_corres)
   apply (simp add: tcb_relation_def)
   done
 
@@ -1783,16 +1783,16 @@ lemma no_fail_return:
   "no_fail x (return y)"
   by wp
 
-lemma addToBitmap_corres_noop:
+lemma addToBitmap_noop_corres:
   "corres dc \<top> \<top> (return ()) (addToBitmap d p)"
   unfolding addToBitmap_def modifyReadyQueuesL1Bitmap_def getReadyQueuesL1Bitmap_def
             modifyReadyQueuesL2Bitmap_def getReadyQueuesL2Bitmap_def
   by (rule corres_noop)
      (wp | simp add: state_relation_def | rule no_fail_pre)+
 
-lemma addToBitmap_if_null_corres_noop: (* used this way in Haskell code *)
+lemma addToBitmap_if_null_noop_corres: (* used this way in Haskell code *)
   "corres dc \<top> \<top> (return ()) (if null queue then addToBitmap d p else return ())"
-  by (cases "null queue", simp_all add: addToBitmap_corres_noop)
+  by (cases "null queue", simp_all add: addToBitmap_noop_corres)
 
 lemma removeFromBitmap_corres_noop:
   "corres dc \<top> \<top> (return ()) (removeFromBitmap tdom prioa)"
@@ -1844,7 +1844,7 @@ proof -
                apply (rule corres_split_noop_rhs2)
                    apply (rule corres_split_noop_rhs2)
                      apply (fastforce intro: threadSet_corres_noop simp: tcb_relation_def exst_same_def)
-                    apply (fastforce intro: addToBitmap_corres_noop)
+                    apply (fastforce intro: addToBitmap_noop_corres)
                    apply wp+
                  apply (simp add: tcb_sched_enqueue_def split del: if_split)
                  apply (rule_tac P=\<top> and Q="K (t \<notin> set queuea)" in corres_assume_pre)
@@ -1864,7 +1864,7 @@ lemma weak_sch_act_wf_updateDomainTime[simp]:
   "weak_sch_act_wf m (ksDomainTime_update f s) = weak_sch_act_wf m s"
   by (simp add:weak_sch_act_wf_def tcb_in_cur_domain'_def )
 
-lemma set_sa_corres:
+lemma setSchedulerAction_corres:
   "sched_act_relation sa sa'
     \<Longrightarrow> corres dc \<top> \<top> (set_scheduler_action sa) (setSchedulerAction sa')"
   apply (simp add: setSchedulerAction_def set_scheduler_action_def)
@@ -1873,7 +1873,7 @@ lemma set_sa_corres:
   apply (clarsimp simp: in_monad simpler_modify_def state_relation_def)
   done
 
-lemma get_sa_corres:
+lemma getSchedulerAction_corres:
   "corres sched_act_relation \<top> \<top> (gets scheduler_action) getSchedulerAction"
   apply (simp add: getSchedulerAction_def)
   apply (clarsimp simp: state_relation_def)
@@ -1885,10 +1885,10 @@ lemma rescheduleRequired_corres:
      (reschedule_required) rescheduleRequired"
   apply (simp add: rescheduleRequired_def reschedule_required_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ get_sa_corres])
+    apply (rule corres_split_deprecated[OF _ getSchedulerAction_corres])
       apply (rule_tac P="case action of switch_thread t \<Rightarrow> P t | _ \<Rightarrow> \<top>"
               and P'="case actiona of SwitchToThread t \<Rightarrow> P' t | _ \<Rightarrow> \<top>" for P P' in corres_split_deprecated[where r'=dc])
-         apply (rule set_sa_corres)
+         apply (rule setSchedulerAction_corres)
          apply simp
         apply (case_tac action)
           apply simp
@@ -1907,7 +1907,7 @@ lemma rescheduleRequired_corres_simple:
   apply (simp add: rescheduleRequired_def)
   apply (rule corres_symb_exec_r[where Q'="\<lambda>rv s. rv = ResumeCurrentThread \<or> rv = ChooseNewThread"])
      apply (rule corres_symb_exec_r)
-        apply (rule set_sa_corres, simp)
+        apply (rule setSchedulerAction_corres, simp)
        apply (wp | clarsimp split: scheduler_action.split)+
     apply (wp | clarsimp simp: sch_act_simple_def split: scheduler_action.split)+
   apply (simp add: getSchedulerAction_def)
@@ -2066,12 +2066,12 @@ lemma thread_get_isRunnable_corres:
   apply (fold liftM_def)
   apply simp
   apply (rule corres_rel_imp)
-   apply (rule assert_get_tcb_corres)
+   apply (rule getObject_TCB_corres)
   apply (clarsimp simp add: tcb_relation_def thread_state_relation_def)
   apply (case_tac "tcb_state x",simp_all)
   done
 
-lemma sts_corres:
+lemma setThreadState_corres:
   "thread_state_relation ts ts' \<Longrightarrow>
    corres dc
           (tcb_at t and pspace_aligned and pspace_distinct)
@@ -2086,8 +2086,8 @@ lemma sts_corres:
        apply simp
        apply (subst thread_get_test[where test="runnable"])
        apply (rule corres_split_deprecated[OF _ thread_get_isRunnable_corres])
-         apply (rule corres_split_deprecated[OF _ gct_corres])
-           apply (rule corres_split_deprecated[OF _ get_sa_corres])
+         apply (rule corres_split_deprecated[OF _ getCurThread_corres])
+           apply (rule corres_split_deprecated[OF _ getSchedulerAction_corres])
              apply (simp only: when_def)
              apply (rule corres_if[where Q=\<top> and Q'=\<top>])
                apply (rule iffI)
@@ -2098,7 +2098,7 @@ lemma sts_corres:
      apply (wp hoare_vcg_conj_lift[where Q'="\<top>\<top>"] | simp add: sch_act_simple_def)+
    done
 
-lemma sbn_corres:
+lemma setBoundNotification_corres:
   "corres dc
           (tcb_at t and pspace_aligned and pspace_distinct)
           \<top>
@@ -3182,7 +3182,7 @@ proof -
   thus ?thesis by (simp add: in_user_frame_def)
 qed
 
-lemma load_word_offs_corres:
+lemma loadWordUser_corres:
   assumes y: "y < unat max_ipc_words"
   shows "corres (=) \<top> (valid_ipc_buffer_ptr' a) (load_word_offs a y) (loadWordUser (a + of_nat y * 8))"
   unfolding loadWordUser_def
@@ -3201,7 +3201,7 @@ lemma load_word_offs_corres:
   apply (simp add: valid_ipc_buffer_ptr'_def msg_align_bits)
   done
 
-lemma store_word_offs_corres:
+lemma storeWordUser_corres:
   assumes y: "y < unat max_ipc_words"
   shows "corres dc (in_user_frame a) (valid_ipc_buffer_ptr' a)
                    (store_word_offs a y w) (storeWordUser (a + of_nat y * 8) w)"
@@ -3268,7 +3268,7 @@ lemma thread_get_registers:
   apply (clarsimp simp: map_upd_triv select_f_def image_def return_def)
   done
 
-lemma get_mrs_corres:
+lemma getMRs_corres:
   "corres (=) (tcb_at t and pspace_aligned and pspace_distinct)
               (case_option \<top> valid_ipc_buffer_ptr' buf)
               (get_mrs t buf mi) (getMRs t buf (message_info_map mi))"
@@ -3280,7 +3280,7 @@ lemma get_mrs_corres:
                   (thread_get (arch_tcb_get_registers o tcb_arch) t)
                   (asUser t (mapM getRegister RISCV64_H.msgRegisters))"
    apply (subst thread_get_registers)
-    apply (rule corres_as_user')
+    apply (rule asUser_corres')
     apply (subst mapM_gets)
      apply (simp add: getRegister_def)
     apply (simp add: S RISCV64_H.msgRegisters_def msg_registers_def)
@@ -3306,7 +3306,7 @@ lemma get_mrs_corres:
               apply simp
              apply simp
             apply (simp add: word_size wordSize_def wordBits_def)
-            apply (rule load_word_offs_corres)
+            apply (rule loadWordUser_corres)
             apply simp
            apply wp+
          apply simp
@@ -3380,7 +3380,7 @@ lemma UserContext_fold:
   apply (clarsimp split: prod.splits)
   by (metis user_context.sel(1))
 
-lemma set_mrs_corres:
+lemma setMRs_corres:
   assumes m: "mrs' = mrs"
   shows
   "corres (=) (tcb_at t and pspace_aligned and pspace_distinct and case_option \<top> in_user_frame buf)
@@ -3406,7 +3406,7 @@ proof -
      apply (clarsimp simp: msgRegisters_unfold setRegister_def2 zipWithM_x_Nil zipWithM_x_modify
                            take_min_len zip_take_triv2 min.commute)
      apply (rule corres_guard_imp)
-       apply (rule corres_split_nor [OF _ corres_as_user'], rule corres_trivial, simp)
+       apply (rule corres_split_nor [OF _ asUser_corres'], rule corres_trivial, simp)
          apply (rule corres_modify')
           apply (fastforce simp: fold_fun_upd[symmetric] msgRegisters_unfold UserContext_fold
                                  modify_registers_def
@@ -3419,11 +3419,11 @@ proof -
                           msgMaxLength_def msgLengthBits_def)
     apply (simp add: msg_max_length_def)
     apply (rule corres_guard_imp)
-      apply (rule corres_split_nor [OF _ corres_as_user'])
+      apply (rule corres_split_nor [OF _ asUser_corres'])
          apply (rule corres_split_nor, rule corres_trivial, clarsimp simp: min.commute)
           apply (rule_tac S="{((x, y), (x', y')). y = y' \<and> x' = (a + (of_nat x * 8)) \<and> x < unat max_ipc_words}"
                         in zipWithM_x_corres)
-              apply (fastforce intro: store_word_offs_corres)
+              apply (fastforce intro: storeWordUser_corres)
              apply wp+
             apply (clarsimp simp add: S msgMaxLength_def msg_max_length_def set_zip)
             apply (simp add: wordSize_def wordBits_def word_size max_ipc_words
@@ -3437,7 +3437,7 @@ proof -
      done
 qed
 
-lemma copy_mrs_corres:
+lemma copyMRs_corres:
   "corres (=) (tcb_at s and tcb_at r and pspace_aligned and pspace_distinct
                and case_option \<top> in_user_frame sb
                and case_option \<top> in_user_frame rb
@@ -3468,7 +3468,7 @@ proof -
              (take (unat n) msgRegisters))"
     apply (rule corres_guard_imp)
     apply (rule_tac S=Id in corres_mapM, simp+)
-        apply (rule corres_split_eqr [OF user_setreg_corres user_getreg_corres])
+        apply (rule corres_split_eqr [OF asUser_setRegister_corres asUser_getRegister_corres])
         apply (wp | clarsimp simp: msg_registers_def msgRegisters_def)+
         done
 
@@ -3504,9 +3504,9 @@ proof -
            apply (rule corres_trivial, simp)
           apply (rule_tac S="{(x, y). y = of_nat x \<and> x < unat max_ipc_words}" in corres_mapM, simp+)
               apply (rule corres_split_eqr)
-               apply (rule store_word_offs_corres)
+               apply (rule storeWordUser_corres)
                apply simp
-               apply (rule load_word_offs_corres)
+               apply (rule loadWordUser_corres)
                apply simp
               apply (wp hoare_vcg_all_lift | simp)+
            apply (clarsimp simp: upto_enum_def)
@@ -3596,7 +3596,7 @@ qed
 
 lemmas valid_ipc_buffer_cap_simps = valid_ipc_buffer_cap_def [split_simps cap.split arch_cap.split]
 
-lemma lipcb_corres':
+lemma lookupIPCBuffer_corres':
   "corres (=) (tcb_at t and valid_objs and pspace_aligned and pspace_distinct)
               (no_0_obj')
               (lookup_ipc_buffer w t) (lookupIPCBuffer w t)"
@@ -3605,7 +3605,7 @@ lemma lipcb_corres':
    apply (fastforce simp: pspace_aligned_cross pspace_distinct_cross state_relation_def)
   apply (simp add: lookup_ipc_buffer_def RISCV64_H.lookupIPCBuffer_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ threadget_corres])
+    apply (rule corres_split_eqr [OF _ threadGet_corres])
        apply (simp add: getThreadBufferSlot_def locateSlot_conv)
        apply (rule corres_split_deprecated [OF _ getSlotCap_corres])
           apply (rule_tac F="valid_ipc_buffer_cap rv buffer_ptr"
@@ -3645,9 +3645,9 @@ lemma lipcb_corres':
   apply clarsimp
   done
 
-lemma lipcb_corres:
+lemma lookupIPCBuffer_corres:
   "corres (=) (tcb_at t and invs) (no_0_obj') (lookup_ipc_buffer w t) (lookupIPCBuffer w t)"
-  using lipcb_corres'
+  using lookupIPCBuffer_corres'
   by (rule corres_guard_imp, auto simp: invs'_def valid_state'_def)
 
 
@@ -4533,7 +4533,7 @@ lemma asUser_irq_handlers':
   apply (wpsimp wp: threadSet_irq_handlers' [OF all_tcbI, OF ball_tcb_cte_casesI] select_f_inv)
   done
 
-(* the brave can try to move this up to near tcb_update_corres' *)
+(* the brave can try to move this up to near setObject_update_TCB_corres' *)
 
 definition non_exst_same :: "Structures_H.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
 where

--- a/proof/refine/RISCV64/Tcb_R.thy
+++ b/proof/refine/RISCV64/Tcb_R.thy
@@ -10,45 +10,45 @@ begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma setNextPCs_corres:
+lemma asUser_setNextPC_corres:
   "corres dc (tcb_at t and invs) (tcb_at' t and invs')
              (as_user t (setNextPC v)) (asUser t (setNextPC v))"
-  apply (rule corres_as_user)
+  apply (rule asUser_corres)
   apply (rule corres_Id, simp, simp)
   apply (rule no_fail_setNextPC)
   done
 
-lemma activate_idle_thread_corres:
+lemma activateIdleThread_corres:
  "corres dc (invs and st_tcb_at idle t)
             (invs' and st_tcb_at' idle' t)
     (arch_activate_idle_thread t) (activateIdleThread t)"
   by (simp add: arch_activate_idle_thread_def activateIdleThread_def)
 
-lemma activate_corres:
+lemma activateThread_corres:
  "corres dc (invs and ct_in_state activatable) (invs' and ct_in_state' activatable')
             activate_thread activateThread"
   apply (simp add: activate_thread_def activateThread_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ gct_corres])
+    apply (rule corres_split_eqr [OF _ getCurThread_corres])
       apply (rule_tac R="\<lambda>ts s. valid_tcb_state ts s \<and> (idle ts \<or> runnable ts)
                                 \<and> invs s \<and> st_tcb_at ((=) ts) thread s"
                   and R'="\<lambda>ts s. valid_tcb_state' ts s \<and> (idle' ts \<or> runnable' ts)
                                 \<and> invs' s \<and> st_tcb_at' (\<lambda>ts'. ts' = ts) thread s"
-                  in  corres_split_deprecated [OF _ gts_corres])
+                  in  corres_split_deprecated [OF _ getThreadState_corres])
         apply (rule_tac F="idle rv \<or> runnable rv" in corres_req, simp)
         apply (rule_tac F="idle' rv' \<or> runnable' rv'" in corres_req, simp)
         apply (case_tac rv, simp_all add:
                   isRunning_def isRestart_def,
                   safe, simp_all)[1]
          apply (rule corres_guard_imp)
-           apply (rule corres_split_eqr [OF _ getRestartPCs_corres])
-             apply (rule corres_split_nor [OF _ setNextPCs_corres])
-               apply (rule sts_corres)
+           apply (rule corres_split_eqr [OF _ asUser_getRestartPC_corres])
+             apply (rule corres_split_nor [OF _ asUser_setNextPC_corres])
+               apply (rule setThreadState_corres)
                apply (simp | wp weak_sch_act_wf_lift_linear)+
           apply (clarsimp simp: st_tcb_at_tcb_at invs_distinct)
          apply fastforce
         apply (rule corres_guard_imp)
-          apply (rule activate_idle_thread_corres)
+          apply (rule activateIdleThread_corres)
          apply (clarsimp elim!: st_tcb_weakenE)
         apply (clarsimp elim!: pred_tcb'_weakenE)
        apply (wp gts_st_tcb gts_st_tcb' gts_st_tcb_at)+
@@ -59,15 +59,15 @@ lemma activate_corres:
   done
 
 
-lemma bind_notification_corres:
+lemma bindNotification_corres:
   "corres dc
          (invs and tcb_at t and ntfn_at a) (invs' and tcb_at' t and ntfn_at' a)
          (bind_notification t a) (bindNotification t a)"
   apply (simp add: bind_notification_def bindNotification_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ get_ntfn_corres])
-      apply (rule corres_split_deprecated[OF _ set_ntfn_corres])
-         apply (rule sbn_corres)
+    apply (rule corres_split_deprecated[OF _ getNotification_corres])
+      apply (rule corres_split_deprecated[OF _ setNotification_corres])
+         apply (rule setBoundNotification_corres)
         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
        apply (wp)+
    apply auto
@@ -206,11 +206,11 @@ lemma restart_corres:
   apply (simp add: Tcb_A.restart_def Thread_H.restart_def)
   apply (simp add: isStopped_def2 liftM_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gts_corres])
+    apply (rule corres_split_deprecated [OF _ getThreadState_corres])
       apply (clarsimp simp add: runnable_tsr idle_tsr when_def)
       apply (rule corres_split_nor [OF _ cancel_ipc_corres])
-        apply (rule corres_split_nor [OF _ setup_reply_master_corres])
-          apply (rule corres_split_nor [OF _ sts_corres])
+        apply (rule corres_split_nor [OF _ setupReplyMaster_corres])
+          apply (rule corres_split_nor [OF _ setThreadState_corres])
              apply (rule corres_split_deprecated [OF possibleSwitchTo_corres tcbSchedEnqueue_corres])
               apply (wp set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at'
                               sts_valid_queues sts_st_tcb'
@@ -274,7 +274,7 @@ lemma
   no_fail_getRegister[wp]: "no_fail \<top> (getRegister r)"
   by (simp add: getRegister_def)
 
-lemma readreg_corres:
+lemma invokeTCB_ReadRegisters_corres:
   "corres (dc \<oplus> (=))
         (einvs  and tcb_at src and ex_nonz_cap_to src)
         (invs' and sch_act_simple and tcb_at' src and ex_nonz_cap_to' src)
@@ -285,9 +285,9 @@ lemma readreg_corres:
                    frameRegisters_def gpRegisters_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_nor)
-       apply (rule corres_split_deprecated [OF _ gct_corres])
+       apply (rule corres_split_deprecated [OF _ getCurThread_corres])
          apply (simp add: liftM_def[symmetric])
-         apply (rule corres_as_user)
+         apply (rule asUser_corres)
          apply (rule corres_Id)
            apply simp
           apply simp
@@ -302,7 +302,7 @@ lemma readreg_corres:
   apply (clarsimp simp: invs'_def valid_state'_def dest!: global'_no_ex_cap)
   done
 
-lemma arch_post_modify_registers_corres:
+lemma asUser_postModifyRegisters_corres:
   "corres dc (tcb_at t) (tcb_at' t and tcb_at' ct)
      (arch_post_modify_registers ct t)
      (asUser t $ postModifyRegisters ct t)"
@@ -313,7 +313,7 @@ lemma arch_post_modify_registers_corres:
     apply (rule corres_stateAssert_assume)
   by simp+
 
-lemma writereg_corres:
+lemma invokeTCB_WriteRegisters_corres:
   "corres (dc \<oplus> (=)) (einvs  and tcb_at dest and ex_nonz_cap_to dest)
         (invs' and sch_act_simple and tcb_at' dest and ex_nonz_cap_to' dest)
         (invoke_tcb (tcb_invocation.WriteRegisters dest resume values arch))
@@ -322,10 +322,10 @@ lemma writereg_corres:
                    sanitiseRegister_def sanitise_register_def getSanitiseRegisterInfo_def
                    frameRegisters_def gpRegisters_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gct_corres])
+    apply (rule corres_split_deprecated [OF _ getCurThread_corres])
       apply (rule corres_split_nor)
          prefer 2
-         apply (rule corres_as_user)
+         apply (rule asUser_corres)
          apply (simp add: zipWithM_mapM getRestartPC_def setNextPC_def)
          apply (rule corres_Id)
            apply (clarsimp simp: mask_def user_vtop_def
@@ -333,7 +333,7 @@ lemma writereg_corres:
           apply simp
          apply (rule no_fail_pre, wp no_fail_mapM)
             apply (clarsimp, (wp no_fail_setRegister | simp)+)
-        apply (rule corres_split_nor[OF _ arch_post_modify_registers_corres[simplified]])
+        apply (rule corres_split_nor[OF _ asUser_postModifyRegisters_corres[simplified]])
           apply (rule corres_split_nor[OF _ corres_when[OF refl restart_corres]])
             apply (rule corres_split_nor[OF _ corres_when[OF refl rescheduleRequired_corres]])
               apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
@@ -372,7 +372,7 @@ lemma suspend_ResumeCurrentThread_imp_notct[wp]:
    \<lbrace>\<lambda>rv s. ksSchedulerAction s = ResumeCurrentThread \<longrightarrow> ksCurThread s \<noteq> t'\<rbrace>"
   by (wpsimp simp: suspend_def)
 
-lemma copyreg_corres:
+lemma invokeTCB_CopyRegisters_corres:
   "corres (dc \<oplus> (=))
         (einvs and simple_sched_action and tcb_at dest and tcb_at src and ex_nonz_cap_to src and
           ex_nonz_cap_to dest)
@@ -394,11 +394,11 @@ proof -
     apply (rule corres_guard_imp)
       apply (rule corres_split_eqr)
         apply (simp add: setRegister_def)
-        apply (rule corres_as_user)
+        apply (rule asUser_corres)
         apply (rule corres_modify')
          apply simp
         apply simp
-       apply (rule user_getreg_corres)
+       apply (rule asUser_getRegister_corres)
        apply (simp add: invs_distinct invs_psp_aligned| wp)+
     done
   have R: "\<And>src src' des des' xs ys. \<lbrakk> src = src'; des = des'; xs = ys \<rbrakk> \<Longrightarrow>
@@ -419,8 +419,8 @@ proof -
                 (do pc \<leftarrow> as_user t getRestartPC; as_user t (setNextPC pc) od)
                 (do pc \<leftarrow> asUser t getRestartPC; asUser t (setNextPC pc) od)"
     apply (rule corres_guard_imp)
-      apply (rule corres_split_eqr [OF _ getRestartPCs_corres])
-        apply (rule setNextPCs_corres)
+      apply (rule corres_split_eqr [OF _ asUser_getRestartPC_corres])
+        apply (rule asUser_setNextPC_corres)
        apply wp+
      apply (simp add: invs_distinct invs_psp_aligned)+
     done
@@ -431,8 +431,8 @@ proof -
         apply (rule corres_split_deprecated [OF _ corres_when [OF refl restart_corres]], simp)
           apply (rule corres_split_nor)
              apply (rule corres_split_nor)
-                apply (rule corres_split_eqr[OF _ gct_corres])
-                  apply (rule corres_split_nor[OF _ arch_post_modify_registers_corres[simplified]])
+                apply (rule corres_split_eqr[OF _ getCurThread_corres])
+                  apply (rule corres_split_nor[OF _ asUser_postModifyRegisters_corres[simplified]])
                     apply (rule corres_split_deprecated[OF _ corres_when[OF refl rescheduleRequired_corres]])
                       apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
                       apply simp
@@ -533,14 +533,14 @@ lemma threadSet_valid_queues'_no_state:
   apply (fastforce simp: inQ_def split: if_split_asm)
   done
 
-lemma gts_isRunnable_corres:
+lemma isRunnable_corres:
   "corres (\<lambda>ts runn. runnable ts = runn)
           (tcb_at t and pspace_aligned and pspace_distinct) \<top>
           (get_thread_state t) (isRunnable t)"
   apply (simp add: isRunnable_def)
   apply (subst bind_return[symmetric])
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gts_corres])
+    apply (rule corres_split_deprecated[OF _ getThreadState_corres])
       apply (case_tac rv, clarsimp+)
      apply (wp hoare_TrueI)+
    apply auto
@@ -621,9 +621,9 @@ lemma sp_corres2:
   apply (rule stronger_corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ tcbSchedDequeue_corres])
       apply (rule corres_split_deprecated [OF _ ethread_set_corres], simp_all)[1]
-         apply (rule corres_split_deprecated [OF _ gts_isRunnable_corres])
+         apply (rule corres_split_deprecated [OF _ isRunnable_corres])
            apply (erule corres_when)
-           apply(rule corres_split_deprecated [OF _ gct_corres])
+           apply(rule corres_split_deprecated [OF _ getCurThread_corres])
              apply (wp corres_if; clarsimp)
               apply (rule rescheduleRequired_corres)
              apply (rule possibleSwitchTo_corres)
@@ -646,7 +646,7 @@ lemma sp_corres2:
   apply (force simp: state_relation_def elim: valid_objs'_maxDomain valid_objs'_maxPriority)
   done
 
-lemma sp_corres:
+lemma setPriority_corres:
   "corres dc (einvs and tcb_at t) (invs' and tcb_at' t and valid_objs' and (\<lambda>_. x \<le> maxPriority))
              (set_priority t x) (setPriority t x)"
   apply (rule corres_guard_imp)
@@ -655,7 +655,7 @@ lemma sp_corres:
   apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak)
   done
 
-lemma smcp_corres:
+lemma setMCPriority_corres:
   "corres dc (tcb_at t and pspace_aligned and pspace_distinct) \<top>
              (set_mcpriority t x) (setMCPriority t x)"
   apply (rule corres_guard_imp)
@@ -783,7 +783,7 @@ lemma sameObject_corres2:
   apply (case_tac arch_capa; simp)
   done
 
-lemma check_cap_at_corres:
+lemma checkCapAt_corres:
   assumes r: "cap_relation cap cap'"
   assumes c: "corres dc Q Q' f f'"
   assumes Q: "\<And>s. P s \<and> cte_wp_at (same_object_as cap) slot s \<Longrightarrow> Q s"
@@ -803,13 +803,13 @@ lemma check_cap_at_corres:
   apply (fastforce elim: cte_wp_at_weakenE' intro: Q')
   done
 
-lemma check_cap_at_corres_weak:
+lemma checkCapAt_weak_corres:
   assumes r: "cap_relation cap cap'"
   assumes c: "corres dc P P' f f'"
   shows "corres dc (P and cte_at slot and invs) (P' and pspace_aligned' and pspace_distinct')
              (check_cap_at cap slot f)
              (checkCapAt cap' (cte_map slot) f')"
-  apply (rule check_cap_at_corres, rule r, rule c)
+  apply (rule checkCapAt_corres, rule r, rule c)
   apply auto
   done
 
@@ -818,7 +818,7 @@ defs
   "assertDerived src cap f \<equiv>
    do stateAssert (\<lambda>s. cte_wp_at' (is_derived' (ctes_of s) src cap o cteCap) src s) []; f od"
 
-lemma checked_insert_corres:
+lemma checkCapAt_cteInsert_corres:
   "cap_relation new_cap newCap \<Longrightarrow>
    corres dc (einvs and cte_wp_at (\<lambda>c. c = cap.NullCap) (target, ref)
                and cte_at slot and K (is_cnode_or_valid_arch new_cap
@@ -844,12 +844,12 @@ lemma checked_insert_corres:
                         and
                         P'="cte_wp_at' (\<lambda>c. cteCap c = NullCap) (cte_map (target, ref))
                             and invs' and valid_cap' newCap"
-                       in check_cap_at_corres, assumption)
-      apply (rule check_cap_at_corres_weak, simp)
+                       in checkCapAt_corres, assumption)
+      apply (rule checkCapAt_weak_corres, simp)
       apply (unfold assertDerived_def)[1]
       apply (rule corres_stateAssert_implied [where P'=\<top>])
        apply simp
-       apply (erule cins_corres [OF _ refl refl])
+       apply (erule cteInsert_corres [OF _ refl refl])
       apply clarsimp
       apply (drule cte_wp_at_norm [where p=src_slot])
       apply (case_tac src_slot)
@@ -1180,7 +1180,7 @@ crunches option_update_thread
   for aligned[wp]: "pspace_aligned"
   and distinct[wp]: "pspace_distinct"
 
-lemma tc_corres:
+lemma transferCaps_corres:
   assumes x: "newroot_rel e e'" and y: "newroot_rel f f'"
       and z: "(case g of None \<Rightarrow> g' = None
                        | Some (vptr, g'') \<Rightarrow> \<exists>g'''. g' = Some (vptr, g''')
@@ -1244,14 +1244,14 @@ proof -
   have S: "\<And>t x. corres dc (einvs and tcb_at t) (invs' and tcb_at' t and valid_objs' and K (valid_option_prio p_auth))
                    (case_option (return ()) (\<lambda>(p, auth). set_priority t p) p_auth)
                    (case_option (return ()) (\<lambda>p'. setPriority t (fst p')) p_auth)"
-    apply (case_tac p_auth; clarsimp simp: sp_corres)
+    apply (case_tac p_auth; clarsimp simp: setPriority_corres)
     done
   have S': "\<And>t x. corres dc
                     (tcb_at t and pspace_aligned and pspace_distinct)
                     \<top>
                     (case_option (return ()) (\<lambda>(mcp, auth). set_mcpriority t mcp) mcp_auth)
                     (case_option (return ()) (\<lambda>mcp'. setMCPriority t (fst mcp')) mcp_auth)"
-    apply(case_tac mcp_auth; clarsimp simp: smcp_corres)
+    apply(case_tac mcp_auth; clarsimp simp: setMCPriority_corres)
     done
   have T: "\<And>x x' ref getfn target.
      \<lbrakk> newroot_rel x x'; getfn = return (cte_map (target, ref));
@@ -1287,9 +1287,9 @@ proof -
     apply (clarsimp simp add: newroot_rel_def returnOk_def split_def)
     apply (rule corres_gen_asm)
     apply (rule corres_guard_imp)
-      apply (rule corres_split_norE [OF _ cap_delete_corres])
+      apply (rule corres_split_norE [OF _ cteDelete_corres])
         apply (simp del: dc_simp)
-        apply (erule checked_insert_corres)
+        apply (erule checkCapAt_cteInsert_corres)
        apply (fold validE_R_def)
        apply (wp cap_delete_deletes cap_delete_cte_at cap_delete_valid_cap
                     | strengthen use_no_cap_to_obj_asid_strg)+
@@ -1365,7 +1365,7 @@ proof -
          apply (rule corres_split_norE)
             apply (rule_tac F="is_aligned aa msg_align_bits" in corres_gen_asm2)
             apply (rule corres_split_nor)
-               apply (rule corres_split_deprecated [OF _ gct_corres], clarsimp)
+               apply (rule corres_split_deprecated [OF _ getCurThread_corres], clarsimp)
                  apply (rule corres_when[OF refl rescheduleRequired_corres])
                 apply (wpsimp wp: gct_wp)+
               apply (rule threadset_corres,
@@ -1373,14 +1373,14 @@ proof -
              apply (wp thread_set_ipc_weak_valid_sched_action|wp (once) hoare_drop_imp)+
             apply simp
             apply (wp threadcontrol_corres_helper2 | wpc | simp)+
-           apply (rule cap_delete_corres)
+           apply (rule cteDelete_corres)
           apply (wp|strengthen einvs_valid_etcbs)+
          apply (wpsimp wp: cteDelete_invs' hoare_vcg_conj_lift)
         apply (fastforce simp: emptyable_def)
        apply fastforce
       apply clarsimp
       apply (rule corres_guard_imp)
-        apply (rule corres_split_norE [OF _ cap_delete_corres])
+        apply (rule corres_split_norE [OF _ cteDelete_corres])
           apply (rule_tac F="is_aligned aa msg_align_bits"
                         in corres_gen_asm)
           apply (rule_tac F="isArchObjectCap ac" in corres_gen_asm2)
@@ -1390,8 +1390,8 @@ proof -
                     simp add: tcb_relation_def, (simp add: exst_same_def)+)
             apply (rule corres_split_deprecated)
                prefer 2
-               apply (erule checked_insert_corres)
-              apply (rule corres_split_deprecated[OF _ gct_corres], clarsimp)
+               apply (erule checkCapAt_cteInsert_corres)
+              apply (rule corres_split_deprecated[OF _ getCurThread_corres], clarsimp)
                 apply (rule corres_when[OF refl rescheduleRequired_corres])
                apply (wp gct_wp)+
              apply (wp hoare_drop_imp threadcontrol_corres_helper3)[1]
@@ -1730,21 +1730,21 @@ where
 | "tcb_inv_wf' (tcbinvocation.SetTLSBase ref w)
              = (tcb_at' ref and ex_nonz_cap_to' ref)"
 
-lemma tcbinv_corres:
+lemma invokeTCB_corres:
  "tcbinv_relation ti ti' \<Longrightarrow>
   corres (dc \<oplus> (=))
          (einvs and simple_sched_action and Tcb_AI.tcb_inv_wf ti)
          (invs' and sch_act_simple and tcb_inv_wf' ti')
          (invoke_tcb ti) (invokeTCB ti')"
   apply (case_tac ti, simp_all only: tcbinv_relation.simps valid_tcb_invocation_def)
-         apply (rule corres_guard_imp [OF writereg_corres], simp+)[1]
-        apply (rule corres_guard_imp [OF readreg_corres], simp+)[1]
-       apply (rule corres_guard_imp [OF copyreg_corres], simp+)[1]
+         apply (rule corres_guard_imp [OF invokeTCB_WriteRegisters_corres], simp+)[1]
+        apply (rule corres_guard_imp [OF invokeTCB_ReadRegisters_corres], simp+)[1]
+       apply (rule corres_guard_imp [OF invokeTCB_CopyRegisters_corres], simp+)[1]
       apply (clarsimp simp del: invoke_tcb.simps)
       apply (rename_tac word one t2 mcp t3 t4 t5 t6 t7 t8 t9 t10 t11)
       apply (rule_tac F="is_aligned word 5" in corres_req)
        apply (clarsimp simp add: is_aligned_weaken [OF tcb_aligned])
-      apply (rule corres_guard_imp [OF tc_corres], clarsimp+)
+      apply (rule corres_guard_imp [OF transferCaps_corres], clarsimp+)
        apply (clarsimp simp: is_cnode_or_valid_arch_def
                       split: option.split option.split_asm)
       apply clarsimp
@@ -1760,14 +1760,14 @@ lemma tcbinv_corres:
    apply (case_tac option)
     apply simp
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated[OF _ unbind_notification_corres])
+      apply (rule corres_split_deprecated[OF _ unbindNotification_corres])
         apply (rule corres_trivial, simp)
        apply wp+
      apply (clarsimp)
     apply clarsimp
    apply simp
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated[OF _ bind_notification_corres])
+     apply (rule corres_split_deprecated[OF _ bindNotification_corres])
        apply (rule corres_trivial, simp)
       apply wp+
     apply clarsimp
@@ -1775,8 +1775,8 @@ lemma tcbinv_corres:
    apply (clarsimp simp: obj_at'_def)
   apply (simp add: invokeTCB_def tlsBaseRegister_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ TcbAcc_R.user_setreg_corres])
-      apply (rule corres_split_deprecated[OF _ Bits_R.gct_corres])
+    apply (rule corres_split_deprecated[OF _ TcbAcc_R.asUser_setRegister_corres])
+      apply (rule corres_split_deprecated[OF _ Bits_R.getCurThread_corres])
         apply (rule corres_split_deprecated[OF _ Corres_UL.corres_when])
             apply (rule corres_trivial, simp)
            apply simp
@@ -1875,7 +1875,7 @@ lemma copyregsets_map_only[simp]:
   "copyregsets_map v = RISCVNoExtraRegisters"
   by (cases "copyregsets_map v", simp)
 
-lemma decode_readreg_corres:
+lemma decodeReadRegisters_corres:
   "corres (ser \<oplus> tcbinv_relation) (invs and tcb_at t) (invs' and tcb_at' t)
      (decode_read_registers args (cap.ThreadCap t))
      (decodeReadRegisters args (ThreadCap t))"
@@ -1891,13 +1891,13 @@ lemma decode_readreg_corres:
        apply (rule corres_trivial)
        apply (fastforce simp: returnOk_def)
       apply (simp add: liftE_bindE)
-      apply (rule corres_split_deprecated[OF _ gct_corres])
+      apply (rule corres_split_deprecated[OF _ getCurThread_corres])
         apply (rule corres_trivial)
         apply (clarsimp simp: whenE_def)
        apply (wp|simp)+
   done
 
-lemma decode_writereg_corres:
+lemma decodeWriteRegisters_corres:
   notes if_cong [cong]
   shows
   "\<lbrakk> length args < 2 ^ word_bits \<rbrakk> \<Longrightarrow>
@@ -1914,7 +1914,7 @@ lemma decode_writereg_corres:
   apply clarsimp
   apply (rule corres_guard_imp)
     apply (simp add: liftE_bindE)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply (rule corres_split_norE)
          apply (rule corres_trivial, simp)
         apply (rule corres_trivial, simp)
@@ -1922,7 +1922,7 @@ lemma decode_writereg_corres:
    apply simp+
   done
 
-lemma decode_copyreg_corres:
+lemma decodeCopyRegisters_corres:
   "\<lbrakk> list_all2 cap_relation extras extras'; length args < 2 ^ word_bits \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation) (invs and tcb_at t) (invs' and tcb_at' t)
      (decode_copy_registers args (cap.ThreadCap t) extras)
@@ -1981,13 +1981,13 @@ lemma eq_ucast_word8[simp]:
                    source_size_def target_size_def word_size)
   done
 
-lemma check_prio_corres:
+lemma checkPrio_corres:
   "corres (ser \<oplus> dc) (tcb_at auth and pspace_aligned and pspace_distinct) \<top>
      (check_prio p auth) (checkPrio p auth)"
   apply (simp add: check_prio_def checkPrio_def)
   apply (rule corres_guard_imp)
     apply (simp add: liftE_bindE)
-    apply (rule corres_split_deprecated[OF _ threadget_corres])
+    apply (rule corres_split_deprecated[OF _ threadGet_corres])
        apply (rule_tac rvr = dc and
                          R = \<top> and
                         R' = \<top> in
@@ -2001,7 +2001,7 @@ lemma check_prio_corres:
    apply (simp add: cur_tcb_def cur_tcb'_def)+
   done
 
-lemma decode_set_priority_corres:
+lemma decodeSetPriority_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
@@ -2013,13 +2013,13 @@ lemma decode_set_priority_corres:
          clarsimp simp: decode_set_priority_def decodeSetPriority_def)
   apply (rename_tac auth_cap auth_slot auth_path rest auth_cap' rest')
   apply (rule corres_split_eqrE)
-     apply (rule corres_splitEE[OF _ check_prio_corres])
+     apply (rule corres_splitEE[OF _ checkPrio_corres])
        apply (rule corres_returnOkTT)
        apply (clarsimp simp: newroot_rel_def elim!: is_thread_cap.elims(2))
       apply wpsimp+
     by (corressimp simp: valid_cap_def valid_cap'_def)+
 
-lemma decode_set_mcpriority_corres:
+lemma decodeSetMCPriority_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
@@ -2031,7 +2031,7 @@ lemma decode_set_mcpriority_corres:
          clarsimp simp: decode_set_mcpriority_def decodeSetMCPriority_def)
   apply (rename_tac auth_cap auth_slot auth_path rest auth_cap' rest')
   apply (rule corres_split_eqrE)
-     apply (rule corres_splitEE[OF _ check_prio_corres])
+     apply (rule corres_splitEE[OF _ checkPrio_corres])
        apply (rule corres_returnOkTT)
        apply (clarsimp simp: newroot_rel_def elim!: is_thread_cap.elims(2))
       apply wpsimp+
@@ -2131,7 +2131,7 @@ lemma decodeSetSchedParams_wf[wp]:
          simp)
   done
 
-lemma decode_set_sched_params_corres:
+lemma decodeSetSchedParams_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
@@ -2147,15 +2147,15 @@ lemma decode_set_sched_params_corres:
    apply (clarsimp split: list.split simp: list_all2_Cons2)
   apply (clarsimp simp: list_all2_Cons1 neq_Nil_conv val_le_length_Cons linorder_not_less)
   apply (rule corres_split_eqrE)
-     apply (rule corres_split_norE[OF _ check_prio_corres])
-       apply (rule corres_splitEE[OF _ check_prio_corres])
+     apply (rule corres_split_norE[OF _ checkPrio_corres])
+       apply (rule corres_splitEE[OF _ checkPrio_corres])
          apply (rule corres_returnOkTT)
          apply (clarsimp simp: newroot_rel_def elim!: is_thread_cap.elims(2))
         apply (wpsimp wp: check_prio_inv checkPrio_inv)+
     apply (corressimp simp: valid_cap_def valid_cap'_def)+
   done
 
-lemma check_valid_ipc_corres:
+lemma checkValidIPCBuffer_corres:
   "cap_relation cap cap' \<Longrightarrow>
    corres (ser \<oplus> dc) \<top> \<top>
      (check_valid_ipc_buffer vptr cap)
@@ -2186,7 +2186,7 @@ lemma checkValidIPCBuffer_ArchObject_wp:
     | wpc | clarsimp simp: ipcBufferSizeBits_def isCap_simps is_aligned_mask msg_align_bits msgAlignBits_def)+
   done
 
-lemma decode_set_ipc_corres:
+lemma decodeSetIPCBuffer_corres:
   notes if_cong [cong]
   shows
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
@@ -2206,9 +2206,9 @@ lemma decode_set_ipc_corres:
              split del: if_split)
   apply (clarsimp simp add: returnOk_def newroot_rel_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_splitEE [OF _ derive_cap_corres])
+    apply (rule corres_splitEE [OF _ deriveCap_corres])
         apply (simp add: o_def newroot_rel_def split_def dc_def[symmetric])
-        apply (erule check_valid_ipc_corres)
+        apply (erule checkValidIPCBuffer_corres)
        apply (wp hoareE_TrueI | simp)+
   apply fastforce
   done
@@ -2256,7 +2256,7 @@ lemma decodeSetMCPriority_is_tc[wp]:
 crunch inv[wp]: decodeSetIPCBuffer "P"
   (simp: crunch_simps)
 
-lemma slot_long_running_corres:
+lemma slotCapLongRunningDelete_corres:
   "cte_map ptr = ptr' \<Longrightarrow>
    corres (=) (cte_at ptr and invs) invs'
            (slot_cap_long_running_delete ptr)
@@ -2266,7 +2266,7 @@ lemma slot_long_running_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ get_cap_corres])
       apply (auto split: cap_relation_split_asm arch_cap.split_asm
-                 intro!: corres_rel_imp [OF final_cap_corres[where ptr=ptr]]
+                 intro!: corres_rel_imp [OF isFinalCapability_corres[where ptr=ptr]]
                    simp: liftM_def[symmetric] final_matters'_def
                          long_running_delete_def
                          longRunningDelete_def isCap_simps)[1]
@@ -2289,7 +2289,7 @@ lemma cap_CNode_case_throw:
      = (doE unlessE (isCNodeCap cap) (throw x); m odE)"
   by (cases cap, simp_all add: isCap_simps unlessE_def)
 
-lemma decode_set_space_corres:
+lemma decodeSetSpace_corres:
   notes if_cong [cong]
   shows
  "\<lbrakk> cap_relation cap cap'; list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras';
@@ -2309,15 +2309,15 @@ lemma decode_set_space_corres:
                     getThreadCSpaceRoot getThreadVSpaceRoot
                  split del: if_split)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated [OF _ slot_long_running_corres])
-        apply (rule corres_split_deprecated [OF _ slot_long_running_corres])
+     apply (rule corres_split_deprecated [OF _ slotCapLongRunningDelete_corres])
+        apply (rule corres_split_deprecated [OF _ slotCapLongRunningDelete_corres])
            apply (rule corres_split_norE)
               apply (simp(no_asm) add: split_def unlessE_throwError_returnOk
                                        bindE_assoc cap_CNode_case_throw
                             split del: if_split)
-              apply (rule corres_splitEE [OF _ derive_cap_corres])
+              apply (rule corres_splitEE [OF _ deriveCap_corres])
                   apply (rule corres_split_norE)
-                     apply (rule corres_splitEE [OF _ derive_cap_corres])
+                     apply (rule corres_splitEE [OF _ deriveCap_corres])
                          apply (rule corres_split_norE)
                             apply (rule corres_trivial)
                             apply (clarsimp simp: returnOk_def newroot_rel_def is_cap_simps
@@ -2426,7 +2426,7 @@ lemma decodeSetSpace_tc_slot[wp]:
   apply simp
   done
 
-lemma decode_tcb_conf_corres:
+lemma decodeTCBConfigure_corres:
   notes if_cong [cong] option.case_cong [cong]
   shows
  "\<lbrakk> cap_relation cap cap'; list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras';
@@ -2443,8 +2443,8 @@ lemma decode_tcb_conf_corres:
   apply (clarsimp simp: linorder_not_less val_le_length_Cons list_all2_Cons1
       priorityBits_def)
   apply (rule corres_guard_imp)
-  apply (rule corres_splitEE [OF _ decode_set_ipc_corres])
-         apply (rule corres_splitEE [OF _ decode_set_space_corres])
+  apply (rule corres_splitEE [OF _ decodeSetIPCBuffer_corres])
+         apply (rule corres_splitEE [OF _ decodeSetSpace_corres])
               apply (rule_tac F="is_thread_control set_params" in corres_gen_asm)
               apply (rule_tac F="is_thread_control set_space" in corres_gen_asm)
   apply (rule_tac F="tcThreadCapSlot setSpace = cte_map slot" in corres_gen_asm2)
@@ -2514,7 +2514,7 @@ lemma corres_splitEE':
    apply (clarsimp simp: lift_def y)+
   done
 
-lemma decode_bind_notification_corres:
+lemma decodeBindNotification_corres:
 notes if_cong[cong] shows
   "\<lbrakk> list_all2 (\<lambda>x y. cap_relation (fst x) (fst y)) extras extras' \<rbrakk> \<Longrightarrow>
     corres (ser \<oplus> tcbinv_relation)
@@ -2538,7 +2538,7 @@ notes if_cong[cong] shows
                                 split: Structures_A.ntfn.splits Structures_H.ntfn.splits
                                        option.splits)
                      apply simp
-                     apply (rule get_ntfn_corres)
+                     apply (rule getNotification_corres)
                     apply wp+
                   apply (rule corres_trivial, clarsimp simp: whenE_def returnOk_def)
                  apply (wp | simp add: whenE_def split del: if_split)+
@@ -2548,7 +2548,7 @@ notes if_cong[cong] shows
               apply (wp | wpc | simp)+
             apply (rule corres_trivial, simp split: option.splits add: returnOk_def)
            apply (wp | wpc | simp)+
-         apply (rule gbn_corres)
+         apply (rule getBoundNotification_corres)
         apply (simp | wp gbn_wp gbn_wp')+
       apply (rule corres_trivial)
       apply (auto simp: returnOk_def whenE_def)[1]
@@ -2556,7 +2556,7 @@ notes if_cong[cong] shows
    apply (fastforce simp: valid_cap_def valid_cap'_def dest: hd_in_set)+
   done
 
-lemma decode_unbind_notification_corres:
+lemma decodeUnbindNotification_corres:
   "corres (ser \<oplus> tcbinv_relation)
       (tcb_at t and pspace_aligned and pspace_distinct)
       \<top>
@@ -2569,12 +2569,12 @@ lemma decode_unbind_notification_corres:
        apply (simp split: option.splits)
        apply (simp add: returnOk_def)
       apply simp
-      apply (rule gbn_corres)
+      apply (rule getBoundNotification_corres)
      apply wp+
    apply auto
   done
 
-lemma decode_set_tls_base_corres:
+lemma decodeSetTLSBase_corres:
   "corres (ser \<oplus> tcbinv_relation) (tcb_at t) (tcb_at' t)
           (decode_set_tls_base w (cap.ThreadCap t))
           (decodeSetTLSBase w (capability.ThreadCap t))"
@@ -2582,7 +2582,7 @@ lemma decode_set_tls_base_corres:
                  split: list.split)
   by (rule sym, rule ucast_id)
 
-lemma decode_tcb_inv_corres:
+lemma decodeTCBInvocation_corres:
  "\<lbrakk> c = Structures_A.ThreadCap t; cap_relation c c';
       list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras';
       length args < 2 ^ word_bits \<rbrakk> \<Longrightarrow>
@@ -2598,18 +2598,18 @@ lemma decode_tcb_inv_corres:
              split del: if_split split: gen_invocation_labels.split)
   apply (simp add: returnOk_def)
   apply (intro conjI impI
-             corres_guard_imp[OF decode_readreg_corres]
-             corres_guard_imp[OF decode_writereg_corres]
-             corres_guard_imp[OF decode_copyreg_corres]
-             corres_guard_imp[OF decode_tcb_conf_corres]
-             corres_guard_imp[OF decode_set_priority_corres]
-             corres_guard_imp[OF decode_set_mcpriority_corres]
-             corres_guard_imp[OF decode_set_sched_params_corres]
-             corres_guard_imp[OF decode_set_ipc_corres]
-             corres_guard_imp[OF decode_set_space_corres]
-             corres_guard_imp[OF decode_bind_notification_corres]
-             corres_guard_imp[OF decode_unbind_notification_corres]
-             corres_guard_imp[OF decode_set_tls_base_corres],
+             corres_guard_imp[OF decodeReadRegisters_corres]
+             corres_guard_imp[OF decodeWriteRegisters_corres]
+             corres_guard_imp[OF decodeCopyRegisters_corres]
+             corres_guard_imp[OF decodeTCBConfigure_corres]
+             corres_guard_imp[OF decodeSetPriority_corres]
+             corres_guard_imp[OF decodeSetMCPriority_corres]
+             corres_guard_imp[OF decodeSetSchedParams_corres]
+             corres_guard_imp[OF decodeSetIPCBuffer_corres]
+             corres_guard_imp[OF decodeSetSpace_corres]
+             corres_guard_imp[OF decodeBindNotification_corres]
+             corres_guard_imp[OF decodeUnbindNotification_corres]
+             corres_guard_imp[OF decodeSetTLSBase_corres],
          simp_all add: valid_cap_simps valid_cap_simps' invs_def valid_state_def
                        valid_pspace_def valid_sched_def)
   apply (auto simp: list_all2_map1 list_all2_map2

--- a/proof/refine/RISCV64/Untyped_R.thy
+++ b/proof/refine/RISCV64/Untyped_R.thy
@@ -92,7 +92,7 @@ lemma corres_check_no_children:
      apply (rule corres_guard_imp[OF corres_splitEE])
          apply (rule corres_returnOkTT)
          apply simp
-        apply (rule ensure_no_children_corres)
+        apply (rule ensureNoChildren_corres)
         apply simp
        apply wp+
       apply simp+
@@ -140,7 +140,7 @@ lemma corres_whenE_throw_merge:
   \<Longrightarrow> corres r P P' f (doE _ \<leftarrow> whenE A (throwError e); _ \<leftarrow>  whenE B (throwError e); h odE)"
   by (auto simp: whenE_def split: if_splits)
 
-lemma dec_untyped_inv_corres:
+lemma decodeUntypedInvocation_corres:
   assumes cap_rel: "list_all2 cap_relation cs cs'"
   shows "corres
         (ser \<oplus> untypinv_relation)
@@ -367,7 +367,7 @@ next
                   apply (rule_tac P = "valid_cap (cap.CNodeCap r bits g) and invs" in corres_guard_imp [where P' = invs'])
                     apply (rule mapME_x_corres_inv [OF _ _ _ refl])
                       apply (simp del: ser_def)
-                      apply (rule ensure_empty_corres)
+                      apply (rule ensureEmptySlot_corres)
                       apply (clarsimp simp: is_cap_simps)
                      apply (simp, wp)
                     apply (simp, wp)
@@ -391,7 +391,7 @@ next
            apply (rule corres_returnOkTT)
            apply (rule crel)
           apply simp
-          apply (rule corres_splitEE[OF _ lsfc_corres])
+          apply (rule corres_splitEE[OF _ lookupSlotForCNodeOp_corres])
               apply simp
               apply (rule getSlotCap_corres,simp)
              apply (rule crel)
@@ -1365,7 +1365,7 @@ crunch work_units_completed[wp]: create_cap_ext "\<lambda>s. P (work_units_compl
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma clearUntypedFreeIndex_corres_noop_psp:
+lemma updateNewFreeIndex_noop_psp_corres:
   "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False True
     dc \<top> (cte_at' slot)
     (return ()) (updateNewFreeIndex slot)"
@@ -1378,7 +1378,7 @@ lemma clearUntypedFreeIndex_corres_noop_psp:
         | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
   done
 
-lemma create_cap_corres:
+lemma insertNewCap_corres:
 notes if_cong[cong del] if_weak_cong[cong]
 shows
   "\<lbrakk> cref' = cte_map (fst tup)
@@ -1497,7 +1497,7 @@ shows
          apply (rule corres_underlying_symb_exec_l [OF set_original_symb_exec_l])
           apply (rule corres_cong[OF refl refl _ refl refl, THEN iffD1])
            apply (rule bind_return[THEN fun_cong])
-          apply (rule corres_split_deprecated [OF _ set_cap_pspace_corres])
+          apply (rule corres_split_deprecated [OF _ setCTE_corres])
              apply (subst bind_return[symmetric],
                     rule corres_split_deprecated)
                 prefer 2
@@ -1505,7 +1505,7 @@ shows
                 apply (rule updateMDB_symb_exec_r)
                apply (simp add: dc_def[symmetric])
                apply (rule corres_split_noop_rhs[OF _ updateMDB_symb_exec_r])
-                apply (rule clearUntypedFreeIndex_corres_noop_psp)
+                apply (rule updateNewFreeIndex_noop_psp_corres)
                apply (wp getCTE_wp set_cdt_valid_objs set_cdt_cte_at
                          hoare_weak_lift_imp | simp add: o_def)+
     apply (clarsimp simp: cte_wp_at_cte_at)
@@ -2846,7 +2846,7 @@ lemma inv_untyped_corres_helper1:
   apply (fold mapM_x_def)
   apply (rule corres_list_all2_mapM_)
      apply (rule corres_guard_imp)
-       apply (erule create_cap_corres)
+       apply (erule insertNewCap_corres)
       apply (clarsimp simp: cte_wp_at_def is_cap_simps)
      apply (clarsimp simp: fun_upd_def cte_wp_at_ctes_of)
     apply clarsimp
@@ -3792,7 +3792,7 @@ lemma descendants_range_ex_cte':
   apply blast
   done
 
-lemma update_untyped_cap_corres:
+lemma updateCap_isUntypedCap_corres:
   "\<lbrakk>is_untyped_cap cap; isUntypedCap cap'; cap_relation cap cap'\<rbrakk>
    \<Longrightarrow> corres dc
          (cte_wp_at (\<lambda>c. is_untyped_cap c \<and> obj_ref_of c = obj_ref_of cap \<and>
@@ -3819,7 +3819,7 @@ lemma update_untyped_cap_corres:
        apply (rule_tac F = " (cap.UntypedCap dev r bits f) = free_index_update (\<lambda>_. f) c"
                        in corres_gen_asm)
        apply simp
-       apply (rule set_untyped_cap_corres)
+       apply (rule setCTE_UntypedCap_corres)
          apply ((clarsimp simp: cte_wp_at_caps_of_state cte_wp_at_ctes_of)+)[3]
       apply (subst identity_eq)
       apply (wp getCTE_sp getCTE_get no_fail_getCTE)+
@@ -3844,7 +3844,7 @@ lemma updateFreeIndex_corres:
           apply (rule_tac F="isUntypedCap capa
                              \<and> cap_relation cap (capFreeIndex_update (\<lambda>_. idx) capa)"
                           in corres_gen_asm2)
-          apply (rule update_untyped_cap_corres, simp+)
+          apply (rule updateCap_isUntypedCap_corres, simp+)
            apply (clarsimp simp: isCap_simps)
           apply simp
          apply (wp getSlotCap_wp)+
@@ -4204,7 +4204,7 @@ lemma ex_tupI:
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma reset_untyped_cap_corres:
+lemma resetUntypedCap_corres:
   "untypinv_relation ui ui'
     \<Longrightarrow> corres (dc \<oplus> dc)
     (invs and valid_untyped_inv_wcap ui
@@ -4224,7 +4224,7 @@ lemma reset_untyped_cap_corres:
                        split del: if_split cong: if_cong)
        apply (rule corres_if[OF refl])
         apply (rule corres_returnOk[where P=\<top> and P'=\<top>], simp)
-       apply (rule corres_split_deprecated[OF _ detype_corres])
+       apply (rule corres_split_deprecated[OF _ deleteObjects_corres])
            apply (rule corres_if)
              apply (simp add: reset_chunk_bits_def resetChunkBits_def)
             apply (simp add: bits_of_def shiftL_nat)
@@ -4254,7 +4254,7 @@ lemma reset_untyped_cap_corres:
               apply (rule corres_guard_imp)
                 apply (rule corres_split_nor)
                    apply (rule corres_split_nor[OF _ updateFreeIndex_corres])
-                       apply (rule preemption_corres)
+                       apply (rule preemptionPoint_corres)
                       apply simp
                      apply (simp add: getFreeRef_def getFreeIndex_def free_index_of_def)
                      apply (subst unat_mult_simple)
@@ -4878,7 +4878,7 @@ lemma inv_untyped_corres':
         apply (rule corres_split_norE)
            prefer 2
            apply (rule corres_whenE, simp)
-            apply (rule reset_untyped_cap_corres[where ui=ui and ui'=ui'])
+            apply (rule resetUntypedCap_corres[where ui=ui and ui'=ui'])
             apply (simp add: ui ui')
            apply simp
           apply simp

--- a/proof/refine/X64/ArchAcc_R.thy
+++ b/proof/refine/X64/ArchAcc_R.thy
@@ -37,7 +37,7 @@ lemma asid_low_bits [simp]:
   "asidLowBits = asid_low_bits"
   by (simp add: asid_low_bits_def asidLowBits_def)
 
-lemma get_asid_pool_corres:
+lemma getObject_ASIDPool_corres:
   "corres (\<lambda>p p'. p = inv ASIDPool p' o ucast)
           (asid_pool_at p) (asid_pool_at' p)
           (get_asid_pool p) (getObject p)"
@@ -100,14 +100,14 @@ lemma aligned_distinct_relation_asid_pool_atI'[elim]:
                         projectKOs)
   done
 
-lemma get_asid_pool_corres':
+lemma getObject_ASIDPool_corres':
   assumes "p' = p"
   shows "corres (\<lambda>p p'. p = inv ASIDPool p' o ucast)
                 (asid_pool_at p) (pspace_aligned' and pspace_distinct')
                 (get_asid_pool p) (getObject p')"
   apply (simp add: assms)
   apply (rule stronger_corres_guard_imp,
-         rule get_asid_pool_corres)
+         rule getObject_ASIDPool_corres)
    apply auto
   done
 
@@ -180,13 +180,13 @@ lemma storePTE_state_refs_of[wp]:
 crunch cte_wp_at'[wp]: setIRQState "\<lambda>s. P (cte_wp_at' P' p s)"
 crunch inv[wp]: getIRQSlot "P"
 
-lemma set_asid_pool_corres:
+lemma setObject_ASIDPool_corres:
   "a = inv ASIDPool a' o ucast \<Longrightarrow>
   corres dc (asid_pool_at p and valid_etcbs) (asid_pool_at' p)
             (set_asid_pool p a) (setObject p a')"
   apply (simp add: set_asid_pool_def)
   apply (rule corres_guard_imp)
-    apply (rule set_other_obj_corres [where P="\<lambda>ko::asidpool. True"])
+    apply (rule setObject_other_corres [where P="\<lambda>ko::asidpool. True"])
           apply simp
          apply (clarsimp simp: obj_at'_def projectKOs)
          apply (erule map_to_ctes_upd_other, simp, simp)
@@ -204,12 +204,12 @@ lemma set_asid_pool_corres:
   apply (simp add: typ_at_to_obj_at_arches)
   done
 
-lemma set_asid_pool_corres':
+lemma setObject_ASIDPool_corres':
   "a = inv ASIDPool a' o ucast \<Longrightarrow>
   corres dc (asid_pool_at p and valid_etcbs) (pspace_aligned' and pspace_distinct')
             (set_asid_pool p a) (setObject p a')"
   apply (rule stronger_corres_guard_imp,
-         erule set_asid_pool_corres)
+         erule setObject_ASIDPool_corres)
    apply auto
   done
 
@@ -218,7 +218,7 @@ lemma mask_pd_bits_inner_beauty:
   (p && ~~ mask pd_bits) + (ucast ((ucast (p && mask pd_bits >> word_size_bits)) :: 9 word) << word_size_bits) = (p :: machine_word)"
   by (rule mask_split_aligned; simp add: bit_simps)
 
-lemma get_pde_corres:
+lemma getObject_PDE_corres:
   "corres (pde_relation') (pde_at p) (pde_at' p)
      (get_pde p) (getObject p)"
   apply (simp add: getObject_def get_pde_def get_pd_def get_object_def split_def bind_assoc)
@@ -279,12 +279,12 @@ lemma aligned_distinct_relation_pde_atI'[elim]:
                         projectKOs)
   done
 
-lemma get_pde_corres':
+lemma getObject_PDE_corres':
   "corres (pde_relation') (pde_at p)
      (pspace_aligned' and pspace_distinct')
      (get_pde p) (getObject p)"
   apply (rule stronger_corres_guard_imp,
-         rule get_pde_corres)
+         rule getObject_PDE_corres)
    apply auto[1]
   apply clarsimp
   apply (rule aligned_distinct_relation_pde_atI')
@@ -296,7 +296,7 @@ lemma mask_pt_bits_inner_beauty:
   (p && ~~ mask pt_bits) + (ucast ((ucast (p && mask pt_bits >> word_size_bits)) :: 9 word) << word_size_bits) = (p::machine_word)"
   by (rule mask_split_aligned; simp add: bit_simps)
 
-lemma get_pte_corres:
+lemma getObject_PTE_corres:
   "corres (pte_relation') (pte_at p) (pte_at' p)
      (get_pte p) (getObject p)"
   apply (simp add: getObject_def get_pte_def get_pt_def get_object_def split_def bind_assoc)
@@ -359,12 +359,12 @@ lemma aligned_distinct_relation_pte_atI'[elim]:
                         projectKOs)
   done
 
-lemma get_pte_corres':
+lemma getObject_PTE_corres':
   "corres (pte_relation') (pte_at p)
      (pspace_aligned' and pspace_distinct')
      (get_pte p) (getObject p)"
   apply (rule stronger_corres_guard_imp,
-         rule get_pte_corres)
+         rule getObject_PTE_corres)
    apply auto[1]
   apply clarsimp
   apply (rule aligned_distinct_relation_pte_atI')
@@ -376,7 +376,7 @@ lemma mask_pdpt_bits_inner_beauty:
   (p && ~~ mask pdpt_bits) + (ucast ((ucast (p && mask pdpt_bits >> word_size_bits)) :: 9 word) << word_size_bits) = (p::machine_word)"
   by (rule mask_split_aligned; simp add: bit_simps)
 
-lemma get_pdpte_corres:
+lemma getObject_PDPTE_corres:
   "corres (pdpte_relation') (pdpte_at p) (pdpte_at' p)
      (get_pdpte p) (getObject p)"
   apply (simp add: getObject_def get_pdpte_def get_pdpt_def get_object_def split_def bind_assoc)
@@ -439,12 +439,12 @@ lemma aligned_distinct_relation_pdpte_atI'[elim]:
                         projectKOs)
   done
 
-lemma get_pdpte_corres':
+lemma getObject_PDPTE_corres':
   "corres (pdpte_relation') (pdpte_at p)
      (pspace_aligned' and pspace_distinct')
      (get_pdpte p) (getObject p)"
   apply (rule stronger_corres_guard_imp,
-         rule get_pdpte_corres)
+         rule getObject_PDPTE_corres)
    apply auto[1]
   apply clarsimp
   apply (rule aligned_distinct_relation_pdpte_atI')
@@ -533,8 +533,8 @@ lemma get_pml4e_corres':
    apply (simp add:state_relation_def)+
   done
 
-\<comment> \<open>set_other_obj_corres unfortunately doesn't work here\<close>
-lemma set_pd_corres:
+\<comment> \<open>setObject_other_corres unfortunately doesn't work here\<close>
+lemma setObject_PD_corres:
   "pde_relation' pde pde' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PageDirectory pd)) (p && ~~ mask pd_bits)
                      and pspace_aligned and valid_etcbs)
@@ -619,8 +619,8 @@ lemma more_pt_inner_beauty:
   shows "(p && ~~ mask pt_bits) + (ucast x << word_size_bits) = p \<Longrightarrow> False"
   by (rule mask_split_aligned_neg[OF _ _ x]; simp add: bit_simps)
 
-\<comment> \<open>set_other_obj_corres unfortunately doesn't work here\<close>
-lemma set_pt_corres:
+\<comment> \<open>setObject_other_corres unfortunately doesn't work here\<close>
+lemma setObject_PT_corres:
   "pte_relation' pte pte' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PageTable pt)) (p && ~~ mask pt_bits)
                      and pspace_aligned and valid_etcbs)
@@ -705,8 +705,8 @@ lemma more_pdpt_inner_beauty:
   shows "(p && ~~ mask pdpt_bits) + (ucast x << word_size_bits) = p \<Longrightarrow> False"
   by (rule mask_split_aligned_neg[OF _ _ x]; simp add: bit_simps)
 
-\<comment> \<open>set_other_obj_corres unfortunately doesn't work here\<close>
-lemma set_pdpt_corres:
+\<comment> \<open>setObject_other_corres unfortunately doesn't work here\<close>
+lemma setObject_PDPT_corres:
   "pdpte_relation' pdpte pdpte' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PDPointerTable pt)) (p && ~~ mask pdpt_bits)
                      and pspace_aligned and valid_etcbs)
@@ -791,8 +791,8 @@ lemma more_pml4_inner_beauty:
   shows "(p && ~~ mask pml4_bits) + (ucast x << word_size_bits) = p \<Longrightarrow> False"
   by (rule mask_split_aligned_neg[OF _ _ x]; simp add: bit_simps)
 
-\<comment> \<open>set_other_obj_corres unfortunately doesn't work here\<close>
-lemma set_pml4_corres:
+\<comment> \<open>setObject_other_corres unfortunately doesn't work here\<close>
+lemma setObject_PML4_corres:
   "pml4e_relation' pml4e pml4e' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PageMapL4 pt)) (p && ~~ mask pml4_bits)
                      and pspace_aligned and valid_etcbs)
@@ -880,7 +880,7 @@ lemma store_pml4e_corres [corres]:
   using assms
   apply (simp add: store_pml4e_def storePML4E_def)
   apply (rule corres_symb_exec_l)
-     apply (erule set_pml4_corres)
+     apply (erule setObject_PML4_corres)
     apply (clarsimp simp: exs_valid_def get_pml4_def get_object_def exec_gets bind_assoc
                           obj_at_def pml4e_at_def)
     apply (clarsimp simp: a_type_def return_def
@@ -902,12 +902,12 @@ lemma store_pml4e_corres':
    apply auto
   done
 
-lemma store_pdpte_corres:
+lemma storePDPTE_corres:
   "pdpte_relation' pdpte pdpte' \<Longrightarrow>
   corres dc (pdpte_at p and pspace_aligned and valid_etcbs) (pdpte_at' p) (store_pdpte p pdpte) (storePDPTE p pdpte')"
   apply (simp add: store_pdpte_def storePDPTE_def)
   apply (rule corres_symb_exec_l)
-     apply (erule set_pdpt_corres)
+     apply (erule setObject_PDPT_corres)
     apply (clarsimp simp: exs_valid_def get_pdpt_def get_object_def exec_gets bind_assoc
                           obj_at_def pdpte_at_def)
     apply (clarsimp simp: a_type_def return_def
@@ -920,22 +920,22 @@ lemma store_pdpte_corres:
                   split: Structures_A.kernel_object.splits arch_kernel_obj.splits if_split_asm)
   done
 
-lemma store_pdpte_corres':
+lemma storePDPTE_corres':
   "pdpte_relation' pdpte pdpte' \<Longrightarrow>
   corres dc
      (pdpte_at p and pspace_aligned and valid_etcbs) (pspace_aligned' and pspace_distinct')
      (store_pdpte p pdpte) (storePDPTE p pdpte')"
   apply (rule stronger_corres_guard_imp,
-         erule store_pdpte_corres)
+         erule storePDPTE_corres)
    apply auto
   done
 
-lemma store_pde_corres:
+lemma storePDE_corres:
   "pde_relation' pde pde' \<Longrightarrow>
   corres dc (pde_at p and pspace_aligned and valid_etcbs) (pde_at' p) (store_pde p pde) (storePDE p pde')"
   apply (simp add: store_pde_def storePDE_def)
   apply (rule corres_symb_exec_l)
-     apply (erule set_pd_corres)
+     apply (erule setObject_PD_corres)
     apply (clarsimp simp: exs_valid_def get_pd_def get_object_def exec_gets bind_assoc
                           obj_at_def pde_at_def)
     apply (clarsimp simp: a_type_def return_def
@@ -948,22 +948,22 @@ lemma store_pde_corres:
                   split: Structures_A.kernel_object.splits arch_kernel_obj.splits if_split_asm)
   done
 
-lemma store_pde_corres':
+lemma storePDE_corres':
   "pde_relation' pde pde' \<Longrightarrow>
   corres dc
      (pde_at p and pspace_aligned and valid_etcbs) (pspace_aligned' and pspace_distinct')
      (store_pde p pde) (storePDE p pde')"
   apply (rule stronger_corres_guard_imp,
-         erule store_pde_corres)
+         erule storePDE_corres)
    apply auto
   done
 
-lemma store_pte_corres:
+lemma storePTE_corres:
   "pte_relation' pte pte' \<Longrightarrow>
   corres dc (pte_at p and pspace_aligned and valid_etcbs) (pte_at' p) (store_pte p pte) (storePTE p pte')"
   apply (simp add: store_pte_def storePTE_def)
   apply (rule corres_symb_exec_l)
-     apply (erule set_pt_corres)
+     apply (erule setObject_PT_corres)
     apply (clarsimp simp: exs_valid_def get_pt_def get_object_def
                           exec_gets bind_assoc obj_at_def pte_at_def)
     apply (clarsimp simp: a_type_def return_def
@@ -976,13 +976,13 @@ lemma store_pte_corres:
                   split: Structures_A.kernel_object.splits arch_kernel_obj.splits if_split_asm)
   done
 
-lemma store_pte_corres':
+lemma storePTE_corres':
   "pte_relation' pte pte' \<Longrightarrow>
   corres dc (pte_at p and pspace_aligned and valid_etcbs)
             (pspace_aligned' and pspace_distinct')
             (store_pte p pte) (storePTE p pte')"
   apply (rule stronger_corres_guard_imp,
-         erule store_pte_corres)
+         erule storePTE_corres)
    apply auto
   done
 
@@ -1244,7 +1244,7 @@ lemma pdpt_at_lift:
 lemmas checkPDPTAt_corres[corresK] =
   corres_stateAssert_implied_frame[OF pdpt_at_lift, folded checkPDPTAt_def]
 
-lemma lookup_pdpt_slot_corres:
+lemma lookupPDPTSlot_corres:
   "corres (lfr \<oplus> (=))
           (pspace_aligned and valid_vspace_objs and page_map_l4_at pml4
           and (\<exists>\<rhd>pml4) and
@@ -1295,7 +1295,7 @@ lemma get_pdpte_valid[wp]:
   done
 
 
-lemma lookup_pd_slot_corres:
+lemma lookupPDSlot_corres:
   "corres (lfr \<oplus> (=))
           (pspace_aligned and valid_vspace_objs and valid_arch_state and equal_kernel_mappings
            and valid_global_objs and (\<exists>\<rhd> pml4) and page_map_l4_at pml4 and
@@ -1304,11 +1304,11 @@ lemma lookup_pd_slot_corres:
           (lookup_pd_slot pml4 vptr) (lookupPDSlot pml4 vptr)"
   apply (simp add: lookup_pd_slot_def lookupPDSlot_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqrE[OF _ lookup_pdpt_slot_corres])
+    apply (rule corres_split_eqrE[OF _ lookupPDPTSlot_corres])
       apply (rule corres_splitEE
       [where R'="\<lambda>_. pspace_distinct'" and R="\<lambda>r. valid_pdpte r and pspace_aligned"])
          prefer 2
-         apply (simp, rule get_pdpte_corres')
+         apply (simp, rule getObject_PDPTE_corres')
         apply (case_tac pdpte; simp add: lookup_failure_map_def bit_simps lookupPDSlotFromPD_def
                                   split: pdpte.splits)
         apply (simp add: returnOk_liftE checkPDAt_def)
@@ -1341,7 +1341,7 @@ lemma get_pde_valid[wp]:
   apply simp
   done
 
-lemma lookup_pt_slot_corres:
+lemma lookupPTSlot_corres:
   "corres (lfr \<oplus> (=))
           (pspace_aligned and valid_vspace_objs and valid_arch_state and equal_kernel_mappings
            and valid_global_objs and (\<exists>\<rhd> pml4) and page_map_l4_at pml4 and
@@ -1350,11 +1350,11 @@ lemma lookup_pt_slot_corres:
           (lookup_pt_slot pml4 vptr) (lookupPTSlot pml4 vptr)"
     apply (simp add: lookup_pt_slot_def lookupPTSlot_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqrE[OF _ lookup_pd_slot_corres])
+    apply (rule corres_split_eqrE[OF _ lookupPDSlot_corres])
       apply (rule corres_splitEE
       [where R'="\<lambda>_. pspace_distinct'" and R="\<lambda>r. valid_pde r and pspace_aligned"])
          prefer 2
-         apply (simp, rule get_pde_corres')
+         apply (simp, rule getObject_PDE_corres')
         apply (case_tac pde; simp add: lookup_failure_map_def bit_simps lookupPTSlotFromPT_def
                                   split: pde.splits)
         apply (simp add: returnOk_liftE checkPTAt_def)
@@ -1467,7 +1467,7 @@ lemma arch_deriveCap_valid:
    apply (simp add: valid_cap'_def capAligned_def capUntypedPtr_def X64_H.capUntypedPtr_def)+
   done
 
-lemma arch_derive_corres:
+lemma arch_deriveCap_corres:
  "cap_relation (cap.ArchObjectCap c) (ArchObjectCap c') \<Longrightarrow>
   corres (ser \<oplus> (\<lambda>c c'. cap_relation c c'))
          \<top> \<top>
@@ -1507,7 +1507,7 @@ definition
 where
   "mapping_map \<equiv> page_entry_map \<otimes> page_entry_ptr_map"
 
-lemma create_mapping_entries_corres:
+lemma createMappingEntries_corres:
   notes mapping_map_simps = page_entry_map_def attr_mask_def attr_mask'_def page_entry_ptr_map_def
   shows
   "\<lbrakk> vm_rights' = vmrights_map vm_rights;
@@ -1527,7 +1527,7 @@ lemma create_mapping_entries_corres:
          apply (rule corres_returnOkTT)
          apply (clarsimp simp: vmattributes_map_def mapping_map_simps)
         apply (rule corres_lookup_error)
-        apply (rule lookup_pt_slot_corres)
+        apply (rule lookupPTSlot_corres)
        apply wp+
      apply clarsimp
     apply simp+
@@ -1536,7 +1536,7 @@ lemma create_mapping_entries_corres:
         apply (rule corres_returnOkTT)
         apply (clarsimp simp: vmattributes_map_def mapping_map_simps)
        apply (rule corres_lookup_error)
-       apply (rule lookup_pd_slot_corres)
+       apply (rule lookupPDSlot_corres)
       apply wp+
     apply clarsimp
    apply simp+
@@ -1545,7 +1545,7 @@ lemma create_mapping_entries_corres:
        apply (rule corres_returnOkTT)
        apply (clarsimp simp: vmattributes_map_def mapping_map_simps)
       apply (rule corres_lookup_error)
-      apply (rule lookup_pdpt_slot_corres)
+      apply (rule lookupPDPTSlot_corres)
      apply wp+
    apply clarsimp
   apply simp
@@ -1599,7 +1599,7 @@ lemma createMappingEntries_wf:
      apply (wp | simp split: vmpage_entry.splits)+
   by auto
 
-lemma ensure_safe_mapping_corres:
+lemma ensureSafeMapping_corres:
   notes mapping_map_simps = mapping_map_def page_entry_map_def page_entry_ptr_map_def attr_mask_def
   shows
   "\<lbrakk>mapping_map m m'\<rbrakk> \<Longrightarrow>
@@ -1624,7 +1624,7 @@ lemma ensure_safe_mapping_corres:
     apply (rule corres_guard_imp)
       apply (rule corres_initial_splitE [where Q="\<lambda>_. \<top>" and Q'="\<lambda>_. \<top>"])
          apply simp
-         apply (rule get_pde_corres')
+         apply (rule getObject_PDE_corres')
         apply (case_tac rv, simp_all add: corres_returnOk split:X64_H.pde.splits if_splits)[1]
        apply wp[2]
       apply (wp hoare_drop_imps | wpc | simp add: valid_mapping_entries_def)+
@@ -1636,7 +1636,7 @@ lemma ensure_safe_mapping_corres:
    apply (rule corres_guard_imp)
      apply (rule corres_initial_splitE [where Q="\<lambda>_. \<top>" and Q'="\<lambda>_. \<top>"])
         apply simp
-        apply (rule get_pdpte_corres')
+        apply (rule getObject_PDPTE_corres')
        apply (case_tac rv, simp_all add: corres_returnOk split:X64_H.pdpte.splits if_splits)[1]
       apply wp[2]
      apply (wp hoare_drop_imps | wpc | simp add: valid_mapping_entries_def)+
@@ -1660,7 +1660,7 @@ lemma le_mask_asidBits_asid_wf:
   "asid_wf asid \<longleftrightarrow> asid \<le> mask asidBits"
   by (simp add: asidBits_def asidHighBits_def asid_wf_def asid_bits_defs mask_def)
 
-lemma find_vspace_for_asid_corres:
+lemma findVSpaceForASID_corres:
   assumes "asid' = asid"
   shows "corres (lfr \<oplus> (=))
                 ((\<lambda>s. valid_arch_state s \<or> vspace_at_asid_ex asid s)
@@ -1681,7 +1681,7 @@ lemma find_vspace_for_asid_corres:
   apply (simp add: liftME_def bindE_assoc)
   apply (simp add: liftE_bindE)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_asid_pool_corres'[OF refl]])
+    apply (rule corres_split_deprecated [OF _ getObject_ASIDPool_corres'[OF refl]])
       apply (rule_tac P="case_option \<top> page_map_l4_at (pool (ucast asid)) and pspace_aligned"
                  and P'="no_0_obj' and pspace_distinct'" in corres_inst)
       apply (rule_tac F="pool (ucast asid) \<noteq> Some 0" in corres_req)
@@ -1736,14 +1736,14 @@ lemma find_vspace_for_asid_corres:
   apply simp
   done
 
-lemma find_vspace_for_asid_corres':
+lemma findVSpaceForASID_corres':
   assumes "asid' = asid"
   shows "corres (lfr \<oplus> (=))
                 (vspace_at_asid_ex asid and valid_vspace_objs
                     and pspace_aligned and  K (0 < asid \<and> asid_wf asid))
                 (pspace_aligned' and pspace_distinct' and no_0_obj')
                 (find_vspace_for_asid asid) (findVSpaceForASID asid')"
-  apply (rule corres_guard_imp, rule find_vspace_for_asid_corres[OF assms])
+  apply (rule corres_guard_imp, rule findVSpaceForASID_corres[OF assms])
    apply fastforce
   apply simp
   done

--- a/proof/refine/X64/Bits_R.thy
+++ b/proof/refine/X64/Bits_R.thy
@@ -195,13 +195,13 @@ lemma tcb_in_valid_state':
   apply (fastforce simp add: valid_obj'_def valid_tcb'_def)
   done
 
-lemma gct_corres: "corres (=) \<top> \<top> (gets cur_thread) getCurThread"
+lemma getCurThread_corres: "corres (=) \<top> \<top> (gets cur_thread) getCurThread"
   by (simp add: getCurThread_def curthread_relation)
 
 lemma gct_wp [wp]: "\<lbrace>\<lambda>s. P (ksCurThread s) s\<rbrace> getCurThread \<lbrace>P\<rbrace>"
   by (unfold getCurThread_def, wp)
 
-lemma git_corres:
+lemma getIdleThread_corres:
   "corres (=) \<top> \<top> (gets idle_thread) getIdleThread"
   by (simp add: getIdleThread_def state_relation_def)
 

--- a/proof/refine/X64/CNodeInv_R.thy
+++ b/proof/refine/X64/CNodeInv_R.thy
@@ -155,7 +155,7 @@ lemma cancelSendRightsEq:
                   split: cap.splits bool.splits if_splits |
          case_tac x)+
 
-lemma dec_cnode_inv_corres:
+lemma decodeCNodeInvocation_corres:
   "\<lbrakk> cap_relation (cap.CNodeCap w n list) cap'; list_all2 cap_relation cs cs';
      length list \<le> 64 \<rbrakk> \<Longrightarrow>
   corres
@@ -174,9 +174,9 @@ lemma dec_cnode_inv_corres:
                    split del: if_split
                         cong: if_cong list.case_cong)
         apply (rule corres_guard_imp)
-          apply (rule corres_splitEE [OF _ lsfc_corres])
-              apply (rule corres_splitEE [OF _ ensure_empty_corres])
-                 apply (rule corres_splitEE [OF _ lsfc_corres])
+          apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
+              apply (rule corres_splitEE [OF _ ensureEmptySlot_corres])
+                 apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
                      apply (simp(no_asm) add: liftE_bindE del: de_Morgan_conj split del: if_split)
                      apply (rule corres_split_deprecated [OF _ get_cap_corres'])
                         prefer 2
@@ -198,7 +198,7 @@ lemma dec_cnode_inv_corres:
                              prefer 2
                              apply (simp add: returnOk_def del: imp_disjL)
                              apply (rule conjI[rotated], rule impI)
-                              apply (rule derive_cap_corres)
+                              apply (rule deriveCap_corres)
                                apply (clarsimp simp: cap_relation_mask
                                                      cap_map_update_data
                                               split: option.split)
@@ -216,7 +216,7 @@ lemma dec_cnode_inv_corres:
        \<comment> \<open>Revoke\<close>
        apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                         isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
-       apply (rule corres_guard_imp, rule corres_splitEE [OF _ lsfc_corres])
+       apply (rule corres_guard_imp, rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
              apply (simp add: split_beta)
              apply (rule corres_returnOkTT)
              apply simp
@@ -229,7 +229,7 @@ lemma dec_cnode_inv_corres:
       apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                        isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
       apply (rule corres_guard_imp)
-        apply (rule corres_splitEE [OF _ lsfc_corres])
+        apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
             apply (simp add: split_beta)
             apply (rule corres_returnOkTT)
             apply simp
@@ -242,12 +242,12 @@ lemma dec_cnode_inv_corres:
      apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                       isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
      apply (rule corres_guard_imp)
-       apply (rule corres_splitEE [OF _ lsfc_corres])
+       apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
            apply (simp add: split_beta)
            apply (rule corres_split_norE)
               apply (rule corres_returnOkTT)
               apply simp
-             apply (rule ensure_empty_corres)
+             apply (rule ensureEmptySlot_corres)
              apply simp
             apply wp+
            apply simp
@@ -260,7 +260,7 @@ lemma dec_cnode_inv_corres:
     apply (simp add: decode_cnode_invocation_def decodeCNodeInvocation_def
                      isCap_simps Let_def unlessE_whenE del: ser_def split del: if_split)
     apply (rule corres_guard_imp)
-      apply (rule corres_splitEE [OF _ lsfc_corres])
+      apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
           apply (simp(no_asm) add: split_beta liftE_bindE)
           apply (rule corres_split_deprecated [OF _ get_cap_corres'])
              apply (rule corres_split_norE)
@@ -279,9 +279,9 @@ lemma dec_cnode_inv_corres:
    apply (simp add: le_diff_conv2 split_def decode_cnode_invocation_def decodeCNodeInvocation_def
                     isCap_simps Let_def unlessE_whenE whenE_whenE_body
                del: disj_not1 ser_def split del: if_split)
-   apply (rule corres_guard_imp, rule corres_splitEE [OF _ lsfc_corres])
+   apply (rule corres_guard_imp, rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])
          apply (rename_tac dest_slot destSlot)
-         apply (rule corres_splitEE [OF _ lsfc_corres])+
+         apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres])+
                  apply (rule_tac R = "\<lambda>s. cte_at pivot_slot s \<and> cte_at dest_slot s
                                         \<and> cte_at src_slot s \<and> invs s" in
                    whenE_throwError_corres' [where R' = \<top>])
@@ -321,7 +321,7 @@ lemma dec_cnode_inv_corres:
                     apply (drule (2) cte_map_inj_eq, clarsimp+)[1]
                    apply (rule corres_guard_imp)
                      apply (erule corres_whenE)
-                      apply (rule ensure_empty_corres)
+                      apply (rule ensureEmptySlot_corres)
                       apply clarsimp
                      apply simp
                     apply clarsimp
@@ -355,7 +355,7 @@ lemma dec_cnode_inv_corres:
                          cnode_invok_case_cleanup
               split del: if_split cong: if_cong)
    apply (rule corres_guard_imp)
-     apply (rule corres_splitEE[OF _ lsfc_corres])
+     apply (rule corres_splitEE[OF _ lookupSlotForCNodeOp_corres])
          apply (rule corres_trivial, clarsimp split: list.split_asm)
         apply simp+
       apply wp+
@@ -365,7 +365,7 @@ lemma dec_cnode_inv_corres:
                         isCNodeCap_CNodeCap split_def unlessE_whenE
              split del: if_split cong: if_cong)
   apply (rule corres_guard_imp)
-   apply (rule corres_splitEE [OF _ lsfc_corres wp_post_tautE wp_post_tautE])
+   apply (rule corres_splitEE [OF _ lookupSlotForCNodeOp_corres wp_post_tautE wp_post_tautE])
      apply (clarsimp simp: list_all2_Cons1 list_all2_Nil
                     split: list.split_asm split del: if_split)
      apply simp
@@ -7096,7 +7096,7 @@ proof (induct rule: rec_del.induct,
                                  whenE_liftE)
         apply (rule corres_when, simp)
         apply simp
-        apply (rule empty_slot_corres)
+        apply (rule emptySlot_corres)
        apply (wp rec_del_invs rec_del_valid_list rec_del_cte_at finaliseSlot_invs hoare_drop_imps
                  preemption_point_inv'
             | simp)+
@@ -7122,10 +7122,10 @@ next
                 simp add: returnOk_def)
         apply (rule spec_corres_splitE')
            apply simp
-           apply (rule final_cap_corres[where ptr=slot])
+           apply (rule isFinalCapability_corres[where ptr=slot])
           apply (rule spec_corres_splitE')
              apply simp
-             apply (rule finalise_cap_corres[where sl=slot])
+             apply (rule finaliseCap_corres[where sl=slot])
                apply simp
               apply simp
              apply simp
@@ -7143,13 +7143,13 @@ next
                apply (erule conjunct2)
               apply (rule drop_spec_corres,
                      simp add: liftME_def[symmetric] o_def dc_def[symmetric])
-              apply (rule cap_update_corres)
+              apply (rule updateCap_corres)
                apply simp
               apply (simp(no_asm_use) add: cap_cyclic_zombie_def split: cap.split_asm)
               apply (simp add: is_cap_simps)
              apply (rule spec_corres_splitE')
                 apply simp
-                apply (rule cap_update_corres, erule conjunct1)
+                apply (rule updateCap_corres, erule conjunct1)
                 apply (case_tac "fst rvb", auto simp: isCap_simps is_cap_simps)[1]
                apply (rule spec_corres_splitE)
                   apply (rule iffD1 [OF spec_corres_liftME2[where fn="\<lambda>v. (True, NullCap)"]])
@@ -7158,7 +7158,7 @@ next
                    apply (rename_tac nat)
                    apply (case_tac nat, simp_all)[1]
                   apply clarsimp
-                 apply (rule spec_corres_splitE'[OF preemption_corres])
+                 apply (rule spec_corres_splitE'[OF preemptionPoint_corres])
                    apply (rule "2.hyps"(2)[unfolded fun_app_def rec_del_concrete_unfold
                                                     finaliseSlot_def],
                           assumption+)
@@ -7281,7 +7281,7 @@ next
        apply (clarsimp simp: cte_wp_at_def)
        apply (drule(1) zombies_finalD2, clarsimp+)
       apply (fold dc_def)
-      apply (rule corres_guard_imp, rule cap_swap_for_delete_corres)
+      apply (rule corres_guard_imp, rule capSwapForDelete_corres)
          apply (simp add: cte_map_replicate)
         apply simp
        apply clarsimp
@@ -7364,7 +7364,7 @@ next
              apply (rule corres_symb_exec_r)
                 apply (rule_tac F="cteCap endCTE = capability.NullCap"
                             in corres_gen_asm2, simp)
-                apply (rule cap_update_corres)
+                apply (rule updateCap_corres)
                  apply simp
                 apply (simp add: is_cap_simps)
                apply (rule_tac Q="\<lambda>rv. cte_at' (cte_map ?target)" in valid_prove_more)
@@ -7460,7 +7460,7 @@ next
     done
 qed
 
-lemma cap_delete_corres:
+lemma cteDelete_corres:
   "corres (dc \<oplus> dc)
       (einvs and simple_sched_action and cte_at ptr and emptyable ptr)
       (invs' and sch_act_simple and cte_at' (cte_map ptr))
@@ -7709,7 +7709,7 @@ lemma cap_revoke_mdb_stuff4:
        apply(simp add: cte_wp_at_def)+
        done
 
-lemma cap_revoke_corres':
+lemma cteRevoke_corres':
   "spec_corres s (dc \<oplus> dc)
       (einvs and simple_sched_action and cte_at ptr)
       (invs' and sch_act_simple and cte_at' (cte_map ptr))
@@ -7831,8 +7831,8 @@ proof (induct rule: cap_revoke.induct)
      apply (rule cap_revoke_mdb_stuff4, (simp add: in_get_cap_cte_wp_at)+)
     apply (clarsimp simp: whenE_def)
     apply (rule spec_corres_guard_imp)
-      apply (rule spec_corres_splitE' [OF cap_delete_corres])
-        apply (rule spec_corres_splitE' [OF preemption_corres])
+      apply (rule spec_corres_splitE' [OF cteDelete_corres])
+        apply (rule spec_corres_splitE' [OF preemptionPoint_corres])
           apply (rule "1.hyps",
                    (simp add: cte_wp_at_def in_monad select_def next_revoke_cap_def select_ext_def
                      | assumption | rule conjI refl)+)[1]
@@ -7846,7 +7846,7 @@ proof (induct rule: cap_revoke.induct)
     done
 qed
 
-lemmas cap_revoke_corres = use_spec_corres [OF cap_revoke_corres']
+lemmas cteRevoke_corres = use_spec_corres [OF cteRevoke_corres']
 
 lemma arch_recycleCap_improve_cases:
    "\<lbrakk> \<not> isPageCap cap; \<not> isPageTableCap cap; \<not> isPageDirectoryCap cap; \<not> isPDPointerTableCap cap;
@@ -8842,7 +8842,7 @@ lemma corres_null_cap_update:
      apply (rule corres_guard_imp, rule getCTE_symb_exec_r, simp+)
     prefer 3
     apply clarsimp
-    apply (rule set_cap_pspace_corres)
+    apply (rule setCTE_corres)
     apply (wp | simp)+
    apply (fastforce elim!: cte_wp_at_weakenE)
   apply wp
@@ -8851,7 +8851,7 @@ lemma corres_null_cap_update:
 
 declare corres_False' [simp]
 
-lemma inv_cnode_corres:
+lemma invokeCNode_corres:
   "cnodeinv_relation ci ci' \<Longrightarrow>
    corres (dc \<oplus> dc)
      (einvs and simple_sched_action and valid_cnode_inv ci)
@@ -8861,18 +8861,18 @@ lemma inv_cnode_corres:
   apply (cases ci, simp_all)
         apply clarsimp
         apply (rule corres_guard_imp)
-          apply (rule cins_corres)
+          apply (rule cteInsert_corres)
             apply simp+
          apply (clarsimp simp: invs_def valid_state_def valid_pspace_def
                         elim!: cte_wp_at_cte_at)
         apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
        apply clarsimp
        apply (rule corres_guard_imp)
-         apply (erule cap_move_corres)
+         apply (erule cteMove_corres)
         apply (clarsimp simp: cte_wp_at_caps_of_state real_cte_tcb_valid)
        apply (clarsimp simp: cte_wp_at_ctes_of)
-       apply (rule cap_revoke_corres)
-     apply (rule corres_guard_imp [OF cap_delete_corres])
+       apply (rule cteRevoke_corres)
+     apply (rule corres_guard_imp [OF cteDelete_corres])
       apply (clarsimp simp: cte_at_typ cap_table_at_typ halted_emptyable)
      apply simp
     apply (rename_tac cap1 cap2 p1 p2 p3)
@@ -8882,7 +8882,7 @@ lemma inv_cnode_corres:
      apply (rule corres_guard_imp)
        apply (rule_tac F="wellformed_cap cap1 \<and> wellformed_cap cap2"
               in corres_gen_asm)
-       apply (erule (1) cap_swap_corres [OF refl refl], simp+)
+       apply (erule (1) cteSwap_corres [OF refl refl], simp+)
       apply (simp add: invs_def valid_state_def valid_pspace_def
                        real_cte_tcb_valid valid_cap_def2)
      apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
@@ -8897,9 +8897,9 @@ lemma inv_cnode_corres:
      apply simp
     apply simp
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated [OF cap_move_corres])
+      apply (rule corres_split_deprecated [OF cteMove_corres])
          apply assumption
-        apply (erule cap_move_corres)
+        apply (erule cteMove_corres)
        apply wp
        apply (simp add: cte_wp_at_caps_of_state)
        apply (wp cap_move_caps_of_state cteMove_cte_wp_at [simplified o_def])+
@@ -8925,7 +8925,7 @@ lemma inv_cnode_corres:
    apply (rename_tac prod)
    apply (simp add: getThreadCallerSlot_def locateSlot_conv objBits_simps)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated [OF _ gct_corres])
+     apply (rule corres_split_deprecated [OF _ getCurThread_corres])
         apply (subgoal_tac "thread + 2^cte_level_bits * tcbCallerSlot = cte_map (thread, tcb_cnode_index 3)")
          prefer 2
          apply (simp add: cte_map_def tcb_cnode_index_def tcbCallerSlot_def)
@@ -8945,7 +8945,7 @@ lemma inv_cnode_corres:
             apply (case_tac cap, simp_all add: isCap_simps is_cap_simps split: bool.split)[1]
             apply clarsimp
             apply (rule corres_guard_imp)
-              apply (rule cap_move_corres)
+              apply (rule cteMove_corres)
               apply (simp add: real_cte_tcb_valid)+
         apply (wp get_cap_wp)
        apply (simp add: getSlotCap_def)
@@ -8975,7 +8975,7 @@ lemma inv_cnode_corres:
                 simp add: is_cap_simps)
    apply (clarsimp simp: when_def unless_def isCap_simps)
    apply (rule corres_guard_imp)
-     apply (rule cancel_badged_sends_corres)
+     apply (rule cancelBadgedSends_corres)
     apply (simp add: valid_cap_def)
    apply (simp add: valid_cap'_def)
   apply (clarsimp)

--- a/proof/refine/X64/CSpace1_R.thy
+++ b/proof/refine/X64/CSpace1_R.thy
@@ -710,7 +710,7 @@ lemma getSlotCap_tcb_corres:
   apply (simp add: o_def cte_map_def tcb_cnode_index_def)
   done
 
-lemma lookup_slot_corres:
+lemma lookupSlotForThread_corres:
   "corres (lfr \<oplus> (\<lambda>(cref, bits) cref'. cref' = cte_map cref))
         (valid_objs and pspace_aligned and tcb_at t)
         (valid_objs' and pspace_aligned' and pspace_distinct' and tcb_at' t)
@@ -769,7 +769,7 @@ lemma lookupSlot_inv[wp]:
   apply (wp | simp add: split_def)+
   done
 
-lemma lc_corres:
+lemma lookupCap_corres:
  "corres (lfr \<oplus> cap_relation)
          (valid_objs and pspace_aligned and tcb_at t)
          (valid_objs' and pspace_aligned' and pspace_distinct' and tcb_at' t)
@@ -777,7 +777,7 @@ lemma lc_corres:
   apply (simp add: lookup_cap_def lookupCap_def bindE_assoc
                    lookupCapAndSlot_def liftME_def split_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_splitEE[OF _ lookup_slot_corres])
+    apply (rule corres_splitEE[OF _ lookupSlotForThread_corres])
       apply (simp add: split_def getSlotCap_def liftM_def[symmetric] o_def)
       apply (rule get_cap_corres)
      apply (rule hoare_pre, wp lookup_slot_cte_at_wp|simp)+
@@ -2422,7 +2422,7 @@ lemma pspace_relationsD:
   "\<lbrakk>pspace_relation kh kh'; ekheap_relation ekh kh'\<rbrakk> \<Longrightarrow> pspace_relations ekh kh kh'"
   by (simp add: pspace_relations_def)
 
-lemma cap_update_corres:
+lemma updateCap_corres:
   "\<lbrakk>cap_relation cap cap';
     is_zombie cap \<or> is_cnode_cap cap \<or> is_thread_cap cap \<rbrakk>
    \<Longrightarrow> corres dc (\<lambda>s. invs s \<and>
@@ -3852,7 +3852,7 @@ lemma updateUntypedCap_descendants_of:
   apply (clarsimp simp:mdb_next_rel_def mdb_next_def split:if_splits)
   done
 
-lemma set_untyped_cap_corres:
+lemma setCTE_UntypedCap_corres:
   "\<lbrakk>cap_relation cap (cteCap cte); is_untyped_cap cap; idx' = idx\<rbrakk>
    \<Longrightarrow> corres dc (cte_wp_at ((=) cap) src and valid_objs and
                   pspace_aligned and pspace_distinct)
@@ -3945,7 +3945,7 @@ lemma getCTE_get:
   apply (clarsimp simp:cte_wp_at_ctes_of)
   done
 
-lemma set_untyped_cap_as_full_corres:
+lemma setUntypedCapAsFull_corres:
   "\<lbrakk>cap_relation c c'; src' = cte_map src; dest' = cte_map dest;
     cap_relation src_cap (cteCap srcCTE); rv = cap.NullCap;
     cteCap rv' = capability.NullCap; mdbPrev (cteMDBNode rv') = nullPointer \<and>
@@ -3964,7 +3964,7 @@ lemma set_untyped_cap_as_full_corres:
         apply (rule corres_symb_exec_r)
            apply (rule_tac F="cte = srcCTE" in corres_gen_asm2)
            apply (simp)
-           apply (rule set_untyped_cap_corres)
+           apply (rule setCTE_UntypedCap_corres)
              apply simp+
            apply (clarsimp simp:free_index_update_def isCap_simps is_cap_simps)
            apply (subst identity_eq)
@@ -5251,7 +5251,7 @@ lemma cte_map_inj_eq':
   done
 
 context begin interpretation Arch . (*FIXME: arch_split*)
-lemma cins_corres:
+lemma cteInsert_corres:
   notes split_paired_All[simp del] split_paired_Ex[simp del]
         trans_state_update'[symmetric,simp]
   assumes "cap_relation c c'" "src' = cte_map src" "dest' = cte_map dest"
@@ -5684,7 +5684,7 @@ lemma cins_corres:
               apply (erule (5) cte_map_inj)
 (* FIXME *)
 
-             apply (rule set_untyped_cap_as_full_corres)
+             apply (rule setUntypedCapAsFull_corres)
                    apply simp+
             apply (wp set_untyped_cap_full_valid_objs set_untyped_cap_as_full_valid_mdb
                set_untyped_cap_as_full_cte_wp_at setUntypedCapAsFull_valid_cap
@@ -6692,7 +6692,7 @@ corres_underlying srel nf rrel G G' (do do_extended_op (return ()); g od) (g')"
   done
 *)
 
-(* consider putting in AINVS or up above cins_corres *)
+(* consider putting in AINVS or up above cteInsert_corres *)
 lemma next_slot_eq:
   "\<lbrakk>next_slot p t' m' = x; t' = t; m' = m\<rbrakk> \<Longrightarrow> next_slot p t m = x"
   by simp
@@ -6701,7 +6701,7 @@ lemma inj_on_image_set_diff15 : (* for compatibility of assumptions *)
   "\<lbrakk>inj_on f C; A \<subseteq> C; B \<subseteq> C\<rbrakk> \<Longrightarrow> f ` (A - B) = f ` A - f ` B"
 by (rule inj_on_image_set_diff; auto)
 
-lemma cap_swap_corres:
+lemma cteSwap_corres:
   assumes srcdst: "src' = cte_map src" "dest' = cte_map dest"
   assumes scr: "cap_relation scap scap'"
   assumes dcr: "cap_relation dcap dcap'"
@@ -7154,7 +7154,7 @@ lemma cap_swap_corres:
      done
 
 
-lemma cap_swap_for_delete_corres:
+lemma capSwapForDelete_corres:
   assumes "src' = cte_map src" "dest' = cte_map dest"
   shows "corres dc
          (valid_objs and pspace_aligned and pspace_distinct and
@@ -7175,7 +7175,7 @@ lemma cap_swap_for_delete_corres:
   apply (rule corres_guard_imp)
     apply (rule_tac P1=wellformed_cap in corres_split_deprecated [OF _ get_cap_corres_P])
       apply (rule_tac P1=wellformed_cap in corres_split_deprecated [OF _ get_cap_corres_P])
-        apply (rule cap_swap_corres, rule refl, rule refl, clarsimp+)
+        apply (rule cteSwap_corres, rule refl, rule refl, clarsimp+)
        apply (wp get_cap_wp getCTE_wp')+
    apply (clarsimp simp: cte_wp_at_caps_of_state)
    apply (drule (1) caps_of_state_valid_cap)+
@@ -7209,7 +7209,7 @@ lemma subtree_no_parent:
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma ensure_no_children_corres:
+lemma ensureNoChildren_corres:
   "p' = cte_map p \<Longrightarrow>
   corres (ser \<oplus> dc) (cte_at p) (pspace_aligned' and pspace_distinct' and cte_at' p' and valid_mdb')
          (ensure_no_children p) (ensureNoChildren p')"

--- a/proof/refine/X64/CSpace_R.thy
+++ b/proof/refine/X64/CSpace_R.thy
@@ -751,7 +751,7 @@ lemma set_cap_not_quite_corres':
                 done
 
 context begin interpretation Arch . (*FIXME: arch_split*)
-lemma cap_move_corres:
+lemma cteMove_corres:
   assumes cr: "cap_relation cap cap'"
   notes trans_state_update'[symmetric,simp]
   shows
@@ -3471,7 +3471,7 @@ lemma cteInsert_invs:
   apply (auto simp: invs'_def valid_state'_def valid_pspace'_def elim: valid_capAligned)
   done
 
-lemma derive_cap_corres:
+lemma deriveCap_corres:
  "\<lbrakk>cap_relation c c'; cte = cte_map slot \<rbrakk> \<Longrightarrow>
   corres (ser \<oplus> cap_relation)
          (cte_at slot)
@@ -3482,14 +3482,14 @@ lemma derive_cap_corres:
             apply (simp_all add: returnOk_def Let_def is_zombie_def isCap_simps
                           split: sum.splits)
    apply (rule_tac Q="\<lambda>_ _. True" and Q'="\<lambda>_ _. True" in
-               corres_initial_splitE [OF ensure_no_children_corres])
+               corres_initial_splitE [OF ensureNoChildren_corres])
       apply simp
      apply clarsimp
     apply wp+
   apply clarsimp
   apply (rule corres_rel_imp)
    apply (rule corres_guard_imp)
-     apply (rule arch_derive_corres)
+     apply (rule arch_deriveCap_corres)
      apply (clarsimp simp: o_def)+
   done
 
@@ -3575,7 +3575,7 @@ lemma lookup_cap_corres:
      (lookupCap thread epcptr')"
   apply (simp add: lookup_cap_def lookupCap_def lookupCapAndSlot_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_splitEE [OF _ lookup_slot_corres])
+    apply (rule corres_splitEE [OF _ lookupSlotForThread_corres])
       apply (simp add: split_def)
       apply (subst bindE_returnOk[symmetric])
       apply (rule corres_splitEE)
@@ -3588,7 +3588,7 @@ lemma lookup_cap_corres:
    apply auto
   done
 
-lemma ensure_empty_corres:
+lemma ensureEmptySlot_corres:
   "q = cte_map p \<Longrightarrow>
    corres (ser \<oplus> dc) (invs and cte_at p) invs'
                      (ensure_empty p) (ensureEmptySlot q)"
@@ -3606,7 +3606,7 @@ lemma ensureEmpty_inv[wp]:
   "\<lbrace>P\<rbrace> ensureEmptySlot p \<lbrace>\<lambda>rv. P\<rbrace>"
   by (simp add: ensureEmptySlot_def unlessE_whenE whenE_def | wp)+
 
-lemma lsfc_corres:
+lemma lookupSlotForCNodeOp_corres:
   "\<lbrakk>cap_relation c c'; ptr = to_bl ptr'\<rbrakk>
   \<Longrightarrow> corres (ser \<oplus> (\<lambda>cref cref'. cref' = cte_map cref))
             (valid_objs and pspace_aligned and valid_cap c)
@@ -3702,7 +3702,7 @@ lemma deriveCap_untyped_derived:
   apply (clarsimp simp: cte_wp_at_ctes_of isCap_simps untyped_derived_eq_def)
   done
 
-lemma set_cap_pspace_corres:
+lemma setCTE_corres:
   "cap_relation cap (cteCap cte) \<Longrightarrow>
    corres_underlying {(s, s'). pspace_relations (ekheap (s)) (kheap s) (ksPSpace s')} False True dc
       (pspace_distinct and pspace_aligned and valid_objs and cte_at p)
@@ -4023,7 +4023,7 @@ lemma create_reply_master_corres:
     apply (clarsimp elim!: state_relationE simp: ghost_relation_of_heap)+
   apply (rule corres_guard_imp)
     apply (rule corres_underlying_symb_exec_l [OF set_original_symb_exec_l'])
-     apply (rule set_cap_pspace_corres)
+     apply (rule setCTE_corres)
      apply simp
     apply wp
    apply (clarsimp simp: cte_wp_at_cte_at valid_pspace_def)
@@ -4117,7 +4117,7 @@ proof -
     by (simp add: noReplyCapsFor_def)
 qed
 
-lemma setup_reply_master_corres:
+lemma setupReplyMaster_corres:
   "corres dc (einvs and tcb_at t) (invs' and tcb_at' t)
        (setup_reply_master t) (setupReplyMaster t)"
   apply (simp add: setupReplyMaster_def setup_reply_master_def)
@@ -4921,7 +4921,7 @@ lemma maskedAsFull_revokable_safe_parent:
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma cins_corres_simple:
+lemma cteInsert_simple_corres:
   assumes "cap_relation c c'" "src' = cte_map src" "dest' = cte_map dest"
   notes trans_state_update'[symmetric,simp]
   shows "corres dc
@@ -5068,7 +5068,7 @@ lemma cins_corres_simple:
          apply (subgoal_tac "cte_map (aa,bb) \<noteq> cte_map dest")
           subgoal by (clarsimp simp: modify_map_def split: if_split_asm)
          apply (erule (5) cte_map_inj)
-         apply (rule set_untyped_cap_as_full_corres)
+         apply (rule setUntypedCapAsFull_corres)
          apply simp+
           apply (wp set_untyped_cap_full_valid_objs set_untyped_cap_as_full_valid_mdb set_untyped_cap_as_full_valid_list
              set_untyped_cap_as_full_cte_wp_at setUntypedCapAsFull_valid_cap
@@ -5124,7 +5124,7 @@ lemma cins_corres_simple:
    apply clarsimp
    apply (drule (5) cte_map_inj)+
    apply simp
-  (* exact reproduction of proof in cins_corres,
+  (* exact reproduction of proof in cteInsert_corres,
      as it does not used is_derived *)
   apply(simp add: cdt_list_relation_def del: split_paired_All split_paired_Ex)
   apply(subgoal_tac "no_mloop (cdt a) \<and> finite_depth (cdt a)")

--- a/proof/refine/X64/Detype_R.thy
+++ b/proof/refine/X64/Detype_R.thy
@@ -609,7 +609,7 @@ lemma sym_refs_hyp_refs_triv[simp]: "sym_refs (state_hyp_refs_of s)"
   apply (clarsimp simp: state_hyp_refs_of_def sym_refs_def)
   by (case_tac "kheap s x"; simp)
 
-lemma detype_corres:
+lemma deleteObjects_corres:
   "is_aligned base magnitude \<Longrightarrow> magnitude \<ge> 3 \<Longrightarrow>
    corres dc
       (\<lambda>s. einvs s

--- a/proof/refine/X64/Finalise_R.thy
+++ b/proof/refine/X64/Finalise_R.thy
@@ -1607,12 +1607,12 @@ lemma emptySlot_invs'[wp]:
                  split: capability.split_asm arch_capability.split_asm)
   by auto
 
-lemma deleted_irq_corres:
+lemma deletedIRQHandler_corres:
   "corres dc \<top> \<top>
     (deleted_irq_handler irq)
     (deletedIRQHandler irq)"
   apply (simp add: deleted_irq_handler_def deletedIRQHandler_def)
-  apply (rule set_irq_state_corres)
+  apply (rule setIRQState_corres)
   apply (simp add: irq_state_relation_def)
   done
 
@@ -1634,7 +1634,7 @@ lemma set_ioport_mask_corres[corres]:
                             foldl_fun_upd)
      by wpsimp+
 
-lemma arch_post_cap_deletion_corres:
+lemma arch_postCapDeletion_corres:
   "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (X64_H.postCapDeletion cap')"
   apply (clarsimp simp: arch_post_cap_deletion_def X64_H.postCapDeletion_def)
   apply (rule corres_guard_imp)
@@ -1643,11 +1643,11 @@ lemma arch_post_cap_deletion_corres:
     apply (rule set_ioport_mask_corres)
    by clarsimp+
 
-lemma post_cap_deletion_corres:
+lemma postCapDeletion_corres:
   "cap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (post_cap_deletion cap) (postCapDeletion cap')"
   apply (cases cap; clarsimp simp: post_cap_deletion_def Retype_H.postCapDeletion_def)
-   apply (corressimp corres: deleted_irq_corres)
-  by (corressimp corres: arch_post_cap_deletion_corres)
+   apply (corressimp corres: deletedIRQHandler_corres)
+  by (corressimp corres: arch_postCapDeletion_corres)
 
 lemma set_cap_trans_state:
   "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),trans_state f s') \<in> fst (set_cap c p (trans_state f s))"
@@ -1657,7 +1657,7 @@ lemma set_cap_trans_state:
       apply (auto simp add: in_monad set_object_def split: if_split_asm)
   done
 
-lemma clearUntypedFreeIndex_corres_noop:
+lemma clearUntypedFreeIndex_noop_corres:
   "corres dc \<top> (cte_at' (cte_map slot))
     (return ()) (clearUntypedFreeIndex (cte_map slot))"
   apply (simp add: clearUntypedFreeIndex_def)
@@ -1680,13 +1680,13 @@ lemma clearUntypedFreeIndex_valid_pspace'[wp]:
    apply (wp | simp add: valid_mdb'_def)+
   done
 
-lemma empty_slot_corres:
+lemma emptySlot_corres:
   "cap_relation info info' \<Longrightarrow> corres dc (einvs and cte_at slot) (invs' and cte_at' (cte_map slot))
              (empty_slot slot info) (emptySlot (cte_map slot) info')"
   unfolding emptySlot_def empty_slot_def
   apply (simp add: case_Null_If)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_noop_rhs[OF _ clearUntypedFreeIndex_corres_noop])
+    apply (rule corres_split_noop_rhs[OF _ clearUntypedFreeIndex_noop_corres])
      apply (rule_tac R="\<lambda>cap. einvs and cte_wp_at ((=) cap) slot" and
                      R'="\<lambda>cte. valid_pspace' and cte_wp_at' ((=) cte) (cte_map slot)" in
                      corres_split_deprecated [OF _ get_cap_corres])
@@ -1703,7 +1703,7 @@ lemma empty_slot_corres:
   apply (rule conjI, clarsimp)
   apply clarsimp
   apply (simp only: bind_assoc[symmetric])
-  apply (rule corres_split'[where r'=dc, OF _ post_cap_deletion_corres])
+  apply (rule corres_split'[where r'=dc, OF _ postCapDeletion_corres])
     defer
     apply wpsimp+
   apply (rule corres_no_failI)
@@ -2214,7 +2214,7 @@ lemma obj_refs_Master:
   by (clarsimp simp: isCap_simps
               split: cap_relation_split_asm arch_cap.split_asm)
 
-lemma final_cap_corres':
+lemma isFinalCapability_corres':
   "final_matters' (cteCap cte) \<Longrightarrow>
    corres (=) (invs and cte_wp_at ((=) cap) ptr)
                (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
@@ -2306,14 +2306,14 @@ lemma final_cap_corres':
   apply (drule_tac x="cap.ArchObjectCap (arch_cap.IOPortCap x31a x32a)" in bspec, fastforce)
   by (clarsimp simp: cap_ioports_def valid_cap_def)
 
-lemma final_cap_corres:
+lemma isFinalCapability_corres:
   "corres (\<lambda>rv rv'. final_matters' (cteCap cte) \<longrightarrow> rv = rv')
           (invs and cte_wp_at ((=) cap) ptr)
           (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
        (is_final_cap cap) (isFinalCapability cte)"
   apply (cases "final_matters' (cteCap cte)")
    apply simp
-   apply (erule final_cap_corres')
+   apply (erule isFinalCapability_corres')
   apply (subst bind_return[symmetric],
          rule corres_symb_exec_r)
      apply (rule corres_no_failI)
@@ -3563,12 +3563,12 @@ lemma interrupt_cap_null_or_ntfn:
                  split: cap.split_asm)
   done
 
-lemma (in delete_one) deleting_irq_corres:
+lemma (in delete_one) deletingIRQHandler_corres:
   "corres dc (einvs) (invs')
           (deleting_irq_handler irq) (deletingIRQHandler irq)"
   apply (simp add: deleting_irq_handler_def deletingIRQHandler_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_irq_slot_corres])
+    apply (rule corres_split_deprecated [OF _ getIRQSlot_corres])
       apply simp
       apply (rule_tac P'="cte_at' (cte_map slot)" in corres_symb_exec_r_conj)
          apply (rule_tac F="isNotificationCap rv \<or> rv = capability.NullCap"
@@ -3593,7 +3593,7 @@ lemma (in delete_one) deleting_irq_corres:
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma arch_finalise_cap_corres:
+lemma arch_finaliseCap_corres:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
            (\<lambda>s. invs s \<and> valid_etcbs s
@@ -3611,32 +3611,32 @@ lemma arch_finalise_cap_corres:
                        o_def dc_def[symmetric]
                 split: option.split,
          safe)
-       apply (rule corres_guard_imp, rule delete_asid_pool_corres[OF refl refl])
+       apply (rule corres_guard_imp, rule deleteASIDPool_corres[OF refl refl])
         apply (clarsimp simp: valid_cap_def mask_def)
        apply (clarsimp simp: valid_cap'_def)
        apply auto[1]
-      apply (rule corres_guard_imp, rule unmap_page_corres[OF refl refl refl refl])
+      apply (rule corres_guard_imp, rule unmapPage_corres[OF refl refl refl refl])
        apply simp
        apply (clarsimp simp: valid_cap_def valid_unmap_def)
        apply (auto simp: vmsz_aligned_def pbfs_atleast_pageBits mask_def wellformed_mapdata_def
                    elim: is_aligned_weaken)[2]
-     apply (rule corres_guard_imp, rule unmap_page_table_corres[OF refl refl refl])
+     apply (rule corres_guard_imp, rule unmapPageTable_corres[OF refl refl refl])
       apply (auto simp: valid_cap_def valid_cap'_def mask_def bit_simps wellformed_mapdata_def
                  elim!: is_aligned_weaken)[2]
-    apply (rule corres_guard_imp, rule unmap_pd_corres[OF refl refl refl])
+    apply (rule corres_guard_imp, rule unmapPageDirectory_corres[OF refl refl refl])
      apply (auto simp: valid_cap_def valid_cap'_def mask_def bit_simps wellformed_mapdata_def
                        vmsz_aligned_def
                 elim!: is_aligned_weaken)[2]
-   apply (rule corres_guard_imp, rule unmap_pdpt_corres[OF refl refl refl])
+   apply (rule corres_guard_imp, rule unmapPDPT_corres[OF refl refl refl])
     apply (auto simp: valid_cap_def valid_cap'_def mask_def bit_simps wellformed_mapdata_def
                       vmsz_aligned_def
                elim!: is_aligned_weaken)[2]
-  apply (rule corres_guard_imp, rule delete_asid_corres[OF refl refl])
+  apply (rule corres_guard_imp, rule deleteASID_corres[OF refl refl])
    apply (auto simp: mask_def valid_cap_def)[2]
   done
 
 
-lemma unbind_notification_corres:
+lemma unbindNotification_corres:
   "corres dc
       (invs and tcb_at t)
       (invs' and tcb_at' t)
@@ -3645,14 +3645,14 @@ lemma unbind_notification_corres:
   supply option.case_cong_weak[cong]
   apply (simp add: unbind_notification_def unbindNotification_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gbn_corres])
+    apply (rule corres_split_deprecated[OF _ getBoundNotification_corres])
       apply (rule corres_option_split)
         apply simp
        apply (rule corres_return_trivial)
-      apply (rule corres_split_deprecated[OF _ get_ntfn_corres])
+      apply (rule corres_split_deprecated[OF _ getNotification_corres])
         apply clarsimp
-        apply (rule corres_split_deprecated[OF _ set_ntfn_corres])
-           apply (rule sbn_corres)
+        apply (rule corres_split_deprecated[OF _ setNotification_corres])
+           apply (rule setBoundNotification_corres)
           apply (clarsimp simp: ntfn_relation_def split:Structures_A.ntfn.splits)
          apply (wp gbn_wp' gbn_wp)+
    apply (clarsimp elim!: obj_at_valid_objsE
@@ -3666,19 +3666,19 @@ lemma unbind_notification_corres:
                   split: option.splits)
   done
 
-lemma unbind_maybe_notification_corres:
+lemma unbindMaybeNotification_corres:
   "corres dc
       (invs and ntfn_at ntfnptr) (invs' and ntfn_at' ntfnptr)
       (unbind_maybe_notification ntfnptr)
       (unbindMaybeNotification ntfnptr)"
   apply (simp add: unbind_maybe_notification_def unbindMaybeNotification_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ get_ntfn_corres])
+    apply (rule corres_split_deprecated[OF _ getNotification_corres])
       apply (rule corres_option_split)
         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
        apply (rule corres_return_trivial)
-      apply (rule corres_split_deprecated[OF _ set_ntfn_corres])
-         apply (rule sbn_corres)
+      apply (rule corres_split_deprecated[OF _ setNotification_corres])
+         apply (rule setBoundNotification_corres)
         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
        apply (wp get_simple_ko_wp getNotification_wp)+
    apply (clarsimp elim!: obj_at_valid_objsE
@@ -3692,7 +3692,7 @@ lemma unbind_maybe_notification_corres:
                   split: option.splits)
   done
 
-lemma fast_finalise_corres:
+lemma fast_finaliseCap_corres:
   "\<lbrakk> final_matters' cap' \<longrightarrow> final = final'; cap_relation cap cap';
      can_fast_finalise cap \<rbrakk>
    \<Longrightarrow> corres dc
@@ -3718,8 +3718,8 @@ lemma fast_finalise_corres:
    apply (simp add: valid_cap'_def)
   apply (clarsimp simp: final_matters'_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ unbind_maybe_notification_corres])
-         apply (rule ntfn_cancel_corres)
+    apply (rule corres_split_deprecated[OF _ unbindMaybeNotification_corres])
+         apply (rule cancelAllSignals_corres)
        apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps getNotification_wp
             | wpc)+
    apply (clarsimp simp: valid_cap_def)
@@ -3738,10 +3738,10 @@ lemma cap_delete_one_corres:
       apply (rule_tac F="can_fast_finalise cap" in corres_gen_asm)
       apply (rule corres_if)
         apply fastforce
-       apply (rule corres_split_deprecated [OF _ final_cap_corres[where ptr=ptr]])
+       apply (rule corres_split_deprecated [OF _ isFinalCapability_corres[where ptr=ptr]])
          apply (simp add: split_def bind_assoc [THEN sym])
-         apply (rule corres_split_deprecated [OF _ fast_finalise_corres[where sl=ptr]])
-              apply (rule empty_slot_corres)
+         apply (rule corres_split_deprecated [OF _ fast_finaliseCap_corres[where sl=ptr]])
+              apply (rule emptySlot_corres)
              apply simp+
           apply (wp hoare_drop_imps)+
         apply (wp isFinalCapability_inv | wp (once) isFinal[where x="cte_map ptr"])+
@@ -3762,7 +3762,7 @@ global_interpretation delete_one
    apply auto
   done
 
-lemma finalise_cap_corres:
+lemma finaliseCap_corres:
   "\<lbrakk> final_matters' cap' \<Longrightarrow> final = final'; cap_relation cap cap';
           flag \<longrightarrow> can_fast_finalise cap \<rbrakk>
      \<Longrightarrow> corres (\<lambda>x y. cap_relation (fst x) (fst y) \<and> cap_relation (snd x) (snd y))
@@ -3784,8 +3784,8 @@ lemma finalise_cap_corres:
         apply (simp add: valid_cap'_def)
        apply (clarsimp simp add: final_matters'_def)
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated[OF _ unbind_maybe_notification_corres])
-           apply (rule ntfn_cancel_corres)
+         apply (rule corres_split_deprecated[OF _ unbindMaybeNotification_corres])
+           apply (rule cancelAllSignals_corres)
           apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps hoare_vcg_all_lift | wpc)+
         apply (clarsimp simp: valid_cap_def)
        apply (clarsimp simp: valid_cap'_def)
@@ -3794,7 +3794,7 @@ lemma finalise_cap_corres:
                                liftM_def[symmetric] o_def zbits_map_def
                                dc_def[symmetric])
      apply (rule corres_guard_imp)
-       apply (rule corres_split_deprecated[OF _ unbind_notification_corres])
+       apply (rule corres_split_deprecated[OF _ unbindNotification_corres])
          apply (rule corres_split_deprecated[OF _ suspend_corres])
             apply (clarsimp simp: liftM_def[symmetric] o_def dc_def[symmetric] zbits_map_def)
           apply (rule prepareThreadDelete_corres)
@@ -3804,7 +3804,7 @@ lemma finalise_cap_corres:
     apply (simp add: final_matters'_def liftM_def[symmetric]
                      o_def dc_def[symmetric])
     apply (intro impI, rule corres_guard_imp)
-      apply (rule deleting_irq_corres)
+      apply (rule deletingIRQHandler_corres)
      apply simp
     apply simp
    apply (clarsimp simp: final_matters'_def)
@@ -3814,7 +3814,7 @@ lemma finalise_cap_corres:
     apply (clarsimp simp: cte_wp_at_caps_of_state)
    apply simp
   apply (clarsimp split del: if_split simp: o_def)
-  apply (rule corres_guard_imp [OF arch_finalise_cap_corres], (fastforce simp: valid_sched_def)+)
+  apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
   done
 
 context begin interpretation Arch . (*FIXME: arch_split*)

--- a/proof/refine/X64/InterruptAcc_R.thy
+++ b/proof/refine/X64/InterruptAcc_R.thy
@@ -8,7 +8,7 @@ theory InterruptAcc_R
 imports TcbAcc_R
 begin
 
-lemma get_irq_slot_corres:
+lemma getIRQSlot_corres:
   "corres (\<lambda>sl sl'. sl' = cte_map sl) \<top> \<top> (get_irq_slot irq) (getIRQSlot irq)"
   apply (simp add: getIRQSlot_def get_irq_slot_def locateSlot_conv
                    liftM_def[symmetric])
@@ -23,7 +23,7 @@ crunch inv[wp]: getIRQSlot "P"
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-lemma set_irq_state_corres:
+lemma setIRQState_corres:
   "irq_state_relation state state' \<Longrightarrow>
    corres dc \<top> \<top> (set_irq_state state irq) (setIRQState state' irq)"
   apply (simp add: set_irq_state_def setIRQState_def
@@ -95,7 +95,7 @@ lemma work_units_and_irq_state_state_relationI [intro!]:
    \<in> state_relation"
   by (simp add: state_relation_def swp_def)
 
-lemma preemption_corres:
+lemma preemptionPoint_corres:
   "corres (dc \<oplus> dc) \<top> \<top> preemption_point preemptionPoint"
   apply (simp add: preemption_point_def preemptionPoint_def)
   by (auto simp: preemption_point_def preemptionPoint_def o_def gets_def liftE_def whenE_def getActiveIRQ_def

--- a/proof/refine/X64/IpcCancel_R.thy
+++ b/proof/refine/X64/IpcCancel_R.thy
@@ -169,7 +169,7 @@ lemma invs_weak_sch_act_wf[elim!]:
 crunch tcb_at[wp]: set_endpoint "tcb_at t"
 crunch tcb_at'[wp]: setEndpoint "tcb_at' t"
 
-lemma blocked_cancel_ipc_corres:
+lemma blocked_cancelIPC_corres:
   "\<lbrakk> st = Structures_A.BlockedOnReceive epPtr p' \<or>
      st = Structures_A.BlockedOnSend epPtr p; thread_state_relation st st' \<rbrakk> \<Longrightarrow>
    corres dc (invs and st_tcb_at ((=) st) t) (invs' and st_tcb_at' ((=) st') t)
@@ -185,7 +185,7 @@ lemma blocked_cancel_ipc_corres:
             od)"
   apply (simp add: blocked_cancel_ipc_def gbep_ret)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres])
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres])
       apply (rule_tac F="ep \<noteq> IdleEP" in corres_gen_asm2)
       apply (rule corres_assert_assume[rotated])
        apply (clarsimp split: endpoint.splits)
@@ -198,8 +198,8 @@ lemma blocked_cancel_ipc_corres:
        apply (case_tac "remove1 t list")
         apply simp
         apply (rule corres_guard_imp)
-          apply (rule corres_split_deprecated [OF _ set_ep_corres])
-             apply (rule sts_corres)
+          apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+             apply (rule setThreadState_corres)
              apply simp
             apply (simp add: ep_relation_def)
            apply (simp add: valid_tcb_state_def pred_conj_def)
@@ -221,8 +221,8 @@ lemma blocked_cancel_ipc_corres:
                               valid_tcb_state'_def)[1]
        apply clarsimp
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
-            apply (rule sts_corres)
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+            apply (rule setThreadState_corres)
             apply simp
            apply (simp add: ep_relation_def)
           apply (wp)+
@@ -246,8 +246,8 @@ lemma blocked_cancel_ipc_corres:
       apply (case_tac "remove1 t list")
        apply simp
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
-            apply (rule sts_corres)
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+            apply (rule setThreadState_corres)
             apply simp
            apply (simp add: ep_relation_def)
           apply (simp add: valid_tcb_state_def pred_conj_def)
@@ -269,8 +269,8 @@ lemma blocked_cancel_ipc_corres:
                              valid_tcb_state'_def)[1]
       apply clarsimp
       apply (rule corres_guard_imp)
-        apply (rule corres_split_deprecated [OF _ set_ep_corres])
-           apply (rule sts_corres)
+        apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+           apply (rule setThreadState_corres)
            apply simp
           apply (simp add: ep_relation_def)
          apply (wp)+
@@ -308,7 +308,7 @@ lemma blocked_cancel_ipc_corres:
   apply (fastforce simp: ko_wp_at'_def obj_at'_def projectKOs dest: sym_refs_st_tcb_atD')
   done
 
-lemma ac_corres:
+lemma cancelSignal_corres:
   "corres dc
           (invs and st_tcb_at ((=) (Structures_A.BlockedOnNotification ntfn)) t)
           (invs' and st_tcb_at' ((=) (BlockedOnNotification ntfn)) t)
@@ -316,7 +316,7 @@ lemma ac_corres:
           (cancelSignal t ntfn)"
   apply (simp add: cancel_signal_def cancelSignal_def Let_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ntfn_corres])
+    apply (rule corres_split_deprecated [OF _ getNotification_corres])
       apply (rule_tac F="isWaitingNtfn (ntfnObj ntfnaa)" in corres_gen_asm2)
       apply (case_tac "ntfn_obj ntfna")
         apply (simp add: ntfn_relation_def isWaitingNtfn_def)
@@ -324,14 +324,14 @@ lemma ac_corres:
        apply (rename_tac list)
        apply (rule_tac R="remove1 t list = []" in corres_cases)
         apply (simp del: dc_simp)
-        apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-           apply (rule sts_corres)
+        apply (rule corres_split_deprecated [OF _ setNotification_corres])
+           apply (rule setThreadState_corres)
            apply simp
           apply (simp add: ntfn_relation_def)
          apply (wp)+
        apply (simp add: list_case_If del: dc_simp)
-       apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-          apply (rule sts_corres)
+       apply (rule corres_split_deprecated [OF _ setNotification_corres])
+          apply (rule setThreadState_corres)
           apply simp
          apply (clarsimp simp add: ntfn_relation_def neq_Nil_conv)
         apply (wp)+
@@ -523,7 +523,7 @@ locale delete_one = delete_one_conc + delete_one_abs +
                (invs' and cte_at' (cte_map ptr))
           (cap_delete_one ptr) (cteDeleteOne (cte_map ptr))"
 
-lemma (in delete_one) reply_cancel_ipc_corres:
+lemma (in delete_one) cancelIPC_ReplyCap_corres:
   "corres dc (einvs  and st_tcb_at awaiting_reply t)
              (invs' and st_tcb_at' awaiting_reply' t)
       (reply_cancel_ipc t)
@@ -613,28 +613,28 @@ lemma (in delete_one) cancel_ipc_corres:
       (cancel_ipc t) (cancelIPC t)"
   apply (simp add: cancel_ipc_def cancelIPC_def Let_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gts_corres])
+    apply (rule corres_split_deprecated [OF _ getThreadState_corres])
       apply (rule_tac P="einvs and st_tcb_at ((=) state) t" and
                       P'="invs' and st_tcb_at' ((=) statea) t" in corres_inst)
       apply (case_tac state, simp_all add: isTS_defs list_case_If)[1]
          apply (rule corres_guard_imp)
-           apply (rule blocked_cancel_ipc_corres)
+           apply (rule blocked_cancelIPC_corres)
             apply fastforce
            apply fastforce
           apply simp
          apply simp
         apply (clarsimp simp add: isTS_defs list_case_If)
         apply (rule corres_guard_imp)
-          apply (rule blocked_cancel_ipc_corres)
+          apply (rule blocked_cancelIPC_corres)
            apply fastforce
           apply fastforce
          apply simp
         apply simp
        apply (rule corres_guard_imp)
-         apply (rule reply_cancel_ipc_corres)
+         apply (rule cancelIPC_ReplyCap_corres)
         apply (clarsimp elim!: st_tcb_weakenE)
        apply (clarsimp elim!: pred_tcb'_weakenE)
-      apply (rule corres_guard_imp [OF ac_corres], simp+)
+      apply (rule corres_guard_imp [OF cancelSignal_corres], simp+)
      apply (wp gts_sp[where P="\<top>",simplified])+
     apply (rule hoare_strengthen_post)
      apply (rule gts_sp'[where P="\<top>"])
@@ -1408,9 +1408,9 @@ lemma (in delete_one) suspend_corres:
   apply (simp add: IpcCancel_A.suspend_def Thread_H.suspend_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_nor [OF _ cancel_ipc_corres])
-      apply (rule corres_split_deprecated [OF _ gts_corres])
+      apply (rule corres_split_deprecated [OF _ getThreadState_corres])
         apply (rule corres_split_nor)
-           apply (rule corres_split_nor [OF _ sts_corres])
+           apply (rule corres_split_nor [OF _ setThreadState_corres])
               apply (rule tcbSchedDequeue_corres')
              apply wpsimp
             apply wp
@@ -1418,7 +1418,7 @@ lemma (in delete_one) suspend_corres:
           apply (rule corres_if)
             apply (case_tac state; simp)
            apply (simp add: update_restart_pc_def updateRestartPC_def)
-           apply (rule corres_as_user')
+           apply (rule asUser_corres')
            apply (simp add: X64.nextInstructionRegister_def X64.faultRegister_def
                             X64_H.nextInstructionRegister_def X64_H.faultRegister_def)
            apply (simp add: X64_H.Register_def)
@@ -1957,7 +1957,7 @@ lemma ep_cancel_corres_helper:
       apply (rule corres_guard_imp)
         apply (subst bind_return_unit, rule corres_split_deprecated [OF tcbSchedEnqueue_corres])
           apply simp
-          apply (rule corres_guard_imp [OF sts_corres])
+          apply (rule corres_guard_imp [OF setThreadState_corres])
             apply simp
            apply (simp add: valid_tcb_state_def)
           apply simp
@@ -1999,7 +1999,7 @@ proof -
                    rescheduleRequired
                 od)"
     apply (rule corres_split')
-       apply (rule corres_guard_imp [OF set_ep_corres])
+       apply (rule corres_guard_imp [OF setEndpoint_corres])
          apply (simp add: ep_relation_def)+
       apply (rule corres_split_deprecated [OF rescheduleRequired_corres])
         apply (rule ep_cancel_corres_helper)
@@ -2022,7 +2022,7 @@ proof -
   show ?thesis
     apply (simp add: cancel_all_ipc_def cancelAllIPC_def)
     apply (rule corres_split' [OF _ _ get_simple_ko_sp get_ep_sp'])
-     apply (rule corres_guard_imp [OF get_ep_corres], simp+)
+     apply (rule corres_guard_imp [OF getEndpoint_corres], simp+)
     apply (case_tac epa, simp_all add: ep_relation_def
                                        get_ep_queue_def)
      apply (rule corres_guard_imp [OF P]
@@ -2044,16 +2044,16 @@ lemma set_ntfn_tcb_obj_at' [wp]:
 apply (clarsimp simp: setNotification_def, wp)
 done
 
-lemma ntfn_cancel_corres:
+lemma cancelAllSignals_corres:
   "corres dc (invs and valid_sched and ntfn_at ntfn) (invs' and ntfn_at' ntfn)
              (cancel_all_signals ntfn) (cancelAllSignals ntfn)"
   apply (simp add: cancel_all_signals_def cancelAllSignals_def)
   apply (rule corres_split' [OF _ _ get_simple_ko_sp get_ntfn_sp'])
-   apply (rule corres_guard_imp [OF get_ntfn_corres])
+   apply (rule corres_guard_imp [OF getNotification_corres])
     apply simp+
   apply (case_tac "ntfn_obj ntfna", simp_all add: ntfn_relation_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
+    apply (rule corres_split_deprecated [OF _ setNotification_corres])
        apply (rule corres_split_deprecated [OF rescheduleRequired_corres])
          apply (rule ep_cancel_corres_helper)
         apply (wp mapM_x_wp'[where 'b="det_ext state"]
@@ -2646,21 +2646,21 @@ lemma cancelBadgedSends_invs[wp]:
 crunch state_refs_of[wp]: tcb_sched_action "\<lambda>s. P (state_refs_of s)"
   (ignore_del: tcb_sched_action)
 
-lemma cancel_badged_sends_corres:
+lemma cancelBadgedSends_corres:
   "corres dc (invs and valid_sched and ep_at epptr) (invs' and ep_at' epptr)
          (cancel_badged_sends epptr bdg) (cancelBadgedSends epptr bdg)"
   apply (simp add: cancel_badged_sends_def cancelBadgedSends_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres get_simple_ko_sp get_ep_sp',
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres get_simple_ko_sp get_ep_sp',
                                  where Q="invs and valid_sched" and Q'=invs'])
     apply simp_all
   apply (case_tac ep, simp_all add: ep_relation_def)
   apply (simp add: filterM_mapM list_case_return cong: list.case_cong)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_nor [OF _ set_ep_corres])
+    apply (rule corres_split_nor [OF _ setEndpoint_corres])
        apply (rule corres_split_eqr[OF _ _ _ hoare_post_add[where R="\<lambda>_. valid_objs'"]])
           apply (rule corres_split_deprecated [OF rescheduleRequired_corres])
-            apply (rule set_ep_corres)
+            apply (rule setEndpoint_corres)
             apply (simp split: list.split add: ep_relation_def)
            apply (wp weak_sch_act_wf_lift_linear)+
          apply (rule_tac S="(=)"
@@ -2670,11 +2670,11 @@ lemma cancel_badged_sends_corres:
                 simp_all add: list_all2_refl)[1]
            apply (clarsimp simp: liftM_def[symmetric] o_def)
            apply (rule corres_guard_imp)
-             apply (rule corres_split_deprecated [OF _ gts_corres])
+             apply (rule corres_split_deprecated [OF _ getThreadState_corres])
                apply (rule_tac F="\<exists>pl. st = Structures_A.BlockedOnSend epptr pl"
                             in corres_gen_asm)
                apply (clarsimp simp: o_def dc_def[symmetric] liftM_def)
-               apply (rule corres_split_deprecated [OF _ sts_corres])
+               apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                   apply (rule corres_split_deprecated[OF _ tcbSchedEnqueue_corres])
                     apply (rule corres_trivial)
                     apply simp

--- a/proof/refine/X64/Ipc_R.thy
+++ b/proof/refine/X64/Ipc_R.thy
@@ -13,14 +13,14 @@ context begin interpretation Arch . (*FIXME: arch_split*)
 lemmas lookup_slot_wrapper_defs'[simp] =
    lookupSourceSlot_def lookupTargetSlot_def lookupPivotSlot_def
 
-lemma get_mi_corres: "corres ((=) \<circ> message_info_map)
+lemma getMessageInfo_corres: "corres ((=) \<circ> message_info_map)
                       (tcb_at t) (tcb_at' t)
                       (get_message_info t) (getMessageInfo t)"
   apply (rule corres_guard_imp)
     apply (unfold get_message_info_def getMessageInfo_def fun_app_def)
     apply (simp add: X64_H.msgInfoRegister_def
              X64.msgInfoRegister_def X64_A.msg_info_register_def)
-    apply (rule corres_split_eqr [OF _ user_getreg_corres])
+    apply (rule corres_split_eqr [OF _ asUser_getRegister_corres])
        apply (rule corres_trivial, simp add: message_info_from_data_eqv)
       apply (wp | simp)+
   done
@@ -100,7 +100,7 @@ lemma valid_ipc_buffer_ptr'D2:
   apply simp
   done
 
-lemma load_ct_corres:
+lemma loadCapTransfer_corres:
   notes msg_max_words_simps = max_ipc_words_def msgMaxLength_def msgMaxExtraCaps_def msgLengthBits_def
                               capTransferDataSize_def msgExtraCapBits_def
   shows
@@ -128,7 +128,7 @@ lemma load_ct_corres:
               simp add: word_size_bits_def is_aligned_def)+
   done
 
-lemma get_recv_slot_corres:
+lemma getReceiveSlots_corres:
   "corres (\<lambda>xs ys. ys = map cte_map xs)
     (tcb_at receiver and valid_objs and pspace_aligned)
     (tcb_at' receiver and valid_objs' and pspace_aligned' and pspace_distinct' and
@@ -139,7 +139,7 @@ lemma get_recv_slot_corres:
    apply (simp add: getReceiveSlots_def)
   apply (simp add: getReceiveSlots_def split_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ load_ct_corres])
+    apply (rule corres_split_deprecated [OF _ loadCapTransfer_corres])
       apply (rule corres_empty_on_failure)
       apply (rule corres_splitEE)
          prefer 2
@@ -151,7 +151,7 @@ lemma get_recv_slot_corres:
            prefer 2
            apply (rule corres_unify_failure)
             apply (simp add: ct_relation_def)
-            apply (erule lsfc_corres [OF _ refl])
+            apply (erule lookupSlotForCNodeOp_corres [OF _ refl])
            apply simp
           apply (simp add: split_def liftE_bindE unlessE_whenE)
           apply (rule corres_split_deprecated [OF _ get_cap_corres])
@@ -211,11 +211,11 @@ declare word_div_1 [simp]
 declare word_minus_one_le [simp]
 declare word64_minus_one_le [simp]
 
-lemma load_word_offs_corres':
+lemma loadWordUser_corres':
   "\<lbrakk> y < unat max_ipc_words; y' = of_nat y * 8 \<rbrakk> \<Longrightarrow>
   corres (=) \<top> (valid_ipc_buffer_ptr' a) (load_word_offs a y) (loadWordUser (a + y'))"
   apply simp
-  apply (erule load_word_offs_corres)
+  apply (erule loadWordUser_corres)
   done
 
 declare loadWordUser_inv [wp]
@@ -257,7 +257,7 @@ lemma corres_set_extra_badge:
           (\<lambda>_. msg_max_length + 2 + n < unat max_ipc_words))
          (set_extra_badge buffer b n) (setExtraBadge buffer b' n)"
   apply (rule corres_gen_asm2)
-  apply (drule store_word_offs_corres [where a=buffer and w=b])
+  apply (drule storeWordUser_corres [where a=buffer and w=b])
   apply (simp add: set_extra_badge_def setExtraBadge_def buffer_cptr_index_def
                    bufferCPtrOffset_def Let_def)
   apply (simp add: word_size word_size_def wordSize_def wordBits_def
@@ -393,7 +393,7 @@ lemma cte_refs'_maskedAsFull[simp]:
  done
 
 
-lemma tc_loop_corres:
+lemma transferCapsToSlots_corres:
   "\<lbrakk> list_all2 (\<lambda>(cap, slot) (cap', slot'). cap_relation cap cap'
              \<and> slot' = cte_map slot) caps caps';
       mi' = message_info_map mi \<rbrakk> \<Longrightarrow>
@@ -459,14 +459,14 @@ next
          prefer 2
          apply (rule unifyFailure_discard2)
           apply (case_tac mi, clarsimp)
-         apply (rule derive_cap_corres)
+         apply (rule deriveCap_corres)
           apply (simp add: remove_rights_def)
          apply clarsimp
         apply (rule corres_split_norE)
            apply (simp add: liftE_bindE)
            apply (rule corres_split_nor)
               prefer 2
-              apply (rule cins_corres, simp_all add: hd_map)[1]
+              apply (rule cteInsert_corres, simp_all add: hd_map)[1]
              apply (simp add: tl_map)
              apply (rule corres_rel_imp, rule Cons.hyps, simp_all)[1]
             apply (wp valid_case_option_post_wp hoare_vcg_const_Ball_lift
@@ -1039,7 +1039,7 @@ lemma grs_distinct'[wp]:
   apply simp
   done
 
-lemma tc_corres:
+lemma transferCaps_corres:
   "\<lbrakk> info' = message_info_map info;
     list_all2 (\<lambda>x y. cap_relation (fst x) (fst y) \<and> snd y = cte_map (snd x))
          caps caps' \<rbrakk>
@@ -1065,12 +1065,12 @@ lemma tc_corres:
                    getThreadCSpaceRoot)
   apply (rule corres_assume_pre)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_recv_slot_corres])
+    apply (rule corres_split_deprecated [OF _ getReceiveSlots_corres])
       apply (rule_tac x=recv_buf in option_corres)
        apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
        apply (case_tac info, simp)
       apply simp
-      apply (rule corres_rel_imp, rule tc_loop_corres,
+      apply (rule corres_rel_imp, rule transferCapsToSlots_corres,
              simp_all add: split_def)[1]
       apply (case_tac info, simp)
      apply (wp hoare_vcg_all_lift get_rs_cte_at static_imp_wp
@@ -1367,7 +1367,7 @@ lemma getMessageInfo_msgExtraCaps[wp]:
    apply wpsimp+
   done
 
-lemma lcs_corres:
+lemma lookupCapAndSlot_corres:
   "cptr = to_bl cptr' \<Longrightarrow>
   corres (lfr \<oplus> (\<lambda>a b. cap_relation (fst a) (fst b) \<and> snd b = cte_map (snd a)))
     (valid_objs and pspace_aligned and tcb_at thread)
@@ -1382,12 +1382,12 @@ lemma lcs_corres:
           apply (rule corres_returnOkTT, simp)
          apply simp
         apply wp+
-      apply (rule corres_rel_imp, rule lookup_slot_corres)
+      apply (rule corres_rel_imp, rule lookupSlotForThread_corres)
       apply (simp add: split_def)
      apply (wp | simp add: liftE_bindE[symmetric])+
   done
 
-lemma lec_corres:
+lemma lookupExtraCaps_corres:
   "\<lbrakk> info' = message_info_map info; buffer = buffer'\<rbrakk> \<Longrightarrow>
   corres (fr \<oplus> list_all2 (\<lambda>x y. cap_relation (fst x) (fst y) \<and> snd y = cte_map (snd x)))
    (valid_objs and pspace_aligned and tcb_at thread and (\<lambda>_. valid_message_info info))
@@ -1428,7 +1428,7 @@ lemma lec_corres:
            apply simp
           apply simp
           apply (rule corres_guard_imp)
-            apply (rule load_word_offs_corres')
+            apply (rule loadWordUser_corres')
              apply (clarsimp simp: buffer_cptr_index_def msg_max_length_def
                                    max_ipc_words valid_message_info_def
                                    msg_max_extra_caps_def word_le_nat_alt)
@@ -1444,7 +1444,7 @@ lemma lec_corres:
             apply simp
            apply simp
           apply simp
-          apply (rule corres_cap_fault [OF lcs_corres])
+          apply (rule corres_cap_fault [OF lookupCapAndSlot_corres])
           apply simp
          apply simp
          apply (wp | simp)+
@@ -1460,7 +1460,7 @@ lemma copyMRs_valid_mdb[wp]:
   "\<lbrace>valid_mdb'\<rbrace> copyMRs t buf t' buf' n \<lbrace>\<lambda>rv. valid_mdb'\<rbrace>"
   by (simp add: valid_mdb'_def copyMRs_ctes_of)
 
-lemma do_normal_transfer_corres:
+lemma doNormalTransfer_corres:
   "corres dc
   (tcb_at sender and tcb_at receiver and (pspace_aligned:: det_state \<Rightarrow> bool)
    and valid_objs and cur_tcb and valid_mdb and valid_list and pspace_distinct
@@ -1478,7 +1478,7 @@ lemma do_normal_transfer_corres:
   apply (simp add: do_normal_transfer_def doNormalTransfer_def)
   apply (rule corres_guard_imp)
 
-    apply (rule corres_split_mapr [OF _ get_mi_corres])
+    apply (rule corres_split_mapr [OF _ getMessageInfo_corres])
       apply (rule_tac F="valid_message_info mi" in corres_gen_asm)
       apply (rule_tac r'="list_all2 (\<lambda>x y. cap_relation (fst x) (fst y) \<and> snd y = cte_map (snd x))"
                   in corres_split_deprecated)
@@ -1486,19 +1486,19 @@ lemma do_normal_transfer_corres:
          apply (rule corres_if[OF refl])
           apply (rule corres_split_catch)
              apply (rule corres_trivial, simp)
-            apply (rule lec_corres, simp+)
+            apply (rule lookupExtraCaps_corres, simp+)
            apply wp+
          apply (rule corres_trivial, simp)
         apply simp
-        apply (rule corres_split_eqr [OF _ copy_mrs_corres])
-          apply (rule corres_split_deprecated [OF _ tc_corres])
+        apply (rule corres_split_eqr [OF _ copyMRs_corres])
+          apply (rule corres_split_deprecated [OF _ transferCaps_corres])
               apply (rename_tac mi' mi'')
               apply (rule_tac F="mi_label mi' = mi_label mi"
                         in corres_gen_asm)
-              apply (rule corres_split_nor [OF _ set_mi_corres])
+              apply (rule corres_split_nor [OF _ setMessageInfo_corres])
                  apply (simp add: badge_register_def badgeRegister_def)
                  apply (fold dc_def)
-                 apply (rule user_setreg_corres)
+                 apply (rule asUser_setRegister_corres)
                 apply (case_tac mi', clarsimp)
                apply wp
              apply simp+
@@ -1518,11 +1518,11 @@ lemma corres_liftE_lift:
   by simp
 
 lemmas corres_ipc_thread_helper =
-  corres_split_eqrE [OF _  corres_liftE_lift [OF gct_corres]]
+  corres_split_eqrE [OF _  corres_liftE_lift [OF getCurThread_corres]]
 
 lemmas corres_ipc_info_helper =
   corres_split_maprE [where f = message_info_map, OF _
-                                corres_liftE_lift [OF get_mi_corres]]
+                                corres_liftE_lift [OF getMessageInfo_corres]]
 
 crunch typ_at'[wp]: doNormalTransfer "\<lambda>s. P (typ_at' T p s)"
 
@@ -1567,55 +1567,55 @@ lemma msgFromLookupFailure_map[simp]:
      = msg_from_lookup_failure lf"
   by (cases lf, simp_all add: lookup_failure_map_def msgFromLookupFailure_def)
 
-lemma getRestartPCs_corres:
+lemma asUser_getRestartPC_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
                  (as_user t getRestartPC) (asUser t getRestartPC)"
-  apply (rule corres_as_user')
+  apply (rule asUser_corres')
   apply (rule corres_Id, simp, simp)
   apply (rule no_fail_getRestartPC)
   done
 
-lemma user_mapM_getRegister_corres:
+lemma asUser_mapM_getRegister_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
      (as_user t (mapM getRegister regs))
      (asUser t (mapM getRegister regs))"
-  apply (rule corres_as_user')
+  apply (rule asUser_corres')
   apply (rule corres_Id [OF refl refl])
   apply (rule no_fail_mapM)
   apply (simp add: getRegister_def)
   done
 
-lemma make_arch_fault_msg_corres:
+lemma makeArchFaultMessage_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
   (make_arch_fault_msg f t)
   (makeArchFaultMessage (arch_fault_map f) t)"
   apply (cases f, clarsimp simp: makeArchFaultMessage_def split: arch_fault.split)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr[OF _ getRestartPCs_corres])
+    apply (rule corres_split_eqr[OF _ asUser_getRestartPC_corres])
       apply (rule corres_trivial, simp add: arch_fault_map_def)
      apply (wp+, auto)
   done
 
-lemma mk_ft_msg_corres:
+lemma makeFaultMessage_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
      (make_fault_msg ft t)
      (makeFaultMessage (fault_map ft) t)"
   apply (cases ft, simp_all add: makeFaultMessage_def split del: if_split)
      apply (rule corres_guard_imp)
-       apply (rule corres_split_eqr [OF _ getRestartPCs_corres])
+       apply (rule corres_split_eqr [OF _ asUser_getRestartPC_corres])
          apply (rule corres_trivial, simp add: fromEnum_def enum_bool)
         apply (wp | simp)+
     apply (simp add: X64_H.syscallMessage_def)
     apply (rule corres_guard_imp)
-      apply (rule corres_split_eqr [OF _ user_mapM_getRegister_corres])
+      apply (rule corres_split_eqr [OF _ asUser_mapM_getRegister_corres])
         apply (rule corres_trivial, simp)
        apply (wp | simp)+
    apply (simp add: X64_H.exceptionMessage_def)
    apply (rule corres_guard_imp)
-     apply (rule corres_split_eqr [OF _ user_mapM_getRegister_corres])
+     apply (rule corres_split_eqr [OF _ asUser_mapM_getRegister_corres])
        apply (rule corres_trivial, simp)
       apply (wp | simp)+
-  apply (rule make_arch_fault_msg_corres)
+  apply (rule makeArchFaultMessage_corres)
   done
 
 lemma makeFaultMessage_inv[wp]:
@@ -1628,11 +1628,11 @@ lemma makeFaultMessage_inv[wp]:
   done
 
 lemmas threadget_fault_corres =
-          threadget_corres [where r = fault_rel_optionation
+          threadGet_corres [where r = fault_rel_optionation
                               and f = tcb_fault and f' = tcbFault,
                             simplified tcb_relation_def, simplified]
 
-lemma do_fault_transfer_corres:
+lemma doFaultTransfer_corres:
   "corres dc
     (obj_at (\<lambda>ko. \<exists>tcb ft. ko = TCB tcb \<and> tcb_fault tcb = Some ft) sender
      and tcb_at receiver and case_option \<top> in_user_frame recv_buf)
@@ -1664,17 +1664,17 @@ lemma do_fault_transfer_corres:
     apply (clarsimp simp: obj_at_def is_tcb)
    apply wp
    apply (rule corres_guard_imp)
-      apply (rule corres_split_eqr [OF _ mk_ft_msg_corres])
-        apply (rule corres_split_eqr [OF _ set_mrs_corres [OF refl]])
-          apply (rule corres_split_nor [OF _ set_mi_corres])
-             apply (rule user_setreg_corres)
+      apply (rule corres_split_eqr [OF _ makeFaultMessage_corres])
+        apply (rule corres_split_eqr [OF _ setMRs_corres [OF refl]])
+          apply (rule corres_split_nor [OF _ setMessageInfo_corres])
+             apply (rule asUser_setRegister_corres)
             apply simp
            apply (wp | simp)+
    apply (rule corres_guard_imp)
-      apply (rule corres_split_eqr [OF _ mk_ft_msg_corres])
-        apply (rule corres_split_eqr [OF _ set_mrs_corres [OF refl]])
-          apply (rule corres_split_nor [OF _ set_mi_corres])
-             apply (rule user_setreg_corres)
+      apply (rule corres_split_eqr [OF _ makeFaultMessage_corres])
+        apply (rule corres_split_eqr [OF _ setMRs_corres [OF refl]])
+          apply (rule corres_split_nor [OF _ setMessageInfo_corres])
+             apply (rule asUser_setRegister_corres)
             apply simp
            apply (wp | simp)+
   done
@@ -1726,7 +1726,7 @@ lemma lookupIPCBuffer_valid_ipc_buffer [wp]:
   apply (simp add: word_bits_conv)
   done
 
-lemma dit_corres:
+lemma doIPCTransfer_corres:
   "corres dc
      (tcb_at s and tcb_at r and valid_objs and pspace_aligned
         and valid_list
@@ -1746,7 +1746,7 @@ lemma dit_corres:
                                     \<comment> \<open>\<exists>ft. tcb_fault tcb = Some ft\<close>) s sa"
                in corres_split')
      apply (rule corres_guard_imp)
-       apply (rule lipcb_corres')
+       apply (rule lookupIPCBuffer_corres')
       apply auto[2]
     apply (rule corres_split' [OF _ _ thread_get_sp threadGet_inv])
      apply (rule corres_guard_imp)
@@ -1757,12 +1757,12 @@ lemma dit_corres:
        apply (subst case_option_If)+
        apply (rule corres_if2)
          apply (simp add: fault_rel_optionation_def)
-        apply (rule corres_split_eqr [OF _ lipcb_corres'])
+        apply (rule corres_split_eqr [OF _ lookupIPCBuffer_corres'])
           apply (simp add: dc_def[symmetric])
-          apply (rule do_normal_transfer_corres)
+          apply (rule doNormalTransfer_corres)
          apply (wp | simp add: valid_pspace'_def)+
        apply (simp add: dc_def[symmetric])
-       apply (rule do_fault_transfer_corres)
+       apply (rule doFaultTransfer_corres)
       apply (clarsimp simp: obj_at_def)
      apply (erule ignore_if)
     apply (wp|simp add: obj_at_def is_tcb valid_pspace'_def)+
@@ -1895,14 +1895,14 @@ lemma handle_fault_reply_registers_corres:
     apply (clarsimp simp: arch_get_sanitise_register_info_def getSanitiseRegisterInfo_def)
        apply (rule corres_split_deprecated)
        apply (rule corres_trivial, simp)
-      apply (rule corres_as_user')
+      apply (rule asUser_corres')
       apply(simp add: setRegister_def syscallMessage_def)
       apply(subst zipWithM_x_modify)+
       apply(rule corres_modify')
        apply (clarsimp simp: sanitise_register_corres|wp)+
   done
 
-lemma handle_fault_reply_corres:
+lemma handleFaultReply_corres:
   "ft' = fault_map ft \<Longrightarrow>
    corres (=) (tcb_at t) (tcb_at' t)
      (handle_fault_reply ft t label msg)
@@ -2155,7 +2155,7 @@ lemma cte_wp_at_is_reply_cap_toI:
    \<Longrightarrow> cte_wp_at (is_reply_cap_to t) ptr s"
   by (fastforce simp: cte_wp_at_reply_cap_to_ex_rights)
 
-lemma do_reply_transfer_corres:
+lemma doReplyTransfer_corres:
   "corres dc
      (einvs and tcb_at receiver and tcb_at sender
            and cte_wp_at ((=) (cap.ReplyCap receiver False rights)) slot)
@@ -2166,7 +2166,7 @@ lemma do_reply_transfer_corres:
   apply (simp add: do_reply_transfer_def doReplyTransfer_def cong: option.case_cong)
   apply (rule corres_split' [OF _ _ gts_sp gts_sp'])
    apply (rule corres_guard_imp)
-     apply (rule gts_corres, (clarsimp simp add: st_tcb_at_tcb_at)+)
+     apply (rule getThreadState_corres, (clarsimp simp add: st_tcb_at_tcb_at)+)
   apply (rule_tac F = "awaiting_reply state" in corres_req)
    apply (clarsimp simp add: st_tcb_at_def obj_at_def is_tcb)
    apply (fastforce simp: invs_def valid_state_def intro: has_reply_cap_cte_wpD
@@ -2195,9 +2195,9 @@ lemma do_reply_transfer_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ threadget_fault_corres])
       apply (case_tac rv, simp_all add: fault_rel_optionation_def bind_assoc)[1]
-       apply (rule corres_split_deprecated [OF _ dit_corres])
+       apply (rule corres_split_deprecated [OF _ doIPCTransfer_corres])
          apply (rule corres_split_deprecated [OF _ cap_delete_one_corres])
-           apply (rule corres_split_deprecated [OF _ sts_corres])
+           apply (rule corres_split_deprecated [OF _ setThreadState_corres])
               apply (rule possibleSwitchTo_corres)
              apply simp
             apply (wp set_thread_state_runnable_valid_sched set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at' sts_st_tcb' sts_valid_queues sts_valid_objs' delete_one_tcbDomain_obj_at'
@@ -2229,11 +2229,11 @@ lemma do_reply_transfer_corres:
 
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ cap_delete_one_corres])
-      apply (rule corres_split_mapr [OF _ get_mi_corres])
-        apply (rule corres_split_eqr [OF _ lipcb_corres'])
-          apply (rule corres_split_eqr [OF _ get_mrs_corres])
+      apply (rule corres_split_mapr [OF _ getMessageInfo_corres])
+        apply (rule corres_split_eqr [OF _ lookupIPCBuffer_corres'])
+          apply (rule corres_split_eqr [OF _ getMRs_corres])
             apply (simp(no_asm) del: dc_simp)
-            apply (rule corres_split_eqr [OF _ handle_fault_reply_corres])
+            apply (rule corres_split_eqr [OF _ handleFaultReply_corres])
                apply (rule corres_split_deprecated [OF _ threadset_corresT])
                      apply (rule_tac Q="valid_sched and cur_tcb and tcb_at receiver"
                                  and Q'="tcb_at' receiver and cur_tcb'
@@ -2242,13 +2242,13 @@ lemma do_reply_transfer_corres:
                                    in corres_guard_imp)
                        apply (case_tac rvb, simp_all)[1]
                         apply (rule corres_guard_imp)
-                          apply (rule corres_split_deprecated [OF _ sts_corres])
+                          apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                       apply (fold dc_def, rule possibleSwitchTo_corres)
                                apply simp
                               apply (wp static_imp_wp static_imp_conj_wp set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at'
                                         sts_st_tcb' sts_valid_queues | simp | force simp: valid_sched_def valid_sched_action_def valid_tcb_state'_def)+
                        apply (rule corres_guard_imp)
-                      apply (rule sts_corres)
+                      apply (rule setThreadState_corres)
                       apply (simp_all)[20]
                    apply (clarsimp simp add: tcb_relation_def fault_rel_optionation_def
                                              tcb_cap_cases_def tcb_cte_cases_def exst_same_def)+
@@ -2282,7 +2282,7 @@ lemma do_reply_transfer_corres:
 
 (* when we cannot talk about reply cap rights explicitly (for instance, when a schematic ?rights
    would be generated too early *)
-lemma do_reply_transfer_corres':
+lemma doReplyTransfer_corres':
   "corres dc
      (einvs and tcb_at receiver and tcb_at sender
            and cte_wp_at (is_reply_cap_to receiver) slot)
@@ -2290,7 +2290,7 @@ lemma do_reply_transfer_corres':
             and valid_pspace' and cte_at' (cte_map slot))
      (do_reply_transfer sender receiver slot grant)
      (doReplyTransfer sender receiver (cte_map slot) grant)"
-  using do_reply_transfer_corres[of receiver sender _ slot]
+  using doReplyTransfer_corres[of receiver sender _ slot]
   by (fastforce simp add: cte_wp_at_reply_cap_to_ex_rights corres_underlying_def)
 
 lemma valid_pspace'_splits[elim!]:
@@ -2315,7 +2315,7 @@ lemma sts_valid_pspace_hangers:
 
 declare no_fail_getSlotCap [wp]
 
-lemma setup_caller_corres:
+lemma setupCallerCap_corres:
   "corres dc
      (st_tcb_at (Not \<circ> halted) sender and tcb_at receiver and
       st_tcb_at (Not \<circ> awaiting_reply) sender and valid_reply_caps and
@@ -2339,7 +2339,7 @@ lemma setup_caller_corres:
           apply (rule corres_symb_exec_r)
              apply (rule_tac F="rv = capability.NullCap"
                           in corres_gen_asm2, simp)
-             apply (rule cins_corres)
+             apply (rule cteInsert_corres)
                apply (simp split: if_splits)
               apply (simp add: cte_map_def tcbReplySlot_def
                                tcb_cnode_index_def cte_level_bits_def)
@@ -2358,7 +2358,7 @@ lemma setup_caller_corres:
         apply blast
        apply (rule no_fail_pre, wp)
        apply (clarsimp simp: cte_wp_at_ctes_of)
-      apply (rule sts_corres)
+      apply (rule setThreadState_corres)
       apply (simp split: option.split)
      apply (wp sts_valid_pspace_hangers
                  | simp add: cte_wp_at_ctes_of)+
@@ -2445,7 +2445,7 @@ crunch tcb_at'[wp]: possibleSwitchTo "tcb_at' t"
 crunch valid_pspace'[wp]: possibleSwitchTo valid_pspace'
   (wp: crunch_wps)
 
-lemma send_ipc_corres:
+lemma sendIPC_corres:
 (* call is only true if called in handleSyscall SysCall, which
    is always blocking. *)
   assumes "call \<longrightarrow> bl"
@@ -2460,7 +2460,7 @@ proof -
   apply (case_tac bl)
    apply clarsimp
    apply (rule corres_guard_imp)
-     apply (rule corres_split_deprecated [OF _ get_ep_corres,
+     apply (rule corres_split_deprecated [OF _ getEndpoint_corres,
               where
               R="\<lambda>rv. einvs and st_tcb_at active t and ep_at ep and
                       valid_ep rv and obj_at (\<lambda>ob. ob = Endpoint rv) ep
@@ -2471,8 +2471,8 @@ proof -
        apply (case_tac rv)
          apply (simp add: ep_relation_def)
          apply (rule corres_guard_imp)
-           apply (rule corres_split_deprecated [OF _ sts_corres])
-              apply (rule set_ep_corres)
+           apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+              apply (rule setEndpoint_corres)
               apply (simp add: ep_relation_def)
              apply (simp add: fault_rel_optionation_def)
             apply wp+
@@ -2481,8 +2481,8 @@ proof -
          \<comment> \<open>concludes IdleEP if bl branch\<close>
         apply (simp add: ep_relation_def)
         apply (rule corres_guard_imp)
-          apply (rule corres_split_deprecated [OF _ sts_corres])
-             apply (rule set_ep_corres)
+          apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+             apply (rule setEndpoint_corres)
              apply (simp add: ep_relation_def)
             apply (simp add: fault_rel_optionation_def)
            apply wp+
@@ -2497,16 +2497,16 @@ proof -
         apply simp
        apply (clarsimp split del: if_split)
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
             apply (simp add: isReceive_def split del:if_split)
-            apply (rule corres_split_deprecated [OF _ gts_corres])
+            apply (rule corres_split_deprecated [OF _ getThreadState_corres])
               apply (rule_tac
                      F="\<exists>data. recv_state = Structures_A.BlockedOnReceive ep data"
                      in corres_gen_asm)
               apply (clarsimp simp: case_bool_If  case_option_If if3_fold
                           simp del: dc_simp split del: if_split cong: if_cong)
-              apply (rule corres_split_deprecated [OF _ dit_corres])
-                apply (rule corres_split_deprecated [OF _ sts_corres])
+              apply (rule corres_split_deprecated [OF _ doIPCTransfer_corres])
+                apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                    apply (rule corres_split_deprecated [OF _ possibleSwitchTo_corres])
                        apply (fold when_def)[1]
 
@@ -2514,8 +2514,8 @@ proof -
                                 in corres_symmetric_bool_cases, blast)
                         apply (simp add: when_def dc_def[symmetric] split del: if_split)
                         apply (rule corres_if2, simp)
-                         apply (rule setup_caller_corres)
-                        apply (rule sts_corres, simp)
+                         apply (rule setupCallerCap_corres)
+                        apply (rule setThreadState_corres, simp)
                        apply (rule corres_trivial)
                        apply (simp add: when_def dc_def[symmetric] split del: if_split)
                       apply (simp split del: if_split add: if_apply_def2)
@@ -2551,7 +2551,7 @@ proof -
       apply wp+
     apply (clarsimp simp: ep_at_def2)+
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres,
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres,
              where
              R="\<lambda>rv. einvs and st_tcb_at active t and ep_at ep and
                      valid_ep rv and obj_at (\<lambda>k. k = Endpoint rv) ep"
@@ -2578,15 +2578,15 @@ proof -
        apply fastforce
       apply (clarsimp split del: if_split)
       apply (rule corres_guard_imp)
-        apply (rule corres_split_deprecated [OF _ set_ep_corres])
-           apply (rule corres_split_deprecated [OF _ gts_corres])
+        apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+           apply (rule corres_split_deprecated [OF _ getThreadState_corres])
              apply (rule_tac
                 F="\<exists>data. recv_state = Structures_A.BlockedOnReceive ep data"
                     in corres_gen_asm)
              apply (clarsimp simp: isReceive_def case_bool_If
                         split del: if_split cong: if_cong)
-             apply (rule corres_split_deprecated [OF _ dit_corres])
-               apply (rule corres_split_deprecated [OF _ sts_corres])
+             apply (rule corres_split_deprecated [OF _ doIPCTransfer_corres])
+               apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                    apply (rule possibleSwitchTo_corres)
                   apply (simp add: if_apply_def2)
                   apply (wp hoare_drop_imps)
@@ -2643,12 +2643,12 @@ lemma valid_sched_weak_strg:
 crunch weak_valid_sched_action[wp]: as_user weak_valid_sched_action
   (wp: weak_valid_sched_action_lift)
 
-lemma send_signal_corres:
+lemma sendSignal_corres:
   "corres dc (einvs and ntfn_at ep) (invs' and ntfn_at' ep)
              (send_signal ep bg) (sendSignal ep bg)"
   apply (simp add: send_signal_def sendSignal_def Let_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ntfn_corres,
+    apply (rule corres_split_deprecated [OF _ getNotification_corres,
                 where
                 R  = "\<lambda>rv. einvs and ntfn_at ep and valid_ntfn rv and
                            ko_at (Structures_A.Notification rv) ep" and
@@ -2662,19 +2662,19 @@ lemma send_signal_corres:
     apply (clarsimp simp add: ntfn_relation_def)
     apply (case_tac "ntfnBoundTCB nTFN")
      apply clarsimp
-     apply (rule corres_guard_imp[OF set_ntfn_corres])
+     apply (rule corres_guard_imp[OF setNotification_corres])
        apply (clarsimp simp add: ntfn_relation_def)+
     apply (rule corres_guard_imp)
-      apply (rule corres_split_deprecated[OF _ gts_corres])
+      apply (rule corres_split_deprecated[OF _ getThreadState_corres])
         apply (rule corres_if)
           apply (fastforce simp: receive_blocked_def receiveBlocked_def
                                  thread_state_relation_def
                           split: Structures_A.thread_state.splits
                                  Structures_H.thread_state.splits)
          apply (rule corres_split_deprecated[OF _ cancel_ipc_corres])
-           apply (rule corres_split_deprecated[OF _ sts_corres])
+           apply (rule corres_split_deprecated[OF _ setThreadState_corres])
               apply (simp add: badgeRegister_def badge_register_def)
-              apply (rule corres_split_deprecated[OF _ user_setreg_corres])
+              apply (rule corres_split_deprecated[OF _ asUser_setRegister_corres])
                 apply (rule possibleSwitchTo_corres)
                apply wp
              apply (clarsimp simp: thread_state_relation_def)
@@ -2687,7 +2687,7 @@ lemma send_signal_corres:
           apply wp
          apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak
                                valid_tcb_state'_def)
-        apply (rule set_ntfn_corres)
+        apply (rule setNotification_corres)
         apply (clarsimp simp add: ntfn_relation_def)
        apply (wp gts_wp gts_wp' | clarsimp)+
      apply (auto simp: valid_ntfn_def receive_blocked_def valid_sched_def invs_cur
@@ -2704,10 +2704,10 @@ lemma send_signal_corres:
     apply (rule corres_guard_imp)
       apply (rule_tac F="list \<noteq> []" in corres_gen_asm)
       apply (simp add: list_case_helper split del: if_split)
-      apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-         apply (rule corres_split_deprecated [OF _ sts_corres])
+      apply (rule corres_split_deprecated [OF _ setNotification_corres])
+         apply (rule corres_split_deprecated [OF _ setThreadState_corres])
             apply (simp add: badgeRegister_def badge_register_def)
-            apply (rule corres_split_deprecated [OF _ user_setreg_corres])
+            apply (rule corres_split_deprecated [OF _ asUser_setRegister_corres])
               apply (rule possibleSwitchTo_corres)
              apply ((wp | simp)+)[1]
             apply (rule_tac Q="\<lambda>_. Invariants_H.valid_queues and valid_queues' and
@@ -2735,10 +2735,10 @@ lemma send_signal_corres:
    apply (rule corres_guard_imp)
      apply (rule_tac F="list \<noteq> []" in corres_gen_asm)
      apply (simp add: list_case_helper)
-     apply (rule corres_split_deprecated [OF _ set_ntfn_corres])
-        apply (rule corres_split_deprecated [OF _ sts_corres])
+     apply (rule corres_split_deprecated [OF _ setNotification_corres])
+        apply (rule corres_split_deprecated [OF _ setThreadState_corres])
            apply (simp add: badgeRegister_def badge_register_def)
-           apply (rule corres_split_deprecated [OF _ user_setreg_corres])
+           apply (rule corres_split_deprecated [OF _ asUser_setRegister_corres])
              apply (rule possibleSwitchTo_corres)
             apply (wp cur_tcb_lift | simp)+
          apply (wp sts_st_tcb_at' set_thread_state_runnable_weak_valid_sched_action
@@ -2760,7 +2760,7 @@ lemma send_signal_corres:
   \<comment> \<open>ActiveNtfn\<close>
   apply (clarsimp simp add: ntfn_relation_def)
   apply (rule corres_guard_imp)
-    apply (rule set_ntfn_corres)
+    apply (rule setNotification_corres)
     apply (simp add: ntfn_relation_def combine_ntfn_badges_def
                      combine_ntfn_msgs_def)
    apply (simp add: invs_def valid_state_def valid_ntfn_def)
@@ -3141,17 +3141,17 @@ lemma sai_invs'[wp]:
                    split: thread_state.splits
                    dest!: global'_no_ex_cap st_tcb_ex_cap'' ko_at_valid_objs')+
 
-lemma rfk_corres:
+lemma replyFromKernel_corres:
   "corres dc (tcb_at t and invs) (tcb_at' t and invs')
              (reply_from_kernel t r) (replyFromKernel t r)"
   apply (case_tac r)
   apply (clarsimp simp: replyFromKernel_def reply_from_kernel_def
                         badge_register_def badgeRegister_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ lipcb_corres])
-      apply (rule corres_split_deprecated [OF _ user_setreg_corres])
-        apply (rule corres_split_eqr [OF _ set_mrs_corres])
-           apply (rule set_mi_corres)
+    apply (rule corres_split_eqr [OF _ lookupIPCBuffer_corres])
+      apply (rule corres_split_deprecated [OF _ asUser_setRegister_corres])
+        apply (rule corres_split_eqr [OF _ setMRs_corres])
+           apply (rule setMessageInfo_corres)
            apply (wp hoare_case_option_wp hoare_valid_ipc_buffer_ptr_typ_at'
                   | clarsimp)+
   done
@@ -3165,7 +3165,7 @@ lemma rfk_invs':
 
 crunch nosch[wp]: replyFromKernel "\<lambda>s. P (ksSchedulerAction s)"
 
-lemma complete_signal_corres:
+lemma completeSignal_corres:
   "corres dc (ntfn_at ntfnptr and tcb_at tcb and pspace_aligned and valid_objs
         \<comment> \<open>and obj_at (\<lambda>ko. ko = Notification ntfn \<and> Ipc_A.isActive ntfn) ntfnptr\<close>)
              (ntfn_at' ntfnptr and tcb_at' tcb and valid_pspace' and obj_at' isActive ntfnptr)
@@ -3174,14 +3174,14 @@ lemma complete_signal_corres:
   apply (rule corres_guard_imp)
     apply (rule_tac R'="\<lambda>ntfn. ntfn_at' ntfnptr and tcb_at' tcb and valid_pspace'
                          and valid_ntfn' ntfn and (\<lambda>_. isActive ntfn)"
-                                in corres_split_deprecated [OF _ get_ntfn_corres])
+                                in corres_split_deprecated [OF _ getNotification_corres])
       apply (rule corres_gen_asm2)
       apply (case_tac "ntfn_obj rv")
         apply (clarsimp simp: ntfn_relation_def isActive_def
                        split: ntfn.splits Structures_H.notification.splits)+
       apply (rule corres_guard2_imp)
        apply (simp add: badgeRegister_def badge_register_def)
-       apply (rule corres_split_deprecated[OF set_ntfn_corres user_setreg_corres])
+       apply (rule corres_split_deprecated[OF setNotification_corres asUser_setRegister_corres])
          apply (clarsimp simp: ntfn_relation_def)
         apply (wp set_simple_ko_valid_objs get_simple_ko_wp getNotification_wp | clarsimp simp: valid_ntfn'_def)+
   apply (clarsimp simp: valid_pspace'_def)
@@ -3190,15 +3190,15 @@ lemma complete_signal_corres:
   done
 
 
-lemma do_nbrecv_failed_transfer_corres:
+lemma doNBRecvFailedTransfer_corres:
   "corres dc (tcb_at thread)
             (tcb_at' thread)
             (do_nbrecv_failed_transfer thread)
             (doNBRecvFailedTransfer thread)"
   unfolding do_nbrecv_failed_transfer_def doNBRecvFailedTransfer_def
-  by (simp add: badgeRegister_def badge_register_def, rule user_setreg_corres)
+  by (simp add: badgeRegister_def badge_register_def, rule asUser_setRegister_corres)
 
-lemma receive_ipc_corres:
+lemma receiveIPC_corres:
   assumes "is_ep_cap cap" and "cap_relation cap cap'"
   shows "
    corres dc (einvs and valid_sched and tcb_at thread and valid_cap cap and ex_nonz_cap_to thread
@@ -3212,15 +3212,15 @@ lemma receive_ipc_corres:
   apply (rename_tac word1 word2 right)
   apply clarsimp
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ get_ep_corres])
+    apply (rule corres_split_deprecated [OF _ getEndpoint_corres])
       apply (rule corres_guard_imp)
-        apply (rule corres_split_deprecated [OF _ gbn_corres])
+        apply (rule corres_split_deprecated [OF _ getBoundNotification_corres])
           apply (rule_tac r'="ntfn_relation" in corres_split_deprecated)
              apply (rule corres_if)
                apply (clarsimp simp: ntfn_relation_def Ipc_A.isActive_def Endpoint_H.isActive_def
                               split: Structures_A.ntfn.splits Structures_H.notification.splits)
               apply clarsimp
-              apply (rule complete_signal_corres)
+              apply (rule completeSignal_corres)
              apply (rule_tac P="einvs and valid_sched and tcb_at thread and
                                        ep_at word1 and valid_ep ep and
                                        obj_at (\<lambda>k. k = Endpoint ep) word1
@@ -3234,12 +3234,12 @@ lemma receive_ipc_corres:
                apply (simp add: ep_relation_def)
                apply (rule corres_guard_imp)
                  apply (case_tac isBlocking; simp)
-                  apply (rule corres_split_deprecated [OF _ sts_corres])
-                     apply (rule set_ep_corres)
+                  apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+                     apply (rule setEndpoint_corres)
                      apply (simp add: ep_relation_def)
                     apply simp
                    apply wp+
-                 apply (rule corres_guard_imp, rule do_nbrecv_failed_transfer_corres, simp)
+                 apply (rule corres_guard_imp, rule doNBRecvFailedTransfer_corres, simp)
                  apply simp
                 apply (clarsimp simp add: invs_def valid_state_def valid_pspace_def
                valid_tcb_state_def st_tcb_at_tcb_at)
@@ -3251,8 +3251,8 @@ lemma receive_ipc_corres:
         apply (clarsimp simp: valid_ep_def)
        apply (case_tac list, simp_all split del: if_split)[1]
        apply (rule corres_guard_imp)
-         apply (rule corres_split_deprecated [OF _ set_ep_corres])
-            apply (rule corres_split_deprecated [OF _ gts_corres])
+         apply (rule corres_split_deprecated [OF _ setEndpoint_corres])
+            apply (rule corres_split_deprecated [OF _ getThreadState_corres])
               apply (rule_tac
                        F="\<exists>data.
                            sender_state =
@@ -3261,7 +3261,7 @@ lemma receive_ipc_corres:
               apply (clarsimp simp: isSend_def case_bool_If
                                     case_option_If if3_fold
                          split del: if_split cong: if_cong)
-              apply (rule corres_split_deprecated [OF _ dit_corres])
+              apply (rule corres_split_deprecated [OF _ doIPCTransfer_corres])
                 apply (simp split del: if_split cong: if_cong)
                 apply (fold dc_def)[1]
                 apply (rule_tac P="valid_objs and valid_mdb and valid_list
@@ -3282,10 +3282,10 @@ lemma receive_ipc_corres:
                                         and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)"
                              in corres_guard_imp [OF corres_if])
                     apply (simp add: fault_rel_optionation_def)
-                   apply (rule corres_if2 [OF _ setup_caller_corres sts_corres])
+                   apply (rule corres_if2 [OF _ setupCallerCap_corres setThreadState_corres])
                            apply simp
                           apply simp
-                         apply (rule corres_split_deprecated [OF _ sts_corres])
+                         apply (rule corres_split_deprecated [OF _ setThreadState_corres])
                             apply (rule possibleSwitchTo_corres)
                            apply simp
                           apply (wp sts_st_tcb_at' set_thread_state_runnable_weak_valid_sched_action
@@ -3315,17 +3315,17 @@ lemma receive_ipc_corres:
              apply (simp add: ep_relation_def)
              apply (rule_tac corres_guard_imp)
                apply (case_tac isBlocking; simp)
-                apply (rule corres_split_deprecated [OF _ sts_corres])
-                   apply (rule set_ep_corres)
+                apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+                   apply (rule setEndpoint_corres)
                    apply (simp add: ep_relation_def)
                   apply simp
                  apply wp+
-               apply (rule corres_guard_imp, rule do_nbrecv_failed_transfer_corres, simp)
+               apply (rule corres_guard_imp, rule doNBRecvFailedTransfer_corres, simp)
                apply simp
               apply (clarsimp simp: valid_tcb_state_def)
              apply (clarsimp simp add: valid_tcb_state'_def)
             apply (rule corres_option_split[rotated 2])
-              apply (rule get_ntfn_corres)
+              apply (rule getNotification_corres)
              apply clarsimp
             apply (rule corres_trivial, simp add: ntfn_relation_def default_notification_def
                                                   default_ntfn_def)
@@ -3343,7 +3343,7 @@ lemma receive_ipc_corres:
              split: option.splits)
   done
 
-lemma receive_signal_corres:
+lemma receiveSignal_corres:
  "\<lbrakk> is_ntfn_cap cap; cap_relation cap cap' \<rbrakk> \<Longrightarrow>
   corres dc (invs and st_tcb_at active thread and valid_cap cap and ex_nonz_cap_to thread)
             (invs' and tcb_at' thread and valid_cap' cap')
@@ -3358,36 +3358,36 @@ lemma receive_signal_corres:
                             obj_at (\<lambda>k. k = Notification rv) word1" and
                             R'="\<lambda>rv'. invs' and tcb_at' thread and ntfn_at' word1 and
                             valid_ntfn' rv'"
-                         in corres_split_deprecated [OF _ get_ntfn_corres])
+                         in corres_split_deprecated [OF _ getNotification_corres])
       apply clarsimp
       apply (case_tac "ntfn_obj rv")
         \<comment> \<open>IdleNtfn\<close>
         apply (simp add: ntfn_relation_def)
         apply (rule corres_guard_imp)
           apply (case_tac isBlocking; simp)
-           apply (rule corres_split_deprecated [OF _ sts_corres])
-              apply (rule set_ntfn_corres)
+           apply (rule corres_split_deprecated [OF _ setThreadState_corres])
+              apply (rule setNotification_corres)
               apply (simp add: ntfn_relation_def)
              apply simp
             apply wp+
-          apply (rule corres_guard_imp, rule do_nbrecv_failed_transfer_corres, simp+)
+          apply (rule corres_guard_imp, rule doNBRecvFailedTransfer_corres, simp+)
        \<comment> \<open>WaitingNtfn\<close>
        apply (simp add: ntfn_relation_def)
        apply (rule corres_guard_imp)
          apply (case_tac isBlocking; simp)
-          apply (rule corres_split_deprecated[OF _ sts_corres])
-             apply (rule set_ntfn_corres)
+          apply (rule corres_split_deprecated[OF _ setThreadState_corres])
+             apply (rule setNotification_corres)
              apply (simp add: ntfn_relation_def)
             apply simp
            apply wp+
          apply (rule corres_guard_imp)
-           apply (rule do_nbrecv_failed_transfer_corres, simp+)
+           apply (rule doNBRecvFailedTransfer_corres, simp+)
       \<comment> \<open>ActiveNtfn\<close>
       apply (simp add: ntfn_relation_def)
       apply (rule corres_guard_imp)
         apply (simp add: badgeRegister_def badge_register_def)
-        apply (rule corres_split_deprecated [OF _ user_setreg_corres])
-          apply (rule set_ntfn_corres)
+        apply (rule corres_split_deprecated [OF _ asUser_setRegister_corres])
+          apply (rule setNotification_corres)
           apply (simp add: ntfn_relation_def)
          apply wp+
        apply (fastforce simp: invs_def valid_state_def valid_pspace_def
@@ -3412,7 +3412,7 @@ lemma tg_sp':
 
 declare lookup_cap_valid' [wp]
 
-lemma send_fault_ipc_corres:
+lemma sendFaultIPC_corres:
   "valid_fault f \<Longrightarrow> fr f f' \<Longrightarrow>
   corres (fr \<oplus> dc)
          (einvs and st_tcb_at active thread and ex_nonz_cap_to thread)
@@ -3439,7 +3439,7 @@ lemma send_fault_ipc_corres:
           apply (rule corres_guard_imp)
             apply (rule corres_if2 [OF refl])
              apply (simp add: dc_def[symmetric])
-             apply (rule corres_split_deprecated [OF send_ipc_corres threadset_corres], simp_all)[1]
+             apply (rule corres_split_deprecated [OF sendIPC_corres threadset_corres], simp_all)[1]
                apply (simp add: tcb_relation_def fault_rel_optionation_def exst_same_def)+
               apply (wp thread_set_invs_trivial thread_set_no_change_tcb_state
                         thread_set_typ_at ep_at_typ_at ex_nonz_cap_to_pres
@@ -3455,7 +3455,7 @@ lemma send_fault_ipc_corres:
           apply auto[1]
          apply (clarsimp simp: lookup_failure_map_def)
         apply wp+
-      apply (rule threadget_corres)
+      apply (rule threadGet_corres)
       apply (simp add: tcb_relation_def)
      apply wp+
    apply (fastforce elim: st_tcb_at_tcb_at)
@@ -3470,7 +3470,7 @@ lemma gets_the_noop_corres:
   apply (clarsimp simp: assert_opt_def return_def dest!: P)
   done
 
-lemma hdf_corres:
+lemma handleDoubleFault_corres:
   "corres dc (tcb_at thread)
              (tcb_at' thread and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s))
              (handle_double_fault thread f ft)
@@ -3478,7 +3478,7 @@ lemma hdf_corres:
   apply (simp add: handle_double_fault_def handleDoubleFault_def)
   apply (rule corres_guard_imp)
     apply (subst bind_return [symmetric],
-           rule corres_split' [OF sts_corres])
+           rule corres_split' [OF setThreadState_corres])
        apply simp
       apply (rule corres_noop2)
          apply (simp add: exs_valid_def return_def)
@@ -4241,7 +4241,7 @@ lemma sfi_invs_plus':
   apply (subst(asm) global'_no_ex_cap, auto)
   done
 
-lemma hf_corres:
+lemma handleFault_corres:
   "fr f f' \<Longrightarrow>
    corres dc (einvs and  st_tcb_at active thread and ex_nonz_cap_to thread
                    and (%_. valid_fault f))
@@ -4255,9 +4255,9 @@ lemma hf_corres:
                rule corres_split_deprecated [where P="tcb_at thread",
                                   OF _ gets_the_noop_corres [where x="()"]])
        apply (rule corres_split_catch)
-          apply (rule hdf_corres)
+          apply (rule handleDoubleFault_corres)
           apply (rule_tac F="valid_fault f" in corres_gen_asm)
-         apply (rule send_fault_ipc_corres, assumption)
+         apply (rule sendFaultIPC_corres, assumption)
          apply simp
         apply wp+
        apply (rule hoare_post_impErr, rule sfi_invs_plus', simp_all)[1]

--- a/proof/refine/X64/KHeap_R.thy
+++ b/proof/refine/X64/KHeap_R.thy
@@ -837,7 +837,7 @@ lemma no_fail_getEndpoint [wp]:
    apply (clarsimp split: option.split_asm simp: objBits_simps' archObjSize_def)
   done
 
-lemma get_ep_corres:
+lemma getEndpoint_corres:
   "corres ep_relation (ep_at ptr) (ep_at' ptr)
      (get_endpoint ptr) (getEndpoint ptr)"
   apply (rule corres_no_failI)
@@ -943,7 +943,7 @@ where
   "exst_same' (KOTCB tcb) (KOTCB tcb') = exst_same tcb tcb'" |
   "exst_same' _ _ = True"
 
-lemma set_other_obj_corres:
+lemma setObject_other_corres:
   fixes ob' :: "'a :: pspace_storable"
   assumes x: "updateObject ob' = updateObject_default ob'"
   assumes z: "\<And>s. obj_at' P ptr s
@@ -1020,21 +1020,21 @@ lemmas obj_at_simps = obj_at_def obj_at'_def projectKOs map_to_ctes_upd_other
                       is_other_obj_relation_type_def
                       a_type_def objBits_simps other_obj_relation_def
                       archObjSize_def pageBits_def
-lemma set_ep_corres:
+lemma setEndpoint_corres:
   "ep_relation e e' \<Longrightarrow>
   corres dc (ep_at ptr) (ep_at' ptr)
             (set_endpoint ptr e) (setEndpoint ptr e')"
   apply (simp add: set_simple_ko_def setEndpoint_def is_ep_def[symmetric])
-    apply (corres_search search: set_other_obj_corres[where P="\<lambda>_. True"])
+    apply (corres_search search: setObject_other_corres[where P="\<lambda>_. True"])
   apply (corressimp wp: get_object_ret get_object_wp)+
   by (fastforce simp: is_ep obj_at_simps objBits_defs partial_inv_def)
 
-lemma set_ntfn_corres:
+lemma setNotification_corres:
   "ntfn_relation ae ae' \<Longrightarrow>
   corres dc (ntfn_at ptr) (ntfn_at' ptr)
             (set_notification ptr ae) (setNotification ptr ae')"
   apply (simp add: set_simple_ko_def setNotification_def is_ntfn_def[symmetric])
-       apply (corres_search search: set_other_obj_corres[where P="\<lambda>_. True"])
+       apply (corres_search search: setObject_other_corres[where P="\<lambda>_. True"])
   apply (corressimp wp: get_object_ret get_object_wp)+
   by (fastforce simp: is_ntfn obj_at_simps objBits_defs partial_inv_def)
 
@@ -1054,7 +1054,7 @@ lemma no_fail_getNotification [wp]:
    apply (clarsimp split: option.split_asm simp: objBits_simps' archObjSize_def)
   done
 
-lemma get_ntfn_corres:
+lemma getNotification_corres:
   "corres ntfn_relation (ntfn_at ptr) (ntfn_at' ptr)
      (get_notification ptr) (getNotification ptr)"
   apply (rule corres_no_failI)

--- a/proof/refine/X64/Refine.thy
+++ b/proof/refine/X64/Refine.thy
@@ -529,7 +529,7 @@ lemma kernel_corres':
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated)
        prefer 2
-       apply (rule corres_split_handle [OF _ he_corres])
+       apply (rule corres_split_handle [OF _ handleEvent_corres])
          apply simp
          apply (rule corres_split_deprecated [OF _ corres_machine_op])
             prefer 2
@@ -541,7 +541,7 @@ lemma kernel_corres':
             apply (simp add: when_def)
            apply (rule corres_when[simplified dc_def], simp)
            apply simp
-           apply (rule handle_interrupt_corres[simplified dc_def])
+           apply (rule handleInterrupt_corres[simplified dc_def])
           apply simp
           apply (wp hoare_drop_imps hoare_vcg_all_lift)[1]
          apply simp
@@ -556,7 +556,7 @@ lemma kernel_corres':
          apply wpsimp+
        apply (simp add: invs'_def valid_state'_def)
       apply (rule corres_split_deprecated [OF _ schedule_corres])
-        apply (rule activate_corres)
+        apply (rule activateThread_corres)
        apply (wp schedule_invs' hoare_vcg_if_lift2 hoare_drop_imps
                  handle_interrupt_valid_sched[unfolded non_kernel_IRQs_def, simplified] |simp)+
      apply (rule_tac Q="\<lambda>_. valid_sched and invs and valid_list" and E="\<lambda>_. valid_sched and invs and valid_list"
@@ -615,7 +615,7 @@ lemma entry_corres:
           (kernel_entry event tc) (kernelEntry event tc)"
   apply (simp add: kernel_entry_def kernelEntry_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ gct_corres])
+    apply (rule corres_split_deprecated [OF _ getCurThread_corres])
       apply (rule corres_split_deprecated)
          prefer 2
          apply simp
@@ -626,8 +626,8 @@ lemma entry_corres:
           apply (clarsimp simp: tcb_cte_cases_def)
          apply (simp add: exst_same_def)
         apply (rule corres_split_deprecated [OF _ kernel_corres])
-          apply (rule corres_split_eqr [OF _ gct_corres])
-            apply (rule threadget_corres)
+          apply (rule corres_split_eqr [OF _ getCurThread_corres])
+            apply (rule threadGet_corres)
             apply (simp add: tcb_relation_def arch_tcb_relation_def
                              arch_tcb_context_get_def atcbContextGet_def)
            apply wp+
@@ -655,7 +655,7 @@ lemma do_user_op_corres:
           (do_user_op f tc) (doUserOp f tc)"
   apply (simp add: do_user_op_def doUserOp_def split_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ gct_corres])
+    apply (rule corres_split_deprecated[OF _ getCurThread_corres])
       apply (rule_tac r'="(=)" and P=einvs and P'=invs' in corres_split_deprecated)
          prefer 2
          apply (fastforce dest: absKState_correct [rotated])
@@ -739,7 +739,7 @@ lemma check_active_irq_corres:
     apply (rule check_active_irq_corres', auto)
   done
 
-lemma check_active_irq_corres_just_running:
+lemma checkActiveIRQ_just_running_corres:
   "corres (=)
     (invs and ct_running and einvs and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and (\<lambda>s. 0 < domain_time s) and valid_domain_list)
@@ -751,7 +751,7 @@ lemma check_active_irq_corres_just_running:
     apply (rule check_active_irq_corres', auto)
   done
 
-lemma check_active_irq_corres_just_idle:
+lemma checkActiveIRQ_just_idle_corres:
   "corres (=)
     (invs and ct_idle and einvs and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and (\<lambda>s. 0 < domain_time s)  and valid_domain_list)
@@ -877,7 +877,7 @@ lemma ckernel_invariant:
    apply (drule use_valid)
      apply (rule hoare_vcg_conj_lift)
       apply (rule checkActiveIRQ_valid_objs')
-     apply (rule valid_corres_combined[OF check_active_irq_invs_just_running check_active_irq_corres_just_running])
+     apply (rule valid_corres_combined[OF check_active_irq_invs_just_running checkActiveIRQ_just_running_corres])
      apply (rule checkActiveIRQ_invs'_just_running[THEN hoare_weaken_pre])
      apply (fastforce simp: ex_abs_def)
     apply (fastforce simp: ex_abs_def ct_running_related sched_act_rct_related)
@@ -888,7 +888,7 @@ lemma ckernel_invariant:
    apply (drule use_valid)
      apply (rule hoare_vcg_conj_lift)
       apply (rule checkActiveIRQ_valid_objs')
-     apply (rule valid_corres_combined[OF check_active_irq_invs_just_idle check_active_irq_corres_just_idle])
+     apply (rule valid_corres_combined[OF check_active_irq_invs_just_idle checkActiveIRQ_just_idle_corres])
      apply (rule checkActiveIRQ_invs'_just_idle[THEN hoare_weaken_pre])
      apply clarsimp
      apply (fastforce simp: ex_abs_def)

--- a/proof/refine/X64/TcbAcc_R.thy
+++ b/proof/refine/X64/TcbAcc_R.thy
@@ -262,7 +262,7 @@ lemma updateObject_tcb_inv:
   "\<lbrace>P\<rbrace> updateObject (obj::tcb) ko p q n \<lbrace>\<lambda>rv. P\<rbrace>"
   by simp (rule updateObject_default_inv)
 
-lemma tcb_update_corres':
+lemma setObject_update_TCB_corres':
   assumes tcbs: "tcb_relation tcb tcb' \<Longrightarrow> tcb_relation tcbu tcbu'"
   assumes tables: "\<forall>(getF, v) \<in> ran tcb_cap_cases. getF tcbu = getF tcb"
   assumes tables': "\<forall>(getF, v) \<in> ran tcb_cte_cases. getF tcbu' = getF tcb'"
@@ -277,7 +277,7 @@ lemma tcb_update_corres':
    apply (clarsimp simp: projectKOs other_obj_relation_def exst)
   apply (rule corres_guard_imp)
     apply (rule corres_rel_imp)
-     apply (rule set_other_obj_corres[where P="(=) tcb'"])
+     apply (rule setObject_other_corres[where P="(=) tcb'"])
            apply (rule ext)+
            apply simp
           defer
@@ -294,7 +294,7 @@ lemma tcb_update_corres':
   apply simp
   done
 
-lemma tcb_update_corres:
+lemma setObject_update_TCB_corres:
   "\<lbrakk> tcb_relation tcb tcb' \<Longrightarrow> tcb_relation tcbu tcbu';
      \<forall>(getF, v) \<in> ran tcb_cap_cases. getF tcbu = getF tcb;
      \<forall>(getF, v) \<in> ran tcb_cte_cases. getF tcbu' = getF tcb';
@@ -303,14 +303,14 @@ lemma tcb_update_corres:
                (\<lambda>s'. (tcb', s') \<in> fst (getObject add s'))
                (set_object add (TCB tcbu)) (setObject add tcbu')"
   apply (rule corres_guard_imp)
-    apply (erule (3) tcb_update_corres', force)
+    apply (erule (3) setObject_update_TCB_corres', force)
    apply fastforce
   apply (clarsimp simp: getObject_def in_monad split_def obj_at'_def
                         loadObject_default_def projectKOs objBits_simps'
                         in_magnitude_check)
   done
 
-lemma assert_get_tcb_corres:
+lemma getObject_TCB_corres:
   "corres tcb_relation (tcb_at t) (tcb_at' t)
           (gets_the (get_tcb t)) (getObject t)"
   apply (rule corres_guard_imp)
@@ -320,14 +320,14 @@ lemma assert_get_tcb_corres:
   apply assumption
   done
 
-lemma threadget_corres:
+lemma threadGet_corres:
   assumes x: "\<And>tcb tcb'. tcb_relation tcb tcb' \<Longrightarrow> r (f tcb) (f' tcb')"
   shows      "corres r (tcb_at t) (tcb_at' t) (thread_get f t) (threadGet f' t)"
   apply (simp add: thread_get_def threadGet_def)
   apply (fold liftM_def)
   apply simp
   apply (rule corres_rel_imp)
-   apply (rule assert_get_tcb_corres)
+   apply (rule getObject_TCB_corres)
   apply (simp add: x)
   done
 
@@ -359,8 +359,8 @@ lemma threadset_corresT:
                     (thread_set f t) (threadSet f' t)"
   apply (simp add: thread_set_def threadSet_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [OF _ assert_get_tcb_corres])
-      apply (rule tcb_update_corres')
+    apply (rule corres_split_deprecated [OF _ getObject_TCB_corres])
+      apply (rule setObject_update_TCB_corres')
           apply (erule x)
          apply (rule y)
         apply (clarsimp simp: bspec_split [OF spec [OF z]])
@@ -1335,7 +1335,7 @@ lemma threadSet_valid_objs':
   apply (clarsimp elim!: obj_at'_weakenE)
   done
 
-lemma corres_as_user':
+lemma asUser_corres':
   assumes y: "corres_underlying Id False True r \<top> \<top> f g"
   shows      "corres r (tcb_at t)
                        (tcb_at' t)
@@ -1364,7 +1364,7 @@ lemma corres_as_user':
                      (\<lambda>s'. (tcb', s') \<in> fst (getObject add s'))
                      (set_object add (TCB (tcb \<lparr> tcb_arch := arch_tcb_context_set con (tcb_arch tcb) \<rparr>)))
                      (setObject add (tcb' \<lparr> tcbArch := atcbContextSet con' (tcbArch tcb') \<rparr>))"
-    by (rule tcb_update_corres [OF L2],
+    by (rule setObject_update_TCB_corres [OF L2],
         (simp add: tcb_cte_cases_def tcb_cap_cases_def exst_same_def)+)
   have L4: "\<And>con con'. con = con' \<Longrightarrow>
             corres (\<lambda>(irv, nc) (irv', nc'). r irv irv' \<and> nc = nc')
@@ -1393,11 +1393,11 @@ lemma corres_as_user':
   done
 qed
 
-lemma corres_as_user:
+lemma asUser_corres:
   assumes y: "corres_underlying Id False True r \<top> \<top> f g"
   shows      "corres r (tcb_at t and invs) (tcb_at' t and invs') (as_user t f) (asUser t g)"
   apply (rule corres_guard_imp)
-    apply (rule corres_as_user' [OF y])
+    apply (rule asUser_corres' [OF y])
    apply (simp add: invs_def valid_state_def valid_pspace_def)
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
   done
@@ -1422,10 +1422,10 @@ proof -
     done
 qed
 
-lemma user_getreg_corres:
+lemma asUser_getRegister_corres:
  "corres (=) (tcb_at t) (tcb_at' t)
         (as_user t (getRegister r)) (asUser t (getRegister r))"
-  apply (rule corres_as_user')
+  apply (rule asUser_corres')
   apply (clarsimp simp: getRegister_def)
   done
 
@@ -1575,21 +1575,21 @@ lemma no_fail_asUser [wp]:
   apply simp
   done
 
-lemma user_setreg_corres:
+lemma asUser_setRegister_corres:
   "corres dc (tcb_at t)
              (tcb_at' t)
              (as_user t (setRegister r v))
              (asUser t (setRegister r v))"
   apply (simp add: setRegister_def)
-  apply (rule corres_as_user')
+  apply (rule asUser_corres')
   apply (rule corres_modify'; simp)
   done
 
-lemma gts_corres:
+lemma getThreadState_corres:
   "corres thread_state_relation (tcb_at t) (tcb_at' t)
           (get_thread_state t) (getThreadState t)"
   apply (simp add: get_thread_state_def getThreadState_def)
-  apply (rule threadget_corres)
+  apply (rule threadGet_corres)
   apply (simp add: tcb_relation_def)
   done
 
@@ -1616,11 +1616,11 @@ lemma gts_st_tcb_at'[wp]: "\<lbrace>st_tcb_at' P t\<rbrace> getThreadState t \<l
 lemma gts_inv'[wp]: "\<lbrace>P\<rbrace> getThreadState t \<lbrace>\<lambda>rv. P\<rbrace>"
   by (simp add: getThreadState_def) wp
 
-lemma gbn_corres:
+lemma getBoundNotification_corres:
   "corres (=) (tcb_at t) (tcb_at' t)
           (get_bound_notification t) (getBoundNotification t)"
   apply (simp add: get_bound_notification_def getBoundNotification_def)
-  apply (rule threadget_corres)
+  apply (rule threadGet_corres)
   apply (simp add: tcb_relation_def)
   done
 
@@ -1781,16 +1781,16 @@ lemma no_fail_return:
   "no_fail x (return y)"
   by wp
 
-lemma addToBitmap_corres_noop:
+lemma addToBitmap_noop_corres:
   "corres dc \<top> \<top> (return ()) (addToBitmap d p)"
   unfolding addToBitmap_def modifyReadyQueuesL1Bitmap_def getReadyQueuesL1Bitmap_def
             modifyReadyQueuesL2Bitmap_def getReadyQueuesL2Bitmap_def
   by (rule corres_noop)
      (wp | simp add: state_relation_def | rule no_fail_pre)+
 
-lemma addToBitmap_if_null_corres_noop: (* used this way in Haskell code *)
+lemma addToBitmap_if_null_noop_corres: (* used this way in Haskell code *)
   "corres dc \<top> \<top> (return ()) (if null queue then addToBitmap d p else return ())"
-  by (cases "null queue", simp_all add: addToBitmap_corres_noop)
+  by (cases "null queue", simp_all add: addToBitmap_noop_corres)
 
 lemma removeFromBitmap_corres_noop:
   "corres dc \<top> \<top> (return ()) (removeFromBitmap tdom prioa)"
@@ -1839,7 +1839,7 @@ proof -
                apply (rule corres_split_noop_rhs2)
                    apply (rule corres_split_noop_rhs2)
                      apply (fastforce intro: threadSet_corres_noop simp: tcb_relation_def exst_same_def)
-                    apply (fastforce intro: addToBitmap_corres_noop)
+                    apply (fastforce intro: addToBitmap_noop_corres)
                    apply wp+
                  apply (simp add: tcb_sched_enqueue_def split del: if_split)
                  apply (rule_tac P=\<top> and Q="K (t \<notin> set queuea)" in corres_assume_pre)
@@ -1859,7 +1859,7 @@ lemma weak_sch_act_wf_updateDomainTime[simp]:
   "weak_sch_act_wf m (ksDomainTime_update f s) = weak_sch_act_wf m s"
   by (simp add:weak_sch_act_wf_def tcb_in_cur_domain'_def )
 
-lemma set_sa_corres:
+lemma setSchedulerAction_corres:
   "sched_act_relation sa sa'
     \<Longrightarrow> corres dc \<top> \<top> (set_scheduler_action sa) (setSchedulerAction sa')"
   apply (simp add: setSchedulerAction_def set_scheduler_action_def)
@@ -1868,7 +1868,7 @@ lemma set_sa_corres:
   apply (clarsimp simp: in_monad simpler_modify_def state_relation_def)
   done
 
-lemma get_sa_corres:
+lemma getSchedulerAction_corres:
   "corres sched_act_relation \<top> \<top> (gets scheduler_action) getSchedulerAction"
   apply (simp add: getSchedulerAction_def)
   apply (clarsimp simp: state_relation_def)
@@ -1879,10 +1879,10 @@ lemma rescheduleRequired_corres:
      (reschedule_required) rescheduleRequired"
   apply (simp add: rescheduleRequired_def reschedule_required_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ get_sa_corres])
+    apply (rule corres_split_deprecated[OF _ getSchedulerAction_corres])
       apply (rule_tac P="case action of switch_thread t \<Rightarrow> P t | _ \<Rightarrow> \<top>"
               and P'="case actiona of SwitchToThread t \<Rightarrow> P' t | _ \<Rightarrow> \<top>" for P P' in corres_split_deprecated[where r'=dc])
-         apply (rule set_sa_corres)
+         apply (rule setSchedulerAction_corres)
          apply simp
         apply (case_tac action)
           apply simp
@@ -1902,7 +1902,7 @@ lemma rescheduleRequired_corres_simple:
   apply (simp add: rescheduleRequired_def)
   apply (rule corres_symb_exec_r[where Q'="\<lambda>rv s. rv = ResumeCurrentThread \<or> rv = ChooseNewThread"])
      apply (rule corres_symb_exec_r)
-        apply (rule set_sa_corres, simp)
+        apply (rule setSchedulerAction_corres, simp)
        apply (wp | clarsimp split: scheduler_action.split)+
     apply (wp | clarsimp simp: sch_act_simple_def split: scheduler_action.split)+
   apply (simp add: getSchedulerAction_def)
@@ -2056,12 +2056,12 @@ lemma thread_get_isRunnable_corres: "corres (=) (tcb_at t) (tcb_at' t) (thread_g
   apply (fold liftM_def)
   apply simp
   apply (rule corres_rel_imp)
-   apply (rule assert_get_tcb_corres)
+   apply (rule getObject_TCB_corres)
   apply (clarsimp simp add: tcb_relation_def thread_state_relation_def)
   apply (case_tac "tcb_state x",simp_all)
   done
 
-lemma sts_corres:
+lemma setThreadState_corres:
   "thread_state_relation ts ts' \<Longrightarrow>
    corres dc
           (tcb_at t)
@@ -2076,8 +2076,8 @@ lemma sts_corres:
        apply simp
        apply (subst thread_get_test[where test="runnable"])
        apply (rule corres_split_deprecated[OF _ thread_get_isRunnable_corres])
-         apply (rule corres_split_deprecated[OF _ gct_corres])
-           apply (rule corres_split_deprecated[OF _ get_sa_corres])
+         apply (rule corres_split_deprecated[OF _ getCurThread_corres])
+           apply (rule corres_split_deprecated[OF _ getSchedulerAction_corres])
              apply (simp only: when_def)
              apply (rule corres_if[where Q=\<top> and Q'=\<top>])
                apply (rule iffI)
@@ -2088,7 +2088,7 @@ lemma sts_corres:
      apply (wp hoare_vcg_conj_lift[where Q'="\<top>\<top>"] | simp add: sch_act_simple_def)+
    done
 
-lemma sbn_corres:
+lemma setBoundNotification_corres:
   "corres dc
           (tcb_at t)
           (tcb_at' t)
@@ -3176,7 +3176,7 @@ proof -
   thus ?thesis by (simp add: in_user_frame_def)
 qed
 
-lemma load_word_offs_corres:
+lemma loadWordUser_corres:
   assumes y: "y < unat max_ipc_words"
   shows "corres (=) \<top> (valid_ipc_buffer_ptr' a) (load_word_offs a y) (loadWordUser (a + of_nat y * 8))"
   unfolding loadWordUser_def
@@ -3195,7 +3195,7 @@ lemma load_word_offs_corres:
   apply (simp add: valid_ipc_buffer_ptr'_def msg_align_bits)
   done
 
-lemma store_word_offs_corres:
+lemma storeWordUser_corres:
   assumes y: "y < unat max_ipc_words"
   shows "corres dc (in_user_frame a) (valid_ipc_buffer_ptr' a)
                    (store_word_offs a y w) (storeWordUser (a + of_nat y * 8) w)"
@@ -3262,7 +3262,7 @@ lemma thread_get_registers:
   apply (clarsimp simp: map_upd_triv select_f_def image_def return_def)
   done
 
-lemma get_mrs_corres:
+lemma getMRs_corres:
   "corres (=) (tcb_at t)
               (tcb_at' t and case_option \<top> valid_ipc_buffer_ptr' buf)
               (get_mrs t buf mi) (getMRs t buf (message_info_map mi))"
@@ -3272,7 +3272,7 @@ lemma get_mrs_corres:
   have T: "corres (\<lambda>con regs. regs = map con msg_registers) (tcb_at t) (tcb_at' t)
      (thread_get (arch_tcb_get_registers o tcb_arch) t) (asUser t (mapM getRegister X64_H.msgRegisters))"
    apply (subst thread_get_registers)
-    apply (rule corres_as_user')
+    apply (rule asUser_corres')
     apply (subst mapM_gets)
      apply (simp add: getRegister_def)
     apply (simp add: S X64_H.msgRegisters_def msg_registers_def)
@@ -3298,7 +3298,7 @@ lemma get_mrs_corres:
               apply simp
              apply simp
             apply (simp add: word_size wordSize_def wordBits_def)
-            apply (rule load_word_offs_corres)
+            apply (rule loadWordUser_corres)
             apply simp
            apply wp+
          apply simp
@@ -3372,7 +3372,7 @@ lemma UserContext_fold:
   apply (clarsimp split: prod.splits)
   by (metis user_context.sel(1) user_context.sel(2))
 
-lemma set_mrs_corres:
+lemma setMRs_corres:
   assumes m: "mrs' = mrs"
   shows
   "corres (=) (tcb_at t and case_option \<top> in_user_frame buf)
@@ -3398,7 +3398,7 @@ proof -
      apply (clarsimp simp: msgRegisters_unfold setRegister_def2 zipWithM_x_Nil zipWithM_x_modify
                            take_min_len zip_take_triv2 min.commute)
      apply (rule corres_guard_imp)
-       apply (rule corres_split_nor [OF _ corres_as_user'], rule corres_trivial, simp)
+       apply (rule corres_split_nor [OF _ asUser_corres'], rule corres_trivial, simp)
          apply (rule corres_modify')
           apply (fastforce simp: fold_fun_upd[symmetric] msgRegisters_unfold UserContext_fold
                                  modify_registers_def
@@ -3411,11 +3411,11 @@ proof -
                           msgMaxLength_def msgLengthBits_def)
     apply (simp add: msg_max_length_def)
     apply (rule corres_guard_imp)
-      apply (rule corres_split_nor [OF _ corres_as_user'])
+      apply (rule corres_split_nor [OF _ asUser_corres'])
          apply (rule corres_split_nor, rule corres_trivial, clarsimp simp: min.commute)
           apply (rule_tac S="{((x, y), (x', y')). y = y' \<and> x' = (a + (of_nat x * 8)) \<and> x < unat max_ipc_words}"
                         in zipWithM_x_corres)
-              apply (fastforce intro: store_word_offs_corres)
+              apply (fastforce intro: storeWordUser_corres)
              apply wp+
             apply (clarsimp simp add: S msgMaxLength_def msg_max_length_def set_zip)
             apply (simp add: wordSize_def wordBits_def word_size max_ipc_words
@@ -3429,7 +3429,7 @@ proof -
      done
 qed
 
-lemma copy_mrs_corres:
+lemma copyMRs_corres:
   "corres (=) (tcb_at s and tcb_at r
                and case_option \<top> in_user_frame sb
                and case_option \<top> in_user_frame rb
@@ -3459,7 +3459,7 @@ proof -
              (take (unat n) msgRegisters))"
     apply (rule corres_guard_imp)
     apply (rule_tac S=Id in corres_mapM, simp+)
-        apply (rule corres_split_eqr [OF user_setreg_corres user_getreg_corres])
+        apply (rule corres_split_eqr [OF asUser_setRegister_corres asUser_getRegister_corres])
         apply (wp | clarsimp simp: msg_registers_def msgRegisters_def)+
         done
 
@@ -3495,9 +3495,9 @@ proof -
            apply (rule corres_trivial, simp)
           apply (rule_tac S="{(x, y). y = of_nat x \<and> x < unat max_ipc_words}" in corres_mapM, simp+)
               apply (rule corres_split_eqr)
-               apply (rule store_word_offs_corres)
+               apply (rule storeWordUser_corres)
                apply simp
-               apply (rule load_word_offs_corres)
+               apply (rule loadWordUser_corres)
                apply simp
               apply (wp hoare_vcg_all_lift | simp)+
            apply (clarsimp simp: upto_enum_def)
@@ -3587,14 +3587,14 @@ qed
 
 lemmas valid_ipc_buffer_cap_simps = valid_ipc_buffer_cap_def [split_simps cap.split arch_cap.split]
 
-lemma lipcb_corres':
+lemma lookupIPCBuffer_corres':
   "corres (=) (tcb_at t and valid_objs and pspace_aligned)
                (tcb_at' t and valid_objs' and pspace_aligned'
                 and pspace_distinct' and no_0_obj')
                (lookup_ipc_buffer w t) (lookupIPCBuffer w t)"
   apply (simp add: lookup_ipc_buffer_def X64_H.lookupIPCBuffer_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr [OF _ threadget_corres])
+    apply (rule corres_split_eqr [OF _ threadGet_corres])
        apply (simp add: getThreadBufferSlot_def locateSlot_conv)
        apply (rule corres_split_deprecated [OF _ getSlotCap_corres])
           apply (rule_tac F="valid_ipc_buffer_cap rv buffer_ptr"
@@ -3634,11 +3634,11 @@ lemma lipcb_corres':
   apply clarsimp
   done
 
-lemma lipcb_corres:
+lemma lookupIPCBuffer_corres:
   "corres (=) (tcb_at t and invs)
                (tcb_at' t and invs')
                (lookup_ipc_buffer w t) (lookupIPCBuffer w t)"
-  using lipcb_corres'
+  using lookupIPCBuffer_corres'
   by (rule corres_guard_imp, auto simp: invs'_def valid_state'_def)
 
 
@@ -4530,7 +4530,7 @@ lemma asUser_irq_handlers':
   apply (wpsimp wp: threadSet_irq_handlers' [OF all_tcbI, OF ball_tcb_cte_casesI] select_f_inv)
   done
 
-(* the brave can try to move this up to near tcb_update_corres' *)
+(* the brave can try to move this up to near setObject_update_TCB_corres' *)
 
 definition non_exst_same :: "Structures_H.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
 where


### PR DESCRIPTION
This a revised version of Victor's original corres rename pull-request.

This does a mass renaming of corres lemmas across l4v. The renamings are done by session and only effect `Refine`, `Infoflow`, and `LibTest`. The renaming is done by looping through `renames.txt` and applying a suitable `sed` command. This is acheived by running the bash script in the appropriate directory.

There is a commit which adds the script and `renames.txt` and a commit that removes them. Unless we want to keep those scripts and list, the two commits should be squashed (to an empty commit) before merging.