### PR TITLE
rt ainvs: valid_ready_qs substatement and cleanup

### DIFF
--- a/proof/invariant-abstract/DetSchedAux_AI.thy
+++ b/proof/invariant-abstract/DetSchedAux_AI.thy
@@ -1140,6 +1140,13 @@ lemma valid_sched_action_weak_valid_sched_action:
 lemmas valid_sched_weak_valid_sched_action =
   valid_sched_valid_sched_action[THEN valid_sched_action_weak_valid_sched_action]
 
+lemma weak_valid_sched_action_no_sc_sched_act_not:
+  "\<lbrakk>weak_valid_sched_action s; pred_map_eq None (tcb_scps_of s) ref\<rbrakk> \<Longrightarrow> scheduler_act_not ref s"
+  by (auto simp: weak_valid_sched_action_def scheduler_act_not_def vs_all_heap_simps)
+
+lemmas valid_sched_action_no_sc_sched_act_not
+  = weak_valid_sched_action_no_sc_sched_act_not[OF valid_sched_action_weak_valid_sched_action]
+
 lemma simple_sched_act_not[simp]:
   "simple_sched_action s \<Longrightarrow> scheduler_act_not t s"
   by (clarsimp simp: simple_sched_action_def scheduler_act_not_def)

--- a/proof/invariant-abstract/DetSchedInvs_AI.thy
+++ b/proof/invariant-abstract/DetSchedInvs_AI.thy
@@ -2294,6 +2294,16 @@ abbreviation valid_ready_qs :: "'z state \<Rightarrow> bool" where
 
 lemmas valid_ready_qs_def = valid_ready_qs_2_def valid_ready_queued_thread_2_def
 
+(* using etcb_eq for the sake of compatibility with valid_ready_qs *)
+(* it would be better to define directly with tcb, and flip the order of p and d *)
+abbreviation
+  "ready_qs_etcb_eq s \<equiv> \<forall>tp d p. tp \<in> set (ready_queues s d p) \<longrightarrow> etcb_eq p d tp s"
+
+lemma valid_ready_qs_etcb_eq[simp]:
+  "valid_ready_qs s \<Longrightarrow> ready_qs_etcb_eq s"
+  by (clarsimp simp: valid_ready_qs_def in_queues_2_def)
+
+
 \<comment> \<open>This predicate is currently used only in refill_update_valid_refills, in particular,
     to show that performing refill_update will not result in overflow.
     The constant 2 is required because refill_update will schedule a refill at most MAX_PERIOD

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -7120,16 +7120,11 @@ lemma no_ofail_refill_head_overlapping:
   apply (clarsimp simp: obind_def obj_at_def read_sched_context_def)
   done
 
-lemma bound_refill_head_overlapping:
-  "kheap s sc_ptr = Some (SchedContext sc n) \<Longrightarrow> bound (refill_head_overlapping sc_ptr s)"
-  apply (clarsimp simp: refill_head_overlapping_def obind_def read_sched_context_def)
-  done
-
 lemma refill_head_overlapping_true_imp_length_at_least_two:
   "\<lbrakk>the (refill_head_overlapping sc_ptr s); pred_map \<top> (sc_refill_cfgs_of s) sc_ptr\<rbrakk>
    \<Longrightarrow> pred_map (\<lambda>cfg. Suc 0 < length (scrc_refills cfg)) (sc_refill_cfgs_of s) sc_ptr"
   apply (clarsimp simp: vs_all_heap_simps)
-  apply (frule bound_refill_head_overlapping)
+  apply (insert no_ofailD[OF no_ofail_refill_head_overlapping])
   apply (fastforce simp: refill_head_overlapping_def vs_all_heap_simps read_sched_context_def)
   done
 
@@ -7139,7 +7134,7 @@ lemma refill_head_overlapping_refills_overlapping:
                        \<le> r_time (hd (scrc_refills cfg)) + r_amount (hd (scrc_refills cfg)))
                  (sc_refill_cfgs_of s) sc_ptr"
   apply (clarsimp simp: vs_all_heap_simps)
-  apply (frule bound_refill_head_overlapping)
+  apply (insert no_ofailD[OF no_ofail_refill_head_overlapping])
   apply (clarsimp simp: refill_head_overlapping_def obind_def read_sched_context_def)
   done
 
@@ -7150,7 +7145,7 @@ lemma refill_head_overlapping_refills_not_overlapping:
                          \<le> r_time (hd (scrc_refills cfg)) + r_amount (hd (scrc_refills cfg))))
                   (sc_refill_cfgs_of s) sc_ptr"
   apply (clarsimp simp: vs_all_heap_simps)
-  apply (frule bound_refill_head_overlapping)
+  apply (insert no_ofailD[OF no_ofail_refill_head_overlapping])
   apply (clarsimp simp: refill_head_overlapping_def obind_def read_sched_context_def)
   done
 

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -10463,14 +10463,6 @@ lemma refill_budget_check_round_robin_valid_ready_qs_not_queued:
   apply (clarsimp simp: obj_at_def vs_all_heap_simps split: if_splits)
   done
 
