### PR TITLE
refine: The state relation is not empty.

### DIFF
--- a/proof/refine/ARM/ADT_H.thy
+++ b/proof/refine/ARM/ADT_H.thy
@@ -10,6 +10,7 @@ theory ADT_H
 imports
   "AInvs.ADT_AI"
   Syscall_R
+  Init_R
 begin
 
 text \<open>

--- a/proof/refine/ARM/Init_R.thy
+++ b/proof/refine/ARM/Init_R.thy
@@ -1,0 +1,131 @@
+(*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory Init_R
+imports
+  KHeap_R
+
+begin
+
+context begin interpretation Arch . (*FIXME: arch_split*)
+
+(*
+  This provides a very simple witness that the state relation used in the first refinement proof is
+  non-trivial, by exhibiting a pair of related states. This helps guard against silly mistakes in
+  the state relation, since we currently assume that the system starts in a state satisfying
+  invariants and state relations.
+
+  Note that the states we exhibit are not intended to be useful states. They are just the simplest
+  possible states that prove non-triviality of the state relation. In particular, these states do
+  not satisfy the respective invariant conditions. In future, this could be improved by exhibiting
+  a tuple of more realistic states that are related across all levels of the refinement, and that
+  also satisfy respective invariant. Ultimately, we would like to prove functional correctness of
+  kernel initialisation. That would allow us to start from a minimal but real configuration that
+  would allow us to make a much smaller set of assumptions about the initial configuration of the
+  system.
+*)
+
+definition zeroed_arch_abstract_state ::
+  arch_state
+  where
+  "zeroed_arch_abstract_state \<equiv> \<lparr>
+    arm_asid_table = Map.empty,
+    arm_hwasid_table = Map.empty,
+    arm_next_asid = 0,
+    arm_asid_map = Map.empty,
+    arm_global_pd = 0,
+    arm_global_pts = [],
+    arm_kernel_vspace = K ArmVSpaceUserRegion
+  \<rparr>"
+
+definition zeroed_main_abstract_state ::
+  abstract_state
+  where
+  "zeroed_main_abstract_state \<equiv> \<lparr>
+    kheap = Map.empty,
+    cdt = Map.empty,
+    is_original_cap = (K True),
+    cur_thread = 0,
+    idle_thread = 0,
+    machine_state = init_machine_state,
+    interrupt_irq_node = (\<lambda>irq. ucast irq << cte_level_bits),
+    interrupt_states = (K irq_state.IRQInactive),
+    arch_state = zeroed_arch_abstract_state
+  \<rparr>"
+
+definition zeroed_extended_state ::
+  det_ext
+  where
+  "zeroed_extended_state \<equiv> \<lparr>
+    work_units_completed_internal = 0,
+    scheduler_action_internal = resume_cur_thread,
+    ekheap_internal = K None,
+    domain_list_internal = [],
+    domain_index_internal = 0,
+    cur_domain_internal = 0,
+    domain_time_internal = 0,
+    ready_queues_internal = (\<lambda>_ _. []),
+    cdt_list_internal = K []
+  \<rparr>"
+
+definition zeroed_abstract_state ::
+  det_state
+  where
+  "zeroed_abstract_state \<equiv> abstract_state.extend zeroed_main_abstract_state
+                           (state.fields zeroed_extended_state)"
+
+definition zeroed_arch_intermediate_state ::
+  Arch.kernel_state
+  where
+  "zeroed_arch_intermediate_state \<equiv> ARMKernelState Map.empty Map.empty 0 Map.empty 0 [] (K ArmVSpaceUserRegion)"
+
+definition zeroed_intermediate_state ::
+  global.kernel_state
+  where
+  "zeroed_intermediate_state \<equiv> \<lparr>
+    ksPSpace = Map.empty,
+    gsUserPages = Map.empty,
+    gsCNodes = Map.empty,
+    gsUntypedZeroRanges = {},
+    gsMaxObjectSize = 0,
+    ksDomScheduleIdx = 0,
+    ksDomSchedule = [],
+    ksCurDomain = 0,
+    ksDomainTime = 0,
+    ksReadyQueues = K [],
+    ksReadyQueuesL1Bitmap = K 0,
+    ksReadyQueuesL2Bitmap = K 0,
+    ksCurThread = 0,
+    ksIdleThread = 0,
+    ksSchedulerAction = ResumeCurrentThread,
+    ksInterruptState = (InterruptState 0 (K IRQInactive)),
+    ksWorkUnitsCompleted = 0,
+    ksArchState = zeroed_arch_intermediate_state,
+    ksMachineState = init_machine_state
+  \<rparr>"
+
+lemmas zeroed_state_defs = zeroed_main_abstract_state_def zeroed_abstract_state_def
+                           zeroed_arch_abstract_state_def zeroed_extended_state_def
+                           zeroed_intermediate_state_def abstract_state.defs
+                           zeroed_arch_intermediate_state_def
+
+lemma non_empty_refine_state_relation:
+  "(zeroed_abstract_state, zeroed_intermediate_state) \<in> state_relation"
+  apply (clarsimp simp: state_relation_def zeroed_state_defs state.defs)
+  apply (intro conjI)
+           apply (clarsimp simp: pspace_relation_def pspace_dom_def)
+          apply (clarsimp simp: ekheap_relation_def)
+         apply (clarsimp simp: ready_queues_relation_def)
+       apply (clarsimp simp: ghost_relation_def)
+      apply (fastforce simp: cdt_relation_def swp_def dest: cte_wp_at_domI)
+     apply (clarsimp simp: cdt_list_relation_def map_to_ctes_def)
+    apply (clarsimp simp: revokable_relation_def map_to_ctes_def)
+   apply (clarsimp simp: zeroed_state_defs arch_state_relation_def)
+  apply (clarsimp simp: interrupt_state_relation_def irq_state_relation_def cte_level_bits_def)
+  done
+
+end
+end

--- a/proof/refine/ARM_HYP/ADT_H.thy
+++ b/proof/refine/ARM_HYP/ADT_H.thy
@@ -10,6 +10,7 @@ theory ADT_H
 imports
   "AInvs.ADT_AI"
   Syscall_R
+  Init_R
 begin
 
 text \<open>

--- a/proof/refine/ARM_HYP/Init_R.thy
+++ b/proof/refine/ARM_HYP/Init_R.thy
@@ -1,0 +1,132 @@
+(*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory Init_R
+imports
+  KHeap_R
+
+begin
+
+context begin interpretation Arch . (*FIXME: arch_split*)
+
+(*
+  This provides a very simple witness that the state relation used in the first refinement proof is
+  non-trivial, by exhibiting a pair of related states. This helps guard against silly mistakes in
+  the state relation, since we currently assume that the system starts in a state satisfying
+  invariants and state relations.
+
+  Note that the states we exhibit are not intended to be useful states. They are just the simplest
+  possible states that prove non-triviality of the state relation. In particular, these states do
+  not satisfy the respective invariant conditions. In future, this could be improved by exhibiting
+  a tuple of more realistic states that are related across all levels of the refinement, and that
+  also satisfy respective invariant. Ultimately, we would like to prove functional correctness of
+  kernel initialisation. That would allow us to start from a minimal but real configuration that
+  would allow us to make a much smaller set of assumptions about the initial configuration of the
+  system.
+*)
+
+definition zeroed_arch_abstract_state ::
+  arch_state
+  where
+  "zeroed_arch_abstract_state \<equiv> \<lparr>
+    arm_asid_table = Map.empty,
+    arm_hwasid_table = Map.empty,
+    arm_next_asid = 0,
+    arm_asid_map = Map.empty,
+    arm_current_vcpu = None,
+    arm_gicvcpu_numlistregs = 0,
+    arm_kernel_vspace = K ArmVSpaceUserRegion,
+    arm_us_global_pd =0
+   \<rparr>"
+
+definition zeroed_main_abstract_state ::
+  abstract_state
+  where
+  "zeroed_main_abstract_state \<equiv> \<lparr>
+    kheap = Map.empty,
+    cdt = Map.empty,
+    is_original_cap = (K True),
+    cur_thread = 0,
+    idle_thread = 0,
+    machine_state = init_machine_state,
+    interrupt_irq_node = (\<lambda>irq. ucast irq << cte_level_bits),
+    interrupt_states = (K irq_state.IRQInactive),
+    arch_state = zeroed_arch_abstract_state
+  \<rparr>"
+
+definition zeroed_extended_state ::
+  det_ext
+  where
+  "zeroed_extended_state \<equiv> \<lparr>
+    work_units_completed_internal = 0,
+    scheduler_action_internal = resume_cur_thread,
+    ekheap_internal = K None,
+    domain_list_internal = [],
+    domain_index_internal = 0,
+    cur_domain_internal = 0,
+    domain_time_internal = 0,
+    ready_queues_internal = (\<lambda>_ _. []),
+    cdt_list_internal = K []
+  \<rparr>"
+
+definition zeroed_abstract_state ::
+  det_state
+  where
+  "zeroed_abstract_state \<equiv> abstract_state.extend zeroed_main_abstract_state
+                           (state.fields zeroed_extended_state)"
+
+definition zeroed_arch_intermediate_state ::
+  Arch.kernel_state
+  where
+  "zeroed_arch_intermediate_state \<equiv> ARMKernelState Map.empty Map.empty 0 Map.empty None 0 0 (K ArmVSpaceUserRegion)"
+
+definition zeroed_intermediate_state ::
+  global.kernel_state
+  where
+  "zeroed_intermediate_state \<equiv> \<lparr>
+    ksPSpace = Map.empty,
+    gsUserPages = Map.empty,
+    gsCNodes = Map.empty,
+    gsUntypedZeroRanges = {},
+    gsMaxObjectSize = 0,
+    ksDomScheduleIdx = 0,
+    ksDomSchedule = [],
+    ksCurDomain = 0,
+    ksDomainTime = 0,
+    ksReadyQueues = K [],
+    ksReadyQueuesL1Bitmap = K 0,
+    ksReadyQueuesL2Bitmap = K 0,
+    ksCurThread = 0,
+    ksIdleThread = 0,
+    ksSchedulerAction = ResumeCurrentThread,
+    ksInterruptState = (InterruptState 0 (K IRQInactive)),
+    ksWorkUnitsCompleted = 0,
+    ksArchState = zeroed_arch_intermediate_state,
+    ksMachineState = init_machine_state
+  \<rparr>"
+
+lemmas zeroed_state_defs = zeroed_main_abstract_state_def zeroed_abstract_state_def
+                           zeroed_arch_abstract_state_def zeroed_extended_state_def
+                           zeroed_intermediate_state_def abstract_state.defs
+                           zeroed_arch_intermediate_state_def
+
+lemma non_empty_refine_state_relation:
+  "(zeroed_abstract_state, zeroed_intermediate_state) \<in> state_relation"
+  apply (clarsimp simp: state_relation_def zeroed_state_defs state.defs)
+  apply (intro conjI)
+           apply (clarsimp simp: pspace_relation_def pspace_dom_def)
+          apply (clarsimp simp: ekheap_relation_def)
+         apply (clarsimp simp: ready_queues_relation_def)
+       apply (clarsimp simp: ghost_relation_def)
+      apply (fastforce simp: cdt_relation_def swp_def dest: cte_wp_at_domI)
+     apply (clarsimp simp: cdt_list_relation_def map_to_ctes_def)
+    apply (clarsimp simp: revokable_relation_def map_to_ctes_def)
+   apply (clarsimp simp: zeroed_state_defs arch_state_relation_def)
+  apply (clarsimp simp: interrupt_state_relation_def irq_state_relation_def cte_level_bits_def)
+  done
+
+end
+end

--- a/proof/refine/RISCV64/ADT_H.thy
+++ b/proof/refine/RISCV64/ADT_H.thy
@@ -7,7 +7,9 @@
 chapter \<open>Abstract datatype for the executable specification\<close>
 
 theory ADT_H
-  imports Syscall_R
+  imports
+    Syscall_R
+    Init_R
 begin
 
 text \<open>

--- a/proof/refine/RISCV64/Init_R.thy
+++ b/proof/refine/RISCV64/Init_R.thy
@@ -1,0 +1,127 @@
+(*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory Init_R
+imports
+  KHeap_R
+
+begin
+
+context begin interpretation Arch . (*FIXME: arch_split*)
+
+(*
+  This provides a very simple witness that the state relation used in the first refinement proof is
+  non-trivial, by exhibiting a pair of related states. This helps guard against silly mistakes in
+  the state relation, since we currently assume that the system starts in a state satisfying
+  invariants and state relations.
+
+  Note that the states we exhibit are not intended to be useful states. They are just the simplest
+  possible states that prove non-triviality of the state relation. In particular, these states do
+  not satisfy the respective invariant conditions. In future, this could be improved by exhibiting
+  a tuple of more realistic states that are related across all levels of the refinement, and that
+  also satisfy respective invariant. Ultimately, we would like to prove functional correctness of
+  kernel initialisation. That would allow us to start from a minimal but real configuration that
+  would allow us to make a much smaller set of assumptions about the initial configuration of the
+  system.
+*)
+
+definition zeroed_arch_abstract_state ::
+  arch_state
+  where
+  "zeroed_arch_abstract_state \<equiv> \<lparr>
+    riscv_asid_table    = Map.empty,
+    riscv_global_pts    = K {},
+    riscv_kernel_vspace = K RISCVVSpaceUserRegion
+  \<rparr>"
+
+definition zeroed_main_abstract_state ::
+  abstract_state
+  where
+  "zeroed_main_abstract_state \<equiv> \<lparr>
+    kheap = Map.empty,
+    cdt = Map.empty,
+    is_original_cap = \<top>,
+    cur_thread = 0,
+    idle_thread = 0,
+    machine_state = init_machine_state,
+    interrupt_irq_node = (\<lambda>irq. ucast irq << cte_level_bits),
+    interrupt_states = (K irq_state.IRQInactive),
+    arch_state = zeroed_arch_abstract_state
+  \<rparr>"
+
+definition zeroed_extended_state ::
+  det_ext
+  where
+  "zeroed_extended_state \<equiv> \<lparr>
+    work_units_completed_internal = 0,
+    scheduler_action_internal = resume_cur_thread,
+    ekheap_internal = Map.empty,
+    domain_list_internal = [],
+    domain_index_internal = 0,
+    cur_domain_internal = 0,
+    domain_time_internal = 0,
+    ready_queues_internal = (\<lambda>_ _. []),
+    cdt_list_internal = K []
+  \<rparr>"
+
+definition zeroed_abstract_state ::
+  det_state
+  where
+  "zeroed_abstract_state \<equiv> abstract_state.extend zeroed_main_abstract_state
+                           (state.fields zeroed_extended_state)"
+
+definition zeroed_arch_intermediate_state ::
+  Arch.kernel_state
+  where
+  "zeroed_arch_intermediate_state \<equiv> RISCVKernelState Map.empty (K []) (K RISCVVSpaceUserRegion)"
+
+definition zeroed_intermediate_state ::
+  global.kernel_state
+  where
+  "zeroed_intermediate_state \<equiv> \<lparr>
+    ksPSpace = Map.empty,
+    gsUserPages = Map.empty,
+    gsCNodes = Map.empty,
+    gsUntypedZeroRanges = {},
+    gsMaxObjectSize = 0,
+    ksDomScheduleIdx = 0,
+    ksDomSchedule = [],
+    ksCurDomain = 0,
+    ksDomainTime = 0,
+    ksReadyQueues = K [],
+    ksReadyQueuesL1Bitmap = K 0,
+    ksReadyQueuesL2Bitmap = K 0,
+    ksCurThread = 0,
+    ksIdleThread = 0,
+    ksSchedulerAction = ResumeCurrentThread,
+    ksInterruptState = (InterruptState 0 (K IRQInactive)),
+    ksWorkUnitsCompleted = 0,
+    ksArchState = zeroed_arch_intermediate_state,
+    ksMachineState = init_machine_state
+  \<rparr>"
+
+lemmas zeroed_state_defs = zeroed_main_abstract_state_def zeroed_abstract_state_def
+                           zeroed_arch_abstract_state_def zeroed_extended_state_def
+                           zeroed_intermediate_state_def abstract_state.defs
+                           zeroed_arch_intermediate_state_def
+
+lemma non_empty_refine_state_relation:
+  "(zeroed_abstract_state, zeroed_intermediate_state) \<in> state_relation"
+  apply (clarsimp simp: state_relation_def zeroed_state_defs state.defs)
+  apply (intro conjI)
+           apply (clarsimp simp: pspace_relation_def pspace_dom_def)
+          apply (clarsimp simp: ekheap_relation_def)
+         apply (clarsimp simp: ready_queues_relation_def)
+       apply (clarsimp simp: ghost_relation_def)
+      apply (fastforce simp: cdt_relation_def swp_def dest: cte_wp_at_domI)
+     apply (clarsimp simp: cdt_list_relation_def map_to_ctes_def)
+    apply (clarsimp simp: revokable_relation_def map_to_ctes_def)
+   apply (clarsimp simp: zeroed_state_defs arch_state_relation_def)
+  apply (clarsimp simp: interrupt_state_relation_def irq_state_relation_def cte_level_bits_def)
+  done
+
+end
+end

--- a/proof/refine/X64/ADT_H.thy
+++ b/proof/refine/X64/ADT_H.thy
@@ -9,6 +9,7 @@ chapter \<open>Abstract datatype for the executable specification\<close>
 theory ADT_H
 imports
   "AInvs.ADT_AI"
+  Init_R
   Syscall_R
 begin
 

--- a/proof/refine/X64/Init_R.thy
+++ b/proof/refine/X64/Init_R.thy
@@ -1,0 +1,134 @@
+(*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory Init_R
+imports
+  KHeap_R
+
+begin
+
+context begin interpretation Arch . (*FIXME: arch_split*)
+
+(*
+  This provides a very simple witness that the state relation used in the first refinement proof is
+  non-trivial, by exhibiting a pair of related states. This helps guard against silly mistakes in
+  the state relation, since we currently assume that the system starts in a state satisfying
+  invariants and state relations.
+
+  Note that the states we exhibit are not intended to be useful states. They are just the simplest
+  possible states that prove non-triviality of the state relation. In particular, these states do
+  not satisfy the respective invariant conditions. In future, this could be improved by exhibiting
+  a tuple of more realistic states that are related across all levels of the refinement, and that
+  also satisfy respective invariant. Ultimately, we would like to prove functional correctness of
+  kernel initialisation. That would allow us to start from a minimal but real configuration that
+  would allow us to make a much smaller set of assumptions about the initial configuration of the
+  system.
+*)
+
+definition zeroed_arch_abstract_state ::
+  arch_state
+  where
+  "zeroed_arch_abstract_state \<equiv> \<lparr>
+    x64_asid_table         = Map.empty,
+    x64_global_pml4        = 0,
+    x64_kernel_vspace      = K X64VSpaceUserRegion,
+    x64_global_pts         = [],
+    x64_global_pdpts       = [],
+    x64_global_pds         = [],
+    x64_current_cr3        = cr3 0 0 ,
+    x64_allocated_io_ports = \<bottom>,
+    x64_num_ioapics        = 0,
+    x64_irq_state          = K IRQFree\<rparr>"
+
+definition zeroed_main_abstract_state ::
+  abstract_state
+  where
+  "zeroed_main_abstract_state \<equiv> \<lparr>
+    kheap = Map.empty,
+    cdt = Map.empty,
+    is_original_cap = \<top>,
+    cur_thread = 0,
+    idle_thread = 0,
+    machine_state = init_machine_state,
+    interrupt_irq_node = (\<lambda>irq. ucast irq << cte_level_bits),
+    interrupt_states = (K irq_state.IRQInactive),
+    arch_state = zeroed_arch_abstract_state
+  \<rparr>"
+
+definition zeroed_extended_state ::
+  det_ext
+  where
+  "zeroed_extended_state \<equiv> \<lparr>
+    work_units_completed_internal = 0,
+    scheduler_action_internal = resume_cur_thread,
+    ekheap_internal = Map.empty,
+    domain_list_internal = [],
+    domain_index_internal = 0,
+    cur_domain_internal = 0,
+    domain_time_internal = 0,
+    ready_queues_internal = (\<lambda>_ _. []),
+    cdt_list_internal = K []
+  \<rparr>"
+
+definition zeroed_abstract_state ::
+  det_state
+  where
+  "zeroed_abstract_state \<equiv> abstract_state.extend zeroed_main_abstract_state
+                           (state.fields zeroed_extended_state)"
+
+definition zeroed_arch_intermediate_state ::
+  Arch.kernel_state
+  where
+  "zeroed_arch_intermediate_state \<equiv> X64KernelState Map.empty 0 [] [] [] (CR3 0 0)
+     (K X64VSpaceUserRegion) \<bottom> 0 (K X64IRQFree)"
+
+definition zeroed_intermediate_state ::
+  global.kernel_state
+  where
+  "zeroed_intermediate_state \<equiv> \<lparr>
+    ksPSpace = Map.empty,
+    gsUserPages = Map.empty,
+    gsCNodes = Map.empty,
+    gsUntypedZeroRanges = {},
+    gsMaxObjectSize = 0,
+    ksDomScheduleIdx = 0,
+    ksDomSchedule = [],
+    ksCurDomain = 0,
+    ksDomainTime = 0,
+    ksReadyQueues = K [],
+    ksReadyQueuesL1Bitmap = K 0,
+    ksReadyQueuesL2Bitmap = K 0,
+    ksCurThread = 0,
+    ksIdleThread = 0,
+    ksSchedulerAction = ResumeCurrentThread,
+    ksInterruptState = (InterruptState 0 (K IRQInactive)),
+    ksWorkUnitsCompleted = 0,
+    ksArchState = zeroed_arch_intermediate_state,
+    ksMachineState = init_machine_state
+  \<rparr>"
+
+lemmas zeroed_state_defs = zeroed_main_abstract_state_def zeroed_abstract_state_def
+                           zeroed_arch_abstract_state_def zeroed_extended_state_def
+                           zeroed_intermediate_state_def abstract_state.defs
+                           zeroed_arch_intermediate_state_def
+
+lemma non_empty_refine_state_relation:
+  "(zeroed_abstract_state, zeroed_intermediate_state) \<in> state_relation"
+  apply (clarsimp simp: state_relation_def zeroed_state_defs state.defs)
+  apply (intro conjI)
+           apply (clarsimp simp: pspace_relation_def pspace_dom_def)
+          apply (clarsimp simp: ekheap_relation_def)
+         apply (clarsimp simp: ready_queues_relation_def)
+       apply (clarsimp simp: ghost_relation_def)
+      apply (fastforce simp: cdt_relation_def swp_def dest: cte_wp_at_domI)
+     apply (clarsimp simp: cdt_list_relation_def map_to_ctes_def)
+    apply (clarsimp simp: revokable_relation_def map_to_ctes_def)
+   apply (fastforce simp: zeroed_state_defs arch_state_relation_def cr3_relation_def x64_irq_relation_def)
+  apply (clarsimp simp: interrupt_state_relation_def irq_state_relation_def cte_level_bits_def)
+  done
+
+end
+end


### PR DESCRIPTION
Defined a series of `zeroed` states on the abstract and haskell sides
that together satisfy the state relation. These states do not satisfy
invs or invs'.

This is connected to https://sel4.atlassian.net/browse/VER-1342