### PR TITLE
refine: fix regression caused by bad theory import

### DIFF
--- a/proof/ROOT
+++ b/proof/ROOT
@@ -38,14 +38,17 @@ session Refine in "refine" = BaseRefine +
     "$L4V_ARCH/Refine"
     "$L4V_ARCH/RAB_FN"
     "$L4V_ARCH/EmptyFail_H"
+    "$L4V_ARCH/Init_R"
   theories [condition = "SKIP_REFINE_PROOFS", quick_and_dirty, skip_proofs]
     "$L4V_ARCH/Refine"
     "$L4V_ARCH/RAB_FN"
     "$L4V_ARCH/EmptyFail_H"
+    "$L4V_ARCH/Init_R"
   theories
     "$L4V_ARCH/Refine"
     "$L4V_ARCH/RAB_FN"
     "$L4V_ARCH/EmptyFail_H"
+    "$L4V_ARCH/Init_R"
 
 (*
  * This theory is in a separate session because the proofs currently

--- a/proof/refine/ARM/ADT_H.thy
+++ b/proof/refine/ARM/ADT_H.thy
@@ -10,7 +10,6 @@ theory ADT_H
 imports
   "AInvs.ADT_AI"
   Syscall_R
-  Init_R
 begin
 
 text \<open>

--- a/proof/refine/ARM_HYP/ADT_H.thy
+++ b/proof/refine/ARM_HYP/ADT_H.thy
@@ -10,7 +10,6 @@ theory ADT_H
 imports
   "AInvs.ADT_AI"
   Syscall_R
-  Init_R
 begin
 
 text \<open>

--- a/proof/refine/RISCV64/ADT_H.thy
+++ b/proof/refine/RISCV64/ADT_H.thy
@@ -7,9 +7,7 @@
 chapter \<open>Abstract datatype for the executable specification\<close>
 
 theory ADT_H
-  imports
-    Syscall_R
-    Init_R
+  imports Syscall_R
 begin
 
 text \<open>

--- a/proof/refine/X64/ADT_H.thy
+++ b/proof/refine/X64/ADT_H.thy
@@ -9,7 +9,6 @@ chapter \<open>Abstract datatype for the executable specification\<close>
 theory ADT_H
 imports
   "AInvs.ADT_AI"
-  Init_R
   Syscall_R
 begin
 


### PR DESCRIPTION
Importing Init_R into ADT_H was causing EmptyFail_H to fail. Since
no other theories actually depend on Init_R we can instead include
it in the Refine session directly.

Signed-off-by: Mitchell Buckley <mitchell.alan.buckley@gmail.com>