### PR TITLE
updateSchedContext_corres, opt_pred, some cleanup, etc.

### DIFF
--- a/lib/Monad_WP/OptionMonad.thy
+++ b/lib/Monad_WP/OptionMonad.thy
@@ -62,6 +62,7 @@ lemma opt_map_upd_Some:
 
 lemmas opt_map_upd[simp] = opt_map_upd_None opt_map_upd_Some
 
+
 lemma case_opt_map_distrib:
   "((\<lambda>s. case_option None g (f s)) |> h)
    = ((\<lambda>s. case_option None (g |> h) (f s)))"
@@ -72,6 +73,22 @@ declare None_upd_eq[simp]
 (* None_upd_eq[simp] so that this pattern is by simp. Hopefully not too much slowdown. *)
 lemma "\<lbrakk> (f |> g) x = None; g v = None \<rbrakk> \<Longrightarrow> f(x \<mapsto> v) |> g = f |> g"
   by simp
+
+(* opt_pred *)
+
+abbreviation
+  opt_pred :: "('a \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> 'a option) \<Rightarrow> ('b \<Rightarrow> bool)" (infixl "|<" 50) where
+  "P |< proj \<equiv> (\<lambda>x. case_option False P (proj x))"
+
+lemma opt_pred_conj:
+  "((P1 |< hp) p \<and> (P2 |< hp) p) = (((P1 and P2) |< hp) p)"
+  by (fastforce simp: pred_conj_def split: option.splits)
+
+lemma opt_pred_disj:
+  "((P1 |< hp) p \<or> (P2 |< hp) p) = (((P1 or P2) |< hp) p)"
+  by (fastforce simp: pred_disj_def split: option.splits)
+
+(* obind, etc. *)
 
 definition
   obind :: "('s,'a) lookup \<Rightarrow> ('a \<Rightarrow> ('s,'b) lookup) \<Rightarrow> ('s,'b) lookup" (infixl "|>>" 53)

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -3958,14 +3958,6 @@ lemma sc_replies_relation_rewrite:
 
 (* end : projection rewrites *)
 
-lemma sc_replies_relation_prevs_list':
-  "\<lbrakk> sc_replies_relation s s';
-     kheap s scp = Some (kernel_object.SchedContext sc n)\<rbrakk>
-    \<Longrightarrow> heap_ls (replyPrevs_of s') (scReplies_of s' scp) (sc_replies sc)"
-  apply (clarsimp simp: sc_replies_relation_def sc_replies_of_scs_def scs_of_kh_def map_project_def)
-  apply (clarsimp simp: opt_map_left_Some sc_of_def)
-  done
-
 (* updateSchedContext *)
 
 context begin interpretation Arch . (*FIXME: arch_split*)
@@ -4046,7 +4038,7 @@ lemma state_relation_sc_update:
      apply (erule obj_relation_cutsE)
             apply ((simp split: if_split_asm)+)[8]
     (* sc_replies_relation *)
