### PR TITLE
`cur_sc_tcb`

### DIFF
--- a/proof/invariant-abstract/AInvs.thy
+++ b/proof/invariant-abstract/AInvs.thy
@@ -45,6 +45,7 @@ lemma akernel_invs:
   unfolding call_kernel_def preemption_path_def
   apply (wpsimp wp: activate_invs check_budget_invs charge_budget_invs is_schedulable_wp
                     update_time_stamp_invs hoare_drop_imps hoare_vcg_all_lift hoare_vcg_if_lift2)
+  apply (fastforce intro: cur_sc_tcb_invs)
   done
 
 (*FIXME: should have (scheduler_action s = resume_cur_thread) as a postcondition*)

--- a/proof/invariant-abstract/ARM/ArchArch_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchArch_AI.thy
@@ -653,7 +653,6 @@ lemma perform_asid_control_invocation_non_cspace_obj_at:
   "\<lbrace>obj_at P t
       and ex_nonz_cap_to t
       and ct_active
-      and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and invs
       and valid_aci aci\<rbrace>
    perform_asid_control_invocation aci
@@ -688,7 +687,6 @@ lemma perform_asid_control_invocation_st_tcb_at:
   "\<lbrace>pred_tcb_at proj P t
       and ex_nonz_cap_to t
       and ct_active
-      and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and invs
       and valid_aci aci\<rbrace>
    perform_asid_control_invocation aci
@@ -700,7 +698,6 @@ lemma perform_asid_control_invocation_sc_at_pred_n:
   "\<lbrace>sc_at_pred_n N proj P scp
       and ex_nonz_cap_to scp
       and ct_active
-      and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and invs
       and valid_aci aci\<rbrace>
    perform_asid_control_invocation aci
@@ -733,7 +730,7 @@ lemma aci_invs':
   assumes retype_region_Q[wp]:"\<And>a b c d e. \<lbrace>Q\<rbrace> retype_region a b c d e \<lbrace>\<lambda>_.Q\<rbrace>"
   assumes set_cap_Q[wp]: "\<And>a b. \<lbrace>Q\<rbrace> set_cap a b \<lbrace>\<lambda>_.Q\<rbrace>"
   shows
-  "\<lbrace>invs and Q and ct_active and (\<lambda>s. scheduler_action s = resume_cur_thread) and valid_aci aci\<rbrace>
+  "\<lbrace>invs and Q and ct_active and valid_aci aci\<rbrace>
    perform_asid_control_invocation aci \<lbrace>\<lambda>y s. invs s \<and> Q s\<rbrace>"
   proof -
   have cap_insert_invsQ:
@@ -872,7 +869,7 @@ qed
 lemmas aci_invs[wp] = aci_invs'[where Q=\<top>,simplified hoare_post_taut, OF refl refl refl TrueI TrueI TrueI,simplified]
 
 lemma invoke_arch_invs[wp]:
-  "\<lbrace>invs and ct_active and (\<lambda>s. scheduler_action s = resume_cur_thread) and valid_arch_inv ai\<rbrace>
+  "\<lbrace>invs and ct_active and valid_arch_inv ai\<rbrace>
    arch_perform_invocation ai
    \<lbrace>\<lambda>rv. invs\<rbrace>"
   apply (cases ai, simp_all add: valid_arch_inv_def arch_perform_invocation_def)
@@ -1504,7 +1501,6 @@ lemma arch_pinv_st_tcb_at:
   "\<lbrace>pred_tcb_at proj P t
       and ex_nonz_cap_to t
       and ct_active
-      and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and invs
       and valid_arch_inv ai\<rbrace>
    arch_perform_invocation ai
@@ -1521,7 +1517,7 @@ crunches arch_perform_invocation
   (wp: crunch_wps simp: crunch_simps)
 
 lemma arch_pinv_ct_active:
