### PR TITLE
Add refillUnblockCheck_corres proof

### DIFF
--- a/proof/refine/ARM/SchedContextInv_R.thy
+++ b/proof/refine/ARM/SchedContextInv_R.thy
@@ -933,7 +933,7 @@ lemma nonOverlappingMergeRefills_corres:
     corres dc (pspace_aligned and pspace_distinct and sc_at sc_ptr and is_active_sc sc_ptr
                 and valid_objs
                 and (\<lambda>s. pred_map (\<lambda>cfg. Suc 0 < length (scrc_refills cfg)) (sc_refill_cfgs_of s) sc_ptr))
-              valid_objs'
+              (valid_refills' sc_ptr)
     (non_overlapping_merge_refills sc_ptr)
     (nonOverlappingMergeRefills scPtr)"
   apply (clarsimp simp: non_overlapping_merge_refills_def nonOverlappingMergeRefills_def)
@@ -970,8 +970,6 @@ lemma nonOverlappingMergeRefills_corres:
      apply (wpsimp simp: updateRefillHd_def simp: objBits_simps)
     apply (simp add: is_active_sc_rewrite[symmetric])
    apply blast
-  apply wpsimp
-  apply (fastforce intro: valid_objs'_valid_refills')
   done
 
 lemma head_insufficient_simp:
@@ -992,7 +990,7 @@ lemma refillHdInsufficient_simp:
 
 lemma head_insufficient_equiv:
   "\<lbrakk>(s, s') \<in> state_relation; pspace_aligned s; pspace_distinct s; valid_objs s;
-    pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> []) (sc_refill_cfgs_of s) scPtr; valid_objs' s'\<rbrakk>
+    pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> []) (sc_refill_cfgs_of s) scPtr; valid_refills' scPtr s'\<rbrakk>
    \<Longrightarrow> head_insufficient scPtr s = refillHdInsufficient scPtr s'"
   apply (prop_tac "sc_at scPtr s")
    apply (fastforce dest: valid_objs_valid_sched_context_size
@@ -1002,10 +1000,9 @@ lemma head_insufficient_equiv:
   apply (frule state_relation_sc_relation; simp?)
   apply (subst head_insufficient_simp; simp?)
   apply (subst refillHdInsufficient_simp; simp)
-  apply (frule refill_hd_relation2[where s'=s'])
-    apply (fastforce simp: vs_all_heap_simps opt_map_def)
-   apply (clarsimp simp: sc_ko_at_valid_objs_valid_sc' opt_map_def projectKOs obj_at'_def)
-  apply (clarsimp simp: obj_at_def sc_at_ppred_def obj_at'_def projectKOs minBudget_def
+  apply (frule refill_hd_relation)
+   apply (fastforce simp: vs_all_heap_simps valid_refills'_def opt_map_def obj_at_simps)
+  apply (clarsimp simp: obj_at_def sc_at_ppred_def obj_at'_def projectKOs minBudget_def refill_map_def
                         MIN_BUDGET_def kernelWCETTicks_def opt_map_def vs_all_heap_simps)
   done
 
@@ -1089,7 +1086,7 @@ lemma headInsufficientLoop_corres:
                                     (sc_refill_cfgs_of s) sc_ptr)
                   and (\<lambda>s. pred_map (\<lambda>cfg. refills_unat_sum (scrc_refills cfg) \<le> unat max_time)
                                     (sc_refill_cfgs_of s) sc_ptr))
-                 valid_objs'
+                 (valid_refills' sc_ptr)
                  (head_insufficient_loop sc_ptr)
                  (headInsufficientLoop scPtr)"
   apply (clarsimp simp: head_insufficient_loop_def headInsufficientLoop_def runReaderT_def)

--- a/proof/refine/ARM/SchedContextInv_R.thy
+++ b/proof/refine/ARM/SchedContextInv_R.thy
@@ -507,7 +507,7 @@ lemma getCurSc_sp:
 lemma refillBudgetCheckRoundRobin_corres:
   "corres dc
           (cur_sc_active and (\<lambda>s. sc_at (cur_sc s) s))
-          (valid_objs' and (\<lambda>s'. sc_at' (ksCurSc s') s'))
+          ((\<lambda>s'. valid_refills' (ksCurSc s') s') and (\<lambda>s'. sc_at' (ksCurSc s') s'))
           (refill_budget_check_round_robin usage) (refillBudgetCheckRoundRobin usage)"
   supply projection_rewrites[simp]
   apply (subst is_active_sc_rewrite)
@@ -529,7 +529,6 @@ lemma refillBudgetCheckRoundRobin_corres:
    apply (clarsimp simp: obj_at_def is_active_sc2_def is_sc_obj opt_map_red
                   split: option.split_asm Structures_A.kernel_object.split_asm)
   apply (clarsimp simp: obj_at_simps fun_upd_def[symmetric] scBits_simps ps_clear_upd)
-  apply (erule (1) valid_objsE')
   apply (clarsimp simp: is_active_sc'_def valid_obj'_def valid_sched_context'_def valid_refills'_def
                  split: option.split_asm)
   done
@@ -898,6 +897,13 @@ lemma updateRefillHd_valid_refills'[wp]:
   apply (clarsimp simp: valid_refills'_def obj_at'_def projectKOs opt_map_def)
   done
 
+lemma updateRefillTl_valid_refills'[wp]:
+  "updateRefillTl scPtr f \<lbrace>valid_refills' scPtr'\<rbrace>"
+  apply (clarsimp simp: updateRefillTl_def updateSchedContext_def setSchedContext_def)
+  apply (wpsimp wp: setObject_sc_wp)
+  apply (clarsimp simp: valid_refills'_def obj_at'_def projectKOs opt_map_def)
+  done
+
 lemma refill_pop_head_is_active_sc[wp]:
   "refill_pop_head sc_ptr \<lbrace>is_active_sc sc_ptr'\<rbrace>"
   apply (wpsimp simp: refill_pop_head_def wp: update_sched_context_wp)
@@ -1151,7 +1157,7 @@ context begin interpretation Arch . (*FIXME: arch_split*)
 lemma scheduleUsed_corres:
   "\<lbrakk>sc_ptr = scPtr; new = refill_map new'\<rbrakk> \<Longrightarrow>
     corres dc (sc_at sc_ptr and is_active_sc2 sc_ptr and pspace_aligned and pspace_distinct)
-              valid_objs'
+              (valid_refills' scPtr)
               (schedule_used sc_ptr new)
               (scheduleUsed scPtr new')"
   apply (clarsimp simp: schedule_used_def scheduleUsed_def get_refills_def bind_assoc)

--- a/proof/refine/ARM/SchedContextInv_R.thy
+++ b/proof/refine/ARM/SchedContextInv_R.thy
@@ -374,14 +374,6 @@ lemma getCurTime_sp:
   "\<lbrace>P\<rbrace> getCurTime \<lbrace>\<lambda>rv. P and (\<lambda>s. rv = ksCurTime s)\<rbrace>"
   by (wpsimp simp: getCurTime_def)
 
-lemma isRoundRobin_corres:
-  "corres (=) (sc_at sc_ptr) (sc_at' sc_ptr)
-              (is_round_robin sc_ptr) (isRoundRobin sc_ptr)"
-  apply (clarsimp simp: is_round_robin_def isRoundRobin_def)
-  apply (corressimp corres: get_sc_corres
-                      simp: sc_relation_def)
-  done
-
 lemma valid_obj'_scPeriod_update[simp]:
   "valid_obj' (KOSchedContext (scPeriod_update (\<lambda>_. period) sc')) = valid_obj' (KOSchedContext sc')"
   by (fastforce simp: valid_obj'_def valid_sched_context'_def valid_sched_context_size'_def objBits_simps)
@@ -504,101 +496,6 @@ lemma getRefills_sp:
   apply (clarsimp simp: obj_at'_def projectKOs)
   done
 
-lemma sc_relation_updateRefillHd:
-  "\<lbrakk>sc_relation sc n sc'; \<forall>refill'. f (refill_map refill') = refill_map (f' refill');
-        sc_valid_refills' sc'\<rbrakk>
-       \<Longrightarrow> sc_relation (sc_refills_update (\<lambda>refills. f (hd refills) # tl refills) sc) n
-            (scRefills_update (\<lambda>_. updateAt (scRefillHead sc') (scRefills sc') f') sc')"
-  apply (prop_tac "wrap_slice (scRefillHead sc') (scRefillCount sc') (scRefillMax sc') (scRefills sc') \<noteq> []")
-   apply (clarsimp intro!: neq_Nil_lengthI)
-  apply (clarsimp simp: sc_relation_def refills_map_def tl_map hd_map)
-  apply (subst hd_Cons_tl[where xs="wrap_slice _ _ _ (updateAt _ _ _)", symmetric])
-   apply (clarsimp intro!: neq_Nil_lengthI)
-  apply simp
-  apply (subst hd_wrap_slice; (simp add: updateAt_index tl_wrap_slice neq_Nil_lengthI)?)+
-  apply (case_tac "Suc (scRefillHead sc') < scRefillMax sc'")
-   apply (prop_tac "wrap_slice (Suc (scRefillHead sc')) (scRefillCount sc' - Suc 0)
-                 (scRefillMax sc') (updateAt (scRefillHead sc') (scRefills sc') f')
-          = wrap_slice (Suc (scRefillHead sc')) (scRefillCount sc' - Suc 0) (scRefillMax sc') (scRefills sc')")
-    apply (subst wrap_slice_updateAt_eq[symmetric]; clarsimp)
-     apply (fastforce simp: neq_Nil_lengthI)+
-  apply (clarsimp simp: not_less le_eq_less_or_eq[where m="scRefillMax sc'" for sc'])
-  done
-
-lemma updateRefillHd_corres:
-  "\<lbrakk>sc_ptr = scPtr; \<forall>refill refill'. refill = refill_map refill' \<longrightarrow> f refill = (refill_map (f' refill'))\<rbrakk>
-   \<Longrightarrow> corres dc
-        (sc_at sc_ptr and is_active_sc2 sc_ptr)
-        (valid_refills' sc_ptr and sc_at' sc_ptr)
-        (update_refill_hd sc_ptr f)
-        (updateRefillHd scPtr f')"
-  supply projection_rewrites[simp]
-  apply (rule_tac Q="is_active_sc' scPtr" in corres_cross_add_guard)
-   apply (fastforce dest!: is_active_sc'_cross[OF state_relation_pspace_relation])
-  apply (clarsimp simp: update_refill_hd_def updateRefillHd_def)
-  apply (rule corres_guard_imp)
-    apply (rule updateSchedContext_corres_gen[where P=\<top>
-      and P'="valid_refills' sc_ptr and is_active_sc' scPtr"])
-      apply (clarsimp, drule (2) state_relation_sc_relation)
-      apply (fastforce simp: is_sc_obj obj_at_simps is_active_sc'_def opt_map_red valid_refills'_def
-                      elim!: sc_relation_updateRefillHd)
-     apply (fastforce simp: obj_at_simps is_sc_obj opt_map_red
-                     dest!: state_relation_sc_replies_relation_sc)
-  by (clarsimp simp: objBits_simps)+
-
-lemma sc_relation_updateRefillTl:
-  "\<lbrakk> sc_relation sc n sc'; \<forall>refill'. f (refill_map refill') = refill_map (f' refill');
-        sc_valid_refills' sc'\<rbrakk>
-       \<Longrightarrow> sc_relation
-            (sc_refills_update (\<lambda>refills. butlast refills @ [f (last refills)]) sc) n
-            (scRefills_update (\<lambda>_. updateAt (refillTailIndex sc') (scRefills sc') f') sc')"
-  apply (prop_tac "scRefills sc' \<noteq> []")
-   apply fastforce
-  apply (clarsimp simp: sc_relation_def refills_map_def)
-  apply (simp add: snoc_eq_iff_butlast)
-  apply (prop_tac "wrap_slice (scRefillHead sc') (scRefillCount sc') (scRefillMax sc')
-              (scRefills sc') \<noteq> []")
-   apply (clarsimp intro!: neq_Nil_lengthI)
-  apply (prop_tac "wrap_slice (scRefillHead sc') (scRefillCount sc') (scRefillMax sc')
-              (updateAt (refillTailIndex sc') (scRefills sc') f') \<noteq> []")
-   apply (clarsimp intro!: neq_Nil_lengthI)
-  apply clarsimp
-  apply (prop_tac "wrap_slice (scRefillHead sc') (scRefillCount sc' - Suc 0)
-             (scRefillMax sc')
-             (updateAt (refillTailIndex sc') (scRefills sc') f') = wrap_slice (scRefillHead sc') (scRefillCount sc' - Suc 0)
-             (scRefillMax sc')
-             (scRefills sc')")
-   apply (subst wrap_slice_updateAt_eq[symmetric]; (simp add: refillTailIndex_def Let_def split: if_split_asm)?)
-   apply (intro conjI impI; linarith)
-  apply (clarsimp simp: butlast_map butlast_wrap_slice)
-  apply (clarsimp simp: last_map)
-  apply (subst last_wrap_slice; simp?)+
-  apply (intro conjI impI)
-   apply (subst updateAt_index; simp add: refillTailIndex_def)+
-  done
-
-lemma updateRefillTl_corres:
-  "\<lbrakk>sc_ptr = scPtr;
-    \<forall>refill refill'. refill = refill_map refill' \<longrightarrow> f refill = (refill_map (f' refill'))\<rbrakk>
-   \<Longrightarrow> corres dc
-              (sc_at sc_ptr and is_active_sc2 sc_ptr)
-              (sc_at' scPtr and valid_objs')
-              (update_refill_tl sc_ptr f)
-              (updateRefillTl scPtr f')"
-  supply projection_rewrites[simp]
-  apply (rule_tac Q="is_active_sc' scPtr" in corres_cross_add_guard)
-   apply (fastforce dest!: is_active_sc'_cross[OF state_relation_pspace_relation])
-  apply (clarsimp simp: update_refill_tl_def updateRefillTl_def)
-  apply (rule corres_guard_imp)
-    apply (rule updateSchedContext_corres_gen[where P=\<top> and P'="valid_objs' and is_active_sc' scPtr"])
-      apply (clarsimp, drule (2) state_relation_sc_relation)
-      apply (clarsimp simp: is_sc_obj obj_at_simps is_active_sc'_def)
-      apply (erule (1) valid_objsE', clarsimp simp: valid_obj'_def valid_sched_context'_def)
-      apply (clarsimp simp: sc_relation_updateRefillTl opt_map_red)
-     apply (fastforce simp: obj_at_simps is_sc_obj opt_map_red
-                     dest!: state_relation_sc_replies_relation_sc)
-  by (clarsimp simp: objBits_simps)+
-
 lemma getCurSc_sp:
   "\<lbrace>P\<rbrace>
    getCurSc
@@ -720,53 +617,6 @@ lemma refillResetRR_corres:
      apply (clarsimp simp: objBits_simps)+
    apply (clarsimp simp: round_robin2_def obj_at_def is_sc_obj rr_valid_refills_def opt_map_red)
   by (clarsimp simp: objBits_simps)
-
-lemma refillPopHead_corres:
-  "corres (\<lambda>refill refill'. refill = refill_map refill')
-              (pspace_aligned and pspace_distinct and sc_at sc_ptr and is_active_sc sc_ptr
-               and sc_refills_sc_at (\<lambda>refills. 1 < length refills) sc_ptr)
-              valid_objs'
-              (refill_pop_head sc_ptr) (refillPopHead sc_ptr)"
-  (is "corres _ ?abs ?conc _ _")
-  supply if_split[split del]
-  supply projection_rewrites[simp]
-  apply (subst is_active_sc_rewrite)
-  apply (rule corres_cross[where Q' = "sc_at' sc_ptr", OF sc_at'_cross_rel], fastforce)
-  apply (rule_tac Q="is_active_sc' sc_ptr" in corres_cross_add_guard)
-   apply (fastforce dest!: is_active_sc'_cross[OF state_relation_pspace_relation])
-  apply (clarsimp simp: refill_pop_head_def refillPopHead_def)
-  apply (clarsimp simp: getRefillNext_getSchedContext get_refills_def liftM_def)
-  apply (rule corres_split'[rotated 2, OF get_sched_context_sp get_sc_sp'])
-   apply (rule corres_guard_imp)
-     apply (rule get_sc_corres)
-    apply simp
-   apply simp
-  apply (rename_tac sc')
-  apply (rule_tac F="refill_hd sc = refill_map (refillHd sc')" in corres_req)
-   apply (clarsimp simp: obj_at_def is_sc_obj obj_at'_def projectKOs)
-   apply (frule (1) pspace_relation_absD[OF _ state_relation_pspace_relation])
-   apply (clarsimp elim!: refill_hd_relation)
-   apply (erule (1) valid_objsE')
-   apply (clarsimp simp: valid_obj'_def valid_sched_context'_def is_active_sc'_def opt_map_red)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split'[OF updateSchedContext_corres_gen[where
-                                    P="(\<lambda>s. ((\<lambda>sc. 1 < length (sc_refills sc)) |< scs_of2 s) sc_ptr)"
-                                and P'="valid_objs' and is_active_sc' sc_ptr"]])
-         apply (clarsimp, drule (2) state_relation_sc_relation)
-         apply (clarsimp simp: sc_relation_def refills_map_def tl_map obj_at_simps is_sc_obj opt_map_red)
-         apply (erule (1) valid_objsE', clarsimp simp: valid_obj'_def valid_sched_context'_def)
-         apply (subst tl_wrap_slice; clarsimp simp: min_def split: if_split)
-         apply (rule conjI impI; clarsimp simp: refillNextIndex_def wrap_slice_start_0 split: if_splits)
-        apply (fastforce simp: obj_at_simps is_sc_obj opt_map_red
-                        dest!: state_relation_sc_replies_relation_sc)
-        apply clarsimp
-       apply (clarsimp simp: objBits_simps)
-      apply simp
-     apply (wpsimp wp: update_sched_context_wp)
-    apply (wpsimp wp: updateSchedContext_wp)
-   apply (clarsimp simp: sc_refills_sc_at_def obj_at_def opt_map_red)
-  apply simp
-  done
 
 lemma refillNew_corres:
   "\<lbrakk>1 < max_refills; valid_refills_number' max_refills (min_sched_context_bits + n)\<rbrakk>
@@ -1046,16 +896,6 @@ lemma updateRefillHd_valid_refills'[wp]:
   apply (clarsimp simp: updateRefillHd_def updateSchedContext_def setSchedContext_def)
   apply (wpsimp wp: setObject_sc_wp)
   apply (clarsimp simp: valid_refills'_def obj_at'_def projectKOs opt_map_def)
-  done
-
-lemma refillPopHead_valid_refills'[wp]:
-  "\<lbrace>\<lambda>s. valid_refills' scPtr' s
-        \<and> (scPtr = scPtr' \<longrightarrow> obj_at' (\<lambda>sc'. Suc 0 < scRefillCount sc') scPtr s)\<rbrace>
-   refillPopHead scPtr
-   \<lbrace>\<lambda>_. valid_refills' scPtr'\<rbrace>"
-  apply (clarsimp simp: refillPopHead_def updateSchedContext_def setSchedContext_def)
-  apply (wpsimp wp: setObject_sc_wp)
-  apply (fastforce simp: valid_refills'_def obj_at'_def projectKOs opt_map_def refillNextIndex_def)
   done
 
 lemma refill_pop_head_is_active_sc[wp]:

--- a/proof/refine/ARM/SchedContext_R.thy
+++ b/proof/refine/ARM/SchedContext_R.thy
@@ -964,7 +964,7 @@ lemma updateRefillTl_corres:
     \<forall>refill refill'. refill = refill_map refill' \<longrightarrow> f refill = (refill_map (f' refill'))\<rbrakk>
    \<Longrightarrow> corres dc
               (sc_at sc_ptr and is_active_sc2 sc_ptr)
-              (sc_at' scPtr and valid_objs')
+              (sc_at' scPtr and valid_refills' scPtr)
               (update_refill_tl sc_ptr f)
               (updateRefillTl scPtr f')"
   supply projection_rewrites[simp]
@@ -972,10 +972,9 @@ lemma updateRefillTl_corres:
    apply (fastforce dest!: is_active_sc'_cross[OF state_relation_pspace_relation])
   apply (clarsimp simp: update_refill_tl_def updateRefillTl_def)
   apply (rule corres_guard_imp)
-    apply (rule updateSchedContext_corres_gen[where P=\<top> and P'="valid_objs' and is_active_sc' scPtr"])
+    apply (rule updateSchedContext_corres_gen[where P=\<top> and P'="valid_refills' scPtr and is_active_sc' scPtr"])
       apply (clarsimp, drule (2) state_relation_sc_relation)
-      apply (clarsimp simp: is_sc_obj obj_at_simps is_active_sc'_def)
-      apply (erule (1) valid_objsE', clarsimp simp: valid_obj'_def valid_sched_context'_def)
+      apply (clarsimp simp: is_sc_obj obj_at_simps is_active_sc'_def valid_refills'_def)
       apply (clarsimp simp: sc_relation_updateRefillTl opt_map_red)
      apply (fastforce simp: obj_at_simps is_sc_obj opt_map_red
                      dest!: state_relation_sc_replies_relation_sc)

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -3939,7 +3939,7 @@ lemma refillPopHead_corres:
   "corres (\<lambda>refill refill'. refill = refill_map refill')
               (pspace_aligned and pspace_distinct and sc_at sc_ptr and is_active_sc sc_ptr
                and sc_refills_sc_at (\<lambda>refills. 1 < length refills) sc_ptr)
-              valid_objs'
+              (valid_refills' sc_ptr)
               (refill_pop_head sc_ptr) (refillPopHead sc_ptr)"
   (is "corres _ ?abs ?conc _ _")
   supply if_split[split del]
@@ -3959,20 +3959,17 @@ lemma refillPopHead_corres:
   apply (rule_tac F="refill_hd sc = refill_map (refillHd sc')" in corres_req)
    apply (clarsimp simp: obj_at_def is_sc_obj obj_at'_def projectKOs)
    apply (frule (1) pspace_relation_absD[OF _ state_relation_pspace_relation])
-   apply (clarsimp elim!: refill_hd_relation)
-   apply (erule (1) valid_objsE')
-   apply (clarsimp simp: valid_obj'_def valid_sched_context'_def is_active_sc'_def opt_map_red)
+   apply (clarsimp elim!: refill_hd_relation simp: valid_refills'_def opt_map_red)
   apply (rule corres_guard_imp)
     apply (rule corres_split'[OF updateSchedContext_corres_gen[where
                                     P="(\<lambda>s. ((\<lambda>sc. 1 < length (sc_refills sc)) |< scs_of2 s) sc_ptr)"
-                                and P'="valid_objs' and is_active_sc' sc_ptr"]])
+                                and P'="valid_refills' sc_ptr and is_active_sc' sc_ptr"]])
          apply (clarsimp, drule (2) state_relation_sc_relation)
          apply (clarsimp simp: sc_relation_def refills_map_def tl_map obj_at_simps is_sc_obj opt_map_red)
-         apply (erule (1) valid_objsE', clarsimp simp: valid_obj'_def valid_sched_context'_def)
+         apply (clarsimp simp: valid_refills'_def opt_map_red)
          apply (subst tl_wrap_slice; clarsimp simp: min_def split: if_split)
          apply (rule conjI impI; clarsimp simp: refillNextIndex_def wrap_slice_start_0 split: if_splits)
-        apply (fastforce simp: obj_at_simps is_sc_obj opt_map_red
-                        dest!: state_relation_sc_replies_relation_sc)
+        apply (fastforce simp: obj_at_simps is_sc_obj opt_map_red dest!: state_relation_sc_replies_relation_sc)
         apply clarsimp
        apply (clarsimp simp: objBits_simps)
       apply simp

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -2407,15 +2407,13 @@ lemma no_ofail_refillHeadOverlapping:
   by (clarsimp dest!: no_ofailD[OF no_ofail_readSchedContext])
 
 lemma refillHeadOverlapping_implies_count_greater_than_one:
-  "\<lbrakk>the (refillHeadOverlapping scPtr s); sc_at' scPtr s;
-    \<forall>sc. ko_at' sc scPtr s \<longrightarrow> valid_sched_context' sc s\<rbrakk>
-   \<Longrightarrow> obj_at' (\<lambda>sc. 1 < scRefillCount sc) scPtr s"
+  "\<lbrakk>the (refillHeadOverlapping scPtr s); sc_at' scPtr s\<rbrakk>
+   \<Longrightarrow> ((\<lambda>sc. 1 < scRefillCount sc) |< scs_of' s) scPtr"
   apply (clarsimp simp: refillHeadOverlapping_def readSchedContext_def oliftM_def
                         readRefillNext_def readRefillSize_def obind_def omonad_defs
                  split: option.splits dest!: readObject_misc_ko_at')
-   apply (prop_tac "sc_at' scPtr s")
-    apply (fastforce dest: no_ofail_sc_at'_readObject[unfolded no_ofail_def, rule_format])+
-  apply (clarsimp simp: obj_at'_def projectKOs valid_sched_context'_def MIN_REFILLS_def)
+   apply (fastforce dest: no_ofail_sc_at'_readObject[unfolded no_ofail_def, rule_format])
+  apply (clarsimp simp: obj_at_simps opt_map_red MIN_REFILLS_def)
   done
 
 lemma refillHeadOverlappingLoop_valid_objs':
@@ -2425,10 +2423,9 @@ lemma refillHeadOverlappingLoop_valid_objs':
   (is "valid ?pre _ _")
   apply (clarsimp simp: refillHeadOverlappingLoop_def)
   apply (wpsimp wp: valid_whileLoop[where I="\<lambda>_. ?pre"] mergeRefills_valid_objs')
-  apply (clarsimp simp: runReaderT_def)
-    apply (fastforce dest: sc_ko_at_valid_objs_valid_sc'
-                           refillHeadOverlapping_implies_count_greater_than_one
-                     simp: obj_at'_def active_sc_at'_def projectKOs)
+    apply (clarsimp simp: runReaderT_def)
+    apply (fastforce dest: refillHeadOverlapping_implies_count_greater_than_one
+                     simp: obj_at_simps active_sc_at'_rewrite opt_map_red)
    apply simp
   apply simp
   done


### PR DESCRIPTION
Adding refillUnblockCheck_corres proof to Schedule_R under
a slightly different name (with ‘), so that it will be available for 
making progress with schedule_corres.

* to be renamed later, when "add refill_unblock_check everywhere" spec
  change is finished, and the corres rule is integrated in proofs in
  the later theory files (this process will remove one sorry)

Also with some tweaks (weakening assumptions). It might help to review commit by commit.
