### PR TITLE
cherry-pick CI update from master

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - master
+      - rt
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 -->
 
 [![DOI][0]](http://dx.doi.org/10.5281/zenodo.591732)
+[![CI](https://github.com/seL4/l4v/actions/workflows/push.yml/badge.svg)](https://github.com/seL4/l4v/actions/workflows/push.yml)
+[![Proofs](https://github.com/seL4/l4v/actions/workflows/proof-deploy.yml/badge.svg)](https://github.com/seL4/l4v/actions/workflows/proof-deploy.yml)
+[![Weekly Clean](https://github.com/seL4/l4v/actions/workflows/weekly-clean.yml/badge.svg)](https://github.com/seL4/l4v/actions/workflows/weekly-clean.yml)
+[![External](https://github.com/seL4/l4v/actions/workflows/external.yml/badge.svg)](https://github.com/seL4/l4v/actions/workflows/external.yml)
+
+MCS:\
+[![CI](https://github.com/seL4/l4v/actions/workflows/push.yml/badge.svg?branch=rt)](https://github.com/seL4/l4v/actions/workflows/push.yml)
+[![RT Proofs](https://github.com/seL4/l4v/actions/workflows/proof.yml/badge.svg?branch=rt)](https://github.com/seL4/l4v/actions/workflows/proof.yml)
 
   [0]: https://zenodo.org/badge/doi/10.5281/zenodo.591732.svg
 


### PR DESCRIPTION
This adds the badges and CI-runs for RT from the master branch so that the MCS CI badge shows actual status information.