### PR TITLE
Refill spec cleanup

### DIFF
--- a/proof/invariant-abstract/RealTime_AI.thy
+++ b/proof/invariant-abstract/RealTime_AI.thy
@@ -56,6 +56,10 @@ lemma update_sched_context_valid_objs_same:
   apply (auto simp: valid_obj_def valid_sched_context_def a_type_def obj_at_def)
   done
 
+lemmas sc_refills_update_valid_objs[wp]
+  = update_sched_context_valid_objs_same[where f="sc_refills_update f" for f,
+                                         simplified valid_sched_context_def, simplified]
+
 lemmas sc_consumed_update_valid_objs[wp]
   = update_sched_context_valid_objs_same[where f="sc_consumed_update f" for f,
                                          simplified valid_sched_context_def, simplified]

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -1641,7 +1641,7 @@ abbreviation active_sc_at :: "obj_ref \<Rightarrow> 'z::state_ext state \<Righta
 lemmas active_sc_at_def = obj_at_def
 
 lemma set_refills_active_sc_at[wp]:
-  "set_refills sc_ptr refills \<lbrace>active_sc_at sc_ptr\<rbrace>"
+  "set_refills sc_ptr refills \<lbrace>\<lambda>s. P (active_sc_at sc_ptr s)\<rbrace>"
   apply (clarsimp simp: set_refills_def)
   apply (wpsimp wp: update_sched_context_wp)
   apply (clarsimp simp: active_sc_at_def)
@@ -1649,9 +1649,9 @@ lemma set_refills_active_sc_at[wp]:
 
 lemma refill_unblock_check_active_sc_at[wp]:
   "refill_unblock_check sc_ptr \<lbrace>\<lambda>s. Q (active_sc_at sc_ptr s)\<rbrace>"
-  apply (clarsimp simp: refill_unblock_check_defs)
+  apply (clarsimp simp: refill_unblock_check_defs simp del: update_refill_hd_def)
   apply (wpsimp wp: set_refills_wp get_refills_wp whileLoop_wp'
-              simp: active_sc_at_def)
+              simp: update_refill_hd_rewrite update_sched_context_set_refills_rewrite active_sc_at_def)
   done
 
 lemma refill_update_invs:

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3473,7 +3473,7 @@ crunches schedContextCompleteYieldTo, unbindNotification, unbindMaybeNotificatio
 lemma schedContextZeroRefillMax_unlive[wp]:
   "schedContextZeroRefillMax scPtr \<lbrace>\<lambda>s. P (ko_wp_at' (Not \<circ> live') p s)\<rbrace>"
   unfolding schedContextZeroRefillMax_def
