### PR TITLE
New corres rule for whileLoop, and headInsufficientLoop_corres

### DIFF
--- a/proof/invariant-abstract/KHeap_AI.thy
+++ b/proof/invariant-abstract/KHeap_AI.thy
@@ -2620,4 +2620,40 @@ lemma st_tcb_recv_reply_state_refs:
                  split: thread_state.splits if_splits kernel_object.splits)
   done
 
+lemma get_sched_context_exs_valid:
+  "\<exists>sc n. kheap s scp = Some (SchedContext sc n)
+   \<Longrightarrow> \<lbrace>(=) s\<rbrace> get_sched_context scp \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
+  by (clarsimp simp: get_sched_context_def get_object_def obj_at_def bind_def
+                     gets_def get_def return_def exs_valid_def gets_the_def)
+
+lemma no_fail_simple_ko_at:
+  "no_fail (ntfn_at p) (get_notification p)"
+  "no_fail (ep_at p) (get_endpoint p)"
+  "no_fail (reply_at p) (get_reply p)"
+  by (wpsimp simp: get_simple_ko_def obj_at_def is_obj_defs a_type_def partial_inv_def
+               wp: get_object_wp split: kernel_object.splits)+
+
+lemmas no_fail_get_notification[wp] = no_fail_simple_ko_at(1)
+lemmas no_fail_get_reply[wp] = no_fail_simple_ko_at(2)
+lemmas no_fail_get_endpoint[wp] = no_fail_simple_ko_at(3)
+
+lemma get_sched_context_no_fail[wp]:
+  "no_fail (\<lambda>s. \<exists>sc n. kheap s scp = Some (SchedContext sc n)) (get_sched_context scp)"
+  by (clarsimp simp: get_sched_context_def no_fail_def bind_def get_object_def return_def get_def
+                     gets_def obj_at_def gets_the_def)
+
+lemma set_object_no_fail[wp]:
+  "no_fail (obj_at (\<lambda>k. a_type obj = a_type k) ptr) (set_object ptr obj)"
+  apply (clarsimp simp: set_object_def)
+  apply (wpsimp wp: get_object_wp)
+  apply (clarsimp simp: obj_at_def)
+  done
+
+lemma update_sched_context_no_fail[wp]:
+  "no_fail (\<lambda>s. \<exists>sc n. kheap s sc_ptr = Some (SchedContext sc n)) (update_sched_context sc_ptr f)"
+  apply (clarsimp simp: update_sched_context_def)
+  apply (wpsimp wp: get_object_wp)
+  apply (clarsimp simp: obj_at_def a_type_def)
+  done
+
 end

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -958,8 +958,8 @@ lemma replyRemoveTCB_corres:
                 apply (fastforce simp: obj_at_def is_reply partial_inv_def a_type_def)
                apply (wpsimp wp: get_sched_context_exs_valid)
                 apply (drule sc_with_reply_SomeD)
