### PR TITLE
add CI badges

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - master
+      - rt
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 -->
 
 [![DOI][0]](http://dx.doi.org/10.5281/zenodo.591732)
+[![CI](https://github.com/seL4/l4v/actions/workflows/push.yml/badge.svg)](https://github.com/seL4/l4v/actions/workflows/push.yml)
+[![Proofs](https://github.com/seL4/l4v/actions/workflows/proof-deploy.yml/badge.svg)](https://github.com/seL4/l4v/actions/workflows/proof-deploy.yml)
+[![Weekly Clean](https://github.com/seL4/l4v/actions/workflows/weekly-clean.yml/badge.svg)](https://github.com/seL4/l4v/actions/workflows/weekly-clean.yml)
+[![External](https://github.com/seL4/l4v/actions/workflows/external.yml/badge.svg)](https://github.com/seL4/l4v/actions/workflows/external.yml)
+
+MCS:\
+[![CI](https://github.com/seL4/l4v/actions/workflows/push.yml/badge.svg?branch=rt)](https://github.com/seL4/l4v/actions/workflows/push.yml)
+[![RT Proofs](https://github.com/seL4/l4v/actions/workflows/proof.yml/badge.svg?branch=rt)](https://github.com/seL4/l4v/actions/workflows/proof.yml)
 
   [0]: https://zenodo.org/badge/doi/10.5281/zenodo.591732.svg
 


### PR DESCRIPTION
This adds badges to the repo README to show CI status overview of the master and rt branches.

It also adds the CI "push" checks to the rt branch, so the "no status" it currently shows should soon change to "passing".