### PR TITLE
Support crunching lifted monadic functions

### DIFF
--- a/lib/crunch-cmd.ML
+++ b/lib/crunch-cmd.ML
@@ -693,17 +693,39 @@ fun proof_failed_warnings const stack cfg wp ctxt t =
   else (warn_const_ignored const cfg ctxt; warn_helper_thms wp ctxt t;
         warn_stack const stack ctxt; all_tac t)
 
+fun collect_preconds (const, mapply, goal) current_goal pre extra ctxt =
+  let
+    val precond = get_inst_precond ctxt pre extra (mapply, goal);
+    val precond' = combine_preconds ctxt (get_precond current_goal) (the_list precond);
+  in Instance.put_precond precond' current_goal end
+  handle ERROR s =>
+    let
+      val default_precond = make_goal (read_const ctxt const) const pre extra ctxt
+        |> get_precond;
+      val goal_precond = Thm.concl_of goal |> HOLogic.dest_Trueprop |> get_precond;
+      val _ =
+        if not (Term.aconv_untyped (goal_precond, default_precond))
+        then (["Failed to collect preconditions from " ^
+               Proof_Context.markup_const ctxt const ^ "; continuing without them.",
+               "This might be due to monadic constants with different state spaces \
+                \being crunched."]
+              |> map Pretty.para |> Pretty.chunks |> Pretty.string_of |> warning;
+              debug_trace s)
+        else ()
+    in current_goal end;
+
 fun crunch cfg pre extra stack const' thms =
   let
     val ctxt = #ctxt cfg |> Context_Position.set_visible false;
     val const = real_const_from_name const' (#nmspce cfg) ctxt;
   in
     let
-      val _ = "crunching constant: " ^ const |> writeln;
+      val _ = "crunching constant: " ^ Proof_Context.markup_const ctxt const |> writeln;
       val const_term = read_const ctxt const;
       val goal = make_goal const_term const pre extra ctxt
                  handle exn => handle_int exn (raise WrongType);
-      val goal_prop = HOLogic.mk_Trueprop goal;
+      val _ = debug_trace_bl
+        [K (Pretty.str "goal: "), fn () => Syntax.pretty_term ctxt goal]
     in (* first check: has this constant already been done or supplied? *)
       case crunch_known_rule cfg const thms goal
         of SOME thm => (SOME thm, [])
@@ -725,19 +747,17 @@ fun crunch cfg pre extra stack const' thms =
           val ctxt'' = ctxt' addsimps ((#simps cfg) @ goals')
               |> Splitter.del_split split_if
 
-          fun collect_preconds pre =
-            let val preconds = map_filter (fn (x, SOME y) => SOME (x, y) | (_, NONE) => NONE) (map snd ms ~~ goals)
-                                                    |> map_filter (get_inst_precond ctxt'' pre extra);
-              val precond = combine_preconds ctxt'' (get_precond goal) preconds;
-            in Instance.put_precond precond goal |> HOLogic.mk_Trueprop end;
-          val goal_prop2 = if Instance.has_preconds then collect_preconds pre else goal_prop;
+          fun collect_preconds' pre =
+            let val preconds = map_filter (fn ((x, y), SOME z) => SOME (x, y, z) | (_, NONE) => NONE)
+                                          (ms ~~ goals);
+            in fold (fn pre' => fn goal => collect_preconds pre' goal pre extra ctxt'') preconds goal end;
+          val goal' = if Instance.has_preconds then collect_preconds' pre else goal;
+          val goal_prop = HOLogic.mk_Trueprop goal';
 
-          val ctxt''' = ctxt'' |> Proof_Context.augment goal_prop2
-          val _ = writeln ("attempting: " ^ Syntax.string_of_term ctxt''' goal_prop2);
-
+          val ctxt''' = ctxt'' |> Proof_Context.augment goal_prop
+          val _ = writeln ("attempting: " ^ Syntax.string_of_term ctxt''' goal_prop);
           fun wp' wp_rules = wp ctxt (map snd (thms @ #wp_rules cfg) @ goals' @ wp_rules)
-
-          val thm = Goal.prove_future ctxt''' [] [] goal_prop2
+          val thm = Goal.prove_future ctxt''' [] [] goal_prop
               ( (*DupSkip.goal_prove_wrapper *) (fn _ =>
               resolve_tac ctxt''' [rule] 1
                 THEN maybe_cheat_tac ctxt'''

--- a/proof/invariant-abstract/CNodeInv_AI.thy
+++ b/proof/invariant-abstract/CNodeInv_AI.thy
@@ -187,7 +187,7 @@ locale CNodeInv_AI =
         \<Longrightarrow> (ptr, nat_to_cref (zombie_cte_bits zbits) m) \<in> cte_refs (Zombie ptr zbits n) irqn"
   assumes finalise_cap_emptyable[wp]:
     "\<And>sl c f.
-      \<lbrace>emptyable sl and (invs and valid_mdb)\<rbrace>
+      \<lbrace>emptyable sl and invs\<rbrace>
         finalise_cap c f
       \<lbrace>\<lambda>_. emptyable sl :: 'state_ext state \<Rightarrow> bool\<rbrace>"
   assumes deleting_irq_handler_emptyable[wp]:


### PR DESCRIPTION
Previously, if `crunch` encountered monadic constants with different state spaces then it would throw a type unification failure due to trying to combine the different preconditions. This meant that any lifted functions had to be explicitly ignored.

This PR changes `crunch` so that it catches and ignores the type unification failure. This allows it to process lifted functions and even prove simple properties about them. However, if the lifted functions require any side conditions for the main property being crunched, then these will not be propagated and the proof of the top-level function will most likely fail.

I do not believe that it is possible to propagate these side conditions without manually passing in a state-lifting function, and I have not yet seen a use case that makes it worth exploring this as a feature.

The concrete example where this was observed involves extended_ops in the abstract state, when you have `('a state, unit) nondet_monad` functions calling lifted `(det_ext state, unit) nondet_monad` functions. This is why there is the slightly convoluted `do_extended_op` test case.