### PR TITLE
proof update for cache fix PR

### DIFF
--- a/proof/access-control/ARM/ArchRetype_AC.thy
+++ b/proof/access-control/ARM/ArchRetype_AC.thy
@@ -370,7 +370,8 @@ lemma dmo_clearMemory_respects'[Retype_AC_assms]:
   apply clarsimp
   apply (erule use_valid)
    apply wp
-    apply (simp add: cleanByVA_PoU_def)
+    apply (simp add: cleanCacheRange_RAM_def cleanCacheRange_PoC_def cacheRangeOp_def cleanL2Range_def
+                     cleanByVA_def split_def dsb_def)
     apply (wp mol_respects mapM_x_wp' storeWord_respects)+
    apply (simp add: word_size_bits_def)
    apply (clarsimp simp: word_size_def word_bits_def upto_enum_step_shift_red[where us=2, simplified])

--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -49,7 +49,7 @@ lemma performPageTableInvocationUnmap_ccorres:
         apply (ctac add: unmapPageTable_ccorres)
           apply csymbr
           apply (simp add: storePTE_def swp_def)
-          apply (ctac add: clearMemory_setObject_PTE_ccorres[unfolded dc_def])
+          apply (ctac add: clearMemory_PT_setObject_PTE_ccorres[unfolded dc_def])
          apply wp
         apply (simp del: Collect_const)
         apply (vcg exspec=unmapPageTable_modifies)

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -1745,7 +1745,7 @@ lemma resetUntypedCap_ccorres:
   supply if_cong[cong] option.case_cong[cong]
   apply (cinit lift: srcSlot_')
    apply (simp add: liftE_bindE getSlotCap_def
-                    Collect_True extra_sle_sless_unfolds)
+                    Collect_True)
    apply (rule ccorres_getCTE, rename_tac cte)
    apply (rule ccorres_move_c_guard_cte)
    apply (rule ccorres_symb_exec_r)

--- a/proof/crefine/ARM/Machine_C.thy
+++ b/proof/crefine/ARM/Machine_C.thy
@@ -132,12 +132,12 @@ assumes cleanInvalidate_D_PoC_ccorres:
 assumes cleanInvalidateL2Range_ccorres:
   "ccorres dc xfdc \<top> (\<lbrace>\<acute>start = w1\<rbrace> \<inter> \<lbrace>\<acute>end = w2\<rbrace>) []
            (doMachineOp (cleanInvalidateL2Range w1 w2))
-           (Call cleanInvalidateL2Range_'proc)"
+           (Call plat_cleanInvalidateL2Range_'proc)"
 
 assumes invalidateL2Range_ccorres:
   "ccorres dc xfdc \<top> (\<lbrace>\<acute>start = w1\<rbrace> \<inter> \<lbrace>\<acute>end = w2\<rbrace>) []
            (doMachineOp (invalidateL2Range w1 w2))
-           (Call invalidateL2Range_'proc)"
+           (Call plat_invalidateL2Range_'proc)"
 
 assumes cleanL2Range_ccorres:
   "ccorres dc xfdc \<top> (\<lbrace>\<acute>start = w1\<rbrace> \<inter> \<lbrace>\<acute>end = w2\<rbrace>) []
@@ -193,7 +193,7 @@ assumes maskInterrupt_ccorres:
            (Call maskInterrupt_'proc)"
 
 assumes invalidateLocalTLB_VAASID_spec:
- "\<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> UNIV (Call invalidateMVA_'proc) UNIV"
+ "\<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> UNIV (Call invalidateLocalTLB_VAASID_'proc) UNIV"
 
 assumes cleanCacheRange_PoU_spec:
  "\<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> UNIV (Call cleanCacheRange_PoU_'proc) UNIV"

--- a/proof/crefine/ARM/Machine_C.thy
+++ b/proof/crefine/ARM/Machine_C.thy
@@ -441,8 +441,8 @@ lemma cleanInvalidateCacheRange_RAM_ccorres:
    apply (rule ccorres_Guard_Seq)
    apply (rule ccorres_basic_srnoop)
      apply (simp add: cleanInvalidateCacheRange_RAM_def doMachineOp_bind
-                      empty_fail_dsb empty_fail_cleanCacheRange_PoC empty_fail_cleanInvalidateL2Range
-                      empty_fail_cacheRangeOp empty_fail_cleanInvalByVA)
+                      empty_fail_dsb empty_fail_cleanInvalidateL2Range
+                      empty_fail_cleanInvalByVA)
      apply (ctac (no_vcg) add: cleanCacheRange_PoC_ccorres)
       apply (ctac (no_vcg) add: dsb_ccorres)
        apply (ctac (no_vcg) add: cleanInvalidateL2Range_ccorres)
@@ -474,8 +474,7 @@ lemma cleanCacheRange_RAM_ccorres:
            (doMachineOp (cleanCacheRange_RAM w1 w2 w3))
            (Call cleanCacheRange_RAM_'proc)"
   apply (cinit' lift: start_' end_' pstart_')
-   apply (simp add: cleanCacheRange_RAM_def doMachineOp_bind
-                    empty_fail_dsb empty_fail_cleanCacheRange_PoC empty_fail_cleanL2Range)
+   apply (simp add: cleanCacheRange_RAM_def doMachineOp_bind empty_fail_dsb empty_fail_cleanL2Range)
    apply (rule ccorres_Guard_Seq)
    apply (rule ccorres_basic_srnoop2, simp)
    apply (ctac (no_vcg) add: cleanCacheRange_PoC_ccorres)
@@ -537,8 +536,7 @@ lemma invalidateCacheRange_RAM_ccorres:
    apply (clarsimp simp: word_sle_def whileAnno_def split del: if_split)
    apply (ccorres_remove_UNIV_guard)
    apply (simp add: invalidateCacheRange_RAM_def doMachineOp_bind when_def
-                    if_split_empty_fail empty_fail_cleanCacheRange_RAM
-                    empty_fail_invalidateL2Range empty_fail_cacheRangeOp empty_fail_invalidateByVA
+                    if_split_empty_fail empty_fail_invalidateL2Range empty_fail_invalidateByVA
                     empty_fail_dsb dmo_if
               split del: if_split)
    apply (rule ccorres_split_nothrow_novcg)

--- a/proof/crefine/ARM/Machine_C.thy
+++ b/proof/crefine/ARM/Machine_C.thy
@@ -76,6 +76,24 @@ assumes cleanByVA_PoU_preserves_kernel_bytes:
          \<and> (\<forall>x. snd (hrs_htd (t_hrs_' (globals s)) x) 0 \<noteq> None
              \<longrightarrow> hrs_mem (t_hrs_' (globals t)) x = hrs_mem (t_hrs_' (globals s)) x)}"
 
+assumes cleanByVA_preserves_kernel_bytes:
+ "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call cleanByVA_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> (\<forall>x. snd (hrs_htd (t_hrs_' (globals s)) x) 0 \<noteq> None
+             \<longrightarrow> hrs_mem (t_hrs_' (globals t)) x = hrs_mem (t_hrs_' (globals s)) x)}"
+
+assumes cleanL2Range_preserves_kernel_bytes:
+ "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call plat_cleanL2Range_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> (\<forall>x. snd (hrs_htd (t_hrs_' (globals s)) x) 0 \<noteq> None
+             \<longrightarrow> hrs_mem (t_hrs_' (globals t)) x = hrs_mem (t_hrs_' (globals s)) x)}"
+
+assumes dsb_preserves_kernel_bytes:
+ "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call dsb_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> (\<forall>x. snd (hrs_htd (t_hrs_' (globals s)) x) 0 \<noteq> None
+             \<longrightarrow> hrs_mem (t_hrs_' (globals t)) x = hrs_mem (t_hrs_' (globals s)) x)}"
+
 assumes invalidateByVA_ccorres:
   "ccorres dc xfdc \<top> (\<lbrace>\<acute>vaddr = w1\<rbrace> \<inter> \<lbrace>\<acute>paddr = w2\<rbrace>) []
            (doMachineOp (invalidateByVA w1 w2))

--- a/proof/crefine/ARM/Recycle_C.thy
+++ b/proof/crefine/ARM/Recycle_C.thy
@@ -428,7 +428,7 @@ lemma clearMemory_PT_setObject_PTE_ccorres:
                         update_pte_map_to_ptes carray_map_relation_upd_triv)
        apply (rule cmap_relation_updI, simp_all)[1]
        apply (simp add: cpte_relation_def Let_def pte_lift_def
-                        fcp_beta pte_get_tag_def pte_tag_defs)
+                        pte_get_tag_def pte_tag_defs)
        apply (simp add: carch_state_relation_def cmachine_state_relation_def
                         typ_heap_simps update_pte_map_tos)
       apply csymbr