-(* FIXME: Move *)
-lemma precondition_cases:
-  "\<lbrace>P and Q\<rbrace> f \<lbrace> R \<rbrace> \<Longrightarrow> \<lbrace>(\<lambda>s. \<not>P s) and Q\<rbrace> f \<lbrace> R \<rbrace> \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace> R \<rbrace>"
-  apply (rule_tac Q="\<lambda>s. (P and Q) s \<or> ((\<lambda>s. \<not> P s) and Q) s" in hoare_weaken_pre)
-  apply (rule_tac Q="\<lambda>rv s. R rv s \<or> R rv s" in hoare_strengthen_post)
-  apply (rule hoare_vcg_disj_lift)
-  by force+
-
 lemma update_refill_hd_valid_release_q:
   "\<lbrace>\<lambda>s. valid_release_q s
         \<and> (\<forall>t. pred_map_eq (Some sc_ptr) (tcb_scps_of s) t
@@ -10742,8 +10734,8 @@ lemma commit_time_valid_release_q:
   apply (case_tac "sc_active sc"; simp add: bind_assoc)
    apply (rule hoare_seq_ext[OF _ gets_sp])
    apply (rename_tac csc sc consumed)
-  apply (rule_tac P="\<lambda>s. \<exists>tp. bound_sc_tcb_at ((=) (Some (cur_sc s))) tp s" in precondition_cases)
-   apply (rule_tac P="\<lambda>s. sc_with_tcb_prop (cur_sc s) (\<lambda>s. in_release_q s) s" in precondition_cases)
+  apply (rule_tac P="\<lambda>s. \<exists>tp. bound_sc_tcb_at ((=) (Some (cur_sc s))) tp s" in hoare_pre_tautI)
+   apply (rule_tac P="\<lambda>s. sc_with_tcb_prop (cur_sc s) (\<lambda>s. in_release_q s) s" in hoare_pre_tautI)
     apply (rule_tac Q="valid_release_q and (\<lambda>s. consumed_time s = consumed)
                        and K (consumed = 0)"
                     in hoare_weaken_pre[rotated])
@@ -10756,7 +10748,7 @@ lemma commit_time_valid_release_q:
                       and (\<lambda>s. sc_not_in_release_q (cur_sc s) s) and (\<lambda>s. cur_sc s = csc)"
                    in hoare_weaken_pre[rotated])
     apply (clarsimp, rule conjI, fastforce)
-    apply (clarsimp simp: obj_at_def)
+    apply (clarsimp simp: obj_at_def pred_neg_def)
     apply (subgoal_tac "t = ta", clarsimp)
     apply (rule_tac z="cur_sc s" in sym_refs_bound_sc_tcb_at_inj)
       apply (clarsimp simp: valid_state_def valid_pspace_def, assumption)

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -2078,7 +2078,7 @@ lemma schedContextBindTCB_corres:
          apply (clarsimp simp: set_tcb_obj_ref_thread_set sc_relation_def)
          apply (rule threadset_corres; clarsimp simp: tcb_relation_def)
         apply (clarsimp simp: pred_conj_def)
-        apply ((wp set_tcb_sched_context_valid_ready_qs_not_queued
+        apply ((wp set_tcb_sched_context_valid_ready_qs
                    set_tcb_sched_context_valid_release_q_not_queued
                    set_tcb_sched_context_simple_weak_valid_sched_action
                | ((rule hoare_vcg_conj_lift)?, rule set_tcb_obj_ref_wp))+)[1]
@@ -2103,7 +2103,7 @@ lemma schedContextBindTCB_corres:
           apply (fastforce dest: idle_no_ex_cap)
          apply (fastforce dest: idle_sc_no_ex_cap)
         apply (fastforce simp: tcb_at_kh_simps pred_map_eq_def
-                        elim!: valid_ready_qs_no_sc_not_queued)
+                        dest!: valid_ready_qs_no_sc_not_queued)
        apply (fastforce simp: tcb_at_kh_simps pred_map_eq_def
                        elim!: valid_release_q_no_sc_not_in_release_q)
       apply (fastforce simp: sc_at_pred_def sc_at_ppred_def obj_at_def bound_sc_tcb_at_def


### PR DESCRIPTION
`valid_ready_qs` is a statement about a thread in a ready_queue that
has three components: one is about the ready queue matching the domain
and the priority of the thread, and the others are the thread being in a
runnable state and has a released SC.

- this commit adds an abbreviation, `ready_queues_etcb_eq`, which states the validity of the first component only, i.e., "if in a ready_queue, it must be in the correct queue (corresponding to its domain and priority)"

- `etcb_eq` is used for better compatibility with current `valid_ready_qs`, for the time being

- `valid_ready_qs` preconditions in some wp rules are replaced with this, as they were too generous; this leads to some simplifications in proofs

- most notable one is the `not_queued` wp rules for `tcb_sched_dequeue`; it removes a thread from its "correct" queue, but we need to assume that that is the only queue possible. Previously, `valid_ready_qs` was used for this purpose.

- a few other cleanups added along the way

This is a small side work of "add `refill_unblock_check`" spec change.



Signed-off-by: Miki Tanaka <miki.tanaka@data61.csiro.au>