### PR TITLE
AInvs projections

### DIFF
--- a/proof/invariant-abstract/DetSchedInvs_AI.thy
+++ b/proof/invariant-abstract/DetSchedInvs_AI.thy
@@ -584,23 +584,15 @@ end
 definition tcb_of :: "kernel_object \<rightharpoonup> tcb" where
   "tcb_of ko \<equiv> case ko of TCB tcb \<Rightarrow> Some tcb | _ \<Rightarrow> None"
 
-lemma tcb_of_simps:
-  "tcb_of (TCB tcb) = Some tcb"
-  "tcb_of (SchedContext sc n) = None"
-  "tcb_of (CNode n cnode) = None"
-  "tcb_of (Endpoint ep) = None"
-  "tcb_of (Notification ntfn) = None"
-  "tcb_of (Reply reply) = None"
-  "tcb_of (ArchObj aobj) = None"
-  by (auto simp: tcb_of_def)
+lemmas tcb_of_simps [simp] = tcb_of_def [split_simps kernel_object.split]
 
-lemma tcb_of_Some:
+lemma tcb_of_Some[simp]:
   "tcb_of ko = Some tcb \<longleftrightarrow> ko = TCB tcb"
-  by (simp add: tcb_of_def split: kernel_object.splits)
+  by (cases ko; simp)
 
 lemma tcb_of_None:
   "tcb_of ko = None \<longleftrightarrow> (\<forall>tcb. ko \<noteq> TCB tcb)"
-  by (simp add: tcb_of_def split: kernel_object.splits)
+  by (cases ko; simp)
 
 definition tcbs_of_kh :: "('obj_ref \<rightharpoonup> kernel_object) \<Rightarrow> 'obj_ref \<rightharpoonup> tcb" where
   "tcbs_of_kh kh \<equiv> kh |> tcb_of"
@@ -721,25 +713,17 @@ lemma etcb_at'_pred_map:
 \<comment> \<open>Project scheduling contexts from the kernel heap\<close>
 
 definition sc_of :: "kernel_object \<rightharpoonup> sched_context" where
-  "sc_of ko \<equiv> case ko of SchedContext sc n \<Rightarrow> Some sc | _ \<Rightarrow> None"
+  "sc_of ko \<equiv> case ko of SchedContext sc _ \<Rightarrow> Some sc | _ \<Rightarrow> None"
 
-lemma sc_of_simps:
-  "sc_of (SchedContext sc n) = Some sc"
-  "sc_of (CNode n cnode) = None"
-  "sc_of (TCB tcb) = None"
-  "sc_of (Endpoint ep) = None"
-  "sc_of (Notification ntfn) = None"
-  "sc_of (Reply reply) = None"
-  "sc_of (ArchObj aobj) = None"
-  by (auto simp: sc_of_def)
+lemmas sc_of_simps [simp] = sc_of_def [split_simps kernel_object.split]
 
-lemma sc_of_Some:
+lemma sc_of_Some[simp]:
   "sc_of ko = Some sc \<longleftrightarrow> (\<exists>n. ko = SchedContext sc n)"
-  by (simp add: sc_of_def split: kernel_object.splits)
+ by (cases ko; simp)
 
 lemma sc_of_None:
   "sc_of ko = None \<longleftrightarrow> (\<forall>sc n. ko \<noteq> SchedContext sc n)"
-  by (simp add: sc_of_def split: kernel_object.splits)
+ by (cases ko; simp)
 
 definition scs_of_kh :: "('obj_ref \<rightharpoonup> kernel_object) \<Rightarrow> 'obj_ref \<rightharpoonup> sched_context" where
   "scs_of_kh kh \<equiv> kh |> sc_of"
@@ -836,53 +820,34 @@ global_interpretation sc_replies:
 \<comment> \<open>Project endpoints from the kernel heap\<close>
 
 definition ep_of :: "kernel_object \<rightharpoonup> endpoint" where
-  "ep_of ko \<equiv> case ko of Endpoint endpoint \<Rightarrow> Some endpoint | _ \<Rightarrow> None"
+  "ep_of ko \<equiv> case ko of Endpoint ep \<Rightarrow> Some ep | _ \<Rightarrow> None"
+
+lemmas ep_of_simps [simp] = ep_of_def [split_simps kernel_object.split]
 
 definition send_q_of :: "endpoint \<rightharpoonup> obj_ref list" where
