### PR TITLE
github: trigger proof run on manifest update

### DIFF
--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -10,6 +10,9 @@ on:
   push:
     branches:
       - master
+  repository_dispatch:
+    types:
+      - manifest-update
 
 jobs:
   code:


### PR DESCRIPTION
The repository_dispatch event will be generated in the [verification-manifest] repo when devel.xml is updated by anyone other than the seL4-ci user.

[verification-manifest]: https://github.com/seL4/verification-manifest