-  apply (wpsimp wp: set_sc'.set_wp)
+  apply (wpsimp wp: set_sc'.set_wp simp: updateSchedContext_def)
   apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKOs live_sc'_def
                         ps_clear_upd objBits_simps)
   done
@@ -4227,7 +4227,7 @@ lemma schedContextZeroRefillMax_invs'[wp]:
    schedContextZeroRefillMax scPtr
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (clarsimp simp: schedContextZeroRefillMax_def)
-  apply (wpsimp wp: setSchedContext_invs')
+  apply (wpsimp wp: setSchedContext_invs' simp: updateSchedContext_def)
   apply (frule (1) invs'_ko_at_valid_sched_context')
   apply (fastforce intro!: if_live_then_nonz_capE'
                      simp: ko_wp_at'_def obj_at'_def projectKOs live_sc'_def
@@ -4909,7 +4909,7 @@ lemma schedContextZeroRefillMax_corres:
   "corres dc (\<lambda>s. sc_at scPtr s) (sc_at' scPtr)
           (sched_context_zero_refill_max scPtr) (schedContextZeroRefillMax scPtr)"
   apply (clarsimp simp: sched_context_zero_refill_max_def schedContextZeroRefillMax_def
-                        set_refills_def sc_at_sc_obj_at)
+                        set_refills_def sc_at_sc_obj_at updateSchedContext_def)
   apply (rule corres_underlying_lift_ex1')
   apply (rule corres_guard_imp)
     apply (subst bind_dummy_ret_val, subst update_sched_context_decompose[symmetric])

--- a/proof/refine/ARM/InvariantUpdates_H.thy
+++ b/proof/refine/ARM/InvariantUpdates_H.thy
@@ -488,4 +488,8 @@ lemma sch_act_sane_ksReprogramTimer[simp]:
   "sch_act_sane (ksReprogramTimer_update f s) = sch_act_sane s"
   by (simp add: sch_act_sane_def)
 
+lemma valid_obj'_scPeriod_update[simp]:
+  "valid_obj' (KOSchedContext (scPeriod_update (\<lambda>_. period) sc')) = valid_obj' (KOSchedContext sc')"
+  by (fastforce simp: valid_obj'_def valid_sched_context'_def valid_sched_context_size'_def objBits_simps)
+
 end

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -2976,18 +2976,22 @@ lemma schedContextResume_corres:
      apply wp
     apply wp
    apply (subgoal_tac "sc_tcb_sc_at (\<lambda>t. bound_sc_tcb_at (\<lambda>sc. sc = Some ptr) (the t) s) ptr s ")
-    apply (clarsimp simp: sc_at_ppred_def obj_at_def is_sc_obj_def bound_sc_tcb_at_def is_tcb_def)
+    apply (clarsimp simp: sc_at_ppred_def obj_at_def is_sc_obj_def bound_sc_tcb_at_def is_tcb_def
+                    cong: conj_cong)
     apply (intro conjI impI; (clarsimp simp: invs_def valid_state_def; fail)?)
-          apply (fastforce simp: invs_def valid_state_def valid_pspace_def valid_obj_def)
-         apply (clarsimp simp: is_schedulable_bool_def get_tcb_def obj_at_kh_kheap_simps)
-         apply (fastforce dest!: active_sc_valid_refillsE
-                           simp: valid_refills_def vs_all_heap_simps rr_valid_refills_def
-                          split: if_splits)
-        apply (fastforce simp: is_schedulable_bool_def get_tcb_def is_sc_active_def
-                               vs_all_heap_simps)
+           apply (fastforce simp: invs_def valid_state_def valid_pspace_def valid_obj_def)
+          apply (clarsimp simp: is_schedulable_bool_def get_tcb_def obj_at_kh_kheap_simps)
+          apply (fastforce simp: valid_refills_def vs_all_heap_simps rr_valid_refills_def
+                                 opt_map_left_Some MIN_REFILLS_def
+                          dest!: active_sc_valid_refillsE split: if_split_asm)
+         apply (clarsimp simp: is_schedulable_bool_def get_tcb_def is_sc_active_kh_simp)
+         apply (fastforce simp: valid_refills_def vs_all_heap_simps rr_valid_refills_def
+                          dest: active_sc_valid_refillsE)
+        apply (clarsimp simp: is_schedulable_bool_def get_tcb_def is_sc_active_def active_sc_def
+                               vs_all_heap_simps opt_map_left_Some)
        apply (prop_tac "is_active_sc ptr s")
         apply (fastforce simp: vs_all_heap_simps is_schedulable_bool_def get_tcb_def
-                               is_sc_active_def)
+                               is_sc_active_def opt_map_left_Some)
        apply (fastforce simp: vs_all_heap_simps valid_ready_qs_2_def
                               valid_ready_queued_thread_2_def in_ready_q_def)+
      apply (clarsimp simp: is_schedulable_bool_def get_tcb_def)
@@ -2997,16 +3001,24 @@ lemma schedContextResume_corres:
    apply (drule sym_refs_ko_atD[rotated], simp add: obj_at_def)
    apply (clarsimp simp: pred_tcb_at_def obj_at_def refs_of_rev)
   apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
-  apply (intro conjI impI allI)
-    apply (fastforce simp: sc_at_ppred_def obj_at_def is_sc_obj_def valid_obj_def
-                     dest: invs_valid_objs intro!: sc_at_cross)
-   apply clarsimp
-  apply (clarsimp simp: state_relation_def obj_at_def sc_at_ppred_def)
-  apply (drule (1) pspace_relation_absD)
-  apply (clarsimp split: if_splits)
-  apply (clarsimp simp: sc_relation_def split: kernel_object.splits)
-  apply (simp only: sc_relation_def eq_commute[where a="Some P" for P])
-  apply (clarsimp simp: obj_at'_def projectKO_eq projectKO_sc)
+  apply (rule context_conjI; clarsimp?)
+   apply (fastforce simp: sc_tcb_sc_at_def obj_at_def is_sc_obj_def valid_obj_def
+                    dest: invs_valid_objs intro!: sc_at_cross)
+  apply (rule conjI, erule valid_objs'_valid_tcbs')
+  apply (clarsimp simp: sc_tcb_sc_at_def obj_at_def)
+  apply (frule (2) sym_ref_sc_tcb[OF invs_sym_refs], clarsimp)
+  apply (prop_tac "scTCB ko = Some y")
+   apply (frule state_relation_sc_relation[where ptr=ptr])
+     apply (clarsimp simp: obj_at_simps is_sc_obj)
+     apply (erule (1) valid_sched_context_size_objsI[OF invs_valid_objs], simp)
+   apply (clarsimp simp: sc_relation_def projection_rewrites obj_at_simps opt_map_left_Some)
+  apply (frule_tac x=y in pspace_relation_absD[OF _ state_relation_pspace_relation]; simp)
+  apply (clarsimp simp: obj_at'_def projectKOs isSchedulable_bool_def projection_rewrites
+                        other_obj_relation_def tcb_relation_def)
+  apply (drule sym[where s="Some ptr"])
+  apply (clarsimp simp: projection_rewrites isScActive_def opt_map_left_Some)
+  apply (erule (1) valid_objsE')
+  apply (clarsimp simp: valid_obj'_def valid_sched_context'_def sc_relation_def valid_refills'_def opt_map_def)
   done
 
 lemma getScTime_wp:
@@ -3024,12 +3036,12 @@ lemma refillUnblockCheck_corres:
 
 lemma updateRefillHd_valid_objs':
   "\<lbrace>valid_objs' and active_sc_at' scPtr\<rbrace> updateRefillHd scPtr f \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (clarsimp simp: updateRefillHd_def2 updateSchedContext_def)
-  apply (wpsimp wp: )
+  apply (clarsimp simp: updateRefillHd_def updateSchedContext_def)
+  apply wpsimp
   apply (frule (1) sc_ko_at_valid_objs_valid_sc')
   apply (clarsimp simp: valid_sched_context'_def active_sc_at'_def obj_at'_real_def ko_wp_at'_def
                         valid_sched_context_size'_def objBits_def objBitsKO_def projectKO_sc
-                        length_replaceAt)
+                        length_updateAt)
   done
 
 lemma getCTE_cap_to_refs[wp]:
@@ -3276,7 +3288,7 @@ lemma updateRefillHd_bound_tcb_sc_at[wp]:
   "updateRefillHd scPtr f \<lbrace>obj_at' (\<lambda>a. \<exists>y. scTCB a = Some y) t\<rbrace>"
   supply if_split [split del]
   unfolding updateRefillHd_def
-  apply (wpsimp wp: set_sc'.obj_at')
+  apply (wpsimp wp: set_sc'.obj_at' simp: updateSchedContext_def)
   by (clarsimp simp: obj_at'_real_def ko_wp_at'_def split: if_split)
 
 crunches refillUnblockCheck

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -3040,8 +3040,7 @@ lemma updateRefillHd_valid_objs':
   apply wpsimp
   apply (frule (1) sc_ko_at_valid_objs_valid_sc')
   apply (clarsimp simp: valid_sched_context'_def active_sc_at'_def obj_at'_real_def ko_wp_at'_def
-                        valid_sched_context_size'_def objBits_def objBitsKO_def projectKO_sc
-                        length_updateAt)
+                        valid_sched_context_size'_def objBits_def objBitsKO_def projectKO_sc)
   done
 
 lemma getCTE_cap_to_refs[wp]:

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -1638,7 +1638,7 @@ lemma setSchedContext_corres:
 qed
 
 lemma setSchedContext_update_corres:
-  assumes R': "sc_relation sc n sc' \<longrightarrow> sc_relation (f sc) n (f' sc')"
+  assumes R': "sc_relation sc n sc' \<longrightarrow> sc_relation (f sc) n (f' (sc'::sched_context))"
   assumes s: "objBits sc' = objBits (f' sc')"
   shows "corres dc
          (\<lambda>s. kheap s ptr = Some (kernel_object.SchedContext sc n))
@@ -4169,6 +4169,7 @@ lemma get_sched_context_no_fail:
                      gets_def obj_at_def is_sc_obj_def gets_the_def
               split: Structures_A.kernel_object.splits)
 
+(* FIXME RT: rename *)
 (* this let us cross the sc size information from concrete to abstract *)
 lemma ko_at'_cross:
   assumes p: "pspace_relation (kheap s) (ksPSpace s')"

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -2192,6 +2192,11 @@ lemma obj_at'_ignoring_obj:
   "obj_at' (\<lambda>_ :: 'a :: pspace_storable. P) p s = (obj_at' (\<lambda>_ :: 'a. True) p s \<and> P)"
   by (rule iffI; clarsimp simp: obj_at'_def)
 
+lemma forall_ko_at'_equiv_projection:
+  "(\<lambda>s. \<forall>ko::'a::pspace_storable. ko_at' ko p s \<longrightarrow> P ko s) =
+   (\<lambda>s. obj_at' (\<lambda>_::'a::pspace_storable. True) p s \<longrightarrow> P (the ((ksPSpace s |> projectKO_opt) p)) s)"
+  by (fastforce simp: obj_at'_def projectKOs opt_map_left_Some)
+
 end
 
 locale pspace_only' =
@@ -2405,7 +2410,15 @@ lemma getObject_wp:
   apply fastforce
   done
 
+lemma getObject_wp':
+  "\<lbrace>\<lambda>s. obj_at' (\<lambda>_::'a. True) p s \<longrightarrow> P (the ((ksPSpace s |> projectKO_opt) p)) s\<rbrace>
+   getObject p
+   \<lbrace>P::'a \<Rightarrow> _ \<Rightarrow> _\<rbrace>"
+  apply (wpsimp wp: getObject_wp)
+  by (metis forall_ko_at'_equiv_projection)
+
 lemmas get_wp = getObject_wp[folded g_def]
+lemmas get_wp' = getObject_wp'[folded g_def]
 
 lemma loadObject_default_inv:
   "\<lbrace>P\<rbrace> gets_the $ loadObject_default addr addr' next obj \<lbrace>\<lambda>rv. P\<rbrace>"
@@ -2750,6 +2763,12 @@ lemmas getNotification_wp = set_ntfn'.get_wp
 lemmas getTCB_wp = set_tcb'.get_wp
 lemmas getReply_wp[wp] = set_reply'.get_wp
 lemmas getSchedContext_wp[wp] = set_sc'.get_wp
+
+lemmas getEndpoint_wp' = set_ep'.get_wp'
+lemmas getNotification_wp' = set_ntfn'.get_wp'
+lemmas getTCB_wp' = set_tcb'.get_wp'
+lemmas getReply_wp' = set_reply'.get_wp'
+lemmas getSchedContext_wp' = set_sc'.get_wp'
 
 lemmas getObject_ep_inv = set_ep'.getObject_inv
 lemmas getObject_ntfn_inv = set_ntfn'.getObject_inv

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -3956,6 +3956,78 @@ lemma sc_replies_relation_rewrite:
   unfolding sc_replies_relation_def sc_replies_relation2_def sc_replies_of_rewrite
   by simp
 
+definition is_active_sc2 where
+  "is_active_sc2 p s \<equiv> ((\<lambda>sc. 0 < sc_refill_max sc) |< scs_of2 s) p"
+
+lemma is_active_sc_rewrite:
+  "is_active_sc p s = is_active_sc2 p s"
+  by (fastforce simp: is_active_sc2_def vs_all_heap_simps is_active_sc_def
+                      active_sc_def opt_map_left_Some opt_map_def
+               split: option.split_asm Structures_A.kernel_object.splits)
+
+definition is_active_sc' where
+  "is_active_sc' p s' \<equiv> ((\<lambda>sc'. 0 < scRefillMax sc') |< scs_of' s') p"
+
+lemma active_sc_at'_imp_is_active_sc':
+  "active_sc_at' scp s \<Longrightarrow> is_active_sc' scp s"
+  by (clarsimp simp: active_sc_at'_def is_active_sc'_def obj_at'_def opt_map_def projectKOs)
+
+lemma active_sc_at'_rewrite:
+  "active_sc_at' scp s = (is_active_sc' scp s \<and> sc_at' scp s)"
+  by (fastforce simp: active_sc_at'_def is_active_sc'_def obj_at'_def opt_map_def projectKOs)
+
+abbreviation
+  "valid_refills2 scp s \<equiv>
+     ((\<lambda>sc. if sc_period sc = 0 then rr_valid_refills (sc_refills sc) (sc_refill_max sc) (sc_budget sc)
+      else sp_valid_refills (sc_refills sc) (sc_refill_max sc) (sc_period sc) (sc_budget sc)) |<
+     scs_of2 s) scp"
+
+lemmas valid_refills2_def = rr_valid_refills_def sp_valid_refills_def
+
+lemma valid_refills_rewrite:
+  "valid_refills scp s = valid_refills2 scp s"
+  by (fastforce simp: opt_map_left_Some valid_refills2_def vs_all_heap_simps valid_refills_def
+               split: option.splits Structures_A.kernel_object.splits)
+
+definition
+  round_robin2 :: "obj_ref \<Rightarrow> 'z state \<Rightarrow> bool"
+where
+  "round_robin2 sc_ptr s \<equiv> ((\<lambda>sc. sc_period sc = 0) |< scs_of2 s) sc_ptr"
+
+lemma round_robin_rewrite:
+  "round_robin scp s = round_robin2 scp s"
+  by (clarsimp simp: round_robin_def round_robin2_def vs_all_heap_simps opt_map_def
+              split: option.splits Structures_A.kernel_object.splits)
+
+abbreviation
+  sc_refills_sc_at2 where
+  "sc_refills_sc_at2 P scp s \<equiv> ((\<lambda>sc. P (sc_refills sc)) |< scs_of2 s) scp"
+
+lemma sc_refills_sc_at_rewrite:
+  "sc_refills_sc_at P scp s = sc_refills_sc_at2 P scp s"
+  by (fastforce simp: sc_refills_sc_at_def obj_at_def is_sc_obj opt_map_left_Some
+               split: option.splits Structures_A.kernel_object.split_asm)
+
+lemmas projection_rewrites = pred_map_rewrite scs_of_rewrite is_active_sc_rewrite
+                             sc_heap_of_state_def sc_of_def sc_refills_sc_at_rewrite
+                             active_sc_at'_rewrite valid_refills_rewrite round_robin_rewrite
+
+lemma is_active_sc'_cross:
+  assumes p: "pspace_relation (kheap s) (ksPSpace s')"
+  assumes t: "is_active_sc2 ptr s"
+  shows "is_active_sc' ptr s'"
+  using assms
+  supply projection_rewrites[simp]
+  apply (clarsimp simp: projectKOs is_active_sc2_def is_active_sc'_def
+                 split: option.split_asm Structures_A.kernel_object.split_asm)
+  apply (drule (1) pspace_relation_absD, clarsimp split: if_split_asm)
+  by (case_tac z; simp add: sc_relation_def opt_map_left_Some)
+
+lemma set_refills_is_active_sc2[wp]:
+  "set_refills ptr new \<lbrace>is_active_sc2 ptr'\<rbrace>"
+  apply (wpsimp simp: is_active_sc2_def wp: set_refills_wp)
+  by (clarsimp simp: obj_at_def opt_map_def)
+
 (* end : projection rewrites *)
 
 (* updateSchedContext *)

--- a/proof/refine/ARM/SchedContextInv_R.thy
+++ b/proof/refine/ARM/SchedContextInv_R.thy
@@ -380,27 +380,6 @@ lemma isRoundRobin_corres:
                       simp: sc_relation_def)
   done
 
-(* updateAt *)
-
-lemma updateAt_index:
-  "\<lbrakk>xs \<noteq> []; i < length xs; j < length xs\<rbrakk>
-   \<Longrightarrow> (updateAt i xs f) ! j = (if i = j then f (xs ! i) else (xs ! j))"
-  by (fastforce simp: updateAt_def null_def nth_append)
-
-lemma wrap_slice_updateAt_eq:
-  "\<lbrakk>if start + count \<le> mx
-       then (i < start \<or> start + count \<le> i)
-       else (start + count - mx \<le> i \<and> i < start);
-    count \<le> mx; start < mx; mx \<le> length xs; xs \<noteq> []; i < mx\<rbrakk>
-   \<Longrightarrow> wrap_slice start count mx xs = wrap_slice start count mx (updateAt i xs new)"
-  apply (rule nth_equalityI)
-   apply clarsimp
-  by (subst wrap_slice_index; clarsimp simp: updateAt_index split: if_split_asm)+
-
-lemma take_updateAt_eq[simp]:
-  "n \<le> i \<Longrightarrow> take n (updateAt i ls f) = take n ls"
-  by (clarsimp simp: updateAt_def)
-
 lemma valid_obj'_scPeriod_update[simp]:
   "valid_obj' (KOSchedContext (scPeriod_update (\<lambda>_. period) sc')) = valid_obj' (KOSchedContext sc')"
   by (fastforce simp: valid_obj'_def valid_sched_context'_def valid_sched_context_size'_def objBits_simps)
@@ -474,24 +453,24 @@ lemma refillAddTail_corres:
       apply (erule disjE)
        apply (simp add: refillNextIndex_def refillTailIndex_def Let_def)
        apply (intro conjI impI;
-              clarsimp simp: Suc_diff_Suc wrap_slice_replaceAt_eq[symmetric] neq_Nil_lengthI
-                             nat_le_Suc_less refill_map_def replaceAt_index)
+              clarsimp simp: Suc_diff_Suc wrap_slice_updateAt_eq[symmetric] neq_Nil_lengthI
+                             nat_le_Suc_less refill_map_def updateAt_index)
       apply (erule disjE)
        apply clarsimp
        apply (rule conjI)
         apply (simp add: refillNextIndex_def refillTailIndex_def Let_def)
-        apply (clarsimp simp: wrap_slice_replaceAt_eq not_le)
-        apply (metis add_leE le_SucI le_refl lessI mult_is_add.mult_commute not_add_less2 not_less_eq wrap_slice_replaceAt_eq)
+        apply (clarsimp simp: wrap_slice_updateAt_eq not_le)
+        apply (metis add_leE le_SucI le_refl lessI mult_is_add.mult_commute not_add_less2 not_less_eq wrap_slice_updateAt_eq)
        apply (clarsimp simp: refillNextIndex_def refillTailIndex_def Let_def not_le)
-       apply (clarsimp simp: replaceAt_index refill_map_def)
+       apply (clarsimp simp: updateAt_index refill_map_def)
       apply clarsimp
       apply (rule conjI)
        apply (clarsimp simp: refillNextIndex_def refillTailIndex_def Let_def)
-       apply (intro conjI impI; (clarsimp simp: not_le wrap_slice_replaceAt_eq)?)
+       apply (intro conjI impI; (clarsimp simp: not_le wrap_slice_updateAt_eq)?)
        apply (metis add_leE le_refl le_simps(1) less_SucI mult_is_add.mult_commute nat_neq_iff
-                    not_less_eq trans_less_add2 wrap_slice_replaceAt_eq)
+                    not_less_eq trans_less_add2 wrap_slice_updateAt_eq)
       apply (clarsimp simp: refillNextIndex_def refillTailIndex_def Let_def not_le)
-      apply (clarsimp simp: replaceAt_index refill_map_def)
+      apply (clarsimp simp: updateAt_index refill_map_def)
      apply (fastforce simp: obj_at_simps is_sc_obj opt_map_left_Some
                      dest!: state_relation_sc_replies_relation_sc)
     apply (clarsimp simp: objBits_simps)
@@ -961,7 +940,7 @@ lemma refillUpdate_corres:
                    apply (rule setSchedContext_corres)
                     apply (unfold sc_relation_def; elim conjE exE; intro conjI; fastforce?)
                     apply (clarsimp simp: refills_map_def wrap_slice_start_0 hd_map neq_Nil_lengthI
-                                          refill_map_def replaceAt_def null_def refillHd_def hd_wrap_slice
+                                          refill_map_def updateAt_def null_def refillHd_def hd_wrap_slice
                                           valid_refills_number'_def max_num_refills_eq_refillAbsoluteMax')
                    apply (clarsimp simp: objBits_simps scBits_simps)
                   apply simp

--- a/proof/refine/ARM/SchedContextInv_R.thy
+++ b/proof/refine/ARM/SchedContextInv_R.thy
@@ -384,28 +384,10 @@ lemma valid_obj'_scPeriod_update[simp]:
   "valid_obj' (KOSchedContext (scPeriod_update (\<lambda>_. period) sc')) = valid_obj' (KOSchedContext sc')"
   by (fastforce simp: valid_obj'_def valid_sched_context'_def valid_sched_context_size'_def objBits_simps)
 
-(* projection *)
-
 (* it would be good to rewrite all getting wp rules in this form *)
 lemma getSchedContext_wp':
   "\<lbrace>\<lambda>s. sc_at' p s  \<longrightarrow> P (the (scs_of' s p)) s\<rbrace> getSchedContext p \<lbrace>P\<rbrace>"
   by (wpsimp simp: obj_at'_def projectKOs opt_map_left_Some)
-
-lemma is_active_sc'_cross:
-  assumes p: "pspace_relation (kheap s) (ksPSpace s')"
-  assumes t: "is_active_sc2 ptr s"
-  shows "is_active_sc' ptr s'"
-  using assms
-  supply projection_rewrites[simp]
-  apply (clarsimp simp: projectKOs is_active_sc2_def is_active_sc'_def
-                 split: option.split_asm Structures_A.kernel_object.split_asm)
-  apply (drule (1) pspace_relation_absD, clarsimp split: if_split_asm)
-  by (case_tac z; simp add: sc_relation_def opt_map_left_Some)
-
-lemma set_refills_is_active_sc2[wp]:
-  "set_refills ptr new \<lbrace>is_active_sc2 ptr'\<rbrace>"
-  apply (wpsimp simp: is_active_sc2_def wp: set_refills_wp)
-  by (clarsimp simp: obj_at_def opt_map_def)
 
 lemma ovalid_readRefillReady'[rule_format, simp]:
   "ovalid (\<lambda>s. sc_at' scp s \<longrightarrow> P (((\<lambda>sc'. rTime (refillHd sc') \<le> ksCurTime s + kernelWCETTicks) |< scs_of' s) scp) s)
@@ -417,12 +399,11 @@ lemma ovalid_readRefillReady'[rule_format, simp]:
                split: option.split_asm)+
 
 lemma refillReady_wp':
-  "\<lbrace>\<lambda>s. sc_at' scp s \<longrightarrow> P (((\<lambda>sc'. rTime (refillHd sc') \<le> ksCurTime s + kernelWCETTicks) |< scs_of' s) scp) s\<rbrace>
+  "\<lbrace>\<lambda>s. sc_at' scp s \<longrightarrow>
+        P (((\<lambda>sc'. rTime (refillHd sc') \<le> ksCurTime s + kernelWCETTicks) |< scs_of' s) scp) s\<rbrace>
     refillReady scp \<lbrace>P\<rbrace>"
   unfolding refillReady_def
   by wpsimp (drule use_ovalid[OF ovalid_readRefillReady'])
-
-(* end : projection *)
 
 lemma refillAddTail_corres:
   "time = time' \<and> amount = amount'

--- a/proof/refine/ARM/SchedContextInv_R.thy
+++ b/proof/refine/ARM/SchedContextInv_R.thy
@@ -384,11 +384,6 @@ lemma valid_obj'_scPeriod_update[simp]:
   "valid_obj' (KOSchedContext (scPeriod_update (\<lambda>_. period) sc')) = valid_obj' (KOSchedContext sc')"
   by (fastforce simp: valid_obj'_def valid_sched_context'_def valid_sched_context_size'_def objBits_simps)
 
-(* it would be good to rewrite all getting wp rules in this form *)
-lemma getSchedContext_wp':
-  "\<lbrace>\<lambda>s. sc_at' p s  \<longrightarrow> P (the (scs_of' s p)) s\<rbrace> getSchedContext p \<lbrace>P\<rbrace>"
-  by (wpsimp simp: obj_at'_def projectKOs opt_map_left_Some)
-
 lemma ovalid_readRefillReady'[rule_format, simp]:
   "ovalid (\<lambda>s. sc_at' scp s \<longrightarrow> P (((\<lambda>sc'. rTime (refillHd sc') \<le> ksCurTime s + kernelWCETTicks) |< scs_of' s) scp) s)
               (readRefillReady scp) P"

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -2219,11 +2219,6 @@ lemma refillTailIndex_bounded:
   apply (clarsimp simp: valid_sched_context'_def refillTailIndex_def Let_def split: if_split)
   by linarith
 
-lemma length_updateAt[simp]:
-  "length (updateAt i lst f) = length lst"
-  apply (clarsimp simp: updateAt_def)
-  by (case_tac lst; simp)
-
 lemma refillAddTail_valid_objs'[wp]:
   "refillAddTail scPtr t \<lbrace>valid_objs'\<rbrace>"
   apply (simp add: refillAddTail_def)

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -10,64 +10,6 @@ begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-(* more projection rewrite *)
-
-definition is_active_sc2 where
-  "is_active_sc2 p s \<equiv> ((\<lambda>sc. 0 < sc_refill_max sc) |< scs_of2 s) p"
-
-lemma is_active_sc_rewrite:
-  "is_active_sc p s = is_active_sc2 p s"
-  by (fastforce simp: is_active_sc2_def vs_all_heap_simps is_active_sc_def
-                      active_sc_def opt_map_left_Some opt_map_def
-               split: option.split_asm Structures_A.kernel_object.splits)
-
-definition is_active_sc' where
-  "is_active_sc' p s' \<equiv> ((\<lambda>sc'. 0 < scRefillMax sc') |< scs_of' s') p"
-
-lemma active_sc_at'_imp_is_active_sc':
-  "active_sc_at' scp s \<Longrightarrow> is_active_sc' scp s"
-  by (clarsimp simp: active_sc_at'_def is_active_sc'_def obj_at'_def opt_map_def projectKOs)
-
-lemma active_sc_at'_rewrite:
-  "active_sc_at' scp s = (is_active_sc' scp s \<and> sc_at' scp s)"
-  by (fastforce simp: active_sc_at'_def is_active_sc'_def obj_at'_def opt_map_def projectKOs)
-
-abbreviation
-  "valid_refills2 scp s \<equiv>
-     ((\<lambda>sc. if sc_period sc = 0 then rr_valid_refills (sc_refills sc) (sc_refill_max sc) (sc_budget sc)
-      else sp_valid_refills (sc_refills sc) (sc_refill_max sc) (sc_period sc) (sc_budget sc)) |<
-     scs_of2 s) scp"
-
-lemmas valid_refills2_def = rr_valid_refills_def sp_valid_refills_def
-
-lemma valid_refills_rewrite:
-  "valid_refills scp s = valid_refills2 scp s"
-  by (fastforce simp: opt_map_left_Some valid_refills2_def vs_all_heap_simps valid_refills_def
-               split: option.splits Structures_A.kernel_object.splits)
-
-definition
-  round_robin2 :: "obj_ref \<Rightarrow> 'z state \<Rightarrow> bool"
-where
-  "round_robin2 sc_ptr s \<equiv> ((\<lambda>sc. sc_period sc = 0) |< scs_of2 s) sc_ptr"
-
-lemma round_robin_rewrite:
-  "round_robin scp s = round_robin2 scp s"
-  by (clarsimp simp: round_robin_def round_robin2_def vs_all_heap_simps opt_map_def
-              split: option.splits Structures_A.kernel_object.splits)
-
-abbreviation
-  sc_refills_sc_at2 where
-  "sc_refills_sc_at2 P scp s \<equiv> ((\<lambda>sc. P (sc_refills sc)) |< scs_of2 s) scp"
-
-lemma sc_refills_sc_at_rewrite:
-  "sc_refills_sc_at P scp s = sc_refills_sc_at2 P scp s"
-  by (fastforce simp: sc_refills_sc_at_def obj_at_def is_sc_obj opt_map_left_Some
-               split: option.splits Structures_A.kernel_object.split_asm)
-
-lemmas projection_rewrites = pred_map_rewrite scs_of_rewrite is_active_sc_rewrite
-                             sc_heap_of_state_def sc_of_def sc_refills_sc_at_rewrite
-                             active_sc_at'_rewrite valid_refills_rewrite round_robin_rewrite
-
 (* using the abstract side size *)
 lemma state_relation_sc_relation:
   "\<lbrakk>(s, s') \<in> state_relation; sc_at ptr s; sc_at' ptr s'\<rbrakk> \<Longrightarrow>

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -1335,8 +1335,7 @@ lemma wrap_slice_replaceAt_eq:
   done
 
 lemma refills_tl_equal:
-  "\<lbrakk>sc_relation sc n sc'; 0 < scRefillCount sc'; scRefillCount sc' \<le> scRefillMax sc';
-    scRefillMax sc' \<le> length (scRefills sc'); scRefillHead sc' < scRefillMax sc'\<rbrakk>
+  "\<lbrakk>sc_relation sc n sc'; sc_valid_refills' sc'\<rbrakk>
    \<Longrightarrow> refill_tl sc = refill_map (refillTl sc')"
   apply (clarsimp simp: sc_relation_def refillTl_def refills_map_def)
   apply (subst last_conv_nth)

--- a/spec/abstract/Ipc_A.thy
+++ b/spec/abstract/Ipc_A.thy
@@ -659,10 +659,10 @@ definition
   refill_reset_rr :: "obj_ref \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
   "refill_reset_rr csc_ptr = do
-     refills \<leftarrow> get_refills csc_ptr;
-     set_refill_hd csc_ptr \<lparr>r_time = r_time (hd refills),
-                            r_amount = r_amount (hd refills) + r_amount (hd (tl refills))\<rparr>;
-     set_refill_tl csc_ptr \<lparr>r_time = r_time (hd (tl refills)), r_amount = 0\<rparr>
+     update_sched_context csc_ptr
+         (sc_refills_update (\<lambda>refills. (r_amount_update
+                                           (\<lambda>m. m + r_amount (hd (tl refills)))) (hd refills) # (tl refills)));
+     update_refill_tl csc_ptr (r_amount_update (\<lambda>_. 0))
    od"
 
 definition

--- a/spec/abstract/SchedContext_A.thy
+++ b/spec/abstract/SchedContext_A.thy
@@ -323,10 +323,8 @@ definition
   refill_update :: "obj_ref \<Rightarrow> ticks \<Rightarrow> ticks \<Rightarrow> nat \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
   "refill_update sc_ptr new_period new_budget new_max_refills = do
-     sc \<leftarrow> get_sched_context sc_ptr;
-     refill_hd \<leftarrow> return (hd (sc_refills sc));
+     update_sched_context sc_ptr (sc_refills_update (\<lambda>rfs. [hd rfs]));
      set_sc_obj_ref sc_refill_max_update sc_ptr new_max_refills;
-     set_refills sc_ptr [refill_hd];
      set_sc_obj_ref sc_period_update sc_ptr new_period;
      set_sc_obj_ref sc_budget_update sc_ptr new_budget;
 

--- a/spec/abstract/SchedContext_A.thy
+++ b/spec/abstract/SchedContext_A.thy
@@ -275,13 +275,13 @@ where
      usage' \<leftarrow> return (usage - r_amount (refill_hd sc));
 
      if single
-
         then update_refill_hd sc_ptr (r_time_update (\<lambda>t. t + sc_period sc))
         else do old_head \<leftarrow> refill_pop_head sc_ptr;
                 full \<leftarrow> refill_full sc_ptr;
-                update_sched_context sc_ptr (sc_refills_update
-                                                  (\<lambda>refills. schedule_used full refills
-                                                   (old_head\<lparr>r_time := r_time old_head + sc_period sc\<rparr>)))
+                update_sched_context sc_ptr
+                    (sc_refills_update
+                         (\<lambda>refills. schedule_used full refills
+                                                 (old_head\<lparr>r_time := r_time old_head + sc_period sc\<rparr>)))
              od;
      return usage'
    od"

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -209,7 +209,6 @@ This module uses the C preprocessor to select a target architecture.
 > refillAddTail scPtr refill = do
 >     sc <- getSchedContext scPtr
 >     assert (scRefillCount sc < scRefillMax sc) "cannot add beyond queue size"
->     newTail <- return $ refillNextIndex (refillTailIndex sc) sc
 >     updateSchedContext scPtr (\sc -> sc { scRefills = replaceAt (refillNextIndex (refillTailIndex sc) sc) (scRefills sc) refill, scRefillCount = scRefillCount sc + 1})
 
 > maybeAddEmptyTail :: PPtr SchedContext -> Kernel ()

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -26,13 +26,13 @@ This module uses the C preprocessor to select a target architecture.
 >         archThreadSet, archThreadGet,
 >         decodeSchedContextInvocation, decodeSchedControlInvocation,
 >         checkBudget, chargeBudget, checkBudgetRestart, mcsIRQ, commitTime, awaken, switchSchedContext,
->         replaceAt, tcbEPAppend, tcbEPDequeue, setTimeArg, isBlocked, isStopped
+>         replaceAt, updateAt, tcbEPAppend, tcbEPDequeue, setTimeArg, isBlocked, isStopped
 >     ) where
 
 \begin{impdetails}
 
 % {-# BOOT-IMPORTS: SEL4.API.Types SEL4.API.Failures SEL4.Machine SEL4.Model SEL4.Object.Structures SEL4.API.Invocation #-}
-% {-# BOOT-EXPORTS: threadGet threadSet asUser setMRs setMessageInfo getThreadCSpaceRoot getThreadVSpaceRoot decodeTCBInvocation invokeTCB getThreadBufferSlot decodeDomainInvocation archThreadSet archThreadGet sanitiseRegister decodeSchedContextInvocation decodeSchedControlInvocation checkBudget chargeBudget replaceAt tcbEPAppend tcbEPDequeue setTimeArg #-}
+% {-# BOOT-EXPORTS: threadGet threadSet asUser setMRs setMessageInfo getThreadCSpaceRoot getThreadVSpaceRoot decodeTCBInvocation invokeTCB getThreadBufferSlot decodeDomainInvocation archThreadSet archThreadGet sanitiseRegister decodeSchedContextInvocation decodeSchedControlInvocation checkBudget chargeBudget replaceAt updateAt tcbEPAppend tcbEPDequeue setTimeArg #-}
 
 > import Prelude hiding (Word)
 > import SEL4.Config
@@ -1002,6 +1002,15 @@ On some architectures, the thread context may include registers that may be modi
 >     in if (null lst || length lst <= i)
 >           then lst
 >           else x ++ [v] ++ y
+
+> updateAt :: Int -> [a] -> (a -> a) -> [a]
+> updateAt i lst f =
+>     let x = take i lst;
+>         u = lst !! i;
+>         y = drop (i + 1) lst
+>     in if (null lst || length lst <= i)
+>           then lst
+>           else x ++ [f u] ++ y
 
 > chargeBudget :: Ticks -> Bool -> Bool -> Kernel ()
 > chargeBudget consumed canTimeoutFault isCurCPU = do

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -26,13 +26,13 @@ This module uses the C preprocessor to select a target architecture.
 >         archThreadSet, archThreadGet,
 >         decodeSchedContextInvocation, decodeSchedControlInvocation,
 >         checkBudget, chargeBudget, checkBudgetRestart, mcsIRQ, commitTime, awaken, switchSchedContext,
->         replaceAt, updateAt, tcbEPAppend, tcbEPDequeue, setTimeArg, isBlocked, isStopped
+>         updateAt, tcbEPAppend, tcbEPDequeue, setTimeArg, isBlocked, isStopped
 >     ) where
 
 \begin{impdetails}
 
 % {-# BOOT-IMPORTS: SEL4.API.Types SEL4.API.Failures SEL4.Machine SEL4.Model SEL4.Object.Structures SEL4.API.Invocation #-}
-% {-# BOOT-EXPORTS: threadGet threadSet asUser setMRs setMessageInfo getThreadCSpaceRoot getThreadVSpaceRoot decodeTCBInvocation invokeTCB getThreadBufferSlot decodeDomainInvocation archThreadSet archThreadGet sanitiseRegister decodeSchedContextInvocation decodeSchedControlInvocation checkBudget chargeBudget replaceAt updateAt tcbEPAppend tcbEPDequeue setTimeArg #-}
+% {-# BOOT-EXPORTS: threadGet threadSet asUser setMRs setMessageInfo getThreadCSpaceRoot getThreadVSpaceRoot decodeTCBInvocation invokeTCB getThreadBufferSlot decodeDomainInvocation archThreadSet archThreadGet sanitiseRegister decodeSchedContextInvocation decodeSchedControlInvocation checkBudget chargeBudget updateAt tcbEPAppend tcbEPDequeue setTimeArg #-}
 
 > import Prelude hiding (Word)
 > import SEL4.Config
@@ -995,21 +995,13 @@ On some architectures, the thread context may include registers that may be modi
 > getSanitiseRegisterInfo :: PPtr TCB -> Kernel Bool
 > getSanitiseRegisterInfo t = Arch.getSanitiseRegisterInfo t
 
-> replaceAt :: Int -> [a] -> a -> [a]
-> replaceAt i lst v =
->     let x = take i lst;
->         y = drop (i + 1) lst
->     in if (null lst || length lst <= i)
->           then lst
->           else x ++ [v] ++ y
-
 > updateAt :: Int -> [a] -> (a -> a) -> [a]
-> updateAt i lst f =
->     let x = take i lst;
->         u = lst !! i;
->         y = drop (i + 1) lst
->     in if (null lst || length lst <= i)
->           then lst
+> updateAt i ls f =
+>     let x = take i ls;
+>         u = ls !! i;
+>         y = drop (i + 1) ls
+>     in if (null ls || length ls <= i)
+>           then ls
 >           else x ++ [f u] ++ y
 
 > chargeBudget :: Ticks -> Bool -> Bool -> Kernel ()


### PR DESCRIPTION
This PR contains several lines of cleanups and improvements that I hope will help with the upcoming refill related proofs. The brief descriptions of the changes are as follows:

- more systematic use of updateSchedContext and its derivatives, mainly in refill related functions
- abstract spec cleanup to go along with the above, with some rewrite rules to take advantage of existing proofs
- more streamlined approach for indexing haskell scRefills (`updateAt`)
- rewrite rules for simplifying projections in the abstract side statements
- projection style wp rules for `getSchedContext`, `updateSchedContext` and others
- rewrite rules for `updateSchedContext`, etc., for managing some complex corres proofs
- rewrite some refill related corres in a more modular style

There are some smaller lemmas that can be moved to KHeap_R or StateRelation.
I think the “projection” rewrites block can stay in Schedule_R where it currently sits, for the time being, unless we are going to them in the earlier theories.


