### PR TITLE
`scheduleUsed_corres`

### DIFF
--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -537,6 +537,13 @@ lemmas corres_when2 =
                 and Q="\<top>" and Q'="\<top>" and r=dc, unfolded if_apply_def2, simplified,
                 folded when_def]
 
+lemma corres_if_split:
+  "\<lbrakk> G = G';
+     G \<Longrightarrow> corres_underlying sr nf nf' r P P' a c;
+     \<not>G \<Longrightarrow> corres_underlying sr nf nf' r P P' b d \<rbrakk>
+   \<Longrightarrow> corres_underlying sr nf nf' r P P' (if G then a else b) (if G' then c else d)"
+  by (clarsimp simp: corres_underlying_def)
+
 text \<open>Some equivalences about liftM and other useful simps\<close>
 
 lemma snd_liftM [simp]:

--- a/lib/LemmaBucket.thy
+++ b/lib/LemmaBucket.thy
@@ -525,4 +525,8 @@ lemma list_length_2:
 
 lemmas add_le_mono_left = order_trans[OF add_le_mono[OF order_refl], rotated]
 
+lemma hd_tl_nth:
+  "Suc 0 < length list \<Longrightarrow> hd (tl list) = list ! 1"
+  by (cases list; simp add: hd_conv_nth)
+
 end

--- a/lib/Word_Lib/Word_Lemmas_Internal.thy
+++ b/lib/Word_Lib/Word_Lemmas_Internal.thy
@@ -416,4 +416,24 @@ lemma unat_minus_plus_one:
    using max_word_wrap apply blast
   by (metis less_is_non_zero_p1 word_less_nat_alt word_overflow_unat)
 
+lemma unat_max_word:
+  "2 ^ LENGTH('a) - 1 = unat (max_word :: 'a :: len word)"
+  apply (rule Suc_inject)
+  apply (simp add: power_two_max_word_fold)
+  done
+
+lemma unat_add_lem'':
+  "(unat (x :: 'a :: len word) + unat y \<le> unat (max_word :: 'a :: len word))
+   \<Longrightarrow> unat (x + y) = unat x + unat y"
+  apply (rule unat_add_lem')
+  apply (clarsimp simp: less_Suc_eq_le[symmetric] unat_max_word[symmetric])
+  done
+
+lemma unat_mult_lem':
+  "unat (x :: 'a :: len word) * unat y \<le> unat (max_word :: 'a :: len word)
+   \<Longrightarrow> unat (x * y) = unat x * unat y"
+  apply (rule unat_mult_lem[THEN iffD1])
+  apply (clarsimp simp: max_word_def)
+  by (meson le_def le_trans unat_lt2p)
+
 end

--- a/proof/invariant-abstract/Deterministic_AI.thy
+++ b/proof/invariant-abstract/Deterministic_AI.thy
@@ -4086,8 +4086,9 @@ lemma postpone_valid_list[wp]:
   "\<lbrace>valid_list\<rbrace> postpone r \<lbrace>\<lambda>_.valid_list\<rbrace>"
    by (wpsimp simp: postpone_def wp: hoare_drop_imp)
 
-crunches set_refills,refill_size
+crunches set_refills,refill_size, schedule_used
   for valid_list[wp]: valid_list
+  (simp: schedule_used_defs wp: get_refills_wp)
 
 lemma refill_budget_check_valid_list[wp]:
   "refill_budget_check usage \<lbrace>valid_list\<rbrace>"

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -269,19 +269,15 @@ This module uses the C preprocessor to select a target architecture.
 >     if empty
 >         then refillAddTail scPtr new
 >         else do
->          full <- refillFull scPtr
 >          if (rTime (refillTl sc) + rAmount (refillTl sc) >= rTime new)
->               then do
->                 let tl = refillTl sc
->                 let tl' = tl { rAmount = rAmount tl + rAmount new}
->                 setRefillTl scPtr tl'
->               else if (not full)
->                         then refillAddTail scPtr new
->                         else do
->                           let tl = refillTl sc
->                           let tl' = tl { rTime = rTime new - rAmount tl,
->                                          rAmount = rAmount tl + rAmount new }
->                           setRefillTl scPtr tl'
+>               then updateRefillTl scPtr (\last -> last { rAmount = rAmount last + rAmount new })
+>               else do
+>                 full <- refillFull scPtr
+>                 if (not full)
+>                    then refillAddTail scPtr new
+>                    else do
+>                      updateRefillTl scPtr (\last -> last { rTime = rTime new - rAmount last})
+>                      updateRefillTl scPtr (\last -> last { rAmount = rAmount last + rAmount new})
 
 > refillResetRR :: PPtr SchedContext -> Kernel ()
 > refillResetRR scPtr = do


### PR DESCRIPTION
This proves `scheduleUsed_corres`.

I've rewritten `schedule_used` in the abstract to be monadic. I had hoped that the changes to AInvs would be minimal, but it turned out to be quite a lot of reorganising. Most of the more difficult word proofs (`schedule_used_no_overflow`, `schedule_used_odered_disjoint`, `schedule_used_window`) are pretty much unchanged. Some of the helper lemmas (`refill_budget_check_ordered_disjoint_helper'`, etc.) are new and replace older, clunkier versions. Nothing very exciting is going on in AInvs.

As expected after rewriting `schedule_used`, the `corres` rule was very straightforward. I had to slightly modify `refillAddTail_corres` to allow it to be applied in my lemma. This did not break anything in this branch, but perhaps it is being used elsewhere