### PR TITLE
use datatype package for abstract endpoint

### DIFF
--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -23678,7 +23678,7 @@ lemma suspend_st_tcb_at_halted:
    \<lbrace>\<lambda>yb s. st_tcb_at (\<lambda>ts. P ts \<or> halted ts) t s\<rbrace>"
   apply (cases "t = thread")
    apply (wpsimp wp: hoare_disjI2 suspend_makes_halted
-               simp: pred_disj_def pred_tcb_at_disj[symmetric])
+               simp: pred_disj_def pred_tcb_at_disj)
   apply (wpsimp wp: suspend_st_tcb_at_other)
   done
 

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -3793,16 +3793,11 @@ lemma cancel_all_ipc_loop_valid_sched:
   apply (rule hoare_gen_asm, rule ball_mapM_x_scheme[OF _ cancel_all_ipc_loop_body_valid_sched])
   by (wpsimp wp: cancel_all_ipc_loop_body_blocked_on_send_recv gts_wp')
 
-(* Can this be made more general? *)
-lemma case_IdleEP_helper:
-  "(case x of IdleEP \<Rightarrow> f | _ \<Rightarrow> g) = (if x=IdleEP then f else g)"
-  by (case_tac x; simp)
-
 lemma cancel_all_ipc_valid_sched:
   "\<lbrace>\<lambda>s. valid_sched s \<and> valid_objs s \<and> valid_idle s \<and> sym_refs (state_refs_of s)\<rbrace>
    cancel_all_ipc epptr
    \<lbrace>\<lambda>rv. valid_sched\<rbrace>"
-  unfolding cancel_all_ipc_def case_IdleEP_helper
+  unfolding cancel_all_ipc_def endpoint.case_eq_if
   apply (wpsimp wp: reschedule_valid_sched_const cancel_all_ipc_loop_valid_sched
                     get_simple_ko_wp get_ep_queue_wp'
               simp: obj_at_def)

--- a/proof/invariant-abstract/Invariants_AI.thy
+++ b/proof/invariant-abstract/Invariants_AI.thy
@@ -3501,8 +3501,8 @@ lemma has_reply_cap_cte_lift:
   by (simp add: cte_wp_at_caps_of_state, rule ctes)
 
 lemma pred_tcb_at_disj:
-  "(pred_tcb_at proj P t s \<or> pred_tcb_at proj Q t s) = pred_tcb_at proj (\<lambda>a. P a \<or> Q a) t s"
-  by (fastforce simp add: pred_tcb_at_def obj_at_def)
+  "pred_tcb_at proj (\<lambda>x. P x \<or> P' x) p s = (pred_tcb_at proj (\<lambda>x. P x) p s \<or> pred_tcb_at proj (\<lambda>x. P' x) p s)"
+  by (fastforce simp: pred_tcb_at_def obj_at_def)
 
 lemma dom_empty_cnode: "dom (empty_cnode us) = {x. length x = us}"
   unfolding empty_cnode_def

--- a/proof/invariant-abstract/Invariants_AI.thy
+++ b/proof/invariant-abstract/Invariants_AI.thy
@@ -693,10 +693,7 @@ definition
 where
   "valid_ep ep s \<equiv> case ep of
     IdleEP \<Rightarrow> True
-  | SendEP ts \<Rightarrow>
-      (ts \<noteq> [] \<and> (\<forall>t \<in> set ts. tcb_at t s) \<and> distinct ts)
-  | RecvEP ts \<Rightarrow>
-      (ts \<noteq> [] \<and> (\<forall>t \<in> set ts. tcb_at t s) \<and> distinct ts)"
+  | _ \<Rightarrow> (\<lambda>ts. ts \<noteq> [] \<and> (\<forall>t \<in> set ts. tcb_at t s) \<and> distinct ts) (ep_queue ep)"
 
 definition
   valid_sched_context :: "sched_context \<Rightarrow> 'z::state_ext state \<Rightarrow> bool"

--- a/proof/invariant-abstract/Ipc_AI.thy
+++ b/proof/invariant-abstract/Ipc_AI.thy
@@ -2042,13 +2042,6 @@ crunches do_ipc_transfer
 
 end
 
-definition
-  "queue_of ep \<equiv> case ep of
-     Structures_A.IdleEP \<Rightarrow> []
-   | Structures_A.SendEP q \<Rightarrow> q
-   | Structures_A.RecvEP q \<Rightarrow> q"
-
-
 primrec
   threads_of_ntfn :: "ntfn \<Rightarrow> obj_ref list"
 where
@@ -2062,7 +2055,7 @@ primrec (nonexhaustive)
 where
   "threads_of (Notification x) = threads_of_ntfn (ntfn_obj x)"
 | "threads_of (TCB x)           = []"
-| "threads_of (Endpoint x)      = queue_of x"
+| "threads_of (Endpoint x)      = ep_queue x"
 
 
 (*
@@ -2792,13 +2785,13 @@ crunch mdb[wp]: set_message_info valid_mdb
 
 lemma ep_queue_cap_to:
   "\<lbrakk> ko_at (Endpoint ep) p s; invs s;
-     \<lbrakk> live (Endpoint ep) \<longrightarrow> queue_of ep \<noteq> [] \<rbrakk>
-        \<Longrightarrow> t \<in> set (queue_of ep) \<rbrakk>
+     \<lbrakk> live (Endpoint ep) \<longrightarrow> ep_queue ep \<noteq> [] \<rbrakk>
+        \<Longrightarrow> t \<in> set (ep_queue ep) \<rbrakk>
      \<Longrightarrow> ex_nonz_cap_to t s"
   apply (frule sym_refs_ko_atD, fastforce)
   apply (erule obj_at_valid_objsE, fastforce)
   apply (clarsimp simp: valid_obj_def)
-  apply (cases ep, simp_all add: queue_of_def valid_ep_def live_def
+  apply (cases ep, simp_all add: ep_queue_def valid_ep_def live_def
                                  st_tcb_at_refs_of_rev)
    apply (drule(1) bspec)
    apply (erule st_tcb_ex_cap, clarsimp+)

--- a/proof/invariant-abstract/KHeap_AI.thy
+++ b/proof/invariant-abstract/KHeap_AI.thy
@@ -1081,6 +1081,8 @@ lemma ep_redux_simps:
   by (fastforce split: list.splits option.splits
                  simp: valid_ep_def valid_ntfn_def valid_bound_obj_def)+
 
+lemma update_ep_queue_triv[simp]: "ep \<noteq> IdleEP \<Longrightarrow> update_ep_queue ep (ep_queue ep) = ep"
+  by (cases ep; clarsimp simp: ep_queue_def)
 
 crunch arch[wp]: set_simple_ko "\<lambda>s. P (arch_state s)"
   (wp: crunch_wps simp: crunch_simps)

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -4634,7 +4634,7 @@ lemma fast_finalise_corres:
     (* EndpointCap *)
     apply clarsimp
     apply (rule corres_guard_imp)
-      apply (rule cancel_all_ipc_corres)
+      apply (rule cancelAllIPC_corres)
      apply (simp add: valid_cap_def)
     apply (simp add: valid_cap'_def)
    (* NotificationCap *)

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -2258,7 +2258,7 @@ lemma cancelAllIPC_loop_body_valid_queues:
   apply (wpsimp wp: sts_valid_queues sts_st_tcb_at'_cases hoare_drop_imps)
   done
 
-lemma cancel_all_ipc_corres_helper:
+lemma cancelAllIPC_corres_helper:
   "distinct list \<Longrightarrow>
    corres dc
           ((\<lambda>s. \<forall>t \<in> set list. blocked_on_send_recv_tcb_at t s \<and> t \<noteq> idle_thread s
@@ -2336,7 +2336,7 @@ lemma in_send_ep_queue_TCBBlockedSend:
   apply (fastforce simp: state_refs_of_def)
   done
 
-lemma cancel_all_ipc_corres:
+lemma cancelAllIPC_corres:
   "corres dc (invs and valid_sched and ep_at ep_ptr) (invs' and ep_at' ep_ptr)
              (cancel_all_ipc ep_ptr) (cancelAllIPC ep_ptr)"
 proof -
@@ -2361,7 +2361,7 @@ proof -
       apply (rule corres_split_deprecated[OF _ set_ep_corres])
          apply clarsimp
          apply (rule corres_split_deprecated[OF rescheduleRequired_corres])
-           apply (erule cancel_all_ipc_corres_helper)
+           apply (erule cancelAllIPC_corres_helper)
           apply (rule_tac Q="?abs_guard list" in hoare_weaken_pre)
            apply (rule hoare_strengthen_post)
             apply (rule ball_mapM_x_scheme)

--- a/spec/abstract/IpcCancel_A.thy
+++ b/spec/abstract/IpcCancel_A.thy
@@ -276,9 +276,8 @@ text \<open>Getting and setting endpoint queues.\<close>
 definition
   get_ep_queue :: "endpoint \<Rightarrow> (obj_ref list,'z::state_ext) s_monad"
 where
- "get_ep_queue ep \<equiv> case ep of SendEP q \<Rightarrow> return q
-                              | RecvEP q \<Rightarrow> return q
-                              | _ \<Rightarrow> fail"
+ "get_ep_queue ep \<equiv> case ep of IdleEP \<Rightarrow> fail
+                              | _ \<Rightarrow> return (ep_queue ep)"
 
 primrec (nonexhaustive)
   update_ep_queue :: "endpoint \<Rightarrow> obj_ref list \<Rightarrow> endpoint"

--- a/spec/abstract/Structures_A.thy
+++ b/spec/abstract/Structures_A.thy
@@ -310,10 +310,12 @@ threads waiting to receive or be idle. Whenever threads would be waiting to
 send and receive simultaneously messages are transferred immediately.
 \<close>
 
-datatype endpoint
-           = IdleEP
-           | SendEP "obj_ref list"
-           | RecvEP "obj_ref list"
+datatype endpoint =
+    IdleEP
+  | SendEP (ep_queue: "obj_ref list")
+  | RecvEP (ep_queue: "obj_ref list")
+  where
+    "ep_queue IdleEP = []"
 
 text \<open>Notifications are sets of binary semaphores (stored in the
 \emph{badge word}). Unlike endpoints, threads may choose to block waiting to


### PR DESCRIPTION
This adds a common selector `ep_queue` for `SendEP` and `RecvEP` in the definition of `endpoint` in Structures_A, consequently triggering the datatype package to generate a bunch of additional facts.

`get_ep_queue` and `valid_ep` are redefined using `ep_queue`. `queue_of` is removed because it is now a duplication of `ep_queue`.

Proof updates are mostly due to the above definition changes, and also from using `endpoint.case_eq_if` in place of locally defined lemmas to simplify the case distinction. Various versions are essentially the same and easily replaced by the `case_eq_if` lemma.

One interesting observation is that the Haskell `endpoint` is defined in a suboptimal order - first `RecvEP`, then `IdleEP`, followed by `SendEP`. It uses a shared queue selector, which is good, but we'd want to swap `RecvEP` and `IdleEP` so that the `case_eq_if` lemma will have `if IdleEP` in the top level (because this is what we mostly use).