### PR TITLE
more opt map lemmas: updates

### DIFF
--- a/lib/Monad_WP/OptionMonad.thy
+++ b/lib/Monad_WP/OptionMonad.thy
@@ -71,21 +71,21 @@ lemma opt_map_fold_l:
   by (clarsimp simp: opt_map_def)
 
 (* LHS is the same as (f ||> id) *)
-lemma opt_map_unit_r[simp]:
-  "(f |> Some) x = f x"
-  by (clarsimp simp: opt_map_def split: option.split)
+lemma opt_map_Some_id_r[simp]:
+  "f |> Some = f"
+  by (fastforce simp: opt_map_def split: option.split)
 
-lemma opt_map_unit_l[simp]:
-  "(Some |> f) x = f x"
+lemma opt_map_Some_id_l[simp]:
+  "Some |> f = f"
   by (clarsimp simp: opt_map_def split: option.split)
 
 lemma opt_map_zero_l[simp]:
-  "(Map.empty |> g) x = None"
+  "Map.empty |> g = Map.empty"
   by (clarsimp simp: opt_map_def)
 
 lemma opt_map_zero_r[simp]:
-  "(f |> Map.empty) x = None"
-  by (clarsimp simp: opt_map_def split: option.split)
+  "f |> Map.empty = Map.empty"
+  by (fastforce simp: opt_map_def split: option.split)
 
 lemma case_opt_map_distrib:
   "((\<lambda>s. case_option None g (f s)) |> h)

--- a/lib/Monad_WP/OptionMonad.thy
+++ b/lib/Monad_WP/OptionMonad.thy
@@ -60,10 +60,27 @@ lemma opt_map_upd_Some:
   "f(x \<mapsto> v) |> g = (f |> g)(x := g v)"
   by (auto simp: opt_map_def)
 
-lemmas opt_map_upd[simp] = opt_map_upd_None opt_map_upd_Some
+lemma opt_map_Some_upd_None:
+  "f(x := None) ||> g = (f ||> g)(x := None)"
+  by (auto simp: opt_map_def)
+
+lemma opt_map_Some_upd_Some:
+  "f(x \<mapsto> v) ||> g = (f ||> g)(x \<mapsto> g v)"
+  by (simp add: opt_map_upd_Some)
+
+lemmas opt_map_upd[simp]
+  = opt_map_upd_None opt_map_upd_Some opt_map_Some_upd_None opt_map_Some_upd_Some
+
+lemma opt_map_upd_triv[simp]:
+  "t k = Some x \<Longrightarrow> (t |> f)(k := f x) = t |> f"
+  by (rule ext) (clarsimp simp add: opt_map_red)
+
+lemma opt_map_Some_upd_triv[simp]:
+  "t k = Some x \<Longrightarrow> (t ||> f)(k \<mapsto> f x) = t ||> f"
+  by (rule ext) (clarsimp simp add: opt_map_red)
 
 lemma opt_map_Some_comp[simp]:
-  "f ||> h o g = f ||> g ||> h"
+  "f ||> g ||> h = f ||> h o g"
   by (fastforce simp: opt_map_def split: option.split)
 
 lemma opt_map_fold_l:


### PR DESCRIPTION
Another small addition to our `opt_map` lemma collection.
For state updates and others. The eta_contraction tweak from the last PR is also included.