--- a/proof/crefine/ARM/Recycle_C.thy
+++ b/proof/crefine/ARM/Recycle_C.thy
@@ -382,7 +382,7 @@ lemma page_table_at_rf_sr_dom_s:
   apply (auto simp add: intvl_def shiftl_t2n)[1]
   done
 
-lemma clearMemory_setObject_PTE_ccorres:
+lemma clearMemory_PT_setObject_PTE_ccorres:
   "ccorres dc xfdc (page_table_at' ptr
                 and (\<lambda>s. 2 ^ ptBits \<le> gsMaxObjectSize s)
                 and (\<lambda>_. is_aligned ptr ptBits \<and> ptr \<noteq> 0 \<and> pstart = addrFromPPtr ptr))
@@ -391,7 +391,7 @@ lemma clearMemory_setObject_PTE_ccorres:
                        [ptr , ptr + 2 ^ pteBits .e. ptr + 2 ^ ptBits - 1];
            doMachineOp (cleanCacheRange_PoU ptr (ptr + 2 ^ ptBits - 1) pstart)
         od)
-       (Call clearMemory_'proc)"
+       (Call clearMemory_PT_'proc)"
   apply (rule ccorres_gen_asm)+
   apply (cinit' lift: ptr___ptr_to_unsigned_long_' bits_')
    apply (rule ccorres_Guard_Seq)

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -6538,9 +6538,8 @@ lemma insertNewCap_preserves_bytes_flip:
   "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call insertNewCap_'proc
       {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
          \<and> byte_regions_unmodified' t s}"
-  by (rule allI, rule conseqPost,
-    rule insertNewCap_preserves_bytes[rule_format],
-    auto elim: byte_regions_unmodified_flip_eq)
+  by (rule allI, rule conseqPost, rule insertNewCap_preserves_bytes[rule_format])
+     (auto elim: byte_regions_unmodified_flip_eq)
 
 lemma copyGlobalMappings_preserves_bytes:
   "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call copyGlobalMappings_'proc
@@ -6549,21 +6548,18 @@ lemma copyGlobalMappings_preserves_bytes:
   apply (hoare_rule HoarePartial.ProcNoRec1)
   apply (clarsimp simp only: whileAnno_def)
   apply (subst whileAnno_def[symmetric, where V=undefined
-       and I="{t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
-         \<and> byte_regions_unmodified' s t}" for s])
+               and I="{t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+                          \<and> byte_regions_unmodified' s t}" for s])
   apply (rule conseqPre, vcg)
-  apply (safe intro!: byte_regions_unmodified_hrs_mem_update
-    elim!: byte_regions_unmodified_trans byte_regions_unmodified_trans[rotated],
-    (simp_all add: h_t_valid_field)+)
-  done
+    by (safe intro!: byte_regions_unmodified_hrs_mem_update
+             elim!: byte_regions_unmodified_trans byte_regions_unmodified_trans[rotated],
+        (simp_all add: h_t_valid_field)+)
 
 lemma cleanByVA_PoU_preserves_bytes:
   "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call cleanByVA_PoU_'proc
       {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
          \<and> byte_regions_unmodified' s t}"
-  apply (rule allI, rule conseqPost,
-    rule cleanByVA_PoU_preserves_kernel_bytes[rule_format])
-   apply simp_all
+  apply (rule allI, rule conseqPost, rule cleanByVA_PoU_preserves_kernel_bytes[rule_format]; simp)
   apply (clarsimp simp: byte_regions_unmodified_def)
   done
 
@@ -6574,13 +6570,12 @@ lemma cleanCacheRange_PoU_preserves_bytes:
   apply (hoare_rule HoarePartial.ProcNoRec1)
   apply (clarsimp simp only: whileAnno_def)
   apply (subst whileAnno_def[symmetric, where V=undefined
-       and I="{t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
-         \<and> byte_regions_unmodified' s t}" for s])
+               and I="{t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+                          \<and> byte_regions_unmodified' s t}" for s])
   apply (rule conseqPre, vcg exspec=cleanByVA_PoU_preserves_bytes)
-  apply (safe intro!: byte_regions_unmodified_hrs_mem_update
-    elim!: byte_regions_unmodified_trans byte_regions_unmodified_trans[rotated],
-    (simp_all add: h_t_valid_field)+)
-  done
+    by (safe intro!: byte_regions_unmodified_hrs_mem_update
+              elim!: byte_regions_unmodified_trans byte_regions_unmodified_trans[rotated],
+        (simp_all add: h_t_valid_field)+)
 
 lemma hrs_htd_update_canon:
   "hrs_htd_update (\<lambda>_. f (hrs_htd hrs)) hrs = hrs_htd_update f hrs"
@@ -6595,20 +6590,20 @@ lemma Arch_createObject_preserves_bytes:
   apply (hoare_rule HoarePartial.ProcNoRec1)
   apply clarsimp
   apply (rule conseqPre, vcg exspec=cap_small_frame_cap_new_modifies
-    exspec=cap_frame_cap_new_modifies
-    exspec=cap_page_table_cap_new_modifies
-    exspec=copyGlobalMappings_preserves_bytes
-    exspec=addrFromPPtr_modifies
-    exspec=cleanCacheRange_PoU_preserves_bytes
-    exspec=cap_page_directory_cap_new_modifies)
+                             exspec=cap_frame_cap_new_modifies
+                             exspec=cap_page_table_cap_new_modifies
+                             exspec=copyGlobalMappings_preserves_bytes
+                             exspec=addrFromPPtr_modifies
+                             exspec=cleanCacheRange_PoU_preserves_bytes
+                             exspec=cap_page_directory_cap_new_modifies)
   apply (safe intro!: byte_regions_unmodified_hrs_mem_update,
-    (simp_all add: h_t_valid_field hrs_htd_update)+)
-  apply (safe intro!: ptr_retyp_d ptr_retyps_out)
-  apply (simp_all add: object_type_from_H_def Kernel_C_defs APIType_capBits_def
-    split: object_type.split_asm ArchTypes_H.apiobject_type.split_asm)
-   apply (rule byte_regions_unmodified_flip, simp)
+         (simp_all add: h_t_valid_field hrs_htd_update)+)
+            apply (safe intro!: ptr_retyp_d ptr_retyps_out)
+            apply (simp_all add: object_type_from_H_def Kernel_C_defs APIType_capBits_def
+                            split: object_type.split_asm apiobject_type.split_asm)
+  apply (rule byte_regions_unmodified_flip, simp)
   apply (rule byte_regions_unmodified_trans[rotated],
-    assumption, simp_all add: hrs_htd_update_canon hrs_htd_update)
+         assumption, simp_all add: hrs_htd_update_canon hrs_htd_update)
   done
 
 lemma ptr_arr_retyps_eq_outside_dom:
@@ -6625,20 +6620,19 @@ lemma createObject_preserves_bytes:
   apply (hoare_rule HoarePartial.ProcNoRec1)
   apply clarsimp
   apply (rule conseqPre, vcg exspec=Arch_createObject_preserves_bytes
-    exspec=cap_thread_cap_new_modifies
-    exspec=cap_endpoint_cap_new_modifies
-    exspec=cap_notification_cap_new_modifies
-    exspec=cap_cnode_cap_new_modifies
-    exspec=cap_untyped_cap_new_modifies)
+                             exspec=cap_thread_cap_new_modifies
+                             exspec=cap_endpoint_cap_new_modifies
+                             exspec=cap_notification_cap_new_modifies
+                             exspec=cap_cnode_cap_new_modifies
+                             exspec=cap_untyped_cap_new_modifies)
   apply (safe intro!: byte_regions_unmodified_hrs_mem_update,
-    (simp_all add: h_t_valid_field hrs_htd_update)+)
-  apply (safe intro!: ptr_retyp_d ptr_retyps_out trans[OF ptr_retyp_d ptr_retyp_d]
-                      ptr_arr_retyps_eq_outside_dom)
-  apply (simp_all add: object_type_from_H_def Kernel_C_defs APIType_capBits_def
-                       objBits_simps' cte_C_size power_add ctcb_offset_defs
-    split: object_type.split_asm ArchTypes_H.apiobject_type.split_asm)
-   apply (erule notE, erule subsetD[rotated],
-     rule intvl_start_le intvl_sub_offset, simp)+
+         (simp_all add: h_t_valid_field hrs_htd_update)+)
+     apply (safe intro!: ptr_retyp_d ptr_retyps_out trans[OF ptr_retyp_d ptr_retyp_d]
+                         ptr_arr_retyps_eq_outside_dom)
+      apply (simp_all add: object_type_from_H_def Kernel_C_defs APIType_capBits_def
+                           objBits_simps' cte_C_size power_add ctcb_offset_defs
+                      split: object_type.split_asm apiobject_type.split_asm)
+    apply (erule notE, erule subsetD[rotated], rule intvl_start_le intvl_sub_offset, simp)+
   done
 
 lemma offset_intvl_first_chunk_subsets:

