### PR TITLE
`PageTableDuplicates` last sorry

### DIFF
--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -609,12 +609,11 @@ lemma copyGlobalMappings_ksPSpace_stable:
       apply (rule ccontr)
       apply clarsimp
       apply (drule(1) pspace_alignedD')
-      apply (drule is_aligned_weaken[where y = 2])
-       apply (case_tac y, simp_all add: objBits_simps' pageBits_def)
-      apply (simp add: archObjSize_def pageBits_def
-                       pteBits_def pdeBits_def
-                  split: arch_kernel_object.splits)
-      sorry
+      apply (drule is_aligned_weaken[where y = 2]; simp?)
+      apply (fastforce simp: archObjSize_def pageBits_def pteBits_def pdeBits_def objBits_simps'
+                             scBits_at_least_2
+                      split: arch_kernel_object.splits kernel_object.splits)
+      done
     have ptr_eqD:
       "\<And>p a b. \<lbrakk>p + a = ptr + b;is_aligned p pdBits;
             a < 2^ pdBits; b < 2^pdBits \<rbrakk>

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -1203,19 +1203,25 @@ lemma scBits_max:
 (*  using assms
   by (clarsimp simp: valid_sched_context_size'_def maxUntypedSizeBits_def)*) sorry
 
-lemma scBits_pos':
-  "0 < scBitsFromRefillLength' us"
+lemma scBits_at_least_2:
+  "2 \<le> scBitsFromRefillLength' us"
 proof -
   note sc_const_eq[simp]
   have "log 2 (of_nat sizeof_sched_context_t)
            \<le> log 2 (of_nat (us * refill_size_bytes + sizeof_sched_context_t))"
     apply (simp only: sc_const_eq(2)[symmetric, simplified schedContextStructSize_def, simplified])
     by (simp only: log_le_cancel_iff[where a="2::real", THEN iffD2])
-  moreover have "0 < log 2 (of_nat sizeof_sched_context_t)"
+  moreover have "1 < log 2 (of_nat sizeof_sched_context_t)"
     by (simp add: sc_const_eq(2)[symmetric, simplified schedContextStructSize_def, simplified])
   ultimately show ?thesis
-    by (clarsimp simp: scBitsFromRefillLength'_def max_num_refills_def)
+    apply (clarsimp simp: scBitsFromRefillLength'_def max_num_refills_def)
+    by linarith
 qed
+
+lemma scBits_pos':
+  "0 < scBitsFromRefillLength' us"
+  using scBits_at_least_2
+  by (metis gr0I not_numeral_le_zero)
 
 lemma scBits_pos:
 (*  assumes "valid_sched_context_size' sc'"*)


### PR DESCRIPTION
This clears the last sorry in `PageTableDuplicates` by proving a lemma I've called `scBits_at_least_2`, which is a slight strengthening of `scBits_pos'`. It was a little annoying replacing the latter with the former, so I decided to keep the latter and prove it using the former. I'm not sure about the name for the new lemma but let me know if you have suggestions