### PR TITLE
Cleanup some FIXMEs in ainvs

### DIFF
--- a/lib/LemmaBucket.thy
+++ b/lib/LemmaBucket.thy
@@ -467,6 +467,10 @@ lemma strenghten_False_imp:
   "\<not>P \<Longrightarrow> P \<longrightarrow> Q"
   by blast
 
+lemma None_in_range_Some [simp]:
+  "(None \<in> range Some) = False"
+  by auto
+
 lemma foldl_fun_or_alt:
   "foldl (\<lambda>x y. x \<or> f y) b ls = foldl (\<or>) b (map f ls)"
   apply (induct ls)
@@ -481,5 +485,32 @@ lemma sorted_imp_sorted_filter:
 lemma sorted_list_of_set_already_sorted:
   "\<lbrakk> distinct xs; sorted xs \<rbrakk> \<Longrightarrow> sorted_list_of_set (set xs) = xs"
   by (simp add: sorted_list_of_set_sort_remdups distinct_remdups_id sorted_sort_id)
+
+lemma inj_on_domD: "\<lbrakk>inj_on f (dom f); f x = Some z; f y = Some z\<rbrakk> \<Longrightarrow> x = y"
+  by (erule inj_onD) clarsimp+
+
+lemma not_emptyI:
+  "\<And>x A B. \<lbrakk>x\<in>A; x\<in>B\<rbrakk> \<Longrightarrow> A \<inter> B \<noteq> {}"
+  by auto
+
+lemma add_mask_lower_bits2:
+  "\<lbrakk>is_aligned (x :: 'a :: len word) n; p && ~~ mask n = 0\<rbrakk> \<Longrightarrow> x + p && ~~ mask n = x"
+  apply (subst word_plus_and_or_coroll)
+  apply (simp add: aligned_mask_disjoint and_mask_0_iff_le_mask)
+   apply (clarsimp simp: word_bool_alg.conj_disj_distrib2)
+  done
+
+(* FIXME: move to GenericLib *)
+lemma if3_fold2:
+  "(if P then x else if Q then x else y) = (if P \<or> Q then x else y)" by simp
+
+lemma inter_UNIV_minus[simp]:
+  "x \<inter> (UNIV - y) = x-y" by blast
+
+lemma imp_and_strg: "Q \<and> C \<longrightarrow> (A \<longrightarrow> Q \<and> C) \<and> C" by blast
+
+lemma cases_conj_strg: "A \<and> B \<longrightarrow> (P \<and> A) \<or> (\<not> P \<and> B)" by simp
+
+lemma and_not_not_or_imp: "(~ A & ~ B | C) = ((A | B) \<longrightarrow> C)" by blast
 
 end

--- a/lib/ListLibLemmas.thy
+++ b/lib/ListLibLemmas.thy
@@ -1087,4 +1087,8 @@ lemma after_in_list_None_last:
   "\<lbrakk>after_in_list list x = None; x \<in> set list\<rbrakk> \<Longrightarrow> x = last list"
   by (induct list x rule: after_in_list.induct,(simp split: if_split_asm)+)
 
+lemma map2_append1:
+  "map2 f (as @ bs) cs = map2 f as (take (length as) cs) @ map2 f bs (drop (length as) cs)"
+  by (simp add: map_def zip_append1)
+
 end

--- a/lib/NonDetMonadLemmaBucket.thy
+++ b/lib/NonDetMonadLemmaBucket.thy
@@ -3128,4 +3128,43 @@ lemma commute_grab_asm:
   "(F \<Longrightarrow> monad_commute P f g) \<Longrightarrow> (monad_commute (P and (K F)) f g)"
   by (clarsimp simp: monad_commute_def)
 
+lemma returnOk_E': "\<lbrace>P\<rbrace> returnOk r -,\<lbrace>E\<rbrace>"
+  by (clarsimp simp: returnOk_def validE_E_def validE_def valid_def return_def)
+
+lemma throwError_R': "\<lbrace>P\<rbrace> throwError e \<lbrace>Q\<rbrace>,-"
+  by (clarsimp simp:throwError_def validE_R_def validE_def valid_def return_def)
+
+lemma select_modify_comm:
+  "(do b \<leftarrow> select S; _ \<leftarrow> modify f; use b od) =
+   (do _ \<leftarrow> modify f; b \<leftarrow> select S; use b od)"
+  by (simp add: bind_def split_def select_def simpler_modify_def image_def)
+
+lemma select_f_modify_comm:
+  "(do b \<leftarrow> select_f S; _ \<leftarrow> modify f; use b od) =
+   (do _ \<leftarrow> modify f; b \<leftarrow> select_f S; use b od)"
+  by (simp add: bind_def split_def select_f_def simpler_modify_def image_def)
+
+lemma hoare_validE_R_conjI:
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, - ; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>, - \<rbrakk>  \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>, -"
+  apply (clarsimp simp: Ball_def validE_R_def validE_def valid_def)
+  by (case_tac a; fastforce)
+
+lemma validE_R_post_conjD1:
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> R r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-"
+  apply (clarsimp simp: validE_R_def validE_def valid_def)
+  by (case_tac a; fastforce)
+
+lemma validE_R_post_conjD2:
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> R r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>,-"
+  apply (clarsimp simp: validE_R_def validE_def valid_def)
+  by (case_tac a; fastforce)
+
+lemma throw_opt_wp[wp]:
+  "\<lbrace>if v = None then E ex else Q (the v)\<rbrace> throw_opt ex v \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  unfolding throw_opt_def by wpsimp auto
+
+lemma hoare_name_pre_state2:
+  "(\<And>s. \<lbrace>P and ((=) s)\<rbrace> f \<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
+  by (auto simp: valid_def intro: hoare_name_pre_state)
+
 end

--- a/lib/Word_Lib/Word_Lemmas.thy
+++ b/lib/Word_Lib/Word_Lemmas.thy
@@ -4280,6 +4280,10 @@ lemma word_shift_by_2:
   "x * 4 = (x::'a::len word) << 2"
   by (simp add: shiftl_t2n)
 
+lemma word_shift_by_3:
+  "x * 8 = (x::'a::len word) << 3"
+  by (simp add: shiftl_t2n)
+
 lemma le_2p_upper_bits:
   "\<lbrakk> (p::'a::len word) \<le> 2^n - 1; n < LENGTH('a) \<rbrakk> \<Longrightarrow>
   \<forall>n'\<ge>n. n' < LENGTH('a) \<longrightarrow> \<not> p !! n'"

--- a/proof/access-control/DomainSepInv.thy
+++ b/proof/access-control/DomainSepInv.thy
@@ -46,7 +46,7 @@ lemma cte_wp_at_not_domain_sep_inv_cap:
                  (\<exists> irq. cte_wp_at ((=) (IRQHandlerCap irq)) slot s)))) \<or>
    cte_wp_at ((=) DomainCap) slot s"
   apply (rule iffI)
-   apply (drule cte_wp_at_eqD)
+   apply (drule cte_wp_at_norm)
    apply clarsimp
    apply (case_tac c, simp_all add: domain_sep_inv_cap_def pred_neg_def)
    apply (auto elim: cte_wp_at_weakenE split: if_splits)
@@ -229,7 +229,7 @@ lemma cte_wp_at_weak_derived_domain_sep_inv_cap:
   apply (cases slot)
   apply (force simp: domain_sep_inv_def domain_sep_inv_cap_def
               split: cap.splits
-               dest: cte_wp_at_eqD weak_derived_irq_handler weak_derived_DomainCap)
+               dest: cte_wp_at_norm weak_derived_irq_handler weak_derived_DomainCap)
   done
 
 lemma is_derived_IRQHandlerCap:
@@ -250,7 +250,7 @@ lemma cte_wp_at_is_derived_domain_sep_inv_cap:
   apply (cases slot)
   apply (fastforce simp: domain_sep_inv_def domain_sep_inv_cap_def
                   split: cap.splits
-                   dest: cte_wp_at_eqD DomainCap_is_derived is_derived_IRQHandlerCap)
+                   dest: cte_wp_at_norm DomainCap_is_derived is_derived_IRQHandlerCap)
   done
 
 lemma domain_sep_inv_exst_update[simp]:

--- a/proof/crefine/ARM/CSpace_C.thy
+++ b/proof/crefine/ARM/CSpace_C.thy
@@ -150,7 +150,7 @@ lemma Arch_maskCapRights_ccorres [corres]:
    apply (rule allI, rule conseqPre, vcg)
    apply (clarsimp simp add: return_def simp del: not_ex)
    apply (cases arch_cap)
-       by (fastforce simp add: cap_get_tag_isCap isCap_simps  simp del: not_ex omgwtfbbq)+
+       by (fastforce simp add: cap_get_tag_isCap isCap_simps  simp del: not_ex simp_thms(44))+
 
 lemma to_bool_mask_to_bool_bf:
   "to_bool (x && mask (Suc 0)) = to_bool_bf (x::word32)"

--- a/proof/crefine/ARM_HYP/CSpace_C.thy
+++ b/proof/crefine/ARM_HYP/CSpace_C.thy
@@ -150,7 +150,7 @@ lemma Arch_maskCapRights_ccorres [corres]:
    apply (rule allI, rule conseqPre, vcg)
    apply (clarsimp simp add: return_def simp del: not_ex)
    apply (cases arch_cap)
-       by (fastforce simp add: cap_get_tag_isCap isCap_simps  simp del: not_ex omgwtfbbq)+
+       by (fastforce simp add: cap_get_tag_isCap isCap_simps  simp del: not_ex simp_thms(44))+
 
 (* FIXME: move to Wellformed_C (or move to_bool_bf out of Wellformed_C) *)
 lemma to_bool_mask_to_bool_bf:

--- a/proof/crefine/RISCV64/CSpace_C.thy
+++ b/proof/crefine/RISCV64/CSpace_C.thy
@@ -107,7 +107,7 @@ lemma Arch_maskCapRights_ccorres [corres]:
    apply (rule allI, rule conseqPre, vcg)
    apply (clarsimp simp add: return_def simp del: not_ex)
    apply (cases arch_cap)
-         by (fastforce simp add: cap_get_tag_isCap isCap_simps  simp del: not_ex omgwtfbbq)+
+         by (fastforce simp add: cap_get_tag_isCap isCap_simps  simp del: not_ex simp_thms(44))+
 
 lemma to_bool_mask_to_bool_bf:
   "to_bool (x && mask (Suc 0)) = to_bool_bf (x::machine_word)"

--- a/proof/crefine/X64/CSpace_C.thy
+++ b/proof/crefine/X64/CSpace_C.thy
@@ -123,7 +123,7 @@ lemma Arch_maskCapRights_ccorres [corres]:
    apply (rule allI, rule conseqPre, vcg)
    apply (clarsimp simp add: return_def simp del: not_ex)
    apply (cases arch_cap)
