### PR TITLE
`check_domain_time`

### DIFF
--- a/proof/invariant-abstract/ARM/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchCNodeInv_AI.thy
@@ -571,12 +571,7 @@ next
      apply (wp replace_cap_invs | simp)
      apply ((wp replace_cap_invs | simp)+)[1]
        apply (wp "2.hyps")
-         apply (wp preemption_point_Q | simp)+
-         apply (wp preemption_point_inv, simp+)
-         apply (wp preemption_point_Q)
-         apply ((wp preemption_point_inv irq_state_independent_A_conjI irq_state_independent_AI
-                    invs_irq_state_independent
-               | simp add: valid_rec_del_call_def irq_state_independent_A_def)+)[1]
+         apply (wpsimp wp: preemption_point_Q hoare_vcg_imp_lift')
         apply (simp(no_asm))
         apply (rule spec_strengthen_postE)
         apply (rule "2.hyps"[simplified rec_del_call.simps slot_rdcall.simps conj_assoc], assumption+)

--- a/proof/invariant-abstract/ARM/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchCSpace_AI.thy
@@ -53,7 +53,7 @@ lemma getCurrentTime_wp[CSpace_AI_assms]:
 
 lemma update_time_stamp_wp[CSpace_AI_assms]:
   "\<lbrakk>update_time_stamp_independent_A P; cur_time_independent_A P;
-    time_state_independent_A P; getCurrentTime_independent_A P\<rbrakk>
+    time_state_independent_A P; getCurrentTime_independent_A P; domain_time_independent_A P\<rbrakk>
    \<Longrightarrow> update_time_stamp \<lbrace>P\<rbrace>"
   apply (simp add: update_time_stamp_def do_machine_op_def split_def
                    getCurrentTime_def select_modify_comm gets_machine_state_modify
@@ -64,7 +64,7 @@ lemma update_time_stamp_wp[CSpace_AI_assms]:
   apply (rule hoare_seq_ext_skip, wpsimp)
    apply (fastforce simp: cur_time_independent_A_def)
   apply wpsimp
-  apply (fastforce simp: update_time_stamp_independent_A_def)
+  apply (fastforce simp: update_time_stamp_independent_A_def domain_time_independent_A_def)
   done
 
 lemma weak_derived_valid_cap [CSpace_AI_assms]:

--- a/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
@@ -24,25 +24,22 @@ crunch domain_list_inv [wp, DetSchedDomainTime_AI_assms]:
   "\<lambda>s::det_state. P (domain_list s)"
   (wp: crunch_wps)
 
-crunch domain_time_inv [wp, DetSchedDomainTime_AI_assms]: arch_finalise_cap "\<lambda>s. P (domain_time s)"
+crunches arch_finalise_cap
+  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]:
+        "\<lambda>s. P (domain_time s)"
   (wp: crunch_wps simp: crunch_simps)
 
-crunch domain_time_inv [wp, DetSchedDomainTime_AI_assms]:
-  arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread,
-  handle_arch_fault_reply, init_arch_objects,
-  arch_invoke_irq_control, handle_vm_fault,
-  prepare_thread_delete, handle_hypervisor_fault,
-  arch_post_modify_registers, arch_post_cap_deletion, arch_invoke_irq_handler
-  "\<lambda>s::det_state. P (domain_time s)"
+crunches arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread,
+         handle_arch_fault_reply, init_arch_objects, arch_invoke_irq_control, handle_vm_fault,
+         prepare_thread_delete, handle_hypervisor_fault, arch_post_modify_registers,
+         arch_post_cap_deletion, arch_invoke_irq_handler
+  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]:
+        "\<lambda>s :: det_state. P (domain_time s)"
   (wp: crunch_wps)
 
 declare init_arch_objects_exst[DetSchedDomainTime_AI_assms]
         make_arch_fault_msg_inv[DetSchedDomainTime_AI_assms]
         arch_get_sanitise_register_info_inv[DetSchedDomainTime_AI_assms]
-
-crunch domain_consumed_time_inv [wp, DetSchedDomainTime_AI_assms]:
-  arch_switch_to_idle_thread,arch_switch_to_thread "\<lambda>s. P (domain_time s)(consumed_time s)"
-  (simp: whenE_def)
 
 end
 
@@ -55,36 +52,15 @@ global_interpretation DetSchedDomainTime_AI?: DetSchedDomainTime_AI
 context Arch begin global_naming ARM
 
 crunches arch_perform_invocation, arch_mask_irq_signal
-  for domain_time_inv [wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
-  and domain_list_inv [wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
-  (wp: crunch_wps check_cap_inv)
+  for domain_list_inv [wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
+  (wp: crunch_wps simp: crunch_simps)
 
 crunch domain_list_inv [wp, DetSchedDomainTime_AI_assms]: arch_perform_invocation "\<lambda>s::det_state. P (domain_list s)"
   (wp: crunch_wps check_cap_inv)
 
-crunch domain_time_sched[wp]: do_machine_op "\<lambda>s. P (domain_time s) (scheduler_action s)"
-
-lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
-  "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace> handle_interrupt i
-   \<lbrace>\<lambda>rv s.  domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread \<rbrace>"
-   apply (unfold handle_interrupt_def)
-   apply (case_tac "maxIRQ < i"; simp)
-    subgoal by (wp hoare_false_imp, simp)
-  apply (rule hoare_pre)
-    apply (wp  | simp add: arch_mask_irq_signal_def | wpc)+
-       apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
-       apply wp
-      apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
-      apply wp+
-     apply simp (* dxo_eq *)
-     apply (clarsimp simp: num_domains_def)
-     apply (wp reschedule_required_valid_domain_time
-           | simp add: handle_reserved_irq_def
-           | wp (once) hoare_drop_imp)+
-    apply clarsimp
-   done
-
-crunch domain_time_inv [wp, DetSchedDomainTime_AI_assms]: handle_reserved_irq "\<lambda>s. P (domain_time s)"
+crunches handle_reserved_irq
+  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]:
+        "\<lambda>s. P (domain_time s)"
   (wp: crunch_wps mapM_wp subset_refl simp: crunch_simps)
 
 crunch domain_list_inv [wp, DetSchedDomainTime_AI_assms]: handle_reserved_irq "\<lambda>s. P (domain_list s)"

--- a/proof/invariant-abstract/ARM/ArchLevityCatch_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchLevityCatch_AI.thy
@@ -55,47 +55,6 @@ lemma asid_high_bits_of_add:
               simp: asid_low_bits_def word_bits_def nth_ucast)
   done
 
-lemma preemption_point_success [simp,intro]:
-  "\<lbrakk>((Inr (), s') \<in> fst (preemption_point s))\<rbrakk>
-   \<Longrightarrow> \<exists>f g es lasttime curtime consumed.
-              s' = s\<lparr>machine_state :=
-                     machine_state s\<lparr>irq_state := f (irq_state (machine_state s)),
-                                     time_state := g (time_state (machine_state s)),
-                                     last_machine_time := lasttime\<rparr>,
-                     cur_time := curtime,
-                     consumed_time := consumed,
-                     exst := es \<rparr>"
-  apply (clarsimp simp: in_monad preemption_point_def do_machine_op_def
-                        select_f_def select_def getActiveIRQ_def alternative_def
-                        do_extended_op_def OR_choiceE_def mk_ef_def
-                        get_sc_refill_sufficient_def get_sched_context_def return_def
-                        refill_sufficient_def get_object_def get_sc_active_def
-                        update_time_stamp_def getCurrentTime_def andM_def ifM_def
-                 split: if_split_asm)
-  apply safe
-        apply ((case_tac x; clarsimp simp: fail_def return_def;
-               rule_tac x=Suc in exI, rule_tac x=Suc in exI, rule_tac x="exst bb" in exI,
-               rule_tac x="of_nat (min (unat (- getCurrentTime_buffer - 1))
-                                       (unat (last_machine_time (machine_state s))
-                                        + time_oracle (Suc (time_state (machine_state s)))))"
-                in exI,
-               rule_tac x="of_nat (min (unat (- getCurrentTime_buffer - 1))
-                                       (unat (last_machine_time (machine_state s))
-                                        + time_oracle (Suc (time_state (machine_state s)))))"
-                in exI,
-               rule_tac x="consumed_time s +
-                           of_nat
-                             (min (unat (- getCurrentTime_buffer - 1))
-                                  (unat (last_machine_time (machine_state s))
-                                   + time_oracle (Suc (time_state (machine_state s)))))
-                             - cur_time s"
-                in exI, force)+)[3]
-     apply (rule_tac x=id in exI, rule_tac x=id in exI, rule_tac x="exst b" in exI,
-            rule_tac x="last_machine_time (machine_state s)" in exI,
-            rule_tac x="cur_time s" in exI,
-            rule_tac x="consumed_time s" in exI, force)+
-  done
-
 lemma pageBits_less_word_bits [simp]:
   "pageBits < word_bits" by (simp add: pageBits_def word_bits_conv)
 

--- a/proof/invariant-abstract/ARM/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchRetype_AI.thy
@@ -1330,6 +1330,7 @@ lemma invs_getCurrentTime_independent:
 lemma invs_update_time_stamp_independent:
   "invs (s\<lparr>cur_time := f (cur_time s)\<rparr>) = invs s"
   "invs (s\<lparr>consumed_time := g (consumed_time s) (cur_time s)\<rparr>) = invs s"
+  "invs (s\<lparr>domain_time := h (domain_time)\<rparr>) = invs s"
   by (clarsimp simp: update_time_stamp_independent_A_def invs_def
       valid_state_def valid_pspace_def valid_mdb_def valid_ioc_def valid_idle_def
       only_idle_def if_unsafe_then_cap_def valid_irq_states_def
@@ -1337,7 +1338,7 @@ lemma invs_update_time_stamp_independent:
       valid_irq_node_def valid_irq_handlers_def valid_machine_state_def
       valid_arch_caps_def valid_global_objs_def
       valid_kernel_mappings_def equal_kernel_mappings_def
-      valid_asid_map_def vspace_at_asid_def
+      valid_asid_map_def vspace_at_asid_def ex_cte_cap_wp_to_def
       pspace_in_kernel_window_def cap_refs_in_kernel_window_def
       cur_tcb_def cur_sc_tcb_def sym_refs_def state_refs_of_def
       swp_def valid_replies_pred_pspaceI; safe; clarsimp)+