--- a/proof/crefine/ARM_HYP/Arch_C.thy
+++ b/proof/crefine/ARM_HYP/Arch_C.thy
@@ -68,7 +68,7 @@ lemma performPageTableInvocationUnmap_ccorres:
         apply (ctac add: unmapPageTable_ccorres)
           apply csymbr
           apply (simp add: storePTE_def' swp_def)
-          apply (ctac add: clearMemory_setObject_PTE_ccorres[simplified objBits_InvalidPTE,
+          apply (ctac add: clearMemory_PT_setObject_PTE_ccorres[simplified objBits_InvalidPTE,
                               unfolded dc_def, simplified])
          apply wp
         apply (simp del: Collect_const)

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -1726,7 +1726,7 @@ lemma clearMemory_untyped_ccorres:
                             carch_state_relation_def cmachine_state_relation_def)
 
      apply csymbr
-     apply (ctac add: cleanCacheRange_PoU_ccorres[unfolded dc_def])
+     apply (ctac add: cleanCacheRange_RAM_ccorres[unfolded dc_def])
     apply wp
    apply (simp add: guard_is_UNIV_def unat_of_nat
                     word_bits_def capAligned_def word_of_nat_less)
@@ -1834,6 +1834,57 @@ lemma byte_regions_unmodified_actually_heap_list:
   apply (clarsimp split: if_split_asm)
   done
 
+lemma cleanByVA_preserves_bytes:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call cleanByVA_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> byte_regions_unmodified' s t}"
+  apply (rule allI, rule conseqPost,
+    rule cleanByVA_preserves_kernel_bytes[rule_format])
+   apply simp_all
+  apply (clarsimp simp: byte_regions_unmodified_def)
+  done
+
+lemma cleanCacheRange_PoC_preserves_bytes:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call cleanCacheRange_PoC_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> byte_regions_unmodified' s t}"
+  apply (hoare_rule HoarePartial.ProcNoRec1)
+  apply (clarsimp simp only: whileAnno_def)
+  apply (subst whileAnno_def[symmetric, where V=undefined
+       and I="{t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> byte_regions_unmodified' s t}" for s])
+  apply (rule conseqPre, vcg exspec=cleanByVA_preserves_bytes)
+  apply (safe intro!: byte_regions_unmodified_hrs_mem_update
+    elim!: byte_regions_unmodified_trans byte_regions_unmodified_trans[rotated],
+    (simp_all add: h_t_valid_field)+)
+  done
+
+lemma cleanL2Range_preserves_bytes:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call plat_cleanL2Range_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> byte_regions_unmodified' s t}"
+  apply (rule allI, rule conseqPost, rule cleanL2Range_preserves_kernel_bytes[rule_format]; simp)
+  apply (clarsimp simp: byte_regions_unmodified_def)
+  done
+
+lemma dsb_preserves_bytes:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call dsb_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> byte_regions_unmodified' s t}"
+  apply (rule allI, rule conseqPost, rule dsb_preserves_kernel_bytes[rule_format]; simp)
+  apply (clarsimp simp: byte_regions_unmodified_def)
+  done
+
+lemma cleanCacheRange_RAM_preserves_bytes:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call cleanCacheRange_RAM_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> byte_regions_unmodified' s t}"
+  apply (hoare_rule HoarePartial.ProcNoRec1, rule allI)
+  apply (rule conseqPre)
+   apply (vcg exspec=cleanL2Range_preserves_bytes exspec=cleanCacheRange_PoC_preserves_bytes exspec=dsb_preserves_bytes)
+  apply (fastforce elim!: byte_regions_unmodified_trans)
+  done
+
 lemma resetUntypedCap_ccorres:
   notes upt.simps[simp del] Collect_const[simp del] replicate_numeral[simp del]
         untypedBits_defs[simp] if_cong[cong] option.case_cong[cong]
@@ -1914,7 +1965,7 @@ lemma resetUntypedCap_ccorres:
           apply (simp add: guard_is_UNIV_def)
          apply wp
         apply simp
-        apply (vcg exspec=cleanCacheRange_PoU_preserves_bytes)
+        apply (vcg exspec=cleanCacheRange_RAM_preserves_bytes)
        apply (rule_tac P="reset_chunk_bits \<le> capBlockSize (cteCap cte)
              \<and> of_nat (capFreeIndex (cteCap cte)) - 1
                  < (2 ^ capBlockSize (cteCap cte) :: addr)"
@@ -2007,7 +2058,7 @@ lemma resetUntypedCap_ccorres:
                 apply (simp add: guard_is_UNIV_def)
                apply (wp hoare_vcg_ex_lift doMachineOp_psp_no_overlap)
               apply clarsimp
-              apply (vcg exspec=cleanCacheRange_PoU_preserves_bytes)
+              apply (vcg exspec=cleanCacheRange_RAM_preserves_bytes)
              apply clarify
              apply (rule conjI)
               apply (clarsimp simp: invs_valid_objs' cte_wp_at_ctes_of
@@ -2080,7 +2131,7 @@ lemma resetUntypedCap_ccorres:
              apply (simp add: is_aligned_def addr_card_def card_word)
              apply clarsimp
 
-            apply (rule conseqPre, vcg exspec=cleanCacheRange_PoU_preserves_bytes
+            apply (rule conseqPre, vcg exspec=cleanCacheRange_RAM_preserves_bytes
               exspec=preemptionPoint_modifies)
             apply (clarsimp simp: in_set_conv_nth isCap_simps
                                   length_upto_enum_step upto_enum_step_nth

--- a/proof/crefine/ARM_HYP/Machine_C.thy
+++ b/proof/crefine/ARM_HYP/Machine_C.thy
@@ -587,8 +587,8 @@ lemma cleanInvalidateCacheRange_RAM_ccorres:
    apply (rule ccorres_Guard_Seq)
    apply (rule ccorres_basic_srnoop)
      apply (simp add: cleanInvalidateCacheRange_RAM_def doMachineOp_bind
-                      empty_fail_dsb empty_fail_cleanCacheRange_PoC empty_fail_cleanInvalidateL2Range
-                      empty_fail_cacheRangeOp empty_fail_cleanInvalByVA)
+                      empty_fail_dsb empty_fail_cleanInvalidateL2Range
+                      empty_fail_cleanInvalByVA)
      apply (ctac (no_vcg) add: cleanCacheRange_PoC_ccorres)
       apply (ctac (no_vcg) add: dsb_ccorres)
        apply (ctac (no_vcg) add: plat_cleanInvalidateL2Range_ccorres)
@@ -620,8 +620,7 @@ lemma cleanCacheRange_RAM_ccorres:
            (doMachineOp (cleanCacheRange_RAM w1 w2 w3))
            (Call cleanCacheRange_RAM_'proc)"
   apply (cinit' lift: start_' end_' pstart_')
-   apply (simp add: cleanCacheRange_RAM_def doMachineOp_bind
-                    empty_fail_dsb empty_fail_cleanCacheRange_PoC empty_fail_cleanL2Range)
+   apply (simp add: cleanCacheRange_RAM_def doMachineOp_bind empty_fail_dsb empty_fail_cleanL2Range)
    apply (rule ccorres_Guard_Seq)
    apply (rule ccorres_basic_srnoop2, simp)
    apply (ctac (no_vcg) add: cleanCacheRange_PoC_ccorres)

--- a/proof/crefine/ARM_HYP/Machine_C.thy
+++ b/proof/crefine/ARM_HYP/Machine_C.thy
@@ -136,6 +136,24 @@ assumes cleanByVA_PoU_preserves_kernel_bytes:
          \<and> (\<forall>x. snd (hrs_htd (t_hrs_' (globals s)) x) 0 \<noteq> None
              \<longrightarrow> hrs_mem (t_hrs_' (globals t)) x = hrs_mem (t_hrs_' (globals s)) x)}"
 
+assumes cleanByVA_preserves_kernel_bytes:
+ "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call cleanByVA_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> (\<forall>x. snd (hrs_htd (t_hrs_' (globals s)) x) 0 \<noteq> None
+             \<longrightarrow> hrs_mem (t_hrs_' (globals t)) x = hrs_mem (t_hrs_' (globals s)) x)}"
+
+assumes cleanL2Range_preserves_kernel_bytes:
+ "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call plat_cleanL2Range_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> (\<forall>x. snd (hrs_htd (t_hrs_' (globals s)) x) 0 \<noteq> None
+             \<longrightarrow> hrs_mem (t_hrs_' (globals t)) x = hrs_mem (t_hrs_' (globals s)) x)}"
+
+assumes dsb_preserves_kernel_bytes:
+ "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call dsb_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> (\<forall>x. snd (hrs_htd (t_hrs_' (globals s)) x) 0 \<noteq> None
+             \<longrightarrow> hrs_mem (t_hrs_' (globals t)) x = hrs_mem (t_hrs_' (globals s)) x)}"
+
 assumes invalidateByVA_ccorres:
   "ccorres dc xfdc \<top> (\<lbrace>\<acute>vaddr = w1\<rbrace> \<inter> \<lbrace>\<acute>paddr = w2\<rbrace>) []
            (doMachineOp (invalidateByVA w1 w2))

--- a/proof/crefine/ARM_HYP/Recycle_C.thy
+++ b/proof/crefine/ARM_HYP/Recycle_C.thy
@@ -367,7 +367,7 @@ lemma clearMemory_PageCap_ccorres:
        subgoal by (simp add: pageBits_def ko_at_projectKO_opt[OF user_data_at_ko])
       subgoal by simp
      apply csymbr
-     apply (ctac add: cleanCacheRange_PoU_ccorres[unfolded dc_def])
+     apply (ctac add: cleanCacheRange_RAM_ccorres[unfolded dc_def])
     apply wp
    apply (simp add: guard_is_UNIV_def unat_of_nat
                     word_bits_def capAligned_def word_of_nat_less)
@@ -628,7 +628,7 @@ lemma page_directory_at_rf_sr_dom_s:
   apply (auto simp add: intvl_def shiftl_t2n)[1]
   done
 
-lemma clearMemory_setObject_PTE_ccorres:
+lemma clearMemory_PT_setObject_PTE_ccorres:
   "ccorres dc xfdc (page_table_at' ptr
                 and (\<lambda>s. 2 ^ ptBits \<le> gsMaxObjectSize s)
                 and (\<lambda>_. is_aligned ptr ptBits \<and> ptr \<noteq> 0 \<and> pstart = addrFromPPtr ptr))
