### PR TITLE
sched_context_resume cleanup

### DIFF
--- a/proof/invariant-abstract/DetSchedAux_AI.thy
+++ b/proof/invariant-abstract/DetSchedAux_AI.thy
@@ -1575,6 +1575,19 @@ lemma valid_refills_tcb_at_bound_sc:
 lemmas active_sc_tcb_at_valid_refills
   = active_sc_valid_refills_tcb_at[THEN valid_refills_tcb_at_bound_sc]
 
+lemma valid_refills_refill_sufficient:
+  "valid_refills scp s \<Longrightarrow> is_refill_sufficient 0 scp s"
+  by (fastforce simp: valid_refills_def rr_valid_refills_def vs_all_heap_simps obj_at_def
+                        refill_sufficient_defs split: if_splits)
+
+lemma valid_refills_budget_sufficient:
+  "valid_refills_tcb_at tp s \<Longrightarrow> budget_sufficient tp s"
+  by (fastforce simp: valid_refills_tcb_at_def budget_sufficient_def2 obj_at_def op_equal
+              intro!: valid_refills_refill_sufficient)
+
+lemmas active_valid_budget_sufficient
+  = valid_refills_budget_sufficient[OF active_sc_valid_refills_tcb_at]
+
 lemma released_sc_tcb_at_valid_refills:
   "\<lbrakk>active_sc_valid_refills s; released_sc_tcb_at tp s;
      bound_sc_tcb_at ((=) (Some scp)) tp s\<rbrakk>

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -6315,18 +6315,6 @@ lemma postpone_in_release_q:
   apply (drule_tac s="Some tcbptr" in sym, simp)
   done
 
-(* FIXME : Move *)
-lemma valid_refills_refill_sufficient:
-  "valid_refills scp s \<Longrightarrow> is_refill_sufficient 0 scp s"
-  by (fastforce simp: valid_refills_def rr_valid_refills_def vs_all_heap_simps obj_at_def
-                        refill_sufficient_defs split: if_splits)
-
-(* FIXME : Move *)
-lemma valid_refills_tcb_at_budget_sufficient:
-  "valid_refills_tcb_at tp s \<Longrightarrow> budget_sufficient tp s"
-  by (fastforce simp: valid_refills_tcb_at_def budget_sufficient_def2 obj_at_def op_equal
-              intro!: valid_refills_refill_sufficient)
-
 lemma sched_context_resume_schedulable_imp_ready:
   "\<lbrace>bound_sc_tcb_at ((=) (Some scp)) t
     and sc_tcb_sc_at ((=) (Some t)) scp
@@ -6374,7 +6362,7 @@ lemma sched_context_bind_tcb_valid_sched:
                      split: if_splits)
       apply (fastforce simp: valid_sched_def runnable_eq_active
                       elim!: valid_blockedE'
-                             valid_refills_tcb_at_budget_sufficient[OF active_sc_valid_refills_tcb_at])
+                             valid_refills_budget_sufficient[OF active_sc_valid_refills_tcb_at])
      apply (wpsimp wp: sched_context_resume_valid_sched_except_blocked
                        sched_context_resume_schedulable_imp_ready)
     apply (rule_tac Q="\<lambda>r. valid_sched_except_blocked and sc_not_in_release_q scptr and
@@ -11964,7 +11952,7 @@ lemma restart_valid_sched:
                      split: if_splits)
       apply (fastforce simp: valid_sched_def runnable_eq_active
                       elim!: valid_blockedE'
-                             valid_refills_tcb_at_budget_sufficient[OF active_sc_valid_refills_tcb_at])
+                             valid_refills_budget_sufficient[OF active_sc_valid_refills_tcb_at])
 
        apply (wpsimp wp: sched_context_resume_valid_sched_except_blocked
                          sched_context_resume_valid_blocked_except_set

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -16151,25 +16151,13 @@ lemmas rec_del_invs''_CTEDeleteCall = rec_del_invs''
                                        simplified pred_conj_def,
                                        THEN use_specE']
 
-lemma tcb_release_enqueue_not_in_release_q:
-  "\<lbrace>not_in_release_q t' and (\<lambda>s. t \<noteq> t')\<rbrace>
-   tcb_release_enqueue t
-   \<lbrace>\<lambda>rv. not_in_release_q t'\<rbrace>"
-  unfolding tcb_release_enqueue_def
-  apply wpsimp
-     apply (rule_tac Q="\<lambda>_ _. not_in_release_q_2 (qs) t' \<and> (t \<noteq> t')" in hoare_strengthen_post[rotated])
-      apply (fastforce simp: not_in_release_q_def in_queue_2_def intro: in_set_zip1)
-     apply wpsimp+
-  done
-
 lemma tcb_release_enqueue_ct_not_in_release_q[wp]:
   "\<lbrace>ct_not_in_release_q and (\<lambda>s. tcb_ptr \<noteq> cur_thread s)\<rbrace>
    tcb_release_enqueue tcb_ptr
    \<lbrace>\<lambda>xa. ct_not_in_release_q\<rbrace>"
   unfolding postpone_def
   apply (rule hoare_weaken_pre, wps)
-  apply (wpsimp wp: tcb_release_enqueue_not_in_release_q)+
-  done
+  by wpsimp+
 
 context DetSchedSchedule_AI begin
 
@@ -18321,7 +18309,7 @@ lemma postpone_not_queued_other:
    postpone sc_ptr
    \<lbrace>\<lambda>_. not_queued t\<rbrace>"
   apply (simp add: postpone_def)
-  by (wpsimp wp: tcb_release_enqueue_not_in_release_q get_sc_obj_ref_wp tcb_dequeue_not_queued)
+  by (wpsimp wp: get_sc_obj_ref_wp tcb_dequeue_not_queued)
 
 lemma sched_context_resume_ct_not_in_release_q:
   "\<lbrace>\<lambda>s. ct_not_in_release_q s \<and> \<not> heap_ref_eq (cur_thread s) sc_ptr (sc_tcbs_of s)\<rbrace>
@@ -18685,7 +18673,7 @@ lemma postpone_not_in_release_q_other:
    postpone sc_ptr
    \<lbrace>\<lambda>_. not_in_release_q t\<rbrace>"
   apply (simp add: postpone_def)
-  apply (wpsimp wp: tcb_release_enqueue_not_in_release_q get_sc_obj_ref_wp)
+  apply (wpsimp wp: get_sc_obj_ref_wp)
   by (simp add: sc_at_ppred_def obj_at_def)
 
 lemma sched_context_resume_not_in_release_q_other:


### PR DESCRIPTION
This PR contains a further cleanup on DetSchedSchedule_AI, in particular, about `sched_context_resume`.

We know that, with `valid_sched` in the precondition, after calling `sched_context_resume` on a thread, the thread being schedulable implies it is ready. We had several versions of lemmas essentially stating the same thing. Those are consolidated into `sched_context_resume_schedulable_imp_ready`.

Also, the existing lemmas mostly argue for "ready and sufficient" but it is actually only the readiness that matters (that could have changed) under `valid_sched`. We carry around separately (as part of `valid_sched`) in `valid_refills` the fact that "active implies sufficient".

Somewhat related, I think it probably makes sense to modify the notion of `released` in our proof to drop the sufficiency condition, so that it means "active and ready" only. We have `valid_sched` which gives us the guarantee that "active implies sufficient" separately, and in C, `sc_released` asserts sufficiency, so it is not actually a guard for it. Unless we are asking too much in `valid_sched`, which is unlikely (I hope).

A few other minor cleanups are also contained in this PR. It might help to review commit by commit.