-  "\<lbrace>invs and valid_arch_inv ai and ct_active and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+  "\<lbrace>invs and valid_arch_inv ai and ct_active\<rbrace>
      arch_perform_invocation ai
    \<lbrace>\<lambda>rv. ct_active\<rbrace>" (is "\<lbrace>?P\<rbrace> _ \<lbrace>_\<rbrace>")
   apply (wpsimp wp: ct_in_state_thread_state_lift'[where Pre="\<lambda>_. ?P"]

--- a/proof/invariant-abstract/ARM/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetype_AI.thy
@@ -563,7 +563,7 @@ context begin interpretation Arch .
 lemma delete_objects_invs[wp]:
   "\<lbrace>(\<lambda>s. \<exists>slot. cte_wp_at ((=) (cap.UntypedCap dev ptr bits f)) slot s
     \<and> descendants_range (cap.UntypedCap dev ptr bits f) slot s) and
-    invs and ct_active and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+    invs and ct_active\<rbrace>
     delete_objects ptr bits \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: delete_objects_def)
   apply (simp add: freeMemory_def word_size_def bind_assoc

--- a/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
@@ -765,8 +765,7 @@ crunch valid_pdpt[wp]: reset_untyped_cap "valid_pdpt_objs"
   (wp: mapME_x_inv_wp crunch_wps simp: crunch_simps unless_def)
 
 lemma invoke_untyped_valid_pdpt[wp]:
-  "\<lbrace>valid_pdpt_objs and invs and ct_active and valid_untyped_inv ui and
-    (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+  "\<lbrace>valid_pdpt_objs and invs and ct_active and valid_untyped_inv ui\<rbrace>
        invoke_untyped ui
    \<lbrace>\<lambda>rv. valid_pdpt_objs\<rbrace>"
   apply (rule hoare_pre, rule invoke_untyped_Q)
@@ -1161,8 +1160,7 @@ crunches check_budget_restart, invoke_sched_control_configure_flags
 
 lemma perform_invocation_valid_pdpt[wp]:
   "\<lbrace>invs and ct_active and valid_invocation i and valid_pdpt_objs and
-    invocation_duplicates_valid i and
-    (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+    invocation_duplicates_valid i\<rbrace>
    perform_invocation blocking call can_donate i
    \<lbrace>\<lambda>rv. valid_pdpt_objs::det_state \<Rightarrow> _\<rbrace>"
   apply (cases i, simp_all)
@@ -1615,12 +1613,11 @@ lemma set_thread_state_duplicates_valid[wp]:
 
 lemma handle_invocation_valid_pdpt[wp]:
   "\<lbrace>\<lambda>s. valid_pdpt_objs s \<and> invs s \<and> ct_active s \<and>
-        scheduler_action s = resume_cur_thread \<and>
         is_schedulable_bool (cur_thread s) s\<rbrace>
      handle_invocation calling blocking can_donate first_phase cptr
    \<lbrace>\<lambda>rv. valid_pdpt_objs::det_state \<Rightarrow> _\<rbrace>"
   apply (simp add: handle_invocation_def)
-  apply (wp syscall_valid set_thread_state_ct_st sts_schedulable_scheduler_action
+  apply (wp syscall_valid set_thread_state_ct_st
          | simp add: split_def cong: conj_cong | wpc
          | wp (once) hoare_drop_imps)+
   apply (fastforce simp: ct_in_state_def fault_tcbs_valid_states_active
@@ -1654,7 +1651,6 @@ lemma schedule_valid_pdpt[wp]: "\<lbrace>valid_pdpt_objs\<rbrace> schedule :: (u
 
 lemma call_kernel_valid_pdpt[wp]:
   "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s) and valid_pdpt_objs
-     and (\<lambda>s. scheduler_action s = resume_cur_thread)
      and (\<lambda>s. is_schedulable_bool (cur_thread s) s)\<rbrace>
       (call_kernel e) :: (unit,det_ext) s_monad
         \<lbrace>\<lambda>_. valid_pdpt_objs\<rbrace>"
@@ -1664,13 +1660,11 @@ lemma call_kernel_valid_pdpt[wp]:
         apply (rule_tac Q="\<lambda>_. (\<lambda>s. \<forall>x\<in>ran (kheap s). obj_valid_pdpt x)" in handleE_wp[rotated])
          apply (rule_tac B="\<lambda>_. invs and ct_running and
            (\<lambda>s. \<forall>x\<in>ran (kheap s). obj_valid_pdpt x) and
-           (\<lambda>s. scheduler_action s = resume_cur_thread) and
            (\<lambda>s. is_schedulable_bool (cur_thread s) s)" in seqE)
           apply (rule liftE_wp)
           apply (wpsimp wp: hoare_vcg_ex_lift)
          apply (rule_tac B="\<lambda>rv. invs and (\<lambda>s. rv \<longrightarrow> ct_running s) and
            (\<lambda>s. \<forall>x\<in>ran (kheap s). obj_valid_pdpt x) and
-           (\<lambda>s. rv \<longrightarrow> scheduler_action s = resume_cur_thread) and
            (\<lambda>s. rv \<longrightarrow> (is_schedulable_bool (cur_thread s) s))" in seqE)
           apply (rule liftE_wp)
           apply (wpsimp wp: check_budget_restart_true)

--- a/proof/invariant-abstract/Detype_AI.thy
+++ b/proof/invariant-abstract/Detype_AI.thy
@@ -481,8 +481,7 @@ locale Detype_AI_2 =
        descendants_range cap ptr s;
        invs s;
        untyped_children_in_mdb s;
-       ct_active s;
-       scheduler_action s = resume_cur_thread
+       ct_active s
       \<rbrakk>
      \<Longrightarrow> (invs and untyped_children_in_mdb)
                (detype (untyped_range cap) (clear_um (untyped_range cap) s))"
@@ -739,7 +738,7 @@ lemma cut_tcb_detype[detype_invs_lemmas]:
   done
 
 lemma cut_sc_tcb_detype[detype_invs_lemmas]:
-  assumes ct_act: "ct_active s \<and> scheduler_action s = resume_cur_thread"
+  assumes ct_act: "ct_active s"
   shows "cur_sc_tcb (detype (untyped_range cap) s)" (* CT_ACT *)
   apply (insert ct_act invs)
   apply (clarsimp simp: detype_def)
@@ -914,7 +913,7 @@ end
 
 context detype_locale_gen_2 begin
 lemma invariants:
-  assumes ct_act: "ct_active s \<and> scheduler_action s = resume_cur_thread"
+  assumes ct_act: "ct_active s"
   shows "(invs and untyped_children_in_mdb)
          (detype (untyped_range cap) (clear_um (untyped_range cap) s))"
   using detype_invs_lemmas detype_invs_assms ct_act

--- a/proof/invariant-abstract/Invariants_AI.thy
+++ b/proof/invariant-abstract/Invariants_AI.thy
@@ -1276,10 +1276,8 @@ definition
   "cur_tcb s \<equiv> tcb_at (cur_thread s) s"
 
 definition
-  "cur_sc_tcb s \<equiv>
-     sc_tcb_sc_at
-       (\<lambda>t. scheduler_action s = resume_cur_thread \<longrightarrow> t = Some (cur_thread s))
-       (cur_sc s) s"
+  "cur_sc_tcb s
+    \<equiv> (scheduler_action s = resume_cur_thread) \<longrightarrow> sc_tcb_sc_at (\<lambda>t. t = Some (cur_thread s)) (cur_sc s) s"
 
 definition valid_machine_time_2 :: "time \<Rightarrow> time \<Rightarrow> bool" where
    "valid_machine_time_2 ct lmt \<equiv> lmt \<le> - getCurrentTime_buffer - 1 \<and> ct \<le> lmt"

--- a/proof/invariant-abstract/IpcDet_AI.thy
+++ b/proof/invariant-abstract/IpcDet_AI.thy
@@ -1225,26 +1225,14 @@ lemma maybe_return_sc_sc_at_ppred:
                       get_object_def)
   by (auto simp: sc_at_pred_n_def obj_at_def pred_tcb_at_def get_tcb_SomeD)
 
-lemma reschedule_required_cur_sc_tcb':
-  "\<lbrace>\<lambda>s. sc_tcb_sc_at \<top> (cur_sc s) s\<rbrace> reschedule_required \<lbrace>\<lambda>_. cur_sc_tcb\<rbrace>"
-  supply set_scheduler_action_cur_sc_tcb [wp del]
-  unfolding reschedule_required_def
-  by (wpsimp simp: reschedule_required_def set_scheduler_action_def tcb_sched_action_def
-                   set_tcb_queue_def get_tcb_queue_def thread_get_def is_schedulable_def
-                   cur_sc_tcb_def sc_tcb_sc_at_def obj_at_def)
-
 lemma maybe_return_sc_cur_sc_tcb[wp]:
   "\<lbrace>cur_sc_tcb and (\<lambda>s. sym_refs (state_refs_of s)) and valid_objs\<rbrace>
-    maybe_return_sc ntfn_ptr thread
+   maybe_return_sc ntfn_ptr thread
    \<lbrace>\<lambda>_. cur_sc_tcb\<rbrace>"
-  supply reschedule_required_cur_sc_tcb' [wp]
-  supply reschedule_required_cur_sc_tcb [wp del]
   apply (wpsimp simp: maybe_return_sc_def update_sched_context_def
                       set_tcb_obj_ref_def set_object_def
                       get_tcb_obj_ref_def thread_get_def get_sk_obj_ref_def get_simple_ko_def
                       get_object_def)
-  apply (case_tac "thread = cur_thread s"; simp)
-   apply (fastforce split: if_split simp: sc_at_pred_n_def obj_at_def cur_sc_tcb_def)
   apply (clarsimp split: if_split simp: sc_at_pred_n_def obj_at_def cur_sc_tcb_def)
   apply (intro conjI allI impI; clarsimp?)
   apply (frule get_tcb_SomeD, clarsimp)

--- a/proof/invariant-abstract/RISCV64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchArch_AI.thy
@@ -710,7 +710,6 @@ lemma perform_asid_control_invocation_non_cspace_obj_at:
   "\<lbrace>obj_at P t
       and ex_nonz_cap_to t
       and ct_active
-      and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and invs
       and valid_aci aci\<rbrace>
    perform_asid_control_invocation aci
@@ -745,7 +744,6 @@ lemma perform_asid_control_invocation_st_tcb_at:
   "\<lbrace>pred_tcb_at proj P t
       and ex_nonz_cap_to t
       and ct_active
-      and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and invs
       and valid_aci aci\<rbrace>
    perform_asid_control_invocation aci
@@ -757,7 +755,6 @@ lemma perform_asid_control_invocation_sc_at_pred_n:
   "\<lbrace>sc_at_pred_n N proj P scp
       and ex_nonz_cap_to scp
       and ct_active
-      and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and invs
       and valid_aci aci\<rbrace>
    perform_asid_control_invocation aci
@@ -793,7 +790,7 @@ lemma aci_invs':
   assumes retype_region_Q[wp]:"\<And>a b c d e. \<lbrace>Q\<rbrace> retype_region a b c d e \<lbrace>\<lambda>_.Q\<rbrace>"
   assumes set_cap_Q[wp]: "\<And>a b. \<lbrace>Q\<rbrace> set_cap a b \<lbrace>\<lambda>_.Q\<rbrace>"
   shows
-  "\<lbrace>invs and Q and ct_active and (\<lambda>s. scheduler_action s = resume_cur_thread) and valid_aci aci\<rbrace>
+  "\<lbrace>invs and Q and ct_active and valid_aci aci\<rbrace>
    perform_asid_control_invocation aci \<lbrace>\<lambda>y s. invs s \<and> Q s\<rbrace>"
   proof -
   have cap_insert_invsQ:
@@ -930,7 +927,7 @@ lemmas aci_invs[wp] =
   aci_invs'[where Q=\<top>,simplified hoare_post_taut, OF refl refl refl TrueI TrueI TrueI,simplified]
 
 lemma invoke_arch_invs[wp]:
-  "\<lbrace>invs and ct_active and (\<lambda>s. scheduler_action s = resume_cur_thread) and valid_arch_inv ai\<rbrace>
+  "\<lbrace>invs and ct_active and valid_arch_inv ai\<rbrace>
    arch_perform_invocation ai
    \<lbrace>\<lambda>rv. invs\<rbrace>"
   apply (cases ai, simp_all add: valid_arch_inv_def arch_perform_invocation_def)
@@ -1319,7 +1316,6 @@ lemma arch_pinv_st_tcb_at:
   "\<lbrace>pred_tcb_at proj P t
       and ex_nonz_cap_to t
       and ct_active
-      and (\<lambda>s. scheduler_action s = resume_cur_thread)
       and invs
       and valid_arch_inv ai\<rbrace>
    arch_perform_invocation ai
@@ -1335,7 +1331,7 @@ crunches arch_perform_invocation
   (wp: crunch_wps simp: crunch_simps)
 
 lemma arch_pinv_ct_active:
-  "\<lbrace>invs and valid_arch_inv ai and ct_active and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+  "\<lbrace>invs and valid_arch_inv ai and ct_active\<rbrace>
      arch_perform_invocation ai
    \<lbrace>\<lambda>rv. ct_active\<rbrace>" (is "\<lbrace>?P\<rbrace> _ \<lbrace>_\<rbrace>")
   apply (wpsimp wp: ct_in_state_thread_state_lift'[where Pre="\<lambda>_. ?P"]

--- a/proof/invariant-abstract/RISCV64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetype_AI.thy
@@ -608,7 +608,7 @@ context begin interpretation Arch .
 lemma delete_objects_invs[wp]:
   "\<lbrace>(\<lambda>s. \<exists>slot. cte_wp_at ((=) (cap.UntypedCap dev ptr bits f)) slot s
     \<and> descendants_range (cap.UntypedCap dev ptr bits f) slot s) and
-    invs and ct_active and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+    invs and ct_active\<rbrace>
     delete_objects ptr bits \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: delete_objects_def)
   apply (simp add: freeMemory_def word_size_def bind_assoc ef_storeWord)

--- a/proof/invariant-abstract/Retype_AI.thy
+++ b/proof/invariant-abstract/Retype_AI.thy
@@ -1921,9 +1921,15 @@ lemma cur_tcb:
   apply (simp add: s'_def)
   done
 
+lemma schduler_action_s':
+  "scheduler_action s' = scheduler_action s"
+  by (simp add: s'_def ps_def)
+
 lemma cur_sc_tcb:
   "cur_sc_tcb s \<Longrightarrow> cur_sc_tcb s'"
-  apply (simp add: cur_sc_tcb_def sc_tcb_sc_at_def, rule obj_at_pres)
+  apply (simp add: cur_sc_tcb_def sc_tcb_sc_at_def schduler_action_s')
+  apply (cases "scheduler_action s"; clarsimp)
+  apply (rule obj_at_pres)
   apply (simp add: s'_def)
   done
 

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -1774,7 +1774,7 @@ lemma sc_sporadic_update_active[wp]:
   by (rule set_sc_obj_ref_active) simp
 
 lemma invoke_sched_control_configure_flags_invs[wp]:
-  "\<lbrace>\<lambda>s. invs s \<and> valid_sched_control_inv i s \<and> bound_sc_tcb_at bound (cur_thread s) s\<rbrace>
+  "\<lbrace>\<lambda>s. invs s \<and> valid_sched_control_inv i s\<rbrace>
    invoke_sched_control_configure_flags i
    \<lbrace>\<lambda>rv. invs\<rbrace>"
   supply if_split[split del]

--- a/proof/invariant-abstract/SchedContext_AI.thy
+++ b/proof/invariant-abstract/SchedContext_AI.thy
@@ -1365,7 +1365,7 @@ lemma tcb_sched_action_cur_sc_tcb [wp]:
   "\<lbrace>cur_sc_tcb\<rbrace> tcb_sched_action action thread \<lbrace>\<lambda>_. cur_sc_tcb\<rbrace>"
   by (wpsimp simp: tcb_sched_action_def set_tcb_queue_def)
 
-lemma reschedule_required_cur_sc_tcb [wp]:
+lemma reschedule_required_cur_sc_tcb_inv:
   "\<lbrace>cur_sc_tcb\<rbrace> reschedule_required \<lbrace>\<lambda>_. cur_sc_tcb\<rbrace>"
   by (wpsimp simp: reschedule_required_def set_scheduler_action_def tcb_sched_action_def
                    set_tcb_queue_def get_tcb_queue_def thread_get_def is_schedulable_def
@@ -1382,13 +1382,21 @@ lemma sched_context_bind_tcb_invs[wp]:
                     update_sched_context_valid_objs_same valid_ioports_lift
                     update_sched_context_iflive_update update_sched_context_refs_of_update
                     update_sched_context_cur_sc_tcb_None update_sched_context_valid_idle
-                    hoare_vcg_all_lift hoare_vcg_conj_lift | wp set_tcb_obj_ref_wp)+
+                    hoare_vcg_all_lift hoare_vcg_conj_lift
+                    reschedule_required_cur_sc_tcb_inv
+         | wp set_tcb_obj_ref_wp)+
   apply (fastforce simp: obj_at_def tcb_cap_cases_def tcb_st_refs_of_def is_sc_obj_def
                          pred_tcb_at_def sc_tcb_sc_at_def valid_sched_context_def
                          is_tcb valid_idle_def state_refs_of_def get_refs_def2
                    elim: ex_cap_to_after_update' delta_sym_refs valid_objs_valid_sched_context_size
                   dest!: symreftype_inverse' split: if_splits)
   done
+
+lemma reschedule_required_cur_sc_tcb[wp]:
+  "\<lbrace>\<top>\<rbrace> reschedule_required \<lbrace>\<lambda>_. cur_sc_tcb\<rbrace>"
+  by (wpsimp simp: reschedule_required_def set_scheduler_action_def tcb_sched_action_def
+                   set_tcb_queue_def get_tcb_queue_def thread_get_def is_schedulable_def
+                   cur_sc_tcb_def sc_tcb_sc_at_def obj_at_def)
 
 lemma maybe_sched_context_bind_tcb_invs[wp]:
   "\<lbrace>invs and (\<lambda>s. tcb_at tcb s \<and> (bound_sc_tcb_at (\<lambda>x. x \<noteq> Some sc) tcb s \<longrightarrow>

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -475,8 +475,8 @@ lemma do_reply_invs[wp]:
   done
 
 lemma pinv_invs[wp]:
-  "\<lbrace>\<lambda>s. invs s \<and> ct_active s \<and> valid_invocation i s \<and>
-        scheduler_action s = resume_cur_thread\<rbrace>
+  "\<lbrace>\<lambda>s. invs s \<and> ct_active s \<and> valid_invocation i s
+        \<and> bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s\<rbrace>
      perform_invocation blocking call can_donate i
    \<lbrace>\<lambda>rv. invs :: 'state_ext state \<Rightarrow> _\<rbrace>"
   apply (cases i
@@ -484,7 +484,7 @@ lemma pinv_invs[wp]:
                 simp: ct_in_state_def)
    apply (auto simp: invs_def valid_state_def valid_pspace_def cur_sc_tcb_def pred_tcb_at_def
                      obj_at_def sym_refs_bound_sc_tcb_iff_sc_tcb_sc_at[symmetric]
-                     if_live_then_nonz_capD2 live_def)
+                     if_live_then_nonz_capD2 live_def)[1]
   done
 
 end
@@ -539,8 +539,8 @@ context Syscall_AI begin
 
 lemma pinv_tcb[wp]:
   "\<And>tptr blocking call can_donate i.
-    \<lbrace>\<lambda>s. invs s \<and> st_tcb_at active tptr s \<and> ct_active s \<and> valid_invocation i s \<and>
-         scheduler_action s = resume_cur_thread\<rbrace>
+    \<lbrace>\<lambda>s. invs s \<and> st_tcb_at active tptr s \<and> ct_active s \<and> valid_invocation i s
+         \<and> bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s\<rbrace>
     perform_invocation blocking call can_donate i
     \<lbrace>\<lambda>rv. tcb_at tptr :: 'state_ext state \<Rightarrow> bool\<rbrace>"
   apply (case_tac i, simp_all split:option.splits)
@@ -1060,11 +1060,18 @@ lemma sts_schedulable_scheduler_action:
                   split: option.splits kernel_object.splits)
   done
 
+lemma set_thread_state_bound_sc_tcb_at_some_cur_thread[wp]:
+  "set_thread_state ref ts \<lbrace>\<lambda>s. bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s\<rbrace>"
+  apply (clarsimp simp: set_thread_state_def set_thread_state_act_def set_scheduler_action_def)
+  apply (wpsimp wp: set_object_wp is_schedulable_wp)
+  apply (clarsimp simp: pred_tcb_at_def obj_at_def is_schedulable_bool_def')
+  done
+
 lemma hinv_invs':
   fixes Q :: "'state_ext state \<Rightarrow> bool" and calling blocking
   assumes perform_invocation_Q[wp]:
     "\<And>block class can_donate i.
-      \<lbrace>invs and Q and ct_active and (\<lambda>s. scheduler_action s = resume_cur_thread)
+      \<lbrace>invs and Q and ct_active and (\<lambda>s. bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s)
        and valid_invocation i\<rbrace>
         perform_invocation block class can_donate i
       \<lbrace>\<lambda>_.Q\<rbrace>"
@@ -1078,7 +1085,7 @@ lemma hinv_invs':
   assumes sts_Q[wp]:
     "\<And>a b. \<lbrace>invs and Q\<rbrace> set_thread_state a b \<lbrace>\<lambda>_.Q\<rbrace>"
   shows
-    "\<lbrace>invs and Q and (\<lambda>s. scheduler_action s = resume_cur_thread) and
+    "\<lbrace>invs and Q and (\<lambda>s. bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s) and
       (\<lambda>s. is_schedulable_bool (cur_thread s) s)\<rbrace>
        handle_invocation calling blocking can_donate first_phase cptr
      \<lbrace>\<lambda>rv s. invs s \<and> Q s\<rbrace>"
@@ -1114,7 +1121,7 @@ lemmas hinv_invs[wp] = hinv_invs'
 lemma hinv_tcb[wp]:
   "\<And>t calling blocking can_donate first_phase cptr.
     \<lbrace>\<lambda>s. st_tcb_at active t s \<and> invs s \<and> ct_active s \<and>
-         scheduler_action s = resume_cur_thread \<and>
+         bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s \<and>
          is_schedulable_bool (cur_thread s) s\<rbrace>
       handle_invocation calling blocking can_donate first_phase cptr
     \<lbrace>\<lambda>rv. tcb_at t :: 'state_ext state \<Rightarrow> bool\<rbrace>"
@@ -1134,7 +1141,7 @@ lemma get_cap_reg_inv[wp]: "\<lbrace>P\<rbrace> get_cap_reg r \<lbrace>\<lambda>
 
 lemma hs_tcb_on_err:
   "\<lbrace>st_tcb_at active t and invs and ct_active and
-    (\<lambda>s. scheduler_action s = resume_cur_thread) and
+    (\<lambda>s. bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s) and
     (\<lambda>s. is_schedulable_bool (cur_thread s) s)\<rbrace>
      handle_send blocking
    -,\<lbrace>\<lambda>e. tcb_at t :: 'state_ext state \<Rightarrow> bool\<rbrace>"
@@ -1143,7 +1150,7 @@ lemma hs_tcb_on_err:
   done
 
 lemma hs_invs[wp]:
-  "\<lbrace>invs and (\<lambda>s. scheduler_action s = resume_cur_thread) and
+  "\<lbrace>invs and (\<lambda>s. bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s) and
     (\<lambda>s. is_schedulable_bool (cur_thread s) s)\<rbrace>
      handle_send blocking
    \<lbrace>\<lambda>r. invs :: 'state_ext state \<Rightarrow> bool\<rbrace>"
@@ -1300,7 +1307,7 @@ lemma do_reply_transfer_nonz_cap:
       | rule conjI)+
 
 lemma hc_invs[wp]:
-  "\<lbrace>invs and (\<lambda>s. scheduler_action s = resume_cur_thread) and
+  "\<lbrace>invs and (\<lambda>s. bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s) and
     (\<lambda>s. is_schedulable_bool (cur_thread s) s)\<rbrace>
      handle_call
    \<lbrace>\<lambda>rv. invs :: 'state_ext state \<Rightarrow> bool\<rbrace>"
@@ -1491,7 +1498,7 @@ lemma retype_region_ct_in_state:
 
 lemma invoke_untyped_ct_active[wp]:
   "\<lbrace>invs and valid_untyped_inv ui and ct_active and
-    (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+    (\<lambda>s. bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s)\<rbrace>
      invoke_untyped ui
    \<lbrace>\<lambda>_. ct_active :: 'state_ext state \<Rightarrow> bool\<rbrace>"
   apply (rule hoare_pre, rule invoke_untyped_Q,
@@ -1535,7 +1542,7 @@ where
 lemma perform_invocation_not_blocking_not_calling_ct_active[wp]:
   "\<lbrace>invs and ct_active and valid_invocation i and
     (\<lambda>s. fault_tcb_at ((=) None) (cur_thread s) s \<and>
-         scheduler_action s = resume_cur_thread) and
+         bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s) and
     K (safe_invocation i)\<rbrace>
      perform_invocation False False can_donate i
    \<lbrace>\<lambda>_. ct_active :: 'state_ext state \<Rightarrow> bool\<rbrace>"
@@ -1550,7 +1557,7 @@ lemma decode_invocation_safe_invocation[wp]:
   by (wpsimp simp: o_def split_def)
 
 lemma handle_invocation_not_blocking_not_calling_first_phase_ct_active[wp]:
-  "\<lbrace>\<lambda>s. invs s \<and> ct_active s \<and> scheduler_action s = resume_cur_thread \<and>
+  "\<lbrace>\<lambda>s. invs s \<and> ct_active s \<and> bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s \<and>
         is_schedulable_bool (cur_thread s) s\<rbrace>
      handle_invocation False False can_donate True cptr
    \<lbrace>\<lambda>_. ct_active :: 'state_ext state \<Rightarrow> bool\<rbrace>"
@@ -1566,7 +1573,7 @@ lemma handle_invocation_not_blocking_not_calling_first_phase_ct_active[wp]:
 lemma he_invs[wp]:
   "\<And>e.
     \<lbrace>\<lambda>s. invs s \<and> (e \<noteq> Interrupt \<longrightarrow> ct_running s) \<and>
-         scheduler_action s = resume_cur_thread \<and>
+         bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s \<and>
          is_schedulable_bool (cur_thread s) s\<rbrace>
       handle_event e
     \<lbrace>\<lambda>_. invs :: 'state_ext state \<Rightarrow> bool\<rbrace>"


### PR DESCRIPTION
This modifies the definition of `cur_sc_tcb` so that we do not need to assume that the scheduler action is resume current thread in as many places. I've attempted to remove this condition from all preconditions in lemmas before AInvs.thy.

I've finished AInvs for the domain time fix. This change to `cur_sc_tcb` works well. I'll remove `schact_is_rct` from a bunch of places in DetSchedSchedule as part of the domain time work