### PR TITLE
`us_to_ticks`

### DIFF
--- a/proof/invariant-abstract/ARM/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedAux_AI.thy
@@ -303,8 +303,9 @@ lemma kernelWCET_us_non_zero:
 
 lemma kernelWCET_ticks_non_zero:
   "kernelWCET_ticks \<noteq> 0"
-  using kernelWCET_us_non_zero us_to_ticks_nonzero
-  by (fastforce simp: kernelWCET_ticks_def)
+  apply (clarsimp simp: kernelWCET_ticks_def)
+  using kernelWCET_pos'
+  by simp
 
 end
 end

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -8865,10 +8865,10 @@ lemma handle_overrun_loop_window:
     apply (wpsimp wp: handle_overrun_loop_body_window)
     apply (fastforce intro!: head_time_buffer_implies_no_overflow
                       dest!: head_time_buffer_true_imp_unat_buffer[THEN iffD1, rotated]
-                       simp: vs_all_heap_simps  unat_MAX_RELEASE_TIME)
+                       simp: vs_all_heap_simps unat_MAX_RELEASE_TIME)
    apply (wpsimp wp: handle_overrun_loop_body_ordered_disjoint)
    apply (fastforce dest: head_time_buffer_true_imp_unat_buffer[THEN iffD1, rotated]
-                    simp: vs_all_heap_simps MAX_RELEASE_TIME_def MAX_PERIOD_mult' unat_sub)
+                    simp: vs_all_heap_simps MAX_RELEASE_TIME_def MAX_PERIOD_mult unat_sub)
   apply (wpsimp wp: handle_overrun_loop_body_refills_unat_sum_equals_budget)
   done
 
@@ -8949,8 +8949,9 @@ lemma handle_overrun_loop_head_bound:
     apply (fastforce simp: vs_all_heap_simps obj_at_kh_kheap_simps)
    apply (clarsimp simp: obj_at_def vs_all_heap_simps word_le_nat_alt)
    apply (rename_tac sc n)