@@ -637,7 +637,7 @@ lemma clearMemory_setObject_PTE_ccorres:
                        [ptr , ptr + 2 ^ objBits ARM_HYP_H.InvalidPTE .e. ptr + 2 ^ ptBits - 1];
            doMachineOp (cleanCacheRange_PoU ptr (ptr + 2 ^ ptBits - 1) pstart)
         od)
-       (Call clearMemory_'proc)"
+       (Call clearMemory_PT_'proc)"
   apply (rule ccorres_gen_asm)+
   apply (cinit' lift: ptr___ptr_to_unsigned_long_' bits_')
    apply (rule ccorres_Guard_Seq)

--- a/proof/crefine/ARM_HYP/Recycle_C.thy
+++ b/proof/crefine/ARM_HYP/Recycle_C.thy
@@ -681,7 +681,7 @@ lemma clearMemory_PT_setObject_PTE_ccorres:
                         update_pte_map_to_ptes carray_map_relation_upd_triv)
        apply (rule cmap_relation_updI, simp_all)[1]
        apply (simp add: cpte_relation_def Let_def pte_lift_def
-                        fcp_beta pte_get_tag_def pte_tag_defs)
+                        pte_get_tag_def pte_tag_defs)
        apply (simp add: carch_state_relation_def cmachine_state_relation_def
                         typ_heap_simps update_pte_map_tos)
       apply csymbr

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -7929,9 +7929,8 @@ lemma insertNewCap_preserves_bytes_flip:
   "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call insertNewCap_'proc
       {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
          \<and> byte_regions_unmodified' t s}"
-  by (rule allI, rule conseqPost,
-    rule insertNewCap_preserves_bytes[rule_format],
-    auto elim: byte_regions_unmodified_flip_eq)
+  by (rule allI, rule conseqPost, rule insertNewCap_preserves_bytes[rule_format])
+     (auto elim: byte_regions_unmodified_flip_eq)
 
 lemma copyGlobalMappings_preserves_bytes:
   "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call copyGlobalMappings_'proc
@@ -7959,13 +7958,12 @@ lemma cleanCacheRange_PoU_preserves_bytes:
   apply (hoare_rule HoarePartial.ProcNoRec1)
   apply (clarsimp simp only: whileAnno_def)
   apply (subst whileAnno_def[symmetric, where V=undefined
-       and I="{t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
-         \<and> byte_regions_unmodified' s t}" for s])
+               and I="{t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+                          \<and> byte_regions_unmodified' s t}" for s])
   apply (rule conseqPre, vcg exspec=cleanByVA_PoU_preserves_bytes)
-  apply (safe intro!: byte_regions_unmodified_hrs_mem_update
-    elim!: byte_regions_unmodified_trans byte_regions_unmodified_trans[rotated],
-    (simp_all add: h_t_valid_field)+)
-  done
+    by (safe intro!: byte_regions_unmodified_hrs_mem_update
+              elim!: byte_regions_unmodified_trans byte_regions_unmodified_trans[rotated],
+        (simp_all add: h_t_valid_field)+)
 
 lemma hrs_htd_update_canon:
   "hrs_htd_update (\<lambda>_. f (hrs_htd hrs)) hrs = hrs_htd_update f hrs"
@@ -8015,20 +8013,19 @@ lemma createObject_preserves_bytes:
   apply (hoare_rule HoarePartial.ProcNoRec1)
   apply clarsimp
   apply (rule conseqPre, vcg exspec=Arch_createObject_preserves_bytes
-    exspec=cap_thread_cap_new_modifies
-    exspec=cap_endpoint_cap_new_modifies
-    exspec=cap_notification_cap_new_modifies
-    exspec=cap_cnode_cap_new_modifies
-    exspec=cap_untyped_cap_new_modifies)
+                             exspec=cap_thread_cap_new_modifies
+                             exspec=cap_endpoint_cap_new_modifies
+                             exspec=cap_notification_cap_new_modifies
+                             exspec=cap_cnode_cap_new_modifies
+                             exspec=cap_untyped_cap_new_modifies)
   apply (safe intro!: byte_regions_unmodified_hrs_mem_update,
-    (simp_all add: h_t_valid_field hrs_htd_update)+)
-  apply (safe intro!: ptr_retyp_d ptr_retyps_out trans[OF ptr_retyp_d ptr_retyp_d]
-                      ptr_arr_retyps_eq_outside_dom)
-  apply (simp_all add: object_type_from_H_def Kernel_C_defs APIType_capBits_def
-                       objBits_simps' cte_C_size power_add ctcb_offset_defs
-    split: object_type.split_asm ArchTypes_H.apiobject_type.split_asm)
-   apply (erule notE, erule subsetD[rotated],
-     rule intvl_start_le intvl_sub_offset, simp)+
+         (simp_all add: h_t_valid_field hrs_htd_update)+)
+     apply (safe intro!: ptr_retyp_d ptr_retyps_out trans[OF ptr_retyp_d ptr_retyp_d]
+                         ptr_arr_retyps_eq_outside_dom)
+      apply (simp_all add: object_type_from_H_def Kernel_C_defs APIType_capBits_def
+                           objBits_simps' cte_C_size power_add ctcb_offset_defs
+                      split: object_type.split_asm apiobject_type.split_asm)
+    apply (erule notE, erule subsetD[rotated], rule intvl_start_le intvl_sub_offset, simp)+
   done
 
 

