### PR TITLE
github: scheduled external + weekly clean proofs

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -1,0 +1,37 @@
+# Copyright 2021 Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: External
+
+# checks default.xml and vanilla Isabelle instead of devel and ts-*
+
+on:
+  schedule:
+    - cron: '1 15 1,15 * *'  # 15:01 UTC on 1st and 15th of month
+
+jobs:
+  all:
+    name: Proofs
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ARM, ARM_HYP, RISCV64, X64]
+    steps:
+    - name: Proofs
+      uses: seL4/ci-actions/aws-proofs@master
+      with:
+        L4V_ARCH: ${{ matrix.arch }}
+        manifest: default.xml
+        session: '-v'  # non-empty argument to `./run-tests` to not exclude AutoCorresSEL4
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_SSH: ${{ secrets.AWS_SSH }}
+        GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    - name: Upload logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: logs-${{ matrix.arch }}
+        path: logs.tar.xz

--- a/.github/workflows/weekly-clean.yml
+++ b/.github/workflows/weekly-clean.yml
@@ -1,0 +1,35 @@
+# Copyright 2021 Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: Weekly Clean
+
+on:
+  schedule:
+    - cron: '1 15 * * 6'  # 15:01 UTC every Sat = 1:01 am Syd every Sun
+
+jobs:
+  all:
+    name: Proofs
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ARM, ARM_HYP, RISCV64, X64]
+    steps:
+    - name: Proofs
+      uses: seL4/ci-actions/aws-proofs@master
+      with:
+        L4V_ARCH: ${{ matrix.arch }}
+        isa_branch: ts-2020
+        cache_read: ''  # start with empty cache, but write cache back (default)
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_SSH: ${{ secrets.AWS_SSH }}
+        GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    - name: Upload logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: logs-${{ matrix.arch }}
+        path: logs.tar.xz


### PR DESCRIPTION
Further step in removing Bamboo:

- External means default.xml and vanilla Isabelle instead of internal TS Isabelle and devel.xml (1st and 15th of month).
- The weekly clean test runs without reading the proof image cache, writing back a fresh cache state (every Sun).