-   apply (subst unat_add_lem', clarsimp simp: max_word_def)
-   apply (insert MAX_PERIOD_mult'[where n=4]; simp)
+   apply (subst unat_add_lem')
+    apply (clarsimp simp: max_word_def)
+   apply (insert MAX_PERIOD_mult[where n=4]; simp)
    apply (clarsimp simp: window_def)
    apply (subst unat_add_lem')
     apply (clarsimp simp: max_word_def word_le_nat_alt)
@@ -9016,7 +9017,7 @@ lemma handle_overrun_loop_head_bound:
    apply (drule_tac x="hd (tl (sc_refills scb))" in bspec)
     apply (simp add: list.set_sel(2))
    apply (clarsimp simp: window_def MAX_RELEASE_TIME_def unat_sub word_le_nat_alt)
-   apply (fastforce simp: MAX_PERIOD_mult'[where n=5])
+   apply (fastforce simp: MAX_PERIOD_mult[where n=5])
   apply clarsimp
   apply (subst unat_sub)
    apply (clarsimp simp: window_def MAX_RELEASE_TIME_def unat_sub word_le_nat_alt)

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedAux_AI.thy
@@ -303,8 +303,9 @@ lemma kernelWCET_us_non_zero:
 
 lemma kernelWCET_ticks_non_zero:
   "kernelWCET_ticks \<noteq> 0"
-  using kernelWCET_us_non_zero us_to_ticks_nonzero
-  by (fastforce simp: kernelWCET_ticks_def)
+  apply (clarsimp simp: kernelWCET_ticks_def)
+  using kernelWCET_pos'
+  by simp
 
 end
 end

--- a/proof/refine/ARM/Refine.thy
+++ b/proof/refine/ARM/Refine.thy
@@ -328,8 +328,9 @@ lemma valid_sched_init[simp]:
 
 lemma valid_domain_list_init[simp]:
   "valid_domain_list init_A_st"
+  apply (insert domain_time_pos)
   apply (simp add: init_A_st_def ext_init_def valid_domain_list_def)
-  sorry
+  done
 
 lemma akernel_invariant:
   "ADT_A uop \<Turnstile> full_invs"

--- a/proof/refine/ARM/SchedContextInv_R.thy
+++ b/proof/refine/ARM/SchedContextInv_R.thy
@@ -142,10 +142,17 @@ lemma decodeSchedControlInvocation_wf:
   apply (clarsimp simp: valid_cap'_def  ko_wp_at'_def scBits_simps valid_refills_number'_def
                         MAX_PERIOD_def maxPeriodUs_def usToTicks_def us_to_ticks_mono
                         MIN_BUDGET_def kernelWCET_ticks_def timeArgSize_def minBudgetUs_def
-                        MIN_REFILLS_def minRefills_def not_less)
-  apply (insert us_to_ticks_mult)
-  using kernelWCET_ticks_no_overflow apply clarsimp
-  using mono_def apply blast
+                        MIN_REFILLS_def minRefills_def not_less
+                  cong: conj_cong)
+  apply (insert getCurrentTime_buffer_bound)
+  apply (intro conjI impI; (fastforce intro: us_to_ticks_mono)?)
+   apply (rule_tac order_trans[OF MIN_BUDGET_helper])
+   apply (rule us_to_ticks_mono)
+    apply blast
+   apply (fastforce intro: order_trans[OF mult_le_mono1]
+                     simp: word_le_nat_alt)
+  apply (fastforce intro: order_trans[OF mult_le_mono1] us_to_ticks_mono
+                    simp: word_le_nat_alt)
   done
 
 lemma decodeSchedcontext_Bind_corres:

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -1749,7 +1749,7 @@ lemma domain_time_corres:
   "corres (=) \<top> \<top> (gets domain_time) getDomainTime"
   by (simp add: getDomainTime_def state_relation_def)
 
-lemma \<mu>s_to_ms_equiv:
+lemma \<mu>s_in_ms_equiv:
   "\<mu>s_in_ms = usInMs"
   by (simp add: usInMs_def \<mu>s_in_ms_def)
 
@@ -1767,7 +1767,7 @@ lemma next_domain_corres:
   apply (clarsimp simp: next_domain_def nextDomain_def reset_work_units_equiv modify_modify)
   apply (rule corres_modify)
   apply (simp add: state_relation_def Let_def dschLength_def dschDomain_def cdt_relation_def
-                   \<mu>s_to_ms_equiv us_to_ticks_equiv)
+                   \<mu>s_in_ms_equiv us_to_ticks_equiv)
   done
 
 lemma next_domain_valid_sched[wp]:

--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -51,8 +51,6 @@ definition
      modify (\<lambda>s. s \<lparr> cur_thread := thread \<rparr>)
    od"
 
-definition "\<mu>s_in_ms = 1000"
-
 definition
   next_domain :: "(unit, 'z::state_ext) s_monad" where
   "next_domain \<equiv> do

--- a/spec/machine/ARM/MachineOps.thy
+++ b/spec/machine/ARM/MachineOps.thy
@@ -120,6 +120,7 @@ consts' max_us_to_ticks :: "64 word"
 
 end
 
+
 qualify ARM (in Arch)
 
 type_synonym ticks = "64 word"
@@ -128,6 +129,75 @@ type_synonym time  = "64 word"
 abbreviation max_time :: time where
   "max_time \<equiv> max_word"
 
+\<comment> \<open>The following notepad shows that the axioms introduced below, which provide various results
+    about several constants and their conversion via us_to_ticks, are consistent.\<close>
+
+notepad begin
+
+define ticks_per_timer_unit :: "64 word" where "ticks_per_timer_unit = of_nat 50"
+define timer_unit :: "64 word" where "timer_unit = of_nat 1"
+define kernelWCET_us :: "64 word" where "kernelWCET_us = of_nat 100"
+define MAX_PERIOD_US :: "64 word" where "MAX_PERIOD_US = 60 * 60 * 1000 * 1000"
+define \<mu>s_in_ms :: "64 word" where "\<mu>s_in_ms = 1000"
+
+have ticks_per_timer_unit_non_zero:
+  "ticks_per_timer_unit \<noteq> 0"
+  by (simp add: ticks_per_timer_unit_def)
+
+have MIN_BUDGET_bound: "2 * unat kernelWCET_us * unat ticks_per_timer_unit < unat max_time"
+  apply (subst unat_max_word[symmetric])
+  apply clarsimp
+  apply (prop_tac "unat kernelWCET_us \<le> 100")
+   apply (fastforce simp: kernelWCET_us_def)
+  apply (prop_tac "unat ticks_per_timer_unit \<le> 50")
+   apply (fastforce simp: ticks_per_timer_unit_def)
+  apply (rule_tac y="10000" in le_less_trans)
+   apply (rule_tac j1=200 and l1=50 in order.trans[OF mult_le_mono]; fastforce)
+  apply simp
+  done
+
+have getCurrentTime_buffer_bound:
+  "unat kernelWCET_us * unat ticks_per_timer_unit
+    + 5 * unat MAX_PERIOD_US * unat ticks_per_timer_unit
+   < unat max_time"
+  apply (subst unat_max_word[symmetric])
+  apply clarsimp
+  apply (rule_tac j1=5000 and l1="5 * 60 * 60 * 1000 * 1000 * 50"
+               in order.strict_trans1[OF add_le_mono])
+    apply (fastforce simp: kernelWCET_us_def ticks_per_timer_unit_def)
+   apply (fastforce simp: kernelWCET_us_def ticks_per_timer_unit_def MAX_PERIOD_US_def)
+  apply linarith
+  done
+
+have kernelWCET_pos': "0 < (kernelWCET_us * ticks_per_timer_unit) div timer_unit"
+  apply (clarsimp simp: word_less_nat_alt)
+  apply (subst unat_mult_lem' | subst unat_div
+         | fastforce simp: kernelWCET_us_def ticks_per_timer_unit_def timer_unit_def max_word_def)+
+  done
+
+have MIN_BUDGET_pos': "0 < 2 * ((kernelWCET_us * ticks_per_timer_unit) div timer_unit)"
+  apply (clarsimp simp: word_less_nat_alt)
+  apply (subst unat_mult_lem' | subst unat_div
+         | fastforce simp: kernelWCET_us_def ticks_per_timer_unit_def timer_unit_def max_word_def)+
+  done
+
+have domain_time_pos: "0 < ((15 * \<mu>s_in_ms) * ticks_per_timer_unit) div timer_unit"
+  apply (clarsimp simp: word_less_nat_alt)
+  apply (subst unat_mult_lem' | subst unat_div
+         | fastforce simp: \<mu>s_in_ms_def ticks_per_timer_unit_def timer_unit_def max_word_def)+
+  done
+
+have getCurrentTime_buffer_pos:
+  "0 < (kernelWCET_us * ticks_per_timer_unit) div timer_unit
+       + 5 * (MAX_PERIOD_US * ticks_per_timer_unit div timer_unit)"
+  apply (clarsimp simp: word_less_nat_alt)
+  apply (subst unat_add_lem'' | subst unat_mult_lem' | subst unat_div
+         | fastforce simp: kernelWCET_us_def MAX_PERIOD_US_def ticks_per_timer_unit_def
+                           timer_unit_def max_word_def)+
+  done
+
+end
+
 axiomatization
   kernelWCET_us :: ticks
 where
@@ -135,33 +205,39 @@ where
 and
   kernelWCET_us_pos2: "0 < 2 * kernelWCET_us"
 
-text \<open>
-  This matches @{text "60 * 60 * MS_IN_S * US_IN_MS"} because it should be in micro-seconds.
-\<close>
-definition
-  MAX_PERIOD_US :: "64 word"
-where
-  "MAX_PERIOD_US \<equiv> 60 * 60 * 1000 * 1000"
+ text \<open>
+   This matches @{text "60 * 60 * MS_IN_S * US_IN_MS"} because it should be in micro-seconds.
+ \<close>
+ definition
+   MAX_PERIOD_US :: "64 word"
+ where
+   "MAX_PERIOD_US \<equiv> 60 * 60 * 1000 * 1000"
 
-axiomatization
-  us_to_ticks :: "ticks \<Rightarrow> ticks"
-where
-  us_to_ticks_mono[intro!]: "mono us_to_ticks"
+definition "\<mu>s_in_ms = 1000"
+
+consts' ticks_per_timer_unit :: ticks
+consts' timer_unit :: ticks
+
+definition
+  "us_to_ticks us = (us * ticks_per_timer_unit) div timer_unit"
+
+axiomatization where
+  ticks_per_timer_unit_non_zero: "ticks_per_timer_unit \<noteq> 0"
 and
-  us_to_ticks_zero[iff]: "us_to_ticks 0 = 0"
+  MIN_BUDGET_bound: "2 * unat kernelWCET_us * unat ticks_per_timer_unit < unat max_time"
 and
-  us_to_ticks_nonzero: "y \<noteq> 0 \<Longrightarrow> us_to_ticks y \<noteq> 0"
-and
-  kernelWCET_ticks_no_overflow: "4 * unat (us_to_ticks kernelWCET_us) \<le> unat max_time"
-and
-  getCurrentTime_buffer_no_overflow:
-    "unat (us_to_ticks kernelWCET_us) + 5 * unat (us_to_ticks MAX_PERIOD_US)
+  getCurrentTime_buffer_bound:
+    "unat kernelWCET_us * unat ticks_per_timer_unit
+      + 5 * unat MAX_PERIOD_US * unat ticks_per_timer_unit
      < unat max_time"
 and
-  us_to_ticks_mult: "unat n * unat (us_to_ticks a) \<le> unat max_time
-                     \<Longrightarrow> n * us_to_ticks a = us_to_ticks (n * a)"
+  kernelWCET_pos': "0 < us_to_ticks kernelWCET_us"
 and
-  getCurrentTime_buffer_nonzero: "0 < us_to_ticks kernelWCET_us + 5 * (us_to_ticks MAX_PERIOD_US)"
+  MIN_BUDGET_pos': "0 < 2 * us_to_ticks kernelWCET_us"
+and
+  domain_time_pos: "0 < us_to_ticks (15 * \<mu>s_in_ms)"
+and
+  getCurrentTime_buffer_pos: "0 < us_to_ticks kernelWCET_us + 5 * us_to_ticks MAX_PERIOD_US"
 
 definition "MAX_PERIOD = us_to_ticks MAX_PERIOD_US"
 
@@ -184,53 +260,77 @@ lemma replicate_no_overflow:
   by (metis (mono_tags, hide_lams) le_unat_uoi of_nat_mult word_of_nat word_unat.Rep_inverse)
 
 lemma kernelWCET_ticks_pos2: "0 < 2 * kernelWCET_ticks"
-  apply (simp add: kernelWCET_ticks_def word_less_nat_alt)
-  apply (subgoal_tac "unat (2 * us_to_ticks kernelWCET_us) = 2 * unat (us_to_ticks kernelWCET_us)")
-   using ARM.kernelWCET_us_pos2 ARM.us_to_ticks_nonzero unat_gt_0 apply force
-  apply (subgoal_tac "2 * unat (us_to_ticks kernelWCET_us) \<le> unat (max_word :: ticks)")
-   using replicate_no_overflow apply fastforce
-  using kernelWCET_ticks_no_overflow by force
+  apply (simp add: kernelWCET_ticks_def)
+  using MIN_BUDGET_pos' by simp
 
 lemma getCurrentTime_buffer_nonzero':
   "0 < getCurrentTime_buffer"
-  apply (insert getCurrentTime_buffer_nonzero)
+  apply (insert getCurrentTime_buffer_pos)
   apply (clarsimp simp: kernelWCET_ticks_def MAX_PERIOD_def)
   done
 
-lemma getCurrentTime_buffer_no_overflow':
-  "unat kernelWCET_ticks + 5 * unat MAX_PERIOD = unat (kernelWCET_ticks + 5 * MAX_PERIOD)"
-  apply (prop_tac "5 * unat (us_to_ticks MAX_PERIOD_US) = unat (5 * us_to_ticks MAX_PERIOD_US)")
-   apply (prop_tac "5 * unat (us_to_ticks MAX_PERIOD_US) \<le> unat (max_word :: 64 word)")
-    using getCurrentTime_buffer_no_overflow apply linarith
-   apply (fastforce dest: replicate_no_overflow[where a="us_to_ticks MAX_PERIOD_US" and n=5])
-  apply (insert getCurrentTime_buffer_no_overflow)
-  apply (clarsimp simp: kernelWCET_ticks_def MAX_PERIOD_def)
-  apply (subst unat_add_lem')
-   apply (clarsimp simp: max_word_def)
-  apply simp
-  done
+lemma us_to_ticks_helper:
+  "unat a * unat ticks_per_timer_unit \<le> unat max_time
+   \<Longrightarrow> unat (us_to_ticks a) \<le> unat a * unat ticks_per_timer_unit"
+  apply (clarsimp simp: us_to_ticks_def)
+  by (subst unat_div | subst unat_mult_lem' | simp)+
+
+lemma getCurrentTime_buffer_no_overflow:
+  "unat kernelWCET_ticks + 5 * unat MAX_PERIOD < unat max_time"
+  apply (insert getCurrentTime_buffer_bound)
+  by (rule_tac j1="unat kernelWCET_us * unat ticks_per_timer_unit"
+           and l1="5 * unat MAX_PERIOD_US * unat ticks_per_timer_unit"
+            in order.strict_trans1[OF add_le_mono]
+      ; fastforce simp: kernelWCET_ticks_def MAX_PERIOD_def
+                 intro: us_to_ticks_helper)
 
 lemma MAX_PERIOD_mult:
-  "unat (5 * MAX_PERIOD) = 5 * unat MAX_PERIOD"
-  apply (insert getCurrentTime_buffer_no_overflow')
-  apply (insert replicate_no_overflow[where n=5 and a=MAX_PERIOD and upper_bound=max_time, atomized])
-  using MAX_PERIOD_def getCurrentTime_buffer_no_overflow by auto
-
-lemma MAX_PERIOD_mult':
   "(n :: 64 word) \<le> 5 \<Longrightarrow> unat (n * MAX_PERIOD) = unat n * unat MAX_PERIOD"
-  apply (insert getCurrentTime_buffer_no_overflow')
-  apply (insert replicate_no_overflow[where n="unat n" and a=MAX_PERIOD and upper_bound=max_time])
-  apply (prop_tac "word_of_int (int (unat n)) = n")
-   apply (metis word_of_nat word_unat.Rep_inverse)
-  by (metis (mono_tags, hide_lams) MAX_PERIOD_mult le_trans max_word_max mult_le_mono1
-                                   of_nat_numeral unat_le_helper word_le_nat_alt)
+  apply (insert getCurrentTime_buffer_bound)
+  apply (insert replicate_no_overflow[where n="unat n" and a=MAX_PERIOD and upper_bound=max_time, atomized])
+  apply (elim impE)
+   apply (clarsimp simp: MAX_PERIOD_def)
+   apply (prop_tac "unat n \<le> (5 :: nat)")
+    apply (clarsimp simp: word_le_nat_alt)
+   apply (prop_tac "unat (us_to_ticks MAX_PERIOD_US) \<le> unat MAX_PERIOD_US * unat ticks_per_timer_unit")
+  apply (simp add: us_to_ticks_helper)
+   apply (prop_tac "5 * (unat MAX_PERIOD_US * unat ticks_per_timer_unit) \<le> unat max_time")
+    apply linarith
+   apply (metis (no_types, hide_lams) le_trans mult.commute mult_le_mono1)
+  by (metis word_of_nat word_unat.Rep_inverse)
+
+lemma getCurrentTime_buffer_no_overflow':
+  "unat kernelWCET_ticks + 5 * unat MAX_PERIOD = unat getCurrentTime_buffer"
+  apply (subst unat_add_lem'')
+   apply (insert getCurrentTime_buffer_bound)
+   apply (clarsimp simp: MAX_PERIOD_mult[where n=5] kernelWCET_ticks_def MAX_PERIOD_def)
+   apply (drule less_imp_le)
+   apply (rule_tac j1="unat kernelWCET_us * unat ticks_per_timer_unit"
+               and l1="5 * unat MAX_PERIOD_US * unat ticks_per_timer_unit"
+                in order.trans[OF add_le_mono])
+     apply (fastforce simp: us_to_ticks_helper)
+    apply (subst unat_div | subst unat_mult_lem')+
+     apply (metis MAX_PERIOD_def MAX_PERIOD_mult add.left_neutral order_refl unat_plus_simple
+                  unat_sum_boundE word_zero_le)
+    apply (fastforce simp: us_to_ticks_helper)
+   apply simp
+  apply (clarsimp simp: MAX_PERIOD_mult kernelWCET_ticks_def)
+  done
 
 lemma getCurrentTime_buffer_no_overflow'_stronger:
   "unat (kernelWCET_ticks + 5 * MAX_PERIOD + 1) = unat kernelWCET_ticks + unat (5 * MAX_PERIOD) + 1"
-  apply (subst unat_add_lem')
-   apply (insert getCurrentTime_buffer_no_overflow' getCurrentTime_buffer_no_overflow)
-   apply (clarsimp simp: kernelWCET_ticks_def MAX_PERIOD_def max_word_def)
-  apply (fastforce simp: MAX_PERIOD_mult)
+  apply (subst unat_add_lem'')
+   apply (subst getCurrentTime_buffer_no_overflow'[symmetric])
+   apply (insert getCurrentTime_buffer_bound)
+   apply (prop_tac "unat kernelWCET_ticks \<le> unat kernelWCET_us * unat ticks_per_timer_unit")
+    apply (fastforce intro: us_to_ticks_helper
+                      simp: kernelWCET_ticks_def)
+   apply (prop_tac "5 * unat MAX_PERIOD \<le> 5 * unat MAX_PERIOD_US * unat ticks_per_timer_unit")
+    apply (fastforce intro: us_to_ticks_helper
+                      simp: MAX_PERIOD_def)
+  apply fastforce
+  apply (insert getCurrentTime_buffer_no_overflow')
+  apply (clarsimp simp: MAX_PERIOD_mult kernelWCET_ticks_def)
   done
 
 lemma getCurrentTime_buffer_minus:
@@ -248,8 +348,46 @@ lemma getCurrentTime_buffer_minus':
   "- kernelWCET_ticks - 5 * MAX_PERIOD - 1 < - kernelWCET_ticks"
   apply (insert getCurrentTime_buffer_minus)
   apply (prop_tac "kernelWCET_ticks \<noteq> 0")
-   using us_to_ticks_nonzero kernelWCET_ticks_def kernelWCET_us_pos apply fastforce
+   using kernelWCET_pos' kernelWCET_ticks_def apply simp
   by (simp add: word_leq_minus_one_le)
+
+lemma us_to_ticks_zero:
+  "us_to_ticks 0 = 0"
+  apply (clarsimp simp: us_to_ticks_def)
+  done
+
+lemma unat_div_helper:
+  "a * ticks_per_timer_unit \<le> b * ticks_per_timer_unit
+   \<Longrightarrow> unat (a * ticks_per_timer_unit div timer_unit) \<le> unat (b * ticks_per_timer_unit div timer_unit)"
+  by (simp add: word_le_nat_alt div_le_mono uno_simps(2) word_arith_nat_div)
+
+lemma us_to_ticks_mono:
+  "\<lbrakk>a \<le> b; unat b * unat ticks_per_timer_unit \<le> unat max_time\<rbrakk>
+    \<Longrightarrow> us_to_ticks a \<le> us_to_ticks b"
+  apply (simp add: us_to_ticks_def)
+  apply (clarsimp simp: word_le_nat_alt)
+  apply (rule unat_div_helper)
+  apply (clarsimp simp: word_le_nat_alt)
+  by (metis (no_types, hide_lams) le_unat_uoi mult_le_mono1 word_arith_nat_defs(2))
+
+lemma divide_le_helper:
+  "\<lbrakk>unat a * unat b  \<le> unat (max_word :: 'a :: len word)\<rbrakk>
+   \<Longrightarrow> (a :: 'a :: len word) * (b  div c) \<le> a * b div c"
+  apply (clarsimp simp: word_le_nat_alt)
+  apply (subst unat_div | subst unat_mult_lem')+
+  apply (blast intro: div_le_dividend le_trans mult_le_mono2)
+  apply (subst unat_div | subst unat_mult_lem' | simp)+
+  by (metis (no_types, hide_lams) Groups.mult_ac(3) arith_extra_simps(19) div_by_0 div_le_mono
+                                  mult_le_mono2 nonzero_mult_div_cancel_left thd)
+
+lemma MIN_BUDGET_helper:
+  "2 * us_to_ticks kernelWCET_us \<le> us_to_ticks (2 * kernelWCET_us)"
+  apply (clarsimp simp: us_to_ticks_def)
+  apply (insert MIN_BUDGET_bound)
+  apply (rule_tac order_trans[OF divide_le_helper])
+   apply (subst unat_mult_lem' | simp)+
+  by (metis (no_types, hide_lams) Rat.sign_simps(5) Rat.sign_simps(6) order_refl)
+
 
 text \<open>
 This encodes the following assumptions:

--- a/spec/machine/MachineExports.thy
+++ b/spec/machine/MachineExports.thy
@@ -67,32 +67,37 @@ requalify_consts
   timerPrecision
   max_time
   getCurrentTime_buffer
+  \<mu>s_in_ms
 
 requalify_facts
-  us_to_ticks_mono
-  us_to_ticks_zero
-  us_to_ticks_nonzero
-  kernelWCET_ticks_no_overflow
   MAX_PERIOD_US_def
   MAX_PERIOD_def
-  us_to_ticks_mult
-  getCurrentTime_buffer_no_overflow
   kernelWCET_ticks_def
   replicate_no_overflow
-  getCurrentTime_buffer_nonzero
   getCurrentTime_buffer_nonzero'
   getCurrentTime_buffer_no_overflow'
   getCurrentTime_buffer_no_overflow'_stronger
   getCurrentTime_buffer_minus
   getCurrentTime_buffer_minus'
   MAX_PERIOD_mult
-  MAX_PERIOD_mult'
+  ticks_per_timer_unit_non_zero
+  MIN_BUDGET_bound
+  getCurrentTime_buffer_bound
+  kernelWCET_pos'
+  MIN_BUDGET_pos'
+  domain_time_pos
+  getCurrentTime_buffer_pos
+  getCurrentTime_buffer_no_overflow
+  us_to_ticks_mono
+  MIN_BUDGET_helper
+  \<mu>s_in_ms_def
+  us_to_ticks_helper
 
 definition "MAX_RELEASE_TIME = max_time - 5 * MAX_PERIOD"
 
 lemma unat_MAX_RELEASE_TIME:
   "unat MAX_RELEASE_TIME = unat max_time - 5 * unat MAX_PERIOD"
-  apply (clarsimp simp: MAX_RELEASE_TIME_def unat_sub MAX_PERIOD_mult')
+  apply (clarsimp simp: MAX_RELEASE_TIME_def unat_sub MAX_PERIOD_mult)
   done
 
 (* HERE IS THE PLACE FOR GENERIC WORD LEMMAS FOR ALL ARCHITECTURES *)

--- a/spec/machine/RISCV64/MachineOps.thy
+++ b/spec/machine/RISCV64/MachineOps.thy
@@ -94,6 +94,75 @@ type_synonym time  = "64 word"
 abbreviation max_time :: time where
   "max_time \<equiv> max_word"
 
+\<comment> \<open>The following notepad shows that the axioms introduced below, which provide various results
+    about several constants and their conversion via us_to_ticks, are consistent.\<close>
+
+notepad begin
+
+define ticks_per_timer_unit :: "64 word" where "ticks_per_timer_unit = of_nat 50"
+define timer_unit :: "64 word" where "timer_unit = of_nat 1"
+define kernelWCET_us :: "64 word" where "kernelWCET_us = of_nat 100"
+define MAX_PERIOD_US :: "64 word" where "MAX_PERIOD_US = 60 * 60 * 1000 * 1000"
+define \<mu>s_in_ms :: "64 word" where "\<mu>s_in_ms = 1000"
+
+have ticks_per_timer_unit_non_zero:
+  "ticks_per_timer_unit \<noteq> 0"
+  by (simp add: ticks_per_timer_unit_def)
+
+have MIN_BUDGET_bound: "2 * unat kernelWCET_us * unat ticks_per_timer_unit < unat max_time"
+  apply (subst unat_max_word[symmetric])
+  apply clarsimp
+  apply (prop_tac "unat kernelWCET_us \<le> 100")
+   apply (fastforce simp: kernelWCET_us_def)
+  apply (prop_tac "unat ticks_per_timer_unit \<le> 50")
+   apply (fastforce simp: ticks_per_timer_unit_def)
+  apply (rule_tac y="10000" in le_less_trans)
+   apply (rule_tac j1=200 and l1=50 in order.trans[OF mult_le_mono]; fastforce)
+  apply simp
+  done
+
+have getCurrentTime_buffer_bound:
+  "unat kernelWCET_us * unat ticks_per_timer_unit
+    + 5 * unat MAX_PERIOD_US * unat ticks_per_timer_unit
+   < unat max_time"
+  apply (subst unat_max_word[symmetric])
+  apply clarsimp
+  apply (rule_tac j1=5000 and l1="5 * 60 * 60 * 1000 * 1000 * 50"
+               in order.strict_trans1[OF add_le_mono])
+    apply (fastforce simp: kernelWCET_us_def ticks_per_timer_unit_def)
+   apply (fastforce simp: kernelWCET_us_def ticks_per_timer_unit_def MAX_PERIOD_US_def)
+  apply linarith
+  done
+
+have kernelWCET_pos': "0 < (kernelWCET_us * ticks_per_timer_unit) div timer_unit"
+  apply (clarsimp simp: word_less_nat_alt)
+  apply (subst unat_mult_lem' | subst unat_div
+         | fastforce simp: kernelWCET_us_def ticks_per_timer_unit_def timer_unit_def max_word_def)+
+  done
+
+have MIN_BUDGET_pos': "0 < 2 * ((kernelWCET_us * ticks_per_timer_unit) div timer_unit)"
+  apply (clarsimp simp: word_less_nat_alt)
+  apply (subst unat_mult_lem' | subst unat_div
+         | fastforce simp: kernelWCET_us_def ticks_per_timer_unit_def timer_unit_def max_word_def)+
+  done
+
+have domain_time_pos: "0 < ((15 * \<mu>s_in_ms) * ticks_per_timer_unit) div timer_unit"
+  apply (clarsimp simp: word_less_nat_alt)
+  apply (subst unat_mult_lem' | subst unat_div
+         | fastforce simp: \<mu>s_in_ms_def ticks_per_timer_unit_def timer_unit_def max_word_def)+
+  done
+
+have getCurrentTime_buffer_pos:
+  "0 < (kernelWCET_us * ticks_per_timer_unit) div timer_unit
+       + 5 * (MAX_PERIOD_US * ticks_per_timer_unit div timer_unit)"
+  apply (clarsimp simp: word_less_nat_alt)
+  apply (subst unat_add_lem'' | subst unat_mult_lem' | subst unat_div
+         | fastforce simp: kernelWCET_us_def MAX_PERIOD_US_def ticks_per_timer_unit_def
+                           timer_unit_def max_word_def)+
+  done
+
+end
+
 axiomatization
   kernelWCET_us :: ticks
 where
@@ -109,25 +178,31 @@ and
  where
    "MAX_PERIOD_US \<equiv> 60 * 60 * 1000 * 1000"
 
-axiomatization
-  us_to_ticks :: "ticks \<Rightarrow> ticks"
-where
-  us_to_ticks_mono[intro!]: "mono us_to_ticks"
+definition "\<mu>s_in_ms = 1000"
+
+consts' ticks_per_timer_unit :: ticks
+consts' timer_unit :: ticks
+
+definition
+  "us_to_ticks us = (us * ticks_per_timer_unit) div timer_unit"
+
+axiomatization where
+  ticks_per_timer_unit_non_zero: "ticks_per_timer_unit \<noteq> 0"
 and
-  us_to_ticks_zero[iff]: "us_to_ticks 0 = 0"
+  MIN_BUDGET_bound: "2 * unat kernelWCET_us * unat ticks_per_timer_unit < unat max_time"
 and
-  us_to_ticks_nonzero: "y \<noteq> 0 \<Longrightarrow> us_to_ticks y \<noteq> 0"
-and
-  kernelWCET_ticks_no_overflow: "4 * unat (us_to_ticks kernelWCET_us) \<le> unat max_time"
-and
-  getCurrentTime_buffer_no_overflow:
-    "unat (us_to_ticks kernelWCET_us) + 5 * unat (us_to_ticks MAX_PERIOD_US)
+  getCurrentTime_buffer_bound:
+    "unat kernelWCET_us * unat ticks_per_timer_unit
+      + 5 * unat MAX_PERIOD_US * unat ticks_per_timer_unit
      < unat max_time"
 and
-  us_to_ticks_mult: "unat n * unat (us_to_ticks a) \<le> unat max_time
-                     \<Longrightarrow> n * us_to_ticks a = us_to_ticks (n * a)"
+  kernelWCET_pos': "0 < us_to_ticks kernelWCET_us"
 and
-  getCurrentTime_buffer_nonzero: "0 < us_to_ticks kernelWCET_us + 5 * (us_to_ticks MAX_PERIOD_US)"
+  MIN_BUDGET_pos': "0 < 2 * us_to_ticks kernelWCET_us"
+and
+  domain_time_pos: "0 < us_to_ticks (15 * \<mu>s_in_ms)"
+and
+  getCurrentTime_buffer_pos: "0 < us_to_ticks kernelWCET_us + 5 * us_to_ticks MAX_PERIOD_US"
 
 definition "MAX_PERIOD = us_to_ticks MAX_PERIOD_US"
 
@@ -150,53 +225,77 @@ lemma replicate_no_overflow:
   by (metis (mono_tags, hide_lams) le_unat_uoi of_nat_mult word_of_nat word_unat.Rep_inverse)
 
 lemma kernelWCET_ticks_pos2: "0 < 2 * kernelWCET_ticks"
-  apply (simp add: kernelWCET_ticks_def word_less_nat_alt)
-  apply (subgoal_tac "unat (2 * us_to_ticks kernelWCET_us) = 2 * unat (us_to_ticks kernelWCET_us)")
-   using RISCV64.kernelWCET_us_pos2 RISCV64.us_to_ticks_nonzero unat_gt_0 apply force
-  apply (subgoal_tac "2 * unat (us_to_ticks kernelWCET_us) \<le> unat (max_word :: ticks)")
-   using replicate_no_overflow apply fastforce
-  using kernelWCET_ticks_no_overflow by force
+  apply (simp add: kernelWCET_ticks_def)
+  using MIN_BUDGET_pos' by simp
 
 lemma getCurrentTime_buffer_nonzero':
   "0 < getCurrentTime_buffer"
-  apply (insert getCurrentTime_buffer_nonzero)
+  apply (insert getCurrentTime_buffer_pos)
   apply (clarsimp simp: kernelWCET_ticks_def MAX_PERIOD_def)
   done
 
-lemma getCurrentTime_buffer_no_overflow':
-  "unat kernelWCET_ticks + 5 * unat MAX_PERIOD = unat (kernelWCET_ticks + 5 * MAX_PERIOD)"
-  apply (prop_tac "5 * unat (us_to_ticks MAX_PERIOD_US) = unat (5 * us_to_ticks MAX_PERIOD_US)")
-   apply (prop_tac "5 * unat (us_to_ticks MAX_PERIOD_US) \<le> unat (max_word :: 64 word)")
-    using getCurrentTime_buffer_no_overflow apply linarith
-   apply (fastforce dest: replicate_no_overflow[where a="us_to_ticks MAX_PERIOD_US" and n=5])
-  apply (insert getCurrentTime_buffer_no_overflow)
-  apply (clarsimp simp: kernelWCET_ticks_def MAX_PERIOD_def)
-  apply (subst unat_add_lem')
-   apply (clarsimp simp: max_word_def)
-  apply simp
-  done
+lemma us_to_ticks_helper:
+  "unat a * unat ticks_per_timer_unit \<le> unat max_time
+   \<Longrightarrow> unat (us_to_ticks a) \<le> unat a * unat ticks_per_timer_unit"
+  apply (clarsimp simp: us_to_ticks_def)
+  by (subst unat_div | subst unat_mult_lem' | simp)+
+
+lemma getCurrentTime_buffer_no_overflow:
+  "unat kernelWCET_ticks + 5 * unat MAX_PERIOD < unat max_time"
+  apply (insert getCurrentTime_buffer_bound)
+  by (rule_tac j1="unat kernelWCET_us * unat ticks_per_timer_unit"
+           and l1="5 * unat MAX_PERIOD_US * unat ticks_per_timer_unit"
+            in order.strict_trans1[OF add_le_mono]
+      ; fastforce simp: kernelWCET_ticks_def MAX_PERIOD_def
+                 intro: us_to_ticks_helper)
 
 lemma MAX_PERIOD_mult:
-  "unat (5 * MAX_PERIOD) = 5 * unat MAX_PERIOD"
-  apply (insert getCurrentTime_buffer_no_overflow')
-  apply (insert replicate_no_overflow[where n=5 and a=MAX_PERIOD and upper_bound=max_time, atomized])
-  using MAX_PERIOD_def getCurrentTime_buffer_no_overflow by auto
-
-lemma MAX_PERIOD_mult':
   "(n :: 64 word) \<le> 5 \<Longrightarrow> unat (n * MAX_PERIOD) = unat n * unat MAX_PERIOD"
-  apply (insert getCurrentTime_buffer_no_overflow')
-  apply (insert replicate_no_overflow[where n="unat n" and a=MAX_PERIOD and upper_bound=max_time])
-  apply (prop_tac "word_of_int (int (unat n)) = n")
-   apply (metis word_of_nat word_unat.Rep_inverse)
-  by (metis (mono_tags, hide_lams) MAX_PERIOD_mult le_trans max_word_max mult_le_mono1
-                                   of_nat_numeral unat_le_helper word_le_nat_alt)
+  apply (insert getCurrentTime_buffer_bound)
+  apply (insert replicate_no_overflow[where n="unat n" and a=MAX_PERIOD and upper_bound=max_time, atomized])
+  apply (elim impE)
+   apply (clarsimp simp: MAX_PERIOD_def)
+   apply (prop_tac "unat n \<le> (5 :: nat)")
+    apply (clarsimp simp: word_le_nat_alt)
+   apply (prop_tac "unat (us_to_ticks MAX_PERIOD_US) \<le> unat MAX_PERIOD_US * unat ticks_per_timer_unit")
+  apply (simp add: us_to_ticks_helper)
+   apply (prop_tac "5 * (unat MAX_PERIOD_US * unat ticks_per_timer_unit) \<le> unat max_time")
+    apply linarith
+   apply (metis (no_types, hide_lams) le_trans mult.commute mult_le_mono1)
+  by (metis word_of_nat word_unat.Rep_inverse)
+
+lemma getCurrentTime_buffer_no_overflow':
+  "unat kernelWCET_ticks + 5 * unat MAX_PERIOD = unat getCurrentTime_buffer"
+  apply (subst unat_add_lem'')
+   apply (insert getCurrentTime_buffer_bound)
+   apply (clarsimp simp: MAX_PERIOD_mult[where n=5] kernelWCET_ticks_def MAX_PERIOD_def)
+   apply (drule less_imp_le)
+   apply (rule_tac j1="unat kernelWCET_us * unat ticks_per_timer_unit"
+               and l1="5 * unat MAX_PERIOD_US * unat ticks_per_timer_unit"
+                in order.trans[OF add_le_mono])
+     apply (fastforce simp: us_to_ticks_helper)
+    apply (subst unat_div | subst unat_mult_lem')+
+     apply (metis MAX_PERIOD_def MAX_PERIOD_mult add.left_neutral order_refl unat_plus_simple
+                  unat_sum_boundE word_zero_le)
+    apply (fastforce simp: us_to_ticks_helper)
+   apply simp
+  apply (clarsimp simp: MAX_PERIOD_mult kernelWCET_ticks_def)
+  done
 
 lemma getCurrentTime_buffer_no_overflow'_stronger:
   "unat (kernelWCET_ticks + 5 * MAX_PERIOD + 1) = unat kernelWCET_ticks + unat (5 * MAX_PERIOD) + 1"
-  apply (subst unat_add_lem')
-   apply (insert getCurrentTime_buffer_no_overflow' getCurrentTime_buffer_no_overflow)
-   apply (clarsimp simp: kernelWCET_ticks_def MAX_PERIOD_def max_word_def)
-  apply (fastforce simp: MAX_PERIOD_mult)
+  apply (subst unat_add_lem'')
+   apply (subst getCurrentTime_buffer_no_overflow'[symmetric])
+   apply (insert getCurrentTime_buffer_bound)
+   apply (prop_tac "unat kernelWCET_ticks \<le> unat kernelWCET_us * unat ticks_per_timer_unit")
+    apply (fastforce intro: us_to_ticks_helper
+                      simp: kernelWCET_ticks_def)
+   apply (prop_tac "5 * unat MAX_PERIOD \<le> 5 * unat MAX_PERIOD_US * unat ticks_per_timer_unit")
+    apply (fastforce intro: us_to_ticks_helper
+                      simp: MAX_PERIOD_def)
+  apply fastforce
+  apply (insert getCurrentTime_buffer_no_overflow')
+  apply (clarsimp simp: MAX_PERIOD_mult kernelWCET_ticks_def)
   done
 
 lemma getCurrentTime_buffer_minus:
@@ -214,8 +313,46 @@ lemma getCurrentTime_buffer_minus':
   "- kernelWCET_ticks - 5 * MAX_PERIOD - 1 < - kernelWCET_ticks"
   apply (insert getCurrentTime_buffer_minus)
   apply (prop_tac "kernelWCET_ticks \<noteq> 0")
-   using us_to_ticks_nonzero kernelWCET_ticks_def kernelWCET_us_pos apply fastforce
+   using kernelWCET_pos' kernelWCET_ticks_def apply simp
   by (simp add: word_leq_minus_one_le)
+
+lemma us_to_ticks_zero:
+  "us_to_ticks 0 = 0"
+  apply (clarsimp simp: us_to_ticks_def)
+  done
+
+lemma unat_div_helper:
+  "a * ticks_per_timer_unit \<le> b * ticks_per_timer_unit
+   \<Longrightarrow> unat (a * ticks_per_timer_unit div timer_unit) \<le> unat (b * ticks_per_timer_unit div timer_unit)"
+  by (simp add: word_le_nat_alt div_le_mono uno_simps(2) word_arith_nat_div)
+
+lemma us_to_ticks_mono:
+  "\<lbrakk>a \<le> b; unat b * unat ticks_per_timer_unit \<le> unat max_time\<rbrakk>
+    \<Longrightarrow> us_to_ticks a \<le> us_to_ticks b"
+  apply (simp add: us_to_ticks_def)
+  apply (clarsimp simp: word_le_nat_alt)
+  apply (rule unat_div_helper)
+  apply (clarsimp simp: word_le_nat_alt)
+  by (metis (no_types, hide_lams) le_unat_uoi mult_le_mono1 word_arith_nat_defs(2))
+
+lemma divide_le_helper:
+  "\<lbrakk>unat a * unat b  \<le> unat (max_word :: 'a :: len word)\<rbrakk>
+   \<Longrightarrow> (a :: 'a :: len word) * (b  div c) \<le> a * b div c"
+  apply (clarsimp simp: word_le_nat_alt)
+  apply (subst unat_div | subst unat_mult_lem')+
+  apply (blast intro: div_le_dividend le_trans mult_le_mono2)
+  apply (subst unat_div | subst unat_mult_lem' | simp)+
+  by (metis (no_types, hide_lams) Groups.mult_ac(3) arith_extra_simps(19) div_by_0 div_le_mono
+                                  mult_le_mono2 nonzero_mult_div_cancel_left thd)
+
+lemma MIN_BUDGET_helper:
+  "2 * us_to_ticks kernelWCET_us \<le> us_to_ticks (2 * kernelWCET_us)"
+  apply (clarsimp simp: us_to_ticks_def)
+  apply (insert MIN_BUDGET_bound)
+  apply (rule_tac order_trans[OF divide_le_helper])
+   apply (subst unat_mult_lem' | simp)+
+  by (metis (no_types, hide_lams) Rat.sign_simps(5) Rat.sign_simps(6) order_refl)
+
 
 text \<open>
 This encodes the following assumptions:
@@ -419,4 +556,5 @@ definition setVSpaceRoot :: "paddr \<Rightarrow> machine_word \<Rightarrow> unit
   "setVSpaceRoot pt asid \<equiv> machine_op_lift $ setVSpaceRoot_impl pt asid"
 
 end
+
 end


### PR DESCRIPTION
This makes `us_to_ticks` a definition, and axiomatizes some of the necessary properties, in a way that is hopefully consistent. If the axioms are all fine, I'd be happy to add a comprehensive comment which motivates each of the axioms. 

The sorry that I recently added to `Refine.thy` related to `valid_domain_list'` being true of the initial state is (easily) solved.

I was hoping that I'd be able to use a more uniform approach that gives no overflow and non zero properties for some collection of constants, but I wasn't able to find a way that was evidently consistent. Any ideas would be appreciated.

I was unsure of what to call `factor1` and `factor2`. Maybe `timer_frequency` would be suitable for `factor1`, but I'm not entirely sure. I wanted to avoid something as boring as `us_to_ticks_mult` and `us_to_ticks_div` if possible, but maybe the latter is fine for `factor2`.