--- a/proof/drefine/KHeap_DR.thy
+++ b/proof/drefine/KHeap_DR.thy
@@ -174,7 +174,6 @@ termination revoke_cap_simple
 
 declare revoke_cap_simple.simps [simp del]
 declare KHeap_DR.resolve_address_bits.simps [simp del]
-declare CSpace_A.resolve_address_bits'.simps [simp del]
 
 lemma dcorres_revoke_cap_simple_helper:
   "\<lbrakk> dcorres r P P'

--- a/proof/infoflow/ADT_IF.thy
+++ b/proof/infoflow/ADT_IF.thy
@@ -3133,6 +3133,9 @@ lemma irq_state_inv_trivE':
   apply simp
   done
 
+crunch irq_state[wp]: cleanCacheRange_PoU "\<lambda>s. P (irq_state s)"
+  (ignore_del: cleanCacheRange_PoU cleanByVA_PoU)
+
 crunch irq_state_of_state[wp]: init_arch_objects "\<lambda>s. P (irq_state_of_state s)"
   (wp: crunch_wps dmo_wp ignore: do_machine_op)
 

--- a/proof/infoflow/IRQMasks_IF.thy
+++ b/proof/infoflow/IRQMasks_IF.thy
@@ -36,6 +36,9 @@ lemma delete_objects_irq_masks[wp]:
   apply(wp dmo_wp no_irq_mapM_x no_irq | simp add: freeMemory_def no_irq_storeWord)+
   done
 
