### PR TITLE
thread_state with datatype package (test)

### DIFF
--- a/proof/invariant-abstract/DetSchedAux_AI.thy
+++ b/proof/invariant-abstract/DetSchedAux_AI.thy
@@ -1575,6 +1575,17 @@ lemma valid_refills_tcb_at_bound_sc:
 lemmas active_sc_tcb_at_valid_refills
   = active_sc_valid_refills_tcb_at[THEN valid_refills_tcb_at_bound_sc]
 
+lemma released_sc_tcb_at_valid_refills:
+  "\<lbrakk>active_sc_valid_refills s; released_sc_tcb_at tp s;
+     bound_sc_tcb_at ((=) (Some scp)) tp s\<rbrakk>
+    \<Longrightarrow> valid_refills scp s"
+  by (fastforce elim!: active_sc_tcb_at_valid_refills simp: released_sc_tcb_at_def)
+
+lemma released_sc_at_valid_refills:
+  "\<lbrakk>active_sc_valid_refills s; released_sc_at scp s\<rbrakk>
+    \<Longrightarrow> valid_refills scp s"
+  by (fastforce elim!: active_sc_valid_refillsE simp: released_sc_at_def)
+
 \<comment> \<open>ordered_disjoint is trivial on lists of length 1\<close>
 lemma ordered_disjoint_length1[simp]:
   "ordered_disjoint [a]"

--- a/proof/invariant-abstract/DetSchedAux_AI.thy
+++ b/proof/invariant-abstract/DetSchedAux_AI.thy
@@ -1558,9 +1558,22 @@ lemma valid_refills_def2:
   "valid_refills scp s = (\<exists>sc n. kheap s scp = Some (SchedContext sc n) \<and> sc_valid_refills sc)"
   by (clarsimp simp: valid_refills_def vs_all_heap_simps)
 
+(* this is not really an "E" lemma... *)
 lemma active_sc_valid_refillsE:
   "pred_map active_scrc (sc_refill_cfgs_of s) scp \<Longrightarrow> active_sc_valid_refills s \<Longrightarrow> valid_refills scp s"
   by (clarsimp simp: active_sc_valid_refills_def)
+
+lemma active_sc_valid_refills_tcb_at:
+  "\<lbrakk>active_sc_valid_refills s; active_sc_tcb_at tp s\<rbrakk> \<Longrightarrow> valid_refills_tcb_at tp s"
+  apply (clarsimp simp: active_sc_tcb_at_def2 valid_refills_tcb_at_def op_equal)
+  by (rule_tac x=scp in exI, clarsimp elim!: active_sc_valid_refillsE)
+
+lemma valid_refills_tcb_at_bound_sc:
+  "\<lbrakk>valid_refills_tcb_at tp s; bound_sc_tcb_at ((=) (Some scp)) tp s\<rbrakk> \<Longrightarrow> valid_refills scp s"
+  by (clarsimp simp: valid_refills_tcb_at_def pred_tcb_at_def obj_at_def dest!: sym[of "Some _"])
+
+lemmas active_sc_tcb_at_valid_refills
+  = active_sc_valid_refills_tcb_at[THEN valid_refills_tcb_at_bound_sc]
 
 \<comment> \<open>ordered_disjoint is trivial on lists of length 1\<close>
 lemma ordered_disjoint_length1[simp]:

--- a/proof/invariant-abstract/DetSchedInvs_AI.thy
+++ b/proof/invariant-abstract/DetSchedInvs_AI.thy
@@ -129,6 +129,15 @@ lemma pred_map_def:
   "pred_map P m x \<longleftrightarrow> (\<exists>y. m x = Some y \<and> P y)"
   by (simp add: pred_map_def2 split: option.splits)
 
+lemma pred_map_if:
+  "pred_map (\<lambda>x. if P x then Q x else R x) p q =
+   (if pred_map P p q then pred_map Q p q else pred_map R p q)"
+  by (fastforce simp: pred_map_def split: if_splits)
+
+lemma pred_map_conj:
+  "pred_map (P and Q ) p q = (pred_map P p q \<and> pred_map Q p q)"
+  by (fastforce simp: pred_map_def split: if_splits)
+
 \<comment> \<open>We use a separate constant for object equality assertions,
     to get nicer simplification rules.\<close>
 definition pred_map_eq :: "'b \<Rightarrow> ('a \<rightharpoonup> 'b) \<Rightarrow> 'a \<Rightarrow> bool" where