-                apply clarsimp+
-              apply wpsimp
+                apply (wpsimp simp: is_sc_obj_def
+                       | clarsimp split: Structures_A.kernel_object.splits)+
               apply (fastforce dest!: sc_with_reply_SomeD1 simp: sc_replies_sc_at_def obj_at_def)
              apply (wpsimp wp: get_sched_context_no_fail)
              apply (fastforce dest!: sc_with_reply_SomeD elim!: valid_sched_context_size_objsI

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -6180,9 +6180,8 @@ lemma doReplyTransfer_corres:
                       apply (clarsimp simp: obj_at_def sc_at_pred_n_def get_sched_context_exs_valid)
                      apply (rule get_sched_context_exs_valid)
                      apply (clarsimp simp: sc_at_pred_n_def obj_at_def)
-                    apply (wpsimp wp: get_sched_context_no_fail)
-                    apply (clarsimp simp: sc_at_pred_n_def obj_at_def is_sc_obj)
-                    apply (frule_tac sc=sc and n=n in valid_objs_valid_sched_context_size[OF invs_valid_objs], fastforce, simp)
+                    apply ((wpsimp simp: obj_at_def is_sc_obj_def
+                           | clarsimp split: Structures_A.kernel_object.splits)+)[1]
                    apply simp
                   apply clarsimp
                  apply (wpsimp wp: thread_get_wp')

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -3982,9 +3982,6 @@ lemma is_active_sc_rewrite:
                       active_sc_def opt_map_red opt_map_def
                split: option.split_asm Structures_A.kernel_object.splits)
 
-definition is_active_sc' where
-  "is_active_sc' p s' \<equiv> ((\<lambda>sc'. 0 < scRefillMax sc') |< scs_of' s') p"
-
 lemma active_sc_at'_imp_is_active_sc':
   "active_sc_at' scp s \<Longrightarrow> is_active_sc' scp s"
   by (clarsimp simp: active_sc_at'_def is_active_sc'_def obj_at'_def opt_map_def projectKOs)
@@ -4233,30 +4230,6 @@ lemmas updateSchedContext_corres = updateSchedContext_corres_gen[where P=\<top> 
 (* end : updateSchedContext *)
 
 end
-
-lemma get_sched_context_exs_valid:
-  "\<exists>sc n. kheap s scp = Some (Structures_A.SchedContext sc n)
-   \<Longrightarrow> \<lbrace>(=) s\<rbrace> get_sched_context scp \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
-  by (clarsimp simp: get_sched_context_def get_object_def obj_at_def bind_def is_sc_obj_def
-                     gets_def get_def return_def exs_valid_def gets_the_def
-              split: Structures_A.kernel_object.splits)
-
-lemma no_fail_simple_ko_at:
-  "no_fail (ntfn_at p) (get_notification p)"
-  "no_fail (ep_at p) (get_endpoint p)"
-  "no_fail (reply_at p) (get_reply p)"
-  by (wpsimp simp: get_simple_ko_def obj_at_def is_obj_defs a_type_def partial_inv_def
-               wp: get_object_wp split:  Structures_A.kernel_object.splits)+
-
-lemmas no_fail_get_notification[wp] = no_fail_simple_ko_at(1)
-lemmas no_fail_get_reply[wp] = no_fail_simple_ko_at(2)
-lemmas no_fail_get_endpoint[wp] = no_fail_simple_ko_at(3)
-
-lemma get_sched_context_no_fail:
-  "no_fail (\<lambda>s. sc_at ptr s) (get_sched_context ptr)"
-  by (clarsimp simp: get_sched_context_def no_fail_def bind_def get_object_def return_def get_def
-                     gets_def obj_at_def is_sc_obj_def gets_the_def
-              split: Structures_A.kernel_object.splits)
 
 (* FIXME RT: rename *)
 (* this let us cross the sc size information from concrete to abstract *)
@@ -4675,6 +4648,18 @@ lemma active_sc_at'_cross:
   apply (drule_tac x=sc_ptr in bspec, blast)
   apply (clarsimp simp: sc_relation_def vs_all_heap_simps active_sc_at'_def obj_at'_def projectKOs
                         active_sc_def)
+  done
+
+lemma is_active_sc'2_cross:
+  "\<lbrakk>(s,s') \<in> state_relation; pspace_aligned s; pspace_distinct s; is_active_sc sc_ptr s;
+    sc_at sc_ptr s\<rbrakk>
+   \<Longrightarrow> is_active_sc' sc_ptr s'"
+  apply (frule state_relation_pspace_relation)
+  apply (frule (3) sc_at_cross)
+  apply (clarsimp simp: pspace_relation_def obj_at_def is_sc_obj_def)
+  apply (drule_tac x=sc_ptr in bspec, blast)
+  apply (clarsimp simp: sc_relation_def vs_all_heap_simps obj_at'_def projectKOs
+                        active_sc_def opt_map_red StateRelation.is_active_sc'_def)
   done
 
 end

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -746,10 +746,8 @@ lemma update_sc_reply_stack_update_ko_at'_corres:
       apply (wpsimp wp: get_sched_context_exs_valid simp: is_sc_obj_def obj_at_def)
        apply (rename_tac ko; case_tac ko; simp)
       apply simp
-     apply (wpsimp simp: obj_at_def is_sc_obj_def)+
-    apply (wpsimp wp: get_sched_context_no_fail)
-   apply (clarsimp simp: obj_at_def is_sc_obj_def)
-  apply simp
+     apply (wpsimp simp: obj_at_def is_sc_obj_def
+            | clarsimp split: Structures_A.kernel_object.splits)+
   done
 
 lemma bindScReply_corres:
@@ -1650,10 +1648,8 @@ lemma setSchedContext_scReply_update_None_corres:
           apply (rename_tac ko; case_tac ko; clarsimp)
          apply simp
         apply (wpsimp simp: obj_at_def is_sc_obj_def vs_heap_simps)
-       apply (wpsimp wp: get_sched_context_no_fail)
-      apply (clarsimp simp: obj_at_def is_sc_obj_def)
-     apply simp
-    apply wpsimp+
+       apply (wpsimp simp: obj_at_def is_sc_obj_def
+              | clarsimp split: Structures_A.kernel_object.splits)+
   done
 
 lemma replyPrevNext_update_commute:


### PR DESCRIPTION
This PR restores the original `corres` rule for `whileLoop`; it seems that the rule which included crossing is unnecessary. A new `corres` rules for `whileLoop` with termination and `no_fail` conditions stated on the abstract side is added. This is then used to prove `headInsufficientLoop_corres`.