-    apply (frule (1) sc_replies_relation_prevs_list'[simplified])
+    apply (frule (2) sc_replies_relation_prevs_list[simplified])
     apply (subst replyPrevs_of_non_reply_update[simplified]; (simp add: typ_at'_def ko_wp_at'_def)?)
     apply (simp add: sc_replies_relation_def)
     apply (rule conjI)
@@ -4148,8 +4140,6 @@ lemma updateSchedContext_corres_gen:
   done
 
 lemmas updateSchedContext_corres = updateSchedContext_corres_gen[where P=\<top> and P'=\<top>, simplified]
-
-declare opt_map_left_Some[simp]
 
 (* end : updateSchedContext *)
 
@@ -4579,8 +4569,8 @@ lemma refillSingle_corres:
   apply (rule stronger_corres_guard_imp)
     apply (rule_tac R'="\<lambda>sc s. valid_refills' sc" and R="\<lambda>_ _ . True" in corres_split)
        apply (rule get_sc_corres)
-      apply (clarsimp simp: sc_relation_def)
-      apply (rule refillSingle_equiv; simp)
+      apply simp
+      apply (metis (mono_tags, hide_lams) refillSingle_equiv sc_relation_def)
      apply wpsimp+
   apply (clarsimp simp: obj_at'_def)
   done

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -1160,19 +1160,32 @@ lemma valid_objs'_replyNexts_of_reply_at':
 
 (** sc_with_reply and sc_replies_relations : crossing information **)
 
+(* modified version of sc_replies_relation_prevs_list in StateRelation.thy;
+   updates only the abstract sc_relies; useful for the following few lemmas *)
+lemma sc_replies_relation_prevs_list':
+  "\<lbrakk> sc_replies_relation s s';
+     kheap s scp = Some (kernel_object.SchedContext sc n)\<rbrakk>
+    \<Longrightarrow> heap_ls (replyPrevs_of s') (scReplies_of s' scp) (sc_replies sc)"
+  apply (clarsimp simp: sc_replies_relation_def sc_replies_of_scs_def scs_of_kh_def map_project_def)
+  apply (clarsimp simp: sc_of_def opt_map_left_Some)
+  done
+
 lemma sc_replies_relation_sc_with_reply_cross_eq_pred:
   "\<lbrakk> sc_replies_relation s s'; pspace_relation (kheap s) (ksPSpace s')\<rbrakk> \<Longrightarrow>
    (\<exists>sc n. kheap s scp = Some (kernel_object.SchedContext sc n) \<and> rp \<in> set (sc_replies sc))
     = (\<exists>xs. heap_ls (replyPrevs_of s') (scReplies_of s' scp) xs \<and> rp \<in> set xs)"
   apply (rule iffI; clarsimp)
-   apply (fastforce dest: sc_replies_relation_prevs_list' heap_path_takeWhile_lookup_next)
+   apply (rule_tac x="the (sc_replies_of2 s scp)" in exI)
+  apply (clarsimp simp: sc_replies_relation_def sc_replies_of_scs_def scs_of_kh_def map_project_def)
+  apply (drule_tac x=scp and y="sc_replies sc" in spec2)
+  apply (clarsimp simp: sc_of_def opt_map_def projectKO_opt_sc split: option.splits)
   apply (case_tac "scReplies_of s' scp", simp)
   apply (rename_tac p)
   apply (drule pspace_relation_sc_at[where scp=scp])
    apply (clarsimp simp: projectKOs opt_map_left_Some)
-  apply (clarsimp simp: obj_at_def is_sc_obj)
-  apply (drule (1) sc_replies_relation_prevs_list', clarsimp simp: opt_map_left_Some)
-  apply (drule (1) heap_ls_unique, clarsimp)
+  apply (clarsimp simp: obj_at_simps is_sc_obj opt_map_left_Some)
+  apply (drule (1) sc_replies_relation_prevs_list', simp add: opt_map_left_Some)
+  apply (drule (1) heap_ls_unique, simp)
   done
 
 (* crossing equality for sc_with_reply *)

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -1160,14 +1160,6 @@ lemma valid_objs'_replyNexts_of_reply_at':
 
 (** sc_with_reply and sc_replies_relations : crossing information **)
 
-lemma sc_replies_relation_prevs_list':
-  "\<lbrakk> sc_replies_relation s s';
-     kheap s scp = Some (kernel_object.SchedContext sc n)\<rbrakk>
-    \<Longrightarrow> heap_ls (replyPrevs_of s') (scReplies_of s' scp) (sc_replies sc)"
-  apply (clarsimp simp: sc_replies_relation_def sc_replies_of_scs_def scs_of_kh_def map_project_def)
-  apply (clarsimp simp: opt_map_left_Some sc_of_def)
-  done
-
 lemma sc_replies_relation_sc_with_reply_cross_eq_pred:
   "\<lbrakk> sc_replies_relation s s'; pspace_relation (kheap s) (ksPSpace s')\<rbrakk> \<Longrightarrow>
    (\<exists>sc n. kheap s scp = Some (kernel_object.SchedContext sc n) \<and> rp \<in> set (sc_replies sc))

--- a/proof/refine/ARM/SchedContextInv_R.thy
+++ b/proof/refine/ARM/SchedContextInv_R.thy
@@ -531,9 +531,8 @@ lemma refillAddTail_corres:
           apply linarith
          apply (fastforce simp: replaceAt_index)
         apply (fastforce simp: replaceAt_index)
-       apply (fastforce simp: refillTailIndex_def Let_def length_replaceAt)
-      apply force
-     apply (fastforce simp: objBits_simps length_replaceAt)
+       apply (fastforce simp: refillTailIndex_def Let_def)
+     apply (fastforce simp: objBits_simps)
     apply fastforce
    apply (clarsimp simp: obj_at_def)
   apply (clarsimp simp: obj_at'_def projectKOs)
@@ -640,42 +639,26 @@ lemma updateRefillHd_corres:
        apply (clarsimp simp: sc_relation_def)
        apply (case_tac "sc_refills sc = []")
         apply clarsimp
-       apply (intro conjI impI)
         apply (prop_tac "scRefills sc' \<noteq> []")
          apply clarsimp
         apply (rule nth_equalityI)
-         apply (fastforce simp: refills_map_def length_replaceAt)
+         apply (fastforce simp: refills_map_def)
 
         apply (case_tac "i=0")
          apply (clarsimp simp: refills_map_def)
          apply (subst hd_map, fastforce)
          apply (subst hd_wrap_slice; simp)
-         apply (subst nth_map)
-          apply (subst length_wrap_slice; simp?)
-          apply (metis length_replaceAt)
          apply (rule_tac f=refill_map in arg_cong)
          apply (subst wrap_slice_index; simp?)
-          apply (metis length_replaceAt)
          apply (fastforce simp: refillHd_def replaceAt_index)
-
         apply (clarsimp simp: refills_map_def nth_tl)
-        apply (subst nth_map)
-         apply (subst length_wrap_slice; simp?)
-         apply (metis length_replaceAt)
-
         apply (rule_tac f=refill_map in arg_cong)
         apply (rule_tac P="\<lambda>t. _ = t" in ssubst)
          apply (erule (1) wrap_slice_index)
-          apply (metis length_replaceAt)
-         apply simp
+         apply simp+
         apply (fastforce simp: replaceAt_index wrap_slice_index)
-
-       apply (metis length_replaceAt)
       apply fastforce
-     apply (clarsimp simp: objBits_simps length_replaceAt)
-    apply simp
-   apply (clarsimp simp: obj_at_def)
-  apply simp
+     apply (clarsimp simp: objBits_simps obj_at_def)+
   done
 
 lemma updateRefillTl_corres:
@@ -728,7 +711,6 @@ lemma updateRefillTl_corres:
        apply (clarsimp simp: sc_relation_def)
        apply (case_tac "sc_refills sc = []")
         apply clarsimp
-       apply (intro conjI impI)
         apply (prop_tac "scRefills sc' \<noteq> []", clarsimp)
 
         apply (rule nth_equalityI)
@@ -753,11 +735,7 @@ lemma updateRefillTl_corres:
           apply (metis One_nat_def nth_append_length)
 
          apply (clarsimp simp: refills_map_def)
-         apply (subst nth_map)
-          apply (subst length_wrap_slice; simp?)
-          apply (metis length_replaceAt)
          apply (subst wrap_slice_index; simp?)
-          apply (metis length_replaceAt)
          apply (clarsimp simp: refillTailIndex_def refillTl_def replaceAt_index)
          apply (subst last_conv_nth, fastforce)+
          apply simp
@@ -778,19 +756,13 @@ lemma updateRefillTl_corres:
           apply (fastforce simp: refills_map_def)
          apply (simp add: nth_append nth_butlast)
         apply (clarsimp simp: refills_map_def)
-        apply (subst nth_map)
-         apply (subst length_wrap_slice; simp?)
-         apply (metis length_replaceAt)
         apply (rule_tac f=refill_map in arg_cong)
         apply (subst wrap_slice_index; simp)
         apply (intro conjI impI)
          apply (subst wrap_slice_index; simp?)
-          apply (metis length_replaceAt)
          apply (fastforce simp: refillTailIndex_def Let_def replaceAt_index split: if_splits)
         apply (subst wrap_slice_index; simp?)
-         apply (metis length_replaceAt)
         apply (fastforce simp: refillTailIndex_def Let_def replaceAt_index split: if_splits)
-       apply (metis length_replaceAt)
       apply fastforce
      apply (clarsimp simp: objBits_simps length_replaceAt)
     apply simp
@@ -1127,11 +1099,9 @@ lemma refillNew_corres:
                    in setSchedContext_no_stack_update_corres)
          apply clarsimp
          apply (clarsimp simp: sc_relation_def)
-         apply (intro conjI impI)
-          apply (clarsimp simp: refills_map_def wrap_slice_def replaceAt_def refill_map_def null_def)
-         apply (fastforce simp: length_replaceAt)
+         apply (clarsimp simp: refills_map_def wrap_slice_def replaceAt_def refill_map_def null_def)
         apply fastforce
-       apply (clarsimp simp: objBits_simps scBits_simps length_replaceAt)
+       apply (clarsimp simp: objBits_simps scBits_simps)
       apply fastforce
      apply wpsimp
      apply (wpsimp wp: set_object_wp)
@@ -1139,32 +1109,29 @@ lemma refillNew_corres:
      apply (wpsimp wp: set_sc'.set_wp)
     apply (wpsimp wp: set_sc_valid_objs')
    apply (clarsimp simp: vs_all_heap_simps)
-  apply (fastforce dest!: valid_objs_ko_at
-                    simp: obj_at_def sc_at_pred_n_def active_sc_def valid_obj_def is_sc_obj_def
-                          valid_sched_context_def)
+   apply (fastforce dest!: valid_objs_ko_at
+                     simp: obj_at_def sc_at_pred_n_def active_sc_def valid_obj_def is_sc_obj_def
+                           valid_sched_context_def)
   apply clarsimp
   apply (intro conjI impI allI)
     apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKOs objBitsKO_def scBits_simps)
     apply (intro conjI impI allI)
-       apply (metis length_replaceAt)
       apply (metis length_replaceAt list.size(3) list_exhaust_size_eq0)
      apply (clarsimp simp: valid_refills_number'_def obj_at'_def projectKOs objBits_simps'
-                           ko_wp_at'_def length_replaceAt)
+                           ko_wp_at'_def)
      apply (rule le_trans, simp)
      apply (fastforce simp: scBits_inverse_sc)
     apply (clarsimp simp: ko_wp_at'_def valid_refills_number'_def obj_at'_def projectKOs
                           objBits_simps)
-    apply (fastforce simp: scBits_inverse_sc length_replaceAt)
+    apply (fastforce simp: scBits_inverse_sc)
    apply (frule (1) sc_ko_at_valid_objs_valid_sc')
    apply (clarsimp simp: valid_sched_context'_def)
-   apply (intro conjI impI)
-    apply (fastforce simp: length_replaceAt)
    apply (clarsimp simp: valid_refills_number'_def obj_at'_def projectKOs objBits_simps'
-                         ko_wp_at'_def length_replaceAt)
+                         ko_wp_at'_def)
    apply (rule le_trans, simp)
    apply (fastforce simp: scBits_inverse_sc)
   apply (fastforce dest: sc_ko_at_valid_objs_valid_sc'
-                   simp: valid_sched_context_size'_def objBits_simps scBits_simps length_replaceAt)
+                   simp: valid_sched_context_size'_def objBits_simps scBits_simps)
   done
 
 lemma refill_update_bundled:
@@ -1313,9 +1280,8 @@ lemma refillUpdate_corres:
                              obj_at_def is_sc_obj_def)
     apply ((wpsimp wp: hoare_vcg_ex_lift hoare_vcg_conj_lift | wpsimp wp: set_sc'.set_wp)+)[1]
     apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-    apply (fastforce simp: valid_sched_context'_def length_replaceAt valid_refills_number'_def
-                           obj_at'_def projectKOs objBits_simps' ko_wp_at'_def scBits_inverse_sc
-                           valid_sched_context_size'_def)
+    apply (fastforce simp: valid_sched_context'_def valid_refills_number'_def obj_at'_def ko_wp_at'_def
+                           valid_sched_context_size'_def projectKOs objBits_simps' scBits_inverse_sc)
 
    apply (rule corres_assume_pre)
    apply (rule corres_guard_imp)
@@ -1328,7 +1294,7 @@ lemma refillUpdate_corres:
         apply (clarsimp simp: sc_relation_def)
         apply (prop_tac "max_refills \<le> length (replaceAt 0 (scRefills sc') (refillHd sc'))")
          apply (clarsimp simp: valid_refills_number'_def obj_at'_def projectKOs objBitsKO_def
-                               ko_wp_at'_def scBits_simps length_replaceAt)
+                               ko_wp_at'_def scBits_simps)
         apply (prop_tac "0 < scRefillCount sc' \<and> scRefillHead sc' < scRefillMax sc'
                          \<and> scRefillMax sc' \<le> length (scRefills sc') \<and> 0 < length (scRefills sc')")
          apply (prop_tac "sc_relation sc n sc'")
@@ -1336,20 +1302,18 @@ lemma refillUpdate_corres:
          apply (frule (1) sc_ko_at_valid_objs_valid_sc')
          apply (fastforce dest: sc_ko_at_valid_objs_valid_sc'
                           simp: valid_sched_context'_def active_sc_at'_def obj_at'_def)
-        apply (intro conjI impI)
-         apply (clarsimp simp: refills_map_def)
-         apply (rule nth_equalityI; clarsimp)
-         apply (subst hd_conv_nth)
-          apply (rule length_greater_0_conv[THEN iffD1])
-          apply (subst length_map)
-          apply (subst length_wrap_slice; simp)
-         apply (subst nth_map)
-          apply (subst length_wrap_slice; simp)
-         apply (subst wrap_slice_index; simp)+
-         apply (subst replaceAt_index; fastforce simp: refillHd_def)
-        apply (fastforce simp: length_replaceAt)
+        apply (clarsimp simp: refills_map_def)
+        apply (rule nth_equalityI; clarsimp)
+        apply (subst hd_conv_nth)
+         apply (rule length_greater_0_conv[THEN iffD1])
+         apply (subst length_map)
+         apply (subst length_wrap_slice; simp)
+        apply (subst nth_map)
+         apply (subst length_wrap_slice; simp)
+        apply (subst wrap_slice_index; simp)+
+        apply (subst replaceAt_index; fastforce simp: refillHd_def)
        apply fastforce
-      apply (fastforce simp: length_replaceAt objBits_simps)
+      apply (fastforce simp: objBits_simps)
      apply simp
     apply (clarsimp simp: obj_at_def)
    apply (clarsimp simp: obj_at'_def)
@@ -1367,9 +1331,8 @@ lemma refillUpdate_corres:
                              sc_at_pred_n_def)
     apply ((wpsimp wp: hoare_vcg_ex_lift hoare_vcg_conj_lift | wpsimp wp: set_sc'.set_wp)+)[1]
     apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-    apply (fastforce simp: valid_sched_context'_def length_replaceAt valid_refills_number'_def
-                           obj_at'_def projectKOs objBits_simps' valid_sched_context_size'_def
-                           ps_clear_def)
+    apply (fastforce simp: valid_sched_context'_def ps_clear_def valid_refills_number'_def
+                           obj_at'_def projectKOs objBits_simps' valid_sched_context_size'_def)
    apply (corressimp corres: update_sc_no_reply_stack_update_ko_at'_corres
                                [where f'="scPeriod_update (\<lambda>_. period)"]
                        simp: sc_relation_def objBits_simps)

--- a/proof/refine/ARM/SchedContext_R.thy
+++ b/proof/refine/ARM/SchedContext_R.thy
@@ -841,4 +841,22 @@ lemmas updateSchedContext_decompose_x2 = updateSchedContext_decompose_fold[where
 lemmas updateSchedContext_decompose_x3 = updateSchedContext_decompose_fold[where fs="[g, h, k]" for f g h k,
  simplified mapM_x_Cons mapM_x_Nil fold_Cons fold_Nil id_def, simplified]
 
+(* should other update wp rules for valid_objs/valid_objs' be in this form? *)
+lemma updateSchedContext_valid_objs'[wp]:
+  "\<lbrace>valid_objs' and
+    (\<lambda>s. ((\<lambda>sc'. valid_obj' (injectKO sc') s \<longrightarrow> valid_obj' (injectKO (f' sc')) s)
+              |< scs_of' s) scp)\<rbrace>
+    updateSchedContext scp f'
+   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  apply (wpsimp simp: updateSchedContext_def wp: set_sc'.valid_objs')
+  by (fastforce simp: valid_obj'_def valid_sched_context'_def valid_sched_context_size'_def
+                      obj_at'_def projectKOs scBits_simps objBits_simps opt_map_left_Some)
+
+lemma updateSchedContext_obj_at'[wp]:
+  "\<forall>sc'. objBits sc' = objBits (f' sc'::sched_context) \<Longrightarrow>
+   updateSchedContext scp f' \<lbrace>\<lambda>s. P (sc_at' p s)\<rbrace>"
+  apply (wpsimp simp: updateSchedContext_def wp: set_sc'.set_wp)
+  apply (clarsimp simp: obj_at'_def ps_clear_upd projectKOs objBits_simps)
+  done
+
 end


### PR DESCRIPTION
This PR contains the following changes, part of the refill spec cleanup PR (#290 ):

- a most generic corres rule and some wp rules for `updateSchedContext`
- some abbreviations and rewrite lemmas for simplifying AInvs projections
- add a bunch of wrap_slice and refill related lemmas
- add `length_replaceAt` to the simp set, and related cleanup

Some more detailed comments on those changes:

- the `updateSchedContext_corres` rules is generic enough to handle all the refill related corres rules in the main PR #290 . The way we implement refill circular list in Haskell introduces unusual interdependency and the rule requires assumptions involving both the abstract and concrete states that satisfy the state relation. This probably suggests one direction we could extend our corres framework, although it is likely to be rare that we need this level of generality and there are ways to get around it.

- there are a bunch of monadic_rewrite lemma on `updateSchedContext` that are used in #290 

- `opt_pred` will let us write conditions on projections in a concise way, and it can be unfolded as needed easily from the heap using `opt_map_left_Some`.
```
abbreviation
  opt_pred :: "('a => bool) => ('b => 'a option) => ('b => bool)" (infixl "|<" 50) where
  "P |< proj == (\<lambda>x. case_option False P (proj x))"
```
Basically, we can have the form `(predicate) |< (layers of projections)`, for instance:
```
bounded_release_time_2 |< (scs_of ||> sc_refills |> hd_opt ||> r_time)
```
There is freedom in the ways to write the predicate and the projections in that, for example, you can apply `r_time` in the predicate instead of projection in the case above. The choice of the direction of application is to mimic the usual predicates, but people might have other preferences.

This can replace `pred_map`, which contains one layer of definition that we could do without. The benefit of replacing will be more smooth and automatic but controlled unfolding and more compact notations. We can use the rewrite lemma to do on-demand replacement:
```
lemma pred_map_rewrite:
  "pred_map P proj = opt_pred P proj"
  by (fastforce simp: pred_map_def2)
```
We could rename `opt_pred` to `pred_map`, too, but I think I’d prefer featuring `opt` for this.

- some wp rules for `updateSchedContext` have preconditions of the form `sc_at’ scp & (conditions on projections)` instead of `!ko. ko_at’ ko scp --> conditions on ko`. This often works nicely because there is no need to deal with superfluous intermediate `ko`s being updated.

- there are some more abbreviations and rewrite lemmas for simplifying AInvs projections in addition to `opt_pred`, such as `scs_of2` which is a full abbreviation that can replace `scs_of`. These are part of my bigger project to simply AInvs DetSched* using simpler projections ([link to WIP](https://github.com/seL4/l4v/blob/projection_rewrite/proof/invariant-abstract/DetSchedInvs_AI.thy#L3857)). I have included some of those simplifications in #290 to make the abstract side conditions easier to handle and more in sync with the concrete side, and it seemed to work quite well.

- the reason for wanting to simply AInvs DetSched* projections is mainly because, although I believe what we currently have is part of the necessary journey to where we are now, it contains a fair bit of legacy definitions that we probably don’t need that can be quite unintuitive to unfold and potential cause of slow down. But the AInvs part is for later and open for discussion. What I would like to be merged soon is a smaller portion that we could use for finishing of the rest of Refine.

- I would really like a shorter name for `opt_map_left_Some`. It is often needed and very handy but has to be added manually, and it’s a bit tedious to type. Any suggestions?
```
lemma opt_map_left_Some:
  “f x = Some y ==> (f |> g) x = g y”
```