--- a/proof/invariant-abstract/DetSchedInvs_AI.thy
+++ b/proof/invariant-abstract/DetSchedInvs_AI.thy
@@ -3748,6 +3748,10 @@ lemma active_sc_tcb_at_fold:
   apply (fastforce simp: pred_tcb_at_def sc_at_pred_n_def obj_at_def vs_all_heap_simps is_sc_active_def2 split: option.splits)
   done
 
+(* valid_refills for tcb_scps_of *)
+definition
+  "valid_refills_tcb_at tp s \<equiv> \<exists>scp. bound_sc_tcb_at ((=) (Some scp)) tp s \<and> valid_refills scp s"
+
 \<comment> \<open>Locales that generate various traditional obj_at lemmas from valid_sched_pred etc.\<close>
 
 locale released_ipc_queues_pred_pre_conj_locale =

--- a/proof/invariant-abstract/DetSchedInvs_AI.thy
+++ b/proof/invariant-abstract/DetSchedInvs_AI.thy
@@ -1585,6 +1585,10 @@ lemma released_sc_tcb_at_lift:
 abbreviation released_sc_at :: "obj_ref \<Rightarrow> 'z state \<Rightarrow> bool" where
   "released_sc_at scptr s \<equiv> pred_map (released_sc (cur_time s)) (sc_refill_cfgs_of s) scptr"
 
+lemma released_sc_at_def:
+  "released_sc_at scp s = (is_active_sc scp s \<and> is_refill_ready scp s \<and> is_refill_sufficient 0 scp s)"
+  by (clarsimp simp: pred_map_conj[simplified pred_conj_def])
+
 lemma sc_at_pred_to_pred_map_sc_refill_cfgs_of:
   assumes "\<And>sc. P sc = P' (sc_refill_cfg_of sc)"
   shows "sc_at_pred P scp s = pred_map P' (sc_refill_cfgs_of s) scp"

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -13923,7 +13923,6 @@ lemma send_signal_WN_sym_refs_helper:
   done
 
 lemma send_signal_WaitingNtfn_helper:
-  notes not_not_in_eq_in[iff] shows
   "ntfn_obj ntfn = WaitingNtfn wnlist \<Longrightarrow>
    \<lbrace>ko_at (Notification ntfn) ntfnptr and
     st_tcb_at ((=) (BlockedOnNotification ntfnptr)) (hd wnlist) and
@@ -14217,7 +14216,6 @@ lemma maybe_return_sc_released_if_bound_sc_tcb_at[wp]:
 context DetSchedSchedule_AI begin
 
 lemma send_signal_BOR_helper:
-  notes not_not_in_eq_in[iff] shows
   "ntfn_obj ntfn = IdleNtfn
    \<Longrightarrow> ntfn_bound_tcb ntfn = Some tcbptr
    \<Longrightarrow> \<lbrace>st_tcb_at ((=) (BlockedOnReceive ep r_opt pl)) tcbptr and
@@ -17154,18 +17152,6 @@ lemma pst_vs_for_invoke_sched_control_configure_flags:
   apply (clarsimp simp: in_release_queue_def not_in_release_q_def valid_blocked_thread_def
                         vs_all_heap_simps)
   done
-
-lemma valid_blocked_except_set_in_ready_q:
-  "\<lbrakk>valid_blocked_except tcbptr s; in_ready_q tcbptr s\<rbrakk> \<Longrightarrow> valid_blocked s"
-  apply (clarsimp simp: valid_blocked_defs)
-  apply (case_tac "t = tcbptr")
-   apply (fastforce iff: not_not_in_eq_in[symmetric])
-  apply (drule_tac x=t in spec; simp)
-  done
-
-lemma valid_blocked_except_cur_thread:
-  "valid_blocked_except_set {cur_thread s} s = valid_blocked s"
-  using valid_blocked_defs by simp
 
 lemma refill_budget_check_sc_refill_max_sc_at:
   "refill_budget_check usage \<lbrace>sc_refill_max_sc_at P sc_ptr\<rbrace>"

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -6927,23 +6927,6 @@ lemma update_sched_context_valid_refills_no_budget_update:
   apply (wpsimp wp: update_sched_context_wp)
   by (clarsimp simp: vs_all_heap_simps obj_at_def)
 