--- a/proof/invariant-abstract/CSpace_AI.thy
+++ b/proof/invariant-abstract/CSpace_AI.thy
@@ -163,6 +163,36 @@ lemma cur_time_independent_A_conjI[intro!]:
    \<Longrightarrow> cur_time_independent_A (\<lambda>s. P s \<and> Q s)"
   by (auto simp: cur_time_independent_A_def)
 
+definition domain_time_independent_A :: "('z state \<Rightarrow> bool) \<Rightarrow> bool" where
+  "domain_time_independent_A P \<equiv> \<forall>f s. P s \<longrightarrow> P (s\<lparr>domain_time := f (domain_time s)\<rparr>)"
+
+lemma domain_time_independent_AI[intro!, simp]:
+  "\<lbrakk>\<And>s f. P (s\<lparr>domain_time := f (domain_time s)\<rparr>) = P s\<rbrakk>
+   \<Longrightarrow> domain_time_independent_A P"
+  by (simp add: domain_time_independent_A_def)
+
+lemma domain_time_independent_A_conjI[intro!]:
+  "\<lbrakk>domain_time_independent_A P; domain_time_independent_A Q\<rbrakk>
+   \<Longrightarrow> domain_time_independent_A (P and Q)"
+  "\<lbrakk>domain_time_independent_A P; domain_time_independent_A Q\<rbrakk>
+   \<Longrightarrow> domain_time_independent_A (\<lambda>s. P s \<and> Q s)"
+  by (auto simp: domain_time_independent_A_def)
+
+definition reprogram_timer_independent_A :: "('z state \<Rightarrow> bool) \<Rightarrow> bool" where
+  "reprogram_timer_independent_A P \<equiv> \<forall>f s. P s \<longrightarrow> P (s\<lparr>reprogram_timer := f (reprogram_timer s)\<rparr>)"
+
+lemma reprogram_timer_independent_AI[intro!, simp]:
+  "\<lbrakk>\<And>s f. P (s\<lparr>reprogram_timer := f (reprogram_timer s)\<rparr>) = P s\<rbrakk>
+   \<Longrightarrow> reprogram_timer_independent_A P"
+  by (simp add: reprogram_timer_independent_A_def)
+
+lemma reprogram_timer_independent_A_conjI[intro!]:
+  "\<lbrakk>reprogram_timer_independent_A P; reprogram_timer_independent_A Q\<rbrakk>
+   \<Longrightarrow> reprogram_timer_independent_A (P and Q)"
+  "\<lbrakk>reprogram_timer_independent_A P; reprogram_timer_independent_A Q\<rbrakk>
+   \<Longrightarrow> reprogram_timer_independent_A (\<lambda>s. P s \<and> Q s)"
+  by (auto simp: reprogram_timer_independent_A_def)
+
 definition update_time_stamp_independent_A :: "('z state \<Rightarrow> bool) \<Rightarrow> bool" where
   "update_time_stamp_independent_A P \<equiv>
       \<forall>f s. P s \<longrightarrow> P (s\<lparr>consumed_time := f (consumed_time s) (cur_time s)\<rparr>)"
@@ -199,6 +229,7 @@ locale CSpace_AI_preemption_point_wp =
     "\<And>P :: 'state_ext state \<Rightarrow> bool.
       update_time_stamp_independent_A P \<Longrightarrow> cur_time_independent_A P \<Longrightarrow>
       time_state_independent_A P \<Longrightarrow> getCurrentTime_independent_A P \<Longrightarrow>
+      domain_time_independent_A P \<Longrightarrow>
       valid P update_time_stamp (\<lambda>_. P)"
 
 context CSpace_AI_preemption_point_wp begin
@@ -206,7 +237,7 @@ context CSpace_AI_preemption_point_wp begin
 lemma preemption_point_inv:
   fixes P :: "'state_ext state \<Rightarrow> bool"
   shows "\<lbrakk>irq_state_independent_A P; time_state_independent_A P; getCurrentTime_independent_A P;
-          update_time_stamp_independent_A P; cur_time_independent_A P;
+          update_time_stamp_independent_A P; cur_time_independent_A P; domain_time_independent_A P;
          \<And>f s. P (trans_state f s) = P s\<rbrakk>
          \<Longrightarrow> \<lbrace>P\<rbrace> preemption_point \<lbrace>\<lambda>_. P\<rbrace>"
   apply (clarsimp simp: preemption_point_def get_sc_refill_sufficient_def get_sc_active_def)

--- a/proof/invariant-abstract/DetSchedAux_AI.thy
+++ b/proof/invariant-abstract/DetSchedAux_AI.thy
@@ -1040,7 +1040,7 @@ lemma update_time_stamp_is_refill_ready[wp]:
   unfolding update_time_stamp_def
   apply (wpsimp wp: dmo_getCurrentTime_wp)
      prefer 2
