### PR TITLE
github: complete "switch proof runs to AWS"

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -9,20 +9,25 @@ on:
     branches:
       - master
       - rt
-  pull_request:
+  # this action needs access to secrets.
+  # The actual test runs in a no-privilege VM, so it's Ok to run on untrusted PRs.
+  pull_request_target:
 
 jobs:
-  aspec:
-    name: ASpec
+  all:
+    name: All
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        arch: [ARM, RISCV64]
+        arch: [ARM, ARM_HYP, RISCV64, X64]
     steps:
     - name: Proofs
-      uses: seL4/ci-actions/aws-proofs@aws-proofs
+      uses: seL4/ci-actions/aws-proofs@master
       with:
         L4V_ARCH: ${{ matrix.arch }}
         isa_branch: ts-2020
-        session: ASpec
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_SSH: ${{ secrets.AWS_SSH }}

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -31,3 +31,8 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_SSH: ${{ secrets.AWS_SSH }}
+    - name: Upload logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: logs-${{ matrix.arch }}
+        path: logs.tar.xz


### PR DESCRIPTION
This completes the previous commit to run all proof tests on reasonably high-powered AWS VMs instead of GitHub runners. All tests run in one go for efficiency.

This needs seL4/ci-actions#113 merged first.

For now we test on each push to master and rt, and for all pull requests. Since runs for fork-PRs need to be approved for the first run, this should be reasonably safe against abuse.

One full run from scratch costs about USD 2.70 of the free, but limited seL4 foundation AWS credits. Most runs will not be from scratch, but if you don't need the results of a run, it's a good idea to cancel. Assuming that, we can do a few thousand test per year, which should be plenty, but we'll monitor cost closely for the first few months.

I'm planning to make the logs a bit prettier, and potentially to upload the full Isabelle logs as build artefacts, but that is a separate step.