-(* FIXME RT: move *)
-lemma pred_map_If:
-  "pred_map (\<lambda>x. if P x then Q x else R x) p q =
-   (if pred_map P p q then pred_map Q p q else pred_map R p q)"
-  apply (rule iffI)
-  apply (clarsimp simp: pred_map_def)
-  apply (clarsimp simp: pred_map_def split: if_splits, fastforce, fastforce)
-  done
-
-(* FIXME RT: move *)
-lemma pred_map_conj:
-  "pred_map (\<lambda>x. P x \<and> Q x) p q = (pred_map P p q \<and> pred_map Q p q)"
-  apply (rule iffI)
-  apply (clarsimp simp: pred_map_def)
-  apply (clarsimp simp: pred_map_def split: if_splits)
-  done
-
 lemma maybe_add_empty_tail_valid_sched_misc[wp]:
   "maybe_add_empty_tail sc_ptr
    \<lbrace>\<lambda>s. P (consumed_time s) (cur_sc s) (ep_send_qs_of s) (ep_recv_qs_of s) (sc_tcbs_of s)
@@ -16415,10 +16398,6 @@ lemma refill_budget_check_round_robin_released_ipc_queues:
   apply (wpsimp wp: set_refills_released_ipc_queues)
   apply (fastforce simp: cur_sc_not_blocked_def pred_map_ipc_queued_thread_state_iff)
   done