-     apply (rule_tac Q="(is_refill_ready scp and (\<lambda>s. cur_time s = prev_time))"
+     apply (rule_tac Q="(is_refill_ready scp and (\<lambda>s. cur_time s = previous_time))"
             in hoare_weaken_pre[rotated], assumption)
      apply wpsimp
     apply (clarsimp simp: vs_all_heap_simps refill_ready_def)
@@ -1060,9 +1060,9 @@ lemma update_time_stamp_cur_time_monotonic:
    \<lbrace>\<lambda>_ s. val \<le> cur_time s\<rbrace>"
   supply minus_add_distrib[simp del]
   apply (clarsimp simp: update_time_stamp_def)
-  apply (rule hoare_seq_ext[OF _ gets_sp])
+  apply (rule hoare_seq_ext[OF _ gets_sp], rename_tac previous_time)
   apply (rule_tac B="\<lambda>rv s. cur_time s \<le> rv \<and> rv \<le> - getCurrentTime_buffer - 1
-                            \<and> cur_time s = val \<and> cur_time s = prev_time"
+                            \<and> cur_time s = val \<and> cur_time s = previous_time"
                in hoare_seq_ext[rotated])
    apply (wpsimp wp: dmo_getCurrentTime_sp)+
   done

--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -15,7 +15,8 @@ text \<open>
 
 (* Note: domains in the domain list should also be \<le> maxDomain, but this is not needed right now *)
 definition
-  "valid_domain_list_2 dlist \<equiv> 0 < length dlist \<and> (\<forall>(d,time) \<in> set dlist. 0 < time)"
+  "valid_domain_list_2 dlist
+     \<equiv> 0 < length dlist \<and> (\<forall>(d,time) \<in> set dlist. 0 < us_to_ticks (time * \<mu>s_in_ms))"
 
 abbreviation
   valid_domain_list :: "'z state \<Rightarrow> bool"
@@ -64,50 +65,18 @@ locale DetSchedDomainTime_AI =
     "\<And>P t f. \<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace> handle_vm_fault t f \<lbrace>\<lambda>_ s. P (domain_list s)\<rbrace>"
   assumes prepare_thread_delete_domain_list_inv'[wp]:
     "\<And>P t. \<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace> prepare_thread_delete t \<lbrace>\<lambda>_ s. P (domain_list s)\<rbrace>"
-  assumes finalise_cap_domain_time_inv'[wp]:
-    "\<And>P cap fin. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> arch_finalise_cap cap fin \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
   assumes arch_activate_idle_thread_domain_time_inv'[wp]:
-    "\<And>P t. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> arch_activate_idle_thread t \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
-  assumes arch_switch_to_thread_domain_time_inv'[wp]:
-    "\<And>P t. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
-  assumes arch_switch_to_thread_domain_consumed_time_inv'[wp]:
-    "\<And>P t. \<lbrace>\<lambda>s::det_state. P (domain_time s)(consumed_time s)\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>_ s. P (domain_time s)(consumed_time s)\<rbrace>"
-  assumes arch_get_sanitise_register_info_domain_time_inv'[wp]:
-    "\<And>P t. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> arch_get_sanitise_register_info t \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
+    "\<And>P t. arch_activate_idle_thread t \<lbrace>\<lambda>s :: det_state. P (domain_time s)\<rbrace>"
+  assumes arch_switch_to_thread_domain_inv'[wp]:
+    "\<And>P t. arch_switch_to_thread t \<lbrace>\<lambda>s :: det_state. P (domain_time s)\<rbrace>"
   assumes arch_switch_to_idle_thread_domain_time_inv'[wp]:
-    "\<And>P. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
-  assumes arch_switch_to_idle_thread_domain_consumed_time_inv'[wp]:
-    "\<And>P. \<lbrace>\<lambda>s::det_state. P (domain_time s)(consumed_time s)\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_ s. P (domain_time s)(consumed_time s)\<rbrace>"
-  assumes handle_arch_fault_reply_domain_time_inv'[wp]:
-    "\<And>P f t x y. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> handle_arch_fault_reply f t x y \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
-  assumes init_arch_objects_domain_time_inv'[wp]:
-    "\<And>P t p n s r. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> init_arch_objects t p n s r \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
-  assumes arch_post_modify_registers_domain_time_inv'[wp]:
-    "\<And>P t p. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> arch_post_modify_registers t p \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
-  assumes arch_invoke_irq_control_domain_time_inv'[wp]:
-    "\<And>P i. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> arch_invoke_irq_control i \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
-  assumes handle_vm_fault_domain_time_inv'[wp]:
-    "\<And>P t f. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> handle_vm_fault t f \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
-  assumes prepare_thread_delete_domain_time_inv'[wp]:
-    "\<And>P t. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> prepare_thread_delete t \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
-  assumes make_arch_fault_msg_domain_time_inv'[wp]:
-    "\<And>P ft t. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> make_arch_fault_msg ft t \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
+    "\<And>P. arch_switch_to_idle_thread \<lbrace>\<lambda>s :: det_state. P (domain_time s)\<rbrace>"
   assumes make_arch_fault_msg_domain_list_inv'[wp]:
     "\<And>P ft t. \<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace> make_arch_fault_msg ft t \<lbrace>\<lambda>_ s. P (domain_list s)\<rbrace>"
-  assumes make_arch_fault_msg_domain_consumed_time_inv'[wp]:
-    "\<And>P ft t. \<lbrace>\<lambda>s::det_state. P (domain_time s)(consumed_time s)\<rbrace>
-         make_arch_fault_msg ft t \<lbrace>\<lambda>_ s. P (domain_time s)(consumed_time s)\<rbrace>"
-  assumes make_arch_fault_msg_domain_consumed_inv'[wp]:
-    "\<And>P ft t. \<lbrace>\<lambda>s::det_state. P (domain_time s)(consumed_time s)\<rbrace>
-             make_arch_fault_msg ft t \<lbrace>\<lambda>_ s. P (domain_time s)(consumed_time s)\<rbrace>"
-  assumes arch_post_cap_deletion_domain_time_inv'[wp]:
-    "\<And>P ft. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> arch_post_cap_deletion ft \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
   assumes arch_post_cap_deletion_domain_list_inv'[wp]:
     "\<And>P ft. \<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace> arch_post_cap_deletion ft \<lbrace>\<lambda>_ s. P (domain_list s)\<rbrace>"
   assumes arch_invoke_irq_handler_domain_list_inv'[wp]:
     "\<And>P i. arch_invoke_irq_handler i \<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace>"
-  assumes arch_invoke_irq_handler_domain_time_inv'[wp]:
-    "\<And>P i. arch_invoke_irq_handler i \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace>"
 
 crunches update_restart_pc
   for domain_list[wp]: "\<lambda>s. P (domain_list s)"
@@ -117,27 +86,12 @@ crunches update_restart_pc
 locale DetSchedDomainTime_AI_2 = DetSchedDomainTime_AI +
   assumes handle_hypervisor_fault_domain_list_inv'[wp]:
     "\<And>P t f. \<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace> handle_hypervisor_fault t f \<lbrace>\<lambda>_ s. P (domain_list s)\<rbrace>"
-  assumes handle_hypervisor_fault_domain_time_inv'[wp]:
-    "\<And>P t f. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> handle_hypervisor_fault t f \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
   assumes arch_perform_invocation_domain_list_inv'[wp]:
     "\<And>P i. \<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace> arch_perform_invocation i \<lbrace>\<lambda>_ s. P (domain_list s)\<rbrace>"
-  assumes arch_perform_invocation_domain_time_inv'[wp]:
-    "\<And>P i. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> arch_perform_invocation i \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
-  assumes handle_interrupt_valid_domain_time:
-    "\<And>i.
-      \<lbrace>\<lambda>s :: det_state. 0 < domain_time s \<rbrace>
-        handle_interrupt i
-      \<lbrace>\<lambda>rv s.  domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread \<rbrace>"
-  assumes handle_reserved_irq_some_time_inv'[wp]:
-    "\<And>P irq. \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> handle_reserved_irq irq \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
   assumes handle_reserved_irq_domain_list_inv'[wp]:
     "\<And>P irq. \<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace> handle_reserved_irq irq \<lbrace>\<lambda>_ s. P (domain_list s)\<rbrace>"
   assumes arch_mask_irq_signal_domain_list_inv'[wp]:
     "\<And>P irq. arch_mask_irq_signal irq \<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace>"
-  assumes arch_mask_irq_signal_domain_time_inv'[wp]:
-    "\<And>P irq. arch_mask_irq_signal irq \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace>"
-
-crunch (empty_fail) empty_fail[wp]: commit_domain_time
 
 context DetSchedDomainTime_AI begin
 
@@ -167,9 +121,6 @@ lemma rec_del_domain_list[wp]:
 
 crunch domain_list_inv[wp]: cap_delete, activate_thread "\<lambda>s::det_state. P (domain_list s)"
   (wp: hoare_drop_imp)
-
-crunch domain_list_inv[wp]: possible_switch_to "\<lambda>s. P (domain_list s)"
-  (simp: get_tcb_obj_ref_def wp: hoare_vcg_if_lift2 hoare_drop_imp)
 
 crunches awaken
   for domain_list_inv[wp]: "\<lambda>s. P (domain_list s)"
@@ -359,8 +310,8 @@ lemma handle_recv_domain_list_inv[wp]:
   by (rule_tac Q'="\<lambda>_ s. P (domain_list s)" in hoare_post_imps(1))  wpsimp+
 
 crunches
-  handle_yield, handle_call, handle_vm_fault, handle_hypervisor_fault
-  for domain_list_inv[wp]: "\<lambda>s::det_state. P (domain_list s)"
+  handle_yield, handle_call, handle_vm_fault, handle_hypervisor_fault, check_domain_time
+  for domain_list_inv[wp]: "\<lambda>s :: det_state. P (domain_list s)"
   (wp: crunch_wps simp: crunch_simps)
 
 crunch domain_list_inv[wp]: check_budget_restart "\<lambda>s::det_state. P (domain_list s)"
@@ -375,6 +326,10 @@ lemma handle_event_domain_list_inv[wp]:
       apply (case_tac syscall, simp_all add: handle_send_def whenE_def)
              apply wpsimp+
   done
+
+crunches preemption_path
+  for domain_list[wp]: "\<lambda>s :: det_state. P (domain_list s)"
+  (wp: crunch_wps simp: crunch_simps)
 
 (* no one modifies domain_list - supplied at compile time *)
 lemma call_kernel_domain_list_inv_det_ext:
@@ -393,363 +348,65 @@ end
 
 section \<open>Preservation of domain time remaining\<close>
 
-crunch domain_time_inv[wp]: do_user_op "\<lambda>s. P (domain_time s)"
-  (wp: select_wp)
+lemma check_domain_time_domain_time_zero_imp_sched_act_choose_new_thread[wp]:
+  "\<lbrace>\<top>\<rbrace>
+   check_domain_time
+   \<lbrace>\<lambda>_ s :: det_state. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
+  apply (clarsimp simp: check_domain_time_def reschedule_required_def set_scheduler_action_def)
+  apply wpsimp
+  apply (clarsimp simp: is_cur_domain_expired_def num_domains_def)
+  done
 
-crunch domain_time_inv[wp]: schedule_tcb,tcb_release_remove "\<lambda>s. P (domain_time s)"
-  (wp: crunch_wps)
-
-crunch domain_time_inv[wp]: set_thread_state,store_word_offs "\<lambda>s. P (domain_time s)"
-  (wp: crunch_wps)
-
-lemma set_mrs_domain_time_inv[wp]:
-  "\<lbrace>\<lambda>s. P (domain_time s)\<rbrace> set_mrs param_a param_b param_c \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
-  by (wpsimp simp: set_mrs_def zipWithM_x_mapM split_del: if_split wp: mapM_wp')
-
-crunch domain_time_inv[wp]: complete_yield_to "\<lambda>s. P (domain_time s)"
-  (wp: crunch_wps maybeM_inv)
-
-context DetSchedDomainTime_AI begin
-
-crunch domain_time_inv[wp]:
-  get_cap, activate_thread, set_scheduler_action, tcb_sched_action
-  "\<lambda>s::det_state. P (domain_time s)" (wp: hoare_drop_imp)
-
-crunch domain_time_inv[wp]: guarded_switch_to "\<lambda>s::det_state. P (domain_time s)"
-  (wp: hoare_drop_imp whenE_inv)
-
-crunch domain_time_inv[wp]: choose_thread "\<lambda>s::det_state. P (domain_time s)"
-crunch domain_time_inv[wp]: sched_context_donate "\<lambda>s::det_state. P (domain_time s)"
-
-crunch domain_time_inv[wp]: reply_remove, maybe_donate_sc "\<lambda>s::det_state. P (domain_time s)"
-  (wp: hoare_drop_imps crunch_wps simp: crunch_simps)
-
-crunch domain_time_inv[wp]: send_signal "\<lambda>s::det_state. P (domain_time s)"
-  (wp: hoare_drop_imps mapM_x_wp_inv maybeM_inv select_wp simp: crunch_simps unless_def)
-
-crunch domain_time_inv[wp]:
-  cap_swap_for_delete, empty_slot, get_object, get_cap, tcb_sched_action
-  "\<lambda>s::det_state. P (domain_time s)"
-
-crunch domain_time_inv[wp]: sched_context_unbind_tcb "\<lambda>s. P (domain_time s)" (wp: hoare_drop_imp)
-
-crunch domain_time_inv[wp]: finalise_cap "\<lambda>s::det_state. P (domain_time s)"
-  (wp: crunch_wps hoare_drop_imps hoare_unless_wp select_inv mapM_wp
-       subset_refl if_fun_split maybeM_inv simp: crunch_simps ignore: tcb_sched_action)
-
-lemma rec_del_domain_time[wp]:
-  "\<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace> rec_del call \<lbrace>\<lambda>rv s. P (domain_time s)\<rbrace>"
-  by (wp rec_del_preservation preemption_point_inv' | simp)+
-
-crunch domain_time_inv[wp]:
-  cap_delete, activate_thread, lookup_cap_and_slot
-  "\<lambda>s::det_state. P (domain_time s)"
-
-end
-
-crunch domain_time_inv[wp]: cap_insert "\<lambda>s::det_state. P (domain_time s)"
+crunches set_next_interrupt
+  for domain_time_inv[wp]: "\<lambda>s. P (domain_time s)"
   (wp: hoare_drop_imps)
 
-crunch domain_time_inv[wp]: set_extra_badge "\<lambda>s. P (domain_time s)"
-
-crunch domain_time_inv[wp]: postpone,reply_push "\<lambda>s::det_state. P (domain_time s)"
-  (wp: hoare_drop_imp mapM_wp' hoare_vcg_if_lift)
-
-context DetSchedDomainTime_AI begin
-
-crunch domain_time_inv[wp]: do_ipc_transfer "\<lambda>s::det_state. P (domain_time s)"
-  (wp: crunch_wps transfer_caps_loop_pres simp: zipWithM_x_mapM ignore: transfer_caps_loop)
-
-crunch domain_time_inv[wp]: send_ipc "\<lambda>s::det_state. P (domain_time s)"
-  (wp: mapM_wp hoare_drop_imps maybeM_inv simp: crunch_simps ignore:copy_mrs sched_context_donate)
-
-crunch domain_time_inv[wp]: send_fault_ipc "\<lambda>s::det_state. P (domain_time s)"
-
-crunch domain_time_inv[wp]: handle_fault "\<lambda>s::det_state. P (domain_time s)"
-  (wp: mapM_wp hoare_drop_imps maybeM_inv hoare_unless_wp simp: crunch_simps ignore:copy_mrs)
-
-crunch domain_time_inv[wp]: reply_from_kernel, create_cap, retype_region
-  "\<lambda>s::det_state. P (domain_time s)"
-
-crunch domain_time_inv[wp]: do_reply_transfer "\<lambda>s::det_state. P (domain_time s)"
-  (wp: hoare_drop_imps maybeM_inv mapM_wp)
-end
-
-crunch domain_time_inv[wp]: delete_objects "\<lambda>s :: det_state. P (domain_time s)"
-  (wp: crunch_wps
-   simp: detype_def wrap_ext_det_ext_ext_def cap_insert_ext_def
-   ignore: freeMemory)
-
-crunch domain_time_inv[wp]: preemption_point "\<lambda>s::det_state. P (domain_time s)"
-  (wp: select_inv OR_choiceE_weak_wp crunch_wps ignore: OR_choiceE ignore_del: preemption_point)
-
-crunch domain_time_inv[wp]: reset_untyped_cap "\<lambda>s::det_state. P (domain_time s)"
-  (wp: crunch_wps hoare_unless_wp mapME_x_inv_wp select_inv
-   simp: crunch_simps)
-
-crunches sched_context_bind_tcb, restart
-  for domain_time_inv[wp]: "\<lambda>s::det_state. P (domain_time s)"
-  (wp: hoare_drop_imp maybeM_inv)
-
-crunches refill_update, refill_new
+crunches switch_sched_context, sc_and_timer
   for domain_time_inv[wp]: "\<lambda>s. P (domain_time s)"
   (wp: crunch_wps)
 
-crunches set_extra_badge, schedule_tcb
-  for domain_consumed_time_inv[wp]: "\<lambda>s. P (domain_time s)(consumed_time s)"
+lemma next_domain_domain_time_left[wp]:
+  "\<lbrace>valid_domain_list\<rbrace> next_domain \<lbrace>\<lambda>_ s. 0 < domain_time s \<rbrace>"
+  apply (clarsimp simp: next_domain_def)
+  apply (rule_tac B="\<lambda>_ s. 0 < domain_time s" in hoare_seq_ext)
+   apply (wpsimp wp: dxo_wp_weak)
+  apply wpsimp
+  apply (clarsimp simp: valid_domain_list_def all_set_conv_all_nth)
+  apply (erule_tac x="Suc (domain_index s) mod length (domain_list s)" in allE)
+  apply clarsimp
+  done
+
+context DetSchedDomainTime_AI begin
+
+crunches choose_thread
+  for domain_time_inv[wp]: "\<lambda>s :: det_state. P (domain_time s)"
   (wp: crunch_wps)
 
-crunches cap_insert, set_thread_state, postpone, reply_push
-  for domain_consumed_time_inv[wp]: "\<lambda>s::det_state. P (domain_time s)(consumed_time s)"
-  (wp: hoare_drop_imps mapM_wp' hoare_vcg_if_lift)
-
-context DetSchedDomainTime_AI begin
-
-crunch domain_time_inv[wp]:
-  refill_budget_check,charge_budget,refill_budget_check_round_robin
-  "\<lambda>s::det_state. P (domain_time s)"
-  (wp: crunch_wps check_cap_inv maybeM_inv simp: Let_def)
-
-crunch domain_time_inv[wp]: invoke_untyped "\<lambda>s::det_state. P (domain_time s)"
-  (wp: crunch_wps
-    simp: crunch_simps mapM_x_defsym)
-
-crunch domain_time_inv[wp]: invoke_tcb "\<lambda>s::det_state. P (domain_time s)"
-  (wp: crunch_wps check_cap_inv
-    simp: crunch_simps)
-
-crunch domain_time_inv[wp]:
-  invoke_domain, invoke_irq_control,invoke_irq_handler
-  "\<lambda>s::det_state. P (domain_time s)"
-  (wp: crunch_wps check_cap_inv maybeM_inv)
-
-
-crunch domain_time_inv[wp]: invoke_sched_context "\<lambda>s::det_state. P (domain_time s)"
-  (wp: crunch_wps check_cap_inv maybeM_inv
-    simp: crunch_simps)
-
-lemma commit_domain_time_domain_time:
-  "\<lbrace>\<lambda>s. P (if domain_time s < consumed_time s then 0 else domain_time s - consumed_time s)\<rbrace>
-      commit_domain_time \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
-  by (wpsimp simp: commit_domain_time_def)
-
-crunch consumed_time_inv[wp]: set_thread_state,store_word_offs "\<lambda>s::det_state. P (consumed_time s)"
-  (wp: crunch_wps dxo_wp_weak)
-
-crunch domain_time_consumed_time[wp]: refill_budget_check, refill_budget_check_round_robin
-  "\<lambda>s::det_state. P (domain_time s)(consumed_time s)"
-  (wp: crunch_wps check_cap_inv maybeM_inv dxo_wp_weak
-   simp: zipWithM_x_mapM Let_def)
-
-crunch domain_time_consumed_time[wp]: do_ipc_transfer
-  "\<lambda>s::det_state. P (domain_time s)(consumed_time s)"
-  (wp: crunch_wps transfer_caps_loop_pres simp: zipWithM_x_mapM ignore: transfer_caps_loop)
-
-crunch domain_time_consumed_time[wp]: end_timeslice
-  "\<lambda>s::det_state. P (domain_time s)(consumed_time s)"
-  (wp: crunch_wps maybeM_inv simp: zipWithM_x_mapM ignore: do_reply_transfer)
-
-crunch valid_domain_list[wp]:
-  charge_budget,check_budget
-  "valid_domain_list :: det_state \<Rightarrow> _"
-  (wp: crunch_wps check_cap_inv mapM_wp' maybeM_inv simp: Let_def zipWithM_x_mapM)
-
-crunch domain_time_inv[wp]:
-  charge_budget,check_budget
-  "\<lambda>s::det_state. P (domain_time s)"
-  (wp: crunch_wps check_cap_inv mapM_wp' maybeM_inv simp: Let_def zipWithM_x_mapM)
-
-lemma charge_budget_domain_time_consumed_time:
-   "\<lbrace>\<lambda>s::det_state. P (domain_time s) 0 \<rbrace>
-    charge_budget consumed canTimeout
-    \<lbrace>\<lambda>_ s. P (domain_time s) (consumed_time s)\<rbrace> "
-  by (wpsimp simp: charge_budget_def wp: assert_inv)
-
-lemma check_budget_domain_time_left[wp]:
-  "\<lbrace> valid_domain_list and (\<lambda>s. consumed_time s < domain_time s)\<rbrace>
-   check_budget
-   \<lbrace>\<lambda>_ s::det_state. 0 < domain_time s \<rbrace>"
-  by (wpsimp simp: check_budget_def word_gt_0)
-
-lemma check_budget_domain_consumed_time_gt[wp]:
-  "\<lbrace>\<lambda>s::det_state. consumed_time s < domain_time s\<rbrace> check_budget \<lbrace>\<lambda>_ s. consumed_time s  < domain_time s \<rbrace>"
-  by (wpsimp simp: check_budget_def word_gt_0
-               wp: charge_budget_domain_time_consumed_time)
-
-lemma commit_domain_time_domain_time_left:
-  "\<lbrace> valid_domain_list and (\<lambda>s. consumed_time s < domain_time s)\<rbrace>
-   commit_domain_time
-   \<lbrace>\<lambda>_ s. 0 < domain_time s \<rbrace>"
-  apply (wpsimp simp: commit_domain_time_def Let_def)
-  using word_gt_0 by fastforce
-
-lemma commit_time_domain_time_left[wp]:
-  "\<lbrace> valid_domain_list and (\<lambda>s. consumed_time s < domain_time s)\<rbrace>
-   commit_time
-   \<lbrace>\<lambda>_ s::det_state. 0 < domain_time s \<rbrace>"
-  by (wpsimp simp: commit_time_def num_domains_def
-               wp: commit_domain_time_domain_time_left hoare_drop_imp)
-
-lemma invoke_sched_control_configure_flags_domain_time_inv[wp]:
-  "\<lbrace>valid_domain_list and (\<lambda>s. consumed_time s < domain_time s)\<rbrace>
-      invoke_sched_control_configure_flags i \<lbrace>\<lambda>_ s::det_state. 0 < domain_time s \<rbrace>"
-  by (cases i)
-     (wpsimp simp: invoke_sched_control_configure_flags_def split_def word_gt_0 tcb_release_remove_def
-       split_del: if_split
-       wp: hoare_vcg_if_lift2 hoare_drop_imp hoare_vcg_conj_lift
-           commit_time_domain_time_left[simplified word_neq_0_conv[symmetric]]
-           check_budget_domain_time_left[simplified word_neq_0_conv[symmetric]])
-
-end
-
-crunch domain_time_inv[wp]: cap_move "\<lambda>s::det_state. P (domain_time s)"
-
-context DetSchedDomainTime_AI begin
-lemma cap_revoke_domain_time_inv[wp]:
-  "\<lbrace>(\<lambda>s :: det_state. P (domain_time s))\<rbrace> cap_revoke a \<lbrace>\<lambda>rv s. P (domain_time s)\<rbrace>"
-  apply (rule cap_revoke_preservation2)
-  apply (wp preemption_point_inv'|simp)+
-  done
-end
-
-crunch domain_time_inv[wp]: cancel_badged_sends "\<lambda>s::det_state. P (domain_time s)"
-  (ignore: filterM clearMemory
-     simp: filterM_mapM crunch_simps
-       wp: crunch_wps)
-
-context DetSchedDomainTime_AI_2 begin
-
-lemma invoke_cnode_domain_time_inv[wp]:
-  "\<lbrace>\<lambda>s :: det_state. P (domain_time s)\<rbrace>
-     invoke_cnode i
-   \<lbrace>\<lambda>rv s. P (domain_time s) \<rbrace>"
-  apply (rule hoare_pre)
-   apply (wp crunch_wps cap_move_src_slot_Null hoare_drop_imps hoare_vcg_all_lift
-          | wpc | simp add: invoke_cnode_def crunch_simps split del: if_split)+
-  done
-
-lemma perform_invocation_domain_time_inv:
-  "\<lbrace>valid_domain_list and (\<lambda>s. consumed_time s < domain_time s)\<rbrace>
-      perform_invocation block call can_donate i \<lbrace>\<lambda>_ s::det_state. 0 < domain_time s \<rbrace>"
-  by (cases i; wpsimp; clarsimp simp: word_gt_0)
-
-lemma handle_invocation_domain_time_inv[wp]:
-  "\<lbrace>valid_domain_list and (\<lambda>s. consumed_time s < domain_time s)\<rbrace>
-     handle_invocation calling blocking can_donate first_phase cptr
-   \<lbrace>\<lambda>_ s::det_state. 0 < domain_time s \<rbrace>"
-  by (wpsimp simp: handle_invocation_def
-      wp: syscall_valid crunch_wps perform_invocation_domain_time_inv)
-     (clarsimp simp: word_gt_0)
-
-crunch domain_time_inv[wp]: receive_ipc,lookup_reply "\<lambda>s::det_state. P (domain_time s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-crunch domain_time_inv[wp]: receive_signal "\<lambda>s::det_state. P (domain_time s)"
-  (wp: hoare_drop_imp hoare_vcg_if_lift2)
-
-lemma handle_recv_domain_time_inv[wp]:
-  "\<lbrace>\<lambda>s. P (domain_time s)\<rbrace>
-  handle_recv is_blocking can_reply \<lbrace>\<lambda>rv s::det_state. P (domain_time s)\<rbrace>"
-  apply (wpsimp simp: handle_recv_def Let_def whenE_def get_sk_obj_ref_def
-                split_del: if_split wp: hoare_drop_imps)
-  by (rule_tac Q'="\<lambda>_ s. P (domain_time s)" in hoare_post_imps(1))  wpsimp+
-
-
-crunch domain_time_inv[wp]: handle_yield, handle_vm_fault, handle_hypervisor_fault
-  "\<lambda>s::det_state. P (domain_time s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma handle_call_domain_time_inv[wp]:
-  "\<lbrace>valid_domain_list and (\<lambda>s. consumed_time s < domain_time s)\<rbrace>
-      handle_call \<lbrace>\<lambda>_ s::det_state. 0 < domain_time s \<rbrace>"
-  by (wpsimp simp: handle_call_def wp: handle_invocation_domain_time_inv)
-
-lemma check_budget_restart_domain_time_inv[wp]:
-  "\<lbrace>valid_domain_list and (\<lambda>s. consumed_time s < domain_time s)\<rbrace>
-      check_budget_restart \<lbrace>\<lambda>_ s::det_state. 0 < domain_time s \<rbrace>"
-  by (wpsimp simp: check_budget_restart_def)
-
-lemma check_budget_restart_domain_consumed_time_gt[wp]:
-  "\<lbrace>(\<lambda>s. consumed_time s < domain_time s)\<rbrace>
-      check_budget_restart \<lbrace>\<lambda>_ s::det_state. consumed_time s  < domain_time s \<rbrace>"
-  by (wpsimp simp: check_budget_restart_def)
-(*
-lemma update_time_stamp_domain_consumed_time_gt[wp]:
-  "\<lbrace>\<lambda>s. P (domain_time s)\<rbrace>
-      update_time_stamp \<lbrace>\<lambda>_ s. P (domain_time s)(consumed_time s) \<rbrace>"
-  apply (clarsimp simp: update_time_stamp_def)
-  apply (wpsimp simp: do_machine_op_def ARM.getCurrentTime_def)
-
-
-lemma handle_event_domain_time_inv:
-  "\<lbrace>valid_domain_list and (\<lambda>s. consumed_time s < domain_time s) and K (e \<noteq> Interrupt)\<rbrace>
-      handle_event e \<lbrace>\<lambda>_ s. 0 < domain_time s\<rbrace>"
-  apply (cases e, simp_all)
-      apply (rename_tac syscall)
-      apply (case_tac syscall, simp_all add: handle_send_def whenE_def)
-             apply (wpsimp split_del: if_split wp: hoare_vcg_if_lift2 hoare_drop_imp)+
-  apply (clarsimp simp: valid_domain_list_def)
-  using word_gt_0 by fastforce*)
-
-end
-
-lemma reschedule_required_valid_domain_time:
-  "\<lbrace> \<top> \<rbrace> reschedule_required
-   \<lbrace>\<lambda>x s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
-  unfolding reschedule_required_def set_scheduler_action_def
-  by (wpsimp wp: hoare_vcg_imp_lift is_schedulable_wp simp: thread_get_def)
-
-crunch domain_time_inv[wp]: set_next_interrupt "\<lambda>s. P (domain_time s)"
-  (wp: hoare_drop_imps)
-
-
-context DetSchedDomainTime_AI begin
-
-lemma switch_sched_context_domain_time_left[wp]:
-  "\<lbrace>valid_domain_list and (\<lambda>s. consumed_time s < domain_time s)\<rbrace>
-   switch_sched_context
-   \<lbrace>\<lambda>_ s :: det_state. 0 < domain_time s\<rbrace>"
-  apply (wpsimp simp: switch_sched_context_def refill_unblock_check_defs
-                  wp: hoare_vcg_if_lift2 hoare_drop_imp whileLoop_wp' split_del: if_split)
-  apply (clarsimp simp: word_gt_0)
-  done
-
-lemma sc_and_timer_domain_time_left[wp]:
-  "\<lbrace> valid_domain_list and (\<lambda>s. consumed_time s < domain_time s)\<rbrace>
-     sc_and_timer \<lbrace>\<lambda>_ s::det_state. 0 < domain_time s \<rbrace>"
-  by (wpsimp simp: sc_and_timer_def Let_def)
-(*
-lemma next_domain_domain_time_left[wp]:
-  "\<lbrace> valid_domain_list \<rbrace> next_domain \<lbrace>\<lambda>_ s. 0 < domain_time s \<rbrace>"
-  apply (wpsimp simp: next_domain_def Let_def)
-   apply (clarsimp simp: valid_domain_list_def)
-   apply (simp add: all_set_conv_all_nth)
-   apply (erule_tac x="Suc (domain_index s) mod length (domain_list s)" in allE)
-   apply (clarsimp simp: \<mu>s_to_ms_def)
-
-
 lemma schedule_choose_new_thread_domain_time_left[wp]:
-  "\<lbrace> valid_domain_list \<rbrace>
+  "\<lbrace>valid_domain_list\<rbrace>
    schedule_choose_new_thread
-   \<lbrace>\<lambda>_ s. 0 < domain_time s \<rbrace>"
+   \<lbrace>\<lambda>_ s :: det_state. 0 < domain_time s \<rbrace>"
   unfolding schedule_choose_new_thread_def
   by (wpsimp simp: word_gt_0)
 
-crunch valid_domain_list: schedule_choose_new_thread valid_domain_list
-
-crunch etcb_at[wp]: tcb_sched_action "etcb_at P t"
-
 lemma schedule_domain_time_left:
-  "\<lbrace>valid_domain_list and (\<lambda>s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread) \<rbrace>
+  "\<lbrace>valid_domain_list\<rbrace>
    schedule
-   \<lbrace>\<lambda>_ s. 0 < domain_time s \<rbrace>" (is "\<lbrace>?P\<rbrace> _ \<lbrace>\<lambda>_ . ?Q\<rbrace>")
+   \<lbrace>\<lambda>_ s :: det_state. 0 < domain_time s \<rbrace>"
   supply word_neq_0_conv[simp]
   apply (simp add: schedule_def)
-  apply (wp|wpc)+
-(*           apply (wp hoare_drop_imps)[1]
-          apply (wpsimp wp: gts_wp hoare_drop_imps simp: is_schedulable_def)+
-  done*)
-*)
+  apply (rule hoare_seq_ext_skip, wpsimp)
+  apply (rule_tac B="\<lambda>_ s. (domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread)
+                           \<and> valid_domain_list s"
+                in hoare_seq_ext[rotated])
+   apply wpsimp
+  apply clarsimp
+  apply (rule hoare_seq_ext[OF _ gets_sp])
+  apply (rule hoare_seq_ext[OF _ is_schedulable_sp])
+  apply (rule hoare_seq_ext[OF _  gets_sp], rename_tac action)
+  apply (case_tac action; wpsimp wp: hoare_drop_imps is_schedulable_wp)
+  done
+
 end
 
 (* FIXME: move to where hoare_drop_imp is, add E/R variants etc *)
@@ -758,29 +415,23 @@ lemma hoare_false_imp:
   by (auto simp: valid_def)
 
 context DetSchedDomainTime_AI_2 begin
-(*
+
+crunches activate_thread
+  for domain_time_inv[wp]: "\<lambda>s :: det_state. P (domain_time s)"
+  (wp: crunch_wps simp: crunch_simps)
+
 lemma call_kernel_domain_time_inv_det_ext:
-  "\<lbrace> (\<lambda>s. 0 < domain_time s) and valid_domain_list and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s) \<rbrace>
-   (call_kernel e) :: (unit,det_ext) s_monad
-   \<lbrace>\<lambda>_ s. 0 < domain_time s \<rbrace>"
+  "\<lbrace>(\<lambda>s. 0 < domain_time s) and valid_domain_list and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s)\<rbrace>
+   call_kernel e
+   \<lbrace>\<lambda>_ s :: det_state. 0 < domain_time s \<rbrace>"
   unfolding call_kernel_def
-  apply (case_tac "e = Interrupt")
-   apply simp
-   apply (rule hoare_pre)
-   apply ((wp schedule_domain_time_left handle_interrupt_valid_domain_time
-           | wpc | simp)+)[1]
-   apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s \<and> valid_domain_list s" in hoare_strengthen_post)
-    apply wp
-   apply fastforce+
-  (* now non-interrupt case; may throw but does not touch domain_time in handle_event *)
-  apply (wp schedule_domain_time_left without_preemption_wp handle_interrupt_valid_domain_time)
-    apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s \<and> valid_domain_list s" in hoare_post_imp)
-(*     apply fastforce
-    apply (wp handle_event_domain_time_inv)+
-   apply (rule_tac Q'="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp_R)
-    apply (wp handle_event_domain_time_inv)
-   apply fastf orce+
-  done*) *)
+  apply (case_tac "e = Interrupt"; clarsimp)
+   subgoal by (wpsimp wp: schedule_domain_time_left | wp (once) hoare_drop_imp)+
+  apply (rule_tac B="\<lambda>_. valid_domain_list" in hoare_seq_ext[rotated])
+   apply wpsimp
+  apply (wp schedule_domain_time_left without_preemption_wp)
+  done
+
 end
 
 end

--- a/proof/invariant-abstract/Deterministic_AI.thy
+++ b/proof/invariant-abstract/Deterministic_AI.thy
@@ -3975,17 +3975,12 @@ global_interpretation reset_work_units_ext_extended: is_extended "reset_work_uni
 
 lemma preemption_point_inv':
   "\<lbrakk>irq_state_independent_A P; time_state_independent_A P; getCurrentTime_independent_A P;
-    update_time_stamp_independent_A P; cur_time_independent_A P;
+    domain_time_independent_A P; update_time_stamp_independent_A P; cur_time_independent_A P;
     \<And>f s. P (work_units_completed_update f s) = P s\<rbrakk>
    \<Longrightarrow> \<lbrace>P\<rbrace> preemption_point \<lbrace>\<lambda>_. P\<rbrace>"
   apply (clarsimp simp: preemption_point_def)
-  apply (rule validE_valid)
-  apply (rule hoare_seq_ext_skipE, wpsimp simp: update_work_units_def)
-  apply (rule valid_validE)
-  apply (rule OR_choiceE_weak_wp)
-  apply (rule alternative_valid; (solves wpsimp)?)
-  apply (wpsimp simp: reset_work_units_def
-                  wp: hoare_vcg_all_lift hoare_drop_imps update_time_stamp_wp)
+  apply (wpsimp simp: reset_work_units_def update_work_units_def
+                  wp: OR_choiceE_weak_wp alternative_valid update_time_stamp_wp hoare_drop_imps)
   done
 
 locale Deterministic_AI_1 =
@@ -4167,7 +4162,8 @@ crunches cap_delete_one, restart
 
 context notes if_cong[cong] begin
 
-crunch valid_list[wp]: update_time_stamp "valid_list"
+crunches update_time_stamp, check_domain_time
+  for valid_list[wp]: valid_list
   (wp: get_object_wp)
 
 crunch valid_list[wp]: reply_from_kernel "valid_list"

--- a/proof/invariant-abstract/EmptyFail_AI.thy
+++ b/proof/invariant-abstract/EmptyFail_AI.thy
@@ -440,7 +440,7 @@ lemma schedule_empty_fail[wp]:
 end
 *)
 crunch (empty_fail) empty_fail[wp]:
-  set_scheduler_action, next_domain, reschedule_required, get_sc_refill_capacity
+  set_scheduler_action, next_domain, reschedule_required, get_sc_refill_capacity, check_domain_time
 
 crunch (empty_fail) empty_fail[wp, intro!, simp]:
   possible_switch_to, awaken, schedule_switch_thread_fastfail
@@ -492,7 +492,7 @@ locale EmptyFail_AI_call_kernel = EmptyFail_AI_schedule state_ext_t
 begin
 
 lemma call_kernel_empty_fail: "empty_fail (call_kernel a :: (unit,'state_ext) s_monad)"
-  apply (simp add: call_kernel_def preemption_path_def)
+  apply (simp add: call_kernel_def preemption_path_def check_domain_time_def)
   apply (wpsimp simp: get_sc_active_def)
   done
 

--- a/proof/invariant-abstract/LevityCatch_AI.thy
+++ b/proof/invariant-abstract/LevityCatch_AI.thy
@@ -12,7 +12,6 @@ begin
 context begin interpretation Arch .
 requalify_facts
   aobj_ref_arch_cap
-  preemption_point_success
 end
 
 (*FIXME: Move or remove *)

--- a/proof/invariant-abstract/RISCV64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchCNodeInv_AI.thy
@@ -582,12 +582,7 @@ next
      apply (wp replace_cap_invs | simp)
      apply ((wp replace_cap_invs | simp)+)[1]
        apply (wp "2.hyps")
-         apply (wp preemption_point_Q | simp)+
-         apply (wp preemption_point_inv, simp+)
-         apply (wp preemption_point_Q)
-         apply ((wp preemption_point_inv irq_state_independent_A_conjI irq_state_independent_AI
-                    invs_irq_state_independent
-               | simp add: valid_rec_del_call_def irq_state_independent_A_def)+)[1]
+         apply (wpsimp wp: preemption_point_Q hoare_vcg_imp_lift')
         apply (simp(no_asm))
         apply (rule spec_strengthen_postE)
         apply (rule "2.hyps"[simplified rec_del_call.simps slot_rdcall.simps conj_assoc], assumption+)

--- a/proof/invariant-abstract/RISCV64/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchCSpace_AI.thy
@@ -62,7 +62,7 @@ lemma getCurrentTime_wp[CSpace_AI_assms]:
 
 lemma update_time_stamp_wp[CSpace_AI_assms]:
   "\<lbrakk>update_time_stamp_independent_A P; cur_time_independent_A P;
-    time_state_independent_A P; getCurrentTime_independent_A P\<rbrakk>
+    time_state_independent_A P; getCurrentTime_independent_A P; domain_time_independent_A P\<rbrakk>
    \<Longrightarrow> update_time_stamp \<lbrace>P\<rbrace>"
   apply (simp add: update_time_stamp_def do_machine_op_def split_def
                    getCurrentTime_def select_modify_comm gets_machine_state_modify
@@ -73,7 +73,7 @@ lemma update_time_stamp_wp[CSpace_AI_assms]:
   apply (rule hoare_seq_ext_skip, wpsimp)
    apply (fastforce simp: cur_time_independent_A_def)
   apply wpsimp
-  apply (fastforce simp: update_time_stamp_independent_A_def)
+  apply (fastforce simp: update_time_stamp_independent_A_def domain_time_independent_A_def)
   done
 
 lemma weak_derived_valid_cap [CSpace_AI_assms]:

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedDomainTime_AI.thy
@@ -24,6 +24,18 @@ crunch domain_list_inv [wp, DetSchedDomainTime_AI_assms]:
   "\<lambda>s::det_state. P (domain_list s)"
   (wp: crunch_wps)
 
+crunches arch_finalise_cap
+   for domain_time_inv[wp, DetSchedDomainTime_AI_assms]:
+         "\<lambda>s. P (domain_time s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+crunches arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread,
+         handle_arch_fault_reply, init_arch_objects, arch_invoke_irq_control, handle_vm_fault,
+         prepare_thread_delete, handle_hypervisor_fault, arch_post_modify_registers,
+         arch_post_cap_deletion, arch_invoke_irq_handler
+  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s :: det_state. P (domain_time s)"
+  (wp: crunch_wps)
+
 crunch domain_time_inv [wp, DetSchedDomainTime_AI_assms]: arch_finalise_cap "\<lambda>s. P (domain_time s)"
   (wp: crunch_wps simp: crunch_simps)
 
@@ -37,17 +49,9 @@ crunch domain_time_inv [wp, DetSchedDomainTime_AI_assms]:
   "\<lambda>s::det_state. P (domain_time s)"
   (wp: crunch_wps)
 
-crunches make_arch_fault_msg
-  for domain_consumed[DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s) (consumed_time s)"
-  (wp: crunch_wps)
-
 declare init_arch_objects_exst[DetSchedDomainTime_AI_assms]
         make_arch_fault_msg_invs[DetSchedDomainTime_AI_assms]
         arch_get_sanitise_register_info_inv[DetSchedDomainTime_AI_assms]
-
-crunch domain_consumed_time_inv [wp, DetSchedDomainTime_AI_assms]:
-  arch_switch_to_idle_thread,arch_switch_to_thread "\<lambda>s. P (domain_time s)(consumed_time s)"
-  (simp: whenE_def)
 
 end
 
@@ -60,35 +64,14 @@ qed
 context Arch begin global_naming RISCV64
 
 crunches arch_perform_invocation, arch_mask_irq_signal
-  for domain_time_inv [wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
-  and domain_list_inv [wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
+  for domain_list_inv [wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
   (wp: crunch_wps check_cap_inv)
 
-crunch domain_time_sched[wp]: do_machine_op "\<lambda>s. P (domain_time s) (scheduler_action s)"
-
-lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
-  "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace> handle_interrupt i
-   \<lbrace>\<lambda>rv s.  domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread \<rbrace>"
-   apply (unfold handle_interrupt_def)
-   apply (case_tac "maxIRQ < i"; simp)
-    subgoal by (wp hoare_false_imp, simp)
-  apply (rule hoare_pre)
-    apply (wp  | simp add: arch_mask_irq_signal_def | wpc)+
-       apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
-       apply wp
-      apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
-      apply wp+
-     apply simp (* dxo_eq *)
-     apply (clarsimp simp: num_domains_def)
-     apply (wp reschedule_required_valid_domain_time
-           | simp add: handle_reserved_irq_def
-           | wp (once) hoare_drop_imp)+
-    apply clarsimp
-   done
-
 crunches handle_reserved_irq
-  for domain_time_inv [wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"
-  and domain_list_inv [wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_list s)"
+   for domain_time_inv[wp, DetSchedDomainTime_AI_assms]:
+         "\<lambda>s. P (domain_time s) (scheduler_action s)"
+
+crunch domain_list_inv [wp, DetSchedDomainTime_AI_assms]: handle_reserved_irq "\<lambda>s. P (domain_list s)"
   (wp: crunch_wps mapM_wp subset_refl simp: crunch_simps)
 
 end

--- a/proof/invariant-abstract/RISCV64/ArchLevityCatch_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchLevityCatch_AI.thy
@@ -56,47 +56,6 @@ lemma asid_high_bits_of_add:
               simp: asid_low_bits_def nth_ucast)
   done
 
-lemma preemption_point_success [simp,intro]:
-  "\<lbrakk>((Inr (), s') \<in> fst (preemption_point s))\<rbrakk>
-   \<Longrightarrow> \<exists>f g es lasttime curtime consumed.
-              s' = s\<lparr>machine_state :=
-                     machine_state s\<lparr>irq_state := f (irq_state (machine_state s)),
-                                     time_state := g (time_state (machine_state s)),
-                                     last_machine_time := lasttime\<rparr>,
-                     cur_time := curtime,
-                     consumed_time := consumed,
-                     exst := es \<rparr>"
-  apply (clarsimp simp: in_monad preemption_point_def do_machine_op_def
-                        select_f_def select_def getActiveIRQ_def alternative_def
-                        do_extended_op_def OR_choiceE_def mk_ef_def
-                        get_sc_refill_sufficient_def get_sched_context_def return_def
-                        refill_sufficient_def get_object_def get_sc_active_def
-                        update_time_stamp_def getCurrentTime_def andM_def ifM_def
-                 split: if_split_asm)
-  apply safe
-        apply ((case_tac x; clarsimp simp: fail_def return_def;
-               rule_tac x=Suc in exI, rule_tac x=Suc in exI, rule_tac x="exst bb" in exI,
-               rule_tac x="of_nat (min (unat (- getCurrentTime_buffer - 1))
-                                       (unat (last_machine_time (machine_state s))
-                                        + time_oracle (Suc (time_state (machine_state s)))))"
-                in exI,
-               rule_tac x="of_nat (min (unat (- getCurrentTime_buffer - 1))
-                                       (unat (last_machine_time (machine_state s))
-                                        + time_oracle (Suc (time_state (machine_state s)))))"
-                in exI,
-               rule_tac x="consumed_time s +
-                           of_nat
-                             (min (unat (- getCurrentTime_buffer - 1))
-                                  (unat (last_machine_time (machine_state s))
-                                   + time_oracle (Suc (time_state (machine_state s)))))
-                             - cur_time s"
-                in exI, force)+)[3]
-     apply (rule_tac x=id in exI, rule_tac x=id in exI, rule_tac x="exst b" in exI,
-            rule_tac x="last_machine_time (machine_state s)" in exI,
-            rule_tac x="cur_time s" in exI,
-            rule_tac x="consumed_time s" in exI, force)+
-  done
-
 lemma pageBits_less_word_bits [simp]:
   "pageBits < word_bits" by (simp add: pageBits_def word_bits_conv)
 

--- a/proof/invariant-abstract/RISCV64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchRetype_AI.thy
@@ -1005,6 +1005,7 @@ lemma invs_getCurrentTime_independent:
 lemma invs_update_time_stamp_independent:
   "invs (s\<lparr>cur_time := f (cur_time s)\<rparr>) = invs s"
   "invs (s\<lparr>consumed_time := g (consumed_time s) (cur_time s)\<rparr>) = invs s"
+  "invs (s\<lparr>domain_time := h (domain_time)\<rparr>) = invs s"
   by (clarsimp simp: update_time_stamp_independent_A_def invs_def
       valid_state_def valid_pspace_def valid_mdb_def valid_ioc_def valid_idle_def
       only_idle_def if_unsafe_then_cap_def valid_irq_states_def
@@ -1012,7 +1013,7 @@ lemma invs_update_time_stamp_independent:
       valid_irq_node_def valid_irq_handlers_def valid_machine_state_def
       valid_arch_caps_def valid_global_objs_def
       valid_kernel_mappings_def equal_kernel_mappings_def
-      valid_asid_map_def vspace_at_asid_def
+      valid_asid_map_def vspace_at_asid_def ex_cte_cap_wp_to_def
       pspace_in_kernel_window_def cap_refs_in_kernel_window_def
       cur_tcb_def cur_sc_tcb_def sym_refs_def state_refs_of_def
       swp_def valid_replies_pred_pspaceI; safe; clarsimp)+

--- a/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
@@ -330,7 +330,7 @@ lemma handle_invocation_valid_vspace_objs'[wp]:
 crunches activate_thread,switch_to_thread, handle_hypervisor_fault,
          switch_to_idle_thread, handle_call, handle_recv, handle_vm_fault,
          handle_send, handle_yield, handle_interrupt, check_budget_restart, update_time_stamp,
-         schedule_choose_new_thread, activate_thread, switch_to_thread
+         schedule_choose_new_thread, activate_thread, switch_to_thread, check_domain_time
   for valid_vspace_objs'[wp]: "valid_vspace_objs'"
   (simp: crunch_simps wp: crunch_wps
    ignore: without_preemption getActiveIRQ resetTimer ackInterrupt update_sk_obj_ref)

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -1378,7 +1378,7 @@ lemma non_empty_tail_length:
   "tl list \<noteq> [] \<Longrightarrow> Suc 0 \<le> length list"
   using le0 list.sel(2) not_less_eq_eq by blast
 
-crunches commit_domain_time, get_sched_context
+crunches get_sched_context
   for sc_at[wp]: "sc_at p"
   and ko_sc_at[wp]: "\<lambda>s. \<exists>sc n. ko_at (SchedContext sc n) p s"
   and ko_sc_at'[wp]: "\<lambda>s. ko_at (SchedContext sc n) p s"

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -54,6 +54,10 @@ crunches awaken
   for invs[wp]: invs
   (wp: crunch_wps simp: tcb_release_dequeue_def)
 
+crunches check_domain_time
+  for invs[wp]: invs
+  (simp: crunch_simps)
+
 lemma set_scheduler_action_valid_state_cur_tcb [wp]:
   "\<lbrace>invs\<rbrace> set_scheduler_action action \<lbrace>\<lambda>_ s. valid_state s \<and> cur_tcb s\<rbrace>"
   apply (wpsimp simp: set_scheduler_action_def)
@@ -100,13 +104,13 @@ lemma schedule_choose_new_thread_valid_state_cur_tcb [wp]:
                wp: set_scheduler_action_valid_state_cur_tcb switch_to_idle_thread_invs
                    guarded_switch_to_invs hoare_drop_imps)
 
-lemma schedule_invs[wp]: "\<lbrace>invs\<rbrace> Schedule_A.schedule \<lbrace>\<lambda>rv. invs\<rbrace>"
-  supply if_split[split del]
-  apply (simp add: Schedule_A.schedule_def)
-  apply (wp switch_to_thread_invs hoare_drop_imps
-            hoare_strengthen_post[OF awaken_invs] sc_and_timer_invs
-         | simp add: if_apply_def2 set_scheduler_action_def invs_def
-         | wpc)+
+lemma schedule_invs[wp]:
+  "schedule \<lbrace>invs\<rbrace>"
+  apply (simp add: schedule_def)
+  apply (wpsimp wp: switch_to_thread_invs hoare_drop_imps sc_and_timer_invs
+              simp: if_apply_def2 set_scheduler_action_def)
+    apply (rule_tac Q="\<lambda>_. invs" in hoare_strengthen_post)
+     apply (wpsimp simp: invs_def)+
   done
 
 lemma invs_domain_time_update[simp]:

--- a/proof/invariant-abstract/Untyped_AI.thy
+++ b/proof/invariant-abstract/Untyped_AI.thy
@@ -2778,8 +2778,9 @@ lemma reset_untyped_cap_invs_etc:
       in mapME_x_validE_nth)
      apply (rule hoare_pre)
       apply (wp set_untyped_cap_invs_simple
+                valid_validE_R[OF preemption_point_inv]
+                valid_validE_E[OF preemption_point_inv]
                 set_cap_no_overlap set_cap_cte_wp_at
-                preemption_point_inv
                 hoare_vcg_ex_lift hoare_vcg_const_imp_lift
                 hoare_vcg_const_Ball_lift set_cap_cte_cap_wp_to
                 | strengthen empty_descendants_range_in
@@ -2787,14 +2788,8 @@ lemma reset_untyped_cap_invs_etc:
                 | rule irq_state_independent_A_conjI
                 | simp add: cte_wp_at_caps_of_state
                 | wp (once) ct_in_state_thread_state_lift
-                | (rule irq_state_independent_A_def[THEN meta_eq_to_obj_eq, THEN iffD2]
-                        getCurrentTime_independent_A_def[THEN meta_eq_to_obj_eq, THEN iffD2]
-                        time_state_independent_A_def[THEN meta_eq_to_obj_eq, THEN iffD2]
-                        cur_time_independent_A_def[THEN meta_eq_to_obj_eq, THEN iffD2]
-                        update_time_stamp_independent_A_def[THEN meta_eq_to_obj_eq, THEN iffD2],
-                  simp add: ex_cte_cap_wp_to_def ct_in_state_def))+
-     apply (simp add: ct_in_state_def ex_cte_cap_wp_to_def cte_wp_at_caps_of_state)
-     apply clarsimp
+                | clarsimp simp: ct_in_state_def ex_cte_cap_wp_to_def
+                | rule conj_cong)+
        apply (clarsimp simp: is_aligned_neg_mask_eq bits_of_def field_simps
                            cte_wp_at_caps_of_state nth_rev)
      apply (strengthen order_trans[where z="2 ^ sz", rotated, mk_strg I E])

--- a/proof/refine/ARM/EmptyFail_H.thy
+++ b/proof/refine/ARM/EmptyFail_H.thy
@@ -296,7 +296,7 @@ lemma awaken_empty_fail[intro!, wp, simp]:
 
 lemma ThreadDecls_H_schedule_empty_fail[intro!, wp, simp]:
   "empty_fail schedule"
-  apply (simp add: schedule_def)
+  apply (simp add: schedule_def checkDomainTime_def)
   apply (clarsimp simp: scheduleChooseNewThread_def split: if_split | wp | wpc)+
   done
 

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -4232,4 +4232,14 @@ lemma updateTimeStamp_independentI[intro!, simp]:
    \<Longrightarrow> updateTimeStamp_independent P"
   by (simp add: updateTimeStamp_independent_def)
 
+definition "domain_time_independent_H (P :: kernel_state \<Rightarrow> bool)
+  \<equiv> \<forall>f s. P s \<longrightarrow>
+           P (s\<lparr>ksDomainTime := f (ksDomainTime s)\<rparr>)"
+
+lemma domain_time_independent_HI[intro!, simp]:
+   "\<lbrakk>\<And>s f. P (s\<lparr>ksDomainTime := f (ksDomainTime s)\<rparr>)
+            = P s\<rbrakk>
+    \<Longrightarrow> domain_time_independent_H P"
+   by (simp add: domain_time_independent_H_def)
+
 end

--- a/proof/refine/ARM/KernelInit_R.thy
+++ b/proof/refine/ARM/KernelInit_R.thy
@@ -40,6 +40,8 @@ axiomatization where
 
 axiomatization where
   ckernel_init_domain_list:
-  "((tc,s),x) \<in> Init_H \<Longrightarrow> length (ksDomSchedule s) > 0 \<and> (\<forall>(d,time) \<in> set (ksDomSchedule s). time > 0)"
+  "((tc,s),x) \<in> Init_H
+   \<Longrightarrow> length (ksDomSchedule s) > 0
+       \<and> (\<forall>(d,time) \<in> set (ksDomSchedule s). us_to_ticks (time * \<mu>s_in_ms) > 0)"
 
 end

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -2269,7 +2269,7 @@ lemma updateTimeStamp_invs'[wp]:
 
 lemma updateTimeStamp_sch_act_simple[wp]:
   "updateTimeStamp \<lbrace>sch_act_simple\<rbrace>"
-  unfolding updateTimeStamp_def sch_act_simple_def
+  unfolding updateTimeStamp_def sch_act_simple_def setDomainTime_def
   by (wpsimp wp: dmo_invs'_simple simp: setCurTime_def)
 
 crunches updateTimeStamp

--- a/proof/refine/ARM/Refine.thy
+++ b/proof/refine/ARM/Refine.thy
@@ -288,6 +288,12 @@ lemma do_user_op_sched_act:
   apply (wp select_wp | simp add: split_def)+
   done
 
+lemma do_user_op_domain_time:
+  "do_user_op f tc \<lbrace>\<lambda>s. 0 < domain_time s\<rbrace>"
+  unfolding do_user_op_def
+  apply (wp select_wp | simp add: split_def)+
+  done
+
 lemma do_user_op_invs2:
   "\<lbrace>einvs  and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread)
     and (\<lambda>s. 0 < domain_time s) and valid_domain_list \<rbrace>
@@ -298,7 +304,7 @@ lemma do_user_op_invs2:
    (\<lambda>s. scheduler_action s = resume_cur_thread) and (invs and ct_running) and
    (\<lambda>s. 0 < domain_time s) and valid_domain_list"
    in hoare_strengthen_post)
-  apply (wp do_user_op_valid_list do_user_op_valid_sched do_user_op_sched_act
+  apply (wp do_user_op_valid_list do_user_op_valid_sched do_user_op_sched_act do_user_op_domain_time
     do_user_op_invs | simp | force)+
   done
 
@@ -322,7 +328,8 @@ lemma valid_sched_init[simp]:
 
 lemma valid_domain_list_init[simp]:
   "valid_domain_list init_A_st"
-  by (simp add: init_A_st_def ext_init_def valid_domain_list_def)
+  apply (simp add: init_A_st_def ext_init_def valid_domain_list_def)
+  sorry
 
 lemma akernel_invariant:
   "ADT_A uop \<Turnstile> full_invs"
@@ -816,6 +823,7 @@ lemma ckernel_invariant:
    apply (frule ckernel_init_domain_time)
    apply (frule ckernel_init_domain_list)
    apply (fastforce simp: Init_H_def valid_domain_list'_def)
+
   apply (clarsimp simp: ADT_A_def ADT_H_def global_automaton_def)
 
   apply (erule_tac P="a \<and> (\<exists>x. b x)" for a b in disjE)

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -1777,8 +1777,8 @@ lemma domain_time_corres:
   by (simp add: getDomainTime_def state_relation_def)
 
 lemma \<mu>s_to_ms_equiv:
-  "\<mu>s_to_ms = usToMs"
-  by (simp add: usToMs_def \<mu>s_to_ms_def)
+  "\<mu>s_in_ms = usInMs"
+  by (simp add: usInMs_def \<mu>s_in_ms_def)
 
 lemma us_to_ticks_equiv:
   "us_to_ticks = usToTicks"
@@ -3131,6 +3131,9 @@ lemma awaken_invs':
   apply (fastforce intro!: releaseQNonEmptyAndReady_implies_releaseQNonEmpty)
   done
 
+crunches checkDomainTime
+  for invs'[wp]: invs'
+
 lemma schedule_invs':
   "\<lbrace>invs'\<rbrace>
    ThreadDecls_H.schedule
@@ -3140,6 +3143,7 @@ lemma schedule_invs':
   apply (simp add: schedule_def)
   apply (rule_tac hoare_seq_ext, rename_tac t)
    apply (rule_tac Q="invs'" in hoare_weaken_pre)
+    apply (rule hoare_seq_ext_skip, wpsimp)
     apply (rule_tac hoare_seq_ext[OF _ getCurThread_sp])
     apply (rule_tac hoare_seq_ext[OF _ isSchedulable_sp])
     apply (rule_tac hoare_seq_ext[OF _ getSchedulerAction_sp])

--- a/spec/abstract/Ipc_A.thy
+++ b/spec/abstract/Ipc_A.thy
@@ -698,11 +698,7 @@ where
 
      if sufficient
      then do dom_exp \<leftarrow> gets is_cur_domain_expired;
-             if dom_exp then do modify (\<lambda>s. s\<lparr> reprogram_timer := True \<rparr>);
-                                reschedule_required;
-                                return False
-                             od
-                        else return True
+             return (\<not>dom_exp)
           od
      else do consumed \<leftarrow> gets consumed_time;
              charge_budget consumed True;

--- a/spec/abstract/KHeap_A.thy
+++ b/spec/abstract/KHeap_A.thy
@@ -638,17 +638,22 @@ text \<open>Allow preemption at this point.\<close>
 definition
   is_cur_domain_expired :: "'z::state_ext state \<Rightarrow> bool"
 where
-  "is_cur_domain_expired = (\<lambda>s. domain_time s < consumed_time s + MIN_BUDGET)"
+  "is_cur_domain_expired = (\<lambda>s. num_domains > 1 \<and> domain_time s = 0)"
 
 text \<open>Update current and consumed time.\<close>
 definition
   update_time_stamp :: "(unit, 'z::state_ext) s_monad"
 where
   "update_time_stamp = do
-    prev_time \<leftarrow> gets cur_time;
-    cur_time' \<leftarrow> do_machine_op getCurrentTime;
-    modify (\<lambda>s. s\<lparr> cur_time := cur_time' \<rparr>);
-    modify (\<lambda>s. s\<lparr> consumed_time := consumed_time s + cur_time' - prev_time \<rparr>)
+     previous_time \<leftarrow> gets cur_time;
+     current_time \<leftarrow> do_machine_op getCurrentTime;
+     consumed \<leftarrow> return (current_time - previous_time);
+     modify (\<lambda>s. s\<lparr> cur_time := current_time \<rparr>);
+     modify (\<lambda>s. s\<lparr> consumed_time := consumed_time s + consumed \<rparr>);
+     domain_time \<leftarrow> gets domain_time;
+     when (num_domains > 1) $ if consumed + MIN_BUDGET \<ge> domain_time
+                                 then modify (\<lambda>s. s\<lparr> domain_time := 0 \<rparr>)
+                                 else modify (\<lambda>s. s\<lparr> domain_time := domain_time - consumed \<rparr>)
   od"
 
 definition

--- a/spec/abstract/SchedContext_A.thy
+++ b/spec/abstract/SchedContext_A.thy
@@ -518,16 +518,6 @@ where
   od"
 
 
-definition
-  commit_domain_time :: "(unit, 'z::state_ext) s_monad"
-where
-  "commit_domain_time = do
-    consumed \<leftarrow> gets consumed_time;
-    domain_time \<leftarrow> gets domain_time;
-    time' \<leftarrow> return (if domain_time < consumed then 0 else domain_time - consumed);
-    modify (\<lambda>s. s\<lparr>domain_time := time'\<rparr>)
-  od"
-
 text \<open> Update time consumption of current scheduling context and current domain. \<close>
 definition
   commit_time :: "(unit, 'z::state_ext) s_monad"
@@ -545,8 +535,6 @@ where
       od;
       update_sched_context csc (\<lambda>sc. sc\<lparr>sc_consumed := (sc_consumed sc) + consumed \<rparr>)
     od;
-    when (num_domains > 1) $
-      commit_domain_time;
     modify (\<lambda>s. s\<lparr>consumed_time := 0\<rparr> )
   od"
 

--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -51,7 +51,7 @@ definition
      modify (\<lambda>s. s \<lparr> cur_thread := thread \<rparr>)
    od"
 
-definition "\<mu>s_to_ms = 1000"
+definition "\<mu>s_in_ms = 1000"
 
 definition
   next_domain :: "(unit, 'z::state_ext) s_monad" where
@@ -61,7 +61,7 @@ definition
       let next_dom = (domain_list s)!domain_index'
       in s\<lparr> domain_index := domain_index',
             cur_domain := fst next_dom,
-            domain_time := us_to_ticks (snd next_dom * \<mu>s_to_ms),
+            domain_time := us_to_ticks (snd next_dom * \<mu>s_in_ms),
             reprogram_timer := True\<rparr>);
     do_extended_op $ modify (\<lambda>s. s \<lparr>work_units_completed := 0\<rparr>)
   od"
@@ -202,8 +202,19 @@ definition
    od"
 
 definition
+  check_domain_time :: "(unit, 'z::state_ext) s_monad"
+where
+  "check_domain_time \<equiv> do
+     exp \<leftarrow> gets is_cur_domain_expired;
+     when exp $ do modify (\<lambda>s. s\<lparr>reprogram_timer := True\<rparr>);
+                   reschedule_required
+                od
+   od"
+
+definition
   "schedule \<equiv> do
      awaken;
+     check_domain_time;
      ct \<leftarrow> gets cur_thread;
      ct_schedulable \<leftarrow> is_schedulable ct;
      action \<leftarrow> gets scheduler_action;

--- a/spec/haskell/src/SEL4/Kernel/Thread.lhs
+++ b/spec/haskell/src/SEL4/Kernel/Thread.lhs
@@ -339,9 +339,17 @@ has the highest runnable priority in the system on kernel entry (unless idle).
 >     then return (targetPrio < curPrio)
 >     else return True
 
+> checkDomainTime :: Kernel ()
+> checkDomainTime = do
+>     exp <- isCurDomainExpired
+>     when exp $ do
+>           setReprogramTimer True
+>           rescheduleRequired
+
 > schedule :: Kernel ()
 > schedule = do
 >     awaken
+>     checkDomainTime
 >     curThread <- getCurThread
 >     isSchedulable <- isSchedulable curThread
 >     action <- getSchedulerAction
@@ -722,4 +730,3 @@ Kernel init will created a initial thread whose tcbPriority is max priority.
 >     threadSet (\t -> t { tcbInReleaseQueue = False }) tcbPtr
 
 %
-

--- a/spec/haskell/src/SEL4/Model/StateData.lhs
+++ b/spec/haskell/src/SEL4/Model/StateData.lhs
@@ -258,8 +258,8 @@ These functions access and modify the current domain and the number of ticks rem
 > curDomain :: Kernel Domain
 > curDomain = gets ksCurDomain
 
-> usToMs :: Word64
-> usToMs = 1000
+> usInMs :: Word64
+> usInMs = 1000
 
 > nextDomain :: Kernel ()
 > nextDomain = modify (\ks ->
@@ -268,7 +268,7 @@ These functions access and modify the current domain and the number of ticks rem
 >   in ks { ksWorkUnitsCompleted = 0,
 >           ksDomScheduleIdx = ksDomScheduleIdx',
 >           ksCurDomain = dschDomain next,
->           ksDomainTime = usToTicks ((dschLength next) * usToMs),
+>           ksDomainTime = usToTicks ((dschLength next) * usInMs),
 >           ksReprogramTimer = True })
 
 > getDomainTime :: Kernel Word64

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -1026,12 +1026,7 @@ On some architectures, the thread context may include registers that may be modi
 >     if sufficient
 >         then do
 >             domExp <- isCurDomainExpired
->             if domExp
->                 then do
->                     setReprogramTimer True
->                     rescheduleRequired
->                     return False
->                 else return True
+>             return (not domExp)
 >         else do
 >             consumed <- getConsumedTime
 >             chargeBudget consumed True True


### PR DESCRIPTION
This proves `call_kernel_domain_time_inv_det_ext` in `DetSchedDomainTime_AI.thy`.

A sorry has been added to `Refine.thy`. It is related to `valid_domain_list` being true of the initial state. I wasn't sure of the status of the initial state, so please let me know what should be done. The sorry can be removed by adding another condition to the axiomatization of `us_to_ticks`, if we would like.

Mitch did most of the work I used before `DetSchedDomainTime_AI.thy` in AInvs, but I wasn't sure how to credit him. Let me know if you know. 