+crunch irq_masks[wp]: cleanCacheRange_PoU "\<lambda>s. P (irq_masks s)"
+   (ignore_del: cleanCacheRange_PoU)
+
 crunch irq_masks[wp]: invoke_untyped "\<lambda>s. P (irq_masks_of_state s)"
   (ignore: delete_objects wp: crunch_wps dmo_wp
        wp: mapME_x_inv_wp preemption_point_inv

--- a/proof/invariant-abstract/ARM/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchRetype_AI.thy
@@ -1300,8 +1300,11 @@ lemma invs_irq_state_independent:
       cur_tcb_def sym_refs_def state_refs_of_def
       swp_def valid_irq_states_def)
 
-crunch irq_masks_inv[wp]: cleanByVA_PoU, storeWord, clearMemory "\<lambda>s. P (irq_masks s)"
-  (wp: crunch_wps ignore_del: cleanByVA_PoU storeWord clearMemory)
+crunches cleanByVA, cleanCacheRange_PoC, dsb, cleanCacheRange_PoC, cleanL2Range, cleanByVA_PoU,
+  storeWord, clearMemory
+  for irq_masks_inv[wp]: "\<lambda>s. P (irq_masks s)"
+  (wp: crunch_wps
+   ignore_del: cleanByVA_PoU storeWord clearMemory cleanL2Range cleanCacheRange_PoC dsb cleanByVA)
 
 crunch underlying_mem_0[wp]: clearMemory
     "\<lambda>s. underlying_memory s p = 0"