-         by (fastforce simp add: cap_get_tag_isCap isCap_simps  simp del: not_ex omgwtfbbq)+
+         by (fastforce simp add: cap_get_tag_isCap isCap_simps  simp del: not_ex simp_thms(44))+
 
 lemma to_bool_mask_to_bool_bf:
   "to_bool (x && mask (Suc 0)) = to_bool_bf (x::machine_word)"

--- a/proof/infoflow/ADT_IF.thy
+++ b/proof/infoflow/ADT_IF.thy
@@ -836,7 +836,7 @@ lemma do_user_op_if_invs:
    do_user_op_if f tc
    \<lbrace>\<lambda>_. invs and ct_running\<rbrace>"
   apply (simp add: do_user_op_if_def split_def)
-  apply (wp ct_running_machine_op select_wp device_update_invs | wp (once) dmo_invs | simp)+
+  apply (wp dmo_ct_in_state select_wp device_update_invs | wp (once) dmo_invs | simp)+
   apply (clarsimp simp: user_mem_def user_memory_update_def simpler_modify_def
                     restrict_map_def invs_def cur_tcb_def ptable_rights_s_def
                     ptable_lift_s_def)

--- a/proof/infoflow/FinalCaps.thy
+++ b/proof/infoflow/FinalCaps.thy
@@ -842,7 +842,7 @@ lemma weak_derived_overlaps:
     Structures_A.obj_refs cap \<noteq> {} \<or> cap_irqs cap \<noteq> {}\<rbrakk> \<Longrightarrow>
     slot \<in> slots_holding_overlapping_caps cap s"
   apply(simp add: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
-  apply(drule cte_wp_at_eqD)
+  apply(drule cte_wp_at_norm)
   apply(erule exE, rename_tac cap')
   apply(rule_tac x=cap' in exI)
   apply(blast dest: weak_derived_overlaps')
@@ -1040,7 +1040,7 @@ lemma is_derived_overlaps:
     Structures_A.obj_refs cap \<noteq> {} \<or> cap_irqs cap \<noteq> {}\<rbrakk> \<Longrightarrow>
     slot \<in> slots_holding_overlapping_caps cap s"
   apply(simp add: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
-  apply(drule cte_wp_at_eqD)
+  apply(drule cte_wp_at_norm)
   apply(erule exE, rename_tac cap')
   apply(rule_tac x=cap' in exI)
   apply(blast dest: is_derived_overlaps')
@@ -1052,7 +1052,7 @@ lemma is_derived_overlaps2:
     Structures_A.obj_refs cap' \<noteq> {} \<or> cap_irqs cap' \<noteq> {}\<rbrakk> \<Longrightarrow>
     slot \<in> slots_holding_overlapping_caps cap' s"
   apply(simp add: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
-  apply(blast dest: cte_wp_at_eqD is_derived_overlaps')
+  apply(blast dest: cte_wp_at_norm is_derived_overlaps')
   done
 
 lemma disj_dup: "A \<and> B \<and> C \<and> C'\<Longrightarrow> A \<and> B \<and> C \<and> A \<and> B \<and> C'"
@@ -1082,7 +1082,7 @@ lemma cap_insert_silc_inv:
    apply fastforce
   apply (rule conjI)
   apply(rule impI)
-  apply(drule cte_wp_at_eqD)
+  apply(drule cte_wp_at_norm)
   apply(elim conjE exE)
   apply(drule (1) cte_wp_at_eqD2)
   apply simp
@@ -1102,7 +1102,7 @@ lemma cte_wp_at_eq:
   assumes a: "\<And> cap. \<lbrace> cte_wp_at ((=) cap) slot \<rbrace> f \<lbrace> \<lambda>_. cte_wp_at ((=) cap) slot \<rbrace>"
   shows   "\<lbrace> cte_wp_at P slot \<rbrace> f \<lbrace> \<lambda>_. cte_wp_at P slot \<rbrace>"
   apply(clarsimp simp: valid_def)
-  apply(drule cte_wp_at_eqD)
+  apply(drule cte_wp_at_norm)
   apply(elim exE conjE, rename_tac cap)
   apply(drule use_valid)
     apply(rule a)
@@ -2271,7 +2271,7 @@ lemma perform_page_table_invocation_silc_ionv_get_cap_helper:
                     pasObjectAbs aag (fst lslot) = SilcLabel))) \<circ> the_arch_cap\<rbrace>"
   apply(wp get_cap_wp)
   apply clarsimp
-  apply(drule cte_wp_at_eqD)
+  apply(drule cte_wp_at_norm)
   apply(clarify)
   apply(drule (1) cte_wp_at_eqD2)
   apply(case_tac cap, simp_all add: is_pg_cap_def is_pt_cap_def)
@@ -2470,7 +2470,7 @@ lemma intra_label_cap_pres':
          f
      \<lbrace>\<lambda> _s. (intra_label_cap aag slot s) \<rbrace>"
   apply(clarsimp simp: valid_def intra_label_cap_def)
-  apply(drule cte_wp_at_eqD)
+  apply(drule cte_wp_at_norm)
   apply(elim exE conjE, rename_tac cap')
   apply(subgoal_tac "cap' = cap", blast)
   apply(drule use_valid[OF _ cte], fastforce)
@@ -2685,7 +2685,7 @@ lemma invoke_irq_handler_silc_inv:
              slots_holding_overlapping_caps_from_silc_inv[where aag=aag and st=st]
          | simp add: authorised_irq_hdl_inv_def get_irq_slot_def conj_comms)+
    apply (clarsimp simp: pas_refined_def irq_map_wellformed_aux_def)
-   apply (drule cte_wp_at_eqD)
+   apply (drule cte_wp_at_norm)
    apply (elim exE conjE, rename_tac cap')
    apply (drule_tac cap=cap' in silc_invD)
      apply assumption

--- a/proof/infoflow/Interrupt_IF.thy
+++ b/proof/infoflow/Interrupt_IF.thy
@@ -30,7 +30,7 @@ lemma invoke_irq_handler_reads_respects_f:
          hoare_vcg_ex_lift slots_holding_overlapping_caps_from_silc_inv[where aag=aag and st=st]| simp | simp add: get_irq_slot_def)+
    apply (clarsimp simp: pas_refined_def irq_map_wellformed_aux_def)
    apply ((rule conjI, assumption) | clarsimp simp: conj_comms authorised_irq_hdl_inv_def)+
-   apply (drule_tac p="(a,b)" in cte_wp_at_eqD)
+   apply (drule_tac p="(a,b)" in cte_wp_at_norm)
    apply (elim exE conjE, rename_tac cap')
    apply (drule_tac cap=cap' in silc_invD)
      apply assumption

--- a/proof/invariant-abstract/AInvs.thy
+++ b/proof/invariant-abstract/AInvs.thy
@@ -39,40 +39,15 @@ lemma akernel_invs_det_ext:
   unfolding call_kernel_def
   by (wpsimp wp: activate_invs simp: active_from_running)
 
-(* FIXME: move *)
-lemma ct_running_machine_op:
-  "\<lbrace>ct_running\<rbrace> do_machine_op f \<lbrace>\<lambda>_. ct_running\<rbrace>"
-  apply (simp add: ct_in_state_def pred_tcb_at_def obj_at_def)
-  apply (rule hoare_lift_Pf [where f=cur_thread])
-  by wp+
-
-(* FIXME: move *)
-(* FIXME: subsumes thread_set_ct_running *)
-lemma thread_set_ct_in_state:
-  "(\<And>tcb. tcb_state (f tcb) = tcb_state tcb) \<Longrightarrow>
-  \<lbrace>ct_in_state st\<rbrace> thread_set f t \<lbrace>\<lambda>rv. ct_in_state st\<rbrace>"
-  apply (simp add: ct_in_state_def)
-  apply (rule hoare_lift_Pf [where f=cur_thread])
-   apply (wp thread_set_no_change_tcb_state; simp)
-  apply (simp add: thread_set_def)
-  apply wp
-  apply simp
-  done
-
 lemma kernel_entry_invs:
   "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s)\<rbrace>
   (kernel_entry e us) :: (user_context,unit) s_monad
   \<lbrace>\<lambda>rv. invs and (\<lambda>s. ct_running s \<or> ct_idle s)\<rbrace>"
   apply (simp add: kernel_entry_def)
   apply (wp akernel_invs thread_set_invs_trivial thread_set_ct_in_state select_wp
-         ct_running_machine_op static_imp_wp hoare_vcg_disj_lift
+         dmo_ct_in_state static_imp_wp hoare_vcg_disj_lift
       | clarsimp simp add: tcb_cap_cases_def)+
   done
-
-(* FIXME: move to Lib.thy *)
-lemma Collect_subseteq:
-  "{x. P x} <= {x. Q x} \<longleftrightarrow> (\<forall>x. P x \<longrightarrow> Q x)"
-  by auto
 
 lemma device_update_invs:
   "\<lbrace>invs and (\<lambda>s. (dom ds) \<subseteq>  (device_region s))\<rbrace> do_machine_op (device_memory_update ds)
@@ -114,7 +89,7 @@ lemma do_user_op_invs:
    \<lbrace>\<lambda>_. invs and ct_running\<rbrace>"
   apply (simp add: do_user_op_def split_def)
   apply (wp device_update_invs)
-  apply (wp ct_running_machine_op select_wp dmo_invs | simp add:dom_restrict_plus_eq)+
+  apply (wp dmo_ct_in_state select_wp dmo_invs | simp add:dom_restrict_plus_eq)+
   apply (clarsimp simp: user_memory_update_def simpler_modify_def
                         restrict_map_def invs_def cur_tcb_def
                  split: option.splits if_split_asm)

--- a/proof/invariant-abstract/ARM/ArchADT_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchADT_AI.thy
@@ -324,31 +324,10 @@ where
    | Some (SuperSectionPDE base attrs rights) \<Rightarrow> Some (base,24, attrs, rights)
    | _ \<Rightarrow> None"
 
-
-(* FIXME: Lemma can be found in Untyped_R;
-   proof mostly copied from ArchAcc_R.pd_shifting *)
 lemma pd_shifting':
-   "is_aligned pd pd_bits \<Longrightarrow>
-    (pd + (vptr >> 20 << 2) && ~~ mask pd_bits) = (pd::word32)"
-  apply (simp add: pd_bits_def pageBits_def)
-  apply (rule word_eqI[rule_format])
-  apply (subst word_plus_and_or_coroll)
-   apply (rule word_eqI)
-   apply (clarsimp simp: word_size nth_shiftr nth_shiftl is_aligned_nth)
-   apply (erule_tac x=na in allE)
-   apply (simp add: linorder_not_less)
-   apply (drule test_bit_size)+
-   apply (simp add: word_size)
-  apply (clarsimp simp: word_size nth_shiftr nth_shiftl is_aligned_nth
-                        word_ops_nth_size pd_bits_def linorder_not_less)
-  apply (rule iffI)
-   apply clarsimp
-   apply (drule test_bit_size)+
-   apply (simp add: word_size)
-  apply clarsimp
-  apply (erule_tac x=n in allE)
-  apply simp
-  done
+ "is_aligned pd pd_bits \<Longrightarrow> (pd + (vptr >> 20 << 2) && ~~ mask pd_bits) = (pd::word32)"
+  unfolding pd_bits_def pageBits_def
+  by (rule pd_shifting_gen; simp add: word_size)
 
 lemma lookup_pt_slot_fail:
   "is_aligned pd pd_bits \<Longrightarrow>

--- a/proof/invariant-abstract/ARM/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchAcc_AI.thy
@@ -1240,15 +1240,6 @@ lemma set_object_caps_of_state:
   apply (auto simp: cte_wp_at_cases)
   done
 
-
-(* FIXME: Move to Invariants_A *)
-lemma pte_ref_pagesD:
-  "pte_ref_pages (pt y) = Some x \<Longrightarrow>
-   (VSRef (ucast y) (Some APageTable), x)
-   \<in> vs_refs_pages (ArchObj (PageTable pt))"
-  by (auto simp: pte_ref_pages_def vs_refs_pages_def graph_of_def)
-
-
 lemma set_pt_valid_vspace_objs[wp]:
   "valid (\<lambda>s. valid_vspace_objs s \<and> ((\<exists>\<rhd> p) s \<longrightarrow> (\<forall>x. valid_pte (pt x) s)))
              (set_pt p pt) (\<lambda>_. valid_vspace_objs)"
@@ -1593,19 +1584,6 @@ lemma set_pt_invs:
   done
 
 
-(* FIXME: move to Invariants_A *)
-lemma invs_valid_asid_table [elim!]:
-  "invs s \<Longrightarrow> valid_asid_table (arm_asid_table (arch_state s)) s"
-  by (simp add: invs_def valid_state_def valid_arch_state_def)
-
-
-(* FIXME: move to Invariants_A *)
-lemma valid_asid_table_ran:
-  "valid_asid_table asid_tbl s \<Longrightarrow> \<forall>p\<in>ran asid_tbl. asid_pool_at p s"
-  by (simp add: invs_def valid_state_def valid_arch_state_def
-                valid_asid_table_def)
-
-
 lemma vs_lookup_pages_pt_eq:
   "\<lbrakk>valid_vspace_objs s;
     \<forall>p\<in>ran (arm_asid_table (arch_state s)). asid_pool_at p s;
@@ -1621,10 +1599,6 @@ lemma vs_lookup_pages_pt_eq:
   apply (auto simp: obj_at_def pte_ref_pages_def data_at_def
                  split: pte.splits)
   done
-
-
-lemmas invs_ran_asid_table = invs_valid_asid_table[THEN valid_asid_table_ran]
-
 
 (* NOTE: we use vs_lookup in the precondition because in this case,
          both are equivalent, but vs_lookup is generally preserved
@@ -1851,16 +1825,6 @@ lemma set_asid_pool_table_caps [wp]:
   apply (wpsimp wp: set_object_wp_strong simp: a_type_def empty_table_def)
   apply (metis kernel_object_exhaust)
   done
-
-
-
-(* FIXME: Move to Invariants_A *)
-lemma vs_lookup_pages_stateI:
-  assumes 1: "(ref \<unrhd> p) s"
-  assumes ko: "\<And>ko p. ko_at ko p s \<Longrightarrow> obj_at (\<lambda>ko'. vs_refs_pages ko \<subseteq> vs_refs_pages ko') p s'"
-  assumes table: "graph_of (arm_asid_table (arch_state s)) \<subseteq> graph_of (arm_asid_table (arch_state s'))"
-  shows "(ref \<unrhd> p) s'"
-  using 1 vs_lookup_pages_sub [OF ko table] by blast
 
 lemma set_asid_pool_vs_lookup_unmap':
   "\<lbrace>valid_vs_lookup and
@@ -2708,54 +2672,26 @@ lemma store_pde_vspace_objs_unmap:
 lemma lookup_pd_slot_add_eq:
   "\<lbrakk> is_aligned pd pd_bits; is_aligned vptr 24; x \<in> set [0 , 4 .e. 0x3C] \<rbrakk>
   \<Longrightarrow> (x + lookup_pd_slot pd vptr && ~~ mask pd_bits) = pd"
-  apply (simp add: pd_bits_def pageBits_def add.commute add.left_commute lookup_pd_slot_def Let_def)
+    apply (simp add: pageBits_def add.commute add.left_commute lookup_pd_slot_def Let_def)
   apply (clarsimp simp: upto_enum_step_def word_shift_by_2)
-  apply (subst add_mask_lower_bits, assumption)
-   prefer 2
-   apply simp
-  apply clarsimp
-  subgoal premises prems for _ n'
-    proof -
-    have H: "(0xF::word32) < 2 ^ 4"  by simp
-    from prems show ?thesis
-    apply (subst (asm) word_plus_and_or_coroll)
-     apply (rule word_eqI)
-     apply (thin_tac "is_aligned pd _")
-     apply (clarsimp simp: word_size nth_shiftl nth_shiftr is_aligned_nth)
-     subgoal for n
-       apply (spec "18 + n")
-       apply (frule test_bit_size[where n="18 + n"])
-       apply (simp add: word_size)
-       apply (insert H)[1]
-        apply (drule (1) order_le_less_trans)
-        apply (drule bang_is_le)
-        apply (drule_tac z="2 ^ 4" in order_le_less_trans, assumption)
-        by (drule word_power_increasing; simp?)
-    apply simp
-    apply (clarsimp simp: word_size nth_shiftl nth_shiftr is_aligned_nth)
-    apply (erule disjE)
-     apply (insert H)[1]
-      apply (drule (1) order_le_less_trans)
-      apply (drule bang_is_le)
-      apply (drule_tac z="2 ^ 4" in order_le_less_trans, assumption)
-      apply (drule word_power_increasing; simp?)
-     apply (spec "18 + n'")
-     apply (frule test_bit_size[where n="18 + n'"])
-    by (simp add: word_size)
-    qed
- done
-
-
-lemma lookup_pd_slot_add:
-  "\<lbrakk> page_directory_at pd s; pspace_aligned s; is_aligned vptr 24; x \<in> set [0 , 4 .e. 0x3C] \<rbrakk>
-  \<Longrightarrow> (x + lookup_pd_slot pd vptr && ~~ mask pd_bits) = pd"
-  apply (clarsimp simp: obj_at_def pspace_aligned_def)
-  apply (drule bspec, blast)
-  apply (clarsimp simp: pd_bits_def pageBits_def a_type_def
-                  split: kernel_object.splits arch_kernel_obj.splits if_split_asm)
-  apply (drule (1) lookup_pd_slot_add_eq [rotated])
-   apply (simp add: pd_bits_def pageBits_def)
-  apply (simp add: pd_bits_def pageBits_def)
+  apply (erule add_mask_lower_bits2)
+  apply (subgoal_tac "2 < pd_bits \<and> size vptr \<le> 18 + pd_bits")
+   apply (simp add: and_mask_0_iff_le_mask le_mask_iff)
+   apply (subst word_plus_and_or_coroll)
+    apply (subst word_bool_alg.conj.commute)
+    apply (rule aligned_mask_disjoint[where n=6])
+     apply (rule is_aligned_shiftl, rule is_aligned_shiftr, simp)
+    apply (rule order.trans, rule leq_high_bits_shiftr_low_bits_leq_bits[where high_bits=4])
+     apply (clarsimp simp: mask_def, simp)
+   apply (clarsimp simp: shiftr_over_or_dist word_or_zero)
+   apply (intro conjI)
+    apply (clarsimp simp: shiftl_shiftr3)
+    apply (subgoal_tac "xa >> pd_bits - 2 = 0", simp)
+    apply (rule shiftr_le_0, rule unat_less_helper)
+    apply (erule order.strict_trans1, simp)
+    apply (clarsimp simp: pd_bits_def pageBits_def)
+   apply (clarsimp simp: shiftl_shiftr2 shiftr_shiftr shiftr_zero_size)
+  apply (clarsimp simp: pd_bits_def pageBits_def word_bits_size word_bits_def)
   done
 
 
@@ -3117,18 +3053,6 @@ lemma set_pd_vms[wp]:
   apply (erule valid_machine_state_heap_updI)
   apply (fastforce simp: a_type_def obj_at_def
            split: Structures_A.kernel_object.splits arch_kernel_obj.splits)+
-  done
-
-
-(* FIXME: Move to Invariants_A *)
-lemma vs_refs_pages_subset: "vs_refs ko \<subseteq> vs_refs_pages ko"
-  apply (clarsimp simp: vs_refs_pages_def vs_refs_def graph_of_def pde_ref_def pde_ref_pages_def
-                  split: kernel_object.splits arch_kernel_obj.splits pde.splits)
-  subgoal for "fun" a b
-  using
-    imageI[where A="{(x, y). (if x \<in> kernel_mapping_slots then None else pde_ref_pages (fun x)) = Some y}"
-             and f="(\<lambda>(r, y). (VSRef (ucast r) (Some APageDirectory), y))" and x="(a,b)"]
-   by (clarsimp simp: pde_ref_def pde_ref_pages_def split: if_splits pde.splits)+
   done
 
 

--- a/proof/invariant-abstract/ARM/ArchArch_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchArch_AI.thy
@@ -1080,12 +1080,6 @@ declare word_less_sub_le [simp del]
 declare ptrFormPAddr_addFromPPtr [simp]
 
 
-(* FIXME: move *)
-lemma valid_mask_vm_rights[simp]:
-  "mask_vm_rights V R \<in> valid_vm_rights"
-  by (simp add: mask_vm_rights_def)
-
-
 lemma vs_lookup_and_unique_refs:
   "\<lbrakk>(ref \<rhd> p) s; caps_of_state s cptr = Some cap; table_cap_ref cap = Some ref';
     p \<in> obj_refs cap; valid_vs_lookup s; unique_table_refs (caps_of_state s)\<rbrakk>

--- a/proof/invariant-abstract/ARM/ArchBits_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchBits_AI.thy
@@ -37,6 +37,9 @@ lemmas valid_cap_def = valid_cap_def[simplified valid_arch_cap_def]
 lemmas valid_cap_simps =
   valid_cap_def[split_simps cap.split arch_cap.split]
 
+lemmas invs_valid_asid_table [elim!] = invs_arch_state[THEN vas_valid_asid_table]
+lemmas invs_ran_asid_table = invs_valid_asid_table[THEN valid_asid_table_ran]
+
 end
 
 end

--- a/proof/invariant-abstract/ARM/ArchCSpacePre_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchCSpacePre_AI.thy
@@ -151,23 +151,6 @@ lemma unique_table_caps_upd_eqD:
   apply (simp add: if_distrib split:if_splits)
   done
 
-lemma set_untyped_cap_as_full_not_final_not_pg_cap:
-  "\<lbrace>\<lambda>s. (\<exists>a b. (a, b) \<noteq> dest \<and> \<not> is_pg_cap cap'
-            \<and> cte_wp_at (\<lambda>cap. gen_obj_refs cap = gen_obj_refs cap' \<and> \<not> is_pg_cap cap) (a, b) s)
-      \<and> cte_wp_at ((=) src_cap) src s\<rbrace>
-  set_untyped_cap_as_full src_cap cap src
-  \<lbrace>\<lambda>_ s.(\<exists>a b. (a, b) \<noteq> dest \<and> \<not> is_pg_cap cap'
-            \<and> cte_wp_at (\<lambda>cap. gen_obj_refs cap = gen_obj_refs cap' \<and> \<not> is_pg_cap cap) (a, b) s)\<rbrace>"
-  apply (rule hoare_pre)
-  apply (wp hoare_vcg_ex_lift)
-   apply (rule_tac Q = "cte_wp_at Q slot"
-               and Q'="cte_wp_at ((=) src_cap) src" for Q slot in P_bool_lift' )
-    apply (wp set_untyped_cap_as_full_cte_wp_at)
-    subgoal by (auto simp: cte_wp_at_caps_of_state is_cap_simps masked_as_full_def cap_bits_untyped_def)
-   apply (wp set_untyped_cap_as_full_cte_wp_at_neg)
-   apply (auto simp: cte_wp_at_caps_of_state is_cap_simps masked_as_full_def cap_bits_untyped_def)
-  done
-
 lemma arch_derived_is_device:
   "\<lbrakk>cap_master_arch_cap c = cap_master_arch_cap c';
         is_derived_arch (ArchObjectCap c) (ArchObjectCap c')\<rbrakk>

--- a/proof/invariant-abstract/ARM/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchIpc_AI.thy
@@ -92,7 +92,7 @@ lemma derive_cap_is_derived [Ipc_AI_assms]:
                     | erule cte_wp_at_weakenE
                     | simp split: cap.split_asm)+)[11]
   apply(wp hoare_drop_imps arch_derive_cap_is_derived)
-  apply(clarify, drule cte_wp_at_eqD, clarify)
+  apply(clarify, drule cte_wp_at_norm, clarify)
   apply(frule(1) cte_wp_at_valid_objs_valid_cap)
   apply(erule cte_wp_at_weakenE)
   apply(clarsimp simp: valid_cap_def)

--- a/proof/invariant-abstract/ARM/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchRetype_AI.thy
@@ -198,14 +198,6 @@ crunch pspace_respects_device_region[wp]: copy_global_mappings "pspace_respects_
 crunch cap_refs_respects_device_region[wp]: copy_global_mappings "cap_refs_respects_device_region"
   (wp: crunch_wps)
 
-(* FIXME: move to VSpace_R *)
-lemma vs_refs_add_one'':
-  "p \<in> kernel_mapping_slots \<Longrightarrow>
-   vs_refs (ArchObj (PageDirectory (pd(p := pde)))) =
-   vs_refs (ArchObj (PageDirectory pd))"
- by (auto simp: vs_refs_def graph_of_def split: if_split_asm)
-
-
 lemma glob_vs_refs_add_one':
   "glob_vs_refs (ArchObj (PageDirectory (pd(p := pde)))) =
    glob_vs_refs (ArchObj (PageDirectory pd))

--- a/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
@@ -488,10 +488,6 @@ lemma valid_arch_state_global_pd:
                          arch_kernel_obj.split_asm if_split_asm)
   done
 
-lemma pd_shifting':
-  "is_aligned (pd :: word32) pd_bits \<Longrightarrow> pd + (vptr >> 20 << 2) && ~~ mask pd_bits = pd"
-  by (rule pd_shifting, simp add: pd_bits_def pageBits_def)
-
 lemma copy_global_mappings_nonempty_table:
   "is_aligned pd pd_bits \<Longrightarrow>
    \<lbrace>\<lambda>s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s) \<and>

--- a/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
@@ -3312,11 +3312,6 @@ lemma store_pde_unmap_page:
   apply (simp add: up_ucast_inj_eq)
   done
 
-(* FIXME: move to Invariants_A *)
-lemma pte_ref_pages_invalid_None[simp]:
-  "pte_ref_pages InvalidPTE = None"
-  by (simp add: pte_ref_pages_def)
-
 lemma store_pte_no_lookup_pages:
   "\<lbrace>\<lambda>s. \<not> (r \<unrhd> q) s\<rbrace>
    store_pte p InvalidPTE
@@ -3332,11 +3327,6 @@ lemma store_pte_no_lookup_pages:
   by (fastforce simp: vs_lookup_pages1_def obj_at_def vs_refs_pages_def
                      graph_of_def image_def
               split: if_split_asm)
-
-(* FIXME: move to Invariants_A *)
-lemma pde_ref_pages_invalid_None[simp]:
-  "pde_ref_pages InvalidPDE = None"
-  by (simp add: pde_ref_pages_def)
 
 lemma store_pde_no_lookup_pages:
   "\<lbrace>\<lambda>s. \<not> (r \<unrhd> q) s\<rbrace> store_pde p InvalidPDE \<lbrace>\<lambda>_ s. \<not> (r \<unrhd> q) s\<rbrace>"
@@ -3977,10 +3967,6 @@ lemma dmo_ccr_invs[wp]:
      apply ((clarsimp | wp)+)[3]
   apply(erule use_valid, wp no_irq_cleanCacheRange_PoU no_irq, assumption)
   done
-
-(* FIXME: move to Invariants_A *)
-lemmas pte_ref_pages_simps[simp] =
-       pte_ref_pages_def[split_simps pte.split]
 
 lemma ex_pt_cap_eq:
   "(\<exists>ref cap. caps_of_state s ref = Some cap \<and>

--- a/proof/invariant-abstract/ARM_HYP/ArchADT_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchADT_AI.thy
@@ -17,8 +17,6 @@ lemma word_1FF_is_mask:
   "0x1FF = mask 9"
   by (simp add: mask_def)
 
-(*** FIXME end ***)
-
 subsection \<open>Constructing a virtual-memory view\<close>
 
 text \<open>
@@ -334,30 +332,11 @@ where
    | _ \<Rightarrow> None"
 
 
-(* FIXME: Lemma can be found in Untyped_R;
-   proof mostly copied from ArchAcc_R.pd_shifting *)
 lemma pd_shifting':
    "is_aligned pd pd_bits \<Longrightarrow>
     (pd + (vptr >> 21 << 3) && ~~ mask pd_bits) = (pd::word32)"
-  apply (simp add: pd_bits_def pageBits_def pde_bits_def)
-  apply (rule word_eqI[rule_format])
-  apply (subst word_plus_and_or_coroll)
-   apply (rule word_eqI)
-   apply (clarsimp simp: word_size nth_shiftr nth_shiftl is_aligned_nth)
-   apply (erule_tac x=na in allE)
-   apply (simp add: linorder_not_less)
-   apply (drule test_bit_size)+
-   apply (simp add: word_size)
-  apply (clarsimp simp: word_size nth_shiftr nth_shiftl is_aligned_nth
-                        word_ops_nth_size pd_bits_def linorder_not_less)
-  apply (rule iffI)
-   apply clarsimp
-   apply (drule test_bit_size)+
-   apply (simp add: word_size)
-  apply clarsimp
-  apply (erule_tac x=n in allE)
-  apply simp
-  done
+  unfolding pde_bits_def pd_bits_def pageBits_def
+  by (rule pd_shifting_gen; simp add: word_size)
 
 lemma lookup_pt_slot_fail:
   "is_aligned pd pd_bits \<Longrightarrow>

--- a/proof/invariant-abstract/ARM_HYP/ArchArch_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchArch_AI.thy
@@ -1261,12 +1261,6 @@ declare word_less_sub_le [simp del]
 declare ptrFormPAddr_addFromPPtr [simp]
 
 
-(* FIXME: move *)
-lemma valid_mask_vm_rights[simp]:
-  "mask_vm_rights V R \<in> valid_vm_rights"
-  by (simp add: mask_vm_rights_def)
-
-
 lemma vs_lookup_and_unique_refs:
   "\<lbrakk>(ref \<rhd> p) s; caps_of_state s cptr = Some cap; table_cap_ref cap = Some ref';
     p \<in> obj_refs cap; valid_vs_lookup s; unique_table_refs (caps_of_state s)\<rbrakk>

--- a/proof/invariant-abstract/ARM_HYP/ArchCSpacePre_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchCSpacePre_AI.thy
@@ -150,23 +150,6 @@ lemma unique_table_caps_upd_eqD:
   apply (simp add: if_distrib split:if_splits)
   done
 
-lemma set_untyped_cap_as_full_not_final_not_pg_cap:
-  "\<lbrace>\<lambda>s. (\<exists>a b. (a, b) \<noteq> dest \<and> \<not> is_pg_cap cap'
-            \<and> cte_wp_at (\<lambda>cap. gen_obj_refs cap = gen_obj_refs cap' \<and> \<not> is_pg_cap cap) (a, b) s)
-      \<and> cte_wp_at ((=) src_cap) src s\<rbrace>
-  set_untyped_cap_as_full src_cap cap src
-  \<lbrace>\<lambda>_ s.(\<exists>a b. (a, b) \<noteq> dest \<and> \<not> is_pg_cap cap'
-            \<and> cte_wp_at (\<lambda>cap. gen_obj_refs cap = gen_obj_refs cap' \<and> \<not> is_pg_cap cap) (a, b) s)\<rbrace>"
-  apply (rule hoare_pre)
-  apply (wp hoare_vcg_ex_lift)
-   apply (rule_tac Q = "cte_wp_at Q slot"
-               and Q'="cte_wp_at ((=) src_cap) src" for Q slot in P_bool_lift' )
-    apply (wp set_untyped_cap_as_full_cte_wp_at)
-    subgoal by (auto simp: cte_wp_at_caps_of_state is_cap_simps masked_as_full_def cap_bits_untyped_def)
-   apply (wp set_untyped_cap_as_full_cte_wp_at_neg)
-   apply (auto simp: cte_wp_at_caps_of_state is_cap_simps masked_as_full_def cap_bits_untyped_def)
-  done
-
 lemma arch_derived_is_device:
   "\<lbrakk>cap_master_arch_cap c = cap_master_arch_cap c';
         is_derived_arch (ArchObjectCap c) (ArchObjectCap c')\<rbrakk>

--- a/proof/invariant-abstract/ARM_HYP/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDetype_AI.thy
@@ -505,11 +505,6 @@ proof -
     done
 qed
 
-(* FIXME: move *)
-lemma not_emptyI:
-  "\<And>x A B. \<lbrakk>x\<in>A; x\<in>B\<rbrakk> \<Longrightarrow> A \<inter> B\<noteq> {}"
-  by auto
-
 lemma in_user_frame_eq:
   notes blah[simp del] =  atLeastAtMost_iff
           atLeastatMost_subset_iff atLeastLessThan_iff

--- a/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
@@ -1673,11 +1673,6 @@ crunch caps_of_state [wp]: vcpu_finalise "\<lambda>s. P (caps_of_state s)"
 crunch caps_of_state [wp]: arch_finalise_cap "\<lambda>s. P (caps_of_state s)"
    (wp: crunch_wps simp: crunch_simps)
 
-(* FIXME: MOVE *)
-lemma hoare_validE_R_conjI:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, - ; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>, - \<rbrakk>  \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>, -"
-  by (auto simp: Ball_def validE_R_def validE_def valid_def)
-
 lemma set_vm_root_empty[wp]:
   "\<lbrace>\<lambda>s. P (obj_at (empty_table {}) p s)\<rbrace> set_vm_root v \<lbrace>\<lambda>_ s. P (obj_at (empty_table {}) p s) \<rbrace>"
   apply (simp add: set_vm_root_def)

--- a/proof/invariant-abstract/ARM_HYP/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchInvariants_AI.thy
@@ -1556,9 +1556,6 @@ lemma vs_lookup_pdI:
   apply (simp add: pde_ref_def)
   done
 
-(* FIXME: move *)
-lemma bexEI: "\<lbrakk>\<exists>x\<in>S. Q x; \<And>x. \<lbrakk>x \<in> S; Q x\<rbrakk> \<Longrightarrow> P x\<rbrakk> \<Longrightarrow> \<exists>x\<in>S. P x" by blast
-
 lemma vs_lookup_pages_vs_lookupI: "(ref \<rhd> p) s \<Longrightarrow> (ref \<unrhd> p) s"
   apply (clarsimp simp: vs_lookup_pages_def vs_lookup_def Image_def
                  elim!: bexEI)
@@ -2542,8 +2539,8 @@ lemma valid_arch_mdb_eqI:
   assumes "valid_arch_mdb (is_original_cap s) (caps_of_state s)"
   assumes "caps_of_state s = caps_of_state s'"
   assumes "is_original_cap s = is_original_cap s'"
-  shows "valid_arch_mdb (is original_cap s') (caps_of_state s')"
-  by (clarsimp simp: valid_arch_mdb_def)
+  shows "valid_arch_mdb (is_original_cap s') (caps_of_state s')"
+  by (clarsimp)
 
 lemma arch_tcb_context_absorbs[simp]:
   "arch_tcb_context_set uc2 (arch_tcb_context_set uc1 a_tcb) \<equiv> arch_tcb_context_set uc2 a_tcb"
@@ -2572,6 +2569,9 @@ proof -
     by (fastforce dest: ko elim: vs_lookup_pages1_stateI2)
   thus ?thesis by (rule rtrancl_mono)
 qed
+
+lemmas pte_ref_pages_simps[simp] = pte_ref_pages_def[split_simps pte.split]
+lemmas pde_ref_pages_simps[simp] = pde_ref_pages_def[split_simps pde.split]
 
 end
 

--- a/proof/invariant-abstract/ARM_HYP/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchIpc_AI.thy
@@ -94,7 +94,7 @@ lemma derive_cap_is_derived [Ipc_AI_assms]:
                     | simp split: cap.split_asm)+)[11]
   including no_pre
   apply(rule hoare_pre, wp hoare_drop_imps arch_derive_cap_is_derived)
-  apply(clarify, drule cte_wp_at_eqD, clarify)
+  apply(clarify, drule cte_wp_at_norm, clarify)
   apply(frule(1) cte_wp_at_valid_objs_valid_cap)
   apply(erule cte_wp_at_weakenE)
   apply(clarsimp simp: valid_cap_def)

--- a/proof/invariant-abstract/ARM_HYP/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchRetype_AI.thy
@@ -190,14 +190,6 @@ crunch cap_refs_respects_device_region[wp]: copy_global_mappings "cap_refs_respe
   (wp: crunch_wps)
 
 
-(* FIXME: move to VSpace_R *) (* ARMHYP remove *)
-lemma vs_refs_add_one'':
-  "p \<in> {} \<Longrightarrow>
-   vs_refs (ArchObj (PageDirectory (pd(p := pde)))) =
-   vs_refs (ArchObj (PageDirectory pd))"
- by (auto simp: vs_refs_def graph_of_def split: if_split_asm)
-
-
 lemma glob_vs_refs_add_one':
   "glob_vs_refs (ArchObj (PageDirectory (pd(p := pde)))) =
    glob_vs_refs (ArchObj (PageDirectory pd))

--- a/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
@@ -402,35 +402,6 @@ lemma store_pde_weaken:
             split: Structures_A.kernel_object.splits arch_kernel_obj.splits)
   done
 
-(* ARMHYP not needed anymore?
-lemma store_pde_nonempty_table:
-  "\<lbrace>\<lambda>s. \<not> (obj_at (nonempty_table {}) r s)
-           \<and> (\<forall>rf. pde_ref pde = Some rf \<longrightarrow>
-                   rf \<in> {})
-           \<and> valid_pde_mappings pde\<rbrace>
-     store_pde pde_ptr pde
-   \<lbrace>\<lambda>rv s. \<not> (obj_at (nonempty_table {}) r s)\<rbrace>"
-  apply (simp add: store_pde_def set_pd_def set_object_def)
-  apply (wp get_object_wp)
-  apply (clarsimp simp: obj_at_def nonempty_table_def a_type_def)
-  apply (clarsimp simp add: empty_table_def vspace_bits_defs)
-  done *)
-
-(*
-lemma valid_arch_state_global_pd: (* ARMHYP restate? *)
-  "\<lbrakk> valid_arch_state s; pspace_aligned s \<rbrakk>
-    \<Longrightarrow> obj_at (\<lambda>ko. \<exists>pd. ko = ArchObj (PageDirectory pd)) (arm_global_pd (arch_state s)) s
-           \<and> is_aligned (arm_global_pd (arch_state s)) pd_bits"
-  apply (clarsimp simp: valid_arch_state_def a_type_def
-                        pd_aligned pd_bits_def pageBits_def
-                 elim!: obj_at_weakenE)
-  apply (clarsimp split: Structures_A.kernel_object.split_asm
-                         arch_kernel_obj.split_asm if_split_asm)
-  done
-*)
-lemma pd_shifting':
-  "is_aligned (pd :: word32) pd_bits \<Longrightarrow> pd + (vptr >> pageBits + pt_bits - pte_bits << pde_bits) && ~~ mask pd_bits = pd"
-  by (rule pd_shifting, simp add: vspace_bits_defs)
 
 lemma copy_global_mappings_nonempty_table: (* ARMHYP need change *)
   "is_aligned pd pd_bits \<Longrightarrow>

--- a/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
@@ -4356,11 +4356,6 @@ lemma store_pde_unmap_page:
   apply (simp add: up_ucast_inj_eq)
 done
 
-(* FIXME: move to Invariants_A *)
-lemma pte_ref_pages_invalid_None[simp]:
-  "pte_ref_pages InvalidPTE = None"
-  by (simp add: pte_ref_pages_def)
-
 lemma store_pte_no_lookup_pages:
   "\<lbrace>\<lambda>s. \<not> (r \<unrhd> q) s\<rbrace>
    store_pte p InvalidPTE
@@ -4377,10 +4372,6 @@ lemma store_pte_no_lookup_pages:
                      graph_of_def image_def
               split: if_split_asm)
 
-(* FIXME: move to Invariants_A *)
-lemma pde_ref_pages_invalid_None[simp]:
-  "pde_ref_pages InvalidPDE = None"
-  by (simp add: pde_ref_pages_def)
 
 lemma store_pde_no_lookup_pages:
   "\<lbrace>\<lambda>s. \<not> (r \<unrhd> q) s\<rbrace> store_pde p InvalidPDE \<lbrace>\<lambda>_ s. \<not> (r \<unrhd> q) s\<rbrace>"
@@ -4567,11 +4558,6 @@ crunches vcpu_enable, vcpu_write_reg, vcpu_update, vcpu_restore, vcpu_enable, vc
 crunch pspace_respects_device_region[wp]: perform_page_invocation "pspace_respects_device_region"
   (simp: crunch_simps when_def
      wp: crunch_wps set_object_pspace_respects_device_region pspace_respects_device_region_dmo)
-
-(* FIXME move to WordLemma *)
-lemma word_shift_by_3:
-  "x * 8 = (x::'a::len word) << 3"
-  by (simp add: shiftl_t2n)
 
 lemma perform_page_directory_invocation_invs[wp]:
   "\<lbrace>invs and valid_pdi pdi\<rbrace>
@@ -5015,10 +5001,6 @@ lemma dmo_ccr_invs[wp]:
      apply ((clarsimp | wp)+)[3]
   apply(erule use_valid, wp no_irq_cleanCacheRange_PoU no_irq, assumption)
   done
-
-(* FIXME: move to Invariants_A *)
-lemmas pte_ref_pages_simps[simp] =
-       pte_ref_pages_def[split_simps pte.split]
 
 lemma ex_pt_cap_eq:
   "(\<exists>ref cap. caps_of_state s ref = Some cap \<and>

--- a/proof/invariant-abstract/CNodeInv_AI.thy
+++ b/proof/invariant-abstract/CNodeInv_AI.thy
@@ -3589,14 +3589,6 @@ lemma invoke_cnode_invs[wp]:
 
 end
 
-crunch pred_tcb_at[wp]: cap_move "pred_tcb_at proj P t"
-
-
-(* FIXME: rename, move *)
-lemma omgwtfbbq[simp]:
-  "(\<forall>x. y \<noteq> x) = False"
-  by clarsimp
-
 
 lemma corres_underlying_lift_ex1:
   assumes c: "\<And>v. corres_underlying sr nf nf' r (P v and Q) P' a c"

--- a/proof/invariant-abstract/CSpaceInv_AI.thy
+++ b/proof/invariant-abstract/CSpaceInv_AI.thy
@@ -627,8 +627,7 @@ lemma set_cap_live[wp]:
      set_cap cap p \<lbrace>\<lambda>rv s. P (obj_at live p' s)\<rbrace>"
   apply (simp add: set_cap_def split_def set_object_def)
   apply (wp get_object_wp | wpc)+
-  apply (auto simp: obj_at_def live_def) (* FIXME: ARMHYP *)
-  done
+  by (fastforce simp: obj_at_def live_def)
 
 
 lemma set_cap_cap_to:

--- a/proof/invariant-abstract/CSpace_AI.thy
+++ b/proof/invariant-abstract/CSpace_AI.thy
@@ -85,18 +85,6 @@ lemma irq_state_independent_A_conjI[intro!]:
   by (auto simp: irq_state_independent_A_def)
 
 (* FIXME: move *)
-lemma select_modify_comm:
-  "(do b \<leftarrow> select S; _ \<leftarrow> modify f; use b od) =
-   (do _ \<leftarrow> modify f; b \<leftarrow> select S; use b od)"
-  by (simp add: bind_def split_def select_def simpler_modify_def image_def)
-
-(* FIXME: move *)
-lemma select_f_modify_comm:
-  "(do b \<leftarrow> select_f S; _ \<leftarrow> modify f; use b od) =
-   (do _ \<leftarrow> modify f; b \<leftarrow> select_f S; use b od)"
-  by (simp add: bind_def split_def select_f_def simpler_modify_def image_def)
-
-(* FIXME: move *)
 lemma gets_machine_state_modify:
   "do x \<leftarrow> gets machine_state;
        u \<leftarrow> modify (machine_state_update (\<lambda>y. x));
@@ -568,10 +556,6 @@ lemmas final_matters_simps[simp]
     = final_matters_def[split_simps cap.split]
 
 
-(* FIXME: replace everywhere *)
-lemmas cte_wp_at_eqD = cte_wp_at_norm
-
-
 lemma no_True_set_nth:
   "(True \<notin> set xs) = (\<forall>n < length xs. xs ! n = False)"
   apply (induct xs)
@@ -585,12 +569,6 @@ lemma no_True_set_nth:
   apply (erule_tac x="Suc n" in allE)
   apply clarsimp
   done
-
-
-lemma map2_append1:
-  "map2 f (as @ bs) cs = map2 f as (take (length as) cs) @ map2 f bs (drop (length as) cs)"
-  by (simp add: map_def zip_append1)
-
 
 lemma set_cap_caps_of_state_monad:
   "(v, s') \<in> fst (set_cap cap p s) \<Longrightarrow> caps_of_state s' = (caps_of_state s (p \<mapsto> cap))"
@@ -909,11 +887,6 @@ lemma mdb_set_cap:
   "(x,s') \<in> fst (set_cap p c s) \<Longrightarrow> cdt s' = cdt s"
   by (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def
                split: if_split_asm Structures_A.kernel_object.splits)
-
-(* FIXME: rename *)
-lemma yes_indeed [simp]:
-  "(None \<in> range Some) = False"
-  by auto
 
 lemma master_cap_obj_refs:
   "cap_master_cap c = cap_master_cap c' \<Longrightarrow> obj_refs c = obj_refs c'"
@@ -4164,11 +4137,6 @@ lemma ct_from_words_inv [wp]:
 
 (* FIXME: move *)
 crunch inv[wp]: stateAssert P
-
-(* FIXME: move *)
-lemma inter_UNIV_minus[simp]:
-  "x \<inter> (UNIV - y) = x-y" by blast
-
 
 lemma not_Null_valid_imp [simp]:
   "(cap \<noteq> cap.NullCap \<longrightarrow> s \<turnstile> cap) = (s \<turnstile> cap)"

--- a/proof/invariant-abstract/Detype_AI.thy
+++ b/proof/invariant-abstract/Detype_AI.thy
@@ -1305,14 +1305,4 @@ lemma range_cover_sz':
   by (clarsimp simp:range_cover_def)
 
 
-(* FIXME: move to GenericLib *)
-lemma if3_fold2:
-  "(if P then x else if Q then x else y) = (if P \<or> Q then x else y)" by simp
-
-(* FIXME: move *)
-lemma not_emptyI:
-  "\<And>x A B. \<lbrakk>x\<in>A; x\<in>B\<rbrakk> \<Longrightarrow> A \<inter> B\<noteq> {}"
-  by auto
-
-
 end

--- a/proof/invariant-abstract/Finalise_AI.thy
+++ b/proof/invariant-abstract/Finalise_AI.thy
@@ -695,13 +695,6 @@ lemma pred_tcb_at_def2:
 (* sseefried: 'st_tcb_at_def2' only exists to make existing proofs go through. Can use 'pred_tcb_at_def2' instead *)
 lemmas st_tcb_at_def2 = pred_tcb_at_def2[where proj=itcb_state,simplified]
 
-lemma imp_and_strg: "Q \<and> C \<longrightarrow> (A \<longrightarrow> Q \<and> C) \<and> C" by blast
-(* FIXME: move *)
-lemma cases_conj_strg: "A \<and> B \<longrightarrow> (P \<and> A) \<or> (\<not> P \<and> B)"
-  by simp
-(* FIXME: move *)
-lemma and_not_not_or_imp: "(~ A & ~ B | C) = ((A | B) \<longrightarrow> C)" by blast
-
 lemmas tcb_cap_valid_imp = mp [OF mp [OF tcb_cap_valid_imp'], rotated]
 
 crunch irq_node[wp]: cancel_all_ipc "\<lambda>s. P (interrupt_irq_node s)"

--- a/proof/invariant-abstract/InvariantsPre_AI.thy
+++ b/proof/invariant-abstract/InvariantsPre_AI.thy
@@ -287,4 +287,17 @@ lemma typ_at_typs_of:
   "typ_at T p s = (typs_of s p = Some T)"
   by (auto simp: obj_at_def in_opt_map_eq)
 
+(* This generalises pd_shifting' in ARM and ARM_HYP *)
+lemma pd_shifting_gen:
+  "\<lbrakk>b \<le> a; size pd - c \<le> a - b; is_aligned pd c \<rbrakk> \<Longrightarrow> pd + (vptr >> a << b) && ~~ mask c = pd"
+  apply (subgoal_tac "(vptr >> a << b) && ~~ mask c = 0")
+   apply (subst word_plus_and_or_coroll)
+    apply (erule aligned_mask_disjoint)
+    apply (simp add: and_mask_0_iff_le_mask[symmetric])
+   apply (simp add: word_bool_alg.conj_disj_distrib2)
+  apply (simp add: shiftr_shiftl1 neg_mask_twice word_bool_alg.conj.assoc)
+  apply (rule shiftr_not_mask_0)
+  apply (fastforce simp: max_def word_size)
+  done
+
 end

--- a/proof/invariant-abstract/Invariants_AI.thy
+++ b/proof/invariant-abstract/Invariants_AI.thy
@@ -3455,6 +3455,10 @@ lemma max_ipc_length_unfold:
   "max_ipc_length = 128"
   by (simp add: max_ipc_length_def cap_transfer_data_size_def msg_max_length_def msg_max_extra_caps_def)
 
+lemma valid_mask_vm_rights[simp]:
+  "mask_vm_rights V R \<in> valid_vm_rights"
+  by (simp add: mask_vm_rights_def)
+
 lemmas invs_implies =
   invs_equal_kernel_mappings
   invs_arch_state

--- a/proof/invariant-abstract/KHeap_AI.thy
+++ b/proof/invariant-abstract/KHeap_AI.thy
@@ -1566,9 +1566,6 @@ lemma set_aobject_cur_tcb [wp]:
   unfolding cur_tcb_def
   by (rule hoare_lift_Pf [where f=cur_thread]) wp+
 
-crunch arch [wp]: set_object "\<lambda>s. P (arch_state s)"
-  (wp: get_object_wp)
-
 lemma set_aobject_valid_idle[wp]:
   "set_object ptr (ArchObj obj) \<lbrace>\<lambda>s. valid_idle s\<rbrace>"
   by (wpsimp wp: valid_idle_lift)
@@ -1581,16 +1578,10 @@ lemma set_aobject_reply_masters[wp]:
   "set_object ptr (ArchObj obj) \<lbrace>valid_reply_masters\<rbrace>"
   by (wp valid_reply_masters_cte_lift)
 
-crunch arch [wp]: set_object "\<lambda>s. P (arch_state s)"
-  (wp: crunch_wps)
-
-crunch idle [wp]: set_object "\<lambda>s. P (idle_thread s)"
-  (wp: crunch_wps)
-
-crunch irq [wp]: set_object "\<lambda>s. P (interrupt_irq_node s)"
-  (wp: crunch_wps)
-
-crunch interrupt_states[wp]: set_object "\<lambda>s. P (interrupt_states s)"
-  (wp: crunch_wps)
+lemma dmo_ct_in_state:
+  "do_machine_op f \<lbrace>ct_in_state P\<rbrace>"
+  apply (simp add: ct_in_state_def)
+  apply (rule hoare_lift_Pf [where f=cur_thread])
+  by wp+
 
 end

--- a/proof/invariant-abstract/RISCV64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchArch_AI.thy
@@ -1020,11 +1020,6 @@ declare word_less_sub_le [simp del]
 declare ptrFormPAddr_addFromPPtr [simp]
 
 
-(* FIXME: move *)
-lemma valid_mask_vm_rights[simp]:
-  "mask_vm_rights V R \<in> valid_vm_rights"
-  by (simp add: mask_vm_rights_def)
-
 lemma le_user_vtop_less_pptr_base[simp]:
   "x \<le> user_vtop \<Longrightarrow> x < pptr_base"
   using dual_order.strict_trans2 by blast

--- a/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
@@ -8,11 +8,6 @@ theory ArchFinalise_AI
 imports Finalise_AI
 begin
 
-(* FIXME: MOVE *)
-lemma hoare_validE_R_conjI:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, - ; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>, - \<rbrakk>  \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>, -"
-  by (auto simp: Ball_def validE_R_def validE_def valid_def)
-
 context Arch begin
 
 named_theorems Finalise_AI_asms

--- a/proof/invariant-abstract/RISCV64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchIpc_AI.thy
@@ -91,7 +91,7 @@ lemma derive_cap_is_derived [Ipc_AI_assms]:
                     | simp split: cap.split_asm)+)[11]
   including no_pre
   apply(rule hoare_pre, wp hoare_drop_imps arch_derive_cap_is_derived)
-  apply(clarify, drule cte_wp_at_eqD, clarify)
+  apply(clarify, drule cte_wp_at_norm, clarify)
   apply(frule(1) cte_wp_at_valid_objs_valid_cap)
   apply(erule cte_wp_at_weakenE)
   apply(clarsimp simp: valid_cap_def)

--- a/proof/invariant-abstract/RISCV64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchVSpace_AI.thy
@@ -12,11 +12,6 @@ theory ArchVSpace_AI
 imports VSpacePre_AI
 begin
 
-(* FIXME: move to lib *)
-lemma throw_opt_wp[wp]:
-  "\<lbrace>if v = None then E ex else Q (the v)\<rbrace> throw_opt ex v \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
-  unfolding throw_opt_def by wpsimp auto
-
 context Arch begin global_naming RISCV64
 
 definition kernel_mappings_only :: "(pt_index \<Rightarrow> pte) \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
@@ -28,7 +23,7 @@ lemma find_vspace_for_asid_wp[wp]:
         (\<forall>pt. vspace_for_asid asid s = Some pt \<longrightarrow> Q pt s) \<rbrace>
    find_vspace_for_asid asid \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   unfolding find_vspace_for_asid_def
-  by (wpsimp wp: throw_opt_wp)
+  by wpsimp
 
 crunch pspace_in_kernel_window[wp]: perform_page_invocation "pspace_in_kernel_window"
   (simp: crunch_simps wp: crunch_wps)

--- a/proof/invariant-abstract/TcbAcc_AI.thy
+++ b/proof/invariant-abstract/TcbAcc_AI.thy
@@ -1822,4 +1822,16 @@ lemma get_tcb_ko_atD:
   "get_tcb t s = Some tcb \<Longrightarrow> ko_at (TCB tcb) t s"
   by auto
 
+(* FIXME: subsumes thread_set_ct_running *)
+lemma thread_set_ct_in_state:
+  "(\<And>tcb. tcb_state (f tcb) = tcb_state tcb) \<Longrightarrow>
+  \<lbrace>ct_in_state st\<rbrace> thread_set f t \<lbrace>\<lambda>rv. ct_in_state st\<rbrace>"
+  apply (simp add: ct_in_state_def)
+  apply (rule hoare_lift_Pf [where f=cur_thread])
+   apply (wp thread_set_no_change_tcb_state; simp)
+  apply (simp add: thread_set_def)
+  apply wp
+  apply simp
+  done
+
 end

--- a/proof/invariant-abstract/VSpacePre_AI.thy
+++ b/proof/invariant-abstract/VSpacePre_AI.thy
@@ -60,12 +60,6 @@ lemma upto_enum_step_subtract:
   "x \<le> z \<Longrightarrow> [x, y .e. z] = (map ((+) x) [0, y - x .e. z - x])"
   by (auto simp add: upto_enum_step_def)
 
-(* FIXME: move *)
-lemma returnOk_E': "\<lbrace>P\<rbrace> returnOk r -,\<lbrace>E\<rbrace>"
-  by (clarsimp simp: returnOk_def validE_E_def validE_def valid_def return_def)
-lemma throwError_R': "\<lbrace>P\<rbrace> throwError e \<lbrace>Q\<rbrace>,-"
-  by (clarsimp simp:throwError_def validE_R_def validE_def valid_def return_def)
-
 lemma invs_valid_irq_states[elim!]:
   "invs s \<Longrightarrow> valid_irq_states s"
   by(auto simp: invs_def valid_state_def)
@@ -85,14 +79,6 @@ lemma uint_ucast:
     apply (clarsimp simp only: word_neq_0_conv[symmetric])
    apply simp_all
   done
-
-(* FIXME: move *)
-lemma inj_on_domD: "\<lbrakk>inj_on f (dom f); f x = Some z; f y = Some z\<rbrakk> \<Longrightarrow> x = y"
-  by (erule inj_onD) clarsimp+
-
-lemma hoare_name_pre_state2:
-  "(\<And>s. \<lbrace>P and ((=) s)\<rbrace> f \<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
-  by (auto simp: valid_def intro: hoare_name_pre_state)
 
 lemma pd_casting_shifting:
   "size x + n < len_of TYPE('a) \<Longrightarrow>

--- a/proof/invariant-abstract/X64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/X64/ArchAcc_AI.thy
@@ -746,17 +746,6 @@ lemma canonical_address_add:
   unfolding canonical_address_sign_extended
   by auto
 
-(* FIXME: move *)
-lemma validE_R_post_conjD1:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> R r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-"
-  by (fastforce simp add: validE_R_def validE_def valid_def)
-
-(* FIXME: move *)
-lemma validE_R_post_conjD2:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> R r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>,-"
-  by (fastforce simp add: validE_R_def validE_def valid_def)
-
-
 (* Lemmas about looking up entries in vspace tables.
    For each level of table, we prove a single private lemma which tells us
    everything we need to know in order to be able to say something about the

--- a/proof/invariant-abstract/X64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/X64/ArchArch_AI.thy
@@ -1151,12 +1151,6 @@ declare word_less_sub_le [simp del]
 declare ptrFormPAddr_addFromPPtr [simp]
 
 
-(* FIXME: move *)
-lemma valid_mask_vm_rights[simp]:
-  "mask_vm_rights V R \<in> valid_vm_rights"
-  by (simp add: mask_vm_rights_def)
-
-
 lemma vs_lookup_and_unique_refs:
   "\<lbrakk>(ref \<rhd> p) s; caps_of_state s cptr = Some cap; table_cap_ref cap = Some ref';
     p \<in> obj_refs cap; valid_vs_lookup s; unique_table_refs (caps_of_state s)\<rbrakk>

--- a/proof/invariant-abstract/X64/ArchCSpacePre_AI.thy
+++ b/proof/invariant-abstract/X64/ArchCSpacePre_AI.thy
@@ -161,24 +161,6 @@ lemma unique_table_caps_upd_eqD:
   apply (simp add: if_distrib split:if_splits)
   done
 
-(* FIXME: unused *)
-lemma set_untyped_cap_as_full_not_final_not_pg_cap:
-  "\<lbrace>\<lambda>s. (\<exists>a b. (a, b) \<noteq> dest \<and> \<not> is_pg_cap cap'
-            \<and> cte_wp_at (\<lambda>cap. gen_obj_refs cap = gen_obj_refs cap' \<and> \<not> is_pg_cap cap) (a, b) s)
-      \<and> cte_wp_at ((=) src_cap) src s\<rbrace>
-  set_untyped_cap_as_full src_cap cap src
-  \<lbrace>\<lambda>_ s.(\<exists>a b. (a, b) \<noteq> dest \<and> \<not> is_pg_cap cap'
-            \<and> cte_wp_at (\<lambda>cap. gen_obj_refs cap = gen_obj_refs cap' \<and> \<not> is_pg_cap cap) (a, b) s)\<rbrace>"
-  apply (rule hoare_pre)
-  apply (wp hoare_vcg_ex_lift)
-   apply (rule_tac Q = "cte_wp_at Q slot"
-               and Q'="cte_wp_at ((=) src_cap) src" for Q slot in P_bool_lift' )
-    apply (wp set_untyped_cap_as_full_cte_wp_at)
-    subgoal by (auto simp: cte_wp_at_caps_of_state is_cap_simps masked_as_full_def cap_bits_untyped_def)
-   apply (wp set_untyped_cap_as_full_cte_wp_at_neg)
-   apply (auto simp: cte_wp_at_caps_of_state is_cap_simps masked_as_full_def cap_bits_untyped_def)
-  done
-
 lemma arch_derived_is_device:
   "\<lbrakk>cap_master_arch_cap c = cap_master_arch_cap c';
         is_derived_arch (ArchObjectCap c) (ArchObjectCap c')\<rbrakk>

--- a/proof/invariant-abstract/X64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/X64/ArchIpc_AI.thy
@@ -94,7 +94,7 @@ lemma derive_cap_is_derived [Ipc_AI_assms]:
                     | erule cte_wp_at_weakenE
                     | simp split: cap.split_asm)+)[11]
   apply(wp arch_derive_cap_is_derived)
-  apply(clarify, drule cte_wp_at_eqD, clarify)
+  apply(clarify, drule cte_wp_at_norm, clarify)
   apply(frule(1) cte_wp_at_valid_objs_valid_cap)
   apply(erule cte_wp_at_weakenE)
   apply(clarsimp simp: valid_cap_def)

--- a/proof/invariant-abstract/X64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/X64/ArchRetype_AI.thy
@@ -177,13 +177,6 @@ crunch pspace_respects_device_region[wp]: copy_global_mappings "pspace_respects_
 crunch cap_refs_respects_device_region[wp]: copy_global_mappings "cap_refs_respects_device_region"
   (wp: crunch_wps simp: set_arch_obj_simps)
 
-(* FIXME: move to VSpace_R *)
-lemma vs_refs_add_one'':
-  "p \<in> kernel_mapping_slots \<Longrightarrow>
-   vs_refs (ArchObj (PageMapL4 (pml4(p := pml4e)))) =
-   vs_refs (ArchObj (PageMapL4 pml4))"
- by (auto simp: vs_refs_def graph_of_def split: if_split_asm)
-
 lemma glob_vs_refs_add_one':
   "glob_vs_refs (ArchObj (PageMapL4 (pm(p := pml4e)))) =
    glob_vs_refs (ArchObj (PageMapL4 pm))

--- a/proof/invariant-abstract/X64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/X64/ArchVSpace_AI.thy
@@ -623,44 +623,6 @@ lemma lookup_pdpt_slot_is_aligned:
   apply (simp add: bit_simps)
   done
 
-(* FIXME x64: need pd, pt versions of this *)
-lemma lookup_pd_slot_is_aligned:
-  "\<lbrace>(\<exists>\<rhd> pm) and K (vmsz_aligned vptr sz) and K (is_aligned pm pml4_bits)
-    and valid_arch_state and valid_vspace_objs and equal_kernel_mappings
-    and pspace_aligned and valid_global_objs\<rbrace>
-     lookup_pd_slot pm vptr
-   \<lbrace>\<lambda>rv s. is_aligned rv word_size_bits\<rbrace>,-"
-  oops (*
-  apply (simp add: lookup_pd_slot_def)
-  apply (rule hoare_pre)
-   apply (wp get_pdpte_wp hoare_vcg_all_lift_R | wpc | simp)+
-   apply (wp (once) hoare_drop_imps)
-   apply (wp hoare_vcg_all_lift_R hoare_vcg_ex_lift_R)
-  apply (clarsimp simp: get_pd_index_def bit_simps)
-  apply (subgoal_tac "is_aligned (ptrFromPAddr x) word_size_bits")
-  apply (clarsimp simp: lookup_pml4_slot_eq)
-  apply (frule(2) valid_arch_objsD[rotated])
-  apply simp
-  apply (rule is_aligned_add)
-   apply (case_tac "ucast (lookup_pml4_slot pm vptr && mask pml4_bits >> word_size_bits) \<in> kernel_mapping_slots")
-    apply (frule kernel_mapping_slots_empty_pml4eI)
-     apply (simp add: obj_at_def)+
-    apply (erule_tac x="ptrFromPAddr x" in allE)
-    apply (simp add: pml4e_ref_def)
-    apply (erule is_aligned_weaken[OF is_aligned_global_pdpt])
-      apply ((simp add: invs_psp_aligned invs_arch_objs invs_arch_state
-                        pdpt_bits_def pageBits_def bit_simps
-                 split: vmpage_size.split)+)[3]
-   apply (drule_tac x="ucast (lookup_pml4_slot pm vptr && mask pml4_bits >> word_size_bits)" in bspec, simp)
-   apply (clarsimp simp: obj_at_def a_type_def)
-   apply (simp split: Structures_A.kernel_object.split_asm if_split_asm
-                     arch_kernel_obj.split_asm)
-   apply (erule is_aligned_weaken[OF pspace_alignedD], simp)
-   apply (simp add: obj_bits_def bit_simps  split: vmpage_size.splits)
-  apply (rule is_aligned_shiftl)
-  apply (simp add: bit_simps)
-  done *)
-
 (* FIXME: remove *)
 lemmas page_directory_at_aligned_pd_bits = is_aligned_pd
 

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -7230,7 +7230,7 @@ next
             apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps)
            apply (clarsimp simp: cte_wp_at_ctes_of)
            apply (frule cte_wp_valid_cap[unfolded cte_wp_at_eq_simp], clarsimp)
-           apply (drule cte_wp_at_eqD[where p="?target"], clarsimp)
+           apply (drule cte_wp_at_norm[where p="?target"], clarsimp)
            apply (erule disjE)
             apply (drule(1) pspace_relation_cte_wp_at
                                 [OF state_relation_pspace_relation],

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -2317,14 +2317,14 @@ lemma updateCap_corres:
        apply (clarsimp simp: cte_wp_at_caps_of_state)
        apply (simp add: is_cap_simps, elim disjE exE, simp_all)[1]
       apply (simp add: eq_commute)
-     apply (drule cte_wp_at_eqD, clarsimp)
+     apply (drule cte_wp_at_norm, clarsimp)
      apply (drule(1) pspace_relation_ctes_ofI, clarsimp+)
      apply (drule(1) capClass_ztc_relation)+
      apply (simp add: capRange_cap_relation obj_ref_of_relation[symmetric])
     apply (rule valid_capAligned, rule ctes_of_valid)
      apply (simp add: cte_wp_at_ctes_of)
     apply clarsimp
-   apply (drule cte_wp_at_eqD, clarsimp)
+   apply (drule cte_wp_at_norm, clarsimp)
    apply (drule(1) pspace_relation_ctes_ofI, clarsimp+)
    apply (simp add: is_cap_simps, elim disjE exE, simp_all add: isCap_simps)[1]
   apply clarsimp

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -2092,7 +2092,7 @@ lemma isFinalCapability_corres':
                          gen_obj_refs_Int
                   split: cap_relation_split_asm arch_cap.split_asm)
   apply clarsimp
-  apply (drule_tac p="(a,b)" in cte_wp_at_eqD)
+  apply (drule_tac p="(a,b)" in cte_wp_at_norm)
   apply clarsimp
   apply (frule_tac slot="(a,b)" in pspace_relation_ctes_ofI, assumption)
     apply fastforce

--- a/proof/refine/ARM_HYP/CNodeInv_R.thy
+++ b/proof/refine/ARM_HYP/CNodeInv_R.thy
@@ -7304,7 +7304,7 @@ next
             apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps)
            apply (clarsimp simp: cte_wp_at_ctes_of)
            apply (frule cte_wp_valid_cap[unfolded cte_wp_at_eq_simp], clarsimp)
-           apply (drule cte_wp_at_eqD[where p="?target"], clarsimp)
+           apply (drule cte_wp_at_norm[where p="?target"], clarsimp)
            apply (erule disjE)
             apply (drule(1) pspace_relation_cte_wp_at
                                 [OF state_relation_pspace_relation],

--- a/proof/refine/ARM_HYP/CSpace1_R.thy
+++ b/proof/refine/ARM_HYP/CSpace1_R.thy
@@ -2482,14 +2482,14 @@ lemma updateCap_corres:
        apply (clarsimp simp: cte_wp_at_caps_of_state)
        apply (simp add: is_cap_simps, elim disjE exE, simp_all)[1]
       apply (simp add: eq_commute)
-     apply (drule cte_wp_at_eqD, clarsimp)
+     apply (drule cte_wp_at_norm, clarsimp)
      apply (drule(1) pspace_relation_ctes_ofI, clarsimp+)
      apply (drule(1) capClass_ztc_relation)+
      apply (simp add: capRange_cap_relation obj_ref_of_relation[symmetric])
     apply (rule valid_capAligned, rule ctes_of_valid)
      apply (simp add: cte_wp_at_ctes_of)
     apply clarsimp
-   apply (drule cte_wp_at_eqD, clarsimp)
+   apply (drule cte_wp_at_norm, clarsimp)
    apply (drule(1) pspace_relation_ctes_ofI, clarsimp+)
    apply (simp add: is_cap_simps, elim disjE exE, simp_all add: isCap_simps)[1]
   apply clarsimp

--- a/proof/refine/ARM_HYP/Finalise_R.thy
+++ b/proof/refine/ARM_HYP/Finalise_R.thy
@@ -2098,7 +2098,7 @@ lemma isFinalCapability_corres':
                          gen_obj_refs_Int
                   split: cap_relation_split_asm arch_cap.split_asm)
   apply clarsimp
-  apply (drule_tac p="(a,b)" in cte_wp_at_eqD)
+  apply (drule_tac p="(a,b)" in cte_wp_at_norm)
   apply clarsimp
   apply (frule_tac slot="(a,b)" in pspace_relation_ctes_ofI, assumption)
     apply fastforce

--- a/proof/refine/RISCV64/CNodeInv_R.thy
+++ b/proof/refine/RISCV64/CNodeInv_R.thy
@@ -7235,7 +7235,7 @@ next
             apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps)
            apply (clarsimp simp: cte_wp_at_ctes_of)
            apply (frule cte_wp_valid_cap[unfolded cte_wp_at_eq_simp], clarsimp)
-           apply (drule cte_wp_at_eqD[where p="?target"], clarsimp)
+           apply (drule cte_wp_at_norm[where p="?target"], clarsimp)
            apply (erule disjE)
             apply (drule(1) pspace_relation_cte_wp_at
                                 [OF state_relation_pspace_relation],

--- a/proof/refine/RISCV64/CSpace1_R.thy
+++ b/proof/refine/RISCV64/CSpace1_R.thy
@@ -2474,14 +2474,14 @@ lemma updateCap_corres:
        apply (clarsimp simp: cte_wp_at_caps_of_state)
        apply (simp add: is_cap_simps, elim disjE exE, simp_all)[1]
       apply (simp add: eq_commute)
-     apply (drule cte_wp_at_eqD, clarsimp)
+     apply (drule cte_wp_at_norm, clarsimp)
      apply (drule(1) pspace_relation_ctes_ofI, clarsimp+)
      apply (drule(1) capClass_ztc_relation)+
      apply (simp add: capRange_cap_relation obj_ref_of_relation[symmetric])
     apply (rule valid_capAligned, rule ctes_of_valid)
      apply (simp add: cte_wp_at_ctes_of)
     apply clarsimp
-   apply (drule cte_wp_at_eqD, clarsimp)
+   apply (drule cte_wp_at_norm, clarsimp)
    apply (drule(1) pspace_relation_ctes_ofI, clarsimp+)
    apply (simp add: is_cap_simps, elim disjE exE, simp_all add: isCap_simps)[1]
   apply clarsimp

--- a/proof/refine/RISCV64/Finalise_R.thy
+++ b/proof/refine/RISCV64/Finalise_R.thy
@@ -2148,7 +2148,7 @@ lemma isFinalCapability_corres':
                          gen_obj_refs_Int
                   split: cap_relation_split_asm arch_cap.split_asm)
   apply clarsimp
-  apply (drule_tac p="(a,b)" in cte_wp_at_eqD)
+  apply (drule_tac p="(a,b)" in cte_wp_at_norm)
   apply clarsimp
   apply (frule_tac slot="(a,b)" in pspace_relation_ctes_ofI, assumption)
     apply fastforce

--- a/proof/refine/X64/CNodeInv_R.thy
+++ b/proof/refine/X64/CNodeInv_R.thy
@@ -7377,7 +7377,7 @@ next
             apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps)
            apply (clarsimp simp: cte_wp_at_ctes_of)
            apply (frule cte_wp_valid_cap[unfolded cte_wp_at_eq_simp], clarsimp)
-           apply (drule cte_wp_at_eqD[where p="?target"], clarsimp)
+           apply (drule cte_wp_at_norm[where p="?target"], clarsimp)
            apply (erule disjE)
             apply (drule(1) pspace_relation_cte_wp_at
                                 [OF state_relation_pspace_relation],

--- a/proof/refine/X64/CSpace1_R.thy
+++ b/proof/refine/X64/CSpace1_R.thy
@@ -2483,14 +2483,14 @@ lemma updateCap_corres:
        apply (clarsimp simp: cte_wp_at_caps_of_state)
        apply (simp add: is_cap_simps, elim disjE exE, simp_all)[1]
       apply (simp add: eq_commute)
-     apply (drule cte_wp_at_eqD, clarsimp)
+     apply (drule cte_wp_at_norm, clarsimp)
      apply (drule(1) pspace_relation_ctes_ofI, clarsimp+)
      apply (drule(1) capClass_ztc_relation)+
      apply (simp add: capRange_cap_relation obj_ref_of_relation[symmetric])
     apply (rule valid_capAligned, rule ctes_of_valid)
      apply (simp add: cte_wp_at_ctes_of)
     apply clarsimp
-   apply (drule cte_wp_at_eqD, clarsimp)
+   apply (drule cte_wp_at_norm, clarsimp)
    apply (drule(1) pspace_relation_ctes_ofI, clarsimp+)
    apply (simp add: is_cap_simps, elim disjE exE, simp_all add: isCap_simps)[1]
   apply clarsimp

--- a/proof/refine/X64/Finalise_R.thy
+++ b/proof/refine/X64/Finalise_R.thy
@@ -2268,7 +2268,7 @@ lemma isFinalCapability_corres':
                          gen_obj_refs_Int
                   split: cap_relation_split_asm arch_cap.split_asm)
   apply clarsimp
-  apply (drule_tac p="(a,b)" in cte_wp_at_eqD)
+  apply (drule_tac p="(a,b)" in cte_wp_at_norm)
   apply clarsimp
   apply (frule_tac slot="(a,b)" in pspace_relation_ctes_ofI, assumption)
     apply fastforce

--- a/proof/sep-capDL/Frame_SD.thy
+++ b/proof/sep-capDL/Frame_SD.thy
@@ -418,8 +418,6 @@ lemma sep_map_o_conj:
   apply (clarsimp simp:sep_map_c_def sep_disj_sep_state_def
      sep_map_general_def sep_state_disj_def map_disj_def)
   apply (clarsimp simp:dom_object_to_sep_state)
-  apply (rule conjI)
-   apply blast
   apply (case_tac s,simp)
   apply (rule ext)
   apply (case_tac "x \<in> {ptr}\<times>UNIV")


### PR DESCRIPTION
This is an attempt to remove some `FIXME`s from ainvs.

* move lots of lemmas up to `lib`.
* replace `cte_wp_at_eqD` with `cte_wp_at_norm` (equal lemmas)
* `pd_shifting_gen` generalises `pd_shifting'` in 2 architectures
* remove some redundant crunch lemmas

I could have kept going with this to make a much larger pull-request, but thought I should check that I'm moving things to the right places.

Testboard here: https://bamboo.ts.data61.csiro.au/browse/L4V-GHTESTBOARD60-1