-  "send_q_of endpoint \<equiv> case endpoint of SendEP q  \<Rightarrow> Some q | _ \<Rightarrow> None"
+  "send_q_of ep \<equiv> case ep of SendEP q \<Rightarrow> Some q | _ \<Rightarrow> None"
+
+lemmas send_q_of_simps [simp] = send_q_of_def [split_simps endpoint.split]
 
 definition recv_q_of :: "endpoint \<rightharpoonup> obj_ref list" where
-  "recv_q_of endpoint \<equiv> case endpoint of RecvEP q  \<Rightarrow> Some q | _ \<Rightarrow> None"
+  "recv_q_of ep \<equiv> case ep of RecvEP q \<Rightarrow> Some q | _ \<Rightarrow> None"
 
-lemma ep_of_simps:
-  "ep_of (SchedContext sc n) = None"
-  "ep_of (CNode n cnode) = None"
-  "ep_of (TCB tcb) = None"
-  "ep_of (Endpoint endpoint) = Some endpoint"
-  "ep_of (Notification ntfn) = None"
-  "ep_of (Reply reply) = None"
-  "ep_of (ArchObj aobj) = None"
-  "send_q_of IdleEP = None"
-  "send_q_of (SendEP q) = Some q"
-  "send_q_of (RecvEP q) = None"
-  "recv_q_of IdleEP = None"
-  "recv_q_of (SendEP q) = None"
-  "recv_q_of (RecvEP q) = Some q"
-  by (auto simp: ep_of_def send_q_of_def recv_q_of_def)
+lemmas recv_q_of_simps [simp] = recv_q_of_def [split_simps endpoint.split]
 
-lemma ep_of_Some:
+lemma ep_of_Some[simp]:
   "ep_of ko = Some ep \<longleftrightarrow> ko = Endpoint ep"
-  by (simp add: ep_of_def split: kernel_object.splits)
+  by (cases ko; simp)
 
 lemma ep_of_None:
   "ep_of ko = None \<longleftrightarrow> (\<forall>ep. ko \<noteq> Endpoint ep)"
-  by (simp add: ep_of_def split: kernel_object.splits)
+  by (cases ko; simp)
 
-lemma send_q_of_Some:
-  "send_q_of ep = Some q \<longleftrightarrow> ep = SendEP q"
-  by (simp add: send_q_of_def split: endpoint.splits)
-
-lemma send_q_of_None:
-  "send_q_of ep = None \<longleftrightarrow> (\<forall>q. ep \<noteq> SendEP q)"
-  by (simp add: send_q_of_def split: endpoint.splits)
-
-lemma recv_q_of_Some:
-  "recv_q_of ep = Some q \<longleftrightarrow> ep = RecvEP q"
-  by (simp add: recv_q_of_def split: endpoint.splits)
-
-lemma recv_q_of_None:
-  "recv_q_of ep = None \<longleftrightarrow> (\<forall>q. ep \<noteq> RecvEP q)"
-  by (simp add: recv_q_of_def split: endpoint.splits)
+lemma shows
+  send_q_of_Some[simp]: "send_q_of ep = Some q \<longleftrightarrow> ep = SendEP q" and
+  send_q_of_None: "send_q_of ep = None \<longleftrightarrow> (\<forall>q. ep \<noteq> SendEP q)" and
+  recv_q_of_Some[simp]: "recv_q_of ep = Some q \<longleftrightarrow> ep = RecvEP q" and
+  recv_q_of_None: "recv_q_of ep = None \<longleftrightarrow> (\<forall>q. ep \<noteq> RecvEP q)"
+  by (cases ep; simp)+
 
 definition eps_of_kh :: "('obj_ref \<rightharpoonup> kernel_object) \<Rightarrow> 'obj_ref \<rightharpoonup> endpoint" where
   "eps_of_kh kh \<equiv> kh |> ep_of"