--- a/proof/invariant-abstract/ARM_HYP/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchRetype_AI.thy
@@ -1152,8 +1152,11 @@ lemma invs_irq_state_independent:
       swp_def valid_irq_states_def split: option.split)
   done
 
-crunch irq_masks_inv[wp]: cleanByVA_PoU, storeWord, clearMemory "\<lambda>s. P (irq_masks s)"
-  (wp: crunch_wps ignore_del: cleanByVA_PoU storeWord clearMemory)
+crunches cleanByVA, cleanCacheRange_PoC, dsb, cleanCacheRange_PoC, cleanL2Range, cleanByVA_PoU,
+  storeWord, clearMemory
+  for irq_masks_inv[wp]: "\<lambda>s. P (irq_masks s)"
+  (wp: crunch_wps
+   ignore_del: cleanByVA_PoU storeWord clearMemory cleanL2Range cleanCacheRange_PoC dsb cleanByVA)
 
 crunch underlying_mem_0[wp]: clearMemory
     "\<lambda>s. underlying_memory s p = 0"

--- a/spec/machine/ARM/MachineOps.thy
+++ b/spec/machine/ARM/MachineOps.thy
@@ -460,7 +460,7 @@ definition
   where
  "clearMemory ptr bytelength \<equiv>
   do mapM_x (\<lambda>p. storeWord p 0) [ptr, ptr + word_size .e. ptr + (of_nat bytelength) - 1];
