### PR TITLE
spec update for seL4 #467

### DIFF
--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -106,7 +106,7 @@ where
     scp \<leftarrow> assert_opt sc_opt;
     sc' \<leftarrow> get_sched_context cur_sc;
 
-    when (scp \<noteq> cur_sc \<and> 0 < sc_refill_max sc') $ do
+    when (scp \<noteq> cur_sc) $ do
       modify (\<lambda>s. s\<lparr>reprogram_timer := True\<rparr>);
       refill_unblock_check scp
      od;


### PR DESCRIPTION
Spec update for seL4 PR#467: "Don't check if old SC is still configured"
https://github.com/seL4/seL4/pull/467

- no proof update needed.

Signed-off-by: Miki Tanaka <miki.tanaka@data61.csiro.au>