### PR TITLE
“add refill_unblock_check” spec update, part I

### DIFF
--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -15569,18 +15569,6 @@ lemma sched_context_yield_to_valid_sched:
   apply (clarsimp simp: is_schedulable_bool_def2)
   apply (case_tac schedulable; clarsimp?, (solves \<open>wpsimp\<close>)?)
 
-  apply (rule hoare_seq_ext_skip)
-   apply ((wpsimp wp: hoare_vcg_conj_lift refill_unblock_check_valid_sched is_schedulable_wp
-                      refill_unblock_check_sc_tcb_sc_at
-                      refill_unblock_check_active_sc_valid_refills refill_unblock_check_ct_released
-                      refill_unblock_check_ct_in_state[simplified ct_in_state_def]
-           | wps)+)[1]
-    apply (intro conjI; (solves \<open>clarsimp simp: valid_sched_def\<close>)?)
-   apply (rule allI, rename_tac t)
-   apply (clarsimp simp: vs_all_heap_simps sc_at_pred_n_def obj_at_def)
-   apply (frule invs_sym_refs)
-   apply (frule_tac tp=t in sym_ref_tcb_sc, blast, blast, simp)
-
   apply (intro hoare_seq_ext[OF _ get_sched_context_sp]
                hoare_seq_ext[OF _ gets_sp]
                hoare_seq_ext[OF _ assert_sp]
@@ -22681,8 +22669,6 @@ lemma sched_context_yield_to_cur_sc_in_release_q_imp_zero_consumed[wp]:
    using strengthen_cur_sc_offset_ready strengthen_cur_sc_offset_sufficient apply blast
   apply (rule hoare_seq_ext_skip, wpsimp)
   apply (rule hoare_if; (solves \<open>wpsimp\<close>)?)
-  apply (rule hoare_seq_ext_skip, wpsimp)+
-  apply (rule hoare_if; wpsimp)
   done
 
 lemma sched_context_unbind_tcb_cur_sc_not_in_release_q[wp]:

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -11733,22 +11733,19 @@ lemma switch_sched_context_valid_sched:
      and (\<lambda>s. \<forall>a. bound_sc_tcb_at ((=) (Some a)) (cur_thread s) s \<longrightarrow> a \<noteq> cur_sc s \<longrightarrow> ct_not_in_release_q s)\<rbrace>
    switch_sched_context
    \<lbrace>\<lambda>_. valid_sched :: ('state_ext state) \<Rightarrow> _\<rbrace>"
-  apply (clarsimp simp: switch_sched_context_def assert_opt_def)
+  apply (clarsimp simp: switch_sched_context_def assert_opt_def if_cond_refill_unblock_check_def)
   apply (rule hoare_seq_ext[OF _ gets_sp])
   apply (rule hoare_seq_ext[OF _ gets_sp])
   apply (rule hoare_seq_ext[OF _ gsc_sp])
   apply (case_tac sc_opt; clarsimp simp: bind_assoc)
-  apply (wpsimp wp: commit_time_valid_sched hoare_drop_imp assert_inv)
-      apply (wpsimp wp: refill_unblock_check_valid_sched)
-     apply (wpsimp wp: refill_unblock_check_valid_sched hoare_drop_imp)
-    apply wpsimp+
+  apply (wpsimp wp: commit_time_valid_sched hoare_drop_imp assert_inv refill_unblock_check_valid_sched)
   apply (clarsimp cong: conj_cong)
-  apply (intro conjI; (simp add: current_time_bounded_def)?)
-   apply (clarsimp simp: tcb_at_kh_simps pred_map_eq_normalise)
-   apply (subgoal_tac "t = cur_thread s", simp)
-   apply (erule (1) heap_refs_inj_eq[rotated])
-   apply (rule sym_refs_inj_tcb_scps, clarsimp simp: valid_state_def valid_pspace_def)
-  apply (clarsimp simp: valid_state_def)
+  apply (intro conjI impI; (simp add: current_time_bounded_def)?)
+    apply (clarsimp simp: tcb_at_kh_simps pred_map_eq_normalise)
+    apply (subgoal_tac "t = cur_thread s", simp)
+    apply (erule (1) heap_refs_inj_eq[rotated])
+    apply (rule sym_refs_inj_tcb_scps, clarsimp simp: valid_state_def valid_pspace_def)
+   apply (clarsimp simp: valid_state_def)+
   done
 
 lemma sc_and_timer_valid_sched:

--- a/proof/invariant-abstract/Deterministic_AI.thy
+++ b/proof/invariant-abstract/Deterministic_AI.thy
@@ -4200,6 +4200,8 @@ lemma delete_objects_valid_list[wp]: "\<lbrace>valid_list\<rbrace> delete_object
 
 lemmas mapM_x_def_bak = mapM_x_def[symmetric]
 
+crunch valid_list[wp]: refill_unblock_check valid_list
+  (wp: hoare_drop_imps crunch_wps simp: crunch_simps is_round_robin_def)
 crunch valid_list[wp]: maybe_donate_sc valid_list (wp: maybeM_inv)
 
 locale Deterministic_AI_2 = Deterministic_AI_1 +

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -2654,6 +2654,10 @@ lemma refillUnblockCheck_invs':
   apply wpsimp
   done
 
+crunches ifCondRefillUnblockCheck
+  for invs'[wp]: invs'
+  (wp: hoare_vcg_if_lift2 crunch_wps simp: crunch_simps)
+
 lemma nonOverlappingMergeRefills_valid_objs':
   "\<lbrace>\<lambda>s. valid_objs' s \<and> sc_at' scPtr s\<rbrace>
    nonOverlappingMergeRefills scPtr

--- a/spec/abstract/ARM/ArchIpcCancel_A.thy
+++ b/spec/abstract/ARM/ArchIpcCancel_A.thy
@@ -12,7 +12,7 @@ chapter \<open>Arch IPC Cancelling\<close>
 
 
 theory ArchIpcCancel_A
-imports "../CSpaceAcc_A"
+imports "../Sporadic_A"
 begin
 
 context Arch begin global_naming ARM_A

--- a/spec/abstract/RISCV64/ArchIpcCancel_A.thy
+++ b/spec/abstract/RISCV64/ArchIpcCancel_A.thy
@@ -7,7 +7,7 @@
 chapter \<open>Arch IPC Cancelling\<close>
 
 theory ArchIpcCancel_A
-imports "../CSpaceAcc_A"
+imports "../Sporadic_A"
 begin
 
 context Arch begin global_naming RISCV64_A

--- a/spec/abstract/SchedContext_A.thy
+++ b/spec/abstract/SchedContext_A.thy
@@ -13,14 +13,6 @@ begin
 text \<open> This theory contains operations on scheduling contexts and scheduling control. \<close>
 
 definition
-  is_round_robin :: "obj_ref \<Rightarrow> (bool,'z::state_ext) s_monad"
-where
-  "is_round_robin sc_ptr = do
-    sc \<leftarrow> get_sched_context sc_ptr;
-    return (sc_period sc = 0)
-  od"
-
-definition
   get_tcb_sc :: "obj_ref \<Rightarrow> (sched_context,'z::state_ext) s_monad"
 where
   "get_tcb_sc tcb_ptr = do
@@ -102,11 +94,6 @@ where
   "set_refills sc_ptr refills = set_sc_obj_ref sc_refills_update sc_ptr refills"
 
 definition
-  update_refill_hd :: "obj_ref \<Rightarrow> (refill \<Rightarrow> refill) \<Rightarrow> (unit, 'z::state_ext) s_monad"
-where
-  "update_refill_hd sc_ptr f = update_sched_context sc_ptr (sc_refills_update (\<lambda>refills. f (hd refills) # (tl refills)))"
-
-definition
   set_refill_hd :: "obj_ref \<Rightarrow> refill \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
   "set_refill_hd sc_ptr new = update_refill_hd sc_ptr (\<lambda>_. new)"
@@ -153,14 +140,6 @@ where
    od"
 
 definition
-  "can_merge_refill r1 r2 \<equiv> r_time r2 \<le> r_time r1 + r_amount r1"
-
-definition
-  merge_refill :: "refill \<Rightarrow> refill \<Rightarrow> refill"
-where
-  "merge_refill r1 r2 = \<lparr> r_time = r_time r1, r_amount = r_amount r2 + r_amount r1 \<rparr>"
-
-definition
   schedule_used :: "obj_ref \<Rightarrow> refill \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
   "schedule_used sc_ptr new \<equiv> do
@@ -179,52 +158,6 @@ where
                        od
                od
    od"
-
-definition
-  refill_pop_head :: "obj_ref \<Rightarrow> (refill, 'z::state_ext) s_monad"
-where
-  "refill_pop_head sc_ptr \<equiv> do
-     refills \<leftarrow> get_refills sc_ptr;
-     update_sched_context sc_ptr (sc_refills_update tl);
-     return (hd refills)
-   od"
-
-definition
-  refill_head_overlapping :: "obj_ref \<Rightarrow> (bool, 'z::state_ext) r_monad"
-where
-  "refill_head_overlapping sc_ptr \<equiv> do {
-    sc \<leftarrow> read_sched_context sc_ptr;
-    oreturn (length (sc_refills sc) > 1
-             \<and> r_time (hd (tl (sc_refills sc))) \<le> r_time (refill_hd sc) + r_amount (refill_hd sc))
-  }"
-
-definition
-  merge_refills :: "obj_ref \<Rightarrow> (unit, 'z::state_ext) s_monad"
-where
-  "merge_refills sc_ptr \<equiv> do
-     head \<leftarrow> refill_pop_head sc_ptr;
-     update_refill_hd sc_ptr (merge_refill head)
-   od"
-
-definition
-  refill_head_overlapping_loop :: "obj_ref \<Rightarrow> (unit, 'z::state_ext) s_monad"
-where
-  "refill_head_overlapping_loop sc_ptr
-     \<equiv> whileLoop (\<lambda>_ s. the ((refill_head_overlapping sc_ptr) s)) (\<lambda>_. merge_refills sc_ptr) ()"
-
-definition
-  refill_unblock_check :: "obj_ref \<Rightarrow> (unit, 'z::state_ext) s_monad"
-where
-  "refill_unblock_check sc_ptr \<equiv> do
-    robin \<leftarrow> is_round_robin sc_ptr;
-    ready \<leftarrow> get_sc_refill_ready sc_ptr;
-    when (ready \<and> \<not>robin) $ do
-      modify (\<lambda>s. s\<lparr> reprogram_timer := True \<rparr>);
-      ct \<leftarrow> gets cur_time;
-      update_refill_hd sc_ptr (r_time_update (\<lambda>_. ct + kernelWCET_ticks));
-      refill_head_overlapping_loop sc_ptr
-    od
-  od"
 
 definition
   refill_budget_check_round_robin :: "ticks \<Rightarrow> (unit, 'z::state_ext) s_monad"

--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -288,7 +288,6 @@ where
     sched_context_resume sc_ptr;
     schedulable <- is_schedulable tcb_ptr;
     if schedulable then do
-      refill_unblock_check sc_ptr;
       sc \<leftarrow> get_sched_context sc_ptr;
       curtime \<leftarrow> gets cur_time;
       assert (sc_refill_ready curtime sc \<and> sc_refill_sufficient 0 sc);

--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -106,7 +106,7 @@ where
 
     when (scp \<noteq> cur_sc) $ do
       modify (\<lambda>s. s\<lparr>reprogram_timer := True\<rparr>);
-      refill_unblock_check scp
+      if_constant_bandwidth_refill_unblock_check (Some scp)
      od;
 
     reprogram \<leftarrow> gets reprogram_timer;

--- a/spec/abstract/Sporadic_A.thy
+++ b/spec/abstract/Sporadic_A.thy
@@ -1,16 +1,18 @@
 (*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2021, UNSW (ABN 57 195 873 197)
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-chapter "Scheduling Contexts and Control"
+chapter "Refill Unblock Check and Sporadic Guards"
 
 theory Sporadic_A
 imports CSpaceAcc_A
 begin
 
-text \<open> This theory contains operations on scheduling contexts and scheduling control. \<close>
+text \<open> This theory contains the definition of refill unblock check function and its components,
+       and functions that combine various guards and a call to refill unblock check \<close>
 
 definition
   is_round_robin :: "obj_ref \<Rightarrow> (bool,'z::state_ext) s_monad"
@@ -78,5 +80,60 @@ where
       refill_head_overlapping_loop sc_ptr
     od
   od"
+
+text \<open>The function defined below encodes several patterns of conditions
+      for calling @{term refill_unblock_check}.
+
+      - this takes an option @{typ obj_ref}, and two @{typ "bool option"} parameters @{term act} and @{term ast}
+      - act and ast encode the conditions for calling @{term refill_unblock_check} as follows:
+
+            act   None       constant\_bandwidth
+                  Some True    sporadic \& active
+                  Some False   sporadic
+                                (currently also tests active, hence identical
+                                 to the Some True case above, until the implication
+                                 "sporadic implies active" is proved)
+            ast   None         no test or assert on cur\_sc
+                  Some True    asserts that the sc pointer is not cur\_sc
+                                (currently replaced by test, i.e.,
+                                 identical to the Some False case below)
+                  Some False   tests if the sc pointer is not cur\_sc\<close>
+
+definition if_cond_refill_unblock_check where
+  "if_cond_refill_unblock_check sc_opt active asst \<equiv>
+    maybeM (\<lambda>scp. do
+      sc \<leftarrow> get_sched_context scp;
+      cur_sc_ptr \<leftarrow> gets cur_sc;
+      guard \<leftarrow> return (case active of
+                         None \<Rightarrow> (\<not> sc_sporadic sc)
+                       | Some True \<Rightarrow> sc_sporadic sc \<and> sc_active sc
+                       | Some False \<Rightarrow> sc_sporadic sc \<and> sc_active sc);
+      when (guard \<and> (asst = Some False \<longrightarrow> scp \<noteq> cur_sc_ptr)) $
+        when (asst = Some True \<longrightarrow> scp \<noteq> cur_sc_ptr) $ refill_unblock_check scp
+    od) sc_opt"
+
+abbreviation "if_sporadic_cur_sc_assert_refill_unblock_check sc_opt \<equiv>
+                  if_cond_refill_unblock_check sc_opt (Some False) (Some True)"
+
+abbreviation "if_sporadic_and_active_refill_unblock_check sc_opt \<equiv>
+                  if_cond_refill_unblock_check sc_opt (Some True) None"
+
+abbreviation "if_sporadic_cur_sc_test_refill_unblock_check sc_opt \<equiv>
+                  if_cond_refill_unblock_check sc_opt (Some False) (Some False)"
+
+abbreviation "if_sporadic_active_cur_sc_test_refill_unblock_check sc_opt \<equiv>
+                  if_cond_refill_unblock_check sc_opt (Some True) (Some False)"
+
+abbreviation "if_sporadic_active_cur_sc_assert_refill_unblock_check sc_opt \<equiv>
+                  if_cond_refill_unblock_check sc_opt (Some True) (Some True)"
+
+abbreviation "if_constant_bandwidth_refill_unblock_check sc_opt \<equiv>
+                  if_cond_refill_unblock_check sc_opt None None"
+
+(* check *)
+thm if_cond_refill_unblock_check_def[of _ "Some False" "Some True", simplified]
+thm if_cond_refill_unblock_check_def[of _ "Some True" "Some True", simplified]
+thm if_cond_refill_unblock_check_def[of _ "Some False" "Some False", simplified]
+thm if_cond_refill_unblock_check_def[of _ "Some True" "Some False", simplified]
 
 end

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -21,7 +21,7 @@ This module uses the C preprocessor to select a target architecture.
 >         setSchedContext, updateTimeStamp, commitTime, rollbackTime,
 >         refillHd, refillTl, minBudget, minBudgetUs, refillCapacity, refillBudgetCheck,
 >         refillBudgetCheckRoundRobin, updateSchedContext, emptyRefill, scBitsFromRefillLength,
->         isCurDomainExpired, refillUnblockCheck,
+>         isCurDomainExpired, refillUnblockCheck,ifCondRefillUnblockCheck,
 >         readRefillReady, refillReady, tcbReleaseEnqueue, tcbReleaseDequeue, refillSufficient, postpone,
 >         schedContextDonate, maybeDonateSc, maybeReturnSc, schedContextUnbindNtfn,
 >         schedContextMaybeUnbindNtfn, isRoundRobin, getRefills, setRefills, refillFull,

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -547,7 +547,6 @@ This module uses the C preprocessor to select a target architecture.
 >     schedulable <- isSchedulable tptr
 >     if schedulable
 >         then do
->             refillUnblockCheck scPtr
 >             ctPtr <- getCurThread
 >             curprio <- threadGet tcbPriority ctPtr
 >             prio <- threadGet tcbPriority tptr

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -393,6 +393,19 @@ This module uses the C preprocessor to select a target architecture.
 >         updateRefillHd scPtr $ \head -> head { rTime = curTime + kernelWCETTicks }
 >         refillHeadOverlappingLoop scPtr
 
+> ifCondRefillUnblockCheck :: Maybe (PPtr SchedContext) -> Maybe Bool -> Maybe Bool -> Kernel ()
+> ifCondRefillUnblockCheck scOpt act ast = do
+>       when (scOpt /= Nothing) $ do
+>           scPtr <- return $ fromJust scOpt
+>           sc <- getSchedContext scPtr
+>           curScPtr <- getCurSc
+>           guard <- return $ (case act of
+>                        Nothing -> not $ scSporadic sc
+>                        Just True -> scSporadic sc && 0 < scRefillMax sc
+>                        Just False -> scSporadic sc && 0 < scRefillMax sc)
+>           when (guard && (if ast == Just False then scPtr /= curScPtr else True)) $
+>               when (if ast == Just True then scPtr /= curScPtr else True) $ refillUnblockCheck scPtr
+
 > schedContextUpdateConsumed :: PPtr SchedContext -> Kernel Time
 > schedContextUpdateConsumed scPtr = do
 >     sc <- getSchedContext scPtr

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -1068,7 +1068,7 @@ On some architectures, the thread context may include registers that may be modi
 >     ctScPtr <- return $ fromJust ctScOpt
 >     when (ctScPtr /= curScPtr) $ do
 >         setReprogramTimer True
->         refillUnblockCheck ctScPtr
+>         ifCondRefillUnblockCheck (Just ctScPtr) Nothing Nothing
 >     reprogram <- getReprogramTimer
 >     when reprogram $ do
 >         commitTime

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -1062,18 +1062,17 @@ On some architectures, the thread context may include registers that may be modi
 
 > switchSchedContext :: Kernel ()
 > switchSchedContext = do
->     scPtr <- getCurSc
+>     curScPtr <- getCurSc
 >     ct <- getCurThread
->     scOpt <- threadGet tcbSchedContext ct
->     csc <- return $ fromJust scOpt
->     sc <- getSchedContext scPtr
->     when (csc /= scPtr && scRefillMax sc /= 0) $ do
+>     ctScOpt <- threadGet tcbSchedContext ct
+>     ctScPtr <- return $ fromJust ctScOpt
+>     when (ctScPtr /= curScPtr) $ do
 >         setReprogramTimer True
->         refillUnblockCheck csc
+>         refillUnblockCheck ctScPtr
 >     reprogram <- getReprogramTimer
 >     when reprogram $ do
 >         commitTime
->     setCurSc csc
+>     setCurSc ctScPtr
 
 > readTCBRefillReady :: PPtr TCB -> KernelR Bool
 > readTCBRefillReady tcbPtr = do


### PR DESCRIPTION
This is the first PR of “adding refill_unblock_check” for thread activation/switching.
The C side change is now part of the "mcs: Add sporadic flag to SchedControl_Configure” commit.

This PR contains the following:
- definition of `if_cond_refill_unblock_check`/`ifCondRefillUnblockCheck`, which package up a call to `refill_unblock_check` with various guards encoded as two bool option parameters
- this encoding currently has unsimplified duplication due to temporary changes added to ease verification (see the commit message for the details)
- remove `refill_unblock_check` from `sched_context_yield_to`, proof fix for that
- add `refill_unblock_check` to `switch_sched_context`, proof fix for that
- add `ifCondRefillUnblockCheck_corres` rule, to be used in the sequel PRs
- also contains missed Haskell fix for seL4PR#467, no proof update needed
- some cleanup, removing duplication and unused lemmas
- add a new file Sporadic_A.thy in ASpec, `refill_unblock_check` definition and what it depends on are moved there
- in DetSchedSchedule_AI, `refill_unblock_check` lemmas are moved to the beginning of the file

There are many commits but it is probably easier to review commit by commit. Happy to be still removing more lines than adding :)