-     cleanCacheRange_PoU ptr (ptr + of_nat bytelength - 1) (addrFromPPtr ptr)
+     cleanCacheRange_RAM ptr (ptr + of_nat bytelength - 1) (addrFromPPtr ptr)
   od"
 
 definition

--- a/spec/machine/ARM_HYP/MachineOps.thy
+++ b/spec/machine/ARM_HYP/MachineOps.thy
@@ -479,7 +479,7 @@ definition
   where
  "clearMemory ptr bytelength \<equiv>
   do mapM_x (\<lambda>p. storeWord p 0) [ptr, ptr + word_size .e. ptr + (of_nat bytelength) - 1];
-     cleanCacheRange_PoU ptr (ptr + of_nat bytelength - 1) (addrFromPPtr ptr)
+     cleanCacheRange_RAM ptr (ptr + of_nat bytelength - 1) (addrFromPPtr ptr)
   od"
 
 definition


### PR DESCRIPTION
This updates the proofs for PR seL4/seL4#485, which fixes the correctness and security issue seL4/seL4#481.

In addition this PR contains one commit for adjacent cleanup and one commit to fix too-general machine assumptions.

The cache fix makes 3 new machine assumptions necessary: that more of the caching functions do not touch memory. This is derivable in ASpec and ExecSpec, but needs to be assumed for the corresponding C/asm-level machine ops.

Test with seL4/seL4#485