### PR TITLE
github: deploy manifest after test on master

### DIFF
--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -1,0 +1,61 @@
+# Copyright 2021 Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# On push to master only: run proofs and deploy manifest update.
+
+name: Proofs
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  code:
+    name: Freeze Code
+    runs-on: ubuntu-latest
+    outputs:
+      xml: ${{ steps.repo.outputs.xml }}
+    steps:
+    - id: repo
+      uses: seL4/ci-actions/repo-checkout@master
+      with:
+        manifest_repo: verification-manifest
+        manifest: devel.xml
+
+  proofs:
+    name: Proof
+    needs: code
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ARM, ARM_HYP, RISCV64, X64]
+    steps:
+    - name: Proofs
+      uses: seL4/ci-actions/aws-proofs@master
+      with:
+        L4V_ARCH: ${{ matrix.arch }}
+        xml: ${{ needs.code.outputs.xml }}
+        session: '-v'  # non-empty argument to `./run-tests` to not exclude AutoCorresSEL4
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_SSH: ${{ secrets.AWS_SSH }}
+    - name: Upload logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: logs-${{ matrix.arch }}
+        path: logs.tar.xz
+
+  deploy:
+    name: Deploy manifest
+    runs-on: ubuntu-latest
+    needs: [code, proofs]
+    steps:
+    - uses: seL4/ci-actions/l4v-deploy@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+      env:
+        GH_SSH: ${{ secrets.CI_SSH }}

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -7,7 +7,6 @@ name: Proofs
 on:
   push:
     branches:
-      - master
       - rt
   # this action needs access to secrets.
   # The actual test runs in a no-privilege VM, so it's Ok to run on untrusted PRs.


### PR DESCRIPTION
This refactors the proof runs into a separate run for the master branch (which has deployment) and development branches (currently RT and PRs).

For the test on the master branch, we need to make sure that all tests and the deployment action see the same revisions of all participating repos.