@@ -916,6 +881,46 @@ global_interpretation ep_recv_qs:
   opt_map_opt_map_cons_def_locale _ ep_of eps_of_kh Endpoint recv_q_of RecvEP ep_recv_qs_of_eps
   using ep_recv_qs_of_eps_def recv_q_of_None recv_q_of_Some by unfold_locales
 
+\<comment> \<open>Notifications\<close>
+
+\<comment> \<open>Project notifications from the kernel heap\<close>
+
+definition ntfn_of :: "kernel_object \<rightharpoonup> notification" where
+  "ntfn_of ko \<equiv> case ko of Notification ntfn \<Rightarrow> Some ntfn | _ \<Rightarrow> None"
+
+lemmas ntfn_of_simps [simp] = ntfn_of_def [split_simps kernel_object.split]
+
+lemma ntfn_of_Some[simp]:
+  "ntfn_of ko = Some obj \<longleftrightarrow> ko = Notification obj"
+  by (cases ko; simp)
+
+lemma ntfn_of_None:
+  "ntfn_of ko = None \<longleftrightarrow> (\<forall>ntfn. ko \<noteq> Notification ntfn)"
+  by (cases ko; simp)
+
+abbreviation ntfns_of :: "'z state \<Rightarrow> obj_ref \<rightharpoonup> Structures_A.notification" where
+  "ntfns_of \<equiv> (\<lambda>s. kheap s |> ntfn_of)"
+
+\<comment> \<open>Replies\<close>
+
+\<comment> \<open>Project replies from the kernel heap\<close>
+
+definition reply_of :: "kernel_object \<rightharpoonup> reply" where
+  "reply_of ko \<equiv> case ko of Reply reply \<Rightarrow> Some reply | _ \<Rightarrow> None"
+
+lemmas reply_of_simps [simp] = reply_of_def [split_simps kernel_object.split]
+
+lemma reply_of_Some[simp]:
+  "reply_of ko = Some obj \<longleftrightarrow> ko = Reply obj"
+  by (cases ko; simp)
+
+lemma reply_of_None:
+  "reply_of ko = None \<longleftrightarrow> (\<forall>reply. ko \<noteq> Reply reply)"
+  by (cases ko; simp)
+
+abbreviation replies_of :: "'z state \<Rightarrow> obj_ref \<rightharpoonup> Structures_A.reply" where
+  "replies_of \<equiv> (\<lambda>s. kheap s |> reply_of)"
+
 \<comment> \<open>Heap simplification rules\<close>
 
 lemmas vs_pred_map_simps =
@@ -948,9 +953,6 @@ lemmas vs_pred_map_simps =
   pred_map_def[where m="kheap s" for s :: "'z state"]
 
 lemmas vs_heap_simps =
-  tcb_of_simps
-  sc_of_simps
-  ep_of_simps
   tcb_heap.simps
   tcb_sts.simps
   tcb_scps.simps

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -21857,7 +21857,7 @@ lemma retype_region_not_pred_map_tcbs_of:
   apply (wpsimp)
   apply (clarsimp simp: tcbs_of_kh_foldr_opt map_set_in)
   using assms
-  apply (cases obj; clarsimp simp: default_object_def tcb_of_def tcb_heap.all_simps
+  apply (cases obj; clarsimp simp: default_object_def tcb_heap.all_simps
                                    pred_map_upd_stronger split: if_splits)
   done
 

--- a/proof/refine/ARM/ArchAcc_R.thy
+++ b/proof/refine/ARM/ArchAcc_R.thy
@@ -913,7 +913,7 @@ lemma set_pd_corres [@lift_corres_args, corres]:
                split: Structures_A.kernel_object.splits arch_kernel_obj.splits)
   apply (rule conjI)
    apply (fastforce simp: sc_replies_relation_def sc_replies_of_scs_def map_project_def
-                          scs_of_kh_def opt_map_def sc_of_def projectKO_opts_defs)
+                          scs_of_kh_def opt_map_def projectKO_opts_defs)
   apply (rule conjI)
    apply (clarsimp simp add: ghost_relation_def)
    apply (erule_tac x="p && ~~ mask pd_bits" in allE)+