-
-(* FIXME RT: move *)
-lemma released_imp_active: "released_sc_tcb_at t s \<Longrightarrow> active_sc_tcb_at t s"
-  by (fastforce simp: pred_map2'_pred_maps elim!: pred_map_weakenE)
 
 lemma refill_pop_head_released_ipc_queues:
   "\<lbrace>\<lambda>s. released_ipc_queues s \<and> cur_sc_not_blocked s \<and> sc_ptr = cur_sc s\<rbrace>

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -1634,7 +1634,7 @@ lemma isSchedulable_bool_cross_rel:
   apply (rule cross_rel_imp[OF isScActive_cross_rel[where t=t]])
    apply (rule cross_rel_imp[OF tcbInReleaseQueue_cross_rel[where t=t]])
     apply (rule cross_rel_imp[OF runnable_cross_rel[where t=t]])
-     apply (clarsimp simp: isSchedulable_bool_def pred_map_conj)
+     apply (clarsimp simp: isSchedulable_bool_def pred_map_conj[simplified pred_conj_def])
     apply (clarsimp simp: is_schedulable_bool_def2)+
   done
 
@@ -3461,7 +3461,7 @@ lemma readTCBRefillReady_simp:
   "\<lbrakk>(s, s') \<in> state_relation; pspace_aligned s; pspace_distinct s; valid_objs s;
     active_sc_tcb_at t s; active_sc_valid_refills s; valid_objs' s'\<rbrakk>
    \<Longrightarrow> read_tcb_refill_ready t s = readTCBRefillReady t s'"
-  apply (frule (1) active_implies_valid_refills_tcb_at)
+  apply (frule (1) active_sc_valid_refills_tcb_at)
   apply (clarsimp simp: obj_at_kh_kheap_simps vs_all_heap_simps)
   apply (rename_tac scp tcb sc n)
   apply (prop_tac "tcb_at' t s' \<and> sc_at' scp s'")
@@ -3499,7 +3499,8 @@ lemma readTCBRefillReady_simp:
    apply (drule_tac x=sc_ptr in bspec, blast)
    apply (fastforce simp: obj_at'_def projectKOs split: if_splits)
   apply (frule refill_hd_relation2)
-    apply (clarsimp simp: vs_all_heap_simps valid_refills_def rr_valid_refills_def
+    apply (clarsimp simp: valid_refills_tcb_at_def valid_refills_def rr_valid_refills_def
+                          pred_tcb_at_def obj_at_def vs_all_heap_simps
                    split: if_splits)
    apply (fastforce dest!: sc_ko_at_valid_objs_valid_sc'
                      simp: obj_at'_def projectKOs)

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -1240,7 +1240,7 @@ lemma hinv_corres:
    apply (clarsimp simp: valid_pspace'_def schact_is_rct_def)
    apply (frule state_relation_schact, simp)
    apply (subgoal_tac "isSchedulable_bool (ksCurThread s') s'")
-    apply (clarsimp simp: isSchedulable_bool_def pred_map_conj)
+    apply (clarsimp simp: isSchedulable_bool_def pred_map_conj[simplified pred_conj_def])
     apply (frule(1) st_tcb_at_idle_thread', simp)
    apply (frule curthread_relation, simp)
    apply (frule_tac t1="cur_thread s" in cross_relF[OF _ isSchedulable_bool_cross_rel];

--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -106,7 +106,7 @@ where
     scp \<leftarrow> assert_opt sc_opt;
     sc' \<leftarrow> get_sched_context cur_sc;
 
-    when (scp \<noteq> cur_sc \<and> 0 < sc_refill_max sc') $ do
+    when (scp \<noteq> cur_sc) $ do
       modify (\<lambda>s. s\<lparr>reprogram_timer := True\<rparr>);
       refill_unblock_check scp
      od;

--- a/spec/abstract/Structures_A.thy
+++ b/spec/abstract/Structures_A.thy
@@ -397,6 +397,8 @@ datatype thread_state
   | "reply_object (BlockedOnNotification _) = None"
   | "reply_object IdleThreadState = None"
 
+declare thread_state.distinct_disc[rule del]
+
 (* FIXME RT: generating the following discriminators and selectors automatically breaks
              unrelated proofs in strange ways *)
 (*

--- a/spec/abstract/Structures_A.thy
+++ b/spec/abstract/Structures_A.thy
@@ -383,24 +383,33 @@ datatype thread_state
   = Running
   | Inactive
   | Restart
-  | BlockedOnReceive obj_ref "obj_ref option" receiver_payload
+  | is_blocked_on_receive: BlockedOnReceive obj_ref (reply_object: "obj_ref option") receiver_payload
   | BlockedOnSend obj_ref sender_payload
   | BlockedOnReply obj_ref
   | BlockedOnNotification obj_ref
   | IdleThreadState
+  where
+  "reply_object (BlockedOnReply reply) = Some reply"
+  | "reply_object Running = None"
+  | "reply_object Inactive = None"
+  | "reply_object Restart = None"
+  | "reply_object (BlockedOnSend _ _) = None"
+  | "reply_object (BlockedOnNotification _) = None"
+  | "reply_object IdleThreadState = None"
 
 (* FIXME RT: generating the following discriminators and selectors automatically breaks
              unrelated proofs in strange ways *)
-
+(*
 fun reply_object where
   "reply_object (BlockedOnReceive _ reply_opt _) = reply_opt"
 | "reply_object (BlockedOnReply reply) = Some reply"
 | "reply_object _ = None"
-
+*)
+(*
 definition is_blocked_on_receive where
  "is_blocked_on_receive st \<equiv>
     \<exists>ep reply_opt receiver_data. st = BlockedOnReceive ep reply_opt receiver_data"
-
+*)
 definition is_blocked_on_send :: "thread_state \<Rightarrow> bool" where
   "is_blocked_on_send st \<equiv> \<exists>ep sender_data. st = BlockedOnSend ep sender_data"
 


### PR DESCRIPTION
This PR is mainly for a demonstration purpose, for now, on JIRA issue: https://sel4.atlassian.net/browse/VER-1381

I went on and tried using the datatype package with `thread_state`. I added the `reply_object` selector as Corey did, and also added on discriminator just to see how it goes.

The AInvs proof breaks in a few places, in a way that has nothing to do with the added selector or discriminator. The breakage wasn't too difficult to fix it but it is quite obscure overall.

I did some digging and tracing, and it seems that one of the generated facts with `[dest]` attribute interacts badly with the simplifier. It is the `thread_state.distinct_disc` rule which looks like:
```
thread_state.distinct_disc:
      ?thread_state = Running ⟹ ?thread_state ≠ Inactive
      ?thread_state = Inactive ⟹ ?thread_state ≠ Running
      ?thread_state = Running ⟹ ¬ is_blocked_on_receive ?thread_state
      is_blocked_on_receive ?thread_state ⟹ ?thread_state ≠ Running
      ?thread_state = Running ⟹ ¬ is_BlockedOnSend ?thread_state
       ....
      ?thread_state = IdleThreadState ⟹ ¬ is_BlockedOnReply ?thread_state
      is_BlockedOnNotification ?thread_state ⟹ ?thread_state ≠ IdleThreadState
      ?thread_state = IdleThreadState ⟹ ¬ is_BlockedOnNotification ?thread_state
``` 
The breakage is often where `idle st` is present, which simplifies to `st = IdleThreadState`, and, from what I saw, this rule and congruence go around in loops.

With the proof fix being not too bad, we could just embrace this situation and go ahead with the change, or we could consider some alternatives.

I haven't checked Refine yet, so there is a chance it breaks.
