### PR TITLE
github: no PR proof run for text file updates

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -6,11 +6,17 @@ name: Proofs
 
 on:
   push:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
     branches:
       - rt
   # this action needs access to secrets.
   # The actual test runs in a no-privilege VM, so it's Ok to run on untrusted PRs.
   pull_request_target:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
 
 jobs:
   all:


### PR DESCRIPTION
Save some CI cycles by not running the full proofs for each documentation update.