@@ -987,7 +987,7 @@ lemma set_pt_corres [@lift_corres_args, corres]:
                split: Structures_A.kernel_object.splits arch_kernel_obj.splits)
   apply (rule conjI)
    apply (fastforce simp: sc_replies_relation_def sc_replies_of_scs_def map_project_def
-                          scs_of_kh_def opt_map_def sc_of_def projectKO_opts_defs)
+                          scs_of_kh_def opt_map_def projectKO_opts_defs)
   apply (rule conjI)
    apply (clarsimp simp add: ghost_relation_def)
    apply (erule_tac x="p && ~~ mask pt_bits" in allE)+

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -4876,7 +4876,7 @@ lemma schedContextUnbindReply_corres:
          apply (fastforce simp: obj_at_def is_sc_obj_def obj_at'_def)
         apply (fastforce simp: obj_at'_def projectKOs opt_map_def)
        apply (fastforce simp: obj_at'_real_def opt_map_def ko_wp_at'_def sc_replies_of_scs_def
-                              map_project_def scs_of_kh_def sc_of_def)
+                              map_project_def scs_of_kh_def)
       apply wpsimp+
     apply (fastforce simp: sym_refs_asrt_def)+
   done

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -591,8 +591,7 @@ lemma sr_inv_sc_with_reply_None_helper:
     apply (prop_tac "rp \<notin> set replies")
      apply (drule_tac sc=scp in valid_replies_sc_with_reply_None, simp)
      apply (clarsimp simp: sc_replies_sc_at_def obj_at_def is_reply sc_replies_of_scs_def
-                           scs_of_kh_def map_project_def sc_of_def)
-     apply (rename_tac ko; case_tac ko; simp)
+                           scs_of_kh_def map_project_def)
     apply (erule (1) heap_ls_prev_not_in)
     apply (fastforce elim!: sym_refs_replyNext_replyPrev_sym[THEN iffD1] simp: opt_map_red)
    apply (wpsimp wp: updateReply_valid_objs' simp: valid_reply'_def obj_at'_def)
@@ -782,7 +781,7 @@ lemma replyRemoveTCB_corres:
                                      simp: obj_at_def is_sc_obj_def state_relation_def obj_at'_def
                                            projectKOs opt_map_def)
                   apply (clarsimp simp: sc_replies_of_scs_def map_project_def opt_map_def
-                                        scs_of_kh_def sc_of_def)
+                                        scs_of_kh_def)
                  apply (fastforce dest!: state_relation_pspace_relation sc_at_cross
                                          valid_objs_valid_sched_context_size
                                    simp: obj_at_def is_sc_obj)

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -1343,7 +1343,7 @@ lemma set_other_obj_corres:
   apply (simp add: sc_replies_relation_def)
   apply (clarsimp simp: sc_replies_of_scs_def map_project_def scs_of_kh_def)
   apply (drule_tac x=p in spec)
-  apply (rule conjI; clarsimp simp: sc_of_def split: Structures_A.kernel_object.split_asm if_split_asm)
+  apply (rule conjI; clarsimp split: Structures_A.kernel_object.split_asm if_split_asm)
    apply(clarsimp simp: a_type_def is_other_obj_relation_type_def)
   apply (rename_tac sc n)
   apply (prop_tac "typ_at' (koTypeOf (injectKO ob')) ptr b")
@@ -1354,7 +1354,7 @@ lemma set_other_obj_corres:
   apply (drule replyPrevs_of_non_reply_update[simplified])
    apply (clarsimp simp: other_obj_relation_def; cases ob; cases "injectKO ob'";
           simp split: arch_kernel_obj.split_asm)
-  apply (clarsimp simp add: opt_map_def sc_of_def)
+  apply (clarsimp simp add: opt_map_def)
   done
 
 lemmas obj_at_simps = obj_at_def obj_at'_def projectKOs map_to_ctes_upd_other
