### PR TITLE
abstract x64+riscv: clean up some Word_Lib imports

### DIFF
--- a/spec/abstract/RISCV64/ArchDecode_A.thy
+++ b/spec/abstract/RISCV64/ArchDecode_A.thy
@@ -10,7 +10,6 @@ theory ArchDecode_A
 imports
   Interrupt_A
   InvocationLabels_A
-  "Word_Lib.Word_Lib"
   "ExecSpec.InvocationLabels_H"
 begin
 

--- a/spec/abstract/X64/ArchDecode_A.thy
+++ b/spec/abstract/X64/ArchDecode_A.thy
@@ -14,7 +14,6 @@ theory ArchDecode_A
 imports
   Interrupt_A
   InvocationLabels_A
-  "Word_Lib.Word_Lib"
   "ExecSpec.InvocationLabels_H"
 begin
 

--- a/spec/abstract/X64/Machine_A.thy
+++ b/spec/abstract/X64/Machine_A.thy
@@ -13,7 +13,6 @@ chapter "x64 Machine Instantiation"
 
 theory Machine_A
 imports
-  "Word_Lib.WordSetup"
   "Lib.NonDetMonad"
   "ExecSpec.MachineTypes"
   "ExecSpec.MachineOps"


### PR DESCRIPTION
These are already imported upstream.

Signed-off-by: Rafal Kolanski <rafal.kolanski@proofcraft.systems>