@@ -1459,9 +1459,8 @@ lemma set_reply_corres: (* for reply update that doesn't touch the reply stack *
     apply (simp add: sc_replies_relation_def)
     apply (clarsimp simp: sc_replies_of_scs_def map_project_def scs_of_kh_def)
     apply (drule_tac x=p in spec)
-    apply (rule conjI; clarsimp simp: sc_of_def split: Structures_A.kernel_object.split_asm if_split_asm)
     by (subst replyPrevs_of_replyPrev_same_update[simplified, where ob'=ae', simplified];
-        simp add: typ_at'_def ko_wp_at'_def obj_at'_def project_inject opt_map_def sc_of_def)
+        simp add: typ_at'_def ko_wp_at'_def obj_at'_def project_inject opt_map_def)
   qed
 
 lemma setReply_not_queued_corres: (* for reply updates on replies not in fst ` replies_with_sc *)
@@ -1530,7 +1529,6 @@ lemma setReply_not_queued_corres: (* for reply updates on replies not in fst ` r
       (* sc_replies_relation *)
     apply (simp add: sc_replies_relation_def)
     apply (clarsimp simp: sc_replies_of_scs_def map_project_def scs_of_kh_def)
-    apply (rule conjI; clarsimp simp: sc_of_def split: Structures_A.kernel_object.split_asm if_split_asm)
     apply (drule_tac x=p in spec)
    apply (subgoal_tac "((scs_of' b)(ptr := sc_of' (KOReply r2)) |> scReply) p = scReplies_of b p")
      apply simp
@@ -1538,9 +1536,9 @@ lemma setReply_not_queued_corres: (* for reply updates on replies not in fst ` r
      apply (erule heap_path_heap_upd_not_in)
      apply (clarsimp simp: sc_at_pred_n_def obj_at_def replies_with_sc_def image_def)
      apply (drule_tac x=p in spec)
-     apply (simp add: typ_at'_def ko_wp_at'_def obj_at'_def project_inject opt_map_def sc_of_def)
-    apply (simp add: typ_at'_def ko_wp_at'_def obj_at'_def project_inject opt_map_def sc_of_def)
-   apply (simp add: typ_at'_def ko_wp_at'_def obj_at'_def project_inject opt_map_def sc_of_def)
+     apply (simp add: typ_at'_def ko_wp_at'_def obj_at'_def project_inject opt_map_def)
+    apply (simp add: typ_at'_def ko_wp_at'_def obj_at'_def project_inject opt_map_def)
+   apply (simp add: typ_at'_def ko_wp_at'_def obj_at'_def project_inject opt_map_def)
   done
   qed
 
@@ -1633,7 +1631,7 @@ lemma setSchedContext_corres:
       (* sc_replies_relation *)
     apply (clarsimp simp: sc_replies_relation_def sc_replies_of_scs_def map_project_def scs_of_kh_def)
     apply (drule_tac x=p in spec)
-    by (auto simp: typ_at'_def ko_wp_at'_def opt_map_def sc_of_def projectKO_opts_defs
+    by (auto simp: typ_at'_def ko_wp_at'_def opt_map_def projectKO_opts_defs
             split: if_splits)
 qed
 
@@ -3729,7 +3727,7 @@ lemma state_refs_of_cross_eq:
    apply (frule sc_replies_relation_scReplies_of)
      apply (fastforce simp: obj_at_def is_sc_obj_def)
     apply (clarsimp simp: opt_map_def)
-   apply (clarsimp simp: opt_map_def sc_replies_of_scs_def map_project_def scs_of_kh_def sc_of_def)
+   apply (clarsimp simp: opt_map_def sc_replies_of_scs_def map_project_def scs_of_kh_def)
   apply (clarsimp simp: reply_relation_def split: Structures_A.ntfn.splits)
   done
 
@@ -3947,7 +3945,7 @@ abbreviation scs_of2 :: "'z state \<Rightarrow> obj_ref \<rightharpoonup> Struct
 
 lemma scs_of_rewrite:
   "scs_of s = scs_of2 s"
-  by (fastforce simp: sc_heap_of_state_def sc_of_def opt_map_def
+  by (fastforce simp: sc_heap_of_state_def opt_map_def
               split: option.splits Structures_A.kernel_object.splits)
 
 abbreviation
@@ -3955,7 +3953,7 @@ abbreviation
 
 lemma sc_replies_of_rewrite:
   "sc_replies_of s = sc_replies_of2 s"
-  by (fastforce simp: sc_heap_of_state_def sc_replies_of_scs_def sc_of_def opt_map_def map_project_def
+  by (fastforce simp: sc_heap_of_state_def sc_replies_of_scs_def opt_map_def map_project_def
               split: option.splits Structures_A.kernel_object.splits)
 
 definition
@@ -4028,7 +4026,7 @@ lemma sc_refills_sc_at_rewrite:
                split: option.splits Structures_A.kernel_object.split_asm)
 
 lemmas projection_rewrites = pred_map_rewrite scs_of_rewrite is_active_sc_rewrite
-                             sc_heap_of_state_def sc_of_def sc_refills_sc_at_rewrite
+                             sc_heap_of_state_def sc_refills_sc_at_rewrite
                              active_sc_at'_rewrite valid_refills_rewrite round_robin_rewrite
 
 lemma is_active_sc'_cross:

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -1167,7 +1167,7 @@ lemma sc_replies_relation_prevs_list':
      kheap s scp = Some (kernel_object.SchedContext sc n)\<rbrakk>
     \<Longrightarrow> heap_ls (replyPrevs_of s') (scReplies_of s' scp) (sc_replies sc)"
   apply (clarsimp simp: sc_replies_relation_def sc_replies_of_scs_def scs_of_kh_def map_project_def)
-  apply (clarsimp simp: sc_of_def opt_map_red)
+  apply (clarsimp simp: opt_map_red)
   done
 
 lemma sc_replies_relation_sc_with_reply_cross_eq_pred:
@@ -1178,7 +1178,7 @@ lemma sc_replies_relation_sc_with_reply_cross_eq_pred:
    apply (rule_tac x="the (sc_replies_of2 s scp)" in exI)
   apply (clarsimp simp: sc_replies_relation_def sc_replies_of_scs_def scs_of_kh_def map_project_def)
   apply (drule_tac x=scp and y="sc_replies sc" in spec2)
-  apply (clarsimp simp: sc_of_def opt_map_def projectKO_opt_sc split: option.splits)
+  apply (clarsimp simp: opt_map_def projectKO_opt_sc split: option.splits)
   apply (case_tac "scReplies_of s' scp", simp)
   apply (rename_tac p)
   apply (drule pspace_relation_sc_at[where scp=scp])
@@ -1298,7 +1298,7 @@ lemma sc_with_reply_replyNext_Some:
   apply (clarsimp simp: obj_at_def is_sc_obj is_reply)
   apply (drule (1) sc_replies_relation_sc_with_reply_heap_path[rotated])
   apply (prop_tac "the (sc_replies_of s scp) = sc_replies sc")
-   apply (clarsimp simp: sc_replies_of_scs_def sc_of_def scs_of_kh_def opt_map_def map_project_def)
+   apply (clarsimp simp: sc_replies_of_scs_def scs_of_kh_def opt_map_def map_project_def)
   apply clarsimp
   apply (prop_tac "replyPrevs_of s' nxt_rp = Some rp")
    apply (erule (1) sym_refs_replyNext_replyPrev_sym[THEN iffD1])
@@ -1840,7 +1840,7 @@ proof -
       apply (drule_tac x=p in spec)
       apply (intro conjI impI allI)
       (* p =  scp *)
-       apply (clarsimp simp: opt_map_red sc_of_def)
+       apply (clarsimp simp: opt_map_red)
        apply (prop_tac "replyPrevs_of s' nrp = Some rp")
         apply (simp add: sym_refs_replyNext_replyPrev_sym[symmetric])
         apply (clarsimp simp: opt_map_red)
@@ -1857,10 +1857,7 @@ proof -
       (* p \<noteq> scp *)
       apply (rule heap_path_heap_upd_not_in)
        apply clarsimp
-      apply (clarsimp simp: sc_of_def opt_map_Some)
-      apply (rename_tac p sc2 ko)
-      apply (case_tac ko; simp)
-      apply (clarsimp simp: opt_map_red sc_of_def)
+      apply (clarsimp simp: opt_map_Some)
       apply (prop_tac "replyPrevs_of s' nrp = Some rp")
        apply (simp add: sym_refs_replyNext_replyPrev_sym[symmetric])
        apply (clarsimp simp: opt_map_red)
@@ -1868,7 +1865,6 @@ proof -
       apply (simp add: sc_with_reply_def the_pred_option_def
                 split: if_split_asm)
       apply blast
-     apply (rule conjI)
       apply (clarsimp simp add: ghost_relation_def)
       apply (erule_tac x=scp in allE)+
       apply (clarsimp simp: obj_at_def a_type_def

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -1292,7 +1292,7 @@ proof -
   show ?thesis
     using sr pr
     unfolding sc_replies_relation_def
-    apply (clarsimp simp: sc_replies_of_scs_def map_project_def scs_of_kh_def sc_of_def
+    apply (clarsimp simp: sc_replies_of_scs_def map_project_def scs_of_kh_def
                    split: Structures_A.kernel_object.split_asm)
     apply (rename_tac sc n'; drule_tac x=p and y="sc_replies sc" in spec2)
     apply (clarsimp simp: foldr_upd_app_if[folded data_map_insert_def] split: if_split_asm)
@@ -1304,7 +1304,7 @@ proof -
      apply (erule notE)
      apply (clarsimp simp: pspace_relation_def)
      apply (simp add: obj_relation_retype_addrs_eq[OF not_unt tysc num_r orr cover,symmetric])
-    apply (clarsimp simp: scs_of_kh_def opt_map_Some sc_of_def sc_replies_of_scs_def map_project_Some)
+    apply (clarsimp simp: scs_of_kh_def opt_map_Some sc_replies_of_scs_def map_project_Some)
     apply (fold foldr_upd_app_if[folded data_map_insert_def])
     apply (simp only: retype_replyPrevs_of[OF pr vs vs' pn pn' ko tysc cover orr num_r, simplified])
     apply (clarsimp simp: pspace_relation_def)

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -925,7 +925,7 @@ lemma sc_replies_relation_scReplies_of:
   "\<lbrakk>sc_replies_relation s s'; sc_at sc_ptr s; bound (scs_of' s' sc_ptr)\<rbrakk>
    \<Longrightarrow> (sc_replies_of s |> hd_opt) sc_ptr = scReplies_of s' sc_ptr"
   by (fastforce simp: sc_replies_relation_def sc_replies_of_scs_def scs_of_kh_def map_project_def
-                      sc_of_def hd_opt_def obj_at_def is_sc_obj_def opt_map_def
+                      hd_opt_def obj_at_def is_sc_obj_def opt_map_def
                split: option.splits Structures_A.kernel_object.splits list.splits)
 
 lemma sc_replies_prevs_walk:
@@ -948,7 +948,7 @@ lemma sc_replies_relation_prevs_list:
     \<Longrightarrow> heap_ls (replyPrevs_of s') (scReply sc') (sc_replies sc)"
   apply (clarsimp simp: sc_replies_relation_def sc_replies_of_scs_def scs_of_kh_def map_project_def)
   apply (drule_tac x=x and y="sc_replies sc" in spec2)
-  apply (clarsimp simp: sc_of_def opt_map_def projectKO_opt_sc split: option.splits)
+  apply (clarsimp simp: opt_map_def projectKO_opt_sc split: option.splits)
   done
 
 lemma list_refs_of_replies'_reftype[simp]:


### PR DESCRIPTION
The main point of this PR is to change the existing AInvs DetSched projections (`tcb_of`, `sc_of` and `ep_of`) to from “definition” to “primrec”.

It also adds `ntfn_of` and `reply_of`, but they are not used yet.

Defining them as primrec seems to work well in terms of simplification and often results in simpler codes. The proof update for this change resulted in slight clean-up overall.


---
So far, tcb_of and sc_of in AInvs are case statements on kernel objects
defined as definitions, and they needed to be explicitly unfolded to
simplify to an option value.

Making them abbreviations is one way to automate the simplification, but
it has a drawback in that the case statement often has unfortunate
interaction with Map.empty, which is an abbreviation of its own, that
tends to produce unwantedly expanded case expressions in subgoals.

It is probably possible to automate the simplication of definitions
by writing a simplification rule for each kernel object case and add
all of such rules to the simp set, but defining these projections as
primrec seems to work just as well, and also often results in shorter
proofs as we can skip case distinctions which would be needed otherwise.

Signed-off-by: Miki Tanaka <miki.tanaka@data61.csiro.au>