### PR TITLE
InfoFlow Arch-Split

### DIFF
--- a/proof/ROOT
+++ b/proof/ROOT
@@ -150,6 +150,8 @@ session Access in "access-control" = AInvs +
     "ExampleSystem"
 
 session InfoFlow in "infoflow" = Access +
+  directories
+    "$L4V_ARCH"
   theories
     "InfoFlow_Image_Toplevel"
 
@@ -164,6 +166,8 @@ session InfoFlowCBase in "infoflow/refine/base" = CRefine +
     "Include_IF_C"
 
 session InfoFlowC in "infoflow/refine" = InfoFlowCBase +
+  directories
+    "$L4V_ARCH"
   theories
     "Noninterference_Refinement"
     "Example_Valid_StateH"

--- a/proof/access-control/Finalise_AC.thy
+++ b/proof/access-control/Finalise_AC.thy
@@ -671,6 +671,13 @@ lemma finalise_cap_auth:
 end
 
 
+lemma aag_cap_auth_recycle_EndpointCap:
+  "\<lbrakk> pas_refined aag s; has_cancel_send_rights (EndpointCap word1 word2 f) \<rbrakk>
+     \<Longrightarrow> pas_cap_cur_auth aag (EndpointCap word1 word2 f) = is_subject aag word1"
+  unfolding aag_cap_auth_def
+  by (auto simp: cli_no_irqs clas_no_asid cap_auth_conferred_def pas_refined_all_auth_is_owns
+                 has_cancel_send_rights_def cap_rights_to_auth_def all_rights_def pas_refined_refl)
+
 lemma aag_cap_auth_Zombie:
   "pas_refined aag s \<Longrightarrow> pas_cap_cur_auth aag (Zombie word a b) = is_subject aag word"
   unfolding aag_cap_auth_def

--- a/proof/access-control/Syscall_AC.thy
+++ b/proof/access-control/Syscall_AC.thy
@@ -426,6 +426,7 @@ locale Syscall_AC_wps =
   assumes respects[wp]: "f \<lbrace>integrity aag X st\<rbrace>"
   and pas_refined[wp]: "f \<lbrace>pas_refined aag\<rbrace>"
 
+
 locale Syscall_AC_1 =
   fixes aag :: "'a PAS"
   assumes invs_irq_state_update[simp]:
@@ -513,48 +514,51 @@ locale Syscall_AC_1 =
               set_thread_state thread Structures_A.thread_state.Running
      od
      \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-begin
 
-interpretation prepare_thread_delete: gpd_wps' "prepare_thread_delete p"
-  by simp
-interpretation arch_finalise_cap: gpd_wps' "arch_finalise_cap acap final"
-  by simp
-interpretation cap_move: gpd_wps' "cap_move new_cap src_slot dest_slot"
-  by simp
-interpretation cancel_badged_sends: gpd_wps' "cancel_badged_sends epptr badge"
-  by simp
 
-interpretation arch_post_modify_registers: gpd_wps "arch_post_modify_registers cur t"
+sublocale Syscall_AC_1 \<subseteq> prepare_thread_delete: gpd_wps' "prepare_thread_delete p"
   by simp
-interpretation arch_perform_invocation: gpd_wps "arch_perform_invocation ai"
+sublocale Syscall_AC_1 \<subseteq> arch_finalise_cap: gpd_wps' "arch_finalise_cap acap final"
   by simp
-interpretation arch_invoke_irq_control: gpd_wps "arch_invoke_irq_control ivk"
+sublocale Syscall_AC_1 \<subseteq> cap_move: gpd_wps' "cap_move new_cap src_slot dest_slot"
   by simp
-interpretation arch_invoke_irq_handler: gpd_wps "arch_invoke_irq_handler ihi"
-  by simp
-interpretation arch_mask_irq_signal: gpd_wps "arch_mask_irq_signal irq"
-  by simp
-interpretation handle_reserved_irq: gpd_wps "handle_reserved_irq irq"
-  by simp
-interpretation handle_arch_fault_reply: gpd_wps "handle_arch_fault_reply vmf thread x y"
-  by simp
-interpretation handle_hypervisor_fault: gpd_wps "handle_hypervisor_fault t hf_t"
-  by simp
-interpretation handle_vm_fault: gpd_wps "handle_vm_fault t vmf_t"
+sublocale Syscall_AC_1 \<subseteq> cancel_badged_sends: gpd_wps' "cancel_badged_sends epptr badge"
   by simp
 
-interpretation arch_switch_to_thread: Syscall_AC_wps "arch_switch_to_thread t" aag
+sublocale Syscall_AC_1 \<subseteq> arch_post_modify_registers: gpd_wps "arch_post_modify_registers cur t"
   by simp
-interpretation arch_switch_to_idle_thread: Syscall_AC_wps "arch_switch_to_idle_thread" aag
+sublocale Syscall_AC_1 \<subseteq> arch_perform_invocation: gpd_wps "arch_perform_invocation ai"
   by simp
-interpretation arch_activate_idle_thread: Syscall_AC_wps "arch_activate_idle_thread t" aag
+sublocale Syscall_AC_1 \<subseteq> arch_invoke_irq_control: gpd_wps "arch_invoke_irq_control ivk"
   by simp
-interpretation arch_mask_irq_signal: Syscall_AC_wps "arch_mask_irq_signal irq" aag
+sublocale Syscall_AC_1 \<subseteq> arch_invoke_irq_handler: gpd_wps "arch_invoke_irq_handler ihi"
   by simp
-interpretation handle_reserved_irq: Syscall_AC_wps "handle_reserved_irq irq" aag
+sublocale Syscall_AC_1 \<subseteq> arch_mask_irq_signal: gpd_wps "arch_mask_irq_signal irq"
   by simp
-interpretation handle_hypervisor_fault: Syscall_AC_wps "handle_hypervisor_fault t hf_t" aag
+sublocale Syscall_AC_1 \<subseteq> handle_reserved_irq: gpd_wps "handle_reserved_irq irq"
   by simp
+sublocale Syscall_AC_1 \<subseteq> handle_arch_fault_reply: gpd_wps "handle_arch_fault_reply vmf thread x y"
+  by simp
+sublocale Syscall_AC_1 \<subseteq> handle_hypervisor_fault: gpd_wps "handle_hypervisor_fault t hf_t"
+  by simp
+sublocale Syscall_AC_1 \<subseteq> handle_vm_fault: gpd_wps "handle_vm_fault t vmf_t"
+  by simp
+
+sublocale Syscall_AC_1 \<subseteq> arch_switch_to_thread: Syscall_AC_wps "arch_switch_to_thread t" aag
+  by simp
+sublocale Syscall_AC_1 \<subseteq> arch_switch_to_idle_thread: Syscall_AC_wps "arch_switch_to_idle_thread" aag
+  by simp
+sublocale Syscall_AC_1 \<subseteq> arch_activate_idle_thread: Syscall_AC_wps "arch_activate_idle_thread t" aag
+  by simp
+sublocale Syscall_AC_1 \<subseteq> arch_mask_irq_signal: Syscall_AC_wps "arch_mask_irq_signal irq" aag
+  by simp
+sublocale Syscall_AC_1 \<subseteq> handle_reserved_irq: Syscall_AC_wps "handle_reserved_irq irq" aag
+  by simp
+sublocale Syscall_AC_1 \<subseteq> handle_hypervisor_fault: Syscall_AC_wps "handle_hypervisor_fault t hf_t" aag
+  by simp
+
+
+context Syscall_AC_1 begin
 
 lemma handle_interrupt_pas_refined:
   "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>

--- a/proof/crefine/ARM/ADT_C.thy
+++ b/proof/crefine/ARM/ADT_C.thy
@@ -55,10 +55,11 @@ definition
    else callKernel_C e"
 
 definition
-  setArchTCB_C :: "arch_tcb_C \<Rightarrow> tcb_C ptr \<Rightarrow> (cstate,unit) nondet_monad"
+  setTCBContext_C :: "user_context_C \<Rightarrow> tcb_C ptr \<Rightarrow> (cstate,unit) nondet_monad"
 where
-  "setArchTCB_C ct thread \<equiv>
-  exec_C \<Gamma> (\<acute>t_hrs :== hrs_mem_update (heap_update (Ptr &(thread\<rightarrow>[''tcbArch_C''])) ct) \<acute>t_hrs)"
+  "setTCBContext_C ct thread \<equiv>
+  exec_C \<Gamma> (\<acute>t_hrs :== hrs_mem_update (heap_update (
+    Ptr &((Ptr &(thread\<rightarrow>[''tcbArch_C'']) :: (arch_tcb_C ptr))\<rightarrow>[''tcbContext_C''])) ct) \<acute>t_hrs)"
 
 lemma Basic_sem_eq:
   "\<Gamma>\<turnstile>\<langle>Basic f,s\<rangle> \<Rightarrow> s' = ((\<exists>t. s = Normal t \<and> s' = Normal (f t)) \<or> (\<forall>t. s \<noteq> Normal t \<and> s' = s))"
@@ -72,14 +73,14 @@ lemma Basic_sem_eq:
   apply (cases s, auto)
   done
 
-lemma setArchTCB_C_corres:
-  "\<lbrakk> ccontext_relation tc (tcbContext_C tc'); t' = tcb_ptr_to_ctcb_ptr t \<rbrakk> \<Longrightarrow>
-  corres_underlying rf_sr nf nf' dc (tcb_at' t) \<top>
-    (threadSet (\<lambda>tcb. tcb \<lparr> tcbArch := atcbContextSet tc (tcbArch tcb)\<rparr>) t) (setArchTCB_C tc' t')"
-  apply (simp add: setArchTCB_C_def exec_C_def Basic_sem_eq corres_underlying_def)
+lemma setTCBContext_C_corres:
+  "\<lbrakk> ccontext_relation tc tc'; t' = tcb_ptr_to_ctcb_ptr t \<rbrakk> \<Longrightarrow>
+  corres_underlying rf_sr nf nf' dc (pspace_domain_valid and tcb_at' t) \<top>
+    (threadSet (\<lambda>tcb. tcb \<lparr> tcbArch := atcbContextSet tc (tcbArch tcb)\<rparr>) t) (setTCBContext_C tc' t')"
+  apply (simp add: setTCBContext_C_def exec_C_def Basic_sem_eq corres_underlying_def)
   apply clarsimp
   apply (simp add: threadSet_def bind_assoc split_def exec_gets)
-  apply (drule (1) obj_at_cslift_tcb)
+  apply (frule (1) obj_at_cslift_tcb)
   apply clarsimp
   apply (frule getObject_eq [rotated -1], simp)
    apply (simp add: objBits_simps')
@@ -102,13 +103,10 @@ lemma setArchTCB_C_corres:
                         carch_state_relation_def cmachine_state_relation_def
                         typ_heap_simps' update_tcb_map_tos)
   apply (simp add: map_to_ctes_upd_tcb_no_ctes map_to_tcbs_upd tcb_cte_cases_def
-                   cvariable_relation_upd_const ko_at_projectKO_opt)
+                   cvariable_relation_upd_const ko_at_projectKO_opt cteSizeBits_def)
   apply (simp add: cep_relations_drop_fun_upd)
-  apply (rule conjI)
-   defer
-   apply (erule cready_queues_relation_not_queue_ptrs)
-    apply (rule ext, simp split: if_split)
-   apply (rule ext, simp split: if_split)
+  apply (apply_conjunct \<open>match conclusion in \<open>cready_queues_relation _ _ _\<close> \<Rightarrow>
+         \<open>erule cready_queues_relation_not_queue_ptrs; rule ext; simp split: if_split\<close>\<close>)
   apply (drule ko_at_projectKO_opt)
   apply (erule (2) cmap_relation_upd_relI)
     apply (simp add: ctcb_relation_def carch_tcb_relation_def)
@@ -159,7 +157,7 @@ definition
   where
   "kernelEntry_C fp e tc \<equiv> do
     t \<leftarrow> gets (ksCurThread_' o globals);
-    setArchTCB_C (arch_tcb_C (to_user_context_C tc)) t;
+    setTCBContext_C (to_user_context_C tc) t;
     if fp then callKernel_withFastpath_C e else callKernel_C e;
     t \<leftarrow> gets (ksCurThread_' o globals);
     gets $ getContext_C t
@@ -1515,15 +1513,16 @@ definition
    else callKernel_C e"
 
 definition
-  setArchTCB_C :: "arch_tcb_C \<Rightarrow> tcb_C ptr \<Rightarrow> (cstate,unit) nondet_monad"
+  setTCBContext_C :: "user_context_C \<Rightarrow> tcb_C ptr \<Rightarrow> (cstate,unit) nondet_monad"
 where
-  "setArchTCB_C ct thread \<equiv>
-  exec_C \<Gamma> (\<acute>t_hrs :== hrs_mem_update (heap_update (Ptr &(thread\<rightarrow>[''tcbArch_C''])) ct) \<acute>t_hrs)"
+  "setTCBContext_C ct thread \<equiv>
+  exec_C \<Gamma> (\<acute>t_hrs :== hrs_mem_update (heap_update (
+    Ptr &((Ptr &(thread\<rightarrow>[''tcbArch_C'']) :: (arch_tcb_C ptr))\<rightarrow>[''tcbContext_C''])) ct) \<acute>t_hrs)"
 
 definition
   "kernelEntry_C fp e tc \<equiv> do
     t \<leftarrow> gets (ksCurThread_' o globals);
-    setArchTCB_C (arch_tcb_C (to_user_context_C tc)) t;
+    setTCBContext_C (to_user_context_C tc) t;
     if fp then callKernel_withFastpath_C e else callKernel_C e;
     t \<leftarrow> gets (ksCurThread_' o globals);
     gets $ getContext_C t

--- a/proof/crefine/ARM/Refine_C.thy
+++ b/proof/crefine/ARM/Refine_C.thy
@@ -704,8 +704,8 @@ lemma entry_corres_C:
        apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
       apply (rule corres_split_deprecated)
          prefer 2
-         apply (rule setArchTCB_C_corres, simp, rule ccontext_rel_to_C)
-         apply simp
+         apply (rule setTCBContext_C_corres, rule ccontext_rel_to_C, simp)
+        apply simp
         apply (rule corres_split_deprecated)
            prefer 2
            apply (rule corres_cases[where R=fp], simp_all add: dc_def[symmetric])[1]
@@ -714,9 +714,9 @@ lemma entry_corres_C:
           apply (rule corres_split_deprecated [where P=\<top> and P'=\<top> and r'="\<lambda>t t'. t' = tcb_ptr_to_ctcb_ptr t"])
              prefer 2
              apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
-            apply (rule getContext_corres, simp)
+            apply (rule getContext_corres[unfolded o_def], simp)
            apply (wp threadSet_all_invs_triv' callKernel_cur)+
-   apply (clarsimp simp: all_invs'_def invs'_def cur_tcb'_def)
+   apply (clarsimp simp: all_invs'_def invs'_def cur_tcb'_def valid_state'_def)
   apply simp
   done
 
@@ -1110,10 +1110,10 @@ lemma kernel_all_subset_kernel:
   apply (intro conjI)
    apply (simp_all add: kernel_global.kernel_call_C_def
                     kernel_call_C_def kernelEntry_C_def
-                    setArchTCB_C_def
+                    setTCBContext_C_def
                     kernel_global.kernelEntry_C_def
                      exec_C_Basic
-                    kernel_global.setArchTCB_C_def
+                    kernel_global.setTCBContext_C_def
                     kernel_call_H_def kernelEntry_def
                     getContext_C_def
                     check_active_irq_C_def checkActiveIRQ_C_def

--- a/proof/infoflow/ADT_IF.thy
+++ b/proof/infoflow/ADT_IF.thy
@@ -1678,7 +1678,7 @@ lemma schedule_if_globals_equiv_scheduler[wp]:
   apply (simp add: schedule_if_def)
   apply wp
     apply (wp globals_equiv_scheduler_inv'[where P="invs"] activate_thread_globals_equiv)
-    apply (simp add: invs_valid_ko_at_arch invs_valid_idle)
+    apply (simp add: invs_arch_state invs_valid_idle)
    apply (wp | simp)+
   done
 

--- a/proof/infoflow/ADT_IF.thy
+++ b/proof/infoflow/ADT_IF.thy
@@ -13,21 +13,23 @@ text \<open>
 
 theory ADT_IF
 imports
-    Noninterference_Base
-    "Access.ArchSyscall_AC"
-    "Access.ArchADT_AC"
-    IRQMasks_IF FinalCaps Scheduler_IF UserOp_IF
+  Noninterference_Base
+  Access.ArchSyscall_AC
+  Access.ArchADT_AC
+  ArchIRQMasks_IF
+  ArchScheduler_IF
+  ArchUserOp_IF
 begin
 
 section \<open>Generic big step automaton\<close>
 
-inductive_set sub_big_steps
-  :: "('a,'b,'c) data_type \<Rightarrow> ('a \<Rightarrow> 'a \<Rightarrow> bool)  \<Rightarrow>  'a  \<Rightarrow> ('a \<times> 'c list) set"
-  for A :: "('a,'b,'c) data_type" and R :: "('a \<Rightarrow> 'a \<Rightarrow> bool)" and s :: "'a"
-where
-  nil: "\<lbrakk>evlist = []; t = s; \<not> R s s\<rbrakk> \<Longrightarrow>  (t,evlist) \<in> sub_big_steps A R s" |
-  step: "\<lbrakk>evlist = evlist' @ [e]; (s',evlist') \<in> sub_big_steps A R s;
-          (s',t) \<in> data_type.Step A e; \<not> R s t\<rbrakk> \<Longrightarrow>  (t,evlist) \<in> sub_big_steps A R s"
+inductive_set sub_big_steps ::
+  "('a,'b,'c) data_type \<Rightarrow> ('a \<Rightarrow> 'a \<Rightarrow> bool)  \<Rightarrow>  'a  \<Rightarrow> ('a \<times> 'c list) set"
+  for A :: "('a,'b,'c) data_type" and R :: "('a \<Rightarrow> 'a \<Rightarrow> bool)" and s :: "'a" where
+  nil: "\<lbrakk> evlist = []; t = s; \<not> R s s \<rbrakk>
+          \<Longrightarrow>  (t,evlist) \<in> sub_big_steps A R s"
+| step: "\<lbrakk> evlist = evlist' @ [e]; (s',evlist') \<in> sub_big_steps A R s; (s',t) \<in> Step A e; \<not> R s t \<rbrakk>
+           \<Longrightarrow>  (t,evlist) \<in> sub_big_steps A R s"
 
 text \<open>
   Turn the (observable) multi-step executions of one automaton into the
@@ -35,129 +37,115 @@ text \<open>
   of the first. We use a relation on observable states of the original
   automaton to demarcate one big step from the next.
 \<close>
-inductive_set big_steps
-  :: "('a,'b,'c) data_type \<Rightarrow> ('a \<Rightarrow> 'a \<Rightarrow> bool) \<Rightarrow> ('c list \<Rightarrow> 'd) \<Rightarrow> ('d \<Rightarrow> ('a \<times> 'a) set)"
-  for A :: "('a,'b,'c) data_type" and R :: "'a \<Rightarrow> 'a \<Rightarrow> bool" and exmap :: "'c list \<Rightarrow> 'd"
-  and ev :: "'d"
-where
-  cstep: "\<lbrakk>(s',as) \<in> sub_big_steps A R s; (s',t) \<in> data_type.Step A a;
-           R s t; ev = exmap (as @ [a])\<rbrakk> \<Longrightarrow>
-          (s,t) \<in> big_steps A R exmap ev"
+inductive_set big_steps ::
+  "('a,'b,'c) data_type \<Rightarrow> ('a \<Rightarrow> 'a \<Rightarrow> bool) \<Rightarrow> ('c list \<Rightarrow> 'd) \<Rightarrow> ('d \<Rightarrow> ('a \<times> 'a) set)"
+  for A :: "('a,'b,'c) data_type" and R :: "'a \<Rightarrow> 'a \<Rightarrow> bool"
+  and exmap :: "'c list \<Rightarrow> 'd" and ev :: "'d" where
+  cstep: "\<lbrakk> (s',as) \<in> sub_big_steps A R s; (s',t) \<in> Step A a; R s t; ev = exmap (as @ [a]) \<rbrakk>
+            \<Longrightarrow> (s,t) \<in> big_steps A R exmap ev"
 
-definition big_step_adt
-  :: "('a,'b,'c) data_type \<Rightarrow> ('a \<Rightarrow> 'a \<Rightarrow> bool) \<Rightarrow> ('c list \<Rightarrow> 'd) \<Rightarrow> ('a,'b,'d) data_type"
-where
-  "big_step_adt A R exmap \<equiv>
-       \<lparr>Init = Init A, Fin = Fin A, Step = big_steps A R exmap\<rparr>"
+definition big_step_adt ::
+  "('a,'b,'c) data_type \<Rightarrow> ('a \<Rightarrow> 'a \<Rightarrow> bool) \<Rightarrow> ('c list \<Rightarrow> 'd) \<Rightarrow> ('a,'b,'d) data_type" where
+  "big_step_adt A R exmap \<equiv> \<lparr>Init = Init A, Fin = Fin A, Step = big_steps A R exmap\<rparr>"
 
 lemma system_Step_def_raw:
-  "system.Step = (\<lambda>A a. {(s,s') . s' \<in> execution A s [a]})"
-  apply(rule ext)
-  apply(rule ext)
-  apply(subst system.Step_def)
-  by(rule refl)
+  "system.Step = (\<lambda>A a. {(s,s'). s' \<in> execution A s [a]})"
+  apply (rule ext)
+  apply (rule ext)
+  apply (subst system.Step_def)
+  by (rule refl)
 
 lemma big_stepsD:
-  "(s,t) \<in> big_steps A R exmap ev \<Longrightarrow>
-    \<exists> s' as a. (s',as) \<in> sub_big_steps A R s \<and> (s',t) \<in> data_type.Step A a \<and>
-                R s t \<and> ev = exmap (as @ [a])"
-  apply(erule big_steps.induct)
+  "(s,t) \<in> big_steps A R exmap ev
+   \<Longrightarrow> \<exists>s' as a. (s',as) \<in> sub_big_steps A R s \<and> (s',t) \<in> Step A a \<and> R s t \<and> ev = exmap (as @ [a])"
+  apply (erule big_steps.induct)
   apply blast
   done
 
 lemma big_stepsE:
   assumes bs: "(s,t) \<in> big_steps A R exmap ev"
   obtains s' as a where "(s',as) \<in> sub_big_steps A R s"
-                        "(s',t) \<in> data_type.Step A a"
+                        "(s',t) \<in> Step A a"
                         "R s t"
                         "ev =  exmap (as @ [a])"
   using bs[THEN big_stepsD] by blast
 
 
 lemma Run_subset:
-  "(\<And> ev. Stepf ev \<subseteq> Stepf' ev) \<Longrightarrow>
-   Run Stepf as \<subseteq> Run Stepf' as"
-  apply(induct as)
+  "(\<And>ev. Stepf ev \<subseteq> Stepf' ev) \<Longrightarrow> Run Stepf as \<subseteq> Run Stepf' as"
+  apply (induct as)
    apply simp
   apply auto
   done
 
 lemma rtranclp_def2:
   "(R\<^sup>*\<^sup>* s0 s) = (R\<^sup>+\<^sup>+ s0 s \<or> s = s0)"
-  apply (safe)
+  apply safe
    apply (drule rtranclpD)
    apply simp
   apply (erule tranclp_into_rtranclp)
   done
 
-definition Fin_trancl
-where
+definition Fin_trancl where
   "Fin_trancl A R s s' \<equiv> R\<^sup>+\<^sup>+ s s' \<or> Fin A s = Fin A s'"
 
 text \<open>
   A sufficient condition to show that the big steps of a big step ADT
   terminate (i.e. that the relation R eventually becomes satisfied.)
 \<close>
-definition rel_terminate
-  :: "('a,'b,'c) data_type \<Rightarrow> 'b \<Rightarrow> ('a \<Rightarrow> 'a \<Rightarrow> bool) \<Rightarrow> ('a set) \<Rightarrow> ('a \<Rightarrow> 'a \<Rightarrow> nat) \<Rightarrow> bool"
-where
+definition rel_terminate ::
+  "('a,'b,'c) data_type \<Rightarrow> 'b \<Rightarrow> ('a \<Rightarrow> 'a \<Rightarrow> bool) \<Rightarrow> ('a set) \<Rightarrow> ('a \<Rightarrow> 'a \<Rightarrow> nat) \<Rightarrow> bool" where
   "rel_terminate A s0 R I measuref \<equiv>
-          (\<forall>s. s \<in> I \<and> (\<exists>s0'\<in> Init A s0. R\<^sup>*\<^sup>* s0' s) \<longrightarrow>
-           (\<forall> as s'. (s',as) \<in> sub_big_steps A R s \<longrightarrow>
-             (\<forall>s'' a. (s',s'') \<in> data_type.Step A a \<longrightarrow> ((measuref s s'' < measuref s s') \<and>
-             (measuref s s' > 0 \<longrightarrow> measuref s s'' = 0 \<longrightarrow> R s s'')))))"
-
-
-
+     (\<forall>s. s \<in> I \<and> (\<exists>s0'\<in> Init A s0. R\<^sup>*\<^sup>* s0' s)
+          \<longrightarrow> (\<forall>as s'. (s',as) \<in> sub_big_steps A R s
+                       \<longrightarrow> (\<forall>s'' a. (s',s'') \<in> Step A a
+                                    \<longrightarrow> (measuref s s'' < measuref s s') \<and>
+                                        (measuref s s' > 0 \<longrightarrow> measuref s s'' = 0 \<longrightarrow> R s s''))))"
 
 
 lemma rel_terminateE:
   assumes a: "rel_terminate A s0 R I measuref"
-  assumes b: "\<lbrakk>(\<And>s s' as s'' a. \<lbrakk>s \<in> I;
-                           \<exists>s0'\<in> Init A s0. R\<^sup>*\<^sup>* s0' s; (s',as) \<in> sub_big_steps A R s;
-                           (s',s'') \<in> data_type.Step A a; measuref s s' > 0;
-                           measuref s s'' = 0\<rbrakk> \<Longrightarrow> R s s'');
-               (\<And>s s' as s'' a. \<lbrakk>s \<in> I; \<exists>s0'\<in> Init A s0. R\<^sup>*\<^sup>* s0' s;
-                                 (s',as) \<in> sub_big_steps A R s;
-                                 (s',s'') \<in> data_type.Step A a\<rbrakk> \<Longrightarrow>
-                                measuref s s'' < measuref s s')\<rbrakk> \<Longrightarrow> C"
+  assumes b:
+    "\<lbrakk> (\<And>s s' as s'' a. \<lbrakk> s \<in> I; \<exists>s0'\<in> Init A s0. R\<^sup>*\<^sup>* s0' s; (s',as) \<in> sub_big_steps A R s;
+                          (s',s'') \<in> Step A a; measuref s s' > 0; measuref s s'' = 0 \<rbrakk>
+                          \<Longrightarrow> R s s'');
+       (\<And>s s' as s'' a. \<lbrakk> s \<in> I; \<exists>s0'\<in> Init A s0. R\<^sup>*\<^sup>* s0' s;
+                          (s',as) \<in> sub_big_steps A R s; (s',s'') \<in> Step A a \<rbrakk>
+                          \<Longrightarrow> measuref s s'' < measuref s s') \<rbrakk>
+       \<Longrightarrow> C"
  shows "C"
-  apply(rule b)
-  using a apply(fastforce simp: rel_terminate_def)+
-  done
+  using a b by (fastforce simp: rel_terminate_def)
 
 lemma Run_big_steps_tranclp:
-  "(s0, s) \<in> Run (big_steps C R exmap) js  \<Longrightarrow>
-   R\<^sup>*\<^sup>* s0 s"
-  apply(induct js arbitrary: s rule: rev_induct)
+  "(s0, s) \<in> Run (big_steps C R exmap) js \<Longrightarrow> R\<^sup>*\<^sup>* s0 s"
+  apply (induct js arbitrary: s rule: rev_induct)
    apply simp
-  apply(fastforce dest: Run_mid elim: big_steps.cases)
+  apply (fastforce dest: Run_mid elim: big_steps.cases)
   done
 
 lemma Step_system_reachable_trans:
-  "Step_system A s0 \<Longrightarrow> system.reachable A s0 s \<Longrightarrow>
-   system.reachable A s s' \<Longrightarrow> system.reachable A s0 s'"
-  apply(clarsimp simp: system.reachable_def)
-  apply(rule Step_system.reachable_execution[simplified system.reachable_def])
+  "\<lbrakk> Step_system A s0; system.reachable A s0 s; system.reachable A s s' \<rbrakk>
+     \<Longrightarrow> system.reachable A s0 s'"
+  apply (clarsimp simp: system.reachable_def)
+  apply (rule Step_system.reachable_execution[simplified system.reachable_def])
     apply blast+
   done
 
 lemma Step_system_reachable:
-  "Step_system A s0 \<Longrightarrow> system.reachable A s0 s \<Longrightarrow>
-  Step_system A s"
-  apply(subst Step_system_def)
-  apply(rule conjI)
-   apply(fastforce simp: system.reachable_def Step_system.execution_Run intro: exI[where x="[]"])
+  "\<lbrakk> Step_system A s0; system.reachable A s0 s \<rbrakk>
+     \<Longrightarrow> Step_system A s"
+  apply (subst Step_system_def)
+  apply (rule conjI)
+   apply (fastforce simp: system.reachable_def Step_system.execution_Run intro: exI[where x="[]"])
   apply clarsimp
-  apply(frule Step_system_reachable_trans, assumption+)
-  apply(simp add: Step_system.execution_Run)
+  apply (frule Step_system_reachable_trans, assumption+)
+  apply (simp add: Step_system.execution_Run)
   done
 
 lemma Step_system_execution_Run_s0:
-  "Step_system A s0 \<Longrightarrow>
-   execution A s0 as = {s'. (s0,s') \<in> Run (system.Step A) as}"
-  apply(rule Step_system.execution_Run, assumption)
-  apply(erule Step_system.reachable_s0)
+  "Step_system A s0 \<Longrightarrow> execution A s0 as = {s'. (s0,s') \<in> Run (system.Step A) as}"
+  apply (rule Step_system.execution_Run, assumption)
+  apply (erule Step_system.reachable_s0)
   done
 
 text \<open>
@@ -165,48 +153,43 @@ text \<open>
   Step relation for states @{term y} reachable from a given state @{term s}
   before the next big step has finished.
 \<close>
-definition step_measuref_rel_from
-  :: "('a,'b,'c) data_type \<Rightarrow> ('a \<Rightarrow> 'a \<Rightarrow> bool) \<Rightarrow> 'a \<Rightarrow> ('a \<times> 'a) set"
-where
+definition step_measuref_rel_from ::
+  "('a,'b,'c) data_type \<Rightarrow> ('a \<Rightarrow> 'a \<Rightarrow> bool) \<Rightarrow> 'a \<Rightarrow> ('a \<times> 'a) set" where
   "step_measuref_rel_from A R s \<equiv>
-      {(x,y). \<exists>a as. (y,x) \<in> data_type.Step A a \<and> (y,as) \<in> sub_big_steps A R s}"
+     {(x,y). \<exists>a as. (y,x) \<in> Step A a \<and> (y,as) \<in> sub_big_steps A R s}"
 
 lemma wf_step_measuref_rel_from:
-  "\<lbrakk>rel_terminate A s0 R I measuref;
-    s \<in> I; \<exists>s0'\<in> Init A s0. R\<^sup>*\<^sup>* s0' s\<rbrakk> \<Longrightarrow>
-    wf (step_measuref_rel_from A R s)"
-  apply(cut_tac wf_measure[where f="measuref s"])
-  apply(erule wf_subset)
-  apply(fastforce simp: measure_def inv_image_def step_measuref_rel_from_def rel_terminate_def)
+  "\<lbrakk> rel_terminate A s0 R I measuref; s \<in> I; \<exists>s0'\<in> Init A s0. R\<^sup>*\<^sup>* s0' s \<rbrakk>
+     \<Longrightarrow> wf (step_measuref_rel_from A R s)"
+  apply (cut_tac wf_measure[where f="measuref s"])
+  apply (erule wf_subset)
+  apply (fastforce simp: measure_def inv_image_def step_measuref_rel_from_def rel_terminate_def)
   done
 
 lemma system_Step_one:
   "(x, s') \<in> system.Step A a \<Longrightarrow> (x, s') \<in> Run (system.Step A) [a]"
-  apply simp
-  done
+  by simp
 
-definition inv_holds
-  :: "('a,'b,'j) data_type \<Rightarrow> 'a set \<Rightarrow> bool" (infix "[>" 60)
-where
+definition inv_holds :: "('a,'b,'j) data_type \<Rightarrow> 'a set \<Rightarrow> bool" (infix "[>" 60) where
   "D [> I \<equiv> (\<forall>j. Step D j `` I \<subseteq> I)"
 
 lemma inv_holdsI:
-  "\<lbrakk> \<forall>j. Step D j `` I \<subseteq> I \<rbrakk> \<Longrightarrow> D [> I"
+  "(\<forall>j. Step D j `` I \<subseteq> I) \<Longrightarrow> D [> I"
   by (simp add: inv_holds_def)
 
 lemma inv_holds_conjI:
-  "D [> P \<Longrightarrow> D [> Q \<Longrightarrow> D [> P \<inter> Q"
+  "\<lbrakk> D [> P; D [> Q \<rbrakk> \<Longrightarrow> D [> P \<inter> Q"
   by (simp add: inv_holds_def) blast
 
 lemma inv_holds_steps:
-  assumes I:"A [> I"
+  assumes I: "A [> I"
   assumes start_I: "B \<subseteq> I"
   shows "steps (Simulation.Step A) B as \<subseteq> I"
   apply clarsimp
   apply (induct as rule: rev_induct)
    apply (simp add: steps_def)
    apply (rule set_mp)
-   apply (rule start_I)
+    apply (rule start_I)
    apply simp
   apply (simp add: steps_def)
   apply (erule ImageE)
@@ -219,19 +202,19 @@ lemma inv_holds_steps:
   apply simp
   done
 
+
 locale serial_system_weak = system +
   fixes I
   assumes I: "A [> I"
   assumes serial: "\<And>s' a. s' \<in> I \<Longrightarrow> (\<exists>t. (s', t) \<in> data_type.Step A a)"
 begin
 
-  lemma step_serial:
-     assumes nonempty_start: "B \<noteq> {}"
-     assumes invariant_start: "B \<subseteq> I"
-     shows
-    "steps (Simulation.Step A) B as \<noteq> {}"
-    apply (induct as rule: rev_induct)
-  apply (simp add: steps_def nonempty_start)
+lemma step_serial:
+  assumes nonempty_start: "B \<noteq> {}"
+  assumes invariant_start: "B \<subseteq> I"
+  shows "steps (Simulation.Step A) B as \<noteq> {}"
+  apply (induct as rule: rev_induct)
+   apply (simp add: steps_def nonempty_start)
   apply (erule nonemptyE)
   apply (frule set_mp[OF inv_holds_steps[OF I invariant_start]])
   apply (frule_tac a=x in serial)
@@ -242,8 +225,10 @@ begin
 
 end
 
+
 lemma sub_big_steps_I_holds:
-  "A [> I \<Longrightarrow> s \<in> I \<Longrightarrow> (x, xs) \<in> sub_big_steps A R s \<Longrightarrow> x \<in> I"
+  "\<lbrakk> A [> I; s \<in> I; (x, xs) \<in> sub_big_steps A R s \<rbrakk>
+     \<Longrightarrow> x \<in> I"
   apply (erule sub_big_steps.induct)
    apply simp
   apply (simp add: inv_holds_def)
@@ -255,46 +240,44 @@ lemma rel_terminate_terminates:
   assumes rt: "rel_terminate A s0 R I measuref"
   assumes si: "s \<in> I"
   assumes sR: "\<exists>s0'\<in> Init A s0. R\<^sup>*\<^sup>* s0' s"
-  shows "\<forall>js. (x,js) \<in> sub_big_steps A R s \<longrightarrow>
-                 (\<exists> as s' a s''. (s',(js@as)) \<in> sub_big_steps A R s \<and>
-                                 (s',s'') \<in> data_type.Step A a \<and> R s s'')"
-  proof -
+  shows "\<forall>js. (x,js) \<in> sub_big_steps A R s
+              \<longrightarrow> (\<exists>as s' a s''. (s',(js@as)) \<in> sub_big_steps A R s \<and>
+                                  (s',s'') \<in> Step A a \<and> R s s'')"
+proof -
   show ?thesis
-  apply(induct x rule: wf_induct)
-   apply(rule wf_step_measuref_rel_from[OF rt si sR])
-  apply clarsimp
-  apply (frule sub_big_steps_I_holds[OF ss[THEN serial_system_weak.I] si])
-  apply (frule_tac  serial_system_weak.serial[OF ss])
-  apply(erule exE, rename_tac s')
-  apply(drule_tac x=s' in spec)
-  apply(erule impE)
-   apply(fastforce simp: step_measuref_rel_from_def)
-  apply(case_tac "R s s'")
-   apply(rule_tac x="[]" in exI)
-   apply(rule_tac x=x in exI)
-   apply fastforce
-  apply(fastforce intro: sub_big_steps.step)
-  done
+    apply (induct x rule: wf_induct)
+     apply (rule wf_step_measuref_rel_from[OF rt si sR])
+    apply clarsimp
+    apply (frule sub_big_steps_I_holds[OF ss[THEN serial_system_weak.I] si])
+    apply (frule_tac serial_system_weak.serial[OF ss])
+    apply (erule exE, rename_tac s')
+    apply (drule_tac x=s' in spec)
+    apply (erule impE)
+     apply (fastforce simp: step_measuref_rel_from_def)
+    apply (case_tac "R s s'")
+     apply (rule_tac x="[]" in exI)
+     apply (rule_tac x=x in exI)
+     apply fastforce
+    apply (fastforce intro: sub_big_steps.step)
+    done
 qed
 
 
 lemma sub_big_steps_nrefl:
   "(\<And>s. \<not> R s s) \<Longrightarrow> (s,[]) \<in> sub_big_steps A R s"
-  apply(blast intro: nil)
-  done
+  by (blast intro: nil)
 
 lemma big_steps_enabled:
-  assumes ss: " serial_system_weak A I"
+  assumes ss: "serial_system_weak A I"
   assumes rt: "rel_terminate A s0 R I measuref"
-  assumes s_I: " s \<in> I"
-  assumes nrefl: "(\<And>s. \<not> R s s)"
-  shows "\<exists>s0'\<in> Init A s0. R\<^sup>*\<^sup>* s0' s
-        \<Longrightarrow> \<exists>x s'. (s, s') \<in> big_steps A R exmap x"
-  apply(frule rel_terminate_terminates[OF ss rt s_I])
-  apply(drule_tac x="[]" in spec)
-  apply(erule impE[OF _ sub_big_steps_nrefl])
-   apply(rule nrefl)
-  apply(fastforce intro: cstep)
+  assumes s_I: "s \<in> I"
+  assumes nrefl: "\<And>s. \<not> R s s"
+  shows "\<exists>s0'\<in> Init A s0. R\<^sup>*\<^sup>* s0' s \<Longrightarrow> \<exists>x s'. (s, s') \<in> big_steps A R exmap x"
+  apply (frule rel_terminate_terminates[OF ss rt s_I])
+  apply (drule_tac x="[]" in spec)
+  apply (erule impE[OF _ sub_big_steps_nrefl])
+   apply (rule nrefl)
+  apply (fastforce intro: cstep)
   done
 
 text \<open>
@@ -308,33 +291,33 @@ lemma Step_system_to_enabled_system:
   assumes st: "Step_system A s0"
   assumes en: "\<And>s. system.reachable A s0 s \<Longrightarrow> \<exists>(x::'b) s'. (s,s') \<in> system.Step A x"
   shows "enabled_system A s0"
-  apply(clarsimp simp: enabled_system_def)
-  proof -
+  apply (clarsimp simp: enabled_system_def)
+proof -
   fix s  js jsa
   assume a: "s \<in> execution A s0 js"
-  show "\<exists> s'. s' \<in> execution A s jsa"
-    proof -
-    have er: "\<And> as. execution A s as = {s'. (s,s') \<in> Run (system.Step A) as}"
-      apply(rule Step_system.execution_Run[OF st])
-      using a apply(fastforce simp: system.reachable_def)
+  show "\<exists>s'. s' \<in> execution A s jsa"
+  proof -
+    have er: "\<And>as. execution A s as = {s'. (s,s') \<in> Run (system.Step A) as}"
+      apply (rule Step_system.execution_Run[OF st])
+      using a apply (fastforce simp: system.reachable_def)
       done
     show ?thesis
-      apply(induct jsa rule: rev_induct)
-       apply(simp add: er)
-      apply(clarsimp simp: er)
-      apply(cut_tac s=s' in en)
-       apply(rule Step_system.reachable_execution[OF st])
-        using a apply(fastforce simp: system.reachable_def)
-       apply(simp add: er)
+      apply (induct jsa rule: rev_induct)
+       apply (simp add: er)
+      apply (clarsimp simp: er)
+      apply (cut_tac s=s' in en)
+       apply (rule Step_system.reachable_execution[OF st])
+      using a apply (fastforce simp: system.reachable_def)
+       apply (simp add: er)
       apply clarify
-      apply(rename_tac b s'a)
-      apply(rule_tac x=s'a in exI)
-      apply(rule Run_trans, assumption)
-      apply(rule system_Step_one)
-      apply(cut_tac x=b and xa=x in single_event[rule_format], simp)
+      apply (rename_tac b s'a)
+      apply (rule_tac x=s'a in exI)
+      apply (rule Run_trans, assumption)
+      apply (rule system_Step_one)
+      apply (cut_tac x=b and xa=x in single_event[rule_format], simp)
       done
-    qed
   qed
+qed
 
 lemma steps_subset:
   "A \<subseteq> B \<Longrightarrow> steps steps1 A as \<subseteq> steps steps1 B as"
@@ -344,23 +327,24 @@ lemma steps_subset:
   apply force
   done
 
+
 locale Init_Fin_serial_weak = serial_system_weak +
-     assumes Init_Fin: "\<And>s'. s' \<in> I \<Longrightarrow> s' \<in> Init A (Fin A s')"
-     assumes s0_I: "Init A s0 \<subseteq> I"
+  assumes Init_Fin: "\<And>s'. s' \<in> I \<Longrightarrow> s' \<in> Init A (Fin A s')"
+  assumes s0_I: "Init A s0 \<subseteq> I"
 begin
 
 lemma enabled:
   "enabled_system A s0"
-  supply image_cong_simp [cong del]
+  supply image_cong_simp[cong del]
   supply ex_image_cong_iff [simp del]
   apply (clarsimp simp: enabled_system_def)
   apply (rename_tac jsa, induct_tac jsa rule: rev_induct)
-  apply (clarsimp simp: execution_def steps_def)
+   apply (clarsimp simp: execution_def steps_def)
    apply (fold steps_def)
-    apply (rule_tac x="Fin A x" in exI)
+   apply (rule_tac x="Fin A x" in exI)
    apply (rule imageI)
    apply (rule Init_Fin)
-    apply (rule set_mp)
+   apply (rule set_mp)
     apply (rule inv_holds_steps[OF I])
     apply (rule s0_I)
    apply simp
@@ -377,7 +361,7 @@ lemma enabled:
     apply assumption
    apply assumption
   apply (cut_tac inv_holds_steps[OF I s0_I])
-  apply (drule(1) subsetD)
+  apply (drule (1) subsetD)
   apply (cut_tac B="{xa}" and as=xs in inv_holds_steps[OF I])
    apply simp
   apply (cut_tac B="{xa}" and as=xs in step_serial)
@@ -389,15 +373,16 @@ lemma enabled:
 
 end
 
+
 lemma invariant_holds_steps:
-  assumes I:"A \<Turnstile> I"
+  assumes I: "A \<Turnstile> I"
   assumes start_I: "B \<subseteq> I"
   shows "steps (Simulation.Step A) B as \<subseteq> I"
   apply clarsimp
   apply (induct as rule: rev_induct)
    apply (simp add: steps_def)
    apply (rule set_mp)
-   apply (rule start_I)
+    apply (rule start_I)
    apply simp
   apply (simp add: steps_def)
   apply (erule ImageE)
@@ -417,13 +402,12 @@ locale serial_system = system +
   assumes serial: "\<And>s' a. s' \<in> I \<Longrightarrow> (\<exists>t. (s', t) \<in> data_type.Step A a)"
 begin
 
-  lemma step_serial:
-     assumes nonempty_start: "B \<noteq> {}"
-     assumes invariant_start: "B \<subseteq> I"
-     shows
-    "steps (Simulation.Step A) B as \<noteq> {}"
-    apply (induct as rule: rev_induct)
-  apply (simp add: steps_def nonempty_start)
+lemma step_serial:
+  assumes nonempty_start: "B \<noteq> {}"
+  assumes invariant_start: "B \<subseteq> I"
+  shows "steps (Simulation.Step A) B as \<noteq> {}"
+  apply (induct as rule: rev_induct)
+   apply (simp add: steps_def nonempty_start)
   apply (erule nonemptyE)
   apply (frule set_mp[OF invariant_holds_steps[OF I invariant_start]])
   apply (frule_tac a=x in serial)
@@ -435,14 +419,12 @@ begin
 lemma fw_sim_serial:
   assumes refines: "LI B A R (I_b \<times> I_a)"
   assumes B_I_b: "B \<Turnstile> I_b'"
-  (*assumes A_I_a: "A \<Turnstile> I_a"*)
   assumes A_I_as: "I \<subseteq> I_a"
   assumes B_I_bs': "I_b' \<subseteq> I_b"
   assumes constrained_B: "\<And>s. s \<in> I_b' \<Longrightarrow> \<exists>s'. s' \<in> I \<and> (s,s') \<in> R"
-  shows
-  "serial_system B I_b'"
+  shows "serial_system B I_b'"
   apply unfold_locales
-     apply (rule B_I_b)
+   apply (rule B_I_b)
   apply (insert refines)
   apply (clarsimp simp: LI_def)
   apply (drule_tac x=a in spec)
@@ -457,10 +439,9 @@ lemma fw_sim_serial:
 end
 
 
-
 locale Init_Fin_serial = serial_system +
-     assumes Init_Fin: "\<And>s'. s' \<in> I \<Longrightarrow> s' \<in> Init A (Fin A s')"
-     assumes s0_I: "Init A s0 \<subseteq> I"
+  assumes Init_Fin: "\<And>s'. s' \<in> I \<Longrightarrow> s' \<in> Init A (Fin A s')"
+  assumes s0_I: "Init A s0 \<subseteq> I"
 begin
 
 lemma enabled:
@@ -468,7 +449,7 @@ lemma enabled:
   supply image_cong_simp [cong del]
   supply ex_image_cong_iff [simp del]
   apply (clarsimp simp: enabled_system_def)
-  apply (induct_tac jsa  rule: rev_induct)
+  apply (induct_tac jsa rule: rev_induct)
    apply (clarsimp simp: execution_def steps_def)
    apply (fold steps_def)
    apply (rule_tac x="Fin A x" in exI)
@@ -498,18 +479,10 @@ lemma enabled:
 end
 
 
-sublocale Init_Fin_serial \<subseteq> enabled_system
-  apply (rule enabled)
-  done
+sublocale Init_Fin_serial \<subseteq> enabled_system by (rule enabled)
 
 sublocale Init_Fin_serial \<subseteq> Init_Fin_serial_weak
-  apply (unfold_locales)
-     using I
-     apply (simp add: inv_holds_def invariant_holds_def)
-    apply (erule serial)
-   apply (erule Init_Fin)
-  apply (rule s0_I)
-  done
+  using I by unfold_locales (auto simp add: inv_holds_def invariant_holds_def elim: serial Init_Fin)
 
 lemma (in Init_Fin_serial) serial_to_weak:
   "Init_Fin_serial_weak A s0 I"
@@ -519,7 +492,7 @@ definition inv_from_rel :: "('a, 'b, 'j) data_type \<Rightarrow> 'b \<Rightarrow
   "inv_from_rel A s0 R \<equiv> {s. \<exists>s0'\<in> Init A s0. R\<^sup>*\<^sup>* s0' s}"
 
 lemma big_step_adt_R_tranclp_inv:
-  "(big_step_adt C R exmap) [> inv_from_rel C s0 R"
+  "big_step_adt C R exmap [> inv_from_rel C s0 R"
   apply (rule inv_holdsI)
   apply (clarsimp simp: big_step_adt_def inv_from_rel_def Fin_trancl_def)
   apply (rule_tac x="s0'" in bexI)
@@ -528,15 +501,15 @@ lemma big_step_adt_R_tranclp_inv:
   done
 
 lemma  big_steps_I_holds:
-  "\<lbrakk>(xa, x) \<in> big_steps A R exmap j; xa \<in> I; A [> I\<rbrakk>
-       \<Longrightarrow> x \<in> I"
+  "\<lbrakk> (xa, x) \<in> big_steps A R exmap j; xa \<in> I; A [> I \<rbrakk>
+     \<Longrightarrow> x \<in> I"
   apply (erule big_stepsE)
   apply (frule sub_big_steps_I_holds, assumption+)
   apply (simp add: inv_holds_def)
   apply blast
   done
 
-lemma  big_step_adt_inv_holds:
+lemma big_step_adt_inv_holds:
   "A [> I \<Longrightarrow> big_step_adt A R exmap [> I"
   apply (simp add: big_step_adt_def inv_holds_def)
   apply clarsimp
@@ -545,8 +518,8 @@ lemma  big_step_adt_inv_holds:
   done
 
 lemma big_step_adt_Init_Fin_serial_weak:
-  assumes single_event: "(\<forall>(x::'b) (y::'b). x = y)"
-  assumes nrefl: "(\<And>s. \<not> R s s)"
+  assumes single_event: "\<forall>(x::'b) (y::'b). x = y"
+  assumes nrefl: "\<And>s. \<not> R s s"
   assumes ifsw: "Init_Fin_serial_weak A s0 I"
   assumes rt: "rel_terminate A s0 R I measuref"
   assumes J_def: "J = inv_from_rel A s0 R \<inter> I"
@@ -574,8 +547,8 @@ lemma big_step_adt_Init_Fin_serial_weak:
   done
 
 lemma big_step_adt_enabled_system:
-  assumes single_event: "(\<forall>(x::'b) (y::'b). x = y)"
-  assumes nrefl: "(\<And>s. \<not> R s s)"
+  assumes single_event: "\<forall>(x::'b) (y::'b). x = y"
+  assumes nrefl: "\<And>s. \<not> R s s"
   assumes ifsw: "Init_Fin_serial_weak A s0 I"
   assumes rt: "rel_terminate A s0 R I measuref"
   shows "enabled_system (big_step_adt A R (exmap::('a list \<Rightarrow> 'b))) s0"
@@ -585,13 +558,12 @@ lemma big_step_adt_enabled_system:
   done
 
 (* For reachability in big_step_adt we need to consider internal reachability. *)
-definition reachable_i
-where
-  "reachable_i A s0 s \<equiv> \<exists>js. (s0, s) \<in> Run (data_type.Step A) js"
+definition reachable_i where
+  "reachable_i A s0 s \<equiv> \<exists>js. (s0, s) \<in> Run (Step A) js"
 
 lemma sub_big_steps_Run:
   "(t,evlist) \<in> sub_big_steps A R s \<Longrightarrow> (s, t) \<in> Run (Step A) evlist \<and> \<not> R s t"
-  apply(induct t evlist rule: sub_big_steps.induct)
+  apply (induct t evlist rule: sub_big_steps.induct)
    apply simp
   apply clarsimp
   apply (rule Run_trans)
@@ -600,29 +572,27 @@ lemma sub_big_steps_Run:
   done
 
 lemma big_step_adt_reachable_i_states:
-  "(s0, s) \<in> Run (data_type.Step (big_step_adt C R exmap)) js \<Longrightarrow>
-         \<exists>js. (s0, s) \<in> Run (Step C) js"
-  apply(induct js arbitrary: s0)
+  "(s0, s) \<in> Run (Step (big_step_adt C R exmap)) js \<Longrightarrow> \<exists>js. (s0, s) \<in> Run (Step C) js"
+  apply (induct js arbitrary: s0)
    apply (rule_tac x="[]" in exI, simp)
   apply (clarsimp simp: big_step_adt_def)
-  apply(rename_tac s0 sa)
-  apply(erule big_stepsE)
-  apply(drule sub_big_steps_Run)
-  apply(subgoal_tac "(s0,sa) \<in> Run (data_type.Step C) (as@[aa])")
+  apply (rename_tac s0 sa)
+  apply (erule big_stepsE)
+  apply (drule sub_big_steps_Run)
+  apply (subgoal_tac "(s0,sa) \<in> Run (data_type.Step C) (as@[aa])")
    apply (blast intro: Run_trans)
-  apply(fastforce intro: Run_trans)
+  apply (fastforce intro: Run_trans)
   done
 
 lemma reachable_i_big_step_adt:
-  "reachable_i (big_step_adt C R exmap) s0 s \<Longrightarrow>
-   reachable_i C s0 s"
-  apply(clarsimp simp: reachable_i_def)
-  apply(blast intro: big_step_adt_reachable_i_states)
+  "reachable_i (big_step_adt C R exmap) s0 s \<Longrightarrow> reachable_i C s0 s"
+  apply (clarsimp simp: reachable_i_def)
+  apply (blast intro: big_step_adt_reachable_i_states)
   done
 
 lemma steps_eq_Run:
-  "(s' \<in> steps (Step A) (Init A s0) js)
-     = (\<exists>s0'. s0' \<in> Init A s0 \<and> (s0', s') \<in> Run (Step A) js)"
+  "(s' \<in> steps (Step A) (Init A s0) js) =
+   (\<exists>s0'. s0' \<in> Init A s0 \<and> (s0', s') \<in> Run (Step A) js)"
   apply (rule iffI)
    apply (clarsimp simp: steps_def image_def Image_def)
    apply (induct js arbitrary: s' rule: rev_induct)
@@ -640,14 +610,16 @@ lemma reachable_reachable_i:
   by (force simp: system.reachable_def reachable_i_def execution_def steps_eq_Run)
 
 lemma reachable_i_reachable:
-  "\<lbrakk>reachable_i A s0' s'; s0' \<in> Init A s0; Fin A s' = s\<rbrakk> \<Longrightarrow> system.reachable A s0 s"
+  "\<lbrakk> reachable_i A s0' s'; s0' \<in> Init A s0; Fin A s' = s \<rbrakk>
+     \<Longrightarrow> system.reachable A s0 s"
   by (force simp: system.reachable_def reachable_i_def execution_def steps_eq_Run)
 
 lemma reachable_big_step_adt:
-  "system.reachable (big_step_adt C R exmap) s0 s \<Longrightarrow>
-   system.reachable C s0 s"
-  by (force dest: reachable_reachable_i intro: reachable_i_reachable reachable_i_big_step_adt
-                simp: big_step_adt_def)
+  "system.reachable (big_step_adt C R exmap) s0 s
+   \<Longrightarrow> system.reachable C s0 s"
+  by (force dest: reachable_reachable_i
+           intro: reachable_i_reachable reachable_i_big_step_adt
+            simp: big_step_adt_def)
 
 lemma big_step_adt_Init_inv_Fin_system:
   "Init_inv_Fin_system A s0 \<Longrightarrow> Init_inv_Fin_system (big_step_adt A R exmap) s0"
@@ -658,27 +630,26 @@ lemma big_step_adt_Init_inv_Fin_system:
 
 lemma big_step_adt_Step_system:
   "Init_inv_Fin_system C s0 \<Longrightarrow> Step_system (big_step_adt C R exmap) s0"
-  apply(rule Init_Fin_system_Step_system)
-  apply(rule Init_inv_Fin_system_Init_Fin_system)
-  apply(rule big_step_adt_Init_inv_Fin_system)
+  apply (rule Init_Fin_system_Step_system)
+  apply (rule Init_inv_Fin_system_Init_Fin_system)
+  apply (rule big_step_adt_Init_inv_Fin_system)
   apply simp
   done
 
 lemma big_step_adt_enabled_Step_system:
-  assumes single_event: "(\<forall>(x::'b) (y::'b). x = y)"
-  assumes nrefl: "(\<And>s. \<not> R s s)"
+  assumes single_event: "\<forall>(x::'b) (y::'b). x = y"
+  assumes nrefl: "\<And>s. \<not> R s s"
   assumes ifsw: "Init_Fin_serial_weak A s0 I"
   assumes iifs: "Init_inv_Fin_system A s0"
   assumes rt: "rel_terminate A s0 R I measuref"
   shows "enabled_Step_system (big_step_adt A R (examp::('a list \<Rightarrow> 'b))) s0"
-  using assms by (simp add: enabled_Step_system_def big_step_adt_Step_system
-                            big_step_adt_enabled_system)
+  using assms
+  by (simp add: enabled_Step_system_def big_step_adt_Step_system big_step_adt_enabled_system)
+
 
 section \<open>ADT_A_if definition and enabledness\<close>
 
 subsection \<open>global_automaton_if definition\<close>
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 text \<open>
   We define a bunch of states that the system can be in. The first two
@@ -724,185 +695,59 @@ text \<open>
   a handle on modelling when user programs request system calls or cause
   other exceptions to occur.
 \<close>
-definition global_automaton_if
-  :: "((user_context \<times> 'k) \<times> irq option \<times> (user_context \<times> 'k)) set
-      \<Rightarrow> ((user_context \<times> 'k) \<times> event option \<times> (user_context \<times> 'k)) set
-      \<Rightarrow> (event \<Rightarrow> ((user_context \<times> 'k) \<times> bool \<times> (user_context \<times> 'k)) set)
-      \<Rightarrow> (((user_context \<times> 'k) \<times> unit \<times> (user_context \<times> 'k)) set)
-      \<Rightarrow> (((user_context \<times> 'k) \<times> unit \<times> (user_context \<times> 'k)) set)
-      \<Rightarrow> (((user_context \<times> 'k) \<times> sys_mode \<times> (user_context \<times> 'k)) set)
-      \<Rightarrow> ('k global_sys_state \<times> 'k global_sys_state) set"
-where
-  "global_automaton_if get_active_irqf do_user_opf kernel_callf
-                       preemptionf schedulef kernel_exitf \<equiv>
+definition global_automaton_if ::
+  "((user_context \<times> 'k) \<times> irq option \<times> (user_context \<times> 'k)) set
+   \<Rightarrow> ((user_context \<times> 'k) \<times> event option \<times> (user_context \<times> 'k)) set
+   \<Rightarrow> (event \<Rightarrow> ((user_context \<times> 'k) \<times> bool \<times> (user_context \<times> 'k)) set)
+   \<Rightarrow> (((user_context \<times> 'k) \<times> unit \<times> (user_context \<times> 'k)) set)
+   \<Rightarrow> (((user_context \<times> 'k) \<times> unit \<times> (user_context \<times> 'k)) set)
+   \<Rightarrow> (((user_context \<times> 'k) \<times> sys_mode \<times> (user_context \<times> 'k)) set)
+   \<Rightarrow> ('k global_sys_state \<times> 'k global_sys_state) set" where
+  "global_automaton_if get_active_irqf do_user_opf kernel_callf preemptionf schedulef kernel_exitf \<equiv>
   \<comment> \<open>Kernel entry with preemption during event handling
      NOTE: kernel cannot be preempted while servicing an interrupt\<close>
-     { ( (s, KernelEntry e),
-         (s', KernelPreempted) ) |s s' e. (s, True, s') \<in> kernel_callf e \<and>
-                                          e \<noteq> Interrupt} \<union>
+     {((s, KernelEntry e),
+       (s', KernelPreempted)) | s s' e. (s, True, s') \<in> kernel_callf e \<and> e \<noteq> Interrupt} \<union>
   \<comment> \<open>kernel entry without preemption during event handling\<close>
-     { ( (s, KernelEntry e),
-         (s', KernelSchedule (e = Interrupt)) ) |s s' e. (s, False, s') \<in> kernel_callf e } \<union>
+     {((s, KernelEntry e),
+       (s', KernelSchedule (e = Interrupt))) | s s' e. (s, False, s') \<in> kernel_callf e } \<union>
   \<comment> \<open>handle in-kernel preemption\<close>
-     { ( (s, KernelPreempted),
-         (s', KernelSchedule True) ) |s s'. (s, (), s') \<in> preemptionf } \<union>
+     {((s, KernelPreempted), (s', KernelSchedule True)) | s s'. (s, (), s') \<in> preemptionf } \<union>
   \<comment> \<open>schedule\<close>
-     { ( (s, KernelSchedule b),
-         (s', KernelExit) ) |s s' b. (s, (), s') \<in> schedulef } \<union>
+     {((s, KernelSchedule b), (s', KernelExit)) | s s' b. (s, (), s') \<in> schedulef } \<union>
   \<comment> \<open>kernel exit\<close>
-     { ( (s, KernelExit),
-         (s', m) ) |s s' m. (s, m, s') \<in> kernel_exitf } \<union>
+     {((s, KernelExit), (s', m)) | s s' m. (s, m, s') \<in> kernel_exitf } \<union>
   \<comment> \<open>User runs, causes exception\<close>
-     { ( (s, InUserMode),
-         (s', KernelEntry e ) ) |s s_aux s' e.
-                                 (s, None, s_aux) \<in> get_active_irqf \<and>
-                                 (s_aux, Some e, s') \<in> do_user_opf \<and>
-                                 e \<noteq> Interrupt} \<union>
+     {((s, InUserMode), (s', KernelEntry e)) | s s_aux s' e. (s, None, s_aux) \<in> get_active_irqf \<and>
+                                                             (s_aux, Some e, s') \<in> do_user_opf \<and>
+                                                             e \<noteq> Interrupt} \<union>
   \<comment> \<open>User runs, no exception happens\<close>
-     { ( (s, InUserMode),
-         (s', InUserMode) ) |s s_aux s'.
-                             (s, None, s_aux) \<in> get_active_irqf \<and>
-                             (s_aux, None, s') \<in> do_user_opf} \<union>
+     {((s, InUserMode), (s', InUserMode) ) | s s_aux s'. (s, None, s_aux) \<in> get_active_irqf \<and>
+                                                         (s_aux, None, s') \<in> do_user_opf} \<union>
   \<comment> \<open>Interrupt while in user mode\<close>
-     { ( (s, InUserMode),
-         (s', KernelEntry Interrupt) ) |s s' i.
-                                        (s, Some i, s') \<in> get_active_irqf} \<union>
+     {((s, InUserMode), (s', KernelEntry Interrupt)) | s s' i. (s, Some i, s') \<in> get_active_irqf} \<union>
   \<comment> \<open>Interrupt while in idle mode\<close>
-     { ( (s, InIdleMode),
-         (s', KernelEntry Interrupt) ) |s s' i.
-                                        (s, Some i, s') \<in> get_active_irqf} \<union>
+     {((s, InIdleMode), (s', KernelEntry Interrupt)) | s s' i. (s, Some i, s') \<in> get_active_irqf} \<union>
   \<comment> \<open>No interrupt while in idle mode\<close>
-     { ( (s, InIdleMode),
-         (s', InIdleMode) ) |s s'. (s, None, s') \<in> get_active_irqf}"
+     {((s, InIdleMode), (s', InIdleMode)) | s s'. (s, None, s') \<in> get_active_irqf}"
 
-type_synonym user_state_if = "user_context \<times> user_mem \<times> device_state \<times> exclusive_monitors"
 
-text \<open>
-  A user transition gives back a possible event that is the next
-  event the user wants to perform
-\<close>
-type_synonym user_transition_if =
-  "obj_ref \<Rightarrow> (word32 \<rightharpoonup> word32) \<Rightarrow> (word32 \<Rightarrow> vm_rights) \<Rightarrow> (word32 \<Rightarrow> bool) \<Rightarrow>
-   user_state_if \<Rightarrow> (event option \<times> user_state_if) set"
+subsection \<open>do_user_op_if\<close>
 
-lemma dmo_getExMonitor_wp[wp]:
-  "\<lbrace>\<lambda>s. P (exclusive_state (machine_state s)) s\<rbrace>
-     do_machine_op getExMonitor
-   \<lbrace>P\<rbrace>"
-  apply(simp add: do_machine_op_def)
-  apply(wp modify_wp | wpc)+
-  apply clarsimp
-  apply(erule use_valid)
-   apply wp
-  apply simp
-  done
-
-lemma setExMonitor_wp[wp]:
-  "\<lbrace>\<lambda>ms. P (ms\<lparr>exclusive_state := es\<rparr>)\<rbrace>
-     setExMonitor es
-   \<lbrace>\<lambda>_. P\<rbrace>"
-  apply(simp add: setExMonitor_def | wp)+
-  done
-
-lemma dmo_setExMonitor_wp[wp]:
-  "\<lbrace>\<lambda>s. P (s\<lparr>machine_state := machine_state s \<lparr>exclusive_state := es\<rparr>\<rparr>)\<rbrace>
-     do_machine_op (setExMonitor es)
-   \<lbrace>\<lambda>_. P\<rbrace>"
-  apply(simp add: do_machine_op_def)
-  apply(wp modify_wp | wpc)+
-  apply clarsimp
-  apply(erule use_valid)
-   apply wp
-  apply simp
-  done
-
-lemma valid_state_exclusive_state_update[iff]:
-  "valid_state (s\<lparr>machine_state := machine_state s\<lparr>exclusive_state := es\<rparr>\<rparr>) = valid_state s"
-  by (simp add: valid_state_def valid_irq_states_def valid_machine_state_def)
-
-lemma cur_tcb_exclusive_state_update[iff]:
-  "cur_tcb (s\<lparr>machine_state := machine_state s\<lparr>exclusive_state := es\<rparr>\<rparr>) = cur_tcb s"
-  by (simp add: cur_tcb_def)
-
-lemma invs_exclusive_state_update[iff]:
-  "invs (s\<lparr>machine_state := machine_state s\<lparr>exclusive_state := es\<rparr>\<rparr>) = invs s"
-  by (simp add: invs_def)
-
-subsection \<open>do_user_op_if lemmas\<close>
-
-(* FIXME: clagged from AInvs.do_user_op_invs *)
-lemma do_user_op_if_invs:
-  "\<lbrace>invs and ct_running\<rbrace>
-   do_user_op_if f tc
-   \<lbrace>\<lambda>_. invs and ct_running\<rbrace>"
-  apply (simp add: do_user_op_if_def split_def)
-  apply (wp dmo_ct_in_state select_wp device_update_invs | wp (once) dmo_invs | simp)+
-  apply (clarsimp simp: user_mem_def user_memory_update_def simpler_modify_def
-                    restrict_map_def invs_def cur_tcb_def ptable_rights_s_def
-                    ptable_lift_s_def)
-  apply (frule ptable_rights_imp_frame)
-    apply fastforce
-   apply simp
-  apply (clarsimp simp: valid_state_def device_frame_in_device_region)
-  done
-
-crunch domain_sep_inv[wp]: do_user_op_if "domain_sep_inv irqs st"
-  (ignore: user_memory_update wp: select_wp)
-
-crunch valid_sched[wp]: do_user_op_if "valid_sched"
-  (ignore: user_memory_update wp: select_wp)
+definition do_user_op_A_if ::
+  "user_transition_if
+   \<Rightarrow> ((user_context \<times> det_state) \<times> event option \<times> (user_context \<times> det_state)) set" where
+  "do_user_op_A_if uop \<equiv>
+     {(s,e,(tc,s'))| s e tc s'. ((e,tc),s') \<in> fst (split (do_user_op_if uop) s)}"
 
 lemma no_irq_user_memory_update[simp]:
   "no_irq (user_memory_update a)"
-  apply(wpsimp simp: no_irq_def user_memory_update_def)
-  done
+  by (wpsimp simp: no_irq_def user_memory_update_def)
 
 lemma no_irq_device_memory_update[simp]:
   "no_irq (device_memory_update a)"
-  apply(wpsimp simp: no_irq_def device_memory_update_def)
-  done
+  by (wpsimp simp: no_irq_def device_memory_update_def)
 
-crunch irq_masks[wp]: do_user_op_if "\<lambda>s. P (irq_masks_of_state s)"
-  (ignore: user_memory_update wp: select_wp dmo_wp no_irq)
-
-crunch valid_list[wp]: do_user_op_if "valid_list"
-  (ignore: user_memory_update wp: select_wp)
-
-lemma do_user_op_if_scheduler_action[wp]:
-  "\<lbrace>(\<lambda>s. P (scheduler_action s))\<rbrace>
-   do_user_op_if f tc
-   \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
-  by (simp add: do_user_op_if_def | wp select_wp | wpc)+
-
-lemma do_user_op_silc_inv[wp]:
-  "\<lbrace>silc_inv aag st\<rbrace> do_user_op_if f tc \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply (simp add: do_user_op_if_def)
-  apply (wp select_wp | wpc | simp)+
-  done
-
-lemma do_user_op_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace> do_user_op_if f tc \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  apply (simp add: do_user_op_if_def)
-  apply (wp select_wp | wpc | simp)+
-  done
-
-crunches do_user_op_if
-  for cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
-  and cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
-  and idle_thread[wp]: "\<lambda>s. P (idle_thread s)"
-  and domain_fields[wp]: "domain_fields P"
-  (wp: select_wp ignore: user_memory_update)
-
-lemma do_use_op_guarded_pas_domain[wp]:
-  "\<lbrace>guarded_pas_domain aag\<rbrace> do_user_op_if f tc \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
-  by (rule guarded_pas_domain_lift; wp)
-
-definition do_user_op_A_if
-  :: "user_transition_if
-      \<Rightarrow> ((user_context \<times> det_state) \<times> event option \<times> (user_context \<times> det_state)) set"
-where
-  "do_user_op_A_if uop \<equiv>
-       {(s,e,(tc,s'))| s e tc s'. ((e,tc),s') \<in> fst (split (do_user_op_if uop) s)}"
 
 subsection \<open>kernel_entry_if\<close>
 
@@ -911,61 +756,30 @@ text \<open>
   unchanged; although it shouldn't matter really what its value is
   while we are still in kernel mode.
 \<close>
-definition kernel_entry_if
-  :: "event \<Rightarrow> user_context \<Rightarrow> (((unit + unit) \<times> user_context),det_ext) s_monad"
-where
-  "kernel_entry_if e tc \<equiv> do
-    t \<leftarrow> gets cur_thread;
-    thread_set (\<lambda>tcb. tcb \<lparr> tcb_arch := arch_tcb_context_set tc (tcb_arch tcb)\<rparr>) t;
-    r \<leftarrow> handle_event e;
-    return (r,tc)
-  od"
+definition kernel_entry_if ::
+  "event \<Rightarrow> user_context \<Rightarrow> (((unit + unit) \<times> user_context),det_ext) s_monad" where
+  "kernel_entry_if e tc \<equiv>
+   do t \<leftarrow> gets cur_thread;
+      thread_set (\<lambda>tcb. tcb \<lparr>tcb_arch := arch_tcb_context_set tc (tcb_arch tcb)\<rparr>) t;
+      r \<leftarrow> handle_event e;
+      return (r,tc)
+   od"
 
 crunch cur_domain[wp]: kernel_entry_if "\<lambda>s. P (cur_domain s)"
 crunch idle_thread[wp]: kernel_entry_if "\<lambda>s::det_state. P (idle_thread s)"
 crunch cur_thread [wp]: kernel_entry_if "\<lambda>s::det_state. P (cur_thread s)"
 
 lemma thread_set_tcb_context_update_ct_active[wp]:
-  "\<lbrace>ct_active\<rbrace>
-   thread_set (tcb_arch_update (arch_tcb_context_set f)) t
-   \<lbrace>\<lambda>rv. ct_active\<rbrace>"
-  apply(simp add: thread_set_def ct_in_state_def | wp set_object_wp)+
-  apply(clarsimp simp: st_tcb_at_def obj_at_def get_tcb_def)
+  "thread_set (tcb_arch_update (arch_tcb_context_set f)) t \<lbrace>ct_active\<rbrace>"
+  apply (simp add: thread_set_def ct_in_state_def | wp set_object_wp)+
+  apply (clarsimp simp: st_tcb_at_def obj_at_def get_tcb_def)
   done
 
 lemma thread_set_tcb_context_update_not_ct_active[wp]:
-  "\<lbrace>\<lambda>s. \<not> ct_active s\<rbrace>
-   thread_set (tcb_arch_update (arch_tcb_context_set f)) t
-   \<lbrace>\<lambda>r s. \<not> ct_active s\<rbrace>"
-  apply(simp add: thread_set_def ct_in_state_def | wp set_object_wp)+
-  apply(clarsimp simp: st_tcb_at_def obj_at_def get_tcb_def
-                split: kernel_object.splits option.splits)
-  done
-
-(*FIXME: Move to FinalCaps*)
-lemma thread_set_silc_inv_trivial:
-  "(\<And>tcb. \<forall>(getF, v)\<in>ran tcb_cap_cases. getF (F tcb) = getF tcb) \<Longrightarrow>
-   \<lbrace>silc_inv aag st\<rbrace>
-   thread_set F word
-   \<lbrace>\<lambda>xa. silc_inv aag st\<rbrace>"
-  unfolding thread_set_def
-  apply(rule silc_inv_pres)
-   apply(wp set_object_wp)
-   apply (simp split: kernel_object.splits)
-   apply(rule impI | simp)+
-   apply(fastforce simp: silc_inv_def dest: get_tcb_SomeD simp: obj_at_def is_cap_table_def)
-  apply(wp set_object_wp | simp)+
-  apply(case_tac "word = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(erule notE)
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(drule get_tcb_SomeD)
-   apply(rule cte_wp_at_tcbI)
-     apply(simp)
-    apply assumption
-   apply (clarsimp simp: tcb_cap_cases_def tcb_registers_caps_merge_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  "thread_set (tcb_arch_update (arch_tcb_context_set f)) t \<lbrace>\<lambda>s. \<not> ct_active s\<rbrace>"
+  apply (simp add: thread_set_def ct_in_state_def | wp set_object_wp)+
+  apply (clarsimp simp: st_tcb_at_def obj_at_def get_tcb_def
+                 split: kernel_object.splits option.splits)
   done
 
 lemma kernel_entry_if_invs:
@@ -973,190 +787,54 @@ lemma kernel_entry_if_invs:
    kernel_entry_if e tc
    \<lbrace>\<lambda>_. invs\<rbrace>"
   unfolding kernel_entry_if_def
-  apply (wpsimp wp: thread_set_invs_trivial static_imp_wp
-              simp: arch_tcb_update_aux2 ran_tcb_cap_cases)+
-  done
-
-lemma idle_equiv_as_globals_equiv:
-  "arm_global_pd (arch_state s) \<noteq> idle_thread s \<Longrightarrow>
-   idle_equiv st s =
-              globals_equiv (st\<lparr>arch_state := arch_state s, machine_state := machine_state s,
-                                kheap:= (kheap st)(arm_global_pd (arch_state s) :=
-                                                   kheap s (arm_global_pd (arch_state s))),
-                                cur_thread := cur_thread s\<rparr>) s"
-  by (clarsimp simp: idle_equiv_def globals_equiv_def tcb_at_def2)
-
-
-
-lemma idle_globals_lift:
-  assumes g: "\<And>st. \<lbrace>globals_equiv st and P\<rbrace> f \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  assumes i: "\<And>s. P s \<Longrightarrow> arm_global_pd (arch_state s) \<noteq> idle_thread s"
-  shows "\<lbrace>idle_equiv st and P\<rbrace> f \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
-  apply (clarsimp simp: valid_def)
-  apply (subgoal_tac "arm_global_pd (arch_state s) \<noteq> idle_thread s")
-   apply (subst (asm) idle_equiv_as_globals_equiv,simp+)
-   apply (frule use_valid[OF _ g])
-    apply simp+
-   apply (clarsimp simp: idle_equiv_def globals_equiv_def tcb_at_def2)
-   apply (erule i)
-  done
-
-lemma idle_equiv_as_globals_equiv_scheduler:
-  "arm_global_pd (arch_state s) \<noteq> idle_thread s \<Longrightarrow>
-   idle_equiv st s =
-       globals_equiv_scheduler (st\<lparr>arch_state := arch_state s, machine_state := machine_state s,
-                                   kheap:= (kheap st)(arm_global_pd (arch_state s) :=
-                                                     kheap s (arm_global_pd (arch_state s)))\<rparr>) s"
-  by (clarsimp simp: idle_equiv_def globals_equiv_scheduler_def tcb_at_def2)
-
-
-
-lemma idle_globals_lift_scheduler:
-  assumes g: "\<And>st. \<lbrace>globals_equiv_scheduler st and P\<rbrace> f \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
-  assumes i: "\<And>s. P s \<Longrightarrow> arm_global_pd (arch_state s) \<noteq> idle_thread s"
-  shows "\<lbrace>idle_equiv st and P\<rbrace> f \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
-  apply (clarsimp simp: valid_def)
-  apply (subgoal_tac "arm_global_pd (arch_state s) \<noteq> idle_thread s")
-   apply (subst (asm) idle_equiv_as_globals_equiv_scheduler,simp+)
-   apply (frule use_valid[OF _ g])
-    apply simp+
-   apply (clarsimp simp: idle_equiv_def globals_equiv_scheduler_def tcb_at_def2)
-   apply (erule i)
-  done
-
-lemma invs_pd_not_idle_thread[intro]:
-  "invs s \<Longrightarrow> arm_global_pd (arch_state s) \<noteq> idle_thread s"
-  by (fastforce simp: invs_def valid_state_def valid_global_objs_def
-                      obj_at_def valid_idle_def pred_tcb_at_def empty_table_def)
-
+  by (wpsimp wp: thread_set_invs_trivial static_imp_wp
+           simp: arch_tcb_update_aux2 ran_tcb_cap_cases)+
 
 lemma kernel_entry_if_globals_equiv:
   "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and globals_equiv st
-    and (\<lambda>s. ct_idle s \<longrightarrow> tc = idle_context s) \<rbrace>
-    kernel_entry_if e tc
+         and (\<lambda>s. ct_idle s \<longrightarrow> tc = idle_context s)\<rbrace>
+   kernel_entry_if e tc
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (simp add: kernel_entry_if_def)
-  apply (wp static_imp_wp
-            handle_event_globals_equiv
-            thread_set_invs_trivial
-            thread_set_context_globals_equiv
-        | simp add: ran_tcb_cap_cases arch_tcb_update_aux2)+
+  apply (wp static_imp_wp handle_event_globals_equiv
+            thread_set_invs_trivial thread_set_context_globals_equiv
+         | simp add: ran_tcb_cap_cases arch_tcb_update_aux2)+
   apply (clarsimp simp: cur_thread_idle)
   done
 
-lemma kernel_entry_if_idle_equiv:
-  "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and idle_equiv st
-       and (\<lambda>s. ct_idle s \<longrightarrow> tc = idle_context s) \<rbrace>
-     kernel_entry_if e tc
-   \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
-  apply (rule hoare_pre)
-   apply (rule idle_globals_lift)
-    apply (wp kernel_entry_if_globals_equiv)
-    apply force
-   apply (fastforce intro!: invs_pd_not_idle_thread)+
-  done
-
 lemma thread_set_tcb_context_update_neg_cte_wp_at[wp]:
-  "\<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>
-     thread_set (tcb_arch_update (arcb_tcb_context_set blah)) param_a
-   \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
-  apply(simp add: thread_set_def)
-  apply(wp set_object_wp get_object_wp | simp)+
-  apply(case_tac "param_a = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(erule notE)
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(drule get_tcb_SomeD)
-   apply(rule cte_wp_at_tcbI)
-     apply(simp)
+  "thread_set (tcb_arch_update f) t \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
+  apply (simp add: thread_set_def)
+  apply (wp set_object_wp get_object_wp | simp)+
+  apply (case_tac "t = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (erule notE)
+   apply (erule cte_wp_atE)
+    apply (fastforce simp: obj_at_def)
+   apply (drule get_tcb_SomeD)
+   apply (rule cte_wp_at_tcbI)
+     apply (simp)
     apply assumption
    apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
 lemma thread_set_tcb_context_update_domain_sep_inv[wp]:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-     thread_set (tcb_arch_update (arch_tcb_context_set f)) t
-   \<lbrace>\<lambda>rv. domain_sep_inv irqs st\<rbrace>"
-  by(wp domain_sep_inv_triv)
+  "thread_set (tcb_arch_update f) t \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  by (wp domain_sep_inv_triv)
 
 lemma kernel_entry_silc_inv[wp]:
-  "\<lbrace>silc_inv aag st and einvs and simple_sched_action and
-       (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) and
-       pas_refined aag and
-       (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s)) and
-       domain_sep_inv (pasMaySendIrqs aag) st'\<rbrace>
-     kernel_entry_if ev tc
+  "\<lbrace>silc_inv aag st and einvs and simple_sched_action and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)
+                    and pas_refined aag and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))
+                    and domain_sep_inv (pasMaySendIrqs aag) st'\<rbrace>
+   kernel_entry_if ev tc
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding kernel_entry_if_def
-  apply (wpsimp simp: ran_tcb_cap_cases arch_tcb_update_aux2
-                  wp: static_imp_wp handle_event_silc_inv thread_set_silc_inv_trivial
-                      thread_set_invs_trivial thread_set_not_state_valid_sched
-                      thread_set_pas_refined
-        | wp (once) hoare_vcg_imp_lift)+
-  by force
+  by (wpsimp simp: ran_tcb_cap_cases arch_tcb_update_aux2
+               wp: static_imp_wp handle_event_silc_inv thread_set_silc_inv thread_set_invs_trivial
+                   thread_set_not_state_valid_sched thread_set_pas_refined
+      | wp (once) hoare_vcg_imp_lift | force)+
 
-lemma kernel_entry_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and guarded_pas_domain aag and
-       domain_sep_inv (pasMaySendIrqs aag) st and einvs and
-       schact_is_rct and
-       (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s)) and
-       (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
-     kernel_entry_if ev tc
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  unfolding kernel_entry_if_def
-  apply (wpsimp simp: ran_tcb_cap_cases schact_is_rct_def arch_tcb_update_aux2 tcb_arch_ref_def
-                  wp: static_imp_wp handle_event_pas_refined
-             thread_set_pas_refined guarded_pas_domain_lift
-             thread_set_invs_trivial thread_set_not_state_valid_sched)+
-  by force
-
-lemma kernel_entry_if_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st and einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
-     kernel_entry_if e tc
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  unfolding kernel_entry_if_def
-  apply( wpsimp simp: ran_tcb_cap_cases arch_tcb_update_aux2 tcb_arch_ref_def
-          wp: handle_event_domain_sep_inv static_imp_wp
-            thread_set_invs_trivial thread_set_not_state_valid_sched)+
-  done
-
-lemma kernel_entry_if_guarded_pas_domain:
-  "\<lbrace>guarded_pas_domain aag\<rbrace>
-     kernel_entry_if e tc
-   \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
-  apply (simp add: kernel_entry_if_def)
-  apply (wp guarded_pas_domain_lift)
-  done
-
-lemma kernel_entry_if_valid_sched:
-  "\<lbrace>valid_sched and invs and (ct_active or ct_idle) and
-       (\<lambda>s. (e \<noteq> Interrupt \<longrightarrow> ct_active s) \<and> scheduler_action s = resume_cur_thread)\<rbrace>
-     kernel_entry_if e tc
-   \<lbrace>\<lambda>_. valid_sched\<rbrace>"
-  apply(wpsimp simp: kernel_entry_if_def ran_tcb_cap_cases arch_tcb_update_aux2 tcb_arch_ref_def
-         wp: handle_event_valid_sched thread_set_invs_trivial hoare_vcg_disj_lift
-             thread_set_no_change_tcb_state ct_in_state_thread_state_lift
-             thread_set_not_state_valid_sched static_imp_wp)+
-  done
-
-lemma kernel_entry_if_irq_masks:
-  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and invs\<rbrace>
-     kernel_entry_if e tc
-   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply( simp add: kernel_entry_if_def ran_tcb_cap_cases arch_tcb_update_aux2 tcb_arch_ref_def
-       | wp handle_event_irq_masks thread_set_invs_trivial)+
-  by fastforce
-
-crunch valid_list[wp]: kernel_entry_if "valid_list"
-
-definition kernel_call_A_if
-  :: "event \<Rightarrow> ((user_context \<times> det_state) \<times> bool \<times> (user_context \<times> det_state)) set"
-where
-  "kernel_call_A_if e \<equiv>
-      {(s, b, (tc,s'))|s b tc s' r. ((r,tc),s') \<in> fst (split (kernel_entry_if e) s) \<and>
-                   b = (case r of Inl _ \<Rightarrow> True | Inr _ \<Rightarrow> False)}"
 
 subsection \<open>handle_preemption_if\<close>
 
@@ -1164,31 +842,260 @@ text \<open>
   Since this executes entirely in kernel mode, leave the
   user context unchanged
 \<close>
-definition handle_preemption_if :: "user_context \<Rightarrow> (user_context,det_ext) s_monad"
-where
-  "handle_preemption_if tc \<equiv> do
-     irq \<leftarrow> do_machine_op (getActiveIRQ False);
-     when (irq \<noteq> None) $ handle_interrupt (the irq);
-     return tc
+definition handle_preemption_if :: "user_context \<Rightarrow> (user_context,det_ext) s_monad" where
+  "handle_preemption_if tc \<equiv>
+   do irq \<leftarrow> do_machine_op (getActiveIRQ False);
+      when (irq \<noteq> None) $ handle_interrupt (the irq);
+      return tc
    od"
 
 
-lemma handle_preemption_if_invs:
-  "\<lbrace>invs\<rbrace>
+subsection \<open>schedule_if\<close>
+
+text \<open>
+  Since this executes entirely in kernel mode, leave the
+  user context unchanged
+\<close>
+definition schedule_if :: "user_context \<Rightarrow> (user_context,det_ext) s_monad" where
+  "schedule_if tc \<equiv>
+   do schedule;
+      activate_thread;
+      return tc
+   od"
+
+crunch silc_inv[wp]: schedule_if "silc_inv aag st"
+crunch domain_sep_inv[wp]: schedule_if "\<lambda>s :: det_state. domain_sep_inv irqs st s"
+crunch idle_thread[wp]: activate_thread "\<lambda>s :: det_state. P (idle_thread s)"
+crunch cur_domain[wp]: activate_thread "\<lambda>s. P (cur_domain s)"
+
+function (domintros) next_irq_state :: "nat \<Rightarrow> (irq \<Rightarrow> bool) \<Rightarrow> nat" where
+  "next_irq_state cur masks =
+     (if irq_at cur masks = None then next_irq_state (Suc cur) masks else cur)"
+  by (pat_completeness, auto)
+
+definition irq_measure_if where
+  "irq_measure_if s \<equiv> let cur = Suc (irq_state (machine_state s))
+                       in (next_irq_state cur (irq_masks (machine_state s))) - cur"
+
+definition irq_measure_if_inv where
+  "irq_measure_if_inv st s \<equiv> irq_measure_if (s::det_state) \<le> irq_measure_if (st::det_state)"
+
+definition irq_state_inv where
+  "irq_state_inv (st :: det_state) (s :: det_state) \<equiv>
+     irq_state (machine_state s) \<ge> irq_state (machine_state st) \<and>
+     irq_masks (machine_state s) = irq_masks (machine_state st) \<and>
+     next_irq_state (Suc (irq_state (machine_state s))) (irq_masks (machine_state s)) =
+     next_irq_state (Suc (irq_state (machine_state st))) (irq_masks (machine_state s))"
+
+definition irq_state_next where
+  "irq_state_next (st :: det_state) (s :: det_state) \<equiv>
+     irq_state (machine_state s) \<ge> irq_state (machine_state st) \<and>
+     irq_masks (machine_state s) = irq_masks (machine_state st) \<and>
+     irq_state (machine_state s) = next_irq_state (Suc (irq_state (machine_state st)))
+                                                  (irq_masks (machine_state s))"
+
+
+locale ADT_IF_1 =
+  fixes initial_aag :: "'a subject_label PAS"
+  assumes do_user_op_if_invs[wp]:
+    "do_user_op_if uop tc \<lbrace>invs and ct_running :: det_state \<Rightarrow> bool\<rbrace>"
+  and do_user_op_if_domain_sep_inv[wp]:
+    "do_user_op_if uop tc \<lbrace>\<lambda>s. domain_sep_inv irqs (st :: det_state) (s :: det_state)\<rbrace>"
+  and do_user_op_if_valid_sched[wp]:
+    "do_user_op_if uop tc \<lbrace>valid_sched\<rbrace>"
+  and do_user_op_if_irq_masks[wp]:
+    "\<And>P. do_user_op_if uop tc \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and do_user_op_if_valid_list[wp]:
+    "do_user_op_if uop tc \<lbrace>valid_list\<rbrace>"
+  and do_user_op_if_scheduler_action[wp]:
+    "\<And>P. do_user_op_if uop tc \<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace>"
+  and do_user_op_silc_inv[wp]:
+    "do_user_op_if uop tc \<lbrace>silc_inv (aag :: 'a subject_label PAS) st\<rbrace>"
+  and do_user_op_pas_refined[wp]:
+    "do_user_op_if uop tc \<lbrace>pas_refined aag\<rbrace>"
+  and do_user_op_cur_thread[wp]:
+    "\<And>P. do_user_op_if uop tc \<lbrace>\<lambda>s :: det_state. P (cur_thread s)\<rbrace>"
+  and do_user_op_cur_domain[wp]:
+    "\<And>P. do_user_op_if uop tc \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  and do_user_op_idle_thread[wp]:
+    "\<And>P. do_user_op_if uop tc \<lbrace>\<lambda>s :: det_state. P (idle_thread s)\<rbrace>"
+  and do_user_op_domain_fields[wp]:
+    "\<And>P. do_user_op_if uop tc \<lbrace>domain_fields P\<rbrace>"
+  and do_use_op_guarded_pas_domain[wp]:
+    "do_user_op_if uop tc \<lbrace>guarded_pas_domain aag\<rbrace>"
+  and tcb_arch_ref_tcb_context_set[simp]:
+    "tcb_arch_ref (tcb_arch_update (arch_tcb_context_set uc) tcb) = tcb_arch_ref tcb"
+  and arch_switch_to_idle_thread_pspace_aligned[wp]:
+    "arch_switch_to_idle_thread \<lbrace>\<lambda>s :: det_ext state. pspace_aligned s\<rbrace>"
+  and arch_switch_to_idle_thread_valid_vspace_objs[wp]:
+    "arch_switch_to_idle_thread \<lbrace>\<lambda>s :: det_ext state. valid_vspace_objs s\<rbrace>"
+  and arch_switch_to_idle_thread_valid_arch_state[wp]:
+    "arch_switch_to_idle_thread \<lbrace>\<lambda>s :: det_ext state. valid_arch_state s\<rbrace>"
+  and arch_switch_to_thread_pspace_aligned[wp]:
+    "arch_switch_to_thread t \<lbrace>\<lambda>s :: det_ext state. pspace_aligned s\<rbrace>"
+  and arch_switch_to_thread_valid_vspace_objs[wp]:
+    "arch_switch_to_thread t \<lbrace>\<lambda>s :: det_ext state. valid_vspace_objs s\<rbrace>"
+  and arch_switch_to_thread_valid_arch_state[wp]:
+    "arch_switch_to_thread t \<lbrace>\<lambda>s :: det_ext state. valid_arch_state s\<rbrace>"
+  and arch_switch_to_thread_cur_thread[wp]:
+    "\<And>P. arch_switch_to_thread t \<lbrace>\<lambda>s :: det_state. P (cur_thread s)\<rbrace>"
+  and arch_activate_idle_thread_cur_thread[wp]:
+    "\<And>P. arch_activate_idle_thread t \<lbrace>\<lambda>s :: det_state. P (cur_thread s)\<rbrace>"
+  and arch_activate_idle_thread_scheduler_action[wp]:
+    "\<And>P. arch_activate_idle_thread t \<lbrace>\<lambda>s :: det_state. P (scheduler_action s)\<rbrace>"
+  and handle_vm_fault_domain_fields[wp]:
+    "\<And>P. handle_vm_fault t vmft \<lbrace>domain_fields P\<rbrace>"
+  and handle_hypervisor_fault_domain_fields[wp]:
+    "\<And>P. handle_hypervisor_fault t hft \<lbrace>domain_fields P\<rbrace>"
+  and arch_perform_invocation_noErr[wp]:
+    "\<And>Q. \<lbrace>\<top>\<rbrace> arch_perform_invocation i -, \<lbrace>\<lambda>rv s :: det_state. Q rv s\<rbrace>"
+  and arch_invoke_irq_control_noErr[wp]:
+    "\<And>Q. \<lbrace>\<top>\<rbrace> arch_invoke_irq_control ici -, \<lbrace>\<lambda>rv s :: det_state. Q rv s\<rbrace>"
+  and init_arch_objects_irq_state_of_state[wp]:
+    "\<And>P. init_arch_objects new_type ptr num_objects obj_sz refs \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and getActiveIRQ_None:
+    "(None, s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) (s :: det_state))
+     \<Longrightarrow> irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = None"
+  and getActiveIRQ_Some:
+    "(Some irq, s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) s)
+     \<Longrightarrow> irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = Some irq"
+  and kernel_entry_if_idle_equiv:
+    "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and idle_equiv st
+           and (\<lambda>s. ct_idle s \<longrightarrow> tc = idle_context s)\<rbrace>
+     kernel_entry_if e tc
+     \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
+  (* FIXME IF: malformed lemma *)
+  and handle_preemption_if_valid_sched[wp]:
+    "\<lbrace>valid_sched and invs and
+      (\<lambda>s. blah \<in> (non_kernel_IRQs :: irq set) \<longrightarrow> scheduler_act_sane s \<and> ct_not_queued s)\<rbrace>
      handle_preemption_if tc
-   \<lbrace>\<lambda>_. invs\<rbrace>"
-  apply(simp add: handle_preemption_if_def | wp)+
+     \<lbrace>\<lambda>_. valid_sched\<rbrace>"
+  and handle_preemption_idle_equiv[wp]:
+    "\<lbrace>idle_equiv st and invs\<rbrace> handle_preemption_if tc \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
+  and schedule_if_idle_equiv[wp]:
+    "\<lbrace>idle_equiv st and invs\<rbrace> schedule_if tc \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
+  and do_user_op_if_idle_equiv[wp]:
+    "\<lbrace>idle_equiv st and invs\<rbrace> do_user_op_if uop tc \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
+  and kernel_entry_if_valid_vspace_objs'[wp]:
+    "\<lbrace>valid_vspace_objs' and invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
+     kernel_entry_if e tc
+     \<lbrace>\<lambda>_. valid_vspace_objs'\<rbrace>"
+  and handle_preemption_if_valid_pdpt_objs[wp]:
+    "handle_preemption_if tc \<lbrace>\<lambda>s. valid_vspace_objs' s\<rbrace>"
+  and schedule_if_valid_pdpt_objs[wp]:
+    "schedule_if tc \<lbrace>\<lambda>s. valid_vspace_objs' s\<rbrace>"
+  and do_user_op_if_valid_pdpt_objs[wp]:
+    "do_user_op_if uop tc \<lbrace>\<lambda>s :: det_state. valid_vspace_objs' s\<rbrace>"
+  and valid_vspace_objs'_ms_update[simp]:
+    "\<And>f. valid_vspace_objs' (machine_state_update f s) = valid_vspace_objs' s"
+  (* FIXME IF: precludes ARM_HYP *)
+  and non_kernel_IRQs_empty:
+    "(non_kernel_IRQs :: irq set) = {}"
+  and do_user_op_if_irq_state_of_state:
+    "\<And>P. do_user_op_if uop tc \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and do_user_op_if_irq_masks_of_state:
+    "\<And>P. do_user_op_if uop tc \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and do_user_op_if_irq_measure_if:
+    "\<And>P. do_user_op_if uop tc \<lbrace>\<lambda>s :: det_state. P (irq_measure_if s)\<rbrace>"
+  and invoke_tcb_irq_state_inv:
+    "\<lbrace>(\<lambda>s. irq_state_inv st s) and domain_sep_inv False (sta :: det_state)
+                               and tcb_inv_wf tinv and K (irq_is_recurring irq st)\<rbrace>
+     invoke_tcb tinv
+     \<lbrace>\<lambda>_ s. irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+  and reset_untyped_cap_irq_state_inv:
+    "\<lbrace>irq_state_inv st and K (irq_is_recurring irq st)\<rbrace>
+     reset_untyped_cap slot
+     \<lbrace>\<lambda>y. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>y. irq_state_next st\<rbrace>"
+  and handle_vm_fault_irq_state_of_state[wp]:
+    "handle_vm_fault t vmft \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and handle_hypervisor_fault_irq_state_of_state[wp]:
+    "handle_hypervisor_fault t hft \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and create_cap_irq_state_of_state[wp]:
+    "create_cap type bits untyped dev sl \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and arch_invoke_irq_control_irq_state_of_state[wp]:
+    "arch_invoke_irq_control ici \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+begin
+
+lemma kernel_entry_pas_refined[wp]:
+  "\<lbrace>pas_refined aag and guarded_pas_domain aag and domain_sep_inv (pasMaySendIrqs aag) st
+                    and einvs and schact_is_rct
+                    and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))
+                    and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
+   kernel_entry_if ev tc
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  unfolding kernel_entry_if_def
+  by (wpsimp simp: ran_tcb_cap_cases schact_is_rct_def arch_tcb_update_aux2
+               wp: static_imp_wp handle_event_pas_refined thread_set_pas_refined
+                   guarded_pas_domain_lift thread_set_invs_trivial thread_set_not_state_valid_sched
+      | force)+
+
+lemma kernel_entry_if_domain_sep_inv:
+  "\<lbrace>domain_sep_inv irqs st and einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
+   kernel_entry_if e tc
+   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
+  unfolding kernel_entry_if_def
+  by (wpsimp simp: ran_tcb_cap_cases arch_tcb_update_aux2
+               wp: handle_event_domain_sep_inv static_imp_wp
+                   thread_set_invs_trivial thread_set_not_state_valid_sched)+
+
+lemma kernel_entry_if_valid_sched:
+  "\<lbrace>valid_sched and invs and (ct_active or ct_idle)
+                and (\<lambda>s. (e \<noteq> Interrupt \<longrightarrow> ct_active s) \<and> scheduler_action s = resume_cur_thread)\<rbrace>
+   kernel_entry_if e tc
+   \<lbrace>\<lambda>_. valid_sched\<rbrace>"
+  by (wpsimp simp: kernel_entry_if_def ran_tcb_cap_cases arch_tcb_update_aux2
+               wp: handle_event_valid_sched thread_set_invs_trivial hoare_vcg_disj_lift
+                   thread_set_no_change_tcb_state ct_in_state_thread_state_lift
+                   thread_set_not_state_valid_sched static_imp_wp)+
+
+lemma kernel_entry_if_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and invs\<rbrace>
+   kernel_entry_if e tc
+   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  by (simp add: kernel_entry_if_def ran_tcb_cap_cases arch_tcb_update_aux2
+      | wp handle_event_irq_masks thread_set_invs_trivial | force)+
+
+crunches schedule
+  for pspace_aligned[wp]: "\<lambda>s :: det_ext state. pspace_aligned s"
+  and valid_vspace_objs[wp]: "\<lambda>s :: det_ext state. valid_vspace_objs s"
+  and valid_arch_state[wp]: "\<lambda>s :: det_ext state. valid_arch_state s"
+  (wp: crunch_wps)
+
+crunch pas_refined[wp]: schedule_if "pas_refined aag"
+
+crunch cur_thread: activate_thread "\<lambda>s :: det_state. P (cur_thread s)"
+
+lemma activate_thread_guarded_pas_domain[wp]:
+  "activate_thread \<lbrace>guarded_pas_domain aag\<rbrace>"
+  by (rule guarded_pas_domain_lift; wp activate_thread_cur_thread)
+
+end
+
+
+lemma kernel_entry_if_guarded_pas_domain:
+  "kernel_entry_if e tc \<lbrace>guarded_pas_domain aag\<rbrace>"
+  apply (simp add: kernel_entry_if_def)
+  apply (wp guarded_pas_domain_lift)
   done
+
+crunch valid_list[wp]: kernel_entry_if "valid_list"
+
+definition kernel_call_A_if ::
+  "event \<Rightarrow> ((user_context \<times> det_state) \<times> bool \<times> (user_context \<times> det_state)) set" where
+  "kernel_call_A_if e \<equiv>
+     {(s, b, (tc,s')) | s b tc s' r. ((r,tc),s') \<in> fst (split (kernel_entry_if e) s) \<and>
+                                     b = (case r of Inl _ \<Rightarrow> True | Inr _ \<Rightarrow> False)}"
+
+lemma handle_preemption_if_invs:
+  "handle_preemption_if tc \<lbrace>invs\<rbrace>"
+  by (simp add: handle_preemption_if_def | wp)+
 
 lemma handle_preemption_if_domain_sep_inv:
-  "\<lbrace>domain_sep_inv irqs st\<rbrace>
-     handle_preemption_if e
-   \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
-  apply(simp add: handle_preemption_if_def | wp)+
-  done
+  "handle_preemption_if e \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  by (simp add: handle_preemption_if_def | wp)+
 
 lemma handle_preemption_if_silc_inv[wp]:
-  "\<lbrace>silc_inv aag st\<rbrace> handle_preemption_if tc \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  "handle_preemption_if tc \<lbrace>silc_inv aag st\<rbrace>"
   apply (simp add: handle_preemption_if_def)
   apply (wp handle_interrupt_silc_inv do_machine_op_silc_inv | simp)+
   done
@@ -1200,91 +1107,42 @@ lemma handle_preemption_if_pas_refined[wp]:
   by (wpsimp wp: handle_interrupt_pas_refined getActiveIRQ_wp hoare_drop_imps
            simp: handle_preemption_if_def if_fun_split)
 
-crunch cur_thread[wp]: handle_preemption_if "\<lambda>s::det_state. P (cur_thread s)"
-crunch cur_domain[wp]: handle_preemption_if " \<lambda>s. P (cur_domain s)"
-crunch idle_thread[wp]: handle_preemption_if "\<lambda>s::det_state. P (idle_thread s)"
+crunch cur_domain[wp]: handle_preemption_if "\<lambda>s. P (cur_domain s)"
+crunch cur_thread[wp]: handle_preemption_if "\<lambda>s :: det_state. P (cur_thread s)"
+crunch idle_thread[wp]: handle_preemption_if "\<lambda>s :: det_state. P (idle_thread s)"
 
 lemma handle_preemption_if_guarded_pas_domain[wp]:
-  "\<lbrace>guarded_pas_domain aag\<rbrace> handle_preemption_if tc \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
+  "handle_preemption_if tc \<lbrace>guarded_pas_domain aag\<rbrace>"
   by (rule guarded_pas_domain_lift; wp)
 
-lemma handle_preemption_if_valid_sched[wp]:
-  "\<lbrace>valid_sched and invs and (\<lambda>s. irq \<in> non_kernel_IRQs \<longrightarrow> scheduler_act_sane s \<and> ct_not_queued s)\<rbrace>
-      handle_preemption_if irq \<lbrace>\<lambda>_. valid_sched\<rbrace>"
-  apply (wpsimp simp: handle_preemption_if_def non_kernel_IRQs_def cong: if_cong)
-   apply (wpsimp wp: hoare_drop_imp hoare_vcg_if_lift2)+
-  done
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 lemma handle_preemption_if_irq_masks:
   "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
    handle_preemption_if tc
    \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply(simp add: handle_preemption_if_def | wp handle_interrupt_irq_masks[where st=st])+
-  apply(rule_tac Q="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s \<and>
-                    (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ) " in hoare_strengthen_post)
-    by(wp | simp)+
-end
+  apply (simp add: handle_preemption_if_def | wp handle_interrupt_irq_masks[where st=st])+
+   apply (rule_tac Q="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s \<and>
+                             (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_strengthen_post)
+  by (wp | simp)+
 
 crunch valid_list[wp]: handle_preemption_if "valid_list"
   (ignore: getActiveIRQ)
 
-definition kernel_handle_preemption_if
-  :: "((user_context \<times> det_state) \<times> unit \<times> (user_context \<times> det_state)) set"
-where
+definition kernel_handle_preemption_if ::
+  "((user_context \<times> det_state) \<times> unit \<times> (user_context \<times> det_state)) set" where
   "kernel_handle_preemption_if \<equiv>
-      {(s, u, s'). s' \<in> fst (split handle_preemption_if s)}"
-
-subsection \<open>schedule_if\<close>
-
-text \<open>
-  Since this executes entirely in kernel mode, leave the
-  user context unchanged
-\<close>
-definition schedule_if
-  :: "user_context \<Rightarrow> (user_context,det_ext) s_monad"
-where
-  "schedule_if tc \<equiv> do
-     schedule;
-     activate_thread;
-     return tc
-   od"
+     {(s, u, s'). s' \<in> fst (split handle_preemption_if s)}"
 
 lemma schedule_if_invs[wp]:
-  "\<lbrace>invs\<rbrace>
-     schedule_if tc
-   \<lbrace>\<lambda>_. invs\<rbrace>"
-  apply(simp add: schedule_if_def | wp)+
-   apply(rule hoare_strengthen_post[OF activate_invs] | simp | wp)+
-  done
-
-crunches schedule
-  for pspace_aligned[wp]: "\<lambda>s :: det_ext state. pspace_aligned s"
-  and valid_vspace_objs[wp]: "\<lambda>s :: det_ext state. valid_vspace_objs s"
-  and valid_arch_state[wp]: "\<lambda>s :: det_ext state. valid_arch_state s"
-  (wp: crunch_wps)
-
-crunch pas_refined[wp]: schedule_if "pas_refined aag"
-
-crunch silc_inv[wp]: schedule_if "silc_inv aag st"
-
-crunch domain_sep_inv[wp]: schedule_if "\<lambda>s::det_state. domain_sep_inv irqs st s"
-
-crunch cur_domain[wp]: activate_thread "\<lambda>s. P (cur_domain s)"
-crunch idle_thread[wp]: activate_thread "\<lambda>s. P (idle_thread s)"
-
-lemma activate_thread_guarded_pas_domain[wp]:
-  "\<lbrace>guarded_pas_domain aag\<rbrace> activate_thread \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
-  by (rule guarded_pas_domain_lift; wp activate_thread_cur_thread)
+  "schedule_if tc \<lbrace>invs\<rbrace>"
+  by (simp add: schedule_if_def | wp | rule hoare_strengthen_post[OF activate_invs])+
 
 lemma guarded_pas_domain_arch_state_update[simp]:
   "guarded_pas_domain aag (s\<lparr>arch_state := x\<rparr>) = guarded_pas_domain aag s"
-  apply (simp add: guarded_pas_domain_def)
-  done
+  by (simp add: guarded_pas_domain_def)
 
 lemma switch_to_thread_guarded_pas_domain:
   "\<lbrace>\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)\<rbrace>
-     switch_to_thread t
+   switch_to_thread t
    \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
   apply (simp add: switch_to_thread_def)
   apply (wp modify_wp hoare_drop_imps| simp add: guarded_pas_domain_def)+
@@ -1292,28 +1150,28 @@ lemma switch_to_thread_guarded_pas_domain:
 
 lemma guarded_pas_domain_machine_state_update[simp]:
   "guarded_pas_domain aag (s\<lparr>machine_state := x\<rparr>) = guarded_pas_domain aag s"
-  apply (simp add: guarded_pas_domain_def)
-  done
+  by (simp add: guarded_pas_domain_def)
 
 (* FIXME: Why was the [wp] attribute clobbered by interpretation of the Arch locale? *)
 declare storeWord_irq_masks[wp]
 
 lemma switch_to_idle_thread_guarded_pas_domain[wp]:
-  "\<lbrace>\<top>\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>xb. guarded_pas_domain aag\<rbrace>"
-  apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def bind_assoc
-                   double_gets_drop_regets)
+  "\<lbrace>\<top>\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
+  apply (simp add: switch_to_idle_thread_def bind_assoc double_gets_drop_regets)
   apply (wp modify_wp dmo_wp hoare_vcg_imp_lift | wp (once) | simp add: guarded_pas_domain_def)+
   done
 
 lemma choose_thread_guarded_pas_domain:
-  "\<lbrace>pas_refined aag and valid_queues\<rbrace> choose_thread \<lbrace>\<lambda>xb. guarded_pas_domain aag\<rbrace>"
+  "\<lbrace>pas_refined aag and valid_queues\<rbrace>
+   choose_thread
+   \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
   apply (simp add: choose_thread_def guarded_switch_to_def
-        | wp switch_to_thread_respects switch_to_idle_thread_respects gts_wp
-             switch_to_thread_guarded_pas_domain)+
+         | wp switch_to_thread_respects switch_to_idle_thread_respects
+              gts_wp switch_to_thread_guarded_pas_domain)+
   apply (clarsimp simp: pas_refined_def)
   apply (clarsimp simp: tcb_domain_map_wellformed_aux_def)
   apply (erule_tac x="(hd (max_non_empty_queue (ready_queues s (cur_domain s))), cur_domain s)"
-                   in ballE)
+                in ballE)
    apply simp
   apply (clarsimp simp: valid_queues_def is_etcb_at_def)
   apply (erule_tac x="cur_domain s" in allE)
@@ -1328,138 +1186,126 @@ lemma choose_thread_guarded_pas_domain:
   apply (erule_tac P="hd A \<in> B" for A B in notE)
   apply (rule Max_prop)
    apply force+
-   done
-
-lemma switch_within_domain:
-  "\<lbrakk>scheduler_action s = switch_thread x;valid_sched s; pas_refined aag s\<rbrakk> \<Longrightarrow>
-   pasObjectAbs aag x \<in> pasDomainAbs aag (cur_domain s)"
-  apply (clarsimp simp: valid_sched_def valid_sched_action_def switch_in_cur_domain_def
-                        in_cur_domain_def etcb_at_def valid_etcbs_def st_tcb_at_def
-                        is_etcb_at_def weak_valid_sched_action_def)
-  apply (drule_tac x=x in spec)
-  apply (simp add: obj_at_def)
-  apply (clarsimp simp add: pas_refined_def tcb_domain_map_wellformed_aux_def)
-  apply (drule_tac x="(x,tcb_domain y)" in bspec)
-   apply (rule domtcbs)
-    apply simp+
   done
 
+lemma schedule_if_ct_running_or_ct_idle[wp]:
+  "\<lbrace>invs\<rbrace> schedule_if tc \<lbrace>\<lambda>_ s. ct_running s \<or> ct_idle s\<rbrace>"
+  apply (simp add: schedule_if_def | wp)+
+    apply (rule hoare_strengthen_post[OF activate_invs] | simp | wp)+
+  done
+
+lemma set_thread_state_scheduler_action:
+  "\<lbrace>(\<lambda>s. P (scheduler_action (s :: det_state))) and st_tcb_at runnable t and K (runnable s)\<rbrace>
+   set_thread_state t s
+   \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
+  apply (simp add: set_thread_state_def | wp sts_ext_running_noop set_object_wp)+
+  apply (clarsimp simp: st_tcb_at_def obj_at_def)
+  done
+
+
+context ADT_IF_1 begin
+
 lemma schedule_guarded_pas_domain:
-  "\<lbrace>guarded_pas_domain aag and einvs and pas_refined aag\<rbrace> schedule \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
+  "\<lbrace>guarded_pas_domain aag and einvs and pas_refined aag\<rbrace>
+   schedule
+   \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
   supply ethread_get_wp[wp del]
   apply (simp add: schedule_def)
   apply (wpsimp wp: guarded_pas_domain_lift[where f="activate_thread"]
                     guarded_pas_domain_lift[where f="set_scheduler_action f" for f]
                     guarded_switch_to_lift switch_to_thread_guarded_pas_domain
                     next_domain_valid_queues activate_thread_cur_thread gts_wp
-          | wpc
-          | rule choose_thread_guarded_pas_domain
-          | simp add: schedule_choose_new_thread_def ethread_get_when_def split del: if_split
-          | wp (once) hoare_drop_imp[where f="ethread_get t v" for t v]
-          | wp (once) hoare_drop_imp[where f="schedule_switch_thread_fastfail c i cp p" for c i cp p])+
-
-
-
-apply (wp hoare_drop_imp)
-
-apply (wpsimp wp: guarded_pas_domain_lift[where f="activate_thread"]
-                    guarded_pas_domain_lift[where f="set_scheduler_action f" for f]
-                    guarded_switch_to_lift switch_to_thread_guarded_pas_domain
-                    next_domain_valid_queues activate_thread_cur_thread gts_wp
-          | wpc
-          | rule choose_thread_guarded_pas_domain
-          | simp add: schedule_choose_new_thread_def ethread_get_when_def split del: if_split
-          | wp (once) hoare_drop_imp[where f="ethread_get t v" for t v]
-          | wp (once) hoare_drop_imp[where f="schedule_switch_thread_fastfail c i cp p" for c i cp p])+
-
-   apply (fastforce intro: switch_within_domain switch_thread_runnable
+         | wpc
+         | rule choose_thread_guarded_pas_domain
+         | simp add: schedule_choose_new_thread_def ethread_get_when_def split del: if_split
+         | wp (once) hoare_drop_imp[where f="ethread_get t v" for t v]
+         | wp (once) hoare_drop_imp[where f="schedule_switch_thread_fastfail c i cp p" for c i cp p])+
+       apply (wp hoare_drop_imp)
+      apply (wpsimp wp: guarded_pas_domain_lift[where f="activate_thread"]
+                        guarded_pas_domain_lift[where f="set_scheduler_action f" for f]
+                        guarded_switch_to_lift switch_to_thread_guarded_pas_domain
+                        next_domain_valid_queues activate_thread_cur_thread gts_wp
+             | wpc
+             | rule choose_thread_guarded_pas_domain
+             | simp add: schedule_choose_new_thread_def ethread_get_when_def split del: if_split
+             | wp (once) hoare_drop_imp[where f="ethread_get t v" for t v]
+             | wp (once) hoare_drop_imp[where f="schedule_switch_thread_fastfail c i cp p" for c i cp p])+
+  apply (fastforce intro: switch_to_cur_domain switch_thread_runnable
                     simp: valid_sched_def elim!: st_tcb_weakenE)+
   done
 
 lemma schedule_if_guarded_pas_domain[wp]:
   "\<lbrace>guarded_pas_domain aag and einvs and pas_refined aag\<rbrace>
-      schedule_if tc
+   schedule_if tc
    \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
   apply (simp add: schedule_if_def)
   apply (wp schedule_guarded_pas_domain)
   done
 
-lemma schedule_if_ct_running_or_ct_idle[wp]:
-  "\<lbrace>invs\<rbrace>
-      schedule_if tc
-   \<lbrace>\<lambda>_ s. ct_running s \<or> ct_idle s\<rbrace>"
-  apply(simp add: schedule_if_def | wp)+
-   apply(rule hoare_strengthen_post[OF activate_invs] | simp | wp)+
-  done
-
-
-
-lemma set_thread_state_scheduler_action:
-  "\<lbrace>(\<lambda>s. P (scheduler_action (s::det_state))) and st_tcb_at runnable t and K (runnable s)\<rbrace>
-      set_thread_state t s
-   \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
-  apply(simp add: set_thread_state_def | wp sts_ext_running_noop set_object_wp)+
-  apply(clarsimp simp: st_tcb_at_def obj_at_def)
-  done
-
 lemma activate_thread_scheduler_action[wp]:
-  "\<lbrace> \<lambda>s. P (scheduler_action (s::det_state)) \<rbrace> activate_thread \<lbrace> \<lambda>_ s. P (scheduler_action s)\<rbrace>"
-  apply(simp add: activate_thread_def arch_activate_idle_thread_def
-       | wp set_thread_state_scheduler_action gts_wp | wpc)+
-  apply(fastforce elim: st_tcb_weakenE)
+  "activate_thread \<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace>"
+  apply (simp add: activate_thread_def | wp set_thread_state_scheduler_action gts_wp | wpc)+
+  apply (fastforce elim: st_tcb_weakenE)
   done
-
-
-
-declare gts_st_tcb_at[wp del]
 
 lemma schedule_if_scheduler_action[wp]:
-  "\<lbrace>\<top>\<rbrace>
-     schedule_if tc
-   \<lbrace>\<lambda>_ (s::det_state). scheduler_action s = resume_cur_thread\<rbrace>"
-  apply(simp add: schedule_if_def | wp | wpc)+
-  apply(simp add: schedule_def schedule_choose_new_thread_def split del: if_split | wp | wpc)+
+  "\<lbrace>\<top>\<rbrace> schedule_if tc \<lbrace>\<lambda>_ s. scheduler_action s = resume_cur_thread\<rbrace>"
+  apply (simp add: schedule_if_def | wp | wpc)+
+  apply (simp add: schedule_def schedule_choose_new_thread_def split del: if_split | wp | wpc)+
   done
 
-crunch valid_sched[wp]: schedule_if "valid_sched"
+lemma do_user_op_if_only_timer_irq_inv[wp]:
+  "\<lbrace>only_timer_irq_inv irq (st :: det_state)\<rbrace>
+   do_user_op_if uop tc
+   \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
+  apply (rule hoare_pre)
+   apply (wp only_timer_irq_inv_pres | simp | blast)+
+  done
+
+lemma kernel_entry_if_only_timer_irq_inv:
+  "\<lbrace>only_timer_irq_inv irq st and einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
+   kernel_entry_if e tc
+   \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
+   by (wp only_timer_irq_inv_pres kernel_entry_if_irq_masks kernel_entry_if_domain_sep_inv
+       | simp | blast)+
+
+end
+
+
+crunches schedule_if
+  for valid_sched[wp]: valid_sched
+  and valid_list[wp]: valid_list
 
 lemma schedule_if_irq_masks:
   "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
    schedule_if tc
    \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply(simp add: schedule_if_def | wp)+
-  done
-
-crunch valid_list[wp]: schedule_if "valid_list"
+  by (simp add: schedule_if_def | wp)+
 
 
-definition kernel_schedule_if
-  :: "((user_context \<times> det_state) \<times> unit \<times> (user_context \<times> det_state)) set"
-where
-  "kernel_schedule_if \<equiv>
-      {(s, e, s'). s' \<in> fst (split schedule_if s)}"
+definition kernel_schedule_if ::
+  "((user_context \<times> det_state) \<times> unit \<times> (user_context \<times> det_state)) set" where
+  "kernel_schedule_if \<equiv> {(s, e, s'). s' \<in> fst (split schedule_if s)}"
+
 
 subsection \<open>kernel_exit_if\<close>
 
 text \<open>
   Restore the user context
 \<close>
-definition kernel_exit_if
-  :: "user_context \<Rightarrow> (user_context,det_ext) s_monad"
-where
-  "kernel_exit_if tc \<equiv> do
-    t' \<leftarrow> gets cur_thread;
-    thread_get (arch_tcb_context_get o tcb_arch) t'
+definition kernel_exit_if :: "user_context \<Rightarrow> (user_context,det_ext) s_monad" where
+  "kernel_exit_if tc \<equiv>
+   do t' \<leftarrow> gets cur_thread;
+      thread_get (arch_tcb_context_get o tcb_arch) t'
   od"
 
 crunch inv[wp]: kernel_exit_if "P"
 
-definition kernel_exit_A_if
-  :: "((user_context \<times> det_state) \<times> sys_mode \<times> (user_context \<times> det_state)) set"
-where
+definition kernel_exit_A_if ::
+  "((user_context \<times> det_state) \<times> sys_mode \<times> (user_context \<times> det_state)) set" where
   "kernel_exit_A_if \<equiv>
-      {(s, m, s'). s' \<in> fst (split kernel_exit_if s) \<and>
-                   m = (if ct_running (snd s') then InUserMode else InIdleMode)}"
+     {(s, m, s'). s' \<in> fst (split kernel_exit_if s) \<and>
+                  m = (if ct_running (snd s') then InUserMode else InIdleMode)}"
 
 
 subsection \<open>check_active_irq_if\<close>
@@ -1469,9 +1315,8 @@ type_synonym observable_if = "det_state global_sys_state"
 text \<open>
   Check for active IRQs without updating the user context
 \<close>
-definition check_active_irq_if
-  :: "user_context \<Rightarrow> (irq option \<times> user_context, ('z :: state_ext)) s_monad"
-where
+definition check_active_irq_if ::
+  "user_context \<Rightarrow> (irq option \<times> user_context, ('z :: state_ext)) s_monad" where
   "check_active_irq_if tc \<equiv>
    do irq \<leftarrow> do_machine_op (getActiveIRQ False);
       return (irq, tc)
@@ -1479,124 +1324,71 @@ where
 
 subsection \<open>ADT_A_if definition\<close>
 
-definition check_active_irq_A_if
-  :: "((user_context \<times> ('z :: state_ext) state) \<times> irq option \<times>
-        (user_context \<times> ('z :: state_ext) state)) set"
-where
+definition check_active_irq_A_if :: "((user_context \<times> ('z :: state_ext) state) \<times> irq option \<times>
+                                      (user_context \<times> ('z :: state_ext) state)) set" where
   "check_active_irq_A_if \<equiv>
-      {((tc, s), irq, (tc', s')). ((irq, tc'), s') \<in> fst (check_active_irq_if tc s)}"
+     {((tc, s), irq, (tc', s')). ((irq, tc'), s') \<in> fst (check_active_irq_if tc s)}"
 
-abbreviation internal_state_if :: "((MachineTypes.register \<Rightarrow> 32 word) \<times> 'a) \<times> sys_mode \<Rightarrow> 'a"
-where
+abbreviation internal_state_if :: "'a global_sys_state \<Rightarrow> 'a" where
   "internal_state_if \<equiv> \<lambda>s. (snd (fst s))"
-
-lemma valid_device_abs_state_eq:
-  "\<lbrakk>valid_machine_state s\<rbrakk> \<Longrightarrow> abs_state s = s"
-  apply (simp add: abs_state_def observable_memory_def)
-  apply (case_tac s)
-   apply clarsimp
-  apply (case_tac machine_state)
-   apply clarsimp
-  apply (rule ext)
-  apply (fastforce simp: user_mem_def option_to_0_def valid_machine_state_def)
-  done
-
-
 
 
 (*Weakened invs_if to properties only necessary for refinement*)
-definition full_invs_if :: "observable_if set"
-where
+definition full_invs_if :: "observable_if set" where
   "full_invs_if \<equiv>
-    {s. einvs (internal_state_if s) \<and>
-        (snd s \<noteq> KernelSchedule True \<longrightarrow> domain_time (internal_state_if s) > 0) \<and>
-        (domain_time (internal_state_if s) = 0
-           \<longrightarrow> scheduler_action (internal_state_if s) = choose_new_thread) \<and>
-        valid_domain_list (internal_state_if s) \<and>
-        (case (snd s)
-          of (KernelEntry e) \<Rightarrow>
-                (e \<noteq> Interrupt \<longrightarrow> ct_running (internal_state_if s))
-                \<and> (ct_running (internal_state_if s) \<or> ct_idle (internal_state_if s))
-                \<and> scheduler_action (internal_state_if s) = resume_cur_thread
-           | KernelExit \<Rightarrow>
-                (ct_running (internal_state_if s) \<or> ct_idle (internal_state_if s))
-                \<and> scheduler_action (internal_state_if s) = resume_cur_thread
-           | InUserMode \<Rightarrow>
-                ct_running (internal_state_if s)
-                \<and> scheduler_action (internal_state_if s) = resume_cur_thread
-           | InIdleMode \<Rightarrow>
-                ct_idle (internal_state_if s)
-                \<and> scheduler_action (internal_state_if s) = resume_cur_thread
-           | _ \<Rightarrow> True) }"
+     {s. einvs (internal_state_if s) \<and>
+         (snd s \<noteq> KernelSchedule True \<longrightarrow> domain_time (internal_state_if s) > 0) \<and>
+         (domain_time (internal_state_if s) = 0
+          \<longrightarrow> scheduler_action (internal_state_if s) = choose_new_thread) \<and>
+         valid_domain_list (internal_state_if s) \<and>
+         (case (snd s) of
+            KernelEntry e \<Rightarrow> (e \<noteq> Interrupt \<longrightarrow> ct_running (internal_state_if s)) \<and>
+                             (ct_running (internal_state_if s) \<or> ct_idle (internal_state_if s)) \<and>
+                             scheduler_action (internal_state_if s) = resume_cur_thread
+          | KernelExit \<Rightarrow> (ct_running (internal_state_if s) \<or> ct_idle (internal_state_if s)) \<and>
+                          scheduler_action (internal_state_if s) = resume_cur_thread
+          | InUserMode \<Rightarrow> ct_running (internal_state_if s) \<and>
+                          scheduler_action (internal_state_if s) = resume_cur_thread
+          | InIdleMode \<Rightarrow> ct_idle (internal_state_if s) \<and>
+                          scheduler_action (internal_state_if s) = resume_cur_thread
+          | _ \<Rightarrow> True) }"
 
-end
 
 (*We'll define this later, currently it doesn't matter if
   we restrict the permitted steps of the system*)
-consts step_restrict :: "(det_state global_sys_state) \<Rightarrow> bool"
+consts step_restrict :: "det_state global_sys_state \<Rightarrow> bool"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-definition ADT_A_if
-  :: "(user_transition_if) \<Rightarrow> (det_state global_sys_state, observable_if, unit) data_type"
-where
- "ADT_A_if uop \<equiv>
-  \<lparr> Init = \<lambda>s. {s} \<inter> full_invs_if \<inter> {s. step_restrict s}, Fin = id,
-    Step = (\<lambda>u. global_automaton_if check_active_irq_A_if (do_user_op_A_if uop) kernel_call_A_if
-                                    kernel_handle_preemption_if kernel_schedule_if kernel_exit_A_if
-             \<inter> {(s,s'). step_restrict s'})\<rparr>"
-
+definition ADT_A_if ::
+  "user_transition_if \<Rightarrow> (det_state global_sys_state, observable_if, unit) data_type" where
+  "ADT_A_if uop \<equiv>
+     \<lparr>Init = \<lambda>s. {s} \<inter> full_invs_if \<inter> {s. step_restrict s}, Fin = id,
+      Step = (\<lambda>u. global_automaton_if check_active_irq_A_if (do_user_op_A_if uop) kernel_call_A_if
+                                      kernel_handle_preemption_if kernel_schedule_if kernel_exit_A_if
+               \<inter> {(s,s'). step_restrict s'})\<rparr>"
 
 lemma check_active_irq_if_wp:
   "\<lbrace>\<lambda>s. P ((irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s))),tc)
-           (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>)\<rbrace>
-     check_active_irq_if tc
+          (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>)\<rbrace>
+   check_active_irq_if tc
    \<lbrace>P\<rbrace>"
-  apply(simp add: check_active_irq_if_def | wp dmo_getActiveIRQ_wp)+
-  done
-
-
-lemma do_user_op_if_only_timer_irq_inv[wp]:
-  "\<lbrace>only_timer_irq_inv irq (st::det_state)\<rbrace>
-   do_user_op_if a b
-   \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
-  apply(rule hoare_pre)
-   apply(wp only_timer_irq_inv_pres | simp | blast)+
-  done
-
-lemma kernel_entry_if_only_timer_irq_inv:
-  "\<lbrace>only_timer_irq_inv irq st and einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
-   kernel_entry_if e tc
-   \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
-  apply(rule hoare_pre)
-   apply(wp only_timer_irq_inv_pres kernel_entry_if_irq_masks kernel_entry_if_domain_sep_inv
-        | simp)+
-  by blast
+  by (wpsimp wp: dmo_getActiveIRQ_wp simp: check_active_irq_if_def)
 
 lemma handle_preemption_if_only_timer_irq_inv[wp]:
-  "\<lbrace>only_timer_irq_inv irq st\<rbrace>
-   handle_preemption_if tc
-   \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
-  apply(rule hoare_pre)
-   apply(wp only_timer_irq_inv_pres handle_preemption_if_irq_masks
-            handle_preemption_if_domain_sep_inv
-        | simp | blast)+
-  done
+  "handle_preemption_if tc \<lbrace>only_timer_irq_inv irq st\<rbrace>"
+  by (wp only_timer_irq_inv_pres handle_preemption_if_irq_masks handle_preemption_if_domain_sep_inv
+      | simp | blast)+
 
 lemma schedule_if_only_timer_irq_inv[wp]:
-  "\<lbrace>only_timer_irq_inv irq st\<rbrace>
-   schedule_if tc
-   \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
-  apply(rule hoare_pre)
-   apply(wp only_timer_irq_inv_pres schedule_if_irq_masks | blast)+
-  done
+  "schedule_if tc \<lbrace>only_timer_irq_inv irq st\<rbrace>"
+  by (wp only_timer_irq_inv_pres schedule_if_irq_masks | blast)+
+
 
 subsection \<open>Big step IF automaton\<close>
 
 fun interrupted_modes where
-  "interrupted_modes KernelPreempted = True" |
-  "interrupted_modes (KernelEntry Interrupt) = True" |
-  "interrupted_modes _ = False"
+  "interrupted_modes KernelPreempted = True"
+| "interrupted_modes (KernelEntry Interrupt) = True"
+| "interrupted_modes _ = False"
 
 text \<open>
   A first attempt at defining the big steps. They look like this:
@@ -1624,26 +1416,20 @@ text \<open>
   whoever is now the current domain begins its big execution step.
 \<close>
 
-definition big_step_R :: "det_state global_sys_state \<Rightarrow> det_state global_sys_state \<Rightarrow> bool"
-where
-  "big_step_R \<equiv> \<lambda> s s'.
-      (snd s = KernelExit \<and> interrupted_modes (snd s')) \<or>
-      (interrupted_modes (snd s) \<and> snd s' = KernelExit)"
+definition big_step_R :: "det_state global_sys_state \<Rightarrow> det_state global_sys_state \<Rightarrow> bool" where
+  "big_step_R \<equiv> \<lambda>s s'. (snd s = KernelExit \<and> interrupted_modes (snd s'))
+                     \<or> (interrupted_modes (snd s) \<and> snd s' = KernelExit)"
 
-definition big_step_evmap :: "unit list \<Rightarrow> unit"
-where
+definition big_step_evmap :: "unit list \<Rightarrow> unit" where
   "big_step_evmap evs \<equiv> ()"
 
-definition big_step_ADT_A_if
-  :: "user_transition_if \<Rightarrow> (observable_if, observable_if, unit) data_type"
-where
+definition big_step_ADT_A_if ::
+  "user_transition_if \<Rightarrow> (observable_if, observable_if, unit) data_type" where
   "big_step_ADT_A_if utf \<equiv> big_step_adt (ADT_A_if utf) big_step_R big_step_evmap"
 
-definition cur_context
-where
+definition cur_context where
   "cur_context s = arch_tcb_context_get (tcb_arch (the (get_tcb (cur_thread s) s)))"
 
-end
 
 subsection \<open>Locales setup\<close>
 
@@ -1654,72 +1440,64 @@ subsection \<open>Locales setup\<close>
 locale invariant_over_ADT_if =
   fixes det_inv :: "sys_mode \<Rightarrow> user_context \<Rightarrow> det_state \<Rightarrow> bool"
   fixes utf :: "user_transition_if"
-
   assumes det_inv_abs_state:
-     "\<And>e tc s. valid_machine_state s \<Longrightarrow> det_inv e tc s \<Longrightarrow> det_inv e tc (abs_state s)"
-
+    "\<And>e tc s. valid_machine_state s \<Longrightarrow> det_inv e tc s \<Longrightarrow> det_inv e tc (abs_state s)"
   assumes kernel_entry_if_det_inv:
-     "\<And>e tc. \<lbrace>einvs and det_inv (KernelEntry e) tc and ct_running and K (e \<noteq> Interrupt)\<rbrace>
-        kernel_entry_if e tc
-      \<lbrace>\<lambda>rv s. case (fst rv) of Inl irq \<Rightarrow> det_inv KernelPreempted (cur_context s) s
-              | Inr () \<Rightarrow> det_inv (KernelSchedule False) (cur_context s) s\<rbrace>"
+    "\<And>e tc. \<lbrace>einvs and det_inv (KernelEntry e) tc and ct_running and K (e \<noteq> Interrupt)\<rbrace>
+             kernel_entry_if e tc
+             \<lbrace>\<lambda>rv s. case (fst rv) of Inl irq \<Rightarrow> det_inv KernelPreempted (cur_context s) s
+                                    | Inr () \<Rightarrow> det_inv (KernelSchedule False) (cur_context s) s\<rbrace>"
   assumes kernel_entry_if_Interrupt_det_inv:
-     "\<And>tc. \<lbrace>einvs and det_inv (KernelEntry Interrupt) tc and (\<lambda>s. ct_running s \<or> ct_idle s)\<rbrace>
-        kernel_entry_if Interrupt tc
-      \<lbrace>\<lambda>rv s. case (fst rv) of Inl irq \<Rightarrow> det_inv KernelPreempted (cur_context s) s
-              | Inr () \<Rightarrow> det_inv (KernelSchedule True) (cur_context s) s\<rbrace>"
+    "\<And>tc. \<lbrace>einvs and det_inv (KernelEntry Interrupt) tc and (\<lambda>s. ct_running s \<or> ct_idle s)\<rbrace>
+           kernel_entry_if Interrupt tc
+           \<lbrace>\<lambda>rv s. case (fst rv) of Inl irq \<Rightarrow> det_inv KernelPreempted (cur_context s) s
+                                  | Inr () \<Rightarrow> det_inv (KernelSchedule True) (cur_context s) s\<rbrace>"
   assumes handle_preemption_if_det_inv:
-     "\<And>tc. \<lbrace>einvs and (\<lambda>s. det_inv KernelPreempted (cur_context s) s)\<rbrace>
-        handle_preemption_if tc
-      \<lbrace>\<lambda>rv s. det_inv (KernelSchedule True) (cur_context s) s\<rbrace>"
+    "\<And>tc. \<lbrace>einvs and (\<lambda>s. det_inv KernelPreempted (cur_context s) s)\<rbrace>
+           handle_preemption_if tc
+           \<lbrace>\<lambda>rv s. det_inv (KernelSchedule True) (cur_context s) s\<rbrace>"
   assumes schedule_if_det_inv:
-     "\<And>b tc. \<lbrace>einvs and (\<lambda>s. det_inv (KernelSchedule b) (cur_context s) s)\<rbrace>
-        schedule_if tc
-      \<lbrace>\<lambda>rv s. det_inv KernelExit (cur_context s) s\<rbrace>"
+    "\<And>b tc. \<lbrace>einvs and (\<lambda>s. det_inv (KernelSchedule b) (cur_context s) s)\<rbrace>
+             schedule_if tc
+             \<lbrace>\<lambda>rv s. det_inv KernelExit (cur_context s) s\<rbrace>"
   assumes kernel_exit_if_det_inv:
-     "\<And>tc. \<lbrace>einvs and (\<lambda>s. det_inv KernelExit (cur_context s) s) and (\<lambda>s. ct_running s \<or> ct_idle s)\<rbrace>
-        kernel_exit_if tc
-      \<lbrace>\<lambda>rv s. if ct_running s then det_inv InUserMode rv s
-              else det_inv InIdleMode rv s\<rbrace>"
+    "\<And>tc. \<lbrace>einvs and (\<lambda>s. det_inv KernelExit (cur_context s) s) and (\<lambda>s. ct_running s \<or> ct_idle s)\<rbrace>
+           kernel_exit_if tc
+           \<lbrace>\<lambda>rv s. if ct_running s then det_inv InUserMode rv s else det_inv InIdleMode rv s\<rbrace>"
   assumes do_user_op_if_det_inv:
-     "\<And>tc. \<lbrace>einvs and det_inv InUserMode tc and ct_running\<rbrace>
-        do_user_op_if utf tc
-      \<lbrace>\<lambda>rv. case (fst rv) of Some e \<Rightarrow> det_inv (KernelEntry e) (snd rv)
-            | None \<Rightarrow> det_inv InUserMode (snd rv)\<rbrace>"
+    "\<And>tc. \<lbrace>einvs and det_inv InUserMode tc and ct_running\<rbrace>
+           do_user_op_if utf tc
+           \<lbrace>\<lambda>rv. case (fst rv) of Some e \<Rightarrow> det_inv (KernelEntry e) (snd rv)
+                                | None \<Rightarrow> det_inv InUserMode (snd rv)\<rbrace>"
   assumes check_active_irq_if_User_det_inv:
-     "\<And>tc. \<lbrace>einvs and det_inv InUserMode tc and ct_running\<rbrace>
-        check_active_irq_if tc
-      \<lbrace>\<lambda>rv. case (fst rv) of Some irq \<Rightarrow> det_inv (KernelEntry Interrupt) (snd rv)
-            | None \<Rightarrow> det_inv InUserMode (snd rv)\<rbrace>"
+    "\<And>tc. \<lbrace>einvs and det_inv InUserMode tc and ct_running\<rbrace>
+           check_active_irq_if tc
+           \<lbrace>\<lambda>rv. case (fst rv) of Some irq \<Rightarrow> det_inv (KernelEntry Interrupt) (snd rv)
+                                | None \<Rightarrow> det_inv InUserMode (snd rv)\<rbrace>"
   assumes check_active_irq_if_Idle_det_inv:
-     "\<And>tc. \<lbrace>einvs and det_inv InIdleMode tc and ct_idle\<rbrace>
-        check_active_irq_if tc
-      \<lbrace>\<lambda>rv. case (fst rv) of Some irq \<Rightarrow> det_inv (KernelEntry Interrupt) (snd rv)
-            | None \<Rightarrow> det_inv InIdleMode (snd rv)\<rbrace>"
+    "\<And>tc. \<lbrace>einvs and det_inv InIdleMode tc and ct_idle\<rbrace>
+           check_active_irq_if tc
+           \<lbrace>\<lambda>rv. case (fst rv) of Some irq \<Rightarrow> det_inv (KernelEntry Interrupt) (snd rv)
+                                | None \<Rightarrow> det_inv InIdleMode (snd rv)\<rbrace>"
 
-locale valid_initial_state_noenabled = invariant_over_ADT_if + Arch + (* FIXME: arch_split *)
+
+locale valid_initial_state_noenabled = invariant_over_ADT_if + (* FIXME: arch_split *)
   fixes s0_internal :: det_state
   fixes initial_aag :: "'a subject_label PAS"
-  fixes timer_irq :: "10 word"
+  fixes timer_irq :: irq
   fixes current_aag
   fixes s0 :: observable_if
   fixes s0_context :: user_context
   defines
-  "current_aag t \<equiv>
-  (initial_aag\<lparr> pasSubject := the_elem (pasDomainAbs initial_aag (cur_domain t)) \<rparr>)"
-
-(* Run the system from right where we exit the kernel for the first time
-   to user-space.
-   It shouldn't matter what the initial machine context is since the first
-   thing that should happen on a KernelExit is to restore it from the
-   cur_thread *)
-  defines
-  "s0 \<equiv> ((if ct_idle s0_internal then idle_context s0_internal else s0_context,s0_internal),
-          KernelExit)"
+    "current_aag t \<equiv> initial_aag\<lparr>pasSubject := the_elem (pasDomainAbs initial_aag (cur_domain t))\<rparr>"
+  (* Run the system from right where we exit the kernel for the first time to user-space.
+     It shouldn't matter what the initial machine context is since the first
+     thing that should happen on a KernelExit is to restore it from the cur_thread *)
+  defines "s0 \<equiv> ((if ct_idle s0_internal then idle_context s0_internal else s0_context,s0_internal),
+                  KernelExit)"
   assumes cur_domain_subject_s0:
-  "pasSubject initial_aag \<in> pasDomainAbs initial_aag (cur_domain s0_internal)"
-  assumes policy_wellformed:
-  "pas_wellformed_noninterference initial_aag"
+    "pasSubject initial_aag \<in> pasDomainAbs initial_aag (cur_domain s0_internal)"
+  assumes policy_wellformed: "pas_wellformed_noninterference initial_aag"
   fixes Invs
   defines "Invs s \<equiv> einvs s \<and> only_timer_irq_inv timer_irq s0_internal s \<and>
                                silc_inv (current_aag s) s0_internal s \<and>
@@ -1727,223 +1505,139 @@ locale valid_initial_state_noenabled = invariant_over_ADT_if + Arch + (* FIXME: 
                                pas_refined (current_aag s) s \<and>
                                guarded_pas_domain (current_aag s) s \<and>
                                idle_equiv s0_internal s \<and>
-                               valid_domain_list s \<and> valid_pdpt_objs s"
+                               valid_domain_list s \<and> valid_vspace_objs' s"
   assumes Invs_s0_internal: "Invs s0_internal"
   assumes det_inv_s0: "det_inv KernelExit (cur_context s0_internal) s0_internal"
-
   assumes scheduler_action_s0_internal: "scheduler_action s0_internal = resume_cur_thread"
   assumes ct_running_or_ct_idle_s0_internal: "ct_running s0_internal \<or> ct_idle s0_internal"
   assumes domain_time_s0_internal: "domain_time s0_internal > 0"
   assumes num_domains_sanity: "num_domains > 1"
-  assumes utf_det: "\<forall>pl pr pxn tc um ds es s. det_inv InUserMode tc s \<and> einvs s \<and>
-                               context_matches_state pl pr pxn um ds es s \<and> ct_running s
-                               \<longrightarrow> (\<exists>x. utf (cur_thread s) pl pr pxn (tc, um, ds, es) = {x})"
-  assumes utf_non_empty: "\<forall>t pl pr pxn tc um ds es. utf t pl pr pxn (tc, um, ds, es) \<noteq> {}"
-  assumes utf_non_interrupt: "\<forall>t pl pr pxn tc um ds es e f g.
-                                (e,f,g) \<in> utf t pl pr pxn (tc, um, ds, es) \<longrightarrow> e \<noteq> Some Interrupt"
+  assumes utf_det:
+    "\<forall>pl pr pxn tc ms s. det_inv InUserMode tc s \<and> einvs s \<and>
+                               context_matches_state pl pr pxn ms s \<and> ct_running s
+                               \<longrightarrow> (\<exists>x. utf (cur_thread s) pl pr pxn (tc, ms) = {x})"
+  assumes utf_non_empty: "\<forall>t pl pr pxn tc ms. utf t pl pr pxn (tc, ms) \<noteq> {}"
+  assumes utf_non_interrupt: "\<forall>t pl pr pxn tc ms e f g.
+                                (e,f,g) \<in> utf t pl pr pxn (tc, ms) \<longrightarrow> e \<noteq> Some Interrupt"
   assumes extras_s0: "step_restrict s0"
   assumes pasMaySendIrqs_initial_aag[simp]: "pasMaySendIrqs initial_aag = False"
 
 
 locale valid_initial_state = valid_initial_state_noenabled +
-       assumes ADT_A_if_enabled_system: "enabled_system (ADT_A_if utf) s0"
-       assumes ADT_A_if_Init_Fin_serial:
-       "Init_Fin_serial (ADT_A_if utf) s0 (full_invs_if \<inter> {s. step_restrict s})"
+   assumes ADT_A_if_enabled_system:
+     "enabled_system (ADT_A_if utf) s0"
+   assumes ADT_A_if_Init_Fin_serial:
+     "Init_Fin_serial (ADT_A_if utf) s0 (full_invs_if \<inter> {s. step_restrict s})"
 
-subsection \<open>TODO\<close>
-
-function (domintros) next_irq_state :: "nat \<Rightarrow> (10 word \<Rightarrow> bool) \<Rightarrow> nat" where
-  "next_irq_state cur masks =
-         (if irq_at cur masks = None then next_irq_state (Suc cur) masks else cur)"
-  by(pat_completeness, auto)
-
-lemma recurring_next_irq_state_dom:
-  "irq_is_recurring irq s \<Longrightarrow> next_irq_state_dom (n,irq_masks (machine_state s))"
-  apply(clarsimp simp: irq_is_recurring_def)
-  apply(drule_tac x=n in spec)
-  apply(erule exE)
-  proof -
-    fix m
-    assume i: "is_irq_at s irq (n + m)"
-    have "n \<le> n + m" by simp
-    thus "next_irq_state_dom (n, irq_masks (machine_state s))"
-    proof(induct rule: inc_induct)
-      from i obtain irq where a: "irq_at (n + m) (irq_masks (machine_state s)) = Some irq"
-        by(fastforce simp: is_irq_at_def)
-      show "next_irq_state_dom (n + m, irq_masks (machine_state s))"
-        using a by(fastforce intro: next_irq_state.domintros)
-    next
-      fix i
-      assume "next_irq_state_dom (Suc i, irq_masks (machine_state s))"
-      thus "next_irq_state_dom (i, irq_masks (machine_state s))"
-        by(rule next_irq_state.domintros)
-    qed
-  qed
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 subsection \<open>domain_field preserved on non-interrupt kernel event\<close>
 
 crunch irq_state_of_state[wp]: cap_move "\<lambda>s. P (irq_state_of_state s)"
 crunch domain_fields[wp]: handle_yield "domain_fields P"
-crunch domain_fields[wp]: handle_vm_fault, handle_hypervisor_fault "domain_fields P"
-  (ignore: getFAR getDFSR getIFSR)
-
+crunch domain_fields[wp]: activate_thread "domain_fields P"
+crunch domain_list[wp]: kernel_entry_if "\<lambda>s. P (domain_list s)"
+crunch domain_list[wp]: handle_preemption_if "\<lambda>s. P (domain_list s)"
 crunch domain_list[wp]: schedule_if "\<lambda>s. P (domain_list s)"
   (wp: crunch_wps simp: crunch_simps)
-
-crunch domain_fields[wp]: activate_thread "domain_fields P"
-
-lemma next_domain_domain_time_nonzero:
-  "\<lbrace>valid_domain_list\<rbrace> next_domain \<lbrace>\<lambda>r s. domain_time s > 0\<rbrace>"
-  apply(simp add: next_domain_def)
-  apply wp
-  apply(clarsimp simp: Let_def valid_domain_list_2_def)
-  apply(drule_tac x="domain_list s ! (Suc (domain_index s) mod length (domain_list s))" in bspec)
-   apply simp
-  apply(simp split: prod.splits)
-  done
-
-lemma nonzero_gt_zero[simp]:
-  "x \<noteq> (0::word32) \<Longrightarrow> x > 0"
-  apply(rule nonzero_data_to_nat_simp)
-  apply(simp add: unat_gt_0)
-  done
 
 lemma schedule_if_domain_time_nonzero':
   "\<lbrace>valid_domain_list and (\<lambda>s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread)\<rbrace>
    schedule_if tc
    \<lbrace>(\<lambda>_ s. domain_time s > 0)\<rbrace>"
   apply (simp add: schedule_if_def schedule_def)
-  apply (wp next_domain_domain_time_nonzero
-        | wpc | simp add: crunch_simps guarded_switch_to_def switch_to_thread_def
-                              choose_thread_def switch_to_idle_thread_def
-                              arch_switch_to_idle_thread_def)+
-              apply(wp hoare_drop_imps)
-             apply(wp hoare_drop_imps)
+  apply (wpsimp wp: next_domain_domain_time_left
+              simp: crunch_simps guarded_switch_to_def switch_to_thread_def
+                    choose_thread_def switch_to_idle_thread_def)+
+              apply (wp hoare_drop_imps)
+             apply (wp hoare_drop_imps)
             apply wp+
-    apply (simp add: choose_thread_def switch_to_idle_thread_def arch_switch_to_idle_thread_def
-                     guarded_switch_to_def switch_to_thread_def | wp)+
-    apply (wp gts_wp)+
-  apply auto
+    apply (wpsimp simp: choose_thread_def switch_to_idle_thread_def
+                        guarded_switch_to_def switch_to_thread_def
+                    wp: gts_wp)+
+  apply (auto simp: word_neq_0_conv)
   done
 
 lemma schedule_if_domain_time_nonzero:
   "\<lbrace>valid_domain_list and (\<lambda>s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread)\<rbrace>
    schedule_if tc
-   \<lbrace>(\<lambda>_ s. domain_time s \<noteq> 0)\<rbrace>"
-  apply(rule hoare_strengthen_post[OF schedule_if_domain_time_nonzero'])
+   \<lbrace>\<lambda>_ s. domain_time s \<noteq> 0\<rbrace>"
+  apply (rule hoare_strengthen_post[OF schedule_if_domain_time_nonzero'])
   apply simp
   done
 
+
+context ADT_IF_1 begin
+
 lemma handle_event_domain_fields:
   notes hy_inv[wp del]
-  shows
-  "\<lbrace>domain_fields P and K (e \<noteq> Interrupt)\<rbrace>
-   handle_event e
-   \<lbrace>\<lambda>_. domain_fields P\<rbrace>"
-  apply(rule hoare_gen_asm)
-  apply(rule hoare_pre)
-  apply(case_tac e)
-       apply(rename_tac syscall)
-       apply(case_tac syscall)
-             apply(wp | simp add: handle_call_def)+
+  shows "\<lbrace>domain_fields P and K (e \<noteq> Interrupt)\<rbrace>
+         handle_event e
+         \<lbrace>\<lambda>_. domain_fields P\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (rule hoare_pre)
+   apply (case_tac e)
+        apply (rename_tac syscall)
+        apply (case_tac syscall)
+               apply (wp | simp add: handle_call_def)+
   done
-
-crunch domain_list[wp]: kernel_entry_if "\<lambda>s. P (domain_list s)"
-crunch domain_list[wp]: handle_preemption_if "\<lambda>s. P (domain_list s)"
-
 
 lemma kernel_entry_if_domain_fields:
   "\<lbrace>domain_fields P and K (e \<noteq> Interrupt)\<rbrace>
    kernel_entry_if e tc
    \<lbrace>\<lambda>_. domain_fields P\<rbrace>"
-  apply(simp add: kernel_entry_if_def)
-  apply(wp handle_event_domain_fields | simp)+
-  done
-
-subsection \<open>to split generic preservation lemma\<close>
-
-lemma hoare_vcg_imp_lift':
-   "\<lbrace>P'\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>
-        \<Longrightarrow> \<lbrace>\<lambda>s. P' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>"
-  apply(auto simp: valid_def)
-  done
-
-lemma timer_tick_domain_time_sched_action:
-  "num_domains > 1 \<Longrightarrow>
-   \<lbrace> \<top> \<rbrace>
-   timer_tick
-   \<lbrace>\<lambda>r s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
-  apply(simp add: timer_tick_def reschedule_required_def   | wp | wpc)+
-  done
-
-lemma gt_zero_nonzero[simp]:
-  "(0::word32) < x \<Longrightarrow> x \<noteq> 0"
-  by (metis word_not_simps(1))
-
-lemma handle_interrupt_domain_time_sched_action:
-  "num_domains > 1 \<Longrightarrow>
-   \<lbrace>\<lambda>s. domain_time s > 0\<rbrace>
-   handle_interrupt e
-   \<lbrace>\<lambda>r s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
-  apply(simp add: handle_interrupt_def split del: if_split)
-  apply (rule hoare_pre)
-  apply (wp)
-   apply(case_tac "st \<noteq> IRQTimer")
-    apply(( wp hoare_vcg_imp_lift'
-          | simp add: handle_reserved_irq_def
-          | wpc)+)[1]
-   apply((wp timer_tick_domain_time_sched_action | simp)+)[1]
-  apply(wp| simp add: get_irq_state_def)+
+  apply (simp add: kernel_entry_if_def)
+  apply (wp handle_event_domain_fields | simp)+
   done
 
 lemma kernel_entry_if_domain_time_sched_action:
-  "num_domains > 1 \<Longrightarrow>
-   \<lbrace>\<lambda>s. domain_time s > 0\<rbrace>
-   kernel_entry_if e tc
-   \<lbrace>\<lambda>_ s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
-  apply(case_tac "e = Interrupt")
+  "num_domains > 1
+   \<Longrightarrow> \<lbrace>\<lambda>s. domain_time s > 0\<rbrace>
+       kernel_entry_if e tc
+       \<lbrace>\<lambda>_ s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
+  apply (case_tac "e = Interrupt")
    apply (simp add: kernel_entry_if_def)
-   apply (wp handle_interrupt_domain_time_sched_action| wpc | simp)+
-     apply(rule_tac Q="\<lambda>r s. domain_time s > 0" in hoare_strengthen_post)
-      apply (wp | simp)+
-  apply(wp hoare_vcg_imp_lift' kernel_entry_if_domain_fields | simp)+
+   apply (wp handle_interrupt_valid_domain_time| wpc | simp)+
+      apply (rule_tac Q="\<lambda>r s. domain_time s > 0" in hoare_strengthen_post)
+       apply (wp | simp)+
+      apply (wp hoare_false_imp kernel_entry_if_domain_fields | fastforce)+
   done
+
+end
+
+
+subsection \<open>to split generic preservation lemma\<close>
 
 lemma handle_preemption_if_domain_time_sched_action:
-  "num_domains > 1 \<Longrightarrow>
-   \<lbrace>\<lambda>s. domain_time s > 0\<rbrace>
-   handle_preemption_if tc
-   \<lbrace>\<lambda>_ s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
-   apply (simp add: handle_preemption_if_def)
-   apply (wp handle_interrupt_domain_time_sched_action| wpc | simp)+
-     apply(rule_tac Q="\<lambda>r s. domain_time s > 0" in hoare_strengthen_post)
-      apply (wp | simp)+
+  "num_domains > 1
+   \<Longrightarrow> \<lbrace>\<lambda>s. domain_time s > 0\<rbrace>
+       handle_preemption_if tc
+       \<lbrace>\<lambda>_ s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
+  apply (simp add: handle_preemption_if_def)
+  apply (wp handle_interrupt_valid_domain_time| wpc | simp)+
+   apply (rule_tac Q="\<lambda>r s. domain_time s > 0" in hoare_strengthen_post)
+    apply (wp | fastforce)+
   done
 
-definition user_context_of :: "'k global_sys_state \<Rightarrow> user_context"
-where
+definition user_context_of :: "'k global_sys_state \<Rightarrow> user_context" where
   "user_context_of \<equiv> \<lambda>s. fst (fst s)"
 
 lemma user_context_of_simp[simp]:
   "user_context_of ((uc,s),mode) = uc"
-  by(simp add: user_context_of_def)
+  by (simp add: user_context_of_def)
 
-definition sys_mode_of :: "'k global_sys_state \<Rightarrow> sys_mode"
-where
+definition sys_mode_of :: "'k global_sys_state \<Rightarrow> sys_mode" where
   "sys_mode_of \<equiv> \<lambda>s. snd s"
 
 lemma sys_mode_of_simp[simp]:
   "sys_mode_of ((uc,s),mode) = mode"
-  by(simp add: sys_mode_of_def)
+  by (simp add: sys_mode_of_def)
 
 lemma exit_idle_context:
   "\<lbrace>ct_idle and invs\<rbrace> kernel_exit_if tc' \<lbrace>\<lambda>tc s. tc = idle_context s\<rbrace>"
   apply (simp add: kernel_exit_if_def thread_get_def)
   apply wp
   apply (subgoal_tac "cur_thread s = idle_thread s")
-  apply (clarsimp simp: cur_thread_idle idle_context_def)+
+   apply (clarsimp simp: cur_thread_idle idle_context_def)+
   done
 
 lemma check_active_irq_context:
@@ -1966,86 +1660,52 @@ lemma handle_preemption_context:
 
 lemma get_tcb_machine_stat_update[simp]:
   "get_tcb t (s\<lparr>machine_state := x\<rparr>) = get_tcb t s"
-  apply (simp add: get_tcb_def)
-  done
+  by (simp add: get_tcb_def)
 
 lemma handle_preemption_globals_equiv[wp]:
   "\<lbrace>globals_equiv st and invs\<rbrace>
-      handle_preemption_if a
+   handle_preemption_if a
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (simp add: handle_preemption_if_def)
   apply (wp handle_interrupt_globals_equiv dmo_getActiveIRQ_globals_equiv crunch_wps
-        | simp add: crunch_simps)+
+         | simp add: crunch_simps)+
   done
-
-lemmas handle_preemption_idle_equiv[wp] =
-             idle_globals_lift[OF handle_preemption_globals_equiv
-                                  invs_pd_not_idle_thread,
-                               simplified]
 
 lemma schedule_if_globals_equiv_scheduler[wp]:
-  "\<lbrace>globals_equiv_scheduler st and invs\<rbrace> schedule_if tc \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
+  "\<lbrace>globals_equiv_scheduler st and invs\<rbrace>
+   schedule_if tc
+   \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
   apply (simp add: schedule_if_def)
   apply wp
-  apply (wp globals_equiv_scheduler_inv'[where P="invs"] activate_thread_globals_equiv)
-  apply (simp add: invs_valid_ko_at_arm invs_valid_idle)
-  apply (wp | simp)+
-  done
-
-lemmas schedule_if_idle_equiv[wp] =
-            idle_globals_lift_scheduler[OF schedule_if_globals_equiv_scheduler
-                                           invs_pd_not_idle_thread,
-                                        simplified]
-
-lemma not_in_global_refs_vs_lookup:
-  "\<lbrakk>(\<exists>\<unrhd>p) s; valid_vs_lookup s; valid_global_refs s;
-    valid_arch_state s; valid_global_objs s\<rbrakk> \<Longrightarrow>
-   p \<notin> global_refs s"
-  apply (clarsimp dest!: valid_vs_lookupD)
-  apply (drule(1) valid_global_refsD2)
-  apply (simp add: cap_range_def)
-  apply blast
-  done
-
-lemma ptrFromPAddr_add_helper:
-  "ptrFromPAddr (a + b) = ptrFromPAddr a + b"
-  apply(simp add: ptrFromPAddr_def)
+    apply (wp globals_equiv_scheduler_inv'[where P="invs"] activate_thread_globals_equiv)
+    apply (simp add: invs_valid_ko_at_arch invs_valid_idle)
+   apply (wp | simp)+
   done
 
 lemma dmo_user_memory_update_idle_equiv:
-  "\<lbrace>idle_equiv st\<rbrace> do_machine_op (user_memory_update um) \<lbrace>\<lambda>y. idle_equiv st\<rbrace>"
+  "\<lbrace>idle_equiv st\<rbrace> do_machine_op (user_memory_update um) \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
   by (wpsimp wp: dmo_wp)
 
 lemma dmo_device_memory_update_idle_equiv:
-  "\<lbrace>idle_equiv st\<rbrace> do_machine_op (device_memory_update um) \<lbrace>\<lambda>y. idle_equiv st\<rbrace>"
+  "\<lbrace>idle_equiv st\<rbrace> do_machine_op (device_memory_update um) \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
   by (wpsimp wp: dmo_wp)
-
-lemma do_user_op_if_idle_equiv[wp]:
-  "\<lbrace>idle_equiv st and invs\<rbrace>
-   do_user_op_if tc uop
-   \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
-  unfolding do_user_op_if_def
-  by (wpsimp wp: dmo_user_memory_update_idle_equiv dmo_device_memory_update_idle_equiv select_wp)
 
 lemma ct_active_not_idle':
   "ct_active s \<Longrightarrow> \<not> ct_idle s"
-  apply (clarsimp simp add: ct_in_state_def st_tcb_at_def obj_at_def)
-  done
+  by (clarsimp simp add: ct_in_state_def st_tcb_at_def obj_at_def)
 
 lemma Init_Fin_serial_weak_strengthen:
-  "\<lbrakk>Init_Fin_serial_weak A s0 I; A [> J; J \<subseteq> I; Init A s0 \<subseteq> J\<rbrakk> \<Longrightarrow> Init_Fin_serial_weak A s0 J"
+  "\<lbrakk> Init_Fin_serial_weak A s0 I; A [> J; J \<subseteq> I; Init A s0 \<subseteq> J \<rbrakk>
+     \<Longrightarrow> Init_Fin_serial_weak A s0 J"
   by (force simp: Init_Fin_serial_weak_def serial_system_weak_def Init_Fin_serial_weak_axioms_def)
 
 lemma rel_terminate_weaken:
-  "rel_terminate A s0 R I measuref \<Longrightarrow> J \<subseteq> I \<Longrightarrow> rel_terminate A s0 R J measuref"
+  "\<lbrakk> rel_terminate A s0 R I measuref; J \<subseteq> I \<rbrakk>
+     \<Longrightarrow> rel_terminate A s0 R J measuref"
   by (force simp: rel_terminate_def)
-
-end
 
 
 context valid_initial_state begin
-
-interpretation Arch . (*FIXME arch_split*)
 
 lemma domains_distinct:
   "pas_domains_distinct initial_aag"
@@ -2056,96 +1716,79 @@ lemma domains_distinct:
 lemma current_domains_distinct:
   "pas_domains_distinct (current_aag s)"
   using domains_distinct
-  apply (simp add: current_aag_def pas_domains_distinct_def)
-  done
+  by (simp add: current_aag_def pas_domains_distinct_def)
 
 lemmas the_subject_of_aag_domain = domain_has_the_label[OF domains_distinct]
 
 lemma current_aag_initial:
   "current_aag s0_internal = initial_aag"
-  apply (simp add: current_aag_def the_subject_of_aag_domain cur_domain_subject_s0)
-  done
+  by (simp add: current_aag_def the_subject_of_aag_domain cur_domain_subject_s0)
 
 subsection \<open>@{term ADT_A_if} is a step system with the invs_if invariant\<close>
 
-definition cur_thread_context_of :: "observable_if \<Rightarrow> user_context"
-where
+definition cur_thread_context_of :: "observable_if \<Rightarrow> user_context" where
   "cur_thread_context_of \<equiv>
-     \<lambda>s. case sys_mode_of s of
-           InUserMode \<Rightarrow> user_context_of s
-         | InIdleMode \<Rightarrow> user_context_of s
-         | KernelEntry e \<Rightarrow> user_context_of s
-         | _ \<Rightarrow> cur_context (internal_state_if s)"
+     \<lambda>s. case sys_mode_of s of InUserMode \<Rightarrow> user_context_of s
+                             | InIdleMode \<Rightarrow> user_context_of s
+                             | KernelEntry e \<Rightarrow> user_context_of s
+                             | _ \<Rightarrow> cur_context (internal_state_if s)"
 
-definition invs_if :: "observable_if \<Rightarrow> bool"
-where
+definition invs_if :: "observable_if \<Rightarrow> bool" where
   "invs_if s \<equiv>
-    Invs (internal_state_if s) \<and>
-    det_inv (sys_mode_of s) (cur_thread_context_of s) (internal_state_if s) \<and>
-    (snd s \<noteq> KernelSchedule True \<longrightarrow> domain_time (internal_state_if s) > 0) \<and>
-    (domain_time (internal_state_if s) = 0
-       \<longrightarrow> scheduler_action (internal_state_if s) = choose_new_thread) \<and>
-    (snd s \<noteq> KernelExit
-       \<longrightarrow> (ct_idle (internal_state_if s)
-             \<longrightarrow> user_context_of s = idle_context (internal_state_if s))) \<and>
-    (case (snd s)
-      of KernelEntry e \<Rightarrow>
-                     (e \<noteq> Interrupt \<longrightarrow> ct_running (internal_state_if s)) \<and>
-                     (ct_running (internal_state_if s) \<or> ct_idle (internal_state_if s)) \<and>
-                     scheduler_action (internal_state_if s) = resume_cur_thread
-        | KernelExit \<Rightarrow>
-                     (ct_running (internal_state_if s) \<or> ct_idle (internal_state_if s)) \<and>
-                     scheduler_action (internal_state_if s) = resume_cur_thread
-        | InUserMode \<Rightarrow>
-                     ct_running (internal_state_if s) \<and>
-                     scheduler_action (internal_state_if s) = resume_cur_thread
-        | InIdleMode \<Rightarrow>
-                     ct_idle (internal_state_if s) \<and>
-                     scheduler_action (internal_state_if s) = resume_cur_thread
-        | _ \<Rightarrow> True)"
+     Invs (internal_state_if s) \<and>
+     det_inv (sys_mode_of s) (cur_thread_context_of s) (internal_state_if s) \<and>
+     (snd s \<noteq> KernelSchedule True \<longrightarrow> domain_time (internal_state_if s) > 0) \<and>
+     (domain_time (internal_state_if s) = 0
+      \<longrightarrow> scheduler_action (internal_state_if s) = choose_new_thread) \<and>
+     (snd s \<noteq> KernelExit
+      \<longrightarrow> (ct_idle (internal_state_if s)
+      \<longrightarrow> user_context_of s = idle_context (internal_state_if s))) \<and>
+     (case (snd s) of
+        KernelEntry e \<Rightarrow> (e \<noteq> Interrupt \<longrightarrow> ct_running (internal_state_if s)) \<and>
+                         (ct_running (internal_state_if s) \<or> ct_idle (internal_state_if s)) \<and>
+                         scheduler_action (internal_state_if s) = resume_cur_thread
+      | KernelExit \<Rightarrow> (ct_running (internal_state_if s) \<or> ct_idle (internal_state_if s)) \<and>
+                      scheduler_action (internal_state_if s) = resume_cur_thread
+      | InUserMode \<Rightarrow> ct_running (internal_state_if s) \<and>
+                      scheduler_action (internal_state_if s) = resume_cur_thread
+      | InIdleMode \<Rightarrow> ct_idle (internal_state_if s) \<and>
+                      scheduler_action (internal_state_if s) = resume_cur_thread
+      | _ \<Rightarrow> True)"
 
 lemma invs_if_s0[simp]:
   "invs_if s0"
-  apply(clarsimp simp: s0_def invs_if_def Invs_s0_internal[simplified]
-                       ct_running_or_ct_idle_s0_internal domain_time_s0_internal
-                       det_inv_s0 cur_thread_context_of_def)
-  apply(simp add: scheduler_action_s0_internal)
-  done
+  apply (clarsimp simp: s0_def invs_if_def Invs_s0_internal[simplified]
+                        ct_running_or_ct_idle_s0_internal domain_time_s0_internal
+                        det_inv_s0 cur_thread_context_of_def scheduler_action_s0_internal)
+  using domain_time_s0_internal by fastforce
 
 lemma only_timer_irq_inv_irq_state_update[simp]:
   "only_timer_irq_inv timer_irq s0_internal
-           (b\<lparr>machine_state := machine_state b
-                \<lparr>irq_state := Suc (irq_state (machine_state b))\<rparr>\<rparr>) =
+     (b\<lparr>machine_state := machine_state b\<lparr>irq_state := Suc (irq_state (machine_state b))\<rparr>\<rparr>) =
    only_timer_irq_inv timer_irq s0_internal b"
-  apply(clarsimp simp: only_timer_irq_inv_def only_timer_irq_def irq_is_recurring_def
-        is_irq_at_def)
-  done
+  by (clarsimp simp: only_timer_irq_inv_def only_timer_irq_def irq_is_recurring_def is_irq_at_def)
 
 lemma initial_aag_bak:
-  "initial_aag = (current_aag s)\<lparr>pasSubject := the_elem (pasDomainAbs (current_aag s) (cur_domain s0_internal))\<rparr>"
-  using current_aag_def cur_domain_subject_s0 the_subject_of_aag_domain
-  by simp
+  "initial_aag =
+   (current_aag s)\<lparr>pasSubject := the_elem (pasDomainAbs (current_aag s) (cur_domain s0_internal))\<rparr>"
+  using current_aag_def cur_domain_subject_s0 the_subject_of_aag_domain by simp
 
 (* By our locale assumptions, every domain has an associated label *)
 lemma the_label_of_domain_exists[intro, simp]:
   "the_elem (pasDomainAbs initial_aag l) \<in> pasDomainAbs initial_aag l"
-  using domains_distinct[simplified pas_domains_distinct_def] the_subject_of_aag_domain
-  apply blast
-  done
+  using domains_distinct[simplified pas_domains_distinct_def] the_subject_of_aag_domain by blast
 
 (* Corollary for current_aag *)
 lemma pas_cur_domain_current_aag:
   "pas_cur_domain (current_aag s) s"
-  apply (simp add: current_aag_def)
-  done
+  by (simp add: current_aag_def)
 
 lemma subject_current_aag:
   "pasSubject (current_aag s) \<in> pasDomainAbs initial_aag (cur_domain s)"
-  apply (simp add: current_aag_def)
-  done
+  by (simp add: current_aag_def)
 
 lemma pas_wellformed_cur[iff]:
- "pas_wellformed_noninterference (current_aag s)"
+  "pas_wellformed_noninterference (current_aag s)"
   apply (cut_tac policy_wellformed)
   apply (simp add: pas_wellformed_noninterference_def current_aag_def pas_domains_distinct_def)
   done
@@ -2153,8 +1796,8 @@ lemma pas_wellformed_cur[iff]:
 declare policy_wellformed[iff]
 
 lemma current_aag_lift:
-  assumes b: "(\<And>aag. \<lbrace>P aag\<rbrace> f \<lbrace>\<lambda>r s. Q aag r s\<rbrace>)"
-  assumes a: "(\<And>P. \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> f \<lbrace>\<lambda>r s. P (cur_domain s)\<rbrace>)"
+  assumes b: "\<And>aag. \<lbrace>P aag\<rbrace> f \<lbrace>\<lambda>r s. Q aag r s\<rbrace>"
+  assumes a: "\<And>P. \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> f \<lbrace>\<lambda>r s. P (cur_domain s)\<rbrace>"
   shows "\<lbrace>\<lambda>s. P (current_aag s) s\<rbrace> f \<lbrace>\<lambda>r s. Q (current_aag s) r s\<rbrace>"
   apply (simp add: current_aag_def)
   apply (rule hoare_lift_Pf3[where f="cur_domain", OF b a])
@@ -2194,55 +1837,45 @@ lemma pas_refined_cur:
     apply blast+
   done
 
-lemma pas_cur_domain_cur:
-  "pas_cur_domain initial_aag s \<Longrightarrow> pas_cur_domain (current_aag s) s"
-  using subject_current_aag current_aag_def
-  by auto
-
 lemma pasObjectAbs_current_aag:
   "pasObjectAbs (current_aag x) = pasObjectAbs initial_aag"
-  by(simp add: current_aag_def)
+  by (simp add: current_aag_def)
 
 lemma pasIRQAbs_current_aag:
   "pasIRQAbs (current_aag x) = pasIRQAbs initial_aag"
-  by(simp add: current_aag_def)
+  by (simp add: current_aag_def)
 
 lemma pasASIDAbs_current_aag:
   "pasASIDAbs (current_aag x) = pasASIDAbs initial_aag"
-  by(simp add: current_aag_def)
+  by (simp add: current_aag_def)
 
 lemma pasPolicy_current_aag:
   "pasPolicy (current_aag x) = pasPolicy initial_aag"
-  by(simp add: current_aag_def)
-
-
+  by (simp add: current_aag_def)
 
 lemma guarded_pas_is_subject_current_aag:
-  "\<lbrakk>guarded_pas_domain (current_aag s) s; invs s\<rbrakk> \<Longrightarrow>
-   ct_active s \<longrightarrow> is_subject (current_aag s) (cur_thread s)"
+  "\<lbrakk> guarded_pas_domain (current_aag s) s; invs s \<rbrakk>
+     \<Longrightarrow> ct_active s \<longrightarrow> is_subject (current_aag s) (cur_thread s)"
   apply (clarsimp simp add: guarded_pas_domain_def current_aag_def)
   apply (rule sym)
-  apply (blast intro: the_elemI dest: domains_distinct[THEN pas_domains_distinct_inj] ct_active_not_idle)
-  done
-
-lemma guarded_pas_domain_machine_state_update[simp]:
-  "guarded_pas_domain aag (s\<lparr>machine_state := x\<rparr>) = guarded_pas_domain aag s"
-  apply (simp add: guarded_pas_domain_def)
+  apply (blast intro: the_elemI
+                dest: domains_distinct[THEN pas_domains_distinct_inj] ct_active_not_idle)
   done
 
 lemma handle_event_was_not_Interrupt:
   "\<lbrace>\<top>\<rbrace> handle_event e -,\<lbrace>\<lambda> r s. e \<noteq> Interrupt\<rbrace>"
-  apply(case_tac e)
-  apply(simp | wp | wpc)+
+  apply (case_tac e)
+  apply (simp | wp | wpc)+
   done
 
 lemma kernel_entry_if_was_not_Interrupt:
-  "\<lbrakk>(x, ba) \<in> fst (kernel_entry_if e a b)\<rbrakk> \<Longrightarrow> (case fst x of Inr a \<Rightarrow> True | _ \<Rightarrow>  e \<noteq> Interrupt)"
-  apply(simp add: kernel_entry_if_def)
-  apply(erule use_valid)
+  "(x, ba) \<in> fst (kernel_entry_if e a b)
+   \<Longrightarrow> (case fst x of Inr a \<Rightarrow> True | _ \<Rightarrow>  e \<noteq> Interrupt)"
+  apply (simp add: kernel_entry_if_def)
+  apply (erule use_valid)
    apply wp
      apply simp
-     apply(rule handle_event_was_not_Interrupt[simplified validE_E_def validE_def])
+     apply (rule handle_event_was_not_Interrupt[simplified validE_E_def validE_def])
     apply wpsimp+
   done
 
@@ -2261,28 +1894,16 @@ lemma ct_idle_lift:
   done
 
 lemma idle_equiv_context_equiv:
-  "idle_equiv s s' \<Longrightarrow> invs s' \<Longrightarrow> idle_context s' = idle_context s"
-  apply (clarsimp simp add: idle_equiv_def idle_context_def invs_def valid_state_def
-                            valid_idle_def)
+  "\<lbrakk> idle_equiv s s'; invs s' \<rbrakk> \<Longrightarrow> idle_context s' = idle_context s"
+  apply (clarsimp simp: idle_equiv_def idle_context_def invs_def valid_state_def valid_idle_def)
   apply (drule pred_tcb_at_tcb_at)
-  apply (clarsimp simp add: tcb_at_def2 get_tcb_def)
-  done
-
-lemma kernel_entry_if_valid_pdpt_objs[wp]:
- "\<lbrace>valid_pdpt_objs and invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
-     kernel_entry_if e tc
-  \<lbrace>\<lambda>s. valid_pdpt_objs\<rbrace>"
-  apply (case_tac "e = Interrupt")
-   apply (simp add: kernel_entry_if_def)
-   apply (wp|wpc|simp add: kernel_entry_if_def)+
-  apply (wpsimp simp: ran_tcb_cap_cases arch_tcb_update_aux2
-         wp: static_imp_wp thread_set_invs_trivial)+
+  apply (clarsimp simp: tcb_at_def2 get_tcb_def)
   done
 
 lemma kernel_entry_if_det_inv':
-  "\<lbrace>einvs and det_inv (KernelEntry e) tc and (\<lambda>s. ct_running s \<or> ct_idle s) and
-        (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s)\<rbrace>
-      kernel_entry_if e tc
+  "\<lbrace>einvs and det_inv (KernelEntry e) tc and (\<lambda>s. ct_running s \<or> ct_idle s)
+                                         and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s)\<rbrace>
+   kernel_entry_if e tc
    \<lbrace>\<lambda>rv s. det_inv (case (fst rv) of Inl irq \<Rightarrow> KernelPreempted
                                    | Inr () \<Rightarrow> KernelSchedule (e = Interrupt)) (cur_context s) s\<rbrace>"
   apply (case_tac "e = Interrupt")
@@ -2297,62 +1918,60 @@ lemma kernel_entry_if_det_inv':
 
 lemma pasMaySendIrqs_current_aag[simp]:
   "pasMaySendIrqs (current_aag s) = False"
-  apply(simp add: current_aag_def)
-  done
+  by (simp add: current_aag_def)
 
-lemma handle_preemption_if_valid_pdpt_objs[wp]:
-  "\<lbrace>valid_pdpt_objs\<rbrace> handle_preemption_if a \<lbrace>\<lambda>rv s. valid_pdpt_objs s\<rbrace>"
-  by (simp add: handle_preemption_if_def | wp)+
+end
 
-lemma schedule_if_valid_pdpt_objs[wp]:
-  "\<lbrace>valid_pdpt_objs\<rbrace> schedule_if a \<lbrace>\<lambda>rv s. valid_pdpt_objs s\<rbrace>"
-  by (simp add: schedule_if_def | wp)+
 
-lemma do_user_op_if_valid_pdpt_objs[wp]:
-  "\<lbrace>valid_pdpt_objs\<rbrace> do_user_op_if a b \<lbrace>\<lambda>rv s. valid_pdpt_objs s\<rbrace>"
-  by (simp add: do_user_op_if_def | wp select_wp | wpc)+
+lemma Fin_ADT_if:
+  "Fin (ADT_A_if utf) = id"
+  by (simp add: ADT_A_if_def)
+
+lemma Init_ADT_if:
+  "Init (ADT_A_if utf) = (\<lambda>s. {s} \<inter> full_invs_if \<inter> {s. step_restrict s})"
+  by (simp add: ADT_A_if_def)
+
+
+locale ADT_valid_initial_state =
+  ADT_IF_1 initial_aag + valid_initial_state _ _ _ initial_aag for initial_aag
+begin
 
 lemma invs_if_Step_ADT_A_if:
   notes active_from_running[simp]
-  shows
-  "\<lbrakk>invs_if s; (s,t) \<in> data_type.Step (ADT_A_if utf) e\<rbrakk> \<Longrightarrow> invs_if t"
-  apply(clarsimp simp: ADT_A_if_def global_automaton_if_def invs_if_def Invs_def
-                       cur_thread_context_of_def
-       | rule guarded_active_ct_cur_domain
-       | clarify )+
+  shows "\<lbrakk> invs_if s; (s,t) \<in> Step (ADT_A_if utf) e \<rbrakk> \<Longrightarrow> invs_if t"
+  apply (clarsimp simp: ADT_A_if_def global_automaton_if_def
+                        invs_if_def Invs_def cur_thread_context_of_def
+         | rule guarded_active_ct_cur_domain)+
   apply (elim disjE)
-           apply(clarsimp simp: kernel_call_A_if_def)
+           apply (clarsimp simp: kernel_call_A_if_def)
            apply (frule kernel_entry_if_was_not_Interrupt)
            apply (frule use_valid[OF _ kernel_entry_if_det_inv])
             apply simp
            apply simp
-           apply(erule use_valid)
+           apply (erule use_valid)
             apply (rule current_aag_lift)
-             apply(wp kernel_entry_if_invs kernel_entry_silc_inv[where st'=s0_internal]
-                      kernel_entry_pas_refined[where st=s0_internal]
-                      kernel_entry_if_valid_sched kernel_entry_if_only_timer_irq_inv
-                      kernel_entry_if_domain_sep_inv kernel_entry_if_guarded_pas_domain
-                      kernel_entry_if_domain_fields
-                      kernel_entry_if_idle_equiv
-                      kernel_entry_if_domain_time_sched_action[OF num_domains_sanity]
-                      hoare_vcg_imp_lift'
-                      ct_idle_lift
-                  | clarsimp intro!: guarded_pas_is_subject_current_aag[rule_format]
-                  | intro conjI)+
+             apply (wp kernel_entry_if_invs kernel_entry_silc_inv[where st'=s0_internal]
+                       kernel_entry_pas_refined[where st=s0_internal]
+                       kernel_entry_if_valid_sched kernel_entry_if_only_timer_irq_inv
+                       kernel_entry_if_domain_sep_inv kernel_entry_if_guarded_pas_domain
+                       kernel_entry_if_domain_fields kernel_entry_if_idle_equiv
+                       kernel_entry_if_domain_time_sched_action[OF num_domains_sanity]
+                       hoare_false_imp ct_idle_lift
+                    | clarsimp intro!: guarded_pas_is_subject_current_aag[rule_format]
+                    | intro conjI)+
               apply (rule guarded_pas_is_subject_current_aag[rule_format],assumption+)
               apply (simp add: schact_is_rct_def)+
             apply (rule guarded_pas_is_subject_current_aag[rule_format],assumption+)
-            apply(simp add: ct_active_not_idle' | elim exE)+
-
-          apply(simp add: kernel_call_A_if_def | elim exE conjE)+
+            apply (simp add: ct_active_not_idle' | elim exE)+
+          apply (simp add: kernel_call_A_if_def | elim exE conjE)+
           apply (rule context_conjI)
-          apply(erule use_valid)
-          apply (rule kernel_entry_if_invs,simp)
+           apply (erule use_valid)
+            apply (rule kernel_entry_if_invs,simp)
           apply (subgoal_tac "idle_equiv s0_internal ba")
-          prefer 2
-          apply (erule use_valid)
-          apply (rule kernel_entry_if_idle_equiv)
-          apply simp
+           prefer 2
+           apply (erule use_valid)
+            apply (rule kernel_entry_if_idle_equiv)
+           apply simp
           apply (simp add: idle_equiv_context_equiv)
           apply (frule use_valid[OF _ kernel_entry_context],simp)
           apply (frule use_valid[OF _ kernel_entry_if_det_inv'])
@@ -2360,51 +1979,48 @@ lemma invs_if_Step_ADT_A_if:
           apply (simp split: unit.splits)
           apply (erule use_valid)
            apply (rule current_aag_lift)
-            apply(wp hoare_vcg_const_imp_lift kernel_entry_if_invs
-                     kernel_entry_silc_inv[where st'=s0_internal]
-                     kernel_entry_pas_refined[where st=s0_internal]
-                     kernel_entry_if_valid_sched kernel_entry_if_only_timer_irq_inv
-                     kernel_entry_if_domain_sep_inv kernel_entry_if_guarded_pas_domain
-                     kernel_entry_if_domain_time_sched_action[OF num_domains_sanity]
-                     ct_idle_lift
-                 | clarsimp intro: guarded_pas_is_subject_current_aag
-                 | wp kernel_entry_if_domain_fields)+
+            apply (wp hoare_vcg_const_imp_lift kernel_entry_if_invs
+                      kernel_entry_silc_inv[where st'=s0_internal]
+                      kernel_entry_pas_refined[where st=s0_internal]
+                      kernel_entry_if_valid_sched kernel_entry_if_only_timer_irq_inv
+                      kernel_entry_if_domain_sep_inv kernel_entry_if_guarded_pas_domain
+                      kernel_entry_if_domain_time_sched_action[OF num_domains_sanity]
+                      ct_idle_lift
+                   | clarsimp intro: guarded_pas_is_subject_current_aag
+                   | wp kernel_entry_if_domain_fields)+
           apply (rule conjI, fastforce intro!: active_from_running)
           apply (simp add: schact_is_rct_def)
           apply (rule guarded_pas_is_subject_current_aag,assumption+)
          apply (simp_all only: silc_inv_cur pas_refined_cur guarded_pas_domain_cur)
-         apply(simp | elim exE)+
+         apply (simp | elim exE)+
          apply (elim exE conjE)
          apply (clarsimp simp add: kernel_handle_preemption_if_def)
          apply (subgoal_tac "idle_equiv s0_internal ba \<and> invs ba")
-         prefer 2
-         apply (erule use_valid)
-         apply (wp handle_preemption_if_invs | simp)+
+          prefer 2
+          apply (erule use_valid)
+           apply (wp handle_preemption_if_invs | simp)+
          apply (clarsimp simp add: idle_equiv_context_equiv)
          apply (erule use_valid)
-         apply (rule hoare_add_post[OF handle_preemption_context, OF TrueI],
-                simp,
-                rule hoare_drop_imps)
-           apply (wp handle_preemption_if_invs handle_preemption_if_domain_sep_inv
-                     handle_preemption_if_domain_time_sched_action[OF num_domains_sanity]
-                     handle_preemption_if_det_inv ct_idle_lift)
-         apply (fastforce simp: non_kernel_IRQs_def)
-        apply(simp add: kernel_schedule_if_def | elim exE conjE)+
-        apply(erule use_valid)
-         apply((wp schedule_if_ct_running_or_ct_idle
-                   schedule_if_domain_time_nonzero' schedule_if_domain_time_nonzero
-                   schedule_if_det_inv
-                   hoare_vcg_imp_lift'
-                | fastforce simp: invs_valid_idle)+)[2]
-       apply(simp add: kernel_exit_A_if_def | elim exE conjE)+
-       apply(frule state_unchanged[OF kernel_exit_if_inv])
-       apply(frule use_valid[OF _ kernel_exit_if_det_inv])
+          apply (rule hoare_add_post[OF handle_preemption_context, OF TrueI], simp,
+                 rule hoare_drop_imps)
+          apply (wp handle_preemption_if_invs handle_preemption_if_domain_sep_inv
+                    handle_preemption_if_domain_time_sched_action[OF num_domains_sanity]
+                    handle_preemption_if_det_inv ct_idle_lift)
+         apply (fastforce simp: non_kernel_IRQs_empty)
+        apply (simp add: kernel_schedule_if_def | elim exE conjE)+
+        apply (erule use_valid)
+         apply ((wp schedule_if_ct_running_or_ct_idle schedule_if_domain_time_nonzero'
+                    schedule_if_domain_time_nonzero schedule_if_det_inv hoare_false_imp
+                 | fastforce simp: invs_valid_idle)+)[2]
+       apply (simp add: kernel_exit_A_if_def | elim exE conjE)+
+       apply (frule state_unchanged[OF kernel_exit_if_inv])
+       apply (frule use_valid[OF _ kernel_exit_if_det_inv])
         apply simp
-       apply(clarsimp)
+       apply (clarsimp)
        apply (elim disjE)
         apply (simp add: ct_active_not_idle')+
        apply (erule use_valid[OF _ exit_idle_context],simp+)
-      apply(simp add: do_user_op_A_if_def check_active_irq_A_if_def | elim exE conjE)+
+      apply (simp add: do_user_op_A_if_def check_active_irq_A_if_def | elim exE conjE)+
       apply (frule use_valid[OF _ do_user_op_if_det_inv])
        apply (frule use_valid[OF _ check_active_irq_if_User_det_inv])
         apply simp
@@ -2412,26 +2028,21 @@ lemma invs_if_Step_ADT_A_if:
        apply (erule use_valid[OF _ check_active_irq_if_wp])
        apply simp
       apply simp
-      apply(erule use_valid, erule use_valid[OF _ check_active_irq_if_wp])
-       apply(rule_tac Q="\<lambda>a. (invs and ct_running) and (\<lambda>b.
-                 valid_pdpt_objs b \<and>
-                 valid_list b \<and>
-                 valid_sched b \<and>
-                 only_timer_irq_inv timer_irq s0_internal b \<and>
-                 silc_inv initial_aag s0_internal b \<and>
-                 pas_refined initial_aag b \<and>
-                 guarded_pas_domain initial_aag b \<and>
-                 idle_equiv s0_internal b \<and>
-                 domain_sep_inv False s0_internal b \<and>
-                 valid_domain_list b \<and> 0 < domain_time b \<and>
-                 scheduler_action b = resume_cur_thread)" in hoare_strengthen_post)
-
-        apply((wp do_user_op_if_invs ct_idle_lift
-              | simp add: ct_active_not_idle' | clarsimp)+)[2]
-      apply(erule use_valid[OF _ check_active_irq_if_wp])
-      apply(simp add: ct_in_state_def)
-     apply(simp add: do_user_op_A_if_def check_active_irq_A_if_def
-           | elim exE conjE)+
+      apply (erule use_valid, erule use_valid[OF _ check_active_irq_if_wp])
+       apply (rule_tac Q="\<lambda>a. (invs and ct_running) and
+                              (\<lambda>b. valid_vspace_objs' b \<and> valid_list b \<and> valid_sched b \<and>
+                                   only_timer_irq_inv timer_irq s0_internal b \<and>
+                                   silc_inv initial_aag s0_internal b \<and>
+                                   pas_refined initial_aag b \<and>
+                                   guarded_pas_domain initial_aag b \<and>
+                                   idle_equiv s0_internal b \<and>
+                                   domain_sep_inv False s0_internal b \<and>
+                                   valid_domain_list b \<and> 0 < domain_time b \<and>
+                                   scheduler_action b = resume_cur_thread)" in hoare_strengthen_post)
+        apply ((wp do_user_op_if_invs ct_idle_lift | simp add: ct_active_not_idle' | clarsimp)+)[2]
+      apply (erule use_valid[OF _ check_active_irq_if_wp])
+      apply (simp add: ct_in_state_def)
+     apply (simp add: do_user_op_A_if_def check_active_irq_A_if_def | elim exE conjE)+
      apply (frule use_valid[OF _ do_user_op_if_det_inv])
       apply (frule use_valid[OF _ check_active_irq_if_User_det_inv])
        apply simp
@@ -2439,60 +2050,46 @@ lemma invs_if_Step_ADT_A_if:
       apply (erule use_valid[OF _ check_active_irq_if_wp])
       apply simp
      apply simp
-     apply(erule use_valid, erule use_valid[OF _ check_active_irq_if_wp])
-      apply(rule_tac Q="\<lambda>a. (invs and ct_running) and (\<lambda>b.
-                 valid_pdpt_objs b \<and>
-                 valid_list b \<and>
-                 valid_sched b \<and>
-                 only_timer_irq_inv timer_irq s0_internal b \<and>
-                 silc_inv initial_aag s0_internal b \<and>
-                 pas_refined initial_aag b \<and>
-                 guarded_pas_domain initial_aag b \<and>
-                 idle_equiv s0_internal b \<and>
-                 domain_sep_inv False s0_internal b \<and>
-                 valid_domain_list b \<and> 0 < domain_time b \<and>
-                 scheduler_action b = resume_cur_thread)" in hoare_strengthen_post)
-       apply((wp do_user_op_if_invs | simp | clarsimp simp: ct_active_not_idle')+)[2]
-     apply(erule use_valid[OF _ check_active_irq_if_wp])
-     apply(simp add: ct_in_state_def)
-    apply(simp add: check_active_irq_A_if_def | elim exE conjE)+
+     apply (erule use_valid, erule use_valid[OF _ check_active_irq_if_wp])
+      apply (rule_tac Q="\<lambda>a. (invs and ct_running) and
+                             (\<lambda>b. valid_vspace_objs' b \<and> valid_list b \<and> valid_sched b \<and>
+                                  only_timer_irq_inv timer_irq s0_internal b \<and>
+                                  silc_inv initial_aag s0_internal b \<and>
+                                  pas_refined initial_aag b \<and>
+                                  guarded_pas_domain initial_aag b \<and>
+                                  idle_equiv s0_internal b \<and>
+                                  domain_sep_inv False s0_internal b \<and>
+                                  valid_domain_list b \<and> 0 < domain_time b \<and>
+                                  scheduler_action b = resume_cur_thread)" in hoare_strengthen_post)
+       apply ((wp do_user_op_if_invs | simp | clarsimp simp: ct_active_not_idle')+)[2]
+     apply (erule use_valid[OF _ check_active_irq_if_wp])
+     apply (simp add: ct_in_state_def)
+    apply (simp add: check_active_irq_A_if_def | elim exE conjE)+
     apply (frule use_valid[OF _ check_active_irq_if_User_det_inv])
      apply simp
     apply simp
-    apply(erule use_valid[OF _ check_active_irq_if_wp])
-    apply(clarsimp simp add: ct_in_state_def st_tcb_at_def obj_at_def)
-   apply(simp add: check_active_irq_A_if_def | elim exE conjE)+
+    apply (erule use_valid[OF _ check_active_irq_if_wp])
+    apply (clarsimp simp: ct_in_state_def st_tcb_at_def obj_at_def)
+   apply (simp add: check_active_irq_A_if_def | elim exE conjE)+
    apply (frule use_valid[OF _ check_active_irq_context],simp)
    apply (frule use_valid[OF _ check_active_irq_if_Idle_det_inv])
     apply simp
    apply simp
-   apply(erule use_valid[OF _ check_active_irq_if_wp])
-   apply(simp add: ct_in_state_def idle_context_def)
-  apply(simp add: check_active_irq_A_if_def | elim exE conjE)+
+   apply (erule use_valid[OF _ check_active_irq_if_wp])
+   apply (simp add: ct_in_state_def idle_context_def)
+  apply (simp add: check_active_irq_A_if_def | elim exE conjE)+
   apply (frule use_valid[OF _ check_active_irq_if_Idle_det_inv])
    apply simp
   apply simp
-  apply(rule use_valid[OF _ check_active_irq_if_wp],assumption)
-  apply(simp add: ct_in_state_def)
+  apply (rule use_valid[OF _ check_active_irq_if_wp],assumption)
+  apply (simp add: ct_in_state_def)
   apply (frule use_valid[OF _ check_active_irq_context],simp+)
   apply (simp add: idle_context_def)
   done
 
-
-lemma Fin_ADT_if:
-  "Fin (ADT_A_if utf) = id"
-  apply (simp add: ADT_A_if_def)
-  done
-
-
-lemma Init_ADT_if:
-  "Init (ADT_A_if utf) = (\<lambda>s. {s} \<inter> full_invs_if \<inter> {s. step_restrict s})"
-  apply (simp add: ADT_A_if_def)
-  done
-
 lemma execution_invs:
- assumes e: "s \<in> execution (ADT_A_if utf) s0 js"
- shows "invs_if s"
+  assumes e: "s \<in> execution (ADT_A_if utf) s0 js"
+  shows "invs_if s"
   apply (insert e)
   apply (induct js arbitrary: s rule: rev_induct)
    apply (clarsimp simp add: execution_def Fin_ADT_if Init_ADT_if
@@ -2500,10 +2097,10 @@ lemma execution_invs:
    apply (simp add: execution_def Fin_ADT_if Init_ADT_if steps_def)
   apply (simp add: execution_def steps_def image_def)
   apply (erule bexE)
-  unfolding Image_def
+  apply (unfold Image_def)
   apply (drule CollectD)
   apply (erule bexE)
-   apply simp
+  apply simp
   apply (rule invs_if_Step_ADT_A_if)
    apply (drule_tac meta_spec)
    apply (fastforce)
@@ -2511,26 +2108,42 @@ lemma execution_invs:
   apply (clarsimp simp: Fin_ADT_if ADT_A_if_def)
   done
 
+end
+
+
 lemma execution_restrict:
- assumes e: "s \<in> execution (ADT_A_if utf) s0 js"
- shows "step_restrict s"
+  assumes e: "s \<in> execution (ADT_A_if utf) s0 js"
+  shows "step_restrict s"
   apply (insert e)
   apply (induct js arbitrary: s rule: rev_induct)
-  apply (clarsimp simp add: execution_def ADT_A_if_def steps_def)
+   apply (clarsimp simp add: execution_def ADT_A_if_def steps_def)
   apply (clarsimp simp add: execution_def Fin_ADT_if Init_ADT_if steps_def)
   apply (simp add: ADT_A_if_def)
   done
 
+lemma Step_ADT_A_if':
+  "((s,s') \<in> system.Step (ADT_A_if utf) u) \<Longrightarrow> ((s,s') \<in> Step (ADT_A_if utf) u)"
+  apply (simp add: system.Step_def execution_def steps_def ADT_A_if_def)
+  apply fastforce
+  done
+
+
+context valid_initial_state begin
+
 lemma invs_if_full_invs_if:
   "invs_if s \<Longrightarrow> s \<in> full_invs_if"
-  by (clarsimp simp add: full_invs_if_def invs_if_def Invs_def)
+  by (clarsimp simp: full_invs_if_def invs_if_def Invs_def)
+
+end
+
+context ADT_valid_initial_state begin
 
 lemma ADT_A_if_Step_system:
   "Step_system (ADT_A_if utf) s0"
-  apply(rule Init_Fin_system_Step_system)
-  apply(rule Init_inv_Fin_system_Init_Fin_system)
-  apply(clarsimp simp add: Init_inv_Fin_system_def ADT_A_if_def invs_if_full_invs_if
-                  system.reachable_def extras_s0)
+  apply (rule Init_Fin_system_Step_system)
+  apply (rule Init_inv_Fin_system_Init_Fin_system)
+  apply (clarsimp simp: Init_inv_Fin_system_def ADT_A_if_def
+                        invs_if_full_invs_if system.reachable_def extras_s0)
   apply (frule execution_invs[simplified ADT_A_if_def])
   apply (frule execution_restrict[simplified ADT_A_if_def])
   apply (frule invs_if_full_invs_if,force)
@@ -2538,169 +2151,111 @@ lemma ADT_A_if_Step_system:
 
 lemma ADT_A_if_Run_reachable:
   "(s0, t) \<in> Run (system.Step (ADT_A_if utf)) as \<Longrightarrow> system.reachable (ADT_A_if utf) s0 t"
-  apply(simp add: system.reachable_def)
-  apply(simp add: Step_system_execution_Run_s0[OF ADT_A_if_Step_system])
+  apply (simp add: system.reachable_def)
+  apply (simp add: Step_system_execution_Run_s0[OF ADT_A_if_Step_system])
   by blast
 
 lemma Step_ADT_A_if:
-  "system.reachable (ADT_A_if utf) s0 s \<Longrightarrow>
-     ((s,s') \<in> system.Step (ADT_A_if utf) u) = ((s,s') \<in> Step (ADT_A_if utf) u)"
+  "system.reachable (ADT_A_if utf) s0 s
+   \<Longrightarrow> ((s,s') \<in> system.Step (ADT_A_if utf) u) = ((s,s') \<in> Step (ADT_A_if utf) u)"
   apply (simp add: system.reachable_def)
   apply (clarsimp)
   apply (frule execution_invs)
   apply (frule invs_if_full_invs_if)
   apply (frule execution_restrict)
-  apply(simp add: system.Step_def execution_def steps_def ADT_A_if_def)
-  done
-
-lemma Step_ADT_A_if':
-  "((s,s') \<in> system.Step (ADT_A_if utf) u) \<Longrightarrow> ((s,s') \<in> Step (ADT_A_if utf) u)"
-  apply(simp add: system.Step_def execution_def steps_def ADT_A_if_def)
-  apply fastforce
+  apply (simp add: system.Step_def execution_def steps_def ADT_A_if_def)
   done
 
 lemma ADT_A_if_reachable_invs_if:
   "system.reachable (ADT_A_if utf) s0 s \<Longrightarrow> invs_if s"
-  apply(clarsimp simp: system.reachable_def)
+  apply (clarsimp simp: system.reachable_def)
   apply (erule execution_invs)
   done
 
 lemma ADT_A_if_reachable_full_invs_if:
   "system.reachable (ADT_A_if utf) s0 s \<Longrightarrow> s \<in> full_invs_if"
-  apply(clarsimp simp: system.reachable_def)
+  apply (clarsimp simp: system.reachable_def)
   apply (rule invs_if_full_invs_if)
   apply (rule ADT_A_if_reachable_invs_if)
   apply (simp add: system.reachable_def)
   apply force
   done
 
-
 lemma ADT_A_if_enabled_Step_system:
   "enabled_Step_system (ADT_A_if utf) s0"
-  apply(simp add: enabled_Step_system_def ADT_A_if_Step_system ADT_A_if_enabled_system)
-  done
+  by (simp add: enabled_Step_system_def ADT_A_if_Step_system ADT_A_if_enabled_system)
+
+end
+
 
 section \<open>IRQs and big step automaton enabledness\<close>
 
-definition irq_measure_if
-where
-  "irq_measure_if s \<equiv>
-   let cur = Suc (irq_state (machine_state s)) in
-     (next_irq_state cur (irq_masks (machine_state s))) - cur"
-
-definition measuref_if :: "det_state global_sys_state \<Rightarrow> det_state global_sys_state \<Rightarrow> nat"
-where
+definition measuref_if :: "det_state global_sys_state \<Rightarrow> det_state global_sys_state \<Rightarrow> nat" where
   "measuref_if s s' \<equiv>
-     (if (snd s) = KernelExit then
-        (if interrupted_modes (snd s') then 0
-         else 1 + (4 * irq_measure_if (internal_state_if s')) +
-              (case (snd s') of (KernelEntry e) \<Rightarrow> 3 |
-               _ \<Rightarrow>
-                    (if (\<exists> b. (snd s') = KernelSchedule b) then 2
-                     else (if (snd s') = KernelExit then 1 else 0)
-                    )
-              )
-        )
-      else
-        (if interrupted_modes (snd s') then 2 else
-           (if (\<exists> b. (snd s') = KernelSchedule b) then 1 else 0)
-        )
-     )"
+     (if (snd s) = KernelExit
+      then (if interrupted_modes (snd s') then 0
+            else 1 + (4 * irq_measure_if (internal_state_if s')) +
+                 (case (snd s') of (KernelEntry e) \<Rightarrow> 3
+                                 | _ \<Rightarrow> (if (\<exists>b. (snd s') = KernelSchedule b) then 2
+                                         else (if (snd s') = KernelExit then 1 else 0))))
+      else (if interrupted_modes (snd s') then 2
+            else (if (\<exists>b. (snd s') = KernelSchedule b) then 1 else 0)))"
 
 crunch irq_state_of_state_inv[wp]: device_memory_update "\<lambda>ms. P (irq_state ms)"
 crunch irq_masks_inv[wp]: device_memory_update "\<lambda>ms. P (irq_masks ms)"
-  (wp: crunch_wps simp: crunch_simps no_irq_device_memory_update no_irq_def)
-
-lemma do_user_op_if_irq_state_of_state:
-  "\<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace> do_user_op_if utf uc
-   \<lbrace>\<lambda>_ s. P (irq_state_of_state s)\<rbrace>"
-  apply(rule hoare_pre)
-  apply(simp add: do_user_op_if_def user_memory_update_def | wp dmo_wp select_wp | wpc)+
-  done
-
-lemma do_user_op_if_irq_masks_of_state:
-  "\<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace> do_user_op_if utf uc
-   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply(rule hoare_pre)
-  apply(simp add: do_user_op_if_def user_memory_update_def | wp dmo_wp select_wp | wpc)+
-  done
-
-lemma do_user_op_if_irq_measure_if:
-  "\<lbrace>\<lambda>s. P (irq_measure_if s)\<rbrace> do_user_op_if utf uc
-   \<lbrace>\<lambda>_ s. P (irq_measure_if s)\<rbrace>"
-  apply(rule hoare_pre)
-  apply(simp add: do_user_op_if_def user_memory_update_def irq_measure_if_def
-    | wps |wp dmo_wp select_wp | wpc)+
-  done
+  (wp: crunch_wps simp: crunch_simps no_irq_def)
 
 lemma next_irq_state_Suc:
-  "\<lbrakk>irq_at cur masks = None; next_irq_state_dom (cur,masks)\<rbrakk> \<Longrightarrow>
-   next_irq_state (Suc cur) masks = next_irq_state cur masks"
-  apply(simp add: next_irq_state.psimps split: if_splits)
-  done
+  "\<lbrakk> irq_at cur masks = None; next_irq_state_dom (cur,masks) \<rbrakk>
+     \<Longrightarrow> next_irq_state (Suc cur) masks = next_irq_state cur masks"
+  by (simp add: next_irq_state.psimps split: if_splits)
 
 lemma next_irq_state_Suc':
-  "\<lbrakk>irq_at cur masks = Some i; next_irq_state_dom (cur,masks)\<rbrakk> \<Longrightarrow>
-   next_irq_state cur masks = cur"
-  apply(simp add: next_irq_state.psimps split: if_splits)
-  done
-
-lemma getActiveIRQ_None:
-  "(None,s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) s)  \<Longrightarrow>
-   irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = None"
-  apply(erule use_valid)
-   apply(wp dmo_getActiveIRQ_wp)
-  by simp
-
-lemma getActiveIRQ_Some:
-  "(Some i,s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) s)  \<Longrightarrow>
-   irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = Some i"
-  apply(erule use_valid)
-   apply(wp dmo_getActiveIRQ_wp)
-  by simp
+  "\<lbrakk> irq_at cur masks = Some i; next_irq_state_dom (cur,masks) \<rbrakk>
+     \<Longrightarrow> next_irq_state cur masks = cur"
+  by (simp add: next_irq_state.psimps split: if_splits)
 
 lemma is_irq_at_next_irq_state_dom':
-  "is_irq_at s irq pos \<Longrightarrow>
-   next_irq_state_dom (pos,irq_masks (machine_state s))"
-  apply(rule next_irq_state.domintros)
-  apply(fastforce simp: is_irq_at_def irq_at_def)
+  "is_irq_at s irq pos \<Longrightarrow> next_irq_state_dom (pos,irq_masks (machine_state s))"
+  apply (rule next_irq_state.domintros)
+  apply (fastforce simp: is_irq_at_def )
   done
 
 lemma is_irq_at_next_irq_state_dom:
-  "\<lbrakk>pos \<le> next; is_irq_at s irq next\<rbrakk> \<Longrightarrow>
-   next_irq_state_dom (pos,irq_masks (machine_state s))"
-  apply(induct rule: inc_induct)
-   apply(erule is_irq_at_next_irq_state_dom')
-  apply(rule next_irq_state.domintros)
-  apply(blast)
+  "\<lbrakk> pos \<le> next; is_irq_at s irq next \<rbrakk>
+     \<Longrightarrow> next_irq_state_dom (pos,irq_masks (machine_state s))"
+  apply (induct rule: inc_induct)
+   apply (erule is_irq_at_next_irq_state_dom')
+  apply (rule next_irq_state.domintros)
+  apply (blast)
   done
 
 lemma is_irq_at_next_irq_state:
-  "is_irq_at s irq pos \<Longrightarrow>
-   next_irq_state pos (irq_masks (machine_state s)) = pos"
-  apply(subst next_irq_state.psimps[OF is_irq_at_next_irq_state_dom'])
+  "is_irq_at s irq pos
+   \<Longrightarrow> next_irq_state pos (irq_masks (machine_state s)) = pos"
+  apply (subst next_irq_state.psimps[OF is_irq_at_next_irq_state_dom'])
    apply assumption
-  apply(fastforce simp: is_irq_at_def)
+  apply (fastforce simp: is_irq_at_def)
   done
 
 lemma next_irq_state_le:
-  "\<lbrakk>irq_is_recurring irq s; masks = (irq_masks (machine_state s))\<rbrakk> \<Longrightarrow>
-   cur \<le> next_irq_state cur masks"
-  apply(clarsimp simp: irq_is_recurring_def)
-  apply(drule_tac x=cur in spec)
-  apply(erule exE)
+  "\<lbrakk> irq_is_recurring irq s; masks = (irq_masks (machine_state s)) \<rbrakk>
+     \<Longrightarrow> cur \<le> next_irq_state cur masks"
+  apply (clarsimp simp: irq_is_recurring_def)
+  apply (drule_tac x=cur in spec)
+  apply (erule exE)
   proof -
     fix m
     assume i: "is_irq_at s irq (cur + m)"
     have le: "cur \<le> cur + m" by simp
     thus "cur \<le> next_irq_state cur (irq_masks (machine_state s))"
       apply -
-      apply(induct rule: inc_induct)
-       apply(clarsimp simp: is_irq_at_next_irq_state[OF i])
-      apply(case_tac "is_irq_at s irq n")
-       apply(simp add: is_irq_at_next_irq_state)
-      apply(subst next_irq_state.psimps)
-       apply(rule is_irq_at_next_irq_state_dom[OF _ i])
+      apply (induct rule: inc_induct)
+       apply (clarsimp simp: is_irq_at_next_irq_state[OF i])
+      apply (case_tac "is_irq_at s irq n")
+       apply (simp add: is_irq_at_next_irq_state)
+      apply (subst next_irq_state.psimps)
+       apply (rule is_irq_at_next_irq_state_dom[OF _ i])
        apply simp
       apply simp
       done
@@ -2710,12 +2265,11 @@ lemma next_irq_state_mono:
   assumes lep: "pos \<le> pos'"
   assumes recur: "irq_is_recurring irq s"
   assumes m: "masks = irq_masks (machine_state s)"
-  shows
-   "next_irq_state pos masks \<le> next_irq_state pos' masks"
-  apply(insert recur m)
-  apply(clarsimp simp: irq_is_recurring_def)
-  apply(drule_tac x=pos' in spec)
-  apply(erule exE)
+  shows "next_irq_state pos masks \<le> next_irq_state pos' masks"
+  apply (insert recur m)
+  apply (clarsimp simp: irq_is_recurring_def)
+  apply (drule_tac x=pos' in spec)
+  apply (erule exE)
   proof -
     fix m
     assume i: "is_irq_at s irq (pos' + m)"
@@ -2723,234 +2277,206 @@ lemma next_irq_state_mono:
     from lep show "next_irq_state pos (irq_masks (machine_state s)) \<le>
                       next_irq_state pos' (irq_masks (machine_state s))"
       apply -
-      apply(induct rule: inc_induct)
+      apply (induct rule: inc_induct)
        apply simp
-      apply(case_tac "is_irq_at s irq n")
-       apply(simp add: is_irq_at_next_irq_state)
-       apply(rule less_imp_le_nat)
-       apply(erule less_le_trans)
-       apply(blast intro: next_irq_state_le[OF recur])
-      apply(subst next_irq_state.psimps)
-       apply(rule is_irq_at_next_irq_state_dom[OF _ i])
+      apply (case_tac "is_irq_at s irq n")
+       apply (simp add: is_irq_at_next_irq_state)
+       apply (rule less_imp_le_nat)
+       apply (erule less_le_trans)
+       apply (blast intro: next_irq_state_le[OF recur])
+      apply (subst next_irq_state.psimps)
+       apply (rule is_irq_at_next_irq_state_dom[OF _ i])
        apply simp
-      apply(clarsimp simp: is_irq_at_def irq_at_def Let_def)
-      apply(rule less_imp_le_nat)
-      apply(erule less_le_trans)
-      apply(blast intro: next_irq_state_le[OF recur])
+      apply (clarsimp simp: is_irq_at_def Let_def)
+      apply (rule less_imp_le_nat)
+      apply (erule less_le_trans)
+      apply (blast intro: next_irq_state_le[OF recur])
       done
   qed
 
+lemma recurring_next_irq_state_dom:
+  "irq_is_recurring irq s \<Longrightarrow> next_irq_state_dom (n,irq_masks (machine_state s))"
+  apply (clarsimp simp: irq_is_recurring_def)
+  apply (drule_tac x=n in spec)
+  apply (erule exE)
+  proof -
+    fix m
+    assume i: "is_irq_at s irq (n + m)"
+    have "n \<le> n + m" by simp
+    thus "next_irq_state_dom (n, irq_masks (machine_state s))"
+    proof(induct rule: inc_induct)
+      from i obtain irq where a: "irq_at (n + m) (irq_masks (machine_state s)) = Some irq"
+        by (fastforce simp: is_irq_at_def)
+      show "next_irq_state_dom (n + m, irq_masks (machine_state s))"
+        using a by (fastforce intro: next_irq_state.domintros)
+    next
+      fix i
+      assume "next_irq_state_dom (Suc i, irq_masks (machine_state s))"
+      thus "next_irq_state_dom (i, irq_masks (machine_state s))"
+        by (rule next_irq_state.domintros)
+    qed
+  qed
 
 lemma next_irq_state_less:
-  "\<lbrakk>irq_at cur masks = None; irq_is_recurring irq s; masks = (irq_masks (machine_state s))\<rbrakk> \<Longrightarrow>
-   cur < next_irq_state cur masks"
-  apply(frule_tac n=cur in recurring_next_irq_state_dom)
-  apply(simp add: next_irq_state.psimps)
-  apply(rule less_le_trans[OF _ next_irq_state_le])
+  "\<lbrakk> irq_at cur masks = None; irq_is_recurring irq s; masks = (irq_masks (machine_state s)) \<rbrakk>
+     \<Longrightarrow> cur < next_irq_state cur masks"
+  apply (frule_tac n=cur in recurring_next_irq_state_dom)
+  apply (simp add: next_irq_state.psimps)
+  apply (rule less_le_trans[OF _ next_irq_state_le])
     apply simp
    apply assumption
-  apply(rule refl)
+  apply (rule refl)
   done
 
 lemma next_irq_state_Suc_le:
   assumes recur: "irq_is_recurring irq s"
   assumes m: "masks = irq_masks (machine_state s)"
-  shows
-   "next_irq_state pos masks \<le> next_irq_state (Suc pos) masks"
-  apply(rule next_irq_state_mono[OF _ recur m], simp)
-  done
-
-lemma kernel_exit_if_inv:
-  "\<lbrace>P\<rbrace> kernel_exit_if blah \<lbrace>\<lambda>_. P\<rbrace>"
-  apply(simp add: kernel_exit_if_def | wp)+
-  done
-
-lemma invs_if_irq_is_recurring[simp]:
-  "invs_if s \<Longrightarrow> irq_is_recurring timer_irq (internal_state_if s)"
-  apply(clarsimp simp: invs_if_def Invs_def only_timer_irq_inv_def only_timer_irq_def)
-  done
-
-definition irq_measure_if_inv where
-  "irq_measure_if_inv st s \<equiv> irq_measure_if (s::det_state) \<le> irq_measure_if (st::det_state)"
-
-definition irq_state_inv where
-  "irq_state_inv (st::det_state) (s::det_state) \<equiv>
-        irq_state (machine_state s) \<ge> irq_state (machine_state st) \<and>
-        irq_masks (machine_state s) = irq_masks (machine_state st) \<and>
-        next_irq_state (Suc (irq_state (machine_state s))) (irq_masks (machine_state s)) =
-        next_irq_state (Suc (irq_state (machine_state st))) (irq_masks (machine_state s))"
+  shows "next_irq_state pos masks \<le> next_irq_state (Suc pos) masks"
+  by (rule next_irq_state_mono[OF _ recur m], simp)
 
 lemma irq_state_inv_refl:
   "irq_state_inv s s"
-  apply(simp add: irq_state_inv_def)
-  done
-
+  by (simp add: irq_state_inv_def)
 
 lemma irq_state_inv_triv:
-  assumes irq_state:
-    "\<And> P. \<lbrace> \<lambda>s. P (irq_state_of_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_state_of_state s)\<rbrace>"
-  assumes irq_masks:
-    "\<And> P. \<lbrace> \<lambda>s. P (irq_masks_of_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  shows
-    "\<lbrace>irq_state_inv st\<rbrace> f \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>"
-  apply(clarsimp simp: valid_def irq_state_inv_def)
-  apply(rule use_valid[OF _ irq_state], assumption)
-  apply(erule use_valid[OF _ irq_masks])
+  assumes irq_state: "\<And>P. f \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  assumes irq_masks: "\<And>P. f \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  shows "f \<lbrace>irq_state_inv st\<rbrace>"
+  apply (clarsimp simp: valid_def irq_state_inv_def)
+  apply (rule use_valid[OF _ irq_state], assumption)
+  apply (erule use_valid[OF _ irq_masks])
   apply simp
   done
 
 lemma irq_state_inv_triv':
-  assumes irq_state:
-    "\<And> P. \<lbrace> \<lambda>s. P (irq_state_of_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_state_of_state s)\<rbrace>"
-  assumes irq_masks:
-    "\<And> P. \<lbrace> (\<lambda>s. P (irq_masks_of_state s)) and Q\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  shows
-    "\<lbrace>irq_state_inv st and Q\<rbrace> f \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>"
-  apply(clarsimp simp: valid_def irq_state_inv_def)
-  apply(rule use_valid[OF _ irq_state], assumption)
-  apply(erule use_valid[OF _ irq_masks])
+  assumes irq_state: "\<And>P. f \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  assumes irq_masks: "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and Q\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  shows "\<lbrace>irq_state_inv st and Q\<rbrace> f \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>"
+  apply (clarsimp simp: valid_def irq_state_inv_def)
+  apply (rule use_valid[OF _ irq_state], assumption)
+  apply (erule use_valid[OF _ irq_masks])
   apply simp
   done
 
-
 lemma OR_choiceE_wp:
   assumes a: "\<And>s. \<lbrace>P and (=) s\<rbrace> b \<lbrace>\<lambda> r s'. (r \<longrightarrow> P' s) \<and> (\<not> r \<longrightarrow> P'' s)\<rbrace>"
-  assumes b: "\<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
-  assumes c: "\<lbrace>P''\<rbrace> g \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
-  shows
-  "\<lbrace>P::det_state \<Rightarrow> bool\<rbrace> OR_choiceE b f g \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
-  apply(simp add: OR_choiceE_def)
-  apply (wp b c| wpc)+
-  apply(clarsimp simp: mk_ef_def wrap_ext_bool_det_ext_ext_def)
-  apply(drule a[simplified valid_def, rule_format, rotated])
+  assumes b: "\<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>"
+  assumes c: "\<lbrace>P''\<rbrace> g \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>"
+  shows "\<lbrace>P\<rbrace> OR_choiceE b f g \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>"
+  apply (simp add: OR_choiceE_def)
+  apply (wp b c | wpc)+
+  apply (clarsimp simp: mk_ef_def wrap_ext_bool_det_ext_ext_def)
+  apply (drule a[simplified valid_def, rule_format, rotated])
    apply simp
-  apply(fastforce split: prod.splits)
+  apply (fastforce split: prod.splits)
   done
-
-definition irq_state_next where
-  "irq_state_next (st::det_state) (s::det_state) \<equiv>
-        irq_state (machine_state s) \<ge> irq_state (machine_state st) \<and>
-        irq_masks (machine_state s) = irq_masks (machine_state st) \<and>
-        irq_state (machine_state s) = next_irq_state (Suc (irq_state (machine_state st)))
-                                                     (irq_masks (machine_state s))"
-
 
 lemma preemption_point_irq_state_inv'[wp]:
   "\<lbrace>irq_state_inv st and K (irq_is_recurring irq st)\<rbrace>
    preemption_point
-  \<lbrace>\<lambda>a. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+   \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
   apply (simp add: preemption_point_def)
-  apply (wp OR_choiceE_wp[where P'="irq_state_inv st and K(irq_is_recurring irq st)"
-                            and P''="irq_state_inv st and K(irq_is_recurring irq st)"]
-            dmo_getActiveIRQ_wp
-        | wpc
-        | simp add: reset_work_units_def)+
-     apply(clarsimp simp: irq_state_inv_def)
-     apply(simp add: next_irq_state_Suc[OF _ recurring_next_irq_state_dom])
+  apply (wpsimp wp: OR_choiceE_wp[where P'="irq_state_inv st and K(irq_is_recurring irq st)"
+                                    and P''="irq_state_inv st and K(irq_is_recurring irq st)"]
+              simp: reset_work_units_def)+
+     apply simp
+     apply (wpsimp wp: OR_choiceE_wp dmo_getActiveIRQ_wp simp: reset_work_units_def)+
+     apply (clarsimp simp: irq_state_inv_def)
+     apply (simp add: next_irq_state_Suc[OF _ recurring_next_irq_state_dom])
      apply (clarsimp simp: irq_state_next_def)
-     apply(simp add: next_irq_state_Suc'[OF _ recurring_next_irq_state_dom])
-    apply(wp | simp add: update_work_units_def irq_state_inv_def | fastforce)+
+     apply (simp add: next_irq_state_Suc'[OF _ recurring_next_irq_state_dom])
+    apply (wp | simp add: update_work_units_def irq_state_inv_def | fastforce)+
   done
 
 lemma validE_validE_E':
-  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f -,\<lbrace>E\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f -, \<lbrace>E\<rbrace>"
   apply (rule validE_validE_E)
   apply (rule hoare_post_impErr)
-  apply assumption
-  apply simp+
+    apply assumption
+   apply simp+
   done
 
 lemmas preemption_point_irq_state_inv[wp] = validE_validE_R'[OF preemption_point_irq_state_inv']
 lemmas preemption_point_irq_state_next[wp] = validE_validE_E'[OF preemption_point_irq_state_inv']
 
-
-
 lemma hoare_add_postE:
-  "\<lbrakk> \<lbrace>S\<rbrace> f \<lbrace>\<lambda>_. S'\<rbrace>;
-     \<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. S' s \<longrightarrow> Q r s\<rbrace>,\<lbrace>\<lambda>r s. S' s \<longrightarrow> E r s\<rbrace>
-   \<rbrakk> \<Longrightarrow> \<lbrace>P and S\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  "\<lbrakk> \<lbrace>S\<rbrace> f \<lbrace>\<lambda>_. S'\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. S' s \<longrightarrow> Q r s\<rbrace>, \<lbrace>\<lambda>r s. S' s \<longrightarrow> E r s\<rbrace> \<rbrakk>
+     \<Longrightarrow> \<lbrace>P and S\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   apply (clarsimp simp: validE_def)
   apply (rule hoare_add_post)
     apply assumption
    apply simp
   apply (rule hoare_strengthen_post)
    apply (rule hoare_pre)
-    apply assumption
-   back
-   apply simp
-  apply (clarsimp split: sum.splits)
+    apply (assumption, simp, fastforce split: sum.splits)
   done
 
 lemma rec_del_irq_state_inv':
-  notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del]
-         rec_del.simps[simp del]
+  notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del] rec_del.simps[simp del]
   shows
-  "s \<turnstile> \<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
-        rec_del call
-        \<lbrace>\<lambda>a s. (case call of
-             FinaliseSlotCall x y \<Rightarrow> y \<or> fst a \<longrightarrow> snd a = NullCap
-          | _ \<Rightarrow> True) \<and>
-         domain_sep_inv False sta s \<and> irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
-  proof (induct s arbitrary: rule: rec_del.induct, simp_all only: rec_del_fails hoare_fail_any)
+    "s \<turnstile> \<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
+         rec_del call
+         \<lbrace>\<lambda>a s. (case call of FinaliseSlotCall x y \<Rightarrow> y \<or> fst a \<longrightarrow> snd a = NullCap
+                            | _ \<Rightarrow> True) \<and>
+                domain_sep_inv False sta s \<and> irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+proof (induct s arbitrary: rule: rec_del.induct, simp_all only: rec_del_fails hoare_fail_any)
   case (1 slot exposed s) show ?case
-    apply(simp add: split_def rec_del.simps)
-    apply(wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp]
-             empty_slot_domain_sep_inv)
-     apply(wp irq_state_inv_triv' empty_slot_irq_masks)
-    apply(rule spec_strengthen_postE[OF "1.hyps", simplified])
+    apply (simp add: split_def rec_del.simps)
+    apply (wp drop_spec_validE[OF returnOk_wp]
+              drop_spec_validE[OF liftE_wp] empty_slot_domain_sep_inv)
+     apply (wp irq_state_inv_triv' empty_slot_irq_masks)
+    apply (rule spec_strengthen_postE[OF "1.hyps", simplified])
     apply fastforce
     done
-  next
+next
   case (2 slot exposed s) show ?case
-    apply(rule hoare_spec_gen_asm)
-    apply(simp add: rec_del.simps split del: if_split)
-    apply(rule hoare_pre_spec_validE)
-     apply(wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
-          |simp add: split_def split del: if_split)+
-         apply(wp irq_state_inv_triv)[1]
+    apply (rule hoare_spec_gen_asm)
+    apply (simp add: rec_del.simps split del: if_split)
+    apply (rule hoare_pre_spec_validE)
+     apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
+            | simp add: split_def split del: if_split)+
+         apply (wp irq_state_inv_triv)[1]
         apply (wp | simp split del: if_split)+
-           apply(rule spec_strengthen_postE)
-            apply(rule "2.hyps"[simplified], fastforce+)
-          apply(rule drop_spec_validE, (wp preemption_point_irq_state_inv[where irq=irq]
-                                       | simp)+)[1]
-         apply(rule spec_strengthen_postE)
-          apply(rule "2.hyps"[simplified], fastforce+)
-         apply(wp  finalise_cap_domain_sep_inv_cap get_cap_wp
-                   finalise_cap_returns_NullCap[where irqs=False, simplified]
-                   drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
-               |simp add: without_preemption_def split del: if_split
-               |wp (once) hoare_drop_imps
-               |wp irq_state_inv_triv)+
-    apply(blast dest: cte_wp_at_domain_sep_inv_cap)
+           apply (rule spec_strengthen_postE)
+            apply (rule "2.hyps"[simplified], fastforce+)
+          apply (rule drop_spec_validE,
+                 (wp preemption_point_irq_state_inv[where irq=irq] | simp)+)[1]
+         apply (rule spec_strengthen_postE)
+          apply (rule "2.hyps"[simplified], fastforce+)
+           apply (wp  finalise_cap_domain_sep_inv_cap get_cap_wp
+                     finalise_cap_returns_NullCap[where irqs=False, simplified]
+                     drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
+                  | simp add: without_preemption_def split del: if_split
+                  | wp (once) hoare_drop_imps
+                  | wp irq_state_inv_triv)+
+    apply (blast dest: cte_wp_at_domain_sep_inv_cap)
     done
-  next
+next
   case (3 ptr bits n slot s) show ?case
-    apply(simp add: rec_del.simps)
+    apply (simp add: rec_del.simps)
     apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] irq_state_inv_triv)
-    apply(rule hoare_pre_spec_validE)
-    apply (wp drop_spec_validE[OF assertE_wp])
-    apply(fastforce)
+    apply (rule hoare_pre_spec_validE)
+     apply (wp drop_spec_validE[OF assertE_wp])
+    apply (fastforce)
     done
-  next
+next
   case (4 ptr bits n slot s) show ?case
-    apply(simp add: rec_del.simps)
-    apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
-              drop_spec_validE[OF assertE_wp] get_cap_wp
-          | simp add: without_preemption_def
-          | wp irq_state_inv_triv)+
+    apply (simp add: rec_del.simps)
+    apply (wpsimp wp: irq_state_inv_triv set_cap_domain_sep_inv drop_spec_validE[OF liftE_wp]
+                      drop_spec_validE[OF assertE_wp] drop_spec_validE[OF returnOk_wp] get_cap_wp)
     apply (rule spec_strengthen_postE[OF "4.hyps", simplified])
-     apply(simp add: returnOk_def return_def)
-    apply(clarsimp simp: domain_sep_inv_cap_def)
+     apply (simp add: returnOk_def return_def)
+    apply (clarsimp simp: domain_sep_inv_cap_def)
     done
-  qed
+qed
 
 lemma rec_del_irq_state_inv:
   "\<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
-    rec_del call
-        \<lbrace>\<lambda>a s. irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
-  apply(rule hoare_post_impErr)
-   apply(rule use_spec)
-   apply(rule rec_del_irq_state_inv')
+   rec_del call
+   \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+  apply (rule hoare_post_impErr)
+    apply (rule use_spec)
+    apply (rule rec_del_irq_state_inv')
    apply auto
   done
 
@@ -2958,81 +2484,69 @@ lemma cap_delete_irq_state_inv':
   "\<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
    cap_delete slot
    \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
-  apply(simp add: cap_delete_def | wp rec_del_irq_state_inv)+
-  by auto
+  by (wpsimp wp: rec_del_irq_state_inv simp: cap_delete_def) auto
 
 lemmas cap_delete_irq_state_inv[wp] = validE_validE_R'[OF cap_delete_irq_state_inv']
 lemmas cap_delete_irq_state_next[wp] = validE_validE_E'[OF cap_delete_irq_state_inv']
 
-
-
 lemma cap_revoke_irq_state_inv'':
   notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del]
   shows
-  "s \<turnstile> \<lbrace> irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
-   cap_revoke slot
-   \<lbrace> \<lambda>_ s. irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
-  proof(induct rule: cap_revoke.induct[where ?a1.0=s])
+    "s \<turnstile> \<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
+         cap_revoke slot
+         \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+proof(induct rule: cap_revoke.induct[where ?a1.0=s])
   case (1 slot s)
   show ?case
-  apply(subst cap_revoke.simps)
-  apply(rule hoare_spec_gen_asm)
-  apply(rule hoare_pre_spec_validE)
-   apply (wp "1.hyps")
-           apply(wp spec_valid_conj_liftE2 | simp)+
-           apply(wp drop_spec_validE[OF preemption_point_irq_state_inv[simplified validE_R_def]]
-                    drop_spec_validE[OF preemption_point_irq_state_inv'[where irq=irq]]
-                    drop_spec_validE[OF valid_validE[OF preemption_point_domain_sep_inv]]
-                    cap_delete_domain_sep_inv cap_delete_irq_state_inv
-                    drop_spec_validE[OF assertE_wp] drop_spec_validE[OF returnOk_wp]
-                    drop_spec_validE[OF liftE_wp] select_wp
-                    drop_spec_validE[OF  hoare_vcg_conj_liftE1]
-                | simp | wp (once) hoare_drop_imps)+
-  apply fastforce
-  done
-  qed
+    apply (subst cap_revoke.simps)
+    apply (rule hoare_spec_gen_asm)
+    apply (rule hoare_pre_spec_validE)
+     apply (wp "1.hyps")
+            apply (wp spec_valid_conj_liftE2 | simp)+
+            apply (wp drop_spec_validE[OF preemption_point_irq_state_inv[simplified validE_R_def]]
+                      drop_spec_validE[OF preemption_point_irq_state_inv'[where irq=irq]]
+                      drop_spec_validE[OF valid_validE[OF preemption_point_domain_sep_inv]]
+                      cap_delete_domain_sep_inv cap_delete_irq_state_inv select_wp
+                      drop_spec_validE[OF assertE_wp] drop_spec_validE[OF returnOk_wp]
+                      drop_spec_validE[OF liftE_wp] drop_spec_validE[OF hoare_vcg_conj_liftE1]
+                   | simp | wp (once) hoare_drop_imps)+
+    apply fastforce
+    done
+qed
 
 lemmas cap_revoke_irq_state_inv' = use_spec(2)[OF cap_revoke_irq_state_inv'']
-
 lemmas cap_revoke_irq_state_inv[wp] = validE_validE_R'[OF cap_revoke_irq_state_inv']
 lemmas cap_revoke_irq_state_next[wp] = validE_validE_E'[OF cap_revoke_irq_state_inv']
 
-
 lemma finalise_slot_irq_state_inv:
   "\<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
-    finalise_slot p e \<lbrace>\<lambda>_ s. irq_state_inv st s\<rbrace>,\<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
-  apply(simp add: finalise_slot_def | wp rec_del_irq_state_inv[folded validE_R_def])+
-  by blast
-
+   finalise_slot p e
+   \<lbrace>\<lambda>_ s. irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+  by (wpsimp wp: rec_del_irq_state_inv[folded validE_R_def] simp: finalise_slot_def) blast
 
 lemma invoke_cnode_irq_state_inv:
-  "\<lbrace>irq_state_inv st and domain_sep_inv False sta and
-    valid_cnode_inv cnode_invocation and K (irq_is_recurring irq st)\<rbrace>
+  "\<lbrace>irq_state_inv st and domain_sep_inv False sta
+                     and valid_cnode_inv cnode_invocation and K (irq_is_recurring irq st)\<rbrace>
    invoke_cnode cnode_invocation
-   \<lbrace>\<lambda>y. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+   \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
   apply (rule hoare_assume_preE)
-  apply(simp add: invoke_cnode_def)
-  apply(rule hoare_pre)
+  apply (simp add: invoke_cnode_def)
+  apply (rule hoare_pre)
    apply wpc
-         apply((wp cap_revoke_irq_state_inv' cap_delete_irq_state_inv hoare_vcg_all_lift
-               | wpc
-               | simp add: cap_move_def split del: if_split
-               | wp (once) irq_state_inv_triv
-               | wp (once) hoare_drop_imps)+)[7]
+         apply ((wp cap_revoke_irq_state_inv' cap_delete_irq_state_inv hoare_vcg_all_lift
+                 | wpc
+                 | simp add: cap_move_def split del: if_split
+                 | wp (once) irq_state_inv_triv
+                 | wp (once) hoare_drop_imps)+)[7]
   apply fastforce
   done
 
 lemma checked_insert_irq_state_of_state[wp]:
-  "\<lbrace>\<lambda> s. P (irq_state_of_state s)\<rbrace>
-   check_cap_at a b
-           (check_cap_at c d
-             (cap_insert e f g))
-          \<lbrace>\<lambda>r s. P (irq_state_of_state s)\<rbrace>"
-  apply(wp | simp add: check_cap_at_def)+
-  done
+  "check_cap_at a b (check_cap_at c d (cap_insert e f g)) \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  by (wp | simp add: check_cap_at_def)+
 
 lemma irq_state_inv_invoke_domain[wp]:
-  "\<lbrace>irq_state_inv st\<rbrace> invoke_domain a b \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>"
+  "invoke_domain a b \<lbrace>irq_state_inv st\<rbrace>"
   apply (simp add: irq_state_inv_def[abs_def])
   apply (rule hoare_pre)
    apply wps
@@ -3040,295 +2554,224 @@ lemma irq_state_inv_invoke_domain[wp]:
   done
 
 crunch irq_state_of_state: bind_notification "\<lambda>s. P (irq_state_of_state s)"
+crunch machine_state[wp]: set_mcpriority "\<lambda>s. P (machine_state s)"
 
 lemmas bind_notification_irq_state_inv[wp] =
   irq_state_inv_triv[OF bind_notification_irq_state_of_state bind_notification_irq_masks]
 
-crunch machine_state[wp]: set_mcpriority "\<lambda>s. P (machine_state s)"
-
-lemma invoke_tcb_irq_state_inv:
-  "\<lbrace>(\<lambda>s. irq_state_inv st s) and domain_sep_inv False sta and
-    Tcb_AI.tcb_inv_wf tinv and K (irq_is_recurring irq st)\<rbrace>
-   invoke_tcb tinv
-   \<lbrace>\<lambda>_ s. irq_state_inv st s\<rbrace>,\<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
-  apply(case_tac tinv)
-       apply((wp hoare_vcg_if_lift  mapM_x_wp[OF _ subset_refl]
-            | wpc
-            | simp split del: if_split add: check_cap_at_def
-            | clarsimp
-            | wp (once) irq_state_inv_triv)+)[3]
-    defer
-    apply((wp irq_state_inv_triv | simp )+)[2]
-  (* just ThreadControl left *)
-  apply (simp add: split_def cong: option.case_cong)
-
-  by (wp hoare_vcg_all_lift_R
-            hoare_vcg_all_lift hoare_vcg_const_imp_lift_R
-            checked_cap_insert_domain_sep_inv
-            cap_delete_deletes  cap_delete_irq_state_inv[where st=st and sta=sta and irq=irq]
-            cap_delete_irq_state_next[where st=st and sta=sta and irq=irq]
-            cap_delete_valid_cap cap_delete_cte_at
-        |wpc
-        |simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
-                  tcb_at_st_tcb_at option_update_thread_def
-        |strengthen use_no_cap_to_obj_asid_strg
-        |wp (once) irq_state_inv_triv
-        |wp (once) hoare_drop_imps | clarsimp split: option.splits | intro impI conjI allI)+
-
 lemma do_reply_transfer_irq_state_inv_triv[wp]:
-  "\<lbrace>irq_state_inv st\<rbrace> do_reply_transfer a b c d \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>"
-  apply (wp irq_state_inv_triv)
-  done
+  "do_reply_transfer a b c d \<lbrace>irq_state_inv st\<rbrace>"
+  by (wp irq_state_inv_triv)
 
 lemma set_domain_irq_state_inv_triv[wp]:
-  "\<lbrace>irq_state_inv st\<rbrace> set_domain a b \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>"
-  apply (wp irq_state_inv_triv)
-  done
-
-lemma arch_invoke_irq_control_noErr[wp]:
-  "\<lbrace>\<top>\<rbrace> arch_invoke_irq_control a -,\<lbrace>Q\<rbrace>"
-  apply (cases a)
-  apply (wp | simp)+
-  done
-
-lemma invoke_irq_control_noErr[wp]:
-  "\<lbrace>\<top>\<rbrace> invoke_irq_control a -,\<lbrace>Q\<rbrace>"
-  apply (cases a)
-  apply (wp | simp add: arch_invoke_irq_control_noErr)+
-  done
-
-lemma arch_perform_invocation_noErr[wp]:
-  "\<lbrace>\<top>\<rbrace> arch_perform_invocation a -,\<lbrace>Q\<rbrace>"
-  apply (simp add: arch_perform_invocation_def)
-  apply wp
-  done
+  "set_domain a b \<lbrace>irq_state_inv st\<rbrace>"
+  by (wp irq_state_inv_triv)
 
 lemma use_validE_E:
-  "\<lbrakk>(Inl r, s') \<in> fst (fa s); \<lbrace>P\<rbrace> fa -, \<lbrace>Q\<rbrace>; P s\<rbrakk> \<Longrightarrow> Q r s'"
-  apply (fastforce simp: validE_E_def validE_def valid_def)
-  done
-
+  "\<lbrakk> (Inl r, s') \<in> fst (fa s); \<lbrace>P\<rbrace> fa -, \<lbrace>Q\<rbrace>; P s \<rbrakk> \<Longrightarrow> Q r s'"
+  by (fastforce simp: validE_E_def validE_def valid_def)
 
 lemma irq_state_inv_trivE':
   assumes irq_state:
-    "\<And> P. \<lbrace> \<lambda>s. P (irq_state_of_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_state_of_state s)\<rbrace>"
+    "\<And>P. f \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
   assumes irq_masks:
-    "\<And> P. \<lbrace> (\<lambda>s. P (irq_masks_of_state s)) and Q\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+    "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and Q\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
   assumes no_err:
-    "\<And> P. \<lbrace>\<top>\<rbrace> f -,\<lbrace>P\<rbrace>"
+    "\<And>P. \<lbrace>\<top>\<rbrace> f -, \<lbrace>P\<rbrace>"
   shows
     "\<lbrace>irq_state_inv st and Q\<rbrace> f \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
-  apply(clarsimp simp: validE_def valid_def irq_state_inv_def split: sum.splits)
-  apply(rule use_valid[OF _ irq_state], assumption)
-  apply(rule use_valid[OF _ irq_masks],assumption)
+  apply (clarsimp simp: validE_def valid_def irq_state_inv_def split: sum.splits)
+  apply (rule use_valid[OF _ irq_state], assumption)
+  apply (rule use_valid[OF _ irq_masks],assumption)
   apply clarsimp
   apply (erule use_validE_E[OF _ no_err])
   apply simp
   done
 
-crunch irq_state[wp]: cleanCacheRange_PoU "\<lambda>s. P (irq_state s)"
-  (ignore_del: cleanCacheRange_PoU cleanByVA_PoU)
 
-crunch irq_state_of_state[wp]: init_arch_objects "\<lambda>s. P (irq_state_of_state s)"
-  (wp: crunch_wps dmo_wp ignore: do_machine_op)
+context ADT_IF_1 begin
 
-lemma reset_untyped_cap_irq_state_inv:
-  "\<lbrace>irq_state_inv st and K (irq_is_recurring irq st)\<rbrace>
-      reset_untyped_cap slot \<lbrace>\<lambda>y. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>y. irq_state_next st\<rbrace>"
-  apply (cases "irq_is_recurring irq st", simp_all)
-  apply (simp add: reset_untyped_cap_def)
-  apply (rule hoare_pre)
-   apply (wp no_irq_clearMemory mapME_x_wp'
-             hoare_vcg_const_imp_lift
-             preemption_point_irq_state_inv'[where irq=irq]
-             get_cap_wp
-     | rule irq_state_inv_triv
-     | simp add: unless_def
-     | wp (once) dmo_wp)+
-  done
+crunch irq_state_of_state[wp]: invoke_irq_control "\<lambda>s. P (irq_state_of_state s)"
+
+lemma invoke_irq_control_noErr[wp]:
+  "\<lbrace>\<top>\<rbrace> invoke_irq_control a -,\<lbrace>\<lambda>rv s :: det_state. Q rv s\<rbrace>"
+  by (cases a; wpsimp simp: arch_invoke_irq_control_noErr)
 
 lemma invoke_untyped_irq_state_inv:
   "\<lbrace>irq_state_inv st and K (irq_is_recurring irq st)\<rbrace>
-    invoke_untyped ui \<lbrace>\<lambda>y. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>y. irq_state_next st\<rbrace>"
+   invoke_untyped ui
+   \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
   apply (cases ui, simp add: invoke_untyped_def mapM_x_def[symmetric])
   apply (rule hoare_pre)
-   apply (wp mapM_x_wp' hoare_whenE_wp
-             reset_untyped_cap_irq_state_inv[where irq=irq]
-     | rule irq_state_inv_triv
-     | simp)+
+   apply (wp mapM_x_wp' hoare_whenE_wp reset_untyped_cap_irq_state_inv[where irq=irq]
+         | rule irq_state_inv_triv | simp)+
   done
 
 lemma perform_invocation_irq_state_inv:
-   "\<lbrace>irq_state_inv st and
-      (\<lambda>s. \<forall>blah.
-            oper = InvokeIRQHandler blah \<longrightarrow>
-             (\<exists>ptr'.
-                 cte_wp_at
-                 ((=) (IRQHandlerCap (irq_of_handler_inv blah)))
-                 ptr' s)) and
-     domain_sep_inv False sta and
-     valid_invocation oper and K (irq_is_recurring irq st)\<rbrace>
-   perform_invocation x y oper \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
-  apply(case_tac oper; simp;
-    (solves \<open>(wp invoke_untyped_irq_state_inv[where irq=irq]
-                 invoke_tcb_irq_state_inv invoke_cnode_irq_state_inv[simplified validE_R_def]
-                 irq_state_inv_triv
-               | simp | clarsimp
-               | simp add: invoke_domain_def)+\<close>)?)
+   "\<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state)
+                      and valid_invocation op and K (irq_is_recurring irq st)
+                      and (\<lambda>s. \<forall>i. op = InvokeIRQHandler i \<longrightarrow>
+                                   (\<exists>p. cte_wp_at ((=) (IRQHandlerCap (irq_of_handler_inv i))) p s))\<rbrace>
+    perform_invocation x y op
+    \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+  apply (case_tac op; simp;
+         (solves \<open>(wp invoke_untyped_irq_state_inv[where irq=irq] irq_state_inv_triv
+                      invoke_tcb_irq_state_inv invoke_cnode_irq_state_inv[simplified validE_R_def]
+                   | clarsimp | simp add: invoke_domain_def)+\<close>)?)
    apply wp
     apply (wp irq_state_inv_triv' invoke_irq_control_irq_masks)
     apply clarsimp
     apply assumption
    apply auto[1]
   apply wp
-   apply(wp irq_state_inv_triv' invoke_irq_handler_irq_masks | clarsimp)+
+   apply (wp irq_state_inv_triv' invoke_irq_handler_irq_masks | clarsimp)+
    apply assumption
   apply auto[1]
   done
 
-
 lemma hoare_drop_impE:
-  assumes a: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
-  shows "\<lbrace>P\<rbrace> f \<lbrace>\<lambda> r s. R r s \<longrightarrow> Q r s\<rbrace>,\<lbrace>E\<rbrace>"
-  using assms apply(fastforce simp: validE_def valid_def split: sum.splits)
-  done
+  assumes a: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>"
+  shows "\<lbrace>P\<rbrace> f \<lbrace>\<lambda> r s. R r s \<longrightarrow> Q r s\<rbrace>, \<lbrace>E\<rbrace>"
+  using assms by (fastforce simp: validE_def valid_def split: sum.splits)
 
 lemma handle_invocation_irq_state_inv:
-   "\<lbrace>invs and domain_sep_inv False sta and irq_state_inv st and K (irq_is_recurring irq st)\<rbrace>
-    handle_invocation x y \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+   "\<lbrace>invs and domain_sep_inv False (sta :: det_state)
+          and irq_state_inv st and K (irq_is_recurring irq st)\<rbrace>
+    handle_invocation x y
+    \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
   apply (simp add: handle_invocation_def ts_Restart_case_helper split_def
                    liftE_liftM_liftME liftME_def bindE_assoc
               split del: if_split)
-  apply(wp syscall_valid)
-         apply ((wp irq_state_inv_triv | wpc | simp)+)[2]
-       apply(wp static_imp_wp perform_invocation_irq_state_inv hoare_vcg_all_lift
-                hoare_vcg_ex_lift decode_invocation_IRQHandlerCap
-            | wpc
-            | wp (once) hoare_drop_imps
-            | simp split del: if_split
-            | wp (once) irq_state_inv_triv)+
+  apply (wp syscall_valid)
+          apply ((wp irq_state_inv_triv | wpc | simp)+)[2]
+        apply (wp static_imp_wp perform_invocation_irq_state_inv hoare_vcg_all_lift
+                  hoare_vcg_ex_lift decode_invocation_IRQHandlerCap
+               | wpc
+               | wp (once) hoare_drop_imps
+               | simp split del: if_split
+               | wp (once) irq_state_inv_triv)+
   apply fastforce
   done
 
 lemma handle_event_irq_state_inv:
-  "event \<noteq> Interrupt \<Longrightarrow>
-   \<lbrace>irq_state_inv st and invs and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
-   handle_event event \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
-  apply(case_tac event; simp)
-      apply(rename_tac syscall)
-      apply(case_tac syscall)
-      apply simp_all
-             apply ((simp add: handle_send_def handle_call_def
-                    | wp handle_invocation_irq_state_inv[where sta=sta and irq=irq]
-                         irq_state_inv_triv[OF handle_recv_irq_state_of_state]
-                         irq_state_inv_triv[OF handle_reply_irq_state_of_state])+)
-       apply (wp irq_state_inv_triv hy_inv | simp)+
-  done
+  "event \<noteq> Interrupt
+   \<Longrightarrow> \<lbrace>irq_state_inv st and invs and domain_sep_inv False (sta :: det_state)
+                                  and K (irq_is_recurring irq st)\<rbrace>
+       handle_event event
+       \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+  apply (case_tac event; simp)
+      apply (rename_tac syscall)
+      apply (case_tac syscall)
+  by (simp add: handle_send_def handle_call_def
+      | wp handle_invocation_irq_state_inv[where sta=sta and irq=irq]
+           irq_state_inv_triv[OF handle_recv_irq_state_of_state] irq_state_inv_triv
+           irq_state_inv_triv[OF handle_reply_irq_state_of_state] hy_inv)+
+
+end
+
 
 lemma schedule_if_irq_state_inv:
-  "\<lbrace>irq_state_inv st\<rbrace> schedule_if tc \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>"
+  "schedule_if tc \<lbrace>irq_state_inv st\<rbrace>"
   by (wp irq_state_inv_triv
-     | simp add: schedule_if_def activate_thread_def arch_activate_idle_thread_def
-     | wpc
-     | wp (once) hoare_drop_imps)+
+      | simp add: schedule_if_def activate_thread_def
+      | wpc
+      | wp (once) hoare_drop_imps)+
 
 lemma irq_measure_if_inv:
   assumes irq_state:
-    "\<And> st. \<lbrace>P st\<rbrace> f \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>,-"
+    "\<And>st. \<lbrace>P st\<rbrace> f \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>,-"
   shows
-    "\<lbrace>\<lambda>s. irq_measure_if_inv st s \<and> (irq_state_inv s s \<longrightarrow> P s s)\<rbrace> f \<lbrace>\<lambda>_. irq_measure_if_inv st\<rbrace>,-"
+    "\<lbrace>\<lambda>s. irq_measure_if_inv st s \<and> (irq_state_inv s s \<longrightarrow> P s s)\<rbrace> f \<lbrace>\<lambda>_. irq_measure_if_inv st\<rbrace>, -"
   apply (clarsimp simp: valid_def validE_R_def validE_def)
   apply (simp add: irq_measure_if_inv_def)
   apply (erule order_trans[rotated])
   apply (simp add: irq_state_inv_refl)
   apply (drule use_validE_R, rule irq_state, assumption)
-  apply (simp add: irq_state_inv_def irq_measure_if_inv_def Let_def
-                   irq_measure_if_def)
-  apply auto
+  apply (auto simp: irq_state_inv_def irq_measure_if_inv_def Let_def irq_measure_if_def)
   done
 
 lemma irq_measure_if_inv_old:
   assumes irq_state:
-    "\<And> st. \<lbrace>irq_state_inv st and Q\<rbrace> f \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>,-"
+    "\<And>st. \<lbrace>irq_state_inv st and Q\<rbrace> f \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, -"
   shows
-    "\<lbrace>irq_measure_if_inv st and Q\<rbrace> f \<lbrace>\<lambda>_. irq_measure_if_inv st\<rbrace>,-"
+    "\<lbrace>irq_measure_if_inv st and Q\<rbrace> f \<lbrace>\<lambda>_. irq_measure_if_inv st\<rbrace>, -"
   by (wpsimp wp: irq_measure_if_inv irq_state)
 
 lemma irq_measure_if_inv':
   assumes irq_state:
-    "\<And> st. \<lbrace>P st\<rbrace> f \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>"
+    "\<And>st. \<lbrace>P st\<rbrace> f \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>"
   shows
     "\<lbrace>\<lambda>s. irq_measure_if_inv st s \<and> (irq_state_inv s s \<longrightarrow> P s s)\<rbrace> f \<lbrace>\<lambda>_. irq_measure_if_inv st\<rbrace>"
-  apply(clarsimp simp: valid_def irq_measure_if_inv_def irq_state_inv_refl)
-  apply(erule le_trans[rotated])
-  apply(drule(1) use_valid[OF _ irq_state])
-  apply(clarsimp simp: irq_measure_if_def Let_def irq_state_inv_def)
+  apply (clarsimp simp: valid_def irq_measure_if_inv_def irq_state_inv_refl)
+  apply (erule le_trans[rotated])
+  apply (drule(1) use_valid[OF _ irq_state])
+  apply (clarsimp simp: irq_measure_if_def Let_def irq_state_inv_def)
   apply auto
   done
 
 lemma irq_measure_if_inv_old':
   assumes irq_state:
-    "\<And> st. \<lbrace>irq_state_inv st and Q\<rbrace> f \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>"
+    "\<And>st. \<lbrace>irq_state_inv st and Q\<rbrace> f \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>"
   shows
     "\<lbrace>irq_measure_if_inv st and Q\<rbrace> f \<lbrace>\<lambda>_. irq_measure_if_inv st\<rbrace>"
   by (wpsimp wp: irq_measure_if_inv' irq_state)
 
 lemma irq_state_inv_irq_is_recurring:
-  "irq_state_inv sta s \<Longrightarrow>
-     irq_is_recurring irq sta = irq_is_recurring irq s"
-  apply(clarsimp simp: irq_is_recurring_def irq_state_inv_def is_irq_at_def)
-  done
+  "irq_state_inv sta s \<Longrightarrow> irq_is_recurring irq sta = irq_is_recurring irq s"
+  by (clarsimp simp: irq_is_recurring_def irq_state_inv_def is_irq_at_def)
 
 abbreviation next_irq_state_of_state where
-  "next_irq_state_of_state s \<equiv>
-     next_irq_state (Suc (irq_state_of_state s)) (irq_masks_of_state s)"
+  "next_irq_state_of_state s \<equiv> next_irq_state (Suc (irq_state_of_state s)) (irq_masks_of_state s)"
+
+
+context ADT_IF_1 begin
 
 lemma kernel_entry_if_next_irq_state_of_state:
-  "\<lbrakk>event \<noteq> Interrupt; invs i_s; domain_sep_inv False st i_s; irq_is_recurring irq i_s;
-    ((Inr (), a), b) \<in> fst (kernel_entry_if event uc i_s)\<rbrakk>
-  \<Longrightarrow> next_irq_state_of_state b = next_irq_state_of_state i_s"
-  apply(simp add: kernel_entry_if_def in_bind in_return | elim conjE exE)+
-  apply(erule use_validE_R)
-   apply(rule_tac Q'="\<lambda>_. irq_state_inv i_s" in hoare_post_imp_R)
-   apply (rule validE_validE_R')
-    apply(rule handle_event_irq_state_inv[where sta=st and irq=irq] | simp)+
-   apply(clarsimp simp: irq_state_inv_def)
+  "\<lbrakk> event \<noteq> Interrupt; invs i_s; domain_sep_inv False (st :: det_state) i_s;
+     irq_is_recurring irq i_s; ((Inr (), a), b) \<in> fst (kernel_entry_if event uc i_s) \<rbrakk>
+     \<Longrightarrow> next_irq_state_of_state b = next_irq_state_of_state i_s"
+  apply (simp add: kernel_entry_if_def in_bind in_return | elim conjE exE)+
+  apply (erule use_validE_R)
+   apply (rule_tac Q'="\<lambda>_. irq_state_inv i_s" in hoare_post_imp_R)
+    apply (rule validE_validE_R')
+    apply (rule handle_event_irq_state_inv[where sta=st and irq=irq] | simp)+
+   apply (clarsimp simp: irq_state_inv_def)
   apply (simp add: arch_tcb_update_aux2)
-  apply(erule_tac f="thread_set (tcb_arch_update (arch_tcb_context_set uc)) t" in use_valid)
-   apply(wpsimp wp: irq_measure_if_inv' irq_state_inv_triv thread_set_invs_trivial
-                    irq_is_recurring_triv[where Q="\<top>"]
-              simp: ran_tcb_cap_cases tcb_arch_ref_def)+
-  apply(erule use_valid)
+  apply (erule_tac f="thread_set (tcb_arch_update (arch_tcb_context_set uc)) t" in use_valid)
+   apply (wpsimp wp: irq_measure_if_inv' irq_state_inv_triv
+                     thread_set_invs_trivial irq_is_recurring_triv
+               simp: ran_tcb_cap_cases)+
+  apply (erule use_valid)
    apply (wp | simp )+
-  apply(simp add: irq_state_inv_def)
+  apply (simp add: irq_state_inv_def)
   done
 
 lemma kernel_entry_if_next_irq_state_of_state_next:
-  "\<lbrakk>event \<noteq> Interrupt; invs i_s; domain_sep_inv False st i_s; irq_is_recurring irq i_s;
-    ((Inl r, a), b) \<in> fst (kernel_entry_if event uc i_s)\<rbrakk>
-  \<Longrightarrow> irq_state_of_state b = next_irq_state_of_state i_s"
-  apply(simp add: kernel_entry_if_def in_bind in_return | elim conjE exE)+
-  apply(erule use_validE_E)
+  "\<lbrakk> event \<noteq> Interrupt; invs i_s; domain_sep_inv False (st :: det_state) i_s;
+     irq_is_recurring irq i_s; ((Inl r, a), b) \<in> fst (kernel_entry_if event uc i_s) \<rbrakk>
+     \<Longrightarrow> irq_state_of_state b = next_irq_state_of_state i_s"
+  apply (simp add: kernel_entry_if_def in_bind in_return | elim conjE exE)+
+  apply (erule use_validE_E)
    apply (rule validE_validE_E)
    apply (rule hoare_post_impErr)
      apply (rule handle_event_irq_state_inv[where sta=st and irq=irq and st=i_s])
      apply simp+
    apply (simp add: irq_state_next_def)
   apply (simp add: arch_tcb_update_aux2)
-  apply(erule_tac f="thread_set (tcb_arch_update (arch_tcb_context_set uc)) t" in use_valid)
-   apply(wpsimp wp: irq_measure_if_inv' irq_state_inv_triv
-                    thread_set_invs_trivial irq_is_recurring_triv[where Q="\<top>"]
-              simp: ran_tcb_cap_cases tcb_arch_ref_def)+
-  apply(erule use_valid)
+  apply (erule_tac f="thread_set (tcb_arch_update (arch_tcb_context_set uc)) t" in use_valid)
+   apply (wpsimp wp: irq_measure_if_inv' irq_state_inv_triv
+                     thread_set_invs_trivial irq_is_recurring_triv
+               simp: ran_tcb_cap_cases)+
+  apply (erule use_valid)
    apply (wp | simp )+
-  apply(simp add: irq_state_inv_def)
+  apply (simp add: irq_state_inv_def)
   done
 
 lemma kernel_entry_if_irq_measure:
-  "\<lbrakk>event \<noteq> Interrupt; invs i_s; domain_sep_inv False st i_s; irq_is_recurring irq i_s\<rbrakk>
-   \<Longrightarrow> ((Inr (), a), b) \<in> fst (kernel_entry_if event uc i_s)
-  \<Longrightarrow> irq_measure_if b \<le> irq_measure_if i_s"
- apply (fold irq_measure_if_inv_def)
+  "\<lbrakk> event \<noteq> Interrupt; invs i_s; domain_sep_inv False (st :: det_state) i_s;
+     irq_is_recurring irq i_s; ((Inr (), a), b) \<in> fst (kernel_entry_if event uc i_s) \<rbrakk>
+     \<Longrightarrow> irq_measure_if b \<le> irq_measure_if i_s"
+  apply (fold irq_measure_if_inv_def)
   apply (rule mp)
    apply (erule_tac P="(=) i_s" and Q="\<lambda>rv s. (isRight (fst rv)) \<longrightarrow> Q s" for Q in use_valid)
     apply (simp_all add: isRight_def)
@@ -3336,276 +2779,46 @@ lemma kernel_entry_if_irq_measure:
   apply (rule hoare_pre, wp)
      apply (rule validE_cases_valid, simp)
      apply (wp irq_measure_if_inv handle_event_irq_state_inv[THEN validE_validE_R'])+
-    apply(wpsimp wp: irq_measure_if_inv' irq_state_inv_triv
-                    thread_set_invs_trivial irq_is_recurring_triv[where Q="\<top>"]
-              simp: ran_tcb_cap_cases arch_tcb_update_aux2 tcb_arch_ref_def
-                    irq_state_inv_refl)+
-  apply(simp add: irq_measure_if_inv_def)
+    apply (wpsimp wp: irq_measure_if_inv' irq_state_inv_triv
+                      thread_set_invs_trivial irq_is_recurring_triv
+                simp: ran_tcb_cap_cases arch_tcb_update_aux2 irq_state_inv_refl)+
+  apply (simp add: irq_measure_if_inv_def)
   done
+
+end
 
 
 lemma schedule_if_irq_measure_if:
-  "(r, b) \<in> fst (schedule_if uc i_s)
-  \<Longrightarrow> irq_measure_if b \<le> irq_measure_if i_s"
-  apply(fold irq_measure_if_inv_def)
-  apply(erule use_valid[OF _ irq_measure_if_inv'] | wp schedule_if_irq_state_inv | simp)+
-  apply(simp add: irq_measure_if_inv_def)
+  "(r, b) \<in> fst (schedule_if uc i_s) \<Longrightarrow> irq_measure_if b \<le> irq_measure_if i_s"
+  apply (fold irq_measure_if_inv_def)
+  apply (erule use_valid[OF _ irq_measure_if_inv'] | wp schedule_if_irq_state_inv | simp)+
+  apply (simp add: irq_measure_if_inv_def)
   done
 
 lemma schedule_if_next_irq_state_of_state:
-  "(r, b) \<in> fst (schedule_if uc i_s)
-  \<Longrightarrow> next_irq_state_of_state b = next_irq_state_of_state i_s"
-  apply(erule use_valid)
-   apply(rule_tac Q="\<lambda>_. irq_state_inv i_s" in hoare_strengthen_post)
-    apply(wp schedule_if_irq_state_inv)
-   apply(auto simp: irq_state_inv_def)
+  "(r, b) \<in> fst (schedule_if uc i_s) \<Longrightarrow> next_irq_state_of_state b = next_irq_state_of_state i_s"
+  apply (erule use_valid)
+   apply (rule_tac Q="\<lambda>_. irq_state_inv i_s" in hoare_strengthen_post)
+    apply (wp schedule_if_irq_state_inv)
+   apply (auto simp: irq_state_inv_def)
   done
 
 lemma next_irq_state_of_state_triv:
-  assumes masks: "\<And>P. \<lbrace>\<lambda> s. P (irq_masks_of_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  assumes sta: "\<And>P. \<lbrace>\<lambda> s. P (irq_state_of_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_state_of_state s)\<rbrace>"
-  shows
-  "\<lbrace>\<lambda>s. P (next_irq_state_of_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (next_irq_state_of_state s)\<rbrace>"
-  apply(clarsimp simp: valid_def)
-  apply(frule use_valid[OF _ masks])
-   apply assumption
-  apply(erule use_valid[OF _ sta])
-  by assumption
-
-lemmas do_user_op_if_next_irq_state_of_state =
-                  next_irq_state_of_state_triv[OF do_user_op_if_irq_masks_of_state
-                                                  do_user_op_if_irq_state_of_state]
+  assumes masks: "\<And>P. f \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  assumes sta: "\<And>P. f \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (next_irq_state_of_state s)\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (frule (1) use_valid[OF _ masks])
+  apply (erule (1) use_valid[OF _ sta])
+  done
 
 lemma interrupted_modes_KernelEntry[simp]:
   "interrupted_modes (KernelEntry e) = (e = Interrupt)"
-  apply(case_tac e, simp_all)
-  done
+  by (case_tac e, simp_all)
 
 lemma rah4:
   "b < a \<Longrightarrow> 4 * (a - Suc b) + 3 < 4 * (a - b)"
-  apply(rule Suc_le_lessD)
-  apply (simp)
-  done
-
-lemma tranclp_s0:
-  "big_step_R\<^sup>*\<^sup>* s0 s \<Longrightarrow>
-   interrupted_modes (snd s) \<or> (snd s) = KernelExit"
-  apply (simp only: rtranclp_def2)
-  apply(erule disjE)
-   apply(induct rule: tranclp.induct)
-    apply (auto simp: big_step_R_def s0_def)
-  done
-
-lemma ADT_A_if_sub_big_steps_measuref_if:
-  "\<lbrakk>(s',evs) \<in> sub_big_steps (ADT_A_if utf) big_step_R s; big_step_R\<^sup>*\<^sup>* s0 s\<rbrakk> \<Longrightarrow>
-  measuref_if s s' > 0"
-  apply(drule tranclp_s0)
-  apply(erule sub_big_steps.induct)
-   apply(clarsimp simp: big_step_R_def measuref_if_def)
-  apply(clarsimp simp: big_step_R_def measuref_if_def split: if_splits)
-  apply(case_tac ba, simp_all, case_tac bc)
-  by(fastforce simp: Step_ADT_A_if' ADT_A_if_def global_automaton_if_def)+
-
-lemma rah_simp:
-  "(\<forall>b. b) = False"
-  apply blast
-  done
-
-lemma ADT_A_if_Step_measure_if':
-  "\<lbrakk>(s,s') \<in> data_type.Step (ADT_A_if utf) x; invs_if s;
-   measuref_if y s > 0\<rbrakk>
-       \<Longrightarrow> measuref_if y s' < measuref_if y s \<and>
-          (\<not> interrupted_modes (snd s) \<longrightarrow> \<not> interrupted_modes (snd s') \<longrightarrow>
-               next_irq_state_of_state (internal_state_if s') =
-               next_irq_state_of_state (internal_state_if s))"
-  apply(frule invs_if_irq_is_recurring)
-  apply(case_tac s, clarsimp)
-  apply(rename_tac uc i_s mode)
-  apply(case_tac mode)
-       apply(simp_all add: rah_simp system.Step_def execution_def steps_def ADT_A_if_def
-                           global_automaton_if_def check_active_irq_A_if_def do_user_op_A_if_def
-                           check_active_irq_if_def in_monad measuref_if_def
-            | safe
-            | split if_splits)+
-                              apply(frule getActiveIRQ_None)
-                              apply(erule use_valid[OF _ do_user_op_if_irq_measure_if])
-                              apply(erule use_valid[OF _ dmo_getActiveIRQ_wp])
-                              apply(clarsimp simp: irq_measure_if_def Let_def)
-                              apply(simp add: next_irq_state_Suc recurring_next_irq_state_dom)
-                              apply(blast intro: rah4[OF next_irq_state_less])
-                             apply(frule getActiveIRQ_None)
-                             apply(erule use_valid[OF _ do_user_op_if_next_irq_state_of_state])
-                             apply(erule use_valid[OF _ dmo_getActiveIRQ_wp])
-                             apply(simp add: next_irq_state_Suc recurring_next_irq_state_dom)
-                            apply(clarsimp split: if_splits)
-                           apply(frule getActiveIRQ_None)
-                           apply(erule use_valid[OF _ do_user_op_if_irq_measure_if])
-                           apply(erule use_valid[OF _ dmo_getActiveIRQ_wp])
-                           apply(clarsimp simp: irq_measure_if_def Let_def)
-                           apply(simp add: next_irq_state_Suc recurring_next_irq_state_dom)
-                           apply(fastforce dest: next_irq_state_less)
-                          apply(frule getActiveIRQ_None)
-                          apply(erule use_valid[OF _ do_user_op_if_next_irq_state_of_state])
-                          apply(erule use_valid[OF _ dmo_getActiveIRQ_wp])
-                          apply(simp add: next_irq_state_Suc recurring_next_irq_state_dom)
-                         apply(clarsimp split: if_splits)+
-                      apply(frule getActiveIRQ_None)
-                      apply(erule use_valid[OF _ dmo_getActiveIRQ_wp])
-                      apply(clarsimp simp: irq_measure_if_def Let_def)
-                      apply(simp add: next_irq_state_Suc recurring_next_irq_state_dom)
-                      apply(fastforce dest: next_irq_state_less)
-                     apply(frule getActiveIRQ_None)
-                     apply(erule use_valid[OF _ dmo_getActiveIRQ_wp])
-                     apply(simp add: next_irq_state_Suc recurring_next_irq_state_dom)
-                    apply(clarsimp split: if_splits)
-                   apply(clarsimp simp: kernel_call_A_if_def kernel_entry_if_def in_monad)
-                  apply(clarsimp split: if_splits)
-                 apply(rule Suc_le_lessD)
-                 apply simp
-                 apply(simp add: kernel_call_A_if_def)
-                 apply(elim exE conjE)
-                 apply(rule_tac event=x3 in kernel_entry_if_irq_measure)
-                     apply((simp add: invs_if_def Invs_def only_timer_irq_inv_def
-                           | elim conjE | assumption)+)[4]
-                 apply(simp)
-                apply(simp add: kernel_call_A_if_def | elim conjE exE)+
-                apply(erule kernel_entry_if_next_irq_state_of_state)
-                    apply((simp add: invs_if_def Invs_def only_timer_irq_inv_def
-                          | elim conjE | assumption)+)[4]
-
-               apply(clarsimp split: if_splits)
-              apply(rule Suc_le_lessD)
-              apply(simp add: kernel_schedule_if_def)
-              apply(blast intro: schedule_if_irq_measure_if)
-             apply(simp add: kernel_schedule_if_def)
-             apply(blast intro: schedule_if_next_irq_state_of_state)
-            apply(simp add: kernel_schedule_if_def)
-            apply(blast intro: schedule_if_next_irq_state_of_state)
-           apply(clarsimp simp: kernel_exit_A_if_def split: if_splits)
-          apply(clarsimp simp: kernel_exit_A_if_def)
-          apply((erule use_valid, wp | simp)+)[1]
-         apply(clarsimp split: if_splits)
-        apply(clarsimp simp: kernel_exit_A_if_def split: if_splits)
-       apply(clarsimp simp: kernel_exit_A_if_def)
-       apply((erule use_valid, wp | simp)+)[1]
-      apply(clarsimp split: if_splits)+
-    apply(clarsimp split: sys_mode.splits | safe)+
-       apply(clarsimp simp: irq_measure_if_def kernel_exit_A_if_def split: if_splits)
-       apply(drule state_unchanged[OF kernel_exit_if_inv], simp)
-      apply(clarsimp simp: irq_measure_if_def kernel_exit_A_if_def split: if_splits)
-      apply(drule state_unchanged[OF kernel_exit_if_inv], simp)
-     apply(clarsimp simp: kernel_exit_A_if_def split: if_splits)
-    apply(clarsimp simp: kernel_exit_A_if_def split: if_splits)
-   apply(clarsimp simp: kernel_exit_A_if_def)
-   apply((erule use_valid, wp | simp)+)[1]
-  apply(clarsimp simp: kernel_exit_A_if_def split: if_splits)
-  done
-
-lemma ADT_A_if_Step_measure_if'':
-  "\<lbrakk>(s,s') \<in> data_type.Step (ADT_A_if utf) x; invs_if s;
-   measuref_if y s > 0\<rbrakk>
-       \<Longrightarrow> measuref_if y s' < measuref_if y s \<and>
-          (\<not> interrupted_modes (snd s) \<longrightarrow> interrupted_modes (snd s')
-            \<longrightarrow> irq_state_of_state (internal_state_if s') =
-                next_irq_state_of_state (internal_state_if s))"
-  apply(frule invs_if_irq_is_recurring)
-  apply(case_tac s, clarsimp)
-  apply(rename_tac uc i_s mode)
-  apply(case_tac mode)
-       apply(simp_all add: rah_simp system.Step_def execution_def steps_def ADT_A_if_def
-                           global_automaton_if_def check_active_irq_A_if_def do_user_op_A_if_def
-                           check_active_irq_if_def in_monad measuref_if_def
-             | safe | split if_splits)+
-                         apply(frule getActiveIRQ_None)
-                         apply(erule use_valid[OF _ do_user_op_if_irq_measure_if])
-                         apply(erule use_valid[OF _ dmo_getActiveIRQ_wp])
-                         apply(clarsimp simp: irq_measure_if_def Let_def)
-                         apply(simp add: next_irq_state_Suc recurring_next_irq_state_dom)
-                         apply(blast intro: rah4[OF next_irq_state_less])
-                        apply(frule getActiveIRQ_None)
-                        apply(erule use_valid[OF _ do_user_op_if_next_irq_state_of_state])
-                        apply(erule use_valid[OF _ dmo_getActiveIRQ_wp])
-                        apply(simp add: next_irq_state_Suc recurring_next_irq_state_dom)
-                        apply(clarsimp split: if_splits)
-                       apply(frule getActiveIRQ_None)
-                       apply(erule use_valid[OF _ do_user_op_if_irq_measure_if])
-                       apply(erule use_valid[OF _ dmo_getActiveIRQ_wp])
-                       apply(clarsimp simp: irq_measure_if_def Let_def)
-                       apply(simp add: next_irq_state_Suc recurring_next_irq_state_dom)
-                       apply(fastforce dest: next_irq_state_less)
-                      apply(frule getActiveIRQ_None)
-                      apply(erule use_valid[OF _ do_user_op_if_next_irq_state_of_state])
-                      apply(erule use_valid[OF _ dmo_getActiveIRQ_wp])
-                      apply(simp add: next_irq_state_Suc recurring_next_irq_state_dom)
-                      apply(clarsimp split: if_splits)+
-                     apply (frule getActiveIRQ_Some)
-                     apply(erule use_valid[OF _ dmo_getActiveIRQ_wp])
-                     apply(simp add: next_irq_state_Suc' recurring_next_irq_state_dom)
-                    apply(clarsimp split: if_splits)
-                   apply (frule getActiveIRQ_Some)
-                   apply(erule use_valid[OF _ dmo_getActiveIRQ_wp])
-                   apply(simp add: next_irq_state_Suc' recurring_next_irq_state_dom)
-                  apply(clarsimp split: if_splits)
-                 apply(frule getActiveIRQ_None)
-                 apply(erule use_valid[OF _ dmo_getActiveIRQ_wp])
-                 apply(clarsimp simp: irq_measure_if_def Let_def)
-                 apply(simp add: next_irq_state_Suc recurring_next_irq_state_dom)
-                 apply(fastforce dest: next_irq_state_less)
-                apply(clarsimp split: if_splits)
-
-               apply(clarsimp simp: kernel_call_A_if_def in_monad)
-               apply (rule kernel_entry_if_next_irq_state_of_state_next,assumption+)
-                  prefer 4
-                  apply fastforce
-                 apply((simp add: invs_if_def Invs_def only_timer_irq_inv_def
-                       | elim conjE
-                       | assumption)+)[3]
-              apply(clarsimp split: if_splits)
-
-            apply(rule Suc_le_lessD)
-            apply simp
-            apply(simp add: kernel_call_A_if_def)
-            apply(elim exE conjE)
-            apply(rule_tac event=x3 in kernel_entry_if_irq_measure)
-                apply((simp add: invs_if_def Invs_def only_timer_irq_inv_def
-                      | elim conjE
-                      | assumption)+)[4]
-            apply(simp)
-           apply(clarsimp split: if_splits)
-          apply(rule Suc_le_lessD)
-          apply(simp add: kernel_schedule_if_def)
-          apply(blast intro: schedule_if_irq_measure_if)
-         apply(clarsimp simp: kernel_exit_A_if_def split: if_splits)
-        apply(clarsimp simp: kernel_exit_A_if_def)
-        apply((erule use_valid, wp | simp)+)[1]
-        apply(clarsimp split: if_splits)
-       apply(clarsimp simp: kernel_exit_A_if_def split: if_splits)
-      apply(clarsimp simp: kernel_exit_A_if_def)
-      apply((erule use_valid, wp | simp)+)[1]
-      apply(clarsimp split: if_splits)+
-     apply(clarsimp simp: kernel_exit_A_if_def split: if_splits)
-    apply(clarsimp split: if_splits)
-   apply(clarsimp split: sys_mode.splits | safe)+
-      apply(clarsimp simp: irq_measure_if_def kernel_exit_A_if_def split: if_splits)
-      apply(drule state_unchanged[OF kernel_exit_if_inv], simp)
-     apply(clarsimp simp: irq_measure_if_def kernel_exit_A_if_def split: if_splits)
-     apply(drule state_unchanged[OF kernel_exit_if_inv], simp)
-    apply(clarsimp simp: kernel_exit_A_if_def split: if_splits)
-   apply(clarsimp simp: kernel_exit_A_if_def split: if_splits)
-  apply(clarsimp simp: kernel_exit_A_if_def)
-  apply((erule use_valid, wp | simp)+)[1]
-  apply(clarsimp simp: kernel_exit_A_if_def split: if_splits)
-  done
-
-lemma invs_if_domain_sep_invs[intro]:
-  "invs_if ((a,s),b) \<Longrightarrow> domain_sep_inv False s0_internal s"
-  apply (simp add: invs_if_def Invs_def)
-  done
-
-lemma invs_if_invs[intro]:
-  "invs_if ((a,s),b) \<Longrightarrow> invs s"
-  apply (simp add: invs_if_def Invs_def)
-  done
+  by (simp add: Suc_le_lessD)
 
 lemma kernel_exit_irq_masks[wp]:
   "\<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace> kernel_exit_if uc \<lbrace>\<lambda>r s. P (irq_masks_of_state s)\<rbrace>"
@@ -3613,22 +2826,245 @@ lemma kernel_exit_irq_masks[wp]:
   apply wp
   done
 
-lemma ADT_A_if_Step_irq_masks:
-  "\<lbrakk>(s,s') \<in> data_type.Step (ADT_A_if utf) x; invs_if s\<rbrakk>
-       \<Longrightarrow> irq_masks_of_state (internal_state_if s') = irq_masks_of_state (internal_state_if s)"
-  apply(case_tac s, clarsimp)
-  apply(rename_tac uc i_s mode)
-  apply(case_tac mode)
-       apply(simp_all add: rah_simp system.Step_def execution_def steps_def ADT_A_if_def
+
+context valid_initial_state begin
+
+lemma invs_if_irq_is_recurring[simp]:
+  "invs_if s \<Longrightarrow> irq_is_recurring timer_irq (internal_state_if s)"
+  by (clarsimp simp: invs_if_def Invs_def only_timer_irq_inv_def only_timer_irq_def)
+
+lemma tranclp_s0:
+  "big_step_R\<^sup>*\<^sup>* s0 s \<Longrightarrow> interrupted_modes (snd s) \<or> (snd s) = KernelExit"
+  apply (simp only: rtranclp_def2)
+  apply (erule disjE)
+   apply (induct rule: tranclp.induct)
+    apply (auto simp: big_step_R_def s0_def)
+  done
+
+lemma ADT_A_if_sub_big_steps_measuref_if:
+  "\<lbrakk> (s',evs) \<in> sub_big_steps (ADT_A_if utf) big_step_R s; big_step_R\<^sup>*\<^sup>* s0 s \<rbrakk>
+     \<Longrightarrow> measuref_if s s' > 0"
+  apply (drule tranclp_s0)
+  apply (erule sub_big_steps.induct)
+   apply (clarsimp simp: big_step_R_def measuref_if_def)
+  apply (clarsimp simp: big_step_R_def measuref_if_def split: if_splits)
+   apply (case_tac ba, simp_all, case_tac bc)
+  by (fastforce simp: Step_ADT_A_if' ADT_A_if_def global_automaton_if_def)+
+
+lemma rah_simp:
+  "(\<forall>b. b) = False"
+  by blast
+
+lemma invs_if_domain_sep_invs[intro]:
+  "invs_if ((a,s),b) \<Longrightarrow> domain_sep_inv False s0_internal s"
+  by (simp add: invs_if_def Invs_def)
+
+lemma invs_if_invs[intro]:
+  "invs_if ((a,s),b) \<Longrightarrow> invs s"
+  by (simp add: invs_if_def Invs_def)
+
+end
+
+
+context ADT_valid_initial_state begin
+
+lemmas do_user_op_if_next_irq_state_of_state =
+  next_irq_state_of_state_triv[OF do_user_op_if_irq_masks_of_state do_user_op_if_irq_state_of_state]
+
+lemma ADT_A_if_Step_measure_if':
+  "\<lbrakk> (s,s') \<in> data_type.Step (ADT_A_if utf) x; invs_if s; measuref_if y s > 0 \<rbrakk>
+     \<Longrightarrow> measuref_if y s' < measuref_if y s \<and>
+         (\<not> interrupted_modes (snd s)
+          \<longrightarrow> \<not> interrupted_modes (snd s')
+              \<longrightarrow> next_irq_state_of_state (internal_state_if s') =
+                  next_irq_state_of_state (internal_state_if s))"
+  apply (frule invs_if_irq_is_recurring)
+  apply (case_tac s, clarsimp)
+  apply (rename_tac uc i_s mode)
+  apply (case_tac mode)
+       apply (simp_all add: rah_simp system.Step_def execution_def steps_def ADT_A_if_def
+                            global_automaton_if_def check_active_irq_A_if_def do_user_op_A_if_def
+                            check_active_irq_if_def in_monad measuref_if_def
+              | safe | split if_splits)+
+                             apply (frule getActiveIRQ_None)
+                             apply (erule use_valid[OF _ do_user_op_if_irq_measure_if])
+                             apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
+                             apply (clarsimp simp: irq_measure_if_def Let_def)
+                             apply (simp add: next_irq_state_Suc recurring_next_irq_state_dom)
+                             apply (blast intro: rah4[OF next_irq_state_less])
+                            apply (frule getActiveIRQ_None)
+                            apply (erule use_valid[OF _ do_user_op_if_next_irq_state_of_state])
+                            apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
+                            apply (simp add: next_irq_state_Suc recurring_next_irq_state_dom)
+                           apply (clarsimp split: if_splits)
+                          apply (frule getActiveIRQ_None)
+                          apply (erule use_valid[OF _ do_user_op_if_irq_measure_if])
+                          apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
+                          apply (clarsimp simp: irq_measure_if_def Let_def)
+                          apply (simp add: next_irq_state_Suc recurring_next_irq_state_dom)
+                          apply (fastforce dest: next_irq_state_less)
+                         apply (frule getActiveIRQ_None)
+                         apply (erule use_valid[OF _ do_user_op_if_next_irq_state_of_state])
+                         apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
+                         apply (simp add: next_irq_state_Suc recurring_next_irq_state_dom)
+                        apply (clarsimp split: if_splits)+
+                     apply (frule getActiveIRQ_None)
+                     apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
+                     apply (clarsimp simp: irq_measure_if_def Let_def)
+                     apply (simp add: next_irq_state_Suc recurring_next_irq_state_dom)
+                     apply (fastforce dest: next_irq_state_less)
+                    apply (frule getActiveIRQ_None)
+                    apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
+                    apply (simp add: next_irq_state_Suc recurring_next_irq_state_dom)
+                   apply (clarsimp split: if_splits)
+                  apply (clarsimp simp: kernel_call_A_if_def kernel_entry_if_def in_monad)
+                  apply (clarsimp split: if_splits)
+                 apply (rule Suc_le_lessD)
+                 apply simp
+                 apply (simp add: kernel_call_A_if_def)
+                 apply (elim exE conjE)
+                 apply (rule_tac event=x3 in kernel_entry_if_irq_measure)
+                     apply ((simp add: invs_if_def Invs_def only_timer_irq_inv_def
+                             | elim conjE | assumption)+)[4]
+                 apply (simp)
+                apply (simp add: kernel_call_A_if_def | elim conjE exE)+
+                apply (erule kernel_entry_if_next_irq_state_of_state)
+                   apply ((simp add: invs_if_def Invs_def only_timer_irq_inv_def
+                           | elim conjE | assumption)+)[4]
+               apply (clarsimp split: if_splits)
+              apply (rule Suc_le_lessD)
+              apply (simp add: kernel_schedule_if_def)
+              apply (blast intro: schedule_if_irq_measure_if)
+             apply (simp add: kernel_schedule_if_def)
+             apply (blast intro: schedule_if_next_irq_state_of_state)
+            apply (simp add: kernel_schedule_if_def)
+            apply (blast intro: schedule_if_next_irq_state_of_state)
+           apply (clarsimp simp: kernel_exit_A_if_def split: if_splits)
+          apply (clarsimp simp: kernel_exit_A_if_def)
+          apply ((erule use_valid, wp | simp)+)[1]
+         apply (clarsimp split: if_splits)
+        apply (clarsimp simp: kernel_exit_A_if_def split: if_splits)
+       apply (clarsimp simp: kernel_exit_A_if_def)
+       apply ((erule use_valid, wp | simp)+)[1]
+      apply (clarsimp split: if_splits)+
+    apply (clarsimp split: sys_mode.splits | safe)+
+       apply (clarsimp simp: irq_measure_if_def kernel_exit_A_if_def split: if_splits)
+       apply (drule state_unchanged[OF kernel_exit_if_inv], simp)
+      apply (clarsimp simp: irq_measure_if_def kernel_exit_A_if_def split: if_splits)
+      apply (drule state_unchanged[OF kernel_exit_if_inv], simp)
+     apply (clarsimp simp: kernel_exit_A_if_def split: if_splits)
+    apply (clarsimp simp: kernel_exit_A_if_def split: if_splits)
+   apply (clarsimp simp: kernel_exit_A_if_def)
+   apply ((erule use_valid, wp | simp)+)[1]
+  apply (clarsimp simp: kernel_exit_A_if_def split: if_splits)
+  done
+
+lemma ADT_A_if_Step_measure_if'':
+  "\<lbrakk> (s,s') \<in> data_type.Step (ADT_A_if utf) x; invs_if s; measuref_if y s > 0 \<rbrakk>
+     \<Longrightarrow> measuref_if y s' < measuref_if y s \<and>
+         (\<not> interrupted_modes (snd s)
+          \<longrightarrow> interrupted_modes (snd s')
+              \<longrightarrow> irq_state_of_state (internal_state_if s') =
+                  next_irq_state_of_state (internal_state_if s))"
+  apply (frule invs_if_irq_is_recurring)
+  apply (case_tac s, clarsimp)
+  apply (rename_tac uc i_s mode)
+  apply (case_tac mode)
+       apply (simp_all add: rah_simp system.Step_def execution_def steps_def ADT_A_if_def
                            global_automaton_if_def check_active_irq_A_if_def do_user_op_A_if_def
-                           check_active_irq_if_def in_monad measuref_if_def kernel_call_A_if_def
-                           kernel_handle_preemption_if_def kernel_schedule_if_def
-                           kernel_exit_A_if_def
-            | safe
-            | split if_splits)+
-           apply (erule use_valid[OF _ do_user_op_if_irq_masks_of_state] |
-                  erule use_valid[OF _ dmo_getActiveIRQ_irq_masks] |
-                  erule use_valid[OF _ kernel_entry_if_irq_masks]
+                           check_active_irq_if_def in_monad measuref_if_def
+              | safe | split if_splits)+
+                        apply (frule getActiveIRQ_None)
+                        apply (erule use_valid[OF _ do_user_op_if_irq_measure_if])
+                        apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
+                        apply (clarsimp simp: irq_measure_if_def Let_def)
+                        apply (simp add: next_irq_state_Suc recurring_next_irq_state_dom)
+                        apply (blast intro: rah4[OF next_irq_state_less])
+                       apply (frule getActiveIRQ_None)
+                       apply (erule use_valid[OF _ do_user_op_if_next_irq_state_of_state])
+                       apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
+                       apply (simp add: next_irq_state_Suc recurring_next_irq_state_dom)
+                       apply (clarsimp split: if_splits)
+                      apply (frule getActiveIRQ_None)
+                      apply (erule use_valid[OF _ do_user_op_if_irq_measure_if])
+                      apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
+                      apply (clarsimp simp: irq_measure_if_def Let_def)
+                      apply (simp add: next_irq_state_Suc recurring_next_irq_state_dom)
+                      apply (fastforce dest: next_irq_state_less)
+                     apply (frule getActiveIRQ_None)
+                     apply (erule use_valid[OF _ do_user_op_if_next_irq_state_of_state])
+                     apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
+                     apply (simp add: next_irq_state_Suc recurring_next_irq_state_dom)
+                     apply (clarsimp split: if_splits)+
+                    apply (frule getActiveIRQ_Some)
+                    apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
+                    apply (simp add: next_irq_state_Suc' recurring_next_irq_state_dom)
+                   apply (clarsimp split: if_splits)
+                  apply (frule getActiveIRQ_Some)
+                  apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
+                  apply (simp add: next_irq_state_Suc' recurring_next_irq_state_dom)
+                 apply (clarsimp split: if_splits)
+                apply (frule getActiveIRQ_None)
+                apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
+                apply (clarsimp simp: irq_measure_if_def Let_def)
+                apply (simp add: next_irq_state_Suc recurring_next_irq_state_dom)
+                apply (fastforce dest: next_irq_state_less)
+               apply (clarsimp split: if_splits)
+              apply (clarsimp simp: kernel_call_A_if_def in_monad)
+              apply (rule kernel_entry_if_next_irq_state_of_state_next,assumption+)
+                 prefer 4
+                 apply fastforce
+                apply ((simp add: invs_if_def Invs_def only_timer_irq_inv_def
+                        | elim conjE | assumption)+)[3]
+             apply (clarsimp split: if_splits)
+            apply (rule Suc_le_lessD)
+            apply simp
+            apply (simp add: kernel_call_A_if_def)
+            apply (elim exE conjE)
+            apply (rule_tac event=x3 in kernel_entry_if_irq_measure)
+                apply ((simp add: invs_if_def Invs_def only_timer_irq_inv_def
+                        | elim conjE | assumption)+)[4]
+            apply (simp)
+           apply (clarsimp split: if_splits)
+          apply (rule Suc_le_lessD)
+          apply (simp add: kernel_schedule_if_def)
+          apply (blast intro: schedule_if_irq_measure_if)
+         apply (clarsimp simp: kernel_exit_A_if_def split: if_splits)
+        apply (clarsimp simp: kernel_exit_A_if_def)
+        apply ((erule use_valid, wp | simp)+)[1]
+        apply (clarsimp split: if_splits)
+       apply (clarsimp simp: kernel_exit_A_if_def split: if_splits)
+      apply (clarsimp simp: kernel_exit_A_if_def)
+      apply ((erule use_valid, wp | simp)+)[1]
+      apply (clarsimp split: if_splits)+
+     apply (clarsimp simp: kernel_exit_A_if_def split: if_splits)
+    apply (clarsimp split: if_splits)
+   apply (clarsimp split: sys_mode.splits | safe)+
+      apply (clarsimp simp: irq_measure_if_def kernel_exit_A_if_def split: if_splits)
+      apply (drule state_unchanged[OF kernel_exit_if_inv], simp)
+     apply (clarsimp simp: irq_measure_if_def kernel_exit_A_if_def split: if_splits)
+     apply (drule state_unchanged[OF kernel_exit_if_inv], simp)
+    apply (clarsimp simp: kernel_exit_A_if_def split: if_splits)
+   apply (clarsimp simp: kernel_exit_A_if_def split: if_splits)
+  apply (clarsimp simp: kernel_exit_A_if_def)
+  apply ((erule use_valid, wp | simp)+)[1]
+  apply (clarsimp simp: kernel_exit_A_if_def split: if_splits)
+  done
+
+lemma ADT_A_if_Step_irq_masks:
+  "\<lbrakk> (s,s') \<in> data_type.Step (ADT_A_if utf) x; invs_if s \<rbrakk>
+     \<Longrightarrow> irq_masks_of_state (internal_state_if s') = irq_masks_of_state (internal_state_if s)"
+  apply (case_tac s, clarsimp)
+  apply (rename_tac uc i_s mode)
+  apply (case_tac mode)
+       apply (simp_all add: system.Step_def steps_def ADT_A_if_def in_monad rah_simp execution_def
+                            global_automaton_if_def check_active_irq_A_if_def do_user_op_A_if_def
+                            check_active_irq_if_def kernel_schedule_if_def  kernel_call_A_if_def
+                            kernel_handle_preemption_if_def kernel_exit_A_if_def measuref_if_def
+              | safe | split if_splits)+
+           apply (erule use_valid[OF _ do_user_op_if_irq_masks_of_state]
+                        use_valid[OF _ dmo_getActiveIRQ_irq_masks]
+                        use_valid[OF _ kernel_entry_if_irq_masks]
                   | rule refl)+
       apply fastforce
      apply (subgoal_tac "irq_masks_of_state b = irq_masks_of_state i_s",simp)
@@ -3640,36 +3076,27 @@ lemma ADT_A_if_Step_irq_masks:
    apply fastforce
   apply (erule use_valid[OF _ kernel_exit_irq_masks])
   apply simp
-       done
+  done
+
+end
 
 
 lemma steps_preserves_equivalence:
-  "\<lbrakk>(s', as) \<in> sub_big_steps A R s1;
-    \<forall>t t' as a. (t, as) \<in> sub_big_steps A R s1 \<longrightarrow>
-                (t, t') \<in> data_type.Step A a \<longrightarrow>
-                \<not> R s1 t' \<longrightarrow>
-               f t = f t'
-   \<rbrakk> \<Longrightarrow> f s1 = f s'"
-  apply (erule sub_big_steps.induct)
-  apply simp
-  apply fastforce
-  done
+  "\<lbrakk> (s', as) \<in> sub_big_steps A R s1; \<forall>t t' as a. (t, as) \<in> sub_big_steps A R s1
+                                                  \<longrightarrow> (t, t') \<in> Step A a
+                                                  \<longrightarrow> \<not> R s1 t'
+                                                  \<longrightarrow> f t = f t' \<rbrakk>
+     \<Longrightarrow> f s1 = f s'"
+  by (fastforce elim: sub_big_steps.induct)
 
 lemma step_out_equivalent:
-  "\<lbrakk> (s', as) \<in> sub_big_steps A R s1;
-     (s', s2) \<in> data_type.Step A a;
-     g s2 = f (g s');
-     \<forall>t t' as a. (t, as) \<in> sub_big_steps A R s1 \<longrightarrow>
-                 (t, t') \<in> data_type.Step A a \<longrightarrow>
-                 \<not> R s1 t' \<longrightarrow>
-                 f (g t) = f (g t')
-   \<rbrakk> \<Longrightarrow> f (g s1) = g s2"
-  apply simp
-  apply (erule steps_preserves_equivalence)
-  apply simp+
-  done
-
-
+  "\<lbrakk> (s', as) \<in> sub_big_steps A R s1; (s', s2) \<in> data_type.Step A a; g s2 = f (g s');
+     \<forall>t t' as a. (t, as) \<in> sub_big_steps A R s1
+                 \<longrightarrow> (t, t') \<in> data_type.Step A a
+                 \<longrightarrow> \<not> R s1 t'
+                 \<longrightarrow> f (g t) = f (g t') \<rbrakk>
+     \<Longrightarrow> f (g s1) = g s2"
+  by (fastforce elim: steps_preserves_equivalence)
 
 (*Clagged from Noninterference*)
 
@@ -3677,34 +3104,67 @@ lemma irq_state_back:
   "P (irq_state_of_state (internal_state_if ((a,b),c)))
      (irq_masks_of_state (internal_state_if ((a,b),c))) \<Longrightarrow>
    P (irq_state_of_state b) (irq_masks_of_state b)"
-  apply simp
-  done
+  by simp
 
 lemma sub_big_steps_not_related:
   "(s,a) \<in> sub_big_steps A R s1 \<Longrightarrow> \<not> R s1 s"
-  apply (erule sub_big_steps.cases,simp+)
+  by (erule sub_big_steps.cases,simp+)
+
+(*Can probably be generalized*)
+lemma small_step_to_big_step:
+  assumes a:
+    "\<And>s' evs. \<lbrakk> (s',evs) \<in> sub_big_steps (ADT_A_if utf) big_step_R s1;
+                (s', s2) \<in> data_type.Step (ADT_A_if utf) a; big_step_R s1 s2 \<rbrakk>
+                \<Longrightarrow> S"
+  assumes b: "(s1, s2) \<in> data_type.Step (big_step_ADT_A_if utf) a"
+  shows S
+  apply (insert b)
+  apply (simp add: big_step_ADT_A_if_def big_step_adt_def)
+  apply (erule big_steps.cases)
+  apply (rule_tac s'=s' and evs=as in a)
+    apply simp+
   done
 
+lemma Step_ADT_A_if_def_global_automaton_if:
+  "Step (ADT_A_if uop) =
+   (\<lambda>u. global_automaton_if check_active_irq_A_if (do_user_op_A_if uop) kernel_call_A_if
+                            kernel_handle_preemption_if kernel_schedule_if kernel_exit_A_if
+        \<inter> {(s, y). step_restrict y})"
+  by (clarsimp simp: ADT_A_if_def)
+
+lemma ADT_A_if_reachable_step_restrict:
+  "system.reachable (ADT_A_if utf) s0 s \<Longrightarrow> step_restrict s"
+  apply (clarsimp simp: system.reachable_def)
+  apply (erule execution_restrict)
+  done
+
+lemma step_restrict_inv_holds_ADT_A_if:
+  "ADT_A_if utf [> {s. step_restrict s}"
+  apply (rule inv_holdsI)
+  apply (clarsimp simp: Image_def ADT_A_if_def)
+  done
+
+
+context ADT_valid_initial_state begin
+
 lemma invs_if_sub_big_steps_ADT_A_if:
-  "\<lbrakk>(s', evs) \<in> sub_big_steps (ADT_A_if utf) big_step_R s; invs_if s\<rbrakk>
-   \<Longrightarrow> invs_if s'"
+  "\<lbrakk> (s', evs) \<in> sub_big_steps (ADT_A_if utf) big_step_R s; invs_if s \<rbrakk>
+     \<Longrightarrow> invs_if s'"
   apply (erule sub_big_steps.induct)
    apply simp
   apply (simp add: invs_if_Step_ADT_A_if)
   done
 
 lemma small_step_irq_state_next_irq:
-  "\<lbrakk>invs_if s1;
-    (s',evs) \<in> sub_big_steps (ADT_A_if utf) big_step_R s1;
-    (s', s2) \<in> data_type.Step (ADT_A_if utf) a;
-    big_step_R\<^sup>*\<^sup>* s0 s1; snd s1 = KernelExit; interrupted_modes (snd s2)\<rbrakk> \<Longrightarrow>
-    next_irq_state_of_state (internal_state_if s1) = irq_state_of_state (internal_state_if s2)"
+  "\<lbrakk> invs_if s1; (s',evs) \<in> sub_big_steps (ADT_A_if utf) big_step_R s1;
+     (s', s2) \<in> Step (ADT_A_if utf) a; big_step_R\<^sup>*\<^sup>* s0 s1;
+     snd s1 = KernelExit; interrupted_modes (snd s2) \<rbrakk>
+     \<Longrightarrow> next_irq_state_of_state (internal_state_if s1) = irq_state_of_state (internal_state_if s2)"
   apply (subgoal_tac "invs_if s'")
    apply (rule step_out_equivalent[where f="\<lambda>(states,mask). (next_irq_state (Suc states) mask,mask)"
                                      and g="\<lambda>s. (irq_state_of_state (internal_state_if s),
                                                  irq_masks_of_state (internal_state_if s))",
-                                   simplified,
-                                   THEN conjunct1])
+                                   simplified, THEN conjunct1])
       apply assumption
      apply assumption
     apply (rule conjI)
@@ -3728,72 +3188,39 @@ lemma small_step_irq_state_next_irq:
     apply (rule sym)
     apply (rule ADT_A_if_Step_irq_masks,assumption+)
    apply (simp add: invs_if_sub_big_steps_ADT_A_if)+
-   done
-
-
-(*Can probably be generalized*)
-lemma small_step_to_big_step:
-  assumes a:
-    "\<And>s' evs. \<lbrakk> (s',evs) \<in> sub_big_steps (ADT_A_if utf) big_step_R s1;
-                (s', s2) \<in> data_type.Step (ADT_A_if utf) a;
-                big_step_R s1 s2
-               \<rbrakk> \<Longrightarrow> S"
-  assumes b: "(s1, s2) \<in> data_type.Step (big_step_ADT_A_if utf) a"
-  shows "S"
-  apply (insert b)
-  apply (simp add: big_step_ADT_A_if_def big_step_adt_def)
-  apply (erule big_steps.cases)
-  apply (rule_tac s'=s' and evs=as in a)
-    apply simp+
   done
 
 lemma big_step_irq_state_next_irq:
-  "\<lbrakk>invs_if s1; big_step_R\<^sup>*\<^sup>* s0 s1;
-    (s1, s2) \<in> data_type.Step (big_step_ADT_A_if utf) a;
-    snd s1 = KernelExit; i_s1 = internal_state_if s1; i_s2 = internal_state_if s2\<rbrakk> \<Longrightarrow>
-   next_irq_state_of_state i_s1 = irq_state_of_state i_s2"
+  "\<lbrakk> invs_if s1; big_step_R\<^sup>*\<^sup>* s0 s1; (s1, s2) \<in> Step (big_step_ADT_A_if utf) a;
+     snd s1 = KernelExit; i_s1 = internal_state_if s1; i_s2 = internal_state_if s2 \<rbrakk>
+     \<Longrightarrow> next_irq_state_of_state i_s1 = irq_state_of_state i_s2"
   apply simp
   apply (rule small_step_to_big_step)
-  apply (rule small_step_irq_state_next_irq,(simp add: big_step_R_def)+)
+   apply (rule small_step_irq_state_next_irq,(simp add: big_step_R_def)+)
   done
 
-lemmas ADT_A_if_Step_measure_if = ADT_A_if_Step_measure_if'[THEN conjunct1]
+lemmas ADT_A_if_Step_measure_if =
+  ADT_A_if_Step_measure_if'[THEN conjunct1]
 
 lemmas ADT_A_if_Step_next_irq_state_of_state =
-               ADT_A_if_Step_measure_if'[THEN conjunct2, rule_format]
-
-
-lemma Step_ADT_A_if_def_global_automaton_if:
-  "Step (ADT_A_if uop) = (\<lambda>u. global_automaton_if check_active_irq_A_if
-          (do_user_op_A_if uop) kernel_call_A_if
-          kernel_handle_preemption_if kernel_schedule_if
-          kernel_exit_A_if \<inter>
-         {(s, y). step_restrict y})"
-  by(clarsimp simp: ADT_A_if_def)
-
+  ADT_A_if_Step_measure_if'[THEN conjunct2, rule_format]
 
 lemma ADT_A_if_big_step_R_terminate:
   "rel_terminate (ADT_A_if utf) s0 big_step_R {s. invs_if s} measuref_if"
-  apply(clarsimp simp: rel_terminate_def)
-  apply(rule conjI)
-   apply(rename_tac uc s mode as uc' s' mode' uc'' s'' mode'')
-   apply(rule ADT_A_if_Step_measure_if)
+  apply (clarsimp simp: rel_terminate_def)
+  apply (rule conjI)
+   apply (rename_tac uc s mode as uc' s' mode' uc'' s'' mode'')
+   apply (rule ADT_A_if_Step_measure_if)
      apply assumption
     apply (simp add: invs_if_sub_big_steps_ADT_A_if)
-   apply(rule ADT_A_if_sub_big_steps_measuref_if)
+   apply (rule ADT_A_if_sub_big_steps_measuref_if)
     apply simp
    apply (simp add: ADT_A_if_def)
   apply (simp add: ADT_A_if_def)
-  apply(drule tranclp_s0)
-  apply(fastforce simp: measuref_if_def big_step_R_def Step_ADT_A_if
-                        Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
+  apply (drule tranclp_s0)
+  apply (fastforce simp: measuref_if_def big_step_R_def Step_ADT_A_if
+                         Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
                  split: if_splits)
-  done
-
-lemma ADT_A_if_reachable_step_restrict:
-  "system.reachable (ADT_A_if utf) s0 s \<Longrightarrow> step_restrict s"
-  apply(clarsimp simp: system.reachable_def)
-  apply (erule execution_restrict)
   done
 
 lemma ADT_A_if_Init_inv_Fin:
@@ -3810,12 +3237,6 @@ lemma invs_if_inv_holds_ADT_A_if:
   "ADT_A_if utf [> Collect invs_if"
   by (force intro: inv_holdsI invs_if_Step_ADT_A_if)
 
-lemma step_restrict_inv_holds_ADT_A_if:
-  "ADT_A_if utf [> {s. step_restrict s}"
-  apply (rule inv_holdsI)
-  apply (clarsimp simp: Image_def ADT_A_if_def)
-  done
-
 lemma ADT_A_if_Init_Fin_serial_weak:
   "Init_Fin_serial_weak (ADT_A_if utf) s0 ({s. invs_if s} \<inter> {s. step_restrict s})"
   apply (rule Init_Fin_serial_weak_strengthen)
@@ -3829,10 +3250,10 @@ lemma ADT_A_if_Init_Fin_serial_weak:
 
 lemma big_step_ADT_A_if_enabled_Step_system:
   "enabled_Step_system (big_step_ADT_A_if utf) s0"
-  apply(simp add: big_step_ADT_A_if_def)
-  apply(rule big_step_adt_enabled_Step_system)
+  apply (simp add: big_step_ADT_A_if_def)
+  apply (rule big_step_adt_enabled_Step_system)
       apply simp
-     apply(fastforce simp: big_step_R_def)
+     apply (fastforce simp: big_step_R_def)
     apply (rule ADT_A_if_Init_Fin_serial_weak)
    apply (rule ADT_A_if_Init_inv_Fin)
   apply (rule rel_terminate_weaken)
@@ -3841,11 +3262,11 @@ lemma big_step_ADT_A_if_enabled_Step_system:
   done
 
 end
-section \<open>Generic big step refinement\<close>
-context begin interpretation Arch . (*FIXME: arch_split*)
 
-definition internal_R
-where
+
+section \<open>Generic big step refinement\<close>
+
+definition internal_R where
   "internal_R A R s s' \<equiv> R (Fin A s) (Fin A s')"
 
 lemma invariant_holds_inv_holds:
@@ -3864,12 +3285,11 @@ lemma inv_holdsE:
   done
 
 lemma LI_sub_big_steps:
-  "\<lbrakk>(s',as) \<in> sub_big_steps C (internal_R C R) s;
-    LI A C S (Ia \<times> Ic); A \<Turnstile> Ia; C \<Turnstile> Ic;
-    (t, s) \<in> S; s \<in> Ic; t \<in> Ia\<rbrakk>
-  \<Longrightarrow> \<exists>t'. (t',as) \<in> sub_big_steps A (internal_R A R) t \<and> (t', s') \<in> S \<and> t' \<in> Ia"
+  "\<lbrakk> (s',as) \<in> sub_big_steps C (internal_R C R) s;
+     LI A C S (Ia \<times> Ic); A \<Turnstile> Ia; C \<Turnstile> Ic; (t, s) \<in> S; s \<in> Ic; t \<in> Ia \<rbrakk>
+     \<Longrightarrow> \<exists>t'. (t',as) \<in> sub_big_steps A (internal_R A R) t \<and> (t', s') \<in> S \<and> t' \<in> Ia"
   apply (induct rule: sub_big_steps.induct)
-   apply(clarsimp simp: LI_def)
+   apply (clarsimp simp: LI_def)
    apply (rule_tac x=t in exI)
    apply clarsimp
    apply (rule sub_big_steps.nil, simp_all)[1]
@@ -3905,10 +3325,9 @@ lemma LI_sub_big_steps:
   done
 
 lemma LI_big_steps:
-  "\<lbrakk>(s, s') \<in> big_steps C (internal_R C R) exmap ev;
-    LI A C S (Ia \<times> Ic); A \<Turnstile> Ia; C \<Turnstile> Ic;
-    (t, s) \<in> S; s \<in> Ic; t \<in> Ia\<rbrakk>
-  \<Longrightarrow> \<exists>t'. (t, t') \<in> big_steps A (internal_R A R) exmap ev \<and> (t', s') \<in> S \<and> t' \<in> Ia"
+  "\<lbrakk> (s, s') \<in> big_steps C (internal_R C R) exmap ev;
+     LI A C S (Ia \<times> Ic); A \<Turnstile> Ia; C \<Turnstile> Ic; (t, s) \<in> S; s \<in> Ic; t \<in> Ia \<rbrakk>
+     \<Longrightarrow> \<exists>t'. (t, t') \<in> big_steps A (internal_R A R) exmap ev \<and> (t', s') \<in> S \<and> t' \<in> Ia"
   apply (drule big_stepsD)
   apply clarsimp
   apply (frule(2) sub_big_steps_I_holds[OF invariant_holds_inv_holds])
@@ -3941,17 +3360,17 @@ lemma LI_big_steps:
   done
 
 lemma inv_holds_Run_big_steps:
-  "\<lbrakk>A [> I; s \<in> I; (s, t) \<in> Run (big_steps A R exmap) js\<rbrakk> \<Longrightarrow> t \<in> I"
+  "\<lbrakk> A [> I; s \<in> I; (s, t) \<in> Run (big_steps A R exmap) js \<rbrakk>
+     \<Longrightarrow> t \<in> I"
   apply (induct js arbitrary: t rule: rev_induct)
    apply force
   apply (force intro: big_steps_I_holds dest: Run_mid)
   done
 
 lemma refines_Run_big_steps:
-  "\<lbrakk>(s, s') \<in> Run (big_steps C (internal_R C R) exmap) js;
-    LI A C S (Ia \<times> Ic); A \<Turnstile> Ia; C \<Turnstile> Ic;
-    (t, s) \<in> S; s \<in> Ic; t \<in> Ia\<rbrakk>
-  \<Longrightarrow> \<exists>t'. (t, t') \<in> Run (big_steps A (internal_R A R) exmap) js \<and> (t', s') \<in> S \<and> t' \<in> Ia"
+  "\<lbrakk> (s, s') \<in> Run (big_steps C (internal_R C R) exmap) js;
+     LI A C S (Ia \<times> Ic); A \<Turnstile> Ia; C \<Turnstile> Ic; (t, s) \<in> S; s \<in> Ic; t \<in> Ia \<rbrakk>
+     \<Longrightarrow> \<exists>t'. (t, t') \<in> Run (big_steps A (internal_R A R) exmap) js \<and> (t', s') \<in> S \<and> t' \<in> Ia"
   apply (induct js arbitrary: s' rule: rev_induct)
    apply force
   apply (frule Run_mid)
@@ -3959,8 +3378,8 @@ lemma refines_Run_big_steps:
   apply atomize
   apply (erule_tac x=ta in allE)
   apply clarsimp
-  apply (drule(4) LI_big_steps)
-    apply (erule(2) inv_holds_Run_big_steps[OF invariant_holds_inv_holds])
+  apply (drule (4) LI_big_steps)
+    apply (erule (2) inv_holds_Run_big_steps[OF invariant_holds_inv_holds])
    apply assumption
   apply clarsimp
   apply (rule_tac x="t'a" in exI)
@@ -3973,8 +3392,8 @@ text\<open>
 \<close>
 
 lemma big_step_adt_refines:
-  "\<lbrakk>LI A C S (Ia \<times> Ic); A \<Turnstile> Ia; C \<Turnstile> Ic\<rbrakk>
-  \<Longrightarrow> refines (big_step_adt C (internal_R C R) exmap) (big_step_adt A (internal_R A R) exmap)"
+  "\<lbrakk> LI A C S (Ia \<times> Ic); A \<Turnstile> Ia; C \<Turnstile> Ic \<rbrakk>
+     \<Longrightarrow> refines (big_step_adt C (internal_R C R) exmap) (big_step_adt A (internal_R A R) exmap)"
   apply (subst refines_def)
   apply (clarsimp simp: execution_def steps_eq_Run)
   apply (clarsimp simp: image_def)
@@ -3984,7 +3403,7 @@ lemma big_step_adt_refines:
    prefer 2
    apply (force simp: LI_def)
   apply clarsimp
-  apply (frule(4) refines_Run_big_steps)
+  apply (frule (4) refines_Run_big_steps)
     apply (force simp: invariant_holds_def)
    apply (force simp: invariant_holds_def)
   apply clarsimp
@@ -4007,29 +3426,23 @@ text \<open>
 text \<open>
   Refinement restricted to states reachable from a common initial state
 \<close>
-definition refines'
-where
+definition refines' where
   "refines' C A s0 \<equiv> \<forall>js s. system.reachable C s0 s \<longrightarrow> execution C s js \<subseteq> execution A s js"
 
 lemma refines_refines':
   "refines C A \<Longrightarrow> refines' C A s"
-  apply(auto simp: refines_def refines'_def)
-  done
+  by (auto simp: refines_def refines'_def)
 
 text \<open>Two validity requirements on the user operation (uop) of the infoflow adt.
         These definitions are mostly only needed in ADT_A_if_Refine.\<close>
 
 text \<open>uop_nonempty is required to prove corres between do_user_op_if and doUserOp_if\<close>
-definition uop_nonempty :: "user_transition_if \<Rightarrow> bool"
-where
+definition uop_nonempty :: "user_transition_if \<Rightarrow> bool" where
   "uop_nonempty uop \<equiv> \<forall>t pl pr pxn tc um es. uop t pl pr pxn (tc, um, es) \<noteq> {}"
 
 text \<open>uop_sane is required to prove that the infoflow adt describes an enabled system\<close>
-definition uop_sane :: "user_transition_if \<Rightarrow> bool"
-where
-  "uop_sane f \<equiv> \<forall>t pl pr pxn tcu. (f t pl pr pxn tcu) \<noteq> {} \<and>
-                (\<forall>tc um es. (Some Interrupt, tc, um, es) \<notin> (f t pl pr pxn tcu))"
-
-end
+definition uop_sane :: "user_transition_if \<Rightarrow> bool" where
+  "uop_sane f \<equiv> \<forall>t pl pr pxn tcu. (f t pl pr pxn tcu) \<noteq> {}
+                                \<and> (\<forall>tc um es. (Some Interrupt, tc, um, es) \<notin> (f t pl pr pxn tcu))"
 
 end

--- a/proof/infoflow/ARM/ArchADT_IF.thy
+++ b/proof/infoflow/ARM/ArchADT_IF.thy
@@ -1,0 +1,385 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+text \<open>
+  This file sets up a kernel automaton, ADT_A_if, which is
+  slightly different from ADT_A.
+  It then setups a big step framework to transfrom this automaton in the
+  big step automaton on which the infoflow theorem will be proved
+\<close>
+
+theory ArchADT_IF
+imports ADT_IF
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems ADT_IF_assms
+
+lemma dmo_getExMonitor_wp[wp]:
+  "\<lbrace>\<lambda>s. P (exclusive_state (machine_state s)) s\<rbrace>
+   do_machine_op getExMonitor
+   \<lbrace>P\<rbrace>"
+  apply (simp add: do_machine_op_def)
+  apply (wp modify_wp | wpc)+
+  apply clarsimp
+  apply (erule use_valid)
+   apply wp
+  apply simp
+  done
+
+lemma setExMonitor_wp[wp]:
+  "\<lbrace>\<lambda>ms. P (ms\<lparr>exclusive_state := es\<rparr>)\<rbrace>
+   setExMonitor es
+   \<lbrace>\<lambda>_. P\<rbrace>"
+  by (simp add: setExMonitor_def | wp)+
+
+lemma dmo_setExMonitor_wp[wp]:
+  "\<lbrace>\<lambda>s. P (s\<lparr>machine_state := machine_state s \<lparr>exclusive_state := es\<rparr>\<rparr>)\<rbrace>
+   do_machine_op (setExMonitor es)
+   \<lbrace>\<lambda>_. P\<rbrace>"
+  apply (simp add: do_machine_op_def)
+  apply (wp modify_wp | wpc)+
+  apply clarsimp
+  apply (erule use_valid)
+   apply wp
+  apply simp
+  done
+
+lemma valid_state_exclusive_state_update[iff]:
+  "valid_state (s\<lparr>machine_state := machine_state s\<lparr>exclusive_state := es\<rparr>\<rparr>) = valid_state s"
+  by (simp add: valid_state_def valid_irq_states_def valid_machine_state_def)
+
+lemma cur_tcb_exclusive_state_update[iff]:
+  "cur_tcb (s\<lparr>machine_state := machine_state s\<lparr>exclusive_state := es\<rparr>\<rparr>) = cur_tcb s"
+  by (simp add: cur_tcb_def)
+
+lemma invs_exclusive_state_update[iff]:
+  "invs (s\<lparr>machine_state := machine_state s\<lparr>exclusive_state := es\<rparr>\<rparr>) = invs s"
+  by (simp add: invs_def)
+
+(* FIXME: clagged from AInvs.do_user_op_invs *)
+lemma do_user_op_if_invs[ADT_IF_assms]:
+  "\<lbrace>invs and ct_running\<rbrace>
+   do_user_op_if f tc
+   \<lbrace>\<lambda>_. invs and ct_running\<rbrace>"
+  apply (simp add: do_user_op_if_def split_def)
+  apply (wp dmo_ct_in_state select_wp device_update_invs | wp (once) dmo_invs | simp)+
+  apply (clarsimp simp: user_mem_def user_memory_update_def simpler_modify_def restrict_map_def
+                        invs_def cur_tcb_def ptable_rights_s_def ptable_lift_s_def)
+  apply (frule ptable_rights_imp_frame)
+    apply fastforce
+   apply simp
+  apply (clarsimp simp: valid_state_def device_frame_in_device_region)
+  done
+
+crunch domain_sep_inv[ADT_IF_assms, wp]: do_user_op_if "domain_sep_inv irqs st"
+  (ignore: user_memory_update wp: select_wp)
+
+crunch valid_sched[ADT_IF_assms, wp]: do_user_op_if "valid_sched"
+  (ignore: user_memory_update wp: select_wp)
+
+crunch irq_masks[ADT_IF_assms, wp]: do_user_op_if "\<lambda>s. P (irq_masks_of_state s)"
+  (ignore: user_memory_update wp: select_wp dmo_wp no_irq)
+
+crunch valid_list[ADT_IF_assms, wp]: do_user_op_if "valid_list"
+  (ignore: user_memory_update wp: select_wp)
+
+lemma do_user_op_if_scheduler_action[ADT_IF_assms, wp]:
+  "do_user_op_if f tc \<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace>"
+  by (simp add: do_user_op_if_def | wp select_wp | wpc)+
+
+lemma do_user_op_silc_inv[ADT_IF_assms, wp]:
+  "do_user_op_if f tc \<lbrace>silc_inv aag st\<rbrace>"
+  apply (simp add: do_user_op_if_def)
+  apply (wp select_wp | wpc | simp)+
+  done
+
+lemma do_user_op_pas_refined[ADT_IF_assms, wp]:
+  "do_user_op_if f tc \<lbrace>pas_refined aag\<rbrace>"
+  apply (simp add: do_user_op_if_def)
+  apply (wp select_wp | wpc | simp)+
+  done
+
+crunches do_user_op_if
+  for cur_thread[ADT_IF_assms, wp]: "\<lambda>s. P (cur_thread s)"
+  and cur_domain[ADT_IF_assms, wp]: "\<lambda>s. P (cur_domain s)"
+  and idle_thread[ADT_IF_assms, wp]: "\<lambda>s. P (idle_thread s)"
+  and domain_fields[ADT_IF_assms, wp]: "domain_fields P"
+  (wp: select_wp ignore: user_memory_update)
+
+lemma do_use_op_guarded_pas_domain[ADT_IF_assms, wp]:
+  "do_user_op_if f tc \<lbrace>guarded_pas_domain aag\<rbrace>"
+  by (rule guarded_pas_domain_lift; wp)
+
+lemma tcb_arch_ref_tcb_context_set[ADT_IF_assms, simp]:
+  "tcb_arch_ref (tcb_arch_update (arch_tcb_context_set tc) tcb) = tcb_arch_ref tcb"
+  by (simp add: tcb_arch_ref_def)
+
+crunches arch_switch_to_idle_thread, arch_switch_to_thread
+  for pspace_aligned[ADT_IF_assms, wp]: "\<lambda>s :: det_state. pspace_aligned s"
+  and valid_vspace_objs[ADT_IF_assms, wp]: "\<lambda>s :: det_state. valid_vspace_objs s"
+  and valid_arch_state[ADT_IF_assms, wp]: "\<lambda>s :: det_state. valid_arch_state s"
+  (wp: crunch_wps)
+
+crunches arch_activate_idle_thread, arch_switch_to_thread
+  for cur_thread[ADT_IF_assms, wp]: "\<lambda>s. P (cur_thread s)"
+
+lemma arch_activate_idle_thread_scheduler_action[ADT_IF_assms, wp]:
+  "arch_activate_idle_thread t \<lbrace>\<lambda>s :: det_state. P (scheduler_action s)\<rbrace>"
+  by (wpsimp simp: arch_activate_idle_thread_def)
+
+crunch domain_fields[ADT_IF_assms, wp]: handle_vm_fault, handle_hypervisor_fault "domain_fields P"
+  (ignore: getFAR getDFSR getIFSR)
+
+lemma arch_perform_invocation_noErr[ADT_IF_assms, wp]:
+  "\<lbrace>\<top>\<rbrace> arch_perform_invocation a -, \<lbrace>Q\<rbrace>"
+  by (wpsimp simp: arch_perform_invocation_def)
+
+lemma arch_invoke_irq_control_noErr[ADT_IF_assms, wp]:
+  "\<lbrace>\<top>\<rbrace> arch_invoke_irq_control a -, \<lbrace>Q\<rbrace>"
+  by (cases a; wpsimp)
+
+crunch irq_state[wp]: cleanCacheRange_PoU "\<lambda>s. P (irq_state s)"
+  (ignore_del: cleanCacheRange_PoU cleanByVA_PoU)
+
+crunch irq_state_of_state[ADT_IF_assms, wp]: init_arch_objects "\<lambda>s. P (irq_state_of_state s)"
+  (wp: crunch_wps dmo_wp ignore: do_machine_op)
+
+lemma getActiveIRQ_None[ADT_IF_assms]:
+  "(None,s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) s)  \<Longrightarrow>
+   irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = None"
+  apply (erule use_valid)
+   apply (wp dmo_getActiveIRQ_wp)
+  by simp
+
+lemma getActiveIRQ_Some[ADT_IF_assms]:
+  "(Some i, s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) s)
+   \<Longrightarrow> irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = Some i"
+  apply (erule use_valid)
+   apply (wp dmo_getActiveIRQ_wp)
+  by simp
+
+lemma idle_equiv_as_globals_equiv:
+  "arm_global_pd (arch_state s) \<noteq> idle_thread s
+   \<Longrightarrow> idle_equiv st s =
+       globals_equiv (st\<lparr>arch_state := arch_state s, machine_state := machine_state s,
+                         kheap:= (kheap st)(arm_global_pd (arch_state s) :=
+                                              kheap s (arm_global_pd (arch_state s))),
+                                            cur_thread := cur_thread s\<rparr>) s"
+  by (clarsimp simp: idle_equiv_def globals_equiv_def tcb_at_def2)
+
+lemma idle_globals_lift:
+  assumes g: "\<And>st. \<lbrace>globals_equiv st and P\<rbrace> f \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  assumes i: "\<And>s. P s \<Longrightarrow> arm_global_pd (arch_state s) \<noteq> idle_thread s"
+  shows "\<lbrace>idle_equiv st and P\<rbrace> f \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (subgoal_tac "arm_global_pd (arch_state s) \<noteq> idle_thread s")
+   apply (subst (asm) idle_equiv_as_globals_equiv,simp+)
+   apply (frule use_valid[OF _ g])
+    apply simp+
+   apply (clarsimp simp: idle_equiv_def globals_equiv_def tcb_at_def2)
+  apply (erule i)
+  done
+
+lemma idle_equiv_as_globals_equiv_scheduler:
+  "arm_global_pd (arch_state s) \<noteq> idle_thread s
+   \<Longrightarrow> idle_equiv st s =
+       globals_equiv_scheduler (st\<lparr>arch_state := arch_state s, machine_state := machine_state s,
+                                   kheap:= (kheap st)(arm_global_pd (arch_state s) :=
+                                                        kheap s (arm_global_pd (arch_state s)))\<rparr>) s"
+  by (clarsimp simp: idle_equiv_def tcb_at_def2 globals_equiv_scheduler_def
+                     arch_globals_equiv_scheduler_def)
+
+lemma idle_globals_lift_scheduler:
+  assumes g: "\<And>st. \<lbrace>globals_equiv_scheduler st and P\<rbrace> f \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
+  assumes i: "\<And>s. P s \<Longrightarrow> arm_global_pd (arch_state s) \<noteq> idle_thread s"
+  shows "\<lbrace>idle_equiv st and P\<rbrace> f \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (subgoal_tac "arm_global_pd (arch_state s) \<noteq> idle_thread s")
+   apply (subst (asm) idle_equiv_as_globals_equiv_scheduler,simp+)
+   apply (frule use_valid[OF _ g])
+    apply simp+
+   apply (clarsimp simp: idle_equiv_def globals_equiv_scheduler_def tcb_at_def2)
+  apply (erule i)
+  done
+
+lemma invs_pd_not_idle_thread[intro]:
+  "invs s \<Longrightarrow> arm_global_pd (arch_state s) \<noteq> idle_thread s"
+  by (fastforce simp: invs_def valid_state_def valid_global_objs_def
+                      obj_at_def valid_idle_def pred_tcb_at_def empty_table_def)
+
+lemma kernel_entry_if_idle_equiv[ADT_IF_assms]:
+  "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and idle_equiv st
+         and (\<lambda>s. ct_idle s \<longrightarrow> tc = idle_context s)\<rbrace>
+   kernel_entry_if e tc
+   \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
+  apply (rule hoare_pre)
+   apply (rule idle_globals_lift)
+    apply (wp kernel_entry_if_globals_equiv)
+    apply force
+   apply (fastforce intro!: invs_pd_not_idle_thread)+
+  done
+
+(* FIXME IF: malformed *)
+lemma handle_preemption_if_valid_sched[ADT_IF_assms, wp]:
+  "\<lbrace>valid_sched and invs and (\<lambda>s. blah \<in> non_kernel_IRQs \<longrightarrow> scheduler_act_sane s \<and> ct_not_queued s)\<rbrace>
+   handle_preemption_if irq
+   \<lbrace>\<lambda>_. valid_sched\<rbrace>"
+  apply (wpsimp simp: handle_preemption_if_def non_kernel_IRQs_def cong: if_cong)
+   apply (wpsimp wp: hoare_drop_imp hoare_vcg_if_lift2)+
+  done
+
+lemmas handle_preemption_idle_equiv[ADT_IF_assms, wp] =
+  idle_globals_lift[OF handle_preemption_globals_equiv invs_pd_not_idle_thread, simplified]
+
+lemmas schedule_if_idle_equiv[ADT_IF_assms, wp] =
+  idle_globals_lift_scheduler[OF schedule_if_globals_equiv_scheduler invs_pd_not_idle_thread, simplified]
+
+lemma do_user_op_if_idle_equiv[ADT_IF_assms, wp]:
+  "\<lbrace>idle_equiv st and invs\<rbrace>
+   do_user_op_if uop tc
+   \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
+  unfolding do_user_op_if_def
+  by (wpsimp wp: dmo_user_memory_update_idle_equiv dmo_device_memory_update_idle_equiv select_wp)
+
+lemma not_in_global_refs_vs_lookup:
+  "\<lbrakk> (\<exists>\<unrhd>p) s; valid_vs_lookup s; valid_global_refs s; valid_arch_state s; valid_global_objs s \<rbrakk>
+     \<Longrightarrow> p \<notin> global_refs s"
+  apply (clarsimp dest!: valid_vs_lookupD)
+  apply (drule(1) valid_global_refsD2)
+  apply (simp add: cap_range_def)
+  apply blast
+  done
+
+lemma kernel_entry_if_valid_pdpt_objs[wp]:
+ "\<lbrace>valid_pdpt_objs and invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
+  kernel_entry_if e tc
+  \<lbrace>\<lambda>_. valid_pdpt_objs\<rbrace>"
+  apply (case_tac "e = Interrupt")
+   apply (simp add: kernel_entry_if_def)
+   apply (wp | wpc | simp add: kernel_entry_if_def)+
+    apply (wpsimp simp: ran_tcb_cap_cases arch_tcb_update_aux2
+                    wp: static_imp_wp thread_set_invs_trivial)+
+  done
+
+lemma kernel_entry_if_valid_vspace_objs'[ADT_IF_assms, wp]:
+  "\<lbrace>valid_vspace_objs' and invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
+   kernel_entry_if e tc
+   \<lbrace>\<lambda>_. valid_vspace_objs'\<rbrace>"
+  by wpsimp
+
+lemma handle_preemption_if_valid_pdpt_objs[ADT_IF_assms, wp]:
+  "\<lbrace>valid_vspace_objs'\<rbrace> handle_preemption_if a \<lbrace>\<lambda>rv s. valid_vspace_objs' s\<rbrace>"
+  by (simp add: handle_preemption_if_def | wp)+
+
+lemma schedule_if_valid_pdpt_objs[ADT_IF_assms, wp]:
+  "\<lbrace>valid_vspace_objs'\<rbrace> schedule_if a \<lbrace>\<lambda>rv s. valid_vspace_objs' s\<rbrace>"
+  by (simp add: schedule_if_def | wp)+
+
+lemma do_user_op_if_valid_pdpt_objs[ADT_IF_assms, wp]:
+  "\<lbrace>valid_vspace_objs'\<rbrace> do_user_op_if a b \<lbrace>\<lambda>rv s. valid_vspace_objs' s\<rbrace>"
+  by (simp add: do_user_op_if_def | wp select_wp | wpc)+
+
+lemma valid_vspace_objs'_ms_update[ADT_IF_assms, simp]:
+  "valid_vspace_objs' (machine_state_update f s) = valid_vspace_objs' s"
+  by auto
+
+lemma non_kernel_IRQs_empty[ADT_IF_assms]:
+  "non_kernel_IRQs = {}"
+  by (simp add: non_kernel_IRQs_def)
+
+lemma do_user_op_if_irq_state_of_state[ADT_IF_assms]:
+  "do_user_op_if utf uc \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  apply (rule hoare_pre)
+  apply (simp add: do_user_op_if_def user_memory_update_def | wp dmo_wp select_wp | wpc)+
+  done
+
+lemma do_user_op_if_irq_masks_of_state[ADT_IF_assms]:
+  "do_user_op_if utf uc \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  apply (rule hoare_pre)
+  apply (simp add: do_user_op_if_def user_memory_update_def | wp dmo_wp select_wp | wpc)+
+  done
+
+lemma do_user_op_if_irq_measure_if[ADT_IF_assms]:
+  "do_user_op_if utf uc \<lbrace>\<lambda>s. P (irq_measure_if s)\<rbrace>"
+  apply (rule hoare_pre)
+  apply (simp add: do_user_op_if_def user_memory_update_def irq_measure_if_def
+         | wps |wp dmo_wp select_wp | wpc)+
+  done
+
+lemma invoke_tcb_irq_state_inv[ADT_IF_assms]:
+  "\<lbrace>(\<lambda>s. irq_state_inv st s) and domain_sep_inv False sta
+                             and tcb_inv_wf tinv and K (irq_is_recurring irq st)\<rbrace>
+   invoke_tcb tinv
+   \<lbrace>\<lambda>_ s. irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+  apply (case_tac tinv)
+       apply ((wp hoare_vcg_if_lift  mapM_x_wp[OF _ subset_refl]
+               | wpc
+               | simp split del: if_split add: check_cap_at_def
+               | clarsimp
+               | wp (once) irq_state_inv_triv)+)[3]
+    defer
+    apply ((wp irq_state_inv_triv | simp)+)[2]
+  (* just ThreadControl left *)
+  apply (simp add: split_def cong: option.case_cong)
+  by (wp hoare_vcg_all_lift_R hoare_vcg_all_lift hoare_vcg_const_imp_lift_R
+         checked_cap_insert_domain_sep_inv cap_delete_deletes
+         cap_delete_irq_state_inv[where st=st and sta=sta and irq=irq]
+         cap_delete_irq_state_next[where st=st and sta=sta and irq=irq]
+         cap_delete_valid_cap cap_delete_cte_at
+      | wpc
+      | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
+                  tcb_at_st_tcb_at option_update_thread_def
+      | strengthen use_no_cap_to_obj_asid_strg
+      | wp (once) irq_state_inv_triv hoare_drop_imps
+      | clarsimp split: option.splits | intro impI conjI allI)+
+
+lemma reset_untyped_cap_irq_state_inv[ADT_IF_assms]:
+  "\<lbrace>irq_state_inv st and K (irq_is_recurring irq st)\<rbrace>
+   reset_untyped_cap slot
+   \<lbrace>\<lambda>y. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>y. irq_state_next st\<rbrace>"
+  apply (cases "irq_is_recurring irq st", simp_all)
+  apply (simp add: reset_untyped_cap_def)
+  apply (rule hoare_pre)
+   apply (wp no_irq_clearMemory mapME_x_wp' hoare_vcg_const_imp_lift
+             get_cap_wp preemption_point_irq_state_inv'[where irq=irq]
+          | rule irq_state_inv_triv
+          | simp add: unless_def
+          | wp (once) dmo_wp)+
+  done
+
+crunch irq_state_of_state[ADT_IF_assms, wp]:
+  handle_vm_fault, handle_hypervisor_fault "\<lambda>s. P (irq_state_of_state s)"
+  (wp: crunch_wps dmo_wp simp: crunch_simps simp: getDFSR_def getFAR_def getIFSR_def)
+
+text \<open>Not true of invoke_untyped any more.\<close>
+crunch irq_state_of_state[ADT_IF_assms, wp]: create_cap "\<lambda>s. P (irq_state_of_state s)"
+  (ignore: freeMemory
+      wp: dmo_wp modify_wp crunch_wps
+    simp: freeMemory_def storeWord_def clearMemory_def
+          machine_op_lift_def machine_rest_lift_def mapM_x_defsym)
+
+crunch irq_state_of_state[ADT_IF_assms, wp]: arch_invoke_irq_control "\<lambda>s. P (irq_state_of_state s)"
+  (wp: dmo_wp crunch_wps simp: setIRQTrigger_def machine_op_lift_def machine_rest_lift_def)
+
+end
+
+
+global_interpretation ADT_IF_1?: ADT_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact ADT_IF_assms)?)
+qed
+
+sublocale valid_initial_state \<subseteq> valid_initial_state?: ADT_valid_initial_state ..
+
+hide_fact ADT_IF_1.do_user_op_silc_inv
+requalify_facts ARM.do_user_op_silc_inv
+declare do_user_op_silc_inv[wp]
+
+end

--- a/proof/infoflow/ARM/ArchArch_IF.thy
+++ b/proof/infoflow/ARM/ArchArch_IF.thy
@@ -1,0 +1,1944 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchArch_IF
+imports Arch_IF
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems Arch_IF_assms
+
+definition valid_ko_at_arch :: "det_state \<Rightarrow> bool" where
+  "valid_ko_at_arch \<equiv>
+     \<lambda>s. \<exists>pd. ko_at (ArchObj (PageDirectory pd)) (arm_global_pd (arch_state s)) s"
+
+lemma irq_state_clearExMonitor[wp]:
+  "clearExMonitor \<lbrace>\<lambda>s. P (irq_state s)\<rbrace>"
+  by (simp add: clearExMonitor_def | wp modify_wp)+
+
+(* we need to know we're not doing an asid pool update, or else this could affect
+   what some other domain sees *)
+lemma set_object_equiv_but_for_labels:
+  "\<lbrace>equiv_but_for_labels aag L st and (\<lambda> s. \<not> asid_pool_at ptr s) and
+    K ((\<forall>asid_pool. obj \<noteq> ArchObj (ASIDPool asid_pool)) \<and> pasObjectAbs aag ptr \<in> L)\<rbrace>
+   set_object ptr obj
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  apply (wpsimp wp: set_object_wp)
+  apply (clarsimp simp: equiv_but_for_labels_def)
+  apply (subst dummy_kheap_update[where st=st])
+  apply (rule states_equiv_for_non_asid_pool_kheap_update)
+     apply assumption
+    apply (fastforce intro: equiv_forI elim: states_equiv_forE equiv_forE)
+   apply (fastforce simp: non_asid_pool_kheap_update_def)
+  apply (clarsimp simp: non_asid_pool_kheap_update_def asid_pool_at_kheap)
+  done
+
+lemma get_tcb_not_asid_pool_at:
+  "get_tcb ref s = Some y \<Longrightarrow> \<not> asid_pool_at ref s"
+  by (fastforce simp: get_tcb_def asid_pool_at_kheap)
+
+lemma as_user_set_register_ev2:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows "labels_are_invisible aag l (pasObjectAbs aag ` {thread,thread'})
+         \<Longrightarrow> equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) (=) \<top> \<top>
+                           (as_user thread (setRegister x y)) (as_user thread' (setRegister a b))"
+  apply (simp add: as_user_def)
+  apply (rule equiv_valid_2_guard_imp)
+   apply (rule_tac L="{pasObjectAbs aag thread}" and L'="{pasObjectAbs aag thread'}"
+               and Q="\<top>" and Q'="\<top>" in ev2_invisible[OF domains_distinct])
+        apply (simp add: labels_are_invisible_def)+
+      apply ((rule modifies_at_mostI | wp set_object_equiv_but_for_labels | simp add: split_def | fastforce dest: get_tcb_not_asid_pool_at)+)[2]
+    apply auto
+  done
+
+crunch valid_global_refs[Arch_IF_assms, wp]: arch_post_cap_deletion "valid_global_refs"
+
+crunch irq_state_of_state[Arch_IF_assms, wp]: store_word_offs "\<lambda>s. P (irq_state_of_state s)"
+  (wp: crunch_wps dmo_wp simp: storeWord_def)
+
+crunches set_irq_state, arch_post_cap_deletion, handle_arch_fault_reply
+  for irq_state_of_state[Arch_IF_assms, wp]: "\<lambda>s. P (irq_state_of_state s)"
+  (wp: crunch_wps dmo_wp simp: crunch_simps maskInterrupt_def)
+
+crunch irq_state_of_state[Arch_IF_assms, wp]: arch_switch_to_idle_thread, arch_switch_to_thread
+  "\<lambda>s :: det_state. P (irq_state_of_state s)"
+  (wp: dmo_wp modify_wp crunch_wps hoare_whenE_wp
+   simp: invalidateLocalTLB_ASID_def setHardwareASID_def set_current_pd_def machine_op_lift_def
+         machine_rest_lift_def crunch_simps storeWord_def dsb_def isb_def writeTTBR0_def)
+
+crunch irq_state_of_state[Arch_IF_assms, wp]: arch_invoke_irq_handler "\<lambda>s. P (irq_state_of_state s)"
+  (wp: dmo_wp simp: maskInterrupt_def)
+
+crunch irq_state_of_state[wp]: arch_perform_invocation "\<lambda>s. P (irq_state_of_state s)"
+  (wp: dmo_wp modify_wp simp: set_current_pd_def invalidateLocalTLB_ASID_def do_flush_defs
+       invalidateLocalTLB_VAASID_def cleanByVA_PoU_def do_flush_def cache_machine_op_defs
+   wp: crunch_wps simp: crunch_simps ignore: ignore_failure)
+
+crunch irq_state_of_state[Arch_IF_assms, wp]: arch_finalise_cap, prepare_thread_delete
+  "\<lambda>s :: det_state. P (irq_state_of_state s)"
+  (wp: select_wp modify_wp crunch_wps dmo_wp
+   simp: crunch_simps invalidateLocalTLB_ASID_def dsb_def
+         cleanCaches_PoU_def invalidate_I_PoU_def clean_D_PoU_def)
+
+lemma equiv_asid_machine_state_update[Arch_IF_assms, simp]:
+  "equiv_asid asid (machine_state_update f s) s' = equiv_asid asid s s'"
+  "equiv_asid asid s (machine_state_update f s') = equiv_asid asid s s'"
+  by (auto simp: equiv_asid_def)
+
+lemma as_user_set_register_reads_respects'[Arch_IF_assms]:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows "reads_respects aag l \<top> (as_user thread (setRegister x y))"
+  apply (case_tac "aag_can_read aag thread \<or> aag_can_affect aag l thread")
+   apply (simp add: as_user_def split_def)
+   apply (rule gen_asm_ev)
+   apply (wp set_object_reads_respects select_f_ev gets_the_ev)
+   apply (auto intro: reads_affects_equiv_get_tcb_eq det_setRegister)[1]
+  apply (simp add: equiv_valid_def2)
+  apply (rule as_user_set_register_ev2[OF domains_distinct])
+  apply (simp add: labels_are_invisible_def)
+  done
+
+lemma store_word_offs_reads_respects[Arch_IF_assms]:
+  "reads_respects aag l \<top> (store_word_offs ptr offs v)"
+  apply (simp add: store_word_offs_def)
+  apply (rule equiv_valid_get_assert)
+  apply (simp add: storeWord_def)
+  apply (simp add: do_machine_op_bind)
+  apply wp
+     apply (rule use_spec_ev)
+     apply (rule do_machine_op_spec_reads_respects)
+      apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def in_monad)
+      apply (fastforce intro: equiv_forI elim: equiv_forE)
+     apply (rule use_spec_ev do_machine_op_spec_reads_respects assert_ev2
+            | simp add: spec_equiv_valid_def | wp modify_wp)+
+  done
+
+lemma set_simple_ko_globals_equiv[Arch_IF_assms]:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+   set_simple_ko f ptr ep
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding set_simple_ko_def
+  apply (wpsimp wp: set_object_globals_equiv[THEN hoare_set_object_weaken_pre] get_object_wp
+              simp: partial_inv_def)+
+  apply (fastforce simp: obj_at_def valid_ko_at_arch_def)
+  done
+
+lemma set_simple_ko_valid_ko_at_arch[Arch_IF_assms, wp]:
+  "\<lbrace>valid_ko_at_arch\<rbrace> set_simple_ko f ptr ep \<lbrace>\<lambda>_. valid_ko_at_arch\<rbrace>"
+  unfolding set_simple_ko_def set_object_def
+  by (wpsimp wp: get_object_wp
+           simp: partial_inv_def a_type_def obj_at_def valid_ko_at_arch_def)+
+
+lemma set_thread_state_globals_equiv[Arch_IF_assms]:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+   set_thread_state ref ts
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding set_thread_state_def
+  apply (wp set_object_globals_equiv dxo_wp_weak |simp)+
+  apply (intro impI conjI allI)
+    apply (clarsimp simp: valid_ko_at_arch_def obj_at_def tcb_at_def2 get_tcb_def is_tcb_def
+                    dest: get_tcb_SomeD
+                   split: option.splits kernel_object.splits)+
+  done
+
+lemma set_object_valid_ko_at_arch[wp]:
+  "\<lbrace>valid_ko_at_arch and (\<lambda>s. ptr = arm_global_pd (arch_state s)
+                              \<longrightarrow> a_type obj = AArch APageDirectory)\<rbrace>
+   set_object ptr obj
+   \<lbrace>\<lambda>_. valid_ko_at_arch\<rbrace>"
+  by (wpsimp wp: set_object_wp
+           simp: a_type_def valid_ko_at_arch_def obj_at_def
+          split: kernel_object.splits arch_kernel_obj.splits if_splits)
+
+lemma valid_ko_at_arch_exst_update[Arch_IF_assms, simp]:
+  "valid_ko_at_arch (trans_state f s) = valid_ko_at_arch s"
+  by (simp add: valid_ko_at_arch_def)
+
+lemma set_thread_state_valid_ko_at_arch[Arch_IF_assms, wp]:
+  "set_thread_state ref ts \<lbrace>valid_ko_at_arch\<rbrace>"
+  unfolding set_thread_state_def
+  apply (wp set_object_valid_ko_at_arch dxo_wp_weak |simp)+
+  apply (fastforce simp: valid_ko_at_arch_def get_tcb_ko_at obj_at_def)
+  done
+
+lemma set_cap_globals_equiv''[Arch_IF_assms]:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+   set_cap cap p
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding set_cap_def
+  apply (simp only: split_def)
+  apply (wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
+  apply (fastforce simp: valid_ko_at_arch_def obj_at_def is_tcb_def)+
+  done
+
+lemma set_cap_valid_ko_at_arch[Arch_IF_assms, wp]:
+  "set_cap cap p \<lbrace>valid_ko_at_arch\<rbrace>"
+  apply (simp add: valid_ko_at_arch_def)
+  apply (rule hoare_ex_wp)
+  apply (rule hoare_pre)
+   apply (simp add: set_cap_def split_def)
+   apply (wp | wpc)+
+     apply (simp add: set_object_def)
+     apply (wp get_object_wp | wpc)+
+  apply (fastforce simp: obj_at_def)
+  done
+
+lemma as_user_globals_equiv[Arch_IF_assms]:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch and (\<lambda>s. tptr \<noteq> idle_thread s)\<rbrace>
+   as_user tptr f
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding as_user_def
+  apply (wpsimp wp: set_object_globals_equiv simp: split_def)
+  apply (clarsimp simp: valid_ko_at_arch_def get_tcb_def obj_at_def)
+  done
+
+end
+
+context begin interpretation Arch .
+
+requalify_consts
+  valid_ko_at_arch
+
+requalify_facts
+  set_simple_ko_globals_equiv
+  set_simple_ko_valid_ko_at_arch
+  retype_region_irq_state_of_state
+  arch_perform_invocation_irq_state_of_state
+
+declare
+  set_simple_ko_valid_ko_at_arch[wp]
+  retype_region_irq_state_of_state[wp]
+  arch_perform_invocation_irq_state_of_state[wp]
+
+end
+
+
+global_interpretation Arch_IF_1?: Arch_IF_1 valid_ko_at_arch
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Arch_IF_assms)?)
+qed
+
+
+context Arch begin global_naming ARM
+
+lemma valid_arch_state_ko_at_arch:
+  "valid_arch_state s \<Longrightarrow> valid_ko_at_arch s"
+  by (fastforce simp: valid_arch_state_def valid_ko_at_arch_def obj_at_def dest: a_type_pdD)
+
+lemma invs_valid_ko_at_arch:
+  "invs s \<Longrightarrow> valid_ko_at_arch s"
+  by (simp add: invs_def valid_state_def valid_arch_state_ko_at_arch)
+
+lemmas invs_imps =
+  invs_valid_vs_lookup invs_sym_refs invs_psp_aligned invs_distinct invs_valid_ko_at_arch
+  invs_valid_global_objs invs_arch_state invs_valid_objs invs_valid_global_refs tcb_at_invs
+  invs_cur invs_kernel_mappings
+
+lemma cte_wp_at_page_directory_not_in_globals:
+  "\<lbrakk> cte_wp_at ((=) (ArchObjectCap (PageDirectoryCap word optiona))) slot s;
+     x \<le> (kernel_base >> 20) - 1; valid_objs s; valid_global_refs s \<rbrakk>
+     \<Longrightarrow> (x << 2) + word && ~~ mask pd_bits \<notin> global_refs s"
+  apply (frule (1) cte_wp_at_valid_objs_valid_cap)
+  apply (simp add: cte_wp_at_caps_of_state)
+  apply (drule (1) valid_global_refsD2)
+  apply (simp add: cap_range_def)
+  apply (frule valid_cap_aligned)
+  apply (simp add: cap_aligned_def)
+  apply (subgoal_tac "is_aligned word pd_bits")
+   apply (rule pd_shifting_global_refs)
+     apply (simp add: pd_bits_def pageBits_def)+
+  done
+
+lemma not_in_global_not_arm:
+  "A \<notin> global_refs s \<Longrightarrow> A \<noteq> arm_global_pd (arch_state s)"
+  by (simp add: global_refs_def)
+
+lemma cte_wp_at_page_cap_bits :
+  "\<lbrakk> cte_wp_at ((=) (ArchObjectCap (PageTableCap word option))) slot s; valid_objs s \<rbrakk>
+     \<Longrightarrow> cte_wp_at (\<lambda>c. (\<lambda>x. x && ~~ mask pt_bits) ` set [word, word + 4 .e. word + 2 ^ pt_bits - 1]
+                        \<subseteq> Structures_A.obj_refs c \<and> is_pt_cap c) slot s"
+  apply (frule (1) cte_wp_at_valid_objs_valid_cap)
+  apply (clarsimp simp: valid_cap_def cap_aligned_def)
+  apply (erule cte_wp_at_weakenE)
+  apply (unfold is_pt_cap_def)
+  apply (subgoal_tac "is_aligned word pt_bits")
+   prefer 2
+   apply (simp add: pt_bits_def pageBits_def)
+  apply (auto simp: word_aligned_pt_slots)
+  done
+
+lemma mapM_x_swp_store_pte_invs' :
+  "\<lbrace>invs and (\<lambda>s. cte_wp_at ((=) (ArchObjectCap (PageTableCap word option))) slot s)\<rbrace>
+   mapM_x (swp store_pte InvalidPTE) [word , word + 4 .e. word + 2 ^ pt_bits - 1]
+   \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (rule hoare_pre)
+   apply (rule mapM_x_swp_store_pte_invs)
+  apply clarsimp
+  apply (case_tac slot)
+  apply (rule_tac x=a in exI)
+  apply (rule_tac x=b in exI)
+  apply (auto simp: cte_wp_at_page_cap_bits invs_def valid_state_def valid_pspace_def)
+  done
+
+lemma cte_wp_at_page_directory_not_in_kernel_mappings:
+  "\<lbrakk> cte_wp_at ((=) (ArchObjectCap (PageDirectoryCap word optiona))) slot s;
+     x \<le> (kernel_base >> 20) - 1; valid_objs s; valid_global_refs s \<rbrakk>
+     \<Longrightarrow> ucast ((x << 2) + word && mask pd_bits >> 2) \<notin> kernel_mapping_slots"
+  apply (frule (1) cte_wp_at_valid_objs_valid_cap)
+  apply (simp add: cte_wp_at_caps_of_state)
+  apply (drule (1) valid_global_refsD2)
+  apply (simp add: cap_range_def)
+  apply (frule valid_cap_aligned)
+  apply (simp add: cap_aligned_def)
+  apply (subgoal_tac "is_aligned word pd_bits")
+   apply (rule pd_shifting_kernel_mapping_slots)
+    apply (simp add: pd_bits_def pageBits_def)+
+  done
+
+lemma get_asid_pool_revrv':
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
+     (\<lambda>rv rv'. aag_can_read aag ptr \<longrightarrow> rv = rv') \<top> (get_asid_pool ptr)"
+  unfolding get_asid_pool_def
+  apply (rule_tac W="\<lambda>rv rv'. aag_can_read aag ptr \<longrightarrow> rv = rv'" in equiv_valid_rv_bind)
+    apply (rule get_object_revrv')
+   apply (case_tac "aag_can_read aag ptr")
+    apply (simp)
+    apply (case_tac rv)
+        apply (simp | rule fail_ev2_l)+
+    apply (rename_tac arch_kernel_obj)
+    apply (case_tac arch_kernel_obj)
+       apply (simp | rule return_ev2 | rule fail_ev2_l)+
+   apply (clarsimp simp: equiv_valid_2_def)
+   apply (case_tac rv)
+       apply (clarsimp simp: fail_def)+
+   apply (case_tac rv')
+       apply (clarsimp simp: fail_def)+
+   apply (rename_tac arch_kernel_obj arch_kernel_obj')
+   apply (case_tac arch_kernel_obj)
+      apply (case_tac arch_kernel_obj')
+         apply (clarsimp simp: fail_def return_def)+
+  apply (rule get_object_inv)
+  done
+
+lemma get_pt_revrv:
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag \<top>\<top> \<top> (get_pt ptr)"
+  unfolding get_pt_def
+  apply (rule equiv_valid_rv_bind)
+    apply (rule get_object_revrv)
+   apply (simp)
+   apply (case_tac rv)
+       apply (simp | rule fail_ev2_l)+
+   apply (case_tac rv')
+       apply (simp | rule fail_ev2_r)+
+   apply (rename_tac arch_kernel_obj arch_kernel_obj')
+   apply (case_tac arch_kernel_obj)
+      apply (simp | rule fail_ev2_l)+
+     apply (case_tac arch_kernel_obj')
+        apply (simp | rule fail_ev2_r | rule return_ev2)+
+    apply (case_tac arch_kernel_obj')
+       apply (simp | rule fail_ev2_l)+
+  apply (rule get_object_inv)
+  done
+
+lemma set_pt_reads_respects:
+  "reads_respects aag l \<top> (set_pt ptr pt)"
+  unfolding set_pt_def
+  by (rule set_object_reads_respects)
+
+lemma get_pt_reads_respects:
+  "reads_respects aag l (K (is_subject aag ptr)) (get_pt ptr)"
+  unfolding get_pt_def
+  by (wpsimp wp: get_object_rev hoare_vcg_all_lift hoare_drop_imps)
+
+lemma store_pte_reads_respects:
+  "reads_respects aag l (K (is_subject aag (p && ~~ mask pt_bits)))
+    (store_pte p pte)"
+  unfolding store_pte_def fun_app_def
+  by (wpsimp wp: set_pt_reads_respects get_pt_reads_respects)
+
+lemma get_asid_pool_rev:
+  "reads_equiv_valid_inv A aag (K (is_subject aag ptr)) (get_asid_pool ptr)"
+  unfolding get_asid_pool_def
+  by (wpsimp wp: get_object_rev)
+
+lemma get_asid_pool_revrv:
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag (\<lambda>rv rv'. rv (ucast asid) = rv' (ucast asid))
+                            (\<lambda>s. Some a = arm_asid_table (arch_state s) (asid_high_bits_of asid) \<and>
+                                 is_subject_asid aag asid \<and> asid \<noteq> 0)
+                            (get_asid_pool a)"
+  unfolding get_asid_pool_def
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule_tac R'="\<lambda>rv rv'. \<forall>p p'. rv = ArchObj (ASIDPool p) \<and> rv' = ArchObj (ASIDPool p')
+                                       \<longrightarrow> p (ucast asid) = p' (ucast asid)"
+               and P="\<lambda>s. Some a = arm_asid_table (arch_state s) (asid_high_bits_of asid) \<and>
+                          is_subject_asid aag asid \<and> asid \<noteq> 0"
+               and P'="\<lambda>s. Some a = arm_asid_table (arch_state s) (asid_high_bits_of asid) \<and>
+                           is_subject_asid aag asid \<and> asid \<noteq> 0"
+                in equiv_valid_2_bind)
+      apply (clarsimp split: kernel_object.splits arch_kernel_obj.splits
+                       simp: fail_ev2_l fail_ev2_r return_ev2)
+     apply (clarsimp simp: get_object_def gets_def assert_def bind_def put_def get_def
+                           equiv_valid_2_def return_def fail_def
+                    split: if_split)
+     apply (erule reads_equivE)
+     apply (clarsimp simp: equiv_asids_def equiv_asid_def asid_pool_at_kheap)
+     apply (drule aag_can_read_own_asids)
+     apply (drule_tac s="Some a" in sym)
+     apply force
+    apply (wp wp_post_taut | simp)+
+  done
+
+lemma asid_high_bits_0_eq_1:
+  "asid_high_bits_of 0 = asid_high_bits_of 1"
+  by (auto simp: asid_high_bits_of_def asid_low_bits_def)
+
+lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq:
+  "\<lbrakk> is_subject_asid aag asid; reads_equiv aag s t; asid \<noteq> 0 \<rbrakk>
+     \<Longrightarrow> arm_asid_table (arch_state s) (asid_high_bits_of asid) =
+         arm_asid_table (arch_state t) (asid_high_bits_of asid)"
+  apply (erule reads_equivE)
+  apply (fastforce simp: equiv_asids_def equiv_asid_def intro: aag_can_read_own_asids)
+  done
+
+lemma find_pd_for_asid_reads_respects:
+  "reads_respects aag l (K (is_subject_asid aag asid)) (find_pd_for_asid asid)"
+  apply (simp add: find_pd_for_asid_def)
+  apply (subst gets_applyE)
+  (* everything up to and including get_asid_pool, both executions are the same.
+     it is only get_asid_pool that can return different values and for which we need
+     to go equiv_valid_2. We rewrite using associativity to make the decomposition
+     easier *)
+  apply (subst bindE_assoc[symmetric])+
+  apply (simp add: equiv_valid_def2)
+  apply (subst rel_sum_comb_equals[symmetric])
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule_tac R'="\<lambda> rv rv'. rv (ucast asid) = rv' (ucast asid)" and Q="\<top>\<top>" and Q'="\<top>\<top>"
+                in equiv_valid_2_bindE)
+      apply (clarsimp split: option.splits simp: throwError_def returnOk_def)
+      apply (intro conjI impI allI)
+       apply (rule return_ev2, simp)
+      apply (rule return_ev2, simp)
+     apply wp+
+   apply (rule_tac R'="(=)"
+               and Q="\<lambda> rv s. rv = (arm_asid_table (arch_state s)) (asid_high_bits_of asid)
+                            \<and> is_subject_asid aag asid \<and> asid \<noteq> 0"
+               and Q'="\<lambda> rv s. rv = (arm_asid_table (arch_state s)) (asid_high_bits_of asid)
+                             \<and> is_subject_asid aag asid \<and> asid \<noteq> 0"
+                in equiv_valid_2_bindE)
+      apply (simp add: equiv_valid_def2[symmetric])
+      apply (split option.splits)
+      apply (intro conjI impI allI)
+       apply (simp add: throwError_def)
+       apply (rule return_ev2, simp)
+      apply (rule equiv_valid_2_liftE)
+      apply (clarsimp)
+      apply (rule get_asid_pool_revrv)
+     apply (wp gets_apply_wp)+
+   apply (subst rel_sum_comb_equals)
+   apply (subst equiv_valid_def2[symmetric])
+   apply (wp gets_apply_ev | simp)+
+  apply (fastforce intro: requiv_arm_asid_table_asid_high_bits_of_asid_eq)
+  done
+
+lemma find_pd_for_asid_assert_reads_respects:
+  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs
+                                         and K (is_subject_asid aag asid))
+                  (find_pd_for_asid_assert asid)"
+  unfolding find_pd_for_asid_assert_def
+  apply (wpsimp wp: get_pde_rev find_pd_for_asid_reads_respects hoare_vcg_all_lift)
+   apply (rule_tac Q'="\<lambda>rv s. is_subject aag (lookup_pd_slot rv 0 && ~~ mask pd_bits)"
+                in hoare_post_imp_R)
+   apply (rule find_pd_for_asid_pd_slot_authorised)
+   apply (subgoal_tac "lookup_pd_slot r 0 = r")
+    apply fastforce
+   apply (simp add: lookup_pd_slot_def)
+  apply fastforce
+  done
+
+lemma modify_arm_hwasid_table_reads_respects:
+  "reads_respects aag l \<top> (modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_hwasid_table := param\<rparr>\<rparr>))"
+  apply (simp add: equiv_valid_def2)
+  apply (rule modify_ev2)
+  (* FIXME: slow 5s *)
+  by (auto simp: reads_equiv_def affects_equiv_def states_equiv_for_def equiv_for_def
+          intro: equiv_asids_triv' split: if_splits)
+
+
+lemma modify_arm_asid_map_reads_respects:
+  "reads_respects aag l \<top> (modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_asid_map := param\<rparr>\<rparr>))"
+  apply (simp add: equiv_valid_def2)
+  apply (rule modify_ev2)
+  (* FIXME: slow 5s *)
+  by (auto simp: reads_equiv_def affects_equiv_def states_equiv_for_def equiv_for_def
+          intro: equiv_asids_triv' split: if_splits)
+
+lemma modify_arm_next_asid_reads_respects:
+  "reads_respects aag l \<top> (modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_next_asid := param\<rparr>\<rparr>))"
+  apply (simp add: equiv_valid_def2)
+  apply (rule modify_ev2)
+  (* FIXME: slow 5s *)
+  by (auto simp: reads_equiv_def affects_equiv_def states_equiv_for_def equiv_for_def
+          intro: equiv_asids_triv' split: if_splits)
+
+lemmas modify_arch_state_reads_respects =
+  modify_arm_asid_map_reads_respects
+  modify_arm_hwasid_table_reads_respects
+  modify_arm_next_asid_reads_respects
+
+lemma states_equiv_for_arm_hwasid_table_update1:
+  "states_equiv_for P Q R S (s\<lparr>arch_state := (arch_state s)\<lparr>arm_hwasid_table := Y\<rparr>\<rparr>) t =
+   states_equiv_for P Q R S s t"
+  by (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def)
+
+lemma states_equiv_for_arm_hwasid_table_update2:
+  "states_equiv_for P Q R S t (s\<lparr>arch_state := (arch_state s)\<lparr>arm_hwasid_table := Y\<rparr>\<rparr>) =
+   states_equiv_for P Q R S t s"
+  apply (rule iffI)
+   apply (drule states_equiv_for_sym)
+   apply (rule states_equiv_for_sym)
+   apply (simp add: states_equiv_for_arm_hwasid_table_update1)
+  apply (drule states_equiv_for_sym)
+  apply (rule states_equiv_for_sym)
+  apply (simp add: states_equiv_for_arm_hwasid_table_update1)
+  done
+
+lemma states_equiv_for_arm_hwasid_table_update':
+  "states_equiv_for P Q R S t (s\<lparr>arch_state := (arch_state s)\<lparr>arm_hwasid_table := Y\<rparr>\<rparr>) =
+   states_equiv_for P Q R S t s"
+  by (rule states_equiv_for_arm_hwasid_table_update2)
+
+lemmas states_equiv_for_arm_hwasid_table_update =
+  states_equiv_for_arm_hwasid_table_update1
+  states_equiv_for_arm_hwasid_table_update2
+
+lemma states_equiv_for_arm_next_asid_update1:
+  "states_equiv_for P Q R S (s\<lparr>arch_state := (arch_state s)\<lparr>arm_next_asid := Y\<rparr>\<rparr>) t =
+   states_equiv_for P Q R S s t"
+  by (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def)
+
+lemma states_equiv_for_arm_next_asid_update2:
+  "states_equiv_for P Q R S t (s\<lparr>arch_state := (arch_state s)\<lparr>arm_next_asid := X\<rparr>\<rparr>)
+     = states_equiv_for P Q R S t s"
+  by (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def)
+
+lemmas states_equiv_for_arm_next_asid_update =
+  states_equiv_for_arm_next_asid_update1
+  states_equiv_for_arm_next_asid_update2
+
+lemma states_equiv_for_arm_asid_map_update1:
+  "states_equiv_for P Q R S (s\<lparr>arch_state := (arch_state s)\<lparr>arm_asid_map := X\<rparr>\<rparr>) t
+     = states_equiv_for P Q R S s t"
+  by (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def)
+
+lemma states_equiv_for_arm_asid_map_update2:
+  "states_equiv_for P Q R S t (s\<lparr>arch_state := (arch_state s)\<lparr>arm_asid_map := X\<rparr>\<rparr>)
+     = states_equiv_for P Q R S t s"
+  by (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def)
+
+lemmas states_equiv_for_arm_asid_map_update =
+  states_equiv_for_arm_asid_map_update1
+  states_equiv_for_arm_asid_map_update2
+
+crunch states_equiv_for: invalidate_hw_asid_entry "states_equiv_for P Q R S st"
+  (simp: states_equiv_for_arm_hwasid_table_update)
+
+crunch states_equiv_for: invalidate_asid "states_equiv_for P Q R S st"
+  (simp: states_equiv_for_arm_asid_map_update)
+
+(* we don't care about the relationship between virtual and hardware asids at all --
+   these should be unobservable, so rightly we don't expect this one to satisfy
+   reads_respects but instead the weaker property where we assert no relation on
+   the return values *)
+lemma find_free_hw_asid_revrv:
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag \<top>\<top> \<top> (find_free_hw_asid)"
+  unfolding find_free_hw_asid_def fun_app_def invalidateLocalTLB_ASID_def
+  apply (rule equiv_valid_2_unobservable)
+  by (wpsimp wp: invalidate_hw_asid_entry_states_equiv_for do_machine_op_mol_states_equiv_for
+                 dmo_wp invalidate_asid_states_equiv_for
+           simp: states_equiv_for_arm_asid_map_update states_equiv_for_arm_hwasid_table_update
+                 states_equiv_for_arm_next_asid_update)+
+
+lemma load_hw_asid_revrv:
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag \<top>\<top> \<top> (load_hw_asid asid)"
+  by (rule equiv_valid_2_unobservable; wpsimp simp: load_hw_asid_def)
+
+lemma states_equiv_for_arch_update1:
+  "arm_asid_table A = arm_asid_table (arch_state s)
+   \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>arch_state := A\<rparr>) t =
+       states_equiv_for P Q R S s t"
+  by (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def)
+
+lemma states_equiv_for_arch_update2:
+  "arm_asid_table A = arm_asid_table (arch_state s)
+   \<Longrightarrow> states_equiv_for P Q R S t (s\<lparr>arch_state := A\<rparr>) =
+       states_equiv_for P Q R S t s"
+  apply (rule iffI)
+   apply (drule states_equiv_for_sym)
+   apply (rule states_equiv_for_sym)
+   apply (simp add: states_equiv_for_arch_update1)
+  apply (drule states_equiv_for_sym)
+  apply (rule states_equiv_for_sym)
+  apply (simp add: states_equiv_for_arch_update1)
+  done
+
+lemmas states_equiv_for_arch_update = states_equiv_for_arch_update1 states_equiv_for_arch_update2
+
+crunch states_equiv_for: store_hw_asid "states_equiv_for P Q R S st"
+  (simp: states_equiv_for_arch_update)
+
+lemma find_free_hw_asid_states_equiv_for:
+  "find_free_hw_asid \<lbrace>states_equiv_for P Q R S st\<rbrace>"
+  unfolding find_free_hw_asid_def
+  by (wpsimp wp: invalidate_hw_asid_entry_states_equiv_for
+                 do_machine_op_mol_states_equiv_for invalidate_asid_states_equiv_for
+           simp: states_equiv_for_arm_next_asid_update invalidateLocalTLB_ASID_def)
+
+crunch states_equiv_for: get_hw_asid "states_equiv_for P Q R S st"
+
+lemma arm_context_switch_reads_respects:
+  "reads_respects aag l \<top> (arm_context_switch pd asid)"
+  unfolding arm_context_switch_def
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_unobservable_unit_return)
+        apply (wp do_machine_op_mol_states_equiv_for get_hw_asid_states_equiv_for
+               | simp add: set_current_pd_def setHardwareASID_def
+                           writeTTBR0_def dsb_def isb_def dmo_bind_valid)+
+  done
+
+lemma arm_context_switch_states_equiv_for:
+  "arm_context_switch pd asid \<lbrace>states_equiv_for P Q R S st\<rbrace>"
+  unfolding arm_context_switch_def
+  by (wp do_machine_op_mol_states_equiv_for get_hw_asid_states_equiv_for
+      | simp add: set_current_pd_def setHardwareASID_def
+                  dmo_bind_valid dsb_def isb_def writeTTBR0_def)+
+
+lemma set_vm_root_states_equiv_for[wp]:
+  "set_vm_root thread \<lbrace>states_equiv_for P Q R S st\<rbrace>"
+  unfolding set_vm_root_def catch_def fun_app_def set_current_pd_def isb_def dsb_def writeTTBR0_def
+  by (wpsimp wp: arm_context_switch_states_equiv_for do_machine_op_mol_states_equiv_for
+                 hoare_vcg_all_lift hoare_whenE_wp hoare_drop_imps
+           simp: dmo_bind_valid if_apply_def2)+
+
+lemma set_vm_root_reads_respects:
+  "reads_respects aag l \<top> (set_vm_root tcb)"
+  by (rule reads_respects_unobservable_unit_return) wp+
+
+lemma get_pte_reads_respects:
+  "reads_respects aag l (K (is_subject aag (ptr && ~~ mask pt_bits))) (get_pte ptr)"
+  unfolding get_pte_def fun_app_def
+  by (wpsimp wp: get_pt_reads_respects)
+
+crunch states_equiv_for: set_vm_root_for_flush "states_equiv_for P Q R S st"
+  (wp: do_machine_op_mol_states_equiv_for ignore: do_machine_op simp: set_current_pd_def)
+
+lemma set_vm_root_for_flush_reads_respects:
+  "reads_respects aag l (is_subject aag \<circ> cur_thread) (set_vm_root_for_flush pd asid)"
+  unfolding set_vm_root_for_flush_def fun_app_def set_current_pd_def
+  apply (rule equiv_valid_guard_imp)
+  by (wpsimp wp: arm_context_switch_reads_respects dmo_mol_reads_respects
+                 hoare_vcg_all_lift hoare_drop_imps gets_cur_thread_ev get_cap_rev)+
+
+crunch states_equiv_for: flush_table "states_equiv_for P Q R S st"
+  (wp: crunch_wps do_machine_op_mol_states_equiv_for
+   ignore: do_machine_op
+   simp: invalidateLocalTLB_ASID_def crunch_simps)
+
+crunch sched_act: flush_table "\<lambda> s. P (scheduler_action s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+crunch wuc: flush_table "\<lambda> s. P (work_units_completed s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma flush_table_reads_respects:
+  "reads_respects aag l \<top> (flush_table pd asid vptr pt)"
+  apply (rule reads_respects_unobservable_unit_return)
+       apply (rule flush_table_states_equiv_for)
+      apply (rule flush_table_cur_thread)
+     apply (rule flush_table_cur_domain)
+    apply (rule flush_table_sched_act)
+   apply (rule flush_table_wuc)
+  apply wp
+  done
+
+lemma page_table_mapped_reads_respects:
+  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs
+                                         and K (is_subject_asid aag asid))
+                  (page_table_mapped asid vaddr pt)"
+  unfolding page_table_mapped_def catch_def fun_app_def
+  by (wpsimp wp: get_pde_rev find_pd_for_asid_reads_respects)+
+
+lemma unmap_page_table_reads_respects:
+  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs
+                                         and K (is_subject_asid aag asid))
+                  (unmap_page_table asid vaddr pt)"
+  unfolding unmap_page_table_def fun_app_def page_table_mapped_def
+  by (wp dmo_mol_reads_respects store_pde_reads_respects get_pde_rev
+         flush_table_reads_respects find_pd_for_asid_reads_respects hoare_vcg_all_lift_R
+      | wpc | simp add: cleanByVA_PoU_def | wp (once) hoare_drop_imps)+
+
+lemma perform_page_table_invocation_reads_respects:
+  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs
+                                         and K (authorised_page_table_inv aag pti))
+                  (perform_page_table_invocation pti)"
+  unfolding perform_page_table_invocation_def fun_app_def cleanCacheRange_PoU_def
+  apply (rule equiv_valid_guard_imp)
+   apply (wp dmo_cacheRangeOp_reads_respects dmo_mol_reads_respects store_pde_reads_respects
+             set_cap_reads_respects mapM_x_ev'' store_pte_reads_respects
+             unmap_page_table_reads_respects get_cap_rev
+          | wpc | simp add: cleanByVA_PoU_def)+
+  apply (case_tac pti; clarsimp simp: authorised_page_table_inv_def)
+  done
+
+lemma do_flush_reads_respects:
+  "reads_respects aag l \<top> (do_machine_op (do_flush typ start end pstart))"
+  apply (cases "typ")
+  by (wp dmo_mol_reads_respects dmo_cacheRangeOp_reads_respects
+      | simp add: do_flush_def cache_machine_op_defs do_flush_defs dmo_bind_ev when_def
+      | rule conjI | clarsimp)+
+
+lemma perform_page_directory_invocation_reads_respects:
+  "reads_respects aag l (is_subject aag \<circ> cur_thread) (perform_page_directory_invocation pdi)"
+  unfolding perform_page_directory_invocation_def
+  apply (cases pdi)
+  by (wp do_flush_reads_respects set_vm_root_reads_respects set_vm_root_for_flush_reads_respects
+      | simp add: when_def requiv_cur_thread_eq split del: if_split
+      | wp (once) hoare_drop_imps | clarsimp)+
+
+lemma check_mapping_pptr_reads_respects:
+  "reads_respects aag l (K (\<forall>x. (tablePtr = Inl x \<longrightarrow> is_subject aag (x && ~~ mask pt_bits)) \<and>
+                                (tablePtr = Inr x \<longrightarrow> is_subject aag (x && ~~ mask pd_bits))))
+                  (check_mapping_pptr pptr pgsz tablePtr)"
+  unfolding check_mapping_pptr_def fun_app_def
+  apply (rule equiv_valid_guard_imp)
+   apply (wpsimp wp: get_pte_reads_respects get_pde_rev)
+  apply simp
+  done
+
+lemma lookup_pt_slot_reads_respects:
+  "reads_respects aag l (K (is_subject aag (lookup_pd_slot pd vptr && ~~ mask pd_bits)))
+                  (lookup_pt_slot pd vptr)"
+  unfolding lookup_pt_slot_def fun_app_def
+  by (wpsimp wp: get_pde_rev)
+
+crunch sched_act: flush_page "\<lambda>s. P (scheduler_action s)"
+  (wp: crunch_wps simp: if_apply_def2)
+
+crunch wuc: flush_page "\<lambda>s. P (work_units_completed s)"
+  (wp: crunch_wps simp: if_apply_def2)
+
+crunch states_equiv_for: flush_page "states_equiv_for P Q R S st"
+  (wp: do_machine_op_mol_states_equiv_for crunch_wps
+   ignore: do_machine_op
+   simp: invalidateLocalTLB_VAASID_def if_apply_def2)
+
+lemma flush_page_reads_respects:
+  "reads_respects aag l \<top> (flush_page page_size pd asid vptr)"
+  by (blast intro: reads_respects_unobservable_unit_return flush_page_states_equiv_for
+                   flush_page_cur_thread flush_page_cur_domain flush_page_sched_act
+                   flush_page_wuc flush_page_irq_state_of_state)
+
+(* clagged some help from unmap_page_respects in Arch_AC *)
+lemma unmap_page_reads_respects:
+  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs
+                                         and K (is_subject_asid aag asid \<and> vptr < kernel_base))
+                  (unmap_page pgsz asid vptr pptr)"
+  unfolding unmap_page_def catch_def fun_app_def cleanCacheRange_PoU_def
+  apply (simp add: unmap_page_def swp_def cong: vmpage_size.case_cong)
+  by (wp dmo_mol_reads_respects dmo_cacheRangeOp_reads_respects store_pte_reads_respects[simplified]
+         check_mapping_pptr_reads_respects throw_on_false_reads_respects
+         lookup_pt_slot_reads_respects lookup_pt_slot_authorised lookup_pt_slot_authorised2
+         store_pde_reads_respects[simplified] flush_page_reads_respects
+         find_pd_for_asid_reads_respects find_pd_for_asid_pd_slot_authorised
+         mapM_ev''[where m="(\<lambda>a. store_pte a InvalidPTE)"
+                     and P="\<lambda>x s. is_subject aag (x && ~~ mask pt_bits)"]
+         mapM_ev''[where m="(\<lambda>a. store_pde a InvalidPDE)"
+                     and P="\<lambda>x s. is_subject aag (x && ~~ mask pd_bits)"]
+      | wpc | wp (once) hoare_drop_imps
+      | simp add: is_aligned_6_masks is_aligned_mask[symmetric] cleanByVA_PoU_def)+
+
+crunch states_equiv_for: invalidate_tlb_by_asid "states_equiv_for P Q R S st"
+  (wp: do_machine_op_mol_states_equiv_for ignore: do_machine_op simp: invalidateLocalTLB_ASID_def)
+
+crunch sched_act[wp]: invalidate_tlb_by_asid "\<lambda>s. P (scheduler_action s)"
+
+crunch wuc[wp]: invalidate_tlb_by_asid "\<lambda>s. P (work_units_completed s)"
+
+lemma invalidate_tlb_by_asid_reads_respects:
+  "reads_respects aag l (\<lambda>_. True) (invalidate_tlb_by_asid asid)"
+  apply (rule reads_respects_unobservable_unit_return)
+       apply (rule invalidate_tlb_by_asid_states_equiv_for)
+      apply wp+
+  done
+
+lemma get_master_pte_reads_respects:
+  "reads_respects aag l (K (is_subject aag (p && ~~ mask pt_bits))) (get_master_pte p)"
+  unfolding get_master_pte_def
+  apply (wpsimp wp: get_pte_reads_respects hoare_drop_imps)
+  apply (fastforce simp: pt_bits_def pageBits_def mask_lower_twice)
+  done
+
+lemma get_master_pde_reads_respects:
+  "reads_respects aag l (K (is_subject aag (x && ~~ mask pd_bits))) (get_master_pde x)"
+  unfolding get_master_pde_def
+  apply (wpsimp wp: get_pde_rev hoare_drop_imps)
+  apply (fastforce simp: pd_bits_def pageBits_def mask_lower_twice)
+  done
+
+lemma perform_page_invocation_reads_respects:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects aag l (pas_refined aag and K (authorised_page_inv aag pgi)
+                                               and valid_page_inv pgi and valid_vspace_objs
+                                               and pspace_aligned and is_subject aag \<circ> cur_thread)
+                        (perform_page_invocation pgi)"
+  unfolding perform_page_invocation_def fun_app_def when_def cleanCacheRange_PoU_def
+  apply (rule equiv_valid_guard_imp)
+  apply wpc
+      apply (simp add: mapM_discarded swp_def)
+      apply (wp dmo_mol_reads_respects dmo_cacheRangeOp_reads_respects  mapM_x_ev''
+                store_pte_reads_respects set_cap_reads_respects mapM_ev'' store_pde_reads_respects
+                unmap_page_reads_respects set_vm_root_reads_respects dmo_mol_2_reads_respects
+                set_vm_root_for_flush_reads_respects get_cap_rev  do_flush_reads_respects
+                invalidate_tlb_by_asid_reads_respects get_master_pte_reads_respects
+                get_master_pde_reads_respects set_mrs_reads_respects set_message_info_reads_respects
+             | simp add: cleanByVA_PoU_def pte_check_if_mapped_def pde_check_if_mapped_def
+             | wpc | wp (once) hoare_drop_imps[where R="\<lambda>r s. r"])+
+  apply (clarsimp simp: authorised_page_inv_def valid_page_inv_def)
+  apply (auto simp: cte_wp_at_caps_of_state valid_slots_def cap_auth_conferred_def
+                    update_map_data_def is_page_cap_def authorised_slots_def valid_page_inv_def
+                    valid_cap_simps cap_links_asid_slot_def label_owns_asid_slot_def
+             dest!: bspec[OF _ rev_subsetD[OF _ tl_subseteq]] clas_caps_of_state pas_refined_Control
+         | (frule aag_can_read_self, simp)+)+
+  done
+
+lemma equiv_asids_arm_asid_table_update:
+  "\<lbrakk> equiv_asids R s t; kheap s pool_ptr = kheap t pool_ptr \<rbrakk>
+     \<Longrightarrow> equiv_asids R
+           (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := arm_asid_table (arch_state s)
+                                                            (asid_high_bits_of asid \<mapsto> pool_ptr)\<rparr>\<rparr>)
+           (t\<lparr>arch_state := arch_state t\<lparr>arm_asid_table := arm_asid_table (arch_state t)
+                                                            (asid_high_bits_of asid \<mapsto> pool_ptr)\<rparr>\<rparr>)"
+  by (clarsimp simp: equiv_asids_def equiv_asid_def asid_pool_at_kheap)
+
+lemma arm_asid_table_update_reads_respects:
+  "reads_respects aag l (K (is_subject aag pool_ptr))
+     (do r \<leftarrow> gets (arm_asid_table \<circ> arch_state);
+         modify (\<lambda>s. s\<lparr>arch_state := arch_state s
+                                       \<lparr>arm_asid_table := r(asid_high_bits_of asid \<mapsto> pool_ptr)\<rparr>\<rparr>)
+      od)"
+  apply (simp add: equiv_valid_def2)
+  apply (rule_tac W="\<top>\<top>"
+              and Q="\<lambda>rv s. is_subject aag pool_ptr \<and> rv = arm_asid_table (arch_state s)"
+               in equiv_valid_rv_bind)
+    apply (rule equiv_valid_rv_guard_imp[OF equiv_valid_rv_trivial])
+     apply wpsimp+
+   apply (rule modify_ev2)
+   apply clarsimp
+   apply (drule (1) is_subject_kheap_eq[rotated])
+   apply (auto simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_for_def
+             intro!: equiv_asids_arm_asid_table_update)
+   done
+
+lemma perform_asid_control_invocation_reads_respects:
+  notes K_bind_ev[wp del]
+  shows "reads_respects aag l (K (authorised_asid_control_inv aag aci))
+                        (perform_asid_control_invocation aci)"
+  unfolding perform_asid_control_invocation_def
+  apply (rule gen_asm_ev)
+  apply (rule equiv_valid_guard_imp)
+   (* we do some hacky rewriting here to separate out the bit that does interesting stuff from the rest *)
+   apply (subst (6) my_bind_rewrite_lemma)
+   apply (subst (1) bind_assoc[symmetric])
+   apply (subst another_hacky_rewrite)
+   apply (subst another_hacky_rewrite)
+   apply (wpc)
+   apply (rule bind_ev)
+     apply (rule K_bind_ev)
+     apply (rule_tac P'=\<top> in bind_ev)
+       apply (rule K_bind_ev)
+       apply (rule bind_ev)
+         apply (rule bind_ev)
+           apply (rule return_ev)
+          apply (rule K_bind_ev)
+          apply simp
+          apply (rule arm_asid_table_update_reads_respects)
+         apply (wp cap_insert_reads_respects retype_region_reads_respects
+                   set_cap_reads_respects delete_objects_reads_respects get_cap_rev
+                | simp add: authorised_asid_control_inv_def)+
+  apply (auto dest!: is_aligned_no_overflow)
+  done
+
+lemma set_asid_pool_reads_respects:
+  "reads_respects aag l \<top> (set_asid_pool ptr pool)"
+  unfolding set_asid_pool_def
+  by (rule set_object_reads_respects)
+
+lemma perform_asid_pool_invocation_reads_respects:
+  "reads_respects aag l (pas_refined aag and K (authorised_asid_pool_inv aag api))
+                  (perform_asid_pool_invocation api)"
+  unfolding perform_asid_pool_invocation_def
+  apply (rule equiv_valid_guard_imp)
+   apply (wpsimp wp: set_asid_pool_reads_respects set_cap_reads_respects
+                     get_asid_pool_rev get_cap_auth_wp[where aag=aag] get_cap_rev)
+  apply (clarsimp simp: authorised_asid_pool_inv_def)
+  done
+
+lemma arch_perform_invocation_reads_respects:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs
+                                               and authorised_arch_inv aag ai
+                                               and valid_arch_inv ai and is_subject aag \<circ> cur_thread)
+                        (arch_perform_invocation ai)"
+  unfolding arch_perform_invocation_def fun_app_def
+  apply (wpsimp wp: perform_page_table_invocation_reads_respects
+                    perform_page_directory_invocation_reads_respects
+                    perform_page_invocation_reads_respects
+                    perform_asid_control_invocation_reads_respects
+                    perform_asid_pool_invocation_reads_respects)
+  apply (case_tac ai)
+  by (auto simp: authorised_arch_inv_def valid_arch_inv_def)
+
+lemma equiv_asids_arm_asid_table_delete:
+  "equiv_asids R s t
+   \<Longrightarrow> equiv_asids R
+         (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := \<lambda>a. if a = asid_high_bits_of asid then None
+                                                             else arm_asid_table (arch_state s) a\<rparr>\<rparr>)
+         (t\<lparr>arch_state := arch_state t\<lparr>arm_asid_table := \<lambda>a. if a = asid_high_bits_of asid then None
+                                                             else arm_asid_table (arch_state t) a\<rparr>\<rparr>)"
+  by (clarsimp simp: equiv_asids_def equiv_asid_def asid_pool_at_kheap)
+
+lemma arm_asid_table_delete_ev2:
+  "equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) \<top>\<top>
+     (\<lambda>s. rv = arm_asid_table (arch_state s)) (\<lambda>s. rv' = arm_asid_table (arch_state s))
+     (modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := \<lambda>a. if a = asid_high_bits_of base
+                                                                     then None
+                                                                     else rv a\<rparr>\<rparr>))
+     (modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := \<lambda>a. if a = asid_high_bits_of base
+                                                                     then None
+                                                                     else rv' a\<rparr>\<rparr>))"
+  apply (rule modify_ev2)
+  (* slow 15s *)
+  by (auto simp: reads_equiv_def2 affects_equiv_def2
+         intro!: states_equiv_forI equiv_forI equiv_asids_arm_asid_table_delete
+          elim!: states_equiv_forE equiv_forE
+           elim: is_subject_kheap_eq[simplified reads_equiv_def2 states_equiv_for_def, rotated])
+
+crunch states_equiv_for: invalidate_asid_entry "states_equiv_for P Q R S st"
+crunch sched_act: invalidate_asid_entry "\<lambda>s. P (scheduler_action s)"
+crunch wuc: invalidate_asid_entry "\<lambda>s. P (work_units_completed s)"
+crunch sched_act: flush_space "\<lambda>s. P (scheduler_action s)"
+crunch wuc: flush_space "\<lambda>s. P (work_units_completed s)"
+crunch states_equiv_for: flush_space "states_equiv_for P Q R S st"
+  (wp: mol_states_equiv_for dmo_wp
+   ignore: do_machine_op
+   simp: invalidateLocalTLB_ASID_def cleanCaches_PoU_def dsb_def invalidate_I_PoU_def clean_D_PoU_def)
+
+lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq':
+  "\<lbrakk> (\<forall>asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of base
+              \<longrightarrow> is_subject_asid aag asid'); reads_equiv aag s t \<rbrakk>
+     \<Longrightarrow> arm_asid_table (arch_state s) (asid_high_bits_of base) =
+         arm_asid_table (arch_state t) (asid_high_bits_of base)"
+  apply (insert asid_high_bits_0_eq_1)
+  apply (case_tac "base = 0")
+   apply (subgoal_tac "is_subject_asid aag 1")
+    apply simp
+    apply (rule requiv_arm_asid_table_asid_high_bits_of_asid_eq[where aag=aag])
+      apply (erule_tac x=1 in allE)
+      apply simp+
+  apply (rule requiv_arm_asid_table_asid_high_bits_of_asid_eq[where aag=aag])
+    apply (erule_tac x=base in allE)
+    apply simp+
+  done
+
+lemma delete_asid_pool_reads_respects:
+  "reads_respects aag l (K (\<forall>asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of base
+                                    \<longrightarrow> is_subject_asid aag asid'))
+                  (delete_asid_pool base ptr)"
+  unfolding delete_asid_pool_def
+  apply (rule equiv_valid_guard_imp)
+   apply (rule bind_ev)
+     apply (simp)
+     apply (subst equiv_valid_def2)
+     apply (rule_tac W="\<top>\<top>"
+                 and Q="\<lambda>rv s. rv = arm_asid_table (arch_state s) \<and>
+                               (\<forall>asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of base
+                                        \<longrightarrow> is_subject_asid aag asid')"
+                  in equiv_valid_rv_bind)
+       apply (rule equiv_valid_rv_guard_imp[OF equiv_valid_rv_trivial])
+        apply (wp, simp)
+      apply (simp add: when_def)
+      apply (clarsimp | rule conjI)+
+        apply (subst bind_assoc[symmetric])
+        apply (subst (3) bind_assoc[symmetric])
+        apply (rule equiv_valid_2_guard_imp)
+          apply (rule equiv_valid_2_bind)
+             apply (rule equiv_valid_2_bind)
+                apply (rule equiv_valid_2_unobservable)
+                           apply (wp set_vm_root_states_equiv_for)+
+               apply (rule arm_asid_table_delete_ev2)
+              apply (wp)+
+            apply (rule equiv_valid_2_unobservable)
+  by (wp mapM_wp' invalidate_asid_entry_states_equiv_for flush_space_states_equiv_for
+         invalidate_asid_entry_cur_thread invalidate_asid_entry_sched_act invalidate_asid_entry_wuc
+         flush_space_cur_thread flush_space_sched_act flush_space_wuc return_ev2
+      | rule conjI | drule (1) requiv_arm_asid_table_asid_high_bits_of_asid_eq'
+      | clarsimp | simp add: equiv_valid_2_def)+
+
+lemma set_asid_pool_state_equal_except_kheap:
+  "((), s') \<in> fst (set_asid_pool ptr pool s)
+   \<Longrightarrow> states_equal_except_kheap_asid s s' \<and>
+       (\<forall>p. p \<noteq> ptr \<longrightarrow> kheap s p = kheap s' p) \<and>
+       kheap s' ptr = Some (ArchObj (ASIDPool pool)) \<and>
+       (\<forall>asid. asid \<noteq> 0
+               \<longrightarrow> arm_asid_table (arch_state s) (asid_high_bits_of asid) =
+                   arm_asid_table (arch_state s') (asid_high_bits_of asid) \<and>
+                   (\<forall>pool_ptr. arm_asid_table (arch_state s) (asid_high_bits_of asid) =
+                               Some pool_ptr
+                               \<longrightarrow> asid_pool_at pool_ptr s = asid_pool_at pool_ptr s' \<and>
+                                   (\<forall>asid_pool asid_pool'. pool_ptr \<noteq> ptr
+                                                           \<longrightarrow> kheap s pool_ptr =
+                                                               Some (ArchObj (ASIDPool asid_pool)) \<and>
+                                                               kheap s' pool_ptr =
+                                                               Some (ArchObj (ASIDPool asid_pool'))
+                                                               \<longrightarrow> asid_pool (ucast asid) =
+                                                                   asid_pool' (ucast asid))))"
+  by (clarsimp simp: set_asid_pool_def put_def bind_def set_object_def get_object_def gets_def
+                     get_def return_def assert_def fail_def states_equal_except_kheap_asid_def
+                     equiv_for_def obj_at_def
+              split: if_split_asm)
+
+lemma set_asid_pool_delete_ev2:
+  "equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) \<top>\<top>
+     (\<lambda>s. arm_asid_table (arch_state s) (asid_high_bits_of asid) = Some a \<and>
+          kheap s a = Some (ArchObj (ASIDPool pool)) \<and> asid \<noteq> 0 \<and> is_subject_asid aag asid)
+     (\<lambda>s. arm_asid_table (arch_state s) (asid_high_bits_of asid) = Some a \<and>
+          kheap s a = Some (ArchObj (ASIDPool pool')) \<and> asid \<noteq> 0 \<and> is_subject_asid aag asid)
+     (set_asid_pool a (pool(ucast asid := None))) (set_asid_pool a (pool'(ucast asid := None)))"
+  apply (clarsimp simp: equiv_valid_2_def)
+  apply (frule_tac s'=b in set_asid_pool_state_equal_except_kheap)
+  apply (frule_tac s'=ba in set_asid_pool_state_equal_except_kheap)
+  apply (clarsimp simp: states_equal_except_kheap_asid_def)
+  apply (rule conjI)
+   apply (clarsimp simp: states_equiv_for_def reads_equiv_def equiv_for_def | rule conjI)+
+    apply (case_tac "x=a")
+     apply (clarsimp)
+    apply (fastforce)
+   apply (clarsimp simp: equiv_asids_def equiv_asid_def | rule conjI)+
+    apply (case_tac "pool_ptr = a")
+     apply (clarsimp)
+     apply (erule_tac x="pasASIDAbs aag asid" in ballE)
+      apply (clarsimp)
+      apply (erule_tac x=asid in allE)+
+      apply (clarsimp)
+     apply (drule aag_can_read_own_asids, simp)
+    apply (erule_tac x="pasASIDAbs aag asida" in ballE)
+     apply (clarsimp)
+     apply (erule_tac x=asida in allE)+
+     apply (clarsimp)
+    apply (clarsimp)
+   apply (clarsimp)
+   apply (case_tac "pool_ptr=a")
+    apply (erule_tac x="pasASIDAbs aag asida" in ballE)
+     apply (clarsimp)+
+  apply (clarsimp simp: affects_equiv_def equiv_for_def states_equiv_for_def | rule conjI)+
+   apply (case_tac "x=a")
+    apply (clarsimp)
+   apply (fastforce)
+  apply (clarsimp simp: equiv_asids_def equiv_asid_def | rule conjI)+
+   apply (case_tac "pool_ptr=a")
+    apply (clarsimp)
+    apply (erule_tac x=asid in allE)+
+    apply (clarsimp simp: asid_pool_at_kheap)
+   apply (erule_tac x=asida in allE)+
+   apply (clarsimp)
+  apply (clarsimp)
+  apply (case_tac "pool_ptr=a")
+   apply (clarsimp)+
+  done
+
+lemma delete_asid_reads_respects:
+  "reads_respects aag l (K (asid \<noteq> 0 \<and> is_subject_asid aag asid)) (delete_asid asid pd)"
+  unfolding delete_asid_def
+  apply (subst equiv_valid_def2)
+  apply (rule_tac W="\<top>\<top>" and Q="\<lambda>rv s. rv = arm_asid_table (arch_state s) \<and>
+                                        is_subject_asid aag asid \<and> asid \<noteq> 0" in equiv_valid_rv_bind)
+    apply (rule equiv_valid_rv_guard_imp[OF equiv_valid_rv_trivial])
+     apply (wp, simp)
+   apply (case_tac "rv (asid_high_bits_of asid) = rv' (asid_high_bits_of asid)")
+    apply (simp)
+    apply (case_tac "rv' (asid_high_bits_of asid)")
+     apply (simp)
+     apply (wp return_ev2, simp)
+    apply (simp)
+    apply (rule equiv_valid_2_guard_imp)
+      apply (rule_tac R'="\<lambda>rv rv'. rv (ucast asid) = rv' (ucast asid)" in equiv_valid_2_bind)
+         apply (simp add: when_def)
+         apply (clarsimp | rule conjI)+
+          apply (rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
+             apply (rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
+                apply (rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
+                   apply (subst equiv_valid_def2[symmetric])
+                   apply (rule reads_respects_unobservable_unit_return)
+                        apply (wp set_vm_root_states_equiv_for)+
+                  apply (rule set_asid_pool_delete_ev2)
+                 apply (wp)+
+               apply (rule equiv_valid_2_unobservable)
+                          apply (wp invalidate_asid_entry_states_equiv_for invalidate_asid_entry_cur_thread)+
+                    apply (simp add: invalidate_asid_entry_def
+                           | wp invalidate_asid_kheap invalidate_hw_asid_entry_kheap load_hw_asid_kheap)+
+            apply (rule equiv_valid_2_unobservable)
+                       apply (wp flush_space_states_equiv_for flush_space_cur_thread)+
+                 apply (wp load_hw_asid_kheap | simp add: flush_space_def | wpc)+
+         apply (clarsimp | rule return_ev2)+
+        apply (rule equiv_valid_2_guard_imp)
+          apply (wp get_asid_pool_revrv)
+         apply (simp)+
+       apply (wp)+
+     apply (clarsimp simp: obj_at_def)+
+   apply (clarsimp simp: equiv_valid_2_def reads_equiv_def
+                         equiv_asids_def equiv_asid_def states_equiv_for_def)
+   apply (erule_tac x="pasASIDAbs aag asid" in ballE)
+    apply (clarsimp)
+   apply (drule aag_can_read_own_asids)
+   apply wpsimp+
+  done
+
+lemma set_asid_pool_globals_equiv:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+   set_asid_pool ptr pool
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding set_asid_pool_def
+  apply (wpsimp wp: set_object_globals_equiv[THEN hoare_set_object_weaken_pre]
+              simp: a_type_def)
+  apply (fastforce simp: valid_ko_at_arch_def obj_at_def)
+  done
+
+crunch globals_equiv[wp]: invalidate_hw_asid_entry "globals_equiv s"
+  (simp: globals_equiv_def)
+
+crunch globals_equiv[wp]: invalidate_asid "globals_equiv s"
+  (simp: globals_equiv_def)
+
+lemma globals_equiv_arm_next_asid_update[simp]:
+  "globals_equiv s (t\<lparr>arch_state := arch_state t\<lparr>arm_next_asid := x\<rparr>\<rparr>) = globals_equiv s t"
+  by (simp add: globals_equiv_def)
+
+lemma globals_equiv_arm_asid_map_update[simp]:
+  "globals_equiv s (t\<lparr>arch_state := arch_state t\<lparr>arm_asid_map := x\<rparr>\<rparr>) = globals_equiv s t"
+  by (simp add: globals_equiv_def)
+
+lemma globals_equiv_arm_hwasid_table_update[simp]:
+  "globals_equiv s (t\<lparr>arch_state := arch_state t\<lparr>arm_hwasid_table := x\<rparr>\<rparr>) = globals_equiv s t"
+  by (simp add: globals_equiv_def)
+
+lemma globals_equiv_arm_asid_table_update[simp]:
+  "globals_equiv s (t\<lparr>arch_state := arch_state t\<lparr>arm_asid_table := x\<rparr>\<rparr>) = globals_equiv s t"
+  by (simp add: globals_equiv_def)
+
+lemma find_free_hw_asid_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s\<rbrace> find_free_hw_asid \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding find_free_hw_asid_def
+  by (wp modify_wp invalidate_hw_asid_entry_globals_equiv
+         dmo_mol_globals_equiv invalidate_asid_globals_equiv
+      | wpc | simp add: invalidateLocalTLB_ASID_def)+
+
+lemma store_hw_asid_globals_equiv[wp]:
+  "store_hw_asid asid hw_asid \<lbrace>globals_equiv s\<rbrace>"
+  unfolding store_hw_asid_def
+  apply (wp find_pd_for_asid_assert_wp | rule modify_wp, simp)+
+  apply (fastforce simp: globals_equiv_def)
+  done
+
+lemma get_hw_asid_globals_equiv[wp]:
+  "get_hw_asid asid \<lbrace>globals_equiv s\<rbrace>"
+  unfolding get_hw_asid_def
+  by (wp store_hw_asid_globals_equiv find_free_hw_asid_globals_equiv load_hw_asid_wp | wpc | simp)+
+
+lemma arm_context_switch_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s\<rbrace> arm_context_switch pd asid \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding arm_context_switch_def setHardwareASID_def
+  by (wp dmo_mol_globals_equiv get_hw_asid_globals_equiv
+      | simp add: dmo_bind_valid set_current_pd_def writeTTBR0_def isb_def dsb_def)+
+
+lemma set_vm_root_globals_equiv[wp]:
+  "set_vm_root tcb \<lbrace>globals_equiv s\<rbrace>"
+  apply (clarsimp simp: set_vm_root_def set_current_pd_def dsb_def
+                        isb_def writeTTBR0_def dmo_bind_valid)
+  apply (wp dmo_mol_globals_equiv arm_context_switch_globals_equiv whenE_inv
+         | wpc
+         | clarsimp simp: dmo_bind_valid isb_def dsb_def writeTTBR0_def)+
+   apply (wp hoare_vcg_all_lift | wp (once) hoare_drop_imps | clarsimp)+
+  done
+
+lemma invalidate_asid_entry_globals_equiv[wp]:
+  "invalidate_asid_entry asid \<lbrace>globals_equiv s\<rbrace>"
+  unfolding invalidate_asid_entry_def
+  by (wpsimp wp: invalidate_hw_asid_entry_globals_equiv
+                 invalidate_asid_globals_equiv load_hw_asid_wp)
+
+lemma flush_space_globals_equiv[wp]:
+  "flush_space asid \<lbrace>globals_equiv s\<rbrace>"
+  unfolding flush_space_def
+  by (wp dmo_mol_globals_equiv load_hw_asid_wp
+      | wpc
+      | simp add: invalidateLocalTLB_ASID_def cleanCaches_PoU_def dsb_def
+                  invalidate_I_PoU_def clean_D_PoU_def dmo_bind_valid)+
+
+lemma delete_asid_pool_globals_equiv[wp]:
+  "delete_asid_pool base ptr \<lbrace>globals_equiv s\<rbrace>"
+  unfolding delete_asid_pool_def
+  by (wpsimp wp: set_vm_root_globals_equiv mapM_wp[OF _ subset_refl] modify_wp
+                 invalidate_asid_entry_globals_equiv flush_space_globals_equiv)
+
+crunch globals_equiv[wp]: invalidate_tlb_by_asid "globals_equiv s"
+  (simp: invalidateLocalTLB_ASID_def wp: dmo_mol_globals_equiv ignore: machine_op_lift do_machine_op)
+
+lemma set_pt_globals_equiv:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+   set_pt ptr pt
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding set_pt_def
+  apply (wpsimp wp: set_object_globals_equiv[THEN hoare_set_object_weaken_pre]
+              simp: a_type_def)
+  apply (fastforce simp: valid_ko_at_arch_def obj_at_def)
+  done
+
+crunch globals_equiv: store_pte "globals_equiv s"
+
+lemma set_vm_root_for_flush_globals_equiv[wp]:
+  "set_vm_root_for_flush pd asid \<lbrace>globals_equiv s\<rbrace>"
+  unfolding set_vm_root_for_flush_def set_current_pd_def fun_app_def
+  by (wpsimp wp: dmo_mol_globals_equiv hoare_drop_imps hoare_vcg_all_lift)
+
+lemma flush_table_globals_equiv[wp]:
+  "flush_table pd asid cptr pt \<lbrace>globals_equiv s\<rbrace>"
+  unfolding flush_table_def invalidateLocalTLB_ASID_def fun_app_def
+  by (wp mapM_wp' dmo_mol_globals_equiv
+      | wpc | simp add: do_machine_op_bind split del: if_split cong: if_cong)+
+
+lemma arm_global_pd_arm_asid_map_update[simp]:
+  "arm_global_pd (arch_state s\<lparr>arm_asid_map := x\<rparr>) = arm_global_pd (arch_state s)"
+  by (simp add: globals_equiv_def)
+
+lemma arm_global_pd_arm_hwasid_table_update[simp]:
+  "arm_global_pd (arch_state s\<lparr>arm_hwasid_table := x\<rparr>) = arm_global_pd (arch_state s)"
+  by (simp add: globals_equiv_def)
+
+crunch arm_global_pd[wp]: flush_table "\<lambda>s. P (arm_global_pd (arch_state s))"
+  (wp: crunch_wps simp: crunch_simps)
+
+crunch globals_equiv[wp]: page_table_mapped "globals_equiv st"
+
+(*FIXME: duplicated, more reasonable version of not_in_global_refs_vs_lookup *)
+
+lemma not_in_global_refs_vs_lookup2:
+  "\<lbrakk> valid_vs_lookup s; valid_global_refs s; valid_arch_state s;
+     valid_global_objs s; page_directory_at p s; (\<exists>\<rhd> p) s \<rbrakk>
+     \<Longrightarrow> p \<notin> global_refs s"
+  apply (insert not_in_global_refs_vs_lookup[where p=p and s=s])
+  apply simp
+  done
+
+lemma find_pd_for_asid_not_arm_global_pd:
+  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_global_objs
+                   and valid_vs_lookup and valid_global_refs and valid_arch_state\<rbrace>
+   find_pd_for_asid asid
+   \<lbrace>\<lambda>rv s. lookup_pd_slot rv vptr && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s)\<rbrace>, -"
+  apply (wp find_pd_for_asid_lots)
+  apply clarsimp
+  apply (subst(asm) lookup_pd_slot_pd)
+   apply (erule page_directory_at_aligned_pd_bits, simp+)
+  apply (frule (4) not_in_global_refs_vs_lookup2)
+   apply (auto simp: global_refs_def)
+  done
+
+lemma find_pd_for_asid_not_arm_global_pd_large_page:
+  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_global_objs
+                   and valid_vs_lookup and valid_global_refs and valid_arch_state\<rbrace>
+   find_pd_for_asid asid
+   \<lbrace>\<lambda>rv s. lookup_pd_slot rv vptr && mask 6 = 0
+           \<longrightarrow> (\<forall>x \<in> set [0 , 4 .e. 0x3C].
+                  x + lookup_pd_slot rv vptr && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s))\<rbrace>, -"
+  apply (wp find_pd_for_asid_lots)
+  apply clarsimp
+  apply (subst (asm) is_aligned_mask[symmetric])
+  apply (frule is_aligned_6_masks[where bits=pd_bits])
+   apply simp+
+  apply (subst(asm) lookup_pd_slot_eq)
+   apply (erule page_directory_at_aligned_pd_bits, simp+)
+  apply (frule (4) not_in_global_refs_vs_lookup2)
+   apply (auto simp: global_refs_def)
+  done
+
+declare dmo_mol_globals_equiv[wp]
+
+lemma unmap_page_table_globals_equiv:
+  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_global_objs and valid_vs_lookup
+  and valid_global_refs and valid_arch_state and globals_equiv st\<rbrace> unmap_page_table asid vaddr pt \<lbrace>\<lambda>rv. globals_equiv st\<rbrace>"
+  unfolding unmap_page_table_def page_table_mapped_def
+  apply (wp store_pde_globals_equiv | wpc | simp add: cleanByVA_PoU_def)+
+     apply (rule_tac Q="\<lambda>_. globals_equiv st and (\<lambda>sa. lookup_pd_slot pd vaddr &&
+                                                    ~~ mask pd_bits \<noteq> arm_global_pd (arch_state sa))"
+                  in hoare_strengthen_post)
+      apply (wp find_pd_for_asid_not_arm_global_pd hoare_post_imp_dc2E_actual | simp)+
+  done
+
+lemma set_pt_valid_ko_at_arch[wp]:
+  "set_pt ptr pt \<lbrace>valid_ko_at_arch\<rbrace>"
+  unfolding set_pt_def
+  by (wpsimp wp: set_object_wp_strong simp: valid_ko_at_arch_def obj_at_def a_type_def)
+
+crunch valid_ko_at_arch[wp]: store_pte "valid_ko_at_arch"
+
+lemma mapM_x_swp_store_pte_globals_equiv:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+   mapM_x (swp store_pte A) slots
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  apply (rule_tac Q="\<lambda>_. globals_equiv s and valid_ko_at_arch" in hoare_strengthen_post)
+   apply (wp mapM_x_wp' store_pte_globals_equiv store_pte_valid_ko_at_arch | simp)+
+  done
+
+lemma mapM_x_swp_store_pte_valid_ko_at_arch[wp]:
+  "mapM_x (swp store_pte A) slots \<lbrace>valid_ko_at_arch\<rbrace>"
+  by (wp mapM_x_wp' | simp add: swp_def)+
+
+lemma do_machine_op_valid_ko_at_arch[wp]:
+  "do_machine_op mol \<lbrace>valid_ko_at_arch\<rbrace>"
+  unfolding do_machine_op_def machine_op_lift_def split_def valid_ko_at_arch_def
+  by (wp modify_wp, simp)
+
+lemma valid_ko_at_arch_interrupt_states[simp]:
+  "valid_ko_at_arch (s\<lparr>interrupt_states := f\<rparr>) = valid_ko_at_arch s"
+  by (simp add: valid_ko_at_arch_def)
+
+lemma valid_ko_at_arch_next_asid[simp]:
+  "valid_ko_at_arch (s\<lparr>arch_state := arch_state s\<lparr>arm_next_asid := x\<rparr>\<rparr>) = valid_ko_at_arch s"
+  by (simp add: valid_ko_at_arch_def)
+
+lemma valid_ko_at_arch_asid_map[simp]:
+  "valid_ko_at_arch (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_map := x\<rparr>\<rparr>) = valid_ko_at_arch s"
+  by (simp add: valid_ko_at_arch_def)
+
+lemma valid_ko_at_arch_hwasid_table[simp]:
+  "valid_ko_at_arch (s\<lparr>arch_state := arch_state s\<lparr>arm_hwasid_table := x\<rparr>\<rparr>) = valid_ko_at_arch s"
+  by (simp add: valid_ko_at_arch_def)
+
+lemma valid_ko_at_arch_asid_table[simp]:
+  "valid_ko_at_arch (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := A\<rparr>\<rparr>) = valid_ko_at_arch s"
+  by (simp add: valid_ko_at_arch_def)
+
+lemma valid_ko_at_arch_arch[simp]:
+  "arm_global_pd A = arm_global_pd (arch_state s)
+   \<Longrightarrow> valid_ko_at_arch (s\<lparr>arch_state := A\<rparr>) = valid_ko_at_arch s"
+  by (simp add: valid_ko_at_arch_def)
+
+crunch valid_ko_at_arch[wp]: arm_context_switch, set_vm_root, set_pd "valid_ko_at_arch"
+  (wp: find_pd_for_asid_assert_wp crunch_wps simp: crunch_simps)
+
+crunch valid_ko_at_arch[wp]: unmap_page_table "valid_ko_at_arch"
+  (wp: crunch_wps simp: crunch_simps a_type_simps)
+
+definition authorised_for_globals_page_table_inv :: "page_table_invocation \<Rightarrow> 'z state \<Rightarrow> bool" where
+  "authorised_for_globals_page_table_inv pti \<equiv>
+     \<lambda>s. case pti of
+           PageTableMap cap ptr pde p \<Rightarrow> p && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s)
+         | _ \<Rightarrow> True"
+
+lemma perform_page_table_invocation_globals_equiv:
+  "\<lbrace>valid_global_refs and valid_global_objs and valid_arch_state and globals_equiv st
+                      and pspace_aligned and valid_vspace_objs and valid_vs_lookup
+                      and valid_kernel_mappings and authorised_for_globals_page_table_inv pti\<rbrace>
+   perform_page_table_invocation pti
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding perform_page_table_invocation_def cleanCacheRange_PoU_def
+  apply (rule hoare_weaken_pre)
+   apply (wp store_pde_globals_equiv set_cap_globals_equiv'' dmo_cacheRangeOp_lift
+             mapM_x_swp_store_pte_globals_equiv unmap_page_table_globals_equiv
+          | wpc | simp add: cleanByVA_PoU_def)+
+  apply (fastforce simp: authorised_for_globals_page_table_inv_def
+                         valid_arch_state_def valid_ko_at_arch_def obj_at_def
+                   dest: a_type_pdD)
+  done
+
+lemma do_flush_globals_equiv:
+  "do_machine_op (do_flush typ start end pstart) \<lbrace>globals_equiv st\<rbrace>"
+  apply (cases "typ")
+  by (wp dmo_cacheRangeOp_lift
+      | simp add: do_flush_def cache_machine_op_defs do_flush_defs do_machine_op_bind when_def
+      | clarsimp | rule conjI)+
+
+lemma perform_page_directory_invocation_globals_equiv:
+  "perform_page_directory_invocation pdi \<lbrace>globals_equiv st\<rbrace>"
+  unfolding perform_page_directory_invocation_def
+  apply (cases pdi)
+   apply (wp do_flush_globals_equiv | simp)+
+  done
+
+lemma flush_page_globals_equiv[wp]:
+  "flush_page page_size pd asid vptr \<lbrace>globals_equiv st\<rbrace>"
+  unfolding flush_page_def invalidateLocalTLB_VAASID_def
+  by (wp | simp cong: if_cong split del: if_split)+
+
+lemma flush_page_arm_global_pd[wp]:
+  "flush_page pgsz pd asid vptr \<lbrace>\<lambda>s. P (arm_global_pd (arch_state s))\<rbrace>"
+  unfolding flush_page_def
+  by (wp | simp cong: if_cong split del: if_split)+
+
+lemma mapM_swp_store_pte_globals_equiv:
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
+   mapM (swp store_pte A) slots
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  apply (rule_tac Q="\<lambda> _. globals_equiv st and valid_ko_at_arch"
+               in hoare_strengthen_post)
+   apply (wp mapM_wp' store_pte_globals_equiv | simp)+
+  done
+
+lemma mapM_swp_store_pde_globals_equiv:
+  "\<lbrace>globals_equiv st and (\<lambda>s. \<forall>x \<in> set slots. x && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s))\<rbrace>
+   mapM (swp store_pde A) slots
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  apply (rule_tac Q="\<lambda>_. globals_equiv st and
+                         (\<lambda>s. \<forall>x \<in> set slots. x && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s))"
+               in hoare_strengthen_post)
+   apply (wp mapM_wp' store_pde_globals_equiv | simp)+
+  done
+
+lemma mapM_swp_store_pte_valid_ko_at_arch[wp]:
+  "mapM (swp store_pte A) slots \<lbrace>valid_ko_at_arch\<rbrace>"
+  by (wp mapM_wp' store_pte_valid_ko_at_arch | simp)+
+
+lemma mapM_x_swp_store_pde_globals_equiv :
+  "\<lbrace>globals_equiv st and (\<lambda>s. \<forall>x \<in> set slots. x && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s))\<rbrace>
+   mapM_x (swp store_pde A) slots
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  apply (rule_tac Q="\<lambda>_. globals_equiv st and
+                         (\<lambda>s. \<forall>x \<in> set slots. x && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s))"
+               in hoare_strengthen_post)
+   apply (wp mapM_x_wp' store_pde_globals_equiv | simp)+
+  done
+
+crunch valid_ko_at_arch[wp]: flush_page "valid_ko_at_arch"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma unmap_page_globals_equiv:
+  "\<lbrace>globals_equiv st and valid_arch_state and pspace_aligned and valid_vspace_objs
+                     and valid_global_objs and valid_vs_lookup and valid_global_refs\<rbrace>
+   unmap_page pgsz asid vptr pptr
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding unmap_page_def cleanCacheRange_PoU_def including no_pre
+  apply (induct pgsz)
+     prefer 4
+     apply (simp only: vmpage_size.simps)
+     apply (wp mapM_swp_store_pde_globals_equiv dmo_cacheRangeOp_lift | simp add: cleanByVA_PoU_def)+
+        apply (rule hoare_drop_imps)
+        apply (wp)+
+       apply (simp)
+       apply (rule hoare_drop_imps)
+       apply (wp)+
+     apply (rule hoare_pre)
+      apply (rule_tac Q="\<lambda>x. globals_equiv st and
+                             (\<lambda>sa. lookup_pd_slot x vptr && mask 6 = 0
+                                   \<longrightarrow> (\<forall>xa\<in>set [0 , 4 .e. 0x3C]. xa + lookup_pd_slot x vptr
+                                                                     && ~~ mask pd_bits
+                                                                   \<noteq> arm_global_pd (arch_state sa)))"
+                  and E="\<lambda>_. globals_equiv st" in hoare_post_impErr)
+        apply (wp find_pd_for_asid_not_arm_global_pd_large_page)
+       apply simp
+      apply simp
+     apply simp
+    apply (wp store_pte_globals_equiv | simp add: cleanByVA_PoU_def)+
+      apply (wp hoare_drop_imps)+
+     apply (wp (once) lookup_pt_slot_inv)
+     apply (wp (once) lookup_pt_slot_inv)
+     apply (wp (once) lookup_pt_slot_inv)
+     apply (wp (once) lookup_pt_slot_inv)
+    apply (simp)
+    apply (rule hoare_pre)
+     apply wp
+    apply (simp add: valid_arch_state_ko_at_arch)
+   apply (simp)
+   apply (rule hoare_pre)
+    apply (wp dmo_cacheRangeOp_lift mapM_swp_store_pde_globals_equiv store_pde_globals_equiv
+              lookup_pt_slot_inv mapM_swp_store_pte_globals_equiv hoare_drop_imps
+           | simp add: cleanByVA_PoU_def)+
+   apply (simp add: valid_arch_state_ko_at_arch)
+  apply (rule hoare_pre)
+   apply (wp store_pde_globals_equiv | simp add: valid_arch_state_ko_at_arch cleanByVA_PoU_def)+
+    apply (wp find_pd_for_asid_not_arm_global_pd hoare_drop_imps)+
+  apply (clarsimp)
+  done (* don't know what happened here. wp deleted globals_equiv from precon *)
+
+lemma cte_wp_parent_not_global_pd:
+  "\<lbrakk> valid_global_refs s; cte_wp_at (parent_for_refs (Inr (a,b))) k s \<rbrakk>
+     \<Longrightarrow> \<forall>x \<in> set b. x && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s)"
+  apply (simp only: cte_wp_at_caps_of_state)
+  apply (elim exE conjE)
+  apply (drule valid_global_refsD2,simp)
+  apply (unfold parent_for_refs_def)
+  apply (simp add: image_def global_refs_def cap_range_def)
+  apply clarsimp
+  apply (subgoal_tac "arm_global_pd (arch_state s) \<in> set b")
+   apply auto
+  done
+
+definition authorised_for_globals_page_inv ::
+  "page_invocation \<Rightarrow> 'z :: state_ext state \<Rightarrow> bool"  where
+  "authorised_for_globals_page_inv pgi \<equiv> \<lambda>s.
+     case pgi of PageMap asid cap ptr m \<Rightarrow> \<exists>slot. cte_wp_at (parent_for_refs m) slot s | _ \<Rightarrow> True"
+
+crunch valid_ko_at_arch[wp]: unmap_page "valid_ko_at_arch"
+  (wp: crunch_wps)
+
+lemma arm_global_pd_not_tcb:
+  "valid_ko_at_arch s \<Longrightarrow> get_tcb (arm_global_pd (arch_state s)) s = None"
+  unfolding valid_ko_at_arch_def
+  apply (case_tac "get_tcb (arm_global_pd (arch_state s)) s")
+   apply simp
+  apply (clarsimp simp: valid_ko_at_arch_def get_tcb_ko_at obj_at_def)
+  done
+
+lemma length_msg_lt_msg_max:
+  "length msg_registers < msg_max_length"
+  by (simp add: msg_registers_def msgRegisters_def upto_enum_def fromEnum_def enum_register msg_max_length_def)
+
+lemma set_mrs_globals_equiv:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch and (\<lambda>sa. thread \<noteq> idle_thread sa)\<rbrace>
+      set_mrs thread buf msgs
+    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding set_mrs_def
+  apply (wp | wpc)+
+       apply (simp add: zipWithM_x_mapM_x)
+       apply (rule conjI)
+        apply (rule impI)
+        apply (rule_tac Q="\<lambda>_. globals_equiv s"
+          in hoare_strengthen_post)
+         apply (wp mapM_x_wp')
+         apply (simp add: split_def)
+         apply (wp store_word_offs_globals_equiv)
+        apply (simp)
+       apply (clarsimp)
+       apply (insert length_msg_lt_msg_max)
+       apply (simp)
+      apply (wp set_object_globals_equiv static_imp_wp)
+     apply (wp hoare_vcg_all_lift set_object_globals_equiv static_imp_wp)+
+   apply (clarsimp simp:arm_global_pd_not_tcb)+
+  done
+
+crunch valid_ko_at_arch[wp]: set_mrs valid_ko_at_arch
+  (wp: crunch_wps simp: crunch_simps arm_global_pd_not_tcb)
+
+lemma perform_page_invocation_globals_equiv:
+  "\<lbrace>authorised_for_globals_page_inv pgi and valid_page_inv pgi and globals_equiv st and
+    valid_arch_state and pspace_aligned and valid_vspace_objs and valid_global_objs and
+    valid_vs_lookup and valid_global_refs and ct_active and valid_idle\<rbrace>
+   perform_page_invocation pgi
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding perform_page_invocation_def cleanCacheRange_PoU_def
+  apply (rule hoare_weaken_pre)
+  apply (wp mapM_swp_store_pte_globals_equiv hoare_vcg_all_lift dmo_cacheRangeOp_lift
+            mapM_swp_store_pde_globals_equiv mapM_x_swp_store_pte_globals_equiv
+            mapM_x_swp_store_pde_globals_equiv set_cap_globals_equiv''
+            unmap_page_globals_equiv store_pte_globals_equiv store_pde_globals_equiv static_imp_wp
+            do_flush_globals_equiv set_mrs_globals_equiv set_message_info_globals_equiv
+         | wpc | simp add: do_machine_op_bind cleanByVA_PoU_def)+
+  by (auto simp: cte_wp_parent_not_global_pd authorised_for_globals_page_inv_def valid_page_inv_def
+                 valid_slots_def valid_idle_def st_tcb_def2 ct_in_state_def pred_tcb_at_def obj_at_def
+           dest: valid_arch_state_ko_at_arch dest!: rev_subsetD[OF _ tl_subseteq])
+
+lemma retype_region_ASIDPoolObj_globals_equiv:
+  "\<lbrace>globals_equiv s and (\<lambda>sa. ptr \<noteq> arm_global_pd (arch_state s)) and (\<lambda>sa. ptr \<noteq> idle_thread sa)\<rbrace>
+   retype_region ptr 1 0 (ArchObject ASIDPoolObj) dev
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding retype_region_def
+  apply (wpsimp wp: modify_wp dxo_wp_weak
+              simp: trans_state_update[symmetric] simp_del: trans_state_update)
+  apply (fastforce simp: globals_equiv_def idle_equiv_def tcb_at_def2)
+  done
+
+lemma retype_region_ASIDPoolObj_valid_ko_at_arch:
+  "\<lbrace>valid_ko_at_arch and (\<lambda>s. ptr \<noteq> arm_global_pd (arch_state s))\<rbrace>
+   retype_region ptr 1 0 (ArchObject ASIDPoolObj) dev
+   \<lbrace>\<lambda>_. valid_ko_at_arch\<rbrace>"
+  supply retype_region_ext_extended.dxo_eq[simp del]
+  apply (simp add: retype_region_def)
+  apply (wp modify_wp dxo_wp_weak |simp add: trans_state_update[symmetric] del: trans_state_update)+
+  apply (clarsimp simp: valid_ko_at_arch_def)
+  apply (rule_tac x=pd in exI)
+  apply (fold fun_upd_def)
+  apply (clarsimp simp: fun_upd_def obj_at_def)
+  done
+
+lemma detype_valid_ko_at_arch:
+  "\<lbrace>valid_ko_at_arch and (\<lambda>s. arm_global_pd (arch_state s) \<notin> {ptr..ptr + 2 ^ bits - 1})\<rbrace>
+   modify (detype {ptr..ptr + 2 ^ bits - 1})
+   \<lbrace>\<lambda>_. valid_ko_at_arch\<rbrace>"
+  apply (wp modify_wp)
+  apply (fastforce simp: valid_ko_at_arch_def detype_def obj_at_def)
+  done
+
+lemma delete_objects_valid_ko_at_arch:
+  "\<lbrace>valid_ko_at_arch and (\<lambda>s. arm_global_pd (arch_state s) \<notin> ptr_range p b)
+                     and K (is_aligned p b \<and> 2 \<le> b \<and> b < word_bits)\<rbrace>
+   delete_objects p b
+   \<lbrace>\<lambda>_. valid_ko_at_arch\<rbrace>"
+  unfolding delete_objects_def
+  by (wp detype_valid_ko_at_arch do_machine_op_valid_ko_at_arch | simp add: ptr_range_def)+
+
+lemma perform_asid_control_invocation_globals_equiv:
+  notes delete_objects_invs[wp del]
+  notes blah[simp del] =  atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+  shows "\<lbrace>globals_equiv s and invs and ct_active and valid_aci aci\<rbrace>
+         perform_asid_control_invocation aci
+         \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding perform_asid_control_invocation_def
+  apply (rule hoare_pre)
+   apply wpc
+   apply (rename_tac word1 cslot_ptr1 cslot_ptr2 word2)
+   apply (wp modify_wp cap_insert_globals_equiv''
+             retype_region_ASIDPoolObj_globals_equiv[simplified]
+             retype_region_invs_extras(5)[where sz=pageBits]
+             retype_region_ASIDPoolObj_valid_ko_at_arch[simplified]
+             set_cap_globals_equiv
+             max_index_upd_invs_simple set_cap_no_overlap
+             set_cap_caps_no_overlap max_index_upd_caps_overlap_reserved
+             region_in_kernel_window_preserved
+             hoare_vcg_all_lift  get_cap_wp static_imp_wp
+             set_cap_idx_up_aligned_area[where dev = False,simplified]
+          | simp)+
+   (* factor out the implication -- we know what the relevant components of the
+      cap referred to in the cte_wp_at are anyway from valid_aci, so just use
+      those directly to simplify the reasoning later on *)
+   apply (rule_tac Q="\<lambda>a b. globals_equiv s b \<and> invs b \<and> valid_ko_at_arch b \<and>
+                             word1 \<noteq> arm_global_pd (arch_state b) \<and> word1 \<noteq> idle_thread b \<and>
+                             (\<exists>idx. cte_wp_at ((=) (UntypedCap False word1 pageBits idx)) cslot_ptr2 b) \<and>
+                             descendants_of cslot_ptr2 (cdt b) = {} \<and>
+                             pspace_no_overlap_range_cover word1 pageBits b"
+                in hoare_strengthen_post)
+    prefer 2
+    apply (clarsimp simp: globals_equiv_def invs_valid_global_objs)
+    apply (drule cte_wp_at_eqD2, assumption)
+    apply clarsimp
+    apply (clarsimp simp: empty_descendants_range_in)
+    apply (rule conjI, fastforce simp: cte_wp_at_def)
+    apply (clarsimp simp: obj_bits_api_def default_arch_object_def)
+    apply (frule untyped_cap_aligned, simp add: invs_valid_objs)
+    apply (clarsimp simp: cte_wp_at_caps_of_state)
+    apply (strengthen refl caps_region_kernel_window_imp[mk_strg I E])
+    apply (simp add: invs_valid_objs invs_cap_refs_in_kernel_window
+                     atLeastatMost_subset_iff word_and_le2)
+    apply (rule conjI, rule descendants_range_caps_no_overlapI)
+       apply assumption
+      apply (simp add: cte_wp_at_caps_of_state)
+     apply (simp add: empty_descendants_range_in)
+    apply (clarsimp simp: range_cover_def)
+    apply (subst is_aligned_neg_mask_eq[THEN sym], assumption)
+    apply (simp add: word_bw_assocs pageBits_def mask_zero)
+   apply (wp add: delete_objects_invs_ex delete_objects_pspace_no_overlap[where dev=False]
+                  delete_objects_globals_equiv delete_objects_valid_ko_at_arch hoare_vcg_ex_lift
+             del: Untyped_AI.delete_objects_pspace_no_overlap
+          | simp add: page_bits_def)+
+  apply (clarsimp simp: conj_comms invs_valid_ko_at_arch
+                        invs_psp_aligned invs_valid_objs valid_aci_def)
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (frule_tac cap="UntypedCap False a b c" for a b c in caps_of_state_valid, assumption)
+  apply (clarsimp simp: valid_cap_def cap_aligned_def untyped_min_bits_def)
+  apply (frule_tac slot="(aa,ba)"
+                in untyped_caps_do_not_overlap_global_refs[rotated, OF invs_valid_global_refs])
+   apply (clarsimp simp: cte_wp_at_caps_of_state)
+   apply ((rule conjI |rule refl | simp)+)[1]
+  apply (rule conjI)
+   apply (clarsimp simp: global_refs_def ptr_range_memI)
+  apply (rule conjI)
+   apply (clarsimp simp: global_refs_def ptr_range_memI)
+  apply (rule conjI, fastforce simp: global_refs_def)
+  apply (rule conjI, fastforce simp: global_refs_def)
+  apply (rule conjI)
+   apply (drule untyped_slots_not_in_untyped_range)
+        apply (blast intro!: empty_descendants_range_in)
+       apply (simp add: cte_wp_at_caps_of_state)
+      apply simp
+     apply (rule refl)
+    apply (rule subset_refl)
+   apply (simp)
+  apply (rule conjI)
+   apply fastforce
+  apply (auto intro: empty_descendants_range_in simp: descendants_range_def2 cap_range_def)
+  done
+
+lemma perform_asid_pool_invocation_globals_equiv:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace> perform_asid_pool_invocation api \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding perform_asid_pool_invocation_def
+  apply (rule hoare_weaken_pre)
+   apply (wp modify_wp set_asid_pool_globals_equiv set_cap_globals_equiv''
+        get_cap_wp | wpc | simp)+
+  done
+
+definition authorised_for_globals_arch_inv ::
+  "arch_invocation \<Rightarrow> ('z::state_ext) state \<Rightarrow> bool" where
+  "authorised_for_globals_arch_inv ai \<equiv>
+    case ai of InvokePageTable oper \<Rightarrow> authorised_for_globals_page_table_inv oper
+             | InvokePage oper \<Rightarrow> authorised_for_globals_page_inv oper
+             | _ \<Rightarrow> \<top>"
+
+lemma arch_perform_invocation_globals_equiv:
+  "\<lbrace>globals_equiv s and invs and ct_active and valid_arch_inv ai
+                    and authorised_for_globals_arch_inv ai\<rbrace>
+   arch_perform_invocation ai
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding arch_perform_invocation_def
+ apply (wpsimp wp: perform_page_table_invocation_globals_equiv
+                   perform_page_directory_invocation_globals_equiv
+                   perform_page_invocation_globals_equiv
+                   perform_asid_control_invocation_globals_equiv
+                   perform_asid_pool_invocation_globals_equiv)+
+  apply (auto simp: authorised_for_globals_arch_inv_def
+              dest: valid_arch_state_ko_at_arch
+              simp: invs_def valid_state_def valid_arch_inv_def invs_valid_vs_lookup)
+  done
+
+lemma find_pd_for_asid_authority3:
+  "\<lbrace>\<lambda>s. \<forall>pd. (pspace_aligned s \<and> valid_vspace_objs s \<longrightarrow> is_aligned pd pd_bits) \<and> (\<exists>\<rhd> pd) s
+             \<longrightarrow> Q pd s\<rbrace>
+   find_pd_for_asid asid
+   \<lbrace>Q\<rbrace>, -"
+  apply (clarsimp simp: validE_R_def validE_def valid_def imp_conjL[symmetric])
+  apply (frule in_inv_by_hoareD[OF find_pd_for_asid_inv], clarsimp)
+  apply (drule spec, erule mp)
+  apply (simp add: use_validE_R[OF _ find_pd_for_asid_authority1]
+                   use_validE_R[OF _ find_pd_for_asid_aligned_pd_bits]
+                   use_validE_R[OF _ find_pd_for_asid_lookup])
+  done
+
+lemma as_user_valid_ko_at_arch[wp]:
+  "as_user thread f \<lbrace>valid_ko_at_arch\<rbrace>"
+  unfolding as_user_def
+  apply wp
+      apply (case_tac x)
+      apply (simp | wp select_wp)+
+  apply (fastforce simp: valid_ko_at_arch_def get_tcb_ko_at obj_at_def)
+  done
+
+lemma valid_arch_arm_asid_table_unmap:
+  "valid_arch_state s \<and> tab = arm_asid_table (arch_state s)
+   \<longrightarrow> valid_arch_state
+         (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := tab(asid_high_bits_of base := None)\<rparr>\<rparr>)"
+  by (clarsimp simp: valid_state_def valid_arch_state_unmap_strg)
+
+lemma valid_arch_objs_arm_asid_table_unmap:
+  "valid_vspace_objs s \<and> tab = arm_asid_table (arch_state s)
+   \<longrightarrow> valid_vspace_objs
+         (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := tab(asid_high_bits_of base := None)\<rparr>\<rparr>)"
+  by (clarsimp simp: valid_state_def valid_vspace_objs_unmap_strg)
+
+lemma valid_vspace_objs_arm_asid_table_unmap:
+  "valid_vspace_objs s \<and> tab = arm_asid_table (arch_state s)
+   \<longrightarrow> valid_vspace_objs
+         (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := tab(asid_high_bits_of base := None)\<rparr>\<rparr>)"
+  by (clarsimp simp: valid_state_def valid_vspace_objs_unmap_strg)
+
+lemmas arm_context_switch_valid_vspace_objs_aux =
+  hoare_drop_imp[of valid_vspace_objs "arm_context_switch _ _" "\<lambda>_ s. valid_vspace_objs s",
+                 OF arm_context_switch_vspace_objs]
+
+lemma delete_asid_pool_valid_vspace_objs[wp]:
+  "delete_asid_pool base pptr \<lbrace>valid_vspace_objs\<rbrace>"
+  unfolding delete_asid_pool_def
+  apply (wp modify_wp)
+      apply (strengthen valid_vspace_objs_arm_asid_table_unmap)
+      apply (wpsimp wp: mapM_wp')+
+  done
+
+lemma set_asid_pool_arch_objs_unmap'':
+  "\<lbrace>(valid_vspace_objs and ko_at (ArchObj (ASIDPool ap)) p) and K(f = (ap |` S))\<rbrace>
+   set_asid_pool p f
+   \<lbrace>\<lambda>_. valid_vspace_objs\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply simp
+  apply (rule set_asid_pool_vspace_objs_unmap)
+  done
+
+lemmas set_asid_pool_vspace_objs_unmap'' = set_asid_pool_arch_objs_unmap''
+
+lemma delete_asid_valid_vspace_objs[wp]:
+  "\<lbrace>valid_vspace_objs and pspace_aligned\<rbrace>
+   delete_asid a b
+   \<lbrace>\<lambda>_. valid_vspace_objs\<rbrace>"
+  unfolding delete_asid_def
+  apply (wpsimp wp: set_asid_pool_vspace_objs_unmap'')
+  apply (fastforce simp: restrict_eq_asn_none)
+  done
+
+lemma cte_wp_at_pt_exists_cap:
+  "\<lbrakk> valid_objs s; cte_wp_at ((=) (ArchObjectCap (PageTableCap word option))) slot s;
+     x \<in> set [word , word + 4 .e. word + 2 ^ pt_bits - 1] \<rbrakk>
+     \<Longrightarrow> \<exists>a b cap. caps_of_state s (a, b) = Some cap \<and>
+                   x && ~~ mask pt_bits \<in> Structures_A.obj_refs cap \<and> is_pt_cap cap"
+  apply (case_tac slot)
+  apply (rule_tac x=a in exI)
+  apply (rule_tac x=b in exI)
+  apply (subgoal_tac "is_aligned word pt_bits")
+   apply (frule (1) word_aligned_pt_slots)
+   apply (simp add:pageBits_def cte_wp_at_caps_of_state is_pt_cap_def)
+  apply (frule (1) cte_wp_valid_cap)
+  apply (simp add: valid_cap_def cap_aligned_def pt_bits_def pageBits_def)
+  done
+
+lemma mapM_x_swp_store_pte_reads_respects':
+  "reads_respects aag l (invs and cte_wp_at ((=) (ArchObjectCap (PageTableCap word option))) slot
+                              and K (is_subject aag word))
+                  (mapM_x (swp store_pte InvalidPTE) [word , word + 4 .e. word + 2 ^ pt_bits - 1])"
+  apply (rule gen_asm_ev)
+  apply (wp mapM_x_ev)
+   apply simp
+   apply (rule equiv_valid_guard_imp)
+    apply (wp store_pte_reads_respects)
+   apply simp
+   apply (elim conjE)
+   apply (subgoal_tac "is_aligned word pt_bits")
+    apply (frule (1) word_aligned_pt_slots)
+    apply simp
+   apply (frule cte_wp_valid_cap)
+    apply (rule invs_valid_objs)
+    apply simp
+   apply (simp add: valid_cap_def cap_aligned_def pt_bits_def pageBits_def)
+  apply simp
+  apply wp
+  apply simp
+  apply (fastforce simp: is_cap_simps dest!: cte_wp_at_pt_exists_cap[OF invs_valid_objs])
+  done
+
+lemma pd_bits_store_pde_helper:
+  "\<lbrakk> xa \<le> (kernel_base >> 20) - 1; is_aligned word pd_bits \<rbrakk>
+     \<Longrightarrow> ((xa << 2) + word && ~~ mask pd_bits) = word"
+  apply (clarsimp simp: field_simps)
+  apply (subst is_aligned_add_helper)
+    apply simp
+   apply (rule shiftl_less_t2n)
+    apply (erule order_le_less_trans)
+    apply (simp add: kernel_base_def  pd_bits_def pageBits_def)+
+  done
+
+lemma mapM_x_swp_store_pde_reads_respects':
+  "reads_respects aag l
+     (cte_wp_at ((=) (ArchObjectCap (PageDirectoryCap w opt))) slot and valid_objs
+                                                                    and K (is_subject aag w))
+     (mapM_x (swp store_pde InvalidPDE)
+             (map ((\<lambda>x. x + w) \<circ> swp (<<) 2) [0 .e. (kernel_base >> 20) - 1]))"
+  apply (wp mapM_x_ev)
+   apply simp
+   apply (rule equiv_valid_guard_imp)
+    apply (wp store_pde_reads_respects)
+   apply clarsimp
+   apply (subgoal_tac "is_aligned w pd_bits")
+    apply (simp add: pd_bits_store_pde_helper)
+   apply (frule (1) cte_wp_valid_cap)
+   apply (simp add: valid_cap_def cap_aligned_def pd_bits_def pageBits_def)
+  apply simp
+  apply wp
+  apply (clarsimp simp: wellformed_pde_def)+
+  done
+
+lemma mapM_x_swp_store_pte_pas_refined_simple:
+  "mapM_x (swp store_pte InvalidPTE) A \<lbrace>pas_refined aag\<rbrace>"
+  by (wpsimp wp: mapM_x_wp' store_pte_pas_refined_simple)
+
+lemma mapM_x_swp_store_pde_pas_refined_simple:
+  "mapM_x (swp store_pde InvalidPDE) A \<lbrace>pas_refined aag\<rbrace>"
+  by (wpsimp wp: mapM_x_wp' store_pde_pas_refined_simple)
+
+crunch valid_global_objs[wp]: arch_post_cap_deletion "valid_global_objs"
+
+lemma get_thread_state_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+   get_thread_state ref
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding get_thread_state_def
+  by (wpsimp wp: set_object_globals_equiv dxo_wp_weak)
+
+(* generalises auth_ipc_buffers_mem_Write *)
+lemma auth_ipc_buffers_mem_Write':
+  "\<lbrakk> x \<in> auth_ipc_buffers s thread; pas_refined aag s; valid_objs s \<rbrakk>
+     \<Longrightarrow> (pasObjectAbs aag thread, Write, pasObjectAbs aag x) \<in> pasPolicy aag"
+  apply (clarsimp simp add: auth_ipc_buffers_member_def)
+  apply (drule (1) cap_auth_caps_of_state)
+  apply simp
+  apply (clarsimp simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def
+                        vspace_cap_rights_to_auth_def vm_read_write_def is_page_cap_def
+                 split: if_split_asm)
+   apply (auto dest: ipcframe_subset_page)
+  done
+
+lemma thread_set_globals_equiv:
+  "(\<And>tcb. arch_tcb_context_get (tcb_arch (f tcb)) = arch_tcb_context_get (tcb_arch tcb))
+   \<Longrightarrow> \<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace> thread_set f tptr \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding thread_set_def
+  apply (wp set_object_globals_equiv)
+  apply simp
+  apply (intro impI conjI allI)
+    apply (fastforce simp: valid_ko_at_arch_def obj_at_def get_tcb_def)+
+  apply (clarsimp simp: get_tcb_def tcb_at_def2 split: kernel_object.splits option.splits)
+  done
+
+end
+
+
+hide_fact as_user_globals_equiv
+
+context begin interpretation Arch .
+
+requalify_consts
+  authorised_for_globals_arch_inv
+
+requalify_facts
+  arch_post_cap_deletion_valid_global_objs
+  get_thread_state_globals_equiv
+  auth_ipc_buffers_mem_Write'
+  thread_set_globals_equiv
+  arch_post_modify_registers_cur_domain
+  arch_post_modify_registers_cur_thread
+  valid_arch_state_ko_at_arch
+  invs_valid_ko_at_arch
+  invs_imps
+  do_machine_op_valid_ko_at_arch
+  valid_ko_at_arch_interrupt_states
+  length_msg_lt_msg_max
+  set_mrs_globals_equiv
+  set_mrs_valid_ko_at_arch
+  store_word_offs_valid_ko_at_arch
+  arch_perform_invocation_globals_equiv
+  as_user_valid_ko_at_arch
+  as_user_globals_equiv
+  prepare_thread_delete_st_tcb_at_halted
+  make_arch_fault_msg_inv
+  check_valid_ipc_buffer_inv
+  arch_tcb_update_aux2
+  valid_ko_at_arch_interrupt_states
+
+declare
+  arch_post_cap_deletion_valid_global_objs[wp]
+  get_thread_state_globals_equiv[wp]
+  arch_post_modify_registers_cur_domain[wp]
+  arch_post_modify_registers_cur_thread[wp]
+  do_machine_op_valid_ko_at_arch[wp]
+  valid_ko_at_arch_interrupt_states[wp]
+  set_mrs_valid_ko_at_arch[wp]
+  store_word_offs_valid_ko_at_arch[wp]
+  as_user_valid_ko_at_arch[wp]
+  prepare_thread_delete_st_tcb_at_halted[wp]
+  valid_ko_at_arch_interrupt_states[simp]
+
+end
+
+declare as_user_globals_equiv[wp]
+
+axiomatization dmo_reads_respects where
+  dmo_getDFSR_reads_respects: "reads_respects aag l \<top> (do_machine_op ARM.getDFSR)" and
+  dmo_getFAR_reads_respects: "reads_respects aag l \<top> (do_machine_op ARM.getFAR)" and
+  dmo_getIFSR_reads_respects: "reads_respects aag l \<top> (do_machine_op ARM.getIFSR)"
+
+end

--- a/proof/infoflow/ARM/ArchCNode_IF.thy
+++ b/proof/infoflow/ARM/ArchCNode_IF.thy
@@ -1,0 +1,151 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchCNode_IF
+imports CNode_IF
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems CNode_IF_assms
+
+lemma set_object_globals_equiv:
+  "\<lbrace>globals_equiv s and (\<lambda>s. ptr \<noteq> arm_global_pd (arch_state s)) and
+    (\<lambda>t. ptr = idle_thread t
+         \<longrightarrow> (\<forall>tcb. kheap t (idle_thread t) = Some (TCB tcb)
+                    \<longrightarrow> (\<exists>tcb'. obj = (TCB tcb')
+                              \<and> arch_tcb_context_get (tcb_arch tcb) = arch_tcb_context_get (tcb_arch tcb'))) \<and>
+             (\<forall>tcb'. obj = (TCB tcb') \<longrightarrow> tcb_at (idle_thread t) t))\<rbrace>
+   set_object ptr obj
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  apply (wpsimp wp: set_object_wp)
+  apply (case_tac "ptr = idle_thread sa")
+   apply (clarsimp simp: globals_equiv_def idle_equiv_def tcb_at_def2)
+   apply (intro impI conjI allI notI iffI | clarsimp)+
+  apply (clarsimp simp: globals_equiv_def idle_equiv_def tcb_at_def2)
+  done
+
+lemma set_object_globals_equiv'':
+  "\<lbrace>globals_equiv s and (\<lambda> s. ptr \<noteq> arm_global_pd (arch_state s)) and (\<lambda>t. ptr \<noteq> idle_thread t)\<rbrace>
+   set_object ptr obj
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  by (wpsimp wp: set_object_globals_equiv)
+
+lemma set_cap_globals_equiv':
+  "\<lbrace>globals_equiv s and (\<lambda> s. fst p \<noteq> arm_global_pd (arch_state s))\<rbrace>
+   set_cap cap p
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding set_cap_def
+  apply (simp only: split_def)
+  apply (wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
+  apply (fastforce simp: obj_at_def is_tcb_def)
+  done
+
+lemma set_cap_globals_equiv[CNode_IF_assms]:
+  "\<lbrace>globals_equiv s and valid_global_objs\<rbrace>
+   set_cap cap p
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding set_cap_def
+  apply (simp only: split_def)
+  apply (wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
+  apply (fastforce simp: valid_global_objs_def valid_vso_at_def obj_at_def is_tcb_def)
+  done
+
+(* moved from ADT_IF *)
+definition irq_at :: "nat \<Rightarrow> (irq \<Rightarrow> bool) \<Rightarrow> irq option" where
+  "irq_at pos masks \<equiv> let i = irq_oracle pos in (if i = 0x3FF \<or> masks i then None else Some i)"
+
+lemma dmo_getActiveIRQ_wp[CNode_IF_assms]:
+  "\<lbrace>\<lambda>s. P (irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)))
+          (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>)\<rbrace>
+   do_machine_op (getActiveIRQ in_kernel)
+   \<lbrace>P\<rbrace>"
+  apply (simp add: do_machine_op_def getActiveIRQ_def non_kernel_IRQs_def)
+  apply (wp modify_wp | wpc)+
+  apply clarsimp
+  apply (erule use_valid)
+   apply (wp modify_wp)
+  apply (auto simp: irq_at_def Let_def split: if_splits)
+  done
+
+lemma arch_globals_equiv_irq_state_update[CNode_IF_assms, simp]:
+  "arch_globals_equiv ct it kh kh' as as' ms (irq_state_update f ms') =
+   arch_globals_equiv ct it kh kh' as as' ms ms'"
+  "arch_globals_equiv ct it kh kh' as as' (irq_state_update f ms) ms' =
+   arch_globals_equiv ct it kh kh' as as' ms ms'"
+  by auto
+
+end
+
+context begin interpretation Arch .
+
+requalify_consts irq_at
+
+end
+
+
+global_interpretation CNode_IF_1?: CNode_IF_1 _ irq_at
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact CNode_IF_assms)?)
+qed
+
+
+context Arch begin global_naming ARM
+
+lemma is_irq_at_triv[CNode_IF_assms]:
+  assumes a: "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
+                   f
+                   \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s))\<rbrace>"
+  shows "\<lbrace>(\<lambda>s. P (is_irq_at s)) and Q\<rbrace> f \<lbrace>\<lambda>rv s. P (is_irq_at s)\<rbrace>"
+  apply (clarsimp simp: valid_def is_irq_at_def irq_at_def Let_def)
+  apply (erule use_valid[OF _ a])
+  apply simp
+  done
+
+lemma is_irq_at_not_masked[CNode_IF_assms]:
+  "is_irq_at s irq pos \<Longrightarrow> \<not> irq_masks (machine_state s) irq"
+  by (clarsimp simp: is_irq_at_def irq_at_def split: option.splits simp: Let_def split: if_splits)
+
+end
+
+
+global_interpretation CNode_IF_2?: CNode_IF_2 irq_at
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact CNode_IF_assms)?)
+qed
+
+
+context Arch begin global_naming ARM
+
+lemma dmo_getActiveIRQ_reads_respects[CNode_IF_assms]:
+  notes gets_ev[wp del]
+  shows "reads_respects aag l (invs and only_timer_irq_inv irq st)
+                       (do_machine_op (getActiveIRQ in_kernel))"
+  apply (rule use_spec_ev)
+  apply (rule do_machine_op_spec_reads_respects')
+   apply (simp add: getActiveIRQ_def)
+   apply (wp irq_state_increment_reads_respects_memory irq_state_increment_reads_respects_device
+             gets_ev[where f="irq_oracle \<circ> irq_state"] equiv_valid_inv_conj_lift
+             gets_irq_masks_equiv_valid modify_wp
+          | simp add: no_irq_def)+
+  apply (rule only_timer_irq_inv_determines_irq_masks, blast+)
+  done
+
+end
+
+
+global_interpretation CNode_IF_3?: CNode_IF_3 irq_at
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact CNode_IF_assms)?)
+qed
+
+end

--- a/proof/infoflow/ARM/ArchDecode_IF.thy
+++ b/proof/infoflow/ARM/ArchDecode_IF.thy
@@ -1,0 +1,360 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchDecode_IF
+imports Decode_IF
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems Decode_IF_assms
+
+lemma data_to_obj_type_rev[Decode_IF_assms]:
+  "reads_equiv_valid_inv A aag \<top> (data_to_obj_type type)"
+  unfolding data_to_obj_type_def fun_app_def arch_data_to_obj_type_def
+  apply (wp | wpc)+
+  apply simp
+  done
+
+lemma check_valid_ipc_buffer_rev[Decode_IF_assms]:
+  "reads_equiv_valid_inv A aag \<top> (check_valid_ipc_buffer vptr cap)"
+  unfolding check_valid_ipc_buffer_def fun_app_def
+  apply (rule equiv_valid_guard_imp)
+   apply (wpc | wp)+
+  apply simp
+  done
+
+lemma arch_check_irq_rev[Decode_IF_assms, wp]:
+  "reads_equiv_valid_inv A aag \<top> (arch_check_irq irq)"
+  unfolding arch_check_irq_def
+  apply (rule equiv_valid_guard_imp)
+   apply wpsimp+
+  done
+
+lemma vspace_cap_rights_to_auth_mono[Decode_IF_assms]:
+  "R \<subseteq> S \<Longrightarrow> vspace_cap_rights_to_auth R \<subseteq> vspace_cap_rights_to_auth S"
+  by (auto simp: vspace_cap_rights_to_auth_def)
+
+lemma arch_decode_irq_control_invocation_rev[Decode_IF_assms]:
+  "reads_equiv_valid_inv A aag
+     (pas_refined aag and
+      K (is_subject aag (fst slot) \<and> (\<forall>cap\<in>set caps. pas_cap_cur_auth aag cap) \<and>
+      (args \<noteq> [] \<longrightarrow> (pasSubject aag, Control, pasIRQAbs aag (ucast (args ! 0))) \<in> pasPolicy aag)))
+     (arch_decode_irq_control_invocation label args slot caps)"
+  unfolding arch_decode_irq_control_invocation_def arch_check_irq_def
+  apply (wp ensure_empty_rev lookup_slot_for_cnode_op_rev
+            is_irq_active_rev whenE_inv
+         | wp (once) hoare_drop_imps
+         | simp add: Let_def)+
+  apply safe
+       apply simp+
+    apply (blast intro: aag_Control_into_owns_irq )
+   apply (drule_tac x="caps ! 0" in bspec)
+    apply (fastforce intro: bang_0_in_set)
+   apply (drule (1) is_cnode_into_is_subject; blast dest: prop_of_obj_ref_of_cnode_cap)
+  apply (fastforce dest: is_cnode_into_is_subject intro: bang_0_in_set)
+  done
+
+requalify_facts check_valid_ipc_buffer_inv
+
+end
+
+
+global_interpretation Decode_IF_1?: Decode_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Decode_IF_assms)?)
+qed
+
+
+context Arch begin global_naming ARM
+
+lemma ensure_safe_mapping_reads_respects:
+  "reads_respects aag l (K (authorised_slots aag entries)) (ensure_safe_mapping entries)"
+  apply (rule gen_asm_ev)
+  apply (case_tac entries)
+   apply (rename_tac a, case_tac a)
+   apply (rename_tac aa b, case_tac aa)
+     apply (fastforce intro: returnOk_ev_pre)
+    apply (rule equiv_valid_guard_imp)
+     apply (wp mapME_x_ev' get_master_pte_reads_respects get_pte_reads_respects | wpc | simp)+
+    apply (clarsimp simp: authorised_slots_def)
+   apply simp
+   apply (rule equiv_valid_guard_imp)
+    apply (wp mapME_x_ev' get_master_pte_reads_respects | wpc | simp)+
+   apply (fastforce simp: authorised_slots_def)
+  apply (rename_tac b, case_tac b)
+  apply (rename_tac a ba, case_tac a)
+     apply (fastforce intro: returnOk_ev)
+    apply simp
+    apply (rule fail_ev)
+   apply simp
+   apply (rule equiv_valid_guard_imp)
+    apply (wp mapME_x_ev' get_master_pde_reads_respects | wpc | simp)+
+   apply (fastforce simp: authorised_slots_def)
+  apply simp
+  apply (rule equiv_valid_guard_imp)
+   apply (wp mapME_x_ev' get_master_pde_reads_respects | wpc | simp)+
+  apply (fastforce simp: authorised_slots_def)
+  done
+
+lemma lookup_pt_slot_rev:
+  "reads_equiv_valid_inv A aag (K (is_subject aag (lookup_pd_slot pd vptr && ~~ mask pd_bits)))
+                         (lookup_pt_slot pd vptr)"
+  apply (simp add: lookup_pt_slot_def lookup_pd_slot_def)
+  apply (wp get_pde_rev | wpc | simp)+
+  done
+
+lemma create_mapping_entries_rev:
+  "reads_equiv_valid_inv A aag (K (typ \<in> {ARMSmallPage,ARMLargePage}
+                                   \<longrightarrow> is_subject aag (lookup_pd_slot pd vptr && ~~ mask pd_bits)))
+                         (create_mapping_entries bast vptr typ vm_rights attrib pd)"
+  apply (rule gen_asm_ev)
+  apply (case_tac "typ")
+     apply (wp lookup_error_on_failure_rev lookup_pt_slot_rev | simp)+
+  done
+
+lemma check_vp_alignment_rev:
+  "reads_equiv_valid_inv A aag \<top> (check_vp_alignment sz vptr)"
+  unfolding check_vp_alignment_def
+  by (wp | simp add: crunch_simps split del: if_split)+
+
+lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq'':
+  "\<lbrakk> \<forall>asid. is_subject_asid aag asid; reads_equiv aag s t; pas_refined aag x \<rbrakk>
+     \<Longrightarrow> arm_asid_table (arch_state s) (asid_high_bits_of base) =
+         arm_asid_table (arch_state t) (asid_high_bits_of base)"
+  apply (subgoal_tac "asid_high_bits_of 0 = asid_high_bits_of 1")
+   apply (case_tac "base = 0")
+    apply (subgoal_tac "is_subject_asid aag 1")
+     apply ((auto intro: requiv_arm_asid_table_asid_high_bits_of_asid_eq) |
+            (auto simp: asid_high_bits_of_def asid_low_bits_def))+
+  done
+
+lemma pas_cap_cur_auth_ASIDControlCap:
+  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap ASIDControlCap); reads_equiv aag s t; pas_refined aag x \<rbrakk>
+     \<Longrightarrow> arm_asid_table (arch_state s) = arm_asid_table (arch_state t)"
+  apply (rule ext)
+  apply (subst asid_high_bits_of_shift[symmetric])
+  apply (subst (3) asid_high_bits_of_shift[symmetric])
+  apply (rule requiv_arm_asid_table_asid_high_bits_of_asid_eq'')
+    apply (clarsimp simp: aag_cap_auth_def cap_links_asid_slot_def label_owns_asid_slot_def)
+    apply (rule pas_refined_Control_into_is_subject_asid, blast+)
+  done
+
+lemma resolve_vaddr_reads_respects:
+  "reads_respects aag l
+     (K (is_subject aag (lookup_pd_slot pd vptr && ~~ mask pd_bits)) and
+        (\<lambda>s. case kheap s (lookup_pd_slot pd vptr && ~~ mask pd_bits) of
+               Some (ArchObj (PageDirectory pd')) \<Rightarrow>
+               (case pd' (ucast (lookup_pd_slot pd vptr && mask pd_bits >> 2)) of
+                  PageTablePDE x y z \<Rightarrow> is_subject aag (lookup_pt_slot_no_fail (ptrFromPAddr x) vptr && ~~ mask pt_bits)
+                | _ \<Rightarrow> True)
+             | _ \<Rightarrow> True))
+     (resolve_vaddr pd vptr)"
+  apply (simp add: resolve_vaddr_def
+         | wp get_master_pte_reads_respects get_master_pde_reads_respects get_master_pde_wp | wpc)+
+  apply (fastforce simp: obj_at_def split: pde.splits)
+  done
+
+lemma lookup_pt_slot_no_fail_is_subject:
+  "\<lbrakk> (\<exists>\<rhd> pd) s; valid_vspace_objs s; pspace_aligned s; pas_refined aag s;
+     is_subject aag pd; is_aligned pd pd_bits; vptr < kernel_base;
+     kheap s pd = Some (ArchObj (PageDirectory pdo)); pdo (ucast (vptr >> 20)) = PageTablePDE p x xa \<rbrakk>
+     \<Longrightarrow> is_subject aag (lookup_pt_slot_no_fail (ptrFromPAddr p) vptr && ~~ mask pt_bits)"
+  apply (clarsimp simp: lookup_pt_slot_no_fail_def)
+  apply (drule valid_vspace_objsD)
+    apply (simp add: obj_at_def)
+   apply assumption
+  apply (drule kheap_eq_state_vrefs_pas_refinedD)
+    apply (erule vs_refs_no_global_pts_pdI)
+    apply (drule(1) less_kernel_base_mapping_slots)
+    apply (simp add: kernel_mapping_slots_def lookup_pd_slot_def pd_shifting_dual' triple_shift_fun)
+   apply assumption
+  apply (simp add: aag_has_Control_iff_owns)
+  apply (drule_tac f="\<lambda>pde. valid_pde pde s" in arg_cong, simp)
+  apply (clarsimp simp: obj_at_def kernel_base_kernel_mapping_slots)
+  apply (erule pspace_alignedE, erule domI)
+  apply (simp add: pt_bits_def pageBits_def)
+  apply (subst is_aligned_add_helper, assumption)
+   apply (rule shiftl_less_t2n)
+    apply (rule order_le_less_trans, rule word_and_le1, simp)
+   apply simp
+  apply simp
+  done
+
+lemma arch_decode_invocation_reads_respects_f[Decode_IF_assms]:
+  notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
+  notes hoare_whenE_wps[wp_split del]
+  shows
+    "reads_respects_f aag l
+       (silc_inv aag st and invs and pas_refined aag and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot
+                        and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)
+                        and K (\<forall>(cap, slot) \<in> {(cap.ArchObjectCap cap, slot)} \<union> set excaps.
+                                 aag_cap_auth aag (pasObjectAbs aag (fst slot)) cap \<and>
+                                 is_subject aag (fst slot) \<and>
+                                 (\<forall>v \<in> cap_asid' cap. is_subject_asid aag v)))
+        (arch_decode_invocation label args cap_index slot cap excaps)"
+  unfolding arch_decode_invocation_def
+  apply (rule equiv_valid_guard_imp)
+   apply (subst gets_applyE)+
+   apply (wp check_vp_wpR  reads_respects_f_inv'[OF get_asid_pool_rev]
+             reads_respects_f_inv'[OF ensure_empty_rev]
+             reads_respects_f_inv'[OF lookup_slot_for_cnode_op_rev]
+             reads_respects_f_inv'[OF ensure_no_children_rev] select_wp
+             reads_respects_f_inv'[OF ensure_safe_mapping_reads_respects]
+             reads_respects_f_inv'[OF resolve_vaddr_reads_respects]
+             reads_respects_f_inv'[OF create_mapping_entries_rev]
+             reads_respects_f_inv'[OF check_vp_alignment_rev]
+             reads_respects_f_inv'[OF lookup_error_on_failure_rev]
+             find_pd_for_asid_reads_respects gets_apply_ev
+             reads_respects_f_inv'[OF get_master_pde_reads_respects]
+             is_final_cap_reads_respects find_pd_for_asid_authority2
+             select_ext_ev_bind_lift
+             select_ext_ev_bind_lift[simplified]
+          | wpc
+          | simp add: Let_def unlessE_whenE
+          | wp (once) whenE_throwError_wp)+
+  apply (intro impI allI conjI)
+                              apply (rule requiv_arm_asid_table_asid_high_bits_of_asid_eq')
+                                apply fastforce
+                               apply (simp add: reads_equiv_f_def)
+                              apply blast
+                             apply (fastforce simp: aag_cap_auth_ASIDPoolCap)
+                            apply (rule pas_cap_cur_auth_ASIDControlCap[where aag=aag])
+                              apply fastforce
+                             apply (simp add: reads_equiv_f_def)
+                            apply blast
+                           apply clarify
+                           apply (subgoal_tac "excaps ! 0 \<in> set excaps", fastforce)
+                           apply (rule nth_mem)
+                            apply (erule less_trans[rotated], simp)
+                          apply (subgoal_tac "excaps ! (Suc 0) \<in> set excaps")
+                           apply (rule_tac slot="snd (excaps ! (Suc 0))"
+                                        in owns_cnode_owns_obj_ref_of_child_cnodes)
+                              apply blast
+                             apply (fastforce)
+                            apply (fastforce)
+                           apply assumption
+                          apply (fastforce intro: nth_mem)
+                         apply clarify
+                         apply (subgoal_tac "excaps ! Suc 0 \<in> set excaps")
+                          apply (rule_tac cap="fst (excaps ! Suc 0)" and p="snd (excaps ! Suc 0)"
+                                       in caps_of_state_pasObjectAbs_eq)
+                              apply (rule cte_wp_at_caps_of_state')
+                              apply fastforce
+                             apply (erule cap_auth_conferred_cnode_cap)
+                            apply fastforce
+                           apply assumption
+                          apply (fastforce intro: nth_mem)
+                         apply (fastforce intro: nth_mem)
+                        apply (subgoal_tac "excaps ! 0 \<in> set excaps")
+                         apply (fastforce intro: aag_cap_auth_PageDirectoryCap_asid)
+                        apply fastforce
+                       apply (simp add: lookup_pd_slot_def)
+                       apply (subgoal_tac "excaps ! 0 \<in> set excaps")
+                        apply (subst vaddr_segment_nonsense)
+                         apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
+                                          simp: obj_ref_of_def cap_aligned_def cap_bits_def)
+                        apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
+                       apply fastforce
+                      apply (simp add: lookup_pd_slot_def)
+                      apply (subgoal_tac "excaps ! 0 \<in> set excaps")
+                       apply (subst vaddr_segment_nonsense)
+                        apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
+                                         simp: obj_ref_of_def cap_aligned_def cap_bits_def)
+                       apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
+                      apply fastforce
+                     apply fastforce
+                    apply (subgoal_tac "excaps ! 0 \<in> set excaps")
+                     apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
+                    apply fastforce
+                   apply fastforce
+                  (* clagged from Arch_AI *)
+                  apply (simp add: linorder_not_le kernel_base_less_observation
+                                   vmsz_aligned_def p_assoc_help)
+                  apply (subst(asm) mask_lower_twice[symmetric])
+                   prefer 2
+                   apply (subst(asm) is_aligned_add_helper,
+                          assumption)
+                   apply (rule word_power_less_1)
+                    apply (case_tac xc, simp_all)[1]
+                   apply simp
+                  apply (case_tac xc, simp_all)[1]
+                 apply (rule ball_subset[OF _ vspace_cap_rights_to_auth_mask_vm_rights])
+                 apply (fastforce simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def)
+                apply (simp add: lookup_pd_slot_def)
+                apply (subgoal_tac "excaps ! 0 \<in> set excaps")
+                 apply (subst vaddr_segment_nonsense)
+                  apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
+                                   simp: obj_ref_of_def cap_aligned_def cap_bits_def)
+                 apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
+                apply fastforce
+               apply (simp add: lookup_pd_slot_def)
+               apply (subgoal_tac "excaps ! 0 \<in> set excaps")
+                apply (subst vaddr_segment_nonsense)
+                 apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
+                                  simp: obj_ref_of_def cap_aligned_def cap_bits_def)
+                apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
+               apply fastforce
+              apply fastforce
+             apply (subgoal_tac "excaps ! 0 \<in> set excaps")
+              apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
+             apply fastforce
+            apply fastforce
+           apply (fastforce dest: cte_wp_valid_cap simp: valid_cap_simps)
+          apply (rule ball_subset[OF _ vspace_cap_rights_to_auth_mask_vm_rights])
+          apply (fastforce simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def)
+         apply (subgoal_tac "excaps ! 0 \<in> set excaps")
+          apply (fastforce intro: aag_cap_auth_PageDirectoryCap_asid)
+         apply fastforce
+        apply (subgoal_tac "excaps ! 0 \<in> set excaps")
+         apply (subst vaddr_segment_nonsense)
+          apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
+                           simp: obj_ref_of_def cap_aligned_def cap_bits_def)
+         apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
+        apply fastforce
+       apply blast
+      apply blast
+     apply (blast dest: aag_can_read_self)
+    apply (force dest: silc_inv_not_subject)
+   apply (simp add: lookup_pd_slot_def)
+   apply (subst vaddr_segment_nonsense)
+    apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
+                     simp: obj_ref_of_def cap_aligned_def cap_bits_def)
+   apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
+  apply (clarsimp simp: lookup_pd_slot_def
+                 split: option.splits kernel_object.splits arch_kernel_obj.splits pde.splits)
+  apply (subst (asm) vaddr_segment_nonsense)
+   apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
+                    simp: obj_ref_of_def cap_aligned_def cap_bits_def)
+  apply (subst(asm) vaddr_segment_nonsense2)
+   apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
+                    simp: obj_ref_of_def cap_aligned_def cap_bits_def)
+  apply (rule_tac pd=x and s=s in lookup_pt_slot_no_fail_is_subject)
+          apply (erule exI)
+         apply (simp add: invs_def valid_state_def)
+        apply (simp add: invs_def valid_state_def valid_pspace_def)
+       apply assumption
+      apply (erule(1) aag_cap_auth_PageDirectoryCap)
+     apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
+                      simp: obj_ref_of_def cap_aligned_def cap_bits_def pd_bits)
+    apply simp
+   apply assumption
+  apply assumption
+  done
+
+end
+
+
+global_interpretation Decode_IF_2?: Decode_IF_2
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Decode_IF_assms)?)
+qed
+
+end

--- a/proof/infoflow/ARM/ArchFinalCaps.thy
+++ b/proof/infoflow/ARM/ArchFinalCaps.thy
@@ -1,0 +1,341 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchFinalCaps
+imports FinalCaps
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems FinalCaps_assms
+
+lemma FIXME_arch_gen_refs[FinalCaps_assms]:
+  "arch_gen_refs cap = {}"
+  by (clarsimp simp: arch_cap_set_map_def arch_gen_obj_refs_def split: cap.splits)
+
+lemma aobj_ref_same_aobject[FinalCaps_assms]:
+  "same_aobject_as cp cp' \<Longrightarrow> aobj_ref cp = aobj_ref cp'"
+  by (cases cp; cases cp'; clarsimp)
+
+lemma set_pt_silc_inv[wp]:
+  "set_pt ptr pt \<lbrace>silc_inv aag st\<rbrace>"
+  unfolding set_pt_def
+  apply (rule silc_inv_pres)
+    apply (wpsimp wp: set_object_wp_strong simp: a_type_def split: kernel_object.splits)
+    apply (fastforce simp: silc_inv_def obj_at_def is_cap_table_def)
+   apply (wp set_object_wp get_object_wp | simp)+
+  apply (case_tac "ptr = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (fastforce elim: cte_wp_atE simp: obj_at_def)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  done
+
+lemma set_pd_silc_inv[wp]:
+  "set_pd ptr pd \<lbrace>silc_inv aag st\<rbrace>"
+  unfolding set_pd_def
+  apply (rule silc_inv_pres)
+    apply (wpsimp wp: set_object_wp_strong simp: a_type_def split: kernel_object.splits)
+    apply (fastforce simp: silc_inv_def obj_at_def is_cap_table_def)
+   apply (wp set_object_wp get_object_wp | simp)+
+  apply (case_tac "ptr = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (fastforce elim: cte_wp_atE simp: obj_at_def)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  done
+
+lemma set_asid_pool_silc_inv[wp]:
+   "set_asid_pool ptr pool \<lbrace>silc_inv aag st\<rbrace>"
+  unfolding set_asid_pool_def
+  apply (rule silc_inv_pres)
+    apply (wpsimp wp: set_object_wp_strong simp: a_type_def split: kernel_object.splits)
+    apply (fastforce simp: silc_inv_def obj_at_def is_cap_table_def)
+   apply (wp set_object_wp get_object_wp | simp)+
+  apply (case_tac "ptr = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (fastforce elim: cte_wp_atE simp: obj_at_def)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  done
+
+crunches arch_finalise_cap, prepare_thread_delete, init_arch_objects
+  for silc_inv[FinalCaps_assms, wp]: "silc_inv aag st"
+  (wp: crunch_wps modify_wp simp: crunch_simps ignore: set_object)
+
+declare finalise_cap_makes_halted[FinalCaps_assms]
+
+crunches handle_reserved_irq, handle_vm_fault, handle_hypervisor_fault, handle_arch_fault_reply,
+         arch_invoke_irq_handler, arch_mask_irq_signal,
+         arch_post_cap_deletion, arch_post_modify_registers,
+         arch_activate_idle_thread, arch_switch_to_idle_thread, arch_switch_to_thread
+for silc_inv[FinalCaps_assms, wp]: "silc_inv aag st"
+
+declare init_arch_objects_cte_wp_at[FinalCaps_assms]
+declare handle_vm_fault_cur_thread[FinalCaps_assms]
+
+lemma arch_derive_cap_silc[FinalCaps_assms]:
+  "\<lbrace>\<lambda>s. cap = ArchObjectCap acap \<and>
+        (\<not> cap_points_to_label aag cap l \<longrightarrow> R (slots_holding_overlapping_caps cap s))\<rbrace>
+   arch_derive_cap acap
+   \<lbrace>\<lambda>cap' s. \<not> cap_points_to_label aag cap' l \<longrightarrow> R (slots_holding_overlapping_caps cap' s)\<rbrace>, -"
+  apply (simp add: arch_derive_cap_def)
+  apply wpsimp
+  apply (auto simp: cap_points_to_label_def slots_holding_overlapping_caps_def)
+  done
+
+end
+
+
+global_interpretation FinalCaps_1?: FinalCaps_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact FinalCaps_assms)?)
+qed
+
+
+context Arch begin global_naming ARM
+
+lemma perform_page_table_invocation_silc_inv_get_cap_helper:
+   "\<lbrace>silc_inv aag st and cte_wp_at (is_pt_cap or is_pg_cap) xa\<rbrace>
+    get_cap xa
+    \<lbrace>(\<lambda>capa s. (\<not> cap_points_to_label aag (ArchObjectCap $ update_map_data capa None)
+                                           (pasObjectAbs aag (fst xa))
+                \<longrightarrow> (\<exists>lslot. lslot \<in> slots_holding_overlapping_caps
+                                       (ArchObjectCap $ update_map_data capa None) s \<and>
+                             pasObjectAbs aag (fst lslot) = SilcLabel))) \<circ> the_arch_cap\<rbrace>"
+  apply (wp get_cap_wp)
+  apply clarsimp
+  apply (drule cte_wp_at_norm)
+  apply (clarify)
+  apply (drule (1) cte_wp_at_eqD2)
+  apply (case_tac cap, simp_all add: is_pg_cap_def is_pt_cap_def)
+  apply (clarsimp simp: cap_points_to_label_def update_map_data_def split: arch_cap.splits)
+   apply (drule silc_invD)
+     apply assumption
+    apply (fastforce simp: intra_label_cap_def cap_points_to_label_def)
+   apply (fastforce simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
+  apply (drule silc_invD)
+    apply assumption
+   apply (fastforce simp: intra_label_cap_def cap_points_to_label_def)
+  apply (fastforce simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
+  done
+
+lemmas perform_page_table_invocation_silc_inv_get_cap_helper' =
+  perform_page_table_invocation_silc_inv_get_cap_helper[simplified o_def fun_app_def]
+
+lemma mapM_x_swp_store_pte_silc_inv[wp]:
+  "mapM_x (swp store_pte A) slots \<lbrace>silc_inv aag st\<rbrace>"
+  by (wp mapM_x_wp[OF _ subset_refl] | simp add: swp_def)+
+
+lemma is_arch_eq_pt_is_pt_or_pg_cap:
+  "cte_wp_at ((=) (ArchObjectCap (PageTableCap xa xb))) slot s
+   \<Longrightarrow> cte_wp_at (\<lambda>a. is_pt_cap a \<or> is_pg_cap a) slot s"
+  apply (erule cte_wp_at_weakenE)
+  by (clarsimp simp: is_pg_cap_def is_pt_cap_def)
+
+lemma is_arch_eq_pg_is_pt_or_pg_cap:
+  "cte_wp_at ((=) (ArchObjectCap (PageCap dev x xa xb xc))) slot s
+   \<Longrightarrow> cte_wp_at (\<lambda>a. is_pt_cap a \<or> is_pg_cap a) slot s"
+  apply (erule cte_wp_at_weakenE)
+  by (clarsimp simp: is_pg_cap_def is_pt_cap_def)
+
+lemma perform_page_table_invocation_silc_inv:
+  "\<lbrace>silc_inv aag st and valid_pti blah and K (authorised_page_table_inv aag blah)\<rbrace>
+   perform_page_table_invocation blah
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding perform_page_table_invocation_def
+  apply (rule hoare_pre)
+  apply (wp set_cap_silc_inv mapM_x_wp[OF _ subset_refl]
+            perform_page_table_invocation_silc_inv_get_cap_helper'[where st=st]
+         | wpc | simp only: o_def fun_app_def K_def swp_def)+
+  apply (clarsimp simp: valid_pti_def authorised_page_table_inv_def
+                 split: page_table_invocation.splits)
+   apply (rule conjI)
+    apply (clarsimp)
+    defer
+    apply (fastforce simp: silc_inv_def)
+   apply (fastforce dest: is_arch_eq_pt_is_pt_or_pg_cap simp: silc_inv_def)
+  apply (drule_tac slot="(aa,ba)" in overlapping_slots_have_labelled_overlapping_caps[rotated])
+    apply (fastforce)
+   apply (fastforce elim: is_arch_update_overlaps[rotated] cte_wp_at_weakenE)
+  apply fastforce
+  done
+
+lemma perform_page_directory_invocation_silc_inv:
+  "perform_page_directory_invocation iv \<lbrace>silc_inv aag st\<rbrace>"
+  unfolding perform_page_directory_invocation_def
+  apply (cases iv)
+   apply (wp | simp)+
+  done
+
+crunch silc_inv[wp]: invalidate_tlb_by_asid "silc_inv aag st"
+
+lemma perform_page_invocation_silc_inv:
+  "\<lbrace>silc_inv aag st and valid_page_inv blah and K (authorised_page_inv aag blah)\<rbrace>
+   perform_page_invocation blah
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding perform_page_invocation_def
+  apply (rule hoare_pre)
+  apply (wp mapM_wp[OF _ subset_refl] set_cap_silc_inv
+            mapM_x_wp[OF _ subset_refl]
+            perform_page_table_invocation_silc_inv_get_cap_helper'[where st=st]
+            hoare_vcg_all_lift hoare_vcg_if_lift static_imp_wp
+         | wpc
+         | simp only: swp_def o_def fun_app_def K_def
+         | wp (once) hoare_drop_imps)+
+  apply (clarsimp simp: valid_page_inv_def authorised_page_inv_def
+                  split: page_invocation.splits)
+   apply (intro allI impI conjI)
+      apply (drule_tac slot="(aa,bb)" in overlapping_slots_have_labelled_overlapping_caps[rotated])
+        apply (fastforce)
+       apply (fastforce elim: is_arch_update_overlaps[rotated] cte_wp_at_weakenE)
+      apply fastforce
+     apply (fastforce simp: silc_inv_def)
+    apply (drule_tac slot="(aa,bb)" in overlapping_slots_have_labelled_overlapping_caps[rotated])
+      apply (fastforce)
+     apply (fastforce elim: is_arch_update_overlaps[rotated] cte_wp_at_weakenE)
+    apply fastforce
+   apply (fastforce simp: silc_inv_def)
+  apply (fastforce dest: is_arch_eq_pg_is_pt_or_pg_cap simp: silc_inv_def)
+  done
+
+lemma perform_asid_control_invocation_silc_inv:
+  notes blah[simp del] = atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+  shows
+  "\<lbrace>silc_inv aag st and valid_aci blah and invs and K (authorised_asid_control_inv aag blah)\<rbrace>
+   perform_asid_control_invocation blah
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (rule hoare_gen_asm)
+  unfolding perform_asid_control_invocation_def
+  apply (rule hoare_pre)
+  apply (wp modify_wp cap_insert_silc_inv' retype_region_silc_inv[where sz=pageBits]
+            set_cap_silc_inv get_cap_slots_holding_overlapping_caps[where st=st]
+            delete_objects_silc_inv static_imp_wp
+         | wpc | simp )+
+  apply (clarsimp simp: authorised_asid_control_inv_def silc_inv_def valid_aci_def ptr_range_def page_bits_def)
+  apply (rule conjI)
+   apply (clarsimp simp: range_cover_def obj_bits_api_def default_arch_object_def asid_bits_def pageBits_def)
+   apply (rule of_nat_inverse)
+    apply simp
+    apply (drule is_aligned_neg_mask_eq'[THEN iffD1, THEN sym])
+    apply (erule_tac t=x in ssubst)
+    apply (simp add: mask_AND_NOT_mask)
+   apply simp
+  apply (simp add: p_assoc_help)
+  apply (clarsimp simp: cap_points_to_label_def)
+  apply (erule bspec)
+  apply (fastforce intro: is_aligned_no_wrap' simp: blah)
+  done
+
+lemma perform_asid_pool_invocation_silc_inv:
+  "\<lbrace>silc_inv aag st and K (authorised_asid_pool_inv aag blah)\<rbrace>
+   perform_asid_pool_invocation blah
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (rule hoare_gen_asm)
+  unfolding perform_asid_pool_invocation_def
+  apply (rule hoare_pre)
+   apply (wp set_cap_silc_inv get_cap_wp | wpc)+
+  apply clarsimp
+  apply (rule conjI, intro impI)
+   apply (drule silc_invD)
+     apply assumption
+    apply (fastforce simp: intra_label_cap_def simp: cap_points_to_label_def)
+   apply (clarsimp simp: slots_holding_overlapping_caps_def)
+  apply (fastforce simp: authorised_asid_pool_inv_def silc_inv_def)
+  done
+
+lemma arch_perform_invocation_silc_inv[FinalCaps_assms]:
+  "\<lbrace>silc_inv aag st and invs and valid_arch_inv ai and authorised_arch_inv aag ai\<rbrace>
+   arch_perform_invocation ai
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding arch_perform_invocation_def
+  apply (rule hoare_pre)
+  apply (wp perform_page_table_invocation_silc_inv
+            perform_page_directory_invocation_silc_inv
+            perform_page_invocation_silc_inv
+            perform_asid_control_invocation_silc_inv
+            perform_asid_pool_invocation_silc_inv
+         | wpc)+
+  apply (clarsimp simp: authorised_arch_inv_def valid_arch_inv_def split: arch_invocation.splits)
+  done
+
+lemma arch_invoke_irq_control_silc_inv[FinalCaps_assms]:
+  "\<lbrace>silc_inv aag st and pas_refined aag and arch_irq_control_inv_valid arch_irq_cinv
+                    and K (arch_authorised_irq_ctl_inv aag arch_irq_cinv)\<rbrace>
+   arch_invoke_irq_control arch_irq_cinv
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding arch_authorised_irq_ctl_inv_def
+  apply (rule hoare_gen_asm)
+  apply (case_tac arch_irq_cinv)
+  apply (wp cap_insert_silc_inv'' hoare_vcg_ex_lift slots_holding_overlapping_caps_lift
+         | simp add: authorised_irq_ctl_inv_def arch_irq_control_inv_valid_def)+
+  apply (fastforce dest: new_irq_handler_caps_are_intra_label)
+  done
+
+lemma invoke_tcb_silc_inv[FinalCaps_assms]:
+  notes static_imp_wp [wp]
+        static_imp_conj_wp [wp]
+  shows "\<lbrace>silc_inv aag st and einvs and simple_sched_action and pas_refined aag and tcb_inv_wf tinv
+                          and K (authorised_tcb_inv aag tinv)\<rbrace>
+         invoke_tcb tinv
+         \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (case_tac tinv)
+         apply ((wp restart_silc_inv hoare_vcg_if_lift suspend_silc_inv mapM_x_wp[OF _ subset_refl]
+                    static_imp_wp
+                 | wpc
+                 | simp split del: if_split add: authorised_tcb_inv_def check_cap_at_def
+                 | clarsimp
+                 | strengthen invs_mdb
+                 | force intro: notE[rotated,OF idle_no_ex_cap,simplified])+)[3]
+      defer
+      apply ((wp suspend_silc_inv restart_silc_inv | simp add: authorised_tcb_inv_def | force)+)[2]
+    (* NotificationControl *)
+    apply (rename_tac option)
+    apply (case_tac option; (wp | simp)+)
+   (* SetTLSBase *)
+   apply (wpsimp split: option.splits)
+  (* just ThreadControl left *)
+  apply (simp add: split_def cong: option.case_cong)
+  (* slow, ~2 mins *)
+  apply (simp only: conj_ac cong: conj_cong imp_cong |
+         wp checked_insert_pas_refined checked_cap_insert_silc_inv hoare_vcg_all_lift_R
+            hoare_vcg_all_lift hoare_vcg_const_imp_lift_R
+            cap_delete_silc_inv_not_transferable
+            cap_delete_pas_refined' cap_delete_deletes
+            cap_delete_valid_cap cap_delete_cte_at
+            check_cap_inv[where P="valid_cap c" for c]
+            check_cap_inv[where P="cte_at p0" for p0]
+            check_cap_inv[where P="\<lambda>s. \<not> tcb_at t s" for t]
+            check_cap_inv2[where Q="\<lambda>_. valid_list"]
+            check_cap_inv2[where Q="\<lambda>_. valid_sched"]
+            check_cap_inv2[where Q="\<lambda>_. simple_sched_action"]
+            checked_insert_no_cap_to
+            thread_set_tcb_fault_handler_update_invs
+            thread_set_pas_refined thread_set_emptyable thread_set_valid_cap
+            thread_set_not_state_valid_sched thread_set_cte_at
+            thread_set_no_cap_to_trivial
+        | wpc
+        | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def st_tcb_at_triv
+                   option_update_thread_def
+        | strengthen use_no_cap_to_obj_asid_strg invs_mdb
+                    invs_psp_aligned invs_vspace_objs invs_arch_state
+        | wp (once) hoare_drop_imps)+
+  apply (clarsimp simp: authorised_tcb_inv_def emptyable_def)
+  (* also slow, ~15s *)
+  by (clarsimp simp: is_cap_simps is_cnode_or_valid_arch_def is_valid_vtable_root_def
+      | intro impI
+      | rule conjI)+
+
+end
+
+
+global_interpretation FinalCaps_2?: FinalCaps_2
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact FinalCaps_assms)?)
+qed
+
+end

--- a/proof/infoflow/ARM/ArchFinalise_IF.thy
+++ b/proof/infoflow/ARM/ArchFinalise_IF.thy
@@ -1,0 +1,410 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchFinalise_IF
+imports Finalise_IF
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems Finalise_IF_assms
+
+crunches arch_post_cap_deletion
+  for globals_equiv[Finalise_IF_assms, wp]: "globals_equiv st"
+
+lemma dmo_maskInterrupt_reads_respects[Finalise_IF_assms]:
+  "reads_respects aag l \<top> (do_machine_op (maskInterrupt m irq))"
+  unfolding maskInterrupt_def
+  apply (rule use_spec_ev)
+  apply (rule do_machine_op_spec_reads_respects)
+   apply (simp add: equiv_valid_def2)
+   apply (rule modify_ev2)
+   apply (fastforce simp: equiv_for_def)
+  apply (wp modify_wp | simp)+
+  done
+
+lemma arch_post_cap_deletion_read_respects[Finalise_IF_assms, wp]:
+  "reads_respects aag l \<top> (arch_post_cap_deletion acap)"
+  by wpsimp
+
+lemma equiv_asid_sa_update[Finalise_IF_assms, simp]:
+  "equiv_asid asid (scheduler_action_update f s) s' = equiv_asid asid s s'"
+  "equiv_asid asid s (scheduler_action_update f s') = equiv_asid asid s s'"
+  by (auto simp: equiv_asid_def)
+
+lemma equiv_asid_ready_queues_update[Finalise_IF_assms, simp]:
+  "equiv_asid asid (ready_queues_update f s) s' = equiv_asid asid s s'"
+  "equiv_asid asid s (ready_queues_update f s') = equiv_asid asid s s'"
+  by (auto simp: equiv_asid_def)
+
+lemma arch_finalise_cap_makes_halted[Finalise_IF_assms]:
+  "\<lbrace>invs and valid_cap (ArchObjectCap arch_cap)
+        and (\<lambda>s. ex = is_final_cap' (ArchObjectCap arch_cap) s)
+        and cte_wp_at ((=) (ArchObjectCap arch_cap)) slot\<rbrace>
+   arch_finalise_cap arch_cap ex
+   \<lbrace>\<lambda>rv s. \<forall>t \<in> Access.obj_refs (fst rv). halted_if_tcb t s\<rbrace>"
+  by (wpsimp simp: arch_finalise_cap_def)
+
+(* FIXME: move *)
+lemma set_object_modifies_at_most:
+  "modifies_at_most aag {pasObjectAbs aag ptr}
+                    (\<lambda>s. \<not> asid_pool_at ptr s \<and> (\<forall>asid_pool. obj \<noteq> ArchObj (ASIDPool asid_pool)))
+                    (set_object ptr obj)"
+  apply (rule modifies_at_mostI)
+  apply (wp set_object_equiv_but_for_labels)
+  apply clarsimp
+  done
+
+lemma set_thread_state_reads_respects[Finalise_IF_assms]:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows "reads_respects aag l (\<lambda>s. is_subject aag (cur_thread s)) (set_thread_state ref ts)"
+  unfolding set_thread_state_def fun_app_def
+  apply (simp add: bind_assoc[symmetric])
+  apply (rule pre_ev)
+   apply (rule_tac P'=\<top> in bind_ev)
+     apply (rule set_thread_state_ext_reads_respects)
+    apply (case_tac "aag_can_read aag ref \<or> aag_can_affect aag l ref")
+     apply (wp set_object_reads_respects gets_the_ev)
+     apply (fastforce simp: get_tcb_def split: option.splits
+                     elim: reads_equivE affects_equivE equiv_forE)
+    apply (simp add: equiv_valid_def2)
+    apply (rule equiv_valid_rv_bind)
+      apply (rule equiv_valid_rv_trivial)
+      apply (wp | simp)+
+     apply (rule_tac P=\<top> and P'=\<top> and L="{pasObjectAbs aag ref}" and L'="{pasObjectAbs aag ref}"
+                  in ev2_invisible[OF domains_distinct])
+         apply (blast | simp add: labels_are_invisible_def)+
+       apply (rule set_object_modifies_at_most)
+      apply (rule set_object_modifies_at_most)
+     apply (simp | wp)+
+    apply (blast dest: get_tcb_not_asid_pool_at)
+   apply (subst thread_set_def[symmetric, simplified fun_app_def])
+   apply (wp | simp)+
+  done
+
+lemma set_thread_state_runnable_reads_respects[Finalise_IF_assms]:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows "runnable ts \<Longrightarrow> reads_respects aag l \<top> (set_thread_state ref ts)"
+  unfolding set_thread_state_def fun_app_def
+  apply (simp add: bind_assoc[symmetric])
+  apply (rule pre_ev)
+   apply (rule_tac P'=\<top> in bind_ev)
+     apply (rule set_thread_state_ext_runnable_reads_respects)
+    apply (case_tac "aag_can_read aag ref \<or> aag_can_affect aag l ref")
+     apply (wp set_object_reads_respects gets_the_ev)
+     apply (fastforce simp: get_tcb_def split: option.splits elim: reads_equivE affects_equivE equiv_forE)
+    apply (simp add: equiv_valid_def2)
+    apply (rule equiv_valid_rv_bind)
+      apply (rule equiv_valid_rv_trivial)
+      apply (wp | simp)+
+     apply (rule_tac P=\<top> and P'=\<top> and L="{pasObjectAbs aag ref}" and L'="{pasObjectAbs aag ref}"
+                  in ev2_invisible[OF domains_distinct])
+         apply (blast | simp add: labels_are_invisible_def)+
+       apply (rule set_object_modifies_at_most)
+      apply (rule set_object_modifies_at_most)
+     apply (simp | wp)+
+    apply (blast dest: get_tcb_not_asid_pool_at)
+   apply (subst thread_set_def[symmetric, simplified fun_app_def])
+   apply (wp thread_set_st_tcb_at | simp)+
+   done
+
+lemma set_bound_notification_none_reads_respects[Finalise_IF_assms]:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows "reads_respects aag l \<top> (set_bound_notification ref None)"
+  unfolding set_bound_notification_def fun_app_def
+  apply (rule pre_ev(5)[where Q=\<top>])
+   apply (case_tac "aag_can_read aag ref \<or> aag_can_affect aag l ref")
+    apply (wp set_object_reads_respects gets_the_ev)[1]
+    apply (fastforce simp: get_tcb_def split: option.splits elim: reads_equivE affects_equivE equiv_forE)
+   apply (simp add: equiv_valid_def2)
+   apply (rule equiv_valid_rv_bind)
+     apply (rule equiv_valid_rv_trivial)
+     apply (wp | simp)+
+    apply (rule_tac P=\<top> and P'=\<top> and L="{pasObjectAbs aag ref}" and L'="{pasObjectAbs aag ref}"
+                 in ev2_invisible[OF domains_distinct])
+        apply (blast | simp add: labels_are_invisible_def)+
+      apply (rule set_object_modifies_at_most)
+     apply (rule set_object_modifies_at_most)
+    apply (simp | wp)+
+   apply (blast dest: get_tcb_not_asid_pool_at)
+  apply simp
+  done
+
+lemma set_tcb_queue_reads_respects[Finalise_IF_assms, wp]:
+  "reads_respects aag l \<top> (set_tcb_queue d prio queue)"
+  unfolding equiv_valid_def2 equiv_valid_2_def
+  apply (clarsimp simp: set_tcb_queue_def bind_def modify_def put_def get_def)
+  apply (rule conjI)
+   apply (rule reads_equiv_ready_queues_update, assumption)
+   apply (fastforce simp: reads_equiv_def affects_equiv_def states_equiv_for_def equiv_for_def)
+  apply (rule affects_equiv_ready_queues_update, assumption)
+  apply (clarsimp simp: reads_equiv_def affects_equiv_def states_equiv_for_def equiv_for_def
+                        equiv_asids_def equiv_asid_def)
+  apply (rule ext)
+  apply force
+  done
+
+lemma set_tcb_queue_modifies_at_most:
+  "modifies_at_most aag L (\<lambda>s. pasDomainAbs aag d \<inter> L \<noteq> {}) (set_tcb_queue d prio queue)"
+  apply (rule modifies_at_mostI)
+  apply (simp add: set_tcb_queue_def modify_def, wp)
+  apply (force simp: equiv_but_for_labels_def states_equiv_for_def equiv_for_def equiv_asids_def)
+  done
+
+lemma set_notification_equiv_but_for_labels[Finalise_IF_assms]:
+  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag ntfnptr \<in> L)\<rbrace>
+   set_notification ntfnptr ntfn
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding set_simple_ko_def
+  apply (wp set_object_equiv_but_for_labels get_object_wp)
+  apply (clarsimp simp: asid_pool_at_kheap partial_inv_def obj_at_def split: kernel_object.splits)
+  done
+
+lemma thread_set_reads_respects[Finalise_IF_assms]:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects aag l \<top> (thread_set x y)"
+  unfolding thread_set_def fun_app_def
+  apply (case_tac "aag_can_read aag y \<or> aag_can_affect aag l y")
+   apply (wp set_object_reads_respects)
+   apply (clarsimp, rule reads_affects_equiv_get_tcb_eq, simp+)[1]
+  apply (simp add: equiv_valid_def2)
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule_tac L="{pasObjectAbs aag y}" and L'="{pasObjectAbs aag y}"
+                in ev2_invisible[OF domains_distinct])
+       apply (assumption | simp add: labels_are_invisible_def)+
+     apply (rule modifies_at_mostI[where P="\<top>"]
+            | wp set_object_equiv_but_for_labels
+            | simp
+            | (clarify, drule get_tcb_not_asid_pool_at))+
+  done
+
+lemma aag_cap_auth_ASIDPoolCap:
+  "pas_cap_cur_auth aag (ArchObjectCap (ASIDPoolCap r asid)) \<Longrightarrow>
+   pas_refined aag s \<Longrightarrow> is_subject aag r"
+  unfolding aag_cap_auth_def
+  by (simp add: clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
+                cli_no_irqs pas_refined_all_auth_is_owns is_page_cap_def)
+
+lemma aag_cap_auth_PageDirectory:
+  "pas_cap_cur_auth aag (ArchObjectCap (PageDirectoryCap word (Some a))) \<Longrightarrow>
+    pas_refined aag s \<Longrightarrow> is_subject aag word"
+  unfolding aag_cap_auth_def
+  by (simp add: clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
+                cli_no_irqs pas_refined_all_auth_is_owns is_page_cap_def)
+
+lemma aag_cap_auth_ASIDPoolCap_asid:
+  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (ASIDPoolCap r asid)); asid' \<noteq> 0;
+     asid_high_bits_of asid' = asid_high_bits_of asid; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> is_subject_asid aag asid'"
+  apply (frule (1) aag_cap_auth_ASIDPoolCap)
+  apply (unfold aag_cap_auth_def)
+  apply (rule is_subject_into_is_subject_asid)
+  apply auto
+  done
+
+lemma aag_cap_auth_PageCap_asid:
+  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (PageCap dev ref r sz (Some (a, b)))); pas_refined aag s \<rbrakk>
+     \<Longrightarrow> is_subject_asid aag a"
+  by (auto simp: aag_cap_auth_def cap_links_asid_slot_def label_owns_asid_slot_def
+          intro: pas_refined_Control_into_is_subject_asid)
+
+lemma aag_cap_auth_PageTableCap:
+  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word option)); pas_refined aag s \<rbrakk>
+     \<Longrightarrow> is_subject aag word"
+  unfolding aag_cap_auth_def
+  by (simp add: clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
+                cli_no_irqs pas_refined_all_auth_is_owns is_page_cap_def)
+
+lemma aag_cap_auth_PageTableCap_asid:
+  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word (Some (a, b)))); pas_refined aag s \<rbrakk>
+     \<Longrightarrow> is_subject_asid aag a"
+  by (auto simp: aag_cap_auth_def cap_links_asid_slot_def label_owns_asid_slot_def
+          intro: pas_refined_Control_into_is_subject_asid)
+
+lemma aag_cap_auth_PageDirectoryCap:
+  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (PageDirectoryCap word option));  pas_refined aag s \<rbrakk>
+     \<Longrightarrow> is_subject aag word"
+  unfolding aag_cap_auth_def
+  by (simp add: clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
+                cli_no_irqs pas_refined_all_auth_is_owns is_page_cap_def)
+
+lemma aag_cap_auth_PageDirectoryCap_asid:
+  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (PageDirectoryCap word (Some a))); pas_refined aag s \<rbrakk>
+     \<Longrightarrow> is_subject_asid aag a"
+  unfolding aag_cap_auth_def
+  by (auto simp: cap_links_asid_slot_def label_owns_asid_slot_def
+          intro: pas_refined_Control_into_is_subject_asid)
+
+lemmas aag_cap_auth_subject = aag_cap_auth_ASIDPoolCap_asid
+                              aag_cap_auth_PageCap_asid
+                              aag_cap_auth_PageTableCap_asid
+                              aag_cap_auth_PageDirectoryCap_asid
+
+lemma prepare_thread_delete_reads_respects_f[Finalise_IF_assms]:
+  "reads_respects_f aag l \<top> (prepare_thread_delete thread)"
+  unfolding prepare_thread_delete_def by wp
+
+lemma arch_finalise_cap_reads_respects[Finalise_IF_assms]:
+  "reads_respects aag l (pas_refined aag and invs and cte_wp_at ((=) (ArchObjectCap cap)) slot
+                                         and K (pas_cap_cur_auth aag (ArchObjectCap cap)))
+                        (arch_finalise_cap cap final)"
+  unfolding arch_finalise_cap_def
+  apply (rule gen_asm_ev)
+  apply (case_tac cap)
+  apply simp
+  apply (simp split: bool.splits)
+  apply (intro impI conjI)
+  by (wp delete_asid_pool_reads_respects
+         unmap_page_reads_respects
+         unmap_page_table_reads_respects
+         delete_asid_reads_respects
+      | simp add: invs_psp_aligned invs_vspace_objs invs_valid_objs valid_cap_def
+           split: option.splits bool.splits
+      | intro impI conjI allI
+      | elim conjE
+      | rule aag_cap_auth_subject,assumption,assumption
+      | drule cte_wp_valid_cap)+
+
+(*NOTE: Required to dance around the issue of the base potentially
+        being zero and thus we can't conclude it is in the current subject.*)
+lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq':
+  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (ASIDPoolCap p b)); reads_equiv aag s t; pas_refined aag x \<rbrakk>
+     \<Longrightarrow> arm_asid_table (arch_state s) (asid_high_bits_of b) =
+         arm_asid_table (arch_state t) (asid_high_bits_of b)"
+  apply (subgoal_tac "asid_high_bits_of 0 = asid_high_bits_of 1")
+   apply (case_tac "b = 0")
+    apply (subgoal_tac "is_subject_asid aag 1")
+     apply ((fastforce intro: requiv_arm_asid_table_asid_high_bits_of_asid_eq
+                              aag_cap_auth_ASIDPoolCap_asid)+)[2]
+   apply (auto intro: requiv_arm_asid_table_asid_high_bits_of_asid_eq
+                      aag_cap_auth_ASIDPoolCap_asid)[1]
+  apply (simp add: asid_high_bits_of_def asid_low_bits_def)
+  done
+
+lemma pt_cap_aligned:
+  "\<lbrakk> caps_of_state s p = Some (ArchObjectCap (PageTableCap word x)); valid_caps (caps_of_state s) s \<rbrakk>
+     \<Longrightarrow> is_aligned word pt_bits"
+  by (auto simp: obj_ref_of_def pt_bits_def pageBits_def
+          dest!: cap_aligned_valid[OF valid_capsD, unfolded cap_aligned_def, THEN conjunct1])
+
+lemma maskInterrupt_no_mem:
+  "maskInterrupt a b \<lbrace>\<lambda>ms. P (underlying_memory ms)\<rbrace>"
+  by (wpsimp simp: maskInterrupt_def)
+
+lemma maskInterrupt_no_exclusive:
+  "maskInterrupt a b \<lbrace>\<lambda>ms. P (exclusive_state ms)\<rbrace>"
+  by (wpsimp simp: maskInterrupt_def)
+
+lemma set_irq_state_valid_global_objs:
+  "set_irq_state state irq \<lbrace>valid_global_objs\<rbrace>"
+  apply (simp add: set_irq_state_def)
+  apply (wp modify_wp)
+  apply (fastforce simp: valid_global_objs_def)
+  done
+
+lemma set_irq_state_globals_equiv[Finalise_IF_assms]:
+  "set_irq_state state irq \<lbrace>globals_equiv st\<rbrace>"
+  apply (simp add: set_irq_state_def)
+  apply (wp dmo_no_mem_globals_equiv maskInterrupt_no_mem maskInterrupt_no_exclusive modify_wp)
+  apply (simp add: globals_equiv_interrupt_states_update)
+  done
+
+lemma set_notification_globals_equiv[Finalise_IF_assms]:
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
+   set_notification ptr ntfn
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding set_simple_ko_def
+  apply (wp set_object_globals_equiv get_object_wp)
+  apply (fastforce simp: valid_ko_at_arch_def obj_at_def)
+  done
+
+lemma set_asid_pool_valid_ko_at_arch[wp]:
+  "\<lbrace>valid_ko_at_arch\<rbrace> set_asid_pool a b\<lbrace>\<lambda>_.valid_ko_at_arch\<rbrace>"
+  unfolding set_asid_pool_def
+  apply (wpsimp wp: set_object_wp_strong simp: a_type_def)
+  apply (fastforce simp: valid_ko_at_arch_def get_tcb_ko_at obj_at_def)
+  done
+
+crunches thread_set, prepare_thread_delete, arch_post_cap_deletion, arch_finalise_cap
+  for valid_ko_at_arch[Finalise_IF_assms, wp]: "valid_ko_at_arch"
+  (wp: hoare_vcg_if_lift2 hoare_drop_imps select_wp modify_wp mapM_wp' dxo_wp_weak
+   simp: unless_def crunch_simps arm_global_pd_not_tcb
+   ignore: empty_slot_ext)
+
+lemma delete_asid_globals_equiv:
+  "\<lbrace>globals_equiv st and valid_arch_state\<rbrace>
+   delete_asid asid pd
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding delete_asid_def
+  by (wp set_vm_root_globals_equiv set_asid_pool_globals_equiv invalidate_asid_entry_globals_equiv
+         flush_space_globals_equiv invalidate_asid_entry_valid_ko_at_arch
+      | wpc | simp add: valid_arch_state_ko_at_arch)+
+
+lemma pagebitsforsize_ge_2[simp]:
+  "2 \<le> pageBitsForSize vmpage_size"
+  by (induct vmpage_size; simp)
+
+lemma arch_finalise_cap_globals_equiv[Finalise_IF_assms]:
+  "\<lbrace>globals_equiv st and valid_global_objs and valid_arch_state and pspace_aligned
+                     and valid_vspace_objs and valid_global_refs and valid_vs_lookup\<rbrace>
+   arch_finalise_cap cap b
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  apply (induct cap; simp add: arch_finalise_cap_def)
+  by (wp delete_asid_pool_globals_equiv case_option_wp unmap_page_globals_equiv
+         unmap_page_table_globals_equiv delete_asid_globals_equiv
+      | wpc | clarsimp split: bool.splits option.splits | intro impI conjI)+
+
+lemma mapM_x_swp_store_kernel_base_globals_equiv:
+  "\<lbrace>invs and globals_equiv st and cte_wp_at ((=) (ArchObjectCap (PageDirectoryCap word option))) slot\<rbrace>
+   mapM_x (swp store_pde InvalidPDE) (map ((\<lambda>x. x + word) \<circ> swp (<<) 2) [0 .e. (kernel_base >> 20) - 1])
+   \<lbrace>\<lambda>_ s. globals_equiv st s \<and> invs s\<rbrace>"
+  apply (rule hoare_pre)
+   apply (wp mapM_x_swp_store_pde_invs_unmap mapM_x_swp_store_pde_globals_equiv)
+  apply clarsimp
+  apply (frule invs_valid_objs)
+  apply (frule invs_valid_global_refs)
+  apply (intro impI conjI allI)
+  by (simp add: cte_wp_at_page_directory_not_in_globals
+                cte_wp_at_page_directory_not_in_kernel_mappings
+                not_in_global_not_arm pde_ref_def)+
+
+declare arch_get_sanitise_register_info_def[simp]
+
+crunch globals_equiv[Finalise_IF_assms, wp]: prepare_thread_delete "globals_equiv st"
+  (wp: dxo_wp_weak)
+
+lemma set_bound_notification_globals_equiv[Finalise_IF_assms]:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+   set_bound_notification ref ts
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding set_bound_notification_def
+  apply (wp set_object_globals_equiv dxo_wp_weak |simp)+
+  apply (intro impI conjI allI)
+  by (clarsimp simp: valid_ko_at_arch_def obj_at_def tcb_at_def2 get_tcb_def is_tcb_def
+               dest: get_tcb_SomeD
+              split: option.splits kernel_object.splits)+
+
+lemma set_bound_notification_valid_ko_at_arch[Finalise_IF_assms, wp]:
+  "set_bound_notification ref ts \<lbrace>valid_ko_at_arch\<rbrace>"
+  unfolding set_bound_notification_def
+  apply (wp set_object_valid_ko_at_arch dxo_wp_weak |simp)+
+  apply (fastforce simp: valid_ko_at_arch_def get_tcb_ko_at obj_at_def)
+  done
+
+crunch valid_ko_at_arch[Finalise_IF_assms, wp]: set_original, set_cdt valid_ko_at_arch
+  (simp: valid_ko_at_arch_def)
+
+end
+
+
+global_interpretation Finalise_IF_1?: Finalise_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Finalise_IF_assms)?)
+qed
+
+end

--- a/proof/infoflow/ARM/ArchIRQMasks_IF.thy
+++ b/proof/infoflow/ARM/ArchIRQMasks_IF.thy
@@ -1,0 +1,179 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchIRQMasks_IF
+imports IRQMasks_IF
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems IRQMasks_IF_assms
+
+declare storeWord_irq_masks_inv[IRQMasks_IF_assms]
+
+lemma resetTimer_irq_masks[IRQMasks_IF_assms, wp]:
+  "resetTimer \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace>"
+  by (simp add: resetTimer_def | wp no_irq)+
+
+lemma delete_objects_irq_masks[IRQMasks_IF_assms, wp]:
+  "delete_objects ptr bits \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  apply (simp add: delete_objects_def)
+  apply (wp dmo_wp no_irq_mapM_x no_irq | simp add: freeMemory_def no_irq_storeWord)+
+  done
+
+crunch irq_masks[wp]: cleanCacheRange_PoU "\<lambda>s. P (irq_masks s)"
+  (ignore_del: cleanCacheRange_PoU)
+
+crunch irq_masks[IRQMasks_IF_assms, wp]: invoke_untyped "\<lambda>s. P (irq_masks_of_state s)"
+  (ignore: delete_objects wp: crunch_wps dmo_wp
+       wp: mapME_x_inv_wp preemption_point_inv
+     simp: crunch_simps no_irq_clearMemory
+           mapM_x_def_bak unless_def)
+
+crunch irq_masks[IRQMasks_IF_assms, wp]: finalise_cap "\<lambda>s. P (irq_masks_of_state s)"
+  (wp: select_wp crunch_wps dmo_wp no_irq
+   simp: crunch_simps no_irq_setHardwareASID  no_irq_invalidateLocalTLB_ASID
+         no_irq_set_current_pd no_irq_invalidateLocalTLB_VAASID no_irq_cleanByVA_PoU)
+
+crunch irq_masks[IRQMasks_IF_assms, wp]: send_signal "\<lambda>s. P (irq_masks_of_state s)"
+  (wp: crunch_wps ignore: do_machine_op wp: dmo_wp simp: crunch_simps)
+
+lemma handle_interrupt_irq_masks[IRQMasks_IF_assms]:
+  notes no_irq[wp del]
+  shows
+    "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and K (irq \<le> maxIRQ)\<rbrace>
+     handle_interrupt irq
+     \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (simp add: handle_interrupt_def split del: if_split)
+  apply (rule hoare_pre)
+   apply (rule hoare_if)
+    apply simp
+   apply (wp dmo_wp
+          | simp add: ackInterrupt_def maskInterrupt_def when_def split del: if_split
+          | wpc
+          | simp add: get_irq_state_def handle_reserved_irq_def
+          | wp (once) hoare_drop_imp)+
+  apply (fastforce simp: domain_sep_inv_def)
+  done
+
+lemma arch_invoke_irq_control_irq_masks[IRQMasks_IF_assms]:
+  "\<lbrace>domain_sep_inv False st and arch_irq_control_inv_valid invok\<rbrace>
+   arch_invoke_irq_control invok
+   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  apply (case_tac invok)
+  apply (clarsimp simp: arch_irq_control_inv_valid_def domain_sep_inv_def valid_def)
+  done
+
+crunches handle_vm_fault, handle_hypervisor_fault
+  for irq_masks[IRQMasks_IF_assms, wp]: "\<lambda>s. P (irq_masks_of_state s)"
+  (wp: dmo_wp no_irq simp: no_irq_getDFSR no_irq_getFAR no_irq_getIFSR)
+
+lemma dmo_getActiveIRQ_irq_masks[IRQMasks_IF_assms, wp]:
+  "do_machine_op (getActiveIRQ in_kernel) \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  apply (rule hoare_pre, rule dmo_wp)
+  apply (simp add: getActiveIRQ_def | wp | simp add: no_irq_def | clarsimp)+
+  done
+
+lemma dmo_getActiveIRQ_return_axiom[IRQMasks_IF_assms, wp]:
+  "\<lbrace>\<top>\<rbrace> do_machine_op (getActiveIRQ in_kernel) \<lbrace>\<lambda>rv s. (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)\<rbrace>"
+  apply (simp add: getActiveIRQ_def)
+  apply (rule hoare_pre, rule dmo_wp)
+   apply (insert irq_oracle_max_irq)
+   apply (wp alternative_wp select_wp dmo_getActiveIRQ_irq_masks)
+  apply clarsimp
+  done
+
+crunch irq_masks[IRQMasks_IF_assms, wp]: activate_thread "\<lambda>s. P (irq_masks_of_state s)"
+
+crunch irq_masks[IRQMasks_IF_assms, wp]: schedule "\<lambda>s. P (irq_masks_of_state s)"
+  (wp: dmo_wp alternative_wp select_wp crunch_wps simp: crunch_simps clearExMonitor_def)
+
+end
+
+
+global_interpretation IRQMasks_IF_1?: IRQMasks_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact IRQMasks_IF_assms)?)
+qed
+
+
+context Arch begin global_naming ARM
+
+crunch irq_masks[IRQMasks_IF_assms, wp]: do_reply_transfer "\<lambda>s. P (irq_masks_of_state s)"
+  (wp: crunch_wps empty_slot_irq_masks simp: crunch_simps unless_def)
+
+crunch irq_masks[IRQMasks_IF_assms, wp]: arch_perform_invocation "\<lambda>s. P (irq_masks_of_state s)"
+  (wp: dmo_wp crunch_wps no_irq
+   simp: no_irq_cleanByVA_PoU no_irq_invalidateLocalTLB_ASID no_irq_do_flush)
+
+(* FIXME: remove duplication in this proof -- requires getting the wp automation
+          to do the right thing with dropping imps in validE goals *)
+lemma invoke_tcb_irq_masks[IRQMasks_IF_assms]:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and tcb_inv_wf tinv\<rbrace>
+   invoke_tcb tinv
+   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  apply (case_tac tinv)
+         apply((wp restart_irq_masks hoare_vcg_if_lift  mapM_x_wp[OF _ subset_refl]
+                | wpc
+                | simp split del: if_split add: check_cap_at_def
+                | clarsimp)+)[3]
+      defer
+      apply ((wp | simp )+)[2]
+    (* NotificationControl *)
+    apply (rename_tac option)
+    apply (case_tac option)
+     apply ((wp | simp)+)[2]
+   (* just ThreadControl left *)
+   apply (simp add: split_def cong: option.case_cong)
+   apply wpsimp+
+       apply (rule hoare_post_impErr[OF cap_delete_irq_masks[where P=P]])
+        apply blast
+       apply blast
+      apply (wpsimp wp: hoare_vcg_all_lift_R hoare_vcg_const_imp_lift_R
+                        checked_cap_insert_domain_sep_inv)+
+      apply (rule_tac Q="\<lambda> r s. domain_sep_inv False st s \<and> P (irq_masks_of_state s)"
+                  and E="\<lambda>_ s. P (irq_masks_of_state s)" in hoare_post_impErr)
+        apply (wp hoare_vcg_conj_liftE1 cap_delete_irq_masks)
+       apply fastforce
+      apply blast
+     apply (wpsimp wp: static_imp_wp hoare_vcg_all_lift checked_cap_insert_domain_sep_inv)+
+     apply (rule_tac Q="\<lambda> r s. domain_sep_inv False st s \<and> P (irq_masks_of_state s)"
+                 and E="\<lambda>_ s. P (irq_masks_of_state s)" in hoare_post_impErr)
+       apply (wp hoare_vcg_conj_liftE1 cap_delete_irq_masks)
+      apply fastforce
+     apply blast
+    apply (simp add: option_update_thread_def | wp static_imp_wp hoare_vcg_all_lift | wpc)+
+  by fastforce+
+
+end
+
+
+global_interpretation IRQMasks_IF_2?: IRQMasks_IF_2
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact IRQMasks_IF_assms)?)
+qed
+
+
+context begin interpretation Arch .
+
+requalify_facts
+  init_arch_objects_irq_masks
+  arch_activate_idle_thread_irq_masks
+  retype_region_irq_masks
+
+end
+
+declare
+  init_arch_objects_irq_masks[wp]
+  arch_activate_idle_thread_irq_masks[wp]
+  retype_region_irq_masks[wp]
+
+end

--- a/proof/infoflow/ARM/ArchInfoFlow.thy
+++ b/proof/infoflow/ARM/ArchInfoFlow.thy
@@ -1,0 +1,81 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchInfoFlow
+imports
+  "Access.ArchSyscall_AC"
+  "Lib.EquivValid"
+begin
+
+context Arch begin global_naming ARM
+
+section \<open>Arch-specific equivalence properties\<close>
+
+subsection \<open>ASID equivalence\<close>
+
+definition equiv_asid :: "asid \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool" where
+  "equiv_asid asid s s' \<equiv>
+    ((arm_asid_table (arch_state s) (asid_high_bits_of asid)) =
+     (arm_asid_table (arch_state s') (asid_high_bits_of asid))) \<and>
+    (\<forall>pool_ptr. arm_asid_table (arch_state s) (asid_high_bits_of asid) = Some pool_ptr
+                \<longrightarrow> asid_pool_at pool_ptr s = asid_pool_at pool_ptr s' \<and>
+                    (\<forall>asid_pool asid_pool'. kheap s pool_ptr = Some (ArchObj (ASIDPool asid_pool)) \<and>
+                                            kheap s' pool_ptr = Some (ArchObj (ASIDPool asid_pool'))
+                                            \<longrightarrow> asid_pool (ucast asid) = asid_pool' (ucast asid)))"
+
+definition equiv_asid' where
+  "equiv_asid' asid pool_ptr_opt pool_ptr_opt' kh kh' \<equiv>
+    (case pool_ptr_opt of None \<Rightarrow> pool_ptr_opt' = None
+                        | Some pool_ptr \<Rightarrow>
+       (case pool_ptr_opt' of None \<Rightarrow> False
+                            | Some pool_ptr' \<Rightarrow>
+          (pool_ptr' = pool_ptr \<and>
+           ((\<exists>asid_pool. kh pool_ptr = Some (ArchObj (ASIDPool asid_pool))) =
+            (\<exists>asid_pool'. kh' pool_ptr' = Some (ArchObj (ASIDPool asid_pool')))) \<and>
+           (\<forall>asid_pool asid_pool'. kh pool_ptr = Some (ArchObj (ASIDPool asid_pool)) \<and>
+                                   kh' pool_ptr' = Some (ArchObj (ASIDPool asid_pool'))
+                                   \<longrightarrow> asid_pool (ucast asid) = asid_pool' (ucast asid)))))"
+
+definition non_asid_pool_kheap_update where
+  "non_asid_pool_kheap_update s kh \<equiv>
+     \<forall>x. (\<exists>asid_pool. kheap s x = Some (ArchObj (ASIDPool asid_pool)) \<or>
+                      kh x = Some (ArchObj (ASIDPool asid_pool)))
+         \<longrightarrow> kheap s x = kh x"
+
+
+subsection \<open>Exclusive machine state equivalence\<close>
+
+abbreviation exclusive_state_equiv where
+  "exclusive_state_equiv s s' \<equiv>
+     exclusive_state (machine_state s) = exclusive_state (machine_state s')"
+
+
+subsection \<open>Global (Kernel) VSpace equivalence\<close>
+(* globals_equiv should be maintained by everything except the scheduler, since
+   nothing else touches the globals frame *)
+
+definition arch_globals_equiv :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> kheap \<Rightarrow> kheap \<Rightarrow> arch_state \<Rightarrow>
+                                  arch_state \<Rightarrow> machine_state \<Rightarrow> machine_state \<Rightarrow> bool" where
+  "arch_globals_equiv ct it kh kh' as as' ms ms' \<equiv>
+     arm_global_pd as = arm_global_pd as' \<and>
+     kh (arm_global_pd as) = kh' (arm_global_pd as) \<and>
+     (ct \<noteq> it \<longrightarrow> exclusive_state ms = exclusive_state ms')"
+
+declare arch_globals_equiv_def[simp]
+
+end
+
+context begin interpretation Arch .
+
+requalify_consts
+  equiv_asid
+  equiv_asid'
+  arch_globals_equiv
+  non_asid_pool_kheap_update
+
+end
+
+end

--- a/proof/infoflow/ARM/ArchInfoFlow_IF.thy
+++ b/proof/infoflow/ARM/ArchInfoFlow_IF.thy
@@ -1,0 +1,120 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchInfoFlow_IF
+imports InfoFlow_IF
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems InfoFlow_IF_assms
+
+lemma asid_pool_at_kheap:
+  "asid_pool_at ptr s = (\<exists>asid_pool. kheap s ptr = Some (ArchObj (ASIDPool asid_pool)))"
+  by (simp add: atyp_at_eq_kheap_obj)
+
+lemma equiv_asid:
+  "equiv_asid asid s s' = equiv_asid' asid (arm_asid_table (arch_state s) (asid_high_bits_of asid))
+                                           (arm_asid_table (arch_state s') (asid_high_bits_of asid))
+                                           (kheap s) (kheap s')"
+  by (auto simp: equiv_asid_def equiv_asid'_def asid_pool_at_kheap split: option.splits )
+
+lemma equiv_asids_refl[InfoFlow_IF_assms]:
+  "equiv_asids R s s"
+  by (auto simp: equiv_asids_def equiv_asid_def)
+
+lemma equiv_asids_sym[InfoFlow_IF_assms]:
+  "equiv_asids R s t \<Longrightarrow> equiv_asids R t s"
+  by (auto simp: equiv_asids_def equiv_asid_def)
+
+lemma equiv_asids_trans[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_asids R s t; equiv_asids R t u \<rbrakk> \<Longrightarrow> equiv_asids R s u"
+  by (fastforce simp: equiv_asids_def equiv_asid_def asid_pool_at_kheap)
+
+lemma equiv_asids_non_asid_pool_kheap_update[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_asids R s s'; non_asid_pool_kheap_update s kh; non_asid_pool_kheap_update s' kh' \<rbrakk>
+     \<Longrightarrow> equiv_asids R (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
+  apply (clarsimp simp: equiv_asids_def equiv_asid non_asid_pool_kheap_update_def)
+  apply (fastforce simp: equiv_asid'_def split: option.splits)
+  done
+
+lemma equiv_asids_identical_kheap_updates[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_asids R s s'; identical_kheap_updates s s' kh kh' \<rbrakk>
+     \<Longrightarrow> equiv_asids R (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
+  apply (clarsimp simp: equiv_asids_def equiv_asid_def identical_kheap_updates_def asid_pool_at_kheap)
+  apply (case_tac "kh pool_ptr = kh' pool_ptr"; fastforce)
+  done
+
+lemma equiv_asids_trivial[InfoFlow_IF_assms]:
+  "(\<And>x. P x \<Longrightarrow> False) \<Longrightarrow> equiv_asids P x y"
+  by (auto simp: equiv_asids_def)
+
+lemma equiv_asids_triv':
+  "\<lbrakk> equiv_asids R s s'; kheap t = kheap s; kheap t' = kheap s';
+     arm_asid_table (arch_state t) = arm_asid_table (arch_state s);
+     arm_asid_table (arch_state t') = arm_asid_table (arch_state s') \<rbrakk>
+     \<Longrightarrow> equiv_asids R t t'"
+  by (fastforce simp: equiv_asids_def equiv_asid equiv_asid'_def)
+
+lemma equiv_asids_triv[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_asids R s s'; kheap t = kheap s; kheap t' = kheap s';
+     arch_state t = arch_state s; arch_state t' = arch_state s' \<rbrakk>
+     \<Longrightarrow> equiv_asids R t t'"
+  by (fastforce simp: equiv_asids_triv')
+
+lemma globals_equiv_refl[InfoFlow_IF_assms]:
+  "globals_equiv s s"
+  by (simp add: globals_equiv_def idle_equiv_refl)
+
+lemma globals_equiv_sym[InfoFlow_IF_assms]:
+  "globals_equiv s t \<Longrightarrow> globals_equiv t s"
+  by (auto simp: globals_equiv_def idle_equiv_def)
+
+lemma globals_equiv_trans[InfoFlow_IF_assms]:
+  "\<lbrakk> globals_equiv s t; globals_equiv t u \<rbrakk> \<Longrightarrow> globals_equiv s u"
+  unfolding globals_equiv_def arch_globals_equiv_def
+  by clarsimp (metis idle_equiv_trans idle_equiv_def)
+
+lemma equiv_asids_guard_imp[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_asids R s s'; \<And>x. Q x \<Longrightarrow> R x \<rbrakk> \<Longrightarrow> equiv_asids Q s s'"
+  by (auto simp: equiv_asids_def)
+
+lemma dmo_loadWord_rev[InfoFlow_IF_assms]:
+  "reads_equiv_valid_inv A aag (K (for_each_byte_of_word (aag_can_read aag) p))
+                               (do_machine_op (loadWord p))"
+  apply (rule gen_asm_ev)
+  apply (rule use_spec_ev)
+  apply (rule spec_equiv_valid_hoist_guard)
+  apply (rule do_machine_op_spec_rev)
+   apply (simp add: loadWord_def equiv_valid_def2 spec_equiv_valid_def)
+   apply (rule_tac R'="\<lambda>rv rv'. for_each_byte_of_word (\<lambda>y. rv y = rv' y) p" and Q="\<top>\<top>" and Q'="\<top>\<top>"
+               and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
+        apply (rule_tac R'="(=)" and Q="\<lambda>r s. p && mask 2 = 0" and Q'="\<lambda>r s. p && mask 2 = 0"
+                    and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
+             apply (rule return_ev2)
+             apply (rule_tac f="word_rcat" in arg_cong)
+             apply (fastforce intro: is_aligned_no_wrap' word_plus_mono_right
+                               simp: is_aligned_mask for_each_byte_of_word_def word_size_def) (* slow *)
+            apply (rule assert_ev2[OF refl])
+           apply (rule assert_wp)+
+         apply simp+
+       apply (clarsimp simp: equiv_valid_2_def in_monad for_each_byte_of_word_def)
+       apply (erule equiv_forD)
+       apply fastforce
+      apply (wp wp_post_taut loadWord_inv | simp)+
+  done
+
+end
+
+
+global_interpretation InfoFlow_IF_1?: InfoFlow_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact InfoFlow_IF_assms)?)
+qed
+
+end

--- a/proof/infoflow/ARM/ArchInterrupt_IF.thy
+++ b/proof/infoflow/ARM/ArchInterrupt_IF.thy
@@ -1,0 +1,56 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchInterrupt_IF
+imports Interrupt_IF
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems Interrupt_IF_assms
+
+lemma arch_invoke_irq_handler_reads_respects[Interrupt_IF_assms, wp]:
+  "reads_respects_f aag l (silc_inv aag st) (arch_invoke_irq_handler irq)"
+  apply (cases irq; wpsimp)
+  apply (rule reads_respects_f[OF dmo_maskInterrupt_reads_respects, where Q=\<top>, simplified])
+  apply wpsimp
+  done
+
+lemma arch_invoke_irq_control_reads_respects[Interrupt_IF_assms]:
+  "reads_respects aag (l :: 'a subject_label) (K (arch_authorised_irq_ctl_inv aag i))
+                  (arch_invoke_irq_control i)"
+  apply (cases i)
+  apply (simp add: setIRQTrigger_def)
+  apply (wp cap_insert_reads_respects set_irq_state_reads_respects dmo_mol_reads_respects | simp)+
+  apply (clarsimp simp: arch_authorised_irq_ctl_inv_def)
+  done
+
+lemma arch_invoke_irq_control_globals_equiv[Interrupt_IF_assms]:
+  "\<lbrace>globals_equiv st and valid_ko_at_arch and valid_global_objs\<rbrace>
+   arch_invoke_irq_control ai
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  apply (induct ai)
+  apply (simp add: setIRQTrigger_def)
+  apply (wp set_irq_state_valid_ko_at_arch set_irq_state_globals_equiv
+            set_irq_state_valid_global_objs cap_insert_globals_equiv'' dmo_mol_globals_equiv
+         | simp)+
+  done
+
+lemma arch_invoke_irq_handler_globals_equiv[Interrupt_IF_assms, wp]:
+  "arch_invoke_irq_handler irq \<lbrace>globals_equiv st\<rbrace>"
+  by (cases irq; wpsimp wp: dmo_no_mem_globals_equiv simp: maskInterrupt_def)
+
+end
+
+
+global_interpretation Interrupt_IF_1?: Interrupt_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Interrupt_IF_assms)?)
+qed
+
+end

--- a/proof/infoflow/ARM/ArchInterrupt_IF.thy
+++ b/proof/infoflow/ARM/ArchInterrupt_IF.thy
@@ -29,14 +29,13 @@ lemma arch_invoke_irq_control_reads_respects[Interrupt_IF_assms]:
   done
 
 lemma arch_invoke_irq_control_globals_equiv[Interrupt_IF_assms]:
-  "\<lbrace>globals_equiv st and valid_ko_at_arch and valid_global_objs\<rbrace>
+  "\<lbrace>globals_equiv st and valid_arch_state and valid_global_objs\<rbrace>
    arch_invoke_irq_control ai
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (induct ai)
   apply (simp add: setIRQTrigger_def)
-  apply (wp set_irq_state_valid_ko_at_arch set_irq_state_globals_equiv
-            set_irq_state_valid_global_objs cap_insert_globals_equiv'' dmo_mol_globals_equiv
-         | simp)+
+  apply (wpsimp wp: set_irq_state_globals_equiv set_irq_state_valid_global_objs
+                    cap_insert_globals_equiv'' dmo_mol_globals_equiv)
   done
 
 lemma arch_invoke_irq_handler_globals_equiv[Interrupt_IF_assms, wp]:

--- a/proof/infoflow/ARM/ArchIpc_IF.thy
+++ b/proof/infoflow/ARM/ArchIpc_IF.thy
@@ -1,0 +1,471 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchIpc_IF
+imports Ipc_IF
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems Ipc_IF_assms
+
+lemma lookup_ipc_buffer_reads_respects[Ipc_IF_assms]:
+  "reads_respects aag l (K (aag_can_read aag thread \<or> aag_can_affect aag l thread))
+                  (lookup_ipc_buffer is_receiver thread)"
+  unfolding lookup_ipc_buffer_def
+  by (wp thread_get_reads_respects get_cap_reads_respects | wpc | simp)+
+
+lemma as_user_equiv_but_for_labels[Ipc_IF_assms]:
+  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L)\<rbrace>
+   as_user thread f
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding as_user_def
+  apply (wp set_object_equiv_but_for_labels | simp add: split_def)+
+  apply (blast dest: get_tcb_not_asid_pool_at)
+  done
+
+lemma storeWord_equiv_but_for_labels[Ipc_IF_assms]:
+  "\<lbrace>\<lambda>ms. equiv_but_for_labels aag L st (s\<lparr>machine_state := ms\<rparr>) \<and>
+         for_each_byte_of_word (\<lambda>x. pasObjectAbs aag x \<in> L) p\<rbrace>
+   storeWord p v
+   \<lbrace>\<lambda>_ ms. equiv_but_for_labels aag L st (s\<lparr>machine_state := ms\<rparr>)\<rbrace>"
+  unfolding storeWord_def
+  apply (wp modify_wp)
+  apply (clarsimp simp: equiv_but_for_labels_def)
+  apply (rule states_equiv_forI)
+           apply (fastforce intro!: equiv_forI elim!: states_equiv_forE dest: equiv_forD)
+          apply (simp add: states_equiv_for_def)
+          apply (rule conjI)
+           apply (rule equiv_forI)
+           apply clarsimp
+           apply (drule_tac f=underlying_memory in equiv_forD,fastforce)
+           apply (fastforce intro: is_aligned_no_wrap' word_plus_mono_right
+                             simp: is_aligned_mask for_each_byte_of_word_def word_size_def)
+          apply (rule equiv_forI)
+          apply clarsimp
+          apply (drule_tac f=device_state in equiv_forD,fastforce)
+          apply clarsimp
+         apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt])
+        apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=ekheap])
+       apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt_list])
+      apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=is_original_cap])
+     apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_states])
+    apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_irq_node])
+   apply (fastforce simp: equiv_asids_def equiv_asid_def elim: states_equiv_forE)
+  apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=ready_queues])
+  done
+
+lemma set_thread_state_runnable_equiv_but_for_labels[Ipc_IF_assms]:
+  "runnable tst
+   \<Longrightarrow> \<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L)\<rbrace>
+       set_thread_state thread tst
+       \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding set_thread_state_def
+  apply (wpsimp wp: set_object_equiv_but_for_labels[THEN hoare_set_object_weaken_pre]
+                    set_thread_state_ext_runnable_equiv_but_for_labels)
+    apply (wpsimp wp: set_object_wp)+
+  apply (fastforce dest: get_tcb_not_asid_pool_at simp: st_tcb_at_def obj_at_def)
+  done
+
+lemma set_endpoint_equiv_but_for_labels[Ipc_IF_assms]:
+  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag epptr \<in> L)\<rbrace>
+   set_endpoint epptr ep
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding set_simple_ko_def
+  apply (wp set_object_equiv_but_for_labels get_object_wp)
+  apply (clarsimp simp: asid_pool_at_kheap partial_inv_def obj_at_def split: kernel_object.splits)
+  done
+
+(* FIXME move *)
+lemma conj_imp:
+  "\<lbrakk> Q \<longrightarrow> R; P \<longrightarrow> Q; P' \<longrightarrow> Q \<rbrakk> \<Longrightarrow> (P \<longrightarrow> R) \<and> (P' \<longrightarrow> R)"
+  by fastforce
+
+(* basically clagged directly from lookup_ipc_buffer_has_auth *)
+lemma lookup_ipc_buffer_has_read_auth[Ipc_IF_assms]:
+  "\<lbrace>pas_refined aag and valid_objs\<rbrace>
+   lookup_ipc_buffer is_receiver thread
+   \<lbrace>\<lambda>rv s. ipc_buffer_has_read_auth aag (pasObjectAbs aag thread) rv\<rbrace>"
+  apply (rule hoare_pre)
+   apply (simp add: lookup_ipc_buffer_def)
+   apply (wp get_cap_wp thread_get_wp' | wpc)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state ipc_buffer_has_read_auth_def get_tcb_ko_at[symmetric])
+  apply (frule caps_of_state_tcb_cap_cases [where idx = "tcb_cnode_index 4"])
+   apply (simp add: dom_tcb_cap_cases)
+  apply (frule (1) caps_of_state_valid_cap)
+  apply (clarsimp simp: vm_read_only_def vm_read_write_def)
+  apply (rule_tac Q="AllowRead \<in> xc" in conj_imp)
+    apply (clarsimp simp: valid_cap_simps cap_aligned_def)
+    apply (rule conjI)
+     apply (erule aligned_add_aligned)
+      apply (rule is_aligned_andI1)
+      apply (drule (1) valid_tcb_objs)
+      apply (clarsimp simp: valid_obj_def valid_tcb_def valid_ipc_buffer_cap_def
+                     split: if_splits)
+     apply (rule order_trans [OF _ pbfs_atleast_pageBits])
+     apply (simp add: msg_align_bits pageBits_def)
+    apply (drule (1) cap_auth_caps_of_state)
+    apply (clarsimp simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def
+                          vspace_cap_rights_to_auth_def vm_read_only_def)
+    apply (drule bspec)
+     apply (erule (3) ipcframe_subset_page)
+    apply (clarsimp split: if_split_asm simp: vspace_cap_rights_to_auth_def is_page_cap_def)
+   apply (simp_all)
+  done
+
+lemma cptrs_in_ipc_buffer[Ipc_IF_assms]:
+  "\<lbrakk> n \<in> set [buffer_cptr_index ..< buffer_cptr_index + unat (mi_extra_caps mi)];
+     is_aligned (p :: obj_ref) msg_align_bits;
+     buffer_cptr_index + unat (mi_extra_caps mi) < 2 ^ (msg_align_bits - word_size_bits) \<rbrakk>
+     \<Longrightarrow> ptr_range (p + of_nat n * of_nat word_size) word_size_bits \<subseteq> ptr_range p msg_align_bits"
+  apply (rule ptr_range_subset)
+     apply assumption
+    apply (simp add: msg_align_bits')
+   apply (simp add: msg_align_bits' word_size_bits_def word_bits_def)
+  apply (simp add: word_size_def)
+  apply (subst upto_enum_step_shift_red[where us=2, simplified])
+     apply (simp add: msg_align_bits' word_bits_def word_size_bits_def)+
+  done
+
+lemma msg_in_ipc_buffer[Ipc_IF_assms]:
+  "\<lbrakk> n = msg_max_length \<or> n < msg_max_length;  is_aligned p msg_align_bits;
+     unat (mi_length mi) < 2 ^ (msg_align_bits - word_size_bits) \<rbrakk>
+     \<Longrightarrow> ptr_range (p + of_nat n * of_nat word_size) word_size_bits
+         \<subseteq> ptr_range (p :: obj_ref) msg_align_bits"
+  apply (rule ptr_range_subset)
+     apply assumption
+    apply (simp add: msg_align_bits')
+   apply (simp add: msg_align_bits word_bits_def)
+  apply (simp add: word_size_def)
+  apply (subst upto_enum_step_shift_red[where us=2, simplified])
+     apply (simp add: msg_align_bits word_bits_def)+
+  apply (simp add: image_def)
+  apply (rule_tac x=n in bexI)
+   apply (rule refl)
+  apply (auto simp: msg_max_length_def)
+  done
+
+lemma arch_derive_cap_reads_respects[Ipc_IF_assms]:
+  "reads_respects aag l \<top> (arch_derive_cap cap)"
+  unfolding arch_derive_cap_def
+  apply (rule equiv_valid_guard_imp)
+   apply (wp | wpc)+
+  apply (simp)
+  done
+
+lemma arch_derive_cap_rev[Ipc_IF_assms]:
+  "reads_equiv_valid_inv aag l \<top> (arch_derive_cap cap)"
+  unfolding arch_derive_cap_def
+  apply (rule equiv_valid_guard_imp)
+   apply (wp | wpc)+
+  apply (simp)
+  done
+
+lemma captransfer_in_ipc_buffer[Ipc_IF_assms]:
+  "\<lbrakk> is_aligned (buf :: obj_ref) msg_align_bits; n \<in> {0..2} \<rbrakk>
+     \<Longrightarrow> ptr_range (buf + (2 + (of_nat msg_max_length + of_nat msg_max_extra_caps)) * word_size
+                                                                                    + n * word_size)
+                   word_size_bits
+         \<subseteq> ptr_range buf msg_align_bits"
+  apply (rule ptr_range_subset)
+     apply assumption
+    apply (simp add: msg_align_bits')
+   apply (simp add: msg_align_bits word_bits_def)
+  apply (simp add: word_size_def)
+  apply (subst upto_enum_step_shift_red[where us=2, simplified])
+     apply (simp add: msg_align_bits word_bits_def)+
+  apply (simp add: image_def msg_max_length_def msg_max_extra_caps_def)
+  apply (rule_tac x="(125::nat) + unat n"  in bexI)
+   apply simp+
+  apply (fastforce intro: unat_less_helper word_leq_minus_one_le)
+  done
+
+lemma mrs_in_ipc_buffer[Ipc_IF_assms]:
+  "\<lbrakk> n \<in> set [length msg_registers + 1 ..< Suc n'];
+     is_aligned (buf :: obj_ref) msg_align_bits; n' < 2 ^ (msg_align_bits - word_size_bits) \<rbrakk>
+     \<Longrightarrow> ptr_range (buf + of_nat n * of_nat word_size) word_size_bits \<subseteq> ptr_range buf msg_align_bits"
+  apply (rule ptr_range_subset)
+     apply assumption
+    apply (simp add: msg_align_bits')
+   apply (simp add: msg_align_bits word_bits_def)
+  apply (simp add: word_size_def)
+  apply (subst upto_enum_step_shift_red[where us=2, simplified])
+     apply (simp add: msg_align_bits word_bits_def word_size_bits_def)+
+  apply (simp add: image_def)
+  apply (rule_tac x=n in bexI)
+   apply (rule refl)
+  apply (fastforce split: if_split_asm)
+  done
+
+lemma dmo_loadWord_reads_respects[Ipc_IF_assms]:
+  "reads_respects aag l (K (for_each_byte_of_word (\<lambda> x. aag_can_read_or_affect aag l x) p))
+                  (do_machine_op (loadWord p))"
+  apply (rule gen_asm_ev)
+  apply (rule use_spec_ev)
+  apply (rule spec_equiv_valid_hoist_guard)
+  apply (rule do_machine_op_spec_reads_respects)
+   apply (simp add: loadWord_def equiv_valid_def2 spec_equiv_valid_def)
+   apply (rule_tac R'="\<lambda>rv rv'. for_each_byte_of_word (\<lambda>y. rv y = rv' y) p"
+               and Q="\<top>\<top>" and Q'="\<top>\<top>" and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
+        apply (rule_tac R'="(=)" and Q="\<lambda> r s. p && mask 2 = 0" and Q'="\<lambda> r s. p && mask 2 = 0"
+                    and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
+             apply (rule return_ev2)
+             apply (rule_tac f="word_rcat" in arg_cong)
+             apply (fastforce intro: is_aligned_no_wrap' word_plus_mono_right
+                               simp: is_aligned_mask for_each_byte_of_word_def word_size_def) (* slow *)
+            apply (rule assert_ev2[OF refl])
+           apply (rule assert_wp)+
+         apply simp+
+       apply (clarsimp simp: equiv_valid_2_def in_monad for_each_byte_of_word_def)
+       apply (fastforce elim: equiv_forD orthD1 simp: ptr_range_def add.commute)
+      apply (wp wp_post_taut loadWord_inv | simp)+
+  done
+
+lemma complete_signal_reads_respects[Ipc_IF_assms]:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects aag l (K (aag_can_read aag ntfnptr \<or> aag_can_affect aag l ntfnptr))
+                        (complete_signal ntfnptr receiver)"
+  unfolding complete_signal_def
+  by (wp set_simple_ko_reads_respects get_simple_ko_reads_respects as_user_set_register_reads_respects'
+      | wpc | simp)+
+
+lemma handle_arch_fault_reply_reads_respects[Ipc_IF_assms, wp]:
+  "reads_respects aag l (K (aag_can_read aag thread)) (handle_arch_fault_reply afault thread x y)"
+  by (simp add: handle_arch_fault_reply_def, wp)
+
+lemma arch_get_sanitise_register_info_reads_respects[Ipc_IF_assms, wp]:
+  "reads_respects aag l \<top> (arch_get_sanitise_register_info t)"
+  by wpsimp
+
+declare arch_get_sanitise_register_info_inv[Ipc_IF_assms]
+
+crunches handle_arch_fault_reply
+  for arch_get_sanitise_register_info[Ipc_IF_assms, wp]: "valid_ko_at_arch"
+
+lemma lookup_ipc_buffer_ptr_range'[Ipc_IF_assms]:
+  "\<lbrace>valid_objs\<rbrace>
+   lookup_ipc_buffer True thread
+   \<lbrace>\<lambda>rv s. rv = Some buf' \<longrightarrow> auth_ipc_buffers s thread = ptr_range buf' msg_align_bits\<rbrace>"
+  unfolding lookup_ipc_buffer_def
+  apply (rule hoare_pre)
+   apply (wp get_cap_wp thread_get_wp' | wpc)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state ipc_buffer_has_auth_def get_tcb_ko_at [symmetric])
+  apply (frule caps_of_state_tcb_cap_cases [where idx = "tcb_cnode_index 4"])
+   apply (simp add: dom_tcb_cap_cases)
+  apply (clarsimp simp: auth_ipc_buffers_def get_tcb_ko_at [symmetric])
+  apply (drule(1) valid_tcb_objs)
+  apply (drule get_tcb_SomeD)+
+  apply (simp add: vm_read_write_def valid_tcb_def valid_ipc_buffer_cap_def split: bool.splits)
+  done
+
+lemma lookup_ipc_buffer_aligned'[Ipc_IF_assms]:
+  "\<lbrace>valid_objs\<rbrace>
+   lookup_ipc_buffer True thread
+   \<lbrace>\<lambda>rv s. rv = Some buf' \<longrightarrow> is_aligned buf' msg_align_bits\<rbrace>"
+  apply (insert lookup_ipc_buffer_aligned)
+  apply (fastforce simp: valid_def)
+  done
+
+lemma handle_arch_fault_reply_globals_equiv[Ipc_IF_assms]:
+  "\<lbrace>globals_equiv st and valid_ko_at_arch and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
+   handle_arch_fault_reply vmf thread x y
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  by (wpsimp simp: handle_arch_fault_reply_def)+
+
+crunches arch_get_sanitise_register_info, handle_arch_fault_reply
+  for valid_global_objs[Ipc_IF_assms, wp]: "valid_global_objs"
+
+end
+
+
+global_interpretation Ipc_IF_1?: Ipc_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Ipc_IF_assms)?)
+qed
+
+
+context Arch begin global_naming ARM
+
+lemma copy_mrs_reads_respects[Ipc_IF_assms]:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows
+  "reads_respects aag (l :: 'a subject_label)
+     (K (aag_can_read_or_affect aag l sender \<and> aag_can_read_or_affect_ipc_buffer aag l sbuf
+                                             \<and> unat n < 2 ^ (msg_align_bits - word_size_bits)))
+     (copy_mrs sender sbuf receiver rbuf n)"
+  unfolding copy_mrs_def fun_app_def
+  apply (rule gen_asm_ev)
+  apply (wp mapM_ev'' store_word_offs_reads_respects load_word_offs_reads_respects
+            as_user_set_register_reads_respects' as_user_reads_respects
+         | wpc
+         | simp add: det_setRegister det_getRegister split del: if_split)+
+  apply clarsimp
+  apply (rename_tac n')
+  apply (subgoal_tac "ptr_range (x + of_nat n' * of_nat word_size) word_size_bits
+                      \<subseteq> ptr_range x msg_align_bits")
+   apply (simp add: for_each_byte_of_word_def2)
+   apply (simp add: aag_can_read_or_affect_ipc_buffer_def)
+   apply (erule conjE)
+   apply (rule ballI)
+   apply (erule bspec)
+   apply (erule (1) subsetD[rotated])
+  apply (rule ptr_range_subset)
+     apply (simp add: aag_can_read_or_affect_ipc_buffer_def)
+    apply (simp add: msg_align_bits')
+   apply (simp add: msg_align_bits word_bits_def)
+  apply (simp add: word_size_def word_size_bits_def)
+  apply (subst upto_enum_step_shift_red[where us=2, simplified])
+     apply (simp add: msg_align_bits word_bits_def aag_can_read_or_affect_ipc_buffer_def )+
+  apply (fastforce simp: image_def)
+  done
+
+lemma get_message_info_reads_respects[Ipc_IF_assms]:
+  "reads_respects aag (l :: 'a subject_label) (K (aag_can_read_or_affect aag l ptr)) (get_message_info ptr)"
+  apply (simp add: get_message_info_def)
+  apply (wp as_user_reads_respects | clarsimp simp: getRegister_def)+
+  done
+
+lemma do_normal_transfer_reads_respects[Ipc_IF_assms]:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows
+  "reads_respects aag (l :: 'a subject_label)
+     (pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
+                      and valid_mdb and valid_objs
+                      and K (aag_can_read_or_affect aag l sender \<and>
+                             ipc_buffer_has_read_auth aag (pasObjectAbs aag sender) sbuf \<and>
+                             ipc_buffer_has_read_auth aag (pasObjectAbs aag receiver) rbuf \<and>
+                             (grant \<longrightarrow> (is_subject aag sender \<and> is_subject aag receiver))))
+     (do_normal_transfer sender sbuf endpoint badge grant receiver rbuf)"
+  apply (cases grant)
+   apply (rule gen_asm_ev)
+   apply (simp add: do_normal_transfer_def)
+   apply (wp copy_mrs_pas_refined get_message_info_rev lookup_extra_caps_rev
+             as_user_set_register_reads_respects' set_message_info_reads_respects
+             transfer_caps_reads_respects copy_mrs_reads_respects lookup_extra_caps_rev
+             lookup_extra_caps_authorised lookup_extra_caps_auth get_message_info_rev
+             get_mi_length' get_mi_length validE_E_wp_post_taut
+             copy_mrs_cte_wp_at hoare_vcg_ball_lift lec_valid_cap'
+             lookup_extra_caps_srcs[simplified ball_conj_distrib,THEN hoare_conjDR1]
+             lookup_extra_caps_srcs[simplified ball_conj_distrib,THEN hoare_conjDR2]
+          | wpc
+          | simp add: det_setRegister ball_conj_distrib)+
+   apply (fastforce intro: aag_has_read_auth_can_read_or_affect_ipc_buffer)
+  apply (rule gen_asm_ev)
+  apply (simp add: do_normal_transfer_def transfer_caps_def)
+  apply (wp ev_irrelevant_bind[where f="get_receive_slots receiver rbuf"]
+            as_user_set_register_reads_respects'
+            set_message_info_reads_respects copy_mrs_reads_respects
+            get_message_info_reads_respects get_mi_length
+         | wpc
+         | simp)+
+  apply (auto simp: ipc_buffer_has_read_auth_def aag_can_read_or_affect_ipc_buffer_def
+               dest: reads_read_thread_read_pages split: option.splits)
+  done
+
+lemma make_arch_fault_msg_reads_respects[Ipc_IF_assms]:
+  "reads_respects aag (l :: 'a subject_label) (\<lambda>y. aag_can_read_or_affect aag l sender)
+                  (make_arch_fault_msg x4 sender)"
+  apply (case_tac x4)
+  apply (wp as_user_reads_respects | simp add: det_getRegister det_getRestartPC)+
+  done
+
+lemma set_mrs_equiv_but_for_labels[Ipc_IF_assms]:
+  "\<lbrace>equiv_but_for_labels (aag :: 'a subject_label PAS) L st and
+    K (pasObjectAbs aag thread \<in> L \<and>
+       (case buf of (Some buf') \<Rightarrow> is_aligned buf' msg_align_bits \<and>
+                                   (\<forall>x \<in> ptr_range buf' msg_align_bits. pasObjectAbs aag x \<in> L)
+                            | _ \<Rightarrow> True))\<rbrace>
+   set_mrs thread buf msgs
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding set_mrs_def
+  apply (wp | wpc)+
+        apply (subst zipWithM_x_mapM_x)
+        apply (rule_tac Q="\<lambda>_. equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L  \<and>
+                               (case buf of (Some buf') \<Rightarrow> is_aligned buf' msg_align_bits \<and>
+                                                           (\<forall>x \<in> ptr_range buf' msg_align_bits.
+                                                              pasObjectAbs aag x \<in> L)
+                                                    | _ \<Rightarrow> True))" in hoare_strengthen_post)
+         apply (wp mapM_x_wp' store_word_offs_equiv_but_for_labels | simp add: split_def)+
+         apply (case_tac xa, clarsimp split: if_split_asm elim!: in_set_zipE)
+         apply (clarsimp simp: for_each_byte_of_word_def)
+         apply (erule bspec)
+         apply (clarsimp simp: ptr_range_def)
+         apply (rule conjI)
+          apply (erule order_trans[rotated])
+          apply (erule is_aligned_no_wrap')
+          apply (rule mul_word_size_lt_msg_align_bits_ofnat)
+          apply (fastforce simp: msg_max_length_def msg_align_bits')
+         apply (erule order_trans)
+         apply (subst p_assoc_help)
+         apply (simp add: add.assoc)
+         apply (rule word_plus_mono_right)
+          apply (rule word_less_sub_1)
+          apply (rule_tac y="of_nat msg_max_length * of_nat word_size + (word_size - 1)"
+                       in le_less_trans)
+           apply (rule word_plus_mono_left)
+            apply (rule word_mult_le_mono1)
+              apply (erule disjE)
+               apply (rule word_of_nat_le)
+               apply (simp add: msg_max_length_def)
+              apply clarsimp
+              apply (rule word_of_nat_le)
+              apply (simp add: msg_max_length_def)
+             apply (simp add: word_size_def)
+            apply (simp add: msg_max_length_def word_size_def)
+           apply (simp add: msg_max_length_def word_size_def)
+          apply (rule mul_add_word_size_lt_msg_align_bits_ofnat)
+           apply (simp add: msg_max_length_def msg_align_bits')
+          apply (simp add: word_size_def)
+         apply (erule is_aligned_no_overflow')
+        apply simp
+       apply (wp set_object_equiv_but_for_labels hoare_vcg_all_lift static_imp_wp | simp)+
+  apply (fastforce dest: get_tcb_not_asid_pool_at)+
+  done
+
+lemma set_mrs_reads_respects'[Ipc_IF_assms]:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows
+    "reads_respects aag (l :: 'a subject_label)
+       (K (ipc_buffer_has_auth aag thread buf \<and>
+           (case buf of (Some buf') \<Rightarrow> is_aligned buf' msg_align_bits | _ \<Rightarrow> True)))
+       (set_mrs thread buf msgs)"
+  apply (case_tac "aag_can_read_or_affect aag l thread")
+   apply ((wp equiv_valid_guard_imp[OF set_mrs_reads_respects] | simp)+)[1]
+  apply (rule gen_asm_ev)
+  apply (simp add: equiv_valid_def2)
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (case_tac buf)
+    apply (rule_tac Q="\<top>" and P="\<top>" and L="{pasObjectAbs aag thread}" in ev_invisible[OF domains_distinct])
+      apply (clarsimp simp: labels_are_invisible_def)
+     apply (rule modifies_at_mostI)
+     apply (simp add: set_mrs_def)
+     apply ((wp set_object_equiv_but_for_labels | simp | auto dest: get_tcb_not_asid_pool_at)+)[1]
+    apply (simp)
+    apply (rule set_mrs_ret_eq)
+   apply (rename_tac buf')
+   apply (rule_tac Q="\<top>" and L="{pasObjectAbs aag thread} \<union> (pasObjectAbs aag)
+                                 ` (ptr_range buf' msg_align_bits)"
+                in ev_invisible[OF domains_distinct])
+     apply (auto simp: labels_are_invisible_def ipc_buffer_has_auth_def
+                 dest: reads_read_page_read_thread simp: aag_can_affect_label_def)[1]
+    apply (rule modifies_at_mostI)
+    apply (wp set_mrs_equiv_but_for_labels | simp)+
+   apply (rule set_mrs_ret_eq)
+  by simp
+
+end
+
+
+global_interpretation Ipc_IF_2?: Ipc_IF_2
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Ipc_IF_assms)?)
+qed
+
+end

--- a/proof/infoflow/ARM/ArchIpc_IF.thy
+++ b/proof/infoflow/ARM/ArchIpc_IF.thy
@@ -242,9 +242,6 @@ lemma arch_get_sanitise_register_info_reads_respects[Ipc_IF_assms, wp]:
 
 declare arch_get_sanitise_register_info_inv[Ipc_IF_assms]
 
-crunches handle_arch_fault_reply
-  for arch_get_sanitise_register_info[Ipc_IF_assms, wp]: "valid_ko_at_arch"
-
 lemma lookup_ipc_buffer_ptr_range'[Ipc_IF_assms]:
   "\<lbrace>valid_objs\<rbrace>
    lookup_ipc_buffer True thread
@@ -270,7 +267,7 @@ lemma lookup_ipc_buffer_aligned'[Ipc_IF_assms]:
   done
 
 lemma handle_arch_fault_reply_globals_equiv[Ipc_IF_assms]:
-  "\<lbrace>globals_equiv st and valid_ko_at_arch and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
+  "\<lbrace>globals_equiv st and valid_arch_state and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
    handle_arch_fault_reply vmf thread x y
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   by (wpsimp simp: handle_arch_fault_reply_def)+

--- a/proof/infoflow/ARM/ArchNoninterference.thy
+++ b/proof/infoflow/ARM/ArchNoninterference.thy
@@ -1,0 +1,337 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchNoninterference
+imports Noninterference
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems Noninterference_assms
+
+lemma globals_equiv_to_exclusive_state_equiv:
+  "globals_equiv s t \<Longrightarrow> cur_thread s \<noteq> idle_thread t \<Longrightarrow> exclusive_state_equiv s t"
+  by (simp add: globals_equiv_def idle_equiv_def)
+
+(* clagged straight from ADT_AC.do_user_op_respects *)
+lemma do_user_op_if_integrity[Noninterference_assms]:
+  "\<lbrace>invs and integrity aag X st and is_subject aag \<circ> cur_thread and pas_refined aag\<rbrace>
+   do_user_op_if uop tc
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  apply (simp add: do_user_op_if_def)
+  apply (wpsimp wp: dmo_user_memory_update_respects_Write dmo_device_update_respects_Write
+                    hoare_vcg_all_lift hoare_vcg_imp_lift)
+             apply (rule hoare_pre_cont)
+            apply (wp select_wp | wpc | clarsimp)+
+  apply (rule conjI)
+   apply clarsimp
+   apply (simp add: restrict_map_def ptable_lift_s_def ptable_rights_s_def split: if_splits)
+   apply (drule_tac auth=Write in user_op_access')
+       apply (simp add: vspace_cap_rights_to_auth_def)+
+  apply clarsimp
+  apply (simp add: restrict_map_def ptable_lift_s_def ptable_rights_s_def split: if_splits)
+  apply (drule_tac auth=Write in user_op_access')
+      apply (simp add: vspace_cap_rights_to_auth_def)+
+  done
+
+lemma globals_equiv_scheduler_exclusive_state_update[simp]:
+  "globals_equiv_scheduler st (s\<lparr>machine_state := machine_state s\<lparr>exclusive_state := es\<rparr>\<rparr>) =
+   globals_equiv_scheduler st s"
+  by (simp add: globals_equiv_scheduler_def)
+
+lemma silc_dom_equiv_exclusive_state_update[simp]:
+  "silc_dom_equiv aag st (s\<lparr>machine_state := machine_state s\<lparr>exclusive_state := es\<rparr>\<rparr>) =
+   silc_dom_equiv aag st s"
+  by (simp add: silc_dom_equiv_def equiv_for_def)
+
+lemma do_user_op_if_globals_equiv_scheduler[Noninterference_assms]:
+  "\<lbrace>globals_equiv_scheduler st and invs\<rbrace>
+   do_user_op_if tc uop
+   \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
+  apply (simp add: do_user_op_if_def)
+  apply (wpsimp wp: dmo_user_memory_update_globals_equiv_scheduler
+                    dmo_device_memory_update_globals_equiv_scheduler select_wp)+
+  apply (auto simp: ptable_lift_s_def ptable_rights_s_def)
+  done
+
+crunch silc_dom_equiv[Noninterference_assms, wp]: do_user_op_if "silc_dom_equiv aag st"
+  (ignore: do_machine_op user_memory_update wp: crunch_wps select_wp)
+
+lemma sameFor_scheduler_affects_equiv[Noninterference_assms]:
+  "\<lbrakk> (s,s') \<in> same_for aag PSched; (s,s') \<in> same_for aag (Partition l);
+     invs (internal_state_if s); invs (internal_state_if s') \<rbrakk>
+     \<Longrightarrow> scheduler_equiv aag (internal_state_if s) (internal_state_if s') \<and>
+         scheduler_affects_equiv aag (OrdinaryLabel l) (internal_state_if s) (internal_state_if s')"
+  apply (rule conjI)
+   apply (blast intro: sameFor_scheduler_equiv)
+  apply (clarsimp simp: scheduler_affects_equiv_def arch_scheduler_affects_equiv_def
+                        sameFor_def silc_dom_equiv_def reads_scheduler_def
+                        sameFor_scheduler_def globals_equiv_to_exclusive_state_equiv)
+  (* simplifying using sameFor_subject_def in assumptions causes simp to loop *)
+  apply (simp (no_asm_use) add: sameFor_subject_def disjoint_iff_not_equal Bex_def)
+  apply (blast intro: globals_equiv_to_scheduler_globals_frame_equiv
+                      globals_equiv_to_exclusive_state_equiv globals_equiv_to_cur_thread_eq)
+  done
+
+lemma do_user_op_if_partitionIntegrity[Noninterference_assms]:
+  "\<lbrace>partitionIntegrity aag st and pas_refined aag and invs and is_subject aag \<circ> cur_thread\<rbrace>
+   do_user_op_if tc uop
+   \<lbrace>\<lambda>_. partitionIntegrity aag st\<rbrace>"
+ apply (rule_tac Q="\<lambda>rv s. integrity (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+                                     (scheduler_affects_globals_frame st) st s \<and>
+                           domain_fields_equiv st s \<and> idle_thread s = idle_thread st \<and>
+                           globals_equiv_scheduler st s \<and> silc_dom_equiv aag st s"
+              in hoare_strengthen_post)
+   apply (wp hoare_vcg_conj_lift do_user_op_if_integrity do_user_op_if_globals_equiv_scheduler
+             hoare_vcg_all_lift domain_fields_equiv_lift[where Q="\<top>" and R="\<top>"] | simp)+
+  apply (clarsimp simp: partitionIntegrity_def)+
+  done
+
+lemma arch_activate_idle_thread_reads_respects_g[Noninterference_assms, wp]:
+  "reads_respects_g aag l \<top> (arch_activate_idle_thread t)"
+  unfolding arch_activate_idle_thread_def by wpsimp
+
+definition arch_globals_equiv_strengthener :: "machine_state \<Rightarrow> machine_state \<Rightarrow> bool" where
+  "arch_globals_equiv_strengthener ms ms' \<equiv> exclusive_state ms = exclusive_state ms'"
+
+declare arch_globals_equiv_strengthener_def[simp]
+
+lemma arch_globals_equiv_strengthener_thread_independent[Noninterference_assms]:
+  "arch_globals_equiv_strengthener (machine_state s) (machine_state s')
+   \<Longrightarrow> \<forall>ct ct' it it'. arch_globals_equiv ct it (kheap s) (kheap s')
+                         (arch_state s) (arch_state s') (machine_state s) (machine_state s') =
+                       arch_globals_equiv ct' it' (kheap s) (kheap s')
+                         (arch_state s) (arch_state s') (machine_state s) (machine_state s')"
+  by auto
+
+lemma owns_mapping_owns_asidpool:
+  "\<lbrakk> kheap s p = Some (ArchObj (ASIDPool pool)); pool r = Some p'; pas_refined aag s;
+     is_subject aag p'; pas_wellformed (aag\<lparr>pasSubject := (pasObjectAbs aag p)\<rparr>) \<rbrakk>
+     \<Longrightarrow> is_subject aag p"
+  apply (frule asid_pool_into_aag)
+    apply assumption+
+  apply (drule pas_wellformed_pasSubject_update_Control)
+   apply assumption
+  apply simp
+  done
+
+lemma partitionIntegrity_subjectAffects_aobj[Noninterference_assms]:
+  "\<lbrakk> kheap s x = Some (ArchObj ao); ao \<noteq> ao'; pas_refined aag s;
+     silc_inv aag st s; pas_wellformed_noninterference aag;
+     arch_integrity_obj_atomic (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+                               {pasSubject aag} (pasObjectAbs aag x) ao ao' \<rbrakk>
+     \<Longrightarrow> subject_can_affect_label_directly aag (pasObjectAbs aag x)"
+  unfolding arch_integrity_obj_atomic.simps asid_pool_integrity_def
+  apply clarsimp
+  apply (rule ccontr)
+  apply (drule fun_noteqD)
+  apply (erule exE, rename_tac r)
+  apply (drule_tac x=r in spec)
+  apply (clarsimp dest!: not_sym[where t=None])
+  apply (subgoal_tac "is_subject aag x", force intro: affects_lrefl)
+  apply (frule (1) aag_Control_into_owns)
+  apply (frule (2) asid_pool_into_aag)
+  apply simp
+  apply (frule (1) pas_wellformed_noninterference_control_to_eq)
+  by (fastforce elim!: silc_inv_cnode_onlyE obj_atE simp: is_cap_table_def)
+
+lemma partitionIntegrity_subjectAffects_asid[Noninterference_assms]:
+  "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s; valid_objs s;
+     valid_arch_state s; valid_arch_state s'; pas_wellformed_noninterference aag;
+     silc_inv aag st s'; invs s'; \<not> equiv_asids (\<lambda>x. pasASIDAbs aag x = a) s s' \<rbrakk>
+     \<Longrightarrow> a \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  apply (clarsimp simp: equiv_asids_def equiv_asid_def asid_pool_at_kheap)
+  apply (case_tac "arm_asid_table (arch_state s) (asid_high_bits_of asid) =
+                   arm_asid_table (arch_state s') (asid_high_bits_of asid)")
+   apply (clarsimp simp: valid_arch_state_def valid_asid_table_def)
+   apply (drule_tac x=pool_ptr in bspec)
+    apply blast
+   apply (drule_tac x=pool_ptr in bspec)
+    apply blast
+   apply (clarsimp simp: asid_pool_at_kheap)
+   apply (rule affects_asidpool_map)
+   apply (rule pas_refined_asid_mem)
+    apply (drule partitionIntegrity_integrity)
+    apply (drule integrity_subjects_obj)
+    apply (drule_tac x="pool_ptr" in spec)+
+    apply (drule tro_tro_alt, erule integrity_obj_alt.cases;simp )
+     apply (drule_tac t="pasSubject aag" in sym)
+     apply simp
+     apply (rule sata_asidpool)
+      apply assumption
+     apply assumption
+    apply (simp add: arch_integrity_obj_alt.simps asid_pool_integrity_def)
+    apply (drule_tac x="ucast asid" in spec)+
+    apply clarsimp
+    apply (drule owns_mapping_owns_asidpool)
+        apply ((simp | blast intro: pas_refined_Control[THEN sym]
+                     | fastforce intro: pas_wellformed_pasSubject_update[simplified])+)[4]
+    apply (drule_tac t="pasSubject aag" in sym)+
+    apply simp
+    apply (rule sata_asidpool)
+     apply assumption
+    apply assumption
+   apply assumption
+  apply clarsimp
+  apply (drule partitionIntegrity_integrity)
+  apply (clarsimp simp: integrity_def)
+  apply (drule_tac x=asid in spec)+
+  apply (clarsimp simp: integrity_asids_def)
+  apply (fastforce intro: affects_lrefl)
+  done
+
+(* clagged mostly from Scheduler_IF.dmo_storeWord_reads_respects_scheduler *)
+lemma dmo_storeWord_reads_respects_g[Noninterference_assms, wp]:
+  "reads_respects_g aag l \<top> (do_machine_op (storeWord ptr w))"
+  apply (clarsimp simp: do_machine_op_def bind_def gets_def get_def return_def fail_def
+                        select_f_def storeWord_def assert_def simpler_modify_def)
+  apply (fold simpler_modify_def)
+  apply (intro impI conjI)
+   apply (rule ev_modify)
+   apply (rule conjI)
+    apply (fastforce simp: reads_equiv_g_def globals_equiv_def reads_equiv_def2 states_equiv_for_def
+                           equiv_for_def equiv_asids_def equiv_asid_def silc_dom_equiv_def)
+   apply (rule affects_equiv_machine_state_update, assumption)
+   apply (fastforce simp: equiv_for_def affects_equiv_def states_equiv_for_def)
+  apply (simp add: equiv_valid_def2 equiv_valid_2_def)
+  done
+
+lemmas set_vm_root_reads_respects_g[wp] =
+  reads_respects_g[OF set_vm_root_reads_respects,
+                   OF doesnt_touch_globalsI[where P="\<top>"],
+                   simplified,
+                   OF set_vm_root_globals_equiv]
+
+lemma dmo_clearExMonitor_reads_respects_g':
+  "equiv_valid (reads_equiv_g aag) (affects_equiv aag l)
+               (\<lambda>s s'. affects_equiv aag l s s' \<and> exclusive_state_equiv s s') \<top>
+               (do_machine_op clearExMonitor)"
+  apply (simp add: clearExMonitor_def)
+  apply (wp dmo_ev ev_modify)
+  apply (simp add: reads_equiv_g_def reads_equiv_def2 affects_equiv_def2 globals_equiv_def
+                   idle_equiv_def states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def)
+  apply metis
+  done
+
+lemma arch_switch_to_thread_reads_respects_g'[Noninterference_assms]:
+  "equiv_valid (reads_equiv_g aag) (affects_equiv aag l)
+               (\<lambda>s s'. affects_equiv aag l s s' \<and>
+                       arch_globals_equiv_strengthener (machine_state s) (machine_state s'))
+               (\<lambda>s. is_subject aag t)
+               (arch_switch_to_thread t)"
+  apply (simp add: arch_switch_to_thread_def)
+  apply (rule equiv_valid_guard_imp)
+  by (wp bind_ev_general dmo_clearExMonitor_reads_respects_g' thread_get_reads_respects_g | simp)+
+
+(* consider rewriting the return-value assumption using equiv_valid_rv_inv *)
+lemma ev2_invisible'[Noninterference_assms]:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows
+    "\<lbrakk> labels_are_invisible aag l L; labels_are_invisible aag l L';
+       modifies_at_most aag L Q f; modifies_at_most aag L' Q' g;
+       doesnt_touch_globals Q f; doesnt_touch_globals Q' g;
+       \<And>st :: det_state. f \<lbrace>\<lambda>s. arch_globals_equiv_strengthener (machine_state st) (machine_state s)\<rbrace>;
+       \<And>st :: det_state. g \<lbrace>\<lambda>s. arch_globals_equiv_strengthener (machine_state st) (machine_state s)\<rbrace>;
+       \<forall>s t. P s \<and> P' t \<longrightarrow> (\<forall>(rva,s') \<in> fst (f s). \<forall>(rvb,t') \<in> fst (g t). W rva rvb) \<rbrakk>
+       \<Longrightarrow> equiv_valid_2 (reads_equiv_g aag)
+                         (\<lambda>s s'. affects_equiv aag l s s' \<and>
+                                 arch_globals_equiv_strengthener (machine_state s) (machine_state s'))
+                         (\<lambda>s s'. affects_equiv aag l s s' \<and>
+                                 arch_globals_equiv_strengthener (machine_state s) (machine_state s'))
+                         W (P and Q) (P' and Q') f g"
+  apply (clarsimp simp: equiv_valid_2_def)
+  apply (rule conjI)
+   apply blast
+  apply (drule_tac s=s in modifies_at_mostD, assumption+)
+  apply (drule_tac s=t in modifies_at_mostD, assumption+)
+  apply (drule_tac s=s in globals_equivI, assumption+)
+  apply (drule_tac s=t in globals_equivI, assumption+)
+  apply (frule (1) equiv_but_for_reads_equiv[OF domains_distinct])
+  apply (frule_tac s=t in equiv_but_for_reads_equiv[OF domains_distinct], assumption)
+  apply (drule (1) equiv_but_for_affects_equiv[OF domains_distinct])
+  apply (drule_tac s=t in equiv_but_for_affects_equiv[OF domains_distinct], assumption)
+  apply (clarsimp simp: reads_equiv_g_def)
+  apply (simp only: conj_assoc[symmetric])
+  apply (rule conjI)
+   apply (blast intro: reads_equiv_trans reads_equiv_sym affects_equiv_trans
+                       affects_equiv_sym globals_equiv_trans globals_equiv_sym)
+  apply atomize
+  apply (erule_tac x=s in allE)
+  apply (erule_tac x=t in allE)
+  apply (clarsimp simp: valid_def)
+  apply (thin_tac "\<forall>x y. P x y" for P)
+  apply (erule_tac x=s in allE)
+  apply (erule_tac x=t in allE)
+  apply fastforce
+  done
+
+lemma arch_switch_to_idle_thread_reads_respects_g[Noninterference_assms, wp]:
+  "reads_respects_g aag l \<top> (arch_switch_to_idle_thread)"
+  apply (simp add: arch_switch_to_idle_thread_def)
+  apply wp
+  apply (clarsimp simp: reads_equiv_g_def globals_equiv_idle_thread_ptr)
+  done
+
+lemma arch_globals_equiv_threads_eq[Noninterference_assms]:
+  "arch_globals_equiv t' t'' kh kh' as as' ms ms'
+   \<Longrightarrow> arch_globals_equiv t t kh kh' as as' ms ms'"
+  by clarsimp
+
+lemma arch_globals_equiv_globals_equiv_scheduler[Noninterference_assms, elim]:
+  "arch_globals_equiv (cur_thread t) (idle_thread s) (kheap s) (kheap t)
+                      (arch_state s) (arch_state t) (machine_state s) (machine_state t)
+   \<Longrightarrow> arch_globals_equiv_scheduler (kheap s) (kheap t) (arch_state s) (arch_state t)"
+  by (auto simp: arch_globals_equiv_scheduler_def)
+
+lemma getActiveIRQ_ret_no_dmo[Noninterference_assms, wp]:
+  "\<lbrace>\<top>\<rbrace> getActiveIRQ in_kernel \<lbrace>\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ\<rbrace>"
+  apply (simp add: getActiveIRQ_def)
+  apply (rule hoare_pre)
+   apply (insert irq_oracle_max_irq)
+   apply (wp alternative_wp select_wp dmo_getActiveIRQ_irq_masks)
+  apply clarsimp
+  done
+
+(*FIXME: Move to scheduler_if*)
+lemma dmo_getActive_IRQ_reads_respect_scheduler[Noninterference_assms]:
+  "reads_respects_scheduler aag l (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+                            (do_machine_op (getActiveIRQ in_kernel))"
+  apply (simp add: getActiveIRQ_def)
+  apply (simp add: dmo_distr dmo_if_distr dmo_gets_distr dmo_modify_distr cong: if_cong)
+  apply wp
+      apply (rule ev_modify[where P=\<top>])
+      apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
+                            scheduler_affects_equiv_def arch_scheduler_affects_equiv_def
+                            states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def
+                            scheduler_globals_frame_equiv_def silc_dom_equiv_def idle_equiv_def)
+     apply wp
+    apply (rule_tac P="\<lambda>s. irq_masks_of_state st = irq_masks_of_state s" in gets_ev')
+   apply wp
+  apply clarsimp
+  apply (simp add: scheduler_equiv_def)
+  done
+
+end
+
+context begin interpretation Arch .
+
+requalify_consts arch_globals_equiv_strengthener
+requalify_facts arch_globals_equiv_strengthener_thread_independent
+
+end
+
+
+global_interpretation Noninterference_1?: Noninterference_1 _ arch_globals_equiv_strengthener
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Noninterference_assms)?)
+qed
+
+sublocale valid_initial_state \<subseteq> valid_initial_state?:
+  Noninterference_valid_initial_state arch_globals_equiv_strengthener ..
+
+end

--- a/proof/infoflow/ARM/ArchPasUpdates.thy
+++ b/proof/infoflow/ARM/ArchPasUpdates.thy
@@ -1,0 +1,120 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchPasUpdates
+imports PasUpdates
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems PasUpdates_assms
+
+crunches arch_post_cap_deletion, arch_finalise_cap, prepare_thread_delete
+  for domain_fields[PasUpdates_assms, wp]: "domain_fields P"
+  (    wp: syscall_valid select_wp crunch_wps rec_del_preservation cap_revoke_preservation modify_wp
+     simp: crunch_simps check_cap_at_def filterM_mapM unless_def
+   ignore: without_preemption filterM rec_del check_cap_at cap_revoke
+   ignore_del: retype_region_ext create_cap_ext cap_insert_ext ethread_set cap_move_ext
+               empty_slot_ext cap_swap_ext set_thread_state_ext tcb_sched_action reschedule_required)
+
+end
+
+
+global_interpretation PasUpdates_1?: PasUpdates_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact PasUpdates_assms)?)
+qed
+
+
+context Arch begin global_naming ARM
+
+declare init_arch_objects_exst[PasUpdates_assms]
+
+crunches arch_perform_invocation, arch_post_modify_registers,
+         arch_invoke_irq_control, arch_invoke_irq_handler, handle_arch_fault_reply
+  for domain_fields[PasUpdates_assms, wp]: "domain_fields P"
+  (wp: syscall_valid crunch_wps mapME_x_inv_wp
+   simp: crunch_simps check_cap_at_def detype_def detype_ext_def mapM_x_defsym
+   ignore: check_cap_at syscall
+   ignore_del: set_domain set_priority possible_switch_to
+   rule: transfer_caps_loop_pres)
+
+lemma state_asids_to_policy_aux_pasSubject_update:
+  "state_asids_to_policy_aux (aag\<lparr>pasSubject := x\<rparr>) caps asid vrefs =
+   state_asids_to_policy_aux aag caps asid vrefs"
+  apply (rule equalityI)
+   apply clarify
+   apply (erule state_asids_to_policy_aux.cases
+          | simp
+          | fastforce intro: state_asids_to_policy_aux.intros)+
+  apply clarify
+  apply (erule state_asids_to_policy_aux.cases)
+    apply (simp, subst pasObjectAbs_pasSubject_update[symmetric]
+               , subst pasASIDAbs_pasSubject_update[symmetric]
+               , rule state_asids_to_policy_aux.intros
+               , assumption+)+
+  done
+
+lemma state_asids_to_policy_pasSubject_update[PasUpdates_assms]:
+  "state_asids_to_policy (aag\<lparr>pasSubject := x\<rparr>) s =
+   state_asids_to_policy aag s"
+  by (simp add: state_asids_to_policy_aux_pasSubject_update)
+
+lemma state_asids_to_policy_aux_pasMayActivate_update:
+  "state_asids_to_policy_aux (aag\<lparr>pasMayActivate := x\<rparr>) caps asid_tab vrefs =
+   state_asids_to_policy_aux aag caps asid_tab vrefs"
+  apply (rule equalityI)
+   apply clarify
+   apply (erule state_asids_to_policy_aux.cases
+          | simp
+          | fastforce intro: state_asids_to_policy_aux.intros)+
+  apply clarify
+  apply (erule state_asids_to_policy_aux.cases)
+    apply (simp, subst pasObjectAbs_pasMayActivate_update[symmetric]
+               , subst pasASIDAbs_pasMayActivate_update[symmetric]
+               , rule state_asids_to_policy_aux.intros
+               , assumption+)+
+  done
+
+lemma state_asids_to_policy_pasMayActivate_update[PasUpdates_assms]:
+  "state_asids_to_policy (aag\<lparr>pasMayActivate := x\<rparr>) s =
+   state_asids_to_policy aag s"
+  by (simp add: state_asids_to_policy_aux_pasMayActivate_update)
+
+lemma state_asids_to_policy_aux_pasMayEditReadyQueues_update:
+  "state_asids_to_policy_aux (aag\<lparr>pasMayEditReadyQueues := x\<rparr>) caps asid_tab vrefs =
+   state_asids_to_policy_aux aag caps asid_tab vrefs"
+  apply (rule equalityI)
+   apply (clarify)
+   apply (erule state_asids_to_policy_aux.cases
+          | simp
+          | fastforce intro: state_asids_to_policy_aux.intros)+
+  apply (clarify)
+  apply (erule state_asids_to_policy_aux.cases)
+    apply (simp, subst pasObjectAbs_pasMayEditReadyQueues_update[symmetric]
+               , subst pasASIDAbs_pasMayEditReadyQueues_update[symmetric]
+               , rule state_asids_to_policy_aux.intros
+               , assumption+)+
+  done
+
+lemma state_asids_to_policy_pasMayEditReadyQueues_update[PasUpdates_assms]:
+  "state_asids_to_policy (aag\<lparr>pasMayEditReadyQueues := x\<rparr>) s =
+   state_asids_to_policy aag s"
+  by (simp add: state_asids_to_policy_aux_pasMayEditReadyQueues_update)
+
+end
+
+
+global_interpretation PasUpdates_2?: PasUpdates_2
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact PasUpdates_assms)?)
+qed
+
+end

--- a/proof/infoflow/ARM/ArchRetype_IF.thy
+++ b/proof/infoflow/ARM/ArchRetype_IF.thy
@@ -1,0 +1,731 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchRetype_IF
+imports Retype_IF
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems Retype_IF_assms
+
+lemma cacheRangeOp_ev[wp]:
+  "(\<And>a b. equiv_valid_inv I A \<top> (oper a b))
+   \<Longrightarrow> equiv_valid_inv I A \<top> (cacheRangeOp oper x y z)"
+  apply (simp add: cacheRangeOp_def split_def)
+  apply (rule mapM_x_ev)
+   apply simp
+  apply (rule hoare_TrueI)
+  done
+
+lemma cleanCacheRange_PoU_ev:
+  "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) \<top> (cleanCacheRange_PoU vs ve ps)"
+  unfolding cleanCacheRange_PoU_def
+  by (wp machine_op_lift_ev | simp add: cleanByVA_PoU_def)+
+
+lemma modify_underlying_memory_update_0_ev:
+  "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) \<top>
+                   (modify (underlying_memory_update (\<lambda>m. m(x := word_rsplit 0 ! 3,
+                                                            x + 1 := word_rsplit 0 ! 2,
+                                                            x + 2 := word_rsplit 0 ! 1,
+                                                            x + 3 := word_rsplit 0 ! 0))))"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def in_monad)
+  apply (fastforce intro: equiv_forI elim: equiv_forE)
+  done
+
+lemma storeWord_ev:
+  "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) \<top> (storeWord x 0)"
+  unfolding storeWord_def
+  by (wp modify_underlying_memory_update_0_ev assert_inv | simp add: no_irq_def)+
+
+lemma cleanCacheRange_RAM_ev:
+  "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) \<top>
+                   (cleanCacheRange_RAM vstart vend pstart)"
+  unfolding cleanCacheRange_RAM_def cleanCacheRange_PoC_def
+            cacheRangeOp_def cleanL2Range_def dsb_def cleanByVA_def
+  by (wpsimp wp: machine_op_lift_ev mapM_x_ev')
+
+lemma clearMemory_ev[Retype_IF_assms]:
+  "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) (\<lambda>_. True) (clearMemory ptr bits)"
+  unfolding clearMemory_def
+  apply simp
+  apply (rule equiv_valid_guard_imp)
+   apply (rule bind_ev)
+     apply (rule cleanCacheRange_RAM_ev)
+    apply (rule mapM_x_ev[OF storeWord_ev])
+    apply (rule wp_post_taut | simp)+
+  done
+
+lemma freeMemory_ev[Retype_IF_assms]:
+  "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) (\<lambda>_. True) (freeMemory ptr bits)"
+  unfolding freeMemory_def
+  apply (rule equiv_valid_guard_imp)
+   apply (rule mapM_x_ev[OF storeWord_ev])
+   apply (rule wp_post_taut | simp)+
+  done
+
+lemma dmo_cacheRangeOp_reads_respects:
+  "(\<And>a b. reads_respects aag l \<top> (do_machine_op (oper a b)))
+   \<Longrightarrow> reads_respects aag l \<top> (do_machine_op (cacheRangeOp oper x y z))"
+  apply (simp add: cacheRangeOp_def)
+  apply (rule dmo_mapM_x_ev)
+   apply (simp add: split_def)
+  apply (rule hoare_TrueI)
+  done
+
+lemma dmo_cleanCacheRange_PoU_reads_respects:
+  "reads_respects aag l \<top> (do_machine_op (cleanCacheRange_PoU vsrat vend pstart))"
+  unfolding cleanCacheRange_PoU_def
+  by (wp dmo_cacheRangeOp_reads_respects dmo_mol_reads_respects | simp add: cleanByVA_PoU_def)+
+
+lemma set_pd_globals_equiv:
+  "\<lbrace>globals_equiv st and (\<lambda>s. a \<noteq> arm_global_pd (arch_state s))\<rbrace> set_pd a b \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding set_pd_def
+  by (wpsimp wp: set_object_globals_equiv[THEN hoare_set_object_weaken_pre] simp: obj_at_def)
+
+lemma set_pd_reads_respects:
+  "reads_respects aag l (K (is_subject aag a)) (set_pd a b)"
+  unfolding set_pd_def
+  by (blast intro: equiv_valid_guard_imp set_object_reads_respects)
+
+
+lemma set_pd_reads_respects_g:
+  "reads_respects_g aag l (\<lambda> s. is_subject aag ptr \<and> ptr \<noteq> arm_global_pd (arch_state s)) (set_pd ptr pd)"
+  by (fastforce intro: equiv_valid_guard_imp[OF reads_respects_g] doesnt_touch_globalsI
+                       set_pd_reads_respects set_pd_globals_equiv)
+
+crunch irq_state[Retype_IF_assms, wp]: clearMemory "\<lambda>s. P (irq_state s)"
+  (wp: crunch_wps simp: crunch_simps storeWord_def cleanByVA_PoU_def
+   ignore_del: clearMemory cleanL2Range dsb cleanByVA)
+
+crunch irq_state[Retype_IF_assms, wp]: freeMemory "\<lambda>s. P (irq_state s)"
+  (wp: crunch_wps simp: crunch_simps storeWord_def)
+
+lemma get_object_arm_global_pd_revg:
+  "reads_equiv_valid_g_inv A aag (\<lambda> s. p = arm_global_pd (arch_state s)) (get_object p)"
+  apply (unfold get_object_def fun_app_def)
+  apply (subst gets_apply)
+  apply (wp gets_apply_ev')
+    defer
+    apply (wp hoare_drop_imps)
+   apply (rule conjI)
+    apply assumption
+   apply simp
+  apply (auto simp: reads_equiv_g_def globals_equiv_def)
+  done
+
+lemma get_pd_rev:
+  "reads_equiv_valid_inv A aag (K (is_subject aag ptr)) (get_pd ptr)"
+  unfolding get_pd_def by (wp get_object_rev | wpc | clarsimp)+
+
+lemma get_pd_revg:
+  "reads_equiv_valid_g_inv A aag (\<lambda> s. ptr = arm_global_pd (arch_state s)) (get_pd ptr)"
+  unfolding get_pd_def by (wp get_object_arm_global_pd_revg | wpc | clarsimp)+
+
+lemma store_pde_reads_respects:
+  "reads_respects aag l (K (is_subject aag (ptr && ~~ mask pd_bits)))
+                         (store_pde ptr pde)"
+  unfolding store_pde_def fun_app_def
+  apply (wp set_pd_reads_respects get_pd_rev)
+  apply (clarsimp)
+  done
+
+lemma store_pde_globals_equiv:
+  "\<lbrace>globals_equiv s and (\<lambda> s. ptr && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s))\<rbrace>
+   store_pde ptr pde
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding store_pde_def
+  apply (wp set_pd_globals_equiv)
+  apply simp
+  done
+
+lemma store_pde_reads_respects_g:
+  "reads_respects_g aag l (\<lambda>s. is_subject aag (ptr && ~~ mask pd_bits) \<and>
+                               ptr && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s))
+                    (store_pde ptr pde)"
+  by (fastforce intro: equiv_valid_guard_imp[OF reads_respects_g] doesnt_touch_globalsI
+                       store_pde_reads_respects store_pde_globals_equiv)
+
+lemma get_pde_rev:
+  "reads_equiv_valid_inv A aag (K (is_subject aag (ptr && ~~ mask pd_bits))) (get_pde ptr)"
+  unfolding get_pde_def fun_app_def
+  by (wpsimp wp: get_pd_rev)
+
+lemma get_pde_revg:
+  "reads_equiv_valid_g_inv A aag (\<lambda>s. (ptr && ~~ mask pd_bits) = arm_global_pd (arch_state s))
+                                 (get_pde ptr)"
+  unfolding get_pde_def fun_app_def
+  by (wpsimp wp: get_pd_revg)
+
+lemma copy_global_mappings_reads_respects_g:
+  "is_aligned x pd_bits
+   \<Longrightarrow> reads_respects_g aag l (\<lambda>s. is_subject aag x \<and> x \<noteq> arm_global_pd (arch_state s)
+                                 \<and> pspace_aligned s \<and> valid_arch_state s)
+                        (copy_global_mappings x)"
+  unfolding copy_global_mappings_def
+  apply simp
+  apply (rule bind_ev_pre)
+     prefer 3
+     apply (rule_tac Q="\<lambda>s. is_subject aag x \<and> x \<noteq> arm_global_pd (arch_state s) \<and>
+                            pspace_aligned s \<and> valid_arch_state s" in hoare_weaken_pre)
+      apply (rule gets_sp)
+     apply (assumption)
+    apply (wp mapM_x_ev store_pde_reads_respects_g get_pde_revg)
+     apply (drule subsetD[OF copy_global_mappings_index_subset])
+     apply (clarsimp simp: pd_shifting' invs_aligned_pdD)
+    apply (wp get_pde_inv store_pde_aligned store_pde_valid_arch | simp | fastforce)+
+  apply (fastforce dest: reads_equiv_gD simp: globals_equiv_def)
+  done
+
+lemma dmo_no_mem_globals_equiv:
+  "\<lbrakk> \<And>P. f \<lbrace>\<lambda>ms. P (underlying_memory ms)\<rbrace>;
+     \<And>P. f \<lbrace>\<lambda>ms. P (device_state ms)\<rbrace>;
+     \<And>P. f \<lbrace>\<lambda>ms. P (exclusive_state ms)\<rbrace> \<rbrakk>
+     \<Longrightarrow> do_machine_op f \<lbrace>globals_equiv s\<rbrace>"
+  unfolding do_machine_op_def
+  apply (wp | simp add: split_def)+
+  apply atomize
+  apply (erule_tac x="(=) (underlying_memory (machine_state sa))" in allE)
+  apply (erule_tac x="(=) (device_state (machine_state sa))" in allE)
+  apply (erule_tac x="(=) (exclusive_state (machine_state sa))" in allE)
+  apply (fastforce simp: valid_def globals_equiv_def idle_equiv_def)
+  done
+
+lemma mol_exclusive_state:
+  "machine_op_lift mop \<lbrace>\<lambda>ms. P (exclusive_state ms)\<rbrace>"
+  apply (simp add: machine_op_lift_def machine_rest_lift_def)
+  apply (wp | simp add: split_def)+
+  done
+
+lemma dmo_mol_globals_equiv:
+  "do_machine_op (machine_op_lift f) \<lbrace>globals_equiv s\<rbrace>"
+  apply (rule dmo_no_mem_globals_equiv)
+    apply (simp add: machine_op_lift_def machine_rest_lift_def)
+    apply (wp mol_exclusive_state | simp add: split_def)+
+  done
+
+lemma dmo_cleanCacheRange_PoU_globals_equiv:
+  "do_machine_op (cleanCacheRange_PoU x y z) \<lbrace>globals_equiv s\<rbrace>"
+  unfolding cleanCacheRange_PoU_def
+  by (wp dmo_mol_globals_equiv dmo_cacheRangeOp_lift | simp add: cleanByVA_PoU_def)+
+
+lemma dmo_cleanCacheRange_reads_respects_g:
+  "reads_respects_g aag l \<top> (do_machine_op (cleanCacheRange_PoU x y z))"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule dmo_cleanCacheRange_PoU_reads_respects)
+   apply (rule doesnt_touch_globalsI[where P="\<top>", simplified, OF dmo_cleanCacheRange_PoU_globals_equiv])
+  by simp
+
+lemma mol_globals_equiv:
+  "machine_op_lift mop \<lbrace>\<lambda>ms. globals_equiv st (s\<lparr>machine_state := ms\<rparr>)\<rbrace>"
+  unfolding machine_op_lift_def
+  apply (simp add: machine_rest_lift_def split_def)
+  apply wp
+  apply (clarsimp simp: globals_equiv_def idle_equiv_def)
+  done
+
+lemma storeWord_globals_equiv:
+  "storeWord p v \<lbrace>\<lambda>ms. globals_equiv st (s\<lparr>machine_state := ms\<rparr>)\<rbrace>"
+  unfolding storeWord_def
+  apply (simp add: is_aligned_mask[symmetric])
+  apply wp
+  apply (clarsimp simp: globals_equiv_def idle_equiv_def)
+  done
+
+lemma dmo_clearMemory_globals_equiv[Retype_IF_assms]:
+  "do_machine_op (clearMemory ptr (2 ^ bits)) \<lbrace>globals_equiv s\<rbrace>"
+  apply (simp add: do_machine_op_def clearMemory_def split_def cleanCacheRange_PoU_def)
+  apply wpsimp
+  apply (erule use_valid)
+  by (wpsimp wp: mapM_x_wp' storeWord_globals_equiv mol_globals_equiv
+           simp: cleanCacheRange_RAM_def cleanL2Range_def dsb_def
+                 cleanCacheRange_PoC_def cleanByVA_def)+
+
+lemma dmo_freeMemory_globals_equiv[Retype_IF_assms]:
+  "do_machine_op (freeMemory ptr bits) \<lbrace>globals_equiv s\<rbrace>"
+  apply (rule hoare_pre)
+   apply (simp add: do_machine_op_def freeMemory_def split_def)
+   apply (wp)
+  apply clarsimp
+  apply (erule use_valid)
+   apply (wp mapM_x_wp' storeWord_globals_equiv mol_globals_equiv)
+  apply (simp_all)
+  done
+
+lemma init_arch_objects_reads_respects_g:
+  "reads_respects_g aag l ((\<lambda>s. arm_global_pd (arch_state s) \<notin> set refs \<and>
+                                pspace_aligned s \<and> valid_arch_state s) and
+                           K (\<forall>x\<in>set refs. is_subject aag x) and
+                           K (\<forall>x\<in>set refs. new_type = ArchObject PageDirectoryObj
+                                           \<longrightarrow> is_aligned x pd_bits) and
+                           K ((0::obj_ref) < of_nat num_objects))
+                    (init_arch_objects new_type ptr num_objects obj_sz refs)"
+  apply (unfold init_arch_objects_def fun_app_def)
+  apply (rule gen_asm_ev)+
+  apply (subst do_machine_op_mapM_x[OF empty_fail_cleanCacheRange_PoU])+
+  apply (rule equiv_valid_guard_imp)
+   apply (wp dmo_cleanCacheRange_reads_respects_g mapM_x_ev''
+          equiv_valid_guard_imp[OF copy_global_mappings_reads_respects_g]
+          copy_global_mappings_valid_arch_state copy_global_mappings_pspace_aligned
+          hoare_vcg_ball_lift | wpc | simp)+
+  apply clarsimp
+  done
+
+lemma copy_global_mappings_globals_equiv:
+  "\<lbrace>globals_equiv s and (\<lambda>s. x \<noteq> arm_global_pd (arch_state s) \<and> is_aligned x pd_bits)\<rbrace>
+   copy_global_mappings x
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding copy_global_mappings_def including no_pre
+  apply simp
+  apply wp
+   apply (rule_tac Q="\<lambda>_. globals_equiv s and (\<lambda>s. x \<noteq> arm_global_pd (arch_state s) \<and>
+                                                   is_aligned x pd_bits)" in hoare_strengthen_post)
+    apply (wp mapM_x_wp[OF _ subset_refl] store_pde_globals_equiv)
+    apply (fastforce dest: subsetD[OF copy_global_mappings_index_subset] simp: pd_shifting')
+   apply (simp_all)
+  done
+
+lemma init_arch_objects_globals_equiv:
+  "\<lbrace>globals_equiv s and (\<lambda>s. arm_global_pd (arch_state s) \<notin> set refs \<and>
+                             pspace_aligned s \<and> valid_arch_state s)
+                    and K (\<forall>x\<in>set refs. is_aligned x (obj_bits_api new_type obj_sz))\<rbrace>
+   init_arch_objects new_type ptr num_objects obj_sz refs
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding init_arch_objects_def fun_app_def
+  apply (rule hoare_gen_asm)+
+  apply (subst do_machine_op_mapM_x[OF empty_fail_cleanCacheRange_PoU])+
+  apply (rule hoare_pre)
+   apply (wpc | wp mapM_x_wp[OF dmo_cleanCacheRange_PoU_globals_equiv subset_refl])+
+    apply (rule_tac Q="\<lambda>_. globals_equiv s and (\<lambda> s. arm_global_pd (arch_state s) \<notin> set refs)"
+                 in hoare_strengthen_post)
+     apply (wp mapM_x_wp[OF _ subset_refl] copy_global_mappings_globals_equiv
+              dmo_cleanCacheRange_PoU_globals_equiv
+            | simp add: obj_bits_api_def default_arch_object_def pd_bits_def pageBits_def
+            | blast)+
+  done
+
+(* FIXME: cleanup this proof *)
+lemma retype_region_globals_equiv[Retype_IF_assms]:
+  notes blah[simp del] = atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+                         Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
+  shows
+    "\<lbrace>globals_equiv s and invs
+                      and (\<lambda>s. \<exists>i. cte_wp_at (\<lambda>c. c = UntypedCap dev (p && ~~ mask sz) sz i) slot s \<and>
+                                   (i \<le> unat (p && mask sz) \<or> pspace_no_overlap_range_cover p sz s))
+                      and K (range_cover p sz (obj_bits_api type o_bits) num \<and> 0 < num)\<rbrace>
+     retype_region p num o_bits type dev
+     \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  apply (simp only: retype_region_def foldr_upd_app_if fun_app_def K_bind_def)
+  apply (wp dxo_wp_weak |simp)+
+      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
+     apply (wp | simp)+
+  apply clarsimp
+  apply (simp only: globals_equiv_def)
+  apply (clarsimp split del: if_split)
+  apply (subgoal_tac "pspace_no_overlap_range_cover p sz sa")
+   apply (rule conjI)
+    apply (clarsimp simp: pspace_no_overlap_def)
+    apply (drule_tac x="arm_global_pd (arch_state sa)" in spec)
+    apply (clarsimp simp: invs_def valid_state_def valid_global_objs_def
+                          valid_vso_at_def obj_at_def ptr_add_def)
+    apply (frule_tac p=x in range_cover_subset)
+      apply (simp add: blah)
+     apply simp
+    apply (frule range_cover_subset')
+     apply simp
+    apply (clarsimp simp: p_assoc_help)
+    apply (drule disjoint_subset_neg1[OF _ subset_thing], rule is_aligned_no_wrap')
+        apply (clarsimp simp: valid_pspace_def pspace_aligned_def)
+        apply (drule_tac x="arm_global_pd (arch_state sa)" and A="dom (kheap sa)"  in bspec)
+         apply (simp add: domI)
+        apply simp
+       apply (rule word_power_less_1)
+       apply (case_tac ao, simp_all add: arch_kobj_size_def word_bits_def)
+      apply (simp add: pageBits_def)
+     apply (simp add: pageBitsForSize_def split: vmpage_size.splits)
+    apply (drule (1) subset_trans)
+    apply (erule_tac P="a \<in> b" for a b in notE)
+    apply (erule_tac A="{p + c..d}" for c d in subsetD)
+    apply (simp add: blah)
+    apply (rule is_aligned_no_wrap')
+     apply (rule is_aligned_add[OF _ is_aligned_mult_triv2])
+     apply (simp add: range_cover_def)
+    apply (rule word_power_less_1)
+    apply (simp add: range_cover_def)
+   apply (erule updates_not_idle)
+   apply (clarsimp simp: pspace_no_overlap_def)
+   apply (drule_tac x="idle_thread sa" in spec)
+   apply (clarsimp simp: invs_def valid_state_def valid_global_objs_def valid_ao_at_def
+                         obj_at_def ptr_add_def valid_idle_def pred_tcb_at_def)
+   apply (frule_tac p=a in range_cover_subset)
+     apply (simp add: blah)
+    apply simp
+   apply (frule range_cover_subset')
+    apply simp
+   apply (clarsimp simp: p_assoc_help)
+   apply (drule disjoint_subset_neg1[OF _ subset_thing], rule is_aligned_no_wrap')
+       apply (clarsimp simp: valid_pspace_def pspace_aligned_def)
+       apply (drule_tac x="idle_thread sa" and A="dom (kheap sa)"  in bspec)
+        apply (simp add: domI)
+       apply simp
+      apply uint_arith
+     apply simp+
+   apply (drule (1) subset_trans)
+   apply (erule_tac P="a \<in> b" for a b in notE)
+   apply (erule_tac A="{idle_thread_ptr..d}" for d in subsetD)
+   apply (simp add: blah)
+   apply (erule_tac t=idle_thread_ptr in subst)
+   apply (rule is_aligned_no_wrap')
+    apply (rule is_aligned_add[OF _ is_aligned_mult_triv2])
+    apply (simp add: range_cover_def)+
+  apply (auto intro!: cte_wp_at_pspace_no_overlapI simp: range_cover_def word_bits_def)[1]
+  done
+
+lemma no_irq_freeMemory[Retype_IF_assms]:
+  "no_irq (freeMemory ptr sz)"
+  apply (simp add: freeMemory_def)
+  apply (wp no_irq_mapM_x no_irq_storeWord)
+  done
+
+lemma equiv_asid_detype[Retype_IF_assms]:
+  "equiv_asid asid s s' \<Longrightarrow> equiv_asid asid (detype N s) (detype N s')"
+  by (auto simp: equiv_asid_def)
+
+end
+
+
+global_interpretation Retype_IF_1?: Retype_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Retype_IF_assms)?)
+qed
+
+
+context Arch begin global_naming ARM
+
+lemma detype_globals_equiv:
+  "\<lbrace>globals_equiv st and ((\<lambda>s. arm_global_pd (arch_state s) \<notin> S) and (\<lambda>s. idle_thread s \<notin> S))\<rbrace>
+   modify (detype S)
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  apply (wp)
+  apply (clarsimp simp: globals_equiv_def detype_def idle_equiv_def tcb_at_def2)
+  done
+
+lemma detype_reads_respects_g:
+  "reads_respects_g aag l ((\<lambda>s. arm_global_pd (arch_state s) \<notin> S) and (\<lambda>s. idle_thread s \<notin> S))
+                    (modify (detype S))"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_g)
+    apply (rule detype_reads_respects)
+   apply (rule doesnt_touch_globalsI[OF detype_globals_equiv])
+  apply simp
+  done
+
+lemma delete_objects_reads_respects_g:
+ "reads_equiv_valid_g_inv (affects_equiv aag l) aag
+    (\<lambda>s. arm_global_pd (arch_state s) \<notin> ptr_range p b \<and>
+         idle_thread s \<notin> ptr_range p b \<and>
+         is_aligned p b \<and> 2 \<le> b \<and> b < word_bits)
+    (delete_objects p b)"
+  apply (simp add: delete_objects_def2)
+  apply (rule equiv_valid_guard_imp)
+   apply (wp dmo_freeMemory_reads_respects_g)
+    apply (rule detype_reads_respects_g)
+   apply wp
+  apply (unfold ptr_range_def)
+  apply simp
+  done
+
+lemma reset_untyped_cap_reads_respects_g:
+ "reads_equiv_valid_g_inv (affects_equiv aag (l :: 'a subject_label)) aag
+    (\<lambda>s. cte_wp_at is_untyped_cap slot s \<and> invs s \<and> ct_active s \<and> only_timer_irq_inv irq st s \<and>
+         is_subject aag (fst slot) \<and> (descendants_of slot (cdt s) = {}))
+    (reset_untyped_cap slot)"
+  apply (simp add: reset_untyped_cap_def cong: if_cong)
+  apply (rule equiv_valid_guard_imp)
+   apply (wp set_cap_reads_respects_g dmo_clearMemory_reads_respects_g
+          | simp add: unless_def when_def split del: if_split)+
+       apply (rule_tac I="invs and cte_wp_at (\<lambda>cp. is_untyped_cap rv
+                                                 \<and> (\<exists>idx. cp = free_index_update (\<lambda>_. idx) rv)
+                                                 \<and> free_index_of rv \<le> 2 ^ (bits_of rv)
+                                                 \<and> is_subject aag (fst slot)) slot
+                               and pspace_no_overlap (untyped_range rv)
+                               and only_timer_irq_inv irq st
+                               and (\<lambda>s. descendants_of slot (cdt s) = {})" in mapME_x_ev)
+        apply (rule equiv_valid_guard_imp)
+         apply wp
+             apply (rule reads_respects_g_from_inv)
+              apply (rule preemption_point_reads_respects[where irq=irq and st=st])
+             apply ((wp preemption_point_inv set_cap_reads_respects_g set_untyped_cap_invs_simple
+                       only_timer_irq_inv_pres[where Q=\<top>, OF _ set_cap_domain_sep_inv]
+                       dmo_clearMemory_reads_respects_g
+                     | simp)+)
+         apply (strengthen empty_descendants_range_in)
+         apply (wp only_timer_irq_inv_pres[where P=\<top> and Q=\<top>] no_irq_clearMemory
+                | simp | wp (once) dmo_wp)+
+        apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps bits_of_def)
+        apply (frule(1) caps_of_state_valid)
+        apply (clarsimp simp: valid_cap_simps cap_aligned_def field_simps
+                              free_index_of_def invs_valid_global_objs)
+        apply (simp add: aligned_add_aligned is_aligned_shiftl)
+        apply (clarsimp simp: reset_chunk_bits_def)
+       apply (rule hoare_pre)
+        apply (wp preemption_point_inv' set_untyped_cap_invs_simple set_cap_cte_wp_at
+                  set_cap_no_overlap only_timer_irq_inv_pres[where Q=\<top>, OF _ set_cap_domain_sep_inv]
+               | simp)+
+        apply (strengthen empty_descendants_range_in)
+         apply (wp only_timer_irq_inv_pres[where P=\<top> and Q=\<top>] no_irq_clearMemory
+                | simp | wp (once) dmo_wp)+
+        apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps bits_of_def)
+        apply (frule(1) caps_of_state_valid)
+        apply (clarsimp simp: valid_cap_simps cap_aligned_def field_simps free_index_of_def)
+       apply (wp | simp)+
+       apply (wp delete_objects_reads_respects_g)
+      apply (simp add: if_apply_def2)
+      apply (strengthen invs_valid_global_objs)
+      apply (wp add: delete_objects_invs_ex hoare_vcg_const_imp_lift
+                     delete_objects_pspace_no_overlap_again
+                     only_timer_irq_inv_pres[where P=\<top> and Q=\<top>]
+                del: Untyped_AI.delete_objects_pspace_no_overlap
+             | simp)+
+     apply (rule get_cap_reads_respects_g)
+    apply (wp get_cap_wp)
+  apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps bits_of_def)
+  apply (frule(1) caps_of_state_valid)
+  apply (clarsimp simp: valid_cap_simps cap_aligned_def field_simps
+                        free_index_of_def invs_valid_global_objs)
+  apply (frule valid_global_refsD2, clarsimp+)
+  apply (clarsimp simp: ptr_range_def[symmetric] global_refs_def descendants_range_def2)
+  apply (frule if_unsafe_then_capD[OF caps_of_state_cteD], clarsimp+)
+  apply (strengthen refl[where t=True] refl ex_tupleI[where t=slot] empty_descendants_range_in
+         | clarsimp)+
+  apply (drule ex_cte_cap_protects[OF _ _ _ _ order_refl], erule caps_of_state_cteD)
+     apply (clarsimp simp: descendants_range_def2 empty_descendants_range_in)
+    apply clarsimp+
+  apply (fastforce simp: untyped_min_bits_def)
+  done
+
+lemma retype_region_ret_pd_aligned:
+  "\<lbrace>K (range_cover ptr sz (obj_bits_api tp us) num_objects)\<rbrace>
+   retype_region ptr num_objects us tp dev
+   \<lbrace>\<lambda>rv. K (\<forall>ref \<in> set rv. tp = ArchObject PageDirectoryObj \<longrightarrow> is_aligned ref pd_bits)\<rbrace>"
+  apply (rule hoare_strengthen_post)
+   apply (rule hoare_weaken_pre)
+    apply (rule retype_region_aligned_for_init)
+   apply simp
+  apply (clarsimp simp: obj_bits_api_def default_arch_object_def pd_bits_def pageBits_def)
+  done
+
+lemma invoke_untyped_reads_respects_g_wcap[Retype_IF_assms]:
+  notes blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff
+                         atLeastatMost_subset_iff atLeastLessThan_iff Int_atLeastAtMost
+                         atLeastatMost_empty_iff split_paired_Ex
+  shows "reads_respects_g aag (l :: 'a subject_label)
+           (invs and valid_untyped_inv_wcap ui (Some (UntypedCap dev ptr sz idx))
+                 and only_timer_irq_inv irq st and ct_active and pas_refined aag
+                 and K (authorised_untyped_inv aag ui))
+           (invoke_untyped ui)"
+  apply (case_tac ui)
+  apply (rename_tac cslot_ptr reset ptr_base ptr' apiobject_type nat list dev')
+  apply (case_tac "\<not> (dev' = dev \<and> ptr = ptr' && ~~ mask sz)")
+   (* contradictory *)
+   apply (rule equiv_valid_guard_imp, rule_tac gen_asm_ev'[where P="\<top>" and Q=False], simp)
+   apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (simp add: invoke_untyped_def mapM_x_def[symmetric])
+  apply (wpsimp wp: mapM_x_ev'' create_cap_reads_respects_g
+                    hoare_vcg_ball_lift init_arch_objects_reads_respects_g)+
+           apply (rule_tac Q="\<lambda>_. invs" in hoare_strengthen_post)
+            apply (wp init_arch_objects_invs_from_restricted)
+           apply (fastforce simp: invs_def)
+          apply (wp retype_region_reads_respects_g[where sz=sz and slot="slot_of_untyped_inv ui"])
+         apply (rule_tac Q="\<lambda>rvc s. (\<forall>x\<in>set rvc. is_subject aag x) \<and>
+                                    (\<forall>x\<in>set rvc. is_aligned x (obj_bits_api apiobject_type nat)) \<and>
+                                    ((0::obj_ref) < of_nat (length list)) \<and>
+                                    post_retype_invs apiobject_type rvc s \<and>
+                                    global_refs s \<inter> set rvc = {} \<and>
+                                    (\<forall>x\<in>set list. is_subject aag (fst x))"
+                     for sz in hoare_strengthen_post)
+          apply (wp retype_region_ret_is_subject[where sz=sz, simplified]
+                   retype_region_global_refs_disjoint[where sz=sz]
+                   retype_region_ret_pd_aligned[where sz=sz]
+                   retype_region_aligned_for_init[where sz=sz]
+                   retype_region_post_retype_invs_spec[where sz=sz])
+         apply (fastforce simp: global_refs_def obj_bits_api_def pd_bits_def
+                                pageBits_def default_arch_object_def
+                         intro: post_retype_invs_pspace_alignedI
+                                post_retype_invs_valid_arch_stateI
+                          elim: in_set_zipE)
+        apply (rule set_cap_reads_respects_g)
+       apply simp
+       apply (wp hoare_vcg_ex_lift set_cap_cte_wp_at_cases
+                 hoare_vcg_disj_lift set_cap_no_overlap
+                 set_free_index_invs_UntypedCap
+                 set_untyped_cap_caps_overlap_reserved
+                 set_cap_caps_no_overlap
+                 region_in_kernel_window_preserved)
+      apply (wp when_ev delete_objects_reads_respects_g hoare_vcg_disj_lift
+                delete_objects_pspace_no_overlap
+                delete_objects_descendants_range_in
+                delete_objects_caps_no_overlap
+                region_in_kernel_window_preserved
+                get_cap_reads_respects_g get_cap_wp
+             | simp split del: if_split)+
+    apply (rule reset_untyped_cap_reads_respects_g[where irq=irq and st=st])
+   apply (rule_tac P="authorised_untyped_inv aag ui \<and>
+                      (\<forall>p \<in> ptr_range ptr sz. is_subject aag p)" in hoare_gen_asmE)
+   apply (rule validE_validE_R,
+          rule_tac E="\<top>\<top>"
+               and Q="\<lambda>_. invs and valid_untyped_inv_wcap ui (Some (UntypedCap dev ptr sz (If reset 0 idx)))
+                               and ct_active
+                               and (\<lambda>s. reset \<longrightarrow> pspace_no_overlap {ptr .. ptr + 2 ^ sz - 1} s)"
+                in hoare_post_impErr)
+     apply (rule hoare_pre, wp hoare_whenE_wp)
+      apply (rule validE_validE_R, rule hoare_post_impErr, rule reset_untyped_cap_invs_etc)
+       apply (clarsimp simp only: if_True simp_thms, intro conjI, assumption+)
+      apply simp
+     apply assumption
+    apply clarify
+    apply (frule(2) invoke_untyped_proofs.intro)
+    apply (clarsimp simp: cte_wp_at_caps_of_state bits_of_def
+                          free_index_of_def untyped_range_def
+                          if_split[where P="\<lambda>x. x \<le> unat v" for v]
+               split del: if_split)
+    apply (frule(1) valid_global_refsD2[OF _ invs_valid_global_refs])
+    apply (strengthen refl)
+    apply (strengthen invs_valid_global_objs)
+    apply (clarsimp simp: authorised_untyped_inv_def conj_comms invoke_untyped_proofs.simps)
+    apply (simp add: arg_cong[OF mask_out_sub_mask, where f="\<lambda>y. x - y" for x]
+                       field_simps invoke_untyped_proofs.idx_le_new_offs
+                       invoke_untyped_proofs.idx_compare' untyped_range_def)
+    apply (strengthen caps_region_kernel_window_imp[mk_strg I E])
+    apply (simp add: invoke_untyped_proofs.simps untyped_range_def invs_cap_refs_in_kernel_window
+                     atLeastatMost_subset_iff[where b=x and d=x for x]
+               cong: conj_cong split del: if_split)
+    apply (intro conjI)
+          (* mostly clagged from Untyped_AI *)
+          apply (simp add: atLeastatMost_subset_iff word_and_le2)
+         apply (case_tac reset)
+          apply (clarsimp elim!: pspace_no_overlap_subset del: subsetI
+                           simp: blah word_and_le2)
+         apply (drule invoke_untyped_proofs.ps_no_overlap)
+         apply (simp add: field_simps)
+        apply (simp add: Int_commute, erule disjoint_subset2[rotated])
+        apply (simp add: atLeastatMost_subset_iff word_and_le2)
+       apply (clarsimp dest!: invoke_untyped_proofs.idx_le_new_offs)
+      apply (simp add: ptr_range_def)
+      apply (erule ball_subset, rule range_subsetI[OF _ order_refl])
+      apply (simp add: word_and_le2)
+     apply (erule order_trans[OF invoke_untyped_proofs.subset_stuff])
+     apply (simp add: atLeastatMost_subset_iff word_and_le2)
+    apply (drule invoke_untyped_proofs.usable_range_disjoint)
+    apply (clarsimp simp: field_simps mask_out_sub_mask shiftl_t2n)
+   apply blast
+  apply (clarsimp simp: cte_wp_at_caps_of_state authorised_untyped_inv_def)
+  apply (strengthen refl)
+  apply (frule(1) cap_auth_caps_of_state)
+  apply (simp add: aag_cap_auth_def untyped_range_def
+                   aag_has_Control_iff_owns ptr_range_def[symmetric])
+  apply (erule disjE, simp_all)[1]
+  done
+
+lemma delete_objects_globals_equiv[wp]:
+  "\<lbrace>globals_equiv st and (\<lambda>s. is_aligned p b \<and> 2 \<le> b \<and> b < word_bits \<and>
+                              arm_global_pd (arch_state s) \<notin> ptr_range p b \<and>
+                              idle_thread s \<notin> ptr_range p b)\<rbrace>
+   delete_objects p b
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  apply (simp add: delete_objects_def)
+  apply (wp detype_globals_equiv dmo_freeMemory_globals_equiv)
+  apply (clarsimp simp: ptr_range_def)+
+  done
+
+lemma reset_untyped_cap_globals_equiv:
+  "\<lbrace>globals_equiv st and invs and cte_wp_at is_untyped_cap slot
+                     and ct_active and (\<lambda>s. descendants_of slot (cdt s) = {})\<rbrace>
+   reset_untyped_cap slot
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  apply (simp add: reset_untyped_cap_def cong: if_cong)
+  apply (rule hoare_pre)
+   apply (wp set_cap_globals_equiv dmo_clearMemory_globals_equiv
+             preemption_point_inv | simp add: unless_def)+
+     apply (rule valid_validE)
+     apply (rule_tac P="cap_aligned cap \<and> is_untyped_cap cap" in hoare_gen_asm)
+     apply (rule_tac Q="\<lambda>_ s. valid_global_objs s \<and> globals_equiv st s"
+                  in hoare_strengthen_post)
+      apply (rule validE_valid, rule mapME_x_wp')
+      apply (rule hoare_pre)
+       apply (wp set_cap_globals_equiv dmo_clearMemory_globals_equiv
+                 preemption_point_inv | simp add: if_apply_def2)+
+    apply (clarsimp simp: is_cap_simps ptr_range_def[symmetric]
+                          cap_aligned_def bits_of_def
+                          free_index_of_def)
+    apply (clarsimp simp: reset_chunk_bits_def)
+    apply (strengthen invs_valid_global_objs)
+    apply (wp delete_objects_invs_ex hoare_vcg_const_imp_lift get_cap_wp)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state descendants_range_def2 is_cap_simps bits_of_def
+             split del: if_split)
+  apply (frule caps_of_state_valid_cap, clarsimp+)
+  apply (clarsimp simp: valid_cap_simps cap_aligned_def untyped_min_bits_def)
+  apply (frule valid_global_refsD2, clarsimp+)
+  apply (clarsimp simp: ptr_range_def[symmetric] global_refs_def)
+  apply (strengthen empty_descendants_range_in)
+  apply (cases slot)
+  apply fastforce
+  done
+
+lemma invoke_untyped_globals_equiv:
+  notes blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff
+                         atLeastatMost_subset_iff atLeastLessThan_iff Int_atLeastAtMost
+                         atLeastatMost_empty_iff split_paired_Ex
+  shows "\<lbrace>globals_equiv st and invs and valid_untyped_inv ui and ct_active\<rbrace>
+         invoke_untyped ui
+         \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  apply (rule hoare_name_pre_state)
+  apply (rule hoare_pre, rule invoke_untyped_Q)
+       apply (wp create_cap_globals_equiv)
+       apply auto[1]
+      apply (wp init_arch_objects_globals_equiv)
+      apply (clarsimp simp: retype_addrs_aligned_range_cover cte_wp_at_caps_of_state
+                  simp del: valid_untyped_inv_wcap.simps)
+      apply (frule valid_global_refsD2)
+       apply (clarsimp simp: post_retype_invs_def split: if_split_asm)
+      apply (drule disjoint_subset2[rotated])
+       apply (rule order_trans, erule retype_addrs_subset_ptr_bits)
+       apply (simp add: untyped_range_def blah word_and_le2 field_simps)
+      apply (auto simp: global_refs_def post_retype_invs_def split: if_split_asm)[1]
+     apply (rule hoare_pre, wp retype_region_globals_equiv[where slot="slot_of_untyped_inv ui"])
+     apply (clarsimp simp: cte_wp_at_caps_of_state)
+     apply (strengthen refl)
+     apply simp
+    apply (wp set_cap_globals_equiv)
+    apply auto[1]
+   apply (wp reset_untyped_cap_globals_equiv)
+  apply (cases ui, clarsimp simp: cte_wp_at_caps_of_state)
+  done
+
+end
+
+
+global_interpretation Retype_IF_2?: Retype_IF_2
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Retype_IF_assms)?)
+qed
+
+
+context begin interpretation Arch .
+
+requalify_facts
+  reset_untyped_cap_reads_respects_g
+  reset_untyped_cap_globals_equiv
+  invoke_untyped_globals_equiv
+  storeWord_globals_equiv
+
+end
+
+end

--- a/proof/infoflow/ARM/ArchScheduler_IF.thy
+++ b/proof/infoflow/ARM/ArchScheduler_IF.thy
@@ -1,0 +1,472 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchScheduler_IF
+imports Scheduler_IF
+
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems Scheduler_IF_assms
+
+definition arch_globals_equiv_scheduler :: "kheap \<Rightarrow> kheap \<Rightarrow> arch_state \<Rightarrow> arch_state \<Rightarrow> bool" where
+  "arch_globals_equiv_scheduler kh kh' as as' \<equiv>
+     arm_global_pd as = arm_global_pd as' \<and> kh (arm_global_pd as) = kh' (arm_global_pd as)"
+
+definition
+  "arch_scheduler_affects_equiv s s' \<equiv> exclusive_state_equiv s s'"
+
+lemma arch_globals_equiv_from_scheduler[Scheduler_IF_assms]:
+  "\<lbrakk> arch_globals_equiv_scheduler (kheap s) (kheap s') (arch_state s) (arch_state s');
+     cur_thread s' \<noteq> idle_thread s \<longrightarrow> arch_scheduler_affects_equiv s s' \<rbrakk>
+     \<Longrightarrow> arch_globals_equiv (cur_thread s') (idle_thread s) (kheap s) (kheap s')
+                            (arch_state s) (arch_state s') (machine_state s) (machine_state s')"
+  by (clarsimp simp: arch_globals_equiv_scheduler_def arch_scheduler_affects_equiv_def)
+
+lemma arch_globals_equiv_scheduler_refl[Scheduler_IF_assms]:
+  "arch_globals_equiv_scheduler (kheap s) (kheap s) (arch_state s) (arch_state s)"
+  by (simp add: idle_equiv_refl arch_globals_equiv_scheduler_def)
+
+lemma arch_globals_equiv_scheduler_sym[Scheduler_IF_assms]:
+  "arch_globals_equiv_scheduler (kheap s) (kheap s') (arch_state s) (arch_state s')
+   \<Longrightarrow> arch_globals_equiv_scheduler (kheap s') (kheap s) (arch_state s') (arch_state s)"
+  by (auto simp: arch_globals_equiv_scheduler_def)
+
+lemma arch_globals_equiv_scheduler_trans[Scheduler_IF_assms]:
+  "\<lbrakk> arch_globals_equiv_scheduler (kheap s) (kheap s') (arch_state s) (arch_state s');
+     arch_globals_equiv_scheduler (kheap s') (kheap s'') (arch_state s') (arch_state s'') \<rbrakk>
+     \<Longrightarrow> arch_globals_equiv_scheduler (kheap s) (kheap s'') (arch_state s) (arch_state s'')"
+  by (clarsimp simp: arch_globals_equiv_scheduler_def)
+
+lemma arch_scheduler_affects_equiv_trans[Scheduler_IF_assms, elim]:
+  "\<lbrakk> arch_scheduler_affects_equiv s s'; arch_scheduler_affects_equiv s' s'' \<rbrakk>
+     \<Longrightarrow> arch_scheduler_affects_equiv s s''"
+  by (simp add: arch_scheduler_affects_equiv_def)
+
+lemma arch_scheduler_affects_equiv_sym[Scheduler_IF_assms, elim]:
+  "arch_scheduler_affects_equiv s s' \<Longrightarrow> arch_scheduler_affects_equiv s' s"
+  by (simp add: arch_scheduler_affects_equiv_def)
+
+lemma arch_scheduler_affects_equiv_sa_update[Scheduler_IF_assms, simp]:
+  "arch_scheduler_affects_equiv (scheduler_action_update f s) s' =
+   arch_scheduler_affects_equiv s s'"
+  "arch_scheduler_affects_equiv s (scheduler_action_update f s') =
+   arch_scheduler_affects_equiv s s'"
+  by (auto simp: arch_scheduler_affects_equiv_def)
+
+
+lemma equiv_asid_cur_thread_update[Scheduler_IF_assms, simp]:
+  "equiv_asid asid (cur_thread_update f s) s' = equiv_asid asid s s'"
+  "equiv_asid asid s (cur_thread_update f s') = equiv_asid asid s s'"
+  by (auto simp: equiv_asid_def)
+
+lemma arch_scheduler_affects_equiv_ready_queues_update[Scheduler_IF_assms, simp]:
+  "arch_scheduler_affects_equiv (ready_queues_update f s) s' = arch_scheduler_affects_equiv s s'"
+  "arch_scheduler_affects_equiv s (ready_queues_update f s') = arch_scheduler_affects_equiv s s'"
+  by (auto simp: arch_scheduler_affects_equiv_def)
+
+crunches arch_switch_to_thread, arch_switch_to_idle_thread
+  for idle_thread[Scheduler_IF_assms, wp]: "\<lambda>s :: det_state. P (idle_thread s)"
+  and kheap[Scheduler_IF_assms, wp]: "\<lambda>s :: det_state. P (kheap s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+crunches arch_switch_to_idle_thread
+  for cur_domain[Scheduler_IF_assms, wp]: "\<lambda>s. P (cur_domain s)"
+  and domain_fields[Scheduler_IF_assms, wp]: "domain_fields P"
+
+crunches arch_switch_to_idle_thread
+  for globals_equiv[Scheduler_IF_assms, wp]: "globals_equiv st"
+  and states_equiv_for[Scheduler_IF_assms, wp]: "states_equiv_for P Q R S st"
+  and work_units_completed[Scheduler_IF_assms, wp]: "\<lambda>s. P (work_units_completed s)"
+
+crunches arch_activate_idle_thread
+  for cur_domain[Scheduler_IF_assms, wp]: "\<lambda>s. P (cur_domain s)"
+  and idle_thread[Scheduler_IF_assms, wp]: "\<lambda>s. P (idle_thread s)"
+  and irq_state_of_state[Scheduler_IF_assms, wp]: "\<lambda>s. P (irq_state_of_state s)"
+  and domain_fields[Scheduler_IF_assms, wp]: "domain_fields P"
+
+lemma arch_scheduler_affects_equiv_cur_thread_update[Scheduler_IF_assms, simp]:
+  "arch_scheduler_affects_equiv (cur_thread_update f s) s' = arch_scheduler_affects_equiv s s'"
+  "arch_scheduler_affects_equiv s (cur_thread_update f s') = arch_scheduler_affects_equiv s s'"
+  by (auto simp: arch_scheduler_affects_equiv_def)
+
+lemma equiv_asid_domain_time_update[Scheduler_IF_assms, simp]:
+  "equiv_asid asid (domain_time_update f s) s' = equiv_asid asid s s'"
+  "equiv_asid asid s (domain_time_update f s') = equiv_asid asid s s'"
+  by (auto simp: equiv_asid_def)
+
+lemma equiv_asid_ekheap_update[Scheduler_IF_assms, simp]:
+  "equiv_asid asid (ekheap_update f s) s' = equiv_asid asid s s'"
+  "equiv_asid asid s (ekheap_update f s') = equiv_asid asid s s'"
+  by (auto simp: equiv_asid_def)
+
+lemma arch_scheduler_affects_equiv_domain_time_update[Scheduler_IF_assms, simp]:
+  "arch_scheduler_affects_equiv (domain_time_update f s) s' = arch_scheduler_affects_equiv s s'"
+  "arch_scheduler_affects_equiv s (domain_time_update f s') = arch_scheduler_affects_equiv s s'"
+  by (auto simp: arch_scheduler_affects_equiv_def)
+
+lemma arch_scheduler_affects_equiv_ekheap_update[Scheduler_IF_assms, simp]:
+  "arch_scheduler_affects_equiv (ekheap_update f s) s' = arch_scheduler_affects_equiv s s'"
+  "arch_scheduler_affects_equiv s (ekheap_update f s') = arch_scheduler_affects_equiv s s'"
+  by (auto simp: arch_scheduler_affects_equiv_def)
+
+crunch irq_state[Scheduler_IF_assms, wp]: ackInterrupt "\<lambda>s. P (irq_state s)"
+
+lemma thread_set_context_globals_equiv[Scheduler_IF_assms]:
+  "\<lbrace>(\<lambda>s. t = idle_thread s \<longrightarrow> tc = idle_context s) and invs and globals_equiv st\<rbrace>
+   thread_set (tcb_arch_update (arch_tcb_context_set tc)) t
+   \<lbrace>\<lambda>rv. globals_equiv st\<rbrace>"
+  apply (clarsimp simp: thread_set_def)
+  apply (wpsimp wp: set_object_wp)
+  apply (subgoal_tac "t \<noteq> arm_global_pd (arch_state s)")
+   apply (clarsimp simp: idle_equiv_def globals_equiv_def tcb_at_def2 get_tcb_def idle_context_def)
+   apply (clarsimp split: option.splits kernel_object.splits)
+  apply (drule arm_global_pd_not_tcb[OF invs_valid_ko_at_arch])
+  apply clarsimp
+  done
+
+lemma arch_scheduler_affects_equiv_update[Scheduler_IF_assms]:
+  "arch_scheduler_affects_equiv st s
+   \<Longrightarrow> arch_scheduler_affects_equiv st (s\<lparr>kheap := kheap s(x \<mapsto> TCB y')\<rparr>)"
+  by (clarsimp simp: arch_scheduler_affects_equiv_def)
+
+lemma equiv_asid_equiv_update[Scheduler_IF_assms]:
+  "\<lbrakk> get_tcb x s = Some y; equiv_asid asid st s \<rbrakk>
+     \<Longrightarrow> equiv_asid asid st (s\<lparr>kheap := kheap s(x \<mapsto> TCB y')\<rparr>)"
+  by (clarsimp simp: equiv_asid_def obj_at_def get_tcb_def)
+
+end
+
+context begin interpretation Arch .
+
+requalify_consts
+  arch_globals_equiv_scheduler
+  arch_scheduler_affects_equiv
+
+end
+
+
+global_interpretation Scheduler_IF_1?:
+  Scheduler_IF_1 arch_globals_equiv_scheduler arch_scheduler_affects_equiv
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Scheduler_IF_assms)?)
+qed
+
+
+context Arch begin global_naming ARM
+
+definition swap_things where
+  "swap_things s t \<equiv>
+     t\<lparr>machine_state := underlying_memory_update
+                          (\<lambda>m a. if a \<in> scheduler_affects_globals_frame t
+                                 then underlying_memory (machine_state s) a
+                                 else m a)
+                          (machine_state t)\<lparr>exclusive_state := exclusive_state (machine_state s)\<rparr>\<rparr>
+      \<lparr>cur_thread := cur_thread s\<rparr>"
+
+lemma globals_equiv_scheduler_inv'[Scheduler_IF_assms]:
+  "(\<And>st. \<lbrace>P and globals_equiv st\<rbrace> f \<lbrace>\<lambda>_. globals_equiv st\<rbrace>)
+   \<Longrightarrow> \<lbrace>P and globals_equiv_scheduler s\<rbrace> f \<lbrace>\<lambda>_. globals_equiv_scheduler s\<rbrace>"
+  apply atomize
+  apply (rule use_spec)
+  apply (simp add: spec_valid_def)
+  apply (erule_tac x="(swap_things sa s)" in allE)
+  apply (rule_tac Q="\<lambda>r st. globals_equiv (swap_things sa s) st" in hoare_strengthen_post)
+   apply (rule hoare_pre)
+    apply assumption
+   apply (clarsimp simp: globals_equiv_def swap_things_def globals_equiv_scheduler_def
+                         arch_globals_equiv_scheduler_def arch_scheduler_affects_equiv_def)+
+  done
+
+lemma clearExMonitor_globals_equiv_scheduler[wp]:
+  "do_machine_op clearExMonitor \<lbrace>globals_equiv_scheduler sta\<rbrace>"
+  unfolding clearExMonitor_def including no_pre
+  apply (wp dmo_no_mem_globals_equiv_scheduler)
+   apply simp
+  apply (simp add: simpler_modify_def valid_def)
+  done
+
+lemma arch_switch_to_thread_globals_equiv_scheduler[Scheduler_IF_assms]:
+  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
+   arch_switch_to_thread thread
+   \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
+  unfolding arch_switch_to_thread_def storeWord_def
+  by (wpsimp wp: clearExMonitor_globals_equiv_scheduler dmo_wp modify_wp thread_get_wp'
+      | wp (once) globals_equiv_scheduler_inv'[where P="\<top>"])+
+
+crunches arch_activate_idle_thread
+  for silc_dom_equiv[Scheduler_IF_assms, wp]: "silc_dom_equiv aag st"
+  and scheduler_affects_equiv[Scheduler_IF_assms, wp]: "scheduler_affects_equiv aag l st"
+
+lemma dmo_mol_exclusive_state[wp]:
+  "do_machine_op (machine_op_lift mop) \<lbrace>\<lambda>s. P (exclusive_state (machine_state s))\<rbrace>"
+  by (wp mol_exclusive_state dmo_wp
+      | simp add: split_def dmo_bind_valid writeTTBR0_def isb_def dsb_def)+
+
+crunch exclusive_state[wp]: set_vm_root "\<lambda>s. P (exclusive_state (machine_state s))"
+  (ignore: do_machine_op
+     simp: invalidateLocalTLB_ASID_def setHardwareASID_def set_current_pd_def dsb_def isb_def
+           writeTTBR0_def dmo_bind_valid crunch_simps)
+
+lemma set_vm_root_arch_scheduler_affects_equiv[wp]:
+  "set_vm_root tcb \<lbrace>arch_scheduler_affects_equiv st\<rbrace>"
+  unfolding arch_scheduler_affects_equiv_def by wpsimp
+
+lemmas set_vm_root_scheduler_affects_equiv[wp] =
+  scheduler_affects_equiv_unobservable[OF set_vm_root_states_equiv_for
+                                          set_vm_root_exst _ _ _ set_vm_root_it
+                                          set_vm_root_arch_scheduler_affects_equiv]
+
+lemma set_vm_root_reads_respects_scheduler[wp]:
+  "reads_respects_scheduler aag l \<top> (set_vm_root thread)"
+  apply (rule reads_respects_scheduler_unobservable'[OF scheduler_equiv_lift'
+                                                          [OF globals_equiv_scheduler_inv']])
+  apply (wp silc_dom_equiv_states_equiv_lift set_vm_root_states_equiv_for | simp)+
+  done
+
+lemma ev_asahi_to_asahi_ex_dmo_clearExMonitor:
+  "equiv_valid (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+               (asahi_ex_scheduler_affects_equiv aag l) \<top> (do_machine_op clearExMonitor)"
+  apply (simp add: clearExMonitor_def)
+  apply (wp dmo_ev)
+  apply (rule ev_modify)
+  apply clarsimp
+  apply (rule conjI)
+   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
+                         silc_dom_equiv_def equiv_for_def)
+  apply (clarsimp simp: midstrength_scheduler_affects_equiv_def asahi_scheduler_affects_equiv_def
+                        asahi_ex_scheduler_affects_equiv_def states_equiv_for_def equiv_for_def
+                        arch_scheduler_affects_equiv_def equiv_asids_def equiv_asid_def
+                        scheduler_globals_frame_equiv_def
+              simp del: split_paired_All)
+  done
+
+lemma store_cur_thread_fragment_midstrength_reads_respects:
+  "equiv_valid (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+               (scheduler_affects_equiv aag l) invs
+               (do y \<leftarrow> do_machine_op clearExMonitor;
+                   x \<leftarrow> modify (cur_thread_update (\<lambda>_. t));
+                   set_scheduler_action resume_cur_thread
+                od)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule bind_ev_general[OF ev_asahi_ex_to_full_fragement])
+    apply (rule ev_asahi_to_asahi_ex_dmo_clearExMonitor)
+   apply wp
+  apply simp
+  done
+
+lemma arch_switch_to_thread_globals_equiv_scheduler':
+  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
+   set_vm_root t
+   \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
+  by (rule globals_equiv_scheduler_inv', wpsimp)
+
+lemma reads_respects_scheduler_clearExMonitor[wp]:
+  "reads_respects_scheduler aag l \<top> (do_machine_op clearExMonitor)"
+  apply (simp add: clearExMonitor_def)
+  apply (wp dmo_ev)
+  apply (rule ev_modify)
+  apply clarsimp
+  apply (rule conjI)
+   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
+                         silc_dom_equiv_def equiv_for_def)
+  apply (clarsimp simp: scheduler_affects_equiv_def arch_scheduler_affects_equiv_def
+                        states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def
+                        scheduler_globals_frame_equiv_def
+              simp del: split_paired_All)
+  done
+
+lemma arch_switch_to_thread_reads_respects_scheduler[wp]:
+  "reads_respects_scheduler aag l
+     ((\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)) and invs)
+     (arch_switch_to_thread t)"
+  apply (rule reads_respects_scheduler_cases)
+     apply (simp add: arch_switch_to_thread_def)
+     apply wp
+    apply (clarsimp simp: scheduler_equiv_def globals_equiv_scheduler_def)
+   apply (simp add: arch_switch_to_thread_def)
+   apply wp
+  apply simp
+  done
+
+lemmas globals_equiv_scheduler_inv = globals_equiv_scheduler_inv'[where P="\<top>",simplified]
+
+lemma arch_switch_to_thread_midstrength_reads_respects_scheduler[Scheduler_IF_assms, wp]:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "midstrength_reads_respects_scheduler aag l
+           (invs and pas_refined aag and (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
+           (do _ <- arch_switch_to_thread t;
+               _ <- modify (cur_thread_update (\<lambda>_. t));
+               modify (scheduler_action_update (\<lambda>_. resume_cur_thread))
+            od)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule midstrength_reads_respects_scheduler_cases[
+                    where Q="(invs and pas_refined aag and
+                                  (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))",
+                    OF domains_distinct])
+       apply (simp add: arch_switch_to_thread_def bind_assoc)
+       apply (rule bind_ev_general)
+         apply (fold set_scheduler_action_def)
+         apply (rule store_cur_thread_fragment_midstrength_reads_respects)
+        apply (rule_tac P="\<top>" and P'="\<top>" in equiv_valid_inv_unobservable)
+            apply (rule hoare_pre)
+             apply (rule scheduler_equiv_lift'[where P=\<top>])
+                  apply (wp globals_equiv_scheduler_inv silc_dom_lift | simp)+
+           apply (wp midstrength_scheduler_affects_equiv_unobservable set_vm_root_states_equiv_for
+                  | simp)+
+          apply (wp cur_thread_update_not_subject_reads_respects_scheduler | simp | fastforce)+
+  done
+
+lemma arch_switch_to_idle_thread_globals_equiv_scheduler[Scheduler_IF_assms, wp]:
+  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
+   arch_switch_to_idle_thread
+   \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
+  unfolding arch_switch_to_idle_thread_def storeWord_def
+  by (wp dmo_wp modify_wp thread_get_wp' arch_switch_to_thread_globals_equiv_scheduler')
+
+lemma arch_switch_to_idle_thread_unobservable[Scheduler_IF_assms]:
+  "\<lbrace>(\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l = {}) and
+    scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and invs\<rbrace>
+   arch_switch_to_idle_thread
+   \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
+  apply (simp add: arch_switch_to_idle_thread_def)
+  apply wp
+  apply (clarsimp simp add: scheduler_equiv_def domain_fields_equiv_def invs_def valid_state_def)
+  done
+
+lemma clearExMonitor_unobservable:
+  "\<lbrace>(\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l = {}) and
+    scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain s = cur_domain st)\<rbrace>
+   do_machine_op clearExMonitor
+   \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
+  apply (simp add: clearExMonitor_def)
+  apply (rule hoare_pre)
+   apply (wp dmo_wp modify_wp)
+  apply (auto simp: states_equiv_for_def scheduler_affects_equiv_def equiv_for_def equiv_asids_def
+                    equiv_asid_def scheduler_globals_frame_equiv_def silc_dom_equiv_def)
+  done
+
+lemma arch_switch_to_thread_unobservable[Scheduler_IF_assms]:
+  "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
+    scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and invs\<rbrace>
+   arch_switch_to_thread t
+   \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
+  apply (simp add: arch_switch_to_thread_def)
+  apply (wp set_vm_root_scheduler_affects_equiv clearExMonitor_unobservable | simp)+
+  done
+
+(* Can split, but probably more effort to generalise *)
+lemma next_domain_midstrength_equiv_scheduler[Scheduler_IF_assms]:
+  "equiv_valid (scheduler_equiv aag) (weak_scheduler_affects_equiv aag l)
+               (midstrength_scheduler_affects_equiv aag l) \<top> next_domain"
+  apply (simp add: next_domain_def)
+  apply (rule ev_modify)
+  apply (clarsimp simp: equiv_for_def equiv_asid_def equiv_asids_def Let_def scheduler_equiv_def
+                        globals_equiv_scheduler_def silc_dom_equiv_def domain_fields_equiv_def
+                        weak_scheduler_affects_equiv_def midstrength_scheduler_affects_equiv_def
+                        states_equiv_for_def idle_equiv_def)
+  done
+
+lemma resetTimer_exclusive_state[wp]:
+  "resetTimer \<lbrace>\<lambda>s. P (exclusive_state s)\<rbrace>"
+  by (wpsimp simp: resetTimer_def wp: mol_exclusive_state)
+
+lemma resetTimer_irq_state[wp]:
+  "resetTimer \<lbrace>\<lambda>s. P (irq_state s)\<rbrace>"
+  apply (simp add: resetTimer_def machine_op_lift_def machine_rest_lift_def)
+  apply (wp | wpc| simp)+
+  done
+
+lemma dmo_resetTimer_reads_respects_scheduler[Scheduler_IF_assms]:
+  "reads_respects_scheduler aag l \<top> (do_machine_op resetTimer)"
+  apply (rule reads_respects_scheduler_unobservable)
+   apply (rule scheduler_equiv_lift)
+        apply (simp add: globals_equiv_scheduler_def[abs_def]  idle_equiv_def)
+        apply (wpsimp wp: dmo_wp)
+       apply ((wp silc_dom_lift dmo_wp | simp)+)[5]
+  apply (rule scheduler_affects_equiv_unobservable)
+        apply (simp add: states_equiv_for_def[abs_def] equiv_for_def equiv_asids_def equiv_asid_def)
+        apply (rule hoare_pre)
+         apply (wp  | simp add: arch_scheduler_affects_equiv_def | wp dmo_wp)+
+  done
+
+lemma ackInterrupt_reads_respects_scheduler[Scheduler_IF_assms]:
+  "reads_respects_scheduler aag l \<top> (do_machine_op (ackInterrupt irq))"
+  apply (rule reads_respects_scheduler_unobservable)
+   apply (rule scheduler_equiv_lift)
+        apply (simp add:  globals_equiv_scheduler_def[abs_def] idle_equiv_def)
+        apply (rule hoare_pre)
+         apply wps
+         apply (wp dmo_wp ackInterrupt_irq_masks | simp add:no_irq_def)+
+        apply clarsimp
+       apply ((wp silc_dom_lift dmo_wp | simp)+)[5]
+  apply (rule scheduler_affects_equiv_unobservable)
+        apply (simp add: states_equiv_for_def[abs_def] equiv_for_def equiv_asids_def equiv_asid_def)
+        apply (rule hoare_pre)
+         apply wps
+         apply (wp dmo_wp | simp add: arch_scheduler_affects_equiv_def ackInterrupt_def)+
+   apply (wp mol_exclusive_state)
+  apply (simp add: arch_scheduler_affects_equiv_def)
+  done
+
+lemma thread_set_scheduler_affects_equiv[Scheduler_IF_assms, wp]:
+  "\<lbrace>(\<lambda>s. x \<noteq> idle_thread s \<longrightarrow> pasObjectAbs aag x \<notin> reads_scheduler aag l) and
+    (\<lambda>s. x = idle_thread s \<longrightarrow> tc = idle_context s) and scheduler_affects_equiv aag l st\<rbrace>
+   thread_set (tcb_arch_update (arch_tcb_context_set tc)) x
+   \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
+  apply (simp add: thread_set_def)
+  apply (wp set_object_wp)
+  apply (intro impI conjI)
+  apply (case_tac "x \<noteq> idle_thread s",simp_all)
+   apply (clarsimp simp: scheduler_affects_equiv_def get_tcb_def scheduler_globals_frame_equiv_def
+                  split: option.splits kernel_object.splits)
+   apply (clarsimp simp: arch_scheduler_affects_equiv_def)
+   apply (elim states_equiv_forE equiv_forE)
+   apply (rule states_equiv_forI,simp_all add: equiv_for_def equiv_asids_def equiv_asid_def)
+   apply (clarsimp simp: obj_at_def)
+  apply (clarsimp simp: idle_context_def get_tcb_def
+                  split: option.splits kernel_object.splits)
+  apply (subst arch_tcb_update_aux)
+  apply simp
+  apply (subgoal_tac "s = (s\<lparr>kheap := kheap s(idle_thread s \<mapsto> TCB y)\<rparr>)", simp)
+  apply (rule state.equality)
+            apply (rule ext)
+            apply simp+
+  done
+
+lemma set_object_reads_respects_scheduler[Scheduler_IF_assms, wp]:
+  "reads_respects_scheduler aag l \<top> (set_object ptr obj)"
+  unfolding equiv_valid_def2 equiv_valid_2_def
+  by (auto simp: set_object_def bind_def get_def put_def return_def get_object_def assert_def
+                 fail_def gets_def scheduler_equiv_def domain_fields_equiv_def equiv_for_def
+                 globals_equiv_scheduler_def arch_globals_equiv_scheduler_def silc_dom_equiv_def
+                 scheduler_affects_equiv_def arch_scheduler_affects_equiv_def
+                 scheduler_globals_frame_equiv_def identical_kheap_updates_def
+          intro: states_equiv_for_identical_kheap_updates idle_equiv_identical_kheap_updates)
+
+lemma arch_activate_idle_thread_reads_respects_scheduler[Scheduler_IF_assms, wp]:
+  "reads_respects_scheduler aag l \<top> (arch_activate_idle_thread rv)"
+  unfolding arch_activate_idle_thread_def by wpsimp
+
+end
+
+
+global_interpretation Scheduler_IF_2?:
+  Scheduler_IF_2 arch_globals_equiv_scheduler arch_scheduler_affects_equiv
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Scheduler_IF_assms)?)
+qed
+
+
+hide_fact Scheduler_IF_2.globals_equiv_scheduler_inv'
+requalify_facts ARM.globals_equiv_scheduler_inv'
+
+end

--- a/proof/infoflow/ARM/ArchScheduler_IF.thy
+++ b/proof/infoflow/ARM/ArchScheduler_IF.thy
@@ -125,7 +125,7 @@ lemma thread_set_context_globals_equiv[Scheduler_IF_assms]:
   apply (subgoal_tac "t \<noteq> arm_global_pd (arch_state s)")
    apply (clarsimp simp: idle_equiv_def globals_equiv_def tcb_at_def2 get_tcb_def idle_context_def)
    apply (clarsimp split: option.splits kernel_object.splits)
-  apply (drule arm_global_pd_not_tcb[OF invs_valid_ko_at_arch])
+  apply (drule arm_global_pd_not_tcb[OF invs_arch_state])
   apply clarsimp
   done
 

--- a/proof/infoflow/ARM/ArchSyscall_IF.thy
+++ b/proof/infoflow/ARM/ArchSyscall_IF.thy
@@ -1,0 +1,199 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchSyscall_IF
+imports Syscall_IF
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems Syscall_IF_assms
+
+lemma globals_equiv_irq_state_update[Syscall_IF_assms, simp]:
+  "globals_equiv st (s\<lparr>machine_state :=
+                       machine_state s \<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>) =
+   globals_equiv st s"
+  by (auto simp: globals_equiv_def idle_equiv_def)
+
+lemma thread_set_globals_equiv'[Syscall_IF_assms]:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch and (\<lambda>s. tptr \<noteq> idle_thread s)\<rbrace>
+   thread_set f tptr
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding thread_set_def
+  apply (wp set_object_globals_equiv)
+  apply simp
+  apply (intro impI conjI allI)
+  apply (fastforce simp: valid_ko_at_arch_def obj_at_def get_tcb_def)+
+  done
+
+lemma arch_perform_invocation_reads_respects_g[Syscall_IF_assms]:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows "reads_respects_g aag l (ct_active and authorised_arch_inv aag ai and valid_arch_inv ai
+                                           and authorised_for_globals_arch_inv ai and invs
+                                           and pas_refined aag and is_subject aag \<circ> cur_thread)
+                          (arch_perform_invocation ai)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_g)
+    apply (rule arch_perform_invocation_reads_respects[OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp arch_perform_invocation_globals_equiv)
+   apply (simp add: invs_valid_vs_lookup invs_def valid_state_def valid_pspace_def)+
+  done
+
+lemma sts_authorised_for_globals_inv[Syscall_IF_assms]:
+  "set_thread_state d f \<lbrace>authorised_for_globals_inv oper\<rbrace>"
+  unfolding authorised_for_globals_inv_def authorised_for_globals_arch_inv_def
+            authorised_for_globals_page_table_inv_def authorised_for_globals_page_inv_def
+  apply (case_tac oper)
+           apply (wp | simp)+
+  apply (rename_tac arch_invocation)
+  apply (case_tac arch_invocation)
+      apply simp
+      apply (rename_tac page_table_invocation)
+      apply (case_tac page_table_invocation)
+       apply wpsimp+
+    apply (rename_tac page_invocation)
+    apply (case_tac page_invocation)
+       apply (simp | wp hoare_ex_wp)+
+  done
+
+lemma dmo_maskInterrupt_globals_equiv[Syscall_IF_assms, wp]:
+  "do_machine_op (maskInterrupt b irq) \<lbrace>globals_equiv s\<rbrace>"
+  unfolding maskInterrupt_def
+  apply (rule dmo_no_mem_globals_equiv)
+    apply (wp modify_wp | simp)+
+  done
+
+lemma dmo_ackInterrupt_globals_equiv[Syscall_IF_assms, wp]:
+  "do_machine_op (ackInterrupt irq) \<lbrace>globals_equiv s\<rbrace>"
+  unfolding ackInterrupt_def by (rule dmo_mol_globals_equiv)
+
+lemma dmo_resetTimer_globals_equiv[Syscall_IF_assms, wp]:
+  "do_machine_op resetTimer \<lbrace>globals_equiv s\<rbrace>"
+  unfolding resetTimer_def by (rule dmo_mol_globals_equiv)
+
+lemma arch_mask_irq_signal_globals_equiv[Syscall_IF_assms, wp]:
+  "arch_mask_irq_signal irq \<lbrace>globals_equiv st\<rbrace>"
+  by wpsimp
+
+lemma handle_reserved_irq_globals_equiv[Syscall_IF_assms, wp]:
+  "handle_reserved_irq irq \<lbrace>globals_equiv st\<rbrace>"
+  unfolding handle_reserved_irq_def by wpsimp
+
+lemma handle_vm_fault_reads_respects[Syscall_IF_assms]:
+  "reads_respects aag l (K (is_subject aag thread)) (handle_vm_fault thread vmfault_type)"
+  apply (cases vmfault_type)
+   apply (wp dmo_getDFSR_reads_respects dmo_getFAR_reads_respects
+             dmo_getIFSR_reads_respects as_user_reads_respects
+          | simp add: getRestartPC_def getRegister_def)+
+  done
+
+lemma handle_hypervisor_fault_reads_respects[Syscall_IF_assms]:
+  "reads_respects aag l \<top> (handle_hypervisor_fault thread hypfault_type)"
+  by (cases hypfault_type; wpsimp)
+
+lemma handle_vm_fault_globals_equiv[Syscall_IF_assms]:
+  "\<lbrace>globals_equiv st and valid_ko_at_arch and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
+   handle_vm_fault thread vmfault_type
+   \<lbrace>\<lambda>r. globals_equiv st\<rbrace>"
+  apply (cases vmfault_type)
+   apply (wp dmo_no_mem_globals_equiv | simp add: getDFSR_def getFAR_def getIFSR_def)+
+  done
+
+lemma handle_hypervisor_fault_globals_equiv[Syscall_IF_assms]:
+  "handle_hypervisor_fault thread hypfault_type \<lbrace>globals_equiv st\<rbrace>"
+  by (cases hypfault_type; wpsimp)
+
+crunches arch_activate_idle_thread
+  for globals_equiv[Syscall_IF_assms, wp]: "globals_equiv st"
+
+lemma select_f_setNextPC_reads_respects[Syscall_IF_assms, wp]:
+  "reads_respects aag l \<top> (select_f (setNextPC a b))"
+  unfolding setNextPC_def setRegister_def
+  by (wpsimp simp: select_f_returns)
+
+lemma select_f_getRestartPC_reads_respects[Syscall_IF_assms, wp]:
+  "reads_respects aag l \<top> (select_f (getRestartPC a))"
+  unfolding getRestartPC_def getRegister_def
+  by (wpsimp simp: select_f_returns)
+
+lemma arch_activate_idle_thread_reads_respects[Syscall_IF_assms, wp]:
+  "reads_respects aag l \<top> (arch_activate_idle_thread t)"
+  unfolding arch_activate_idle_thread_def by wpsimp
+
+lemma decode_arch_invocation_authorised_for_globals[Syscall_IF_assms]:
+  "\<lbrace>invs and cte_wp_at ((=) (ArchObjectCap cap)) slot
+         and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)\<rbrace>
+   arch_decode_invocation label msg x_slot slot cap excaps
+   \<lbrace>authorised_for_globals_arch_inv\<rbrace>, -"
+  unfolding arch_decode_invocation_def authorised_for_globals_arch_inv_def
+  apply (rule hoare_pre)
+   apply (simp add: split_def Let_def
+               cong: cap.case_cong arch_cap.case_cong if_cong option.case_cong
+               split del: if_split)
+   apply (wp select_wp select_ext_weak_wp whenE_throwError_wp check_vp_wpR unlessE_wp get_pde_wp
+             get_master_pde_wp find_pd_for_asid_authority3 create_mapping_entries_parent_for_refs
+          | wpc
+          | simp add: authorised_for_globals_page_inv_def
+                 del: hoare_True_E_R)+
+     apply (simp cong: if_cong)
+     apply (wp hoare_vcg_if_lift2)
+     apply (rule hoare_conjI)
+      apply (rule hoare_drop_imps)
+      apply (simp add: authorised_for_globals_page_table_inv_def)
+      apply wp
+     apply (rule hoare_drop_imps)
+     apply wp
+    apply ((wp hoare_TrueI hoare_vcg_all_lift hoare_drop_imps | wpc | simp)+)[3]
+  apply (clarsimp simp: authorised_asid_pool_inv_def authorised_page_table_inv_def
+                        neq_Nil_conv invs_psp_aligned invs_vspace_objs cli_no_irqs)
+  apply (drule cte_wp_valid_cap, clarsimp+)
+  apply (cases cap, simp_all)
+    \<comment> \<open>PageCap\<close>
+    apply (clarsimp simp: valid_cap_simps cli_no_irqs)
+    apply (cases "invocation_type label";
+           (rename_tac arch, case_tac arch; simp add: isPageFlushLabel_def isPDFlushLabel_def))
+          \<comment> \<open>Map\<close>
+          apply (rename_tac word cap_rights vmpage_size option arch)
+          apply (clarsimp simp: isPageFlushLabel_def isPDFlushLabel_def | rule conjI)+
+            apply (drule cte_wp_valid_cap)
+             apply (clarsimp simp: invs_def valid_state_def)
+            apply (simp add: valid_cap_def)
+           apply (simp add: vmsz_aligned_def)
+           apply (drule_tac ptr="msg ! 0" and off="2 ^ pageBitsForSize vmpage_size - 1"
+                         in is_aligned_no_wrap')
+            apply (insert pbfs_less_wb')
+            apply (clarsimp)
+           apply (fastforce simp: x_power_minus_1)
+          apply (clarsimp)
+          apply (fastforce dest: cte_wp_valid_cap simp: invs_def valid_state_def valid_cap_def)
+         \<comment> \<open>Unmap\<close>
+         apply (simp add: authorised_for_globals_page_inv_def)+
+   apply (clarsimp)
+   \<comment> \<open>PageTableCap\<close>
+   apply (clarsimp simp: authorised_for_globals_page_table_inv_def)
+   apply (frule_tac vptr="msg ! 0" in pd_shifting')
+   apply (clarsimp simp: invs_def valid_state_def valid_global_refs_def valid_refs_def global_refs_def)
+   apply (erule_tac x=aa in allE)
+   apply (erule_tac x=b in allE)
+   apply (drule_tac P'="\<lambda>c. idle_thread s \<in> cap_range c
+                          \<or> arm_global_pd (arch_state s) \<in> cap_range c
+                          \<or> (range (interrupt_irq_node s) \<union> set (arm_global_pts (arch_state s)))
+                             \<inter> cap_range c \<noteq> {}" in cte_wp_at_weakenE)
+    apply (auto simp: cap_range_def)
+  done
+
+end
+
+
+global_interpretation Syscall_IF_1?: Syscall_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Syscall_IF_assms)?)
+qed
+
+end

--- a/proof/infoflow/ARM/ArchSyscall_IF.thy
+++ b/proof/infoflow/ARM/ArchSyscall_IF.thy
@@ -19,14 +19,14 @@ lemma globals_equiv_irq_state_update[Syscall_IF_assms, simp]:
   by (auto simp: globals_equiv_def idle_equiv_def)
 
 lemma thread_set_globals_equiv'[Syscall_IF_assms]:
-  "\<lbrace>globals_equiv s and valid_ko_at_arch and (\<lambda>s. tptr \<noteq> idle_thread s)\<rbrace>
+  "\<lbrace>globals_equiv s and valid_arch_state and (\<lambda>s. tptr \<noteq> idle_thread s)\<rbrace>
    thread_set f tptr
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding thread_set_def
   apply (wp set_object_globals_equiv)
   apply simp
   apply (intro impI conjI allI)
-  apply (fastforce simp: valid_ko_at_arch_def obj_at_def get_tcb_def)+
+  apply (fastforce simp: obj_at_def get_tcb_def valid_arch_state_def)+
   done
 
 lemma arch_perform_invocation_reads_respects_g[Syscall_IF_assms]:
@@ -96,7 +96,7 @@ lemma handle_hypervisor_fault_reads_respects[Syscall_IF_assms]:
   by (cases hypfault_type; wpsimp)
 
 lemma handle_vm_fault_globals_equiv[Syscall_IF_assms]:
-  "\<lbrace>globals_equiv st and valid_ko_at_arch and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
+  "\<lbrace>globals_equiv st and valid_arch_state and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
    handle_vm_fault thread vmfault_type
    \<lbrace>\<lambda>r. globals_equiv st\<rbrace>"
   apply (cases vmfault_type)

--- a/proof/infoflow/ARM/ArchTcb_IF.thy
+++ b/proof/infoflow/ARM/ArchTcb_IF.thy
@@ -34,10 +34,6 @@ lemma cap_ne_global_pd:
   apply blast
   done
 
-lemma valid_ko_at_arch_irq_state_independent_A[Tcb_IF_assms, simp, intro!]:
-  "irq_state_independent_A (valid_ko_at_arch)"
-  by (auto simp: irq_state_independent_A_def valid_ko_at_arch_def)
-
 lemma valid_arch_caps_vs_lookup[Tcb_IF_assms]:
   "valid_arch_caps s \<Longrightarrow> valid_vs_lookup s"
   by (simp add: valid_arch_caps_def)
@@ -61,7 +57,7 @@ lemma no_cap_to_idle_thread''[Tcb_IF_assms]:
 
 crunches arch_post_modify_registers
   for globals_equiv[Tcb_IF_assms, wp]: "globals_equiv st"
-  and valid_ko_at_arch[Tcb_IF_assms, wp]: valid_ko_at_arch
+  and valid_arch_state[Tcb_IF_assms, wp]: valid_arch_state
 
 lemma arch_post_modify_registers_reads_respects_f[Tcb_IF_assms, wp]:
   "reads_respects_f aag l \<top> (arch_post_modify_registers cur t)"

--- a/proof/infoflow/ARM/ArchTcb_IF.thy
+++ b/proof/infoflow/ARM/ArchTcb_IF.thy
@@ -1,0 +1,252 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchTcb_IF
+imports Tcb_IF
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems Tcb_IF_assms
+
+section "arm global pd"
+
+crunch arm_global_pd[wp]: set_irq_state, suspend "\<lambda>s. P (arm_global_pd (arch_state s))"
+  (wp: mapM_x_wp select_inv hoare_vcg_if_lift2 hoare_drop_imps dxo_wp_weak
+   simp: unless_def
+   ignore: empty_slot_ext reschedule_required)
+
+crunch arm_global_pd[wp]: as_user, restart "\<lambda>s. P (arm_global_pd (arch_state s))" (wp: dxo_wp_weak)
+
+lemma cap_ne_global_pd:
+  "\<lbrakk> ex_nonz_cap_to word s; valid_global_refs s \<rbrakk>
+     \<Longrightarrow> word \<noteq> arm_global_pd (arch_state s)"
+  unfolding ex_nonz_cap_to_def
+  apply (simp only: cte_wp_at_caps_of_state zobj_refs_to_obj_refs)
+  apply (elim exE conjE)
+  apply (drule valid_global_refsD2,simp)
+  apply (unfold global_refs_def)
+  apply clarsimp
+  apply (unfold cap_range_def)
+  apply blast
+  done
+
+lemma valid_ko_at_arch_irq_state_independent_A[Tcb_IF_assms, simp, intro!]:
+  "irq_state_independent_A (valid_ko_at_arch)"
+  by (auto simp: irq_state_independent_A_def valid_ko_at_arch_def)
+
+lemma valid_arch_caps_vs_lookup[Tcb_IF_assms]:
+  "valid_arch_caps s \<Longrightarrow> valid_vs_lookup s"
+  by (simp add: valid_arch_caps_def)
+
+lemma no_cap_to_idle_thread'[Tcb_IF_assms]:
+  "valid_global_refs s \<Longrightarrow> \<not> ex_nonz_cap_to (idle_thread s) s"
+  apply (clarsimp simp add: ex_nonz_cap_to_def valid_global_refs_def valid_refs_def)
+  apply (drule_tac x=a in spec)
+  apply (drule_tac x=b in spec)
+  apply (clarsimp simp: cte_wp_at_def global_refs_def cap_range_def)
+  apply (case_tac cap,simp_all)
+  done
+
+lemma no_cap_to_idle_thread''[Tcb_IF_assms]:
+  "valid_global_refs s \<Longrightarrow> caps_of_state s ref \<noteq> Some (ThreadCap (idle_thread s))"
+  apply (clarsimp simp add: valid_global_refs_def valid_refs_def cte_wp_at_caps_of_state)
+  apply (drule_tac x="fst ref" in spec)
+  apply (drule_tac x="snd ref" in spec)
+  apply (simp add: cap_range_def global_refs_def)
+  done
+
+crunches arch_post_modify_registers
+  for globals_equiv[Tcb_IF_assms, wp]: "globals_equiv st"
+  and valid_ko_at_arch[Tcb_IF_assms, wp]: valid_ko_at_arch
+
+lemma arch_post_modify_registers_reads_respects_f[Tcb_IF_assms, wp]:
+  "reads_respects_f aag l \<top> (arch_post_modify_registers cur t)"
+  by wpsimp
+
+lemma arch_get_sanitise_register_info_reads_respects_f[Tcb_IF_assms, wp]:
+  "reads_respects_f aag l \<top> (arch_get_sanitise_register_info rv)"
+  by wpsimp
+
+end
+
+
+global_interpretation Tcb_IF_1?: Tcb_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Tcb_IF_assms)?)
+qed
+
+
+context Arch begin global_naming ARM
+
+(* FIXME: Pretty general. Probably belongs somewhere else *)
+lemma invoke_tcb_thread_preservation[Tcb_IF_assms]:
+  assumes cap_delete_P: "\<And>slot. \<lbrace>invs and P and emptyable slot\<rbrace> cap_delete slot \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes cap_insert_P: "\<And>new_cap src dest. \<lbrace>invs and P\<rbrace> cap_insert new_cap src dest \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes thread_set_P: "\<And>f ptr. \<lbrace>invs and P\<rbrace> thread_set (tcb_ipc_buffer_update f) ptr \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes thread_set_P': "\<And>f ptr. \<lbrace>invs and P\<rbrace> thread_set (tcb_fault_handler_update f) ptr \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes set_mcpriority_P: "\<And>mcp ptr. \<lbrace>invs and P\<rbrace> set_mcpriority ptr mcp \<lbrace>\<lambda>_.P\<rbrace>"
+  assumes P_trans[simp]: "\<And>f s. P (trans_state f s) = P s"
+  shows
+    "\<lbrace>P and invs and tcb_inv_wf (tcb_invocation.ThreadControl t sl ep mcp prio croot vroot buf)\<rbrace>
+     invoke_tcb (tcb_invocation.ThreadControl t sl ep mcp prio croot vroot buf)
+     \<lbrace>\<lambda>rv s :: det_state. P s\<rbrace>"
+  supply set_priority_extended.dxo_eq[simp del]
+         reschedule_required_ext_extended.dxo_eq[simp del]
+  apply (simp add: split_def cong: option.case_cong)
+  apply (rule hoare_vcg_precond_imp)
+   apply (rule_tac P="case ep of Some v \<Rightarrow> length v = word_bits | _ \<Rightarrow> True"
+                in hoare_gen_asm)
+   apply wp
+        apply ((simp add: conj_comms(1, 2) del: hoare_True_E_R
+                | rule wp_split_const_if wp_split_const_if_R hoare_vcg_all_lift_R
+                       hoare_vcg_E_elim hoare_vcg_const_imp_lift_R hoare_vcg_R_conj
+                | (wp check_cap_inv2[where Q="\<lambda>_. pas_refined aag"]
+                      check_cap_inv2[where Q="\<lambda>_ s. t \<noteq> idle_thread s"]
+                      out_invs_trivial case_option_wpE cap_delete_deletes
+                      cap_delete_valid_cap cap_insert_valid_cap out_cte_at
+                      cap_insert_cte_at cap_delete_cte_at out_valid_cap out_tcb_valid
+                      hoare_vcg_const_imp_lift_R hoare_vcg_all_lift_R
+                      thread_set_tcb_ipc_buffer_cap_cleared_invs
+                      thread_set_invs_trivial[OF ball_tcb_cap_casesI]
+                      hoare_vcg_all_lift thread_set_valid_cap out_emptyable
+                      check_cap_inv [where P="valid_cap c" for c]
+                      check_cap_inv [where P="tcb_cap_valid c p" for c p]
+                      check_cap_inv[where P="cte_at p0" for p0]
+                      check_cap_inv[where P="tcb_at p0" for p0]
+                      thread_set_cte_at thread_set_no_cap_to_trivial[OF ball_tcb_cap_casesI]
+                      checked_insert_no_cap_to
+                      thread_set_cte_wp_at_trivial[where Q="\<lambda>x. x", OF ball_tcb_cap_casesI]
+                      out_no_cap_to_trivial[OF ball_tcb_cap_casesI] thread_set_ipc_tcb_cap_valid
+                      check_cap_inv2[where Q="\<lambda>_. P"] cap_delete_P cap_insert_P
+                      thread_set_P thread_set_P' set_mcpriority_P set_mcpriority_idle_thread
+                      dxo_wp_weak static_imp_wp)
+                | simp add: ran_tcb_cap_cases dom_tcb_cap_cases[simplified] emptyable_def
+                       del: hoare_True_E_R
+                | wpc
+                | strengthen use_no_cap_to_obj_asid_strg
+                             tcb_cap_always_valid_strg[where p="tcb_cnode_index 0"]
+                             tcb_cap_always_valid_strg[where p="tcb_cnode_index (Suc 0)"])+)
+  apply (unfold option_update_thread_def)
+  apply (wp itr_wps thread_set_P thread_set_P'
+         | simp add: emptyable_def | wpc)+ (*slow*)
+  apply (clarsimp simp: tcb_at_cte_at_0 tcb_at_cte_at_1[simplified]
+                        is_cap_simps is_valid_vtable_root_def
+                        is_cnode_or_valid_arch_def tcb_cap_valid_def
+                        tcb_at_st_tcb_at[symmetric] invs_valid_objs
+                        cap_asid_def vs_cap_ref_def
+                        clas_no_asid cli_no_irqs no_cap_to_idle_thread
+                 split: option.split_asm
+         | rule conjI)+ (* also slow *)
+  done
+
+lemma tc_reads_respects_f[Tcb_IF_assms]:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  and tc[simp]: "ti = ThreadControl x41 x42 x43 x44 x45 x46 x47 x48"
+  notes validE_valid[wp del] static_imp_wp [wp]
+  shows
+    "reads_respects_f aag l
+       (silc_inv aag st and only_timer_irq_inv irq st' and einvs and simple_sched_action
+                        and pas_refined aag and pas_cur_domain aag and tcb_inv_wf ti
+                        and is_subject aag \<circ> cur_thread
+                        and K (authorised_tcb_inv aag ti \<and> authorised_tcb_inv_extra aag ti))
+       (invoke_tcb ti)"
+  apply (simp add: split_def cong: option.case_cong)
+  apply (wpsimp wp: set_priority_reads_respects[THEN reads_respects_f[where  st=st and Q=\<top>]])
+                    apply (wpsimp wp: hoare_vcg_const_imp_lift_R simp: when_def | wpc)+
+                    apply (rule conjI)
+                     apply ((wpsimp wp: reschedule_required_reads_respects_f)+)[4]
+                 apply ((wp reads_respects_f[OF cap_insert_reads_respects, where st=st]
+                           reads_respects_f[OF thread_set_reads_respects, where st=st and Q="\<top>"]
+                           set_priority_reads_respects[THEN
+                                               reads_respects_f[where aag=aag and st=st and Q=\<top>]]
+                           set_mcpriority_reads_respects[THEN
+                                               reads_respects_f[where aag=aag and st=st and Q=\<top>]]
+                           check_cap_inv[OF check_cap_inv[OF cap_insert_valid_list]]
+                           check_cap_inv[OF check_cap_inv[OF cap_insert_valid_sched]]
+                           check_cap_inv[OF check_cap_inv[OF cap_insert_schedact]]
+                           check_cap_inv[OF check_cap_inv[OF cap_insert_cur_domain]]
+                           check_cap_inv[OF check_cap_inv[OF cap_insert_ct]]
+                           get_thread_state_rev[THEN
+                                               reads_respects_f[where aag=aag and st=st and Q=\<top>]]
+                           hoare_vcg_all_lift_R hoare_vcg_all_lift
+                           cap_delete_reads_respects[where st=st] checked_insert_pas_refined
+                           thread_set_pas_refined
+                           reads_respects_f[OF checked_insert_reads_respects, where st=st]
+                           checked_cap_insert_silc_inv[where st=st]
+                           cap_delete_silc_inv_not_transferable[where st=st]
+                           checked_cap_insert_only_timer_irq_inv[where st=st' and irq=irq]
+                           cap_delete_only_timer_irq_inv[where st=st' and irq=irq]
+                           set_priority_only_timer_irq_inv[where st=st' and irq=irq]
+                           set_mcpriority_only_timer_irq_inv[where st=st' and irq=irq]
+                           cap_delete_deletes cap_delete_valid_cap cap_delete_cte_at
+                           cap_delete_pas_refined' itr_wps(12) itr_wps(14) cap_insert_cte_at
+                           checked_insert_no_cap_to hoare_vcg_const_imp_lift_R hoare_vcg_conj_lift
+                           as_user_reads_respects_f thread_set_mdb cap_delete_invs
+                      | wpc
+                      | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
+                                  tcb_at_st_tcb_at when_def
+                      | strengthen use_no_cap_to_obj_asid_strg invs_mdb
+                                   invs_psp_aligned invs_vspace_objs invs_arch_state
+                      | solves auto)+)[7]
+          apply ((simp add: conj_comms, strengthen imp_consequent[where Q="x = None" for x]
+                                      , simp cong: conj_cong)
+                 | wp reads_respects_f[OF cap_insert_reads_respects, where st=st]
+                      reads_respects_f[OF thread_set_reads_respects, where st=st and Q="\<top>"]
+                      set_priority_reads_respects[THEN reads_respects_f[where st=st and Q=\<top>]]
+                      set_mcpriority_reads_respects[THEN reads_respects_f[where st=st and Q=\<top>]]
+                      check_cap_inv[OF check_cap_inv[OF cap_insert_valid_list]]
+                      check_cap_inv[OF check_cap_inv[OF cap_insert_valid_sched]]
+                      check_cap_inv[OF check_cap_inv[OF cap_insert_schedact]]
+                      check_cap_inv[OF check_cap_inv[OF cap_insert_cur_domain]]
+                      check_cap_inv[OF check_cap_inv[OF cap_insert_ct]]
+                      get_thread_state_rev[THEN reads_respects_f[where st=st and Q=\<top>]]
+                      hoare_vcg_all_lift_R hoare_vcg_all_lift
+                      cap_delete_reads_respects[where st=st] checked_insert_pas_refined
+                      thread_set_pas_refined reads_respects_f[OF checked_insert_reads_respects]
+                      checked_cap_insert_silc_inv[where st=st]
+                      cap_delete_silc_inv_not_transferable[where st=st]
+                      checked_cap_insert_only_timer_irq_inv[where st=st' and irq=irq]
+                      cap_delete_only_timer_irq_inv[where st=st' and irq=irq]
+                      set_priority_only_timer_irq_inv[where st=st' and irq=irq]
+                      set_mcpriority_only_timer_irq_inv[where st=st' and irq=irq]
+                      cap_delete_deletes cap_delete_valid_cap cap_delete_cte_at
+                      cap_delete_pas_refined' itr_wps(12) itr_wps(14) cap_insert_cte_at
+                      checked_insert_no_cap_to hoare_vcg_const_imp_lift_R
+                      as_user_reads_respects_f cap_delete_invs
+                 | wpc
+                 | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def when_def st_tcb_at_triv
+                 | strengthen use_no_cap_to_obj_asid_strg invs_mdb
+                              invs_psp_aligned invs_vspace_objs invs_arch_state
+                 | wp (once) hoare_drop_imp)+
+    apply (simp add: option_update_thread_def tcb_cap_cases_def
+           | wp static_imp_wp static_imp_conj_wp thread_set_pas_refined
+                reads_respects_f[OF thread_set_reads_respects, where st=st and Q="\<top>"]
+           | wpc)+
+   apply (wp hoare_vcg_all_lift thread_set_tcb_fault_handler_update_invs
+             thread_set_tcb_fault_handler_update_silc_inv
+             thread_set_not_state_valid_sched
+             thread_set_pas_refined thread_set_emptyable thread_set_valid_cap
+             thread_set_cte_at thread_set_no_cap_to_trivial
+             thread_set_tcb_fault_handler_update_only_timer_irq_inv
+          | simp add: tcb_cap_cases_def | wpc | wp (once) hoare_drop_imp)+
+  apply (clarsimp simp: authorised_tcb_inv_def  authorised_tcb_inv_extra_def emptyable_def)
+  by (clarsimp simp: is_cap_simps is_cnode_or_valid_arch_def is_valid_vtable_root_def det_setRegister
+      | intro impI conjI)+
+
+end
+
+
+global_interpretation Tcb_IF_2?: Tcb_IF_2
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact Tcb_IF_assms)?)
+qed
+
+end

--- a/proof/infoflow/ARM/ArchUserOp_IF.thy
+++ b/proof/infoflow/ARM/ArchUserOp_IF.thy
@@ -1,0 +1,1011 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchUserOp_IF
+imports UserOp_IF
+begin
+
+context Arch begin global_naming ARM
+
+definition ptable_lift_s where
+  "ptable_lift_s s \<equiv> ptable_lift (cur_thread s) s"
+
+definition ptable_rights_s where
+  "ptable_rights_s s \<equiv> ptable_rights (cur_thread s) s"
+
+(* FIXME: move to ADT_AI.thy *)
+definition ptable_attrs :: "obj_ref \<Rightarrow> 'z state \<Rightarrow> word32 \<Rightarrow> vm_attributes" where
+ "ptable_attrs tcb s \<equiv>
+    \<lambda>addr. case_option {} (fst o snd o snd)
+             (get_page_info (\<lambda>obj. get_arch_obj (kheap s obj))
+                            (get_pd_of_thread (kheap s) (arch_state s) tcb) addr)"
+
+definition ptable_attrs_s :: "'z state \<Rightarrow> obj_ref \<Rightarrow> vm_attributes" where
+ "ptable_attrs_s s \<equiv> ptable_attrs (cur_thread s) s"
+
+definition ptable_xn_s where
+  "ptable_xn_s s \<equiv>  \<lambda>addr. XNever \<in> ptable_attrs_s s addr"
+
+definition getExMonitor :: "exclusive_monitors machine_monad" where
+  "getExMonitor \<equiv> gets exclusive_state"
+
+definition setExMonitor :: "exclusive_monitors \<Rightarrow> unit machine_monad" where
+  "setExMonitor es \<equiv> modify (\<lambda>ms. ms\<lparr>exclusive_state := es\<rparr>)"
+
+
+type_synonym user_state_if = "user_context \<times> user_mem \<times> device_state \<times> exclusive_monitors"
+
+text \<open>
+  A user transition gives back a possible event that is the next
+  event the user wants to perform
+\<close>
+type_synonym user_transition_if =
+  "obj_ref \<Rightarrow> vm_mapping \<Rightarrow> mem_rights \<Rightarrow> (obj_ref \<Rightarrow> bool) \<Rightarrow>
+   user_state_if \<Rightarrow> (event option \<times> user_state_if) set"
+
+definition do_user_op_if ::
+  "user_transition_if \<Rightarrow> user_context \<Rightarrow> (event option \<times> user_context,'z::state_ext) s_monad" where
+  "do_user_op_if uop tc =
+   do
+      \<comment> \<open>Get the page rights of each address (ReadOnly, ReadWrite, None, etc).\<close>
+      pr \<leftarrow> gets ptable_rights_s;
+
+      \<comment> \<open>Fetch the 'execute never' bits of the current thread's page mappings.\<close>
+      pxn \<leftarrow> gets (\<lambda>s x. pr x \<noteq> {} \<and> ptable_xn_s s x);
+
+      \<comment> \<open>Get the mapping from virtual to physical addresses.\<close>
+      pl \<leftarrow> gets (\<lambda>s. restrict_map (ptable_lift_s s) {x. pr x \<noteq> {}});
+
+      allow_read \<leftarrow> return  {y. EX x. pl x = Some y \<and> AllowRead \<in> pr x};
+      allow_write \<leftarrow> return  {y. EX x. pl x = Some y \<and> AllowWrite \<in> pr x};
+
+      \<comment> \<open>Get the current thread.\<close>
+      t \<leftarrow> gets cur_thread;
+
+      \<comment> \<open>Generate user memory by throwing away anything from global
+         memory that the user doesn't have access to. (The user must
+         have both (1) a mapping to the page; (2) that mapping has the
+         AllowRead right.\<close>
+      um \<leftarrow> gets (\<lambda>s. (user_mem s) \<circ> ptrFromPAddr);
+      dm \<leftarrow> gets (\<lambda>s. (device_mem s) \<circ> ptrFromPAddr);
+      ds \<leftarrow> gets (device_state \<circ> machine_state);
+
+      es \<leftarrow> do_machine_op getExMonitor;
+
+      \<comment> \<open>Non-deterministically execute one of the user's operations.\<close>
+      u \<leftarrow> return (uop t pl pr pxn (tc, um|`allow_read, (ds \<circ> ptrFromPAddr)|` allow_read, es));
+      assert (u \<noteq> {});
+      (e,(tc',um',ds',es')) \<leftarrow> select u;
+
+      \<comment> \<open>Update the changes the user made to memory into our model.
+         We ignore changes that took place where they didn't have
+         write permissions. (uop shouldn't be doing that --- if it is,
+         uop isn't correctly modelling real hardware.)\<close>
+      do_machine_op (user_memory_update (((um' |` allow_write) \<circ> addrFromPPtr) |` (-(dom ds))));
+
+      do_machine_op (device_memory_update (((ds' |` allow_write) \<circ> addrFromPPtr) |` (dom ds)));
+
+      \<comment> \<open>Update exclusive monitor state used by the thread.\<close>
+      do_machine_op (setExMonitor es');
+
+      return (e,tc')
+   od"
+
+
+named_theorems UserOp_IF_assms
+
+lemma arch_globals_equiv_underlying_memory_update[UserOp_IF_assms, simp]:
+  "arch_globals_equiv ct it kh kh' as as' (underlying_memory_update f ms) ms' =
+   arch_globals_equiv ct it kh kh' as as' ms ms'"
+  "arch_globals_equiv ct it kh kh' as as' ms (underlying_memory_update f ms') =
+   arch_globals_equiv ct it kh kh' as as' ms ms'"
+  by auto
+
+lemma arch_globals_equiv_device_state_update[UserOp_IF_assms, simp]:
+  "arch_globals_equiv ct it kh kh' as as' (device_state_update f ms) ms' =
+   arch_globals_equiv ct it kh kh' as as' ms ms'"
+  "arch_globals_equiv ct it kh kh' as as' ms (device_state_update f ms') =
+   arch_globals_equiv ct it kh kh' as as' ms ms'"
+  by auto
+
+end
+
+context begin interpretation Arch .
+
+requalify_types user_transition_if
+
+end
+
+
+global_interpretation UserOp_IF_1?: UserOp_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact UserOp_IF_assms)?)
+qed
+
+
+context Arch begin global_naming ARM
+
+lemma requiv_get_pd_of_thread_eq:
+  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; is_subject aag (cur_thread s);
+     pd_ref \<noteq> arm_global_pd (arch_state s); pd_ref' \<noteq> arm_global_pd (arch_state s');
+     get_pd_of_thread (kheap s) (arch_state s) (cur_thread s) = pd_ref;
+     get_pd_of_thread (kheap s') (arch_state s') (cur_thread s') = pd_ref' \<rbrakk>
+     \<Longrightarrow> pd_ref = pd_ref'"
+  apply (erule reads_equivE)
+  apply (erule equiv_forE)
+  apply (subgoal_tac "aag_can_read aag (cur_thread s)")
+   apply (clarsimp simp: get_pd_of_thread_eq)
+  apply simp
+  done
+
+lemma requiv_get_pt_entry_eq:
+  "\<lbrakk> reads_equiv aag s s'; is_subject aag pt \<rbrakk>
+     \<Longrightarrow> get_pt_entry (\<lambda>obj. get_arch_obj (kheap s obj)) pt x =
+         get_pt_entry (\<lambda>obj. get_arch_obj (kheap s' obj)) pt x"
+  apply (erule reads_equivE)
+  apply (erule equiv_forE)
+  apply (subgoal_tac "aag_can_read aag pt")
+   apply (simp add: get_pt_entry_def split: option.splits)
+  apply (simp add: reads_lrefl)
+  done
+
+lemma requiv_get_pt_info_eq:
+  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; is_subject aag pt \<rbrakk>
+     \<Longrightarrow> get_pt_info (\<lambda>obj. get_arch_obj (kheap s obj)) pt x =
+         get_pt_info (\<lambda>obj. get_arch_obj (kheap s' obj)) pt x"
+  apply (simp add: get_pt_info_def)
+  apply (subst requiv_get_pt_entry_eq, simp+)
+  done
+
+lemma requiv_get_pd_entry_eq:
+  "\<lbrakk> reads_equiv aag s s'; is_subject aag pd \<rbrakk>
+     \<Longrightarrow> get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj)) pd x =
+         get_pd_entry (\<lambda>obj. get_arch_obj (kheap s' obj)) pd x"
+  apply (erule reads_equivE)
+  apply (erule equiv_forE)
+  apply (subgoal_tac "aag_can_read aag pd")
+   apply (simp add: get_pd_entry_def split: option.splits)
+  apply simp
+  done
+
+lemma requiv_get_page_info_eq:
+  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; is_subject aag pd; x \<notin> kernel_mappings \<rbrakk>
+     \<Longrightarrow> get_page_info (\<lambda>obj. get_arch_obj (kheap s obj)) pd x =
+         get_page_info (\<lambda>obj. get_arch_obj (kheap s' obj)) pd x"
+  apply (simp add: get_page_info_def)
+  apply (subst requiv_get_pd_entry_eq[symmetric], simp+)
+  apply (clarsimp split: option.splits pde.splits)
+  apply (frule pt_in_pd_same_agent, fastforce+)
+  apply (rule requiv_get_pt_info_eq, simp+)
+  done
+
+lemma requiv_pd_of_thread_global_pd:
+  "\<lbrakk> reads_equiv aag s s'; is_subject aag (cur_thread s); invs s; pas_refined aag s;
+     get_pd_of_thread (kheap s) (arch_state s) (cur_thread s) = arm_global_pd (arch_state s) \<rbrakk>
+     \<Longrightarrow> get_pd_of_thread (kheap s') (arch_state s') (cur_thread s') = arm_global_pd (arch_state s')"
+  apply (erule reads_equivE)
+  apply (erule equiv_forE)
+  apply (subgoal_tac "aag_can_read aag (cur_thread s)")
+   prefer 2
+   apply simp
+  apply (clarsimp simp: get_pd_of_thread_def2
+                 split: option.splits kernel_object.splits cap.splits arch_cap.splits)
+  apply (rename_tac tcb word word' p apool)
+  apply (subgoal_tac "aag_can_read_asid aag word'")
+   apply (subgoal_tac "s \<turnstile> ArchObjectCap (PageDirectoryCap word (Some word'))")
+    apply (clarsimp simp: equiv_asids_def equiv_asid_def valid_cap_def)
+    apply (drule_tac x=word' in spec)
+    apply (clarsimp simp: word_gt_0 typ_at_eq_kheap_obj)
+    apply (drule invs_valid_global_refs)
+    apply (drule_tac ptr="((cur_thread s), tcb_cnode_index 1)" in valid_global_refsD2[rotated])
+     apply (subst caps_of_state_tcb_cap_cases)
+       apply (simp add: get_tcb_def)
+      apply (simp add: dom_tcb_cap_cases[simplified])
+     apply simp
+    apply (simp add: cap_range_def global_refs_def)
+   apply (cut_tac s=s and t="cur_thread s" and tcb=tcb in objs_valid_tcb_vtable)
+     apply (fastforce simp: invs_valid_objs get_tcb_def)+
+  apply (subgoal_tac "(pasObjectAbs aag (cur_thread s), Control, pasASIDAbs aag word')
+                        \<in> state_asids_to_policy aag s")
+   apply (frule pas_refined_Control_into_is_subject_asid)
+    apply (fastforce simp: pas_refined_def)
+   apply simp
+  apply (cut_tac aag=aag and ptr="(cur_thread s, tcb_cnode_index 1)" in sata_asid)
+    prefer 3
+    apply simp
+   apply (subst caps_of_state_tcb_cap_cases)
+     apply (simp add: get_tcb_def)
+    apply (simp add: dom_tcb_cap_cases[simplified])+
+  done
+
+lemma requiv_ptable_rights_eq:
+  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; pas_refined aag s';
+     is_subject aag (cur_thread s); invs s; invs s' \<rbrakk>
+     \<Longrightarrow> ptable_rights_s s = ptable_rights_s s'"
+  apply (simp add: ptable_rights_s_def)
+  apply (rule ext)
+  apply (case_tac "x \<in> kernel_mappings")
+   apply (clarsimp simp: ptable_rights_def split: option.splits)
+   apply (rule conjI)
+    apply clarsimp
+    apply (frule some_get_page_info_kmapsD)
+       apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
+                               vspace_cap_rights_to_auth_def)+)[4]
+   apply clarsimp
+   apply (frule some_get_page_info_kmapsD)
+      apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
+                              vspace_cap_rights_to_auth_def)+)[4]
+   apply clarsimp
+   apply (frule_tac r=b in some_get_page_info_kmapsD)
+      apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
+                              vspace_cap_rights_to_auth_def)+)[4]
+  apply (case_tac "get_pd_of_thread (kheap s) (arch_state s) (cur_thread s) =
+                   arm_global_pd (arch_state s)")
+   apply (frule requiv_pd_of_thread_global_pd)
+       apply (fastforce+)[4]
+   apply (clarsimp simp: ptable_rights_def split: option.splits)
+   apply (rule conjI)
+    apply clarsimp
+    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
+      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+   apply clarsimp
+   apply (rule conjI)
+    apply clarsimp
+    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
+      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+   apply clarsimp
+   apply (frule get_page_info_gpd_kmaps[rotated, rotated])
+     apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+  apply (case_tac "get_pd_of_thread (kheap s') (arch_state s') (cur_thread s') =
+                   arm_global_pd (arch_state s')")
+   apply (drule reads_equiv_sym)
+   apply (frule requiv_pd_of_thread_global_pd)
+       apply ((fastforce simp: reads_equiv_def)+)[5]
+  apply (simp add: ptable_rights_def)
+  apply (frule requiv_get_pd_of_thread_eq)
+        apply (fastforce+)[6]
+  apply (frule pd_of_thread_same_agent, simp+)
+  apply (subst requiv_get_page_info_eq, simp+)
+  done
+
+lemma requiv_ptable_attrs_eq:
+  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; pas_refined aag s';
+     is_subject aag (cur_thread s); invs s; invs s'; ptable_rights_s s x \<noteq> {} \<rbrakk>
+     \<Longrightarrow> ptable_attrs_s s x = ptable_attrs_s s' x"
+  apply (simp add: ptable_attrs_s_def ptable_rights_s_def)
+  apply (case_tac "x \<in> kernel_mappings")
+   apply (clarsimp simp: ptable_attrs_def split: option.splits)
+   apply (rule conjI)
+    apply clarsimp
+    apply (frule some_get_page_info_kmapsD)
+       apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
+                               vspace_cap_rights_to_auth_def ptable_rights_def)+)[4]
+   apply clarsimp
+   apply (frule some_get_page_info_kmapsD)
+      apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
+                              vspace_cap_rights_to_auth_def ptable_rights_def)+)[4]
+  apply (case_tac "get_pd_of_thread (kheap s) (arch_state s) (cur_thread s) =
+                   arm_global_pd (arch_state s)")
+   apply (frule requiv_pd_of_thread_global_pd)
+       apply (fastforce+)[4]
+   apply (clarsimp simp: ptable_attrs_def split: option.splits)
+   apply (rule conjI)
+    apply clarsimp
+    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
+      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+   apply clarsimp
+   apply (rule conjI)
+    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
+      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+   apply clarsimp
+   apply (frule get_page_info_gpd_kmaps[rotated, rotated])
+     apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+  apply (case_tac "get_pd_of_thread (kheap s') (arch_state s') (cur_thread s') =
+                   arm_global_pd (arch_state s')")
+   apply (drule reads_equiv_sym)
+   apply (frule requiv_pd_of_thread_global_pd)
+       apply ((fastforce simp: reads_equiv_def)+)[5]
+  apply (simp add: ptable_attrs_def)
+  apply (frule requiv_get_pd_of_thread_eq, simp+)[1]
+  apply (frule pd_of_thread_same_agent, simp+)[1]
+  apply (subst requiv_get_page_info_eq, simp+)[1]
+  done
+
+lemma requiv_ptable_lift_eq:
+  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; pas_refined aag s'; invs s;
+     invs s'; is_subject aag (cur_thread s); ptable_rights_s s x \<noteq> {} \<rbrakk>
+     \<Longrightarrow> ptable_lift_s s x = ptable_lift_s s' x"
+  apply (simp add: ptable_lift_s_def ptable_rights_s_def)
+  apply (case_tac "x \<in> kernel_mappings")
+   apply (clarsimp simp: ptable_lift_def split: option.splits)
+   apply (rule conjI)
+    apply clarsimp
+    apply (frule some_get_page_info_kmapsD)
+       apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
+                               vspace_cap_rights_to_auth_def ptable_rights_def)+)[4]
+   apply clarsimp
+   apply (frule some_get_page_info_kmapsD)
+      apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
+                              vspace_cap_rights_to_auth_def ptable_rights_def)+)[4]
+  apply (case_tac "get_pd_of_thread (kheap s) (arch_state s) (cur_thread s) =
+                   arm_global_pd (arch_state s)")
+   apply (frule requiv_pd_of_thread_global_pd)
+       apply (fastforce+)[4]
+   apply (clarsimp simp: ptable_lift_def split: option.splits)
+   apply (rule conjI)
+    apply clarsimp
+    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
+      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+   apply clarsimp
+   apply (rule conjI)
+    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
+      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+   apply clarsimp
+   apply (frule get_page_info_gpd_kmaps[rotated, rotated])
+     apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+  apply (case_tac "get_pd_of_thread (kheap s') (arch_state s') (cur_thread s') =
+                   arm_global_pd (arch_state s')")
+   apply (drule reads_equiv_sym)
+   apply (frule requiv_pd_of_thread_global_pd)
+       apply ((fastforce simp: reads_equiv_def)+)[5]
+  apply (simp add: ptable_lift_def)
+  apply (frule requiv_get_pd_of_thread_eq, simp+)[1]
+  apply (frule pd_of_thread_same_agent, simp+)[1]
+  apply (subst requiv_get_page_info_eq, simp+)[1]
+  done
+
+lemma requiv_ptable_xn_eq:
+  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; pas_refined aag s';
+     is_subject aag (cur_thread s); invs s; invs s'; ptable_rights_s s x \<noteq> {} \<rbrakk>
+     \<Longrightarrow> ptable_xn_s s x = ptable_xn_s s' x"
+  by (simp add: ptable_xn_s_def requiv_ptable_attrs_eq)
+
+lemma mask_shift_le:
+  "z \<le> y \<Longrightarrow> (x :: 'a :: len word) && ~~ mask z >> y = x >> y"
+proof -
+  assume le: "z \<le> y"
+  have shifttwice: "\<And>(x :: 'a :: len word). x >> y = x >> z >> y - z"
+    by (simp add: shiftr_shiftr le)
+  show ?thesis
+    apply (subst shifttwice)
+    apply simp
+    apply (simp add: shiftr_shiftr le)
+    done
+qed
+
+lemma data_at_obj_range:
+  "\<lbrakk> data_at sz ptr s; pspace_aligned s; valid_objs s \<rbrakk>
+     \<Longrightarrow> ptr + (offset && mask (pageBitsForSize sz)) \<in> obj_range ptr (ArchObj (DataPage dev sz))"
+  apply (clarsimp simp: data_at_def)
+  apply (elim disjE)
+   apply (clarsimp simp: obj_at_def)
+   apply (drule (2) ptr_in_obj_range)
+   apply (clarsimp simp: obj_bits_def obj_range_def)
+   apply fastforce
+  apply (clarsimp simp: obj_at_def)
+  apply (drule (2) ptr_in_obj_range)
+  apply (clarsimp simp: obj_bits_def obj_range_def)
+  apply fastforce
+  done
+
+lemma obj_range_data_for_cong:
+  "obj_range ptr (ArchObj (DataPage dev sz')) = obj_range ptr (ArchObj (DataPage False sz'))"
+  by (simp add: obj_range_def)
+
+lemma pspace_distinct_def':
+  "pspace_distinct \<equiv>
+     \<lambda>s. \<forall>x y ko ko'. kheap s x = Some ko \<and> kheap s y = Some ko' \<and> x \<noteq> y
+                      \<longrightarrow> obj_range x ko \<inter> obj_range y ko' = {}"
+  by (auto simp: pspace_distinct_def obj_range_def field_simps)
+
+lemma data_at_disjoint_equiv:
+  "\<lbrakk> ptr' \<noteq> ptr;data_at sz' ptr' s; data_at sz ptr s; valid_objs s; pspace_aligned s;
+     pspace_distinct s; ptr' \<in> obj_range ptr (ArchObj (DataPage dev sz)) \<rbrakk>
+     \<Longrightarrow> False"
+  apply (frule (2) data_at_obj_range[where offset = 0,simplified])
+  apply (clarsimp simp: data_at_def obj_at_def)
+  apply (elim disjE)
+  by (clarsimp dest!: spec simp: obj_at_def pspace_distinct_def'
+      , erule impE, erule conjI2[OF conjI2], (fastforce+)[2]
+      , fastforce cong: obj_range_data_for_cong)+
+
+lemma ptrFromPAddr_mask_simp:
+  "ptrFromPAddr z && ~~ mask (pageBitsForSize l) =
+   ptrFromPAddr (z && ~~ mask (pageBitsForSize l))"
+  apply (simp add: ptrFromPAddr_def field_simps)
+  apply (subst mask_out_add_aligned[OF is_aligned_pptrBaseOffset])
+  apply simp
+  done
+
+lemma pageBitsForSize_le_t24:
+  "pageBitsForSize sz \<le> 24"
+  by (cases sz, simp_all)
+
+lemma data_at_same_size:
+  assumes dat_sz':
+    "data_at sz' (ptrFromPAddr base) s"
+  and dat_sz:
+    "data_at sz
+       (ptrFromPAddr (base + (x && mask (pageBitsForSize sz'))) && ~~ mask (pageBitsForSize sz)) s"
+  and vs:
+    "pspace_distinct s" "pspace_aligned s" "valid_objs s"
+  shows "sz' = sz"
+proof -
+  from dat_sz' and dat_sz
+  have trivial:
+    "sz' \<noteq> sz
+     \<Longrightarrow> ptrFromPAddr (base + (x && mask (pageBitsForSize sz'))) && ~~ mask (pageBitsForSize sz) \<noteq>
+         ptrFromPAddr base"
+    by (auto simp: data_at_def obj_at_def)
+  have sz_equiv: "(pageBitsForSize sz = pageBitsForSize sz') = (sz' = sz)"
+    by (clarsimp simp: pageBitsForSize_def split: vmpage_size.splits)
+  show ?thesis
+    apply (rule sz_equiv[THEN iffD1])
+    apply (rule ccontr)
+    apply (drule neq_iff[THEN iffD1])
+    using dat_sz' dat_sz vs
+    apply (cut_tac trivial) prefer 2
+     apply (fastforce simp: sz_equiv)
+    apply (frule(1) data_at_aligned)
+    apply (elim disjE)
+     apply (erule(5) data_at_disjoint_equiv)
+     apply (unfold obj_range_def)
+     apply (rule mask_in_range[THEN iffD1])
+      apply (simp add: obj_bits_def)+
+     apply (simp add: mask_lower_twice ptrFromPAddr_mask_simp)
+     apply (rule arg_cong[where f = ptrFromPAddr])
+     apply (drule is_aligned_ptrFromPAddrD[OF _ pageBitsForSize_le_t24])
+     apply (subst neg_mask_add_aligned[OF _ and_mask_less'])
+       apply simp
+      apply (fastforce simp: pbfs_less_wb'[unfolded word_bits_def,simplified])
+     apply (simp add: is_aligned_neg_mask_eq)
+    apply (drule not_sym)
+    apply (erule(5) data_at_disjoint_equiv)
+    apply (unfold obj_range_def)
+    apply (rule mask_in_range[THEN iffD1])
+     apply (simp add: obj_bits_def is_aligned_neg_mask)+
+    apply (simp add: mask_lower_twice ptrFromPAddr_mask_simp)
+    apply (rule arg_cong[where f = ptrFromPAddr])
+    apply (drule is_aligned_ptrFromPAddrD[OF _ pageBitsForSize_le_t24])
+    apply (subst mask_lower_twice[symmetric])
+     apply (erule less_imp_le_nat)
+    apply (rule sym)
+    apply (subst mask_lower_twice[symmetric])
+     apply (erule less_imp_le_nat)
+    apply (rule arg_cong[where f = "\<lambda>x. x && ~~ mask z" for z])
+    apply (subst neg_mask_add_aligned[OF _ and_mask_less'])
+      apply simp
+     apply (fastforce simp: pbfs_less_wb'[unfolded word_bits_def,simplified])
+    apply simp
+    done
+qed
+
+lemma valid_pdpt_align_ptD:
+  "\<lbrakk> kheap s ptr = Some (ArchObj (PageTable pt)); valid_pdpt_objs s; pt a = entry \<rbrakk>
+     \<Longrightarrow> is_aligned a (pte_range_sz entry)"
+  apply (drule (1) valid_pdpt_objs_ptD)
+  apply (clarsimp simp: entries_align_def)
+  done
+
+lemma valid_pdpt_align_pdD:
+  "\<lbrakk> kheap s ptr = Some (ArchObj (PageDirectory pd));valid_pdpt_objs s; pd a = entry \<rbrakk>
+     \<Longrightarrow> is_aligned a (pde_range_sz entry)"
+  apply (drule (1) valid_pdpt_objs_pdD)
+  apply (clarsimp simp: entries_align_def)
+  done
+
+lemma valid_vspace_objsD2:
+  "\<lbrakk> (\<exists>\<rhd> p) s; ko_at (ArchObj ao) p s; valid_vspace_objs s \<rbrakk>
+     \<Longrightarrow> valid_vspace_obj ao s"
+  by (clarsimp simp: valid_vspace_objsD)
+
+lemma ptable_lift_data_consistant:
+  assumes vs: "valid_state s"
+  and vpdpt: "valid_pdpt_objs s"
+  and pt_lift: "ptable_lift t s x = Some ptr"
+  and dat: "data_at sz ((ptrFromPAddr ptr) && ~~ mask (pageBitsForSize sz)) s"
+  and misc: "get_pd_of_thread (kheap s) (arch_state s) t \<noteq> arm_global_pd (arch_state s)"
+            "x \<notin> kernel_mappings"
+  shows "ptable_lift t s (x && ~~ mask (pageBitsForSize sz)) =
+         Some (ptr && ~~ mask (pageBitsForSize sz))"
+proof -
+  have aligned_stuff:
+    "is_aligned (ucast ((x >> 12) && mask 8) :: word8) 4 \<Longrightarrow> (x && ~~ mask 16 >> 12) = x >> 12"
+    by (simp add: is_aligned_mask mask_def) word_bitwise
+  have aligned_stuff':
+    "is_aligned ((ucast (x >> 20)):: 12 word) 4 \<Longrightarrow> x && ~~ mask 24 >> 20 = x >> 20"
+    by (simp add: is_aligned_mask mask_def) word_bitwise
+  have vs': "valid_objs s \<and> valid_vspace_objs s \<and> pspace_distinct s \<and> pspace_aligned s"
+    using vs by (simp add: valid_state_def valid_pspace_def)
+  have x_less_kb: "x < kernel_base"
+    using misc by (simp add: kernel_mappings_def) (* FIXME: any rules exists already ? *)
+  thus ?thesis
+    using pt_lift dat vs'
+    apply (clarsimp simp: ptable_rights_def ptable_lift_def split: option.splits)
+    apply (clarsimp simp: get_page_info_def split: option.splits)
+    apply (rename_tac base sz' attrs rights pde)
+    apply (case_tac pde,simp_all)
+      apply (clarsimp simp: get_pd_entry_def split: arch_kernel_obj.split_asm option.splits)
+      apply (clarsimp simp: get_pt_info_def get_arch_obj_def get_pt_entry_def
+                     split: option.splits arch_kernel_obj.split_asm kernel_object.splits)
+      apply (rename_tac pd_base vmattr mw pd pt)
+      apply (cut_tac get_pd_of_thread_reachable[OF misc(1)])
+      apply (frule(1) valid_vspace_objsD2[rotated,unfolded obj_at_def,simplified],simp)
+      apply simp
+      apply (drule bspec)
+       apply (rule Compl_iff[THEN iffD2])
+       apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
+      apply (clarsimp simp: valid_pde_def obj_at_def a_type_def)
+      apply (case_tac "pt (ucast ((x >> 12) && mask 8))",simp_all)
+       apply (frule valid_vspace_objsD2[where p = "ptrFromPAddr p" for p,
+                                        rotated,unfolded obj_at_def,simplified], simp)
+        apply (rule exI)
+        apply (erule vs_lookup_step)
+        apply (simp add: vs_lookup1_def lookup_pd_slot_def Let_def
+                         pd_shifting pd_shifting_dual obj_at_def)
+        apply (rule_tac x="VSRef (x>>20) (Some APageDirectory)" in exI)
+        apply (rule context_conjI,simp)
+        apply (erule vs_refs_pdI)
+         apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
+        apply (intro allI impI)
+        apply (simp add: nth_shiftr)
+        apply (rule bang_big[simplified])
+        apply (simp add: word_size)
+       apply (frule (1) valid_pdpt_align_ptD[OF _ vpdpt])
+       apply simp
+       apply (drule_tac x="(ucast ((x >> 12) && mask 8))" in spec)
+       apply (frule data_at_same_size[where sz=sz and sz'=ARMLargePage,rotated,simplified], simp+)
+       apply (clarsimp simp: mask_shift_le get_pt_info_def get_pt_entry_def
+                             get_arch_obj_def entries_align_def aligned_stuff mask_AND_NOT_mask
+                      dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a = 16,simplified])
+       apply (simp add: neg_mask_add_aligned[OF _ and_mask_less'] is_aligned_neg_mask_eq)
+      apply (frule valid_vspace_objsD2[where p = "ptrFromPAddr p" for p,
+                                       rotated,unfolded obj_at_def,simplified], simp)
+       apply (rule exI)
+       apply (erule vs_lookup_step)
+       apply (simp add: vs_lookup1_def lookup_pd_slot_def Let_def
+                        pd_shifting pd_shifting_dual obj_at_def)
+       apply (rule_tac x="VSRef (x>>20) (Some APageDirectory)" in exI)
+       apply (rule context_conjI,simp)
+       apply (erule vs_refs_pdI)
+        apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
+       apply (intro allI impI)
+       apply (simp add: nth_shiftr)
+       apply (rule bang_big[simplified])
+       apply (simp add: word_size)
+      apply (frule(1) valid_pdpt_align_ptD[OF _ vpdpt])
+      apply simp
+      apply (drule_tac x="(ucast ((x >> 12) && mask 8))" in spec)
+      apply (frule data_at_same_size[where sz=sz and sz'=ARMSmallPage,rotated,simplified], simp+)
+      apply (clarsimp simp: mask_shift_le get_pt_info_def get_pt_entry_def get_arch_obj_def
+                            neg_mask_add_aligned[OF _ and_mask_less'] mask_AND_NOT_mask
+                     dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a = 12,simplified])
+     apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
+                    split: arch_kernel_obj.split_asm option.splits)
+     apply (clarsimp simp: get_pt_entry_def
+                    split: option.splits arch_kernel_obj.split_asm kernel_object.splits)
+     apply (rename_tac pd_base vmattr mw pd caprights)
+     apply (cut_tac get_pd_of_thread_reachable[OF misc(1)])
+     apply (frule(1) valid_vspace_objsD2[rotated,unfolded obj_at_def,simplified],simp)
+     apply simp
+     apply (drule bspec)
+      apply (rule Compl_iff[THEN iffD2])
+      apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
+     apply (clarsimp simp: valid_pde_def obj_at_def)
+     apply (frule(1) valid_pdpt_align_pdD[OF _ vpdpt])
+     apply (frule data_at_same_size[where sz=sz and sz'=ARMSection,rotated,simplified], simp+)
+    apply (clarsimp simp: aligned_stuff' neg_mask_add_aligned[OF _ and_mask_less'] mask_AND_NOT_mask
+                   dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a = 20,simplified])
+    apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
+                   split: arch_kernel_obj.split_asm option.splits)
+    apply (clarsimp simp: get_pt_entry_def
+                   split: option.splits arch_kernel_obj.split_asm kernel_object.splits)
+    apply (rename_tac pd_base vmattr rights pd)
+    apply (cut_tac get_pd_of_thread_reachable[OF misc(1)])
+    apply (frule(1) valid_vspace_objsD2[rotated,unfolded obj_at_def,simplified],simp)
+    apply simp
+    apply (drule bspec)
+     apply (rule Compl_iff[THEN iffD2])
+     apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
+    apply (clarsimp simp: valid_pde_def obj_at_def)
+    apply (frule(1) valid_pdpt_align_pdD[OF _ vpdpt])
+    apply (frule data_at_same_size[where sz=sz and sz'=ARMSuperSection,rotated,simplified], simp+)
+    apply (clarsimp simp: aligned_stuff' neg_mask_add_aligned[OF _ and_mask_less'] mask_AND_NOT_mask
+                   dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a = 24,simplified])
+    done
+qed
+
+lemma ptable_rights_data_consistant:
+  assumes vs: "valid_state s"
+  and vpdpt: "valid_pdpt_objs s"
+  and pt_lift: "ptable_lift t s x = Some ptr"
+  and dat: "data_at sz ((ptrFromPAddr ptr) && ~~ mask (pageBitsForSize sz)) s"
+  and misc: "get_pd_of_thread (kheap s) (arch_state s) t \<noteq>
+             arm_global_pd (arch_state s)" "x \<notin> kernel_mappings"
+  shows "ptable_rights t s (x && ~~ mask (pageBitsForSize sz)) = ptable_rights t s x"
+proof -
+  have aligned_stuff:
+    "is_aligned (ucast ((x >> 12) && mask 8) :: word8) 4 \<Longrightarrow> (x && ~~ mask 16 >> 12) = x >> 12"
+    by (simp add: is_aligned_mask mask_def) word_bitwise
+  have aligned_stuff':
+    "is_aligned ((ucast (x >> 20)):: 12 word) 4 \<Longrightarrow> x && ~~ mask 24 >> 20 = x >> 20"
+    by (simp add: is_aligned_mask mask_def) word_bitwise
+  have vs': "valid_objs s \<and> valid_vspace_objs s \<and> pspace_distinct s \<and> pspace_aligned s"
+    using vs
+    by (simp add: valid_state_def valid_pspace_def)
+  have x_less_kb: "x < kernel_base"
+    using misc
+    by (simp add: kernel_mappings_def) (* FIXME: any rules exists already ? *)
+  thus ?thesis
+    using pt_lift dat vs'
+    apply (clarsimp simp: ptable_rights_def ptable_lift_def split: option.splits)
+    apply (clarsimp simp: get_page_info_def split: option.splits)
+    apply (rename_tac base sz' attrs rights pde)
+    apply (case_tac pde, simp_all)
+      apply (clarsimp simp: get_pd_entry_def split: arch_kernel_obj.split_asm option.splits)
+      apply (clarsimp simp: get_pt_info_def get_arch_obj_def get_pt_entry_def
+                     split: option.splits arch_kernel_obj.split_asm kernel_object.splits)
+      apply (rename_tac pd_base vmattr mw pd pt)
+      apply (cut_tac get_pd_of_thread_reachable[OF misc(1)])
+      apply (frule (1) valid_vspace_objsD2[rotated,unfolded obj_at_def,simplified],simp)
+      apply simp
+      apply (drule bspec)
+       apply (rule Compl_iff[THEN iffD2])
+       apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
+      apply (clarsimp simp: valid_pde_def obj_at_def a_type_def)
+      apply (case_tac "pt (ucast ((x >> 12) && mask 8))",simp_all)
+       apply (frule valid_vspace_objsD2[where p = "ptrFromPAddr p" for p,
+                                        rotated,unfolded obj_at_def,simplified], simp)
+        apply (rule exI)
+        apply (erule vs_lookup_step)
+        apply (simp add: vs_lookup1_def lookup_pd_slot_def Let_def
+                         pd_shifting pd_shifting_dual obj_at_def)
+        apply (rule_tac x = "VSRef (x>>20) (Some APageDirectory)" in exI)
+        apply (rule context_conjI,simp)
+        apply (erule vs_refs_pdI)
+         apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
+        apply (intro allI impI)
+        apply (simp add: nth_shiftr)
+        apply (rule bang_big[simplified])
+        apply (simp add: word_size)
+       apply (frule (1) valid_pdpt_align_ptD[OF _ vpdpt])
+       apply simp
+       apply (drule_tac x="(ucast ((x >> 12) && mask 8))" in spec)
+       apply (frule data_at_same_size[where sz=sz and sz'=ARMLargePage,rotated,simplified], simp+)
+       apply (clarsimp simp: mask_shift_le get_pt_info_def get_pt_entry_def
+                             get_arch_obj_def entries_align_def aligned_stuff mask_AND_NOT_mask
+                      dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a=16,simplified])
+      apply (frule valid_vspace_objsD2[where p = "ptrFromPAddr p" for p,
+                                       rotated,unfolded obj_at_def,simplified], simp)
+       apply (rule exI)
+       apply (erule vs_lookup_step)
+       apply (simp add: vs_lookup1_def lookup_pd_slot_def Let_def
+                        pd_shifting pd_shifting_dual obj_at_def)
+       apply (rule_tac x = "VSRef (x>>20) (Some APageDirectory)" in exI)
+       apply (rule context_conjI,simp)
+       apply (erule vs_refs_pdI)
+        apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
+       apply (intro allI impI)
+       apply (simp add: nth_shiftr)
+       apply (rule bang_big[simplified])
+       apply (simp add: word_size)
+      apply (frule(1) valid_pdpt_align_ptD[OF _ vpdpt])
+      apply simp
+      apply (drule_tac x="(ucast ((x >> 12) && mask 8))" in spec)
+      apply (frule data_at_same_size[where sz=sz and sz'=ARMSmallPage,rotated,simplified], simp+)
+      apply (clarsimp simp: mask_shift_le get_pt_info_def get_pt_entry_def get_arch_obj_def
+                     dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a=12,simplified])
+     apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
+                    split: arch_kernel_obj.split_asm option.splits)
+     apply (clarsimp simp: get_pt_entry_def
+                    split: option.splits arch_kernel_obj.split_asm kernel_object.splits)
+     apply (rename_tac pd_base vmattr mw pd caprights)
+     apply (cut_tac get_pd_of_thread_reachable[OF misc(1)])
+     apply (frule(1) valid_vspace_objsD2[rotated,unfolded obj_at_def,simplified],simp)
+     apply simp
+     apply (drule bspec)
+      apply (rule Compl_iff[THEN iffD2])
+      apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
+     apply (clarsimp simp: valid_pde_def obj_at_def)
+     apply (frule(1) valid_pdpt_align_pdD[OF _ vpdpt])
+     apply (frule data_at_same_size[where sz = sz and sz' = ARMSection,rotated,simplified],
+          clarsimp+)
+    apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
+                   split: arch_kernel_obj.split_asm option.splits)
+    apply (clarsimp simp: get_pt_entry_def
+                   split: option.splits arch_kernel_obj.split_asm kernel_object.splits)
+    apply (rename_tac pd_base vmattr rights pd)
+    apply (cut_tac get_pd_of_thread_reachable[OF misc(1)])
+    apply (frule (1) valid_vspace_objsD2[rotated,unfolded obj_at_def,simplified],simp)
+    apply simp
+    apply (drule bspec)
+     apply (rule Compl_iff[THEN iffD2])
+     apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
+    apply (clarsimp simp: valid_pde_def obj_at_def)
+    apply (frule(1) valid_pdpt_align_pdD[OF _ vpdpt])
+    apply (frule data_at_same_size[where sz=sz and sz'=ARMSuperSection,rotated,simplified], simp+)
+    apply (clarsimp simp: aligned_stuff' neg_mask_add_aligned[OF _ and_mask_less'] mask_AND_NOT_mask
+                   dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a = 24,simplified])
+    done
+qed
+
+lemma user_op_access_data_at:
+  "\<lbrakk> invs s; valid_pdpt_objs s;pas_refined aag s; is_subject aag tcb; ptable_lift tcb s x = Some ptr;
+     data_at sz ((ptrFromPAddr ptr) && ~~ mask (pageBitsForSize sz)) s;
+     auth \<in> vspace_cap_rights_to_auth (ptable_rights tcb s x) \<rbrakk>
+     \<Longrightarrow> (pasObjectAbs aag tcb, auth,
+          pasObjectAbs aag (ptrFromPAddr (ptr && ~~ mask (pageBitsForSize sz)))) \<in> pasPolicy aag"
+  apply (case_tac "x \<in> kernel_mappings")
+   apply (clarsimp simp: ptable_lift_def ptable_rights_def split: option.splits)
+   apply (frule some_get_page_info_kmapsD)
+      apply (fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
+                             vspace_cap_rights_to_auth_def)+
+  apply (case_tac "get_pd_of_thread (kheap s) (arch_state s) tcb = arm_global_pd (arch_state s)")
+   apply (clarsimp simp: ptable_lift_def ptable_rights_def split: option.splits)
+   apply (frule get_page_info_gpd_kmaps[rotated, rotated])
+     apply (fastforce simp: invs_valid_global_objs invs_arch_state)+
+  apply (frule (3) ptable_lift_data_consistant[rotated 2])
+    apply fastforce
+   apply fastforce
+  apply (frule (3) ptable_rights_data_consistant[rotated 2])
+    apply fastforce
+   apply fastforce
+  apply (erule (3) user_op_access)
+  apply simp
+  done
+
+lemma user_frame_at_equiv:
+  "\<lbrakk> typ_at (AArch (AUserData sz)) p s; equiv_for P kheap s s'; P p \<rbrakk>
+     \<Longrightarrow> typ_at (AArch (AUserData sz)) p s'"
+  by (clarsimp simp: equiv_for_def obj_at_def)
+
+lemma device_frame_at_equiv:
+  "\<lbrakk> typ_at (AArch (ADeviceData sz)) p s; equiv_for P kheap s s'; P p \<rbrakk>
+     \<Longrightarrow> typ_at (AArch (ADeviceData sz)) p s'"
+  by (clarsimp simp: equiv_for_def obj_at_def)
+
+lemma typ_at_user_data_at:
+  "typ_at (AArch (AUserData sz)) p s \<Longrightarrow> data_at sz p s"
+  by (simp add: data_at_def)
+
+lemma typ_at_device_data_at:
+  "typ_at (AArch (ADeviceData sz)) p s \<Longrightarrow> data_at sz p s"
+  by (simp add: data_at_def)
+
+lemma requiv_device_mem_eq:
+  "\<lbrakk> reads_equiv aag s s'; globals_equiv s s'; invs s; invs s'; valid_pdpt_objs s;
+     valid_pdpt_objs s'; is_subject aag (cur_thread s); AllowRead \<in> ptable_rights_s s x;
+     ptable_lift_s s x = Some y; pas_refined aag s; pas_refined aag s' \<rbrakk>
+     \<Longrightarrow> device_mem s (ptrFromPAddr y) = device_mem s' (ptrFromPAddr y)"
+  apply (simp add: device_mem_def)
+  apply (rule conjI)
+   apply (erule reads_equivE)
+   apply (clarsimp simp: in_device_frame_def)
+   apply (rule exI)
+   apply (rule device_frame_at_equiv)
+     apply assumption+
+   apply (erule_tac f="underlying_memory" in equiv_forE)
+   apply (frule_tac auth=Read in user_op_access_data_at[where s=s])
+         apply (fastforce simp: ptable_lift_s_def ptable_rights_s_def vspace_cap_rights_to_auth_def
+                | intro typ_at_device_data_at)+
+   apply (rule reads_read)
+   apply (fastforce simp: ptrFromPAddr_mask_simp)
+  apply clarsimp
+  apply (frule requiv_ptable_rights_eq, fastforce+)
+  apply (frule requiv_ptable_lift_eq, fastforce+)
+  apply (clarsimp simp: globals_equiv_def)
+  apply (erule notE)
+  apply (erule reads_equivE)
+  apply (clarsimp simp: in_device_frame_def)
+  apply (rule exI)
+  apply (rule device_frame_at_equiv)
+    apply assumption+
+   apply (erule_tac f="underlying_memory" in equiv_forE)
+   apply (erule equiv_symmetric[THEN iffD1])
+  apply (frule_tac auth=Read in user_op_access_data_at[where s=s'])
+        apply (fastforce simp: ptable_lift_s_def ptable_rights_s_def vspace_cap_rights_to_auth_def
+               | intro typ_at_device_data_at)+
+  apply (rule reads_read)
+  apply (fastforce simp: ptrFromPAddr_mask_simp)
+  done
+
+lemma requiv_user_mem_eq:
+  "\<lbrakk> reads_equiv aag s s'; globals_equiv s s'; invs s; invs s'; valid_pdpt_objs s;
+     valid_pdpt_objs s'; is_subject aag (cur_thread s); AllowRead \<in> ptable_rights_s s x;
+     ptable_lift_s s x = Some y; pas_refined aag s; pas_refined aag s' \<rbrakk>
+     \<Longrightarrow> user_mem s (ptrFromPAddr y) = user_mem s' (ptrFromPAddr y)"
+  apply (simp add: user_mem_def)
+  apply (rule conjI)
+   apply clarsimp
+   apply (rule context_conjI')
+    apply (erule reads_equivE)
+    apply (clarsimp simp: in_user_frame_def)
+    apply (rule exI)
+    apply (rule user_frame_at_equiv)
+      apply assumption+
+    apply (erule_tac f="underlying_memory" in equiv_forE)
+    apply (frule_tac auth=Read in user_op_access_data_at[where s = s])
+          apply (fastforce simp: ptable_lift_s_def ptable_rights_s_def vspace_cap_rights_to_auth_def
+                 | intro typ_at_user_data_at)+
+    apply (rule reads_read)
+    apply (fastforce simp: ptrFromPAddr_mask_simp)
+   apply clarsimp
+   apply (subgoal_tac "aag_can_read aag (ptrFromPAddr y)")
+    apply (erule reads_equivE)
+    apply clarsimp
+    apply (erule_tac f="underlying_memory" in equiv_forE)
+    apply simp
+   apply (frule_tac auth=Read in user_op_access)
+       apply (fastforce simp: ptable_lift_s_def ptable_rights_s_def vspace_cap_rights_to_auth_def)+
+   apply (rule reads_read)
+   apply simp
+  apply (frule requiv_ptable_rights_eq, fastforce+)
+  apply (frule requiv_ptable_lift_eq, fastforce+)
+  apply (clarsimp simp: globals_equiv_def)
+  apply (erule notE)
+  apply (erule reads_equivE)
+  apply (clarsimp simp: in_user_frame_def)
+  apply (rule exI)
+  apply (rule user_frame_at_equiv)
+    apply assumption+
+   apply (erule_tac f="underlying_memory" in equiv_forE)
+   apply (erule equiv_symmetric[THEN iffD1])
+  apply (frule_tac auth=Read in user_op_access_data_at[where s=s'])
+        apply (fastforce simp: ptable_lift_s_def ptable_rights_s_def vspace_cap_rights_to_auth_def
+               | intro typ_at_user_data_at)+
+  apply (rule reads_read)
+  apply (fastforce simp: ptrFromPAddr_mask_simp)
+  done
+
+lemma ptable_rights_imp_frameD:
+  "\<lbrakk> ptable_lift t s x = Some y;valid_state s;ptable_rights t s x \<noteq> {} \<rbrakk>
+     \<Longrightarrow> \<exists>sz. data_at sz (ptrFromPAddr y && ~~ mask (pageBitsForSize sz)) s"
+  apply (subst (asm) addrFromPPtr_ptrFromPAddr_id[symmetric])
+  apply (drule ptable_rights_imp_frame)
+    apply simp+
+   apply (rule addrFromPPtr_ptrFromPAddr_id[symmetric])
+  apply (auto simp: in_user_frame_def in_device_frame_def
+             dest!: spec typ_at_user_data_at typ_at_device_data_at)
+  done
+
+lemma requiv_user_device_eq:
+  "\<lbrakk> reads_equiv aag s s'; globals_equiv s s'; invs s; invs s'; valid_pdpt_objs s;
+     valid_pdpt_objs s'; is_subject aag (cur_thread s); AllowRead \<in> ptable_rights_s s x;
+     ptable_lift_s s x = Some y; pas_refined aag s; pas_refined aag s' \<rbrakk>
+     \<Longrightarrow> device_state (machine_state s) (ptrFromPAddr y) =
+         device_state (machine_state s') (ptrFromPAddr y)"
+  apply (simp add: ptable_lift_s_def)
+  apply (frule ptable_rights_imp_frameD)
+    apply fastforce
+   apply (fastforce simp: ptable_rights_s_def)
+  apply (erule reads_equivE)
+  apply clarsimp
+  apply (erule_tac f="device_state" in equiv_forD)
+  apply (frule_tac auth=Read in user_op_access_data_at[where s = s])
+        apply ((fastforce simp: ptable_lift_s_def ptable_rights_s_def vspace_cap_rights_to_auth_def
+                | intro typ_at_user_data_at)+)[6]
+  apply (rule reads_read)
+  apply (frule_tac auth=Read in user_op_access)
+      apply (fastforce simp: ptable_lift_s_def ptable_rights_s_def vspace_cap_rights_to_auth_def)+
+  done
+
+
+definition context_matches_state where
+  "context_matches_state pl pr pxn ms s \<equiv> case ms of (um, ds, es) \<Rightarrow>
+     pl = ptable_lift_s s |` {x. pr x \<noteq> {}} \<and>
+     pr = ptable_rights_s s \<and>
+     pxn = (\<lambda>x. pr x \<noteq> {} \<and> ptable_xn_s s x) \<and>
+     um = (user_mem s \<circ> ptrFromPAddr) |` {y. \<exists>x. pl x = Some y \<and> AllowRead \<in> pr x} \<and>
+     ds = (device_state (machine_state s) \<circ> ptrFromPAddr) |`
+          {y. \<exists>x. pl x = Some y \<and> AllowRead \<in> pr x} \<and>
+     es = exclusive_state (machine_state s)"
+
+
+lemma dmo_setExMonitor_reads_respects_g:
+  "reads_respects_g aag l \<top> (do_machine_op (setExMonitor es))"
+  apply (simp add: setExMonitor_def)
+  apply (wp dmo_ev ev_modify)
+  apply (auto simp: reads_equiv_g_def reads_equiv_def affects_equiv_def states_equiv_for_def
+                    equiv_for_def equiv_asids_def equiv_asid_def globals_equiv_def idle_equiv_def
+             split: if_splits)
+  done
+
+lemma dmo_getExMonitor_reads_respects_g:
+  "reads_respects_g aag l (\<lambda>s. cur_thread s \<noteq> idle_thread s) (do_machine_op getExMonitor)"
+  apply (simp add: getExMonitor_def)
+  apply (wp dmo_ev gets_ev'')
+  apply (clarsimp simp: reads_equiv_g_def globals_equiv_def)
+  done
+
+lemma getExMonitor_wp[wp]:
+  "\<lbrace>\<lambda>ms. P (exclusive_state ms) ms\<rbrace> getExMonitor \<lbrace>P\<rbrace>"
+  by (simp add: getExMonitor_def | wp)+
+
+
+definition valid_vspace_objs' where
+  "valid_vspace_objs' \<equiv> valid_pdpt_objs"
+
+declare valid_vspace_objs'_def[simp]
+
+
+lemma do_user_op_reads_respects_g:
+  notes split_paired_All[simp del]
+  shows
+    "(\<forall>pl pr pxn tc ms s. P tc s \<and> context_matches_state pl pr pxn ms s
+                                \<longrightarrow> (\<exists>x. uop (cur_thread s) pl pr pxn (tc, ms) = {x}))
+     \<Longrightarrow> reads_respects_g aag l (pas_refined aag and invs and valid_vspace_objs'
+                                                 and is_subject aag \<circ> cur_thread
+                                                 and (\<lambda>s. cur_thread s \<noteq> idle_thread s) and P tc)
+                          (do_user_op_if uop tc)"
+  apply (simp add: do_user_op_if_def)
+  apply (rule use_spec_ev)
+  apply (rule spec_equiv_valid_add_asm)
+  apply (rule spec_equiv_valid_add_rel[OF _ reads_equiv_g_refl])
+  apply (rule spec_equiv_valid_add_rel'[OF _ affects_equiv_refl])
+  apply (rule spec_equiv_valid_inv_gets[where proj=id,simplified])
+   apply (clarsimp simp: reads_equiv_g_def)
+   apply (rule requiv_ptable_rights_eq,simp+)[1]
+  apply (rule spec_equiv_valid_inv_gets[where proj=id,simplified])
+   apply (rule ext)
+   apply (clarsimp simp: reads_equiv_g_def)
+   apply (case_tac "ptable_rights_s st x = {}", simp)
+   apply simp
+   apply (rule requiv_ptable_xn_eq,simp+)[1]
+  apply (rule spec_equiv_valid_inv_gets[where proj=id,simplified])
+   apply (subst expand_restrict_map_eq,clarsimp)
+   apply (clarsimp simp: reads_equiv_g_def)
+   apply (rule requiv_ptable_lift_eq,simp+)[1]
+  apply (rule spec_equiv_valid_inv_gets[where proj=id,simplified])
+   apply (clarsimp simp: reads_equiv_g_def)
+   apply (rule requiv_cur_thread_eq,fastforce)
+  apply (rule spec_equiv_valid_inv_gets_more[where proj="\<lambda>m. dom m \<inter> cw"
+                                               and projsnd="\<lambda>m. m |` cr" for cr and cw])
+   apply (rule context_conjI')
+    apply (subst expand_restrict_map_eq)
+    apply (clarsimp simp: reads_equiv_g_def restrict_map_def)
+    apply (rule requiv_user_mem_eq)
+              apply simp+
+   apply fastforce
+  apply (rule spec_equiv_valid_inv_gets[where proj = "\<lambda>x. ()", simplified])
+  apply (rule spec_equiv_valid_inv_gets_more[where proj = "\<lambda>m. (m \<circ> ptrFromPAddr) |` cr" for cr])
+   apply (rule conjI)
+    apply (subst expand_restrict_map_eq)
+    apply (clarsimp simp: restrict_map_def reads_equiv_g_def)
+    apply (rule requiv_user_device_eq)
+              apply simp+
+   apply (clarsimp simp: globals_equiv_def reads_equiv_g_def)
+  apply (rule spec_equiv_valid_guard_imp)
+   apply (wpsimp wp: dmo_user_memory_update_reads_respects_g dmo_device_state_update_reads_respects_g
+                     dmo_setExMonitor_reads_respects_g dmo_device_state_update_reads_respects_g
+                     select_ev select_wp dmo_getExMonitor_reads_respects_g dmo_wp)
+  apply clarsimp
+  apply (rule conjI)
+   apply clarsimp
+   apply (drule spec)+
+   apply (erule impE)
+    prefer 2
+    apply assumption
+   apply (clarsimp simp: context_matches_state_def comp_def  reads_equiv_g_def globals_equiv_def)
+  apply (clarsimp simp: reads_equiv_g_def globals_equiv_def)
+  done
+
+end
+
+context begin interpretation Arch .
+
+requalify_consts
+  do_user_op_if
+  valid_vspace_objs'
+  context_matches_state
+
+requalify_facts
+  do_user_op_reads_respects_g
+
+end
+
+end

--- a/proof/infoflow/ARM/Example_Valid_State.thy
+++ b/proof/infoflow/ARM/Example_Valid_State.thy
@@ -6,7 +6,7 @@
 
 theory Example_Valid_State
 imports
-  "Noninterference"
+  "ArchNoninterference"
   "Lib.Distinct_Cmd"
 begin
 
@@ -589,7 +589,7 @@ where
      tcb_fault         = None,
      tcb_bound_notification     = None,
      tcb_mcpriority    = Low_mcp,
-     tcb_arch = \<lparr> tcb_context = undefined \<rparr>\<rparr>"
+     tcb_arch = \<lparr>tcb_context = undefined\<rparr>\<rparr>"
 
 definition
   Low_etcb :: etcb
@@ -618,7 +618,7 @@ where
      tcb_fault         = None,
      tcb_bound_notification     = None,
      tcb_mcpriority    = High_mcp,
-     tcb_arch = \<lparr> tcb_context = undefined \<rparr>\<rparr>"
+     tcb_arch = \<lparr>tcb_context = undefined\<rparr>\<rparr>"
 
 definition
   High_etcb :: etcb
@@ -646,7 +646,7 @@ where
      tcb_fault         = None,
      tcb_bound_notification     = None,
      tcb_mcpriority    = default_priority,
-     tcb_arch = \<lparr> tcb_context = empty_context \<rparr>\<rparr>"
+     tcb_arch = \<lparr>tcb_context = empty_context\<rparr>\<rparr>"
 
 
 definition
@@ -834,7 +834,7 @@ definition machine_state0 :: "machine_state" where
                      underlying_memory = const 0,
                      device_state = Map.empty,
                      exclusive_state = undefined,
-                     machine_state_rest = undefined \<rparr>"
+                     machine_state_rest = undefined\<rparr>"
 
 definition arch_state0 :: "arch_state" where
   "arch_state0 \<equiv> \<lparr>arm_asid_table = Map.empty,
@@ -859,7 +859,7 @@ where
     interrupt_states = (\<lambda>_. irq_state.IRQInactive) (timer_irq := irq_state.IRQTimer),
     arch_state = arch_state0,
      exst = exst0
-    \<rparr>"
+   \<rparr>"
 
 
 subsubsection \<open>Defining the policy graph\<close>
@@ -929,7 +929,7 @@ definition Sys1PAS :: "(auth_graph_label subject_label) PAS" where
     pasMayActivate = True,
     pasMayEditReadyQueues = True, pasMaySendIrqs = False,
     pasDomainAbs = ((\<lambda>_. {partition_label High})(0 := {partition_label Low}))
-    \<rparr>"
+   \<rparr>"
 
 subsubsection \<open>Proof of pas_refined for Sys1\<close>
 
@@ -1812,10 +1812,10 @@ text \<open>One invariant we need on s0 is that there exists
 
 lemma Sys1_valid_initial_state_noenabled:
   assumes extras_s0: "step_restrict s0"
-  assumes utf_det: "\<forall>pl pr pxn tc um ds es s. det_inv InUserMode tc s \<and> einvs s \<and> context_matches_state pl pr pxn um ds es s \<and> ct_running s
-                   \<longrightarrow> (\<exists>x. utf (cur_thread s) pl pr pxn (tc, um, ds, es) = {x})"
-  assumes utf_non_empty: "\<forall>t pl pr pxn tc um ds es. utf t pl pr pxn (tc, um, ds, es) \<noteq> {}"
-  assumes utf_non_interrupt: "\<forall>t pl pr pxn tc um ds es e f g. (e,f,g) \<in> utf t pl pr pxn (tc, um, ds, es) \<longrightarrow> e \<noteq> Some Interrupt"
+  assumes utf_det: "\<forall>pl pr pxn tc ms s. det_inv InUserMode tc s \<and> einvs s \<and> context_matches_state pl pr pxn ms s \<and> ct_running s
+                   \<longrightarrow> (\<exists>x. utf (cur_thread s) pl pr pxn (tc, ms) = {x})"
+  assumes utf_non_empty: "\<forall>t pl pr pxn tc ms. utf t pl pr pxn (tc, ms) \<noteq> {}"
+  assumes utf_non_interrupt: "\<forall>t pl pr pxn tc ms e f g. (e,f,g) \<in> utf t pl pr pxn (tc, ms) \<longrightarrow> e \<noteq> Some Interrupt"
   assumes det_inv_invariant: "invariant_over_ADT_if det_inv utf"
   assumes det_inv_s0: "det_inv KernelExit (cur_context s0_internal) s0_internal"
   shows "valid_initial_state_noenabled det_inv utf s0_internal Sys1PAS timer_irq s0_context"

--- a/proof/infoflow/Arch_IF.thy
+++ b/proof/infoflow/Arch_IF.thy
@@ -5,828 +5,150 @@
  *)
 
 theory Arch_IF
-imports Retype_IF
+imports ArchRetype_IF
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 abbreviation irq_state_of_state :: "det_state \<Rightarrow> nat" where
   "irq_state_of_state s \<equiv> irq_state (machine_state s)"
 
+
+crunches cap_insert, cap_swap_for_delete
+  for irq_state_of_state[wp]: "\<lambda>s. P (irq_state_of_state s)"
+  (wp: crunch_wps)
+
 lemma do_extended_op_irq_state_of_state[wp]:
-  "\<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace> do_extended_op f \<lbrace>\<lambda>_ s. P (irq_state_of_state s)\<rbrace>"
+  "do_extended_op f \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
   by (wpsimp wp: dxo_wp_weak)
 
 lemma no_irq_underlying_memory_update[simp]:
   "no_irq (modify (underlying_memory_update f))"
   by (wpsimp simp: no_irq_def)
 
-crunch irq_state_of_state[wp]: cap_insert "\<lambda>s. P (irq_state_of_state s)"
-  (wp: crunch_wps)
-
-crunch irq_state_of_state[wp]: set_extra_badge "\<lambda>s. P (irq_state_of_state s)"
-  (wp: crunch_wps dmo_wp simp: storeWord_def)
-
-
-lemma transfer_caps_loop_irq_state[wp]:
-  "\<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace> transfer_caps_loop a b c d e f \<lbrace>\<lambda>_ s. P (irq_state_of_state s)\<rbrace>"
-  apply(wp transfer_caps_loop_pres)
-  done
-
-crunch irq_state_of_state[wp]: set_mrs "\<lambda>s. P (irq_state_of_state s)"
-  (wp: crunch_wps dmo_wp simp: crunch_simps maskInterrupt_def store_word_offs_def storeWord_def ignore: const_on_failure)
-
-crunch irq_state_of_state[wp]: handle_recv "\<lambda>s. P (irq_state_of_state s)"
-  (wp: crunch_wps dmo_wp simp: crunch_simps maskInterrupt_def store_word_offs_def storeWord_def ignore: const_on_failure)
-
-crunch irq_state_of_state[wp]: handle_reply "\<lambda>s. P (irq_state_of_state s)"
-  (wp: crunch_wps dmo_wp simp: crunch_simps maskInterrupt_def unless_def store_word_offs_def storeWord_def ignore: const_on_failure)
-
-crunch irq_state_of_state[wp]: handle_vm_fault, handle_hypervisor_fault "\<lambda>s. P (irq_state_of_state s)"
-  (wp: crunch_wps dmo_wp simp: crunch_simps maskInterrupt_def unless_def store_word_offs_def storeWord_def ignore: const_on_failure getFAR getDFSR getIFSR simp: getDFSR_def no_irq_getFAR getFAR_def getIFSR_def)
-
-
-lemma irq_state_clearExMonitor[wp]: "\<lbrace> \<lambda>s. P (irq_state s) \<rbrace> clearExMonitor \<lbrace> \<lambda>_ s. P (irq_state s) \<rbrace>"
-  apply (simp add: clearExMonitor_def | wp modify_wp)+
-  done
-
-crunch irq_state_of_state[wp]: schedule "\<lambda>(s::det_state). P (irq_state_of_state s)"
-  (wp: dmo_wp modify_wp crunch_wps hoare_whenE_wp
-       simp: invalidateLocalTLB_ASID_def setHardwareASID_def set_current_pd_def
-             machine_op_lift_def machine_rest_lift_def crunch_simps storeWord_def
-             dsb_def isb_def writeTTBR0_def)
-
-crunch irq_state_of_state[wp]: reply_from_kernel "\<lambda>s. P (irq_state_of_state s)"
-
-
 lemma detype_irq_state_of_state[simp]:
   "irq_state_of_state (detype S s) = irq_state_of_state s"
-  apply(simp add: detype_def)
-  done
-
-text \<open>Not true of invoke_untyped any more.\<close>
-crunch irq_state_of_state[wp]: retype_region,create_cap,delete_objects "\<lambda>s. P (irq_state_of_state s)"
-  (wp: dmo_wp modify_wp crunch_wps
-    simp: crunch_simps ignore: freeMemory
-    simp: freeMemory_def storeWord_def clearMemory_def machine_op_lift_def machine_rest_lift_def mapM_x_defsym)
-
-crunch irq_state_of_state[wp]: invoke_irq_control "\<lambda>s. P (irq_state_of_state s)"
-  (wp: dmo_wp crunch_wps
-   simp: crunch_simps setIRQTrigger_def machine_op_lift_def machine_rest_lift_def)
-
-crunch irq_state_of_state[wp]: invoke_irq_handler "\<lambda>s. P (irq_state_of_state s)"
-  (wp: dmo_wp simp: maskInterrupt_def)
-
-crunch irq_state_of_state[wp]: arch_perform_invocation "\<lambda>(s::det_state). P (irq_state_of_state s)"
-  (wp: dmo_wp modify_wp simp: set_current_pd_def invalidateLocalTLB_ASID_def invalidateLocalTLB_VAASID_def cleanByVA_PoU_def do_flush_def cache_machine_op_defs do_flush_defs wp: crunch_wps simp: crunch_simps ignore: ignore_failure)
-
-crunch irq_state_of_state[wp]: finalise_cap "\<lambda>(s::det_state). P (irq_state_of_state s)"
-  (wp: select_wp modify_wp crunch_wps dmo_wp simp: crunch_simps invalidateLocalTLB_ASID_def cleanCaches_PoU_def dsb_def invalidate_I_PoU_def clean_D_PoU_def)
-
-crunch irq_state_of_state[wp]: send_signal "\<lambda>s. P (irq_state_of_state s)"
-
-crunch irq_state_of_state[wp]: cap_swap_for_delete "\<lambda>(s::det_state). P (irq_state_of_state s)"
-
-crunch irq_state_of_state[wp]: cancel_badged_sends "\<lambda>(s::det_state). P (irq_state_of_state s)"
-  (wp: crunch_wps dmo_wp hoare_unless_wp modify_wp simp: filterM_mapM crunch_simps no_irq_clearMemory simp: clearMemory_def storeWord_def invalidateLocalTLB_ASID_def
-   ignore: filterM)
-
-crunch irq_state_of_state[wp]: restart,invoke_domain "\<lambda>(s::det_state). P (irq_state_of_state s)"
-
-subsection "reads_equiv"
-
-(* this to go in InfloFlowBase? *)
-lemma get_object_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag \<top>\<top> \<top> (get_object ptr)"
-  unfolding get_object_def
-  apply(rule equiv_valid_rv_bind)
-    apply(rule equiv_valid_rv_guard_imp)
-     apply(rule gets_kheap_revrv')
-    apply(simp, simp)
-   apply(rule equiv_valid_2_bind)
-      apply(rule return_ev2)
-      apply(simp)
-     apply(rule assert_ev2)
-     apply(simp)
-    apply(wpsimp)+
-  done
-
-lemma get_object_revrv':
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
-   (\<lambda>rv rv'. aag_can_read aag ptr \<longrightarrow> rv = rv')
-   \<top> (get_object ptr)"
-  unfolding get_object_def
-  apply(rule equiv_valid_rv_bind)
-    apply(rule equiv_valid_rv_guard_imp)
-     apply(rule gets_kheap_revrv)
-    apply(simp, simp)
-   apply(rule equiv_valid_2_bind)
-      apply(rule return_ev2)
-      apply(simp)
-     apply(rule assert_ev2)
-     apply(simp add: equiv_for_def)
-    apply(wpsimp)+
-  done
-
-lemma get_asid_pool_revrv':
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
-   (\<lambda>rv rv'. aag_can_read aag ptr \<longrightarrow> rv = rv')
-   \<top> (get_asid_pool ptr)"
-  unfolding get_asid_pool_def
-  apply(rule_tac W="\<lambda>rv rv'. aag_can_read aag ptr \<longrightarrow>rv = rv'" in equiv_valid_rv_bind)
-    apply(rule get_object_revrv')
-   apply(case_tac "aag_can_read aag ptr")
-    apply(simp split: kernel_object.splits)
-    apply(rule conjI | clarsimp | rule fail_ev2_l)+
-    apply(simp split: arch_kernel_obj.splits)
-    apply(rule conjI | clarsimp | rule return_ev2 | rule fail_ev2_l)+
-   apply(clarsimp simp: equiv_valid_2_def)
-   apply(case_tac rv)
-       apply(clarsimp simp: fail_def)+
-   apply(case_tac rv')
-       apply(clarsimp simp: fail_def)+
-   apply(rename_tac arch_kernel_obj arch_kernel_obj')
-   apply(case_tac arch_kernel_obj)
-      apply(case_tac arch_kernel_obj')
-         apply(clarsimp simp: fail_def return_def)+
-  apply(rule get_object_inv)
-  done
-
-lemma get_pt_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag \<top>\<top> \<top> (get_pt ptr)"
-  unfolding get_pt_def
-  apply(rule equiv_valid_rv_bind)
-    apply(rule get_object_revrv)
-   apply(simp)
-   apply(case_tac rv)
-       apply(simp | rule fail_ev2_l)+
-   apply(case_tac rv')
-       apply(simp | rule fail_ev2_r)+
-   apply(rename_tac arch_kernel_obj arch_kernel_obj')
-   apply(case_tac arch_kernel_obj)
-      apply(simp | rule fail_ev2_l)+
-     apply(case_tac arch_kernel_obj')
-        apply(simp | rule fail_ev2_r | rule return_ev2)+
-    apply(case_tac arch_kernel_obj')
-       apply(simp | rule fail_ev2_l)+
-  apply(rule get_object_inv)
-  done
-
-lemma set_pt_reads_respects:
-  "reads_respects aag l \<top> (set_pt ptr pt)"
-  unfolding set_pt_def
-  by (rule set_object_reads_respects)
-
-lemma get_pt_reads_respects:
-  "reads_respects aag l (K (is_subject aag ptr)) (get_pt ptr)"
-  unfolding get_pt_def
-  apply(wp get_object_rev hoare_vcg_all_lift
-       | wp (once) hoare_drop_imps | simp | wpc)+
-  done
-
-lemma store_pte_reads_respects:
-  "reads_respects aag l (K (is_subject aag (p && ~~ mask pt_bits)))
-    (store_pte p pte)"
-  unfolding store_pte_def fun_app_def
-  apply(wp set_pt_reads_respects get_pt_reads_respects)
-  apply(simp)
-  done
-
-lemma get_asid_pool_rev:
-  "reads_equiv_valid_inv A aag (K (is_subject aag ptr)) (get_asid_pool ptr)"
-  unfolding get_asid_pool_def
-  apply(wp get_object_rev | wpc | simp)+
-  done
-
-
-lemma assertE_reads_respects:
-  "reads_respects aag l \<top> (assertE P)"
-  by (rule assertE_ev)
+  by (simp add: detype_def)
 
 lemma gets_applyE:
-  "liftE (gets f) >>=E (\<lambda> f. g (f x)) = liftE (gets_apply f x) >>=E g"
-  apply(simp add: liftE_bindE)
-  apply(rule gets_apply)
+  "liftE (gets f) >>=E (\<lambda>f. g (f x)) = liftE (gets_apply f x) >>=E g"
+  apply (simp add: liftE_bindE)
+  apply (rule gets_apply)
   done
 
 lemma aag_can_read_own_asids:
   "is_subject_asid aag asid \<Longrightarrow> aag_can_read_asid aag asid"
   by simp
 
-lemma get_asid_pool_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
-         (\<lambda>rv rv'. rv (ucast asid) = rv' (ucast asid))
-         (\<lambda>s. Some a = arm_asid_table (arch_state s) (asid_high_bits_of asid) \<and>
-          is_subject_asid aag asid \<and> asid \<noteq> 0)
-         (get_asid_pool a)"
-  unfolding get_asid_pool_def
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule_tac R'="\<lambda> rv rv'.
-                         \<forall> asid_pool asid_pool'.
-                            rv = ArchObj (ASIDPool asid_pool) \<and> rv' = ArchObj (ASIDPool asid_pool')
-                            \<longrightarrow> asid_pool (ucast asid) = asid_pool' (ucast asid)"
-              and P="\<lambda>s. Some a = arm_asid_table (arch_state s) (asid_high_bits_of asid) \<and>
-                         is_subject_asid aag asid \<and> asid \<noteq> 0"
-              and P'="\<lambda>s. Some a = arm_asid_table (arch_state s) (asid_high_bits_of asid) \<and>
-                          is_subject_asid aag asid \<and> asid \<noteq> 0"
-               in equiv_valid_2_bind)
-      apply(clarsimp split: kernel_object.splits arch_kernel_obj.splits
-                      simp: fail_ev2_l fail_ev2_r return_ev2)
-     apply(clarsimp simp: get_object_def gets_def assert_def bind_def put_def get_def
-                          equiv_valid_2_def return_def fail_def
-                   split: if_split)
-     apply(erule reads_equivE)
-     apply(clarsimp simp: equiv_asids_def equiv_asid_def asid_pool_at_kheap)
-     apply(drule aag_can_read_own_asids)
-     apply(drule_tac s="Some a" in sym)
-     apply force
-    apply (wp wp_post_taut | simp)+
-  done
-
-lemma asid_high_bits_0_eq_1:
-  "asid_high_bits_of 0 = asid_high_bits_of 1"
-  by (auto simp: asid_high_bits_of_def asid_low_bits_def)
-
-
-
-lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq:
-  "\<lbrakk>is_subject_asid aag asid; reads_equiv aag s t; asid \<noteq> 0\<rbrakk> \<Longrightarrow>
-               arm_asid_table (arch_state s) (asid_high_bits_of asid) =
-               arm_asid_table (arch_state t) (asid_high_bits_of asid)"
-  apply(erule reads_equivE)
-  apply(fastforce simp: equiv_asids_def equiv_asid_def intro: aag_can_read_own_asids)
-  done
-
-lemma find_pd_for_asid_reads_respects:
-  "reads_respects aag l (K (is_subject_asid aag asid)) (find_pd_for_asid asid)"
-  apply(simp add: find_pd_for_asid_def)
-  apply(subst gets_applyE)
-  (* everything up to and including get_asid_pool, both executions are the same.
-     it is only get_asid_pool that can return different values and for which we need
-     to go equiv_valid_2. We rewrite using associativity to make the decomposition
-     easier *)
-  apply(subst bindE_assoc[symmetric])+
-  apply(simp add: equiv_valid_def2)
-  apply(subst rel_sum_comb_equals[symmetric])
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule_tac R'="\<lambda> rv rv'. rv (ucast asid) = rv' (ucast asid)" and Q="\<top>\<top>" and Q'="\<top>\<top>"
-               in equiv_valid_2_bindE)
-      apply(clarsimp split: option.splits simp: throwError_def returnOk_def)
-      apply(intro conjI impI allI)
-       apply(rule return_ev2, simp)
-      apply(rule return_ev2, simp)
-     apply wp+
-   apply(rule_tac R'="(=)"
-              and Q="\<lambda> rv s. rv = (arm_asid_table (arch_state s)) (asid_high_bits_of asid)
-                           \<and> is_subject_asid aag asid \<and> asid \<noteq> 0"
-              and Q'="\<lambda> rv s. rv = (arm_asid_table (arch_state s)) (asid_high_bits_of asid)
-                            \<and> is_subject_asid aag asid \<and> asid \<noteq> 0"
-               in equiv_valid_2_bindE)
-      apply (simp add: equiv_valid_def2[symmetric])
-      apply (split option.splits)
-      apply (intro conjI impI allI)
-       apply (simp add: throwError_def)
-       apply (rule return_ev2, simp)
-      apply(rule equiv_valid_2_liftE)
-      apply(clarsimp)
-      apply(rule get_asid_pool_revrv)
-     apply(wp gets_apply_wp)+
-   apply(subst rel_sum_comb_equals)
-   apply(subst equiv_valid_def2[symmetric])
-   apply(wp gets_apply_ev | simp)+
-  apply(fastforce intro: requiv_arm_asid_table_asid_high_bits_of_asid_eq)
-  done
-
-lemma find_pd_for_asid_assert_reads_respects:
-  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs and
-    K (is_subject_asid aag asid))
-  (find_pd_for_asid_assert asid)"
-  unfolding find_pd_for_asid_assert_def
-  apply(wp get_pde_rev find_pd_for_asid_reads_respects hoare_vcg_all_lift
-       | wpc | simp)+
-   apply(rule_tac Q'="\<lambda>rv s. is_subject aag (lookup_pd_slot rv 0 && ~~ mask pd_bits)"
-               in hoare_post_imp_R)
-   apply(rule find_pd_for_asid_pd_slot_authorised)
-   apply(subgoal_tac "lookup_pd_slot r 0 = r")
-    apply(fastforce)
-   apply(simp add: lookup_pd_slot_def)
-  apply(fastforce)
-  done
-
-lemma modify_arm_hwasid_table_reads_respects:
-  "reads_respects aag l \<top> (modify
-          (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_hwasid_table := param\<rparr>\<rparr>))"
-  apply(simp add: equiv_valid_def2)
-  apply(rule modify_ev2)
-  (* FIXME: slow 5s *)
-  by(auto simp: reads_equiv_def affects_equiv_def states_equiv_for_def equiv_for_def
-          intro: equiv_asids_triv split: if_splits)
-
-
-lemma modify_arm_asid_map_reads_respects:
-  "reads_respects aag l \<top> (modify
-          (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_asid_map := param\<rparr>\<rparr>))"
-  apply(simp add: equiv_valid_def2)
-  apply(rule modify_ev2)
-  (* FIXME: slow 5s *)
-  by(auto simp: reads_equiv_def affects_equiv_def states_equiv_for_def equiv_for_def
-          intro: equiv_asids_triv split: if_splits)
-
-lemma modify_arm_next_asid_reads_respects:
-  "reads_respects aag l \<top> (modify
-          (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_next_asid := param\<rparr>\<rparr>))"
-  apply(simp add: equiv_valid_def2)
-  apply(rule modify_ev2)
-  (* FIXME: slow 5s *)
-  by(auto simp: reads_equiv_def affects_equiv_def states_equiv_for_def equiv_for_def
-          intro: equiv_asids_triv split: if_splits)
-
-
-lemmas modify_arch_state_reads_respects =
-  modify_arm_asid_map_reads_respects
-  modify_arm_hwasid_table_reads_respects
-  modify_arm_next_asid_reads_respects
-
-lemma states_equiv_for_arm_hwasid_table_update1:
-  "states_equiv_for P Q R S (s\<lparr> arch_state := (arch_state s)\<lparr> arm_hwasid_table := Y \<rparr>\<rparr>) t
-     = states_equiv_for P Q R S s t"
-  by (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def
-                     asid_pool_at_kheap)
-
-lemma states_equiv_for_arm_hwasid_table_update2:
-  "states_equiv_for P Q R S t (s\<lparr> arch_state := (arch_state s)\<lparr> arm_hwasid_table := Y \<rparr>\<rparr>)
-     = states_equiv_for P Q R S t s"
-  apply(rule iffI)
-   apply(drule states_equiv_for_sym)
-   apply(rule states_equiv_for_sym)
-   apply(simp add: states_equiv_for_arm_hwasid_table_update1)
-  apply(drule states_equiv_for_sym)
-  apply(rule states_equiv_for_sym)
-  apply(simp add: states_equiv_for_arm_hwasid_table_update1)
-  done
-
-lemma states_equiv_for_arm_hwasid_table_update':
-  "states_equiv_for P Q R S t (s\<lparr> arch_state := (arch_state s)\<lparr> arm_hwasid_table := Y \<rparr>\<rparr>)
-     = states_equiv_for P Q R S t s"
-  by (rule states_equiv_for_arm_hwasid_table_update2)
-
-lemmas states_equiv_for_arm_hwasid_table_update =
-  states_equiv_for_arm_hwasid_table_update1
-  states_equiv_for_arm_hwasid_table_update2
-
-
-lemma states_equiv_for_arm_next_asid_update1:
-  "states_equiv_for P Q R S (s\<lparr> arch_state := (arch_state s)\<lparr> arm_next_asid := Y \<rparr>\<rparr>) t
-     = states_equiv_for P Q R S s t"
-  by (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def
-                       asid_pool_at_kheap)
-
-lemma states_equiv_for_arm_next_asid_update2:
-  "states_equiv_for P Q R S t (s\<lparr> arch_state := (arch_state s)\<lparr> arm_next_asid := X \<rparr>\<rparr>)
-     = states_equiv_for P Q R S t s"
-  by (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def
-                     asid_pool_at_kheap)
-
-lemmas states_equiv_for_arm_next_asid_update =
-  states_equiv_for_arm_next_asid_update1
-  states_equiv_for_arm_next_asid_update2
-
-lemma states_equiv_for_arm_asid_map_update1:
-  "states_equiv_for P Q R S (s\<lparr> arch_state := (arch_state s)\<lparr> arm_asid_map := X \<rparr>\<rparr>) t
-     = states_equiv_for P Q R S s t"
-  by (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def
-                     asid_pool_at_kheap)
-
-lemma states_equiv_for_arm_asid_map_update2:
-  "states_equiv_for P Q R S t (s\<lparr> arch_state := (arch_state s)\<lparr> arm_asid_map := X \<rparr>\<rparr>)
-     = states_equiv_for P Q R S t s"
-  by (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def
-                     asid_pool_at_kheap)
-
-lemmas states_equiv_for_arm_asid_map_update =
-  states_equiv_for_arm_asid_map_update1
-  states_equiv_for_arm_asid_map_update2
-
 (* for things that only modify parts of the state not in the state relations,
    we don't care what they read since these reads are unobservable anyway;
    however, we cannot assert anything about their return-values *)
 lemma equiv_valid_2_unobservable:
   assumes f:
-    "\<And> P Q R S X st. \<lbrace> states_equiv_for P Q R S st \<rbrace> f \<lbrace>\<lambda>_. states_equiv_for P Q R S st\<rbrace>"
+    "\<And>P Q R S st. \<lbrace>states_equiv_for P Q R S st\<rbrace> f \<lbrace>\<lambda>_. states_equiv_for P Q R S st\<rbrace>"
   assumes f':
-    "\<And> P Q R S X st. \<lbrace> states_equiv_for P Q R S st \<rbrace> f' \<lbrace>\<lambda>_. states_equiv_for P Q R S st\<rbrace>"
+    "\<And>P Q R S st. \<lbrace>states_equiv_for P Q R S st\<rbrace> f' \<lbrace>\<lambda>_. states_equiv_for P Q R S st\<rbrace>"
   assumes g:
-    "\<And> P. \<lbrace> \<lambda> s. P (cur_thread s) \<rbrace> f \<lbrace> \<lambda> rv s. P (cur_thread s) \<rbrace>"
+    "\<And>P. \<lbrace>\<lambda>s. P (cur_thread s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cur_thread s)\<rbrace>"
   assumes g':
-    "\<And> P. \<lbrace> \<lambda> s. P (cur_thread s) \<rbrace> f' \<lbrace> \<lambda> rv s. P (cur_thread s) \<rbrace>"
+    "\<And>P. \<lbrace>\<lambda>s. P (cur_thread s)\<rbrace> f' \<lbrace>\<lambda>rv s. P (cur_thread s)\<rbrace>"
   assumes h:
-    "\<And> P. \<lbrace> \<lambda> s. P (cur_domain s) \<rbrace> f \<lbrace> \<lambda> rv s. P (cur_domain s) \<rbrace>"
+    "\<And>P. \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cur_domain s)\<rbrace>"
   assumes h':
-    "\<And> P. \<lbrace> \<lambda> s. P (cur_domain s) \<rbrace> f' \<lbrace> \<lambda> rv s. P (cur_domain s) \<rbrace>"
+    "\<And>P. \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> f' \<lbrace>\<lambda>rv s. P (cur_domain s)\<rbrace>"
   assumes j:
-    "\<And> P. \<lbrace> \<lambda> s. P (scheduler_action s) \<rbrace> f \<lbrace> \<lambda> rv s. P (scheduler_action s) \<rbrace>"
+    "\<And>P. \<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> f \<lbrace>\<lambda>rv s. P (scheduler_action s)\<rbrace>"
   assumes j':
-    "\<And> P. \<lbrace> \<lambda> s. P (scheduler_action s) \<rbrace> f' \<lbrace> \<lambda> rv s. P (scheduler_action s) \<rbrace>"
+    "\<And>P. \<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> f' \<lbrace>\<lambda>rv s. P (scheduler_action s)\<rbrace>"
   assumes k:
-    "\<And> P. \<lbrace> \<lambda> s. P (work_units_completed s) \<rbrace> f \<lbrace> \<lambda> rv s. P (work_units_completed s) \<rbrace>"
+    "\<And>P. \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace> f \<lbrace>\<lambda>rv s. P (work_units_completed s)\<rbrace>"
   assumes k':
-    "\<And> P. \<lbrace> \<lambda> s. P (work_units_completed s) \<rbrace> f' \<lbrace> \<lambda> rv s. P (work_units_completed s) \<rbrace>"
+    "\<And>P. \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace> f' \<lbrace>\<lambda>rv s. P (work_units_completed s)\<rbrace>"
   assumes l:
-    "\<And> P. \<lbrace> \<lambda> s. P (irq_state (machine_state s)) \<rbrace> f \<lbrace> \<lambda> rv s. P (irq_state (machine_state s)) \<rbrace>"
+    "\<And>P. \<lbrace>\<lambda>s. P (irq_state (machine_state s))\<rbrace> f \<lbrace>\<lambda>rv s. P (irq_state (machine_state s))\<rbrace>"
   assumes l':
-    "\<And> P. \<lbrace> \<lambda> s. P (irq_state (machine_state s)) \<rbrace> f' \<lbrace> \<lambda> rv s. P (irq_state (machine_state s)) \<rbrace>"
-
+    "\<And>P. \<lbrace>\<lambda>s. P (irq_state (machine_state s))\<rbrace> f' \<lbrace>\<lambda>rv s. P (irq_state (machine_state s))\<rbrace>"
   shows
     "equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) \<top>\<top> \<top> \<top> f f'"
-  apply(clarsimp simp: equiv_valid_2_def)
-  apply(frule use_valid[OF _ f])
-   apply(rule states_equiv_for_refl)
-  apply(frule use_valid[OF _ f'])
-   apply(rule states_equiv_for_refl)
-  apply(frule use_valid[OF _ f])
-   apply(rule states_equiv_for_refl)
-  apply(frule use_valid[OF _ f'])
-   apply(rule states_equiv_for_refl)
-  apply(frule use_valid)
-    apply(rule_tac P="(=) (cur_thread s)" in g)
-   apply(rule refl)
-  apply(frule_tac f=f' in use_valid)
-    apply(rule_tac P="(=) (cur_thread t)" in g')
-   apply(rule refl)
-  apply(frule use_valid)
-    apply(rule_tac P="(=) (cur_domain s)" in h)
-   apply(rule refl)
-  apply(frule_tac f=f' in use_valid)
-    apply(rule_tac P="(=) (cur_domain t)" in h')
-   apply(rule refl)
-  apply(frule use_valid)
-    apply(rule_tac P="(=) (scheduler_action s)" in j)
-   apply(rule refl)
-  apply(frule_tac f=f' in use_valid)
-    apply(rule_tac P="(=) (scheduler_action t)" in j')
-   apply(rule refl)
-  apply(frule use_valid)
-    apply(rule_tac P="(=) (work_units_completed s)" in k)
-   apply(rule refl)
-  apply(frule_tac f=f' in use_valid)
-    apply(rule_tac P="(=) (work_units_completed t)" in k')
-   apply(rule refl)
-  apply(frule use_valid)
-    apply(rule_tac P="(=) (irq_state (machine_state s))" in l)
-   apply(rule refl)
-  apply(frule_tac f=f' in use_valid)
-    apply(rule_tac P="(=) (irq_state (machine_state t))" in l')
-   apply(rule refl)
-
-  apply(clarsimp simp: reads_equiv_def2 affects_equiv_def2)
-  apply(auto intro: states_equiv_for_sym states_equiv_for_trans)
+  apply (clarsimp simp: equiv_valid_2_def)
+  apply (frule use_valid[OF _ f])
+   apply (rule states_equiv_for_refl)
+  apply (frule use_valid[OF _ f'])
+   apply (rule states_equiv_for_refl)
+  apply (frule use_valid[OF _ f])
+   apply (rule states_equiv_for_refl)
+  apply (frule use_valid[OF _ f'])
+   apply (rule states_equiv_for_refl)
+  apply (frule use_valid)
+    apply (rule_tac P="(=) (cur_thread s)" in g)
+   apply (rule refl)
+  apply (frule_tac f=f' in use_valid)
+    apply (rule_tac P="(=) (cur_thread t)" in g')
+   apply (rule refl)
+  apply (frule use_valid)
+    apply (rule_tac P="(=) (cur_domain s)" in h)
+   apply (rule refl)
+  apply (frule_tac f=f' in use_valid)
+    apply (rule_tac P="(=) (cur_domain t)" in h')
+   apply (rule refl)
+  apply (frule use_valid)
+    apply (rule_tac P="(=) (scheduler_action s)" in j)
+   apply (rule refl)
+  apply (frule_tac f=f' in use_valid)
+    apply (rule_tac P="(=) (scheduler_action t)" in j')
+   apply (rule refl)
+  apply (frule use_valid)
+    apply (rule_tac P="(=) (work_units_completed s)" in k)
+   apply (rule refl)
+  apply (frule_tac f=f' in use_valid)
+    apply (rule_tac P="(=) (work_units_completed t)" in k')
+   apply (rule refl)
+  apply (frule use_valid)
+    apply (rule_tac P="(=) (irq_state (machine_state s))" in l)
+   apply (rule refl)
+  apply (frule_tac f=f' in use_valid)
+    apply (rule_tac P="(=) (irq_state (machine_state t))" in l')
+   apply (rule refl)
+  apply (clarsimp simp: reads_equiv_def2 affects_equiv_def2)
+  apply (auto intro: states_equiv_for_sym states_equiv_for_trans)
   done
-
-
-crunch states_equiv_for: invalidate_hw_asid_entry "states_equiv_for P Q R S st"
-  (simp: states_equiv_for_arm_hwasid_table_update)
-
-crunch states_equiv_for: invalidate_asid "states_equiv_for P Q R S st"
-  (simp: states_equiv_for_arm_asid_map_update)
-
-lemma mol_states_equiv_for:
-  "\<lbrace>\<lambda>ms. states_equiv_for P Q R S st (s\<lparr>machine_state := ms\<rparr>)\<rbrace> machine_op_lift mop \<lbrace>\<lambda>a b. states_equiv_for P Q R S st (s\<lparr>machine_state := b\<rparr>)\<rbrace>"
-  unfolding machine_op_lift_def
-  apply (simp add: machine_rest_lift_def split_def)
-  apply (wp modify_wp)
-  apply (clarsimp simp: states_equiv_for_def)
-  apply (clarsimp simp: equiv_asids_def equiv_asid_def)
-  apply (fastforce elim!: equiv_forE intro!: equiv_forI)
-  done
-
-lemma do_machine_op_mol_states_equiv_for:
-  "invariant (do_machine_op (machine_op_lift f)) (states_equiv_for P Q R S st)"
-  apply(simp add: do_machine_op_def)
-  apply(wp modify_wp | simp add: split_def)+
-  apply(clarify)
-  apply(erule use_valid)
-   apply simp
-   apply(rule mol_states_equiv_for)
-  by simp
-
-
-(* we don't care about the relationship between virtual and hardware asids at all --
-   these should be unobservable, so rightly we don't expect this one to satisfy
-   reads_respects but instead the weaker property where we assert no relation on
-   the return values *)
-lemma find_free_hw_asid_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag \<top>\<top> \<top> (find_free_hw_asid)"
-  unfolding find_free_hw_asid_def fun_app_def invalidateLocalTLB_ASID_def
-  apply(rule equiv_valid_2_unobservable)
-     apply (wp modify_wp invalidate_hw_asid_entry_states_equiv_for
-               do_machine_op_mol_states_equiv_for
-               invalidate_asid_states_equiv_for dmo_wp
-           | wpc
-           | simp add: states_equiv_for_arm_asid_map_update
-                       states_equiv_for_arm_hwasid_table_update
-                       states_equiv_for_arm_next_asid_update)+
-  done
-
-lemma load_hw_asid_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag \<top>\<top> \<top> (load_hw_asid asid)"
-
-  apply(rule equiv_valid_2_unobservable)
-     apply(simp add: load_hw_asid_def | wp)+
-  done
-
-lemma states_equiv_for_arch_update1:
-  "\<lbrakk>arm_globals_frame A = arm_globals_frame (arch_state s);
-    arm_asid_table A = arm_asid_table (arch_state s)\<rbrakk> \<Longrightarrow>
-    states_equiv_for P Q R S (s\<lparr> arch_state := A\<rparr>) t =
-    states_equiv_for P Q R S s t"
-  apply(clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def asid_pool_at_kheap)
-  done
-
-lemma states_equiv_for_arch_update2:
-  "\<lbrakk>arm_globals_frame A = arm_globals_frame (arch_state s);
-    arm_asid_table A = arm_asid_table (arch_state s)\<rbrakk> \<Longrightarrow>
-    states_equiv_for P Q R S t (s\<lparr> arch_state := A\<rparr>) =
-    states_equiv_for P Q R S t s"
-  apply(rule iffI)
-   apply(drule states_equiv_for_sym)
-   apply(rule states_equiv_for_sym)
-   apply(simp add: states_equiv_for_arch_update1)
-  apply(drule states_equiv_for_sym)
-  apply(rule states_equiv_for_sym)
-  apply(simp add: states_equiv_for_arch_update1)
-  done
-
-lemmas states_equiv_for_arch_update = states_equiv_for_arch_update1 states_equiv_for_arch_update2
-
-crunch states_equiv_for: store_hw_asid "states_equiv_for P Q R S st"
-  (simp: states_equiv_for_arch_update)
-
-lemma find_free_hw_asid_states_equiv_for:
-  "invariant (find_free_hw_asid) (states_equiv_for P Q R S st)"
-  apply(simp add: find_free_hw_asid_def)
-  apply(wp modify_wp invalidate_hw_asid_entry_states_equiv_for do_machine_op_mol_states_equiv_for invalidate_asid_states_equiv_for | wpc | simp add: states_equiv_for_arm_next_asid_update invalidateLocalTLB_ASID_def)+
-  done
-
-crunch states_equiv_for: get_hw_asid "states_equiv_for P Q R S st"
 
 lemma reads_respects_unobservable_unit_return:
   assumes f:
-    "\<And> P Q R S st. \<lbrace> states_equiv_for P Q R S st \<rbrace> f \<lbrace>\<lambda>_. states_equiv_for P Q R S st\<rbrace>"
+    "\<And>P Q R S st. \<lbrace>states_equiv_for P Q R S st\<rbrace> f \<lbrace>\<lambda>_. states_equiv_for P Q R S st\<rbrace>"
   assumes g:
-    "\<And> P. \<lbrace> \<lambda> s. P (cur_thread s) \<rbrace> f \<lbrace> \<lambda> rv s. P (cur_thread s) \<rbrace>"
+    "\<And>P. \<lbrace>\<lambda>s. P (cur_thread s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cur_thread s)\<rbrace>"
   assumes h:
-    "\<And> P. \<lbrace> \<lambda> s. P (cur_domain s) \<rbrace> f \<lbrace> \<lambda> rv s. P (cur_domain s) \<rbrace>"
+    "\<And>P. \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cur_domain s)\<rbrace>"
   assumes j:
-    "\<And> P. \<lbrace> \<lambda> s. P (scheduler_action s) \<rbrace> f \<lbrace> \<lambda> rv s. P (scheduler_action s) \<rbrace>"
+    "\<And>P. \<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> f \<lbrace>\<lambda>rv s. P (scheduler_action s)\<rbrace>"
   assumes k:
-    "\<And> P. \<lbrace> \<lambda> s. P (work_units_completed s) \<rbrace> f \<lbrace> \<lambda> rv s. P (work_units_completed s) \<rbrace>"
+    "\<And>P. \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace> f \<lbrace>\<lambda>rv s. P (work_units_completed s)\<rbrace>"
   assumes l:
-    "\<And> P. \<lbrace> \<lambda> s. P (irq_state_of_state s) \<rbrace> f \<lbrace> \<lambda> rv s. P (irq_state_of_state s) \<rbrace>"
-
+    "\<And>P. \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace> f \<lbrace>\<lambda>rv s. P (irq_state_of_state s)\<rbrace>"
   shows
     "reads_respects aag l \<top> (f::(unit,det_ext) s_monad)"
-  apply(subgoal_tac "reads_equiv_valid_rv_inv (affects_equiv aag l) aag \<top>\<top> \<top> f")
-   apply(clarsimp simp: equiv_valid_2_def equiv_valid_def2)
-  apply(rule equiv_valid_2_unobservable[OF f f g g h h j j k k l l])
+  apply (subgoal_tac "reads_equiv_valid_rv_inv (affects_equiv aag l) aag \<top>\<top> \<top> f")
+   apply (clarsimp simp: equiv_valid_2_def equiv_valid_def2)
+  apply (rule equiv_valid_2_unobservable[OF f f g g h h j j k k l l])
   done
 
 lemma dmo_mol_irq_state_of_state[wp]:
-  "\<And>P. \<lbrace>\<lambda>s. P (irq_state_of_state s) \<rbrace> do_machine_op (machine_op_lift m)
-       \<lbrace>\<lambda>_ s. P (irq_state_of_state s) \<rbrace>"
-  apply(wp dmo_wp | simp)+
-  done
-
-lemma arm_context_switch_reads_respects:
-  "reads_respects aag l \<top> (arm_context_switch pd asid)"
-  unfolding arm_context_switch_def
-  apply(rule equiv_valid_guard_imp)
-  apply(rule reads_respects_unobservable_unit_return)
-    apply (wp do_machine_op_mol_states_equiv_for get_hw_asid_states_equiv_for
-     | simp add: set_current_pd_def dsb_def isb_def writeTTBR0_def dmo_bind_valid setHardwareASID_def)+
-  done
-
-lemma arm_context_switch_states_equiv_for:
-  "invariant (arm_context_switch pd asid) (states_equiv_for P Q R S st)"
-  unfolding arm_context_switch_def
-  apply (wp do_machine_op_mol_states_equiv_for get_hw_asid_states_equiv_for | simp add: setHardwareASID_def dmo_bind_valid set_current_pd_def dsb_def isb_def writeTTBR0_def)+
-  done
-
-lemma set_vm_root_states_equiv_for[wp]:
-  "invariant (set_vm_root thread) (states_equiv_for P Q R S st)"
-  unfolding set_vm_root_def catch_def fun_app_def set_current_pd_def isb_def dsb_def writeTTBR0_def
-  apply (wp (once) hoare_drop_imps
-        |wp do_machine_op_mol_states_equiv_for hoare_vcg_all_lift arm_context_switch_states_equiv_for hoare_whenE_wp
-        | wpc | simp add: dmo_bind_valid if_apply_def2)+
-  done
-
-lemma set_vm_root_reads_respects:
-  "reads_respects aag l \<top> (set_vm_root tcb)"
-  by (rule reads_respects_unobservable_unit_return) wp+
-
-lemma get_pte_reads_respects:
-  "reads_respects aag l (K (is_subject aag (ptr && ~~ mask pt_bits))) (get_pte ptr)"
-  unfolding get_pte_def fun_app_def
-  by (wpsimp wp: get_pt_reads_respects)
-
-lemma gets_cur_thread_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag (=) \<top> (gets cur_thread)"
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule gets_evrv)
-  apply(fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist elim: reads_equivE affects_equivE)
-  done
-
-crunch states_equiv_for: set_vm_root_for_flush "states_equiv_for P Q R S st"
-  (wp: do_machine_op_mol_states_equiv_for ignore: do_machine_op simp: set_current_pd_def)
-
-lemma set_vm_root_for_flush_reads_respects:
-  "reads_respects aag l (is_subject aag \<circ> cur_thread)
-    (set_vm_root_for_flush pd asid)"
-  unfolding set_vm_root_for_flush_def fun_app_def set_current_pd_def
-  apply(rule equiv_valid_guard_imp)
-  apply (wp (once) hoare_drop_imps
-        |wp arm_context_switch_reads_respects dmo_mol_reads_respects
-            hoare_vcg_all_lift gets_cur_thread_ev get_cap_rev
-        |wpc)+
-  apply (clarsimp simp: reads_equiv_def)
-  done
-
-crunch states_equiv_for: flush_table "states_equiv_for P Q R S st"
-  (wp: crunch_wps do_machine_op_mol_states_equiv_for ignore: do_machine_op simp: invalidateLocalTLB_ASID_def crunch_simps)
-
-crunch sched_act: flush_table "\<lambda> s. P (scheduler_action s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-crunch wuc: flush_table "\<lambda> s. P (work_units_completed s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma flush_table_reads_respects:
-  "reads_respects aag l \<top> (flush_table pd asid vptr pt)"
-  apply(rule reads_respects_unobservable_unit_return)
-       apply(rule flush_table_states_equiv_for)
-      apply(rule flush_table_cur_thread)
-     apply(rule flush_table_cur_domain)
-    apply(rule flush_table_sched_act)
-   apply(rule flush_table_wuc)
-  apply wp
-  done
-
-lemma page_table_mapped_reads_respects:
-  "reads_respects aag l
-    (pas_refined aag and pspace_aligned
-     and valid_vspace_objs and K (is_subject_asid aag asid))
-  (page_table_mapped asid vaddr pt)"
-  unfolding page_table_mapped_def catch_def fun_app_def
-  apply(wp get_pde_rev | wpc | simp)+
-     apply(wp find_pd_for_asid_reads_respects | simp)+
-  done
-
-
-lemma unmap_page_table_reads_respects:
-  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs and K (is_subject_asid aag asid))
-   (unmap_page_table asid vaddr pt)"
-  unfolding unmap_page_table_def fun_app_def page_table_mapped_def
-  apply(wp find_pd_for_asid_pd_slot_authorised
-           dmo_mol_reads_respects store_pde_reads_respects get_pde_rev get_pde_wp
-           flush_table_reads_respects find_pd_for_asid_reads_respects hoare_vcg_all_lift_R catch_ev
-       | wpc | simp add: cleanByVA_PoU_def | wp (once) hoare_drop_imps)+
-  done
-
-
-lemma perform_page_table_invocation_reads_respects:
-  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs and K (authorised_page_table_inv aag pti))
-    (perform_page_table_invocation pti)"
-  unfolding perform_page_table_invocation_def fun_app_def cleanCacheRange_PoU_def
-  apply(rule equiv_valid_guard_imp)
-  apply(wp dmo_cacheRangeOp_reads_respects dmo_mol_reads_respects store_pde_reads_respects
-           set_cap_reads_respects
-           mapM_x_ev'' store_pte_reads_respects unmap_page_table_reads_respects get_cap_rev
-       | wpc | simp add: cleanByVA_PoU_def)+
-  apply(clarsimp simp: authorised_page_table_inv_def)
-  apply(case_tac pti)
-  apply auto
-  done
-
-lemma do_flush_reads_respects:
-  "reads_respects aag l \<top> (do_machine_op (do_flush typ start end pstart))"
-  apply (rule equiv_valid_guard_imp)
-   apply (cases "typ")
-      apply (wp dmo_mol_reads_respects dmo_cacheRangeOp_reads_respects | simp add: do_flush_def cache_machine_op_defs do_flush_defs dmo_bind_ev when_def | rule conjI | clarsimp)+
-      done
-
-lemma perform_page_directory_invocation_reads_respects:
-  "reads_respects aag l (is_subject aag \<circ> cur_thread) (perform_page_directory_invocation pdi)"
-  unfolding perform_page_directory_invocation_def
-  apply (cases pdi)
-  apply (wp do_flush_reads_respects set_vm_root_reads_respects set_vm_root_for_flush_reads_respects | simp add: when_def requiv_cur_thread_eq split del: if_split | wp (once) hoare_drop_imps | clarsimp)+
-  done
+  "do_machine_op (machine_op_lift m) \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  by (wpsimp wp: dmo_wp)
 
 lemma throw_on_false_reads_respects:
-  "reads_respects aag l P f \<Longrightarrow>
-  reads_respects aag l P (throw_on_false ex f)"
-  unfolding throw_on_false_def fun_app_def unlessE_def
-  apply(wp | simp)+
-  done
-
-lemma check_mapping_pptr_reads_respects:
-  "reads_respects aag l
-    (K (\<forall>x.   (tablePtr = Inl x \<longrightarrow> is_subject aag (x && ~~ mask pt_bits))
-            \<and> (tablePtr = Inr x \<longrightarrow> is_subject aag (x && ~~ mask pd_bits))))
-  (check_mapping_pptr pptr pgsz tablePtr)"
-  unfolding check_mapping_pptr_def fun_app_def
-  apply(rule equiv_valid_guard_imp)
-   apply(wp get_pte_reads_respects get_pde_rev | wpc)+
-  apply(simp)
-  done
-
-lemma lookup_pt_slot_reads_respects:
-  "reads_respects aag l (K (is_subject aag (lookup_pd_slot pd vptr && ~~ mask pd_bits))) (lookup_pt_slot pd vptr)"
-  unfolding lookup_pt_slot_def fun_app_def
-  apply(wp get_pde_rev | wpc | simp)+
-  done
-
-crunch sched_act: flush_page "\<lambda>s. P (scheduler_action s)"
-  (wp: crunch_wps simp: if_apply_def2)
-
-crunch wuc: flush_page "\<lambda>s. P (work_units_completed s)"
-  (wp: crunch_wps simp: if_apply_def2)
-
-crunch states_equiv_for: flush_page "states_equiv_for P Q R S st"
-  (wp: do_machine_op_mol_states_equiv_for crunch_wps ignore: do_machine_op simp: invalidateLocalTLB_VAASID_def if_apply_def2)
-
-lemma flush_page_reads_respects:
-  "reads_respects aag l \<top> (flush_page page_size pd asid vptr)"
-  apply (blast intro: reads_respects_unobservable_unit_return flush_page_states_equiv_for flush_page_cur_thread flush_page_cur_domain flush_page_sched_act flush_page_wuc flush_page_irq_state_of_state)
-  done
-
-(* clagged some help from unmap_page_respects in Arch_AC *)
-lemma unmap_page_reads_respects:
-  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs and K (is_subject_asid aag asid \<and> vptr < kernel_base)) (unmap_page pgsz asid vptr pptr)"
-  unfolding unmap_page_def catch_def fun_app_def cleanCacheRange_PoU_def
-  apply (simp add: unmap_page_def swp_def cong: vmpage_size.case_cong)
-  apply(wp dmo_mol_reads_respects dmo_cacheRangeOp_reads_respects
-           store_pte_reads_respects[simplified]
-           check_mapping_pptr_reads_respects
-           throw_on_false_reads_respects  lookup_pt_slot_reads_respects
-           lookup_pt_slot_authorised lookup_pt_slot_authorised2
-           store_pde_reads_respects[simplified] flush_page_reads_respects
-           find_pd_for_asid_reads_respects find_pd_for_asid_pd_slot_authorised
-           mapM_ev''[
-                     where m = "(\<lambda>a. store_pte a InvalidPTE)"
-                       and P = "\<lambda>x s. is_subject aag (x && ~~ mask pt_bits)"]
-           mapM_ev''[where m = "(\<lambda>a. store_pde a InvalidPDE)"
-                       and P = "\<lambda>x s. is_subject aag (x && ~~ mask pd_bits)"]
-
-       | wpc
-       | simp add: is_aligned_6_masks is_aligned_mask[symmetric] cleanByVA_PoU_def
-       | wp (once) hoare_drop_imps)+
-  done
+  "reads_respects aag l P f
+   \<Longrightarrow> reads_respects aag l P (throw_on_false ex f)"
+  unfolding throw_on_false_def fun_app_def unlessE_def by wpsimp
 
 lemma dmo_mol_2_reads_respects:
   "reads_respects aag l \<top> (do_machine_op (machine_op_lift mop >>= (\<lambda> y. machine_op_lift mop')))"
-  apply(rule use_spec_ev)
-  apply(rule do_machine_op_spec_reads_respects)
-  apply wp
-     apply(rule machine_op_lift_ev)
-    apply(rule machine_op_lift_ev)
-   apply(rule wp_post_taut)
-  by (wp | simp)+
+  apply (rule use_spec_ev)
+  apply (rule do_machine_op_spec_reads_respects)
+  by (wpsimp wp: machine_op_lift_ev)+
 
 lemma tl_subseteq:
   "set (tl xs) \<subseteq> set xs"
   by (induct xs, auto)
-
-
-crunch states_equiv_for: invalidate_tlb_by_asid "states_equiv_for P Q R S st"
-  (wp: do_machine_op_mol_states_equiv_for ignore: do_machine_op simp: invalidateLocalTLB_ASID_def)
-
-
-crunch sched_act[wp]: invalidate_tlb_by_asid "\<lambda>s. P (scheduler_action s)"
-crunch wuc[wp]: invalidate_tlb_by_asid "\<lambda>s. P (work_units_completed s)"
-
-lemma invalidate_tlb_by_asid_reads_respects:
-  "reads_respects aag l (\<lambda>_. True) (invalidate_tlb_by_asid asid)"
-  apply(rule reads_respects_unobservable_unit_return)
-      apply (rule invalidate_tlb_by_asid_states_equiv_for)
-     apply wp+
-  done
-
-
-lemma get_master_pte_reads_respects:
-  "reads_respects aag l (K (is_subject aag (p && ~~ mask pt_bits))) (get_master_pte p)"
-  unfolding get_master_pte_def
-  apply(wp get_pte_reads_respects | wpc | simp
-       | wp (once) hoare_drop_imps)+
-  apply(fastforce simp: pt_bits_def pageBits_def mask_lower_twice)
-  done
-
-
-lemma get_master_pde_reads_respects:
-  "reads_respects aag l (K (is_subject aag (x && ~~ mask pd_bits))) (get_master_pde x)"
-  unfolding get_master_pde_def
-  apply(wp get_pde_rev | wpc | simp
-       | wp (once) hoare_drop_imps)+
-  apply(fastforce simp: pd_bits_def pageBits_def mask_lower_twice)
-  done
 
 
 abbreviation(input) aag_can_read_label where
@@ -834,259 +156,103 @@ abbreviation(input) aag_can_read_label where
 
 definition labels_are_invisible where
   "labels_are_invisible aag l L \<equiv>
-         (\<forall> d \<in> L. \<not> aag_can_read_label aag d) \<and>
-         (aag_can_affect_label aag l \<longrightarrow>
-              (\<forall> d \<in> L. d \<notin> subjectReads (pasPolicy aag) l))"
+     (\<forall>d \<in> L. \<not> aag_can_read_label aag d) \<and>
+     (aag_can_affect_label aag l \<longrightarrow> (\<forall>d \<in> L. d \<notin> subjectReads (pasPolicy aag) l))"
 
 
 lemma equiv_but_for_reads_equiv:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "\<lbrakk>labels_are_invisible aag l L; equiv_but_for_labels aag L s s'\<rbrakk> \<Longrightarrow>
-   reads_equiv aag s s'"
-  apply(simp add: reads_equiv_def2)
-  apply(rule conjI)
-   apply(clarsimp simp: labels_are_invisible_def equiv_but_for_labels_def)
-   apply(rule states_equiv_forI)
-             apply(fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+
-       apply((auto intro!: equiv_forI elim!: states_equiv_forE elim!: equiv_forD
-             |clarsimp simp: o_def)+)[1]
-      apply(fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+
-    apply(fastforce simp: equiv_asids_def elim: states_equiv_forE elim: equiv_forD)
+  "\<lbrakk> pas_domains_distinct aag; labels_are_invisible aag l L; equiv_but_for_labels aag L s s' \<rbrakk>
+     \<Longrightarrow> reads_equiv aag s s'"
+  apply (simp add: reads_equiv_def2)
+  apply (rule conjI)
+   apply (clarsimp simp: labels_are_invisible_def equiv_but_for_labels_def)
+   apply (rule states_equiv_forI)
+            apply (fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+
+       apply (auto intro!: equiv_forI elim!: states_equiv_forE elim!: equiv_forD simp: o_def)[1]
+      apply (fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+
+    apply (fastforce simp: equiv_asids_def elim: states_equiv_forE elim: equiv_forD)
    apply (clarsimp simp: equiv_for_def states_equiv_for_def disjoint_iff_not_equal)
-   apply (metis domains_distinct[THEN pas_domains_distinct_inj])
-  apply(fastforce simp: equiv_but_for_labels_def)
+   apply (metis pas_domains_distinct_inj)
+  apply (fastforce simp: equiv_but_for_labels_def)
   done
 
 lemma equiv_but_for_affects_equiv:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "\<lbrakk>labels_are_invisible aag l L; equiv_but_for_labels aag L s s'\<rbrakk> \<Longrightarrow>
-   affects_equiv aag l s s'"
-  apply(subst affects_equiv_def2)
-  apply(clarsimp simp: labels_are_invisible_def equiv_but_for_labels_def aag_can_affect_label_def)
-  apply(rule states_equiv_forI)
-         apply(fastforce intro!: equiv_forI elim!: states_equiv_forE equiv_forD)+
-   apply(fastforce simp: equiv_asids_def elim!: states_equiv_forE elim!: equiv_forD)
+  "\<lbrakk> pas_domains_distinct aag; labels_are_invisible aag l L; equiv_but_for_labels aag L s s' \<rbrakk>
+     \<Longrightarrow> affects_equiv aag l s s'"
+  apply (subst affects_equiv_def2)
+  apply (clarsimp simp: labels_are_invisible_def equiv_but_for_labels_def aag_can_affect_label_def)
+  apply (rule states_equiv_forI)
+           apply (fastforce intro!: equiv_forI elim!: states_equiv_forE equiv_forD)+
+   apply (fastforce simp: equiv_asids_def elim!: states_equiv_forE elim!: equiv_forD)
   apply (clarsimp simp: equiv_for_def states_equiv_for_def disjoint_iff_not_equal)
-  apply (metis domains_distinct[THEN pas_domains_distinct_inj])
+  apply (metis pas_domains_distinct_inj)
   done
 
 (* consider rewriting the return-value assumption using equiv_valid_rv_inv *)
 lemma ev2_invisible:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "\<lbrakk>labels_are_invisible aag l L;
-    labels_are_invisible aag l L';
-    modifies_at_most aag L Q f;
-    modifies_at_most aag L' Q' g;
-    \<forall> s t. P s \<and> P' t \<longrightarrow> (\<forall>(rva,s') \<in> fst (f s). \<forall>(rvb,t') \<in> fst (g t). W rva rvb)\<rbrakk>
-  \<Longrightarrow>
-  equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l)
-    W (P and Q) (P' and Q') f g"
-  apply(clarsimp simp: equiv_valid_2_def)
-  apply(rule conjI)
+  "\<lbrakk> labels_are_invisible aag l L; labels_are_invisible aag l L';
+     modifies_at_most aag L Q f; modifies_at_most aag L' Q' g;
+     \<forall>s t. P s \<and> P' t \<longrightarrow> (\<forall>(rva,s') \<in> fst (f s). \<forall>(rvb,t') \<in> fst (g t). W rva rvb) \<rbrakk>
+     \<Longrightarrow> equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l)
+                        W (P and Q) (P' and Q') f g"
+  apply (clarsimp simp: equiv_valid_2_def)
+  apply (rule conjI)
    apply blast
-  apply(drule_tac s=s in modifies_at_mostD, assumption+)
-  apply(drule_tac s=t in modifies_at_mostD, assumption+)
-  apply(frule (1) equiv_but_for_reads_equiv[OF domains_distinct])
-  apply(frule_tac s=t in equiv_but_for_reads_equiv[OF domains_distinct], assumption)
-  apply(drule (1) equiv_but_for_affects_equiv[OF domains_distinct])
-  apply(drule_tac s=t in equiv_but_for_affects_equiv[OF domains_distinct], assumption)
-  apply(blast intro: reads_equiv_trans reads_equiv_sym affects_equiv_trans affects_equiv_sym)
+  apply (drule_tac s=s in modifies_at_mostD, assumption+)
+  apply (drule_tac s=t in modifies_at_mostD, assumption+)
+  apply (frule (1) equiv_but_for_reads_equiv[OF domains_distinct])
+  apply (frule_tac s=t in equiv_but_for_reads_equiv[OF domains_distinct], assumption)
+  apply (drule (1) equiv_but_for_affects_equiv[OF domains_distinct])
+  apply (drule_tac s=t in equiv_but_for_affects_equiv[OF domains_distinct], assumption)
+  apply (blast intro: reads_equiv_trans reads_equiv_sym affects_equiv_trans affects_equiv_sym)
   done
+
+lemma ev_invisible:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows
+    "\<lbrakk> labels_are_invisible aag l L; modifies_at_most aag L Q f;
+       \<forall>s t. P s \<and> P t \<longrightarrow> (\<forall>(rva, s') \<in> fst (f s). \<forall>(rvb, t') \<in> fst(f t). W rva rvb) \<rbrakk>
+       \<Longrightarrow> equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l)
+                         W (P and Q) (P and Q) f f"
+  by (rule ev2_invisible[OF domains_distinct]; simp)
 
 lemma modify_det:
   "det (modify f)"
-  apply(clarsimp simp: det_def modify_def get_def put_def bind_def)
-  done
+  by (clarsimp simp: det_def modify_def get_def put_def bind_def)
 
 lemma dummy_kheap_update:
-  "st = st\<lparr> kheap := kheap st \<rparr>"
+  "st = st\<lparr>kheap := kheap st\<rparr>"
   by simp
 
-(* we need to know we're not doing an asid pool update, or else this could affect
-   what some other domain sees *)
-lemma set_object_equiv_but_for_labels:
-  "\<lbrace>equiv_but_for_labels aag L st and (\<lambda> s. \<not> asid_pool_at ptr s) and
-    K ((\<forall> asid_pool. obj \<noteq> ArchObj (ASIDPool asid_pool)) \<and> pasObjectAbs aag ptr \<in> L)\<rbrace>
-   set_object ptr obj
-   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
-  apply (wpsimp wp: set_object_wp)
-  apply(clarsimp simp: equiv_but_for_labels_def)
-  apply(subst dummy_kheap_update[where st=st])
-  apply(rule states_equiv_for_non_asid_pool_kheap_update)
-     apply assumption
-    apply(fastforce intro: equiv_forI elim: states_equiv_forE equiv_forE)
-   apply(fastforce simp: non_asid_pool_kheap_update_def)
-  apply(clarsimp simp: non_asid_pool_kheap_update_def asid_pool_at_kheap)
-  done
-
-
-lemma get_tcb_not_asid_pool_at:
-  "get_tcb ref s = Some y \<Longrightarrow> \<not> asid_pool_at ref s"
-  by(fastforce simp: get_tcb_def asid_pool_at_kheap)
-
-lemma as_user_set_register_ev2:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "labels_are_invisible aag l (pasObjectAbs aag ` {thread,thread'}) \<Longrightarrow>
-   equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) (=) \<top> \<top> (as_user thread (setRegister x y)) (as_user thread' (setRegister a b))"
-  apply(simp add: as_user_def)
-  apply(rule equiv_valid_2_guard_imp)
-   apply(rule_tac L="{pasObjectAbs aag thread}" and L'="{pasObjectAbs aag thread'}" and Q="\<top>" and Q'="\<top>" in ev2_invisible[OF domains_distinct])
-        apply(simp add: labels_are_invisible_def)+
-      apply((rule modifies_at_mostI | wp set_object_equiv_but_for_labels | simp add: split_def | fastforce dest: get_tcb_not_asid_pool_at)+)[2]
-    apply auto
-  done
-
-
 lemma reads_affects_equiv_kheap_eq:
-  "\<lbrakk>reads_equiv aag s s'; affects_equiv aag l s s';
-    aag_can_affect aag l x \<or> aag_can_read aag x\<rbrakk> \<Longrightarrow>
-   kheap s x = kheap s' x"
-  apply(erule disjE)
-   apply(fastforce elim: affects_equivE equiv_forE)
-  apply(fastforce elim: reads_equivE equiv_forE)
-  done
+  "\<lbrakk> reads_equiv aag s s'; affects_equiv aag l s s'; aag_can_affect aag l x \<or> aag_can_read aag x \<rbrakk>
+     \<Longrightarrow> kheap s x = kheap s' x"
+  by (fastforce elim: affects_equivE reads_equivE equiv_forE)
 
 lemma reads_affects_equiv_get_tcb_eq:
-  "\<lbrakk>aag_can_read aag thread \<or> aag_can_affect aag l thread;
-    reads_equiv aag s t; affects_equiv aag l s t\<rbrakk> \<Longrightarrow>
-   get_tcb thread s = get_tcb thread t"
-  apply (fastforce simp: get_tcb_def split: kernel_object.splits option.splits simp: reads_affects_equiv_kheap_eq)
-  done
-
-lemma as_user_set_register_reads_respects':
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l \<top> (as_user thread (setRegister x y))"
-  apply (case_tac "aag_can_read aag thread \<or> aag_can_affect aag l thread")
-   apply (simp add: as_user_def split_def)
-   apply (rule gen_asm_ev)
-   apply (wp set_object_reads_respects select_f_ev gets_the_ev)
-   apply (auto intro: reads_affects_equiv_get_tcb_eq det_setRegister)[1]
-  apply(simp add: equiv_valid_def2)
-  apply(rule as_user_set_register_ev2[OF domains_distinct])
-  apply(simp add: labels_are_invisible_def)
-  done
-
-lemma as_user_get_register_reads_respects:
-  "reads_respects aag l (K (is_subject aag thread)) (as_user thread (getRegister reg))"
-  apply (simp add: as_user_def split_def)
-  apply (wp set_object_reads_respects select_f_ev gets_the_ev)
-  apply (auto intro: reads_affects_equiv_get_tcb_eq det_getRegister)[1]
-  done
-
-lemma set_message_info_reads_respects:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l \<top>
-    (set_message_info thread info)"
-  unfolding set_message_info_def fun_app_def
-  apply(rule as_user_set_register_reads_respects'[OF domains_distinct])
-  done
+  "\<lbrakk> aag_can_read aag t \<or> aag_can_affect aag l t; reads_equiv aag s s'; affects_equiv aag l s s' \<rbrakk>
+     \<Longrightarrow> get_tcb t s = get_tcb t s'"
+  by (fastforce simp: get_tcb_def reads_affects_equiv_kheap_eq)
 
 lemma equiv_valid_get_assert:
-  "equiv_valid_inv I A P f \<Longrightarrow>
-   equiv_valid_inv I A P (get >>= (\<lambda> s. assert (g s) >>= (\<lambda> y. f)))"
-  apply(subst equiv_valid_def2)
-  apply(rule_tac W="\<top>\<top>" in equiv_valid_rv_bind)
-    apply(rule equiv_valid_rv_guard_imp)
-     apply(rule equiv_valid_rv_trivial)
+  "equiv_valid_inv I A P f
+   \<Longrightarrow> equiv_valid_inv I A P (get >>= (\<lambda> s. assert (g s) >>= (\<lambda> y. f)))"
+  apply (subst equiv_valid_def2)
+  apply (rule_tac W="\<top>\<top>" in equiv_valid_rv_bind)
+    apply (rule equiv_valid_rv_guard_imp)
+     apply (rule equiv_valid_rv_trivial)
      apply wpsimp+
-   apply(rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
-      apply(simp add: equiv_valid_def2)
-     apply(rule assert_ev2)
+   apply (rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
+      apply (simp add: equiv_valid_def2)
+     apply (rule assert_ev2)
      apply (wp | simp)+
   done
 
-lemma store_word_offs_reads_respects:
-  "reads_respects aag l \<top> (store_word_offs ptr offs v)"
-  apply(simp add: store_word_offs_def)
-  apply(rule equiv_valid_get_assert)
-  apply(simp add: storeWord_def)
-  apply(simp add: do_machine_op_bind)
-  apply(wp)
-     apply(rule use_spec_ev)
-     apply(rule do_machine_op_spec_reads_respects)
-     apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def in_monad)
-     apply(fastforce intro: equiv_forI elim: equiv_forE)
-    apply(rule use_spec_ev | rule do_machine_op_spec_reads_respects
-         | simp add: spec_equiv_valid_def | rule assert_ev2 | wp modify_wp)+
-  done
-
-
-lemma set_mrs_reads_respects:
-  "reads_respects aag l (K (aag_can_read aag thread \<or> aag_can_affect aag l thread)) (set_mrs thread buf msgs)"
-  apply(simp add: set_mrs_def cong: option.case_cong_weak)
-  apply(wp mapM_x_ev' store_word_offs_reads_respects set_object_reads_respects
-       | wpc | simp add: split_def split del: if_split add: zipWithM_x_mapM_x)+
-  apply(auto intro: reads_affects_equiv_get_tcb_eq)
-  done
-
-lemma perform_page_invocation_reads_respects:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (pas_refined aag and K (authorised_page_inv aag pgi) and valid_page_inv pgi and valid_vspace_objs and pspace_aligned and is_subject aag \<circ> cur_thread) (perform_page_invocation pgi)"
-  unfolding perform_page_invocation_def fun_app_def when_def cleanCacheRange_PoU_def
-  apply(rule equiv_valid_guard_imp)
-  apply wpc
-      apply(simp add: mapM_discarded swp_def)
-      apply (wp dmo_mol_reads_respects dmo_cacheRangeOp_reads_respects
-                mapM_x_ev'' store_pte_reads_respects
-                set_cap_reads_respects mapM_ev'' store_pde_reads_respects
-                unmap_page_reads_respects set_vm_root_reads_respects
-                dmo_mol_2_reads_respects set_vm_root_for_flush_reads_respects get_cap_rev
-                do_flush_reads_respects invalidate_tlb_by_asid_reads_respects
-                get_master_pte_reads_respects get_master_pde_reads_respects
-                set_mrs_reads_respects set_message_info_reads_respects
-            | simp add: cleanByVA_PoU_def pte_check_if_mapped_def pde_check_if_mapped_def  | wpc | wp (once) hoare_drop_imps[where R="\<lambda> r s. r"])+
-  apply(clarsimp simp: authorised_page_inv_def valid_page_inv_def)
-  apply (auto simp: cte_wp_at_caps_of_state valid_slots_def cap_auth_conferred_def
-                    update_map_data_def is_page_cap_def authorised_slots_def
-                    valid_page_inv_def valid_cap_simps
-             dest!: bspec[OF _ rev_subsetD[OF _ tl_subseteq]]
-       | auto dest!: clas_caps_of_state
-               simp: cap_links_asid_slot_def label_owns_asid_slot_def
-              dest!: pas_refined_Control
-       | (frule aag_can_read_self, simp)+)+
-  done
-
-lemma equiv_asids_arm_asid_table_update:
-  "\<lbrakk>equiv_asids R s t; kheap s pool_ptr = kheap t pool_ptr\<rbrakk> \<Longrightarrow>
-   equiv_asids R (s\<lparr>arch_state := arch_state s
-                   \<lparr>arm_asid_table := arm_asid_table (arch_state s)
-                      (asid_high_bits_of asid \<mapsto> pool_ptr)\<rparr>\<rparr>)
-              (t\<lparr>arch_state := arch_state t
-                   \<lparr>arm_asid_table := arm_asid_table (arch_state t)
-                      (asid_high_bits_of asid \<mapsto> pool_ptr)\<rparr>\<rparr>)"
-  apply(clarsimp simp: equiv_asids_def equiv_asid_def asid_pool_at_kheap)
-  done
-
-
-lemma arm_asid_table_update_reads_respects:
-  "reads_respects aag l (K (is_subject aag pool_ptr))
-        (do r \<leftarrow> gets (arm_asid_table \<circ> arch_state);
-            modify
-             (\<lambda>s. s\<lparr>arch_state := arch_state s
-                      \<lparr>arm_asid_table := r(asid_high_bits_of asid \<mapsto> pool_ptr)\<rparr>\<rparr>)
-         od)"
-  apply(simp add: equiv_valid_def2)
-  apply(rule_tac W="\<top>\<top>" and Q="\<lambda> rv s. is_subject aag pool_ptr \<and> rv = arm_asid_table (arch_state s)" in equiv_valid_rv_bind)
-    apply(rule equiv_valid_rv_guard_imp[OF equiv_valid_rv_trivial])
-     apply wpsimp+
-   apply(rule modify_ev2)
-   apply clarsimp
-   apply (drule(1) is_subject_kheap_eq[rotated])
-   apply (auto simp add: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_for_def intro!: equiv_asids_arm_asid_table_update)
-   done
-
-
 lemma my_bind_rewrite_lemma:
   "(f >>= g) =  (f >>= (\<lambda> r. (g r) >>= (\<lambda> x. return ())))"
-  apply simp
-  done
+  by simp
 
 lemma delete_objects_reads_respects:
   "reads_respects aag l (\<lambda>_. True) (delete_objects p b)"
@@ -1096,160 +262,8 @@ lemma delete_objects_reads_respects:
 
 lemma another_hacky_rewrite:
   "do a; (do x \<leftarrow> f; g x od); h; j od = do a; (f >>= g >>= (\<lambda>_. h)); j od"
-  apply(simp add: bind_assoc[symmetric])
-  done
+  by (simp add: bind_assoc[symmetric])
 
-lemma perform_asid_control_invocation_reads_respects:
-  notes K_bind_ev[wp del]
-  shows
-  "reads_respects aag l (K (authorised_asid_control_inv aag aci))
-  (perform_asid_control_invocation aci)"
-  unfolding perform_asid_control_invocation_def
-  apply(rule gen_asm_ev)
-  apply(rule equiv_valid_guard_imp)
-   (* we do some hacky rewriting here to separate out the bit that does interesting stuff from the rest *)
-   apply(subst (6) my_bind_rewrite_lemma)
-   apply(subst (1) bind_assoc[symmetric])
-   apply(subst another_hacky_rewrite)
-   apply(subst another_hacky_rewrite)
-   apply(wpc)
-   apply(rule bind_ev)
-     apply(rule K_bind_ev)
-     apply(rule_tac P'=\<top> in bind_ev)
-       apply(rule K_bind_ev)
-       apply(rule bind_ev)
-         apply(rule bind_ev)
-           apply(rule return_ev)
-          apply(rule K_bind_ev)
-          apply simp
-          apply(rule arm_asid_table_update_reads_respects)
-         apply (wp cap_insert_reads_respects retype_region_reads_respects
-                   set_cap_reads_respects delete_objects_reads_respects get_cap_rev
-               | simp add: authorised_asid_control_inv_def)+
-  apply(auto dest!: is_aligned_no_overflow)
-  done
-
-
-lemma set_asid_pool_reads_respects:
-  "reads_respects aag l \<top> (set_asid_pool ptr pool)"
-  unfolding set_asid_pool_def
-  by (rule set_object_reads_respects)
-
-lemma perform_asid_pool_invocation_reads_respects:
-  "reads_respects aag l (pas_refined aag and K (authorised_asid_pool_inv aag api))  (perform_asid_pool_invocation api)"
-  unfolding perform_asid_pool_invocation_def
-  apply(rule equiv_valid_guard_imp)
-   apply(wp set_asid_pool_reads_respects set_cap_reads_respects
-            get_asid_pool_rev get_cap_auth_wp[where aag=aag] get_cap_rev
-        | wpc | simp)+
-  apply(clarsimp simp: authorised_asid_pool_inv_def)
-  done
-
-lemma arch_perform_invocation_reads_respects:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs and
-                         authorised_arch_inv aag ai and valid_arch_inv ai and is_subject aag \<circ> cur_thread)
-    (arch_perform_invocation ai)"
-  unfolding arch_perform_invocation_def fun_app_def
-  apply(wp perform_page_table_invocation_reads_respects perform_page_directory_invocation_reads_respects perform_page_invocation_reads_respects perform_asid_control_invocation_reads_respects perform_asid_pool_invocation_reads_respects | wpc)+
-  apply(case_tac ai)
-  apply(auto simp: authorised_arch_inv_def valid_arch_inv_def)
-  done
-
-lemma equiv_asids_arm_asid_table_delete:
-  "\<lbrakk>equiv_asids R s t\<rbrakk> \<Longrightarrow>
-   equiv_asids R (s\<lparr>arch_state := arch_state s
-                   \<lparr>arm_asid_table :=
-                        \<lambda>a. if a = asid_high_bits_of asid then None
-                             else arm_asid_table (arch_state s) a\<rparr>\<rparr>)
-              (t\<lparr>arch_state := arch_state t
-                   \<lparr>arm_asid_table :=
-                        \<lambda>a. if a = asid_high_bits_of asid then None
-                             else arm_asid_table (arch_state t) a\<rparr>\<rparr>)"
-  apply(clarsimp simp: equiv_asids_def equiv_asid_def asid_pool_at_kheap)
-  done
-
-lemma arm_asid_table_delete_ev2:
-  "equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l)
-     \<top>\<top> (\<lambda>s. rv = arm_asid_table (arch_state s))
-        (\<lambda>s. rv' = arm_asid_table (arch_state s))
-          (modify
-             (\<lambda>s. s\<lparr>arch_state := arch_state s
-                      \<lparr>arm_asid_table :=
-                        \<lambda>a. if a = asid_high_bits_of base then None
-                             else rv a\<rparr>\<rparr>))
-          (modify
-             (\<lambda>s. s\<lparr>arch_state := arch_state s
-                      \<lparr>arm_asid_table :=
-                        \<lambda>a. if a = asid_high_bits_of base then None
-                             else rv' a\<rparr>\<rparr>))"
-  apply(rule modify_ev2)
-  (* slow 15s *)
-  by(auto simp: reads_equiv_def2 affects_equiv_def2
-          intro!: states_equiv_forI elim!: states_equiv_forE
-          intro!: equiv_forI elim!: equiv_forE
-          intro!: equiv_asids_arm_asid_table_delete
-          elim: is_subject_kheap_eq[simplified reads_equiv_def2 states_equiv_for_def, rotated])
-
-crunch states_equiv_for: invalidate_asid_entry "states_equiv_for P Q R S st"
-crunch sched_act: invalidate_asid_entry "\<lambda>s. P (scheduler_action s)"
-crunch wuc: invalidate_asid_entry "\<lambda>s. P (work_units_completed s)"
-crunch states_equiv_for: flush_space "states_equiv_for P Q R S st"
-  (wp: mol_states_equiv_for dmo_wp ignore: do_machine_op simp: invalidateLocalTLB_ASID_def cleanCaches_PoU_def dsb_def invalidate_I_PoU_def clean_D_PoU_def)
-crunch sched_act: flush_space "\<lambda>s. P (scheduler_action s)"
-crunch wuc: flush_space "\<lambda>s. P (work_units_completed s)"
-
-
-
-
-lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq':
-  "\<lbrakk>(\<forall>asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of base \<longrightarrow> is_subject_asid aag asid');reads_equiv aag s t\<rbrakk> \<Longrightarrow>
-    arm_asid_table (arch_state s) (asid_high_bits_of base) =
-    arm_asid_table (arch_state t) (asid_high_bits_of base)"
-  apply (insert asid_high_bits_0_eq_1)
-   apply(case_tac "base = 0")
-    apply(subgoal_tac "is_subject_asid aag 1")
-    apply simp
-    apply (rule requiv_arm_asid_table_asid_high_bits_of_asid_eq[where aag=aag])
-    apply (erule_tac x=1 in allE)
-    apply simp+
-    apply (rule requiv_arm_asid_table_asid_high_bits_of_asid_eq[where aag=aag])
-    apply (erule_tac x=base in allE)
-    apply simp+
-done
-
-
-lemma delete_asid_pool_reads_respects:
-  "reads_respects aag l (K (\<forall>asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of base \<longrightarrow> is_subject_asid aag asid')) (delete_asid_pool base ptr)"
-  unfolding delete_asid_pool_def
-  apply(rule equiv_valid_guard_imp)
-   apply(rule bind_ev)
-     apply(simp)
-     apply(subst equiv_valid_def2)
-     apply(rule_tac W="\<top>\<top>" and Q="\<lambda>rv s. rv = arm_asid_table (arch_state s)
-        \<and> (\<forall>asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of base \<longrightarrow> is_subject_asid aag asid')"
-                     in equiv_valid_rv_bind)
-       apply(rule equiv_valid_rv_guard_imp[OF equiv_valid_rv_trivial])
-        apply(wp, simp)
-      apply(simp add: when_def)
-      apply(clarsimp | rule conjI)+
-        apply(subst bind_assoc[symmetric])
-        apply(subst (3) bind_assoc[symmetric])
-        apply(rule equiv_valid_2_guard_imp)
-          apply(rule equiv_valid_2_bind)
-             apply(rule equiv_valid_2_bind)
-                apply(rule equiv_valid_2_unobservable)
-                           apply(wp set_vm_root_states_equiv_for)+
-               apply(rule arm_asid_table_delete_ev2)
-              apply(wp)+
-            apply(rule equiv_valid_2_unobservable)
-                       apply(wp mapM_wp' invalidate_asid_entry_states_equiv_for flush_space_states_equiv_for invalidate_asid_entry_cur_thread invalidate_asid_entry_sched_act invalidate_asid_entry_wuc flush_space_cur_thread flush_space_sched_act flush_space_wuc | clarsimp)+
-       apply( wp return_ev2 |
-              drule (1) requiv_arm_asid_table_asid_high_bits_of_asid_eq' |
-              clarsimp   | rule conjI |
-              simp add: equiv_valid_2_def )+
-done
 
 definition states_equal_except_kheap_asid :: "det_state \<Rightarrow> det_state \<Rightarrow> bool" where
   "states_equal_except_kheap_asid s s' \<equiv>
@@ -1267,1169 +281,231 @@ definition states_equal_except_kheap_asid :: "det_state \<Rightarrow> det_state 
      work_units_completed s = work_units_completed s' \<and>
      irq_state_of_state s = irq_state_of_state s'"
 
-lemma set_asid_pool_state_equal_except_kheap:
-  "((), s') \<in> fst (set_asid_pool ptr pool s) \<Longrightarrow>
-    states_equal_except_kheap_asid s s' \<and>
-    (\<forall>p. p \<noteq> ptr \<longrightarrow> kheap s p = kheap s' p) \<and>
-    kheap s' ptr = Some (ArchObj (ASIDPool pool)) \<and>
-    (\<forall>asid. asid \<noteq> 0 \<longrightarrow>
-      arm_asid_table (arch_state s) (asid_high_bits_of asid) =
-      arm_asid_table (arch_state s') (asid_high_bits_of asid) \<and>
-      (\<forall>pool_ptr. arm_asid_table (arch_state s) (asid_high_bits_of asid) =
-        Some pool_ptr \<longrightarrow>
-          asid_pool_at pool_ptr s = asid_pool_at pool_ptr s' \<and>
-          (\<forall>asid_pool asid_pool'. pool_ptr \<noteq> ptr \<longrightarrow>
-            kheap s pool_ptr = Some (ArchObj (ASIDPool asid_pool)) \<and>
-            kheap s' pool_ptr = Some (ArchObj (ASIDPool asid_pool')) \<longrightarrow>
-              asid_pool (ucast asid) = asid_pool' (ucast asid))))"
-  by (clarsimp simp: set_asid_pool_def put_def bind_def set_object_def get_object_def gets_def
-                     get_def return_def assert_def fail_def states_equal_except_kheap_asid_def
-                     equiv_for_def obj_at_def
-              split: if_split_asm)
-
-lemma set_asid_pool_delete_ev2:
-  "equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l)
-     \<top>\<top> (\<lambda>s. arm_asid_table (arch_state s) (asid_high_bits_of asid) = Some a \<and>
-            kheap s a = Some (ArchObj (ASIDPool pool)) \<and>
-            asid \<noteq> 0 \<and> is_subject_asid aag asid)
-        (\<lambda>s. arm_asid_table (arch_state s) (asid_high_bits_of asid) = Some a \<and>
-            kheap s a = Some (ArchObj (ASIDPool pool')) \<and>
-            asid \<noteq> 0 \<and> is_subject_asid aag asid)
-          (set_asid_pool a (pool(ucast asid := None)))
-          (set_asid_pool a (pool'(ucast asid := None)))"
-  apply(clarsimp simp: equiv_valid_2_def)
-  apply(frule_tac s'=b in set_asid_pool_state_equal_except_kheap)
-  apply(frule_tac s'=ba in set_asid_pool_state_equal_except_kheap)
-  apply(clarsimp simp: states_equal_except_kheap_asid_def)
-  apply(rule conjI)
-   apply(clarsimp simp: states_equiv_for_def reads_equiv_def equiv_for_def | rule conjI)+
-     apply(case_tac "x=a")
-      apply(clarsimp)
-     apply(fastforce)
-    apply(clarsimp simp: equiv_asids_def equiv_asid_def | rule conjI)+
-     apply(case_tac "pool_ptr = a")
-      apply(clarsimp)
-      apply(erule_tac x="pasASIDAbs aag asid" in ballE)
-       apply(clarsimp)
-       apply(erule_tac x=asid in allE)+
-       apply(clarsimp)
-      apply(drule aag_can_read_own_asids, simp)
-     apply(erule_tac x="pasASIDAbs aag asida" in ballE)
-      apply(clarsimp)
-      apply(erule_tac x=asida in allE)+
-      apply(clarsimp)
-     apply(clarsimp)
-    apply(clarsimp)
-    apply(case_tac "pool_ptr=a")
-     apply(erule_tac x="pasASIDAbs aag asida" in ballE)
-      apply(clarsimp)+
-  apply(clarsimp simp: affects_equiv_def equiv_for_def states_equiv_for_def | rule conjI)+
-   apply(case_tac "x=a")
-    apply(clarsimp)
-   apply(fastforce)
-  apply(clarsimp simp: equiv_asids_def equiv_asid_def | rule conjI)+
-   apply(case_tac "pool_ptr=a")
-    apply(clarsimp)
-    apply(erule_tac x=asid in allE)+
-    apply(clarsimp simp: asid_pool_at_kheap)
-   apply(erule_tac x=asida in allE)+
-   apply(clarsimp)
-  apply(clarsimp)
-  apply(case_tac "pool_ptr=a")
-   apply(clarsimp)+
-  done
-
-lemma delete_asid_reads_respects:
-  "reads_respects aag l (K (asid \<noteq> 0 \<and> is_subject_asid aag asid))
-    (delete_asid asid pd)"
-  unfolding delete_asid_def
-  apply(subst equiv_valid_def2)
-  apply(rule_tac W="\<top>\<top>" and Q="\<lambda>rv s. rv = arm_asid_table (arch_state s)
-        \<and> is_subject_asid aag asid \<and> asid \<noteq> 0" in equiv_valid_rv_bind)
-    apply(rule equiv_valid_rv_guard_imp[OF equiv_valid_rv_trivial])
-     apply(wp, simp)
-   apply(case_tac "rv (asid_high_bits_of asid) =
-                   rv' (asid_high_bits_of asid)")
-    apply(simp)
-    apply(case_tac "rv' (asid_high_bits_of asid)")
-     apply(simp)
-     apply(wp return_ev2, simp)
-    apply(simp)
-    apply(rule equiv_valid_2_guard_imp)
-    apply(rule_tac R'="\<lambda>rv rv'. rv (ucast asid) = rv' (ucast asid)"
-                in equiv_valid_2_bind)
-       apply(simp add: when_def)
-       apply(clarsimp | rule conjI)+
-        apply(rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
-           apply(rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
-              apply(rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
-                 apply(subst equiv_valid_def2[symmetric])
-                 apply(rule reads_respects_unobservable_unit_return)
-                  apply(wp set_vm_root_states_equiv_for)+
-                apply(rule set_asid_pool_delete_ev2)
-               apply(wp)+
-             apply(rule equiv_valid_2_unobservable)
-                apply(wp invalidate_asid_entry_states_equiv_for
-                         invalidate_asid_entry_cur_thread)+
-            apply(simp add: invalidate_asid_entry_def
-                | wp invalidate_asid_kheap invalidate_hw_asid_entry_kheap
-                     load_hw_asid_kheap)+
-          apply(rule equiv_valid_2_unobservable)
-             apply(wp flush_space_states_equiv_for flush_space_cur_thread)+
-         apply(wp load_hw_asid_kheap | simp add: flush_space_def | wpc)+
-       apply(clarsimp | rule return_ev2)+
-      apply(rule equiv_valid_2_guard_imp)
-        apply(wp get_asid_pool_revrv)
-       apply(simp)+
-     apply(wp)+
-   apply(clarsimp simp: obj_at_def)+
-   apply(clarsimp simp: equiv_valid_2_def reads_equiv_def equiv_asids_def equiv_asid_def states_equiv_for_def)
-   apply(erule_tac x="pasASIDAbs aag asid" in ballE)
-    apply(clarsimp)
-   apply(drule aag_can_read_own_asids)
-   apply(clarsimp | wpsimp)+
-   done
-
-
-subsection "globals_equiv"
-
-
-lemma set_simple_ko_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm\<rbrace> set_simple_ko f ptr ep \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_simple_ko_def
-  apply(wpsimp wp: set_object_globals_equiv[THEN hoare_set_object_weaken_pre] get_object_wp
-             simp: partial_inv_def)+
-  apply(fastforce simp: obj_at_def valid_ko_at_arm_def)
-  done
-
-lemma set_endpoint_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm\<rbrace> set_simple_ko f ptr ep \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  unfolding set_simple_ko_def set_object_def
-  apply(wpsimp wp: get_object_wp
-        simp: partial_inv_def a_type_def obj_at_def valid_ko_at_arm_def)+
-  done
-
-lemma set_thread_state_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm\<rbrace> set_thread_state ref ts \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_thread_state_def
-  apply(wp set_object_globals_equiv dxo_wp_weak |simp)+
-  apply (intro impI conjI allI)
-  apply(clarsimp simp: valid_ko_at_arm_def obj_at_def tcb_at_def2 get_tcb_def is_tcb_def dest: get_tcb_SomeD
-                 split: option.splits kernel_object.splits)+
-  done
-
-lemma set_bound_notification_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm\<rbrace> set_bound_notification ref ts \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_bound_notification_def
-  apply(wp set_object_globals_equiv dxo_wp_weak |simp)+
-  apply (intro impI conjI allI)
-  apply(clarsimp simp: valid_ko_at_arm_def obj_at_def tcb_at_def2 get_tcb_def is_tcb_def
-                 dest: get_tcb_SomeD
-                split: option.splits kernel_object.splits)+
-  done
-
-lemma set_object_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm and (\<lambda>s. ptr = arm_global_pd (arch_state s) \<longrightarrow>
-   a_type obj = AArch APageDirectory)\<rbrace>
-     set_object ptr obj \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  by (wpsimp wp: set_object_wp
-           simp: a_type_def valid_ko_at_arm_def obj_at_def
-          split: kernel_object.splits arch_kernel_obj.splits if_splits)
-
-lemma valid_ko_at_arm_exst_update[simp]: "valid_ko_at_arm (trans_state f s) = valid_ko_at_arm s"
-  apply (simp add: valid_ko_at_arm_def)
-  done
-
-lemma set_thread_state_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm\<rbrace> set_thread_state ref ts \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  unfolding set_thread_state_def
-  apply(wp set_object_valid_ko_at_arm dxo_wp_weak |simp)+
-  apply(fastforce simp: valid_ko_at_arm_def get_tcb_ko_at obj_at_def)
-  done
-
-lemma set_bound_notification_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm\<rbrace> set_bound_notification ref ts \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  unfolding set_bound_notification_def
-  apply(wp set_object_valid_ko_at_arm dxo_wp_weak |simp)+
-  apply(fastforce simp: valid_ko_at_arm_def get_tcb_ko_at obj_at_def)
-  done
-
-crunch globals_equiv: cancel_badged_sends "globals_equiv s"
- (wp: filterM_preserved dxo_wp_weak ignore: reschedule_required tcb_sched_action)
-
-lemma thread_set_globals_equiv:
-  "(\<And>tcb. arch_tcb_context_get (tcb_arch (f tcb)) = arch_tcb_context_get (tcb_arch tcb))
-     \<Longrightarrow> \<lbrace>globals_equiv s and valid_ko_at_arm\<rbrace> thread_set f tptr \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding thread_set_def
-  apply(wp set_object_globals_equiv)
-  apply simp
-  apply (intro impI conjI allI)
-  apply(fastforce simp: valid_ko_at_arm_def obj_at_def get_tcb_def)+
-  apply (clarsimp simp: get_tcb_def tcb_at_def2 split: kernel_object.splits option.splits)
-  done
-
-lemma set_asid_pool_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm\<rbrace> set_asid_pool ptr pool \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_asid_pool_def
-  apply (wpsimp wp: set_object_globals_equiv[THEN hoare_set_object_weaken_pre]
-              simp: a_type_def)
-  apply (fastforce simp: valid_ko_at_arm_def obj_at_def)
-  done
 
 lemma idle_equiv_arch_state_update[simp]: "idle_equiv st (s\<lparr>arch_state := x\<rparr>) = idle_equiv st s"
-  apply (simp add: idle_equiv_def)
-  done
+  by (simp add: idle_equiv_def)
 
-crunch globals_equiv[wp]: invalidate_hw_asid_entry "globals_equiv s"
- (simp: globals_equiv_def)
+(* FIXME: This should either be straightforward or moved somewhere else *)
+lemma case_junk:
+  "(case rv of Inl e \<Rightarrow> True | Inr r \<Rightarrow> P r) \<longrightarrow> (case rv of Inl e \<Rightarrow> True | Inr r \<Rightarrow> R r) =
+   (case rv of Inl e \<Rightarrow> True | Inr r \<Rightarrow> P r \<longrightarrow> R r)"
+  by (case_tac rv; simp)
 
-crunch globals_equiv[wp]: invalidate_asid "globals_equiv s"
- (simp: globals_equiv_def)
-
-lemma globals_equiv_arm_next_asid_update[simp]:
-  "globals_equiv s (t\<lparr>arch_state := arch_state t\<lparr>arm_next_asid := x\<rparr>\<rparr>) = globals_equiv s t"
-  by (simp add: globals_equiv_def)
-
-lemma globals_equiv_arm_asid_map_update[simp]:
-  "globals_equiv s (t\<lparr>arch_state := arch_state t\<lparr>arm_asid_map := x\<rparr>\<rparr>) = globals_equiv s t"
-  by (simp add: globals_equiv_def)
-
-lemma globals_equiv_arm_hwasid_table_update[simp]:
-  "globals_equiv s (t\<lparr>arch_state := arch_state t\<lparr>arm_hwasid_table := x\<rparr>\<rparr>) = globals_equiv s t"
-  by (simp add: globals_equiv_def)
-
-lemma globals_equiv_arm_asid_table_update[simp]:
-  "globals_equiv s (t\<lparr>arch_state := arch_state t\<lparr>arm_asid_table := x\<rparr>\<rparr>) = globals_equiv s t"
-  by (simp add: globals_equiv_def)
-
-lemma find_free_hw_asid_globals_equiv[wp]:
-  "\<lbrace>globals_equiv s\<rbrace> find_free_hw_asid \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding find_free_hw_asid_def
-  apply(wp modify_wp invalidate_hw_asid_entry_globals_equiv
-          dmo_mol_globals_equiv invalidate_asid_globals_equiv
-       | wpc | simp add: invalidateLocalTLB_ASID_def)+
-  done
-
-lemma store_hw_asid_globals_equiv[wp]:
-  "\<lbrace>globals_equiv s\<rbrace> store_hw_asid asid hw_asid \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding store_hw_asid_def
-  apply(wp find_pd_for_asid_assert_wp | rule modify_wp, simp)+
-  apply(fastforce simp: globals_equiv_def)
-  done
-
-lemma get_hw_asid_globals_equiv[wp]:
-  "\<lbrace>globals_equiv s\<rbrace> get_hw_asid asid \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding get_hw_asid_def
-  apply(wp store_hw_asid_globals_equiv find_free_hw_asid_globals_equiv load_hw_asid_wp | wpc | simp)+
-  done
-
-lemma arm_context_switch_globals_equiv[wp]:
-  "\<lbrace>globals_equiv s\<rbrace> arm_context_switch pd asid \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding arm_context_switch_def  setHardwareASID_def
-  apply(wp dmo_mol_globals_equiv get_hw_asid_globals_equiv
-       | simp add: dmo_bind_valid set_current_pd_def writeTTBR0_def isb_def dsb_def )+
-  done
-
-lemma set_vm_root_globals_equiv[wp]:
-  "\<lbrace>globals_equiv s\<rbrace> set_vm_root tcb \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  apply (clarsimp simp:set_vm_root_def set_current_pd_def dsb_def
-                       isb_def writeTTBR0_def dmo_bind_valid)
-  apply(wp dmo_mol_globals_equiv arm_context_switch_globals_equiv whenE_inv
-        | wpc
-        | clarsimp simp: dmo_bind_valid isb_def dsb_def writeTTBR0_def)+
-   apply(wp hoare_vcg_all_lift | wp (once) hoare_drop_imps | clarsimp)+
-   done
-
-lemma invalidate_asid_entry_globals_equiv[wp]:
-  "\<lbrace>globals_equiv s\<rbrace> invalidate_asid_entry asid \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding invalidate_asid_entry_def
-  apply(wp invalidate_hw_asid_entry_globals_equiv invalidate_asid_globals_equiv load_hw_asid_wp)
-  apply(clarsimp)
-  done
-
-lemma flush_space_globals_equiv[wp]:
-  "\<lbrace>globals_equiv s\<rbrace> flush_space asid \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-unfolding flush_space_def
-apply(wp dmo_mol_globals_equiv load_hw_asid_wp
-    | wpc
-    | simp add: invalidateLocalTLB_ASID_def cleanCaches_PoU_def dsb_def invalidate_I_PoU_def clean_D_PoU_def dmo_bind_valid)+
-done
-
-lemma delete_asid_pool_globals_equiv[wp]:
-  "\<lbrace>globals_equiv s\<rbrace> delete_asid_pool base ptr \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding delete_asid_pool_def
-  apply(wp set_vm_root_globals_equiv mapM_wp[OF _ subset_refl] modify_wp invalidate_asid_entry_globals_equiv flush_space_globals_equiv | simp)+
-  done
-
-crunch globals_equiv[wp]: invalidate_tlb_by_asid "globals_equiv s"
-  (simp: invalidateLocalTLB_ASID_def wp: dmo_mol_globals_equiv ignore: machine_op_lift do_machine_op)
-
-lemma set_pt_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm\<rbrace> set_pt ptr pt \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_pt_def
-  apply (wpsimp wp: set_object_globals_equiv[THEN hoare_set_object_weaken_pre]
-              simp: a_type_def)
-  apply (fastforce simp: valid_ko_at_arm_def obj_at_def)
-  done
-
-crunch globals_equiv: store_pte "globals_equiv s"
-
-lemma set_vm_root_for_flush_globals_equiv[wp]:
-  "\<lbrace>globals_equiv s\<rbrace> set_vm_root_for_flush pd asid \<lbrace>\<lambda>rv. globals_equiv s\<rbrace>"
-  unfolding set_vm_root_for_flush_def set_current_pd_def fun_app_def
-  apply(wp dmo_mol_globals_equiv | wpc | simp)+
-    apply(rule_tac Q="\<lambda>rv. globals_equiv s" in hoare_strengthen_post)
-     apply(wp | simp)+
-     done
-
-lemma flush_table_globals_equiv[wp]:
-  "\<lbrace>globals_equiv s\<rbrace> flush_table pd asid cptr pt \<lbrace>\<lambda>rv. globals_equiv s\<rbrace>"
-  unfolding flush_table_def invalidateLocalTLB_ASID_def fun_app_def
-  apply (wp mapM_wp' dmo_mol_globals_equiv | wpc | simp add: do_machine_op_bind split del: if_split cong: if_cong)+
-  done
-
-lemma arm_global_pd_arm_asid_map_update[simp]:
-  "arm_global_pd (arch_state s\<lparr>arm_asid_map := x\<rparr>) = arm_global_pd (arch_state s)"
-  by (simp add: globals_equiv_def)
-
-lemma arm_global_pd_arm_hwasid_table_update[simp]:
-  "arm_global_pd (arch_state s\<lparr>arm_hwasid_table := x\<rparr>) = arm_global_pd (arch_state s)"
-  by (simp add: globals_equiv_def)
-
-crunch arm_global_pd[wp]: flush_table "\<lambda>s. P (arm_global_pd (arch_state s))"
-  (wp: crunch_wps simp: crunch_simps)
-
-crunch globals_equiv[wp]: page_table_mapped "globals_equiv st"
-
-(*FIXME: duplicated, more reasonable version of not_in_global_refs_vs_lookup *)
-
-lemma not_in_global_refs_vs_lookup2: "\<lbrakk>
-  valid_vs_lookup s;
-  valid_global_refs s;
-  valid_arch_state s; valid_global_objs s; page_directory_at p s; (\<exists>\<rhd> p) s\<rbrakk> \<Longrightarrow>
-  p \<notin> global_refs s"
-  apply (insert not_in_global_refs_vs_lookup[where p=p and s=s])
-  apply simp
-done
-
-(*FIXME: This should either be straightforward or moved somewhere else*)
-
-lemma case_junk : "((case rv of Inl e \<Rightarrow> True | Inr r \<Rightarrow> P r) \<longrightarrow> (case rv of Inl e \<Rightarrow> True | Inr r \<Rightarrow> R r)) =
-  (case rv of Inl e \<Rightarrow> True | Inr r \<Rightarrow> P r \<longrightarrow> R r)"
-  apply (case_tac rv)
-  apply simp+
-done
-
-(*FIXME: Same here*)
-lemma hoare_add_postE : "\<lbrace>Q\<rbrace> f \<lbrace>\<lambda> r. P r\<rbrace>,- \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>\<lambda> r s. (P r s) \<longrightarrow> (R r s) \<rbrace>,- \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>\<lambda> r. R r\<rbrace>,-"
+(* FIXME: Same here *)
+lemma hoare_add_postE:
+  "\<lbrakk> \<lbrace>Q\<rbrace> f \<lbrace>P\<rbrace>, - ; \<lbrace>Q\<rbrace> f \<lbrace>\<lambda>rv s. (P rv s) \<longrightarrow> (R rv s)\<rbrace>, - \<rbrakk>
+     \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>,-"
   unfolding validE_R_def validE_def
   apply (erule hoare_add_post)
    apply simp
   apply (erule hoare_post_imp[rotated])
   apply (simp add: case_junk)
-done
-
-lemma find_pd_for_asid_not_arm_global_pd:
-  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_global_objs and valid_vs_lookup
-  and valid_global_refs and valid_arch_state\<rbrace>
-  find_pd_for_asid asid
-  \<lbrace>\<lambda>rv s. lookup_pd_slot rv vptr && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s)\<rbrace>, -"
-  apply (wp find_pd_for_asid_lots)
-  apply clarsimp
-  apply (subst(asm) lookup_pd_slot_pd)
-   apply (erule page_directory_at_aligned_pd_bits, simp+)
-  apply (frule (4) not_in_global_refs_vs_lookup2)
-   apply (auto simp: global_refs_def)
-done
-
-lemma find_pd_for_asid_not_arm_global_pd_large_page:
-  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_global_objs and valid_vs_lookup
-  and valid_global_refs and valid_arch_state\<rbrace>
-  find_pd_for_asid asid
-  \<lbrace>\<lambda>rv s.
-  (lookup_pd_slot rv vptr && mask 6 = 0) \<longrightarrow>
-  (\<forall> x \<in> set [0 , 4 .e. 0x3C].
-  x + lookup_pd_slot rv vptr && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s))\<rbrace>, -"
-  apply (wp find_pd_for_asid_lots)
-  apply clarsimp
-  apply (subst (asm) is_aligned_mask[symmetric])
-  apply (frule is_aligned_6_masks[where bits=pd_bits])
-  apply simp+
-  apply (subst(asm) lookup_pd_slot_eq)
-   apply (erule page_directory_at_aligned_pd_bits, simp+)
-  apply (frule (4) not_in_global_refs_vs_lookup2)
-   apply (auto simp: global_refs_def)
-  done
-
-declare dmo_mol_globals_equiv[wp]
-
-lemma unmap_page_table_globals_equiv:
-  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_global_objs and valid_vs_lookup
-  and valid_global_refs and valid_arch_state and globals_equiv st\<rbrace> unmap_page_table asid vaddr pt \<lbrace>\<lambda>rv. globals_equiv st\<rbrace>"
-  unfolding unmap_page_table_def page_table_mapped_def
-  apply(wp store_pde_globals_equiv | wpc | simp add: cleanByVA_PoU_def)+
-    apply(rule_tac Q="\<lambda>_. globals_equiv st and (\<lambda>sa. lookup_pd_slot pd vaddr && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state sa))" in hoare_strengthen_post)
-     apply(wp find_pd_for_asid_not_arm_global_pd hoare_post_imp_dc2E_actual | simp)+
-  done
-
-lemma set_pt_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm\<rbrace> set_pt ptr pt \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  unfolding set_pt_def
-  by (wpsimp wp: set_object_wp_strong simp: valid_ko_at_arm_def obj_at_def a_type_def)
-
-crunch valid_ko_at_arm[wp]: store_pte "valid_ko_at_arm"
-
-lemma mapM_x_swp_store_pte_globals_equiv:
-  " \<lbrace>globals_equiv s and valid_ko_at_arm\<rbrace>
-          mapM_x (swp store_pte A) slots
-          \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  apply(rule_tac Q="\<lambda>_. globals_equiv s and valid_ko_at_arm" in hoare_strengthen_post)
-   apply(wp mapM_x_wp' store_pte_globals_equiv store_pte_valid_ko_at_arm | simp)+
-   done
-
-lemma mapM_x_swp_store_pte_valid_ko_at_arm[wp]:
-  " \<lbrace>valid_ko_at_arm\<rbrace>
-          mapM_x (swp store_pte A) slots
-          \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  apply(wp mapM_x_wp' | simp add: swp_def)+
-  done
-
-lemma set_cap_globals_equiv'':
-  "\<lbrace>globals_equiv s and valid_ko_at_arm\<rbrace>
-  set_cap cap p \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_cap_def
-  apply(simp only: split_def)
-  apply(wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
-   apply(fastforce simp: valid_ko_at_arm_def valid_ao_at_def obj_at_def is_tcb_def)+
-  done
-
-lemma do_machine_op_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm\<rbrace> do_machine_op mol \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  unfolding do_machine_op_def machine_op_lift_def split_def valid_ko_at_arm_def
-  apply(wp modify_wp, simp)
-  done
-
-lemma valid_ko_at_arm_next_asid[simp]:
-  "valid_ko_at_arm (s\<lparr>arch_state := arch_state s\<lparr>arm_next_asid := x\<rparr>\<rparr>)
-  = valid_ko_at_arm s"
-  by (simp add: valid_ko_at_arm_def)
-
-lemma valid_ko_at_arm_asid_map[simp]:
-  "valid_ko_at_arm (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_map := x\<rparr>\<rparr>)
-  = valid_ko_at_arm s"
-  by (simp add: valid_ko_at_arm_def)
-
-lemma valid_ko_at_arm_hwasid_table[simp]:
-  "valid_ko_at_arm (s\<lparr>arch_state := arch_state s\<lparr>arm_hwasid_table := x\<rparr>\<rparr>)
-  = valid_ko_at_arm s"
-  by (simp add: valid_ko_at_arm_def)
-
-lemma valid_ko_at_arm_asid_table[simp]:
-  "valid_ko_at_arm
-                (s\<lparr>arch_state := arch_state s
-                     \<lparr>arm_asid_table := A\<rparr>\<rparr>) =
-   valid_ko_at_arm s" by (simp add: valid_ko_at_arm_def)
-
-lemma valid_ko_at_arm_interrupt_states[simp]:
-  "valid_ko_at_arm (s\<lparr>interrupt_states := f\<rparr>)
-  = valid_ko_at_arm s"
-  by (simp add: valid_ko_at_arm_def)
-
-lemma valid_ko_at_arm_arch[simp]:
-  "arm_global_pd A = arm_global_pd (arch_state s) \<Longrightarrow>
-   valid_ko_at_arm (s\<lparr>arch_state := A\<rparr>) = valid_ko_at_arm s"
-  by (simp add: valid_ko_at_arm_def)
-
-crunch valid_ko_at_arm[wp]: arm_context_switch, set_vm_root, set_pd "valid_ko_at_arm"
-  (wp: find_pd_for_asid_assert_wp crunch_wps simp: crunch_simps)
-
-crunch valid_ko_at_arm[wp]: unmap_page_table "valid_ko_at_arm"
-  (wp: crunch_wps simp: crunch_simps a_type_simps)
-
-definition authorised_for_globals_page_table_inv ::
-    "page_table_invocation \<Rightarrow> 'z state \<Rightarrow> bool" where
-  "authorised_for_globals_page_table_inv pti \<equiv>
-    \<lambda>s. case pti of PageTableMap cap ptr pde p
-  \<Rightarrow> p && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s) | _ \<Rightarrow> True"
-
-lemma perform_page_table_invocation_globals_equiv:
-  "\<lbrace>valid_global_refs and valid_global_objs and valid_arch_state and
-    globals_equiv st and pspace_aligned and valid_vspace_objs and
-    valid_vs_lookup and valid_kernel_mappings and authorised_for_globals_page_table_inv pti\<rbrace>
-  perform_page_table_invocation pti \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding perform_page_table_invocation_def cleanCacheRange_PoU_def
-  apply(rule hoare_weaken_pre)
-   apply(wp store_pde_globals_equiv set_cap_globals_equiv'' dmo_cacheRangeOp_lift
-            mapM_x_swp_store_pte_globals_equiv unmap_page_table_globals_equiv
-           | wpc | simp add: cleanByVA_PoU_def)+
-  apply(fastforce simp: authorised_for_globals_page_table_inv_def valid_arch_state_def valid_ko_at_arm_def obj_at_def dest: a_type_pdD)
-  done
-
-lemma do_flush_globals_equiv:
-  "\<lbrace>globals_equiv st\<rbrace> do_machine_op (do_flush typ start end pstart)
-    \<lbrace>\<lambda>rv. globals_equiv st\<rbrace>"
-  apply (cases "typ")
-     apply (wp dmo_cacheRangeOp_lift | simp add: do_flush_def cache_machine_op_defs do_flush_defs do_machine_op_bind when_def | clarsimp | rule conjI)+
-     done
-
-lemma perform_page_directory_invocation_globals_equiv:
-  "\<lbrace>globals_equiv st\<rbrace>
-  perform_page_directory_invocation pdi \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding perform_page_directory_invocation_def
-  apply (cases pdi)
-   apply (wp do_flush_globals_equiv | simp)+
-   done
-
-lemma flush_page_globals_equiv[wp]:
-  "\<lbrace>globals_equiv st\<rbrace> flush_page page_size pd asid vptr \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding flush_page_def invalidateLocalTLB_VAASID_def
-  apply(wp | simp cong: if_cong split del: if_split)+
-  done
-
-lemma flush_page_arm_global_pd[wp]:
-  "\<lbrace>\<lambda>s. P (arm_global_pd (arch_state s))\<rbrace>
-     flush_page pgsz pd asid vptr
-   \<lbrace>\<lambda>rv s. P (arm_global_pd (arch_state s))\<rbrace>"
-  unfolding flush_page_def
-  apply(wp | simp cong: if_cong split del: if_split)+
-  done
-
-lemma mapM_swp_store_pte_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm\<rbrace>
-    mapM (swp store_pte A) slots \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply(rule_tac Q="\<lambda> _. globals_equiv st and valid_ko_at_arm"
-        in hoare_strengthen_post)
-   apply(wp mapM_wp' store_pte_globals_equiv | simp)+
-   done
-
-lemma mapM_swp_store_pde_globals_equiv:
-  "\<lbrace>globals_equiv st and (\<lambda>s. \<forall>x \<in> set slots.
-   x && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s))\<rbrace>
-     mapM (swp store_pde A) slots \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (rule_tac Q="\<lambda> _. globals_equiv st and (\<lambda> s. \<forall>x \<in> set slots.
-                      x && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s))"
-         in hoare_strengthen_post)
-   apply (wp mapM_wp' store_pde_globals_equiv | simp)+
-   done
-
-lemma mapM_swp_store_pte_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm\<rbrace> mapM (swp store_pte A) slots \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  apply(wp mapM_wp' store_pte_valid_ko_at_arm | simp)+
-  done
-
-lemma mapM_x_swp_store_pde_globals_equiv :
-  "\<lbrace>globals_equiv st and (\<lambda>s. \<forall>x \<in> set slots.
-   x && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s))\<rbrace>
-     mapM_x (swp store_pde A) slots \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (rule_tac Q="\<lambda>_. globals_equiv st and (\<lambda> s. \<forall>x \<in> set slots.
-                     x && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s))"
-         in hoare_strengthen_post)
-   apply (wp mapM_x_wp' store_pde_globals_equiv | simp)+
-   done
-
-crunch valid_ko_at_arm[wp]: flush_page "valid_ko_at_arm"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma unmap_page_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_arch_state and pspace_aligned and valid_vspace_objs
-  and valid_global_objs and valid_vs_lookup and valid_global_refs \<rbrace> unmap_page pgsz asid vptr pptr
-   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding unmap_page_def cleanCacheRange_PoU_def including no_pre
-  apply (induct pgsz)
-     prefer 4
-     apply (simp only: vmpage_size.simps)
-     apply(wp mapM_swp_store_pde_globals_equiv dmo_cacheRangeOp_lift | simp add: cleanByVA_PoU_def)+
-        apply(rule hoare_drop_imps)
-        apply(wp)+
-       apply(simp)
-       apply(rule hoare_drop_imps)
-       apply(wp)+
-     apply (rule hoare_pre)
-      apply (rule_tac Q="\<lambda>x. globals_equiv st and (\<lambda>sa. lookup_pd_slot x vptr && mask 6 = 0 \<longrightarrow> (\<forall>xa\<in>set [0 , 4 .e. 0x3C]. xa + lookup_pd_slot x vptr && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state sa)))" and E="\<lambda>_. globals_equiv st" in hoare_post_impErr)
-        apply(wp find_pd_for_asid_not_arm_global_pd_large_page)
-       apply simp
-      apply simp
-     apply simp
-    apply(wp store_pte_globals_equiv | simp add: cleanByVA_PoU_def)+
-      apply(wp hoare_drop_imps)+
-     apply(wp (once) lookup_pt_slot_inv)
-     apply(wp (once) lookup_pt_slot_inv)
-     apply(wp (once) lookup_pt_slot_inv)
-     apply(wp (once) lookup_pt_slot_inv)
-    apply(simp)
-    apply(rule hoare_pre)
-     apply wp
-    apply(simp add: valid_arch_state_ko_at_arm)
-   apply(simp)
-   apply(rule hoare_pre)
-    apply(wp dmo_cacheRangeOp_lift mapM_swp_store_pde_globals_equiv store_pde_globals_equiv lookup_pt_slot_inv mapM_swp_store_pte_globals_equiv hoare_drop_imps | simp add: cleanByVA_PoU_def)+
-   apply(simp add: valid_arch_state_ko_at_arm)
-  apply(rule hoare_pre)
-   apply(wp store_pde_globals_equiv | simp add: valid_arch_state_ko_at_arm cleanByVA_PoU_def)+
-    apply(wp find_pd_for_asid_not_arm_global_pd hoare_drop_imps)+
-  apply(clarsimp)
-  done (* don't know what happened here. wp deleted globals_equiv from precon *)
-
-
-lemma cte_wp_parent_not_global_pd: "valid_global_refs s \<Longrightarrow> cte_wp_at (parent_for_refs (Inr (a,b))) k s \<Longrightarrow> \<forall>x \<in> set b. x && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s)"
-  apply (simp only: cte_wp_at_caps_of_state)
-  apply (elim exE conjE)
-  apply (drule valid_global_refsD2,simp)
-  apply (unfold parent_for_refs_def)
-  apply (simp add: image_def global_refs_def cap_range_def)
-  apply clarsimp
-  apply (subgoal_tac "arm_global_pd (arch_state s) \<in> set b")
-   apply auto
-  done
-
-definition authorised_for_globals_page_inv :: "page_invocation \<Rightarrow> 'z::state_ext state \<Rightarrow> bool"
-  where "authorised_for_globals_page_inv pgi \<equiv>
-    \<lambda>s. case pgi of PageMap asid cap ptr m \<Rightarrow> \<exists>slot. cte_wp_at (parent_for_refs m) slot s | _ \<Rightarrow> True"
-
-lemma set_cap_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm\<rbrace> set_cap cap p \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  apply(simp add: valid_ko_at_arm_def)
-  apply(rule hoare_ex_wp)
-  apply(rule hoare_pre)
-   apply(simp add: set_cap_def split_def)
-   apply(wp | wpc)+
-     apply(simp add: set_object_def)
-     apply(wp get_object_wp | wpc)+
-  apply(fastforce simp: obj_at_def)
-  done
-
-crunch valid_ko_at_arm[wp]: unmap_page "valid_ko_at_arm"
-  (wp: crunch_wps)
-
-lemma as_user_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm and (\<lambda>s. tptr \<noteq> idle_thread s)\<rbrace> as_user tptr f
-    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding as_user_def
-  apply(wp)
-      apply(simp add: split_def)
-      apply(wp set_object_globals_equiv)+
-  apply(clarsimp simp: valid_ko_at_arm_def get_tcb_def obj_at_def)
-  done
-
-
-lemma set_message_info_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace> set_message_info thread info \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_message_info_def
-  apply(wp as_user_globals_equiv)
   done
 
 lemma store_word_offs_globals_equiv:
-  "\<lbrace>globals_equiv s\<rbrace>
-    store_word_offs ptr offs v
-    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  "store_word_offs ptr offs v \<lbrace>globals_equiv s\<rbrace>"
   unfolding store_word_offs_def fun_app_def
   apply (wp do_machine_op_globals_equiv)
-    apply clarsimp
-    apply (erule use_valid[OF _ storeWord_globals_equiv])
-    apply (wp | simp | force)+
+     apply clarsimp
+     apply (erule use_valid[OF _ storeWord_globals_equiv])
+     apply (wp | simp | force)+
   done
-
-
-lemma length_msg_registers:
-  "length msg_registers = 4"
-  unfolding msg_registers_def
-  by (simp add: msgRegisters_def upto_enum_def fromEnum_def enum_register)
-
-lemma length_msg_lt_msg_max:
-  "length msg_registers < msg_max_length"
-  apply(simp add: length_msg_registers msg_max_length_def)
-  done
-
-
-lemma arm_global_pd_not_tcb:
-  "valid_ko_at_arm s \<Longrightarrow> get_tcb (arm_global_pd (arch_state s)) s = None"
-  unfolding valid_ko_at_arm_def
-  apply (case_tac "get_tcb (arm_global_pd (arch_state s)) s")
-  apply simp
-  apply(clarsimp simp: valid_ko_at_arm_def get_tcb_ko_at obj_at_def)
-  done
-
-
-lemma set_mrs_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm and (\<lambda>sa. thread \<noteq> idle_thread sa)\<rbrace>
-      set_mrs thread buf msgs
-    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_mrs_def
-  apply(wp | wpc)+
-       apply(simp add: zipWithM_x_mapM_x)
-       apply(rule conjI)
-        apply(rule impI)
-        apply(rule_tac Q="\<lambda>_. globals_equiv s"
-          in hoare_strengthen_post)
-         apply(wp mapM_x_wp')
-         apply(simp add: split_def)
-         apply(wp store_word_offs_globals_equiv)
-        apply(simp)
-       apply(clarsimp)
-       apply(insert length_msg_lt_msg_max)
-       apply(simp)
-      apply(wp set_object_globals_equiv static_imp_wp)
-     apply(wp hoare_vcg_all_lift set_object_globals_equiv static_imp_wp)+
-   apply(clarsimp simp:arm_global_pd_not_tcb)+
-  done
-
-crunch valid_ko_at_arm[wp]: set_mrs valid_ko_at_arm
-  (wp: crunch_wps simp: crunch_simps arm_global_pd_not_tcb)
-
-lemma perform_page_invocation_globals_equiv:
-  "\<lbrace>authorised_for_globals_page_inv pgi and valid_page_inv pgi and globals_equiv st
-    and valid_arch_state and pspace_aligned and valid_vspace_objs and valid_global_objs
-    and valid_vs_lookup and valid_global_refs and ct_active and valid_idle\<rbrace>
-   perform_page_invocation pgi
-   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding perform_page_invocation_def cleanCacheRange_PoU_def
-  apply(rule hoare_weaken_pre)
-  apply(wp mapM_swp_store_pte_globals_equiv hoare_vcg_all_lift dmo_cacheRangeOp_lift
-        mapM_swp_store_pde_globals_equiv mapM_x_swp_store_pte_globals_equiv
-        mapM_x_swp_store_pde_globals_equiv set_cap_globals_equiv''
-        unmap_page_globals_equiv store_pte_globals_equiv store_pde_globals_equiv static_imp_wp
-        do_flush_globals_equiv set_mrs_globals_equiv set_message_info_globals_equiv
-       | wpc | simp add: do_machine_op_bind cleanByVA_PoU_def)+
-  by (auto simp: cte_wp_parent_not_global_pd authorised_for_globals_page_inv_def
-                   valid_page_inv_def valid_slots_def valid_idle_def st_tcb_def2 ct_in_state_def
-                   pred_tcb_at_def obj_at_def
-           dest: valid_arch_state_ko_at_arm
-           dest!:rev_subsetD[OF _ tl_subseteq])
-
-lemma retype_region_ASIDPoolObj_globals_equiv:
-  "\<lbrace>globals_equiv s and (\<lambda>sa. ptr \<noteq> arm_global_pd (arch_state s)) and (\<lambda>sa. ptr \<noteq> idle_thread sa)\<rbrace>
-  retype_region ptr 1 0 (ArchObject ASIDPoolObj) dev
-  \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding retype_region_def
-  apply(wp modify_wp dxo_wp_weak | simp | fastforce simp: globals_equiv_def default_arch_object_def obj_bits_api_def)+
-      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-     apply wp+
-  apply (fastforce simp: globals_equiv_def idle_equiv_def tcb_at_def2)
-  done
-
-crunch valid_ko_at_arm[wp]: "set_untyped_cap_as_full" "valid_ko_at_arm"
-
-lemma cap_insert_globals_equiv'':
-  "\<lbrace>globals_equiv s and valid_global_objs and valid_ko_at_arm\<rbrace>
-  cap_insert new_cap src_slot dest_slot \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding  cap_insert_def
-  apply(wp set_original_globals_equiv update_cdt_globals_equiv set_cap_globals_equiv'' dxo_wp_weak
-         | rule hoare_drop_imps | simp)+
-  done
-
-
-
-lemma retype_region_ASIDPoolObj_valid_ko_at_arm:
-  "\<lbrace>valid_ko_at_arm and (\<lambda>s. ptr \<noteq> arm_global_pd (arch_state s))\<rbrace>
-  retype_region ptr 1 0 (ArchObject ASIDPoolObj) dev
-  \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  apply(simp add: retype_region_def)
-  apply(wp modify_wp dxo_wp_weak |simp add: trans_state_update[symmetric] del: trans_state_update)+
-  apply(clarsimp simp: valid_ko_at_arm_def)
-  apply(rule_tac x=pd in exI)
-  apply(fold fun_upd_def)
-  apply(clarsimp simp: fun_upd_def obj_at_def)
-  done
-
-lemma detype_valid_ko_at_arm:
-  "\<lbrace>valid_ko_at_arm and (\<lambda>s.
-      arm_global_pd (arch_state s) \<notin> {ptr..ptr + 2 ^ bits - 1})\<rbrace>
-   modify (detype {ptr..ptr + 2 ^ bits - 1}) \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  apply(wp modify_wp)
-  apply(fastforce simp: valid_ko_at_arm_def detype_def obj_at_def)
-  done
-
-lemma detype_valid_arch_state:
-  "\<lbrace>valid_arch_state and
-    (\<lambda>s. arm_globals_frame (arch_state s) \<notin> {ptr..ptr + 2 ^ bits - 1} \<and>
-         arm_global_pd (arch_state s) \<notin> {ptr..ptr + 2 ^ bits - 1} \<and>
-    {ptr..ptr + 2 ^ bits - 1} \<inter> ran (arm_asid_table (arch_state s)) = {} \<and>
-    {ptr..ptr + 2 ^ bits - 1} \<inter> set (arm_global_pts (arch_state s)) = {})\<rbrace>
-   modify (detype {ptr..ptr + (1 << bits) - 1}) \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  apply(wp modify_wp)
-  apply(simp add: valid_arch_state_def)
-  apply(rule conjI)
-   apply(clarsimp simp: valid_asid_table_def)
-   apply(erule_tac x=p in in_empty_interE)
-    apply(simp)+
-  apply(clarsimp simp: valid_global_pts_def)
-  apply(erule_tac x=p and B="set (arm_global_pts (arch_state s))" in in_empty_interE)
-   apply(simp)+
-   done
-
-
-lemma delete_objects_valid_ko_at_arm:
-   "\<lbrace>valid_ko_at_arm and
-   (\<lambda>s. arm_global_pd (arch_state s) \<notin> ptr_range p b) and
-    K (is_aligned p b \<and>
-        2 \<le> b \<and>
-        b < word_bits)\<rbrace>
-  delete_objects p b \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  apply(rule hoare_gen_asm)
-  unfolding delete_objects_def
-  apply(wp detype_valid_ko_at_arm do_machine_op_valid_ko_at_arm | simp add: ptr_range_def)+
-  done
-
-lemma perform_asid_control_invocation_globals_equiv:
-  notes delete_objects_invs[wp del]
-  notes blah[simp del] =  atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
-  shows
-  "\<lbrace>globals_equiv s and invs and ct_active and valid_aci aci\<rbrace>
-   perform_asid_control_invocation aci \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding perform_asid_control_invocation_def
-  apply(rule hoare_pre)
-   apply wpc
-   apply (rename_tac word1 cslot_ptr1 cslot_ptr2 word2)
-   apply (wp modify_wp cap_insert_globals_equiv''
-             retype_region_ASIDPoolObj_globals_equiv[simplified]
-             retype_region_invs_extras(5)[where sz=pageBits]
-             retype_region_ASIDPoolObj_valid_ko_at_arm[simplified]
-             set_cap_globals_equiv
-             max_index_upd_invs_simple set_cap_no_overlap
-             set_cap_caps_no_overlap max_index_upd_caps_overlap_reserved
-             region_in_kernel_window_preserved
-             hoare_vcg_all_lift  get_cap_wp static_imp_wp
-             set_cap_idx_up_aligned_area[where dev = False,simplified]
-         | simp)+
-   (* factor out the implication -- we know what the relevant components of the
-      cap referred to in the cte_wp_at are anyway from valid_aci, so just use
-      those directly to simplify the reasoning later on *)
-   apply(rule_tac Q="\<lambda> a b. globals_equiv s b \<and>
-                            invs b \<and> valid_ko_at_arm b \<and> word1 \<noteq> arm_global_pd (arch_state b) \<and>
-                            word1 \<noteq> idle_thread b \<and>
-                            (\<exists> idx. cte_wp_at ((=) (UntypedCap False word1 pageBits idx)) cslot_ptr2 b) \<and>
-                             descendants_of cslot_ptr2 (cdt b) = {} \<and>
-                             pspace_no_overlap_range_cover word1 pageBits b"
-         in hoare_strengthen_post)
-    prefer 2
-    apply (clarsimp simp: globals_equiv_def invs_valid_global_objs)
-    apply (drule cte_wp_at_eqD2, assumption)
-    apply clarsimp
-    apply (clarsimp simp: empty_descendants_range_in)
-    apply (rule conjI, fastforce simp: cte_wp_at_def)
-    apply (clarsimp simp: obj_bits_api_def default_arch_object_def)
-    apply (frule untyped_cap_aligned, simp add: invs_valid_objs)
-    apply (clarsimp simp: cte_wp_at_caps_of_state)
-    apply (strengthen refl caps_region_kernel_window_imp[mk_strg I E])
-    apply (simp add: invs_valid_objs invs_cap_refs_in_kernel_window
-                     atLeastatMost_subset_iff word_and_le2)
-    apply(rule conjI, rule descendants_range_caps_no_overlapI)
-       apply assumption
-      apply(simp add: cte_wp_at_caps_of_state)
-     apply(simp add: empty_descendants_range_in)
-    apply(clarsimp simp: range_cover_def)
-    apply(subst is_aligned_neg_mask_eq[THEN sym], assumption)
-    apply(simp add: word_bw_assocs pageBits_def mask_zero)
-   apply(wp add: delete_objects_invs_ex delete_objects_pspace_no_overlap[where dev=False]
-            delete_objects_globals_equiv delete_objects_valid_ko_at_arm
-            hoare_vcg_ex_lift
-            del: Untyped_AI.delete_objects_pspace_no_overlap
-        | simp add: page_bits_def)+
-  apply (clarsimp simp: conj_comms invs_valid_ko_at_arm invs_psp_aligned invs_valid_objs valid_aci_def)
-  apply (clarsimp simp: cte_wp_at_caps_of_state)
-  apply (frule_tac cap="UntypedCap False a b c" for a b c  in caps_of_state_valid, assumption)
-  apply (clarsimp simp: valid_cap_def cap_aligned_def untyped_min_bits_def)
-  apply (frule_tac slot="(aa,ba)" in untyped_caps_do_not_overlap_global_refs[rotated, OF invs_valid_global_refs])
-   apply (clarsimp simp: cte_wp_at_caps_of_state)
-   apply ((rule conjI |rule refl | simp)+)[1]
-  apply(rule conjI)
-   apply(clarsimp simp: global_refs_def ptr_range_memI)
-  apply(rule conjI)
-   apply(clarsimp simp: global_refs_def ptr_range_memI)
-  apply(rule conjI, fastforce simp: global_refs_def)
-  apply(rule conjI, fastforce simp: global_refs_def)
-  apply(rule conjI)
-   apply(drule untyped_slots_not_in_untyped_range)
-        apply(blast intro!: empty_descendants_range_in)
-       apply(simp add: cte_wp_at_caps_of_state)
-      apply simp
-     apply(rule refl)
-    apply(rule subset_refl)
-   apply(simp)
-  apply(rule conjI)
-   apply fastforce
-  apply (auto intro: empty_descendants_range_in simp: descendants_range_def2 cap_range_def)
-  done
-
-
-lemma perform_asid_pool_invocation_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm\<rbrace> perform_asid_pool_invocation api \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding perform_asid_pool_invocation_def
-  apply(rule hoare_weaken_pre)
-   apply(wp modify_wp set_asid_pool_globals_equiv set_cap_globals_equiv''
-        get_cap_wp | wpc | simp)+
-  done
-
-definition
-  authorised_for_globals_arch_inv :: "arch_invocation \<Rightarrow> ('z::state_ext) state \<Rightarrow> bool" where
-  "authorised_for_globals_arch_inv ai \<equiv> case ai of
-  InvokePageTable oper \<Rightarrow> authorised_for_globals_page_table_inv oper |
-  InvokePage oper \<Rightarrow> authorised_for_globals_page_inv oper |
-  _ \<Rightarrow> \<top>"
-
-lemma arch_perform_invocation_globals_equiv:
-  "\<lbrace>globals_equiv s and invs and ct_active and valid_arch_inv ai and authorised_for_globals_arch_inv ai\<rbrace>
-  arch_perform_invocation ai \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding arch_perform_invocation_def
-  apply wp
-   apply(wpc)
-       apply(wp perform_page_table_invocation_globals_equiv perform_page_directory_invocation_globals_equiv
-                perform_page_invocation_globals_equiv perform_asid_control_invocation_globals_equiv
-                perform_asid_pool_invocation_globals_equiv)+
-  apply(auto simp: authorised_for_globals_arch_inv_def
-             dest: valid_arch_state_ko_at_arm
-             simp: invs_def valid_state_def valid_arch_inv_def invs_valid_vs_lookup)
-  done
-
-lemma find_pd_for_asid_authority3:
-  "\<lbrace>\<lambda>s. \<forall>pd. (pspace_aligned s \<and> valid_vspace_objs s \<longrightarrow> is_aligned pd pd_bits)
-           \<and> (\<exists>\<rhd> pd) s
-           \<longrightarrow> Q pd s\<rbrace> find_pd_for_asid asid \<lbrace>Q\<rbrace>, -"
-  (is "\<lbrace>?P\<rbrace> ?f \<lbrace>Q\<rbrace>,-")
-  apply (clarsimp simp: validE_R_def validE_def valid_def imp_conjL[symmetric])
-  apply (frule in_inv_by_hoareD[OF find_pd_for_asid_inv], clarsimp)
-  apply (drule spec, erule mp)
-  apply (simp add: use_validE_R[OF _ find_pd_for_asid_authority1]
-                   use_validE_R[OF _ find_pd_for_asid_aligned_pd_bits]
-                   use_validE_R[OF _ find_pd_for_asid_lookup])
-  done
-
-lemma decode_arch_invocation_authorised_for_globals:
-  "\<lbrace>invs and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot
-        and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)\<rbrace>
-  arch_decode_invocation label msg x_slot slot cap excaps
-  \<lbrace>\<lambda>rv. authorised_for_globals_arch_inv rv\<rbrace>, -"
-  unfolding arch_decode_invocation_def authorised_for_globals_arch_inv_def
-  apply (rule hoare_pre)
-   apply (simp add: split_def Let_def
-               cong: cap.case_cong arch_cap.case_cong if_cong option.case_cong
-               split del: if_split)
-   apply (wp select_wp select_ext_weak_wp whenE_throwError_wp check_vp_wpR unlessE_wp get_pde_wp get_master_pde_wp
-             find_pd_for_asid_authority3 create_mapping_entries_parent_for_refs
-           | wpc
-           | simp add:  authorised_for_globals_page_inv_def
-                  del: hoare_True_E_R
-                  split del: if_split)+
-     apply(simp cong: if_cong)
-     apply(wp hoare_vcg_if_lift2)
-     apply(rule hoare_conjI)
-      apply(rule hoare_drop_imps)
-      apply(simp add: authorised_for_globals_page_table_inv_def)
-      apply(wp)
-     apply(rule hoare_drop_imps)
-     apply((wp hoare_TrueI hoare_vcg_all_lift hoare_drop_imps | wpc | simp)+)[3]
-  apply (clarsimp simp: authorised_asid_pool_inv_def authorised_page_table_inv_def
-                        neq_Nil_conv invs_psp_aligned invs_vspace_objs cli_no_irqs)
-  apply (drule cte_wp_valid_cap, clarsimp+)
-  apply (cases cap, simp_all)
-    \<comment> \<open>PageCap\<close>
-    apply (clarsimp simp: valid_cap_simps cli_no_irqs)
-    apply (cases "invocation_type label";(rename_tac arch, case_tac arch; simp add: isPageFlushLabel_def isPDFlushLabel_def))
-           \<comment> \<open>Map\<close>
-           apply (rename_tac word cap_rights vmpage_size option arch)
-           apply(clarsimp simp: isPageFlushLabel_def isPDFlushLabel_def | rule conjI)+
-            apply(drule cte_wp_valid_cap)
-             apply(clarsimp simp: invs_def valid_state_def)
-            apply(simp add: valid_cap_def)
-           apply(simp add: vmsz_aligned_def)
-           apply(drule_tac ptr="msg ! 0" and off="2 ^ pageBitsForSize vmpage_size - 1" in is_aligned_no_wrap')
-            apply(insert pbfs_less_wb')
-            apply(clarsimp)
-           apply(fastforce simp: x_power_minus_1)
-          apply(clarsimp)
-          apply(fastforce dest: cte_wp_valid_cap simp: invs_def valid_state_def valid_cap_def)
-         \<comment> \<open>Unmap\<close>
-         apply(simp add: authorised_for_globals_page_inv_def)+
-   apply(clarsimp)
-   \<comment> \<open>PageTableCap\<close>
-   apply(simp add: authorised_for_globals_page_table_inv_def)
-   apply(clarsimp)
-   apply(frule_tac vptr="msg ! 0" in pd_shifting')
-   apply(clarsimp)
-   apply(clarsimp simp: invs_def valid_state_def valid_global_refs_def valid_refs_def global_refs_def)
-   apply(erule_tac x=aa in allE)
-   apply(erule_tac x=b in allE)
-   apply(drule_tac P'="\<lambda>c. idle_thread s \<in> cap_range c \<or>
-                 arm_global_pd (arch_state s) \<in> cap_range c \<or>
-                 (range (interrupt_irq_node s) \<union>
-                  set (arm_global_pts (arch_state s))) \<inter>
-                 cap_range c \<noteq>
-                 {}" in cte_wp_at_weakenE)
-    apply(clarsimp simp: cap_range_def)
-   apply(simp)
-  by(fastforce)
-
-
-lemma as_user_valid_ko_at_arm[wp]:
-  "\<lbrace> valid_ko_at_arm \<rbrace>
-  as_user thread f
-  \<lbrace> \<lambda>_. valid_ko_at_arm\<rbrace>"
-  unfolding as_user_def
-  apply wp
-     apply (case_tac x)
-     apply (simp | wp select_wp)+
-  apply(fastforce simp: valid_ko_at_arm_def get_tcb_ko_at obj_at_def)
-  done
-
-lemma valid_arch_arm_asid_table_unmap:
-  "valid_arch_state s
-       \<and> tab = arm_asid_table (arch_state s)
-     \<longrightarrow> valid_arch_state (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := tab(asid_high_bits_of base := None)\<rparr>\<rparr>)"
-  apply (clarsimp simp: valid_state_def valid_arch_state_unmap_strg)
-  done
-
-lemma valid_arch_objs_arm_asid_table_unmap:
-  "valid_vspace_objs s
-       \<and> tab = arm_asid_table (arch_state s)
-     \<longrightarrow> valid_vspace_objs (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := tab(asid_high_bits_of base := None)\<rparr>\<rparr>)"
-  apply (clarsimp simp: valid_state_def valid_vspace_objs_unmap_strg)
-  done
-
-lemma valid_vspace_objs_arm_asid_table_unmap:
-  "valid_vspace_objs s
-       \<and> tab = arm_asid_table (arch_state s)
-     \<longrightarrow> valid_vspace_objs (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := tab(asid_high_bits_of base := None)\<rparr>\<rparr>)"
-  apply (clarsimp simp: valid_state_def valid_vspace_objs_unmap_strg)
-  done
-
-lemmas arm_context_switch_valid_vspace_objs_aux =
-  hoare_drop_imp[of valid_vspace_objs "arm_context_switch _ _" "\<lambda>_ s. valid_vspace_objs s"
-                , OF arm_context_switch_vspace_objs]
-
-lemma delete_asid_pool_valid_arch_obsj[wp]:
-  "\<lbrace>valid_vspace_objs\<rbrace>
-    delete_asid_pool base pptr
-  \<lbrace>\<lambda>_. valid_vspace_objs\<rbrace>"
-  unfolding delete_asid_pool_def
-  apply (wp modify_wp)
-      apply (strengthen valid_vspace_objs_arm_asid_table_unmap)
-      apply (wpsimp wp: mapM_wp')+
-  done
-
-lemma delete_asid_pool_valid_vspace_objs[wp]:
-  "\<lbrace>valid_vspace_objs\<rbrace>
-    delete_asid_pool base pptr
-  \<lbrace>\<lambda>_. valid_vspace_objs\<rbrace>"
-  unfolding delete_asid_pool_def
-  apply (wp modify_wp)
-      apply (strengthen valid_vspace_objs_arm_asid_table_unmap)
-      apply (wpsimp wp: mapM_wp')+
-  done
-
-crunch valid_vspace_objs[wp]: cap_swap_for_delete "valid_vspace_objs"
-
-lemma set_asid_pool_arch_objs_unmap'':
- "\<lbrace>(valid_vspace_objs and ko_at (ArchObj (ASIDPool ap)) p) and K(f = (ap |` S))\<rbrace> set_asid_pool p f \<lbrace>\<lambda>_. valid_vspace_objs\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply simp
-  apply (rule set_asid_pool_vspace_objs_unmap)
-  done
-
-lemmas set_asid_pool_vspace_objs_unmap'' = set_asid_pool_arch_objs_unmap''
-
 
 lemma restrict_eq_asn_none: "f(N := None) = f |` {s. s \<noteq> N}" by auto
 
-lemma delete_asid_valid_arch_objs[wp]:
-  "\<lbrace>valid_vspace_objs and pspace_aligned\<rbrace> delete_asid a b \<lbrace>\<lambda>_. valid_vspace_objs\<rbrace>"
-  unfolding delete_asid_def
-  apply (wpsimp wp: set_asid_pool_arch_objs_unmap'')
-  apply (fastforce simp: restrict_eq_asn_none)
-  done
-
-lemma delete_asid_valid_vspace_objs[wp]:
-  "\<lbrace>valid_vspace_objs and pspace_aligned\<rbrace> delete_asid a b \<lbrace>\<lambda>_. valid_vspace_objs\<rbrace>"
-  unfolding delete_asid_def
-  apply (wpsimp wp: set_asid_pool_vspace_objs_unmap'')
-  apply (fastforce simp: restrict_eq_asn_none)
-  done
-
-lemma store_pte_valid_vspace_objs[wp]:
-  "\<lbrace>valid_vspace_objs and valid_pte pte\<rbrace>
-    store_pte p pte
-  \<lbrace>\<lambda>_. (valid_vspace_objs)\<rbrace>"
-  unfolding store_pte_def
-  apply wp
-  apply clarsimp
-  apply (unfold valid_vspace_objs_def)
-  apply (erule_tac x="p && ~~ mask pt_bits" in allE)
-  apply auto
-done
-
-declare get_cap_global_refs[wp]
-
-crunch valid_global_refs[wp]: cap_swap_for_delete "valid_global_refs"
-  (wp: set_cap_globals dxo_wp_weak
-   simp: crunch_simps
-   ignore: set_object cap_swap_ext)
-
-crunch valid_global_refs[wp]: empty_slot "valid_global_refs"
-  (wp: hoare_drop_imps set_cap_globals dxo_wp_weak
-   simp: cap_range_def
-   ignore: set_object empty_slot_ext)
+crunches cap_swap_for_delete
+  for valid_vspace_objs[wp]: valid_vspace_objs
+  and valid_global_refs[wp]: valid_global_refs
+  (simp: crunch_simps)
 
 lemma thread_set_fault_valid_global_refs[wp]:
-  "\<lbrace>valid_global_refs\<rbrace> thread_set (tcb_fault_update A) thread \<lbrace>\<lambda>_. valid_global_refs\<rbrace>"
+  "thread_set (tcb_fault_update A) thread \<lbrace>valid_global_refs\<rbrace>"
   apply (wp thread_set_global_refs_triv thread_set_refs_trivial thread_set_obj_at_impossible | simp)+
   apply (rule ball_tcb_cap_casesI, simp+)
   done
 
-
 lemma cap_swap_for_delete_valid_arch_caps[wp]:
-  "\<lbrace>valid_arch_caps\<rbrace> cap_swap_for_delete a b \<lbrace>\<lambda>_. valid_arch_caps\<rbrace>"
+  "cap_swap_for_delete a b \<lbrace>valid_arch_caps\<rbrace>"
   unfolding cap_swap_for_delete_def
   apply (wp get_cap_wp)
   apply (clarsimp simp: cte_wp_at_weakenE)
   done
 
-lemma mapM_x_swp_store_pte_reads_respects':
-  "reads_respects aag l (invs and (cte_wp_at ((=) (ArchObjectCap (PageTableCap word option))) slot) and K (is_subject aag word))
-                        (mapM_x (swp store_pte InvalidPTE) [word , word + 4 .e. word + 2 ^ pt_bits - 1])"
-  apply (rule gen_asm_ev)
-  apply (wp mapM_x_ev)
-   apply simp
-   apply (rule equiv_valid_guard_imp)
-    apply (wp store_pte_reads_respects)
-   apply simp
-   apply (elim conjE)
-   apply (subgoal_tac "is_aligned word pt_bits")
-    apply (frule (1) word_aligned_pt_slots)
-    apply simp
-   apply (frule cte_wp_valid_cap)
-    apply (rule invs_valid_objs)
-    apply simp
-   apply (simp add: valid_cap_def cap_aligned_def pt_bits_def pageBits_def)
-  apply simp
-  apply wp
-   apply simp
-  apply (fastforce simp: is_cap_simps dest!: cte_wp_at_pt_exists_cap[OF invs_valid_objs])
+(* this to go in InfloFlowBase? *)
+lemma get_object_revrv:
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag \<top>\<top> \<top> (get_object ptr)"
+  unfolding get_object_def
+  apply (rule equiv_valid_rv_bind)
+    apply (rule equiv_valid_rv_guard_imp)
+     apply (rule gets_kheap_revrv')
+    apply (simp, simp)
+   apply (rule equiv_valid_2_bind)
+      apply (rule return_ev2)
+      apply (simp)
+     apply (rule assert_ev2)
+     apply (simp)
+    apply (wpsimp)+
   done
 
-lemma mapM_x_swp_store_pde_reads_respects':
-  "reads_respects aag l (cte_wp_at ((=) (ArchObjectCap (PageDirectoryCap word option))) slot and valid_objs and K(is_subject aag word))
-             (mapM_x (swp store_pde InvalidPDE)
-               (map ((\<lambda>x. x + word) \<circ> swp (<<) 2) [0.e.(kernel_base >> 20) - 1]))"
-  apply (wp mapM_x_ev)
-   apply simp
-   apply (rule equiv_valid_guard_imp)
-    apply (wp store_pde_reads_respects)
-   apply clarsimp
-   apply (subgoal_tac "is_aligned word pd_bits")
-    apply (simp add: pd_bits_store_pde_helper)
-   apply (frule (1) cte_wp_valid_cap)
-   apply (simp add: valid_cap_def cap_aligned_def pd_bits_def pageBits_def)
-  apply simp
-  apply wp
-    apply (clarsimp simp: wellformed_pde_def)+
+lemma get_object_revrv':
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
+   (\<lambda>rv rv'. aag_can_read aag ptr \<longrightarrow> rv = rv')
+   \<top> (get_object ptr)"
+  unfolding get_object_def
+  apply (rule equiv_valid_rv_bind)
+    apply (rule equiv_valid_rv_guard_imp)
+     apply (rule gets_kheap_revrv)
+    apply (simp, simp)
+   apply (rule equiv_valid_2_bind)
+      apply (rule return_ev2)
+      apply (simp)
+     apply (rule assert_ev2)
+     apply (simp add: equiv_for_def)
+    apply (wpsimp)+
   done
 
-lemma mapM_x_swp_store_pte_pas_refined_simple:
-  "invariant  (mapM_x (swp store_pte InvalidPTE) A) (pas_refined aag)"
-  by (wpsimp wp: mapM_x_wp' store_pte_pas_refined_simple)
+crunch irq_state_of_state[wp]: cancel_badged_sends "\<lambda>s. P (irq_state_of_state s)"
+  (wp: crunch_wps simp: filterM_mapM)
 
-lemma mapM_x_swp_store_pde_pas_refined_simple:
-  "invariant (mapM_x (swp store_pde InvalidPDE) A) (pas_refined aag)"
-  by (wpsimp wp: mapM_x_wp' store_pde_pas_refined_simple)
+
+locale Arch_IF_1 =
+  fixes valid_ko_at_arch :: "det_state \<Rightarrow> bool"
+  and aag :: "'a PAS"
+  assumes arch_post_cap_deletion_valid_global_refs:
+    "arch_post_cap_deletion acap \<lbrace>\<lambda>s :: det_state. valid_global_refs s\<rbrace>"
+  and arch_post_cap_deletion_irq_state_of_state[wp]:
+    "arch_post_cap_deletion acap \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and store_word_offs_irq_state_of_state[wp]:
+    "store_word_offs ptr offs v \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and set_irq_state_irq_state_of_state[wp]:
+    "set_irq_state state irq \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and handle_arch_fault_reply_irq_state_of_state[wp]:
+    "handle_arch_fault_reply vmf thread x y \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and arch_switch_to_idle_thread_irq_state_of_state[wp]:
+    "arch_switch_to_idle_thread \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and arch_switch_to_thread_irq_state_of_state[wp]:
+    "arch_switch_to_thread t \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and arch_invoke_irq_handler_irq_state_of_state[wp]:
+    "arch_invoke_irq_handler hi \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and arch_finalise_cap_irq_state_of_state[wp]:
+    "arch_finalise_cap acap b \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and prepare_thread_delete_irq_state_of_state[wp]:
+    "prepare_thread_delete t \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and equiv_asid_machine_state_update[simp]:
+    "\<And>f. equiv_asid asid (machine_state_update f s) s' = equiv_asid asid s s'"
+    "\<And>f. equiv_asid asid s (machine_state_update f s') = equiv_asid asid s s'"
+  and as_user_set_register_reads_respects':
+    "pas_domains_distinct aag \<Longrightarrow> reads_respects aag l \<top> (as_user t (setRegister r v))"
+  and store_word_offs_reads_respects:
+    "reads_respects aag l \<top> (store_word_offs ptr offs v)"
+  and set_endpoint_globals_equiv:
+    "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+     set_endpoint ptr ep
+     \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  and set_cap_globals_equiv'':
+    "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+     set_cap cap p
+     \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  and set_thread_state_globals_equiv:
+    "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+     set_thread_state ref ts
+     \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  and as_user_globals_equiv:
+    "\<And>f :: unit user_monad.
+     \<lbrace>globals_equiv s and valid_ko_at_arch and (\<lambda>s. tptr \<noteq> idle_thread s)\<rbrace>
+     as_user tptr f
+     \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  and set_endpoint_valid_ko_at_arch[wp]:
+    "set_endpoint ptr ep \<lbrace>valid_ko_at_arch\<rbrace>"
+  and set_cap_valid_ko_at_arch[wp]:
+    "set_cap cap p \<lbrace>valid_ko_at_arch\<rbrace>"
+  and set_thread_state_valid_ko_at_arch[wp]:
+    "set_thread_state ref ts \<lbrace>valid_ko_at_arch\<rbrace>"
+  and valid_ko_at_arch_exst_update[simp]:
+    "\<And>f. valid_ko_at_arch (trans_state f s) = valid_ko_at_arch s"
+begin
+
+crunch valid_global_refs[wp]: empty_slot "\<lambda>s :: det_state. valid_global_refs s"
+  (simp: cap_range_def)
+
+crunches set_extra_badge, set_mrs, reply_from_kernel, invoke_domain
+  for irq_state_of_state[wp]: "\<lambda>s. P (irq_state_of_state s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma transfer_caps_loop_irq_state[wp]:
+  "transfer_caps_loop a b c d e f \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  by (wp transfer_caps_loop_pres)
+
+crunch irq_state_of_state[wp]: handle_recv, handle_reply "\<lambda>s. P (irq_state_of_state s)"
+  (wp: crunch_wps dmo_wp simp: crunch_simps)
+
+crunch irq_state_of_state[wp]: invoke_irq_handler "\<lambda>s. P (irq_state_of_state s)"
+
+crunch irq_state_of_state[wp]: schedule "\<lambda>s. P (irq_state_of_state s)"
+  (wp: dmo_wp modify_wp crunch_wps hoare_whenE_wp
+   simp: machine_op_lift_def machine_rest_lift_def crunch_simps)
+
+crunch irq_state_of_state[wp]: finalise_cap "\<lambda>s. P (irq_state_of_state s)"
+  (wp: select_wp modify_wp crunch_wps dmo_wp simp: crunch_simps)
+
+crunch irq_state_of_state[wp]: send_signal, restart "\<lambda>s. P (irq_state_of_state s)"
+
+lemma mol_states_equiv_for:
+  "machine_op_lift mop \<lbrace>\<lambda>ms. states_equiv_for P Q R S st (s\<lparr>machine_state := ms\<rparr>)\<rbrace>"
+  unfolding machine_op_lift_def
+  apply (simp add: machine_rest_lift_def split_def)
+  apply (wp modify_wp)
+  apply (clarsimp simp: states_equiv_for_def equiv_asids_def)
+  apply (fastforce elim!: equiv_forE intro!: equiv_forI)
+  done
+
+lemma do_machine_op_mol_states_equiv_for:
+  "do_machine_op (machine_op_lift f) \<lbrace>states_equiv_for P Q R S st\<rbrace>"
+  apply (simp add: do_machine_op_def)
+  apply (wp modify_wp | simp add: split_def)+
+  apply (clarify)
+  apply (erule use_valid)
+   apply simp
+   apply (rule mol_states_equiv_for)
+  by simp
+
+lemma set_message_info_reads_respects:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows "reads_respects aag l \<top> (set_message_info thread info)"
+  unfolding set_message_info_def fun_app_def
+  by (rule as_user_set_register_reads_respects'[OF domains_distinct])
+
+lemma set_mrs_reads_respects:
+  "reads_respects aag l (K (aag_can_read aag t \<or> aag_can_affect aag l t)) (set_mrs t buf msgs)"
+  apply (simp add: set_mrs_def cong: option.case_cong_weak)
+  apply (wp mapM_x_ev' store_word_offs_reads_respects set_object_reads_respects
+         | wpc | simp add: split_def split del: if_split add: zipWithM_x_mapM_x)+
+  apply (auto intro: reads_affects_equiv_get_tcb_eq)
+  done
+
+crunch valid_ko_at_arch[wp]: set_untyped_cap_as_full valid_ko_at_arch
+
+lemma cap_insert_globals_equiv'':
+  "\<lbrace>globals_equiv s and valid_global_objs and valid_ko_at_arch\<rbrace>
+   cap_insert new_cap src_slot dest_slot
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding cap_insert_def
+  by (wpsimp wp: set_original_globals_equiv update_cdt_globals_equiv
+                 set_cap_globals_equiv'' dxo_wp_weak hoare_drop_imps)
+
+lemma set_message_info_globals_equiv:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
+   set_message_info thread info
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding set_message_info_def by (wp as_user_globals_equiv)
+
+lemma cancel_badged_sends_globals_equiv:
+  "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+   cancel_badged_sends epptr badge
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace> "
+  unfolding cancel_badged_sends_def
+  by (wpsimp wp: set_endpoint_globals_equiv set_thread_state_globals_equiv
+                 filterM_preserved dxo_wp_weak hoare_drop_imps)
 
 end
 

--- a/proof/infoflow/Arch_IF.thy
+++ b/proof/infoflow/Arch_IF.thy
@@ -369,8 +369,7 @@ crunch irq_state_of_state[wp]: cancel_badged_sends "\<lambda>s. P (irq_state_of_
 
 
 locale Arch_IF_1 =
-  fixes valid_ko_at_arch :: "det_state \<Rightarrow> bool"
-  and aag :: "'a PAS"
+  fixes aag :: "'a PAS"
   assumes arch_post_cap_deletion_valid_global_refs:
     "arch_post_cap_deletion acap \<lbrace>\<lambda>s :: det_state. valid_global_refs s\<rbrace>"
   and arch_post_cap_deletion_irq_state_of_state[wp]:
@@ -399,30 +398,22 @@ locale Arch_IF_1 =
   and store_word_offs_reads_respects:
     "reads_respects aag l \<top> (store_word_offs ptr offs v)"
   and set_endpoint_globals_equiv:
-    "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+    "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
      set_endpoint ptr ep
      \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   and set_cap_globals_equiv'':
-    "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+    "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
      set_cap cap p
      \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   and set_thread_state_globals_equiv:
-    "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+    "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
      set_thread_state ref ts
      \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   and as_user_globals_equiv:
     "\<And>f :: unit user_monad.
-     \<lbrace>globals_equiv s and valid_ko_at_arch and (\<lambda>s. tptr \<noteq> idle_thread s)\<rbrace>
+     \<lbrace>globals_equiv s and valid_arch_state and (\<lambda>s. tptr \<noteq> idle_thread s)\<rbrace>
      as_user tptr f
      \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  and set_endpoint_valid_ko_at_arch[wp]:
-    "set_endpoint ptr ep \<lbrace>valid_ko_at_arch\<rbrace>"
-  and set_cap_valid_ko_at_arch[wp]:
-    "set_cap cap p \<lbrace>valid_ko_at_arch\<rbrace>"
-  and set_thread_state_valid_ko_at_arch[wp]:
-    "set_thread_state ref ts \<lbrace>valid_ko_at_arch\<rbrace>"
-  and valid_ko_at_arch_exst_update[simp]:
-    "\<And>f. valid_ko_at_arch (trans_state f s) = valid_ko_at_arch s"
 begin
 
 crunch valid_global_refs[wp]: empty_slot "\<lambda>s :: det_state. valid_global_refs s"
@@ -483,10 +474,8 @@ lemma set_mrs_reads_respects:
   apply (auto intro: reads_affects_equiv_get_tcb_eq)
   done
 
-crunch valid_ko_at_arch[wp]: set_untyped_cap_as_full valid_ko_at_arch
-
 lemma cap_insert_globals_equiv'':
-  "\<lbrace>globals_equiv s and valid_global_objs and valid_ko_at_arch\<rbrace>
+  "\<lbrace>globals_equiv s and valid_global_objs and valid_arch_state\<rbrace>
    cap_insert new_cap src_slot dest_slot
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding cap_insert_def
@@ -494,13 +483,13 @@ lemma cap_insert_globals_equiv'':
                  set_cap_globals_equiv'' dxo_wp_weak hoare_drop_imps)
 
 lemma set_message_info_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arch and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
+  "\<lbrace>globals_equiv s and valid_arch_state and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
    set_message_info thread info
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding set_message_info_def by (wp as_user_globals_equiv)
 
 lemma cancel_badged_sends_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
    cancel_badged_sends epptr badge
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace> "
   unfolding cancel_badged_sends_def

--- a/proof/infoflow/CNode_IF.thy
+++ b/proof/infoflow/CNode_IF.thy
@@ -5,43 +5,38 @@
  *)
 
 theory CNode_IF
-imports FinalCaps
+imports ArchFinalCaps
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
-
 lemma cap_fault_on_failure_rev:
-  "reads_equiv_valid_inv A aag P m \<Longrightarrow> reads_equiv_valid_inv A aag P (cap_fault_on_failure cptr rp m)"
+  "reads_equiv_valid_inv A aag P m
+   \<Longrightarrow> reads_equiv_valid_inv A aag P (cap_fault_on_failure cptr rp m)"
   unfolding cap_fault_on_failure_def handleE'_def
-  apply(wp | wpc | simp add: o_def)+
-  done
+  by (wp | wpc | simp add: o_def)+
 
 lemma cap_fault_on_failure_rev_g:
   "reads_respects_g aag l P m \<Longrightarrow> reads_respects_g aag l P (cap_fault_on_failure cptr rp m)"
   unfolding cap_fault_on_failure_def handleE'_def
-  apply (wp | wpc | simp add: o_def)+
-done
+  by (wp | wpc | simp add: o_def)+
 
 definition gets_apply where
   "gets_apply f x \<equiv>
-  do
-   s \<leftarrow> get;
-   return ((f s) x)
-  od"
+     do s \<leftarrow> get;
+        return ((f s) x)
+     od"
 
 lemma gets_apply_ev:
-  "equiv_valid I A A (K (\<forall> s t. I s t \<and> A s t \<longrightarrow> (f s) x = (f t) x)) (gets_apply f x)"
-  apply(simp add: gets_apply_def get_def bind_def return_def)
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  "equiv_valid I A A (K (\<forall>s t. I s t \<and> A s t \<longrightarrow> (f s) x = (f t) x)) (gets_apply f x)"
+  apply (simp add: gets_apply_def get_def bind_def return_def)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
   done
 
 lemma gets_apply:
-  "gets f >>= (\<lambda> f. g (f x)) = gets_apply f x >>= g"
-  apply(simp add: gets_apply_def gets_def)
-  done
+  "gets f >>= (\<lambda>f. g (f x)) = gets_apply f x >>= g"
+  by (simp add: gets_apply_def gets_def)
 
 lemma get_object_rev:
-  "reads_equiv_valid_inv A aag (\<lambda> s. aag_can_read aag oref) (get_object oref)"
+  "reads_equiv_valid_inv A aag (\<lambda>s. aag_can_read aag oref) (get_object oref)"
   apply (unfold get_object_def fun_app_def)
   apply (subst gets_apply)
   apply (wp gets_apply_ev | wp (once) hoare_drop_imps)+
@@ -51,34 +46,33 @@ lemma get_object_rev:
 lemma get_cap_rev:
   "reads_equiv_valid_inv A aag (K (aag_can_read aag (fst slot))) (get_cap slot)"
   unfolding get_cap_def
-  apply(wp get_object_rev | wpc | simp add: split_def)+
-  done
+  by (wp get_object_rev | wpc | simp add: split_def)+
 
 declare if_weak_cong[cong]
 
 lemma resolve_address_bits_spec_rev:
-  "reads_spec_equiv_valid_inv s A aag (pas_refined aag and K (is_cnode_cap (fst ref) \<longrightarrow> is_subject aag (obj_ref_of (fst ref)))) (resolve_address_bits ref)"
-unfolding resolve_address_bits_def
-proof(induct ref arbitrary: s rule: resolve_address_bits'.induct)
+  "reads_spec_equiv_valid_inv s A aag
+     (pas_refined aag and K (is_cnode_cap (fst ref) \<longrightarrow> is_subject aag (obj_ref_of (fst ref))))
+     (resolve_address_bits ref)"
+proof(unfold resolve_address_bits_def, induct ref arbitrary: s rule: resolve_address_bits'.induct)
   case (1 z cap' cref' s') show ?case
     apply (subst resolve_address_bits'.simps)
     apply (cases cap')
-      apply (simp_all add: drop_spec_ev throwError_ev_pre
-                     cong: if_cong
-                split del: if_split)
-   apply (wp "1.hyps")
-    apply (assumption | simp add: in_monad | rule conjI)+
-   apply (wp get_cap_rev get_cap_wp whenE_throwError_wp)+
-   apply (auto simp: cte_wp_at_caps_of_state is_cap_simps cap_auth_conferred_def
-               dest: caps_of_state_pasObjectAbs_eq)
-   done
+               apply (simp_all add: drop_spec_ev throwError_ev_pre
+                              cong: if_cong
+                         split del: if_split)
+    apply (wp "1.hyps")
+                   apply (assumption | simp add: in_monad | rule conjI)+
+           apply (wp get_cap_rev get_cap_wp whenE_throwError_wp)+
+    apply (auto simp: cte_wp_at_caps_of_state is_cap_simps cap_auth_conferred_def
+                dest: caps_of_state_pasObjectAbs_eq)
+    done
 qed
 
 lemma resolve_address_bits_rev:
-  "reads_equiv_valid_inv A aag (pas_refined aag
-                                and K (is_cnode_cap (fst ref)
-                                       \<longrightarrow> is_subject aag (obj_ref_of (fst ref))))
-                (resolve_address_bits ref)"
+  "reads_equiv_valid_inv A aag
+     (pas_refined aag and K (is_cnode_cap (fst ref) \<longrightarrow> is_subject aag (obj_ref_of (fst ref))))
+     (resolve_address_bits ref)"
   by (rule use_spec_ev[OF resolve_address_bits_spec_rev])
 
 lemma lookup_slot_for_thread_rev:
@@ -86,80 +80,74 @@ lemma lookup_slot_for_thread_rev:
                          (lookup_slot_for_thread thread cptr)"
   unfolding lookup_slot_for_thread_def fun_app_def
   apply (rule gen_asm_ev)
-  apply (wp resolve_address_bits_rev gets_the_ev
-       | simp)+
+  apply (wp resolve_address_bits_rev gets_the_ev | simp)+
   apply (rule conjI)
    apply blast
   apply (clarsimp simp: tcb.splits)
   apply (erule (2) owns_thread_owns_cspace)
-  defer
-  apply (case_tac tcb_ctablea, simp_all)
+   defer
+   apply (case_tac tcb_ctablea, simp_all)
   done
 
 lemma lookup_cap_and_slot_rev[wp]:
   "reads_equiv_valid_inv A aag (pas_refined aag and K (is_subject aag thread))
                          (lookup_cap_and_slot thread cptr)"
   unfolding lookup_cap_and_slot_def
-  apply (wp lookup_slot_for_thread_rev lookup_slot_for_thread_authorised get_cap_rev
-        | simp add: split_def
-        | strengthen aag_can_read_self)+
-  done
-
+  by (wp lookup_slot_for_thread_rev lookup_slot_for_thread_authorised get_cap_rev
+      | simp add: split_def
+      | strengthen aag_can_read_self)+
 
 lemmas lookup_cap_and_slot_reads_respects_g =
-                  reads_respects_g_from_inv[OF lookup_cap_and_slot_rev lookup_cap_and_slot_inv]
+  reads_respects_g_from_inv[OF lookup_cap_and_slot_rev lookup_cap_and_slot_inv]
 
 lemma set_cap_reads_respects:
   "reads_respects aag l (K (aag_can_read aag (fst slot))) (set_cap cap slot)"
-  apply(simp add: set_cap_def split_def)
-  apply(wp set_object_reads_respects get_object_rev hoare_vcg_all_lift
-       | wpc
-       | simp )+
-  done
-
+  by (wpsimp wp: set_object_reads_respects get_object_rev hoare_vcg_all_lift
+           simp: set_cap_def split_def)
 
 lemma set_original_reads_respects:
   "reads_respects aag l \<top> (set_original slot v)"
   unfolding set_original_def
-  apply(unfold equiv_valid_def2)
-  apply(rule_tac Q="\<top>\<top>" in equiv_valid_rv_bind)
-    apply(rule gets_is_original_cap_revrv)
-   apply(rule modify_ev2)
-   apply(clarsimp simp: equiv_for_or or_comp_dist)
-   apply(safe)
-    apply(erule reads_equiv_is_original_cap_update)
-    apply(erule equiv_for_id_update)
-   apply(erule affects_equiv_is_original_cap_update)
-   apply(erule equiv_for_id_update)
+  apply (unfold equiv_valid_def2)
+  apply (rule_tac Q="\<top>\<top>" in equiv_valid_rv_bind)
+    apply (rule gets_is_original_cap_revrv)
+   apply (rule modify_ev2)
+   apply (clarsimp simp: equiv_for_or or_comp_dist)
+   apply (safe)
+    apply (erule reads_equiv_is_original_cap_update)
+    apply (erule equiv_for_id_update)
+   apply (erule affects_equiv_is_original_cap_update)
+   apply (erule equiv_for_id_update)
   apply wp
   done
-
 
 lemma set_cdt_reads_respects:
   "reads_respects aag l \<top> (set_cdt c)"
   unfolding set_cdt_def
-  apply(unfold equiv_valid_def2)
-  apply(rule get_bind_ev2)
-  apply(unfold fun_app_def, rule put_ev2)
-  apply(fastforce intro: reads_equiv_cdt_update affects_equiv_cdt_update equiv_for_refl)
+  apply (unfold equiv_valid_def2)
+  apply (rule get_bind_ev2)
+  apply (unfold fun_app_def, rule put_ev2)
+  apply (fastforce intro: reads_equiv_cdt_update affects_equiv_cdt_update equiv_for_refl)
   done
 
 lemma set_cdt_ev2:
-  "equiv_for (((aag_can_read aag) or (aag_can_affect aag l)) \<circ> fst) id c c' \<Longrightarrow>
-   equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) (=) \<top> \<top> (set_cdt c) (set_cdt c')"
+  "equiv_for (((aag_can_read aag) or (aag_can_affect aag l)) \<circ> fst) id c c'
+   \<Longrightarrow> equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l)
+                     (=) \<top> \<top> (set_cdt c) (set_cdt c')"
   unfolding set_cdt_def
-  apply(rule get_bind_ev2)
-  apply(unfold fun_app_def, rule put_ev2)
-  apply(fastforce simp: equiv_for_or or_comp_dist reads_equiv_cdt_update affects_equiv_cdt_update)
+  apply (rule get_bind_ev2)
+  apply (unfold fun_app_def, rule put_ev2)
+  apply (fastforce simp: equiv_for_or or_comp_dist reads_equiv_cdt_update affects_equiv_cdt_update)
   done
 
 lemma set_cdt_list_ev2:
-  "equiv_for (((aag_can_read aag) or (aag_can_affect aag l)) \<circ> fst) id c c' \<Longrightarrow>
-   equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) (=) \<top> \<top> (set_cdt_list c) (set_cdt_list c')"
+  "equiv_for (((aag_can_read aag) or (aag_can_affect aag l)) \<circ> fst) id c c'
+   \<Longrightarrow> equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l)
+                     (=) \<top> \<top> (set_cdt_list c) (set_cdt_list c')"
   unfolding set_cdt_list_def
-  apply(rule get_bind_ev2)
-  apply(unfold fun_app_def, rule put_ev2)
-  apply(fastforce simp: equiv_for_or or_comp_dist reads_equiv_cdt_list_update affects_equiv_cdt_list_update)
+  apply (rule get_bind_ev2)
+  apply (unfold fun_app_def, rule put_ev2)
+  apply (fastforce simp: equiv_for_or or_comp_dist reads_equiv_cdt_list_update affects_equiv_cdt_list_update)
   done
 
 lemma kheap_get_tcb_eq: "kheap s ref = kheap t ref \<Longrightarrow> get_tcb ref s = get_tcb ref t"
@@ -171,34 +159,34 @@ lemma thread_get_rev:
   by (wp gets_the_ev) (fastforce intro: kheap_get_tcb_eq elim: reads_equivE equiv_forD)
 
 lemma update_cdt_reads_respects:
-  "reads_respects aag l (K  (\<forall> rv rv'.
-       equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id rv rv' \<longrightarrow>
-       equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) f rv rv'))
-      (update_cdt f)"
+  "reads_respects aag l (K (\<forall>rv rv'.
+      equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id rv rv' \<longrightarrow>
+      equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) f rv rv'))
+     (update_cdt f)"
   unfolding update_cdt_def
-  apply(rule gen_asm_ev)
-  apply(unfold equiv_valid_def2)
-  apply(rule equiv_valid_rv_bind)
-    apply(rule equiv_valid_rv_guard_imp[OF gets_cdt_revrv])
-    apply(rule TrueI)
-   apply(rule set_cdt_ev2)
-   apply(simp add: equiv_for_comp[symmetric])
+  apply (rule gen_asm_ev)
+  apply (unfold equiv_valid_def2)
+  apply (rule equiv_valid_rv_bind)
+    apply (rule equiv_valid_rv_guard_imp[OF gets_cdt_revrv])
+    apply (rule TrueI)
+   apply (rule set_cdt_ev2)
+   apply (simp add: equiv_for_comp[symmetric])
   apply wp
   done
 
 lemma update_cdt_list_reads_respects:
-  "reads_respects aag l (K  (\<forall> rv rv'.
-       equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id rv rv' \<longrightarrow>
-       equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) f rv rv'))
-      (update_cdt_list f)"
+  "reads_respects aag l (K  (\<forall>rv rv'.
+      equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id rv rv' \<longrightarrow>
+      equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) f rv rv'))
+     (update_cdt_list f)"
   unfolding update_cdt_list_def
-  apply(rule gen_asm_ev)
-  apply(unfold equiv_valid_def2)
-  apply(rule equiv_valid_rv_bind)
-    apply(rule equiv_valid_rv_guard_imp[OF gets_cdt_list_revrv])
-    apply(rule TrueI)
-   apply(rule set_cdt_list_ev2)
-   apply(simp add: equiv_for_comp[symmetric])
+  apply (rule gen_asm_ev)
+  apply (unfold equiv_valid_def2)
+  apply (rule equiv_valid_rv_bind)
+    apply (rule equiv_valid_rv_guard_imp[OF gets_cdt_list_revrv])
+    apply (rule TrueI)
+   apply (rule set_cdt_list_ev2)
+   apply (simp add: equiv_for_comp[symmetric])
   apply wp
   done
 
@@ -209,39 +197,17 @@ lemma gen_asm_ev2':
 
 lemmas gen_asm_ev2 = gen_asm_ev2'[where P=\<top> and P'=\<top>, simplified]
 
-lemma hoare_vcg_post_lift:
-  "\<lbrakk>P \<Longrightarrow> Q\<rbrakk> \<Longrightarrow> \<lbrace> \<lambda> s. P \<rbrace> f \<lbrace> \<lambda> rv s. Q \<rbrace>"
-  by(simp add: valid_def)
-
-lemmas hoare_vcg_post_lift' = hoare_vcg_post_lift[where P="True", simplified]
-
 lemma set_untyped_cap_as_full_reads_respects:
   "reads_respects aag l (K (aag_can_read aag (fst src_slot)))
-        (set_untyped_cap_as_full src_cap new_cap src_slot)"
+     (set_untyped_cap_as_full src_cap new_cap src_slot)"
   unfolding set_untyped_cap_as_full_def
   apply (wp set_cap_reads_respects)
   apply auto
   done
 
-
-
 lemma gets_apply_wp[wp]:
   "\<lbrace>\<lambda>s. P (f s x) s\<rbrace> gets_apply f x \<lbrace>P\<rbrace>"
-  apply (simp add: gets_apply_def)
-  apply wp
-  done
-
-
-lemma morestuff: "\<lbrakk>is_subject aag (fst src_slot);
-        reads_equiv aag sa t\<rbrakk>
-       \<Longrightarrow> is_original_cap sa src_slot = is_original_cap t src_slot"
-  apply (clarsimp simp: reads_equiv_def2)
-  apply (erule states_equiv_forE_is_original_cap)
-  apply (drule_tac x="src_slot" in meta_spec)
-  apply (frule aag_can_read_self)
-  apply simp
-  done
-
+  by (wpsimp simp: gets_apply_def)
 
 lemma cap_insert_reads_respects:
   notes split_paired_All[simp del]
@@ -249,26 +215,25 @@ lemma cap_insert_reads_respects:
   "reads_respects aag l (K (aag_can_read aag (fst src_slot) \<and> aag_can_read aag (fst dest_slot)))
                   (cap_insert new_cap src_slot dest_slot)"
   unfolding cap_insert_def
-  apply(rule gen_asm_ev)
-  apply(subst gets_apply)
+  apply (rule gen_asm_ev)
+  apply (subst gets_apply)
   apply (simp only: cap_insert_ext_extended.dxo_eq)
   apply (simp only: cap_insert_ext_def)
-  apply(wp set_original_reads_respects update_cdt_reads_respects set_cap_reads_respects
-           gets_apply_ev update_cdt_list_reads_respects set_untyped_cap_as_full_reads_respects
-           get_cap_wp get_cap_rev
-       | simp split del: if_split
-       | clarsimp simp: equiv_for_def split: option.splits)+
+  apply (wp set_original_reads_respects update_cdt_reads_respects set_cap_reads_respects
+            gets_apply_ev update_cdt_list_reads_respects set_untyped_cap_as_full_reads_respects
+            get_cap_wp get_cap_rev
+         | simp split del: if_split
+         | clarsimp simp: equiv_for_def split: option.splits)+
   by (fastforce simp: reads_equiv_def2 equiv_for_def
                 elim: states_equiv_forE_is_original_cap states_equiv_forE_cdt
                 dest: aag_can_read_self
                split: option.splits)
 
-
 lemma cap_move_reads_respects:
   notes split_paired_All[simp del]
   shows
   "reads_respects aag l (K (is_subject aag (fst src_slot) \<and> is_subject aag (fst dest_slot)))
-                 (cap_move new_cap src_slot dest_slot)"
+                  (cap_move new_cap src_slot dest_slot)"
   unfolding cap_move_def
   apply (subst gets_apply)
   apply (simp add: bind_assoc[symmetric])
@@ -276,407 +241,130 @@ lemma cap_move_reads_respects:
   apply (simp add: bind_assoc cap_move_ext_def)
   apply (rule gen_asm_ev)
   apply (elim conjE)
-  apply(wp set_original_reads_respects gets_apply_ev update_cdt_reads_respects
-           set_cap_reads_respects update_cdt_list_reads_respects
-       | simp split del: if_split | fastforce simp: equiv_for_def split: option.splits)+
+  apply (wp set_original_reads_respects gets_apply_ev update_cdt_reads_respects
+            set_cap_reads_respects update_cdt_list_reads_respects
+         | simp split del: if_split | fastforce simp: equiv_for_def split: option.splits)+
   apply (intro impI conjI allI)
-  apply(fastforce simp: reads_equiv_def2 equiv_for_def
-                  elim: states_equiv_forE_is_original_cap states_equiv_forE_cdt
-                  dest: aag_can_read_self
-                 split: option.splits)+
+  apply (fastforce simp: reads_equiv_def2 equiv_for_def
+                   elim: states_equiv_forE_is_original_cap states_equiv_forE_cdt
+                   dest: aag_can_read_self
+                  split: option.splits)+
   done
 
 lemma get_idemp:
   "do s1 \<leftarrow> get; s2 \<leftarrow> get; f s1 s2 od =
    do s1 \<leftarrow> get; f s1 s1 od"
-  apply(simp add: get_def bind_def)
-  done
+  by (simp add: get_def bind_def)
 
 lemma gets_apply2:
   "gets f >>= (\<lambda> f. g (f x) (f y)) =
    gets_apply f x >>= (\<lambda> x. gets_apply f y >>= (\<lambda> y. g x y))"
-  apply(simp add: gets_def gets_apply_def get_idemp)
-  done
+  by (simp add: gets_def gets_apply_def get_idemp)
 
 lemma cap_swap_reads_respects:
   notes split_paired_All[simp del]
-  shows
-  "reads_respects aag l (K (is_subject aag (fst slot1) \<and> is_subject aag (fst slot2))) (cap_swap cap1 slot1 cap2 slot2)"
+  shows "reads_respects aag l (K (is_subject aag (fst slot1) \<and> is_subject aag (fst slot2)))
+                        (cap_swap cap1 slot1 cap2 slot2)"
   unfolding cap_swap_def
   apply (subst gets_apply2)
   apply (simp add: bind_assoc[symmetric])
   apply (fold update_cdt_def)
   apply (simp add: bind_assoc cap_swap_ext_def)
   apply (rule gen_asm_ev)
-  apply(wp set_original_reads_respects update_cdt_reads_respects gets_apply_ev set_cap_reads_respects update_cdt_list_reads_respects | simp split del: if_split | fastforce simp: equiv_for_def split: option.splits)+
+  apply (wp set_original_reads_respects update_cdt_reads_respects gets_apply_ev
+            set_cap_reads_respects update_cdt_list_reads_respects
+         | simp split del: if_split | fastforce simp: equiv_for_def split: option.splits)+
   apply (intro impI conjI allI)
-      apply((fastforce simp: reads_equiv_def2 equiv_for_def elim: states_equiv_forE_is_original_cap states_equiv_forE_cdt dest: aag_can_read_self split: option.splits)+)[2]
-    apply (frule_tac x = slot1 in equiv_forD,elim conjE,drule aag_can_read_self,simp)
-    apply (frule_tac x = slot2 in equiv_forD,elim conjE)
+      apply ((fastforce simp: reads_equiv_def2 equiv_for_def
+                        elim: states_equiv_forE_is_original_cap states_equiv_forE_cdt
+                        dest: aag_can_read_self
+                       split: option.splits)+)[2]
+    apply (frule_tac x = slot1 in equiv_forD, elim conjE,drule aag_can_read_self,simp)
+    apply (frule_tac x = slot2 in equiv_forD, elim conjE)
      apply (drule aag_can_read_self)+
      apply clarsimp
     apply clarsimp
-    apply(erule equiv_forE)
-    apply(fastforce intro: equiv_forI)
-   apply(fastforce simp: equiv_for_def dest: aag_can_read_self elim: reads_equivE equiv_forE[where f="is_original_cap"] split: option.splits)+
+    apply (erule equiv_forE)
+    apply (fastforce intro: equiv_forI)
+   apply (fastforce simp: equiv_for_def dest: aag_can_read_self
+                    elim: reads_equivE equiv_forE[where f="is_original_cap"] split: option.splits)+
   done
 
 lemma tcb_at_def2: "tcb_at ptr s = (\<exists>tcb. kheap s ptr = Some (TCB tcb))"
-  apply (clarsimp simp: tcb_at_def get_tcb_def split: kernel_object.splits option.splits)
-  done
-
-lemma set_object_globals_equiv:
-  "\<lbrace> globals_equiv s and (\<lambda> s. ptr \<noteq> arm_global_pd (arch_state s))
-    and (\<lambda>t. ptr = idle_thread t \<longrightarrow>
-                (\<forall>tcb. kheap t (idle_thread t) = Some (TCB tcb) \<longrightarrow> (\<exists>tcb'. obj = (TCB tcb')
-             \<and> arch_tcb_context_get (tcb_arch tcb) = arch_tcb_context_get (tcb_arch tcb')))
-             \<and> (\<forall>tcb'. obj = (TCB tcb') \<longrightarrow> tcb_at (idle_thread t) t)) \<rbrace>
-   set_object ptr obj
-   \<lbrace> \<lambda>_. globals_equiv s \<rbrace>"
-  apply (wpsimp wp: set_object_wp)
-  apply (case_tac "ptr = idle_thread sa")
-   apply (clarsimp simp: globals_equiv_def idle_equiv_def tcb_at_def2)
-   apply (intro impI conjI allI notI iffI | clarsimp)+
-  apply (clarsimp simp: globals_equiv_def idle_equiv_def tcb_at_def2)
-  done
-
-lemma set_object_globals_equiv'':
-  "\<lbrace> globals_equiv s and (\<lambda> s. ptr \<noteq> arm_global_pd (arch_state s)) and (\<lambda>t. ptr \<noteq> idle_thread t)\<rbrace>
-   set_object ptr obj
-   \<lbrace> \<lambda>_. globals_equiv s \<rbrace>"
-  apply (wp set_object_globals_equiv)
-  apply simp
-  done
-
-lemma set_cap_globals_equiv':
-  "\<lbrace>globals_equiv s and (\<lambda> s. fst p \<noteq> arm_global_pd (arch_state s))\<rbrace>
-   set_cap cap p \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_cap_def
-  apply(simp only: split_def)
-  apply(wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
-   apply (fastforce simp: obj_at_def is_tcb_def)+
-  done
-
-
-lemma set_cap_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_global_objs\<rbrace>
-   set_cap cap p \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_cap_def
-  apply(simp only: split_def)
-  apply(wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
-   apply(fastforce simp: valid_global_objs_def valid_vso_at_def obj_at_def is_tcb_def)+
-  done
-
+  by (clarsimp simp: tcb_at_def get_tcb_def split: kernel_object.splits option.splits)
 
 lemma set_cdt_globals_equiv:
-  "\<lbrace>globals_equiv s\<rbrace> set_cdt c \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  "set_cdt c \<lbrace>globals_equiv s\<rbrace>"
   unfolding set_cdt_def
-  apply(wp)
-  apply(fastforce simp: globals_equiv_def idle_equiv_def)
-  done
+  by (wpsimp simp: globals_equiv_def idle_equiv_def)
 
 lemma update_cdt_globals_equiv:
-  "\<lbrace>globals_equiv s\<rbrace> update_cdt f \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  "update_cdt f \<lbrace>globals_equiv s\<rbrace>"
   unfolding update_cdt_def
-  apply(wp set_cdt_globals_equiv)
-  done
+  by (wp set_cdt_globals_equiv)
 
-declare set_original_wp [wp del]
+declare set_original_wp[wp del]
+
 lemma set_original_globals_equiv:
-  "\<lbrace>globals_equiv s\<rbrace> set_original slot v \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  "set_original slot v \<lbrace>globals_equiv s\<rbrace>"
   unfolding set_original_def
-  apply(wp)
-  apply(fastforce simp: globals_equiv_def idle_equiv_def)
-  done
-
-crunch globals_equiv[wp]: set_untyped_cap_as_full "globals_equiv st"
+  by (wpsimp simp: globals_equiv_def idle_equiv_def)
 
 lemma globals_equiv_exst_update[simp]:
   "globals_equiv st (trans_state f s) =
    globals_equiv st s"
   by (simp add: globals_equiv_def idle_equiv_def)
 
-end
-
 lemma (in is_extended') globals_equiv: "I (globals_equiv st)" by (rule lift_inv,simp)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+lemma domain_sep_inv_refl:
+  "domain_sep_inv irqs st s \<Longrightarrow> domain_sep_inv irqs s s"
+  by (fastforce simp: domain_sep_inv_def)
+
+
+locale CNode_IF_1 =
+  fixes state_ext_t :: "'s :: state_ext itself"
+  and irq_at :: "nat \<Rightarrow> (irq \<Rightarrow> bool) \<Rightarrow> irq option"
+  assumes set_cap_globals_equiv:
+    "\<lbrace>globals_equiv s and valid_global_objs\<rbrace> set_cap cap p \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  and dmo_getActiveIRQ_wp:
+    "\<lbrace>\<lambda>s. P (irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)))
+            (s\<lparr>machine_state := machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>\<rparr>)\<rbrace>
+     do_machine_op (getActiveIRQ in_kernel)
+     \<lbrace>\<lambda>rv s :: 's state. P rv s\<rbrace>"
+  and arch_globals_equiv_irq_state_update[simp]:
+    "arch_globals_equiv ct it kh kh' as as' ms (irq_state_update f ms') =
+     arch_globals_equiv ct it kh kh' as as' ms ms'"
+    "arch_globals_equiv ct it kh kh' as as' (irq_state_update f ms) ms' =
+     arch_globals_equiv ct it kh kh' as as' ms ms'"
+begin
+
+crunch globals_equiv[wp]: set_untyped_cap_as_full "globals_equiv st"
 
 lemma cap_insert_globals_equiv:
   "\<lbrace>globals_equiv s and valid_global_objs\<rbrace>
    cap_insert new_cap src_slot dest_slot
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding cap_insert_def fun_app_def
-  apply(wp update_cdt_globals_equiv set_original_globals_equiv set_cap_globals_equiv hoare_drop_imps dxo_wp_weak| simp)+
-  done
+  by (wpsimp wp: update_cdt_globals_equiv set_original_globals_equiv
+                 set_cap_globals_equiv hoare_drop_imps dxo_wp_weak)
 
 lemma cap_move_globals_equiv:
   "\<lbrace>globals_equiv s and valid_global_objs\<rbrace>
-    cap_move new_cap src_slot dest_slot
+   cap_move new_cap src_slot dest_slot
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding cap_move_def fun_app_def
-  apply(wp set_original_globals_equiv set_cdt_globals_equiv set_cap_globals_equiv
-           dxo_wp_weak | simp)+
-  done
+  by (wpsimp wp: set_original_globals_equiv set_cdt_globals_equiv set_cap_globals_equiv dxo_wp_weak)
 
 lemma cap_swap_globals_equiv:
   "\<lbrace>globals_equiv s and valid_global_objs\<rbrace>
    cap_swap cap1 slot1 cap2 slot2
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding cap_swap_def
-  apply(wp set_original_globals_equiv set_cdt_globals_equiv set_cap_globals_equiv
-           dxo_wp_weak|simp)+
-  done
-
-lemma aag_cap_auth_ASIDPoolCap:
-  "pas_cap_cur_auth aag (ArchObjectCap (ASIDPoolCap r asid)) \<Longrightarrow>
-   pas_refined aag s \<Longrightarrow> is_subject aag r"
-unfolding aag_cap_auth_def
-  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
-                   pas_refined_all_auth_is_owns is_page_cap_def)
-  done
-
-lemma aag_cap_auth_PageDirectory:
-  "pas_cap_cur_auth aag (ArchObjectCap (PageDirectoryCap word (Some a))) \<Longrightarrow>
-    pas_refined aag s \<Longrightarrow> is_subject aag word"
-  unfolding aag_cap_auth_def
-  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
-                   pas_refined_all_auth_is_owns is_page_cap_def)
-  done
-
-lemma aag_cap_auth_ASIDPoolCap_asid:
-  "pas_cap_cur_auth aag (ArchObjectCap (ASIDPoolCap r asid)) \<Longrightarrow>
-  asid' \<noteq> 0 \<Longrightarrow> asid_high_bits_of asid' = asid_high_bits_of asid \<Longrightarrow>
-  pas_refined aag s \<Longrightarrow>
-  is_subject_asid aag asid'"
-  apply (frule (1) aag_cap_auth_ASIDPoolCap)
-  unfolding aag_cap_auth_def
-  apply (rule is_subject_into_is_subject_asid)
-  apply auto
-  done
-
-lemma aag_cap_auth_PageCap_asid:
-  "pas_cap_cur_auth aag (ArchObjectCap (PageCap dev word fun vmpage_size (Some (a, b))))
-  \<Longrightarrow> pas_refined aag s
-  \<Longrightarrow> is_subject_asid aag a"
-  apply (auto simp add: aag_cap_auth_def cap_auth_conferred_def
-                        cap_links_asid_slot_def label_owns_asid_slot_def
-                 intro: pas_refined_Control_into_is_subject_asid)
-  done
-
-lemma aag_cap_auth_PageTableCap:
-  "pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word option)) \<Longrightarrow>
-   pas_refined aag s \<Longrightarrow> is_subject aag word"
-  unfolding aag_cap_auth_def
-  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
-                   pas_refined_all_auth_is_owns is_page_cap_def)
-  done
-
-lemma aag_cap_auth_PageTableCap_asid: "pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word (Some (a, b)))) \<Longrightarrow> pas_refined aag s \<Longrightarrow> is_subject_asid aag a"
-  apply (auto simp add: aag_cap_auth_def cap_auth_conferred_def
-                   cap_links_asid_slot_def label_owns_asid_slot_def
-                   intro: pas_refined_Control_into_is_subject_asid)
-  done
-
-lemma aag_cap_auth_PageDirectoryCap:"pas_cap_cur_auth aag (ArchObjectCap (PageDirectoryCap word option)) \<Longrightarrow> pas_refined aag s \<Longrightarrow>
-  is_subject aag word"
-  unfolding aag_cap_auth_def
-  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def   pas_refined_all_auth_is_owns is_page_cap_def)
-  done
-
-
-lemma aag_cap_auth_PageDirectoryCap_asid:"pas_cap_cur_auth aag (ArchObjectCap (PageDirectoryCap word (Some a))) \<Longrightarrow> pas_refined aag s \<Longrightarrow>
-  is_subject_asid aag a"
-  unfolding aag_cap_auth_def
-  apply (auto simp add: aag_cap_auth_def cap_auth_conferred_def
-                   cap_links_asid_slot_def label_owns_asid_slot_def
-                   intro: pas_refined_Control_into_is_subject_asid)
-done
-
-
-lemma aag_cap_auth_recycle_EndpointCap:"pas_cap_cur_auth aag (EndpointCap word1 word2 f) \<Longrightarrow>
-  pas_refined aag s \<Longrightarrow>
-  has_cancel_send_rights (EndpointCap word1 word2 f) \<Longrightarrow>
-  is_subject aag word1"
-  unfolding aag_cap_auth_def
-  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def
-                   pas_refined_all_auth_is_owns is_page_cap_def
-                   has_cancel_send_rights_def cap_rights_to_auth_def
-                   all_rights_def)
-  done
-
-lemma aag_cap_auth_Zombie:"pas_cap_cur_auth aag (Zombie word x y) \<Longrightarrow>
-  pas_refined aag s \<Longrightarrow>
- is_subject aag word"
-  unfolding aag_cap_auth_def
-  apply (simp add: cli_no_irqs clas_no_asid cap_auth_conferred_def
-        pas_refined_all_auth_is_owns is_page_cap_def cap_rights_to_auth_def)
-  done
-
-lemmas aag_cap_auth_subject = aag_cap_auth_PageTableCap
-                              aag_cap_auth_PageDirectory
-                              aag_cap_auth_ASIDPoolCap
-                              aag_cap_auth_ASIDPoolCap_asid
-                              aag_cap_auth_PageCap_asid
-                              aag_cap_auth_PageTableCap_asid
-                              aag_cap_auth_PageDirectoryCap
-                              aag_cap_auth_PageDirectoryCap_asid
-                              aag_cap_auth_Zombie
-                              aag_cap_auth_recycle_EndpointCap
-
-(*Pushed up from Arch_IF*)
-definition valid_ko_at_arm :: "'a::state_ext state \<Rightarrow> bool" where
-  "valid_ko_at_arm \<equiv>
-    \<lambda>s. \<exists>pd. ko_at (ArchObj (PageDirectory pd)) (arm_global_pd (arch_state s)) s"
-
-lemma valid_arch_state_ko_at_arm:
-  "valid_arch_state s \<Longrightarrow> valid_ko_at_arm s"
-  apply(fastforce simp: valid_arch_state_def valid_ko_at_arm_def obj_at_def dest: a_type_pdD)
-  done
-
-lemma invs_valid_ko_at_arm:
-  "invs s \<Longrightarrow> valid_ko_at_arm s" by (simp add: invs_def valid_state_def valid_arch_state_ko_at_arm)
-
-lemmas invs_imps = invs_valid_vs_lookup invs_sym_refs invs_psp_aligned invs_distinct invs_valid_ko_at_arm invs_valid_global_objs invs_arch_state invs_valid_objs invs_valid_global_refs tcb_at_invs invs_cur invs_kernel_mappings
-
-lemma cte_wp_at_page_cap_aligned :
-  "\<lbrakk>cte_wp_at
-           ((=) (ArchObjectCap (PageCap dev word fun vmpage_size option))) slot s ; valid_objs s \<rbrakk>\<Longrightarrow>
-  is_aligned word (pageBitsForSize vmpage_size)"
-  apply (simp add: cte_wp_at_caps_of_state)
-  apply (case_tac slot)
-  apply simp
-  apply (frule caps_of_state_valid_cap)
-   apply simp
-  apply (frule valid_cap_aligned)
-  apply (simp add: cap_aligned_def)
-done
-
-lemma cte_wp_at_pt_exists_cap:
-  "valid_objs s \<Longrightarrow> cte_wp_at ((=) (ArchObjectCap (PageTableCap word option))) slot s \<Longrightarrow>
-    x \<in> set [word , word + 4 .e. word + 2 ^ pt_bits - 1]
-    \<Longrightarrow>\<exists>a b cap.
-               caps_of_state s (a, b) = Some cap \<and>
-               x && ~~ mask pt_bits \<in> Structures_A.obj_refs cap \<and> is_pt_cap cap"
-  apply (case_tac slot)
-  apply (rule_tac x=a in exI)
-  apply (rule_tac x=b in exI)
-  apply (subgoal_tac "is_aligned word pt_bits")
-   apply (frule (1) word_aligned_pt_slots)
-   apply (simp add:pageBits_def cte_wp_at_caps_of_state is_pt_cap_def)
-  apply (frule (1) cte_wp_valid_cap)
-  apply (simp add: valid_cap_def cap_aligned_def pt_bits_def pageBits_def)
-done
-
-
-lemma pd_bits_store_pde_helper:
-  "xa \<le> (kernel_base >> 20) - 1 \<Longrightarrow>
-    is_aligned word pd_bits \<Longrightarrow>
-   ((xa << 2) + word && ~~ mask pd_bits) = word"
-  apply (clarsimp simp: field_simps)
-  apply (subst is_aligned_add_helper)
-    apply simp
-   apply (rule shiftl_less_t2n)
-    apply (erule order_le_less_trans)
-    apply (simp add: kernel_base_def  pd_bits_def pageBits_def)+
-done
-
-
-lemma cte_wp_at_page_directory_not_in_globals:
-  "\<lbrakk>cte_wp_at ((=) (ArchObjectCap (PageDirectoryCap word optiona)))
-           slot s; x \<le> (kernel_base >> 20) - 1; valid_objs s; valid_global_refs s\<rbrakk> \<Longrightarrow>
-    (x << 2) + word && ~~ mask pd_bits \<notin> global_refs s
-            "
-  apply (frule (1) cte_wp_at_valid_objs_valid_cap)
-  apply (simp add: cte_wp_at_caps_of_state)
-  apply (drule (1) valid_global_refsD2)
-  apply (simp add: cap_range_def)
-  apply (frule valid_cap_aligned)
-  apply (simp add: cap_aligned_def)
-  apply (subgoal_tac "is_aligned word pd_bits")
-  apply (rule pd_shifting_global_refs)
-  apply (simp add: pd_bits_def pageBits_def)+
-done
-
-
-lemma not_in_global_not_arm:
-  "A \<notin> global_refs s \<Longrightarrow> A \<noteq> arm_global_pd (arch_state s)" by (simp add: global_refs_def)
-
-
-lemma cte_wp_at_page_cap_bits :
-  "\<lbrakk>cte_wp_at ((=) (ArchObjectCap (PageTableCap word option))) slot
-           s; valid_objs s\<rbrakk> \<Longrightarrow>
-    cte_wp_at
-                   (\<lambda>c. (\<lambda>x. x && ~~ mask pt_bits) `
-                        set [word , word + 4 .e. word + 2 ^ pt_bits - 1]
-                        \<subseteq> Structures_A.obj_refs c \<and>
-                        is_pt_cap c)
-                   slot s"
-  apply (frule (1) cte_wp_at_valid_objs_valid_cap)
-  apply (clarsimp simp: valid_cap_def cap_aligned_def)
-  apply (erule cte_wp_at_weakenE)
-  apply (unfold is_pt_cap_def)
-  apply (subgoal_tac "is_aligned word pt_bits")
-  prefer 2
-  apply (simp add: pt_bits_def pageBits_def)
-  apply (auto simp: word_aligned_pt_slots)
-done
-
-lemma mapM_x_swp_store_pte_invs' :
-  "\<lbrace>invs
-     and
-     (\<lambda>s. cte_wp_at ((=) (ArchObjectCap (PageTableCap word option))) slot
-           s)\<rbrace>
-    mapM_x (swp store_pte InvalidPTE) [word , word + 4 .e. word + 2 ^ pt_bits - 1] \<lbrace>\<lambda>_. invs\<rbrace>"
-  apply (rule hoare_pre)
-  apply (rule mapM_x_swp_store_pte_invs)
-  apply clarsimp
-  apply (case_tac slot)
-  apply (rule_tac x=a in exI)
-  apply (rule_tac x=b in exI)
-  apply (auto simp: cte_wp_at_page_cap_bits invs_def valid_state_def valid_pspace_def)
-done
-
-lemma cte_wp_at_page_directory_not_in_kernel_mappings:
-  "\<lbrakk>cte_wp_at ((=) (ArchObjectCap (PageDirectoryCap word optiona)))
-           slot s; x \<le> (kernel_base >> 20) - 1; valid_objs s; valid_global_refs s\<rbrakk> \<Longrightarrow>
-  ucast ((x << 2) + word && mask pd_bits >> 2) \<notin> kernel_mapping_slots"
-  apply (frule (1) cte_wp_at_valid_objs_valid_cap)
-  apply (simp add: cte_wp_at_caps_of_state)
-  apply (drule (1) valid_global_refsD2)
-  apply (simp add: cap_range_def)
-  apply (frule valid_cap_aligned)
-  apply (simp add: cap_aligned_def)
-  apply (subgoal_tac "is_aligned word pd_bits")
-  apply (rule pd_shifting_kernel_mapping_slots)
-  apply (simp add: pd_bits_def pageBits_def)+
-done
-
-lemma preemption_point_def2:
-  "(preemption_point :: (unit,det_ext) p_monad)
-     = doE liftE update_work_units;
-           rv \<leftarrow> liftE work_units_limit_reached;
-           if rv then doE
-             liftE reset_work_units;
-             liftE (do_machine_op (getActiveIRQ True)) >>=E
-             case_option (returnOk ()) (K (throwError $ ()))
-           odE else returnOk()
-       odE"
-  apply (rule ext)
-  apply (simp add: preemption_point_def OR_choiceE_def wrap_ext_bool_det_ext_ext_def ef_mk_ef work_units_limit_reached_empty_fail)
-  apply (simp add: select_f_def)
-  apply (clarsimp simp: work_units_limit_reached_def gets_def liftE_def select_f_def get_def lift_def return_def bind_def bindE_def split_def image_def split: option.splits sum.splits)
-  done
-
-
-(* moved from ADT_IF *)
-definition irq_at :: "nat \<Rightarrow> (10 word \<Rightarrow> bool) \<Rightarrow> irq option" where
-  "irq_at pos masks \<equiv>
-  let i = irq_oracle pos in
-  (if i = 0x3FF \<or> masks i then None else Some i)"
+  by (wpsimp wp: set_original_globals_equiv set_cdt_globals_equiv set_cap_globals_equiv dxo_wp_weak)
 
 definition is_irq_at :: "('z::state_ext) state \<Rightarrow> irq \<Rightarrow> nat \<Rightarrow> bool" where
-  "is_irq_at s \<equiv> \<lambda> irq pos. irq_at pos (irq_masks (machine_state s)) = Some irq"
+  "is_irq_at s \<equiv> \<lambda>irq pos. irq_at pos (irq_masks (machine_state s)) = Some irq"
 
 text \<open>
   We require that interrupts recur in order to ensure that no individual
@@ -685,260 +373,171 @@ text \<open>
 definition irq_is_recurring :: "irq \<Rightarrow> ('z::state_ext) state \<Rightarrow> bool" where
   "irq_is_recurring irq s \<equiv> \<forall>n. (\<exists>m. is_irq_at s irq (n+m))"
 
-
-lemma dmo_getActiveIRQ_wp:
-  "\<lbrace>\<lambda>s. P (irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s))) (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>)\<rbrace> do_machine_op (getActiveIRQ in_kernel) \<lbrace>P\<rbrace>"
-  apply(simp add: do_machine_op_def getActiveIRQ_def non_kernel_IRQs_def)
-  apply(wp modify_wp | wpc)+
-  apply clarsimp
-  apply(erule use_valid)
-   apply (wp modify_wp)
-  apply(auto simp: irq_at_def Let_def split: if_splits)
-  done
-
-lemma only_timer_irqs:
-  "\<lbrakk>domain_sep_inv False st s; valid_irq_states s; is_irq_at s irq n\<rbrakk> \<Longrightarrow>
-  interrupt_states s irq = IRQTimer"
-  apply(clarsimp simp: is_irq_at_def irq_at_def Let_def split: if_split_asm)
-  apply(case_tac "interrupt_states s (irq_oracle n)")
-     apply(blast elim: valid_irq_statesE)
-    apply(fastforce simp: domain_sep_inv_def)
-   apply assumption
-  apply(fastforce simp: domain_sep_inv_def)
-  done
-
-lemma dmo_getActiveIRQ_only_timer:
-  "\<lbrace>domain_sep_inv False st and valid_irq_states\<rbrace>
-   do_machine_op (getActiveIRQ in_kernel)
-   \<lbrace>\<lambda>rv s. (\<forall>x. rv = Some x \<longrightarrow> interrupt_states s x = IRQTimer)\<rbrace>"
-  apply(wp dmo_getActiveIRQ_wp)
-  apply clarsimp
-  apply(erule (1) only_timer_irqs)
-  apply(simp add: is_irq_at_def)
-  done
-
 text \<open>
   There is only one interrupt turned on, namely @{term irq}, and it is
   a timer interrupt.
 \<close>
-definition only_timer_irq :: "10 word \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
+definition only_timer_irq :: "irq \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
   "only_timer_irq irq s \<equiv> (\<forall>x. interrupt_states s x = IRQTimer \<longrightarrow> x = irq) \<and> irq_is_recurring irq s"
 
-lemma is_irq_at_triv:
-  assumes a:
-  "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
-        f
-       \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s)) \<rbrace>"
-  shows
-  "\<lbrace> (\<lambda>s. P (is_irq_at s)) and Q \<rbrace> f \<lbrace> \<lambda>rv s. P (is_irq_at s) \<rbrace>"
-  apply(clarsimp simp: valid_def is_irq_at_def irq_at_def Let_def)
-  apply(erule use_valid[OF _ a])
-  apply simp
-  done
+end
+
+
+locale CNode_IF_2 = CNode_IF_1 state_ext_t
+  for state_ext_t :: "'s :: state_ext itself"
+  and f :: "('s state, 'a) nondet_monad" +
+  assumes is_irq_at_triv:
+    "(\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
+           f
+           \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s))\<rbrace>)
+     \<Longrightarrow> \<lbrace>(\<lambda>s. P (is_irq_at s)) and Q\<rbrace>
+         f
+         \<lbrace>\<lambda>rv s. P (is_irq_at s)\<rbrace>"
+  and is_irq_at_not_masked:
+    "is_irq_at (s :: det_state) irq pos \<Longrightarrow> \<not> irq_masks (machine_state s) irq"
+begin
 
 lemma irq_is_recurring_triv:
-  assumes a:
-  "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
-        f
-       \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s))\<rbrace>"
-  shows
-  "\<lbrace>irq_is_recurring irq and Q\<rbrace> f \<lbrace>\<lambda>_. irq_is_recurring irq\<rbrace>"
-  apply(clarsimp simp: irq_is_recurring_def valid_def)
-  apply(rule use_valid[OF _ is_irq_at_triv[OF a]])
+  assumes a: "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
+                   (f :: ('s state, 'a) nondet_monad)
+                   \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s))\<rbrace>"
+  shows "\<lbrace>irq_is_recurring irq and Q\<rbrace> f \<lbrace>\<lambda>_. irq_is_recurring irq\<rbrace>"
+  apply (clarsimp simp: irq_is_recurring_def valid_def)
+  apply (rule use_valid[OF _ is_irq_at_triv[OF a]])
    apply assumption
   apply simp
   done
 
-lemma domain_sep_inv_refl:
-  "domain_sep_inv irqs st s \<Longrightarrow> domain_sep_inv irqs s s"
-  apply(fastforce simp: domain_sep_inv_def)
-  done
-
 lemma domain_sep_inv_to_interrupt_states_pres:
-  assumes a: "\<And> st. \<lbrace>domain_sep_inv False (st::'z::state_ext state) and P\<rbrace> f \<lbrace>\<lambda>_. domain_sep_inv False st\<rbrace>"
-  shows "\<lbrace>(\<lambda>s. Q (interrupt_states (s::'z::state_ext state))) and P and domain_sep_inv False st\<rbrace> f \<lbrace>\<lambda>_ s. Q (interrupt_states s)\<rbrace>"
-  apply(clarsimp simp: valid_def)
-   apply(erule use_valid)
-   apply(rule hoare_strengthen_post)
-    apply(rule_tac st=s in a)
-   apply(fastforce simp: domain_sep_inv_def)
-  apply(simp add: domain_sep_inv_refl)
+  assumes a: "\<And>st. \<lbrace>domain_sep_inv False (st :: 's state) and P\<rbrace> f \<lbrace>\<lambda>_. domain_sep_inv False st\<rbrace>"
+  shows "\<lbrace>(\<lambda>s. Q (interrupt_states s)) and P and domain_sep_inv False st\<rbrace>
+         f
+         \<lbrace>\<lambda>_ s. Q (interrupt_states s)\<rbrace>"
+  apply (clarsimp simp: valid_def)
+   apply (erule use_valid)
+   apply (rule hoare_strengthen_post)
+    apply (rule_tac st3=s in a)
+   apply (fastforce simp: domain_sep_inv_def)
+  apply (simp add: domain_sep_inv_refl)
   done
 
 lemma only_timer_irq_pres:
-  assumes a:
-  "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
-        f
-       \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s)) \<rbrace>"
+  assumes a: "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
+                   f
+                   \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s))\<rbrace>"
   assumes b:
-  "\<And> st::'z::state_ext state. \<lbrace>domain_sep_inv False st and P\<rbrace> f \<lbrace>\<lambda>_. domain_sep_inv False st\<rbrace>"
+    "\<And>st :: 's state. \<lbrace>domain_sep_inv False st and P\<rbrace> f \<lbrace>\<lambda>_. domain_sep_inv False st\<rbrace>"
   shows
-  "\<lbrace>only_timer_irq irq and Q and P and (\<lambda>s. domain_sep_inv False (st::'z::state_ext state) (s::'z::state_ext state))\<rbrace> f \<lbrace>\<lambda>_. only_timer_irq irq\<rbrace>"
-  apply(clarsimp simp: only_timer_irq_def valid_def)
-  apply(rule conjI)
-   apply(clarsimp)
-   apply(drule spec)
-   apply(erule mp)
-   apply(erule contrapos_pp, erule use_valid, rule domain_sep_inv_to_interrupt_states_pres, rule b, fastforce)
-  apply(erule use_valid[OF _ irq_is_recurring_triv[OF a]])
+    "\<lbrace>only_timer_irq irq and Q and P and (\<lambda>s. domain_sep_inv False (st :: 's state) s)\<rbrace>
+     f
+     \<lbrace>\<lambda>_. only_timer_irq irq\<rbrace>"
+  apply (clarsimp simp: only_timer_irq_def valid_def)
+  apply (rule conjI)
+   apply (clarsimp)
+   apply (drule spec)
+   apply (erule mp)
+   apply (erule contrapos_pp, erule use_valid, rule domain_sep_inv_to_interrupt_states_pres, rule b, fastforce)
+  apply (erule use_valid[OF _ irq_is_recurring_triv[OF a]])
   by simp
 
-definition only_timer_irq_inv :: "10 word \<Rightarrow> 'a::state_ext state \<Rightarrow> 'a state \<Rightarrow> bool" where
+definition only_timer_irq_inv :: "irq \<Rightarrow> 'z :: state_ext state \<Rightarrow> 'z state \<Rightarrow> bool" where
   "only_timer_irq_inv irq st \<equiv> domain_sep_inv False st and only_timer_irq irq"
 
 lemma only_timer_irq_inv_pres:
   assumes a:
-  "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
-        f
-       \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s)) \<rbrace>"
-  assumes b: "\<And>st::'z::state_ext state. \<lbrace>domain_sep_inv False st and P\<rbrace> f \<lbrace>\<lambda>_. domain_sep_inv False st\<rbrace>"
-  shows "\<lbrace>only_timer_irq_inv irq (st::'z::state_ext state) and Q and P\<rbrace> f \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
-  apply(clarsimp simp: only_timer_irq_inv_def valid_def)
-  apply(rule conjI)
-   apply(erule use_valid[OF _ b], simp)
-  apply(erule use_valid[OF _ only_timer_irq_pres[OF a b]])
+    "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
+          f
+          \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s))\<rbrace>"
+  assumes b: "\<And>st :: 's state. \<lbrace>domain_sep_inv False st and P\<rbrace> f \<lbrace>\<lambda>_. domain_sep_inv False st\<rbrace>"
+  shows "\<lbrace>only_timer_irq_inv irq (st :: 's state) and Q and P\<rbrace> f \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
+  apply (clarsimp simp: only_timer_irq_inv_def valid_def)
+  apply (rule conjI)
+   apply (erule use_valid[OF _ b], simp)
+  apply (erule use_valid[OF _ only_timer_irq_pres[OF a b]])
   apply simp
   done
 
 lemma only_timer_irq_inv_domain_sep_inv[intro]:
   "only_timer_irq_inv irq st s \<Longrightarrow> domain_sep_inv False st s"
-  apply(simp add: only_timer_irq_inv_def)
-  done
-
-(* FIXME: repalce Infoflow.do_machine_op_spec_reads_respects' with this *)
-lemma do_machine_op_spec_reads_respects':
-  assumes equiv_dmo:
-   "equiv_valid_inv (equiv_machine_state (aag_can_read aag) And equiv_irq_state)  (equiv_machine_state (aag_can_affect aag l)) Q f"
-  assumes guard:
-    "\<And> s. P s \<Longrightarrow> Q (machine_state s)"
-  shows
-  "spec_reads_respects st aag l P (do_machine_op f)"
-  unfolding do_machine_op_def spec_equiv_valid_def
-  apply(rule equiv_valid_2_guard_imp)
-   apply(rule_tac  R'="\<lambda> rv rv'. equiv_machine_state (aag_can_read aag or aag_can_affect aag l) rv rv' \<and> equiv_irq_state rv rv'" and Q="\<lambda> r s. st = s \<and> Q r" and Q'="\<lambda> r s. Q r" and P="(=) st" and P'="\<top>" in equiv_valid_2_bind)
-       apply(rule gen_asm_ev2_l[simplified K_def pred_conj_def])
-       apply(rule gen_asm_ev2_r')
-       apply(rule_tac R'="\<lambda> (r, ms') (r', ms'').  r = r' \<and> equiv_machine_state (aag_can_read aag)  ms' ms'' \<and> equiv_machine_state (aag_can_affect aag l) ms' ms'' \<and> equiv_irq_state ms' ms''" and Q="\<lambda> r s. st = s" and Q'="\<top>\<top>" and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
-            apply(clarsimp simp: modify_def get_def put_def bind_def return_def equiv_valid_2_def)
-            apply(fastforce intro: reads_equiv_machine_state_update affects_equiv_machine_state_update)
-            apply(insert equiv_dmo)[1]
-           apply(clarsimp simp: select_f_def equiv_valid_2_def equiv_valid_def2 equiv_for_or simp: split_def split: prod.splits simp: equiv_for_def)[1]
-           apply(drule_tac x=rv in spec, drule_tac x=rv' in spec)
-           apply(fastforce)
-          apply(rule select_f_inv)
-         apply(rule wp_post_taut)
-        apply simp+
-      apply(clarsimp simp: equiv_valid_2_def in_monad)
-      apply(fastforce elim: reads_equivE affects_equivE equiv_forE intro: equiv_forI)
-     apply(wp | simp add: guard)+
-  done
-
-lemma is_irq_at_not_masked:
-  "is_irq_at s irq pos \<Longrightarrow> \<not> irq_masks (machine_state s) irq"
-  apply(clarsimp simp: is_irq_at_def irq_at_def split: option.splits simp: Let_def split: if_splits)
-  done
-
+  by (simp add: only_timer_irq_inv_def)
 
 lemma irq_is_recurring_not_masked:
-  "irq_is_recurring irq s \<Longrightarrow> \<not> irq_masks (machine_state s) irq"
-  apply(clarsimp simp: irq_is_recurring_def)
-  apply(blast dest: is_irq_at_not_masked)
+  "irq_is_recurring irq (s :: det_state) \<Longrightarrow> \<not> irq_masks (machine_state s) irq"
+  apply (clarsimp simp: irq_is_recurring_def)
+  apply (blast dest: is_irq_at_not_masked)
   done
 
 lemma only_timer_irq_inv_determines_irq_masks:
-  "\<lbrakk>invs s; only_timer_irq_inv irq st s\<rbrakk> \<Longrightarrow>
+  "\<lbrakk>invs (s :: det_state); only_timer_irq_inv irq st s\<rbrakk> \<Longrightarrow>
    \<not> irq_masks (machine_state s) irq \<and>
    (\<forall>x. x \<noteq> irq \<longrightarrow> irq_masks (machine_state s) x)"
-  apply(rule conjI)
-   apply(clarsimp simp: only_timer_irq_inv_def only_timer_irq_def)
-   apply(blast dest: irq_is_recurring_not_masked)
-  apply(clarsimp simp: only_timer_irq_inv_def domain_sep_inv_def only_timer_irq_def)
-  apply(case_tac "interrupt_states s x")
-    apply(fastforce simp: invs_def valid_state_def valid_irq_states_def valid_irq_masks_def)
+  apply (rule conjI)
+   apply (clarsimp simp: only_timer_irq_inv_def only_timer_irq_def)
+   apply (blast dest: irq_is_recurring_not_masked)
+  apply (clarsimp simp: only_timer_irq_inv_def domain_sep_inv_def only_timer_irq_def)
+  apply (case_tac "interrupt_states s x")
+    apply (fastforce simp: invs_def valid_state_def valid_irq_states_def valid_irq_masks_def)
    apply fastforce+
-  done
-
-lemma gets_irq_masks_equiv_valid:
-  "equiv_valid_inv I A (\<lambda>s. \<not> (irq_masks s) irq \<and> (\<forall>x. x \<noteq> irq \<longrightarrow> (irq_masks s) x)) (gets irq_masks)"
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def in_monad)
-  apply(auto)
-  done
-
-lemma irq_state_increment_reads_respects_memory:
-  "equiv_valid_inv
-          (equiv_machine_state (\<lambda>x. aag_can_read_label aag (pasObjectAbs aag x))
-            And
-           equiv_irq_state)
-          (equiv_for
-            (\<lambda>x. aag_can_affect_label aag l \<and>
-                 pasObjectAbs aag x \<in> subjectReads (pasPolicy aag) l)
-            underlying_memory)  \<top> (modify (\<lambda>s. s\<lparr>irq_state := Suc (irq_state s)\<rparr>))"
-  apply(simp add: equiv_valid_def2)
-  apply(rule modify_ev2)
-  apply(fastforce intro: equiv_forI elim: equiv_forE)
-  done
-
-lemma irq_state_increment_reads_respects_device:
-  "equiv_valid_inv
-          (equiv_machine_state (\<lambda>x. aag_can_read_label aag (pasObjectAbs aag x))
-            And
-           equiv_irq_state)
-          (equiv_for
-            (\<lambda>x. aag_can_affect_label aag l \<and>
-                 pasObjectAbs aag x \<in> subjectReads (pasPolicy aag) l)
-            device_state)  \<top> (modify (\<lambda>s. s\<lparr>irq_state := Suc (irq_state s)\<rparr>))"
-  apply(simp add: equiv_valid_def2)
-  apply(rule modify_ev2)
-  apply(fastforce intro: equiv_forI elim: equiv_forE)
-  done
-
-lemma use_equiv_valid_inv:
-  "\<lbrakk>x\<in>fst (f st); y\<in> fst (f s); g s; g st;I s st;P s st; equiv_valid_inv I P g f \<rbrakk>
-  \<Longrightarrow> fst x = fst y \<and> P (snd y) (snd x) \<and> I (snd y) (snd x)"
- apply (clarsimp simp add: equiv_valid_def spec_equiv_valid_def equiv_valid_2_def)
- apply (drule spec)+
- apply (erule impE)
- apply fastforce
- apply (drule(1) bspec | clarsimp)+
- done
-
-lemma equiv_valid_inv_conj_lift:
- assumes P: "equiv_valid_inv I (\<lambda>s s'. P s s') g f"
-     and P': "equiv_valid_inv I (\<lambda>s s'. P' s s') g f"
- shows "equiv_valid_inv I (\<lambda>s s'. P s s' \<and> P' s s') g f"
- apply (clarsimp simp add: equiv_valid_def spec_equiv_valid_def equiv_valid_2_def)
- apply (frule_tac st = t and s = st in use_equiv_valid_inv[OF _ _ _ _ _ _ P])
-  apply fastforce+
- apply (frule_tac st = t and s = st in use_equiv_valid_inv[OF _ _ _ _ _ _ P'])
-  apply fastforce+
- done
-
-lemma dmo_getActiveIRQ_reads_respects:
-  notes gets_ev[wp del]
-  shows
-  "reads_respects aag l (invs and only_timer_irq_inv irq st) (do_machine_op (getActiveIRQ in_kernel))"
-  apply(rule use_spec_ev)
-  apply(rule do_machine_op_spec_reads_respects')
-   apply(simp add: getActiveIRQ_def)
-   apply (wp irq_state_increment_reads_respects_memory irq_state_increment_reads_respects_device
-             gets_ev[where f="irq_oracle \<circ> irq_state"] equiv_valid_inv_conj_lift
-             gets_irq_masks_equiv_valid modify_wp
-         | simp add: no_irq_def)+
-  apply(rule only_timer_irq_inv_determines_irq_masks, blast+)
   done
 
 lemma dmo_getActiveIRQ_globals_equiv:
   "\<lbrace>globals_equiv st\<rbrace> do_machine_op (getActiveIRQ in_kernel) \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (wp dmo_getActiveIRQ_wp)
-  apply(auto simp: globals_equiv_def idle_equiv_def)
+  apply (auto simp: globals_equiv_def idle_equiv_def)
   done
 
-lemma dmo_getActiveIRQ_reads_respects_g :
-  "reads_respects_g aag l (invs and only_timer_irq_inv irq st) (do_machine_op (getActiveIRQ in_kernel))"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_g])
-    apply(rule dmo_getActiveIRQ_reads_respects)
-   apply(rule doesnt_touch_globalsI)
-   apply(wp dmo_getActiveIRQ_globals_equiv | blast)+
+crunches reset_work_units, work_units_limit_reached, update_work_units
+  for only_timer_irq_inv[wp]: "only_timer_irq_inv irq st"
+  (simp: only_timer_irq_inv_def only_timer_irq_def irq_is_recurring_def is_irq_at_def)
+
+end
+
+
+lemma gets_irq_masks_equiv_valid:
+  "equiv_valid_inv I A (\<lambda>s. \<not> (irq_masks s) irq \<and> (\<forall>x. x \<noteq> irq \<longrightarrow> (irq_masks s) x)) (gets irq_masks)"
+  by (fastforce simp: equiv_valid_def2 equiv_valid_2_def in_monad)
+
+lemma irq_state_increment_reads_respects_memory:
+  "equiv_valid_inv (equiv_machine_state P And equiv_irq_state)
+                   (equiv_for (\<lambda>x. aag_can_affect_label aag l \<and>
+                                   pasObjectAbs aag x \<in> subjectReads (pasPolicy aag) l)
+                              underlying_memory)
+                   \<top> (modify (\<lambda>s. s\<lparr>irq_state := Suc (irq_state s)\<rparr>))"
+  apply (simp add: equiv_valid_def2)
+  apply (rule modify_ev2)
+  apply (fastforce intro: equiv_forI elim: equiv_forE)
+  done
+
+lemma irq_state_increment_reads_respects_device:
+  "equiv_valid_inv (equiv_machine_state P And equiv_irq_state)
+                   (equiv_for (\<lambda>x. aag_can_affect_label aag l \<and>
+                                   pasObjectAbs aag x \<in> subjectReads (pasPolicy aag) l)
+                              device_state)
+                   \<top> (modify (\<lambda>s. s\<lparr>irq_state := Suc (irq_state s)\<rparr>))"
+  apply (simp add: equiv_valid_def2)
+  apply (rule modify_ev2)
+  apply (fastforce intro: equiv_forI elim: equiv_forE)
+  done
+
+lemma use_equiv_valid_inv:
+  "\<lbrakk> x \<in> fst (f st); y \<in> fst (f s); g s; g st; I s st; P s st; equiv_valid_inv I P g f \<rbrakk>
+     \<Longrightarrow> fst x = fst y \<and> P (snd y) (snd x) \<and> I (snd y) (snd x)"
+  apply (clarsimp simp add: equiv_valid_def spec_equiv_valid_def equiv_valid_2_def)
+  apply (drule spec)+
+  apply (erule impE)
+   apply fastforce
+  apply (drule(1) bspec | clarsimp)+
+  done
+
+lemma equiv_valid_inv_conj_lift:
+  assumes P: "equiv_valid_inv I (\<lambda>s s'. P s s') g f"
+      and P': "equiv_valid_inv I (\<lambda>s s'. P' s s') g f"
+  shows "equiv_valid_inv I (\<lambda>s s'. P s s' \<and> P' s s') g f"
+  apply (clarsimp simp add: equiv_valid_def spec_equiv_valid_def equiv_valid_2_def)
+  apply (frule_tac st = t and s = st in use_equiv_valid_inv[OF _ _ _ _ _ _ P])
+       apply fastforce+
+  apply (frule_tac st = t and s = st in use_equiv_valid_inv[OF _ _ _ _ _ _ P'])
+       apply fastforce+
   done
 
 lemma reset_work_units_reads_respects[wp]:
@@ -961,47 +560,51 @@ lemma work_units_limit_reached_reads_respects[wp]:
   apply force
   done
 
-crunches reset_work_units, work_units_limit_reached, update_work_units
-     for only_timer_irq_inv[wp]: "only_timer_irq_inv irq st"
-  (simp: only_timer_irq_inv_def only_timer_irq_def irq_is_recurring_def is_irq_at_def)
-
 crunch invs[wp]: work_units_limit_reached invs
 
-lemma preemption_point_reads_respects:
-  "reads_respects aag l (invs and only_timer_irq_inv irq st) preemption_point"
-  apply (simp add: preemption_point_def2)
-  apply (wp | wpc | simp add: comp_def)+
-            apply ((wp dmo_getActiveIRQ_reads_respects hoare_TrueI | simp
-                  | wp (once) hoare_drop_imps)+)[8]
-   apply wp
-  apply force
+lemma preemption_point_def2:
+  "(preemption_point :: (unit,det_ext) p_monad) =
+   doE liftE update_work_units;
+       rv \<leftarrow> liftE work_units_limit_reached;
+       if rv then doE liftE reset_work_units;
+                      liftE (do_machine_op (getActiveIRQ True)) >>=E
+                      case_option (returnOk ()) (K (throwError $ ()))
+                  odE
+       else returnOk()
+   odE"
+  apply (rule ext)
+  apply (simp add: preemption_point_def OR_choiceE_def wrap_ext_bool_det_ext_ext_def
+                   ef_mk_ef work_units_limit_reached_def select_f_def)
+  apply (clarsimp simp: work_units_limit_reached_def gets_def liftE_def select_f_def get_def
+                        lift_def return_def bind_def bindE_def split_def image_def
+                 split: option.splits sum.splits)
   done
 
 lemma all_children_descendants_equal:
-  "\<lbrakk>equiv_for P id s t; all_children P s; all_children P t; P slot\<rbrakk>
-   \<Longrightarrow> descendants_of slot s = descendants_of slot t"
-  apply(clarsimp | rule equalityI)+
-   apply(frule_tac p="(a, b)" and q="slot" and m=s in all_children_descendants_of)
-     apply(simp)+
-   apply(simp add: descendants_of_def cdt_parent_rel_def is_cdt_parent_def)
-   apply(rule_tac r'="{(p, c). s c = Some p}" and Q="P" in trancl_subset_equivalence)
-     apply(clarsimp)+
-    apply(frule_tac p="(aa, ba)" and q="slot" in all_children_descendants_of)
-      apply(fastforce simp: descendants_of_def cdt_parent_rel_def is_cdt_parent_def)+
-   apply(fastforce simp: equiv_for_def)
-  apply(clarsimp)
-  apply(frule_tac p="(a, b)" and q="slot" and m=t in all_children_descendants_of)
-    apply(simp)+
-  apply(simp add: descendants_of_def cdt_parent_rel_def is_cdt_parent_def)
-  apply(rule_tac r'="{(p, c). t c = Some p}" and Q="P" in trancl_subset_equivalence)
-    apply(clarsimp)+
-   apply(frule_tac p="(aa, ba)" and q="slot" and m=t in all_children_descendants_of)
-     apply(fastforce simp: equiv_for_def descendants_of_def cdt_parent_rel_def is_cdt_parent_def)+
+  "\<lbrakk> equiv_for P id s t; all_children P s; all_children P t; P slot \<rbrakk>
+     \<Longrightarrow> descendants_of slot s = descendants_of slot t"
+  apply (clarsimp | rule equalityI)+
+   apply (frule_tac p="(a, b)" and q="slot" and m=s in all_children_descendants_of)
+     apply (simp)+
+   apply (simp add: descendants_of_def cdt_parent_rel_def is_cdt_parent_def)
+   apply (rule_tac r'="{(p, c). s c = Some p}" and Q="P" in trancl_subset_equivalence)
+     apply (clarsimp)+
+    apply (frule_tac p="(aa, ba)" and q="slot" in all_children_descendants_of)
+      apply (fastforce simp: descendants_of_def cdt_parent_rel_def is_cdt_parent_def)+
+   apply (fastforce simp: equiv_for_def)
+  apply (clarsimp)
+  apply (frule_tac p="(a, b)" and q="slot" and m=t in all_children_descendants_of)
+    apply (simp)+
+  apply (simp add: descendants_of_def cdt_parent_rel_def is_cdt_parent_def)
+  apply (rule_tac r'="{(p, c). t c = Some p}" and Q="P" in trancl_subset_equivalence)
+    apply (clarsimp)+
+   apply (frule_tac p="(aa, ba)" and q="slot" and m=t in all_children_descendants_of)
+     apply (fastforce simp: equiv_for_def descendants_of_def cdt_parent_rel_def is_cdt_parent_def)+
   done
 
 lemma cca_can_read:
-  "\<lbrakk>valid_mdb s; valid_objs s; cdt_change_allowed' aag slot s; pas_refined aag s\<rbrakk>
-    \<Longrightarrow> aag_can_read aag (fst slot)"
+  "\<lbrakk> valid_mdb s; valid_objs s; cdt_change_allowed' aag slot s; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> aag_can_read aag (fst slot)"
   apply (frule(3) cdt_change_allowed_delete_derived)
   by (rule read_delder_thread_read_thread_rev[OF reads_lrefl])
 
@@ -1013,8 +616,8 @@ lemma all_children_subjectReads:
   by (rule aag_cdt_link_DeleteDerived)
 
 lemma descendants_of_eq:
-  "\<lbrakk>reads_equiv aag s t; affects_equiv aag l s t; pas_refined aag s;
-    pas_refined aag t; is_subject aag (fst slot)\<rbrakk>
+  "\<lbrakk> reads_equiv aag s t; affects_equiv aag l s t;
+     pas_refined aag s; pas_refined aag t; is_subject aag (fst slot) \<rbrakk>
    \<Longrightarrow> descendants_of slot (cdt s) = descendants_of slot (cdt t)"
   apply (rule all_children_descendants_equal[OF _ all_children_subjectReads all_children_subjectReads])
      apply (elim reads_equivE)
@@ -1025,31 +628,57 @@ lemma gets_descendants_of_revrv:
   "reads_equiv_valid_rv_inv (affects_equiv aag l) aag (=)
                             (pas_refined aag and K (is_subject aag (fst slot)))
                             (gets (descendants_of slot \<circ> cdt))"
-  apply(rule gets_evrv'')
+  apply (rule gets_evrv'')
   apply clarsimp
   by (rule descendants_of_eq)
 
-lemma silc_dom_equiv_trans:
-  "\<lbrakk>silc_dom_equiv aag s t; silc_dom_equiv aag t u\<rbrakk> \<Longrightarrow> silc_dom_equiv aag s u"
+lemma silc_dom_equiv_trans[elim]:
+  "\<lbrakk> silc_dom_equiv aag s t; silc_dom_equiv aag t u \<rbrakk>
+     \<Longrightarrow> silc_dom_equiv aag s u"
   by (auto simp: silc_dom_equiv_def elim: equiv_for_trans)
 
-lemma silc_dom_equiv_sym:
-  "\<lbrakk>silc_dom_equiv aag s t\<rbrakk> \<Longrightarrow> silc_dom_equiv aag t s"
+lemma silc_dom_equiv_sym[elim]:
+  "silc_dom_equiv aag s t \<Longrightarrow> silc_dom_equiv aag t s"
   by (auto simp: silc_dom_equiv_def elim: equiv_for_sym)
 
 lemma reads_respects_f:
-  "\<lbrakk>reads_respects aag l P f; \<lbrace>silc_inv aag st and Q\<rbrace> f \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>\<rbrakk> \<Longrightarrow>
-   reads_respects_f aag l (silc_inv aag st and P and Q) f"
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def reads_equiv_f_def)
-  apply(rule conjI, fastforce)
-  apply(rule conjI, fastforce)
-  apply(subst conj_commute, rule conjI, fastforce)
-  apply(rule silc_dom_equiv_trans)
-   apply(rule silc_dom_equiv_sym)
-   apply(rule silc_inv_silc_dom_equiv)
-   apply(erule (1) use_valid, simp)
-  apply(rule silc_inv_silc_dom_equiv)
-  apply(erule (1) use_valid, simp)
+  "\<lbrakk> reads_respects aag l P f; \<lbrace>silc_inv aag st and Q\<rbrace> f \<lbrace>\<lambda>_. silc_inv aag st\<rbrace> \<rbrakk>
+     \<Longrightarrow> reads_respects_f aag l (silc_inv aag st and P and Q) f"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def reads_equiv_f_def)
+  apply (rule conjI, fastforce)
+  apply (rule conjI, fastforce)
+  apply (subst conj_commute, rule conjI, fastforce)
+  apply (rule silc_dom_equiv_trans)
+   apply (rule silc_dom_equiv_sym)
+   apply (rule silc_inv_silc_dom_equiv)
+   apply (erule (1) use_valid, simp)
+  apply (rule silc_inv_silc_dom_equiv)
+  apply (erule (1) use_valid, simp)
+  done
+
+
+locale CNode_IF_3 = CNode_IF_2 +
+  fixes aag :: "'a subject_label PAS"
+  assumes dmo_getActiveIRQ_reads_respects:
+    "reads_respects aag l (invs and only_timer_irq_inv irq st) (do_machine_op (getActiveIRQ in_kernel))"
+begin
+
+lemma dmo_getActiveIRQ_reads_respects_g :
+  "reads_respects_g aag l (invs and only_timer_irq_inv irq st) (do_machine_op (getActiveIRQ in_kernel))"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule dmo_getActiveIRQ_reads_respects)
+   apply (rule doesnt_touch_globalsI)
+   apply (wp dmo_getActiveIRQ_globals_equiv | blast)+
+  done
+
+lemma preemption_point_reads_respects:
+  "reads_respects aag l (invs and only_timer_irq_inv irq st) preemption_point"
+  apply (simp add: preemption_point_def2)
+  apply (wp | wpc | simp add: comp_def)+
+           apply ((wp dmo_getActiveIRQ_reads_respects hoare_TrueI | simp
+                   | wp (once) hoare_drop_imps)+)[8]
+   apply wp
+  apply force
   done
 
 lemma preemption_point_reads_respects_f:
@@ -1060,9 +689,13 @@ lemma preemption_point_reads_respects_f:
    apply (wp, force+)
   done
 
+end
+
+
 abbreviation
-  reads_spec_equiv_valid_f :: "det_state \<Rightarrow> (det_state \<Rightarrow> det_state \<Rightarrow> bool) \<Rightarrow> (det_state \<Rightarrow> det_state \<Rightarrow> bool) \<Rightarrow> 'a subject_label PAS \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool"
-where
+  reads_spec_equiv_valid_f ::
+    "det_state \<Rightarrow> (det_state \<Rightarrow> det_state \<Rightarrow> bool) \<Rightarrow> (det_state \<Rightarrow> det_state \<Rightarrow> bool) \<Rightarrow>
+    'a subject_label PAS \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow> (det_state, 'b) nondet_monad \<Rightarrow> bool" where
   "reads_spec_equiv_valid_f s A B aag P f \<equiv> spec_equiv_valid s (reads_equiv_f aag) A B P f"
 
 abbreviation reads_spec_equiv_valid_f_inv
@@ -1070,83 +703,80 @@ where
   "reads_spec_equiv_valid_f_inv s A aag P f \<equiv> reads_spec_equiv_valid_f s A A aag P f"
 
 abbreviation
-  spec_reads_respects_f :: "det_state \<Rightarrow> 'a subject_label PAS \<Rightarrow> 'a subject_label \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool"
-where
+  spec_reads_respects_f :: "det_state \<Rightarrow> 'a subject_label PAS \<Rightarrow> 'a subject_label \<Rightarrow>
+                            (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool" where
   "spec_reads_respects_f s aag l P f \<equiv> reads_spec_equiv_valid_f_inv s (affects_equiv aag l) aag P f"
 
 definition reads_equiv_f_g where
   "reads_equiv_f_g aag s s' \<equiv> reads_equiv aag s s' \<and> globals_equiv s s' \<and> silc_dom_equiv aag s s'"
 
-abbreviation reads_respects_f_g :: "'a subject_label PAS \<Rightarrow> 'a subject_label \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool"
-where
+abbreviation reads_respects_f_g :: "'a subject_label PAS \<Rightarrow> 'a subject_label \<Rightarrow>
+                                    (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool" where
 "reads_respects_f_g aag l P f \<equiv>
    equiv_valid_inv (reads_equiv_f_g aag) (affects_equiv aag l) P f"
 
 lemma reads_equiv_f_g_conj:
   "reads_equiv_f_g aag s s' \<equiv> reads_equiv_f aag s s' \<and> reads_equiv_g aag s s'"
-  apply(simp add: reads_equiv_f_g_def reads_equiv_f_def reads_equiv_g_def conj_comms)
-  done
+  by (simp add: reads_equiv_f_g_def reads_equiv_f_def reads_equiv_g_def conj_comms)
 
 lemma reads_respects_f_g:
-  "\<lbrakk>reads_respects_f aag l P f; doesnt_touch_globals Q f\<rbrakk> \<Longrightarrow>
-   reads_respects_f_g aag l (P and Q) f"
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
-  apply(subst (asm) reads_equiv_f_g_conj, erule conjE)
-  apply(subst reads_equiv_f_g_conj)
-  apply(drule reads_equiv_gD)
+  "\<lbrakk> reads_respects_f aag l P f; doesnt_touch_globals Q f \<rbrakk>
+     \<Longrightarrow> reads_respects_f_g aag l (P and Q) f"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (subst (asm) reads_equiv_f_g_conj, erule conjE)
+  apply (subst reads_equiv_f_g_conj)
+  apply (drule reads_equiv_gD)
   apply clarsimp
-  apply(subgoal_tac "reads_equiv_g aag b ba", blast)
-  apply(subgoal_tac "globals_equiv b ba", fastforce intro: reads_equiv_gI simp: reads_equiv_f_def)
-  apply(rule globals_equiv_trans)
-   apply(rule globals_equiv_sym)
-   apply(fastforce intro: globals_equivI)
-  apply(rule globals_equiv_trans)
-   apply(assumption)
-  apply(fastforce intro: globals_equivI)
+  apply (subgoal_tac "reads_equiv_g aag b ba", blast)
+  apply (subgoal_tac "globals_equiv b ba", fastforce intro: reads_equiv_gI simp: reads_equiv_f_def)
+  apply (rule globals_equiv_trans)
+   apply (rule globals_equiv_sym)
+   apply (fastforce intro: globals_equivI)
+  apply (rule globals_equiv_trans)
+   apply (assumption)
+  apply (fastforce intro: globals_equivI)
   done
 
 lemma reads_equiv_valid_rv_inv_f:
   assumes a: "reads_equiv_valid_rv_inv A aag R P f"
-  assumes b: "\<And> P. \<lbrace> P \<rbrace> f \<lbrace>\<lambda>_. P \<rbrace>"
+  assumes b: "\<And>P. \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. P\<rbrace>"
   shows "equiv_valid_rv_inv (reads_equiv_f aag) A R P f"
-  apply(clarsimp simp: equiv_valid_2_def reads_equiv_f_def)
-  apply(insert a, clarsimp simp: equiv_valid_2_def)
-  apply(drule_tac x=s in spec, drule_tac x=t in spec, clarsimp)
-  apply(drule (1) bspec, clarsimp)
-  apply(drule (1) bspec, clarsimp)
-  apply(drule state_unchanged[OF b])+
+  apply (clarsimp simp: equiv_valid_2_def reads_equiv_f_def)
+  apply (insert a, clarsimp simp: equiv_valid_2_def)
+  apply (drule_tac x=s in spec, drule_tac x=t in spec, clarsimp)
+  apply (drule (1) bspec, clarsimp)
+  apply (drule (1) bspec, clarsimp)
+  apply (drule state_unchanged[OF b])+
   by simp
 
-
 lemma set_cap_silc_inv':
-  "\<lbrace>silc_inv aag st and (((\<lambda>s. \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst slot)) \<longrightarrow>
-              (\<exists>lslot.
-                  lslot \<in> slots_holding_overlapping_caps cap s \<and>
-                  pasObjectAbs aag (fst lslot) = SilcLabel)) and
-         K (pasObjectAbs aag (fst slot) \<noteq> SilcLabel)))\<rbrace> set_cap cap slot
+  "\<lbrace>silc_inv aag st and (\<lambda>s. \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst slot))
+                             \<longrightarrow> (\<exists>lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
+                                          pasObjectAbs aag (fst lslot) = SilcLabel))
+                    and K (pasObjectAbs aag (fst slot) \<noteq> SilcLabel)\<rbrace>
+   set_cap cap slot
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(rule hoare_pre)
-   apply(rule set_cap_silc_inv)
+  apply (rule hoare_pre)
+   apply (rule set_cap_silc_inv)
   by blast
 
 lemma set_cap_reads_respects_f:
-  "reads_respects_f aag l (silc_inv aag st and
-         (\<lambda>s. \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst slot)) \<longrightarrow>
-               (\<exists>lslot.
-                   lslot \<in> slots_holding_overlapping_caps cap s \<and>
-                   pasObjectAbs aag (fst lslot) = SilcLabel)) and
-         K (is_subject aag (fst slot))) (set_cap cap slot)"
-  apply(rule equiv_valid_guard_imp)
-   apply(rule reads_respects_f[OF set_cap_reads_respects, OF set_cap_silc_inv'])
-  apply(auto simp: silc_inv_def)
+  "reads_respects_f aag l
+     (silc_inv aag st and (\<lambda>s. \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst slot))
+                               \<longrightarrow> (\<exists>lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
+                                            pasObjectAbs aag (fst lslot) = SilcLabel))
+                      and K (is_subject aag (fst slot))) (set_cap cap slot)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_f[OF set_cap_reads_respects])
+   apply (wp set_cap_silc_inv')
+   apply (auto simp: silc_inv_def)
   done
 
 lemma select_ext_ev:
-  "(\<And>s t. I s t \<Longrightarrow> A s t \<Longrightarrow> a s \<in> S \<Longrightarrow> a t \<in> S \<Longrightarrow> a s = a t) \<Longrightarrow> equiv_valid_inv I A (\<top> :: det_ext state \<Rightarrow> bool) (select_ext a S)"
+  "(\<And>s t. I s t \<Longrightarrow> A s t \<Longrightarrow> a s \<in> S \<Longrightarrow> a t \<in> S \<Longrightarrow> a s = a t)
+   \<Longrightarrow> equiv_valid_inv I A (\<top> :: det_state \<Rightarrow> bool) (select_ext a S)"
   apply (clarsimp simp: select_ext_def gets_def get_def assert_def return_def bind_def)
   apply (simp add: equiv_valid_def2 equiv_valid_2_def return_def fail_def)
   done
-
-end
 
 end

--- a/proof/infoflow/Decode_IF.thy
+++ b/proof/infoflow/Decode_IF.thy
@@ -5,118 +5,75 @@
  *)
 
 theory Decode_IF
-imports Ipc_IF
+imports ArchIpc_IF
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-lemma data_to_obj_type_rev:
-  "reads_equiv_valid_inv A aag \<top> (data_to_obj_type type)"
-  unfolding data_to_obj_type_def fun_app_def arch_data_to_obj_type_def
-  apply (wp | wpc)+
-  apply simp
-  done
-
 
 lemma ensure_empty_rev:
   "reads_equiv_valid_inv A aag (K (is_subject aag (fst slot))) (ensure_empty slot)"
   unfolding ensure_empty_def fun_app_def
-  apply (wp get_cap_rev | simp)+
-  done
-
+  by (wp get_cap_rev | simp)+
 
 lemma prop_of_obj_ref_of_cnode_cap:
-  "\<lbrakk>is_cnode_cap cap; \<forall>r\<in>obj_refs cap. P r\<rbrakk> \<Longrightarrow> P (obj_ref_of cap)"
-  by(case_tac cap, simp_all)
+  "\<lbrakk> is_cnode_cap cap; \<forall>r\<in>obj_refs cap. P r \<rbrakk>
+     \<Longrightarrow> P (obj_ref_of cap)"
+  by (case_tac cap, simp_all)
 
-
-lemma decode_untyped_invocation_rev:
-  "reads_equiv_valid_inv A aag (pas_refined aag and
-                                (K (cap = UntypedCap dev bs sz idx \<and>
-                                    is_subject aag (fst slot) \<and>
-                                    (\<forall>c\<in>set excaps. pas_cap_cur_auth aag c))))
-        (decode_untyped_invocation label args slot cap excaps)"
-  unfolding decode_untyped_invocation_def fun_app_def
-  apply(rule gen_asm_ev)
-  apply(simp add: unlessE_def[symmetric] unlessE_whenE
-       split del: if_split)
-  apply (wp (once) whenE_throwError_wp
-       | wp mapME_x_ev' ensure_empty_rev get_cap_rev
-             lookup_slot_for_cnode_op_rev
-             ensure_no_children_rev
-             const_on_failure_ev mapME_x_inv_wp
-       | assumption
-       | simp
-       | rule validE_R_validE | strengthen aag_can_read_self)+
-                  apply(rule hoare_strengthen_post[
-                                  where Q="\<lambda> rv s. (is_cnode_cap rv
-                                                         \<longrightarrow> is_subject aag (obj_ref_of rv))
-                                                 \<and> pas_refined aag s"])
-                   apply(wp (once) whenE_throwError_wp
-                        |wp get_cap_ret_is_subject
-                            data_to_obj_type_rev data_to_obj_type_inv
-                        | simp
-                        | wp (once) hoare_drop_imps)+
-  apply(clarify, drule_tac x="excaps ! 0" in bspec, fastforce intro: bang_0_in_set)
-  apply(auto dest: is_cnode_into_is_subject elim: prop_of_obj_ref_of_cnode_cap)
+lemma get_irq_state_rev:
+  "reads_equiv_valid_inv A aag (K (is_subject_irq aag irq)) (get_irq_state irq)"
+  unfolding get_irq_state_def
+  apply (rule equiv_valid_guard_imp[OF gets_ev])
+  apply (fastforce simp: reads_equiv_def2
+                   elim: states_equiv_forE_interrupt_states
+                  intro: aag_can_read_irq_self)
   done
 
-lemma derive_cap_rev':
-  "reads_equiv_valid_inv A aag (\<lambda> s. (\<exists>x xa xb dev. cap = cap.UntypedCap dev x xa xb) \<longrightarrow>
-         pas_refined aag s \<and> is_subject aag (fst slot)) (derive_cap slot cap)"
-  unfolding derive_cap_def arch_derive_cap_def
-  apply(rule equiv_valid_guard_imp)
-  apply(wp ensure_no_children_rev | wpc | simp)+
-  done
-
-lemma derive_cap_rev:
-  "reads_equiv_valid_inv A aag (\<lambda> s. pas_refined aag s \<and> is_subject aag (fst slot)) (derive_cap slot cap)"
-  by(blast intro: equiv_valid_guard_imp[OF derive_cap_rev'])
+lemma is_irq_active_rev:
+  "reads_equiv_valid_inv A aag (K (is_subject_irq aag irq)) (is_irq_active irq)"
+  unfolding is_irq_active_def fun_app_def
+  by (wp get_irq_state_rev)
 
 (* FIXME: move *)
 lemma if_apply_ev:
   "equiv_valid I A B P (if a then b x  else c x) \<Longrightarrow>
    equiv_valid I A B P ((if a then b else c) x)"
-  by(simp split: if_split_asm)
+  by (simp split: if_split_asm)
 
 lemma whenE_throwError_bindE_ev:
   assumes ev: "\<not> b \<Longrightarrow> equiv_valid I A A P f"
   shows "equiv_valid I A A P (whenE b (throwError x) >>=E (\<lambda>_. f))"
-  apply(rule_tac Q="\<lambda> rv s. \<not> b \<and> P s" in bindE_ev_pre)
-     using ev apply(fastforce simp: equiv_valid_def2 equiv_valid_2_def)
-    apply(wp whenE_throwError_sp)+
+  apply (rule_tac Q="\<lambda> rv s. \<not> b \<and> P s" in bindE_ev_pre)
+     using ev apply (fastforce simp: equiv_valid_def2 equiv_valid_2_def)
+    apply (wp whenE_throwError_sp)+
   by simp
 
 lemma expand_len_gr_Suc_0:
   "Suc 0 < length xs = (xs \<noteq> [] \<and> Suc (Suc 0) \<le> length xs)"
-  apply fastforce
-  done
+  by fastforce
 
 (* FIXME: remove *)
 lemmas hoare_vcg_imp_lift_R = hoare_vcg_const_imp_lift_R
 
 lemma decode_cnode_invocation_rev:
-  "reads_equiv_valid_inv A aag (pas_refined aag and
-                                K (\<forall>c\<in>{cap} \<union> set excaps. pas_cap_cur_auth aag c))
+  "reads_equiv_valid_inv A (aag :: 'a subject_label PAS)
+     (pas_refined aag and K (\<forall>c \<in> {cap} \<union> set excaps. pas_cap_cur_auth aag c))
      (decode_cnode_invocation label args cap excaps)"
   unfolding decode_cnode_invocation_def fun_app_def
   apply (rule equiv_valid_guard_imp)
   apply (simp add: unlessE_whenE)
   apply wp
-  apply ((wp if_apply_ev derive_cap_rev whenE_inv hoare_vcg_imp_lift_R
-            lookup_slot_for_cnode_op_rev hoare_vcg_all_lift_R
-            lookup_slot_for_cnode_op_authorised ensure_empty_rev get_cap_rev
-        | simp add: split_def unlessE_whenE split del: if_split
-               del: hoare_True_E_R
-        | wpc
-        | (wp (once) hoare_drop_imps, wp (once) lookup_slot_for_cnode_op_authorised)
-        | strengthen aag_can_read_self)+)
+  apply (wp if_apply_ev derive_cap_rev whenE_inv hoare_vcg_imp_lift_R
+             lookup_slot_for_cnode_op_rev hoare_vcg_all_lift_R
+             lookup_slot_for_cnode_op_authorised ensure_empty_rev get_cap_rev
+         | simp add: split_def unlessE_whenE split del: if_split del: hoare_True_E_R
+         | wpc
+         | wp (once) hoare_drop_imps, wp (once) lookup_slot_for_cnode_op_authorised
+         | strengthen aag_can_read_self)+
   apply clarsimp
   apply (cases excaps; cases "tl excaps"; clarsimp)
     apply (auto dest: bspec[where x="excaps ! 0"] bspec[where x="excaps ! Suc 0"]
                       is_cnode_into_is_subject
                intro: nth_mem elim: prop_of_obj_ref_of_cnode_cap
-               simp: expand_len_gr_Suc_0)
+                simp: expand_len_gr_Suc_0)
   done
 
 lemma range_check_ev:
@@ -127,54 +84,37 @@ lemma range_check_ev:
   apply simp
   done
 
-
-(* FIXME: move *)
-lemma cte_wp_at_caps_of_state:
-  "cte_wp_at ((=) c) slot s \<Longrightarrow> caps_of_state s slot = Some c"
-  by(simp add: caps_of_state_def cte_wp_at_def)
-
 (* FIXME: move *)
 lemma aag_has_auth_to_obj_refs_of_owned_cap:
-  "\<lbrakk>pas_refined aag s;
-    is_subject aag (fst slot);
-    cte_wp_at ((=) cap) slot s;
-    a \<in> cap_auth_conferred cap; x \<in> Access.obj_refs cap\<rbrakk> \<Longrightarrow>
-   aag_has_auth_to aag a x"
-  apply(drule sym, erule ssubst)
-  apply(rule_tac s=s in pas_refined_mem)
-   apply(fastforce intro: sta_caps[OF cte_wp_at_caps_of_state])
+  "\<lbrakk> pas_refined aag s; is_subject aag (fst slot); cte_wp_at ((=) cap) slot s;
+     a \<in> cap_auth_conferred cap; x \<in> Access.obj_refs cap \<rbrakk>
+     \<Longrightarrow> aag_has_auth_to aag a x"
+  apply (drule sym, erule ssubst)
+  apply (rule_tac s=s in pas_refined_mem)
+   apply (fastforce intro: sta_caps[OF cte_wp_at_caps_of_state'])
   apply assumption
   done
 
 (* FIXME: move *)
 lemma slot_cap_long_running_delete_reads_respects_f:
-  "reads_respects_f aag l (silc_inv aag st and pas_refined aag and valid_objs and zombies_final
-         and K (is_subject aag (fst slot)))
-     (slot_cap_long_running_delete slot)"
+  "reads_respects_f aag l (silc_inv aag st and pas_refined aag and valid_objs
+                                           and zombies_final and K (is_subject aag (fst slot)))
+                    (slot_cap_long_running_delete slot)"
   unfolding slot_cap_long_running_delete_def
-  apply(rule bind_ev_pre)
-  apply(wpc)
-               apply(wp)[1]
-              apply(fastforce simp: long_running_delete_def is_final_cap_def gets_bind_ign
-                             intro: return_ev)+
-          apply((wp is_final_cap_reads_respects[where slot=slot and st=st])+)[2]
-        apply(fastforce simp: long_running_delete_def is_final_cap_def gets_bind_ign intro: return_ev)+
-      apply(wp is_final_cap_reads_respects[where st=st])[1]
-     apply(fastforce simp: long_running_delete_def is_final_cap_def gets_bind_ign intro: return_ev)+
-    apply(wp reads_respects_f[OF get_cap_rev, where Q="\<top>" and st=st], blast)
-   apply(wp get_cap_wp | simp)+
-  apply(fastforce intro!: cte_wp_valid_cap aag_has_auth_to_obj_refs_of_owned_cap simp: is_zombie_def
-                    dest: silc_inv_not_subject)
+  apply (rule bind_ev_pre)
+     apply (wpc)
+                apply wp
+               apply (fastforce simp: long_running_delete_def is_final_cap_def gets_bind_ign
+                               intro: return_ev)+
+           apply ((wp is_final_cap_reads_respects[where slot=slot and st=st])+)[2]
+         apply (fastforce simp: long_running_delete_def is_final_cap_def gets_bind_ign intro: return_ev)+
+      apply (wp is_final_cap_reads_respects[where st=st])[1]
+     apply (fastforce simp: long_running_delete_def is_final_cap_def gets_bind_ign intro: return_ev)+
+    apply (wp reads_respects_f[OF get_cap_rev, where Q="\<top>" and st=st], blast)
+   apply (wp get_cap_wp | simp)+
+  apply (fastforce intro!: cte_wp_valid_cap aag_has_auth_to_obj_refs_of_owned_cap simp: is_zombie_def
+                     dest: silc_inv_not_subject)
   done
-
-lemma check_valid_ipc_buffer_rev:
-  "reads_equiv_valid_inv A aag \<top> (check_valid_ipc_buffer vptr cap)"
-  unfolding check_valid_ipc_buffer_def fun_app_def
-  apply(rule equiv_valid_guard_imp)
-  apply(wpc | wp)+
-  apply simp
-  done
-
 
 lemma no_state_changes:
   "(\<And>P. \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. P\<rbrace>) \<Longrightarrow> f = (do s \<leftarrow> get; (rv,s') \<leftarrow> select_f (f s); return rv od)"
@@ -190,11 +130,9 @@ lemma no_state_changes:
   apply force
   done
 
-
-
 lemma OR_choice_def2:
-  "(\<And>P. \<lbrace>P\<rbrace> (c :: bool det_ext_monad) \<lbrace>\<lambda>_.P\<rbrace>) \<Longrightarrow> empty_fail c \<Longrightarrow>
-     (OR_choice c f g) = (do b \<leftarrow> c; if b then f else g od)"
+  "\<lbrakk> \<And>P. \<lbrace>P\<rbrace> (c :: bool det_ext_monad) \<lbrace>\<lambda>_. P\<rbrace>; empty_fail c \<rbrakk>
+     \<Longrightarrow> (OR_choice c f g) = (do b \<leftarrow> c; if b then f else g od)"
   apply (simp add: OR_choice_def wrap_ext_bool_det_ext_ext_def ef_mk_ef)
   by (subst no_state_changes[where f=c], simp, fastforce simp: bind_assoc split_def)
 
@@ -202,65 +140,105 @@ lemma check_prio_rev:
   "reads_respects aag l (\<lambda>s. is_subject aag auth) (check_prio prio auth)"
   by (wpsimp simp: check_prio_def wp: thread_get_reads_respects hoare_drop_imps)
 
-
 lemma decode_set_priority_rev:
-  "reads_respects aag l (K(\<forall>x \<in> set excs. pas_cap_cur_auth aag (fst x)) and (pas_refined aag))
-      (decode_set_priority args (ThreadCap t) slot excs)"
+  "reads_respects aag l (K (\<forall>x \<in> set excs. pas_cap_cur_auth aag (fst x)) and (pas_refined aag))
+                  (decode_set_priority args (ThreadCap t) slot excs)"
   apply (wpsimp simp: decode_set_priority_def aag_cap_auth_Thread[symmetric]
                 wp: check_prio_rev whenE_throwError_wp)
   apply (case_tac excs; simp)
   done
 
-
 lemma decode_set_mcpriority_rev:
-  "reads_respects aag l (K(\<forall>x \<in> set excs. pas_cap_cur_auth aag (fst x)) and (pas_refined aag))
-    (decode_set_mcpriority args cap slot excs)"
+  "reads_respects aag l (K (\<forall>x \<in> set excs. pas_cap_cur_auth aag (fst x)) and (pas_refined aag))
+                  (decode_set_mcpriority args cap slot excs)"
   apply (wpsimp simp: decode_set_mcpriority_def aag_cap_auth_Thread[symmetric]
-                wp: check_prio_rev whenE_throwError_wp)
+                  wp: check_prio_rev whenE_throwError_wp)
   apply (case_tac excs; simp)
   done
 
-
 lemma decode_set_sched_params_rev:
-  "reads_respects aag l (K(\<forall>x \<in> set excs. pas_cap_cur_auth aag (fst x)) and (pas_refined aag))
-    (decode_set_sched_params args cap slot excs)"
+  "reads_respects aag l (K (\<forall>x \<in> set excs. pas_cap_cur_auth aag (fst x)) and (pas_refined aag))
+                  (decode_set_sched_params args cap slot excs)"
   apply (wpsimp simp: decode_set_sched_params_def aag_cap_auth_Thread[symmetric]
-                wp: check_prio_rev whenE_throwError_wp)
+                  wp: check_prio_rev whenE_throwError_wp)
   apply (case_tac excs; clarsimp)
+  done
+
+
+locale Decode_IF_1 =
+  fixes aag :: "'a subject_label PAS"
+  assumes data_to_obj_type_rev:
+    "reads_equiv_valid_inv A aag \<top> (data_to_obj_type type)"
+  and check_valid_ipc_buffer_rev:
+    "reads_equiv_valid_inv A aag \<top> (check_valid_ipc_buffer vptr cap)"
+  and arch_check_irq_rev[wp]:
+    "reads_equiv_valid_inv A aag \<top> (arch_check_irq irq)"
+  and vspace_cap_rights_to_auth_mono:
+    "R \<subseteq> S \<Longrightarrow> vspace_cap_rights_to_auth R \<subseteq> vspace_cap_rights_to_auth S"
+  and arch_decode_irq_control_invocation_rev:
+    "reads_equiv_valid_inv A aag
+       (pas_refined aag and
+        K (is_subject aag (fst slot) \<and>
+           (\<forall>cap\<in>set caps. pas_cap_cur_auth aag cap) \<and>
+           (args \<noteq> [] \<longrightarrow> (pasSubject aag, Control, pasIRQAbs aag (ucast (args ! 0))) \<in> pasPolicy aag)))
+       (arch_decode_irq_control_invocation label args slot caps)"
+begin
+
+lemma decode_untyped_invocation_rev:
+  "reads_equiv_valid_inv A aag (pas_refined aag and (K (cap = UntypedCap dev bs sz idx \<and>
+                                                        is_subject aag (fst slot) \<and>
+                                                        (\<forall>c\<in>set excaps. pas_cap_cur_auth aag c))))
+                         (decode_untyped_invocation label args slot cap excaps)"
+  unfolding decode_untyped_invocation_def fun_app_def
+  apply (rule gen_asm_ev)
+  apply (simp add: unlessE_def[symmetric] unlessE_whenE split del: if_split)
+  apply (wp (once) whenE_throwError_wp
+         | wp mapME_x_ev' ensure_empty_rev get_cap_rev
+              lookup_slot_for_cnode_op_rev
+              ensure_no_children_rev
+              const_on_failure_ev mapME_x_inv_wp
+         | assumption
+         | simp
+         | rule validE_R_validE | strengthen aag_can_read_self)+
+                  apply (rule hoare_strengthen_post[
+                                  where Q="\<lambda> rv s. (is_cnode_cap rv
+                                                         \<longrightarrow> is_subject aag (obj_ref_of rv))
+                                                 \<and> pas_refined aag s"])
+                   apply (wp (once) whenE_throwError_wp
+                          | wp get_cap_ret_is_subject data_to_obj_type_rev data_to_obj_type_inv
+                          | simp
+                          | wp (once) hoare_drop_imps)+
+  apply (clarify, drule_tac x="excaps ! 0" in bspec, fastforce intro: bang_0_in_set)
+  apply (auto dest: is_cnode_into_is_subject elim: prop_of_obj_ref_of_cnode_cap)
   done
 
 lemma decode_tcb_invocation_reads_respects_f:
   notes respects_f = reads_respects_f[where st=st and Q=\<top>]
   shows
-  "reads_respects_f aag l (silc_inv aag st and pas_refined aag and is_subject aag \<circ> cur_thread and
-                           valid_objs and zombies_final and (K (is_subject aag t \<and>
-                           (\<forall>x \<in> set excaps. is_subject aag (fst (snd x))) \<and>
-                           (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x)))))
-                           (decode_tcb_invocation label args (ThreadCap t) slot excaps)"
-  unfolding decode_tcb_invocation_def decode_read_registers_def
-  decode_write_registers_def decode_copy_registers_def
-  decode_tcb_configure_def decode_set_space_def decode_bind_notification_def
-  decode_set_ipc_buffer_def fun_app_def decode_unbind_notification_def
-  decode_set_tls_base_def
-  apply (simp add: unlessE_def[symmetric] unlessE_whenE
-        split del: if_split
+    "reads_respects_f aag l (silc_inv aag st and pas_refined aag and is_subject aag \<circ> cur_thread and
+                             valid_objs and zombies_final and
+                             K (is_subject aag t \<and> (\<forall>x \<in> set excaps. is_subject aag (fst (snd x)))
+                                                 \<and> (\<forall>x \<in> set excaps. pas_cap_cur_auth aag (fst x))))
+                      (decode_tcb_invocation label args (ThreadCap t) slot excaps)"
+  unfolding decode_tcb_invocation_def decode_read_registers_def decode_write_registers_def
+            decode_copy_registers_def decode_tcb_configure_def decode_set_space_def
+            decode_bind_notification_def decode_set_ipc_buffer_def fun_app_def
+            decode_unbind_notification_def decode_set_tls_base_def
+  apply (simp add: unlessE_def[symmetric] unlessE_whenE split del: if_split
              cong: gen_invocation_labels.case_cong)
   apply (rule equiv_valid_guard_imp)
-   apply (wp (once) requiv_cur_thread_eq range_check_ev
-             respects_f[OF derive_cap_rev]
-             derive_cap_inv slot_cap_long_running_delete_reads_respects_f[where st=st]
-             respects_f[OF check_valid_ipc_buffer_rev]
-             check_valid_ipc_buffer_inv
-             respects_f[OF decode_set_priority_rev]
-             respects_f[OF decode_set_mcpriority_rev]
-             respects_f[OF decode_set_sched_params_rev]
-             respects_f[OF get_simple_ko_reads_respects]
-             respects_f[OF get_bound_notification_reads_respects']
-        | wp (once) whenE_throwError_wp
-        | wp (once) hoare_drop_imps
-        | wpc
-        | simp add: if_apply_def2 split del: if_split add: o_def split_def)+
-  unfolding get_tcb_ctable_ptr_def get_tcb_vtable_ptr_def
+   apply (wp (once) requiv_cur_thread_eq range_check_ev respects_f[OF derive_cap_rev]
+                    derive_cap_inv slot_cap_long_running_delete_reads_respects_f[where st=st]
+                    respects_f[OF check_valid_ipc_buffer_rev] check_valid_ipc_buffer_inv
+                    respects_f[OF decode_set_priority_rev] respects_f[OF decode_set_mcpriority_rev]
+                    respects_f[OF decode_set_sched_params_rev]
+                    respects_f[OF get_simple_ko_reads_respects]
+                    respects_f[OF get_bound_notification_reads_respects']
+          | wp (once) whenE_throwError_wp
+          | wp (once) hoare_drop_imps
+          | wpc
+          | simp add: if_apply_def2 split del: if_split add: o_def split_def)+
+  apply (simp add: get_tcb_ctable_ptr_def get_tcb_vtable_ptr_def)
   apply (subgoal_tac "\<not>length excaps < 3 \<longrightarrow> is_subject aag (fst (snd (excaps ! 2)))")
    prefer 2
    apply (fastforce intro: nth_mem)
@@ -269,197 +247,63 @@ lemma decode_tcb_invocation_reads_respects_f:
    apply (fastforce intro: nth_mem)
   apply (intro allI impI conjI; (rule disjI1 | fastforce simp: reads_equiv_f_def))
   apply (rule reads_ep[where auth="Receive",simplified])
-  apply (cases excaps;simp)
+  apply (cases excaps; simp)
   by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def cap_rights_to_auth_def)
 
-
-lemma get_irq_state_rev:
-  "reads_equiv_valid_inv A aag (K (is_subject_irq aag irq)) (get_irq_state irq)"
-  unfolding get_irq_state_def
-  apply(rule equiv_valid_guard_imp[OF gets_ev])
-  apply(fastforce simp: reads_equiv_def2 elim: states_equiv_forE_interrupt_states
-                 intro: aag_can_read_irq_self)
-  done
-
-lemma is_irq_active_rev:
-  "reads_equiv_valid_inv A aag (K (is_subject_irq aag irq)) (is_irq_active irq)"
-  unfolding is_irq_active_def fun_app_def
-  apply (wp get_irq_state_rev)
-  done
-
-lemma arch_decode_irq_control_invocation_rev:
-  "reads_equiv_valid_inv A aag (pas_refined aag and
-   K (is_subject aag (fst slot) \<and>
-      (\<forall>cap\<in>set caps. pas_cap_cur_auth aag cap) \<and>
-      (args \<noteq> [] \<longrightarrow>
-       (pasSubject aag, Control, pasIRQAbs aag (ucast (args ! 0)))
-       \<in> pasPolicy aag))) (arch_decode_irq_control_invocation label args slot caps)"
-  unfolding arch_decode_irq_control_invocation_def arch_check_irq_def
-  apply (wp ensure_empty_rev lookup_slot_for_cnode_op_rev
-            is_irq_active_rev whenE_inv
-        | wp (once) hoare_drop_imps
-        | simp add: Let_def)+
-  apply safe
-       apply simp+
-    apply(blast intro: aag_Control_into_owns_irq )
-   apply(drule_tac x="caps ! 0" in bspec)
-    apply(fastforce intro: bang_0_in_set)
-   apply(drule (1) is_cnode_into_is_subject; blast dest: prop_of_obj_ref_of_cnode_cap)
-  apply(fastforce dest: is_cnode_into_is_subject intro: bang_0_in_set)
-  done
-
 lemma decode_irq_control_invocation_rev:
-  "reads_equiv_valid_inv A aag (pas_refined aag and
-   K (is_subject aag (fst slot) \<and>
-      (\<forall>cap\<in>set caps. pas_cap_cur_auth aag cap) \<and>
-      (args \<noteq> [] \<longrightarrow>
-       (pasSubject aag, Control, pasIRQAbs aag (ucast (args ! 0)))
-       \<in> pasPolicy aag))) (decode_irq_control_invocation label args slot caps)"
-  unfolding decode_irq_control_invocation_def arch_check_irq_def
+  "reads_equiv_valid_inv A aag
+     (pas_refined aag and
+      K (is_subject aag (fst slot) \<and> (\<forall>cap\<in>set caps. pas_cap_cur_auth aag cap) \<and>
+         (args \<noteq> [] \<longrightarrow> (pasSubject aag, Control, pasIRQAbs aag (ucast (args ! 0)))  \<in> pasPolicy aag)))
+     (decode_irq_control_invocation label args slot caps)"
+  unfolding decode_irq_control_invocation_def
   apply (wp ensure_empty_rev lookup_slot_for_cnode_op_rev
             is_irq_active_rev whenE_inv arch_decode_irq_control_invocation_rev
          | wp (once) hoare_drop_imps
          | simp add: Let_def)+
   apply safe
        apply simp+
-    apply(blast intro: aag_Control_into_owns_irq )
-   apply(drule_tac x="caps ! 0" in bspec)
-    apply(fastforce intro: bang_0_in_set)
-   apply(drule (1) is_cnode_into_is_subject; blast dest: prop_of_obj_ref_of_cnode_cap)
-  apply(fastforce dest: is_cnode_into_is_subject intro: bang_0_in_set)
+    apply (blast intro: aag_Control_into_owns_irq )
+   apply (drule_tac x="caps ! 0" in bspec)
+    apply (fastforce intro: bang_0_in_set)
+   apply (drule (1) is_cnode_into_is_subject; blast dest: prop_of_obj_ref_of_cnode_cap)
+  apply (fastforce dest: is_cnode_into_is_subject intro: bang_0_in_set)
   done
+
+lemma vspace_cap_rights_to_auth_mask_vm_rights:
+  "vspace_cap_rights_to_auth (mask_vm_rights R d) \<subseteq> vspace_cap_rights_to_auth R"
+  apply (rule vspace_cap_rights_to_auth_mono)
+  apply (auto simp: mask_vm_rights_def dest: subsetD[OF validate_vm_rights_subseteq])
+  done
+
+end
+
 
 (* this one doesn't read from the state at all *)
 lemma decode_irq_handler_invocation_rev:
-  "reads_equiv_valid_inv A aag \<top>
-      (decode_irq_handler_invocation label irq cps)"
+  "reads_equiv_valid_inv A aag \<top> (decode_irq_handler_invocation label irq cps)"
   unfolding decode_irq_handler_invocation_def
-  apply (wp | simp add: split_def Let_def | rule conjI impI)+
-  done
-
-
-lemma ensure_safe_mapping_reads_respects:
-  "reads_respects aag l (K (authorised_slots aag entries)) (ensure_safe_mapping entries)"
-  apply(rule gen_asm_ev)
-  apply(case_tac entries)
-   apply(rename_tac a, case_tac a)
-   apply(rename_tac aa b, case_tac aa)
-     apply(fastforce intro: returnOk_ev_pre)
-    apply(rule equiv_valid_guard_imp)
-     apply(wp mapME_x_ev' get_master_pte_reads_respects get_pte_reads_respects | wpc | simp)+
-    apply(clarsimp simp: authorised_slots_def)
-   apply simp
-   apply(rule equiv_valid_guard_imp)
-    apply(wp mapME_x_ev' get_master_pte_reads_respects | wpc | simp)+
-   apply(fastforce simp: authorised_slots_def)
-  apply(rename_tac b, case_tac b)
-  apply(rename_tac a ba, case_tac a)
-     apply(fastforce intro: returnOk_ev)
-    apply simp
-    apply(rule fail_ev)
-   apply simp
-   apply(rule equiv_valid_guard_imp)
-   apply(wp mapME_x_ev' get_master_pde_reads_respects | wpc | simp)+
-   apply(fastforce simp: authorised_slots_def)
-  apply simp
-  apply(rule equiv_valid_guard_imp)
-  apply(wp mapME_x_ev' get_master_pde_reads_respects | wpc | simp)+
-  apply(fastforce simp: authorised_slots_def)
-  done
-
-lemma lookup_pt_slot_rev:
-  "reads_equiv_valid_inv A aag (K (is_subject aag (lookup_pd_slot pd vptr && ~~ mask pd_bits)))
-     (lookup_pt_slot pd vptr)"
-  apply(simp add: lookup_pt_slot_def lookup_pd_slot_def)
-  apply(wp get_pde_rev | wpc | simp)+
-  done
-
-
-lemma create_mapping_entries_rev:
-  "reads_equiv_valid_inv A aag (K (typ \<in> {ARMSmallPage,ARMLargePage}
-                                   \<longrightarrow> is_subject aag (lookup_pd_slot pd vptr && ~~ mask pd_bits)))
-     (create_mapping_entries bast vptr typ vm_rights attrib pd)"
-  apply(rule gen_asm_ev)
-  apply(case_tac "typ")
-     apply(wp lookup_error_on_failure_rev lookup_pt_slot_rev | simp)+
-  done
-
-
-lemma check_vp_alignment_rev:
-  "reads_equiv_valid_inv A aag \<top> (check_vp_alignment sz vptr)"
-  unfolding check_vp_alignment_def
-  apply(wp | simp add: crunch_simps split del: if_split)+
-  done
+  by (wp | simp add: split_def Let_def | rule conjI impI)+
 
 lemmas reads_respects_f_inv = reads_respects_f[where Q="\<top>", simplified]
 
 lemma gets_applyE:
   "(liftE $ gets f) >>=E (\<lambda> f. g (f x)) = liftE (gets_apply f x) >>=E g"
-  apply(simp add: liftE_bindE)
-  apply(rule gets_apply)
-  done
-
-lemma gets_apply_wp:
-  "\<lbrace>\<lambda> s. P (f s x) s\<rbrace> gets_apply f x \<lbrace>P\<rbrace>"
-  apply(simp add: gets_apply_def)
-  apply wp
-  done
-
-lemma asid_high_bits_of_1:
-  "asid_high_bits_of 1 = 0"
-  apply(simp add: asid_high_bits_of_def asid_low_bits_def)
-  done
-
-lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq'':
-  "\<lbrakk>\<forall> asid. is_subject_asid aag asid; reads_equiv aag s t; pas_refined aag x\<rbrakk>
-   \<Longrightarrow>
-   arm_asid_table (arch_state s) (asid_high_bits_of base) =
-   arm_asid_table (arch_state t) (asid_high_bits_of base)"
-  apply (subgoal_tac "asid_high_bits_of 0 = asid_high_bits_of 1")
-   apply(case_tac "base = 0")
-    apply(subgoal_tac "is_subject_asid aag 1")
-     apply ((auto intro: requiv_arm_asid_table_asid_high_bits_of_asid_eq
-                       ) |
-            (auto simp: asid_high_bits_of_def asid_low_bits_def))+
-  done
-
-lemma pas_cap_cur_auth_ASIDControlCap:
-  "\<lbrakk>pas_cap_cur_auth aag (ArchObjectCap ASIDControlCap);
-   reads_equiv aag s t; pas_refined aag x\<rbrakk>
-  \<Longrightarrow> arm_asid_table (arch_state s) =
-     arm_asid_table (arch_state t)"
-  apply(rule ext)
-  apply(subst asid_high_bits_of_shift[symmetric])
-  apply(subst (3) asid_high_bits_of_shift[symmetric])
-  apply(rule requiv_arm_asid_table_asid_high_bits_of_asid_eq'')
-    apply(clarsimp simp: aag_cap_auth_def cap_links_asid_slot_def label_owns_asid_slot_def)
-    apply(rule pas_refined_Control_into_is_subject_asid, blast+)
+  apply (simp add: liftE_bindE)
+  apply (rule gets_apply)
   done
 
 lemma owns_cnode_owns_obj_ref_of_child_cnodes:
-  "\<lbrakk>pas_refined aag s; is_subject aag (fst slot);
-        cte_wp_at ((=) cap) slot s; is_cnode_cap cap\<rbrakk>
-       \<Longrightarrow> is_subject aag (obj_ref_of cap)"
+  "\<lbrakk> pas_refined aag s; is_subject aag (fst slot); cte_wp_at ((=) cap) slot s; is_cnode_cap cap \<rbrakk>
+     \<Longrightarrow> is_subject aag (obj_ref_of cap)"
   by (blast intro: owns_cnode_owns_obj_ref_of_child_cnodes_threads_and_zombies)
 
-lemma vspace_cap_rights_to_auth_mono:
-  "R \<subseteq> S \<Longrightarrow> vspace_cap_rights_to_auth R \<subseteq> vspace_cap_rights_to_auth S"
-  apply(auto simp: vspace_cap_rights_to_auth_def)
-  done
-
-lemma vspace_cap_rights_to_auth_mask_vm_rights:
-  "vspace_cap_rights_to_auth
-              (mask_vm_rights R d) \<subseteq> vspace_cap_rights_to_auth R"
-  apply(rule vspace_cap_rights_to_auth_mono)
-  apply(auto simp: mask_vm_rights_def dest: subsetD[OF validate_vm_rights_subseteq])
-  done
-
-lemma select_ext_ev_bind: "(\<And>s t. \<lbrakk>I s t; A s t; a s \<in> S; a t \<in> S\<rbrakk>
-       \<Longrightarrow> a s = a t) \<Longrightarrow> (\<And>x. x \<in> S \<Longrightarrow> equiv_valid_inv I A P (g x)) \<Longrightarrow>
-       (equiv_valid_inv I A P ((select_ext a S) >>= (\<lambda>r (s :: det_ext state). g r s)))"
-  apply (clarsimp simp add: equiv_valid_def2 equiv_valid_2_def
-                            select_ext_def bind_def gets_def return_def
-                            get_def assert_def fail_def)
+lemma select_ext_ev_bind:
+  "(\<And>s t. \<lbrakk>I s t; A s t; a s \<in> S; a t \<in> S\<rbrakk> \<Longrightarrow> a s = a t)
+   \<Longrightarrow> (\<And>x. x \<in> S \<Longrightarrow> equiv_valid_inv I A P (g x))
+   \<Longrightarrow> equiv_valid_inv I A P ((select_ext a S) >>= (\<lambda>r s :: det_state. g r s))"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def select_ext_def
+                        bind_def gets_def return_def get_def assert_def fail_def)
   apply (drule_tac x=s in meta_spec)
   apply (drule_tac x="a s" in meta_spec)
   apply (drule_tac x=t in meta_spec)
@@ -470,277 +314,88 @@ lemma select_ext_ev_bind: "(\<And>s t. \<lbrakk>I s t; A s t; a s \<in> S; a t \
   apply force
   done
 
-lemma select_ext_ev_bind_lift: "(\<And>s t. \<lbrakk>I s t; A s t; a s \<in> S; a t \<in> S\<rbrakk>
-       \<Longrightarrow> a s = a t) \<Longrightarrow> (\<And>x. x \<in> S \<Longrightarrow> equiv_valid_inv I A P (g x)) \<Longrightarrow>
-       (equiv_valid_inv I A P (doE x \<leftarrow> (liftE $ ((select_ext a S) :: ('a,det_ext) s_monad)); g x odE))"
+lemma select_ext_ev_bind_lift:
+  "(\<And>s t. \<lbrakk>I s t; A s t; a s \<in> S; a t \<in> S\<rbrakk> \<Longrightarrow> a s = a t)
+   \<Longrightarrow> (\<And>x. x \<in> S \<Longrightarrow> equiv_valid_inv I A P (g x))
+   \<Longrightarrow> equiv_valid_inv I A P (doE x \<leftarrow> (liftE $ (select_ext a S :: ('a, det_ext) s_monad)); g x odE)"
   apply (simp add: bindE_def liftE_def lift_def)
   apply (rule select_ext_ev_bind)
   apply simp+
   done
 
-lemma resolve_vaddr_reads_respects:
-  "reads_respects aag l (K (is_subject aag (lookup_pd_slot pd vptr && ~~ mask pd_bits)) and
-    (\<lambda>s. case kheap s (lookup_pd_slot pd vptr && ~~ mask pd_bits)
-         of Some (ArchObj (PageDirectory pd')) \<Rightarrow>
-           (case pd' (ucast (lookup_pd_slot pd vptr && mask pd_bits >> 2))
-            of PageTablePDE x y z \<Rightarrow>
-              is_subject aag (lookup_pt_slot_no_fail (ptrFromPAddr x) vptr && ~~ mask pt_bits)
-            | _ \<Rightarrow> True)
-         | _ \<Rightarrow> True)) (resolve_vaddr pd vptr)"
-  apply (simp add: resolve_vaddr_def
-        | wp get_master_pte_reads_respects get_master_pde_reads_respects get_master_pde_wp | wpc)+
-  apply (fastforce simp: obj_at_def split: pde.splits)
-  done
-
-lemma lookup_pt_slot_no_fail_is_subject:
-  "\<lbrakk>(\<exists>\<rhd> pd) s; valid_vspace_objs s; pspace_aligned s; pas_refined aag s;
-    is_subject aag pd; is_aligned pd pd_bits; vptr < kernel_base;
-    kheap s pd = Some (ArchObj (PageDirectory pdo));
-    pdo (ucast (vptr >> 20)) = PageTablePDE p x xa\<rbrakk>
-    \<Longrightarrow> is_subject aag (lookup_pt_slot_no_fail (ptrFromPAddr p) vptr && ~~ mask pt_bits)"
-  apply (clarsimp simp: lookup_pt_slot_no_fail_def)
-  apply (drule valid_vspace_objsD)
-    apply (simp add: obj_at_def)
-   apply assumption
-  apply (drule kheap_eq_state_vrefs_pas_refinedD)
-    apply (erule vs_refs_no_global_pts_pdI)
-    apply (drule(1) less_kernel_base_mapping_slots)
-    apply (simp add: kernel_mapping_slots_def lookup_pd_slot_def pd_shifting_dual' triple_shift_fun)
-   apply assumption
-  apply (simp add: aag_has_Control_iff_owns)
-  apply (drule_tac f="\<lambda>pde. valid_pde pde s" in arg_cong, simp)
-  apply (clarsimp simp: obj_at_def kernel_base_kernel_mapping_slots)
-  apply (erule pspace_alignedE, erule domI)
-  apply (simp add: pt_bits_def pageBits_def)
-  apply (subst is_aligned_add_helper, assumption)
-   apply (rule shiftl_less_t2n)
-    apply (rule order_le_less_trans, rule word_and_le1, simp)
-   apply simp
-  apply simp
-  done
-
-lemma arch_decode_invocation_reads_respects_f:
-  notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
-  notes hoare_whenE_wps[wp_split del]
-  shows
-  "reads_respects_f aag l (silc_inv aag st and invs and pas_refined aag
-        and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot
-        and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)
-        and K (\<forall>(cap, slot) \<in> {(cap.ArchObjectCap cap, slot)} \<union> set excaps.
-                      aag_cap_auth aag (pasObjectAbs aag (fst slot)) cap \<and> is_subject aag (fst slot)
-                   \<and> (\<forall>v \<in> cap_asid' cap. is_subject_asid aag v)))
-        (arch_decode_invocation label args cap_index slot cap excaps)"
-  unfolding arch_decode_invocation_def
-  apply(rule equiv_valid_guard_imp)
-   apply(subst gets_applyE)+
-   apply (wp check_vp_wpR  reads_respects_f_inv'[OF get_asid_pool_rev]
-              reads_respects_f_inv'[OF ensure_empty_rev]
-             reads_respects_f_inv'[OF lookup_slot_for_cnode_op_rev]
-             reads_respects_f_inv'[OF ensure_no_children_rev] select_wp
-             reads_respects_f_inv'[OF ensure_safe_mapping_reads_respects]
-             reads_respects_f_inv'[OF resolve_vaddr_reads_respects]
-             reads_respects_f_inv'[OF create_mapping_entries_rev]
-             reads_respects_f_inv'[OF check_vp_alignment_rev]
-             reads_respects_f_inv'[OF lookup_error_on_failure_rev]
-             find_pd_for_asid_reads_respects gets_apply_ev
-             reads_respects_f_inv'[OF get_master_pde_reads_respects]
-             is_final_cap_reads_respects find_pd_for_asid_authority2
-             select_ext_ev_bind_lift
-             select_ext_ev_bind_lift[simplified]
-         | wpc
-         | simp add: Let_def unlessE_whenE
-         | wp (once) whenE_throwError_wp)+
-  apply (intro impI allI conjI)
-                              apply(rule requiv_arm_asid_table_asid_high_bits_of_asid_eq')
-                                apply fastforce
-                               apply(simp add: reads_equiv_f_def)
-                              apply blast
-                             apply(fastforce simp: aag_cap_auth_ASIDPoolCap)
-                            apply(rule pas_cap_cur_auth_ASIDControlCap[where aag=aag])
-                              apply fastforce
-                             apply(simp add: reads_equiv_f_def)
-                            apply blast
-                           apply clarify
-                           apply(subgoal_tac "excaps ! 0 \<in> set excaps", fastforce)
-                           apply(rule nth_mem)
-                            apply(erule less_trans[rotated], simp)
-                          apply(subgoal_tac "excaps ! (Suc 0) \<in> set excaps")
-                           apply(rule_tac slot="snd (excaps ! (Suc 0))"
-                                       in owns_cnode_owns_obj_ref_of_child_cnodes)
-                              apply blast
-                             apply(fastforce)
-                            apply(fastforce)
-                           apply assumption
-                          apply(fastforce intro: nth_mem)
-                         apply clarify
-                         apply(subgoal_tac "excaps ! Suc 0 \<in> set excaps")
-                          apply(rule_tac cap="fst (excaps ! Suc 0)" and p="snd (excaps ! Suc 0)"
-                                      in caps_of_state_pasObjectAbs_eq)
-                              apply(rule cte_wp_at_caps_of_state)
-                              apply fastforce
-                             apply(erule cap_auth_conferred_cnode_cap)
-                            apply fastforce
-                           apply assumption
-                          apply(fastforce intro: nth_mem)
-                         apply(fastforce intro: nth_mem)
-                        apply(subgoal_tac "excaps ! 0 \<in> set excaps")
-                         apply(fastforce intro: aag_cap_auth_PageDirectoryCap_asid)
-                        apply fastforce
-                       apply(simp add: lookup_pd_slot_def)
-                       apply(subgoal_tac "excaps ! 0 \<in> set excaps")
-                        apply(subst vaddr_segment_nonsense)
-                         apply(fastforce dest: cte_wp_valid_cap cap_aligned_valid
-                                         simp: obj_ref_of_def cap_aligned_def cap_bits_def)
-                        apply(fastforce dest: aag_cap_auth_PageDirectoryCap)
-                       apply fastforce
-                      apply(simp add: lookup_pd_slot_def)
-                      apply(subgoal_tac "excaps ! 0 \<in> set excaps")
-                       apply(subst vaddr_segment_nonsense)
-                        apply(fastforce dest: cte_wp_valid_cap cap_aligned_valid
-                                        simp: obj_ref_of_def cap_aligned_def cap_bits_def)
-                       apply(fastforce dest: aag_cap_auth_PageDirectoryCap)
-                      apply fastforce
-                     apply fastforce
-                    apply(subgoal_tac "excaps ! 0 \<in> set excaps")
-                     apply(fastforce dest: aag_cap_auth_PageDirectoryCap)
-                    apply fastforce
-                   apply fastforce
-                  (* clagged from Arch_AI *)
-                  apply (simp add: linorder_not_le kernel_base_less_observation
-                                   vmsz_aligned_def p_assoc_help)
-                  apply (subst(asm) mask_lower_twice[symmetric])
-                   prefer 2
-                   apply (subst(asm) is_aligned_add_helper,
-                          assumption)
-                   apply (rule word_power_less_1)
-                    apply(case_tac xc, simp_all)[1]
-                   apply simp
-                  apply(case_tac xc, simp_all)[1]
-                 apply(rule ball_subset[OF _ vspace_cap_rights_to_auth_mask_vm_rights])
-                 apply(fastforce simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def)
-                apply(simp add: lookup_pd_slot_def)
-                apply(subgoal_tac "excaps ! 0 \<in> set excaps")
-                 apply(subst vaddr_segment_nonsense)
-                  apply(fastforce dest: cte_wp_valid_cap cap_aligned_valid
-                                  simp: obj_ref_of_def cap_aligned_def cap_bits_def)
-                 apply(fastforce dest: aag_cap_auth_PageDirectoryCap)
-                apply fastforce
-               apply(simp add: lookup_pd_slot_def)
-               apply(subgoal_tac "excaps ! 0 \<in> set excaps")
-                apply(subst vaddr_segment_nonsense)
-                 apply(fastforce dest: cte_wp_valid_cap cap_aligned_valid
-                                 simp: obj_ref_of_def cap_aligned_def cap_bits_def)
-                apply(fastforce dest: aag_cap_auth_PageDirectoryCap)
-               apply fastforce
-              apply fastforce
-             apply(subgoal_tac "excaps ! 0 \<in> set excaps")
-              apply(fastforce dest: aag_cap_auth_PageDirectoryCap)
-             apply fastforce
-            apply fastforce
-           apply(fastforce dest: cte_wp_valid_cap simp: valid_cap_simps)
-          apply(rule ball_subset[OF _ vspace_cap_rights_to_auth_mask_vm_rights])
-          apply(fastforce simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def)
-         apply(subgoal_tac "excaps ! 0 \<in> set excaps")
-          apply(fastforce intro: aag_cap_auth_PageDirectoryCap_asid)
-         apply fastforce
-        apply(subgoal_tac "excaps ! 0 \<in> set excaps")
-         apply(subst vaddr_segment_nonsense)
-          apply(fastforce dest: cte_wp_valid_cap cap_aligned_valid
-                          simp: obj_ref_of_def cap_aligned_def cap_bits_def)
-         apply(fastforce dest: aag_cap_auth_PageDirectoryCap)
-        apply fastforce
-       apply blast
-      apply blast
-     apply (blast dest:aag_can_read_self)
-    apply (force dest:silc_inv_not_subject)
-   apply(simp add: lookup_pd_slot_def)
-   apply(subst vaddr_segment_nonsense)
-    apply(fastforce dest: cte_wp_valid_cap cap_aligned_valid
-                    simp: obj_ref_of_def cap_aligned_def cap_bits_def)
-   apply(fastforce dest: aag_cap_auth_PageDirectoryCap)
-  apply(clarsimp simp: lookup_pd_slot_def
-                split: option.splits kernel_object.splits arch_kernel_obj.splits pde.splits)
-  apply(subst(asm) vaddr_segment_nonsense)
-   apply(fastforce dest: cte_wp_valid_cap cap_aligned_valid
-                   simp: obj_ref_of_def cap_aligned_def cap_bits_def)
-  apply(subst(asm) vaddr_segment_nonsense2)
-   apply(fastforce dest: cte_wp_valid_cap cap_aligned_valid
-                   simp: obj_ref_of_def cap_aligned_def cap_bits_def)
-  apply (rule_tac pd=x and s=s in lookup_pt_slot_no_fail_is_subject)
-          apply (erule exI)
-         apply (simp add: invs_def valid_state_def)
-        apply (simp add: invs_def valid_state_def valid_pspace_def)
-       apply assumption
-      apply (erule(1) aag_cap_auth_PageDirectoryCap)
-     apply(fastforce dest: cte_wp_valid_cap cap_aligned_valid simp: obj_ref_of_def cap_aligned_def cap_bits_def pd_bits)
-    apply simp
-   apply assumption
-  apply assumption
-  done
-
 lemma decode_domain_invocation_reads_respects_f:
   "reads_respects_f aag l \<top> (decode_domain_invocation label args excaps)"
-apply (simp add: decode_domain_invocation_def)
-apply (wp | wpc | simp)+
-done
+  apply (simp add: decode_domain_invocation_def)
+  apply (wp | wpc | simp)+
+  done
+
+
+locale Decode_IF_2 = Decode_IF_1 +
+  assumes arch_decode_invocation_reads_respects_f:
+    "reads_respects_f aag l
+       (silc_inv aag st and invs and pas_refined aag and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot
+                        and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)
+                        and K (\<forall>(cap, slot) \<in> {(cap.ArchObjectCap cap, slot)} \<union> set excaps.
+                                 aag_cap_auth aag (pasObjectAbs aag (fst slot)) cap \<and>
+                                 is_subject aag (fst slot) \<and>
+                                 (\<forall>v \<in> cap_asid' cap. is_subject_asid aag v)))
+       (arch_decode_invocation label args cap_index slot cap excaps)"
+begin
 
 lemma decode_invocation_reads_respects_f:
   "reads_respects_f aag l
-  (silc_inv aag st and pas_refined aag and valid_cap cap and invs and ct_active and cte_wp_at ((=) cap) slot
-           and ex_cte_cap_to slot
-           and (\<lambda>s. \<forall>r\<in>zobj_refs cap. ex_nonz_cap_to r s)
-           and (\<lambda>s. \<forall>r\<in>cte_refs cap (interrupt_irq_node s). ex_cte_cap_to r s)
-           and (\<lambda>s. \<forall>cap \<in> set excaps. \<forall>r\<in>cte_refs (fst cap) (interrupt_irq_node s). ex_cte_cap_to r s)
-           and (\<lambda>s. \<forall>x \<in> set excaps. s \<turnstile> (fst x))
-           and (\<lambda>s. \<forall>x \<in> set excaps. \<forall>r\<in>zobj_refs (fst x). ex_nonz_cap_to r s)
-           and (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at ((=) (fst x)) (snd x) s)
-           and (\<lambda>s. \<forall>x \<in> set excaps. real_cte_at (snd x) s)
-           and (\<lambda>s. \<forall>x \<in> set excaps. ex_cte_cap_wp_to is_cnode_cap (snd x) s)
-           and (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at (interrupt_derived (fst x)) (snd x) s)
-           and (is_subject aag \<circ> cur_thread) and
-              K (is_subject aag (fst slot) \<and> pas_cap_cur_auth aag cap
-                \<and> (\<forall>slot \<in> set excaps. is_subject aag (fst (snd slot)))
-                \<and> (\<forall>slot \<in> set excaps. pas_cap_cur_auth aag (fst slot))))
-  (decode_invocation label args cap_index slot cap excaps)"
-  apply(rule equiv_valid_guard_imp)
-   unfolding decode_invocation_def fun_app_def
-  apply (wp reads_respects_f[OF decode_untyped_invocation_rev, where Q="\<top>"]
-            reads_respects_f[OF decode_cnode_invocation_rev, where Q="\<top>"]
-            decode_tcb_invocation_reads_respects_f
-            decode_domain_invocation_reads_respects_f
-            reads_respects_f[OF decode_irq_control_invocation_rev, where Q="\<top>"]
-            reads_respects_f[OF decode_irq_handler_invocation_rev, where Q="\<top>"]
-            arch_decode_invocation_reads_respects_f
-       | wpc
-       | simp
-       | (rule hoare_pre, wp (once)))+
+     (silc_inv aag st and pas_refined aag and valid_cap cap and invs and ct_active
+                      and cte_wp_at ((=) cap) slot and ex_cte_cap_to slot
+                      and (\<lambda>s. \<forall>r\<in>zobj_refs cap. ex_nonz_cap_to r s)
+                      and (\<lambda>s. \<forall>r\<in>cte_refs cap (interrupt_irq_node s). ex_cte_cap_to r s)
+                      and (\<lambda>s. \<forall>cap \<in> set excaps.
+                                 \<forall>r\<in>cte_refs (fst cap) (interrupt_irq_node s). ex_cte_cap_to r s)
+                      and (\<lambda>s. \<forall>x \<in> set excaps. s \<turnstile> (fst x))
+                      and (\<lambda>s. \<forall>x \<in> set excaps. \<forall>r\<in>zobj_refs (fst x). ex_nonz_cap_to r s)
+                      and (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at ((=) (fst x)) (snd x) s)
+                      and (\<lambda>s. \<forall>x \<in> set excaps. real_cte_at (snd x) s)
+                      and (\<lambda>s. \<forall>x \<in> set excaps. ex_cte_cap_wp_to is_cnode_cap (snd x) s)
+                      and (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at (interrupt_derived (fst x)) (snd x) s)
+                      and (is_subject aag \<circ> cur_thread)
+                      and K (is_subject aag (fst slot) \<and> pas_cap_cur_auth aag cap \<and>
+                             (\<forall>slot \<in> set excaps. is_subject aag (fst (snd slot))) \<and>
+                             (\<forall>slot \<in> set excaps. pas_cap_cur_auth aag (fst slot))))
+     (decode_invocation label args cap_index slot cap excaps)"
+  unfolding decode_invocation_def fun_app_def
+  apply (rule equiv_valid_guard_imp)
+   apply (wp reads_respects_f[OF decode_untyped_invocation_rev, where Q="\<top>"]
+             reads_respects_f[OF decode_cnode_invocation_rev, where Q="\<top>"]
+             decode_tcb_invocation_reads_respects_f
+             decode_domain_invocation_reads_respects_f
+             reads_respects_f[OF decode_irq_control_invocation_rev, where Q="\<top>"]
+             reads_respects_f[OF decode_irq_handler_invocation_rev, where Q="\<top>"]
+             arch_decode_invocation_reads_respects_f
+          | wpc | simp | (rule hoare_pre, wp (once)))+
   apply (clarsimp simp: aag_has_Control_iff_owns split_def aag_cap_auth_def)
   apply (cases cap, simp_all)
-  apply ((clarsimp simp: valid_cap_def cte_wp_at_eq_simp
-                        is_cap_simps
-                        ex_cte_cap_wp_to_weakenE[OF _ TrueI]
-                        cap_auth_conferred_def cap_rights_to_auth_def pas_refined_all_auth_is_owns
-           | rule conjI | (subst split_paired_Ex[symmetric], erule exI)
-           | erule cte_wp_at_weakenE
-           | drule(1) bspec
-           | erule eq_no_cap_to_obj_with_diff_ref
-           | assumption)+)[1]
+    apply ((clarsimp simp: valid_cap_def cte_wp_at_eq_simp is_cap_simps
+                           ex_cte_cap_wp_to_weakenE[OF _ TrueI] cap_auth_conferred_def
+                           cap_rights_to_auth_def pas_refined_all_auth_is_owns
+            | rule conjI | (subst split_paired_Ex[symmetric], erule exI)
+            | erule cte_wp_at_weakenE
+            | drule(1) bspec
+            | erule eq_no_cap_to_obj_with_diff_ref
+            | assumption)+)[1]
    apply (rule conjI, assumption)
-   apply (rule impI, erule subst, rule pas_refined_sita_mem [OF sita_controlled], auto
-          simp: cte_wp_at_caps_of_state)[1]
+   apply (rule impI, erule subst, rule pas_refined_sita_mem[OF sita_controlled],
+          auto simp: cte_wp_at_caps_of_state)[1]
   apply (rename_tac arch_cap)
   apply (subgoal_tac "(\<forall>x\<in>cap_asid' (ArchObjectCap arch_cap). is_subject_asid aag x) \<and>
           (\<forall>x\<in>set excaps. \<forall>v\<in>cap_asid' (fst x). is_subject_asid aag v)")
-  prefer 2
-  apply (clarsimp simp: cap_links_asid_slot_def label_owns_asid_slot_def)
-  apply (fastforce dest!: pas_refined_Control)
-
+   prefer 2
+   apply (clarsimp simp: cap_links_asid_slot_def label_owns_asid_slot_def)
+   apply (fastforce dest!: pas_refined_Control)
   apply auto
   done
 
 lemmas decode_invocation_reads_respects_f_g =
-       reads_respects_f_g[OF decode_invocation_reads_respects_f doesnt_touch_globalsI,
-                          where Q="\<top>", simplified, OF decode_inv_inv]
+  reads_respects_f_g[OF decode_invocation_reads_respects_f doesnt_touch_globalsI,
+                     where Q="\<top>", simplified, OF decode_inv_inv]
 
 end
 

--- a/proof/infoflow/ExampleSystemPolicyFlows.thy
+++ b/proof/infoflow/ExampleSystemPolicyFlows.thy
@@ -6,7 +6,7 @@
 
 theory ExampleSystemPolicyFlows
 imports
-  Noninterference
+  ArchNoninterference
   "Access.ExampleSystem"
 begin
 
@@ -77,15 +77,13 @@ lemma Sys3UT3Reads_correct_bw : "x \<in> Sys3Reads \<Longrightarrow> x \<in> sub
   apply (erule disjE)
    apply (rule_tac auth = SyncSend in reads_ep)
     apply (simp)
-    apply (simp add:insertI1)
+   apply (simp add:insertI1)
   (* UT3 reads T3 *)
-  apply (rule_tac auth = SyncSend and ep = "OrdinaryLabel (EP3)" and a = "OrdinaryLabel (UT3)" in read_sync_ep_read_receivers)
-     apply (simp)
-     apply (simp)
-    apply (rule_tac auth = SyncSend in reads_ep)
+  apply (rule_tac ep = "OrdinaryLabel (EP3)" in read_sync_ep_read_receivers)
+   apply (rule_tac auth = SyncSend in reads_ep)
     apply (simp)
-    apply (rule insertI1)
-    apply (simp add: insertI1)
+   apply (rule insertI1)
+  apply (simp add: insertI1)
   done
 
 lemma Sys3UT3Affects_correct_bw : "x \<in> Sys3Affects \<Longrightarrow> x \<in> subjectAffects Sys3AuthGraph (OrdinaryLabel (UT3))"
@@ -109,19 +107,17 @@ lemma Sys3T3Reads_correct_bw : "x \<in> Sys3Reads \<Longrightarrow> x \<in> subj
   apply (simp add: Sys3AuthGraph_def Sys3AuthGraph_aux_def complete_AuthGraph_def Sys3Reads_def)
   apply (erule disjE)
    (* T3 reads UT3 *)
-   apply (rule_tac auth = Receive and ep = "OrdinaryLabel (EP3)" and a = "OrdinaryLabel (T3)" in read_sync_ep_read_senders)
-      apply (simp)
-     apply (simp)
+   apply (rule_tac ep = "OrdinaryLabel (EP3)" in read_sync_ep_read_senders)
     apply (rule_tac auth = Receive in reads_ep)
      apply (simp)
-     apply (simp add:insertI1)
-   apply (simp add: insertI1)
-   (* T3 reads EP3 *)
-  apply (erule disjE)
-  apply (rule_tac auth = Receive in reads_ep)
-    apply (simp)
     apply (simp add:insertI1)
-   (* T3 reads T3 *)
+   apply (simp add: insertI1)
+  (* T3 reads EP3 *)
+  apply (erule disjE)
+   apply (rule_tac auth = Receive in reads_ep)
+    apply (simp)
+   apply (simp add:insertI1)
+  (* T3 reads T3 *)
   apply simp
   done
 
@@ -152,17 +148,15 @@ lemma Sys3EP3Reads_correct_bw : "x \<in> Sys3Reads \<Longrightarrow> x \<in> sub
   apply (erule disjE)
    (* EP3 reads UT3 *)
    apply simp
-   apply (rule_tac a = "OrdinaryLabel (T3)" and auth=Receive and ep = "OrdinaryLabel (EP3)" and b = "OrdinaryLabel (UT3)" in read_sync_ep_read_senders)
-      apply (simp)
-     apply (simp add:insertI1)
-    apply simp
-   apply simp
+   apply (rule_tac ep = "OrdinaryLabel (EP3)" and b = "OrdinaryLabel (UT3)" in read_sync_ep_read_senders)
+    apply (simp)
+   apply (simp add:insertI1)
   (* EP3 reads EP3 *)
   apply (erule disjE)
    apply simp
   (* EP3 reads T3 *)
-  apply (rule_tac a = "OrdinaryLabel (UT3)" and auth = SyncSend and ep = "OrdinaryLabel (EP3)" and a = "OrdinaryLabel (T3)" in read_sync_ep_read_receivers)
-     apply simp_all
+  apply (rule_tac ep = "OrdinaryLabel (EP3)" in read_sync_ep_read_receivers)
+   apply simp_all
   done
 
 lemma Sys3EP3Affects_correct_fw : "x \<in> subjectAffects Sys3AuthGraph (OrdinaryLabel (EP3)) \<Longrightarrow> x \<in> Sys3EP3Affects"

--- a/proof/infoflow/FinalCaps.thy
+++ b/proof/infoflow/FinalCaps.thy
@@ -12,77 +12,43 @@ text \<open>
 \<close>
 
 theory FinalCaps
-imports InfoFlow
+imports ArchInfoFlow_IF
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-declare arch_gen_obj_refs_def[simp]
-
-lemma arm_only_arch_gen_refs:
-  "arch_gen_refs cap = {}"
-  by (auto simp:arch_cap_set_map_def split: cap.splits)
-
 (* FIXME: arch_split: need to have a label on arch refs*)
-fun pasGenAbs :: "'a PAS \<Rightarrow> gen_obj_ref \<Rightarrow> 'a"
-where
+fun pasGenAbs :: "'a PAS \<Rightarrow> gen_obj_ref \<Rightarrow> 'a" where
   "pasGenAbs aag (ObjRef ref) = pasObjectAbs aag ref"
 | "pasGenAbs aag (IRQRef ref) = pasIRQAbs aag ref"
 
 (*FIXME REPLACE by alternative definition *)
-definition cap_points_to_label
-where
+definition cap_points_to_label where
   "cap_points_to_label aag cap l \<equiv>
-         (\<forall> x \<in> Structures_A.obj_refs cap. (pasObjectAbs aag x = l))
-     \<and>   (\<forall> x \<in> cap_irqs cap. (pasIRQAbs aag x = l))"
-
-lemma cap_points_to_label_def':
-  "cap_points_to_label aag cap l = (\<forall> x \<in> gen_obj_refs cap. pasGenAbs aag x = l)"
-  unfolding cap_points_to_label_def
-  by (simp add: gen_obj_refs_def ball_Un arm_only_arch_gen_refs)
+     (\<forall>x \<in> Structures_A.obj_refs cap. (pasObjectAbs aag x = l)) \<and>
+     (\<forall>x \<in> cap_irqs cap. (pasIRQAbs aag x = l))"
 
 (* WARNING: Reply cap will be considered as intra_label even if they are between labels *)
-definition intra_label_cap
-where
+definition intra_label_cap where
   "intra_label_cap aag slot s \<equiv>
-      (\<forall> cap. cte_wp_at ((=) cap) slot s \<longrightarrow>
-         (cap_points_to_label aag cap (pasObjectAbs aag (fst slot))))"
+     (\<forall>cap. cte_wp_at ((=) cap) slot s
+            \<longrightarrow> (cap_points_to_label aag cap (pasObjectAbs aag (fst slot))))"
 
 (*FIXME REPLACE by alternative definition *)
-definition slots_holding_overlapping_caps :: "cap \<Rightarrow> ('z::state_ext) state \<Rightarrow> cslot_ptr set"
-where
+definition slots_holding_overlapping_caps :: "cap \<Rightarrow> ('z::state_ext) state \<Rightarrow> cslot_ptr set" where
   "slots_holding_overlapping_caps cap s \<equiv>
-   {cref. \<exists>cap'. fst (get_cap cref s) = {(cap', s)} \<and>
-                 (Structures_A.obj_refs cap \<inter> Structures_A.obj_refs cap' \<noteq> {} \<or>
-                 cap_irqs cap \<inter> cap_irqs cap' \<noteq> {} \<or>
-                 arch_gen_refs cap \<inter> arch_gen_refs cap' \<noteq> {})}"
-end
-(* FIXME MOVE *)
-context strengthen_implementation begin
-  lemma strengthen_cte_wp_at[strg]:
-    "(\<And>x. st F (\<longrightarrow>) (P x) (Q x)) \<Longrightarrow> st F (\<longrightarrow>) (cte_wp_at P slot s) (cte_wp_at Q slot s)"
-    by (cases F, auto elim:cte_wp_at_weakenE)
-end
-context begin interpretation Arch .
-
-lemma slots_holding_overlapping_caps_def':
-  "slots_holding_overlapping_caps cap s =
-   {cref. cte_wp_at (\<lambda>cap'. gen_obj_refs cap \<inter> gen_obj_refs cap' \<noteq> {}) cref s}"
-  unfolding slots_holding_overlapping_caps_def cte_wp_at_def gen_obj_refs_def
-  by blast
-
+     {cref. \<exists>cap'. fst (get_cap cref s) = {(cap', s)} \<and>
+                   (Structures_A.obj_refs cap \<inter> Structures_A.obj_refs cap' \<noteq> {} \<or>
+                    cap_irqs cap \<inter> cap_irqs cap' \<noteq> {} \<or>
+                    arch_gen_refs cap \<inter> arch_gen_refs cap' \<noteq> {})}"
 
 (* FIXME MOVE *)
-abbreviation subject_can_affect :: "'a PAS \<Rightarrow> obj_ref \<Rightarrow> bool"
-where
+abbreviation subject_can_affect :: "'a PAS \<Rightarrow> obj_ref \<Rightarrow> bool" where
   "subject_can_affect aag ptr \<equiv>
-          pasObjectAbs aag ptr \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+     pasObjectAbs aag ptr \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
 
 
-abbreviation subject_can_affect_label_directly :: "'a PAS \<Rightarrow> 'a \<Rightarrow> bool"
-where
+abbreviation subject_can_affect_label_directly :: "'a PAS \<Rightarrow> 'a \<Rightarrow> bool" where
   "subject_can_affect_label_directly aag l \<equiv>
-          l \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+     l \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
 
 
 text \<open>We introduce a new label. The name 'silc' here stands for 'safe inter-label caps',
@@ -92,8 +58,7 @@ text \<open>We introduce a new label. The name 'silc' here stands for 'safe inte
 datatype 'a subject_label = OrdinaryLabel 'a | SilcLabel
 
 
-abbreviation(input) aag_can_read_not_silc
-where
+abbreviation(input) aag_can_read_not_silc where
   "aag_can_read_not_silc aag ptr \<equiv> aag_can_read aag ptr \<and> pasObjectAbs aag ptr \<noteq> SilcLabel"
 
 
@@ -105,10 +70,8 @@ text\<open>We need to introduce an equivalence on the dummy domain, and add
    relatively easy. The annoying part is that now we end up proving
    a different property; it will take some finesse to avoid having
    to do a search/replace on @{term reads_respects} \<rightarrow> reads_respects_f\<close>
-definition silc_dom_equiv
-where
-  "silc_dom_equiv aag \<equiv>
-    equiv_for (\<lambda> x. pasObjectAbs aag x = SilcLabel) kheap"
+definition silc_dom_equiv where
+  "silc_dom_equiv aag \<equiv> equiv_for (\<lambda>x. pasObjectAbs aag x = SilcLabel) kheap"
 
 text\<open>This is an invariant that ensures that the info leak due to is_final_cap doesn't
    arise. Silc stands for 'safe inter label caps'.
@@ -117,29 +80,45 @@ text\<open>This is an invariant that ensures that the info leak due to is_final_
    invariant is preserved anyway. Including it here saves duplicating essentially identical
    reasoning.\<close>
 
-definition silc_inv :: "'a subject_label PAS \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool"
-where
+definition silc_inv :: "'a subject_label PAS \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool" where
   "silc_inv aag st s \<equiv>
-      (SilcLabel \<noteq> pasSubject aag) \<and>
-      (\<forall> x. pasObjectAbs aag x = SilcLabel \<longrightarrow>  (\<exists> sz. cap_table_at sz x s)) \<and>
-      (\<forall> y auth. (y,auth,SilcLabel) \<in> pasPolicy aag \<longrightarrow> y = SilcLabel) \<and>
-      (\<forall> slot cap. cte_wp_at ((=) cap) slot s \<and>
-          \<not> intra_label_cap aag slot s \<longrightarrow>
-         (\<exists> lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
-           (pasObjectAbs aag (fst lslot) = SilcLabel))) \<and>
-      all_children (\<lambda>x. pasObjectAbs aag (fst x) = SilcLabel) (cdt s) \<and>
-      silc_dom_equiv aag st s \<and>
-      \<comment> \<open>We want the following condition to hold on s as well,
-          but stating that here makes proofs more difficult.
-          It is shown below in silc_inv_no_transferable'.\<close>
-      (\<forall> slot. pasObjectAbs aag (fst slot) = SilcLabel \<and>
-               cte_wp_at (\<lambda>cap. cap \<noteq> NullCap \<and> is_transferable_cap cap) slot st
-           \<longrightarrow> False)"
+     (SilcLabel \<noteq> pasSubject aag) \<and>
+     (\<forall>x. pasObjectAbs aag x = SilcLabel \<longrightarrow>  (\<exists>sz. cap_table_at sz x s)) \<and>
+     (\<forall>y auth. (y, auth, SilcLabel) \<in> pasPolicy aag \<longrightarrow> y = SilcLabel) \<and>
+     (\<forall>slot cap. cte_wp_at ((=) cap) slot s \<and>
+                 \<not> intra_label_cap aag slot s
+                 \<longrightarrow> (\<exists>lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
+                              (pasObjectAbs aag (fst lslot) = SilcLabel))) \<and>
+     all_children (\<lambda>x. pasObjectAbs aag (fst x) = SilcLabel) (cdt s) \<and>
+     silc_dom_equiv aag st s \<and>
+     \<comment> \<open>We want the following condition to hold on s as well,
+         but stating that here makes proofs more difficult.
+         It is shown below in silc_inv_no_transferable'.\<close>
+     (\<forall>slot. pasObjectAbs aag (fst slot) = SilcLabel \<and>
+             cte_wp_at (\<lambda>cap. cap \<noteq> NullCap \<and> is_transferable_cap cap) slot st
+             \<longrightarrow> False)"
+
+
+(* FIXME MOVE *)
+context strengthen_implementation begin
+
+lemma strengthen_cte_wp_at[strg]:
+  "(\<And>x. st F (\<longrightarrow>) (P x) (Q x)) \<Longrightarrow> st F (\<longrightarrow>) (cte_wp_at P slot s) (cte_wp_at Q slot s)"
+  by (cases F, auto elim:cte_wp_at_weakenE)
+
+end
+
+
+lemma slots_holding_overlapping_caps_def':
+  "slots_holding_overlapping_caps cap s =
+   {cref. cte_wp_at (\<lambda>cap'. gen_obj_refs cap \<inter> gen_obj_refs cap' \<noteq> {}) cref s}"
+  unfolding slots_holding_overlapping_caps_def cte_wp_at_def gen_obj_refs_def
+  by blast
 
 lemma silc_inv_exst[simp]:
   "silc_inv aag st (trans_state f s) = silc_inv aag st s"
-  apply(auto simp: silc_inv_def intra_label_cap_def slots_holding_overlapping_caps_def silc_dom_equiv_def equiv_for_def)
-  done
+  by (auto simp: silc_inv_def silc_dom_equiv_def intra_label_cap_def
+                 equiv_for_def slots_holding_overlapping_caps_def)
 
 lemma silc_inv_not_subject:
   "silc_inv aag st s \<Longrightarrow> SilcLabel \<noteq> pasSubject aag"
@@ -150,7 +129,8 @@ lemma silc_inv_silc_dom_equiv:
   unfolding silc_inv_def by force
 
 lemma silc_inv_cnode_only:
-  "silc_inv aag st s \<Longrightarrow> pasObjectAbs aag x = SilcLabel \<Longrightarrow> (\<exists> sz. cap_table_at sz x s)"
+  "\<lbrakk> silc_inv aag st s; pasObjectAbs aag x = SilcLabel \<rbrakk>
+     \<Longrightarrow> \<exists>sz. cap_table_at sz x s"
   unfolding silc_inv_def by force
 
 lemma silc_inv_cnode_onlyE:
@@ -160,55 +140,48 @@ lemma silc_inv_cnode_onlyE:
   using si posl silc_inv_cnode_only by blast
 
 lemma silc_inv_no_transferable:
-  "silc_inv aag st s \<Longrightarrow> pasObjectAbs aag (fst slot) = SilcLabel \<Longrightarrow>
-   cte_wp_at (\<lambda>cap. cap \<noteq> NullCap \<and> is_transferable_cap cap) slot st \<Longrightarrow> False"
-  unfolding silc_inv_def by (force simp del:split_paired_All)
+  "\<lbrakk> silc_inv aag st s;  pasObjectAbs aag (fst slot) = SilcLabel;
+     cte_wp_at (\<lambda>cap. cap \<noteq> NullCap \<and> is_transferable_cap cap) slot st \<rbrakk>
+     \<Longrightarrow> False"
+  unfolding silc_inv_def by (force simp del: split_paired_All)
+
 lemmas silc_inv_no_transferableD = silc_inv_no_transferable[where slot="(a,b)" for a b,simplified]
 
-
 lemma cte_wp_at_pspace_specI:
-  "\<lbrakk> cte_wp_at P slot s; kheap s (fst slot) = kheap s' (fst slot) \<rbrakk> \<Longrightarrow> cte_wp_at P slot s'"
+  "\<lbrakk> cte_wp_at P slot s; kheap s (fst slot) = kheap s' (fst slot) \<rbrakk>
+     \<Longrightarrow> cte_wp_at P slot s'"
   by (simp add: cte_wp_at_cases)
 
 lemma silc_inv_no_transferable':
   "silc_inv aag st s \<Longrightarrow> pasObjectAbs aag (fst slot) = SilcLabel \<Longrightarrow>
    cte_wp_at (\<lambda>cap. cap \<noteq> NullCap \<and> is_transferable_cap cap) slot s \<Longrightarrow> False"
-  using [[simp_trace=true, simp_trace_depth_limit=10]]
-  apply (frule(1) silc_inv_no_transferable)
-  apply (drule silc_inv_silc_dom_equiv)
-  apply (simp add:silc_dom_equiv_def)
-  apply (drule(1) equiv_forD)
-  apply (elim cte_wp_at_pspace_specI)
+  apply (frule (1) silc_inv_no_transferable)
+   apply (drule silc_inv_silc_dom_equiv)
+   apply (simp add:silc_dom_equiv_def)
+   apply (drule (1) equiv_forD)
+   apply (elim cte_wp_at_pspace_specI)
   by simp+
-lemmas silc_inv_no_transferableD' =
-                 silc_inv_no_transferable'[where slot="(a,b)" for a b, simplified]
 
-end
+lemmas silc_inv_no_transferableD' =
+  silc_inv_no_transferable'[where slot="(a,b)" for a b, simplified]
 
 lemma (in is_extended') silc_inv[wp]: "I (silc_inv aag st)" by (rule lift_inv,simp)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
-
 lemma get_cap_cte_wp_at':
   "(fst (get_cap p s) = {(r,s)}) = cte_wp_at ((=) r) p s"
-  apply(auto simp: cte_wp_at_def)
-  done
+  by (auto simp: cte_wp_at_def)
 
 lemma silc_invD:
-  "\<lbrakk>silc_inv aag st s;
-    cte_wp_at ((=) cap) slot s;
-    \<not> intra_label_cap aag slot s\<rbrakk> \<Longrightarrow>
-         (\<exists> lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
-           (pasObjectAbs aag (fst lslot) = SilcLabel))"
-  apply(clarsimp simp: silc_inv_def)
-  apply(drule_tac x="fst slot" in spec, drule_tac x="snd slot" in spec, fastforce)
+  "\<lbrakk> silc_inv aag st s; cte_wp_at ((=) cap) slot s; \<not> intra_label_cap aag slot s \<rbrakk>
+     \<Longrightarrow> (\<exists>lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
+                 pasObjectAbs aag (fst lslot) = SilcLabel)"
+  apply (clarsimp simp: silc_inv_def)
+  apply (drule_tac x="fst slot" in spec, drule_tac x="snd slot" in spec, fastforce)
   done
 
 lemma is_final_cap'_def4:
-  "is_final_cap' cap s \<equiv>
-   \<exists> a b. slots_holding_overlapping_caps cap s = {(a,b)}"
-  apply(simp add: is_final_cap'_def slots_holding_overlapping_caps_def gen_obj_refs_Int)
-  done
+  "is_final_cap' cap s \<equiv> \<exists>a b. slots_holding_overlapping_caps cap s = {(a,b)}"
+  by (simp add: is_final_cap'_def slots_holding_overlapping_caps_def gen_obj_refs_Int)
 
 
 (* I think this property is strong enough to give us a sane
@@ -218,25 +191,25 @@ lemma is_final_cap'_def4:
 (* FIXME DELETE *)
 lemma silc_inv:
   "silc_inv aag st s \<Longrightarrow>
-      (\<forall> cap slot. cte_wp_at ((=) cap) slot s \<and> is_final_cap' cap s \<longrightarrow>
-        (intra_label_cap aag slot s \<or> (pasObjectAbs aag (fst slot) = SilcLabel)))"
+     (\<forall>cap slot. cte_wp_at ((=) cap) slot s \<and> is_final_cap' cap s \<longrightarrow>
+                 (intra_label_cap aag slot s \<or> (pasObjectAbs aag (fst slot) = SilcLabel)))"
   apply clarsimp
-  apply(erule contrapos_np)
-  apply(drule (2) silc_invD)
-  apply(subgoal_tac "(a,b) \<in> slots_holding_overlapping_caps cap s")
-   apply(clarsimp simp: is_final_cap'_def4 cte_wp_at_def)
-  apply(auto simp: slots_holding_overlapping_caps_def cte_wp_at_def)
+  apply (erule contrapos_np)
+  apply (drule (2) silc_invD)
+  apply (subgoal_tac "(a,b) \<in> slots_holding_overlapping_caps cap s")
+   apply (clarsimp simp: is_final_cap'_def4 cte_wp_at_def)
+  apply (auto simp: slots_holding_overlapping_caps_def cte_wp_at_def)
   done
 
 lemma silc_inv_finalD:
-  "silc_inv aag st s \<Longrightarrow> cte_wp_at ((=) cap) slot s \<Longrightarrow> is_final_cap' cap s \<Longrightarrow>
-        intra_label_cap aag slot s \<or> (pasObjectAbs aag (fst slot) = SilcLabel)"
+  "\<lbrakk> silc_inv aag st s; cte_wp_at ((=) cap) slot s; is_final_cap' cap s \<rbrakk>
+     \<Longrightarrow> intra_label_cap aag slot s \<or> (pasObjectAbs aag (fst slot) = SilcLabel)"
   apply clarsimp
-  apply(erule contrapos_np)
-  apply(drule (2) silc_invD)
-  apply(subgoal_tac "slot \<in> slots_holding_overlapping_caps cap s")
-   apply(clarsimp simp: is_final_cap'_def4 cte_wp_at_def)
-  apply(auto simp: slots_holding_overlapping_caps_def cte_wp_at_def)
+  apply (erule contrapos_np)
+  apply (drule (2) silc_invD)
+  apply (subgoal_tac "slot \<in> slots_holding_overlapping_caps cap s")
+   apply (clarsimp simp: is_final_cap'_def4 cte_wp_at_def)
+  apply (auto simp: slots_holding_overlapping_caps_def cte_wp_at_def)
   done
 
 lemma silc_inv_finalE:
@@ -244,35 +217,30 @@ lemma silc_inv_finalE:
   obtains "intra_label_cap aag slot s" | "pasObjectAbs aag (fst slot) = SilcLabel"
   using hyp silc_inv_finalD by blast
 
-
-
-
-
 lemma cte_wp_at_pspace':
   "kheap s (fst p) = kheap s' (fst p) \<Longrightarrow> cte_wp_at P p s = cte_wp_at P p s'"
-  apply(rule iffI)
-   apply(erule cte_wp_atE)
-    apply(auto intro: cte_wp_at_cteI dest: sym)[1]
-   apply(auto intro: cte_wp_at_tcbI dest: sym)[1]
-  apply(erule cte_wp_atE)
-   apply(auto intro: cte_wp_at_cteI dest: sym)[1]
-  apply(auto intro: cte_wp_at_tcbI dest: sym)[1]
+  apply (rule iffI)
+   apply (erule cte_wp_atE)
+    apply (auto intro: cte_wp_at_cteI dest: sym)[1]
+   apply (auto intro: cte_wp_at_tcbI dest: sym)[1]
+  apply (erule cte_wp_atE)
+   apply (auto intro: cte_wp_at_cteI dest: sym)[1]
+  apply (auto intro: cte_wp_at_tcbI dest: sym)[1]
   done
 
 lemma caps_of_state_pspace':
   assumes x: "kheap s (fst slot) = kheap s' (fst slot)"
-  shows      "caps_of_state s slot = caps_of_state s' slot"
+  shows "caps_of_state s slot = caps_of_state s' slot"
   by (simp add: caps_of_state_cte_wp_at cte_wp_at_pspace'[OF x])
 
 lemma caps_of_state_intra_label_cap:
-  "\<lbrakk>caps_of_state s slot = Some cap; caps_of_state t slot = Some cap;
-    intra_label_cap aag slot s\<rbrakk> \<Longrightarrow> intra_label_cap aag slot t"
+  "\<lbrakk> caps_of_state s slot = Some cap; caps_of_state t slot = Some cap; intra_label_cap aag slot s\<rbrakk>
+     \<Longrightarrow> intra_label_cap aag slot t"
   by (fastforce simp: intra_label_cap_def cte_wp_at_caps_of_state)
 
 lemma not_is_final_cap_caps_of_stateE:
-  assumes hyp: "\<not> is_final_cap' cap s" "caps_of_state s slot = Some cap"
-               "gen_obj_refs cap \<noteq> {}"
-  obtains slot' where  "slot' \<noteq> slot" "slot' \<in> slots_holding_overlapping_caps cap s"
+  assumes hyp: "\<not> is_final_cap' cap s" "caps_of_state s slot = Some cap" "gen_obj_refs cap \<noteq> {}"
+  obtains slot' where "slot' \<noteq> slot" "slot' \<in> slots_holding_overlapping_caps cap s"
   using hyp
   apply (simp add: is_final_cap'_def4)
   apply (subgoal_tac "slot \<in> slots_holding_overlapping_caps cap s")
@@ -282,59 +250,28 @@ lemma not_is_final_cap_caps_of_stateE:
   apply (auto simp: slots_holding_overlapping_caps_def' cte_wp_at_caps_of_state)
   done
 
-
 lemma is_final_then_nonempty_refs:
   "is_final_cap' cap s \<Longrightarrow> gen_obj_refs cap \<noteq> {}"
   by (auto simp add: is_final_cap'_def)
 
 lemma caps_ref_single_objects:
-  "\<lbrakk>x \<in> Structures_A.obj_refs cap;
-       y \<in> Structures_A.obj_refs cap\<rbrakk> \<Longrightarrow>
-      x = y"
-  apply(case_tac cap)
-  apply(simp_all)
-  done
+  "\<lbrakk> x \<in> Structures_A.obj_refs cap; y \<in> Structures_A.obj_refs cap \<rbrakk> \<Longrightarrow> x = y"
+  by (cases cap; simp)
 
 lemma caps_ref_single_irqs:
-  "\<lbrakk>x \<in> cap_irqs cap;
-       y \<in> cap_irqs cap\<rbrakk> \<Longrightarrow>
-      x = y"
-  apply(case_tac cap)
-  apply(simp_all)
+  "\<lbrakk> x \<in> cap_irqs cap; y \<in> cap_irqs cap \<rbrakk> \<Longrightarrow> x = y"
+  by (cases cap; simp)
+
+lemma not_is_final_cap[rotated -1]:
+  "\<lbrakk> caps_of_state s slot = Some cap; caps_of_state s slot' = Some cap';
+     gen_obj_refs cap \<inter> gen_obj_refs cap' \<noteq> {}; slot' \<noteq> slot \<rbrakk>
+     \<Longrightarrow> \<not> is_final_cap' cap s"
+  apply (rule ccontr)
+  apply (clarsimp simp: is_final_cap'_def get_cap_cte_wp_at' cte_wp_at_caps_of_state)
+  apply (erule_tac B="{(a,b)}" in equalityE)
+  apply (frule_tac c=slot in subsetD; fastforce)
   done
 
-lemma not_is_final_cap:
-  "\<lbrakk>slot' \<noteq> slot;
-    caps_of_state s slot = Some cap;
-    caps_of_state s slot' = Some cap';
-    gen_obj_refs cap \<inter> gen_obj_refs cap' \<noteq> {}\<rbrakk>
-   \<Longrightarrow> \<not> is_final_cap' cap s"
-  apply(rule ccontr)
-  apply(clarsimp simp: is_final_cap'_def get_cap_cte_wp_at' cte_wp_at_caps_of_state)
-  apply(erule_tac B="{(a,b)}" in equalityE)
-   apply(frule_tac c=slot in subsetD)
-    apply fastforce
-  apply(drule_tac c=slot' in subsetD)
-   subgoal by fastforce
-  by fastforce
-
-lemma caps_ref_either_an_object_or_irq:
-   "ref \<in> Structures_A.obj_refs cap' \<Longrightarrow>
-       (cap_irqs cap' = {} \<and> arch_gen_refs cap' = {})"
-  apply(case_tac cap', simp_all)
-  done
-
-lemma caps_ref_either_an_object_or_irq':
-   "ref \<in> cap_irqs cap' \<Longrightarrow>
-       (Structures_A.obj_refs cap' = {} \<and> arch_gen_refs cap' = {})"
-  apply(case_tac cap', simp_all)
-  done
-
-lemma caps_ref_either_an_object_or_irq'':
-   "ref \<in> arch_gen_refs cap' \<Longrightarrow>
-       (Structures_A.obj_refs cap' = {} \<and> cap_irqs cap' = {})"
-  apply(case_tac cap', simp_all)
-  done
 
 definition reads_equiv_f
 where
@@ -344,43 +281,115 @@ abbreviation reads_respects_f
 where
   "reads_respects_f aag l P f \<equiv> equiv_valid_inv (reads_equiv_f aag) (affects_equiv aag l) P f"
 
+
 lemma intra_label_capD:
-  "\<lbrakk>intra_label_cap aag slot s;
-      cte_wp_at ((=) cap) slot s\<rbrakk> \<Longrightarrow>
-         (cap_points_to_label aag cap (pasObjectAbs aag (fst slot)))"
+  "\<lbrakk> intra_label_cap aag slot s; cte_wp_at ((=) cap) slot s \<rbrakk>
+     \<Longrightarrow> cap_points_to_label aag cap (pasObjectAbs aag (fst slot))"
   by (auto simp: intra_label_cap_def)
 
 lemma intra_label_capD':
-  "\<lbrakk>intra_label_cap aag slot s;
-      caps_of_state s slot = Some cap\<rbrakk> \<Longrightarrow>
-         (cap_points_to_label aag cap (pasObjectAbs aag (fst slot)))"
+  "\<lbrakk> intra_label_cap aag slot s; caps_of_state s slot = Some cap \<rbrakk>
+     \<Longrightarrow> cap_points_to_label aag cap (pasObjectAbs aag (fst slot))"
   by (auto simp: intra_label_cap_def cte_wp_at_caps_of_state)
 
 lemma is_subject_kheap_eq:
-  "\<lbrakk>reads_equiv aag s t; is_subject aag ptr\<rbrakk> \<Longrightarrow> kheap s ptr = kheap t ptr"
+  "\<lbrakk> reads_equiv aag s t; is_subject aag ptr \<rbrakk>
+     \<Longrightarrow> kheap s ptr = kheap t ptr"
   apply (clarsimp simp: reads_equiv_def2)
   apply (erule states_equiv_forE_kheap)
   apply (blast intro: aag_can_read_self)
   done
 
 lemma aag_can_read_kheap_eq:
-  "\<lbrakk>reads_equiv aag s t; aag_can_read aag ptr\<rbrakk> \<Longrightarrow> kheap s ptr = kheap t ptr"
+  "\<lbrakk> reads_equiv aag s t; aag_can_read aag ptr \<rbrakk>
+     \<Longrightarrow> kheap s ptr = kheap t ptr"
   apply (clarsimp simp: reads_equiv_def2)
   apply (erule states_equiv_forE_kheap)
   apply blast
   done
 
+lemma caps_ref_either_an_object_or_irq':
+   "ref \<in> cap_irqs cap' \<Longrightarrow>
+    (Structures_A.obj_refs cap' = {} \<and> arch_gen_refs cap' = {})"
+  apply (case_tac cap', simp_all)
+  done
+
+
+locale FinalCaps_1 =
+  fixes aag :: "'a subject_label PAS"
+  (* FIXME IF: precludes X64 *)
+  assumes FIXME_arch_gen_refs:
+    "arch_gen_refs cap = {}"
+  and aobj_ref_same_aobject:
+    "same_aobject_as cp cp' \<Longrightarrow> aobj_ref cp = aobj_ref cp'"
+  and arch_invoke_irq_handler_silc_inv[wp]:
+    "arch_invoke_irq_handler hi \<lbrace>silc_inv aag st\<rbrace>"
+  and arch_post_cap_deletion_silc_inv[wp]:
+    "arch_post_cap_deletion acap \<lbrace>silc_inv aag st\<rbrace>"
+  and arch_finalise_cap_silc_inv[wp]:
+    "arch_finalise_cap c x \<lbrace>silc_inv aag st\<rbrace>"
+  and prepare_thread_delete_silc_inv[wp]:
+    "prepare_thread_delete p \<lbrace>silc_inv aag st\<rbrace>"
+  and handle_reserved_irq_silc_inv[wp]:
+    "handle_reserved_irq irq \<lbrace>silc_inv aag st\<rbrace>"
+  and arch_mask_irq_signal_silc_inv[wp]:
+    "arch_mask_irq_signal irq \<lbrace>silc_inv aag st\<rbrace>"
+  and handle_vm_fault_silc_inv[wp]:
+    "handle_vm_fault t vmft \<lbrace>silc_inv aag st\<rbrace>"
+  and handle_vm_fault_cur_thread[wp]:
+    "\<And>P. handle_vm_fault t vmft \<lbrace>\<lambda>s :: det_state. P (cur_thread s)\<rbrace>"
+  and handle_hypervisor_fault_silc_inv[wp]:
+    "handle_hypervisor_fault t hvft \<lbrace>silc_inv aag st\<rbrace>"
+  and arch_activate_idle_threadt_silc_inv[wp]:
+    "arch_activate_idle_thread t \<lbrace>silc_inv aag st\<rbrace>"
+  and arch_switch_to_idle_thread_silc_inv[wp]:
+    "arch_switch_to_idle_thread \<lbrace>silc_inv aag st\<rbrace>"
+  and arch_switch_to_thread_silc_inv[wp]:
+    "arch_switch_to_thread t \<lbrace>silc_inv aag st\<rbrace>"
+  and init_arch_objects_silc_inv[wp]:
+    "init_arch_objects typ ptr num sz refs \<lbrace>silc_inv aag st\<rbrace>"
+  and init_arch_objects_cte_wp_at[wp]:
+    "\<And>P. init_arch_objects typ ptr num sz refs \<lbrace>\<lambda>s :: det_state. P (cte_wp_at P' slot s)\<rbrace>"
+  (* FIXME IF: having to qualify obj_refs is very annoying *)
+  and finalise_cap_makes_halted:
+    "\<lbrace>invs and valid_cap cap and (\<lambda>s. ex = is_final_cap' cap s) and cte_wp_at ((=) cap) slot\<rbrace>
+     finalise_cap cap ex
+     \<lbrace>\<lambda>rv s :: det_state. \<forall>t \<in> Structures_A.obj_refs (fst rv). halted_if_tcb t s\<rbrace>"
+  and arch_post_modify_registers_silc_inv[wp]:
+    "arch_post_modify_registers cur t \<lbrace>silc_inv aag st\<rbrace>"
+  and arch_derive_cap_silc:
+    "\<lbrace>\<lambda>s :: det_state. cap = ArchObjectCap acap \<and>
+                       (\<not> cap_points_to_label aag cap l \<longrightarrow> R (slots_holding_overlapping_caps cap s))\<rbrace>
+     arch_derive_cap acap
+     \<lbrace>\<lambda>cap' s. \<not> cap_points_to_label aag cap' l \<longrightarrow> R (slots_holding_overlapping_caps cap' s)\<rbrace>,-"
+begin
+
+lemma cap_points_to_label_def':
+  "cap_points_to_label aag cap l = (\<forall>x \<in> gen_obj_refs cap. pasGenAbs aag x = l)"
+  unfolding cap_points_to_label_def
+  by (simp add: gen_obj_refs_def ball_Un FIXME_arch_gen_refs)
+
+lemma caps_ref_either_an_object_or_irq:
+   "ref \<in> Structures_A.obj_refs cap'
+    \<Longrightarrow> cap_irqs cap' = {} \<and> arch_gen_refs cap' = {}"
+  apply (clarsimp simp: FIXME_arch_gen_refs)
+  apply (case_tac cap'; clarsimp)
+  done
+
+lemma caps_ref_either_an_object_or_irq'':
+   "ref \<in> arch_gen_refs cap'
+    \<Longrightarrow> Structures_A.obj_refs cap' = {} \<and> cap_irqs cap' = {}"
+  apply (clarsimp simp: FIXME_arch_gen_refs)
+  done
+
 lemma arch_gen_refs_no_intersection[simp]:
   "arch_gen_refs c \<inter> arch_gen_refs c' = {}"
-  by (cases c; auto)
-
+  by (cases c; auto simp: FIXME_arch_gen_refs)
 
 lemma is_final_cap'_read_equiv_imp:
-  "\<lbrakk>silc_inv aag st s; cte_wp_at ((=) cap) slot s;
-           silc_inv aag st t; cte_wp_at ((=) cap) slot t;
-           aag_can_read_not_silc aag (fst slot); reads_equiv aag s t;
-           is_final_cap' cap s\<rbrakk>
-          \<Longrightarrow> is_final_cap' cap t"
+  "\<lbrakk> silc_inv aag st s; cte_wp_at ((=) cap) slot s; silc_inv aag st t; cte_wp_at ((=) cap) slot t;
+     aag_can_read_not_silc aag (fst slot); reads_equiv aag s t; is_final_cap' cap s \<rbrakk>
+     \<Longrightarrow> is_final_cap' cap t"
   unfolding F[symmetric]
   subgoal premises prems
   proof (rule ccontr)
@@ -389,20 +398,17 @@ lemma is_final_cap'_read_equiv_imp:
       by (fastforce elim: silc_inv_finalE[OF _ caps_of_state_cteD, where s = s])
     hence ilct: "intra_label_cap aag slot t"
       using prems caps_of_state_intra_label_cap by blast
-
     from prems have sdest: "silc_dom_equiv aag s t"
       by (fastforce simp: silc_dom_equiv_def intro: equiv_for_trans
-                    elim: equiv_for_sym       dest: silc_inv_silc_dom_equiv)
+                    dest: silc_inv_silc_dom_equiv elim: equiv_for_sym)
 
     (* if cap is non final, then there must exists another cap overlapping somewhere *)
     from not_final prems obtain slot' where "slot' \<in> slots_holding_overlapping_caps cap t"
                                         and diff: "slot' \<noteq> slot"
-      by (fastforce  elim: not_is_final_cap_caps_of_stateE[OF _ _ is_final_then_nonempty_refs])
-
+      by (fastforce elim: not_is_final_cap_caps_of_stateE[OF _ _ is_final_then_nonempty_refs])
     then obtain cap' where cap': "caps_of_state t slot' = Some cap'"
                        and cap_overlap_cap': "gen_obj_refs cap \<inter> gen_obj_refs cap' \<noteq> {}"
       by (fastforce simp: slots_holding_overlapping_caps_def' cte_wp_at_caps_of_state)
-
     note prems = prems not_final cap' cap_overlap_cap' diff
     show False
     proof (cases "aag_can_read aag (fst slot')")
@@ -419,24 +425,19 @@ lemma is_final_cap'_read_equiv_imp:
       (* slot is in subjectRead, slot' isn't. However they hold overlaping caps. Thus: *)
       hence not_intra : "\<not> intra_label_cap aag slot' t"
         using prems ilct by (fastforce simp: cap_points_to_label_def' dest!: intra_label_capD')
-
-
       (* Then, accroding to silc_inv, there is a third cap in SilcLabel overlapping cap and cap'*)
       then obtain lslot where "lslot \<in> slots_holding_overlapping_caps cap' t"
                           and lslot_silc: "pasObjectAbs aag (fst lslot) = SilcLabel"
         using prems silc_invD[simplified F[symmetric]] by blast
-
       then obtain lcap where lcap_t: "caps_of_state t lslot = Some lcap"
                          and lcap_overlap_cap': "gen_obj_refs cap' \<inter> gen_obj_refs lcap \<noteq> {}"
         by (fastforce simp: slots_holding_overlapping_caps_def' cte_wp_at_caps_of_state)
-
       (* As lslot is in SilcLabel, kheap do not change between s and t and thus: *)
       have lcap_s: "caps_of_state s lslot = Some lcap"
         using lcap_t prems sdest
         apply (unfold silc_dom_equiv_def)
         apply (drule equiv_forD, rule lslot_silc)
         by (subst caps_of_state_pspace'; assumption)
-
       (* lcap thus overlaps cap in s but cap was final in s: contradiction *)
       then show ?thesis (* TODO CLEANUP *)
         using prems lslot_silc lcap_overlap_cap' lcap_s
@@ -453,24 +454,24 @@ lemma is_final_cap'_read_equiv_imp:
   done
 
 lemma is_final_cap'_read_equiv_eq:
-  "\<lbrakk>silc_inv aag st s; cte_wp_at ((=) cap) slot s;
-           silc_inv aag st t; cte_wp_at ((=) cap) slot t;
-           aag_can_read_not_silc aag (fst slot); reads_equiv aag s t\<rbrakk>
-          \<Longrightarrow> is_final_cap' cap s = is_final_cap' cap t"
+  "\<lbrakk> silc_inv aag st s; cte_wp_at ((=) cap) slot s; silc_inv aag st t;
+     cte_wp_at ((=) cap) slot t; aag_can_read_not_silc aag (fst slot); reads_equiv aag s t \<rbrakk>
+     \<Longrightarrow> is_final_cap' cap s = is_final_cap' cap t"
   apply (rule iffI)
   subgoal by (rule is_final_cap'_read_equiv_imp)
   apply (drule reads_equiv_sym)
   subgoal by (rule is_final_cap'_read_equiv_imp)
   done
 
-
 lemma is_final_cap_reads_respects:
-  "reads_respects_f aag l (silc_inv aag st and ( \<lambda> s. cte_wp_at ((=) cap) slot s \<and>
-                           aag_can_read_not_silc aag (fst slot)))
-                    (is_final_cap cap)"
+  "reads_respects_f aag l (silc_inv aag st and (\<lambda>s. cte_wp_at ((=) cap) slot s \<and>
+                                                    aag_can_read_not_silc aag (fst slot)))
+                          (is_final_cap cap)"
   unfolding is_final_cap_def
-  by (clarsimp simp: equiv_valid_def2 equiv_valid_2_def in_monad reads_equiv_f_def
-                     is_final_cap'_read_equiv_eq)
+  by (clarsimp simp: equiv_valid_def2 equiv_valid_2_def in_monad
+                     reads_equiv_f_def is_final_cap'_read_equiv_eq)
+
+end
 
 
 definition ctes_wp_at
@@ -479,443 +480,299 @@ where
 
 lemma slots_holding_overlapping_caps_def2:
   "slots_holding_overlapping_caps cap s =
-     ctes_wp_at (\<lambda> c. (Structures_A.obj_refs cap \<inter> Structures_A.obj_refs c \<noteq> {}) \<or>
-                      (cap_irqs cap \<inter> cap_irqs c \<noteq> {}) \<or>
-                      (arch_gen_refs cap \<inter> arch_gen_refs c \<noteq> {})) s"
-  apply(simp add: slots_holding_overlapping_caps_def ctes_wp_at_def cte_wp_at_def)
-  done
-
+     ctes_wp_at (\<lambda>c. (Structures_A.obj_refs cap \<inter> Structures_A.obj_refs c \<noteq> {}) \<or>
+                     (cap_irqs cap \<inter> cap_irqs c \<noteq> {}) \<or>
+                     (arch_gen_refs cap \<inter> arch_gen_refs c \<noteq> {})) s"
+  by (simp add: slots_holding_overlapping_caps_def ctes_wp_at_def cte_wp_at_def)
 
 lemma intra_label_cap_pres:
-  assumes cte: "\<And> P. \<lbrace>\<lambda> s. \<not> (cte_wp_at P slot s)\<rbrace> f \<lbrace>\<lambda> _ s. \<not>  (cte_wp_at P slot s)\<rbrace>"
-  shows "\<lbrace>\<lambda> s. (intra_label_cap aag slot s) \<rbrace> f \<lbrace>\<lambda> _s. (intra_label_cap aag slot s) \<rbrace>"
-  apply(clarsimp simp: valid_def intra_label_cap_def)
-  apply(drule_tac x=cap in spec)
-  apply(case_tac "cte_wp_at ((=) cap) slot s")
+  assumes cte: "\<And>P. \<lbrace>\<lambda> s. \<not> cte_wp_at P slot s\<rbrace> f \<lbrace>\<lambda> _ s. \<not> cte_wp_at P slot s\<rbrace>"
+  shows "\<lbrace>intra_label_cap aag slot\<rbrace> f \<lbrace>\<lambda>_. intra_label_cap aag slot\<rbrace>"
+  apply (clarsimp simp: valid_def intra_label_cap_def)
+  apply (drule_tac x=cap in spec)
+  apply (case_tac "cte_wp_at ((=) cap) slot s")
    apply blast
-  apply(drule_tac use_valid[OF _ cte])
+  apply (drule_tac use_valid[OF _ cte])
    apply assumption
   apply blast
   done
 
 lemma not_intra_label_cap_pres:
-  assumes cte: "\<And>P. \<lbrace>\<lambda> s. (cte_wp_at P slot s)\<rbrace> f \<lbrace>\<lambda> _ s. (cte_wp_at P slot s)\<rbrace>"
-  shows "\<lbrace>\<lambda> s. \<not> (intra_label_cap aag slot s) \<rbrace> f \<lbrace>\<lambda> _s. \<not> (intra_label_cap aag slot s) \<rbrace>"
-  apply(clarsimp simp: valid_def intra_label_cap_def)
-  apply(rule_tac x=cap in exI)
-  apply(drule_tac use_valid[OF _ cte], assumption)
+  assumes cte: "\<And>P. \<lbrace>cte_wp_at P slot\<rbrace> f \<lbrace>\<lambda>_. cte_wp_at P slot\<rbrace>"
+  shows "\<lbrace>\<lambda>s. \<not> intra_label_cap aag slot s\<rbrace> f \<lbrace>\<lambda>_ s. \<not> intra_label_cap aag slot s\<rbrace>"
+  apply (clarsimp simp: valid_def intra_label_cap_def)
+  apply (rule_tac x=cap in exI)
+  apply (drule_tac use_valid[OF _ cte], assumption)
   apply blast
   done
 
 lemma cte_wp_at_pres_from_kheap':
   assumes l:
-    "\<And> ptr P.
-     \<lbrace> R and (\<lambda> s. P (kheap s ptr)) and K (pasObjectAbs aag ptr = l)\<rbrace>
-        f
-     \<lbrace>\<lambda> _ s. P (kheap s ptr)\<rbrace>"
-  shows
-    "\<lbrace>(\<lambda> s. Q (cte_wp_at P slot s)) and R and K (pasObjectAbs aag (fst slot) = l)\<rbrace>
-        f
-     \<lbrace>( \<lambda> _ s. Q (cte_wp_at P slot s))\<rbrace>"
-  apply(rule hoare_gen_asm)
-  apply(simp add: valid_def | intro allI impI ballI)+
-  apply(rename_tac x, case_tac x, simp, rename_tac rv s')
-  apply(subgoal_tac "\<exists> x. kheap s (fst slot) = x")
-   apply(erule exE, rename_tac x)
-   apply(drule use_valid)
-     apply(rule_tac ptr="fst slot" and P="\<lambda> y. y = x" in l)
+    "\<And>ptr P.
+     \<lbrace>R and (\<lambda>s. P (kheap s ptr)) and K (pasObjectAbs aag ptr = l)\<rbrace>
+     f
+     \<lbrace>\<lambda>_ s. P (kheap s ptr)\<rbrace>"
+  shows "\<lbrace>(\<lambda>s. Q (cte_wp_at P slot s)) and R and K (pasObjectAbs aag (fst slot) = l)\<rbrace>
+         f
+         \<lbrace>(\<lambda>_ s. Q (cte_wp_at P slot s))\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (simp add: valid_def | intro allI impI ballI)+
+  apply (rename_tac x, case_tac x, simp, rename_tac rv s')
+  apply (subgoal_tac "\<exists>x. kheap s (fst slot) = x")
+   apply (erule exE, rename_tac x)
+   apply (drule use_valid)
+     apply (rule_tac ptr="fst slot" and P="\<lambda> y. y = x" in l)
     apply simp
-   apply(drule trans, erule sym)
-   apply(drule_tac P=P in cte_wp_at_pspace')
+   apply (drule trans, erule sym)
+   apply (drule_tac P=P in cte_wp_at_pspace')
    apply simp
   apply blast
   done
 
-
 lemmas cte_wp_at_pres_from_kheap = cte_wp_at_pres_from_kheap'[where R="\<top>", simplified]
 
 lemma hoare_contrapositive:
-  "\<lbrakk>\<lbrace> P \<rbrace> f \<lbrace> Q \<rbrace>;  \<not> Q r s'; (r, s') \<in> fst (f s)\<rbrakk> \<Longrightarrow>
-   \<not> P s"
-  apply(case_tac "P s")
-   apply(blast dest: use_valid)
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<not> Q r s'; (r, s') \<in> fst (f s) \<rbrakk> \<Longrightarrow> \<not> P s"
+  apply (case_tac "P s")
+   apply (blast dest: use_valid)
   apply assumption
   done
 
-
-lemma allI': "\<forall>x y. P x y \<Longrightarrow> \<forall> y x. P x y"
+lemma allI': "\<forall>x y. P x y \<Longrightarrow> \<forall>y x. P x y"
   by simp
 
 lemma silc_inv_pres:
-  assumes l:
-    "\<And> ptr P.
-     \<lbrace> silc_inv aag st and (\<lambda> s. P (kheap s ptr)) and K (pasObjectAbs aag ptr = SilcLabel)\<rbrace>
-       f
-     \<lbrace>\<lambda> _ s. P (kheap s ptr)\<rbrace>"
-  assumes c: "\<And>P. \<lbrace>\<lambda>s. P (cdt s) \<rbrace> f \<lbrace>\<lambda> _ s. P (cdt s)\<rbrace>"
-  assumes ncte: "\<And> P slot. \<lbrace> \<lambda> s. \<not> (cte_wp_at P slot s) \<rbrace> f \<lbrace> \<lambda> _ s. \<not> (cte_wp_at P slot s) \<rbrace>"
-  shows
-    "\<lbrace> silc_inv aag st \<rbrace> f \<lbrace> \<lambda>_. silc_inv aag st\<rbrace>"
-  apply(clarsimp simp: valid_def silc_inv_def)
-  apply(clarsimp simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-  apply(rule conjI)
-   apply(intro allI impI)
-   apply(frule_tac x=x in spec, erule (1) impE)
-   apply(erule exE, rename_tac sz, rule_tac x=sz in exI)
-   apply(simp add: obj_at_def)
-   apply(elim exE conjE, rename_tac ko)
-   apply(rule_tac x=ko in exI, simp)
-   apply(erule use_valid[OF _ l])
+  assumes l: "\<And>ptr P.
+              \<lbrace>silc_inv aag st and (\<lambda>s. P (kheap s ptr)) and K (pasObjectAbs aag ptr = SilcLabel)\<rbrace>
+              f
+              \<lbrace>\<lambda>_ s. P (kheap s ptr)\<rbrace>"
+  assumes c: "\<And>P. \<lbrace>\<lambda>s. P (cdt s)\<rbrace> f \<lbrace>\<lambda>_ s. P (cdt s)\<rbrace>"
+  assumes ncte: "\<And>P slot. \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace> f \<lbrace>\<lambda>_ s. \<not> cte_wp_at P slot s\<rbrace>"
+  shows "\<lbrace>silc_inv aag st\<rbrace> f \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (clarsimp simp: valid_def silc_inv_def)
+  apply (clarsimp simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
+  apply (rule conjI)
+   apply (intro allI impI)
+   apply (frule_tac x=x in spec, erule (1) impE)
+   apply (erule exE, rename_tac sz, rule_tac x=sz in exI)
+   apply (simp add: obj_at_def)
+   apply (elim exE conjE, rename_tac ko)
+   apply (rule_tac x=ko in exI, simp)
+   apply (erule use_valid[OF _ l])
    apply simp
-   apply(clarsimp simp: silc_inv_def obj_at_def slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-  apply(rule conjI)
+   apply (clarsimp simp: silc_inv_def obj_at_def slots_holding_overlapping_caps_def2 ctes_wp_at_def)
+  apply (rule conjI)
    apply clarsimp
-   apply(frule_tac x=aa in spec, drule_tac x=ba in spec, drule_tac x=cap in spec)
-   apply(subgoal_tac "cte_wp_at ((=) cap) (aa, ba) s \<and> \<not> intra_label_cap aag (aa,ba) s")
-    apply(erule (1) impE)
+   apply (frule_tac x=aa in spec, drule_tac x=ba in spec, drule_tac x=cap in spec)
+   apply (subgoal_tac "cte_wp_at ((=) cap) (aa, ba) s \<and> \<not> intra_label_cap aag (aa,ba) s")
+    apply (erule (1) impE)
     apply (elim exE conjE)+
     apply (rule_tac x=ab in exI, rule conjI, rule_tac x=bb in exI)
      apply (erule use_valid[OF _ cte_wp_at_pres_from_kheap'[where R="silc_inv aag st"]])
-      apply(rule l)
+      apply (rule l)
      apply simp
-     apply(clarsimp simp: silc_inv_def tcb_at_typ obj_at_def
-                          slots_holding_overlapping_caps_def2 ctes_wp_at_def)
+     apply (clarsimp simp: silc_inv_def tcb_at_typ obj_at_def
+                           slots_holding_overlapping_caps_def2 ctes_wp_at_def)
     apply assumption
-   apply(rule conjI)
-    apply(erule (1) hoare_contrapositive[OF ncte, simplified])
-   apply(rule hoare_contrapositive[OF intra_label_cap_pres, simplified, OF ncte], assumption+)
+   apply (rule conjI)
+    apply (erule (1) hoare_contrapositive[OF ncte, simplified])
+   apply (rule hoare_contrapositive[OF intra_label_cap_pres, simplified, OF ncte], assumption+)
   apply (rule conjI)
    apply (erule use_valid[OF _ c])
    apply simp
-  apply(simp add: silc_dom_equiv_def)
-  apply(rule equiv_forI)
-  apply(erule use_valid[OF _ l])
-  apply(fastforce simp: silc_inv_def obj_at_def slots_holding_overlapping_caps_def2
-                        ctes_wp_at_def silc_dom_equiv_def
-                  elim: equiv_forE)
+  apply (simp add: silc_dom_equiv_def)
+  apply (rule equiv_forI)
+  apply (erule use_valid[OF _ l])
+  apply (fastforce simp: silc_inv_def obj_at_def slots_holding_overlapping_caps_def2
+                         ctes_wp_at_def silc_dom_equiv_def
+                   elim: equiv_forE)
   done
 
 
 (* if we don't touch any caps or modify any object-types, then
    silc_inv is preserved *)
 lemma silc_inv_triv:
-  assumes kheap: "\<And> P x. \<lbrace>\<lambda> s. P (kheap s x) \<rbrace> f \<lbrace> \<lambda>_ s. P (kheap s x) \<rbrace>"
-  assumes c: "\<And>P. \<lbrace>\<lambda>s. P (cdt s) \<rbrace> f \<lbrace>\<lambda> _ s. P (cdt s)\<rbrace>"
-  assumes cte: "\<And> Q P slot. \<lbrace>\<lambda> s. Q (cte_wp_at P slot s)\<rbrace> f \<lbrace>\<lambda> _ s. Q (cte_wp_at P slot s)\<rbrace>"
-  assumes typ_at: "\<And> P T p. \<lbrace> \<lambda> s. P (typ_at T p s) \<rbrace> f \<lbrace> \<lambda> _ s. P (typ_at T p s) \<rbrace>"
-  shows
-    "\<lbrace> silc_inv aag st \<rbrace> f \<lbrace> \<lambda>_. silc_inv aag st \<rbrace>"
-  apply(clarsimp simp: valid_def silc_inv_def)
-  apply(rule conjI)
-   apply(intro allI impI)
-   apply(erule use_valid)
-    apply(rule hoare_vcg_ex_lift)
-    apply(rule cap_table_at_lift_valid[OF typ_at])
+  assumes kheap: "\<And>P x. \<lbrace>\<lambda>s. P (kheap s x)\<rbrace> f \<lbrace>\<lambda>_ s. P (kheap s x)\<rbrace>"
+  assumes c: "\<And>P. \<lbrace>\<lambda>s. P (cdt s)\<rbrace> f \<lbrace>\<lambda> _ s. P (cdt s)\<rbrace>"
+  assumes cte: "\<And>Q P slot. \<lbrace>\<lambda>s. Q (cte_wp_at P slot s)\<rbrace> f \<lbrace>\<lambda>_ s. Q (cte_wp_at P slot s)\<rbrace>"
+  assumes typ_at: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at T p s)\<rbrace>"
+  shows "\<lbrace>silc_inv aag st\<rbrace> f \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (clarsimp simp: valid_def silc_inv_def)
+  apply (rule conjI)
+   apply (intro allI impI)
+   apply (erule use_valid)
+    apply (rule hoare_vcg_ex_lift)
+    apply (rule cap_table_at_lift_valid[OF typ_at])
    apply blast
-  apply(rule conjI)
-   apply(clarsimp simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-   apply(drule_tac x=aa in spec, drule_tac x=ba in spec, drule_tac x=cap in spec)
-   apply(subgoal_tac "cte_wp_at ((=) cap) (aa, ba) s \<and> \<not> intra_label_cap aag (aa,ba) s")
-    apply(elim exE conjE | simp)+
+  apply (rule conjI)
+   apply (clarsimp simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
+   apply (drule_tac x=aa in spec, drule_tac x=ba in spec, drule_tac x=cap in spec)
+   apply (subgoal_tac "cte_wp_at ((=) cap) (aa, ba) s \<and> \<not> intra_label_cap aag (aa,ba) s")
+    apply (elim exE conjE | simp)+
     apply (rule_tac x=ab in exI, rule conjI, rule_tac x=bb in exI)
      apply (erule (1) use_valid[OF _ cte])
-    apply(assumption)
-   apply(rule conjI)
-    apply(case_tac "cte_wp_at ((=) cap) (aa, ba) s")
+    apply (assumption)
+   apply (rule conjI)
+    apply (case_tac "cte_wp_at ((=) cap) (aa, ba) s")
      apply assumption
-    apply(drule use_valid[OF _ cte[where Q="\<lambda> x. \<not> x"]])
+    apply (drule use_valid[OF _ cte[where Q="\<lambda> x. \<not> x"]])
      apply assumption
     apply blast
-   apply(case_tac "intra_label_cap aag (aa, ba) s")
-    apply(drule_tac use_valid[OF _ intra_label_cap_pres[OF cte]])
+   apply (case_tac "intra_label_cap aag (aa, ba) s")
+    apply (drule_tac use_valid[OF _ intra_label_cap_pres[OF cte]])
      apply assumption
     apply blast
    apply assumption
-  apply(simp add: silc_dom_equiv_def)
+  apply (simp add: silc_dom_equiv_def)
   apply (rule conjI)
    apply (erule use_valid[OF _ c])
    apply simp
-  apply(rule equiv_forI)
-  apply(erule use_valid[OF _ kheap])
-  apply(fastforce elim: equiv_forE)
+  apply (rule equiv_forI)
+  apply (erule use_valid[OF _ kheap])
+  apply (fastforce elim: equiv_forE)
   done
 
-
-lemma set_object_wp:
-  "\<lbrace> \<lambda> s. P (s\<lparr>kheap := kheap s(ptr \<mapsto> obj)\<rparr>) \<rbrace>
-   set_object ptr obj
-   \<lbrace> \<lambda>_. P \<rbrace>"
-  by (wpsimp wp: set_object_wp)
-
-
-
 lemma set_cap_well_formed_cnode_helper:
-  "\<lbrakk>well_formed_cnode_n x xa; xa (snd slot) = Some y\<rbrakk> \<Longrightarrow>
-    well_formed_cnode_n x
-           (\<lambda>a. if a = snd slot then Some cap else xa a)"
-  apply(simp add: well_formed_cnode_n_def)
-  apply(rule equalityI)
-   apply(drule equalityD1)
-   apply(fastforce dest: subsetD split: if_splits)
-  apply(drule equalityD2)
-  apply(fastforce dest: subsetD split: if_splits)
+  "\<lbrakk> well_formed_cnode_n x xa; xa (snd slot) = Some y \<rbrakk>
+     \<Longrightarrow> well_formed_cnode_n x (\<lambda>a. if a = snd slot then Some cap else xa a)"
+  apply (simp add: well_formed_cnode_n_def)
+  apply (rule equalityI)
+   apply (drule equalityD1)
+   apply (fastforce dest: subsetD split: if_splits)
+  apply (drule equalityD2)
+  apply (fastforce dest: subsetD split: if_splits)
   done
 
 lemma set_cap_slots_holding_overlapping_caps_helper:
-  "\<lbrakk>x \<in> slots_holding_overlapping_caps cap s; fst x \<noteq> fst slot;
-        ko_at (TCB tcb) (fst slot) s;
-        Structures_A.obj_refs cap = {} \<longrightarrow> cap_irqs cap \<noteq> {};
-        tcb_cap_cases (snd slot) = Some (getF, setF, blah)\<rbrakk>
-       \<Longrightarrow> x \<in> slots_holding_overlapping_caps cap
+  "\<lbrakk> x \<in> slots_holding_overlapping_caps cap s; fst x \<noteq> fst slot;
+     Structures_A.obj_refs cap = {} \<longrightarrow> cap_irqs cap \<noteq> {};
+     ko_at (TCB tcb) (fst slot) s; tcb_cap_cases (snd slot) = Some (getF, setF, blah) \<rbrakk>
+     \<Longrightarrow> x \<in> slots_holding_overlapping_caps cap
                (s\<lparr>kheap := kheap s(fst slot \<mapsto>
                     TCB (setF (\<lambda> x. capa) tcb))\<rparr>)"
-  apply(clarsimp simp: slots_holding_overlapping_caps_def)
-  apply(rule_tac x=cap' in exI)
-  apply(clarsimp simp: get_cap_cte_wp_at')
-  apply(erule (1) upd_other_cte_wp_at)
+  apply (clarsimp simp: slots_holding_overlapping_caps_def)
+  apply (rule_tac x=cap' in exI)
+  apply (clarsimp simp: get_cap_cte_wp_at')
+  apply (erule (1) upd_other_cte_wp_at)
   done
 
 lemma set_cap_slots_holding_overlapping_caps_other:
-  "\<lbrace> \<lambda> s. x \<in> slots_holding_overlapping_caps capa s \<and>
-          pasObjectAbs aag (fst x) \<noteq> pasObjectAbs aag (fst slot) \<rbrace>
-    set_cap cap slot
-   \<lbrace> \<lambda> rv s. x \<in> slots_holding_overlapping_caps capa s \<rbrace>"
+  "\<lbrace>\<lambda>s. x \<in> slots_holding_overlapping_caps capa s \<and>
+        pasObjectAbs aag (fst x) \<noteq> pasObjectAbs aag (fst slot)\<rbrace>
+   set_cap cap slot
+   \<lbrace>\<lambda>rv s. x \<in> slots_holding_overlapping_caps capa s\<rbrace>"
   unfolding set_cap_def
   apply (wpsimp wp: set_object_wp get_object_wp)+
-  apply(case_tac "Structures_A.obj_refs capa = {} \<and> cap_irqs capa = {}")
-   apply(clarsimp simp: slots_holding_overlapping_caps_def)
-  apply(subgoal_tac "fst x \<noteq> fst slot")
-   apply(intro allI impI conjI)
-        apply(clarsimp simp: slots_holding_overlapping_caps_def)
-        apply(rule_tac x=cap' in exI)
+  apply (case_tac "Structures_A.obj_refs capa = {} \<and> cap_irqs capa = {}")
+   apply (clarsimp simp: slots_holding_overlapping_caps_def)
+   apply (fastforce simp: get_cap_def get_object_def bind_def split_def gets_def get_def
+                          return_def assert_def assert_opt_def fail_def
+                   split: kernel_object.splits if_splits option.splits)
+  apply (subgoal_tac "fst x \<noteq> fst slot")
+   apply (intro allI impI conjI)
+        apply (clarsimp simp: slots_holding_overlapping_caps_def)
+        apply (rule_tac x=cap' in exI)
         apply clarsimp
-        apply(subst get_cap_cte_wp_at')
-        apply(rule upd_other_cte_wp_at)
-         apply(simp add: cte_wp_at_def)
+        apply (subst get_cap_cte_wp_at')
+        apply (rule upd_other_cte_wp_at)
+         apply (simp add: cte_wp_at_def)
         apply assumption
-       apply((drule set_cap_slots_holding_overlapping_caps_helper[where slot=slot], simp+)+)[5]
+        apply (clarsimp simp: get_cap_caps_of_state)
+       apply ((drule set_cap_slots_holding_overlapping_caps_helper[where slot=slot], simp+)+)[5]
   apply clarsimp
   done
-
 
 lemma set_cap_cte_wp_at_triv:
-  "\<lbrace>\<top>\<rbrace> set_cap cap slot
-   \<lbrace>\<lambda>_. cte_wp_at ((=) cap) slot\<rbrace>"
+  "\<lbrace>\<top>\<rbrace> set_cap cap slot \<lbrace>\<lambda>_. cte_wp_at ((=) cap) slot\<rbrace>"
   unfolding set_cap_def
   apply (wpsimp wp: set_object_wp get_object_wp)
-  apply(intro impI conjI allI)
-       apply(rule cte_wp_at_cteI)
+  apply (intro impI conjI allI)
+       apply (rule cte_wp_at_cteI)
           apply fastforce
          apply clarsimp
-         apply(drule set_cap_well_formed_cnode_helper[where slot=slot], simp+)
-      apply(fastforce intro: cte_wp_at_tcbI simp: tcb_cap_cases_def)+
+         apply (drule set_cap_well_formed_cnode_helper[where slot=slot], simp+)
+      apply (fastforce intro: cte_wp_at_tcbI simp: tcb_cap_cases_def)+
   done
-
-lemma set_cap_neg_cte_wp_at_other_helper':
-  "\<lbrakk>oslot \<noteq> slot;
-    ko_at (TCB x) (fst oslot) s;
-    tcb_cap_cases (snd oslot) = Some (ogetF, osetF, orestr);
-        kheap
-         (s\<lparr>kheap := kheap s(fst oslot \<mapsto>
-              TCB (osetF (\<lambda> x. cap) x))\<rparr>)
-         (fst slot) =
-        Some (TCB tcb);
-        tcb_cap_cases (snd slot) = Some (getF, setF, restr);
-        P (getF tcb)\<rbrakk> \<Longrightarrow>
-   cte_wp_at P slot s"
-  apply(case_tac "fst oslot = fst slot")
-   apply(rule cte_wp_at_tcbI)
-     apply(fastforce split: if_splits simp: obj_at_def)
-    apply assumption
-   apply(fastforce split: if_splits simp: tcb_cap_cases_def dest: prod_eqI)
-  apply(rule cte_wp_at_tcbI)
-    apply(fastforce split: if_splits simp: obj_at_def)
-   apply assumption
-  apply assumption
-  done
-
-lemma set_cap_neg_cte_wp_at_other_helper:
-  "\<lbrakk>\<not> cte_wp_at P slot s; oslot \<noteq> slot; ko_at (TCB x) (fst oslot) s;
-     tcb_cap_cases (snd oslot) = Some (getF, setF, restr)\<rbrakk>  \<Longrightarrow>
-   \<not> cte_wp_at P slot (s\<lparr>kheap := kheap s(fst oslot \<mapsto> TCB (setF (\<lambda> x. cap) x))\<rparr>)"
-  apply(rule notI)
-  apply(erule cte_wp_atE)
-   apply(fastforce elim: notE intro: cte_wp_at_cteI split: if_splits)
-  apply(fastforce elim: notE intro: set_cap_neg_cte_wp_at_other_helper')
-  done
-
-
-lemma set_cap_neg_cte_wp_at_other:
-  "oslot \<noteq> slot \<Longrightarrow>
-   \<lbrace>\<lambda>s. \<not> (cte_wp_at P slot s)\<rbrace>
-      set_cap cap oslot
-   \<lbrace>\<lambda>rv s. \<not>  (cte_wp_at P slot s) \<rbrace>"
-  apply(rule hoare_pre)
-  unfolding set_cap_def
-  apply(wp set_object_wp get_object_wp | wpc | simp add: split_def)+
-  apply(intro allI impI conjI)
-       apply(rule notI)
-       apply(erule cte_wp_atE)
-        apply (fastforce split: if_splits dest: prod_eqI elim: notE intro: cte_wp_at_cteI simp: obj_at_def)
-       apply(fastforce split: if_splits elim: notE intro: cte_wp_at_tcbI)
-      apply(auto dest: set_cap_neg_cte_wp_at_other_helper)
-  done
-
-
-
 
 lemma set_cap_silc_inv:
-  "\<lbrace>(\<lambda>s. \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst slot)) \<longrightarrow>
-           (\<exists> lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
-                     pasObjectAbs aag (fst lslot) = SilcLabel))
-        and silc_inv aag st and K (pasObjectAbs aag (fst slot) \<noteq> SilcLabel)\<rbrace>
-      set_cap cap slot
-   \<lbrace>\<lambda>rv. silc_inv aag st\<rbrace>"
-  apply(rule hoare_gen_asm)
-  apply(clarsimp simp: valid_def silc_inv_def)
-  apply(intro conjI impI allI)
-    apply(erule use_valid)
-     apply(rule hoare_vcg_ex_lift)
-     apply(rule cap_table_at_lift_valid[OF set_cap_typ_at])
+  "\<lbrace>(\<lambda>s. \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst slot))
+         \<longrightarrow> (\<exists>lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
+                      pasObjectAbs aag (fst lslot) = SilcLabel)) and
+    silc_inv aag st and K (pasObjectAbs aag (fst slot) \<noteq> SilcLabel)\<rbrace>
+   set_cap cap slot
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (clarsimp simp: valid_def silc_inv_def)
+  apply (intro conjI impI allI)
+    apply (erule use_valid)
+     apply (rule hoare_vcg_ex_lift)
+     apply (rule cap_table_at_lift_valid[OF set_cap_typ_at])
     apply blast
-   apply(case_tac "slot = (a,ba)")
-    apply(subgoal_tac "cap = capa")
+   apply (case_tac "slot = (a,ba)")
+    apply (subgoal_tac "cap = capa")
      apply (simp)
-     apply(erule impE)
-      apply(simp add: intra_label_cap_def)
-      apply(elim conjE exE)
-      apply(blast dest: cte_wp_at_eqD2)
-     apply(elim exE conjE)
-     apply(rule_tac x=aa in exI, simp)
-     apply(rule_tac x=bb in exI)
-     apply(erule use_valid[OF _ set_cap_slots_holding_overlapping_caps_other[where aag=aag]])
+     apply (erule impE)
+      apply (simp add: intra_label_cap_def)
+      apply (elim conjE exE)
+      apply (blast dest: cte_wp_at_eqD2)
+     apply (elim exE conjE)
+     apply (rule_tac x=aa in exI, simp)
+     apply (rule_tac x=bb in exI)
+     apply (erule use_valid[OF _ set_cap_slots_holding_overlapping_caps_other[where aag=aag]])
      apply fastforce
-    apply(rule cte_wp_at_eqD2)
+    apply (rule cte_wp_at_eqD2)
      apply blast
-    apply(drule_tac s=slot in sym, simp)
-    apply(erule use_valid[OF _ set_cap_cte_wp_at_triv], rule TrueI)
-   apply(drule_tac x=a in spec, drule_tac x=ba in spec, drule_tac x= capa in spec)
-   apply(erule impE, rule conjI)
-     apply(fastforce elim!: hoare_contrapositive[OF set_cap_neg_cte_wp_at_other, simplified])
-    apply(rule_tac P="\<lambda> s. intra_label_cap aag (a, ba) s" in hoare_contrapositive)
-      apply(rule intra_label_cap_pres)
-      apply(erule set_cap_neg_cte_wp_at_other)
-     apply(erule conjE, assumption)
+    apply (drule_tac s=slot in sym, simp)
+    apply (erule use_valid[OF _ set_cap_cte_wp_at_triv], rule TrueI)
+   apply (drule_tac x=a in spec, drule_tac x=ba in spec, drule_tac x= capa in spec)
+   apply (erule impE, rule conjI)
+     apply (fastforce elim!: hoare_contrapositive[OF set_cap_neg_cte_wp_at_other, simplified])
+    apply (rule_tac P="\<lambda> s. intra_label_cap aag (a, ba) s" in hoare_contrapositive)
+      apply (rule intra_label_cap_pres)
+      apply (erule set_cap_neg_cte_wp_at_other)
+     apply (erule conjE, assumption)
     apply assumption
    apply clarsimp
-   apply(rule_tac x=aa in exI, simp)
-   apply(rule_tac x=bb in exI)
-   apply(erule use_valid[OF _ set_cap_slots_holding_overlapping_caps_other[where aag=aag]])
+   apply (rule_tac x=aa in exI, simp)
+   apply (rule_tac x=bb in exI)
+   apply (erule use_valid[OF _ set_cap_slots_holding_overlapping_caps_other[where aag=aag]])
    apply fastforce
    apply (erule use_valid[OF _ set_cap_rvk_cdt_ct_ms(4)],simp)
-  apply(simp add: silc_dom_equiv_def)
-  apply(rule equiv_forI)
-  apply(erule use_valid)
+  apply (simp add: silc_dom_equiv_def)
+  apply (rule equiv_forI)
+  apply (erule use_valid)
   unfolding set_cap_def
-  apply(wp set_object_wp get_object_wp static_imp_wp | simp add: split_def | wpc)+
+  apply (wp set_object_wp get_object_wp static_imp_wp | simp add: split_def | wpc)+
   apply clarsimp
-  apply(rule conjI)
+  apply (rule conjI)
    apply fastforce
   apply (fastforce elim: equiv_forE)
   done
 
-
-
-lemma weak_derived_overlaps':
-  "\<lbrakk>weak_derived cap cap';
-    Structures_A.obj_refs cap \<noteq> {} \<or> cap_irqs cap \<noteq> {}\<rbrakk> \<Longrightarrow>
-   Structures_A.obj_refs cap \<inter> Structures_A.obj_refs cap' \<noteq> {} \<or>
-   cap_irqs cap \<inter> cap_irqs cap' \<noteq> {}"
-  apply(simp add: weak_derived_def)
-  apply(erule disjE)
-   prefer 2
-   apply simp
-  apply(simp add: copy_of_def split: if_split_asm add: same_object_as_def split: cap.splits)
-       apply((case_tac cap; simp)+)[5]
-  subgoal for arch1 arch2 by (cases arch1; cases arch2; simp)
-  done
-
-
-
-lemma weak_derived_overlaps:
-  "\<lbrakk>cte_wp_at (weak_derived cap) slot s;
-    Structures_A.obj_refs cap \<noteq> {} \<or> cap_irqs cap \<noteq> {}\<rbrakk> \<Longrightarrow>
-    slot \<in> slots_holding_overlapping_caps cap s"
-  apply(simp add: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
-  apply(drule cte_wp_at_norm)
-  apply(erule exE, rename_tac cap')
-  apply(rule_tac x=cap' in exI)
-  apply(blast dest: weak_derived_overlaps')
-  done
-
-lemma not_cap_points_to_label_transfers_across_overlapping_caps:
-  "\<lbrakk>\<not> cap_points_to_label aag cap (pasObjectAbs aag (fst slot));
-     slot \<in> slots_holding_overlapping_caps cap s\<rbrakk>
-           \<Longrightarrow> \<not> intra_label_cap aag slot s"
-  apply(simp add: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
-  apply(elim exE conjE, rename_tac cap')
-  apply(simp add: intra_label_cap_def)
-  apply(rule_tac x=cap' in exI)
-  apply(auto simp: cap_points_to_label_def
-             dest: caps_ref_single_objects caps_ref_single_irqs caps_ref_either_an_object_or_irq)
-  done
-
-lemma overlapping_transfers_across_overlapping_caps:
-  "\<lbrakk>slot \<in> FinalCaps.slots_holding_overlapping_caps cap s;
-    cte_wp_at ((=) cap') slot s;
-    lslot \<in> FinalCaps.slots_holding_overlapping_caps cap' s\<rbrakk> \<Longrightarrow>
-   lslot \<in> FinalCaps.slots_holding_overlapping_caps cap s"
-  apply(simp add: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
-  apply(elim exE conjE)
-  apply(drule (1) cte_wp_at_eqD2)+
-  apply clarsimp
-  apply(rename_tac lcap)
-  apply(rule_tac x=lcap in exI)
-  apply(auto dest: caps_ref_single_objects caps_ref_single_irqs caps_ref_either_an_object_or_irq)
-  done
-
 lemma slots_holding_overlapping_caps_hold_caps:
-  "slot \<in> slots_holding_overlapping_caps cap s \<Longrightarrow>
-   \<exists> cap'. cte_wp_at ((=) cap') slot s"
-  apply(fastforce simp: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
-  done
-
-lemma overlapping_slots_have_labelled_overlapping_caps:
-  "\<lbrakk>slot \<in> slots_holding_overlapping_caps cap s; silc_inv aag st s;
-    \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst slot))\<rbrakk> \<Longrightarrow>
-         (\<exists> lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
-           pasObjectAbs aag (fst lslot) = SilcLabel)"
-  apply(drule not_cap_points_to_label_transfers_across_overlapping_caps)
-   apply assumption
-  apply(frule slots_holding_overlapping_caps_hold_caps)
-  apply(erule exE, rename_tac cap')
-  apply(drule silc_invD)
-    apply assumption
-   apply assumption
-  apply(blast dest: overlapping_transfers_across_overlapping_caps)
-  done
+  "slot \<in> slots_holding_overlapping_caps cap s \<Longrightarrow> \<exists>cap'. cte_wp_at ((=) cap') slot s"
+  by (fastforce simp: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
 
 crunch silc_inv[wp]: set_original "silc_inv aag st"
   (wp: silc_inv_triv wp_del:set_original_wp)
 
 lemma nonempty_refs:
   "\<not> cap_points_to_label aag cap l \<Longrightarrow> Structures_A.obj_refs cap \<noteq> {} \<or> cap_irqs cap \<noteq> {}"
-  apply(simp add: cap_points_to_label_def)
-  apply auto
-  done
+  by (auto simp: cap_points_to_label_def)
 
 lemma set_cdt_silc_inv:
-  "\<lbrace>silc_inv aag st and K(all_children (\<lambda>x. pasObjectAbs aag (fst x) = SilcLabel) m)\<rbrace>
-      set_cdt m
+  "\<lbrace>silc_inv aag st and K (all_children (\<lambda>x. pasObjectAbs aag (fst x) = SilcLabel) m)\<rbrace>
+   set_cdt m
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   apply (simp add: set_cdt_def)
   apply wp
-  apply (simp add: silc_inv_def intra_label_cap_def slots_holding_overlapping_caps_def silc_dom_equiv_def equiv_for_def)
+  apply (simp add: intra_label_cap_def slots_holding_overlapping_caps_def
+                   silc_inv_def silc_dom_equiv_def equiv_for_def)
   done
 
 lemma update_cdt_silc_inv:
   "\<lbrace>silc_inv aag st and (\<lambda>s. all_children (\<lambda>x. pasObjectAbs aag (fst x) = SilcLabel) (f (cdt s)))\<rbrace>
-      update_cdt f
+   update_cdt f
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   apply (simp add: update_cdt_def)
   apply (wp set_cdt_silc_inv | simp)+
@@ -923,9 +780,135 @@ lemma update_cdt_silc_inv:
 
 lemma silc_inv_all_children:
   "silc_inv aag st s \<Longrightarrow> all_children (\<lambda>x. pasObjectAbs aag (fst x) = SilcLabel) (cdt s)"
-  apply (simp add: silc_inv_def)
+  by (simp add: silc_inv_def)
+
+lemma cap_irqs_max_free_index_update[simp]:
+  "cap_irqs (max_free_index_update cap) = cap_irqs cap"
+  apply (case_tac cap, simp_all add: free_index_update_def)
   done
 
+lemma cap_points_to_label_max_free_index_update[simp]:
+  "cap_points_to_label aag (max_free_index_update cap) l =  cap_points_to_label aag cap l"
+  apply (simp add: cap_points_to_label_def)
+  done
+
+crunch silc_inv': set_untyped_cap_as_full "silc_inv aag st"
+  (wp: set_cap_silc_inv)
+
+lemmas set_untyped_cap_as_full_silc_inv[wp] = set_untyped_cap_as_full_silc_inv'[simplified]
+
+lemma set_untyped_cap_as_full_slots_holding_overlapping_caps_other:
+  "\<lbrace>\<lambda>s. x \<in> slots_holding_overlapping_caps capa s \<and>
+        pasObjectAbs aag (fst x) \<noteq> pasObjectAbs aag (fst slot)\<rbrace>
+   set_untyped_cap_as_full src_cap cap slot
+   \<lbrace>\<lambda>_ s. x \<in> slots_holding_overlapping_caps capa s\<rbrace>"
+  unfolding set_untyped_cap_as_full_def
+  apply (rule hoare_pre)
+   apply (wp set_cap_slots_holding_overlapping_caps_other[where aag=aag])
+  apply clarsimp
+  done
+
+lemma is_derived_overlaps':
+  "\<lbrakk> is_derived (cdt s) slot cap cap';
+     (Structures_A.obj_refs cap' \<noteq> {} \<or> cap_irqs cap' \<noteq> {}) \<or>
+     (Structures_A.obj_refs cap \<noteq> {} \<or> cap_irqs cap \<noteq> {}) \<rbrakk>
+     \<Longrightarrow> Structures_A.obj_refs cap \<inter> Structures_A.obj_refs cap' \<noteq> {} \<or>
+         cap_irqs cap \<inter> cap_irqs cap' \<noteq> {}"
+  apply (simp add: is_derived_def)
+  apply (case_tac cap', simp_all add: cap_master_cap_def split: cap.splits)
+  apply (fastforce dest: master_arch_cap_obj_refs)
+  done
+
+lemma is_derived_overlaps:
+  "\<lbrakk> cte_wp_at (is_derived (cdt s) slot cap) slot s;
+     Structures_A.obj_refs cap \<noteq> {} \<or> cap_irqs cap \<noteq> {} \<rbrakk>
+     \<Longrightarrow> slot \<in> slots_holding_overlapping_caps cap s"
+  apply (simp add: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
+  apply (drule cte_wp_at_norm)
+  apply (erule exE, rename_tac cap')
+  apply (rule_tac x=cap' in exI)
+  apply (blast dest: is_derived_overlaps')
+  done
+
+lemma is_derived_overlaps2:
+  "\<lbrakk> cte_wp_at ((=) cap') slot s;
+     is_derived (cdt s) slot cap cap';
+     Structures_A.obj_refs cap' \<noteq> {} \<or> cap_irqs cap' \<noteq> {} \<rbrakk>
+     \<Longrightarrow> slot \<in> slots_holding_overlapping_caps cap' s"
+  apply (simp add: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
+  apply (blast dest: cte_wp_at_norm is_derived_overlaps')
+  done
+
+lemma disj_dup: "A \<and> B \<and> C \<and> C'\<Longrightarrow> A \<and> B \<and> C \<and> A \<and> B \<and> C'"
+  by simp
+
+
+context FinalCaps_1 begin
+
+lemma weak_derived_overlaps':
+  "\<lbrakk> weak_derived cap cap'; Structures_A.obj_refs cap \<noteq> {} \<or> cap_irqs cap \<noteq> {} \<rbrakk>
+     \<Longrightarrow> Structures_A.obj_refs cap \<inter> Structures_A.obj_refs cap' \<noteq> {} \<or>
+         cap_irqs cap \<inter> cap_irqs cap' \<noteq> {}"
+  apply (simp add: weak_derived_def)
+  apply (erule disjE)
+   prefer 2
+   apply simp
+  apply (simp add: copy_of_def split: if_split_asm add: same_object_as_def split: cap.splits)
+       apply ((case_tac cap; simp)+)[5]
+  apply (clarsimp simp: aobj_ref_same_aobject)
+  done
+
+lemma weak_derived_overlaps:
+  "\<lbrakk> cte_wp_at (weak_derived cap) slot s;
+     Structures_A.obj_refs cap \<noteq> {} \<or> cap_irqs cap \<noteq> {} \<rbrakk>
+     \<Longrightarrow> slot \<in> slots_holding_overlapping_caps cap s"
+  apply (simp add: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
+  apply (drule cte_wp_at_norm)
+  apply (erule exE, rename_tac cap')
+  apply (rule_tac x=cap' in exI)
+  apply (blast dest: weak_derived_overlaps')
+  done
+
+lemma not_cap_points_to_label_transfers_across_overlapping_caps:
+  "\<lbrakk> \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst slot));
+     slot \<in> slots_holding_overlapping_caps cap s \<rbrakk>
+     \<Longrightarrow> \<not> intra_label_cap aag slot s"
+  apply (simp add: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
+  apply (elim exE conjE, rename_tac cap')
+  apply (simp add: intra_label_cap_def)
+  apply (rule_tac x=cap' in exI)
+  apply (auto simp: cap_points_to_label_def
+              dest: caps_ref_single_objects caps_ref_single_irqs caps_ref_either_an_object_or_irq)
+  done
+
+lemma overlapping_transfers_across_overlapping_caps:
+  "\<lbrakk> slot \<in> slots_holding_overlapping_caps cap s;
+     cte_wp_at ((=) cap') slot s;
+     lslot \<in> slots_holding_overlapping_caps cap' s \<rbrakk>
+     \<Longrightarrow> lslot \<in> slots_holding_overlapping_caps cap s"
+  apply (simp add: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
+  apply (elim exE conjE)
+  apply (drule (1) cte_wp_at_eqD2)+
+  apply clarsimp
+  apply (rename_tac lcap)
+  apply (rule_tac x=lcap in exI)
+  apply (auto dest: caps_ref_single_objects caps_ref_single_irqs caps_ref_either_an_object_or_irq)
+  done
+
+lemma overlapping_slots_have_labelled_overlapping_caps:
+  "\<lbrakk> slot \<in> slots_holding_overlapping_caps cap s; silc_inv aag st s;
+     \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst slot)) \<rbrakk>
+     \<Longrightarrow> (\<exists>lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
+                  pasObjectAbs aag (fst lslot) = SilcLabel)"
+  apply (drule not_cap_points_to_label_transfers_across_overlapping_caps)
+   apply assumption
+  apply (frule slots_holding_overlapping_caps_hold_caps)
+  apply (erule exE, rename_tac cap')
+  apply (drule silc_invD)
+    apply assumption
+   apply assumption
+  apply (blast dest: overlapping_transfers_across_overlapping_caps)
+  done
 
 lemma cap_swap_silc_inv:
   "\<lbrace>silc_inv aag st and cte_wp_at (weak_derived cap) slot and
@@ -934,24 +917,24 @@ lemma cap_swap_silc_inv:
          pasObjectAbs aag (fst slot') \<noteq> SilcLabel)\<rbrace>
       cap_swap cap slot cap' slot'
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(rule hoare_gen_asm)
+  apply (rule hoare_gen_asm)
   unfolding cap_swap_def
-  apply(rule hoare_pre)
+  apply (rule hoare_pre)
   apply (wp set_cap_silc_inv hoare_vcg_ex_lift static_imp_wp
             set_cap_slots_holding_overlapping_caps_other[where aag=aag] set_cdt_silc_inv
         | simp  split del: if_split)+
-  apply(rule conjI)
-   apply(rule impI, elim conjE)
-   apply(drule weak_derived_overlaps)
-    apply(erule nonempty_refs)
-   apply(drule overlapping_slots_have_labelled_overlapping_caps)
+  apply (rule conjI)
+   apply (rule impI, elim conjE)
+   apply (drule weak_derived_overlaps)
+    apply (erule nonempty_refs)
+   apply (drule overlapping_slots_have_labelled_overlapping_caps)
      apply assumption
     apply simp
    apply fastforce
   apply (rule conjI)
-  apply(rule impI, elim conjE)
-  apply(drule weak_derived_overlaps, erule nonempty_refs)
-  apply(drule overlapping_slots_have_labelled_overlapping_caps)
+  apply (rule impI, elim conjE)
+  apply (drule weak_derived_overlaps, erule nonempty_refs)
+  apply (drule overlapping_slots_have_labelled_overlapping_caps)
     apply assumption
    apply simp
   apply fastforce
@@ -962,27 +945,26 @@ lemma cap_swap_silc_inv:
   by (fastforce simp: all_children_def simp del: split_paired_All
      | simp add: all_children_def del: split_paired_All)+ (*slow*)
 
-
 lemma cap_move_silc_inv:
-  "\<lbrace> silc_inv aag st and cte_wp_at (weak_derived cap) slot and
+  "\<lbrace>silc_inv aag st and cte_wp_at (weak_derived cap) slot and
        K(pasObjectAbs aag (fst slot) = pasObjectAbs aag (fst slot') \<and>
-         pasObjectAbs aag (fst slot') \<noteq> SilcLabel) \<rbrace>
+         pasObjectAbs aag (fst slot') \<noteq> SilcLabel)\<rbrace>
      cap_move cap slot slot'
-   \<lbrace> \<lambda>_. silc_inv aag st \<rbrace>"
-  apply(rule hoare_gen_asm)
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (rule hoare_gen_asm)
   unfolding cap_move_def
-  apply(rule hoare_pre)
+  apply (rule hoare_pre)
   apply (wp set_cap_silc_inv hoare_vcg_ex_lift
             set_cap_slots_holding_overlapping_caps_other[where aag=aag]
             set_cdt_silc_inv static_imp_wp
         | simp)+
-  apply(rule conjI)
-   apply(fastforce simp: cap_points_to_label_def)
   apply (rule conjI)
-  apply(rule impI, elim conjE)
-  apply(drule weak_derived_overlaps)
-   apply(erule nonempty_refs)
-  apply(drule overlapping_slots_have_labelled_overlapping_caps)
+   apply (fastforce simp: cap_points_to_label_def)
+  apply (rule conjI)
+  apply (rule impI, elim conjE)
+  apply (drule weak_derived_overlaps)
+   apply (erule nonempty_refs)
+  apply (drule overlapping_slots_have_labelled_overlapping_caps)
     apply assumption
    apply simp
   apply fastforce
@@ -991,80 +973,17 @@ lemma cap_move_silc_inv:
   apply (fastforce simp: all_children_def simp del: split_paired_All)
   done
 
-lemma cap_irqs_max_free_index_update[simp]:
-  "cap_irqs (max_free_index_update cap) = cap_irqs cap"
-  apply(case_tac cap, simp_all add: free_index_update_def)
-  done
-
-lemma cap_points_to_label_max_free_index_update[simp]:
-  "cap_points_to_label aag (max_free_index_update cap) l =  cap_points_to_label aag cap l"
-  apply(simp add: cap_points_to_label_def)
-  done
-
 lemma slots_holding_overlapping_caps_max_free_index_update[simp]:
   "slots_holding_overlapping_caps (max_free_index_update cap) s =
    slots_holding_overlapping_caps cap s"
-  apply(simp add: slots_holding_overlapping_caps_def)
-  done
-
-crunch silc_inv': set_untyped_cap_as_full "silc_inv aag st"
-  (wp: set_cap_silc_inv)
-
-lemmas set_untyped_cap_as_full_silc_inv[wp] = set_untyped_cap_as_full_silc_inv'[simplified]
-
-
-
-lemma set_untyped_cap_as_full_slots_holding_overlapping_caps_other:
-  "\<lbrace> \<lambda> s. x \<in> slots_holding_overlapping_caps capa s \<and>
-        pasObjectAbs aag (fst x) \<noteq> pasObjectAbs aag (fst slot) \<rbrace>
-    set_untyped_cap_as_full src_cap cap slot
-   \<lbrace> \<lambda> rv s. x \<in> slots_holding_overlapping_caps capa s \<rbrace>"
-  unfolding set_untyped_cap_as_full_def
-  apply(rule hoare_pre)
-   apply(wp set_cap_slots_holding_overlapping_caps_other[where aag=aag])
-  apply clarsimp
-  done
-
-lemma is_derived_overlaps':
-  "\<lbrakk>is_derived (cdt s) slot cap cap';
-    (Structures_A.obj_refs cap' \<noteq> {} \<or> cap_irqs cap' \<noteq> {}) \<or>
-    (Structures_A.obj_refs cap \<noteq> {} \<or> cap_irqs cap \<noteq> {})\<rbrakk> \<Longrightarrow>
-   Structures_A.obj_refs cap \<inter> Structures_A.obj_refs cap' \<noteq> {} \<or>
-   cap_irqs cap \<inter> cap_irqs cap' \<noteq> {}"
-  apply(simp add: is_derived_def)
-  apply(case_tac cap', simp_all add: cap_master_cap_def split: cap.splits arch_cap.splits)
-  done
-
-lemma is_derived_overlaps:
-  "\<lbrakk>cte_wp_at (is_derived (cdt s) slot cap) slot s;
-    Structures_A.obj_refs cap \<noteq> {} \<or> cap_irqs cap \<noteq> {}\<rbrakk> \<Longrightarrow>
-    slot \<in> slots_holding_overlapping_caps cap s"
-  apply(simp add: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
-  apply(drule cte_wp_at_norm)
-  apply(erule exE, rename_tac cap')
-  apply(rule_tac x=cap' in exI)
-  apply(blast dest: is_derived_overlaps')
-  done
-
-lemma is_derived_overlaps2:
-  "\<lbrakk>cte_wp_at ((=) cap') slot s;
-    is_derived (cdt s) slot cap cap';
-    Structures_A.obj_refs cap' \<noteq> {} \<or> cap_irqs cap' \<noteq> {}\<rbrakk> \<Longrightarrow>
-    slot \<in> slots_holding_overlapping_caps cap' s"
-  apply(simp add: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
-  apply(blast dest: cte_wp_at_norm is_derived_overlaps')
-  done
-
-lemma disj_dup: "A \<and> B \<and> C \<and> C'\<Longrightarrow> A \<and> B \<and> C \<and> A \<and> B \<and> C'"
-  apply simp
-  done
+  by (simp add: slots_holding_overlapping_caps_def)
 
 lemma cap_insert_silc_inv:
-  "\<lbrace> silc_inv aag st and (\<lambda>s. cte_wp_at (is_derived (cdt s) slot cap) slot s) and
-      K (pasObjectAbs aag (fst slot) = pasObjectAbs aag (fst slot') \<and>
-         pasObjectAbs aag (fst slot') \<noteq> SilcLabel) \<rbrace>
-    cap_insert cap slot slot'
-   \<lbrace> \<lambda>_. silc_inv aag st \<rbrace>"
+  "\<lbrace>silc_inv aag st and (\<lambda>s. cte_wp_at (is_derived (cdt s) slot cap) slot s) and
+    K (pasObjectAbs aag (fst slot) = pasObjectAbs aag (fst slot') \<and>
+       pasObjectAbs aag (fst slot') \<noteq> SilcLabel)\<rbrace>
+   cap_insert cap slot slot'
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding cap_insert_def
   (* The order here matters. The first two need to be first. *)
   apply (wp assert_wp static_imp_conj_wp set_cap_silc_inv hoare_vcg_ex_lift
@@ -1072,24 +991,24 @@ lemma cap_insert_silc_inv:
             get_cap_wp update_cdt_silc_inv | simp | wp (once) hoare_drop_imps)+
   apply clarsimp
   apply (rule disj_dup)
-  apply(rule conjI)
-   apply(rule impI)
-   apply(drule is_derived_overlaps)
-    apply(erule nonempty_refs)
-   apply(drule overlapping_slots_have_labelled_overlapping_caps)
+  apply (rule conjI)
+   apply (rule impI)
+   apply (drule is_derived_overlaps)
+    apply (erule nonempty_refs)
+   apply (drule overlapping_slots_have_labelled_overlapping_caps)
      apply assumption
     apply simp
    apply fastforce
   apply (rule conjI)
-  apply(rule impI)
-  apply(drule cte_wp_at_norm)
-  apply(elim conjE exE)
-  apply(drule (1) cte_wp_at_eqD2)
+  apply (rule impI)
+  apply (drule cte_wp_at_norm)
+  apply (elim conjE exE)
+  apply (drule (1) cte_wp_at_eqD2)
   apply simp
-  apply(drule_tac cap'=capa in is_derived_overlaps2)
+  apply (drule_tac cap'=capa in is_derived_overlaps2)
     apply assumption
-   apply(erule nonempty_refs)
-  apply(drule overlapping_slots_have_labelled_overlapping_caps)
+   apply (erule nonempty_refs)
+  apply (drule overlapping_slots_have_labelled_overlapping_caps)
     apply assumption
    apply simp
   apply fastforce
@@ -1098,22 +1017,25 @@ lemma cap_insert_silc_inv:
   apply (fastforce simp: all_children_def simp del: split_paired_All)+
   done
 
+end
+
+
 lemma cte_wp_at_eq:
-  assumes a: "\<And> cap. \<lbrace> cte_wp_at ((=) cap) slot \<rbrace> f \<lbrace> \<lambda>_. cte_wp_at ((=) cap) slot \<rbrace>"
-  shows   "\<lbrace> cte_wp_at P slot \<rbrace> f \<lbrace> \<lambda>_. cte_wp_at P slot \<rbrace>"
-  apply(clarsimp simp: valid_def)
-  apply(drule cte_wp_at_norm)
-  apply(elim exE conjE, rename_tac cap)
-  apply(drule use_valid)
-    apply(rule a)
+  assumes a: "\<And>cap. \<lbrace>cte_wp_at ((=) cap) slot\<rbrace> f \<lbrace>\<lambda>_. cte_wp_at ((=) cap) slot\<rbrace>"
+  shows "\<lbrace>cte_wp_at P slot\<rbrace> f \<lbrace>\<lambda>_. cte_wp_at P slot\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (drule cte_wp_at_norm)
+  apply (elim exE conjE, rename_tac cap)
+  apply (drule use_valid)
+    apply (rule a)
    apply assumption
-  apply(simp add: cte_wp_at_def)
+  apply (simp add: cte_wp_at_def)
   done
 
 lemma set_simple_ko_silc_inv[wp]:
-   "\<lbrace> silc_inv aag st \<rbrace>
-    set_simple_ko f ptr ep
-    \<lbrace> \<lambda> _. silc_inv aag st \<rbrace>"
+  "\<lbrace>silc_inv aag st\<rbrace>
+   set_simple_ko f ptr ep
+   \<lbrace>\<lambda> _. silc_inv aag st\<rbrace>"
   unfolding set_simple_ko_def
   apply (rule silc_inv_pres)
     apply (wpsimp wp: set_object_wp_strong get_object_wp simp: obj_at_def)
@@ -1121,8 +1043,8 @@ lemma set_simple_ko_silc_inv[wp]:
    apply (wpsimp wp: set_object_wp get_object_wp)
   apply (wpsimp wp: set_object_wp_strong get_object_wp simp: obj_at_def)
   apply (case_tac "ptr = fst (a,b)")
-   apply(fastforce elim: cte_wp_atE simp: obj_at_def)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+   apply (fastforce elim: cte_wp_atE simp: obj_at_def)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
 crunch kheap[wp]: deleted_irq_handler "\<lambda>s. P (kheap s x)"
@@ -1130,34 +1052,30 @@ crunch kheap[wp]: deleted_irq_handler "\<lambda>s. P (kheap s x)"
 crunch silc_inv[wp]: deleted_irq_handler "silc_inv aag st"
   (wp: silc_inv_triv)
 
-end
-
 lemma (in is_extended') not_cte_wp_at[wp]: "I (\<lambda>s. \<not> cte_wp_at P t s)" by (rule lift_inv,simp)
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma set_thread_state_silc_inv[wp]:
   "\<lbrace>silc_inv aag st\<rbrace>
    set_thread_state tptr ts
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding set_thread_state_def
-  apply(rule silc_inv_pres)
-   apply(wp set_object_wp|simp split del: if_split)+
-   apply (simp split: kernel_object.splits)
-   apply(rule impI | simp)+
-   apply(fastforce simp: silc_inv_def dest: get_tcb_SomeD simp: obj_at_def is_cap_table_def)
-  apply(wp set_object_wp | simp)+
-  apply(case_tac "tptr = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(erule notE)
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(drule get_tcb_SomeD)
-   apply(rule cte_wp_at_tcbI)
-     apply(simp)
+  apply (rule silc_inv_pres)
+    apply (wp set_object_wp | simp split del: if_split)+
+    apply (simp split: kernel_object.splits)
+    apply (rule impI | simp)+
+    apply (fastforce simp: silc_inv_def dest: get_tcb_SomeD simp: obj_at_def is_cap_table_def)
+   apply (wp set_object_wp | simp)+
+  apply (case_tac "tptr = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (erule notE)
+   apply (erule cte_wp_atE)
+    apply (fastforce simp: obj_at_def)
+   apply (drule get_tcb_SomeD)
+   apply (rule cte_wp_at_tcbI)
+     apply (simp)
     apply assumption
    apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
 lemma set_bound_notification_silc_inv[wp]:
@@ -1165,108 +1083,64 @@ lemma set_bound_notification_silc_inv[wp]:
    set_bound_notification tptr ntfn
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding set_bound_notification_def
-  apply(rule silc_inv_pres)
-    apply(wp set_object_wp|simp split del: if_split)+
+  apply (rule silc_inv_pres)
+    apply (wp set_object_wp|simp split del: if_split)+
     apply (simp split: kernel_object.splits)
-    apply(rule impI | simp)+
-    apply(fastforce simp: silc_inv_def dest: get_tcb_SomeD simp: obj_at_def is_cap_table_def)
-   apply(wp set_object_wp | simp)+
-  apply(case_tac "tptr = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(erule notE)
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(drule get_tcb_SomeD)
-   apply(rule cte_wp_at_tcbI)
-     apply(simp)
+    apply (rule impI | simp)+
+    apply (fastforce simp: silc_inv_def dest: get_tcb_SomeD simp: obj_at_def is_cap_table_def)
+   apply (wp set_object_wp | simp)+
+  apply (case_tac "tptr = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (erule notE)
+   apply (erule cte_wp_atE)
+    apply (fastforce simp: obj_at_def)
+   apply (drule get_tcb_SomeD)
+   apply (rule cte_wp_at_tcbI)
+     apply (simp)
     apply assumption
    apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
 crunch silc_inv[wp]: fast_finalise, unbind_notification "silc_inv aag st"
   (ignore: set_object wp: crunch_wps simp: crunch_simps)
 
 lemma slots_holding_overlapping_caps_lift:
-  assumes a: "\<And> P Q slot. \<lbrace>\<lambda>s. Q (cte_wp_at P slot s)\<rbrace> f \<lbrace>\<lambda>_ s. Q (cte_wp_at P slot s)\<rbrace>"
-  shows
-    "\<lbrace>\<lambda>s. P (slots_holding_overlapping_caps cap s)\<rbrace>
-       f
-     \<lbrace>\<lambda>_ s. P (slots_holding_overlapping_caps cap s)\<rbrace>"
-  apply(clarsimp simp: valid_def)
-  apply(subgoal_tac "slots_holding_overlapping_caps cap b = slots_holding_overlapping_caps cap s",
-        simp)
-  apply(clarsimp simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-  apply(rule Collect_cong)
-  apply(erule use_valid[OF _ a])
-  apply(rule refl)
+  assumes a: "\<And>P Q slot. \<lbrace>\<lambda>s. Q (cte_wp_at P slot s)\<rbrace> f \<lbrace>\<lambda>_ s. Q (cte_wp_at P slot s)\<rbrace>"
+  shows "\<lbrace>\<lambda>s. P (slots_holding_overlapping_caps cap s)\<rbrace>
+         f
+         \<lbrace>\<lambda>_ s. P (slots_holding_overlapping_caps cap s)\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (subgoal_tac "slots_holding_overlapping_caps cap b =
+                      slots_holding_overlapping_caps cap s", simp)
+  apply (clarsimp simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
+  apply (rule Collect_cong)
+  apply (erule use_valid[OF _ a])
+  apply (rule refl)
   done
 
-crunch cte_wp_at'[wp]: set_original "\<lambda> s. Q (cte_wp_at P slot s)"
+crunch cte_wp_at'[wp]: set_original "\<lambda>s. Q (cte_wp_at P slot s)"
   (wp_del:set_original_wp)
 
 lemma slots_holding_overlapping_caps_exst_update[simp]:
   "slots_holding_overlapping_caps cap (trans_state f s) =
    slots_holding_overlapping_caps cap s"
-  apply(simp add: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-  done
+  by (simp add: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
 
-crunch cte_wp_at'[wp]: set_cdt "\<lambda> s. Q (cte_wp_at P slot s)"
-
-
+crunch cte_wp_at'[wp]: set_cdt "\<lambda>s. Q (cte_wp_at P slot s)"
 
 lemma slots_holding_overlapping_caps_is_original_cap_update[simp]:
   "slots_holding_overlapping_caps cap (s\<lparr>is_original_cap := X\<rparr>) =
    slots_holding_overlapping_caps cap s"
-  apply(simp add: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-  done
+  by (simp add: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
 
 lemma intra_label_cap_is_original_cap[simp]:
   "intra_label_cap aag slot (s\<lparr>is_original_cap := X\<rparr>) = intra_label_cap aag slot s"
-  apply(simp add: intra_label_cap_def)
-  done
+  by (simp add: intra_label_cap_def)
 
 lemma silc_inv_is_original_cap[simp]:
   "silc_inv aag st (s\<lparr>is_original_cap := X\<rparr>) = silc_inv aag st s"
-  apply(simp add: silc_inv_def silc_dom_equiv_def equiv_for_def)
-  done
-
-lemma empty_slot_silc_inv:
-  "\<lbrace>silc_inv aag st and K (pasObjectAbs aag (fst slot) \<noteq> SilcLabel)\<rbrace>
-   empty_slot slot free_irq
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding empty_slot_def post_cap_deletion_def
-  apply(wp set_cap_silc_inv hoare_vcg_all_lift hoare_vcg_ex_lift
-           slots_holding_overlapping_caps_lift get_cap_wp
-           set_cdt_silc_inv dxo_wp_weak hoare_drop_imps
-       | wpc | simp del: empty_slot_extended.dxo_eq)+
-  apply(clarsimp simp: cap_points_to_label_def)
-  apply (drule silc_inv_all_children)
-  apply (fastforce simp: all_children_def simp del: split_paired_All)
-  done
-
-
-
-
-
-
-lemma cap_delete_one_silc_inv:
-  "\<lbrace>silc_inv aag st and K (pasObjectAbs aag (fst slot) \<noteq> SilcLabel) \<rbrace>
-   cap_delete_one slot
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding cap_delete_one_def
-  by (wpsimp wp: hoare_unless_wp empty_slot_silc_inv get_cap_wp)
-
-lemma cap_delete_one_silc_inv_subject:
- "\<lbrace>silc_inv aag st and K (is_subject aag (fst slot)) \<rbrace>
-   cap_delete_one slot
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding cap_delete_one_def
-  apply (wpsimp wp: hoare_unless_wp empty_slot_silc_inv get_cap_wp)
-  unfolding silc_inv_def
-  by simp
-
-
+  by (simp add: silc_inv_def silc_dom_equiv_def equiv_for_def)
 
 lemma thread_set_silc_inv:
   assumes cap_inv: "\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb"
@@ -1287,27 +1161,61 @@ lemma thread_set_tcb_fault_update_silc_inv[wp]:
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   by (rule thread_set_silc_inv; simp add: tcb_cap_cases_def)
 
-
 (* FIXME MOVE *)
 lemma reply_masters_mdbE:
   assumes rmm: "reply_masters_mdb m cs"
   assumes csr: "cs ptr = Some (ReplyCap t True rights)"
   obtains "m ptr = None"
-      and "\<And> ptr'. ptr' \<in> descendants_of ptr m \<Longrightarrow> \<exists>R. cs ptr' = Some(ReplyCap t False R)"
+      and "\<And>ptr'. ptr' \<in> descendants_of ptr m \<Longrightarrow> \<exists>R. cs ptr' = Some(ReplyCap t False R)"
   using rmm csr unfolding reply_masters_mdb_def by force
 
+crunch silc_inv[wp]: cancel_signal "silc_inv aag st"
+
+
+context FinalCaps_1 begin
+
+lemma empty_slot_silc_inv:
+  "\<lbrace>silc_inv aag st and K (pasObjectAbs aag (fst slot) \<noteq> SilcLabel)\<rbrace>
+   empty_slot slot free_irq
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding empty_slot_def post_cap_deletion_def
+  apply (wp set_cap_silc_inv hoare_vcg_all_lift hoare_vcg_ex_lift
+            slots_holding_overlapping_caps_lift get_cap_wp
+            set_cdt_silc_inv dxo_wp_weak hoare_drop_imps
+         | wpc | simp del: empty_slot_extended.dxo_eq)+
+  apply (clarsimp simp: cap_points_to_label_def)
+  apply (drule silc_inv_all_children)
+  apply (fastforce simp: all_children_def simp del: split_paired_All)
+  done
+
+lemma cap_delete_one_silc_inv:
+  "\<lbrace>silc_inv aag st and K (pasObjectAbs aag (fst slot) \<noteq> SilcLabel)\<rbrace>
+   cap_delete_one slot
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding cap_delete_one_def
+  by (wpsimp wp: hoare_unless_wp empty_slot_silc_inv get_cap_wp)
+
+lemma cap_delete_one_silc_inv_subject:
+  "\<lbrace>silc_inv aag st and K (is_subject aag (fst slot))\<rbrace>
+   cap_delete_one slot
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding cap_delete_one_def
+  apply (wpsimp wp: hoare_unless_wp empty_slot_silc_inv get_cap_wp)
+  unfolding silc_inv_def
+  by simp
+
 lemma reply_cancel_ipc_silc_inv:
-  "\<lbrace>silc_inv aag st and valid_mdb and pas_refined aag and K (is_subject aag t) \<rbrace>
+  "\<lbrace>silc_inv aag st and valid_mdb and pas_refined aag and K (is_subject aag t)\<rbrace>
    reply_cancel_ipc t
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding reply_cancel_ipc_def
   apply (wp cap_delete_one_silc_inv select_wp hoare_vcg_if_lift | simp)+
-  apply wps
-  apply (wp static_imp_wp hoare_vcg_all_lift hoare_vcg_ball_lift)
+   apply wps
+   apply (wp static_imp_wp hoare_vcg_all_lift hoare_vcg_ball_lift)
   apply clarsimp
   apply (rename_tac b a)
   apply (frule(1) descendants_of_owned_or_transferable, force, force, elim disjE)
-  apply (clarsimp simp add:silc_inv_def)
+   apply (clarsimp simp add:silc_inv_def)
   apply (case_tac "cdt s (a,b)")
    apply (fastforce dest: descendants_of_NoneD)
   apply (elim is_transferable.cases)
@@ -1317,112 +1225,56 @@ lemma reply_cancel_ipc_silc_inv:
   apply (force simp add:cte_wp_at_caps_of_state)
   done
 
-
-crunch silc_inv[wp]: cancel_signal "silc_inv aag st"
-
 lemma cancel_ipc_silc_inv:
-  "\<lbrace>silc_inv aag st and valid_mdb and pas_refined aag and K (is_subject aag t) \<rbrace>
+  "\<lbrace>silc_inv aag st and valid_mdb and pas_refined aag and K (is_subject aag t)\<rbrace>
    cancel_ipc t
-   \<lbrace> \<lambda>_. silc_inv aag st \<rbrace>"
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding cancel_ipc_def
-  apply(wp get_simple_ko_wp reply_cancel_ipc_silc_inv get_thread_state_inv hoare_vcg_all_lift
-       | wpc
-       | simp(no_asm) add: blocked_cancel_ipc_def get_ep_queue_def
-                            get_blocking_object_def
-       | wp (once) hoare_drop_imps)+
+  apply (wp get_simple_ko_wp reply_cancel_ipc_silc_inv get_thread_state_inv hoare_vcg_all_lift
+         | wpc
+         | simp (no_asm) add: blocked_cancel_ipc_def get_ep_queue_def get_blocking_object_def
+         | wp (once) hoare_drop_imps)+
   apply auto
   done
 
+end
+
+
 lemma cancel_ipc_indirect_silc_inv:
-  "\<lbrace>silc_inv aag st and st_tcb_at receive_blocked t \<rbrace>
+  "\<lbrace>silc_inv aag st and st_tcb_at receive_blocked t\<rbrace>
     cancel_ipc t
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding cancel_ipc_def
   apply (rule hoare_seq_ext[OF _ gts_sp])
   apply (rule hoare_name_pre_state)
-   apply (clarsimp simp: st_tcb_def2 receive_blocked_def)
+  apply (clarsimp simp: st_tcb_def2 receive_blocked_def)
   apply (simp add: blocked_cancel_ipc_def split: thread_state.splits)
-  apply (wp)
-  apply simp
+  apply wpsimp
   done
 
 lemma intra_label_cap_machine_state[simp]:
   "intra_label_cap aag slot (s\<lparr>machine_state := X\<rparr>) = intra_label_cap aag slot s"
-  apply(simp add: intra_label_cap_def)
-  done
+  by (simp add: intra_label_cap_def)
 
 lemma slots_holding_overlapping_caps_machine_state[simp]:
   "slots_holding_overlapping_caps cap (s\<lparr>machine_state := X\<rparr>) = slots_holding_overlapping_caps cap s"
-  apply(simp add: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-  done
+  by (simp add: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
 
 lemma silc_inv_machine_state[simp]:
   "silc_inv aag st (s\<lparr>machine_state := X\<rparr>) = silc_inv aag st s"
-  apply(simp add: silc_inv_def silc_dom_equiv_def equiv_for_def)
-  done
+  by (simp add: silc_inv_def silc_dom_equiv_def equiv_for_def)
 
 lemma intra_label_cap_arch_state[simp]:
   "intra_label_cap aag slot (s\<lparr>arch_state := X\<rparr>) = intra_label_cap aag slot s"
-  apply(simp add: intra_label_cap_def)
-  done
+  by (simp add: intra_label_cap_def)
 
 lemma slots_holding_overlapping_caps_arch_state[simp]:
   "slots_holding_overlapping_caps cap (s\<lparr>arch_state := X\<rparr>) = slots_holding_overlapping_caps cap s"
-  apply(simp add: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-  done
+  by (simp add: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
 
 lemma silc_inv_arch_state[simp]:
   "silc_inv aag st (s\<lparr>arch_state := X\<rparr>) = silc_inv aag st s"
-  apply(simp add: silc_inv_def silc_dom_equiv_def equiv_for_def)
-  done
-
-lemma set_pt_silc_inv[wp]:
-   "\<lbrace> silc_inv aag st \<rbrace>
-    set_pt ptr pt
-    \<lbrace> \<lambda> _. silc_inv aag st \<rbrace>"
-  unfolding set_pt_def
-  apply(rule silc_inv_pres)
-    apply(wpsimp wp: set_object_wp_strong simp: a_type_def split: kernel_object.splits)
-    apply(fastforce simp: silc_inv_def obj_at_def is_cap_table_def)
-   apply(wp set_object_wp get_object_wp | simp)+
-  apply(case_tac "ptr = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(fastforce elim: cte_wp_atE simp: obj_at_def)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  done
-
-lemma set_pd_silc_inv[wp]:
-   "\<lbrace> silc_inv aag st \<rbrace>
-    set_pd ptr pt
-    \<lbrace> \<lambda> _. silc_inv aag st \<rbrace>"
-  unfolding set_pd_def
-  apply(rule silc_inv_pres)
-    apply(wpsimp wp: set_object_wp_strong simp: a_type_def split: kernel_object.splits)
-    apply(fastforce simp: silc_inv_def obj_at_def is_cap_table_def)
-   apply(wp set_object_wp get_object_wp | simp)+
-  apply(case_tac "ptr = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(fastforce elim: cte_wp_atE simp: obj_at_def)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  done
-
-lemma set_asid_pool_silc_inv[wp]:
-   "\<lbrace> silc_inv aag st \<rbrace>
-    set_asid_pool ptr pt
-    \<lbrace> \<lambda> _. silc_inv aag st \<rbrace>"
-  unfolding set_asid_pool_def
-  apply(rule silc_inv_pres)
-    apply(wpsimp wp: set_object_wp_strong simp: a_type_def split: kernel_object.splits)
-    apply(fastforce simp: silc_inv_def obj_at_def is_cap_table_def)
-   apply(wp set_object_wp get_object_wp | simp)+
-  apply(case_tac "ptr = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(fastforce elim: cte_wp_atE simp: obj_at_def)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  done
-
-crunch silc_inv[wp]: arch_finalise_cap,prepare_thread_delete "silc_inv aag st"
-  (wp: crunch_wps modify_wp simp: crunch_simps ignore: set_object)
+  by (simp add: silc_inv_def silc_dom_equiv_def equiv_for_def)
 
 (* FIXME MOVE *)
 lemma is_subject_not_silc_inv:
@@ -1432,378 +1284,358 @@ lemma is_subject_not_silc_inv:
 lemma update_restart_pc_silc_inv[wp]:
   "\<lbrace>silc_inv aag st\<rbrace> update_restart_pc t \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding update_restart_pc_def
-  apply(rule silc_inv_pres)
+  apply (rule silc_inv_pres)
     apply (simp add: as_user_def)
-    apply(wpsimp simp: set_object_wp)
-       apply(wp set_object_wp)+
+    apply (wpsimp simp: set_object_wp)
+       apply (wp set_object_wp)+
     apply clarsimp+
     apply (fastforce simp: silc_inv_def dest: get_tcb_SomeD simp: obj_at_def is_cap_table_def)
    apply wp+
   done
+
+lemma validE_validE_R':
+  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>R\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, -"
+  apply (rule validE_validE_R)
+  apply (erule hoare_post_impErr)
+  by auto
+
+lemma finalise_cap_ret_subset_cap_irqs:
+  "\<lbrace>\<lambda>s. (cap_irqs cap) = X\<rbrace>
+   finalise_cap cap blah
+   \<lbrace>\<lambda>rv s :: det_state. (cap_irqs (fst rv)) \<subseteq> X\<rbrace>"
+  apply (cases cap)
+  by (wp arch_finalise_cap_rv | simp add: o_def split del: if_split | simp split: if_split)+
+
+lemma finalise_cap_ret_subset_obj_refs:
+  "\<lbrace>\<lambda>s. Structures_A.obj_refs cap = X\<rbrace>
+   finalise_cap cap blah
+   \<lbrace>\<lambda>rv s :: det_state. (Structures_A.obj_refs (fst rv)) \<subseteq> X\<rbrace>"
+  apply (cases cap)
+  by (wp arch_finalise_cap_rv | simp add: o_def split del: if_split | simp split: if_split)+
+
+lemma finalise_cap_ret_intra_label_cap:
+  "\<lbrace>\<lambda>s. cap_points_to_label aag cap l\<rbrace>
+   finalise_cap cap blah
+   \<lbrace>\<lambda>rv s :: det_state. cap_points_to_label aag (fst rv) l\<rbrace>"
+  apply (clarsimp simp: cap_points_to_label_def valid_def)
+  apply (rule conjI)
+   apply (erule ball_subset)
+   apply (drule use_valid[OF _ finalise_cap_ret_subset_obj_refs])
+    apply (rule refl)
+   apply simp
+  apply (erule ball_subset)
+  apply (drule use_valid[OF _ finalise_cap_ret_subset_cap_irqs])
+   apply (rule refl)
+  by simp
+
+lemma silc_inv_preserves_silc_dom_caps:
+  "\<lbrakk> silc_inv aag st s; silc_inv aag st s';
+     pasObjectAbs aag (fst lslot) = SilcLabel;
+     lslot \<in> FinalCaps.slots_holding_overlapping_caps cap s \<rbrakk>
+     \<Longrightarrow> lslot \<in> FinalCaps.slots_holding_overlapping_caps cap s'"
+  apply (clarsimp simp: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
+  apply (rule_tac x=cap' in exI)
+  apply simp
+  apply (subst (asm) cte_wp_at_pspace'[where s'=s'])
+   apply (fastforce simp: silc_inv_def silc_dom_equiv_def equiv_for_def)
+  apply assumption
+  done
+
+
+context FinalCaps_1 begin
 
 lemma finalise_cap_silc_inv:
   "\<lbrace>silc_inv aag st and pspace_aligned and valid_vspace_objs and valid_arch_state
                     and valid_mdb and pas_refined aag and K (pas_cap_cur_auth aag cap)\<rbrace>
    finalise_cap cap final
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(case_tac cap)
-            apply(wp cancel_ipc_silc_inv | simp split del: if_split add: suspend_def| clarsimp)+
-      apply(fastforce simp: aag_cap_auth_Thread)
-     apply(wp | simp split del: if_split | clarsimp split del: if_split)+
-    apply(rule hoare_pre)
-    apply (wp cap_delete_one_silc_inv
-          | simp add: deleting_irq_handler_def
-          | strengthen is_subject_not_silc_inv)+
+  apply (case_tac cap)
+             apply (wp cancel_ipc_silc_inv | simp split del: if_split add: suspend_def| clarsimp)+
+       apply (fastforce simp: aag_cap_auth_Thread)
+      apply (wp | simp split del: if_split | clarsimp split del: if_split)+
+      apply (rule hoare_pre)
+       apply (wp cap_delete_one_silc_inv
+              | simp add: deleting_irq_handler_def
+              | strengthen is_subject_not_silc_inv)+
     apply (fastforce simp: aag_cap_auth_def cap_links_irq_def elim: aag_Control_into_owns_irq)
-   apply(wp | simp split del: if_split)+
-  done
-
-
-lemma validE_validE_R':
-  "\<lbrace> P \<rbrace> f \<lbrace> Q \<rbrace>,\<lbrace> R \<rbrace> \<Longrightarrow> \<lbrace> P \<rbrace> f \<lbrace> Q \<rbrace>,-"
-  apply(rule validE_validE_R)
-  apply(erule hoare_post_impErr)
-  by auto
-
-lemma finalise_cap_ret_subset_cap_irqs:
-  "\<lbrace>\<lambda> s. (cap_irqs cap) = X\<rbrace> finalise_cap cap blah \<lbrace>\<lambda>rv s. (cap_irqs (fst rv)) \<subseteq> X\<rbrace>"
-  apply(case_tac cap)
-            apply(wp | simp add: o_def split del: if_split)+
-       apply(simp split: if_split)
-      apply(wp | simp add: o_def | safe)+
-  apply(simp add: arch_finalise_cap_def)
-  apply(rule hoare_pre)
-   apply(wpc | wp | simp)+
-  done
-
-lemma finalise_cap_ret_subset_obj_refs:
-  "\<lbrace>\<lambda>s. (Structures_A.obj_refs cap) = X\<rbrace>
-      finalise_cap cap blah
-   \<lbrace>\<lambda>rv s. (Structures_A.obj_refs (fst rv)) \<subseteq> X\<rbrace>"
-  apply(case_tac cap)
-            apply(wp | simp add: o_def split del: if_split)+
-       apply(simp split: if_split)
-      apply(wp | simp add: o_def | safe)+
-  apply(simp add: arch_finalise_cap_def)
-  apply(rule hoare_pre)
-   apply(wpc | wp | simp)+
-  done
-
-lemma finalise_cap_ret_intra_label_cap:
-  "\<lbrace>\<lambda> s. cap_points_to_label aag cap l\<rbrace>
-      finalise_cap cap blah
-   \<lbrace>\<lambda>rv s. cap_points_to_label aag (fst rv) l\<rbrace>"
-  apply(clarsimp simp: cap_points_to_label_def valid_def)
-  apply(rule conjI)
-   apply(erule ball_subset)
-   apply(drule use_valid[OF _ finalise_cap_ret_subset_obj_refs])
-    apply(rule refl)
-   apply simp
-  apply(erule ball_subset)
-  apply(drule use_valid[OF _ finalise_cap_ret_subset_cap_irqs])
-   apply(rule refl)
-  by simp
-
-
-lemma silc_inv_preserves_silc_dom_caps:
-  "\<lbrakk>silc_inv aag st s; silc_inv aag st s';
-    pasObjectAbs aag (fst lslot) = SilcLabel;
-    lslot \<in> FinalCaps.slots_holding_overlapping_caps cap s\<rbrakk> \<Longrightarrow>
-  lslot \<in> FinalCaps.slots_holding_overlapping_caps cap s'"
-  apply(clarsimp simp: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
-  apply(rule_tac x=cap' in exI)
-  apply simp
-  apply(subst (asm) cte_wp_at_pspace'[where s'=s'])
-   apply(fastforce simp: silc_inv_def silc_dom_equiv_def equiv_for_def)
-  apply assumption
+   apply (wp | simp split del: if_split)+
   done
 
 lemma finalise_cap_ret_is_silc:
   "\<lbrace>silc_inv aag st and pspace_aligned and valid_vspace_objs and valid_arch_state and valid_mdb
                     and cte_wp_at ((=) cap) slot and pas_refined aag and K (pas_cap_cur_auth aag cap)\<rbrace>
    finalise_cap cap blah
-   \<lbrace>\<lambda>rvb s. (\<not> cap_points_to_label aag (fst rvb) (pasObjectAbs aag (fst slot)) \<longrightarrow>
-                 (\<exists> lslot. lslot
-                           \<in> FinalCaps.slots_holding_overlapping_caps (fst rvb) s \<and>
-                      pasObjectAbs aag (fst lslot) = SilcLabel))\<rbrace>"
-  apply(clarsimp simp: valid_def)
-  apply(rename_tac a b s')
-  apply(cut_tac aag1=aag and r="(a,b)" and l1="pasObjectAbs aag (fst slot)"
-             in hoare_contrapositive[OF finalise_cap_ret_intra_label_cap])
+   \<lbrace>\<lambda>rvb s. \<not> cap_points_to_label aag (fst rvb) (pasObjectAbs aag (fst slot))
+            \<longrightarrow> (\<exists>lslot. lslot \<in> slots_holding_overlapping_caps (fst rvb) s \<and>
+                         pasObjectAbs aag (fst lslot) = SilcLabel)\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (rename_tac a b s')
+  apply (cut_tac aag1=aag and r="(a,b)" and l1="pasObjectAbs aag (fst slot)"
+              in hoare_contrapositive[OF finalise_cap_ret_intra_label_cap])
     apply simp
    apply assumption
-  apply(frule use_valid[OF _ finalise_cap_silc_inv[where aag=aag and st=st]])
+  apply (frule use_valid[OF _ finalise_cap_silc_inv[where st=st]])
    apply simp
-  apply(frule_tac s=s in silc_invD)
+  apply (frule_tac s=s in silc_invD)
     apply assumption
-   apply(fastforce simp: intra_label_cap_def)
-  apply(simp, elim exE conjE)
-  apply(rename_tac la lb)
-  apply(rule_tac x=la in exI, simp)
-  apply(rule_tac x=lb in exI)
-  apply(drule_tac lslot="(la,lb)" in silc_inv_preserves_silc_dom_caps, simp+)
-  apply(drule nonempty_refs)+
-  apply(erule disjE[where P="Structures_A.obj_refs cap \<noteq> {}"])
-   apply(subgoal_tac "cap_irqs cap = {} \<and> cap_irqs a = {}")
-    apply(clarsimp simp: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
-    apply(rename_tac cap'a)
-    apply(rule_tac x=cap'a in exI)
+   apply (fastforce simp: intra_label_cap_def)
+  apply (simp, elim exE conjE)
+  apply (rename_tac la lb)
+  apply (rule_tac x=la in exI, simp)
+  apply (rule_tac x=lb in exI)
+  apply (drule_tac lslot="(la,lb)" in silc_inv_preserves_silc_dom_caps, simp+)
+  apply (drule nonempty_refs)+
+  apply (erule disjE[where P="Structures_A.obj_refs cap \<noteq> {}"])
+   apply (subgoal_tac "cap_irqs cap = {} \<and> cap_irqs a = {}")
+    apply (clarsimp simp: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
+    apply (rename_tac cap'a)
+    apply (rule_tac x=cap'a in exI)
     apply simp
-    apply(subgoal_tac "\<exists> x. Structures_A.obj_refs cap = {x} \<and> Structures_A.obj_refs a = {x}")
+    apply (subgoal_tac "\<exists>x. Structures_A.obj_refs cap = {x} \<and> Structures_A.obj_refs a = {x}")
      apply blast
-    apply(erule nonemptyE)
-    apply(rename_tac x)
-    apply(rule_tac x=x in exI)
-    apply(subgoal_tac "Structures_A.obj_refs a \<subseteq> Structures_A.obj_refs cap")
-     apply(drule (1) subsetD)
-     apply(blast dest: caps_ref_single_objects)
-    apply(fastforce dest: use_valid[OF _ finalise_cap_ret_subset_obj_refs])
-   apply(fastforce dest: caps_ref_either_an_object_or_irq
-                         use_valid[OF _ finalise_cap_ret_subset_cap_irqs])
-  apply(subgoal_tac "Structures_A.obj_refs cap = {} \<and> Structures_A.obj_refs a = {}")
-   apply(clarsimp simp: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
-   apply(rename_tac cap'a)
-   apply(rule_tac x=cap'a in exI)
+    apply (erule nonemptyE)
+    apply (rename_tac x)
+    apply (rule_tac x=x in exI)
+    apply (subgoal_tac "Structures_A.obj_refs a \<subseteq> Structures_A.obj_refs cap")
+     apply (drule (1) subsetD)
+     apply (blast dest: caps_ref_single_objects)
+    apply (fastforce dest: use_valid[OF _ finalise_cap_ret_subset_obj_refs])
+   apply (fastforce dest: caps_ref_either_an_object_or_irq
+                          use_valid[OF _ finalise_cap_ret_subset_cap_irqs])
+  apply (subgoal_tac "Structures_A.obj_refs cap = {} \<and> Structures_A.obj_refs a = {}")
+   apply (clarsimp simp: slots_holding_overlapping_caps_def get_cap_cte_wp_at')
+   apply (rename_tac cap'a)
+   apply (rule_tac x=cap'a in exI)
    apply simp
-   apply(subgoal_tac "\<exists> x. cap_irqs cap = {x} \<and> cap_irqs a = {x}")
+   apply (subgoal_tac "\<exists>x. cap_irqs cap = {x} \<and> cap_irqs a = {x}")
     apply blast
-   apply(erule nonemptyE)
-   apply(rename_tac x)
-   apply(rule_tac x=x in exI)
-   apply(subgoal_tac "cap_irqs a \<subseteq> cap_irqs cap")
-    apply(drule (1) subsetD)
-    apply(blast dest: caps_ref_single_irqs)
-   apply(fastforce dest: use_valid[OF _ finalise_cap_ret_subset_cap_irqs])
-  apply(fastforce dest: caps_ref_either_an_object_or_irq'
-                        use_valid[OF _ finalise_cap_ret_subset_obj_refs])
+   apply (erule nonemptyE)
+   apply (rename_tac x)
+   apply (rule_tac x=x in exI)
+   apply (subgoal_tac "cap_irqs a \<subseteq> cap_irqs cap")
+    apply (drule (1) subsetD)
+    apply (blast dest: caps_ref_single_irqs)
+   apply (fastforce dest: use_valid[OF _ finalise_cap_ret_subset_cap_irqs])
+  apply (fastforce dest: caps_ref_either_an_object_or_irq'
+                         use_valid[OF _ finalise_cap_ret_subset_obj_refs])
   done
 
+end
+
+
 lemma arch_finalise_cap_ret:
-  "(rv, s') \<in> fst (arch_finalise_cap arch_cap final s) \<Longrightarrow> rv = (NullCap, NullCap)"
-  apply(erule use_valid)
-  unfolding arch_finalise_cap_def
-  apply(wp | wpc | simp)+
+  "(rv, s') \<in> fst (arch_finalise_cap arch_cap final (s :: det_state)) \<Longrightarrow> rv = (NullCap, NullCap)"
+  apply (erule use_valid)
+   apply (wpsimp wp: arch_finalise_cap_rv)+
   done
 
 lemma finalise_cap_ret:
-  "(rv, s') \<in> fst (finalise_cap cap final s)
+  "(rv, s') \<in> fst (finalise_cap cap final (s :: det_state))
    \<Longrightarrow> case (fst rv) of NullCap \<Rightarrow> True | Zombie ptr bits n \<Rightarrow> True | _ \<Rightarrow> False"
-  apply(case_tac cap, simp_all add: return_def)
-       apply(fastforce simp: liftM_def when_def bind_def return_def split: if_split_asm)+
-  apply(drule arch_finalise_cap_ret)
-  apply(simp)
+  apply (case_tac cap, simp_all add: return_def)
+       apply (fastforce simp: liftM_def when_def bind_def return_def split: if_split_asm)+
+  apply (drule arch_finalise_cap_ret)
+  apply simp
   done
 
 lemma finalise_cap_ret_is_subject:
   "\<lbrace>K ((is_cnode_cap cap \<or> is_thread_cap cap \<or> is_zombie cap) \<longrightarrow> is_subject aag (obj_ref_of cap))\<rbrace>
-      finalise_cap cap is_final
-   \<lbrace>\<lambda>rv _. case (fst rv) of Zombie ptr bits n \<Rightarrow> is_subject aag (obj_ref_of (fst rv)) | _ \<Rightarrow> True\<rbrace>"
+   finalise_cap cap is_final
+   \<lbrace>\<lambda>rv _ :: det_state. case (fst rv) of Zombie ptr bits n \<Rightarrow> is_subject aag (obj_ref_of (fst rv))
+                                                       | _ \<Rightarrow> True\<rbrace>"
   including no_pre
-  apply(case_tac cap, simp_all add: is_zombie_def)
-            apply(wp | simp add: comp_def | rule impI | rule conjI)+
-  apply(fastforce simp: valid_def dest: arch_finalise_cap_ret)
+  apply (case_tac cap, simp_all add: is_zombie_def)
+             apply (wp | simp add: comp_def | rule impI | rule conjI)+
+  apply (fastforce simp: valid_def dest: arch_finalise_cap_ret)
   done
 
 lemma finalise_cap_ret_is_subject':
-  "\<lbrace>K(is_cnode_cap rv \<or> is_thread_cap rv \<or> is_zombie rv \<longrightarrow> is_subject aag (obj_ref_of rv))\<rbrace>
-      finalise_cap rv rva
-   \<lbrace>\<lambda>rv s. (is_zombie (fst rv) \<longrightarrow> is_subject aag (obj_ref_of (fst rv)))\<rbrace>"
-  apply(clarsimp simp: valid_def)
-  apply(drule use_valid[OF _ finalise_cap_ret_is_subject[where aag=aag]])
+  "\<lbrace>K (is_cnode_cap rv \<or> is_thread_cap rv \<or> is_zombie rv \<longrightarrow> is_subject aag (obj_ref_of rv))\<rbrace>
+   finalise_cap rv rva
+   \<lbrace>\<lambda>rv s :: det_state. (is_zombie (fst rv) \<longrightarrow> is_subject aag (obj_ref_of (fst rv)))\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (drule use_valid[OF _ finalise_cap_ret_is_subject[where aag=aag]])
    apply simp
-  apply(case_tac a, simp_all add: is_zombie_def)
+  apply (case_tac a, simp_all add: is_zombie_def)
   done
 
 lemma get_cap_weak_derived[wp]:
-   "\<lbrace>\<top>\<rbrace>
-       get_cap slot
-    \<lbrace>\<lambda>rv s. cte_wp_at (weak_derived rv) slot s\<rbrace>"
+  "\<lbrace>\<top>\<rbrace> get_cap slot \<lbrace>\<lambda>rv s. cte_wp_at (weak_derived rv) slot s\<rbrace>"
   unfolding get_cap_def
-  apply(wp get_object_wp | simp add: split_def | wpc)+
+  apply (wp get_object_wp | simp add: split_def | wpc)+
   apply safe
-   apply(rule cte_wp_at_cteI)
-      apply(fastforce simp: obj_at_def)
+   apply (rule cte_wp_at_cteI)
+      apply (fastforce simp: obj_at_def)
      apply assumption
     apply assumption
    apply simp
-  apply(clarsimp simp: tcb_cnode_map_tcb_cap_cases)
-  apply(rule cte_wp_at_tcbI)
-    apply(fastforce simp: obj_at_def)
+  apply (clarsimp simp: tcb_cnode_map_tcb_cap_cases)
+  apply (rule cte_wp_at_tcbI)
+    apply (fastforce simp: obj_at_def)
    apply assumption
   apply simp
   done
 
-
-
-crunch silc_inv: cap_swap_for_delete "silc_inv aag st"
-  (simp: crunch_simps)
-
 lemma get_thread_cap_ret_is_subject:
   "\<lbrace>(pas_refined aag) and K (is_subject aag (fst slot))\<rbrace>
-      get_cap slot
+   get_cap slot
    \<lbrace>\<lambda>rv s. is_thread_cap rv \<longrightarrow> (is_subject aag (obj_ref_of rv))\<rbrace>"
-  apply(clarsimp simp: valid_def)
-  apply(frule get_cap_det)
-  apply(drule_tac f=fst in arg_cong)
-  apply(subst (asm) fst_conv)
-  apply(drule in_get_cap_cte_wp_at[THEN iffD1])
-  apply(clarsimp simp: cte_wp_at_caps_of_state)
-  apply(rule caps_of_state_pasObjectAbs_eq)
-      apply(blast intro: sym)
-     apply(fastforce simp: cap_auth_conferred_def split: cap.split)
+  apply (clarsimp simp: valid_def)
+  apply (frule get_cap_det)
+  apply (drule_tac f=fst in arg_cong)
+  apply (subst (asm) fst_conv)
+  apply (drule in_get_cap_cte_wp_at[THEN iffD1])
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (rule caps_of_state_pasObjectAbs_eq)
+      apply (blast intro: sym)
+     apply (fastforce simp: cap_auth_conferred_def split: cap.split)
     apply assumption+
-  apply(case_tac a, simp_all)
+  apply (case_tac a, simp_all)
   done
 
 lemma get_zombie_ret_is_subject:
-  "\<lbrace>(pas_refined aag) and K (is_subject aag (fst slot))\<rbrace>
-      get_cap slot
+  "\<lbrace>pas_refined aag and K (is_subject aag (fst slot))\<rbrace>
+   get_cap slot
    \<lbrace>\<lambda>rv s. is_zombie rv \<longrightarrow> (is_subject aag (obj_ref_of rv))\<rbrace>"
-  apply(clarsimp simp: valid_def is_zombie_def)
-  apply(frule get_cap_det)
-  apply(drule_tac f=fst in arg_cong)
-  apply(subst (asm) fst_conv)
-  apply(drule in_get_cap_cte_wp_at[THEN iffD1])
-  apply(clarsimp simp: cte_wp_at_caps_of_state)
-  apply(rule caps_of_state_pasObjectAbs_eq)
-      apply(blast intro: sym)
-     apply(fastforce simp: cap_auth_conferred_def split: cap.split)
+  apply (clarsimp simp: valid_def is_zombie_def)
+  apply (frule get_cap_det)
+  apply (drule_tac f=fst in arg_cong)
+  apply (subst (asm) fst_conv)
+  apply (drule in_get_cap_cte_wp_at[THEN iffD1])
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (rule caps_of_state_pasObjectAbs_eq)
+      apply (blast intro: sym)
+     apply (fastforce simp: cap_auth_conferred_def split: cap.split)
     apply assumption+
-  apply(case_tac a, simp_all)
+  apply (case_tac a, simp_all)
   done
 
 lemma ran_caps_of_state_cte_wp_at:
- "(\<forall>cap\<in>ran (caps_of_state s). P cap) \<Longrightarrow>
-    (\<forall>cap. cte_wp_at ((=) cap) slot s \<longrightarrow> P cap)"
-  apply(simp add: cte_wp_at_caps_of_state)
-  apply(fastforce)
-  done
-
+ "(\<forall>cap \<in> ran (caps_of_state s). P cap) \<Longrightarrow> (\<forall>cap. cte_wp_at ((=) cap) slot s \<longrightarrow> P cap)"
+  by (fastforce simp: cte_wp_at_caps_of_state)
 
 declare if_weak_cong[cong]
 
 lemma finalise_cap_ret':
-  "\<lbrace>\<top>\<rbrace> finalise_cap cap final
-          \<lbrace>\<lambda>rv s. (is_zombie (fst rv) \<or> fst rv = NullCap)\<rbrace>"
-  apply(auto simp: valid_def dest!: finalise_cap_ret split: cap.splits simp: is_zombie_def)
-  done
+  "\<lbrace>\<top>\<rbrace> finalise_cap cap final \<lbrace>\<lambda>rv s :: det_state. (is_zombie (fst rv) \<or> fst rv = NullCap)\<rbrace>"
+  by (auto simp: valid_def dest!: finalise_cap_ret split: cap.splits simp: is_zombie_def)
 
 lemma silc_inv_irq_state_independent_A[simp, intro!]:
   "irq_state_independent_A (silc_inv aag st)"
-  apply(simp add: silc_inv_def irq_state_independent_A_def silc_dom_equiv_def equiv_for_def)
-  done
+  by (simp add: silc_inv_def irq_state_independent_A_def silc_dom_equiv_def equiv_for_def)
 
+
+context FinalCaps_1 begin
+
+crunch silc_inv: cap_swap_for_delete "silc_inv aag st"
+  (simp: crunch_simps)
 
 lemma rec_del_silc_inv':
   notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del]
         drop_spec_ev[wp_split del] rec_del.simps[simp del]
   shows
-  "s \<turnstile> \<lbrace> silc_inv aag st and einvs and simple_sched_action and valid_rec_del_call call
-         and emptyable (slot_rdcall call)
-         and pas_refined aag
-         and K (case call of
-                   CTEDeleteCall slot exposed \<Rightarrow> is_subject aag (fst slot) |
-                   FinaliseSlotCall slot exposed \<Rightarrow> is_subject aag (fst slot) |
-                   ReduceZombieCall cap slot exposed \<Rightarrow> is_subject aag (fst slot) \<and>
-                                                        is_subject aag (obj_ref_of cap))\<rbrace>
-     rec_del call
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>,\<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  "s \<turnstile> \<lbrace>silc_inv aag st and einvs and simple_sched_action and valid_rec_del_call call
+                        and emptyable (slot_rdcall call) and pas_refined aag
+                        and K (case call of
+                                 CTEDeleteCall slot _ \<Rightarrow> is_subject aag (fst slot) |
+                                 FinaliseSlotCall slot _ \<Rightarrow> is_subject aag (fst slot) |
+                                 ReduceZombieCall cap slot _ \<Rightarrow> is_subject aag (fst slot) \<and>
+                                                                is_subject aag (obj_ref_of cap))\<rbrace>
+       rec_del call
+       \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>, \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   proof (induct s rule: rec_del.induct, simp_all only: rec_del_fails hoare_fail_any)
   case (1 slot exposed s) show ?case
-    apply(simp add: split_def rec_del.simps)
-    apply(rule hoare_pre_spec_validE)
-     apply(wp empty_slot_silc_inv drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp]
-          | simp)+
-     apply(rule_tac Q'="\<lambda>_ s. silc_inv aag st s \<and> is_subject aag (fst slot)"
-                and E="\<lambda>_. silc_inv aag st"
-                 in spec_strengthen_postE)
-      apply(rule spec_valid_conj_liftE2)
-       apply(wp)
-      apply(rule "1.hyps"[simplified])
-     apply(simp | fastforce simp: silc_inv_def)+
+    apply (simp add: split_def rec_del.simps)
+    apply (rule hoare_pre_spec_validE)
+     apply (wp empty_slot_silc_inv drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp]
+            | simp)+
+     apply (rule_tac Q'="\<lambda>_ s. silc_inv aag st s \<and> is_subject aag (fst slot)"
+                 and E="\<lambda>_. silc_inv aag st"
+                  in spec_strengthen_postE)
+      apply (rule spec_valid_conj_liftE2)
+       apply wp
+      apply (rule "1.hyps"[simplified])
+     apply (simp | fastforce simp: silc_inv_def)+
     done
   next
   case (2 slot exposed s) show ?case
-    apply(simp add: rec_del.simps split del: if_split)
-    apply(rule hoare_pre_spec_validE)
-     apply(wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] set_cap_silc_inv
-              "2.hyps"
-          |simp add: split_def split del: if_split)+
-          apply(rule drop_spec_validE, (wp preemption_point_inv'| simp)+)[1]
+    apply (simp add: rec_del.simps split del: if_split)
+    apply (rule hoare_pre_spec_validE)
+     apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] set_cap_silc_inv "2.hyps"
+            | simp add: split_def split del: if_split)+
+          apply (rule drop_spec_validE, (wp preemption_point_inv'| simp)+)[1]
          apply simp
-         apply(rule spec_valid_conj_liftE2)
-          apply(wp rec_del_ReduceZombie_emptyable preemption_point_inv' rec_del_invs
-                   valid_validE_R[OF rec_del_respects(2)[simplified]] "2.hyps"
-                   drop_spec_validE[OF liftE_wp] set_cap_silc_inv
-                   set_cap_pas_refined replace_cap_invs  final_cap_same_objrefs set_cap_cte_cap_wp_to
-                  set_cap_cte_wp_at static_imp_wp hoare_vcg_ball_lift
-               |simp add: finalise_cap_not_reply_master_unlifted split del: if_split)+
+         apply (rule spec_valid_conj_liftE2)
+          apply (wp rec_del_ReduceZombie_emptyable preemption_point_inv' rec_del_invs
+                    valid_validE_R[OF rec_del_respects(2)[simplified]] "2.hyps"
+                    drop_spec_validE[OF liftE_wp] set_cap_silc_inv
+                    set_cap_pas_refined replace_cap_invs  final_cap_same_objrefs set_cap_cte_cap_wp_to
+                    set_cap_cte_wp_at static_imp_wp hoare_vcg_ball_lift
+                 | simp add: finalise_cap_not_reply_master_unlifted split del: if_split)+
        (* where the action is *)
-       apply(simp cong: conj_cong add: conj_comms)
-       apply(rule hoare_strengthen_post)
-        apply(rule_tac Q="\<lambda> fin s. pas_refined aag s \<and>
-                                   replaceable s slot (fst fin) rv \<and>
-                                   cte_wp_at ((=) rv) slot s \<and>
-                                   ex_cte_cap_wp_to (appropriate_cte_cap rv) slot s \<and>
-                                   (\<forall>t\<in>Structures_A.obj_refs (fst fin). halted_if_tcb t s) \<and>
-                                   einvs s \<and>
-                                   silc_inv aag st s \<and>
-                                   pasSubject aag \<noteq> SilcLabel \<and>
-                                   emptyable slot s \<and> s \<turnstile> (fst fin) \<and>
-                                   simple_sched_action s \<and>
-                                   pas_cap_cur_auth aag (fst fin) \<and>
-                                   is_subject aag (fst slot) \<and>
-                                   (is_zombie (fst fin) \<or> fst fin = NullCap) \<and>
-                                   (is_zombie (fst fin) \<longrightarrow> is_subject aag (obj_ref_of (fst fin))) \<and>
-                                   (\<not> cap_points_to_label aag (fst fin) (pasObjectAbs aag (fst slot)) \<longrightarrow>
-                                      (\<exists>slot. slot  \<in> FinalCaps.slots_holding_overlapping_caps (fst fin) s
-                                                \<and> pasObjectAbs aag (fst slot) = SilcLabel))"
-                          in hoare_vcg_conj_lift[OF _ finalise_cap_cases[where slot=slot]])
+       apply (simp cong: conj_cong add: conj_comms)
+       apply (rule hoare_strengthen_post)
+        apply (rule_tac Q="\<lambda> fin s. pas_refined aag s \<and>
+                                    replaceable s slot (fst fin) rv \<and>
+                                    cte_wp_at ((=) rv) slot s \<and>
+                                    ex_cte_cap_wp_to (appropriate_cte_cap rv) slot s \<and>
+                                    (\<forall>t\<in>Structures_A.obj_refs (fst fin). halted_if_tcb t s) \<and>
+                                    einvs s \<and>
+                                    silc_inv aag st s \<and>
+                                    pasSubject aag \<noteq> SilcLabel \<and>
+                                    emptyable slot s \<and> s \<turnstile> (fst fin) \<and>
+                                    simple_sched_action s \<and>
+                                    pas_cap_cur_auth aag (fst fin) \<and>
+                                    is_subject aag (fst slot) \<and>
+                                    (is_zombie (fst fin) \<or> fst fin = NullCap) \<and>
+                                    (is_zombie (fst fin) \<longrightarrow> is_subject aag (obj_ref_of (fst fin))) \<and>
+                                    (\<not> cap_points_to_label aag (fst fin) (pasObjectAbs aag (fst slot))
+                                     \<longrightarrow> (\<exists>slot. slot \<in> slots_holding_overlapping_caps (fst fin) s
+                                               \<and> pasObjectAbs aag (fst slot) = SilcLabel))"
+                     in hoare_vcg_conj_lift[OF _ finalise_cap_cases[where slot=slot]])
         prefer 2
         subgoal for cap s'' isfinal s' fin s0
-          apply (clarsimp simp:cte_wp_at_caps_of_state simp del:split_paired_Ex split_paired_All)
-          apply (elim disjE;clarsimp simp:cte_wp_at_caps_of_state simp del:split_paired_Ex split_paired_All)
-
+          apply (clarsimp simp: cte_wp_at_caps_of_state simp del:split_paired_Ex split_paired_All)
+          apply (elim disjE; clarsimp simp: cte_wp_at_caps_of_state)
           apply (clarsimp simp: is_cap_simps gen_obj_refs_eq replaceable_zombie_not_transferable
                                 cap_auth_conferred_def clas_no_asid aag_cap_auth_def
                                 pas_refined_all_auth_is_owns cli_no_irqs
-                          simp del: split_paired_Ex split_paired_All
-                          dest!: appropriate_Zombie[symmetric, THEN trans, symmetric])
+                      simp del: split_paired_Ex split_paired_All
+                         dest!: appropriate_Zombie[symmetric, THEN trans, symmetric])
           apply (fastforce dest: sym[where s="{_}"])
           done
-       apply(wp finalise_cap_pas_refined finalise_cap_silc_inv finalise_cap_auth' finalise_cap_ret'
-                finalise_cap_ret_is_subject' finalise_cap_ret_is_silc[where st=st]
-                finalise_cap_invs[where slot=slot]
-                finalise_cap_replaceable[where sl=slot]
-                finalise_cap_makes_halted[where slot=slot]
-                finalise_cap_auth' static_imp_wp)
+       apply (wp finalise_cap_pas_refined finalise_cap_silc_inv finalise_cap_auth' finalise_cap_ret'
+                 finalise_cap_ret_is_subject' finalise_cap_ret_is_silc[where st=st]
+                 finalise_cap_invs[where slot=slot]
+                 finalise_cap_replaceable[where sl=slot]
+                 finalise_cap_makes_halted[where slot=slot]
+                 finalise_cap_auth' static_imp_wp)
 
-      apply(wp drop_spec_validE[OF liftE_wp] get_cap_auth_wp[where aag=aag]
-           | simp add: is_final_cap_def)+
+      apply (wp drop_spec_validE[OF liftE_wp] get_cap_auth_wp[where aag=aag]
+             | simp add: is_final_cap_def)+
     apply (clarsimp simp: conj_comms caps_of_state_cteD)
     apply (frule (1) caps_of_state_valid)
     apply (frule if_unsafe_then_capD [OF caps_of_state_cteD]; clarsimp)
-
     apply (rule conjI, clarsimp simp: silc_inv_def)
-    apply(case_tac cap;
-          simp add: is_zombie_def aag_cap_auth_CNode aag_cap_auth_Thread aag_cap_auth_Zombie;
-          fastforce dest:caps_of_state_valid silc_inv_not_subject)
+    apply (case_tac cap;
+           simp add: is_zombie_def aag_cap_auth_CNode aag_cap_auth_Thread aag_cap_auth_Zombie;
+           fastforce dest:caps_of_state_valid silc_inv_not_subject)
     done
   next
   case (3 ptr bits n slot s) show ?case
-    apply(simp add: rec_del.simps)
+    apply (simp add: rec_del.simps)
     apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp]
               cap_swap_for_delete_silc_inv)
-    apply(simp add: pred_conj_def)
-    apply(rule hoare_pre_spec_validE)
-     apply(rule spec_valid_conj_liftE2)
+    apply (simp add: pred_conj_def)
+    apply (rule hoare_pre_spec_validE)
+     apply (rule spec_valid_conj_liftE2)
       apply (wp | simp)+
     apply (wp drop_spec_validE[OF assertE_wp])
-    apply(fastforce simp: silc_inv_def)
+    apply (fastforce simp: silc_inv_def)
     done
   next
   case (4 ptr bits n slot s) show ?case
-    apply(simp add: rec_del.simps)
+    apply (simp add: rec_del.simps)
     apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] set_cap_silc_inv
               drop_spec_validE[OF assertE_wp] get_cap_wp | simp)+
     apply (rule_tac Q'="\<lambda> _. silc_inv aag st and
@@ -1812,31 +1644,32 @@ lemma rec_del_silc_inv':
      apply (clarsimp)
      apply (drule silc_invD)
        apply assumption
-      apply(simp add: intra_label_cap_def)
-      apply(rule exI)
-      apply(rule conjI)
+      apply (simp add: intra_label_cap_def)
+      apply (rule exI)
+      apply (rule conjI)
        apply assumption
-      apply(fastforce simp: cap_points_to_label_def)
-     apply(clarsimp simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
+      apply (fastforce simp: cap_points_to_label_def)
+     apply (clarsimp simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
     apply (simp add: pred_conj_def)
     apply (rule hoare_pre_spec_validE)
-     apply(wp spec_valid_conj_liftE2 "4.hyps")
-     apply(simp add: in_monad)
-    apply(fastforce simp: silc_inv_def cte_wp_at_caps_of_state zombie_ptr_emptyable)
+     apply (wp spec_valid_conj_liftE2 "4.hyps")
+     apply (simp add: in_monad)
+    apply (fastforce simp: silc_inv_def cte_wp_at_caps_of_state zombie_ptr_emptyable)
     done
   qed
 
 schematic_goal rec_del_silc_inv_not_transferable:
-  "\<lbrace>?P\<rbrace>
-     rec_del call
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>, \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(rule use_spec)
-  apply(rule rec_del_silc_inv')
+  "\<lbrace>?P\<rbrace> rec_del call \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>, \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (rule use_spec)
+  apply (rule rec_del_silc_inv')
   done
 
+end
+
+
 lemma cdt_change_allowed_not_silc:
-  "\<lbrakk>valid_objs s; valid_mdb s; pas_refined aag s; silc_inv aag st s; cdt_change_allowed' aag ptr s\<rbrakk>
-   \<Longrightarrow> pasObjectAbs aag (fst ptr) \<noteq> SilcLabel"
+  "\<lbrakk> valid_objs s; valid_mdb s; pas_refined aag s; silc_inv aag st s; cdt_change_allowed' aag ptr s \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag (fst ptr) \<noteq> SilcLabel"
   (* very manual *)
   apply (frule(3) cca_to_transferable_or_subject)
   apply (frule silc_inv_not_subject)
@@ -1856,49 +1689,6 @@ lemma cdt_change_allowed_not_silc:
   apply (force simp add:is_cap_table obj_at_def)
   done
 
-
-lemma rec_del_silc_inv_CTEDelete_transferable':
-  "\<lbrace>silc_inv aag st and pas_refined aag
-                  and einvs and simple_sched_action and emptyable slot
-                  and (\<lambda>s. \<not> exposed \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) slot s)
-                  and cdt_change_allowed' aag slot \<rbrace>
-     rec_del (CTEDeleteCall slot exposed)
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>,
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply (cases "is_subject aag (fst slot)")
-   apply (wp rec_del_silc_inv_not_transferable)
-   apply (solves \<open>simp\<close>)
-  apply (subst rec_del.simps[abs_def])
-  apply (wp add: hoare_K_bind without_preemption_wp empty_slot_silc_inv static_imp_wp wp_transferable
-                 rec_del_Finalise_transferable
-            del: wp_not_transferable
-        | wpc)+
-   apply (rule hoare_post_impErr,rule rec_del_Finalise_transferable)
-    apply force
-   apply force
-  apply (clarsimp)
-  apply (frule(3) cca_to_transferable_or_subject[OF invs_valid_objs invs_mdb])
-  apply (frule(4) cdt_change_allowed_not_silc[OF invs_valid_objs invs_mdb])
-  by (force)
-
-lemma cap_delete_silc_inv:
-  "\<lbrace> silc_inv aag st and einvs and simple_sched_action and
-     emptyable slot and pas_refined aag and cdt_change_allowed' aag slot \<rbrace>
-   cap_delete slot
-   \<lbrace> \<lambda>_. silc_inv aag st \<rbrace>"
-  unfolding cap_delete_def
-  apply(wp rec_del_silc_inv_CTEDelete_transferable' | simp)+
-  done
-
-lemma cap_delete_silc_inv_not_transferable:
-  "\<lbrace> silc_inv aag st and einvs and simple_sched_action and
-     emptyable slot and pas_refined aag and K (is_subject aag (fst slot)) \<rbrace>
-   cap_delete slot
-   \<lbrace> \<lambda>_. silc_inv aag st \<rbrace>"
-  unfolding cap_delete_def
-  apply(wp rec_del_silc_inv_not_transferable | simp)+
-  done
-
 crunch_ignore (valid) (add: getActiveIRQ)
 crunch tcb_domain_map_wellformed[wp]: update_work_units, reset_work_units
                                       "tcb_domain_map_wellformed aag"
@@ -1907,31 +1697,82 @@ crunches preemption_point
   and pas_refined[wp]: "pas_refined aag"
   (wp: crunch_wps OR_choiceE_weak_wp ignore_del: preemption_point)
 
+lemma thread_set_tcb_registers_caps_merge_default_tcb_silc_inv[wp]:
+  "\<lbrace>silc_inv aag st\<rbrace>
+   thread_set (tcb_registers_caps_merge default_tcb) word
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  by (rule thread_set_silc_inv; simp add: tcb_cap_cases_def tcb_registers_caps_merge_def)
+
+crunch silc_inv[wp]: cancel_badged_sends "silc_inv aag st"
+  (  wp: crunch_wps hoare_unless_wp simp: crunch_simps ignore: filterM set_object thread_set
+   simp: filterM_mapM)
+
+
+context FinalCaps_1 begin
+
+lemma rec_del_silc_inv_CTEDelete_transferable':
+  "\<lbrace>silc_inv aag st and pas_refined aag and einvs and simple_sched_action and emptyable slot
+                    and (\<lambda>s. \<not> exposed \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) slot s)
+                    and cdt_change_allowed' aag slot\<rbrace>
+   rec_del (CTEDeleteCall slot exposed)
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>, \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (cases "is_subject aag (fst slot)")
+   apply (wp rec_del_silc_inv_not_transferable)
+   apply simp
+  apply (subst rec_del.simps[abs_def])
+  apply (wp add: hoare_K_bind without_preemption_wp empty_slot_silc_inv static_imp_wp wp_transferable
+                 rec_del_Finalise_transferable
+            del: wp_not_transferable
+         | wpc)+
+   apply (rule hoare_post_impErr,rule rec_del_Finalise_transferable)
+    apply force
+   apply force
+  apply (clarsimp)
+  apply (frule(3) cca_to_transferable_or_subject[OF invs_valid_objs invs_mdb])
+  apply (frule(4) cdt_change_allowed_not_silc[OF invs_valid_objs invs_mdb])
+  by force
+
+lemma cap_delete_silc_inv:
+  "\<lbrace>silc_inv aag st and einvs and simple_sched_action and emptyable slot
+                    and pas_refined aag and cdt_change_allowed' aag slot\<rbrace>
+   cap_delete slot
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding cap_delete_def
+  by (wp rec_del_silc_inv_CTEDelete_transferable' | simp)+
+
+lemma cap_delete_silc_inv_not_transferable:
+  "\<lbrace>silc_inv aag st and einvs and simple_sched_action and emptyable slot
+                    and pas_refined aag and K (is_subject aag (fst slot))\<rbrace>
+   cap_delete slot
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding cap_delete_def
+  by (wp rec_del_silc_inv_not_transferable | simp)+
+
 lemma cap_revoke_silc_inv':
   notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del]
         drop_spec_ev[wp_split del] rec_del.simps[simp del]
   shows
-  "s \<turnstile> \<lbrace> silc_inv aag st and pas_refined aag and einvs and simple_sched_action and
-         K (is_subject aag (fst slot)) \<rbrace>
-      cap_revoke slot
-   \<lbrace> \<lambda>_. silc_inv aag st \<rbrace>, \<lbrace> \<lambda>_. silc_inv aag st \<rbrace>"
+  "s \<turnstile> \<lbrace>silc_inv aag st and pas_refined aag and einvs
+                        and simple_sched_action and K (is_subject aag (fst slot))\<rbrace>
+       cap_revoke slot
+       \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>, \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   proof(induct rule: cap_revoke.induct[where ?a1.0=s])
   case (1 slot s)
   show ?case
-    apply(subst cap_revoke.simps)
-    apply(rule hoare_pre_spec_validE)
+    apply (subst cap_revoke.simps)
+    apply (rule hoare_pre_spec_validE)
      apply (wp "1.hyps")
-            apply(wp spec_valid_conj_liftE2 | simp)+
-             apply(wp drop_spec_validE[OF valid_validE[OF preemption_point_silc_inv]]
+            apply (wp spec_valid_conj_liftE2 | simp)+
+             apply (wp drop_spec_validE[OF valid_validE[OF preemption_point_silc_inv]]
                       cap_delete_silc_inv preemption_point_inv' | simp)+
-           apply(rule spec_valid_conj_liftE1)
-            apply(rule validE_validE_R'[OF valid_validE[OF cap_delete_pas_refined]])
-           apply(rule spec_valid_conj_liftE1, (wp | simp)+)
-           apply(rule spec_valid_conj_liftE1, (wp | simp)+)
-           apply(rule spec_valid_conj_liftE1, (wp | simp)+)
-           apply(rule spec_valid_conj_liftE1, (wp | simp)+)
-           apply(rule spec_valid_conj_liftE1, (wp | simp)+)
-           apply(rule drop_spec_validE[OF valid_validE[OF cap_delete_silc_inv]])
+           apply (rule spec_valid_conj_liftE1)
+            apply (rule validE_validE_R'[OF valid_validE[OF cap_delete_pas_refined]])
+           apply (rule spec_valid_conj_liftE1, (wp | simp)+)
+           apply (rule spec_valid_conj_liftE1, (wp | simp)+)
+           apply (rule spec_valid_conj_liftE1, (wp | simp)+)
+           apply (rule spec_valid_conj_liftE1, (wp | simp)+)
+           apply (rule spec_valid_conj_liftE1, (wp | simp)+)
+           apply (rule drop_spec_validE[OF valid_validE[OF cap_delete_silc_inv]])
           apply (wp drop_spec_validE[OF assertE_wp] drop_spec_validE[OF without_preemption_wp]
                     get_cap_wp select_wp drop_spec_validE[OF returnOk_wp])+
     apply clarsimp
@@ -1945,100 +1786,90 @@ lemma cap_revoke_silc_inv':
   qed
 
 lemma cap_revoke_silc_inv:
-  "\<lbrace> silc_inv aag st and pas_refined aag and einvs and simple_sched_action and
-         K (is_subject aag (fst slot)) \<rbrace>
-      cap_revoke slot
-   \<lbrace> \<lambda>_. silc_inv aag st \<rbrace>, \<lbrace> \<lambda>_. silc_inv aag st \<rbrace>"
-  apply(rule use_spec)
-  apply(rule cap_revoke_silc_inv')
+  "\<lbrace>silc_inv aag st and pas_refined aag and einvs
+                    and simple_sched_action and K (is_subject aag (fst slot))\<rbrace>
+   cap_revoke slot
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>, \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (rule use_spec)
+  apply (rule cap_revoke_silc_inv')
   done
 
-lemma thread_set_tcb_registers_caps_merge_default_tcb_silc_inv[wp]:
-  "\<lbrace>silc_inv aag st\<rbrace>
-     thread_set (tcb_registers_caps_merge default_tcb) word
-   \<lbrace>\<lambda>xa. silc_inv aag st\<rbrace>"
-  by (rule thread_set_silc_inv; simp add: tcb_cap_cases_def tcb_registers_caps_merge_def)
-
-crunch silc_inv[wp]: cancel_badged_sends "silc_inv aag st"
-  ( wp: crunch_wps hoare_unless_wp simp: crunch_simps ignore: filterM set_object thread_set
-  simp: filterM_mapM)
-
-
 lemma finalise_slot_silc_inv:
-  "\<lbrace>silc_inv aag st and einvs and pas_refined aag
-       and simple_sched_action and emptyable slot and K (is_subject aag (fst slot))\<rbrace>
-     finalise_slot slot blah
-   \<lbrace>\<lambda>_. silc_inv aag st \<rbrace>"
+  "\<lbrace>silc_inv aag st and einvs and pas_refined aag and simple_sched_action
+                    and emptyable slot and K (is_subject aag (fst slot))\<rbrace>
+   finalise_slot slot blah
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding finalise_slot_def
-  apply(rule validE_valid)
-  apply(rule hoare_pre)
-   apply(rule rec_del_silc_inv_not_transferable)
+  apply (rule validE_valid)
+  apply (rule hoare_pre)
+   apply (rule rec_del_silc_inv_not_transferable)
   apply simp
   done
 
 lemma invoke_cnode_silc_inv:
-  "\<lbrace>silc_inv aag st and einvs and simple_sched_action and pas_refined aag and
-       valid_cnode_inv i and authorised_cnode_inv aag i and is_subject aag \<circ> cur_thread \<rbrace>
-     invoke_cnode i
-   \<lbrace>\<lambda>_. silc_inv aag st \<rbrace>"
+  "\<lbrace>silc_inv aag st and einvs and simple_sched_action and pas_refined aag and valid_cnode_inv i
+                    and authorised_cnode_inv aag i and is_subject aag \<circ> cur_thread\<rbrace>
+   invoke_cnode i
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding invoke_cnode_def
-  apply(case_tac i)
-        apply(wp cap_insert_silc_inv | simp)+
-        apply(fastforce simp: silc_inv_def authorised_cnode_inv_def)
-       apply(wp cap_move_silc_inv | simp)+
-       apply(fastforce simp: silc_inv_def authorised_cnode_inv_def)
-      apply(wp cap_revoke_silc_inv | simp)+
-      apply(fastforce simp: authorised_cnode_inv_def)
-     apply(wp cap_delete_silc_inv_not_transferable | simp)+
-     apply(force simp: authorised_cnode_inv_def intro: real_cte_emptyable_strg[rule_format])
-    apply(rule hoare_pre)
-     apply(wp cap_move_silc_inv cap_swap_silc_inv cap_move_cte_wp_at_other
-          | simp split del: if_split)+
-    apply(fastforce simp: silc_inv_def authorised_cnode_inv_def)
-   apply(wp cap_move_silc_inv get_cap_wp | wpc | simp)+
-   apply(clarsimp simp: silc_inv_def authorised_cnode_inv_def)
-   apply(erule cte_wp_at_weak_derived_ReplyCap)
-  apply(wp cancel_badged_sends_silc_inv | simp | wpc | rule hoare_pre)+
+  apply (case_tac i)
+        apply (wp cap_insert_silc_inv | simp)+
+        apply (fastforce simp: silc_inv_def authorised_cnode_inv_def)
+       apply (wp cap_move_silc_inv | simp)+
+       apply (fastforce simp: silc_inv_def authorised_cnode_inv_def)
+      apply (wp cap_revoke_silc_inv | simp)+
+      apply (fastforce simp: authorised_cnode_inv_def)
+     apply (wp cap_delete_silc_inv_not_transferable | simp)+
+     apply (force simp: authorised_cnode_inv_def intro: real_cte_emptyable_strg[rule_format])
+    apply (rule hoare_pre)
+     apply (wp cap_move_silc_inv cap_swap_silc_inv cap_move_cte_wp_at_other
+            | simp split del: if_split)+
+    apply (fastforce simp: silc_inv_def authorised_cnode_inv_def)
+   apply (wp cap_move_silc_inv get_cap_wp | wpc | simp)+
+   apply (clarsimp simp: silc_inv_def authorised_cnode_inv_def)
+   apply (erule cte_wp_at_weak_derived_ReplyCap)
+  apply (wp cancel_badged_sends_silc_inv | simp | wpc | rule hoare_pre)+
   done
+
+end
+
 
 lemma set_cap_default_cap_silc_inv:
   "\<lbrace>silc_inv aag st and K (is_subject aag (fst slot) \<and> is_subject aag oref)\<rbrace>
-    set_cap (default_cap a oref b dev) slot
+   set_cap (default_cap a oref b dev) slot
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(rule hoare_pre)
-   apply(rule set_cap_silc_inv)
+  apply (rule hoare_pre)
+   apply (rule set_cap_silc_inv)
   apply (auto simp: cap_points_to_label_def
               dest: subsetD[OF obj_refs_default_cap] simp: silc_inv_def)
   done
 
 lemma create_cap_silc_inv:
-  "\<lbrace> silc_inv aag st and K (is_subject aag (fst (fst ref)) \<and> is_subject aag (snd ref) \<and>
-                            is_subject aag (fst c))\<rbrace>
-       create_cap a b c dev ref
-   \<lbrace> \<lambda>_. silc_inv aag st \<rbrace>"
+  "\<lbrace>silc_inv aag st and K (is_subject aag (fst (fst ref)) \<and>
+                           is_subject aag (snd ref) \<and>
+                           is_subject aag (fst c))\<rbrace>
+   create_cap a b c dev ref
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding create_cap_def
-  apply(rule hoare_gen_asm)
-  apply(wp set_cap_default_cap_silc_inv set_cdt_silc_inv | simp add: split_def)+
+  apply (rule hoare_gen_asm)
+  apply (wp set_cap_default_cap_silc_inv set_cdt_silc_inv | simp add: split_def)+
   apply (subgoal_tac "pasObjectAbs aag (fst c) \<noteq> SilcLabel")
    apply (drule silc_inv_all_children)
    apply (simp add: all_children_def del: split_paired_All)
   apply (clarsimp simp: silc_inv_def)
   done
 
-crunch silc_inv[wp]: init_arch_objects "silc_inv aag st"
-  (wp: crunch_wps hoare_unless_wp simp: crunch_simps)
-
 lemma retype_region_silc_inv:
-  "\<lbrace>silc_inv aag st  and K (range_cover ptr sz (obj_bits_api type o_bits) num_objects \<and>
-      (\<forall>x\<in>{ptr..(ptr && ~~ mask sz) + (2 ^ sz - 1)}. is_subject aag x)) \<rbrace>
+  "\<lbrace>silc_inv aag st and K (range_cover ptr sz (obj_bits_api type o_bits) num_objects \<and>
+                           (\<forall>x\<in>{ptr..(ptr && ~~ mask sz) + (2 ^ sz - 1)}. is_subject aag x))\<rbrace>
    retype_region ptr num_objects o_bits type dev
-   \<lbrace>\<lambda>_. silc_inv aag st \<rbrace>"
-  apply(rule hoare_gen_asm)+
-  apply(simp only: retype_region_def retype_addrs_def
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (rule hoare_gen_asm)+
+  apply (simp only: retype_region_def retype_addrs_def
                    foldr_upd_app_if fun_app_def K_bind_def)
-  apply(wp modify_wp dxo_wp_weak | simp)+
-  apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-  apply wp+
+  apply (wp modify_wp dxo_wp_weak | simp)+
+       apply (simp add: trans_state_update[symmetric] del: trans_state_update)
+      apply wp+
   apply (clarsimp simp: not_less)
   apply (clarsimp simp add: silc_inv_def)
   apply (intro conjI impI allI)
@@ -2049,108 +1880,199 @@ lemma retype_region_silc_inv:
    apply (fastforce simp: silc_dom_equiv_def equiv_for_def silc_inv_def
                     dest: retype_addrs_subset_ptr_bits[simplified retype_addrs_def]
                     simp: image_def p_assoc_help power_sub)
-  apply(case_tac "a \<in> (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api type o_bits)) `
+  apply (case_tac "a \<in> (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api type o_bits)) `
                          {0..<num_objects}")
    apply clarsimp
-   apply(subgoal_tac "cap = NullCap")
-    apply(clarsimp simp: intra_label_cap_def cap_points_to_label_def)
-    apply(drule (1) cte_wp_at_eqD2)
+   apply (subgoal_tac "cap = NullCap")
+    apply (clarsimp simp: intra_label_cap_def cap_points_to_label_def)
+    apply (drule (1) cte_wp_at_eqD2)
     apply fastforce
-   apply(erule cte_wp_atE)
+   apply (erule cte_wp_atE)
     subgoal by (fastforce simp: default_object_def empty_cnode_def
                          split: apiobject_type.splits if_splits)
    subgoal by (clarsimp simp: default_object_def default_tcb_def tcb_cap_cases_def
                        split: apiobject_type.splits if_splits)
-  apply(subgoal_tac "cte_wp_at ((=) cap) (a,b) s \<and> \<not> intra_label_cap aag (a,b) s")
-   apply(drule_tac x=a in spec, drule_tac x=b in spec, drule_tac x=cap in spec, simp)
-   apply(elim exE conjE, rename_tac la lb)
-   apply(rule_tac x=la in exI, simp, rule_tac x=lb in exI)
-   apply(simp add: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-   apply(subgoal_tac "la \<notin> (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api type o_bits)) `
+  apply (subgoal_tac "cte_wp_at ((=) cap) (a,b) s \<and> \<not> intra_label_cap aag (a,b) s")
+   apply (drule_tac x=a in spec, drule_tac x=b in spec, drule_tac x=cap in spec, simp)
+   apply (elim exE conjE, rename_tac la lb)
+   apply (rule_tac x=la in exI, simp, rule_tac x=lb in exI)
+   apply (simp add: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
+   apply (subgoal_tac "la \<notin> (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api type o_bits)) `
                           {0..<num_objects}")
-    apply(erule_tac t="(la,lb)" in cte_wp_atE)
-     apply(rule cte_wp_at_cteI)
+    apply (erule_tac t="(la,lb)" in cte_wp_atE)
+     apply (rule cte_wp_at_cteI)
         apply fastforce
        apply assumption
       apply assumption
      apply assumption
-    apply(rule cte_wp_at_tcbI)
+    apply (rule cte_wp_at_tcbI)
       apply fastforce
      apply assumption
     apply assumption
    subgoal by (fastforce simp: silc_inv_def
                          dest: retype_addrs_subset_ptr_bits[simplified retype_addrs_def]
                          simp: image_def p_assoc_help power_sub)
-  apply(rule conjI)
+  apply (rule conjI)
    subgoal by (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  apply(clarsimp simp: intra_label_cap_def cap_points_to_label_def)
-  apply(drule (1) cte_wp_at_eqD2)
-  apply(rule_tac x=capa in exI)
+  apply (clarsimp simp: intra_label_cap_def cap_points_to_label_def)
+  apply (drule (1) cte_wp_at_eqD2)
+  apply (rule_tac x=capa in exI)
   apply clarsimp
   by (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
 
 lemma slots_holding_overlapping_caps_from_silc_inv:
-  assumes a: "\<lbrace> silc_inv aag st and P \<rbrace> f \<lbrace>\<lambda>_. silc_inv aag st \<rbrace>"
-  shows
-    "\<lbrace> silc_inv aag st and (\<lambda> s. slot \<in> (slots_holding_overlapping_caps cap s) \<and>
-                                 pasObjectAbs aag (fst slot) = SilcLabel) and P \<rbrace>
+  assumes a: "\<lbrace>silc_inv aag st and P\<rbrace> f \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  shows "\<lbrace>silc_inv aag st and (\<lambda> s. slot \<in> (slots_holding_overlapping_caps cap s) \<and>
+                                pasObjectAbs aag (fst slot) = SilcLabel) and P\<rbrace>
          f
-     \<lbrace> \<lambda>_ s. slot \<in> (slots_holding_overlapping_caps cap s) \<rbrace>"
-  apply(simp add: valid_def split_def | intro impI allI ballI | elim conjE)+
-  apply(simp add: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-  apply(erule subst[rotated], rule cte_wp_at_pspace')
-  apply(case_tac x, simp)
-  apply(drule  use_valid[OF _ a])
+         \<lbrace>\<lambda>_ s. slot \<in> (slots_holding_overlapping_caps cap s)\<rbrace>"
+  apply (simp add: valid_def split_def | intro impI allI ballI | elim conjE)+
+  apply (simp add: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
+  apply (erule subst[rotated], rule cte_wp_at_pspace')
+  apply (case_tac x, simp)
+  apply (drule use_valid[OF _ a])
    apply simp
   by (fastforce simp: silc_inv_def silc_dom_equiv_def elim: equiv_forE)
 
-lemma slots_holding_overlapping_caps_eq:
-  assumes "Structures_A.obj_refs cap = Structures_A.obj_refs cap'"
-  assumes "cap_irqs cap = cap_irqs cap'"
-  shows
-  "slots_holding_overlapping_caps cap s = slots_holding_overlapping_caps cap' s"
-  using assms
-  apply(fastforce simp: slots_holding_overlapping_caps_def)
-  done
-
 lemma detype_silc_inv:
-  "\<lbrace> silc_inv aag st and (K (\<forall>p\<in>S. is_subject aag p))\<rbrace>
+  "\<lbrace>silc_inv aag st and (K (\<forall>p\<in>S. is_subject aag p))\<rbrace>
    modify (detype S)
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(wp modify_wp)
-  apply(clarsimp simp: silc_inv_def)
-  apply(rule conjI, fastforce)
-  apply(rule conjI)
+  apply (wp modify_wp)
+  apply (clarsimp simp: silc_inv_def)
+  apply (rule conjI, fastforce)
+  apply (rule conjI)
    apply (clarsimp simp: slots_holding_overlapping_caps_def intra_label_cap_def
                          cap_points_to_label_def get_cap_cte_wp_at')
-   apply(drule (1) cte_wp_at_eqD2)
+   apply (drule (1) cte_wp_at_eqD2)
    apply clarsimp
-   apply(drule_tac x=a in spec, drule_tac x=b in spec, drule_tac x=cap in spec)
+   apply (drule_tac x=a in spec, drule_tac x=b in spec, drule_tac x=cap in spec)
    apply simp
-   apply(erule impE)
+   apply (erule impE)
     apply fastforce
-   apply(elim exE conjE, rename_tac la lb lcap)
-   apply(rule_tac x=la in exI, simp, rule_tac x=lb in exI, rule_tac x=lcap in exI)
+   apply (elim exE conjE, rename_tac la lb lcap)
+   apply (rule_tac x=la in exI, simp, rule_tac x=lb in exI, rule_tac x=lcap in exI)
    apply simp
    apply fastforce
-  apply(clarsimp simp: silc_dom_equiv_def equiv_for_def detype_def)
+  apply (clarsimp simp: silc_dom_equiv_def equiv_for_def detype_def)
   done
 
 lemma delete_objects_silc_inv:
-  "\<lbrace> silc_inv aag st and (K (\<forall>p\<in>ptr_range ptr bits. is_subject aag p))\<rbrace>
+  "\<lbrace>silc_inv aag st and K (\<forall>p\<in>ptr_range ptr bits. is_subject aag p)\<rbrace>
    delete_objects ptr bits
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(rule hoare_gen_asm)
+  apply (rule hoare_gen_asm)
   unfolding delete_objects_def
   apply (wp detype_silc_inv |  simp add: ptr_range_def)+
   done
 
+lemma reset_untyped_cap_untyped_cap:
+  "\<lbrace>cte_wp_at (\<lambda>cp. is_untyped_cap cp \<and> P True (untyped_range cp)) slot and
+    invs and (\<lambda>s. descendants_of slot (cdt s) = {})\<rbrace>
+   reset_untyped_cap slot
+   \<lbrace>\<lambda>rv. cte_wp_at (\<lambda>cp. P (is_untyped_cap cp) (untyped_range cp)) slot\<rbrace>"
+  apply (simp add: reset_untyped_cap_def cong: if_cong)
+  apply (rule hoare_pre)
+   apply (wp set_cap_cte_wp_at | simp add: unless_def)+
+     apply (rule valid_validE,
+            rule_tac Q="\<lambda>rv. cte_wp_at (\<lambda>cp. is_untyped_cap cp \<and> is_untyped_cap cap \<and>
+                                             untyped_range cp = untyped_range cap \<and>
+                                             P True (untyped_range cp)) slot"
+                  in hoare_strengthen_post)
+     apply (wp mapME_x_inv_wp preemption_point_inv set_cap_cte_wp_at
+            | simp add: if_apply_def2
+            | clarsimp simp: cte_wp_at_caps_of_state is_cap_simps bits_of_def ptr_range_def[symmetric])+
+   apply (wp get_cap_wp)
+  apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps ptr_range_def[symmetric])
+  apply (frule if_unsafe_then_capD[OF caps_of_state_cteD], clarsimp+)
+  apply (drule ex_cte_cap_protects[OF _ _ _ _ order_refl], erule caps_of_state_cteD)
+     apply (clarsimp simp: descendants_range_def2 empty_descendants_range_in)
+    apply clarsimp+
+  done
+
+lemma is_arch_update_overlaps:
+  "\<lbrakk> cte_wp_at (\<lambda>c. is_arch_update cap c) slot s; \<not> cap_points_to_label aag cap l \<rbrakk>
+     \<Longrightarrow> slot \<in> slots_holding_overlapping_caps cap s"
+  apply (clarsimp simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
+  apply (erule cte_wp_at_weakenE)
+  apply (clarsimp simp: is_arch_update_def)
+  apply (clarsimp simp: cap_master_cap_def cap_points_to_label_def split: cap.splits)
+  apply (fastforce dest: master_arch_cap_obj_refs)
+  done
+
+lemma as_user_silc_inv[wp]:
+  "as_user t f \<lbrace>silc_inv aag st\<rbrace>"
+  unfolding as_user_def
+  apply (rule silc_inv_pres)
+   apply (wp set_object_wp | simp add: split_def)+
+   apply (clarsimp)
+   apply (fastforce simp: silc_inv_def dest: get_tcb_SomeD simp: obj_at_def is_cap_table_def)
+  apply (wp set_object_wp | simp add: split_def)+
+  apply (case_tac "t = fst slot")
+   apply (clarsimp split: kernel_object.splits)
+   apply (erule notE)
+   apply (erule cte_wp_atE)
+    apply (fastforce simp: obj_at_def)
+   apply (drule get_tcb_SomeD)
+   apply (rule cte_wp_at_tcbI)
+     apply (simp)
+    apply assumption
+   apply (fastforce simp: tcb_cap_cases_def split: if_splits)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  done
+
+crunch silc_inv[wp]: store_word_offs "silc_inv aag st"
+
+crunch kheap[wp]: store_word_offs "\<lambda> s. P (kheap s x)"
+
+crunch cte_wp_at'[wp]: store_word_offs "\<lambda> s. Q (cte_wp_at P slot s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma set_mrs_silc_inv[wp]:
+  "set_mrs a b c \<lbrace>silc_inv aag st\<rbrace>"
+  unfolding set_mrs_def
+  apply (rule silc_inv_pres)
+   apply (wp crunch_wps set_object_wp | wpc | simp add: crunch_simps split del: if_split)+
+   apply clarsimp
+   apply (fastforce simp: silc_inv_def dest: get_tcb_SomeD simp: obj_at_def is_cap_table_def)
+  apply (wp crunch_wps set_object_wp | wpc | simp add: crunch_simps split del: if_split)+
+  apply (case_tac "a = fst slot")
+   apply (clarsimp split: kernel_object.splits cong: conj_cong)
+   apply (erule notE)
+   apply (erule cte_wp_atE)
+    apply (fastforce simp: obj_at_def)
+   apply (drule get_tcb_SomeD)
+   apply (rule cte_wp_at_tcbI)
+     apply simp
+    apply assumption
+   apply (fastforce simp: tcb_cap_cases_def split: if_splits)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  done
+
+crunch silc_inv[wp]: update_waiting_ntfn, set_message_info "silc_inv aag st"
+
+lemma send_signal_silc_inv[wp]:
+  "send_signal ntfnptr badge \<lbrace>silc_inv aag st\<rbrace>"
+  unfolding send_signal_def
+  apply (wp get_simple_ko_wp gts_wp cancel_ipc_indirect_silc_inv | wpc | simp)+
+  apply (clarsimp simp: receive_blocked_def pred_tcb_at_def obj_at_def)
+  done
+
+
+context FinalCaps_1 begin
+
+lemma slots_holding_overlapping_caps_eq:
+  assumes "Structures_A.obj_refs cap = Structures_A.obj_refs cap'"
+  assumes "cap_irqs cap = cap_irqs cap'"
+  shows "slots_holding_overlapping_caps cap s = slots_holding_overlapping_caps cap' s"
+  using assms by (fastforce simp: slots_holding_overlapping_caps_def)
+
 lemma set_cap_silc_inv_simple:
-  "\<lbrace> silc_inv aag st and cte_wp_at (\<lambda>cp. cap_irqs cp = cap_irqs cap
-          \<and> Structures_A.obj_refs cp = Structures_A.obj_refs cap) slot
-      and K (is_subject aag (fst slot))\<rbrace>
-    set_cap cap slot
-    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  "\<lbrace>silc_inv aag st and cte_wp_at (\<lambda>cp. cap_irqs cp = cap_irqs cap \<and>
+                                        Structures_A.obj_refs cp = Structures_A.obj_refs cap) slot
+                    and K (is_subject aag (fst slot))\<rbrace>
+   set_cap cap slot
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   apply (wp set_cap_silc_inv)
   apply (clarsimp simp: cte_wp_at_caps_of_state)
   apply (rule conjI; clarsimp)
@@ -2164,18 +2086,18 @@ lemma set_cap_silc_inv_simple:
   done
 
 lemma reset_untyped_cap_silc_inv:
-  "\<lbrace> silc_inv aag st and cte_wp_at is_untyped_cap slot
-      and invs and pas_refined aag
-      and (\<lambda>s. descendants_of slot (cdt s) = {})
-      and K (is_subject aag (fst slot))\<rbrace>
-    reset_untyped_cap slot
-  \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  "\<lbrace>silc_inv aag st and cte_wp_at is_untyped_cap slot
+                    and invs and pas_refined aag
+                    and (\<lambda>s. descendants_of slot (cdt s) = {})
+                    and K (is_subject aag (fst slot))\<rbrace>
+   reset_untyped_cap slot
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: reset_untyped_cap_def cong: if_cong)
   apply (rule validE_valid, rule hoare_pre)
    apply (wp set_cap_silc_inv_simple | simp add: unless_def)+
-     apply (rule valid_validE, rule_tac Q="\<lambda>_. cte_wp_at is_untyped_cap slot
-           and silc_inv aag st" in hoare_strengthen_post)
+     apply (rule valid_validE, rule_tac Q="\<lambda>_. cte_wp_at is_untyped_cap slot and
+                                               silc_inv aag st" in hoare_strengthen_post)
       apply (rule validE_valid, rule mapME_x_inv_wp, rule hoare_pre)
        apply (wp mapME_x_inv_wp preemption_point_inv set_cap_cte_wp_at
                  set_cap_silc_inv_simple | simp)+
@@ -2183,7 +2105,7 @@ lemma reset_untyped_cap_silc_inv:
      apply simp
     apply (wp hoare_vcg_const_imp_lift delete_objects_silc_inv get_cap_wp
               set_cap_silc_inv_simple
-       | simp add: if_apply_def2)+
+           | simp add: if_apply_def2)+
   apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps bits_of_def)
   apply (frule(1) cap_auth_caps_of_state)
   apply (clarsimp simp: aag_cap_auth_def aag_has_Control_iff_owns
@@ -2194,44 +2116,18 @@ lemma reset_untyped_cap_silc_inv:
     apply clarsimp+
   done
 
-lemma reset_untyped_cap_untyped_cap:
-  "\<lbrace>cte_wp_at (\<lambda>cp. is_untyped_cap cp \<and> P True (untyped_range cp)) slot
-      and invs
-      and (\<lambda>s. descendants_of slot (cdt s) = {})\<rbrace>
-    reset_untyped_cap slot
-  \<lbrace>\<lambda>rv. cte_wp_at (\<lambda>cp. P (is_untyped_cap cp) (untyped_range cp)) slot\<rbrace>"
-  apply (simp add: reset_untyped_cap_def cong: if_cong)
-  apply (rule hoare_pre)
-   apply (wp set_cap_cte_wp_at | simp add: unless_def)+
-     apply (rule valid_validE, rule_tac Q="\<lambda>rv. cte_wp_at (\<lambda>cp. is_untyped_cap cp
-           \<and> is_untyped_cap cap
-           \<and> untyped_range cp = untyped_range cap
-           \<and> P True (untyped_range cp)) slot"
-       in hoare_strengthen_post)
-     apply (wp mapME_x_inv_wp preemption_point_inv set_cap_cte_wp_at
-       | simp add: if_apply_def2
-       | clarsimp simp: cte_wp_at_caps_of_state is_cap_simps bits_of_def
-                               ptr_range_def[symmetric])+
-   apply (wp get_cap_wp)
-  apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps ptr_range_def[symmetric])
-  apply (frule if_unsafe_then_capD[OF caps_of_state_cteD], clarsimp+)
-  apply (drule ex_cte_cap_protects[OF _ _ _ _ order_refl], erule caps_of_state_cteD)
-     apply (clarsimp simp: descendants_range_def2 empty_descendants_range_in)
-    apply clarsimp+
-  done
-
 lemma invoke_untyped_silc_inv:
-  "\<lbrace> silc_inv aag st and invs and pas_refined aag
-      and ct_active and valid_untyped_inv ui
-      and K (authorised_untyped_inv aag ui)\<rbrace>
+  "\<lbrace>silc_inv aag st and invs and pas_refined aag and ct_active
+                    and valid_untyped_inv ui and K (authorised_untyped_inv aag ui)\<rbrace>
    invoke_untyped ui
-   \<lbrace> \<lambda>_. silc_inv aag st \<rbrace>"
-  apply(rule hoare_gen_asm)
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (rule hoare_gen_asm)
   apply (rule hoare_pre)
-   apply (rule_tac Q="\<lambda>_. silc_inv aag st
-          and cte_wp_at (\<lambda>cp. is_untyped_cap cp \<longrightarrow> (\<forall>x \<in> untyped_range cp.
-              is_subject aag x)) (case ui of Invocations_A.Retype src_slot _ _ _ _ _ _ _ \<Rightarrow>
-              src_slot)" in hoare_strengthen_post)
+   apply (rule_tac Q="\<lambda>_. silc_inv aag st and
+                          cte_wp_at (\<lambda>cp. is_untyped_cap cp
+                                          \<longrightarrow> (\<forall>x \<in> untyped_range cp. is_subject aag x))
+                                    (case ui of Retype src_slot _ _ _ _ _ _ _ \<Rightarrow> src_slot)"
+                in hoare_strengthen_post)
     apply (rule invoke_untyped_Q)
         apply (rule hoare_pre, wp create_cap_silc_inv create_cap_pas_refined)
         apply (clarsimp simp: authorised_untyped_inv_def)
@@ -2248,237 +2144,48 @@ lemma invoke_untyped_silc_inv:
      apply (rule hoare_pre)
       apply (wp set_cap_silc_inv_simple set_cap_cte_wp_at)
      apply (cases ui, clarsimp simp: cte_wp_at_caps_of_state is_cap_simps
-                 split del: if_split cong: if_cong)
+                          split del: if_split cong: if_cong)
      apply (clarsimp simp: authorised_untyped_inv_def)
     apply (wp reset_untyped_cap_silc_inv reset_untyped_cap_untyped_cap)
    apply simp
-  apply (cases ui, clarsimp simp: cte_wp_at_caps_of_state
-    authorised_untyped_inv_def)
-  apply (frule(1) cap_auth_caps_of_state)
+  apply (cases ui, clarsimp simp: cte_wp_at_caps_of_state authorised_untyped_inv_def)
+  apply (frule (1) cap_auth_caps_of_state)
   apply (clarsimp simp: aag_cap_auth_def aag_has_Control_iff_owns)
-  done
-
-lemma perform_page_table_invocation_silc_ionv_get_cap_helper:
-   "\<lbrace>silc_inv aag st and cte_wp_at (is_pt_cap or is_pg_cap) xa\<rbrace>
-     get_cap xa
-          \<lbrace>(\<lambda>capa s.
-               (\<not> cap_points_to_label aag
-                   (ArchObjectCap $ update_map_data capa None)
-                   (pasObjectAbs aag (fst xa)) \<longrightarrow>
-                (\<exists>lslot.
-                    lslot
-                    \<in> FinalCaps.slots_holding_overlapping_caps
-                       (ArchObjectCap $ update_map_data capa None)
-                       s \<and>
-                    pasObjectAbs aag (fst lslot) = SilcLabel))) \<circ> the_arch_cap\<rbrace>"
-  apply(wp get_cap_wp)
-  apply clarsimp
-  apply(drule cte_wp_at_norm)
-  apply(clarify)
-  apply(drule (1) cte_wp_at_eqD2)
-  apply(case_tac cap, simp_all add: is_pg_cap_def is_pt_cap_def)
-  apply(clarsimp simp: cap_points_to_label_def update_map_data_def split: arch_cap.splits)
-   apply(drule silc_invD)
-     apply assumption
-    apply(fastforce simp: intra_label_cap_def cap_points_to_label_def)
-   apply(fastforce simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-  apply(drule silc_invD)
-    apply assumption
-   apply(fastforce simp: intra_label_cap_def cap_points_to_label_def)
-  apply(fastforce simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-  done
-
-
-lemmas perform_page_table_invocation_silc_inv_get_cap_helper' =
-               perform_page_table_invocation_silc_ionv_get_cap_helper[simplified o_def fun_app_def]
-
-lemma mapM_x_swp_store_pte_silc_inv[wp]:
-  "\<lbrace>silc_inv aag st\<rbrace> mapM_x (swp store_pte A) slots
-  \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  by (wp mapM_x_wp[OF _ subset_refl] | simp add: swp_def)+
-
-lemma is_arch_eq_pt_is_pt_or_pg_cap:
-  "cte_wp_at ((=) (ArchObjectCap (PageTableCap xa xb))) slot s
-       \<Longrightarrow> cte_wp_at (\<lambda>a. is_pt_cap a \<or> is_pg_cap a) slot s"
-  apply (erule cte_wp_at_weakenE)
-  by (clarsimp simp: is_pg_cap_def is_pt_cap_def)
-
-lemma is_arch_eq_pg_is_pt_or_pg_cap:
-  "cte_wp_at ((=) (ArchObjectCap (PageCap dev x xa xb xc))) slot s
-       \<Longrightarrow> cte_wp_at (\<lambda>a. is_pt_cap a \<or> is_pg_cap a) slot s"
-  apply (erule cte_wp_at_weakenE)
-  by (clarsimp simp: is_pg_cap_def is_pt_cap_def)
-
-
-lemma is_arch_update_overlaps:
-  "\<lbrakk>cte_wp_at (\<lambda>c. is_arch_update cap c) slot s;
-   \<not> cap_points_to_label aag cap l\<rbrakk>
-       \<Longrightarrow> slot \<in> slots_holding_overlapping_caps cap s"
-  apply(clarsimp simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-  apply(erule cte_wp_at_weakenE)
-  apply(clarsimp simp: is_arch_update_def)
-  apply(clarsimp simp: cap_master_cap_def split: cap.splits arch_cap.splits
-                 simp: cap_points_to_label_def)
-  done
-
-lemma perform_page_table_invocation_silc_inv:
-  "\<lbrace>silc_inv aag st and valid_pti blah and K (authorised_page_table_inv aag blah)\<rbrace>
-   perform_page_table_invocation blah
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding perform_page_table_invocation_def
-  apply(rule hoare_pre)
-  apply(wp set_cap_silc_inv
-           perform_page_table_invocation_silc_inv_get_cap_helper'[where st=st]
-           mapM_x_wp[OF _ subset_refl]
-       | wpc | simp only: o_def fun_app_def K_def swp_def)+
-  apply clarsimp
-  apply(clarsimp simp: valid_pti_def authorised_page_table_inv_def
-                split: page_table_invocation.splits)
-   apply(rule conjI)
-    apply(clarsimp)
-    defer
-    apply(fastforce simp: silc_inv_def)
-   apply(fastforce dest: is_arch_eq_pt_is_pt_or_pg_cap simp: silc_inv_def)
-  apply(drule_tac slot="(aa,ba)" in overlapping_slots_have_labelled_overlapping_caps[rotated])
-    apply(fastforce)
-   apply(fastforce elim: is_arch_update_overlaps[rotated] cte_wp_at_weakenE)
-  apply fastforce
-  done
-
-lemma perform_page_directory_invocation_silc_inv:
-  "\<lbrace>silc_inv aag st\<rbrace>
-   perform_page_directory_invocation blah
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding perform_page_directory_invocation_def
-  apply (cases blah)
-   apply (wp | simp)+
-   done
-
-
-lemma as_user_silc_inv[wp]:
-  "\<lbrace>silc_inv aag st\<rbrace>
-   as_user t f
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding as_user_def
-  apply(rule silc_inv_pres)
-   apply(wp set_object_wp | simp add: split_def)+
-   apply (clarsimp)
-   apply(fastforce simp: silc_inv_def dest: get_tcb_SomeD simp: obj_at_def is_cap_table_def)
-  apply(wp set_object_wp | simp add: split_def)+
-  apply(case_tac "t = fst slot")
-   apply(clarsimp split: kernel_object.splits)
-   apply(erule notE)
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(drule get_tcb_SomeD)
-   apply(rule cte_wp_at_tcbI)
-     apply(simp)
-    apply assumption
-   apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  done
-
-crunch silc_inv[wp]: store_word_offs "silc_inv aag st"
-
-crunch kheap[wp]: store_word_offs "\<lambda> s. P (kheap s x)"
-
-crunch cte_wp_at'[wp]: store_word_offs "\<lambda> s. Q (cte_wp_at P slot s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-
-lemma set_mrs_silc_inv[wp]:
-  "\<lbrace>silc_inv aag st\<rbrace>
-   set_mrs a b c
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding set_mrs_def
-  apply(rule silc_inv_pres)
-   apply(wp crunch_wps set_object_wp | wpc | simp add: crunch_simps split del: if_split)+
-   apply (clarsimp)
-   apply(fastforce simp: silc_inv_def dest: get_tcb_SomeD simp: obj_at_def is_cap_table_def)
-  apply(wp crunch_wps set_object_wp | wpc | simp add: crunch_simps split del: if_split)+
-  apply(case_tac "a = fst slot")
-   apply(clarsimp split: kernel_object.splits cong: conj_cong)
-   apply(erule notE)
-   apply(erule cte_wp_atE)
-    apply(fastforce simp: obj_at_def)
-   apply(drule get_tcb_SomeD)
-   apply(rule cte_wp_at_tcbI)
-     apply(simp)
-    apply assumption
-   apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply(fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  done
-
-crunch silc_inv[wp]: update_waiting_ntfn, set_message_info, invalidate_tlb_by_asid "silc_inv aag st"
-
-lemma send_signal_silc_inv[wp]:
-  "\<lbrace>silc_inv aag st\<rbrace> send_signal param_a param_b \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding send_signal_def
-  apply (wp get_simple_ko_wp gts_wp cancel_ipc_indirect_silc_inv | wpc | simp)+
-  apply (clarsimp simp: receive_blocked_def pred_tcb_at_def obj_at_def)
-  done
-
-lemma perform_page_invocation_silc_inv:
-  "\<lbrace>silc_inv aag st and valid_page_inv blah and K (authorised_page_inv aag blah)\<rbrace>
-   perform_page_invocation blah
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding perform_page_invocation_def
-  apply(rule hoare_pre)
-  apply(wp mapM_wp[OF _ subset_refl] set_cap_silc_inv
-           mapM_x_wp[OF _ subset_refl]
-           perform_page_table_invocation_silc_inv_get_cap_helper'[where st=st]
-           hoare_vcg_all_lift hoare_vcg_if_lift static_imp_wp
-       | wpc
-       | simp only: swp_def o_def fun_app_def K_def
-       |wp (once) hoare_drop_imps)+
-  apply (clarsimp simp: valid_page_inv_def authorised_page_inv_def
-                  split: page_invocation.splits)
-   apply(intro allI impI conjI)
-      apply(drule_tac slot="(aa,bb)" in overlapping_slots_have_labelled_overlapping_caps[rotated])
-        apply(fastforce)
-       apply(fastforce elim: is_arch_update_overlaps[rotated] cte_wp_at_weakenE)
-      apply fastforce
-     apply(fastforce simp: silc_inv_def)
-    apply(drule_tac slot="(aa,bb)" in overlapping_slots_have_labelled_overlapping_caps[rotated])
-      apply(fastforce)
-     apply(fastforce elim: is_arch_update_overlaps[rotated] cte_wp_at_weakenE)
-    apply fastforce
-   apply(fastforce simp: silc_inv_def)
-  apply(fastforce dest: is_arch_eq_pg_is_pt_or_pg_cap simp: silc_inv_def)
   done
 
 lemma cap_insert_silc_inv':
   "\<lbrace>silc_inv aag st and K (is_subject aag (fst dest) \<and> is_subject aag (fst src) \<and>
                            cap_points_to_label aag cap (pasSubject aag))\<rbrace>
-       cap_insert cap src dest
+   cap_insert cap src dest
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding cap_insert_def
   apply (wp set_cap_silc_inv hoare_vcg_ex_lift
             set_untyped_cap_as_full_slots_holding_overlapping_caps_other[where aag=aag]
             get_cap_wp update_cdt_silc_inv set_cap_caps_of_state2
             set_untyped_cap_as_full_cdt_is_original_cap static_imp_wp
-        | simp split del: if_split)+
+         | simp split del: if_split)+
   apply (intro allI impI conjI)
     apply clarsimp
-    apply(fastforce dest: silc_invD simp: intra_label_cap_def)
-   apply(clarsimp simp: silc_inv_def)
+    apply (fastforce dest: silc_invD simp: intra_label_cap_def)
+   apply (clarsimp simp: silc_inv_def)
   apply (fastforce dest!: silc_inv_all_children simp: all_children_def simp del: split_paired_All)
   done
 
-lemma intra_label_cap_pres':
-  assumes cte: "\<And> P. \<lbrace> \<lambda> s. cte_wp_at P slot s \<and> R s \<rbrace> f \<lbrace>\<lambda> _. cte_wp_at P slot \<rbrace>"
-  shows
-    "\<lbrace> intra_label_cap aag slot and cte_wp_at Q slot and R \<rbrace>
-         f
-     \<lbrace>\<lambda> _s. (intra_label_cap aag slot s) \<rbrace>"
-  apply(clarsimp simp: valid_def intra_label_cap_def)
-  apply(drule cte_wp_at_norm)
-  apply(elim exE conjE, rename_tac cap')
-  apply(subgoal_tac "cap' = cap", blast)
-  apply(drule use_valid[OF _ cte], fastforce)
-  apply(rule_tac s=b in cte_wp_at_eqD2, auto)
-  done
+end
 
+
+lemma intra_label_cap_pres':
+  assumes cte: "\<And>P. \<lbrace>\<lambda>s. cte_wp_at P slot s \<and> R s\<rbrace> f \<lbrace>\<lambda> _. cte_wp_at P slot\<rbrace>"
+  shows "\<lbrace>intra_label_cap aag slot and cte_wp_at Q slot and R\<rbrace>
+         f
+         \<lbrace>\<lambda>_ s. intra_label_cap aag slot s\<rbrace>"
+  apply (clarsimp simp: valid_def intra_label_cap_def)
+  apply (drule cte_wp_at_norm)
+  apply (elim exE conjE, rename_tac cap')
+  apply (subgoal_tac "cap' = cap", blast)
+  apply (drule use_valid[OF _ cte], fastforce)
+  apply (rule_tac s=b in cte_wp_at_eqD2, auto)
+  done
 
 lemma max_free_index_update_intra_label_cap[wp]:
   "\<lbrace>intra_label_cap aag slot and cte_wp_at ((=) cap) slot\<rbrace>
@@ -2486,165 +2193,107 @@ lemma max_free_index_update_intra_label_cap[wp]:
    \<lbrace>\<lambda>rv s. intra_label_cap aag slot s\<rbrace>"
   unfolding set_cap_def
   apply (wp set_object_wp get_object_wp | wpc| simp add: split_def)+
-  apply(clarsimp simp: intra_label_cap_def cap_points_to_label_def)
-  apply(fastforce elim: cte_wp_atE)
+  apply (clarsimp simp: intra_label_cap_def cap_points_to_label_def)
+  apply (fastforce elim: cte_wp_atE)
   done
 
 lemma get_cap_slots_holding_overlapping_caps:
-  "\<lbrace>silc_inv aag st\<rbrace> get_cap slot
-          \<lbrace>\<lambda>cap s. (\<not> cap_points_to_label aag cap (pasObjectAbs aag (fst slot)) \<longrightarrow>
-                   (\<exists>a. (\<exists>b. (a, b) \<in> FinalCaps.slots_holding_overlapping_caps cap s) \<and>
-                        pasObjectAbs aag a = SilcLabel))\<rbrace>"
-  apply(wp get_cap_wp)
-  apply(fastforce dest: silc_invD simp: intra_label_cap_def)
+  "\<lbrace>silc_inv aag st\<rbrace>
+   get_cap slot
+   \<lbrace>\<lambda>cap s. \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst slot))
+            \<longrightarrow> (\<exists>a. (\<exists>b. (a, b) \<in> slots_holding_overlapping_caps cap s) \<and>
+                     pasObjectAbs aag a = SilcLabel)\<rbrace>"
+  apply (wp get_cap_wp)
+  apply (fastforce dest: silc_invD simp: intra_label_cap_def)
   done
 
 lemma get_cap_cte_wp_at_triv:
-  "\<lbrace> \<top> \<rbrace> get_cap slot \<lbrace>\<lambda> rv s. cte_wp_at ((=) rv) slot s \<rbrace>"
-  apply(wp get_cap_wp, simp)
-  done
+  "\<lbrace>\<top>\<rbrace> get_cap slot \<lbrace>\<lambda>rv s. cte_wp_at ((=) rv) slot s\<rbrace>"
+  by (wp get_cap_wp, simp)
 
 lemma get_cap_valid_max_free_index_update:
-  "\<lbrace> \<lambda> s. \<exists> cap. cte_wp_at ((=) cap) slot s \<and> valid_cap cap s \<and> is_untyped_cap cap \<rbrace>
+  "\<lbrace>\<lambda>s. \<exists>cap. cte_wp_at ((=) cap) slot s \<and> valid_cap cap s \<and> is_untyped_cap cap\<rbrace>
    get_cap slot
    \<lbrace>\<lambda>rv s. s \<turnstile> max_free_index_update rv\<rbrace>"
-  apply(wp get_cap_wp)
+  apply (wp get_cap_wp)
   apply clarsimp
-  apply(drule (1) cte_wp_at_eqD2, clarsimp)
+  apply (drule (1) cte_wp_at_eqD2, clarsimp)
   done
 
 lemma get_cap_perform_asid_control_invocation_helper:
-  "\<lbrace>\<lambda> s. (\<exists> cap. cte_wp_at ((=) cap) x2 s \<and> valid_cap cap s \<and> is_untyped_cap cap) \<and> R\<rbrace>
-         get_cap x2
-          \<lbrace>\<lambda>rv s. free_index_of rv \<le> max_free_index (untyped_sz_bits rv) \<and>
-                  is_untyped_cap rv \<and>
-                  max_free_index (untyped_sz_bits rv) \<le> 2 ^ cap_bits rv \<and> R\<rbrace>"
-  apply(wp get_cap_wp)
+  "\<lbrace>\<lambda>s. (\<exists>cap. cte_wp_at ((=) cap) x2 s \<and> valid_cap cap s \<and> is_untyped_cap cap) \<and> R\<rbrace>
+   get_cap x2
+   \<lbrace>\<lambda>rv s. free_index_of rv \<le> max_free_index (untyped_sz_bits rv) \<and> is_untyped_cap rv \<and>
+           max_free_index (untyped_sz_bits rv) \<le> 2 ^ cap_bits rv \<and> R\<rbrace>"
+  apply (wp get_cap_wp)
   apply clarsimp
-  apply(drule (1) cte_wp_at_eqD2)
-  apply(case_tac capa, simp_all add: max_free_index_def free_index_of_def valid_cap_simps)
+  apply (drule (1) cte_wp_at_eqD2)
+  apply (case_tac capa, simp_all add: max_free_index_def free_index_of_def valid_cap_simps)
   done
 
 lemma retype_region_cte_wp_at_other':
-  "\<lbrace> cte_wp_at P slot and K ((fst slot) \<notin>  set (retype_addrs ptr ty n us)) \<rbrace>
-    retype_region ptr n us ty dev
-   \<lbrace> \<lambda>_. cte_wp_at P slot \<rbrace>"
-  apply(rule hoare_gen_asm)
-  apply(clarsimp simp: valid_def)
-  apply(subst cte_wp_at_pspace')
+  "\<lbrace>cte_wp_at P slot and K ((fst slot) \<notin> set (retype_addrs ptr ty n us))\<rbrace>
+   retype_region ptr n us ty dev
+   \<lbrace>\<lambda>_. cte_wp_at P slot\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (clarsimp simp: valid_def)
+  apply (subst cte_wp_at_pspace')
    prefer 2
    apply assumption
-  apply(erule use_valid)
-   apply(simp only: retype_region_def retype_addrs_def
-                    foldr_upd_app_if fun_app_def K_bind_def)
-   apply(wp modify_wp | simp)+
+  apply (erule use_valid)
+   apply (simp only: retype_region_def retype_addrs_def
+                     foldr_upd_app_if fun_app_def K_bind_def)
+   apply (wp modify_wp | simp)+
   apply (clarsimp simp: not_less retype_addrs_def)
   done
 
 lemma untyped_caps_are_intra_label:
-  "\<lbrakk>cte_wp_at is_untyped_cap slot s\<rbrakk>
-       \<Longrightarrow> intra_label_cap aag slot s"
-  apply(clarsimp simp: intra_label_cap_def cap_points_to_label_def)
-  apply(drule (1) cte_wp_at_eqD2)
-  apply(case_tac cap, simp_all)
-  done
-
-
-lemma perform_asid_control_invocation_silc_inv:
-  notes blah[simp del] =  atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
-  shows
-  "\<lbrace>silc_inv aag st and valid_aci blah and invs and K (authorised_asid_control_inv aag blah)\<rbrace>
-   perform_asid_control_invocation blah
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(rule hoare_gen_asm)
-  unfolding perform_asid_control_invocation_def
-  apply(rule hoare_pre)
-  apply (wp modify_wp cap_insert_silc_inv' retype_region_silc_inv[where sz=pageBits]
-            set_cap_silc_inv get_cap_slots_holding_overlapping_caps[where st=st]
-            delete_objects_silc_inv static_imp_wp
-        | wpc | simp )+
-  apply (clarsimp simp: authorised_asid_control_inv_def silc_inv_def valid_aci_def ptr_range_def page_bits_def)
-  apply(rule conjI)
-   apply(clarsimp simp: range_cover_def obj_bits_api_def default_arch_object_def asid_bits_def pageBits_def)
-   apply(rule of_nat_inverse)
-    apply simp
-    apply(drule is_aligned_neg_mask_eq'[THEN iffD1, THEN sym])
-    apply(erule_tac t=x in ssubst)
-    apply(simp add: mask_AND_NOT_mask)
-   apply simp
-  apply(simp add: p_assoc_help)
-  apply(clarsimp simp: cap_points_to_label_def)
-  apply(erule bspec)
-  apply(fastforce intro: is_aligned_no_wrap' simp: blah)
-  done
-
-
-lemma perform_asid_pool_invocation_silc_inv:
-  "\<lbrace>silc_inv aag st and K (authorised_asid_pool_inv aag blah)\<rbrace>
-   perform_asid_pool_invocation blah
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(rule hoare_gen_asm)
-  unfolding perform_asid_pool_invocation_def
-  apply(rule hoare_pre)
-   apply(wp set_cap_silc_inv get_cap_wp | wpc)+
-  apply clarsimp
-  apply(rule conjI, intro impI)
-   apply(drule silc_invD)
-     apply assumption
-    apply(fastforce simp: intra_label_cap_def simp: cap_points_to_label_def)
-   apply(clarsimp simp: slots_holding_overlapping_caps_def)
-  apply(fastforce simp: authorised_asid_pool_inv_def silc_inv_def)
-  done
-
-
-
-lemma arch_perform_invocation_silc_inv:
-  "\<lbrace>silc_inv aag st and invs and valid_arch_inv ai and authorised_arch_inv aag ai\<rbrace>
-   arch_perform_invocation ai
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding arch_perform_invocation_def
-  apply(rule hoare_pre)
-  apply(wp perform_page_table_invocation_silc_inv
-           perform_page_directory_invocation_silc_inv
-           perform_page_invocation_silc_inv
-           perform_asid_control_invocation_silc_inv
-           perform_asid_pool_invocation_silc_inv
-       | wpc)+
-  apply(clarsimp simp: authorised_arch_inv_def valid_arch_inv_def split: arch_invocation.splits)
+  "cte_wp_at is_untyped_cap slot s \<Longrightarrow> intra_label_cap aag slot s"
+  apply (clarsimp simp: intra_label_cap_def cap_points_to_label_def)
+  apply (drule (1) cte_wp_at_eqD2)
+  apply (case_tac cap, simp_all)
   done
 
 lemma interrupt_derived_ntfn_cap_identical_refs:
   "\<lbrakk>interrupt_derived cap cap'; is_ntfn_cap cap\<rbrakk> \<Longrightarrow>
    Structures_A.obj_refs cap = Structures_A.obj_refs cap' \<and>
    cap_irqs cap = cap_irqs cap'"
-  apply(case_tac cap)
-  apply(simp_all add: interrupt_derived_def cap_master_cap_def split: cap.splits)
+  apply (case_tac cap)
+  apply (simp_all add: interrupt_derived_def cap_master_cap_def split: cap.splits)
   done
 
-lemma subject_not_silc: "is_subject aag x \<Longrightarrow> silc_inv aag st s \<Longrightarrow> pasObjectAbs aag x \<noteq> SilcLabel"
-  apply (clarsimp simp add: silc_inv_def)
+lemma cap_delete_one_cte_wp_at_other:
+  "\<lbrace>cte_wp_at P slot and K (slot \<noteq> irq_slot)\<rbrace>
+   cap_delete_one irq_slot
+   \<lbrace>\<lambda>rv s. cte_wp_at P slot s\<rbrace>"
+  unfolding cap_delete_one_def
+  apply (wp hoare_unless_wp empty_slot_cte_wp_elsewhere get_cap_wp | simp)+
   done
+
+
+context FinalCaps_1 begin
 
 lemma cap_insert_silc_inv''':
-  "\<lbrace>silc_inv aag st and (\<lambda> s. \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst dest)) \<longrightarrow>
-                              (\<exists> lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
-                              pasObjectAbs aag (fst lslot) = SilcLabel)) and
-          K (pasObjectAbs aag (fst src) \<noteq> SilcLabel \<and> pasObjectAbs aag (fst dest) \<noteq> SilcLabel)\<rbrace>
-      cap_insert cap src dest
+  "\<lbrace>silc_inv aag st and (\<lambda> s. \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst dest))
+                              \<longrightarrow> (\<exists>lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
+                                           pasObjectAbs aag (fst lslot) = SilcLabel))
+                    and K (pasObjectAbs aag (fst src) \<noteq> SilcLabel \<and>
+                           pasObjectAbs aag (fst dest) \<noteq> SilcLabel)\<rbrace>
+   cap_insert cap src dest
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding cap_insert_def
   apply (wp set_cap_silc_inv hoare_vcg_ex_lift
             set_untyped_cap_as_full_slots_holding_overlapping_caps_other[where aag=aag]
             get_cap_wp update_cdt_silc_inv set_cap_caps_of_state2
             set_untyped_cap_as_full_cdt_is_original_cap static_imp_wp
-        | simp split del: if_split)+
+         | simp split del: if_split)+
   apply (intro impI conjI allI)
     apply clarsimp
-    apply(fastforce simp: silc_inv_def)
+    apply (fastforce simp: silc_inv_def)
    apply clarsimp
-   apply(drule_tac cap=capa in silc_invD)
+   apply (drule_tac cap=capa in silc_invD)
      apply assumption
-    apply(fastforce simp: intra_label_cap_def)
+    apply (fastforce simp: intra_label_cap_def)
    apply fastforce
   apply (elim conjE)
   apply (drule silc_inv_all_children)
@@ -2654,93 +2303,172 @@ lemma cap_insert_silc_inv''':
 
 (* special case of newer cap_insert_silc_inv''' *)
 lemma cap_insert_silc_inv'':
-  "\<lbrace>silc_inv aag st and (\<lambda> s. \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst dest)) \<longrightarrow>
-                              (\<exists> lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
-                              pasObjectAbs aag (fst lslot) = SilcLabel)) and
-          K (is_subject aag (fst src) \<and> is_subject aag (fst dest))\<rbrace>
-      cap_insert cap src dest
+  "\<lbrace>silc_inv aag st and (\<lambda> s. \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst dest))
+                              \<longrightarrow> (\<exists>lslot. lslot \<in> slots_holding_overlapping_caps cap s \<and>
+                                           pasObjectAbs aag (fst lslot) = SilcLabel))
+                    and K (is_subject aag (fst src) \<and> is_subject aag (fst dest))\<rbrace>
+   cap_insert cap src dest
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   apply (rule hoare_pre_imp[rotated])
    apply (rule cap_insert_silc_inv''')
   apply clarsimp
-  by (metis subject_not_silc)
-
-
-lemma cap_delete_one_cte_wp_at_other:
-  "\<lbrace> cte_wp_at P slot and K (slot \<noteq> irq_slot) \<rbrace>
-   cap_delete_one irq_slot
-   \<lbrace>\<lambda>rv s. cte_wp_at P slot s \<rbrace>"
-  unfolding cap_delete_one_def
-  apply(wp hoare_unless_wp empty_slot_cte_wp_elsewhere get_cap_wp | simp)+
-  done
-
+  by (metis is_subject_not_silc_inv)
 
 lemma invoke_irq_handler_silc_inv:
-  "\<lbrace>silc_inv aag st and pas_refined aag and irq_handler_inv_valid blah and
-         K (authorised_irq_hdl_inv aag blah) \<rbrace>
-      invoke_irq_handler blah
+  "\<lbrace>silc_inv aag st and pas_refined aag and irq_handler_inv_valid hi
+                    and K (authorised_irq_hdl_inv aag hi)\<rbrace>
+   invoke_irq_handler hi
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(rule hoare_gen_asm)
-  apply(case_tac blah)
-    apply(wp cap_insert_silc_inv'' cap_delete_one_silc_inv_subject cap_delete_one_cte_wp_at_other
-             static_imp_wp hoare_vcg_ex_lift
-             slots_holding_overlapping_caps_from_silc_inv[where aag=aag and st=st]
-         | simp add: authorised_irq_hdl_inv_def get_irq_slot_def conj_comms)+
+  apply (rule hoare_gen_asm)
+  apply (case_tac hi)
+    apply (wp cap_insert_silc_inv'' cap_delete_one_silc_inv_subject cap_delete_one_cte_wp_at_other
+              static_imp_wp hoare_vcg_ex_lift
+              slots_holding_overlapping_caps_from_silc_inv[where aag=aag and st=st]
+           | simp add: authorised_irq_hdl_inv_def get_irq_slot_def conj_comms)+
    apply (clarsimp simp: pas_refined_def irq_map_wellformed_aux_def)
    apply (drule cte_wp_at_norm)
    apply (elim exE conjE, rename_tac cap')
    apply (drule_tac cap=cap' in silc_invD)
      apply assumption
-    apply(fastforce simp: intra_label_cap_def cap_points_to_label_def
+    apply (fastforce simp: intra_label_cap_def cap_points_to_label_def
+                           interrupt_derived_ntfn_cap_identical_refs)
+   apply (fastforce simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def
                           interrupt_derived_ntfn_cap_identical_refs)
-   apply(fastforce simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def
-                         interrupt_derived_ntfn_cap_identical_refs)
-  apply(wp cap_delete_one_silc_inv_subject
-       | simp add: pas_refined_def irq_map_wellformed_aux_def authorised_irq_hdl_inv_def)+
+  apply (wp cap_delete_one_silc_inv_subject
+         | simp add: pas_refined_def irq_map_wellformed_aux_def authorised_irq_hdl_inv_def)+
   done
 
+end
+
+
 lemma new_irq_handler_caps_are_intra_label:
-  "\<lbrakk>cte_wp_at ((=) (IRQControlCap)) slot s; pas_refined aag s; is_subject aag (fst slot)\<rbrakk>
-       \<Longrightarrow> cap_points_to_label aag (IRQHandlerCap irq) (pasSubject aag)"
-  apply(clarsimp simp: cap_points_to_label_def)
-  apply(frule cap_cur_auth_caps_of_state[rotated])
+  "\<lbrakk> cte_wp_at ((=) (IRQControlCap)) slot s; pas_refined aag s; is_subject aag (fst slot) \<rbrakk>
+     \<Longrightarrow> cap_points_to_label aag (IRQHandlerCap irq) (pasSubject aag)"
+  apply (clarsimp simp: cap_points_to_label_def)
+  apply (frule cap_cur_auth_caps_of_state[rotated])
     apply assumption
-   apply(simp add: cte_wp_at_caps_of_state)
-  apply(clarsimp simp: aag_cap_auth_def cap_links_irq_def)
-  apply(blast intro: aag_Control_into_owns_irq)
+   apply (simp add: cte_wp_at_caps_of_state)
+  apply (clarsimp simp: aag_cap_auth_def cap_links_irq_def)
+  apply (blast intro: aag_Control_into_owns_irq)
   done
 
 crunch silc_inv[wp]: set_irq_state "silc_inv aag st"
   (wp: silc_inv_triv)
 
-lemma arch_invoke_irq_control_silc_inv:
-  "\<lbrace>silc_inv aag st and pas_refined aag and arch_irq_control_inv_valid arch_irq_cinv and
-         K (arch_authorised_irq_ctl_inv aag arch_irq_cinv) \<rbrace>
-      arch_invoke_irq_control arch_irq_cinv
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding arch_authorised_irq_ctl_inv_def
-  apply(rule hoare_gen_asm)
-  apply(case_tac arch_irq_cinv)
-  apply(wp cap_insert_silc_inv'' hoare_vcg_ex_lift slots_holding_overlapping_caps_lift
-        | simp add: authorised_irq_ctl_inv_def arch_irq_control_inv_valid_def)+
-  apply(fastforce dest: new_irq_handler_caps_are_intra_label)
+crunch silc_inv[wp]: receive_signal "silc_inv aag st"
+
+crunch silc_inv[wp]: set_extra_badge "silc_inv aag st"
+
+crunch silc_inv[wp]: copy_mrs, set_message_info "silc_inv aag st"
+  (wp: crunch_wps)
+
+crunch silc_inv[wp]: do_fault_transfer, complete_signal "silc_inv aag st"
+
+(* doesn't need sym_refs *)
+lemma valid_ep_recv_dequeue':
+  "\<lbrakk> ko_at (Endpoint (Structures_A.endpoint.RecvEP (t # ts))) epptr s; valid_objs s \<rbrakk>
+     \<Longrightarrow> valid_ep (case ts of [] \<Rightarrow> IdleEP | b # bs \<Rightarrow> RecvEP ts) s"
+  unfolding valid_objs_def valid_obj_def valid_ep_def obj_at_def
+  apply (drule bspec)
+  apply (auto split: list.splits)
   done
+
+(* FIXME MOVE next to get_tcb definition*)
+lemma get_tcb_Some:
+  "get_tcb t s = Some v \<longleftrightarrow> kheap s t = Some (TCB v)"
+  by (simp add: get_tcb_def split: kernel_object.splits option.splits)
+
+
+context FinalCaps_1 begin
+
+lemma derive_cap_silc:
+  "\<lbrace>\<lambda>s :: det_state. \<not> cap_points_to_label aag cap l \<longrightarrow> R (slots_holding_overlapping_caps cap s)\<rbrace>
+   derive_cap slot cap
+   \<lbrace>\<lambda>cap' s. \<not> cap_points_to_label aag cap' l \<longrightarrow> R (slots_holding_overlapping_caps cap' s)\<rbrace>,-"
+  apply (simp add: derive_cap_def)
+  apply (wp arch_derive_cap_silc | wpc | simp add: split_def)+
+  apply (auto simp: cap_points_to_label_def slots_holding_overlapping_caps_def)
+  done
+
+lemma transfer_caps_silc_inv:
+  "\<lbrace>silc_inv aag st and valid_objs and valid_mdb and pas_refined aag
+                    and (\<lambda>s. (\<forall>x \<in> set caps. s \<turnstile> fst x) \<and>
+                             (\<forall>x \<in> set caps. cte_wp_at (\<lambda>cp. fst x \<noteq> NullCap \<longrightarrow> cp = fst x) (snd x) s
+                                           \<and> real_cte_at (snd x) s))
+                    and K (is_subject aag receiver \<and> (\<forall>cap \<in> set caps. is_subject aag (fst (snd cap))))\<rbrace>
+  transfer_caps mi caps endpoint receiver receive_buffer
+  \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (simp add: transfer_caps_def)
+  apply (wpc | wp)+
+    apply (rule_tac P = "\<forall>x \<in> set dest_slots. is_subject aag (fst x)" in hoare_gen_asm)
+    apply (wp transfer_caps_loop_pres_dest cap_insert_silc_inv)
+     apply (fastforce simp: silc_inv_def)
+    apply (wp get_receive_slots_authorised hoare_vcg_all_lift hoare_vcg_imp_lift | simp)+
+  apply (fastforce elim: cte_wp_at_weakenE)
+  done
+
+lemma do_normal_transfer_silc_inv:
+  "\<lbrace>silc_inv aag st and pspace_aligned and valid_vspace_objs and valid_arch_state
+                    and valid_objs and valid_mdb and pas_refined aag
+                    and K (grant \<longrightarrow> is_subject aag sender \<and> is_subject aag receiver)\<rbrace>
+   do_normal_transfer sender send_buffer ep badge grant receiver recv_buffer
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding do_normal_transfer_def
+  apply (case_tac grant)
+   apply ((wp transfer_caps_silc_inv copy_mrs_cte_wp_at hoare_vcg_ball_lift lec_valid_cap'
+              lookup_extra_caps_authorised copy_mrs_pas_refined
+           | simp)+)[1]
+  apply simp
+  apply (wp transfer_caps_empty_inv | simp)+
+  done
+
+lemma do_ipc_transfer_silc_inv:
+  "\<lbrace>silc_inv aag st and pspace_aligned and valid_vspace_objs and valid_arch_state
+                    and valid_objs and valid_mdb and pas_refined aag
+                    and K (grant \<longrightarrow> is_subject aag sender \<and> is_subject aag receiver)\<rbrace>
+   do_ipc_transfer sender ep badge grant receiver
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding do_ipc_transfer_def
+  apply (wp do_normal_transfer_silc_inv hoare_vcg_all_lift | wpc | wp (once) hoare_drop_imps)+
+  apply clarsimp
+  done
+
+end
+
+
+locale FinalCaps_2 = FinalCaps_1 +
+  assumes arch_perform_invocation_silc_inv:
+    "\<lbrace>silc_inv aag st and invs and valid_arch_inv ai and authorised_arch_inv aag ai\<rbrace>
+     arch_perform_invocation ai
+     \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  and handle_arch_fault_reply_silc_inv[wp]:
+    "handle_arch_fault_reply vmf thread x y \<lbrace>silc_inv aag st\<rbrace>"
+  and arch_invoke_irq_control_silc_inv:
+    "\<lbrace>silc_inv aag st and pas_refined aag and arch_irq_control_inv_valid arch_irq_cinv
+                      and K (arch_authorised_irq_ctl_inv aag arch_irq_cinv)\<rbrace>
+     arch_invoke_irq_control arch_irq_cinv
+     \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  and invoke_tcb_silc_inv:
+    "\<lbrace>silc_inv aag st and einvs and simple_sched_action and pas_refined aag and tcb_inv_wf tinv
+                      and K (authorised_tcb_inv aag tinv)\<rbrace>
+     invoke_tcb tinv
+     \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+begin
 
 lemma invoke_irq_control_silc_inv:
   "\<lbrace>silc_inv aag st and pas_refined aag and irq_control_inv_valid blah and
-         K (authorised_irq_ctl_inv aag blah) \<rbrace>
+         K (authorised_irq_ctl_inv aag blah)\<rbrace>
       invoke_irq_control blah
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding authorised_irq_ctl_inv_def
-  apply(case_tac blah)
-   apply(rule hoare_gen_asm)
-   apply(wp cap_insert_silc_inv'' hoare_vcg_ex_lift slots_holding_overlapping_caps_lift
+  apply (case_tac blah)
+   apply (rule hoare_gen_asm)
+   apply (wp cap_insert_silc_inv'' hoare_vcg_ex_lift slots_holding_overlapping_caps_lift
          | simp add: authorised_irq_ctl_inv_def)+
-   apply(fastforce dest: new_irq_handler_caps_are_intra_label)
+   apply (fastforce dest: new_irq_handler_caps_are_intra_label)
   apply (simp, rule arch_invoke_irq_control_silc_inv[simplified])
   done
-
-crunch silc_inv[wp]: receive_signal "silc_inv aag st"
 
 lemma setup_caller_cap_silc_inv:
   "\<lbrace>silc_inv aag st and K (grant \<longrightarrow> is_subject aag sender \<and> is_subject aag receiver)
@@ -2752,86 +2480,6 @@ lemma setup_caller_cap_silc_inv:
             slots_holding_overlapping_caps_from_silc_inv[where aag=aag and st=st and P="\<top>"]
         | simp)+
   apply (auto simp: cap_points_to_label_def)
-  done
-
-crunch silc_inv[wp]: set_extra_badge "silc_inv aag st"
-
-lemma imp_ball_lemma:
-  "(R y \<longrightarrow> (\<forall>x\<in>S. P y x)) = (\<forall>x\<in>S. R y \<longrightarrow> P y x)"
-  apply auto
-  done
-
-lemma derive_cap_silc:
-  "\<lbrace> \<lambda> s. (\<not> cap_points_to_label aag cap l) \<longrightarrow> (R (slots_holding_overlapping_caps cap s)) \<rbrace>
-      derive_cap slot cap
-   \<lbrace> \<lambda> cap' s. (\<not> cap_points_to_label aag cap' l) \<longrightarrow> (R (slots_holding_overlapping_caps cap' s)) \<rbrace>,-"
-  apply(rule hoare_pre)
-  apply(simp add: derive_cap_def)
-  apply(wp | wpc | simp add: split_def arch_derive_cap_def)+
-  apply(clarsimp simp: cap_points_to_label_def)
-  apply (auto simp: slots_holding_overlapping_caps_def)
-  done
-
-lemma transfer_caps_silc_inv:
-  "\<lbrace>silc_inv aag st and valid_objs and valid_mdb and pas_refined aag
-        and (\<lambda> s. (\<forall>x\<in>set caps. s \<turnstile> fst x)
-                \<and> (\<forall>x\<in>set caps. cte_wp_at (\<lambda>cp. fst x \<noteq> NullCap \<longrightarrow> cp = fst x) (snd x) s
-                              \<and> real_cte_at (snd x) s)) and
-     K (is_subject aag receiver \<and> (\<forall>cap\<in>set caps.
-           is_subject aag (fst (snd cap))))\<rbrace>
-  transfer_caps mi caps endpoint receiver receive_buffer
-  \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: transfer_caps_def)
-  apply (wpc | wp)+
-    apply (rule_tac P = "\<forall>x \<in> set dest_slots. is_subject aag (fst x)" in hoare_gen_asm)
-    apply (wp transfer_caps_loop_pres_dest cap_insert_silc_inv)
-     apply(fastforce simp: silc_inv_def)
-    apply(wp get_receive_slots_authorised hoare_vcg_all_lift hoare_vcg_imp_lift | simp)+
-  apply(fastforce elim: cte_wp_at_weakenE)
-  done
-
-crunch silc_inv[wp]: copy_mrs, set_message_info "silc_inv aag st"
-  (wp: crunch_wps)
-
-
-lemma do_normal_transfer_silc_inv:
-  "\<lbrace>silc_inv aag st and pspace_aligned and valid_vspace_objs and valid_arch_state
-                    and valid_objs and valid_mdb and pas_refined aag
-                    and K (grant \<longrightarrow> is_subject aag sender \<and> is_subject aag receiver)\<rbrace>
-   do_normal_transfer sender send_buffer ep badge grant receiver recv_buffer
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding do_normal_transfer_def
-  apply(case_tac grant)
-   apply ((wp transfer_caps_silc_inv copy_mrs_cte_wp_at hoare_vcg_ball_lift lec_valid_cap'
-              lookup_extra_caps_authorised copy_mrs_pas_refined
-        | simp)+)[1]
-  apply simp
-  apply(wp transfer_caps_empty_inv | simp)+
-  done
-
-crunch silc_inv[wp]: do_fault_transfer, complete_signal "silc_inv aag st"
-
-(* doesn't need sym_refs *)
-lemma valid_ep_recv_dequeue':
-  "\<lbrakk> ko_at (Endpoint (Structures_A.endpoint.RecvEP (t # ts))) epptr s;
-     valid_objs s\<rbrakk>
-     \<Longrightarrow> valid_ep (case ts of [] \<Rightarrow> Structures_A.endpoint.IdleEP
-                            | b # bs \<Rightarrow> Structures_A.endpoint.RecvEP ts) s"
-  unfolding valid_objs_def valid_obj_def valid_ep_def obj_at_def
-  apply (drule bspec)
-  apply (auto split: list.splits)
-  done
-
-lemma do_ipc_transfer_silc_inv:
-  "\<lbrace>silc_inv aag st and pspace_aligned and valid_vspace_objs and valid_arch_state
-                    and valid_objs and valid_mdb and pas_refined aag
-                    and K (grant \<longrightarrow> is_subject aag sender \<and> is_subject aag receiver)\<rbrace>
-     do_ipc_transfer sender ep badge grant receiver
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding do_ipc_transfer_def
-  apply (wp do_normal_transfer_silc_inv hoare_vcg_all_lift | wpc | wp (once) hoare_drop_imps)+
-  apply clarsimp
   done
 
 lemma send_ipc_silc_inv:
@@ -2885,13 +2533,6 @@ lemma send_ipc_silc_inv:
     done
   done
 
-(* FIXME MOVE next to get_tcb definition*)
-lemma get_tcb_Some:
-  "get_tcb t s = Some v \<longleftrightarrow> kheap s t = Some (TCB v)"
-  by (simp add: get_tcb_def split: kernel_object.splits option.splits)
-
-
-
 lemma receive_ipc_base_silc_inv:
   notes do_nbrecv_failed_transfer_def[simp]
   shows
@@ -2924,7 +2565,6 @@ lemma receive_ipc_base_silc_inv:
        | (drule aag_wellformed_grant_Control_to_send_by_reply[OF _ _ _ pas_refined_wellformed],
           blast, blast, blast, simp add: aag_has_Control_iff_owns)))
 
-
 lemma receive_ipc_silc_inv:
   "\<lbrace>silc_inv aag st and invs and pas_refined aag and
      K (is_subject aag receiver \<and> pas_cap_cur_auth aag cap \<and>
@@ -2951,30 +2591,28 @@ lemma receive_ipc_silc_inv:
   done
 
 lemma send_fault_ipc_silc_inv:
-  "\<lbrace>pas_refined aag and invs and is_subject aag \<circ> cur_thread and
-     silc_inv aag st and
-     K (valid_fault fault) and
-     K (is_subject aag thread)\<rbrace>
-    send_fault_ipc thread fault
-    \<lbrace>\<lambda>rv. silc_inv aag st\<rbrace>"
-  apply(rule hoare_gen_asm)+
+  "\<lbrace>pas_refined aag and invs and is_subject aag \<circ> cur_thread and silc_inv aag st
+                    and K (valid_fault fault \<and> is_subject aag thread)\<rbrace>
+   send_fault_ipc thread fault
+   \<lbrace>\<lambda>rv. silc_inv aag st\<rbrace>"
+  apply (rule hoare_gen_asm)+
   unfolding send_fault_ipc_def
-  apply(wp send_ipc_silc_inv  thread_set_tcb_fault_set_invs
-           thread_set_fault_pas_refined thread_set_refs_trivial thread_set_obj_at_impossible
-           hoare_vcg_ex_lift get_cap_wp hoare_vcg_conj_lift hoare_vcg_ex_lift hoare_vcg_all_lift
-       | wpc
-       | simp add: Let_def split_def lookup_cap_def valid_tcb_fault_update)+
+  apply (wp send_ipc_silc_inv  thread_set_tcb_fault_set_invs
+            thread_set_fault_pas_refined thread_set_refs_trivial thread_set_obj_at_impossible
+            hoare_vcg_ex_lift get_cap_wp hoare_vcg_conj_lift hoare_vcg_ex_lift hoare_vcg_all_lift
+         | wpc
+         | simp add: Let_def split_def lookup_cap_def valid_tcb_fault_update)+
     apply (rule_tac Q'="\<lambda>rv s. silc_inv aag st s \<and> pas_refined aag s
-                          \<and> is_subject aag (cur_thread s)
-                          \<and> invs s
-                          \<and> valid_fault fault
-                          \<and> is_subject aag (fst (fst rv))"
-               in hoare_post_imp_R[rotated])
+                             \<and> is_subject aag (cur_thread s)
+                             \<and> invs s
+                             \<and> valid_fault fault
+                             \<and> is_subject aag (fst (fst rv))"
+                 in hoare_post_imp_R[rotated])
      apply (force dest!: cap_auth_caps_of_state
                    simp: invs_valid_objs invs_sym_refs cte_wp_at_caps_of_state aag_cap_auth_def
                          cap_auth_conferred_def cap_rights_to_auth_def)
    apply (wp get_cap_auth_wp[where aag=aag] lookup_slot_for_thread_authorised
-        | simp add: add: lookup_cap_def split_def)+
+          | simp add: add: lookup_cap_def split_def)+
   done
 
 crunch silc_inv[wp]: handle_fault "silc_inv aag st"
@@ -2982,20 +2620,26 @@ crunch silc_inv[wp]: handle_fault "silc_inv aag st"
 crunch silc_inv[wp]: do_reply_transfer "silc_inv aag st"
   (wp: thread_set_tcb_fault_update_silc_inv crunch_wps  ignore: set_object thread_set)
 
+end
+
+
 crunch silc_inv[wp]: reply_from_kernel "silc_inv aag st"
   (wp: crunch_wps simp: crunch_simps)
 
 lemma setup_reply_master_silc_inv:
   "\<lbrace>silc_inv aag st and K (is_subject aag thread)\<rbrace>
-      setup_reply_master thread
+   setup_reply_master thread
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding setup_reply_master_def
   apply (wp set_cap_silc_inv hoare_vcg_ex_lift
             slots_holding_overlapping_caps_from_silc_inv[where aag=aag and st=st and P="\<top>"]
             get_cap_wp static_imp_wp
-        | simp)+
-  apply(clarsimp simp: cap_points_to_label_def silc_inv_def)
+         | simp)+
+  apply (clarsimp simp: cap_points_to_label_def silc_inv_def)
   done
+
+
+context FinalCaps_1 begin
 
 crunch silc_inv: restart "silc_inv aag st"
   (wp: crunch_wps simp: crunch_simps)
@@ -3003,43 +2647,44 @@ crunch silc_inv: restart "silc_inv aag st"
 crunch silc_inv: suspend "silc_inv aag st"
 
 lemma same_object_as_cap_points_to_label:
-  "\<lbrakk>same_object_as a cap;
-        \<not> cap_points_to_label aag a (pasSubject aag)\<rbrakk>
-       \<Longrightarrow> \<not> cap_points_to_label aag cap (pasSubject aag)"
-  apply(simp add: same_object_as_def cap_points_to_label_def split: cap.splits)
-      apply(case_tac cap, simp_all)
-     apply(case_tac cap, simp_all)
-    apply(case_tac cap, simp_all)
-   apply(case_tac cap, simp_all)
-  subgoal for arch1 arch2 by (cases arch1; cases arch2; simp)
+  "\<lbrakk> same_object_as a cap; \<not> cap_points_to_label aag a (pasSubject aag) \<rbrakk>
+     \<Longrightarrow> \<not> cap_points_to_label aag cap (pasSubject aag)"
+  apply (simp add: same_object_as_def cap_points_to_label_def split: cap.splits)
+      apply (case_tac cap, simp_all)
+     apply (case_tac cap, simp_all)
+    apply (case_tac cap, simp_all)
+   apply (case_tac cap, simp_all)
+  apply (fastforce dest: aobj_ref_same_aobject)
   done
 
 lemma same_object_as_slots_holding_overlapping_caps:
-  "\<lbrakk>same_object_as a cap;
-        \<not> cap_points_to_label aag a (pasSubject aag)\<rbrakk> \<Longrightarrow>
-    slots_holding_overlapping_caps cap s = slots_holding_overlapping_caps a s"
-  apply(simp add: same_object_as_def slots_holding_overlapping_caps_def2 ctes_wp_at_def
+  "\<lbrakk> same_object_as a cap; \<not> cap_points_to_label aag a (pasSubject aag) \<rbrakk>
+     \<Longrightarrow> slots_holding_overlapping_caps cap s = slots_holding_overlapping_caps a s"
+  apply (simp add: same_object_as_def slots_holding_overlapping_caps_def2 ctes_wp_at_def
            split: cap.splits)
-       apply(case_tac cap, simp_all)
-      apply(case_tac cap, simp_all)
-     apply(case_tac cap, simp_all)
-    apply(case_tac cap, simp_all)
-   apply(case_tac cap, simp_all)
-  subgoal for arch1 arch2 by (cases arch1; cases arch2; simp)
+       apply (case_tac cap, simp_all)
+      apply (case_tac cap, simp_all)
+     apply (case_tac cap, simp_all)
+    apply (case_tac cap, simp_all)
+   apply (case_tac cap, simp_all)
+  apply (fastforce dest: aobj_ref_same_aobject)
   done
 
 lemma checked_cap_insert_silc_inv:
   "\<lbrace>silc_inv aag st and K (is_subject aag (fst b) \<and> is_subject aag (fst e))\<rbrace>
    check_cap_at a b (check_cap_at c d (cap_insert a b e))
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(wp cap_insert_silc_inv'' get_cap_wp | simp add: check_cap_at_def)+
+  apply (wp cap_insert_silc_inv'' get_cap_wp | simp add: check_cap_at_def)+
   apply clarsimp
-  apply(drule_tac cap=cap in silc_invD)
+  apply (drule_tac cap=cap in silc_invD)
     apply assumption
-   apply(clarsimp simp: intra_label_cap_def)
-   apply(fastforce dest: same_object_as_cap_points_to_label)
-  apply(fastforce dest: same_object_as_slots_holding_overlapping_caps)
+   apply (clarsimp simp: intra_label_cap_def)
+   apply (fastforce dest: same_object_as_cap_points_to_label)
+  apply (fastforce dest: same_object_as_slots_holding_overlapping_caps)
   done
+
+end
+
 
 lemma thread_set_tcb_ipc_buffer_update_silc_inv[wp]:
   "\<lbrace>silc_inv aag st\<rbrace>
@@ -3056,13 +2701,13 @@ lemma thread_set_tcb_fault_handler_update_silc_inv[wp]:
 lemma thread_set_tcb_fault_handler_update_invs:
   "\<lbrace>invs and K (length a = word_bits)\<rbrace>
    thread_set (tcb_fault_handler_update (\<lambda>y. a)) word
-   \<lbrace>\<lambda>rv s. invs s\<rbrace>"
-  apply(rule hoare_gen_asm)
-  apply(wp itr_wps | simp)+
+   \<lbrace>\<lambda>_ s. invs s\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (wp itr_wps | simp)+
   done
 
 lemma set_mcpriority_silc_inv[wp]:
-  "\<lbrace>silc_inv aag st\<rbrace> set_mcpriority t mcp \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  "set_mcpriority t mcp \<lbrace>silc_inv aag st\<rbrace>"
   unfolding set_mcpriority_def
   by (rule thread_set_silc_inv; simp add: tcb_cap_cases_def)
 
@@ -3070,7 +2715,7 @@ crunch silc_inv[wp]: bind_notification "silc_inv aag st"
 
 (* FIXME MOVE to the previous one and replace it: keep things generic please + wps is nice *)
 lemma cap_delete_tcb[wp]:
- "\<lbrace>\<lambda>s. P (tcb_at t s)\<rbrace> cap_delete ptr \<lbrace>\<lambda>rv s. P (tcb_at t s)\<rbrace>"
+ "cap_delete ptr \<lbrace>\<lambda>s. P (tcb_at t s)\<rbrace>"
   unfolding cap_delete_def tcb_at_typ
   by (simp add: tcb_at_typ | wp rec_del_typ_at)+
 
@@ -3079,202 +2724,8 @@ lemma st_tcb_at_triv:
   by (simp add:tcb_at_st_tcb_at st_tcb_at_tcb_states_of_state) blast
 
 lemma cap_insert_no_tcb_at[wp]:
- "\<lbrace>\<lambda>s. \<not> tcb_at t s\<rbrace> cap_insert cap src dest \<lbrace>\<lambda>rv s. \<not> tcb_at t s\<rbrace>"
+ "cap_insert cap src dest \<lbrace>\<lambda>s. \<not> tcb_at t s\<rbrace>"
   unfolding tcb_at_st_tcb_at by (wp cap_insert_no_pred_tcb_at)
-
-lemma invoke_tcb_silc_inv:
-  notes static_imp_wp [wp]
-        static_imp_conj_wp [wp]
-  shows
-  "\<lbrace>silc_inv aag st and einvs and simple_sched_action and pas_refined aag and
-    Tcb_AI.tcb_inv_wf tinv and K (authorised_tcb_inv aag tinv)\<rbrace>
-   invoke_tcb tinv
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(case_tac tinv)
-         apply((wp restart_silc_inv hoare_vcg_if_lift suspend_silc_inv mapM_x_wp[OF _ subset_refl]
-                   static_imp_wp
-             | wpc
-             | simp split del: if_split add: authorised_tcb_inv_def check_cap_at_def
-             | clarsimp
-             | strengthen invs_mdb
-             | force intro: notE[rotated,OF idle_no_ex_cap,simplified])+)[3]
-      defer
-      apply((wp suspend_silc_inv restart_silc_inv | simp add: authorised_tcb_inv_def | force)+)[2]
-    (* NotificationControl *)
-    apply (rename_tac option)
-    apply (case_tac option; (wp | simp)+)
-   (* SetTLSBase *)
-   apply (wpsimp split: option.splits)
-  (* just ThreadControl left *)
-  apply (simp add: split_def cong: option.case_cong)
-  (* slow, ~2 mins *)
-  apply (simp only: conj_ac cong: conj_cong imp_cong |
-         wp checked_insert_pas_refined checked_cap_insert_silc_inv hoare_vcg_all_lift_R
-            hoare_vcg_all_lift hoare_vcg_const_imp_lift_R
-            cap_delete_silc_inv_not_transferable
-            cap_delete_pas_refined' cap_delete_deletes
-            cap_delete_valid_cap cap_delete_cte_at
-            check_cap_inv[where P="valid_cap c" for c]
-            check_cap_inv[where P="cte_at p0" for p0]
-            check_cap_inv[where P="\<lambda>s. \<not> tcb_at t s" for t]
-            check_cap_inv2[where Q="\<lambda>_. valid_list"]
-            check_cap_inv2[where Q="\<lambda>_. valid_sched"]
-            check_cap_inv2[where Q="\<lambda>_. simple_sched_action"]
-            checked_insert_no_cap_to
-            thread_set_tcb_fault_handler_update_invs
-            thread_set_pas_refined thread_set_emptyable thread_set_valid_cap
-            thread_set_not_state_valid_sched thread_set_cte_at
-            thread_set_no_cap_to_trivial
-        |wpc
-        |simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def st_tcb_at_triv
-                   option_update_thread_def
-        |strengthen use_no_cap_to_obj_asid_strg invs_mdb
-                    invs_psp_aligned invs_vspace_objs invs_arch_state
-        |wp (once) hoare_drop_imps)+
-  apply (clarsimp simp: authorised_tcb_inv_def emptyable_def)
-  (* also slow, ~15s *)
-  by (clarsimp simp: is_cap_simps is_cnode_or_valid_arch_def is_valid_vtable_root_def
-     |intro impI
-     |rule conjI)+
-
-lemma perform_invocation_silc_inv:
-  "\<lbrace>silc_inv aag st and valid_invocation iv and
-         authorised_invocation aag iv and einvs and simple_sched_action
-         and pas_refined aag and is_subject aag \<circ> cur_thread\<rbrace>
-      perform_invocation block call iv
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(case_tac iv)
-          apply(wp invoke_untyped_silc_inv send_ipc_silc_inv
-                   invoke_tcb_silc_inv invoke_cnode_silc_inv
-                   invoke_irq_control_silc_inv
-                   invoke_irq_handler_silc_inv
-                   arch_perform_invocation_silc_inv
-               | simp add: authorised_invocation_def invs_valid_objs
-                           invs_mdb invs_sym_refs
-                           split_def invoke_domain_def
-               | fastforce dest:silc_inv_not_subject)+
-  done
-
-lemma handle_invocation_silc_inv:
-  "\<lbrace>silc_inv aag st and einvs and simple_sched_action and pas_refined aag and
-       is_subject aag \<circ> cur_thread and ct_active and domain_sep_inv (pasMaySendIrqs aag) st'\<rbrace>
-     handle_invocation calling blocking
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply (simp add: handle_invocation_def ts_Restart_case_helper split_def
-                   liftE_liftM_liftME liftME_def bindE_assoc
-              split del: if_split)
-  apply(wp syscall_valid perform_invocation_silc_inv set_thread_state_runnable_valid_sched
-           set_thread_state_pas_refined decode_invocation_authorised
-       | simp split del: if_split)+
-       apply(rule_tac E="\<lambda>ft. silc_inv aag st and pas_refined aag and
-                  is_subject aag \<circ> cur_thread and
-                  invs and
-                  (\<lambda>y. valid_fault ft) and
-                  (\<lambda>y. is_subject aag thread)" and R="Q" and Q=Q for Q in hoare_post_impErr)
-         apply(wp lookup_extra_caps_authorised lookup_extra_caps_auth
-              | simp)+
-     apply(rule_tac E="\<lambda>ft. silc_inv aag st and pas_refined aag and
-                  is_subject aag \<circ> cur_thread and
-                  invs and
-                  (\<lambda>y. valid_fault (CapFault x False ft)) and
-                  (\<lambda>y. is_subject aag thread)" and R="Q" and Q=Q for Q in hoare_post_impErr)
-       apply (wp lookup_cap_and_slot_authorised
-                 lookup_cap_and_slot_cur_auth
-            | simp)+
-  apply (auto intro: st_tcb_ex_cap simp: ct_in_state_def runnable_eq_active)
-  done
-
-lemmas handle_send_silc_inv =
-           handle_invocation_silc_inv[where calling=False, folded handle_send_def]
-
-lemmas handle_call_silc_inv =
-           handle_invocation_silc_inv[where calling=True and blocking=True, folded handle_call_def]
-
-lemma cte_wp_at_caps_of_state':
-  "cte_wp_at ((=) c) slot s \<Longrightarrow> caps_of_state s slot = Some c"
-  by(simp add: caps_of_state_def cte_wp_at_def)
-
-
-lemma handle_reply_silc_inv:
-  "\<lbrace>silc_inv aag st and invs and pas_refined aag and
-    is_subject aag \<circ> cur_thread\<rbrace>
-   handle_reply
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding handle_reply_def
-  apply (wp hoare_vcg_all_lift get_cap_wp | wpc )+
-  by (force dest: cap_auth_caps_of_state silc_inv_not_subject
-            simp: cte_wp_at_caps_of_state aag_cap_auth_def cap_auth_conferred_def
-                  reply_cap_rights_to_auth_def
-           intro:aag_Control_into_owns)
-
-
-
-crunch silc_inv: delete_caller_cap "silc_inv aag st"
-
-lemma handle_recv_silc_inv:
-  "\<lbrace>silc_inv aag st and invs and pas_refined aag and
-    is_subject aag \<circ> cur_thread\<rbrace>
-   handle_recv is_blocking
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply (simp add: handle_recv_def Let_def lookup_cap_def split_def)
-  apply (wp hoare_vcg_all_lift get_simple_ko_wp delete_caller_cap_silc_inv
-            receive_ipc_silc_inv
-            lookup_slot_for_thread_authorised
-            lookup_slot_for_thread_cap_fault
-            get_cap_auth_wp[where aag=aag]
-        | wpc | simp
-        | rule_tac Q="\<lambda>rv s. invs s \<and> pas_refined aag s \<and> is_subject aag thread
-                        \<and> (pasSubject aag, Receive, pasObjectAbs aag x31) \<in> pasPolicy aag"
-                    in hoare_strengthen_post, wp, clarsimp simp: invs_valid_objs invs_sym_refs)+
-    apply (rule_tac Q'="\<lambda>r s. silc_inv aag st s \<and> invs s \<and> pas_refined aag s
-                           \<and> is_subject aag thread \<and> tcb_at thread s
-                           \<and> cur_thread s = thread" in hoare_post_imp_R)
-     apply wp
-    apply ((clarsimp simp add: invs_valid_objs invs_sym_refs
-           | intro impI allI conjI
-           | rule cte_wp_valid_cap caps_of_state_cteD
-           | fastforce simp: aag_cap_auth_def cap_auth_conferred_def
-             cap_rights_to_auth_def valid_fault_def dest:silc_inv_not_subject
-           )+)[1]
-   apply (wp delete_caller_cap_silc_inv | simp add: split_def cong: conj_cong)+
-  apply(wp | simp add: invs_valid_objs invs_mdb invs_sym_refs tcb_at_invs)+
-  done
-
-lemma handle_interrupt_silc_inv:
-  "\<lbrace>silc_inv aag st\<rbrace> handle_interrupt irq \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  unfolding handle_interrupt_def
-  apply (rule hoare_if)
-  apply(wp | wpc | simp add: handle_reserved_irq_def | wp (once) hoare_drop_imps)+
-  done
-
-lemma handle_vm_fault_silc_inv:
-  "\<lbrace>silc_inv aag st\<rbrace> handle_vm_fault thread vmfault_type
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(case_tac vmfault_type)
-   apply(wp | simp)+
-  done
-
-crunch silc_inv: handle_hypervisor_fault "silc_inv aag st"
-
-lemma handle_event_silc_inv:
-  "\<lbrace> silc_inv aag st and einvs and simple_sched_action and
-       (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) and
-       pas_refined aag and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s)) and
-       domain_sep_inv (pasMaySendIrqs aag) st'\<rbrace>
-     handle_event ev
-   \<lbrace> \<lambda>_. silc_inv aag st\<rbrace>"
-  apply(case_tac ev; simp_all)
-  by (wpc
-     | wp handle_send_silc_inv[where st'=st']
-          handle_call_silc_inv[where st'=st']
-          handle_recv_silc_inv
-          handle_reply_silc_inv
-          handle_interrupt_silc_inv
-          handle_vm_fault_silc_inv hy_inv
-          handle_hypervisor_fault_silc_inv
-     | simp add: invs_valid_objs invs_mdb invs_sym_refs)+
-
-crunch silc_inv[wp]: activate_thread "silc_inv aag st"
 
 lemma intra_label_cap_cur_thread[simp]:
   "intra_label_cap aag slot (s\<lparr>cur_thread := X\<rparr>) = intra_label_cap aag slot s"
@@ -3288,19 +2739,135 @@ lemma silc_inv_cur_thread[simp]:
   "silc_inv aag st (s\<lparr>cur_thread := X\<rparr>) = silc_inv aag st s"
   by (simp add: silc_inv_def silc_dom_equiv_def equiv_for_def)
 
+
+context FinalCaps_2 begin
+
+lemma perform_invocation_silc_inv:
+  "\<lbrace>silc_inv aag st and valid_invocation iv and authorised_invocation aag iv
+                    and einvs and simple_sched_action
+                    and pas_refined aag and is_subject aag \<circ> cur_thread\<rbrace>
+   perform_invocation block call iv
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (cases iv)
+  by (wp invoke_untyped_silc_inv send_ipc_silc_inv
+         invoke_tcb_silc_inv invoke_cnode_silc_inv
+         invoke_irq_control_silc_inv
+         invoke_irq_handler_silc_inv
+         arch_perform_invocation_silc_inv
+      | simp add: authorised_invocation_def invs_valid_objs
+                  invs_mdb invs_sym_refs
+                  split_def invoke_domain_def
+      | fastforce dest:silc_inv_not_subject)+
+
+lemma handle_invocation_silc_inv:
+  "\<lbrace>silc_inv aag st and einvs and simple_sched_action and pas_refined aag
+                    and is_subject aag \<circ> cur_thread and ct_active
+                    and domain_sep_inv (pasMaySendIrqs aag) st'\<rbrace>
+   handle_invocation calling blocking
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (simp add: handle_invocation_def ts_Restart_case_helper split_def
+                   liftE_liftM_liftME liftME_def bindE_assoc
+              split del: if_split)
+  apply (wp syscall_valid perform_invocation_silc_inv set_thread_state_runnable_valid_sched
+            set_thread_state_pas_refined decode_invocation_authorised
+         | simp split del: if_split)+
+       apply (rule_tac E="\<lambda>ft. silc_inv aag st and pas_refined aag and
+                               is_subject aag \<circ> cur_thread and invs and
+                               (\<lambda>_. valid_fault ft \<and> is_subject aag thread)"
+                   and R="Q" and Q=Q for Q in hoare_post_impErr)
+         apply (wp lookup_extra_caps_authorised lookup_extra_caps_auth | simp)+
+     apply (rule_tac E="\<lambda>ft. silc_inv aag st and pas_refined aag and
+                             is_subject aag \<circ> cur_thread and invs and
+                             (\<lambda>_. valid_fault (CapFault x False ft) \<and> is_subject aag thread)"
+                 and R="Q" and Q=Q for Q in hoare_post_impErr)
+        apply (wp lookup_cap_and_slot_authorised lookup_cap_and_slot_cur_auth | simp)+
+  apply (auto intro: st_tcb_ex_cap simp: ct_in_state_def runnable_eq_active)
+  done
+
+lemmas handle_send_silc_inv =
+  handle_invocation_silc_inv[where calling=False, folded handle_send_def]
+
+lemmas handle_call_silc_inv =
+  handle_invocation_silc_inv[where calling=True and blocking=True, folded handle_call_def]
+
+lemma cte_wp_at_caps_of_state':
+  "cte_wp_at ((=) c) slot s \<Longrightarrow> caps_of_state s slot = Some c"
+  by (simp add: caps_of_state_def cte_wp_at_def)
+
+lemma handle_reply_silc_inv:
+  "\<lbrace>silc_inv aag st and invs and pas_refined aag and is_subject aag \<circ> cur_thread\<rbrace>
+   handle_reply
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding handle_reply_def
+  apply (wp hoare_vcg_all_lift get_cap_wp | wpc )+
+  by (force dest: cap_auth_caps_of_state silc_inv_not_subject
+            simp: cte_wp_at_caps_of_state aag_cap_auth_def cap_auth_conferred_def
+                  reply_cap_rights_to_auth_def
+           intro: aag_Control_into_owns)
+
+crunch silc_inv: delete_caller_cap "silc_inv aag st"
+
+lemma handle_recv_silc_inv:
+  "\<lbrace>silc_inv aag st and invs and pas_refined aag and is_subject aag \<circ> cur_thread\<rbrace>
+   handle_recv is_blocking
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (simp add: handle_recv_def Let_def lookup_cap_def split_def)
+  apply (wp hoare_vcg_all_lift get_simple_ko_wp delete_caller_cap_silc_inv
+            receive_ipc_silc_inv lookup_slot_for_thread_authorised
+            lookup_slot_for_thread_cap_fault get_cap_auth_wp[where aag=aag]
+         | wpc | simp
+         | rule_tac Q="\<lambda>rv s. invs s \<and> pas_refined aag s \<and> is_subject aag thread \<and>
+                              (pasSubject aag, Receive, pasObjectAbs aag x31) \<in> pasPolicy aag"
+                 in hoare_strengthen_post, wp, clarsimp simp: invs_valid_objs invs_sym_refs)+
+    apply (rule_tac Q'="\<lambda>r s. silc_inv aag st s \<and> invs s \<and> pas_refined aag s \<and>
+                              is_subject aag thread \<and> tcb_at thread s \<and> cur_thread s = thread"
+                 in hoare_post_imp_R)
+     apply wp
+    apply ((clarsimp simp add: invs_valid_objs invs_sym_refs
+            | intro impI allI conjI
+            | rule cte_wp_valid_cap caps_of_state_cteD
+            | fastforce simp: aag_cap_auth_def cap_auth_conferred_def
+                              cap_rights_to_auth_def valid_fault_def
+                        dest: silc_inv_not_subject)+)[1]
+   apply (wp delete_caller_cap_silc_inv | simp add: split_def cong: conj_cong)+
+  apply fastforce
+  done
+
+lemma handle_interrupt_silc_inv:
+  "handle_interrupt irq \<lbrace>silc_inv aag st\<rbrace>"
+  unfolding handle_interrupt_def by (wpsimp wp: hoare_drop_imps)
+
+lemma handle_event_silc_inv:
+  "\<lbrace>silc_inv aag st and einvs and simple_sched_action and pas_refined aag
+                    and domain_sep_inv (pasMaySendIrqs aag) st'
+                    and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)
+                    and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))\<rbrace>
+   handle_event ev
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (case_tac ev; simp_all)
+  by (wpsimp wp: handle_send_silc_inv[where st'=st']
+                 handle_call_silc_inv[where st'=st']
+                 handle_recv_silc_inv
+                 handle_reply_silc_inv
+                 handle_interrupt_silc_inv
+                 handle_vm_fault_silc_inv hy_inv
+                 handle_hypervisor_fault_silc_inv
+           simp: invs_valid_objs invs_mdb invs_sym_refs)+
+
+crunch silc_inv[wp]: activate_thread "silc_inv aag st"
+
 crunch silc_inv[wp]: schedule "silc_inv aag st"
-  (   wp: alternative_wp OR_choice_weak_wp select_wp crunch_wps
-  ignore: set_scheduler_action ARM.clearExMonitor
-    simp: crunch_simps
-  ignore: set_scheduler_action ARM.clearExMonitor)
+  (    wp: alternative_wp OR_choice_weak_wp select_wp crunch_wps
+   ignore: set_scheduler_action
+     simp: crunch_simps)
 
 lemma call_kernel_silc_inv:
-  "\<lbrace> silc_inv aag st and einvs and simple_sched_action and
-       (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) and
-       pas_refined aag and is_subject aag \<circ> cur_thread and domain_sep_inv (pasMaySendIrqs aag) st'\<rbrace>
-     call_kernel ev
-   \<lbrace> \<lambda>_. silc_inv aag st\<rbrace>"
-  apply (simp add: call_kernel_def getActiveIRQ_def)
+  "\<lbrace>silc_inv aag st and einvs and simple_sched_action and pas_refined aag
+                    and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)
+                    and is_subject aag \<circ> cur_thread and domain_sep_inv (pasMaySendIrqs aag) st'\<rbrace>
+   call_kernel ev
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (simp add: call_kernel_def)
   apply (wp handle_interrupt_silc_inv handle_event_silc_inv[where st'=st'] | simp)+
   done
 

--- a/proof/infoflow/Finalise_IF.thy
+++ b/proof/infoflow/Finalise_IF.thy
@@ -5,100 +5,135 @@
  *)
 
 theory Finalise_IF
-imports Arch_IF IRQMasks_IF
+imports ArchArch_IF ArchIRQMasks_IF
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-crunch_ignore (add: tcb_sched_action)
-
-lemma dmo_maskInterrupt_reads_respects:
-  "reads_respects aag l \<top> (do_machine_op (maskInterrupt m irq))"
-  unfolding maskInterrupt_def
-  apply(rule use_spec_ev)
-  apply(rule do_machine_op_spec_reads_respects)
-   apply(simp add: equiv_valid_def2)
-   apply(rule modify_ev2)
-   apply(fastforce simp: equiv_for_def)
-  apply (wp modify_wp | simp)+
-  done
+locale Finalise_IF_1 =
+  fixes aag :: "'a subject_label PAS"
+  assumes dmo_maskInterrupt_reads_respects:
+    "reads_respects aag l \<top> (do_machine_op (maskInterrupt m irq))"
+  and arch_post_cap_deletion_read_respects[wp]:
+    "reads_respects aag l \<top> (arch_post_cap_deletion acap)"
+  and equiv_asid_sa_update[simp]:
+    "\<And>f. equiv_asid asid (scheduler_action_update f s) s' = equiv_asid asid s s'"
+    "\<And>f. equiv_asid asid s (scheduler_action_update f s') = equiv_asid asid s s'"
+  and equiv_asid_ready_queues_update[simp]:
+    "\<And>f. equiv_asid asid (ready_queues_update f s) s' = equiv_asid asid s s'"
+    "\<And>f. equiv_asid asid s (ready_queues_update f s') = equiv_asid asid s s'"
+  and set_thread_state_reads_respects:
+    "pas_domains_distinct aag
+     \<Longrightarrow> reads_respects aag l (\<lambda>s. is_subject aag (cur_thread s)) (set_thread_state ref ts)"
+  and set_bound_notification_globals_equiv:
+    "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace> set_bound_notification ref nopt \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  and set_bound_notification_valid_ko_at_arch[wp]:
+    "set_bound_notification ref nopt \<lbrace>valid_ko_at_arch\<rbrace>"
+  and set_original_valid_ko_at_arch[wp]:
+    "set_original slot v \<lbrace>valid_ko_at_arch\<rbrace>"
+  and set_cdt_valid_ko_at_arch[wp]:
+    "set_cdt ct \<lbrace>valid_ko_at_arch\<rbrace>"
+  and set_thread_state_runnable_reads_respects:
+    "\<lbrakk> pas_domains_distinct aag; runnable ts \<rbrakk> \<Longrightarrow> reads_respects aag l \<top> (set_thread_state ref ts)"
+  and set_bound_notification_none_reads_respects:
+    "pas_domains_distinct aag \<Longrightarrow> reads_respects aag l \<top> (set_bound_notification ref None)"
+  and thread_set_reads_respects:
+    "pas_domains_distinct aag \<Longrightarrow> reads_respects aag l \<top> (thread_set x y)"
+  and set_tcb_queue_reads_respects[wp]:
+    "reads_respects aag l \<top> (set_tcb_queue d prio queue)"
+  and set_notification_equiv_but_for_labels:
+    "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag ntfnptr \<in> L)\<rbrace>
+     set_notification ntfnptr ntfn
+     \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  and prepare_thread_delete_reads_respects_f:
+    "reads_respects_f aag l \<top> (prepare_thread_delete t)"
+  and arch_finalise_cap_reads_respects:
+    "reads_respects aag l (pas_refined aag and invs and cte_wp_at ((=) (ArchObjectCap cap)) slot
+                                           and K (pas_cap_cur_auth aag (ArchObjectCap cap)))
+                          (arch_finalise_cap cap is_final)"
+  and arch_finalise_cap_makes_halted:
+    "\<lbrace>invs and valid_cap (ArchObjectCap acap)
+           and (\<lambda>s. ex = is_final_cap' (ArchObjectCap acap) s)
+           and cte_wp_at ((=) (ArchObjectCap acap)) slot\<rbrace>
+     arch_finalise_cap acap ex
+     \<lbrace>\<lambda>rv s :: det_state. \<forall>t \<in> Access.obj_refs (fst rv). halted_if_tcb t s\<rbrace>"
+  and set_notification_globals_equiv:
+    "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
+     set_notification ntfnptr ntfn
+     \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  and arch_post_cap_deletion_globals_equiv[wp]:
+    "arch_post_cap_deletion acap \<lbrace>globals_equiv st\<rbrace>"
+  and set_irq_state_globals_equiv:
+    "set_irq_state state irq \<lbrace>globals_equiv st\<rbrace>"
+  and arch_finalise_cap_globals_equiv:
+    "\<lbrace>globals_equiv st and valid_global_objs and valid_arch_state and pspace_aligned
+                       and valid_vspace_objs and valid_global_refs and valid_vs_lookup\<rbrace>
+     arch_finalise_cap acap ex
+     \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  and prepare_thread_delete_globals_equiv[wp]:
+    "prepare_thread_delete t \<lbrace>globals_equiv st\<rbrace>"
+  and thread_set_valid_ko_at_arch[wp]:
+    "\<And>f. thread_set f t \<lbrace>valid_ko_at_arch\<rbrace>"
+  and prepare_thread_delete_valid_ko_at_arch[wp]:
+    "prepare_thread_delete t \<lbrace>valid_ko_at_arch\<rbrace>"
+  and arch_post_cap_deletion_valid_ko_at_arch[wp]:
+    "arch_post_cap_deletion acap \<lbrace>valid_ko_at_arch\<rbrace>"
+  and arch_finalise_cap_valid_ko_at_arch[wp]:
+    "arch_finalise_cap acap ex \<lbrace>valid_ko_at_arch\<rbrace>"
+begin
 
 lemma set_irq_state_reads_respects:
   "reads_respects aag l \<top> (set_irq_state state irq)"
   unfolding set_irq_state_def fun_app_def
-  apply(wp dmo_maskInterrupt_reads_respects)
-    apply(subst equiv_valid_def2)
-    apply(rule_tac P="\<top>" and P'="\<top>" in modify_ev2)
-    apply clarsimp
-    apply(rule conjI)
-     apply(fastforce intro!: reads_equiv_interrupt_states_update elim: reads_equivE intro: equiv_forI elim: equiv_forE)
-    apply(fastforce intro!: affects_equiv_interrupt_states_update elim: affects_equivE intro: equiv_forI elim: equiv_forE)
-   apply(wp)
-  apply(fastforce)
+  apply (wp dmo_maskInterrupt_reads_respects)
+    apply (subst equiv_valid_def2)
+    apply (rule_tac P="\<top>" and P'="\<top>" in modify_ev2)
+    apply (fastforce elim: affects_equivE reads_equivE equiv_forE intro: equiv_forI
+                   intro!: reads_equiv_interrupt_states_update affects_equiv_interrupt_states_update)
+   apply wpsimp+
   done
-
 
 lemma deleted_irq_handler_reads_respects:
   "reads_respects aag l \<top> (deleted_irq_handler irq)"
   unfolding deleted_irq_handler_def
-  apply(rule set_irq_state_reads_respects)
-  done
+  by (rule set_irq_state_reads_respects)
 
 lemma empty_slot_reads_respects:
   notes split_paired_All[simp del] split_paired_Ex[simp del]
-  shows
-  "reads_respects aag l (K (aag_can_read aag (fst slot))) (empty_slot slot free_irq)"
+  shows "reads_respects aag l (K (aag_can_read aag (fst slot))) (empty_slot slot free_irq)"
   unfolding empty_slot_def post_cap_deletion_def fun_app_def
   apply (simp add: bind_assoc[symmetric] cong: if_cong)
   apply (fold update_cdt_def)
   apply (simp add: bind_assoc empty_slot_ext_def cong: if_cong)
-  apply(rule gen_asm_ev)
+  apply (rule gen_asm_ev)
   apply (wp deleted_irq_handler_reads_respects set_cap_reads_respects set_original_reads_respects
             update_cdt_list_reads_respects update_cdt_reads_respects get_cap_wp get_cap_rev
-        | wpc
-        | simp
-        | frule aag_can_read_self, fastforce simp: equiv_for_def split: option.splits)+
+         | wpsimp
+         | frule aag_can_read_self, fastforce simp: equiv_for_def split: option.splits)+
   by (fastforce simp: reads_equiv_def2 equiv_for_def
                 elim: states_equiv_forE_cdt
                 dest: aag_can_read_self
                split: option.splits)
 
-lemma requiv_get_tcb_eq':
-  "\<lbrakk>reads_equiv aag s t; aag_can_read aag thread\<rbrakk> \<Longrightarrow>
-    get_tcb thread s = get_tcb thread t"
-  by (auto simp: reads_equiv_def2 get_tcb_def
-           elim: states_equiv_forE_kheap
-          dest!: aag_can_read_self
-          split: option.split kernel_object.split)
-
-lemma requiv_the_get_tcb_eq':
-  "\<lbrakk>reads_equiv aag s t; aag_can_read aag thread\<rbrakk> \<Longrightarrow>
-    the (get_tcb thread s) = the (get_tcb thread t)"
-  apply(subgoal_tac "get_tcb thread s = get_tcb thread t")
-   apply(simp)
-  apply(fastforce intro: requiv_get_tcb_eq')
-  done
-
-(* FIXME: move *)
-lemma set_object_modifies_at_most:
-  "modifies_at_most aag {pasObjectAbs aag ptr} (\<lambda> s. \<not> asid_pool_at ptr s \<and> (\<forall> asid_pool. obj \<noteq> ArchObj (ASIDPool asid_pool))) (set_object ptr obj)"
-  apply(rule modifies_at_mostI)
-  apply(wp set_object_equiv_but_for_labels)
-  apply clarsimp
-  done
-
-
 lemma scheduler_action_states_equiv[simp]:
   "states_equiv_for P Q R S st (scheduler_action_update f s) = states_equiv_for P Q R S st s"
-  apply (simp add: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def)
-  done
+  by (simp add: states_equiv_for_def equiv_for_def equiv_asids_def)
 
 crunch states_equiv[wp]: set_thread_state_ext "states_equiv_for P Q R S st"
   (ignore_del: set_thread_state_ext)
 
+end
+
+
+lemma requiv_get_tcb_eq':
+  "\<lbrakk> reads_equiv aag s t; aag_can_read aag thread \<rbrakk>
+     \<Longrightarrow> get_tcb thread s = get_tcb thread t"
+  by (auto simp: reads_equiv_def2 get_tcb_def
+           elim: states_equiv_forE_kheap
+          dest!: aag_can_read_self)
+
 lemma set_scheduler_action_reads_respects[wp]:
   "reads_respects aag l \<top> (set_scheduler_action action)"
-  by (simp add: set_scheduler_action_def modify_def put_def get_def bind_def equiv_valid_def2 equiv_valid_2_def reads_equiv_scheduler_action_update affects_equiv_scheduler_action_update)
+  by (simp add: set_scheduler_action_def equiv_valid_def2 equiv_valid_2_def modify_def bind_def put_def
+                get_def reads_equiv_scheduler_action_update affects_equiv_scheduler_action_update)
 
 lemma set_thread_state_ext_reads_respects:
   "reads_respects aag l (\<lambda>s. is_subject aag (cur_thread s)) (set_thread_state_ext ref)"
@@ -108,7 +143,9 @@ lemma set_thread_state_ext_reads_respects:
   apply (simp add: set_thread_state_ext_def when_def)
   apply (simp add: equiv_valid_def2)
   apply (rule equiv_valid_rv_bind[where W="\<top>\<top>"])
-    apply (clarsimp simp: equiv_valid_2_def get_thread_state_def thread_get_def gets_the_def return_def bind_def assert_opt_def gets_def get_tcb_def fail_def get_def split: option.splits kernel_object.splits)
+    apply (clarsimp simp: equiv_valid_2_def get_thread_state_def thread_get_def gets_the_def
+                          return_def bind_def assert_opt_def gets_def get_tcb_def fail_def get_def
+                   split: option.splits)
    apply clarsimp
    apply (rule equiv_valid_2_bind[where R'="(=)" and Q="\<lambda>rv _. rv \<noteq> ref" and Q'="\<lambda>rv _. rv \<noteq> ref"])
       apply (rule gen_asm_ev2)
@@ -119,63 +156,11 @@ lemma set_thread_state_ext_reads_respects:
   apply force
   done
 
-lemma set_thread_state_reads_respects:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (\<lambda>s. is_subject aag (cur_thread s)) (set_thread_state ref ts)"
-  unfolding set_thread_state_def fun_app_def
-  apply (simp add: bind_assoc[symmetric])
-  apply (rule pre_ev)
-   apply (rule_tac P'=\<top> in bind_ev)
-     apply (rule set_thread_state_ext_reads_respects)
-    apply(case_tac "aag_can_read aag ref \<or> aag_can_affect aag l ref")
-     apply(wp set_object_reads_respects gets_the_ev)
-     apply(fastforce simp: get_tcb_def split: option.splits
-                     elim: reads_equivE affects_equivE equiv_forE)
-    apply(simp add: equiv_valid_def2)
-    apply(rule equiv_valid_rv_bind)
-      apply(rule equiv_valid_rv_trivial)
-      apply (wp | simp)+
-     apply(rule_tac P="\<top>" and P'="\<top>" and L="{pasObjectAbs aag ref}"
-                    and L'="{pasObjectAbs aag ref}"
-                    in ev2_invisible[OF domains_distinct])
-         apply (blast | simp add: labels_are_invisible_def)+
-       apply(rule set_object_modifies_at_most)
-      apply(rule set_object_modifies_at_most)
-     apply(simp | wp)+
-    apply(blast dest: get_tcb_not_asid_pool_at)
-   apply (subst thread_set_def[symmetric, simplified fun_app_def])
-   apply (wp | simp)+
-   done
-
-lemma set_bound_notification_reads_respects:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (\<lambda>s. is_subject aag (cur_thread s)) (set_bound_notification ref ntfn)"
-  unfolding set_bound_notification_def fun_app_def
-  apply (rule pre_ev(5)[where Q=\<top>])
-   apply(case_tac "aag_can_read aag ref \<or> aag_can_affect aag l ref")
-    apply(wp set_object_reads_respects gets_the_ev)[1]
-    apply (fastforce simp: get_tcb_def split: option.splits elim: reads_equivE affects_equivE equiv_forE)
-   apply (simp add: equiv_valid_def2)
-   apply(rule equiv_valid_rv_bind)
-     apply(rule equiv_valid_rv_trivial)
-     apply (wp | simp)+
-    apply(rule_tac P="\<top>" and P'="\<top>" and L="{pasObjectAbs aag ref}" and L'="{pasObjectAbs aag ref}" in ev2_invisible[OF domains_distinct])
-        apply (blast | simp add: labels_are_invisible_def)+
-      apply(rule set_object_modifies_at_most)
-     apply(rule set_object_modifies_at_most)
-    apply(simp | wp)+
-   apply(blast dest: get_tcb_not_asid_pool_at)
-  apply simp
-  done
-
 lemma set_thread_state_ext_owned_reads_respects:
   "reads_respects aag l (\<lambda>s. aag_can_read aag ref) (set_thread_state_ext ref)"
   apply (simp add: set_thread_state_ext_def when_def get_thread_state_def | wp thread_get_rev)+
   apply (simp add: reads_equiv_def)
   done
-
 
 lemma set_thread_state_owned_reads_respects:
   "reads_respects aag l (\<lambda>s. aag_can_read aag ref) (set_thread_state ref ts)"
@@ -183,114 +168,59 @@ lemma set_thread_state_owned_reads_respects:
   apply (wp set_object_reads_respects gets_the_ev set_thread_state_ext_owned_reads_respects)
   by (fastforce intro: kheap_get_tcb_eq elim: reads_equivE equiv_forD)
 
-
 lemma set_bound_notification_owned_reads_respects:
   "reads_respects aag l (\<lambda>s. is_subject aag ref) (set_bound_notification ref ntfn)"
-  apply (simp add:set_bound_notification_def)
+  apply (simp add: set_bound_notification_def)
   apply (wp set_object_reads_respects gets_the_ev)
   apply (force elim: reads_equivE equiv_forE)
   done
 
-lemma get_thread_state_runnable[wp]: "\<lbrace>st_tcb_at runnable ref\<rbrace> get_thread_state ref \<lbrace>\<lambda>rv _. runnable rv\<rbrace>"
-  apply (simp add: get_thread_state_def thread_get_def)
-  apply wp
-  apply (clarsimp simp: st_tcb_at_def obj_at_def get_tcb_def)
-  done
+lemma get_thread_state_runnable[wp]:
+   "\<lbrace>st_tcb_at runnable ref\<rbrace> get_thread_state ref \<lbrace>\<lambda>rv _. runnable rv\<rbrace>"
+  by (wpsimp wp: gts_st_tcb_at)
 
 lemma set_thread_state_ext_runnable_reads_respects:
   "reads_respects aag l (st_tcb_at runnable ref) (set_thread_state_ext ref)"
   apply (simp add: set_thread_state_ext_def when_def)
   apply (simp add: equiv_valid_def2)
   apply (rule equiv_valid_rv_bind[where W="\<top>\<top>" and Q="\<lambda>rv _. runnable rv"])
-    apply (clarsimp simp: equiv_valid_2_def get_thread_state_def thread_get_def gets_the_def return_def bind_def assert_opt_def gets_def get_tcb_def fail_def get_def split: option.splits kernel_object.splits)
+    apply (clarsimp simp: equiv_valid_2_def get_thread_state_def thread_get_def gets_the_def
+                          return_def bind_def assert_opt_def gets_def get_tcb_def fail_def get_def
+                   split: option.splits)
    apply (rule gen_asm_ev2)
    apply (clarsimp simp: equiv_valid_def2[symmetric] | wp)+
    apply (simp add: reads_equiv_def)
   apply wp
   done
 
-lemma set_thread_state_runnable_reads_respects:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "runnable ts \<Longrightarrow> reads_respects aag l \<top> (set_thread_state ref ts)"
-  unfolding set_thread_state_def fun_app_def
-  apply (simp add: bind_assoc[symmetric])
-  apply (rule pre_ev)
-   apply (rule_tac P'=\<top> in bind_ev)
-     apply (rule set_thread_state_ext_runnable_reads_respects)
-    apply(case_tac "aag_can_read aag ref \<or> aag_can_affect aag l ref")
-     apply(wp set_object_reads_respects gets_the_ev)
-     apply(fastforce simp: get_tcb_def split: option.splits elim: reads_equivE affects_equivE equiv_forE)
-    apply(simp add: equiv_valid_def2)
-    apply(rule equiv_valid_rv_bind)
-      apply(rule equiv_valid_rv_trivial)
-      apply (wp | simp)+
-     apply(rule_tac P="\<top>" and P'="\<top>" and L="{pasObjectAbs aag ref}" and L'="{pasObjectAbs aag ref}" in ev2_invisible[OF domains_distinct])
-         apply (blast | simp add: labels_are_invisible_def)+
-       apply(rule set_object_modifies_at_most)
-      apply(rule set_object_modifies_at_most)
-     apply(simp | wp)+
-    apply(blast dest: get_tcb_not_asid_pool_at)
-   apply (subst thread_set_def[symmetric, simplified fun_app_def])
-   apply (wp thread_set_st_tcb_at | simp)+
-   done
-
-lemma set_bound_notification_none_reads_respects:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l \<top> (set_bound_notification ref None)"
-  unfolding set_bound_notification_def fun_app_def
-  apply (rule pre_ev(5)[where Q=\<top>])
-   apply(case_tac "aag_can_read aag ref \<or> aag_can_affect aag l ref")
-    apply(wp set_object_reads_respects gets_the_ev)[1]
-    apply (fastforce simp: get_tcb_def split: option.splits elim: reads_equivE affects_equivE equiv_forE)
-   apply (simp add: equiv_valid_def2)
-   apply(rule equiv_valid_rv_bind)
-     apply(rule equiv_valid_rv_trivial)
-     apply (wp | simp)+
-    apply(rule_tac P="\<top>" and P'="\<top>" and L="{pasObjectAbs aag ref}" and L'="{pasObjectAbs aag ref}" in ev2_invisible[OF domains_distinct])
-        apply (blast | simp add: labels_are_invisible_def)+
-      apply(rule set_object_modifies_at_most)
-     apply(rule set_object_modifies_at_most)
-    apply(simp | wp)+
-   apply(blast dest: get_tcb_not_asid_pool_at)
-  apply simp
-  done
-
-lemma get_object_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag \<top>\<top> \<top> (get_object ptr)"
-  apply(rule equiv_valid_rv_trivial)
-  apply wp
-  done
-
 lemma set_simple_ko_reads_respects:
   "reads_respects aag l \<top> (set_simple_ko f ptr ep)"
   unfolding set_simple_ko_def
-  apply(simp add: equiv_valid_def2)
-  apply(rule equiv_valid_rv_bind)
-    apply(rule equiv_valid_rv_guard_imp)
-     apply(rule get_object_revrv)
-    apply(simp, simp)
-   apply(rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
-      apply(rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
-         apply(subst equiv_valid_def2[symmetric])
-         apply(rule set_object_reads_respects)
-        apply(rule assert_ev2)
-        apply(simp)
-       apply(rule assert_inv)+
-     apply(rule assert_ev2)
-     apply(simp)
-    apply(rule assert_inv)+
-  apply(simp)
-  apply(wp get_object_inv)
+  apply (simp add: equiv_valid_def2)
+  apply (rule equiv_valid_rv_bind)
+    apply (rule equiv_valid_rv_guard_imp)
+     apply (rule get_object_revrv)
+    apply (simp, simp)
+   apply (rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
+      apply (rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
+         apply (subst equiv_valid_def2[symmetric])
+         apply (rule set_object_reads_respects)
+        apply (rule assert_ev2)
+        apply (simp)
+       apply (rule assert_inv)+
+     apply (rule assert_ev2)
+     apply (simp)
+    apply (rule assert_inv)+
+  apply (simp)
+  apply (wp get_object_inv)
   done
 
 lemma get_ep_queue_reads_respects:
   "reads_respects aag l \<top> (get_ep_queue ep)"
   unfolding get_ep_queue_def
-  apply(rule equiv_valid_guard_imp)
-   apply(wp | wpc)+
-  apply(simp)
+  apply (rule equiv_valid_guard_imp)
+   apply (wp | wpc)+
+  apply (simp)
   done
 
 lemma get_object_reads_respects:
@@ -305,157 +235,141 @@ lemma get_simple_ko_reads_respects:
   "reads_respects aag l (K (aag_can_read aag ptr \<or> aag_can_affect aag l ptr))
     (get_simple_ko f ptr)"
   unfolding get_simple_ko_def
-  apply(wp get_object_reads_respects | wpc | simp)+
-  done
+  by (wp get_object_reads_respects | wpc | simp)+
 
 lemma get_epq_SendEP_ret:
   "\<lbrace>\<lambda>s. \<forall>x\<in>set list. P x\<rbrace> get_ep_queue (SendEP list) \<lbrace>\<lambda>rv s. \<forall>x\<in>set rv. P x\<rbrace>"
-  apply(simp add: get_ep_queue_def)
-  apply(wp)
-  done
+  by (wpsimp simp: get_ep_queue_def)
 
 lemma get_epq_RecvEP_ret:
   "\<lbrace>\<lambda>s. \<forall>x\<in>set list. P x\<rbrace> get_ep_queue (RecvEP list) \<lbrace>\<lambda>rv s. \<forall>x\<in>set rv. P x\<rbrace>"
-  apply(simp add: get_ep_queue_def)
-  apply(wp)
-  done
+  by (wpsimp simp: get_ep_queue_def)
+
 
 fun ep_queue_invisible where
-  "ep_queue_invisible aag l (SendEP list) = labels_are_invisible aag l ((pasObjectAbs aag) ` (set list))" |
-  "ep_queue_invisible aag l (RecvEP list) = labels_are_invisible aag l ((pasObjectAbs aag) ` (set list))" |
-  "ep_queue_invisible aag l IdleEP = True"
+  "ep_queue_invisible aag l (SendEP list) = labels_are_invisible aag l ((pasObjectAbs aag) ` (set list))"
+| "ep_queue_invisible aag l (RecvEP list) = labels_are_invisible aag l ((pasObjectAbs aag) ` (set list))"
+| "ep_queue_invisible aag l IdleEP = True"
+
 
 lemma obj_eq_st_tcb_at:
-  "\<lbrakk>kheap s x = kheap s' x; st_tcb_at P x s'\<rbrakk> \<Longrightarrow>
-  st_tcb_at P x s"
-  apply(clarsimp simp: st_tcb_at_def obj_at_def)
-  done
-
+  "\<lbrakk> kheap s x = kheap s' x; st_tcb_at P x s' \<rbrakk>
+    \<Longrightarrow> st_tcb_at P x s"
+  by (clarsimp simp: st_tcb_at_def obj_at_def)
 
 lemma send_blocked_on_tcb_st_to_auth:
-  "send_blocked_on epptr ts
-   \<Longrightarrow> (epptr, SyncSend) \<in> tcb_st_to_auth ts"
-  apply(case_tac ts, simp_all)
-  done
+  "send_blocked_on epptr ts \<Longrightarrow> (epptr, SyncSend) \<in> tcb_st_to_auth ts"
+  by (case_tac ts, simp_all)
 
 lemma receive_blocked_on_tcb_st_to_auth:
-  "receive_blocked_on epptr ts
-   \<Longrightarrow> (epptr, Receive) \<in> tcb_st_to_auth ts"
-  apply(case_tac ts, simp_all)
-  done
-
+  "receive_blocked_on epptr ts \<Longrightarrow> (epptr, Receive) \<in> tcb_st_to_auth ts"
+  by (case_tac ts, simp_all)
 
 lemma not_ep_queue_invisible:
-  "\<lbrakk>\<not> ep_queue_invisible aag l eplist; eplist = SendEP list \<or> eplist = RecvEP list\<rbrakk>  \<Longrightarrow>
-  (\<exists> t \<in> set list. aag_can_read aag t \<or> aag_can_affect aag l t)"
-  apply(auto simp: labels_are_invisible_def)
-  done
+  "\<lbrakk> \<not> ep_queue_invisible aag l eplist; eplist = SendEP list \<or> eplist = RecvEP list \<rbrakk>
+     \<Longrightarrow> \<exists>t \<in> set list. aag_can_read aag t \<or> aag_can_affect aag l t"
+  by (auto simp: labels_are_invisible_def)
 
 lemma ep_queued_st_tcb_at'':
-  "\<And>P. \<lbrakk>ko_at (Endpoint ep) ptr s; (t, rt) \<in> ep_q_refs_of ep;
-         valid_objs s; sym_refs (state_refs_of s);
-         \<And>pl pl'. (rt = EPSend \<and> P (Structures_A.BlockedOnSend ptr pl)) \<or>
-                  (rt = EPRecv \<and> P (Structures_A.BlockedOnReceive ptr pl')) \<rbrakk>
-    \<Longrightarrow> st_tcb_at P t s"
+  "\<And>P. \<lbrakk> ko_at (Endpoint ep) ptr s; (t, rt) \<in> ep_q_refs_of ep;
+          valid_objs s; sym_refs (state_refs_of s);
+          \<And>pl pl'. (rt = EPSend \<and> P (BlockedOnSend ptr pl)) \<or>
+                    (rt = EPRecv \<and> P (BlockedOnReceive ptr pl')) \<rbrakk>
+          \<Longrightarrow> st_tcb_at P t s"
   apply (case_tac ep, simp_all)
   apply (frule (1) sym_refs_ko_atD, fastforce simp: st_tcb_at_def obj_at_def refs_of_rev)+
   done
 
 lemma ep_queues_are_invisible_or_eps_are_equal':
-  "\<lbrakk>(pasSubject aag, Reset, pasObjectAbs aag epptr) \<in> pasPolicy aag;
-    ko_at (Endpoint ep) epptr s;
-    ko_at (Endpoint ep') epptr s';
-    reads_equiv aag s s'; affects_equiv aag l s s';
-    valid_objs s; sym_refs (state_refs_of s); valid_objs s';
-    sym_refs (state_refs_of s'); pas_refined aag s; pas_refined aag s'\<rbrakk> \<Longrightarrow>
-  (\<not> ep_queue_invisible aag l ep) \<longrightarrow> ep = ep'"
-  apply(rule impI)
-  apply(case_tac "\<exists> list. ep = SendEP list \<or> ep = RecvEP list")
-   apply(erule exE)
-   apply(drule (1) not_ep_queue_invisible)
+  "\<lbrakk> (pasSubject aag, Reset, pasObjectAbs aag epptr) \<in> pasPolicy aag;
+     ko_at (Endpoint ep) epptr s; ko_at (Endpoint ep') epptr s';
+     reads_equiv aag s s'; affects_equiv aag l s s';
+     valid_objs s; sym_refs (state_refs_of s); valid_objs s';
+     sym_refs (state_refs_of s'); pas_refined aag s; pas_refined aag s' \<rbrakk>
+     \<Longrightarrow> (\<not> ep_queue_invisible aag l ep) \<longrightarrow> ep = ep'"
+  apply (rule impI)
+  apply (case_tac "\<exists>list. ep = SendEP list \<or> ep = RecvEP list")
+   apply (erule exE)
+   apply (drule (1) not_ep_queue_invisible)
    apply clarsimp
-   apply(erule disjE)
-    apply(erule disjE)
-     apply(drule_tac auth="SyncSend" and t="pasObjectAbs aag t" in reads_read_queued_thread_read_ep)
+   apply (erule disjE)
+    apply (erule disjE)
+     apply (drule_tac auth="SyncSend" and t="pasObjectAbs aag t" in reads_read_queued_thread_read_ep)
          apply blast
-        apply(erule pas_refined_mem[rotated])
-        apply(rule sta_ts)
-        apply(drule_tac P="send_blocked_on epptr" and s=s and t=t in ep_queued_st_tcb_at'')
-            apply(simp)+
-        apply(simp add: thread_st_auth_def split: option.splits)
-        apply(clarsimp simp: tcb_states_of_state_def st_tcb_def2 send_blocked_on_tcb_st_to_auth)
+        apply (erule pas_refined_mem[rotated])
+        apply (rule sta_ts)
+        apply (drule_tac P="send_blocked_on epptr" and s=s and t=t in ep_queued_st_tcb_at'')
+            apply (simp)+
+        apply (simp add: thread_st_auth_def split: option.splits)
+        apply (clarsimp simp: tcb_states_of_state_def st_tcb_def2 send_blocked_on_tcb_st_to_auth)
        apply blast
       apply assumption
-     apply(fastforce dest: reads_affects_equiv_kheap_eq simp: obj_at_def)
-    apply(drule_tac auth="SyncSend" and t="pasObjectAbs aag t" in reads_read_queued_thread_read_ep)
+     apply (fastforce dest: reads_affects_equiv_kheap_eq simp: obj_at_def)
+    apply (drule_tac auth="SyncSend" and t="pasObjectAbs aag t" in reads_read_queued_thread_read_ep)
         apply blast
-       apply(erule pas_refined_mem[rotated])
-       apply(rule sta_ts)
-       apply(drule_tac P="send_blocked_on epptr" and s=s and t=t in ep_queued_st_tcb_at'')
-           apply(simp)+
-       apply(simp add: thread_st_auth_def split: option.splits)
-       apply(clarsimp simp: tcb_states_of_state_def st_tcb_def2 send_blocked_on_tcb_st_to_auth)
+       apply (erule pas_refined_mem[rotated])
+       apply (rule sta_ts)
+       apply (drule_tac P="send_blocked_on epptr" and s=s and t=t in ep_queued_st_tcb_at'')
+           apply (simp)+
+       apply (simp add: thread_st_auth_def split: option.splits)
+       apply (clarsimp simp: tcb_states_of_state_def st_tcb_def2 send_blocked_on_tcb_st_to_auth)
       apply blast
-     apply(erule conjE, assumption)
-    apply(drule_tac x=epptr in reads_affects_equiv_kheap_eq, simp+)
-    apply(fastforce simp: obj_at_def)
-   apply(erule disjE)
-    apply(drule_tac auth="Receive" and t="pasObjectAbs aag t" in reads_read_queued_thread_read_ep)
+     apply (erule conjE, assumption)
+    apply (drule_tac x=epptr in reads_affects_equiv_kheap_eq, simp+)
+    apply (fastforce simp: obj_at_def)
+   apply (erule disjE)
+    apply (drule_tac auth="Receive" and t="pasObjectAbs aag t" in reads_read_queued_thread_read_ep)
         apply blast
-       apply(erule pas_refined_mem[rotated])
-       apply(rule sta_ts)
-       apply(drule_tac P="receive_blocked_on epptr" and s=s and t=t in ep_queued_st_tcb_at'')
-           apply(simp)+
-       apply(simp add: thread_st_auth_def split: option.splits)
-       apply(clarsimp simp: tcb_states_of_state_def st_tcb_def2 receive_blocked_on_tcb_st_to_auth)
+       apply (erule pas_refined_mem[rotated])
+       apply (rule sta_ts)
+       apply (drule_tac P="receive_blocked_on epptr" and s=s and t=t in ep_queued_st_tcb_at'')
+           apply (simp)+
+       apply (simp add: thread_st_auth_def split: option.splits)
+       apply (clarsimp simp: tcb_states_of_state_def st_tcb_def2 receive_blocked_on_tcb_st_to_auth)
       apply blast
      apply assumption
-    apply(fastforce dest: reads_affects_equiv_kheap_eq simp: obj_at_def)
-   apply(drule_tac auth="Receive" and t="pasObjectAbs aag t" in reads_read_queued_thread_read_ep)
+    apply (fastforce dest: reads_affects_equiv_kheap_eq simp: obj_at_def)
+   apply (drule_tac auth="Receive" and t="pasObjectAbs aag t" in reads_read_queued_thread_read_ep)
        apply blast
-      apply(erule pas_refined_mem[rotated])
-      apply(rule sta_ts)
-      apply(drule_tac P="receive_blocked_on epptr" and s=s and t=t in ep_queued_st_tcb_at'')
-          apply(simp)+
-      apply(simp add: thread_st_auth_def split: option.splits)
-      apply(clarsimp simp: tcb_states_of_state_def st_tcb_def2 receive_blocked_on_tcb_st_to_auth)
+      apply (erule pas_refined_mem[rotated])
+      apply (rule sta_ts)
+      apply (drule_tac P="receive_blocked_on epptr" and s=s and t=t in ep_queued_st_tcb_at'')
+          apply (simp)+
+      apply (simp add: thread_st_auth_def split: option.splits)
+      apply (clarsimp simp: tcb_states_of_state_def st_tcb_def2 receive_blocked_on_tcb_st_to_auth)
      apply blast
-    apply(erule conjE, assumption)
-   apply(drule_tac x=epptr in reads_affects_equiv_kheap_eq, simp+)
-   apply(fastforce simp: obj_at_def)
-  apply(case_tac ep, auto)
+    apply (erule conjE, assumption)
+   apply (drule_tac x=epptr in reads_affects_equiv_kheap_eq, simp+)
+   apply (fastforce simp: obj_at_def)
+  apply (case_tac ep, auto)
   done
-
 
 lemma ep_queues_are_invisible_or_eps_are_equal:
-  "\<lbrakk>(pasSubject aag, Reset, pasObjectAbs aag epptr) \<in> pasPolicy aag;
-    ko_at (Endpoint ep) epptr s;
-    ko_at (Endpoint ep') epptr s';
-    reads_equiv aag s s'; affects_equiv aag l s s';
-    valid_objs s; sym_refs (state_refs_of s); valid_objs s';
-    sym_refs (state_refs_of s'); pas_refined aag s; pas_refined aag s'\<rbrakk> \<Longrightarrow>
-  (\<not> ep_queue_invisible aag l ep \<or> \<not> ep_queue_invisible aag l ep') \<longrightarrow> ep = ep'"
-  apply(rule impI)
-  apply(erule disjE)
-   apply(blast intro!: ep_queues_are_invisible_or_eps_are_equal'[rule_format])
-  apply(rule sym)
-  apply(erule ep_queues_are_invisible_or_eps_are_equal'[rule_format])
-            apply (assumption | erule reads_equiv_sym | erule affects_equiv_sym)+
-  done
+  "\<lbrakk> (pasSubject aag, Reset, pasObjectAbs aag epptr) \<in> pasPolicy aag;
+     ko_at (Endpoint ep) epptr s; ko_at (Endpoint ep') epptr s';
+     reads_equiv aag s s'; affects_equiv aag l s s';
+     valid_objs s; sym_refs (state_refs_of s); valid_objs s';
+     sym_refs (state_refs_of s'); pas_refined aag s; pas_refined aag s' \<rbrakk>
+     \<Longrightarrow> (\<not> ep_queue_invisible aag l ep \<or> \<not> ep_queue_invisible aag l ep') \<longrightarrow> ep = ep'"
+  apply (rule impI)
+  apply (erule disjE)
+   apply (blast intro!: ep_queues_are_invisible_or_eps_are_equal'[rule_format])
+  apply (rule sym)
+  apply (erule ep_queues_are_invisible_or_eps_are_equal'[rule_format])
+  by (assumption | erule reads_equiv_sym | erule affects_equiv_sym)+
 
 lemma get_simple_ko_revrv:
-  "inj C \<Longrightarrow> reads_equiv_valid_rv_inv R aag
-        (\<lambda>obj obj'. \<exists>s t. reads_equiv aag s t
-            \<and> R s t \<and> P s \<and> P t \<and> ko_at (C obj) ptr s
-            \<and> ko_at (C obj') ptr t)
-        P
-        (get_simple_ko C ptr)"
+  "inj C \<Longrightarrow> reads_equiv_valid_rv_inv R aag (\<lambda>obj obj'. \<exists>s t. reads_equiv aag s t
+                                                            \<and> R s t \<and> P s \<and> P t
+                                                            \<and> ko_at (C obj) ptr s
+                                                            \<and> ko_at (C obj') ptr t)
+                                      P (get_simple_ko C ptr)"
   apply (simp add: get_simple_ko_def)
-  apply(rule_tac Q="\<lambda> rv. ko_at rv ptr and P" in equiv_valid_rv_bind)
-    apply(rule equiv_valid_rv_guard_imp[OF equiv_valid_rv_trivial])
+  apply (rule_tac Q="\<lambda> rv. ko_at rv ptr and P" in equiv_valid_rv_bind)
+    apply (rule equiv_valid_rv_guard_imp[OF equiv_valid_rv_trivial])
      apply wpsimp+
    apply (clarsimp simp add: assert_def fail_ev2_l fail_ev2_r
-        simp del: imp_disjL split: option.split)
+                   simp del: imp_disjL split: option.split)
    apply (rule return_ev2)
    apply (auto simp: proj_inj)[1]
   apply (rule hoare_strengthen_post[OF get_object_sp])
@@ -464,23 +378,21 @@ lemma get_simple_ko_revrv:
 
 lemma get_endpoint_revrv:
   "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
-        (\<lambda>ep ep'. (\<not> ep_queue_invisible aag l ep \<or> \<not> ep_queue_invisible aag l ep') \<longrightarrow> ep = ep')
-        (pas_refined aag and valid_objs and sym_refs \<circ> state_refs_of and
-         K ((pasSubject aag, Reset, pasObjectAbs aag epptr) \<in> pasPolicy aag))
-        (get_endpoint epptr)"
+     (\<lambda>ep ep'. (\<not> ep_queue_invisible aag l ep \<or> \<not> ep_queue_invisible aag l ep') \<longrightarrow> ep = ep')
+     (pas_refined aag and valid_objs and sym_refs \<circ> state_refs_of
+                      and K ((pasSubject aag, Reset, pasObjectAbs aag epptr) \<in> pasPolicy aag))
+     (get_endpoint epptr)"
   apply (rule equiv_valid_2_rvrel_imp, rule get_simple_ko_revrv)
    apply (simp add: inj_Endpoint)
   apply (auto elim: ep_queues_are_invisible_or_eps_are_equal[rule_format])
   done
 
 lemma gen_asm_ev2_r:
-  "\<lbrakk>P' \<Longrightarrow> equiv_valid_2 I A B R P \<top> f f'\<rbrakk> \<Longrightarrow>
-   equiv_valid_2 I A B R P (\<lambda>s. P') f f'"
+  "(P' \<Longrightarrow> equiv_valid_2 I A B R P \<top> f f') \<Longrightarrow> equiv_valid_2 I A B R P (\<lambda>s. P') f f'"
   by (rule gen_asm_ev2_r')
 
 lemma gen_asm_ev2_l:
-  "\<lbrakk>P \<Longrightarrow> equiv_valid_2 I A B R \<top> P' f f'\<rbrakk> \<Longrightarrow>
-   equiv_valid_2 I A B R (\<lambda>s. P) P' f f'"
+  "(P \<Longrightarrow> equiv_valid_2 I A B R \<top> P' f f') \<Longrightarrow> equiv_valid_2 I A B R (\<lambda>s. P) P' f f'"
   by (rule gen_asm_ev2_l')
 
 lemma bind_return_unit2:
@@ -488,173 +400,132 @@ lemma bind_return_unit2:
   by simp
 
 lemma mapM_x_ev2_invisible:
-  assumes
-    domains_distinct: "pas_domains_distinct aag"
-  assumes
-    mam: "\<And> ptr. modifies_at_most aag (L ptr) \<top> ((f::word32 \<Rightarrow> (unit,det_ext) s_monad) ptr)"
-  assumes
-    mam': "\<And> ptr. modifies_at_most aag (L' ptr) \<top> ((f'::word32 \<Rightarrow> (unit,det_ext) s_monad) ptr)"
+  assumes domains_distinct:
+    "pas_domains_distinct aag"
+  assumes mam:
+    "\<And>ptr. modifies_at_most aag (L ptr) \<top> ((f :: obj_ref \<Rightarrow> (unit, det_ext) s_monad) ptr)"
+  assumes mam':
+    "\<And>ptr. modifies_at_most aag (L' ptr) \<top> ((f' :: obj_ref \<Rightarrow> (unit, det_ext) s_monad) ptr)"
   shows
-  "equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l)
-   (=)
-   (K (\<forall>x. x \<in> set list' \<longrightarrow> (labels_are_invisible aag l (L' x))))
-   (K (\<forall>x. x \<in> set list \<longrightarrow>  (labels_are_invisible aag l (L x))))
-   (mapM_x f' list') (mapM_x f list)"
-  apply(induct list)
-   apply(induct_tac list')
+    "equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) (=)
+                   (K (\<forall>x. x \<in> set list' \<longrightarrow> (labels_are_invisible aag l (L' x))))
+                   (K (\<forall>x. x \<in> set list \<longrightarrow> (labels_are_invisible aag l (L x))))
+                   (mapM_x f' list') (mapM_x f list)"
+  apply (induct list)
+   apply (induct_tac list')
     apply (simp add: mapM_x_Nil)
     apply (blast intro: return_ev2)
    apply (simp add: mapM_x_Cons mapM_x_Nil)
    apply (subst bind_return_unit[where f="return ()"])
-   apply (rule_tac R'="(=)" and P="\<lambda> s. labels_are_invisible aag l (L' a)" in equiv_valid_2_bind_pre)
+   apply (rule_tac R'="(=)" and P="\<lambda>s. labels_are_invisible aag l (L' a)" in equiv_valid_2_bind_pre)
         apply simp
-       apply(rule gen_asm_ev2_l)
-       apply(rule equiv_valid_2_guard_imp[OF ev2_invisible[OF domains_distinct]], assumption+)
-           apply(rule mam')
-          apply(rule_tac P="\<top>" in modifies_at_mostI)
-          apply(wp | simp)+
+       apply (rule gen_asm_ev2_l)
+       apply (rule equiv_valid_2_guard_imp[OF ev2_invisible[OF domains_distinct]], assumption+)
+           apply (rule mam')
+          apply (rule_tac P="\<top>" in modifies_at_mostI)
+          apply (wp | simp)+
+  apply (simp add: mapM_x_Cons)
+  apply (subst bind_return_unit2)
+  apply (rule_tac R'="(=)" and P'="\<lambda>s. labels_are_invisible aag l (L a)" in equiv_valid_2_bind_pre)
+       apply simp
+      apply (rule gen_asm_ev2_r)
+      apply (rule equiv_valid_2_guard_imp[OF ev2_invisible[OF domains_distinct]], assumption+)
+          apply (rule_tac P="\<top>" in modifies_at_mostI)
+          apply (wp | simp)+
+         apply (rule mam)
+        apply (wp | simp)+
+  done
+
+lemma ev2_inv:
+  assumes inv: "\<And>P. f \<lbrace>P\<rbrace>"
+  assumes inv': "\<And>P. g \<lbrace>P\<rbrace>"
+  shows "equiv_valid_2 I A A \<top>\<top> \<top> \<top> f g"
+  apply (clarsimp simp: equiv_valid_2_def)
+  apply (drule state_unchanged[OF inv])
+  apply (drule state_unchanged[OF inv'])
+  by simp
+
+lemma mapM_x_ev2_r_invisible:
+  assumes domains_distinct:
+    "pas_domains_distinct aag"
+  assumes mam:
+    "\<And>ptr. modifies_at_most aag (L ptr) \<top> ((f :: obj_ref \<Rightarrow> (unit, det_ext) s_monad) ptr)"
+  assumes inv:
+    "\<And>P. g \<lbrace>P\<rbrace>"
+  shows
+    "equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) (=) \<top>
+                   (K (\<forall>x. x \<in> set list \<longrightarrow>  labels_are_invisible aag l (L x))) g (mapM_x f list)"
+  apply (induct list)
+   apply (simp add: mapM_x_Nil)
+   apply (rule ev2_inv[OF inv])
+   apply wp
   apply (simp add: mapM_x_Cons)
   apply (subst bind_return_unit2)
   apply (rule_tac R'="(=)" and P'="\<lambda> s. labels_are_invisible aag l (L a)" in equiv_valid_2_bind_pre)
        apply simp
-       apply(rule gen_asm_ev2_r)
-       apply(rule equiv_valid_2_guard_imp[OF ev2_invisible[OF domains_distinct]], assumption+)
-          apply(rule_tac P="\<top>" in modifies_at_mostI)
-          apply(wp | simp)+
-         apply(rule mam)
-        apply(wp | simp)+
-  done
-
-lemma ev2_inv:
-  assumes
-    inv: "\<And> P. invariant f P"
-  assumes
-    inv': "\<And> P. invariant g P"
-  shows
-  "equiv_valid_2 I A A \<top>\<top> \<top> \<top> f g"
-  apply(clarsimp simp: equiv_valid_2_def)
-  apply(drule state_unchanged[OF inv])
-  apply(drule state_unchanged[OF inv'])
-  by simp
-
-lemma mapM_x_ev2_r_invisible:
-  assumes
-    domains_distinct: "pas_domains_distinct aag"
-  assumes
-    mam: "\<And> ptr. modifies_at_most aag (L ptr) \<top> ((f::word32 \<Rightarrow> (unit,det_ext) s_monad) ptr)"
-  assumes
-    inv: "\<And> P. invariant g P"
-  shows
-  "equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l)
-   (=) \<top>
-   (K (\<forall>x. x \<in> set list \<longrightarrow>  labels_are_invisible aag l (L x)))
-   g (mapM_x f list)"
-  apply(induct list)
-   apply(simp add: mapM_x_Nil)
-   apply(rule ev2_inv[OF inv])
-   apply wp
-   apply (simp add: mapM_x_Cons)
-  apply (subst bind_return_unit2)
-  apply (rule_tac R'="(=)" and P'="\<lambda> s. labels_are_invisible aag l (L a)" in equiv_valid_2_bind_pre)
-       apply simp
-      apply(rule gen_asm_ev2_r)
-      apply(rule equiv_valid_2_guard_imp[OF ev2_invisible[OF domains_distinct]], assumption+)
-          apply(rule_tac P="\<top>" in modifies_at_mostI)
-          apply(wp | simp)+
-         apply(rule mam)
-        apply(wp | simp)+
+      apply (rule gen_asm_ev2_r)
+      apply (rule equiv_valid_2_guard_imp[OF ev2_invisible[OF domains_distinct]], assumption+)
+          apply (rule_tac P="\<top>" in modifies_at_mostI)
+          apply (wp | simp)+
+         apply (rule mam)
+        apply (wp | simp)+
   done
 
 (* MOVE *)
 lemma ev2_sym:
-  assumes
-   symI: "\<And> x y. I x y \<Longrightarrow> I y x"
-  assumes
-   symA: "\<And> x y. A x y \<Longrightarrow> A y x"
-  assumes
-   symB: "\<And> x y. B x y \<Longrightarrow> B y x"
-  assumes
-   symR: "\<And> x y. R x y \<Longrightarrow> R y x"
-  shows
-  "equiv_valid_2 I A B R P' P f' f \<Longrightarrow>
-   equiv_valid_2 I A B R P P' f f'"
-  apply(clarsimp simp: equiv_valid_2_def)
-  apply(blast intro: symA symB symI symR)
+  assumes symI: "\<And>x y. I x y \<Longrightarrow> I y x"
+  assumes symA: "\<And>x y. A x y \<Longrightarrow> A y x"
+  assumes symB: "\<And>x y. B x y \<Longrightarrow> B y x"
+  assumes symR: "\<And>x y. R x y \<Longrightarrow> R y x"
+  shows "equiv_valid_2 I A B R P' P f' f \<Longrightarrow>
+         equiv_valid_2 I A B R P P' f f'"
+  apply (clarsimp simp: equiv_valid_2_def)
+  apply (blast intro: symA symB symI symR)
   done
 
 lemma mapM_x_ev2_l_invisible:
-  assumes
-    domains_distinct: "pas_domains_distinct aag"
-  assumes
-    mam: "\<And> ptr. modifies_at_most aag (L ptr) \<top> ((f::word32 \<Rightarrow> (unit,det_ext) s_monad) ptr)"
-  assumes
-    inv: "\<And> P. invariant g P"
+  assumes domains_distinct:
+    "pas_domains_distinct aag"
+  assumes mam:
+    "\<And>ptr. modifies_at_most aag (L ptr) \<top> ((f :: obj_ref \<Rightarrow> (unit, det_ext) s_monad) ptr)"
+  assumes inv:
+    "\<And>P. g \<lbrace>P\<rbrace>"
   shows
-  "equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l)
-   (=)
-   (K (\<forall>x. x \<in> set list \<longrightarrow> labels_are_invisible aag l (L x)))
-   \<top>
-   (mapM_x f list) g"
-  apply(rule ev2_sym[OF reads_equiv_sym affects_equiv_sym affects_equiv_sym])
-      apply(simp_all)[4]
-  apply(rule mapM_x_ev2_r_invisible[OF domains_distinct mam inv])
+    "equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) (=)
+                   (K (\<forall>x. x \<in> set list \<longrightarrow> labels_are_invisible aag l (L x))) \<top> (mapM_x f list) g"
+  apply (rule ev2_sym[OF reads_equiv_sym affects_equiv_sym affects_equiv_sym])
+      apply (simp_all)[4]
+  apply (rule mapM_x_ev2_r_invisible[OF domains_distinct mam inv])
   done
-
-
-lemma set_endpoint_equiv_but_for_labels:
-  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag epptr \<in> L)\<rbrace>
-   set_endpoint epptr ep
-   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
-  unfolding set_simple_ko_def
-  apply (wp set_object_equiv_but_for_labels get_object_wp)
-  apply (clarsimp simp: asid_pool_at_kheap partial_inv_def split: kernel_object.splits simp: obj_at_def)
-  done
-
 
 lemma not_label_is_invisible:
   "(\<not> labels_are_invisible aag l {(pasObjectAbs aag x)}) =
-    (aag_can_read aag x \<or> aag_can_affect aag l x)"
-  apply(simp add: labels_are_invisible_def)
-  done
+   (aag_can_read aag x \<or> aag_can_affect aag l x)"
+  by (simp add: labels_are_invisible_def)
 
 lemma label_is_invisible:
   "(labels_are_invisible aag l {(pasObjectAbs aag x)}) =
    (\<not> (aag_can_read aag x \<or> aag_can_affect aag l x))"
-  apply(simp add: labels_are_invisible_def)
-  done
+  by (simp add: labels_are_invisible_def)
 
 lemma op_eq_unit_taut: "(=) = (\<lambda> (_:: unit) _. True)"
-  apply (rule ext | simp)+
-  done
+  by (rule ext | simp)+
 
-lemma ev2_symmetric: "equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) (=) P P f f' \<Longrightarrow> equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) (=) P P f' f"
+lemma ev2_symmetric:
+  "equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) (=) P P f f'
+   \<Longrightarrow> equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) (=) P P f' f"
   apply (clarsimp simp add: equiv_valid_2_def)
   apply (drule_tac x=t in spec)
   apply (drule_tac x=s in spec)
   apply (fastforce elim: affects_equiv_sym reads_equiv_sym)
   done
 
-lemma reads_respects_ethread_get: "reads_respects aag l (\<lambda>_. is_subject aag thread) (ethread_get f thread)"
+lemma reads_respects_ethread_get:
+  "reads_respects aag l (\<lambda>_. is_subject aag thread) (ethread_get f thread)"
   apply (simp add: ethread_get_def)
   apply wp
   apply (drule aag_can_read_self)
-  apply (fastforce simp add: reads_equiv_def2 get_etcb_def
-                             equiv_for_def states_equiv_for_def)
-  done
-
-lemma set_tcb_queue_reads_respects[wp]:
-  "reads_respects aag l (\<lambda>_. True) (set_tcb_queue d prio queue)"
-  unfolding equiv_valid_def2 equiv_valid_2_def
-  apply (clarsimp simp: set_tcb_queue_def bind_def modify_def put_def get_def)
-   (* FIXME: cleanup *)
-  apply (rule conjI)
-   apply (rule reads_equiv_ready_queues_update, assumption)
-   apply (fastforce simp: reads_equiv_def affects_equiv_def states_equiv_for_def equiv_for_def)
-  apply (rule affects_equiv_ready_queues_update, assumption)
-  apply (clarsimp simp: reads_equiv_def affects_equiv_def states_equiv_for_def equiv_for_def
-                        equiv_asids_def equiv_asid_def)
-  apply (rule ext)
-  apply force
+  apply (fastforce simp: reads_equiv_def2 get_etcb_def equiv_for_def states_equiv_for_def)
   done
 
 lemma aag_can_read_self'[simp]:
@@ -667,38 +538,51 @@ lemma gets_apply_ready_queues_reads_respects:
   apply (force elim: reads_equivE simp: equiv_for_def)
   done
 
+(* FIXME: move *)
+lemma equiv_valid_rv_trivial':
+  assumes inv: "\<And>P. f \<lbrace>P\<rbrace>"
+  shows "equiv_valid_rv_inv I A \<top>\<top> Q f"
+  by (auto simp: equiv_valid_2_def dest: state_unchanged[OF inv])
+
+lemma gets_cur_domain_ev:
+  "reads_equiv_valid_inv A aag \<top> (gets cur_domain)"
+  apply (rule equiv_valid_guard_imp)
+   apply wp
+  apply (simp add: reads_equiv_def)
+  done
+
+crunch sched_act[wp]: set_simple_ko "\<lambda>s. P (scheduler_action s)"
+  (wp: crunch_wps)
+
+
+
+context Finalise_IF_1 begin
+
 lemma set_tcb_queue_modifies_at_most:
   "modifies_at_most aag L (\<lambda>s. pasDomainAbs aag d \<inter> L \<noteq> {}) (set_tcb_queue d prio queue)"
   apply (rule modifies_at_mostI)
   apply (simp add: set_tcb_queue_def modify_def, wp)
-  apply (force simp: equiv_but_for_labels_def states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def)
+  apply (force simp: equiv_but_for_labels_def states_equiv_for_def equiv_for_def equiv_asids_def)
   done
-
-(* FIXME: move *)
-lemma equiv_valid_rv_trivial':
-  assumes inv: "\<And> P. \<lbrace> P \<rbrace> f \<lbrace> \<lambda>_. P \<rbrace>"
-  shows "equiv_valid_rv_inv I A \<top>\<top> Q f"
-  by(auto simp: equiv_valid_2_def dest: state_unchanged[OF inv])
 
 lemma tcb_sched_action_reads_respects:
   assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (pas_refined aag) (tcb_sched_action action thread)"
+  shows "reads_respects aag l (pas_refined aag) (tcb_sched_action action t)"
   apply (simp add: tcb_sched_action_def get_tcb_queue_def)
   apply (subst gets_apply)
-  apply (case_tac "aag_can_read aag thread \<or> aag_can_affect aag l thread")
+  apply (case_tac "aag_can_read aag t \<or> aag_can_affect aag l t")
    apply (simp add: ethread_get_def)
    apply wp
-         apply (rule_tac Q="\<lambda>s. pasObjectAbs aag thread \<in> pasDomainAbs aag (tcb_domain rv)" in equiv_valid_guard_imp)
+         apply (rule_tac Q="\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (tcb_domain rv)"
+                      in equiv_valid_guard_imp)
           apply (wp gets_apply_ev')
           apply (fastforce simp: reads_equiv_def affects_equiv_def equiv_for_def states_equiv_for_def)
          apply (wp | simp)+
    apply (intro conjI impI allI
-         | fastforce simp: get_etcb_def elim: reads_equivE affects_equivE equiv_forE)+
+          | fastforce simp: get_etcb_def elim: reads_equivE affects_equivE equiv_forE)+
    apply (clarsimp simp: pas_refined_def tcb_domain_map_wellformed_aux_def split: option.splits)
-   apply (erule_tac x="(thread, tcb_domain y)" in ballE, force)
+   apply (erule_tac x="(t, tcb_domain y)" in ballE, force)
    apply (force intro: domtcbs simp: get_etcb_def)
-
   apply (simp add: equiv_valid_def2 ethread_get_def)
   apply (rule equiv_valid_rv_bind)
     apply (wp equiv_valid_rv_trivial', simp)
@@ -706,54 +590,42 @@ lemma tcb_sched_action_reads_respects:
       prefer 2
       apply (wp equiv_valid_rv_trivial, simp)
      apply (rule equiv_valid_2_bind)
-        apply (rule_tac P="\<top>" and P'="\<top>" and L="{pasObjectAbs aag thread}" and L'="{pasObjectAbs aag thread}" in ev2_invisible[OF domains_distinct])
+        apply (rule_tac P=\<top> and P'=\<top> and L="{pasObjectAbs aag t}" and L'="{pasObjectAbs aag t}"
+                     in ev2_invisible[OF domains_distinct])
             apply (blast | simp add: labels_are_invisible_def)+
           apply (rule set_tcb_queue_modifies_at_most)
          apply (rule set_tcb_queue_modifies_at_most)
         apply (simp | wp)+
-       apply (clarsimp simp: equiv_valid_2_def gets_apply_def get_def bind_def return_def labels_are_invisible_def)
+       apply (clarsimp simp: equiv_valid_2_def gets_apply_def get_def
+                             bind_def return_def labels_are_invisible_def)
       apply wp+
-  apply clarsimp
-  apply (clarsimp simp: pas_refined_def tcb_domain_map_wellformed_aux_def)
-  apply (erule_tac x="(thread, tcb_domain y)" in ballE)
-   apply force
-  apply (force intro: domtcbs simp: get_etcb_def)
+  apply (force intro: domtcbs simp: get_etcb_def pas_refined_def tcb_domain_map_wellformed_aux_def)
   done
 
 lemma reschedule_required_reads_respects[wp]:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (pas_refined aag) reschedule_required"
+  shows "reads_respects aag l (pas_refined aag) reschedule_required"
   apply (simp add: reschedule_required_def | wp tcb_sched_action_reads_respects | wpc)+
-  apply (simp add: reads_equiv_def)
-  done
-
-lemma gets_cur_domain_ev:
-  "reads_equiv_valid_inv A aag \<top> (gets cur_domain)"
-  apply (rule equiv_valid_guard_imp)
-  apply wp
   apply (simp add: reads_equiv_def)
   done
 
 lemma possible_switch_to_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l
-    (pas_refined aag and pas_cur_domain aag and (\<lambda>s. is_subject aag (cur_thread s)))
-    (possible_switch_to tptr)"
+  shows "reads_respects aag l (pas_refined aag and pas_cur_domain aag
+                                               and (\<lambda>s. is_subject aag (cur_thread s)))
+                              (possible_switch_to tptr)"
   apply (simp add: possible_switch_to_def ethread_get_def)
   apply (case_tac "aag_can_read aag tptr \<or> aag_can_affect aag l tptr")
-   subgoal
-     apply (wp static_imp_wp tcb_sched_action_reads_respects | wpc | simp)+
-     apply (clarsimp simp: get_etcb_def)
-     apply (intro conjI impI allI
-           | elim aag_can_read_self reads_equivE affects_equivE equiv_forE conjE disjE
-           | force)+
-   done
+   apply (wp static_imp_wp tcb_sched_action_reads_respects | wpc | simp)+
+   apply (clarsimp simp: get_etcb_def)
+   apply ((intro conjI impI allI
+          | elim aag_can_read_self reads_equivE affects_equivE equiv_forE conjE disjE
+          | force)+)[1]
   apply clarsimp
   apply (wp (once), rename_tac cur_dom)
-   apply (simp add: equiv_valid_def2)
-     apply (rule_tac W="\<top>\<top>" and Q="\<lambda>tcb. pas_refined aag and K (tcb_domain tcb \<noteq> cur_dom)" in equiv_valid_rv_bind)
+     apply (simp add: equiv_valid_def2)
+     apply (rule_tac W="\<top>\<top>" and Q="\<lambda>tcb. pas_refined aag and K (tcb_domain tcb \<noteq> cur_dom)"
+                  in equiv_valid_rv_bind)
        prefer 3
        apply wp
       apply (monad_eq simp: get_etcb_def equiv_valid_2_def)
@@ -768,14 +640,10 @@ lemma possible_switch_to_reads_respects:
   apply (fastforce dest: domains_distinct[THEN pas_domains_distinct_inj])
   done
 
-crunch sched_act[wp]: set_simple_ko "\<lambda>s. P (scheduler_action s)"
-  (wp: crunch_wps)
-
 lemma cancel_all_ipc_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs
-                                         and valid_arch_state and K (aag_can_read aag epptr))
+  shows "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs
+                                               and valid_arch_state and K (aag_can_read aag epptr))
                         (cancel_all_ipc epptr)"
   unfolding cancel_all_ipc_def fun_app_def
   by (wp mapM_x_ev'' tcb_sched_action_reads_respects set_thread_state_runnable_reads_respects
@@ -792,72 +660,125 @@ lemma cancel_all_ipc_reads_respects:
                                                                 and valid_vspace_objs
                                                                 and valid_arch_state", OF mapM_x_wp])+
 
+end
+
+
 fun ntfn_queue_invisible where
-  "ntfn_queue_invisible aag l (WaitingNtfn list) =
-     labels_are_invisible aag l ((pasObjectAbs aag) ` (set list))" |
-  "ntfn_queue_invisible aag l _ = True"
+  "ntfn_queue_invisible aag l (WaitingNtfn list) = labels_are_invisible aag l ((pasObjectAbs aag) ` (set list))"
+| "ntfn_queue_invisible aag l _ = True"
 
 
 lemma not_ntfn_queue_invisible:
-  "\<lbrakk>\<not> ntfn_queue_invisible aag l eplist; eplist = WaitingNtfn list\<rbrakk>  \<Longrightarrow>
-  (\<exists> t \<in> set list. aag_can_read aag t \<or> aag_can_affect aag l t)"
-  apply(auto simp: labels_are_invisible_def)
-  done
+  "\<lbrakk> \<not> ntfn_queue_invisible aag l eplist; eplist = WaitingNtfn list \<rbrakk>
+     \<Longrightarrow> (\<exists>t \<in> set list. aag_can_read aag t \<or> aag_can_affect aag l t)"
+  by (auto simp: labels_are_invisible_def)
 
 lemma ntfn_queues_are_invisible_or_ntfns_are_equal':
-  "\<lbrakk>(pasSubject aag, Reset, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag;
-    ko_at (Notification ntfn) ntfnptr s;
-    ko_at (Notification ntfn') ntfnptr s';
-    reads_equiv aag s s'; affects_equiv aag l s s';
-    valid_objs s; sym_refs (state_refs_of s); valid_objs s';
-    sym_refs (state_refs_of s'); pas_refined aag s; pas_refined aag s'\<rbrakk> \<Longrightarrow>
-  \<not> ntfn_queue_invisible aag l (ntfn_obj ntfn) \<longrightarrow> ntfn_obj ntfn = ntfn_obj ntfn'"
-  apply(rule impI)
-  apply(case_tac "\<exists> list. ntfn_obj ntfn = WaitingNtfn list")
-   apply(erule exE)
-   apply(drule (1) not_ntfn_queue_invisible)
+  "\<lbrakk> (pasSubject aag, Reset, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag;
+     ko_at (Notification ntfn) ntfnptr s; ko_at (Notification ntfn') ntfnptr s';
+     reads_equiv aag s s'; affects_equiv aag l s s';
+     valid_objs s; sym_refs (state_refs_of s); valid_objs s';
+     sym_refs (state_refs_of s'); pas_refined aag s; pas_refined aag s' \<rbrakk>
+     \<Longrightarrow> \<not> ntfn_queue_invisible aag l (ntfn_obj ntfn) \<longrightarrow> ntfn_obj ntfn = ntfn_obj ntfn'"
+  apply (rule impI)
+  apply (case_tac "\<exists>list. ntfn_obj ntfn = WaitingNtfn list")
+   apply (erule exE)
+   apply (drule (1) not_ntfn_queue_invisible)
    apply clarsimp
-   apply(erule disjE)
-    apply(drule_tac auth="Receive" and t="pasObjectAbs aag t" in reads_read_queued_thread_read_ep)
+   apply (erule disjE)
+    apply (drule_tac auth="Receive" and t="pasObjectAbs aag t" in reads_read_queued_thread_read_ep)
         apply blast
-       apply(erule pas_refined_mem[rotated])
-       apply(rule sta_ts)
-       apply(drule_tac P="receive_blocked_on ntfnptr" and s=s and t=t in ntfn_queued_st_tcb_at')
-           apply(simp)+
-       apply(simp add: thread_st_auth_def split: option.splits)
-       apply(clarsimp simp: tcb_states_of_state_def st_tcb_def2 receive_blocked_on_tcb_st_to_auth)
+       apply (erule pas_refined_mem[rotated])
+       apply (rule sta_ts)
+       apply (drule_tac P="receive_blocked_on ntfnptr" and s=s and t=t in ntfn_queued_st_tcb_at')
+           apply (simp)+
+       apply (simp add: thread_st_auth_def split: option.splits)
+       apply (clarsimp simp: tcb_states_of_state_def st_tcb_def2 receive_blocked_on_tcb_st_to_auth)
       apply blast
      apply assumption
-    apply(fastforce dest: reads_affects_equiv_kheap_eq simp: obj_at_def)
-   apply(drule_tac auth="Receive" and t="pasObjectAbs aag t" in reads_read_queued_thread_read_ep)
+    apply (fastforce dest: reads_affects_equiv_kheap_eq simp: obj_at_def)
+   apply (drule_tac auth="Receive" and t="pasObjectAbs aag t" in reads_read_queued_thread_read_ep)
        apply blast
-      apply(erule pas_refined_mem[rotated])
-      apply(rule sta_ts)
-      apply(drule_tac P="receive_blocked_on ntfnptr" and s=s and t=t in ntfn_queued_st_tcb_at')
-          apply(simp)+
-      apply(simp add: thread_st_auth_def split: option.splits)
-      apply(clarsimp simp: tcb_states_of_state_def st_tcb_def2 receive_blocked_on_tcb_st_to_auth)
+      apply (erule pas_refined_mem[rotated])
+      apply (rule sta_ts)
+      apply (drule_tac P="receive_blocked_on ntfnptr" and s=s and t=t in ntfn_queued_st_tcb_at')
+          apply (simp)+
+      apply (simp add: thread_st_auth_def split: option.splits)
+      apply (clarsimp simp: tcb_states_of_state_def st_tcb_def2 receive_blocked_on_tcb_st_to_auth)
      apply blast
-    apply(erule conjE, assumption)
-   apply(drule_tac x=ntfnptr in reads_affects_equiv_kheap_eq, simp+)
-   apply(fastforce simp: obj_at_def)
-  apply(case_tac "ntfn_obj ntfn", auto)
+    apply (erule conjE, assumption)
+   apply (drule_tac x=ntfnptr in reads_affects_equiv_kheap_eq, simp+)
+   apply (fastforce simp: obj_at_def)
+  apply (case_tac "ntfn_obj ntfn", auto)
   done
 
-lemma set_notification_equiv_but_for_labels:
-  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag ntfnptr \<in> L)\<rbrace>
-   set_notification ntfnptr ntfn
-   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
-  unfolding set_simple_ko_def
-  apply (wp set_object_equiv_but_for_labels get_object_wp)
-  apply (clarsimp simp: asid_pool_at_kheap partial_inv_def obj_at_def split: kernel_object.splits)
+lemma get_bound_notification_reads_respects':
+  "reads_respects aag l (K(is_subject aag thread)) (get_bound_notification thread)"
+  unfolding get_bound_notification_def thread_get_def
+  apply (wp | simp)+
+  apply clarify
+  apply (rule requiv_get_tcb_eq)
+   apply simp+
   done
+
+lemma thread_get_reads_respects:
+  "reads_respects aag l (K (aag_can_read aag thread \<or> aag_can_affect aag l thread))
+                  (thread_get f thread)"
+  unfolding thread_get_def fun_app_def
+  apply (wp gets_the_ev)
+  apply (auto intro: reads_affects_equiv_get_tcb_eq)
+  done
+
+lemma get_bound_notification_reads_respects:
+  "reads_respects aag l (\<lambda> s. aag_can_read aag thread \<or> aag_can_affect aag l thread)
+                  (get_bound_notification thread)"
+  unfolding get_bound_notification_def
+  apply (rule equiv_valid_guard_imp)
+   apply (wp thread_get_reads_respects | simp)+
+  done
+
+lemma bound_tcb_at_implies_read:
+  "\<lbrakk> pas_refined aag s; is_subject aag t; bound_tcb_at ((=) (Some x)) t s \<rbrakk>
+     \<Longrightarrow> aag_can_read_label aag (pasObjectAbs aag x)"
+  apply (frule bound_tcb_at_implies_receive, simp)
+  apply clarsimp
+  apply (frule_tac l="pasSubject aag" and auth=Receive in reads_ep, simp)
+  apply (auto simp: aag_can_read_read)
+  done
+
+lemma bound_tcb_at_eq:
+  "\<lbrakk> sym_refs (state_refs_of s); valid_objs s; kheap s ntfnptr = Some (Notification ntfn);
+     ntfn_bound_tcb ntfn = Some tcbptr; bound_tcb_at ((=) (Some ntfnptr')) tcbptr s \<rbrakk>
+     \<Longrightarrow> ntfnptr = ntfnptr'"
+  apply (drule_tac x=ntfnptr in sym_refsD[rotated])
+   apply (fastforce simp: state_refs_of_def)
+  apply (auto simp: pred_tcb_at_def obj_at_def valid_obj_def valid_ntfn_def
+                    is_tcb state_refs_of_def refs_of_rev
+          simp del: refs_of_simps)
+  done
+
+lemma unbind_notification_is_subj_reads_respects:
+  "reads_respects aag l (pas_refined aag and invs and K (is_subject aag t))
+                  (unbind_notification t)"
+  apply (clarsimp simp: unbind_notification_def)
+  apply (wp set_bound_notification_owned_reads_respects set_simple_ko_reads_respects
+            get_simple_ko_reads_respects get_bound_notification_reads_respects
+            gbn_wp[unfolded get_bound_notification_def, simplified]
+         | wpc
+         | simp add: get_bound_notification_def)+
+  apply (clarsimp)
+  apply (rule bound_tcb_at_implies_read, auto)
+  done
+
+
+context Finalise_IF_1 begin
 
 lemma cancel_all_signals_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
-                                         and K (aag_can_read aag ntfnptr)) (cancel_all_signals ntfnptr)"
+    "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs
+                                           and valid_arch_state and K (aag_can_read aag ntfnptr))
+                   (cancel_all_signals ntfnptr)"
   unfolding cancel_all_signals_def
   by (wp mapM_x_ev'' tcb_sched_action_reads_respects set_thread_state_runnable_reads_respects
          set_thread_state_pas_refined hoare_vcg_ball_lift
@@ -873,118 +794,47 @@ lemma cancel_all_signals_reads_respects:
                                                                 and valid_vspace_objs
                                                                 and valid_arch_state", OF mapM_x_wp])+
 
-lemma get_bound_notification_reads_respects':
-  "reads_respects aag l (K(is_subject aag thread)) (get_bound_notification thread)"
-  unfolding get_bound_notification_def thread_get_def
-  apply (wp | simp)+
-  apply clarify
-  apply (rule requiv_get_tcb_eq)
-  apply simp+
-  done
-
-lemma reads_affects_equiv_get_tcb_eq:
-  "\<lbrakk>aag_can_read aag thread \<or> aag_can_affect aag l thread;
-    reads_equiv aag s t; affects_equiv aag l s t\<rbrakk> \<Longrightarrow>
-   get_tcb thread s = get_tcb thread t"
-  apply (fastforce simp: get_tcb_def split: kernel_object.splits option.splits
-                   simp: reads_affects_equiv_kheap_eq)
-  done
-
-lemma thread_get_reads_respects:
-  "reads_respects aag l (K (aag_can_read aag thread \<or> aag_can_affect aag l thread))
-                  (thread_get f thread)"
-  unfolding thread_get_def fun_app_def
-  apply (wp gets_the_ev)
-  apply (auto intro: reads_affects_equiv_get_tcb_eq)
-  done
-
-lemma get_bound_notification_reads_respects:
-  "reads_respects aag l (\<lambda> s. aag_can_read aag thread \<or> aag_can_affect aag l thread)
-                  (get_bound_notification thread)"
-  unfolding get_bound_notification_def
-  apply(rule equiv_valid_guard_imp)
-   apply(wp thread_get_reads_respects | simp)+
-  done
-
-
-lemma bound_tcb_at_implies_read:
-  "\<lbrakk>pas_refined aag s; is_subject aag t; bound_tcb_at ((=) (Some x)) t s\<rbrakk>
-     \<Longrightarrow> aag_can_read_label aag (pasObjectAbs aag x)"
-  apply (frule bound_tcb_at_implies_receive, simp)
-  apply clarsimp
-apply (frule_tac l="pasSubject aag" and auth=Receive in reads_ep, simp)
-apply (auto simp: aag_can_read_read)
-  done
-
-lemma bound_tcb_at_eq:
-  "\<lbrakk>sym_refs (state_refs_of s); valid_objs s; kheap s ntfnptr = Some (Notification ntfn);
-    ntfn_bound_tcb ntfn = Some tcbptr; bound_tcb_at ((=) (Some ntfnptr')) tcbptr s\<rbrakk>
-    \<Longrightarrow> ntfnptr = ntfnptr'"
-    apply (drule_tac x=ntfnptr in sym_refsD[rotated])
-   apply (fastforce simp: state_refs_of_def)
-  apply (auto simp: pred_tcb_at_def obj_at_def valid_obj_def valid_ntfn_def is_tcb
-                    state_refs_of_def refs_of_rev
-          simp del: refs_of_simps)
-  done
-
 lemma unbind_maybe_notification_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects aag l
-     (pas_refined aag and invs and K (aag_can_read aag ntfnptr))
-     (unbind_maybe_notification ntfnptr)"
+  "reads_respects aag l (pas_refined aag and invs and K (aag_can_read aag ntfnptr))
+                  (unbind_maybe_notification ntfnptr)"
   unfolding unbind_maybe_notification_def
-  by (wp set_bound_notification_none_reads_respects set_simple_ko_reads_respects
-         get_simple_ko_reads_respects
-     | wpc
-     | simp)+
-
-lemma unbind_notification_is_subj_reads_respects:
-  "reads_respects aag l (pas_refined aag and invs and K (is_subject aag t))
-       (unbind_notification t)"
-  apply (clarsimp simp: unbind_notification_def)
-  apply (wp set_bound_notification_owned_reads_respects set_simple_ko_reads_respects
-            get_simple_ko_reads_respects get_bound_notification_reads_respects
-            gbn_wp[unfolded get_bound_notification_def, simplified]
-       | wpc
-       | simp add: get_bound_notification_def)+
-  apply (clarsimp)
-  apply (rule bound_tcb_at_implies_read, auto)
-  done
+  by (wp set_bound_notification_none_reads_respects
+         set_simple_ko_reads_respects get_simple_ko_reads_respects
+      | wpc | simp)+
 
 (* aag_can_read is transitive on endpoints but intransitive on notifications *)
 lemma fast_finalise_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects aag l (pas_refined aag and invs and
-    K (fin \<longrightarrow> (case cap of EndpointCap r badge rights \<Rightarrow> aag_can_read aag r |
-                            NotificationCap r badge rights \<Rightarrow> is_subject aag r |
-                            _ \<Rightarrow> True)))
-  (fast_finalise cap fin)"
-  apply(case_tac cap, simp_all)
-  apply(wp equiv_valid_guard_imp[OF cancel_all_ipc_reads_respects]
-           equiv_valid_guard_imp[OF cancel_all_signals_reads_respects]
-           unbind_notification_is_subj_reads_respects
-           unbind_maybe_notification_reads_respects
-           get_simple_ko_reads_respects get_simple_ko_wp
+    "reads_respects aag l (pas_refined aag and invs and
+                           K (fin \<longrightarrow> (case cap of EndpointCap r badge rights \<Rightarrow> aag_can_read aag r
+                                             | NotificationCap r badge rights \<Rightarrow> is_subject aag r
+                                             | _ \<Rightarrow> True)))
+                    (fast_finalise cap fin)"
+  apply (case_tac cap, simp_all)
+  by (wp equiv_valid_guard_imp[OF cancel_all_ipc_reads_respects]
+         equiv_valid_guard_imp[OF cancel_all_signals_reads_respects]
+         unbind_notification_is_subj_reads_respects
+         unbind_maybe_notification_reads_respects
+         get_simple_ko_reads_respects get_simple_ko_wp
       | simp add: when_def
       | wpc
       | intro conjI impI
       | fastforce simp: aag_cap_auth_def cap_auth_conferred_def cap_rights_to_auth_def)+
-  done
 
 lemma cap_delete_one_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_f aag l (silc_inv aag st and invs and pas_refined aag
-                              and K (is_subject aag (fst slot)))
-                    (cap_delete_one slot)"
+  shows "reads_respects_f aag l (silc_inv aag st and invs and pas_refined aag
+                                                 and K (is_subject aag (fst slot)))
+                          (cap_delete_one slot)"
   unfolding cap_delete_one_def fun_app_def
-  apply(unfold unless_def when_def)
-  apply(rule equiv_valid_guard_imp)
-   apply(wp is_final_cap_reads_respects
-            reads_respects_f[OF empty_slot_reads_respects, where st=st and aag=aag]
-            reads_respects_f[OF fast_finalise_reads_respects, where st=st and aag=aag]
+  apply (unfold unless_def when_def)
+  apply (rule equiv_valid_guard_imp)
+   apply (wp is_final_cap_reads_respects
+            reads_respects_f[OF empty_slot_reads_respects, where st=st]
+            reads_respects_f[OF fast_finalise_reads_respects, where st=st]
             empty_slot_silc_inv
         | simp | elim conjE)+
       apply (rule_tac Q="\<lambda>rva s. rva = is_final_cap' rv s \<and>
@@ -1002,25 +852,23 @@ lemma cap_delete_one_reads_respects_f:
        apply (drule(1) intra_label_capD)
        apply (clarsimp simp: cap_points_to_label_def split: cap.splits)
       apply force
-     apply(wp reads_respects_f[OF get_cap_rev, where st=st and aag=aag]
-              get_cap_auth_wp[where aag=aag]
-        | simp | elim conjE)+
+     apply (wp reads_respects_f[OF get_cap_rev] get_cap_auth_wp | simp | elim conjE)+
   by (fastforce simp: cte_wp_at_caps_of_state silc_inv_def)
 
 lemma cap_delete_one_reads_respects_f_transferable:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects_f aag l (silc_inv aag st and invs and pas_refined aag
-                            and K(aag_can_read_not_silc aag (fst slot)) and is_transferable_in slot)
-                    (cap_delete_one slot)"
+  "reads_respects_f aag l
+     (silc_inv aag st and invs and pas_refined aag
+                      and K (aag_can_read_not_silc aag (fst slot)) and is_transferable_in slot)
+     (cap_delete_one slot)"
   unfolding cap_delete_one_def fun_app_def
-  apply(unfold unless_def when_def)
-  apply(rule equiv_valid_guard_imp)
-   apply(wp is_final_cap_reads_respects
-            reads_respects_f[OF empty_slot_reads_respects, where st=st and aag=aag]
-            reads_respects_f[OF fast_finalise_reads_respects, where st=st and aag=aag]
-            empty_slot_silc_inv
-        | simp | elim conjE)+
+  apply (unfold unless_def when_def)
+  apply (rule equiv_valid_guard_imp)
+   apply (wp is_final_cap_reads_respects empty_slot_silc_inv
+             reads_respects_f[OF empty_slot_reads_respects, where st=st]
+             reads_respects_f[OF fast_finalise_reads_respects, where st=st]
+          | simp | elim conjE)+
       apply (rule_tac Q="\<lambda>rva s. rva = is_final_cap' rv s \<and>
                                  cte_wp_at ((=) rv) slot s \<and>
                                  silc_inv aag st s \<and>
@@ -1036,60 +884,53 @@ lemma cap_delete_one_reads_respects_f_transferable:
        apply (drule(1) intra_label_capD)
        apply (clarsimp simp: cap_points_to_label_def' cte_wp_at_caps_of_state split: cap.splits)
       apply (force elim: is_transferable_capE)
-     apply(wp reads_respects_f[OF get_cap_rev, where st=st and aag=aag]
-              get_cap_wp
-        | simp | elim conjE)+
+     apply (wp reads_respects_f[OF get_cap_rev] get_cap_wp | simp | elim conjE)+
   by (fastforce simp: cte_wp_at_caps_of_state silc_inv_def)
+
+end
 
 
 lemma get_blocking_object_reads_respects:
-  "reads_respects aag l \<top>  (get_blocking_object state)"
+  "reads_respects aag l \<top> (get_blocking_object state)"
   unfolding get_blocking_object_def
-  apply(rule equiv_valid_guard_imp)
-   apply(wp | wpc | simp)+
-   done
+  apply (rule equiv_valid_guard_imp)
+   apply (wp | wpc | simp)+
+  done
 
-fun tcb_st_to_auth'
-where
+
+fun tcb_st_to_auth' where
   "tcb_st_to_auth' (BlockedOnSend x pl) = SyncSend"
 | "tcb_st_to_auth' (BlockedOnReceive x pl) = Receive"
 | "tcb_st_to_auth' (BlockedOnNotification x) = Receive"
 
 
-
-
 lemma owns_thread_blocked_reads_endpoint:
-  "\<lbrakk>pas_refined aag s; invs s;
-    st_tcb_at (\<lambda> y. y = state) tptr s;
-    is_subject aag tptr;
-    state = (BlockedOnReceive x pl) \<or> state = (BlockedOnSend x xb) \<or> state = BlockedOnNotification x\<rbrakk>
-   \<Longrightarrow> aag_can_read aag x"
-  apply(rule_tac auth="tcb_st_to_auth' state" in reads_ep)
-   apply(drule sym, simp, rule pas_refined_mem)
-    apply(rule_tac s=s in sta_ts)
-    apply(clarsimp simp: thread_st_auth_def split: option.splits
-                   simp: tcb_states_of_state_def st_tcb_at_def get_tcb_def obj_at_def)
+  "\<lbrakk> pas_refined aag s; invs s; st_tcb_at (\<lambda> y. y = state) tptr s; is_subject aag tptr;
+     state = BlockedOnReceive x pl \<or> state = BlockedOnSend x xb \<or> state = BlockedOnNotification x \<rbrakk>
+     \<Longrightarrow> aag_can_read aag x"
+  apply (rule_tac auth="tcb_st_to_auth' state" in reads_ep)
+   apply (drule sym, simp, rule pas_refined_mem)
+    apply (rule_tac s=s in sta_ts)
+    apply (clarsimp simp: thread_st_auth_def tcb_states_of_state_def
+                          st_tcb_at_def get_tcb_def obj_at_def)
     apply fastforce
    apply assumption
   apply fastforce
   done
 
-
 lemma st_tcb_at_sym:
   "st_tcb_at ((=) x) t s = st_tcb_at (\<lambda> y. y = x) t s"
-  apply(auto simp: st_tcb_at_def obj_at_def)
-  done
+  by (auto simp: st_tcb_at_def obj_at_def)
 
 lemma blocked_cancel_ipc_reads_respects:
   "reads_respects aag l (pas_refined aag and invs and st_tcb_at ((=) state) tptr
-                                         and (\<lambda>_. (is_subject aag tptr)))
-    (blocked_cancel_ipc state tptr)"
+                                                  and K (is_subject aag tptr))
+                  (blocked_cancel_ipc state tptr)"
   unfolding blocked_cancel_ipc_def
-  apply(wp set_thread_state_owned_reads_respects set_simple_ko_reads_respects
-           get_ep_queue_reads_respects
-           get_simple_ko_reads_respects get_blocking_object_reads_respects
-      | simp add: get_blocking_object_def | wpc)+
-  apply(fastforce intro: aag_can_read_self owns_thread_blocked_reads_endpoint simp: st_tcb_at_sym)
+  apply (wp set_thread_state_owned_reads_respects set_simple_ko_reads_respects
+            get_ep_queue_reads_respects get_simple_ko_reads_respects get_blocking_object_reads_respects
+         | simp add: get_blocking_object_def | wpc)+
+  apply (fastforce intro: aag_can_read_self owns_thread_blocked_reads_endpoint simp: st_tcb_at_sym)
   done
 
 lemma select_singleton_ev:
@@ -1098,30 +939,12 @@ lemma select_singleton_ev:
 
 lemma thread_set_fault_pas_refined':
   "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
-     thread_set (tcb_fault_update fault) thread
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+   thread_set (tcb_fault_update fault) thread
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   by (wp thread_set_pas_refined | simp)+
 
 (* FIXME MERGE names *)
 lemmas thread_set_fault_empty_invs = thread_set_tcb_fault_reset_invs
-
-lemma thread_set_reads_respects:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l \<top> (thread_set x y)"
-  unfolding thread_set_def fun_app_def
-  apply(case_tac "aag_can_read aag y \<or> aag_can_affect aag l y")
-   apply(wp set_object_reads_respects)
-   apply(clarsimp, rule reads_affects_equiv_get_tcb_eq, simp+)[1]
-  apply(simp add: equiv_valid_def2)
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule_tac L="{pasObjectAbs aag y}" and L'="{pasObjectAbs aag y}" in ev2_invisible[OF domains_distinct])
-       apply (assumption | simp add: labels_are_invisible_def)+
-     apply(rule modifies_at_mostI[where P="\<top>"]
-          | wp set_object_equiv_but_for_labels
-          | simp
-          | (clarify, drule get_tcb_not_asid_pool_at))+
-  done
 
 lemma get_thread_state_rev:
   "reads_equiv_valid_inv A aag (K (aag_can_read aag ref)) (get_thread_state ref)"
@@ -1131,17 +954,16 @@ lemma get_thread_state_rev:
 lemma get_irq_slot_reads_respects:
   "reads_respects aag l (K (is_subject_irq aag irq)) (get_irq_slot irq)"
   unfolding get_irq_slot_def
-  apply(rule equiv_valid_guard_imp)
-  apply(rule gets_ev)
-  apply(simp add: reads_equiv_def states_equiv_for_def equiv_for_def
-       affects_equiv_def)
-   apply(drule aag_can_read_irq_self)
-   apply(simp)
-   done
+  apply (rule equiv_valid_guard_imp)
+   apply (rule gets_ev)
+  apply (simp add: reads_equiv_def states_equiv_for_def equiv_for_def affects_equiv_def)
+  apply (drule aag_can_read_irq_self)
+  apply (simp)
+  done
 
 lemma thread_set_tcb_at:
-  "\<lbrace>\<lambda>s. Q s\<rbrace> thread_set x ptr \<lbrace>\<lambda>_ s. P s\<rbrace> \<Longrightarrow>
-   \<lbrace>\<lambda>s. tcb_at ptr s \<longrightarrow> Q s\<rbrace> thread_set x ptr \<lbrace>\<lambda>_ s. P s\<rbrace>"
+  "\<lbrace>\<lambda>s. Q s\<rbrace> thread_set x ptr \<lbrace>\<lambda>_ s. P s\<rbrace>
+   \<Longrightarrow> \<lbrace>\<lambda>s. tcb_at ptr s \<longrightarrow> Q s\<rbrace> thread_set x ptr \<lbrace>\<lambda>_ s. P s\<rbrace>"
   apply (rule use_spec(1))
   apply (case_tac "tcb_at ptr s")
    apply (clarsimp simp add: spec_valid_def valid_def)
@@ -1154,28 +976,51 @@ lemma thread_set_tcb_at:
 (* FIXME: Why was the [wp] attribute on this lemma clobbered by interpretation of the Arch locale? *)
 lemmas [wp] = thread_set_fault_valid_global_refs
 
+lemma cancel_signal_owned_reads_respects:
+  "reads_respects aag l
+     (K (is_subject aag threadptr \<and> (aag_can_read aag ntfnptr \<or> aag_can_affect aag l ntfnptr)))
+     (cancel_signal threadptr ntfnptr)"
+  unfolding cancel_signal_def
+  by (wp set_thread_state_owned_reads_respects set_simple_ko_reads_respects
+         get_simple_ko_reads_respects hoare_drop_imps
+      | wpc | simp)+
+
+lemma as_user_get_register_reads_respects:
+  "reads_respects aag l (K (is_subject aag thread)) (as_user thread (getRegister reg))"
+  by (fastforce simp: equiv_valid_guard_imp[OF as_user_reads_respects] det_getRegister)
+
+lemma update_restart_pc_reads_respects[wp]:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects aag l (silc_inv aag s and K (is_subject aag thread))
+                        (update_restart_pc thread)"
+  unfolding update_restart_pc_def
+  apply (subst as_user_bind)
+  apply (wpsimp wp: as_user_set_register_reads_respects' as_user_get_register_reads_respects)
+  done
+
+
+context Finalise_IF_1 begin
 
 lemma reply_cancel_ipc_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  notes gets_ev[wp del]
-  shows
-  "reads_respects_f aag l (silc_inv aag st and pas_refined aag and invs and tcb_at tptr
-                             and K (is_subject aag tptr))
-      (reply_cancel_ipc tptr)"
-  apply (rule gen_asm_ev)
+  notes gets_ev[wp del] thread_set_valid_ko_at_arch[wp del]
+  shows "reads_respects_f aag l (silc_inv aag st and pas_refined aag and invs
+                                                 and tcb_at tptr and K (is_subject aag tptr))
+                          (reply_cancel_ipc tptr)"
   unfolding reply_cancel_ipc_def
-  apply (wp cap_delete_one_reads_respects_f_transferable[where st=st and aag=aag]
+  apply (rule gen_asm_ev)
+  apply (wp cap_delete_one_reads_respects_f_transferable[where st=st]
             select_singleton_ev select_inv select_wp assert_wp
-            reads_respects_f[OF get_cap_rev, where st=st and aag=aag]
-            reads_respects_f[OF thread_set_reads_respects, where st=st and aag=aag ]
+            reads_respects_f[OF get_cap_rev, where st=st]
+            reads_respects_f[OF thread_set_reads_respects, where st=st]
             reads_respects_f[OF gets_descendants_of_revrv[folded equiv_valid_def2]]
-        | simp add: when_def split del: if_split | elim conjE)+
-   apply(rule_tac Q="\<lambda> rv s. silc_inv aag st s \<and> invs s \<and> pas_refined aag s \<and> tcb_at tptr s
-                           \<and> is_subject aag tptr"
-               in hoare_strengthen_post)
-    apply(wp thread_set_tcb_fault_update_silc_inv hoare_vcg_imp_lift hoare_vcg_ball_lift
-             thread_set_fault_empty_invs thread_set_fault_pas_refined'
-         | wps | simp)+
+         | simp add: when_def split del: if_split | elim conjE)+
+   apply (rule_tac Q="\<lambda> rv s. silc_inv aag st s \<and> invs s \<and> pas_refined aag s
+                                                \<and> tcb_at tptr s \<and> is_subject aag tptr"
+                in hoare_strengthen_post)
+    apply (wp thread_set_tcb_fault_update_silc_inv hoare_vcg_imp_lift hoare_vcg_ball_lift
+              thread_set_fault_empty_invs thread_set_fault_pas_refined'
+           | wps | simp)+
    apply clarsimp apply (rule conjI,rule TrueI)
    apply clarsimp
    apply (frule(1) reply_cap_descends_from_master0)
@@ -1184,348 +1029,260 @@ lemma reply_cancel_ipc_reads_respects_f:
                     elim: silc_inv_no_transferable'[where slot = "(a,b)" for a b,simplified])
   by fastforce
 
-lemma cancel_signal_reads_respects:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l ((\<lambda>s. is_subject aag (cur_thread s))
-                           and K (aag_can_read aag ntfnptr \<or> aag_can_affect aag l ntfnptr))
-      (cancel_signal threadptr ntfnptr)"
-  unfolding cancel_signal_def
-  by (wp set_thread_state_reads_respects set_simple_ko_reads_respects
-         get_simple_ko_reads_respects hoare_drop_imps
-     | wpc | simp)+
-
-lemma cancel_signal_owned_reads_respects:
-  "reads_respects aag l (K (is_subject aag threadptr)
-                         and K (aag_can_read aag ntfnptr \<or> aag_can_affect aag l ntfnptr))
-     (cancel_signal threadptr ntfnptr)"
-  unfolding cancel_signal_def
-  by (wp set_thread_state_owned_reads_respects set_simple_ko_reads_respects
-         get_simple_ko_reads_respects hoare_drop_imps
-     | wpc | simp)+
-
 lemma cancel_ipc_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_f aag l (silc_inv aag st and pas_refined aag and invs and tcb_at t and
-   (K (is_subject aag t)))
-    (cancel_ipc t)"
+  shows "reads_respects_f aag l (silc_inv aag st and pas_refined aag and invs and tcb_at t and
+                          (K (is_subject aag t))) (cancel_ipc t)"
   unfolding cancel_ipc_def
-  apply(wp reads_respects_f[OF blocked_cancel_ipc_reads_respects, where st=st and Q="\<top>"]
-           reply_cancel_ipc_reads_respects_f[where st=st]
-           reads_respects_f[OF cancel_signal_owned_reads_respects, where st=st and Q="\<top>"]
-           reads_respects_f[OF get_thread_state_rev, where st=st and Q="\<top>"] gts_wp
-       | wpc | simp add: blocked_cancel_ipc_def | erule conjE)+
-  apply(clarsimp simp: st_tcb_at_def obj_at_def)
-  apply(rule owns_thread_blocked_reads_endpoint)
-       apply (simp add: st_tcb_at_def obj_at_def | blast)+
-  done
-
-lemma update_restart_pc_reads_respects[wp]:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (silc_inv aag s and K (is_subject aag thread))
-      (update_restart_pc thread)"
-  unfolding update_restart_pc_def
-  apply (subst as_user_bind)
-  apply (wpsimp wp: as_user_set_register_reads_respects' as_user_get_register_reads_respects)
+  apply (wp reads_respects_f[OF blocked_cancel_ipc_reads_respects, where st=st and Q="\<top>"]
+            reply_cancel_ipc_reads_respects_f[where st=st]
+            reads_respects_f[OF cancel_signal_owned_reads_respects, where st=st and Q="\<top>"]
+            reads_respects_f[OF get_thread_state_rev, where st=st and Q="\<top>"] gts_wp
+         | wpc | simp add: blocked_cancel_ipc_def | erule conjE)+
+  apply (clarsimp simp: st_tcb_at_def obj_at_def)
+  apply (rule owns_thread_blocked_reads_endpoint)
+      apply (simp add: st_tcb_at_def obj_at_def | blast)+
   done
 
 lemma suspend_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_f aag l (silc_inv aag st and pas_refined aag and invs and tcb_at thread and
-  (K (is_subject aag thread))) (suspend thread)"
+  shows "reads_respects_f aag l (silc_inv aag st and pas_refined aag and invs and tcb_at thread
+                                                 and K (is_subject aag thread))
+                          (suspend thread)"
   unfolding suspend_def
-  apply(wp reads_respects_f[OF set_thread_state_owned_reads_respects, where st=st and Q="\<top>"]
-           reads_respects_f[OF tcb_sched_action_reads_respects, where st=st and Q=\<top>]
-           reads_respects_f[OF get_thread_state_rev, where st=st and Q="\<top>"]
-           reads_respects_f[OF update_restart_pc_reads_respects, where st=st and Q="\<top>"]
-           gts_wp
-           set_thread_state_pas_refined| simp)+
-    apply(wp cancel_ipc_reads_respects_f[where st=st] cancel_ipc_silc_inv)+
+  apply (wp reads_respects_f[OF set_thread_state_owned_reads_respects, where st=st and Q="\<top>"]
+            reads_respects_f[OF tcb_sched_action_reads_respects, where st=st and Q=\<top>]
+            reads_respects_f[OF get_thread_state_rev, where st=st and Q="\<top>"]
+            reads_respects_f[OF update_restart_pc_reads_respects, where st=st and Q="\<top>"]
+            gts_wp set_thread_state_pas_refined | simp)+
+    apply (wp cancel_ipc_reads_respects_f[where st=st] cancel_ipc_silc_inv)+
    apply clarsimp
    apply (wp hoare_allI hoare_drop_imps)
     apply clarsimp
-    apply(wp cancel_ipc_silc_inv)+
+    apply (wp cancel_ipc_silc_inv)+
   apply auto
-  done
-
-lemma prepare_thread_delete_reads_respects_f:
-  "reads_respects_f aag l \<top> (prepare_thread_delete thread)"
-  unfolding prepare_thread_delete_def
-  by wp
-
-lemma arch_finalise_cap_reads_respects:
-  "reads_respects aag l (pas_refined aag and invs and
-    cte_wp_at ((=) (ArchObjectCap cap)) slot and
-    K(pas_cap_cur_auth aag (ArchObjectCap cap))) (arch_finalise_cap cap is_final)"
-  apply (rule gen_asm_ev)
-  unfolding arch_finalise_cap_def
-  apply (case_tac cap)
-  apply simp
-  apply (simp split: bool.splits)
-  apply (intro impI conjI)
-  apply (wp delete_asid_pool_reads_respects
-            unmap_page_reads_respects
-            unmap_page_table_reads_respects
-            delete_asid_reads_respects
-        | simp add: invs_psp_aligned invs_vspace_objs invs_valid_objs valid_cap_def
-             split: option.splits bool.splits
-        | intro impI conjI allI
-        | elim conjE
-        | rule aag_cap_auth_subject,assumption,assumption
-        | drule cte_wp_valid_cap)+
   done
 
 lemma deleting_irq_handler_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_f aag l (silc_inv aag st and invs and pas_refined aag and K (is_subject_irq aag irq)) (deleting_irq_handler irq)"
+  shows "reads_respects_f aag l (silc_inv aag st and invs and pas_refined aag
+                                                 and K (is_subject_irq aag irq))
+                          (deleting_irq_handler irq)"
   unfolding deleting_irq_handler_def
-  apply(wp cap_delete_one_reads_respects_f
-           reads_respects_f[OF get_irq_slot_reads_respects]
-       | simp | blast)+
-  done
+  by (wp cap_delete_one_reads_respects_f reads_respects_f[OF get_irq_slot_reads_respects]
+      | simp | blast)+
 
 lemma finalise_cap_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects_f aag l (silc_inv aag st and pas_refined aag and invs
-                          and cte_wp_at ((=) cap) slot and K (pas_cap_cur_auth aag cap)
-    and K (final \<longrightarrow> (case cap of EndpointCap r badge rights \<Rightarrow> is_subject aag r |
-                           NotificationCap r badge rights \<Rightarrow> is_subject aag r |
-                            _ \<Rightarrow> True))) (finalise_cap cap final)"
-  apply(case_tac cap, simp_all split del: if_split)
-            apply ((wp cancel_all_ipc_reads_respects cancel_all_signals_reads_respects
-                      prepare_thread_delete_reads_respects_f
-                      suspend_reads_respects_f[where st=st] deleting_irq_handler_reads_respects
-                      unbind_notification_is_subj_reads_respects
-                      unbind_maybe_notification_reads_respects
-                      unbind_notification_invs unbind_maybe_notification_invs
-                  | simp add: when_def split del: if_split
-                         add: invs_valid_objs invs_sym_refs aag_cap_auth_def
-                              cap_auth_conferred_def cap_rights_to_auth_def
-                              cap_links_irq_def aag_has_Control_iff_owns
-                              cte_wp_at_caps_of_state
-                  | rule aag_Control_into_owns_irq
-                  | clarsimp split del: if_split
-                  | rule conjI
-                  | wp (once) reads_respects_f[where st=st]
-                  | blast
-                  | clarsimp
-                  | force dest:caps_of_state_valid simp: valid_cap_def)+)[11]
+    "reads_respects_f aag l
+       (silc_inv aag st and pas_refined aag and invs and cte_wp_at ((=) cap) slot
+                        and K (pas_cap_cur_auth aag cap)
+                        and K (final \<longrightarrow> (case cap of EndpointCap r badge rights \<Rightarrow> is_subject aag r
+                                                | NotificationCap r badge rights \<Rightarrow> is_subject aag r
+                                                | _ \<Rightarrow> True)))
+       (finalise_cap cap final)"
+  apply (case_tac cap, simp_all split del: if_split)
+             apply ((wp cancel_all_ipc_reads_respects cancel_all_signals_reads_respects
+                        prepare_thread_delete_reads_respects_f
+                        suspend_reads_respects_f[where st=st] deleting_irq_handler_reads_respects
+                        unbind_notification_is_subj_reads_respects
+                        unbind_maybe_notification_reads_respects
+                        unbind_notification_invs unbind_maybe_notification_invs
+                     | simp add: when_def invs_valid_objs invs_sym_refs aag_cap_auth_def
+                                 cap_auth_conferred_def cap_rights_to_auth_def cap_links_irq_def
+                                 aag_has_Control_iff_owns cte_wp_at_caps_of_state
+                            split del: if_split
+                     | rule aag_Control_into_owns_irq
+                     | clarsimp split del: if_split
+                     | rule conjI
+                     | wp (once) reads_respects_f[where st=st]
+                     | blast
+                     | clarsimp
+                     | force dest: caps_of_state_valid simp: valid_cap_def)+)[11]
   apply (rule equiv_valid_guard_imp)
-  by ((wp arch_finalise_cap_reads_respects reads_respects_f[where st=st] arch_finalise_cap_silc_inv
-      | simp | elim conjE)+)[2]
+  by (wp arch_finalise_cap_reads_respects reads_respects_f[where st=st] arch_finalise_cap_silc_inv
+      | simp | elim conjE)+
+
+end
 
 
 lemma cap_swap_for_delete_reads_respects:
   "reads_respects aag l (K (is_subject aag (fst slot1) \<and> is_subject aag (fst slot2)))
-     (cap_swap_for_delete slot1 slot2)"
+                 (cap_swap_for_delete slot1 slot2)"
   unfolding cap_swap_for_delete_def
-  apply(simp add: when_def)
-  apply(rule conjI, rule impI)
-   apply(rule equiv_valid_guard_imp)
-    apply(wp cap_swap_reads_respects get_cap_rev)
-   apply(simp)
-  apply(rule impI, wp)
+  apply (simp add: when_def)
+  apply (rule conjI, rule impI)
+   apply (rule equiv_valid_guard_imp)
+    apply (wp cap_swap_reads_respects get_cap_rev)
+   apply (simp)
+  apply (rule impI, wp)
   done
 
 lemma owns_cnode_owns_obj_ref_of_child_cnodes_threads_and_zombies:
-  "\<lbrakk>pas_refined aag s; is_subject aag (fst slot);
-        cte_wp_at ((=) cap) slot s; is_cnode_cap cap \<or> is_thread_cap cap \<or> is_zombie cap\<rbrakk>
-       \<Longrightarrow> is_subject aag (obj_ref_of cap)"
-  apply(frule (1) cap_cur_auth_caps_of_state[rotated])
-  apply(simp add: cte_wp_at_caps_of_state)
-  apply(clarsimp simp: aag_cap_auth_def)
-  apply(case_tac cap, simp_all add: is_zombie_def)
-    apply(drule_tac x=Control in bspec)
+  "\<lbrakk> pas_refined aag s; is_subject aag (fst slot); cte_wp_at ((=) cap) slot s;
+     is_cnode_cap cap \<or> is_thread_cap cap \<or> is_zombie cap \<rbrakk>
+     \<Longrightarrow> is_subject aag (obj_ref_of cap)"
+  apply (frule (1) cap_cur_auth_caps_of_state[rotated])
+   apply (simp add: cte_wp_at_caps_of_state)
+  apply (clarsimp simp: aag_cap_auth_def)
+  apply (case_tac cap, simp_all add: is_zombie_def)
+    apply (drule_tac x=Control in bspec)
      apply (clarsimp simp: cap_auth_conferred_def)
-    apply(erule (1) aag_Control_into_owns)
-   apply(drule_tac x=Control in bspec)
+    apply (erule (1) aag_Control_into_owns)
+   apply (drule_tac x=Control in bspec)
     apply (clarsimp simp: cap_auth_conferred_def)
-   apply(erule (1) aag_Control_into_owns)
-  apply(drule_tac x=Control in bspec)
+   apply (erule (1) aag_Control_into_owns)
+  apply (drule_tac x=Control in bspec)
    apply (clarsimp simp: cap_auth_conferred_def)
-  apply(erule (1) aag_Control_into_owns)
+  apply (erule (1) aag_Control_into_owns)
   done
 
-lemmas only_timer_irq_inv_irq_state_independent_A[intro!]
-       = irq_state_independent_A_only_timer_irq_inv
+lemmas only_timer_irq_inv_irq_state_independent_A[intro!] =
+  irq_state_independent_A_only_timer_irq_inv
 
 lemma rec_del_only_timer_irq:
-  "\<lbrace>only_timer_irq_inv irq (st::det_ext state)\<rbrace> rec_del call \<lbrace>\<lambda>_. only_timer_irq irq\<rbrace>"
+  "\<lbrace>only_timer_irq_inv irq (st :: det_state)\<rbrace>
+   rec_del call
+   \<lbrace>\<lambda>_. only_timer_irq irq\<rbrace>"
   apply (simp add: only_timer_irq_inv_def)
   apply (rule hoare_pre, rule only_timer_irq_pres)
     apply (rule hoare_pre, wp rec_del_irq_masks)
-    apply (wp rec_del_domain_sep_inv | force
-      | (rule hoare_pre, wp (once) rec_del_domain_sep_inv))+
+    apply (wp rec_del_domain_sep_inv | force | rule hoare_pre, wp (once) rec_del_domain_sep_inv)+
   done
 
 lemma rec_del_only_timer_irq_inv:
-  "\<lbrace>only_timer_irq_inv irq (st::det_ext state)\<rbrace> rec_del call \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
+  "\<lbrace>only_timer_irq_inv irq (st :: det_state)\<rbrace>
+   rec_del call
+   \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
   apply (simp add: only_timer_irq_inv_def)
   apply (rule hoare_wp_simps)
   apply (rule hoare_conjI)
    apply (wp rec_del_domain_sep_inv rec_del_only_timer_irq | force simp: only_timer_irq_inv_def)+
-   done
+  done
 
 lemma set_cap_only_timer_irq_inv:
-  "\<lbrace>only_timer_irq_inv irq (st::det_ext state) and K (domain_sep_inv_cap False cap)\<rbrace>
-   set_cap cap slot \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
+  "\<lbrace>only_timer_irq_inv irq (st :: det_state) and K (domain_sep_inv_cap False cap)\<rbrace>
+   set_cap cap slot
+   \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
   apply (simp add: only_timer_irq_inv_def)
   apply (wp only_timer_irq_pres set_cap_domain_sep_inv | force)+
   done
 
 lemma finalise_cap_only_timer_irq_inv:
-  "\<lbrace>only_timer_irq_inv irq (st::det_ext state)\<rbrace>
-   finalise_cap cap final \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
+  "\<lbrace>only_timer_irq_inv irq (st :: det_state)\<rbrace>
+   finalise_cap cap final
+   \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
   apply (simp add: only_timer_irq_inv_def)
   apply (wp only_timer_irq_pres | force)+
   done
 
-lemma finalise_cap_makes_halted:
-  "\<lbrace>invs and valid_cap cap and (\<lambda>s. ex = is_final_cap' cap s)
-         and cte_wp_at ((=) cap) slot\<rbrace>
-    finalise_cap cap ex
-   \<lbrace>\<lambda>rv s. \<forall>t \<in> obj_refs (fst rv). halted_if_tcb t s\<rbrace>"
-  apply (case_tac cap, simp_all)
-            apply (wp unbind_notification_valid_objs
-                 | clarsimp simp: o_def valid_cap_def cap_table_at_typ
-                                  is_tcb obj_at_def
-                 | clarsimp simp: halted_if_tcb_def
-                           split: option.split
-                 | intro impI conjI
-                 | rule hoare_drop_imp)+
-   apply (fastforce simp: st_tcb_at_def obj_at_def is_tcb live_def
-                  dest!: final_zombie_not_live)
-  apply (rename_tac arch_cap)
-  apply (case_tac arch_cap, simp_all add: arch_finalise_cap_def)
-      apply (wp
-           | clarsimp simp: valid_cap_def split: option.split bool.split
-           | intro impI conjI)+
-  done
+
+context Finalise_IF_1 begin
 
 lemma rec_del_spec_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del]
         drop_spec_ev[wp_split del] rec_del.simps[simp del]
   shows
-  "spec_reads_respects_f s aag l (silc_inv aag st and only_timer_irq_inv irq st' and
-   einvs and simple_sched_action and pas_refined aag and
-   valid_rec_del_call call and
-   emptyable (slot_rdcall call) and
-   (\<lambda>s. \<not> exposed_rdcall call \<longrightarrow>
-        ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) (slot_rdcall call) s) and
-    K (case call of
-     CTEDeleteCall slot exposed \<Rightarrow> is_subject aag (fst slot) |
-     FinaliseSlotCall slot exposed \<Rightarrow> is_subject aag (fst slot) |
-     ReduceZombieCall cap slot exposed \<Rightarrow> is_subject aag (fst slot) \<and>
-                                          is_subject aag (obj_ref_of cap)))
- (rec_del call)"
+  "spec_reads_respects_f s aag l
+     (silc_inv aag st and only_timer_irq_inv irq st' and einvs and simple_sched_action
+                      and pas_refined aag and valid_rec_del_call call and emptyable (slot_rdcall call)
+                      and (\<lambda>s. \<not> exposed_rdcall call
+                               \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) (slot_rdcall call) s)
+                      and K (case call of CTEDeleteCall slot exposed \<Rightarrow> is_subject aag (fst slot)
+                               | FinaliseSlotCall slot exposed \<Rightarrow> is_subject aag (fst slot)
+                               | ReduceZombieCall cap slot exposed \<Rightarrow> is_subject aag (fst slot) \<and>
+                                                                      is_subject aag (obj_ref_of cap)))
+     (rec_del call)"
 proof (induct s rule: rec_del.induct, simp_all only: rec_del_fails drop_spec_ev[OF fail_ev_pre])
   case (1 slot exposed s) show ?case
-    apply(rule spec_equiv_valid_guard_imp)
-     apply(simp add: rec_del.simps split_def when_def)
-     apply(wp drop_spec_ev[OF returnOk_ev_pre] drop_spec_ev[OF liftE_ev] hoareE_TrueI
-              reads_respects_f[OF empty_slot_reads_respects, where st=st] empty_slot_silc_inv)
-      apply(rule "1.hyps")
-     apply(rule_tac Q'="\<lambda>r s. silc_inv aag st s \<and> is_subject aag (fst slot)" in hoare_post_imp_R)
-      apply((wp validE_validE_R'[OF rec_del_silc_inv_not_transferable]
-            | fastforce simp: silc_inv_def)+)[2]
-    apply simp
+    apply (rule spec_equiv_valid_guard_imp)
+     apply (simp add: rec_del.simps split_def when_def)
+     apply (wp drop_spec_ev[OF returnOk_ev_pre] drop_spec_ev[OF liftE_ev] hoareE_TrueI
+               reads_respects_f[OF empty_slot_reads_respects, where st=st] empty_slot_silc_inv)
+      apply (rule "1.hyps")
+     apply (rule_tac Q'="\<lambda>r s. silc_inv aag st s \<and> is_subject aag (fst slot)" in hoare_post_imp_R)
+      apply (wp validE_validE_R'[OF rec_del_silc_inv_not_transferable] | fastforce simp: silc_inv_def)+
     done
 next
   case (2 slot exposed s) show ?case
-    apply(simp add: rec_del.simps)
-    apply(rule spec_equiv_valid_guard_imp)
-     apply(wp drop_spec_ev[OF returnOk_ev] drop_spec_ev[OF liftE_ev]
-              set_cap_reads_respects_f "2.hyps" preemption_point_inv'
-              drop_spec_ev[OF preemption_point_reads_respects_f[where st=st and st'=st']]
-              validE_validE_R'[OF rec_del_silc_inv_not_transferable] rec_del_invs
-              rec_del_respects(2) rec_del_only_timer_irq_inv
-          | simp add: split_def split del: if_split | (rule irq_state_independent_A_conjI, simp)+)+
-             apply(rule_tac Q'="\<lambda>rv s.
-                                emptyable (slot_rdcall (ReduceZombieCall (fst rvb) slot exposed)) s
-                             \<and> (\<not> exposed \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) slot s)
-                                            \<and> is_subject aag (fst slot)"
-                         in hoare_post_imp_R)
-              apply(wp rec_del_emptyable reduce_zombie_cap_to)
+    apply (simp add: rec_del.simps)
+    apply (rule spec_equiv_valid_guard_imp)
+     apply (wp drop_spec_ev[OF returnOk_ev] drop_spec_ev[OF liftE_ev]
+               set_cap_reads_respects_f "2.hyps" preemption_point_inv'
+               drop_spec_ev[OF preemption_point_reads_respects_f[where st=st and st'=st']]
+               validE_validE_R'[OF rec_del_silc_inv_not_transferable] rec_del_invs
+               rec_del_respects(2) rec_del_only_timer_irq_inv
+            | simp add: split_def split del: if_split | (rule irq_state_independent_A_conjI, simp)+)+
+             apply (rule_tac
+                    Q'="\<lambda>rv s. emptyable (slot_rdcall (ReduceZombieCall (fst rvb) slot exposed)) s \<and>
+                               (\<not> exposed \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) slot s) \<and>
+                               is_subject aag (fst slot)" in hoare_post_imp_R)
+              apply (wp rec_del_emptyable reduce_zombie_cap_to)
              apply simp
-            apply(wp drop_spec_ev[OF liftE_ev] set_cap_reads_respects_f[where st=st]
-                     set_cap_silc_inv[where st=st]
-                 | simp)+
-           apply(wp replace_cap_invs set_cap_cte_wp_at set_cap_sets final_cap_same_objrefs
-                    set_cap_cte_cap_wp_to  hoare_vcg_const_Ball_lift static_imp_wp
-                    drop_spec_ev[OF liftE_ev] finalise_cap_reads_respects set_cap_silc_inv
-                    set_cap_only_timer_irq_inv set_cap_pas_refined_not_transferable
-                | simp add: cte_wp_at_eq_simp
-                | erule finalise_cap_not_reply_master[simplified Inr_in_liftE_simp])+
-         apply(rule hoare_strengthen_post)
-          apply (rule_tac Q="\<lambda>fin s. silc_inv aag st s
-                                 \<and> only_timer_irq_inv irq st' s
-                                 \<and>
-                       (\<not> cap_points_to_label aag (fst fin) (pasObjectAbs aag (fst slot)) \<longrightarrow>
-                          (\<exists>lslot. lslot \<in> slots_holding_overlapping_caps (fst fin) s \<and>
-                                     pasObjectAbs aag (fst lslot) = SilcLabel))
-                                 \<and> einvs s \<and> replaceable s slot (fst fin) rv
-                                 \<and> cte_wp_at ((=) rv) slot s \<and> s \<turnstile> (fst fin)
-                                 \<and> ex_cte_cap_wp_to (appropriate_cte_cap rv) slot s
-                                 \<and> (\<forall>t\<in>obj_refs (fst fin). halted_if_tcb t s)
-                                 \<and> pas_refined aag s
-                                 \<and> emptyable slot s
-                                 \<and> simple_sched_action s
-                                 \<and> pas_cap_cur_auth aag (fst fin)
-                                 \<and> is_subject aag (fst slot)
-                                 \<and> (case (fst fin) of Zombie ptr bits n \<Rightarrow>
-                                                            is_subject aag (obj_ref_of (fst fin))
-                                                     | _ \<Rightarrow> True)
-                                 \<and> (is_zombie (fst fin) \<or> fst fin = NullCap) \<and>
-                                   (is_zombie (fst fin) \<or> fst fin = NullCap)" in hoare_vcg_conj_lift)
-           apply(wp finalise_cap_invs finalise_cap_replaceable finalise_cap_makes_halted
-                    finalise_cap_auth'
-                    finalise_cap_ret_is_subject finalise_cap_ret' finalise_cap_silc_inv
-                    finalise_cap_ret_is_silc finalise_cap_only_timer_irq_inv)[1]
-          apply(rule finalise_cap_cases[where slot=slot])
+            apply (wp drop_spec_ev[OF liftE_ev] set_cap_reads_respects_f[where st=st]
+                      set_cap_silc_inv[where st=st] | simp)+
+           apply (wp replace_cap_invs set_cap_cte_wp_at set_cap_sets final_cap_same_objrefs
+                     set_cap_cte_cap_wp_to  hoare_vcg_const_Ball_lift static_imp_wp
+                     drop_spec_ev[OF liftE_ev] finalise_cap_reads_respects set_cap_silc_inv
+                     set_cap_only_timer_irq_inv set_cap_pas_refined_not_transferable
+                  | simp add: cte_wp_at_eq_simp
+                  | erule finalise_cap_not_reply_master[simplified Inr_in_liftE_simp])+
+         apply (rule hoare_strengthen_post)
+          apply (rule_tac
+                 Q="\<lambda>fin s. silc_inv aag st s \<and> only_timer_irq_inv irq st' s
+                         \<and> (\<not> cap_points_to_label aag (fst fin) (pasObjectAbs aag (fst slot))
+                            \<longrightarrow> (\<exists>lslot. lslot \<in> slots_holding_overlapping_caps (fst fin) s \<and>
+                                         pasObjectAbs aag (fst lslot) = SilcLabel))
+                         \<and> einvs s \<and> replaceable s slot (fst fin) rv
+                         \<and> cte_wp_at ((=) rv) slot s \<and> s \<turnstile> (fst fin)
+                         \<and> ex_cte_cap_wp_to (appropriate_cte_cap rv) slot s
+                         \<and> (\<forall>t\<in>obj_refs (fst fin). halted_if_tcb t s)
+                         \<and> pas_refined aag s
+                         \<and> emptyable slot s
+                         \<and> simple_sched_action s
+                         \<and> pas_cap_cur_auth aag (fst fin)
+                         \<and> is_subject aag (fst slot)
+                         \<and> (case (fst fin) of Zombie _ _ _ \<Rightarrow> is_subject aag (obj_ref_of (fst fin))
+                                                       | _ \<Rightarrow> True)
+                         \<and> (is_zombie (fst fin) \<or> fst fin = NullCap)
+                         \<and> (is_zombie (fst fin) \<or> fst fin = NullCap)" in hoare_vcg_conj_lift)
+           apply (wp finalise_cap_replaceable Finalise_AC_1.finalise_cap_makes_halted
+                     finalise_cap_invs finalise_cap_auth' finalise_cap_ret_is_subject finalise_cap_ret'
+                     finalise_cap_silc_inv finalise_cap_ret_is_silc finalise_cap_only_timer_irq_inv)[1]
+          apply (rule finalise_cap_cases[where slot=slot])
          apply (clarsimp simp: cte_wp_at_caps_of_state)
          apply (erule disjE)
           apply (clarsimp simp: cap_irq_opt_def cte_wp_at_def is_zombie_def gen_obj_refs_eq
                          split: cap.split_asm if_split_asm
                          elim!: ranE dest!: caps_of_state_cteD)
-          apply(clarsimp cong: conj_cong simp: conj_comms)
-          apply(rename_tac word option nat)
-          apply(drule_tac s="{word}" in sym)
-          apply(clarsimp simp: invs_psp_aligned invs_arch_state invs_vspace_objs)
-          apply(rule conjI, fastforce)
-          apply(clarsimp, rule conjI) apply (erule replaceable_zombie_not_transferable)(* WHY *)
-           apply (rule conjI)
-           apply(fastforce simp: silc_inv_def)
-          apply(rule conjI)
-           apply(fastforce simp: domain_sep_inv_def domain_sep_inv_cap_def
-                                                      only_timer_irq_inv_def)
-
-          apply(rule conjI[rotated], force)
-          apply(clarsimp simp: ex_cte_cap_wp_to_def)+
-          apply(rule_tac x="a" in exI, rule_tac x="b" in exI)
-          apply(clarsimp simp: cte_wp_at_def appropriate_cte_cap_def)
-          apply(drule_tac x="cap" in fun_cong)
-          apply(clarsimp simp: appropriate_cte_cap_def split: cap.splits)
-         apply(clarsimp cong: conj_cong simp: conj_comms)
-        apply(wp drop_spec_ev[OF liftE_ev] is_final_cap_reads_respects | simp)+
-
-
-       apply(rule_tac Q="\<lambda> rva s. rva = is_final_cap' rv s \<and> cte_wp_at ((=) rv) slot s \<and>
-                            only_timer_irq_inv irq st' s \<and>
-                            silc_inv aag st s \<and>
-                            pas_refined aag s \<and>
-                            pas_cap_cur_auth aag rv \<and>
-                            invs s \<and> valid_list s \<and> valid_sched s \<and> simple_sched_action s \<and>
-                            s \<turnstile> rv \<and>
-                            is_subject aag (fst slot) \<and>
-                            emptyable slot s \<and>
-                            ex_cte_cap_wp_to (appropriate_cte_cap rv) slot s"
-            in hoare_strengthen_post)
+          apply (clarsimp cong: conj_cong simp: conj_comms)
+          apply (rename_tac word option nat)
+          apply (drule_tac s="{word}" in sym)
+          apply (clarsimp simp: invs_psp_aligned invs_arch_state invs_vspace_objs)
+          apply (rule conjI, fastforce)
+          apply (clarsimp, rule conjI)
+           apply (erule replaceable_zombie_not_transferable)(* WHY *)
+          apply (rule conjI)
+           apply (fastforce simp: silc_inv_def)
+          apply (rule conjI)
+           apply (fastforce simp: domain_sep_inv_def domain_sep_inv_cap_def only_timer_irq_inv_def)
+          apply (rule conjI[rotated], force)
+          apply (clarsimp simp: ex_cte_cap_wp_to_def)+
+          apply (rule_tac x="a" in exI, rule_tac x="b" in exI)
+          apply (clarsimp simp: cte_wp_at_def appropriate_cte_cap_def)
+          apply (drule_tac x="cap" in fun_cong)
+          apply (clarsimp simp: appropriate_cte_cap_def split: cap.splits)
+         apply (clarsimp cong: conj_cong simp: conj_comms)
+        apply (wp drop_spec_ev[OF liftE_ev] is_final_cap_reads_respects | simp)+
+       apply (rule_tac Q="\<lambda>rva s. rva = is_final_cap' rv s \<and> cte_wp_at ((=) rv) slot s \<and>
+                                  only_timer_irq_inv irq st' s \<and> silc_inv aag st s \<and>
+                                  pas_refined aag s \<and> pas_cap_cur_auth aag rv \<and>
+                                  invs s \<and> valid_list s \<and> valid_sched s \<and> simple_sched_action s \<and>
+                                  s \<turnstile> rv \<and> is_subject aag (fst slot) \<and> emptyable slot s \<and>
+                                  ex_cte_cap_wp_to (appropriate_cte_cap rv) slot s"
+                    in hoare_strengthen_post)
         apply (wp is_final_cap_is_final | simp)+
        apply clarsimp
        apply (rule conjI)
@@ -1538,59 +1295,59 @@ next
          apply (clarsimp simp: cap_points_to_label_def split: cap.splits)
         apply (simp add: silc_inv_def)
        apply (force simp: owns_cnode_owns_obj_ref_of_child_cnodes_threads_and_zombies)
-      apply(wp drop_spec_ev[OF liftE_ev] reads_respects_f[OF get_cap_rev, where st=st and Q="\<top>"]
-               get_cap_wp
-           | simp)+
-    apply(clarsimp cong: conj_cong simp:invs_valid_objs invs_arch_state invs_psp_aligned)
-    apply(intro conjI impI | clarsimp | assumption | fastforce dest:silc_inv_not_subject)+
-      apply(erule (1) cap_cur_auth_caps_of_state[rotated])
-      apply(simp add: cte_wp_at_caps_of_state)
-     apply(fastforce dest: cte_wp_at_valid_objs_valid_cap simp: invs_valid_objs)
-    apply(drule if_unsafe_then_capD)
-      apply(simp add: invs_ifunsafe)
+      apply (wp drop_spec_ev reads_respects_f[OF get_cap_rev, where st=st and Q="\<top>"] get_cap_wp
+             | simp)+
+    apply (clarsimp cong: conj_cong simp: invs_valid_objs invs_arch_state invs_psp_aligned)
+    apply (intro conjI impI | clarsimp | assumption | fastforce dest: silc_inv_not_subject)+
+      apply (erule (1) cap_cur_auth_caps_of_state[rotated])
+      apply (simp add: cte_wp_at_caps_of_state)
+     apply (fastforce dest: cte_wp_at_valid_objs_valid_cap simp: invs_valid_objs)
+    apply (drule if_unsafe_then_capD)
+      apply (simp add: invs_ifunsafe)
      apply simp
-    apply(clarsimp simp: ex_cte_cap_wp_to_def)
-   done
+    apply (clarsimp simp: ex_cte_cap_wp_to_def)
+    done
 next
   case (3 ptr bits n slot s) show ?case
-    apply(simp add: rec_del.simps)
-    apply(rule spec_equiv_valid_guard_imp)
-     apply(wp drop_spec_ev[OF liftE_ev] drop_spec_ev[OF returnOk_ev]
+    apply (simp add: rec_del.simps)
+    apply (rule spec_equiv_valid_guard_imp)
+     apply (wp drop_spec_ev[OF liftE_ev] drop_spec_ev[OF returnOk_ev]
               reads_respects_f[OF cap_swap_for_delete_reads_respects] cap_swap_for_delete_silc_inv
               drop_spec_ev[OF assertE_ev])+
-    apply(fastforce simp: silc_inv_def)
+    apply (fastforce simp: silc_inv_def)
     done
 next
   case (4 ptr bits n slot s) show ?case
-    apply(simp add: rec_del.simps)
-    apply(rule spec_equiv_valid_guard_imp)
-     apply(wp drop_spec_ev[OF returnOk_ev] drop_spec_ev[OF liftE_ev] set_cap_reads_respects_f
-              drop_spec_ev[OF assertE_ev] get_cap_wp "4.hyps"
-              reads_respects_f[OF get_cap_rev, where st=st and Q="\<top>"]
-              validE_validE_R'[OF rec_del_silc_inv_not_transferable]
-          | simp add: in_monad)+
-    apply (rule_tac Q'="\<lambda> _. silc_inv aag st and
-                           K (pasObjectAbs aag (fst slot) \<noteq> SilcLabel \<and> is_subject aag (fst slot))"
-                 in hoare_post_imp_R)
-     prefer 2
-     apply (clarsimp)
-     apply(rule conjI, assumption)
-     apply(rule impI)
-     apply (drule silc_invD)
-       apply assumption
-      apply(simp add: intra_label_cap_def)
-      apply(rule exI)
-      apply(rule conjI)
-       apply assumption
-      apply(fastforce simp: cap_points_to_label_def)
-     apply(clarsimp simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
-    apply(wp validE_validE_R'[OF rec_del_silc_inv_not_transferable] | simp)+
-    apply (clarsimp simp add: zombie_is_cap_toE)
-    apply (clarsimp simp: cte_wp_at_caps_of_state zombie_ptr_emptyable silc_inv_def)
-   done
+    apply (simp add: rec_del.simps)
+    apply (rule spec_equiv_valid_guard_imp)
+     apply (wp drop_spec_ev[OF returnOk_ev] drop_spec_ev[OF liftE_ev] set_cap_reads_respects_f
+               drop_spec_ev[OF assertE_ev] get_cap_wp "4.hyps"
+               reads_respects_f[OF get_cap_rev, where st=st and Q="\<top>"]
+               validE_validE_R'[OF rec_del_silc_inv_not_transferable]
+            | simp add: in_monad)+
+     apply (rule_tac Q'="\<lambda> _. silc_inv aag st and
+                            K (pasObjectAbs aag (fst slot) \<noteq> SilcLabel \<and> is_subject aag (fst slot))"
+                  in hoare_post_imp_R)
+      prefer 2
+      apply (clarsimp)
+      apply (rule conjI, assumption)
+      apply (rule impI)
+      apply (drule silc_invD)
+        apply assumption
+       apply (simp add: intra_label_cap_def)
+       apply (rule exI)
+       apply (rule conjI)
+        apply assumption
+       apply (fastforce simp: cap_points_to_label_def)
+      apply (clarsimp simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def)
+     apply (wp validE_validE_R'[OF rec_del_silc_inv_not_transferable] | simp)+
+    apply (clarsimp simp: zombie_is_cap_toE cte_wp_at_caps_of_state zombie_ptr_emptyable silc_inv_def)
+    done
 qed
 
 lemmas rec_del_reads_respects_f = use_spec_ev[OF rec_del_spec_reads_respects_f]
+
+end
 
 
 (* FIXME MOVE in lib *)
@@ -1603,8 +1360,8 @@ lemma finalise_cap_transferable_ev:
   by (rule gen_asm_ev) (erule is_transferable_capE; wpsimp wp: return_ev)
 
 lemma rec_del_Finalise_transferable_read_respects_f:
-  "reads_respects_f aag l (silc_inv aag st and is_transferable_in slot
-                           and K(aag_can_read_not_silc aag (fst slot)))
+  "reads_respects_f aag l
+     (silc_inv aag st and is_transferable_in slot and K(aag_can_read_not_silc aag (fst slot)))
      (rec_del (FinaliseSlotCall slot exposed))"
   apply (subst rec_del.simps[abs_def])
   apply (wp | wpc | simp)+
@@ -1612,28 +1369,30 @@ lemma rec_del_Finalise_transferable_read_respects_f:
         apply simp
         apply (wp liftE_ev finalise_cap_transferable_ev | simp)+
        apply (rule hoare_post_imp[OF _ finalise_cap_transferable[where P=\<top>]], fastforce)
-      apply (wp is_final_cap_reads_respects hoare_drop_imp get_cap_wp
-                reads_respects_f[OF get_cap_rev, where st=st and Q="\<top>"]
-            | simp)+
+      apply (wpsimp wp: is_final_cap_reads_respects hoare_drop_imp get_cap_wp
+                        reads_respects_f[OF get_cap_rev, where st=st and Q="\<top>"])+
   by (fastforce simp: cte_wp_at_caps_of_state)
 
 lemma rec_del_Finalise_transferableE_R:
   "\<lbrace>(\<lambda>s. is_transferable (caps_of_state s slot)) and P\<rbrace>
-     rec_del (FinaliseSlotCall slot exposed)
-   \<lbrace>\<lambda>_.P \<rbrace>, -"
+   rec_del (FinaliseSlotCall slot exposed)
+   \<lbrace>\<lambda>_. P\<rbrace>, -"
   apply (rule hoare_pre)
    apply (simp add: validE_R_def)
    apply (rule hoare_post_impErr)
      apply (rule rec_del_Finalise_transferable)
   by force+
 
+
+context Finalise_IF_1 begin
+
 lemma rec_del_CTEDeleteCall_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects_f aag l (silc_inv aag st and only_timer_irq_inv irq st' and einvs
-                           and simple_sched_action and pas_refined aag and emptyable slot
-                           and (\<lambda>s. \<not> exposed \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) slot s)
-                           and cdt_change_allowed' aag slot)
+  "reads_respects_f aag l
+     (silc_inv aag st and only_timer_irq_inv irq st' and einvs and simple_sched_action
+                      and pas_refined aag and emptyable slot and cdt_change_allowed' aag slot
+                      and (\<lambda>s. \<not> exposed \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) slot s))
      (rec_del (CTEDeleteCall slot exposed))"
   apply (cases "is_subject aag (fst slot)")
    apply (rule equiv_valid_guard_imp)
@@ -1643,7 +1402,7 @@ lemma rec_del_CTEDeleteCall_reads_respects_f:
   apply (wp when_ev reads_respects_f[OF empty_slot_reads_respects] empty_slot_silc_inv
             rec_del_Finalise_transferable_read_respects_f hoare_vcg_all_lift_R hoare_drop_impE_R
             rec_del_Finalise_transferableE_R
-        | wpc | simp)+
+         | wpc | simp)+
   apply clarsimp
   apply (frule(3) cca_can_read[OF invs_mdb invs_valid_objs])
   apply (frule(2) cdt_change_allowed_not_silc[rotated 2], force, force)
@@ -1651,219 +1410,116 @@ lemma rec_del_CTEDeleteCall_reads_respects_f:
   apply force
   done
 
-
-
 lemma cap_delete_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
   "reads_respects_f aag l (silc_inv aag st and only_timer_irq_inv irq st' and einvs
-                           and simple_sched_action and pas_refined aag and emptyable slot
-                           and K (is_subject aag (fst slot)))
-    (cap_delete slot)"
+                                           and simple_sched_action and pas_refined aag
+                                           and emptyable slot and K (is_subject aag (fst slot)))
+                    (cap_delete slot)"
   unfolding cap_delete_def
-  by(wp rec_del_spec_reads_respects_f | rule use_spec_ev | simp | elim conjE | force)+
+  by (wp rec_del_spec_reads_respects_f | rule use_spec_ev | simp | elim conjE | force)+
 
+end
 
-
-(*NOTE: Required to dance around the issue of the base potentially
-        being zero and thus we can't conclude it is in the current subject.*)
-lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq':
-  "\<lbrakk>pas_cap_cur_auth aag (ArchObjectCap (ASIDPoolCap ptr base)); reads_equiv aag s t;
-    pas_refined aag x\<rbrakk>
-   \<Longrightarrow> arm_asid_table (arch_state s) (asid_high_bits_of base) =
-       arm_asid_table (arch_state t) (asid_high_bits_of base)"
-  apply (subgoal_tac "asid_high_bits_of 0 = asid_high_bits_of 1")
-   apply(case_tac "base = 0")
-    apply(subgoal_tac "is_subject_asid aag 1")
-     apply ((fastforce intro: requiv_arm_asid_table_asid_high_bits_of_asid_eq
-                              aag_cap_auth_ASIDPoolCap_asid)+)[2]
-   apply (auto intro: requiv_arm_asid_table_asid_high_bits_of_asid_eq
-                      aag_cap_auth_ASIDPoolCap_asid)[1]
-  apply (simp add: asid_high_bits_of_def asid_low_bits_def)
-  done
-
-lemma pt_cap_aligned:
-  "\<lbrakk>caps_of_state s p = Some (ArchObjectCap (PageTableCap word x));
-    valid_caps (caps_of_state s) s\<rbrakk>
-   \<Longrightarrow> is_aligned word pt_bits"
-  by (auto simp: obj_ref_of_def pt_bits_def pageBits_def
-          dest!: cap_aligned_valid[OF valid_capsD, unfolded cap_aligned_def,
-                                   THEN conjunct1])
-
-section "globals_equiv"
-
-lemma maskInterrupt_no_mem:
-  "invariant (maskInterrupt a b) (\<lambda>ms. P (underlying_memory ms))"
-  apply(unfold maskInterrupt_def)
-  apply(wp modify_wp)
-  by simp
-
-lemma maskInterrupt_no_exclusive:
-  "invariant (maskInterrupt a b) (\<lambda>ms. P (exclusive_state ms))"
-  apply(unfold maskInterrupt_def)
-  apply(wp modify_wp)
-  by simp
 
 lemma globals_equiv_interrupt_states_update:
-  "globals_equiv st (s\<lparr> interrupt_states := x \<rparr>) = globals_equiv st s"
-  by(auto simp: globals_equiv_def idle_equiv_def)
-
-lemma set_irq_state_valid_global_objs:
-  "invariant (set_irq_state state irq) (valid_global_objs)"
-  apply(simp add: set_irq_state_def)
-  apply(wp modify_wp)
-  apply(fastforce simp: valid_global_objs_def)
-  done
-
-crunch device_state_invs[wp]: maskInterrupt "\<lambda> ms. P (device_state ms)"
-  (ignore_del: maskInterrupt)
-
-lemma set_irq_state_globals_equiv:
-  "invariant (set_irq_state state irq) (globals_equiv st)"
-  apply(simp add: set_irq_state_def)
-  apply(wp dmo_no_mem_globals_equiv maskInterrupt_no_mem maskInterrupt_no_exclusive modify_wp)
-  apply(simp add: globals_equiv_interrupt_states_update)
-  done
+  "globals_equiv st (s\<lparr>interrupt_states := x\<rparr>) = globals_equiv st s"
+  by (auto simp: globals_equiv_def idle_equiv_def)
 
 lemma cancel_all_ipc_globals_equiv':
-  "\<lbrace> globals_equiv st and valid_ko_at_arm \<rbrace>
-   cancel_all_ipc epptr
-   \<lbrace> \<lambda>_. globals_equiv st and valid_ko_at_arm \<rbrace>"
+  "cancel_all_ipc epptr \<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>"
   unfolding cancel_all_ipc_def
-  apply(wp mapM_x_wp[OF _ subset_refl] set_thread_state_globals_equiv
-           set_simple_ko_globals_equiv hoare_vcg_all_lift get_object_inv
-           dxo_wp_weak | wpc | simp
-        | wp (once) hoare_drop_imps)+
-  done
+  by (wp mapM_x_wp[OF _ subset_refl] set_thread_state_globals_equiv
+         set_simple_ko_globals_equiv hoare_vcg_all_lift get_object_inv dxo_wp_weak
+      | wpc | simp | wp (once) hoare_drop_imps)+
 
 lemma cancel_all_ipc_globals_equiv:
-  "\<lbrace> globals_equiv st and valid_ko_at_arm \<rbrace>
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
    cancel_all_ipc epptr
-   \<lbrace> \<lambda>_. globals_equiv st \<rbrace>"
-  apply(rule hoare_strengthen_post[OF cancel_all_ipc_globals_equiv'])
-  by simp
-
-lemma set_notification_globals_equiv:
-  "\<lbrace> globals_equiv st and valid_ko_at_arm \<rbrace>
-  set_notification ptr ntfn
-   \<lbrace> \<lambda>_. globals_equiv st \<rbrace>"
-  unfolding set_simple_ko_def
-  apply(wp set_object_globals_equiv get_object_wp | simp)+
-  apply(fastforce simp: valid_ko_at_arm_def obj_at_def)+
-  done
-
-lemma set_notification_valid_ko_at_arm:
-  "\<lbrace> valid_ko_at_arm \<rbrace> set_notification ptr ntfn \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  unfolding set_simple_ko_def
-  apply (wp get_object_wp)
-  apply(fastforce simp: valid_ko_at_arm_def get_tcb_ko_at obj_at_def)
-done
-
-lemma cancel_all_signals_globals_equiv':
-  "\<lbrace> globals_equiv st and valid_ko_at_arm \<rbrace>
-   cancel_all_signals epptr
-   \<lbrace> \<lambda>_. globals_equiv st and valid_ko_at_arm \<rbrace>"
-  unfolding cancel_all_signals_def
-  apply(wp mapM_x_wp[OF _ subset_refl] set_thread_state_globals_equiv
-           set_notification_valid_ko_at_arm dxo_wp_weak
-           set_notification_globals_equiv hoare_vcg_all_lift | wpc | simp
-        | wp (once) hoare_drop_imps)+
-  done
-
-lemma cancel_all_signals_globals_equiv:
-  "\<lbrace> globals_equiv st and valid_ko_at_arm \<rbrace>
-   cancel_all_signals epptr
-   \<lbrace> \<lambda>_. globals_equiv st \<rbrace>"
-  apply(rule hoare_strengthen_post[OF cancel_all_signals_globals_equiv'])
-  by simp
-
-lemma unbind_notification_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm \<rbrace>
-   unbind_notification t
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding unbind_notification_def
-  by (wp gbn_wp set_bound_notification_globals_equiv set_notification_valid_ko_at_arm
-            set_notification_globals_equiv
-          | wpc
-          | simp)+
-
-lemma unbind_notification_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm \<rbrace>
-   unbind_notification t
-   \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  unfolding unbind_notification_def
-  by (wp gbn_wp set_bound_notification_valid_ko_at_arm set_notification_valid_ko_at_arm
-
-          | wpc
-          | simp)+
-
-lemma unbind_maybe_notification_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm \<rbrace>
-   unbind_maybe_notification a
-   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding unbind_maybe_notification_def
-  by (wp gbn_wp set_bound_notification_globals_equiv set_notification_valid_ko_at_arm
-            set_notification_globals_equiv get_simple_ko_wp
-          | wpc
-          | simp)+
-
-lemma unbind_maybe_notification_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm \<rbrace>
-   unbind_maybe_notification a
-   \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  unfolding unbind_maybe_notification_def
-  by (wp gbn_wp set_bound_notification_valid_ko_at_arm set_notification_valid_ko_at_arm
-         get_simple_ko_wp
-          | wpc
-          | simp)+
+  by (fastforce intro: hoare_strengthen_post[OF cancel_all_ipc_globals_equiv'])
 
 crunch valid_global_objs: fast_finalise "valid_global_objs"
   (wp: crunch_wps dxo_wp_weak ignore: reschedule_required)
 
+lemma tcb_sched_action_enqueue_valid_ko_at_arch[wp]:
+  "tcb_sched_action tcb_sched_enqueue word \<lbrace>valid_ko_at_arch\<rbrace>"
+  by (wpsimp simp: tcb_sched_action_def etcb_at_def)
+
+lemma tcb_sched_action_dequeue_valid_ko_at_arch[wp]:
+  "tcb_sched_action tcb_sched_dequeue word \<lbrace>valid_ko_at_arch\<rbrace>"
+  by (wpsimp simp: tcb_sched_action_def etcb_at_def)
+
+crunch valid_ko_at_arch[wp]: set_message_info "valid_ko_at_arch"
+crunch valid_ko_at_arch[wp]: set_extra_badge "valid_ko_at_arch"
+crunch valid_ko_at_arch[wp]: copy_mrs "valid_ko_at_arch" (wp: mapM_wp')
+
+lemma cancel_all_signals_globals_equiv':
+  "cancel_all_signals epptr \<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>"
+  unfolding cancel_all_signals_def
+  by (wp mapM_x_wp[OF _ subset_refl] set_thread_state_globals_equiv
+         set_simple_ko_globals_equiv hoare_vcg_all_lift get_object_inv dxo_wp_weak
+      | wpc | simp | wp (once) hoare_drop_imps)+
+
+lemma cancel_all_signals_globals_equiv:
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
+   cancel_all_signals epptr
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  by (fastforce intro: hoare_strengthen_post[OF cancel_all_signals_globals_equiv'])
+
+
+context Finalise_IF_1 begin
+
+lemma unbind_notification_globals_equiv:
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
+   unbind_notification t
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding unbind_notification_def
+  by (wpsimp wp: gbn_wp set_bound_notification_globals_equiv set_notification_globals_equiv)
+
+lemma unbind_maybe_notification_globals_equiv:
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
+   unbind_maybe_notification a
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding unbind_maybe_notification_def
+  by (wpsimp wp: gbn_wp set_bound_notification_globals_equiv
+                 set_notification_globals_equiv get_simple_ko_wp)
+
+lemma unbind_notification_valid_ko_at_arch[wp]:
+  "unbind_notification t \<lbrace>valid_ko_at_arch\<rbrace>"
+  unfolding unbind_notification_def
+  by (wpsimp wp: gbn_wp set_bound_notification_valid_ko_at_arch)+
+
+lemma unbind_maybe_notification_valid_ko_at_arch[wp]:
+  "unbind_maybe_notification a \<lbrace>valid_ko_at_arch\<rbrace>"
+  unfolding unbind_maybe_notification_def
+  by (wpsimp wp: gbn_wp set_bound_notification_valid_ko_at_arch get_simple_ko_wp)
+
 lemma fast_finalise_globals_equiv:
-  "\<lbrace> globals_equiv st and valid_ko_at_arm \<rbrace>
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
    fast_finalise cap final
-   \<lbrace> \<lambda>_. globals_equiv st \<rbrace>"
-  apply(case_tac cap)
-  apply(clarsimp simp: when_def | wp cancel_all_ipc_globals_equiv cancel_all_signals_globals_equiv unbind_maybe_notification_globals_equiv | rule conjI)+
-  done
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  apply (cases cap)
+  by (wpsimp wp: cancel_all_ipc_globals_equiv cancel_all_signals_globals_equiv
+                    unbind_maybe_notification_globals_equiv
+              simp: when_def split_del: if_split)+
 
-lemma tcb_sched_action_enqueue_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm\<rbrace> tcb_sched_action tcb_sched_enqueue word \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  apply (simp add: tcb_sched_action_def)
-  apply wp
-  apply (simp add: etcb_at_def)
-  done
-
-lemma tcb_sched_action_dequeue_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm\<rbrace> tcb_sched_action tcb_sched_dequeue word \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  apply (simp add: tcb_sched_action_def)
-  apply wp
-  apply (simp add: etcb_at_def)
- done
-
-crunch valid_ko_at_arm[wp]: fast_finalise "valid_ko_at_arm"
+crunch valid_ko_at_arch[wp]: fast_finalise "valid_ko_at_arch"
   (wp: mapM_x_wp' dxo_wp_weak ignore: reschedule_required)
-crunch valid_ko_at_arm[wp]: set_original "valid_ko_at_arm"
-  (simp: valid_ko_at_arm_def)
-crunch valid_ko_at_arm[wp]: set_cdt "valid_ko_at_arm" (simp: valid_ko_at_arm_def)
 
-crunch valid_ko_at_arm[wp]: cap_insert "valid_ko_at_arm"
-  (wp: hoare_drop_imps dxo_wp_weak simp: crunch_simps ignore: cap_insert_ext)
+crunch valid_ko_at_arch[wp]: cap_insert "valid_ko_at_arch"
+  (wp: hoare_drop_imps dxo_wp_weak simp: crunch_simps simp_del: cap_insert_ext_extended.dxo_eq)
 
-crunch valid_ko_at_arm[wp]: set_message_info "valid_ko_at_arm"
-crunch valid_ko_at_arm[wp]: set_extra_badge "valid_ko_at_arm"
-crunch valid_ko_at_arm[wp]: copy_mrs "valid_ko_at_arm" (wp: mapM_wp')
+lemma transfer_caps_valid_ko_at_arch[wp]:
+  "transfer_caps a b c d e \<lbrace>valid_ko_at_arch\<rbrace>"
+  unfolding transfer_caps_def
+  by (wpsimp wp: transfer_caps_loop_pres cap_insert_valid_ko_at_arch)
 
 crunch globals_equiv[wp]: deleted_irq_handler "globals_equiv st"
 
-lemma transfer_caps_valid_ko_at_arm[wp]:
-  "\<lbrace> valid_ko_at_arm \<rbrace> transfer_caps a b c d e \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
-  unfolding transfer_caps_def
-  by (wpsimp wp: transfer_caps_loop_pres cap_insert_valid_ko_at_arm)
-
 lemma empty_slot_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm\<rbrace> empty_slot s b\<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace> empty_slot s b \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding empty_slot_def post_cap_deletion_def
   by (wpsimp wp: set_cap_globals_equiv'' set_original_globals_equiv hoare_vcg_if_lift2
                  set_cdt_globals_equiv dxo_wp_weak hoare_drop_imps hoare_vcg_all_lift)
@@ -1871,78 +1527,49 @@ lemma empty_slot_globals_equiv:
 crunch globals_equiv: cap_delete_one "globals_equiv st"
   (wp: set_cap_globals_equiv'' hoare_drop_imps simp: crunch_simps unless_def)
 
-crunch valid_ko_at_arm[wp]: thread_set "valid_ko_at_arm" (simp: arm_global_pd_not_tcb)
+(*FIXME: Lots of this stuff should be in arch *)
+crunch globals_equiv[wp]: deleting_irq_handler "globals_equiv st"
 
-lemma set_asid_pool_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm\<rbrace> set_asid_pool a b\<lbrace>\<lambda>_.valid_ko_at_arm\<rbrace>"
-  unfolding set_asid_pool_def
-  apply (wpsimp wp: set_object_wp_strong simp: a_type_def)
-  apply(fastforce simp: valid_ko_at_arm_def get_tcb_ko_at obj_at_def)
-  done
-
-crunch valid_ko_at_arm[wp]: finalise_cap "valid_ko_at_arm"
+crunch valid_ko_at_arch[wp]: finalise_cap "valid_ko_at_arch"
   (wp: hoare_vcg_if_lift2 hoare_drop_imps select_wp modify_wp mapM_wp' dxo_wp_weak
    simp: unless_def crunch_simps
    ignore: empty_slot_ext)
 
-lemma delete_asid_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_arch_state \<rbrace>
-    delete_asid asid pd
-   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding delete_asid_def
-  apply (wp set_vm_root_globals_equiv set_asid_pool_globals_equiv invalidate_asid_entry_globals_equiv
-     flush_space_globals_equiv invalidate_asid_entry_valid_ko_at_arm
-    | wpc | simp add: valid_arch_state_ko_at_arm)+
-done
+crunch valid_ko_at_arch[wp]: setup_reply_master "valid_ko_at_arch"
 
-lemma pagebitsforsize_ge_2[simp] :
-  "2 \<le> pageBitsForSize vmpage_size"
-  apply (induct vmpage_size)
-  apply simp+
-done
+crunch globals_equiv[wp]: cancel_ipc "globals_equiv st"
+  (wp: mapM_x_wp select_inv hoare_drop_imps hoare_vcg_if_lift2 cancel_signal_valid_ko_at_arch
+   simp: unless_def)
 
-lemma arch_finalise_cap_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_global_objs and valid_arch_state and pspace_aligned
-     and valid_vspace_objs and valid_global_refs and valid_vs_lookup\<rbrace>
-     arch_finalise_cap cap b
-   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (induct cap)
-  apply (simp_all add:arch_finalise_cap_def)
-  apply (wp delete_asid_pool_globals_equiv case_option_wp unmap_page_globals_equiv
-            unmap_page_table_globals_equiv delete_asid_globals_equiv |
-         wpc | clarsimp split: bool.splits option.splits | intro impI conjI)+
-done
+lemma suspend_globals_equiv[ wp]:
+  "\<lbrace>globals_equiv st and (\<lambda>s. t \<noteq> idle_thread s) and valid_ko_at_arch\<rbrace> suspend t \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding suspend_def update_restart_pc_def
+  apply (wp tcb_sched_action_extended.globals_equiv dxo_wp_weak)
+       apply simp
+      apply (wp set_thread_state_globals_equiv)
+     apply wp+
+    apply clarsimp
+    apply (rule hoare_vcg_conj_lift)
+     prefer 2
+     apply (rule hoare_drop_imps)
+     apply wp+
+    apply (rule hoare_drop_imps)
+    apply wp+
+  apply auto
+  done
 
-
-lemma arch_finalise_cap_globals_equiv' : "\<lbrace>globals_equiv st and invs\<rbrace>
-  arch_finalise_cap cap b \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (rule hoare_weaken_pre)
-  apply (rule arch_finalise_cap_globals_equiv)
-  apply (simp add: invs_def valid_state_def valid_pspace_def valid_arch_caps_def)
-done
-
-
-lemma mapM_x_swp_store_kernel_base_globals_equiv:
-  "\<lbrace>invs and globals_equiv st and cte_wp_at ((=) (ArchObjectCap (PageDirectoryCap word option)))
-         slot\<rbrace>
-  mapM_x (swp store_pde InvalidPDE)
-        (map ((\<lambda>x. x + word) \<circ> swp (<<) 2)
-          [0.e.(kernel_base >> 20) - 1])
-       \<lbrace>\<lambda>y s. globals_equiv st s \<and>
-              invs s\<rbrace>"
-  apply (rule hoare_pre)
-  apply (wp mapM_x_swp_store_pde_invs_unmap mapM_x_swp_store_pde_globals_equiv)
-  apply clarsimp
-  apply (frule invs_valid_objs)
-  apply (frule invs_valid_global_refs)
-  apply (intro impI conjI allI)
-  apply (simp add: cte_wp_at_page_directory_not_in_globals
-                   cte_wp_at_page_directory_not_in_kernel_mappings
-                   not_in_global_not_arm
-                   pde_ref_def)+
-done
-
-declare arch_get_sanitise_register_info_def[simp]
+lemma finalise_cap_globals_equiv:
+  "\<lbrace>globals_equiv st and (\<lambda>s. \<forall>p. cap = ThreadCap p \<longrightarrow> p \<noteq> idle_thread s)
+                     and valid_global_objs and valid_arch_state and pspace_aligned
+                     and valid_vspace_objs and valid_global_refs and valid_vs_lookup\<rbrace>
+   finalise_cap cap b
+   \<lbrace>\<lambda> _. globals_equiv st\<rbrace>"
+  apply (induct cap; simp)
+  by (wp cancel_all_ipc_globals_equiv cancel_all_ipc_valid_global_objs
+         cancel_all_signals_globals_equiv cancel_all_signals_valid_global_objs
+         arch_finalise_cap_globals_equiv unbind_maybe_notification_globals_equiv
+         unbind_notification_globals_equiv liftM_wp when_def
+      | clarsimp simp: valid_arch_state_ko_at_arch | intro impI conjI)+
 
 end
 

--- a/proof/infoflow/IRQMasks_IF.thy
+++ b/proof/infoflow/IRQMasks_IF.thy
@@ -8,45 +8,76 @@ theory IRQMasks_IF
 imports "Access.ArchDomainSepInv"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
-
 abbreviation irq_masks_of_state :: "det_ext state \<Rightarrow> irq \<Rightarrow> bool" where
   "irq_masks_of_state s \<equiv> irq_masks (machine_state s)"
 
-lemma resetTimer_irq_masks[wp]:
-  "\<lbrace>\<lambda>s. P (irq_masks s)\<rbrace> resetTimer \<lbrace>\<lambda>_ s. P (irq_masks s)\<rbrace>"
-  apply(simp add: resetTimer_def | wp no_irq)+
-  done
-
-lemma storeWord_irq_masks[wp]:
-  "\<lbrace>\<lambda>s. P (irq_masks s)\<rbrace> storeWord x y \<lbrace>\<lambda>_ s. P (irq_masks s)\<rbrace>"
-  apply(wp del: no_irq | simp add: storeWord_def)+
-  done
-
-
 lemma detype_irq_masks[simp]:
   "irq_masks (machine_state (detype S s)) = irq_masks_of_state s"
-  apply(simp add: detype_def)
-  done
-
-lemma delete_objects_irq_masks[wp]:
-  "\<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace> delete_objects param_a param_b
-   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply(simp add: delete_objects_def)
-  apply(wp dmo_wp no_irq_mapM_x no_irq | simp add: freeMemory_def no_irq_storeWord)+
-  done
-
-crunch irq_masks[wp]: cleanCacheRange_PoU "\<lambda>s. P (irq_masks s)"
-   (ignore_del: cleanCacheRange_PoU)
-
-crunch irq_masks[wp]: invoke_untyped "\<lambda>s. P (irq_masks_of_state s)"
-  (ignore: delete_objects wp: crunch_wps dmo_wp
-       wp: mapME_x_inv_wp preemption_point_inv
-     simp: crunch_simps no_irq_clearMemory
-           mapM_x_def_bak unless_def)
+  by (simp add: detype_def)
 
 crunch irq_masks[wp]: cap_insert "\<lambda>s. P (irq_masks_of_state s)"
   (wp: crunch_wps)
+
+lemma invoke_irq_handler_irq_masks:
+  "\<lbrace>domain_sep_inv False st and (\<lambda>s. (\<exists>ptr'. cte_wp_at ((=) (IRQHandlerCap irq)) ptr' s))\<rbrace>
+   invoke_irq_handler blah
+   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  by (clarsimp simp: valid_def domain_sep_inv_def)
+
+lemma empty_slot_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and K (irq_opt = NullCap)\<rbrace>
+   empty_slot slot irq_opt
+   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (wpsimp simp: empty_slot_def post_cap_deletion_def)
+  done
+
+lemma spec_strengthen_errE:
+  "\<lbrakk> s \<turnstile> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E'\<rbrace>; \<And>s r. E' s r \<Longrightarrow> E s r \<rbrakk>
+     \<Longrightarrow> s \<turnstile> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>"
+  by (auto simp: spec_validE_def validE_def valid_def split: sum.splits)
+
+crunch irq_masks[wp]: create_cap "\<lambda>s. P (irq_masks_of_state s)"
+crunch irq_masks[wp]: cap_swap_for_delete "\<lambda>s. P (irq_masks_of_state s)"
+
+
+locale IRQMasks_IF_1 =
+  fixes state_t :: "'s :: state_ext state"
+  assumes resetTimer_irq_masks[wp]:
+    "resetTimer \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace>"
+  and storeWord_irq_masks[wp]:
+    "storeWord x y \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace>"
+  and delete_objects_irq_masks[wp]:
+    "delete_objects ptr bits \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and invoke_untyped_irq_masks[wp]:
+    "invoke_untyped ui \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and finalise_cap_irq_masks[wp]:
+    "finalise_cap cap final \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and send_signal_irq_masks[wp]:
+    "send_signal ntfnptr badge \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and handle_vm_fault_irq_masks[wp]:
+    "handle_vm_fault t vmft \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and handle_hypervisor_fault_irq_masks[wp]:
+    "handle_hypervisor_fault t hvft \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and handle_interrupt_irq_masks:
+    "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and K (irq \<le> maxIRQ)\<rbrace>
+     handle_interrupt irq
+     \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  and arch_invoke_irq_control_irq_masks:
+    "\<lbrace>domain_sep_inv False st and arch_irq_control_inv_valid ivk\<rbrace>
+     arch_invoke_irq_control ivk
+     \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  and dmo_getActiveIRQ_irq_masks[wp]:
+    "do_machine_op (getActiveIRQ in_kernel) \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and dmo_getActiveIRQ_return_axiom[wp]:
+    "\<lbrace>\<top>\<rbrace>
+     do_machine_op (getActiveIRQ in_kernel)
+     \<lbrace>\<lambda>rv s :: det_state. (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)\<rbrace>"
+  and activate_thread_irq_masks[wp]:
+    "activate_thread \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and schedule_irq_masks[wp]:
+    "schedule \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+begin
 
 crunch irq_masks[wp]: set_extra_badge "\<lambda>s. P (irq_masks_of_state s)"
   (wp: crunch_wps dmo_wp)
@@ -54,287 +85,166 @@ crunch irq_masks[wp]: set_extra_badge "\<lambda>s. P (irq_masks_of_state s)"
 crunch irq_masks[wp]: send_ipc "\<lambda>s. P (irq_masks_of_state s)"
   (wp: crunch_wps simp: crunch_simps ignore: const_on_failure rule: transfer_caps_loop_pres)
 
-lemma invoke_irq_handler_irq_masks:
-  shows
-  "\<lbrace>domain_sep_inv False st and (\<lambda>s. (\<exists>ptr'. cte_wp_at ((=) (IRQHandlerCap irq)) ptr' s))\<rbrace>
-    invoke_irq_handler blah
-   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply(clarsimp simp: valid_def domain_sep_inv_def)
-  done
-
-
-lemma empty_slot_irq_masks:
-  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and K (irq_opt = NullCap)\<rbrace>
-   empty_slot slot irq_opt
-   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply(rule hoare_gen_asm)
-  apply(simp add: empty_slot_def post_cap_deletion_def | wp)+
-  done
-
-crunch irq_masks[wp]: do_reply_transfer "\<lambda>s. P (irq_masks_of_state s)"
-  (wp: crunch_wps empty_slot_irq_masks simp: crunch_simps unless_def)
-
-
-crunch irq_masks[wp]: finalise_cap "\<lambda>s. P (irq_masks_of_state s)"
-  (wp: select_wp crunch_wps dmo_wp no_irq simp: crunch_simps no_irq_setHardwareASID no_irq_set_current_pd no_irq_invalidateLocalTLB_ASID no_irq_invalidateLocalTLB_VAASID no_irq_cleanByVA_PoU)
-
-crunch irq_masks[wp]: send_signal "\<lambda>s. P (irq_masks_of_state s)"
-  (wp: crunch_wps ignore: do_machine_op wp: dmo_wp simp: crunch_simps)
-
-lemma handle_interrupt_irq_masks:
-  notes no_irq[wp del]
-
-  shows
-  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and K (irq \<le> maxIRQ)\<rbrace>
-   handle_interrupt irq
-   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply(simp add: handle_interrupt_def split del: if_split)
-  apply (rule hoare_pre)
-   apply (rule hoare_if)
-    apply simp
-   apply( wp dmo_wp
-        | simp add: ackInterrupt_def maskInterrupt_def when_def split del: if_split
-        | wpc
-        | simp add: get_irq_state_def handle_reserved_irq_def
-        | wp (once) hoare_drop_imp)+
-  apply (fastforce simp: domain_sep_inv_def)
-  done
-
-crunch irq_masks[wp]: cap_swap_for_delete "\<lambda>s. P (irq_masks_of_state s)"
-
 (* Clagged from re_del_domain_sep_inv' -- would Dan's annotations be good here? *)
 lemma rec_del_irq_masks':
-  notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del]
-         rec_del.simps[simp del]
-  shows
-  "s \<turnstile> \<lbrace> (\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
-     (rec_del call)
-   \<lbrace>\<lambda> a s. (case call of (FinaliseSlotCall x y) \<Rightarrow> y \<or> fst a \<longrightarrow> snd a = NullCap | _ \<Rightarrow> True) \<and> domain_sep_inv False st s \<and> P (irq_masks_of_state s)\<rbrace>,\<lbrace>\<lambda>_. domain_sep_inv False st and (\<lambda>s. P (irq_masks_of_state s))\<rbrace>"
-  proof (induct s arbitrary: rule: rec_del.induct, simp_all only: rec_del_fails hoare_fail_any)
+  notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del] rec_del.simps[simp del]
+  shows "s \<turnstile> \<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+             rec_del call
+             \<lbrace>\<lambda>a s. (case call of (FinaliseSlotCall x y) \<Rightarrow> y \<or> fst a \<longrightarrow> snd a = NullCap
+                                | _ \<Rightarrow> True) \<and>
+                    domain_sep_inv False st s \<and> P (irq_masks_of_state s)\<rbrace>,
+             \<lbrace>\<lambda>_. domain_sep_inv False st and (\<lambda>s. P (irq_masks_of_state s))\<rbrace>"
+proof (induct s arbitrary: rule: rec_del.induct, simp_all only: rec_del_fails hoare_fail_any)
   case (1 slot exposed s) show ?case
-    apply(simp add: split_def rec_del.simps)
-    apply(wp empty_slot_domain_sep_inv empty_slot_irq_masks drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] | simp)+
-    apply(rule spec_strengthen_postE[OF "1.hyps", simplified])
+    apply (wpsimp wp: empty_slot_domain_sep_inv empty_slot_irq_masks
+                      drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp]
+                simp: split_def rec_del.simps)
+    apply (fastforce intro: spec_strengthen_postE[OF "1.hyps", simplified])
+    done
+next
+  case (2 slot exposed s) show ?case
+    apply (simp add: rec_del.simps split del: if_split)
+    apply (rule hoare_pre_spec_validE)
+     apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
+            | simp add: split_def split del: if_split)+
+           apply (rule spec_strengthen_postE)
+            apply (rule "2.hyps"[simplified], fastforce+)
+          apply (rule drop_spec_validE, (wp preemption_point_inv | simp)+)[1]
+         apply simp
+         apply (rule spec_strengthen_postE)
+          apply (rule "2.hyps"[simplified], fastforce+)
+        apply (wp finalise_cap_domain_sep_inv_cap get_cap_wp
+                  finalise_cap_returns_NullCap[where irqs=False, simplified]
+                  drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
+               | simp split del: if_split
+               | wp (once) hoare_drop_imps)+
+    apply (blast dest: cte_wp_at_domain_sep_inv_cap)
+    done
+next
+  case (3 ptr bits n slot s) show ?case
+    apply (simp add: rec_del.simps)
+    apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp])
+    apply (rule hoare_pre_spec_validE)
+     apply (wp drop_spec_validE[OF assertE_wp])
     apply fastforce
     done
-  next
-  case (2 slot exposed s) show ?case
-    apply(simp add: rec_del.simps split del: if_split)
-    apply(rule hoare_pre_spec_validE)
-     apply(wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
-          |simp add: split_def split del: if_split)+
-           apply(rule spec_strengthen_postE)
-            apply(rule "2.hyps"[simplified], fastforce+)
-          apply(rule drop_spec_validE, (wp preemption_point_inv | simp)+)[1]
-         apply simp
-         apply(rule spec_strengthen_postE)
-          apply(rule "2.hyps"[simplified], fastforce+)
-         apply(wp  finalise_cap_domain_sep_inv_cap get_cap_wp
-                   finalise_cap_returns_NullCap[where irqs=False, simplified]
-                   drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
-               |simp split del: if_split
-               |wp (once) hoare_drop_imps)+
-    apply(blast dest: cte_wp_at_domain_sep_inv_cap)
-    done
-  next
-  case (3 ptr bits n slot s) show ?case
-    apply(simp add: rec_del.simps)
-    apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp])
-    apply(rule hoare_pre_spec_validE)
-    apply (wp drop_spec_validE[OF assertE_wp])
-    apply(fastforce)
-    done
-  next
+next
   case (4 ptr bits n slot s) show ?case
-    apply(simp add: rec_del.simps)
-    apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
-              drop_spec_validE[OF assertE_wp] get_cap_wp | simp)+
+    apply (simp add: rec_del.simps)
+    apply (wpsimp wp: drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp]
+                      set_cap_domain_sep_inv drop_spec_validE[OF assertE_wp] get_cap_wp)
     apply (rule spec_strengthen_postE[OF "4.hyps", simplified])
-     apply(simp add: returnOk_def return_def)
-    apply(clarsimp simp: domain_sep_inv_cap_def)
+     apply (simp add: returnOk_def return_def)
+    apply (clarsimp simp: domain_sep_inv_cap_def)
     done
-  qed
-
-lemma spec_strengthen_errE:
-  "\<lbrakk>s \<turnstile> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E'\<rbrace>; \<And>s r. E' s r \<Longrightarrow> E s r\<rbrakk> \<Longrightarrow> s \<turnstile> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>"
-  apply(auto simp: spec_validE_def validE_def valid_def split: sum.splits)
-  done
-
+qed
 
 lemma rec_del_irq_masks:
-  "\<lbrace> (\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
-     (rec_del call)
-   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>,\<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply(rule use_spec)
-  apply(rule hoare_pre_spec_validE)
-   apply(rule spec_strengthen_postE)
-   apply(rule spec_strengthen_errE[OF rec_del_irq_masks'])
-  apply auto
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+   rec_del call
+   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>, \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  apply (rule use_spec)
+  apply (rule hoare_pre_spec_validE)
+   apply (rule spec_strengthen_postE)
+    apply (rule spec_strengthen_errE[OF rec_del_irq_masks'])
+    apply auto
   done
 
 lemma cap_delete_irq_masks:
-  "\<lbrace> (\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
-     cap_delete blah
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+   cap_delete blah
    \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>,\<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
   by (simp add: cap_delete_def) (wpsimp wp: rec_del_irq_masks)
 
-lemma arch_invoke_irq_control_irq_masks:
-  "\<lbrace>domain_sep_inv False st and arch_irq_control_inv_valid invok\<rbrace>
-   arch_invoke_irq_control invok
-   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply(case_tac invok)
-  apply(clarsimp simp: arch_irq_control_inv_valid_def domain_sep_inv_def valid_def)
-  done
-
 lemma invoke_irq_control_irq_masks:
-  "\<lbrace>domain_sep_inv False st and irq_control_inv_valid invok\<rbrace>
-   invoke_irq_control invok
+  "\<lbrace>domain_sep_inv False (st :: 's state) and irq_control_inv_valid ivk\<rbrace>
+   invoke_irq_control ivk
    \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply(case_tac invok)
-   apply(clarsimp simp: irq_control_inv_valid_def domain_sep_inv_def valid_def)
+  apply (cases ivk)
+   apply (clarsimp simp: irq_control_inv_valid_def domain_sep_inv_def valid_def)
   apply (clarsimp simp: arch_invoke_irq_control_irq_masks)
   done
 
-crunch irq_masks[wp]: arch_perform_invocation, bind_notification "\<lambda>s. P (irq_masks_of_state s)"
-  (wp: dmo_wp crunch_wps no_irq simp: crunch_simps no_irq_cleanByVA_PoU no_irq_invalidateLocalTLB_ASID no_irq_do_flush)
+end
+
+
+crunch irq_masks[wp]: cancel_ipc "\<lambda>s. P (irq_masks_of_state s)"
+  (wp: select_wp crunch_wps  simp: crunch_simps)
 
 crunch irq_masks[wp]: restart, set_mcpriority "\<lambda>s. P (irq_masks_of_state s)"
 
+crunch irq_masks[wp]: bind_notification, unbind_notification "\<lambda>s. P (irq_masks_of_state s)"
+  (wp: dmo_wp crunch_wps no_irq simp: crunch_simps)
+
+crunch irq_masks[wp]: suspend "\<lambda>s. P (irq_masks_of_state s)"
+
 lemma checked_insert_irq_masks[wp]:
-  "\<lbrace>\<lambda> s. P (irq_masks_of_state s)\<rbrace>
-   check_cap_at a b
-           (check_cap_at c d
-             (cap_insert e f g))
-          \<lbrace>\<lambda>r s. P (irq_masks_of_state s)\<rbrace>"
-  apply(wp | simp add: check_cap_at_def)+
-  done
-
-(* FIXME: remove duplication in this proof -- requires getting the wp
-          automation to do the right thing with dropping imps in validE
-          goals *)
-lemma invoke_tcb_irq_masks:
-  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and
-    Tcb_AI.tcb_inv_wf tinv\<rbrace>
-   invoke_tcb tinv
-   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply(case_tac tinv)
-       apply((wp restart_irq_masks hoare_vcg_if_lift  mapM_x_wp[OF _ subset_refl]
-            | wpc
-            | simp split del: if_split add: check_cap_at_def
-            | clarsimp)+)[3]
-    defer
-    apply((wp | simp )+)[2]
-  (* NotificationControl *)
-   apply (rename_tac option)
-   apply (case_tac option)
-    apply ((wp | simp)+)[2]
-  (* just ThreadControl left *)
-  apply (simp add: split_def cong: option.case_cong)
-
-  apply (wp hoare_vcg_all_lift_R
-            hoare_vcg_all_lift hoare_vcg_const_imp_lift_R
-            checked_cap_insert_domain_sep_inv
-            cap_delete_deletes
-            cap_delete_valid_cap cap_delete_cte_at
-        |wpc
-        |simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
-                  tcb_at_st_tcb_at
-        |strengthen use_no_cap_to_obj_asid_strg)+
-     apply(rule hoare_post_impErr[OF cap_delete_irq_masks[where P=P]])
-      apply blast
-     apply blast
-    apply (wp hoare_vcg_all_lift_R
-              hoare_vcg_all_lift hoare_vcg_const_imp_lift_R
-              checked_cap_insert_domain_sep_inv
-              cap_delete_deletes
-              cap_delete_valid_cap cap_delete_cte_at
-          |wpc
-          |simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
-                    tcb_at_st_tcb_at
-          |strengthen use_no_cap_to_obj_asid_strg)+
-    apply(rule_tac Q="\<lambda> r s. domain_sep_inv False st s \<and> P (irq_masks_of_state s)" and E="\<lambda>_ s. P (irq_masks_of_state s)" in hoare_post_impErr)
-      apply(wp hoare_vcg_conj_liftE1 cap_delete_irq_masks)
-     apply fastforce
-    apply blast
-   apply (wp static_imp_wp hoare_vcg_all_lift_R
-             hoare_vcg_all_lift hoare_vcg_const_imp_lift_R
-             checked_cap_insert_domain_sep_inv
-             cap_delete_deletes
-             cap_delete_valid_cap cap_delete_cte_at
-         |wpc
-         |simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
-                   tcb_at_st_tcb_at
-         |strengthen use_no_cap_to_obj_asid_strg)+
-   apply(rule_tac Q="\<lambda> r s. domain_sep_inv False st s \<and> P (irq_masks_of_state s)" and E="\<lambda>_ s. P (irq_masks_of_state s)" in hoare_post_impErr)
-     apply(wp hoare_vcg_conj_liftE1 cap_delete_irq_masks)
-    apply fastforce
-   apply blast
-  apply(rule hoare_pre)
-  apply(simp add: option_update_thread_def tcb_cap_cases_def
-       | wp static_imp_wp hoare_vcg_all_lift
-            thread_set_emptyable
-            thread_set_valid_cap
-            thread_set_cte_at  thread_set_no_cap_to_trivial
-       | wpc)+
-  by fastforce+
+  "check_cap_at a b (check_cap_at c d (cap_insert e f g)) \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  by (wpsimp simp: check_cap_at_def)
 
 crunch irq_masks[wp]: cap_move "\<lambda>s. P (irq_masks_of_state s)"
 
-lemma irq_state_independent_irq_masks:
-  "irq_state_independent (\<lambda>s. P (irq_masks s))"
-  apply(clarsimp simp: irq_state_independent_def)
-  done
-
 lemma preemption_point_irq_masks[wp]:
-  "\<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace> preemption_point \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  "preemption_point \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
   by (wp preemption_point_inv, simp+)
+
+crunch irq_masks[wp]: cancel_badged_sends "\<lambda>s. P (irq_masks_of_state s)"
+  (wp: crunch_wps dmo_wp no_irq hoare_unless_wp
+   simp: filterM_mapM crunch_simps no_irq_clearMemory
+   ignore: filterM)
+
+
+context IRQMasks_IF_1 begin
 
 lemma cap_revoke_irq_masks':
   notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del]
-  shows
-  "s \<turnstile> \<lbrace> (\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
-   cap_revoke slot
-   \<lbrace> \<lambda>_ s. P (irq_masks_of_state s)\<rbrace>, \<lbrace> \<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  proof(induct rule: cap_revoke.induct[where ?a1.0=s])
+  shows "s \<turnstile> \<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+             cap_revoke slot
+             \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>, \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+proof (induct rule: cap_revoke.induct[where ?a1.0=s])
   case (1 slot s)
   show ?case
-  apply(subst cap_revoke.simps)
-  apply(rule hoare_pre_spec_validE)
-   apply (wp "1.hyps")
-           apply(wp spec_valid_conj_liftE2 | simp)+
-           apply(wp drop_spec_validE[OF valid_validE[OF preemption_point_irq_masks]]
-                    drop_spec_validE[OF valid_validE[OF preemption_point_domain_sep_inv]]
-                    cap_delete_domain_sep_inv cap_delete_irq_masks
-                    drop_spec_validE[OF assertE_wp] drop_spec_validE[OF returnOk_wp]
-                    drop_spec_validE[OF liftE_wp] select_wp
-                    drop_spec_validE[OF  hoare_vcg_conj_liftE1]
-                | simp | wp (once) hoare_drop_imps)+
-  apply fastforce
-  done
-  qed
+    apply (subst cap_revoke.simps)
+    apply (rule hoare_pre_spec_validE)
+     apply (wp "1.hyps")
+            apply (wp spec_valid_conj_liftE2 | simp)+
+            apply (wp drop_spec_validE[OF valid_validE[OF preemption_point_irq_masks]]
+                      drop_spec_validE[OF valid_validE[OF preemption_point_domain_sep_inv]]
+                      cap_delete_domain_sep_inv cap_delete_irq_masks
+                      drop_spec_validE[OF assertE_wp] drop_spec_validE[OF returnOk_wp]
+                      drop_spec_validE[OF liftE_wp] select_wp
+                      drop_spec_validE[OF  hoare_vcg_conj_liftE1]
+                   | simp | wp (once) hoare_drop_imps)+
+    apply fastforce
+    done
+qed
 
 lemmas cap_revoke_irq_masks = use_spec(2)[OF cap_revoke_irq_masks']
 
-crunch irq_masks[wp]: cancel_badged_sends "\<lambda>s. P (irq_masks_of_state s)"
-  (wp: crunch_wps dmo_wp no_irq hoare_unless_wp simp: filterM_mapM crunch_simps no_irq_clearMemory no_irq_invalidateLocalTLB_ASID
-   ignore: filterM)
-
 lemma finalise_slot_irq_masks:
-  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace> finalise_slot p e \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply(simp add: finalise_slot_def | wp rec_del_irq_masks)+
-  done
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+   finalise_slot p e
+   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  by (simp add: finalise_slot_def | wp rec_del_irq_masks)+
 
 lemma invoke_cnode_irq_masks:
-  "\<lbrace> (\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and
-     valid_cnode_inv ci\<rbrace>
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and valid_cnode_inv ci\<rbrace>
    invoke_cnode ci
    \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
   unfolding invoke_cnode_def
-  apply(case_tac ci)
-        apply(wp cap_insert_irq_masks cap_move_irq_masks cap_revoke_irq_masks[where st=st] cap_delete_irq_masks[where st=st] | simp split del: if_split)+
-    apply(rule hoare_pre)
-     by(wp hoare_vcg_all_lift  | simp | wpc | wp (once) hoare_drop_imps | rule hoare_pre)+
+  apply (cases ci)
+  by (wpsimp wp: cap_move_irq_masks cap_insert_irq_masks hoare_vcg_all_lift hoare_drop_imps
+                 cap_revoke_irq_masks[where st=st] cap_delete_irq_masks[where st=st]
+      split_del: if_split)+
+
+crunch irq_masks[wp]: handle_fault "\<lambda>s. P (irq_masks_of_state s)"
+  (simp: crunch_simps wp: crunch_wps)
+
+crunch irq_masks[wp]: reply_from_kernel "\<lambda>s. P (irq_masks_of_state s)"
+  (simp: crunch_simps wp: crunch_wps)
+
+end
+
 
 fun irq_of_handler_inv where
   "irq_of_handler_inv (ACKIrq irq) = irq" |
@@ -343,52 +253,62 @@ fun irq_of_handler_inv where
 
 crunch irq_masks[wp]: invoke_domain "\<lambda>s. P (irq_masks_of_state s)"
 
-lemma perform_invocation_irq_masks:
-  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and (\<lambda>s. (\<forall> blah. oper = InvokeIRQHandler blah \<longrightarrow>  (\<exists>ptr'. cte_wp_at ((=) (IRQHandlerCap (irq_of_handler_inv blah))) ptr' s))) and domain_sep_inv False st and valid_invocation oper\<rbrace>
-  perform_invocation blocking calling oper
-  \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply(case_tac oper)
-          apply(simp | wp invoke_tcb_irq_masks invoke_cnode_irq_masks[where st=st] invoke_irq_control_irq_masks[where st=st] invoke_irq_handler_irq_masks[where st=st])+
-   apply blast
-  apply(simp | wp)+
-  done
-
-crunch irq_masks[wp]: handle_fault "\<lambda>s. P (irq_masks_of_state s)"
-  (simp: crunch_simps wp: crunch_wps)
-
-crunch irq_masks[wp]: reply_from_kernel "\<lambda>s. P (irq_masks_of_state s)"
-  (simp: crunch_simps wp: crunch_wps)
-
-
-
 lemma decode_invocation_IRQHandlerCap:
-  "\<lbrace> cte_wp_at ((=) cap) slot \<rbrace>
+  "\<lbrace>cte_wp_at ((=) cap) slot\<rbrace>
    decode_invocation label args cap_index slot cap blah
-       \<lbrace>\<lambda>rv s.
-           (\<forall>x. rv = InvokeIRQHandler x \<longrightarrow>
-                (\<exists>a b. cte_wp_at
-                        ((=) (IRQHandlerCap (irq_of_handler_inv x)))
-                        (a, b) s))\<rbrace>,-"
-  apply(simp add: decode_invocation_def split del: if_split)
-  apply(rule hoare_pre)
+   \<lbrace>\<lambda>rv s. \<forall>x. rv = InvokeIRQHandler x
+               \<longrightarrow> (\<exists>a b. cte_wp_at ((=) (IRQHandlerCap (irq_of_handler_inv x))) (a, b) s)\<rbrace>, -"
+  apply (simp add: decode_invocation_def split del: if_split)
+  apply (rule hoare_pre)
    apply (wp | wpc | simp add: o_def)+
        apply (rule hoare_post_imp_R[where Q'="\<top>\<top>"])
         apply wp
        apply (clarsimp simp: uncurry_def)
-      apply(wp | wpc | simp add: decode_irq_handler_invocation_def o_def split del: if_split)+
-  apply (safe | rule TrueI | simp add: op_equal | rule exI[where x="fst slot"], rule exI[where x="snd slot"])+
+      apply (wp | wpc | simp add: decode_irq_handler_invocation_def o_def split del: if_split)+
+  apply (safe | simp add: op_equal | rule exI[where x="fst slot"] exI[where x="snd slot"])+
   done
 
+lemma handle_yield_irq_masks_of_state[wp]:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and invs\<rbrace>
+   handle_yield
+   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  by (wpsimp simp: handle_yield_def)
+
+
+locale IRQMasks_IF_2 = IRQMasks_IF_1 state_t
+  for state_t :: "'s :: state_ext state" +
+  assumes do_reply_transfer_irq_masks[wp]:
+    "do_reply_transfer sender receiver slot grant \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and arch_perform_invocation_irq_masks[wp]:
+    "arch_perform_invocation i \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and invoke_tcb_irq_masks:
+    "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and tcb_inv_wf tinv\<rbrace>
+     invoke_tcb tinv
+     \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+begin
+
+lemma perform_invocation_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and
+    (\<lambda>s. (\<forall>blah. oper = InvokeIRQHandler blah
+                 \<longrightarrow> (\<exists>ptr'. cte_wp_at ((=) (IRQHandlerCap (irq_of_handler_inv blah))) ptr' s))) and
+    domain_sep_inv False (st :: 's state) and valid_invocation oper\<rbrace>
+   perform_invocation blocking calling oper
+   \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  apply (cases oper)
+  by (wpsimp wp: invoke_tcb_irq_masks invoke_cnode_irq_masks[where st=st]
+                 invoke_irq_control_irq_masks[where st=st]
+                 invoke_irq_handler_irq_masks[where st=st]
+      | fastforce)+
+
 lemma handle_invocation_irq_masks:
-  "\<lbrace> (\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and invs\<rbrace>
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and invs\<rbrace>
    handle_invocation calling blocking
-   \<lbrace> \<lambda> rv s. P (irq_masks_of_state s) \<rbrace>"
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
   apply (simp add: handle_invocation_def ts_Restart_case_helper split_def
-                   liftE_liftM_liftME liftME_def bindE_assoc
-              split del: if_split)
-  apply(wp static_imp_wp syscall_valid perform_invocation_irq_masks[where st=st] hoare_vcg_all_lift hoare_vcg_ex_lift decode_invocation_IRQHandlerCap
-       | simp split del: if_split)+
-  apply(simp add: invs_valid_objs)
+                   liftE_liftM_liftME liftME_def bindE_assoc)
+  apply (wp static_imp_wp syscall_valid perform_invocation_irq_masks[where st=st]
+            hoare_vcg_all_lift hoare_vcg_ex_lift decode_invocation_IRQHandlerCap
+         | simp add: invs_valid_objs)+
   done
 
 crunch irq_masks[wp]: handle_reply "\<lambda>s. P (irq_masks_of_state s)"
@@ -396,72 +316,39 @@ crunch irq_masks[wp]: handle_reply "\<lambda>s. P (irq_masks_of_state s)"
 crunch irq_masks[wp]: handle_recv "\<lambda>s. P (irq_masks_of_state s)"
   (wp: crunch_wps simp: crunch_simps)
 
-crunch irq_masks[wp]: handle_vm_fault, handle_hypervisor_fault "\<lambda>s. P (irq_masks_of_state s)"
-  (wp: dmo_wp no_irq ignore: getFAR getDFSR getIFSR simp: no_irq_getDFSR no_irq_getFAR no_irq_getIFSR)
-
-lemma dmo_getActiveIRQ_irq_masks[wp]:
-  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s))\<rbrace>
-    do_machine_op (getActiveIRQ in_kernel)
-    \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)  \<rbrace>"
-  apply(rule hoare_pre, rule dmo_wp)
-  apply(simp add: getActiveIRQ_def | wp | simp add: no_irq_def | clarsimp)+
-  done
-
-lemma dmo_getActiveIRQ_return_axiom[wp]:
-  "\<lbrace>\<top>\<rbrace>
-  do_machine_op (getActiveIRQ in_kernel)
-  \<lbrace>(\<lambda>rv s. (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)) \<rbrace>"
-  apply (simp add: getActiveIRQ_def)
-  apply(rule hoare_pre, rule dmo_wp)
-   apply (insert irq_oracle_max_irq)
-   apply (wp alternative_wp select_wp dmo_getActiveIRQ_irq_masks)
-  apply clarsimp
-  done
-
-
-lemma handle_yield_irq_masks_of_state[wp]:
-  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and invs\<rbrace>
-  handle_yield
-  \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
-  apply (simp add: handle_yield_def)
-  apply wp
-  apply simp
-  done
-
 lemma handle_event_irq_masks:
-  "\<lbrace> (\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and invs\<rbrace>
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and invs\<rbrace>
    handle_event ev
-   \<lbrace> \<lambda> rv s. P (irq_masks_of_state s) \<rbrace>"
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
   apply ((case_tac ev, rename_tac syscall, case_tac syscall);
-    (solves \<open>(simp add: handle_send_def handle_call_def
-                 | wp handle_invocation_irq_masks[where st=st] handle_interrupt_irq_masks[where st=st]
-                      hoare_vcg_all_lift
-                 | wpc
-                 | wp (once) hoare_drop_imps)+\<close>)?)
-  apply (rule hoare_pre)
+         (solves \<open>(simp add: handle_send_def handle_call_def
+                   | wp handle_invocation_irq_masks[where st=st]
+                        handle_interrupt_irq_masks[where st=st]
+                         hoare_vcg_all_lift
+                   | wpc
+                   | wp (once) hoare_drop_imps)+\<close>)?)
   apply simp
-  apply (wp handle_interrupt_irq_masks[where st=st] | wpc | simp )+
-   apply (rule_tac Q="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s
-                        \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_strengthen_post)
-    apply (wp | clarsimp)+
+  apply (wp handle_interrupt_irq_masks[where st=st] | wpc | simp)+
+   apply (rule_tac Q="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s \<and>
+                             (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_strengthen_post)
+    apply wpsimp+
   done
-
-crunch irq_masks[wp]: activate_thread "\<lambda>s. P (irq_masks_of_state s)"
-
-crunch irq_masks[wp]: schedule "\<lambda>s. P (irq_masks_of_state s)"
-  (wp: dmo_wp alternative_wp select_wp crunch_wps simp: crunch_simps clearExMonitor_def)
 
 lemma call_kernel_irq_masks:
-  "\<lbrace> (\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and einvs and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and einvs
+                                   and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
    call_kernel ev
-   \<lbrace> \<lambda> rv s. P (irq_masks_of_state s) \<rbrace>"
-  apply(simp add: call_kernel_def)
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  apply (simp add: call_kernel_def)
   apply (wp handle_interrupt_irq_masks[where st=st])+
-    apply (rule_tac Q="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_strengthen_post)
+    apply (rule_tac Q="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s \<and>
+                              (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_strengthen_post)
      apply (wp | simp)+
-   apply(rule_tac Q="\<lambda> x s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s" and F="E" for E in hoare_post_impErr)
-     apply(rule valid_validE)
-     apply(wp handle_event_irq_masks[where st=st] valid_validE[OF handle_event_domain_sep_inv] | simp)+
+   apply (rule_tac Q="\<lambda>x s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s"
+               and F="E" for E in hoare_post_impErr)
+     apply (rule valid_validE)
+     apply (wp handle_event_irq_masks[where st=st] valid_validE[OF handle_event_domain_sep_inv]
+            | simp)+
   done
 
 end

--- a/proof/infoflow/InfoFlow.thy
+++ b/proof/infoflow/InfoFlow.thy
@@ -16,12 +16,8 @@ text \<open>
 
 
 theory InfoFlow
-imports
-  "Access.ArchSyscall_AC"
-  "Lib.EquivValid"
+imports ArchInfoFlow
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 section \<open>Scheduler domain constraint\<close>
 
@@ -40,26 +36,6 @@ definition pas_domains_distinct :: "('a, 'b) PAS_scheme \<Rightarrow> bool"
   where
     "pas_domains_distinct aag \<equiv> \<forall>d. \<exists>l. pasDomainAbs aag d = {l}"
 
-lemma pas_domains_distinct_inj:
-  "\<lbrakk> pas_domains_distinct aag;
-     l1 \<in> pasDomainAbs aag d;
-     l2 \<in> pasDomainAbs aag d \<rbrakk> \<Longrightarrow>
-   l1 = l2"
-  apply (clarsimp simp: pas_domains_distinct_def)
-  apply (drule_tac x=d in spec)
-  apply auto
-  done
-
-lemma domain_has_unique_label:
-  "pas_domains_distinct aag \<Longrightarrow> \<exists>l. pasDomainAbs aag d = {l}"
-  by (simp add: pas_domains_distinct_def)
-
-lemma domain_has_the_label:
-  "pas_domains_distinct aag \<Longrightarrow> l \<in> pasDomainAbs aag d \<Longrightarrow> the_elem (pasDomainAbs aag d) = l"
-  apply (simp add: pas_domains_distinct_def)
-  apply (metis singletonD the_elem_eq)
-  done
-
 
 section \<open>Reading: subjectReads and associated equivalence properties\<close>
 
@@ -77,17 +53,16 @@ text\<open>We take the authority graph from the access proofs. We identify each
 (* TODO: consider putting the current subject as a parameter and restricting
          the inductive rules to require that 'a' is the current subject *)
 inductive_set subjectReads :: "'a auth_graph \<Rightarrow> 'a \<Rightarrow> 'a set"
-  for g :: "'a auth_graph" and l :: "'a"
-where
+  for g :: "'a auth_graph" and l :: "'a" where
   (* clearly, l can read from anything it has Read authority to *)
-  reads_read: "(l,Read,l') \<in> g \<Longrightarrow>  l' \<in> subjectReads g l" |
+  reads_read: "(l,Read,l') \<in> g \<Longrightarrow>  l' \<in> subjectReads g l"
   (* l can read from itself *)
-  reads_lrefl[simp,intro!]: "l \<in> subjectReads g l" |
+| reads_lrefl[simp,intro!]: "l \<in> subjectReads g l"
   (* if l has SyncSend or Receive authority to an endpoint, l can read it *)
-  reads_ep:
-  "\<lbrakk>(l,auth,ep) \<in> g;  auth \<in> {SyncSend,Receive}\<rbrakk> \<Longrightarrow>
-   ep \<in> subjectReads g l" |
-  reads_read_queued_thread_read_ep:
+|  reads_ep:
+  "\<lbrakk> (l,auth,ep) \<in> g; auth \<in> {SyncSend,Receive} \<rbrakk>
+     \<Longrightarrow> ep \<in> subjectReads g l"
+|  reads_read_queued_thread_read_ep:
   (* if someone can send on or reset an endpoint, and l can read from a thread t
      that can receive or send synchronously on that endpoint, then l needs to
      be able to read from the endpoint too. This is because the thread t might
@@ -95,38 +70,37 @@ where
      party completes the rendezvous,
      the affects caused to t depend of course on the state of the endpoint.
      Since t is in l's domain, the ep better be too. *)
-  "\<lbrakk>(a, auth', ep) \<in> g; auth' \<in> {Notify,SyncSend,Reset};
-    (t, auth, ep) \<in> g; auth \<in> {SyncSend, Receive};
-   t \<in> subjectReads g l\<rbrakk>
-   \<Longrightarrow> ep \<in> subjectReads g l" |
+  "\<lbrakk> (a, auth', ep) \<in> g; auth' \<in> {Notify,SyncSend,Reset};
+     (t, auth, ep) \<in> g; auth \<in> {SyncSend, Receive}; t \<in> subjectReads g l \<rbrakk>
+     \<Longrightarrow> ep \<in> subjectReads g l"
   (* if someone, t, can write to a page, and the page is in l's domain, that the
      writer better be too. This is needed for when the page is t's ipc buffer,
      and t is blocked on an IPC and the other party completes the operation.
      The affects caused to the page in question naturally depend on t's state,
      so if the page is part of l's domain, t better be too. *)
-  reads_read_page_read_thread:
-  "\<lbrakk>b \<in> subjectReads g l; (t,Write,b) \<in> g\<rbrakk> \<Longrightarrow>
-   t \<in> subjectReads g l" |
+| reads_read_page_read_thread:
+  "\<lbrakk> b \<in> subjectReads g l; (t,Write,b) \<in> g \<rbrakk>
+     \<Longrightarrow> t \<in> subjectReads g l"
   (* This is the symmetric case for the rule reads_read_page_read_thread.
      Here now suppose t is a sender of an IPC and p is its IPC buffer, to which
      it necessarily has Read authority. Suppose t is blocked waiting to complete
      the send, and the receiver completes the rendezvous.
      IF t is in l's domain, then the IPC buffer  had better be too, since it
      will clearly be read during the operation to send the IPC *)
-  reads_read_thread_read_pages:
-   "\<lbrakk>t \<in> subjectReads g l; (t,Read,p) \<in> g\<rbrakk> \<Longrightarrow>
-    p \<in> subjectReads g l" |
+| reads_read_thread_read_pages:
+  "\<lbrakk> t \<in> subjectReads g l; (t,Read,p) \<in> g \<rbrakk>
+     \<Longrightarrow> p \<in> subjectReads g l"
   (* This rule allows domain l to read from all senders to synchronous endpoints
      for all such endpoints in its domain. This is needed for when someone
      does a receive (for which a sender is already blocked) or reset on the ep.
      The affects on the ep here will depend on the state of any blocked
      senders. So if the ep is in l's domain, the senders better be too. *)
-  read_sync_ep_read_senders_strong:
-  "\<lbrakk>ep \<in> subjectReads g l; (b,SyncSend,ep) \<in> g\<rbrakk> \<Longrightarrow>
-   b \<in> subjectReads g l" |
-  read_sync_ep_call_senders_strong:
-  "\<lbrakk>ep \<in> subjectReads g l; (b,Call,ep) \<in> g\<rbrakk> \<Longrightarrow>
-   b \<in> subjectReads g l" |
+| read_sync_ep_read_senders:
+  "\<lbrakk> ep \<in> subjectReads g l; (b,SyncSend,ep) \<in> g \<rbrakk>
+     \<Longrightarrow> b \<in> subjectReads g l"
+| read_sync_ep_call_senders:
+  "\<lbrakk> ep \<in> subjectReads g l; (b,Call,ep) \<in> g \<rbrakk>
+     \<Longrightarrow> b \<in> subjectReads g l"
   (* This rule allows anyone who can read a synchronous endpoint, to also be
      able to read from its receivers. The intuition is that the state of the
      receivers can affect how the endpoint is affected. *)
@@ -144,231 +118,73 @@ where
      cannot imagine a useful intransitive noninterference policy that permits
      the latter case but not the former, so the extra cost of doing away with
      this rule does not seem worth it IMO. *)
-  read_sync_ep_read_receivers_strong:
-  "\<lbrakk>ep \<in> subjectReads g l; (b,Receive,ep) \<in> g\<rbrakk> \<Longrightarrow>
-   b \<in> subjectReads g l" |
-
+| read_sync_ep_read_receivers:
+  "\<lbrakk> ep \<in> subjectReads g l; (b,Receive,ep) \<in> g \<rbrakk>
+     \<Longrightarrow> b \<in> subjectReads g l"
   (* if t can reply to t', then t can send directly information to t' *)
-  read_reply_thread_read_thread:
-  "\<lbrakk>t' \<in> subjectReads g l; (t,Reply,t') \<in> g\<rbrakk> \<Longrightarrow>
-   t \<in> subjectReads g l" |
+| read_reply_thread_read_thread:
+  "\<lbrakk> t' \<in> subjectReads g l; (t,Reply,t') \<in> g \<rbrakk>
+     \<Longrightarrow> t \<in> subjectReads g l"
   (* This rule is only there for convinience if Reply authorities corresponds to Call authorities*)
-  read_reply_thread_read_thread_rev:
-  "\<lbrakk>t' \<in> subjectReads g l; (t',Reply,t) \<in> g\<rbrakk> \<Longrightarrow>
-   t \<in> subjectReads g l" |
+| read_reply_thread_read_thread_rev:
+  "\<lbrakk> t' \<in> subjectReads g l; (t',Reply,t) \<in> g \<rbrakk>
+     \<Longrightarrow> t \<in> subjectReads g l"
   (* if t can reply to t', then t can send directly information to t' *)
-  read_delder_thread_read_thread:
-  "\<lbrakk>t' \<in> subjectReads g l; (t,DeleteDerived,t') \<in> g\<rbrakk> \<Longrightarrow>
-   t \<in> subjectReads g l" |
+| read_delder_thread_read_thread:
+  "\<lbrakk> t' \<in> subjectReads g l; (t,DeleteDerived,t') \<in> g \<rbrakk>
+     \<Longrightarrow> t \<in> subjectReads g l"
   (* This rule is only there for convinience if Reply authorities corresponds to Call authorities*)
-  read_delder_thread_read_thread_rev:
-  "\<lbrakk>t' \<in> subjectReads g l; (t',DeleteDerived,t) \<in> g\<rbrakk> \<Longrightarrow>
-   t \<in> subjectReads g l"
+| read_delder_thread_read_thread_rev:
+  "\<lbrakk> t' \<in> subjectReads g l; (t',DeleteDerived,t) \<in> g \<rbrakk>
+     \<Longrightarrow> t \<in> subjectReads g l"
 
-
-lemma read_sync_ep_read_senders:
-  "\<lbrakk>(a,auth,ep) \<in> g; auth \<in> {Reset,Receive};
-    ep \<in> subjectReads g l; (b,SyncSend,ep) \<in> g\<rbrakk> \<Longrightarrow>
-   b \<in> subjectReads g l"
-   by (rule read_sync_ep_read_senders_strong)
-
-lemma read_sync_ep_read_receivers:
-  "\<lbrakk>(a,auth,ep) \<in> g; auth \<in> {SyncSend};
-    ep \<in> subjectReads g l; (b,Receive,ep) \<in> g\<rbrakk> \<Longrightarrow>
-   b \<in> subjectReads g l"
-   by (rule read_sync_ep_read_receivers_strong)
-
-
-abbreviation aag_can_read :: "'a PAS \<Rightarrow> word32 \<Rightarrow> bool"
-where
+abbreviation aag_can_read :: "'a PAS \<Rightarrow> obj_ref \<Rightarrow> bool" where
   "aag_can_read aag x \<equiv> (pasObjectAbs aag x) \<in> subjectReads (pasPolicy aag) (pasSubject aag)"
 
-abbreviation aag_can_read_irq :: "'a PAS \<Rightarrow> 10 word \<Rightarrow> bool"
-where
+abbreviation aag_can_read_irq :: "'a PAS \<Rightarrow> irq \<Rightarrow> bool" where
   "aag_can_read_irq aag x \<equiv> (pasIRQAbs aag x) \<in> subjectReads (pasPolicy aag) (pasSubject aag)"
 
-abbreviation aag_can_read_asid :: "'a PAS \<Rightarrow> asid \<Rightarrow> bool"
-where
+abbreviation aag_can_read_asid :: "'a PAS \<Rightarrow> asid \<Rightarrow> bool" where
   "aag_can_read_asid aag x \<equiv> (pasASIDAbs aag x) \<in> subjectReads (pasPolicy aag) (pasSubject aag)"
 
 (* FIXME: having an op\<noteq> in the definition causes clarsimp to spuriously
    apply classical rules. Using @{term disjnt} may avoid this issue *)
-abbreviation aag_can_read_domain :: "'a PAS \<Rightarrow> domain \<Rightarrow> bool"
-where
+abbreviation aag_can_read_domain :: "'a PAS \<Rightarrow> domain \<Rightarrow> bool" where
   "aag_can_read_domain aag x \<equiv>
      pasDomainAbs aag x \<inter> subjectReads (pasPolicy aag) (pasSubject aag) \<noteq> {}"
 
-lemma aag_can_read_self:
-  "is_subject aag x \<Longrightarrow> aag_can_read aag x"
-  by simp
-
-lemma aag_can_read_read:
-  "aag_has_auth_to aag Read x \<Longrightarrow> aag_can_read aag x"
-  by (rule reads_read)
-
-lemma aag_can_read_irq_self:
-  "is_subject_irq aag x \<Longrightarrow> aag_can_read_irq aag x"
-  by simp
 
 subsection \<open>Generic equivalence\<close>
 
-definition equiv_for
-where
-  "equiv_for P f c c' \<equiv>  \<forall> x. P x \<longrightarrow> f c x = f c' x"
+definition equiv_for where
+  "equiv_for P f c c' \<equiv>  \<forall>x. P x \<longrightarrow> f c x = f c' x"
 
-lemma equiv_forE:
-  assumes e: "equiv_for P f c c'"
-  obtains "\<And> x. P x \<Longrightarrow> f c x = f c' x"
-  apply (erule meta_mp)
-  apply(erule e[simplified equiv_for_def, rule_format])
-  done
-
-lemma equiv_forI:
-  "(\<And> x. P x \<Longrightarrow> f c x = f c' x) \<Longrightarrow> equiv_for P f c c'"
-  by(simp add: equiv_for_def)
-
-lemma equiv_forD:
-  "equiv_for P f c c' \<Longrightarrow> P x \<Longrightarrow> f c x = f c' x"
-  apply(blast elim: equiv_forE)
-  done
-
-lemma equiv_for_comp:
-  "equiv_for P (f \<circ> g) s s' = equiv_for P f (g s) (g s')"
-  apply(simp add: equiv_for_def)
-  done
-
-lemma equiv_for_or:
-  "equiv_for (A or B) f c c' = (equiv_for A f c c' \<and> equiv_for B f c c')"
-  by (fastforce simp: equiv_for_def)
-
-lemma equiv_for_id_update:
-  "equiv_for P id c c' \<Longrightarrow>
-   equiv_for P id (c(x := v)) (c'(x := v))"
-  by (simp add: equiv_for_def)
 
 subsection \<open>Machine state equivalence\<close>
-abbreviation equiv_machine_state
-  :: "(word32 \<Rightarrow> bool)  \<Rightarrow> 'a machine_state_scheme \<Rightarrow> 'a machine_state_scheme \<Rightarrow> bool"
+
+abbreviation equiv_machine_state :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> machine_state \<Rightarrow> machine_state \<Rightarrow> bool"
 where
-  "equiv_machine_state P s s' \<equiv> equiv_for (\<lambda>x. P x) underlying_memory s s' \<and>
-                                equiv_for (\<lambda>x. P x) device_state s s'"
+  "equiv_machine_state P s s' \<equiv> equiv_for (\<lambda>x. P x) underlying_memory s s'
+                              \<and> equiv_for (\<lambda>x. P x) device_state s s'"
+
 
 subsection \<open>ASID equivalence\<close>
 
-definition equiv_asid :: "asid \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool"
-where
-  "equiv_asid asid s s' \<equiv>
-    ((arm_asid_table (arch_state s) (asid_high_bits_of asid)) =
-     (arm_asid_table (arch_state s') (asid_high_bits_of asid))) \<and>
-    (\<forall> pool_ptr.
-         arm_asid_table (arch_state s) (asid_high_bits_of asid) = Some pool_ptr \<longrightarrow>
-          asid_pool_at pool_ptr s = asid_pool_at pool_ptr s' \<and>
-          (\<forall> asid_pool asid_pool'.
-             kheap s pool_ptr = Some (ArchObj (ASIDPool asid_pool)) \<and>
-             kheap s' pool_ptr = Some (ArchObj (ASIDPool asid_pool')) \<longrightarrow>
-               asid_pool (ucast asid) = asid_pool' (ucast asid)))"
+definition equiv_asids :: "(asid \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "equiv_asids R s s' \<equiv> \<forall>asid. asid \<noteq> 0 \<and> R asid \<longrightarrow> equiv_asid asid s s'"
 
-
-definition equiv_asid'
-where
-  "equiv_asid' asid pool_ptr_opt pool_ptr_opt' kh kh' \<equiv>
-    (case pool_ptr_opt of None \<Rightarrow> pool_ptr_opt' = None
-                        | Some pool_ptr \<Rightarrow>
-       (case pool_ptr_opt' of None \<Rightarrow> False
-                            | Some pool_ptr' \<Rightarrow>
-          (pool_ptr' = pool_ptr \<and>
-           ((\<exists> asid_pool. kh pool_ptr = Some (ArchObj (ASIDPool asid_pool))) =
-            (\<exists> asid_pool'. kh' pool_ptr' = Some (ArchObj (ASIDPool asid_pool')))) \<and>
-           (\<forall> asid_pool asid_pool'.
-             kh pool_ptr = Some (ArchObj (ASIDPool asid_pool)) \<and>
-             kh' pool_ptr' = Some (ArchObj (ASIDPool asid_pool')) \<longrightarrow>
-               asid_pool (ucast asid) = asid_pool' (ucast asid)))
-       )
-    )"
-
-lemma asid_pool_at_kheap:
-  "asid_pool_at ptr s = (\<exists> asid_pool. kheap s ptr = Some (ArchObj (ASIDPool asid_pool)))"
-  apply(clarsimp simp:  obj_at_def)
-  apply(rule iffI)
-   apply(erule exE, rename_tac ko, clarsimp)
-  apply (clarsimp simp: a_type_simps)
-  done
-
-lemma equiv_asid:
-  "equiv_asid asid s s' = equiv_asid' asid (arm_asid_table (arch_state s) (asid_high_bits_of asid))
-                                      (arm_asid_table (arch_state s') (asid_high_bits_of asid))
-                                      (kheap s) (kheap s')"
-  apply(auto simp: equiv_asid_def equiv_asid'_def split: option.splits simp: asid_pool_at_kheap)
-  done
-
-
-definition equiv_asids :: "(asid \<Rightarrow> bool) \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool"
-where
-  "equiv_asids R s s' \<equiv> \<forall> asid. asid \<noteq> 0 \<and> R asid \<longrightarrow> equiv_asid asid s s'"
-
-lemma equiv_asids_refl:
-  "equiv_asids R s s"
-  apply(auto simp: equiv_asids_def equiv_asid_def)
-  done
-
-lemma equiv_asids_sym:
-  "equiv_asids R s t \<Longrightarrow> equiv_asids R t s"
-  apply(auto simp: equiv_asids_def equiv_asid_def)
-  done
-
-lemma equiv_asids_trans:
-  "\<lbrakk>equiv_asids R s t; equiv_asids R t u\<rbrakk> \<Longrightarrow> equiv_asids R s u"
-  apply(fastforce simp: equiv_asids_def equiv_asid_def asid_pool_at_kheap)
-  done
-
-
-definition non_asid_pool_kheap_update
-where
-  "non_asid_pool_kheap_update s kh \<equiv>
-    \<forall>x. (\<exists> asid_pool. kheap s x = Some (ArchObj (ASIDPool asid_pool)) \<or>
-         kh x = Some (ArchObj (ASIDPool asid_pool))) \<longrightarrow> kheap s x = kh x"
-
-definition identical_updates
-where
+definition identical_updates where
   "identical_updates k k' kh kh' \<equiv> \<forall>x. (kh x \<noteq> kh' x \<longrightarrow> (k x = kh x \<and> k' x = kh' x))"
 
-abbreviation identical_kheap_updates
-where
+abbreviation identical_kheap_updates where
   "identical_kheap_updates s s' kh kh' \<equiv> identical_updates (kheap s) (kheap s') kh kh'"
 
-abbreviation identical_ekheap_updates
-where
+abbreviation identical_ekheap_updates where
   "identical_ekheap_updates s s' kh kh' \<equiv> identical_updates (ekheap s) (ekheap s') kh kh'"
 
 lemmas identical_kheap_updates_def = identical_updates_def
 lemmas identical_ekheap_updates_def = identical_updates_def
 
-lemma equiv_asids_non_asid_pool_kheap_update:
-  "\<lbrakk>equiv_asids R s s';
-    non_asid_pool_kheap_update s kh; non_asid_pool_kheap_update s' kh'\<rbrakk> \<Longrightarrow>
-  equiv_asids R (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
-  apply(clarsimp simp: equiv_asids_def equiv_asid non_asid_pool_kheap_update_def)
-  apply(fastforce simp: equiv_asid'_def split: option.splits)
-  done
-
-lemma equiv_asids_identical_kheap_updates:
-  "\<lbrakk>equiv_asids R s s';
-    identical_kheap_updates s s' kh kh'\<rbrakk> \<Longrightarrow>
-  equiv_asids R (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
-  apply(clarsimp simp: equiv_asids_def identical_kheap_updates_def)
-  apply(clarsimp simp: equiv_asid_def asid_pool_at_kheap)
-  apply(case_tac "kh pool_ptr = kh' pool_ptr")
-   apply fastforce
-  apply fastforce
-  done
-
-lemma equiv_asids_triv:
-  "\<lbrakk>equiv_asids R s s';
-    kheap t = kheap s; arm_asid_table (arch_state t) = arm_asid_table (arch_state s);
-    kheap t' = kheap s'; arm_asid_table (arch_state t') = arm_asid_table (arch_state s')\<rbrakk> \<Longrightarrow>
-   equiv_asids R t t'"
-  apply(fastforce simp: equiv_asids_def equiv_asid equiv_asid'_def)
-  done
 
 subsection \<open>Generic state equivalence\<close>
 
@@ -383,429 +199,80 @@ The first four parameters are just predicate for those four sets:
 
 (*FIXME: We're not ancient Romans and don't need to condense the meaning of
          the universe into S P Q R *)
-definition states_equiv_for
-  :: "(word32 \<Rightarrow> bool) \<Rightarrow> (10 word \<Rightarrow> bool) \<Rightarrow> (asid \<Rightarrow> bool) \<Rightarrow> (domain \<Rightarrow> bool) \<Rightarrow>
-      det_state \<Rightarrow> det_state \<Rightarrow> bool"
-where
+definition states_equiv_for ::
+  "(obj_ref \<Rightarrow> bool) \<Rightarrow> (irq \<Rightarrow> bool) \<Rightarrow> (asid \<Rightarrow> bool) \<Rightarrow>
+   (domain \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
   "states_equiv_for P Q R S s s' \<equiv>
-   equiv_for P kheap s s' \<and>
-   equiv_machine_state P (machine_state s) (machine_state s') \<and>
-   equiv_for (P \<circ> fst) cdt s s' \<and>
-   equiv_for P ekheap s s' \<and>
-   equiv_for (P \<circ> fst) cdt_list s s' \<and>
-   equiv_for (P \<circ> fst) is_original_cap s s' \<and>
-   equiv_for Q interrupt_states s s' \<and>
-   equiv_for Q interrupt_irq_node s s' \<and>
-   equiv_for S  ready_queues s s' \<and>
-   equiv_asids R s s'"
+     equiv_for P kheap s s' \<and>
+     equiv_machine_state P (machine_state s) (machine_state s') \<and>
+     equiv_for (P \<circ> fst) cdt s s' \<and>
+     equiv_for P ekheap s s' \<and>
+     equiv_for (P \<circ> fst) cdt_list s s' \<and>
+     equiv_for (P \<circ> fst) is_original_cap s s' \<and>
+     equiv_for Q interrupt_states s s' \<and>
+     equiv_for Q interrupt_irq_node s s' \<and>
+     equiv_for S  ready_queues s s' \<and>
+     equiv_asids R s s'"
 
 (* This the main use of states_equiv_for : P is use to restrict the labels we want to consider *)
-abbreviation states_equiv_for_labels :: "'a PAS \<Rightarrow> ('a \<Rightarrow> bool)\<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool"
-where
+abbreviation states_equiv_for_labels ::
+  "'a PAS \<Rightarrow> ('a \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
   "states_equiv_for_labels aag P \<equiv>
-      states_equiv_for (\<lambda> x. P (pasObjectAbs aag x)) (\<lambda> x. P (pasIRQAbs aag x))
-                       (\<lambda> x. P (pasASIDAbs aag x))   (\<lambda> x. \<exists>l\<in>pasDomainAbs aag x. P l)"
+      states_equiv_for (\<lambda>x. P (pasObjectAbs aag x)) (\<lambda>x. P (pasIRQAbs aag x))
+                       (\<lambda>x. P (pasASIDAbs aag x)) (\<lambda>x. \<exists>l\<in>pasDomainAbs aag x. P l)"
 
 (* We need this to correctly complement the domain mapping, i.e. it's not true that
      states_equiv_but_for_labels aag P = states_equiv_for_labels aag (not P) *)
-abbreviation states_equiv_but_for_labels :: "'a PAS \<Rightarrow> ('a \<Rightarrow> bool)\<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool"
-where
+abbreviation states_equiv_but_for_labels ::
+  "'a PAS \<Rightarrow> ('a \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
   "states_equiv_but_for_labels aag P \<equiv>
-      states_equiv_for (\<lambda> x. \<not> P (pasObjectAbs aag x)) (\<lambda> x. \<not> P (pasIRQAbs aag x))
-                       (\<lambda> x. \<not> P (pasASIDAbs aag x))   (\<lambda> x. \<forall>l\<in>pasDomainAbs aag x. \<not> P l)"
-
-lemma states_equiv_forI:
-  "\<lbrakk>equiv_for P kheap s s';
-   equiv_machine_state P (machine_state s) (machine_state s');
-   equiv_for (P \<circ> fst) cdt s s';
-   equiv_for P ekheap s s';
-   equiv_for (P \<circ> fst) cdt_list s s';
-   equiv_for (P \<circ> fst) is_original_cap s s';
-   equiv_for Q interrupt_states s s';
-   equiv_for Q interrupt_irq_node s s';
-   equiv_asids R s s';
-   equiv_for S ready_queues s s'\<rbrakk> \<Longrightarrow>
-   states_equiv_for P Q R S s s'"
-  by(auto simp: states_equiv_for_def)
-
-
-lemma states_equiv_for_machine_state_update:
-  "\<lbrakk>states_equiv_for P Q R S s s'; equiv_machine_state P kh kh'\<rbrakk> \<Longrightarrow>
-   states_equiv_for P Q R S (s\<lparr> machine_state := kh \<rparr>) (s'\<lparr> machine_state := kh' \<rparr>)"
-  apply(fastforce simp: states_equiv_for_def elim: equiv_forE intro: equiv_forI
-                 elim!: equiv_asids_triv)
-  done
-
-lemma states_equiv_for_non_asid_pool_kheap_update:
-  "\<lbrakk>states_equiv_for P Q R S s s'; equiv_for P id kh kh';
-    non_asid_pool_kheap_update s kh; non_asid_pool_kheap_update s' kh'\<rbrakk> \<Longrightarrow>
-   states_equiv_for P Q R S (s\<lparr> kheap := kh \<rparr>) (s'\<lparr> kheap := kh' \<rparr>)"
-  apply(fastforce simp: states_equiv_for_def elim: equiv_forE intro: equiv_forI
-                 elim!: equiv_asids_non_asid_pool_kheap_update)
-  done
-
-lemma states_equiv_for_identical_kheap_updates:
-  "\<lbrakk>states_equiv_for P Q R S s s';
-    identical_kheap_updates s s' kh kh'\<rbrakk> \<Longrightarrow>
-   states_equiv_for P Q R S (s\<lparr> kheap := kh \<rparr>) (s'\<lparr> kheap := kh' \<rparr>)"
-  apply(clarsimp simp: states_equiv_for_def)
-  apply(auto elim!: equiv_forE intro!: equiv_forI elim!: equiv_asids_identical_kheap_updates
-              simp: identical_kheap_updates_def)
-  done
-
-lemma states_equiv_for_cdt_update:
-  "\<lbrakk>states_equiv_for P Q R S s s'; equiv_for (P \<circ> fst) id kh kh'\<rbrakk> \<Longrightarrow>
-   states_equiv_for P Q R S (s\<lparr> cdt := kh \<rparr>) (s'\<lparr> cdt := kh' \<rparr>)"
-  by (fastforce simp: states_equiv_for_def elim: equiv_forE intro: equiv_forI
-               elim!: equiv_asids_triv)
-
-
-
-lemma states_equiv_for_cdt_list_update:
-  "\<lbrakk>states_equiv_for P Q R S s s'; equiv_for (P \<circ> fst) id (kh (cdt_list s)) (kh' (cdt_list s'))\<rbrakk> \<Longrightarrow>
-   states_equiv_for P Q R S (cdt_list_update kh s) (cdt_list_update kh' s')"
-  by (fastforce simp: states_equiv_for_def elim: equiv_forE intro: equiv_forI
-               elim!: equiv_asids_triv)
-
-
-lemma states_equiv_for_identical_ekheap_updates:
-  "\<lbrakk>states_equiv_for P Q R S s s';
-    identical_ekheap_updates s s' (kh (ekheap s)) (kh' (ekheap s'))\<rbrakk> \<Longrightarrow>
-    states_equiv_for P Q R S (ekheap_update kh s) (ekheap_update kh' s')"
-  by (fastforce simp: identical_ekheap_updates_def equiv_for_def states_equiv_for_def
-                      equiv_asids_def equiv_asid_def)
-
-
-lemma states_equiv_for_ekheap_update:
-  "\<lbrakk>states_equiv_for P Q R S s s';
-    equiv_for P id (kh (ekheap s)) (kh' (ekheap s'))\<rbrakk> \<Longrightarrow>
-   states_equiv_for P Q R S (ekheap_update kh s) (ekheap_update kh' s')"
-  by (fastforce simp: states_equiv_for_def elim: equiv_forE intro: equiv_forI
-               elim!: equiv_asids_triv)
-
-
-lemma states_equiv_for_is_original_cap_update:
-  "\<lbrakk>states_equiv_for P Q R S s s'; equiv_for (P \<circ> fst) id kh kh'\<rbrakk> \<Longrightarrow>
-   states_equiv_for P Q R S (s\<lparr> is_original_cap := kh \<rparr>) (s'\<lparr> is_original_cap := kh' \<rparr>)"
-  by (fastforce simp: states_equiv_for_def elim: equiv_forE intro: equiv_forI
-               elim!: equiv_asids_triv)
-
-
-lemma states_equiv_for_interrupt_states_update:
-  "\<lbrakk>states_equiv_for P Q R S s s'; equiv_for Q id kh kh'\<rbrakk> \<Longrightarrow>
-   states_equiv_for P Q R S (s\<lparr> interrupt_states := kh \<rparr>) (s'\<lparr> interrupt_states := kh' \<rparr>)"
-  by (fastforce simp: states_equiv_for_def elim: equiv_forE intro: equiv_forI
-               elim!: equiv_asids_triv)
-
-
-lemma states_equiv_for_interrupt_irq_node_update:
-  "\<lbrakk>states_equiv_for P Q R S s s'; equiv_for Q id kh kh'\<rbrakk> \<Longrightarrow>
-   states_equiv_for P Q R S (s\<lparr> interrupt_irq_node := kh \<rparr>) (s'\<lparr> interrupt_irq_node := kh' \<rparr>)"
-  by (fastforce simp: states_equiv_for_def elim: equiv_forE intro: equiv_forI
-               elim!: equiv_asids_triv)
-
-
-lemma states_equiv_for_ready_queues_update:
-  "\<lbrakk>states_equiv_for P Q R S s s'; equiv_for S id kh kh'\<rbrakk> \<Longrightarrow>
-   states_equiv_for P Q R S (s\<lparr> ready_queues := kh \<rparr>) (s'\<lparr> ready_queues := kh' \<rparr>)"
-  by (fastforce simp: states_equiv_for_def elim: equiv_forE intro: equiv_forI
-               elim!: equiv_asids_triv)
-
-
-lemma states_equiv_forE:
-  assumes sef: "states_equiv_for P Q R S s s'"
-  obtains "equiv_machine_state P (machine_state s) (machine_state s')"
-          "equiv_for P kheap s s'"
-          "equiv_for (P \<circ> fst) cdt s s'"
-          "equiv_for (P \<circ> fst) cdt_list s s'"
-          "equiv_for P ekheap s s'"
-          "equiv_for (P \<circ> fst) is_original_cap s s'"
-          "equiv_for Q interrupt_states s s'"
-          "equiv_for Q interrupt_irq_node s s'"
-          "equiv_asids R s s'"
-          "equiv_for S ready_queues s s'"
-  using sef[simplified states_equiv_for_def] by auto
-
-lemma equiv_for_apply: "equiv_for P g (f s) (f s') = equiv_for P (g o f) s s'"
-  by (simp add: equiv_for_def)
-
-
-lemma states_equiv_forE_kheap:
-  assumes sef: "states_equiv_for P Q R S s s'"
-  obtains "\<And> x. P x \<Longrightarrow> kheap s x = kheap s' x"
-  using sef by(auto simp: states_equiv_for_def elim: equiv_forE)
-
-lemma states_equiv_forE_mem:
-  assumes sef: "states_equiv_for P Q R S s s'"
-  obtains "\<And> x. P x \<Longrightarrow>
-    (underlying_memory (machine_state s)) x = (underlying_memory (machine_state s')) x \<and>
-    (device_state (machine_state s)) x = (device_state (machine_state s')) x"
-  using sef
-  apply (clarsimp simp: states_equiv_for_def elim: equiv_forE)
-  apply (elim equiv_forE)
-  apply fastforce
-  done
-
-lemma states_equiv_forE_cdt:
-  assumes sef: "states_equiv_for P Q R S s s'"
-  obtains "\<And> x. P (fst x) \<Longrightarrow> cdt s x = cdt s' x"
-  using sef by(auto simp: states_equiv_for_def elim: equiv_forE)
-
-lemma states_equiv_forE_cdt_list:
-  assumes sef: "states_equiv_for P Q R S s s'"
-  obtains "\<And> x. P (fst x) \<Longrightarrow> cdt_list s x = cdt_list s' x"
-  using sef by(auto simp: states_equiv_for_def elim: equiv_forE)
-
-lemma states_equiv_forE_ekheap:
-  assumes sef: "states_equiv_for P Q R S s s'"
-  obtains "\<And> x. P x \<Longrightarrow> ekheap s x = ekheap s' x"
-  using sef by(auto simp: states_equiv_for_def elim: equiv_forE)
-
-lemma states_equiv_forE_is_original_cap:
-  assumes sef: "states_equiv_for P Q R S s s'"
-  obtains "\<And> x. P (fst x) \<Longrightarrow> is_original_cap s x = is_original_cap s' x"
-  using sef by(auto simp: states_equiv_for_def elim: equiv_forE)
-
-lemma states_equiv_forE_interrupt_states:
-  assumes sef: "states_equiv_for P Q R S s s'"
-  obtains "\<And> x. Q x \<Longrightarrow> interrupt_states s x = interrupt_states s' x"
-  using sef by(auto simp: states_equiv_for_def elim: equiv_forE)
-
-lemma states_equiv_forE_interrupt_irq_node:
-  assumes sef: "states_equiv_for P Q R S s s'"
-  obtains "\<And> x. Q x \<Longrightarrow> interrupt_irq_node s x = interrupt_irq_node s' x"
-  using sef by(auto simp: states_equiv_for_def elim: equiv_forE)
-
-lemma states_equiv_forE_ready_queues:
-  assumes sef: "states_equiv_for P Q R S s s'"
-  obtains "\<And> x. S x \<Longrightarrow> ready_queues s x = ready_queues s' x"
-  using sef by(auto simp: states_equiv_for_def elim: equiv_forE)
-
-lemma equiv_for_refl:
-  "equiv_for P f s s"
-  by(auto simp: equiv_for_def)
-
-lemma equiv_for_sym:
-  "equiv_for P f s t \<Longrightarrow> equiv_for P f t s"
-  by(auto simp: equiv_for_def)
-
-lemma equiv_for_trans:
-  "\<lbrakk>equiv_for P f s t; equiv_for P f t u\<rbrakk> \<Longrightarrow>
-   equiv_for P f s u"
-  by(auto simp: equiv_for_def)
-
-
-lemma states_equiv_for_refl:
-  "states_equiv_for P Q R S s s"
-  by(auto simp: states_equiv_for_def  intro: equiv_for_refl equiv_asids_refl)
-
-
-lemma states_equiv_for_sym:
-  "states_equiv_for P Q R S s t \<Longrightarrow> states_equiv_for P Q R S t s"
-  by (auto simp: states_equiv_for_def intro: equiv_for_sym equiv_asids_sym simp: equiv_for_def)
-
-
-
-lemma states_equiv_for_trans:
-  "\<lbrakk>states_equiv_for P Q R S s t; states_equiv_for P Q R S t u\<rbrakk> \<Longrightarrow>
-   states_equiv_for P Q R S s u"
-  by (auto simp: states_equiv_for_def
-          intro: equiv_for_trans equiv_asids_trans equiv_forI
-           elim: equiv_forE)
-
-(* FIXME MOVE *)
-lemma or_comp_dist:
-  "(A or B) \<circ> f = (A \<circ> f or B \<circ> f)"
-  by (simp add: pred_disj_def comp_def)
-
+     states_equiv_for (\<lambda>x. \<not> P (pasObjectAbs aag x)) (\<lambda> x. \<not> P (pasIRQAbs aag x))
+                      (\<lambda>x. \<not> P (pasASIDAbs aag x)) (\<lambda> x. \<forall>l\<in>pasDomainAbs aag x. \<not> P l)"
 
 
 subsection \<open>Idle thread equivalence\<close>
 
-definition idle_equiv :: "('z :: state_ext) state \<Rightarrow> ('z :: state_ext) state \<Rightarrow> bool"
-where
-"idle_equiv s s' \<equiv> idle_thread s = idle_thread s' \<and>
-                  (\<forall>tcb tcb'. kheap s (idle_thread s) = Some (TCB tcb) \<longrightarrow>
-                  kheap s' (idle_thread s) = Some (TCB tcb') \<longrightarrow>
-                  arch_tcb_context_get (tcb_arch  tcb) = arch_tcb_context_get (tcb_arch tcb')) \<and>
-                  (tcb_at (idle_thread s) s \<longleftrightarrow> tcb_at (idle_thread s) s')"
+definition idle_equiv :: "('z :: state_ext) state \<Rightarrow> ('z :: state_ext) state \<Rightarrow> bool" where
+  "idle_equiv s s' \<equiv> idle_thread s = idle_thread s' \<and>
+                     (\<forall>tcb tcb'. kheap s (idle_thread s) = Some (TCB tcb)
+                                 \<longrightarrow> kheap s' (idle_thread s) = Some (TCB tcb')
+                                 \<longrightarrow> arch_tcb_context_get (tcb_arch tcb) =
+                                     arch_tcb_context_get (tcb_arch tcb')) \<and>
+                     (tcb_at (idle_thread s) s \<longleftrightarrow> tcb_at (idle_thread s) s')"
 
-lemma idle_equiv_refl: "idle_equiv s s"
-  by (simp add: idle_equiv_def)
-
-lemma idle_equiv_sym: "idle_equiv s s' \<Longrightarrow> idle_equiv s' s"
-  by (clarsimp simp add: idle_equiv_def)
-
-lemma idle_equiv_trans: "idle_equiv s s' \<Longrightarrow> idle_equiv s' s'' \<Longrightarrow> idle_equiv s s''"
-  by (clarsimp simp add: idle_equiv_def tcb_at_def get_tcb_def split: option.splits
-                  kernel_object.splits)
-
-subsection \<open>Exclusive machine state equivalence\<close>
-abbreviation exclusive_state_equiv
-where
-  "exclusive_state_equiv s s' \<equiv>
-     exclusive_state (machine_state s) = exclusive_state (machine_state s')"
 
 subsection \<open>Global (Kernel) VSpace equivalence\<close>
-(* globals_equiv should be maintained by everything except the scheduler, since
-   nothing else touches the globals frame *)
 
 (* cur_thread is included here also to enforce this being an equivalence relation *)
-definition globals_equiv :: "('z :: state_ext) state \<Rightarrow> ('z :: state_ext) state \<Rightarrow> bool" where
+definition globals_equiv :: "det_state \<Rightarrow> det_state \<Rightarrow> bool" where
   "globals_equiv s s' \<equiv>
-     arm_global_pd (arch_state s) = arm_global_pd (arch_state s') \<and>
-     kheap s (arm_global_pd (arch_state s)) = kheap s' (arm_global_pd (arch_state s)) \<and>
-      idle_equiv s s' \<and>
-      dom (device_state (machine_state s)) = dom (device_state (machine_state s')) \<and>
-      cur_thread s = cur_thread s' \<and>
-      (cur_thread s \<noteq> idle_thread s \<longrightarrow> exclusive_state_equiv s s')"
+     arch_globals_equiv (cur_thread s) (idle_thread s) (kheap s) (kheap s')
+                        (arch_state s) (arch_state s') (machine_state s) (machine_state s') \<and>
+     idle_equiv s s' \<and> cur_thread s = cur_thread s' \<and>
+     dom (device_state (machine_state s)) = dom (device_state (machine_state s'))"
+
 
 subsection \<open>read_equiv\<close>
+
 (* Basically defines the domain of the current thread, excluding globals.
    This also includes the things that are in the scheduler's domain, which
    the current domain is always allowed to read. *)
-definition reads_equiv :: "'a PAS \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool"
-where
+definition reads_equiv :: "'a PAS \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
   "reads_equiv aag s s' \<equiv>
-   ((\<forall> d\<in>subjectReads (pasPolicy aag) (pasSubject aag).
-         states_equiv_for_labels aag ((=) d) s s') \<and>
-         cur_thread s = cur_thread s' \<and>
-         cur_domain s = cur_domain s' \<and>
-         scheduler_action s = scheduler_action s' \<and>
-         work_units_completed s = work_units_completed s' \<and>
-         irq_state (machine_state s) = irq_state (machine_state s'))"
+     (\<forall>d\<in>subjectReads (pasPolicy aag) (pasSubject aag).
+        states_equiv_for_labels aag ((=) d) s s') \<and>
+        cur_thread s = cur_thread s' \<and>
+        cur_domain s = cur_domain s' \<and>
+        scheduler_action s = scheduler_action s' \<and>
+        work_units_completed s = work_units_completed s' \<and>
+        irq_state (machine_state s) = irq_state (machine_state s')"
 
 
 (* this is the main equivalence we want to be maintained, since it defines
    everything the current thread can read from; however, we'll deal with
    reads_equiv in the reads_respects proofs, since globals_equiv is always preserved *)
-definition reads_equiv_g :: "'a PAS \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool"
-where
+definition reads_equiv_g :: "'a PAS \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
   "reads_equiv_g aag s s' \<equiv> reads_equiv aag s s' \<and> globals_equiv s s'"
-
-
-lemma reads_equiv_def2:
-  "reads_equiv aag s s' =
-  (states_equiv_for (aag_can_read aag) (aag_can_read_irq aag) (aag_can_read_asid aag)
-                    (aag_can_read_domain aag) s s' \<and>
-   cur_thread s = cur_thread s' \<and> cur_domain s = cur_domain s' \<and>
-   scheduler_action s = scheduler_action s' \<and> work_units_completed s = work_units_completed s' \<and>
-   irq_state (machine_state s) = irq_state (machine_state s'))"
-  apply(rule iffI)
-   apply(auto simp: reads_equiv_def equiv_for_def states_equiv_for_def equiv_asids_def)
-  done
-
-
-lemma reads_equivE:
-  assumes sef: "reads_equiv aag s s'"
-  obtains "equiv_for (aag_can_read aag) kheap s s'"
-          "equiv_machine_state (aag_can_read aag) (machine_state s) (machine_state s')"
-          "equiv_for ((aag_can_read aag) \<circ> fst) cdt s s'"
-          "equiv_for ((aag_can_read aag) \<circ> fst) cdt_list s s'"
-          "equiv_for (aag_can_read aag) ekheap s s'"
-          "equiv_for ((aag_can_read aag) \<circ> fst) is_original_cap s s'"
-          "equiv_for (aag_can_read_irq aag) interrupt_states s s'"
-          "equiv_for (aag_can_read_irq aag) interrupt_irq_node s s'"
-          "equiv_asids (aag_can_read_asid aag) s s'"
-          "equiv_for (aag_can_read_domain aag) ready_queues s s'"
-          "cur_thread s = cur_thread s'"
-          "cur_domain s = cur_domain s'"
-          "scheduler_action s = scheduler_action s'"
-          "work_units_completed s = work_units_completed s'"
-          "irq_state (machine_state s) = irq_state (machine_state s')"
-  using sef by(auto simp: reads_equiv_def2 elim: states_equiv_forE)
-
-
-lemma reads_equiv_machine_state_update:
- "\<lbrakk>reads_equiv aag s s'; equiv_machine_state (aag_can_read aag)  kh kh'; irq_state kh = irq_state kh'\<rbrakk> \<Longrightarrow>
-   reads_equiv aag (s\<lparr> machine_state := kh \<rparr>) (s'\<lparr> machine_state := kh' \<rparr>)"
-  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_machine_state_update)
-
-
-lemma reads_equiv_non_asid_pool_kheap_update:
-  "\<lbrakk>reads_equiv aag s s'; equiv_for (aag_can_read aag) id kh kh';
-    non_asid_pool_kheap_update s kh; non_asid_pool_kheap_update s' kh'\<rbrakk> \<Longrightarrow>
-   reads_equiv aag (s\<lparr> kheap := kh \<rparr>) (s'\<lparr> kheap := kh' \<rparr>)"
-  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_non_asid_pool_kheap_update)
-
-
-lemma reads_equiv_identical_kheap_updates:
-  "\<lbrakk>reads_equiv aag s s';
-    identical_kheap_updates s s' kh kh'\<rbrakk> \<Longrightarrow>
-   reads_equiv aag (s\<lparr> kheap := kh \<rparr>) (s'\<lparr> kheap := kh' \<rparr>)"
-  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_identical_kheap_updates)
-
-
-
-lemma reads_equiv_cdt_update:
-  "\<lbrakk>reads_equiv aag s s'; equiv_for ((aag_can_read aag) \<circ> fst) id kh kh'\<rbrakk> \<Longrightarrow>
-   reads_equiv aag (s\<lparr> cdt := kh \<rparr>) (s'\<lparr> cdt := kh' \<rparr>)"
-  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_cdt_update)
-
-
-
-lemma reads_equiv_cdt_list_update:
-  "\<lbrakk>reads_equiv aag s s'; equiv_for ((aag_can_read aag) \<circ> fst) id (kh (cdt_list s)) (kh' (cdt_list s'))\<rbrakk> \<Longrightarrow>
-   reads_equiv aag (cdt_list_update kh s) (cdt_list_update kh' s')"
-  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_cdt_list_update)
-
-
-lemma reads_equiv_identical_ekheap_updates:
-  "\<lbrakk>reads_equiv aag s s'; identical_ekheap_updates s s' (kh (ekheap s)) (kh' (ekheap s'))\<rbrakk> \<Longrightarrow>
-   reads_equiv aag (ekheap_update kh s) (ekheap_update kh' s')"
-  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_identical_ekheap_updates)
-
-
-lemma reads_equiv_ekheap_updates:
-  "\<lbrakk>reads_equiv aag s s'; equiv_for (aag_can_read aag) id (kh (ekheap s)) (kh' (ekheap s')) \<rbrakk> \<Longrightarrow>
-   reads_equiv aag (ekheap_update kh s) (ekheap_update kh' s')"
-  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_ekheap_update)
-
-
-lemma reads_equiv_is_original_cap_update:
-  "\<lbrakk>reads_equiv aag s s'; equiv_for ((aag_can_read aag) \<circ> fst) id kh kh'\<rbrakk> \<Longrightarrow>
-   reads_equiv aag (s\<lparr> is_original_cap := kh \<rparr>) (s'\<lparr> is_original_cap := kh' \<rparr>)"
-  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_is_original_cap_update)
-
-
-lemma reads_equiv_interrupt_states_update:
-  "\<lbrakk>reads_equiv aag s s'; equiv_for (aag_can_read_irq aag) id kh kh'\<rbrakk> \<Longrightarrow>
-   reads_equiv aag (s\<lparr> interrupt_states := kh \<rparr>) (s'\<lparr> interrupt_states := kh' \<rparr>)"
-  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_interrupt_states_update)
-
-
-lemma reads_equiv_interrupt_irq_node_update:
-  "\<lbrakk>reads_equiv aag s s'; equiv_for (aag_can_read_irq aag) id kh kh'\<rbrakk> \<Longrightarrow>
-   reads_equiv aag (s\<lparr> interrupt_irq_node := kh \<rparr>) (s'\<lparr> interrupt_irq_node := kh' \<rparr>)"
-  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_interrupt_irq_node_update)
-
-
-lemma reads_equiv_ready_queues_update:
-  "\<lbrakk>reads_equiv aag s s'; equiv_for (aag_can_read_domain aag) id kh kh'\<rbrakk> \<Longrightarrow>
-   reads_equiv aag (s\<lparr> ready_queues := kh \<rparr>) (s'\<lparr> ready_queues := kh' \<rparr>)"
-  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_ready_queues_update)
-
-
-lemma reads_equiv_scheduler_action_update:
-  "reads_equiv aag s s' \<Longrightarrow>
-   reads_equiv aag (s\<lparr> scheduler_action := kh \<rparr>) (s'\<lparr> scheduler_action := kh \<rparr>)"
-  by (fastforce simp: reads_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
-
-
-lemma reads_equiv_work_units_completed_update:
-  "reads_equiv aag s s' \<Longrightarrow>
-   reads_equiv aag (s\<lparr> work_units_completed := kh \<rparr>) (s'\<lparr> work_units_completed := kh \<rparr>)"
-  by (fastforce simp: reads_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
-
-
-lemma reads_equiv_work_units_completed_update':
-  "reads_equiv aag s s' \<Longrightarrow>
-   reads_equiv aag (s\<lparr> work_units_completed := (f (work_units_completed s)) \<rparr>)
-                   (s'\<lparr> work_units_completed := (f (work_units_completed s')) \<rparr>)"
-  by (fastforce simp: reads_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
-
-
-
 
 
 section \<open>Writing: subjectsAffects and affects_equiv\<close>
@@ -822,883 +289,125 @@ text \<open>
   since, in this case, the subject has Control rights to the asid.
 *)
 inductive_set subjectAffects :: "'a auth_graph \<Rightarrow> 'a \<Rightarrow> 'a set"
-  for g :: "'a auth_graph" and l :: "'a"
-where
+  for g :: "'a auth_graph" and l :: "'a" where
   affects_lrefl:
-    "l \<in> subjectAffects g l" |
-  affects_write:
-    "\<lbrakk>(l,auth,l') \<in> g; auth \<in> {Control, Write}\<rbrakk> \<Longrightarrow>
-     l' \<in> subjectAffects g l" |
-  affects_ep:
-    "\<lbrakk>(l,auth,l') \<in> g; auth \<in> {Receive, Notify, SyncSend, Call, Reset}\<rbrakk> \<Longrightarrow>
-     l' \<in> subjectAffects g l" |
+    "l \<in> subjectAffects g l"
+| affects_write:
+    "\<lbrakk> (l,auth,l') \<in> g; auth \<in> {Control, Write} \<rbrakk>
+       \<Longrightarrow> l' \<in> subjectAffects g l"
+| affects_ep:
+    "\<lbrakk> (l,auth,l') \<in> g; auth \<in> {Receive, Notify, SyncSend, Call, Reset} \<rbrakk>
+       \<Longrightarrow> l' \<in> subjectAffects g l"
   (* ipc buffer is not necessarily owned by thread *)
-  affects_send:
-    "\<lbrakk>(l,auth,ep) \<in> g; auth \<in> {SyncSend, Notify, Call}; (l',Receive,ep) \<in> g;
-      (l',Write,l'') \<in> g\<rbrakk> \<Longrightarrow>
-     l'' \<in> subjectAffects g l" |
+| affects_send:
+    "\<lbrakk> (l,auth,ep) \<in> g; auth \<in> {SyncSend, Notify, Call}; (l',Receive,ep) \<in> g; (l',Write,l'') \<in> g \<rbrakk>
+       \<Longrightarrow> l'' \<in> subjectAffects g l"
   (* synchronous sends provide a back-channel from receiver to sender *)
-  affects_recv:
-    "\<lbrakk>(l,Receive,ep) \<in> g; (l',SyncSend,ep) \<in> g\<rbrakk> \<Longrightarrow>
-     l' \<in> subjectAffects g l" |
+| affects_recv:
+    "\<lbrakk> (l,Receive,ep) \<in> g; (l',SyncSend,ep) \<in> g \<rbrakk>
+       \<Longrightarrow> l' \<in> subjectAffects g l"
   (* a reply right can only exist if l has a call right to l',
    * so including this case saves us from having to re-derive it *)
-  affects_reply_back:
-    "\<lbrakk>(l',Reply,l) \<in> g\<rbrakk> \<Longrightarrow>
-     l' \<in> subjectAffects g l" |
+| affects_reply_back:
+    "(l',Reply,l) \<in> g \<Longrightarrow> l' \<in> subjectAffects g l"
   (* reply direct ipc buffer writing *)
-  affects_reply:
-    "\<lbrakk>(l,Reply,l') \<in> g; (l',Write,l'') \<in> g\<rbrakk> \<Longrightarrow>
-     l'' \<in> subjectAffects g l" |
+| affects_reply:
+    "\<lbrakk> (l,Reply,l') \<in> g; (l',Write,l'') \<in> g \<rbrakk>
+       \<Longrightarrow> l'' \<in> subjectAffects g l"
   (* deletion direct channel *)
-  affects_delete_derived:
-    "\<lbrakk>(l,DeleteDerived,l') \<in> g\<rbrakk> \<Longrightarrow>
-     l' \<in> subjectAffects g l" |
+| affects_delete_derived:
+    "(l,DeleteDerived,l') \<in> g \<Longrightarrow> l' \<in> subjectAffects g l"
   (* If two agents can delete the same caps, they can affect each other *)
-  affects_delete_derived2:
-    "\<lbrakk>(l,DeleteDerived,l') \<in> g; (l'',DeleteDerived,l') \<in> g\<rbrakk> \<Longrightarrow>
-     l'' \<in> subjectAffects g l" |
+| affects_delete_derived2:
+    "\<lbrakk> (l,DeleteDerived,l') \<in> g; (l'',DeleteDerived,l') \<in> g \<rbrakk>
+       \<Longrightarrow> l'' \<in> subjectAffects g l"
   (* integrity definitions allow resets to modify ipc buffer *)
-  affects_reset:
-    "\<lbrakk>(l,Reset,ep) \<in> g; (l',auth,ep) \<in> g; auth \<in> {SyncSend, Receive};
-      (l',Write,l'') \<in> g\<rbrakk> \<Longrightarrow>
-     l'' \<in> subjectAffects g l" |
+| affects_reset:
+    "\<lbrakk> (l,Reset,ep) \<in> g; (l',auth,ep) \<in> g; auth \<in> {SyncSend, Receive}; (l',Write,l'') \<in> g \<rbrakk>
+       \<Longrightarrow> l'' \<in> subjectAffects g l"
   (* if you alter an asid mapping, you affect the domain who owns that asid *)
-  affects_asidpool_map:
-    "(l,AAuth ASIDPoolMapsASID,l') \<in> g \<Longrightarrow> l' \<in> subjectAffects g l" |
-  (* if you are sending to an ntfn, which is bound to a tcb that is
+| affects_asidpool_map:
+    "(l,AAuth ASIDPoolMapsASID,l') \<in> g \<Longrightarrow> l' \<in> subjectAffects g l"
+  (* if you are sending to an ntfn, which is bound to a tcb that i
      receive blocked on an ep, then you can affect that ep *)
-  affects_ep_bound_trans:
-    "\<lbrakk>\<exists>tcb ntfn. (tcb, Receive, ntfn) \<in> g \<and> (tcb, Receive, ep) \<in> g \<and>
-                (l, Notify, ntfn) \<in> g\<rbrakk> \<Longrightarrow>
-        ep \<in> subjectAffects g l"
+| affects_ep_bound_trans:
+    "(\<exists>tcb ntfn. (tcb, Receive, ntfn) \<in> g \<and> (tcb, Receive, ep) \<in> g \<and> (l, Notify, ntfn) \<in> g)
+     \<Longrightarrow> ep \<in> subjectAffects g l"
 
 (* We define when the current subject can affect another domain whose label is
    l. This occurs when the current subject can affect some label d that is
    considered to be part of what domain l can read. *)
-definition aag_can_affect_label
-where
-  "aag_can_affect_label aag l \<equiv> \<exists> d. d \<in> subjectAffects (pasPolicy aag) (pasSubject aag) \<and>
-                                     d \<in> subjectReads (pasPolicy aag) l"
-
-lemma aag_can_affect_labelI[intro!]:
-  "\<lbrakk>d \<in> subjectAffects (pasPolicy aag) (pasSubject aag); d \<in> subjectReads (pasPolicy aag) l\<rbrakk>
-     \<Longrightarrow> aag_can_affect_label aag l"
-  by (auto simp: aag_can_affect_label_def)
+definition aag_can_affect_label where
+  "aag_can_affect_label aag l \<equiv> \<exists>d. d \<in> subjectAffects (pasPolicy aag) (pasSubject aag)
+                                  \<and> d \<in> subjectReads (pasPolicy aag) l"
 
 (* Defines when two states are equivalent for some domain l that can be affected
    by the current subject. When the current subject cannot affect domain l,
    we relate all states. *)
-definition affects_equiv :: "'a PAS \<Rightarrow> 'a \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool"
-where
+definition affects_equiv :: "'a PAS \<Rightarrow> 'a \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
   "affects_equiv aag l s s' \<equiv>
-     (if (aag_can_affect_label aag l) then
-         (states_equiv_for_labels aag (\<lambda>l'. l' \<in> subjectReads (pasPolicy aag) l) s s')
-      else True)"
+     if aag_can_affect_label aag l
+     then states_equiv_for_labels aag (\<lambda>l'. l' \<in> subjectReads (pasPolicy aag) l) s s'
+     else True"
 
+abbreviation aag_can_affect where
+  "aag_can_affect aag l \<equiv> \<lambda>x. aag_can_affect_label aag l
+                            \<and> pasObjectAbs aag x \<in> subjectReads (pasPolicy aag) l"
 
-lemma equiv_for_trivial:
-  "(\<And> x. P x \<Longrightarrow> False) \<Longrightarrow> equiv_for P f c c'"
-  by (auto simp: equiv_for_def)
+abbreviation aag_can_affect_irq where
+  "aag_can_affect_irq aag l \<equiv> \<lambda>x. aag_can_affect_label aag l
+                                \<and> pasIRQAbs aag x \<in> subjectReads (pasPolicy aag) l"
 
-lemma equiv_asids_trivial:
-  "(\<And> x. P x \<Longrightarrow> False) \<Longrightarrow> equiv_asids P x y"
-  by (auto simp: equiv_asids_def)
+abbreviation aag_can_affect_asid where
+  "aag_can_affect_asid aag l \<equiv> \<lambda>x. aag_can_affect_label aag l
+                                 \<and> pasASIDAbs aag x \<in> subjectReads (pasPolicy aag) l"
 
-abbreviation aag_can_affect
-where
-  "aag_can_affect aag l \<equiv> \<lambda>x. aag_can_affect_label aag l \<and>
-                              pasObjectAbs aag x \<in> subjectReads (pasPolicy aag) l"
+abbreviation aag_can_affect_domain where
+  "aag_can_affect_domain aag l \<equiv> \<lambda>x. aag_can_affect_label aag l
+                                   \<and> pasDomainAbs aag x \<inter> subjectReads (pasPolicy aag) l \<noteq> {}"
 
-abbreviation aag_can_affect_irq
-where
-  "aag_can_affect_irq aag l \<equiv> \<lambda>x. aag_can_affect_label aag l \<and>
-                                  pasIRQAbs aag x \<in> subjectReads (pasPolicy aag) l"
-
-abbreviation aag_can_affect_asid
-where
-  "aag_can_affect_asid aag l \<equiv> \<lambda>x. aag_can_affect_label aag l \<and>
-                                   pasASIDAbs aag x \<in> subjectReads (pasPolicy aag) l"
-
-abbreviation aag_can_affect_domain
-where
-  "aag_can_affect_domain aag l \<equiv> \<lambda>x. aag_can_affect_label aag l \<and>
-                                      pasDomainAbs aag x \<inter> subjectReads (pasPolicy aag) l \<noteq> {}"
-
-
-lemma affects_equiv_def2:
-  "affects_equiv aag l s s' = states_equiv_for (aag_can_affect aag l) (aag_can_affect_irq aag l) (aag_can_affect_asid aag l) (aag_can_affect_domain aag l) s s'"
-  apply(clarsimp simp: affects_equiv_def)
-  apply(auto intro!: states_equiv_forI equiv_forI equiv_asids_trivial
-             dest: equiv_forD
-             elim!: states_equiv_forE)
-  done
-
-lemma affects_equivE:
-  assumes sef: "affects_equiv aag l s s'"
-  obtains "equiv_for (aag_can_affect aag l) kheap s s'"
-          "equiv_machine_state (aag_can_affect aag l) (machine_state s) (machine_state s')"
-          "equiv_for ((aag_can_affect aag l) \<circ> fst) cdt s s'"
-          "equiv_for ((aag_can_affect aag l) \<circ> fst) cdt_list s s'"
-          "equiv_for (aag_can_affect aag l) ekheap s s'"
-          "equiv_for ((aag_can_affect aag l) \<circ> fst) is_original_cap s s'"
-          "equiv_for (aag_can_affect_irq aag l) interrupt_states s s'"
-          "equiv_for (aag_can_affect_irq aag l) interrupt_irq_node s s'"
-          "equiv_asids (aag_can_affect_asid aag l) s s'"
-          "equiv_for (aag_can_affect_domain aag l) ready_queues s s'"
-  using sef by(auto simp: affects_equiv_def2 elim: states_equiv_forE)
-
-
-lemma affects_equiv_machine_state_update:
-  "\<lbrakk>affects_equiv aag l s s'; equiv_machine_state (aag_can_affect aag l) kh kh'\<rbrakk> \<Longrightarrow>
-   affects_equiv aag l (s\<lparr> machine_state := kh \<rparr>) (s'\<lparr> machine_state := kh' \<rparr>)"
-  apply(fastforce simp: affects_equiv_def2 intro: states_equiv_for_machine_state_update)
-  done
-
-lemma affects_equiv_non_asid_pool_kheap_update:
-  "\<lbrakk>affects_equiv aag l s s'; equiv_for (aag_can_affect aag l) id kh kh';
-    non_asid_pool_kheap_update s kh; non_asid_pool_kheap_update s' kh'\<rbrakk> \<Longrightarrow>
-   affects_equiv aag l (s\<lparr> kheap := kh \<rparr>) (s'\<lparr> kheap := kh' \<rparr>)"
-  apply(fastforce simp: affects_equiv_def2 intro: states_equiv_for_non_asid_pool_kheap_update)
-  done
-
-lemma affects_equiv_identical_kheap_updates:
-  "\<lbrakk>affects_equiv aag l s s';
-    identical_kheap_updates s s' kh kh'\<rbrakk> \<Longrightarrow>
-   affects_equiv aag l (s\<lparr> kheap := kh \<rparr>) (s'\<lparr> kheap := kh' \<rparr>)"
-  apply(fastforce simp: affects_equiv_def2 intro: states_equiv_for_identical_kheap_updates)
-  done
-
-lemma affects_equiv_cdt_update:
-  "\<lbrakk>affects_equiv aag l s s'; equiv_for ((aag_can_affect aag l) \<circ> fst) id kh kh'\<rbrakk> \<Longrightarrow>
-   affects_equiv aag l (s\<lparr> cdt := kh \<rparr>) (s'\<lparr> cdt := kh' \<rparr>)"
-  apply(fastforce simp: affects_equiv_def2 intro: states_equiv_for_cdt_update)
-  done
-
-lemma affects_equiv_cdt_list_update:
-  "\<lbrakk>affects_equiv aag l s s'; equiv_for ((aag_can_affect aag l) \<circ> fst) id (kh (cdt_list s)) (kh' (cdt_list s'))\<rbrakk> \<Longrightarrow>
-   affects_equiv aag l (cdt_list_update kh s) (cdt_list_update kh' s')"
-  apply(fastforce simp: affects_equiv_def2 intro: states_equiv_for_cdt_list_update)
-  done
-
-lemma affects_equiv_identical_ekheap_updates:
-  "\<lbrakk>affects_equiv aag l s s'; identical_ekheap_updates s s' (kh (ekheap s)) (kh' (ekheap s'))\<rbrakk> \<Longrightarrow>
-    affects_equiv aag l (ekheap_update kh s) (ekheap_update kh' s')"
-  apply(fastforce simp: affects_equiv_def2 intro: states_equiv_for_identical_ekheap_updates)
-  done
-
-lemma affects_equiv_ekheap_update:
-  "\<lbrakk>affects_equiv aag l s s'; equiv_for (aag_can_affect aag l) id (kh (ekheap s)) (kh' (ekheap s')) \<rbrakk> \<Longrightarrow>
-    affects_equiv aag l (ekheap_update kh s) (ekheap_update kh' s')"
-  apply(fastforce simp: affects_equiv_def2 intro: states_equiv_for_ekheap_update)
-  done
-
-lemma affects_equiv_is_original_cap_update:
-  "\<lbrakk>affects_equiv aag l s s'; equiv_for ((aag_can_affect aag l) \<circ> fst) id kh kh'\<rbrakk> \<Longrightarrow>
-   affects_equiv aag l (s\<lparr> is_original_cap := kh \<rparr>) (s'\<lparr> is_original_cap := kh' \<rparr>)"
-  apply(fastforce simp: affects_equiv_def2 intro: states_equiv_for_is_original_cap_update)
-  done
-
-lemma affects_equiv_interrupt_states_update:
-  "\<lbrakk>affects_equiv aag l s s'; equiv_for (aag_can_affect_irq aag l) id kh kh'\<rbrakk> \<Longrightarrow>
-   affects_equiv aag l (s\<lparr> interrupt_states := kh \<rparr>) (s'\<lparr> interrupt_states := kh' \<rparr>)"
-  apply(fastforce simp: affects_equiv_def2 intro: states_equiv_for_interrupt_states_update)
-  done
-
-lemma affects_equiv_interrupt_irq_node_update:
-  "\<lbrakk>affects_equiv aag l s s'; equiv_for (aag_can_affect_irq aag l) id kh kh'\<rbrakk> \<Longrightarrow>
-   affects_equiv aag l (s\<lparr> interrupt_irq_node := kh \<rparr>) (s'\<lparr> interrupt_irq_node := kh' \<rparr>)"
-  apply(fastforce simp: affects_equiv_def2 intro: states_equiv_for_interrupt_irq_node_update)
-  done
-
-lemma affects_equiv_ready_queues_update:
-  "\<lbrakk>affects_equiv aag l s s'; equiv_for (aag_can_affect_domain aag l) id kh kh'\<rbrakk> \<Longrightarrow>
-   affects_equiv aag l (s\<lparr> ready_queues := kh \<rparr>) (s'\<lparr> ready_queues := kh' \<rparr>)"
-  apply(fastforce simp: affects_equiv_def2 intro: states_equiv_for_ready_queues_update)
-  done
-
-lemma affects_equiv_scheduler_action_update:
-  "affects_equiv aag l s s' \<Longrightarrow>
-   affects_equiv aag l (s\<lparr> scheduler_action := kh \<rparr>) (s'\<lparr> scheduler_action := kh \<rparr>)"
-  apply(fastforce simp: affects_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
-  done
-
-lemma affects_equiv_work_units_completed_update:
-  "affects_equiv aag l s s' \<Longrightarrow>
-   affects_equiv aag l (s\<lparr> work_units_completed := kh \<rparr>) (s'\<lparr> work_units_completed := kh \<rparr>)"
-  apply(fastforce simp: affects_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
-  done
-
-lemma affects_equiv_work_units_completed_update':
-  "affects_equiv aag l s s' \<Longrightarrow>
-   affects_equiv aag l (s\<lparr> work_units_completed := (f (work_units_completed s)) \<rparr>)
-                       (s'\<lparr> work_units_completed := (f (work_units_completed s')) \<rparr>)"
-  apply(fastforce simp: affects_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
-  done
-
-(* reads_equiv and affects_equiv want to be equivalence relations *)
-lemma reads_equiv_refl:
-  "reads_equiv aag s s"
-  by(auto simp: reads_equiv_def2 intro: states_equiv_for_refl equiv_asids_refl)
-
-lemma reads_equiv_sym:
-  "reads_equiv aag s t \<Longrightarrow> reads_equiv aag t s"
-  by(auto simp: reads_equiv_def2 intro: states_equiv_for_sym equiv_asids_sym)
-
-lemma reads_equiv_trans:
-  "\<lbrakk>reads_equiv aag s t; reads_equiv aag t u\<rbrakk> \<Longrightarrow>
-   reads_equiv aag s u"
-  by(auto simp: reads_equiv_def2 intro: states_equiv_for_trans equiv_asids_trans)
-
-lemma affects_equiv_refl:
-  "affects_equiv aag l s s"
-  by(auto simp: affects_equiv_def intro: states_equiv_for_refl equiv_asids_refl)
-
-lemma affects_equiv_sym:
-  "affects_equiv aag l s t \<Longrightarrow> affects_equiv aag l t s"
-  by(auto simp: affects_equiv_def2 intro: states_equiv_for_sym equiv_asids_sym)
-
-lemma affects_equiv_trans:
-  "\<lbrakk>affects_equiv aag l s t; affects_equiv aag l t u\<rbrakk> \<Longrightarrow>
-   affects_equiv aag l s u"
-  by(auto simp: affects_equiv_def2 intro: states_equiv_for_trans equiv_asids_trans)
 
 section \<open>reads_respects\<close>
 
-abbreviation reads_equiv_valid
-  :: "(det_state \<Rightarrow> det_state \<Rightarrow> bool) \<Rightarrow> (det_state \<Rightarrow> det_state \<Rightarrow> bool) \<Rightarrow>
-      'a PAS \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool"
-where
+abbreviation reads_equiv_valid ::
+  "(det_state \<Rightarrow> det_state \<Rightarrow> bool) \<Rightarrow> (det_state \<Rightarrow> det_state \<Rightarrow> bool) \<Rightarrow>
+   'a PAS \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool" where
   "reads_equiv_valid A B aag P f \<equiv> equiv_valid (reads_equiv aag) A B P f"
 
-abbreviation reads_equiv_valid_inv
-where
+abbreviation reads_equiv_valid_inv where
   "reads_equiv_valid_inv A aag P f \<equiv> reads_equiv_valid A A aag P f"
 
-
-abbreviation reads_spec_equiv_valid
-  :: "det_state \<Rightarrow> (det_state \<Rightarrow> det_state \<Rightarrow> bool) \<Rightarrow>
-      (det_state \<Rightarrow> det_state \<Rightarrow> bool) \<Rightarrow> 'a PAS \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow>
-      (det_state,'b) nondet_monad \<Rightarrow> bool"
-where
+abbreviation reads_spec_equiv_valid ::
+  "det_state \<Rightarrow> (det_state \<Rightarrow> det_state \<Rightarrow> bool) \<Rightarrow> (det_state \<Rightarrow> det_state \<Rightarrow> bool) \<Rightarrow>
+   'a PAS \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool" where
   "reads_spec_equiv_valid s A B aag P f \<equiv> spec_equiv_valid s (reads_equiv aag) A B P f"
 
-abbreviation reads_spec_equiv_valid_inv
-where
+abbreviation reads_spec_equiv_valid_inv where
   "reads_spec_equiv_valid_inv s A aag P f \<equiv> reads_spec_equiv_valid s A A aag P f"
-
 
 (* This property is essentially the confidentiality unwinding condition for
    noninterference. *)
-abbreviation reads_respects
-  :: "'a PAS \<Rightarrow> 'a \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool"
-where
-  "reads_respects aag l P f \<equiv>
-   reads_equiv_valid_inv (affects_equiv aag l) aag P f"
+abbreviation reads_respects ::
+  "'a PAS \<Rightarrow> 'a \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool" where
+  "reads_respects aag l P f \<equiv> reads_equiv_valid_inv (affects_equiv aag l) aag P f"
 
-abbreviation spec_reads_respects
-  :: "det_state \<Rightarrow> 'a PAS \<Rightarrow> 'a \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool"
-where
+abbreviation spec_reads_respects ::
+  "det_state \<Rightarrow> 'a PAS \<Rightarrow> 'a \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool" where
   "spec_reads_respects s aag l P f \<equiv> reads_spec_equiv_valid_inv s (affects_equiv aag l) aag P f"
 
-abbreviation reads_respects_g
-  :: "'a PAS \<Rightarrow> 'a \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool"
-where
-  "reads_respects_g aag l P f \<equiv>
-   equiv_valid_inv (reads_equiv_g aag) (affects_equiv aag l) P f"
+abbreviation reads_respects_g ::
+  "'a PAS \<Rightarrow> 'a \<Rightarrow> (det_state \<Rightarrow> bool) \<Rightarrow> (det_state,'b) nondet_monad \<Rightarrow> bool" where
+  "reads_respects_g aag l P f \<equiv> equiv_valid_inv (reads_equiv_g aag) (affects_equiv aag l) P f"
 
-definition doesnt_touch_globals
-where
-  "doesnt_touch_globals P f \<equiv>
-   \<forall> s. P s \<longrightarrow> (\<forall>(rv,s')\<in>fst (f s). globals_equiv s s')"
+definition doesnt_touch_globals where
+  "doesnt_touch_globals P f \<equiv> \<forall>(s :: det_state). P s \<longrightarrow> (\<forall>(rv,s')\<in>fst (f s). globals_equiv s s')"
 
-lemma globals_equivI:
-  "\<lbrakk>doesnt_touch_globals P f; P s; (rv,s')\<in>fst(f s)\<rbrakk> \<Longrightarrow> globals_equiv s s'"
-  by(fastforce simp: doesnt_touch_globals_def)
-
-lemma reads_equiv_gD:
-  "reads_equiv_g aag s s' \<Longrightarrow> reads_equiv aag s s' \<and> globals_equiv s s'"
-  by(simp add: reads_equiv_g_def)
-
-lemma reads_equiv_gI:
-  "\<lbrakk>reads_equiv aag s s'; globals_equiv s s'\<rbrakk> \<Longrightarrow> reads_equiv_g aag s s'"
-  by(simp add: reads_equiv_g_def)
-
-lemma globals_equiv_refl:
-  "globals_equiv s s"
-  by(simp add: globals_equiv_def idle_equiv_refl)
-
-lemma globals_equiv_sym:
-  "globals_equiv s t \<Longrightarrow> globals_equiv t s"
-  by(auto simp: globals_equiv_def idle_equiv_def)
-
-
-lemma globals_equiv_trans:
-  "\<lbrakk>globals_equiv s t; globals_equiv t u\<rbrakk> \<Longrightarrow> globals_equiv s u"
-  unfolding globals_equiv_def
-  by clarsimp (metis idle_equiv_trans idle_equiv_def)
-
-(* since doesnt_touch_globals is true for all of the kernel except the scheduler,
-   the following lemma shows that we can just prove reads_respects for it, and
-   from there get the stronger reads_respects_g result that we need for the
-   noninterference theorem *)
-lemma reads_respects_g:
-  "\<lbrakk>reads_respects aag l P f; doesnt_touch_globals Q f\<rbrakk> \<Longrightarrow>
-   reads_respects_g aag l (P and Q) f"
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
-  apply(drule reads_equiv_gD)
-  apply(subgoal_tac "globals_equiv b ba", fastforce intro: reads_equiv_gI)
-  apply(rule globals_equiv_trans)
-   apply(rule globals_equiv_sym)
-   apply(fastforce intro: globals_equivI)
-  apply(rule globals_equiv_trans)
-   apply(elim conjE, assumption)
-  apply(fastforce intro: globals_equivI)
-  done
-
-
-
-(* prove doesnt_touch_globals as an invariant *)
-lemma globals_equiv_invD:
-  "\<lbrace> globals_equiv st and P \<rbrace> f \<lbrace> \<lambda>_. globals_equiv st \<rbrace> \<Longrightarrow>
-   \<lbrace> P and (=) st \<rbrace> f \<lbrace> \<lambda>_. globals_equiv st \<rbrace>"
-  by(fastforce simp: valid_def intro: globals_equiv_refl)
-
-lemma doesnt_touch_globalsI:
-  assumes globals_equiv_inv:
-    "\<And> st. \<lbrace> globals_equiv st and P \<rbrace> f \<lbrace> \<lambda>_. globals_equiv st \<rbrace>"
-  shows "doesnt_touch_globals P f"
-  apply(clarsimp simp: doesnt_touch_globals_def)
-  apply(cut_tac st=s in globals_equiv_inv)
-  apply(drule globals_equiv_invD)
-  by(fastforce simp: valid_def)
-
-
-(* Slightly nicer to use version to lift up trivial cases*)
-lemma reads_respects_g_from_inv:
-  "\<lbrakk>reads_respects aag l P f; \<And>st. invariant f (globals_equiv st)\<rbrakk> \<Longrightarrow>
-  reads_respects_g aag l P f"
-  apply (rule equiv_valid_guard_imp)
-   apply (erule reads_respects_g[where Q="\<lambda>s. True"])
-   apply (rule doesnt_touch_globalsI)
-   apply simp+
-  done
-
-
-(*Useful for chaining OFs so we don't have to re-state rules*)
-lemma reads_respects_g':
-  assumes rev: "reads_respects aag l P f"
-  assumes gev: "\<And>st. \<lbrace>\<lambda> s. R (globals_equiv st s) s\<rbrace> f \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  assumes and_imp: "\<And> st s. Q st s \<Longrightarrow> P s \<and> R (globals_equiv st s) s"
-  assumes gev_imp: "\<And> st s. R (globals_equiv st s) s \<Longrightarrow> globals_equiv st s"
-  shows
-   "reads_respects_g aag l (Q st) f"
-  apply (rule equiv_valid_guard_imp)
-   apply (rule reads_respects_g[OF rev, where Q="\<lambda>s. R (globals_equiv st s) s"])
-   apply (rule doesnt_touch_globalsI)
-   apply (rule hoare_pre)
-    apply (rule gev)
-   apply clarsimp
-   apply (frule gev_imp)
-   apply (simp add: and_imp)+
-  done
-
-
-lemma equiv_for_guard_imp:
-  "\<lbrakk>equiv_for P f s s'; \<And> x. Q x \<Longrightarrow> P x\<rbrakk> \<Longrightarrow> equiv_for Q f s s'"
-  by(auto simp: equiv_for_def)
-
-lemma equiv_asids_guard_imp:
-  "\<lbrakk>equiv_asids R s s'; \<And> x. Q x \<Longrightarrow> R x\<rbrakk> \<Longrightarrow>  equiv_asids Q s s'"
-  by(auto simp: equiv_asids_def)
-
-lemma states_equiv_for_guard_imp:
-  "\<lbrakk>states_equiv_for P Q R S s s'; \<And> x. P' x \<Longrightarrow> P x; \<And> x. Q' x \<Longrightarrow> Q x; \<And> x. R' x \<Longrightarrow> R x;
-    \<And> x. S' x \<Longrightarrow> S x\<rbrakk> \<Longrightarrow> states_equiv_for P' Q' R' S' s s'"
-  by(auto simp: states_equiv_for_def intro: equiv_for_guard_imp equiv_asids_guard_imp)
-
-lemma cur_subject_reads_equiv_affects_equiv:
-  "pasSubject aag = l \<Longrightarrow>
-   reads_equiv aag s s' \<Longrightarrow> affects_equiv aag l s s'"
-  apply(auto simp: reads_equiv_def2 affects_equiv_def equiv_for_def states_equiv_for_def)
-  done
-
-(* This lemma says that, if we prove reads_respects above for all l, we will
-   prove that information can flow into the domain only from what it is allowed
-   to read. *)
-lemma reads_equiv_self_reads_respects:
-  "pasSubject aag = l \<Longrightarrow>
-   reads_equiv_valid_inv \<top>\<top> aag P f = reads_respects aag l P f"
-  unfolding equiv_valid_def2 equiv_valid_2_def
-  apply(fastforce intro: cur_subject_reads_equiv_affects_equiv)
-  done
-
-lemma requiv_get_tcb_eq[intro]:
-  "\<lbrakk>reads_equiv aag s t; is_subject aag thread\<rbrakk> \<Longrightarrow> get_tcb thread s = get_tcb thread t"
-  apply(auto simp: reads_equiv_def2 elim: states_equiv_forE_kheap dest!: aag_can_read_self
-             simp: get_tcb_def split: option.split kernel_object.split)
-  done
-
-lemma requiv_cur_thread_eq[intro]:
-  "reads_equiv aag s t \<Longrightarrow> cur_thread s = cur_thread t"
-  apply (simp add: reads_equiv_def2)
-  done
-
-lemma requiv_cur_domain_eq[intro]:
-  "reads_equiv aag s t \<Longrightarrow> cur_domain s = cur_domain t"
-  apply (simp add: reads_equiv_def2)
-  done
-
-lemma requiv_sched_act_eq[intro]:
-  "reads_equiv aag s t \<Longrightarrow> scheduler_action s = scheduler_action t"
-  apply (simp add: reads_equiv_def2)
-  done
-
-lemma requiv_wuc_eq[intro]:
-  "reads_equiv aag s t \<Longrightarrow> work_units_completed s = work_units_completed t"
-  apply (simp add: reads_equiv_def2)
-  done
-
-lemma set_object_reads_respects:
-  "reads_respects aag l \<top> (set_object ptr obj)"
-  unfolding set_object_def
-  apply(clarsimp simp: set_object_def bind_def' get_def gets_def put_def return_def fail_def assert_def
-                       get_object_def identical_kheap_updates_def
-                 cong del: if_weak_cong)
-  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
-  apply (rule conjI)
-   apply (erule reads_equiv_identical_kheap_updates)
-   apply (clarsimp simp: identical_kheap_updates_def)
-  apply (erule affects_equiv_identical_kheap_updates)
-  apply (clarsimp simp: identical_kheap_updates_def)
-  done
-
-lemma update_object_noop:
-  "kheap s ptr = Some obj \<Longrightarrow> s\<lparr>kheap := kheap s(ptr \<mapsto> obj)\<rparr> = s"
-  apply(subgoal_tac "kheap s(ptr \<mapsto> obj) = kheap s")
-   apply(simp)
-  apply(blast intro: map_upd_triv)
-  done
-
-lemma set_object_rev:
-  "reads_equiv_valid_inv A aag (\<lambda> s. kheap s ptr = Some obj \<and> is_subject aag ptr) (set_object ptr obj)"
-  unfolding equiv_valid_def2 equiv_valid_2_def
-  apply(clarsimp simp: set_object_def bind_def get_def gets_def put_def return_def assert_def get_object_def)
-  apply(fastforce dest: update_object_noop)
-  done
-
-lemma lookup_error_on_failure_rev:
-  "reads_equiv_valid_inv A aag P m \<Longrightarrow>
-   reads_equiv_valid_inv A aag P (lookup_error_on_failure s m)"
-  unfolding lookup_error_on_failure_def
-  apply(unfold handleE'_def)
-  apply (wp | wpc | simp)+
-  done
-
-abbreviation reads_equiv_valid_rv
-where
+abbreviation reads_equiv_valid_rv where
   "reads_equiv_valid_rv A B aag R P f \<equiv> equiv_valid_2 (reads_equiv aag) A B R P P f f"
 
-abbreviation reads_equiv_valid_rv_inv
-where
+abbreviation reads_equiv_valid_rv_inv where
   "reads_equiv_valid_rv_inv A aag R P f \<equiv> reads_equiv_valid_rv A A aag R P f"
 
-section \<open>Basic getters/modifiers lemmas\<close>
-
-lemma gets_kheap_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
-               (equiv_for (aag_can_read aag or aag_can_affect aag l) id) \<top> (gets kheap)"
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule gets_evrv)
-  apply(fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist
-                  elim: reads_equivE affects_equivE)
-  done
-
-lemma gets_kheap_revrv':
-  "reads_equiv_valid_rv_inv A aag (equiv_for (aag_can_read aag) id) \<top> (gets kheap)"
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule gets_evrv)
-  apply(fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist elim: reads_equivE)
-  done
-
-abbreviation equiv_irq_state
-where
-  "equiv_irq_state ms ms' \<equiv> irq_state ms = irq_state ms'"
-
-lemma gets_machine_state_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
-          (equiv_machine_state (aag_can_read aag or aag_can_affect aag l) And equiv_irq_state)
-          \<top> (gets machine_state)"
-  apply(simp add: gets_def get_def return_def bind_def)
-  apply(clarsimp simp: equiv_valid_2_def)
-  apply(fastforce intro: equiv_forI elim: reads_equivE affects_equivE equiv_forE)
-  done
-
-lemma gets_machine_state_revrv':
-  "reads_equiv_valid_rv_inv A aag (equiv_machine_state (aag_can_read aag) And equiv_irq_state) \<top>
-                           (gets machine_state)"
-  apply(simp add: gets_def get_def return_def bind_def)
-  apply(clarsimp simp: equiv_valid_2_def)
-  apply(fastforce intro: equiv_forI elim: reads_equivE affects_equivE equiv_forE)
-  done
-
-lemma gets_cdt_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
-                            (equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id)
-                            \<top> (gets cdt)"
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule gets_evrv)
-  apply(fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist
-                  elim: reads_equivE affects_equivE)
-  done
-
-
-lemma gets_cdt_revrv':
-  "reads_equiv_valid_rv_inv A aag (equiv_for (aag_can_read aag \<circ> fst) id) \<top> (gets cdt)"
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule gets_evrv)
-  apply(fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist elim: reads_equivE)
-  done
-
-lemma internal_exst[simp]:"cdt_list_internal o exst = cdt_list"
-                           "ekheap_internal o exst = ekheap"
-  apply (simp add: o_def)+
-  done
-
-lemma gets_cdt_list_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
-                            (equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id)
-                            \<top> (gets cdt_list)"
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule gets_evrv)
-  apply(fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist
-                  elim: reads_equivE affects_equivE)
-  done
-
-
-lemma gets_cdt_list_revrv':
-  "reads_equiv_valid_rv_inv A aag (equiv_for (aag_can_read aag \<circ> fst) id) \<top> (gets cdt_list)"
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule gets_evrv)
-  apply(fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist elim: reads_equivE)
-  done
-
-lemma gets_ekheap_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
-                            (equiv_for (aag_can_read aag or aag_can_affect aag l) id) \<top> (gets ekheap)"
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule gets_evrv)
-  apply(fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist
-                  elim: reads_equivE affects_equivE)
-  done
-
-lemma gets_ekheap_revrv':
-  "reads_equiv_valid_rv_inv A aag (equiv_for (aag_can_read aag) id) \<top> (gets kheap)"
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule gets_evrv)
-  apply(fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist elim: reads_equivE)
-  done
-
-lemma gets_is_original_cap_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
-                            (equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id)
-                            \<top> (gets is_original_cap)"
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule gets_evrv)
-  apply(fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist
-                  elim: reads_equivE affects_equivE)
-  done
-
-lemma gets_is_original_cap_revrv':
-  "reads_equiv_valid_rv_inv A aag (equiv_for (aag_can_read aag \<circ> fst) id) \<top> (gets is_original_cap)"
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule gets_evrv)
-  apply(fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist elim: reads_equivE)
-  done
-
-lemma gets_ready_queues_revrv:
-  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
-                            (equiv_for (aag_can_read_domain aag or aag_can_affect_domain aag l) id)
-                            \<top> (gets ready_queues)"
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule gets_evrv)
-  (* NB: only clarsimp works here *)
-  apply(clarsimp simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist equiv_for_def disjoint_iff_not_equal
-                 elim!: reads_equivE affects_equivE)
-  done
-
-
-lemma gets_ready_queues_revrv':
-  "reads_equiv_valid_rv_inv A aag (equiv_for (aag_can_read_domain aag) id) \<top> (gets ready_queues)"
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule gets_evrv)
-  (* NB: only force works here *)
-  apply(force simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist equiv_for_def disjoint_iff_not_equal
-              elim: reads_equivE)
-  done
-
-
-(* We want to prove this kind of thing for functions that don't modify the
-   state *)
-lemma gets_cur_thread_ev:
-  "reads_equiv_valid_inv A aag \<top> (gets cur_thread)"
-  apply (rule equiv_valid_guard_imp)
-  apply wp
-  apply (simp add: reads_equiv_def)
-  done
-
-lemma as_user_rev:
-  "reads_equiv_valid_inv A aag (K (det f \<and> (\<forall>P. invariant f P) \<and> is_subject aag thread)) (as_user thread f)"
-  unfolding as_user_def fun_app_def split_def
-  apply (wp set_object_rev select_f_ev)
-  apply (rule conjI, fastforce)
-  apply (clarsimp split: option.split_asm kernel_object.split_asm simp: get_tcb_def)
-  apply (drule state_unchanged[rotated,symmetric])
-   apply simp_all
-  done
-
-lemma as_user_reads_respects:
-  "reads_respects aag l (K (det f \<and> is_subject aag thread)) (as_user thread f)"
-  apply (simp add: as_user_def split_def)
-  apply (rule gen_asm_ev)
-  apply (wp set_object_reads_respects select_f_ev gets_the_ev)
-  apply fastforce
-  done
-
-lemma get_message_info_rev:
-  "reads_equiv_valid_inv A aag (K (is_subject aag ptr)) (get_message_info ptr)"
-  apply (simp add: get_message_info_def)
-  apply (wp as_user_rev | clarsimp simp: getRegister_def)+
-  done
-
-lemma syscall_rev:
-  assumes reads_res_m_fault:
-    "reads_equiv_valid_inv A aag P m_fault"
-  assumes reads_res_m_error:
-    "\<And> v. reads_equiv_valid_inv A aag (Q (Inr v)) (m_error v)"
-  assumes reads_res_h_fault:
-    "\<And> v. reads_equiv_valid_inv A aag (Q (Inl v)) (h_fault v)"
-  assumes reads_res_m_finalise:
-    "\<And> v. reads_equiv_valid_inv A aag (R (Inr v)) (m_finalise v)"
-  assumes reads_res_h_error:
-    "\<And> v. reads_equiv_valid_inv A aag (R (Inl v)) (h_error v)"
-  assumes m_fault_hoare:
-    "\<lbrace> P \<rbrace> m_fault \<lbrace> Q \<rbrace>"
-  assumes m_error_hoare:
-    "\<And> v. \<lbrace> Q (Inr v) \<rbrace> m_error v \<lbrace> R \<rbrace>"
-  shows "reads_equiv_valid_inv A aag P (Syscall_A.syscall m_fault h_fault m_error h_error m_finalise)"
-  unfolding Syscall_A.syscall_def without_preemption_def fun_app_def
-  apply (wp assms equiv_valid_guard_imp[OF liftE_bindE_ev]
-       | rule hoare_strengthen_post[OF m_error_hoare]
-       | rule hoare_strengthen_post[OF m_fault_hoare]
-       | wpc
-       | fastforce)+
-  done
-
-lemma syscall_reads_respects_g:
-  assumes reads_res_m_fault:
-    "reads_respects_g aag l P m_fault"
-  assumes reads_res_m_error:
-    "\<And> v. reads_respects_g aag l (Q'' v) (m_error v)"
-  assumes reads_res_h_fault:
-    "\<And> v. reads_respects_g aag l (Q' v) (h_fault v)"
-  assumes reads_res_m_finalise:
-    "\<And> v. reads_respects_g aag l (R'' v) (m_finalise v)"
-  assumes reads_res_h_error:
-    "\<And> v. reads_respects_g aag l (R' v) (h_error v)"
-  assumes m_fault_hoare:
-    "\<lbrace> P \<rbrace> m_fault \<lbrace> case_sum Q' Q'' \<rbrace>"
-  assumes m_error_hoare:
-    "\<And> v. \<lbrace> Q'' v \<rbrace> m_error v \<lbrace> case_sum R' R'' \<rbrace>"
-  shows "reads_respects_g aag l P (Syscall_A.syscall m_fault h_fault m_error h_error m_finalise)"
-  unfolding Syscall_A.syscall_def without_preemption_def fun_app_def
-  apply (wp assms equiv_valid_guard_imp[OF liftE_bindE_ev]
-       | rule hoare_strengthen_post[OF m_error_hoare]
-       | rule hoare_strengthen_post[OF m_fault_hoare]
-       | wpc
-       | fastforce)+
-  done
-
-
-lemma do_machine_op_spec_reads_respects':
-  assumes equiv_dmo:
-   "equiv_valid_inv (equiv_machine_state (aag_can_read aag) And equiv_irq_state)
-                    (equiv_machine_state (aag_can_affect aag l) ) \<top> f"
-  shows
-  "spec_reads_respects st aag l \<top> (do_machine_op f)"
-  unfolding do_machine_op_def spec_equiv_valid_def
-  apply(rule equiv_valid_2_guard_imp)
-   apply(rule_tac R'="\<lambda> rv rv'. equiv_machine_state (aag_can_read aag or aag_can_affect aag l) rv rv'
-                               \<and> equiv_irq_state rv rv'"
-              and Q="\<lambda> r s. st = s" and Q'="\<top>\<top>" and P="(=) st" and P'="\<top>"  in equiv_valid_2_bind)
-       apply(rule_tac R'="\<lambda> (r, ms') (r', ms'').  r = r'
-                                   \<and> equiv_machine_state (aag_can_read aag)  ms' ms''
-                                   \<and> equiv_machine_state (aag_can_affect aag l)  ms' ms''
-                                   \<and> equiv_irq_state ms' ms''"
-                  and Q="\<lambda> r s. st = s" and Q'="\<top>\<top>" and P="\<top>" and P'="\<top>"
-             in equiv_valid_2_bind_pre)
-            apply(clarsimp simp: modify_def get_def put_def bind_def return_def equiv_valid_2_def)
-            apply(fastforce intro: reads_equiv_machine_state_update affects_equiv_machine_state_update)
-            apply(insert equiv_dmo)[1]
-           apply(clarsimp simp: select_f_def equiv_valid_2_def equiv_valid_def2 equiv_for_or
-                                split_def equiv_for_def
-                         split: prod.splits)
-           apply(drule_tac x=rv in spec, drule_tac x=rv' in spec)
-           apply(fastforce)
-          apply(rule select_f_inv)
-         apply(rule wp_post_taut)
-        apply simp+
-      apply(clarsimp simp: equiv_valid_2_def in_monad)
-      apply(fastforce elim: reads_equivE affects_equivE equiv_forE intro: equiv_forI)
-     apply(wp | simp)+
-  done
-
-(* most of the time (i.e. always except for getActiveIRQ) you'll want this rule *)
-lemma do_machine_op_spec_reads_respects:
-  assumes equiv_dmo:
-   "equiv_valid_inv (equiv_machine_state (aag_can_read aag)) (equiv_machine_state (aag_can_affect aag l)) \<top> f"
-  assumes irq_state_inv:
-    "\<And>P. \<lbrace>\<lambda>ms. P (irq_state ms)\<rbrace> f \<lbrace>\<lambda>_ ms. P (irq_state ms)\<rbrace>"
-  shows
-  "spec_reads_respects st aag l \<top> (do_machine_op f)"
-  apply(rule do_machine_op_spec_reads_respects')
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
-  apply(subgoal_tac "equiv_irq_state b ba", simp)
-   apply(insert equiv_dmo, fastforce simp: equiv_valid_def2 equiv_valid_2_def)
-  apply(insert irq_state_inv)
-  apply(drule_tac x="\<lambda>ms. ms = irq_state s" in meta_spec)
-  apply(clarsimp simp: valid_def)
-  apply(frule_tac x=s in spec)
-  apply(erule (1) impE)
-  apply(drule bspec, assumption, simp)
-  apply(drule_tac x=t in spec, simp)
-  apply(drule bspec, assumption)
-  apply simp
-  done
-
-
-lemma do_machine_op_spec_rev:
-  assumes equiv_dmo:
-   "spec_equiv_valid_inv (machine_state st) (equiv_machine_state (aag_can_read aag)) \<top>\<top> \<top> f"
-  assumes mo_inv: "\<And> P. invariant f P"
-  shows
-  "reads_spec_equiv_valid_inv st A aag P (do_machine_op f)"
-  unfolding do_machine_op_def spec_equiv_valid_def
-  apply(rule equiv_valid_2_guard_imp)
-   apply(rule_tac R'="\<lambda> rv rv'. equiv_machine_state (aag_can_read aag) rv rv' \<and>
-                                equiv_irq_state rv rv'"
-              and Q="\<lambda> r s. st = s \<and> r = machine_state s"
-              and Q'="\<lambda>r s. r = machine_state s"
-              and P="(=) st" and P'="\<top>"
-               in equiv_valid_2_bind)
-       apply(rule_tac R'="\<lambda> (r, ms') (r', ms'').  r = r' \<and>
-                                        equiv_machine_state (aag_can_read aag) ms' ms''"
-                  and Q="\<lambda> (r,ms') s. ms' = rv \<and> rv = machine_state s \<and> st = s"
-                  and Q'="\<lambda> (r,ms') s. ms' = rv' \<and> rv' = machine_state s"
-                  and P="\<lambda> s. st = s \<and> rv = machine_state s" and P'="\<lambda> s. rv' = machine_state s"
-                  and S="\<lambda> s. st = s \<and> rv = machine_state s" and S'="\<lambda>s. rv' = machine_state s"
-                   in equiv_valid_2_bind_pre)
-            apply(clarsimp simp: modify_def get_def put_def bind_def return_def equiv_valid_2_def)
-           apply(clarsimp simp: select_f_def equiv_valid_2_def equiv_valid_def2 equiv_for_or
-                                split_def equiv_for_def
-                         split: prod.splits)
-           apply(insert equiv_dmo)[1]
-           apply(clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
-           apply(drule_tac x="machine_state t" in spec)
-           apply(clarsimp simp: equiv_for_def)
-           apply blast
-          apply(wp select_f_inv)
-          apply clarsimp
-          apply(drule state_unchanged[OF mo_inv], simp)
-         apply(wp select_f_inv)
-         apply clarsimp
-         apply(drule state_unchanged[OF mo_inv], simp)
-        apply simp+
-      apply(clarsimp simp: equiv_valid_2_def in_monad)
-      apply(fastforce intro: elim: equiv_forE reads_equivE)
-     apply(wp | simp)+
-  done
-
-lemma do_machine_op_rev:
-  assumes equiv_dmo: "equiv_valid_inv (equiv_machine_state (aag_can_read aag)) \<top>\<top> \<top> f"
-  assumes mo_inv: "\<And> P. invariant f P"
-  shows "reads_equiv_valid_inv A aag \<top> (do_machine_op f)"
-  unfolding do_machine_op_def equiv_valid_def2
-  apply(rule_tac W="\<lambda> rv rv'. equiv_machine_state (aag_can_read aag) rv rv' \<and> equiv_irq_state rv rv'"
-             and Q="\<lambda> rv s. rv = machine_state s " in equiv_valid_rv_bind)
-    apply(blast intro: equiv_valid_rv_guard_imp[OF gets_machine_state_revrv'[simplified bipred_conj_def]])
-   apply(rule_tac R'="\<lambda> (r, ms') (r', ms'').  r = r' \<and> equiv_machine_state (aag_can_read aag) ms' ms''"
-              and Q="\<lambda> (r,ms') s. ms' = rv \<and> rv = machine_state s "
-              and Q'="\<lambda> (r',ms'') s. ms'' = rv' \<and> rv' = machine_state s"
-              and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
-        apply(clarsimp simp: modify_def get_def put_def bind_def return_def equiv_valid_2_def)
-       apply(clarsimp simp: select_f_def equiv_valid_2_def)
-       apply(insert equiv_dmo, clarsimp simp: equiv_valid_def2 equiv_valid_2_def)[1]
-       apply(blast)
-    apply(wp select_f_inv)+
-    apply(fastforce simp: select_f_def dest: state_unchanged[OF mo_inv])+
-  done
-
-definition for_each_byte_of_word :: "(word32 \<Rightarrow> bool) \<Rightarrow> word32 \<Rightarrow> bool"
-where
-  "for_each_byte_of_word P w \<equiv> \<forall> y\<in>{w..w + 3}. P y"
-
-lemma spec_equiv_valid_hoist_guard:
-  "((P st) \<Longrightarrow> spec_equiv_valid_inv st I A \<top> f) \<Longrightarrow> spec_equiv_valid_inv st I A P f"
-  apply(clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
-  done
-
-lemma dmo_loadWord_rev:
-  "reads_equiv_valid_inv A aag (K (for_each_byte_of_word (aag_can_read aag) p))
-     (do_machine_op (loadWord p))"
-  apply(rule gen_asm_ev)
-  apply(rule use_spec_ev)
-  apply(rule spec_equiv_valid_hoist_guard)
-  apply(rule do_machine_op_spec_rev)
-  apply(simp add: loadWord_def equiv_valid_def2 spec_equiv_valid_def)
-  apply(rule_tac R'="\<lambda> rv rv'. for_each_byte_of_word (\<lambda> y. rv y = rv' y) p" and Q="\<top>\<top>" and Q'="\<top>\<top>"
-             and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
-       apply(rule_tac R'="(=)" and Q="\<lambda> r s. p && mask 2 = 0" and Q'="\<lambda> r s. p && mask 2 = 0"
-                  and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
-            apply(rule return_ev2)
-            apply(rule_tac f="word_rcat" in arg_cong)
-            apply(fastforce intro: is_aligned_no_wrap' word_plus_mono_right
-                             simp: is_aligned_mask for_each_byte_of_word_def) (* slow *)
-           apply(rule assert_ev2[OF refl])
-          apply(rule assert_wp)+
-        apply simp+
-       apply(clarsimp simp: equiv_valid_2_def in_monad for_each_byte_of_word_def)
-       apply(erule equiv_forD)
-       apply fastforce
-      apply (wp wp_post_taut loadWord_inv | simp)+
-  done
-
-lemma for_each_byte_of_word_imp:
-  "(\<And> x. P x \<Longrightarrow> Q x) \<Longrightarrow>
-   for_each_byte_of_word P p \<Longrightarrow> for_each_byte_of_word Q p"
-  apply(fastforce simp: for_each_byte_of_word_def)
-  done
-
-lemma load_word_offs_rev:
-  "\<lbrakk>for_each_byte_of_word (aag_can_read aag) (a + of_nat x * of_nat word_size)\<rbrakk> \<Longrightarrow>
-  reads_equiv_valid_inv A aag \<top> (load_word_offs a x)"
-  unfolding load_word_offs_def fun_app_def
-  apply(rule equiv_valid_guard_imp[OF dmo_loadWord_rev])
-  apply(clarsimp)
-  done
-
-(* generalises auth_ipc_buffers_mem_Write *)
-lemma auth_ipc_buffers_mem_Write':
-  "\<lbrakk> x \<in> auth_ipc_buffers s thread; pas_refined aag s; valid_objs s\<rbrakk>
-  \<Longrightarrow> (pasObjectAbs aag thread, Write, pasObjectAbs aag x) \<in> pasPolicy aag"
-  apply (clarsimp simp add: auth_ipc_buffers_member_def)
-  apply (drule (1) cap_auth_caps_of_state)
-    apply simp
-  apply (clarsimp simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def
-                        vspace_cap_rights_to_auth_def vm_read_write_def is_page_cap_def
-                 split: if_split_asm)
-   apply (auto dest: ipcframe_subset_page)
-  done
 
 section \<open>Constraining modifications to a set of label\<close>
 (*
@@ -1719,41 +428,21 @@ section \<open>Constraining modifications to a set of label\<close>
    cannot be observed. We need to be able to reason about this, hence this
    machinery.
 *)
-definition equiv_but_for_labels
-where
-  "equiv_but_for_labels aag L s s' \<equiv>
-      states_equiv_but_for_labels aag (\<lambda>l. l \<in> L) s s' \<and>
-      cur_thread s = cur_thread s' \<and> cur_domain s = cur_domain s' \<and>
-      scheduler_action s = scheduler_action s' \<and> work_units_completed s = work_units_completed s' \<and>
-      equiv_irq_state (machine_state s) (machine_state s')"
 
-definition equiv_but_for_domain
-where
+abbreviation equiv_irq_state where
+  "equiv_irq_state ms ms' \<equiv> irq_state ms = irq_state ms'"
+
+definition equiv_but_for_labels where
+  "equiv_but_for_labels aag L s s' \<equiv>
+     states_equiv_but_for_labels aag (\<lambda>l. l \<in> L) s s' \<and>
+     cur_thread s = cur_thread s' \<and> cur_domain s = cur_domain s' \<and>
+     scheduler_action s = scheduler_action s' \<and> work_units_completed s = work_units_completed s' \<and>
+     equiv_irq_state (machine_state s) (machine_state s')"
+
+definition equiv_but_for_domain where
   "equiv_but_for_domain aag l s s' \<equiv> equiv_but_for_labels aag (subjectReads (pasPolicy aag) l) s s'"
 
-definition modifies_at_most
-where
-  "modifies_at_most aag L P f \<equiv> \<forall> s. P s \<longrightarrow> (\<forall> (rv,s')\<in>fst(f s). equiv_but_for_labels aag L s s')"
-
-lemma modifies_at_mostD:
-  "\<lbrakk>modifies_at_most aag L P f; P s; (rv,s') \<in> fst(f s)\<rbrakk> \<Longrightarrow>
-   equiv_but_for_labels aag L s s'"
-  by(auto simp: modifies_at_most_def)
-
-lemma modifies_at_mostI:
-  assumes hoare: "\<And> st. \<lbrace> P and equiv_but_for_labels aag L st \<rbrace> f \<lbrace> \<lambda>_. equiv_but_for_labels aag L st \<rbrace>"
-  shows "modifies_at_most aag L P f"
-  apply(clarsimp simp: modifies_at_most_def)
-  apply(erule use_valid)
-   apply(rule hoare)
-  apply(fastforce simp: equiv_but_for_labels_def states_equiv_for_refl)
-  done
-
-(*FIXME: Move*)
-lemma invs_kernel_mappings:
-  "invs s \<Longrightarrow> valid_kernel_mappings s"
-  by (auto simp: invs_def valid_state_def)
-
-end
+definition modifies_at_most where
+  "modifies_at_most aag L P f \<equiv> \<forall>s. P s \<longrightarrow> (\<forall>(rv,s')\<in>fst(f s). equiv_but_for_labels aag L s s')"
 
 end

--- a/proof/infoflow/InfoFlow_IF.thy
+++ b/proof/infoflow/InfoFlow_IF.thy
@@ -1,0 +1,1049 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory InfoFlow_IF
+imports InfoFlow
+begin
+
+section \<open>InfoFlow lemmas\<close>
+
+lemma pas_domains_distinct_inj:
+  "\<lbrakk> pas_domains_distinct aag; l1 \<in> pasDomainAbs aag d; l2 \<in> pasDomainAbs aag d \<rbrakk>
+     \<Longrightarrow> l1 = l2"
+  apply (clarsimp simp: pas_domains_distinct_def)
+  apply (drule_tac x=d in spec)
+  apply auto
+  done
+
+lemma domain_has_unique_label:
+  "pas_domains_distinct aag \<Longrightarrow> \<exists>l. pasDomainAbs aag d = {l}"
+  by (simp add: pas_domains_distinct_def)
+
+lemma domain_has_the_label:
+  "\<lbrakk> pas_domains_distinct aag; l \<in> pasDomainAbs aag d \<rbrakk>
+     \<Longrightarrow> the_elem (pasDomainAbs aag d) = l"
+  apply (simp add: pas_domains_distinct_def)
+  apply (metis singletonD the_elem_eq)
+  done
+
+lemma aag_can_read_self:
+  "is_subject aag x \<Longrightarrow> aag_can_read aag x"
+  by simp
+
+lemma aag_can_read_read:
+  "aag_has_auth_to aag Read x \<Longrightarrow> aag_can_read aag x"
+  by (rule reads_read)
+
+lemma aag_can_read_irq_self:
+  "is_subject_irq aag x \<Longrightarrow> aag_can_read_irq aag x"
+  by simp
+
+lemma equiv_forE:
+  assumes e: "equiv_for P f c c'"
+  obtains "\<And>x. P x \<Longrightarrow> f c x = f c' x"
+  apply (erule meta_mp)
+  apply(erule e[simplified equiv_for_def, rule_format])
+  done
+
+lemma equiv_forI:
+  "(\<And>x. P x \<Longrightarrow> f c x = f c' x) \<Longrightarrow> equiv_for P f c c'"
+  by(simp add: equiv_for_def)
+
+lemma equiv_forD:
+  "\<lbrakk> equiv_for P f c c'; P x \<rbrakk> \<Longrightarrow> f c x = f c' x"
+  by (blast elim: equiv_forE)
+
+lemma equiv_for_comp:
+  "equiv_for P (f \<circ> g) s s' = equiv_for P f (g s) (g s')"
+  by (simp add: equiv_for_def)
+
+lemma equiv_for_or:
+  "equiv_for (A or B) f c c' = (equiv_for A f c c' \<and> equiv_for B f c c')"
+  by (fastforce simp: equiv_for_def)
+
+lemma equiv_for_id_update:
+  "equiv_for P id c c' \<Longrightarrow>
+   equiv_for P id (c(x := v)) (c'(x := v))"
+  by (simp add: equiv_for_def)
+
+lemma states_equiv_forI:
+  "\<lbrakk> equiv_for P kheap s s';
+     equiv_machine_state P (machine_state s) (machine_state s');
+     equiv_for (P \<circ> fst) cdt s s';
+     equiv_for P ekheap s s';
+     equiv_for (P \<circ> fst) cdt_list s s';
+     equiv_for (P \<circ> fst) is_original_cap s s';
+     equiv_for Q interrupt_states s s';
+     equiv_for Q interrupt_irq_node s s';
+     equiv_asids R s s';
+     equiv_for S ready_queues s s' \<rbrakk>
+     \<Longrightarrow> states_equiv_for P Q R S s s'"
+  by (auto simp: states_equiv_for_def)
+
+definition for_each_byte_of_word :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> obj_ref \<Rightarrow> bool" where
+  "for_each_byte_of_word P w \<equiv> \<forall>y\<in>{w..w + (word_size - 1)}. P y"
+
+
+locale InfoFlow_IF_1 =
+  fixes aag :: "'a PAS"
+  assumes equiv_asids_refl:
+    "equiv_asids R s s"
+  and equiv_asids_sym:
+    "equiv_asids R s t \<Longrightarrow> equiv_asids R t s"
+  and equiv_asids_trans:
+    "\<lbrakk> equiv_asids R s t; equiv_asids R t u \<rbrakk> \<Longrightarrow> equiv_asids R s u"
+  and equiv_asids_identical_kheap_updates:
+    "\<lbrakk> equiv_asids R s s'; identical_kheap_updates s s' kh kh' \<rbrakk>
+       \<Longrightarrow> equiv_asids R (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
+  (* FIXME IF: names of the following two lemmas are too similar *)
+  and equiv_asids_trivial:
+  "(\<And>x. P x \<Longrightarrow> False) \<Longrightarrow> equiv_asids P x y"
+  and equiv_asids_triv:
+    "\<lbrakk> equiv_asids R s s'; kheap t = kheap s; kheap t' = kheap s';
+       arch_state t = arch_state s; arch_state t' = arch_state s' \<rbrakk>
+       \<Longrightarrow> equiv_asids R t t'"
+  and equiv_asids_non_asid_pool_kheap_update:
+  "\<lbrakk> equiv_asids R s s'; non_asid_pool_kheap_update s kh; non_asid_pool_kheap_update s' kh' \<rbrakk>
+     \<Longrightarrow> equiv_asids R (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
+  and globals_equiv_refl:
+    "globals_equiv s s"
+  and globals_equiv_sym:
+    "globals_equiv s t \<Longrightarrow> globals_equiv t s"
+  and globals_equiv_trans:
+    "\<lbrakk> globals_equiv s t; globals_equiv t u \<rbrakk> \<Longrightarrow> globals_equiv s u"
+  and equiv_asids_guard_imp:
+    "\<lbrakk> equiv_asids R s s'; \<And>x. Q x \<Longrightarrow> R x \<rbrakk> \<Longrightarrow> equiv_asids Q s s'"
+  and dmo_loadWord_rev:
+    "reads_equiv_valid_inv A aag (K (for_each_byte_of_word (aag_can_read aag) p))
+                                 (do_machine_op (loadWord p))"
+begin
+
+lemma states_equiv_for_machine_state_update:
+  "\<lbrakk> states_equiv_for P Q R S s s'; equiv_machine_state P kh kh' \<rbrakk>
+     \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>machine_state := kh\<rparr>) (s'\<lparr>machine_state := kh'\<rparr>)"
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+               intro: equiv_forI simp: states_equiv_for_def)
+
+lemma states_equiv_for_cdt_update:
+  "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for (P \<circ> fst) id kh kh' \<rbrakk>
+     \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>cdt := kh\<rparr>) (s'\<lparr>cdt := kh'\<rparr>)"
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+               intro: equiv_forI simp: states_equiv_for_def)
+
+lemma states_equiv_for_cdt_list_update:
+  "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for (P \<circ> fst) id (kh (cdt_list s)) (kh' (cdt_list s')) \<rbrakk>
+     \<Longrightarrow> states_equiv_for P Q R S (cdt_list_update kh s) (cdt_list_update kh' s')"
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+               intro: equiv_forI simp: states_equiv_for_def)
+
+lemma states_equiv_for_is_original_cap_update:
+  "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for (P \<circ> fst) id kh kh' \<rbrakk>
+     \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>is_original_cap := kh\<rparr>) (s'\<lparr>is_original_cap := kh'\<rparr>)"
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+               intro: equiv_forI simp: states_equiv_for_def)
+
+lemma states_equiv_for_interrupt_states_update:
+  "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for Q id kh kh' \<rbrakk>
+    \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>interrupt_states := kh\<rparr>) (s'\<lparr>interrupt_states := kh'\<rparr>)"
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+               intro: equiv_forI simp: states_equiv_for_def)
+
+lemma states_equiv_for_interrupt_irq_node_update:
+  "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for Q id kh kh' \<rbrakk>
+     \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>interrupt_irq_node := kh\<rparr>) (s'\<lparr>interrupt_irq_node := kh'\<rparr>)"
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+               intro: equiv_forI simp: states_equiv_for_def)
+
+lemma states_equiv_for_ready_queues_update:
+  "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for S id kh kh' \<rbrakk>
+     \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>ready_queues := kh\<rparr>) (s'\<lparr>ready_queues := kh'\<rparr>)"
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+               intro: equiv_forI simp: states_equiv_for_def)
+
+lemma states_equiv_for_ekheap_update:
+  "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for P id (kh (ekheap s)) (kh' (ekheap s')) \<rbrakk>
+     \<Longrightarrow> states_equiv_for P Q R S (ekheap_update kh s) (ekheap_update kh' s')"
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+               intro: equiv_forI simp: states_equiv_for_def)
+
+lemma states_equiv_for_identical_ekheap_updates:
+  "\<lbrakk> states_equiv_for P Q R S s s'; identical_ekheap_updates s s' (kh (ekheap s)) (kh' (ekheap s')) \<rbrakk>
+     \<Longrightarrow> states_equiv_for P Q R S (ekheap_update kh s) (ekheap_update kh' s')"
+  by (fastforce simp: identical_ekheap_updates_def equiv_for_def states_equiv_for_def equiv_asids_triv)
+
+lemma states_equiv_for_identical_kheap_updates:
+  "\<lbrakk> states_equiv_for P Q R S s s'; identical_kheap_updates s s' kh kh' \<rbrakk>
+     \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
+  by (auto simp: states_equiv_for_def identical_kheap_updates_def
+          elim!: equiv_forE equiv_asids_identical_kheap_updates
+         intro!: equiv_forI)
+
+end
+
+
+lemma states_equiv_forE:
+  assumes sef: "states_equiv_for P Q R S s s'"
+  obtains "equiv_machine_state P (machine_state s) (machine_state s')"
+          "equiv_for P kheap s s'"
+          "equiv_for (P \<circ> fst) cdt s s'"
+          "equiv_for (P \<circ> fst) cdt_list s s'"
+          "equiv_for P ekheap s s'"
+          "equiv_for (P \<circ> fst) is_original_cap s s'"
+          "equiv_for Q interrupt_states s s'"
+          "equiv_for Q interrupt_irq_node s s'"
+          "equiv_asids R s s'"
+          "equiv_for S ready_queues s s'"
+  using sef[simplified states_equiv_for_def] by auto
+
+lemma equiv_for_apply: "equiv_for P g (f s) (f s') = equiv_for P (g o f) s s'"
+  by (simp add: equiv_for_def)
+
+lemma states_equiv_forE_kheap:
+  assumes sef: "states_equiv_for P Q R S s s'"
+  obtains "\<And>x. P x \<Longrightarrow> kheap s x = kheap s' x"
+  using sef by (auto simp: states_equiv_for_def elim: equiv_forE)
+
+lemma states_equiv_forE_mem:
+  assumes sef: "states_equiv_for P Q R S s s'"
+  obtains "\<And>x. P x \<Longrightarrow>
+    (underlying_memory (machine_state s)) x = (underlying_memory (machine_state s')) x \<and>
+    (device_state (machine_state s)) x = (device_state (machine_state s')) x"
+  using sef
+  apply (clarsimp simp: states_equiv_for_def elim: equiv_forE)
+  apply (elim equiv_forE)
+  apply fastforce
+  done
+
+lemma states_equiv_forE_cdt:
+  assumes sef: "states_equiv_for P Q R S s s'"
+  obtains "\<And>x. P (fst x) \<Longrightarrow> cdt s x = cdt s' x"
+  using sef by (auto simp: states_equiv_for_def elim: equiv_forE)
+
+lemma states_equiv_forE_cdt_list:
+  assumes sef: "states_equiv_for P Q R S s s'"
+  obtains "\<And>x. P (fst x) \<Longrightarrow> cdt_list s x = cdt_list s' x"
+  using sef by (auto simp: states_equiv_for_def elim: equiv_forE)
+
+lemma states_equiv_forE_ekheap:
+  assumes sef: "states_equiv_for P Q R S s s'"
+  obtains "\<And>x. P x \<Longrightarrow> ekheap s x = ekheap s' x"
+  using sef by (auto simp: states_equiv_for_def elim: equiv_forE)
+
+lemma states_equiv_forE_is_original_cap:
+  assumes sef: "states_equiv_for P Q R S s s'"
+  obtains "\<And>x. P (fst x) \<Longrightarrow> is_original_cap s x = is_original_cap s' x"
+  using sef by (auto simp: states_equiv_for_def elim: equiv_forE)
+
+lemma states_equiv_forE_interrupt_states:
+  assumes sef: "states_equiv_for P Q R S s s'"
+  obtains "\<And>x. Q x \<Longrightarrow> interrupt_states s x = interrupt_states s' x"
+  using sef by (auto simp: states_equiv_for_def elim: equiv_forE)
+
+lemma states_equiv_forE_interrupt_irq_node:
+  assumes sef: "states_equiv_for P Q R S s s'"
+  obtains "\<And>x. Q x \<Longrightarrow> interrupt_irq_node s x = interrupt_irq_node s' x"
+  using sef by (auto simp: states_equiv_for_def elim: equiv_forE)
+
+lemma states_equiv_forE_ready_queues:
+  assumes sef: "states_equiv_for P Q R S s s'"
+  obtains "\<And>x. S x \<Longrightarrow> ready_queues s x = ready_queues s' x"
+  using sef by (auto simp: states_equiv_for_def elim: equiv_forE)
+
+lemma equiv_for_refl:
+  "equiv_for P f s s"
+  by (auto simp: equiv_for_def)
+
+lemma equiv_for_sym:
+  "equiv_for P f s t \<Longrightarrow> equiv_for P f t s"
+  by (auto simp: equiv_for_def)
+
+lemma equiv_for_trans:
+  "\<lbrakk> equiv_for P f s t; equiv_for P f t u \<rbrakk> \<Longrightarrow> equiv_for P f s u"
+  by (auto simp: equiv_for_def)
+
+
+context InfoFlow_IF_1 begin
+
+lemma states_equiv_for_refl:
+  "states_equiv_for P Q R S s s"
+  by (auto simp: states_equiv_for_def  intro: equiv_for_refl equiv_asids_refl)
+
+lemma states_equiv_for_sym:
+  "states_equiv_for P Q R S s t \<Longrightarrow> states_equiv_for P Q R S t s"
+  by (auto simp: states_equiv_for_def intro: equiv_for_sym equiv_asids_sym simp: equiv_for_def)
+
+lemma states_equiv_for_trans:
+  "\<lbrakk> states_equiv_for P Q R S s t; states_equiv_for P Q R S t u \<rbrakk>
+     \<Longrightarrow> states_equiv_for P Q R S s u"
+  by (auto simp: states_equiv_for_def
+          intro: equiv_for_trans equiv_asids_trans equiv_forI
+           elim: equiv_forE)
+
+end
+
+
+(* FIXME MOVE *)
+lemma or_comp_dist:
+  "(A or B) \<circ> f = (A \<circ> f or B \<circ> f)"
+  by (simp add: pred_disj_def comp_def)
+
+lemma idle_equiv_refl:
+  "idle_equiv s s"
+  by (simp add: idle_equiv_def)
+
+lemma idle_equiv_sym:
+  "idle_equiv s s' \<Longrightarrow> idle_equiv s' s"
+  by (clarsimp simp add: idle_equiv_def)
+
+lemma idle_equiv_trans:
+  "\<lbrakk> idle_equiv s s'; idle_equiv s' s'' \<rbrakk> \<Longrightarrow> idle_equiv s s''"
+  by (clarsimp simp add: idle_equiv_def tcb_at_def get_tcb_def split: option.splits
+                  kernel_object.splits)
+
+lemma equiv_asids_aag_can_read_asid:
+  "equiv_asids (aag_can_read_asid aag) s s' =
+   (\<forall>d \<in> subjectReads (pasPolicy aag) (pasSubject aag). equiv_asids (\<lambda>x. d = pasASIDAbs aag x) s s')"
+  by (auto simp: equiv_asids_def)
+
+lemma reads_equiv_def2:
+  "reads_equiv aag s s' = (states_equiv_for (aag_can_read aag) (aag_can_read_irq aag)
+                                            (aag_can_read_asid aag) (aag_can_read_domain aag) s s' \<and>
+                           cur_thread s = cur_thread s' \<and>
+                           cur_domain s = cur_domain s' \<and>
+                           scheduler_action s = scheduler_action s' \<and>
+                           work_units_completed s = work_units_completed s' \<and>
+                           irq_state (machine_state s) = irq_state (machine_state s'))"
+  by (auto simp: reads_equiv_def equiv_for_def states_equiv_for_def equiv_asids_aag_can_read_asid)
+
+lemma reads_equivE:
+  assumes sef: "reads_equiv aag s s'"
+  obtains "equiv_for (aag_can_read aag) kheap s s'"
+          "equiv_machine_state (aag_can_read aag) (machine_state s) (machine_state s')"
+          "equiv_for ((aag_can_read aag) \<circ> fst) cdt s s'"
+          "equiv_for ((aag_can_read aag) \<circ> fst) cdt_list s s'"
+          "equiv_for (aag_can_read aag) ekheap s s'"
+          "equiv_for ((aag_can_read aag) \<circ> fst) is_original_cap s s'"
+          "equiv_for (aag_can_read_irq aag) interrupt_states s s'"
+          "equiv_for (aag_can_read_irq aag) interrupt_irq_node s s'"
+          "equiv_asids (aag_can_read_asid aag) s s'"
+          "equiv_for (aag_can_read_domain aag) ready_queues s s'"
+          "cur_thread s = cur_thread s'"
+          "cur_domain s = cur_domain s'"
+          "scheduler_action s = scheduler_action s'"
+          "work_units_completed s = work_units_completed s'"
+          "irq_state (machine_state s) = irq_state (machine_state s')"
+  using sef by (auto simp: reads_equiv_def2 elim: states_equiv_forE)
+
+
+context InfoFlow_IF_1 begin
+
+lemma reads_equiv_machine_state_update:
+  "\<lbrakk> reads_equiv aag s s'; equiv_machine_state (aag_can_read aag) kh kh'; irq_state kh = irq_state kh' \<rbrakk>
+     \<Longrightarrow> reads_equiv aag (s\<lparr>machine_state := kh\<rparr>) (s'\<lparr>machine_state := kh'\<rparr>)"
+  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_machine_state_update)
+
+lemma states_equiv_for_non_asid_pool_kheap_update:
+  "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for P id kh kh';
+     non_asid_pool_kheap_update s kh; non_asid_pool_kheap_update s' kh' \<rbrakk>
+     \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
+  by (fastforce elim: equiv_forE elim!: equiv_asids_non_asid_pool_kheap_update
+               intro: equiv_forI simp: states_equiv_for_def)
+
+lemma reads_equiv_non_asid_pool_kheap_update:
+  "\<lbrakk> reads_equiv aag s s'; equiv_for (aag_can_read aag) id kh kh';
+     non_asid_pool_kheap_update s kh; non_asid_pool_kheap_update s' kh' \<rbrakk>
+     \<Longrightarrow> reads_equiv aag (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
+  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_non_asid_pool_kheap_update)
+
+lemma reads_equiv_identical_kheap_updates:
+  "\<lbrakk> reads_equiv aag s s'; identical_kheap_updates s s' kh kh' \<rbrakk>
+     \<Longrightarrow> reads_equiv aag (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
+  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_identical_kheap_updates)
+
+lemma reads_equiv_cdt_update:
+  "\<lbrakk> reads_equiv aag s s'; equiv_for ((aag_can_read aag) \<circ> fst) id kh kh' \<rbrakk>
+     \<Longrightarrow> reads_equiv aag (s\<lparr>cdt := kh\<rparr>) (s'\<lparr>cdt := kh'\<rparr>)"
+  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_cdt_update)
+
+lemma reads_equiv_cdt_list_update:
+  "\<lbrakk> reads_equiv aag s s'; equiv_for ((aag_can_read aag) \<circ> fst) id (kh (cdt_list s)) (kh' (cdt_list s')) \<rbrakk>
+     \<Longrightarrow> reads_equiv aag (cdt_list_update kh s) (cdt_list_update kh' s')"
+  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_cdt_list_update)
+
+lemma reads_equiv_identical_ekheap_updates:
+  "\<lbrakk> reads_equiv aag s s'; identical_ekheap_updates s s' (kh (ekheap s)) (kh' (ekheap s')) \<rbrakk>
+     \<Longrightarrow> reads_equiv aag (ekheap_update kh s) (ekheap_update kh' s')"
+  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_identical_ekheap_updates)
+
+lemma reads_equiv_ekheap_updates:
+  "\<lbrakk> reads_equiv aag s s'; equiv_for (aag_can_read aag) id (kh (ekheap s)) (kh' (ekheap s')) \<rbrakk>
+     \<Longrightarrow> reads_equiv aag (ekheap_update kh s) (ekheap_update kh' s')"
+  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_ekheap_update)
+
+lemma reads_equiv_is_original_cap_update:
+  "\<lbrakk>reads_equiv aag s s'; equiv_for ((aag_can_read aag) \<circ> fst) id kh kh'\<rbrakk> \<Longrightarrow>
+   reads_equiv aag (s\<lparr>is_original_cap := kh\<rparr>) (s'\<lparr>is_original_cap := kh'\<rparr>)"
+  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_is_original_cap_update)
+
+lemma reads_equiv_interrupt_states_update:
+  "\<lbrakk> reads_equiv aag s s'; equiv_for (aag_can_read_irq aag) id kh kh' \<rbrakk>
+     \<Longrightarrow> reads_equiv aag (s\<lparr>interrupt_states := kh\<rparr>) (s'\<lparr>interrupt_states := kh'\<rparr>)"
+  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_interrupt_states_update)
+
+lemma reads_equiv_interrupt_irq_node_update:
+  "\<lbrakk> reads_equiv aag s s'; equiv_for (aag_can_read_irq aag) id kh kh' \<rbrakk>
+     \<Longrightarrow> reads_equiv aag (s\<lparr>interrupt_irq_node := kh\<rparr>) (s'\<lparr>interrupt_irq_node := kh'\<rparr>)"
+  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_interrupt_irq_node_update)
+
+lemma reads_equiv_ready_queues_update:
+  "\<lbrakk> reads_equiv aag s s'; equiv_for (aag_can_read_domain aag) id kh kh' \<rbrakk>
+     \<Longrightarrow> reads_equiv aag (s\<lparr>ready_queues := kh\<rparr>) (s'\<lparr>ready_queues := kh'\<rparr>)"
+  by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_ready_queues_update)
+
+lemma reads_equiv_scheduler_action_update:
+  "reads_equiv aag s s' \<Longrightarrow>
+   reads_equiv aag (s\<lparr>scheduler_action := kh\<rparr>) (s'\<lparr>scheduler_action := kh\<rparr>)"
+  by (fastforce simp: reads_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
+
+lemma reads_equiv_work_units_completed_update:
+  "reads_equiv aag s s' \<Longrightarrow>
+   reads_equiv aag (s\<lparr>work_units_completed := kh\<rparr>) (s'\<lparr>work_units_completed := kh\<rparr>)"
+  by (fastforce simp: reads_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
+
+lemma reads_equiv_work_units_completed_update':
+  "reads_equiv aag s s' \<Longrightarrow>
+   reads_equiv aag (s\<lparr>work_units_completed := (f (work_units_completed s))\<rparr>)
+                   (s'\<lparr>work_units_completed := (f (work_units_completed s'))\<rparr>)"
+  by (fastforce simp: reads_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
+
+lemma affects_equiv_def2:
+  "affects_equiv aag l s s' = states_equiv_for (aag_can_affect aag l)
+                                               (aag_can_affect_irq aag l)
+                                               (aag_can_affect_asid aag l)
+                                               (aag_can_affect_domain aag l) s s'"
+  by (auto simp: affects_equiv_def
+           dest: equiv_forD
+          elim!: states_equiv_forE
+         intro!: states_equiv_forI equiv_forI equiv_asids_trivial)
+
+lemma affects_equivE:
+  assumes sef: "affects_equiv aag l s s'"
+  obtains "equiv_for (aag_can_affect aag l) kheap s s'"
+          "equiv_machine_state (aag_can_affect aag l) (machine_state s) (machine_state s')"
+          "equiv_for ((aag_can_affect aag l) \<circ> fst) cdt s s'"
+          "equiv_for ((aag_can_affect aag l) \<circ> fst) cdt_list s s'"
+          "equiv_for (aag_can_affect aag l) ekheap s s'"
+          "equiv_for ((aag_can_affect aag l) \<circ> fst) is_original_cap s s'"
+          "equiv_for (aag_can_affect_irq aag l) interrupt_states s s'"
+          "equiv_for (aag_can_affect_irq aag l) interrupt_irq_node s s'"
+          "equiv_asids (aag_can_affect_asid aag l) s s'"
+          "equiv_for (aag_can_affect_domain aag l) ready_queues s s'"
+  using sef by (auto simp: affects_equiv_def2 elim: states_equiv_forE)
+
+lemma affects_equiv_machine_state_update:
+  "\<lbrakk> affects_equiv aag l s s'; equiv_machine_state (aag_can_affect aag l) kh kh' \<rbrakk>
+     \<Longrightarrow> affects_equiv aag l (s\<lparr>machine_state := kh\<rparr>) (s'\<lparr>machine_state := kh'\<rparr>)"
+  by (fastforce simp: affects_equiv_def2 intro: states_equiv_for_machine_state_update)
+
+lemma affects_equiv_non_asid_pool_kheap_update:
+  "\<lbrakk> affects_equiv aag l s s'; equiv_for (aag_can_affect aag l) id kh kh';
+     non_asid_pool_kheap_update s kh; non_asid_pool_kheap_update s' kh' \<rbrakk>
+     \<Longrightarrow> affects_equiv aag l (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
+  by (fastforce simp: affects_equiv_def2 intro: states_equiv_for_non_asid_pool_kheap_update)
+
+lemma affects_equiv_identical_kheap_updates:
+  "\<lbrakk>affects_equiv aag l s s';
+    identical_kheap_updates s s' kh kh'\<rbrakk> \<Longrightarrow>
+   affects_equiv aag l (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
+  by (fastforce simp: affects_equiv_def2 intro: states_equiv_for_identical_kheap_updates)
+
+lemma affects_equiv_cdt_update:
+  "\<lbrakk>affects_equiv aag l s s'; equiv_for ((aag_can_affect aag l) \<circ> fst) id kh kh'\<rbrakk> \<Longrightarrow>
+   affects_equiv aag l (s\<lparr>cdt := kh\<rparr>) (s'\<lparr>cdt := kh'\<rparr>)"
+  by (fastforce simp: affects_equiv_def2 intro: states_equiv_for_cdt_update)
+
+lemma affects_equiv_cdt_list_update:
+  "\<lbrakk>affects_equiv aag l s s'; equiv_for ((aag_can_affect aag l) \<circ> fst) id (kh (cdt_list s)) (kh' (cdt_list s'))\<rbrakk> \<Longrightarrow>
+   affects_equiv aag l (cdt_list_update kh s) (cdt_list_update kh' s')"
+  by (fastforce simp: affects_equiv_def2 intro: states_equiv_for_cdt_list_update)
+
+lemma affects_equiv_identical_ekheap_updates:
+  "\<lbrakk>affects_equiv aag l s s'; identical_ekheap_updates s s' (kh (ekheap s)) (kh' (ekheap s'))\<rbrakk> \<Longrightarrow>
+    affects_equiv aag l (ekheap_update kh s) (ekheap_update kh' s')"
+  by (fastforce simp: affects_equiv_def2 intro: states_equiv_for_identical_ekheap_updates)
+
+lemma affects_equiv_ekheap_update:
+  "\<lbrakk>affects_equiv aag l s s'; equiv_for (aag_can_affect aag l) id (kh (ekheap s)) (kh' (ekheap s')) \<rbrakk> \<Longrightarrow>
+    affects_equiv aag l (ekheap_update kh s) (ekheap_update kh' s')"
+  by (fastforce simp: affects_equiv_def2 intro: states_equiv_for_ekheap_update)
+
+lemma affects_equiv_is_original_cap_update:
+  "\<lbrakk>affects_equiv aag l s s'; equiv_for ((aag_can_affect aag l) \<circ> fst) id kh kh'\<rbrakk> \<Longrightarrow>
+   affects_equiv aag l (s\<lparr>is_original_cap := kh\<rparr>) (s'\<lparr>is_original_cap := kh'\<rparr>)"
+  by (fastforce simp: affects_equiv_def2 intro: states_equiv_for_is_original_cap_update)
+
+lemma affects_equiv_interrupt_states_update:
+  "\<lbrakk>affects_equiv aag l s s'; equiv_for (aag_can_affect_irq aag l) id kh kh'\<rbrakk> \<Longrightarrow>
+   affects_equiv aag l (s\<lparr>interrupt_states := kh\<rparr>) (s'\<lparr>interrupt_states := kh'\<rparr>)"
+  by (fastforce simp: affects_equiv_def2 intro: states_equiv_for_interrupt_states_update)
+
+lemma affects_equiv_interrupt_irq_node_update:
+  "\<lbrakk>affects_equiv aag l s s'; equiv_for (aag_can_affect_irq aag l) id kh kh'\<rbrakk> \<Longrightarrow>
+   affects_equiv aag l (s\<lparr>interrupt_irq_node := kh\<rparr>) (s'\<lparr>interrupt_irq_node := kh'\<rparr>)"
+  by (fastforce simp: affects_equiv_def2 intro: states_equiv_for_interrupt_irq_node_update)
+
+lemma affects_equiv_ready_queues_update:
+  "\<lbrakk>affects_equiv aag l s s'; equiv_for (aag_can_affect_domain aag l) id kh kh'\<rbrakk> \<Longrightarrow>
+   affects_equiv aag l (s\<lparr>ready_queues := kh\<rparr>) (s'\<lparr>ready_queues := kh'\<rparr>)"
+  by (fastforce simp: affects_equiv_def2 intro: states_equiv_for_ready_queues_update)
+
+lemma affects_equiv_scheduler_action_update:
+  "affects_equiv aag l s s' \<Longrightarrow>
+   affects_equiv aag l (s\<lparr>scheduler_action := kh\<rparr>) (s'\<lparr>scheduler_action := kh\<rparr>)"
+  by (fastforce simp: affects_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
+
+lemma affects_equiv_work_units_completed_update:
+  "affects_equiv aag l s s' \<Longrightarrow>
+   affects_equiv aag l (s\<lparr>work_units_completed := kh\<rparr>) (s'\<lparr>work_units_completed := kh\<rparr>)"
+  by (fastforce simp: affects_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
+
+lemma affects_equiv_work_units_completed_update':
+  "affects_equiv aag l s s' \<Longrightarrow>
+   affects_equiv aag l (s\<lparr>work_units_completed := (f (work_units_completed s))\<rparr>)
+                       (s'\<lparr>work_units_completed := (f (work_units_completed s'))\<rparr>)"
+  by (fastforce simp: affects_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
+
+(* reads_equiv and affects_equiv want to be equivalence relations *)
+lemma reads_equiv_refl:
+  "reads_equiv aag s s"
+  by (auto simp: reads_equiv_def2 intro: states_equiv_for_refl equiv_asids_refl)
+
+lemma reads_equiv_sym:
+  "reads_equiv aag s t \<Longrightarrow> reads_equiv aag t s"
+  by (auto simp: reads_equiv_def2 intro: states_equiv_for_sym equiv_asids_sym)
+
+lemma reads_equiv_trans:
+  "\<lbrakk> reads_equiv aag s t; reads_equiv aag t u \<rbrakk> \<Longrightarrow> reads_equiv aag s u"
+  by (auto simp: reads_equiv_def2 intro: states_equiv_for_trans equiv_asids_trans)
+
+lemma affects_equiv_refl:
+  "affects_equiv aag l s s"
+  by (auto simp: affects_equiv_def intro: states_equiv_for_refl equiv_asids_refl)
+
+lemma affects_equiv_sym:
+  "affects_equiv aag l s t \<Longrightarrow> affects_equiv aag l t s"
+  by (auto simp: affects_equiv_def2 intro: states_equiv_for_sym equiv_asids_sym)
+
+lemma affects_equiv_trans:
+  "\<lbrakk> affects_equiv aag l s t; affects_equiv aag l t u \<rbrakk>
+     \<Longrightarrow> affects_equiv aag l s u"
+  by (auto simp: affects_equiv_def2 intro: states_equiv_for_trans equiv_asids_trans)
+
+end
+
+
+lemma globals_equivI:
+  "\<lbrakk> doesnt_touch_globals P f; P s; (rv, s') \<in> fst (f s) \<rbrakk>
+     \<Longrightarrow> globals_equiv s s'"
+  by(fastforce simp: doesnt_touch_globals_def)
+
+lemma reads_equiv_gD:
+  "reads_equiv_g aag s s' \<Longrightarrow> reads_equiv aag s s' \<and> globals_equiv s s'"
+  by(simp add: reads_equiv_g_def)
+
+lemma reads_equiv_gI:
+  "\<lbrakk> reads_equiv aag s s'; globals_equiv s s' \<rbrakk> \<Longrightarrow> reads_equiv_g aag s s'"
+  by (simp add: reads_equiv_g_def)
+
+lemma equiv_for_guard_imp:
+  "\<lbrakk> equiv_for P f s s'; \<And>x. Q x \<Longrightarrow> P x \<rbrakk> \<Longrightarrow> equiv_for Q f s s'"
+  by(auto simp: equiv_for_def)
+
+
+context InfoFlow_IF_1 begin
+
+(* since doesnt_touch_globals is true for all of the kernel except the scheduler,
+   the following lemma shows that we can just prove reads_respects for it, and
+   from there get the stronger reads_respects_g result that we need for the
+   noninterference theorem *)
+lemma reads_respects_g:
+  "\<lbrakk> reads_respects aag l P f; doesnt_touch_globals Q f \<rbrakk>
+     \<Longrightarrow> reads_respects_g aag l (P and Q) f"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (drule reads_equiv_gD)
+  apply (subgoal_tac "globals_equiv b ba", fastforce intro: reads_equiv_gI)
+  apply (rule globals_equiv_trans)
+   apply (rule globals_equiv_sym)
+   apply (fastforce intro: globals_equivI)
+  apply (rule globals_equiv_trans)
+   apply (elim conjE, assumption)
+  apply (fastforce intro: globals_equivI)
+  done
+
+(* prove doesnt_touch_globals as an invariant *)
+lemma globals_equiv_invD:
+  "\<lbrace>globals_equiv st and P\<rbrace> f \<lbrace>\<lambda>_. globals_equiv st\<rbrace>
+   \<Longrightarrow> \<lbrace>P and (=) st\<rbrace> f \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  by (fastforce simp: valid_def intro: globals_equiv_refl)
+
+lemma doesnt_touch_globalsI:
+  assumes globals_equiv_inv: "\<And>st. \<lbrace>globals_equiv st and P\<rbrace> f \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  shows "doesnt_touch_globals P f"
+  apply (clarsimp simp: doesnt_touch_globals_def)
+  apply (cut_tac st=s in globals_equiv_inv)
+  by (fastforce dest: globals_equiv_invD simp: valid_def)
+
+(* Slightly nicer to use version to lift up trivial cases*)
+lemma reads_respects_g_from_inv:
+  "\<lbrakk> reads_respects aag l P f; \<And>st. f \<lbrace>globals_equiv st\<rbrace> \<rbrakk>
+     \<Longrightarrow> reads_respects_g aag l P f"
+  apply (rule equiv_valid_guard_imp)
+   apply (erule reads_respects_g[where Q="\<lambda>s. True"])
+   apply (rule doesnt_touch_globalsI)
+   apply simp+
+  done
+
+(*Useful for chaining OFs so we don't have to re-state rules*)
+lemma reads_respects_g':
+  assumes rev: "reads_respects aag l P f"
+  assumes gev: "\<And>st. \<lbrace>\<lambda> s. R (globals_equiv st s) s\<rbrace> f \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  assumes and_imp: "\<And>st s. Q st s \<Longrightarrow> P s \<and> R (globals_equiv st s) s"
+  assumes gev_imp: "\<And>st s. R (globals_equiv st s) s \<Longrightarrow> globals_equiv st s"
+  shows "reads_respects_g aag l (Q st) f"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_g[OF rev, where Q="\<lambda>s. R (globals_equiv st s) s"])
+   apply (rule doesnt_touch_globalsI)
+   apply (rule hoare_pre)
+    apply (rule gev)
+   apply clarsimp
+   apply (frule gev_imp)
+   apply (simp add: and_imp)+
+  done
+
+lemma states_equiv_for_guard_imp:
+  assumes "states_equiv_for P Q R S s s'"
+  and "\<And>x. P' x \<Longrightarrow> P x"
+  and "\<And>x. Q' x \<Longrightarrow> Q x"
+  and "\<And>x. R' x \<Longrightarrow> R x"
+  and "\<And>x. S' x \<Longrightarrow> S x"
+  shows "states_equiv_for P' Q' R' S' s s'"
+  using assms by (auto simp: states_equiv_for_def intro: equiv_for_guard_imp equiv_asids_guard_imp)
+
+lemma set_object_reads_respects:
+  "reads_respects aag l \<top> (set_object ptr obj)"
+  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def set_object_def get_object_def
+                       bind_def' get_def gets_def put_def return_def fail_def assert_def)
+  apply (rule conjI)
+   apply (erule reads_equiv_identical_kheap_updates)
+   apply (clarsimp simp: identical_kheap_updates_def)
+  apply (erule affects_equiv_identical_kheap_updates)
+  apply (clarsimp simp: identical_kheap_updates_def)
+  done
+
+end
+
+
+lemma cur_subject_reads_equiv_affects_equiv:
+  "\<lbrakk> pasSubject aag = l; reads_equiv aag s s' \<rbrakk> \<Longrightarrow> affects_equiv aag l s s'"
+  by (auto simp: reads_equiv_def2 affects_equiv_def equiv_for_def states_equiv_for_def)
+
+(* This lemma says that, if we prove reads_respects above for all l, we will prove
+   that information can flow into the domain only from what it is allowed to read. *)
+lemma reads_equiv_self_reads_respects:
+  "pasSubject aag = l \<Longrightarrow> reads_equiv_valid_inv \<top>\<top> aag P f = reads_respects aag l P f"
+  unfolding equiv_valid_def2 equiv_valid_2_def
+  by (fastforce intro: cur_subject_reads_equiv_affects_equiv)
+
+lemma requiv_get_tcb_eq[intro]:
+  "\<lbrakk> reads_equiv aag s t; is_subject aag thread \<rbrakk>
+     \<Longrightarrow> get_tcb thread s = get_tcb thread t"
+  by (auto simp: reads_equiv_def2 get_tcb_def elim: states_equiv_forE_kheap)
+
+lemma requiv_cur_thread_eq[intro]:
+  "reads_equiv aag s t \<Longrightarrow> cur_thread s = cur_thread t"
+  by (simp add: reads_equiv_def2)
+
+lemma requiv_cur_domain_eq[intro]:
+  "reads_equiv aag s t \<Longrightarrow> cur_domain s = cur_domain t"
+  by (simp add: reads_equiv_def2)
+
+lemma requiv_sched_act_eq[intro]:
+  "reads_equiv aag s t \<Longrightarrow> scheduler_action s = scheduler_action t"
+  by (simp add: reads_equiv_def2)
+
+lemma requiv_wuc_eq[intro]:
+  "reads_equiv aag s t \<Longrightarrow> work_units_completed s = work_units_completed t"
+  by (simp add: reads_equiv_def2)
+
+lemma update_object_noop:
+  "kheap s ptr = Some obj \<Longrightarrow> s\<lparr>kheap := kheap s(ptr \<mapsto> obj)\<rparr> = s"
+  by (clarsimp simp: map_upd_triv)
+
+lemma set_object_rev:
+  "reads_equiv_valid_inv A aag (\<lambda> s. kheap s ptr = Some obj \<and> is_subject aag ptr) (set_object ptr obj)"
+  by (fastforce simp: equiv_valid_def2 equiv_valid_2_def set_object_def bind_def
+                      get_def gets_def put_def return_def assert_def get_object_def
+                dest: update_object_noop)
+
+lemma lookup_error_on_failure_rev:
+  "reads_equiv_valid_inv A aag P m \<Longrightarrow>
+   reads_equiv_valid_inv A aag P (lookup_error_on_failure s m)"
+  unfolding lookup_error_on_failure_def handleE'_def by (wp | wpc | simp)+
+
+lemma internal_exst[simp]:
+  "cdt_list_internal o exst = cdt_list"
+  "ekheap_internal o exst = ekheap"
+  by (simp_all add: o_def)
+
+lemma gets_kheap_revrv':
+  "reads_equiv_valid_rv_inv A aag (equiv_for (aag_can_read aag) id) \<top> (gets kheap)"
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule gets_evrv)
+  apply (fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist elim: reads_equivE)
+  done
+
+lemma gets_cdt_revrv':
+  "reads_equiv_valid_rv_inv A aag (equiv_for (aag_can_read aag \<circ> fst) id) \<top> (gets cdt)"
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule gets_evrv)
+  apply (fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist elim: reads_equivE)
+  done
+
+lemma gets_cdt_list_revrv':
+  "reads_equiv_valid_rv_inv A aag (equiv_for (aag_can_read aag \<circ> fst) id) \<top> (gets cdt_list)"
+  apply(rule equiv_valid_rv_guard_imp)
+   apply(rule gets_evrv)
+  apply(fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist elim: reads_equivE)
+  done
+
+lemma gets_is_original_cap_revrv':
+  "reads_equiv_valid_rv_inv A aag (equiv_for (aag_can_read aag \<circ> fst) id) \<top> (gets is_original_cap)"
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule gets_evrv)
+  apply (fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist elim: reads_equivE)
+  done
+
+lemma gets_ready_queues_revrv':
+  "reads_equiv_valid_rv_inv A aag (equiv_for (aag_can_read_domain aag) id) \<top> (gets ready_queues)"
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule gets_evrv)
+  (* NB: only force works here *)
+  apply (force simp: equiv_for_comp equiv_for_def disjoint_iff_not_equal elim: reads_equivE)
+  done
+
+(* We want to prove this kind of thing for functions that don't modify the state *)
+lemma gets_cur_thread_ev:
+  "reads_equiv_valid_inv A aag \<top> (gets cur_thread)"
+  apply (rule equiv_valid_guard_imp)
+  apply wp
+  apply (simp add: reads_equiv_def)
+  done
+
+lemma as_user_rev:
+  "reads_equiv_valid_inv A aag (K (det f \<and> (\<forall>P. f \<lbrace>P\<rbrace>) \<and> is_subject aag thread)) (as_user thread f)"
+  unfolding as_user_def fun_app_def split_def
+  apply (wp set_object_rev select_f_ev)
+  apply (rule conjI, fastforce)
+  apply (clarsimp split: option.split_asm kernel_object.split_asm simp: get_tcb_def)
+  apply (drule state_unchanged[rotated,symmetric])
+   apply simp_all
+  done
+
+
+context InfoFlow_IF_1 begin
+
+lemma gets_kheap_revrv:
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
+                            (equiv_for (aag_can_read aag or aag_can_affect aag l) id) \<top> (gets kheap)"
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule gets_evrv)
+  apply (fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist
+                   elim: reads_equivE affects_equivE)
+  done
+
+lemma gets_machine_state_revrv:
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
+     (equiv_machine_state (aag_can_read aag or aag_can_affect aag l) And equiv_irq_state)
+     \<top> (gets machine_state)"
+  by (fastforce simp: equiv_valid_2_def gets_def get_def return_def bind_def
+                elim: reads_equivE affects_equivE equiv_forE
+               intro: equiv_forI)
+
+lemma gets_machine_state_revrv':
+  "reads_equiv_valid_rv_inv A aag (equiv_machine_state (aag_can_read aag) And equiv_irq_state)
+                            \<top> (gets machine_state)"
+  by (fastforce simp: equiv_valid_2_def gets_def get_def return_def bind_def
+                elim: reads_equivE affects_equivE equiv_forE
+               intro: equiv_forI)
+
+lemma gets_cdt_revrv:
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
+                            (equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id)
+                            \<top> (gets cdt)"
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule gets_evrv)
+  apply (fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist
+                   elim: reads_equivE affects_equivE)
+  done
+
+lemma gets_cdt_list_revrv:
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
+                            (equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id)
+                            \<top> (gets cdt_list)"
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule gets_evrv)
+  apply (fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist
+                   elim: reads_equivE affects_equivE)
+  done
+
+lemma gets_ekheap_revrv:
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
+                            (equiv_for (aag_can_read aag or aag_can_affect aag l) id) \<top> (gets ekheap)"
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule gets_evrv)
+  apply (fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist
+                   elim: reads_equivE affects_equivE)
+  done
+
+lemma gets_is_original_cap_revrv:
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
+                            (equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id)
+                            \<top> (gets is_original_cap)"
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule gets_evrv)
+  apply (fastforce simp: equiv_for_comp[symmetric] equiv_for_or or_comp_dist
+                  elim: reads_equivE affects_equivE)
+  done
+
+lemma gets_ready_queues_revrv:
+  "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
+                            (equiv_for (aag_can_read_domain aag or aag_can_affect_domain aag l) id)
+                            \<top> (gets ready_queues)"
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule gets_evrv)
+  (* NB: only clarsimp works here *)
+  apply (clarsimp simp: equiv_for_def disjoint_iff_not_equal elim!: reads_equivE affects_equivE)
+  done
+
+lemma as_user_reads_respects:
+  "reads_respects aag l (K (det f \<and> is_subject aag thread)) (as_user thread f)"
+  apply (simp add: as_user_def split_def)
+  apply (rule gen_asm_ev)
+  apply (wp set_object_reads_respects select_f_ev gets_the_ev)
+  apply fastforce
+  done
+
+end
+
+
+lemma get_message_info_rev:
+  "reads_equiv_valid_inv A aag (K (is_subject aag ptr)) (get_message_info ptr)"
+  by (wpsimp wp: as_user_rev getRegister_inv simp: get_message_info_def det_getRegister)
+
+lemma syscall_rev:
+  assumes reads_res_m_fault:
+    "reads_equiv_valid_inv A aag P m_fault"
+  assumes reads_res_m_error:
+    "\<And>v. reads_equiv_valid_inv A aag (Q (Inr v)) (m_error v)"
+  assumes reads_res_h_fault:
+    "\<And>v. reads_equiv_valid_inv A aag (Q (Inl v)) (h_fault v)"
+  assumes reads_res_m_finalise:
+    "\<And>v. reads_equiv_valid_inv A aag (R (Inr v)) (m_finalise v)"
+  assumes reads_res_h_error:
+    "\<And>v. reads_equiv_valid_inv A aag (R (Inl v)) (h_error v)"
+  assumes m_fault_hoare:
+    "\<lbrace>P\<rbrace> m_fault \<lbrace>Q\<rbrace>"
+  assumes m_error_hoare:
+    "\<And>v. \<lbrace>Q (Inr v)\<rbrace> m_error v \<lbrace>R\<rbrace>"
+  shows "reads_equiv_valid_inv A aag P (Syscall_A.syscall m_fault h_fault m_error h_error m_finalise)"
+  unfolding Syscall_A.syscall_def without_preemption_def fun_app_def
+  by (wp assms equiv_valid_guard_imp[OF liftE_bindE_ev]
+      | rule hoare_strengthen_post[OF m_error_hoare]
+      | rule hoare_strengthen_post[OF m_fault_hoare]
+      | wpc
+      | fastforce)+
+
+lemma syscall_reads_respects_g:
+  assumes reads_res_m_fault:
+    "reads_respects_g aag l P m_fault"
+  assumes reads_res_m_error:
+    "\<And>v. reads_respects_g aag l (Q'' v) (m_error v)"
+  assumes reads_res_h_fault:
+    "\<And>v. reads_respects_g aag l (Q' v) (h_fault v)"
+  assumes reads_res_m_finalise:
+    "\<And>v. reads_respects_g aag l (R'' v) (m_finalise v)"
+  assumes reads_res_h_error:
+    "\<And>v. reads_respects_g aag l (R' v) (h_error v)"
+  assumes m_fault_hoare:
+    "\<lbrace>P\<rbrace> m_fault \<lbrace>case_sum Q' Q''\<rbrace>"
+  assumes m_error_hoare:
+    "\<And>v. \<lbrace>Q'' v\<rbrace> m_error v \<lbrace>case_sum R' R''\<rbrace>"
+  shows "reads_respects_g aag l P (Syscall_A.syscall m_fault h_fault m_error h_error m_finalise)"
+  unfolding Syscall_A.syscall_def without_preemption_def fun_app_def
+  by (wp assms equiv_valid_guard_imp[OF liftE_bindE_ev]
+      | rule hoare_strengthen_post[OF m_error_hoare]
+      | rule hoare_strengthen_post[OF m_fault_hoare]
+      | wpc
+      | fastforce)+
+
+
+context InfoFlow_IF_1 begin
+
+lemma do_machine_op_spec_reads_respects':
+  assumes equiv_dmo:
+   "equiv_valid_inv (equiv_machine_state (aag_can_read aag) And equiv_irq_state)
+                    (equiv_machine_state (aag_can_affect aag l)) Q f"
+  assumes guard:
+    "\<And>s. P s \<Longrightarrow> Q (machine_state s)"
+  shows
+  "spec_reads_respects st aag l P (do_machine_op f)"
+  unfolding do_machine_op_def spec_equiv_valid_def
+  apply (rule equiv_valid_2_guard_imp)
+   apply (rule_tac  R'="\<lambda> rv rv'. equiv_machine_state (aag_can_read aag or aag_can_affect aag l) rv rv' \<and> equiv_irq_state rv rv'" and Q="\<lambda> r s. st = s \<and> Q r" and Q'="\<lambda> r s. Q r" and P="(=) st" and P'="\<top>" in equiv_valid_2_bind)
+       apply (rule gen_asm_ev2_l[simplified K_def pred_conj_def])
+       apply (rule gen_asm_ev2_r')
+       apply (rule_tac R'="\<lambda> (r, ms') (r', ms'').  r = r' \<and> equiv_machine_state (aag_can_read aag)  ms' ms'' \<and> equiv_machine_state (aag_can_affect aag l) ms' ms'' \<and> equiv_irq_state ms' ms''" and Q="\<lambda> r s. st = s" and Q'="\<top>\<top>" and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
+            apply (clarsimp simp: modify_def get_def put_def bind_def return_def equiv_valid_2_def)
+            apply (fastforce intro: reads_equiv_machine_state_update affects_equiv_machine_state_update)
+            apply (insert equiv_dmo)[1]
+           apply (clarsimp simp: select_f_def equiv_valid_2_def equiv_valid_def2 equiv_for_or simp: split_def split: prod.splits simp: equiv_for_def)[1]
+           apply (drule_tac x=rv in spec, drule_tac x=rv' in spec)
+           apply (fastforce)
+          apply (rule select_f_inv)
+         apply (rule wp_post_taut)
+        apply simp+
+      apply (clarsimp simp: equiv_valid_2_def in_monad)
+      apply (fastforce elim: reads_equivE affects_equivE equiv_forE intro: equiv_forI)
+     apply (wp | simp add: guard)+
+  done
+
+(* most of the time (i.e. always except for getActiveIRQ) you'll want this rule *)
+lemma do_machine_op_spec_reads_respects:
+  assumes equiv_dmo:
+   "equiv_valid_inv (equiv_machine_state (aag_can_read aag)) (equiv_machine_state (aag_can_affect aag l)) \<top> f"
+  assumes irq_state_inv:
+    "\<And>P. \<lbrace>\<lambda>ms. P (irq_state ms)\<rbrace> f \<lbrace>\<lambda>_ ms. P (irq_state ms)\<rbrace>"
+  shows
+    "spec_reads_respects st aag l \<top> (do_machine_op f)"
+  apply (rule do_machine_op_spec_reads_respects'[where Q=\<top>, simplified])
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (subgoal_tac "equiv_irq_state b ba", simp)
+   apply (insert equiv_dmo, fastforce simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (insert irq_state_inv)
+  apply (drule_tac x="\<lambda>ms. ms = irq_state s" in meta_spec)
+  apply (clarsimp simp: valid_def)
+  apply (frule_tac x=s in spec)
+  apply (erule (1) impE)
+  apply (drule bspec, assumption, simp)
+  apply (drule_tac x=t in spec, simp)
+  apply (drule bspec, assumption)
+  apply simp
+  done
+
+lemma do_machine_op_rev:
+  assumes equiv_dmo: "equiv_valid_inv (equiv_machine_state (aag_can_read aag)) \<top>\<top> \<top> f"
+  assumes mo_inv: "\<And>P. f \<lbrace>P\<rbrace>"
+  shows "reads_equiv_valid_inv A aag \<top> (do_machine_op f)"
+  unfolding do_machine_op_def equiv_valid_def2
+  apply (rule_tac W="\<lambda> rv rv'. equiv_machine_state (aag_can_read aag) rv rv' \<and> equiv_irq_state rv rv'"
+             and Q="\<lambda> rv s. rv = machine_state s " in equiv_valid_rv_bind)
+    apply (blast intro: equiv_valid_rv_guard_imp[OF gets_machine_state_revrv'[simplified bipred_conj_def]])
+   apply (rule_tac R'="\<lambda> (r, ms') (r', ms'').  r = r' \<and> equiv_machine_state (aag_can_read aag) ms' ms''"
+              and Q="\<lambda> (r,ms') s. ms' = rv \<and> rv = machine_state s "
+              and Q'="\<lambda> (r',ms'') s. ms'' = rv' \<and> rv' = machine_state s"
+              and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
+        apply (clarsimp simp: modify_def get_def put_def bind_def return_def equiv_valid_2_def)
+       apply (clarsimp simp: select_f_def equiv_valid_2_def)
+       apply (insert equiv_dmo, clarsimp simp: equiv_valid_def2 equiv_valid_2_def)[1]
+       apply blast
+    apply (wp select_f_inv)+
+    apply (fastforce simp: select_f_def dest: state_unchanged[OF mo_inv])+
+  done
+
+end
+
+
+lemma do_machine_op_spec_rev:
+  assumes equiv_dmo:
+    "spec_equiv_valid_inv (machine_state st) (equiv_machine_state (aag_can_read aag)) \<top>\<top> \<top> f"
+  assumes mo_inv: "\<And>P. f \<lbrace>P\<rbrace>"
+  shows "reads_spec_equiv_valid_inv st A aag P (do_machine_op f)"
+  unfolding do_machine_op_def spec_equiv_valid_def
+  apply (rule equiv_valid_2_guard_imp)
+   apply (rule_tac R'="\<lambda>rv rv'. equiv_machine_state (aag_can_read aag) rv rv' \<and>
+                                equiv_irq_state rv rv'"
+               and Q="\<lambda>r s. st = s \<and> r = machine_state s"
+               and Q'="\<lambda>r s. r = machine_state s"
+               and P="(=) st" and P'=\<top>
+                in equiv_valid_2_bind)
+       apply (rule_tac R'="\<lambda>(r, ms') (r', ms''). r = r' \<and>
+                                                 equiv_machine_state (aag_can_read aag) ms' ms''"
+                   and Q="\<lambda>(r,ms') s. ms' = rv \<and> rv = machine_state s \<and> st = s"
+                   and Q'="\<lambda>(r,ms') s. ms' = rv' \<and> rv' = machine_state s"
+                   and P="\<lambda>s. st = s \<and> rv = machine_state s" and P'="\<lambda> s. rv' = machine_state s"
+                   and S="\<lambda>s. st = s \<and> rv = machine_state s" and S'="\<lambda>s. rv' = machine_state s"
+                    in equiv_valid_2_bind_pre)
+            apply (clarsimp simp: modify_def get_def put_def bind_def return_def equiv_valid_2_def)
+           apply (clarsimp simp: select_f_def equiv_valid_2_def equiv_valid_def2 equiv_for_or
+                                 split_def equiv_for_def
+                          split: prod.splits)
+           apply (insert equiv_dmo)[1]
+           apply (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
+           apply (drule_tac x="machine_state t" in spec)
+           apply (clarsimp simp: equiv_for_def)
+           apply blast
+          apply (wp select_f_inv)
+          apply clarsimp
+          apply (drule state_unchanged[OF mo_inv], simp)
+         apply (wp select_f_inv)
+         apply clarsimp
+         apply (drule state_unchanged[OF mo_inv], simp)
+        apply simp+
+      apply (clarsimp simp: equiv_valid_2_def in_monad)
+      apply (fastforce intro: elim: equiv_forE reads_equivE)
+     apply (wp | simp)+
+  done
+
+lemma spec_equiv_valid_hoist_guard:
+  "((P st) \<Longrightarrow> spec_equiv_valid_inv st I A \<top> f) \<Longrightarrow> spec_equiv_valid_inv st I A P f"
+  by (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
+
+lemma for_each_byte_of_word_imp:
+  "\<lbrakk> \<And>x. P x \<Longrightarrow> Q x; for_each_byte_of_word P p \<rbrakk>
+     \<Longrightarrow> for_each_byte_of_word Q p"
+  by (fastforce simp: for_each_byte_of_word_def)
+
+lemma modifies_at_mostD:
+  "\<lbrakk> modifies_at_most aag L P f; P s; (rv,s') \<in> fst(f s) \<rbrakk>
+     \<Longrightarrow> equiv_but_for_labels aag L s s'"
+  by (auto simp: modifies_at_most_def)
+
+(* FIXME: Move *)
+lemma invs_kernel_mappings:
+  "invs s \<Longrightarrow> valid_kernel_mappings s"
+  by (auto simp: invs_def valid_state_def)
+
+
+context InfoFlow_IF_1 begin
+
+lemma load_word_offs_rev:
+  "for_each_byte_of_word (aag_can_read aag) (a + of_nat x * of_nat word_size)
+   \<Longrightarrow> reads_equiv_valid_inv A aag \<top> (load_word_offs a x)"
+  unfolding load_word_offs_def fun_app_def
+  by (fastforce intro: equiv_valid_guard_imp[OF dmo_loadWord_rev])
+
+lemma modifies_at_mostI:
+  assumes hoare: "\<And>st. \<lbrace>P and equiv_but_for_labels aag L st\<rbrace> f \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  shows "modifies_at_most aag L P f"
+  apply (clarsimp simp: modifies_at_most_def)
+  apply (erule use_valid)
+   apply (rule hoare)
+  apply (fastforce simp: equiv_but_for_labels_def states_equiv_for_refl)
+  done
+
+end
+
+end

--- a/proof/infoflow/InfoFlow_Image_Toplevel.thy
+++ b/proof/infoflow/InfoFlow_Image_Toplevel.thy
@@ -11,7 +11,7 @@
 
 theory InfoFlow_Image_Toplevel
 imports
-  Noninterference
+  ArchNoninterference
   Noninterference_Base_Refinement
   PolicyExample
   PolicySystemSAC

--- a/proof/infoflow/Interrupt_IF.thy
+++ b/proof/infoflow/Interrupt_IF.thy
@@ -5,114 +5,114 @@
  *)
 
 theory Interrupt_IF
-imports Finalise_IF
+imports ArchFinalise_IF
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+crunch valid_global_objs[wp]: cap_delete_one "valid_global_objs"
+  (wp: dxo_wp_weak simp: unless_def ignore: empty_slot_ext)
 
-subsection "reads respects"
+
+locale Interrupt_IF_1 =
+  fixes aag :: "'a subject_label PAS"
+  assumes arch_invoke_irq_handler_reads_respects[wp]:
+    "reads_respects_f aag (l :: 'a subject_label) (silc_inv aag st) (arch_invoke_irq_handler hi)"
+  and arch_invoke_irq_control_reads_respects:
+    "reads_respects aag l (K (arch_authorised_irq_ctl_inv aag irq_ctl_inv))
+                    (arch_invoke_irq_control irq_ctl_inv)"
+  and arch_invoke_irq_control_globals_equiv:
+    "\<lbrace>globals_equiv st and valid_ko_at_arch and valid_global_objs\<rbrace>
+     arch_invoke_irq_control ai
+     \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  and arch_invoke_irq_handler_globals_equiv[wp]:
+    "arch_invoke_irq_handler hi \<lbrace>globals_equiv st\<rbrace>"
+begin
 
 (* invs comes from cap_delete_one *)
 lemma invoke_irq_handler_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects_f aag l (silc_inv aag st and pas_refined aag and invs and pas_refined aag and irq_handler_inv_valid irq_inv and K (authorised_irq_hdl_inv aag irq_inv)) (invoke_irq_handler irq_inv)"
-  apply(case_tac irq_inv)
-    apply(simp)
-    apply(rule equiv_valid_guard_imp)
-     apply(rule reads_respects_f[OF dmo_maskInterrupt_reads_respects, where Q="\<top>" and st=st], wp)
-     apply(simp)
-    apply(simp)
-   apply(simp)
-   apply(wp reads_respects_f[OF cap_insert_reads_respects] cap_delete_one_reads_respects_f[where st=st]
-         reads_respects_f[OF get_irq_slot_reads_respects, where Q="\<top>"] cap_insert_silc_inv''
-         cap_delete_one_silc_inv_subject cap_delete_one_cte_wp_at_other static_imp_wp
-         hoare_vcg_ex_lift slots_holding_overlapping_caps_from_silc_inv[where aag=aag and st=st]| simp | simp add: get_irq_slot_def)+
+  "reads_respects_f aag l (silc_inv aag st and pas_refined aag and invs and pas_refined aag
+                                           and irq_handler_inv_valid irq_inv
+                                           and K (authorised_irq_hdl_inv aag irq_inv))
+                    (invoke_irq_handler irq_inv)"
+  apply (case_tac irq_inv)
+    apply (simp)
+    apply (rule equiv_valid_guard_imp)
+     apply wpsimp
+    apply fastforce
+   apply (wp reads_respects_f[OF cap_insert_reads_respects]
+             cap_delete_one_reads_respects_f[where st=st]
+             reads_respects_f[OF get_irq_slot_reads_respects, where Q="\<top>"]
+             cap_insert_silc_inv'' cap_delete_one_silc_inv_subject
+             cap_delete_one_cte_wp_at_other static_imp_wp
+             hoare_vcg_ex_lift slots_holding_overlapping_caps_from_silc_inv[where aag=aag and st=st]
+          | simp | simp add: get_irq_slot_def)+
    apply (clarsimp simp: pas_refined_def irq_map_wellformed_aux_def)
    apply ((rule conjI, assumption) | clarsimp simp: conj_comms authorised_irq_hdl_inv_def)+
    apply (drule_tac p="(a,b)" in cte_wp_at_norm)
    apply (elim exE conjE, rename_tac cap')
    apply (drule_tac cap=cap' in silc_invD)
      apply assumption
-    apply(fastforce simp: intra_label_cap_def cap_points_to_label_def interrupt_derived_ntfn_cap_identical_refs)
-   apply(fastforce simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def interrupt_derived_ntfn_cap_identical_refs)
-  apply(clarsimp)
-  apply(wp reads_respects_f[OF get_irq_slot_reads_respects, where Q="\<top>" and st=st] cap_delete_one_reads_respects_f | simp)+
-  apply(auto simp: authorised_irq_hdl_inv_def)[1]
-  done
-
-lemma arch_invoke_irq_control_reads_respects:
-  "reads_respects aag l (K (arch_authorised_irq_ctl_inv aag irq_ctl_inv)) (arch_invoke_irq_control irq_ctl_inv)"
-  apply (case_tac irq_ctl_inv)
-  apply (simp add: setIRQTrigger_def)
-  apply (wp cap_insert_reads_respects set_irq_state_reads_respects dmo_mol_reads_respects | simp)+
-  apply (clarsimp simp: arch_authorised_irq_ctl_inv_def)
+    apply (fastforce simp: intra_label_cap_def cap_points_to_label_def
+                           interrupt_derived_ntfn_cap_identical_refs)
+   apply (fastforce simp: slots_holding_overlapping_caps_def2 ctes_wp_at_def
+                          interrupt_derived_ntfn_cap_identical_refs)
+  apply (clarsimp)
+  apply (wpsimp wp: reads_respects_f[OF get_irq_slot_reads_respects, where Q=\<top>]
+                    cap_delete_one_reads_respects_f)
+  apply (auto simp: authorised_irq_hdl_inv_def)[1]
   done
 
 lemma invoke_irq_control_reads_respects:
-  "reads_respects aag l (K (authorised_irq_ctl_inv aag irq_ctl_inv)) (invoke_irq_control irq_ctl_inv)"
-  apply (case_tac irq_ctl_inv)
+  "reads_respects aag l (K (authorised_irq_ctl_inv aag i)) (invoke_irq_control i)"
+  apply (cases i)
    apply (wp cap_insert_reads_respects set_irq_state_reads_respects | simp)+
    apply (clarsimp simp: authorised_irq_ctl_inv_def)
   apply (simp add: authorised_irq_ctl_inv_def)
   apply (rule arch_invoke_irq_control_reads_respects[simplified])
   done
 
-subsection "globals equiv"
-
-crunch valid_ko_at_arm[wp]:  set_irq_state "valid_ko_at_arm"
-
-lemma arch_invoke_irq_control_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm and valid_global_objs \<rbrace> arch_invoke_irq_control a
-   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (induct a)
-  apply (simp add: setIRQTrigger_def)
-  apply (wp set_irq_state_valid_ko_at_arm set_irq_state_globals_equiv cap_insert_globals_equiv''
-            set_irq_state_valid_global_objs dmo_mol_globals_equiv
-        | simp)+
-  done
-
 lemma invoke_irq_control_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm and valid_global_objs \<rbrace> invoke_irq_control a
+  "\<lbrace>globals_equiv st and valid_ko_at_arch and valid_global_objs\<rbrace> invoke_irq_control a
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (induct a)
-   apply (wp set_irq_state_valid_ko_at_arm set_irq_state_globals_equiv cap_insert_globals_equiv''
+   apply (wp set_irq_state_valid_ko_at_arch set_irq_state_globals_equiv cap_insert_globals_equiv''
              set_irq_state_valid_global_objs arch_invoke_irq_control_globals_equiv
           | simp)+
   done
 
-crunch valid_global_objs[wp]: cap_delete_one "valid_global_objs" (wp: dxo_wp_weak simp: unless_def ignore: empty_slot_ext)
-
 lemma invoke_irq_handler_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm  and valid_global_objs \<rbrace>
+  "\<lbrace>globals_equiv st and valid_ko_at_arch  and valid_global_objs\<rbrace>
     invoke_irq_handler a
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (induct a)
-    by (wp dmo_no_mem_globals_equiv modify_wp cap_insert_globals_equiv''
-           cap_delete_one_globals_equiv cap_delete_one_valid_ko_at_arm
-           cap_delete_one_valid_global_objs
-            | simp add: maskInterrupt_def)+
+  by (wpsimp wp: modify_wp cap_insert_globals_equiv'' cap_delete_one_globals_equiv
+                 cap_delete_one_valid_ko_at_arch cap_delete_one_valid_global_objs)+
 
 subsection "reads_respects_g"
-
 
 lemma invoke_irq_handler_reads_respects_f_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects_f_g aag l (silc_inv aag st and invs and pas_refined aag and irq_handler_inv_valid irq_inv and K (authorised_irq_hdl_inv aag irq_inv)) (invoke_irq_handler irq_inv)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_f_g])
-   apply(rule invoke_irq_handler_reads_respects_f[OF domains_distinct])
-  apply(rule doesnt_touch_globalsI)
-   apply(wp invoke_irq_handler_globals_equiv | simp)+
-  apply(simp add: invs_valid_ko_at_arm invs_valid_global_objs)
+  "reads_respects_f_g aag l (silc_inv aag st and invs and pas_refined aag
+                                             and irq_handler_inv_valid irq_inv
+                                             and K (authorised_irq_hdl_inv aag irq_inv))
+                      (invoke_irq_handler irq_inv)"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_f_g])
+    apply (rule invoke_irq_handler_reads_respects_f[OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp invoke_irq_handler_globals_equiv | simp)+
+  apply (simp add: invs_valid_ko_at_arch invs_valid_global_objs)
   by auto
 
 lemma invoke_irq_control_reads_respects_g:
-  "reads_respects_g aag l (valid_global_objs and valid_ko_at_arm and K (authorised_irq_ctl_inv aag irq_ctl_inv)) (invoke_irq_control irq_ctl_inv)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_g])
-   apply(rule invoke_irq_control_reads_respects)
-  apply(rule doesnt_touch_globalsI)
-   apply(wp invoke_irq_control_globals_equiv | simp)+
+  "reads_respects_g aag l (valid_global_objs and valid_ko_at_arch
+                                             and K (authorised_irq_ctl_inv aag i))
+                    (invoke_irq_control i)"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule invoke_irq_control_reads_respects)
+   apply (rule doesnt_touch_globalsI)
+   apply (wp invoke_irq_control_globals_equiv | simp)+
   done
 
 end

--- a/proof/infoflow/Interrupt_IF.thy
+++ b/proof/infoflow/Interrupt_IF.thy
@@ -20,7 +20,7 @@ locale Interrupt_IF_1 =
     "reads_respects aag l (K (arch_authorised_irq_ctl_inv aag irq_ctl_inv))
                     (arch_invoke_irq_control irq_ctl_inv)"
   and arch_invoke_irq_control_globals_equiv:
-    "\<lbrace>globals_equiv st and valid_ko_at_arch and valid_global_objs\<rbrace>
+    "\<lbrace>globals_equiv st and valid_arch_state and valid_global_objs\<rbrace>
      arch_invoke_irq_control ai
      \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   and arch_invoke_irq_handler_globals_equiv[wp]:
@@ -73,21 +73,21 @@ lemma invoke_irq_control_reads_respects:
   done
 
 lemma invoke_irq_control_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arch and valid_global_objs\<rbrace> invoke_irq_control a
+  "\<lbrace>globals_equiv st and valid_arch_state and valid_global_objs\<rbrace>
+   invoke_irq_control a
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (induct a)
-   apply (wp set_irq_state_valid_ko_at_arch set_irq_state_globals_equiv cap_insert_globals_equiv''
-             set_irq_state_valid_global_objs arch_invoke_irq_control_globals_equiv
-          | simp)+
+   apply (wpsimp wp: set_irq_state_globals_equiv cap_insert_globals_equiv''
+                     set_irq_state_valid_global_objs arch_invoke_irq_control_globals_equiv)+
   done
 
 lemma invoke_irq_handler_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arch  and valid_global_objs\<rbrace>
-    invoke_irq_handler a
+  "\<lbrace>globals_equiv st and valid_arch_state and valid_global_objs\<rbrace>
+   invoke_irq_handler a
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (induct a)
-  by (wpsimp wp: modify_wp cap_insert_globals_equiv'' cap_delete_one_globals_equiv
-                 cap_delete_one_valid_ko_at_arch cap_delete_one_valid_global_objs)+
+  by (wpsimp wp: modify_wp cap_insert_globals_equiv''
+                 cap_delete_one_globals_equiv cap_delete_one_valid_global_objs)+
 
 subsection "reads_respects_g"
 
@@ -102,11 +102,10 @@ lemma invoke_irq_handler_reads_respects_f_g:
     apply (rule invoke_irq_handler_reads_respects_f[OF domains_distinct])
    apply (rule doesnt_touch_globalsI)
    apply (wp invoke_irq_handler_globals_equiv | simp)+
-  apply (simp add: invs_valid_ko_at_arch invs_valid_global_objs)
   by auto
 
 lemma invoke_irq_control_reads_respects_g:
-  "reads_respects_g aag l (valid_global_objs and valid_ko_at_arch
+  "reads_respects_g aag l (valid_global_objs and valid_arch_state
                                              and K (authorised_irq_ctl_inv aag i))
                     (invoke_irq_control i)"
   apply (rule equiv_valid_guard_imp[OF reads_respects_g])

--- a/proof/infoflow/Ipc_IF.thy
+++ b/proof/infoflow/Ipc_IF.thy
@@ -5,183 +5,37 @@
  *)
 
 theory Ipc_IF
-imports Finalise_IF
+imports ArchFinalise_IF
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
-
 section "reads_respects"
+
 subsection "Notifications"
 
-lemma equiv_valid_2_get_assert:
-  "equiv_valid_2 I A A R P P' f f' \<Longrightarrow>
-   equiv_valid_2 I A A R P P' (get >>= (\<lambda> s. assert (g s) >>= (\<lambda> y. f))) (get >>= (\<lambda> s. assert (g' s) >>= (\<lambda> y. f')))"
-  apply(rule equiv_valid_2_guard_imp)
-   apply(rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
-       apply(rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
-          apply assumption
-         apply(simp add: assert_ev2)
-        apply(wp equiv_valid_rv_trivial | simp)+
-  done
+definition ipc_buffer_has_read_auth :: "'a PAS \<Rightarrow> 'a \<Rightarrow> obj_ref option \<Rightarrow> bool" where
+  "ipc_buffer_has_read_auth aag l \<equiv>
+     case_option True
+       (\<lambda>buf'. is_aligned buf' msg_align_bits \<and>
+               (\<forall>x \<in> ptr_range buf' msg_align_bits. (l,Read,pasObjectAbs aag x) \<in> (pasPolicy aag)))"
 
-lemma dummy_machine_state_update:
-  "st = st\<lparr>machine_state := machine_state st\<rparr>"
-  apply simp
-  done
+abbreviation aag_can_read_or_affect where
+  "aag_can_read_or_affect aag l x \<equiv>
+    aag_can_read aag x \<or> aag_can_affect aag l x"
 
-lemma dmo_storeWord_modifies_at_most:
-  "modifies_at_most aag (pasObjectAbs aag ` ptr_range p 2) \<top>
-        (do_machine_op (storeWord p w))"
-  apply(rule modifies_at_mostI)
-  apply(simp add: do_machine_op_def storeWord_def)
-  apply(wp modify_wp | simp add: split_def)+
-  apply clarsimp
-  apply(erule use_valid)
-  apply(wp modify_wp)
-  apply(clarsimp simp: equiv_but_for_labels_def)
-  apply(subst (asm) is_aligned_mask[symmetric])
-  apply(subst dummy_machine_state_update)
-  apply(rule states_equiv_for_machine_state_update)
-   apply assumption
-  apply (erule states_equiv_forE_mem)
-  apply (intro conjI equiv_forI)
-   apply(fastforce simp: image_def dest: distinct_lemma[where f="pasObjectAbs aag"] intro: ptr_range_memI ptr_range_add_memI)+
-  done
-
-
-
-lemma get_object_reads_respects:
-  "reads_respects aag l (K (aag_can_read aag oref \<or> aag_can_affect aag l oref)) (get_object oref)"
-  unfolding get_object_def
-  apply(subst gets_apply)
-  apply(wp gets_apply_ev | wpc | simp)+
-  apply(blast intro: reads_affects_equiv_kheap_eq)
-  done
 
 lemma get_cap_reads_respects:
   "reads_respects aag l (K (aag_can_read aag (fst slot) \<or> aag_can_affect aag l (fst slot))) (get_cap slot)"
-  apply(simp add: get_cap_def split_def)
-  apply(wp get_object_reads_respects | wpc | simp)+
+  apply (simp add: get_cap_def split_def)
+  apply (wp get_object_reads_respects | wpc | simp)+
   done
 
-lemma lookup_ipc_buffer_reads_respects:
-  "reads_respects aag l (K (aag_can_read aag thread \<or> aag_can_affect aag l thread)) (lookup_ipc_buffer is_receiver thread)"
-  unfolding lookup_ipc_buffer_def
-  apply(wp thread_get_reads_respects get_cap_reads_respects | wpc | simp)+
-  done
-
-
-lemmas lookup_ipc_buffer_reads_respects_g = reads_respects_g_from_inv[OF lookup_ipc_buffer_reads_respects lookup_ipc_buffer_inv]
-
-lemma as_user_equiv_but_for_labels:
-  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L)\<rbrace>
-    as_user thread f
-    \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
-  unfolding as_user_def
-  apply (wp set_object_equiv_but_for_labels | simp add: split_def)+
-  apply(blast dest: get_tcb_not_asid_pool_at)
-  done
-
-crunch equiv_but_for_labels: set_message_info "equiv_but_for_labels aag L st"
-
-
-lemma storeWord_equiv_but_for_labels:
-  "\<lbrace>\<lambda>ms. equiv_but_for_labels aag L st (s\<lparr>machine_state := ms\<rparr>) \<and>
-        for_each_byte_of_word (\<lambda> x. pasObjectAbs aag x \<in> L) p\<rbrace>
-    storeWord p v \<lbrace>\<lambda>a b. equiv_but_for_labels aag L st (s\<lparr>machine_state := b\<rparr>)\<rbrace>"
-  unfolding storeWord_def
-  apply (wp modify_wp)
-  apply (clarsimp simp: equiv_but_for_labels_def)
-  apply (rule states_equiv_forI)
-            apply(fastforce intro!: equiv_forI elim!: states_equiv_forE dest: equiv_forD[where f=kheap])
-           apply (simp add: states_equiv_for_def)
-          apply (rule conjI)
-           apply(rule equiv_forI)
-           apply clarsimp
-           apply(drule_tac f=underlying_memory in equiv_forD,fastforce)
-           apply(fastforce intro: is_aligned_no_wrap' word_plus_mono_right simp: is_aligned_mask for_each_byte_of_word_def)
-           apply(rule equiv_forI)
-          apply clarsimp
-          apply(drule_tac f=device_state in equiv_forD,fastforce)
-          apply clarsimp
-         apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt])
-        apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=ekheap])
-       apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt_list])
-      apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=is_original_cap])
-     apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_states])
-    apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_irq_node])
-   apply(fastforce simp: equiv_asids_def equiv_asid_def elim: states_equiv_forE)
-  apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=ready_queues])
-  done
-
-lemma store_word_offs_equiv_but_for_labels:
-  "\<lbrace> equiv_but_for_labels aag L st and K (for_each_byte_of_word (\<lambda>x. pasObjectAbs aag x \<in> L) (ptr + of_nat offs * of_nat word_size)) \<rbrace>
-   store_word_offs ptr offs v
-   \<lbrace> \<lambda>_. equiv_but_for_labels aag L st \<rbrace>"
-  unfolding store_word_offs_def
-  apply(wp modify_wp | simp add: do_machine_op_def split_def)+
-  apply clarsimp
-  apply(erule use_valid[OF _ storeWord_equiv_but_for_labels])
-  apply simp
-  done
-
-definition
-  ipc_buffer_has_read_auth :: "'a PAS \<Rightarrow> 'a \<Rightarrow> word32 option \<Rightarrow> bool"
-where
-"ipc_buffer_has_read_auth aag l \<equiv>
-    case_option True (\<lambda>buf'. is_aligned buf' msg_align_bits \<and> (\<forall>x \<in> ptr_range buf' msg_align_bits. (l,Read,pasObjectAbs aag x) \<in> (pasPolicy aag)))"
-
-
-lemma set_mrs_equiv_but_for_labels:
-  "\<lbrace> equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L \<and>
-       (case buf of (Some buf') \<Rightarrow>
-        is_aligned buf' msg_align_bits \<and>
-        (\<forall>x \<in> ptr_range buf' msg_align_bits. pasObjectAbs aag x \<in> L)
-                 | _ \<Rightarrow> True)) \<rbrace>
-   set_mrs thread buf msgs
-   \<lbrace> \<lambda>_. equiv_but_for_labels aag L st \<rbrace>"
-  unfolding set_mrs_def
-  apply (wp | wpc)+
-       apply(subst zipWithM_x_mapM_x)
-       apply(rule_tac Q="\<lambda>_. equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L  \<and>
-       (case buf of (Some buf') \<Rightarrow>
-        is_aligned buf' msg_align_bits \<and>
-        (\<forall>x \<in> ptr_range buf' msg_align_bits. pasObjectAbs aag x \<in> L)
-                 | _ \<Rightarrow> True))" in hoare_strengthen_post)
-       apply(wp mapM_x_wp' store_word_offs_equiv_but_for_labels | simp add: split_def)+
-        apply(case_tac xa, clarsimp split: if_split_asm elim!: in_set_zipE)
-        apply(clarsimp simp: for_each_byte_of_word_def)
-        apply(erule bspec)
-        apply(clarsimp simp: ptr_range_def)
-        apply(rule conjI)
-         apply(erule order_trans[rotated])
-         apply(erule is_aligned_no_wrap')
-         apply(rule mul_word_size_lt_msg_align_bits_ofnat)
-         apply(fastforce simp: msg_max_length_def msg_align_bits')
-        apply(erule order_trans)
-        apply(subst p_assoc_help)
-        apply(simp add: add.assoc)
-        apply(rule word_plus_mono_right)
-         apply(rule word_less_sub_1)
-         apply(rule_tac y="of_nat msg_max_length * of_nat word_size + 3" in le_less_trans)
-          apply(rule word_plus_mono_left)
-           apply(rule word_mult_le_mono1)
-             apply(erule disjE)
-              apply(rule word_of_nat_le)
-              apply(simp add: msg_max_length_def)
-             apply clarsimp
-             apply(rule word_of_nat_le)
-             apply(simp add: msg_max_length_def)
-            apply(simp add: word_size_def)
-           apply(simp add: msg_max_length_def word_size_def)
-          apply(simp add: msg_max_length_def word_size_def)
-         apply(rule mul_add_word_size_lt_msg_align_bits_ofnat)
-          apply(simp add: msg_max_length_def msg_align_bits')
-         apply(simp add: word_size_def)
-        apply(erule is_aligned_no_overflow')
-       apply simp
-      apply(wp set_object_equiv_but_for_labels hoare_vcg_all_lift static_imp_wp | simp)+
-   apply (fastforce dest: get_tcb_not_asid_pool_at)+
+lemma set_thread_state_ext_runnable_equiv_but_for_labels:
+  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L) and st_tcb_at runnable thread\<rbrace>
+   set_thread_state_ext thread
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  apply (simp add: set_thread_state_ext_def)
+  apply (wp gts_wp | rule hoare_pre_cont)+
+  apply (force simp: st_tcb_at_def obj_at_def)
   done
 
 
@@ -191,80 +45,45 @@ definition all_to_which_has_auth where
 definition all_with_auth_to where
   "all_with_auth_to aag auth target \<equiv> {x. (x, auth, target) \<in> pasPolicy aag}"
 
+
 lemma valid_ntfn_WaitingNtfn_tl:
-  "\<lbrakk>ntfn_obj ntfn = (WaitingNtfn list); valid_ntfn ntfn s; tl list \<noteq> []; ntfn' = ntfn\<lparr>ntfn_obj := (WaitingNtfn (tl list))\<rparr> \<rbrakk> \<Longrightarrow>
-   valid_ntfn ntfn' s"
-  apply(case_tac list, simp_all)
-  apply(rename_tac a lista)
-  apply(case_tac lista, simp_all)
-  apply(clarsimp simp: valid_ntfn_def split: option.splits)
-  done
-
-(* FIXME: many redundant conditions *)
-lemma update_waiting_ntfn_reads_respects:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (pspace_aligned and valid_vspace_objs and valid_arch_state and valid_objs and
-                         sym_refs \<circ> state_refs_of and pas_refined aag and pas_cur_domain aag and
-                         ko_at (Notification ntfn) ntfnptr and (\<lambda>s. is_subject aag (cur_thread s)) and
-                         K (ntfn_obj ntfn = WaitingNtfn queue)) (update_waiting_ntfn ntfnptr queue bound_tcb badge)"
-  unfolding update_waiting_ntfn_def fun_app_def
-  apply (wp assert_sp possible_switch_to_reads_respects gets_cur_thread_ev | simp add: split_def)+
-  apply (wp as_user_set_register_reads_respects' set_thread_state_reads_respects
-            set_simple_ko_reads_respects set_thread_state_pas_refined
-            set_simple_ko_valid_objs hoare_vcg_disj_lift set_simple_ko_pas_refined
-         | simp add: split_def)+
-  done
-
-lemma set_thread_state_ext_runnable_equiv_but_for_labels:
-  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L) and st_tcb_at runnable thread\<rbrace>
-    set_thread_state_ext thread
-    \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
-  apply (simp add: set_thread_state_ext_def)
-  apply wp
-     apply (rule hoare_pre_cont)
-    apply (wp gts_wp)+
-  apply (force simp: st_tcb_at_def obj_at_def)
-  done
-
-lemma set_thread_state_runnable_equiv_but_for_labels:
-  "runnable tst \<Longrightarrow> \<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L)\<rbrace>
-    set_thread_state thread tst
-    \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
-  unfolding set_thread_state_def
-  apply (wpsimp wp: set_object_equiv_but_for_labels[THEN hoare_set_object_weaken_pre]
-                    set_thread_state_ext_runnable_equiv_but_for_labels)
-    apply (wpsimp wp: set_object_wp)+
-  apply (fastforce dest: get_tcb_not_asid_pool_at simp: st_tcb_at_def obj_at_def)
+  "\<lbrakk> ntfn_obj ntfn = (WaitingNtfn list); valid_ntfn ntfn s;
+     tl list \<noteq> []; ntfn' = ntfn\<lparr>ntfn_obj := (WaitingNtfn (tl list))\<rparr> \<rbrakk>
+     \<Longrightarrow> valid_ntfn ntfn' s"
+  apply (case_tac list, simp_all)
+  apply (rename_tac a lista)
+  apply (case_tac lista, simp_all)
+  apply (clarsimp simp: valid_ntfn_def split: option.splits)
   done
 
 lemma tcb_sched_action_equiv_but_for_labels:
   "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L) and pas_refined aag\<rbrace>
-    tcb_sched_action action thread
-    \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+   tcb_sched_action action thread
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
   apply (simp add: tcb_sched_action_def, wp)
   apply (clarsimp simp: etcb_at_def equiv_but_for_labels_def split: option.splits)
   apply (rule states_equiv_forI)
-           apply(fastforce intro!: equiv_forI elim!: states_equiv_forE dest: equiv_forD[where f=kheap])
+           apply (fastforce intro!: equiv_forI elim!: states_equiv_forE dest: equiv_forD[where f=kheap])
           apply (simp add: states_equiv_for_def)
-         apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt])
-        apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=ekheap])
-       apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt_list])
-      apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=is_original_cap])
-     apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_states])
-    apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_irq_node])
-   apply(fastforce simp: equiv_asids_def equiv_asid_def elim: states_equiv_forE)
+         apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt])
+        apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=ekheap])
+       apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt_list])
+      apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=is_original_cap])
+     apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_states])
+    apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_irq_node])
+   apply (fastforce simp: equiv_asids_def elim: states_equiv_forE)
   apply (clarsimp simp: pas_refined_def tcb_domain_map_wellformed_aux_def split: option.splits)
   apply (rule equiv_forI)
   apply (erule_tac x="(thread, tcb_domain (the (ekheap s thread)))" in ballE)
-   apply(fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=ready_queues])
+   apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=ready_queues])
   apply (force intro: domtcbs)
   done
 
 lemma possible_switch_to_equiv_but_for_labels:
-  "\<lbrace>equiv_but_for_labels aag L st and (\<lambda>s. etcb_at (\<lambda>etcb. tcb_domain etcb \<noteq> cur_domain s) target s) and K (pasObjectAbs aag target \<in> L) and pas_refined aag\<rbrace>
-    possible_switch_to target
-    \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  "\<lbrace>equiv_but_for_labels aag L st and (\<lambda>s. etcb_at (\<lambda>etcb. tcb_domain etcb \<noteq> cur_domain s) target s)
+                                  and K (pasObjectAbs aag target \<in> L) and pas_refined aag\<rbrace>
+   possible_switch_to target
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
   apply (simp add: possible_switch_to_def)
   apply (wp tcb_sched_action_equiv_but_for_labels)
        (* possible_switch_to does not modify scheduler action if target is in different domain *)
@@ -275,103 +94,196 @@ lemma possible_switch_to_equiv_but_for_labels:
   apply (clarsimp simp: etcb_at_def split: option.splits)
   done
 
-crunch etcb_at_cdom[wp]: set_thread_state_ext, set_thread_state, set_simple_ko
-   "\<lambda>s. etcb_at (P (cur_domain s)) t s"
+crunches set_thread_state_ext, set_thread_state, set_simple_ko
+  for etcb_at_cdom[wp]: "\<lambda>s. etcb_at (P (cur_domain s)) t s"
   (wp: crunch_wps)
 
+
+locale Ipc_IF_1 =
+  fixes aag :: "'a subject_label PAS"
+  assumes lookup_ipc_buffer_reads_respects:
+    "reads_respects aag l (K (aag_can_read aag thread \<or> aag_can_affect aag l thread))
+                          (lookup_ipc_buffer is_receiver thread)"
+  and as_user_equiv_but_for_labels:
+    "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L)\<rbrace>
+     as_user thread (f :: unit user_monad)
+     \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  and storeWord_equiv_but_for_labels:
+    "\<lbrace>\<lambda>ms. equiv_but_for_labels aag L st (s\<lparr>machine_state := ms\<rparr>) \<and>
+           for_each_byte_of_word (\<lambda>x. pasObjectAbs aag x \<in> L) p\<rbrace>
+     storeWord p v
+     \<lbrace>\<lambda>_ ms. equiv_but_for_labels aag L st (s\<lparr>machine_state := ms\<rparr>)\<rbrace>"
+  and set_thread_state_runnable_equiv_but_for_labels:
+    "runnable tst
+     \<Longrightarrow> \<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L)\<rbrace>
+         set_thread_state thread tst
+         \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  and set_endpoint_equiv_but_for_labels:
+    "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag epptr \<in> L)\<rbrace>
+     set_endpoint epptr ep
+     \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  and lookup_ipc_buffer_has_read_auth:
+    "\<lbrace>pas_refined aag and valid_objs\<rbrace>
+     lookup_ipc_buffer is_receiver thread
+     \<lbrace>\<lambda>rv _. ipc_buffer_has_read_auth aag (pasObjectAbs aag thread) rv\<rbrace>"
+  and dmo_loadWord_reads_respects:
+    "reads_respects aag l (K (for_each_byte_of_word (\<lambda> x. aag_can_read_or_affect aag l x) p))
+                          (do_machine_op (loadWord p))"
+  and arch_derive_cap_reads_respects:
+    "reads_respects aag l \<top> (arch_derive_cap acap)"
+  and arch_derive_cap_rev:
+    "reads_equiv_valid_inv A aag \<top> (arch_derive_cap acap)"
+  and cptrs_in_ipc_buffer:
+    "\<lbrakk> n \<in> set [buffer_cptr_index ..< buffer_cptr_index + unat (mi_extra_caps mi)];
+       is_aligned p msg_align_bits;
+       buffer_cptr_index + unat (mi_extra_caps mi) < 2 ^ (msg_align_bits - word_size_bits) \<rbrakk>
+       \<Longrightarrow> ptr_range (p + of_nat n * of_nat word_size) word_size_bits \<subseteq> ptr_range p msg_align_bits"
+  and msg_in_ipc_buffer:
+    "\<lbrakk> n = msg_max_length \<or> n < msg_max_length; is_aligned p msg_align_bits;
+       unat (mi_length mi) < 2 ^ (msg_align_bits - word_size_bits) \<rbrakk>
+       \<Longrightarrow> ptr_range (p + of_nat n * of_nat word_size) word_size_bits \<subseteq> ptr_range p msg_align_bits"
+  and captransfer_in_ipc_buffer:
+    "\<lbrakk> is_aligned (buf :: obj_ref) msg_align_bits; p \<in> {0..2} \<rbrakk>
+       \<Longrightarrow> ptr_range (buf + (2 + (of_nat msg_max_length + of_nat msg_max_extra_caps))
+                          * word_size + p * word_size) word_size_bits
+           \<subseteq> ptr_range buf msg_align_bits"
+  and mrs_in_ipc_buffer:
+    "\<lbrakk> n \<in> set [length msg_registers + 1 ..< Suc n'];
+       is_aligned buf msg_align_bits; n' < 2 ^ (msg_align_bits - word_size_bits) \<rbrakk>
+       \<Longrightarrow> ptr_range (buf + of_nat n * of_nat word_size) word_size_bits
+           \<subseteq> ptr_range buf msg_align_bits"
+  and complete_signal_reads_respects:
+    "pas_domains_distinct aag
+     \<Longrightarrow> reads_respects aag l (K (aag_can_read aag nptr \<or> aag_can_affect aag l nptr))
+                        (complete_signal nptr receiver)"
+  and handle_arch_fault_reply_reads_respects:
+    "reads_respects aag l (K (aag_can_read aag thread)) (handle_arch_fault_reply afault thread x y)"
+  and arch_get_sanitise_register_info_reads_respects[wp]:
+    "reads_respects aag l \<top> (arch_get_sanitise_register_info t)"
+  and handle_arch_fault_reply_valid_ko_at_arch[wp]:
+    "handle_arch_fault_reply vmf t x y \<lbrace>valid_ko_at_arch\<rbrace>"
+  and arch_get_sanitise_register_info_valid_global_objs[wp]:
+    "arch_get_sanitise_register_info t \<lbrace>\<lambda>s :: det_state. valid_global_objs s\<rbrace>"
+  and handle_arch_fault_reply_valid_global_objs[wp]:
+    "handle_arch_fault_reply vmf thread x y \<lbrace>\<lambda>s :: det_state. valid_global_objs s\<rbrace>"
+  and lookup_ipc_buffer_ptr_range':
+    "\<lbrace>valid_objs\<rbrace>
+     lookup_ipc_buffer True t
+     \<lbrace>\<lambda>rv s :: det_state. rv = Some buf' \<longrightarrow> auth_ipc_buffers s t = ptr_range buf' msg_align_bits\<rbrace>"
+  and lookup_ipc_buffer_aligned':
+    "\<lbrace>valid_objs\<rbrace>
+     lookup_ipc_buffer True t
+     \<lbrace>\<lambda>rv s :: det_state. rv = Some buf' \<longrightarrow> is_aligned buf' msg_align_bits\<rbrace>"
+  and handle_arch_fault_reply_globals_equiv:
+    "\<lbrace>globals_equiv st and valid_ko_at_arch and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
+     handle_arch_fault_reply vmf thread x y
+     \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+begin
+
+lemma store_word_offs_equiv_but_for_labels:
+  "\<lbrace>equiv_but_for_labels aag L st and
+    K (for_each_byte_of_word (\<lambda>x. pasObjectAbs aag x \<in> L) (ptr + of_nat offs * of_nat word_size))\<rbrace>
+   store_word_offs ptr offs v
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding store_word_offs_def
+  apply (wp modify_wp | simp add: do_machine_op_def split_def)+
+  apply clarsimp
+  apply (erule use_valid[OF _ storeWord_equiv_but_for_labels])
+  apply simp
+  done
+
+(* FIXME: many redundant conditions *)
+lemma update_waiting_ntfn_reads_respects:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows
+    "reads_respects aag l (pspace_aligned and valid_vspace_objs and valid_arch_state and valid_objs
+                                          and sym_refs \<circ> state_refs_of and pas_refined aag
+                                          and pas_cur_domain aag and ko_at (Notification ntfn) nptr
+                                          and (\<lambda>s. is_subject aag (cur_thread s))
+                                          and K (ntfn_obj ntfn = WaitingNtfn queue))
+                    (update_waiting_ntfn nptr queue bound_tcb badge)"
+  unfolding update_waiting_ntfn_def fun_app_def
+  apply (wp assert_sp possible_switch_to_reads_respects gets_cur_thread_ev | simp add: split_def)+
+  by (wp as_user_set_register_reads_respects' set_thread_state_reads_respects
+         set_simple_ko_reads_respects set_thread_state_pas_refined
+         set_simple_ko_valid_objs hoare_vcg_disj_lift set_simple_ko_pas_refined
+      | simp add: split_def)+
+
 lemma update_waiting_ntfn_equiv_but_for_labels:
-  "\<lbrace> equiv_but_for_labels aag L st and pas_refined aag and
-     pspace_aligned and valid_vspace_objs and valid_arch_state and valid_objs and
-     ko_at (Notification ntfn) ntfnptr and
-     sym_refs \<circ> state_refs_of and
-     (\<lambda>s. \<forall>t\<in> set list. etcb_at (\<lambda>etcb. tcb_domain etcb \<noteq> cur_domain s) t s) and
-     K (ntfn_obj ntfn = WaitingNtfn list \<and> pasObjectAbs aag ntfnptr \<in> L \<and>
-        all_with_auth_to aag Receive (pasObjectAbs aag ntfnptr) \<subseteq> L \<and>
-       \<Union> ((all_to_which_has_auth aag Write) ` (all_with_auth_to aag Receive (pasObjectAbs aag ntfnptr))) \<subseteq> L)\<rbrace>
-   update_waiting_ntfn ntfnptr list boundtcb badge
-   \<lbrace> \<lambda>_. equiv_but_for_labels aag L st \<rbrace>"
+  "\<lbrace>equiv_but_for_labels aag L st and pas_refined aag and pspace_aligned and valid_vspace_objs and
+    valid_arch_state and valid_objs and ko_at (Notification ntfn) nptr and sym_refs \<circ> state_refs_of and
+    (\<lambda>s. \<forall>t\<in> set list. etcb_at (\<lambda>etcb. tcb_domain etcb \<noteq> cur_domain s) t s) and
+    K (ntfn_obj ntfn = WaitingNtfn list \<and> pasObjectAbs aag nptr \<in> L \<and>
+       all_with_auth_to aag Receive (pasObjectAbs aag nptr) \<subseteq> L \<and>
+       \<Union> (all_to_which_has_auth aag Write ` all_with_auth_to aag Receive (pasObjectAbs aag nptr)) \<subseteq> L)\<rbrace>
+   update_waiting_ntfn nptr list boundtcb badge
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
   unfolding update_waiting_ntfn_def
   apply (wp static_imp_wp as_user_equiv_but_for_labels set_thread_state_runnable_equiv_but_for_labels
             set_thread_state_pas_refined set_notification_equiv_but_for_labels
             set_simple_ko_pred_tcb_at set_simple_ko_pas_refined
             hoare_vcg_disj_lift possible_switch_to_equiv_but_for_labels
-        | wpc | simp add: split_def)+
+         | wpc | simp add: split_def)+
   apply clarsimp
-  apply(frule_tac P="receive_blocked_on ntfnptr" and t="hd list" in ntfn_queued_st_tcb_at')
-      apply(fastforce)
+  apply (frule_tac P="receive_blocked_on nptr" and t="hd list" in ntfn_queued_st_tcb_at')
+      apply (fastforce)
      apply assumption
     apply assumption
    apply simp
-  apply (subgoal_tac "pasObjectAbs aag (hd list) \<in> all_with_auth_to aag Receive (pasObjectAbs aag ntfnptr)")
-   apply(fastforce)
-  apply(clarsimp simp: all_with_auth_to_def)
+  apply (subgoal_tac "pasObjectAbs aag (hd list) \<in> all_with_auth_to aag Receive (pasObjectAbs aag nptr)")
+   apply (fastforce)
+  apply (clarsimp simp: all_with_auth_to_def)
   apply (erule pas_refined_mem[rotated])
   apply (rule sta_ts)
-  apply(clarsimp simp: thread_st_auth_def split: option.split simp: tcb_states_of_state_def st_tcb_def2)
-  apply(case_tac "tcb_state tcb", simp_all)
+  apply (clarsimp simp: thread_st_auth_def tcb_states_of_state_def st_tcb_def2)
+  apply (case_tac "tcb_state tcb", simp_all)
   done
 
-
-lemma update_waiting_ntfn_modifies_at_most:
-  "modifies_at_most aag
-          ({pasObjectAbs aag ntfnptr} \<union>
-           all_with_auth_to aag Receive (pasObjectAbs aag ntfnptr) \<union>
-           \<Union> ((all_to_which_has_auth aag Write) ` (all_with_auth_to aag Receive (pasObjectAbs aag ntfnptr))))
-          (pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state and
-           valid_objs and ko_at (Notification ntfn) ntfnptr and
-           (\<lambda>s. \<forall>t\<in> set list. etcb_at (\<lambda>etcb. tcb_domain etcb \<noteq> cur_domain s) t s) and
-           sym_refs \<circ> state_refs_of and K (ntfn_obj ntfn = WaitingNtfn list))
-          (update_waiting_ntfn ntfnptr list boundtcb badge)"
-  apply(rule modifies_at_mostI)
-  apply(wp update_waiting_ntfn_equiv_but_for_labels | fastforce)+
-  done
+end
 
 
 lemma invisible_ntfn_invisible_receivers_and_ipcbuffers:
-  "\<lbrakk>labels_are_invisible aag l {pasObjectAbs aag ntfnptr};
-    (pasSubject aag, Notify, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag\<rbrakk>
-    \<Longrightarrow> labels_are_invisible aag l
-        ({pasObjectAbs aag ntfnptr} \<union>
-         all_with_auth_to aag Receive (pasObjectAbs aag ntfnptr) \<union>
-         \<Union>(all_to_which_has_auth aag Write `
-          all_with_auth_to aag Receive (pasObjectAbs aag ntfnptr)))"
-  apply(auto simp: labels_are_invisible_def aag_can_affect_label_def dest: reads_read_page_read_thread reads_read_queued_thread_read_ep simp: all_to_which_has_auth_def all_with_auth_to_def)
-  done
-
-lemma invisible_ntfn_invisible_receivers_and_receivers:
-  "\<lbrakk>labels_are_invisible aag l {pasObjectAbs aag ntfnptr};
-    (pasSubject aag, auth, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag;
-    auth \<in> {Notify,Receive,SyncSend}\<rbrakk>
-    \<Longrightarrow> labels_are_invisible aag l
-        ({pasObjectAbs aag ntfnptr} \<union>
-         all_with_auth_to aag Receive (pasObjectAbs aag ntfnptr) \<union>
-         (\<Union>(all_to_which_has_auth aag Receive `
-          all_with_auth_to aag Receive (pasObjectAbs aag ntfnptr))) \<union>
-         (\<Union>(all_to_which_has_auth aag Write `
-          all_with_auth_to aag Receive (pasObjectAbs aag ntfnptr))))"
+  "\<lbrakk> labels_are_invisible aag l {pasObjectAbs aag nptr};
+     (pasSubject aag, Notify, pasObjectAbs aag nptr) \<in> pasPolicy aag\<rbrakk>
+     \<Longrightarrow> labels_are_invisible aag l ({pasObjectAbs aag nptr} \<union>
+                                     all_with_auth_to aag Receive (pasObjectAbs aag nptr) \<union>
+                                     \<Union>(all_to_which_has_auth aag Write
+                                        ` all_with_auth_to aag Receive (pasObjectAbs aag nptr)))"
   by (auto simp: labels_are_invisible_def aag_can_affect_label_def
-        dest: read_sync_ep_read_senders_strong read_sync_ep_read_receivers_strong
-              reads_read_queued_thread_read_ep
-              reads_read_page_read_thread
-              reads_ep
-        simp: all_to_which_has_auth_def all_with_auth_to_def)
+                 all_to_which_has_auth_def all_with_auth_to_def
+           dest: reads_read_page_read_thread reads_read_queued_thread_read_ep)
+
+lemma invisible_ntfn_invisible_receivers_and_receivers[rotated 1]:
+  "\<lbrakk> auth \<in> {Notify,Receive,SyncSend}; labels_are_invisible aag l {pasObjectAbs aag nptr};
+     (pasSubject aag, auth, pasObjectAbs aag nptr) \<in> pasPolicy aag \<rbrakk>
+     \<Longrightarrow> labels_are_invisible aag l ({pasObjectAbs aag nptr} \<union>
+                                     all_with_auth_to aag Receive (pasObjectAbs aag nptr) \<union>
+                                     (\<Union>(all_to_which_has_auth aag Receive
+                                         ` all_with_auth_to aag Receive (pasObjectAbs aag nptr))) \<union>
+                                     (\<Union>(all_to_which_has_auth aag Write
+                                         ` all_with_auth_to aag Receive (pasObjectAbs aag nptr))))"
+  by (auto simp: labels_are_invisible_def aag_can_affect_label_def
+                 all_to_which_has_auth_def all_with_auth_to_def
+           dest: read_sync_ep_read_senders read_sync_ep_read_receivers
+                 reads_read_queued_thread_read_ep reads_read_page_read_thread reads_ep)
 
 lemma read_queued_thread_reads_ntfn:
-  "\<lbrakk>ko_at (Notification ntfn) ntfnptr s; t \<in> set queue; aag_can_read aag t;
-    valid_objs s; sym_refs (state_refs_of s); pas_refined aag s; ntfn_obj ntfn = WaitingNtfn queue;
-    (pasSubject aag, Notify, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag\<rbrakk>
-  \<Longrightarrow> aag_can_read aag ntfnptr"
-  apply(frule_tac P="receive_blocked_on ntfnptr" and t=t in ntfn_queued_st_tcb_at')
-      apply(fastforce)
+  "\<lbrakk> ko_at (Notification ntfn) ntfnptr s; t \<in> set queue; aag_can_read aag t; valid_objs s;
+     sym_refs (state_refs_of s); pas_refined aag s; ntfn_obj ntfn = WaitingNtfn queue;
+     (pasSubject aag, Notify, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag \<rbrakk>
+     \<Longrightarrow> aag_can_read aag ntfnptr"
+  apply (frule_tac P="receive_blocked_on ntfnptr" and t=t in ntfn_queued_st_tcb_at')
+      apply (fastforce)
      apply assumption
     apply assumption
    apply simp
-  apply (rule_tac t="pasObjectAbs aag t" and auth="Receive" and auth'="Notify" in reads_read_queued_thread_read_ep)
+  apply (rule_tac t="pasObjectAbs aag t" and auth="Receive" and auth'="Notify"
+               in reads_read_queued_thread_read_ep)
       apply assumption
      apply simp
     apply (erule pas_refined_mem[rotated])
     apply (rule sta_ts)
-    apply(clarsimp simp: thread_st_auth_def split: option.split simp: tcb_states_of_state_def st_tcb_def2)
+    apply (clarsimp simp: thread_st_auth_def tcb_states_of_state_def st_tcb_def2)
     apply (case_tac "tcb_state tcb", simp_all)[1]
    apply simp
   apply simp
@@ -379,10 +291,9 @@ lemma read_queued_thread_reads_ntfn:
 
 lemma not_etcb_at_not_cdom_can_read:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "\<lbrakk>\<not> etcb_at (\<lambda>etcb. tcb_domain etcb \<noteq> cur_domain s) t s;
-   tcb_at t s; valid_etcbs s; pas_refined aag s; pas_cur_domain aag s\<rbrakk>
-  \<Longrightarrow> aag_can_read aag t"
+  shows "\<lbrakk> \<not> etcb_at (\<lambda>etcb. tcb_domain etcb \<noteq> cur_domain s) t s;
+           tcb_at t s; valid_etcbs s; pas_refined aag s; pas_cur_domain aag s \<rbrakk>
+           \<Longrightarrow> aag_can_read aag t"
   apply (clarsimp simp: valid_etcbs_def tcb_at_st_tcb_at etcb_at_def is_etcb_at_def
                         pas_refined_def tcb_domain_map_wellformed_aux_def)
   apply (erule_tac x="(t, cur_domain s)" in ballE)
@@ -391,43 +302,37 @@ lemma not_etcb_at_not_cdom_can_read:
   done
 
 lemma tcb_at_ntfn_queue:
-  "\<lbrakk>valid_objs s; t \<in> set queue; ko_at (Notification ntfn) ntfnptr s; ntfn_obj ntfn = WaitingNtfn queue\<rbrakk>
-  \<Longrightarrow> tcb_at t s"
-  apply (erule valid_objsE, force simp: obj_at_def)
-  apply (simp add: valid_obj_def valid_ntfn_def)
-  done
-
+  "\<lbrakk> valid_objs s; t \<in> set q; ko_at (Notification ntfn) nptr s; ntfn_obj ntfn = WaitingNtfn q \<rbrakk>
+     \<Longrightarrow> tcb_at t s"
+  by (fastforce simp: obj_at_def valid_obj_def valid_ntfn_def)
 
 lemma invisible_ep_invisible_receiver:
-  "\<lbrakk>labels_are_invisible aag l {pasObjectAbs aag epptr};
-    (pasObjectAbs aag tcb, Receive, pasObjectAbs aag epptr) \<in> pasPolicy aag;
-    (pasObjectAbs aag tcb, Reset, pasObjectAbs aag epptr) \<in> pasPolicy aag\<rbrakk>
-   \<Longrightarrow> labels_are_invisible aag l
-          ({pasObjectAbs aag epptr} \<union> {pasObjectAbs aag tcb})"
-  apply (auto simp: labels_are_invisible_def aag_can_affect_label_def
-                    all_with_auth_to_def
-                  dest: reads_ep reads_read_queued_thread_read_ep)
-  done
+  "\<lbrakk> labels_are_invisible aag l {pasObjectAbs aag epptr};
+     (pasObjectAbs aag tcb, Receive, pasObjectAbs aag epptr) \<in> pasPolicy aag;
+     (pasObjectAbs aag tcb, Reset, pasObjectAbs aag epptr) \<in> pasPolicy aag \<rbrakk>
+     \<Longrightarrow> labels_are_invisible aag l ({pasObjectAbs aag epptr} \<union> {pasObjectAbs aag tcb})"
+  by (auto simp: labels_are_invisible_def aag_can_affect_label_def all_with_auth_to_def
+           dest: reads_ep reads_read_queued_thread_read_ep)
 
-
-lemma no_fail_gts:"no_fail (tcb_at tcb) (get_thread_state tcb)"
+lemma no_fail_gts:
+  "no_fail (tcb_at tcb) (get_thread_state tcb)"
   apply (clarsimp simp: get_thread_state_def thread_get_def)
   apply (rule no_fail_pre)
    apply wp
   by (clarsimp simp: get_tcb_def tcb_at_def)
 
-lemma monadic_rewrite_impossible: "monadic_rewrite F E (\<lambda>_. False) f g"
+lemma monadic_rewrite_impossible:
+  "monadic_rewrite F E \<bottom> f g"
   by (clarsimp simp: monadic_rewrite_def)
 
 lemma monadic_rewrite_add_get:
-  "monadic_rewrite F E P (do x <- get; f od) (do x <- get; g od) \<Longrightarrow>
-       monadic_rewrite F E P f g"
-       by (clarsimp simp: bind_def get_def)
+  "monadic_rewrite F E P (do x <- get; f od) (do x <- get; g od)
+   \<Longrightarrow> monadic_rewrite F E P f g"
+  by (clarsimp simp: bind_def get_def)
 
 lemma sts_noop:
    "monadic_rewrite True True (tcb_at tcb and (\<lambda>s. tcb \<noteq> cur_thread s))
-   (set_thread_state_ext tcb)
-   (return ())"
+                    (set_thread_state_ext tcb) (return ())"
   apply (rule monadic_rewrite_imp)
    apply (rule monadic_rewrite_add_get)
    apply (rule monadic_rewrite_bind_tail)
@@ -449,8 +354,9 @@ lemma sts_noop:
   by (auto simp: pred_tcb_at_def obj_at_def is_tcb_def get_tcb_def)
 
 lemma sts_to_modify':
-  "monadic_rewrite True True (tcb_at tcb and (\<lambda>s :: det_ext state. tcb \<noteq> cur_thread s))
-       (set_thread_state tcb st)  (modify (\<lambda>s. s\<lparr>kheap := kheap s(tcb \<mapsto> TCB (the (get_tcb tcb s)\<lparr>tcb_state := st\<rparr>))\<rparr>))"
+  "monadic_rewrite True True (tcb_at tcb and (\<lambda>s :: det_state. tcb \<noteq> cur_thread s))
+     (set_thread_state tcb st)
+     (modify (\<lambda>s. s\<lparr>kheap := kheap s(tcb \<mapsto> TCB (the (get_tcb tcb s)\<lparr>tcb_state := st\<rparr>))\<rparr>))"
   apply (clarsimp simp: set_thread_state_def set_object_def)
   apply (rule monadic_rewrite_add_get)
   apply (rule monadic_rewrite_bind_tail)
@@ -469,25 +375,25 @@ lemma sts_to_modify':
   apply wp
   by (clarsimp simp: get_tcb_def tcb_at_def)
 
-
-lemma
-  monadic_rewrite_weaken_failure:
-  "monadic_rewrite True True P f f' \<Longrightarrow>
-  no_fail P' f \<Longrightarrow> no_fail Q' f' \<Longrightarrow>
-   monadic_rewrite F E (P and P' and Q') f f'"
+lemma monadic_rewrite_weaken_failure:
+  "\<lbrakk> monadic_rewrite True True P f f'; no_fail P' f; no_fail Q' f' \<rbrakk>
+     \<Longrightarrow> monadic_rewrite F E (P and P' and Q') f f'"
   by (clarsimp simp: monadic_rewrite_def no_fail_def)
 
-lemma
-  sts_no_fail:
-  "no_fail (\<lambda>s :: det_ext state. tcb_at tcb s) (set_thread_state tcb st)"
+lemma sts_no_fail:
+  "no_fail (\<lambda>s :: det_state. tcb_at tcb s) (set_thread_state tcb st)"
   apply (simp add: set_thread_state_def set_object_def)
-  apply (simp add: set_thread_state_ext_def get_thread_state_def thread_get_def set_scheduler_action_def)
+  apply (simp add: set_thread_state_ext_def get_thread_state_def
+                   thread_get_def set_scheduler_action_def)
   apply (rule no_fail_pre)
    apply (wpsimp wp: get_object_wp)+
-  apply (clarsimp simp: get_tcb_def tcb_at_def obj_at_def a_type_def is_tcb_def split: kernel_object.splits option.splits)
+  apply (clarsimp simp: get_tcb_def tcb_at_def obj_at_def a_type_def is_tcb_def
+                 split: kernel_object.splits option.splits)
   by (metis kernel_object.exhaust option.inject)
 
-lemmas sts_to_modify = monadic_rewrite_weaken_failure[OF sts_to_modify' sts_no_fail no_fail_modify,simplified]
+lemmas sts_to_modify =
+  monadic_rewrite_weaken_failure[OF sts_to_modify' sts_no_fail no_fail_modify,simplified]
+
 
 definition "blocked_cancel_ipc_nosts tcb \<equiv>
   do state <- get_thread_state tcb;
@@ -500,12 +406,11 @@ definition "blocked_cancel_ipc_nosts tcb \<equiv>
      set_thread_state tcb Running
   od"
 
+
 lemma cancel_ipc_to_blocked_nosts:
-      "monadic_rewrite False False
-       (\<lambda>s. st_tcb_at receive_blocked tcb (s :: det_ext state) \<and>
-       cur_thread s \<noteq> tcb)
-       (blocked_cancel_ipc_nosts tcb)
-       (cancel_ipc tcb >>= (\<lambda>_. set_thread_state tcb Running))"
+  "monadic_rewrite False False (\<lambda>s :: det_state. st_tcb_at receive_blocked tcb s \<and> cur_thread s \<noteq> tcb)
+     (blocked_cancel_ipc_nosts tcb)
+     (cancel_ipc tcb >>= (\<lambda>_. set_thread_state tcb Running))"
   apply (simp add: cancel_ipc_def bind_assoc blocked_cancel_ipc_nosts_def)
   apply (rule monadic_rewrite_bind_tail)
    apply (rule monadic_rewrite_transverse)
@@ -532,75 +437,68 @@ lemma cancel_ipc_to_blocked_nosts:
        apply (fastforce simp add: simpler_modify_def o_def get_tcb_def)
       apply (wp gts_wp)+
   apply (simp add: set_thread_state_def bind_assoc gets_the_def)
-  apply (clarsimp simp add: pred_tcb_at_def receive_blocked_def obj_at_def is_tcb_def split: thread_state.splits)
-  by (case_tac "tcb_state tcba";fastforce)
-
+  apply (clarsimp simp: pred_tcb_at_def receive_blocked_def obj_at_def is_tcb_def)
+  by (case_tac "tcb_state tcba"; fastforce)
 
 lemma gts_reads_respects:
-  "reads_respects aag l (K (aag_can_read aag thread \<or> aag_can_affect aag l thread)) (get_thread_state thread)"
+  "reads_respects aag l (K (aag_can_read aag t \<or> aag_can_affect aag l t)) (get_thread_state t)"
   unfolding get_thread_state_def
   by (wp thread_get_reads_respects)
 
-
 lemma ev2_invisible_simple:
   assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "labels_are_invisible aag l L \<Longrightarrow>
-       modifies_at_most aag L Q f \<Longrightarrow>
-       reads_respects aag l Q (f :: det_ext state \<Rightarrow> (unit \<times> det_ext state) set \<times> bool)"
+  shows "\<lbrakk> labels_are_invisible aag l L; modifies_at_most aag L Q f \<rbrakk>
+           \<Longrightarrow> reads_respects aag l Q (f :: (det_state, unit) nondet_monad)"
   apply (simp add: equiv_valid_def2)
   apply (rule equiv_valid_2_guard_imp)
     apply (rule ev2_invisible[OF domains_distinct])
-        by fastforce+
+  by fastforce+
+
+crunch silc_inv[wp]: blocked_cancel_ipc_nosts "silc_inv aag st"
+
+
+context Ipc_IF_1 begin
 
 lemma blocked_cancel_ipc_nosts_equiv_but_for_labels:
-  "\<lbrace>pas_refined aag and
-    st_tcb_at (\<lambda>st. st = BlockedOnReceive x pl) t and
-    bound_tcb_at ((=) (Some ntfnptr)) t and
-    equiv_but_for_labels aag L st and
-    K(pasObjectAbs aag x \<in> L) and
-    K(pasObjectAbs aag t \<in> L) \<rbrace>
+  "\<lbrace>pas_refined aag and st_tcb_at (\<lambda>st. st = BlockedOnReceive x pl) t
+                    and bound_tcb_at ((=) (Some ntfnptr)) t
+                    and equiv_but_for_labels aag L st
+                    and K (pasObjectAbs aag x \<in> L)
+                    and K (pasObjectAbs aag t \<in> L)\<rbrace>
    blocked_cancel_ipc_nosts t
    \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
   unfolding blocked_cancel_ipc_nosts_def get_blocking_object_def
   apply (wp set_endpoint_equiv_but_for_labels get_object_wp gts_wp
             set_thread_state_runnable_equiv_but_for_labels
-       | wpc
-       | simp)+
+         | wpc | simp)+
   by (clarsimp simp: pred_tcb_at_def obj_at_def)
 
 lemma blocked_cancel_ipc_nosts_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects aag l (pas_refined aag
-                          and st_tcb_at (\<lambda>st. \<exists>xa. st = (BlockedOnReceive x pl)) t
-
-                          and bound_tcb_at ((=) (Some ntfnptr)) t
-                          and (\<lambda>s. is_subject aag (cur_thread s))
-                          and K (
-                              (pasObjectAbs aag t, Receive, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag
-                            \<and> (pasSubject aag, Notify, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag
-                            \<and> (pasObjectAbs aag t, Receive, pasObjectAbs aag x) \<in> pasPolicy aag))
-           (blocked_cancel_ipc_nosts t)"
+  "reads_respects aag l
+     (pas_refined aag and st_tcb_at (\<lambda>st. \<exists>xa. st = (BlockedOnReceive x pl)) t
+                      and bound_tcb_at ((=) (Some ntfnptr)) t
+                      and (\<lambda>s. is_subject aag (cur_thread s))
+                      and K ((pasObjectAbs aag t, Receive, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag
+                           \<and> (pasSubject aag, Notify, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag
+                           \<and> (pasObjectAbs aag t, Receive, pasObjectAbs aag x) \<in> pasPolicy aag))
+     (blocked_cancel_ipc_nosts t)"
   unfolding blocked_cancel_ipc_nosts_def
   apply (simp only:bind_assoc[symmetric])
   apply (rule bind_ev[where P''=\<top>,simplified])
     apply (wp set_thread_state_runnable_reads_respects,simp)
-
-    subgoal
-    proof (cases "aag_can_read_label aag (pasObjectAbs aag x) \<or> aag_can_affect aag l x")
+    subgoal proof (cases "aag_can_read_label aag (pasObjectAbs aag x) \<or> aag_can_affect aag l x")
       case True thus ?thesis \<comment> \<open>boring case, can read or affect ep\<close>
       unfolding blocked_cancel_ipc_nosts_def get_blocking_object_def
       apply clarsimp
       apply (rule pre_ev)
-       apply ((wp set_thread_state_reads_respects get_ep_queue_reads_respects
-                  get_simple_ko_reads_respects get_blocking_object_reads_respects
-                  gts_reads_respects set_simple_ko_reads_respects
-                  gts_wp
-                  | wpc
-                  | simp add: get_blocking_object_def get_thread_state_rev)+)[2]
+       apply (wpsimp wp: set_thread_state_reads_respects get_ep_queue_reads_respects
+                         get_simple_ko_reads_respects get_blocking_object_reads_respects
+                         gts_reads_respects set_simple_ko_reads_respects gts_wp
+                   simp: get_blocking_object_def get_thread_state_rev)+
       apply (clarsimp simp: pred_tcb_at_def obj_at_def)
-      by (fastforce dest:read_sync_ep_read_receivers_strong )
+      by (fastforce dest:read_sync_ep_read_receivers )
 
     next
       case False thus ?thesis apply -  \<comment> \<open>can't read or affect ep\<close>
@@ -611,39 +509,35 @@ lemma blocked_cancel_ipc_nosts_reads_respects:
       apply (simp add: get_blocking_object_def)
       apply (rule modifies_at_mostI)
       apply (rule hoare_pre)
-       apply (wp set_thread_state_runnable_equiv_but_for_labels
-                 set_endpoint_equiv_but_for_labels get_object_wp gts_wp
-                 set_thread_state_runnable_equiv_but_for_labels
-            | wpc
-            | simp)+
+       apply (wpsimp wp: set_thread_state_runnable_equiv_but_for_labels
+                         set_endpoint_equiv_but_for_labels get_object_wp gts_wp
+                         set_thread_state_runnable_equiv_but_for_labels)+
       by (fastforce simp: pred_tcb_at_def obj_at_def)
     qed
   by wp
 
-crunch silc_inv[wp]: "blocked_cancel_ipc_nosts" "silc_inv aag st"
-
 lemmas blocked_cancel_ipc_nosts_reads_respects_f =
-  reads_respects_f[where Q=\<top>,simplified,
+  reads_respects_f[where Q=\<top>, simplified,
                    OF blocked_cancel_ipc_nosts_reads_respects
                       blocked_cancel_ipc_nosts_silc_inv,
                       simplified]
 
+end
+
+
 lemma monadic_rewrite_is_valid:
-  "monadic_rewrite False False P' f f' \<Longrightarrow>
-  \<lbrace>P\<rbrace> do x <- f; g x od \<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P and P'\<rbrace> do x <- f'; g x od  \<lbrace>Q\<rbrace>"
+  "\<lbrakk> monadic_rewrite False False P' f f'; \<lbrace>P\<rbrace> do x <- f; g x od \<lbrace>Q\<rbrace> \<rbrakk>
+     \<Longrightarrow> \<lbrace>P and P'\<rbrace> do x <- f'; g x od \<lbrace>Q\<rbrace>"
   by (fastforce simp: monadic_rewrite_def valid_def bind_def)
 
 lemma monadic_rewrite_reads_respects:
-  "monadic_rewrite False False P f f' \<Longrightarrow>
-   reads_respects l aag P' (do x <- f; g x od) \<Longrightarrow>
-   reads_respects l aag (P and P') (do x <- f'; g x od)"
-  apply (clarsimp simp: monadic_rewrite_def equiv_valid_def
-                        spec_equiv_valid_def equiv_valid_2_def
-                        bind_def)
+  "\<lbrakk> monadic_rewrite False False P f f'; reads_respects aag l P' (do x <- f; g x od) \<rbrakk>
+     \<Longrightarrow> reads_respects aag l (P and P') (do x <- f'; g x od)"
+  apply (clarsimp simp: monadic_rewrite_def spec_equiv_valid_def
+                        equiv_valid_def equiv_valid_2_def bind_def)
   apply (frule_tac x=st in spec)
   apply (drule_tac x=t in spec)
   by fastforce
-
 
 lemmas cancel_ipc_reads_respects_rewrite =
   monadic_rewrite_reads_respects[OF cancel_ipc_to_blocked_nosts, simplified bind_assoc]
@@ -670,43 +564,38 @@ crunches blocked_cancel_ipc_nosts
   and valid_vspace_objs[wp]: valid_vspace_objs
   and valid_arch_state[wp]: valid_arch_state
 
+
+context Ipc_IF_1 begin
+
 lemma send_signal_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   notes set_thread_state_owned_reads_respects[wp del]
         cancel_ipc_pas_refined[wp del]
   shows
-  "reads_respects aag l (pas_refined aag and pas_cur_domain aag and
-                         pspace_aligned and valid_vspace_objs and valid_arch_state and
-                         (\<lambda>s. is_subject aag (cur_thread s)) and valid_etcbs and ct_active and
-                         (\<lambda>s. sym_refs (state_refs_of s)) and valid_objs and
-                         K ((pasSubject aag, Notify, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag))
-                        (send_signal ntfnptr badge)"
+    "reads_respects aag l
+       (pas_refined aag and pas_cur_domain aag and pspace_aligned
+                        and valid_vspace_objs and valid_arch_state
+                        and (\<lambda>s. is_subject aag (cur_thread s))
+                        and valid_etcbs and ct_active
+                        and (\<lambda>s. sym_refs (state_refs_of s)) and valid_objs
+                        and K ((pasSubject aag, Notify, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag))
+       (send_signal ntfnptr badge)"
   unfolding send_signal_def fun_app_def
-  subgoal
-  proof (cases "aag_can_read aag ntfnptr \<or> aag_can_affect aag l ntfnptr")
+  subgoal proof (cases "aag_can_read aag ntfnptr \<or> aag_can_affect aag l ntfnptr")
     case True
     note visible = this
     show ?thesis
     apply (rule pre_ev)
      apply (simp split del: if_split
-          | rule_tac ntfnptr=ntfnptr in blocked_cancel_ipc_nosts_reads_respects
-          | rule cancel_ipc_reads_respects_rewrite
-          | wp (once)
-              set_simple_ko_reads_respects
-              possible_switch_to_reads_respects
-              as_user_set_register_reads_respects'
-              set_thread_state_pas_refined
-              set_thread_state_pas_refined
-              set_simple_ko_reads_respects
-              gts_reads_respects
-              cancel_ipc_receive_blocked_pas_refined
-              gts_wp
-              hoare_vcg_imp_lift
-              update_waiting_ntfn_reads_respects
-              get_simple_ko_wp
-              get_simple_ko_reads_respects
-          | wpc
-          | simp )+
+            | rule_tac ntfnptr=ntfnptr in blocked_cancel_ipc_nosts_reads_respects
+            | rule cancel_ipc_reads_respects_rewrite
+            | wp (once) set_simple_ko_reads_respects possible_switch_to_reads_respects
+                        as_user_set_register_reads_respects' set_thread_state_pas_refined
+                        set_simple_ko_reads_respects cancel_ipc_receive_blocked_pas_refined
+                        gts_reads_respects gts_wp hoare_vcg_imp_lift get_simple_ko_wp
+                        get_simple_ko_reads_respects update_waiting_ntfn_reads_respects
+            | wpc
+            | simp )+
     apply (insert visible)
     apply clarsimp
     apply (rule conjI[rotated])
@@ -719,9 +608,9 @@ lemma send_signal_reads_respects:
      apply (frule (1) bound_tcb_at_implies_receive)
      apply (elim disjE)
       apply (rule disjI1)
-      apply (fastforce dest:read_sync_ep_read_receivers_strong)
+      apply (fastforce dest:read_sync_ep_read_receivers)
      apply (rule disjI2)
-     apply (fastforce dest:read_sync_ep_read_receivers_strong)
+     apply (fastforce dest:read_sync_ep_read_receivers)
     apply (clarsimp)
     apply (frule (1) ntfn_bound_tcb_at[where P="(=) (Some ntfnptr)",OF _ _ _ _ refl])
       apply (fastforce simp: obj_at_def)
@@ -735,14 +624,11 @@ lemma send_signal_reads_respects:
      apply (rule context_conjI)
       apply (fastforce dest!: receive_blockedD intro: BlockedOnReceive_inj)
      apply (frule_tac t=x and tcb=tcb and ep = "case (tcb_state tcb) of BlockedOnReceive a pl \<Rightarrow> a"
-              in get_tcb_recv_blocked_implies_receive)
+                   in get_tcb_recv_blocked_implies_receive)
        apply (fastforce simp: pred_tcb_at_def get_tcb_def obj_at_def)
       apply (fastforce simp: receive_blocked_def split:thread_state.splits)
-     apply (fastforce simp: receive_blocked_def intro!: BlockedOnReceive_inj split:thread_state.splits)
-    by (fastforce simp: pred_tcb_at_def get_tcb_def obj_at_def receive_blocked_def
-                        ct_in_state_def
-                  split:thread_state.splits)
-
+     apply (fastforce simp: receive_blocked_def intro!: BlockedOnReceive_inj)
+    by (fastforce simp: pred_tcb_at_def get_tcb_def obj_at_def receive_blocked_def ct_in_state_def)
   next
     case False note invisible = this show ?thesis
     apply (insert label_is_invisible[THEN iffD2, OF invisible])
@@ -751,23 +637,15 @@ lemma send_signal_reads_respects:
      apply simp
      apply (rule ev2_invisible_simple[OF domains_distinct],assumption)
      apply (rule modifies_at_mostI)
-
-     apply ( simp split del: if_split
-           | rule cancel_ipc_valid_rewrite
-           | wp (once)
-               set_notification_equiv_but_for_labels
-               possible_switch_to_equiv_but_for_labels
-               as_user_equiv_but_for_labels
-               set_thread_state_runnable_equiv_but_for_labels
-               set_thread_state_pas_refined
-               blocked_cancel_ipc_nosts_equiv_but_for_labels
-               gts_wp
-               update_waiting_ntfn_equiv_but_for_labels
-               get_simple_ko_wp
-           | wpc
-           | wps
-           )+
-
+     apply (simp split del: if_split
+            | rule cancel_ipc_valid_rewrite
+            | wp (once) set_thread_state_pas_refined set_notification_equiv_but_for_labels
+                        possible_switch_to_equiv_but_for_labels as_user_equiv_but_for_labels
+                        set_thread_state_runnable_equiv_but_for_labels get_simple_ko_wp
+                        gts_wp update_waiting_ntfn_equiv_but_for_labels
+                        blocked_cancel_ipc_nosts_equiv_but_for_labels
+            | wpc
+            | wps)+
     apply (elim conjE)
     apply (match premises in "ntfn_bound_tcb _ = _" \<Rightarrow> \<open>fail\<close>
                                                \<bar> _ \<Rightarrow> \<open>rule allI impI conjI\<close>)+
@@ -778,16 +656,15 @@ lemma send_signal_reads_respects:
        apply (rule ccontr)
        apply (frule (3) not_etcb_at_not_cdom_can_read[OF domains_distinct, rotated 2])
         apply (rule tcb_at_ntfn_queue;assumption)
-       apply(frule (7) read_queued_thread_reads_ntfn)
+       apply (frule (7) read_queued_thread_reads_ntfn)
        using invisible
        by (fastforce simp add: all_with_auth_to_def all_to_which_has_auth_def)
-
-     apply (frule (1)
-       ntfn_bound_tcb_at[where P="(=) (Some ntfnptr)",OF _ _ _ _ refl])
+     apply (frule (1) ntfn_bound_tcb_at[where P="(=) (Some ntfnptr)", OF _ _ _ _ refl])
        apply (fastforce simp: obj_at_def)
       apply assumption
      apply (intro allI conjI impI)
-            apply (fastforce simp: pred_tcb_at_def receive_blocked_def obj_at_def split:thread_state.splits
+            apply (fastforce simp: pred_tcb_at_def receive_blocked_def obj_at_def
+                            split: thread_state.splits
                            intro!: BlockedOnReceive_inj)
            apply assumption
           apply distinct_subgoals
@@ -808,10 +685,10 @@ lemma send_signal_reads_respects:
             apply (rule bexI[OF _ bound_tcb_can_receive])
             apply (simp add: all_with_auth_to_def all_to_which_has_auth_def)
             using prems
-            apply (case_tac sta;(clarsimp simp: pred_tcb_at_def obj_at_def receive_blocked_def split:thread_state.splits))
+            apply (case_tac sta; (clarsimp simp: pred_tcb_at_def obj_at_def receive_blocked_def))
             apply (rule get_tcb_recv_blocked_implies_receive, assumption)
              apply (fastforce simp: get_tcb_def)
-            by (fastforce  split:thread_state.splits)
+            by (fastforce split: thread_state.splits)
          apply (rule ccontr)
          apply (insert prems)
          apply (frule (4) not_etcb_at_not_cdom_can_read[OF domains_distinct])
@@ -826,117 +703,63 @@ lemma send_signal_reads_respects:
   qed
   done
 
+end
+
+
 lemma receive_signal_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects aag l (valid_objs and pas_refined aag and
-        (\<lambda>s. is_subject aag (cur_thread s)) and
-        K ((\<forall>ntfnptr\<in>Access.obj_refs cap.
-            (pasSubject aag, Receive, pasObjectAbs aag ntfnptr)
-             \<in> pasPolicy aag \<and> is_subject aag thread)))
-         (receive_signal thread cap is_blocking)"
+  "reads_respects aag (l :: 'a subject_label)
+     (valid_objs and pas_refined aag and (\<lambda>s. is_subject aag (cur_thread s))
+                 and K ((\<forall>ntfnptr \<in> Access.obj_refs cap.
+                           (pasSubject aag, Receive, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag \<and>
+                           is_subject aag thread)))
+     (receive_signal thread cap is_blocking)"
   unfolding receive_signal_def fun_app_def do_nbrecv_failed_transfer_def
-  apply(wp set_simple_ko_reads_respects set_thread_state_reads_respects
-           as_user_set_register_reads_respects' get_simple_ko_reads_respects hoare_vcg_all_lift
-       | wpc
-       | wp (once) hoare_drop_imps)+
-  apply(force dest: reads_ep)
-  done
+  by (wp set_simple_ko_reads_respects set_thread_state_reads_respects
+         as_user_set_register_reads_respects' get_simple_ko_reads_respects hoare_vcg_all_lift
+      | wpc
+      | wp (once) hoare_drop_imps
+      | force dest: reads_ep)+
+
 
 subsection "Sync IPC"
 
-(* FIXME move *)
-lemma conj_imp:
-  "\<lbrakk>Q \<longrightarrow> R; P \<longrightarrow> Q; P' \<longrightarrow> Q\<rbrakk> \<Longrightarrow>
-    (P \<longrightarrow> R) \<and> (P' \<longrightarrow> R)"
-  by(fastforce)
+definition aag_can_read_or_affect_ipc_buffer :: "'a PAS \<Rightarrow> 'a \<Rightarrow> obj_ref option \<Rightarrow> bool" where
+  "aag_can_read_or_affect_ipc_buffer aag l \<equiv>
+     case_option True
+       (\<lambda>buf'. is_aligned buf' msg_align_bits \<and>
+               (\<forall>x \<in> ptr_range buf' msg_align_bits. aag_can_read aag x \<or> aag_can_affect aag l x))"
 
-(* basically clagged directly from lookup_ipc_buffer_has_auth *)
-lemma lookup_ipc_buffer_has_read_auth:
-  "\<lbrace>pas_refined aag and valid_objs\<rbrace>
-   lookup_ipc_buffer is_receiver thread
-   \<lbrace>\<lambda>rv s. ipc_buffer_has_read_auth aag (pasObjectAbs aag thread) rv\<rbrace>"
-  apply (rule hoare_pre)
-   apply (simp add: lookup_ipc_buffer_def)
-   apply (wp get_cap_wp thread_get_wp'
-        | wpc)+
-  apply (clarsimp simp: cte_wp_at_caps_of_state ipc_buffer_has_read_auth_def get_tcb_ko_at [symmetric])
-  apply (frule caps_of_state_tcb_cap_cases [where idx = "tcb_cnode_index 4"])
-   apply (simp add: dom_tcb_cap_cases)
-  apply (frule (1) caps_of_state_valid_cap)
-  apply (clarsimp simp: vm_read_only_def vm_read_write_def)
-  apply (rule_tac Q="AllowRead \<in> xc" in conj_imp)
-    apply (clarsimp simp: valid_cap_simps cap_aligned_def)
-    apply (rule conjI)
-     apply (erule aligned_add_aligned)
-      apply (rule is_aligned_andI1)
-      apply (drule (1) valid_tcb_objs)
-      apply (clarsimp simp: valid_obj_def valid_tcb_def valid_ipc_buffer_cap_def
-                     split: if_splits)
-     apply (rule order_trans [OF _ pbfs_atleast_pageBits])
-     apply (simp add: msg_align_bits pageBits_def)
-    apply (drule (1) cap_auth_caps_of_state)
-    apply (clarsimp simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def
-                          vspace_cap_rights_to_auth_def vm_read_only_def)
-    apply (drule bspec)
-     apply (erule (3) ipcframe_subset_page)
-    apply (clarsimp split: if_split_asm simp: vspace_cap_rights_to_auth_def is_page_cap_def)
-   apply(simp_all)
-  done
+lemma for_each_byte_of_word_def2:
+  "for_each_byte_of_word P ptr \<equiv> (\<forall>x\<in>ptr_range ptr word_size_bits. P x)"
+  by (simp add: for_each_byte_of_word_def ptr_range_def word_size_size_bits_word add_diff_eq)
 
 
-definition
-  aag_can_read_or_affect_ipc_buffer :: "'a PAS \<Rightarrow> 'a \<Rightarrow> word32 option \<Rightarrow> bool"
-where
-"aag_can_read_or_affect_ipc_buffer aag l \<equiv>
-    case_option True (\<lambda>buf'. is_aligned buf' msg_align_bits \<and> (\<forall>x \<in> ptr_range buf' msg_align_bits. aag_can_read aag x \<or> aag_can_affect aag l x))"
-
+context Ipc_IF_1 begin
 
 lemma lookup_ipc_buffer_aag_can_read_or_affect:
   "\<lbrace>pas_refined aag and valid_objs and K (aag_can_read aag thread \<or> aag_can_affect aag l thread)\<rbrace>
-    lookup_ipc_buffer is_receiver thread
+   lookup_ipc_buffer is_receiver thread
    \<lbrace>\<lambda>rv s. aag_can_read_or_affect_ipc_buffer aag l rv\<rbrace>"
-  apply(rule hoare_gen_asm)
-  apply(rule hoare_strengthen_post[OF lookup_ipc_buffer_has_read_auth])
-  apply(auto simp: ipc_buffer_has_read_auth_def aag_can_read_or_affect_ipc_buffer_def intro: reads_read_thread_read_pages simp: aag_can_affect_label_def split: option.splits)
-  done
-
-lemma cptrs_in_ipc_buffer:
-  "\<lbrakk>x \<in> set [buffer_cptr_index..<
-             buffer_cptr_index + unat (mi_extra_caps mi)];
-    is_aligned a msg_align_bits;
-    buffer_cptr_index + unat (mi_extra_caps mi) < 2 ^ (msg_align_bits - word_size_bits)\<rbrakk>
-   \<Longrightarrow>
-     ptr_range (a + of_nat x * of_nat word_size) 2 \<subseteq>
-     ptr_range (a :: word32) msg_align_bits"
-  apply(rule ptr_range_subset)
-     apply assumption
-    apply(simp add: msg_align_bits')
-   apply(simp add: msg_align_bits word_size_bits_def word_bits_def)
-  apply(simp add: word_size_def)
-  apply(subst upto_enum_step_shift_red[where us=2, simplified])
-     apply (simp add: msg_align_bits word_bits_def word_size_bits_def)+
-  done
-
-lemma for_each_byte_of_word_def2:
-  "for_each_byte_of_word P ptr \<equiv> (\<forall> x\<in>ptr_range ptr 2. P x)"
-  apply(simp add: for_each_byte_of_word_def ptr_range_def add.commute)
+  apply (rule hoare_gen_asm)
+  apply (rule hoare_strengthen_post[OF lookup_ipc_buffer_has_read_auth])
+  apply (auto simp: ipc_buffer_has_read_auth_def aag_can_read_or_affect_ipc_buffer_def
+             intro: reads_read_thread_read_pages
+              simp: aag_can_affect_label_def split: option.splits)
   done
 
 lemma aag_has_auth_to_read_cptrs:
-  "\<lbrakk>x \<in> set [buffer_cptr_index..<
-             buffer_cptr_index + unat (mi_extra_caps mi)];
-    ipc_buffer_has_read_auth aag (pasSubject aag) (Some a);
-    buffer_cptr_index + unat (mi_extra_caps mi) < 2 ^ (msg_align_bits - word_size_bits)\<rbrakk>
-   \<Longrightarrow>
-   for_each_byte_of_word (\<lambda> y. aag_can_read aag y)
-     (a + of_nat x * of_nat word_size)"
-  apply(simp add: for_each_byte_of_word_def2 ipc_buffer_has_read_auth_def)
-  apply(rule ballI)
-  apply(rule reads_read)
-  apply(clarify)
-  apply(erule bspec)
-  apply(rule subsetD[OF cptrs_in_ipc_buffer])
+  "\<lbrakk> x \<in> set [buffer_cptr_index ..< buffer_cptr_index + unat (mi_extra_caps mi)];
+     ipc_buffer_has_read_auth aag (pasSubject aag) (Some a);
+     buffer_cptr_index + unat (mi_extra_caps mi) < 2 ^ (msg_align_bits - word_size_bits) \<rbrakk>
+     \<Longrightarrow> for_each_byte_of_word (\<lambda> y. aag_can_read aag y) (a + of_nat x * of_nat word_size)"
+  apply (simp add: for_each_byte_of_word_def2 ipc_buffer_has_read_auth_def)
+  apply (rule ballI)
+  apply (rule reads_read)
+  apply (clarify)
+  apply (erule bspec)
+  apply (rule subsetD[OF cptrs_in_ipc_buffer])
      apply fastforce
     apply assumption
    apply assumption
@@ -944,62 +767,41 @@ lemma aag_has_auth_to_read_cptrs:
   done
 
 lemma get_extra_cptrs_rev:
-  "reads_equiv_valid_inv A aag (K (ipc_buffer_has_read_auth aag (pasSubject aag) buffer \<and> (buffer_cptr_index + unat (mi_extra_caps mi) < 2 ^ (msg_align_bits - word_size_bits))))
-      (get_extra_cptrs buffer mi)"
+  "reads_equiv_valid_inv A aag
+     (K (ipc_buffer_has_read_auth aag (pasSubject aag) buffer \<and>
+         (buffer_cptr_index + unat (mi_extra_caps mi) < 2 ^ (msg_align_bits - word_size_bits))))
+     (get_extra_cptrs buffer mi)"
   unfolding get_extra_cptrs_def
   apply (rule gen_asm_ev)
   apply clarsimp
-  apply(case_tac buffer, simp_all add: return_ev_pre)
+  apply (case_tac buffer, simp_all add: return_ev_pre)
   apply (wp mapM_ev equiv_valid_guard_imp[OF load_word_offs_rev]
-       | erule (2) aag_has_auth_to_read_cptrs)+
+         | erule (2) aag_has_auth_to_read_cptrs)+
   done
 
 lemma lookup_extra_caps_rev:
-  shows "reads_equiv_valid_inv A aag (pas_refined aag and (K (is_subject aag thread))  and (\<lambda> s. ipc_buffer_has_read_auth aag (pasSubject aag) buffer \<and> buffer_cptr_index + unat (mi_extra_caps mi) < 2 ^ (msg_align_bits - word_size_bits)))
+  "reads_equiv_valid_inv A aag
+     (pas_refined aag and (K (is_subject aag thread)) and
+      (\<lambda>s. ipc_buffer_has_read_auth aag (pasSubject aag) buffer \<and>
+           buffer_cptr_index + unat (mi_extra_caps mi) < 2 ^ (msg_align_bits - word_size_bits)))
      (lookup_extra_caps thread buffer mi)"
-  apply(rule gen_asm_ev)
   unfolding lookup_extra_caps_def fun_app_def
-  apply (wp mapME_ev cap_fault_on_failure_rev lookup_cap_and_slot_rev
-            get_extra_cptrs_rev)
-  apply simp
-  done
+  by (wpsimp wp: mapME_ev cap_fault_on_failure_rev lookup_cap_and_slot_rev get_extra_cptrs_rev)
 
-lemmas lookup_extra_caps_reads_respects_g =  reads_respects_g_from_inv[OF lookup_extra_caps_rev lookup_extra_caps_inv]
-
-lemma msg_in_ipc_buffer:
-  "\<lbrakk>x = msg_max_length \<or> x < msg_max_length;
-    unat (mi_length mi) < 2 ^ (msg_align_bits - word_size_bits);
-    is_aligned a msg_align_bits\<rbrakk>
-   \<Longrightarrow>
-     ptr_range (a + of_nat x * of_nat word_size) 2 \<subseteq>
-     ptr_range (a::word32) msg_align_bits"
-  apply(rule ptr_range_subset)
-     apply assumption
-    apply(simp add: msg_align_bits)
-   apply(simp add: msg_align_bits word_bits_def)
-  apply(simp add: word_size_def)
-  apply(subst upto_enum_step_shift_red[where us=2, simplified])
-     apply (simp add: msg_align_bits word_bits_def)+
-  apply(simp add: image_def)
-  apply(rule_tac x=x in bexI)
-   apply(rule refl)
-  apply(auto simp: msg_max_length_def)
-  done
-
+lemmas lookup_extra_caps_reads_respects_g =
+  reads_respects_g_from_inv[OF lookup_extra_caps_rev lookup_extra_caps_inv]
 
 lemma aag_has_auth_to_read_msg:
-  "\<lbrakk>x = msg_max_length \<or> x < msg_max_length;
-    ipc_buffer_has_read_auth aag (pasSubject aag) (Some a);
-    unat (mi_length mi) < 2 ^ (msg_align_bits - word_size_bits)\<rbrakk>
-   \<Longrightarrow>
-   for_each_byte_of_word (aag_can_read aag)
-     (a + of_nat x * of_nat word_size)"
-  apply(simp add: for_each_byte_of_word_def2 ipc_buffer_has_read_auth_def)
-  apply(rule ballI)
-  apply(rule reads_read)
-  apply(clarify)
-  apply(erule bspec)
-  apply(rule subsetD[OF msg_in_ipc_buffer[where x=x]])
+  "\<lbrakk> n = msg_max_length \<or> n < msg_max_length;
+     ipc_buffer_has_read_auth aag (pasSubject aag) (Some p);
+     unat (mi_length mi) < 2 ^ (msg_align_bits - word_size_bits) \<rbrakk>
+     \<Longrightarrow> for_each_byte_of_word (aag_can_read aag) (p + of_nat n * of_nat word_size)"
+  apply (simp add: for_each_byte_of_word_def2 ipc_buffer_has_read_auth_def)
+  apply (rule ballI)
+  apply (rule reads_read)
+  apply (clarify)
+  apply (erule bspec)
+  apply (rule subsetD[OF msg_in_ipc_buffer[where n=n]])
      apply assumption
     apply assumption
    apply assumption
@@ -1009,34 +811,34 @@ lemma aag_has_auth_to_read_msg:
 (* only called within do_reply_transfer for which access assumes sender
    and receiver in same domain *)
 lemma get_mrs_rev:
-  shows "reads_equiv_valid_inv A aag ((K (is_subject aag thread \<and> ipc_buffer_has_read_auth aag (pasSubject aag) buf \<and> unat (mi_length mi) < 2 ^ (msg_align_bits - word_size_bits)))) (get_mrs thread buf mi)"
-  apply (rule gen_asm_ev)
+  "reads_equiv_valid_inv A aag
+     (K (is_subject aag thread \<and> ipc_buffer_has_read_auth aag (pasSubject aag) buf
+                               \<and> unat (mi_length mi) < 2 ^ (msg_align_bits - word_size_bits)))
+     (get_mrs thread buf mi)"
   unfolding get_mrs_def
+  apply (rule gen_asm_ev)
   apply (wp mapM_ev'' load_word_offs_rev thread_get_rev
-       | wpc
-       | rule aag_has_auth_to_read_msg[where mi=mi]
-       | clarsimp split: if_split_asm)+
+         | wpc
+         | rule aag_has_auth_to_read_msg[where mi=mi]
+         | clarsimp split: if_split_asm)+
   done
 
 lemmas get_mrs_reads_respects_g = reads_respects_g_from_inv[OF get_mrs_rev get_mrs_inv]
 
+end
 
 
 lemma setup_caller_cap_reads_respects:
   "reads_respects aag l (K (aag_can_read aag sender \<and> aag_can_read aag receiver))
-    (setup_caller_cap sender receiver grant)"
+                  (setup_caller_cap sender receiver grant)"
   unfolding setup_caller_cap_def
-  apply(wp cap_insert_reads_respects set_thread_state_owned_reads_respects | simp)+
-  done
-
+  by (wp cap_insert_reads_respects set_thread_state_owned_reads_respects | simp)+
 
 lemma const_on_failure_ev:
-  "equiv_valid_inv I A P m \<Longrightarrow>
-   equiv_valid_inv I A P (const_on_failure c m)"
+  "equiv_valid_inv I A P m
+   \<Longrightarrow> equiv_valid_inv I A P (const_on_failure c m)"
   unfolding const_on_failure_def catch_def
-  apply(wp | wpc | simp)+
-  done
-
+  by (wp | wpc | simp)+
 
 lemma set_extra_badge_reads_respects:
   "reads_respects aag l \<top> (set_extra_badge buffer badge n)"
@@ -1044,102 +846,99 @@ lemma set_extra_badge_reads_respects:
   by (rule store_word_offs_reads_respects)
 
 lemma reads_equiv_cdt_has_children0:
-  "\<lbrakk>pas_refined aag s; pas_refined aag s'; aag_can_read aag (fst slot);
-    equiv_for (aag_can_read aag \<circ> fst) cdt s s'\<rbrakk> \<Longrightarrow>
-    (cdt s) c = Some slot \<longleftrightarrow> (cdt s') c = Some slot"
-  apply(rule iffI)
+  "\<lbrakk> pas_refined aag s; pas_refined aag s'; aag_can_read aag (fst slot);
+     equiv_for (aag_can_read aag \<circ> fst) cdt s s' \<rbrakk>
+     \<Longrightarrow> (cdt s) c = Some slot \<longleftrightarrow> (cdt s') c = Some slot"
+  apply (rule iffI)
    apply (drule equiv_forD)
-   apply (erule(1) all_children_subjectReads[THEN all_childrenD];fastforce)
+    apply (erule(1) all_children_subjectReads[THEN all_childrenD];fastforce)
    apply fastforce
   apply (drule equiv_forD)
    apply (erule(1) all_children_subjectReads[THEN all_childrenD];fastforce)
-   apply fastforce
+  apply fastforce
   done
 
 lemma reads_equiv_cdt_has_children:
-  "\<lbrakk>pas_refined aag s; pas_refined aag s'; is_subject aag (fst slot);
-    equiv_for (aag_can_read aag \<circ> fst) cdt s s'\<rbrakk> \<Longrightarrow>
-    (\<exists> c. (cdt s) c = Some slot) = (\<exists> c. (cdt s') c = Some slot)"
+  "\<lbrakk> pas_refined aag s; pas_refined aag s'; is_subject aag (fst slot);
+     equiv_for (aag_can_read aag \<circ> fst) cdt s s' \<rbrakk>
+     \<Longrightarrow> (\<exists>c. (cdt s) c = Some slot) = (\<exists>c. (cdt s') c = Some slot)"
   apply (rule iff_exI)
   by (erule reads_equiv_cdt_has_children0; force)
 
 
 lemma ensure_no_children_rev:
   "reads_equiv_valid_inv A aag (pas_refined aag and K (is_subject aag (fst slot)))
-  (ensure_no_children slot)"
+                        (ensure_no_children slot)"
   unfolding ensure_no_children_def fun_app_def equiv_valid_def2
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule_tac Q="\<lambda> rv s. pas_refined aag s \<and> is_subject aag (fst slot) \<and> rv = cdt s"
-                  in equiv_valid_rv_liftE_bindE[OF equiv_valid_rv_guard_imp[OF gets_cdt_revrv']])
-     apply(rule TrueI)
-    apply(clarsimp simp: equiv_valid_2_def)
-    apply(drule reads_equiv_cdt_has_children)
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule_tac Q="\<lambda> rv s. pas_refined aag s \<and> is_subject aag (fst slot) \<and> rv = cdt s"
+                in equiv_valid_rv_liftE_bindE[OF equiv_valid_rv_guard_imp[OF gets_cdt_revrv']])
+     apply (rule TrueI)
+    apply (clarsimp simp: equiv_valid_2_def)
+    apply (drule reads_equiv_cdt_has_children)
        apply assumption
       apply assumption
-     apply(fastforce elim: reads_equivE)
-    apply(fastforce simp: in_whenE in_throwError)
-   apply(wp, simp)
+     apply (fastforce elim: reads_equivE)
+    apply (fastforce simp: in_whenE in_throwError)
+   apply (wp, simp)
   done
-
-lemma arch_derive_cap_reads_respects:
-  "reads_respects aag l \<top> (arch_derive_cap cap)"
-  unfolding arch_derive_cap_def
-  apply(rule equiv_valid_guard_imp)
-   apply(wp | wpc)+
-  apply(simp)
-  done
-
-lemma derive_cap_rev':
-  "reads_equiv_valid_inv A aag (\<lambda> s. (\<exists>x xa xb d. cap = cap.UntypedCap d x xa xb) \<longrightarrow>
-         pas_refined aag s \<and> is_subject aag (fst slot)) (derive_cap slot cap)"
-  unfolding derive_cap_def arch_derive_cap_def
-  apply(rule equiv_valid_guard_imp)
-  apply(wp ensure_no_children_rev | wpc | simp)+
-  done
-
-lemma derive_cap_rev:
-  "reads_equiv_valid_inv A aag (\<lambda> s. pas_refined aag s \<and> is_subject aag (fst slot))
-       (derive_cap slot cap)"
-  by (blast intro: equiv_valid_guard_imp[OF derive_cap_rev'])
 
 (* FIXME MOVE *)
 lemma ball_subsetE:
-  "\<lbrakk> \<forall> x \<in> S. P x; S' \<subseteq> S; \<And> x. P x \<Longrightarrow> Q x\<rbrakk> \<Longrightarrow> \<forall> x \<in> S'. Q x" by blast
+  "\<lbrakk> \<forall>x \<in> S. P x; S' \<subseteq> S; \<And>x. P x \<Longrightarrow> Q x \<rbrakk>
+     \<Longrightarrow> \<forall>x \<in> S'. Q x"
+  by blast
+
+
+context Ipc_IF_1 begin
+
+lemma derive_cap_rev':
+  "reads_equiv_valid_inv A aag (\<lambda>s. (\<exists>x xa xb d. cap = cap.UntypedCap d x xa xb)
+                                    \<longrightarrow> pas_refined aag s \<and> is_subject aag (fst slot))
+                         (derive_cap slot cap)"
+  unfolding derive_cap_def
+  apply (rule equiv_valid_guard_imp)
+  apply (wp ensure_no_children_rev arch_derive_cap_rev | wpc | simp)+
+  done
+
+lemma derive_cap_rev:
+  "reads_equiv_valid_inv A aag (\<lambda>s. pas_refined aag s \<and> is_subject aag (fst slot))
+                         (derive_cap slot cap)"
+  by (blast intro: equiv_valid_guard_imp[OF derive_cap_rev'])
 
 lemma transfer_caps_loop_reads_respects':
   "reads_respects aag l
-       (pas_refined aag and pspace_aligned and valid_vspace_objs and
-        valid_arch_state and valid_mdb and valid_objs and
-        (\<lambda>s. (\<forall>cap\<in>set caps. valid_cap (fst cap) s
-                           \<and> is_subject aag (fst (snd cap))
-                           \<and> pas_cap_cur_auth aag (fst cap)
-                           \<and> cte_wp_at (\<lambda>cp. fst cap \<noteq> NullCap
-                                          \<longrightarrow> cp \<noteq> fst cap
-                                          \<longrightarrow> cp = masked_as_full (fst cap) (fst cap)) (snd cap) s)
-           \<and> (\<forall>slot\<in>set slots. is_subject aag (fst slot)
-                             \<and> cte_wp_at ((=) NullCap) slot s
-                             \<and> real_cte_at slot s)
-           \<and> distinct slots))
-    (transfer_caps_loop ep rcv_buffer n caps slots mi)"
-  apply(induct caps arbitrary: slots n mi)
+     (pas_refined aag and pspace_aligned and valid_vspace_objs and
+      valid_arch_state and valid_mdb and valid_objs and
+      (\<lambda>s. (\<forall>cap\<in>set caps. valid_cap (fst cap) s
+                         \<and> is_subject aag (fst (snd cap))
+                         \<and> pas_cap_cur_auth aag (fst cap)
+                         \<and> cte_wp_at (\<lambda>cp. fst cap \<noteq> NullCap
+                                           \<longrightarrow> cp \<noteq> fst cap
+                                           \<longrightarrow> cp = masked_as_full (fst cap) (fst cap)) (snd cap) s)
+         \<and> (\<forall>slot\<in>set slots. is_subject aag (fst slot)
+                           \<and> cte_wp_at ((=) NullCap) slot s
+                           \<and> real_cte_at slot s)
+         \<and> distinct slots))
+     (transfer_caps_loop ep rcv_buffer n caps slots mi)"
+  apply (induct caps arbitrary: slots n mi)
    apply simp
-   apply(rule return_ev_pre)
-  apply(case_tac a,rename_tac cap obj ind)
-  apply(simp split del: if_split)
-  apply(rule equiv_valid_guard_imp)
-  apply(wp const_on_failure_ev
-       | simp | intro conjI impI)+
-       apply fast
-      apply(wp set_extra_badge_reads_respects hoare_vcg_ball_lift | simp)+
-           apply fast
-          apply(wp cap_insert_reads_respects cap_insert_pas_refined whenE_throwError_wp
+   apply (rule return_ev_pre)
+  apply (case_tac a, rename_tac cap obj ind)
+  apply (simp split del: if_split)
+  apply (rule equiv_valid_guard_imp)
+   apply (wp const_on_failure_ev | simp | intro conjI impI)+
+      apply fast
+     apply (wp set_extra_badge_reads_respects hoare_vcg_ball_lift | simp)+
+          apply fast
+         apply (wp cap_insert_reads_respects cap_insert_pas_refined whenE_throwError_wp
                    derive_cap_rev derive_cap_cap_cur_auth derive_cap_is_derived
                    hoare_vcg_ball_lift cap_insert_cte_wp_at
-               | simp split del: if_split)+
-    apply (rule_tac Q' ="\<lambda>capd s. (capd\<noteq> cap.NullCap \<longrightarrow>
-          cte_wp_at (is_derived (cdt s) (obj,ind) capd) (obj, ind) s)
-          \<and> (capd\<noteq> cap.NullCap \<longrightarrow> QM s capd)" for QM
-          in hoare_post_imp_R)
+                | simp split del: if_split)+
+    apply (rule_tac Q'="\<lambda>capd s. (capd \<noteq> NullCap
+                                  \<longrightarrow> cte_wp_at (is_derived (cdt s) (obj,ind) capd) (obj, ind) s)
+                               \<and> (capd \<noteq> NullCap \<longrightarrow> QM s capd)" for QM
+                 in hoare_post_imp_R)
      prefer 2
      apply (clarsimp simp: cte_wp_at_caps_of_state split del: if_split)
      apply (strengthen is_derived_is_transferable[mk_strg I' O], assumption, solves\<open>simp\<close>)
@@ -1147,7 +946,7 @@ lemma transfer_caps_loop_reads_respects':
      apply (rule derive_cap_is_derived)
     apply (wp derive_cap_is_derived_foo')
    apply wp
-  apply(clarsimp simp: remove_rights_cur_auth cte_wp_at_caps_of_state split del: if_split)
+  apply (clarsimp simp: remove_rights_cur_auth cte_wp_at_caps_of_state split del: if_split)
   apply (rename_tac actual_cap)
   apply (strengthen real_cte_tcb_valid)
   apply (clarsimp)
@@ -1166,53 +965,53 @@ lemma transfer_caps_loop_reads_respects':
 
 lemma transfer_caps_loop_reads_respects:
   "reads_respects aag l
-       (pas_refined aag and pspace_aligned and valid_vspace_objs and
-        valid_arch_state and valid_mdb and valid_objs and
-        (\<lambda>s. (\<forall>cap\<in>set caps. valid_cap (fst cap) s
-                           \<and> is_subject aag (fst (snd cap))
-                           \<and> pas_cap_cur_auth aag (fst cap)
-                           \<and> cte_wp_at (\<lambda>cp. fst cap \<noteq> NullCap \<longrightarrow> cp = fst cap) (snd cap) s)
-           \<and> (\<forall>slot\<in>set slots. is_subject aag (fst slot)
-                             \<and> cte_wp_at ((=) NullCap) slot s
-                             \<and> real_cte_at slot s)
-           \<and> distinct slots))
-    (transfer_caps_loop ep rcv_buffer n caps slots mi)"
-  apply(rule equiv_valid_guard_imp, rule transfer_caps_loop_reads_respects')
-  by (fastforce elim:cte_wp_at_weakenE)
+     (pas_refined aag and pspace_aligned and valid_vspace_objs and
+      valid_arch_state and valid_mdb and valid_objs and
+      (\<lambda>s. (\<forall>cap\<in>set caps. valid_cap (fst cap) s
+                         \<and> is_subject aag (fst (snd cap))
+                         \<and> pas_cap_cur_auth aag (fst cap)
+                         \<and> cte_wp_at (\<lambda>cp. fst cap \<noteq> NullCap \<longrightarrow> cp = fst cap) (snd cap) s)
+         \<and> (\<forall>slot\<in>set slots. is_subject aag (fst slot)
+                           \<and> cte_wp_at ((=) NullCap) slot s
+                           \<and> real_cte_at slot s)
+         \<and> distinct slots))
+     (transfer_caps_loop ep rcv_buffer n caps slots mi)"
+  apply (rule equiv_valid_guard_imp, rule transfer_caps_loop_reads_respects')
+  by (fastforce elim: cte_wp_at_weakenE)
+
+end
 
 
 lemma empty_on_failure_ev:
   "equiv_valid_inv I A P m \<Longrightarrow>
   equiv_valid_inv I A P (empty_on_failure m)"
   unfolding empty_on_failure_def catch_def
-  apply(wp | wpc | simp)+
-  done
+  by (wp | wpc | simp)+
 
 lemma unify_failure_ev:
   "equiv_valid_inv I A P m \<Longrightarrow>
   equiv_valid_inv I A P (unify_failure m)"
   unfolding unify_failure_def handleE'_def
-  apply(wp | wpc | simp)+
-  done
+  by (wp | wpc | simp)+
 
 lemma lookup_slot_for_cnode_op_rev:
-  "reads_equiv_valid_inv A aag (\<lambda>s. ((depth \<noteq> 0 \<and> depth \<le> word_bits)
-                                \<longrightarrow> (pas_refined aag s
-                                    \<and> (is_cnode_cap croot \<longrightarrow> is_subject aag (obj_ref_of croot)))))
+  "reads_equiv_valid_inv A aag
+     (\<lambda>s. (depth \<noteq> 0 \<and> depth \<le> word_bits)
+          \<longrightarrow> (pas_refined aag s \<and> (is_cnode_cap croot \<longrightarrow> is_subject aag (obj_ref_of croot))))
      (lookup_slot_for_cnode_op is_source croot ptr depth)"
   unfolding lookup_slot_for_cnode_op_def
   apply (clarsimp split del: if_split)
   apply (wp resolve_address_bits_rev lookup_error_on_failure_rev
             whenE_throwError_wp
-       | wpc
-       | rule hoare_post_imp_R[OF hoare_True_E_R[where P="\<top>"]]
-       | simp add: split_def split del: if_split)+
+         | wpc
+         | rule hoare_post_imp_R[OF hoare_True_E_R[where P="\<top>"]]
+         | simp add: split_def split del: if_split)+
   done
 
 lemma lookup_slot_for_cnode_op_reads_respects:
   "reads_respects aag l (pas_refined aag and K (is_subject aag (obj_ref_of croot)))
      (lookup_slot_for_cnode_op is_source croot ptr depth)"
-  apply(rule equiv_valid_guard_imp[OF lookup_slot_for_cnode_op_rev])
+  apply (rule equiv_valid_guard_imp[OF lookup_slot_for_cnode_op_rev])
   by simp
 
 lemma lookup_cap_rev:
@@ -1224,170 +1023,115 @@ lemma lookup_cap_rev:
   apply simp
   done
 
-lemma captransfer_indices_in_range:
-  "x \<in> {0..2} \<Longrightarrow>
-  ((2::word32) + (of_nat msg_max_length + of_nat msg_max_extra_caps)) * word_size + (x * word_size) \<le> 2 ^ msg_align_bits - 1"
-  apply(rule order_trans)
-   prefer 2
-   apply(rule word_less_sub_1)
-   apply(rule_tac p=127 in mul_word_size_lt_msg_align_bits_ofnat)
-   apply(simp add: msg_align_bits')
-  apply(rule_tac y="0x7F * word_size" in order_trans)
-   apply(clarsimp simp: msg_max_length_def msg_max_extra_caps_def word_size_def)
-   apply(drule_tac k=4 in word_mult_le_mono1)
-     apply simp
-    apply simp
-   apply(drule_tac x="0x1F4" in word_plus_mono_right)
-    apply simp
-   apply simp
-  apply (simp add: word_size_def)
-  done
-
-
 lemma word_plus_power_2_offset_le:
-  "\<lbrakk>is_aligned (p :: 'a :: len word) n; is_aligned q m; p < q; n \<le> m; n < len_of TYPE('a)\<rbrakk> \<Longrightarrow> p + (2^n) \<le> q"
-  apply(drule is_aligned_weaken, assumption)
-  apply(clarsimp simp: is_aligned_def)
-  apply(elim dvdE)
-  apply(rename_tac k ka)
-  apply(rule_tac ua=0 and n="int k" and n'="int ka" in udvd_incr')
+  "\<lbrakk> is_aligned (p :: 'l :: len word) n; is_aligned q m; p < q; n \<le> m; n < len_of TYPE('l) \<rbrakk>
+     \<Longrightarrow> p + 2^n \<le> q"
+  apply (drule is_aligned_weaken, assumption)
+  apply (clarsimp simp: is_aligned_def)
+  apply (elim dvdE)
+  apply (rename_tac k ka)
+  apply (rule_tac ua=0 and n="int k" and n'="int ka" in udvd_incr')
     apply assumption
-  apply(clarsimp simp: uint_nat)+
+   apply (clarsimp simp: uint_nat)+
   done
 
 
-lemma is_aligned_mult_word_size:
-  "is_aligned (p * word_size) 2"
-  apply(rule_tac k=p in is_alignedI)
-  apply(fastforce simp: word_size_def)
-  done
-
-
-lemma captransfer_in_ipc_buffer:
-  "\<lbrakk>is_aligned (buffer :: word32) msg_align_bits;
-    x \<in> {0..2}\<rbrakk> \<Longrightarrow>
-  ptr_range (buffer + (2 + (of_nat msg_max_length + of_nat msg_max_extra_caps)) *
-          word_size + x * word_size) 2 \<subseteq> ptr_range buffer msg_align_bits"
-  apply(rule ptr_range_subset)
-     apply assumption
-    apply(simp add: msg_align_bits)
-   apply(simp add: msg_align_bits word_bits_def)
-  apply(simp add: word_size_def)
-  apply(subst upto_enum_step_shift_red[where us=2, simplified])
-     apply (simp add: msg_align_bits word_bits_def)+
-  apply(simp add: image_def msg_max_length_def msg_max_extra_caps_def)
-  apply(rule_tac x="(125::nat) + unat x"  in bexI)
-   apply simp+
-  apply(fastforce intro: unat_less_helper word_leq_minus_one_le)
-  done
+context Ipc_IF_1 begin
 
 lemma aag_has_auth_to_read_captransfer:
-  "\<lbrakk>ipc_buffer_has_read_auth aag (pasSubject aag) (Some buffer);
-    x \<in> {0..2}\<rbrakk> \<Longrightarrow>
-  for_each_byte_of_word (aag_can_read aag) (buffer + (2 + (of_nat msg_max_length + of_nat msg_max_extra_caps)) *
-          word_size + x * word_size)"
-  apply(simp add: for_each_byte_of_word_def2 ipc_buffer_has_read_auth_def)
-  apply(rule ballI)
-  apply(rule reads_read)
-  apply(clarify)
-  apply(erule bspec)
-  apply(rule subsetD[OF captransfer_in_ipc_buffer])
-     apply fastforce+
+  "\<lbrakk> ipc_buffer_has_read_auth aag (pasSubject aag) (Some buffer); x \<in> {0..2} \<rbrakk>
+     \<Longrightarrow> for_each_byte_of_word (aag_can_read aag)
+           (buffer + (2 + (of_nat msg_max_length + of_nat msg_max_extra_caps)) * word_size
+                                                                               + x * word_size)"
+  apply (simp add: for_each_byte_of_word_def2 ipc_buffer_has_read_auth_def)
+  apply (rule ballI)
+  apply (rule reads_read)
+  apply (clarify)
+  apply (erule bspec)
+  apply (rule subsetD[OF captransfer_in_ipc_buffer])
+    apply fastforce+
   done
 
 lemma load_cap_transfer_rev:
   "reads_equiv_valid_inv A aag (K (ipc_buffer_has_read_auth aag (pasSubject aag) (Some buffer)))
-    (load_cap_transfer buffer)"
+     (load_cap_transfer buffer)"
   unfolding load_cap_transfer_def fun_app_def captransfer_from_words_def
-  apply(wp dmo_loadWord_rev | simp)+
+  apply (wp dmo_loadWord_rev | simp)+
   apply safe
-      apply(erule aag_has_auth_to_read_captransfer[where x=0, simplified])
-    apply(erule aag_has_auth_to_read_captransfer[where x=1, simplified])
-  apply(erule aag_has_auth_to_read_captransfer[where x=2, simplified])
+    apply (erule aag_has_auth_to_read_captransfer[where x=0, simplified])
+   apply (erule aag_has_auth_to_read_captransfer[where x=1, simplified])
+  apply (erule aag_has_auth_to_read_captransfer[where x=2, simplified])
   done
+
+end
 
 
 lemma get_endpoint_rev:
   "reads_equiv_valid_inv A aag (K (is_subject aag ptr)) (get_endpoint ptr)"
   unfolding get_simple_ko_def
-  apply(wp get_object_rev | wpc | simp)+
-  done
+  by (wp get_object_rev | wpc | simp)+
 
 lemma send_endpoint_threads_blocked:
-"\<lbrakk>valid_objs s; (sym_refs \<circ> state_refs_of) s;
-  ko_at (Endpoint (SendEP list)) ep s; x\<in>set list\<rbrakk> \<Longrightarrow>
-  st_tcb_at (send_blocked_on ep) x s"
+  "\<lbrakk> valid_objs s; (sym_refs \<circ> state_refs_of) s; ko_at (Endpoint (SendEP list)) ep s; x \<in> set list \<rbrakk>
+     \<Longrightarrow> st_tcb_at (send_blocked_on ep) x s"
   apply (rule ep_queued_st_tcb_at'')
   apply simp+
   done
 
 lemma send_blocked_threads_have_SyncSend_auth:
-  "\<lbrakk>pas_refined aag s; valid_objs s; sym_refs (state_refs_of s);
-    st_tcb_at (send_blocked_on ep) x s\<rbrakk> \<Longrightarrow>
-  (pasObjectAbs aag x,SyncSend,pasObjectAbs aag ep) \<in> pasPolicy aag"
-  apply(drule_tac auth="SyncSend" and x=x in pas_refined_mem[rotated])
-   apply(rule sta_ts)
-   apply(clarsimp simp: thread_st_auth_def split: option.split simp: tcb_states_of_state_def st_tcb_def2)
-   apply(case_tac "tcb_state tcb", simp_all)
+  "\<lbrakk> pas_refined aag s; valid_objs s; sym_refs (state_refs_of s); st_tcb_at (send_blocked_on ep) x s \<rbrakk>
+     \<Longrightarrow> (pasObjectAbs aag x, SyncSend, pasObjectAbs aag ep) \<in> pasPolicy aag"
+  apply (drule_tac auth="SyncSend" and x=x in pas_refined_mem[rotated])
+   apply (rule sta_ts)
+   apply (clarsimp simp: thread_st_auth_def split: option.split simp: tcb_states_of_state_def st_tcb_def2)
+   apply (case_tac "tcb_state tcb", simp_all)
   done
-
-
-(*MOVE*)
-lemma ev_invisible:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "\<lbrakk>labels_are_invisible aag l L; modifies_at_most aag L Q f; \<forall>s t. P s \<and> P t \<longrightarrow> (\<forall>(rva, s') \<in> fst (f s). \<forall>(rvb, t') \<in> fst(f t). W rva rvb)\<rbrakk> \<Longrightarrow>
-  equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l) W (P and Q) (P and Q) f f"
-  apply (rule ev2_invisible[OF domains_distinct])
-  apply simp+
-  done
-
 
 lemma get_thread_state_reads_respects:
-  "reads_respects aag l (\<lambda> s. aag_can_read aag thread \<or> aag_can_affect aag l thread) (get_thread_state thread)"
+  "reads_respects aag l (\<lambda>s. aag_can_read aag t \<or> aag_can_affect aag l t) (get_thread_state t)"
   unfolding get_thread_state_def
-  apply(rule equiv_valid_guard_imp)
-   apply(wp thread_get_reads_respects | simp)+
+  apply (rule equiv_valid_guard_imp)
+   apply (wp thread_get_reads_respects | simp)+
   done
 
 lemma send_endpoint_reads_affects_queued:
-  "\<lbrakk>(pasSubject aag, auth, pasObjectAbs aag epptr) \<in> pasPolicy aag;
-    auth \<in> {Receive,Reset};
-    aag_can_read aag epptr \<or>
-    aag_can_affect aag l epptr;
-    pas_refined aag s; valid_objs s; sym_refs (state_refs_of s);
-    ko_at (Endpoint (SendEP list)) epptr s; ep = SendEP list;
-    x \<in> set list\<rbrakk>
-   \<Longrightarrow> aag_can_read aag x \<or> aag_can_affect aag l x"
-  apply(frule send_endpoint_threads_blocked, (simp | assumption)+)
-  apply(drule send_blocked_threads_have_SyncSend_auth, (simp | assumption)+)
-  apply(auto dest: read_sync_ep_read_senders)
+  "\<lbrakk> (pasSubject aag, auth, pasObjectAbs aag epptr) \<in> pasPolicy aag;
+     auth \<in> {Receive,Reset};
+     aag_can_read aag epptr \<or> aag_can_affect aag l epptr;
+     pas_refined aag s; valid_objs s; sym_refs (state_refs_of s);
+     ko_at (Endpoint (SendEP list)) epptr s; ep = SendEP list; x \<in> set list \<rbrakk>
+     \<Longrightarrow> aag_can_read aag x \<or> aag_can_affect aag l x"
+  apply (frule send_endpoint_threads_blocked, (simp | assumption)+)
+  apply (drule send_blocked_threads_have_SyncSend_auth, (simp | assumption)+)
+  apply (auto dest: read_sync_ep_read_senders)
   done
 
 lemma mapM_ev''':
-  assumes reads_res: "\<And> x. x \<in> set lst \<Longrightarrow> equiv_valid_inv D A (Q and P x) (m x)"
-  assumes inv: "\<And> x. x \<in> set lst \<Longrightarrow> invariant (m x) (\<lambda> s. Q s \<and> (\<forall>x\<in>set lst. P x s))"
-  shows "equiv_valid_inv D A (\<lambda> s. Q s \<and> (\<forall>x\<in>set lst. P x s)) (mapM m lst)"
-  apply(rule mapM_ev)
-  apply(rule equiv_valid_guard_imp[OF reads_res], simp+)
-  apply(wpsimp wp: inv)
+  assumes reads_res: "\<And>x. x \<in> set lst \<Longrightarrow> equiv_valid_inv D A (Q and P x) (m x)"
+  assumes inv: "\<And>x. x \<in> set lst \<Longrightarrow> m x \<lbrace>\<lambda>s. Q s \<and> (\<forall>x \<in> set lst. P x s)\<rbrace>"
+  shows "equiv_valid_inv D A (\<lambda>s. Q s \<and> (\<forall>x \<in> set lst. P x s)) (mapM m lst)"
+  apply (rule mapM_ev)
+   apply (rule equiv_valid_guard_imp[OF reads_res], simp+)
+  apply (wpsimp wp: inv)
   done
 
 lemma cancel_badged_sends_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   notes gts_st_tcb_at[wp del]
   shows
-  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs and
-                         valid_arch_state and valid_objs and (sym_refs \<circ> state_refs_of) and
-                         (\<lambda>s. is_subject aag (cur_thread s)) and K (is_subject aag epptr))
-      (cancel_badged_sends epptr badge)"
+    "reads_respects aag (l :: 'a subject_label)
+       (pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
+                        and valid_objs and (sym_refs \<circ> state_refs_of)
+                        and (\<lambda>s. is_subject aag (cur_thread s)) and K (is_subject aag epptr))
+       (cancel_badged_sends epptr badge)"
   apply (rule gen_asm_ev)+
-  apply(simp add: cancel_badged_sends_def)
+  apply (simp add: cancel_badged_sends_def)
   apply wp
-     apply ((wp mapM_ev'' mapM_wp get_thread_state_reads_respects set_thread_state_runnable_reads_respects
+     apply ((wp mapM_ev''  get_thread_state_reads_respects set_thread_state_runnable_reads_respects
                 set_simple_ko_reads_respects get_simple_ko_reads_respects hoare_vcg_ball_lift
-                tcb_sched_action_reads_respects set_thread_state_pas_refined
-            | wpc | simp add: filterM_mapM tcb_at_st_tcb_at[symmetric] | wp (once) hoare_drop_imps | rule subset_refl | force)+)[1]
+                tcb_sched_action_reads_respects set_thread_state_pas_refined mapM_wp
+             | wpc | simp add: filterM_mapM tcb_at_st_tcb_at[symmetric]
+             | wp (once) hoare_drop_imps | rule subset_refl | force)+)[1]
     apply (wp get_simple_ko_reads_respects)
    apply (wp get_simple_ko_wp)
   apply simp
@@ -1395,115 +1139,78 @@ lemma cancel_badged_sends_reads_respects:
   by (rule send_endpoint_reads_affects_queued[where epptr = epptr];
       (assumption | force simp: pas_refined_def policy_wellformed_def))
 
-
 lemma get_cap_ret_is_subject':
-  "\<lbrace>pas_refined aag and K (is_subject aag (fst ptr))\<rbrace> get_cap ptr
-       \<lbrace>\<lambda>rv s. is_cnode_cap rv \<longrightarrow> (\<forall>x\<in>Access.obj_refs rv. is_subject aag x)\<rbrace>"
-  apply(rule hoare_strengthen_post[OF get_cap_ret_is_subject])
-  apply(clarsimp simp: is_cap_simps)
+  "\<lbrace>pas_refined aag and K (is_subject aag (fst ptr))\<rbrace>
+   get_cap ptr
+   \<lbrace>\<lambda>rv s. is_cnode_cap rv \<longrightarrow> (\<forall>x\<in>Access.obj_refs rv. is_subject aag x)\<rbrace>"
+  apply (rule hoare_strengthen_post[OF get_cap_ret_is_subject])
+  apply (clarsimp simp: is_cap_simps)
   done
 
 
+context Ipc_IF_1 begin
+
 lemma get_receive_slots_rev:
-  "reads_equiv_valid_inv A aag (pas_refined aag and (K (is_subject aag thread \<and>
-         ipc_buffer_has_read_auth aag (pasSubject aag) buf)))
-   (get_receive_slots thread buf)"
-  apply(case_tac buf)
-   apply(fastforce intro: return_ev_pre)
-  apply(simp add: lookup_cap_def split_def
-       | wp empty_on_failure_ev unify_failure_ev lookup_slot_for_cnode_op_rev get_cap_rev
-            lookup_slot_for_thread_rev lookup_slot_for_thread_authorised
-            get_cap_ret_is_subject get_cap_ret_is_subject' load_cap_transfer_rev
-       | wp (once) hoare_drop_imps
-       | strengthen aag_can_read_self)+
+  "reads_equiv_valid_inv A aag
+     (pas_refined aag and (K (is_subject aag thread \<and>
+                              ipc_buffer_has_read_auth aag (pasSubject aag) buf)))
+     (get_receive_slots thread buf)"
+  apply (case_tac buf)
+   apply (fastforce intro: return_ev_pre)
+  apply (simp add: lookup_cap_def split_def
+         | wp empty_on_failure_ev unify_failure_ev lookup_slot_for_cnode_op_rev get_cap_rev
+              lookup_slot_for_thread_rev lookup_slot_for_thread_authorised
+              get_cap_ret_is_subject get_cap_ret_is_subject' load_cap_transfer_rev
+         | wp (once) hoare_drop_imps
+         | strengthen aag_can_read_self)+
   done
 
 lemma transfer_caps_reads_respects:
-  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs and
-                         valid_arch_state and valid_mdb and valid_objs and
-                         (\<lambda>s. (\<forall>cap\<in>set caps. s \<turnstile> fst cap
-                                            \<and> is_subject aag (fst (snd cap))
-                                            \<and> pas_cap_cur_auth aag (fst cap)
-                                            \<and> cte_wp_at (\<lambda>cp. fst cap \<noteq> NullCap \<longrightarrow> cp = fst cap)
-                                                        (snd cap) s)) and
-                         K (is_subject aag receiver \<and>
-                            ipc_buffer_has_read_auth aag (pasSubject aag) receive_buffer))
+  "reads_respects aag l
+     (pas_refined aag and pspace_aligned and valid_vspace_objs
+                      and valid_arch_state and valid_mdb and valid_objs
+                      and (\<lambda>s. (\<forall>cap\<in>set caps. s \<turnstile> fst cap
+                                             \<and> is_subject aag (fst (snd cap))
+                                             \<and> pas_cap_cur_auth aag (fst cap)
+                                             \<and> cte_wp_at (\<lambda>cp. fst cap \<noteq> NullCap \<longrightarrow> cp = fst cap)
+                                                         (snd cap) s))
+                      and K (is_subject aag receiver \<and>
+                             ipc_buffer_has_read_auth aag (pasSubject aag) receive_buffer))
      (transfer_caps mi caps endpoint receiver receive_buffer)"
   unfolding transfer_caps_def fun_app_def
-  apply (wp transfer_caps_loop_reads_respects get_receive_slots_rev get_receive_slots_authorised
-           hoare_vcg_all_lift static_imp_wp
-        | wpc | simp add: ball_conj_distrib)+
-  done
-
-lemma mrs_in_ipc_buffer:
-  "\<lbrakk>is_aligned (buf :: word32) msg_align_bits;
-    x \<in> set [length msg_registers + 1..<Suc n];
-    n < 2 ^ (msg_align_bits - word_size_bits)\<rbrakk>
-       \<Longrightarrow> ptr_range
-           (buf + of_nat x * of_nat word_size) 2 \<subseteq> ptr_range buf msg_align_bits"
-  apply(rule ptr_range_subset)
-     apply assumption
-    apply(simp add: msg_align_bits)
-   apply(simp add: msg_align_bits word_bits_def)
-  apply(simp add: word_size_def)
-  apply(subst upto_enum_step_shift_red[where us=2, simplified])
-     apply (simp add: msg_align_bits word_bits_def word_size_bits_def)+
-  apply(simp add: image_def)
-  apply(rule_tac x=x in bexI)
-   apply(rule refl)
-  apply (fastforce split: if_split_asm)
-  done
+  by (wp transfer_caps_loop_reads_respects get_receive_slots_rev
+         get_receive_slots_authorised hoare_vcg_all_lift static_imp_wp
+      | wpc | simp add: ball_conj_distrib)+
 
 lemma aag_has_auth_to_read_mrs:
-  "\<lbrakk>aag_can_read_or_affect_ipc_buffer aag l (Some buf);
-    x \<in> set [length msg_registers + 1..<Suc n];
-    n < 2 ^ (msg_align_bits - word_size_bits)\<rbrakk>
-       \<Longrightarrow> for_each_byte_of_word (\<lambda>x. aag_can_read_label aag (pasObjectAbs aag x) \<or> aag_can_affect aag l x)
-           (buf + of_nat x * of_nat word_size)"
-  apply(simp add: for_each_byte_of_word_def2 aag_can_read_or_affect_ipc_buffer_def)
-  apply(rule ballI)
-  apply(erule conjE)
-  apply(erule bspec)
-  apply(rule subsetD[OF mrs_in_ipc_buffer[where x=x and n=n]])
-     apply assumption
-    apply (clarsimp split: if_splits)
+  "\<lbrakk> aag_can_read_or_affect_ipc_buffer aag l (Some buf);
+     n \<in> set [length msg_registers + 1..<Suc n'];
+     n' < 2 ^ (msg_align_bits - word_size_bits) \<rbrakk>
+     \<Longrightarrow> for_each_byte_of_word
+           (\<lambda>x. aag_can_read_label aag (pasObjectAbs aag x) \<or> aag_can_affect aag l x)
+           (buf + of_nat n * of_nat word_size)"
+  apply (simp add: for_each_byte_of_word_def2 aag_can_read_or_affect_ipc_buffer_def)
+  apply (rule ballI)
+  apply (erule conjE)
+  apply (erule bspec)
+  apply (rule subsetD[OF mrs_in_ipc_buffer[where n=n and n'=n']])
+     apply (clarsimp split: if_splits)
+    apply assumption
    apply assumption
   apply assumption
   done
 
-
-abbreviation aag_can_read_or_affect where
-  "aag_can_read_or_affect aag l x \<equiv>
-    aag_can_read aag x \<or> aag_can_affect aag l x"
-
-lemma dmo_loadWord_reads_respects:
-  "reads_respects aag l (K (for_each_byte_of_word (\<lambda> x. aag_can_read_or_affect aag l x) p))
-     (do_machine_op (loadWord p))"
-  apply(rule gen_asm_ev)
-  apply(rule use_spec_ev)
-  apply(rule spec_equiv_valid_hoist_guard)
-
-  apply(rule do_machine_op_spec_reads_respects)
-  apply(simp add: loadWord_def equiv_valid_def2 spec_equiv_valid_def)
-  apply(rule_tac R'="\<lambda> rv rv'. for_each_byte_of_word (\<lambda> y. rv y = rv' y) p" and Q="\<top>\<top>" and Q'="\<top>\<top>" and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
-       apply(rule_tac R'="(=)" and Q="\<lambda> r s. p && mask 2 = 0" and Q'="\<lambda> r s. p && mask 2 = 0" and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
-            apply(rule return_ev2)
-            apply(rule_tac f="word_rcat" in arg_cong)
-            apply(fastforce intro: is_aligned_no_wrap' word_plus_mono_right simp: is_aligned_mask for_each_byte_of_word_def) (* slow *)
-           apply(rule assert_ev2[OF refl])
-          apply(rule assert_wp)+
-        apply simp+
-       apply(clarsimp simp: equiv_valid_2_def in_monad for_each_byte_of_word_def)
-       apply(fastforce elim: equiv_forD orthD1 simp: ptr_range_def add.commute)
-      apply (wp wp_post_taut loadWord_inv | simp)+
-  done
-
 lemma load_word_offs_reads_respects:
-  "reads_respects aag l (\<lambda> s. for_each_byte_of_word (\<lambda> x. aag_can_read_or_affect aag l x) (a + of_nat x * of_nat word_size)) (load_word_offs a x)"
+  "reads_respects aag l (\<lambda>s. for_each_byte_of_word (\<lambda>x. aag_can_read_or_affect aag l x)
+                                                   (a + of_nat x * of_nat word_size))
+                  (load_word_offs a x)"
   unfolding load_word_offs_def fun_app_def
-  apply(rule equiv_valid_guard_imp[OF dmo_loadWord_reads_respects])
-  apply(clarsimp)
+  apply (rule equiv_valid_guard_imp[OF dmo_loadWord_reads_respects])
+  apply (clarsimp)
   done
+
+end
+
 
 lemma as_user_reads_respects:
   "reads_respects aag l (K (det f \<and> aag_can_read_or_affect aag l thread)) (as_user thread f)"
@@ -1513,204 +1220,63 @@ lemma as_user_reads_respects:
   apply (auto intro: reads_affects_equiv_get_tcb_eq[where aag=aag])
   done
 
-lemma copy_mrs_reads_respects:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (K (aag_can_read_or_affect aag l sender \<and> aag_can_read_or_affect_ipc_buffer aag l sbuf \<and> unat n < 2 ^ (msg_align_bits - word_size_bits))) (copy_mrs sender sbuf receiver rbuf n)"
-  unfolding copy_mrs_def fun_app_def
-  apply(rule gen_asm_ev)
-  apply(wp mapM_ev'' store_word_offs_reads_respects
-           load_word_offs_reads_respects as_user_set_register_reads_respects'
-           as_user_reads_respects
-       | wpc
-       | simp add: det_setRegister det_getRegister split del: if_split)+
-  apply clarsimp
-  apply(rename_tac n')
-  apply(subgoal_tac " ptr_range (x + of_nat n' * of_nat word_size) 2
-          \<subseteq> ptr_range x msg_align_bits")
-   apply(simp add: for_each_byte_of_word_def2)
-   apply(simp add: aag_can_read_or_affect_ipc_buffer_def)
-   apply(erule conjE)
-   apply(rule ballI)
-   apply(erule bspec)
-   apply(erule (1) subsetD[rotated])
-  apply(rule ptr_range_subset)
-     apply(simp add: aag_can_read_or_affect_ipc_buffer_def)
-    apply(simp add: msg_align_bits)
-    apply(simp add: msg_align_bits word_bits_def)
-   apply(simp add: word_size_def word_size_bits_def)
-  apply(subst upto_enum_step_shift_red[where us=2, simplified])
-     apply (simp add: msg_align_bits word_bits_def aag_can_read_or_affect_ipc_buffer_def )+
-  apply(fastforce simp: image_def)
-  done
-
 lemma get_mi_length':
-   "\<lbrace>\<top>\<rbrace> get_message_info sender
-    \<lbrace>\<lambda>rv s. buffer_cptr_index + unat (mi_extra_caps rv)
-            < 2 ^ (msg_align_bits - word_size_bits)\<rbrace>"
-  apply(rule hoare_post_imp[OF _ get_mi_valid'])
-  apply(clarsimp simp: valid_message_info_def msg_align_bits' msg_max_length_def word_le_nat_alt
+   "\<lbrace>\<top>\<rbrace> get_message_info sender \<lbrace>\<lambda>rv s. buffer_cptr_index + unat (mi_extra_caps rv)
+                                         < 2 ^ (msg_align_bits - word_size_bits)\<rbrace>"
+  apply (rule hoare_post_imp[OF _ get_mi_valid'])
+  apply (clarsimp simp: valid_message_info_def msg_align_bits' msg_max_length_def word_le_nat_alt
                        buffer_cptr_index_def msg_max_extra_caps_def)
   done
 
 lemma validE_E_wp_post_taut:
-   "\<lbrace> P \<rbrace> f -, \<lbrace>\<lambda> r s. True \<rbrace>"
-  by(auto simp: validE_E_def validE_def valid_def)
+   "\<lbrace>P\<rbrace> f -, \<lbrace>\<top>\<top>\<rbrace>"
+  by (auto simp: validE_E_def validE_def valid_def)
 
 lemma aag_has_read_auth_can_read_or_affect_ipc_buffer:
-  "ipc_buffer_has_read_auth aag (pasSubject aag) buf \<Longrightarrow>
-   aag_can_read_or_affect_ipc_buffer aag l buf"
-  apply(clarsimp simp: ipc_buffer_has_read_auth_def
-                       aag_can_read_or_affect_ipc_buffer_def
+  "ipc_buffer_has_read_auth aag (pasSubject aag) buf
+   \<Longrightarrow> aag_can_read_or_affect_ipc_buffer aag l buf"
+  apply (clarsimp simp: ipc_buffer_has_read_auth_def aag_can_read_or_affect_ipc_buffer_def
                  split: option.splits)
-  apply(rule reads_read)
+  apply (rule reads_read)
   apply blast
   done
 
 lemma ev_irrelevant_bind:
-  assumes inv: "\<And> P. \<lbrace> P \<rbrace> f \<lbrace>\<lambda>_. P \<rbrace>"
+  assumes inv: "\<And>P. \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. P\<rbrace>"
   assumes ev: "equiv_valid I A A P g"
   shows "equiv_valid I A A P (do y \<leftarrow> f; g od)"
-  apply(simp add: equiv_valid_def2)
-  apply(rule equiv_valid_rv_guard_imp)
-   apply(rule equiv_valid_2_bind)
-      apply(rule ev[simplified equiv_valid_def2])
-     apply(wp equiv_valid_rv_trivial[OF inv] inv | simp)+
-  done
-
-lemma get_message_info_reads_respects:
-  "reads_respects aag l (K (aag_can_read_or_affect aag l ptr)) (get_message_info ptr)"
-  apply (simp add: get_message_info_def)
-  apply (wp as_user_reads_respects | clarsimp simp: getRegister_def)+
-  done
-
-lemma do_normal_transfer_reads_respects:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs and
-                         valid_arch_state and valid_mdb and valid_objs and
-                         K (aag_can_read_or_affect aag l sender \<and>
-                            ipc_buffer_has_read_auth aag (pasObjectAbs aag sender) sbuf \<and>
-                            ipc_buffer_has_read_auth aag (pasObjectAbs aag receiver) rbuf \<and>
-                            (grant \<longrightarrow> (is_subject aag sender \<and> is_subject aag receiver))))
-                        (do_normal_transfer sender sbuf endpoint badge grant receiver rbuf)"
-  apply(cases grant)
-   apply(rule gen_asm_ev)
-   apply(simp add: do_normal_transfer_def)
-   apply(wp copy_mrs_pas_refined get_message_info_rev lookup_extra_caps_rev
-            as_user_set_register_reads_respects' set_message_info_reads_respects
-            transfer_caps_reads_respects copy_mrs_reads_respects
-            lookup_extra_caps_rev lookup_extra_caps_authorised
-            lookup_extra_caps_auth get_message_info_rev
-            get_mi_length' get_mi_length validE_E_wp_post_taut
-            copy_mrs_cte_wp_at
-            hoare_vcg_ball_lift lec_valid_cap'
-            lookup_extra_caps_srcs[simplified ball_conj_distrib,THEN hoare_conjDR1]
-            lookup_extra_caps_srcs[simplified ball_conj_distrib,THEN hoare_conjDR2]
-        | wpc
-        | simp add: det_setRegister ball_conj_distrib)+
-   apply (fastforce intro: aag_has_read_auth_can_read_or_affect_ipc_buffer)
-  apply(rule gen_asm_ev)
-  apply(simp add: do_normal_transfer_def transfer_caps_def)
-  apply(wp ev_irrelevant_bind[where f="get_receive_slots receiver rbuf"]
-           as_user_set_register_reads_respects'
-           set_message_info_reads_respects copy_mrs_reads_respects
-           get_message_info_reads_respects get_mi_length
-       |wpc
-       |simp)+
-  apply(auto simp: ipc_buffer_has_read_auth_def aag_can_read_or_affect_ipc_buffer_def dest: reads_read_thread_read_pages split: option.splits)
-  done
-
-lemma getRestartPC_det:
-  "det getRestartPC"
-  apply (clarsimp simp: getRestartPC_def getRegister_def)
-  done
-
-lemma getRegister_det:
-  "det (getRegister x)"
-  by (clarsimp simp: getRegister_def)
-
-lemma make_fault_msg_reads_respects:
-  "reads_respects aag l (K (aag_can_read_or_affect aag l sender)) (make_fault_msg rva sender)"
-  apply(case_tac rva)
-     apply (wp as_user_reads_respects
-           | simp split del: if_split
-                  add: getRestartPC_det getRegister_det
-           | rule det_mapM
-           | rule subset_refl)+
-  apply (case_tac x4)
-  apply (wp as_user_reads_respects
-        | simp split del: if_split
-               add: getRestartPC_det getRegister_det)+
+  apply (simp add: equiv_valid_def2)
+  apply (rule equiv_valid_rv_guard_imp)
+   apply (rule equiv_valid_2_bind)
+      apply (rule ev[simplified equiv_valid_def2])
+     apply (wp equiv_valid_rv_trivial[OF inv] inv | simp)+
   done
 
 lemma set_mrs_returns_a_constant:
-  "\<exists> x. \<lbrace> \<top> \<rbrace> set_mrs thread buf msgs \<lbrace> \<lambda> rv s. rv = x \<rbrace>"
-  apply(case_tac buf)
-   apply(rule exI)
-   apply((simp add: set_mrs_def | wp | rule impI)+)[1]
-  apply(rule exI)
-  apply((simp add: set_mrs_def split del: if_split | wp | rule impI)+)[1]
+  "\<exists>x. \<lbrace>\<top>\<rbrace> set_mrs thread buf msgs \<lbrace>\<lambda>rv s. rv = x\<rbrace>"
+  apply (case_tac buf)
+   apply (rule exI)
+   apply ((simp add: set_mrs_def | wp | rule impI)+)[1]
+  apply (rule exI)
+  apply (simp add: set_mrs_def split del: if_split | wp | rule impI)+
   done
 
 lemma set_mrs_ret_eq:
-  "\<forall>(s::'a::state_ext state) (t::'a::state_ext state). \<forall>(rva, s')\<in>fst (set_mrs thread buf msgs s).
-                \<forall>(rvb, t')\<in>fst (set_mrs thread  buf msgs t). rva = rvb"
-  apply(clarsimp)
-  apply(cut_tac thread=thread and buf=buf and msgs=msgs in set_mrs_returns_a_constant)
-  apply(erule exE)
-  apply(subgoal_tac "a = x \<and> aa = x")
+  "\<forall>(s::'s::state_ext state) (t::'s::state_ext state).
+   \<forall>(rva, s') \<in> fst (set_mrs thread buf msgs s).
+   \<forall>(rvb, t') \<in> fst (set_mrs thread buf msgs t). rva = rvb"
+  apply (clarsimp)
+  apply (cut_tac thread=thread and buf=buf and msgs=msgs in set_mrs_returns_a_constant)
+  apply (erule exE)
+  apply (subgoal_tac "a = x \<and> aa = x")
    apply simp
-  apply(rule conjI)
-   apply(erule (1) use_valid | simp)+
+  apply (rule conjI)
+   apply (erule (1) use_valid | simp)+
   done
-
-
-lemma set_mrs_reads_respects':
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (K (ipc_buffer_has_auth aag thread buf \<and>  (case buf of (Some buf') \<Rightarrow>
-        is_aligned buf' msg_align_bits | _ \<Rightarrow> True))) (set_mrs thread buf msgs)"
-  apply(case_tac "aag_can_read_or_affect aag l thread")
-   apply((wp equiv_valid_guard_imp[OF set_mrs_reads_respects] | simp)+)[1]
-  apply(rule gen_asm_ev)
-  apply(simp add: equiv_valid_def2)
-  apply(rule equiv_valid_rv_guard_imp)
-  apply(case_tac buf)
-   apply(rule_tac Q="\<top>" and P="\<top>" and L="{pasObjectAbs aag thread}" in ev_invisible[OF domains_distinct])
-      apply(clarsimp simp: labels_are_invisible_def)
-     apply(rule modifies_at_mostI)
-     apply(simp add: set_mrs_def)
-     apply((wp set_object_equiv_but_for_labels | simp | auto dest: get_tcb_not_asid_pool_at)+)[1]
-    apply(simp)
-    apply(rule set_mrs_ret_eq)
-   apply(rename_tac buf')
-   apply(rule_tac Q="\<top>" and L="{pasObjectAbs aag thread} \<union> (pasObjectAbs aag) ` (ptr_range buf' msg_align_bits)" in ev_invisible[OF domains_distinct])
-     apply(auto simp: labels_are_invisible_def ipc_buffer_has_auth_def dest: reads_read_page_read_thread simp: aag_can_affect_label_def)[1]
-    apply(rule modifies_at_mostI)
-    apply(wp set_mrs_equiv_but_for_labels | simp)+
-   apply(rule set_mrs_ret_eq)
-  by simp
-
-lemma do_fault_transfer_reads_respects:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (K (aag_can_read_or_affect aag l sender \<and> ipc_buffer_has_auth aag receiver buf \<and>
-    (case buf of None \<Rightarrow> True | Some buf' \<Rightarrow> is_aligned buf' msg_align_bits))) (do_fault_transfer badge sender receiver buf)"
-  unfolding do_fault_transfer_def
-  apply (wp as_user_set_register_reads_respects' as_user_reads_respects set_message_info_reads_respects
-            set_mrs_reads_respects' make_fault_msg_reads_respects thread_get_reads_respects
-         | wpc
-         | simp add: split_def det_setRegister
-         | wp (once) hoare_drop_imps)+
-  done
-
-
 
 lemma tl_tl_in_set:
   "tl xs = (x # xs') \<Longrightarrow> set xs' \<subseteq> set xs"
-  apply(case_tac xs, auto)
-  done
+  by (case_tac xs, auto)
 
 (* GENERALIZE the following is possible *)
 lemma ptr_in_obj_range:
@@ -1734,6 +1300,68 @@ lemma ptr_in_obj_range:
   apply (erule(1) pspace_alignedD)
   done
 
+lemma ko_at_eq:
+  "ko_at obj pos s \<longleftrightarrow> kheap s pos = Some obj"
+  by (force simp:obj_at_def)
+
+
+locale Ipc_IF_2 = Ipc_IF_1 +
+  assumes copy_mrs_reads_respects:
+    "pas_domains_distinct aag
+     \<Longrightarrow> reads_respects aag l (K (aag_can_read_or_affect aag l sender \<and>
+                                  aag_can_read_or_affect_ipc_buffer aag l sbuf \<and>
+                                  unat n < 2 ^ (msg_align_bits - word_size_bits)))
+                        (copy_mrs sender sbuf receiver rbuf n)"
+  and get_message_info_reads_respects:
+    "reads_respects aag l (K (aag_can_read_or_affect aag l ptr)) (get_message_info ptr)"
+  and do_normal_transfer_reads_respects:
+    "pas_domains_distinct aag
+     \<Longrightarrow> reads_respects aag l (pas_refined aag and pspace_aligned and valid_vspace_objs and
+                               valid_arch_state and valid_mdb and valid_objs and
+                               K (aag_can_read_or_affect aag l sender \<and>
+                                  ipc_buffer_has_read_auth aag (pasObjectAbs aag sender) sbuf \<and>
+                                  ipc_buffer_has_read_auth aag (pasObjectAbs aag receiver) rbuf \<and>
+                                  (grant \<longrightarrow> (is_subject aag sender \<and> is_subject aag receiver))))
+                        (do_normal_transfer sender sbuf endpoint badge grant receiver rbuf)"
+  and make_arch_fault_msg_reads_respects:
+    "reads_respects aag l (\<lambda>y. aag_can_read_or_affect aag l sender) (make_arch_fault_msg x4 sender)"
+  and set_mrs_equiv_but_for_labels:
+    "\<lbrace>equiv_but_for_labels aag L st and
+      K (pasObjectAbs aag thread \<in> L \<and>
+         (case buf of (Some buf') \<Rightarrow> is_aligned buf' msg_align_bits \<and>
+                                     (\<forall>x \<in> ptr_range buf' msg_align_bits. pasObjectAbs aag x \<in> L)
+                              | _ \<Rightarrow> True))\<rbrace>
+     set_mrs thread buf msgs
+     \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  and set_mrs_reads_respects':
+    "pas_domains_distinct aag
+     \<Longrightarrow> reads_respects aag l (K (ipc_buffer_has_auth aag thread buf \<and>
+                                  (case buf of (Some buf') \<Rightarrow> is_aligned buf' msg_align_bits
+                                                       | _ \<Rightarrow> True))) (set_mrs thread buf msgs)"
+begin
+
+lemma make_fault_msg_reads_respects:
+  "reads_respects aag l (K (aag_can_read_or_affect aag l sender)) (make_fault_msg rva sender)"
+  apply (case_tac rva)
+  by (wp as_user_reads_respects make_arch_fault_msg_reads_respects
+       | simp split del: if_split add: det_getRegister det_getRestartPC
+       | rule det_mapM
+       | rule subset_refl)+
+
+lemma do_fault_transfer_reads_respects:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows
+    "reads_respects aag l
+       (K (aag_can_read_or_affect aag l sender \<and> ipc_buffer_has_auth aag receiver buf \<and>
+           (case buf of None \<Rightarrow> True | Some buf' \<Rightarrow> is_aligned buf' msg_align_bits)))
+       (do_fault_transfer badge sender receiver buf)"
+  unfolding do_fault_transfer_def
+  by (wp as_user_set_register_reads_respects' as_user_reads_respects set_message_info_reads_respects
+         set_mrs_reads_respects' make_fault_msg_reads_respects thread_get_reads_respects
+      | wpc
+      | simp add: split_def det_setRegister
+      | wp (once) hoare_drop_imps)+
+
 lemma do_ipc_transfer_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
@@ -1756,33 +1384,16 @@ lemma do_ipc_transfer_reads_respects:
         | fastforce)+
   done
 
-lemma complete_signal_reads_respects:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l ( K(aag_can_read aag ntfnptr \<or> aag_can_affect aag l ntfnptr))
-     (complete_signal ntfnptr receiver)"
-  unfolding complete_signal_def
-  apply (wp set_simple_ko_reads_respects
-            get_simple_ko_reads_respects
-            as_user_set_register_reads_respects'
-        | wpc
-        | simp)+
-  done
-
-lemma ko_at_eq:
-  "ko_at obj pos s \<longleftrightarrow> kheap s pos = Some obj"
-  by (force simp:obj_at_def)
-
 lemma receive_ipc_base_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   notes do_nbrecv_failed_transfer_def[simp]
-  shows "reads_respects aag l
+  shows "reads_respects aag (l :: 'a subject_label)
      (invs and pas_refined aag and pas_cur_domain aag
       and ko_at (Endpoint ep) epptr
       and is_subject aag \<circ> cur_thread
       and K (is_subject aag receiver
            \<and> aag_has_auth_to aag Receive epptr
-           \<and> (\<forall> auth \<in> cap_rights_to_auth rights True . aag_has_auth_to aag auth epptr)))
+           \<and> (\<forall>auth \<in> cap_rights_to_auth rights True . aag_has_auth_to aag auth epptr)))
      (receive_ipc_base aag receiver ep epptr rights is_blocking)"
   apply (rule gen_asm_ev)
   apply (simp add: thread_get_def split: endpoint.split)
@@ -1810,14 +1421,15 @@ lemma receive_ipc_base_reads_respects:
                       elim: receive_ipc_sender_can_grant_helper
                      intro: requiv_get_tcb_eq')
     apply (frule(2) receive_ipc_sender_helper)
-    apply (solves \<open>auto intro:reads_ep read_sync_ep_read_senders_strong\<close>)
+    apply (solves \<open>auto intro:reads_ep read_sync_ep_read_senders\<close>)
     done
   done
 
 lemma receive_ipc_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects aag l (invs and
+  "reads_respects aag (l :: 'a subject_label)
+                      (invs and
                          pas_refined aag and pas_cur_domain aag and valid_cap cap
                      and is_subject aag \<circ> cur_thread
                      and K (is_subject aag receiver \<and> pas_cap_cur_auth aag cap
@@ -1845,6 +1457,8 @@ lemma receive_ipc_reads_respects:
   by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def cap_rights_to_auth_def
                 dest: bound_tcb_at_implies_receive reads_ep)
 
+end
+
 
 lemma receive_endpoint_threads_blocked:
 "\<lbrakk>valid_objs s; (sym_refs \<circ> state_refs_of) s;
@@ -1858,10 +1472,10 @@ lemma receive_blocked_threads_have_Receive_auth:
   "\<lbrakk>pas_refined aag s; valid_objs s; sym_refs (state_refs_of s);
     st_tcb_at (receive_blocked_on ep) x s\<rbrakk> \<Longrightarrow>
   (pasObjectAbs aag x,Receive,pasObjectAbs aag ep) \<in> pasPolicy aag"
-  apply(drule_tac auth="Receive" and x=x in pas_refined_mem[rotated])
-   apply(rule sta_ts)
-   apply(clarsimp simp: thread_st_auth_def split: option.split simp: tcb_states_of_state_def st_tcb_def2)
-   apply(case_tac "tcb_state tcb", simp_all)
+  apply (drule_tac auth="Receive" and x=x in pas_refined_mem[rotated])
+   apply (rule sta_ts)
+   apply (clarsimp simp: thread_st_auth_def split: option.split simp: tcb_states_of_state_def st_tcb_def2)
+   apply (case_tac "tcb_state tcb", simp_all)
   done
 
 lemma receive_endpoint_reads_affects_queued:
@@ -1874,15 +1488,19 @@ lemma receive_endpoint_reads_affects_queued:
        \<Longrightarrow>
              aag_can_read_label aag (pasObjectAbs aag x) \<or>
              aag_can_affect aag l x"
-  apply(frule receive_endpoint_threads_blocked, (simp | assumption)+)
-  apply(drule receive_blocked_threads_have_Receive_auth, (simp | assumption)+)
-  apply(auto dest: read_sync_ep_read_receivers)
+  apply (frule receive_endpoint_threads_blocked, (simp | assumption)+)
+  apply (drule receive_blocked_threads_have_Receive_auth, (simp | assumption)+)
+  apply (auto dest: read_sync_ep_read_receivers)
   done
+
+
+context Ipc_IF_2 begin
 
 lemma send_ipc_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects aag l (pas_refined aag and invs and pas_cur_domain aag
+  "reads_respects aag (l :: 'a subject_label)
+        (pas_refined aag and invs and pas_cur_domain aag
           and is_subject aag \<circ> cur_thread
           and K (can_grant \<longrightarrow> (aag_has_auth_to aag Grant epptr))
           and K (is_subject aag thread \<and> aag_has_auth_to aag SyncSend epptr))
@@ -1910,7 +1528,7 @@ lemma send_ipc_reads_respects:
    prefer 2
    apply (frule(2) pas_refined_ep_recv, rule head_in_set)
    apply (rule conjI)
-    subgoal by (rule read_sync_ep_read_receivers_strong)
+    subgoal by (rule read_sync_ep_read_receivers)
    apply (fastforce dest: aag_wellformed_grant_Control_to_recv[OF _ _ pas_refined_wellformed]
                     simp: aag_has_Control_iff_owns)
   by (fastforce elim: send_ipc_valid_ep_helper reads_equivE equiv_forD
@@ -1922,7 +1540,7 @@ subsection "Faults"
 lemma send_fault_ipc_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects aag l (invs and pas_refined aag and pas_cur_domain aag
+  "reads_respects aag (l :: 'a subject_label) (invs and pas_refined aag and pas_cur_domain aag
          and is_subject aag \<circ> cur_thread and K (is_subject aag thread \<and> valid_fault fault))
      (send_fault_ipc thread fault)"
   apply (rule gen_asm_ev)
@@ -1957,52 +1575,56 @@ lemma send_fault_ipc_reads_respects:
 lemma handle_fault_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects aag l (invs and pas_refined aag and pas_cur_domain aag
+  "reads_respects aag (l :: 'a subject_label) (invs and pas_refined aag and pas_cur_domain aag
         and is_subject aag \<circ> cur_thread
         and K (is_subject aag thread \<and> valid_fault fault))
      (handle_fault thread fault)"
   unfolding handle_fault_def catch_def fun_app_def handle_double_fault_def
-  apply(wp (once) hoare_drop_imps |
+  apply (wp (once) hoare_drop_imps |
         wp set_thread_state_reads_respects send_fault_ipc_reads_respects | wpc | simp)+
-  apply(fastforce intro: reads_affects_equiv_get_tcb_eq)
+  apply (fastforce intro: reads_affects_equiv_get_tcb_eq)
   done
 
+end
 
 
 subsection "Replies"
 
-lemma handle_arch_fault_reply_reads_respects:
-  "reads_respects aag l (K (aag_can_read aag thread)) (handle_arch_fault_reply afault thread x y)"
-  by (simp add: handle_arch_fault_reply_def, wp)
+context Ipc_IF_1 begin
 
 lemma handle_fault_reply_reads_respects:
   "reads_respects aag l (K (aag_can_read aag thread)) (handle_fault_reply fault thread x y)"
-  apply(case_tac fault)
+  apply (case_tac fault)
      apply (wp as_user_reads_respects thread_get_reads_respects
                thread_get_wp' handle_arch_fault_reply_reads_respects[simplified K_def]
-          | simp add: det_zipWithM_x det_setRegister)+
+            | simp add: det_zipWithM_x det_setRegister)+
   done
 
 lemma lookup_ipc_buffer_has_read_auth':
   "\<lbrace>pas_refined aag and valid_objs and K (is_subject aag thread)\<rbrace>
    lookup_ipc_buffer is_receiver thread
    \<lbrace>\<lambda>rv s. ipc_buffer_has_read_auth aag (pasSubject aag) rv\<rbrace>"
-  apply(rule hoare_gen_asm)
-  apply(rule hoare_strengthen_post[OF lookup_ipc_buffer_has_read_auth])
-  apply(drule sym, simp)
+  apply (rule hoare_gen_asm)
+  apply (rule hoare_strengthen_post[OF lookup_ipc_buffer_has_read_auth])
+  apply (drule sym, simp)
   done
 
+crunch valid_ko_at_arch[wp]: handle_fault_reply valid_ko_at_arch
 
-crunch valid_ko_at_arm[wp]: handle_fault_reply "valid_ko_at_arm"
+end
+
+context Ipc_IF_2 begin
 
 lemma do_reply_transfer_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects_f aag l (silc_inv aag st and invs and pas_refined aag and pas_cur_domain aag
-         and tcb_at receiver and tcb_at sender and emptyable slot  and is_subject aag \<circ> cur_thread
-         and K (grant \<longrightarrow> is_subject aag receiver)
-         and K (is_subject aag sender \<and> aag_can_read aag receiver \<and> is_subject aag (fst slot)))
-     (do_reply_transfer sender receiver slot grant)"
+    "reads_respects_f aag l
+       (silc_inv aag st and invs and pas_refined aag and pas_cur_domain aag and tcb_at receiver
+                        and tcb_at sender and emptyable slot  and is_subject aag \<circ> cur_thread
+                        and K (grant \<longrightarrow> is_subject aag receiver)
+                        and K (is_subject aag sender \<and> aag_can_read aag receiver
+                                                     \<and> is_subject aag (fst slot)))
+       (do_reply_transfer sender receiver slot grant)"
   unfolding do_reply_transfer_def
   apply (rule gen_asm_ev)+
   apply (wp gets_cur_thread_ev[THEN reads_respects_f[where aag=aag and st=st and Q=\<top>]]
@@ -2016,66 +1638,67 @@ lemma do_reply_transfer_reads_respects_f:
             set_thread_state_pas_refined thread_set_fault_pas_refined'
             possible_switch_to_reads_respects[THEN reads_respects_f[where aag=aag and st=st and Q=\<top>]]
             when_ev
-        | wpc
-        | simp split del: if_split
-        | wp (once) reads_respects_f[where aag=aag and st=st]
-        | elim conjE
-        | wp (once) hoare_drop_imps)+
-         apply(rule_tac Q="\<lambda> rv s. pas_refined aag s \<and> pas_cur_domain aag s \<and> invs s
+         | wpc
+         | simp split del: if_split
+         | wp (once) reads_respects_f[where aag=aag and st=st]
+         | elim conjE
+         | wp (once) hoare_drop_imps)+
+         apply (rule_tac Q="\<lambda> rv s. pas_refined aag s \<and> pas_cur_domain aag s \<and> invs s
                                  \<and> is_subject aag (cur_thread s)
                                  \<and> silc_inv aag st s"
                      in hoare_strengthen_post[rotated])
-          apply((wp (once) hoare_drop_imps
-               | wp cap_delete_one_invs  hoare_vcg_all_lift
-                    cap_delete_one_silc_inv reads_respects_f[OF thread_get_reads_respects]
-                    reads_respects_f[OF get_thread_state_rev]
-               | simp add: invs_valid_objs invs_psp_aligned invs_valid_global_refs
-                           invs_distinct invs_arch_state invs_valid_ko_at_arm
-                           invs_psp_aligned invs_vspace_objs invs_arch_state
-               | rule conjI
-               | elim conjE
-               | assumption)+)[8]
-   by (fastforce dest: silc_inv_not_subject)
+          apply ((wp (once) hoare_drop_imps
+                  | wp cap_delete_one_invs  hoare_vcg_all_lift
+                       cap_delete_one_silc_inv reads_respects_f[OF thread_get_reads_respects]
+                       reads_respects_f[OF get_thread_state_rev]
+                  | simp add: invs_valid_objs invs_psp_aligned invs_valid_global_refs
+                              invs_distinct invs_arch_state invs_valid_ko_at_arch
+                              invs_psp_aligned invs_vspace_objs invs_arch_state
+                  | rule conjI
+                  | elim conjE
+                  | assumption)+)[8]
+  by (fastforce dest: silc_inv_not_subject)
 
 lemma handle_reply_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects_f aag l (silc_inv aag st and invs and pas_refined aag and pas_cur_domain aag
-                           and is_subject aag \<circ> cur_thread)
-     (handle_reply)"
+    "reads_respects_f aag l (silc_inv aag st and invs and pas_refined aag and pas_cur_domain aag
+                                             and is_subject aag \<circ> cur_thread) handle_reply"
   unfolding handle_reply_def
-  apply (wp do_reply_transfer_reads_respects_f get_cap_wp reads_respects_f[OF get_cap_reads_respects, where Q="\<top>" and st=st] hoare_vcg_all_lift | wpc | blast)+
-  apply(rule conjI)
-   apply(fastforce simp: reads_equiv_f_def)
+  apply (wp do_reply_transfer_reads_respects_f hoare_vcg_all_lift
+            get_cap_wp reads_respects_f[OF get_cap_reads_respects, where Q="\<top>" and st=st]
+         | wpc | blast)+
+  apply (rule conjI)
+   apply (fastforce simp: reads_equiv_f_def)
   apply clarsimp
-  apply(rule conjI)
+  apply (rule conjI)
    apply assumption
-  apply(rule conjI)
-   apply(drule cte_wp_valid_cap)
-    apply(erule invs_valid_objs)
-   apply(simp add: valid_cap_simps)
-  apply(rule conjI, fastforce simp: tcb_at_invs)
-  apply(rule conjI)
-   apply(erule emptyable_cte_wp_atD)
-    apply(erule invs_valid_objs)
-   apply(simp add: is_master_reply_cap_def)
-  apply(frule_tac p="(cur_thread s, tcb_cnode_index 3)" in cap_cur_auth_caps_of_state[rotated])
+  apply (rule conjI)
+   apply (drule cte_wp_valid_cap)
+    apply (erule invs_valid_objs)
+   apply (simp add: valid_cap_simps)
+  apply (rule conjI, fastforce simp: tcb_at_invs)
+  apply (rule conjI)
+   apply (erule emptyable_cte_wp_atD)
+    apply (erule invs_valid_objs)
+   apply (simp add: is_master_reply_cap_def)
+  apply (frule_tac p="(cur_thread s, tcb_cnode_index 3)" in cap_cur_auth_caps_of_state[rotated])
     apply simp
-   apply(simp add: cte_wp_at_caps_of_state)
-  apply(fastforce intro: read_reply_thread_read_thread_rev
-                   simp: aag_cap_auth_def cap_auth_conferred_def reply_cap_rights_to_auth_def
-                   dest: aag_Control_into_owns)
+   apply (simp add: cte_wp_at_caps_of_state)
+  apply (fastforce intro: read_reply_thread_read_thread_rev
+                    simp: aag_cap_auth_def cap_auth_conferred_def reply_cap_rights_to_auth_def
+                    dest: aag_Control_into_owns)
   done
 
 lemma reply_from_kernel_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (K (is_subject aag thread)) (reply_from_kernel thread x)"
+  shows "reads_respects aag l (K (is_subject aag thread)) (reply_from_kernel thread x)"
   unfolding reply_from_kernel_def fun_app_def
-  apply (wp set_message_info_reads_respects set_mrs_reads_respects
-            as_user_reads_respects lookup_ipc_buffer_reads_respects
-        | simp add: split_def det_setRegister)+
-  done
+  by (wp set_message_info_reads_respects set_mrs_reads_respects
+         as_user_reads_respects lookup_ipc_buffer_reads_respects
+      | simp add: split_def det_setRegister)+
+
+end
 
 
 (* FIXME in whole section replace preconditions with 10 differents invariants by invs *)
@@ -2084,197 +1707,118 @@ section "globals_equiv"
 subsection "Sync IPC"
 
 lemma setup_caller_cap_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm and valid_global_objs\<rbrace>
-     setup_caller_cap sender receiver grant
-    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  "\<lbrace>globals_equiv s and valid_ko_at_arch and valid_global_objs\<rbrace>
+   setup_caller_cap sender receiver grant
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding setup_caller_cap_def
-  apply(wp cap_insert_globals_equiv'' set_thread_state_globals_equiv)
-   apply(simp_all)
-   done
-
-lemma set_extra_badge_globals_equiv:
-  "\<lbrace>globals_equiv s \<rbrace>
-    set_extra_badge buffer badge n
-    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_extra_badge_def
-  apply(wp store_word_offs_globals_equiv)
+  apply (wp cap_insert_globals_equiv'' set_thread_state_globals_equiv)
+  apply (simp_all)
   done
 
+lemma set_extra_badge_globals_equiv:
+  "set_extra_badge buffer badge n \<lbrace>globals_equiv s\<rbrace>"
+  unfolding set_extra_badge_def
+  by (wp store_word_offs_globals_equiv)
+
 lemma transfer_caps_loop_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm and valid_global_objs\<rbrace>
-    transfer_caps_loop ep rcv_buffer n caps slots mi
-    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  "\<lbrace>globals_equiv st and valid_ko_at_arch and valid_global_objs\<rbrace>
+   transfer_caps_loop ep rcv_buffer n caps slots mi
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
 proof (induct caps arbitrary: slots n mi)
   case Nil
   thus ?case by (simp, wp, simp)
 next
   case (Cons c caps')
   show ?case
-    apply(cases c)
-    apply(simp split del: if_split cong: if_cong)
-    apply(rule hoare_pre)
-     apply(wp)
-       apply(erule conjE, erule subst, rule Cons.hyps)
-      apply(clarsimp)
-      apply(wp set_extra_badge_globals_equiv)+
-         apply(rule Cons.hyps)
-        apply(simp)
-        apply(wp cap_insert_globals_equiv'')
-       apply(rule_tac Q="\<lambda>_. globals_equiv st and valid_ko_at_arm and valid_global_objs"
-                  and E="\<lambda>_. globals_equiv st and valid_ko_at_arm and valid_global_objs"
-                   in hoare_post_impErr)
-         apply(simp add: whenE_def, rule conjI)
-          apply(rule impI, wp)+
-         apply(simp)+
+    apply (cases c)
+    apply (simp split del: if_split cong: if_cong)
+    apply (rule hoare_pre)
+     apply (wp)
+       apply (erule conjE, erule subst, rule Cons.hyps)
+      apply (clarsimp)
+      apply (wp set_extra_badge_globals_equiv)+
+         apply (rule Cons.hyps)
+        apply (simp)
+        apply (wp cap_insert_globals_equiv'')
+       apply (rule_tac Q="\<lambda>_. globals_equiv st and valid_ko_at_arch and valid_global_objs"
+                   and E="\<lambda>_. globals_equiv st and valid_ko_at_arch and valid_global_objs"
+                    in hoare_post_impErr)
+         apply (simp add: whenE_def, rule conjI)
+          apply (rule impI, wp)+
+         apply (simp)+
        apply wp+
-    apply(fastforce)
+    apply (fastforce)
     done
 qed
 
 lemma transfer_caps_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm and valid_global_objs\<rbrace>
-    transfer_caps info caps endpoint receiver recv_buffer
-    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  "\<lbrace>globals_equiv st and valid_ko_at_arch and valid_global_objs\<rbrace>
+   transfer_caps info caps endpoint receiver recv_buffer
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding transfer_caps_def
-  apply(wp transfer_caps_loop_globals_equiv | wpc | simp)+
-  done
+  by (wp transfer_caps_loop_globals_equiv | wpc | simp)+
 
 lemma copy_mrs_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm and (\<lambda>s. receiver \<noteq> idle_thread s)\<rbrace>
-    copy_mrs sender sbuf receiver rbuf n
-    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  "\<lbrace>globals_equiv s and valid_ko_at_arch and (\<lambda>s. receiver \<noteq> idle_thread s)\<rbrace>
+   copy_mrs sender sbuf receiver rbuf n
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding copy_mrs_def including no_pre
-  apply(wp | wpc)+
-    apply(rule_tac Q="\<lambda>_. globals_equiv s"
-         in hoare_strengthen_post)
-     apply(wp mapM_wp' | wpc)+
-      apply(wp store_word_offs_globals_equiv)+
-     apply fastforce
-    apply simp
-   apply(rule_tac Q="\<lambda>_. globals_equiv s and valid_ko_at_arm and (\<lambda>sa. receiver \<noteq> idle_thread sa)"
-          in hoare_strengthen_post)
-    apply(wp mapM_wp' as_user_globals_equiv)
-    apply(simp)
-   apply(fastforce)
+  apply (wp | wpc)+
+    apply (rule_tac Q="\<lambda>_. globals_equiv s" in hoare_strengthen_post)
+     apply (wp mapM_wp' | wpc)+
+      apply (wp store_word_offs_globals_equiv)+
+    apply fastforce
+   apply simp
+   apply (rule_tac Q="\<lambda>_. globals_equiv s and valid_ko_at_arch and (\<lambda>sa. receiver \<noteq> idle_thread sa)"
+                in hoare_strengthen_post)
+    apply (wp mapM_wp' as_user_globals_equiv)
+    apply (simp)
+   apply (fastforce)
   apply simp
   done
 
 (* FIXME: move *)
 lemma validE_to_valid:
   "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. \<forall>v. rv = Inr v \<longrightarrow> Q v s\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>v. Q v\<rbrace>, -"
-  apply(rule validE_validE_R)
-  apply(simp add: validE_def valid_def)
+  apply (rule validE_validE_R)
+  apply (simp add: validE_def valid_def)
   done
-
 
 lemma do_normal_transfer_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm and valid_global_objs and
-    (\<lambda>sa. receiver \<noteq> idle_thread sa)\<rbrace>
-    do_normal_transfer sender sbuf endpoint badge grant receiver rbuf
-    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  "\<lbrace>globals_equiv st and valid_ko_at_arch and valid_global_objs and (\<lambda>sa. receiver \<noteq> idle_thread sa)\<rbrace>
+   do_normal_transfer sender sbuf endpoint badge grant receiver rbuf
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding do_normal_transfer_def
-  apply(wp as_user_globals_equiv set_message_info_globals_equiv transfer_caps_globals_equiv)
-    apply(wp copy_mrs_globals_equiv)
-     apply(subst K_def)
-     apply(wp | rule impI)+
-  apply(clarsimp)
+  apply (wp as_user_globals_equiv set_message_info_globals_equiv transfer_caps_globals_equiv)
+     apply (wp copy_mrs_globals_equiv)
+    apply (subst K_def)
+    apply (wp | rule impI)+
+  apply (clarsimp)
   done
-
-
 
 lemma do_fault_transfer_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm and
-    (\<lambda>sa. receiver \<noteq> idle_thread sa)\<rbrace>
-      do_fault_transfer badge sender receiver buf
-    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  "\<lbrace>globals_equiv s and valid_ko_at_arch and (\<lambda>sa. receiver \<noteq> idle_thread sa)\<rbrace>
+   do_fault_transfer badge sender receiver buf
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding do_fault_transfer_def
-  apply(wp)
-     apply(simp add: split_def)
-     apply(wp as_user_globals_equiv set_message_info_globals_equiv
-              set_mrs_globals_equiv | wpc)+
-  apply(clarsimp)
-  apply(rule hoare_drop_imps)
-  apply(wp thread_get_inv, simp)
-  done
-
-lemma lookup_ipc_buffer_ptr_range':
-  "\<lbrace>valid_objs\<rbrace>
-  lookup_ipc_buffer True thread
-  \<lbrace>\<lambda>rv s. rv = Some buf' \<longrightarrow> auth_ipc_buffers s thread = ptr_range buf' msg_align_bits\<rbrace>"
-  unfolding lookup_ipc_buffer_def
-  apply (rule hoare_pre)
-  apply (wp get_cap_wp thread_get_wp' | wpc)+
-  apply (clarsimp simp: cte_wp_at_caps_of_state ipc_buffer_has_auth_def get_tcb_ko_at [symmetric])
-  apply (frule caps_of_state_tcb_cap_cases [where idx = "tcb_cnode_index 4"])
-   apply (simp add: dom_tcb_cap_cases)
-  apply (clarsimp simp: auth_ipc_buffers_def get_tcb_ko_at [symmetric])
-  apply (drule(1) valid_tcb_objs)
-  apply (drule get_tcb_SomeD)+
-  apply (simp add: vm_read_write_def valid_tcb_def valid_ipc_buffer_cap_def split: bool.splits)
-  done
-
-lemma lookup_ipc_buffer_aligned':
-  "\<lbrace>valid_objs\<rbrace> lookup_ipc_buffer True thread
-\<lbrace>\<lambda>rv s. rv = Some buf' \<longrightarrow> is_aligned buf' msg_align_bits\<rbrace>"
-  apply(insert lookup_ipc_buffer_aligned)
-  apply(fastforce simp: valid_def)
+  apply (wp)
+      apply (simp add: split_def)
+      apply (wp as_user_globals_equiv set_message_info_globals_equiv
+               set_mrs_globals_equiv | wpc)+
+   apply (clarsimp)
+   apply (rule hoare_drop_imps)
+   apply (wp thread_get_inv, simp)
   done
 
 lemma set_collection: "a = {x. x\<in>a}"
   by simp
 
-lemma do_ipc_transfer_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm and valid_objs and valid_arch_state and valid_global_refs
-    and pspace_distinct and pspace_aligned and valid_global_objs and (\<lambda>s. receiver \<noteq> idle_thread s)\<rbrace>
-    do_ipc_transfer sender ep badge grant receiver
-    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding do_ipc_transfer_def
-  apply(wp do_normal_transfer_globals_equiv do_fault_transfer_globals_equiv | wpc)+
-    apply(rule_tac Q="\<lambda>_. globals_equiv st and valid_ko_at_arm and valid_global_objs and
-           (\<lambda>sa. receiver \<noteq> idle_thread sa) and
-           (\<lambda>sa. (\<forall>rb. recv_buffer = Some rb \<longrightarrow>
-           auth_ipc_buffers sa receiver = ptr_range rb msg_align_bits) \<and>
-           (\<forall>rb. recv_buffer = Some rb \<longrightarrow> is_aligned rb msg_align_bits))"
-           in hoare_strengthen_post)
-     apply(wp)
-    apply(clarsimp | rule conjI)+
-   apply(wp hoare_vcg_all_lift lookup_ipc_buffer_ptr_range' lookup_ipc_buffer_aligned' | fastforce)+
-  done
+crunch valid_ko_at_arch[wp]: do_ipc_transfer "valid_ko_at_arch"
+  (wp: make_arch_fault_msg_inv)
 
-crunch valid_ko_at_arm[wp]: do_ipc_transfer "valid_ko_at_arm"
-
-lemma send_ipc_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
-    and pspace_distinct and pspace_aligned and valid_global_objs and valid_idle and (\<lambda>s. sym_refs (state_refs_of s))\<rbrace>
-    send_ipc block call badge can_grant can_grant_reply thread epptr
-    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding send_ipc_def
-  apply(wp set_simple_ko_globals_equiv set_thread_state_globals_equiv
-           setup_caller_cap_globals_equiv | wpc)+
-         apply(rule_tac Q="\<lambda>_. globals_equiv st and valid_ko_at_arm and valid_global_objs"
-               in hoare_strengthen_post[rotated])
-         apply(fastforce)
-        apply(wp set_thread_state_globals_equiv dxo_wp_weak | simp)+
-        apply wpc
-      apply(wp do_ipc_transfer_globals_equiv)+
-    apply(clarsimp)
-    apply(rule hoare_drop_imps)
-    apply(wp set_simple_ko_globals_equiv)+
-  apply(rule_tac Q="\<lambda>ep. ko_at (Endpoint ep) epptr and globals_equiv st and valid_objs
-        and valid_arch_state and valid_global_refs and pspace_distinct and pspace_aligned
-        and valid_global_objs and (\<lambda>s. sym_refs (state_refs_of s)) and valid_idle"
-        in hoare_strengthen_post)
-   apply(wp get_simple_ko_sp)
-    apply(clarsimp simp: valid_arch_state_ko_at_arm)+
-  apply (rule context_conjI)
-   apply(rule valid_ep_recv_dequeue')
-    apply(simp)+
-  apply (frule_tac x=xa in receive_endpoint_threads_blocked,simp+)
-  by (clarsimp simp add: valid_idle_def pred_tcb_at_def obj_at_def)+
-
-
-lemma valid_ep_send_enqueue: "\<lbrakk>ko_at (Endpoint (SendEP (t # ts))) a s; valid_objs s\<rbrakk>
-       \<Longrightarrow> valid_ep (case ts of [] \<Rightarrow> IdleEP | b # bs \<Rightarrow> SendEP (b # bs)) s"
+lemma valid_ep_send_enqueue:
+  "\<lbrakk> ko_at (Endpoint (SendEP (t # ts))) a s; valid_objs s \<rbrakk>
+     \<Longrightarrow> valid_ep (case ts of [] \<Rightarrow> IdleEP | b # bs \<Rightarrow> SendEP (b # bs)) s"
   unfolding valid_objs_def valid_obj_def valid_ep_def obj_at_def
   apply (drule bspec)
   apply (auto split: list.splits)
@@ -2283,412 +1827,464 @@ lemma valid_ep_send_enqueue: "\<lbrakk>ko_at (Endpoint (SendEP (t # ts))) a s; v
 crunch globals_equiv[wp]: complete_signal "globals_equiv st"
 
 lemma case_list_cons_cong:
-  "(case xxs of [] \<Rightarrow> f | x # xs \<Rightarrow> g xxs)
- = (case xxs of [] \<Rightarrow> f | x # xs \<Rightarrow> g (x # xs))"
+  "(case xxs of [] \<Rightarrow> f | x # xs \<Rightarrow> g xxs) =
+   (case xxs of [] \<Rightarrow> f | x # xs \<Rightarrow> g (x # xs))"
   by (simp split: list.split)
+
+
+context Ipc_IF_1 begin
+
+lemma do_ipc_transfer_globals_equiv:
+  "\<lbrace>globals_equiv st and valid_ko_at_arch and valid_objs and valid_arch_state and valid_global_refs
+                     and pspace_distinct and pspace_aligned
+                     and valid_global_objs and (\<lambda>s. receiver \<noteq> idle_thread s)\<rbrace>
+   do_ipc_transfer sender ep badge grant receiver
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding do_ipc_transfer_def
+  apply (wp do_normal_transfer_globals_equiv do_fault_transfer_globals_equiv | wpc)+
+    apply (rule_tac Q="\<lambda>_. globals_equiv st and valid_ko_at_arch and valid_global_objs and
+                           (\<lambda>sa. receiver \<noteq> idle_thread sa) and
+                           (\<lambda>sa. (\<forall>rb. recv_buffer = Some rb
+                                 \<longrightarrow> auth_ipc_buffers sa receiver = ptr_range rb msg_align_bits) \<and>
+                                 (\<forall>rb. recv_buffer = Some rb \<longrightarrow> is_aligned rb msg_align_bits))"
+                 in hoare_strengthen_post)
+     apply (wp)
+    apply (clarsimp | rule conjI)+
+   apply (wp hoare_vcg_all_lift lookup_ipc_buffer_ptr_range' lookup_ipc_buffer_aligned' | fastforce)+
+  done
+
+lemma send_ipc_globals_equiv:
+  "\<lbrace>globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
+                     and pspace_distinct and pspace_aligned and valid_global_objs
+                     and valid_idle and (\<lambda>s. sym_refs (state_refs_of s))\<rbrace>
+   send_ipc block call badge can_grant can_grant_reply thread epptr
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding send_ipc_def
+  apply (wp set_simple_ko_globals_equiv set_thread_state_globals_equiv
+            setup_caller_cap_globals_equiv | wpc)+
+        apply (rule_tac Q="\<lambda>_. globals_equiv st and valid_ko_at_arch and valid_global_objs"
+                     in hoare_strengthen_post[rotated])
+         apply (fastforce)
+        apply (wp set_thread_state_globals_equiv dxo_wp_weak | simp)+
+      apply wpc
+             apply (wp do_ipc_transfer_globals_equiv)+
+     apply (clarsimp)
+     apply (rule hoare_drop_imps)
+     apply (wp set_simple_ko_globals_equiv)+
+   apply (rule_tac Q="\<lambda>ep. ko_at (Endpoint ep) epptr and globals_equiv st and valid_objs and
+                           valid_arch_state and valid_global_refs and pspace_distinct and
+                           pspace_aligned and valid_global_objs and
+                           (\<lambda>s. sym_refs (state_refs_of s)) and valid_idle"
+                in hoare_strengthen_post)
+    apply (wp get_simple_ko_sp)
+   apply (clarsimp simp: valid_arch_state_ko_at_arch)+
+   apply (rule context_conjI)
+    apply (rule valid_ep_recv_dequeue')
+     apply (simp)+
+   apply (frule_tac x=xa in receive_endpoint_threads_blocked,simp+)
+  by (clarsimp simp add: valid_idle_def pred_tcb_at_def obj_at_def)+
 
 lemma receive_ipc_globals_equiv:
   notes do_nbrecv_failed_transfer_def[simp]
-  shows "\<lbrace>globals_equiv st and valid_objs and valid_arch_state and valid_global_refs and pspace_distinct
-     and pspace_aligned and valid_global_objs and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
-     receive_ipc thread cap is_blocking
-    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  shows "\<lbrace>globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
+                           and pspace_distinct and pspace_aligned and valid_global_objs
+                           and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
+         receive_ipc thread cap is_blocking
+         \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding receive_ipc_def thread_get_def including no_pre
-  apply(wp)
-   apply(simp add: split_def)
-   apply(wp set_simple_ko_globals_equiv set_thread_state_globals_equiv
+  apply (wp)
+   apply (simp add: split_def)
+   apply (wp set_simple_ko_globals_equiv set_thread_state_globals_equiv
              setup_caller_cap_globals_equiv dxo_wp_weak as_user_globals_equiv
-       | wpc
-       | simp split del: if_split)+
-             apply (rule hoare_strengthen_post[where Q= "\<lambda>_. globals_equiv st and valid_ko_at_arm and valid_global_objs"])
+          | wpc
+          | simp split del: if_split)+
+             apply (rule hoare_strengthen_post[where Q= "\<lambda>_. globals_equiv st and valid_ko_at_arch
+                                                                              and valid_global_objs"])
               apply (wp do_ipc_transfer_globals_equiv as_user_globals_equiv)
              apply clarsimp
             apply (wp gts_wp get_simple_ko_sp | wpc)+
           apply (wp hoare_vcg_all_lift hoare_drop_imps)[1]
-           apply(wp set_simple_ko_globals_equiv | wpc)+
-       apply(wp set_thread_state_globals_equiv)
+           apply (wp set_simple_ko_globals_equiv | wpc)+
+       apply (wp set_thread_state_globals_equiv)
       apply (wp get_simple_ko_wp gbn_wp get_simple_ko_wp as_user_globals_equiv | wpc | simp)+
   apply (rule hoare_pre)
-   apply(wpc)
-              apply(rule fail_wp | rule return_wp)+
-  by (auto intro: valid_arch_state_ko_at_arm valid_ep_send_enqueue
-          simp: neq_Nil_conv cong: case_list_cons_cong)
+   apply (wpc)
+              apply (rule fail_wp | rule return_wp)+
+  by (auto intro: valid_arch_state_ko_at_arch valid_ep_send_enqueue
+            simp: neq_Nil_conv cong: case_list_cons_cong)
+
+end
 
 
 subsection "Notifications"
 
 lemma valid_ntfn_dequeue:
-  "\<lbrakk> ko_at (Notification ntfn) ntfnptr s; ntfn_obj ntfn = (WaitingNtfn (t # ts));
-     valid_objs s; ts \<noteq> []\<rbrakk>
+  "\<lbrakk> ko_at (Notification ntfn) ntfnptr s;
+     ntfn_obj ntfn = (WaitingNtfn (t # ts)); valid_objs s; ts \<noteq> [] \<rbrakk>
      \<Longrightarrow> valid_ntfn ntfn s"
   unfolding valid_objs_def valid_obj_def valid_ntfn_def obj_at_def
   apply (drule bspec)
   apply (auto split: list.splits)
   done
 
-
 (* FIXME: NTFN OBJECT CHANGED *)
-
 lemma update_waiting_ntfn_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_objs and valid_arch_state and valid_global_refs and ko_at (Notification ntfn) ntfnptr and pspace_distinct and sym_refs \<circ> state_refs_of and (\<lambda>s. idle_thread s \<notin> set queue) and K (ntfn_obj ntfn = WaitingNtfn queue)\<rbrace>
-    update_waiting_ntfn ntfnptr queue bound_tcb badge
-    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  "\<lbrace>globals_equiv s and valid_objs and valid_arch_state and valid_global_refs
+                    and ko_at (Notification ntfn) ntfnptr and pspace_distinct
+                    and sym_refs \<circ> state_refs_of and (\<lambda>s. idle_thread s \<notin> set queue)
+                    and K (ntfn_obj ntfn = WaitingNtfn queue)\<rbrace>
+   update_waiting_ntfn ntfnptr queue bound_tcb badge
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding update_waiting_ntfn_def
-  apply(wp)
-    apply(simp add: split_def)
-    apply(wp set_thread_state_globals_equiv as_user_globals_equiv
-             set_notification_globals_equiv set_notification_valid_ko_at_arm
-             dxo_wp_weak | simp)+
-  by (auto intro: valid_arch_state_ko_at_arm simp: neq_Nil_conv)
-
-lemma
-  blocked_cancel_ipc_globals_equiv[wp]:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm\<rbrace> blocked_cancel_ipc a b \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding blocked_cancel_ipc_def
-  by (wp set_thread_state_globals_equiv set_simple_ko_globals_equiv | wpc | simp)+
-
-
-
+  supply possible_switch_to_extended.dxo_eq[simp del]
+  apply (wpsimp wp: set_thread_state_globals_equiv as_user_globals_equiv
+                    set_notification_globals_equiv dxo_wp_weak)
+  by (auto intro: valid_arch_state_ko_at_arch simp: neq_Nil_conv)
 
 lemma cancel_ipc_blocked_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm and st_tcb_at receive_blocked a\<rbrace>
-    cancel_ipc a \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  "\<lbrace>globals_equiv st and valid_ko_at_arch and st_tcb_at receive_blocked a\<rbrace>
+   cancel_ipc a
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding cancel_ipc_def
   apply (rule hoare_seq_ext[OF _ gts_sp])
   apply (rule hoare_pre)
-  apply (wpc; (simp,rule blocked_cancel_ipc_globals_equiv)?)
-  apply (rule hoare_pre_cont)+
+   apply (wpc; (simp,rule blocked_cancel_ipc_globals_equiv)?)
+        apply (rule hoare_pre_cont)+
   apply clarsimp
   apply (case_tac state;(clarsimp simp: pred_tcb_at_def obj_at_def receive_blocked_def))
   by (simp add: eq_commute)
 
-
-crunch globals_equiv[wp]: possible_switch_to "globals_equiv (st :: det_ext state)"
+crunch globals_equiv[wp]: possible_switch_to "globals_equiv st"
   (wp: tcb_sched_action_extended.globals_equiv reschedule_required_ext_extended.globals_equiv
    ignore_del: possible_switch_to)
 
 lemma send_signal_globals_equiv:
-  "\<lbrace>globals_equiv (s :: det_ext state) and valid_objs and valid_arch_state
-     and valid_global_refs and sym_refs \<circ> state_refs_of and
-     pspace_distinct and valid_idle\<rbrace> send_signal ntfnptr badge
-    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  "\<lbrace>globals_equiv s and valid_objs and valid_arch_state and valid_global_refs
+                    and sym_refs \<circ> state_refs_of and pspace_distinct and valid_idle\<rbrace>
+   send_signal ntfnptr badge
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding send_signal_def
-  apply (wp set_notification_globals_equiv
-            possible_switch_to_globals_equiv
-            set_thread_state_globals_equiv
-            as_user_globals_equiv
-            cancel_ipc_blocked_globals_equiv
-            update_waiting_ntfn_globals_equiv
-            get_simple_ko_wp
-            gts_wp
-       | wpc
-       | simp)+
+  apply (wp set_notification_globals_equiv possible_switch_to_globals_equiv
+            set_thread_state_globals_equiv as_user_globals_equiv cancel_ipc_blocked_globals_equiv
+            update_waiting_ntfn_globals_equiv get_simple_ko_wp gts_wp
+         | wpc | simp)+
   apply clarsimp
   apply (frule (1) sym_refs_ko_atD)
   apply (intro allI impI conjI)
            prefer 8
            apply clarsimp
            apply (frule_tac t="idle_thread sa" and P="\<lambda>ref. \<not> idle ref" in ntfn_queued_st_tcb_at')
-               by (auto intro: valid_arch_state_ko_at_arm
-                         simp: pred_tcb_at_def obj_at_def valid_idle_def receive_blocked_def)
+  by (auto intro: valid_arch_state_ko_at_arch
+            simp: pred_tcb_at_def obj_at_def valid_idle_def receive_blocked_def)
 
-(*FIXME: belongs in Arch_IF*)
 
+(* FIXME: belongs in Arch_IF *)
 lemma receive_signal_globals_equiv:
   "\<lbrace>globals_equiv s and valid_objs and valid_arch_state and valid_global_refs
-     and pspace_distinct and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
-     receive_signal thread cap is_blocking
-    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+                    and pspace_distinct and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
+   receive_signal thread cap is_blocking
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding receive_signal_def fun_app_def do_nbrecv_failed_transfer_def
   apply (rule hoare_pre)
-  apply(wp set_notification_globals_equiv set_thread_state_globals_equiv
-           as_user_globals_equiv get_simple_ko_wp
-       | wpc)+
-   apply(simp add: valid_arch_state_ko_at_arm)
+   apply (wp set_notification_globals_equiv set_thread_state_globals_equiv
+             as_user_globals_equiv get_simple_ko_wp
+          | wpc)+
+  apply (simp add: valid_arch_state_ko_at_arch)
   done
-
-lemma set_object_valid_global_refs:
-  "\<lbrace>valid_global_refs and
-      (\<lambda>s. \<forall>b. (\<forall>sz fun. obj=CNode sz fun \<longrightarrow> well_formed_cnode_n sz fun \<longrightarrow>
-        (\<forall>cap. fun b = Some cap \<longrightarrow> global_refs s \<inter> cap_range cap = {})) \<and>
-      (\<forall>tcb. obj = (TCB tcb) \<longrightarrow> (\<forall>get. (\<forall>set restr. tcb_cap_cases b \<noteq> Some (get, set, restr) \<or>
-        global_refs s \<inter> cap_range(get tcb) = {}))))\<rbrace>
-    set_object ptr obj
-    \<lbrace>\<lambda>_. valid_global_refs\<rbrace>"
-  unfolding valid_global_refs_def valid_refs_def
-  apply (wpsimp wp: set_object_wp simp: cte_wp_at_cases)
-  apply (erule_tac x=b in allE)
-  apply (erule_tac x=get in allE)
-  apply (simp)
-  done
-
-
-lemma send_fault_ipc_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
-    and pspace_distinct and pspace_aligned
-    and valid_global_objs and valid_idle and (\<lambda>s. sym_refs (state_refs_of s)) and K (valid_fault fault)\<rbrace>
-    send_fault_ipc tptr fault
-    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding send_fault_ipc_def
-  apply(wp)
-    apply(simp add: Let_def)
-    apply(wp send_ipc_globals_equiv thread_set_globals_equiv thread_set_valid_objs'' thread_set_fault_valid_global_refs thread_set_valid_idle_trivial thread_set_refs_trivial | wpc | simp)+
-   apply(rule_tac Q'="\<lambda>_. globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
-        and pspace_distinct and pspace_aligned and
-        valid_global_objs and K (valid_fault fault) and valid_idle and (\<lambda>s. sym_refs (state_refs_of s))"
-        in hoare_post_imp_R)
-    apply(wp | simp)+
-   apply(clarsimp simp: valid_arch_state_ko_at_arm)
-   apply(rule valid_tcb_fault_update)
-    apply(wp | simp)+
-    done
 
 lemma handle_double_fault_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm\<rbrace>
-     handle_double_fault tptr ex1 ex2
+  "\<lbrace>globals_equiv s and valid_ko_at_arch\<rbrace>
+   handle_double_fault tptr ex1 ex2
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding handle_double_fault_def
   by (wp set_thread_state_globals_equiv)
 
 lemma send_ipc_valid_global_objs:
-  "\<lbrace>valid_global_objs \<rbrace>
-     send_ipc block call badge can_grant can_grant_reply thread epptr
+  "\<lbrace>valid_global_objs\<rbrace>
+   send_ipc block call badge can_grant can_grant_reply thread epptr
    \<lbrace>\<lambda>_. valid_global_objs\<rbrace>"
   unfolding send_ipc_def
   by (wp dxo_wp_weak hoare_drop_imps hoare_vcg_all_lift | simp | wpc | intro conjI impI)+
 
 lemma send_fault_ipc_valid_global_objs:
-  "\<lbrace>valid_global_objs \<rbrace> send_fault_ipc tptr fault
-    \<lbrace>\<lambda>_. valid_global_objs\<rbrace>"
+  "send_fault_ipc tptr fault \<lbrace>valid_global_objs\<rbrace>"
   unfolding send_fault_ipc_def
-  apply(wp)
-     apply(simp add: Let_def)
-     apply(wp send_ipc_valid_global_objs | wpc)+
-    apply(rule_tac Q'="\<lambda>_. valid_global_objs" in hoare_post_imp_R)
-     apply(wp | simp)+
+  apply (wp)
+     apply (simp add: Let_def)
+     apply (wp send_ipc_valid_global_objs | wpc)+
+    apply (rule_tac Q'="\<lambda>_. valid_global_objs" in hoare_post_imp_R)
+     apply (wp | simp)+
   done
 
-crunch valid_ko_at_arm[wp]: send_ipc "valid_ko_at_arm"
+crunch valid_ko_at_arch[wp]: send_ipc "valid_ko_at_arch"
   (wp: hoare_drop_imps hoare_vcg_if_lift2 dxo_wp_weak)
 
-lemma send_fault_ipc_valid_ko_at_arm[wp]:
-  "invariant (send_fault_ipc a b) valid_ko_at_arm"
+lemma send_fault_ipc_valid_ko_at_arch[wp]:
+  "send_fault_ipc a b \<lbrace>valid_ko_at_arch\<rbrace>"
   unfolding send_fault_ipc_def
   apply wp
-    apply(simp add: Let_def)
-    apply (wp send_ipc_valid_ko_at_arm | wpc)+
-   apply(rule_tac Q'="\<lambda>_. valid_ko_at_arm" in hoare_post_imp_R)
-  apply (wp | simp)+
-done
+     apply (simp add: Let_def)
+     apply (wp send_ipc_valid_ko_at_arch | wpc)+
+    apply (rule_tac Q'="\<lambda>_. valid_ko_at_arch" in hoare_post_imp_R)
+     apply (wp | simp)+
+  done
+
+
+context Ipc_IF_1 begin
+
+lemma send_fault_ipc_globals_equiv:
+  "\<lbrace>globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
+                    and pspace_distinct and pspace_aligned and valid_global_objs
+                    and valid_idle and (\<lambda>s. sym_refs (state_refs_of s)) and K (valid_fault fault)\<rbrace>
+   send_fault_ipc tptr fault
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding send_fault_ipc_def
+  apply (wp)
+     apply (simp add: Let_def)
+     apply (wp send_ipc_globals_equiv thread_set_globals_equiv thread_set_valid_objs''
+               thread_set_fault_valid_global_refs thread_set_valid_idle_trivial thread_set_refs_trivial
+            | wpc | simp)+
+    apply (rule_tac Q'="\<lambda>_. globals_equiv st and valid_objs and valid_arch_state and
+                            valid_global_refs and pspace_distinct and pspace_aligned and
+                            valid_global_objs and K (valid_fault fault) and valid_idle and
+                            (\<lambda>s. sym_refs (state_refs_of s))" in hoare_post_imp_R)
+     apply (wp | simp)+
+    apply (clarsimp simp: valid_arch_state_ko_at_arch)
+    apply (rule valid_tcb_fault_update)
+     apply (wp | simp)+
+  done
 
 lemma handle_fault_globals_equiv:
   "\<lbrace>globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
-       and pspace_distinct and pspace_aligned
-       and valid_global_objs and valid_idle and (\<lambda>s. sym_refs (state_refs_of s))
-       and K (valid_fault ex)\<rbrace>
-     handle_fault thread ex
+                     and pspace_distinct and pspace_aligned and valid_global_objs
+                     and valid_idle and (\<lambda>s. sym_refs (state_refs_of s)) and K (valid_fault ex)\<rbrace>
+   handle_fault thread ex
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding handle_fault_def
-  apply(wp handle_double_fault_globals_equiv)
-   apply(rule_tac Q="\<lambda>_. globals_equiv st and valid_ko_at_arm" and
-             E="\<lambda>_. globals_equiv st and valid_ko_at_arm" in hoare_post_impErr)
-     apply(wp send_fault_ipc_globals_equiv
-          | simp add: valid_arch_state_ko_at_arm)+
-     done
-
+  apply (wp handle_double_fault_globals_equiv)
+    apply (rule_tac Q="\<lambda>_. globals_equiv st and valid_ko_at_arch" and
+                    E="\<lambda>_. globals_equiv st and valid_ko_at_arch" in hoare_post_impErr)
+      apply (wp send_fault_ipc_globals_equiv | simp add: valid_arch_state_ko_at_arch)+
+  done
 
 lemma handle_fault_reply_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
-      handle_fault_reply fault thread x y
+  "\<lbrace>globals_equiv st and valid_ko_at_arch and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
+   handle_fault_reply fault thread x y
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply(case_tac fault)
-     apply(wp as_user_globals_equiv | simp add: handle_arch_fault_reply_def)+
-     done
+  by (cases fault; wpsimp wp: as_user_globals_equiv handle_arch_fault_reply_globals_equiv)
 
-crunch valid_global_objs: handle_fault_reply "valid_global_objs"
+crunch valid_global_objs: handle_fault_reply "\<lambda>s :: det_state. valid_global_objs s"
 
 lemma do_reply_transfer_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_objs and valid_arch_state and valid_global_refs and pspace_distinct
-       and pspace_aligned and valid_global_objs and valid_idle\<rbrace>
-     do_reply_transfer sender receiver slot grant
+  "\<lbrace>globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
+                     and pspace_distinct and pspace_aligned and valid_global_objs and valid_idle\<rbrace>
+   do_reply_transfer sender receiver slot grant
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding do_reply_transfer_def
-  apply(wp set_thread_state_globals_equiv cap_delete_one_globals_equiv do_ipc_transfer_globals_equiv
-           thread_set_globals_equiv handle_fault_reply_globals_equiv dxo_wp_weak
-       | wpc
-       | simp split del: if_split)+
-    apply(rule_tac Q="\<lambda>_. globals_equiv st and valid_ko_at_arm and valid_objs and valid_arch_state
-                          and valid_global_refs and pspace_distinct and pspace_aligned
-                          and valid_global_objs and (\<lambda>s. receiver \<noteq> idle_thread s) and valid_idle"
-                in hoare_strengthen_post)
-    apply (wp gts_wp
-          | fastforce simp: valid_arch_state_ko_at_arm pred_tcb_at_def obj_at_def valid_idle_def)+
-    done
+  apply (wp set_thread_state_globals_equiv cap_delete_one_globals_equiv do_ipc_transfer_globals_equiv
+            thread_set_globals_equiv handle_fault_reply_globals_equiv dxo_wp_weak
+         | wpc | simp split del: if_split)+
+     apply (rule_tac Q="\<lambda>_. globals_equiv st and valid_ko_at_arch and valid_objs and valid_arch_state
+                                             and valid_global_refs and pspace_distinct
+                                             and pspace_aligned and valid_global_objs
+                                             and (\<lambda>s. receiver \<noteq> idle_thread s) and valid_idle"
+                  in hoare_strengthen_post)
+      apply (wp gts_wp
+             | fastforce simp: valid_arch_state_ko_at_arch pred_tcb_at_def obj_at_def valid_idle_def)+
+  done
 
 lemma handle_reply_globals_equiv:
   "\<lbrace>globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
-       and pspace_distinct and pspace_aligned and valid_global_objs and valid_idle\<rbrace>
-     handle_reply
+                     and pspace_distinct and pspace_aligned and valid_global_objs and valid_idle\<rbrace>
+   handle_reply
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding handle_reply_def
-  apply(wp do_reply_transfer_globals_equiv | wpc)+
-   apply(rule_tac Q="\<lambda>_. globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
-        and pspace_distinct and pspace_aligned and valid_global_objs and valid_idle"
-        in hoare_strengthen_post)
-    apply(wp | simp)+
-    done
+  apply (wp do_reply_transfer_globals_equiv | wpc)+
+    apply (rule_tac Q="\<lambda>_. globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
+                                            and pspace_distinct and pspace_aligned
+                                            and valid_global_objs and valid_idle"
+                 in hoare_strengthen_post)
+     apply (wp | simp)+
+  done
+
+end
+
 
 lemma reply_from_kernel_globals_equiv:
   "\<lbrace>globals_equiv s and valid_objs and valid_arch_state and valid_global_refs and pspace_distinct
-       and pspace_aligned and  (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
-     reply_from_kernel thread x
+                    and pspace_aligned and  (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
+   reply_from_kernel thread x
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding reply_from_kernel_def
-  apply(wp set_message_info_globals_equiv set_mrs_globals_equiv
+  apply (wp set_message_info_globals_equiv set_mrs_globals_equiv
            as_user_globals_equiv | simp add: split_def)+
-  apply(insert length_msg_lt_msg_max)
-  apply(simp add: valid_arch_state_ko_at_arm)
+  apply (insert length_msg_lt_msg_max)
+  apply (simp add: valid_arch_state_ko_at_arch)
   done
+
 
 section "reads_respects_g"
 
 subsection "Notifications"
 
+context Ipc_IF_1 begin
+
 lemma send_signal_reads_respects_g:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "reads_respects_g aag l (pas_refined aag and pas_cur_domain aag and valid_etcbs and
-                           pspace_aligned and valid_vspace_objs and valid_arch_state and
-                           valid_objs and valid_global_objs and valid_arch_state and
-                           valid_global_refs and pspace_distinct and valid_idle and ct_active and
-                           sym_refs \<circ> state_refs_of and is_subject aag \<circ> cur_thread and
-                           K ((pasSubject aag, Notify, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag))
-                          (send_signal ntfnptr badge)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_g])
-    apply(rule send_signal_reads_respects[OF domains_distinct])
-   apply(rule doesnt_touch_globalsI)
-   apply(wp send_signal_globals_equiv | simp)+
+  "reads_respects_g aag l
+     (pas_refined aag and pas_cur_domain aag and valid_etcbs and pspace_aligned
+                      and valid_vspace_objs and valid_arch_state and valid_objs
+                      and valid_global_objs and valid_arch_state and valid_global_refs
+                      and pspace_distinct and valid_idle and ct_active
+                      and sym_refs \<circ> state_refs_of and is_subject aag \<circ> cur_thread
+                      and K ((pasSubject aag, Notify, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag))
+     (send_signal ntfnptr badge)"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule send_signal_reads_respects[OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp send_signal_globals_equiv | simp)+
   done
+
+end
+
 
 lemma receive_signal_reads_respects_g:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "reads_respects_g aag l (valid_global_objs and valid_objs and valid_arch_state and valid_global_refs and pspace_distinct and pas_refined aag and (\<lambda>s. thread \<noteq> idle_thread s) and is_subject aag \<circ> cur_thread and K ((\<forall>ntfnptr\<in>Access.obj_refs cap.
-          (pasSubject aag, Receive, pasObjectAbs aag ntfnptr)
-          \<in> pasPolicy aag \<and>
-      is_subject aag thread))) (receive_signal thread cap is_blocking)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_g])
-    apply(rule receive_signal_reads_respects[OF domains_distinct])
-   apply(rule doesnt_touch_globalsI)
-   apply(wp receive_signal_globals_equiv | simp)+
+    "reads_respects_g aag (l :: 'a subject_label)
+       (valid_global_objs and valid_objs and valid_arch_state and valid_global_refs
+                          and pspace_distinct and pas_refined aag and (\<lambda>s. thread \<noteq> idle_thread s)
+                          and is_subject aag \<circ> cur_thread
+                          and K (\<forall>nptr\<in>Access.obj_refs cap.
+                                   (pasSubject aag, Receive, pasObjectAbs aag nptr) \<in> pasPolicy aag
+                                 \<and> is_subject aag thread))
+       (receive_signal thread cap is_blocking)"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule receive_signal_reads_respects[OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp receive_signal_globals_equiv | simp)+
   done
 
-subsection "Sycn IPC"
+
+context Ipc_IF_2 begin
+
+subsection "Sync IPC"
 
 lemma send_ipc_reads_respects_g:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "reads_respects_g aag l (pas_refined aag and pas_cur_domain aag and invs
-         and is_subject aag \<circ> cur_thread
-         and (\<lambda> s. (can_grant \<longrightarrow> aag_has_auth_to aag Grant epptr))
-         and K (is_subject aag thread \<and> aag_has_auth_to aag SyncSend epptr))
-  (send_ipc block call badge can_grant can_grant_reply thread epptr)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_g])
-    apply(rule send_ipc_reads_respects[OF domains_distinct])
-   apply(rule doesnt_touch_globalsI)
-   apply(wp send_ipc_globals_equiv | simp)+
+    "reads_respects_g aag l
+       (pas_refined aag and pas_cur_domain aag and invs and is_subject aag \<circ> cur_thread
+                        and (\<lambda>s. (can_grant \<longrightarrow> aag_has_auth_to aag Grant epptr))
+                        and K (is_subject aag thread \<and> aag_has_auth_to aag SyncSend epptr))
+       (send_ipc block call badge can_grant can_grant_reply thread epptr)"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule send_ipc_reads_respects[OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp send_ipc_globals_equiv | simp)+
   by fastforce
 
 lemma receive_ipc_reads_respects_g:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "reads_respects_g aag l (invs and (\<lambda>s. receiver \<noteq> idle_thread s) and pas_refined aag
-         and pas_cur_domain aag and valid_cap cap and is_subject aag \<circ> cur_thread
-         and K (is_subject aag receiver \<and> pas_cap_cur_auth aag cap \<and> AllowRead \<in> cap_rights cap))
-   (receive_ipc receiver cap is_blocking)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_g])
-    apply(rule receive_ipc_reads_respects[OF domains_distinct])
-   apply(rule doesnt_touch_globalsI)
-   apply(wp receive_ipc_globals_equiv | simp)+
+    "reads_respects_g aag l
+       (invs and (\<lambda>s. receiver \<noteq> idle_thread s) and pas_refined aag
+             and pas_cur_domain aag and valid_cap cap and is_subject aag \<circ> cur_thread
+             and K (is_subject aag receiver \<and> pas_cap_cur_auth aag cap \<and> AllowRead \<in> cap_rights cap))
+       (receive_ipc receiver cap is_blocking)"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule receive_ipc_reads_respects[OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp receive_ipc_globals_equiv | simp)+
   by fastforce
-
 
 subsection "Faults"
 
 lemma send_fault_ipc_reads_respects_g:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "reads_respects_g aag l (invs and pas_refined aag and pas_cur_domain aag
+  "reads_respects_g aag l
+   (invs and pas_refined aag and pas_cur_domain aag
          and is_subject aag \<circ> cur_thread and K (is_subject aag thread \<and> valid_fault fault))
      (send_fault_ipc thread fault)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_g])
-    apply(rule send_fault_ipc_reads_respects[OF domains_distinct])
-   apply(rule doesnt_touch_globalsI)
-   apply(wp send_fault_ipc_globals_equiv | simp)+
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule send_fault_ipc_reads_respects[OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp send_fault_ipc_globals_equiv | simp)+
   by fastforce
-
 
 lemma handle_fault_reads_respects_g:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "reads_respects_g aag l (invs and pas_refined aag and pas_cur_domain aag
-         and is_subject aag \<circ> cur_thread and K (is_subject aag thread \<and> valid_fault fault))
-     (handle_fault thread fault)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_g])
-    apply(rule handle_fault_reads_respects[OF domains_distinct])
-   apply(rule doesnt_touch_globalsI)
-   apply(wp handle_fault_globals_equiv | simp)+
+    "reads_respects_g aag l
+       (invs and pas_refined aag and pas_cur_domain aag
+             and is_subject aag \<circ> cur_thread and K (is_subject aag thread \<and> valid_fault fault))
+       (handle_fault thread fault)"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule handle_fault_reads_respects[OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp handle_fault_globals_equiv | simp)+
   by fastforce
 
 subsection "Replies"
 
 lemma handle_fault_reply_reads_respects_g:
-  "reads_respects_g aag l (valid_ko_at_arm and (\<lambda>s. thread \<noteq> idle_thread s) and K (is_subject aag thread)) (handle_fault_reply fault thread x y)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_g])
-    apply(rule handle_fault_reply_reads_respects)
-   apply(rule doesnt_touch_globalsI)
-   apply(wp handle_fault_reply_globals_equiv | simp)+
+  "reads_respects_g aag l
+     (valid_ko_at_arch and (\<lambda>s. thread \<noteq> idle_thread s) and K (is_subject aag thread))
+     (handle_fault_reply fault thread x y)"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule handle_fault_reply_reads_respects)
+   apply (rule doesnt_touch_globalsI)
+   apply (wp handle_fault_reply_globals_equiv | simp)+
   done
 
 lemma do_reply_transfer_reads_respects_f_g:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "reads_respects_f_g aag l (silc_inv aag st and invs and pas_refined aag and pas_cur_domain aag
-         and tcb_at receiver and tcb_at sender and emptyable slot and is_subject aag \<circ> cur_thread
-          and K (grant \<longrightarrow> is_subject aag receiver)
-         and K (is_subject aag sender \<and> aag_can_read aag receiver \<and> is_subject aag (fst slot)))
-     (do_reply_transfer sender receiver slot grant)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_f_g])
-    apply(rule do_reply_transfer_reads_respects_f[OF domains_distinct])
-   apply(rule doesnt_touch_globalsI)
-   apply(wp do_reply_transfer_globals_equiv | simp)+
-  apply(simp add: invs_def valid_state_def valid_pspace_def | blast)+
+    "reads_respects_f_g aag l (silc_inv aag st and invs and pas_refined aag and pas_cur_domain aag
+                                               and tcb_at receiver and tcb_at sender
+                                               and emptyable slot and is_subject aag \<circ> cur_thread
+                                               and K (grant \<longrightarrow> is_subject aag receiver)
+                                               and K (is_subject aag sender \<and>
+                                                      aag_can_read aag receiver \<and>
+                                                      is_subject aag (fst slot)))
+                        (do_reply_transfer sender receiver slot grant)"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_f_g])
+    apply (rule do_reply_transfer_reads_respects_f[OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp do_reply_transfer_globals_equiv | simp)+
+  apply (simp add: invs_def valid_state_def valid_pspace_def | blast)+
   done
 
 lemma handle_reply_reads_respects_g:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "reads_respects_f_g aag l (silc_inv aag st and invs and
-        pas_refined aag and pas_cur_domain aag and
-        is_subject aag \<circ> cur_thread) (handle_reply)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_f_g])
-    apply(rule handle_reply_reads_respects_f[OF domains_distinct])
-   apply(rule doesnt_touch_globalsI)
-   apply(wp handle_reply_globals_equiv | simp)+
-  apply(simp add: invs_def valid_state_def valid_pspace_def | blast)+
+    "reads_respects_f_g aag l (silc_inv aag st and invs and pas_refined aag and pas_cur_domain aag
+                                               and is_subject aag \<circ> cur_thread) (handle_reply)"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_f_g])
+    apply (rule handle_reply_reads_respects_f[OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp handle_reply_globals_equiv | simp)+
+  apply (simp add: invs_def valid_state_def valid_pspace_def | blast)+
   done
 
 lemma reply_from_kernel_reads_respects_g:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "reads_respects_g aag l (valid_global_objs and
-        valid_objs and valid_arch_state and valid_global_refs and pspace_distinct
-        and pspace_aligned and (\<lambda>s. thread \<noteq> idle_thread s) and K (is_subject aag thread)) (reply_from_kernel thread x)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_g])
-    apply(rule reply_from_kernel_reads_respects[OF domains_distinct])
-   apply(rule doesnt_touch_globalsI)
-   apply(wp reply_from_kernel_globals_equiv | simp)+
+    "reads_respects_g aag l (valid_global_objs and valid_objs and valid_arch_state
+                                               and valid_global_refs and pspace_distinct
+                                               and pspace_aligned and (\<lambda>s. thread \<noteq> idle_thread s)
+                                               and K (is_subject aag thread))
+                      (reply_from_kernel thread x)"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule reply_from_kernel_reads_respects[OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp reply_from_kernel_globals_equiv | simp)+
   done
+
+lemmas lookup_ipc_buffer_reads_respects_g =
+  reads_respects_g_from_inv[OF lookup_ipc_buffer_reads_respects lookup_ipc_buffer_inv]
 
 end
 

--- a/proof/infoflow/Noninterference.thy
+++ b/proof/infoflow/Noninterference.thy
@@ -8,8 +8,8 @@ theory Noninterference
 imports
   Noninterference_Base
   Noninterference_Base_Alternatives
-  Scheduler_IF
-  ADT_IF
+  ArchScheduler_IF
+  ArchADT_IF
   Access.ArchADT_AC
 begin
 
@@ -31,94 +31,78 @@ holds in integrity_part.
 
 \<close>
 
-context begin interpretation Arch . (*FIXME: arch_split*)
-
 section \<open>sameFor : unwinding relation\<close>
 
 datatype 'a partition = Partition 'a | PSched
 
-
 fun scheduler_modes where
-  "scheduler_modes KernelPreempted = True" |
-  "scheduler_modes (KernelEntry Interrupt) = True" |
-  "scheduler_modes (KernelSchedule b) = b" |
-  "scheduler_modes _ = False"
+  "scheduler_modes KernelPreempted = True"
+| "scheduler_modes (KernelEntry Interrupt) = True"
+| "scheduler_modes (KernelSchedule b) = b"
+| "scheduler_modes _ = False"
 
 (*Modes where thread context is valid*)
 fun user_modes where
-  "user_modes KernelExit = False" |
-  "user_modes _ = True"
+  "user_modes KernelExit = False"
+| "user_modes _ = True"
 
-definition sameFor_subject
-  :: "'a subject_label auth_graph \<Rightarrow> 'a subject_label agent_map \<Rightarrow>
-      'a subject_label agent_irq_map \<Rightarrow> 'a subject_label agent_asid_map  \<Rightarrow>
-      'a subject_label agent_domain_map \<Rightarrow> 'a \<Rightarrow> (observable_if \<times> observable_if) set"
-where
+definition sameFor_subject ::
+  "'a subject_label auth_graph \<Rightarrow> 'a subject_label agent_map \<Rightarrow>
+   'a subject_label agent_irq_map \<Rightarrow> 'a subject_label agent_asid_map  \<Rightarrow>
+   'a subject_label agent_domain_map \<Rightarrow> 'a \<Rightarrow> (observable_if \<times> observable_if) set" where
   "sameFor_subject g ab irqab asidab domainab l \<equiv>
-    {(os,os') | os os' s s'.
-             s = internal_state_if os \<and>
-             s' = internal_state_if os' \<and>
-             states_equiv_for
-                 (\<lambda>x. ab x \<in> subjectReads g (OrdinaryLabel l))
-                 (\<lambda>x. irqab x \<in> subjectReads g (OrdinaryLabel l))
-                 (\<lambda>x. asidab x \<in> subjectReads g (OrdinaryLabel l))
-                 (\<lambda>x. domainab x \<inter> subjectReads g (OrdinaryLabel l) \<noteq> {})
-                 s s' \<and>
-             ((domainab (cur_domain s) \<inter> subjectReads g (OrdinaryLabel l) \<noteq> {} \<or>
-                   domainab (cur_domain s') \<inter> subjectReads g (OrdinaryLabel l) \<noteq> {}) \<longrightarrow>
-                (cur_domain s = cur_domain s' \<and> globals_equiv s s' \<and>
-                scheduler_action s = scheduler_action s' \<and>
-                work_units_completed s = work_units_completed s' \<and>
-                irq_state (machine_state s) = irq_state (machine_state s') \<and>
-                (user_modes (sys_mode_of os) \<longrightarrow>
-                   user_context_of os = user_context_of os') \<and>
-                   sys_mode_of os = sys_mode_of os' \<and>
-                   equiv_for (\<lambda> x. ab x = SilcLabel) kheap s s'))}"
+     {(os,os') | os os' s s'.
+        s = internal_state_if os \<and> s' = internal_state_if os' \<and>
+        states_equiv_for (\<lambda>x. ab x \<in> subjectReads g (OrdinaryLabel l))
+                         (\<lambda>x. irqab x \<in> subjectReads g (OrdinaryLabel l))
+                         (\<lambda>x. asidab x \<in> subjectReads g (OrdinaryLabel l))
+                         (\<lambda>x. domainab x \<inter> subjectReads g (OrdinaryLabel l) \<noteq> {}) s s' \<and>
+        ((domainab (cur_domain s) \<inter> subjectReads g (OrdinaryLabel l) \<noteq> {} \<or>
+          domainab (cur_domain s') \<inter> subjectReads g (OrdinaryLabel l) \<noteq> {})
+          \<longrightarrow> (cur_domain s = cur_domain s' \<and> globals_equiv s s' \<and>
+               scheduler_action s = scheduler_action s' \<and>
+               work_units_completed s = work_units_completed s' \<and>
+               irq_state (machine_state s) = irq_state (machine_state s') \<and>
+               (user_modes (sys_mode_of os) \<longrightarrow> user_context_of os = user_context_of os') \<and>
+               sys_mode_of os = sys_mode_of os' \<and> equiv_for (\<lambda>x. ab x = SilcLabel) kheap s s'))}"
 
-definition sameFor_scheduler
-  :: "'a subject_label auth_graph \<Rightarrow> 'a subject_label agent_map \<Rightarrow>
-      'a subject_label agent_irq_map \<Rightarrow> 'a subject_label agent_asid_map \<Rightarrow>
-      'a subject_label agent_domain_map \<Rightarrow> (observable_if \<times> observable_if) set"
-where
+definition sameFor_scheduler ::
+   "'a subject_label auth_graph \<Rightarrow> 'a subject_label agent_map \<Rightarrow>
+    'a subject_label agent_irq_map \<Rightarrow> 'a subject_label agent_asid_map \<Rightarrow>
+    'a subject_label agent_domain_map \<Rightarrow> (observable_if \<times> observable_if) set" where
   "sameFor_scheduler g ab irqab asidab domainab \<equiv>
    {(os,os') | os os' s s'.
-        s = internal_state_if os \<and>
-        s' = internal_state_if os' \<and>
-        domain_fields_equiv s s' \<and>
-        idle_thread s = idle_thread s' \<and>
-        globals_equiv_scheduler s s' \<and>
-        equiv_for (\<lambda> x. ab x = SilcLabel) kheap s s' \<and>
-        irq_state_of_state s = irq_state_of_state s' \<and>
-        scheduler_modes (sys_mode_of os) = scheduler_modes (sys_mode_of os') \<and>
-        interrupted_modes (sys_mode_of os) = interrupted_modes (sys_mode_of os')}"
+      s = internal_state_if os \<and> s' = internal_state_if os' \<and> domain_fields_equiv s s' \<and>
+      idle_thread s = idle_thread s' \<and> globals_equiv_scheduler s s' \<and>
+      equiv_for (\<lambda>x. ab x = SilcLabel) kheap s s' \<and> irq_state_of_state s = irq_state_of_state s' \<and>
+      scheduler_modes (sys_mode_of os) = scheduler_modes (sys_mode_of os') \<and>
+      interrupted_modes (sys_mode_of os) = interrupted_modes (sys_mode_of os')}"
 
 text \<open>
   From the graph we define an equivalence relation on states for each partition.
 
   This is the unwinding relation of domain d with the right parameters (cf uwr later in this file)
 \<close>
-definition sameFor
-  :: "'a subject_label auth_graph \<Rightarrow> 'a subject_label agent_map \<Rightarrow>
-      'a subject_label agent_irq_map \<Rightarrow> 'a subject_label agent_asid_map \<Rightarrow>
-      'a subject_label agent_domain_map \<Rightarrow> 'a partition  \<Rightarrow> (observable_if \<times> observable_if) set"
-where
+definition sameFor ::
+  "'a subject_label auth_graph \<Rightarrow> 'a subject_label agent_map \<Rightarrow>
+   'a subject_label agent_irq_map \<Rightarrow> 'a subject_label agent_asid_map \<Rightarrow>
+   'a subject_label agent_domain_map \<Rightarrow> 'a partition \<Rightarrow> (observable_if \<times> observable_if) set" where
   "sameFor g ab irqab asidab domainab d \<equiv>
-                 case d of Partition l \<Rightarrow> sameFor_subject g ab irqab asidab domainab l |
-                           PSched \<Rightarrow> sameFor_scheduler g ab irqab asidab domainab"
+     case d of Partition l \<Rightarrow> sameFor_subject g ab irqab asidab domainab l
+             | PSched \<Rightarrow> sameFor_scheduler g ab irqab asidab domainab"
 
-abbreviation same_for
-where
+abbreviation same_for where
   "same_for aag d \<equiv> sameFor (pasPolicy aag) (pasObjectAbs aag) (pasIRQAbs aag)
-                                             (pasASIDAbs aag) (pasDomainAbs aag) d"
+                             (pasASIDAbs aag) (pasDomainAbs aag) d"
 
 text \<open>
   We want @{term sameFor} to be an equivalence relation always.
 \<close>
 lemma sameFor_refl: "refl (sameFor g ab irqab asidab domainab d)"
-  by(auto intro!: refl_onI equiv_for_refl
-               simp: sameFor_def sameFor_subject_def sameFor_scheduler_def domain_fields_equiv_def
-              split: partition.splits
-              intro: states_equiv_for_refl globals_equiv_refl globals_equiv_scheduler_refl)
+  by (auto intro!: refl_onI equiv_for_refl
+             simp: sameFor_def sameFor_subject_def sameFor_scheduler_def domain_fields_equiv_def
+            split: partition.splits
+            intro: states_equiv_for_refl globals_equiv_refl globals_equiv_scheduler_refl)
 
 lemma domain_fields_equiv_sym:
   "domain_fields_equiv s t \<Longrightarrow> domain_fields_equiv t s"
@@ -132,34 +116,35 @@ lemma sameFor_sym:
                 intro: states_equiv_for_sym globals_equiv_sym equiv_for_sym domain_fields_equiv_sym)
 
 lemma domain_fields_equiv_trans:
-  "domain_fields_equiv s t \<Longrightarrow> domain_fields_equiv t u \<Longrightarrow> domain_fields_equiv s u"
-  by(clarsimp simp: domain_fields_equiv_def)
+  "\<lbrakk> domain_fields_equiv s t; domain_fields_equiv t u \<rbrakk>
+     \<Longrightarrow> domain_fields_equiv s u"
+  by (clarsimp simp: domain_fields_equiv_def)
 
-lemma sameFor_trans: "trans (sameFor g ab irqab asidab domainab d)"
+lemma sameFor_trans:
+  "trans (sameFor g ab irqab asidab domainab d)"
   apply (rule transI)
   apply (auto simp: sameFor_def sameFor_subject_def sameFor_scheduler_def
              split: partition.splits
-             intro: states_equiv_for_trans globals_equiv_trans equiv_for_trans
-                    domain_fields_equiv_trans)
+             intro: states_equiv_for_trans globals_equiv_trans
+                    equiv_for_trans domain_fields_equiv_trans)
   done
 
 fun label_of where
   "label_of (OrdinaryLabel l) = l"
 
-lemma is_label [simp]: "\<lbrakk>x \<noteq> SilcLabel\<rbrakk> \<Longrightarrow> OrdinaryLabel (label_of x) = x"
-  by(case_tac x, auto)
+lemma is_label[simp]:
+  "x \<noteq> SilcLabel \<Longrightarrow> OrdinaryLabel (label_of x) = x"
+  by (case_tac x, auto)
 
 lemma pasSubject_not_SilcLabel:
   "silc_inv aag s s' \<Longrightarrow> pasSubject aag \<noteq> SilcLabel"
-  by(auto simp: silc_inv_def)
+  by (auto simp: silc_inv_def)
 
 (* needs silc_inv to ensure pasSubject is not SilcLabel *)
 lemma sameFor_reads_equiv_f_g:
-  "pasSubject aag \<in> pasDomainAbs aag (cur_domain s) \<or>
-   pasSubject aag \<in> pasDomainAbs aag (cur_domain s') \<Longrightarrow>
-   silc_inv aag st' st'' \<Longrightarrow>
-   reads_equiv_f_g aag s s' \<Longrightarrow>
-   (((uc,s),mode),((uc,s'),mode)) \<in> same_for aag (Partition (label_of (pasSubject aag)))"
+  "\<lbrakk> reads_equiv_f_g aag s s'; silc_inv aag st' st'';
+     pasSubject aag \<in> pasDomainAbs aag (cur_domain s) \<union> pasDomainAbs aag (cur_domain s') \<rbrakk>
+     \<Longrightarrow> (((uc,s),mode),((uc,s'),mode)) \<in> same_for aag (Partition (label_of (pasSubject aag)))"
   apply (clarsimp simp: reads_equiv_f_g_def reads_equiv_def2 sameFor_def silc_dom_equiv_def)
   apply (simp add: sameFor_subject_def)
   apply (frule pasSubject_not_SilcLabel)
@@ -167,135 +152,107 @@ lemma sameFor_reads_equiv_f_g:
   done
 
 lemma sameFor_reads_equiv_f_g':
-  "\<lbrakk>pas_cur_domain aag s \<or> pas_cur_domain aag s';
-   silc_inv aag st s;
-   (((uc,s),mode),((uc',s'),mode')) \<in> same_for aag (Partition (label_of (pasSubject aag)))\<rbrakk> \<Longrightarrow>
-  reads_equiv_f_g aag s s'"
+  "\<lbrakk> pas_cur_domain aag s \<or> pas_cur_domain aag s'; silc_inv aag st s;
+     (((uc,s),mode),((uc',s'),mode')) \<in> same_for aag (Partition (label_of (pasSubject aag))) \<rbrakk>
+     \<Longrightarrow> reads_equiv_f_g aag s s'"
   apply (frule pasSubject_not_SilcLabel)
-  apply (simp add: reads_equiv_f_g_def reads_equiv_def2 sameFor_def sameFor_subject_def
-                   silc_dom_equiv_def globals_equiv_def)
-  apply auto
+  apply (auto simp: reads_equiv_f_g_def reads_equiv_def2 sameFor_def
+                    sameFor_subject_def silc_dom_equiv_def globals_equiv_def)
   done
 
 lemma sameFor_scheduler_equiv:
-  "(s,s') \<in> same_for aag PSched \<Longrightarrow>
-   scheduler_equiv aag (internal_state_if s) (internal_state_if s')"
-  by(clarsimp simp: scheduler_equiv_def sameFor_def sameFor_scheduler_def silc_dom_equiv_def)
+  "(s,s') \<in> same_for aag PSched
+   \<Longrightarrow> scheduler_equiv aag (internal_state_if s) (internal_state_if s')"
+  by (clarsimp simp: scheduler_equiv_def sameFor_def sameFor_scheduler_def silc_dom_equiv_def)
 
 
 definition label_can_affect_partition where
-  "label_can_affect_partition g k l \<equiv> \<exists> d. d \<in> subjectAffects g k \<and> d \<in> subjectReads g l"
+  "label_can_affect_partition g k l \<equiv> \<exists>d. d \<in> subjectAffects g k \<and> d \<in> subjectReads g l"
 
 definition partsSubjectAffects where
   "partsSubjectAffects g l \<equiv>
-           Partition ` {x. label_can_affect_partition g (OrdinaryLabel l) (OrdinaryLabel x)}"
+     Partition ` {x. label_can_affect_partition g (OrdinaryLabel l) (OrdinaryLabel x)}"
 
 
 lemma reads_g_affects_equiv_sameFor:
-  "\<lbrakk>reads_equiv_f_g aag s s' \<and> affects_equiv aag (OrdinaryLabel l) s s';
-    pas_cur_domain aag s;
-    silc_inv aag st' st'';
-    Partition l \<in> partsSubjectAffects (pasPolicy aag) (label_of (pasSubject aag))\<rbrakk> \<Longrightarrow>
-   (((uc,s),mode),((uc,s'),mode)) \<in> same_for aag (Partition l)"
-  apply(clarsimp simp: partsSubjectAffects_def)
-  apply(simp add: affects_equiv_def2 sameFor_def sameFor_subject_def)
+  "\<lbrakk> reads_equiv_f_g aag s s' \<and> affects_equiv aag (OrdinaryLabel l) s s';
+     pas_cur_domain aag s; silc_inv aag st' st'';
+     Partition l \<in> partsSubjectAffects (pasPolicy aag) (label_of (pasSubject aag)) \<rbrakk>
+     \<Longrightarrow> (((uc,s),mode),((uc,s'),mode)) \<in> same_for aag (Partition l)"
+  apply (clarsimp simp: partsSubjectAffects_def)
+  apply (simp add: affects_equiv_def2 sameFor_def sameFor_subject_def)
   apply (frule pasSubject_not_SilcLabel)
-  apply(simp add: reads_equiv_f_g_def reads_equiv_def2 silc_dom_equiv_def)
-  apply(erule states_equiv_for_guard_imp)
-     apply(simp add: aag_can_affect_label_def label_can_affect_partition_def)+
+  apply (simp add: reads_equiv_f_g_def reads_equiv_def2 silc_dom_equiv_def)
+  apply (erule states_equiv_for_guard_imp)
+     apply (simp add: aag_can_affect_label_def label_can_affect_partition_def)+
   done
 
-
 lemma schedule_reads_affects_equiv_sameFor_PSched:
-  "\<lbrakk>scheduler_equiv aag s s'; scheduler_modes mode = scheduler_modes mode';
-    interrupted_modes mode = interrupted_modes mode'\<rbrakk> \<Longrightarrow>
-    (((uc,s),mode),((uc',s'),mode')) \<in> same_for aag PSched"
+  "\<lbrakk> scheduler_equiv aag s s'; scheduler_modes mode = scheduler_modes mode';
+     interrupted_modes mode = interrupted_modes mode' \<rbrakk>
+     \<Longrightarrow> (((uc,s),mode),((uc',s'),mode')) \<in> same_for aag PSched"
   by (simp add: sameFor_def sameFor_scheduler_def scheduler_equiv_def silc_dom_equiv_def)
 
 lemma schedule_reads_affects_equiv_sameFor_PSched':
-  "\<lbrakk>scheduler_equiv aag (internal_state_if s) (internal_state_if s');
-    scheduler_modes (sys_mode_of s) = scheduler_modes (sys_mode_of s');
-    interrupted_modes (sys_mode_of s) = interrupted_modes (sys_mode_of s')\<rbrakk> \<Longrightarrow>
-    (s,s') \<in> same_for aag PSched"
+  "\<lbrakk> scheduler_equiv aag (internal_state_if s) (internal_state_if s');
+     scheduler_modes (sys_mode_of s) = scheduler_modes (sys_mode_of s');
+     interrupted_modes (sys_mode_of s) = interrupted_modes (sys_mode_of s') \<rbrakk>
+     \<Longrightarrow> (s,s') \<in> same_for aag PSched"
   apply (case_tac s)
   apply (case_tac a)
   apply (case_tac s')
   apply (case_tac ab)
   apply clarsimp
-  apply (rule schedule_reads_affects_equiv_sameFor_PSched)
-  apply simp+
+  apply (rule schedule_reads_affects_equiv_sameFor_PSched; simp)
   done
 
 lemma observable_if_cases:
   "P (s::observable_if) \<Longrightarrow> P (((user_context_of s),(internal_state_if s)),sys_mode_of s)"
-  by(case_tac s, case_tac "fst s", simp)
+  by (case_tac s, case_tac "fst s", simp)
 
 lemma sameFor_reads_f_g_affects_equiv:
-  "\<lbrakk>pas_cur_domain aag (internal_state_if s);
-    silc_inv aag st (internal_state_if s);
-    (s,s') \<in> same_for aag (Partition (label_of (pasSubject aag)));
-    Partition l \<in> partsSubjectAffects (pasPolicy aag) (label_of (pasSubject aag));
-    (s,s') \<in> same_for aag (Partition l)\<rbrakk> \<Longrightarrow>
-   reads_equiv_f_g aag (internal_state_if s) (internal_state_if s') \<and>
-   affects_equiv aag (OrdinaryLabel l) (internal_state_if s) (internal_state_if s')"
-  apply(rule conjI)
-   apply(rule sameFor_reads_equiv_f_g')
+  "\<lbrakk> pas_cur_domain aag (internal_state_if s); silc_inv aag st (internal_state_if s);
+     (s,s') \<in> same_for aag (Partition (label_of (pasSubject aag)));
+     Partition l \<in> partsSubjectAffects (pasPolicy aag) (label_of (pasSubject aag));
+     (s,s') \<in> same_for aag (Partition l) \<rbrakk>
+     \<Longrightarrow> reads_equiv_f_g aag (internal_state_if s) (internal_state_if s') \<and>
+         affects_equiv aag (OrdinaryLabel l) (internal_state_if s) (internal_state_if s')"
+  apply (rule conjI)
+   apply (rule sameFor_reads_equiv_f_g')
      apply blast
     apply blast
-   apply(rule_tac s=s in observable_if_cases)
-   apply(erule_tac s=s' in observable_if_cases)
+   apply (rule_tac s=s in observable_if_cases)
+   apply (erule_tac s=s' in observable_if_cases)
   apply (simp add: partsSubjectAffects_def)
   apply (frule pasSubject_not_SilcLabel)
   apply clarsimp
-  apply(clarsimp simp: affects_equiv_def2 sameFor_def)
-  apply(clarsimp simp: sameFor_subject_def[where l=l])
-  apply(blast intro: states_equiv_for_guard_imp)
+  apply (clarsimp simp: affects_equiv_def2 sameFor_def)
+  apply (clarsimp simp: sameFor_subject_def[where l=l])
+  apply (blast intro: states_equiv_for_guard_imp)
   done
 
-
 lemma schedule_reads_affects_equiv_sameFor:
-  "\<lbrakk>scheduler_equiv aag s s' \<and> scheduler_affects_equiv aag (OrdinaryLabel l) s s';
-    user_modes mode \<longrightarrow> uc = uc'\<rbrakk> \<Longrightarrow>
-    (((uc,s),mode),((uc',s'),mode)) \<in> same_for aag (Partition l)"
+  "\<lbrakk> scheduler_equiv aag s s'; scheduler_affects_equiv aag (OrdinaryLabel l) s s';
+     user_modes mode \<longrightarrow> uc = uc' \<rbrakk>
+     \<Longrightarrow> (((uc,s),mode),((uc',s'),mode)) \<in> same_for aag (Partition l)"
   by (auto simp: scheduler_equiv_def scheduler_affects_equiv_def sameFor_def sameFor_subject_def
                  silc_dom_equiv_def reads_scheduler_def domain_fields_equiv_def
                  disjoint_iff_not_equal Bex_def
-           intro: globals_equiv_from_scheduler)
-
+          intro: globals_equiv_from_scheduler)
 
 lemma globals_equiv_to_scheduler_globals_frame_equiv:
-  "globals_equiv s t \<Longrightarrow> invs s \<Longrightarrow> invs t\<Longrightarrow> scheduler_globals_frame_equiv s t"
+  "\<lbrakk> globals_equiv s t; invs s; invs t \<rbrakk>
+     \<Longrightarrow> scheduler_globals_frame_equiv s t"
   by (simp add: globals_equiv_def scheduler_globals_frame_equiv_def)
 
 lemma globals_equiv_to_cur_thread_eq:
   "globals_equiv s t \<Longrightarrow> cur_thread s = cur_thread t"
-  by(simp add: globals_equiv_def)
-
-lemma globals_equiv_to_exclusive_state_equiv:
-  "globals_equiv s t \<Longrightarrow> cur_thread s \<noteq> idle_thread t \<Longrightarrow> exclusive_state_equiv s t"
-  by(simp add: globals_equiv_def idle_equiv_def)
-
-lemma sameFor_scheduler_affects_equiv:
-  "\<lbrakk>(s,s') \<in> same_for aag PSched;
-    (s,s') \<in> same_for aag (Partition l);
-    invs (internal_state_if s);invs (internal_state_if s')\<rbrakk> \<Longrightarrow>
-    scheduler_equiv aag (internal_state_if s) (internal_state_if s') \<and>
-    scheduler_affects_equiv aag (OrdinaryLabel l) (internal_state_if s) (internal_state_if s')"
-  apply (rule conjI)
-   apply (blast intro: sameFor_scheduler_equiv)
-  apply (clarsimp simp: scheduler_affects_equiv_def sameFor_def silc_dom_equiv_def
-                        reads_scheduler_def sameFor_scheduler_def
-                        globals_equiv_to_exclusive_state_equiv)
-  (* simplifying using sameFor_subject_def in assumptions causes simp to loop *)
-  apply (simp (no_asm_use) add: sameFor_subject_def disjoint_iff_not_equal Bex_def)
-  apply (blast intro: globals_equiv_to_scheduler_globals_frame_equiv
-                      globals_equiv_to_exclusive_state_equiv globals_equiv_to_cur_thread_eq)
-  done
-
+  by (simp add: globals_equiv_def)
 
 lemma no_subject_affects_PSched:
   "PSched \<notin> partsSubjectAffects g l"
-  by(auto simp: partsSubjectAffects_def elim: subjectAffects.cases)
+  by (auto simp: partsSubjectAffects_def elim: subjectAffects.cases)
+
 
 section \<open>InfoFlow policy and partition integrity\<close>
 
@@ -307,48 +264,40 @@ text \<open>
 \<close>
 
 inductive_set policyFlows :: "'a subject_label auth_graph \<Rightarrow> ('a partition \<times> 'a partition) set"
-  for g :: "'a subject_label auth_graph"
-where
-  policy_affects: "d \<in> partsSubjectAffects g l \<Longrightarrow> (Partition l, d) \<in> policyFlows g" |
-  policy_scheduler: "(PSched,d) \<in> policyFlows g"
-
+  for g :: "'a subject_label auth_graph" where
+  policy_affects: "d \<in> partsSubjectAffects g l \<Longrightarrow> (Partition l, d) \<in> policyFlows g"
+| policy_scheduler: "(PSched,d) \<in> policyFlows g"
 
 lemma no_partition_flows_to_PSched:
   "(Partition l, PSched) \<notin> policyFlows g"
-  apply(rule notI)
-  apply(erule policyFlows.cases)
-   apply(simp_all add: no_subject_affects_PSched)
+  apply (rule notI)
+  apply (erule policyFlows.cases)
+   apply (simp_all add: no_subject_affects_PSched)
   done
-
-
 
 lemma partsSubjectAffects_bounds_those_subject_not_allowed_to_affect:
   "(Partition l,d) \<notin> policyFlows g \<Longrightarrow> d \<notin> partsSubjectAffects g l"
-  apply(clarify)
-  apply(drule policy_affects)
-  apply(blast)
+  apply (clarify)
+  apply (drule policy_affects)
+  apply (blast)
   done
-
-
 
 lemma PSched_flows_to_all:
   "(PSched,d) \<in> policyFlows g"
   by (rule policyFlows.intros)
 
-
 lemma policyFlows_refl:
   "refl (policyFlows g)"
-  apply(rule refl_onI)
+  apply (rule refl_onI)
    apply simp
-  apply(case_tac x)
+  apply (case_tac x)
    apply simp
-   apply(rule policy_affects)
-   apply(simp add: partsSubjectAffects_def image_def)
-   apply(simp add: label_can_affect_partition_def)
-   apply(blast intro: affects_lrefl)
-  apply(blast intro: PSched_flows_to_all)
+   apply (rule policy_affects)
+   apply (simp add: partsSubjectAffects_def image_def)
+   apply (simp add: label_can_affect_partition_def)
+   apply (blast intro: affects_lrefl)
+  apply (blast intro: PSched_flows_to_all)
   done
-
 
 
 (* a more constrained integrity property for non-PSched transitions
@@ -356,69 +305,37 @@ lemma policyFlows_refl:
 definition partitionIntegrity :: "'a subject_label PAS \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool"
 where
   "partitionIntegrity aag s s' \<equiv>
-    integrity (aag\<lparr> pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
-              (scheduler_affects_globals_frame s) s s' \<and>
-    domain_fields_equiv s s' \<and> idle_thread s = idle_thread s' \<and>
-    globals_equiv_scheduler s s' \<and> silc_dom_equiv aag s s'"
+     integrity (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+               (scheduler_affects_globals_frame s) s s' \<and>
+     domain_fields_equiv s s' \<and> idle_thread s = idle_thread s' \<and>
+     globals_equiv_scheduler s s' \<and> silc_dom_equiv aag s s'"
 
-
-
-lemma integrity_irq_state_independent:
-  "irq_state_independent
-         (\<lambda>sa. integrity aag X st (s\<lparr>machine_state := sa\<rparr>))"
-  by (auto simp: irq_state_independent_def integrity_def)
-
-lemma pas_refined_irq_state_independent:
-  "irq_state_independent (\<lambda>sa. pas_refined aag s)"
-  by (rule irq_state_independent_irq_masks)
-
-lemma irq_update_pspace_respects_device_region[simp]:
-  "pspace_respects_device_region (s\<lparr>machine_state := irq_state_update f sa\<rparr>)
-  = pspace_respects_device_region (s\<lparr>machine_state := sa\<rparr>)"
-  by (clarsimp simp: pspace_respects_device_region_def user_mem_def device_mem_def cong: if_cong)
-
-lemma irq_update_cap_refs_respects_device_region[simp]:
-  "cap_refs_respects_device_region (s\<lparr>machine_state := irq_state_update f sa\<rparr>)
-  = cap_refs_respects_device_region (s\<lparr>machine_state := sa\<rparr>)"
-  by (clarsimp simp: cap_refs_respects_device_region_def user_mem_def
-    device_mem_def cap_range_respects_device_region_def)
-
-lemma invs_irq_state_independent:
-  "irq_state_independent
-         (\<lambda>sa. invs (s\<lparr>machine_state := sa\<rparr>))"
-  by(auto simp: irq_state_independent_def invs_def valid_state_def
-                valid_machine_state_def cur_tcb_def valid_irq_states_def)
 
 lemma thread_set_tcb_context_update_ct_active[wp]:
-  "\<lbrace>\<lambda>s. P (ct_active s)\<rbrace>
-   thread_set (tcb_arch_update (arch_tcb_context_set f)) t
-   \<lbrace>\<lambda>rv s. P (ct_active s)\<rbrace>"
-  apply(simp add: thread_set_def ct_in_state_def | wp set_object_wp)+
-  apply(clarsimp simp: st_tcb_at_def obj_at_def get_tcb_def
-                split: option.splits kernel_object.splits)
+  "thread_set (tcb_arch_update (arch_tcb_context_set f)) t \<lbrace>\<lambda>s. P (ct_active s)\<rbrace>"
+  apply (simp add: thread_set_def ct_in_state_def | wp set_object_wp)+
+  apply (clarsimp simp: st_tcb_at_def obj_at_def get_tcb_def
+                 split: option.splits kernel_object.splits)
   done
 
 lemma prop_of_two_valid:
-  assumes f: "\<And>P. \<lbrace>\<lambda>s. P (f s)\<rbrace> m \<lbrace>\<lambda>_ s. P (f s)\<rbrace>"
-  assumes g: "\<And>P. \<lbrace>\<lambda>s. P (g s)\<rbrace> m \<lbrace>\<lambda>_ s. P (g s)\<rbrace>"
-  shows
-  "\<lbrace>\<lambda>s. P (f s) (g s)\<rbrace> m \<lbrace>\<lambda>_ s. P (f s) (g s)\<rbrace>"
+  assumes f: "\<And>P. m \<lbrace>\<lambda>s. P (f s)\<rbrace>"
+  assumes g: "\<And>P. m \<lbrace>\<lambda>s. P (g s)\<rbrace>"
+  shows "m \<lbrace>\<lambda>s. P (f s) (g s)\<rbrace>"
   by (rule hoare_pre, wps f g, wp, simp)
 
 lemma integrity_update_reference_state:
-  "is_subject aag t \<Longrightarrow> integrity aag X st s \<Longrightarrow>
-   st = st'\<lparr> kheap := kheap st'( t \<mapsto> blah)\<rparr> \<Longrightarrow>
-   integrity aag X st' s"
-  apply(erule integrity_trans[rotated])
+  "\<lbrakk> is_subject aag t; integrity aag X st s; st = st'\<lparr>kheap := kheap st'(t \<mapsto> blah)\<rparr> \<rbrakk>
+     \<Longrightarrow> integrity aag X st' s"
+  apply (erule integrity_trans[rotated])
   apply (clarsimp simp: integrity_def)
   done
 
 lemma thread_set_tcb_context_update_wp:
-  "\<lbrace>\<lambda>s. P (s\<lparr>kheap := kheap s(t \<mapsto>
-                     TCB (tcb_arch_update (arch_tcb_context_set tc) (the (get_tcb t s))))\<rparr>)\<rbrace>
-       thread_set (tcb_arch_update (arch_tcb_context_set tc)) t
-       \<lbrace>\<lambda>_. P\<rbrace>"
-  apply(simp add: thread_set_def)
+  "\<lbrace>\<lambda>s. P (s\<lparr>kheap := kheap s(t \<mapsto> TCB (tcb_arch_update f (the (get_tcb t s))))\<rparr>)\<rbrace>
+   thread_set (tcb_arch_update f) t
+   \<lbrace>\<lambda>_. P\<rbrace>"
+  apply (simp add: thread_set_def)
   apply (wp set_object_wp)
   apply simp
   done
@@ -427,51 +344,48 @@ lemma thread_set_tcb_context_update_wp:
    be identical to the initial one, but it isn't because we first update the
    context of cur_thread *)
 lemma kernel_entry_if_integrity:
-  shows
-  "\<lbrace> einvs and schact_is_rct and pas_refined aag and is_subject aag \<circ> cur_thread and
-     domain_sep_inv (pasMaySendIrqs aag) st' and guarded_pas_domain aag and
-     (\<lambda> s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and (=) st\<rbrace>
+  "\<lbrace>einvs and schact_is_rct and pas_refined aag and is_subject aag \<circ> cur_thread
+          and domain_sep_inv (pasMaySendIrqs aag) st' and guarded_pas_domain aag
+          and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and (=) st\<rbrace>
    kernel_entry_if e tc
-   \<lbrace> \<lambda>_. integrity aag X st \<rbrace>"
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   unfolding kernel_entry_if_def
   apply wp
-    apply(rule valid_validE)
-    apply(rule_tac Q=
-            "\<lambda>_ s. integrity aag X
-                     (st\<lparr>kheap := (kheap st)
-                           (cur_thread st \<mapsto> TCB (tcb_arch_update (arch_tcb_context_set tc)
-                                                          (the (get_tcb (cur_thread st) st))))\<rparr>) s
-                            \<and> is_subject aag (cur_thread s)
-                            \<and> cur_thread s = cur_thread st"
-                   in hoare_strengthen_post)
-     apply(wp handle_event_integrity handle_event_cur_thread | simp)+
-    apply(fastforce intro: integrity_update_reference_state)
-   apply(wp thread_set_integrity_autarch thread_set_pas_refined
-           guarded_pas_domain_lift thread_set_invs_trivial thread_set_not_state_valid_sched
-          | simp add: tcb_cap_cases_def schact_is_rct_def arch_tcb_update_aux2 tcb_arch_ref_def)+
-   apply(wp (once) prop_of_two_valid[where f="ct_active" and g="cur_thread"])
-     apply (wp | simp)+
-   apply(wp thread_set_tcb_context_update_wp)+
-  apply(clarsimp simp: schact_is_rct_def)
-  apply(rule conjI)
-   apply(erule integrity_update_reference_state[where blah="the (kheap st (cur_thread st))",
-                                                OF _ integrity_refl])
+     apply (rule valid_validE)
+     apply (rule_tac Q="\<lambda>_ s. integrity aag X (st\<lparr>kheap :=
+                         (kheap st)(cur_thread st \<mapsto> TCB (tcb_arch_update (arch_tcb_context_set tc)
+                                                            (the (get_tcb (cur_thread st) st))))\<rparr>) s
+                       \<and> is_subject aag (cur_thread s)
+                       \<and> cur_thread s = cur_thread st" in hoare_strengthen_post)
+      apply (wp handle_event_integrity handle_event_cur_thread | simp)+
+     apply (fastforce intro: integrity_update_reference_state)
+    apply (wp thread_set_integrity_autarch thread_set_pas_refined guarded_pas_domain_lift
+              thread_set_invs_trivial thread_set_not_state_valid_sched
+           | simp add: tcb_cap_cases_def schact_is_rct_def arch_tcb_update_aux2)+
+    apply (wp (once) prop_of_two_valid[where f="ct_active" and g="cur_thread"])
+      apply (wp | simp)+
+    apply (wp thread_set_tcb_context_update_wp)+
+  apply (clarsimp simp: schact_is_rct_def)
+  apply (rule conjI)
+   apply (erule integrity_update_reference_state[where blah="the (kheap st (cur_thread st))",
+                                                 OF _ integrity_refl])
    apply simp
-   apply(subgoal_tac "kheap st (cur_thread st) \<noteq> None")
+   apply (subgoal_tac "kheap st (cur_thread st) \<noteq> None")
     apply clarsimp
-   apply(drule tcb_at_invs, clarsimp simp:  tcb_at_def get_tcb_def
-                                    split: kernel_object.splits option.splits)
-  apply(clarsimp simp: invs_psp_aligned invs_vspace_objs invs_arch_state)
-  apply(rule conjI)
+   apply (drule tcb_at_invs, clarsimp simp: tcb_at_def get_tcb_def
+                                     split: kernel_object.splits option.splits)
+  apply (clarsimp simp: invs_psp_aligned invs_vspace_objs invs_arch_state)
+  apply (rule conjI)
    apply assumption
-  apply(rule state.equality, simp_all)
-  apply(rule ext, simp_all)
+  apply (rule state.equality, simp_all)
+  apply (rule ext, simp_all)
   done
+
 
 lemma dmo_device_update_respects_Write:
   "\<lbrace>integrity aag X st and K (\<forall>p \<in> dom um'. aag_has_auth_to aag Write p)\<rbrace>
-     do_machine_op (device_memory_update um')
-   \<lbrace>\<lambda>a. integrity aag X st\<rbrace>"
+   do_machine_op (device_memory_update um')
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: device_memory_update_def)
   apply (rule hoare_pre)
    apply (wp dmo_wp)
@@ -480,50 +394,23 @@ lemma dmo_device_update_respects_Write:
   apply (rule integrity_device_state_update)
     apply simp
    apply clarify
-   apply (drule(1) bspec)
+   apply (drule (1) bspec)
    apply simp
   apply fastforce
   done
 
-(* clagged straight from ADT_AC.do_user_op_respects *)
-lemma do_user_op_if_integrity:
- "\<lbrace> invs and integrity aag X st and is_subject aag \<circ> cur_thread and pas_refined aag \<rbrace>
-    do_user_op_if uop tc
-  \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply (simp add: do_user_op_if_def)
-   apply (wp dmo_user_memory_update_respects_Write dmo_device_update_respects_Write
-     hoare_vcg_all_lift hoare_vcg_imp_lift
-        | wpc | clarsimp)+
-       apply (rule hoare_pre_cont)
-      apply (wp   select_wp | wpc | clarsimp)+
-  apply (rule conjI)
-   apply clarsimp
-   apply (simp add: restrict_map_def ptable_lift_s_def ptable_rights_s_def split: if_splits)
-   apply (drule_tac auth=Write in user_op_access')
-     apply (simp add: vspace_cap_rights_to_auth_def)+
-  apply clarsimp
-  apply (simp add: restrict_map_def ptable_lift_s_def ptable_rights_s_def split: if_splits)
-  apply (drule_tac auth=Write in user_op_access')
-      apply (simp add: vspace_cap_rights_to_auth_def)+
-  done
-
 lemma check_active_irq_if_integrity:
- "\<lbrace> integrity aag X st \<rbrace>
-    check_active_irq_if tc
-  \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
-  apply(wp check_active_irq_if_wp)
-  apply(simp add: integrity_subjects_def)
-  done
-
+  "check_active_irq_if tc \<lbrace>integrity aag X st\<rbrace>"
+  by (wpsimp wp: check_active_irq_if_wp simp: integrity_subjects_def)
 
 lemma silc_dom_equiv_from_silc_inv_valid':
-  assumes "\<And> st. \<lbrace>P and silc_inv aag st\<rbrace> f \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  assumes "\<And>st. \<lbrace>P and silc_inv aag st\<rbrace> f \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   shows "\<lbrace>P and silc_inv aag st and silc_dom_equiv aag sta\<rbrace> f \<lbrace>\<lambda>_. silc_dom_equiv aag sta\<rbrace>"
   apply (rule hoare_pre)
    apply (rule hoare_strengthen_post)
     apply (rule assms)
    apply (fastforce simp: silc_inv_def)
-  (* we can't use clarsimp below because it splits pairs unconditionally *)
+    (* we can't use clarsimp below because it splits pairs unconditionally *)
   apply (simp add: silc_inv_def silc_dom_equiv_def del: split_paired_All)
   apply (elim conjE)
   apply (intro allI impI notI)
@@ -532,17 +419,18 @@ lemma silc_dom_equiv_from_silc_inv_valid':
   apply (drule spec, drule(1) mp, erule notE, erule(1) cte_wp_at_pspace'[THEN iffD2])
   done
 
-lemma ct_running_not_idle: "ct_running s \<Longrightarrow> valid_idle s \<Longrightarrow> cur_thread s \<noteq> idle_thread s"
+lemma ct_running_not_idle:
+  "\<lbrakk> ct_running s; valid_idle s \<rbrakk> \<Longrightarrow> cur_thread s \<noteq> idle_thread s"
   by (clarsimp simp add: ct_in_state_def pred_tcb_at_def obj_at_def valid_idle_def)
 
 lemma kernel_entry_if_globals_equiv_scheduler:
-  "\<lbrace>globals_equiv_scheduler st and
-    (valid_ko_at_arm and invs and (\<lambda>s. param_a \<noteq> Interrupt \<longrightarrow> ct_active s)
-     and (\<lambda>s. ct_idle s \<longrightarrow> param_b = idle_context s))\<rbrace>
-   kernel_entry_if param_a param_b
+  "\<lbrace>globals_equiv_scheduler st and valid_ko_at_arch and invs
+                               and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)
+                               and (\<lambda>s. ct_idle s \<longrightarrow> tc = idle_context s)\<rbrace>
+   kernel_entry_if e tc
    \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
-  apply(wp globals_equiv_scheduler_inv' kernel_entry_if_globals_equiv)
-   apply(clarsimp)
+  apply (wp globals_equiv_scheduler_inv' kernel_entry_if_globals_equiv)
+   apply (clarsimp)
    apply assumption
   apply clarsimp
   done
@@ -551,158 +439,104 @@ lemma domain_fields_equiv_lift:
   assumes a: "\<And>P. \<lbrace>domain_fields P and Q\<rbrace> f \<lbrace>\<lambda>_. domain_fields P\<rbrace>"
   assumes b: "\<And>P. \<lbrace>(\<lambda>s. P (cur_domain s)) and R\<rbrace> f \<lbrace>\<lambda>_ s. P (cur_domain s)\<rbrace>"
   shows "\<lbrace>domain_fields_equiv st and Q and R\<rbrace> f \<lbrace>\<lambda>_. domain_fields_equiv st\<rbrace>"
-  apply(clarsimp simp: valid_def domain_fields_equiv_def)
-  apply(erule use_valid, wp a b)
+  apply (clarsimp simp: valid_def domain_fields_equiv_def)
+  apply (erule use_valid, wp a b)
   apply simp
   done
 
 lemma kernel_entry_if_partitionIntegrity:
-  "\<lbrace>silc_inv aag st and pas_refined aag and einvs and schact_is_rct and
-       is_subject aag \<circ> cur_thread  and domain_sep_inv (pasMaySendIrqs aag) st' and
-       guarded_pas_domain aag and (\<lambda>s. ev \<noteq> Interrupt \<and> ct_active s) and (=) st\<rbrace>
-     kernel_entry_if ev tc
-   \<lbrace>\<lambda> rv. partitionIntegrity aag st\<rbrace>"
-  apply(rule_tac Q="\<lambda>rv s. (\<forall> X. integrity (aag\<lparr> pasMayActivate := False,
-                                                 pasMayEditReadyQueues := False \<rparr>) X st s) \<and>
-                                 domain_fields_equiv st s \<and>
-                                 globals_equiv_scheduler st s \<and>
-                                 idle_thread s = idle_thread st \<and>
-                                 silc_dom_equiv aag st s" in hoare_strengthen_post)
-   apply(wp hoare_vcg_conj_lift)
-     apply(rule hoare_vcg_all_lift[OF kernel_entry_if_integrity[where st'=st']])
-    apply(wp kernel_entry_if_cur_thread kernel_entry_if_globals_equiv_scheduler
-             kernel_entry_if_cur_domain domain_fields_equiv_lift[where R="\<top>"]
-             kernel_entry_if_domain_fields
-         | simp)+
-    apply(rule_tac P="pas_refined aag and einvs and schact_is_rct and
-                      is_subject aag \<circ> cur_thread and domain_sep_inv (pasMaySendIrqs aag) st' and
-                      (\<lambda> s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)"
-                   in silc_dom_equiv_from_silc_inv_valid')
-    apply(wp kernel_entry_silc_inv[where st'=st'], simp add: schact_is_rct_simple)
-   apply(fastforce simp: pas_refined_pasMayActivate_update pas_refined_pasMayEditReadyQueues_update
-                         globals_equiv_scheduler_refl silc_dom_equiv_def equiv_for_refl
-                         invs_valid_ko_at_arm domain_fields_equiv_def ct_active_not_idle')
-  apply(fastforce simp: partitionIntegrity_def)
+  "\<lbrace>silc_inv aag st and pas_refined aag and einvs and schact_is_rct
+                    and is_subject aag \<circ> cur_thread and domain_sep_inv (pasMaySendIrqs aag) st'
+                    and guarded_pas_domain aag and (\<lambda>s. ev \<noteq> Interrupt \<and> ct_active s) and (=) st\<rbrace>
+   kernel_entry_if ev tc
+   \<lbrace>\<lambda>_. partitionIntegrity aag st\<rbrace>"
+  apply (rule_tac Q="\<lambda>rv s. (\<forall>X. integrity (aag\<lparr>pasMayActivate := False,
+                                                pasMayEditReadyQueues := False\<rparr>) X st s) \<and>
+                            domain_fields_equiv st s \<and> globals_equiv_scheduler st s \<and>
+                            idle_thread s = idle_thread st \<and> silc_dom_equiv aag st s"
+               in hoare_strengthen_post)
+   apply (wp hoare_vcg_conj_lift)
+     apply (rule hoare_vcg_all_lift[OF kernel_entry_if_integrity[where st'=st']])
+    apply (wp kernel_entry_if_cur_thread kernel_entry_if_globals_equiv_scheduler
+              kernel_entry_if_cur_domain domain_fields_equiv_lift[where R="\<top>"]
+              kernel_entry_if_domain_fields | simp)+
+    apply (rule_tac P="pas_refined aag and einvs and schact_is_rct and
+                       is_subject aag \<circ> cur_thread and domain_sep_inv (pasMaySendIrqs aag) st' and
+                       (\<lambda> s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)"
+                 in silc_dom_equiv_from_silc_inv_valid')
+    apply (wp kernel_entry_silc_inv[where st'=st'], simp add: schact_is_rct_simple)
+   apply (fastforce simp: pas_refined_pasMayActivate_update pas_refined_pasMayEditReadyQueues_update
+                          globals_equiv_scheduler_refl silc_dom_equiv_def equiv_for_refl
+                          invs_valid_ko_at_arch domain_fields_equiv_def ct_active_not_idle')
+  apply (fastforce simp: partitionIntegrity_def)
   done
 
 lemma check_active_irq_if_partitionIntegrity:
-  "\<lbrace>partitionIntegrity aag st\<rbrace>
-   check_active_irq_if tc \<lbrace>\<lambda> rv. partitionIntegrity aag st\<rbrace>"
-  apply(simp add: check_active_irq_if_def)
-  apply(wp dmo_getActiveIRQ_wp)
-  apply(simp add: partitionIntegrity_def integrity_subjects_def)
-  apply(simp add: silc_dom_equiv_def equiv_for_def globals_equiv_scheduler_def)
-  apply(fastforce simp: domain_fields_equiv_def)
+  "check_active_irq_if tc \<lbrace>partitionIntegrity aag st\<rbrace>"
+  apply (simp add: check_active_irq_if_def)
+  apply (wp dmo_getActiveIRQ_wp)
+  apply (simp add: partitionIntegrity_def integrity_subjects_def)
+  apply (simp add: silc_dom_equiv_def equiv_for_def globals_equiv_scheduler_def)
+  apply (fastforce simp: domain_fields_equiv_def)
   done
-
 
 lemma do_machine_op_globals_equiv_scheduler:
-   "(\<And> s sa. \<lbrakk>P sa; globals_equiv_scheduler s sa\<rbrakk> \<Longrightarrow>
-         \<forall>x\<in>fst (f (machine_state sa)).
-            globals_equiv_scheduler s (sa\<lparr>machine_state := snd x\<rparr>)) \<Longrightarrow>
-  \<lbrace> globals_equiv_scheduler s and P \<rbrace>
-   do_machine_op f
-   \<lbrace> \<lambda>_. globals_equiv_scheduler s \<rbrace>"
-  unfolding do_machine_op_def
-  apply (wp | simp add: split_def)+
-  done
+   "(\<And>s sa. \<lbrakk> P sa; globals_equiv_scheduler s sa \<rbrakk>
+              \<Longrightarrow> \<forall>x \<in> fst (f (machine_state sa)).
+                    globals_equiv_scheduler s (sa\<lparr>machine_state := snd x\<rparr>))
+    \<Longrightarrow> \<lbrace>globals_equiv_scheduler s and P\<rbrace>
+        do_machine_op f
+        \<lbrace>\<lambda>_. globals_equiv_scheduler s\<rbrace>"
+  unfolding do_machine_op_def by (wp | simp add: split_def)+
 
 lemma dmo_user_memory_update_globals_equiv_scheduler:
-  "\<lbrace>globals_equiv_scheduler st and (invs and (\<lambda>s. pl = ptable_lift t s |` {x. pr x \<noteq> {}} \<and>
-                                        pr = ptable_rights t s))\<rbrace>
-          do_machine_op
-           (user_memory_update
-             ((ba |`
-              {y. \<exists>x. pl x = Some y \<and>
-                      AllowWrite \<in> pr x} \<circ>
-              addrFromPPtr) |` S))
-   \<lbrace>\<lambda>y. globals_equiv_scheduler st\<rbrace>"
-   apply(rule do_machine_op_globals_equiv_scheduler)
-   apply clarsimp
-   apply(erule use_valid)
-   apply(simp add: user_memory_update_def)
-   apply(wp modify_wp)
-  apply(clarsimp simp: globals_equiv_scheduler_def split: option.splits)
+  "\<lbrace>globals_equiv_scheduler st and
+    (invs and (\<lambda>s. pl = ptable_lift t s |` {x. pr x \<noteq> {}} \<and> pr = ptable_rights t s))\<rbrace>
+   do_machine_op
+     (user_memory_update ((ba |` {y. \<exists>x. pl x = Some y \<and> AllowWrite \<in> pr x} \<circ> addrFromPPtr) |` S))
+   \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
+  apply (rule do_machine_op_globals_equiv_scheduler)
+  apply clarsimp
+  apply (erule use_valid)
+   apply (simp add: user_memory_update_def)
+   apply (wp modify_wp)
+  apply (clarsimp simp: globals_equiv_scheduler_def split: option.splits)
   done
 
 lemma dmo_device_memory_update_globals_equiv_scheduler:
   "\<lbrace>globals_equiv_scheduler st and (\<lambda>s. device_region s = S)\<rbrace>
-          do_machine_op
-           (device_memory_update
-             ((ba |`
-              {y. \<exists>x. pl x = Some y \<and>
-                      AllowWrite \<in> pr x} \<circ>
-              addrFromPPtr) |` S))
-   \<lbrace>\<lambda>y. globals_equiv_scheduler st\<rbrace>"
-   apply(rule do_machine_op_globals_equiv_scheduler)
-   apply clarsimp
-   apply(simp add: device_memory_update_def simpler_modify_def)
-  apply(clarsimp simp: globals_equiv_scheduler_def split: option.splits)
-  done
-
-
-lemma globals_equiv_scheduler_exclusive_state_update[simp]:
-  "globals_equiv_scheduler st (s\<lparr>machine_state := machine_state s\<lparr>exclusive_state := es\<rparr>\<rparr>) =
-   globals_equiv_scheduler st s"
-  by (simp add: globals_equiv_scheduler_def)
-
-lemma do_user_op_if_globals_equiv_scheduler:
-  "\<lbrace>globals_equiv_scheduler st and invs\<rbrace>
-   do_user_op_if tc uop
+   do_machine_op
+     (device_memory_update ((ba |` {y. \<exists>x. pl x = Some y \<and> AllowWrite \<in> pr x} \<circ> addrFromPPtr) |` S))
    \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
-  apply(simp add: do_user_op_if_def)
-  apply (wp dmo_user_memory_update_globals_equiv_scheduler
-    dmo_device_memory_update_globals_equiv_scheduler select_wp | wpc | simp)+
-  apply (auto simp: ptable_lift_s_def ptable_rights_s_def)
+  apply (rule do_machine_op_globals_equiv_scheduler)
+  apply clarsimp
+  apply (simp add: device_memory_update_def simpler_modify_def)
+  apply (clarsimp simp: globals_equiv_scheduler_def split: option.splits)
   done
-
-lemma silc_dom_equiv_exclusive_state_update[simp]:
-  "silc_dom_equiv aag st (s\<lparr>machine_state := machine_state s\<lparr>exclusive_state := es\<rparr>\<rparr>) =
-   silc_dom_equiv aag st s"
-  by (simp add: silc_dom_equiv_def equiv_for_def)
-
-crunch silc_dom_equiv[wp]: do_user_op_if "silc_dom_equiv aag st"
-  (ignore: do_machine_op user_memory_update wp: crunch_wps select_wp)
 
 lemma pas_refined_pasMayActivate_update[simp]:
-  "pas_refined (aag\<lparr>pasMayActivate := x, pasMayEditReadyQueues := x\<rparr>) s = pas_refined aag s"
-  apply(simp add: pas_refined_def irq_map_wellformed_aux_def tcb_domain_map_wellformed_aux_def)
-  apply(simp add: state_asids_to_policy_pasMayActivate_update[simplified]
+  "pas_refined (aag\<lparr>pasMayActivate := x, pasMayEditReadyQueues := x\<rparr>) s =
+   pas_refined (aag :: 'a subject_label PAS) s"
+  apply (simp add: pas_refined_def irq_map_wellformed_aux_def tcb_domain_map_wellformed_aux_def)
+  apply (simp add: state_asids_to_policy_pasMayActivate_update[simplified]
                   state_irqs_to_policy_pasMayActivate_update
                   state_asids_to_policy_pasMayEditReadyQueues_update[simplified]
                   state_irqs_to_policy_pasMayEditReadyQueues_update)
   done
 
-
-lemma do_user_op_if_partitionIntegrity:
-  "\<lbrace>partitionIntegrity aag st and pas_refined aag and invs and is_subject aag \<circ> cur_thread\<rbrace>
-     do_user_op_if tc uop
-   \<lbrace>\<lambda> rv. partitionIntegrity aag st\<rbrace>"
- apply(rule_tac Q="\<lambda>rv s. integrity (aag\<lparr> pasMayActivate := False, pasMayEditReadyQueues := False \<rparr>)
-                                    (scheduler_affects_globals_frame st) st s \<and>
-                          domain_fields_equiv st s \<and> idle_thread s = idle_thread st \<and>
-                          globals_equiv_scheduler st s \<and> silc_dom_equiv aag st s"
-                in hoare_strengthen_post)
-   apply(wp hoare_vcg_conj_lift do_user_op_if_integrity do_user_op_if_globals_equiv_scheduler
-            hoare_vcg_all_lift domain_fields_equiv_lift[where Q="\<top>" and R="\<top>"]
-        | simp)+
-  apply(clarsimp simp: partitionIntegrity_def)+
-  done
-
-
 lemma activate_thread_globals_equiv_scheduler:
-  "\<lbrace>globals_equiv_scheduler st and valid_ko_at_arm and valid_idle\<rbrace>
-      activate_thread
+  "\<lbrace>globals_equiv_scheduler st and valid_ko_at_arch and valid_idle\<rbrace>
+   activate_thread
    \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
-  apply(wp globals_equiv_scheduler_inv' activate_thread_globals_equiv | force | fastforce)+
-  done
+  by (wp globals_equiv_scheduler_inv' activate_thread_globals_equiv | force | fastforce)+
 
 lemma schedule_cur_domain:
   "\<lbrace>\<lambda>s. P (cur_domain s) \<and> domain_time s \<noteq> 0\<rbrace>
    schedule
-  \<lbrace>\<lambda> r s. P (cur_domain s)\<rbrace>" (is "\<lbrace>?PRE\<rbrace> _ \<lbrace>_\<rbrace>")
-  supply ethread_get_wp[wp del] hoare_pre_cont[where a=next_domain, wp add]
-  supply if_split[split del] if_cong[cong]
+   \<lbrace>\<lambda>_ s. P (cur_domain s)\<rbrace>"
+   (is "\<lbrace>?PRE\<rbrace> _ \<lbrace>_\<rbrace>")
+  supply hoare_pre_cont[where a=next_domain, wp add]
+         ethread_get_wp[wp del] if_split[split del] if_cong[cong]
   apply (simp add: schedule_def schedule_choose_new_thread_def | wp | wpc)+
                apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_strengthen_post)
                 apply (simp | wp gts_wp | wp (once) hoare_drop_imps)+
@@ -716,9 +550,10 @@ lemma schedule_cur_domain:
 lemma schedule_domain_fields:
   "\<lbrace>domain_fields P and (\<lambda>s. domain_time s \<noteq> 0)\<rbrace>
    schedule
-  \<lbrace>\<lambda> r. domain_fields P\<rbrace>"  (is "\<lbrace>?PRE\<rbrace> _ \<lbrace>_\<rbrace>")
-  supply ethread_get_wp[wp del] hoare_pre_cont[where a=next_domain, wp add]
-  supply if_split[split del] if_cong[cong]
+   \<lbrace>\<lambda>_. domain_fields P\<rbrace>"
+   (is "\<lbrace>?PRE\<rbrace> _ \<lbrace>_\<rbrace>")
+  supply hoare_pre_cont[where a=next_domain, wp add]
+         ethread_get_wp[wp del] if_split[split del] if_cong[cong]
   apply (simp add: schedule_def schedule_choose_new_thread_def | wp | wpc)+
                apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_strengthen_post)
                 apply (simp | wp gts_wp | wp (once) hoare_drop_imps)+
@@ -731,69 +566,61 @@ lemma schedule_domain_fields:
 
 lemma schedule_if_partitionIntegrity:
   assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "\<lbrace>partitionIntegrity aag st and guarded_pas_domain aag and pas_cur_domain aag and
-       (\<lambda>s. domain_time s \<noteq> 0) and silc_inv aag st and einvs and pas_refined aag\<rbrace>
-     schedule_if tc
-   \<lbrace>\<lambda> rv. partitionIntegrity aag st\<rbrace>"
-  apply(simp add: schedule_if_def)
-  apply(rule_tac Q="\<lambda>rv s. integrity (aag\<lparr> pasMayActivate := False, pasMayEditReadyQueues := False \<rparr>)
-                                     (scheduler_affects_globals_frame st) st s \<and>
-                           domain_fields_equiv st s \<and> idle_thread s = idle_thread st \<and>
-                           globals_equiv_scheduler st s \<and> silc_dom_equiv aag st s"
-                 in hoare_strengthen_post)
-   apply (wp activate_thread_integrity activate_thread_globals_equiv_scheduler
-             silc_dom_equiv_from_silc_inv_valid'[where P="\<top>"] schedule_integrity
-             hoare_vcg_all_lift domain_fields_equiv_lift[where Q="\<top>" and R="\<top>"]
-         | simp)+
-    apply(rule_tac Q="\<lambda> r s. guarded_pas_domain aag s \<and> pas_cur_domain aag s \<and>
-                domain_fields_equiv st s \<and>
-                idle_thread s = idle_thread st \<and>
-                globals_equiv_scheduler st s \<and>
-                silc_inv aag st s \<and> silc_dom_equiv aag st s \<and>
-            invs s" in hoare_strengthen_post)
+  shows "\<lbrace>partitionIntegrity aag st and guarded_pas_domain aag and pas_cur_domain aag and
+          (\<lambda>s. domain_time s \<noteq> 0) and silc_inv aag st and einvs and pas_refined aag\<rbrace>
+         schedule_if tc
+         \<lbrace>\<lambda>_. partitionIntegrity aag st\<rbrace>"
+  apply (simp add: schedule_if_def)
+  apply (rule_tac Q="\<lambda>rv s. integrity (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+                                      (scheduler_affects_globals_frame st) st s \<and>
+                            domain_fields_equiv st s \<and> idle_thread s = idle_thread st \<and>
+                            globals_equiv_scheduler st s \<and> silc_dom_equiv aag st s"
+               in hoare_strengthen_post)
+   apply (wpsimp wp: activate_thread_integrity activate_thread_globals_equiv_scheduler
+                     silc_dom_equiv_from_silc_inv_valid'[where P="\<top>"] schedule_integrity
+                     hoare_vcg_all_lift domain_fields_equiv_lift[where Q="\<top>" and R="\<top>"])
+    apply (rule_tac Q="\<lambda>r s. guarded_pas_domain aag s \<and> pas_cur_domain aag s \<and>
+                             domain_fields_equiv st s \<and> idle_thread s = idle_thread st \<and>
+                             globals_equiv_scheduler st s \<and> silc_inv aag st s \<and>
+                             silc_dom_equiv aag st s \<and> invs s" in hoare_strengthen_post)
      apply (wp schedule_guarded_pas_domain schedule_cur_domain
                silc_dom_equiv_from_silc_inv_valid'[where P="\<top>" and st=st]
                domain_fields_equiv_lift schedule_cur_domain schedule_domain_fields
-           | simp
-           | simp add: silc_inv_def partitionIntegrity_def guarded_pas_domain_def
-                       invs_valid_idle invs_valid_ko_at_arm silc_dom_equiv_def)+
-    apply(fastforce simp: equiv_for_refl dest: domains_distinct[THEN pas_domains_distinct_inj])
-   apply(fastforce simp: partitionIntegrity_def globals_equiv_scheduler_def)+
+            | simp add: silc_inv_def partitionIntegrity_def guarded_pas_domain_def
+                        invs_valid_idle invs_valid_ko_at_arch silc_dom_equiv_def)+
+    apply (fastforce simp: equiv_for_refl dest: domains_distinct[THEN pas_domains_distinct_inj])
+   apply (fastforce simp: partitionIntegrity_def globals_equiv_scheduler_def)+
   done
 
-
 lemma partitionIntegrity_integrity:
-  "partitionIntegrity aag s s' \<Longrightarrow>
-   integrity (aag\<lparr> pasMayActivate := False, pasMayEditReadyQueues := False \<rparr>)
-             (scheduler_affects_globals_frame s) s s'"
+  "partitionIntegrity aag s s'
+   \<Longrightarrow> integrity (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+                 (scheduler_affects_globals_frame s) s s'"
   by (clarsimp simp: partitionIntegrity_def)
 
 lemma receive_blocked_on_eq:
-  "\<lbrakk>receive_blocked_on ep ts; receive_blocked_on ep' ts\<rbrakk> \<Longrightarrow>
-    ep = ep'"
+  "\<lbrakk> receive_blocked_on ep ts; receive_blocked_on ep' ts \<rbrakk>
+     \<Longrightarrow> ep = ep'"
   by (case_tac ts; simp)
 
 lemma receive_blocked_on_eq':
-  "\<lbrakk>receive_blocked_on ep ts; blocked_on ep' ts\<rbrakk> \<Longrightarrow>
-    ep = ep'"
+  "\<lbrakk> receive_blocked_on ep ts; blocked_on ep' ts \<rbrakk>
+     \<Longrightarrow> ep = ep'"
   by (case_tac ts; simp)
 
 lemma receive_blocked_on_contradiction:
-  "\<lbrakk>receive_blocked_on ep ts; send_blocked_on ep' ts\<rbrakk> \<Longrightarrow>
-    False"
+  "\<lbrakk> receive_blocked_on ep ts; send_blocked_on ep' ts \<rbrakk>
+     \<Longrightarrow> False"
   by (case_tac ts; simp)
 
 lemma pas_refined_tcb_st_to_auth:
-  "\<lbrakk>pas_refined aag s; (ep, auth) \<in> tcb_st_to_auth (tcb_state tcb);
-    kheap s p = Some (TCB tcb)\<rbrakk> \<Longrightarrow>
-   (pasObjectAbs aag p, auth, pasObjectAbs aag ep) \<in> pasPolicy aag"
+  "\<lbrakk> pas_refined aag s; (ep, auth) \<in> tcb_st_to_auth (tcb_state tcb); kheap s p = Some (TCB tcb) \<rbrakk>
+     \<Longrightarrow> (pasObjectAbs aag p, auth, pasObjectAbs aag ep) \<in> pasPolicy aag"
   apply (rule pas_refined_mem)
    apply (rule_tac s=s in sta_ts)
    apply (simp add: thread_st_auth_def tcb_states_of_state_def get_tcb_def)
   apply assumption
   done
-
 
 (* FIXME DO _state abreviation for all elements and use them to write rule explicitely *)
 
@@ -826,200 +653,254 @@ lemmas integrity_subjects_asids =
 
 lemma pas_wellformed_pasSubject_update_Control:
   "\<lbrakk> pas_wellformed (aag\<lparr>pasSubject := pasObjectAbs aag p\<rparr>);
-     (pasObjectAbs aag p, Control, pasObjectAbs aag p') \<in> pasPolicy aag \<rbrakk> \<Longrightarrow>
-   pasObjectAbs aag p = pasObjectAbs aag p'"
-  apply(fastforce simp: policy_wellformed_def)
-  done
+     (pasObjectAbs aag p, Control, pasObjectAbs aag p') \<in> pasPolicy aag \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag p = pasObjectAbs aag p'"
+  by (fastforce simp: policy_wellformed_def)
 
 lemma pas_wellformed_noninterference_policy_refl:
-  "\<lbrakk> pas_wellformed_noninterference aag; pasObjectAbs aag x \<noteq> SilcLabel \<rbrakk> \<Longrightarrow>
-   (pasObjectAbs aag x, auth, pasObjectAbs aag x) \<in> pasPolicy aag"
+  "\<lbrakk> pas_wellformed_noninterference aag; pasObjectAbs aag x \<noteq> SilcLabel \<rbrakk>
+     \<Longrightarrow> (pasObjectAbs aag x, auth, pasObjectAbs aag x) \<in> pasPolicy aag"
   unfolding pas_wellformed_noninterference_def
   by (fastforce intro!:aag_wellformed_refl)
 
 lemma pas_wellformed_noninterference_control_to_eq:
   "\<lbrakk> pas_wellformed_noninterference aag;
-     (pasObjectAbs aag x, Control, l) \<in> pasPolicy aag;
-     pasObjectAbs aag x \<noteq> SilcLabel \<rbrakk> \<Longrightarrow>
-   pasObjectAbs aag x = l"
+     (pasObjectAbs aag x, Control, l) \<in> pasPolicy aag; pasObjectAbs aag x \<noteq> SilcLabel \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag x = l"
   unfolding pas_wellformed_noninterference_def
   by (erule aag_wellformed_Control; fastforce)
 
-lemma owns_mapping_owns_asidpool:
-  "\<lbrakk>kheap s p = Some (ArchObj (ASIDPool pool)); pool r = Some p';
-   pas_refined aag s; is_subject aag p';
-   pas_wellformed (aag\<lparr> pasSubject := (pasObjectAbs aag p) \<rparr>)\<rbrakk> \<Longrightarrow>
-   is_subject aag p"
-  apply(frule asid_pool_into_aag)
-    apply assumption+
-  apply(drule pas_wellformed_pasSubject_update_Control)
-   apply assumption
-  apply simp
-  done
-
 (* FIXME: MOVE *)
 lemma fun_noteqD:
-  "f \<noteq> g \<Longrightarrow> \<exists> a. f a \<noteq> g a"
+  "f \<noteq> g \<Longrightarrow> \<exists>a. f a \<noteq> g a"
   by blast
+
+
+locale Noninterference_1 =
+  fixes current_aag :: "det_state \<Rightarrow> 'a subject_label PAS"
+  and arch_globals_equiv_strengthener :: "machine_state \<Rightarrow> machine_state \<Rightarrow> bool"
+  assumes do_user_op_if_integrity:
+    "\<lbrace>invs and integrity aag X st and is_subject aag \<circ> cur_thread and pas_refined aag\<rbrace>
+     do_user_op_if uop tc
+     \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  and do_user_op_if_globals_equiv_scheduler:
+    "\<lbrace>globals_equiv_scheduler st and invs\<rbrace>
+     do_user_op_if uop tc
+     \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
+  and do_user_op_if_silc_dom_equiv[wp]:
+    "do_user_op_if uop tc \<lbrace>silc_dom_equiv (aag :: 'a subject_label PAS) st\<rbrace>"
+  and sameFor_scheduler_affects_equiv:
+    "\<And>s s'. \<lbrakk> (s,s') \<in> same_for aag PSched; (s,s') \<in> same_for aag (Partition l');
+              invs (internal_state_if s); invs (internal_state_if s') \<rbrakk>
+              \<Longrightarrow> scheduler_equiv aag (internal_state_if s) (internal_state_if s') \<and>
+                  scheduler_affects_equiv aag (OrdinaryLabel l')
+                                          (internal_state_if s) (internal_state_if s')"
+  and do_user_op_if_partitionIntegrity:
+    "\<And>aag :: 'a subject_label PAS.
+     \<lbrace>partitionIntegrity aag st and pas_refined aag and invs and is_subject aag \<circ> cur_thread\<rbrace>
+     do_user_op_if uop tc
+     \<lbrace>\<lambda>_. partitionIntegrity aag st\<rbrace>"
+  and arch_activate_idle_thread_reads_respects_g[wp]:
+    "reads_respects_g aag l \<top> (arch_activate_idle_thread t)"
+  and dmo_storeWord_reads_respects_g[wp]:
+    "reads_respects_g aag l \<top> (do_machine_op (storeWord ptr w))"
+  and partitionIntegrity_subjectAffects_aobj:
+    "\<lbrakk> kheap s x = Some (ArchObj ao); ao \<noteq> ao'; pas_refined aag s;
+       silc_inv aag st s; pas_wellformed_noninterference aag;
+       arch_integrity_obj_atomic (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+                               {pasSubject aag} (pasObjectAbs aag x) ao ao' \<rbrakk>
+       \<Longrightarrow> subject_can_affect_label_directly aag (pasObjectAbs aag x)"
+  and partitionIntegrity_subjectAffects_asid:
+    "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s; valid_objs s; valid_arch_state s;
+       valid_arch_state s'; pas_wellformed_noninterference aag; silc_inv aag st s'; invs s';
+       \<not> equiv_asids (\<lambda>x. pasASIDAbs aag x = a) s s'\<rbrakk>
+       \<Longrightarrow> a \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  and arch_switch_to_thread_reads_respects_g':
+    "equiv_valid (reads_equiv_g aag) (affects_equiv aag l)
+                 (\<lambda>s s'. affects_equiv aag l s s' \<and>
+                         arch_globals_equiv_strengthener (machine_state s) (machine_state s'))
+                 (\<lambda>s. is_subject aag t) (arch_switch_to_thread t)"
+  and arch_globals_equiv_strengthener_thread_independent:
+    "arch_globals_equiv_strengthener (machine_state s) (machine_state s')
+     \<Longrightarrow> \<forall>ct ct' it it'. arch_globals_equiv ct it (kheap s) (kheap s')
+                           (arch_state s) (arch_state s') (machine_state s) (machine_state s') =
+                         arch_globals_equiv ct' it' (kheap s) (kheap s')
+                           (arch_state s) (arch_state s') (machine_state s) (machine_state s')"
+  and ev2_invisible':
+    "\<lbrakk> pas_domains_distinct aag; labels_are_invisible aag l L; labels_are_invisible aag l L';
+       modifies_at_most aag L Q f; modifies_at_most aag L' Q' g;
+       doesnt_touch_globals Q f; doesnt_touch_globals Q' g;
+       \<And>st :: det_state. f \<lbrace>\<lambda>s. arch_globals_equiv_strengthener (machine_state st) (machine_state s)\<rbrace>;
+       \<And>st :: det_state. g \<lbrace>\<lambda>s. arch_globals_equiv_strengthener (machine_state st) (machine_state s)\<rbrace>;
+       \<forall>s t. P s \<and> P' t \<longrightarrow> (\<forall>(rva,s') \<in> fst (f s). \<forall>(rvb,t') \<in> fst (g t). W rva rvb) \<rbrakk>
+       \<Longrightarrow> equiv_valid_2 (reads_equiv_g aag)
+                         (\<lambda>s s'. affects_equiv aag l s s' \<and>
+                                 arch_globals_equiv_strengthener (machine_state s) (machine_state s'))
+                         (\<lambda>s s'. affects_equiv aag l s s' \<and>
+                                 arch_globals_equiv_strengthener (machine_state s) (machine_state s'))
+                         (W :: unit \<Rightarrow> unit \<Rightarrow> bool) (P and Q) (P' and Q') f g"
+  and arch_switch_to_idle_thread_reads_respects_g[wp]:
+    "reads_respects_g aag l \<top> (arch_switch_to_idle_thread)"
+  and arch_globals_equiv_threads_eq:
+    "arch_globals_equiv t' t'' kh kh' as as' ms ms'
+     \<Longrightarrow> arch_globals_equiv t t kh kh' as as' ms ms'"
+  and arch_globals_equiv_globals_equiv_scheduler[elim]:
+    "arch_globals_equiv (cur_thread s') (idle_thread s) (kheap s) (kheap s')
+                        (arch_state s) (arch_state s') (machine_state s) (machine_state s')
+     \<Longrightarrow> arch_globals_equiv_scheduler (kheap s) (kheap s') (arch_state s) (arch_state s')"
+  and getActiveIRQ_ret_no_dmo[wp]:
+    "\<lbrace>\<top>\<rbrace> getActiveIRQ in_kernel \<lbrace>\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ\<rbrace>"
+  and dmo_getActive_IRQ_reads_respect_scheduler:
+    "reads_respects_scheduler aag l (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+                             (do_machine_op (getActiveIRQ in_kernel))"
+begin
 
 text \<open>
   This a very important theorem that ensures that @{const subjectAffects} is
   coherent with @{const integrity_obj}
 \<close>
 lemma partitionIntegrity_subjectAffects_obj:
-  assumes par_inte: "partitionIntegrity aag s s'"
+  assumes par_inte: "partitionIntegrity (aag :: 'a subject_label PAS) s s'"
   assumes pas_ref: "pas_refined aag s"
   assumes invs: "invs s"
   assumes pwni: "pas_wellformed_noninterference aag"
   assumes silc_inv: "silc_inv aag st s"
   assumes kh_diff: "kheap s x \<noteq> kheap s' x"
-  notes  inte_obj = par_inte[THEN partitionIntegrity_integrity, THEN integrity_subjects_obj,
-                             THEN spec[where x=x], simplified integrity_obj_def, simplified]
-  shows
-   "pasObjectAbs aag x \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  notes inte_obj = par_inte[THEN partitionIntegrity_integrity, THEN integrity_subjects_obj,
+                            THEN spec[where x=x], simplified integrity_obj_def, simplified]
+  shows "pasObjectAbs aag x \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
   using inte_obj
-  proof (induct "kheap s x" rule: converse_rtranclp_induct)
-    case base
-    thus ?case using kh_diff by force
+proof (induct "kheap s x" rule: converse_rtranclp_induct)
+  case base
+  thus ?case using kh_diff by force
+next
+  case (step z)
+  note troa = step.hyps(1)
+  show ?case
+  proof (cases "z = kheap s x")
+    case True
+    thus ?thesis using step.hyps by blast
   next
-    case (step z)
-    note troa = step.hyps(1)
-    show ?case
-    proof (cases "z = kheap s x")
-      case True
-      thus ?thesis using step.hyps by blast
-    next
-      case False
-      note hyps = this pwni pas_ref invs silc_inv kh_diff
-      hence sym_helper: "\<And> auth tcb. kheap s x = Some (TCB tcb) \<Longrightarrow>
-                           (pasObjectAbs aag x, auth, pasObjectAbs aag x) \<in> pasPolicy aag"
+    case False
+    note hyps = this pwni pas_ref invs silc_inv kh_diff
+    hence sym_helper: "\<And>auth tcb. kheap s x = Some (TCB tcb) \<Longrightarrow>
+                                  (pasObjectAbs aag x, auth, pasObjectAbs aag x) \<in> pasPolicy aag"
       by (fastforce elim!: pas_wellformed_noninterference_policy_refl
                            silc_inv_cnode_onlyE obj_atE
                      simp: is_cap_table_def)
-      show ?thesis
+    show ?thesis
       using troa
-      proof (cases rule: integrity_obj_atomic.cases)
-        case troa_lrefl
-        thus ?thesis by (fastforce intro: subjectAffects.intros)
-      next
-        case (troa_ntfn ntfn ntfn' auth s)
-        thus ?thesis by (fastforce intro: affects_ep)
-      next
-        case (troa_ep ep ep' auth s)
-        thus ?thesis by (fastforce intro: affects_ep)
-      next
-        case (troa_ep_unblock ep ep' tcb ntfn)
-        thus ?thesis by (fastforce intro: affects_ep_bound_trans)
-      next
-        case (troa_tcb_send tcb tcb' ctxt' ep)
-        thus ?thesis using hyps
-          apply (clarsimp simp: direct_send_def indirect_send_def)
-          apply (erule disjE)
-           apply (clarsimp simp: receive_blocked_on_def2)
-           apply (frule(2) pas_refined_tcb_st_to_auth)
-           apply (fastforce intro!: affects_send sym_helper)
-          apply (fastforce intro!: affects_send bound_tcb_at_implies_receive
-                                   pred_tcb_atI sym_helper)
-          done
-      next
-        case (troa_tcb_call tcb tcb' caller R ctxt' ep)
-        thus ?thesis using hyps
-          apply (clarsimp simp add: direct_call_def ep_recv_blocked_def)
-          apply (rule affects_send[rotated 2])
-             apply (erule(1) pas_refined_tcb_st_to_auth[rotated 2]; force)
-            apply (fastforce intro: sym_helper)
-           apply assumption
-          apply blast
-          done
-      next
-        case (troa_tcb_reply tcb tcb' new_st ctxt')
-        thus ?thesis using hyps
-          apply clarsimp
-          apply (erule affects_reply)
-          by (rule sym_helper)
-      next
-        case (troa_tcb_receive tcb tcb' new_st ep)
-        thus ?thesis using hyps
-          by (auto intro: affects_recv pas_refined_tcb_st_to_auth simp: send_blocked_on_def2)
-      next
-        case (troa_tcb_restart tcb tcb' ep)
-        thus ?thesis using hyps
-          by (fastforce intro: affects_reset[where auth=Receive] affects_reset[where auth=SyncSend]
-                         elim: blocked_on.elims pas_refined_tcb_st_to_auth[rotated 2]
-                       intro!: sym_helper)
-      next
-        case (troa_tcb_unbind tcb tcb')
-        thus ?thesis using hyps
-          apply -
-          by (cases "tcb_bound_notification tcb" ;
-              fastforce intro: affects_reset[where auth=Receive] bound_tcb_at_implies_receive
-                               pred_tcb_atI sym_helper)
-      next
-        case (troa_tcb_empty_ctable tcb tcb' cap')
-        thus ?thesis using hyps
-          apply (clarsimp simp:reply_cap_deletion_integrity_def; elim disjE; clarsimp)
-          apply (rule affects_delete_derived)
-          apply (rule aag_wellformed_delete_derived[rotated -1, OF pas_refined_wellformed],
-                 assumption)
-          apply (frule cap_auth_caps_of_state[rotated,where p ="(x,tcb_cnode_index 0)"],
-                 force simp: caps_of_state_def')
-          by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def
-                              reply_cap_rights_to_auth_def
-                       split: if_splits)
-      next
-        case (troa_tcb_empty_caller tcb tcb' cap')
-        thus ?thesis using hyps
-          apply (clarsimp simp:reply_cap_deletion_integrity_def)
-          apply (elim disjE; clarsimp)
-          apply (rule affects_delete_derived)
-          apply (rule aag_wellformed_delete_derived[rotated -1, OF pas_refined_wellformed],
-                 assumption)
-          apply (frule cap_auth_caps_of_state[rotated,where p ="(x,tcb_cnode_index 3)"],
-                 force simp: caps_of_state_def')
-          by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def
-                              reply_cap_rights_to_auth_def
-                       split: if_splits)
-      next
-        case (troa_tcb_activate tcb tcb')
-        thus ?thesis by blast
-      next
-        case (troa_arch ao ao')
-        thus ?thesis (* TODO cleanup that one *)
-          using hyps unfolding arch_integrity_obj_atomic.simps asid_pool_integrity_def
-          apply clarsimp
-          apply (rule ccontr)
-          apply (drule fun_noteqD)
-          apply (erule exE, rename_tac r)
-          apply (drule_tac x=r in spec)
-          apply (clarsimp dest!:not_sym[where t=None])
-          apply (subgoal_tac "is_subject aag x", force intro:affects_lrefl)
-          apply (frule(1) aag_Control_into_owns)
-          apply (frule(2) asid_pool_into_aag)
-          apply simp
-          apply (frule(1) pas_wellformed_noninterference_control_to_eq)
-          by (fastforce elim!: silc_inv_cnode_onlyE obj_atE
-              simp: is_cap_table_def)
-      next
-        case (troa_cnode n content content')
-        thus ?thesis
-          using hyps unfolding cnode_integrity_def
-          apply clarsimp
-          apply (drule fun_noteqD)
-          apply (erule exE, rename_tac l)
-          apply (drule_tac x=l in spec)
-          apply (clarsimp dest!:not_sym[where t=None])
-          apply (clarsimp simp:reply_cap_deletion_integrity_def)
-          apply (rule affects_delete_derived)
-          apply (rule aag_wellformed_delete_derived[rotated -1, OF pas_refined_wellformed],
-                 assumption)
-          apply (frule_tac p="(x,l)" in cap_auth_caps_of_state[rotated])
-           apply (force simp: caps_of_state_def' intro:well_formed_cnode_invsI)
-          by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def
-                              reply_cap_rights_to_auth_def
-                       split: if_splits)
-      qed
+    proof (cases rule: integrity_obj_atomic.cases)
+      case troa_lrefl
+      thus ?thesis by (fastforce intro: subjectAffects.intros)
+    next
+      case (troa_ntfn ntfn ntfn' auth s)
+      thus ?thesis by (fastforce intro: affects_ep)
+    next
+      case (troa_ep ep ep' auth s)
+      thus ?thesis by (fastforce intro: affects_ep)
+    next
+      case (troa_ep_unblock ep ep' tcb ntfn)
+      thus ?thesis by (fastforce intro: affects_ep_bound_trans)
+    next
+      case (troa_tcb_send tcb tcb' ctxt' ep)
+      thus ?thesis using hyps
+        apply (clarsimp simp: direct_send_def indirect_send_def)
+        apply (erule disjE)
+         apply (clarsimp simp: receive_blocked_on_def2)
+         apply (frule (2) pas_refined_tcb_st_to_auth)
+         apply (fastforce intro!: affects_send sym_helper)
+        apply (fastforce intro!: affects_send bound_tcb_at_implies_receive
+                                 pred_tcb_atI sym_helper)
+        done
+    next
+      case (troa_tcb_call tcb tcb' caller R ctxt' ep)
+      thus ?thesis using hyps
+        apply (clarsimp simp add: direct_call_def ep_recv_blocked_def)
+        apply (rule affects_send[rotated 2])
+           apply (erule (1) pas_refined_tcb_st_to_auth[rotated 2]; force)
+          apply (fastforce intro: sym_helper)
+         apply assumption
+        apply blast
+        done
+    next
+      case (troa_tcb_reply tcb tcb' new_st ctxt')
+      thus ?thesis using hyps
+        apply clarsimp
+        apply (erule affects_reply)
+        by (rule sym_helper)
+    next
+      case (troa_tcb_receive tcb tcb' new_st ep)
+      thus ?thesis using hyps
+        by (auto intro: affects_recv pas_refined_tcb_st_to_auth simp: send_blocked_on_def2)
+    next
+      case (troa_tcb_restart tcb tcb' ep)
+      thus ?thesis using hyps
+        by (fastforce intro: affects_reset[where auth=Receive] affects_reset[where auth=SyncSend]
+                       elim: blocked_on.elims pas_refined_tcb_st_to_auth[rotated 2]
+                     intro!: sym_helper)
+    next
+      case (troa_tcb_unbind tcb tcb')
+      thus ?thesis using hyps
+        apply -
+        by (cases "tcb_bound_notification tcb" ;
+            fastforce intro: affects_reset[where auth=Receive] bound_tcb_at_implies_receive
+                             pred_tcb_atI sym_helper)
+    next
+      case (troa_tcb_empty_ctable tcb tcb' cap')
+      thus ?thesis using hyps
+        apply (clarsimp simp:reply_cap_deletion_integrity_def; elim disjE; clarsimp)
+        apply (rule affects_delete_derived)
+        apply (rule aag_wellformed_delete_derived[rotated -1, OF pas_refined_wellformed],
+               assumption)
+        apply (frule cap_auth_caps_of_state[rotated,where p ="(x,tcb_cnode_index 0)"],
+               force simp: caps_of_state_def')
+        by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def reply_cap_rights_to_auth_def
+                     split: if_splits)
+    next
+      case (troa_tcb_empty_caller tcb tcb' cap')
+      thus ?thesis using hyps
+        apply (clarsimp simp:reply_cap_deletion_integrity_def)
+        apply (elim disjE; clarsimp)
+        apply (rule affects_delete_derived)
+        apply (rule aag_wellformed_delete_derived[rotated -1, OF pas_refined_wellformed],
+               assumption)
+        apply (frule cap_auth_caps_of_state[rotated,where p ="(x,tcb_cnode_index 3)"],
+               force simp: caps_of_state_def')
+        by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def
+                            reply_cap_rights_to_auth_def
+                     split: if_splits)
+    next
+      case (troa_tcb_activate tcb tcb')
+      thus ?thesis by blast
+    next
+      case (troa_arch ao ao')
+      thus ?thesis (* TODO cleanup that one *)
+        using hyps partitionIntegrity_subjectAffects_aobj by fastforce
+    next
+      case (troa_cnode n content content')
+      thus ?thesis
+        using hyps unfolding cnode_integrity_def
+        apply clarsimp
+        apply (drule fun_noteqD)
+        apply (erule exE, rename_tac l)
+        apply (drule_tac x=l in spec)
+        apply (clarsimp dest!:not_sym[where t=None])
+        apply (clarsimp simp:reply_cap_deletion_integrity_def)
+        apply (rule affects_delete_derived)
+        apply (rule aag_wellformed_delete_derived[rotated -1, OF pas_refined_wellformed],
+               assumption)
+        apply (frule_tac p="(x,l)" in cap_auth_caps_of_state[rotated])
+         apply (force simp: caps_of_state_def' intro:well_formed_cnode_invsI)
+        by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def
+                            reply_cap_rights_to_auth_def
+                     split: if_splits)
     qed
   qed
+qed
+
+end
+
 
 lemma kheap_ep_tcb_states_of_state_eq:
   "kheap s x = kheap s' x \<Longrightarrow> tcb_states_of_state s x = tcb_states_of_state s' x"
@@ -1031,13 +912,14 @@ lemma partitionIntegrity_subjectAffects_mem:
   assumes invs: "invs s"
   assumes um_diff:
     "underlying_memory (machine_state s) x \<noteq> underlying_memory (machine_state s') x"
-  notes inte_mem = par_inte[THEN partitionIntegrity_integrity, THEN integrity_subjects_mem, THEN spec[where x=x]]
+  notes inte_mem =
+    par_inte[THEN partitionIntegrity_integrity, THEN integrity_subjects_mem, THEN spec[where x=x]]
   shows
   "pasObjectAbs aag x \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
   using inte_mem
   proof (cases rule: integrity_mem.cases)
     case trm_lrefl
-    thus ?thesis by(fastforce intro: affects_lrefl)
+    thus ?thesis by (fastforce intro: affects_lrefl)
   next
     case trm_orefl
     thus ?thesis using um_diff by blast
@@ -1061,7 +943,7 @@ lemma partitionIntegrity_subjectAffects_mem:
         apply (clarsimp simp: direct_send_def indirect_send_def)
         apply (erule disjE)
          apply (clarsimp simp: receive_blocked_on_def2)
-         apply (frule(2) pas_refined_tcb_st_to_auth)
+         apply (frule (2) pas_refined_tcb_st_to_auth)
          apply (fastforce intro!: affects_send auth_ipc_buffers_mem_Write')
         apply clarsimp
         apply (rule affects_send[rotated 2])
@@ -1076,7 +958,7 @@ lemma partitionIntegrity_subjectAffects_mem:
       thus ?thesis using hyps
         apply (clarsimp simp add: direct_call_def ep_recv_blocked_def)
         apply (rule affects_send[rotated 2])
-           apply (erule(1) pas_refined_tcb_st_to_auth[rotated 2]; force)
+           apply (erule (1) pas_refined_tcb_st_to_auth[rotated 2]; force)
           apply (fastforce intro!: auth_ipc_buffers_mem_Write')
          apply assumption
         apply blast
@@ -1084,7 +966,7 @@ lemma partitionIntegrity_subjectAffects_mem:
     next
       case (tro_alt_tcb_reply tcb tcb' ccap' cap' ntfn' new_st)
       thus ?thesis using hyps
-        apply (clarsimp simp:direct_reply_def)
+        apply (clarsimp simp: direct_reply_def)
         apply (erule affects_reply)
         by (force intro: auth_ipc_buffers_mem_Write')
     next
@@ -1092,10 +974,10 @@ lemma partitionIntegrity_subjectAffects_mem:
       thus ?thesis using hyps
         apply (clarsimp elim!: tcb_states_of_state_kheapE send_blocked_on.elims
                                can_receive_ipc.elims)
-        apply (frule(1) pas_refined_tcb_st_to_auth[rotated 2,where auth=Call and ep =ep])
+        apply (frule (1) pas_refined_tcb_st_to_auth[rotated 2,where auth=Call and ep =ep])
          apply force
         apply (rule affects_reply)
-         apply (erule(1) aag_wellformed_reply, force)
+         apply (erule (1) aag_wellformed_reply, force)
         apply (fastforce intro!: auth_ipc_buffers_mem_Write')
         done
     next
@@ -1104,39 +986,28 @@ lemma partitionIntegrity_subjectAffects_mem:
         by (fastforce intro: affects_reset[where auth=Receive] affects_reset[where auth=SyncSend]
                        elim: blocked_on.elims pas_refined_tcb_st_to_auth[rotated 2]
                      intro!: auth_ipc_buffers_mem_Write')
-    qed (insert hyps, force elim:tcb_states_of_state_kheapE)+
+    qed (insert hyps, force elim: tcb_states_of_state_kheapE)+
   qed
 
-lemma blocked_onD:
-  "blocked_on ref ts \<Longrightarrow> receive_blocked_on ref ts \<or> send_blocked_on ref ts"
-  apply(case_tac ts)
-  apply(simp_all)
-  done
-
-(* FIXME: cleanup *)
 lemma partitionIntegrity_subjectAffects_cdt:
-  "\<lbrakk>partitionIntegrity aag s s'; pas_refined aag s; valid_mdb s; valid_objs s;
-    cdt s (x,y) \<noteq> cdt s' (x,y)\<rbrakk> \<Longrightarrow>
-   pasObjectAbs aag x
-     \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
-  apply(drule partitionIntegrity_integrity)
-  apply(drule integrity_subjects_cdt)
-  apply(drule_tac x="(x,y)" in spec)
-  apply(clarsimp simp: integrity_cdt_def)
+  "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s;
+     valid_mdb s; valid_objs s; cdt s (x,y) \<noteq> cdt s' (x,y) \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag x \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  apply (drule partitionIntegrity_integrity)
+  apply (drule integrity_subjects_cdt)
+  apply (drule_tac x="(x,y)" in spec)
+  apply (clarsimp simp: integrity_cdt_def)
   apply (rule affects_delete_derived)
-  apply (frule(3) cdt_change_allowed_delete_derived)
+  apply (frule (3) cdt_change_allowed_delete_derived)
   by simp
 
 lemma partitionIntegrity_subjectAffects_cdt_list:
-  "\<lbrakk>partitionIntegrity aag s s'; pas_refined aag s; pas_refined aag s';
-   valid_list s; valid_list s'; silc_inv aag st s; silc_inv aag st' s';
-    pas_wellformed_noninterference aag;
-    invs s; invs s';
-    cdt_list s (x,y) \<noteq> cdt_list s' (x,y)\<rbrakk> \<Longrightarrow>
-   pasObjectAbs aag x
-     \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
-  apply(drule partitionIntegrity_integrity)
-  apply(drule integrity_subjects_cdt_list)
+  "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s; pas_refined aag s';
+     valid_list s; valid_list s'; silc_inv aag st s; silc_inv aag st' s';
+     pas_wellformed_noninterference aag; invs s; invs s'; cdt_list s (x,y) \<noteq> cdt_list s' (x,y) \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag x \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  apply (drule partitionIntegrity_integrity)
+  apply (drule integrity_subjects_cdt_list)
   apply (simp add: integrity_cdt_list_def)
   apply (drule_tac x="x" in spec)
   apply (drule_tac x="y" in spec)
@@ -1147,12 +1018,12 @@ lemma partitionIntegrity_subjectAffects_cdt_list:
     apply (subgoal_tac "pasObjectAbs aag (fst xa) = SilcLabel")
      apply simp
      apply (rule affects_delete_derived)
-     apply (frule(3) cdt_change_allowed_delete_derived[OF invs_valid_objs invs_mdb])
+     apply (frule (3) cdt_change_allowed_delete_derived[OF invs_valid_objs invs_mdb])
      apply force
     subgoal by (fastforce simp add: silc_inv_def valid_list_2_def all_children_def
                           simp del: split_paired_All)
    apply (rule affects_delete_derived2)
-    apply (frule(3) cdt_change_allowed_delete_derived[OF invs_valid_objs invs_mdb])
+    apply (frule (3) cdt_change_allowed_delete_derived[OF invs_valid_objs invs_mdb])
     apply assumption
    subgoal by (fastforce dest!: aag_cdt_link_DeleteDerived
                          simp add: valid_list_2_def
@@ -1171,56 +1042,50 @@ lemma partitionIntegrity_subjectAffects_is_original_cap:
   apply (drule_tac x="(x,y)" in spec)
   apply (clarsimp simp: integrity_cdt_def)
   apply (rule affects_delete_derived)
-  apply (frule(3) cdt_change_allowed_delete_derived)
+  apply (frule (3) cdt_change_allowed_delete_derived)
   by simp
 
 lemma partitionIntegrity_subjectAffects_interrupt_states:
-  "\<lbrakk>partitionIntegrity aag s s'; pas_refined aag s; valid_objs s;
-    interrupt_states s x \<noteq> interrupt_states s' x\<rbrakk> \<Longrightarrow>
-   pasIRQAbs aag x
-     \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
-  apply(drule partitionIntegrity_integrity)
-  apply(drule integrity_subjects_interrupts)
-  apply(drule_tac x=x in spec)
-  apply(clarsimp simp: integrity_interrupts_def)
-  apply(rule affects_lrefl)
+  "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s;
+     valid_objs s; interrupt_states s x \<noteq> interrupt_states s' x \<rbrakk>
+     \<Longrightarrow> pasIRQAbs aag x \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  apply (drule partitionIntegrity_integrity)
+  apply (drule integrity_subjects_interrupts)
+  apply (drule_tac x=x in spec)
+  apply (clarsimp simp: integrity_interrupts_def)
+  apply (rule affects_lrefl)
   done
 
 lemma partitionIntegrity_subjectAffects_interrupt_irq_node:
-  "\<lbrakk>partitionIntegrity aag s s'; pas_refined aag s; valid_objs s;
-    interrupt_irq_node s x \<noteq> interrupt_irq_node s' x\<rbrakk> \<Longrightarrow>
-   pasIRQAbs aag x
-     \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
-  apply(drule partitionIntegrity_integrity)
-  apply(drule integrity_subjects_interrupts)
-  apply(drule_tac x=x in spec)
-  apply(clarsimp simp: integrity_interrupts_def)
-  apply(rule affects_lrefl)
+  "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s; valid_objs s;
+     interrupt_irq_node s x \<noteq> interrupt_irq_node s' x \<rbrakk>
+     \<Longrightarrow> pasIRQAbs aag x \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  apply (drule partitionIntegrity_integrity)
+  apply (drule integrity_subjects_interrupts)
+  apply (drule_tac x=x in spec)
+  apply (clarsimp simp: integrity_interrupts_def)
+  apply (rule affects_lrefl)
   done
 
-
 lemma pas_wellformed_pasSubject_update:
-  "\<lbrakk>pas_wellformed_noninterference aag; silc_inv aag st s;  invs s;
-   (kheap s x = Some (TCB t) \<or> kheap s x = Some (ArchObj (ASIDPool a)))\<rbrakk> \<Longrightarrow>
-   pas_wellformed (aag\<lparr>pasSubject := pasObjectAbs aag x\<rparr>)"
-  apply(simp add: pas_wellformed_noninterference_def)
-  apply(elim conjE)
-  apply(erule bspec)
-  apply(clarsimp simp:  silc_inv_def obj_at_def split: kernel_object.splits)
-  apply(drule spec, erule (1) impE)
-  apply(fastforce simp: is_cap_table_def)
+  "\<lbrakk> pas_wellformed_noninterference aag; silc_inv aag st s; invs s;
+     kheap s x = Some (TCB t) \<or> kheap s x = Some (ArchObj a) \<rbrakk>
+     \<Longrightarrow> pas_wellformed (aag\<lparr>pasSubject := pasObjectAbs aag x\<rparr>)"
+  apply (simp add: pas_wellformed_noninterference_def)
+  apply (elim conjE)
+  apply (erule bspec)
+  apply (clarsimp simp:  silc_inv_def obj_at_def split: kernel_object.splits)
+  apply (drule spec, erule (1) impE)
+  apply (fastforce simp: is_cap_table_def)
   done
 
 lemma partitionIntegrity_subjectAffects_eobj:
-  "\<lbrakk>partitionIntegrity aag s s'; pas_refined aag s; valid_objs s;
-    einvs s; einvs s';
-    pas_wellformed_noninterference aag; silc_inv aag st s;
-    silc_inv aag st' s';
-    ekheap s x \<noteq> ekheap s' x\<rbrakk> \<Longrightarrow>
-   pasObjectAbs aag x
-     \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
-  apply(drule partitionIntegrity_integrity)
-  apply(drule integrity_subjects_eobj)
+  "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s;
+     valid_objs s; einvs s; einvs s'; pas_wellformed_noninterference aag;
+     silc_inv aag st s; silc_inv aag st' s'; ekheap s x \<noteq> ekheap s' x \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag x \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  apply (drule partitionIntegrity_integrity)
+  apply (drule integrity_subjects_eobj)
   apply (drule_tac x=x in spec)
   apply (erule integrity_eobj.cases)
    apply simp
@@ -1230,50 +1095,48 @@ lemma partitionIntegrity_subjectAffects_eobj:
 
 (*FIXME: Move*)
 lemma prefix_helper:
-  "\<lbrakk>a @ l = l'; distinct l; distinct l'\<rbrakk> \<Longrightarrow> set a \<inter> set l = {} \<and> set a \<subseteq> set l'"
-    apply (induct l)
-    apply simp+
-    by (metis append_Cons disjoint_iff_not_equal distinct.simps(2) distinct_append
-              distinct_length_2_or_more subset_code(1))
+  "\<lbrakk> a @ l = l'; distinct l; distinct l' \<rbrakk> \<Longrightarrow> set a \<inter> set l = {} \<and> set a \<subseteq> set l'"
+  apply (induct l)
+   apply simp+
+  by (metis append_Cons disjoint_iff_not_equal distinct.simps(2) distinct_append
+            distinct_length_2_or_more subset_code(1))
 
 (*FIXME: Move*)
-lemma valid_queuesE: "valid_queues s \<Longrightarrow> t \<in> set (ready_queues s d p) \<Longrightarrow>
-                     (\<lbrakk>is_etcb_at t s; etcb_at (\<lambda>t. tcb_priority t = p \<and> tcb_domain t = d) t s;
-                      st_tcb_at runnable t s; distinct (ready_queues s d p)\<rbrakk> \<Longrightarrow> R) \<Longrightarrow> R"
-  by (clarsimp simp: valid_queues_def)
+lemma valid_queuesE:
+  assumes "valid_queues s"
+  assumes "t \<in> set (ready_queues s d p)"
+  assumes "\<lbrakk> is_etcb_at t s; etcb_at (\<lambda>t. tcb_priority t = p \<and> tcb_domain t = d) t s;
+             st_tcb_at runnable t s; distinct (ready_queues s d p) \<rbrakk>
+             \<Longrightarrow> R "
+  shows R
+  using assms by (clarsimp simp: valid_queues_def)
 
-
-lemma valid_blocked_imp: "valid_blocked s \<Longrightarrow> tcb_at t s \<Longrightarrow> not_queued t s \<Longrightarrow>
-                         t \<noteq> cur_thread s \<Longrightarrow> scheduler_action s \<noteq> switch_thread t \<Longrightarrow>
-                         st_tcb_at (\<lambda>s. \<not> runnable s) t s"
-  apply (fastforce simp: valid_blocked_def st_tcb_at_def
-                        tcb_at_st_tcb_at runnable_eq_active
-                        obj_at_def)
-  done
+lemma valid_blocked_imp:
+  "\<lbrakk> valid_blocked s; tcb_at t s; not_queued t s;
+     t \<noteq> cur_thread s; scheduler_action s \<noteq> switch_thread t \<rbrakk>
+     \<Longrightarrow> st_tcb_at (\<lambda>s. \<not> runnable s) t s"
+  by (fastforce simp: valid_blocked_def st_tcb_at_def
+                      tcb_at_st_tcb_at runnable_eq_active obj_at_def)
 
 lemma valid_queues_not_in_place:
-  "\<lbrakk>valid_queues s; t \<notin> set (ready_queues s d a);
-    etcb_at (\<lambda>t. tcb_priority t = a \<and> tcb_domain t = d) t s; is_etcb_at t s\<rbrakk>
-    \<Longrightarrow> not_queued t s"
-  by (clarsimp simp: valid_queues_def not_queued_def etcb_at_def
-                        is_etcb_at_def
-                  split: option.splits)
+  "\<lbrakk> valid_queues s; t \<notin> set (ready_queues s d a);
+     etcb_at (\<lambda>t. tcb_priority t = a \<and> tcb_domain t = d) t s; is_etcb_at t s\<rbrakk>
+     \<Longrightarrow> not_queued t s"
+  by (clarsimp simp: valid_queues_def not_queued_def etcb_at_def is_etcb_at_def
+              split: option.splits)
 
 lemma ready_queues_alters_kheap:
-   assumes a: "valid_queues s"
-   assumes b: "valid_blocked s"
-   assumes c: "valid_idle s'"
-  shows
-   "\<lbrakk>ready_queues s d a \<noteq> ready_queues s' d a;
-        threads @ ready_queues s d a = ready_queues s' d a;
-         valid_queues s'; valid_etcbs s; valid_etcbs s';
-        t \<in> set threads; ekheap s t = ekheap s' t;
-        (t \<noteq> idle_thread s \<longrightarrow> (t \<noteq> cur_thread s \<and> t \<noteq> cur_thread s'));
-        scheduler_action s \<noteq> switch_thread t; idle_thread s = idle_thread s'\<rbrakk>
-       \<Longrightarrow> kheap s t \<noteq> kheap s' t"
+  assumes a: "valid_queues s"
+  assumes b: "valid_blocked s"
+  assumes c: "valid_idle s'"
+  shows "\<lbrakk> ready_queues s d a \<noteq> ready_queues s' d a;
+           threads @ ready_queues s d a = ready_queues s' d a; valid_queues s';
+           valid_etcbs s; valid_etcbs s'; t \<in> set threads; ekheap s t = ekheap s' t;
+           t \<noteq> idle_thread s \<longrightarrow> (t \<noteq> cur_thread s \<and> t \<noteq> cur_thread s');
+           scheduler_action s \<noteq> switch_thread t; idle_thread s = idle_thread s' \<rbrakk>
+           \<Longrightarrow> kheap s t \<noteq> kheap s' t"
   apply (frule prefix_helper)
-    using a
-    apply ((simp add: valid_queues_def)+)[2]
+    using a apply ((simp add: valid_queues_def)+)[2]
   apply clarsimp
   apply (drule(1) set_mp)
   apply (drule(1) orthD1)
@@ -1283,24 +1146,23 @@ lemma ready_queues_alters_kheap:
       apply (rule valid_queues_not_in_place[OF a],assumption)
        apply (simp add: etcb_at_def)
       apply (simp add: is_etcb_at_def)
-     using c
-     apply (clarsimp simp: pred_tcb_at_def tcb_at_st_tcb_at
-                           obj_at_def valid_idle_def)+
+     using c apply (auto simp: pred_tcb_at_def tcb_at_st_tcb_at obj_at_def valid_idle_def)
    done
 
 lemma valid_sched_valid_blocked: "valid_sched s \<Longrightarrow> valid_blocked s"
   by (simp add: valid_sched_def)
 
+
+context Noninterference_1 begin
+
 lemma partitionIntegrity_subjectAffects_ready_queues:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "\<lbrakk>partitionIntegrity aag s s'; pas_refined aag s; valid_objs s;
-    einvs s; einvs s'; pas_refined aag s'; pas_cur_domain aag s;
-    pas_wellformed_noninterference aag; silc_inv aag st s;
-    silc_inv aag st' s'; cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject aag (cur_thread s);
-     cur_thread s' \<noteq> idle_thread s' \<longrightarrow> is_subject aag (cur_thread s');
-    ready_queues s d \<noteq> ready_queues s' d\<rbrakk> \<Longrightarrow>
-   pasDomainAbs aag d \<inter> subjectAffects (pasPolicy aag) (pasSubject aag) \<noteq> {}"
+  assumes domains_distinct: "pas_domains_distinct (aag :: 'a subject_label PAS)"
+  shows "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s; valid_objs s; einvs s; einvs s';
+           pas_refined aag s'; pas_cur_domain aag s; pas_wellformed_noninterference aag;
+           silc_inv aag st s; silc_inv aag st' s'; ready_queues s d \<noteq> ready_queues s' d;
+           cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject aag (cur_thread s);
+           cur_thread s' \<noteq> idle_thread s' \<longrightarrow> is_subject aag (cur_thread s') \<rbrakk>
+           \<Longrightarrow> pasDomainAbs aag d \<inter> subjectAffects (pasPolicy aag) (pasSubject aag) \<noteq> {}"
   apply (clarsimp simp: disjoint_iff_not_equal)
   apply (frule valid_sched_valid_blocked[where s=s])
   apply (case_tac "pasSubject aag \<in> pasDomainAbs aag d")
@@ -1320,114 +1182,69 @@ lemma partitionIntegrity_subjectAffects_ready_queues:
   apply (rename_tac tcb_ptr tcbs tcb)
   apply (rule_tac x = "pasObjectAbs aag tcb_ptr" in bexI)
    apply (case_tac "scheduler_action s = switch_thread tcb_ptr")
-    apply (drule switch_within_domain)
+    apply (drule switch_to_cur_domain[rotated])
       apply simp
      apply simp
     apply (fastforce dest: domains_distinct[THEN pas_domains_distinct_inj])
-
    apply (case_tac "ekheap s tcb_ptr \<noteq> ekheap s' tcb_ptr")
     apply (rule_tac s=s and s'=s' in partitionIntegrity_subjectAffects_eobj)
-           apply (simp add: partitionIntegrity_def)+
+            apply (simp add: partitionIntegrity_def)+
    apply (subgoal_tac "kheap s tcb_ptr \<noteq> kheap s' tcb_ptr")
     apply (rule partitionIntegrity_subjectAffects_obj)
-            apply (fastforce simp add: partitionIntegrity_def valid_sched_def)+
+         apply (fastforce simp add: partitionIntegrity_def valid_sched_def)+
    apply (rule_tac threads="tcb_ptr # tcbs" in ready_queues_alters_kheap)
                apply (fastforce simp add: partitionIntegrity_def valid_sched_def)+
   done
 
+end
+
+
 lemma pas_refined_asid_mem:
   "\<lbrakk> v \<in> state_asids_to_policy aag s; pas_refined aag s \<rbrakk>
-         \<Longrightarrow> v \<in> pasPolicy aag"
+     \<Longrightarrow> v \<in> pasPolicy aag"
   by (auto simp add: pas_refined_def)
-
-lemma partitionIntegrity_subjectAffects_asid:
-  "\<lbrakk>partitionIntegrity aag s s'; pas_refined aag s; valid_objs s; valid_arch_state s;
-    valid_arch_state s';
-    pas_wellformed_noninterference aag; silc_inv aag st s'; invs s';
-    \<not> equiv_asids (\<lambda>x. pasASIDAbs aag x = a) s s'\<rbrakk> \<Longrightarrow>
-         a \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
-  apply (clarsimp simp: equiv_asids_def equiv_asid_def asid_pool_at_kheap)
-  apply (case_tac "arm_asid_table (arch_state s) (asid_high_bits_of asid) =
-                  arm_asid_table (arch_state s') (asid_high_bits_of asid)")
-   apply (clarsimp simp: valid_arch_state_def valid_asid_table_def)
-   apply (drule_tac x=pool_ptr in bspec)
-    apply blast
-   apply (drule_tac x=pool_ptr in bspec)
-    apply blast
-   apply (clarsimp simp: asid_pool_at_kheap)
-   apply (rule affects_asidpool_map)
-   apply (rule pas_refined_asid_mem)
-    apply (drule partitionIntegrity_integrity)
-    apply (drule integrity_subjects_obj)
-    apply (drule_tac x="pool_ptr" in spec)+
-    apply (drule tro_tro_alt, erule integrity_obj_alt.cases;simp )
-     apply (drule_tac t="pasSubject aag" in sym)
-     apply simp
-     apply (rule sata_asidpool)
-      apply assumption
-     apply assumption
-    apply (simp add: arch_integrity_obj_alt.simps asid_pool_integrity_def)
-    apply (drule_tac x="ucast asid" in spec)+
-    apply clarsimp
-    apply (drule owns_mapping_owns_asidpool)
-        apply ((simp
-              | blast intro: pas_refined_Control[THEN sym]
-              | fastforce intro: pas_wellformed_pasSubject_update[simplified])+)[4]
-    apply (drule_tac t="pasSubject aag" in sym)+
-    apply simp
-    apply (rule sata_asidpool)
-     apply assumption
-    apply assumption
-   apply assumption
-  apply clarsimp
-  apply (drule partitionIntegrity_integrity)
-  apply (clarsimp simp: integrity_def)
-  apply (drule_tac x=asid in spec)+
-  apply (clarsimp simp: integrity_asids_def)
-  apply (fastforce intro: affects_lrefl)
-  done
 
 lemma sameFor_subject_def2:
   "sameFor_subject g ab irqab asidab domainab l =
-    {(os,os')|os os' s s'. s = internal_state_if os \<and> s' = internal_state_if os' \<and>
-              (\<forall> d \<in> subjectReads g (OrdinaryLabel l).
-                          states_equiv_for (\<lambda>x. ab x = d) (\<lambda>x. irqab x  = d) (\<lambda>x. asidab x = d)
-                                           (\<lambda>x. d \<in> domainab x) s s') \<and>
-              ((domainab (cur_domain s) \<inter> subjectReads g (OrdinaryLabel l) \<noteq> {} \<or>
-                domainab (cur_domain s') \<inter> subjectReads g (OrdinaryLabel l) \<noteq> {}) \<longrightarrow>
-                 cur_domain s = cur_domain s' \<and> globals_equiv s s' \<and>
-                 scheduler_action s = scheduler_action s' \<and>
-                 work_units_completed s = work_units_completed s' \<and>
-                 irq_state (machine_state s) = irq_state (machine_state s') \<and>
-                 (user_modes (sys_mode_of os) \<longrightarrow> user_context_of os = user_context_of os') \<and>
-                 sys_mode_of os = sys_mode_of os' \<and>
-                 equiv_for (\<lambda> x. ab x = SilcLabel) kheap s s')}"
-  apply(clarsimp simp: sameFor_subject_def)
-  apply(rule equalityI)
-   apply(rule subsetI)
-   apply(drule CollectD)
-   apply(rule CollectI)
-   apply(clarify)
-   apply(rule exI)+
-   apply(rule conjI, rule refl)
-   apply(rule conjI)
-    apply(rule ballI)
-    apply(erule states_equiv_for_guard_imp)
-       apply(blast+)[4]
-   apply(fastforce simp: globals_equiv_def)
-  apply(rule subsetI)
-  apply(drule CollectD)
-  apply(rule CollectI)
-  apply(clarify)
-  apply(rule exI)+
-  apply(rule conjI, rule refl)
-  apply(rule conjI)
-   apply(rule states_equiv_forI)
-           apply((fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+)[5]
-       apply(fastforce intro: equiv_forI elim: states_equiv_forE_is_original_cap)
-      apply((fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+)[2]
-    apply(solves \<open>clarsimp simp: equiv_asids_def equiv_asid_def states_equiv_for_def\<close>)
-   apply(fastforce intro: equiv_forI elim: states_equiv_forE_ready_queues)
+     {(os,os') | os os' s s'. s = internal_state_if os \<and> s' = internal_state_if os' \<and>
+                 (\<forall>d \<in> subjectReads g (OrdinaryLabel l).
+                    states_equiv_for (\<lambda>x. ab x = d) (\<lambda>x. irqab x  = d)
+                                     (\<lambda>x. asidab x = d) (\<lambda>x. d \<in> domainab x) s s') \<and>
+                 ((domainab (cur_domain s) \<inter> subjectReads g (OrdinaryLabel l) \<noteq> {} \<or>
+                   domainab (cur_domain s') \<inter> subjectReads g (OrdinaryLabel l) \<noteq> {})
+                  \<longrightarrow> cur_domain s = cur_domain s' \<and> globals_equiv s s' \<and>
+                      scheduler_action s = scheduler_action s' \<and>
+                      work_units_completed s = work_units_completed s' \<and>
+                      irq_state (machine_state s) = irq_state (machine_state s') \<and>
+                      (user_modes (sys_mode_of os) \<longrightarrow> user_context_of os = user_context_of os') \<and>
+                      sys_mode_of os = sys_mode_of os' \<and>
+                      equiv_for (\<lambda>x. ab x = SilcLabel) kheap s s')}"
+  apply (clarsimp simp: sameFor_subject_def)
+  apply (rule equalityI)
+   apply (rule subsetI)
+   apply (drule CollectD)
+   apply (rule CollectI)
+   apply (clarify)
+   apply (rule exI)+
+   apply (rule conjI, rule refl)
+   apply (rule conjI)
+    apply (rule ballI)
+    apply (erule states_equiv_for_guard_imp)
+       apply (blast+)[4]
+   apply (fastforce simp: globals_equiv_def)
+  apply (rule subsetI)
+  apply (drule CollectD)
+  apply (rule CollectI)
+  apply (clarify)
+  apply (rule exI)+
+  apply (rule conjI, rule refl)
+  apply (rule conjI)
+   apply (rule states_equiv_forI)
+            apply ((fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+)[5]
+       apply (fastforce intro: equiv_forI elim: states_equiv_forE_is_original_cap)
+      apply ((fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+)[2]
+    apply (solves \<open>clarsimp simp: equiv_asids_def states_equiv_for_def\<close>)
+   apply (fastforce intro: equiv_forI elim: states_equiv_forE_ready_queues)
   apply fastforce
   done
 
@@ -1437,29 +1254,27 @@ text \<open>
 \<close>
 
 lemma subject_can_affect_its_own_partition:
-  "d\<notin>partsSubjectAffects (pasPolicy aag) (label_of (pasSubject aag)) \<Longrightarrow>
-   d \<noteq> Partition (label_of (pasSubject aag))"
-  apply(erule contrapos_nn)
-  apply(simp add: partsSubjectAffects_def image_def label_can_affect_partition_def)
-  apply(blast intro: affects_lrefl)
+  "d \<notin> partsSubjectAffects (pasPolicy aag) (label_of (pasSubject aag))
+   \<Longrightarrow> d \<noteq> Partition (label_of (pasSubject aag))"
+  apply (erule contrapos_nn)
+  apply (simp add: partsSubjectAffects_def image_def label_can_affect_partition_def)
+  apply (blast intro: affects_lrefl)
   done
 
 (* FIXME: cleanup this wonderful proof *)
 lemma partitionIntegrity_subjectAffects_device:
-  "\<lbrakk>partitionIntegrity aag s s'; pas_refined aag s; invs s;
-    invs s';
-    device_state (machine_state s) x \<noteq> device_state (machine_state s') x;
-    x \<notin> range_of_arm_globals_frame s \<or> x \<notin> range_of_arm_globals_frame s'\<rbrakk>
-   \<Longrightarrow> pasObjectAbs aag x \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
-  apply(drule partitionIntegrity_integrity)
-  apply(frule integrity_subjects_device)
-  apply(drule_tac x=x in spec)
-  apply(erule integrity_device.cases)
-    apply(fastforce intro: affects_lrefl)
+  "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s; invs s; invs s';
+     device_state (machine_state s) x \<noteq> device_state (machine_state s') x;
+     x \<notin> range_of_arm_globals_frame s \<or> x \<notin> range_of_arm_globals_frame s' \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag x \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  apply (drule partitionIntegrity_integrity)
+  apply (frule integrity_subjects_device)
+  apply (drule_tac x=x in spec)
+  apply (erule integrity_device.cases)
+    apply (fastforce intro: affects_lrefl)
    apply blast
-  apply(fastforce intro: affects_write)
+  apply (fastforce intro: affects_write)
   done
-
 
 
 (* a hack to prevent safe etc. below from taking apart the implication *)
@@ -1468,25 +1283,26 @@ where
   "guarded_is_subject_cur_thread aag s \<equiv>
         cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject aag (cur_thread s)"
 
+
+context Noninterference_1 begin
+
 lemma partsSubjectAffects_bounds_subjects_affects:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "\<lbrakk>partitionIntegrity aag s s'; pas_refined aag s; pas_refined aag s'; valid_objs s;
-    valid_arch_state s'; einvs s; einvs s'; silc_inv aag st s; silc_inv aag st' s';
-    pas_wellformed_noninterference aag; pas_cur_domain aag s;
-    guarded_is_subject_cur_thread aag s; guarded_is_subject_cur_thread aag s';
-    d \<notin> partsSubjectAffects (pasPolicy aag) (label_of (pasSubject aag));
-    d \<noteq> PSched\<rbrakk> \<Longrightarrow>
-   (((uc,s),mode),((uc',s'),mode')) \<in> same_for aag d"
+  assumes domains_distinct: "pas_domains_distinct (aag :: 'a subject_label PAS)"
+  shows "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s; pas_refined aag s'; valid_objs s;
+           valid_arch_state s'; einvs s; einvs s'; silc_inv aag st s; silc_inv aag st' s';
+           pas_wellformed_noninterference aag; pas_cur_domain aag s;
+           guarded_is_subject_cur_thread aag s; guarded_is_subject_cur_thread aag s';
+           d \<notin> partsSubjectAffects (pasPolicy aag) (label_of (pasSubject aag)); d \<noteq> PSched \<rbrakk>
+           \<Longrightarrow> (((uc,s),mode),((uc',s'),mode')) \<in> same_for aag d"
   apply (frule pasSubject_not_SilcLabel)
-  apply(erule contrapos_np)
-  apply(cases d)
+  apply (erule contrapos_np)
+  apply (cases d)
    prefer 2
    apply simp
-  apply(clarsimp simp: sameFor_def sameFor_subject_def2 states_equiv_for_def equiv_for_def
+  apply (clarsimp simp: sameFor_def sameFor_subject_def2 states_equiv_for_def equiv_for_def
                        partsSubjectAffects_def image_def label_can_affect_partition_def)
   apply (safe del: iffI notI)
-                             apply(fastforce dest: partitionIntegrity_subjectAffects_obj)
+                             apply (fastforce dest: partitionIntegrity_subjectAffects_obj)
                             apply ((auto dest: partitionIntegrity_subjectAffects_obj
                                                partitionIntegrity_subjectAffects_eobj
                                                partitionIntegrity_subjectAffects_mem
@@ -1498,167 +1314,159 @@ lemma partsSubjectAffects_bounds_subjects_affects:
                                                partitionIntegrity_subjectAffects_interrupt_irq_node
                                                partitionIntegrity_subjectAffects_asid
                                                partitionIntegrity_subjectAffects_ready_queues
-                                                 [folded guarded_is_subject_cur_thread_def, OF domains_distinct]
+                                                 [folded guarded_is_subject_cur_thread_def,
+                                                  OF domains_distinct]
                                                domains_distinct[THEN pas_domains_distinct_inj]
-                                  | fastforce simp: partitionIntegrity_def silc_dom_equiv_def equiv_for_def)+)[11]
-                 apply ((fastforce intro: affects_lrefl simp: partitionIntegrity_def domain_fields_equiv_def
+                                    | fastforce simp: partitionIntegrity_def
+                                                      silc_dom_equiv_def equiv_for_def)+)[11]
+                 apply ((fastforce intro: affects_lrefl
+                                   simp: partitionIntegrity_def domain_fields_equiv_def
                                    dest: domains_distinct[THEN pas_domains_distinct_inj])+)[16]
   done
 
+end
+
+
 lemma cur_thread_not_SilcLabel:
-  "\<lbrakk>silc_inv aag st s; invs s\<rbrakk> \<Longrightarrow>
-   pasObjectAbs aag (cur_thread s) \<noteq> SilcLabel"
-  apply(rule notI)
-  apply(simp add: silc_inv_def)
-  apply(drule tcb_at_invs)
+  "\<lbrakk> silc_inv aag st s; invs s \<rbrakk> \<Longrightarrow> pasObjectAbs aag (cur_thread s) \<noteq> SilcLabel"
+  apply (rule notI)
+  apply (simp add: silc_inv_def)
+  apply (drule tcb_at_invs)
   apply clarify
-  apply(drule_tac x="cur_thread s" in spec, erule (1) impE)
-  apply(auto simp: obj_at_def is_tcb_def is_cap_table_def)
-  apply(case_tac ko, simp_all)
+  apply (drule_tac x="cur_thread s" in spec, erule (1) impE)
+  apply (auto simp: obj_at_def is_tcb_def is_cap_table_def)
+  apply (case_tac ko, simp_all)
   done
 
-
-
-
-
-lemma ev_add_pre: "equiv_valid_inv I A P f \<Longrightarrow> equiv_valid_inv I A (P and Q) f"
+lemma ev_add_pre:
+  "equiv_valid_inv I A P f \<Longrightarrow> equiv_valid_inv I A (P and Q) f"
   apply (rule equiv_valid_guard_imp)
-  apply assumption
+   apply assumption
   apply simp
   done
 
 crunch invs[wp]: check_active_irq_if "einvs"
   (wp: dmo_getActiveIRQ_wp ignore: do_machine_op)
 
-definition partition :: "'a subject_label agent_domain_map \<Rightarrow> det_state \<Rightarrow> 'a"
-where
-  "partition ab s \<equiv> label_of (the_elem (ab (cur_domain s)))"
-
-
 crunch schact_is_rct[wp]: thread_set "schact_is_rct"
   (wp: get_object_wp simp: schact_is_rct_def)
 
-end
+definition partition :: "'a subject_label agent_domain_map \<Rightarrow> det_state \<Rightarrow> 'a" where
+  "partition ab s \<equiv> label_of (the_elem (ab (cur_domain s)))"
+
+lemma silc_inv_refl:
+  "silc_inv aag st s \<Longrightarrow> silc_inv aag s s"
+  by (fastforce simp: silc_inv_def silc_dom_equiv_def equiv_for_refl
+              intro!: silc_inv_no_transferableD')
+
 
 section \<open>Valid initial state is complete unwinding system\<close>
 
 context valid_initial_state begin
 
-text\<open>current running partition\<close>
-definition part
-where
+text \<open>current running partition\<close>
+definition part where
   "part s \<equiv> if scheduler_modes (sys_mode_of s) then PSched
              else Partition (partition (pasDomainAbs initial_aag) (internal_state_if s))"
 
-text\<open>unwinding relation\<close>
-definition uwr
-where
+text \<open>unwinding relation\<close>
+definition uwr where
   "uwr \<equiv> same_for initial_aag"
 
 end
 
-text \<open>Here we are basically that the big step ADT of the kernel is a
-        valid complete unwinding system on the policyFlow policy
+
+text \<open>
+  Here we are basically that the big step ADT of the kernel is a
+  valid complete unwinding system on the policyFlow policy
 
   For those unfamiliar with the local subtleties, we are importing the all the facts
   of the complete_unwinding_system locale in the valid_initial_state locale under namespace ni.
 \<close>
-sublocale valid_initial_state \<subseteq>
-          ni?: complete_unwinding_system
-                           "big_step_ADT_A_if utf" (* the ADT that we prove infoflow for *)
-                           s0                      (* initial state *)
-                           "\<lambda>e s. part s"          (* dom function *)
-                           "uwr" (* uwr *)
-                           "policyFlows (pasPolicy initial_aag)" (* policy *)
-                           "undefined"             (* out -- unused *)
-                           PSched                  (* scheduler partition name *)
-  apply(simp add: complete_unwinding_system_def big_step_ADT_A_if_enabled_Step_system
-                  unwinding_system_def complete_unwinding_system_axioms_def)
-  apply(rule conjI)
-   apply(unfold_locales)
+sublocale valid_initial_state \<subseteq> ni?:
+   complete_unwinding_system "big_step_ADT_A_if utf" (* the ADT that we prove infoflow for *)
+                             s0                      (* initial state *)
+                             "\<lambda>e s. part s"          (* dom function *)
+                             uwr                     (* uwr *)
+                             "policyFlows (pasPolicy initial_aag)" (* policy *)
+                             undefined               (* out -- unused *)
+                             PSched                  (* scheduler partition name *)
+  apply (simp add: complete_unwinding_system_def big_step_ADT_A_if_enabled_Step_system
+                   unwinding_system_def complete_unwinding_system_axioms_def)
+  apply (rule conjI)
+   apply (unfold_locales)
       apply (clarsimp simp: equiv_def uwr_def, safe)[1]
-        apply(simp add: sameFor_refl)
-       apply(simp add: sameFor_sym)
-      apply(simp add: sameFor_trans)
-     apply(clarsimp simp: uwr_def sameFor_def sameFor_scheduler_def part_def
+        apply (simp add: sameFor_refl)
+       apply (simp add: sameFor_sym)
+      apply (simp add: sameFor_trans)
+     apply (clarsimp simp: uwr_def sameFor_def sameFor_scheduler_def part_def
                           domain_fields_equiv_def partition_def)
-    apply(rule PSched_flows_to_all)
-   apply(case_tac x)
-    apply(fastforce simp: no_partition_flows_to_PSched)
+    apply (rule PSched_flows_to_all)
+   apply (case_tac x)
+    apply (fastforce simp: no_partition_flows_to_PSched)
    apply simp
-  apply(simp add: refl_onD[OF policyFlows_refl])
+  apply (simp add: refl_onD[OF policyFlows_refl])
   done
 
 lemma Fin_big_step_adt:
   "Fin (big_step_adt A R evmap) = Fin A"
-  apply (simp add: big_step_adt_def)
-  done
+  by (simp add: big_step_adt_def)
+
 
 context valid_initial_state begin
 
-interpretation Arch . (*FIXME: arch_split*)
-
-
-
 lemma small_step_reachable:
   "ni.reachable s \<Longrightarrow> system.reachable (ADT_A_if utf) s0 s"
-  apply(rule reachable_big_step_adt)
-  apply(simp add: big_step_ADT_A_if_def)
+  apply (rule reachable_big_step_adt)
+  apply (simp add: big_step_ADT_A_if_def)
   done
 
 lemma reachable_invs_if:
   "ni.reachable s \<Longrightarrow> invs_if s"
-  apply(rule ADT_A_if_reachable_invs_if)
-  apply(erule small_step_reachable)
+  apply (rule ADT_A_if_reachable_invs_if)
+  apply (erule small_step_reachable)
   done
 
-abbreviation pas_refined_if
-where
+abbreviation pas_refined_if where
   "pas_refined_if s \<equiv> pas_refined (current_aag (internal_state_if s)) (internal_state_if s)"
 
-abbreviation guarded_pas_domain_if
-where
+abbreviation guarded_pas_domain_if where
   "guarded_pas_domain_if s \<equiv>
-      guarded_pas_domain (current_aag (internal_state_if s)) (internal_state_if s)"
+     guarded_pas_domain (current_aag (internal_state_if s)) (internal_state_if s)"
 
 lemma pas_refined_if:
   "ni.reachable  s \<Longrightarrow> pas_refined_if s"
-  apply(drule reachable_invs_if)
-  apply(simp add: invs_if_def Invs_def)
+  apply (drule reachable_invs_if)
+  apply (simp add: invs_if_def Invs_def)
   done
 
 lemma guarded_pas_domain_if:
   "ni.reachable  s \<Longrightarrow> guarded_pas_domain_if s"
-  apply(drule reachable_invs_if)
-  apply(simp add: invs_if_def Invs_def)
+  apply (drule reachable_invs_if)
+  apply (simp add: invs_if_def Invs_def)
   done
 
 lemma current_aag_eqI:
-  "cur_domain s = cur_domain t \<Longrightarrow>
-   current_aag s = current_aag t"
-  apply(simp add: current_aag_def)
-  done
+  "cur_domain s = cur_domain t \<Longrightarrow> current_aag s = current_aag t"
+  by (simp add: current_aag_def)
 
 lemma pas_refined_current_aag':
-  "\<lbrakk>reachable t; current_aag (internal_state_if s) = current_aag (internal_state_if t)\<rbrakk> \<Longrightarrow>
-   pas_refined (current_aag (internal_state_if s)) (internal_state_if t)"
-  apply(fastforce intro: pas_refined_if)
-  done
+  "\<lbrakk> reachable t; current_aag (internal_state_if s) = current_aag (internal_state_if t) \<rbrakk>
+     \<Longrightarrow> pas_refined (current_aag (internal_state_if s)) (internal_state_if t)"
+  by (fastforce intro: pas_refined_if)
 
 lemma guarded_pas_domain_current_aag':
-  "\<lbrakk>reachable t; current_aag (internal_state_if s) = current_aag (internal_state_if t)\<rbrakk> \<Longrightarrow>
-   guarded_pas_domain (current_aag (internal_state_if s)) (internal_state_if t)"
-  apply(fastforce intro: guarded_pas_domain_if)
-  done
+  "\<lbrakk> reachable t; current_aag (internal_state_if s) = current_aag (internal_state_if t) \<rbrakk>
+     \<Longrightarrow> guarded_pas_domain (current_aag (internal_state_if s)) (internal_state_if t)"
+  by (fastforce intro: guarded_pas_domain_if)
 
-abbreviation partition_if
-where
+abbreviation partition_if where
   "partition_if s \<equiv> partition (pasDomainAbs initial_aag) (internal_state_if s)"
 
 lemma pasDomainAbs_not_SilcLabel[simp]:
   "SilcLabel \<notin> pasDomainAbs initial_aag x"
-  apply(rule pas_wellformed_noninterference_silc)
-  apply(rule policy_wellformed)
+  apply (rule pas_wellformed_noninterference_silc)
+  apply (rule policy_wellformed)
   done
 
 lemma domain_in_ordinary_label[simp]:
@@ -1670,28 +1478,30 @@ lemma domain_in_ordinary_label[simp]:
   done
 
 lemma uwr_partition_if:
-  "\<lbrakk>(os,os') \<in> uwr (Partition (partition_if os));
-    s = internal_state_if os; s' = internal_state_if os'\<rbrakk> \<Longrightarrow>
-   states_equiv_for
-     (\<lambda>x. pasObjectAbs initial_aag x \<in>
-            subjectReads (pasPolicy initial_aag) (OrdinaryLabel (partition (pasDomainAbs initial_aag) s)))
-     (\<lambda>x. pasIRQAbs initial_aag x \<in>
-            subjectReads (pasPolicy initial_aag) (OrdinaryLabel (partition (pasDomainAbs initial_aag) s)))
-     (\<lambda>x. pasASIDAbs initial_aag x \<in>
-            subjectReads (pasPolicy initial_aag) (OrdinaryLabel (partition (pasDomainAbs initial_aag) s)))
-     (\<lambda>x. pasDomainAbs initial_aag x \<inter>
-              subjectReads (pasPolicy initial_aag) (OrdinaryLabel (partition (pasDomainAbs initial_aag) s))
-            \<noteq> {})
-     s s' \<and>
-   cur_thread s = cur_thread s' \<and> cur_domain s = cur_domain s' \<and>
-   globals_equiv s s' \<and> scheduler_action s = scheduler_action s' \<and>
-   work_units_completed s = work_units_completed s' \<and>
-   irq_state (machine_state s) = irq_state (machine_state s') \<and>
-   (user_modes (sys_mode_of os) \<longrightarrow> user_context_of os = user_context_of os') \<and>
-   sys_mode_of os = sys_mode_of os' \<and>
-   equiv_for (\<lambda>x. pasObjectAbs initial_aag x = SilcLabel) kheap s s'"
-  apply(simp add: uwr_def sameFor_def sameFor_subject_def)
-  apply(clarify | simp (no_asm_use) add: partition_def)+
+  "\<lbrakk> (os,os') \<in> uwr (Partition (partition_if os));
+     s = internal_state_if os; s' = internal_state_if os' \<rbrakk>
+     \<Longrightarrow> states_equiv_for
+           (\<lambda>x. pasObjectAbs initial_aag x \<in>
+                  subjectReads (pasPolicy initial_aag)
+                               (OrdinaryLabel (partition (pasDomainAbs initial_aag) s)))
+           (\<lambda>x. pasIRQAbs initial_aag x \<in>
+                  subjectReads (pasPolicy initial_aag)
+                               (OrdinaryLabel (partition (pasDomainAbs initial_aag) s)))
+           (\<lambda>x. pasASIDAbs initial_aag x \<in>
+                  subjectReads (pasPolicy initial_aag)
+                               (OrdinaryLabel (partition (pasDomainAbs initial_aag) s)))
+           (\<lambda>x. pasDomainAbs initial_aag x \<inter>
+                subjectReads (pasPolicy initial_aag)
+                             (OrdinaryLabel (partition (pasDomainAbs initial_aag) s)) \<noteq> {}) s s' \<and>
+         cur_thread s = cur_thread s' \<and> cur_domain s = cur_domain s' \<and>
+         globals_equiv s s' \<and> scheduler_action s = scheduler_action s' \<and>
+         work_units_completed s = work_units_completed s' \<and>
+         irq_state (machine_state s) = irq_state (machine_state s') \<and>
+         (user_modes (sys_mode_of os) \<longrightarrow> user_context_of os = user_context_of os') \<and>
+         sys_mode_of os = sys_mode_of os' \<and>
+         equiv_for (\<lambda>x. pasObjectAbs initial_aag x = SilcLabel) kheap s s'"
+  apply (simp add: uwr_def sameFor_def sameFor_subject_def)
+  apply (clarify | simp (no_asm_use) add: partition_def)+
   apply (subst (asm) the_subject_of_aag_domain, rule subject_current_aag)+
   apply (simp add: current_aag_def)
   apply (erule impE)
@@ -1699,248 +1509,205 @@ lemma uwr_partition_if:
   apply (fastforce simp: globals_equiv_def)
   done
 
-
 lemma schact_is_rct_eqI:
-  "\<lbrakk>(s,t) \<in> uwr(Partition (partition_if s))\<rbrakk> \<Longrightarrow>
-       schact_is_rct (internal_state_if s) = schact_is_rct (internal_state_if t)"
-  apply(drule uwr_partition_if[OF _ refl refl])
-  apply(simp add: schact_is_rct_def)
+  "(s,t) \<in> uwr(Partition (partition_if s))
+   \<Longrightarrow> schact_is_rct (internal_state_if s) = schact_is_rct (internal_state_if t)"
+  apply (drule uwr_partition_if[OF _ refl refl])
+  apply (simp add: schact_is_rct_def)
   done
 
 (*FIXME move*)
 lemma handle_ev[wp]:
-  assumes ok:
-    "equiv_valid I AA AA P f"
-  assumes err:
-    "\<And> e. equiv_valid I AA AA (E e) (handler e)"
-  assumes hoare:
-    "\<lbrace> P \<rbrace> f -, \<lbrace> E \<rbrace>"
-  shows
-  "equiv_valid I AA AA P (f <handle> handler)"
-  apply(simp add: handleE_def handleE'_def)
+  assumes ok: "equiv_valid I AA AA P f"
+  assumes err: "\<And>e. equiv_valid I AA AA (E e) (handler e)"
+  assumes hoare: "\<lbrace>P\<rbrace> f -, \<lbrace>E\<rbrace>"
+  shows "equiv_valid I AA AA P (f <handle> handler)"
+  apply (simp add: handleE_def handleE'_def)
   apply (wp err ok | wpc | simp)+
-   apply(insert hoare[simplified validE_E_def validE_def])[1]
-   apply(simp split: sum.splits)
+   apply (insert hoare[simplified validE_E_def validE_def])[1]
+   apply (simp split: sum.splits)
   by simp
 
-(*
-lemma Step[simp]:
-  "ni.Step = system.Step (big_step_ADT_A_if utf)"
-  apply(rule ext)
-  apply(simp add: system.Step_def execution_def big_step_ADT_A_if_def big_step_adt_def steps_def)
-  done
-*)
-
-
 lemma pas_refined_initial_aag_reachable:
-  "system.reachable (big_step_ADT_A_if utf) s0 s \<Longrightarrow>
-   pas_refined initial_aag (internal_state_if s)"
-  apply(simp add: initial_aag_bak[where s="internal_state_if s"])
-  apply(rule pas_refined_pasSubject_update[OF pas_refined_if pas_wellformed_cur])
+  "system.reachable (big_step_ADT_A_if utf) s0 s
+   \<Longrightarrow> pas_refined initial_aag (internal_state_if s)"
+  apply (simp add: initial_aag_bak[where s="internal_state_if s"])
+  apply (rule pas_refined_pasSubject_update[OF pas_refined_if pas_wellformed_cur])
    apply assumption
   apply (clarsimp simp: current_aag_def)
   apply blast
   done
 
 lemma silc_inv_initial_aag_reachable:
-  "system.reachable (big_step_ADT_A_if utf) s0 s \<Longrightarrow>
-   silc_inv initial_aag s0_internal (internal_state_if s)"
-  apply(simp add: silc_inv_cur[symmetric])
-  apply(fastforce dest: reachable_invs_if simp: invs_if_def Invs_def)
+  "system.reachable (big_step_ADT_A_if utf) s0 s
+   \<Longrightarrow> silc_inv initial_aag s0_internal (internal_state_if s)"
+  apply (simp add: silc_inv_cur[symmetric])
+  apply (fastforce dest: reachable_invs_if simp: invs_if_def Invs_def)
   done
 
 lemma uwr_def_cur:
   "uwr \<equiv> same_for (current_aag (internal_state_if s))"
-  apply(simp add: uwr_def current_aag_def)
-  done
+  by (simp add: uwr_def current_aag_def)
 
 lemma Step_big_step_ADT_A_if:
   "data_type.Step (big_step_ADT_A_if utf) = big_steps (ADT_A_if utf) big_step_R big_step_evmap"
-  apply(simp add: big_step_ADT_A_if_def big_step_adt_def)
-  done
+  by (simp add: big_step_ADT_A_if_def big_step_adt_def)
 
 lemma partitionIntegrity_refl:
   "partitionIntegrity aag s s"
-  apply(fastforce simp: partitionIntegrity_def intro: integrity_refl globals_equiv_scheduler_refl
-                  simp: silc_dom_equiv_def domain_fields_equiv_def intro: equiv_for_refl)
-  done
+  by (fastforce simp: partitionIntegrity_def silc_dom_equiv_def domain_fields_equiv_def
+               intro: integrity_refl globals_equiv_scheduler_refl equiv_for_refl)
 
 lemma partitionIntegrity_trans:
-  "partitionIntegrity aag s t \<Longrightarrow> partitionIntegrity aag t u \<Longrightarrow> partitionIntegrity aag s u"
-  apply(clarsimp simp: partitionIntegrity_def)
-  apply(rule conjI)
-   apply(blast intro: integrity_trans)
-  apply(fastforce intro: domain_fields_equiv_trans
-                   simp: silc_dom_equiv_def)
+  "\<lbrakk> partitionIntegrity aag s t; partitionIntegrity aag t u \<rbrakk>
+     \<Longrightarrow> partitionIntegrity aag s u"
+  apply (clarsimp simp: partitionIntegrity_def)
+  apply (rule conjI)
+   apply (blast intro: integrity_trans)
+  apply (fastforce intro: domain_fields_equiv_trans simp: silc_dom_equiv_def)
   done
 
 lemma check_active_irq_A_if_partitionIntegrity:
   "((a, b), x, aa, ba) \<in> check_active_irq_A_if
-  \<Longrightarrow> partitionIntegrity (current_aag b) b ba"
-  apply(simp add: check_active_irq_A_if_def)
-  apply(erule use_valid)
-   apply(wp check_active_irq_if_partitionIntegrity)
-  apply(rule partitionIntegrity_refl)
+   \<Longrightarrow> partitionIntegrity (current_aag b) b ba"
+  apply (simp add: check_active_irq_A_if_def)
+  apply (erule use_valid)
+   apply (wp check_active_irq_if_partitionIntegrity)
+  apply (rule partitionIntegrity_refl)
   done
 
 lemma check_active_irq_A_if_result_state:
-  "((a, b), x, aa, ba) \<in> check_active_irq_A_if \<Longrightarrow>
-    ba =  (b\<lparr>machine_state := machine_state b
-              \<lparr>irq_state := irq_state_of_state b + 1\<rparr>\<rparr>)"
-  apply(simp add: check_active_irq_A_if_def check_active_irq_if_def)
-  apply(erule use_valid)
-   apply(wp dmo_getActiveIRQ_wp)
-  apply(simp)
+  "((a, b), x, aa, ba) \<in> check_active_irq_A_if
+   \<Longrightarrow> ba = (b\<lparr>machine_state := (machine_state b)\<lparr>irq_state := irq_state_of_state b + 1\<rparr>\<rparr>)"
+  apply (simp add: check_active_irq_A_if_def check_active_irq_if_def)
+  apply (erule use_valid)
+   apply (wp dmo_getActiveIRQ_wp)
+  apply simp
   done
 
 lemma ct_running_not_ct_idle:
-  "valid_idle s \<Longrightarrow> ct_running s \<Longrightarrow> \<not> ct_idle s"
-  apply(simp add: ct_in_state_def valid_idle_def)
-  apply(simp add: st_tcb_at_def obj_at_def)
-  apply auto
-  done
-
-lemma do_user_op_A_if_partitionIntegrity:
-  "((a, b), x, aa, ba) \<in> do_user_op_A_if uop \<Longrightarrow> ct_running b \<Longrightarrow> Invs b
-  \<Longrightarrow> partitionIntegrity (current_aag b) b ba"
-  apply(simp add: do_user_op_A_if_def)
-  apply(erule use_valid)
-   apply(wp do_user_op_if_partitionIntegrity)
-  apply(simp add: partitionIntegrity_refl)
-  apply(simp add: Invs_def)
-  apply(clarsimp simp: guarded_pas_domain_def current_aag_def)
-  apply(erule impE)
-   apply(erule ct_running_not_idle)
-    apply (simp add: invs_valid_idle)
-  apply (simp add: the_subject_of_aag_domain)
-  done
-
-lemma partitionIntegrity_current_aag_eq:
-  "partitionIntegrity (current_aag ( s)) ( s)
-      ( s') \<Longrightarrow>
-        current_aag ( s') = current_aag ( s)"
-  apply(simp add: current_aag_def partitionIntegrity_def domain_fields_equiv_def)
-  done
-
-lemma partitionIntegrity_trans':
-  "\<lbrakk>partitionIntegrity (current_aag ( s)) ( s)
-         ( s');
-   partitionIntegrity (current_aag ( s')) ( s')
-           ( t)\<rbrakk>  \<Longrightarrow>
-   partitionIntegrity (current_aag ( s)) ( s)
-           ( t)"
-  apply(rule partitionIntegrity_trans, assumption)
-  apply(simp add: partitionIntegrity_current_aag_eq)
-  done
-
-
-lemma user_small_Step_partitionIntegrity:
-  "\<lbrakk>((a, b), x, aa, ba) \<in> check_active_irq_A_if; ct_running b; Invs b;
-        ((aa, ba), y, ab, bb) \<in> do_user_op_A_if utf\<rbrakk>
-       \<Longrightarrow> partitionIntegrity (current_aag b) b bb"
-  apply(rule partitionIntegrity_trans'[rotated])
-   apply(rule do_user_op_A_if_partitionIntegrity)
-     apply assumption
-    apply(drule check_active_irq_A_if_result_state)
-    apply simp
-   apply(drule check_active_irq_A_if_result_state)
-   apply(simp add: Invs_def current_aag_def)
-  apply(rule check_active_irq_A_if_partitionIntegrity)
-  apply assumption
-  done
-
-lemma silc_inv_refl:
-  "silc_inv aag st s \<Longrightarrow> silc_inv aag s s"
-  by (fastforce simp: silc_inv_def silc_dom_equiv_def equiv_for_refl
-                intro!: silc_inv_no_transferableD')
-
-lemma ct_active_cur_thread_not_idle_thread:
-  "valid_idle s \<Longrightarrow> ct_active s \<Longrightarrow> cur_thread s \<noteq> idle_thread s"
-  apply(simp add: ct_in_state_def valid_idle_def)
-  apply(simp add: pred_tcb_at_def obj_at_def)
-  apply auto
-  done
+  "\<lbrakk> valid_idle s; ct_running s \<rbrakk> \<Longrightarrow> \<not> ct_idle s"
+  by (auto simp: ct_in_state_def valid_idle_def st_tcb_at_def obj_at_def)
 
 lemma kernel_call_A_if_partitionIntegrity:
-  "\<lbrakk>((a, b), x, aa, ba) \<in> kernel_call_A_if e; e \<noteq> Interrupt; ct_active b; Invs b;
-    scheduler_action b = resume_cur_thread\<rbrakk>
-  \<Longrightarrow> partitionIntegrity (current_aag b) b ba"
-  apply(clarsimp simp: kernel_call_A_if_def)
-  apply(erule use_valid)
-   apply(wp kernel_entry_if_partitionIntegrity)
-  apply(clarsimp simp: partitionIntegrity_refl Invs_def silc_inv_refl)
-  apply(simp add: guarded_pas_domain_def current_aag_def active_from_running schact_is_rct_def)
-  apply(erule impE)
-   apply(rule ct_active_cur_thread_not_idle_thread, simp add: invs_valid_idle)
+  "\<lbrakk> ((a, b), x, aa, ba) \<in> kernel_call_A_if e; e \<noteq> Interrupt;
+     ct_active b; Invs b; scheduler_action b = resume_cur_thread \<rbrakk>
+     \<Longrightarrow> partitionIntegrity (current_aag b) b ba"
+  apply (clarsimp simp: kernel_call_A_if_def)
+  apply (erule use_valid)
+   apply (wp kernel_entry_if_partitionIntegrity)
+  apply (clarsimp simp: partitionIntegrity_refl Invs_def silc_inv_refl)
+  apply (simp add: guarded_pas_domain_def current_aag_def active_from_running schact_is_rct_def)
+  apply (erule impE)
+   apply (rule ct_active_cur_thread_not_idle_thread, simp add: invs_valid_idle)
    apply simp
   apply (simp add: the_subject_of_aag_domain)
   done
 
 lemma not_schedule_modes_KernelEntry:
   "(\<not> scheduler_modes (KernelEntry event)) = (event \<noteq> Interrupt)"
-  apply(case_tac event, simp_all)
-  done
+  by (case_tac event, simp_all)
 
 lemma Step_ADT_A_if'':
-  "(s, t) \<in> data_type.Step (ADT_A_if utf) () \<Longrightarrow>
-       system.reachable (ADT_A_if utf) s0 s \<Longrightarrow>
-       (s,t) \<in> system.Step (ADT_A_if utf) ()"
+  "\<lbrakk> (s, t) \<in> data_type.Step (ADT_A_if utf) (); system.reachable (ADT_A_if utf) s0 s \<rbrakk>
+     \<Longrightarrow> (s, t) \<in> system.Step (ADT_A_if utf) ()"
   apply (simp add: system.reachable_def)
   apply (clarsimp)
   apply (frule execution_invs)
   apply (frule invs_if_full_invs_if)
   apply (frule execution_restrict)
-  apply(simp add: system.Step_def execution_def steps_def ADT_A_if_def)
+  apply (simp add: system.Step_def execution_def steps_def ADT_A_if_def)
+  done
+
+end
+
+
+locale Noninterference_valid_initial_state =
+  Noninterference_1 current_aag + valid_initial_state _ _ _ _ _ current_aag for current_aag
+begin
+
+lemma do_user_op_A_if_partitionIntegrity:
+  "((a, b), x, aa, ba) \<in> do_user_op_A_if uop \<Longrightarrow> ct_running b \<Longrightarrow> Invs b
+   \<Longrightarrow> partitionIntegrity (current_aag b) b ba"
+  apply (simp add: do_user_op_A_if_def)
+  apply (erule use_valid)
+   apply (wp do_user_op_if_partitionIntegrity)
+  apply (simp add: partitionIntegrity_refl)
+  apply (simp add: Invs_def)
+  apply (clarsimp simp: guarded_pas_domain_def current_aag_def)
+  apply (erule impE)
+   apply (erule ct_running_not_idle)
+   apply (simp add: invs_valid_idle)
+  apply (simp add: the_subject_of_aag_domain)
+  done
+
+lemma partitionIntegrity_current_aag_eq:
+  "partitionIntegrity (current_aag s) s s' \<Longrightarrow> current_aag s' = current_aag s"
+  by (simp add: current_aag_def partitionIntegrity_def domain_fields_equiv_def)
+
+lemma partitionIntegrity_trans':
+  "\<lbrakk> partitionIntegrity (current_aag s) s s';
+     partitionIntegrity (current_aag s') s' t \<rbrakk>
+     \<Longrightarrow> partitionIntegrity (current_aag s) s t"
+  apply (rule partitionIntegrity_trans, assumption)
+  apply (simp add: partitionIntegrity_current_aag_eq)
+  done
+
+lemma user_small_Step_partitionIntegrity:
+  "\<lbrakk> ((a, b), x, aa, ba) \<in> check_active_irq_A_if;
+     ct_running b; Invs b; ((aa, ba), y, ab, bb) \<in> do_user_op_A_if utf \<rbrakk>
+     \<Longrightarrow> partitionIntegrity (current_aag b) b bb"
+  apply (rule partitionIntegrity_trans'[rotated])
+   apply (rule do_user_op_A_if_partitionIntegrity)
+     apply assumption
+    apply (drule check_active_irq_A_if_result_state)
+    apply simp
+   apply (drule check_active_irq_A_if_result_state)
+   apply (simp add: Invs_def current_aag_def)
+  apply (rule check_active_irq_A_if_partitionIntegrity)
+  apply assumption
   done
 
 lemma small_Step_partitionIntegrity:
   notes active_from_running[simp]
   assumes step: "(s, t) \<in> data_type.Step (ADT_A_if utf) ()"
-      and reachable: "system.reachable (ADT_A_if utf) s0 s"
-      and sched: "part s \<noteq> PSched"
-  shows
-  "partitionIntegrity (current_aag (internal_state_if s))
-     (internal_state_if s) (internal_state_if t)"
+  and reachable: "system.reachable (ADT_A_if utf) s0 s"
+  and sched: "part s \<noteq> PSched"
+  shows "partitionIntegrity (current_aag (internal_state_if s))
+                            (internal_state_if s) (internal_state_if t)"
 proof (cases "sys_mode_of s")
   case InUserMode
   with assms show ?thesis
-    apply (fastforce dest: ADT_A_if_reachable_invs_if
-                     simp: invs_if_def part_def
-                           Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
-                     intro: user_small_Step_partitionIntegrity
-                            check_active_irq_A_if_partitionIntegrity)
-    done
-  next case InIdleMode
+    by (fastforce dest: ADT_A_if_reachable_invs_if
+                  simp: invs_if_def part_def global_automaton_if_def
+                        Step_ADT_A_if_def_global_automaton_if
+                 intro: user_small_Step_partitionIntegrity check_active_irq_A_if_partitionIntegrity)
+next case InIdleMode
   with assms show ?thesis
-    apply (fastforce simp: Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
-                     intro: check_active_irq_A_if_partitionIntegrity)
-    done
-  next case KernelEntry
+    by (fastforce simp: Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
+                 intro: check_active_irq_A_if_partitionIntegrity)
+next case KernelEntry
   with assms show ?thesis
-    apply (fastforce dest: ADT_A_if_reachable_invs_if
-                     simp: invs_if_def part_def
-                           Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
-                           not_schedule_modes_KernelEntry
-                     intro: kernel_call_A_if_partitionIntegrity)
-    done
-  next case KernelExit
+    by (fastforce dest: ADT_A_if_reachable_invs_if
+                 simp: invs_if_def part_def Step_ADT_A_if_def_global_automaton_if
+                       global_automaton_if_def not_schedule_modes_KernelEntry
+                intro: kernel_call_A_if_partitionIntegrity)
+next case KernelExit
   with assms show ?thesis
-    apply (clarsimp simp: Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
-                          kernel_exit_A_if_def)
+    apply (clarsimp simp: Step_ADT_A_if_def_global_automaton_if
+                          global_automaton_if_def kernel_exit_A_if_def)
     apply (safe; simp)
     apply (erule use_valid)
-    apply wp
+     apply wp
     apply (rule partitionIntegrity_refl)
     done
-  next case KernelPreempted
+next case KernelPreempted
   with assms show ?thesis
-    apply (simp add: part_def)
-    done
-  next case KernelSchedule
+    by (simp add: part_def)
+next case KernelSchedule
   with assms show ?thesis
-    apply (clarsimp simp: part_def
-                          Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
-                          kernel_schedule_if_def)
+    apply (clarsimp simp: part_def Step_ADT_A_if_def_global_automaton_if
+                          global_automaton_if_def kernel_schedule_if_def)
     apply (safe; simp)
     apply (erule use_valid)
      apply (wp schedule_if_partitionIntegrity[OF current_domains_distinct])
@@ -1950,10 +1717,15 @@ proof (cases "sys_mode_of s")
     done
 qed
 
+end
+
+
+context valid_initial_state begin
+
 lemma sub_big_steps_reachable:
-  "\<lbrakk>(s', evlist') \<in> sub_big_steps (ADT_A_if utf) big_step_R s;
-    system.reachable (ADT_A_if utf) s0 s\<rbrakk>
-       \<Longrightarrow> system.reachable (ADT_A_if utf) s0 s'"
+  "\<lbrakk> (s', evlist') \<in> sub_big_steps (ADT_A_if utf) big_step_R s;
+     system.reachable (ADT_A_if utf) s0 s \<rbrakk>
+     \<Longrightarrow> system.reachable (ADT_A_if utf) s0 s'"
   apply (rule_tac s=s and js=evlist' in Step_system.reachable_execution[OF ADT_A_if_Step_system])
    apply assumption
   apply (drule sub_big_steps_Run)
@@ -1971,319 +1743,246 @@ lemma sub_big_steps_reachable:
   apply (simp add: ADT_A_if_def)
   done
 
-lemma Step2[simp]:
-  "system.Step (ADT_A_if utf) = Simulation.Step (ADT_A_if utf)"
-  apply(rule ext)
-  apply(simp add: system.Step_def execution_def ADT_A_if_def steps_def Image_def)
-  oops
-
-lemma Step2:
-  "(s,s') \<in> system.Step (ADT_A_if utf) u \<Longrightarrow> (s,s') \<in> Simulation.Step (ADT_A_if utf) u"
-  apply(simp add: system.Step_def execution_def ADT_A_if_def steps_def)
-  apply blast
-  done
-
-
 lemma sub_big_steps_not_PSched:
-  "\<lbrakk>(s', blah) \<in> sub_big_steps (ADT_A_if utf) big_step_R s;
-    big_step_R\<^sup>*\<^sup>* s0 s; part s \<noteq> PSched\<rbrakk> \<Longrightarrow>
-   part s' \<noteq> PSched"
-  apply(drule tranclp_s0)
-  apply(induct s' blah rule: sub_big_steps.induct)
+  "\<lbrakk> (s', blah) \<in> sub_big_steps (ADT_A_if utf) big_step_R s; big_step_R\<^sup>*\<^sup>* s0 s; part s \<noteq> PSched \<rbrakk>
+     \<Longrightarrow> part s' \<noteq> PSched"
+  apply (drule tranclp_s0)
+  apply (induct s' blah rule: sub_big_steps.induct)
    apply simp
   apply simp
-  apply(simp add: part_def split: if_splits)
-  apply(case_tac "sys_mode_of s", simp_all add: sys_mode_of_def)
-  apply(case_tac "sys_mode_of s'", simp_all add: sys_mode_of_def)
-      apply(case_tac "sys_mode_of t", simp_all add: sys_mode_of_def big_step_R_def split: if_splits)
-       apply(rename_tac event)
-       apply(case_tac event, simp_all)
-      apply((fastforce simp: ADT_A_if_def global_automaton_if_def)+)[2]
-    apply(case_tac "sys_mode_of t", simp_all add: sys_mode_of_def big_step_R_def split: if_splits)
-     apply(fastforce simp: ADT_A_if_def global_automaton_if_def)+
-  apply(case_tac "sys_mode_of t", simp_all add: sys_mode_of_def)
-  apply(clarsimp simp: ADT_A_if_def global_automaton_if_def kernel_exit_A_if_def split: if_splits)+
-  done
-
-lemma sub_big_steps_partitionIntegrity:
-  "\<lbrakk>(t, as) \<in> sub_big_steps (ADT_A_if utf) big_step_R s;
-    big_step_R\<^sup>*\<^sup>* s0 s;
-    system.reachable (ADT_A_if utf) s0 s; part s \<noteq> PSched\<rbrakk> \<Longrightarrow>
-   partitionIntegrity (current_aag (internal_state_if s)) (internal_state_if s)
-           (internal_state_if t)"
-  apply(induct t as rule: sub_big_steps.induct)
-   apply(simp add: partitionIntegrity_def globals_equiv_scheduler_refl silc_dom_equiv_def
-                   equiv_for_refl domain_fields_equiv_def)
-  apply simp
-  apply(erule partitionIntegrity_trans')
-  apply(erule small_Step_partitionIntegrity)
-   apply(blast intro: sub_big_steps_reachable)
-  apply(rule sub_big_steps_not_PSched, simp+)
-  done
-
-lemma Fin_ADT_A_if:
-  "Fin (ADT_A_if uop) = id"
-  by (simp add: ADT_A_if_def)
-
-lemma Step_partitionIntegrity':
-  "\<lbrakk>(s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) ()\<rbrakk> \<Longrightarrow>
-   system.reachable (big_step_ADT_A_if utf) s0 s \<and>
-    part s \<noteq> PSched \<longrightarrow>
-   partitionIntegrity (current_aag (internal_state_if s)) (internal_state_if s) (internal_state_if s')"
-  apply(simp add: Step_big_step_ADT_A_if)
-  apply(erule big_steps.induct)
-  apply(simp add: big_step_evmap_def)
-  apply(intro impI | elim conjE)+
-  apply(rule partitionIntegrity_trans')
-   apply(erule sub_big_steps_partitionIntegrity)
-     apply(simp add: reachable_def execution_def)
-     apply(clarsimp simp: big_step_ADT_A_if_def Fin_big_step_adt Fin_ADT_A_if steps_eq_Run)
-     apply(rule Run_big_steps_tranclp)
-     apply(simp add: big_step_ADT_A_if_def big_step_adt_def Init_ADT_if)
-    apply(blast intro: small_step_reachable)
-   apply assumption
-  apply(erule small_Step_partitionIntegrity)
-   apply(erule(1) sub_big_steps_reachable[OF _ small_step_reachable])
-  apply(rule sub_big_steps_not_PSched, simp+)
-   apply(simp add: reachable_def execution_def)
-   apply(clarsimp simp: big_step_ADT_A_if_def Fin_big_step_adt Fin_ADT_A_if steps_eq_Run)
-   apply(rule Run_big_steps_tranclp)
-   apply(simp add: big_step_ADT_A_if_def big_step_adt_def Init_ADT_if)
-  by simp
-
-lemma Step_partitionIntegrity:
-  "\<lbrakk>system.reachable (big_step_ADT_A_if utf) s0 s;
-    (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) (); part s \<noteq> PSched\<rbrakk> \<Longrightarrow>
-   partitionIntegrity (current_aag (internal_state_if s)) (internal_state_if s) (internal_state_if s')"
-  apply(blast dest: Step_partitionIntegrity')
-  done
-
-lemma Step_cur_domain_unchanged:
-  "\<lbrakk>system.reachable (big_step_ADT_A_if utf) s0 s;
-   (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
-   part s \<noteq> PSched\<rbrakk> \<Longrightarrow>
-   cur_domain (internal_state_if s') = cur_domain (internal_state_if s)"
-  apply(fastforce dest: Step_partitionIntegrity
-                  simp: partitionIntegrity_def domain_fields_equiv_def)
-  done
-
-lemma Step_current_aag_unchanged:
-  "\<lbrakk>system.reachable (big_step_ADT_A_if utf) s0 s;
-    (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
-    part s \<noteq> PSched\<rbrakk> \<Longrightarrow>
-     current_aag (internal_state_if s') = current_aag (internal_state_if s)"
-  apply(simp add: current_aag_def)
-  apply(metis Step_cur_domain_unchanged)
+  apply (simp add: part_def split: if_splits)
+  apply (case_tac "sys_mode_of s", simp_all add: sys_mode_of_def)
+  apply (case_tac "sys_mode_of s'", simp_all add: sys_mode_of_def)
+      apply (case_tac "sys_mode_of t", simp_all add: sys_mode_of_def big_step_R_def split: if_splits)
+       apply (rename_tac event)
+       apply (case_tac event, simp_all)
+      apply ((fastforce simp: ADT_A_if_def global_automaton_if_def)+)[2]
+    apply (case_tac "sys_mode_of t", simp_all add: sys_mode_of_def big_step_R_def split: if_splits)
+     apply (fastforce simp: ADT_A_if_def global_automaton_if_def)+
+  apply (case_tac "sys_mode_of t", simp_all add: sys_mode_of_def)
+   apply (clarsimp simp: ADT_A_if_def global_automaton_if_def kernel_exit_A_if_def split: if_splits)+
   done
 
 lemma reachable_Step':
-  "\<lbrakk>system.reachable (big_step_ADT_A_if utf) s0 s;
-    (s, s') \<in> data_type.Step (big_step_ADT_A_if utf) a\<rbrakk>
-    \<Longrightarrow> system.reachable (big_step_ADT_A_if utf) s0 s'"
+  "\<lbrakk> system.reachable (big_step_ADT_A_if utf) s0 s;
+     (s, s') \<in> data_type.Step (big_step_ADT_A_if utf) a \<rbrakk>
+     \<Longrightarrow> system.reachable (big_step_ADT_A_if utf) s0 s'"
   apply (rule reachable_Step, assumption)
   apply (drule small_step_reachable)
   apply (frule ADT_A_if_reachable_full_invs_if)
   apply (drule ADT_A_if_reachable_step_restrict)
-  apply (clarsimp simp: system.Step_def execution_def big_step_ADT_A_if_def Fin_big_step_adt
-                        Fin_ADT_A_if steps_eq_Run)
+  apply (clarsimp simp: system.Step_def execution_def big_step_ADT_A_if_def
+                        Fin_big_step_adt Fin_ADT_if steps_eq_Run)
   apply (simp add: big_step_ADT_A_if_def big_step_adt_def Init_ADT_if)
   apply (cases s)
   apply (case_tac a)
   apply blast
   done
 
+end
+
+
+context Noninterference_valid_initial_state begin
+
+lemma sub_big_steps_partitionIntegrity:
+  "\<lbrakk> (t, as) \<in> sub_big_steps (ADT_A_if utf) big_step_R s;
+     big_step_R\<^sup>*\<^sup>* s0 s; system.reachable (ADT_A_if utf) s0 s; part s \<noteq> PSched \<rbrakk>
+     \<Longrightarrow> partitionIntegrity (current_aag (internal_state_if s))
+                            (internal_state_if s) (internal_state_if t)"
+  apply (induct t as rule: sub_big_steps.induct)
+   apply (simp add: partitionIntegrity_def globals_equiv_scheduler_refl
+                    silc_dom_equiv_def equiv_for_refl domain_fields_equiv_def)
+  apply simp
+  apply (erule partitionIntegrity_trans')
+  apply (erule small_Step_partitionIntegrity)
+   apply (blast intro: sub_big_steps_reachable)
+  apply (rule sub_big_steps_not_PSched, simp+)
+  done
+
+lemma Step_partitionIntegrity':
+  "\<lbrakk> (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) ()\<rbrakk>
+     \<Longrightarrow> system.reachable (big_step_ADT_A_if utf) s0 s \<and> part s \<noteq> PSched
+         \<longrightarrow> partitionIntegrity (current_aag (internal_state_if s))
+                                (internal_state_if s) (internal_state_if s')"
+  apply (simp add: Step_big_step_ADT_A_if)
+  apply (erule big_steps.induct)
+  apply (simp add: big_step_evmap_def)
+  apply (intro impI | elim conjE)+
+  apply (rule partitionIntegrity_trans')
+   apply (erule sub_big_steps_partitionIntegrity)
+     apply (simp add: reachable_def execution_def)
+     apply (clarsimp simp: big_step_ADT_A_if_def Fin_big_step_adt Fin_ADT_if steps_eq_Run)
+     apply (rule Run_big_steps_tranclp)
+     apply (simp add: big_step_ADT_A_if_def big_step_adt_def Init_ADT_if)
+    apply (blast intro: small_step_reachable)
+   apply assumption
+  apply (erule small_Step_partitionIntegrity)
+   apply (erule(1) sub_big_steps_reachable[OF _ small_step_reachable])
+  apply (rule sub_big_steps_not_PSched, simp+)
+   apply (simp add: reachable_def execution_def)
+   apply (clarsimp simp: big_step_ADT_A_if_def Fin_big_step_adt Fin_ADT_if steps_eq_Run)
+   apply (rule Run_big_steps_tranclp)
+   apply (simp add: big_step_ADT_A_if_def big_step_adt_def Init_ADT_if)
+  by simp
+
+lemma Step_partitionIntegrity:
+  "\<lbrakk> system.reachable (big_step_ADT_A_if utf) s0 s;
+     (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) (); part s \<noteq> PSched \<rbrakk>
+     \<Longrightarrow> partitionIntegrity (current_aag (internal_state_if s))
+                            (internal_state_if s) (internal_state_if s')"
+  by (blast dest: Step_partitionIntegrity')
+
+lemma Step_cur_domain_unchanged:
+  "\<lbrakk> system.reachable (big_step_ADT_A_if utf) s0 s;
+     (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) (); part s \<noteq> PSched \<rbrakk>
+     \<Longrightarrow> cur_domain (internal_state_if s') = cur_domain (internal_state_if s)"
+  by (fastforce dest: Step_partitionIntegrity
+                simp: partitionIntegrity_def domain_fields_equiv_def)
+
+lemma Step_current_aag_unchanged:
+  "\<lbrakk> system.reachable (big_step_ADT_A_if utf) s0 s;
+     (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) (); part s \<noteq> PSched \<rbrakk>
+     \<Longrightarrow> current_aag (internal_state_if s') = current_aag (internal_state_if s)"
+  apply (simp add: current_aag_def)
+  apply (metis Step_cur_domain_unchanged)
+  done
+
 (* TOPLEVEL *)
 lemma integrity_part:
-  "\<lbrakk>system.reachable (big_step_ADT_A_if utf) s0 s;
-    (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
-    (part s, u) \<notin> policyFlows (pasPolicy initial_aag); u \<noteq> PSched; part s \<noteq> PSched\<rbrakk> \<Longrightarrow>
-   (s,s') \<in> uwr u"
+  "\<lbrakk> system.reachable (big_step_ADT_A_if utf) s0 s;
+     (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
+     (part s, u) \<notin> policyFlows (pasPolicy initial_aag); u \<noteq> PSched; part s \<noteq> PSched \<rbrakk>
+     \<Longrightarrow> (s,s') \<in> uwr u"
   supply [[simp_depth_limit=0]] \<comment> \<open>speedup\<close>
-  apply(simp add: uwr_def_cur[where s=s])
-  apply(case_tac s, case_tac s', simp)
-  apply(case_tac a, case_tac aa, simp)
-  apply(rule partsSubjectAffects_bounds_subjects_affects)
-                 apply(rule current_domains_distinct)
-                apply(fastforce dest: Step_partitionIntegrity)
-               apply(fastforce dest: pas_refined_initial_aag_reachable simp: pas_refined_cur)
-              apply(frule(2) pas_refined_current_aag'[OF _ Step_current_aag_unchanged[symmetric],
-                                                      OF reachable_Step']; force)
-             apply(fastforce dest!: reachable_invs_if simp: invs_if_def Invs_def)
-            apply(fastforce dest!: reachable_invs_if[OF reachable_Step'] simp: invs_if_def Invs_def)
-           apply(fastforce  dest!: reachable_invs_if simp: invs_if_def Invs_def)
-          apply(fastforce  dest!: reachable_invs_if[OF reachable_Step'] simp: invs_if_def Invs_def)
-         apply(fastforce dest: silc_inv_initial_aag_reachable simp: silc_inv_cur)
-        apply(frule Step_current_aag_unchanged[symmetric];simp)
-        apply(fastforce dest: silc_inv_initial_aag_reachable[OF reachable_Step'] simp: silc_inv_cur)
-       apply(rule pas_wellformed_cur)
-      apply(simp add: current_aag_def)
-     supply [[simp_depth_limit=0]] \<comment> \<open>speeds up the rest of the proof\<close>
-     apply(fastforce dest!: reachable_invs_if domains_distinct[THEN pas_domains_distinct_inj]
-                     simp: invs_if_def Invs_def guarded_pas_domain_def
-                           guarded_is_subject_cur_thread_def current_aag_def)
-    apply(frule Step_current_aag_unchanged[symmetric];simp)
-    apply(fastforce dest!:reachable_invs_if[OF reachable_Step']
-                          domains_distinct[THEN pas_domains_distinct_inj]
-                    simp: invs_if_def Invs_def guarded_pas_domain_def
-                          guarded_is_subject_cur_thread_def current_aag_def)
-   apply(rule partsSubjectAffects_bounds_those_subject_not_allowed_to_affect,
-         simp add: part_def split: if_split_asm add: partition_def current_aag_def)
+  apply (simp add: uwr_def_cur[where s=s])
+  apply (case_tac s, case_tac s', simp)
+  apply (case_tac a, case_tac aa, simp)
+  apply (rule partsSubjectAffects_bounds_subjects_affects)
+                 apply (rule current_domains_distinct)
+                apply (fastforce dest: Step_partitionIntegrity)
+               apply (fastforce dest: pas_refined_initial_aag_reachable simp: pas_refined_cur)
+              apply (frule (2) pas_refined_current_aag'[OF _ Step_current_aag_unchanged[symmetric],
+                                                        OF reachable_Step']; force)
+             apply (fastforce dest!: reachable_invs_if simp: invs_if_def Invs_def)
+            apply (fastforce dest!: reachable_invs_if[OF reachable_Step'] simp: invs_if_def Invs_def)
+           apply (fastforce dest!: reachable_invs_if simp: invs_if_def Invs_def)
+          apply (fastforce dest!: reachable_invs_if[OF reachable_Step'] simp: invs_if_def Invs_def)
+         apply (fastforce dest: silc_inv_initial_aag_reachable simp: silc_inv_cur)
+        apply (frule Step_current_aag_unchanged[symmetric];simp)
+        apply (fastforce dest: silc_inv_initial_aag_reachable[OF reachable_Step'] simp: silc_inv_cur)
+       apply (rule pas_wellformed_cur)
+      apply (simp add: current_aag_def)
+     apply (fastforce dest!: reachable_invs_if domains_distinct[THEN pas_domains_distinct_inj]
+                       simp: invs_if_def Invs_def guarded_pas_domain_def
+                             guarded_is_subject_cur_thread_def current_aag_def)
+    apply (frule Step_current_aag_unchanged[symmetric];simp)
+    apply (fastforce dest!: reachable_invs_if[OF reachable_Step']
+                            domains_distinct[THEN pas_domains_distinct_inj]
+                      simp: invs_if_def Invs_def guarded_pas_domain_def
+                            guarded_is_subject_cur_thread_def current_aag_def)
+   apply (rule partsSubjectAffects_bounds_those_subject_not_allowed_to_affect)
+   apply (simp add: part_def partition_def current_aag_def split: if_split_asm)
   apply assumption
   done
 
+end
+
+
+context valid_initial_state begin
+
 lemma not_PSched:
-  "\<lbrakk>(x, u) \<notin> policyFlows (pasPolicy initial_aag); u \<noteq> PSched\<rbrakk> \<Longrightarrow>
-   x \<noteq> PSched"
-  apply(erule contrapos_nn)
+  "\<lbrakk> (x, u) \<notin> policyFlows (pasPolicy initial_aag); u \<noteq> PSched \<rbrakk>
+     \<Longrightarrow> x \<noteq> PSched"
+  apply (erule contrapos_nn)
   apply simp
-  apply(rule schedFlowsToAll)
+  apply (rule schedFlowsToAll)
   done
 
-lemma part_equiv: "(s,t) \<in> uwr PSched \<Longrightarrow> part s = part t"
-  by (clarsimp simp: uwr_def sameFor_def
-                     sameFor_scheduler_def part_def
-                     Noninterference.partition_def
-                     domain_fields_equiv_def
-              split: partition.splits)
-
 lemma not_PSched_big_step_R:
-  "\<lbrakk>part s \<noteq> PSched; big_step_R s t\<rbrakk>
-   \<Longrightarrow> sys_mode_of s = KernelExit \<and> interrupted_modes (sys_mode_of t)"
-  apply(clarsimp simp: part_def big_step_R_def sys_mode_of_def split: if_split_asm)
-  apply(cases s, simp, case_tac b; simp)
+  "\<lbrakk> part s \<noteq> PSched; big_step_R s t \<rbrakk>
+     \<Longrightarrow> sys_mode_of s = KernelExit \<and> interrupted_modes (sys_mode_of t)"
+  apply (clarsimp simp: part_def big_step_R_def sys_mode_of_def split: if_split_asm)
+  apply (cases s, simp, case_tac b; simp)
   done
 
 lemma sub_big_steps_Nil:
   "(s',[]) \<in> sub_big_steps A R s \<Longrightarrow> s' = s \<and> \<not> R s s"
-  by(erule sub_big_steps.cases; simp)
+  by (erule sub_big_steps.cases; simp)
 
 lemma sub_big_steps_App:
-  "(s',as @ [a]) \<in> sub_big_steps A R s \<Longrightarrow> \<exists>s'a. (s'a, as) \<in> sub_big_steps A R s \<and>
-                                                 (s'a, s') \<in> data_type.Step A a \<and> \<not> R s s'"
-  by(erule sub_big_steps.cases; fastforce)
+  "(s',as @ [a]) \<in> sub_big_steps A R s
+   \<Longrightarrow> \<exists>s'a. (s'a, as) \<in> sub_big_steps A R s \<and> (s'a, s') \<in> data_type.Step A a \<and> \<not> R s s'"
+  by (erule sub_big_steps.cases; fastforce)
 
 (* FIXME: move to ADT_IF.thy *)
 lemma relation_preserved_across_sub_big_steps:
-  "\<lbrakk>(s', as) \<in> sub_big_steps A R s;
-    (t', as') \<in> sub_big_steps A R t; X s t; as' = as;
-       \<forall> sa ta sa' ta'. X sa ta \<and>
-        (\<exists>bs. (sa,bs) \<in> sub_big_steps A R s \<and> (sa',bs @ [()]) \<in> sub_big_steps A R s) \<and>
-        (\<exists>cs. (ta,cs) \<in> sub_big_steps A R t \<and> (sa',cs @ [()]) \<in> sub_big_steps A R s) \<and>
-           (sa,sa') \<in> data_type.Step A () \<and> (ta,ta') \<in> data_type.Step A () \<longrightarrow>
-              X sa' ta'\<rbrakk> \<Longrightarrow>
-      X s' t'"
+  "\<lbrakk> (s', as) \<in> sub_big_steps A R s; (t', as') \<in> sub_big_steps A R t; X s t; as' = as;
+     \<forall>sa ta sa' ta'. X sa ta \<and>
+       (\<exists>bs. (sa,bs) \<in> sub_big_steps A R s \<and> (sa',bs @ [()]) \<in> sub_big_steps A R s) \<and>
+       (\<exists>cs. (ta,cs) \<in> sub_big_steps A R t \<and> (sa',cs @ [()]) \<in> sub_big_steps A R s) \<and>
+       (sa,sa') \<in> data_type.Step A () \<and> (ta,ta') \<in> data_type.Step A ()
+       \<longrightarrow> X sa' ta' \<rbrakk>
+     \<Longrightarrow> X s' t'"
   apply hypsubst_thin
-  apply(induct as arbitrary: s t s' t' rule: rev_induct)
-   apply(drule sub_big_steps_Nil)+
+  apply (induct as arbitrary: s t s' t' rule: rev_induct)
+   apply (drule sub_big_steps_Nil)+
    apply simp
-  apply(frule_tac s=s in sub_big_steps_App)
-  apply(frule_tac s=t in sub_big_steps_App)
+  apply (frule_tac s=s in sub_big_steps_App)
+  apply (frule_tac s=t in sub_big_steps_App)
   apply clarify
-  apply(drule_tac x=s in meta_spec)
-  apply(drule_tac x=t in meta_spec)
-  apply(drule_tac x=s'a in meta_spec)
-  apply(drule_tac x=s'aa in meta_spec)
+  apply (drule_tac x=s in meta_spec)
+  apply (drule_tac x=t in meta_spec)
+  apply (drule_tac x=s'a in meta_spec)
+  apply (drule_tac x=s'aa in meta_spec)
   apply simp
   apply blast
   done
+
+end
+
 
 (* FIXME: move these next lemmas culminating in reads_respects_g
    for activate_thread and schedule into Schedule_IF or similar *)
 lemma set_thread_state_runnable_reads_respects_g:
   assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects_g aag l (valid_ko_at_arm and K (runnable ts)) (set_thread_state t ts)"
-  apply(rule gen_asm_ev)
-  apply(rule equiv_valid_guard_imp)
-   apply(rule reads_respects_g[OF set_thread_state_runnable_reads_respects[OF domains_distinct]])
+  shows "reads_respects_g aag (l :: 'a subject_label)
+                          (valid_ko_at_arch and K (runnable ts)) (set_thread_state t ts)"
+  apply (rule gen_asm_ev)
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_g[OF set_thread_state_runnable_reads_respects[OF domains_distinct]])
     apply assumption
-   apply(rule doesnt_touch_globalsI)
-   apply(wp set_thread_state_globals_equiv | simp)+
+   apply (rule doesnt_touch_globalsI)
+   apply (wp set_thread_state_globals_equiv | simp)+
   done
 
 lemma globals_equiv_idle_thread_ptr:
   "globals_equiv s t \<Longrightarrow> idle_thread s= idle_thread t"
-  apply(simp add: globals_equiv_def idle_equiv_def)
-  done
+  by (simp add: globals_equiv_def idle_equiv_def)
 
 lemma get_thread_state_reads_respects_g:
   "reads_respects_g aag l (valid_idle and (\<lambda>s. is_subject aag t \<or> t = idle_thread s))
-      (get_thread_state t)"
-  apply(rule use_spec_ev)
-  apply(case_tac "t = idle_thread st")
-   apply(clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
-   apply(drule_tac Q="\<lambda>rv s. s = st \<and> idle rv" in use_valid[OF _ gts_wp])
-    apply(simp add: valid_idle_def)
-    apply(clarsimp simp: pred_tcb_at_def obj_at_def)
-   apply(drule_tac Q="\<lambda>rv s. s = ta \<and> idle rv" in use_valid[OF _ gts_wp])
-    apply(simp add: valid_idle_def)
-    apply(fastforce simp: pred_tcb_at_def obj_at_def reads_equiv_g_def globals_equiv_idle_thread_ptr)
+                    (get_thread_state t)"
+  apply (rule use_spec_ev)
+  apply (case_tac "t = idle_thread st")
+   apply (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
+   apply (drule_tac Q="\<lambda>rv s. s = st \<and> idle rv" in use_valid[OF _ gts_wp])
+    apply (simp add: valid_idle_def)
+    apply (clarsimp simp: pred_tcb_at_def obj_at_def)
+   apply (drule_tac Q="\<lambda>rv s. s = ta \<and> idle rv" in use_valid[OF _ gts_wp])
+    apply (simp add: valid_idle_def)
+    apply (fastforce simp: pred_tcb_at_def obj_at_def reads_equiv_g_def globals_equiv_idle_thread_ptr)
    apply (simp add: pred_tcb_at_def obj_at_def)
-  apply(clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
-  apply(frule aag_can_read_self)
-  apply(frule get_thread_state_reads_respects_g
-                [simplified equiv_valid_def2 equiv_valid_2_def,
-                 rule_format, OF conjI, simplified];
-        fastforce)
-  done
-
-
-lemma activate_thread_reads_respects_g:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_g aag l ((\<lambda>s. cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject aag (cur_thread s))
-                           and invs) activate_thread"
-  apply(simp add: activate_thread_def)
-  apply(wp set_thread_state_runnable_reads_respects_g as_user_reads_respects_g
-           get_thread_state_reads_respects_g gts_wp
-       | wpc
-       | simp add: det_setNextPC arch_activate_idle_thread_def)+
-  apply clarsimp
-  apply(rule conjI)
-   apply(blast intro: requiv_g_cur_thread_eq)
-  apply(frule invs_valid_idle)
-  apply(simp add: invs_valid_ko_at_arm)
-  apply(rule conjI)
-   apply blast
-  apply(rule impI)
-  apply(clarsimp simp: pred_tcb_at_def obj_at_def valid_idle_def)
-  apply(fastforce simp: invs_valid_ko_at_arm det_getRestartPC)
+  apply (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
+  apply (frule aag_can_read_self)
+  apply (frule get_thread_state_reads_respects_g[simplified equiv_valid_def2 equiv_valid_2_def,
+                                                 rule_format, OF conjI, simplified]; fastforce)
   done
 
 lemmas set_scheduler_action_reads_respects_g =
-    reads_respects_g[OF set_scheduler_action_reads_respects,
-                     OF doesnt_touch_globalsI[where P="\<top>"],
-                     simplified,
-                     OF set_scheduler_action_globals_equiv]
-
-lemma cur_thread_update_reads_respects_g':
-  "equiv_valid (reads_equiv_g aag) (\<lambda>s s'. affects_equiv aag l s s' \<and> exclusive_state_equiv s s')
-               (affects_equiv aag l) \<top>
-               (modify (cur_thread_update (\<lambda>_. t)))"
-  apply(simp add: equiv_valid_def2)
-  apply(rule modify_ev2)
-  apply(clarsimp simp: reads_equiv_g_def reads_equiv_def2 affects_equiv_def2 globals_equiv_def
-                       idle_equiv_def)
-  apply(fastforce intro: states_equiv_for_sym)
-  done
-
-(* clagged mostly from Scheduler_IF.dmo_storeWord_reads_respects_scheduler *)
-lemma dmo_storeWord_reads_respects_g[wp]:
-  "reads_respects_g aag l \<top> (do_machine_op (storeWord ptr w))"
-  apply (clarsimp simp add: do_machine_op_def bind_def gets_def get_def
-                    return_def select_f_def storeWord_def
-                    assert_def simpler_modify_def fail_def)
-  apply (fold simpler_modify_def)
-  apply (intro impI conjI)
-   apply (rule ev_modify)
-   apply(rule conjI)
-    apply (fastforce simp: reads_equiv_g_def globals_equiv_def reads_equiv_def2 states_equiv_for_def
-                           equiv_for_def equiv_asids_def equiv_asid_def silc_dom_equiv_def)
-   apply(rule affects_equiv_machine_state_update, assumption)
-   apply(fastforce simp: equiv_for_def affects_equiv_def states_equiv_for_def)
-  apply (simp add: equiv_valid_def2 equiv_valid_2_def)
-  done
-
+  reads_respects_g[OF set_scheduler_action_reads_respects,
+                   OF doesnt_touch_globalsI[where P="\<top>"],
+                   simplified,
+                   OF set_scheduler_action_globals_equiv]
 
 lemmas thread_get_reads_respects_g =
     reads_respects_g[OF thread_get_rev,
@@ -2291,47 +1990,19 @@ lemmas thread_get_reads_respects_g =
                      simplified,
                      OF thread_get_inv]
 
-lemmas set_vm_root_reads_respects_g[wp] =
-    reads_respects_g[OF set_vm_root_reads_respects,
-                     OF doesnt_touch_globalsI[where P="\<top>"],
-                     simplified,
-                     OF set_vm_root_globals_equiv]
-
-
-lemma dmo_clearExMonitor_reads_respects_g':
-  "equiv_valid (reads_equiv_g aag) (affects_equiv aag l)
-               (\<lambda>s s'. affects_equiv aag l s s' \<and> exclusive_state_equiv s s') \<top>
-               (do_machine_op clearExMonitor)"
-  apply (simp add: clearExMonitor_def)
-  apply (wp dmo_ev ev_modify)
-  apply (simp add: reads_equiv_g_def reads_equiv_def2 affects_equiv_def2 globals_equiv_def
-                   idle_equiv_def states_equiv_for_def equiv_for_def equiv_asids_def
-                   equiv_asid_def)
-  apply metis
-  done
-
-lemma arch_switch_to_thread_reads_respects_g':
-  "equiv_valid (reads_equiv_g aag) (affects_equiv aag l)
-               (\<lambda>s s'. affects_equiv aag l s s' \<and> exclusive_state_equiv s s')
-               (\<lambda>s. is_subject aag t)
-               (arch_switch_to_thread t)"
-  apply(simp add: arch_switch_to_thread_def)
-  apply (rule equiv_valid_guard_imp)
-   apply (wp bind_ev_general dmo_clearExMonitor_reads_respects_g' thread_get_reads_respects_g
-         | simp)+
-  done
-
 lemmas tcb_sched_action_reads_respects_g =
     reads_respects_g[OF tcb_sched_action_reads_respects,
                      OF _ doesnt_touch_globalsI[where P="\<top>"],
                      simplified,
                      OF _ tcb_sched_action_extended.globals_equiv]
 
-
 lemma set_tcb_queue_reads_respects_g':
-  "equiv_valid (reads_equiv_g aag) (\<lambda>s s'. affects_equiv aag l s s' \<and> exclusive_state_equiv s s')
-               (\<lambda>s s'. affects_equiv aag l s s' \<and> exclusive_state_equiv s s') \<top>
-               (set_tcb_queue d prio queu)"
+  "equiv_valid (reads_equiv_g aag)
+               (\<lambda>s s'. affects_equiv aag l s s' \<and>
+                       arch_globals_equiv_strengthener  (machine_state s) (machine_state s'))
+               (\<lambda>s s'. affects_equiv aag l s s' \<and>
+                       arch_globals_equiv_strengthener (machine_state s) (machine_state s'))
+               \<top> (set_tcb_queue d prio queue)"
   unfolding equiv_valid_def2 equiv_valid_2_def
   supply if_cong[cong]
   apply (clarsimp simp: set_tcb_queue_def bind_def modify_def put_def get_def)
@@ -2339,61 +2010,57 @@ lemma set_tcb_queue_reads_respects_g':
        | rule affects_equiv_ready_queues_update reads_equiv_ready_queues_update, assumption
        | clarsimp simp: reads_equiv_g_def
        | fastforce elim!: affects_equivE reads_equivE
-                   simp: equiv_for_def globals_equiv_def idle_equiv_def)+)
-
-(* consider rewriting the return-value assumption using equiv_valid_rv_inv *)
-lemma ev2_invisible':
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "\<lbrakk>labels_are_invisible aag l L;
-    labels_are_invisible aag l L';
-    modifies_at_most aag L Q f;
-    modifies_at_most aag L' Q' g;
-    doesnt_touch_globals Q f;
-    doesnt_touch_globals Q' g;
-    \<And>P. \<lbrace>\<lambda>s. P (exclusive_state (machine_state s))\<rbrace> f \<lbrace>\<lambda>_ s. P (exclusive_state (machine_state s))\<rbrace>;
-    \<And>P. \<lbrace>\<lambda>s. P (exclusive_state (machine_state s))\<rbrace> g \<lbrace>\<lambda>_ s. P (exclusive_state (machine_state s))\<rbrace>;
-    \<forall> s t. P s \<and> P' t \<longrightarrow> (\<forall>(rva,s') \<in> fst (f s). \<forall>(rvb,t') \<in> fst (g t). W rva rvb)\<rbrakk>
-  \<Longrightarrow>
-  equiv_valid_2 (reads_equiv_g aag) (\<lambda>s s'. affects_equiv aag l s s' \<and> exclusive_state_equiv s s')
-                (\<lambda>s s'. affects_equiv aag l s s' \<and> exclusive_state_equiv s s')
-    W (P and Q) (P' and Q') f g"
-  apply(clarsimp simp: equiv_valid_2_def)
-  apply(rule conjI)
-   apply blast
-  apply(drule_tac s=s in modifies_at_mostD, assumption+)
-  apply(drule_tac s=t in modifies_at_mostD, assumption+)
-  apply(drule_tac s=s in globals_equivI, assumption+)
-  apply(drule_tac s=t in globals_equivI, assumption+)
-  apply(frule (1) equiv_but_for_reads_equiv[OF domains_distinct])
-  apply(frule_tac s=t in equiv_but_for_reads_equiv[OF domains_distinct], assumption)
-  apply(drule (1) equiv_but_for_affects_equiv[OF domains_distinct])
-  apply(drule_tac s=t in equiv_but_for_affects_equiv[OF domains_distinct], assumption)
-  apply(clarsimp simp: reads_equiv_g_def)
-  apply(simp only: conj_assoc[symmetric])
-  apply (rule conjI)
-   apply(blast intro: reads_equiv_trans reads_equiv_sym affects_equiv_trans affects_equiv_sym
-                      globals_equiv_trans globals_equiv_sym)
-  apply atomize
-  apply (erule_tac x="(=) (exclusive_state (machine_state s))" in allE)
-  apply (erule_tac x="(=) (exclusive_state (machine_state t))" in allE)
-  apply(clarsimp simp: valid_def)
-  apply (thin_tac "\<forall>x y. P x y" for P)
-  apply (erule_tac x=s in allE)
-  apply (erule_tac x=t in allE)
-  apply fastforce
-  done
+                    simp: equiv_for_def globals_equiv_def idle_equiv_def)+)
 
 lemma set_tcb_queue_globals_equiv[wp]:
-  "\<lbrace>globals_equiv st\<rbrace> set_tcb_queue d prio queue \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (simp add: set_tcb_queue_def modify_def | wp)+
+  "set_tcb_queue d prio queue \<lbrace>globals_equiv st\<rbrace>"
+  by (simp add: set_tcb_queue_def modify_def | wp)+
+
+
+context Noninterference_1 begin
+
+lemma activate_thread_reads_respects_g:
+  assumes domains_distinct[wp]: "pas_domains_distinct pas"
+  shows "reads_respects_g pas (l :: 'a subject_label)
+           ((\<lambda>s. cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject pas (cur_thread s)) and invs)
+           activate_thread"
+  apply (simp add: activate_thread_def)
+  apply (wp set_thread_state_runnable_reads_respects_g as_user_reads_respects_g
+            get_thread_state_reads_respects_g gts_wp
+         | wpc | simp add: det_setNextPC)+
+  apply (clarsimp cong: conj_cong)
+  apply (rule conjI)
+   apply (blast intro: requiv_g_cur_thread_eq)
+  apply (frule invs_valid_idle)
+  apply (simp add: invs_valid_ko_at_arch)
+  apply (rule conjI)
+   apply blast
+  apply (rule impI)
+  apply (clarsimp simp: pred_tcb_at_def obj_at_def valid_idle_def)
+  apply (fastforce simp: invs_valid_ko_at_arch det_getRestartPC)
+  done
+
+lemma cur_thread_update_reads_respects_g':
+  "equiv_valid (reads_equiv_g aag)
+               (\<lambda>s s'. affects_equiv aag l s s' \<and>
+                       arch_globals_equiv_strengthener (machine_state s) (machine_state s'))
+               (affects_equiv aag l) \<top> (modify (cur_thread_update (\<lambda>_. t)))"
+  apply (simp add: equiv_valid_def2)
+  apply (rule modify_ev2)
+  apply (clarsimp simp: reads_equiv_g_def reads_equiv_def2
+                        affects_equiv_def2 globals_equiv_def idle_equiv_def)
+  apply (fastforce intro: states_equiv_for_sym
+                    dest: arch_globals_equiv_strengthener_thread_independent)
   done
 
 lemma tcb_sched_action_reads_respects_g':
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "equiv_valid (reads_equiv_g aag) (\<lambda>s s'. affects_equiv aag l s s' \<and> exclusive_state_equiv s s')
-               (\<lambda>s s'. affects_equiv aag l s s' \<and> exclusive_state_equiv s s')
+  "equiv_valid (reads_equiv_g aag)
+               (\<lambda>s s'. affects_equiv aag (l :: 'a subject_label) s s' \<and>
+                       arch_globals_equiv_strengthener (machine_state s) (machine_state s'))
+               (\<lambda>s s'. affects_equiv aag l s s' \<and>
+                       arch_globals_equiv_strengthener (machine_state s) (machine_state s'))
                (pas_refined aag) (tcb_sched_action action thread)"
   apply (simp add: tcb_sched_action_def get_tcb_queue_def)
   apply (subst gets_apply)
@@ -2401,20 +2068,19 @@ lemma tcb_sched_action_reads_respects_g':
    apply (simp add: ethread_get_def)
    apply (wp set_tcb_queue_reads_respects_g')
          apply (rule_tac Q="\<lambda>s. pasObjectAbs aag thread \<in> pasDomainAbs aag (tcb_domain rv)"
-                         in equiv_valid_guard_imp)
-         apply (wp gets_apply_ev')
+                      in equiv_valid_guard_imp)
+          apply (wp gets_apply_ev')
           apply (clarsimp simp: reads_equiv_g_def)
           apply (elim reads_equivE affects_equivE equiv_forE)
           apply (clarsimp simp: disjoint_iff_not_equal)
           apply metis (* only one that works *)
          apply (wp | simp)+
    apply (intro conjI impI allI
-         | fastforce simp: get_etcb_def reads_equiv_g_def
-                     elim: reads_equivE affects_equivE equiv_forE)+
+          | fastforce simp: get_etcb_def reads_equiv_g_def
+                      elim: reads_equivE affects_equivE equiv_forE)+
    apply (clarsimp simp: pas_refined_def tcb_domain_map_wellformed_aux_def split: option.splits)
    apply (erule_tac x="(thread, tcb_domain y)" in ballE, force)
    apply (force intro: domtcbs simp: get_etcb_def)
-
   apply (simp add: equiv_valid_def2 ethread_get_def)
   apply (rule equiv_valid_rv_bind)
     apply (wp equiv_valid_rv_trivial', simp)
@@ -2423,15 +2089,14 @@ lemma tcb_sched_action_reads_respects_g':
       apply (wp equiv_valid_rv_trivial, simp)
      apply (rule equiv_valid_2_bind)
         apply (rule_tac P="\<top>" and P'="\<top>" and L="{pasObjectAbs aag thread}" and
-                        L'="{pasObjectAbs aag thread}"
-                        in ev2_invisible')
-                apply (blast | simp add: labels_are_invisible_def)+
+                                              L'="{pasObjectAbs aag thread}" in ev2_invisible')
+                 apply (blast | simp add: labels_are_invisible_def)+
               apply (rule set_tcb_queue_modifies_at_most)
              apply (rule set_tcb_queue_modifies_at_most)
             apply (rule doesnt_touch_globalsI | simp | wp)+
        apply (clarsimp simp: equiv_valid_2_def gets_apply_def get_def bind_def return_def
                              labels_are_invisible_def)
-      apply wp+
+       apply wp+
   apply clarsimp
   apply (clarsimp simp: pas_refined_def tcb_domain_map_wellformed_aux_def)
   apply (erule_tac x="(thread, tcb_domain y)" in ballE)
@@ -2441,74 +2106,67 @@ lemma tcb_sched_action_reads_respects_g':
 
 lemma switch_to_thread_reads_respects_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_g aag l (pas_refined aag and (\<lambda>s. is_subject aag t)) (switch_to_thread t)"
-  apply(simp add: switch_to_thread_def)
-  apply(subst bind_assoc[symmetric])
-  apply(rule equiv_valid_guard_imp)
-   apply(rule bind_ev)
+  shows "reads_respects_g aag (l :: 'a subject_label)
+                          (pas_refined aag and (\<lambda>s. is_subject aag t)) (switch_to_thread t)"
+  apply (simp add: switch_to_thread_def)
+  apply (subst bind_assoc[symmetric])
+  apply (rule equiv_valid_guard_imp)
+   apply (rule bind_ev)
      apply (wp bind_ev_general cur_thread_update_reads_respects_g'
                tcb_sched_action_reads_respects_g' arch_switch_to_thread_reads_respects_g')
-    apply(simp add: equiv_valid_def2)
-    apply(rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
-       apply(rule assert_ev2 | simp)+
-      apply(rule equiv_valid_rv_trivial, wp+)
+    apply (simp add: equiv_valid_def2)
+    apply (rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
+       apply (rule assert_ev2 | simp)+
+      apply (rule equiv_valid_rv_trivial, wp+)
   apply fastforce
   done
 
 lemma guarded_switch_to_reads_respects_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_g aag l (pas_refined aag and valid_idle and (\<lambda>s. is_subject aag t))
-                    (guarded_switch_to t)"
-  apply(simp add: guarded_switch_to_def)
+  shows "reads_respects_g aag (l :: 'a subject_label)
+                          (pas_refined aag and valid_idle and (\<lambda>s. is_subject aag t))
+                          (guarded_switch_to t)"
+  apply (simp add: guarded_switch_to_def)
   apply (wp switch_to_thread_reads_respects_g get_thread_state_reads_respects_g gts_wp)
   apply fastforce
   done
 
-lemma arch_switch_to_idle_thread_reads_respects_g[wp]:
-  "reads_respects_g aag l \<top> (arch_switch_to_idle_thread)"
-  apply(simp add: arch_switch_to_idle_thread_def)
-  apply wp
-  apply (clarsimp simp: reads_equiv_g_def globals_equiv_idle_thread_ptr)
-  done
-
 lemma cur_thread_update_idle_reads_respects_g':
-  "reads_respects_g aag l (\<lambda>s. t = idle_thread s) (modify (cur_thread_update (\<lambda>_. t)))"
-  apply(simp add: equiv_valid_def2)
-  apply(rule modify_ev2)
-  apply(clarsimp simp: reads_equiv_g_def reads_equiv_def2 affects_equiv_def2 globals_equiv_def
-                       idle_equiv_def)
-  apply(fastforce intro: states_equiv_for_sym)
+  "reads_respects_g aag (l :: 'a subject_label) (\<lambda>s. t = idle_thread s) (modify (cur_thread_update (\<lambda>_. t)))"
+  apply (simp add: equiv_valid_def2)
+  apply (rule modify_ev2)
+  apply (clarsimp simp: reads_equiv_g_def reads_equiv_def2
+                        affects_equiv_def2 globals_equiv_def idle_equiv_def)
+  apply (fastforce intro: states_equiv_for_sym arch_globals_equiv_threads_eq)
   done
 
 lemma switch_to_idle_thread_reads_respects_g[wp]:
-  "reads_respects_g aag l \<top> (switch_to_idle_thread)"
-  apply(simp add: switch_to_idle_thread_def)
+  "reads_respects_g aag (l :: 'a subject_label) \<top> (switch_to_idle_thread)"
+  apply (simp add: switch_to_idle_thread_def)
   apply (wp cur_thread_update_idle_reads_respects_g')
-  apply(fastforce simp: reads_equiv_g_def globals_equiv_idle_thread_ptr)
+  apply (fastforce simp: reads_equiv_g_def globals_equiv_idle_thread_ptr)
   done
 
 lemma choose_thread_reads_respects_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_g aag l ((\<lambda>s. cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject aag (cur_thread s)) and
-                           einvs and valid_queues and pas_cur_domain aag and pas_refined aag)
-                    choose_thread"
-  apply(simp add: choose_thread_def)
+  shows "reads_respects_g aag (l :: 'a subject_label)
+           ((\<lambda>s. cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject aag (cur_thread s)) and
+                 einvs and valid_queues and pas_cur_domain aag and pas_refined aag)
+           choose_thread"
+  apply (simp add: choose_thread_def)
   apply (wp guarded_switch_to_reads_respects_g)
-  apply(rule conjI)
-   apply(fastforce simp: reads_equiv_g_def reads_equiv_def)
-  apply(rule conjI)
-   apply (clarsimp simp: reads_equiv_g_def reads_equiv_def2 states_equiv_for_def equiv_for_def
-                         disjoint_iff_not_equal)
+  apply (rule conjI)
+   apply (fastforce simp: reads_equiv_g_def reads_equiv_def)
+  apply (rule conjI)
+   apply (clarsimp simp: reads_equiv_g_def reads_equiv_def2
+                         states_equiv_for_def equiv_for_def disjoint_iff_not_equal)
    apply (metis reads_lrefl)
   apply (simp add: invs_valid_idle)
   (* everything from here clagged from Syscall_AC.choose_thread_respects *)
   apply (clarsimp simp: pas_refined_def)
   apply (clarsimp simp: tcb_domain_map_wellformed_aux_def)
   apply (erule_tac x="(hd (max_non_empty_queue (ready_queues s (cur_domain s))), cur_domain s)"
-                   in ballE)
+                in ballE)
    apply (fastforce dest: domains_distinct[THEN pas_domains_distinct_inj])
   apply (clarsimp simp: valid_queues_def is_etcb_at_def)
   apply (erule_tac x="cur_domain s" in allE)
@@ -2525,38 +2183,37 @@ lemma choose_thread_reads_respects_g:
    apply force+
   done
 
+end
+
+
 lemma scheduler_action_switch_thread_is_subject:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "\<lbrakk>valid_sched s;
-        pas_cur_domain aag s;
-        pas_refined aag s\<rbrakk>
-        \<Longrightarrow> \<forall>x. scheduler_action s = switch_thread x \<longrightarrow>
-               is_subject aag x"
-  apply(clarsimp simp: valid_sched_def valid_sched_action_2_def switch_in_cur_domain_2_def
-                       in_cur_domain_def)
-  apply(clarsimp simp: pas_refined_def tcb_domain_map_wellformed_aux_def)
-  apply(drule_tac x="(x,cur_domain s)" in bspec)
-   apply(clarsimp simp: etcb_at_def)
-   apply(clarsimp simp: weak_valid_sched_action_2_def)
-   apply(clarsimp simp: valid_etcbs_def)
-   apply(drule_tac x=x in spec)
-   apply(simp add: st_tcb_weakenE)
-   apply(simp add: is_etcb_at_def split: option.splits)
-   apply(fastforce elim: domains_of_state_aux.intros)
-  apply(fastforce dest: domains_distinct[THEN pas_domains_distinct_inj])
+  shows "\<lbrakk> valid_sched s; pas_cur_domain aag s; pas_refined aag s \<rbrakk>
+           \<Longrightarrow> \<forall>x. scheduler_action s = switch_thread x \<longrightarrow> is_subject aag x"
+  apply (clarsimp simp: valid_sched_def valid_sched_action_2_def
+                        switch_in_cur_domain_2_def in_cur_domain_def)
+  apply (clarsimp simp: pas_refined_def tcb_domain_map_wellformed_aux_def)
+  apply (drule_tac x="(x,cur_domain s)" in bspec)
+   apply (clarsimp simp: etcb_at_def)
+   apply (clarsimp simp: weak_valid_sched_action_2_def)
+   apply (clarsimp simp: valid_etcbs_def)
+   apply (drule_tac x=x in spec)
+   apply (simp add: st_tcb_weakenE)
+   apply (simp add: is_etcb_at_def split: option.splits)
+   apply (fastforce elim: domains_of_state_aux.intros)
+  apply (fastforce dest: domains_distinct[THEN pas_domains_distinct_inj])
   done
 
 lemma gets_app_rewrite:
   "(gets y >>= (\<lambda>x. g (f x))) = (gets (\<lambda>s. f (y s)) >>= g)"
-  apply(rule ext)
-  apply(simp add: gets_def bind_def get_def return_def)
+  apply (rule ext)
+  apply (simp add: gets_def bind_def get_def return_def)
   done
 
 lemma gets_domain_time_zero_ev:
   "equiv_valid_inv I A (\<lambda>s. domain_time s > 0) (gets (\<lambda>s. domain_time s = 0))"
-  apply(rule gets_ev'')
-  apply simp
+  apply (rule gets_ev'')
+  apply fastforce
   done
 
 lemma reads_equiv_valid_g_inv_schedule_switch_thread_fastfail:
@@ -2566,46 +2223,17 @@ lemma reads_equiv_valid_g_inv_schedule_switch_thread_fastfail:
   unfolding schedule_switch_thread_fastfail_def
   by (wpsimp wp: reads_respects_g_from_inv[OF reads_respects_ethread_get])
 
-lemma gets_apply_ready_queues_reads_respects':
-  "reads_respects aag l (\<lambda>_. pasSubject aag \<in> pasDomainAbs aag d) (gets_apply ready_queues d)"
-  apply (rule gets_apply_ready_queues_reads_respects)
-  done
-
-lemma gets_ev_blah:
-  "\<forall> s t. I s t \<and> A s t \<and> P s \<and> P t \<longrightarrow> g (f s) = g (f t) \<Longrightarrow>
-   equiv_valid I A A P (gets (\<lambda>s. g (f s)))"
-  apply(simp add: gets_def get_def bind_def return_def)
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
-  done
-
 lemma reads_respects_gets_ready_queues:
   "reads_respects aag l (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag d)
      (gets (\<lambda>s. f (ready_queues s d)))"
-  apply (wp gets_ev_blah)
+  apply (wp gets_ev'')
   apply (force elim: reads_equivE simp: equiv_for_def)
   done
 
 lemma reads_respects_is_highest_prio:
   "reads_respects aag l (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag d)
-     (gets (\<lambda>s. is_highest_prio d p s))"
+                  (gets (\<lambda>s. is_highest_prio d p s))"
   by (fastforce simp: is_highest_prio_def intro: reads_respects_gets_ready_queues)
-
-lemma schedule_choose_new_thread_reads_respects_g:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_g aag l
-     ((\<lambda>s. domain_time s \<noteq> 0) and einvs
-        and pas_cur_domain aag and pas_refined aag
-        and (\<lambda>s. (cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject aag (cur_thread s))))
-     schedule_choose_new_thread"
-  apply (simp add: schedule_choose_new_thread_def )
-  apply (subst gets_app_rewrite[where y=domain_time and f="\<lambda>x. x = 0"])+
-  apply (wp gets_domain_time_zero_ev set_scheduler_action_reads_respects_g
-            choose_thread_reads_respects_g when_ev
-            equiv_valid_vacuous[where f=next_domain]
-            hoare_pre_cont[where a=next_domain])
-  apply (clarsimp simp: valid_sched_def)
-  done
 
 lemma reads_respects_ethread_get_when:
   "reads_respects aag l (\<lambda>_. b \<longrightarrow> is_subject aag thread) (ethread_get_when b f thread)"
@@ -2618,20 +2246,35 @@ lemma reads_respects_ethread_get_when:
 text \<open>strengthening of @{thm ArchSyscall_AC.valid_sched_action_switch_subject_thread}\<close>
 lemma valid_sched_action_switch_is_subject:
   assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-   "\<lbrakk> scheduler_action s = switch_thread t ; valid_sched_action s ;
-      valid_etcbs s ; pas_refined aag s ; pas_cur_domain aag s \<rbrakk>
-    \<Longrightarrow> is_subject aag t"
-  apply (fastforce dest: valid_sched_action_switch_subject_thread
-                         domains_distinct[THEN pas_domains_distinct_inj])
+  shows "\<lbrakk> scheduler_action s = switch_thread t ; valid_sched_action s ;
+           valid_etcbs s ; pas_refined aag s ; pas_cur_domain aag s \<rbrakk>
+           \<Longrightarrow> is_subject aag t"
+  by (fastforce dest: valid_sched_action_switch_subject_thread
+                      domains_distinct[THEN pas_domains_distinct_inj])
+
+
+context Noninterference_1 begin
+
+lemma schedule_choose_new_thread_reads_respects_g:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects_g aag (l :: 'a subject_label)
+           ((\<lambda>s. domain_time s \<noteq> 0) and einvs and pas_cur_domain aag and pas_refined aag and
+            (\<lambda>s. (cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject aag (cur_thread s))))
+           schedule_choose_new_thread"
+  apply (simp add: schedule_choose_new_thread_def )
+  apply (subst gets_app_rewrite[where y=domain_time and f="\<lambda>x. x = 0"])+
+  apply (wp gets_domain_time_zero_ev set_scheduler_action_reads_respects_g
+            choose_thread_reads_respects_g ev_pre_cont[where f=next_domain]
+            hoare_pre_cont[where a=next_domain] when_ev)
+  apply (clarsimp simp: valid_sched_def word_neq_0_conv)
   done
 
 lemma schedule_reads_respects_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_g aag l
-    ((\<lambda>s. cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject aag (cur_thread s)) and einvs
-     and pas_cur_domain aag and (\<lambda>s. domain_time s \<noteq> 0) and pas_refined aag) schedule"
+  shows "reads_respects_g aag (l :: 'a subject_label)
+           ((\<lambda>s. cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject aag (cur_thread s)) and einvs and
+            pas_cur_domain aag and (\<lambda>s. domain_time s \<noteq> 0) and pas_refined aag)
+           schedule"
   supply ethread_get_wp[wp del]
   supply set_scheduler_action_wp[wp del]
   supply conj_cong[cong del] (* knowing the scheduler action messes with valid_sched_2 *)
@@ -2642,385 +2285,370 @@ lemma schedule_reads_respects_g:
            apply wp[1]
           prefer 2
           (* choose new thread *)
-          apply ((wp set_scheduler_action_reads_respects_g
+          apply ((wp set_scheduler_action_reads_respects_g tcb_sched_action_reads_respects_g
                      schedule_choose_new_thread_reads_respects_g when_ev
-                     tcb_sched_action_reads_respects_g
-                 | wpc | simp)+)[1]
-
+                  | wpc | simp)+)[1]
          (* now switch_thread case *)
          apply (wpsimp wp: schedule_choose_new_thread_reads_respects_g enqueue_thread_queued
                            set_scheduler_action_reads_respects_g tcb_sched_action_reads_respects_g
                            set_scheduler_action_cnt_valid_sched)+
                         (* tcb_sched_action tcb_sched_append *)
-                        apply (wp append_thread_queued
-                                  set_scheduler_action_reads_respects_g
+                        apply (wp append_thread_queued set_scheduler_action_reads_respects_g
                                   guarded_switch_to_reads_respects_g
                                   reads_respects_g_from_inv[OF reads_respects_is_highest_prio]
                                   reads_equiv_valid_g_inv_schedule_switch_thread_fastfail)+
                  (* fastfail calculation *)
                  apply (wpsimp wp: reads_respects_g_from_inv[OF reads_respects_ethread_get]
                                    reads_respects_g_from_inv[OF reads_respects_ethread_get_when]
-                                   when_ev gts_wp
-                                   tcb_sched_action_reads_respects_g
+                                   when_ev gts_wp tcb_sched_action_reads_respects_g
                                    tcb_sched_action_enqueue_valid_blocked_except
                                    get_thread_state_reads_respects_g
                         | wp (once) hoare_drop_imp)+
-
   apply (clarsimp simp: invs_valid_idle)
-  apply (intro allI conjI impI ; (elim conjE)?
-         ; (solves \<open>clarsimp simp: valid_sched_def valid_sched_action_switch_is_subject[OF domains_distinct]
-                             dest!: reads_equiv_gD intro!: globals_equiv_idle_thread_ptr\<close>)?)
-                    apply (tactic \<open>distinct_subgoals_tac\<close>)
-              apply (all \<open>(erule requiv_g_cur_thread_eq)?\<close>)
-             apply (simp_all add: requiv_sched_act_eq[OF reads_equiv_gD[THEN conjunct1]])
-           apply (simp_all add: requiv_cur_domain_eq[OF reads_equiv_gD[THEN conjunct1]])
+  apply (intro allI conjI impI; (elim conjE)?;
+         ((fastforce simp: valid_sched_def valid_sched_action_switch_is_subject[OF domains_distinct]
+                    dest!: reads_equiv_gD intro!: globals_equiv_idle_thread_ptr))?)
+               apply (tactic \<open>distinct_subgoals_tac\<close>)
+         apply (all \<open>(erule requiv_g_cur_thread_eq)?\<close>)
+         apply (simp_all add: requiv_sched_act_eq[OF reads_equiv_gD[THEN conjunct1]])
          apply (all \<open>(solves \<open>clarsimp elim!: st_tcb_weakenE\<close>)?\<close>)
        apply (all \<open>(solves \<open>clarsimp simp: not_cur_thread_def\<close>)?\<close>)
    apply (clarsimp simp: valid_sched_def valid_sched_action_def weak_valid_sched_action_def)+
   done
 
 lemma schedule_if_reads_respects_g:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_g aag l (einvs and pas_cur_domain aag and guarded_pas_domain aag and
-                           (\<lambda>s. domain_time s > 0) and pas_refined aag)
-                    (schedule_if tc)"
-  apply(simp add: schedule_if_def)
-  apply(wp schedule_reads_respects_g activate_thread_reads_respects_g)
-   apply(rule_tac Q="\<lambda>rv s. guarded_pas_domain aag s \<and> invs s \<and> pas_cur_domain aag s"
-                  in hoare_strengthen_post)
+  assumes domains_distinct[wp]: "pas_domains_distinct pas"
+  shows "reads_respects_g pas (l :: 'a subject_label)
+           (einvs and pas_cur_domain pas and guarded_pas_domain pas
+                  and (\<lambda>s. domain_time s > 0) and pas_refined pas) (schedule_if tc)"
+  apply (simp add: schedule_if_def)
+  apply (wp schedule_reads_respects_g activate_thread_reads_respects_g)
+   apply (rule_tac Q="\<lambda>rv s. guarded_pas_domain pas s \<and> invs s \<and> pas_cur_domain pas s"
+                in hoare_strengthen_post)
     apply (wp schedule_guarded_pas_domain schedule_cur_domain
-          | simp add: guarded_pas_domain_def
-          | fastforce dest: domains_distinct[THEN pas_domains_distinct_inj])+
+           | simp add: guarded_pas_domain_def
+           | fastforce dest: domains_distinct[THEN pas_domains_distinct_inj])+
   done
 
+lemma globals_equiv_globals_equiv_scheduler[elim]:
+  "globals_equiv s t \<Longrightarrow> globals_equiv_scheduler s t"
+  by (auto simp: globals_equiv_def globals_equiv_scheduler_def)
+
+end
+
+
+lemma sameFor_current_partition_sys_mode_of_eq:
+  "\<lbrakk> (s, t) \<in> sameFor_subject (pasPolicy initial_aag) (pasObjectAbs initial_aag)
+                              (pasIRQAbs initial_aag) (pasASIDAbs initial_aag)
+                              (pasDomainAbs initial_aag) a;
+     label_of (the_elem (pasDomainAbs initial_aag (cur_domain (internal_state_if t)))) = a;
+     OrdinaryLabel a \<in> pasDomainAbs initial_aag (cur_domain (internal_state_if s)) \<rbrakk>
+     \<Longrightarrow> sys_mode_of s = sys_mode_of t"
+  apply (simp add: sameFor_subject_def2)
+  apply clarify
+  apply (erule impE)
+   apply fastforce
+  apply simp
+  done
+
+lemma flow_then_affect:
+  "(Partition x, Partition l) \<in> policyFlows (pasPolicy initial_aag)
+   \<Longrightarrow> Partition l \<in> partsSubjectAffects (pasPolicy initial_aag) x"
+  by (erule policyFlows.cases, simp_all add: partsSubjectAffects_def)
+
+
+context valid_initial_state begin
+
 lemma do_user_op_if_reads_respects_g:
-  "reads_respects_g aag l (pas_refined aag and valid_pdpt_objs and einvs and
+  "reads_respects_g aag l (pas_refined aag and valid_vspace_objs' and einvs and
                            is_subject aag \<circ> cur_thread and det_inv InUserMode tc and ct_running)
                     (do_user_op_if utf tc)"
   apply (rule equiv_valid_guard_imp)
-   apply (rule UserOp_IF.do_user_op_reads_respects_g[where P="\<lambda>tc. einvs and
+   apply (rule do_user_op_reads_respects_g[where P="\<lambda>tc. einvs and
                det_inv InUserMode tc and ct_running"])
-   using utf_det
-   apply fastforce
+   using utf_det apply fastforce
   apply simp
   apply (rule ct_running_not_idle)
    apply simp
   apply (simp add: invs_valid_idle)
   done
 
-lemma sameFor_current_partition_sys_mode_of_eq:
-  "\<lbrakk> (s, t) \<in> sameFor_subject
-                (pasPolicy initial_aag) (pasObjectAbs initial_aag)
-                (pasIRQAbs initial_aag) (pasASIDAbs initial_aag)
-                (pasDomainAbs initial_aag) a;
-     label_of (the_elem (pasDomainAbs initial_aag (cur_domain (internal_state_if t)))) = a;
-     OrdinaryLabel a \<in> pasDomainAbs initial_aag (cur_domain (internal_state_if s)) \<rbrakk>
-   \<Longrightarrow> sys_mode_of s = sys_mode_of t"
-  apply(simp add: sameFor_subject_def2)
-  apply clarify
-  apply(erule impE)
-   apply(fastforce)
-  apply simp
-  done
-
 lemma uwr_part_sys_mode_of_eq:
-  "\<lbrakk>(s,t) \<in> uwr (part s); part t = part s; part s \<noteq> PSched\<rbrakk> \<Longrightarrow> sys_mode_of s = sys_mode_of t"
-  apply(simp add: part_def split: if_split_asm)
-  apply(simp add: partition_def)
-  apply(cut_tac pas_wellformed_noninterference_silc[OF policy_wellformed, where d="cur_domain (internal_state_if s)"])
-  apply(case_tac "the_elem (pasDomainAbs initial_aag (cur_domain (internal_state_if s)))")
-   apply(simp add: uwr_def sameFor_def)
+  "\<lbrakk> (s,t) \<in> uwr (part s); part t = part s; part s \<noteq> PSched \<rbrakk>
+     \<Longrightarrow> sys_mode_of s = sys_mode_of t"
+  apply (simp add: part_def split: if_split_asm)
+  apply (simp add: partition_def)
+  apply (cut_tac pas_wellformed_noninterference_silc
+                   [OF policy_wellformed, where d="cur_domain (internal_state_if s)"])
+  apply (case_tac "the_elem (pasDomainAbs initial_aag (cur_domain (internal_state_if s)))")
+   apply (simp add: uwr_def sameFor_def)
    apply (erule (1) sameFor_current_partition_sys_mode_of_eq)
    apply (metis the_subject_of_aag_domain subject_current_aag)
   apply (metis the_label_of_domain_exists)
   done
 
-
-lemma flow_then_affect:
-  "(Partition x, Partition l) \<in> policyFlows (pasPolicy initial_aag)
-        \<Longrightarrow> Partition l
-       \<in> partsSubjectAffects (pasPolicy initial_aag) x"
-  apply(erule policyFlows.cases, simp_all add: partsSubjectAffects_def)
-  done
-
 lemma uwr_reads_equiv_f_g_affects_equiv:
-  "\<lbrakk>(s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr (Partition l);
-        invs_if s; invs_if t;
-        (part s, Partition l) \<in> policyFlows (pasPolicy initial_aag); part s \<noteq> PSched\<rbrakk> \<Longrightarrow>
-  reads_equiv_f_g (current_aag (internal_state_if s)) (internal_state_if s) (internal_state_if t) \<and>
-     affects_equiv (current_aag (internal_state_if s)) (OrdinaryLabel l) (internal_state_if s)
-      (internal_state_if t)"
-  apply(rule sameFor_reads_f_g_affects_equiv)
-      apply(simp add: current_aag_def)
-     apply(simp add: invs_if_def Invs_def)
+  "\<lbrakk> (s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr (Partition l); invs_if s; invs_if t;
+     (part s, Partition l) \<in> policyFlows (pasPolicy initial_aag); part s \<noteq> PSched \<rbrakk>
+     \<Longrightarrow> reads_equiv_f_g (current_aag (internal_state_if s))
+                         (internal_state_if s) (internal_state_if t) \<and>
+         affects_equiv (current_aag (internal_state_if s)) (OrdinaryLabel l)
+                       (internal_state_if s) (internal_state_if t)"
+  apply (rule sameFor_reads_f_g_affects_equiv)
+      apply (simp add: current_aag_def)
+     apply (simp add: invs_if_def Invs_def)
      apply blast
-    apply(clarsimp simp: uwr_def part_def current_aag_def partition_def split: if_splits)
-   apply(simp add: part_def split: if_splits add: partition_def current_aag_def flow_then_affect)
-  apply(clarsimp simp: uwr_def part_def current_aag_def partition_def split: if_splits)
+    apply (clarsimp simp: uwr_def part_def current_aag_def partition_def split: if_splits)
+   apply (simp add: part_def split: if_splits add: partition_def current_aag_def flow_then_affect)
+  apply (clarsimp simp: uwr_def part_def current_aag_def partition_def split: if_splits)
   done
+
+end
+
 
 lemma check_active_irq_if_reads_respects_g:
-  "reads_respects_g aag l (invs and only_timer_irq_inv irq st) (check_active_irq_if tc)"
-  apply(simp add: check_active_irq_if_def)
-  apply(wp dmo_getActiveIRQ_reads_respects_g| blast)+
+  "reads_respects_g aag (l :: 'a subject_label)
+     (invs and only_timer_irq_inv irq st) (check_active_irq_if tc)"
+  apply (simp add: check_active_irq_if_def)
+  apply (wp dmo_getActiveIRQ_reads_respects_g| blast)+
   done
 
 lemma check_active_irq_if_reads_respects_f_g:
-  "reads_respects_f_g aag l (silc_inv aag st and invs and only_timer_irq_inv irq st') (check_active_irq_if tc)"
-  apply(rule equiv_valid_guard_imp)
-  apply(rule reads_respects_f_g'[where Q="\<top>", OF check_active_irq_if_reads_respects_g])
-  apply(wp check_active_irq_if_wp)
-  apply fastforce+
+  "reads_respects_f_g aag (l :: 'a subject_label)
+     (silc_inv aag st and invs and only_timer_irq_inv irq st') (check_active_irq_if tc)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_f_g'[where Q="\<top>", OF check_active_irq_if_reads_respects_g])
+   apply (wp check_active_irq_if_wp)
+   apply fastforce+
   done
 
 lemma partitionIntegrity_cur_domain:
   "partitionIntegrity aag s s' \<Longrightarrow> cur_domain s = cur_domain s'"
-  apply(clarsimp simp: partitionIntegrity_def domain_fields_equiv_def)
-  done
-
-lemma globals_equiv_globals_equiv_scheduler[elim]:
-  "globals_equiv s t \<Longrightarrow> globals_equiv_scheduler s t"
-  apply(clarsimp simp: globals_equiv_def globals_equiv_scheduler_def)
-  done
-
-lemma reads_equiv_f_g_affects_equiv_uwr:
-  "\<lbrakk>reads_equiv_f_g (current_aag (internal_state_if s)) (internal_state_if s')
-         (internal_state_if t');
-        affects_equiv (current_aag (internal_state_if s)) (OrdinaryLabel a)
-         (internal_state_if s') (internal_state_if t');
-      (part s, Partition a) \<in> policyFlows (pasPolicy initial_aag); part s \<noteq> PSched;
-      silc_inv (current_aag (internal_state_if s')) s0_internal (internal_state_if s');
-      (s,t) \<in> uwr PSched;
-      partitionIntegrity (current_aag (internal_state_if s)) (internal_state_if s)
-        (internal_state_if s');
-      partitionIntegrity (current_aag (internal_state_if t)) (internal_state_if t)
-        (internal_state_if t');
-       sys_mode_of s' = sys_mode_of t'; user_context_of s' = user_context_of t'\<rbrakk>
-       \<Longrightarrow> (s', t') \<in> uwr (Partition a) \<and>
-          (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
-  apply(frule_tac s="internal_state_if s" in partitionIntegrity_cur_domain)
-  apply(subgoal_tac "current_aag (internal_state_if s) = current_aag (internal_state_if s')")
-   apply(case_tac s', case_tac t')
-   apply(case_tac aa, case_tac aaa)
-   apply(rule conjI)
-    apply simp
-    apply(drule (1) reads_g_affects_equiv_sameFor[OF conjI])
-       apply(simp add: current_aag_def)
-      apply(fastforce)
-     apply(simp add: current_aag_def)
-     apply(rule flow_then_affect)
-     apply(simp add: part_def partition_def split: if_splits)
-    apply(clarsimp simp: uwr_def current_aag_def)
-    apply assumption
-   apply(rule conjI)
-    apply(clarsimp simp: uwr_def sameFor_def sameFor_scheduler_def)
-    apply(clarsimp simp: reads_equiv_f_g_def silc_dom_equiv_def current_aag_def globals_equiv_idle_thread_ptr globals_equiv_globals_equiv_scheduler reads_equiv_def)
-    apply(fastforce simp: domain_fields_equiv_def partitionIntegrity_def)
-   apply(drule sameFor_reads_equiv_f_g[rotated, rotated])
-     apply(fastforce simp: current_aag_def)
-    apply(fastforce simp: invs_if_def Invs_def)
-   apply(simp add: uwr_def part_def partition_def current_aag_def split: if_splits)
-  apply(simp add: current_aag_def)
-  done
+  by (clarsimp simp: partitionIntegrity_def domain_fields_equiv_def)
 
 lemma use_ev:
-  "\<lbrakk>equiv_valid I A B P f; (rv,s') \<in> fst (f s); (rv',t') \<in> fst (f t);
-    P s; P t; I s t; A s t\<rbrakk> \<Longrightarrow>
-    rv' = rv \<and> I s' t' \<and> B s' t'"
-  apply(fastforce simp: equiv_valid_def2 equiv_valid_2_def)
-  done
+  "\<lbrakk> equiv_valid I A B P f; (rv,s') \<in> fst (f s); (rv',t') \<in> fst (f t); P s; P t; I s t; A s t \<rbrakk>
+    \<Longrightarrow> rv' = rv \<and> I s' t' \<and> B s' t'"
+  by (fastforce simp: equiv_valid_def2 equiv_valid_2_def)
+
+
+context valid_initial_state begin
 
 lemma uwr_part_sys_mode_of_user_context_of_eq:
-  "\<lbrakk>(s,t) \<in> uwr (part s); part s \<noteq> PSched\<rbrakk> \<Longrightarrow>
-   sys_mode_of s = sys_mode_of t \<and> (user_modes (sys_mode_of s) \<longrightarrow> user_context_of s = user_context_of t)"
-  apply(clarsimp simp: part_def split: if_splits)
-  apply(simp add: uwr_partition_if)
-  done
+  "\<lbrakk> (s,t) \<in> uwr (part s); part s \<noteq> PSched \<rbrakk>
+     \<Longrightarrow> sys_mode_of s = sys_mode_of t \<and>
+         (user_modes (sys_mode_of s) \<longrightarrow> user_context_of s = user_context_of t)"
+  by (clarsimp simp: part_def uwr_partition_if split: if_splits)
 
 lemma uwr_PSched_cur_domain:
   "(s,t) \<in> uwr PSched \<Longrightarrow> cur_domain (internal_state_if s) = cur_domain (internal_state_if t)"
-  apply(fastforce simp: uwr_def sameFor_def sameFor_scheduler_def domain_fields_equiv_def)
-  done
+  by (fastforce simp: uwr_def sameFor_def sameFor_scheduler_def domain_fields_equiv_def)
 
 lemma uwr_PSched_cur_domain':
   "(((sx, s), sm), ((tx, t), tm)) \<in> uwr PSched \<Longrightarrow> cur_domain s = cur_domain t"
   by (fastforce dest: uwr_PSched_cur_domain)
 
+lemma part_not_PSched_sys_mode_of_not_KernelSchedule_True:
+  "part s \<noteq> PSched \<Longrightarrow> sys_mode_of s \<noteq> KernelSchedule True"
+  apply (erule contrapos_nn)
+  apply (simp add: part_def)
+  done
+
+end
+
+
+context Noninterference_valid_initial_state begin
+
+lemma reads_equiv_f_g_affects_equiv_uwr:
+  "\<lbrakk> reads_equiv_f_g (current_aag (internal_state_if s))
+                     (internal_state_if s') (internal_state_if t');
+     affects_equiv (current_aag (internal_state_if s)) (OrdinaryLabel a)
+                   (internal_state_if s') (internal_state_if t');
+     (part s, Partition a) \<in> policyFlows (pasPolicy initial_aag); part s \<noteq> PSched;
+     silc_inv (current_aag (internal_state_if s')) s0_internal (internal_state_if s');
+     (s,t) \<in> uwr PSched;
+     partitionIntegrity (current_aag (internal_state_if s))
+                        (internal_state_if s) (internal_state_if s');
+     partitionIntegrity (current_aag (internal_state_if t))
+                        (internal_state_if t) (internal_state_if t');
+     sys_mode_of s' = sys_mode_of t'; user_context_of s' = user_context_of t' \<rbrakk>
+     \<Longrightarrow> (s', t') \<in> uwr (Partition a) \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
+  apply (frule_tac s="internal_state_if s" in partitionIntegrity_cur_domain)
+  apply (subgoal_tac "current_aag (internal_state_if s) = current_aag (internal_state_if s')")
+   apply (case_tac s', case_tac t')
+   apply (case_tac aa, case_tac aaa)
+   apply (rule conjI)
+    apply simp
+    apply (drule (1) reads_g_affects_equiv_sameFor[OF conjI])
+       apply (simp add: current_aag_def)
+      apply (fastforce)
+     apply (simp add: current_aag_def)
+     apply (rule flow_then_affect)
+     apply (simp add: part_def partition_def split: if_splits)
+    apply (clarsimp simp: uwr_def current_aag_def)
+    apply assumption
+   apply (rule conjI)
+    apply (clarsimp simp: uwr_def sameFor_def sameFor_scheduler_def)
+    apply (clarsimp simp: reads_equiv_f_g_def reads_equiv_def silc_dom_equiv_def current_aag_def
+                          globals_equiv_idle_thread_ptr globals_equiv_globals_equiv_scheduler)
+    apply (fastforce simp: domain_fields_equiv_def partitionIntegrity_def)
+   apply (drule sameFor_reads_equiv_f_g)
+     apply (fastforce simp: invs_if_def Invs_def)
+    apply (fastforce simp: current_aag_def)
+   apply (simp add: uwr_def part_def partition_def current_aag_def split: if_splits)
+  apply (simp add: current_aag_def)
+  done
+
 lemma check_active_irq_A_if_confidentiality_helper:
-  notes
-    reads_respects_irq =
-      use_ev[OF check_active_irq_if_reads_respects_f_g[
-        where st=s0_internal and st'=s0_internal and irq=timer_irq]]
+  notes reads_respects_irq = use_ev[OF check_active_irq_if_reads_respects_f_g[where st=s0_internal
+                                                                                and st'=s0_internal
+                                                                                and irq=timer_irq]]
   shows
-  "\<lbrakk>(s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
-    invs_if s;     invs_if t;     silc_inv (current_aag (internal_state_if s')) s0_internal (internal_state_if s');
-    (part s, u) \<in> policyFlows (pasPolicy initial_aag);
-    part s \<noteq> PSched; u \<noteq> PSched; user_modes (sys_mode_of s);
-    ((fst s),x,(fst s')) \<in> check_active_irq_A_if;
-    ((fst t),y,(fst t')) \<in> check_active_irq_A_if
-    \<rbrakk> \<Longrightarrow>
-   x = y \<and>
-  (snd s' = f x \<and> snd t' = f y \<longrightarrow>
-   (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s))"
-  apply(frule (1) uwr_part_sys_mode_of_user_context_of_eq)
-  apply(clarsimp simp: check_active_irq_A_if_def)
-  apply(case_tac s, case_tac t, simp_all)
-  apply(case_tac u, simp_all)
-  apply(frule (6) uwr_reads_equiv_f_g_affects_equiv)
-  apply (match premises in "s = ((_, p), _)" and "t = ((_, q), _)" and
-             H: "(_, _) \<in> fst (check_active_irq_if _ p)"
-          for p q \<Rightarrow>
-          \<open>rule revcut_rl[OF reads_respects_irq[where s=p and t=q, OF H]]\<close>)
+    "\<lbrakk> (s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u; invs_if s; invs_if t;
+       silc_inv (current_aag (internal_state_if s')) s0_internal (internal_state_if s');
+       (part s, u) \<in> policyFlows (pasPolicy initial_aag);
+       part s \<noteq> PSched; u \<noteq> PSched; user_modes (sys_mode_of s);
+       ((fst s),x,(fst s')) \<in> check_active_irq_A_if; ((fst t),y,(fst t')) \<in> check_active_irq_A_if \<rbrakk>
+       \<Longrightarrow> x = y \<and> (snd s' = f x \<and> snd t' = f y
+                    \<longrightarrow> (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s))"
+  apply (frule (1) uwr_part_sys_mode_of_user_context_of_eq)
+  apply (clarsimp simp: check_active_irq_A_if_def)
+  apply (case_tac s, case_tac t, simp_all)
+  apply (case_tac u, simp_all)
+  apply (frule (6) uwr_reads_equiv_f_g_affects_equiv)
+  apply (match premises in "s = ((_, p), _)" and "t = ((_, q), _)"
+                    and H: "(_, _) \<in> fst (check_active_irq_if _ p)"
+                    for p q \<Rightarrow> \<open>rule revcut_rl[OF reads_respects_irq[where s=p and t=q, OF H]]\<close>)
        apply assumption
-      apply(simp add: invs_if_def Invs_def)
-      apply(elim conjE)
+      apply (simp add: invs_if_def Invs_def)
+      apply (elim conjE)
       apply assumption
-     apply(simp add: invs_if_def Invs_def)
-     apply(simp only: current_aag_eqI[OF uwr_PSched_cur_domain'])
+     apply (simp add: invs_if_def Invs_def)
+     apply (simp only: current_aag_eqI[OF uwr_PSched_cur_domain'])
     apply simp
    apply fastforce
   apply simp
-  apply(rule impI)
-  apply(rule reads_equiv_f_g_affects_equiv_uwr)
-            apply simp+
-     apply(erule use_valid[OF _ check_active_irq_if_partitionIntegrity])
-     apply(rule partitionIntegrity_refl)
+  apply (rule impI)
+  apply (rule reads_equiv_f_g_affects_equiv_uwr)
+           apply simp+
+     apply (erule use_valid[OF _ check_active_irq_if_partitionIntegrity])
+     apply (rule partitionIntegrity_refl)
     apply simp
-    apply(erule use_valid[OF _ check_active_irq_if_partitionIntegrity])
-    apply(rule partitionIntegrity_refl)
-   apply(simp add: sys_mode_of_def)
-  apply(simp add: user_context_of_def)
+    apply (erule use_valid[OF _ check_active_irq_if_partitionIntegrity])
+    apply (rule partitionIntegrity_refl)
+   apply (simp add: sys_mode_of_def)
+  apply (simp add: user_context_of_def)
   done
 
 lemma check_active_irq_A_if_confidentiality:
-  "\<lbrakk>(s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
-    invs_if s;     invs_if t;
-    (part s, u) \<in> policyFlows (pasPolicy initial_aag);
-    part s \<noteq> PSched; u \<noteq> PSched; user_modes (sys_mode_of s);
-    ((fst s),x,(fst s')) \<in> check_active_irq_A_if;
-    ((fst t),y,(fst t')) \<in> check_active_irq_A_if
-    \<rbrakk> \<Longrightarrow>
-   x = y \<and>
-  (snd s' = f x \<and> snd t' = f y \<longrightarrow>
-   (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s))"
-  apply(subgoal_tac "silc_inv (current_aag (internal_state_if s')) s0_internal (internal_state_if s')")
-   apply(blast dest!: check_active_irq_A_if_confidentiality_helper)
-  apply(case_tac s', simp)
-  apply(case_tac a, simp)
-  apply(clarsimp simp: check_active_irq_A_if_def)
-  apply(erule use_valid)
-   apply(wp check_active_irq_if_wp)
-  apply(fastforce simp: invs_if_def Invs_def current_aag_def)
+  "\<lbrakk> (s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u; invs_if s; invs_if t;
+     (part s, u) \<in> policyFlows (pasPolicy initial_aag);
+     part s \<noteq> PSched; u \<noteq> PSched; user_modes (sys_mode_of s);
+     ((fst s),x,(fst s')) \<in> check_active_irq_A_if; ((fst t),y,(fst t')) \<in> check_active_irq_A_if \<rbrakk>
+     \<Longrightarrow> x = y \<and> (snd s' = f x \<and> snd t' = f y
+                  \<longrightarrow> (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s))"
+  apply (subgoal_tac "silc_inv (current_aag (internal_state_if s')) s0_internal (internal_state_if s')")
+   apply (blast dest!: check_active_irq_A_if_confidentiality_helper)
+  apply (case_tac s', simp)
+  apply (case_tac a, simp)
+  apply (clarsimp simp: check_active_irq_A_if_def)
+  apply (erule use_valid)
+   apply (wp check_active_irq_if_wp)
+  apply (fastforce simp: invs_if_def Invs_def current_aag_def)
   done
 
 lemma check_active_irq_A_if_confidentiality':
-  "\<lbrakk>(XX, YY) \<in> uwr PSched; XX = s; YY = t; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
-    invs_if s;     invs_if t;
-    (part s, u) \<in> policyFlows (pasPolicy initial_aag);
-    part s \<noteq> PSched; u \<noteq> PSched; user_modes (sys_mode_of s);
-    ((fst s),x,(fst s')) \<in> check_active_irq_A_if;
-    ((fst t),y,(fst t')) \<in> check_active_irq_A_if;
-    snd s' = (case x of None \<Rightarrow> InUserMode | Some xx \<Rightarrow> KernelEntry Interrupt);
-    snd t' = (case y of None \<Rightarrow> InUserMode | Some yy \<Rightarrow> KernelEntry Interrupt)\<rbrakk> \<Longrightarrow>
-   x = y \<and>
-   (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
-  apply(blast dest: check_active_irq_A_if_confidentiality)
-  done
+  "\<lbrakk> (XX, YY) \<in> uwr PSched; XX = s; YY = t; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
+     invs_if s; invs_if t; (part s, u) \<in> policyFlows (pasPolicy initial_aag);
+     part s \<noteq> PSched; u \<noteq> PSched; user_modes (sys_mode_of s);
+     ((fst s),x,(fst s')) \<in> check_active_irq_A_if; ((fst t),y,(fst t')) \<in> check_active_irq_A_if;
+     snd s' = (case x of None \<Rightarrow> InUserMode | Some xx \<Rightarrow> KernelEntry Interrupt);
+     snd t' = (case y of None \<Rightarrow> InUserMode | Some yy \<Rightarrow> KernelEntry Interrupt) \<rbrakk>
+     \<Longrightarrow> x = y \<and> (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
+  by (blast dest: check_active_irq_A_if_confidentiality)
 
 lemma check_active_irq_A_if_confidentiality'':
-  "\<lbrakk>(XX, YY) \<in> uwr PSched; XX = s; YY = t; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
-    invs_if s;     invs_if t;
-    (part s, u) \<in> policyFlows (pasPolicy initial_aag);
+  "\<lbrakk> (XX, YY) \<in> uwr PSched; XX = s; YY = t; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
+    invs_if s; invs_if t; (part s, u) \<in> policyFlows (pasPolicy initial_aag);
     part s \<noteq> PSched; u \<noteq> PSched; user_modes (sys_mode_of s);
-    ((fst s),x,(fst s')) \<in> check_active_irq_A_if;
-    ((fst t),y,(fst t')) \<in> check_active_irq_A_if;
+    ((fst s),x,(fst s')) \<in> check_active_irq_A_if; ((fst t),y,(fst t')) \<in> check_active_irq_A_if;
     snd s' = (case x of None \<Rightarrow> InIdleMode | Some xx \<Rightarrow> KernelEntry Interrupt);
-    snd t' = (case y of None \<Rightarrow> InIdleMode | Some yy \<Rightarrow> KernelEntry Interrupt)\<rbrakk> \<Longrightarrow>
-   x = y \<and>
-   (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
-  apply(blast dest: check_active_irq_A_if_confidentiality)
-  done
+    snd t' = (case y of None \<Rightarrow> InIdleMode | Some yy \<Rightarrow> KernelEntry Interrupt) \<rbrakk>
+    \<Longrightarrow> x = y \<and> (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
+  by (blast dest: check_active_irq_A_if_confidentiality)
 
 lemma check_active_irq_A_if_retval_eq:
-  "\<lbrakk>(XX, YY) \<in> uwr PSched; XX = s; YY = t; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
-    invs_if s;     invs_if t;
-    (part s, u) \<in> policyFlows (pasPolicy initial_aag);
-    part s \<noteq> PSched; u \<noteq> PSched; user_modes (sys_mode_of s);
-    ((fst s),x,s') \<in> check_active_irq_A_if;
-    ((fst t),y,t') \<in> check_active_irq_A_if\<rbrakk> \<Longrightarrow>
-   x = y"
+  "\<lbrakk> (XX, YY) \<in> uwr PSched; XX = s; YY = t; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
+     invs_if s; invs_if t; (part s, u) \<in> policyFlows (pasPolicy initial_aag);
+     part s \<noteq> PSched; u \<noteq> PSched; user_modes (sys_mode_of s);
+     ((fst s),x,s') \<in> check_active_irq_A_if; ((fst t),y,t') \<in> check_active_irq_A_if \<rbrakk>
+     \<Longrightarrow> x = y"
   apply simp
-  apply(drule_tac s'="(s',undefined)" and t'="(t',undefined)" and u=u
-               in check_active_irq_A_if_confidentiality, simp+)
-  apply(elim conjE, assumption)
+  apply (drule_tac s'="(s',undefined)" and t'="(t',undefined)" and u=u
+                in check_active_irq_A_if_confidentiality, simp+)
+  apply (elim conjE, assumption)
   done
 
 lemmas do_user_op_if_reads_respects_f_g =
-          reads_respects_f_g'[where Q="\<top>", simplified, OF do_user_op_if_reads_respects_g,
-                              OF do_user_op_silc_inv]
-
+  reads_respects_f_g'[where Q="\<top>", simplified,
+                      OF do_user_op_if_reads_respects_g,
+                      OF do_user_op_silc_inv]
 
 lemma partitionIntegrity_irq_state_update[simp]:
-  "partitionIntegrity aag y
-           (y\<lparr>machine_state := machine_state y
-                \<lparr>irq_state := X\<rparr>\<rparr>)"
-  apply(cut_tac s=y and aag=aag in partitionIntegrity_refl)
-  apply(clarsimp simp: partitionIntegrity_def integrity_subjects_def domain_fields_equiv_def
-                       globals_equiv_scheduler_def silc_dom_equiv_def equiv_for_def)
+  "partitionIntegrity aag y (y\<lparr>machine_state := (machine_state y)\<lparr>irq_state := X\<rparr>\<rparr>)"
+  apply (cut_tac s=y and aag=aag in partitionIntegrity_refl)
+  apply (clarsimp simp: partitionIntegrity_def integrity_subjects_def domain_fields_equiv_def
+                        globals_equiv_scheduler_def silc_dom_equiv_def equiv_for_def)
   done
 
 lemma invs_if_Invs:
   "invs_if s
-    \<Longrightarrow> Invs (internal_state_if s)
-        \<and> det_inv (sys_mode_of s) (cur_thread_context_of s) (internal_state_if s)"
+   \<Longrightarrow> Invs (internal_state_if s) \<and>
+       det_inv (sys_mode_of s) (cur_thread_context_of s) (internal_state_if s)"
   by (simp add: invs_if_def)
 
 lemma do_user_op_A_if_confidentiality:
-  notes
-    read_respects_irq =
-      use_ev[OF check_active_irq_if_reads_respects_f_g[
-        where st=s0_internal and st'=s0_internal and irq=timer_irq
-          and aag="current_aag (internal_state_if s)"]] and
-    read_respects_user_op =
-      use_ev[OF do_user_op_if_reads_respects_f_g[
-        where aag="current_aag (internal_state_if s)" and st="s0_internal"]]
+  notes read_respects_irq =
+    use_ev[OF check_active_irq_if_reads_respects_f_g[where st=s0_internal
+                                                       and st'=s0_internal
+                                                       and irq=timer_irq
+                                                       and aag="current_aag (internal_state_if s)"]]
+  and read_respects_user_op =
+    use_ev[OF do_user_op_if_reads_respects_f_g[where aag="current_aag (internal_state_if s)"
+                                                 and st="s0_internal"]]
   shows
-  "\<lbrakk>(s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
-    invs_if s;     invs_if t;     invs_if s';    invs_if t';
-    (part s, u) \<in> policyFlows (pasPolicy initial_aag);
-    part s \<noteq> PSched; u \<noteq> PSched; sys_mode_of s = InUserMode; sys_mode_of t = InUserMode;
-    ((fst s),None,s_aux) \<in> check_active_irq_A_if;
-    ((fst t),None,t_aux) \<in> check_active_irq_A_if;
-    (s_aux,xx,fst s') \<in> do_user_op_A_if utf;
-    (t_aux,yy,fst t') \<in> do_user_op_A_if utf; snd s' = f xx; snd t' = f yy\<rbrakk> \<Longrightarrow>
-   xx = yy \<and>
-   (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
+    "\<lbrakk> (s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u; invs_if s; invs_if t;
+       invs_if s'; invs_if t'; (part s, u) \<in> policyFlows (pasPolicy initial_aag);
+       part s \<noteq> PSched; u \<noteq> PSched; sys_mode_of s = InUserMode; sys_mode_of t = InUserMode;
+       (fst s, None, s_aux) \<in> check_active_irq_A_if; (fst t, None, t_aux) \<in> check_active_irq_A_if;
+       (s_aux, xx, fst s') \<in> do_user_op_A_if utf; (t_aux, yy, fst t') \<in> do_user_op_A_if utf;
+       snd s' = f xx; snd t' = f yy \<rbrakk>
+       \<Longrightarrow> xx = yy \<and> (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
   including no_pre
   supply [[simp_depth_limit=2]] \<comment> \<open>speedup\<close>
-  apply(frule (1) uwr_part_sys_mode_of_user_context_of_eq)
-  apply(clarsimp simp: check_active_irq_A_if_def)
-  apply(case_tac s, case_tac t, simp_all)
-  apply(case_tac u, simp_all)
-  apply(frule (6) uwr_reads_equiv_f_g_affects_equiv)
-  apply (match premises in "s = ((_,p),_)" and "t = ((_,q),_)" and
-             H: "(_,_) \<in> fst (check_active_irq_if _ p)"
-          for p q \<Rightarrow> \<open>rule revcut_rl[OF read_respects_irq[where t=q, OF H]]\<close>)
+  apply (frule (1) uwr_part_sys_mode_of_user_context_of_eq)
+  apply (clarsimp simp: check_active_irq_A_if_def)
+  apply (case_tac s, case_tac t, simp_all)
+  apply (case_tac u, simp_all)
+  apply (frule (6) uwr_reads_equiv_f_g_affects_equiv)
+  apply (match premises in "s = ((_,p),_)" and "t = ((_,q),_)"
+                    and H: "(_,_) \<in> fst (check_active_irq_if _ p)"
+                    for p q \<Rightarrow> \<open>rule revcut_rl[OF read_respects_irq[where t=q, OF H]]\<close>)
        apply assumption
       apply (clarsimp dest!: invs_if_Invs simp: Invs_def)
      apply (drule uwr_PSched_cur_domain)
      apply (clarsimp dest!: invs_if_Invs simp: Invs_def)
-     subgoal by(clarsimp simp: current_aag_def)
+     subgoal by (clarsimp simp: current_aag_def)
     apply simp
    apply fastforce
-  apply(simp add: do_user_op_A_if_def | elim exE conjE)+
-  apply (match premises in "s_aux = (_,p)" and "t_aux = (_,q)" and
-             H: "(_,_) \<in> fst (do_user_op_if _ _ p)"
-          for p q \<Rightarrow> \<open>rule revcut_rl[OF read_respects_user_op[where t=q, OF H]]\<close>)
+  apply (simp add: do_user_op_A_if_def | elim exE conjE)+
+  apply (match premises in "s_aux = (_,p)" and "t_aux = (_,q)"
+                    and H: "(_,_) \<in> fst (do_user_op_if _ _ p)"
+                    for p q \<Rightarrow> \<open>rule revcut_rl[OF read_respects_user_op[where t=q, OF H]]\<close>)
        apply assumption
       apply (match premises in "s = ((_,p),_)" and H: "(_,_) \<in> fst (check_active_irq_if _ p)"
-              for p \<Rightarrow> \<open>rule revcut_rl[OF use_valid[OF H check_active_irq_if_User_det_inv]]\<close>)
-       apply (simp(no_asm_use) add: invs_if_def Invs_def cur_thread_context_of_def)
+                   for p \<Rightarrow> \<open>rule revcut_rl[OF use_valid[OF H check_active_irq_if_User_det_inv]]\<close>)
+       apply (simp (no_asm_use) add: invs_if_def Invs_def cur_thread_context_of_def)
        apply metis
       apply simp
       apply (erule use_valid)
@@ -3028,220 +2656,214 @@ lemma do_user_op_A_if_confidentiality:
       apply (clarsimp simp: invs_if_def Invs_def)
       apply (blast intro!: guarded_pas_is_subject_current_aag[rule_format] active_from_running)
      apply (match premises in "t_aux = (_,q)" and H: "(_,q) \<in> fst (check_active_irq_if _ _)"
-              for q \<Rightarrow> \<open>rule revcut_rl[OF use_valid[OF H check_active_irq_if_User_det_inv]]\<close>)
-      apply (simp(no_asm_use) add: invs_if_def Invs_def cur_thread_context_of_def)
+                  for q \<Rightarrow> \<open>rule revcut_rl[OF use_valid[OF H check_active_irq_if_User_det_inv]]\<close>)
+      apply (simp (no_asm_use) add: invs_if_def Invs_def cur_thread_context_of_def)
       apply metis
      apply simp
      apply (erule_tac s'=yc in use_valid)
       apply (wp check_active_irq_if_wp)
      apply (clarsimp simp: invs_if_def Invs_def current_aag_eqI[OF uwr_PSched_cur_domain'])
      apply (match premises in "t = ((_,q),_)" and H: "invs q" for q \<Rightarrow>
-             \<open>rule revcut_rl[OF ct_running_not_idle[OF _ invs_valid_idle[OF H]]]\<close>)
+              \<open>rule revcut_rl[OF ct_running_not_idle[OF _ invs_valid_idle[OF H]]]\<close>)
       apply assumption
      apply (match premises in "t = ((_,q),_)" for q \<Rightarrow>
-             \<open>rule revcut_rl[OF current_aag_def[where t=q]]\<close>)
+              \<open>rule revcut_rl[OF current_aag_def[where t=q]]\<close>)
      apply (blast intro!: guarded_pas_is_subject_current_aag[rule_format] active_from_running)
     apply simp
    apply simp
   apply simp
-  apply(rule reads_equiv_f_g_affects_equiv_uwr)
+  apply (rule reads_equiv_f_g_affects_equiv_uwr)
            apply ((clarsimp simp: Invs_def dest!: invs_if_Invs; rule TrueI)+)
       apply (simp add: invs_if_def Invs_def)
      apply (simp add: invs_if_def Invs_def)
-     apply(erule use_valid[OF _ do_user_op_if_partitionIntegrity])
-     apply(erule use_valid[OF _ check_active_irq_if_wp])
+     apply (erule use_valid[OF _ do_user_op_if_partitionIntegrity])
+     apply (erule use_valid[OF _ check_active_irq_if_wp])
      apply clarsimp
-     apply(frule (1) ct_running_not_idle[OF _ invs_valid_idle])
+     apply (frule (1) ct_running_not_idle[OF _ invs_valid_idle])
      apply (blast intro!: guarded_pas_is_subject_current_aag[rule_format] active_from_running)
     apply simp
-    apply(erule_tac s'=s'aa in use_valid[OF _ do_user_op_if_partitionIntegrity])
-    apply(erule_tac s'=yc in use_valid[OF _ check_active_irq_if_wp])
-    apply(clarsimp simp: invs_if_def Invs_def)
+    apply (erule_tac s'=s'aa in use_valid[OF _ do_user_op_if_partitionIntegrity])
+    apply (erule_tac s'=yc in use_valid[OF _ check_active_irq_if_wp])
+    apply (clarsimp simp: invs_if_def Invs_def)
     apply (match premises in "t = ((_,q),_)" and H: "invs q" for q \<Rightarrow>
-            \<open>rule revcut_rl[OF ct_running_not_idle[OF _ invs_valid_idle[OF H]]]\<close>)
+             \<open>rule revcut_rl[OF ct_running_not_idle[OF _ invs_valid_idle[OF H]]]\<close>)
      apply assumption
     apply (blast intro!: guarded_pas_is_subject_current_aag[rule_format] active_from_running)
-   apply(simp add: sys_mode_of_def)
-  apply(simp add: user_context_of_def)
+   apply (simp add: sys_mode_of_def)
+  apply (simp add: user_context_of_def)
   done
 
 lemma do_user_op_A_if_confidentiality':
-  "\<lbrakk>(XX, YY) \<in> uwr PSched; XX = s; YY = t; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
-    invs_if s;     invs_if t;     invs_if s';    invs_if t';
-    (part s, u) \<in> policyFlows (pasPolicy initial_aag);
-    part s \<noteq> PSched; u \<noteq> PSched; sys_mode_of s = InUserMode; sys_mode_of t = InUserMode;
-    ((fst s),None,s_aux) \<in> check_active_irq_A_if;
-    ((fst t),None,t_aux) \<in> check_active_irq_A_if;
-    (s_aux,xx,fst s') \<in> do_user_op_A_if utf;
-    (t_aux,yy,fst t') \<in> do_user_op_A_if utf;
-    snd s' = (case xx of None \<Rightarrow> InUserMode | Some xxx \<Rightarrow> KernelEntry xxx);
-    snd t' = (case yy of None \<Rightarrow> InUserMode | Some yyy \<Rightarrow> KernelEntry yyy)\<rbrakk> \<Longrightarrow>
-  xx = yy \<and>
-   (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
-  apply(rule do_user_op_A_if_confidentiality, simp+)
-  done
+  "\<lbrakk> (XX, YY) \<in> uwr PSched; XX = s; YY = t; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u; invs_if s;
+     invs_if t; invs_if s'; invs_if t'; (part s, u) \<in> policyFlows (pasPolicy initial_aag);
+     part s \<noteq> PSched; u \<noteq> PSched; sys_mode_of s = InUserMode; sys_mode_of t = InUserMode;
+     ((fst s),None,s_aux) \<in> check_active_irq_A_if; ((fst t),None,t_aux) \<in> check_active_irq_A_if;
+     (s_aux,xx,fst s') \<in> do_user_op_A_if utf; (t_aux,yy,fst t') \<in> do_user_op_A_if utf;
+     snd s' = (case xx of None \<Rightarrow> InUserMode | Some xxx \<Rightarrow> KernelEntry xxx);
+     snd t' = (case yy of None \<Rightarrow> InUserMode | Some yyy \<Rightarrow> KernelEntry yyy) \<rbrakk>
+     \<Longrightarrow> xx = yy \<and> (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
+  by (rule do_user_op_A_if_confidentiality, simp+)
+
+end
+
+
+context Noninterference_valid_initial_state begin
 
 lemmas schedule_if_reads_respects_f_g =
          reads_respects_f_g'[where Q="\<top>", simplified, OF schedule_if_reads_respects_g,
                              OF _ schedule_if_silc_inv]
 
-lemma part_not_PSched_sys_mode_of_not_KernelSchedule_True:
-  "part s \<noteq> PSched \<Longrightarrow> sys_mode_of s \<noteq> KernelSchedule True"
-  apply(erule contrapos_nn)
-  apply(simp add: part_def)
-  done
-
 lemma kernel_schedule_if_confidentiality:
-  "\<lbrakk>(s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
-    invs_if s;     invs_if t;   invs_if s'; invs_if t';
-    (part s, u) \<in> policyFlows (pasPolicy initial_aag);
-    part s \<noteq> PSched; u \<noteq> PSched; user_modes (sys_mode_of s);
-    ((fst s),(),(fst s')) \<in> kernel_schedule_if;
-    ((fst t),(),(fst t')) \<in> kernel_schedule_if;
-    snd s' = snd t'\<rbrakk> \<Longrightarrow>
-   (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
+  "\<lbrakk> (s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u; invs_if s; invs_if t;
+     invs_if s'; invs_if t'; (part s, u) \<in> policyFlows (pasPolicy initial_aag);
+     part s \<noteq> PSched; u \<noteq> PSched; user_modes (sys_mode_of s);
+     ((fst s),(),(fst s')) \<in> kernel_schedule_if;
+     ((fst t),(),(fst t')) \<in> kernel_schedule_if; snd s' = snd t' \<rbrakk>
+     \<Longrightarrow> (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
   supply [[simp_depth_limit=1]] \<comment> \<open>speedup\<close>
-  apply(frule (1) uwr_part_sys_mode_of_user_context_of_eq)
-  apply(frule part_not_PSched_sys_mode_of_not_KernelSchedule_True)
-  apply(clarsimp simp: kernel_schedule_if_def)
-  apply(case_tac s, case_tac t, simp_all)
-  apply(case_tac u, simp_all)
-  apply(frule (6) uwr_reads_equiv_f_g_affects_equiv)
-  apply(simp split: prod.splits)
-  apply(rename_tac x1 x1' x2 x1'' x2')
-  supply [[simproc del: defined_all]]
-  apply(case_tac s', case_tac t')
-  apply(simp add: split_paired_all)
-  apply(frule_tac s=x2 and t=x2' and s2=x2
-               in use_ev[OF schedule_if_reads_respects_f_g
-                              [where st=s0_internal, OF current_domains_distinct]])
+  apply (frule (1) uwr_part_sys_mode_of_user_context_of_eq)
+  apply (frule part_not_PSched_sys_mode_of_not_KernelSchedule_True)
+  apply (clarsimp simp: kernel_schedule_if_def)
+  apply (case_tac s, case_tac t, simp_all)
+  apply (case_tac u, simp_all)
+  apply (frule (6) uwr_reads_equiv_f_g_affects_equiv)
+  apply (simp split: prod.splits)
+  apply (case_tac s', case_tac t')
+  apply (simp add: split_paired_all)
+  apply (frule_tac s=x2 and t=bb and s2=x2
+                in use_ev[OF schedule_if_reads_respects_f_g
+                               [where st=s0_internal, OF current_domains_distinct]])
        apply assumption
-      apply(clarsimp simp: invs_if_def Invs_def current_aag_def)
-     apply(clarsimp simp: invs_if_def Invs_def)
-     apply(drule uwr_PSched_cur_domain)
-     apply(clarsimp simp: current_aag_def)
+      apply (clarsimp simp: invs_if_def Invs_def current_aag_def)
+     apply (clarsimp simp: invs_if_def Invs_def)
+     apply (drule uwr_PSched_cur_domain)
+     apply (clarsimp simp: current_aag_def)
     apply simp
    apply fastforce
   apply simp
-  apply(rule reads_equiv_f_g_affects_equiv_uwr)
-            apply simp+
-       apply(fastforce simp: invs_if_def Invs_def)
+  apply (rule reads_equiv_f_g_affects_equiv_uwr)
+           apply simp+
+       apply (fastforce simp: invs_if_def Invs_def)
       apply simp
      apply simp
-     apply(erule use_valid[OF _ schedule_if_partitionIntegrity[OF current_domains_distinct]])
-     apply(clarsimp simp: partitionIntegrity_refl invs_if_def Invs_def current_aag_def silc_inv_refl)
+     apply (erule use_valid[OF _ schedule_if_partitionIntegrity[OF current_domains_distinct]])
+     apply (clarsimp simp: partitionIntegrity_refl invs_if_def Invs_def current_aag_def silc_inv_refl)
     apply simp
-    apply(erule use_valid[OF _ schedule_if_partitionIntegrity[OF current_domains_distinct]])
-    apply(clarsimp simp: partitionIntegrity_refl invs_if_def Invs_def current_aag_def silc_inv_refl)
-   apply(simp add: sys_mode_of_def)
-  apply(simp add: user_context_of_def)
+    apply (erule use_valid[OF _ schedule_if_partitionIntegrity[OF current_domains_distinct]])
+    apply (clarsimp simp: partitionIntegrity_refl invs_if_def Invs_def current_aag_def silc_inv_refl)
+   apply (simp add: sys_mode_of_def)
+  apply (simp add: user_context_of_def)
   done
 
 lemma kernel_schedule_if_confidentiality':
-  "\<lbrakk>(XX, YY) \<in> uwr PSched; XX = s; YY = t; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
-    invs_if s;     invs_if t;   invs_if s'; invs_if t';
-    (part s, u) \<in> policyFlows (pasPolicy initial_aag);
-    part s \<noteq> PSched; u \<noteq> PSched; user_modes (sys_mode_of s);
-    ((fst s),(),(fst s')) \<in> kernel_schedule_if;
-    ((fst t),(),(fst t')) \<in> kernel_schedule_if;
-    snd s' = snd t'\<rbrakk> \<Longrightarrow>
-   (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
-  apply(blast dest: kernel_schedule_if_confidentiality)
-  done
+  "\<lbrakk> (XX, YY) \<in> uwr PSched; XX = s; YY = t; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u; invs_if s;
+     invs_if t; invs_if s'; invs_if t'; (part s, u) \<in> policyFlows (pasPolicy initial_aag);
+     part s \<noteq> PSched; u \<noteq> PSched; user_modes (sys_mode_of s);
+     ((fst s),(),(fst s')) \<in> kernel_schedule_if;
+     ((fst t),(),(fst t')) \<in> kernel_schedule_if; snd s' = snd t' \<rbrakk>
+     \<Longrightarrow> (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
+  by (blast dest: kernel_schedule_if_confidentiality)
+
+end
+
 
 lemma thread_set_tcb_context_update_runnable_globals_equiv:
   "\<lbrace>globals_equiv st and st_tcb_at runnable t and invs\<rbrace>
    thread_set (tcb_arch_update (arch_tcb_context_set uc)) t
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply(rule hoare_pre)
-  apply(rule thread_set_context_globals_equiv)
+  apply (rule hoare_pre)
+  apply (rule thread_set_context_globals_equiv)
   apply clarsimp
-  apply(frule invs_valid_idle)
-  apply(fastforce simp: valid_idle_def pred_tcb_at_def obj_at_def)
+  apply (frule invs_valid_idle)
+  apply (fastforce simp: valid_idle_def pred_tcb_at_def obj_at_def)
   done
 
 lemma thread_set_tcb_context_update_reads_respects_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_g aag l (st_tcb_at runnable t and invs)
-                    (thread_set (tcb_arch_update (arch_tcb_context_set uc)) t)"
-  apply(rule equiv_valid_guard_imp)
-   apply(rule reads_respects_g)
-    apply(rule thread_set_reads_respects[OF domains_distinct])
-   apply(rule doesnt_touch_globalsI)
-   apply(wp thread_set_tcb_context_update_runnable_globals_equiv)
+  shows "reads_respects_g aag (l :: 'a subject_label) (st_tcb_at runnable t and invs)
+                          (thread_set (tcb_arch_update (arch_tcb_context_set uc)) t)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_g)
+    apply (rule thread_set_reads_respects[OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp thread_set_tcb_context_update_runnable_globals_equiv)
    apply simp+
   done
 
 lemma thread_set_tcb_context_update_silc_inv:
-  "\<lbrace>silc_inv aag st\<rbrace>
-   thread_set (tcb_arch_update (arch_tcb_context_set f)) t
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply(rule thread_set_silc_inv_trivial)
-  apply(simp add: tcb_cap_cases_def)
+  "thread_set (tcb_arch_update (arch_tcb_context_set f)) t \<lbrace>silc_inv aag st\<rbrace>"
+  apply (rule thread_set_silc_inv)
+  apply (simp add: tcb_cap_cases_def)
   done
 
 lemmas thread_set_tcb_context_update_reads_respects_f_g =
-                reads_respects_f_g'[where Q="\<top>", simplified,
-                                    OF thread_set_tcb_context_update_reads_respects_g,
-                                    OF _ thread_set_tcb_context_update_silc_inv]
+  reads_respects_f_g'[where Q="\<top>", simplified,
+                      OF thread_set_tcb_context_update_reads_respects_g,
+                      OF _ thread_set_tcb_context_update_silc_inv]
 
 lemma kernel_entry_if_reads_respects_f_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_f_g aag l (ct_active and silc_inv aag st
-                                       and einvs
-                                       and only_timer_irq_inv irq st'
-                                       and schact_is_rct
-                                       and pas_refined aag
-                                       and pas_cur_domain aag
-                                       and guarded_pas_domain aag
-                                       and K (ev \<noteq> Interrupt \<and> \<not> pasMaySendIrqs aag))
+  shows "reads_respects_f_g aag l (ct_active and silc_inv aag st and einvs
+                                             and only_timer_irq_inv irq st'
+                                             and schact_is_rct and pas_refined aag
+                                             and pas_cur_domain aag and guarded_pas_domain aag
+                                             and K (ev \<noteq> Interrupt \<and> \<not> pasMaySendIrqs aag))
                             (kernel_entry_if ev tc)"
-  apply(simp add: kernel_entry_if_def)
-  apply (wp handle_event_reads_respects_f_g
-            thread_set_tcb_context_update_reads_respects_f_g
-            thread_set_tcb_context_update_silc_inv
-            only_timer_irq_inv_pres[where P="\<top>" and Q="\<top>"]
-            thread_set_invs_trivial
-            thread_set_not_state_valid_sched
-            thread_set_pas_refined
-        | simp add: tcb_cap_cases_def arch_tcb_update_aux2 tcb_arch_ref_def)+
-  apply(elim conjE)
-  apply(frule (1) ct_active_cur_thread_not_idle_thread[OF invs_valid_idle])
-  apply(clarsimp simp:  ct_in_state_def runnable_eq_active)
-  apply(rule conjI)
-   apply(fastforce dest: requiv_g_cur_thread_eq simp: reads_equiv_f_g_def)
-  apply(clarsimp simp: guarded_pas_domain_def)
-  apply(fastforce simp: only_timer_irq_inv_def invs_valid_idle
-                  dest: domains_distinct[THEN pas_domains_distinct_inj])
+  apply (simp add: kernel_entry_if_def)
+  apply (wp handle_event_reads_respects_f_g thread_set_tcb_context_update_reads_respects_f_g
+            thread_set_tcb_context_update_silc_inv only_timer_irq_inv_pres[where P="\<top>" and Q="\<top>"]
+            thread_set_invs_trivial thread_set_not_state_valid_sched thread_set_pas_refined
+         | simp add: tcb_cap_cases_def arch_tcb_update_aux2)+
+  apply (elim conjE)
+  apply (frule (1) ct_active_cur_thread_not_idle_thread[OF invs_valid_idle])
+  apply (clarsimp simp: ct_in_state_def runnable_eq_active)
+  apply (rule conjI)
+   apply (fastforce dest: requiv_g_cur_thread_eq simp: reads_equiv_f_g_def)
+  apply (clarsimp simp: guarded_pas_domain_def)
+  apply (fastforce simp: only_timer_irq_inv_def invs_valid_idle
+                   dest: domains_distinct[THEN pas_domains_distinct_inj])
+  done
+
+lemma reads_respects_f_g_2':
+  "\<lbrakk> equiv_valid_2 (reads_equiv_g aag) (affects_equiv aag l) (affects_equiv aag l) (=) P P' f f';
+     \<lbrace>silc_inv aag st and Q\<rbrace> f \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>;
+     \<lbrace>silc_inv aag st and Q'\<rbrace> f' \<lbrace>\<lambda>_. silc_inv aag st\<rbrace> \<rbrakk>
+     \<Longrightarrow> equiv_valid_2 (reads_equiv_f_g aag) (affects_equiv aag l) (affects_equiv aag l) (=)
+                       (silc_inv aag st and P and Q) (silc_inv aag st and P' and Q') f f'"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def reads_equiv_f_g_def reads_equiv_g_def)
+  apply (rule conjI, fastforce)
+  apply (rule conjI, fastforce)
+  apply (rule conjI, fastforce)
+  apply (subst conj_commute, rule conjI, fastforce)
+  apply (rule silc_dom_equiv_trans)
+   apply (rule silc_dom_equiv_sym)
+   apply (rule silc_inv_silc_dom_equiv)
+   apply (erule (1) use_valid, fastforce)
+  apply (rule silc_inv_silc_dom_equiv)
+  apply (erule (1) use_valid, fastforce)
   done
 
 
+context Noninterference_valid_initial_state begin
+
 lemma kernel_call_A_if_confidentiality:
   notes active_from_running[simp]
-  shows
-  "\<lbrakk>(s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
-    invs_if s;     invs_if t;   invs_if s'; invs_if t';
-    (part s, u) \<in> policyFlows (pasPolicy initial_aag);
-    part s \<noteq> PSched; u \<noteq> PSched;
-    ((fst s),x,(fst s')) \<in> kernel_call_A_if e;
-    ((fst t),y,(fst t')) \<in> kernel_call_A_if e;
-    e \<noteq> Interrupt;
-    sys_mode_of s = KernelEntry e; sys_mode_of t = KernelEntry e;
-    snd s' = f x; snd t' = f y\<rbrakk> \<Longrightarrow>
-   x = y \<and>
-   (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
+  shows "\<lbrakk> (s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u; invs_if s; invs_if t;
+           invs_if s'; invs_if t'; (part s, u) \<in> policyFlows (pasPolicy initial_aag);
+           part s \<noteq> PSched; u \<noteq> PSched; ((fst s),x,(fst s')) \<in> kernel_call_A_if e;
+           ((fst t),y,(fst t')) \<in> kernel_call_A_if e; e \<noteq> Interrupt;
+           sys_mode_of s = KernelEntry e; sys_mode_of t = KernelEntry e; snd s' = f x; snd t' = f y \<rbrakk>
+           \<Longrightarrow> x = y \<and> (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
   supply [[simp_depth_limit=3]] \<comment> \<open>speedup\<close>
-  apply(frule (1) uwr_part_sys_mode_of_user_context_of_eq)
-  apply(frule part_not_PSched_sys_mode_of_not_KernelSchedule_True)
-  apply(clarsimp simp: kernel_call_A_if_def)
-  apply(case_tac s, case_tac t, simp_all)
-  apply(case_tac u, simp_all)
-  apply(frule (6) uwr_reads_equiv_f_g_affects_equiv)
-  apply(frule_tac s=b and t=ba and s2=b
-               in use_ev[OF kernel_entry_if_reads_respects_f_g
-                              [where st=s0_internal, OF current_domains_distinct]])
+  apply (frule (1) uwr_part_sys_mode_of_user_context_of_eq)
+  apply (frule part_not_PSched_sys_mode_of_not_KernelSchedule_True)
+  apply (clarsimp simp: kernel_call_A_if_def)
+  apply (case_tac s, case_tac t, simp_all)
+  apply (case_tac u, simp_all)
+  apply (frule (6) uwr_reads_equiv_f_g_affects_equiv)
+  apply (frule_tac s=b and t=ba and s2=b
+                in use_ev[OF kernel_entry_if_reads_respects_f_g
+                               [where st=s0_internal, OF current_domains_distinct]])
        apply assumption
       apply (clarsimp simp: invs_if_def Invs_def schact_is_rct_def current_aag_def)
       apply assumption
@@ -3251,78 +2873,66 @@ lemma kernel_call_A_if_confidentiality:
     apply simp
    apply fastforce
   apply simp
-  apply(rule reads_equiv_f_g_affects_equiv_uwr)
-            apply simp+
-       apply(fastforce simp: invs_if_def Invs_def)
+  apply (rule reads_equiv_f_g_affects_equiv_uwr)
+           apply simp+
+       apply (fastforce simp: invs_if_def Invs_def)
       apply simp
      apply simp
-     apply(erule use_valid[OF _ kernel_entry_if_partitionIntegrity])
-     apply(clarsimp simp: partitionIntegrity_refl invs_if_def Invs_def current_aag_def
-                          silc_inv_refl schact_is_rct_def guarded_pas_domain_def
-                          ct_active_cur_thread_not_idle_thread[OF invs_valid_idle])
+     apply (erule use_valid[OF _ kernel_entry_if_partitionIntegrity])
+     apply (clarsimp simp: partitionIntegrity_refl invs_if_def Invs_def current_aag_def
+                           silc_inv_refl schact_is_rct_def guarded_pas_domain_def
+                           ct_active_cur_thread_not_idle_thread[OF invs_valid_idle])
      (* XXX: the conjI is needed here -- metis won't instantiate a schematic var *)
-     apply(rule conjI)
+     apply (rule conjI)
       apply (metis the_subject_of_aag_domain)
      apply assumption
     apply simp
-    apply(erule use_valid[OF _ kernel_entry_if_partitionIntegrity])
-    apply(clarsimp simp: partitionIntegrity_refl invs_if_def Invs_def current_aag_def
-                         silc_inv_refl schact_is_rct_def guarded_pas_domain_def
-                         ct_active_cur_thread_not_idle_thread[OF invs_valid_idle])
-     (* XXX: and here *)
-    apply(rule conjI)
+    apply (erule use_valid[OF _ kernel_entry_if_partitionIntegrity])
+    apply (clarsimp simp: partitionIntegrity_refl invs_if_def Invs_def current_aag_def
+                          silc_inv_refl schact_is_rct_def guarded_pas_domain_def
+                          ct_active_cur_thread_not_idle_thread[OF invs_valid_idle])
+    (* XXX: and here *)
+    apply (rule conjI)
      apply (metis the_subject_of_aag_domain)
     apply assumption
-   apply(simp add: sys_mode_of_def)
-  apply(simp add: user_context_of_def)
+   apply (simp add: sys_mode_of_def)
+  apply (simp add: user_context_of_def)
   done
 
 lemma kernel_call_A_if_confidentiality':
-  "\<lbrakk>(XX, YY) \<in> uwr PSched; XX = s; YY = t; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
-    invs_if s;     invs_if t;   invs_if s'; invs_if t';
-    (part s, u) \<in> policyFlows (pasPolicy initial_aag);
-    part s \<noteq> PSched; u \<noteq> PSched;
-    ((fst s),x,(fst s')) \<in> kernel_call_A_if e;
-    ((fst t),y,(fst t')) \<in> kernel_call_A_if e;
-    e \<noteq> Interrupt;
-    sys_mode_of s = KernelEntry e; sys_mode_of t = KernelEntry e;
-    snd s' = (case x of True \<Rightarrow> KernelPreempted | _ \<Rightarrow> KernelSchedule False);
-    snd t' = (case y of True \<Rightarrow> KernelPreempted | _ \<Rightarrow> KernelSchedule False)\<rbrakk> \<Longrightarrow>
-   x = y \<and>
-   (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
-  apply(blast dest: kernel_call_A_if_confidentiality)
-  done
+  "\<lbrakk> (XX, YY) \<in> uwr PSched; XX = s; YY = t; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
+     invs_if s; invs_if t; invs_if s'; invs_if t';
+     (part s, u) \<in> policyFlows (pasPolicy initial_aag); part s \<noteq> PSched; u \<noteq> PSched;
+     ((fst s),x,(fst s')) \<in> kernel_call_A_if e; ((fst t),y,(fst t')) \<in> kernel_call_A_if e;
+     e \<noteq> Interrupt; sys_mode_of s = KernelEntry e; sys_mode_of t = KernelEntry e;
+     snd s' = (case x of True \<Rightarrow> KernelPreempted | _ \<Rightarrow> KernelSchedule False);
+     snd t' = (case y of True \<Rightarrow> KernelPreempted | _ \<Rightarrow> KernelSchedule False) \<rbrakk>
+     \<Longrightarrow> x = y \<and> (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
+  by (blast dest: kernel_call_A_if_confidentiality)
 
 lemma thread_get_tcb_context_reads_respects_g_helper:
-  "equiv_valid_rv_inv (reads_equiv_g aag)
-     (affects_equiv aag l)
+  "equiv_valid_rv_inv (reads_equiv_g aag) (affects_equiv aag l)
      (\<lambda>rv rv'. arch_tcb_context_get (tcb_arch rv) = arch_tcb_context_get (tcb_arch rv'))
      (\<lambda>s. t = idle_thread s \<or> is_subject aag t)
      (gets (get_tcb t) >>= assert_opt)"
-  apply(clarsimp simp: equiv_valid_2_def in_monad)
-  apply(clarsimp simp: reads_equiv_g_def)
-  apply(erule disjE)
-   apply(frule globals_equiv_idle_thread_ptr)
-   apply(simp)
-   apply(simp add: get_tcb_def split: kernel_object.splits option.splits)
-   apply(fastforce simp: globals_equiv_def idle_equiv_def)
-  apply simp
-  apply(fastforce dest: requiv_get_tcb_eq)
+  apply (clarsimp simp: equiv_valid_2_def in_monad reads_equiv_g_def)
+  apply (erule disjE)
+   apply (frule globals_equiv_idle_thread_ptr)
+   apply (simp add: get_tcb_def split: kernel_object.splits option.splits)
+   apply (fastforce simp: globals_equiv_def idle_equiv_def)
+  apply (fastforce dest: requiv_get_tcb_eq)
   done
 
 lemma thread_get_tcb_context_reads_respects_g:
   "reads_respects_g aag l
-          (\<lambda>s. t = idle_thread s \<or> is_subject aag t) (thread_get (arch_tcb_context_get o tcb_arch) t)"
-  apply(simp add: thread_get_def gets_the_def)
-  apply(simp add: equiv_valid_def2)
-  apply(rule_tac W="\<lambda> rv rv'. arch_tcb_context_get (tcb_arch rv) = arch_tcb_context_get (tcb_arch rv')"
-             and Q="\<top>\<top>"
-             in equiv_valid_rv_bind)
-    apply(rule thread_get_tcb_context_reads_respects_g_helper)
-   apply(rule return_ev2, simp)
-  apply(rule hoare_post_taut)
+     (\<lambda>s. t = idle_thread s \<or> is_subject aag t) (thread_get (arch_tcb_context_get o tcb_arch) t)"
+  apply (simp add: thread_get_def gets_the_def equiv_valid_def2)
+  apply (rule_tac W="\<lambda> rv rv'. arch_tcb_context_get (tcb_arch rv) = arch_tcb_context_get (tcb_arch rv')"
+              and Q="\<top>\<top>" in equiv_valid_rv_bind)
+    apply (rule thread_get_tcb_context_reads_respects_g_helper)
+   apply (rule return_ev2, simp)
+  apply (rule hoare_post_taut)
   done
-
 
 (* this is a little more complicated because the context isn't
    guaranteed to be equal when called, so we need an equiv_valid_2
@@ -3332,71 +2942,131 @@ lemma kernel_exit_if_reads_respects_g_2:
                  (\<lambda>s. cur_thread s = idle_thread s \<or> is_subject aag (cur_thread s))
                  (\<lambda>s. cur_thread s = idle_thread s \<or> is_subject aag (cur_thread s))
                  (kernel_exit_if tc) (kernel_exit_if tc')"
-  apply(simp add: kernel_exit_if_def)
-  apply(fold equiv_valid_def2)
-  apply(wp thread_get_tcb_context_reads_respects_g)
-  apply(fastforce dest: requiv_g_cur_thread_eq)
-  done
-
-lemma reads_respects_f_g_2':
-  "\<lbrakk>equiv_valid_2 (reads_equiv_g aag) (affects_equiv aag l) (affects_equiv aag l) (=) P P' f f';
-     \<lbrace>silc_inv aag st and Q\<rbrace> f \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>;
-     \<lbrace>silc_inv aag st and Q'\<rbrace> f' \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>\<rbrakk> \<Longrightarrow>
-   equiv_valid_2 (reads_equiv_f_g aag) (affects_equiv aag l) (affects_equiv aag l) (=)
-                (silc_inv aag st and P and Q) (silc_inv aag st and P' and Q') f f'"
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def reads_equiv_f_g_def reads_equiv_g_def)
-  apply(rule conjI, fastforce)
-  apply(rule conjI, fastforce)
-  apply(rule conjI, fastforce)
-  apply(subst conj_commute, rule conjI, fastforce)
-  apply(rule silc_dom_equiv_trans)
-   apply(rule silc_dom_equiv_sym)
-   apply(rule silc_inv_silc_dom_equiv)
-   apply(erule (1) use_valid, fastforce)
-  apply(rule silc_inv_silc_dom_equiv)
-  apply(erule (1) use_valid, fastforce)
+  apply (simp add: kernel_exit_if_def)
+  apply (fold equiv_valid_def2)
+  apply (wp thread_get_tcb_context_reads_respects_g)
+  apply (fastforce dest: requiv_g_cur_thread_eq)
   done
 
 lemma kernel_exit_if_reads_respects_f_g_2:
   "equiv_valid_2 (reads_equiv_f_g aag) (affects_equiv aag l) (affects_equiv aag l) (=)
-                 (silc_inv aag st and (\<lambda>s. cur_thread s = idle_thread s
-                                         \<or> is_subject aag (cur_thread s)))
-                 (silc_inv aag st and (\<lambda>s. cur_thread s = idle_thread s
-                                         \<or> is_subject aag (cur_thread s)))
-                 (kernel_exit_if tc) (kernel_exit_if tc')"
-  apply(rule equiv_valid_2_guard_imp)
-    apply(rule reads_respects_f_g_2'[where Q="\<top>" and Q'="\<top>", OF kernel_exit_if_reads_respects_g_2])
-   apply(wp | simp | blast)+
+     (silc_inv aag st and (\<lambda>s. cur_thread s = idle_thread s \<or> is_subject aag (cur_thread s)))
+     (silc_inv aag st and (\<lambda>s. cur_thread s = idle_thread s \<or> is_subject aag (cur_thread s)))
+     (kernel_exit_if tc) (kernel_exit_if tc')"
+  apply (rule equiv_valid_2_guard_imp)
+    apply (rule reads_respects_f_g_2'[where Q="\<top>" and Q'="\<top>", OF kernel_exit_if_reads_respects_g_2])
+     apply (wp | simp | blast)+
   done
 
+end
+
+
 lemma use_ev2:
-  "\<lbrakk>equiv_valid_2 I A B R P P' f f'; (rv,s') \<in> fst (f s); (rv',t') \<in> fst (f' t);
-    P s; P' t; I s t; A s t\<rbrakk> \<Longrightarrow>
-    R rv rv' \<and> I s' t' \<and> B s' t'"
-  apply(fastforce simp: equiv_valid_2_def)
-  done
+  "\<lbrakk> equiv_valid_2 I A B R P P' f f'; (rv,s') \<in> fst (f s);
+     (rv',t') \<in> fst (f' t); P s; P' t; I s t; A s t \<rbrakk>
+     \<Longrightarrow> R rv rv' \<and> I s' t' \<and> B s' t'"
+  by (fastforce simp: equiv_valid_2_def)
 
 lemma reads_equiv_f_g_reads_equiv_g:
   "reads_equiv_f_g aag s t \<Longrightarrow> reads_equiv_g aag s t"
-  apply(fastforce simp: reads_equiv_f_g_def reads_equiv_g_def)
-  done
+  by (fastforce simp: reads_equiv_f_g_def reads_equiv_g_def)
+
+
+context valid_initial_state begin
 
 lemma reads_equiv_g_ct_running_eq:
-  "\<lbrakk>reads_equiv_g (current_aag bb) bd be; Invs bd; Invs be;
-    current_aag bb = current_aag bd\<rbrakk> \<Longrightarrow> ct_running bd = ct_running be"
-  apply(clarsimp simp: reads_equiv_f_g_def)
-  apply(clarsimp simp: reads_equiv_g_def)
-  apply(frule globals_equiv_idle_thread_ptr)
-  apply(frule requiv_cur_thread_eq)
-  apply(case_tac "cur_thread bd = idle_thread bd")
-   apply(simp add: Invs_def)
-   apply(elim conjE)
-   apply(drule invs_valid_idle)+
-   apply(clarsimp simp: ct_in_state_def pred_tcb_at_def obj_at_def valid_idle_def)
-  apply(clarsimp simp: ct_in_state_def pred_tcb_at_def obj_at_def)
-  apply(fastforce simp: Invs_def guarded_pas_domain_def simp: current_aag_def
-                  dest: is_subject_kheap_eq domains_distinct[THEN pas_domains_distinct_inj])
+  "\<lbrakk> reads_equiv_g (current_aag bb) bd be; Invs bd; Invs be; current_aag bb = current_aag bd \<rbrakk>
+     \<Longrightarrow> ct_running bd = ct_running be"
+  apply (clarsimp simp: reads_equiv_f_g_def)
+  apply (clarsimp simp: reads_equiv_g_def)
+  apply (frule globals_equiv_idle_thread_ptr)
+  apply (frule requiv_cur_thread_eq)
+  apply (case_tac "cur_thread bd = idle_thread bd")
+   apply (simp add: Invs_def)
+   apply (elim conjE)
+   apply (drule invs_valid_idle)+
+   apply (clarsimp simp: ct_in_state_def pred_tcb_at_def obj_at_def valid_idle_def)
+  apply (clarsimp simp: ct_in_state_def pred_tcb_at_def obj_at_def)
+  apply (fastforce simp: Invs_def guarded_pas_domain_def simp: current_aag_def
+                   dest: is_subject_kheap_eq domains_distinct[THEN pas_domains_distinct_inj])
   done
+
+lemma partitionIntegrity_part_unchanged:
+  "\<lbrakk>partitionIntegrity aag (internal_state_if s) (internal_state_if s'); part s \<noteq> PSched;
+    part s' \<noteq> PSched\<rbrakk> \<Longrightarrow> part s' = part s"
+  apply (simp add: part_def split: if_splits
+             add: partition_def partitionIntegrity_def domain_fields_equiv_def)
+  done
+
+lemma big_step_R_rtranclp:
+  "system.reachable (big_step_ADT_A_if utf) s0 s
+       \<Longrightarrow> big_step_R\<^sup>*\<^sup>* s0 s"
+  apply (simp add: reachable_def execution_def)
+  apply (clarsimp simp: big_step_ADT_A_if_def Fin_big_step_adt Fin_ADT_if steps_eq_Run)
+  apply (rule Run_big_steps_tranclp)
+  apply (simp add: big_step_ADT_A_if_def big_step_adt_def Init_ADT_if)
+  done
+
+lemma sub_big_steps_strict_prefix:
+  "(s', as @ bs) \<in> sub_big_steps A R s \<Longrightarrow>
+   \<exists>t. (t, as) \<in> sub_big_steps A R s"
+  apply (induct bs arbitrary: s s' rule: rev_induct)
+   apply fastforce
+  apply (subst (asm) append_assoc[symmetric])
+  apply (drule sub_big_steps_App)
+  apply blast
+  done
+
+lemma uwr_part_sys_mode_of_eq':
+  "\<lbrakk>(s,t) \<in> uwr (part x); part s = part x; part t = part x; part x \<noteq> PSched\<rbrakk>
+    \<Longrightarrow> sys_mode_of s = sys_mode_of t"
+  apply (fastforce intro: uwr_part_sys_mode_of_eq)
+  done
+
+end
+
+
+lemma app_Cons:
+  "xs @ (a # b) = (xs @ [a]) @ b"
+  by simp
+
+lemma sys_mode_of_eq_big_step_R_contradiction:
+  "\<lbrakk> sys_mode_of s = sys_mode_of t; sys_mode_of s' = sys_mode_of t';
+     big_step_R s s'; \<not> big_step_R t t' \<rbrakk>
+     \<Longrightarrow> False"
+  apply (simp add: big_step_R_def)
+  apply (case_tac s, case_tac t, simp_all)
+  apply (case_tac s', case_tac t', simp_all)
+  apply auto
+  done
+
+lemma unit_list_as_replicate:
+  "(as::unit list) = replicate (length as) ()"
+  apply (induct as, auto)
+  done
+
+lemma unit_lists_unequal:
+  "(as::unit list) \<noteq> (as'::unit list) \<Longrightarrow> as < as' \<or> as' < as"
+  apply (simp add: less_list_def' strict_prefix_def)
+  apply (case_tac "length as \<ge> length as'")
+  apply (rule disjI2)
+   apply (subst unit_list_as_replicate[where as=as])
+   apply (subst unit_list_as_replicate[where as=as'])
+   apply (clarsimp simp: prefix_def)
+   apply (rule_tac x="replicate (length as - length as') ()" in exI)
+   apply (subst replicate_add[symmetric])
+   apply simp
+  apply (rule disjI1)
+  apply (subst unit_list_as_replicate[where as=as])
+  apply (subst unit_list_as_replicate[where as=as'])
+  apply (clarsimp simp: prefix_def)
+  apply (rule_tac x="replicate (length as' - length as) ()" in exI)
+  apply (subst replicate_add[symmetric])
+  apply simp
+  done
+
+
+context Noninterference_valid_initial_state begin
 
 lemma kernel_exit_A_if_confidentiality:
   "\<lbrakk>(s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
@@ -3410,45 +3080,45 @@ lemma kernel_exit_A_if_confidentiality:
    x = y \<and>
    (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
   supply [[simp_depth_limit=2]] \<comment> \<open>speedup\<close>
-  apply(clarsimp simp: kernel_exit_A_if_def)
-  apply(case_tac s, case_tac t, simp_all)
-  apply(case_tac u, simp_all)
-  apply(frule (6) uwr_reads_equiv_f_g_affects_equiv)
-  apply(simp split: prod.splits)
-  apply(case_tac "fst s'", simp)
-  apply(case_tac "fst t'", simp)
-  apply(frule_tac s=x2 and t=x2a and aag1="current_aag x2" in use_ev2[OF kernel_exit_if_reads_respects_f_g_2[where st=s0_internal]])
+  apply (clarsimp simp: kernel_exit_A_if_def)
+  apply (case_tac s, case_tac t, simp_all)
+  apply (case_tac u, simp_all)
+  apply (frule (6) uwr_reads_equiv_f_g_affects_equiv)
+  apply (simp split: prod.splits)
+  apply (case_tac "fst s'", simp)
+  apply (case_tac "fst t'", simp)
+  apply (frule_tac s=x2 and t=x2a and aag1="current_aag x2"
+                in use_ev2[OF kernel_exit_if_reads_respects_f_g_2[where st=s0_internal]])
        apply assumption
-      apply(clarsimp simp: invs_if_def Invs_def current_aag_def guarded_pas_domain_def)
-      apply(metis the_subject_of_aag_domain)
-     apply(clarsimp simp: invs_if_def Invs_def)
-     apply(drule uwr_PSched_cur_domain)
-     apply(clarsimp simp: current_aag_def guarded_pas_domain_def)
-     apply(metis the_subject_of_aag_domain)
+      apply (clarsimp simp: invs_if_def Invs_def current_aag_def guarded_pas_domain_def)
+      apply (metis the_subject_of_aag_domain)
+     apply (clarsimp simp: invs_if_def Invs_def)
+     apply (drule uwr_PSched_cur_domain)
+     apply (clarsimp simp: current_aag_def guarded_pas_domain_def)
+     apply (metis the_subject_of_aag_domain)
     apply simp
    apply fastforce
   apply simp
-  apply(elim conjE)
-  apply(drule state_unchanged[OF kernel_exit_if_inv])+
-  apply(subgoal_tac "ct_running bb = ct_running bc")
+  apply (elim conjE)
+  apply (drule state_unchanged[OF kernel_exit_if_inv])+
+  apply (subgoal_tac "ct_running bb = ct_running bc")
    apply simp
-   apply(rule reads_equiv_f_g_affects_equiv_uwr)
+   apply (rule reads_equiv_f_g_affects_equiv_uwr)
             apply simp+
         apply (fastforce simp: invs_if_def Invs_def)
        apply simp
       apply simp
-      apply(rule partitionIntegrity_refl)
+      apply (rule partitionIntegrity_refl)
      apply simp
-     apply(rule partitionIntegrity_refl)
-    apply(simp add: sys_mode_of_def)
-   apply(simp add: user_context_of_def)
-  apply(frule_tac bd=bb in reads_equiv_g_ct_running_eq[OF reads_equiv_f_g_reads_equiv_g])
-     apply(fastforce simp: invs_if_def)
-    apply(fastforce simp: invs_if_def)
-   apply(fastforce simp: reads_equiv_f_g_def reads_equiv_def current_aag_def)
+     apply (rule partitionIntegrity_refl)
+    apply (simp add: sys_mode_of_def)
+   apply (simp add: user_context_of_def)
+  apply (frule_tac bd=bb in reads_equiv_g_ct_running_eq[OF reads_equiv_f_g_reads_equiv_g])
+     apply (fastforce simp: invs_if_def)
+    apply (fastforce simp: invs_if_def)
+   apply (fastforce simp: reads_equiv_f_g_def reads_equiv_def current_aag_def)
   apply simp
   done
-
 
 lemma kernel_exit_A_if_confidentiality':
   "\<lbrakk>(XX, YY) \<in> uwr PSched; XX = s; YY = t; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
@@ -3461,7 +3131,7 @@ lemma kernel_exit_A_if_confidentiality':
     snd s' = f x; snd t' = f y\<rbrakk> \<Longrightarrow>
    x = y \<and>
    (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
-  apply(blast dest: kernel_exit_A_if_confidentiality)
+  apply (blast dest: kernel_exit_A_if_confidentiality)
   done
 
 lemma small_Step_confidentiality_part_not_PSched:
@@ -3474,131 +3144,90 @@ lemma small_Step_confidentiality_part_not_PSched:
     (part s, u) \<in> policyFlows (pasPolicy initial_aag);
     part s \<noteq> PSched; u \<noteq> PSched\<rbrakk> \<Longrightarrow>
    (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s)"
-  apply(frule part_equiv)
-  apply(frule uwr_part_sys_mode_of_eq, simp+)
-  apply(frule_tac s=s in ADT_A_if_reachable_invs_if)
-  apply(frule_tac s=t in ADT_A_if_reachable_invs_if)
-  apply(frule(2) Step_system.reachable_Step[where s=s, OF ADT_A_if_Step_system _ Step_ADT_A_if''])
-  apply(frule(2) Step_system.reachable_Step[where s=t, OF ADT_A_if_Step_system _ Step_ADT_A_if''])
-  apply(frule_tac s=s' in ADT_A_if_reachable_invs_if)
-  apply(frule_tac s=t' in ADT_A_if_reachable_invs_if)
-  apply(case_tac "sys_mode_of s")
+  apply (frule schedIncludesCurrentDom)
+  apply (frule uwr_part_sys_mode_of_eq, simp+)
+  apply (frule_tac s=s in ADT_A_if_reachable_invs_if)
+  apply (frule_tac s=t in ADT_A_if_reachable_invs_if)
+  apply (frule(2) Step_system.reachable_Step[where s=s, OF ADT_A_if_Step_system _ Step_ADT_A_if''])
+  apply (frule(2) Step_system.reachable_Step[where s=t, OF ADT_A_if_Step_system _ Step_ADT_A_if''])
+  apply (frule_tac s=s' in ADT_A_if_reachable_invs_if)
+  apply (frule_tac s=t' in ADT_A_if_reachable_invs_if)
+  apply (case_tac "sys_mode_of s")
        (* InUserMode *)
-       apply((simp add: Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
+       apply ((simp add: Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
                  split: if_splits
               | intro impI allI
               | elim exE conjE disjE
               | simp_all add: not_schedule_modes_KernelEntry)+)[1]
-               apply(drule do_user_op_A_if_confidentiality'[
+               apply (drule do_user_op_A_if_confidentiality'[
                                      where s=s and t=t and s'=s' and t'=t' and u=u],simp+)
-              apply(drule do_user_op_A_if_confidentiality'[
+              apply (drule do_user_op_A_if_confidentiality'[
                                   where s=s and t=t and s'=s' and t'=t' and u=u], simp+)
-             apply(drule_tac s=s and t=t and u=u and s'="(aa,ba)"
+             apply (drule_tac s=s and t=t and u=u and s'="(aa,ba)"
                           in check_active_irq_A_if_retval_eq, simp+)
-            apply(drule do_user_op_A_if_confidentiality'[
+            apply (drule do_user_op_A_if_confidentiality'[
                                 where s=s and t=t and s'=s' and t'=t' and u=u], simp+)
-           apply(drule_tac s=s and t=t and u=u and s'="(ad,bd)"
+           apply (drule_tac s=s and t=t and u=u and s'="(ad,bd)"
                         in check_active_irq_A_if_retval_eq, simp+)
-          apply(drule do_user_op_A_if_confidentiality'[
+          apply (drule do_user_op_A_if_confidentiality'[
                                 where s=s and t=t and s'=s' and t'=t' and u=u], simp+)
-         apply(drule_tac s=s and t=t and u=u and s'="(aa,ba)"
+         apply (drule_tac s=s and t=t and u=u and s'="(aa,ba)"
                       in check_active_irq_A_if_retval_eq, simp+)
-        apply(drule_tac s=s and t=t and u=u and s'="(ad,bd)"
+        apply (drule_tac s=s and t=t and u=u and s'="(ad,bd)"
                     in check_active_irq_A_if_retval_eq, simp+)
-       apply(drule check_active_irq_A_if_confidentiality'[
+       apply (drule check_active_irq_A_if_confidentiality'[
                             where s=s and t=t and s'=s' and t'=t' and u=u], simp+)
       (* InIdleMode *)
-      apply((simp add: Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
+      apply ((simp add: Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
                   split: if_splits
              | intro impI allI
              | elim exE conjE disjE
              | simp_all add: not_schedule_modes_KernelEntry)+)[1]
-         apply(drule check_active_irq_A_if_confidentiality'[
+         apply (drule check_active_irq_A_if_confidentiality'[
                                       where s=s and t=t and s'=s' and t'=t' and u=u], simp+)
-        apply(drule_tac s=s and t=t and u=u and s'="(aa,ba)" in check_active_irq_A_if_retval_eq,
+        apply (drule_tac s=s and t=t and u=u and s'="(aa,ba)" in check_active_irq_A_if_retval_eq,
               simp+)
-       apply(drule_tac s=s and t=t and u=u and s'="(aa,ba)" in check_active_irq_A_if_retval_eq,
+       apply (drule_tac s=s and t=t and u=u and s'="(aa,ba)" in check_active_irq_A_if_retval_eq,
              simp+)
-      apply(drule check_active_irq_A_if_confidentiality''[
+      apply (drule check_active_irq_A_if_confidentiality''[
                           where s=s and t=t and s'=s' and t'=t' and u=u],simp+)
      (* KernelEntry event -- where event \<noteq> Interrupt *)
-     apply(rename_tac event)
-     apply(subgoal_tac "event \<noteq> Interrupt")
+     apply (rename_tac event)
+     apply (subgoal_tac "event \<noteq> Interrupt")
       prefer 2
-      apply(case_tac t, simp)
-      apply(case_tac event, (fastforce simp: part_def split: if_splits)+)[1]
-     apply((simp add: Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
+      apply (case_tac t, simp)
+      apply (case_tac event, (fastforce simp: part_def split: if_splits)+)[1]
+     apply ((simp add: Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
                  split: if_splits
             | intro impI allI
             | elim exE conjE disjE
             | simp_all add: not_schedule_modes_KernelEntry)+)[1]
-        apply(drule kernel_call_A_if_confidentiality'[where s=s and t=t and s'=s' and t'=t' and u=u],
+        apply (drule kernel_call_A_if_confidentiality'[where s=s and t=t and s'=s' and t'=t' and u=u],
               simp+)
-       apply(drule kernel_call_A_if_confidentiality'[where s=s and t=t and s'=s' and t'=t' and u=u],
+       apply (drule kernel_call_A_if_confidentiality'[where s=s and t=t and s'=s' and t'=t' and u=u],
              simp+)
-      apply(drule kernel_call_A_if_confidentiality'[where s=s and t=t and s'=s' and t'=t' and u=u],
+      apply (drule kernel_call_A_if_confidentiality'[where s=s and t=t and s'=s' and t'=t' and u=u],
             simp+)
-     apply(drule kernel_call_A_if_confidentiality'[where s=s and t=t and s'=s' and t'=t' and u=u],
+     apply (drule kernel_call_A_if_confidentiality'[where s=s and t=t and s'=s' and t'=t' and u=u],
            simp+)
     (* KernelPreempted *)
-    apply(simp add: part_def)
+    apply (simp add: part_def)
     (* KernelSchedule bool -- where \<not> bool *)
-   apply((simp add: Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
+   apply ((simp add: Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
                split: if_splits
          | intro impI allI
          | elim exE conjE disjE
          | simp_all add: not_schedule_modes_KernelEntry)+)[1]
-   apply(drule kernel_schedule_if_confidentiality'[where s=s and t=t and s'=s' and t'=t' and u=u],
+   apply (drule kernel_schedule_if_confidentiality'[where s=s and t=t and s'=s' and t'=t' and u=u],
          simp+)
   (* KernelExit *)
-  apply((simp add: Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
+  apply ((simp add: Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
               split: if_splits
         | intro impI allI
         | elim exE conjE disjE
         | simp_all add: not_schedule_modes_KernelEntry)+)[1]
-  apply(drule kernel_exit_A_if_confidentiality'[where s=s and t=t and s'=s' and t'=t' and u=u],
+  apply (drule kernel_exit_A_if_confidentiality'[where s=s and t=t and s'=s' and t'=t' and u=u],
         simp+)
-  done
-
-lemma unit_list_as_replicate:
-  "(as::unit list) = replicate (length as) ()"
-  apply(induct as, auto)
-  done
-
-lemma unit_lists_unequal:
-  "(as::unit list) \<noteq> (as'::unit list) \<Longrightarrow> as < as' \<or> as' < as"
-  apply(simp add: less_list_def' strict_prefix_def)
-  apply(case_tac "length as \<ge> length as'")
-  apply(rule disjI2)
-   apply(subst unit_list_as_replicate[where as=as])
-   apply(subst unit_list_as_replicate[where as=as'])
-   apply (clarsimp simp: prefix_def)
-   apply (rule_tac x="replicate (length as - length as') ()" in exI)
-   apply(subst replicate_add[symmetric])
-   apply simp
-  apply(rule disjI1)
-  apply(subst unit_list_as_replicate[where as=as])
-  apply(subst unit_list_as_replicate[where as=as'])
-  apply (clarsimp simp: prefix_def)
-  apply(rule_tac x="replicate (length as' - length as) ()" in exI)
-  apply(subst replicate_add[symmetric])
-  apply simp
-  done
-
-lemma partitionIntegrity_part_unchanged:
-  "\<lbrakk>partitionIntegrity aag (internal_state_if s) (internal_state_if s'); part s \<noteq> PSched;
-    part s' \<noteq> PSched\<rbrakk> \<Longrightarrow> part s' = part s"
-  apply(simp add: part_def split: if_splits
-             add: partition_def partitionIntegrity_def domain_fields_equiv_def)
-  done
-
-lemma big_step_R_rtranclp:
-  "system.reachable (big_step_ADT_A_if utf) s0 s
-       \<Longrightarrow> big_step_R\<^sup>*\<^sup>* s0 s"
-  apply(simp add: reachable_def execution_def)
-  apply(clarsimp simp: big_step_ADT_A_if_def Fin_big_step_adt Fin_ADT_A_if steps_eq_Run)
-  apply(rule Run_big_steps_tranclp)
-  apply(simp add: big_step_ADT_A_if_def big_step_adt_def Init_ADT_if)
   done
 
 lemma sub_big_steps_not_PSched_confidentiality_part:
@@ -3610,88 +3239,46 @@ lemma sub_big_steps_not_PSched_confidentiality_part:
      system.reachable (big_step_ADT_A_if utf) s0 t; part s \<noteq> PSched\<rbrakk> \<Longrightarrow>
   (s', t') \<in> uwr u \<and> (s', t') \<in> uwr PSched \<and> (s', t') \<in> uwr (part s) \<and>
    part s' = part s"
-  apply(frule_tac s=s and t=t and X="\<lambda>s t. part s \<noteq> PSched \<and> ((s, t) \<in> uwr PSched \<and>
+  apply (frule_tac s=s and t=t and X="\<lambda>s t. part s \<noteq> PSched \<and> ((s, t) \<in> uwr PSched \<and>
                                           (s, t) \<in> uwr (part s) \<and> (s, t) \<in> uwr u \<and>
                                           system.reachable (ADT_A_if utf) s0 s \<and>
                                           system.reachable (ADT_A_if utf) s0 t)"
                in relation_preserved_across_sub_big_steps)
       apply (simp add: small_step_reachable del: split_paired_All)+
-   apply(intro impI allI | elim conjE)+
-   apply(rename_tac sx tx sx' tx')
-   apply(subgoal_tac "part sx = part s \<and> part sx' = part s")
-    apply(frule_tac u=u and s=sx and t=tx in small_Step_confidentiality_part_not_PSched)
-              apply(simp add: small_step_reachable)+
-    apply(fastforce intro: Step_system.reachable_Step[OF ADT_A_if_Step_system _ Step_ADT_A_if'',
+   apply (intro impI allI | elim conjE)+
+   apply (rename_tac sx tx sx' tx')
+   apply (subgoal_tac "part sx = part s \<and> part sx' = part s")
+    apply (frule_tac u=u and s=sx and t=tx in small_Step_confidentiality_part_not_PSched)
+              apply (simp add: small_step_reachable)+
+    apply (fastforce intro: Step_system.reachable_Step[OF ADT_A_if_Step_system _ Step_ADT_A_if'',
                                                       rotated])
-   apply(elim exE conjE)
-   apply(frule part_equiv)
-   apply(frule_tac s'=sx in partitionIntegrity_part_unchanged[OF sub_big_steps_partitionIntegrity])
-        apply(blast intro: big_step_R_rtranclp)
-       apply(erule small_step_reachable)
+   apply (elim exE conjE)
+   apply (frule schedIncludesCurrentDom)
+   apply (frule_tac s'=sx in partitionIntegrity_part_unchanged[OF sub_big_steps_partitionIntegrity])
+        apply (blast intro: big_step_R_rtranclp)
+       apply (erule small_step_reachable)
       apply assumption
      apply assumption
     apply assumption
-   apply(rule conjI, assumption)
-   apply(rule partitionIntegrity_part_unchanged[OF sub_big_steps_partitionIntegrity])
+   apply (rule conjI, assumption)
+   apply (rule partitionIntegrity_part_unchanged[OF sub_big_steps_partitionIntegrity])
         apply assumption
-       apply(blast intro: big_step_R_rtranclp)
-      apply(erule small_step_reachable)
+       apply (blast intro: big_step_R_rtranclp)
+      apply (erule small_step_reachable)
      apply assumption
     apply assumption
-   apply(rule sub_big_steps_not_PSched)
+   apply (rule sub_big_steps_not_PSched)
      apply assumption
-    apply(blast intro: big_step_R_rtranclp)
+    apply (blast intro: big_step_R_rtranclp)
    apply assumption
-  apply(frule_tac s'=s' in partitionIntegrity_part_unchanged[OF sub_big_steps_partitionIntegrity])
-       apply(blast intro: big_step_R_rtranclp)
-      apply(erule small_step_reachable)
+  apply (frule_tac s'=s' in partitionIntegrity_part_unchanged[OF sub_big_steps_partitionIntegrity])
+       apply (blast intro: big_step_R_rtranclp)
+      apply (erule small_step_reachable)
      apply assumption
     apply assumption
    apply blast
   apply simp
   done
-
-
-lemma sub_big_steps_strict_prefix:
-  "(s', as @ bs) \<in> sub_big_steps A R s \<Longrightarrow>
-   \<exists> t. (t, as) \<in> sub_big_steps A R s"
-  apply(induct bs arbitrary: s s' rule: rev_induct)
-   apply fastforce
-  apply(subst (asm) append_assoc[symmetric])
-  apply(drule sub_big_steps_App)
-  apply blast
-  done
-
-lemma app_Cons:
-  "xs @ (a # b) = (xs @ [a]) @ b"
-  apply simp
-  done
-
-lemma uwr_part_sys_mode_of_eq':
-  "\<lbrakk>(s,t) \<in> uwr (part x); part s = part x; part t = part x; part x \<noteq> PSched\<rbrakk>
-    \<Longrightarrow> sys_mode_of s = sys_mode_of t"
-  apply(fastforce intro: uwr_part_sys_mode_of_eq)
-  done
-
-lemma sys_mode_of_eq_big_step_R_contradiction:
-  "\<lbrakk>sys_mode_of s = sys_mode_of t; sys_mode_of s' = sys_mode_of t'; big_step_R s s';
-   \<not> big_step_R t t'\<rbrakk> \<Longrightarrow> False"
-  apply(simp add: big_step_R_def)
-  apply(case_tac s, case_tac t, simp_all)
-  apply(case_tac s', case_tac t', simp_all)
-  apply auto
-  done
-
-lemma strict_prefixE'[elim?]:
-  assumes "xs < ys"
-  obtains z zs where "ys = xs @ z # zs"
-proof -
-  from \<open>xs < ys\<close> obtain us where "ys = xs @ us" and "xs \<noteq> ys"
-    apply(simp add: less_list_def' strict_prefix_def prefix_def)
-    apply blast
-    done
-  with that show ?thesis by (auto simp add: neq_Nil_conv)
-qed
 
 lemma non_PSched_steps_run_in_lock_step':
   "\<lbrakk>(s', as) \<in> sub_big_steps (ADT_A_if utf) big_step_R s;
@@ -3702,46 +3289,46 @@ lemma non_PSched_steps_run_in_lock_step':
      system.reachable (big_step_ADT_A_if utf) s0 s;
      system.reachable (big_step_ADT_A_if utf) s0 sa; part s \<noteq> PSched;
      asa < as\<rbrakk> \<Longrightarrow> False"
-  apply(erule strict_prefixE')
-  apply(simp, subst (asm) app_Cons)
-  apply(drule sub_big_steps_strict_prefix)
-  apply(erule exE, rename_tac s'ab)
-  apply(frule sub_big_steps_App)
-  apply(erule exE, rename_tac s'aa)
+  apply (erule strict_prefixE')
+  apply (simp, subst (asm) app_Cons)
+  apply (drule sub_big_steps_strict_prefix)
+  apply (erule exE, rename_tac s'ab)
+  apply (frule sub_big_steps_App)
+  apply (erule exE, rename_tac s'aa)
   (* s'ab and ta need to be equivalent with respect to part s, which means their
      modes must be equal. The modes between sa and s are equal too,
       which means that big_step_R sa ta and \<not> big_step_R s s'ab is a contradiction *)
-  apply(elim conjE)
-  apply(frule_tac s=sa in sub_big_steps_reachable, simp add: small_step_reachable)
-  apply(frule_tac s=s and s'=s'aa in sub_big_steps_reachable, simp add: small_step_reachable)
-  apply(frule_tac s=sa and t=s and u="part s" in sub_big_steps_not_PSched_confidentiality_part)
-          apply((fastforce simp: uwr_sym dest: part_equiv
+  apply (elim conjE)
+  apply (frule_tac s=sa in sub_big_steps_reachable, simp add: small_step_reachable)
+  apply (frule_tac s=s and s'=s'aa in sub_big_steps_reachable, simp add: small_step_reachable)
+  apply (frule_tac s=sa and t=s and u="part s" in sub_big_steps_not_PSched_confidentiality_part)
+          apply ((fastforce simp: uwr_sym dest: schedIncludesCurrentDom
                            simp: refl_onD[OF policyFlows_refl, simplified])+)[9]
-  apply(elim conjE)
-  (*apply(simp del: split_paired_All)*)
-  apply(frule_tac s=s'aa and t=s'a and u="part sa" in small_Step_confidentiality_part_not_PSched)
-          apply((fastforce simp: uwr_sym dest: part_equiv
+  apply (elim conjE)
+  (*apply (simp del: split_paired_All)*)
+  apply (frule_tac s=s'aa and t=s'a and u="part sa" in small_Step_confidentiality_part_not_PSched)
+          apply ((fastforce simp: uwr_sym dest: schedIncludesCurrentDom
                            simp: refl_onD[OF policyFlows_refl, simplified])+)[9] (* slowish *)
-  apply(elim conjE)
-  apply(subgoal_tac "part ta = part s")
-   apply(drule part_equiv)+
-   apply(rule_tac s=sa and t=s in  sys_mode_of_eq_big_step_R_contradiction)
-      apply(fastforce intro: uwr_part_sys_mode_of_eq'[symmetric])
+  apply (elim conjE)
+  apply (subgoal_tac "part ta = part s")
+   apply (drule schedIncludesCurrentDom)+
+   apply (rule_tac s=sa and t=s in  sys_mode_of_eq_big_step_R_contradiction)
+      apply (fastforce intro: uwr_part_sys_mode_of_eq'[symmetric])
      prefer 2
      apply assumption
     prefer 2
     apply assumption
-   apply(fastforce intro: uwr_part_sys_mode_of_eq'[symmetric])
-  apply(rule sym)
-  apply(rule trans[rotated])
-   apply(erule part_equiv)
-  apply(rule sym, rule partitionIntegrity_part_unchanged[OF sub_big_steps_partitionIntegrity])
+   apply (fastforce intro: uwr_part_sys_mode_of_eq'[symmetric])
+  apply (rule sym)
+  apply (rule trans[rotated])
+   apply (erule schedIncludesCurrentDom)
+  apply (rule sym, rule partitionIntegrity_part_unchanged[OF sub_big_steps_partitionIntegrity])
        apply assumption
-      apply(erule big_step_R_rtranclp)
-     apply(erule small_step_reachable)
+      apply (erule big_step_R_rtranclp)
+     apply (erule small_step_reachable)
     apply simp+
-  apply(rule sub_big_steps_not_PSched, assumption)
-   apply(erule big_step_R_rtranclp)
+  apply (rule sub_big_steps_not_PSched, assumption)
+   apply (erule big_step_R_rtranclp)
   apply simp
   done
 
@@ -3755,12 +3342,12 @@ lemma non_PSched_steps_run_in_lock_step:
     system.reachable (big_step_ADT_A_if utf) s0 sa;
     part s \<noteq> PSched\<rbrakk>
    \<Longrightarrow> asa = as"
-  apply(case_tac "asa = as", assumption)
-  apply(drule unit_lists_unequal)
-  apply(erule disjE)
-   apply(drule non_PSched_steps_run_in_lock_step', simp+)
-  apply(frule part_equiv[symmetric])
-  apply(drule_tac as=asa and asa=as in non_PSched_steps_run_in_lock_step', (simp add: uwr_sym)+)
+  apply (case_tac "asa = as", assumption)
+  apply (drule unit_lists_unequal)
+  apply (erule disjE)
+   apply (drule non_PSched_steps_run_in_lock_step', simp+)
+  apply (frule schedIncludesCurrentDom[symmetric])
+  apply (drule_tac as=asa and asa=as in non_PSched_steps_run_in_lock_step', (simp add: uwr_sym)+)
   done
 
 lemma confidentiality_part_not_PSched:
@@ -3772,98 +3359,97 @@ lemma confidentiality_part_not_PSched:
     (part s, u) \<in> policyFlows (pasPolicy initial_aag) \<and>
     part s \<noteq> PSched \<and> u \<noteq> PSched \<longrightarrow>
    (s', t') \<in> uwr u"
-  apply(simp add: Step_big_step_ADT_A_if)
-  apply(erule big_steps.induct)+
-  apply(intro impI | elim conjE)+
-  apply(subgoal_tac "asa = as")
-   apply(drule_tac X="\<lambda>s t. (s, t) \<in> uwr PSched \<and> (s, t) \<in> uwr (part s) \<and>
+  apply (simp add: Step_big_step_ADT_A_if)
+  apply (erule big_steps.induct)+
+  apply (intro impI | elim conjE)+
+  apply (subgoal_tac "asa = as")
+   apply (drule_tac X="\<lambda>s t. (s, t) \<in> uwr PSched \<and> (s, t) \<in> uwr (part s) \<and>
     (s, t) \<in> uwr u \<and>
     system.reachable (ADT_A_if utf) s0 s \<and>
     system.reachable (ADT_A_if utf) s0 t \<and>
     (part s, u) \<in> policyFlows (pasPolicy initial_aag) \<and>
     part s \<noteq> PSched" in relation_preserved_across_sub_big_steps)
       apply assumption
-     apply(fastforce simp: small_step_reachable)
+     apply (fastforce simp: small_step_reachable)
     apply assumption
-   apply(simp del: split_paired_All)
-   apply(thin_tac "(x,y) \<in> data_type.Step A b" for x y A b
+   apply (simp del: split_paired_All)
+   apply (thin_tac "(x,y) \<in> data_type.Step A b" for x y A b
          | thin_tac "big_step_R a b" for a b)+
-   apply(intro allI impI | elim conjE)+
-   apply(rename_tac x_s x_t x_s' x_t')
-   apply(subgoal_tac "part x_s' = part x_s")
-    apply(simp del: split_paired_All)
-    apply(frule_tac u=u and s=x_s and t=x_t in small_Step_confidentiality_part_not_PSched)
-              apply(simp add: small_step_reachable)+
-     apply(fastforce intro: Step_system.reachable_Step[OF ADT_A_if_Step_system _ Step_ADT_A_if'',
+   apply (intro allI impI | elim conjE)+
+   apply (rename_tac x_s x_t x_s' x_t')
+   apply (subgoal_tac "part x_s' = part x_s")
+    apply (simp del: split_paired_All)
+    apply (frule_tac u=u and s=x_s and t=x_t in small_Step_confidentiality_part_not_PSched)
+              apply (simp add: small_step_reachable)+
+     apply (fastforce intro: Step_system.reachable_Step[OF ADT_A_if_Step_system _ Step_ADT_A_if'',
                                                        rotated])
-    apply(elim exE)
-    apply(rule trans)
-     apply(rule partitionIntegrity_part_unchanged[OF sub_big_steps_partitionIntegrity])
+    apply (elim exE)
+    apply (rule trans)
+     apply (rule partitionIntegrity_part_unchanged[OF sub_big_steps_partitionIntegrity])
           apply blast
-         apply(erule big_step_R_rtranclp)
-        apply(erule small_step_reachable)
+         apply (erule big_step_R_rtranclp)
+        apply (erule small_step_reachable)
        apply simp+
-     apply(rule sub_big_steps_not_PSched)
+     apply (rule sub_big_steps_not_PSched)
        apply blast
-      apply(erule big_step_R_rtranclp)
+      apply (erule big_step_R_rtranclp)
      apply simp
-    apply(rule sym)
-    apply(rule partitionIntegrity_part_unchanged[OF sub_big_steps_partitionIntegrity])
+    apply (rule sym)
+    apply (rule partitionIntegrity_part_unchanged[OF sub_big_steps_partitionIntegrity])
          apply blast
-        apply(erule big_step_R_rtranclp)
-       apply(erule small_step_reachable)
-      apply(simp+)[3]
-   apply(elim conjE)
+        apply (erule big_step_R_rtranclp)
+       apply (erule small_step_reachable)
+      apply (simp+)[3]
+   apply (elim conjE)
    apply simp
-   apply(drule_tac s=s' and t=s'a and u=u in small_Step_confidentiality_part_not_PSched)
+   apply (drule_tac s=s' and t=s'a and u=u in small_Step_confidentiality_part_not_PSched)
              apply (simp+)[10]
-  apply(fastforce dest: non_PSched_steps_run_in_lock_step)
+  apply (fastforce dest: non_PSched_steps_run_in_lock_step)
   done
 
-lemma getActiveIRQ_ret_no_dmo[wp]:
-  "\<lbrace>\<lambda>_. True\<rbrace> getActiveIRQ in_kernel \<lbrace>\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ\<rbrace>"
-  apply (simp add: getActiveIRQ_def)
-  apply(rule hoare_pre)
-   apply (insert irq_oracle_max_irq)
-   apply (wp alternative_wp select_wp dmo_getActiveIRQ_irq_masks)
-  apply clarsimp
-  done
+end
 
 
-lemma try_some_magic: "(\<forall>x. y = Some x \<longrightarrow> P x) = ((\<exists>x. y = Some x) \<longrightarrow> P (the y))"
-by auto
+lemma try_some_magic:
+  "(\<forall>x. y = Some x \<longrightarrow> P x) = ((\<exists>x. y = Some x) \<longrightarrow> P (the y))"
+  by auto
 
 lemma thread_set_as_user2:
-  "thread_set (tcb_arch_update (arch_tcb_context_set uc)) t
-    = as_user t (modify (\<lambda>_. uc))"
+  "thread_set (tcb_arch_update (arch_tcb_context_set uc)) t = as_user t (modify (\<lambda>_. uc))"
 proof -
   have P: "\<And>f. det (modify f)"
     by (simp add: modify_def)
   thus ?thesis
     apply (simp add: as_user_def P thread_set_def)
-    apply (clarsimp simp add: select_f_def
-                              simpler_modify_def
-                              bind_def image_def
-                              arch_tcb_update_aux3)
+    apply (clarsimp simp: select_f_def simpler_modify_def bind_def
+                          image_def fun_cong[OF arch_tcb_update_aux2])
     done
 qed
 
+lemma handle_preemption_agnostic_tc:
+  "\<forall>P Q uc uc'. \<lbrace>P\<rbrace> handle_preemption_if uc \<lbrace>\<lambda>_. Q\<rbrace> \<longrightarrow> \<lbrace>P\<rbrace> handle_preemption_if uc' \<lbrace>\<lambda>_. Q\<rbrace>"
+  apply (clarsimp simp add: handle_preemption_if_def bind_assoc[symmetric])
+  apply (erule bind_return_ign)
+  done
+
+
+context Noninterference_1 begin
 
 lemma preemption_interrupt_scheduler_invisible:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-    "equiv_valid_2 (scheduler_equiv aag) (scheduler_affects_equiv aag l)
-      (scheduler_affects_equiv aag l) (\<lambda>r r'. r = uc \<and> snd r' = uc')
-      (einvs and pas_refined aag and guarded_pas_domain aag and domain_sep_inv False st and
-         silc_inv aag st' and (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s) and
-         (\<lambda>s. ct_idle s \<longrightarrow> uc = idle_context s) and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
-         guarded_pas_domain aag)
-      (einvs and pas_refined aag and guarded_pas_domain aag and domain_sep_inv False st and
-         silc_inv aag st' and  (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s) and
-         (\<lambda>s. ct_idle s \<longrightarrow> uc' = idle_context s) and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
-         guarded_pas_domain aag)
-      (handle_preemption_if uc)
-      (kernel_entry_if Interrupt uc')"
+  assumes domains_distinct[wp]: "pas_domains_distinct (aag :: 'a subject_label PAS)"
+  shows "equiv_valid_2 (scheduler_equiv aag) (scheduler_affects_equiv aag l)
+                       (scheduler_affects_equiv aag l) (\<lambda>r r'. r = uc \<and> snd r' = uc')
+                       (einvs and pas_refined aag and guarded_pas_domain aag
+                              and domain_sep_inv False st and silc_inv aag st'
+                              and (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+                              and (\<lambda>s. ct_idle s \<longrightarrow> uc = idle_context s)
+                              and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s))
+                       (einvs and pas_refined aag and guarded_pas_domain aag
+                              and domain_sep_inv False st and silc_inv aag st'
+                              and (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+                              and (\<lambda>s. ct_idle s \<longrightarrow> uc' = idle_context s)
+                              and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s))
+                       (handle_preemption_if uc) (kernel_entry_if Interrupt uc')"
   apply (simp add: kernel_entry_if_def handle_preemption_if_def)
   apply (rule equiv_valid_2_bind_right)
        apply (rule equiv_valid_2_bind_right)
@@ -3881,63 +3467,50 @@ lemma preemption_interrupt_scheduler_invisible:
                 apply (rule equiv_valid_2)
                 apply (rule dmo_getActive_IRQ_reads_respect_scheduler)
                apply (wp dmo_getActiveIRQ_return_axiom[simplified try_some_magic]
-                     | simp  add: imp_conjR arch_tcb_update_aux2
-                     | elim conjE
-                     | intro conjI
-                     | wp (once) hoare_drop_imps)+
+                      | simp  add: imp_conjR arch_tcb_update_aux2
+                      | elim conjE
+                      | intro conjI
+                      | wp (once) hoare_drop_imps)+
            apply (subst thread_set_as_user2)
            apply (wp guarded_pas_domain_lift)
           apply ((simp add:  arch_tcb_update_aux2 | wp | force)+)[7]
    apply (fastforce simp: silc_inv_not_cur_thread cur_thread_idle guarded_pas_domain_def)+
   done
 
-
-lemma handle_preemption_agnostic_tc:
-  "\<forall>P Q uc uc'. \<lbrace>P\<rbrace> handle_preemption_if uc \<lbrace>\<lambda>_. Q\<rbrace> \<longrightarrow> \<lbrace>P\<rbrace> handle_preemption_if uc' \<lbrace>\<lambda>_.Q\<rbrace>"
-  apply (clarsimp simp add: handle_preemption_if_def bind_assoc[symmetric])
-  apply (erule bind_return_ign)
-  done
-
-lemma handle_preemption_agnostic_ret:
-  "\<lbrace>\<top>\<rbrace> handle_preemption_if uc' \<lbrace>\<lambda>r s. r = uc'\<rbrace>"
-  apply (clarsimp simp add: handle_preemption_if_def)
-  apply (wp | simp)+
-  done
-
-
 lemma handle_preemption_reads_respects_scheduler:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  assumes domains_distinct[wp]: "pas_domains_distinct (aag :: 'a subject_label PAS)"
   shows
-  "reads_respects_scheduler aag l (einvs and pas_refined aag and guarded_pas_domain aag and
-                                   domain_sep_inv False st and silc_inv aag st' and
-                                   (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s))
-                  (handle_preemption_if uc)"
+    "reads_respects_scheduler aag l (einvs and pas_refined aag and guarded_pas_domain aag
+                                           and domain_sep_inv False st and silc_inv aag st'
+                                           and (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s))
+                              (handle_preemption_if uc)"
   apply (simp add: handle_preemption_if_def)
   apply (wp when_ev handle_interrupt_reads_respects_scheduler
             dmo_getActiveIRQ_return_axiom[simplified try_some_magic]
-         dmo_getActive_IRQ_reads_respect_scheduler | simp add: imp_conjR| wp (once) hoare_drop_imps)+
+            dmo_getActive_IRQ_reads_respect_scheduler
+         | simp add: imp_conjR| wp (once) hoare_drop_imps)+
   apply force
   done
 
 lemmas handle_preemption_reads_respects_scheduler_2 =
-              agnostic_to_ev2[OF handle_preemption_agnostic_tc handle_preemption_agnostic_ret
-                                 handle_preemption_reads_respects_scheduler]
-
+  agnostic_to_ev2[OF handle_preemption_agnostic_tc handle_preemption_context
+                     handle_preemption_reads_respects_scheduler]
 
 lemma kernel_entry_scheduler_equiv_2:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-    "equiv_valid_2 (scheduler_equiv aag) (scheduler_affects_equiv aag l)
-       (scheduler_affects_equiv aag l) (\<lambda>r r'. snd r = uc \<and> snd r' = uc')
-       (einvs and pas_refined aag and guarded_pas_domain aag and domain_sep_inv False st and
-          silc_inv aag st' and (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s) and
-          (\<lambda>s. ct_idle s \<longrightarrow> uc = idle_context s) and
-          (\<lambda>s. reads_scheduler_cur_domain aag l s \<longrightarrow> uc = uc'))
-       (einvs and pas_refined aag and guarded_pas_domain aag and domain_sep_inv False st and
-          silc_inv aag st' and  (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s) and
-          (\<lambda>s. ct_idle s \<longrightarrow> uc' = idle_context s) and
-          (\<lambda>s. reads_scheduler_cur_domain aag l s \<longrightarrow> uc = uc'))
-       (kernel_entry_if Interrupt uc) (kernel_entry_if Interrupt uc')"
+  assumes domains_distinct[wp]: "pas_domains_distinct (aag :: 'a subject_label PAS)"
+  shows "equiv_valid_2 (scheduler_equiv aag) (scheduler_affects_equiv aag l)
+                       (scheduler_affects_equiv aag l) (\<lambda>r r'. snd r = uc \<and> snd r' = uc')
+                       (einvs and pas_refined aag and guarded_pas_domain aag
+                              and domain_sep_inv False st and silc_inv aag st'
+                              and (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+                              and (\<lambda>s. ct_idle s \<longrightarrow> uc = idle_context s)
+                              and (\<lambda>s. reads_scheduler_cur_domain aag l s \<longrightarrow> uc = uc'))
+                       (einvs and pas_refined aag and guarded_pas_domain aag
+                              and domain_sep_inv False st and silc_inv aag st'
+                              and (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+                              and (\<lambda>s. ct_idle s \<longrightarrow> uc' = idle_context s)
+                              and (\<lambda>s. reads_scheduler_cur_domain aag l s \<longrightarrow> uc = uc'))
+                       (kernel_entry_if Interrupt uc) (kernel_entry_if Interrupt uc')"
   apply (simp add: kernel_entry_if_def)
   apply (simp add: bind_assoc[symmetric])
   apply (rule equiv_valid_2_bind_pre[where R'="(=)"])
@@ -3947,99 +3520,70 @@ lemma kernel_entry_scheduler_equiv_2:
            apply (rule equiv_valid_2)
            apply simp
            apply (wp del: no_irq add: handle_interrupt_reads_respects_scheduler[where st=st]
-                     dmo_getActive_IRQ_reads_respect_scheduler
-                 | wpc
-                 | simp add: imp_conjR all_conj_distrib  arch_tcb_update_aux2
-                 | wp (once) hoare_drop_imps)+
-           apply (rule context_update_cur_thread_snippit)
+                                      dmo_getActive_IRQ_reads_respect_scheduler
+                  | wpc
+                  | simp add: imp_conjR all_conj_distrib  arch_tcb_update_aux2
+                  | wp (once) hoare_drop_imps)+
+          apply (rule context_update_cur_thread_snippit)
          apply (wp thread_set_invs_trivial guarded_pas_domain_lift
                    thread_set_pas_refined thread_set_not_state_valid_sched
-               | simp add: tcb_cap_cases_def arch_tcb_update_aux2)+
+                | simp add: tcb_cap_cases_def arch_tcb_update_aux2)+
    apply (fastforce simp: silc_inv_not_cur_thread cur_thread_idle)+
   done
 
-(*Probably not needed*)
-lemma kernel_entry_if_reads_respects_scheduler:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "valid_exclusive_state
-      \<Longrightarrow> reads_respects_scheduler aag l (einvs and pas_refined aag and guarded_pas_domain aag and
-          domain_sep_inv False st and silc_inv aag st' and
-          (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s) and
-          (\<lambda>s. ct_idle s \<longrightarrow> uc = idle_context s)) (kernel_entry_if Interrupt uc)"
-  apply (simp add: kernel_entry_if_def)
-  apply (simp add: bind_assoc[symmetric])
-  apply (rule bind_ev_pre)
-     apply wp
-    apply (rule bind_ev_pre)
-       apply ((wp del: no_irq
-                  add: when_ev handle_interrupt_reads_respects_scheduler[where st=st]
-                       dmo_getActive_IRQ_reads_respect_scheduler liftE_ev
-              | simp add: imp_conjR all_conj_distrib
-              | wpc
-              | wp (once) hoare_drop_imps)+)[1]
-      apply (rule reads_respects_scheduler_cases')
-         prefer 3
-         apply (rule reads_respects_scheduler_unobservable'')
-           apply (( wp thread_set_scheduler_equiv
-                  | simp add:  arch_tcb_update_aux2
-                  | elim conjE)+)[3]
-        apply ((wp | simp add:  arch_tcb_update_aux2 | elim conjE)+)[2]
-      apply (clarsimp simp: guarded_pas_domain_def disjoint_iff_not_equal)
-     apply (( wp thread_set_invs_trivial guarded_pas_domain_lift hoare_vcg_all_lift
-                  thread_set_pas_refined thread_set_not_state_valid_sched
-            | simp add: tcb_cap_cases_def  arch_tcb_update_aux2)+)
-  apply (clarsimp simp: cur_thread_idle cur_thread_not_SilcLabel)
-  apply force
-  done
+end
+
+
+context valid_initial_state begin
 
 lemma interrupt_step:
   assumes interrupt:
     "\<And>r. (r,internal_state_if s')
-                      \<in> fst (kernel_entry_if Interrupt (user_context_of s) (internal_state_if s))
-           \<Longrightarrow> sys_mode_of s = KernelEntry Interrupt \<Longrightarrow> (sys_mode_of s' = KernelSchedule True)
-           \<Longrightarrow> snd r = user_context_of s \<Longrightarrow> snd r = user_context_of s'
-           \<Longrightarrow> cur_domain (internal_state_if s') = cur_domain (internal_state_if s) \<Longrightarrow> P"
+            \<in> fst (kernel_entry_if Interrupt (user_context_of s) (internal_state_if s))
+          \<Longrightarrow> sys_mode_of s = KernelEntry Interrupt \<Longrightarrow> (sys_mode_of s' = KernelSchedule True)
+          \<Longrightarrow> snd r = user_context_of s \<Longrightarrow> snd r = user_context_of s'
+          \<Longrightarrow> cur_domain (internal_state_if s') = cur_domain (internal_state_if s)
+          \<Longrightarrow> P"
   assumes preemption:
     "\<And>r. (r,internal_state_if s')
-                      \<in> fst (handle_preemption_if (user_context_of s) (internal_state_if s))
-           \<Longrightarrow> sys_mode_of s = KernelPreempted \<Longrightarrow> sys_mode_of s' = KernelSchedule True
-           \<Longrightarrow> r = user_context_of s \<Longrightarrow> r = user_context_of s'
-           \<Longrightarrow> cur_domain (internal_state_if s') = cur_domain (internal_state_if s) \<Longrightarrow> P"
-  shows "interrupted_modes (sys_mode_of s) \<Longrightarrow> (s,s') \<in> data_type.Step (ADT_A_if utf) () \<Longrightarrow> P"
+            \<in> fst (handle_preemption_if (user_context_of s) (internal_state_if s))
+          \<Longrightarrow> sys_mode_of s = KernelPreempted \<Longrightarrow> sys_mode_of s' = KernelSchedule True
+          \<Longrightarrow> r = user_context_of s \<Longrightarrow> r = user_context_of s'
+          \<Longrightarrow> cur_domain (internal_state_if s') = cur_domain (internal_state_if s)
+          \<Longrightarrow> P"
+  shows "\<lbrakk> interrupted_modes (sys_mode_of s); (s,s') \<in> data_type.Step (ADT_A_if utf) () \<rbrakk> \<Longrightarrow> P"
   apply (insert interrupt preemption)
   apply atomize
-  apply(case_tac s, clarsimp)
-  apply(rename_tac uc i_s mode)
-  apply(case_tac mode ; clarsimp)
+  apply (case_tac s, clarsimp)
+  apply (rename_tac uc i_s mode)
+  apply (case_tac mode ; clarsimp)
    subgoal for uc i_s
      apply (clarsimp simp: system.Step_def execution_def steps_def ADT_A_if_def
                             global_automaton_if_def kernel_call_A_if_def
                             kernel_handle_preemption_if_def del: notI)
      apply (frule use_valid[OF _ kernel_entry_context] ; clarsimp)
-     apply (frule_tac P1="\<lambda>x. x = cur_domain i_s" in use_valid[OF _ kernel_entry_if_cur_domain]
-            ; clarsimp)
+     apply (frule_tac P1="\<lambda>x. x = cur_domain i_s" in use_valid[OF _ kernel_entry_if_cur_domain])
+      apply auto
      done
   subgoal for uc i_s
     apply (clarsimp simp: system.Step_def execution_def steps_def ADT_A_if_def
                            global_automaton_if_def kernel_call_A_if_def
                            kernel_handle_preemption_if_def del: notI)
     apply (frule use_valid[OF _ handle_preemption_context] ; clarsimp)
-    apply (frule_tac P1="\<lambda>x. x = cur_domain i_s" in use_valid[OF _ handle_preemption_if_cur_domain]
-           ; clarsimp)
+    apply (frule_tac P1="\<lambda>x. x = cur_domain i_s" in use_valid[OF _ handle_preemption_if_cur_domain])
+     apply auto
     done
   done
 
-lemma irq_masks_constant': "\<lbrakk>system.reachable (ADT_A_if utf) s0 s1;
-       i_s1 = internal_state_if s1\<rbrakk> \<Longrightarrow>
-       irq_masks_of_state i_s1 = irq_masks_of_state (internal_state_if s0)"
+lemma irq_masks_constant':
+  "\<lbrakk> system.reachable (ADT_A_if utf) s0 s1; i_s1 = internal_state_if s1 \<rbrakk>
+     \<Longrightarrow> irq_masks_of_state i_s1 = irq_masks_of_state (internal_state_if s0)"
   apply simp
-
   apply (rule Step_system.reachable_induct[OF ADT_A_if_Step_system,rotated,rotated], rule refl)
    apply (rule trans)
     prefer 2
     apply assumption
-   apply (rule ADT_A_if_Step_irq_masks, simp add: Step2)
+   apply (rule ADT_A_if_Step_irq_masks, simp add: Step_ADT_A_if')
    apply (rule ADT_A_if_reachable_invs_if,assumption)
   apply simp
   done
@@ -4047,8 +3591,10 @@ lemma irq_masks_constant': "\<lbrakk>system.reachable (ADT_A_if utf) s0 s1;
 lemmas irq_masks_constant = irq_masks_constant'[OF small_step_reachable]
 
 lemma internal_state_s0: "internal_state_if s0 = s0_internal"
-  apply (simp add: s0_def)
-  done
+  by (simp add: s0_def)
+
+end
+
 
 (* FIXME: clarify the following comment *)
 (*Lets pretend PSched is labeled with SilcLabel*)
@@ -4056,16 +3602,19 @@ fun label_for_partition where
    "label_for_partition (Partition a) = (OrdinaryLabel a)"
  | "label_for_partition PSched = SilcLabel"
 
+
+context Noninterference_valid_initial_state begin
+
 lemma uwr_scheduler_affects_equiv:
-  "\<lbrakk>(s,s') \<in> uwr PSched; (s,s') \<in> uwr u; invs_if s; invs_if s'\<rbrakk> \<Longrightarrow>
-    scheduler_equiv initial_aag (internal_state_if s) (internal_state_if s') \<and>
-    scheduler_affects_equiv initial_aag (label_for_partition u) (internal_state_if s)
-                            (internal_state_if s')"
+  "\<lbrakk> (s,s') \<in> uwr PSched; (s,s') \<in> uwr u; invs_if s; invs_if s' \<rbrakk>
+     \<Longrightarrow> scheduler_equiv initial_aag (internal_state_if s) (internal_state_if s') \<and>
+         scheduler_affects_equiv initial_aag (label_for_partition u)
+                                 (internal_state_if s) (internal_state_if s')"
   apply (simp add: uwr_def)
   apply (case_tac u)
    apply simp
    apply (rule sameFor_scheduler_affects_equiv)
-     apply (simp add: invs_if_def Invs_def)+
+      apply (simp add: invs_if_def Invs_def)+
   apply (rule context_conjI)
    apply (rule sameFor_scheduler_equiv,simp+)
   apply (rule SilcLabel_affects_scheduler_equiv)
@@ -4075,14 +3624,14 @@ lemma uwr_scheduler_affects_equiv:
 lemma scheduler_affects_equiv_uwr:
   assumes schedeq:
     "scheduler_equiv initial_aag (internal_state_if s) (internal_state_if s') \<and>
-     scheduler_affects_equiv initial_aag (label_for_partition u) (internal_state_if s)
-                             (internal_state_if s')"
+     scheduler_affects_equiv initial_aag (label_for_partition u)
+                             (internal_state_if s) (internal_state_if s')"
   assumes imodes: "interrupted_modes (sys_mode_of s) = interrupted_modes (sys_mode_of s')"
   assumes smodes: "scheduler_modes (sys_mode_of s) = scheduler_modes (sys_mode_of s')"
-  assumes dom_context:"
-   (reads_scheduler_cur_domain initial_aag (label_for_partition u) (internal_state_if s) \<longrightarrow>
-     (user_modes (sys_mode_of s) \<longrightarrow> user_context_of s = user_context_of s') \<and>
-     sys_mode_of s = sys_mode_of s')"
+  assumes dom_context:
+    "reads_scheduler_cur_domain initial_aag (label_for_partition u) (internal_state_if s)
+     \<longrightarrow> (user_modes (sys_mode_of s) \<longrightarrow> user_context_of s = user_context_of s') \<and>
+         sys_mode_of s = sys_mode_of s'"
   shows "(s,s') \<in> uwr u"
   apply (case_tac u)
    prefer 2
@@ -4092,11 +3641,10 @@ lemma scheduler_affects_equiv_uwr:
      apply (simp add: schedeq imodes smodes)+
   apply (insert schedeq dom_context)
   apply (case_tac "reads_scheduler_cur_domain initial_aag (label_for_partition u) (internal_state_if s)")
-   apply simp
+   apply clarsimp
    apply (frule_tac s="internal_state_if s" and mode="sys_mode_of s" and uc="user_context_of s"
                 and uc'="user_context_of s'" and aag="initial_aag"
-                 in schedule_reads_affects_equiv_sameFor,
-          simp)
+                 in schedule_reads_affects_equiv_sameFor, simp, simp)
    apply (simp add: uwr_def user_context_of_def sys_mode_of_def)
    apply (case_tac s)
    apply fastforce
@@ -4113,21 +3661,46 @@ lemma scheduler_affects_equiv_uwr:
   apply metis
   done
 
-
 lemma cur_domain_reads:
-  "(s,s') \<in> uwr u \<Longrightarrow>
-   reads_scheduler_cur_domain initial_aag (label_for_partition u) (internal_state_if s) \<Longrightarrow>
-    (user_modes (sys_mode_of s) \<longrightarrow> user_context_of s = user_context_of s') \<and>
-    sys_mode_of s = sys_mode_of s'"
-  apply (case_tac u)
-  apply (auto simp: reads_scheduler_def uwr_def sameFor_def sameFor_subject_def)
-  done
+  "(s,s') \<in> uwr u
+   \<Longrightarrow> reads_scheduler_cur_domain initial_aag (label_for_partition u) (internal_state_if s)
+   \<Longrightarrow> (user_modes (sys_mode_of s) \<longrightarrow> user_context_of s = user_context_of s') \<and>
+       sys_mode_of s = sys_mode_of s'"
+  by (cases u) (auto simp: reads_scheduler_def uwr_def sameFor_def sameFor_subject_def)
 
 lemmas domain_can_read_context = cur_domain_reads[THEN conjunct1]
 lemmas domain_can_read_context' = cur_domain_reads[OF uwr_sym, THEN conjunct1]
-
 lemmas domain_can_read_sys_mode = cur_domain_reads[THEN conjunct2]
 lemmas domain_can_read_sys_mode' = cur_domain_reads[OF uwr_sym, THEN conjunct2]
+
+lemma equiv_valid_2E:
+  assumes ev: "equiv_valid_2 I A B R P P' f g"
+  assumes f: "(a,s') \<in> fst (f s)"
+  assumes g: "(b,t') \<in> fst (g t)"
+  assumes I: "I s t \<and> A s t"
+  assumes P: "P s"
+  assumes P': "P' t"
+  assumes Q: "I s' t' \<Longrightarrow> B s' t' \<Longrightarrow> R a b \<Longrightarrow> S"
+  shows S
+  apply (insert ev)
+  apply (clarsimp simp: equiv_valid_2_def)
+  apply (drule_tac x=s in spec)
+  apply (drule_tac x=t in spec)
+  apply (simp add: I P P')
+  apply (drule bspec[OF _ f],simp)
+  apply (drule bspec[OF _ g],simp)
+  apply (rule Q,simp+)
+  done
+
+lemma ev2_sym:
+  assumes symI: "\<And>x y. I x y \<Longrightarrow> I y x"
+  assumes symA: "\<And>x y. A x y \<Longrightarrow> A y x"
+  assumes symB: "\<And>x y. B x y \<Longrightarrow> B y x"
+  assumes symR: "\<And>x y. R x y \<Longrightarrow> R' y x"
+  shows "equiv_valid_2 I A B R P' P f' f \<Longrightarrow> equiv_valid_2 I A B R' P P' f f'"
+  apply (clarsimp simp: equiv_valid_2_def)
+  apply (blast intro: symA symB symI symR)
+  done
 
 lemma scheduler_step_1_confidentiality:
   notes blob = invs_if_def Invs_def sys_mode_of_def
@@ -4135,14 +3708,12 @@ lemma scheduler_step_1_confidentiality:
                domain_can_read_context domain_can_read_context'
                domain_can_read_sys_mode'[simplified sys_mode_of_def]
                domain_can_read_sys_mode[simplified sys_mode_of_def]
-
   assumes uwr: "(s,t) \<in> uwr PSched"  "(s,t) \<in> uwr u"
   assumes step_s: "(s,s') \<in> data_type.Step (ADT_A_if utf) ()"
   assumes step_t: "(t,t') \<in> data_type.Step (ADT_A_if utf) ()"
   assumes reach_s: "system.reachable (ADT_A_if utf) s0 s"
   assumes reach_t: "system.reachable (ADT_A_if utf) s0 t"
-  shows "\<lbrakk>interrupted_modes (sys_mode_of s)\<rbrakk> \<Longrightarrow>
-       (s',t') \<in> uwr u"
+  shows "interrupted_modes (sys_mode_of s) \<Longrightarrow> (s',t') \<in> uwr u"
   supply [[simp_depth_limit=2]] \<comment> \<open>speedup\<close>
   apply (insert uwr step_s step_t)
   apply (cut_tac ADT_A_if_reachable_invs_if[OF reach_s])
@@ -4153,28 +3724,24 @@ lemma scheduler_step_1_confidentiality:
    apply (rule_tac s=s and s'=s' in interrupt_step,simp_all)
     apply (rule_tac s=t and s'=t' in interrupt_step,simp_all)
      apply (rule equiv_valid_2E[where s="internal_state_if s" and t="internal_state_if t",
-                                OF kernel_entry_scheduler_equiv_2[
-                                         where aag="initial_aag" and st="s0_internal"
-                                           and st'="s0_internal" and l="label_for_partition u",
-                                         OF domains_distinct]],
-            assumption,assumption)
+                                OF kernel_entry_scheduler_equiv_2
+                                     [where aag="initial_aag" and st="s0_internal"
+                                        and st'="s0_internal" and l="label_for_partition u",
+                                      OF domains_distinct]], assumption, assumption)
         apply (rule uwr_scheduler_affects_equiv,assumption+)
        apply ((clarsimp simp: blob)+)[2]
      apply (rule scheduler_affects_equiv_uwr,simp+)
      apply (clarsimp simp: blob)
-    apply (rule
-      equiv_valid_2E[
-        where s="internal_state_if s" and t="internal_state_if t",
-        OF ev2_sym[
-          where R'="\<lambda>r r'. r' = user_context_of t \<and> snd r = user_context_of s",
-          OF _ _ _ _
-             preemption_interrupt_scheduler_invisible[
-               where aag="initial_aag" and st="s0_internal" and st'="s0_internal" and
-                     uc="user_context_of t" and uc'="user_context_of s" and
-                     l="label_for_partition u",
-               OF domains_distinct],
-          OF scheduler_equiv_sym scheduler_affects_equiv_sym scheduler_affects_equiv_sym,
-          simplified]])
+    apply (rule equiv_valid_2E
+                  [where s="internal_state_if s" and t="internal_state_if t",
+                   OF ev2_sym[where R'="\<lambda>r r'. r' = user_context_of t \<and> snd r = user_context_of s",
+                              OF _ _ _ _ preemption_interrupt_scheduler_invisible
+                                           [where aag="initial_aag" and st="s0_internal"
+                                              and st'="s0_internal" and l="label_for_partition u"
+                                              and uc="user_context_of t" and uc'="user_context_of s",
+                                           OF domains_distinct],
+                              OF scheduler_equiv_sym scheduler_affects_equiv_sym
+                                 scheduler_affects_equiv_sym, simplified]])
          apply (fastforce+)[2]
        apply (rule uwr_scheduler_affects_equiv,assumption+)
       (* FIXME: manual frule *)
@@ -4198,11 +3765,10 @@ lemma scheduler_step_1_confidentiality:
    apply (rule_tac s=t and s'=t' in interrupt_step,simp_all)
     apply (rule equiv_valid_2E[where s="internal_state_if s" and t="internal_state_if t",
                                OF preemption_interrupt_scheduler_invisible
-                                             [where aag="initial_aag" and st="s0_internal"
-                                                and st'="s0_internal" and uc="user_context_of s"
-                                                and l="label_for_partition u",
-                                              OF domains_distinct]],
-           assumption,assumption)
+                                    [where aag="initial_aag" and st="s0_internal"
+                                       and st'="s0_internal" and uc="user_context_of s"
+                                       and l="label_for_partition u", OF domains_distinct]],
+           assumption, assumption)
        apply (rule uwr_scheduler_affects_equiv,assumption+)
       (* FIXME: also clean up here *)
       apply (clarsimp simp: blob)
@@ -4224,10 +3790,9 @@ lemma scheduler_step_1_confidentiality:
     apply (clarsimp simp: blob)
    apply (rule equiv_valid_2E[where s="internal_state_if s" and t="internal_state_if t",
                               OF handle_preemption_reads_respects_scheduler_2
-                                        [where aag="initial_aag" and st="s0_internal"
-                                           and st'="s0_internal" and l="label_for_partition u",
-                                         OF domains_distinct]],
-          assumption,assumption)
+                                   [where aag="initial_aag" and st="s0_internal"
+                                      and st'="s0_internal" and l="label_for_partition u",
+                                    OF domains_distinct]], assumption, assumption)
       apply (rule uwr_scheduler_affects_equiv,assumption+)
      apply ((clarsimp simp: blob)+)[2]
    apply (rule scheduler_affects_equiv_uwr,simp+)
@@ -4235,88 +3800,56 @@ lemma scheduler_step_1_confidentiality:
   apply (clarsimp simp add: sameFor_def sameFor_scheduler_def uwr_def)
   done
 
-lemma schedule_if_context: "\<lbrace>\<top>\<rbrace> schedule_if tc \<lbrace>\<lambda>r s. r = tc\<rbrace>"
+end
+
+
+lemma schedule_if_context:
+  "\<lbrace>\<top>\<rbrace> schedule_if tc \<lbrace>\<lambda>r s. r = tc\<rbrace>"
   apply (simp add: schedule_if_def)
   apply (wp | simp)+
   done
 
-
-
-
 lemma schedule_step:
   assumes schedule:
-    "\<And>r. (r,internal_state_if s') \<in> fst (schedule_if (user_context_of s) (internal_state_if s))
-     \<Longrightarrow> (sys_mode_of s' = KernelExit) \<Longrightarrow> r = user_context_of s \<Longrightarrow> r = user_context_of s'  \<Longrightarrow> P"
-  shows "(sys_mode_of s) = KernelSchedule True \<Longrightarrow> (s,s') \<in> data_type.Step (ADT_A_if utf) () \<Longrightarrow> P"
+    "\<And>r. \<lbrakk> (r,internal_state_if s') \<in> fst (schedule_if (user_context_of s) (internal_state_if s));
+            sys_mode_of s' = KernelExit; r = user_context_of s; r = user_context_of s' \<rbrakk>
+            \<Longrightarrow> P"
+  shows
+    "\<lbrakk> (sys_mode_of s) = KernelSchedule True; (s,s') \<in> data_type.Step (ADT_A_if utf) () \<rbrakk>
+       \<Longrightarrow> P"
   apply (insert schedule)
   apply atomize
-  apply(case_tac s, clarsimp)
-  apply(rename_tac uc i_s)
-       apply (simp_all add: system.Step_def execution_def steps_def ADT_A_if_def
-                            global_automaton_if_def kernel_schedule_if_def
-             | safe |clarsimp)+
-       apply (frule use_valid[OF _ schedule_if_context],simp+)+
+  apply (case_tac s, clarsimp)
+  apply (rename_tac uc i_s)
+  apply (simp_all add: system.Step_def execution_def steps_def ADT_A_if_def
+                       global_automaton_if_def kernel_schedule_if_def
+         | safe | clarsimp)+
+   apply (frule use_valid[OF _ schedule_if_context], simp+)+
   done
-
-
 
 lemma schedule_if_reads_respects_scheduler:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_scheduler aag l
-   (einvs and pas_refined aag and silc_inv aag st and guarded_pas_domain aag and
-    tick_done)
-   (schedule_if uc)"
+  shows "reads_respects_scheduler aag l
+           (einvs and pas_refined aag and silc_inv aag st and guarded_pas_domain aag and tick_done)
+           (schedule_if uc)"
   apply (simp add: schedule_if_def)
-  apply (wp schedule_reads_respects_scheduler
-            schedule_guarded_pas_domain)
+  apply (wp schedule_reads_respects_scheduler schedule_guarded_pas_domain)
   apply fastforce
   done
 
 lemma schedule_if_agnostic_tc:
-  "\<forall>P Q uc uc'. \<lbrace>P\<rbrace> schedule_if uc \<lbrace>\<lambda>_. Q\<rbrace> \<longrightarrow> \<lbrace>P\<rbrace> schedule_if uc' \<lbrace>\<lambda>_.Q\<rbrace>"
+  "\<forall>P Q uc uc'. \<lbrace>P\<rbrace> schedule_if uc \<lbrace>\<lambda>_. Q\<rbrace> \<longrightarrow> \<lbrace>P\<rbrace> schedule_if uc' \<lbrace>\<lambda>_. Q\<rbrace>"
   apply (clarsimp simp add: schedule_if_def bind_assoc[symmetric])
   apply (erule bind_return_ign)
   done
 
 
-lemmas schedule_if_reads_respects_scheduler_2 =
-              agnostic_to_ev2[OF schedule_if_agnostic_tc schedule_if_context
-                                 schedule_if_reads_respects_scheduler]
-
-
-
-lemma scheduler_step_2_confidentiality:
-  notes blob = invs_if_def Invs_def sys_mode_of_def silc_inv_cur pas_refined_cur
-               guarded_pas_domain_cur internal_state_s0 tick_done_def
-  assumes uwr: "(s,t) \<in> uwr PSched" "(s,t) \<in> uwr u"
-  assumes step_s: "(s,s') \<in> data_type.Step (ADT_A_if utf) ()"
-  assumes step_t: "(t,t') \<in> data_type.Step (ADT_A_if utf) ()"
-  assumes reach_s: "system.reachable (ADT_A_if utf) s0 s"
-  assumes reach_t: "system.reachable (ADT_A_if utf) s0 t"
-  shows "\<lbrakk> (sys_mode_of s) = KernelSchedule True;
-       (sys_mode_of t) = KernelSchedule True\<rbrakk> \<Longrightarrow>
-       (s',t') \<in> uwr u"
-  apply (insert uwr step_s step_t)
-  apply (rule_tac s=s and s'=s' in schedule_step,simp_all)
-  apply (rule_tac s=t and s'=t' in schedule_step,simp_all)
-    apply (cut_tac ADT_A_if_reachable_invs_if[OF reach_s])
-  apply (cut_tac ADT_A_if_reachable_invs_if[OF reach_t])
-  apply (rule equiv_valid_2E[where s="internal_state_if s" and t="internal_state_if t",
-                             OF schedule_if_reads_respects_scheduler_2
-                                            [where aag="initial_aag" and st="s0_internal"
-                                               and l="label_for_partition u",
-                                             OF domains_distinct]],
-         assumption,assumption)
-      apply (rule uwr_scheduler_affects_equiv,simp+)
-    apply ((clarsimp simp: blob)+)[2]
-    apply (rule scheduler_affects_equiv_uwr,simp+)
-  done
+context valid_initial_state begin
 
 lemma step_from_interrupt_to_schedule:
-  "\<lbrakk>(s', evs) \<in> sub_big_steps (ADT_A_if utf) big_step_R s; evs \<noteq> [];
-       interrupted_modes (sys_mode_of s)\<rbrakk> \<Longrightarrow>
-    (s,s') \<in> data_type.Step (ADT_A_if utf) () \<and> (sys_mode_of s') = KernelSchedule True"
+  "\<lbrakk> (s', evs) \<in> sub_big_steps (ADT_A_if utf) big_step_R s;
+     evs \<noteq> []; interrupted_modes (sys_mode_of s) \<rbrakk>
+     \<Longrightarrow> (s,s') \<in> data_type.Step (ADT_A_if utf) () \<and> (sys_mode_of s') = KernelSchedule True"
   apply (induct rule: sub_big_steps.induct)
    apply simp
   apply (case_tac "evlist'")
@@ -4332,7 +3865,6 @@ lemma step_from_interrupt_to_schedule:
   apply (simp add: big_step_R_def sys_mode_of_def)
   done
 
-
 lemma scheduler_steps:
   assumes big_step: "(s,s'') \<in> data_type.Step (big_step_ADT_A_if utf) ()"
   assumes interrupted: "part s = PSched"
@@ -4344,9 +3876,9 @@ lemma scheduler_steps:
   apply (simp add: big_steps.simps)
   apply clarsimp
   apply (subgoal_tac "interrupted_modes (sys_mode_of s)")
-  prefer 2
-  apply (clarsimp simp add: big_step_R_def part_def sys_mode_of_def split: if_split_asm)
-  apply (case_tac "snd s",simp_all)
+   prefer 2
+   apply (clarsimp simp add: big_step_R_def part_def sys_mode_of_def split: if_split_asm)
+   apply (case_tac "snd s",simp_all)
   apply (case_tac "as = []")
 
    apply (erule sub_big_steps.cases)
@@ -4356,85 +3888,110 @@ lemma scheduler_steps:
   apply (frule step_from_interrupt_to_schedule)
   by clarsimp+
 
-
-lemma reachable_tranclp_R:
-  assumes b:"system.reachable (big_step_ADT_A_if utf) s0 s"
-  shows "big_step_R\<^sup>*\<^sup>* s0 s"
-  (* repeated lemma *)
-  by (rule big_step_R_rtranclp[OF b])
-
-lemma PSched_reachable_interrupted: "part s = PSched \<Longrightarrow>
-       system.reachable (big_step_ADT_A_if utf) s0 s \<Longrightarrow>
-       interrupted_modes (sys_mode_of s)"
-  apply (drule reachable_tranclp_R)
-  apply (drule  tranclp_s0)
+lemma PSched_reachable_interrupted:
+  "\<lbrakk> part s = PSched; system.reachable (big_step_ADT_A_if utf) s0 s \<rbrakk>
+     \<Longrightarrow> interrupted_modes (sys_mode_of s)"
+  apply (drule big_step_R_rtranclp)
+  apply (drule tranclp_s0)
   apply (clarsimp simp add: part_def sys_mode_of_def split: if_split_asm)
   done
 
-lemma confidentiality_part_sched_transition:
-    "\<lbrakk>(s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
-      system.reachable (big_step_ADT_A_if utf) s0 s;
-      system.reachable (big_step_ADT_A_if utf) s0 t;
-      (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
-      (t, t') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
-      (part s, u) \<in> policyFlows (pasPolicy initial_aag);
-      part s = PSched\<rbrakk> \<Longrightarrow>
-     (s', t') \<in> uwr u"
-  apply (frule part_equiv)
-  apply (case_tac "part s = PSched")
-   apply simp
-   apply (erule scheduler_steps,assumption+)
-   apply (erule scheduler_steps,simp)
-   apply (frule(3) scheduler_step_1_confidentiality[where u=PSched])
-      apply (erule small_step_reachable)+
-    apply (rule PSched_reachable_interrupted,simp+)
-   apply (frule(3) scheduler_step_1_confidentiality[where u=u])
-      apply (erule small_step_reachable)+
-    apply (rule PSched_reachable_interrupted,simp+)
-   apply (frule_tac s="s'a" and t="s'aa" and u=u in scheduler_step_2_confidentiality,
-          assumption,assumption,assumption)
-       apply (rule Step_system.reachable_Step[OF ADT_A_if_Step_system _ Step_ADT_A_if''])
-         apply (erule small_step_reachable,simp)
-       apply (erule small_step_reachable)
-      apply (rule Step_system.reachable_Step[OF ADT_A_if_Step_system _ Step_ADT_A_if''])
-        apply (erule small_step_reachable,simp)
-      apply (erule small_step_reachable)
-     apply simp+
- done
-
-
-(*If we're starting a non_schedule partition then we must have just
-  exited*)
-lemma reachable_nonsched_exit: "system.reachable (big_step_ADT_A_if utf) s0 s \<Longrightarrow>
-       part s \<noteq> PSched \<Longrightarrow> (snd s) = KernelExit"
-  apply (drule reachable_tranclp_R)
+(*If we're starting a non_schedule partition then we must have just exited*)
+lemma reachable_nonsched_exit:
+  "\<lbrakk> system.reachable (big_step_ADT_A_if utf) s0 s; part s \<noteq> PSched \<rbrakk>
+     \<Longrightarrow> (snd s) = KernelExit"
+  apply (drule big_step_R_rtranclp)
   apply (drule tranclp_s0)
   apply (clarsimp simp add: part_def split: if_split_asm)
   apply (case_tac s)
   apply simp
   apply (simp add: sys_mode_of_def)
-  apply (case_tac b)
-       apply simp+
+  apply (case_tac b; simp)
   done
-
-
 
 lemma silc_dom_equiv_current_aag:
   "silc_dom_equiv (current_aag s) st s' = silc_dom_equiv initial_aag st s'"
-  apply (simp add: silc_dom_equiv_def pasObjectAbs_current_aag)
+  by (simp add: silc_dom_equiv_def pasObjectAbs_current_aag)
+
+end
+
+
+lemmas schedule_if_reads_respects_scheduler_2 =
+  agnostic_to_ev2[OF schedule_if_agnostic_tc schedule_if_context
+                     schedule_if_reads_respects_scheduler]
+
+lemma big_Step2:
+  "(s,s') \<in> system.Step (big_step_ADT_A_if utf) u \<Longrightarrow>
+   (s,s') \<in> Simulation.Step (big_step_ADT_A_if utf) u"
+  apply (simp add: system.Step_def execution_def big_step_ADT_A_if_def
+                   big_step_adt_def ADT_A_if_def steps_def)
+  apply blast
   done
 
 
+context Noninterference_valid_initial_state begin
+
+lemma scheduler_step_2_confidentiality:
+  notes blob = invs_if_def Invs_def sys_mode_of_def silc_inv_cur pas_refined_cur
+               guarded_pas_domain_cur internal_state_s0 tick_done_def
+  assumes uwr: "(s,t) \<in> uwr PSched" "(s,t) \<in> uwr u"
+  assumes step_s: "(s,s') \<in> data_type.Step (ADT_A_if utf) ()"
+  assumes step_t: "(t,t') \<in> data_type.Step (ADT_A_if utf) ()"
+  assumes reach_s: "system.reachable (ADT_A_if utf) s0 s"
+  assumes reach_t: "system.reachable (ADT_A_if utf) s0 t"
+  shows "\<lbrakk> (sys_mode_of s) = KernelSchedule True; (sys_mode_of t) = KernelSchedule True \<rbrakk>
+           \<Longrightarrow> (s',t') \<in> uwr u"
+  apply (insert uwr step_s step_t)
+  apply (rule_tac s=s and s'=s' in schedule_step,simp_all)
+  apply (rule_tac s=t and s'=t' in schedule_step,simp_all)
+  apply (cut_tac ADT_A_if_reachable_invs_if[OF reach_s])
+  apply (cut_tac ADT_A_if_reachable_invs_if[OF reach_t])
+  apply (rule equiv_valid_2E[where s="internal_state_if s" and t="internal_state_if t",
+                             OF schedule_if_reads_respects_scheduler_2
+                                  [where aag="initial_aag" and st="s0_internal"
+                                     and l="label_for_partition u", OF domains_distinct]],
+         assumption,assumption)
+     apply (rule uwr_scheduler_affects_equiv,simp+)
+    apply ((clarsimp simp: blob)+)[2]
+  apply (rule scheduler_affects_equiv_uwr,simp+)
+  done
+
+lemma confidentiality_part_sched_transition:
+  "\<lbrakk> (s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
+     system.reachable (big_step_ADT_A_if utf) s0 s; system.reachable (big_step_ADT_A_if utf) s0 t;
+     (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
+     (t, t') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
+     (part s, u) \<in> policyFlows (pasPolicy initial_aag); part s = PSched \<rbrakk>
+     \<Longrightarrow> (s', t') \<in> uwr u"
+  apply (frule schedIncludesCurrentDom)
+  apply (case_tac "part s = PSched")
+   apply simp
+   apply (erule scheduler_steps, assumption+)
+   apply (erule scheduler_steps, simp)
+   apply (frule (3) scheduler_step_1_confidentiality[where u=PSched])
+      apply (erule small_step_reachable)+
+    apply (rule PSched_reachable_interrupted,simp+)
+   apply (frule (3) scheduler_step_1_confidentiality[where u=u])
+      apply (erule small_step_reachable)+
+    apply (rule PSched_reachable_interrupted,simp+)
+   apply (frule_tac s="s'a" and t="s'aa" and u=u in scheduler_step_2_confidentiality,
+          assumption, assumption, assumption)
+       apply (rule Step_system.reachable_Step[OF ADT_A_if_Step_system _ Step_ADT_A_if''])
+         apply (erule small_step_reachable, simp)
+       apply (erule small_step_reachable)
+      apply (rule Step_system.reachable_Step[OF ADT_A_if_Step_system _ Step_ADT_A_if''])
+        apply (erule small_step_reachable, simp)
+      apply (erule small_step_reachable)
+     apply simp+
+  done
 
 lemma confidentiality_for_sched:
-  "\<lbrakk>(s, t) \<in> uwr PSched;
-    system.reachable (big_step_ADT_A_if utf) s0 s;
-    system.reachable (big_step_ADT_A_if utf) s0 t;
-    (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
-    (t, t') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
-    part s \<noteq> PSched\<rbrakk> \<Longrightarrow>
-  (s', t') \<in> uwr PSched"
-  apply (frule part_equiv)
+  "\<lbrakk> (s, t) \<in> uwr PSched;
+     system.reachable (big_step_ADT_A_if utf) s0 s; system.reachable (big_step_ADT_A_if utf) s0 t;
+     (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
+     (t, t') \<in> Simulation.Step (big_step_ADT_A_if utf) (); part s \<noteq> PSched \<rbrakk>
+     \<Longrightarrow> (s', t') \<in> uwr PSched"
+  apply (frule schedIncludesCurrentDom)
   apply (frule_tac s=s in reachable_nonsched_exit,assumption)
   apply (frule_tac s=t in reachable_nonsched_exit,simp)
   apply (frule_tac s=s and s'=s' in Step_partitionIntegrity,simp+)
@@ -4476,62 +4033,48 @@ lemma confidentiality_for_sched:
   apply (erule big_stepsE)
   apply (erule big_stepsE)
   apply (simp add: big_step_R_def)
-  apply (case_tac baa,simp_all)
-   apply (case_tac bca,simp_all)
-  apply (case_tac bca,simp_all)
- done
-
-
-
-lemma confidentiality_part:
-  "\<lbrakk>(s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
-    system.reachable (big_step_ADT_A_if utf) s0 s;
-    system.reachable (big_step_ADT_A_if utf) s0 t;
-    (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
-    (t, t') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
-    (part s, u) \<in> policyFlows (pasPolicy initial_aag);
-    u = PSched \<longrightarrow> part s = PSched\<rbrakk> \<Longrightarrow>
-   (s', t') \<in> uwr u"
-  apply (frule part_equiv)
-  apply (case_tac "part s = PSched")
-   apply(fastforce intro:  confidentiality_part_sched_transition)
-  apply(fastforce intro: confidentiality_part_not_PSched[rule_format])
+  apply (case_tac baa, simp_all)
+   apply (case_tac bca, simp_all)
+  apply (case_tac bca, simp_all)
   done
 
-lemma big_Step2:
-  "(s,s') \<in> system.Step (big_step_ADT_A_if utf) u \<Longrightarrow>
-   (s,s') \<in> Simulation.Step (big_step_ADT_A_if utf) u"
-  apply(simp add: system.Step_def execution_def big_step_ADT_A_if_def big_step_adt_def
-                  ADT_A_if_def steps_def)
-  apply blast
+lemma confidentiality_part:
+  "\<lbrakk> (s, t) \<in> uwr PSched; (s, t) \<in> uwr (part s); (s, t) \<in> uwr u;
+     system.reachable (big_step_ADT_A_if utf) s0 s; system.reachable (big_step_ADT_A_if utf) s0 t;
+     (s, s') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
+     (t, t') \<in> Simulation.Step (big_step_ADT_A_if utf) ();
+     (part s, u) \<in> policyFlows (pasPolicy initial_aag); u = PSched \<longrightarrow> part s = PSched \<rbrakk>
+     \<Longrightarrow> (s', t') \<in> uwr u"
+  apply (frule schedIncludesCurrentDom)
+  apply (case_tac "part s = PSched")
+   apply (fastforce intro: confidentiality_part_sched_transition)
+  apply (fastforce intro: confidentiality_part_not_PSched[rule_format])
   done
 
 lemma confidentiality_u:
   notes split_paired_All[simp del]
-  shows
-  "ni.confidentiality_u"
-  apply(simp add: ni.confidentiality_u_def | intro allI impI | elim conjE)+
-  apply(case_tac "(part s, u) \<in> policyFlows (pasPolicy initial_aag)")
-   apply(simp)
-   apply(fastforce intro: confidentiality_part schedNotGlobalChannel simp: big_Step2)
-  apply(case_tac "u = PSched")
-   apply(subgoal_tac "part s \<noteq> PSched")
-    apply(blast intro: confidentiality_for_sched big_Step2)
-   apply(fastforce intro: policyFlows_refl[THEN refl_onD])
-  apply(metis integrity_part ni.uwr_sym ni.uwr_trans ni.schedIncludesCurrentDom not_PSched big_Step2)
+  shows "ni.confidentiality_u"
+  apply (simp add: ni.confidentiality_u_def | intro allI impI | elim conjE)+
+  apply (case_tac "(part s, u) \<in> policyFlows (pasPolicy initial_aag)")
+   apply (simp)
+   apply (fastforce intro: confidentiality_part schedNotGlobalChannel simp: big_Step2)
+  apply (case_tac "u = PSched")
+   apply (subgoal_tac "part s \<noteq> PSched")
+    apply (blast intro: confidentiality_for_sched big_Step2)
+   apply (fastforce intro: policyFlows_refl[THEN refl_onD])
+  apply (metis integrity_part uwr_sym uwr_trans schedIncludesCurrentDom not_PSched big_Step2)
   done
 
 (* TOPLEVEL *)
 lemma nonleakage:
   "ni.Nonleakage_gen"
-  apply(rule Nonleakage_gen[OF confidentiality_u])
+  apply (rule Nonleakage_gen[OF confidentiality_u])
   done
-
 
 (* TOPLEVEL *)
 lemma xnonleakage:
   "ni.xNonleakage_gen"
-  apply(rule xNonleakage_gen[OF confidentiality_u])
+  apply (rule xNonleakage_gen[OF confidentiality_u])
   done
 
 end

--- a/proof/infoflow/Noninterference.thy
+++ b/proof/infoflow/Noninterference.thy
@@ -424,7 +424,7 @@ lemma ct_running_not_idle:
   by (clarsimp simp add: ct_in_state_def pred_tcb_at_def obj_at_def valid_idle_def)
 
 lemma kernel_entry_if_globals_equiv_scheduler:
-  "\<lbrace>globals_equiv_scheduler st and valid_ko_at_arch and invs
+  "\<lbrace>globals_equiv_scheduler st and valid_arch_state and invs
                                and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)
                                and (\<lambda>s. ct_idle s \<longrightarrow> tc = idle_context s)\<rbrace>
    kernel_entry_if e tc
@@ -467,7 +467,7 @@ lemma kernel_entry_if_partitionIntegrity:
     apply (wp kernel_entry_silc_inv[where st'=st'], simp add: schact_is_rct_simple)
    apply (fastforce simp: pas_refined_pasMayActivate_update pas_refined_pasMayEditReadyQueues_update
                           globals_equiv_scheduler_refl silc_dom_equiv_def equiv_for_refl
-                          invs_valid_ko_at_arch domain_fields_equiv_def ct_active_not_idle')
+                          domain_fields_equiv_def ct_active_not_idle')
   apply (fastforce simp: partitionIntegrity_def)
   done
 
@@ -525,7 +525,7 @@ lemma pas_refined_pasMayActivate_update[simp]:
   done
 
 lemma activate_thread_globals_equiv_scheduler:
-  "\<lbrace>globals_equiv_scheduler st and valid_ko_at_arch and valid_idle\<rbrace>
+  "\<lbrace>globals_equiv_scheduler st and valid_arch_state and valid_idle\<rbrace>
    activate_thread
    \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
   by (wp globals_equiv_scheduler_inv' activate_thread_globals_equiv | force | fastforce)+
@@ -587,7 +587,7 @@ lemma schedule_if_partitionIntegrity:
                silc_dom_equiv_from_silc_inv_valid'[where P="\<top>" and st=st]
                domain_fields_equiv_lift schedule_cur_domain schedule_domain_fields
             | simp add: silc_inv_def partitionIntegrity_def guarded_pas_domain_def
-                        invs_valid_idle invs_valid_ko_at_arch silc_dom_equiv_def)+
+                        invs_valid_idle silc_dom_equiv_def)+
     apply (fastforce simp: equiv_for_refl dest: domains_distinct[THEN pas_domains_distinct_inj])
    apply (fastforce simp: partitionIntegrity_def globals_equiv_scheduler_def)+
   done
@@ -1946,7 +1946,7 @@ end
 lemma set_thread_state_runnable_reads_respects_g:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows "reads_respects_g aag (l :: 'a subject_label)
-                          (valid_ko_at_arch and K (runnable ts)) (set_thread_state t ts)"
+                          (valid_arch_state and K (runnable ts)) (set_thread_state t ts)"
   apply (rule gen_asm_ev)
   apply (rule equiv_valid_guard_imp)
    apply (rule reads_respects_g[OF set_thread_state_runnable_reads_respects[OF domains_distinct]])
@@ -2032,12 +2032,12 @@ lemma activate_thread_reads_respects_g:
   apply (rule conjI)
    apply (blast intro: requiv_g_cur_thread_eq)
   apply (frule invs_valid_idle)
-  apply (simp add: invs_valid_ko_at_arch)
+  apply simp
   apply (rule conjI)
    apply blast
   apply (rule impI)
   apply (clarsimp simp: pred_tcb_at_def obj_at_def valid_idle_def)
-  apply (fastforce simp: invs_valid_ko_at_arch det_getRestartPC)
+  apply (fastforce simp: det_getRestartPC)
   done
 
 lemma cur_thread_update_reads_respects_g':

--- a/proof/infoflow/Noninterference_Base.thy
+++ b/proof/infoflow/Noninterference_Base.thy
@@ -19,69 +19,66 @@ text \<open>
 section \<open>Generic systems\<close>
 
 lemma un_eq:
-  "\<lbrakk>S = S'; T = T'\<rbrakk> \<Longrightarrow> S \<union> T = S' \<union> T'"
+  "\<lbrakk> S = S'; T = T' \<rbrakk> \<Longrightarrow> S \<union> T = S' \<union> T'"
   by auto
 
 lemma Un_eq:
-  "\<lbrakk>\<And> x y. \<lbrakk>x \<in> xs; y \<in> ys\<rbrakk> \<Longrightarrow> P x = Q y; \<exists> x. x \<in> xs; \<exists> y. y \<in> ys\<rbrakk>
-    \<Longrightarrow> (\<Union>x\<in>xs. P x) = (\<Union>y\<in>ys. Q y)"
+  "\<lbrakk> \<And>x y. \<lbrakk> x \<in> xs; y \<in> ys \<rbrakk> \<Longrightarrow> P x = Q y; \<exists>x. x \<in> xs; \<exists>y. y \<in> ys \<rbrakk>
+     \<Longrightarrow> (\<Union>x \<in> xs. P x) = (\<Union>y \<in> ys. Q y)"
   by auto
 
 lemma Int_eq:
-  "\<lbrakk>\<And> x y. \<lbrakk>x \<in> xs; y \<in> ys\<rbrakk> \<Longrightarrow> P x = Q y; \<exists> x. x \<in> xs; \<exists> y. y \<in> ys\<rbrakk>
-    \<Longrightarrow> (\<Inter>x\<in>xs. P x) = (\<Inter>y\<in>ys. Q y)"
+  "\<lbrakk> \<And>x y. \<lbrakk> x \<in> xs; y \<in> ys \<rbrakk> \<Longrightarrow> P x = Q y; \<exists>x. x \<in> xs; \<exists>y. y \<in> ys \<rbrakk>
+     \<Longrightarrow> (\<Inter>x \<in> xs. P x) = (\<Inter>y \<in> ys. Q y)"
   by auto
 
 lemma Un_eq_Int:
-  assumes ex: "\<exists> x. x \<in> xs"
-  assumes ey: "\<exists> y. y \<in> ys"
-  assumes a: "\<And> x y. \<lbrakk>x \<in> xs; y \<in> ys\<rbrakk> \<Longrightarrow> S x = S' y"
-  shows "(\<Union>x\<in>xs. S x) = (\<Inter>x\<in>ys. S' x)"
-  apply(rule equalityI)
-   apply(clarsimp)
-   apply(drule a, assumption, simp)
+  assumes ex: "\<exists>x. x \<in> xs"
+  assumes ey: "\<exists>y. y \<in> ys"
+  assumes a: "\<And>x y. \<lbrakk> x \<in> xs; y \<in> ys \<rbrakk> \<Longrightarrow> S x = S' y"
+  shows "(\<Union>x \<in> xs. S x) = (\<Inter>x \<in> ys. S' x)"
+  apply (rule equalityI)
+   apply (clarsimp)
+   apply (drule a, assumption, simp)
   apply clarsimp
-  apply(insert ex ey)
+  apply (insert ex ey)
   apply clarsimp
-  apply(frule a, assumption)
+  apply (frule a, assumption)
   apply fastforce
   done
+
 
 subsection\<open>Run function\<close>
 
-primrec Run :: "('e \<Rightarrow> ('s \<times> 's) set) \<Rightarrow> 'e list \<Rightarrow> ('s \<times> 's) set"
-where
-  "Run Stepf []     = Id" |
-  "Run Stepf (a#as) = Stepf a O Run Stepf as"
+primrec Run :: "('e \<Rightarrow> ('s \<times> 's) set) \<Rightarrow> 'e list \<Rightarrow> ('s \<times> 's) set" where
+  "Run Stepf []     = Id"
+| "Run Stepf (a#as) = Stepf a O Run Stepf as"
 
 
 lemma Run_mid[rule_format]:
-  shows
-  "(s,u) \<in> Run Stepf (as @ bs) \<longrightarrow> (\<exists> t. (s,t) \<in> Run Stepf as \<and> (t,u) \<in> Run Stepf bs)"
-  proof(induct as arbitrary: s u bs)
+  "(s,u) \<in> Run Stepf (as @ bs) \<longrightarrow> (\<exists>t. (s,t) \<in> Run Stepf as \<and> (t,u) \<in> Run Stepf bs)"
+proof (induct as arbitrary: s u bs)
   case Nil show ?case
-   apply(clarsimp)
-   done
-  next
+    by (clarsimp)
+next
   case (Cons a as) show ?case
-  apply(clarsimp simp: relcomp_def)
-  apply(drule "Cons.hyps"[rule_format])
-  apply fastforce
-  done
+    apply (clarsimp simp: relcomp_def)
+    apply (drule "Cons.hyps"[rule_format])
+    apply fastforce
+    done
 qed
 
 lemma Run_trans:
-  "\<lbrakk>(s,t) \<in> Run Stepf as; (t,u) \<in> Run Stepf bs\<rbrakk> \<Longrightarrow> (s,u) \<in> Run Stepf (as @ bs)"
+  "\<lbrakk> (s,t) \<in> Run Stepf as; (t,u) \<in> Run Stepf bs \<rbrakk>
+     \<Longrightarrow> (s,u) \<in> Run Stepf (as @ bs)"
   by (induct as arbitrary: bs s t u) auto
 
 lemma Run_app:
   "Run Stepf (as @ bs) = (Run Stepf as) O (Run Stepf bs)"
-  apply(rule equalityI)
-   apply(fastforce dest: Run_mid)
-  apply(fastforce intro: Run_trans)
+  apply (rule equalityI)
+   apply (fastforce dest: Run_mid)
+  apply (fastforce intro: Run_trans)
   done
-
-
 
 
 subsection \<open>Base system locale\<close>
@@ -93,28 +90,25 @@ locale system =
 begin
 
 (* State 's' is reachable from the initial state 's0'. *)
-definition reachable
-where
-  "reachable s \<equiv> \<exists> js. s \<in> execution A s0 js"
+definition reachable where
+  "reachable s \<equiv> \<exists>js. s \<in> execution A s0 js"
 
-definition Step
-where
+definition Step where
   "Step a \<equiv> {(s,s') . s' \<in> execution A s [a]}"
 
 (* The system is "observationally deterministic": that is, the
  * observable part of the system is always deterministic. *)
-definition obs_det
-where
-  "obs_det \<equiv> \<forall> s js. (\<exists> s'. execution A s js = {s'})"
+definition obs_det where
+  "obs_det \<equiv> \<forall>s js. (\<exists>s'. execution A s js = {s'})"
 
 lemmas obs_detD = obs_det_def[THEN meta_eq_to_obj_eq, THEN iffD1, rule_format]
 
 (* The abstraction/concretisation functions "Init"/"Fin"
  * don't abstract away information. *)
-definition no_abs
-where
-  "no_abs \<equiv> \<forall> x s as . reachable s \<longrightarrow> x \<in> steps (Simulation.Step A) (Init A s) as
-                        \<longrightarrow> Init A (Fin A x) = {x}"
+definition no_abs where
+  "no_abs \<equiv> \<forall>x s as . reachable s
+                       \<longrightarrow> x \<in> steps (Simulation.Step A) (Init A s) as
+                       \<longrightarrow> Init A (Fin A x) = {x}"
 
 lemmas no_absD = no_abs_def[THEN meta_eq_to_obj_eq, THEN iffD1, rule_format]
 
@@ -130,21 +124,21 @@ text\<open>
   is always an enabled transition from every reachable state.\<close>
 
 locale enabled_system = system +
-  assumes enabled: "(\<exists> js. s \<in> execution A s0 js) \<Longrightarrow> \<exists> s'. s' \<in> execution A s js"
+  assumes enabled: "(\<exists>js. s \<in> execution A s0 js) \<Longrightarrow> \<exists>s'. s' \<in> execution A s js"
 begin
 
 lemma reachable_enabled:
-  "reachable s \<Longrightarrow> \<exists> s'. s' \<in> execution A s js"
-  apply(simp add: reachable_def)
-  apply(erule enabled)
+  "reachable s \<Longrightarrow> \<exists>s'. s' \<in> execution A s js"
+  apply (simp add: reachable_def)
+  apply (erule enabled)
   done
 
 lemma enabled_Step:
-  "reachable s \<Longrightarrow> \<exists> s'. (s,s') \<in> Step a"
-  apply(simp add: Step_def, blast intro: reachable_enabled)
-  done
+  "reachable s \<Longrightarrow> \<exists>s'. (s,s') \<in> Step a"
+  by (simp add: Step_def, blast intro: reachable_enabled)
 
 end
+
 
 subsection \<open>Step system\<close>
 
@@ -164,8 +158,8 @@ begin
 
 lemma execution_Run':
   "s \<in> execution A s0 js \<Longrightarrow> execution A s as = {s'. (s,s') \<in> Run Step as}"
-  apply(rule execution_Run)
-  apply(fastforce simp: reachable_def)
+  apply (rule execution_Run)
+  apply (fastforce simp: reachable_def)
   done
 
 lemma reachable_Run:
@@ -182,33 +176,32 @@ lemma Run_reachable:
   apply blast
   done
 
-
 lemma reachable_execution:
-  "\<lbrakk>reachable s; s' \<in> execution A s js\<rbrakk> \<Longrightarrow> reachable s'"
-  apply(clarsimp simp: reachable_def)
-  apply(rule_tac x="jsa @ js" in exI)
-  apply(frule execution_Run'[where s=s and as=js])
-  apply(simp add: execution_Run[where s=s0, simplified reachable_s0])
-  apply(fastforce simp: Run_app)
+  "\<lbrakk> reachable s; s' \<in> execution A s js \<rbrakk> \<Longrightarrow> reachable s'"
+  apply (clarsimp simp: reachable_def)
+  apply (rule_tac x="jsa @ js" in exI)
+  apply (frule execution_Run'[where s=s and as=js])
+  apply (simp add: execution_Run[where s=s0, simplified reachable_s0])
+  apply (fastforce simp: Run_app)
   done
 
 lemma reachable_Step:
-  "\<lbrakk>reachable s; (s,s') \<in> Step a\<rbrakk> \<Longrightarrow> reachable s'"
-  apply(erule reachable_execution)
-  apply(simp add: Step_def)
+  "\<lbrakk> reachable s; (s,s') \<in> Step a \<rbrakk> \<Longrightarrow> reachable s'"
+  apply (erule reachable_execution)
+  apply (simp add: Step_def)
   done
 
 lemma reachable_induct_helper:
-  assumes a:
-    "\<And>s s' a. \<lbrakk>reachable s; P s; (s, s') \<in> Step a\<rbrakk> \<Longrightarrow> P s'"
-  shows "\<lbrakk>(s0, s1) \<in> Run Step as; P s0\<rbrakk> \<Longrightarrow> P s1"
+  assumes a: "\<And>s s' a. \<lbrakk> reachable s; P s; (s, s') \<in> Step a \<rbrakk> \<Longrightarrow> P s'"
+  shows "\<lbrakk> (s0, s1) \<in> Run Step as; P s0 \<rbrakk> \<Longrightarrow> P s1"
   apply (induct as arbitrary: s1 rule: rev_induct)
    apply simp
-  apply(fastforce dest: Run_mid intro: a Run_reachable)
+  apply (fastforce dest: Run_mid intro: a Run_reachable)
   done
 
 lemma reachable_induct:
-  "\<lbrakk>(\<And>s s' a. reachable s \<Longrightarrow> (s,s') \<in> (Step a) \<Longrightarrow> P s \<Longrightarrow> P s'); reachable s1; P s0\<rbrakk> \<Longrightarrow> P s1"
+  "\<lbrakk> \<And>s s' a. reachable s \<Longrightarrow> (s,s') \<in> (Step a) \<Longrightarrow> P s \<Longrightarrow> P s'; reachable s1; P s0 \<rbrakk>
+     \<Longrightarrow> P s1"
   apply (drule reachable_Run)
   apply (elim exE)
   apply (rule reachable_induct_helper)
@@ -216,6 +209,7 @@ lemma reachable_induct:
   done
 
 end
+
 
 subsection \<open>Init Fin system\<close>
 
@@ -229,90 +223,91 @@ locale Init_Fin_system = system A s0
   for A :: "('a,'s,'e) data_type" and s0 :: "'s"  +
   assumes reachable_s0: "reachable s0"
   assumes Fin_Init: "reachable s \<Longrightarrow> Fin A ` Init A s = {s}"
-  assumes Init_Fin: "reachable s \<Longrightarrow> x \<in> steps (Simulation.Step A) (Init A s) as \<Longrightarrow>  x \<in> Init A (Fin A x)"
+  assumes Init_Fin: "\<lbrakk> reachable s; x \<in> steps (Simulation.Step A) (Init A s) as \<rbrakk>
+                       \<Longrightarrow> x \<in> Init A (Fin A x)"
   assumes obs_det_or_no_abs: "obs_det \<or> no_abs"
 begin
 
-
 lemma execution_subset_Run:
   "reachable s \<Longrightarrow> execution A s as \<subseteq> {s'. (s,s') \<in> Run Step as}"
-  apply(induct as arbitrary: s rule: rev_induct)
-   apply(simp add: execution_def steps_def Fin_Init)
-  apply(simp add: execution_def steps_def)
-  apply(rule subsetI)
+  apply (induct as arbitrary: s rule: rev_induct)
+   apply (simp add: execution_def steps_def Fin_Init)
+  apply (simp add: execution_def steps_def)
+  apply (rule subsetI)
   apply clarsimp
-  apply(rule Run_trans)
+  apply (rule Run_trans)
    apply blast
-  apply(cut_tac x=xc and s=s and as=xs in Init_Fin, (simp add: steps_def)+)
-  apply(clarsimp simp: Step_def execution_def steps_def)
+  apply (cut_tac x=xc and s=s and as=xs in Init_Fin, (simp add: steps_def)+)
+  apply (clarsimp simp: Step_def execution_def steps_def)
   apply blast
   done
 
 lemma Run_subset_execution:
-  "\<lbrakk>no_abs; reachable s\<rbrakk> \<Longrightarrow> {s'. (s,s') \<in> Run Step as} \<subseteq> execution A s as"
-  apply(induct as arbitrary: s rule: rev_induct)
-   apply(simp add: execution_def steps_def Fin_Init)
-  apply(simp add: execution_def steps_def)
-  apply(rule subsetI)
+  "\<lbrakk> no_abs; reachable s \<rbrakk> \<Longrightarrow> {s'. (s,s') \<in> Run Step as} \<subseteq> execution A s as"
+  apply (induct as arbitrary: s rule: rev_induct)
+   apply (simp add: execution_def steps_def Fin_Init)
+  apply (simp add: execution_def steps_def)
+  apply (rule subsetI)
   apply clarsimp
-  apply(drule Run_mid)
+  apply (drule Run_mid)
   apply clarsimp
-  apply(drule_tac x=s in meta_spec)
+  apply (drule_tac x=s in meta_spec)
   apply clarsimp
-  apply(drule_tac subsetD)
+  apply (drule_tac subsetD)
    apply blast
-  apply(clarsimp simp: Image_def image_def Step_def execution_def steps_def)
-  apply(rule_tac x=xc in exI)
+  apply (clarsimp simp: Image_def image_def Step_def execution_def steps_def)
+  apply (rule_tac x=xc in exI)
   apply clarsimp
-  apply(rule_tac x=xd in bexI)
+  apply (rule_tac x=xd in bexI)
    apply assumption
-  apply(drule_tac x=xb in no_absD)
-    apply(simp add: steps_def Image_def)+
+  apply (drule_tac x=xb in no_absD)
+    apply (simp add: steps_def Image_def)+
   done
 
 lemma Run_det:
-  "obs_det \<Longrightarrow> \<exists> s'. {s'. (s,s') \<in> Run Step as} = {s'}"
-  apply(induct as arbitrary: s rule: rev_induct)
+  "obs_det \<Longrightarrow> \<exists>s'. {s'. (s,s') \<in> Run Step as} = {s'}"
+  apply (induct as arbitrary: s rule: rev_induct)
    apply simp
-  apply(simp add: Run_app relcomp_def)
-  apply(drule_tac x=s in meta_spec)
+  apply (simp add: Run_app relcomp_def)
+  apply (drule_tac x=s in meta_spec)
   apply clarsimp
-  apply(drule_tac s=s' and js="[x]" in obs_detD)
+  apply (drule_tac s=s' and js="[x]" in obs_detD)
   apply (clarsimp simp: Step_def)
-  apply(rule_tac x="s'a" in exI)
+  apply (rule_tac x="s'a" in exI)
   apply (auto dest: equalityD1)
   done
 
 lemma eq:
-  "\<lbrakk>S \<subseteq> T; \<exists> x. S = {x}; \<exists> y. T = {y}\<rbrakk> \<Longrightarrow> S = T"
-  apply blast
-  done
+  "\<lbrakk> S \<subseteq> T; \<exists>x. S = {x}; \<exists>y. T = {y} \<rbrakk> \<Longrightarrow> S = T"
+  by blast
 
 lemma execution_Run:
   "reachable s \<Longrightarrow> execution A s as = {s'. (s,s') \<in> Run Step as}"
-  apply(rule disjE[OF obs_det_or_no_abs])
-   apply(rule eq)
-     apply(erule execution_subset_Run)
-    apply(erule obs_detD)
-   apply(erule Run_det)
-  apply(rule equalityI)
-   apply(erule execution_subset_Run)
-  apply(erule (1) Run_subset_execution)
+  apply (rule disjE[OF obs_det_or_no_abs])
+   apply (rule eq)
+     apply (erule execution_subset_Run)
+    apply (erule obs_detD)
+   apply (erule Run_det)
+  apply (rule equalityI)
+   apply (erule execution_subset_Run)
+  apply (erule (1) Run_subset_execution)
   done
 
 end
 
+
 lemma Init_Fin_system_Step_system:
   "Init_Fin_system A s0 \<Longrightarrow> Step_system A s0"
-  apply(unfold_locales)
-   apply(erule Init_Fin_system.reachable_s0)
-  apply(erule (1) Init_Fin_system.execution_Run)
+  apply (unfold_locales)
+   apply (erule Init_Fin_system.reachable_s0)
+  apply (erule (1) Init_Fin_system.execution_Run)
   done
 
 sublocale Init_Fin_system \<subseteq> Step_system
-  apply(rule Init_Fin_system_Step_system)
-  apply(unfold_locales)
+  apply (rule Init_Fin_system_Step_system)
+  apply (unfold_locales)
   done
+
 
 subsection \<open>Init inv Fin system\<close>
 
@@ -334,75 +329,73 @@ locale Init_inv_Fin_system = system A s0
 begin
 
 lemma inv_and_inj: "reachable s \<Longrightarrow> Fin A i = s \<Longrightarrow> Init A s = {i}"
-  using Fin_inj Init_inv_Fin by (blast dest:injD)
+  using Fin_inj Init_inv_Fin by (blast dest: injD)
 
 lemma s0_reachable:
   "reachable s0"
-  apply(simp add: reachable_def)
-  apply(rule_tac x="[]" in exI)
-  apply(simp add: execution_def steps_def)
-  using Fin_Init_s0.
+  apply (simp add: reachable_def)
+  apply (rule_tac x="[]" in exI)
+  apply (simp add: execution_def steps_def)
+  using Fin_Init_s0 .
 
 lemma foldl_foldl_Step:
-  "\<lbrakk>x \<in> foldl (\<lambda>S j. data_type.Step A j `` S) M as;
-   M \<subseteq> foldl (\<lambda>S j. data_type.Step A j `` S) B js\<rbrakk>
-       \<Longrightarrow> x \<in> foldl (\<lambda>S j. data_type.Step A j `` S)
-               (foldl (\<lambda>S j. data_type.Step A j `` S) B js) as"
-  apply(induct  as arbitrary: x M js B rule: rev_induct)
+  "\<lbrakk> x \<in> foldl (\<lambda>S j. data_type.Step A j `` S) M as;
+     M \<subseteq> foldl (\<lambda>S j. data_type.Step A j `` S) B js \<rbrakk>
+     \<Longrightarrow> x \<in> foldl (\<lambda>S j. data_type.Step A j `` S) (foldl (\<lambda>S j. data_type.Step A j `` S) B js) as"
+  apply (induct as arbitrary: x M js B rule: rev_induct)
    apply fastforce
   apply simp
-  apply(erule ImageE)
-  apply(drule_tac x=xb in meta_spec)
-  apply(drule_tac x=M in meta_spec)
+  apply (erule ImageE)
+  apply (drule_tac x=xb in meta_spec)
+  apply (drule_tac x=M in meta_spec)
   apply simp
-  apply(drule_tac x=js in meta_spec)
-  apply(drule_tac x=B in meta_spec, simp)
-  apply(blast)
+  apply (drule_tac x=js in meta_spec)
+  apply (drule_tac x=B in meta_spec, simp)
+  apply (blast)
   done
 
 lemma reachable_Fin:
-  "\<lbrakk>reachable s;
-    x \<in> steps (Simulation.Step A) (Init A s) as\<rbrakk>
-   \<Longrightarrow> reachable (Fin A x)"
-  apply(cut_tac s=s in Init_inv_Fin, assumption)
-  apply(clarsimp simp: reachable_def execution_def steps_def)
-  apply(rule_tac x="js@as" in exI)
-  apply(rule imageI)
-  apply(subgoal_tac "{s'. Fin A s' = Fin A xa} = {xa}")
+  "\<lbrakk> reachable s; x \<in> steps (Simulation.Step A) (Init A s) as \<rbrakk>
+     \<Longrightarrow> reachable (Fin A x)"
+  apply (cut_tac s=s in Init_inv_Fin, assumption)
+  apply (clarsimp simp: reachable_def execution_def steps_def)
+  apply (rule_tac x="js@as" in exI)
+  apply (rule imageI)
+  apply (subgoal_tac "{s'. Fin A s' = Fin A xa} = {xa}")
    apply simp
-   apply(erule foldl_foldl_Step)
+   apply (erule foldl_foldl_Step)
    apply blast
-  apply(blast dest: injD[OF Fin_inj])
+  apply (blast dest: injD[OF Fin_inj])
   done
 
 end
 
+
 lemma Init_inv_Fin_system_Init_Fin_system:
   "Init_inv_Fin_system A s0 \<Longrightarrow> Init_Fin_system A s0"
-  apply(unfold_locales)
-     apply(erule Init_inv_Fin_system.s0_reachable)
-    apply(simp add: Init_inv_Fin_system.Init_inv_Fin)
-    apply(simp add: image_def)
-    apply(fastforce simp: system.reachable_def execution_def)
-   apply(cut_tac s="Fin A x" in Init_inv_Fin_system.Init_inv_Fin)
+  apply (unfold_locales)
+     apply (erule Init_inv_Fin_system.s0_reachable)
+    apply (simp add: Init_inv_Fin_system.Init_inv_Fin)
+    apply (simp add: image_def)
+    apply (fastforce simp: system.reachable_def execution_def)
+   apply (cut_tac s="Fin A x" in Init_inv_Fin_system.Init_inv_Fin)
      apply assumption
-    apply(blast intro: Init_inv_Fin_system.reachable_Fin)
+    apply (blast intro: Init_inv_Fin_system.reachable_Fin)
    apply simp
-  apply(rule disjI2)
-  apply(clarsimp simp: system.no_abs_def)
-  apply(frule Init_inv_Fin_system.Fin_inj)
-  apply(cut_tac s="Fin A x" in Init_inv_Fin_system.Init_inv_Fin)
+  apply (rule disjI2)
+  apply (clarsimp simp: system.no_abs_def)
+  apply (frule Init_inv_Fin_system.Fin_inj)
+  apply (cut_tac s="Fin A x" in Init_inv_Fin_system.Init_inv_Fin)
     apply assumption
-   apply(blast intro: Init_inv_Fin_system.reachable_Fin)
+   apply (blast intro: Init_inv_Fin_system.reachable_Fin)
   apply simp
-  apply(fastforce dest: injD)
+  apply (fastforce dest: injD)
   done
 
 sublocale Init_inv_Fin_system \<subseteq> Init_Fin_system
-  apply(rule Init_inv_Fin_system_Init_Fin_system)
-  apply(unfold_locales)
+  apply (rule Init_inv_Fin_system_Init_Fin_system)
+  apply (unfold_locales)
   done
-
 
 
 section \<open>Non interference\<close>
@@ -427,60 +420,53 @@ locale noninterference_policy =
     "(x,schedDomain) \<in> policy \<Longrightarrow> x = schedDomain"
 begin
 
-abbreviation uwr2 :: "'s \<Rightarrow> 'd \<Rightarrow> 's \<Rightarrow> bool" ("(_/ \<sim>_\<sim>/ _)" [50,100,50] 1000)
-where
+abbreviation uwr2 :: "'s \<Rightarrow> 'd \<Rightarrow> 's \<Rightarrow> bool" ("(_/ \<sim>_\<sim>/ _)" [50,100,50] 1000) where
   "s \<sim>u\<sim> t \<equiv> (s,t) \<in> uwr u"
 
-abbreviation policy2 :: "'d \<Rightarrow> 'd \<Rightarrow> bool" (infix "\<leadsto>" 50)
-where
+abbreviation policy2 :: "'d \<Rightarrow> 'd \<Rightarrow> bool" (infix "\<leadsto>" 50) where
   "u \<leadsto> v \<equiv> (u,v) \<in> policy"
 
 lemma uwr_refl:
   "s \<sim>(u::'d)\<sim> s"
-  apply(cut_tac u=u in uwr_equiv_rel)
-  apply(clarsimp simp: equiv_def)
-  apply(blast dest: refl_onD)
+  apply (cut_tac u=u in uwr_equiv_rel)
+  apply (clarsimp simp: equiv_def)
+  apply (blast dest: refl_onD)
   done
 
 lemma uwr_sym:
   "x \<sim>(u::'d)\<sim> y \<Longrightarrow> y \<sim>u\<sim> x"
-  apply(cut_tac u=u in uwr_equiv_rel)
-  apply(clarsimp simp: equiv_def)
-  apply(blast dest: symD)
+  apply (cut_tac u=u in uwr_equiv_rel)
+  apply (clarsimp simp: equiv_def)
+  apply (blast dest: symD)
   done
 
 lemma uwr_trans:
-  "\<lbrakk>x \<sim>(u::'d)\<sim> y; y \<sim>u\<sim> z\<rbrakk> \<Longrightarrow> x \<sim>u\<sim> z"
-  apply(cut_tac u=u in uwr_equiv_rel)
-  apply(clarsimp simp: equiv_def)
-  apply(blast dest: transD)
+  "\<lbrakk> x \<sim>(u::'d)\<sim> y; y \<sim>u\<sim> z \<rbrakk> \<Longrightarrow> x \<sim>u\<sim> z"
+  apply (cut_tac u=u in uwr_equiv_rel)
+  apply (clarsimp simp: equiv_def)
+  apply (blast dest: transD)
   done
 
-definition sameFor_dom :: "'s \<Rightarrow> 'd set \<Rightarrow> 's \<Rightarrow> bool"  ("(_/ \<approx>_\<approx>/ _)" [50,100,50] 1000)
-where
- "s \<approx>us\<approx> t \<equiv> \<forall>u\<in>us. (s,t) \<in> uwr u"
+definition sameFor_dom :: "'s \<Rightarrow> 'd set \<Rightarrow> 's \<Rightarrow> bool"  ("(_/ \<approx>_\<approx>/ _)" [50,100,50] 1000) where
+  "s \<approx>us\<approx> t \<equiv> \<forall>u\<in>us. (s,t) \<in> uwr u"
 
 lemma sameFor_subset_dom: "\<lbrakk>s \<approx>(x::'d set)\<approx> t; y \<subseteq> x\<rbrakk> \<Longrightarrow> s \<approx>y\<approx> t"
-  by(fastforce simp: sameFor_dom_def)
-
+  by (fastforce simp: sameFor_dom_def)
 
 lemma sameFor_inter_domI: "s \<approx>(S::'d set)\<approx> t \<Longrightarrow> s \<approx>(S \<inter> B)\<approx> t"
-  by(auto simp: sameFor_dom_def)
-
+  by (auto simp: sameFor_dom_def)
 
 lemma sameFor_sym_dom:
   "s \<approx>(S::'d set)\<approx> t \<Longrightarrow> t \<approx>S\<approx> s"
-  by(auto simp: sameFor_dom_def uwr_sym)
+  by (auto simp: sameFor_dom_def uwr_sym)
 
 end
 
 
-
-
 subsection \<open>Non interference system\<close>
 
-locale noninterference_system = enabled_system A s0 +
-                                noninterference_policy dom uwr policy out schedDomain
+locale noninterference_system =
+  enabled_system A s0 + noninterference_policy dom uwr policy out schedDomain
   for A :: "('a,'s,'e) data_type"
   and s0 :: "'s"
   and dom :: "'e \<Rightarrow> 's \<Rightarrow> 'd"
@@ -492,289 +478,240 @@ begin
 
 (* The set of domains (which carry out actions in the list "as") which
  * may influence "u", assuming we start in state "s". *)
-primrec
- sources :: "'e list \<Rightarrow> 's \<Rightarrow> 'd \<Rightarrow> 'd set"
-where
- sources_Nil: "sources [] s u = {u}"|
- sources_Cons: "sources (a#as) s u = (\<Union>{sources as s' u| s'. (s,s') \<in> Step a}) \<union>
-      {w. w = dom a s \<and> (\<exists> v s'. dom a s \<leadsto> v \<and> (s,s') \<in> Step a \<and> v \<in> sources as s' u)}"
+primrec sources :: "'e list \<Rightarrow> 's \<Rightarrow> 'd \<Rightarrow> 'd set" where
+  sources_Nil: "sources [] s u = {u}"
+| sources_Cons: "sources (a#as) s u =
+    (\<Union>{sources as s' u| s'. (s,s') \<in> Step a}) \<union>
+    {w. w = dom a s \<and> (\<exists>v s'. dom a s \<leadsto> v \<and> (s,s') \<in> Step a \<and> v \<in> sources as s' u)}"
 
 declare sources_Nil [simp del]
 declare sources_Cons [simp del]
 
+definition obs_equiv :: "'s \<Rightarrow> 'e list \<Rightarrow> 's \<Rightarrow> 'e list \<Rightarrow> 'd \<Rightarrow> bool" where
+  "obs_equiv s as t bs d \<equiv>
+     \<forall>s' t'. s' \<in> execution A s as \<and> t' \<in> execution A t bs \<longrightarrow> out d s' = out d t'"
 
-
-definition obs_equiv :: "'s \<Rightarrow> 'e list \<Rightarrow> 's \<Rightarrow> 'e list \<Rightarrow> 'd \<Rightarrow> bool"
-where
-  "obs_equiv s as t bs d \<equiv> \<forall> s' t'. s' \<in> execution A s as \<and> t' \<in> execution A t bs \<longrightarrow>
-                out d s' = out d t'"
-
-
-definition uwr_equiv :: "'s \<Rightarrow> 'e list \<Rightarrow> 's \<Rightarrow> 'e list \<Rightarrow> 'd \<Rightarrow> bool"
-where
-  "uwr_equiv s as t bs d \<equiv> \<forall> s' t'. s' \<in> execution A s as \<and> t' \<in> execution A t bs \<longrightarrow>
-                s' \<sim>d\<sim> t'"
-
+definition uwr_equiv :: "'s \<Rightarrow> 'e list \<Rightarrow> 's \<Rightarrow> 'e list \<Rightarrow> 'd \<Rightarrow> bool" where
+  "uwr_equiv s as t bs d \<equiv>
+     \<forall>s' t'. s' \<in> execution A s as \<and> t' \<in> execution A t bs \<longrightarrow> s' \<sim>d\<sim> t'"
 
 
 text \<open>Nonleakage\<close>
-definition Nonleakage :: "bool"
-where
-  "Nonleakage \<equiv> \<forall>as s u t. reachable s \<and> reachable t \<longrightarrow>
-     s \<sim>schedDomain\<sim> t \<longrightarrow>
-     s \<approx>(sources as s u)\<approx> t \<longrightarrow> obs_equiv s as t as u"
+definition Nonleakage :: "bool" where
+  "Nonleakage \<equiv> \<forall>as s u t. reachable s \<and> reachable t
+                            \<longrightarrow> s \<sim>schedDomain\<sim> t
+                            \<longrightarrow> s \<approx>(sources as s u)\<approx> t
+                            \<longrightarrow> obs_equiv s as t as u"
+
 
 text \<open>A generalisation of Nonleakage.\<close>
-definition Nonleakage_gen :: "bool"
-where
-  "Nonleakage_gen \<equiv> \<forall>as s u t. reachable s \<and> reachable t \<longrightarrow>
-     s \<sim>schedDomain\<sim> t \<longrightarrow>
-       s \<approx>(sources as s u)\<approx> t \<longrightarrow> uwr_equiv s as t as u"
-
-
+definition Nonleakage_gen :: "bool" where
+  "Nonleakage_gen \<equiv>
+     \<forall>as s u t. reachable s \<and> reachable t
+                \<longrightarrow> s \<sim>schedDomain\<sim> t
+                \<longrightarrow> s \<approx>(sources as s u)\<approx> t
+                \<longrightarrow> uwr_equiv s as t as u"
 
 
 lemma uwr_equiv_sym:
   "uwr_equiv s as t bs u \<Longrightarrow> uwr_equiv t bs s as u"
-  apply(fastforce simp: uwr_equiv_def uwr_sym)
-  done
+  by (fastforce simp: uwr_equiv_def uwr_sym)
 
 lemma uwr_equiv_trans:
-  "\<lbrakk>reachable t; uwr_equiv s as t bs x; uwr_equiv t bs u cs x\<rbrakk> \<Longrightarrow> uwr_equiv s as u cs x"
-  apply(clarsimp simp: uwr_equiv_def)
-  apply(cut_tac s=t and js=bs in reachable_enabled)
+  "\<lbrakk> reachable t; uwr_equiv s as t bs x; uwr_equiv t bs u cs x \<rbrakk>
+     \<Longrightarrow> uwr_equiv s as u cs x"
+  apply (clarsimp simp: uwr_equiv_def)
+  apply (cut_tac s=t and js=bs in reachable_enabled)
    apply assumption
-  apply(blast intro: uwr_trans)
+  apply (blast intro: uwr_trans)
   done
 
-primrec gen_purge :: "('e list \<Rightarrow> 's \<Rightarrow> 'd \<Rightarrow> 'd set) \<Rightarrow> 'd \<Rightarrow> 'e list \<Rightarrow> 's set \<Rightarrow> 'e list"
-where
-  Nil : "gen_purge source_func u []     ss = []" |
-  Cons: "gen_purge source_func u (a#as) ss =
-            (if (\<exists>s\<in>ss. dom a s \<in> source_func (a#as) s u) then
-               a#gen_purge source_func u as (\<Union>s\<in>ss. {s'. (s,s') \<in> Step a})
-             else
-               gen_purge source_func u as ss)"
+primrec gen_purge :: "('e list \<Rightarrow> 's \<Rightarrow> 'd \<Rightarrow> 'd set) \<Rightarrow> 'd \<Rightarrow> 'e list \<Rightarrow> 's set \<Rightarrow> 'e list" where
+  Nil: "gen_purge source_func u [] ss = []"
+| Cons: "gen_purge source_func u (a#as) ss =
+           (if \<exists>s\<in>ss. dom a s \<in> source_func (a#as) s u
+            then a # gen_purge source_func u as (\<Union>s\<in>ss. {s'. (s,s') \<in> Step a})
+            else gen_purge source_func u as ss)"
 
-
-
-definition ipurge
-where
- "ipurge \<equiv> gen_purge sources"
+definition ipurge where
+  "ipurge \<equiv> gen_purge sources"
 
 lemma ipurge_Nil:
   "ipurge u [] ss = []"
-  by(auto simp: ipurge_def)
-
-lemma ipurge_Cons:
-  "ipurge u (a#as) ss =
-     (if (\<exists> s\<in>ss. dom a s \<in> sources (a#as) s u) then
-         a#ipurge u as (\<Union>s\<in>ss. {s'. (s,s') \<in> Step a})
-      else
-         ipurge u as ss)"
   by (auto simp: ipurge_def)
 
+lemma ipurge_Cons:
+  "ipurge u (a#as) ss = (if (\<exists>s\<in>ss. dom a s \<in> sources (a#as) s u)
+                         then a#ipurge u as (\<Union>s\<in>ss. {s'. (s,s') \<in> Step a})
+                         else ipurge u as ss)"
+  by (auto simp: ipurge_def)
 
 lemma gen_purge_shortens:
   "length (gen_purge sf u as ss) \<le> length as"
-  apply(induct as arbitrary: ss)
-   apply(simp)
-  apply(clarsimp)
-  apply(rule le_trans)
+  apply (induct as arbitrary: ss; clarsimp)
+  apply (rule le_trans)
    apply assumption
   apply simp
   done
 
-
-
-
 lemma INT_cong':
-  assumes a: "\<And> x. Q x \<Longrightarrow> P x = P' x"
-  shows
-  "\<Inter>{P x|x. Q x} = \<Inter>{P' x|x. Q x}"
-  apply (auto simp: a)
-  done
+  assumes a: "\<And>x. Q x \<Longrightarrow> P x = P' x"
+  shows "\<Inter>{P x|x. Q x} = \<Inter>{P' x|x. Q x}"
+  by (auto simp: a)
 
 
 text \<open>Standard Noninterference\<close>
-
-definition Noninterference :: "bool"
-where
- "Noninterference \<equiv>
-  \<forall> u as s. reachable s \<longrightarrow>
-         (obs_equiv s as s (ipurge u as {s}) u)"
+definition Noninterference :: bool where
+ "Noninterference \<equiv> \<forall>u as s. reachable s \<longrightarrow> (obs_equiv s as s (ipurge u as {s}) u)"
 
 
 text \<open>Strong Noninterference\<close>
-definition Noninterference_strong :: "bool"
-where
- "Noninterference_strong \<equiv>
-  \<forall> u as bs s. reachable s \<longrightarrow>
-         (ipurge u as {s}) = (ipurge u bs {s}) \<longrightarrow>
-         (obs_equiv s as s bs u)"
-
+definition Noninterference_strong :: bool where
+  "Noninterference_strong \<equiv> \<forall>u as bs s. reachable s
+                                         \<longrightarrow> ipurge u as {s} = ipurge u bs {s}
+                                         \<longrightarrow> obs_equiv s as s bs u"
 
 
 lemma obs_equiv_sym:
   "obs_equiv s as t bs u \<Longrightarrow> obs_equiv t bs s as u"
-  apply(clarsimp simp: obs_equiv_def)
-  done
+  by (clarsimp simp: obs_equiv_def)
 
 lemma obs_equiv_trans:
-  "\<lbrakk>reachable t; obs_equiv s as t bs u; obs_equiv t bs x cs u\<rbrakk> \<Longrightarrow> obs_equiv s as x cs u"
-  apply(clarsimp simp: obs_equiv_def)
-  apply(cut_tac s=t and js=bs in reachable_enabled, assumption, blast)
+  "\<lbrakk> reachable t; obs_equiv s as t bs u; obs_equiv t bs x cs u \<rbrakk>
+     \<Longrightarrow> obs_equiv s as x cs u"
+  apply (clarsimp simp: obs_equiv_def)
+  apply (cut_tac s=t and js=bs in reachable_enabled, assumption, blast)
   done
 
 lemma Noninterference_Noninterference_strong:
-  "\<lbrakk>Noninterference\<rbrakk> \<Longrightarrow> Noninterference_strong"
-  apply(clarsimp simp: Noninterference_def Noninterference_strong_def)
-  apply(drule_tac x=u in spec)
-  apply(frule_tac x=as in spec, drule_tac x=s in spec)
-  apply(drule_tac x=bs in spec, drule_tac x=s in spec)
+  "Noninterference \<Longrightarrow> Noninterference_strong"
+  apply (clarsimp simp: Noninterference_def Noninterference_strong_def)
+  apply (drule_tac x=u in spec)
+  apply (frule_tac x=as in spec, drule_tac x=s in spec)
+  apply (drule_tac x=bs in spec, drule_tac x=s in spec)
   apply clarsimp
-  apply(rule obs_equiv_trans)
+  apply (rule obs_equiv_trans)
     apply assumption
    apply assumption
-  apply(erule obs_equiv_sym)
+  apply (erule obs_equiv_sym)
   done
 
 
-text \<open>Noninfluence -- the combination of Noninterference and
-   Nonleakage.
-
-   We add the assumption about equivalence wrt the scheduler's domain, as
-   is common in e.g. GVW.\<close>
-definition Noninfluence  :: "bool"
-where
+text \<open>
+  Noninfluence -- the combination of Noninterference and Nonleakage.
+  We add the assumption about equivalence wrt the scheduler's domain, as
+  is common in e.g. GVW.
+\<close>
+definition Noninfluence :: bool where
  "Noninfluence \<equiv>
-  \<forall> u as s t. reachable s \<and> reachable t \<longrightarrow>
-      s \<approx>(sources as s u)\<approx> t \<longrightarrow>  s \<sim>schedDomain\<sim> t \<longrightarrow>
-         obs_equiv s as t (ipurge u as {t}) u"
-
-
-
+    \<forall>u as s t. reachable s \<and> reachable t
+               \<longrightarrow> s \<approx>(sources as s u)\<approx> t
+               \<longrightarrow> s \<sim>schedDomain\<sim> t
+               \<longrightarrow> obs_equiv s as t (ipurge u as {t}) u"
 
 definition Noninfluence_strong  :: "bool"
 where
- "Noninfluence_strong \<equiv>
-  \<forall> u as bs s t. reachable s  \<and> reachable t \<longrightarrow>
-      s \<approx>(sources as s u)\<approx> t \<longrightarrow>  s \<sim>schedDomain\<sim> t \<longrightarrow>
-         ipurge u as {s} = ipurge u bs {s} \<longrightarrow>
-         obs_equiv s as t bs u"
-
-
+ "Noninfluence_strong \<equiv> \<forall>u as bs s t. reachable s \<and> reachable t
+                                      \<longrightarrow> s \<approx>(sources as s u)\<approx> t
+                                      \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                      \<longrightarrow> ipurge u as {s} = ipurge u bs {s}
+                                      \<longrightarrow> obs_equiv s as t bs u"
 
 
 lemma notin_policyI:
-  "\<lbrakk>dom a s \<notin> sources (a # list) s u; \<exists> s'. (s,s') \<in> Step a \<and> ua \<in> sources list s' u\<rbrakk> \<Longrightarrow>
-   (dom a s,ua) \<notin> policy"
-  apply(clarsimp simp: sources_Cons)
-  done
-
+  "\<lbrakk> dom a s \<notin> sources (a # list) s u; \<exists>s'. (s,s') \<in> Step a \<and> ua \<in> sources list s' u \<rbrakk>
+     \<Longrightarrow> (dom a s,ua) \<notin> policy"
+  by (clarsimp simp: sources_Cons)
 
 lemma Noninfluence_strong_Noninterference_strong:
   "Noninfluence_strong \<Longrightarrow> Noninterference_strong"
-  apply(clarsimp simp: Noninfluence_strong_def Noninterference_strong_def)
-  apply(drule_tac x=u in spec, drule_tac x=as in spec, drule_tac x=bs in spec)
-  apply(fastforce simp: sameFor_dom_def uwr_refl)
+  apply (clarsimp simp: Noninfluence_strong_def Noninterference_strong_def)
+  apply (drule_tac x=u in spec, drule_tac x=as in spec, drule_tac x=bs in spec)
+  apply (fastforce simp: sameFor_dom_def uwr_refl)
   done
 
 lemma Noninfluence_strong_Nonleakage:
   "Noninfluence_strong \<Longrightarrow> Nonleakage"
-  apply(clarsimp simp: Noninfluence_strong_def Nonleakage_def)
-  done
+  by (clarsimp simp: Noninfluence_strong_def Nonleakage_def)
+
 
 text \<open>This stronger condition is needed
    to make the induction proof work for Noninterference. It can be viewed
    as a generalisation of Noninfluence; hence its name here.
 \<close>
-definition Noninfluence_gen :: "bool"
-where
- "Noninfluence_gen \<equiv>
-  \<forall> u as s ts. reachable s \<and> (\<forall> t \<in> ts. reachable t) \<longrightarrow>
-      (\<forall>t \<in> ts. s \<approx>(sources as s u)\<approx> t) \<longrightarrow>  (\<forall>t \<in> ts. s \<sim>schedDomain\<sim> t) \<longrightarrow>
-         (\<forall>t \<in> ts. uwr_equiv s as t (ipurge u as ts) u)"
+definition Noninfluence_gen :: bool where
+  "Noninfluence_gen \<equiv> \<forall>u as s ts. reachable s \<and> (\<forall>t \<in> ts. reachable t)
+                                   \<longrightarrow> (\<forall>t \<in> ts. s \<approx>(sources as s u)\<approx> t)
+                                   \<longrightarrow> (\<forall>t \<in> ts. s \<sim>schedDomain\<sim> t)
+                                   \<longrightarrow> (\<forall>t \<in> ts. uwr_equiv s as t (ipurge u as ts) u)"
 
-definition Noninfluence_uwr  :: "bool"
-where
- "Noninfluence_uwr \<equiv>
-  \<forall> u as s t. reachable s \<and> reachable t \<longrightarrow>
-      s \<approx>(sources as s u)\<approx> t \<longrightarrow>  s \<sim>schedDomain\<sim> t \<longrightarrow>
-         uwr_equiv s as t (ipurge u as {t}) u"
+definition Noninfluence_uwr  :: bool where
+  "Noninfluence_uwr \<equiv> \<forall>u as s t. reachable s \<and> reachable t
+                                  \<longrightarrow> s \<approx>(sources as s u)\<approx> t
+                                  \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                  \<longrightarrow> uwr_equiv s as t (ipurge u as {t}) u"
 
-definition Noninfluence_strong_uwr :: "bool"
-where
- "Noninfluence_strong_uwr \<equiv>
-  \<forall> u as bs s t. reachable s  \<and> reachable t \<longrightarrow>
-      s \<approx>(sources as s u)\<approx> t \<longrightarrow>  s \<sim>schedDomain\<sim> t \<longrightarrow>
-         ipurge u as {s} = ipurge u bs {s} \<longrightarrow>
-         uwr_equiv s as t bs u"
+definition Noninfluence_strong_uwr :: bool where
+  "Noninfluence_strong_uwr \<equiv> \<forall>u as bs s t. reachable s \<and> reachable t
+                                            \<longrightarrow> s \<approx>(sources as s u)\<approx> t
+                                            \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                            \<longrightarrow> ipurge u as {s} = ipurge u bs {s}
+                                            \<longrightarrow> uwr_equiv s as t bs u"
 
+definition output_consistent :: bool where
+  "output_consistent \<equiv> \<forall>u s s'. s \<sim>u\<sim> s'  \<longrightarrow> (out u s = out u s')"
 
-
-
-definition output_consistent :: "bool"
-where
-  "output_consistent \<equiv> \<forall> u s s'. s \<sim>u\<sim> s'  \<longrightarrow> (out u s = out u s')"
-
-definition confidentiality_u :: "bool"
-where
-  "confidentiality_u \<equiv> \<forall> a u s t.  reachable s \<and> reachable t \<longrightarrow>
-    s \<sim>schedDomain\<sim> t \<longrightarrow>
-    ((dom a s \<leadsto> u) \<longrightarrow> s \<sim>dom a s\<sim> t) \<longrightarrow>
-      s \<sim>u\<sim> t \<longrightarrow>
-      (\<forall> s' t'. (s,s') \<in> Step a \<and> (t,t') \<in> Step a \<longrightarrow>
-        s' \<sim>u\<sim> t')"
+definition confidentiality_u :: bool where
+  "confidentiality_u \<equiv> \<forall>a u s t. reachable s \<and> reachable t
+                                  \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                  \<longrightarrow> ((dom a s \<leadsto> u) \<longrightarrow> s \<sim>dom a s\<sim> t)
+                                  \<longrightarrow> s \<sim>u\<sim> t
+                                  \<longrightarrow> (\<forall>s' t'. (s,s') \<in> Step a \<and> (t,t') \<in> Step a \<longrightarrow> s' \<sim>u\<sim> t')"
 
 lemma no_domain_visible_nondeterminism:
-  "\<lbrakk>confidentiality_u; reachable s; (s,s') \<in> Step a; (s,s'') \<in> Step a\<rbrakk> \<Longrightarrow> s' \<sim>d\<sim> s''"
-  apply(clarsimp simp: confidentiality_u_def)
-  apply(fastforce intro: uwr_refl)
+  "\<lbrakk> confidentiality_u; reachable s; (s,s') \<in> Step a; (s,s'') \<in> Step a \<rbrakk>
+     \<Longrightarrow> s' \<sim>d\<sim> s''"
+  apply (clarsimp simp: confidentiality_u_def)
+  apply (fastforce intro: uwr_refl)
   done
 
-definition integrity_u :: "bool"
-where
-  "integrity_u \<equiv> \<forall> a u s. reachable  s \<longrightarrow>
-   (dom a s,u) \<notin> policy  \<longrightarrow>
-   (\<forall> s'. (s,s') \<in> Step a \<longrightarrow> s \<sim>u\<sim> s')"
+definition integrity_u :: bool where
+  "integrity_u \<equiv>
+     \<forall>a u s. reachable s \<longrightarrow> (dom a s,u) \<notin> policy \<longrightarrow> (\<forall>s'. (s,s') \<in> Step a \<longrightarrow> s \<sim>u\<sim> s')"
 
 (*<*)
 (* integrity_u actually guarantees this (seemingly) stronger condition *)
-definition integrity_u_more :: "bool"
-where
-  "integrity_u_more \<equiv> \<forall> a u s. reachable s \<longrightarrow>
-   (dom a s,u) \<notin> policy \<longrightarrow>
-   (\<forall> s' t. s \<sim>u\<sim> t \<and> (s,s') \<in> Step a \<longrightarrow> s' \<sim>u\<sim> t)"
+definition integrity_u_more :: bool where
+  "integrity_u_more \<equiv> \<forall>a u s. reachable s
+                               \<longrightarrow> (dom a s,u) \<notin> policy
+                               \<longrightarrow> (\<forall>s' t. s \<sim>u\<sim> t \<and> (s,s') \<in> Step a \<longrightarrow> s' \<sim>u\<sim> t)"
 
 lemma integrity_u_more:
   "integrity_u \<Longrightarrow> integrity_u_more"
-  apply(clarsimp simp: integrity_u_more_def integrity_u_def)
-  apply(blast dest: uwr_sym uwr_trans)
+  apply (clarsimp simp: integrity_u_more_def integrity_u_def)
+  apply (blast dest: uwr_sym uwr_trans)
   done
 (*>*)
 
 lemma integrity_uD:
-  "\<lbrakk>integrity_u; reachable s; (dom a s,u) \<notin> policy;
-    s \<sim>u\<sim> t; (s,s') \<in> Step a\<rbrakk> \<Longrightarrow>
-   s' \<sim>u\<sim> t"
-  apply(drule integrity_u_more)
-  apply(simp add: integrity_u_more_def)
+  "\<lbrakk> integrity_u; reachable s; (dom a s,u) \<notin> policy; s \<sim>u\<sim> t; (s,s') \<in> Step a \<rbrakk>
+     \<Longrightarrow> s' \<sim>u\<sim> t"
+  apply (drule integrity_u_more)
+  apply (simp add: integrity_u_more_def)
   done
-
-
-
 
 text \<open>
   A weaker version of @{prop confidentiality_u} that, with
   @{prop integrity_u}, implies it.
 \<close>
-definition confidentiality_u_weak
-where
-  "confidentiality_u_weak \<equiv> \<forall> a u s t.  reachable s \<and> reachable t \<longrightarrow>
-    s \<sim>schedDomain\<sim> t \<longrightarrow> dom a s \<leadsto> u \<longrightarrow> s \<sim>(dom a s)\<sim> t \<longrightarrow>
-      s \<sim>u\<sim> t \<longrightarrow>
-        (\<forall> s' t'. (s,s') \<in> Step a \<and> (t,t') \<in> Step a \<longrightarrow> s' \<sim>u\<sim> t')"
+definition confidentiality_u_weak where
+  "confidentiality_u_weak \<equiv> \<forall>a u s t. reachable s \<and> reachable t
+                                       \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                       \<longrightarrow> dom a s \<leadsto> u
+                                       \<longrightarrow> s \<sim>(dom a s)\<sim> t
+                                       \<longrightarrow> s \<sim>u\<sim> t
+                                       \<longrightarrow> (\<forall>s' t'. (s,s') \<in> Step a \<and> (t,t') \<in> Step a
+                                                    \<longrightarrow> s' \<sim>u\<sim> t')"
 
 lemma confidentiality_u_confidentiality_u_weak:
   "confidentiality_u \<Longrightarrow> confidentiality_u_weak"
@@ -783,112 +720,108 @@ lemma confidentiality_u_confidentiality_u_weak:
   done
 
 lemma impCE':
-  "\<lbrakk>P \<longrightarrow> Q; \<lbrakk>P; Q\<rbrakk> \<Longrightarrow> R; \<not> P \<Longrightarrow> R\<rbrakk> \<Longrightarrow> R"
-  apply auto
-  done
+  "\<lbrakk> P \<longrightarrow> Q; \<lbrakk>P; Q\<rbrakk> \<Longrightarrow> R; \<not> P \<Longrightarrow> R \<rbrakk> \<Longrightarrow> R"
+  by auto
 
 lemma confidentiality_u_weak:
-  "\<lbrakk>confidentiality_u_weak; integrity_u\<rbrakk> \<Longrightarrow>
-  confidentiality_u"
-  apply(clarsimp simp: confidentiality_u_def)
-  apply(erule impCE')
-   apply(subst (asm) confidentiality_u_weak_def, blast)
-  apply(frule integrity_uD, simp+)
-  apply(drule_tac s=t and t="s'" in integrity_uD)
+  "\<lbrakk> confidentiality_u_weak; integrity_u \<rbrakk>
+     \<Longrightarrow> confidentiality_u"
+  apply (clarsimp simp: confidentiality_u_def)
+  apply (erule impCE')
+   apply (subst (asm) confidentiality_u_weak_def, blast)
+  apply (frule integrity_uD, simp+)
+  apply (drule_tac s=t and t="s'" in integrity_uD)
       apply assumption
-     apply(drule_tac e=a in schedIncludesCurrentDom)
+     apply (drule_tac e=a in schedIncludesCurrentDom)
      apply simp
-    apply(blast intro: uwr_sym)
+    apply (blast intro: uwr_sym)
    apply assumption
-  apply(erule uwr_sym)
+  apply (erule uwr_sym)
   done
 
 lemma obs_equivI:
-  "\<lbrakk>output_consistent; uwr_equiv s as t bs ob\<rbrakk> \<Longrightarrow> obs_equiv s as t bs ob"
-  apply(clarsimp simp: obs_equiv_def)
-  apply(auto simp: uwr_equiv_def output_consistent_def)
+  "\<lbrakk> output_consistent; uwr_equiv s as t bs ob \<rbrakk> \<Longrightarrow> obs_equiv s as t bs ob"
+  apply (clarsimp simp: obs_equiv_def)
+  apply (auto simp: uwr_equiv_def output_consistent_def)
   done
 
 lemma Noninfluence_uwr_Noninfluence:
-  "\<lbrakk>output_consistent; Noninfluence_uwr\<rbrakk> \<Longrightarrow> Noninfluence"
-  apply(clarsimp simp: Noninfluence_def)
-  apply(erule obs_equivI)
-  apply(auto simp: Noninfluence_uwr_def)
+  "\<lbrakk> output_consistent; Noninfluence_uwr \<rbrakk> \<Longrightarrow> Noninfluence"
+  apply (clarsimp simp: Noninfluence_def)
+  apply (erule obs_equivI)
+  apply (auto simp: Noninfluence_uwr_def)
   done
 
 lemma Noninfluence_strong_uwr_Noninfluence_strong:
-  "\<lbrakk>output_consistent; Noninfluence_strong_uwr\<rbrakk> \<Longrightarrow> Noninfluence_strong"
-  apply(clarsimp simp: Noninfluence_strong_def)
-  apply(erule obs_equivI)
-  apply(auto simp: Noninfluence_strong_uwr_def)
+  "\<lbrakk> output_consistent; Noninfluence_strong_uwr \<rbrakk> \<Longrightarrow> Noninfluence_strong"
+  apply (clarsimp simp: Noninfluence_strong_def)
+  apply (erule obs_equivI)
+  apply (auto simp: Noninfluence_strong_uwr_def)
   done
 
 lemma sched_equiv_preserved:
-  "\<lbrakk>confidentiality_u;  reachable s; reachable t;
-   s \<sim>schedDomain\<sim> t; (s,s') \<in> Step a; (t,t') \<in> Step a\<rbrakk> \<Longrightarrow>
-   s' \<sim>schedDomain\<sim> t'"
-  apply(case_tac "dom a s = schedDomain")
-   apply(subst (asm) confidentiality_u_def)
-   apply(drule_tac x=a in spec)
-   apply(drule_tac x=schedDomain in spec)
-   apply(drule_tac x=s in spec)
-   apply(drule_tac x=t in spec)
+  "\<lbrakk> confidentiality_u; reachable s; reachable t;
+     s \<sim>schedDomain\<sim> t; (s,s') \<in> Step a; (t,t') \<in> Step a \<rbrakk>
+     \<Longrightarrow> s' \<sim>schedDomain\<sim> t'"
+  apply (case_tac "dom a s = schedDomain")
+   apply (subst (asm) confidentiality_u_def)
+   apply (drule_tac x=a in spec)
+   apply (drule_tac x=schedDomain in spec)
+   apply (drule_tac x=s in spec)
+   apply (drule_tac x=t in spec)
    apply simp
-  apply(subst (asm) confidentiality_u_def)
-  apply(blast intro: schedNotGlobalChannel)
+  apply (subst (asm) confidentiality_u_def)
+  apply (blast intro: schedNotGlobalChannel)
   done
 
 lemma sched_equiv_preserved_left:
-  "\<lbrakk>integrity_u; s \<sim>schedDomain\<sim> t;
-    dom a s \<noteq> schedDomain; (s,s') \<in> Step a; reachable s\<rbrakk> \<Longrightarrow>
-    s' \<sim>schedDomain\<sim> t"
-  apply(blast intro: integrity_uD schedNotGlobalChannel)
-  done
+  "\<lbrakk> integrity_u; s \<sim>schedDomain\<sim> t;
+     dom a s \<noteq> schedDomain; (s,s') \<in> Step a; reachable s \<rbrakk>
+     \<Longrightarrow> s' \<sim>schedDomain\<sim> t"
+  by (blast intro: integrity_uD schedNotGlobalChannel)
 
 lemma Noninfluence_gen_Noninterference:
-  "\<lbrakk>output_consistent; Noninfluence_gen\<rbrakk> \<Longrightarrow> Noninterference"
-  apply(clarsimp simp: Noninterference_def Noninfluence_gen_def)
-  apply(erule_tac x=u in allE)
-  apply(erule_tac x=as in allE)
-  apply(erule_tac x=s in allE)
-  apply(erule_tac x="{s}" in allE)
-  apply(clarsimp simp: sameFor_dom_def uwr_refl)
-  apply(blast intro: obs_equivI)
+  "\<lbrakk> output_consistent; Noninfluence_gen \<rbrakk> \<Longrightarrow> Noninterference"
+  apply (clarsimp simp: Noninterference_def Noninfluence_gen_def)
+  apply (erule_tac x=u in allE)
+  apply (erule_tac x=as in allE)
+  apply (erule_tac x=s in allE)
+  apply (erule_tac x="{s}" in allE)
+  apply (clarsimp simp: sameFor_dom_def uwr_refl)
+  apply (blast intro: obs_equivI)
   done
 
 lemma Noninfluence_gen_Noninfluence:
-  "\<lbrakk>output_consistent; Noninfluence_gen\<rbrakk> \<Longrightarrow> Noninfluence"
-  apply(clarsimp simp: Noninfluence_def Noninfluence_gen_def)
-  apply(erule_tac x=u in allE)
-  apply(erule_tac x=as in allE)
-  apply(erule_tac x=s in allE)
-  apply(erule_tac x="{t}" in allE)
-  apply(blast intro: obs_equivI)
+  "\<lbrakk> output_consistent; Noninfluence_gen \<rbrakk> \<Longrightarrow> Noninfluence"
+  apply (clarsimp simp: Noninfluence_def Noninfluence_gen_def)
+  apply (erule_tac x=u in allE)
+  apply (erule_tac x=as in allE)
+  apply (erule_tac x=s in allE)
+  apply (erule_tac x="{t}" in allE)
+  apply (blast intro: obs_equivI)
   done
 
 lemma Noninfluence_gen_Noninfluence_uwr:
-  "\<lbrakk>Noninfluence_gen\<rbrakk> \<Longrightarrow> Noninfluence_uwr"
-  apply(clarsimp simp: Noninfluence_uwr_def Noninfluence_gen_def)
-  done
+  "Noninfluence_gen \<Longrightarrow> Noninfluence_uwr"
+  by (clarsimp simp: Noninfluence_uwr_def Noninfluence_gen_def)
 
 lemma Noninfluence_gen_Noninterference_strong:
-  "\<lbrakk>output_consistent; Noninfluence_gen\<rbrakk> \<Longrightarrow> Noninterference_strong"
-  apply(rule Noninterference_Noninterference_strong)
-  apply(blast intro: Noninfluence_gen_Noninterference)
+  "\<lbrakk> output_consistent; Noninfluence_gen \<rbrakk> \<Longrightarrow> Noninterference_strong"
+  apply (rule Noninterference_Noninterference_strong)
+  apply (blast intro: Noninfluence_gen_Noninterference)
   done
 
-
 end
+
 
 subsection \<open>Noninterference on enabled Step system : unwinding system\<close>
 
 locale enabled_Step_system = enabled_system A s0 + Step_system A s0
   for A :: "('a,'s,'e) data_type" and s0 :: "'s"
 
-
 (* we define the unwinding conditions for any system *)
-locale unwinding_system = enabled_Step_system A s0 +
-                          noninterference_policy dom uwr policy out schedDomain
+locale unwinding_system =
+  enabled_Step_system A s0 + noninterference_policy dom uwr policy out schedDomain
   for A :: "('a,'s,'e) data_type"
   and s0 :: "'s"
   and dom :: "'e \<Rightarrow> 's \<Rightarrow> 'd"
@@ -897,436 +830,408 @@ locale unwinding_system = enabled_Step_system A s0 +
   and out :: "'d \<Rightarrow> 's \<Rightarrow> 'p"
   and schedDomain :: "'d"
 
-sublocale unwinding_system \<subseteq> noninterference_system
-  apply(unfold_locales)
-  done
+sublocale unwinding_system \<subseteq> noninterference_system by unfold_locales
 
 context unwinding_system begin
 
-
-
-
 lemma sources_refl:
   "reachable s \<Longrightarrow> u \<in> sources as s u"
-  apply(induct as arbitrary: s)
-   apply(simp add: sources_Nil)
-  apply(simp add: sources_Cons)
-  apply(frule_tac a=a in enabled_Step)
+  apply (induct as arbitrary: s)
+   apply (simp add: sources_Nil)
+  apply (simp add: sources_Cons)
+  apply (frule_tac a=a in enabled_Step)
   apply (auto simp: reachable_Step)
   done
 
-
-
 lemma schedDomain_in_sources_Cons:
-  "reachable s \<Longrightarrow> dom a s = schedDomain \<Longrightarrow> dom a s \<in> sources (a#as) s u"
-  apply(unfold sources_Cons)
-  apply(erule ssubst)
-  apply(rule UnI2)
-  apply(clarsimp)
-  apply(rule_tac x=u in exI)
-  apply(safe)
-   apply(rule schedFlowsToAll)
-  apply(frule_tac a=a in enabled_Step)
-  apply(fastforce dest: sources_refl reachable_Step)
+  "\<lbrakk> reachable s; dom a s = schedDomain \<rbrakk>
+     \<Longrightarrow> dom a s \<in> sources (a#as) s u"
+  apply (unfold sources_Cons)
+  apply (erule ssubst)
+  apply (rule UnI2)
+  apply (clarsimp)
+  apply (rule_tac x=u in exI)
+  apply (safe)
+   apply (rule schedFlowsToAll)
+  apply (frule_tac a=a in enabled_Step)
+  apply (fastforce dest: sources_refl reachable_Step)
   done
-
-
 
 lemma sources_eq':
   "confidentiality_u \<and> s \<sim>schedDomain\<sim> t \<and> reachable s \<and> reachable t
    \<longrightarrow> sources as s u = sources as t u"
-  proof (induct as arbitrary: s t)
+proof (induct as arbitrary: s t)
   case Nil show ?case
-   apply(simp add: sources_Nil)
-   done
-  next
+    by (simp add: sources_Nil)
+next
   case (Cons a as) show ?case
-  apply(clarsimp simp: sources_Cons)
-  apply(rule un_eq)
-   apply(simp only: Union_eq, simp only: UNION_eq[symmetric])
-   apply(rule Un_eq, clarsimp)
-     apply(metis "Cons.hyps"[rule_format] sched_equiv_preserved reachable_Step)
-    apply(fastforce intro: enabled_Step)
-   apply(fastforce intro: enabled_Step)
-  apply(clarsimp simp: schedIncludesCurrentDom)
-  apply(rule Collect_cong)
-  apply(rule conj_cong, rule refl)
-  apply(rule iff_exI)
-  apply(metis "Cons.hyps"[rule_format] sched_equiv_preserved reachable_Step enabled_Step)
-  done
-  qed
-
+    apply (clarsimp simp: sources_Cons)
+    apply (rule un_eq)
+     apply (simp only: Union_eq, simp only: UNION_eq[symmetric])
+     apply (rule Un_eq, clarsimp)
+       apply (metis "Cons.hyps"[rule_format] sched_equiv_preserved reachable_Step)
+      apply (fastforce intro: enabled_Step)
+     apply (fastforce intro: enabled_Step)
+    apply (clarsimp simp: schedIncludesCurrentDom)
+    apply (rule Collect_cong)
+    apply (rule conj_cong, rule refl)
+    apply (rule iff_exI)
+    apply (metis "Cons.hyps"[rule_format] sched_equiv_preserved reachable_Step enabled_Step)
+    done
+qed
 
 lemma sources_eq:
-  "\<lbrakk>confidentiality_u; s \<sim>schedDomain\<sim> t; reachable s; reachable t\<rbrakk> \<Longrightarrow>
-  sources as s u = sources as t u"
-  by(rule sources_eq'[rule_format], simp)
-
+  "\<lbrakk> confidentiality_u; s \<sim>schedDomain\<sim> t; reachable s; reachable t \<rbrakk>
+     \<Longrightarrow> sources as s u = sources as t u"
+  by (rule sources_eq'[rule_format], simp)
 
 lemma sameFor_sources_dom:
-  "\<lbrakk>s \<approx>(sources (a#as) s u)\<approx> t; dom a s \<leadsto> x; x \<in> sources as s' u; (s,s') \<in> Step a\<rbrakk> \<Longrightarrow>
-   s \<sim>(dom a s)\<sim> t"
-  apply(simp add: sameFor_dom_def)
-  apply(erule bspec)
-  apply(subst sources_Cons)
-  apply(rule UnI2)
+  "\<lbrakk> s \<approx>(sources (a#as) s u)\<approx> t; dom a s \<leadsto> x; x \<in> sources as s' u; (s,s') \<in> Step a \<rbrakk>
+     \<Longrightarrow> s \<sim>(dom a s)\<sim> t"
+  apply (simp add: sameFor_dom_def)
+  apply (erule bspec)
+  apply (subst sources_Cons)
+  apply (rule UnI2)
   apply blast
   done
 
 lemma sources_unwinding_step:
-  "\<lbrakk>s \<approx>(sources (a#as) s u)\<approx> t; s \<sim>schedDomain\<sim> t; confidentiality_u;
-    (s,s') \<in> Step a; (t,t') \<in> Step a; reachable s; reachable t\<rbrakk>  \<Longrightarrow>
-    s' \<approx>(sources as s' u)\<approx> t'"
-  apply(clarsimp simp: sameFor_dom_def sources_Cons)
-  apply(subst (asm) confidentiality_u_def)
-  apply(drule_tac x=a in spec)
-  apply(drule_tac x=ua in spec)
-  apply(drule_tac x=s in spec)
-  apply(drule_tac x=t in spec)
-  apply(fastforce intro: sameFor_sources_dom)
+  "\<lbrakk> s \<approx>(sources (a#as) s u)\<approx> t; s \<sim>schedDomain\<sim> t; confidentiality_u;
+     (s,s') \<in> Step a; (t,t') \<in> Step a; reachable s; reachable t \<rbrakk>
+     \<Longrightarrow> s' \<approx>(sources as s' u)\<approx> t'"
+  apply (clarsimp simp: sameFor_dom_def sources_Cons)
+  apply (subst (asm) confidentiality_u_def)
+  apply (drule_tac x=a in spec)
+  apply (drule_tac x=ua in spec)
+  apply (drule_tac x=s in spec)
+  apply (drule_tac x=t in spec)
+  apply (fastforce intro: sameFor_sources_dom)
   done
 
 lemma ipurge_eq'_helper:
-  "\<lbrakk>s \<in> ss; dom a s \<in> sources (a # as) s u; \<forall>s\<in>ts. dom a s \<notin> sources (a # as) s u;
-   (\<forall>s t. s \<in> ss \<and> t \<in> ts \<longrightarrow> s \<sim>schedDomain\<sim> t \<and> reachable s \<and> reachable t);
-   t \<in> ts; confidentiality_u\<rbrakk> \<Longrightarrow>
-  False"
-  apply(cut_tac s=s and t=t and as=as and u=u in sources_eq, simp+)
-  apply(clarsimp  simp: sources_Cons | safe)+
-  apply(rename_tac s')
-   apply(drule_tac x=t in bspec, simp)
+  "\<lbrakk> s \<in> ss; dom a s \<in> sources (a # as) s u; \<forall>s\<in>ts. dom a s \<notin> sources (a # as) s u;
+     (\<forall>s t. s \<in> ss \<and> t \<in> ts \<longrightarrow> s \<sim>schedDomain\<sim> t \<and> reachable s \<and> reachable t);
+     t \<in> ts; confidentiality_u \<rbrakk>
+     \<Longrightarrow> False"
+  apply (cut_tac s=s and t=t and as=as and u=u in sources_eq, simp+)
+  apply (clarsimp  simp: sources_Cons | safe)+
+   apply (rename_tac s')
+   apply (drule_tac x=t in bspec, simp)
    apply clarsimp
-   apply(cut_tac s=t in enabled_Step, simp)
-   apply(erule exE, rename_tac t')
-   apply(drule_tac x="sources as t' u" in spec)
-   apply(cut_tac s=s' and t=t' and u=u in sources_eq, simp+)
-      apply(fastforce elim: sched_equiv_preserved)
-     apply(fastforce intro: reachable_Step)
-    apply(fastforce intro: reachable_Step)
-   apply(fastforce simp: schedIncludesCurrentDom)
-  apply(drule_tac x=t in bspec, simp)
+   apply (cut_tac s=t in enabled_Step, simp)
+   apply (erule exE, rename_tac t')
+   apply (drule_tac x="sources as t' u" in spec)
+   apply (cut_tac s=s' and t=t' and u=u in sources_eq, simp+)
+      apply (fastforce elim: sched_equiv_preserved)
+     apply (fastforce intro: reachable_Step)
+    apply (fastforce intro: reachable_Step)
+   apply (fastforce simp: schedIncludesCurrentDom)
+  apply (drule_tac x=t in bspec, simp)
   apply clarsimp
-  apply(rename_tac v s')
-  apply(drule_tac x=v in spec, erule impE, fastforce simp: schedIncludesCurrentDom)
-  apply(cut_tac s=t in enabled_Step[where a=a], simp, clarsimp, rename_tac t')
-  apply(cut_tac s=s' and t=t' and u=u in sources_eq, simp+)
-     apply(fastforce elim: sched_equiv_preserved)
-    apply(fastforce intro: reachable_Step)
-   apply(fastforce intro: reachable_Step)
-  apply(fastforce simp: schedIncludesCurrentDom)
+  apply (rename_tac v s')
+  apply (drule_tac x=v in spec, erule impE, fastforce simp: schedIncludesCurrentDom)
+  apply (cut_tac s=t in enabled_Step[where a=a], simp, clarsimp, rename_tac t')
+  apply (cut_tac s=s' and t=t' and u=u in sources_eq, simp+)
+     apply (fastforce elim: sched_equiv_preserved)
+    apply (fastforce intro: reachable_Step)
+   apply (fastforce intro: reachable_Step)
+  apply (fastforce simp: schedIncludesCurrentDom)
   done
 
-
-
 lemma ipurge_eq':
-  "(\<forall> s t. s\<in>ss \<and> t\<in>ts \<longrightarrow> s \<sim>schedDomain\<sim> t \<and> reachable s \<and> reachable t) \<and>
-   (\<exists> s. s \<in> ss) \<and> (\<exists> t. t \<in> ts) \<and> confidentiality_u
-    \<longrightarrow> ipurge u as ss = ipurge u as ts"
-  proof (induct as arbitrary: ss ts)
+  "(\<forall>s t. s\<in>ss \<and> t\<in>ts \<longrightarrow> s \<sim>schedDomain\<sim> t \<and> reachable s \<and> reachable t) \<and>
+   (\<exists>s. s \<in> ss) \<and> (\<exists>t. t \<in> ts) \<and> confidentiality_u
+   \<longrightarrow> ipurge u as ss = ipurge u as ts"
+proof (induct as arbitrary: ss ts)
   case Nil show ?case
-   apply(simp add: ipurge_def)
-   done
-  next
+    apply (simp add: ipurge_def)
+    done
+next
   case (Cons a as) show ?case
-   apply(clarsimp simp: ipurge_Cons schedIncludesCurrentDom)
-   apply(intro conjI impI)
-      apply(rule "Cons.hyps"[rule_format])
+    apply (clarsimp simp: ipurge_Cons schedIncludesCurrentDom)
+    apply (intro conjI impI)
+       apply (rule "Cons.hyps"[rule_format])
+       apply clarsimp
+       apply (metis sched_equiv_preserved reachable_Step enabled_Step)
       apply clarsimp
-      apply(metis sched_equiv_preserved reachable_Step enabled_Step)
+      apply (drule ipurge_eq'_helper, simp+)[1]
      apply clarsimp
-     apply(drule ipurge_eq'_helper, simp+)[1]
-    apply clarsimp
-    apply(drule ipurge_eq'_helper, (simp add: uwr_sym)+)[1]
-   apply(rule "Cons.hyps"[rule_format], auto)
-   done
-  qed
+     apply (drule ipurge_eq'_helper, (simp add: uwr_sym)+)[1]
+    apply (rule "Cons.hyps"[rule_format], auto)
+    done
+qed
 
 lemma ipurge_eq:
-  "\<lbrakk>s \<sim>schedDomain\<sim> t; reachable s; reachable t;
-    confidentiality_u\<rbrakk> \<Longrightarrow>
-   ipurge u as {s} = ipurge u as {t}"
-  by(rule ipurge_eq'[rule_format], simp)
+  "\<lbrakk> s \<sim>schedDomain\<sim> t; reachable s; reachable t; confidentiality_u \<rbrakk>
+     \<Longrightarrow> ipurge u as {s} = ipurge u as {t}"
+  by (rule ipurge_eq'[rule_format], simp)
 
 lemma Noninfluence_uwr_Noninfluence_strong_uwr:
-  "\<lbrakk>confidentiality_u; Noninfluence_uwr\<rbrakk> \<Longrightarrow> Noninfluence_strong_uwr"
-  apply(clarsimp simp: Noninfluence_uwr_def Noninfluence_strong_uwr_def)
-  apply(frule_tac s=s and t=t and as=as and u=u in ipurge_eq)
+  "\<lbrakk> confidentiality_u; Noninfluence_uwr \<rbrakk> \<Longrightarrow> Noninfluence_strong_uwr"
+  apply (clarsimp simp: Noninfluence_uwr_def Noninfluence_strong_uwr_def)
+  apply (frule_tac s=s and t=t and as=as and u=u in ipurge_eq)
      apply assumption+
-  apply(frule_tac s=s and t=t and as=bs and u=u in ipurge_eq)
+  apply (frule_tac s=s and t=t and as=bs and u=u in ipurge_eq)
      apply assumption+
   apply clarsimp
-  apply(drule_tac x=u in spec)
-  apply(frule_tac x=as in spec)
-  apply(drule_tac x=s in spec, drule_tac x=t in spec)
-  apply(drule_tac x=bs in spec)
-  apply(drule_tac x=t in spec, drule_tac x=t in spec)
+  apply (drule_tac x=u in spec)
+  apply (frule_tac x=as in spec)
+  apply (drule_tac x=s in spec, drule_tac x=t in spec)
+  apply (drule_tac x=bs in spec)
+  apply (drule_tac x=t in spec, drule_tac x=t in spec)
   apply clarsimp
-  apply(rule_tac t=t in uwr_equiv_trans)
+  apply (rule_tac t=t in uwr_equiv_trans)
     apply assumption
    apply assumption
-  apply(rule uwr_equiv_sym)
-  apply(clarsimp simp: sameFor_dom_def uwr_refl)
+  apply (rule uwr_equiv_sym)
+  apply (clarsimp simp: sameFor_dom_def uwr_refl)
   done
 
 lemma Noninfluence_Noninfluence_strong:
-  "\<lbrakk>confidentiality_u; Noninfluence\<rbrakk> \<Longrightarrow> Noninfluence_strong"
-  apply(clarsimp simp: Noninfluence_def Noninfluence_strong_def)
-  apply(frule_tac s=s and t=t and as=as and u=u in ipurge_eq)
+  "\<lbrakk> confidentiality_u; Noninfluence \<rbrakk> \<Longrightarrow> Noninfluence_strong"
+  apply (clarsimp simp: Noninfluence_def Noninfluence_strong_def)
+  apply (frule_tac s=s and t=t and as=as and u=u in ipurge_eq)
      apply assumption+
-  apply(frule_tac s=s and t=t and as=bs and u=u in ipurge_eq)
+  apply (frule_tac s=s and t=t and as=bs and u=u in ipurge_eq)
      apply assumption+
   apply clarsimp
-  apply(drule_tac x=u in spec)
-  apply(frule_tac x=as in spec)
-  apply(drule_tac x=s in spec, drule_tac x=t in spec)
-  apply(drule_tac x=bs in spec)
-  apply(drule_tac x=t in spec, drule_tac x=t in spec)
+  apply (drule_tac x=u in spec)
+  apply (frule_tac x=as in spec)
+  apply (drule_tac x=s in spec, drule_tac x=t in spec)
+  apply (drule_tac x=bs in spec)
+  apply (drule_tac x=t in spec, drule_tac x=t in spec)
   apply clarsimp
-  apply(rule_tac t=t in obs_equiv_trans)
+  apply (rule_tac t=t in obs_equiv_trans)
     apply assumption
    apply assumption
-  apply(rule obs_equiv_sym)
-  apply(clarsimp simp: sameFor_dom_def uwr_refl)
+  apply (rule obs_equiv_sym)
+  apply (clarsimp simp: sameFor_dom_def uwr_refl)
   done
-
 
 lemma dom_in_sources_Cons:
-  "\<lbrakk>confidentiality_u; reachable s; reachable t;
-    s \<approx>(sources (a#as) s u)\<approx> t; s \<sim>schedDomain\<sim> t;
-    (dom a s \<in> sources (a#as) s u)\<rbrakk> \<Longrightarrow>
-    (dom a t \<in> sources (a#as) t u)"
-  apply(subgoal_tac "dom a s = dom a t")
-   apply(fastforce dest: sources_eq)
-  apply(blast intro: schedIncludesCurrentDom)
+  "\<lbrakk> confidentiality_u; reachable s; reachable t; s \<approx>(sources (a#as) s u)\<approx> t;
+     s \<sim>schedDomain\<sim> t; (dom a s \<in> sources (a#as) s u) \<rbrakk>
+     \<Longrightarrow> (dom a t \<in> sources (a#as) t u)"
+  apply (subgoal_tac "dom a s = dom a t")
+   apply (fastforce dest: sources_eq)
+  apply (blast intro: schedIncludesCurrentDom)
   done
-
-
 
 lemma uwr_equiv_Cons_bothI:
-   "\<lbrakk>reachable s; reachable t;
-     \<forall> s' t'. (s,s') \<in> Step a \<and> (t,t') \<in> Step b \<longrightarrow> uwr_equiv s' as t' bs u\<rbrakk> \<Longrightarrow>
-    uwr_equiv s (a # as) t (b # bs) u"
-  apply(clarsimp simp: uwr_equiv_def)
-  apply(clarsimp simp: execution_Run)
-  apply(fastforce simp: execution_Run reachable_Step)
-  done
+  "\<lbrakk> reachable s; reachable t;
+      \<forall>s' t'. (s,s') \<in> Step a \<and> (t,t') \<in> Step b \<longrightarrow> uwr_equiv s' as t' bs u \<rbrakk>
+     \<Longrightarrow> uwr_equiv s (a # as) t (b # bs) u"
+  by (fastforce simp: uwr_equiv_def execution_Run reachable_Step)
 
 lemma uwr_equiv_Cons_leftI:
-   "\<lbrakk>reachable s; \<forall> s'. (s,s') \<in> Step a \<longrightarrow> uwr_equiv s' as t bs u\<rbrakk> \<Longrightarrow>
-    uwr_equiv s (a # as) t bs u"
-  by(fastforce simp: uwr_equiv_def execution_Run reachable_Step)
-
+  "\<lbrakk> reachable s; \<forall>s'. (s,s') \<in> Step a \<longrightarrow> uwr_equiv s' as t bs u \<rbrakk>
+     \<Longrightarrow> uwr_equiv s (a # as) t bs u"
+  by (fastforce simp: uwr_equiv_def execution_Run reachable_Step)
 
 lemma notin_policyI':
-  "\<lbrakk>reachable s;
-    dom a s \<notin> sources (a # list) s u; (s,s') \<in> Step a; ua \<in> sources list s' u\<rbrakk> \<Longrightarrow>
-   (dom a s,ua) \<notin> policy"
-  apply(rule notin_policyI)
-  apply auto
+  "\<lbrakk> reachable s; dom a s \<notin> sources (a # list) s u; (s,s') \<in> Step a; ua \<in> sources list s' u \<rbrakk>
+     \<Longrightarrow> (dom a s,ua) \<notin> policy"
+  apply (rule notin_policyI)
+   apply auto
   done
 
 lemma sources_eq_Step:
-  "\<lbrakk>integrity_u; confidentiality_u; reachable s; (s,s') \<in> Step a; dom a s \<noteq> schedDomain\<rbrakk> \<Longrightarrow>
-   (sources as s' u) = (sources as s u)"
-  apply(rule sources_eq, simp+)
-    apply(rule_tac t=s and s=s and a=a in sched_equiv_preserved_left,
-          (simp add: uwr_refl reachable_Step)+)
+  "\<lbrakk> integrity_u; confidentiality_u; reachable s; (s,s') \<in> Step a; dom a s \<noteq> schedDomain \<rbrakk>
+     \<Longrightarrow> (sources as s' u) = (sources as s u)"
+  apply (rule sources_eq, simp+)
+    apply (rule_tac t=s and s=s and a=a in sched_equiv_preserved_left)
+        apply (auto simp add: uwr_refl reachable_Step)
   done
 
 lemma sources_equiv_preserved_left:
-  "\<lbrakk>integrity_u; confidentiality_u; reachable s; reachable t; s \<sim>schedDomain\<sim> t;
-    dom a s \<notin> sources (a#as) s u; s \<approx>sources (a#as) s u\<approx> t; (s,s') \<in> Step a; dom a s \<noteq> schedDomain\<rbrakk>
-    \<Longrightarrow> s' \<approx>sources as s' u\<approx> t"
-  apply(clarsimp simp: sameFor_dom_def)
-  apply(rename_tac v)
-  apply(case_tac "(dom a s, v) \<in> policy")
-   apply(fastforce simp: sources_Cons)
-  apply(fastforce dest: integrity_uD simp: sources_Cons)
+  "\<lbrakk> integrity_u; confidentiality_u; reachable s; reachable t; s \<sim>schedDomain\<sim> t;
+     dom a s \<notin> sources (a#as) s u; s \<approx>sources (a#as) s u\<approx> t; (s,s') \<in> Step a;
+     dom a s \<noteq> schedDomain \<rbrakk>
+     \<Longrightarrow> s' \<approx>sources as s' u\<approx> t"
+  apply (clarsimp simp: sameFor_dom_def)
+  apply (rename_tac v)
+  apply (case_tac "(dom a s, v) \<in> policy")
+   apply (fastforce simp: sources_Cons)
+  apply (fastforce dest: integrity_uD simp: sources_Cons)
   done
 
 lemma Noninfluence_gen:
-  "\<lbrakk>confidentiality_u; integrity_u\<rbrakk> \<Longrightarrow> Noninfluence_gen"
-  apply(subst Noninfluence_gen_def)
-  apply(intro allI)
-  proof -
+  "\<lbrakk> confidentiality_u; integrity_u \<rbrakk> \<Longrightarrow> Noninfluence_gen"
+  apply (subst Noninfluence_gen_def)
+  apply (intro allI)
+proof -
   assume conf: "confidentiality_u"
   assume integ: "integrity_u"
   fix u as s ts
-  show "reachable s \<and> Ball ts reachable \<longrightarrow>
-          Ball ts (sameFor_dom s (sources as s u)) \<longrightarrow> (\<forall>t\<in>ts. s \<sim>schedDomain\<sim> t)
-          \<longrightarrow> (\<forall>t\<in>ts. uwr_equiv s as t (ipurge u as ts) u)"
-    proof(induct as arbitrary: s ts)
+  show "reachable s \<and> Ball ts reachable
+        \<longrightarrow> Ball ts (sameFor_dom s (sources as s u))
+        \<longrightarrow> (\<forall>t\<in>ts. s \<sim>schedDomain\<sim> t)
+        \<longrightarrow> (\<forall>t\<in>ts. uwr_equiv s as t (ipurge u as ts) u)"
+  proof(induct as arbitrary: s ts)
     case Nil
     show ?case
-      apply(clarsimp simp: sameFor_dom_def ipurge_Nil sources_Nil uwr_equiv_def)
-      apply(clarsimp simp: execution_Run)
+      apply (clarsimp simp: sameFor_dom_def ipurge_Nil sources_Nil uwr_equiv_def)
+      apply (clarsimp simp: execution_Run)
       done
-    next
+  next
     case (Cons a as)
     show ?case
-  apply(clarsimp simp: ipurge_Cons | safe)+
-   apply(rule uwr_equiv_Cons_bothI)
-     apply assumption
-    apply blast
-   apply(clarify)
-   apply(rename_tac ta tb s' tb')
-   apply(rule Cons.hyps[rule_format])
-      apply(blast intro: reachable_Step)
-     apply(clarsimp)
-     apply(rename_tac tc' tc)
-     using conf apply(rule_tac s=s and t=tc and a=a in sources_unwinding_step, simp+)[1]
-    apply(clarsimp, rename_tac tc' tc)
-    apply(rule sched_equiv_preserved[OF conf], (auto simp: sources_refl))[1]
-   apply blast
-  apply(rename_tac ta)
-  apply(rule uwr_equiv_Cons_leftI, blast)
-  apply(clarsimp, rename_tac s')
-  apply(case_tac "dom a s = schedDomain")
-   apply(cut_tac s=s and a=a and as=as and u=u in schedDomain_in_sources_Cons, assumption+)
-   apply(metis schedIncludesCurrentDom sources_eq[OF conf])
-  apply(rule Cons.hyps[rule_format])
-     apply(blast intro: reachable_Step)
-    apply(rename_tac tb)
-    apply(rule_tac a=a in sources_equiv_preserved_left[OF integ conf], simp+)
-       apply(fastforce simp: schedIncludesCurrentDom sources_eq[OF conf])
-      apply blast
-     apply assumption
-    apply assumption
-   apply(rule_tac s=s and a=a in sched_equiv_preserved_left[OF integ], simp+)
-  done
+      apply (clarsimp simp: ipurge_Cons | safe)+
+       apply (rule uwr_equiv_Cons_bothI)
+         apply assumption
+        apply blast
+       apply (clarify)
+       apply (rename_tac ta tb s' tb')
+       apply (rule Cons.hyps[rule_format])
+          apply (blast intro: reachable_Step)
+         apply (clarsimp)
+         apply (rename_tac tc' tc)
+      using conf apply (rule_tac s=s and t=tc and a=a in sources_unwinding_step, simp+)[1]
+        apply (clarsimp, rename_tac tc' tc)
+        apply (rule sched_equiv_preserved[OF conf], (auto simp: sources_refl))[1]
+       apply blast
+      apply (rename_tac ta)
+      apply (rule uwr_equiv_Cons_leftI, blast)
+      apply (clarsimp, rename_tac s')
+      apply (case_tac "dom a s = schedDomain")
+       apply (cut_tac s=s and a=a and as=as and u=u in schedDomain_in_sources_Cons, assumption+)
+       apply (metis schedIncludesCurrentDom sources_eq[OF conf])
+      apply (rule Cons.hyps[rule_format])
+         apply (blast intro: reachable_Step)
+        apply (rename_tac tb)
+        apply (rule_tac a=a in sources_equiv_preserved_left[OF integ conf], simp+)
+           apply (fastforce simp: schedIncludesCurrentDom sources_eq[OF conf])
+          apply blast
+         apply assumption
+        apply assumption
+       apply (rule_tac s=s and a=a in sched_equiv_preserved_left[OF integ], simp+)
+      done
   qed
-  qed
+qed
 
 lemma Nonleakage_gen:
-  "\<lbrakk>confidentiality_u\<rbrakk> \<Longrightarrow> Nonleakage_gen"
-  apply(subst Nonleakage_gen_def)
-  apply(rule allI)
-  apply(induct_tac as)
-   apply(simp add: sources_Nil uwr_equiv_def execution_Run sameFor_dom_def)
-  apply(clarsimp)
-  apply(rule uwr_equiv_Cons_bothI)
+  "confidentiality_u \<Longrightarrow> Nonleakage_gen"
+  apply (subst Nonleakage_gen_def)
+  apply (rule allI)
+  apply (induct_tac as)
+   apply (simp add: sources_Nil uwr_equiv_def execution_Run sameFor_dom_def)
+  apply (clarsimp)
+  apply (rule uwr_equiv_Cons_bothI)
     apply assumption
    apply assumption
   apply clarsimp
-  apply(drule_tac x=s' in spec, drule_tac x=u in spec, drule_tac x=t' in spec)
-  apply(clarsimp simp: reachable_Step)
-  apply(erule impE)
-   apply(blast intro: sched_equiv_preserved)
-  apply(erule mp)
-  apply(blast intro: sources_unwinding_step)
+  apply (drule_tac x=s' in spec, drule_tac x=u in spec, drule_tac x=t' in spec)
+  apply (clarsimp simp: reachable_Step)
+  apply (erule impE)
+   apply (blast intro: sched_equiv_preserved)
+  apply (erule mp)
+  apply (blast intro: sources_unwinding_step)
   done
 
-
-
 lemma Noninterference:
-  "\<lbrakk>confidentiality_u_weak; output_consistent; integrity_u\<rbrakk> \<Longrightarrow>
-   Noninterference"
-  apply(rule Noninfluence_gen_Noninterference)
+  "\<lbrakk> confidentiality_u_weak; output_consistent; integrity_u \<rbrakk>
+     \<Longrightarrow> Noninterference"
+  apply (rule Noninfluence_gen_Noninterference)
    apply assumption
-  apply(blast intro: Noninfluence_gen confidentiality_u_weak)
+  apply (blast intro: Noninfluence_gen confidentiality_u_weak)
   done
 
 lemma Noninterference_strong:
-  "\<lbrakk>confidentiality_u_weak; output_consistent; integrity_u\<rbrakk> \<Longrightarrow>
-   Noninterference_strong"
-  apply(rule Noninfluence_gen_Noninterference_strong)
+  "\<lbrakk> confidentiality_u_weak; output_consistent; integrity_u \<rbrakk>
+     \<Longrightarrow> Noninterference_strong"
+  apply (rule Noninfluence_gen_Noninterference_strong)
    apply assumption
-  apply(blast intro: Noninfluence_gen confidentiality_u_weak)
+  apply (blast intro: Noninfluence_gen confidentiality_u_weak)
   done
 
-
-
 lemma Noninfluence:
-  "\<lbrakk>confidentiality_u_weak; output_consistent; integrity_u\<rbrakk> \<Longrightarrow>
-   Noninfluence"
-  apply(rule Noninfluence_gen_Noninfluence)
+  "\<lbrakk> confidentiality_u_weak; output_consistent; integrity_u \<rbrakk>
+     \<Longrightarrow> Noninfluence"
+  apply (rule Noninfluence_gen_Noninfluence)
    apply assumption
-  apply(blast intro: Noninfluence_gen confidentiality_u_weak)
+  apply (blast intro: Noninfluence_gen confidentiality_u_weak)
   done
 
 lemma Noninfluence_strong:
-  "\<lbrakk>confidentiality_u_weak; output_consistent; integrity_u\<rbrakk> \<Longrightarrow>
-   Noninfluence_strong"
-  apply(rule Noninfluence_Noninfluence_strong)
-   apply(blast intro: confidentiality_u_weak)
-  apply(blast intro: Noninfluence)
+  "\<lbrakk> confidentiality_u_weak; output_consistent; integrity_u \<rbrakk>
+     \<Longrightarrow> Noninfluence_strong"
+  apply (rule Noninfluence_Noninfluence_strong)
+   apply (blast intro: confidentiality_u_weak)
+  apply (blast intro: Noninfluence)
   done
 
 
 lemma Noninfluence_uwr:
-  "\<lbrakk>confidentiality_u_weak; integrity_u\<rbrakk> \<Longrightarrow>
-   Noninfluence_uwr"
-  apply(rule Noninfluence_gen_Noninfluence_uwr)
-  apply(blast intro: Noninfluence_gen confidentiality_u_weak)
+  "\<lbrakk> confidentiality_u_weak; integrity_u \<rbrakk>
+     \<Longrightarrow> Noninfluence_uwr"
+  apply (rule Noninfluence_gen_Noninfluence_uwr)
+  apply (blast intro: Noninfluence_gen confidentiality_u_weak)
   done
 
 lemma Noninfluence_strong_uwr:
-  "\<lbrakk>confidentiality_u_weak; integrity_u\<rbrakk> \<Longrightarrow>
-   Noninfluence_strong_uwr"
-  apply(rule Noninfluence_uwr_Noninfluence_strong_uwr)
-   apply(blast intro: confidentiality_u_weak)
-  apply(blast intro: Noninfluence_uwr)
+  "\<lbrakk> confidentiality_u_weak; integrity_u \<rbrakk>
+     \<Longrightarrow> Noninfluence_strong_uwr"
+  apply (rule Noninfluence_uwr_Noninfluence_strong_uwr)
+   apply (blast intro: confidentiality_u_weak)
+  apply (blast intro: Noninfluence_uwr)
   done
 
 lemma sources_Step:
-  "\<lbrakk>reachable s; (dom a s, u) \<notin> policy\<rbrakk> \<Longrightarrow>
-  sources [a] s u = {u}"
-  apply(auto simp: sources_Cons sources_Nil enabled_Step dest: enabled_Step)
-  done
+  "\<lbrakk> reachable s; (dom a s, u) \<notin> policy \<rbrakk>
+     \<Longrightarrow> sources [a] s u = {u}"
+  by (auto simp: sources_Cons sources_Nil enabled_Step dest: enabled_Step)
 
 lemma sources_Step_2:
-  "\<lbrakk>reachable s; (dom a s, u) \<in> policy\<rbrakk> \<Longrightarrow>
-  sources [a] s u = {dom a s,u}"
-  apply(auto simp: sources_Cons sources_Nil enabled_Step dest: enabled_Step)
-  done
+  "\<lbrakk> reachable s; (dom a s, u) \<in> policy \<rbrakk>
+     \<Longrightarrow> sources [a] s u = {dom a s,u}"
+  by (auto simp: sources_Cons sources_Nil enabled_Step dest: enabled_Step)
 
 lemma execution_Nil:
   "reachable s \<Longrightarrow> execution A s [] = {s}"
-  apply(simp add: execution_Run)
-  done
+  by (simp add: execution_Run)
 
 lemma Noninfluence_gen_confidentiality_u_weak:
   "Noninfluence_gen \<Longrightarrow> confidentiality_u_weak"
-  apply(clarsimp simp: Noninfluence_gen_def confidentiality_u_weak_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x="{t}" in spec)
-  apply(simp add: sources_Step_2 sameFor_dom_def uwr_equiv_def Step_def ipurge_Cons ipurge_Nil
-           split: if_splits
-             add: schedIncludesCurrentDom)
+  apply (clarsimp simp: Noninfluence_gen_def confidentiality_u_weak_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x="{t}" in spec)
+  apply (simp add: sources_Step_2 sameFor_dom_def uwr_equiv_def Step_def
+                   ipurge_Cons ipurge_Nil schedIncludesCurrentDom
+            split: if_splits)
   done
 
 lemma Noninfluence_strong_uwr_confidentiality_u_weak:
   "Noninfluence_strong_uwr \<Longrightarrow> confidentiality_u_weak"
-  apply(clarsimp simp: Noninfluence_strong_uwr_def confidentiality_u_weak_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=t in spec)
-  apply(simp add: sources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
+  apply (clarsimp simp: Noninfluence_strong_uwr_def confidentiality_u_weak_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=t in spec)
+  apply (simp add: sources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
   done
 
 lemma Nonleakage_gen_confidentiality_u:
   "Nonleakage_gen \<Longrightarrow> confidentiality_u"
-  apply(clarsimp simp: Nonleakage_gen_def confidentiality_u_def)
-  apply(drule_tac x="[a]" in spec, drule_tac x=s in spec)
-  apply(drule_tac x=u in spec, drule_tac x=t in spec)
-  apply(case_tac "dom a s \<leadsto> u")
-   apply(simp add: sources_Step_2 uwr_equiv_def sameFor_dom_def Step_def)
-  apply(simp add: sources_Step uwr_equiv_def sameFor_dom_def Step_def)
+  apply (clarsimp simp: Nonleakage_gen_def confidentiality_u_def)
+  apply (drule_tac x="[a]" in spec, drule_tac x=s in spec)
+  apply (drule_tac x=u in spec, drule_tac x=t in spec)
+  apply (case_tac "dom a s \<leadsto> u")
+   apply (simp add: sources_Step_2 uwr_equiv_def sameFor_dom_def Step_def)
+  apply (simp add: sources_Step uwr_equiv_def sameFor_dom_def Step_def)
   done
 
 lemma Nonleakage_gen_equiv_confidentiality_u:
   "Nonleakage_gen = confidentiality_u"
-  apply(blast intro: Nonleakage_gen_confidentiality_u Nonleakage_gen)
-  done
+  by (blast intro: Nonleakage_gen_confidentiality_u Nonleakage_gen)
 
 lemma non_sched_doms_cannot_schedule:
-  "\<lbrakk>integrity_u; reachable s; dom a s \<noteq> schedDomain; (s,s') \<in> Step a\<rbrakk> \<Longrightarrow> s \<sim>schedDomain\<sim> s'"
-  apply(drule_tac u=schedDomain in integrity_uD)
+  "\<lbrakk> integrity_u; reachable s; dom a s \<noteq> schedDomain; (s,s') \<in> Step a \<rbrakk>
+     \<Longrightarrow> s \<sim>schedDomain\<sim> s'"
+  apply (drule_tac u=schedDomain in integrity_uD)
       apply assumption
-     apply(erule contrapos_nn)
-     apply(erule schedNotGlobalChannel)
-    apply(rule uwr_refl)
+     apply (erule contrapos_nn)
+     apply (erule schedNotGlobalChannel)
+    apply (rule uwr_refl)
    apply assumption
-  apply(erule uwr_sym)
+  apply (erule uwr_sym)
   done
 
 
@@ -1339,29 +1244,29 @@ text \<open>
    event) doesn't satisfy @{prop integrity_u}.
 \<close>
 lemma integrity_u_and_single_event_systems:
-  "\<lbrakk>integrity_u; reachable s; dom a s \<noteq> schedDomain; s' \<in> execution A s as;
-    \<forall> y::'e. y = a\<rbrakk> \<Longrightarrow> dom e s' \<noteq> schedDomain"
-  apply(frule_tac x=e in spec)
-  apply(erule ssubst)
-  apply(rule_tac P="\<lambda>x. x \<noteq> schedDomain" in subst[rotated])
+  "\<lbrakk> integrity_u; reachable s; dom a s \<noteq> schedDomain; s' \<in> execution A s as; \<forall>y. y = a \<rbrakk>
+     \<Longrightarrow> dom e s' \<noteq> schedDomain"
+  apply (frule_tac x=e in spec)
+  apply (erule ssubst)
+  apply (rule_tac P="\<lambda>x. x \<noteq> schedDomain" in subst[rotated])
    apply assumption
-  apply(induct as arbitrary: s s' a rule: rev_induct)
-   apply(simp add: execution_Run)
-  apply(simp add: execution_Run)
-  apply(drule Run_mid)
-  apply(erule exE, rename_tac t)
-  apply(drule_tac x=s in meta_spec)
-  apply(drule_tac x=t in meta_spec)
-  apply(drule_tac x=a in meta_spec)
+  apply (induct as arbitrary: s s' a rule: rev_induct)
+   apply (simp add: execution_Run)
+  apply (simp add: execution_Run)
+  apply (drule Run_mid)
+  apply (erule exE, rename_tac t)
+  apply (drule_tac x=s in meta_spec)
+  apply (drule_tac x=t in meta_spec)
+  apply (drule_tac x=a in meta_spec)
   apply simp
-  apply(rule schedIncludesCurrentDom)
-  apply(rule non_sched_doms_cannot_schedule)
+  apply (rule schedIncludesCurrentDom)
+  apply (rule non_sched_doms_cannot_schedule)
      apply assumption
-    apply(rule reachable_execution)
+    apply (rule reachable_execution)
      apply assumption
-    apply(fastforce simp: execution_Run)
+    apply (fastforce simp: execution_Run)
    apply assumption
-  apply(drule_tac x=x in spec)
+  apply (drule_tac x=x in spec)
   apply blast
   done
 
@@ -1372,31 +1277,30 @@ subsection \<open>Complete unwinding system\<close>
 
 text \<open>The unwinding conditions are not only sound but also complete when policy is reflexive\<close>
 locale complete_unwinding_system = unwinding_system +
-  assumes  policy_refl:
-  "(u,u) \<in> policy"
+  assumes policy_refl: "(u,u) \<in> policy"
 begin
 
 lemma Noninfluence_gen_integrity_u:
   "Noninfluence_gen \<Longrightarrow> integrity_u"
-  apply(clarsimp simp: Noninfluence_gen_def integrity_u_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x="{s}" in spec)
-  apply(simp add: sources_Step sameFor_dom_def uwr_equiv_def Step_def ipurge_Cons ipurge_Nil
-           split: if_splits add: uwr_refl policy_refl execution_Nil uwr_sym)
+  apply (clarsimp simp: Noninfluence_gen_def integrity_u_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x="{s}" in spec)
+  apply (simp add: sources_Step sameFor_dom_def uwr_equiv_def Step_def ipurge_Cons ipurge_Nil
+                   uwr_refl policy_refl execution_Nil uwr_sym
+            split: if_splits )
   done
-
 
 lemma Noninfluence_strong_uwr_integrity_u:
   "Noninfluence_strong_uwr \<Longrightarrow> integrity_u"
-  apply(clarsimp simp: Noninfluence_strong_uwr_def integrity_u_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=s in spec)
-  apply(simp add: sources_Step sameFor_dom_def uwr_refl uwr_equiv_def Step_def ipurge_Cons
-                  ipurge_Nil
-           split: if_splits)
-   apply(simp add: policy_refl)
-  apply(simp add: execution_Nil)
-  apply(blast intro: uwr_sym)
+  apply (clarsimp simp: Noninfluence_strong_uwr_def integrity_u_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=s in spec)
+  apply (simp add: sources_Step sameFor_dom_def uwr_refl
+                   uwr_equiv_def Step_def ipurge_Cons ipurge_Nil
+            split: if_splits)
+   apply (simp add: policy_refl)
+  apply (simp add: execution_Nil)
+  apply (blast intro: uwr_sym)
   done
 
 text \<open>
@@ -1407,14 +1311,14 @@ text \<open>
 \<close>
 lemma Noninfluence_gen_equiv_Noninfluence_strong_uwr:
   "Noninfluence_gen = Noninfluence_strong_uwr"
-  apply(rule iffI)
-   apply(rule Noninfluence_strong_uwr)
-    apply(erule Noninfluence_gen_confidentiality_u_weak)
-   apply(erule Noninfluence_gen_integrity_u)
-  apply(rule Noninfluence_gen)
-   apply(rule confidentiality_u_weak)
-    apply(erule Noninfluence_strong_uwr_confidentiality_u_weak)
-   apply(erule Noninfluence_strong_uwr_integrity_u)+
+  apply (rule iffI)
+   apply (rule Noninfluence_strong_uwr)
+    apply (erule Noninfluence_gen_confidentiality_u_weak)
+   apply (erule Noninfluence_gen_integrity_u)
+  apply (rule Noninfluence_gen)
+   apply (rule confidentiality_u_weak)
+    apply (erule Noninfluence_strong_uwr_confidentiality_u_weak)
+   apply (erule Noninfluence_strong_uwr_integrity_u)+
   done
 
 end

--- a/proof/infoflow/Noninterference_Base_Alternatives.thy
+++ b/proof/infoflow/Noninterference_Base_Alternatives.thy
@@ -8,7 +8,6 @@ theory Noninterference_Base_Alternatives
 imports Noninterference_Base "Lib.Eisbach_Methods"
 begin
 
-
 text \<open>
   This theory explores a bunch of alternative definitions for the @{term sources}
   and @{term ipurge} functions that are the basis of our noninterference formulation
@@ -16,180 +15,165 @@ text \<open>
 \<close>
 context noninterference_system begin
 
-
 (* the following definition turns out to yield an information flow property equivalent
    to the above one -- see below *)
-primrec xources :: "'e list \<Rightarrow> 's \<Rightarrow> 'd \<Rightarrow> 'd set"
-where
- xources_Nil: "xources [] s u = {u}"|
- xources_Cons: "xources (a#as) s u = (\<Inter>{xources as s' u| s'. (s,s') \<in> Step a}) \<union>
-      {w. w = dom a s \<and> (\<forall> s'. (s,s') \<in> Step a \<longrightarrow> (\<exists> v. dom a s \<leadsto> v \<and> v \<in> xources as s' u))}"
+primrec xources :: "'e list \<Rightarrow> 's \<Rightarrow> 'd \<Rightarrow> 'd set" where
+  xources_Nil: "xources [] s u = {u}"
+| xources_Cons: "xources (a # as) s u =
+    (\<Inter>{xources as s' u | s'. (s,s') \<in> Step a}) \<union>
+    {w. w = dom a s \<and> (\<forall>s'. (s,s') \<in> Step a \<longrightarrow> (\<exists>v. dom a s \<leadsto> v \<and> v \<in> xources as s' u))}"
 
 lemma in_xources_ConsD:
-  "x \<in> (xources (a # as) s u) \<Longrightarrow>
-   (\<forall> s'. (s,s') \<in> Step a \<longrightarrow> x \<in> xources as s' u) \<or>
-   (x = dom a s \<and> (\<forall> s'. (s,s') \<in> Step a \<longrightarrow> (\<exists> v. dom a s \<leadsto> v \<and> v \<in> xources as s' u)))"
+  "x \<in> (xources (a # as) s u)
+   \<Longrightarrow> (\<forall>s'. (s,s') \<in> Step a \<longrightarrow> x \<in> xources as s' u) \<or>
+       (x = dom a s \<and> (\<forall>s'. (s,s') \<in> Step a \<longrightarrow> (\<exists>v. dom a s \<leadsto> v \<and> v \<in> xources as s' u)))"
   by auto
 
 lemma in_xources_ConsI1:
-  "\<lbrakk>\<forall> s'. (s,s') \<in> Step a \<longrightarrow> x \<in> xources as s' u\<rbrakk> \<Longrightarrow> x \<in> xources (a#as) s u"
+  "(\<forall>s'. (s,s') \<in> Step a \<longrightarrow> x \<in> xources as s' u)
+   \<Longrightarrow> x \<in> xources (a # as) s u"
   by auto
 
 lemma in_xources_ConsI2:
-  "\<lbrakk>x = dom a s; \<forall> s'. (s,s') \<in> Step a \<longrightarrow> (\<exists> v. dom a s \<leadsto> v \<and> v \<in> xources as s' u)\<rbrakk> \<Longrightarrow>
-  x \<in> xources (a#as) s u"
+  "\<lbrakk> x = dom a s; \<forall>s'. (s,s') \<in> Step a \<longrightarrow> (\<exists>v. dom a s \<leadsto> v \<and> v \<in> xources as s' u) \<rbrakk>
+     \<Longrightarrow> x \<in> xources (a # as) s u"
   by auto
-
 
 declare xources_Nil [simp del]
 declare xources_Cons [simp del]
 
-
 lemma xources_subset_xources_Cons:
-  "\<Inter>{xources as s' u|s'. (s,s') \<in> Step a} \<subseteq> xources (a#as) s u"
-  by(fastforce simp: xources_Cons)
+  "\<Inter>{xources as s' u | s'. (s,s') \<in> Step a} \<subseteq> xources (a # as) s u"
+  by (fastforce simp: xources_Cons)
 
+primrec gen_purgx :: "('e list \<Rightarrow> 's \<Rightarrow> 'd \<Rightarrow> 'd set) \<Rightarrow> 'd \<Rightarrow> 'e list \<Rightarrow> 's set \<Rightarrow> 'e list" where
+  Nil: "gen_purgx sf u [] ss = []"
+| Cons: "gen_purgx sf u (a#as) ss = (if \<forall>s \<in> ss. dom a s \<in> sf (a#as) s u
+                                     then a # gen_purgx sf u as (\<Union>s \<in> ss. {s'. (s,s') \<in> Step a})
+                                     else gen_purgx sf u as ss)"
 
-primrec gen_purgx :: "('e list \<Rightarrow> 's \<Rightarrow> 'd \<Rightarrow> 'd set) \<Rightarrow> 'd \<Rightarrow> 'e list \<Rightarrow> 's set \<Rightarrow> 'e list"
-where
-  Nil : "gen_purgx sf u []     ss = []" |
-  Cons: "gen_purgx sf u (a#as) ss =
-            (if (\<forall>s\<in>ss. dom a s \<in> sf (a#as) s u) then
-               a#gen_purgx sf u as (\<Union>s\<in>ss. {s'. (s,s') \<in> Step a})
-             else
-               gen_purgx sf u as ss)"
+definition xpurge :: "'d \<Rightarrow> 'e list \<Rightarrow> 's set \<Rightarrow> 'e list" where
+  "xpurge \<equiv> gen_purge xources"
 
+definition ipurgx :: "'d \<Rightarrow> 'e list \<Rightarrow> 's set \<Rightarrow> 'e list" where
+  "ipurgx \<equiv> gen_purgx sources"
 
-
-definition xpurge :: "'d \<Rightarrow> 'e list \<Rightarrow> 's set \<Rightarrow> 'e list"
-where
- "xpurge \<equiv> gen_purge xources"
-
-definition ipurgx :: "'d \<Rightarrow> 'e list \<Rightarrow> 's set \<Rightarrow> 'e list"
-where
- "ipurgx \<equiv> gen_purgx sources"
-
-definition xpurgx :: "'d \<Rightarrow> 'e list \<Rightarrow> 's set \<Rightarrow> 'e list"
-where
- "xpurgx \<equiv> gen_purgx xources"
-
+definition xpurgx :: "'d \<Rightarrow> 'e list \<Rightarrow> 's set \<Rightarrow> 'e list" where
+  "xpurgx \<equiv> gen_purgx xources"
 
 lemma xpurge_Nil:
   "xpurge u [] ss = []"
-  by(auto simp: xpurge_def)
+  by (auto simp: xpurge_def)
 
 lemma ipurgx_Nil:
   "ipurgx u [] ss = []"
-  by(auto simp: ipurgx_def)
+  by (auto simp: ipurgx_def)
 
 lemma xpurgx_Nil:
   "xpurgx u [] ss = []"
-  by(auto simp: xpurgx_def)
+  by (auto simp: xpurgx_def)
 
 lemma xpurge_Cons:
-  "xpurge u (a#as) ss =
-     (if (\<exists>s\<in>ss. dom a s \<in> xources (a#as) s u) then
-         a#xpurge u as (\<Union>s\<in>ss. {s'. (s,s') \<in> Step a})
-      else
-         xpurge u as ss)"
+  "xpurge u (a # as) ss = (if \<exists>s \<in> ss. dom a s \<in> xources (a # as) s u
+                           then a # xpurge u as (\<Union>s\<in>ss. {s'. (s,s') \<in> Step a})
+                           else xpurge u as ss)"
   by (auto simp: xpurge_def)
 
 lemma ipurgx_Cons:
-  "ipurgx u (a#as) ss =
-     (if (\<forall>s\<in>ss. dom a s \<in> sources (a#as) s u) then
-         a#ipurgx u as (\<Union>s\<in>ss. {s'. (s,s') \<in> Step a})
-      else
-         ipurgx u as ss)"
+  "ipurgx u (a # as) ss = (if (\<forall>s\<in>ss. dom a s \<in> sources (a # as) s u)
+                           then a # ipurgx u as (\<Union>s \<in> ss. {s'. (s,s') \<in> Step a})
+                           else ipurgx u as ss)"
   by (auto simp: ipurgx_def)
 
 lemma xpurgx_Cons:
-  "xpurgx u (a#as) ss =
-     (if (\<forall>s\<in>ss. dom a s \<in> xources (a#as) s u) then
-         a#xpurgx u as (\<Union>s\<in>ss. {s'. (s,s') \<in> Step a})
-      else
-         xpurgx u as ss)"
+  "xpurgx u (a # as) ss = (if (\<forall>s\<in>ss. dom a s \<in> xources (a # as) s u)
+                           then a # xpurgx u as (\<Union>s\<in>ss. {s'. (s,s') \<in> Step a})
+                           else xpurgx u as ss)"
   by (auto simp: xpurgx_def)
 
-definition xNonleakage_gen :: "bool" where
-  "xNonleakage_gen \<equiv> \<forall>as s u t. reachable s \<and> reachable t \<longrightarrow>
-     s \<sim>schedDomain\<sim> t \<longrightarrow>
-       s \<approx>(xources as s u)\<approx> t \<longrightarrow> uwr_equiv s as t as u"
-
+definition xNonleakage_gen :: bool where
+  "xNonleakage_gen \<equiv> \<forall>as s u t. reachable s \<and> reachable t
+                                 \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                 \<longrightarrow> s \<approx>(xources as s u)\<approx> t
+                                 \<longrightarrow> uwr_equiv s as t as u"
 
 end
 
+
 context unwinding_system begin
+
 lemma xources_sources:
   "confidentiality_u \<Longrightarrow> reachable s \<longrightarrow> (xources as s u = sources as s u)"
-  apply(induct as arbitrary: s)
-   apply(simp add: xources_Nil sources_Nil)
-  apply(simp add: sources_Cons xources_Cons)
-  apply(rule impI)
-  apply(rule un_eq)
-   apply(rule sym)
-   apply(simp only: Union_eq, simp only: UNION_eq[symmetric])
-   apply(simp only: Inter_eq, simp only: INTER_eq[symmetric])
-   apply(rule Un_eq_Int)
+  apply (induct as arbitrary: s)
+   apply (simp add: xources_Nil sources_Nil)
+  apply (simp add: sources_Cons xources_Cons)
+  apply (rule impI)
+  apply (rule un_eq)
+   apply (rule sym)
+   apply (simp only: Union_eq, simp only: UNION_eq[symmetric])
+   apply (simp only: Inter_eq, simp only: INTER_eq[symmetric])
+   apply (rule Un_eq_Int)
      apply (clarsimp simp: Step_def)
-     apply(erule reachable_enabled)
+     apply (erule reachable_enabled)
     apply (clarsimp simp: Step_def)
-    apply(erule reachable_enabled)
+    apply (erule reachable_enabled)
    apply clarsimp
-   apply(drule_tac x=s'a in meta_spec, clarsimp simp: reachable_Step)
-   apply(rule sources_eq)
+   apply (drule_tac x=s'a in meta_spec, clarsimp simp: reachable_Step)
+   apply (rule sources_eq)
       apply assumption
-     apply(fastforce intro: sched_equiv_preserved uwr_refl)
-    apply(fastforce intro: reachable_Step)
-   apply(fastforce intro: reachable_Step)
-  apply(rule Collect_cong)
-  apply(rule conj_cong, rule refl)
+     apply (fastforce intro: sched_equiv_preserved uwr_refl)
+    apply (fastforce intro: reachable_Step)
+   apply (fastforce intro: reachable_Step)
+  apply (rule Collect_cong)
+  apply (rule conj_cong, rule refl)
   apply safe
-   apply(cut_tac s=s and a=a in enabled_Step)
+   apply (cut_tac s=s and a=a in enabled_Step)
     apply assumption
    apply clarsimp
-   apply(drule_tac x=s' in spec)
+   apply (drule_tac x=s' in spec)
    apply clarsimp
-   apply(rule_tac x=v in exI)
+   apply (rule_tac x=v in exI)
    apply clarsimp
-   apply(rule_tac x=s' in exI)
-   apply(drule_tac x=s' in meta_spec)
-   apply(fastforce intro: reachable_Step)
-  apply(rule_tac x=v in exI, clarsimp)
-  apply(drule_tac x=s' in meta_spec)
-  apply(clarsimp simp: reachable_Step)
-  apply(rule subst[OF sources_eq])
+   apply (rule_tac x=s' in exI)
+   apply (drule_tac x=s' in meta_spec)
+   apply (fastforce intro: reachable_Step)
+  apply (rule_tac x=v in exI, clarsimp)
+  apply (drule_tac x=s' in meta_spec)
+  apply (clarsimp simp: reachable_Step)
+  apply (rule subst[OF sources_eq])
       apply assumption
      prefer 4
      apply assumption
-    apply(fastforce intro: sched_equiv_preserved uwr_refl)
-  by(auto intro: reachable_Step)
+    apply (fastforce intro: sched_equiv_preserved uwr_refl)
+  by (auto intro: reachable_Step)
 
 lemma xpurge_ipurge':
-  "confidentiality_u \<Longrightarrow> (\<forall> s\<in>ss. reachable s) \<longrightarrow> xpurge u as ss = ipurge u as ss"
-  apply(induct as arbitrary: ss)
-   apply(simp add: xpurge_Nil ipurge_Nil)
-  apply(clarsimp simp: ipurge_Cons xpurge_Cons xources_sources[rule_format] intro: reachable_Step
-       | safe)+
-  apply(drule_tac x="\<Union>s\<in>ss. {s'. (s,s') \<in> Step a}" in meta_spec)
-  apply(fastforce intro: reachable_Step)
+  "confidentiality_u
+   \<Longrightarrow> (\<forall>s\<in>ss. reachable s) \<longrightarrow> xpurge u as ss = ipurge u as ss"
+  apply (induct as arbitrary: ss)
+   apply (simp add: xpurge_Nil ipurge_Nil)
+  apply (clarsimp simp: ipurge_Cons xpurge_Cons xources_sources[rule_format] intro: reachable_Step
+         | safe)+
+  apply (drule_tac x="\<Union>s\<in>ss. {s'. (s,s') \<in> Step a}" in meta_spec)
+  apply (fastforce intro: reachable_Step)
   done
 
 lemma ipurgx_xpurge':
   "confidentiality_u
-   \<Longrightarrow> (\<forall> s\<in>ss. reachable s) \<and> (\<exists>s. s \<in> ss) \<and>
-       (\<forall> s s'. s\<in>ss \<and> s'\<in>ss \<longrightarrow> s\<sim>schedDomain\<sim>s') \<longrightarrow> ipurgx u as ss = xpurge u as ss"
-  apply(induct as arbitrary: ss)
-   apply(simp add: ipurgx_Nil xpurge_Nil)
-  apply(clarsimp simp: xpurge_Cons ipurgx_Cons | safe)+
-    apply(drule_tac x="\<Union>s\<in>ss. {s'. (s,s') \<in> Step a}" in meta_spec)
-    apply(erule impE)
-     apply(rule conjI)
-      apply(fastforce intro: reachable_Step)
-     apply(rule conjI)
-      apply(drule bspec, assumption, frule_tac a=a in enabled_Step)
+   \<Longrightarrow> (\<forall>s\<in>ss. reachable s) \<and> (\<exists>s. s \<in> ss) \<and> (\<forall>s s'. s\<in>ss \<and> s'\<in>ss \<longrightarrow> s\<sim>schedDomain\<sim>s')
+       \<longrightarrow> ipurgx u as ss = xpurge u as ss"
+  apply (induct as arbitrary: ss)
+   apply (simp add: ipurgx_Nil xpurge_Nil)
+  apply (clarsimp simp: xpurge_Cons ipurgx_Cons | safe)+
+    apply (drule_tac x="\<Union>s\<in>ss. {s'. (s,s') \<in> Step a}" in meta_spec)
+    apply (erule impE)
+     apply (rule conjI)
+      apply (fastforce intro: reachable_Step)
+     apply (rule conjI)
+      apply (drule bspec, assumption, frule_tac a=a in enabled_Step)
       apply blast
      apply clarsimp
-     apply(match conclusion in \<open>s' \<sim>schedDomain\<sim> t'\<close> for s' t' \<Rightarrow>
+     apply (match conclusion in \<open>s' \<sim>schedDomain\<sim> t'\<close> for s' t' \<Rightarrow>
              \<open>match premises in \<open>(s,s') \<in> Step a\<close> and \<open>(t,t') \<in> Step a\<close> for a s t \<Rightarrow>
                 \<open>rule sched_equiv_preserved[of s t]\<close>\<close>)
           apply assumption
@@ -199,392 +183,383 @@ lemma ipurgx_xpurge':
       apply assumption
      apply assumption
     apply assumption
-   apply(simp add: xources_sources)
-  apply(simp add: xources_sources)
-  apply(erule notE)
-  apply(frule_tac s=s and t=sa in sources_eq, simp+)
-  apply(erule ssubst)
-  apply(subst schedIncludesCurrentDom)
+   apply (simp add: xources_sources)
+  apply (simp add: xources_sources)
+  apply (erule notE)
+  apply (frule_tac s=s and t=sa in sources_eq, simp+)
+  apply (erule ssubst)
+  apply (subst schedIncludesCurrentDom)
    prefer 2
    apply assumption
   apply blast
   done
 
 lemma ipurgx_xpurgx':
-  "confidentiality_u \<Longrightarrow> (\<forall> s\<in>ss. reachable s)  \<longrightarrow> ipurgx u as ss = xpurgx u as ss"
-  apply(induct as arbitrary: ss)
-   apply(simp add: ipurgx_Nil xpurgx_Nil)
-  apply(clarsimp simp: xpurgx_Cons ipurgx_Cons | safe)+
-    apply(drule_tac x="\<Union>s\<in>ss. {s'. (s,s') \<in> Step a}" in meta_spec)
-    apply(fastforce intro: reachable_Step)
-   apply(simp add: xources_sources)
-  apply(simp add: xources_sources)
+  "confidentiality_u \<Longrightarrow> (\<forall>s\<in>ss. reachable s) \<longrightarrow> ipurgx u as ss = xpurgx u as ss"
+  apply (induct as arbitrary: ss)
+   apply (simp add: ipurgx_Nil xpurgx_Nil)
+  apply (clarsimp simp: xpurgx_Cons ipurgx_Cons | safe)+
+    apply (drule_tac x="\<Union>s\<in>ss. {s'. (s,s') \<in> Step a}" in meta_spec)
+    apply (fastforce intro: reachable_Step)
+   apply (simp add: xources_sources)
+  apply (simp add: xources_sources)
   done
 
 lemma xpurge_ipurge:
-  "confidentiality_u \<Longrightarrow> reachable s \<Longrightarrow> xpurge u as {s} = ipurge u as {s}"
-  apply(subst xpurge_ipurge', auto)
-  done
+  "\<lbrakk> confidentiality_u; reachable s \<rbrakk>
+     \<Longrightarrow> xpurge u as {s} = ipurge u as {s}"
+  by (subst xpurge_ipurge', auto)
 
 lemma ipurgx_ipurge:
-  "confidentiality_u \<Longrightarrow> reachable s \<Longrightarrow> ipurgx u as {s} = ipurge u as {s}"
-  apply(subst ipurgx_xpurge', (simp add: uwr_refl)+)
-  apply(subst xpurge_ipurge', auto)
+  "\<lbrakk> confidentiality_u; reachable s \<rbrakk>
+     \<Longrightarrow> ipurgx u as {s} = ipurge u as {s}"
+  apply (subst ipurgx_xpurge', (simp add: uwr_refl)+)
+  apply (subst xpurge_ipurge', auto)
   done
 
 lemma xpurgx_ipurge:
-  "confidentiality_u \<Longrightarrow> reachable s \<Longrightarrow> xpurgx u as {s} = ipurge u as {s}"
-  apply(subst ipurgx_xpurgx'[rule_format, THEN sym], simp+)
-  apply(subst ipurgx_xpurge', (simp add: uwr_refl)+)
-  apply(subst xpurge_ipurge', auto)
+  "\<lbrakk> confidentiality_u; reachable s \<rbrakk>
+     \<Longrightarrow> xpurgx u as {s} = ipurge u as {s}"
+  apply (subst ipurgx_xpurgx'[rule_format, THEN sym], simp+)
+  apply (subst ipurgx_xpurge', (simp add: uwr_refl)+)
+  apply (subst xpurge_ipurge', auto)
   done
 
 (* we have four different purge functions, and two different sources functions.
    So we should be able to make 8 different definitions of security. All of which
    are equivalent. One of those definitions is of course the one above. *)
-definition
-  xNoninfluence_strong_uwr_xources_ipurge :: "bool" where
- "xNoninfluence_strong_uwr_xources_ipurge \<equiv>
-  \<forall> u as bs s t. reachable s  \<and> reachable t \<longrightarrow>
-      s \<approx>(xources as s u)\<approx> t \<longrightarrow>  s \<sim>schedDomain\<sim> t \<longrightarrow>
-         ipurge u as {s} = ipurge u bs {s} \<longrightarrow>
-         uwr_equiv s as t bs u"
+definition xNoninfluence_strong_uwr_xources_ipurge :: bool where
+  "xNoninfluence_strong_uwr_xources_ipurge \<equiv> \<forall>u as bs s t. reachable s \<and> reachable t
+                                                            \<longrightarrow> s \<approx>(xources as s u)\<approx> t
+                                                            \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                                            \<longrightarrow> ipurge u as {s} = ipurge u bs {s}
+                                                            \<longrightarrow> uwr_equiv s as t bs u"
+
+definition xNoninfluence_strong_uwr_sources_xpurge :: bool where
+  "xNoninfluence_strong_uwr_sources_xpurge \<equiv> \<forall>u as bs s t. reachable s \<and> reachable t
+                                                            \<longrightarrow> s \<approx>(sources as s u)\<approx> t
+                                                            \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                                            \<longrightarrow> xpurge u as {s} = xpurge u bs {s}
+                                                            \<longrightarrow> uwr_equiv s as t bs u"
+
+definition xNoninfluence_strong_uwr_xources_xpurge :: bool where
+  "xNoninfluence_strong_uwr_xources_xpurge \<equiv> \<forall>u as bs s t. reachable s \<and> reachable t
+                                                            \<longrightarrow> s \<approx>(xources as s u)\<approx> t
+                                                            \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                                            \<longrightarrow> xpurge u as {s} = xpurge u bs {s}
+                                                            \<longrightarrow> uwr_equiv s as t bs u"
+
+definition xNoninfluence_strong_uwr_sources_ipurgx :: bool where
+  "xNoninfluence_strong_uwr_sources_ipurgx \<equiv> \<forall>u as bs s t. reachable s \<and> reachable t
+                                                            \<longrightarrow> s \<approx>(sources as s u)\<approx> t
+                                                            \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                                            \<longrightarrow> ipurgx u as {s} = ipurgx u bs {s}
+                                                            \<longrightarrow> uwr_equiv s as t bs u"
 
 definition
-  xNoninfluence_strong_uwr_sources_xpurge :: "bool" where
- "xNoninfluence_strong_uwr_sources_xpurge \<equiv>
-  \<forall> u as bs s t. reachable s  \<and> reachable t \<longrightarrow>
-      s \<approx>(sources as s u)\<approx> t \<longrightarrow>  s \<sim>schedDomain\<sim> t \<longrightarrow>
-         xpurge u as {s} = xpurge u bs {s} \<longrightarrow>
-         uwr_equiv s as t bs u"
+  xNoninfluence_strong_uwr_xources_ipurgx :: bool where
+  "xNoninfluence_strong_uwr_xources_ipurgx \<equiv> \<forall>u as bs s t. reachable s \<and> reachable t
+                                                            \<longrightarrow> s \<approx>(xources as s u)\<approx> t
+                                                            \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                                            \<longrightarrow> ipurgx u as {s} = ipurgx u bs {s}
+                                                            \<longrightarrow> uwr_equiv s as t bs u"
 
-definition
-  xNoninfluence_strong_uwr_xources_xpurge :: "bool" where
- "xNoninfluence_strong_uwr_xources_xpurge \<equiv>
-  \<forall> u as bs s t. reachable s  \<and> reachable t \<longrightarrow>
-      s \<approx>(xources as s u)\<approx> t \<longrightarrow>  s \<sim>schedDomain\<sim> t \<longrightarrow>
-         xpurge u as {s} = xpurge u bs {s} \<longrightarrow>
-         uwr_equiv s as t bs u"
+definition xNoninfluence_strong_uwr_sources_xpurgx :: bool where
+  "xNoninfluence_strong_uwr_sources_xpurgx \<equiv> \<forall>u as bs s t. reachable s \<and> reachable t
+                                                            \<longrightarrow> s \<approx>(sources as s u)\<approx> t
+                                                            \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                                            \<longrightarrow> xpurgx u as {s} = xpurgx u bs {s}
+                                                            \<longrightarrow> uwr_equiv s as t bs u"
 
-definition
-  xNoninfluence_strong_uwr_sources_ipurgx :: "bool" where
- "xNoninfluence_strong_uwr_sources_ipurgx \<equiv>
-  \<forall> u as bs s t. reachable s  \<and> reachable t \<longrightarrow>
-      s \<approx>(sources as s u)\<approx> t \<longrightarrow>  s \<sim>schedDomain\<sim> t \<longrightarrow>
-         ipurgx u as {s} = ipurgx u bs {s} \<longrightarrow>
-         uwr_equiv s as t bs u"
-
-definition
-  xNoninfluence_strong_uwr_xources_ipurgx :: "bool" where
- "xNoninfluence_strong_uwr_xources_ipurgx \<equiv>
-  \<forall> u as bs s t. reachable s  \<and> reachable t \<longrightarrow>
-      s \<approx>(xources as s u)\<approx> t \<longrightarrow>  s \<sim>schedDomain\<sim> t \<longrightarrow>
-         ipurgx u as {s} = ipurgx u bs {s} \<longrightarrow>
-         uwr_equiv s as t bs u"
-
-definition
-  xNoninfluence_strong_uwr_sources_xpurgx :: "bool" where
- "xNoninfluence_strong_uwr_sources_xpurgx \<equiv>
-  \<forall> u as bs s t. reachable s  \<and> reachable t \<longrightarrow>
-      s \<approx>(sources as s u)\<approx> t \<longrightarrow>  s \<sim>schedDomain\<sim> t \<longrightarrow>
-         xpurgx u as {s} = xpurgx u bs {s} \<longrightarrow>
-         uwr_equiv s as t bs u"
-
-definition
-  xNoninfluence_strong_uwr_xources_xpurgx :: "bool" where
- "xNoninfluence_strong_uwr_xources_xpurgx \<equiv>
-  \<forall> u as bs s t. reachable s  \<and> reachable t \<longrightarrow>
-      s \<approx>(xources as s u)\<approx> t \<longrightarrow>  s \<sim>schedDomain\<sim> t \<longrightarrow>
-         xpurgx u as {s} = xpurgx u bs {s} \<longrightarrow>
-         uwr_equiv s as t bs u"
+definition xNoninfluence_strong_uwr_xources_xpurgx :: bool where
+  "xNoninfluence_strong_uwr_xources_xpurgx \<equiv> \<forall>u as bs s t. reachable s \<and> reachable t
+                                                            \<longrightarrow> s \<approx>(xources as s u)\<approx> t
+                                                            \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                                            \<longrightarrow> xpurgx u as {s} = xpurgx u bs {s}
+                                                            \<longrightarrow> uwr_equiv s as t bs u"
 
 (* The following perhaps feels more natural, but we show is equivalent.
    'pg' here is for Pete Gammie who pushed me to prove this. *)
-definition
-  Noninfluence_strong_uwr_pg :: "bool" where
- "Noninfluence_strong_uwr_pg \<equiv>
-  \<forall> u as bs s t. reachable s  \<and> reachable t \<longrightarrow>
-      s \<approx>(sources as s u)\<approx> t \<longrightarrow>  s \<sim>schedDomain\<sim> t \<longrightarrow>
-         ipurge u as {s} = ipurge u bs {t} \<longrightarrow>
-         uwr_equiv s as t bs u"
+definition Noninfluence_strong_uwr_pg :: bool where
+  "Noninfluence_strong_uwr_pg \<equiv> \<forall>u as bs s t. reachable s \<and> reachable t
+                                               \<longrightarrow> s \<approx>(sources as s u)\<approx> t
+                                               \<longrightarrow> s \<sim>schedDomain\<sim> t
+                                               \<longrightarrow> ipurge u as {s} = ipurge u bs {t}
+                                               \<longrightarrow> uwr_equiv s as t bs u"
 
 lemma xNoninfluence_strong_uwr_xources_ipurge_Noninfluence_strong_uwr:
-  "\<lbrakk>confidentiality_u_weak; integrity_u\<rbrakk> \<Longrightarrow>
-  xNoninfluence_strong_uwr_xources_ipurge = Noninfluence_strong_uwr"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_xources_ipurge_def Noninfluence_strong_uwr_def)
-  apply(frule (1) confidentiality_u_weak)
-  apply(simp add: xources_sources)
+  "\<lbrakk> confidentiality_u_weak; integrity_u \<rbrakk>
+     \<Longrightarrow> xNoninfluence_strong_uwr_xources_ipurge = Noninfluence_strong_uwr"
+  apply (clarsimp simp: xNoninfluence_strong_uwr_xources_ipurge_def Noninfluence_strong_uwr_def)
+  apply (frule (1) confidentiality_u_weak)
+  apply (simp add: xources_sources)
   done
 
-
 lemma xNoninfluence_strong_uwr_sources_xpurge_Noninfluence_strong_uwr:
-  "\<lbrakk>confidentiality_u_weak; integrity_u\<rbrakk> \<Longrightarrow>
-  xNoninfluence_strong_uwr_sources_xpurge = Noninfluence_strong_uwr"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_sources_xpurge_def Noninfluence_strong_uwr_def)
-  apply(frule (1) confidentiality_u_weak)
-  apply(simp add: xpurge_ipurge)
+  "\<lbrakk> confidentiality_u_weak; integrity_u \<rbrakk>
+     \<Longrightarrow> xNoninfluence_strong_uwr_sources_xpurge = Noninfluence_strong_uwr"
+  apply (clarsimp simp: xNoninfluence_strong_uwr_sources_xpurge_def Noninfluence_strong_uwr_def)
+  apply (frule (1) confidentiality_u_weak)
+  apply (simp add: xpurge_ipurge)
   done
 
 lemma xNoninfluence_strong_uwr_xources_xpurge_Noninfluence_strong_uwr:
-  "\<lbrakk>confidentiality_u_weak; integrity_u\<rbrakk> \<Longrightarrow>
-  xNoninfluence_strong_uwr_xources_xpurge = Noninfluence_strong_uwr"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_xources_xpurge_def Noninfluence_strong_uwr_def)
-  apply(frule (1) confidentiality_u_weak)
-  apply(simp add: xources_sources xpurge_ipurge)
+  "\<lbrakk> confidentiality_u_weak; integrity_u \<rbrakk>
+    \<Longrightarrow> xNoninfluence_strong_uwr_xources_xpurge = Noninfluence_strong_uwr"
+  apply (clarsimp simp: xNoninfluence_strong_uwr_xources_xpurge_def Noninfluence_strong_uwr_def)
+  apply (frule (1) confidentiality_u_weak)
+  apply (simp add: xources_sources xpurge_ipurge)
   done
 
 lemma xNoninfluence_strong_uwr_sources_ipurgx_Noninfluence_strong_uwr:
-  "\<lbrakk>confidentiality_u_weak; integrity_u\<rbrakk> \<Longrightarrow>
-  xNoninfluence_strong_uwr_sources_ipurgx = Noninfluence_strong_uwr"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_sources_ipurgx_def Noninfluence_strong_uwr_def)
-  apply(frule (1) confidentiality_u_weak)
-  apply(simp add: ipurgx_ipurge)
+  "\<lbrakk> confidentiality_u_weak; integrity_u \<rbrakk>
+     \<Longrightarrow> xNoninfluence_strong_uwr_sources_ipurgx = Noninfluence_strong_uwr"
+  apply (clarsimp simp: xNoninfluence_strong_uwr_sources_ipurgx_def Noninfluence_strong_uwr_def)
+  apply (frule (1) confidentiality_u_weak)
+  apply (simp add: ipurgx_ipurge)
   done
 
 lemma xNoninfluence_strong_uwr_xources_ipurgx_Noninfluence_strong_uwr:
-  "\<lbrakk>confidentiality_u_weak; integrity_u\<rbrakk> \<Longrightarrow>
-  xNoninfluence_strong_uwr_xources_ipurgx = Noninfluence_strong_uwr"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_xources_ipurgx_def Noninfluence_strong_uwr_def)
-  apply(frule (1) confidentiality_u_weak)
-apply(simp add: xources_sources ipurgx_ipurge)
+  "\<lbrakk> confidentiality_u_weak; integrity_u \<rbrakk>
+     \<Longrightarrow> xNoninfluence_strong_uwr_xources_ipurgx = Noninfluence_strong_uwr"
+  apply (clarsimp simp: xNoninfluence_strong_uwr_xources_ipurgx_def Noninfluence_strong_uwr_def)
+  apply (frule (1) confidentiality_u_weak)
+  apply (simp add: xources_sources ipurgx_ipurge)
   done
 
 lemma xNoninfluence_strong_uwr_sources_xpurgx_Noninfluence_strong_uwr:
-  "\<lbrakk>confidentiality_u_weak; integrity_u\<rbrakk> \<Longrightarrow>
-  xNoninfluence_strong_uwr_sources_xpurgx = Noninfluence_strong_uwr"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_sources_xpurgx_def Noninfluence_strong_uwr_def)
-  apply(frule (1) confidentiality_u_weak)
-  apply(simp add: xpurgx_ipurge)
+  "\<lbrakk> confidentiality_u_weak; integrity_u \<rbrakk>
+     \<Longrightarrow> xNoninfluence_strong_uwr_sources_xpurgx = Noninfluence_strong_uwr"
+  apply (clarsimp simp: xNoninfluence_strong_uwr_sources_xpurgx_def Noninfluence_strong_uwr_def)
+  apply (frule (1) confidentiality_u_weak)
+  apply (simp add: xpurgx_ipurge)
   done
 
 lemma xNoninfluence_strong_uwr_xources_xpurgx_Noninfluence_strong_uwr:
-  "\<lbrakk>confidentiality_u_weak; integrity_u\<rbrakk> \<Longrightarrow>
-  xNoninfluence_strong_uwr_xources_xpurgx = Noninfluence_strong_uwr"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_xources_xpurgx_def Noninfluence_strong_uwr_def)
-  apply(frule (1) confidentiality_u_weak)
-  apply(simp add: xpurgx_ipurge xources_sources)
+  "\<lbrakk> confidentiality_u_weak; integrity_u \<rbrakk>
+     \<Longrightarrow> xNoninfluence_strong_uwr_xources_xpurgx = Noninfluence_strong_uwr"
+  apply (clarsimp simp: xNoninfluence_strong_uwr_xources_xpurgx_def Noninfluence_strong_uwr_def)
+  apply (frule (1) confidentiality_u_weak)
+  apply (simp add: xpurgx_ipurge xources_sources)
   done
 
 lemma Noninfluence_strong_uwr_pg_Noninfluence_strong_uwr:
-  "\<lbrakk>confidentiality_u_weak; integrity_u\<rbrakk> \<Longrightarrow>
-  Noninfluence_strong_uwr_pg = Noninfluence_strong_uwr"
-  apply(clarsimp simp: Noninfluence_strong_uwr_pg_def Noninfluence_strong_uwr_def)
-  apply(frule (1) confidentiality_u_weak)
-  apply(simp add: ipurge_eq)
+  "\<lbrakk> confidentiality_u_weak; integrity_u \<rbrakk>
+     \<Longrightarrow> Noninfluence_strong_uwr_pg = Noninfluence_strong_uwr"
+  apply (clarsimp simp: Noninfluence_strong_uwr_pg_def Noninfluence_strong_uwr_def)
+  apply (frule (1) confidentiality_u_weak)
+  apply (simp add: ipurge_eq)
   done
 
 lemma xources_Step:
-  "\<lbrakk>reachable s; (dom a s, u) \<notin> policy\<rbrakk> \<Longrightarrow>
-  xources [a] s u = {u}"
-  apply(auto simp: xources_Cons xources_Nil enabled_Step dest: enabled_Step)
-  done
+  "\<lbrakk> reachable s; (dom a s, u) \<notin> policy \<rbrakk> \<Longrightarrow> xources [a] s u = {u}"
+  by (auto simp: xources_Cons xources_Nil enabled_Step dest: enabled_Step)
 
 lemma xources_Step_2:
-  "\<lbrakk>reachable s; (dom a s, u) \<in> policy\<rbrakk> \<Longrightarrow>
-  xources [a] s u = {dom a s,u}"
-  apply(auto simp: xources_Cons xources_Nil enabled_Step dest: enabled_Step)
-  done
+  "\<lbrakk> reachable s; (dom a s, u) \<in> policy \<rbrakk> \<Longrightarrow> xources [a] s u = {dom a s,u}"
+  by (auto simp: xources_Cons xources_Nil enabled_Step dest: enabled_Step)
 
 lemma xNoninfluence_strong_uwr_xources_ipurge_confidentiality_u_weak:
   "xNoninfluence_strong_uwr_xources_ipurge \<Longrightarrow> confidentiality_u_weak"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_xources_ipurge_def confidentiality_u_weak_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=t in spec)
-  apply(simp add: xources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_xources_ipurge_def confidentiality_u_weak_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=t in spec)
+  apply (simp add: xources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
   done
 
 lemma xNoninfluence_strong_uwr_sources_xpurge_confidentiality_u_weak:
   "xNoninfluence_strong_uwr_sources_xpurge \<Longrightarrow> confidentiality_u_weak"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_sources_xpurge_def confidentiality_u_weak_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=t in spec)
-  apply(simp add: sources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_sources_xpurge_def confidentiality_u_weak_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=t in spec)
+  apply (simp add: sources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
   done
 
 lemma xNoninfluence_strong_uwr_xources_xpurge_confidentiality_u_weak:
   "xNoninfluence_strong_uwr_xources_xpurge \<Longrightarrow> confidentiality_u_weak"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_xources_xpurge_def confidentiality_u_weak_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=t in spec)
-  apply(simp add: xources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_xources_xpurge_def confidentiality_u_weak_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=t in spec)
+  apply (simp add: xources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
   done
 
 lemma xNoninfluence_strong_uwr_sources_ipurgx_confidentiality_u_weak:
   "xNoninfluence_strong_uwr_sources_ipurgx \<Longrightarrow> confidentiality_u_weak"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_sources_ipurgx_def confidentiality_u_weak_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=t in spec)
-  apply(simp add: sources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_sources_ipurgx_def confidentiality_u_weak_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=t in spec)
+  apply (simp add: sources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
   done
 
 lemma xNoninfluence_strong_uwr_xources_ipurgx_confidentiality_u_weak:
   "xNoninfluence_strong_uwr_xources_ipurgx \<Longrightarrow> confidentiality_u_weak"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_xources_ipurgx_def confidentiality_u_weak_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=t in spec)
-  apply(simp add: xources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_xources_ipurgx_def confidentiality_u_weak_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=t in spec)
+  apply (simp add: xources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
   done
 
 lemma xNoninfluence_strong_uwr_sources_xpurgx_confidentiality_u_weak:
   "xNoninfluence_strong_uwr_sources_xpurgx \<Longrightarrow> confidentiality_u_weak"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_sources_xpurgx_def confidentiality_u_weak_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=t in spec)
-  apply(simp add: sources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_sources_xpurgx_def confidentiality_u_weak_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=t in spec)
+  apply (simp add: sources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
   done
 
 lemma xNoninfluence_strong_uwr_xources_xpurgx_confidentiality_u_weak:
   "xNoninfluence_strong_uwr_xources_xpurgx \<Longrightarrow> confidentiality_u_weak"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_xources_xpurgx_def confidentiality_u_weak_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=t in spec)
-  apply(simp add: xources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_xources_xpurgx_def confidentiality_u_weak_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=t in spec)
+  apply (simp add: xources_Step_2 sameFor_dom_def uwr_equiv_def Step_def)
   done
 
 lemma ipurge_single_eq:
-  "\<lbrakk>reachable s; reachable t; s \<sim>schedDomain\<sim> t\<rbrakk> \<Longrightarrow>
-   ipurge u [a] {s} = ipurge u [a] {t}"
-  apply(frule_tac e=a in schedIncludesCurrentDom)
-  apply(simp add: ipurge_Cons ipurge_Nil sources_Cons sources_Nil)
+  "\<lbrakk> reachable s; reachable t; s \<sim>schedDomain\<sim> t \<rbrakk>
+     \<Longrightarrow> ipurge u [a] {s} = ipurge u [a] {t}"
+  apply (frule_tac e=a in schedIncludesCurrentDom)
+  apply (simp add: ipurge_Cons ipurge_Nil sources_Cons sources_Nil)
   apply (auto dest: enabled_Step)
   done
 
 lemma Noninfluence_strong_uwr_pg_confidentiality_u_weak:
   "Noninfluence_strong_uwr_pg \<Longrightarrow> confidentiality_u_weak"
-  apply(clarsimp simp: Noninfluence_strong_uwr_pg_def confidentiality_u_weak_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=t in spec)
-  apply(simp add: sources_Step_2 sameFor_dom_def uwr_equiv_def Step_def ipurge_single_eq)
+  apply (clarsimp simp: Noninfluence_strong_uwr_pg_def confidentiality_u_weak_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[a]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=t in spec)
+  apply (simp add: sources_Step_2 sameFor_dom_def uwr_equiv_def Step_def ipurge_single_eq)
   done
 
 end
+
 
 context complete_unwinding_system begin
 
 lemma Nonleakage_gen_xNonleakage_gen:
   "confidentiality_u \<Longrightarrow> Nonleakage_gen = xNonleakage_gen"
-  apply(simp add: Nonleakage_gen_def xNonleakage_gen_def)
-  apply(fastforce simp: xources_sources)
+  apply (simp add: Nonleakage_gen_def xNonleakage_gen_def)
+  apply (fastforce simp: xources_sources)
   done
 
 lemma xNonleakage_gen:
   "confidentiality_u \<Longrightarrow> xNonleakage_gen"
-  apply(simp add: Nonleakage_gen_xNonleakage_gen[symmetric])
-  apply(erule Nonleakage_gen)
+  apply (simp add: Nonleakage_gen_xNonleakage_gen[symmetric])
+  apply (erule Nonleakage_gen)
   done
 
 lemma xNonleakage_gen_confidentiality_u:
   "xNonleakage_gen \<Longrightarrow> confidentiality_u"
-  apply(clarsimp simp: xNonleakage_gen_def confidentiality_u_def)
-  apply(drule_tac x="[a]" in spec, drule_tac x=s in spec)
-  apply(drule_tac x=u in spec, drule_tac x=t in spec)
-  apply(case_tac "dom a s \<leadsto> u")
-   apply(simp add: xources_Step_2 uwr_equiv_def sameFor_dom_def Step_def)
-  apply(simp add: xources_Step uwr_equiv_def sameFor_dom_def Step_def)
+  apply (clarsimp simp: xNonleakage_gen_def confidentiality_u_def)
+  apply (drule_tac x="[a]" in spec, drule_tac x=s in spec)
+  apply (drule_tac x=u in spec, drule_tac x=t in spec)
+  apply (case_tac "dom a s \<leadsto> u")
+   apply (simp add: xources_Step_2 uwr_equiv_def sameFor_dom_def Step_def)
+  apply (simp add: xources_Step uwr_equiv_def sameFor_dom_def Step_def)
   done
 
 lemma xNoninfluence_strong_uwr_xources_ipurge_integrity_u:
   "xNoninfluence_strong_uwr_xources_ipurge \<Longrightarrow> integrity_u"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_xources_ipurge_def integrity_u_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=s in spec)
-  apply(simp add: sources_Step sameFor_dom_def uwr_refl uwr_equiv_def Step_def ipurge_Cons
-                  ipurge_Nil
-           split: if_splits)
-   apply(simp add: policy_refl)
-  apply(simp add: execution_Nil)
-  apply(blast intro: uwr_sym)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_xources_ipurge_def integrity_u_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=s in spec)
+  apply (simp add: sources_Step sameFor_dom_def uwr_refl
+                   uwr_equiv_def Step_def ipurge_Cons ipurge_Nil
+            split: if_splits)
+   apply (simp add: policy_refl)
+  apply (simp add: execution_Nil)
+  apply (blast intro: uwr_sym)
   done
 
 lemma xNoninfluence_strong_uwr_sources_xpurge_integrity_u:
   "xNoninfluence_strong_uwr_sources_xpurge \<Longrightarrow> integrity_u"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_sources_xpurge_def integrity_u_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=s in spec)
-  apply(simp add: xources_Step sameFor_dom_def uwr_refl uwr_equiv_def Step_def xpurge_Cons
-                  xpurge_Nil
-           split: if_splits)
-   apply(simp add: policy_refl)
-  apply(simp add: execution_Nil)
-  apply(blast intro: uwr_sym)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_sources_xpurge_def integrity_u_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=s in spec)
+  apply (simp add: xources_Step sameFor_dom_def uwr_refl
+                   uwr_equiv_def Step_def xpurge_Cons xpurge_Nil
+            split: if_splits)
+   apply (simp add: policy_refl)
+  apply (simp add: execution_Nil)
+  apply (blast intro: uwr_sym)
   done
 
 lemma xNoninfluence_strong_uwr_xources_xpurge_integrity_u:
   "xNoninfluence_strong_uwr_xources_xpurge \<Longrightarrow> integrity_u"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_xources_xpurge_def integrity_u_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=s in spec)
-  apply(simp add: xources_Step sameFor_dom_def uwr_refl uwr_equiv_def Step_def xpurge_Cons
-                  xpurge_Nil
-           split: if_splits)
-   apply(simp add: policy_refl)
-  apply(simp add: execution_Nil)
-  apply(blast intro: uwr_sym)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_xources_xpurge_def integrity_u_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=s in spec)
+  apply (simp add: xources_Step sameFor_dom_def uwr_refl
+                   uwr_equiv_def Step_def xpurge_Cons xpurge_Nil
+            split: if_splits)
+   apply (simp add: policy_refl)
+  apply (simp add: execution_Nil)
+  apply (blast intro: uwr_sym)
   done
-
 
 lemma xNoninfluence_strong_uwr_sources_ipurgx_integrity_u:
   "xNoninfluence_strong_uwr_sources_ipurgx \<Longrightarrow> integrity_u"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_sources_ipurgx_def integrity_u_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=s in spec)
-  apply(simp add: sources_Step sameFor_dom_def uwr_refl uwr_equiv_def Step_def ipurgx_Cons
-                  ipurgx_Nil
-           split: if_splits)
-   apply(simp add: policy_refl)
-  apply(simp add: execution_Nil)
-  apply(blast intro: uwr_sym)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_sources_ipurgx_def integrity_u_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=s in spec)
+  apply (simp add: sources_Step sameFor_dom_def uwr_refl
+                   uwr_equiv_def Step_def ipurgx_Cons ipurgx_Nil
+            split: if_splits)
+   apply (simp add: policy_refl)
+  apply (simp add: execution_Nil)
+  apply (blast intro: uwr_sym)
   done
 
 lemma xNoninfluence_strong_uwr_xources_ipurgx_integrity_u:
   "xNoninfluence_strong_uwr_xources_ipurgx \<Longrightarrow> integrity_u"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_xources_ipurgx_def integrity_u_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=s in spec)
-  apply(simp add: sources_Step sameFor_dom_def uwr_refl uwr_equiv_def Step_def ipurgx_Cons
-                  ipurgx_Nil
-           split: if_splits)
-   apply(simp add: policy_refl)
-  apply(simp add: execution_Nil)
-  apply(blast intro: uwr_sym)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_xources_ipurgx_def integrity_u_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=s in spec)
+  apply (simp add: sources_Step sameFor_dom_def uwr_refl
+                   uwr_equiv_def Step_def ipurgx_Cons ipurgx_Nil
+            split: if_splits)
+   apply (simp add: policy_refl)
+  apply (simp add: execution_Nil)
+  apply (blast intro: uwr_sym)
   done
 
 lemma xNoninfluence_strong_uwr_sources_xpurgx_integrity_u:
   "xNoninfluence_strong_uwr_sources_xpurgx \<Longrightarrow> integrity_u"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_sources_xpurgx_def integrity_u_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=s in spec)
-  apply(simp add: xources_Step sameFor_dom_def uwr_refl uwr_equiv_def Step_def xpurgx_Cons
-                  xpurgx_Nil
-           split: if_splits)
-   apply(simp add: policy_refl)
-  apply(simp add: execution_Nil)
-  apply(blast intro: uwr_sym)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_sources_xpurgx_def integrity_u_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=s in spec)
+  apply (simp add: xources_Step sameFor_dom_def uwr_refl
+                   uwr_equiv_def Step_def xpurgx_Cons xpurgx_Nil
+            split: if_splits)
+   apply (simp add: policy_refl)
+  apply (simp add: execution_Nil)
+  apply (blast intro: uwr_sym)
   done
 
 lemma xNoninfluence_strong_uwr_xources_xpurgx_integrity_u:
   "xNoninfluence_strong_uwr_xources_xpurgx \<Longrightarrow> integrity_u"
-  apply(clarsimp simp: xNoninfluence_strong_uwr_xources_xpurgx_def integrity_u_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=s in spec)
-  apply(simp add: xources_Step sameFor_dom_def uwr_refl uwr_equiv_def Step_def xpurgx_Cons
-                  xpurgx_Nil
-           split: if_splits)
-   apply(simp add: policy_refl)
-  apply(simp add: execution_Nil)
-  apply(blast intro: uwr_sym)
+  apply (clarsimp simp: xNoninfluence_strong_uwr_xources_xpurgx_def integrity_u_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=s in spec)
+  apply (simp add: xources_Step sameFor_dom_def uwr_refl
+                   uwr_equiv_def Step_def xpurgx_Cons xpurgx_Nil
+            split: if_splits)
+   apply (simp add: policy_refl)
+  apply (simp add: execution_Nil)
+  apply (blast intro: uwr_sym)
   done
 
-lemma Noninfluence_strong_uwr_pg_integrity_u: "Noninfluence_strong_uwr_pg \<Longrightarrow> integrity_u"
-  apply(clarsimp simp: Noninfluence_strong_uwr_pg_def integrity_u_def)
-  apply(drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
-  apply(drule_tac x=s in spec, drule_tac x=s in spec)
-  apply(simp add: sources_Step sameFor_dom_def uwr_refl uwr_equiv_def Step_def ipurge_Cons
-                  ipurge_Nil
-           split: if_splits)
-   apply(simp add: policy_refl)
-  apply(simp add: execution_Nil)
-  apply(blast intro: uwr_sym)
+lemma Noninfluence_strong_uwr_pg_integrity_u:
+  "Noninfluence_strong_uwr_pg \<Longrightarrow> integrity_u"
+  apply (clarsimp simp: Noninfluence_strong_uwr_pg_def integrity_u_def)
+  apply (drule_tac x=u in spec, drule_tac x="[a]" in spec, drule_tac x="[]" in spec)
+  apply (drule_tac x=s in spec, drule_tac x=s in spec)
+  apply (simp add: sources_Step sameFor_dom_def uwr_refl
+                   uwr_equiv_def Step_def ipurge_Cons ipurge_Nil
+            split: if_splits)
+   apply (simp add: policy_refl)
+  apply (simp add: execution_Nil)
+  apply (blast intro: uwr_sym)
   done
 
 (* The choice as to which sources/ipurge definition to adopt doesn't matter.
@@ -593,101 +568,100 @@ lemma Noninfluence_strong_uwr_pg_integrity_u: "Noninfluence_strong_uwr_pg \<Long
    same "kind". *)
 lemma Noninfluence_strong_uwr_equiv_xNoninfluence_strong_uwr_xources_ipurge:
   "Noninfluence_strong_uwr = xNoninfluence_strong_uwr_xources_ipurge"
-  apply(rule iffI)
-   apply(subst xNoninfluence_strong_uwr_xources_ipurge_Noninfluence_strong_uwr)
-     apply(erule Noninfluence_strong_uwr_confidentiality_u_weak)
-    apply(erule Noninfluence_strong_uwr_integrity_u)
+  apply (rule iffI)
+   apply (subst xNoninfluence_strong_uwr_xources_ipurge_Noninfluence_strong_uwr)
+     apply (erule Noninfluence_strong_uwr_confidentiality_u_weak)
+    apply (erule Noninfluence_strong_uwr_integrity_u)
    apply assumption
-  apply(rule Noninfluence_strong_uwr)
-   apply(erule xNoninfluence_strong_uwr_xources_ipurge_confidentiality_u_weak)
-  apply(erule xNoninfluence_strong_uwr_xources_ipurge_integrity_u)
+  apply (rule Noninfluence_strong_uwr)
+   apply (erule xNoninfluence_strong_uwr_xources_ipurge_confidentiality_u_weak)
+  apply (erule xNoninfluence_strong_uwr_xources_ipurge_integrity_u)
   done
 
 lemma Noninfluence_strong_uwr_equiv_xNoninfluence_strong_uwr_sources_xpurge:
   "Noninfluence_strong_uwr = xNoninfluence_strong_uwr_sources_xpurge"
-  apply(rule iffI)
-   apply(subst xNoninfluence_strong_uwr_sources_xpurge_Noninfluence_strong_uwr)
-     apply(erule Noninfluence_strong_uwr_confidentiality_u_weak)
-    apply(erule Noninfluence_strong_uwr_integrity_u)
+  apply (rule iffI)
+   apply (subst xNoninfluence_strong_uwr_sources_xpurge_Noninfluence_strong_uwr)
+     apply (erule Noninfluence_strong_uwr_confidentiality_u_weak)
+    apply (erule Noninfluence_strong_uwr_integrity_u)
    apply assumption
-  apply(rule Noninfluence_strong_uwr)
-   apply(erule xNoninfluence_strong_uwr_sources_xpurge_confidentiality_u_weak)
-  apply(erule xNoninfluence_strong_uwr_sources_xpurge_integrity_u)
+  apply (rule Noninfluence_strong_uwr)
+   apply (erule xNoninfluence_strong_uwr_sources_xpurge_confidentiality_u_weak)
+  apply (erule xNoninfluence_strong_uwr_sources_xpurge_integrity_u)
   done
 
 lemma Noninfluence_strong_uwr_equiv_xNoninfluence_strong_uwr_xources_xpurge:
   "Noninfluence_strong_uwr = xNoninfluence_strong_uwr_xources_xpurge"
-  apply(rule iffI)
-   apply(subst xNoninfluence_strong_uwr_xources_xpurge_Noninfluence_strong_uwr)
-     apply(erule Noninfluence_strong_uwr_confidentiality_u_weak)
-    apply(erule Noninfluence_strong_uwr_integrity_u)
+  apply (rule iffI)
+   apply (subst xNoninfluence_strong_uwr_xources_xpurge_Noninfluence_strong_uwr)
+     apply (erule Noninfluence_strong_uwr_confidentiality_u_weak)
+    apply (erule Noninfluence_strong_uwr_integrity_u)
    apply assumption
-  apply(rule Noninfluence_strong_uwr)
-   apply(erule xNoninfluence_strong_uwr_xources_xpurge_confidentiality_u_weak)
-  apply(erule xNoninfluence_strong_uwr_xources_xpurge_integrity_u)
+  apply (rule Noninfluence_strong_uwr)
+   apply (erule xNoninfluence_strong_uwr_xources_xpurge_confidentiality_u_weak)
+  apply (erule xNoninfluence_strong_uwr_xources_xpurge_integrity_u)
   done
 
 lemma Noninfluence_strong_uwr_equiv_xNoninfluence_strong_uwr_sources_ipurgx:
   "Noninfluence_strong_uwr = xNoninfluence_strong_uwr_sources_ipurgx"
-  apply(rule iffI)
-   apply(subst xNoninfluence_strong_uwr_sources_ipurgx_Noninfluence_strong_uwr)
-     apply(erule Noninfluence_strong_uwr_confidentiality_u_weak)
-    apply(erule Noninfluence_strong_uwr_integrity_u)
+  apply (rule iffI)
+   apply (subst xNoninfluence_strong_uwr_sources_ipurgx_Noninfluence_strong_uwr)
+     apply (erule Noninfluence_strong_uwr_confidentiality_u_weak)
+    apply (erule Noninfluence_strong_uwr_integrity_u)
    apply assumption
-  apply(rule Noninfluence_strong_uwr)
-   apply(erule xNoninfluence_strong_uwr_sources_ipurgx_confidentiality_u_weak)
-  apply(erule xNoninfluence_strong_uwr_sources_ipurgx_integrity_u)
+  apply (rule Noninfluence_strong_uwr)
+   apply (erule xNoninfluence_strong_uwr_sources_ipurgx_confidentiality_u_weak)
+  apply (erule xNoninfluence_strong_uwr_sources_ipurgx_integrity_u)
   done
 
 lemma Noninfluence_strong_uwr_equiv_xNoninfluence_strong_uwr_xources_ipurgx:
   "Noninfluence_strong_uwr = xNoninfluence_strong_uwr_xources_ipurgx"
-  apply(rule iffI)
-   apply(subst xNoninfluence_strong_uwr_xources_ipurgx_Noninfluence_strong_uwr)
-     apply(erule Noninfluence_strong_uwr_confidentiality_u_weak)
-    apply(erule Noninfluence_strong_uwr_integrity_u)
+  apply (rule iffI)
+   apply (subst xNoninfluence_strong_uwr_xources_ipurgx_Noninfluence_strong_uwr)
+     apply (erule Noninfluence_strong_uwr_confidentiality_u_weak)
+    apply (erule Noninfluence_strong_uwr_integrity_u)
    apply assumption
-  apply(rule Noninfluence_strong_uwr)
-   apply(erule xNoninfluence_strong_uwr_xources_ipurgx_confidentiality_u_weak)
-  apply(erule xNoninfluence_strong_uwr_xources_ipurgx_integrity_u)
+  apply (rule Noninfluence_strong_uwr)
+   apply (erule xNoninfluence_strong_uwr_xources_ipurgx_confidentiality_u_weak)
+  apply (erule xNoninfluence_strong_uwr_xources_ipurgx_integrity_u)
   done
 
 lemma Noninfluence_strong_uwr_equiv_xNoninfluence_strong_uwr_sources_xpurgx:
   "Noninfluence_strong_uwr = xNoninfluence_strong_uwr_sources_xpurgx"
-  apply(rule iffI)
-   apply(subst xNoninfluence_strong_uwr_sources_xpurgx_Noninfluence_strong_uwr)
-     apply(erule Noninfluence_strong_uwr_confidentiality_u_weak)
-    apply(erule Noninfluence_strong_uwr_integrity_u)
+  apply (rule iffI)
+   apply (subst xNoninfluence_strong_uwr_sources_xpurgx_Noninfluence_strong_uwr)
+     apply (erule Noninfluence_strong_uwr_confidentiality_u_weak)
+    apply (erule Noninfluence_strong_uwr_integrity_u)
    apply assumption
-  apply(rule Noninfluence_strong_uwr)
-   apply(erule xNoninfluence_strong_uwr_sources_xpurgx_confidentiality_u_weak)
-  apply(erule xNoninfluence_strong_uwr_sources_xpurgx_integrity_u)
+  apply (rule Noninfluence_strong_uwr)
+   apply (erule xNoninfluence_strong_uwr_sources_xpurgx_confidentiality_u_weak)
+  apply (erule xNoninfluence_strong_uwr_sources_xpurgx_integrity_u)
   done
 
 lemma Noninfluence_strong_uwr_equiv_xNoninfluence_strong_uwr_xources_xpurgx:
   "Noninfluence_strong_uwr = xNoninfluence_strong_uwr_xources_xpurgx"
-  apply(rule iffI)
-   apply(subst xNoninfluence_strong_uwr_xources_xpurgx_Noninfluence_strong_uwr)
-     apply(erule Noninfluence_strong_uwr_confidentiality_u_weak)
-    apply(erule Noninfluence_strong_uwr_integrity_u)
+  apply (rule iffI)
+   apply (subst xNoninfluence_strong_uwr_xources_xpurgx_Noninfluence_strong_uwr)
+     apply (erule Noninfluence_strong_uwr_confidentiality_u_weak)
+    apply (erule Noninfluence_strong_uwr_integrity_u)
    apply assumption
-  apply(rule Noninfluence_strong_uwr)
-   apply(erule xNoninfluence_strong_uwr_xources_xpurgx_confidentiality_u_weak)
-  apply(erule xNoninfluence_strong_uwr_xources_xpurgx_integrity_u)
+  apply (rule Noninfluence_strong_uwr)
+   apply (erule xNoninfluence_strong_uwr_xources_xpurgx_confidentiality_u_weak)
+  apply (erule xNoninfluence_strong_uwr_xources_xpurgx_integrity_u)
   done
 
 lemma Noninfluence_strong_uwr_equiv_Noninfluence_strong_uwr_pg:
   "Noninfluence_strong_uwr = Noninfluence_strong_uwr_pg"
-  apply(rule iffI)
-   apply(subst Noninfluence_strong_uwr_pg_Noninfluence_strong_uwr)
-     apply(erule Noninfluence_strong_uwr_confidentiality_u_weak)
-    apply(erule Noninfluence_strong_uwr_integrity_u)
+  apply (rule iffI)
+   apply (subst Noninfluence_strong_uwr_pg_Noninfluence_strong_uwr)
+     apply (erule Noninfluence_strong_uwr_confidentiality_u_weak)
+    apply (erule Noninfluence_strong_uwr_integrity_u)
    apply assumption
-  apply(rule Noninfluence_strong_uwr)
-   apply(erule Noninfluence_strong_uwr_pg_confidentiality_u_weak)
-  apply(erule Noninfluence_strong_uwr_pg_integrity_u)
+  apply (rule Noninfluence_strong_uwr)
+   apply (erule Noninfluence_strong_uwr_pg_confidentiality_u_weak)
+  apply (erule Noninfluence_strong_uwr_pg_integrity_u)
   done
 
 end
-
 
 end

--- a/proof/infoflow/PasUpdates.thy
+++ b/proof/infoflow/PasUpdates.thy
@@ -12,64 +12,64 @@ text \<open>
 
 theory PasUpdates
 imports
-    "Arch_IF"
+    "ArchArch_IF"
     "FinalCaps"
     "AInvs.EmptyFail_AI"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
-
 section \<open>Separation lemmas for the idle thread and domain fields\<close>
 
-abbreviation (input) domain_fields
-where
+abbreviation (input) domain_fields where
   "domain_fields P s \<equiv> P (domain_time s) (domain_index s) (domain_list s)"
 
 lemma preemption_point_domain_fields[wp]:
-  "\<lbrace>domain_fields P\<rbrace> preemption_point \<lbrace>\<lambda>_. domain_fields P\<rbrace>"
+  "preemption_point \<lbrace>domain_fields P\<rbrace>"
   by (simp add: preemption_point_def
       | wp OR_choiceE_weak_wp modify_wp
       | wpc
       | simp add: reset_work_units_def update_work_units_def)+
 
-crunch domain_fields[wp]: retype_region_ext,create_cap_ext,cap_insert_ext,ethread_set,
-                          cap_move_ext,empty_slot_ext,cap_swap_ext,set_thread_state_ext,
-                          tcb_sched_action,reschedule_required,cap_swap_for_delete,
-                          finalise_cap,cap_move,cap_swap,cap_delete,cancel_badged_sends,
-                          cap_insert
-                          "domain_fields P"
+
+locale PasUpdates_1 =
+  fixes aag :: "'a subject_label PAS"
+  assumes arch_post_cap_deletion_domain_fields[wp]:
+    "arch_post_cap_deletion acap \<lbrace>domain_fields P\<rbrace>"
+  and arch_finalise_cap_domain_fields[wp]:
+    "arch_finalise_cap acap b \<lbrace>domain_fields P\<rbrace>"
+  and prepare_thread_delete_domain_fields[wp]:
+    "prepare_thread_delete p \<lbrace>domain_fields P\<rbrace>"
+begin
+
+crunch domain_fields[wp]:
+  retype_region_ext, create_cap_ext, cap_insert_ext, ethread_set, cap_move_ext, empty_slot_ext,
+  cap_swap_ext, set_thread_state_ext, tcb_sched_action, reschedule_required, cap_swap_for_delete,
+  finalise_cap, cap_move, cap_swap, cap_delete, cancel_badged_sends, cap_insert
+  "domain_fields P"
   (    wp: syscall_valid select_wp crunch_wps rec_del_preservation cap_revoke_preservation modify_wp
      simp: crunch_simps check_cap_at_def filterM_mapM unless_def
    ignore: without_preemption filterM rec_del check_cap_at cap_revoke
    ignore_del: retype_region_ext create_cap_ext cap_insert_ext ethread_set cap_move_ext
                empty_slot_ext cap_swap_ext set_thread_state_ext tcb_sched_action reschedule_required)
 
-lemma cap_revoke_domain_fields[wp]:"\<lbrace>domain_fields P\<rbrace> cap_revoke a \<lbrace>\<lambda>_. domain_fields P\<rbrace>"
+lemma cap_revoke_domain_fields[wp]:
+  "cap_revoke a \<lbrace>domain_fields P\<rbrace>"
   by (rule cap_revoke_preservation2; wp)
 
-lemma invoke_cnode_domain_fields[wp]: "\<lbrace>domain_fields P\<rbrace> invoke_cnode a \<lbrace>\<lambda>_. domain_fields P\<rbrace>"
+lemma invoke_cnode_domain_fields[wp]:
+  "invoke_cnode a \<lbrace>domain_fields P\<rbrace>"
   unfolding invoke_cnode_def
-  by (wpsimp wp: get_cap_wp hoare_vcg_all_lift hoare_vcg_imp_lift
-      | rule conjI)+
+  by (wpsimp wp: get_cap_wp hoare_vcg_all_lift hoare_vcg_imp_lift | rule conjI)+
 
-crunch domain_fields[wp]:
-  set_domain,possible_switch_to,set_priority,set_extra_badge,
-  handle_send,handle_recv,handle_reply
-  "domain_fields P"
-  (wp: syscall_valid crunch_wps mapME_x_inv_wp
-   simp: crunch_simps check_cap_at_def detype_def detype_ext_def mapM_x_defsym
-   ignore: check_cap_at syscall
-   ignore_del: set_domain set_priority possible_switch_to
-   rule: transfer_caps_loop_pres)
+end
+
 
 section \<open>PAS wellformedness property for non-interference\<close>
 
 definition pas_wellformed_noninterference where
   "pas_wellformed_noninterference aag \<equiv>
-    (\<forall>l\<in>range (pasObjectAbs aag) \<union> \<Union>(range (pasDomainAbs aag)) - {SilcLabel}.
-         pas_wellformed (aag\<lparr> pasSubject := l \<rparr>)) \<and>
-    (\<forall>d. SilcLabel \<notin> pasDomainAbs aag d) \<and>
-    pas_domains_distinct aag"
+     (\<forall>l \<in> range (pasObjectAbs aag) \<union> \<Union>(range (pasDomainAbs aag)) - {SilcLabel}.
+        pas_wellformed (aag\<lparr>pasSubject := l\<rparr>)) \<and>
+     (\<forall>d. SilcLabel \<notin> pasDomainAbs aag d) \<and> pas_domains_distinct aag"
 
 lemma pas_wellformed_noninterference_domains_distinct:
   "pas_wellformed_noninterference aag \<Longrightarrow> pas_domains_distinct aag"
@@ -77,160 +77,149 @@ lemma pas_wellformed_noninterference_domains_distinct:
 
 lemma pas_wellformed_noninterference_silc[intro!]:
   "pas_wellformed_noninterference aag \<Longrightarrow> SilcLabel \<notin> pasDomainAbs aag d"
-  apply (fastforce simp: pas_wellformed_noninterference_def)
-  done
+  by (fastforce simp: pas_wellformed_noninterference_def)
+
 
 section \<open>PAS subject update\<close>
 
 lemma pasObjectAbs_pasSubject_update:
-  "pasObjectAbs (aag\<lparr> pasSubject := x \<rparr>) = pasObjectAbs aag"
-  apply simp
-  done
+  "pasObjectAbs (aag\<lparr>pasSubject := x\<rparr>) = pasObjectAbs aag"
+  by simp
 
 lemma pasASIDAbs_pasSubject_update:
-  "pasASIDAbs (aag\<lparr> pasSubject := x \<rparr>) = pasASIDAbs aag"
-  apply simp
-  done
+  "pasASIDAbs (aag\<lparr>pasSubject := x\<rparr>) = pasASIDAbs aag"
+  by simp
 
 lemma pasIRQAbs_pasSubject_update:
-  "pasIRQAbs (aag\<lparr> pasSubject := x \<rparr>) = pasIRQAbs aag"
-  apply simp
-  done
-
-lemma state_asids_to_policy_pasSubject_update:
-  "state_asids_to_policy_aux (aag\<lparr> pasSubject := x \<rparr>) caps asid vrefs =
-   state_asids_to_policy_aux aag caps asid vrefs"
-  apply(rule equalityI)
-   apply(clarify)
-   apply(erule state_asids_to_policy_aux.cases
-        |simp
-        |fastforce intro: state_asids_to_policy_aux.intros)+
-  apply(clarify)
-  apply(erule state_asids_to_policy_aux.cases)
-   apply(simp,
-         subst pasObjectAbs_pasSubject_update[symmetric],
-         subst pasASIDAbs_pasSubject_update[symmetric],
-         rule state_asids_to_policy_aux.intros, assumption+)+
-  done
+  "pasIRQAbs (aag\<lparr>pasSubject := x\<rparr>) = pasIRQAbs aag"
+  by simp
 
 lemma state_irqs_to_policy_pasSubject_update:
-  "state_irqs_to_policy_aux (aag\<lparr> pasSubject := x \<rparr>) caps =
+  "state_irqs_to_policy_aux (aag\<lparr>pasSubject := x\<rparr>) caps =
    state_irqs_to_policy_aux aag caps"
-  apply(rule equalityI)
-   apply(clarify)
-   apply(erule state_irqs_to_policy_aux.cases, simp,
-         blast intro: state_irqs_to_policy_aux.intros)
-  apply(clarify)
-  apply(erule state_irqs_to_policy_aux.cases)
-  apply(simp)
-  apply(subst pasObjectAbs_pasSubject_update[symmetric])
-  apply(subst pasIRQAbs_pasSubject_update[symmetric])
-  apply(rule state_irqs_to_policy_aux.intros)
+  apply (rule equalityI; clarify)
+   apply (erule state_irqs_to_policy_aux.cases, simp, blast intro: state_irqs_to_policy_aux.intros)
+  apply (erule state_irqs_to_policy_aux.cases)
+  apply simp
+  apply (subst pasObjectAbs_pasSubject_update[symmetric])
+  apply (subst pasIRQAbs_pasSubject_update[symmetric])
+  apply (rule state_irqs_to_policy_aux.intros)
    apply assumption+
   done
 
-
 lemma irq_map_wellformed_pasSubject_update:
-  "irq_map_wellformed_aux (aag\<lparr> pasSubject := x \<rparr>) irqn =
+  "irq_map_wellformed_aux (aag\<lparr>pasSubject := x\<rparr>) irqn =
    irq_map_wellformed_aux aag irqn"
   by (clarsimp simp: irq_map_wellformed_aux_def)
 
 lemma tcb_domain_map_wellformed_pasSubject_update:
-  "tcb_domain_map_wellformed_aux (aag\<lparr> pasSubject := x \<rparr>) irqn =
+  "tcb_domain_map_wellformed_aux (aag\<lparr>pasSubject := x\<rparr>) irqn =
    tcb_domain_map_wellformed_aux aag irqn"
   by (clarsimp simp: tcb_domain_map_wellformed_aux_def)
 
+
+locale PasUpdates_2 = PasUpdates_1 +
+  assumes arch_perform_invocation_domain_fields[wp]:
+    "arch_perform_invocation i \<lbrace>domain_fields P\<rbrace>"
+  and arch_invoke_irq_control_domain_fields[wp]:
+    "arch_invoke_irq_control ci \<lbrace>domain_fields P\<rbrace>"
+  and arch_invoke_irq_handler_domain_fields[wp]:
+    "arch_invoke_irq_handler hi \<lbrace>domain_fields P\<rbrace>"
+  and arch_post_modify_registers_domain_fields[wp]:
+    "arch_post_modify_registers cur t \<lbrace>domain_fields P\<rbrace>"
+  and handle_arch_fault_reply_domain_fields[wp]:
+    "handle_arch_fault_reply vmf thread x y \<lbrace>domain_fields P\<rbrace>"
+  and init_arch_objects_domain_fields[wp]:
+    "init_arch_objects typ ptr num sz refs \<lbrace>domain_fields P\<rbrace>"
+  and state_asids_to_policy_pasSubject_update:
+    "state_asids_to_policy (aag\<lparr>pasSubject := subject\<rparr>) s =
+     state_asids_to_policy aag s"
+  and state_asids_to_policy_pasMayActivate_update:
+    "state_asids_to_policy (aag\<lparr>pasMayActivate := b\<rparr>) s =
+     state_asids_to_policy aag s"
+  and state_asids_to_policy_pasMayEditReadyQueues_update:
+    "state_asids_to_policy (aag\<lparr>pasMayEditReadyQueues := b\<rparr>) s =
+     state_asids_to_policy aag s"
+begin
+
+crunch domain_fields[wp]:
+  set_domain,possible_switch_to,set_priority,set_extra_badge,handle_send,handle_recv,handle_reply
+  "domain_fields P"
+  (wp: syscall_valid crunch_wps mapME_x_inv_wp
+   simp: crunch_simps check_cap_at_def detype_def detype_ext_def mapM_x_defsym
+   ignore: check_cap_at syscall
+   ignore_del: set_domain set_priority possible_switch_to
+   rule: transfer_caps_loop_pres)
+
 lemma pas_refined_pasSubject_update':
-   "\<lbrakk>pas_refined aag s; pas_wellformed (aag\<lparr> pasSubject := x \<rparr>)\<rbrakk> \<Longrightarrow>
-   pas_refined (aag\<lparr> pasSubject := x \<rparr>) s"
-  apply(subst pas_refined_def)
-  apply(safe del: subsetI)
+  "\<lbrakk> pas_refined aag s; pas_wellformed (aag\<lparr>pasSubject := x\<rparr>) \<rbrakk>
+     \<Longrightarrow> pas_refined (aag\<lparr>pasSubject := x\<rparr>) s"
+  apply (subst pas_refined_def)
+  apply (safe del: subsetI)
       apply (simp add: irq_map_wellformed_pasSubject_update pas_refined_def)
      apply (simp add: tcb_domain_map_wellformed_pasSubject_update pas_refined_def)
     apply (clarsimp simp: pas_refined_def)
-   apply(fastforce simp: pas_refined_def state_asids_to_policy_pasSubject_update)
-  apply(fastforce simp: pas_refined_def state_irqs_to_policy_pasSubject_update)
+   apply (clarsimp simp: pas_refined_def state_asids_to_policy_pasSubject_update)
+  apply (fastforce simp: pas_refined_def state_irqs_to_policy_pasSubject_update)
   done
 
 lemma pas_wellformed_pasSubject_update:
-  "\<lbrakk>pas_wellformed_noninterference aag; l \<in> pasDomainAbs aag d\<rbrakk> \<Longrightarrow>
-   pas_wellformed (aag\<lparr>pasSubject := l\<rparr>)"
+  "\<lbrakk> pas_wellformed_noninterference aag; l \<in> pasDomainAbs aag d \<rbrakk>
+     \<Longrightarrow> pas_wellformed (aag\<lparr>pasSubject := l\<rparr>)"
   by (auto simp: pas_wellformed_noninterference_def)
 
 lemmas pas_refined_pasSubject_update =
-                   pas_refined_pasSubject_update'[OF _ pas_wellformed_pasSubject_update]
+  pas_refined_pasSubject_update'[OF _ pas_wellformed_pasSubject_update]
+
+end
+
 
 lemma guarded_pas_domain_pasSubject_update[simp]:
   "guarded_pas_domain (aag\<lparr>pasSubject := x\<rparr>) s = guarded_pas_domain aag s"
   by (simp add: guarded_pas_domain_def)
 
-
 lemma silc_inv_pasSubject_update':
-  "\<lbrakk>silc_inv aag st s; x \<noteq> SilcLabel\<rbrakk> \<Longrightarrow> silc_inv (aag\<lparr>pasSubject := x\<rparr>) st s"
+  "\<lbrakk> silc_inv aag st s; x \<noteq> SilcLabel \<rbrakk>
+     \<Longrightarrow> silc_inv (aag\<lparr>pasSubject := x\<rparr>) st s"
   by (auto simp: silc_inv_def silc_dom_equiv_def intra_label_cap_def cap_points_to_label_def)
 
 lemma silc_inv_pasSubject_update:
-  "\<lbrakk>silc_inv aag st s; pas_wellformed_noninterference aag; l \<in> pasDomainAbs aag d\<rbrakk>
-   \<Longrightarrow> silc_inv (aag\<lparr>pasSubject := l\<rparr>) st s"
-  apply (fastforce intro: silc_inv_pasSubject_update' dest: pas_wellformed_noninterference_silc)
-  done
+  "\<lbrakk> silc_inv aag st s; pas_wellformed_noninterference aag; l \<in> pasDomainAbs aag d \<rbrakk>
+     \<Longrightarrow> silc_inv (aag\<lparr>pasSubject := l\<rparr>) st s"
+  by (fastforce intro: silc_inv_pasSubject_update' dest: pas_wellformed_noninterference_silc)
+
 
 section \<open>PAS MayActivate update\<close>
 
 lemma prop_of_pasMayActivate_update_idemp:
-  "\<lbrakk>P aag; pasMayActivate aag = v\<rbrakk> \<Longrightarrow> P (aag\<lparr> pasMayActivate := v \<rparr>)"
+  "\<lbrakk> P aag; pasMayActivate aag = v \<rbrakk> \<Longrightarrow> P (aag\<lparr>pasMayActivate := v\<rparr>)"
   by (hypsubst, auto)
 
 lemma pasObjectAbs_pasMayActivate_update:
-  "pasObjectAbs (aag\<lparr> pasMayActivate := x \<rparr>) = pasObjectAbs aag"
+  "pasObjectAbs (aag\<lparr>pasMayActivate := x\<rparr>) = pasObjectAbs aag"
   by simp
 
 lemma pasASIDAbs_pasMayActivate_update:
-  "pasASIDAbs (aag\<lparr> pasMayActivate := x \<rparr>) = pasASIDAbs aag"
+  "pasASIDAbs (aag\<lparr>pasMayActivate := x\<rparr>) = pasASIDAbs aag"
   by simp
 
 lemma pasIRQAbs_pasMayActivate_update:
-  "pasIRQAbs (aag\<lparr> pasMayActivate := x \<rparr>) = pasIRQAbs aag"
+  "pasIRQAbs (aag\<lparr>pasMayActivate := x\<rparr>) = pasIRQAbs aag"
   by simp
 
-lemma state_asids_to_policy_pasMayActivate_update:
-  "state_asids_to_policy (aag\<lparr> pasMayActivate := x \<rparr>) s =
-   state_asids_to_policy aag s"
-  apply(rule equalityI)
-   apply(clarify)
-   apply(erule state_asids_to_policy_aux.cases
-        |simp
-        |fastforce intro: state_asids_to_policy_aux.intros)+
-  apply(clarify)
-  apply(erule state_asids_to_policy_aux.cases)
-   apply(simp,
-         subst pasObjectAbs_pasMayActivate_update[symmetric],
-         subst pasASIDAbs_pasMayActivate_update[symmetric],
-         rule state_asids_to_policy_aux.intros, assumption+)+
-  done
-
 lemma state_irqs_to_policy_pasMayActivate_update:
-  "state_irqs_to_policy (aag\<lparr> pasMayActivate := x \<rparr>) s =
+  "state_irqs_to_policy (aag\<lparr>pasMayActivate := x\<rparr>) s =
    state_irqs_to_policy aag s"
-  apply(rule equalityI)
-   apply(clarify)
-   apply(erule state_irqs_to_policy_aux.cases
-        |simp
-        |fastforce intro: state_irqs_to_policy_aux.intros)+
-  apply(clarify)
-  apply(erule state_irqs_to_policy_aux.cases)
-   apply(simp,
-         subst pasObjectAbs_pasMayActivate_update[symmetric],
-         subst pasIRQAbs_pasMayActivate_update[symmetric],
-         rule state_irqs_to_policy_aux.intros, assumption+)+
-  done
-
-lemma pas_refined_pasMayActivate_update:
-  "pas_refined aag s \<Longrightarrow>
-   pas_refined (aag\<lparr> pasMayActivate := x \<rparr>) s"
-  apply(simp add: pas_refined_def)
-  apply(clarsimp simp: irq_map_wellformed_aux_def state_asids_to_policy_pasMayActivate_update[simplified]
-                       state_irqs_to_policy_pasMayActivate_update tcb_domain_map_wellformed_aux_def)
+  apply (rule equalityI)
+   apply (clarify)
+   apply (erule state_irqs_to_policy_aux.cases
+          | simp
+          | fastforce intro: state_irqs_to_policy_aux.intros)+
+  apply (clarify)
+  apply (erule state_irqs_to_policy_aux.cases)
+  apply (simp, subst pasObjectAbs_pasMayActivate_update[symmetric]
+             , subst pasIRQAbs_pasMayActivate_update[symmetric]
+             , rule state_irqs_to_policy_aux.intros, assumption+)
   done
 
 lemma guarded_pas_domainMayActivate_update[simp]:
@@ -238,69 +227,62 @@ lemma guarded_pas_domainMayActivate_update[simp]:
   by (simp add: guarded_pas_domain_def)
 
 lemma cdt_change_allowedMayActivate_update[simp]:
-  "cdt_change_allowed (aag\<lparr>pasMayActivate := x\<rparr>) =
-   cdt_change_allowed aag "
+  "cdt_change_allowed (aag\<lparr>pasMayActivate := x\<rparr>) = cdt_change_allowed aag "
   by (simp add: cdt_change_allowed_def[abs_def] cdt_direct_change_allowed.simps direct_call_def)
+
 
 section \<open>PAS MayEditReadyQueue update\<close>
 
 lemma prop_of_pasMayEditReadyQueues_update_idemp:
-  "\<lbrakk>P aag; pasMayEditReadyQueues aag = v\<rbrakk> \<Longrightarrow> P (aag\<lparr> pasMayEditReadyQueues := v \<rparr>)"
+  "\<lbrakk> P aag; pasMayEditReadyQueues aag = v \<rbrakk> \<Longrightarrow> P (aag\<lparr>pasMayEditReadyQueues := v\<rparr>)"
   by clarsimp
 
 lemma pasObjectAbs_pasMayEditReadyQueues_update:
-  "pasObjectAbs (aag\<lparr> pasMayEditReadyQueues := x \<rparr>) = pasObjectAbs aag"
+  "pasObjectAbs (aag\<lparr>pasMayEditReadyQueues := x\<rparr>) = pasObjectAbs aag"
   by simp
 
 lemma pasASIDAbs_pasMayEditReadyQueues_update:
-  "pasASIDAbs (aag\<lparr> pasMayEditReadyQueues := x \<rparr>) = pasASIDAbs aag"
+  "pasASIDAbs (aag\<lparr>pasMayEditReadyQueues := x\<rparr>) = pasASIDAbs aag"
   by simp
 
 lemma pasIRQAbs_pasMayEditReadyQueues_update:
-  "pasIRQAbs (aag\<lparr> pasMayEditReadyQueues := x \<rparr>) = pasIRQAbs aag"
+  "pasIRQAbs (aag\<lparr>pasMayEditReadyQueues := x\<rparr>) = pasIRQAbs aag"
   by simp
 
-lemma state_asids_to_policy_pasMayEditReadyQueues_update:
-  "state_asids_to_policy (aag\<lparr> pasMayEditReadyQueues := x \<rparr>) s =
-   state_asids_to_policy aag s"
-  apply(rule equalityI)
-   apply(clarify)
-   apply(erule state_asids_to_policy_aux.cases
-        |simp
-        |fastforce intro: state_asids_to_policy_aux.intros)+
-  apply(clarify)
-  apply(erule state_asids_to_policy_aux.cases)
-   apply(simp,
-         subst pasObjectAbs_pasMayEditReadyQueues_update[symmetric],
-         subst pasASIDAbs_pasMayEditReadyQueues_update[symmetric],
-         rule state_asids_to_policy_aux.intros, assumption+)+
+lemma state_irqs_to_policy_pasMayEditReadyQueues_update:
+  "state_irqs_to_policy (aag\<lparr>pasMayEditReadyQueues := x\<rparr>) s =
+   state_irqs_to_policy aag s"
+  apply (rule equalityI)
+   apply (clarify)
+   apply (erule state_irqs_to_policy_aux.cases
+          | simp
+          | fastforce intro: state_irqs_to_policy_aux.intros)+
+  apply (clarify)
+  apply (erule state_irqs_to_policy_aux.cases)
+  apply (simp, subst pasObjectAbs_pasMayEditReadyQueues_update[symmetric]
+             , subst pasIRQAbs_pasMayEditReadyQueues_update[symmetric]
+             , rule state_irqs_to_policy_aux.intros, assumption+)
   done
 
-lemma state_irqs_to_policy_pasMayEditReadyQueues_update:
-  "state_irqs_to_policy (aag\<lparr> pasMayEditReadyQueues := x \<rparr>) s =
-   state_irqs_to_policy aag s"
-  apply(rule equalityI)
-   apply(clarify)
-   apply(erule state_irqs_to_policy_aux.cases
-        |simp
-        |fastforce intro: state_irqs_to_policy_aux.intros)+
-  apply(clarify)
-  apply(erule state_irqs_to_policy_aux.cases)
-   apply(simp,
-         subst pasObjectAbs_pasMayEditReadyQueues_update[symmetric],
-         subst pasIRQAbs_pasMayEditReadyQueues_update[symmetric],
-         rule state_irqs_to_policy_aux.intros, assumption+)+
-  done
+
+context PasUpdates_2 begin
+
+lemma pas_refined_pasMayActivate_update:
+  "pas_refined aag s
+   \<Longrightarrow> pas_refined (aag\<lparr>pasMayActivate := x\<rparr>) s"
+  by (simp add: pas_refined_def irq_map_wellformed_aux_def
+                state_asids_to_policy_pasMayActivate_update[simplified]
+                state_irqs_to_policy_pasMayActivate_update tcb_domain_map_wellformed_aux_def)
 
 lemma pas_refined_pasMayEditReadyQueues_update:
-  "pas_refined aag s \<Longrightarrow>
-   pas_refined (aag\<lparr> pasMayEditReadyQueues := x \<rparr>) s"
-  apply(simp add: pas_refined_def)
-  apply(clarsimp simp: irq_map_wellformed_aux_def
-                       state_asids_to_policy_pasMayEditReadyQueues_update[simplified]
-                       state_irqs_to_policy_pasMayEditReadyQueues_update
-                       tcb_domain_map_wellformed_aux_def)
-  done
+  "pas_refined aag s
+   \<Longrightarrow> pas_refined (aag\<lparr>pasMayEditReadyQueues := x\<rparr>) s"
+  by (clarsimp simp: pas_refined_def irq_map_wellformed_aux_def tcb_domain_map_wellformed_aux_def
+                     state_asids_to_policy_pasMayEditReadyQueues_update[simplified]
+                     state_irqs_to_policy_pasMayEditReadyQueues_update)
+
+end
+
 
 lemma guarded_pas_domainMayEditReadyQueues_update[simp]:
   "guarded_pas_domain (aag\<lparr>pasMayEditReadyQueues := False\<rparr>) = guarded_pas_domain aag"
@@ -310,7 +292,5 @@ lemma cdt_change_allowedMayEditReadyQueues_update[simp]:
   "cdt_change_allowed (aag\<lparr>pasMayEditReadyQueues := x\<rparr>) =
    cdt_change_allowed aag"
   by (simp add: cdt_change_allowed_def[abs_def] cdt_direct_change_allowed.simps direct_call_def)
-
-end
 
 end

--- a/proof/infoflow/PolicyExample.thy
+++ b/proof/infoflow/PolicyExample.thy
@@ -5,7 +5,7 @@
  *)
 
 theory PolicyExample
-imports Noninterference
+imports ArchNoninterference
 begin
 
 (* This first example_auth_graphample shows how notifications and endpoints differ.
@@ -58,13 +58,12 @@ lemma C_in_subjectReads_NTFN1:
 
 lemma RM_in_subjectReads_NTFN1:
   "partition_label RM \<in> subjectReads example_auth_graph (partition_label NTFN1)"
-  apply(rule read_sync_ep_read_receivers, auto intro: EP_in_subjectReads_NTFN1[simplified])
-  done
+  by (rule read_sync_ep_read_receivers; fastforce intro: EP_in_subjectReads_NTFN1)
 
 lemma NTFN2_in_subjectReads_NTFN1:
   "partition_label NTFN2 \<in> subjectReads example_auth_graph (partition_label NTFN1)"
-  apply(rule reads_read_queued_thread_read_ep[where t="partition_label RM" and a="partition_label NTFN2"], auto intro: RM_in_subjectReads_NTFN1[simplified])
-  done
+  apply (rule reads_read_queued_thread_read_ep[where t="partition_label RM" and a="partition_label NTFN2"])
+  by (auto intro: RM_in_subjectReads_NTFN1[simplified])
 
 lemmas subjectReads_NTFN1' = reads_lrefl[of "partition_label NTFN1"]
                             CTR_in_subjectReads_NTFN1
@@ -93,7 +92,7 @@ lemma EP_in_subjectReads_NTFN2:
 
 lemma CTR_in_subjectReads_NTFN2:
   "partition_label CTR \<in> subjectReads example_auth_graph (partition_label NTFN2)"
-  apply(rule read_sync_ep_read_senders[where ep="partition_label EP" and a="partition_label EP"], auto intro: EP_in_subjectReads_NTFN2[simplified])
+  apply(rule read_sync_ep_read_senders[where ep="partition_label EP"], auto intro: EP_in_subjectReads_NTFN2[simplified])
   done
 
 lemma C_in_subjectReads_NTFN2:
@@ -134,9 +133,7 @@ lemma EP_in_subjectReads_CTR:
 lemma RM_in_subjectReads_CTR:
   "partition_label RM \<in> subjectReads example_auth_graph (partition_label CTR)"
   apply(clarsimp)
-  apply(rule_tac ep="partition_label EP" and auth="SyncSend" in read_sync_ep_read_receivers)
-     apply blast
-    apply blast
+  apply(rule_tac ep="partition_label EP" in read_sync_ep_read_receivers)
    apply(rule EP_in_subjectReads_CTR[simplified])
   apply fastforce
   done
@@ -186,8 +183,8 @@ lemma EP_in_subjectReads_C:
 lemma RM_in_subjectReads_C:
   "partition_label RM \<in> subjectReads example_auth_graph (partition_label C)"
   apply(clarsimp)
-  apply(rule_tac a="partition_label CTR" in read_sync_ep_read_receivers[OF _ _ EP_in_subjectReads_C[simplified]])
-    apply simp+
+  apply(rule read_sync_ep_read_receivers[OF EP_in_subjectReads_C[simplified]])
+  apply simp
   done
 
 lemma CTR_in_subjectReads_C:
@@ -219,7 +216,7 @@ lemma subjectReads_C:
 lemma CTR_in_subjectReads_EP:
   "partition_label CTR \<in> subjectReads example_auth_graph (partition_label EP)"
   apply(clarsimp)
-  apply(rule_tac a="partition_label RM" and ep="partition_label EP" in read_sync_ep_read_senders)
+  apply(rule_tac ep="partition_label EP" in read_sync_ep_read_senders)
      apply simp+
   done
 
@@ -237,7 +234,7 @@ lemma C_in_subjectReads_EP:
 
 lemma RM_in_subjectReads_EP:
   "partition_label RM \<in> subjectReads example_auth_graph (partition_label EP)"
-  apply(rule read_sync_ep_read_receivers[OF _ _ reads_lrefl])
+  apply(rule read_sync_ep_read_receivers[OF reads_lrefl])
   apply(auto)
   done
 
@@ -274,7 +271,7 @@ lemma EP_in_subjectReads_RM:
 
 lemma CTR_in_subjectReads_RM:
    "partition_label CTR \<in> subjectReads example_auth_graph (partition_label RM)"
-  apply(rule read_sync_ep_read_senders[where a="partition_label RM" and ep="partition_label EP", OF _ _ EP_in_subjectReads_RM], auto)
+  apply(rule read_sync_ep_read_senders[where ep="partition_label EP", OF EP_in_subjectReads_RM], auto)
   done
 
 lemma C_in_subjectReads_RM:

--- a/proof/infoflow/PolicySystemSAC.thy
+++ b/proof/infoflow/PolicySystemSAC.thy
@@ -6,7 +6,7 @@
 
 theory PolicySystemSAC
 imports
-  Noninterference
+  ArchNoninterference
   "Access.ExampleSystem"
 begin
 
@@ -40,7 +40,7 @@ definition complete_AgentAuthGraph where
   "complete_AgentAuthGraph g \<equiv>
      g \<union> {(y,a,y) | a y. True}
        \<union> {(x,a,y) | x a y. (x,Control,y) \<in> g }
-       \<union> {(x,a,y)|x a y. \<exists> z. (x,Control,z) \<in> g \<and> (z, Control,y) \<in> g} "
+       \<union> {(x,a,y)|x a y. \<exists>z. (x,Control,z) \<in> g \<and> (z, Control,y) \<in> g} "
 declare complete_AgentAuthGraph_def [simp]
 
 abbreviation partition_label where
@@ -126,8 +126,8 @@ lemma abdrm_reads_ep : "x \<in> {NicA, NicB, NicD, RM} \<Longrightarrow> partiti
   done
 
 lemma abdrm_reads_sc : "x \<in> {NicA, NicB, NicD, RM} \<Longrightarrow> partition_label SC \<in> subjectReads SACAuthGraph (partition_label x)"
-    apply (rule_tac auth = "Receive" and b = "partition_label SC" and a = "partition_label RM" and ep = "partition_label EP" in read_sync_ep_read_senders)
-      apply (simp, simp, simp del: SACAuthGraph_def add: abdrm_reads_ep, simp)
+    apply (rule_tac b = "partition_label SC" and ep = "partition_label EP" in read_sync_ep_read_senders)
+      apply (simp del: SACAuthGraph_def add: abdrm_reads_ep, simp)
 done
 
 lemma abd_reads_rm : "x \<in> {NicA, NicB, NicD} \<Longrightarrow> partition_label RM \<in> subjectReads SACAuthGraph (partition_label x)"
@@ -255,8 +255,7 @@ lemma c_reads_ep : "partition_label EP \<in> subjectReads SACAuthGraph (partitio
 done
 
 lemma c_reads_rm : "partition_label RM \<in> subjectReads SACAuthGraph (partition_label NicC)"
-  apply (rule_tac auth = SyncSend and a = "partition_label SC" and ep = "partition_label EP" in read_sync_ep_read_receivers)
-   apply (simp, simp)
+  apply (rule_tac ep = "partition_label EP" in read_sync_ep_read_receivers)
    apply (rule c_reads_ep)
    apply (simp)
 done
@@ -319,8 +318,8 @@ lemma r_reads_ep : "partition_label EP \<in> subjectReads SACAuthGraph (partitio
 done
 
 lemma r_reads_sc : "partition_label SC \<in> subjectReads SACAuthGraph (partition_label R)"
-    apply (rule_tac a="partition_label RM" and auth="Receive" and ep="partition_label EP" and b="partition_label SC" in read_sync_ep_read_senders)
-    apply (simp, simp, rule r_reads_ep, simp)
+    apply (rule_tac ep="partition_label EP" and b="partition_label SC" in read_sync_ep_read_senders)
+    apply (rule r_reads_ep, simp)
 done
 
 lemma r_reads_a : "partition_label NicA \<in> subjectReads SACAuthGraph (partition_label R)"
@@ -408,7 +407,7 @@ lemma r_affects : "subjectAffects SACAuthGraph (partition_label R) =
 subsection \<open>RM reads/affects\<close>
 
 lemma rm_reads_sc : "partition_label SC \<in> subjectReads SACAuthGraph (partition_label RM)"
-  apply (rule_tac a="partition_label RM" and auth="Receive" and ep="partition_label EP" in read_sync_ep_read_senders)
+  apply (rule_tac ep="partition_label EP" in read_sync_ep_read_senders)
   apply (simp_all add:reads_ep)
 done
 
@@ -492,7 +491,7 @@ lemma rm_affects : "subjectAffects SACAuthGraph (partition_label RM) =
 subsection \<open>SC\<close>
 
 lemma sc_reads_rm : "partition_label RM \<in> subjectReads SACAuthGraph (partition_label SC)"
-  apply (rule_tac a="partition_label SC" and ep="partition_label EP" and auth="SyncSend" and b="partition_label RM" in read_sync_ep_read_receivers)
+  apply (rule_tac ep="partition_label EP" and b="partition_label RM" in read_sync_ep_read_receivers)
   apply (simp_all add:reads_ep)
 done
 
@@ -549,13 +548,13 @@ done
 subsection \<open>EP\<close>
 
 lemma ep_reads_sc : "partition_label SC \<in> subjectReads SACAuthGraph (partition_label EP)"
-  apply (rule_tac a="partition_label EP" and ep="partition_label EP" and auth="Receive" in read_sync_ep_read_senders)
-  apply (simp, simp, rule reads_lrefl, simp_all)
+  apply (rule_tac ep="partition_label EP" in read_sync_ep_read_senders)
+  apply (rule reads_lrefl, simp_all)
 done
 
 lemma ep_reads_rm : "partition_label RM \<in> subjectReads SACAuthGraph (partition_label EP)"
-  apply (rule_tac a="partition_label SC" and ep="partition_label EP" and b="partition_label RM" and auth="SyncSend" in read_sync_ep_read_receivers)
-  apply (simp, simp, rule reads_lrefl, simp)
+  apply (rule_tac ep="partition_label EP" and b="partition_label RM" in read_sync_ep_read_receivers)
+  apply (rule reads_lrefl, simp)
 done
 
 lemma ep_reads_c : "partition_label NicC \<in> subjectReads SACAuthGraph (partition_label EP)"
@@ -627,8 +626,8 @@ subsection \<open>NTFN1,2,3\<close>
 subsubsection \<open>NTFN1 reads SC, EP, RM, R\<close>
 
 lemma ntfn1_reads_sc : "partition_label SC \<in> subjectReads SACAuthGraph (partition_label NTFN1)"
-  apply (rule_tac ep="partition_label NTFN1" and auth="SyncSend" and a="partition_label NTFN1" in read_sync_ep_read_receivers)
-  apply (simp, simp, rule reads_lrefl, simp)
+  apply (rule_tac ep="partition_label NTFN1" in read_sync_ep_read_receivers)
+  apply (rule reads_lrefl, simp)
 done
 
 lemma ntfn1_reads_ep : "partition_label EP \<in> subjectReads SACAuthGraph (partition_label NTFN1)"
@@ -637,15 +636,15 @@ lemma ntfn1_reads_ep : "partition_label EP \<in> subjectReads SACAuthGraph (part
 done
 
 lemma ntfn1_reads_rm : "partition_label RM \<in> subjectReads SACAuthGraph (partition_label NTFN1)"
-  apply (rule_tac b="partition_label RM" and ep="partition_label EP" and auth="SyncSend" and a="partition_label SC" in read_sync_ep_read_receivers)
-  apply (simp, simp, rule ntfn1_reads_ep, simp)
+  apply (rule_tac b="partition_label RM" and ep="partition_label EP" in read_sync_ep_read_receivers)
+  apply (rule ntfn1_reads_ep, simp)
 done
 
 subsubsection \<open>NTFN2 reads SC, EP, RM, R\<close>
 
 lemma ntfn2_reads_rm : "partition_label RM \<in> subjectReads SACAuthGraph (partition_label NTFN2)"
-  apply (rule_tac ep="partition_label NTFN2" and auth="SyncSend" and a="partition_label NTFN2" in read_sync_ep_read_receivers)
-  apply (simp, simp, rule reads_lrefl, simp)
+  apply (rule_tac ep="partition_label NTFN2" in read_sync_ep_read_receivers)
+  apply (rule reads_lrefl, simp)
 done
 
 lemma ntfn2_reads_ep : "partition_label EP \<in> subjectReads SACAuthGraph (partition_label NTFN2)"
@@ -654,15 +653,15 @@ lemma ntfn2_reads_ep : "partition_label EP \<in> subjectReads SACAuthGraph (part
 done
 
 lemma ntfn2_reads_sc : "partition_label SC \<in> subjectReads SACAuthGraph (partition_label NTFN2)"
-  apply (rule_tac b="partition_label SC" and ep="partition_label EP" and auth="Reset" and a="partition_label EP" in read_sync_ep_read_senders)
-  apply (simp, simp, rule ntfn2_reads_ep, simp)
+  apply (rule_tac b="partition_label SC" and ep="partition_label EP" in read_sync_ep_read_senders)
+  apply (rule ntfn2_reads_ep, simp)
 done
 
 subsubsection \<open>NTFN3 reads SC, EP, RM, R\<close>
 
 lemma ntfn3_reads_r : "partition_label R \<in> subjectReads SACAuthGraph (partition_label NTFN3)"
-  apply (rule_tac ep="partition_label NTFN3" and auth="SyncSend" and a="partition_label NTFN3" in read_sync_ep_read_receivers)
-  apply (simp, simp, rule reads_lrefl, simp)
+  apply (rule_tac ep="partition_label NTFN3" in read_sync_ep_read_receivers)
+  apply (rule reads_lrefl, simp)
 done
 
 lemma ntfn3_reads_rm : "partition_label RM \<in> subjectReads SACAuthGraph (partition_label NTFN3)"
@@ -676,8 +675,8 @@ lemma ntfn3_reads_ep : "partition_label EP \<in> subjectReads SACAuthGraph (part
 done
 
 lemma ntfn3_reads_sc : "partition_label SC \<in> subjectReads SACAuthGraph (partition_label NTFN3)"
-  apply (rule_tac ep="partition_label EP" and auth="Receive" and a="partition_label RM" in read_sync_ep_read_senders)
-  apply (simp, simp, rule ntfn3_reads_ep, simp)
+  apply (rule_tac ep="partition_label EP" in read_sync_ep_read_senders)
+  apply (rule ntfn3_reads_ep, simp)
 done
 
 subsubsection \<open>NTFN1,2,3 reads C\<close>

--- a/proof/infoflow/Retype_IF.thy
+++ b/proof/infoflow/Retype_IF.thy
@@ -5,10 +5,8 @@
  *)
 
 theory Retype_IF
-imports CNode_IF
+imports ArchCNode_IF
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma create_cap_reads_respects:
   "reads_respects aag l (K (is_subject aag (fst (fst slot))))
@@ -17,762 +15,352 @@ lemma create_cap_reads_respects:
   apply (simp add: create_cap_def split_def bind_assoc[symmetric])
   apply (fold update_cdt_def)
   apply (simp add: bind_assoc create_cap_ext_def)
-  apply (wp set_cap_reads_respects set_original_reads_respects update_cdt_list_reads_respects update_cdt_reads_respects| simp | fastforce simp: equiv_for_def split: option.splits)+
+  apply (wp set_cap_reads_respects set_original_reads_respects
+            update_cdt_list_reads_respects update_cdt_reads_respects
+         | simp | fastforce simp: equiv_for_def split: option.splits)+
   apply (intro impI conjI allI)
-   apply (fastforce simp: reads_equiv_def2 equiv_for_def
-                    elim: states_equiv_forE_is_original_cap states_equiv_forE_cdt
-                    dest: aag_can_read_self
-                   split: option.splits)+
-  done
+  by (fastforce simp: reads_equiv_def2 equiv_for_def
+                elim: states_equiv_forE_is_original_cap states_equiv_forE_cdt
+                dest: aag_can_read_self
+               split: option.splits)+
 
 lemma gets_any_evrv:
   "equiv_valid_rv_inv I A \<top>\<top> \<top> (gets f)"
-  apply(clarsimp simp: equiv_valid_2_def in_monad)
-  done
+  by (clarsimp simp: equiv_valid_2_def in_monad)
 
 lemma select_f_any_evrv:
   "equiv_valid_rv_inv I A \<top>\<top> \<top> (select_f f)"
-  apply(clarsimp simp: equiv_valid_2_def select_f_def)
-  done
+  by (clarsimp simp: equiv_valid_2_def select_f_def)
 
 lemma select_f_any_ev2:
   "equiv_valid_2 I A A \<top>\<top> \<top> \<top> (select_f f) (select_f f')"
-  apply(clarsimp simp: equiv_valid_2_def select_f_def)
-  done
+  by (clarsimp simp: equiv_valid_2_def select_f_def)
 
 lemma machine_op_lift_ev':
-  "equiv_valid_inv I A (K (\<forall> s t x y. (I s t \<longrightarrow> I (s\<lparr>machine_state_rest := x\<rparr>) (t\<lparr>machine_state_rest := y\<rparr>)) \<and> (A s t \<longrightarrow> A (s\<lparr>machine_state_rest := x\<rparr>) (t\<lparr>machine_state_rest := y\<rparr>)))) (machine_op_lift mop)"
-  apply(rule gen_asm_ev)
+  "equiv_valid_inv I A
+     (K (\<forall>s t x y. (I s t \<longrightarrow> I (s\<lparr>machine_state_rest := x\<rparr>) (t\<lparr>machine_state_rest := y\<rparr>)) \<and>
+                   (A s t \<longrightarrow> A (s\<lparr>machine_state_rest := x\<rparr>) (t\<lparr>machine_state_rest := y\<rparr>))))
+     (machine_op_lift mop)"
   unfolding machine_op_lift_def comp_def machine_rest_lift_def
-  apply(simp add: equiv_valid_def2)
-  apply(rule equiv_valid_rv_bind)
-    apply(rule gets_any_evrv)
-   apply(rule_tac R'="\<top>\<top>" and Q="\<top>\<top>" and Q'="\<top>\<top>" in equiv_valid_2_bind_pre)
-        apply(simp add: split_def)
-        apply(rule modify_ev2)
-        apply(auto)[1]
-       apply(rule select_f_any_ev2)
-      apply (rule wp_post_taut | simp)+
+  apply (rule gen_asm_ev)
+  apply (simp add: equiv_valid_def2)
+  apply (rule equiv_valid_rv_bind)
+    apply (rule gets_any_evrv)
+   apply (rule_tac R'="\<top>\<top>" and Q="\<top>\<top>" and Q'="\<top>\<top>" in equiv_valid_2_bind_pre)
+        apply (simp add: split_def)
+        apply (rule modify_ev2)
+        apply fastforce
+       apply (rule select_f_any_ev2)
+      apply wpsimp+
   done
 
-
 lemma equiv_machine_state_machine_state_rest_update:
-  "equiv_machine_state P s t \<Longrightarrow>
-   equiv_machine_state P (s\<lparr> machine_state_rest := x \<rparr>) (t\<lparr> machine_state_rest := y \<rparr>)"
-  by(fastforce intro: equiv_forI elim: equiv_forE)
+  "equiv_machine_state P s t
+   \<Longrightarrow> equiv_machine_state P (s\<lparr>machine_state_rest := x\<rparr>) (t\<lparr>machine_state_rest := y\<rparr>)"
+  by (fastforce intro: equiv_forI elim: equiv_forE)
 
 lemma machine_op_lift_ev:
   "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) \<top> (machine_op_lift mop)"
   apply (rule equiv_valid_guard_imp)
-  apply (rule machine_op_lift_ev')
+   apply (rule machine_op_lift_ev')
   apply clarsimp
   apply (intro conjI impI)
-  apply (drule equiv_machine_state_machine_state_rest_update, fastforce)+
-  done
-
-lemma cacheRangeOp_ev[wp]:
-  "(\<And>a b. equiv_valid_inv I A \<top> (oper a b))
-    \<Longrightarrow> equiv_valid_inv I A \<top> (cacheRangeOp oper x y z)"
-  apply (simp add: cacheRangeOp_def split_def)
-  apply (rule mapM_x_ev)
-   apply simp
-  apply (rule hoare_TrueI)
-  done
-
-lemma cleanCacheRange_PoU_ev:
-  "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) \<top> (cleanCacheRange_PoU vstart vend pstart)"
-  unfolding cleanCacheRange_PoU_def
-  apply (wp machine_op_lift_ev | simp add: cleanByVA_PoU_def)+
-  done
-
-lemma cleanCacheRange_RAM_ev:
-  "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) \<top> (cleanCacheRange_RAM vstart vend pstart)"
-  unfolding cleanCacheRange_RAM_def cleanCacheRange_PoC_def cacheRangeOp_def cleanL2Range_def
-            dsb_def cleanByVA_def
-  by (wpsimp wp: machine_op_lift_ev mapM_x_ev')
-
-lemma modify_underlying_memory_update_0_ev:
-  "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) \<top>
-          (modify
-            (underlying_memory_update
-              (\<lambda>m. m(x := word_rsplit 0 ! 3, x + 1 := word_rsplit 0 ! 2,
-                     x + 2 := word_rsplit 0 ! 1, x + 3 := word_rsplit 0 ! 0))))"
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def in_monad)
-  apply(fastforce intro: equiv_forI elim: equiv_forE)
-  done
-
-lemma storeWord_ev:
-  "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) \<top> (storeWord x 0)"
-  unfolding storeWord_def
-  apply (wp modify_underlying_memory_update_0_ev assert_inv | simp add: no_irq_def)+
-  done
-
-lemma clearMemory_ev:
-  "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) (\<lambda>_. True) (clearMemory ptr bits)"
-  unfolding clearMemory_def
-  apply simp
-  apply(rule equiv_valid_guard_imp)
-   apply(rule bind_ev)
-     apply(rule cleanCacheRange_RAM_ev)
-    apply(rule mapM_x_ev[OF storeWord_ev])
-    apply(rule wp_post_taut | simp)+
-  done
-
-lemma freeMemory_ev:
-  "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) (\<lambda>_. True) (freeMemory ptr bits)"
-  unfolding freeMemory_def
-  apply(rule equiv_valid_guard_imp)
-   apply(rule mapM_x_ev[OF storeWord_ev])
-   apply(rule wp_post_taut | simp)+
+     apply (drule equiv_machine_state_machine_state_rest_update, fastforce)+
   done
 
 lemma machine_op_lift_irq_state[wp]:
-  " \<lbrace>\<lambda>ms. P (irq_state ms)\<rbrace> machine_op_lift mop \<lbrace>\<lambda>_ ms. P (irq_state ms)\<rbrace>"
-  apply(simp add: machine_op_lift_def machine_rest_lift_def | wp | wpc)+
-  done
+  "machine_op_lift mop \<lbrace>\<lambda>ms. P (irq_state ms)\<rbrace>"
+  by (simp add: machine_op_lift_def machine_rest_lift_def | wp | wpc)+
 
 lemma dmo_mol_reads_respects:
   "reads_respects aag l \<top> (do_machine_op (machine_op_lift mop))"
-  apply(rule use_spec_ev)
-  apply(rule do_machine_op_spec_reads_respects)
-   apply(rule equiv_valid_guard_imp[OF machine_op_lift_ev])
+  apply (rule use_spec_ev)
+  apply (rule do_machine_op_spec_reads_respects)
+   apply (rule equiv_valid_guard_imp[OF machine_op_lift_ev])
    apply simp
   apply wp
   done
 
 lemma dmo_bind_ev:
-  "equiv_valid_inv I A P (do_machine_op (a >>= b)) = equiv_valid_inv I A P (do_machine_op a >>= (\<lambda>rv. do_machine_op (b rv)))"
-  by (fastforce simp: do_machine_op_def gets_def get_def select_f_def modify_def put_def return_def bind_def equiv_valid_def2 equiv_valid_2_def)
+  "equiv_valid_inv I A P (do_machine_op (a >>= b)) =
+   equiv_valid_inv I A P (do_machine_op a >>= (\<lambda>rv. do_machine_op (b rv)))"
+  by (fastforce simp: do_machine_op_def gets_def get_def select_f_def modify_def
+                      put_def return_def bind_def equiv_valid_def2 equiv_valid_2_def)
 
 lemma dmo_bind_ev':
-  "equiv_valid_inv I A P (a >>= (\<lambda>rv. do_machine_op (b rv >>= c rv)))
-    = equiv_valid_inv I A P (a >>= (\<lambda>rv. do_machine_op (b rv) >>= (\<lambda>rv'. do_machine_op (c rv rv'))))"
-  by (fastforce simp: do_machine_op_def gets_def get_def select_f_def modify_def put_def return_def bind_def equiv_valid_def2 equiv_valid_2_def)
+  "equiv_valid_inv I A P (a >>= (\<lambda>rv. do_machine_op (b rv >>= c rv))) =
+   equiv_valid_inv I A P (a >>= (\<lambda>rv. do_machine_op (b rv) >>= (\<lambda>rv'. do_machine_op (c rv rv'))))"
+  by (fastforce simp: do_machine_op_def gets_def get_def select_f_def modify_def
+                      put_def return_def bind_def equiv_valid_def2 equiv_valid_2_def)
 
 lemma dmo_mapM_ev_pre:
-  assumes reads_res: "\<And> x. x \<in> set lst \<Longrightarrow> equiv_valid_inv D A I (do_machine_op (m x))"
-  assumes invariant: "\<And> x. x \<in> set lst \<Longrightarrow> \<lbrace> I \<rbrace> do_machine_op (m x) \<lbrace> \<lambda>_. I \<rbrace>"
-  assumes inv_established: "\<And> s. P s \<Longrightarrow> I s"
+  assumes reads_res: "\<And>x. x \<in> set lst \<Longrightarrow> equiv_valid_inv D A I (do_machine_op (m x))"
+  assumes invariant: "\<And>x. x \<in> set lst \<Longrightarrow> do_machine_op (m x) \<lbrace>I\<rbrace>"
+  assumes inv_established: "\<And>s. P s \<Longrightarrow> I s"
   shows "equiv_valid_inv D A P (do_machine_op (mapM m lst))"
   using assms
-  apply(atomize)
-  apply(rule_tac Q=I in equiv_valid_guard_imp)
-  apply(induct lst)
-    apply(simp add: mapM_Nil return_ev_pre)
-   apply(subst mapM_Cons)
-   apply(simp add: dmo_bind_ev dmo_bind_ev')
-   apply(rule bind_ev_pre[where P''="I"])
-    apply(rule bind_ev[OF return_ev])
-    apply fastforce
-    apply (rule wp_post_taut)
-    apply fastforce+
+  apply atomize
+  apply (rule_tac Q=I in equiv_valid_guard_imp)
+   apply (induct lst)
+    apply (simp add: mapM_Nil return_ev_pre)
+   apply (subst mapM_Cons)
+   apply (simp add: dmo_bind_ev dmo_bind_ev')
+   apply (rule bind_ev_pre[where P''="I"])
+      apply (rule bind_ev[OF return_ev])
+       apply fastforce
+      apply (rule wp_post_taut)
+     apply fastforce+
   done
 
 lemma dmo_mapM_x_ev_pre:
-  assumes reads_res: "\<And> x. x \<in> set lst \<Longrightarrow> equiv_valid_inv D A I (do_machine_op (m x))"
-  assumes invariant: "\<And> x. x \<in> set lst \<Longrightarrow> \<lbrace> I \<rbrace> do_machine_op (m x) \<lbrace> \<lambda>_. I \<rbrace>"
-  assumes inv_established: "\<And> s. P s \<Longrightarrow> I s"
+  assumes reads_res: "\<And>x. x \<in> set lst \<Longrightarrow> equiv_valid_inv D A I (do_machine_op (m x))"
+  assumes invariant: "\<And>x. x \<in> set lst \<Longrightarrow> do_machine_op (m x) \<lbrace>I\<rbrace>"
+  assumes inv_established: "\<And>s. P s \<Longrightarrow> I s"
   shows "equiv_valid_inv D A P (do_machine_op (mapM_x m lst))"
-  apply(subst mapM_x_mapM)
-  apply(simp add: dmo_bind_ev)
-  apply(rule bind_ev_pre[OF return_ev dmo_mapM_ev_pre])
-  apply (blast intro: reads_res invariant inv_established wp_post_taut)+
-  done
+  apply (subst mapM_x_mapM)
+  apply (simp add: dmo_bind_ev)
+  apply (rule bind_ev_pre[OF return_ev dmo_mapM_ev_pre])
+  by (blast intro: reads_res invariant inv_established wp_post_taut)+
 
 lemma dmo_mapM_ev:
-  assumes reads_res: "\<And> x. x \<in> set lst \<Longrightarrow> equiv_valid_inv D A I (do_machine_op (m x))"
-  assumes invariant: "\<And> x. x \<in> set lst \<Longrightarrow> \<lbrace> I \<rbrace> do_machine_op (m x) \<lbrace> \<lambda>_. I \<rbrace>"
+  assumes reads_res: "\<And>x. x \<in> set lst \<Longrightarrow> equiv_valid_inv D A I (do_machine_op (m x))"
+  assumes invariant: "\<And>x. x \<in> set lst \<Longrightarrow> \<lbrace>I\<rbrace> do_machine_op (m x) \<lbrace>\<lambda>_. I\<rbrace>"
   shows "equiv_valid_inv D A I (do_machine_op (mapM m lst))"
   using assms by (auto intro: dmo_mapM_ev_pre)
 
 lemma dmo_mapM_x_ev:
-  assumes reads_res: "\<And> x. x \<in> set lst \<Longrightarrow> equiv_valid_inv D A I (do_machine_op (m x))"
-  assumes invariant: "\<And> x. x \<in> set lst \<Longrightarrow> \<lbrace> I \<rbrace> do_machine_op (m x) \<lbrace> \<lambda>_. I \<rbrace>"
+  assumes reads_res: "\<And>x. x \<in> set lst \<Longrightarrow> equiv_valid_inv D A I (do_machine_op (m x))"
+  assumes invariant: "\<And>x. x \<in> set lst \<Longrightarrow> \<lbrace>I\<rbrace> do_machine_op (m x) \<lbrace>\<lambda>_. I\<rbrace>"
   shows "equiv_valid_inv D A I (do_machine_op (mapM_x m lst))"
   using assms by (auto intro: dmo_mapM_x_ev_pre)
 
-lemma dmo_cacheRangeOp_reads_respects:
-  "(\<And>a b. reads_respects aag l \<top> (do_machine_op (oper a b)))
-    \<Longrightarrow> reads_respects aag l \<top> (do_machine_op (cacheRangeOp oper x y z))"
-  apply (simp add: cacheRangeOp_def)
-  apply (rule dmo_mapM_x_ev)
-   apply (simp add: split_def)
-  apply (rule hoare_TrueI)
-  done
 
-lemma dmo_cleanCacheRange_PoU_reads_respects:
-  "reads_respects aag l \<top> (do_machine_op (cleanCacheRange_PoU vsrat vend pstart))"
-  unfolding cleanCacheRange_PoU_def
-  by(wp dmo_cacheRangeOp_reads_respects dmo_mol_reads_respects | simp add: cleanByVA_PoU_def)+
-
-crunch irq_state[wp]: clearMemory "\<lambda>s. P (irq_state s)"
-  (wp: crunch_wps simp: crunch_simps storeWord_def cleanByVA_PoU_def
-   ignore_del: clearMemory cleanL2Range dsb cleanByVA)
+locale Retype_IF_1 =
+  assumes clearMemory_ev:
+    "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) \<top> (clearMemory ptr bits)"
+  and freeMemory_ev:
+    "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) \<top> (freeMemory ptr bits)"
+  and no_irq_freeMemory:
+    "no_irq (freeMemory ptr sz)"
+  and equiv_asid_detype:
+    "equiv_asid asid s s' \<Longrightarrow> equiv_asid asid (detype N s) (detype N s')"
+  and clearMemory_irq_state[wp]:
+    "\<And>P. clearMemory ptr bits \<lbrace>\<lambda>s. P (irq_state s)\<rbrace>"
+  and freeMemory_irq_state[wp]:
+    "\<And>P. freeMemory ptr bits \<lbrace>\<lambda>s. P (irq_state s)\<rbrace>"
+  and dmo_clearMemory_globals_equiv:
+    "do_machine_op (clearMemory ptr (2 ^ bits)) \<lbrace>globals_equiv s\<rbrace>"
+  and dmo_freeMemory_globals_equiv:
+    "do_machine_op (freeMemory ptr bits) \<lbrace>globals_equiv s\<rbrace>"
+  and retype_region_globals_equiv:
+    "\<lbrace>globals_equiv s and invs
+                      and (\<lambda>s. \<exists>i. cte_wp_at (\<lambda>c. c = UntypedCap dev (p && ~~ mask sz) sz i) slot s \<and>
+                                   (i \<le> unat (p && mask sz) \<or> pspace_no_overlap_range_cover p sz s))
+                      and K (range_cover p sz (obj_bits_api type o_bits) num \<and> 0 < num)\<rbrace>
+     retype_region p num o_bits type dev
+     \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+begin
 
 lemma dmo_clearMemory_reads_respects:
   "reads_respects aag l \<top> (do_machine_op (clearMemory ptr bits))"
-  apply(rule use_spec_ev)
-  apply(rule do_machine_op_spec_reads_respects)
-   apply(rule equiv_valid_guard_imp[OF clearMemory_ev], rule TrueI)
+  apply (rule use_spec_ev)
+  apply (rule do_machine_op_spec_reads_respects)
+   apply (rule equiv_valid_guard_imp[OF clearMemory_ev], rule TrueI)
   apply wp
   done
-
-crunch irq_state[wp]: freeMemory "\<lambda>s. P (irq_state s)"
-  (wp: crunch_wps simp: crunch_simps storeWord_def)
 
 lemma dmo_freeMemory_reads_respects:
   "reads_respects aag l \<top> (do_machine_op (freeMemory ptr bits))"
-  apply(rule use_spec_ev)
-  apply(rule do_machine_op_spec_reads_respects)
-   apply(rule equiv_valid_guard_imp[OF freeMemory_ev], rule TrueI)
+  apply (rule use_spec_ev)
+  apply (rule do_machine_op_spec_reads_respects)
+   apply (rule equiv_valid_guard_imp[OF freeMemory_ev], rule TrueI)
   apply wp
   done
 
-lemma set_pd_globals_equiv:
-  "\<lbrace>globals_equiv st and (\<lambda>s. a \<noteq> arm_global_pd (arch_state s))\<rbrace> set_pd a b \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding set_pd_def
-  by (wpsimp wp: set_object_globals_equiv[THEN hoare_set_object_weaken_pre]
-           simp: obj_at_def)
-
-lemma globals_equiv_cdt_update[simp]:
-  "globals_equiv s (s'\<lparr> cdt := x \<rparr>) = globals_equiv s s'"
-  by(fastforce simp: globals_equiv_def idle_equiv_def)
-
-lemma globals_equiv_is_original_cap_update[simp]:
-  "globals_equiv s (s'\<lparr> is_original_cap := x \<rparr>) = globals_equiv s s'"
-  by(fastforce simp: globals_equiv_def idle_equiv_def)
-
-lemma create_cap_globals_equiv:
-  "\<lbrace> globals_equiv s and valid_global_objs \<rbrace> create_cap type bits untyped dev slot
-   \<lbrace> \<lambda>_. globals_equiv s \<rbrace>"
-  apply (simp add: create_cap_def split_def)
-  apply (wp set_cap_globals_equiv set_original_globals_equiv set_cdt_globals_equiv
-            set_cdt_valid_global_objs dxo_wp_weak set_original_wp | simp)+
+lemma dmo_clearMemory_reads_respects_g:
+  "reads_respects_g aag l \<top> (do_machine_op (clearMemory ptr (2 ^bits)))"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_g)
+    apply (rule dmo_clearMemory_reads_respects)
+   apply (rule doesnt_touch_globalsI[where P = \<top>, simplified, OF dmo_clearMemory_globals_equiv])
+  apply clarsimp
   done
 
-lemma set_pd_reads_respects:
-  "reads_respects aag l (K (is_subject aag a)) (set_pd a b)"
-  unfolding set_pd_def
-  by (blast intro: equiv_valid_guard_imp set_object_reads_respects)
+lemma dmo_freeMemory_reads_respects_g:
+  "reads_respects_g aag l (\<lambda> s. is_aligned ptr bits \<and> 2 \<le> bits \<and> bits < word_bits)
+                    (do_machine_op (freeMemory ptr bits))"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_g)
+    apply (rule dmo_freeMemory_reads_respects)
+   apply (rule doesnt_touch_globalsI[where P = \<top>, simplified, OF dmo_freeMemory_globals_equiv])
+  apply clarsimp
+  done
+
+end
 
 
-lemma set_pd_reads_respects_g:
-  "reads_respects_g aag l (\<lambda> s. is_subject aag ptr \<and> ptr \<noteq> arm_global_pd (arch_state s)) (set_pd ptr pd)"
-  apply(fastforce intro: equiv_valid_guard_imp[OF reads_respects_g]
-                 intro: doesnt_touch_globalsI
-                        set_pd_reads_respects set_pd_globals_equiv)
+lemma globals_equiv_cdt_update[simp]:
+  "globals_equiv s (s'\<lparr>cdt := x\<rparr>) = globals_equiv s s'"
+  by (fastforce simp: globals_equiv_def idle_equiv_def)
+
+lemma globals_equiv_is_original_cap_update[simp]:
+  "globals_equiv s (s'\<lparr>is_original_cap := x\<rparr>) = globals_equiv s s'"
+  by (fastforce simp: globals_equiv_def idle_equiv_def)
+
+lemma create_cap_globals_equiv:
+  "\<lbrace>globals_equiv s and valid_global_objs\<rbrace>
+   create_cap type bits untyped dev slot
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  apply (simp only: create_cap_def split_def)
+  apply (wp set_cap_globals_equiv set_original_globals_equiv set_cdt_globals_equiv
+            set_cdt_valid_global_objs dxo_wp_weak set_original_wp | simp)+
   done
 
 abbreviation reads_equiv_valid_g_inv where
 "reads_equiv_valid_g_inv A aag P f \<equiv> equiv_valid_inv (reads_equiv_g aag) A P f"
 
 lemma gets_apply_ev':
-  "\<forall> s t. I s t \<and> A s t \<and> P s \<and> P t \<longrightarrow> (f s) x = (f t) x \<Longrightarrow>
-   equiv_valid I A A P (gets_apply f x)"
-  apply(simp add: gets_apply_def get_def bind_def return_def)
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
-  done
-
-lemma get_object_arm_global_pd_revg:
-  "reads_equiv_valid_g_inv A aag (\<lambda> s. p = arm_global_pd (arch_state s)) (get_object p)"
-  apply(unfold get_object_def fun_app_def)
-  apply(subst gets_apply)
-  apply(wp gets_apply_ev')
-    defer
-    apply(wp hoare_drop_imps)
-   apply(rule conjI)
-    apply assumption
-   apply simp
-  apply(auto simp: reads_equiv_g_def globals_equiv_def)
-  done
-
-lemma get_pd_rev:
-  "reads_equiv_valid_inv A aag (K (is_subject aag ptr)) (get_pd ptr)"
-  unfolding get_pd_def
-  apply(wp get_object_rev | wpc | clarsimp)+
-  done
-
-lemma get_pd_revg:
-  "reads_equiv_valid_g_inv A aag (\<lambda> s. ptr = arm_global_pd (arch_state s)) (get_pd ptr)"
-  unfolding get_pd_def
-  apply(wp get_object_arm_global_pd_revg | wpc | clarsimp)+
-  done
-
-lemma store_pde_reads_respects:
-  "reads_respects aag l (K (is_subject aag (ptr && ~~ mask pd_bits)))
-                         (store_pde ptr pde)"
-  unfolding store_pde_def fun_app_def
-  apply(wp set_pd_reads_respects get_pd_rev)
-  apply(clarsimp)
-  done
-
-
-lemma store_pde_globals_equiv:
-  "\<lbrace> globals_equiv s and (\<lambda> s. ptr && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s)) \<rbrace>
-   (store_pde ptr pde)
-   \<lbrace> \<lambda>_. globals_equiv s \<rbrace>"
-  unfolding store_pde_def
-  apply(wp set_pd_globals_equiv)
-  apply simp
-  done
-
-lemma store_pde_reads_respects_g:
-  "reads_respects_g aag l (\<lambda> s. is_subject aag (ptr && ~~ mask pd_bits) \<and> ptr && ~~ mask pd_bits \<noteq> arm_global_pd (arch_state s)) (store_pde ptr pde)"
-  apply(fastforce intro: equiv_valid_guard_imp[OF reads_respects_g]
-                 intro: doesnt_touch_globalsI
-                        store_pde_reads_respects store_pde_globals_equiv)
-  done
-
-lemma get_pde_rev:
-  "reads_equiv_valid_inv A aag (K (is_subject aag (ptr && ~~ mask pd_bits)))
-                                 (get_pde ptr)"
-  unfolding get_pde_def fun_app_def
-  by (wpsimp wp: get_pd_rev)
-
-lemma get_pde_revg:
-  "reads_equiv_valid_g_inv A aag (\<lambda> s. (ptr && ~~ mask pd_bits) = arm_global_pd (arch_state s))
-                                 (get_pde ptr)"
-  unfolding get_pde_def fun_app_def
-  by (wpsimp wp: get_pd_revg)
-
-lemma copy_global_mappings_reads_respects_g:
-  "is_aligned x pd_bits \<Longrightarrow>
-  reads_respects_g aag l (\<lambda> s. (is_subject aag x \<and> x \<noteq> arm_global_pd (arch_state s)) \<and> pspace_aligned s \<and> valid_arch_state s) (copy_global_mappings x)"
-  unfolding copy_global_mappings_def
-  apply simp
-  apply(rule bind_ev_pre)
-     prefer 3
-     apply(rule_tac Q="\<lambda> s. pspace_aligned s \<and> valid_arch_state s \<and> is_subject aag x \<and> x \<noteq> arm_global_pd (arch_state s)" in hoare_weaken_pre)
-      apply(rule gets_sp)
-     apply(assumption)
-    apply(wp mapM_x_ev store_pde_reads_respects_g get_pde_revg)
-     apply(drule subsetD[OF copy_global_mappings_index_subset])
-     apply(clarsimp simp: pd_shifting' invs_aligned_pdD)
-    apply(wp get_pde_inv store_pde_aligned store_pde_valid_arch | simp | fastforce)+
-  apply(fastforce dest: reads_equiv_gD simp: globals_equiv_def)
-  done
+  "\<forall>s t. I s t \<and> A s t \<and> P s \<and> P t \<longrightarrow> (f s) x = (f t) x
+   \<Longrightarrow> equiv_valid I A A P (gets_apply f x)"
+  by (clarsimp simp: gets_apply_def get_def bind_def return_def equiv_valid_def2 equiv_valid_2_def)
 
 lemma do_machine_op_globals_equiv:
-   "(\<And> s sa. \<lbrakk>P sa; globals_equiv s sa\<rbrakk> \<Longrightarrow>
-         \<forall>x\<in>fst (f (machine_state sa)).
-            globals_equiv s (sa\<lparr>machine_state := snd x\<rparr>)) \<Longrightarrow>
-  \<lbrace> globals_equiv s and P \<rbrace>
-   do_machine_op f
-   \<lbrace> \<lambda>_. globals_equiv s \<rbrace>"
+   "(\<And>s sa. \<lbrakk> P sa; globals_equiv s sa \<rbrakk>
+              \<Longrightarrow> \<forall>x\<in>fst (f (machine_state sa)). globals_equiv s (sa\<lparr>machine_state := snd x\<rparr>))
+    \<Longrightarrow> \<lbrace>globals_equiv s and P\<rbrace>
+        do_machine_op f
+        \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding do_machine_op_def
   apply (wp | simp add: split_def)+
-  done
-
-lemma dmo_no_mem_globals_equiv:
-  "\<lbrakk>\<And>P. invariant f (\<lambda>ms. P (underlying_memory ms));
-    \<And>P. invariant f (\<lambda>ms. P (device_state ms));
-    \<And>P. invariant f (\<lambda>ms. P (exclusive_state ms))\<rbrakk> \<Longrightarrow>
-  invariant (do_machine_op f) (globals_equiv s)"
-  unfolding do_machine_op_def
-  apply (wp | simp add: split_def)+
-  apply atomize
-  apply (erule_tac x="(=) (underlying_memory (machine_state sa))" in allE)
-  apply (erule_tac x="(=) (device_state (machine_state sa))" in allE)
-  apply (erule_tac x="(=) (exclusive_state (machine_state sa))" in allE)
-  apply (fastforce simp: valid_def globals_equiv_def idle_equiv_def)
-  done
-
-lemma mol_globals_equiv:
-  "\<lbrace>\<lambda>ms. globals_equiv st (s\<lparr>machine_state := ms\<rparr>)\<rbrace> machine_op_lift mop \<lbrace>\<lambda>a b. globals_equiv st (s\<lparr>machine_state := b\<rparr>)\<rbrace>"
-  unfolding machine_op_lift_def
-  apply (simp add: machine_rest_lift_def split_def)
-  apply wp
-  apply (clarsimp simp: globals_equiv_def idle_equiv_def)
-  done
-
-lemma mol_exclusive_state:
-  "invariant (machine_op_lift mop) (\<lambda>ms. P (exclusive_state ms))"
-  apply (simp add: machine_op_lift_def machine_rest_lift_def)
-  apply (wp | simp add: split_def)+
-  done
-
-lemma dmo_mol_globals_equiv:
-  "invariant (do_machine_op (machine_op_lift f)) (globals_equiv s)"
-  apply(rule dmo_no_mem_globals_equiv)
-   apply(simp add: machine_op_lift_def machine_rest_lift_def)
-   apply(wp mol_exclusive_state | simp add: split_def)+
-   done
-
-lemma dmo_cleanCacheRange_PoU_globals_equiv:
-  "invariant (do_machine_op (cleanCacheRange_PoU x y z)) (globals_equiv s)"
-  unfolding cleanCacheRange_PoU_def
-  by(wp dmo_mol_globals_equiv dmo_cacheRangeOp_lift | simp add: cleanByVA_PoU_def)+
-
-lemma dmo_cleanCacheRange_reads_respects_g:
-  "reads_respects_g aag l \<top> (do_machine_op (cleanCacheRange_PoU x y z))"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_g])
-    apply(rule dmo_cleanCacheRange_PoU_reads_respects)
-   apply(rule doesnt_touch_globalsI[where P="\<top>", simplified, OF dmo_cleanCacheRange_PoU_globals_equiv])
-  by simp
-
-lemma storeWord_globals_equiv:
-  "\<lbrace>\<lambda>ms. globals_equiv st (s\<lparr>machine_state := ms\<rparr>)\<rbrace> storeWord p v \<lbrace>\<lambda>a b. globals_equiv st (s\<lparr>machine_state := b\<rparr>)\<rbrace>"
-  unfolding storeWord_def
-  apply (simp add: is_aligned_mask[symmetric])
-  apply wp
-  apply (clarsimp simp: globals_equiv_def idle_equiv_def)
   done
 
 lemma ptr_range_memE:
-  "\<lbrakk>x \<in> ptr_range ptr bits; \<lbrakk>ptr \<le> x; x \<le> ptr + 2 ^ bits - 1\<rbrakk> \<Longrightarrow> R\<rbrakk> \<Longrightarrow> R"
-  by(clarsimp simp: ptr_range_def)
+  "\<lbrakk> x \<in> ptr_range ptr bits; \<lbrakk> ptr \<le> x; x \<le> ptr + 2 ^ bits - 1 \<rbrakk> \<Longrightarrow> R \<rbrakk> \<Longrightarrow> R"
+  by (clarsimp simp: ptr_range_def)
 
-lemma is_aligned_2_upto_enum_step_mem:
-  fixes ptr :: "word32"
-  shows
-  "\<lbrakk>is_aligned ptr bits; 2 \<le> bits; bits < word_bits;
-    x \<in> set [ptr , ptr + word_size .e. ptr + 2 ^ bits - 1]\<rbrakk> \<Longrightarrow>
-   is_aligned x 2"
-  apply(clarsimp simp: upto_enum_step_shift_red[where us=2, simplified] word_size_def word_bits_def)
-  apply(erule aligned_add_aligned)
-    apply(rule is_alignedI)
-    apply(simp add: mult.commute)
-   apply(simp add: word_bits_conv)
+lemma is_aligned_word_size_bits_upto_enum_step_mem:
+  fixes ptr :: obj_ref
+  shows "\<lbrakk> is_aligned ptr bits; word_size_bits \<le> bits; bits < word_bits;
+           x \<in> set [ptr, ptr + word_size .e. ptr + 2 ^ bits - 1] \<rbrakk>
+           \<Longrightarrow> is_aligned x word_size_bits"
+  apply (clarsimp simp: word_size_size_bits_word[symmetric])
+  apply (subst (asm) upto_enum_step_shift_red; (fastforce simp: word_bits_def)?)
+  apply clarsimp
+  apply (erule aligned_add_aligned)
+   apply (rule is_alignedI)
+   apply (simp add: mult.commute)
+  apply (simp add: word_bits_conv)
   done
 
 (* TODO: cleanup this beautiful proof *)
 lemma ptr_range_subset:
-  fixes ptr :: "word32"
-  shows
-  "\<lbrakk>is_aligned ptr bits; 2 \<le> bits; bits < word_bits;
-    x \<in> set [ptr , ptr + word_size .e. ptr + 2 ^ bits - 1]\<rbrakk> \<Longrightarrow>
-   ptr_range x 2 \<subseteq> ptr_range ptr bits"
-  apply(frule is_aligned_2_upto_enum_step_mem, assumption+)
-  apply(rule subsetI)
-  apply(clarsimp simp: upto_enum_step_shift_red[where us=2, simplified] word_size_def word_bits_def)
-  apply(subst ptr_range_def)
-  apply(clarsimp)
-  apply(erule ptr_range_memE)
-  apply(rule conjI)
-   apply(erule order_trans[rotated])
-   apply(erule is_aligned_no_wrap')
-   apply(rule word_less_power_trans2[where k=2, simplified])
-     apply(erule of_nat_power)
-     apply(simp add: word_bits_conv)
-    apply assumption
-   apply simp
-  apply(erule order_trans)
-  apply(subgoal_tac "ptr + of_nat xaa * 4 + 2\<^sup>2 - 1 = ptr + (3 + of_nat xaa * 4)")
-   apply(subgoal_tac "ptr + 2 ^ bits - 1 = ptr + (2 ^ bits - 1)")
-    apply(erule ssubst)+
-    apply(rule word_plus_mono_right)
-     apply(drule is_aligned_addD1)
-      apply(erule (1) is_aligned_weaken)
+  fixes ptr :: obj_ref
+  shows "\<lbrakk> is_aligned ptr bits; word_size_bits \<le> bits; bits < word_bits;
+           x \<in> set [ptr , ptr + word_size .e. ptr + 2 ^ bits - 1] \<rbrakk>
+           \<Longrightarrow> ptr_range x word_size_bits \<subseteq> ptr_range ptr bits"
+  apply (frule is_aligned_word_size_bits_upto_enum_step_mem, assumption+)
+  apply (rule subsetI)
+  apply (clarsimp simp: word_size_size_bits_word[symmetric])
+  apply (subst (asm) upto_enum_step_shift_red; (fastforce simp: word_bits_def)?)
+  apply (subst ptr_range_def)
+  apply (clarsimp)
+  apply (erule ptr_range_memE)
+  apply (rule conjI)
+   apply (erule order_trans[rotated])
+   apply (erule is_aligned_no_wrap')
+   apply (rule word_less_power_trans2[where k=word_size_bits, simplified];
+         fastforce elim: of_nat_power simp: word_bits_conv word_bits_def)
+  apply (erule order_trans)
+  apply (clarsimp simp: word_size_size_bits_word)
+  apply (subgoal_tac "ptr + of_nat xaa * word_size + word_size - 1 =
+                      ptr + ((2 ^ word_size_bits - 1) + of_nat xaa * word_size)")
+   apply (subgoal_tac "ptr + 2 ^ bits - 1 = ptr + (2 ^ bits - 1)")
+    apply (erule ssubst)+
+    apply (rule word_plus_mono_right)
+     apply (drule is_aligned_addD1)
+      apply (erule (1) is_aligned_weaken)
      prefer 2
-     apply(erule is_aligned_no_wrap')
+     apply (erule is_aligned_no_wrap')
      apply simp
-    apply(simp_all)
-  apply(drule (1) word_less_power_trans_ofnat[where 'a=machine_word_len], simp)
-  apply simp
-  apply(subst add.commute)
-  apply(erule is_aligned_add_less_t2n)
-  apply(simp_all)
-  done
-
-
-
-lemma dmo_clearMemory_globals_equiv:
-  "\<lbrace> globals_equiv s \<rbrace>
-   do_machine_op (clearMemory ptr (2 ^ bits))
-   \<lbrace> \<lambda>_. globals_equiv s \<rbrace>"
-  apply(rule hoare_pre)
-  apply(simp add: do_machine_op_def clearMemory_def split_def cleanCacheRange_PoU_def)
-  apply(wp)
-  apply clarsimp
-  apply(erule use_valid)
-   apply(wpsimp wp: mapM_x_wp' storeWord_globals_equiv mol_globals_equiv
-                simp: cleanCacheRange_RAM_def cleanL2Range_def dsb_def cleanCacheRange_PoC_def
-                     cleanByVA_def)
-  apply simp
-  done
-
-lemma dmo_clearMemory_reads_respects_g:
-  "reads_respects_g aag l \<top> (do_machine_op (clearMemory ptr (2 ^bits)))"
-  apply(rule equiv_valid_guard_imp)
-   apply(rule reads_respects_g)
-    apply(rule dmo_clearMemory_reads_respects)
-   apply(rule doesnt_touch_globalsI[where P = \<top>, simplified, OF dmo_clearMemory_globals_equiv])
-  apply clarsimp
-  done
-
-lemma dmo_freeMemory_globals_equiv:
-  "\<lbrace> globals_equiv s\<rbrace>
-   do_machine_op (freeMemory ptr bits)
-   \<lbrace> \<lambda>_. globals_equiv s \<rbrace>"
-  apply(rule hoare_pre)
-  apply(simp add: do_machine_op_def freeMemory_def split_def)
-  apply(wp)
-  apply clarsimp
-  apply(erule use_valid)
-  apply(wp mapM_x_wp' storeWord_globals_equiv mol_globals_equiv)
-  apply(simp_all)
-  done
-
-lemma dmo_freeMemory_reads_respects_g:
-  "reads_respects_g aag l (\<lambda> s. is_aligned ptr bits \<and> 2 \<le> bits \<and> bits < word_bits)
-  (do_machine_op (freeMemory ptr bits))"
-  apply(rule equiv_valid_guard_imp)
-   apply(rule reads_respects_g)
-    apply(rule dmo_freeMemory_reads_respects)
-   apply(rule doesnt_touch_globalsI[where P = \<top>, simplified, OF dmo_freeMemory_globals_equiv])
-  apply clarsimp
-  done
+    apply (simp_all add: word_size_size_bits_word)
+  apply (drule (1) word_less_power_trans_ofnat[where 'a=machine_word_len], simp add: word_bits_def)
+  apply (subst add.commute)
+  apply (erule is_aligned_add_less_t2n)
+    apply (simp_all add: word_size_size_bits_word)
+  using zero_less_word_size gt0_iff_gem1 by blast
 
 lemma do_machine_op_mapM_x:
-  assumes ef:
-  "\<And> a. empty_fail (f a)"
-  shows
-    "do_machine_op (mapM_x f xs) = mapM_x (\<lambda> x. do_machine_op (f x)) xs"
-  apply(induct xs)
-   apply(simp add: mapM_x_Nil)
-  apply(clarsimp simp: mapM_x_Cons do_machine_op_bind[OF ef empty_fail_mapM_x[OF ef]])
-  done
-
-text \<open>
-
-        | simp add: unless_def when_def
-        | intro conjI impI)+
-     (create_word_objects ptr numObjects bits dev)"
-\<close>
-
-lemma init_arch_objects_reads_respects_g:
-  "reads_respects_g aag l
-         ((\<lambda> s. arm_global_pd (arch_state s) \<notin> set refs \<and>
-                 pspace_aligned s \<and> valid_arch_state s) and
-          K (\<forall>x\<in>set refs. is_subject aag x) and
-          K (\<forall>x\<in>set refs. new_type = ArchObject PageDirectoryObj
-                            \<longrightarrow> is_aligned x pd_bits) and
-          K ((0::word32) < of_nat num_objects))
-        (init_arch_objects new_type ptr num_objects obj_sz refs)"
-  apply (unfold init_arch_objects_def fun_app_def)
-  apply (rule gen_asm_ev)+
-  apply (subst do_machine_op_mapM_x[OF empty_fail_cleanCacheRange_PoU])+
-  apply (rule equiv_valid_guard_imp)
-  apply (wp dmo_cleanCacheRange_reads_respects_g mapM_x_ev''
-         equiv_valid_guard_imp[OF copy_global_mappings_reads_respects_g]
-         copy_global_mappings_valid_arch_state copy_global_mappings_pspace_aligned
-         hoare_vcg_ball_lift | wpc | simp)+
-  apply clarsimp
-  done
-
-lemma copy_global_mappings_globals_equiv:
-  "\<lbrace> globals_equiv s and (\<lambda> s. x \<noteq> arm_global_pd (arch_state s) \<and> is_aligned x pd_bits)\<rbrace>
-   copy_global_mappings x
-   \<lbrace> \<lambda>_. globals_equiv s \<rbrace>"
-  unfolding copy_global_mappings_def including no_pre
-  apply simp
-  apply wp
-   apply(rule_tac Q="\<lambda>_. globals_equiv s and (\<lambda> s. x \<noteq> arm_global_pd (arch_state s) \<and>  is_aligned x pd_bits)" in hoare_strengthen_post)
-    apply(wp mapM_x_wp[OF _ subset_refl] store_pde_globals_equiv)
-    apply(fastforce dest: subsetD[OF copy_global_mappings_index_subset] simp: pd_shifting')
-   apply(simp_all)
-  done
-
-lemma init_arch_objects_globals_equiv:
-  "\<lbrace> globals_equiv s and
-     (\<lambda> s. arm_global_pd (arch_state s) \<notin> set refs \<and>
-           pspace_aligned s \<and> valid_arch_state s) and
-     K (\<forall>x\<in>set refs. is_aligned x (obj_bits_api new_type obj_sz))\<rbrace>
-   (init_arch_objects new_type ptr num_objects obj_sz refs)
-   \<lbrace> \<lambda>_. globals_equiv s \<rbrace>"
-  unfolding init_arch_objects_def fun_app_def
-  apply(rule hoare_gen_asm)+
-  apply(subst do_machine_op_mapM_x[OF empty_fail_cleanCacheRange_PoU])+
-  apply(rule hoare_pre)
-  apply(wpc | wp mapM_x_wp[OF dmo_cleanCacheRange_PoU_globals_equiv subset_refl])+
-  apply(rule_tac Q="\<lambda>_. globals_equiv s and (\<lambda> s. arm_global_pd (arch_state s) \<notin> set refs)" in hoare_strengthen_post)
-      apply(wp mapM_x_wp[OF _ subset_refl] copy_global_mappings_globals_equiv
-               dmo_cleanCacheRange_PoU_globals_equiv
-            | simp add: obj_bits_api_def default_arch_object_def
-                        pd_bits_def pageBits_def | blast)+
+  assumes ef: "\<And>a. empty_fail (f a)"
+  shows "do_machine_op (mapM_x f xs) = mapM_x (\<lambda> x. do_machine_op (f x)) xs"
+  apply (induct xs)
+   apply (simp add: mapM_x_Nil)
+  apply (clarsimp simp: mapM_x_Cons do_machine_op_bind[OF ef empty_fail_mapM_x[OF ef]])
   done
 
 lemma create_cap_reads_respects_g:
   "reads_respects_g aag l (K (is_subject aag (fst (fst slot))) and valid_global_objs)
-  (create_cap type bits untyped dev slot)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_g])
-    apply(rule create_cap_reads_respects)
-   apply(rule doesnt_touch_globalsI[OF create_cap_globals_equiv])
+                    (create_cap type bits untyped dev slot)"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule create_cap_reads_respects)
+   apply (rule doesnt_touch_globalsI[OF create_cap_globals_equiv])
   by simp
-
-lemma default_object_not_asid_pool:
-  "\<lbrakk>type \<noteq> ArchObject ASIDPoolObj; type \<noteq> Untyped\<rbrakk> \<Longrightarrow>
-        \<not> default_object type o_bits dev = ArchObj (ASIDPool asid_pool)"
-  apply(clarsimp simp: default_object_def split: apiobject_type.splits
-    simp: default_arch_object_def split: aobject_type.splits)
-  done
 
 lemma retype_region_ext_def2:
   "retype_region_ext a b =
-   modify (\<lambda>exst. ekheap_update (\<lambda>ekh x. if x \<in> set a then default_ext b (cur_domain exst) else ekh x) exst)"
-  apply (simp add: retype_region_ext_def foldr_upd_app_if' gets_def bind_def return_def
-                   modify_def get_def put_def fun_eq_iff)
-  done
+   modify (\<lambda>s. ekheap_update (\<lambda>ekh x. if x \<in> set a then default_ext b (cur_domain s) else ekh x) s)"
+  by (simp add: retype_region_ext_def foldr_upd_app_if' gets_def bind_def
+                return_def modify_def get_def put_def fun_eq_iff)
 
 lemma retype_region_reads_respects:
   "reads_respects aag l \<top> (retype_region ptr num_objects o_bits type dev)"
-  apply(simp only: retype_region_def retype_addrs_def
-                   foldr_upd_app_if fun_app_def K_bind_def when_def
-                   retype_region_ext_extended.dxo_eq
-                   )
+  apply (simp only: retype_region_def retype_addrs_def foldr_upd_app_if fun_app_def
+                    K_bind_def when_def retype_region_ext_extended.dxo_eq)
   apply (simp only: retype_region_ext_def2)
-  apply(simp split del: if_split add: equiv_valid_def2)
-  apply(rule_tac W="\<top>\<top>" and Q="\<top>\<top>" in equiv_valid_rv_bind)
-    apply(rule equiv_valid_rv_guard_imp[OF if_evrv])
+  apply (simp split del: if_split add: equiv_valid_def2)
+  apply (rule_tac W="\<top>\<top>" and Q="\<top>\<top>" in equiv_valid_rv_bind)
+    apply (rule equiv_valid_rv_guard_imp[OF if_evrv])
       apply (rule equiv_valid_rv_bind[OF gets_kheap_revrv])
        apply simp
-       apply (rule_tac Q="\<lambda>_ s. rv = kheap s" and Q'="\<lambda>_ s. rv' = kheap s" and R'="(=)" in equiv_valid_2_bind_pre)
+       apply (rule_tac Q="\<lambda>_ s. rv = kheap s" and Q'="\<lambda>_ s. rv' = kheap s" and R'="(=)"
+                    in equiv_valid_2_bind_pre)
             apply (rule modify_ev2)
-            apply(fastforce elim: reads_equiv_identical_kheap_updates affects_equiv_identical_kheap_updates simp: identical_kheap_updates_def)
+            apply (fastforce elim: reads_equiv_identical_kheap_updates
+                                   affects_equiv_identical_kheap_updates
+                             simp: identical_kheap_updates_def)
            apply (rule_tac P=\<top> and P'=\<top> in modify_ev2)
-           apply (fastforce intro: reads_equiv_identical_ekheap_updates affects_equiv_identical_ekheap_updates simp: identical_updates_def default_ext_def reads_equiv_def)
+           apply (fastforce intro: reads_equiv_identical_ekheap_updates
+                                   affects_equiv_identical_ekheap_updates
+                             simp: identical_updates_def default_ext_def reads_equiv_def)
           apply (wp | simp)+
-     apply(rule return_ev2 | simp | rule impI, rule TrueI)+
-  apply(intro impI, wp)
+     apply (rule return_ev2 | simp | rule impI, rule TrueI)+
+  apply (intro impI, wp)
   done
 
 lemma subset_thing:
-  "\<lbrakk>a \<le> b; a \<le> a\<rbrakk> \<Longrightarrow> {a} \<subseteq> {a..b}"
-  apply (auto)
-  done
+  "\<lbrakk> a \<le> b; a \<le> a \<rbrakk> \<Longrightarrow> {a} \<subseteq> {a..b}"
+  by auto
 
-lemma updates_not_idle: "idle_equiv st s \<Longrightarrow> \<forall>a \<in> S. a \<noteq> idle_thread s  \<Longrightarrow>
-        idle_equiv st
-           (s\<lparr>kheap :=
-                 \<lambda>a. if a \<in> S
-                     then y else kheap s a\<rparr>)"
-  apply (clarsimp simp add: idle_equiv_def tcb_at_def2)
-  apply blast
-  done
-
-(* FIXME: cleanup this proof *)
-lemma retype_region_globals_equiv:
-  notes blah[simp del] = atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
-          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
-  shows
-  "\<lbrace>globals_equiv s and
-    (\<lambda>s. \<exists>idx. cte_wp_at (\<lambda>c. c = UntypedCap dev (ptr && ~~ mask sz) sz idx)
-               slot s \<and>
-              (idx \<le> unat (ptr && mask sz) \<or>
-               pspace_no_overlap_range_cover ptr sz s)) and
-    invs and
-    K (range_cover ptr sz (obj_bits_api type o_bits) num_objects) and
-    K (0 < num_objects)\<rbrace>
-  retype_region ptr num_objects o_bits type dev
-  \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  apply(simp only: retype_region_def foldr_upd_app_if fun_app_def K_bind_def)
-  apply (wp dxo_wp_weak |simp)+
-      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-     apply (wp | simp)+
-  apply clarsimp
-  apply (simp only: globals_equiv_def)
-  apply (clarsimp split del: if_split)
-  apply (subgoal_tac "pspace_no_overlap_range_cover ptr sz sa")
-   apply (rule conjI)
-    apply(clarsimp simp: pspace_no_overlap_def)
-    apply(drule_tac x="arm_global_pd (arch_state sa)" in spec)
-    apply(clarsimp simp: invs_def valid_state_def valid_global_objs_def valid_vso_at_def obj_at_def ptr_add_def)
-    apply(frule_tac p=x in range_cover_subset)
-      apply(simp add: blah)
-     apply simp
-    apply(frule range_cover_subset')
-     apply simp
-    apply(clarsimp simp: p_assoc_help)
-    apply(drule disjoint_subset_neg1[OF _ subset_thing], rule is_aligned_no_wrap')
-        apply(clarsimp simp: valid_pspace_def pspace_aligned_def)
-        apply(drule_tac x="arm_global_pd (arch_state sa)" and A="dom (kheap sa)"  in bspec)
-         apply (simp add: domI)
-        apply simp
-       apply(rule word_power_less_1)
-       apply(case_tac ao, simp_all add: arch_kobj_size_def word_bits_def)
-      apply(simp add: pageBits_def)
-     apply(simp add: pageBitsForSize_def split: vmpage_size.splits)
-    apply(drule (1) subset_trans)
-    apply(erule_tac P="a \<in> b" for a b in notE)
-    apply(erule_tac A="{ptr + c..d}" for c d in subsetD)
-    apply(simp add: blah)
-    apply(rule is_aligned_no_wrap')
-     apply(rule is_aligned_add[OF _ is_aligned_mult_triv2])
-     apply(simp add: range_cover_def)
-    apply(rule word_power_less_1)
-    apply(simp add: range_cover_def)
-   apply (erule updates_not_idle)
-   apply(clarsimp simp: pspace_no_overlap_def)
-   apply(drule_tac x="idle_thread sa" in spec)
-   apply(clarsimp simp: invs_def valid_state_def valid_global_objs_def valid_ao_at_def obj_at_def ptr_add_def valid_idle_def pred_tcb_at_def)
-   apply(frule_tac p=a in range_cover_subset)
-     apply(simp add: blah)
-    apply simp
-   apply(frule range_cover_subset')
-    apply simp
-   apply(clarsimp simp: p_assoc_help)
-   apply(drule disjoint_subset_neg1[OF _ subset_thing], rule is_aligned_no_wrap')
-       apply(clarsimp simp: valid_pspace_def pspace_aligned_def)
-       apply(drule_tac x="idle_thread sa" and A="dom (kheap sa)"  in bspec)
-        apply (simp add: domI)
-       apply simp
-      apply uint_arith
-     apply simp+
-   apply(drule (1) subset_trans)
-   apply(erule_tac P="a \<in> b" for a b in notE)
-   apply(erule_tac A="{idle_thread_ptr..d}" for d in subsetD)
-   apply(simp add: blah)
-   apply (erule_tac t=idle_thread_ptr in subst)
-   apply(rule is_aligned_no_wrap')
-    apply(rule is_aligned_add[OF _ is_aligned_mult_triv2])
-    apply (simp add: range_cover_def)+
-  apply(auto intro!: cte_wp_at_pspace_no_overlapI simp: range_cover_def word_bits_def)[1]
-  done
-
-
-lemma retype_region_reads_respects_g:
-  "reads_respects_g aag l
-        ((\<lambda>s. \<exists>idx. cte_wp_at (\<lambda>c. c = UntypedCap dev (ptr && ~~ mask sz) sz idx)
-                    slot s \<and>
-                    (idx \<le> unat (ptr && mask sz) \<or>
-                     pspace_no_overlap_range_cover ptr sz s)) and
-         invs and
-         K (range_cover ptr sz (obj_bits_api type o_bits) num_objects) and
-         K (0 < num_objects))
-   (retype_region ptr num_objects o_bits type dev)"
-  apply(rule equiv_valid_guard_imp[OF reads_respects_g[OF retype_region_reads_respects]])
-   apply(rule doesnt_touch_globalsI)
-   apply(rule hoare_weaken_pre[OF retype_region_globals_equiv])
-   apply simp
-  apply (auto)
-  done
+lemma updates_not_idle:
+  "\<lbrakk> idle_equiv st s; \<forall>a \<in> S. a \<noteq> idle_thread s \<rbrakk>
+     \<Longrightarrow> idle_equiv st (s\<lparr>kheap := \<lambda>a. if a \<in> S then y else kheap s a\<rparr>)"
+  by (fastforce simp: idle_equiv_def tcb_at_def2)
 
 lemma post_retype_invs_valid_arch_stateI:
   "post_retype_invs ty rv s \<Longrightarrow> valid_arch_state s"
-  apply(clarsimp simp: post_retype_invs_def invs_def valid_state_def split: if_split_asm)
-  done
+  by (clarsimp simp: post_retype_invs_def invs_def valid_state_def split: if_split_asm)
 
 lemma post_retype_invs_pspace_alignedI:
   "post_retype_invs ty rv s \<Longrightarrow> pspace_aligned s"
-  apply(clarsimp simp: post_retype_invs_def invs_def valid_state_def split: if_split_asm)
-  done
+  by (clarsimp simp: post_retype_invs_def invs_def valid_state_def split: if_split_asm)
 
-lemma detype_def2: "detype S (s :: det_state) = s
-\<lparr>kheap := \<lambda>x. if x \<in> S then None else kheap s x,
- ekheap := \<lambda>x. if x \<in> S then None else ekheap s x\<rparr>"
-  apply (simp add: detype_def detype_ext_def)
-  done
-
-lemma states_equiv_for_detype:
-  "states_equiv_for P Q R S s s' \<Longrightarrow> states_equiv_for P Q R S (detype N s) (detype N s')"
-  apply(simp add: detype_def detype_ext_def)
-  apply (simp add: states_equiv_for_def equiv_for_def equiv_asids_def
-         equiv_asid_def obj_at_def)
-  done
+lemma detype_def2:
+   "detype S (s :: det_state) = s\<lparr>kheap := \<lambda>x. if x \<in> S then None else kheap s x,
+                                  ekheap := \<lambda>x. if x \<in> S then None else ekheap s x\<rparr>"
+  by (simp add: detype_def detype_ext_def)
 
 lemma cur_thread_detype:
   "cur_thread (detype S s) = cur_thread s"
-  by(auto simp: detype_def)
+  by (auto simp: detype_def)
 
 lemma cur_domain_detype:
   "cur_domain (detype S s) = cur_domain s"
@@ -790,6 +378,28 @@ lemma machine_state_detype:
   "machine_state (detype S s) = machine_state s"
   by (auto simp: detype_def detype_ext_def)
 
+
+context Retype_IF_1 begin
+
+lemma retype_region_reads_respects_g:
+  "reads_respects_g aag l
+     ((\<lambda>s. \<exists>idx. cte_wp_at (\<lambda>c. c = UntypedCap dev (ptr && ~~ mask sz) sz idx) slot s \<and>
+                 (idx \<le> unat (ptr && mask sz) \<or> pspace_no_overlap_range_cover ptr sz s)) and
+      invs and K (range_cover ptr sz (obj_bits_api type o_bits) num_objects \<and> 0 < num_objects))
+     (retype_region ptr num_objects o_bits type dev)"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g[OF retype_region_reads_respects]])
+   apply (rule doesnt_touch_globalsI)
+   apply (rule hoare_weaken_pre[OF retype_region_globals_equiv])
+   apply simp
+  apply auto
+  done
+
+lemma states_equiv_for_detype:
+  "states_equiv_for P Q R S s s' \<Longrightarrow> states_equiv_for P Q R S (detype N s) (detype N s')"
+  apply (simp add: states_equiv_for_def equiv_for_def equiv_asids_def obj_at_def equiv_asid_detype)
+  apply (simp add: detype_def detype_ext_def)
+  done
+
 lemma detype_reads_respects:
   "reads_respects aag l \<top> (modify (detype S))"
   apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def in_monad reads_equiv_def2 affects_equiv_def2)
@@ -797,43 +407,18 @@ lemma detype_reads_respects:
   apply (fastforce intro: states_equiv_for_detype)
   done
 
-lemma detype_globals_equiv:
-  "\<lbrace> globals_equiv st and ((\<lambda> s. arm_global_pd (arch_state s) \<notin> S) and (\<lambda> s. idle_thread s \<notin> S)) \<rbrace>
-   modify (detype S)
-   \<lbrace> \<lambda>_. globals_equiv st \<rbrace>"
-  apply(wp)
-  apply(clarsimp simp: globals_equiv_def detype_def idle_equiv_def tcb_at_def2)
-  done
-lemma detype_reads_respects_g:
-  "reads_respects_g aag l ((\<lambda> s. arm_global_pd (arch_state s) \<notin> S) and (\<lambda>s. idle_thread s \<notin> S)) (modify (detype S))"
-  apply (rule equiv_valid_guard_imp)
-   apply (rule reads_respects_g)
-    apply (rule detype_reads_respects)
-   apply (rule doesnt_touch_globalsI[OF detype_globals_equiv])
-  apply simp
-  done
+crunch irq_masks[wp]: delete_objects "\<lambda>s. P (irq_masks (machine_state s))"
+  (ignore: do_machine_op wp: dmo_wp no_irq_freeMemory no_irq simp: detype_def)
 
-lemma a_type_small_pageD:
-  "a_type ko = AArch (AUserData ARMSmallPage) \<Longrightarrow>
-  ko = ArchObj (DataPage False ARMSmallPage)"
-  apply clarsimp
-  done
-
-lemma obj_range_small_page_as_ptr_range:
-  "obj_range ptr (ArchObj (DataPage dev ARMSmallPage)) =
-   ptr_range ptr 12"
-  apply(simp add: obj_range_def)
-  apply(simp add: ptr_range_def)
-  done
+end
 
 
 lemma untyped_caps_do_not_overlap_global_refs:
-  "\<lbrakk>cte_wp_at ((=) (UntypedCap dev word sz idx)) slot s;
-    valid_global_refs s\<rbrakk> \<Longrightarrow>
-  ptr_range word sz \<inter> global_refs s = {}"
-   apply(simp add: cte_wp_at_caps_of_state)
-   apply(drule (1) valid_global_refsD2)
-   apply(fastforce simp: cap_range_def ptr_range_def)
+  "\<lbrakk> cte_wp_at ((=) (UntypedCap dev word sz idx)) slot s; valid_global_refs s \<rbrakk>
+     \<Longrightarrow> ptr_range word sz \<inter> global_refs s = {}"
+  apply (simp add: cte_wp_at_caps_of_state)
+  apply (drule (1) valid_global_refsD2)
+  apply (fastforce simp: cap_range_def ptr_range_def)
   done
 
 lemma singleton_set_size:
@@ -842,103 +427,44 @@ lemma singleton_set_size:
 
 lemma cap_range_of_valid_capD:
   "valid_cap cap s \<Longrightarrow> (cap_range cap = {}) \<or> (\<exists>ptr sz. (cap_range cap = ptr_range ptr sz))"
-   apply (rule disj_subst)
-   apply (case_tac cap,auto simp: valid_cap_def valid_untyped_def cap_aligned_def cap_range_def ptr_range_def)[1]
-   apply (intro exI | rule singleton_set_size[symmetric])+
-   done
-
-(* FIX ME: Many ptr_range proofs are not nice, should use the following lemma instead *)
-lemma ptr_range_disjoint_strong:
-  "\<lbrakk>ptr'  \<notin> ptr_range (ptr :: ('a :: len word)) sz; is_aligned ptr sz; is_aligned ptr' sz';
-       sz < len_of TYPE('a); sz'\<le> sz \<rbrakk>
-       \<Longrightarrow> ptr_range ptr sz \<inter> ptr_range ptr' sz' = {}"
-  apply (unfold ptr_range_def)
-  apply (frule(1) aligned_ranges_subset_or_disjoint[where p'=ptr'])
-  apply (elim disjE)
-    apply simp
-   apply clarsimp
-   apply (drule order_trans[where x = ptr and y = "ptr + a - b" for a b])
-    apply simp
-   apply (drule neg_mask_mono_le[where n = sz'])
-   apply (subst (asm) is_aligned_neg_mask_eq)
-    apply (erule is_aligned_weaken)
-     apply simp
-    apply (subst(asm) x_t2n_sub_1_neg_mask)
-      apply simp
-     apply simp
-   apply (subst (asm) is_aligned_neg_mask_eq)
-    apply (erule is_aligned_weaken)
-     apply simp
-   apply simp
-  apply (drule base_member_set[where sz = sz'],simp)
-   apply fastforce
-  done
-
-lemma obj_range_page_as_ptr_range_pageBitsForSize:
-  "obj_range ptr (ArchObj (DataPage dev vmpage_size)) =
-   ptr_range ptr (pageBitsForSize vmpage_size)"
-  apply(simp add: obj_range_def)
-  apply(simp add: ptr_range_def)
-  done
-
-
-lemma pspace_distinct_def':
-  "pspace_distinct \<equiv> \<lambda>s. \<forall>x y ko ko'.
-             kheap s x = Some ko \<and> kheap s y = Some ko' \<and> x \<noteq> y \<longrightarrow>
-             obj_range x ko \<inter> obj_range y ko' = {}"
-  by(auto simp: pspace_distinct_def obj_range_def field_simps)
-
-lemma delete_objects_reads_respects_g:
- "reads_equiv_valid_g_inv (affects_equiv aag l) aag
-    (\<lambda>s. arm_global_pd (arch_state s) \<notin> ptr_range p b \<and>
-         idle_thread s \<notin> ptr_range p b \<and>
-         is_aligned p b \<and> 2 \<le> b \<and> b < word_bits)
-    (delete_objects p b)"
-  apply (simp add: delete_objects_def2)
-  apply (rule equiv_valid_guard_imp)
-   apply (wp dmo_freeMemory_reads_respects_g)
-    apply (rule detype_reads_respects_g)
-   apply wp
-  apply (unfold ptr_range_def)
-  apply simp
-  done
+  apply (rule disj_subst)
+  apply (cases cap)
+  by (clarsimp simp: valid_cap_def valid_untyped_def cap_aligned_def cap_range_def ptr_range_def
+      | intro exI | rule singleton_set_size[symmetric] | fastforce)+
 
 lemma set_cap_reads_respects_g:
   "reads_respects_g aag l (valid_global_objs and K (is_subject aag (fst slot))) (set_cap cap slot)"
-  apply(rule equiv_valid_guard_imp)
-   apply(rule reads_respects_g[OF set_cap_reads_respects])
-   apply(rule doesnt_touch_globalsI[OF set_cap_globals_equiv])
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_g[OF set_cap_reads_respects])
+   apply (rule doesnt_touch_globalsI[OF set_cap_globals_equiv])
   by simp
 
 (*FIXME move*)
 lemma when_ev:
-  "\<lbrakk>C \<Longrightarrow> equiv_valid I A A P handle\<rbrakk> \<Longrightarrow>
-   equiv_valid I A A (\<lambda>s. C \<longrightarrow> P s) (when C handle)"
-  apply (wp | auto simp: when_def)+
-  done
-
+  "(C \<Longrightarrow> equiv_valid I A A P handle) \<Longrightarrow> equiv_valid I A A (\<lambda>s. C \<longrightarrow> P s) (when C handle)"
+  by (wp | auto simp: when_def)+
 
 lemma delete_objects_caps_no_overlap:
-  "\<lbrace> invs and ct_active and (\<lambda> s. \<exists> slot idx.
-    cte_wp_at ((=) (UntypedCap dev ptr sz idx)) slot s \<and> descendants_range_in {ptr..ptr + 2 ^ sz - 1} slot s) \<rbrace>
-    delete_objects ptr sz
-  \<lbrace>\<lambda>_ s :: det_ext state. caps_no_overlap ptr sz s\<rbrace>"
-  apply(clarsimp simp: valid_def)
-  apply(rule descendants_range_caps_no_overlapI)
-    apply(erule use_valid | wp | simp add: descendants_range_def2 | blast)+
-   apply(frule untyped_cap_aligned,
+  "\<lbrace>invs and ct_active and (\<lambda>s. \<exists>slot idx. cte_wp_at ((=) (UntypedCap dev ptr sz idx)) slot s \<and>
+                                           descendants_range_in {ptr..ptr + 2 ^ sz - 1} slot s)\<rbrace>
+   delete_objects ptr sz
+   \<lbrace>\<lambda>_ s :: det_ext state. caps_no_overlap ptr sz s\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (rule descendants_range_caps_no_overlapI)
+    apply (erule use_valid | wp | simp add: descendants_range_def2 | blast)+
+   apply (frule untyped_cap_aligned,
          (simp add: invs_valid_objs)+)
-   apply(rule conjI, assumption)
-   apply(drule (2) untyped_slots_not_in_untyped_range, simp+, rule subset_refl)
-    apply simp
-  apply(erule use_valid | wp delete_objects_descendants_range_in | simp | blast)+
+   apply (rule conjI, assumption)
+   apply (drule (2) untyped_slots_not_in_untyped_range, simp+, rule subset_refl)
+   apply simp
+  apply (erule use_valid | wp delete_objects_descendants_range_in | simp | blast)+
   done
 
 lemma get_cap_reads_respects_g:
   "reads_respects_g aag l (K (is_subject aag (fst slot))) (get_cap slot)"
-  apply(rule equiv_valid_guard_imp)
-   apply(rule reads_respects_g[OF get_cap_rev])
-   apply(rule doesnt_touch_globalsI)
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_g[OF get_cap_rev])
+   apply (rule doesnt_touch_globalsI)
    apply wp
    apply clarsimp
   apply simp
@@ -946,8 +472,7 @@ lemma get_cap_reads_respects_g:
 
 lemma irq_state_independent_globals_equiv[simp,intro!]:
   "irq_state_independent_A (globals_equiv st)"
-  by (clarsimp simp: irq_state_independent_A_def globals_equiv_def
-                     idle_equiv_def)
+  by (clarsimp simp: irq_state_independent_A_def globals_equiv_def idle_equiv_def)
 
 lemma irq_state_independent_A_only_timer_irq_inv[simp]:
   "irq_state_independent_A (only_timer_irq_inv irq st)"
@@ -967,116 +492,26 @@ lemma only_timer_irq_inv_work_units_completed[simp]:
                    irq_is_recurring_def is_irq_at_def)
   done
 
-lemma no_irq_freeMemory:
-  "no_irq (freeMemory ptr sz)"
-  apply (simp add: freeMemory_def)
-  apply (wp no_irq_mapM_x no_irq_storeWord)
-  done
-
-crunch irq_masks[wp]: delete_objects "\<lambda>s. P (irq_masks (machine_state s))"
-  (ignore: do_machine_op wp: dmo_wp no_irq_freeMemory no_irq
-     simp: detype_def)
-
 lemma delete_objects_pspace_no_overlap_again:
-  "\<lbrace> pspace_aligned and valid_objs and
-     (\<lambda> s. \<exists>slot. cte_wp_at (\<lambda>cp. is_untyped_cap cp \<and> obj_ref_of cp = ptr \<and> bits_of cp = sz) slot s)
-     and K (S \<subseteq> {ptr .. ptr + 2 ^ sz - 1})\<rbrace>
-    delete_objects ptr sz
-   \<lbrace>\<lambda>rv. pspace_no_overlap S\<rbrace>"
+  "\<lbrace>pspace_aligned and valid_objs and (\<lambda>s. \<exists>slot. cte_wp_at (\<lambda>cp. is_untyped_cap cp \<and>
+                                                                  obj_ref_of cp = ptr \<and>
+                                                                  bits_of cp = sz) slot s)
+                                  and K (S \<subseteq> {ptr .. ptr + 2 ^ sz - 1})\<rbrace>
+   delete_objects ptr sz
+   \<lbrace>\<lambda>_. pspace_no_overlap S\<rbrace>"
   unfolding delete_objects_def do_machine_op_def
-  apply(wp | simp add: split_def detype_machine_state_update_comm)+
-  apply(clarsimp simp: cte_wp_at_caps_of_state is_cap_simps bits_of_def)
-  apply(drule caps_of_state_cteD)
-  apply(frule cte_wp_at_valid_objs_valid_cap, clarsimp+)
-  apply(erule pspace_no_overlap_subset[rotated])
-  apply(rule pspace_no_overlap_subset, rule pspace_no_overlap_detype, simp+)
-  apply(simp add: valid_cap_simps cap_aligned_def field_simps)
+  apply (wp | simp add: split_def detype_machine_state_update_comm)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps bits_of_def)
+  apply (drule caps_of_state_cteD)
+  apply (frule cte_wp_at_valid_objs_valid_cap, clarsimp+)
+  apply (erule pspace_no_overlap_subset[rotated])
+  apply (rule pspace_no_overlap_subset, rule pspace_no_overlap_detype, simp+)
+  apply (simp add: valid_cap_simps cap_aligned_def field_simps)
   done
 
 lemma ex_tupleI:
   "P (fst t) (snd t) \<Longrightarrow> \<exists>a b. P a b"
   by blast
-
-lemma reset_untyped_cap_reads_respects_g:
- "reads_equiv_valid_g_inv (affects_equiv aag l) aag
-    (\<lambda>s. cte_wp_at is_untyped_cap slot s \<and> invs s \<and> ct_active s
-        \<and> only_timer_irq_inv irq st s
-        \<and> is_subject aag (fst slot)
-        \<and> (descendants_of slot (cdt s) = {}))
-    (reset_untyped_cap slot)"
-  apply (simp add: reset_untyped_cap_def cong: if_cong)
-  apply (rule equiv_valid_guard_imp)
-   apply (wp set_cap_reads_respects_g dmo_clearMemory_reads_respects_g
-       | simp add: unless_def when_def split del: if_split)+
-       apply (rule_tac I="invs and cte_wp_at (\<lambda>cp. is_untyped_cap rv
-             \<and> (\<exists>idx. cp = free_index_update (\<lambda>_. idx) rv)
-             \<and> free_index_of rv \<le> 2 ^ (bits_of rv)
-             \<and> is_subject aag (fst slot)) slot
-             and pspace_no_overlap (untyped_range rv)
-             and only_timer_irq_inv irq st
-             and (\<lambda>s. descendants_of slot (cdt s) = {})" in mapME_x_ev)
-        apply (rule equiv_valid_guard_imp)
-         apply wp
-             apply (rule reads_respects_g_from_inv)
-              apply (rule preemption_point_reads_respects[where irq=irq and st=st])
-             apply ((wp preemption_point_inv set_cap_reads_respects_g
-                       set_untyped_cap_invs_simple
-                       only_timer_irq_inv_pres[where Q=\<top>, OF _ set_cap_domain_sep_inv]
-                       dmo_clearMemory_reads_respects_g
-                     | simp)+)
-         apply (strengthen empty_descendants_range_in)
-         apply (wp only_timer_irq_inv_pres[where P=\<top> and Q=\<top>]
-                   no_irq_clearMemory
-              | simp
-              | wp (once) dmo_wp)+
-        apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps bits_of_def)
-        apply (frule(1) caps_of_state_valid)
-        apply (clarsimp simp: valid_cap_simps cap_aligned_def field_simps
-                              free_index_of_def invs_valid_global_objs)
-        apply (simp add: aligned_add_aligned is_aligned_shiftl)
-        apply (clarsimp simp: reset_chunk_bits_def)
-       apply (rule hoare_pre)
-        apply (wp preemption_point_inv' set_untyped_cap_invs_simple
-                  set_cap_cte_wp_at set_cap_no_overlap
-                  only_timer_irq_inv_pres[where Q=\<top>, OF _ set_cap_domain_sep_inv]
-           | simp)+
-        apply (strengthen empty_descendants_range_in)
-         apply (wp only_timer_irq_inv_pres[where P=\<top> and Q=\<top>]
-                   no_irq_clearMemory
-             | simp
-             | wp (once) dmo_wp)+
-        apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps bits_of_def)
-        apply (frule(1) caps_of_state_valid)
-        apply (clarsimp simp: valid_cap_simps cap_aligned_def field_simps
-                              free_index_of_def)
-       apply (wp | simp)+
-       apply (wp delete_objects_reads_respects_g)
-      apply (simp add: if_apply_def2)
-      apply (strengthen invs_valid_global_objs)
-      apply (wp add: delete_objects_invs_ex
-                      hoare_vcg_const_imp_lift delete_objects_pspace_no_overlap_again
-                      only_timer_irq_inv_pres[where P=\<top> and Q=\<top>]
-                 del: Untyped_AI.delete_objects_pspace_no_overlap
-          | simp)+
-     apply (rule get_cap_reads_respects_g)
-    apply (wp get_cap_wp)
-  apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps bits_of_def)
-  apply (frule(1) caps_of_state_valid)
-  apply (clarsimp simp: valid_cap_simps cap_aligned_def field_simps
-                        free_index_of_def invs_valid_global_objs)
-  apply (frule valid_global_refsD2, clarsimp+)
-  apply (clarsimp simp: ptr_range_def[symmetric] global_refs_def
-                        descendants_range_def2)
-  apply (frule if_unsafe_then_capD[OF caps_of_state_cteD], clarsimp+)
-  apply (strengthen refl[where t=True] refl ex_tupleI[where t=slot]
-            empty_descendants_range_in
-    | clarsimp)+
-  apply (drule ex_cte_cap_protects[OF _ _ _ _ order_refl],
-    erule caps_of_state_cteD)
-     apply (clarsimp simp: descendants_range_def2 empty_descendants_range_in)
-    apply clarsimp+
-  apply (fastforce simp: untyped_min_bits_def)
-  done
 
 lemma equiv_valid_obtain:
   assumes fn_eq: "\<And>s t. I s t \<Longrightarrow> A s t \<Longrightarrow> P s \<Longrightarrow> P t \<Longrightarrow>  fn s = fn t"
@@ -1090,178 +525,34 @@ lemma equiv_valid_obtain:
   done
 
 lemma reads_equiv_cte_wp_at:
-  "reads_equiv aag s s'
-    \<Longrightarrow> is_subject aag (fst slot)
-    \<Longrightarrow> cte_wp_at P slot s = cte_wp_at P slot s'"
+  "\<lbrakk> reads_equiv aag s s'; is_subject aag (fst slot) \<rbrakk>
+     \<Longrightarrow> cte_wp_at P slot s = cte_wp_at P slot s'"
   apply (frule(1) is_subject_kheap_eq)
   apply (simp add: cte_wp_at_cases)
   done
 
 lemma reads_equiv_caps_of_state:
-  "reads_equiv aag s s'
-    \<Longrightarrow> is_subject aag (fst slot)
-    \<Longrightarrow> caps_of_state s slot = caps_of_state s' slot"
+  "\<lbrakk> reads_equiv aag s s'; is_subject aag (fst slot) \<rbrakk>
+     \<Longrightarrow> caps_of_state s slot = caps_of_state s' slot"
   apply (frule(1) reads_equiv_cte_wp_at[where P="(=) (the (caps_of_state s slot))"])
   apply (frule(1) reads_equiv_cte_wp_at[where P="\<top>"])
   apply (auto simp: cte_wp_at_caps_of_state)
   done
 
-lemma untyped_cap_refs_in_kernel_window_helper:
-  "\<lbrakk> caps_of_state s p = Some (UntypedCap dev ptr sz idx);
-    cap_refs_in_kernel_window s;
-    S' \<subseteq> {ptr .. ptr + 2 ^ sz - 1} \<rbrakk>
-    \<Longrightarrow> \<forall>r \<in> S'.  arm_kernel_vspace (arch_state s) r = ArmVSpaceKernelWindow"
-  apply (drule(1) cap_refs_in_kernel_windowD)
-  apply (simp add: untyped_range_def)
-  apply blast
-  done
 
-lemma invs_valid_global_objs_strg:
-  "invs s \<longrightarrow> valid_global_objs s"
-  by (clarsimp simp: invs_def valid_state_def)
-
-lemma retype_region_ret_pd_aligned:
-  "\<lbrace>K (range_cover ptr sz (obj_bits_api tp us) num_objects)\<rbrace>
-   retype_region ptr num_objects us tp dev
-   \<lbrace>\<lambda>rv. K (\<forall> ref \<in> set rv. tp = ArchObject PageDirectoryObj \<longrightarrow> is_aligned ref pd_bits)\<rbrace>"
-  apply(rule hoare_strengthen_post)
-  apply(rule hoare_weaken_pre)
-  apply(rule retype_region_aligned_for_init)
-   apply simp
-  apply (clarsimp simp: obj_bits_api_def default_arch_object_def pd_bits_def pageBits_def)
-  done
-
-lemma invoke_untyped_reads_respects_g_wcap:
-  notes blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
-          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
-  shows
-  "reads_respects_g aag l (invs and valid_untyped_inv_wcap ui (Some (UntypedCap dev ptr sz idx))
-      and only_timer_irq_inv irq st
-      and ct_active and pas_refined aag
-      and K (authorised_untyped_inv aag ui)) (invoke_untyped ui)"
-  apply(case_tac ui)
-  apply(rename_tac cslot_ptr reset ptr_base ptr' apiobject_type nat list dev')
-  apply(case_tac "\<not> (dev' = dev \<and> ptr = ptr' && ~~ mask sz)")
-   (* contradictory *)
-   apply (rule equiv_valid_guard_imp, rule_tac gen_asm_ev'[where P="\<top>" and Q=False],
-     simp)
-   apply (clarsimp simp: cte_wp_at_caps_of_state)
-  apply(simp add: invoke_untyped_def mapM_x_def[symmetric])
-  apply(wp mapM_x_ev'' create_cap_reads_respects_g hoare_vcg_ball_lift
-           init_arch_objects_reads_respects_g
-        | simp)+
-           apply(rule_tac Q="\<lambda>_. invs" in hoare_strengthen_post)
-            apply(wp init_arch_objects_invs_from_restricted)
-           apply(fastforce simp: invs_def)
-          apply(wp retype_region_reads_respects_g[where sz=sz and slot="slot_of_untyped_inv ui"])
-         apply(rule_tac Q="\<lambda>rvc s.
-                                (\<forall>x\<in>set rvc. is_subject aag x) \<and>
-                                (\<forall>x\<in>set rvc. is_aligned x (obj_bits_api apiobject_type nat)) \<and>
-                                ((0::word32) < of_nat (length list)) \<and>
-                                post_retype_invs apiobject_type rvc s \<and>
-                                global_refs s \<inter> set rvc = {} \<and>
-                                (\<forall>x\<in>set list. is_subject aag (fst x))"
-                for sz in hoare_strengthen_post)
-          apply(wp retype_region_ret_is_subject[where sz=sz, simplified]
-                   retype_region_global_refs_disjoint[where sz=sz]
-                   retype_region_ret_pd_aligned[where sz=sz]
-                   retype_region_aligned_for_init[where sz=sz]
-                   retype_region_post_retype_invs_spec[where sz=sz])
-         apply(fastforce simp: global_refs_def
-                        intro: post_retype_invs_pspace_alignedI
-                               post_retype_invs_valid_arch_stateI
-                        simp: obj_bits_api_def default_arch_object_def
-                              pd_bits_def pageBits_def
-                        elim: in_set_zipE)
-        apply(rule set_cap_reads_respects_g)
-       apply simp
-       apply(wp hoare_vcg_ex_lift set_cap_cte_wp_at_cases
-                 hoare_vcg_disj_lift set_cap_no_overlap
-                 set_free_index_invs_UntypedCap
-                 set_untyped_cap_caps_overlap_reserved
-                 set_cap_caps_no_overlap
-                 region_in_kernel_window_preserved)
-      apply(wp when_ev delete_objects_reads_respects_g hoare_vcg_disj_lift
-               delete_objects_pspace_no_overlap
-               delete_objects_descendants_range_in
-               delete_objects_caps_no_overlap
-               region_in_kernel_window_preserved
-               get_cap_reads_respects_g get_cap_wp
-           |simp split del: if_split)+
-    apply (rule reset_untyped_cap_reads_respects_g[where irq=irq and st=st])
-  apply (rule_tac P="authorised_untyped_inv aag ui
-        \<and> (\<forall>p \<in> ptr_range ptr sz. is_subject aag p)" in hoare_gen_asmE)
-  apply (rule validE_validE_R, rule_tac E="\<top>\<top>" and Q="\<lambda>_. invs and valid_untyped_inv_wcap ui
-      (Some (UntypedCap dev ptr sz (if reset then 0 else idx))) and ct_active
-      and (\<lambda>s. reset \<longrightarrow> pspace_no_overlap {ptr .. ptr + 2 ^ sz - 1} s)"
-    in hoare_post_impErr)
-     apply (rule hoare_pre, wp hoare_whenE_wp)
-      apply (rule validE_validE_R, rule hoare_post_impErr, rule reset_untyped_cap_invs_etc)
-       apply (clarsimp simp only: if_True simp_thms, intro conjI, assumption+)
-      apply simp
-     apply assumption
-    apply (clarsimp simp only: )
-    apply (frule(2) invoke_untyped_proofs.intro)
-    apply (clarsimp simp: cte_wp_at_caps_of_state bits_of_def
-                          free_index_of_def untyped_range_def
-                          if_split[where P="\<lambda>x. x \<le> unat v" for v]
-               split del: if_split)
-    apply (frule(1) valid_global_refsD2[OF _ invs_valid_global_refs])
-    apply (strengthen refl)
-    apply (strengthen invs_valid_global_objs_strg)
-    apply (clarsimp simp: authorised_untyped_inv_def conj_comms
-                          invoke_untyped_proofs.simps)
-    apply (simp add: arg_cong[OF mask_out_sub_mask, where f="\<lambda>y. x - y" for x]
-                       field_simps invoke_untyped_proofs.idx_le_new_offs
-                       invoke_untyped_proofs.idx_compare'
-                       untyped_range_def)
-    apply (strengthen caps_region_kernel_window_imp[mk_strg I E])
-    apply (simp add: invoke_untyped_proofs.simps untyped_range_def
-                     invs_cap_refs_in_kernel_window
-                     atLeastatMost_subset_iff[where b=x and d=x for x]
-               cong: conj_cong split del: if_split)
-    apply (intro conjI)
-         (* mostly clagged from Untyped_AI *)
-           apply (simp add: atLeastatMost_subset_iff word_and_le2)
-
-          apply (case_tac reset)
-           apply (clarsimp elim!: pspace_no_overlap_subset del: subsetI
-                            simp: blah word_and_le2)
-          apply (drule invoke_untyped_proofs.ps_no_overlap)
-          apply (simp add: field_simps)
-
-         apply (simp add: Int_commute, erule disjoint_subset2[rotated])
-         apply (simp add: atLeastatMost_subset_iff word_and_le2)
-
-        apply (clarsimp dest!: invoke_untyped_proofs.idx_le_new_offs)
-
-       apply (simp add: ptr_range_def)
-       apply (erule ball_subset, rule range_subsetI[OF _ order_refl])
-       apply (simp add: word_and_le2)
-
-      apply (erule order_trans[OF invoke_untyped_proofs.subset_stuff])
-      apply (simp add: atLeastatMost_subset_iff word_and_le2)
-
-     apply (drule invoke_untyped_proofs.usable_range_disjoint)
-     apply (clarsimp simp: field_simps mask_out_sub_mask shiftl_t2n)
-
-    apply blast
-
-   apply simp
-
-  apply (clarsimp simp: cte_wp_at_caps_of_state authorised_untyped_inv_def)
-  apply (strengthen refl)
-  apply (frule(1) cap_auth_caps_of_state)
-  apply (simp add: aag_cap_auth_def untyped_range_def
-                   aag_has_Control_iff_owns ptr_range_def[symmetric])
-  apply (erule disjE, simp_all)[1]
-  done
+locale Retype_IF_2 = Retype_IF_1 +
+  fixes aag :: "'a subject_label PAS"
+  assumes invoke_untyped_reads_respects_g_wcap:
+    "reads_respects_g aag l (invs and valid_untyped_inv_wcap ui (Some (UntypedCap dev ptr sz idx))
+        and only_timer_irq_inv irq st
+        and ct_active and pas_refined aag
+        and K (authorised_untyped_inv aag ui)) (invoke_untyped ui)"
+begin
 
 lemma invoke_untyped_reads_respects_g:
-  "reads_respects_g aag l (invs and valid_untyped_inv ui
-      and only_timer_irq_inv irq st
-      and ct_active and pas_refined aag
-      and K (authorised_untyped_inv aag ui)) (invoke_untyped ui)"
+  "reads_respects_g aag l (invs and valid_untyped_inv ui and only_timer_irq_inv irq st
+                                and ct_active and pas_refined aag
+                                and K (authorised_untyped_inv aag ui)) (invoke_untyped ui)"
   apply (rule_tac fn="\<lambda>s. caps_of_state s (slot_of_untyped_inv ui)" in equiv_valid_obtain)
    apply (cases ui, clarsimp simp: valid_untyped_inv_wcap reads_equiv_g_def)
    apply (simp add: authorised_untyped_inv_def
@@ -1274,83 +565,6 @@ lemma invoke_untyped_reads_respects_g:
   apply (rule equiv_valid_guard_imp, rule gen_asm_ev'[where Q=False])
    apply simp
   apply (cases ui, clarsimp simp: valid_untyped_inv_wcap cte_wp_at_caps_of_state)
-  done
-
-lemma delete_objects_globals_equiv[wp]:
-  "\<lbrace>globals_equiv st and
-    (\<lambda>s. is_aligned p b \<and> 2 \<le> b \<and> b < word_bits \<and>
-         arm_global_pd (arch_state s) \<notin> ptr_range p b \<and>
-         idle_thread s \<notin> ptr_range p b)\<rbrace>
-   delete_objects p b
-   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (simp add: delete_objects_def)
-  apply (wp detype_globals_equiv dmo_freeMemory_globals_equiv)
-  apply (clarsimp simp: ptr_range_def)+
-  done
-
-lemma reset_untyped_cap_globals_equiv:
-  "\<lbrace>globals_equiv st and invs and cte_wp_at is_untyped_cap slot
-      and ct_active and (\<lambda>s. descendants_of slot (cdt s) = {})\<rbrace>
-    reset_untyped_cap slot
-  \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (simp add: reset_untyped_cap_def cong: if_cong)
-  apply (rule hoare_pre)
-   apply (wp set_cap_globals_equiv dmo_clearMemory_globals_equiv
-             preemption_point_inv | simp add: unless_def)+
-     apply (rule valid_validE)
-     apply (rule_tac P="cap_aligned cap \<and> is_untyped_cap cap" in hoare_gen_asm)
-     apply (rule_tac Q="\<lambda>_ s. valid_global_objs s \<and> globals_equiv st s"
-       in hoare_strengthen_post)
-      apply (rule validE_valid, rule mapME_x_wp')
-      apply (rule hoare_pre)
-       apply (wp set_cap_globals_equiv dmo_clearMemory_globals_equiv
-                 preemption_point_inv | simp add: if_apply_def2)+
-      apply (clarsimp simp: is_cap_simps ptr_range_def[symmetric]
-                            cap_aligned_def bits_of_def
-                            free_index_of_def)
-    apply (clarsimp simp: reset_chunk_bits_def)
-    apply (strengthen invs_valid_global_objs)
-    apply (wp delete_objects_invs_ex
-       hoare_vcg_const_imp_lift get_cap_wp)+
-  apply (clarsimp simp: cte_wp_at_caps_of_state descendants_range_def2 is_cap_simps bits_of_def
-             split del: if_split)
-  apply (frule caps_of_state_valid_cap, clarsimp+)
-  apply (clarsimp simp: valid_cap_simps cap_aligned_def untyped_min_bits_def)
-  apply (frule valid_global_refsD2, clarsimp+)
-  apply (clarsimp simp: ptr_range_def[symmetric] global_refs_def)
-  apply (strengthen empty_descendants_range_in)
-  apply (cases slot)
-  apply fastforce
-  done
-
-lemma invoke_untyped_globals_equiv:
-  notes blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
-          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
-  shows
-  "\<lbrace> globals_equiv st and invs and valid_untyped_inv ui and ct_active\<rbrace>
-   invoke_untyped ui
-   \<lbrace> \<lambda>_. globals_equiv st \<rbrace>"
-  apply (rule hoare_name_pre_state)
-  apply (rule hoare_pre, rule invoke_untyped_Q)
-       apply (wp create_cap_globals_equiv)
-       apply auto[1]
-      apply (wp init_arch_objects_globals_equiv)
-      apply (clarsimp simp: retype_addrs_aligned_range_cover cte_wp_at_caps_of_state
-                  simp del: valid_untyped_inv_wcap.simps)
-      apply (frule valid_global_refsD2)
-       apply (clarsimp simp: post_retype_invs_def split: if_split_asm)
-      apply (drule disjoint_subset2[rotated])
-       apply (rule order_trans, erule retype_addrs_subset_ptr_bits)
-       apply (simp add: untyped_range_def blah word_and_le2 field_simps)
-      apply (auto simp: global_refs_def post_retype_invs_def split: if_split_asm)[1]
-     apply (rule hoare_pre, wp retype_region_globals_equiv[where slot="slot_of_untyped_inv ui"])
-     apply (clarsimp simp: cte_wp_at_caps_of_state)
-     apply (strengthen refl)
-     apply simp
-    apply (wp set_cap_globals_equiv)
-    apply auto[1]
-   apply (wp reset_untyped_cap_globals_equiv)
-  apply (cases ui, clarsimp simp: cte_wp_at_caps_of_state)
   done
 
 end

--- a/proof/infoflow/Scheduler_IF.thy
+++ b/proof/infoflow/Scheduler_IF.thy
@@ -5,101 +5,180 @@
  *)
 
 theory Scheduler_IF
-imports    "Syscall_IF" "PasUpdates"
-
+imports "ArchSyscall_IF" "ArchPasUpdates"
 begin
-
-context begin interpretation Arch . (*FIXME: arch_splits*)
-
-crunch cur_thread: activate_thread "\<lambda>s. P (cur_thread s)"
-crunch cur_thread: arch_switch_to_thread "\<lambda>s. P( cur_thread s)"
 
 (* After SELFOUR-553 scheduler no longer writes to shared memory *)
 abbreviation scheduler_affects_globals_frame where
- "scheduler_affects_globals_frame s \<equiv>  {}"
+  "scheduler_affects_globals_frame s \<equiv> {}"
 
-definition globals_equiv_scheduler :: "'z::state_ext state \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
-"globals_equiv_scheduler s s' \<equiv> arm_global_pd (arch_state s) = arm_global_pd (arch_state s') \<and>
-     kheap s (arm_global_pd (arch_state s)) = kheap s' (arm_global_pd (arch_state s))
-     \<and> idle_equiv s s' \<and> device_region s = device_region s'"
+definition scheduler_globals_frame_equiv ::
+  "'z :: state_ext state \<Rightarrow> 'z :: state_ext state \<Rightarrow> bool" where
+  "scheduler_globals_frame_equiv s s' \<equiv>
+     \<forall>x\<in>scheduler_affects_globals_frame s.
+       underlying_memory (machine_state s) x = underlying_memory (machine_state s') x \<and>
+       device_state (machine_state s) x = device_state (machine_state s') x"
 
-definition scheduler_globals_frame_equiv :: "'z::state_ext state \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
-"scheduler_globals_frame_equiv s s' \<equiv> (\<forall>x\<in>scheduler_affects_globals_frame s. underlying_memory (machine_state s) x = underlying_memory (machine_state s') x
-  \<and> device_state (machine_state s) x = device_state (machine_state s') x)"
-
-definition domain_fields_equiv :: "det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool"
-where
-"domain_fields_equiv s s' \<equiv> cur_domain s = cur_domain s' \<and>
-                            domain_time s = domain_time s' \<and>
-                            domain_index s = domain_index s' \<and>
-                            domain_list s = domain_list s'"
-
-
-definition scheduler_equiv :: "'a subject_label PAS  \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool"
-where
-"scheduler_equiv aag s s'  \<equiv>
-    domain_fields_equiv s s' \<and> idle_thread s = idle_thread s' \<and> globals_equiv_scheduler s s' \<and> silc_dom_equiv aag s s' \<and> irq_state_of_state s = irq_state_of_state s'"
-
-(* The equivalence relation for what the scheduler can affect.
-   Since information can flow from the scheduler to any domain,
-   we assert that the result states are equivalent with respect
-   to any domain.
-
-*)
-
-
+definition domain_fields_equiv :: "det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "domain_fields_equiv s s' \<equiv> cur_domain s = cur_domain s'
+                            \<and> domain_time s = domain_time s'
+                            \<and> domain_index s = domain_index s'
+                            \<and> domain_list s = domain_list s'"
 
 definition reads_scheduler where
-"reads_scheduler aag l \<equiv> if (l = SilcLabel) then {} else
-                         subjectReads (pasPolicy aag) l"
+"reads_scheduler aag l \<equiv> if (l = SilcLabel) then {} else subjectReads (pasPolicy aag) l"
 
 abbreviation reads_scheduler_cur_domain where
   "reads_scheduler_cur_domain aag l s \<equiv>
      pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l \<noteq> {}"
 
-definition scheduler_affects_equiv :: "'a subject_label PAS  \<Rightarrow> ('a subject_label) \<Rightarrow>
-                                       det_state \<Rightarrow> det_state \<Rightarrow> bool"
-where
-"scheduler_affects_equiv aag l s s' \<equiv>
-  (states_equiv_for_labels aag (\<lambda>l'. l' \<in> reads_scheduler aag l) s s' \<and>
-  (reads_scheduler_cur_domain aag l s \<or> reads_scheduler_cur_domain aag l s' \<longrightarrow>
-     (cur_thread s = cur_thread s' \<and> scheduler_action s = scheduler_action s' \<and>
-      work_units_completed s = work_units_completed s' \<and>
-      scheduler_globals_frame_equiv s s' \<and>
-      idle_thread s = idle_thread s' \<and>
-      (cur_thread s \<noteq> idle_thread s' \<longrightarrow> exclusive_state_equiv s s'))))"
+definition idle_context where
+  "idle_context s = arch_tcb_context_get (tcb_arch (the (get_tcb (idle_thread s) s)))"
 
-lemma ev_modify:
-  "(\<And> s t. \<lbrakk>P s; P t; A s t; I s t\<rbrakk> \<Longrightarrow> (I (f s) (f t)) \<and> (B (f s) (f t)))
-   \<Longrightarrow> equiv_valid I A B P (modify f)"
-  apply (clarsimp simp add: equiv_valid_def2 equiv_valid_2_def simpler_modify_def)
-  done
 
-abbreviation reads_respects_scheduler
-where
-"reads_respects_scheduler aag l P f  \<equiv>
-   equiv_valid_inv (scheduler_equiv aag) (scheduler_affects_equiv aag l) P f"
+locale Scheduler_IF_1 =
+  fixes arch_globals_equiv_scheduler :: "kheap \<Rightarrow> kheap \<Rightarrow> arch_state \<Rightarrow> arch_state \<Rightarrow> bool"
+  and arch_scheduler_affects_equiv :: "det_state \<Rightarrow> det_state \<Rightarrow> bool"
+  assumes arch_globals_equiv_from_scheduler:
+    "\<lbrakk> arch_globals_equiv_scheduler (kheap s) (kheap s') (arch_state s) (arch_state s');
+       cur_thread s' \<noteq> idle_thread s \<longrightarrow> arch_scheduler_affects_equiv s s' \<rbrakk>
+       \<Longrightarrow> arch_globals_equiv (cur_thread s') (idle_thread s) (kheap s) (kheap s')
+                              (arch_state s) (arch_state s') (machine_state s) (machine_state s')"
+  and arch_globals_equiv_scheduler_refl:
+    "arch_globals_equiv_scheduler (kheap s) (kheap s) (arch_state s) (arch_state s)"
+  and arch_globals_equiv_scheduler_sym:
+    "arch_globals_equiv_scheduler (kheap s) (kheap s') (arch_state s) (arch_state s')
+     \<Longrightarrow> arch_globals_equiv_scheduler (kheap s') (kheap s) (arch_state s') (arch_state s)"
+  and arch_globals_equiv_scheduler_trans:
+    "\<lbrakk> arch_globals_equiv_scheduler (kheap s) (kheap s') (arch_state s) (arch_state s');
+       arch_globals_equiv_scheduler (kheap s') (kheap s'') (arch_state s') (arch_state s'') \<rbrakk>
+       \<Longrightarrow> arch_globals_equiv_scheduler (kheap s) (kheap s'') (arch_state s) (arch_state s'')"
+  and arch_scheduler_affects_equiv_trans[elim]:
+    "\<lbrakk> arch_scheduler_affects_equiv s s'; arch_scheduler_affects_equiv s' s'' \<rbrakk>
+       \<Longrightarrow> arch_scheduler_affects_equiv s (s'' :: det_state)"
+  and arch_scheduler_affects_equiv_sym[elim]:
+    "arch_scheduler_affects_equiv s s' \<Longrightarrow> arch_scheduler_affects_equiv s' s"
+  and arch_scheduler_affects_equiv_update:
+    "arch_scheduler_affects_equiv st s
+     \<Longrightarrow> arch_scheduler_affects_equiv st (s\<lparr>kheap := kheap s(x \<mapsto> TCB y')\<rparr>)"
+  and arch_scheduler_affects_equiv_sa_update[simp]:
+    "\<And>f. arch_scheduler_affects_equiv (scheduler_action_update f s) s' =
+          arch_scheduler_affects_equiv s s'"
+    "\<And>f. arch_scheduler_affects_equiv s (scheduler_action_update f s') =
+          arch_scheduler_affects_equiv s s'"
+  and arch_scheduler_affects_equiv_ready_queues_update[simp]:
+    "\<And>f. arch_scheduler_affects_equiv (ready_queues_update f s) s' =
+          arch_scheduler_affects_equiv s s'"
+    "\<And>f. arch_scheduler_affects_equiv s (ready_queues_update f s') =
+          arch_scheduler_affects_equiv s s'"
+  and arch_scheduler_affects_equiv_cur_thread_update[simp]:
+    "\<And>f. arch_scheduler_affects_equiv (cur_thread_update f s) s' =
+          arch_scheduler_affects_equiv s s'"
+    "\<And>f. arch_scheduler_affects_equiv s (cur_thread_update f s') =
+          arch_scheduler_affects_equiv s s'"
+  and arch_scheduler_affects_equiv_domain_time_update[simp]:
+    "\<And>f. arch_scheduler_affects_equiv (domain_time_update f s) s' =
+          arch_scheduler_affects_equiv s s'"
+    "\<And>f. arch_scheduler_affects_equiv s (domain_time_update f s') =
+          arch_scheduler_affects_equiv s s'"
+  and arch_scheduler_affects_equiv_ekheap_update[simp]:
+    "\<And>f. arch_scheduler_affects_equiv (ekheap_update f s) s' =
+          arch_scheduler_affects_equiv s s'"
+    "\<And>f. arch_scheduler_affects_equiv s (ekheap_update f s') =
+          arch_scheduler_affects_equiv s s'"
+  and arch_switch_to_thread_kheap[wp]:
+    "\<And>P. arch_switch_to_thread t \<lbrace>\<lambda>s :: det_state. P (kheap s)\<rbrace>"
+  and arch_switch_to_idle_thread_kheap[wp]:
+    "\<And>P. arch_switch_to_idle_thread \<lbrace>\<lambda>s :: det_state. P (kheap s)\<rbrace>"
+  and arch_switch_to_thread_idle_thread[wp]:
+    "\<And>P. arch_switch_to_thread t \<lbrace>\<lambda>s :: det_state. P (idle_thread s)\<rbrace>"
+  and arch_switch_to_idle_thread_idle_thread[wp]:
+    "\<And>P. arch_switch_to_idle_thread \<lbrace>\<lambda>s :: det_state. P (idle_thread s)\<rbrace>"
+  and arch_switch_to_idle_thread_cur_domain[wp]:
+    "\<And>P. arch_switch_to_idle_thread \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  and arch_switch_to_idle_thread_domain_fields[wp]:
+    "\<And>P. arch_switch_to_idle_thread \<lbrace>\<lambda>s. P (domain_time s) (domain_index s) (domain_list s)\<rbrace>"
+  and arch_switch_to_idle_thread_globals_equiv[wp]:
+    "arch_switch_to_idle_thread \<lbrace>globals_equiv st\<rbrace>"
+  and arch_switch_to_idle_thread_states_equiv_for[wp]:
+    "\<And>P Q R S. arch_switch_to_idle_thread \<lbrace>states_equiv_for P Q R S st\<rbrace>"
+  and arch_switch_to_idle_thread_work_units_completed[wp]:
+    "\<And>P. arch_switch_to_idle_thread \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace>"
+  and equiv_asid_equiv_update:
+    "\<lbrakk> get_tcb x s = Some y; equiv_asid asid st s \<rbrakk>
+       \<Longrightarrow> equiv_asid asid st (s\<lparr>kheap := kheap s(x \<mapsto> TCB y')\<rparr>)"
+  and equiv_asid_cur_thread_update[simp]:
+    "\<And>f. equiv_asid asid (cur_thread_update f s) s' = equiv_asid asid s s'"
+    "\<And>f. equiv_asid asid s (cur_thread_update f s') = equiv_asid asid s s'"
+  and equiv_asid_domain_time_update[simp]:
+    "\<And>f. equiv_asid asid (domain_time_update f s) s' = equiv_asid asid s s'"
+    "\<And>f. equiv_asid asid s (domain_time_update f s') = equiv_asid asid s s'"
+  and equiv_asid_ekheap_update[simp]:
+    "\<And>f. equiv_asid asid (ekheap_update f s) s' = equiv_asid asid s s'"
+    "\<And>f. equiv_asid asid s (ekheap_update f s') = equiv_asid asid s s'"
+  and ackInterrupt_irq_state[wp]:
+    "\<And>P. ackInterrupt irq \<lbrace>\<lambda>s. P (irq_state s)\<rbrace>"
+  and thread_set_context_globals_equiv:
+    "\<lbrace>(\<lambda>s. t = idle_thread s \<longrightarrow> tc = idle_context s) and invs and globals_equiv st\<rbrace>
+     thread_set (tcb_arch_update (arch_tcb_context_set tc)) t
+     \<lbrace>\<lambda>rv. globals_equiv st\<rbrace>"
+  and arch_activate_idle_thread_cur_domain[wp]:
+    "\<And>P. arch_activate_idle_thread t \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  and arch_activate_idle_thread_idle_thread[wp]:
+    "\<And>P. arch_activate_idle_thread t \<lbrace>\<lambda>s :: det_state. P (idle_thread s)\<rbrace>"
+  and arch_activate_idle_thread_irq_state_of_state[wp]:
+    "\<And>P. arch_activate_idle_thread t \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and arch_activate_idle_thread_domain_fields[wp]:
+    "\<And>P. arch_activate_idle_thread t \<lbrace>domain_fields P\<rbrace>"
+begin
+
+definition globals_equiv_scheduler :: "det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "globals_equiv_scheduler s s' \<equiv>
+     arch_globals_equiv_scheduler (kheap s) (kheap s') (arch_state s) (arch_state s') \<and>
+     idle_equiv s s' \<and> device_region s = device_region s'"
+
+definition scheduler_equiv :: "'a subject_label PAS \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "scheduler_equiv aag s s' \<equiv> domain_fields_equiv s s' \<and> idle_thread s = idle_thread s'
+                            \<and> globals_equiv_scheduler s s' \<and> silc_dom_equiv aag s s'
+                            \<and> irq_state_of_state s = irq_state_of_state s'"
+
+definition scheduler_affects_equiv ::
+  "'a subject_label PAS  \<Rightarrow> ('a subject_label) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "scheduler_affects_equiv aag l s s' \<equiv>
+     (states_equiv_for_labels aag (\<lambda>l'. l' \<in> reads_scheduler aag l) s s' \<and>
+      (reads_scheduler_cur_domain aag l s \<or> reads_scheduler_cur_domain aag l s'
+       \<longrightarrow> (cur_thread s = cur_thread s' \<and> scheduler_action s = scheduler_action s' \<and>
+            work_units_completed s = work_units_completed s' \<and>
+            scheduler_globals_frame_equiv s s' \<and> idle_thread s = idle_thread s' \<and>
+            (cur_thread s \<noteq> idle_thread s' \<longrightarrow> arch_scheduler_affects_equiv s s'))))"
+
+abbreviation reads_respects_scheduler where
+  "reads_respects_scheduler aag l P f  \<equiv>
+     equiv_valid_inv (scheduler_equiv aag) (scheduler_affects_equiv aag l) P f"
+
 
 lemma globals_equiv_from_scheduler:
   "\<lbrakk> globals_equiv_scheduler s s'; scheduler_globals_frame_equiv s s'; cur_thread s = cur_thread s';
-    cur_thread s \<noteq> idle_thread s \<longrightarrow> exclusive_state_equiv s s'\<rbrakk> \<Longrightarrow>
-  globals_equiv s s'"
+     cur_thread s \<noteq> idle_thread s \<longrightarrow> arch_scheduler_affects_equiv s s' \<rbrakk>
+     \<Longrightarrow> globals_equiv s s'"
   by (clarsimp simp: globals_equiv_scheduler_def scheduler_globals_frame_equiv_def
-                     globals_equiv_def)
+                     globals_equiv_def arch_globals_equiv_from_scheduler)
 
 lemma globals_equiv_scheduler_refl:
   "globals_equiv_scheduler s s"
-  by (simp add: globals_equiv_scheduler_def idle_equiv_refl)
+  by (simp add: globals_equiv_scheduler_def idle_equiv_refl arch_globals_equiv_scheduler_refl)
 
-lemma globals_equiv_scheduler_sym:
+lemma globals_equiv_scheduler_sym[elim]:
   "globals_equiv_scheduler s s' \<Longrightarrow> globals_equiv_scheduler s' s"
-  by (auto simp add: globals_equiv_scheduler_def idle_equiv_sym)
+  by (auto simp: globals_equiv_scheduler_def idle_equiv_sym arch_globals_equiv_scheduler_sym)
 
-lemma globals_equiv_scheduler_trans:
-  "globals_equiv_scheduler s s' \<Longrightarrow> globals_equiv_scheduler s' s'' \<Longrightarrow> globals_equiv_scheduler s s''"
-  apply (clarsimp simp add: globals_equiv_scheduler_def)
-  apply (rule idle_equiv_trans,assumption,assumption)
-  done
+lemma globals_equiv_scheduler_trans[elim]:
+  "\<lbrakk> globals_equiv_scheduler s s'; globals_equiv_scheduler s' s'' \<rbrakk>
+     \<Longrightarrow> globals_equiv_scheduler s s''"
+  unfolding globals_equiv_scheduler_def
+  by (fastforce elim: arch_globals_equiv_scheduler_trans idle_equiv_trans)
+
+end
 
 
 lemma scheduler_globals_frame_equiv_refl:
@@ -111,21 +190,21 @@ lemma scheduler_globals_frame_equiv_sym[elim]:
   by (simp add: scheduler_globals_frame_equiv_def)
 
 lemma scheduler_globals_frame_equiv_trans[elim]:
-  "scheduler_globals_frame_equiv s s' \<Longrightarrow> scheduler_globals_frame_equiv s' s''
-   \<Longrightarrow> scheduler_globals_frame_equiv s s''"
+  "\<lbrakk> scheduler_globals_frame_equiv s s'; scheduler_globals_frame_equiv s' s'' \<rbrakk>
+     \<Longrightarrow> scheduler_globals_frame_equiv s s''"
   by (simp add: scheduler_globals_frame_equiv_def)
 
 lemma preserves_equivalence_2_weak:
-assumes A: "(u,b) \<in> fst (f s)"
-assumes B: "(u',ba) \<in> fst (g t)"
-assumes R_preserved: "\<And>st. \<lbrace>P and (R st)\<rbrace> f \<lbrace>\<lambda>_.(R st)\<rbrace>"
-assumes R_preserved': "\<And>st. \<lbrace>S and (R st)\<rbrace> g \<lbrace>\<lambda>_.(R st)\<rbrace>"
-assumes R_sym: "\<forall>s s'. R s s' \<longrightarrow> R s' s"
-assumes R_trans: "\<forall>s s' s''. R s s' \<longrightarrow> R s' s'' \<longrightarrow> R s s''"
-shows "\<lbrakk> R s t;P s; S t\<rbrakk> \<Longrightarrow> R b ba"
+  assumes A: "(u,b) \<in> fst (f s)"
+  assumes B: "(u',ba) \<in> fst (g t)"
+  assumes R_preserved: "\<And>st. \<lbrace>P and R st\<rbrace> f \<lbrace>\<lambda>_. R st\<rbrace>"
+  assumes R_preserved': "\<And>st. \<lbrace>S and R st\<rbrace> g \<lbrace>\<lambda>_. R st\<rbrace>"
+  assumes R_sym: "\<forall>s s'. R s s' \<longrightarrow> R s' s"
+  assumes R_trans: "\<forall>s s' s''. R s s' \<longrightarrow> R s' s'' \<longrightarrow> R s s''"
+  shows "\<lbrakk> R s t; P s; S t \<rbrakk> \<Longrightarrow> R b ba"
   apply (insert A B)
   apply (drule use_valid[OF _ R_preserved])
-  apply simp
+   apply simp
    apply (rule R_sym[rule_format])
    apply assumption
   apply (drule use_valid[OF _ R_preserved'])
@@ -134,76 +213,14 @@ shows "\<lbrakk> R s t;P s; S t\<rbrakk> \<Longrightarrow> R b ba"
   done
 
 lemma preserves_equivalence_weak:
-assumes A: "(u,b) \<in> fst (f s)"
-assumes B: "(u',ba) \<in> fst (f t)"
-assumes R_preserved: "\<And>st. \<lbrace>P and (R st)\<rbrace> f \<lbrace>\<lambda>_.(R st)\<rbrace>"
-assumes R_sym: "\<forall>s s'. R s s' \<longrightarrow> R s' s"
-assumes R_trans: "\<forall>s s' s''. R s s' \<longrightarrow> R s' s'' \<longrightarrow> R s s''"
-shows "\<lbrakk> R s t;P s; P t\<rbrakk> \<Longrightarrow> R b ba"
+  assumes A: "(u,b) \<in> fst (f s)"
+  assumes B: "(u',ba) \<in> fst (f t)"
+  assumes R_preserved: "\<And>st. \<lbrace>P and R st\<rbrace> f \<lbrace>\<lambda>_. R st\<rbrace>"
+  assumes R_sym: "\<forall>s s'. R s s' \<longrightarrow> R s' s"
+  assumes R_trans: "\<forall>s s' s''. R s s' \<longrightarrow> R s' s'' \<longrightarrow> R s s''"
+  shows "\<lbrakk> R s t; P s; P t \<rbrakk> \<Longrightarrow> R b ba"
   using assms
-  apply (blast intro: preserves_equivalence_2_weak)
-  done
-
-
-
-lemma scheduler_equiv_trans[elim]:
-  "scheduler_equiv aag s s' \<Longrightarrow> scheduler_equiv aag s' s'' \<Longrightarrow> scheduler_equiv aag s s''"
-  apply (simp add: scheduler_equiv_def domain_fields_equiv_def)
-  apply clarify
-  apply (rule conjI)
-   apply (rule globals_equiv_scheduler_trans)
-   apply simp+
-  apply(blast intro: silc_dom_equiv_trans)
-  done
-
-
-
-lemma scheduler_equiv_sym[elim]:
-  "scheduler_equiv aag s s' \<Longrightarrow> scheduler_equiv aag s' s"
-  by (simp add: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_sym
-                silc_dom_equiv_sym)
-
-lemma scheduler_affects_equiv_trans[elim]:
-  "\<lbrakk>scheduler_affects_equiv aag l s s'; scheduler_equiv aag s s';
-    scheduler_affects_equiv aag l s' s''; scheduler_equiv aag s' s''\<rbrakk>
-   \<Longrightarrow> scheduler_affects_equiv aag l s s''"
-   apply (simp add: scheduler_affects_equiv_def scheduler_equiv_trans[where s'=s'])+
-  apply clarify
-  apply (rule conjI)
-   apply (rule states_equiv_for_trans[where t=s'])
-    apply simp+
-  apply (force simp: scheduler_globals_frame_equiv_trans[where s'=s'] scheduler_equiv_def
-                     domain_fields_equiv_def)
-  done
-
-lemma scheduler_affects_equiv_sym[elim]:
-  "scheduler_affects_equiv aag l s s' \<Longrightarrow> scheduler_affects_equiv aag l s' s"
-  apply (simp add: scheduler_affects_equiv_def)
-  (* faster than the one-liner *)
-  apply (clarsimp simp: scheduler_globals_frame_equiv_sym states_equiv_for_sym silc_dom_equiv_sym)
-  apply force
-  done
-
-declare globals_equiv_scheduler_sym[elim]
-declare globals_equiv_scheduler_trans[elim]
-declare silc_dom_equiv_sym[elim]
-declare silc_dom_equiv_trans[elim]
-
-lemma scheduler_equiv_lift':
-  assumes s: "\<And>st. \<lbrace>P and globals_equiv_scheduler st\<rbrace>  f \<lbrace>\<lambda>_.(globals_equiv_scheduler st)\<rbrace>"
-  assumes d: "\<And>Q. \<lbrace>P and (\<lambda>s. Q (cur_domain s))\<rbrace> f \<lbrace>\<lambda>r s. Q (cur_domain s)\<rbrace>"
-  assumes i: "\<And>P. invariant f (\<lambda>s. P (idle_thread s))"
-  assumes e: "\<And>Q. \<lbrace>P and domain_fields Q\<rbrace> f \<lbrace>\<lambda>_. domain_fields Q\<rbrace>"
-  assumes g: "\<And>P. invariant f (\<lambda>s. P (irq_state_of_state s))"
-  assumes f: "\<And>st. \<lbrace>P and silc_dom_equiv aag st\<rbrace> f \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
-  shows "\<lbrace>P and scheduler_equiv aag st\<rbrace> f \<lbrace>\<lambda>_. scheduler_equiv aag st\<rbrace>"
-  apply (simp add: scheduler_equiv_def[abs_def] domain_fields_equiv_def)
-  apply (rule hoare_pre)
-  apply (wp d e s i f g)
-  apply simp
-  done
-
-lemmas scheduler_equiv_lift = scheduler_equiv_lift'[where P=\<top>,simplified]
+  by (blast intro: preserves_equivalence_2_weak)
 
 lemma equiv_valid_inv_unobservable:
   assumes f: "\<And>st. \<lbrace>P and I st and A st\<rbrace> f \<lbrace>\<lambda>_. I st\<rbrace>"
@@ -211,7 +228,7 @@ lemma equiv_valid_inv_unobservable:
   assumes sym: "\<forall>s s'. I s s' \<and> A s s' \<longrightarrow> I s' s \<and> A s' s"
   assumes trans: "\<forall>s s' s''. I s s' \<and> A s s' \<longrightarrow> I s' s'' \<and> A s' s'' \<longrightarrow> I s s'' \<and> A s s''"
   assumes s: "\<And>s. Q s \<Longrightarrow> P s \<and> P' s"
-  shows "equiv_valid_inv I A  Q (f:: 'a \<Rightarrow> (unit \<times> 'a) set \<times> bool)"
+  shows "equiv_valid_inv I A  Q (f :: 'a \<Rightarrow> (unit \<times> 'a) set \<times> bool)"
   apply (clarsimp simp add: equiv_valid_def spec_equiv_valid_def equiv_valid_2_def)
   apply (erule preserves_equivalence_weak,assumption)
        apply (rule hoare_pre)
@@ -223,32 +240,81 @@ lemma equiv_valid_inv_unobservable:
       apply (fastforce intro!: sym trans)+
   done
 
-lemma reads_respects_scheduler_unobservable'':
-        "\<lbrakk>\<And>st. \<lbrace>P and scheduler_equiv aag st and scheduler_affects_equiv aag l st\<rbrace> f
-              \<lbrace>\<lambda>_. scheduler_equiv aag st\<rbrace>;
-         \<And>st. \<lbrace>P' and scheduler_equiv aag st and scheduler_affects_equiv aag l st\<rbrace> f
-              \<lbrace>\<lambda>(_ :: unit). scheduler_affects_equiv aag l st\<rbrace>;
-         \<And>s. Q s \<Longrightarrow> P s \<and> P' s\<rbrakk>
-        \<Longrightarrow> reads_respects_scheduler aag l Q f"
-  apply (rule equiv_valid_inv_unobservable,fastforce+)
+
+context Scheduler_IF_1 begin
+
+lemma scheduler_equiv_trans[elim]:
+  "\<lbrakk> scheduler_equiv aag s s'; scheduler_equiv aag s' s'' \<rbrakk>
+     \<Longrightarrow> scheduler_equiv aag s s''"
+  apply (simp add: scheduler_equiv_def domain_fields_equiv_def)
+  apply clarify
+  apply (rule conjI)
+   apply (rule globals_equiv_scheduler_trans)
+    apply simp+
+  apply (blast intro: silc_dom_equiv_trans)
   done
+
+lemma scheduler_equiv_sym[elim]:
+  "scheduler_equiv aag s s' \<Longrightarrow> scheduler_equiv aag s' s"
+  by (simp add: scheduler_equiv_def domain_fields_equiv_def
+                globals_equiv_scheduler_sym silc_dom_equiv_sym)
+
+lemma scheduler_affects_equiv_trans[elim]:
+  "\<lbrakk> scheduler_affects_equiv aag l s s'; scheduler_equiv aag s s';
+     scheduler_affects_equiv aag l s' s''; scheduler_equiv aag s' s'' \<rbrakk>
+     \<Longrightarrow> scheduler_affects_equiv aag l s s''"
+  apply (simp add: scheduler_affects_equiv_def scheduler_equiv_trans[where s'=s'])+
+  apply clarify
+  apply (rule conjI)
+   apply (rule states_equiv_for_trans[where t=s'])
+    apply simp+
+  apply (clarsimp simp: scheduler_globals_frame_equiv_trans[where s'=s']
+                        scheduler_equiv_def domain_fields_equiv_def)
+  apply (erule (1) arch_scheduler_affects_equiv_trans)
+  done
+
+lemma scheduler_affects_equiv_sym[elim]:
+  "scheduler_affects_equiv aag l s s' \<Longrightarrow> scheduler_affects_equiv aag l s' s"
+  apply (simp add: scheduler_affects_equiv_def)
+  (* faster than the one-liner *)
+  apply (clarsimp simp: scheduler_globals_frame_equiv_sym states_equiv_for_sym silc_dom_equiv_sym)
+  apply force
+  done
+
+lemma scheduler_equiv_lift':
+  assumes s: "\<And>st. \<lbrace>P and globals_equiv_scheduler st\<rbrace>  f \<lbrace>\<lambda>_.(globals_equiv_scheduler st)\<rbrace>"
+  assumes d: "\<And>Q. \<lbrace>P and (\<lambda>s. Q (cur_domain s))\<rbrace> f \<lbrace>\<lambda>r s. Q (cur_domain s)\<rbrace>"
+  assumes i: "\<And>P. f \<lbrace>\<lambda>s. P (idle_thread s)\<rbrace>"
+  assumes e: "\<And>Q. \<lbrace>P and domain_fields Q\<rbrace> f \<lbrace>\<lambda>_. domain_fields Q\<rbrace>"
+  assumes g: "\<And>P. f \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  assumes f: "\<And>st. \<lbrace>P and silc_dom_equiv aag st\<rbrace> f \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
+  shows "\<lbrace>P and scheduler_equiv aag st\<rbrace> f \<lbrace>\<lambda>_. scheduler_equiv aag st\<rbrace>"
+  apply (simp add: scheduler_equiv_def[abs_def] domain_fields_equiv_def)
+  apply (rule hoare_pre)
+   apply (wp d e s i f g)
+  apply simp
+  done
+
+lemmas scheduler_equiv_lift = scheduler_equiv_lift'[where P=\<top>,simplified]
+
+lemma reads_respects_scheduler_unobservable'':
+  assumes "\<And>st. \<lbrace>P and scheduler_equiv aag st and scheduler_affects_equiv aag l st\<rbrace>
+                 f
+                 \<lbrace>\<lambda>_. scheduler_equiv aag st\<rbrace>"
+  assumes "\<And>st. \<lbrace>P' and scheduler_equiv aag st and scheduler_affects_equiv aag l st\<rbrace>
+                 f
+                 \<lbrace>\<lambda>_ :: unit. scheduler_affects_equiv aag l st\<rbrace>"
+  assumes "\<And>s. Q s \<Longrightarrow> P s \<and> P' s"
+  shows "reads_respects_scheduler aag l Q f"
+  by (rule equiv_valid_inv_unobservable) (wp assms | force)+
 
 lemma reads_respects_scheduler_unobservable':
   assumes f: "\<And>st. \<lbrace>P and scheduler_equiv aag st\<rbrace> f \<lbrace>\<lambda>_. scheduler_equiv aag st\<rbrace>"
-  assumes g:
-    "\<And>st. \<lbrace>P and scheduler_affects_equiv aag l st\<rbrace> f \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
-  shows "reads_respects_scheduler aag l P (f:: (unit,det_ext) s_monad)"
-  apply (rule reads_respects_scheduler_unobservable'')
-   apply (wp f g | force)+
-  done
+  assumes g: "\<And>st. \<lbrace>P and scheduler_affects_equiv aag l st\<rbrace> f \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
+  shows "reads_respects_scheduler aag l P (f :: (unit,det_ext) s_monad)"
+  by (rule reads_respects_scheduler_unobservable'') (wp f g | force)+
 
-definition swap_things where
-  "swap_things s t \<equiv> t\<lparr> machine_state := underlying_memory_update
-                                         (\<lambda>m a. if  a \<in> scheduler_affects_globals_frame t
-                                                     then (underlying_memory (machine_state s) a)
-                                                else m a) (machine_state t)
-                        \<lparr>exclusive_state := exclusive_state (machine_state s)\<rparr>\<rparr>
-                      \<lparr>cur_thread := cur_thread s\<rparr>"
+end
 
 
 lemma idle_equiv_machine_state_update[simp]:
@@ -262,24 +328,6 @@ lemma idle_equiv_machine_state_update'[simp]:
 lemma idle_equiv_cur_thread_update'[simp]:
   "idle_equiv (st\<lparr>cur_thread := x\<rparr>) s = idle_equiv st s"
   by (simp add: idle_equiv_def)
-
-lemma globals_equiv_scheduler_inv':
-  "\<lbrakk>(\<And>st. \<lbrace> P and globals_equiv st\<rbrace> f \<lbrace>\<lambda>_. globals_equiv st\<rbrace>)\<rbrakk> \<Longrightarrow>
-    \<lbrace> P and globals_equiv_scheduler s\<rbrace> f \<lbrace>\<lambda>_. globals_equiv_scheduler s\<rbrace>"
-  apply atomize
-  apply (rule use_spec)
-  apply (simp add: spec_valid_def)
-  apply (erule_tac x="(swap_things sa s)" in allE)
-  apply (rule_tac Q="\<lambda>r st. globals_equiv (swap_things sa s) st" in hoare_strengthen_post )
-   apply (rule hoare_pre)
-    apply assumption
-   apply (clarsimp simp add: globals_equiv_def swap_things_def globals_equiv_scheduler_def)+
-  done
-
-lemmas globals_equiv_scheduler_inv = globals_equiv_scheduler_inv'[where P="\<top>",simplified]
-
-lemmas reads_respects_scheduler_unobservable =
-             reads_respects_scheduler_unobservable'[where P="\<top>",simplified]
 
 lemma silc_dom_equiv_scheduler_action_update[simp]:
   "silc_dom_equiv aag st (s\<lparr>scheduler_action := x\<rparr>) = silc_dom_equiv aag st s"
@@ -299,32 +347,6 @@ lemma idle_equiv_scheduler_action_update[simp]:
 lemma idle_equiv_scheduler_action_update'[simp]:
   "idle_equiv st (scheduler_action_update f s) = idle_equiv st s"
   by (simp add: idle_equiv_def)
-
-lemma set_scheduler_action_rev_scheduler[wp]:
-  "reads_respects_scheduler aag l \<top> (set_scheduler_action a)"
-  apply (clarsimp simp add: set_scheduler_action_def)
-  apply (rule ev_modify)
-  apply (clarsimp simp add: scheduler_affects_equiv_def
-                            scheduler_equiv_def states_equiv_for_def
-                            equiv_asids_def equiv_asid_def
-                            domain_fields_equiv_def
-                            globals_equiv_scheduler_def
-                            silc_dom_equiv_def
-                            scheduler_globals_frame_equiv_def
-                            equiv_for_def)
-  done
-
-lemma globals_equiv_scheduler_cur_thread_update[simp]:
-  "globals_equiv_scheduler st (s\<lparr>cur_thread := x\<rparr>) = globals_equiv_scheduler st s"
-  by (simp add: globals_equiv_scheduler_def idle_equiv_def)
-
-lemma globals_equiv_scheduler_trans_state_update[simp]:
-  "globals_equiv_scheduler st (trans_state f s) = globals_equiv_scheduler st s"
-  by (simp add: globals_equiv_scheduler_def idle_equiv_def)
-
-lemma states_equiv_for_cur_thread_update[simp]:
-  "states_equiv_for P Q R S s (s'\<lparr>cur_thread := x\<rparr>) = states_equiv_for P Q R S s s'"
-  by (simp add: states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def)
 
 lemma scheduler_globals_frame_equiv_cur_thread_update[simp]:
   "scheduler_globals_frame_equiv st (s\<lparr>cur_thread := x\<rparr>) = scheduler_globals_frame_equiv st s"
@@ -354,17 +376,55 @@ lemma silc_dom_equiv_cur_thread_update'[simp]:
   "silc_dom_equiv aag (st\<lparr>cur_thread := x\<rparr>) s = silc_dom_equiv aag st s"
   by (simp add: silc_dom_equiv_def equiv_for_def)
 
+lemma tcb_domain_wellformed:
+  "\<lbrakk> pas_refined aag s; ekheap s t = Some a \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag t \<in> pasDomainAbs aag (tcb_domain a)"
+  apply (clarsimp simp add: pas_refined_def tcb_domain_map_wellformed_aux_def)
+  apply (drule_tac x="(t,tcb_domain a)" in bspec)
+  apply (rule domtcbs)
+  apply force+
+  done
+
+lemma silc_dom_equiv_trans_state[simp]:
+  "silc_dom_equiv aag st (trans_state f s) = silc_dom_equiv aag st s"
+  by (simp add: silc_dom_equiv_def equiv_for_def)
+
+lemma (in is_extended') silc_dom_equiv[wp]:
+  "I (silc_dom_equiv aag st)"
+  by (rule lift_inv,simp)
+
+
+context Scheduler_IF_1 begin
+
+lemma set_scheduler_action_rev_scheduler[wp]:
+  "reads_respects_scheduler aag l \<top> (set_scheduler_action a)"
+  apply (clarsimp simp: set_scheduler_action_def)
+  apply (rule ev_modify)
+  by (clarsimp simp: scheduler_affects_equiv_def scheduler_equiv_def states_equiv_for_def
+                     equiv_asids_def domain_fields_equiv_def globals_equiv_scheduler_def
+                     silc_dom_equiv_def scheduler_globals_frame_equiv_def equiv_for_def)
+
+lemma globals_equiv_scheduler_cur_thread_update[simp]:
+  "globals_equiv_scheduler st (s\<lparr>cur_thread := x\<rparr>) = globals_equiv_scheduler st s"
+  by (simp add: globals_equiv_scheduler_def idle_equiv_def)
+
+lemma globals_equiv_scheduler_trans_state_update[simp]:
+  "globals_equiv_scheduler st (trans_state f s) = globals_equiv_scheduler st s"
+  by (simp add: globals_equiv_scheduler_def idle_equiv_def)
+
+lemma states_equiv_for_cur_thread_update[simp]:
+  "states_equiv_for P Q R S s (s'\<lparr>cur_thread := x\<rparr>) = states_equiv_for P Q R S s s'"
+  by (simp add: states_equiv_for_def equiv_for_def equiv_asids_def)
 
 lemma scheduler_equiv_ready_queues_update[simp]:
   "scheduler_equiv aag (st\<lparr>ready_queues := x\<rparr>) s = scheduler_equiv aag st s"
-  by (simp add: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
-                   idle_equiv_def)
+  by (simp add: scheduler_equiv_def domain_fields_equiv_def
+                globals_equiv_scheduler_def idle_equiv_def)
 
 lemma scheduler_equiv_ready_queues_update'[simp]:
   "scheduler_equiv aag st (s\<lparr>ready_queues := x\<rparr>) = scheduler_equiv aag st s"
-  by (simp add: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
-                   idle_equiv_def)
-
+  by (simp add: scheduler_equiv_def domain_fields_equiv_def
+                globals_equiv_scheduler_def idle_equiv_def)
 
 lemma get_tcb_queue_reads_respects_scheduler[wp]:
   "reads_respects_scheduler aag l (K(pasDomainAbs aag rv \<inter> reads_scheduler aag l \<noteq> {}))
@@ -387,33 +447,13 @@ lemma ethread_get_reads_respects_scheduler[wp]:
   done
 
 lemma ethread_get_when_reads_respects_scheduler[wp]:
-  "reads_respects_scheduler aag l (K(b \<longrightarrow> pasObjectAbs aag t \<in> reads_scheduler aag l))
+  "reads_respects_scheduler aag l (K (b \<longrightarrow> pasObjectAbs aag t \<in> reads_scheduler aag l))
     (ethread_get_when b f t)"
   apply (simp add: ethread_get_when_def)
   apply (rule conjI; clarsimp)
-   using ethread_get_reads_respects_scheduler
+  using ethread_get_reads_respects_scheduler
    apply fastforce
   apply wp
-  done
-
-end
-
-lemma (in is_extended') globals_equiv[wp]:
-  "I (globals_equiv st)"
-  by (rule lift_inv,simp)
-
-lemma (in is_extended') globals_equiv_scheduler[wp]:
-  "I (globals_equiv_scheduler st)"
-  by (rule lift_inv,simp)
-
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-lemma tcb_domain_wellformed:
-  "\<lbrakk>pas_refined aag s; ekheap s t = Some a\<rbrakk> \<Longrightarrow> pasObjectAbs aag t \<in> pasDomainAbs aag (tcb_domain a)"
-  apply (clarsimp simp add: pas_refined_def tcb_domain_map_wellformed_aux_def)
-  apply (drule_tac x="(t,tcb_domain a)" in bspec)
-  apply (rule domtcbs)
-  apply force+
   done
 
 lemma reads_respects_scheduler_cases:
@@ -426,39 +466,24 @@ lemma reads_respects_scheduler_cases:
   shows "reads_respects_scheduler aag l Q (f t)"
   apply (insert b b' c c')
   apply (case_tac "pasObjectAbs aag t \<in> reads_scheduler aag l")
-  apply (fastforce intro: equiv_valid_guard_imp)+
+   apply (fastforce intro: equiv_valid_guard_imp)+
   done
-
-
-lemma silc_dom_equiv_trans_state[simp]:
-  "silc_dom_equiv aag st (trans_state f s) = silc_dom_equiv aag st s"
-  by (simp add: silc_dom_equiv_def equiv_for_def)
-
-end
-
-lemma (in is_extended') silc_dom_equiv[wp]:
-  "I (silc_dom_equiv aag st)"
-  by (rule lift_inv,simp)
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma tcb_action_reads_respects_scheduler[wp]:
   assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects_scheduler aag l (pas_refined aag) (tcb_sched_action f t)"
+  shows "reads_respects_scheduler aag l (pas_refined aag) (tcb_sched_action f t)"
   apply (rule reads_respects_scheduler_cases)
      apply (simp add: tcb_sched_action_def set_tcb_queue_def)
      apply wp
            apply (rule ev_modify[where P=\<top>])
-           apply (clarsimp simp add: scheduler_equiv_def domain_fields_equiv_def
-                            globals_equiv_scheduler_def)
+           apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def
+                                 globals_equiv_scheduler_def)
            apply (clarsimp simp: scheduler_affects_equiv_def states_equiv_for_def
-                                 equiv_for_def equiv_asids_def equiv_asid_def idle_equiv_def
-                                 )
+                                 equiv_for_def equiv_asids_def idle_equiv_def)
            apply metis
           apply wp+
     apply (clarsimp simp add: etcb_at_def split: option.splits)
-    apply (frule(1) tcb_domain_wellformed)
+    apply (frule (1) tcb_domain_wellformed)
     apply blast
    apply (simp add: tcb_sched_action_def set_tcb_queue_def)
    apply (rule reads_respects_scheduler_unobservable'[where P="pas_refined aag"])
@@ -467,135 +492,57 @@ lemma tcb_action_reads_respects_scheduler[wp]:
    apply wp
    apply (clarsimp simp: etcb_at_def split: option.splits)
    apply (clarsimp simp: scheduler_affects_equiv_def states_equiv_for_def
-                         equiv_for_def equiv_asids_def equiv_asid_def)
-   apply (frule(1) tcb_domain_wellformed)
+                         equiv_for_def equiv_asids_def)
+   apply (frule (1) tcb_domain_wellformed)
    apply (rule ext)
    apply (solves \<open>auto dest: domains_distinct[THEN pas_domains_distinct_inj]\<close>)
   apply assumption
   done
 
 lemma dmo_no_mem_globals_equiv_scheduler:
-  assumes a: "(\<And>P. invariant f (\<lambda>ms. P (underlying_memory ms)))"
-       and b: "(\<And>P. invariant f (\<lambda>ms. P (device_state ms)))"
-  shows "invariant (do_machine_op f) (globals_equiv_scheduler s)"
+  assumes a: "\<And>P. f \<lbrace>\<lambda>ms. P (underlying_memory ms)\<rbrace>"
+      and b: "\<And>P. f \<lbrace>\<lambda>ms. P (device_state ms)\<rbrace>"
+  shows "do_machine_op f \<lbrace>globals_equiv_scheduler s\<rbrace>"
   unfolding do_machine_op_def
   apply (rule hoare_pre)
   apply (wp | simp add: split_def)+
   apply clarsimp
-  apply (frule_tac P1 = "\<lambda>um. um = underlying_memory (machine_state sa)" in use_valid[OF _ a])
+  apply (frule_tac P4 = "\<lambda>um. um = underlying_memory (machine_state sa)" in use_valid[OF _ a])
    apply simp
-  apply (frule_tac P1 = "\<lambda>um. um = device_state (machine_state sa)" in use_valid[OF _ b])
+  apply (frule_tac P4 = "\<lambda>um. um = device_state (machine_state sa)" in use_valid[OF _ b])
    apply simp
   apply (fastforce simp: valid_def globals_equiv_scheduler_def idle_equiv_def)
   done
 
-lemma clearExMonitor_globals_equiv_scheduler[wp]:
-  "\<lbrace> globals_equiv_scheduler sta \<rbrace> do_machine_op clearExMonitor \<lbrace> \<lambda>_. globals_equiv_scheduler sta \<rbrace>"
-  unfolding clearExMonitor_def including no_pre
-  apply (wp dmo_no_mem_globals_equiv_scheduler)
-   apply simp
-  apply (simp add: simpler_modify_def valid_def)
-  done
+end
 
-lemma arch_switch_to_thread_globals_equiv_scheduler:
-  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace> arch_switch_to_thread thread
-       \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
-  unfolding arch_switch_to_thread_def storeWord_def
-  by (wpsimp wp: clearExMonitor_globals_equiv_scheduler dmo_wp modify_wp thread_get_wp'
-           | wp (once) globals_equiv_scheduler_inv'[where P="\<top>"])+
 
-lemma dmo_storeWord_reads_respects_scheduler[wp]:
-  "reads_respects_scheduler aag l \<top> (do_machine_op (storeWord rva rvb))"
-  apply (clarsimp simp add: do_machine_op_def bind_def gets_def get_def
-                    return_def select_f_def storeWord_def
-                    assert_def simpler_modify_def fail_def)
-  apply (fold simpler_modify_def)
-  apply (intro impI conjI)
-   apply (rule ev_modify)
-   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def
-                         globals_equiv_scheduler_def)
-   apply (clarsimp simp add: scheduler_affects_equiv_def states_equiv_for_def
-                    equiv_for_def equiv_asids_def equiv_asid_def
-                    scheduler_globals_frame_equiv_def silc_dom_equiv_def
-                    )
-  apply (simp add: equiv_valid_def2 equiv_valid_2_def)
-  done
+definition weak_scheduler_affects_equiv ::
+  "'a subject_label PAS  \<Rightarrow> ('a subject_label) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "weak_scheduler_affects_equiv aag l s s' \<equiv>
+     (states_equiv_for_labels aag (\<lambda>l'. l' \<in> reads_scheduler aag l) s s')"
 
-definition weak_scheduler_affects_equiv :: "'a subject_label PAS  \<Rightarrow> ('a subject_label) \<Rightarrow>
-                                            det_state \<Rightarrow> det_state \<Rightarrow> bool"
-where
-"weak_scheduler_affects_equiv aag l s s' \<equiv>
-  (states_equiv_for_labels aag (\<lambda>l'. l' \<in> reads_scheduler aag l) s s')"
-
-definition midstrength_scheduler_affects_equiv :: "'a subject_label PAS  \<Rightarrow> ('a subject_label) \<Rightarrow>
-                                                   det_state \<Rightarrow> det_state \<Rightarrow> bool"
-where
-"midstrength_scheduler_affects_equiv aag l s s' \<equiv>
-  (states_equiv_for_labels aag (\<lambda>l'. l' \<in> reads_scheduler aag l) s s') \<and>
-  (reads_scheduler_cur_domain aag l s \<or> reads_scheduler_cur_domain aag l s' \<longrightarrow>
-     work_units_completed s = work_units_completed s')"
-
-abbreviation strong_reads_respects_scheduler
-where
-"strong_reads_respects_scheduler aag l P f  \<equiv>
-   equiv_valid (scheduler_equiv aag) (weak_scheduler_affects_equiv aag l)
-               (scheduler_affects_equiv aag l) P f"
-
-abbreviation midstrength_reads_respects_scheduler
-where
-"midstrength_reads_respects_scheduler aag l P f  \<equiv>
-   equiv_valid (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
-               (scheduler_affects_equiv aag l) P f"
-
-abbreviation weak_reads_respects_scheduler
-where
-"weak_reads_respects_scheduler aag l P f  \<equiv>
-   equiv_valid (scheduler_equiv aag) (weak_scheduler_affects_equiv aag l)
-               (weak_scheduler_affects_equiv aag l) P f"
-
-lemma store_cur_thread_midstrength_reads_respects:
-  "equiv_valid (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
-           (scheduler_affects_equiv aag l) (invs and (\<lambda>s. t = idle_thread s))
-           (do x \<leftarrow> modify (cur_thread_update (\<lambda>_. t));
-               set_scheduler_action resume_cur_thread
-            od)"
-  apply (clarsimp simp add: do_machine_op_def bind_def gets_def get_def
-                    return_def select_f_def storeWord_def bind_def
-                    set_scheduler_action_def
-                    assert_def simpler_modify_def fail_def)
-  apply (fold simpler_modify_def)
-   apply (rule ev_modify)
-   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def
-                         globals_equiv_scheduler_def)
-   apply (clarsimp simp: scheduler_affects_equiv_def states_equiv_for_def
-                         equiv_for_def equiv_asids_def equiv_asid_def
-                         scheduler_globals_frame_equiv_def silc_dom_equiv_def
-                         weak_scheduler_affects_equiv_def midstrength_scheduler_affects_equiv_def
-                        idle_equiv_def)
-   done
+definition midstrength_scheduler_affects_equiv ::
+  "'a subject_label PAS  \<Rightarrow> ('a subject_label) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "midstrength_scheduler_affects_equiv aag l s s' \<equiv>
+     (states_equiv_for_labels aag (\<lambda>l'. l' \<in> reads_scheduler aag l) s s') \<and>
+     (reads_scheduler_cur_domain aag l s \<or> reads_scheduler_cur_domain aag l s'
+      \<longrightarrow> work_units_completed s = work_units_completed s')"
 
 lemma globals_frame_equiv_as_states_equiv:
   "scheduler_globals_frame_equiv st s =
-   states_equiv_for
-     (\<lambda>x. x \<in> scheduler_affects_globals_frame s) \<bottom> \<bottom> \<bottom>
-     (s\<lparr>machine_state := machine_state st, arch_state := arch_state st\<rparr>) s"
-  by (clarsimp simp add: states_equiv_for_def equiv_for_def
-                         scheduler_globals_frame_equiv_def
-                         equiv_asids_def)
+   states_equiv_for (\<lambda>x. x \<in> scheduler_affects_globals_frame s) \<bottom> \<bottom> \<bottom>
+                    (s\<lparr>machine_state := machine_state st, arch_state := arch_state st\<rparr>) s"
+  by (simp add: states_equiv_for_def equiv_for_def scheduler_globals_frame_equiv_def equiv_asids_def)
 
 lemma silc_dom_equiv_as_states_equiv:
   "silc_dom_equiv aag st s =
-   states_equiv_for
-     (\<lambda>x. pasObjectAbs aag x = SilcLabel) \<bottom> \<bottom> \<bottom>
-     (s\<lparr>kheap := kheap st\<rparr>) s"
-  apply (clarsimp simp add: states_equiv_for_def equiv_for_def
-                            silc_dom_equiv_def
-                            equiv_asids_def)
-  done
+   states_equiv_for (\<lambda>x. pasObjectAbs aag x = SilcLabel) \<bottom> \<bottom> \<bottom> (s\<lparr>kheap := kheap st\<rparr>) s"
+  by (simp add: states_equiv_for_def equiv_for_def silc_dom_equiv_def equiv_asids_def)
 
 lemma silc_dom_equiv_states_equiv_lift:
-  assumes a: "\<And>P Q R S st. \<lbrace>states_equiv_for P Q R S st\<rbrace> f \<lbrace>\<lambda>_. states_equiv_for P Q R S st\<rbrace>"
-  shows "\<lbrace>silc_dom_equiv aag st\<rbrace> f \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
+  assumes a: "\<And>P Q R S st. f \<lbrace>states_equiv_for P Q R S st\<rbrace>"
+  shows "f \<lbrace>silc_dom_equiv aag st\<rbrace>"
   apply (simp add: silc_dom_equiv_as_states_equiv[abs_def])
   apply (clarsimp simp add: valid_def)
   apply (frule use_valid[OF _ a])
@@ -603,175 +550,130 @@ lemma silc_dom_equiv_states_equiv_lift:
   apply (simp add: states_equiv_for_def equiv_for_def equiv_asids_def)
   done
 
-lemma scheduler_affects_equiv_unobservable:
-  assumes a: "\<And>P Q R S st. \<lbrace>states_equiv_for P Q R S st\<rbrace> f \<lbrace>\<lambda>_. states_equiv_for P Q R S st\<rbrace>"
-  assumes c: "\<And>P. \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> f \<lbrace>\<lambda>r s. P (cur_domain s)\<rbrace>"
-  assumes e: "\<And>P. \<lbrace>\<lambda>s. P (cur_thread s)\<rbrace> f \<lbrace>\<lambda>r s. P (cur_thread s)\<rbrace>"
-  assumes s: "\<And>P. \<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> f \<lbrace>\<lambda>r s. P (scheduler_action s)\<rbrace>"
-  assumes w: "\<And>P. \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace> f \<lbrace>\<lambda>r s. P (work_units_completed s)\<rbrace>"
-  assumes i: "\<And>P. \<lbrace>\<lambda>s. P (idle_thread s)\<rbrace> f \<lbrace>\<lambda>r s. P (idle_thread s)\<rbrace>"
-  assumes x:
-    "\<And>P. \<lbrace>\<lambda>s. P (exclusive_state (machine_state s))\<rbrace>
-            f
-          \<lbrace>\<lambda>r s. P (exclusive_state (machine_state s))\<rbrace>"
-  shows "\<lbrace>scheduler_affects_equiv aag l st\<rbrace>
-           f
-         \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
-  proof -
-  have d: "\<lbrace>scheduler_globals_frame_equiv st\<rbrace> f \<lbrace>\<lambda>_. scheduler_globals_frame_equiv st\<rbrace>"
-  apply (simp add: globals_frame_equiv_as_states_equiv[abs_def])
-  apply (clarsimp simp add: valid_def)
-  apply (frule use_valid[OF _ a])
-   apply assumption
-  apply (simp add: states_equiv_for_def equiv_for_def equiv_asids_def)
+
+context Scheduler_IF_1 begin
+
+abbreviation strong_reads_respects_scheduler where
+  "strong_reads_respects_scheduler aag l P f  \<equiv>
+     equiv_valid (scheduler_equiv aag) (weak_scheduler_affects_equiv aag l)
+                 (scheduler_affects_equiv aag l) P f"
+
+abbreviation midstrength_reads_respects_scheduler where
+  "midstrength_reads_respects_scheduler aag l P f  \<equiv>
+     equiv_valid (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+                 (scheduler_affects_equiv aag l) P f"
+
+abbreviation weak_reads_respects_scheduler where
+  "weak_reads_respects_scheduler aag l P f  \<equiv>
+     equiv_valid (scheduler_equiv aag) (weak_scheduler_affects_equiv aag l)
+                 (weak_scheduler_affects_equiv aag l) P f"
+
+lemma store_cur_thread_midstrength_reads_respects:
+  "equiv_valid (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+               (scheduler_affects_equiv aag l) (invs and (\<lambda>s. t = idle_thread s))
+               (do x \<leftarrow> modify (cur_thread_update (\<lambda>_. t));
+                   set_scheduler_action resume_cur_thread
+                od)"
+  apply (clarsimp simp: do_machine_op_def bind_def gets_def get_def return_def select_f_def
+                        set_scheduler_action_def assert_def simpler_modify_def fail_def)
+  apply (fold simpler_modify_def)
+  apply (rule ev_modify)
+  apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
+                        scheduler_affects_equiv_def states_equiv_for_def idle_equiv_def equiv_for_def
+                        equiv_asids_def scheduler_globals_frame_equiv_def silc_dom_equiv_def
+                        weak_scheduler_affects_equiv_def midstrength_scheduler_affects_equiv_def)
   done
+
+lemma scheduler_affects_equiv_unobservable:
+  assumes a: "\<And>P Q R S st. f \<lbrace>states_equiv_for P Q R S st\<rbrace>"
+  assumes c: "\<And>P. f \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  assumes e: "\<And>P. f \<lbrace>\<lambda>s. P (cur_thread s)\<rbrace>"
+  assumes s: "\<And>P. f \<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace>"
+  assumes w: "\<And>P. f \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace>"
+  assumes i: "\<And>P. f \<lbrace>\<lambda>s. P (idle_thread s)\<rbrace>"
+  assumes x: "f \<lbrace>arch_scheduler_affects_equiv st\<rbrace>"
+  shows "f \<lbrace>scheduler_affects_equiv aag l st\<rbrace>"
+proof -
+  have d: "\<lbrace>scheduler_globals_frame_equiv st\<rbrace> f \<lbrace>\<lambda>_. scheduler_globals_frame_equiv st\<rbrace>"
+    apply (simp add: globals_frame_equiv_as_states_equiv[abs_def])
+    apply (clarsimp simp add: valid_def)
+    apply (frule use_valid[OF _ a])
+     apply assumption
+    apply (simp add: states_equiv_for_def equiv_for_def equiv_asids_def)
+    done
   show ?thesis
     apply (simp add: scheduler_affects_equiv_def[abs_def])
     apply (rule hoare_pre)
      apply (wps c)
      apply (wp static_imp_wp a silc_dom_equiv_states_equiv_lift d e s w i x hoare_vcg_imp_lift)
     apply fastforce
-  done
+    done
 qed
 
 lemma midstrength_scheduler_affects_equiv_unobservable:
-  assumes a: "\<And>P Q R S st. \<lbrace>states_equiv_for P Q R S st\<rbrace> f \<lbrace>\<lambda>_. states_equiv_for P Q R S st\<rbrace>"
-  assumes w:
-    "\<And>P. \<lbrace>\<lambda>s. P (cur_domain s) (work_units_completed s)\<rbrace>
-            f
-         \<lbrace>\<lambda>r s. P (cur_domain s) (work_units_completed s)\<rbrace>"
-  shows "\<lbrace>midstrength_scheduler_affects_equiv aag l st\<rbrace>
-           f
-         \<lbrace>\<lambda>_. midstrength_scheduler_affects_equiv aag l st\<rbrace>"
-    apply (simp add: midstrength_scheduler_affects_equiv_def[abs_def])
-    apply (rule hoare_pre)
-     apply (wp a w silc_dom_equiv_states_equiv_lift)
-    apply clarsimp
-  done
-
-lemma dmo_mol_exclusive_state[wp]:
-  "invariant (do_machine_op (machine_op_lift mop)) (\<lambda>s. P (exclusive_state (machine_state s)))"
-  by(wp mol_exclusive_state dmo_wp
-    | simp add: split_def dmo_bind_valid writeTTBR0_def isb_def dsb_def )+
-
-crunch exclusive_state[wp]: set_vm_root "\<lambda>s. P (exclusive_state (machine_state s))"
-  (ignore: do_machine_op
-     simp: invalidateLocalTLB_ASID_def setHardwareASID_def set_current_pd_def dsb_def isb_def
-           writeTTBR0_def dmo_bind_valid crunch_simps)
-
-lemmas set_vm_root_scheduler_affects_equiv[wp] =
-        scheduler_affects_equiv_unobservable[OF set_vm_root_states_equiv_for
-                                                set_vm_root_exst _ _ _ set_vm_root_it
-                                                set_vm_root_exclusive_state]
-
-lemma set_vm_root_reads_respects_scheduler[wp]:
-  "reads_respects_scheduler aag l \<top> (set_vm_root thread)"
-  apply (rule reads_respects_scheduler_unobservable'[
-                             OF scheduler_equiv_lift'[OF globals_equiv_scheduler_inv']])
-  apply (wp silc_dom_equiv_states_equiv_lift set_vm_root_states_equiv_for | simp)+
+  assumes a: "\<And>P Q R S st. f \<lbrace>states_equiv_for P Q R S st\<rbrace>"
+  assumes w: "\<And>P. f \<lbrace>\<lambda>s. P (cur_domain s) (work_units_completed s)\<rbrace>"
+  shows "f \<lbrace>midstrength_scheduler_affects_equiv aag l st\<rbrace>"
+  apply (simp add: midstrength_scheduler_affects_equiv_def[abs_def])
+  apply (rule hoare_pre)
+   apply (wp a w silc_dom_equiv_states_equiv_lift)
+  apply clarsimp
   done
 
 lemma thread_get_reads_respects_scheduler[wp]:
-  "reads_respects_scheduler aag l (K(pasObjectAbs aag t \<in> reads_scheduler aag l)) (thread_get f t)"
+  "reads_respects_scheduler aag l (K (pasObjectAbs aag t \<in> reads_scheduler aag l)) (thread_get f t)"
   apply (rule gen_asm_ev)
   apply (simp add: thread_get_def)
-  apply wp
-  apply (clarsimp simp add: scheduler_affects_equiv_def states_equiv_for_def
-                            equiv_for_def get_tcb_def)
+  apply (wpsimp simp: scheduler_affects_equiv_def states_equiv_for_def equiv_for_def get_tcb_def)
   done
 
 crunch idle_thread[wp]: guarded_switch_to,schedule "\<lambda>(s :: det_state). P (idle_thread s)"
   (wp: crunch_wps simp: crunch_simps)
 
-lemma silc_dom_lift:
-  assumes a: "\<And>P. \<lbrace>\<lambda>s. P (kheap s)\<rbrace> f \<lbrace>\<lambda>r s. P (kheap s)\<rbrace>"
-         shows "\<lbrace>silc_dom_equiv aag st\<rbrace> f \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
-  apply (simp add: silc_dom_equiv_def equiv_for_def[abs_def])
-  apply (wp a)
-  done
-
-lemma dmo_silc_dom[wp]:
-  "\<lbrace>silc_dom_equiv aag st\<rbrace> do_machine_op mop \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
-  by (wp silc_dom_lift)
-
 crunch kheap[wp]: guarded_switch_to, schedule "\<lambda>s :: det_state. P (kheap s)"
   (wp: dxo_wp_weak crunch_wps simp: crunch_simps)
 
-lemma storeWord_irq_state_of_state[wp]:
-  "\<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace> do_machine_op (storeWord x y) \<lbrace>\<lambda>_ s. P (irq_state_of_state s)\<rbrace>"
-  apply (simp add: storeWord_def)
-  apply (wp dmo_wp modify_wp)
-  apply simp
-  done
+end
 
-lemma clearExMonitor_irq_state_of_state[wp]:
-  "\<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace> do_machine_op clearExMonitor \<lbrace>\<lambda>_ s. P (irq_state_of_state s)\<rbrace>"
-  by (wpsimp wp: dmo_wp irq_state_clearExMonitor)
 
-lemma clearExMonitor_scheduler_equiv[wp]:
-  "\<lbrace> scheduler_equiv aag st \<rbrace> do_machine_op clearExMonitor \<lbrace> \<lambda>_. scheduler_equiv aag st \<rbrace>"
-  by (rule scheduler_equiv_lift; wp)
+lemma silc_dom_lift:
+  assumes a: "\<And>P. f \<lbrace>\<lambda>s. P (kheap s)\<rbrace>"
+  shows "f \<lbrace>silc_dom_equiv aag st\<rbrace>"
+  by (wpsimp wp: a simp: silc_dom_equiv_def equiv_for_def[abs_def])
 
-lemma dmo_ev:
-  "(\<And>s s'. equiv_valid (\<lambda>ms ms'. I (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>))
-                   (\<lambda>ms ms'. A (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>))
-                   (\<lambda>ms ms'. B (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>))
-          (K (P s \<and> P s')) f)
-    \<Longrightarrow> equiv_valid I A B P (do_machine_op f)"
-  apply (clarsimp simp: do_machine_op_def bind_def equiv_valid_def2 equiv_valid_2_def gets_def
-                        get_def select_f_def modify_def put_def return_def split_def)
-  apply atomize
-  apply (erule_tac x=s in allE)
-  apply (erule_tac x=t in allE)
-  apply simp
-  apply (erule_tac x="machine_state s" in allE)
-  apply (erule_tac x="machine_state t" in allE)
-  apply fastforce
-  done
+lemma dmo_silc_dom[wp]:
+  "do_machine_op mop \<lbrace>silc_dom_equiv aag st\<rbrace>"
+  by (wp silc_dom_lift)
 
-lemma [wp]: "reads_respects_scheduler aag l (\<lambda>_. True) (do_machine_op clearExMonitor)"
-  apply (simp add: clearExMonitor_def)
-  apply (wp dmo_ev)
-  apply (rule ev_modify)
-  apply clarsimp
-  apply (rule conjI)
-   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
-                         silc_dom_equiv_def equiv_for_def)
-  apply (clarsimp simp: scheduler_affects_equiv_def states_equiv_for_def equiv_for_def
-                        equiv_asids_def equiv_asid_def scheduler_globals_frame_equiv_def
-              simp del: split_paired_All)
-  done
 
 definition asahi_scheduler_affects_equiv ::
-  "'a subject_label PAS \<Rightarrow> 'a subject_label \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool"
-  where
-    "asahi_scheduler_affects_equiv aag l s s' \<equiv>
-       states_equiv_for_labels aag (\<lambda>x. x \<in> reads_scheduler aag l) s s' \<and>
-       (reads_scheduler_cur_domain aag l s \<or> reads_scheduler_cur_domain aag l s' \<longrightarrow>
-          work_units_completed s = work_units_completed s' \<and>
-          scheduler_globals_frame_equiv s s')"
+  "'a subject_label PAS \<Rightarrow> 'a subject_label \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool" where
+  "asahi_scheduler_affects_equiv aag l s s' \<equiv>
+     states_equiv_for_labels aag (\<lambda>x. x \<in> reads_scheduler aag l) s s' \<and>
+     (reads_scheduler_cur_domain aag l s \<or> reads_scheduler_cur_domain aag l s'
+      \<longrightarrow> work_units_completed s = work_units_completed s' \<and> scheduler_globals_frame_equiv s s')"
+
 
 lemma asahi_scheduler_affects_equiv_unobservable:
-  assumes a: "\<And>P Q R S X st. \<lbrace>states_equiv_for P Q R S st\<rbrace> f \<lbrace>\<lambda>_. states_equiv_for P Q R S st\<rbrace>"
-  assumes c: "\<And>P. \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> f \<lbrace>\<lambda>r s. P (cur_domain s)\<rbrace>"
-  assumes w: "\<And>P. \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace> f \<lbrace>\<lambda>r s. P (work_units_completed s)\<rbrace>"
-  shows "\<lbrace>asahi_scheduler_affects_equiv aag l st\<rbrace> f
-         \<lbrace>\<lambda>_. asahi_scheduler_affects_equiv aag l st\<rbrace>"
-  proof -
+  assumes a: "\<And>P Q R S st. f \<lbrace>states_equiv_for P Q R S st\<rbrace>"
+  assumes c: "\<And>P. f \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  assumes w: "\<And>P. f \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace>"
+  shows "f \<lbrace>asahi_scheduler_affects_equiv aag l st\<rbrace>"
+proof -
   have d: "\<lbrace>scheduler_globals_frame_equiv st\<rbrace> f \<lbrace>\<lambda>_. scheduler_globals_frame_equiv st\<rbrace>"
-  apply (simp add: globals_frame_equiv_as_states_equiv[abs_def])
-  apply (clarsimp simp add: valid_def)
-  apply (frule use_valid[OF _ a])
-   apply assumption
-  apply (simp add: states_equiv_for_def equiv_for_def equiv_asids_def)
-  done
+    apply (simp add: globals_frame_equiv_as_states_equiv[abs_def])
+    apply (clarsimp simp add: valid_def)
+    apply (frule use_valid[OF _ a])
+     apply assumption
+    apply (simp add: states_equiv_for_def equiv_for_def equiv_asids_def)
+    done
   show ?thesis
     apply (simp add: asahi_scheduler_affects_equiv_def[abs_def])
     apply (rule hoare_pre)
      apply (wps c)
      apply (wp static_imp_wp a silc_dom_equiv_states_equiv_lift d w)
     apply clarsimp
-  done
+    done
 qed
 
 lemma asahi_scheduler_affects_equiv_sym[elim]:
@@ -780,55 +682,58 @@ lemma asahi_scheduler_affects_equiv_sym[elim]:
   apply (auto simp: scheduler_globals_frame_equiv_sym states_equiv_for_sym silc_dom_equiv_sym)
   done
 
+lemma midstrength_weak[intro]:
+  "midstrength_scheduler_affects_equiv aag l s s' \<Longrightarrow> weak_scheduler_affects_equiv aag l s s'"
+  by (auto simp: midstrength_scheduler_affects_equiv_def weak_scheduler_affects_equiv_def)
+
+
+context Scheduler_IF_1 begin
+
 lemma asahi_scheduler_affects_equiv_trans[elim]:
-  "\<lbrakk>asahi_scheduler_affects_equiv aag l s s'; scheduler_equiv aag s s';
-    asahi_scheduler_affects_equiv aag l s' s''; scheduler_equiv aag s' s''\<rbrakk>
-   \<Longrightarrow> asahi_scheduler_affects_equiv aag l s s''"
-   apply (simp add: asahi_scheduler_affects_equiv_def scheduler_equiv_trans[where s'=s'])+
+  "\<lbrakk> asahi_scheduler_affects_equiv aag l s s'; scheduler_equiv aag s s';
+     asahi_scheduler_affects_equiv aag l s' s''; scheduler_equiv aag s' s'' \<rbrakk>
+     \<Longrightarrow> asahi_scheduler_affects_equiv aag l s s''"
+  apply (simp add: asahi_scheduler_affects_equiv_def scheduler_equiv_trans[where s'=s'])+
   apply clarify
   apply (rule conjI)
    apply (rule states_equiv_for_trans[where t=s'])
     apply simp+
-  apply (force simp: scheduler_globals_frame_equiv_trans[where s'=s'] scheduler_equiv_def
-                     domain_fields_equiv_def)
+  apply (force simp: scheduler_globals_frame_equiv_trans[where s'=s']
+                     scheduler_equiv_def domain_fields_equiv_def)
   done
+
 
 definition asahi_ex_scheduler_affects_equiv ::
-  "'a subject_label PAS \<Rightarrow> 'a subject_label \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool"
-  where
-    "asahi_ex_scheduler_affects_equiv aag l s s' \<equiv>
-       states_equiv_for_labels aag (\<lambda>x. x \<in> reads_scheduler aag l) s s' \<and>
-       (reads_scheduler_cur_domain aag l s \<or> reads_scheduler_cur_domain aag l s' \<longrightarrow>
-          work_units_completed s = work_units_completed s' \<and>
+  "'a subject_label PAS \<Rightarrow> 'a subject_label \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "asahi_ex_scheduler_affects_equiv aag l s s' \<equiv>
+     states_equiv_for_labels aag (\<lambda>x. x \<in> reads_scheduler aag l) s s' \<and>
+     (reads_scheduler_cur_domain aag l s \<or> reads_scheduler_cur_domain aag l s'
+      \<longrightarrow> work_units_completed s = work_units_completed s' \<and>
           scheduler_globals_frame_equiv s s' \<and>
-          exclusive_state_equiv s s')"
+          arch_scheduler_affects_equiv s s')"
+
 
 lemma asahi_ex_scheduler_affects_equiv_unobservable:
-  assumes a: "\<And>P Q R S X st. \<lbrace>states_equiv_for P Q R S st\<rbrace> f \<lbrace>\<lambda>_. states_equiv_for P Q R S st\<rbrace>"
-  assumes c: "\<And>P. \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> f \<lbrace>\<lambda>r s. P (cur_domain s)\<rbrace>"
-  assumes w: "\<And>P. \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace> f \<lbrace>\<lambda>r s. P (work_units_completed s)\<rbrace>"
-  assumes x:
-    "\<And>P. \<lbrace>\<lambda>s. P (exclusive_state (machine_state s))\<rbrace>
-            f
-         \<lbrace>\<lambda>r s. P (exclusive_state (machine_state s))\<rbrace>"
-  shows "\<lbrace>asahi_ex_scheduler_affects_equiv aag l st\<rbrace>
-           f
-         \<lbrace>\<lambda>_. asahi_ex_scheduler_affects_equiv aag l st\<rbrace>"
-  proof -
-  have d: "\<lbrace>scheduler_globals_frame_equiv st\<rbrace> f \<lbrace>\<lambda>_. scheduler_globals_frame_equiv st\<rbrace>"
-  apply (simp add: globals_frame_equiv_as_states_equiv[abs_def])
-  apply (clarsimp simp add: valid_def)
-  apply (frule use_valid[OF _ a])
-   apply assumption
-  apply (simp add: states_equiv_for_def equiv_for_def equiv_asids_def)
-  done
+  assumes a: "\<And>P Q R S st. f \<lbrace>states_equiv_for P Q R S st\<rbrace>"
+  assumes c: "\<And>P. f \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  assumes w: "\<And>P. f \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace>"
+  assumes x: "f \<lbrace>arch_scheduler_affects_equiv st\<rbrace>"
+  shows "f \<lbrace>asahi_ex_scheduler_affects_equiv aag l st\<rbrace>"
+proof -
+  have d: "f \<lbrace>scheduler_globals_frame_equiv st\<rbrace>"
+    apply (simp add: globals_frame_equiv_as_states_equiv[abs_def])
+    apply (clarsimp simp add: valid_def)
+    apply (frule use_valid[OF _ a])
+     apply assumption
+    apply (simp add: states_equiv_for_def equiv_for_def equiv_asids_def)
+    done
   show ?thesis
     apply (simp add: asahi_ex_scheduler_affects_equiv_def[abs_def])
     apply (rule hoare_pre)
      apply (wps c)
-     apply (wp static_imp_wp a silc_dom_equiv_states_equiv_lift d w x)
+     apply (wp static_imp_wp a silc_dom_equiv_states_equiv_lift d w x hoare_vcg_imp_lift')
     apply clarsimp
-  done
+    done
 qed
 
 lemma asahi_ex_scheduler_affects_equiv_sym[elim]:
@@ -838,33 +743,17 @@ lemma asahi_ex_scheduler_affects_equiv_sym[elim]:
   done
 
 lemma asahi_ex_scheduler_affects_equiv_trans[elim]:
-  "\<lbrakk>asahi_ex_scheduler_affects_equiv aag l s s'; scheduler_equiv aag s s';
-    asahi_ex_scheduler_affects_equiv aag l s' s''; scheduler_equiv aag s' s''\<rbrakk>
-    \<Longrightarrow> asahi_ex_scheduler_affects_equiv aag l s s''"
-   apply (simp add: asahi_ex_scheduler_affects_equiv_def scheduler_equiv_trans[where s'=s'])+
+  "\<lbrakk> asahi_ex_scheduler_affects_equiv aag l s s'; scheduler_equiv aag s s';
+     asahi_ex_scheduler_affects_equiv aag l s' s''; scheduler_equiv aag s' s'' \<rbrakk>
+     \<Longrightarrow> asahi_ex_scheduler_affects_equiv aag l s s''"
+  apply (simp add: asahi_ex_scheduler_affects_equiv_def scheduler_equiv_trans[where s'=s'])+
   apply clarify
   apply (rule conjI)
    apply (rule states_equiv_for_trans[where t=s'])
     apply simp+
-  apply (force simp: scheduler_globals_frame_equiv_trans[where s'=s'] scheduler_equiv_def
-                     domain_fields_equiv_def)
-  done
-
-lemma ev_asahi_to_asahi_ex_dmo_clearExMonitor:
-  "equiv_valid (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
-               (asahi_ex_scheduler_affects_equiv aag l)
-   \<top> (do_machine_op clearExMonitor)"
-  apply (simp add: clearExMonitor_def)
-  apply (wp dmo_ev)
-  apply (rule ev_modify)
-  apply clarsimp
-  apply (rule conjI)
-   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
-                         silc_dom_equiv_def equiv_for_def)
-  apply (clarsimp simp: midstrength_scheduler_affects_equiv_def asahi_scheduler_affects_equiv_def
-                        asahi_ex_scheduler_affects_equiv_def states_equiv_for_def equiv_for_def
-                        equiv_asids_def equiv_asid_def scheduler_globals_frame_equiv_def
-              simp del: split_paired_All)
+  apply (auto intro: arch_scheduler_affects_equiv_trans
+               simp: scheduler_globals_frame_equiv_trans[where s'=s']
+                     scheduler_equiv_def domain_fields_equiv_def)
   done
 
 lemma ev_asahi_ex_to_full_fragement:
@@ -879,73 +768,27 @@ lemma ev_asahi_ex_to_full_fragement:
   apply (rule ev_modify)
   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def states_equiv_for_def
                         globals_equiv_scheduler_def scheduler_affects_equiv_def
-                        equiv_for_def equiv_asids_def equiv_asid_def
+                        equiv_for_def equiv_asids_def
                         scheduler_globals_frame_equiv_def silc_dom_equiv_def
                         weak_scheduler_affects_equiv_def
                         asahi_ex_scheduler_affects_equiv_def idle_equiv_def)
-   done
-
-lemma store_cur_thread_fragment_midstrength_reads_respects:
-  "equiv_valid (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
-           (scheduler_affects_equiv aag l) invs
-           (do y \<leftarrow> do_machine_op clearExMonitor;
-               x \<leftarrow> modify (cur_thread_update (\<lambda>_. t));
-               set_scheduler_action resume_cur_thread
-            od)"
-  apply (rule equiv_valid_guard_imp)
-  apply (rule bind_ev_general[OF ev_asahi_ex_to_full_fragement])
-  apply (rule ev_asahi_to_asahi_ex_dmo_clearExMonitor)
-  apply wp
-  apply simp
   done
-(*******************************)
-
-lemma arch_switch_to_thread_globals_equiv_scheduler':
-  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
-        set_vm_root t
-       \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
-  by (rule globals_equiv_scheduler_inv', wpsimp)
-
-lemma arch_switch_to_thread_reads_respects_scheduler[wp]:
-  "reads_respects_scheduler aag l ((\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)) and
-                                    invs)
-                            (arch_switch_to_thread t)"
-  apply (rule reads_respects_scheduler_cases)
-     apply (simp add: arch_switch_to_thread_def)
-     apply wp
-    apply (clarsimp simp: scheduler_equiv_def globals_equiv_scheduler_def)
-   apply (simp add: arch_switch_to_thread_def)
-   apply wp
-  apply simp
-  done
-
-lemma arch_switch_to_thread_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace>
-    arch_switch_to_thread t
-  \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
-  unfolding arch_switch_to_thread_def
-  by (wp do_machine_op_pas_refined | simp)+
-
 
 lemma cur_thread_update_idle_reads_respects_scheduler:
-  "reads_respects_scheduler aag l (\<lambda>s. t = idle_thread s)
-        (modify (cur_thread_update (\<lambda>_. t)))"
+  "reads_respects_scheduler aag l (\<lambda>s. t = idle_thread s) (modify (cur_thread_update (\<lambda>_. t)))"
   apply (rule ev_modify)
   apply (clarsimp simp add: scheduler_affects_equiv_def
                    scheduler_equiv_def domain_fields_equiv_def
                    globals_equiv_scheduler_def states_equiv_for_def
-                   equiv_for_def equiv_asids_def equiv_asid_def
+                   equiv_for_def equiv_asids_def
                    scheduler_globals_frame_equiv_def idle_equiv_def)
   done
 
 lemma strong_cur_domain_unobservable:
-  "reads_respects_scheduler aag l
-             (P and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)) f
-   \<Longrightarrow> strong_reads_respects_scheduler aag l
-             (P and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)) f"
-  apply (clarsimp simp add: equiv_valid_def2 equiv_valid_2_def
-                            scheduler_equiv_def domain_fields_equiv_def
-                            scheduler_affects_equiv_def weak_scheduler_affects_equiv_def)
+  "reads_respects_scheduler aag l (P and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)) f
+   \<Longrightarrow> strong_reads_respects_scheduler aag l (P and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)) f"
+  apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def scheduler_affects_equiv_def
+                        equiv_valid_def2 equiv_valid_2_def weak_scheduler_affects_equiv_def)
   apply (drule_tac x=s in spec)
   apply (drule_tac x=t in spec)
   apply clarsimp
@@ -954,13 +797,11 @@ lemma strong_cur_domain_unobservable:
   done
 
 lemma midstrength_cur_domain_unobservable:
-  "reads_respects_scheduler aag l
-         (P and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)) f
+  "reads_respects_scheduler aag l (P and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)) f
    \<Longrightarrow> midstrength_reads_respects_scheduler aag l
          (P and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)) f"
-  apply (clarsimp simp add: equiv_valid_def2 equiv_valid_2_def
-                            scheduler_equiv_def domain_fields_equiv_def
-                            scheduler_affects_equiv_def midstrength_scheduler_affects_equiv_def)
+  apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def scheduler_affects_equiv_def
+                        equiv_valid_def2 equiv_valid_2_def  midstrength_scheduler_affects_equiv_def)
   apply (drule_tac x=s in spec)
   apply (drule_tac x=t in spec)
   apply clarsimp
@@ -968,62 +809,42 @@ lemma midstrength_cur_domain_unobservable:
   apply (drule_tac x="(aa,ba)" in bspec,clarsimp+)
   done
 
-
-lemma equiv_valid_get_assert:
-  "equiv_valid I A B P f \<Longrightarrow>
-   equiv_valid I A B P (get >>= (\<lambda> s. assert (g s) >>= (\<lambda> y. f)))"
-  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def bind_def get_def
-                        assert_def return_def fail_def)
-  apply fastforce
-  done
-
-
-
 lemma midstrength_reads_respects_scheduler_cases:
   assumes domains_distinct: "pas_domains_distinct aag"
-  assumes b:
-    "pasObjectAbs aag t \<in> reads_scheduler aag l
-     \<Longrightarrow> midstrength_reads_respects_scheduler aag l P' (f t)"
+  assumes b: "pasObjectAbs aag t \<in> reads_scheduler aag l
+              \<Longrightarrow> midstrength_reads_respects_scheduler aag l P' (f t)"
   assumes b': "\<And>s. Q s \<Longrightarrow> pasObjectAbs aag t \<in> reads_scheduler aag l \<Longrightarrow> P' s"
-  assumes c:
-    "pasObjectAbs aag t \<notin> reads_scheduler aag l
-     \<Longrightarrow> reads_respects_scheduler aag l P'' (f t)"
+  assumes c: "pasObjectAbs aag t \<notin> reads_scheduler aag l
+              \<Longrightarrow> reads_respects_scheduler aag l P'' (f t)"
   assumes c': "\<And>s. Q s \<Longrightarrow> pasObjectAbs aag t \<notin> reads_scheduler aag l \<Longrightarrow> P'' s"
   assumes d: "\<And>s. Q s \<Longrightarrow> pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)"
   shows "midstrength_reads_respects_scheduler aag l Q (f t)"
   apply (case_tac "pasObjectAbs aag t \<in> reads_scheduler aag l")
    apply (rule equiv_valid_guard_imp)
     apply (rule b)
-     apply simp+
+    apply simp+
    apply (rule b')
-     apply simp+
+    apply simp+
   apply (rule equiv_valid_guard_imp)
    apply (rule midstrength_cur_domain_unobservable)
    apply (rule equiv_valid_guard_imp)
     apply (rule c)
-     apply simp+
+    apply simp+
    apply fastforce
   apply clarsimp
   apply (rule conjI)
    apply (rule c')
-     apply simp+
+    apply simp+
   apply (fastforce dest: d domains_distinct[THEN pas_domains_distinct_inj])
   done
 
 lemma thread_get_weak_reads_respects_scheduler[wp]:
-  "weak_reads_respects_scheduler aag l
-     (K (pasObjectAbs aag t \<in> reads_scheduler aag l))
-     (thread_get f t)"
+  "weak_reads_respects_scheduler aag l (K (pasObjectAbs aag t \<in> reads_scheduler aag l))
+                                 (thread_get f t)"
   apply (rule gen_asm_ev)
   apply (simp add: thread_get_def)
   apply wp
-  apply (clarsimp simp add: weak_scheduler_affects_equiv_def states_equiv_for_def
-                            equiv_for_def get_tcb_def)
-  done
-
-lemma midstrength_weak[intro]:
-  "midstrength_scheduler_affects_equiv aag l s s' \<Longrightarrow> weak_scheduler_affects_equiv aag l s s'"
-  apply(auto simp: midstrength_scheduler_affects_equiv_def weak_scheduler_affects_equiv_def)
+  apply (simp add: weak_scheduler_affects_equiv_def states_equiv_for_def equiv_for_def get_tcb_def)
   done
 
 lemma weak_reads_respects_scheduler_to_midstrength:
@@ -1031,29 +852,58 @@ lemma weak_reads_respects_scheduler_to_midstrength:
   assumes i: "\<And>P. \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. P\<rbrace>"
   shows "equiv_valid_inv (scheduler_equiv aag)
         (midstrength_scheduler_affects_equiv aag l) P f"
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
-  apply(rule conjI)
-   apply(insert w)[1]
-   apply(fastforce simp: equiv_valid_def2 equiv_valid_2_def)
-  apply(blast dest: state_unchanged[OF i])
-  done
-
-lemma weak_scheduler_affects_equiv_trans[elim]:
-  "\<lbrakk>weak_scheduler_affects_equiv aag l s s'; weak_scheduler_affects_equiv aag l s' s''\<rbrakk>
-    \<Longrightarrow> weak_scheduler_affects_equiv aag l s s''"
-  apply (simp add: weak_scheduler_affects_equiv_def)
-  apply (fastforce intro: states_equiv_for_trans)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (rule conjI)
+   apply (insert w)[1]
+   apply (fastforce simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (blast dest: state_unchanged[OF i])
   done
 
 lemma midstrength_scheduler_affects_equiv_trans[elim]:
-  "\<lbrakk>scheduler_equiv aag s s'; midstrength_scheduler_affects_equiv aag l s s';
-    scheduler_equiv aag s' s''; midstrength_scheduler_affects_equiv aag l s' s''\<rbrakk>
-    \<Longrightarrow> midstrength_scheduler_affects_equiv aag l s s''"
-  apply (simp add: midstrength_scheduler_affects_equiv_def scheduler_equiv_def
-                   domain_fields_equiv_def)
+  "\<lbrakk> scheduler_equiv aag s s'; midstrength_scheduler_affects_equiv aag l s s';
+     scheduler_equiv aag s' s''; midstrength_scheduler_affects_equiv aag l s' s'' \<rbrakk>
+     \<Longrightarrow> midstrength_scheduler_affects_equiv aag l s s''"
+  apply (simp add: midstrength_scheduler_affects_equiv_def
+                   scheduler_equiv_def domain_fields_equiv_def)
   apply (fastforce intro: states_equiv_for_trans)
   done
 
+lemma cur_thread_update_not_subject_reads_respects_scheduler:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows
+    "reads_respects_scheduler aag l (\<lambda>s. pasObjectAbs aag t \<notin> reads_scheduler aag l \<and>
+                                         pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s))
+                              (modify (cur_thread_update (\<lambda>_. t)))"
+  apply (rule ev_modify)
+  apply (clarsimp simp: scheduler_affects_equiv_def scheduler_equiv_def domain_fields_equiv_def
+                        globals_equiv_scheduler_def states_equiv_for_def equiv_for_def
+                        equiv_asids_def scheduler_globals_frame_equiv_def idle_equiv_def)
+  apply (blast dest: domains_distinct[THEN pas_domains_distinct_inj])
+  done
+
+lemma gets_evrv':
+  "equiv_valid_rv I A B R (K (\<forall>s t. I s t \<and> A s t  \<longrightarrow> R (f s) (f t) \<and> B s t)) (gets f)"
+  apply (auto simp: equiv_valid_2_def in_monad)
+  done
+
+lemma gets_ev_no_inv:
+  shows "equiv_valid I A B (\<lambda> s. \<forall>s t. I s t \<and> A s t  \<longrightarrow> f s = f t \<and> B s t) (gets f)"
+  apply (simp add: equiv_valid_def2)
+  apply (auto intro: equiv_valid_rv_guard_imp[OF gets_evrv'])
+  done
+
+lemmas reads_respects_scheduler_unobservable =
+  reads_respects_scheduler_unobservable'[where P="\<top>",simplified]
+
+end
+
+
+lemma weak_scheduler_affects_equiv_trans[elim]:
+  "\<lbrakk> weak_scheduler_affects_equiv aag l s s'; weak_scheduler_affects_equiv aag l s' s'' \<rbrakk>
+     \<Longrightarrow> weak_scheduler_affects_equiv aag l s s''"
+  apply (simp add: weak_scheduler_affects_equiv_def)
+  apply (fastforce intro: states_equiv_for_trans)
+  done
 
 lemma weak_scheduler_affects_equiv_sym[elim]:
   "weak_scheduler_affects_equiv aag l s s' \<Longrightarrow> weak_scheduler_affects_equiv aag l s' s"
@@ -1070,21 +920,17 @@ lemma midstrength_scheduler_affects_equiv_sym[elim]:
 
 lemma ethread_get_oblivious_cur_thread:
   "oblivious (cur_thread_update f) (ethread_get a b)"
-  apply (simp add: ethread_get_def gets_the_def)
-  apply (wp oblivious_bind | simp add: oblivious_gets get_etcb_def)+
-  done
+  by (wpsimp wp: oblivious_bind simp: ethread_get_def gets_the_def get_etcb_def)
 
 lemma ethread_get_oblivious_schact:
   "oblivious (scheduler_action_update f) (ethread_get a b)"
-  apply (simp add: ethread_get_def gets_the_def)
-  apply (wp oblivious_bind | simp add: oblivious_gets get_etcb_def)+
-  done
+  by (wpsimp wp: oblivious_bind simp: ethread_get_def gets_the_def get_etcb_def)
 
 lemma tcb_action_oblivious_cur_thread:
   "oblivious (cur_thread_update a) (tcb_sched_action f t)"
    apply (simp add: tcb_sched_action_def)
    apply (wp oblivious_bind ethread_get_oblivious_cur_thread
-         | clarsimp simp add: get_tcb_queue_def set_tcb_queue_def)+
+          | clarsimp simp: get_tcb_queue_def set_tcb_queue_def)+
    apply (fastforce intro: state.equality det_ext.equality)
    done
 
@@ -1092,70 +938,18 @@ lemma tcb_action_oblivious_schact:
   "oblivious (scheduler_action_update a) (tcb_sched_action f t)"
    apply (simp add: tcb_sched_action_def)
    apply (wp oblivious_bind ethread_get_oblivious_schact
-         | clarsimp simp add: get_tcb_queue_def set_tcb_queue_def)+
+          | clarsimp simp: get_tcb_queue_def set_tcb_queue_def)+
    apply (fastforce intro: state.equality det_ext.equality)
    done
 
-lemma cur_thread_update_not_subject_reads_respects_scheduler:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects_scheduler aag l (\<lambda>s. pasObjectAbs aag t \<notin> reads_scheduler aag l \<and>
-                                       pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s))
-        (modify (cur_thread_update (\<lambda>_. t)))"
-  apply (rule ev_modify)
-  apply (clarsimp simp add: scheduler_affects_equiv_def
-                   scheduler_equiv_def domain_fields_equiv_def
-                   globals_equiv_scheduler_def states_equiv_for_def
-                   equiv_for_def equiv_asids_def equiv_asid_def
-                   scheduler_globals_frame_equiv_def idle_equiv_def)
-  apply (blast dest: domains_distinct[THEN pas_domains_distinct_inj])
-  done
-
-lemma switch_to_thread_midstrength_reads_respects_scheduler[wp]:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "midstrength_reads_respects_scheduler aag l
-              (invs and pas_refined aag and
-                 (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
-              (switch_to_thread t >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
-  apply (simp add: switch_to_thread_def)
-  apply (subst oblivious_modify_swap[symmetric, OF tcb_action_oblivious_cur_thread])
-  apply (simp add: bind_assoc)
-  apply (simp add: set_scheduler_action_def)
-  apply (subst oblivious_modify_swap[symmetric, OF tcb_action_oblivious_schact])
-  apply (rule equiv_valid_get_assert)
-  apply (rule equiv_valid_guard_imp)
-   apply (simp add: bind_assoc[symmetric])
-   apply (rule bind_ev_general)
-     apply (rule tcb_action_reads_respects_scheduler[OF domains_distinct])
-    apply (simp add: bind_assoc)
-    apply (rule midstrength_reads_respects_scheduler_cases[
-                     where Q="(invs and pas_refined aag and
-                                   (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))",
-                     OF domains_distinct])
-        apply (simp add: arch_switch_to_thread_def bind_assoc)
-        apply (rule bind_ev_general)
-              apply (fold set_scheduler_action_def)
-              apply (rule store_cur_thread_fragment_midstrength_reads_respects)
-         apply (rule_tac P="\<top>" and P'="\<top>" in equiv_valid_inv_unobservable)
-             apply (rule hoare_pre)
-              apply (rule scheduler_equiv_lift'[where P=\<top>])
-                   apply (wp globals_equiv_scheduler_inv silc_dom_lift | simp)+
-            apply (wp midstrength_scheduler_affects_equiv_unobservable set_vm_root_states_equiv_for
-                  | simp)+
-           apply (wp cur_thread_update_not_subject_reads_respects_scheduler | simp | fastforce)+
-  done
-
-lemma switch_to_thread_globals_equiv_scheduler[wp]:
-  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace> switch_to_thread thread
-       \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
-  apply (simp add: switch_to_thread_def)
-  apply (wp dxo_wp_weak arch_switch_to_thread_globals_equiv_scheduler | simp)+
-  done
-
+lemma equiv_valid_get_assert:
+  "equiv_valid I A B P f
+   \<Longrightarrow> equiv_valid I A B P (get >>= (\<lambda> s. assert (g s) >>= (\<lambda>y. f)))"
+  by (fastforce simp: equiv_valid_def2 equiv_valid_2_def bind_def
+                      get_def assert_def return_def fail_def)
 
 lemma ev_irrelevant_bind:
-  assumes inv: "\<And> P. \<lbrace> P \<rbrace> f \<lbrace>\<lambda>_. P \<rbrace>"
+  assumes inv: "\<And>P. f \<lbrace>P\<rbrace>"
   assumes ev: "equiv_valid I A B P g"
   shows "equiv_valid I A B P (do y \<leftarrow> f; g od)"
   proof -
@@ -1173,100 +967,167 @@ lemma ev_irrelevant_bind:
   done
 qed
 
-lemma guarded_switch_to_thread_midstrength_reads_respects_scheduler[wp]:
+
+locale Scheduler_IF_is_extended' = is_extended' + Scheduler_IF_1
+begin
+
+lemma globals_equiv_scheduler[wp]:
+  "I (globals_equiv_scheduler st)"
+  by (rule lift_inv, simp)
+
+end
+
+sublocale Scheduler_IF_1 \<subseteq> tcb_sched_action_extended:
+  Scheduler_IF_is_extended' "tcb_sched_action a t" ..
+sublocale Scheduler_IF_1 \<subseteq> set_scheduler_action_extended:
+  Scheduler_IF_is_extended' "set_scheduler_action a" ..
+sublocale Scheduler_IF_1 \<subseteq> next_domain_extended:
+  Scheduler_IF_is_extended' "next_domain" ..
+sublocale Scheduler_IF_1 \<subseteq> ethread_set_extended:
+  Scheduler_IF_is_extended' "ethread_set f t" ..
+sublocale Scheduler_IF_1 \<subseteq> reschedule_required_extended:
+  Scheduler_IF_is_extended' "reschedule_required" ..
+
+
+locale Scheduler_IF_2 = Scheduler_IF_1 +
+  fixes aag :: "'a subject_label PAS"
+  assumes arch_switch_to_thread_globals_equiv_scheduler:
+    "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
+     arch_switch_to_thread thread
+     \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
+  and arch_switch_to_idle_thread_globals_equiv_scheduler[wp]:
+    "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
+     arch_switch_to_idle_thread
+     \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
+  and arch_switch_to_thread_midstrength_reads_respects_scheduler[wp]:
+    "pas_domains_distinct aag
+     \<Longrightarrow> midstrength_reads_respects_scheduler aag l
+           (invs and pas_refined aag and (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
+           (do _ <- arch_switch_to_thread t;
+               _ <- modify (cur_thread_update (\<lambda>_. t));
+               modify (scheduler_action_update (\<lambda>_. resume_cur_thread))
+            od)"
+  and globals_equiv_scheduler_inv':
+    "(\<And>st. \<lbrace>P and globals_equiv st\<rbrace> (f :: (det_state, unit) nondet_monad) \<lbrace>\<lambda>_. globals_equiv st\<rbrace>)
+     \<Longrightarrow> \<lbrace>P and globals_equiv_scheduler s\<rbrace> f \<lbrace>\<lambda>_. globals_equiv_scheduler s\<rbrace>"
+  and arch_switch_to_idle_thread_unobservable:
+    "\<lbrace>(\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l = {}) and
+      scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and invs\<rbrace>
+     arch_switch_to_idle_thread
+     \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
+  and arch_switch_to_thread_unobservable:
+    "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
+      scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and invs\<rbrace>
+     arch_switch_to_thread t
+     \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
+  and next_domain_midstrength_equiv_scheduler:
+    "equiv_valid (scheduler_equiv aag) (weak_scheduler_affects_equiv aag l)
+                 (midstrength_scheduler_affects_equiv aag l) \<top> next_domain"
+  and dmo_resetTimer_reads_respects_scheduler:
+    "reads_respects_scheduler aag l \<top> (do_machine_op resetTimer)"
+  and ackInterrupt_reads_respects_scheduler:
+    "reads_respects_scheduler aag l \<top> (do_machine_op (ackInterrupt irq))"
+  and thread_set_scheduler_affects_equiv[wp]:
+    "\<lbrace>(\<lambda>s. x \<noteq> idle_thread s \<longrightarrow> pasObjectAbs aag x \<notin> reads_scheduler aag l) and
+      (\<lambda>s. x = idle_thread s \<longrightarrow> tc = idle_context s) and scheduler_affects_equiv aag l st\<rbrace>
+     thread_set (tcb_arch_update (arch_tcb_context_set tc)) x
+     \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
+  and set_object_reads_respects_scheduler[wp]:
+    "reads_respects_scheduler aag l \<top> (set_object ptr obj)"
+  and arch_activate_idle_thread_reads_respects_scheduler[wp]:
+    "reads_respects_scheduler aag l \<top> (arch_activate_idle_thread rv)"
+  and arch_activate_idle_thread_silc_dom_equiv[wp]:
+    "arch_activate_idle_thread t \<lbrace>silc_dom_equiv aag st\<rbrace>"
+  and arch_activate_idle_thread_scheduler_affects_equiv[wp]:
+    "arch_activate_idle_thread t \<lbrace>scheduler_affects_equiv aag l s\<rbrace>"
+begin
+
+lemma switch_to_thread_midstrength_reads_respects_scheduler[wp]:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
   "midstrength_reads_respects_scheduler aag l
-         (invs and pas_refined aag and
-            (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
-         (guarded_switch_to t >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
+     (invs and pas_refined aag and (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
+     (switch_to_thread t >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
+  apply (simp add: switch_to_thread_def)
+  apply (subst oblivious_modify_swap[symmetric, OF tcb_action_oblivious_cur_thread])
+  apply (simp add: bind_assoc)
+  apply (simp add: set_scheduler_action_def)
+  apply (subst oblivious_modify_swap[symmetric, OF tcb_action_oblivious_schact])
+  apply (rule equiv_valid_get_assert)
+  apply (rule equiv_valid_guard_imp)
+   apply (simp add: bind_assoc[symmetric])
+   apply (rule bind_ev_general)
+     apply (rule tcb_action_reads_respects_scheduler[OF domains_distinct])
+    apply (simp add: bind_assoc)
+    apply wpsimp+
+  done
+
+lemma switch_to_thread_globals_equiv_scheduler[wp]:
+  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
+   switch_to_thread thread
+   \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
+  apply (simp add: switch_to_thread_def)
+  apply (wp dxo_wp_weak arch_switch_to_thread_globals_equiv_scheduler | simp)+
+  done
+
+lemma guarded_switch_to_thread_midstrength_reads_respects_scheduler[wp]:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "midstrength_reads_respects_scheduler aag l
+           (invs and pas_refined aag and (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
+           (guarded_switch_to t >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
   apply (simp add: guarded_switch_to_def bind_assoc)
   apply (subst bind_assoc[symmetric])
   apply (rule ev_irrelevant_bind)
    apply (wp gts_wp | simp)+
   done
 
-lemma arch_switch_to_idle_thread_globals_equiv_scheduler[wp]:
-  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace> arch_switch_to_idle_thread
-       \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
-  unfolding arch_switch_to_idle_thread_def storeWord_def
-  by (wp dmo_wp modify_wp thread_get_wp' arch_switch_to_thread_globals_equiv_scheduler')
-
 lemma switch_to_idle_thread_globals_equiv_scheduler[wp]:
-  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace> switch_to_idle_thread
-       \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
+  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
+   switch_to_idle_thread
+   \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
   apply (simp add: switch_to_idle_thread_def)
   apply (wp | simp)+
   done
 
-crunch cur_domain[wp]: guarded_switch_to,arch_switch_to_idle_thread,choose_thread
-                       "\<lambda>s. P (cur_domain s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-crunch domain_fields[wp]: guarded_switch_to,arch_switch_to_idle_thread, choose_thread
-                          "domain_fields P"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma gets_evrv':
-  "equiv_valid_rv I A B R (K (\<forall>s t. I s t \<and> A s t  \<longrightarrow> R (f s) (f t) \<and> B s t)) (gets f)"
-  apply (auto simp: equiv_valid_2_def in_monad)
-  done
-
-lemma gets_ev_no_inv:
-  shows "equiv_valid I A B (\<lambda> s. \<forall> s t. I s t \<and> A s t  \<longrightarrow> f s = f t \<and> B s t) (gets f)"
-  apply (simp add: equiv_valid_def2)
-  apply (auto intro: equiv_valid_rv_guard_imp[OF gets_evrv'])
-  done
+lemmas globals_equiv_scheduler_inv = globals_equiv_scheduler_inv'[where P="\<top>",simplified]
 
 lemma switch_to_idle_thread_midstrength_reads_respects_scheduler[wp]:
   "midstrength_reads_respects_scheduler aag l (invs and pas_refined aag)
-       (switch_to_idle_thread >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
+     (switch_to_idle_thread >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
   apply (simp add: switch_to_idle_thread_def)
   apply (rule equiv_valid_guard_imp)
-   apply (simp add: arch_switch_to_idle_thread_def bind_assoc double_gets_drop_regets)
+   apply (simp add: bind_assoc double_gets_drop_regets)
    apply (rule bind_ev_general)
-   apply (rule bind_ev_general)
+     apply (rule bind_ev_general)
        apply (rule store_cur_thread_midstrength_reads_respects)
       apply (rule_tac P="\<top>" and P'="\<top>" in equiv_valid_inv_unobservable)
           apply (rule hoare_pre)
            apply (rule scheduler_equiv_lift'[where P=\<top>])
-                apply (wp globals_equiv_scheduler_inv silc_dom_lift  | simp)+
-         apply (wp midstrength_scheduler_affects_equiv_unobservable set_vm_root_states_equiv_for
-               | simp)+
-        apply (wp cur_thread_update_not_subject_reads_respects_scheduler
-              | assumption | simp | fastforce)+
+                apply (wp globals_equiv_scheduler_inv silc_dom_lift | simp)+
+         apply (wp midstrength_scheduler_affects_equiv_unobservable
+                | simp | (rule hoare_pre, wps))+
+        apply (wp cur_thread_update_not_subject_reads_respects_scheduler arch_stit_invs
+               | assumption | simp | fastforce)+
   apply (clarsimp simp: scheduler_equiv_def)
   done
 
+end
+
+
 lemma gets_read_queue_ev_from_weak_sae:
   "(\<forall>s t. B s t \<longrightarrow> weak_scheduler_affects_equiv aag l s t)
-    \<Longrightarrow> equiv_valid_inv R B
-        (\<lambda>s. pasDomainAbs aag d \<inter> reads_scheduler aag l \<noteq> {}) (gets (\<lambda>s. f (ready_queues s d)))"
+   \<Longrightarrow> equiv_valid_inv R B
+         (\<lambda>s. pasDomainAbs aag d \<inter> reads_scheduler aag l \<noteq> {}) (gets (\<lambda>s. f (ready_queues s d)))"
   apply (rule equiv_valid_guard_imp)
   apply wp
-  apply (force simp: weak_scheduler_affects_equiv_def states_equiv_for_def
-                     equiv_for_def)
+  apply (force simp: weak_scheduler_affects_equiv_def states_equiv_for_def equiv_for_def)
   done
-
-lemma gets_read_queue_reads_respects_scheduler[wp]:
-  "weak_reads_respects_scheduler aag l
-    (\<lambda>s. pasDomainAbs aag d \<inter> reads_scheduler aag l \<noteq> {}) (gets (\<lambda>s. f (ready_queues s d)))"
-  by (rule gets_read_queue_ev_from_weak_sae, simp)
 
 lemma gets_ready_queue_midstrength_equiv_scheduler[wp]:
   "equiv_valid_inv (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
      (\<lambda>s. pasDomainAbs aag d \<inter> reads_scheduler aag l \<noteq> {})
      (gets (\<lambda>s. f (ready_queues s d)))"
   by (rule gets_read_queue_ev_from_weak_sae, auto)
-
-lemma gets_cur_domain_reads_respects_scheduler[wp]:
-  "equiv_valid (scheduler_equiv aag) A A \<top> (gets cur_domain)"
-  apply (rule equiv_valid_guard_imp)
-  apply wp
-  apply (clarsimp simp add: scheduler_equiv_def states_equiv_for_def
-                            equiv_for_def domain_fields_equiv_def)
-  done
-
 
 lemma any_valid_thread:
   "queues p \<noteq> [] \<Longrightarrow> (\<And>x prio. x \<in> set (queues prio) \<Longrightarrow> P x)
@@ -1282,33 +1143,110 @@ lemma any_valid_thread:
   done
 
 lemma tcb_with_domain_at:
-  "valid_queues s \<Longrightarrow> x \<in> set (ready_queues s d p) \<Longrightarrow>
-   \<exists>t. ekheap s x = Some t \<and> (tcb_domain t) = d"
-   apply (fastforce simp add: valid_queues_def is_etcb_at_def etcb_at_def
-                   split: option.splits)
-   done
+  "\<lbrakk> valid_queues s; x \<in> set (ready_queues s d p) \<rbrakk>
+     \<Longrightarrow> \<exists>t. ekheap s x = Some t \<and> (tcb_domain t) = d"
+   by (fastforce simp: valid_queues_def is_etcb_at_def etcb_at_def split: option.splits)
 
 lemma if_ev_bind:
-  "\<lbrakk>b \<Longrightarrow> equiv_valid I A B P (f >>= s); \<not> b \<Longrightarrow> equiv_valid I A B Q (g >>= s)\<rbrakk>
-   \<Longrightarrow> equiv_valid I A B (\<lambda>s. (b \<longrightarrow> P s) \<and> (\<not> b \<longrightarrow> Q s)) ((if b then f else g) >>= s)"
-  apply simp
+  "\<lbrakk> b \<Longrightarrow> equiv_valid I A B P (f >>= s); \<not> b \<Longrightarrow> equiv_valid I A B Q (g >>= s) \<rbrakk>
+     \<Longrightarrow> equiv_valid I A B (\<lambda>s. (b \<longrightarrow> P s) \<and> (\<not> b \<longrightarrow> Q s)) ((if b then f else g) >>= s)"
+  by simp
+
+lemma equiv_valid_cases':
+  "\<lbrakk> \<And>s t. A s t \<Longrightarrow> I s t \<Longrightarrow> P s = P t;
+     equiv_valid I A B (R and P) f; equiv_valid I A B ((\<lambda>s. \<not>P s) and R) f \<rbrakk>
+     \<Longrightarrow> equiv_valid I A B R f"
+  by (fastforce simp: equiv_valid_def2 equiv_valid_2_def)
+
+lemmas equiv_valid_cases = equiv_valid_cases'[rotated]
+
+lemma ev_weaken_pre_relation:
+  "\<lbrakk> equiv_valid I A B P f; \<And>s t. A' s t \<Longrightarrow> A s t \<rbrakk>
+     \<Longrightarrow> equiv_valid I A' B P f"
+  by (fastforce simp: equiv_valid_def2 equiv_valid_2_def)
+
+
+context Scheduler_IF_1 begin
+
+lemma gets_cur_domain_reads_respects_scheduler[wp]:
+  "equiv_valid (scheduler_equiv aag) A A \<top> (gets cur_domain)"
+  apply (rule equiv_valid_guard_imp)
+  apply wp
+  apply (simp add: scheduler_equiv_def states_equiv_for_def equiv_for_def domain_fields_equiv_def)
   done
+
+lemma gets_read_queue_reads_respects_scheduler[wp]:
+  "weak_reads_respects_scheduler aag l
+     (\<lambda>s. pasDomainAbs aag d \<inter> reads_scheduler aag l \<noteq> {}) (gets (\<lambda>s. f (ready_queues s d)))"
+  by (rule gets_read_queue_ev_from_weak_sae, simp)
+
+crunches guarded_switch_to, choose_thread
+  for cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
+  and domain_fields[wp]: "domain_fields P"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma cur_thread_update_unobservable:
+  "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and scheduler_affects_equiv aag l st
+                                               and (\<lambda>s. cur_domain s = cur_domain st)\<rbrace>
+   modify (cur_thread_update (\<lambda>_. thread))
+   \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
+  by (wpsimp simp: scheduler_affects_equiv_def scheduler_equiv_def domain_fields_equiv_def)
+
+lemma weak_scheduler_affects_equiv[intro]:
+  "scheduler_affects_equiv aag l st s \<Longrightarrow> weak_scheduler_affects_equiv aag l st s"
+  by (simp add: scheduler_affects_equiv_def weak_scheduler_affects_equiv_def)
+
+lemma midstrength_scheduler_affects_equiv[intro]:
+  "scheduler_affects_equiv aag l st s \<Longrightarrow> midstrength_scheduler_affects_equiv aag l st s"
+  by (simp add: scheduler_affects_equiv_def midstrength_scheduler_affects_equiv_def)
+
+lemma get_thread_state_reads_respects_scheduler:
+  "reads_respects_scheduler aag l
+     ((\<lambda>s. st_tcb_at \<top> rv s
+           \<longrightarrow> pasObjectAbs aag rv \<in> reads_scheduler aag l \<or> rv = idle_thread s) and valid_idle)
+     (get_thread_state rv)"
+  apply (clarsimp simp: get_thread_state_def thread_get_def gets_the_def gets_def get_def
+                        assert_opt_def get_tcb_def bind_def return_def fail_def valid_idle_def
+                        pred_tcb_at_def obj_at_def equiv_valid_def2 equiv_valid_2_def
+                 split: option.splits kernel_object.splits)
+  apply (clarsimp simp add: scheduler_equiv_def)
+  apply (elim disjE, simp_all)
+  apply (clarsimp simp: scheduler_affects_equiv_def states_equiv_for_def equiv_for_def)
+  done
+
+lemma get_cur_thread_reads_respects_scheduler[wp]:
+  "reads_respects_scheduler aag l
+     (\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l \<noteq> {})
+     (gets cur_thread)"
+  by (clarsimp simp: scheduler_equiv_def scheduler_affects_equiv_def domain_fields_equiv_def
+                     gets_def get_def bind_def return_def equiv_valid_def2 equiv_valid_2_def)
+
+lemma get_scheduler_action_reads_respects_scheduler[wp]:
+  "reads_respects_scheduler aag l
+     (\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l \<noteq> {})
+     (gets scheduler_action)"
+  by (clarsimp simp: scheduler_equiv_def scheduler_affects_equiv_def domain_fields_equiv_def
+                     gets_def get_def bind_def return_def equiv_valid_def2 equiv_valid_2_def)
+
+end
+
+
+context Scheduler_IF_2 begin
 
 lemma choose_thread_reads_respects_scheduler_cur_domain:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "midstrength_reads_respects_scheduler aag l
-           (invs and pas_refined aag and valid_queues and
-                (\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l \<noteq> {}))
+  shows "midstrength_reads_respects_scheduler aag l
+           (invs and pas_refined aag and valid_queues
+                 and (\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l \<noteq> {}))
            (choose_thread >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
   apply (simp add: choose_thread_def bind_assoc)
   apply (rule equiv_valid_guard_imp)
    apply (rule bind_ev_general)
-   apply (rule bind_ev_general)
+     apply (rule bind_ev_general)
        apply (rule if_ev_bind)
         apply (rule switch_to_idle_thread_midstrength_reads_respects_scheduler)
        apply (rule guarded_switch_to_thread_midstrength_reads_respects_scheduler)
-      apply wp+
+       apply wp+
   apply clarsimp
   apply (erule any_valid_thread)
   apply (frule(1) tcb_with_domain_at)
@@ -1317,90 +1255,40 @@ lemma choose_thread_reads_respects_scheduler_cur_domain:
   apply simp
   done
 
-lemma cur_thread_update_unobservable:
-  "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
-        scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain s = cur_domain st)\<rbrace>
-     modify (cur_thread_update (\<lambda>_. thread))
-   \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
-  apply wp
-  apply (clarsimp simp  add: scheduler_affects_equiv_def scheduler_equiv_def
-                   domain_fields_equiv_def)
-  done
-
-
-lemma arch_switch_to_idle_thread_unobservable:
-  "\<lbrace>(\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l = {}) and
-        scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and invs\<rbrace>
-     arch_switch_to_idle_thread
-   \<lbrace>\<lambda>rv s. scheduler_affects_equiv aag l st s\<rbrace>"
-  apply (simp add: arch_switch_to_idle_thread_def)
-  apply wp
-  apply (clarsimp simp add: scheduler_equiv_def domain_fields_equiv_def
-                   invs_def valid_state_def)
-  done
-
-
 lemma switch_to_idle_thread_unobservable:
   "\<lbrace>(\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l = {}) and
-        scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain s = cur_domain st) and invs\<rbrace>
-      switch_to_idle_thread
+         scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain s = cur_domain st) and invs\<rbrace>
+   switch_to_idle_thread
    \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
   apply (simp add: switch_to_idle_thread_def)
   apply (wp cur_thread_update_unobservable arch_switch_to_idle_thread_unobservable)
-  apply (clarsimp simp add: scheduler_equiv_def domain_fields_equiv_def)
-  done
-
-lemma clearExMonitor_unobservable:
-  "\<lbrace>(\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l = {}) and
-         scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain s = cur_domain st)\<rbrace>
-      do_machine_op clearExMonitor
-   \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
-  apply (simp add: clearExMonitor_def)
-  apply (rule hoare_pre)
-   apply (wp dmo_wp modify_wp)
-  apply (clarsimp simp add: states_equiv_for_def
-                            scheduler_affects_equiv_def equiv_for_def
-                            equiv_asids_def equiv_asid_def
-                            scheduler_globals_frame_equiv_def
-                            silc_dom_equiv_def)
-  done
-
-lemma arch_switch_to_thread_unobservable:
-  "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
-         scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and invs\<rbrace>
-      arch_switch_to_thread t
-   \<lbrace>\<lambda>rv s. scheduler_affects_equiv aag l st s\<rbrace>"
-  apply (simp add: arch_switch_to_thread_def)
-  apply (wp set_vm_root_scheduler_affects_equiv clearExMonitor_unobservable | simp)+
+  apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def)
   done
 
 lemma tcb_sched_action_unobservable:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "\<lbrace>pas_refined aag and scheduler_affects_equiv aag l st and
-        (\<lambda>s. pasObjectAbs aag t \<notin> reads_scheduler aag l)\<rbrace>
-      tcb_sched_action f t
-   \<lbrace>\<lambda>rv. scheduler_affects_equiv aag l st\<rbrace>"
+  "\<lbrace>pas_refined aag and scheduler_affects_equiv aag l st
+                    and (\<lambda>s. pasObjectAbs aag t \<notin> reads_scheduler aag l)\<rbrace>
+   tcb_sched_action f t
+   \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
   apply (simp add: tcb_sched_action_def)
   apply wp
-  apply (clarsimp simp add: etcb_at_def split: option.splits)
-  apply (clarsimp simp: scheduler_affects_equiv_def states_equiv_for_def
-                        equiv_for_def equiv_asids_def equiv_asid_def)
+  apply (clarsimp simp: etcb_at_def scheduler_affects_equiv_def split: option.splits)
+  apply (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def)
   apply (rule ext)
   apply clarsimp
   apply (frule(1) tcb_domain_wellformed)
   apply (metis domains_distinct[THEN pas_domains_distinct_inj])
   done
 
-
 lemma switch_to_thread_unobservable:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
-         (\<lambda>s. pasObjectAbs aag t \<notin> reads_scheduler aag l) and
-         scheduler_affects_equiv aag l st and scheduler_equiv aag st and invs and pas_refined aag\<rbrace>
-      switch_to_thread t
-   \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
+  shows "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
+          (\<lambda>s. pasObjectAbs aag t \<notin> reads_scheduler aag l) and
+          scheduler_affects_equiv aag l st and scheduler_equiv aag st and invs and pas_refined aag\<rbrace>
+         switch_to_thread t
+         \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
   apply (simp add: switch_to_thread_def)
   apply (wp cur_thread_update_unobservable arch_switch_to_idle_thread_unobservable
             tcb_sched_action_unobservable arch_switch_to_thread_unobservable)
@@ -1409,52 +1297,37 @@ lemma switch_to_thread_unobservable:
 
 lemma choose_thread_reads_respects_scheduler_other_domain:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_scheduler aag l ( invs and pas_refined aag and valid_queues and
-              (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s))
-              choose_thread"
-  apply (rule reads_respects_scheduler_unobservable''[
-                      where P'="\<lambda>s. \<not> reads_scheduler_cur_domain aag l s \<and>
-                                    invs s \<and> pas_refined aag s \<and> valid_queues s"])
+  shows "reads_respects_scheduler aag l ( invs and pas_refined aag and valid_queues and
+                                  (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)) choose_thread"
+  apply (rule reads_respects_scheduler_unobservable''
+                [where P'="\<lambda>s. \<not> reads_scheduler_cur_domain aag l s \<and>
+                               invs s \<and> pas_refined aag s \<and> valid_queues s"])
   apply (rule hoare_pre)
      apply (rule scheduler_equiv_lift'[where P="invs"])
           apply (simp add: choose_thread_def)
           apply (wp guarded_switch_to_lift silc_dom_lift | simp)+
     apply force
-
    apply (simp add: choose_thread_def)
-   apply (wp guarded_switch_to_lift switch_to_idle_thread_unobservable
-             switch_to_thread_unobservable | simp)+
+   apply (wp guarded_switch_to_lift switch_to_idle_thread_unobservable switch_to_thread_unobservable
+          | simp)+
    apply clarsimp
    apply (intro impI conjI)
     apply (simp add: scheduler_equiv_def domain_fields_equiv_def)
    apply (elim exE)
    apply (erule any_valid_thread)
-   apply (frule(1) tcb_with_domain_at)
+   apply (frule (1) tcb_with_domain_at)
    apply clarsimp
-   apply (frule(1) tcb_domain_wellformed)
+   apply (frule (1) tcb_domain_wellformed)
    apply (force simp: disjoint_iff_not_equal)
   apply simp
   done
 
-lemma equiv_valid_cases':
-  "(\<And>s t. A s t \<Longrightarrow> I s t \<Longrightarrow> P s = P t) \<Longrightarrow> equiv_valid I A B (R and P) f
-   \<Longrightarrow> equiv_valid I A B ((\<lambda>s. \<not>P s) and R) f
-   \<Longrightarrow> equiv_valid I A B R f"
-  apply (simp add: equiv_valid_def2 equiv_valid_2_def)
-  apply fastforce
-  done
-
-lemmas equiv_valid_cases = equiv_valid_cases'[rotated]
-
-
 lemma choose_thread_reads_respects_scheduler:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "midstrength_reads_respects_scheduler aag l (invs and pas_refined aag and valid_queues)
-                       (choose_thread >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
-  apply (rule equiv_valid_cases[
-                      where P="\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l \<noteq> {}"])
+  shows "midstrength_reads_respects_scheduler aag l (invs and pas_refined aag and valid_queues)
+           (choose_thread >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
+  apply (rule equiv_valid_cases
+                [where P="\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l \<noteq> {}"])
     apply (rule equiv_valid_guard_imp)
      apply (rule choose_thread_reads_respects_scheduler_cur_domain[OF domains_distinct])
     apply simp
@@ -1463,54 +1336,18 @@ lemma choose_thread_reads_respects_scheduler:
     apply (rule equiv_valid_guard_imp)
      apply (wp choose_thread_reads_respects_scheduler_other_domain | simp)+
     apply force
-   apply (clarsimp simp: reads_lrefl)
+   apply clarsimp
   apply (simp add: scheduler_equiv_def domain_fields_equiv_def)
-  done
-
-
-lemma next_domain_midstrength_equiv_scheduler:
-  "equiv_valid (scheduler_equiv aag) (weak_scheduler_affects_equiv aag l)
-               (midstrength_scheduler_affects_equiv aag l) \<top>
-               next_domain"
-  apply (simp add: next_domain_def)
-  apply (rule ev_modify)
-  apply (clarsimp simp add: scheduler_equiv_def Let_def
-                            domain_fields_equiv_def globals_equiv_scheduler_def
-                            silc_dom_equiv_def equiv_for_def
-                            weak_scheduler_affects_equiv_def
-                            midstrength_scheduler_affects_equiv_def
-                            states_equiv_for_def equiv_asids_def
-                            equiv_asid_def idle_equiv_def)
-  done
-
-
-lemma ev_weaken_pre_relation:
-  "equiv_valid I A B P f \<Longrightarrow> (\<And>s t. A' s t \<Longrightarrow> A s t) \<Longrightarrow> equiv_valid I A' B P f"
-  apply (clarsimp simp add: equiv_valid_def2 equiv_valid_2_def)
-  apply fastforce
-  done
-
-
-lemma weak_scheduler_affects_equiv[intro]:
-  "scheduler_affects_equiv aag l st s \<Longrightarrow> weak_scheduler_affects_equiv aag l st s"
-  apply (simp add: scheduler_affects_equiv_def weak_scheduler_affects_equiv_def)
-  done
-
-lemma midstrength_scheduler_affects_equiv[intro]:
-  "scheduler_affects_equiv aag l st s  \<Longrightarrow> midstrength_scheduler_affects_equiv aag l st s"
-  apply (simp add: scheduler_affects_equiv_def midstrength_scheduler_affects_equiv_def)
   done
 
 lemma next_domain_snippit:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_scheduler aag l (invs and pas_refined aag and valid_queues)
-      (do
-        dom_time \<leftarrow> gets domain_time;
-        y \<leftarrow> when (dom_time = 0) next_domain;
-        y\<leftarrow> choose_thread;
-        set_scheduler_action resume_cur_thread
-       od)"
+  shows "reads_respects_scheduler aag l (invs and pas_refined aag and valid_queues)
+           (do dom_time \<leftarrow> gets domain_time;
+               y \<leftarrow> when (dom_time = 0) next_domain;
+               y \<leftarrow> choose_thread;
+               set_scheduler_action resume_cur_thread
+            od)"
   apply (simp add: when_def)
   apply (rule bind_ev_pre)
      apply (rule bind_ev_general)
@@ -1529,75 +1366,35 @@ lemma next_domain_snippit:
 
 lemma schedule_choose_new_thread_read_respects_scheduler:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_scheduler aag l (invs and pas_refined aag and valid_queues)
-     schedule_choose_new_thread"
+  shows "reads_respects_scheduler aag l (invs and pas_refined aag and valid_queues)
+                                  schedule_choose_new_thread"
   unfolding schedule_choose_new_thread_def
   by (simp add: next_domain_snippit[OF domains_distinct])
 
-lemma get_thread_state_reads_respects_scheduler:
-  "reads_respects_scheduler aag l
-     ((\<lambda>s. st_tcb_at \<top> rv s \<longrightarrow>
-             pasObjectAbs aag rv \<in> reads_scheduler aag l \<or> rv = idle_thread s)
-      and valid_idle)
-     (get_thread_state rv)"
-  apply (clarsimp simp add: get_thread_state_def thread_get_def gets_the_def
-                   gets_def get_def assert_opt_def get_tcb_def
-                   bind_def return_def fail_def
-                   valid_idle_def pred_tcb_at_def
-                   obj_at_def
-                   equiv_valid_def2 equiv_valid_2_def
-                  split: option.splits kernel_object.splits
-                   )
-  apply (clarsimp simp add: scheduler_equiv_def)
-  apply (elim disjE,simp_all)
-  apply (clarsimp simp: scheduler_affects_equiv_def
-                        states_equiv_for_def equiv_for_def)
-  done
+end
 
-lemma get_cur_thread_reads_respects_scheduler[wp]:
-  "reads_respects_scheduler aag l
-     (\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l \<noteq> {})
-     (gets cur_thread)"
-  by (clarsimp simp: scheduler_equiv_def scheduler_affects_equiv_def
-                     domain_fields_equiv_def gets_def get_def bind_def return_def
-                     equiv_valid_def2 equiv_valid_2_def)
-
-lemma get_scheduler_action_reads_respects_scheduler[wp]:
-  "reads_respects_scheduler aag l ( (\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l \<noteq> {}))
-                            (gets scheduler_action)"
-  by (clarsimp simp: scheduler_equiv_def scheduler_affects_equiv_def
-                     domain_fields_equiv_def gets_def get_def bind_def return_def
-                     equiv_valid_def2 equiv_valid_2_def)
 
 lemma switch_to_cur_domain:
-  "\<lbrakk>valid_sched s; scheduler_action s = switch_thread x; pas_refined aag s\<rbrakk>
-    \<Longrightarrow> pasObjectAbs aag x \<in> pasDomainAbs aag (cur_domain s)"
-    apply (clarsimp simp add: valid_sched_def
-                              valid_sched_action_def
-                              switch_in_cur_domain_def
-                              in_cur_domain_def etcb_at_def
-                              weak_valid_sched_action_def
-                              is_etcb_at_def st_tcb_at_def
-                              obj_at_def
-                              valid_etcbs_def)
-    apply (drule_tac x=x in spec)
-    apply clarsimp
-    apply (drule(1) tcb_domain_wellformed)
-    apply simp
-    done
+  "\<lbrakk> valid_sched s; scheduler_action s = switch_thread x; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag x \<in> pasDomainAbs aag (cur_domain s)"
+  apply (clarsimp simp: valid_sched_def valid_sched_action_def switch_in_cur_domain_def
+                        in_cur_domain_def etcb_at_def weak_valid_sched_action_def
+                        is_etcb_at_def st_tcb_at_def obj_at_def valid_etcbs_def)
+  apply (drule_tac x=x in spec)
+  apply clarsimp
+  apply (drule(1) tcb_domain_wellformed)
+  apply simp
+  done
 
 lemma equiv_valid_dc:
-  assumes a:"(\<And>P. \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. P\<rbrace>)"
-  assumes b:"(\<And>P. \<lbrace>P\<rbrace> f' \<lbrace>\<lambda>_. P\<rbrace>)"
+  assumes a: "\<And>P. f \<lbrace>P\<rbrace>"
+  assumes b: "\<And>P. f' \<lbrace>P\<rbrace>"
   shows "equiv_valid_2 I A A dc P P' f f'"
   apply (clarsimp simp add: equiv_valid_2_def)
   apply (erule use_valid[OF _ a])
   apply (erule use_valid[OF _ b])
   apply simp
   done
-
-
 
 lemma equiv_valid_2_unobservable:
   assumes fI: "\<And>st. \<lbrace>P and I st and A st\<rbrace> f \<lbrace>\<lambda>_. I st\<rbrace>"
@@ -1609,40 +1406,190 @@ lemma equiv_valid_2_unobservable:
   shows "equiv_valid_2 I A A dc (P and P') (S and S') (f:: 'a \<Rightarrow> (unit \<times> 'a) set \<times> bool) g"
   apply (clarsimp simp add: equiv_valid_def spec_equiv_valid_def equiv_valid_2_def)
   apply (erule preserves_equivalence_2_weak,assumption)
+        apply (rule hoare_pre)
+         apply (rule hoare_vcg_conj_lift)
+          apply (rule fI)
+         apply (rule fA)
+        apply force
        apply (rule hoare_pre)
         apply (rule hoare_vcg_conj_lift)
-         apply (rule fI)
-        apply (rule fA)
-       apply force
-       apply (rule hoare_pre)
-       apply (rule hoare_vcg_conj_lift)
-       apply (rule gI)
-       apply (rule gA)
+         apply (rule gI)
+        apply (rule gA)
        apply force
       apply (fastforce intro!: sym trans)+
   done
 
-
 lemma equiv_valid_2:
   "equiv_valid I A B P f \<Longrightarrow> equiv_valid_rv I A B (=) P f"
-  apply (simp add: equiv_valid_def2)
-  done
+  by (simp add: equiv_valid_def2)
 
 lemma ev_gets_const:
   "equiv_valid_inv I A (\<lambda>s. f s = x) (gets f)"
-  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def
-                        gets_def get_def bind_def return_def)
+  by (clarsimp simp: equiv_valid_def2 equiv_valid_2_def gets_def get_def bind_def return_def)
+
+lemma when_next_domain_domain_fields:
+  "\<lbrace>\<lambda>s. \<not> B \<and> domain_fields Q s\<rbrace>
+   when B next_domain
+   \<lbrace>\<lambda>_. domain_fields Q\<rbrace>"
+  by (wpsimp | rule hoare_pre_cont[where a=next_domain])+
+
+lemma cur_thread_cur_domain:
+  "\<lbrakk> st_tcb_at ((=) st) (cur_thread s) s; \<not> idle st; invs s; guarded_pas_domain aag s \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag (cur_thread s) \<in> pasDomainAbs aag (cur_domain s)"
+  by (clarsimp simp: pred_tcb_at_def invs_def valid_idle_def
+                     valid_state_def obj_at_def guarded_pas_domain_def)
+
+lemma valid_sched_valid_queues[intro]:
+  "valid_sched s \<Longrightarrow> valid_queues s"
+  by (simp add: valid_sched_def)
+
+lemma ethread_get_wp2:
+  "\<lbrace>\<lambda>s. \<forall>etcb. etcb_at ((=) etcb) t s \<longrightarrow> Q (f etcb) s\<rbrace>
+   ethread_get f t
+   \<lbrace>Q\<rbrace>"
+  apply wp
+  apply (clarsimp simp: etcb_at_def split: option.split)
   done
 
+lemma switch_thread_runnable:
+  "\<lbrakk> valid_sched s; scheduler_action s = switch_thread t \<rbrakk>
+     \<Longrightarrow> st_tcb_at runnable t s"
+  unfolding valid_sched_def valid_sched_action_def weak_valid_sched_action_def
+  by clarsimp
+
+lemma gets_highest_prio_ev_from_weak_sae:
+  "(\<forall>s t. B s t \<longrightarrow> weak_scheduler_affects_equiv aag l s t)
+   \<Longrightarrow> equiv_valid_inv R B (\<lambda>s. pasDomainAbs aag d \<inter> reads_scheduler aag l \<noteq> {})
+                       (gets (\<lambda>s. is_highest_prio d p s))"
+  apply (simp add: is_highest_prio_def)
+  apply (erule gets_read_queue_ev_from_weak_sae)
+  done
+
+lemma etcb_in_domains_of_state:
+  "\<lbrakk> is_etcb_at tcb_ptr s; etcb_at (\<lambda>t. tcb_domain t = tcb_dom) tcb_ptr s \<rbrakk>
+     \<Longrightarrow> (tcb_ptr, tcb_dom) \<in> domains_of_state s"
+  by (auto simp: domains_of_state_aux.simps is_etcb_at_def etcb_at_def)
+
+lemma guarded_active_ct_cur_domain:
+  "\<lbrakk> guarded_pas_domain aag s; ct_active s; invs s \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag (cur_thread s) \<in> pasDomainAbs aag (cur_domain s)"
+  by (fastforce simp: guarded_pas_domain_def invs_def valid_state_def
+                      valid_idle_def ct_in_state_def pred_tcb_at_def obj_at_def)
+
+
+context Scheduler_IF_1 begin
+
+lemma schedule_no_domain_switch:
+  "\<lbrace>(\<lambda>s. domain_time s \<noteq> 0) and (\<lambda>s. Q (cur_domain s))\<rbrace>
+   schedule
+   \<lbrace>\<lambda>r s. Q (cur_domain s)\<rbrace>"
+  unfolding schedule_def
+  supply ethread_get_wp[wp del]
+  apply (wpsimp wp: hoare_drop_imps simp: if_apply_def2
+         | simp add: schedule_choose_new_thread_def
+         | wpc
+         | rule hoare_pre_cont[where a=next_domain] )+
+  done
+
+lemma schedule_no_domain_fields:
+  "\<lbrace>(\<lambda>s. domain_time s \<noteq> 0) and domain_fields Q\<rbrace>
+   schedule
+   \<lbrace>\<lambda>_. domain_fields Q\<rbrace>"
+  unfolding schedule_def
+  supply ethread_get_wp[wp del]
+  apply (wpsimp wp: hoare_drop_imps simp: if_apply_def2
+         | simp add: schedule_choose_new_thread_def
+         | wpc
+         | rule hoare_pre_cont[where a=next_domain] )+
+  done
+
+lemma set_scheduler_action_unobservable:
+  "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and scheduler_affects_equiv aag l st
+                                               and (\<lambda>s. cur_domain st = cur_domain s)\<rbrace>
+   set_scheduler_action a
+   \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
+  apply (simp add: set_scheduler_action_def)
+  apply wp
+  apply (clarsimp simp: scheduler_affects_equiv_def scheduler_equiv_def domain_fields_equiv_def)
+  done
+
+lemma sched_equiv_cur_domain[intro]:
+  "scheduler_equiv aag st s \<Longrightarrow> cur_domain st = cur_domain s"
+  by (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def)
+
+lemma reschedule_required_scheduler_equiv[wp]:
+  "reschedule_required \<lbrace>scheduler_equiv aag st\<rbrace>"
+  apply (simp add: reschedule_required_def)
+  apply (wp scheduler_equiv_lift | wpc | simp)+
+  done
+
+lemma reads_respects_scheduler_cases':
+  assumes b: "reads_respects_scheduler aag l P' (f t)"
+  assumes b': "\<And>s. Q s \<Longrightarrow> reads_scheduler_cur_domain aag l s \<Longrightarrow> P' s"
+  assumes c: "reads_respects_scheduler aag l P'' (f t)"
+  assumes c': "\<And>s. Q s \<Longrightarrow> \<not> reads_scheduler_cur_domain aag l s \<Longrightarrow> P'' s"
+  shows "reads_respects_scheduler aag l Q (f t)"
+  apply (rule_tac P="\<lambda>s. reads_scheduler_cur_domain aag l s" in equiv_valid_cases)
+    apply (rule equiv_valid_guard_imp)
+     apply (rule b)
+    apply (simp add: b')
+   apply (rule equiv_valid_guard_imp)
+    apply (rule c)
+   apply (simp add: c')
+  apply (simp add: scheduler_equiv_def domain_fields_equiv_def)
+  done
+
+lemma dec_domain_time_reads_respects_scheduler[wp]:
+  "reads_respects_scheduler aag l \<top> dec_domain_time"
+  apply (simp add: dec_domain_time_def)
+  apply (wp ev_modify)
+  apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
+                        scheduler_globals_frame_equiv_def silc_dom_equiv_def states_equiv_for_def
+                        scheduler_affects_equiv_def equiv_for_def equiv_asids_def idle_equiv_def)
+  done
+
+lemma ethread_set_reads_respects_scheduler:
+  "reads_respects_scheduler aag l (\<lambda>s. pasObjectAbs aag t \<in> reads_scheduler aag l)
+                            (ethread_set f t)"
+  apply (clarsimp simp: thread_set_time_slice_def ethread_set_def gets_the_def gets_def get_def
+                        bind_def put_def get_etcb_def return_def assert_opt_def set_eobject_def
+                        fail_def equiv_valid_def2 equiv_valid_2_def scheduler_equiv_def
+                        domain_fields_equiv_def globals_equiv_scheduler_def idle_equiv_def
+                 split: option.splits)
+  apply (rule conjI)
+   apply (clarsimp simp: silc_dom_equiv_def reads_scheduler_def equiv_for_def split: if_split_asm)
+  apply (simp add: scheduler_affects_equiv_def)
+  apply clarsimp
+  apply (rule conjI)
+   apply (rule states_equiv_for_identical_ekheap_updates,assumption)
+   apply (elim states_equiv_forE equiv_forE)
+   apply (clarsimp simp: identical_ekheap_updates_def)
+  apply (clarsimp simp: scheduler_globals_frame_equiv_def)
+  done
+
+lemma ethread_set_unobservable[wp]:
+   "\<lbrace>(\<lambda>s. pasObjectAbs aag t \<notin> reads_scheduler aag l) and scheduler_affects_equiv aag l st\<rbrace>
+    ethread_set f t
+    \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
+  apply (simp add: ethread_set_def set_eobject_def)
+  apply wp
+  apply (clarsimp simp: get_etcb_def scheduler_affects_equiv_def)
+  apply (elim states_equiv_forE equiv_forE)
+  apply (clarsimp simp: equiv_for_def states_equiv_for_def equiv_asids_def)+
+  done
+
+end
+
+context Scheduler_IF_2 begin
 
 lemma reads_respects_scheduler_invisible_domain_switch:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects_scheduler aag l
-     (\<lambda>s. pas_refined aag s \<and> invs s \<and> valid_queues s \<and> guarded_pas_domain aag s
-          \<and> domain_time s = 0 \<and> scheduler_action s = choose_new_thread
-          \<and> \<not> reads_scheduler_cur_domain aag l s)
-     schedule"
+    "reads_respects_scheduler aag l (\<lambda>s. pas_refined aag s \<and> invs s \<and> valid_queues s
+                                       \<and> guarded_pas_domain aag s \<and> domain_time s = 0
+                                       \<and> scheduler_action s = choose_new_thread
+                                       \<and> \<not> reads_scheduler_cur_domain aag l s)
+                              schedule"
   apply (rule equiv_valid_guard_imp)
    apply (simp add: schedule_def)
    apply (simp add: equiv_valid_def2)
@@ -1659,15 +1606,14 @@ lemma reads_respects_scheduler_invisible_domain_switch:
               apply (rule equiv_valid_2_bind_pre)
                    apply (rule equiv_valid_2)
                    apply (rule schedule_choose_new_thread_read_respects_scheduler[OF domains_distinct])
-                  apply (rule_tac P="\<top>" and
+                  apply (rule_tac P="\<top>" and S="\<top>" and
                                   P'="pas_refined aag and
-                                     (\<lambda>s. (runnable rva \<longrightarrow>
-                                              (pasObjectAbs aag rv \<notin> reads_scheduler aag l)))" and
-                                  S="\<top>" and
+                                     (\<lambda>s. runnable rva
+                                          \<longrightarrow> (pasObjectAbs aag rv \<notin> reads_scheduler aag l))" and
                                   S'="pas_refined aag and
-                                     (\<lambda>s. (runnable rv'a \<longrightarrow>
-                                               pasObjectAbs aag rv' \<notin> reads_scheduler aag l))"
-                           in equiv_valid_2_unobservable)
+                                     (\<lambda>s. runnable rv'a
+                                           \<longrightarrow> pasObjectAbs aag rv' \<notin> reads_scheduler aag l)"
+                               in equiv_valid_2_unobservable)
                        apply wp
                         apply (rule scheduler_equiv_lift)
                              apply wp+
@@ -1698,59 +1644,22 @@ lemma reads_respects_scheduler_invisible_domain_switch:
    apply (simp add: guarded_pas_domain_def)
    apply (subgoal_tac "cur_thread s \<noteq> idle_thread s")
     apply (force simp: disjoint_iff_not_equal)
-   apply (clarsimp simp add: pred_tcb_at_def obj_at_def valid_state_def
-                              valid_idle_def invs_def)+
+   apply (clarsimp simp: pred_tcb_at_def obj_at_def valid_state_def valid_idle_def invs_def)+
   done
 
 crunch globals_equiv_scheduler[wp]: schedule "(\<lambda>s:: det_state. globals_equiv_scheduler st s)"
-  (   wp: guarded_switch_to_lift crunch_wps hoare_drop_imps
-  wp_del: ethread_get_wp
-  ignore: guarded_switch_to
-    simp: crunch_simps)
-
-lemma schedule_no_domain_switch:
-  "\<lbrace>(\<lambda>s. domain_time s \<noteq> 0) and (\<lambda>s. Q (cur_domain s))\<rbrace> schedule \<lbrace>\<lambda>r s. Q (cur_domain s)\<rbrace>"
-  unfolding schedule_def
-  supply ethread_get_wp[wp del]
-  apply (wpsimp wp: hoare_drop_imps simp: if_apply_def2
-         | simp add: schedule_choose_new_thread_def
-         | wpc
-         | rule hoare_pre_cont[where a=next_domain] )+
-  done
-
-lemma when_next_domain_domain_fields:
-  "\<lbrace>\<lambda>s. \<not> B \<and>  domain_fields Q s \<rbrace> when B next_domain \<lbrace> \<lambda>_. domain_fields Q \<rbrace>"
-  by (wpsimp | rule hoare_pre_cont[where a=next_domain])+
-
-lemma schedule_no_domain_fields:
-  "\<lbrace>(\<lambda>s. domain_time s \<noteq> 0) and domain_fields Q\<rbrace> schedule \<lbrace>\<lambda>_. domain_fields Q\<rbrace>"
-  unfolding schedule_def
-  supply ethread_get_wp[wp del]
-  apply (wpsimp wp: hoare_drop_imps simp: if_apply_def2
-         | simp add: schedule_choose_new_thread_def
-         | wpc
-         | rule hoare_pre_cont[where a=next_domain] )+
-  done
-
-lemma set_scheduler_action_unobservable:
-  "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
-          scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s)\<rbrace>
-      set_scheduler_action a
-   \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
-  apply (simp add: set_scheduler_action_def)
-  apply wp
-  apply (clarsimp simp add: scheduler_affects_equiv_def
-                   scheduler_equiv_def domain_fields_equiv_def)
-  done
+  (    wp: guarded_switch_to_lift crunch_wps hoare_drop_imps
+   wp_del: ethread_get_wp
+   ignore: guarded_switch_to
+     simp: crunch_simps)
 
 lemma choose_thread_unobservable:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
-         scheduler_affects_equiv aag l st and invs and valid_queues and pas_refined aag and
-         scheduler_equiv aag st\<rbrace>
-      choose_thread
-   \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
+    "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and scheduler_affects_equiv aag l st and
+      invs and valid_queues and pas_refined aag and scheduler_equiv aag st\<rbrace>
+     choose_thread
+     \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
   apply (simp add: choose_thread_def)
   apply (wp switch_to_idle_thread_unobservable guarded_switch_to_lift
             switch_to_thread_unobservable)
@@ -1766,62 +1675,29 @@ lemma choose_thread_unobservable:
   done
 
 lemma tcb_sched_action_scheduler_equiv[wp]:
-  "\<lbrace>scheduler_equiv aag st\<rbrace> tcb_sched_action f a\<lbrace>\<lambda>_. scheduler_equiv aag st\<rbrace>"
+  "tcb_sched_action f a \<lbrace>scheduler_equiv aag st\<rbrace>"
   by (rule scheduler_equiv_lift; wp)
-
-lemma cur_thread_cur_domain:
-  "\<lbrakk>st_tcb_at ((=) st) (cur_thread s) s; \<not> idle st; invs s; guarded_pas_domain aag s\<rbrakk>
-    \<Longrightarrow> pasObjectAbs aag (cur_thread s) \<in> pasDomainAbs aag (cur_domain s)"
-  apply (clarsimp simp add: pred_tcb_at_def invs_def valid_idle_def
-                            valid_state_def
-                            obj_at_def guarded_pas_domain_def)
-  done
-
-lemma sched_equiv_cur_domain[intro]:
-  "scheduler_equiv aag st s \<Longrightarrow> cur_domain st = cur_domain s"
-  apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def)
-  done
-
-lemma valid_sched_valid_queues[intro]:
-  "valid_sched s \<Longrightarrow> valid_queues s"
-  apply (simp add: valid_sched_def)
-  done
-
-lemma ethread_get_wp2:
-  "\<lbrace>\<lambda>s. \<forall>etcb. etcb_at ((=) etcb) t s \<longrightarrow> Q (f etcb) s\<rbrace> ethread_get f t \<lbrace>Q\<rbrace>"
-  apply wp
-  apply (clarsimp simp: etcb_at_def split: option.split)
-  done
-
-lemma switch_thread_runnable:
-  "\<lbrakk> valid_sched s ; scheduler_action s = switch_thread t \<rbrakk> \<Longrightarrow> st_tcb_at runnable t s"
-  unfolding valid_sched_def valid_sched_action_def weak_valid_sched_action_def
-  by clarsimp
 
 lemma schedule_choose_new_thread_schedule_affects_no_switch:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "\<lbrace>\<lambda>s. invs s \<and> pas_refined aag s \<and> valid_queues s \<and> domain_time s \<noteq> 0
-        \<and> \<not> reads_scheduler_cur_domain aag l s
-        \<and> scheduler_affects_equiv aag l st s \<and> scheduler_equiv aag st s
-        \<and> cur_domain st = cur_domain s \<rbrace>
+    "\<lbrace>\<lambda>s. invs s \<and> pas_refined aag s \<and> valid_queues s \<and> domain_time s \<noteq> 0
+                 \<and> \<not> reads_scheduler_cur_domain aag l s \<and> scheduler_equiv aag st s
+                 \<and> scheduler_affects_equiv aag l st s \<and> cur_domain st = cur_domain s\<rbrace>
      schedule_choose_new_thread
-   \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st \<rbrace>"
+     \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
   unfolding schedule_choose_new_thread_def
-  apply (wp set_scheduler_action_unobservable choose_thread_unobservable
-            hoare_pre_cont[where a=next_domain])
-  apply clarsimp
-  done
+  by (wpsimp wp: set_scheduler_action_unobservable choose_thread_unobservable
+                 hoare_pre_cont[where a=next_domain])
 
 lemma reads_respects_scheduler_invisible_no_domain_switch:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
   "reads_respects_scheduler aag l
-    (\<lambda>s. pas_refined aag s \<and> invs s \<and> valid_sched s \<and> guarded_pas_domain aag s
-         \<and> domain_time s \<noteq> 0 \<and> \<not> reads_scheduler_cur_domain aag l s)
-    schedule"
-  supply ethread_get_wp[wp del]
-  supply if_split[split del]
+     (\<lambda>s. pas_refined aag s \<and> invs s \<and> valid_sched s \<and> guarded_pas_domain aag s
+                            \<and> domain_time s \<noteq> 0 \<and> \<not> reads_scheduler_cur_domain aag l s)
+     schedule"
+  supply ethread_get_wp[wp del] if_split[split del]
   apply (rule reads_respects_scheduler_unobservable''[where P=Q and P'=Q and Q=Q for Q])
   apply (rule hoare_pre)
      apply (rule scheduler_equiv_lift'[where P="invs and (\<lambda>s. domain_time s \<noteq> 0)"])
@@ -1847,21 +1723,20 @@ lemma reads_respects_scheduler_invisible_no_domain_switch:
                      schedule_choose_new_thread_schedule_affects_no_switch)+
    apply (clarsimp simp: if_apply_def2)
    (* slow 15s *)
-   by (safe
-      ; (fastforce simp: switch_thread_runnable
-        | fastforce dest!: switch_to_cur_domain cur_thread_cur_domain
-        | fastforce simp: st_tcb_at_def obj_at_def))+
+   by (safe; (fastforce simp: switch_thread_runnable
+              | fastforce dest!: switch_to_cur_domain cur_thread_cur_domain
+              | fastforce simp: st_tcb_at_def obj_at_def))+
 
 lemma read_respects_scheduler_switch_thread_case:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects_scheduler aag l
-    (invs and valid_queues and (\<lambda>s. scheduler_action s = switch_thread t)
-      and valid_sched_action and pas_refined aag)
-    (do tcb_sched_action tcb_sched_enqueue t;
-        set_scheduler_action choose_new_thread;
-        schedule_choose_new_thread
-    od)"
+    "reads_respects_scheduler aag l
+       (invs and valid_queues and (\<lambda>s. scheduler_action s = switch_thread t)
+             and valid_sched_action and pas_refined aag)
+       (do tcb_sched_action tcb_sched_enqueue t;
+           set_scheduler_action choose_new_thread;
+           schedule_choose_new_thread
+        od)"
   unfolding schedule_choose_new_thread_def
   apply (rule equiv_valid_guard_imp)
    apply simp
@@ -1880,12 +1755,12 @@ lemma read_respects_scheduler_switch_thread_case_app:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
   "reads_respects_scheduler aag l
-    (invs and valid_queues and (\<lambda>s. scheduler_action s = switch_thread t)
-      and valid_sched_action and pas_refined aag)
-    (do tcb_sched_action tcb_sched_append t;
-        set_scheduler_action choose_new_thread;
-        schedule_choose_new_thread
-    od)"
+     (invs and valid_queues and (\<lambda>s. scheduler_action s = switch_thread t)
+           and valid_sched_action and pas_refined aag)
+     (do tcb_sched_action tcb_sched_append t;
+         set_scheduler_action choose_new_thread;
+         schedule_choose_new_thread
+      od)"
   unfolding schedule_choose_new_thread_def
   apply (rule equiv_valid_guard_imp)
    apply simp
@@ -1900,34 +1775,12 @@ lemma read_respects_scheduler_switch_thread_case_app:
   apply (clarsimp simp: valid_sched_action_def weak_valid_sched_action_def)
   done
 
-lemma gets_highest_prio_ev_from_weak_sae:
-  "(\<forall>s t. B s t \<longrightarrow> weak_scheduler_affects_equiv aag l s t)
-    \<Longrightarrow> equiv_valid_inv R B
-        (\<lambda>s. pasDomainAbs aag d \<inter> reads_scheduler aag l \<noteq> {}) (gets (\<lambda>s. is_highest_prio d p s))"
-  apply (simp add: is_highest_prio_def)
-  apply (erule gets_read_queue_ev_from_weak_sae)
-  done
-
-lemma etcb_in_domains_of_state:
-  "\<lbrakk> is_etcb_at tcb_ptr s;
-     etcb_at (\<lambda>t. tcb_domain t = tcb_dom) tcb_ptr s \<rbrakk>
-   \<Longrightarrow> (tcb_ptr, tcb_dom) \<in> domains_of_state s"
-  by (auto simp: domains_of_state_aux.simps is_etcb_at_def etcb_at_def)
-
-lemma guarded_active_ct_cur_domain:
-  "\<lbrakk>guarded_pas_domain aag s; ct_active s; invs s\<rbrakk> \<Longrightarrow>
-  pasObjectAbs aag (cur_thread s) \<in> pasDomainAbs aag (cur_domain s)"
-  apply (fastforce simp add: guarded_pas_domain_def invs_def valid_state_def valid_idle_def
-                   ct_in_state_def pred_tcb_at_def obj_at_def)
-  done
-
 lemma schedule_reads_respects_scheduler_cur_domain:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects_scheduler aag l
-        (invs and pas_refined aag and valid_sched
-         and guarded_pas_domain aag and
-        (\<lambda>s. reads_scheduler_cur_domain aag l s)) schedule"
+  "reads_respects_scheduler aag l (invs and pas_refined aag and valid_sched
+                                        and guarded_pas_domain aag
+                                        and (\<lambda>s. reads_scheduler_cur_domain aag l s)) schedule"
   supply ethread_get_wp[wp del]
   apply (simp add: schedule_def schedule_switch_thread_fastfail_def)
   apply (rule equiv_valid_guard_imp)
@@ -1952,10 +1805,10 @@ lemma schedule_reads_respects_scheduler_cur_domain:
                        apply fastforce
                       apply (rule gets_highest_prio_ev_from_weak_sae)
                       apply fastforce
-                     apply ((wpsimp wp: when_ev gts_wp get_thread_state_reads_respects_scheduler
+                     apply (wpsimp wp: when_ev gts_wp get_thread_state_reads_respects_scheduler
                                         ethread_get_when_reads_respects_scheduler
                                         hoare_vcg_all_lift
-                            | wp (once) hoare_vcg_conj_lift hoare_drop_imps)+)+
+                             | wp (once) hoare_vcg_conj_lift hoare_drop_imps)+
   (* TODO: cleanup *)
   apply (intro impI conjI allI
          ; (fastforce simp: guarded_pas_domain_def valid_sched_def
@@ -1964,9 +1817,8 @@ lemma schedule_reads_respects_scheduler_cur_domain:
                             switch_to_cur_domain reads_lrefl)?
          ; (fastforce simp: guarded_pas_domain_def scheduler_equiv_def st_tcb_at_def obj_at_def
                             switch_to_cur_domain valid_sched_def reads_scheduler_def
-                      split: if_splits
+                     split: if_splits
                       dest: domains_distinct[THEN pas_domains_distinct_inj])?)
-
    (* Last remaining goal is more fiddly (duplicated modulo "runnable st")
       We are switching to a new thread but still in the current domain.
       By the domains_distinct condition, we must remain in the current label as well
@@ -1976,19 +1828,74 @@ lemma schedule_reads_respects_scheduler_cur_domain:
                        tcb_domain_map_wellformed_aux_def
                        valid_sched_def valid_sched_action_def weak_valid_sched_action_def
                        switch_in_cur_domain_def in_cur_domain_def
-                 intro: etcb_in_domains_of_state tcb_at_is_etcb_at st_tcb_at_tcb_at
+                intro: etcb_in_domains_of_state tcb_at_is_etcb_at st_tcb_at_tcb_at
                  dest: domains_distinct[THEN pas_domains_distinct_inj]
-                 split: if_splits prod.splits)+
+                split: if_splits prod.splits)+
+
+end
+
+
+lemma switch_to_cur_domain':
+  "\<lbrakk> valid_etcbs s; valid_sched_action s; scheduler_action s = switch_thread x; pas_refined aag s \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag x \<in> pasDomainAbs aag (cur_domain s)"
+  apply (clarsimp simp: valid_sched_def valid_sched_action_def switch_in_cur_domain_def
+                        in_cur_domain_def etcb_at_def weak_valid_sched_action_def
+                        is_etcb_at_def st_tcb_at_def obj_at_def valid_etcbs_def)
+  apply (drule_tac x=x in spec)
+  apply clarsimp
+  apply (drule (1) tcb_domain_wellformed)
+  apply simp
+  done
+
+lemma ethread_set_time_slice_valid_queues[wp]:
+  "ethread_set (tcb_time_slice_update f) t \<lbrace>valid_queues\<rbrace>"
+  apply (simp add: ethread_set_def set_eobject_def)
+  apply wp
+  apply (clarsimp simp: get_etcb_def valid_sched_def valid_etcbs_def is_etcb_at_def valid_queues_def
+                        etcb_at'_def valid_sched_action_def weak_valid_sched_action_def
+                        switch_in_cur_domain_def ct_in_cur_domain_def in_cur_domain_def)
+  apply (intro impI conjI allI ballI)
+   apply fastforce+
+  done
+
+lemma ethread_set_time_slice_valid_sched_action[wp]:
+  "ethread_set (tcb_time_slice_update f) t \<lbrace>valid_sched_action\<rbrace>"
+  apply (simp add: ethread_set_def set_eobject_def)
+  apply wp
+  apply (clarsimp simp: get_etcb_def valid_sched_def valid_etcbs_def is_etcb_at_def valid_queues_def
+                        etcb_at'_def valid_sched_action_def weak_valid_sched_action_def
+                        switch_in_cur_domain_def ct_in_cur_domain_def in_cur_domain_def)
+  done
+
+lemma dec_domain_time_valid_queues[wp]:
+  "dec_domain_time \<lbrace>valid_queues\<rbrace>"
+  apply (simp add: dec_domain_time_def)
+  apply (wp | simp)+
+  done
+
+lemma dec_domain_time_valid_etcbs[wp]:
+  "dec_domain_time \<lbrace>valid_etcbs\<rbrace>"
+  apply (simp add: dec_domain_time_def)
+  apply (wp | simp)+
+  done
+
+lemma dec_domain_time_valid_sched_action[wp]:
+  "dec_domain_time \<lbrace>valid_sched_action\<rbrace>"
+  apply (simp add: dec_domain_time_def)
+  apply (wp | simp)+
+  done
+
+
+context Scheduler_IF_2 begin
 
 definition tick_done where
-"tick_done s \<equiv> domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread"
+  "tick_done s \<equiv> domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread"
 
 lemma schedule_reads_respects_scheduler:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "reads_respects_scheduler aag l
-          (invs and pas_refined aag and valid_sched and
-           guarded_pas_domain aag and tick_done) schedule"
+    "reads_respects_scheduler aag l (invs and pas_refined aag and valid_sched
+                                          and guarded_pas_domain aag and tick_done) schedule"
   apply (rule_tac P="\<lambda>s. reads_scheduler_cur_domain aag l s"
                in equiv_valid_cases)
     apply (rule equiv_valid_guard_imp)
@@ -2004,180 +1911,40 @@ lemma schedule_reads_respects_scheduler:
    apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def)+
   done
 
-lemma reschedule_required_scheduler_equiv[wp]:
-  "\<lbrace>scheduler_equiv aag st\<rbrace> reschedule_required \<lbrace>\<lambda>_. scheduler_equiv aag st\<rbrace>"
-  apply (simp add: reschedule_required_def)
-  apply (wp scheduler_equiv_lift | wpc | simp)+
-  done
-
-lemma switch_to_cur_domain':
-  "\<lbrakk>valid_etcbs s; valid_sched_action s; scheduler_action s = switch_thread x; pas_refined aag s\<rbrakk>
-    \<Longrightarrow> pasObjectAbs aag x \<in> pasDomainAbs aag (cur_domain s)"
-  apply (clarsimp simp add: valid_sched_def
-                            valid_sched_action_def
-                            switch_in_cur_domain_def
-                            in_cur_domain_def etcb_at_def
-                            weak_valid_sched_action_def
-                            is_etcb_at_def st_tcb_at_def
-                            obj_at_def
-                            valid_etcbs_def)
-  apply (drule_tac x=x in spec)
-  apply clarsimp
-  apply (drule(1) tcb_domain_wellformed)
-  apply simp
-  done
-
 lemma reschedule_required_scheduler_affects_equiv_unobservable[wp]:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "\<lbrace>pas_refined aag and
-          (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
-          valid_queues and
-          valid_etcbs and
-          valid_sched_action and
-          scheduler_equiv aag st and
-          scheduler_affects_equiv aag l st\<rbrace>
-         reschedule_required \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
+  shows "\<lbrace>pas_refined aag and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)
+                          and valid_queues and valid_etcbs and valid_sched_action
+                          and scheduler_equiv aag st and scheduler_affects_equiv aag l st\<rbrace>
+         reschedule_required
+         \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
   apply (simp add: reschedule_required_def)
-  apply (wp set_scheduler_action_unobservable
-              tcb_sched_action_unobservable
-          | wpc | simp)+
-  apply ((fastforce intro!: valid_sched_valid_queues
-                     dest!: switch_to_cur_domain' cur_thread_cur_domain)+)
-  done
-
-lemma reads_respects_scheduler_cases':
-  assumes b: "reads_respects_scheduler aag l P' (f t)"
-  assumes b': "\<And>s. Q s \<Longrightarrow> reads_scheduler_cur_domain aag l s \<Longrightarrow> P' s"
-  assumes c: "reads_respects_scheduler aag l P'' (f t)"
-  assumes c': "\<And>s. Q s \<Longrightarrow> \<not> reads_scheduler_cur_domain aag l s \<Longrightarrow> P'' s"
-  shows "reads_respects_scheduler aag l Q (f t)"
-  apply (rule_tac P="\<lambda>s. reads_scheduler_cur_domain aag l s"
-               in equiv_valid_cases)
-    apply (rule equiv_valid_guard_imp)
-     apply (rule b)
-    apply (simp add: b')
-   apply (rule equiv_valid_guard_imp)
-    apply (rule c)
-   apply (simp add: c')
-  apply (simp add: scheduler_equiv_def domain_fields_equiv_def)
+  apply (wp set_scheduler_action_unobservable tcb_sched_action_unobservable | wpc | simp)+
+  apply (fastforce dest!: switch_to_cur_domain' cur_thread_cur_domain)
   done
 
 lemma reschedule_required_reads_respects_scheduler:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_scheduler aag l (pas_refined aag and valid_queues and valid_etcbs and
-                                   valid_sched_action)
-                            reschedule_required"
+  shows "reads_respects_scheduler aag l (pas_refined aag and valid_queues and valid_etcbs
+                                                         and valid_sched_action)
+                                  reschedule_required"
   apply (rule reads_respects_scheduler_cases')
-    apply (simp add: reschedule_required_def)
-    apply (wp | wpc)+
+     apply (simp add: reschedule_required_def)
+     apply (wp | wpc)+
     apply clarsimp
-    apply (rule reads_respects_scheduler_unobservable'')
-    apply (wp | simp | force)+
+   apply (rule reads_respects_scheduler_unobservable'')
+     apply (wp | simp | force)+
   done
-
-
-
-lemma dec_domain_time_reads_respects_scheduler[wp]:
-  "reads_respects_scheduler aag l \<top> dec_domain_time"
-  apply (simp add: dec_domain_time_def)
-  apply (wp ev_modify)
-  apply (fastforce simp add: scheduler_equiv_def
-                            domain_fields_equiv_def
-                            globals_equiv_scheduler_def
-                            scheduler_globals_frame_equiv_def
-                            silc_dom_equiv_def
-                            equiv_for_def
-                            scheduler_affects_equiv_def
-                            states_equiv_for_def equiv_for_def
-                            equiv_asids_def equiv_asid_def idle_equiv_def)
-  done
-
-lemma ethread_set_reads_respects_scheduler:
-  "reads_respects_scheduler aag l (\<lambda>s. pasObjectAbs aag t \<in> reads_scheduler aag l)
-           (ethread_set f t)"
-  apply (clarsimp simp add: thread_set_time_slice_def
-                   ethread_set_def gets_the_def
-                   gets_def get_def bind_def put_def get_etcb_def
-                   return_def assert_opt_def set_eobject_def
-                   fail_def equiv_valid_def2 equiv_valid_2_def
-                 split: option.splits)
-  apply (clarsimp simp add: scheduler_equiv_def domain_fields_equiv_def
-                   globals_equiv_scheduler_def idle_equiv_def
-                   )
-  apply (rule conjI)
-   apply (clarsimp simp: silc_dom_equiv_def reads_scheduler_def
-                         equiv_for_def
-                   split: if_split_asm)
-  apply (simp add: scheduler_affects_equiv_def)
-  apply clarsimp
-  apply (rule conjI)
-   apply (rule states_equiv_for_identical_ekheap_updates,assumption)
-   apply (elim states_equiv_forE equiv_forE)
-   apply (clarsimp simp: identical_ekheap_updates_def)
-  apply (clarsimp simp: scheduler_globals_frame_equiv_def)
-  done
-
-lemma ethread_set_time_slice_valid_queues[wp]:
-  "\<lbrace>valid_queues\<rbrace> ethread_set (tcb_time_slice_update f) t \<lbrace>\<lambda>_. valid_queues\<rbrace>"
-  apply (simp add: ethread_set_def set_eobject_def)
-  apply (wp)
-  apply (clarsimp simp: get_etcb_def valid_sched_def
-                        valid_etcbs_def is_etcb_at_def
-                        valid_queues_def etcb_at'_def
-                        valid_sched_action_def
-                        weak_valid_sched_action_def
-                        switch_in_cur_domain_def
-                        ct_in_cur_domain_def
-                        in_cur_domain_def)
-  apply (intro impI conjI allI ballI)
-  apply fastforce+
-  done
-
-lemma ethread_set_time_slice_valid_sched_action[wp]:
-  "\<lbrace>valid_sched_action\<rbrace> ethread_set (tcb_time_slice_update f) t \<lbrace>\<lambda>_. valid_sched_action\<rbrace>"
-  apply (simp add: ethread_set_def set_eobject_def)
-  apply (wp)
-  apply (clarsimp simp: get_etcb_def valid_sched_def
-                        valid_etcbs_def is_etcb_at_def
-                        valid_queues_def etcb_at'_def
-                        valid_sched_action_def
-                        weak_valid_sched_action_def
-                        switch_in_cur_domain_def
-                        ct_in_cur_domain_def
-                        in_cur_domain_def)
-  done
-
-lemma dec_domain_time_valid_queues[wp]:
-  "\<lbrace>valid_queues\<rbrace> dec_domain_time \<lbrace>\<lambda>_. valid_queues\<rbrace>"
-  apply (simp add: dec_domain_time_def)
-  apply (wp | simp)+
-  done
-
-lemma dec_domain_time_valid_etcbs[wp]:
-  "\<lbrace>valid_etcbs\<rbrace> dec_domain_time \<lbrace>\<lambda>_. valid_etcbs\<rbrace>"
-  apply (simp add: dec_domain_time_def)
-  apply (wp | simp)+
-  done
-
-lemma dec_domain_time_valid_sched_action[wp]:
-  "\<lbrace>valid_sched_action\<rbrace> dec_domain_time \<lbrace>\<lambda>_. valid_sched_action\<rbrace>"
-  apply (simp add: dec_domain_time_def)
-  apply (wp | simp)+
-  done
-
 
 lemma timer_tick_snippit:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-      "reads_respects_scheduler aag l (pas_refined aag and valid_queues and valid_etcbs and
-                                       valid_sched_action)
-            (when (Suc 0 < num_domains)
-                  (do x \<leftarrow> dec_domain_time;
-                      dom_time \<leftarrow> gets domain_time;
-                      when (dom_time = 0) reschedule_required
-                   od))"
+  shows "reads_respects_scheduler aag l (pas_refined aag and valid_queues and valid_etcbs
+                                                         and valid_sched_action)
+                                 (when (Suc 0 < num_domains)
+                                    (do x \<leftarrow> dec_domain_time;
+                                        dom_time \<leftarrow> gets domain_time;
+                                        when (dom_time = 0) reschedule_required
+                                     od))"
   apply (rule equiv_valid_guard_imp)
    apply (wp when_ev | wp (once) hoare_drop_imps)+
        apply (clarsimp simp: scheduler_equiv_def)
@@ -2185,15 +1952,12 @@ lemma timer_tick_snippit:
   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def)
   done
 
-
-
 lemma timer_tick_reads_respects_scheduler_cur_domain:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_scheduler aag l
-     (reads_scheduler_cur_domain aag l and invs and guarded_pas_domain aag and
-      pas_refined aag and valid_sched)
-     timer_tick"
+  shows "reads_respects_scheduler aag l
+           (reads_scheduler_cur_domain aag l and invs and guarded_pas_domain aag
+                                             and pas_refined aag and valid_sched)
+           timer_tick"
   apply (simp add: timer_tick_def)
   apply (subst Let_def)
   apply (subst thread_set_time_slice_def)+
@@ -2201,34 +1965,19 @@ lemma timer_tick_reads_respects_scheduler_cur_domain:
             ethread_set_reads_respects_scheduler
             get_thread_state_reads_respects_scheduler gts_wp
          | wpc | wp (once) hoare_drop_imps)+
-  apply (fastforce simp add: invs_def valid_state_def valid_idle_def
-                            pred_tcb_at_def obj_at_def guarded_pas_domain_def
-                            scheduler_equiv_def domain_fields_equiv_def
-                            valid_sched_def valid_sched_action_def
+  apply (fastforce simp: invs_def valid_state_def valid_idle_def pred_tcb_at_def obj_at_def
+                         guarded_pas_domain_def scheduler_equiv_def domain_fields_equiv_def
+                         valid_sched_def valid_sched_action_def
                   split: option.splits
-                  dest: domains_distinct[THEN pas_domains_distinct_inj])
+                   dest: domains_distinct[THEN pas_domains_distinct_inj])
   done
-
-lemma ethread_set_unobservable[wp]:
-   "\<lbrace>(\<lambda>s. pasObjectAbs aag t \<notin> reads_scheduler aag l) and scheduler_affects_equiv aag l st\<rbrace>
-       ethread_set f t
-    \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
-  apply (simp add: ethread_set_def set_eobject_def)
-  apply wp
-  apply (clarsimp simp: get_etcb_def
-                        scheduler_affects_equiv_def)
-  apply (elim states_equiv_forE equiv_forE)
-  apply (clarsimp simp: equiv_for_def states_equiv_for_def
-                        equiv_asids_def equiv_asid_def)+
-  done
-
 
 lemma timer_tick_reads_respects_scheduler_unobservable:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_scheduler aag l ((\<lambda>s. \<not>reads_scheduler_cur_domain aag l s) and invs and guarded_pas_domain aag and
-                                   pas_refined aag and valid_sched)
-                            timer_tick"
+  shows "reads_respects_scheduler aag l
+           ((\<lambda>s. \<not>reads_scheduler_cur_domain aag l s) and invs and guarded_pas_domain aag
+                                                      and pas_refined aag and valid_sched)
+           timer_tick"
   apply (simp add: timer_tick_def)
   apply (subst Let_def)
   apply (subst thread_set_time_slice_def)+
@@ -2236,8 +1985,8 @@ lemma timer_tick_reads_respects_scheduler_unobservable:
   apply (rule bind_ev_pre)
      apply (simp add: bind_assoc)
      apply (rule timer_tick_snippit[OF domains_distinct])
-    apply (rule_tac P=\<top> and P'="(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and invs and guarded_pas_domain aag and
-                                 pas_refined aag and valid_sched"
+    apply (rule_tac P=\<top> and P'="(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and invs and
+                                 guarded_pas_domain aag and pas_refined aag and valid_sched"
                  in reads_respects_scheduler_unobservable'')
       apply (rule hoare_pre)
        apply (rule scheduler_equiv_lift)
@@ -2249,17 +1998,15 @@ lemma timer_tick_reads_respects_scheduler_unobservable:
         apply ((clarsimp simp add: st_tcb_at_def obj_at_def valid_sched_def)+)[3]
      apply (fastforce dest!: cur_thread_cur_domain)
     apply force
-   apply (wp gts_wp| wpc)+
+   apply (wp gts_wp | wpc)+
   apply (clarsimp simp: etcb_at_def valid_sched_def st_tcb_at_def
                         obj_at_def valid_sched_action_def split: option.splits)
   done
 
 lemma timer_tick_reads_respects_scheduler:
   assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects_scheduler aag l (invs and guarded_pas_domain aag and pas_refined aag and
-                                   valid_sched)
-                            timer_tick"
+  shows "reads_respects_scheduler aag l
+           (invs and guarded_pas_domain aag and pas_refined aag and valid_sched) timer_tick"
   apply (rule reads_respects_scheduler_cases')
      apply (rule timer_tick_reads_respects_scheduler_cur_domain[OF domains_distinct])
     apply simp
@@ -2267,78 +2014,17 @@ lemma timer_tick_reads_respects_scheduler:
   apply simp
   done
 
+end
+
 
 lemma gets_ev':
   "equiv_valid_inv I A (P and K(\<forall>s t. P s \<longrightarrow> P t \<longrightarrow> I s t \<and> A s t \<longrightarrow> f s = f t)) (gets f)"
-  by (clarsimp simp: equiv_valid_def2 equiv_valid_2_def
-                     gets_def get_def bind_def
-                     return_def)
-
-lemma get_irq_state_reads_respects_scheduler_trivial:
-  "reads_respects_scheduler aag l (domain_sep_inv False st) (get_irq_state irq)"
-  apply (simp add: get_irq_state_def)
-  apply (rule equiv_valid_guard_imp)
-  apply (rule_tac P="domain_sep_inv False st" in  gets_ev')
-  apply clarsimp
-  apply (clarsimp simp: domain_sep_inv_def)
-  done
-
-
-lemma resetTimer_underlying_memory[wp]:
-  "\<lbrace>\<lambda>s. P(underlying_memory s)\<rbrace> resetTimer \<lbrace>\<lambda>r s. P (underlying_memory s)\<rbrace>"
-  apply (simp add: resetTimer_def machine_op_lift_def machine_rest_lift_def)
-  apply (wp | wpc| simp)+
-  done
-
-lemma resetTimer_irq_state[wp]:
-  "\<lbrace>\<lambda>s. P(irq_state s)\<rbrace> resetTimer \<lbrace>\<lambda>r s. P (irq_state s)\<rbrace>"
-  apply (simp add: resetTimer_def machine_op_lift_def machine_rest_lift_def)
-  apply (wp | wpc| simp)+
-  done
-
-
-lemma dmo_resetTimer_underlying_memory[wp]:
-  "\<lbrace>\<lambda>s. P(underlying_memory (machine_state s))\<rbrace>
-      do_machine_op resetTimer
-   \<lbrace>\<lambda>r s. P (underlying_memory (machine_state s))\<rbrace>"
-  apply (wp dmo_wp | simp)+
-  done
-
-lemma dmo_resetTimer_arch_state[wp]:
-  "\<lbrace>\<lambda>s. P(arch_state s)\<rbrace> do_machine_op resetTimer \<lbrace>\<lambda>r s. P (arch_state s)\<rbrace>"
-  by (wp dmo_wp | simp)+
-
-lemma dmo_resetTimer_device_state[wp]:
-  "\<lbrace>\<lambda>s. P( device_state (machine_state s))\<rbrace>
-      do_machine_op resetTimer
-   \<lbrace>\<lambda>r s. P (device_state (machine_state s))\<rbrace>"
-  by (wp dmo_wp | simp)+
-
-lemma dmo_resetTimer_exclusive_state[wp]:
-  "\<lbrace>\<lambda>s. P (exclusive_state (machine_state s))\<rbrace>
-      do_machine_op resetTimer
-   \<lbrace>\<lambda>r s. P (exclusive_state (machine_state s))\<rbrace>"
-  by (wp dmo_mol_exclusive_state | simp add: resetTimer_def)+
-
-lemma dmo_resetTimer_reads_respects_scheduler:
-  "reads_respects_scheduler aag l \<top> (do_machine_op resetTimer)"
-  apply (rule reads_respects_scheduler_unobservable)
-   apply (rule scheduler_equiv_lift)
-        apply (simp add: globals_equiv_scheduler_def[abs_def] idle_equiv_def)
-        apply (rule hoare_pre)
-         apply wps
-         apply wp
-        apply clarsimp
-       apply ((wp silc_dom_lift dmo_wp | simp)+)[5]
-  apply (rule scheduler_affects_equiv_unobservable)
-     apply (simp add: states_equiv_for_def[abs_def] equiv_for_def equiv_asids_def
-                      equiv_asid_def)
-     apply (rule hoare_pre)
-  apply (wp | simp | wp dmo_wp)+
-  done
+  by (clarsimp simp: equiv_valid_def2 equiv_valid_2_def gets_def get_def bind_def return_def)
 
 lemma irq_inactive_or_timer:
-  "\<lbrace>domain_sep_inv False st and Q IRQTimer and Q IRQInactive\<rbrace> get_irq_state irq \<lbrace>Q\<rbrace>"
+  "\<lbrace>domain_sep_inv False st and Q IRQTimer and Q IRQInactive\<rbrace>
+   get_irq_state irq
+   \<lbrace>Q\<rbrace>"
   apply (simp add:get_irq_state_def)
   apply wp
   apply (clarsimp simp add: domain_sep_inv_def)
@@ -2348,82 +2034,22 @@ lemma irq_inactive_or_timer:
   apply (drule_tac x=aa in spec, drule_tac x=ba in spec)
   apply clarsimp
   apply (case_tac "interrupt_states st irq")
-    apply clarsimp+
+     apply clarsimp+
   done
-
-lemma ackInterrupt_no_irq[wp]:
-  "no_irq (ackInterrupt irq)"
-  apply (clarsimp simp add:no_irq_def)
-  apply (wp dmo_wp ackInterrupt_irq_masks | simp add:no_irq_def)+
-  done
-
-crunch irq_state[wp]: ackInterrupt "\<lambda>s. P (irq_state s)"
-
-lemma ackInterrupt_reads_respects_scheduler:
-  "reads_respects_scheduler aag l \<top> (do_machine_op (ackInterrupt irq))"
-  apply (rule reads_respects_scheduler_unobservable)
-   apply (rule scheduler_equiv_lift)
-        apply (simp add:  globals_equiv_scheduler_def[abs_def] idle_equiv_def)
-        apply (rule hoare_pre)
-         apply wps
-         apply (wp dmo_wp ackInterrupt_irq_masks | simp add:no_irq_def)+
-         apply clarsimp
-        apply ((wp silc_dom_lift dmo_wp | simp)+)[5]
-  apply (rule scheduler_affects_equiv_unobservable)
-        apply (simp add: states_equiv_for_def[abs_def] equiv_for_def equiv_asids_def equiv_asid_def)
-        apply (rule hoare_pre)
-         apply wps
-         apply (wp dmo_wp | simp add:ackInterrupt_def)+
-   apply (wp mol_exclusive_state)
-  apply assumption
-  done
-
-
-
-lemma handle_interrupt_reads_respects_scheduler:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_scheduler aag l (invs and guarded_pas_domain aag and pas_refined aag and
-                                   valid_sched and domain_sep_inv False st and K (irq \<le> maxIRQ))
-                            (handle_interrupt irq)"
-  apply (simp add: handle_interrupt_def )
-  apply (rule conjI; rule impI )
-   apply (rule gen_asm_ev)
-   apply simp
-  apply (wp modify_wp | simp )+
-  apply (rule ackInterrupt_reads_respects_scheduler)
-     apply (rule_tac Q="rv = IRQTimer \<or> rv = IRQInactive" in gen_asm_ev(2))
-     apply (elim disjE)
-      apply (wp timer_tick_reads_respects_scheduler
-        ackInterrupt_reads_respects_scheduler
-        dmo_resetTimer_reads_respects_scheduler
-        get_irq_state_reads_respects_scheduler_trivial
-        fail_ev irq_inactive_or_timer | simp )+
-   apply force
-  done
-
 
 (*FIXME: MOVE corres-like statement for out of step equiv_valid. Move to scheduler_IF?*)
 lemma equiv_valid_2_bind_right:
-  "\<lbrakk>\<And>rv. equiv_valid_2 D A A R T' (Q rv) g' (g rv);
-    \<lbrace>S\<rbrace> f \<lbrace>Q\<rbrace>;
-    \<And>st. \<lbrace>D st and A st and S'\<rbrace> f \<lbrace>\<lambda>r. D st\<rbrace>;
-    \<And>st. \<lbrace>A st and D st and S''\<rbrace> f \<lbrace>\<lambda>r. A st\<rbrace>;
-    \<And>s. T s \<Longrightarrow> P s \<and> S s \<and> S' s \<and> S'' s;
-    \<And>s. T' s \<Longrightarrow> P s\<rbrakk>
-   \<Longrightarrow> equiv_valid_2 D A A R T' T g' (f >>= g) "
+  "\<lbrakk> \<And>rv. equiv_valid_2 D A A R T' (Q rv) g' (g rv);
+     \<lbrace>S\<rbrace> f \<lbrace>Q\<rbrace>;
+     \<And>st. \<lbrace>D st and A st and S'\<rbrace> f \<lbrace>\<lambda>r. D st\<rbrace>;
+     \<And>st. \<lbrace>A st and D st and S''\<rbrace> f \<lbrace>\<lambda>r. A st\<rbrace>;
+     \<And>s. T s \<Longrightarrow> P s \<and> S s \<and> S' s \<and> S'' s;
+     \<And>s. T' s \<Longrightarrow> P s\<rbrakk>
+     \<Longrightarrow> equiv_valid_2 D A A R T' T g' (f >>= g) "
   apply atomize
   apply (clarsimp simp: equiv_valid_2_def equiv_valid_def2 valid_def bind_def)
   apply fastforce
   done
-
-(*FIXME: Move to scheduler_IF*)
-lemma reads_respects_only_scheduler:
-  "reads_respects_scheduler aag SilcLabel P f \<Longrightarrow> equiv_valid_inv (scheduler_equiv aag) \<top>\<top> P f"
-  by (fastforce simp: equiv_valid_def2 equiv_valid_2_def scheduler_affects_equiv_def
-                      reads_scheduler_def
-                      states_equiv_for_def equiv_for_def scheduler_equiv_def equiv_asids_def
-                      equiv_asid_def globals_equiv_scheduler_def)
 
 (*FIXME: MOVE do_machine_op distributing over binds/basic operations*)
 lemma dmo_distr:
@@ -2433,198 +2059,139 @@ lemma dmo_distr:
                   bind_def get_def return_def)
   apply (rule ext)
   apply safe
-      apply ((clarsimp, force)+)[5]
+       apply ((clarsimp, force)+)[5]
   apply (simp add: image_def)
   done
 
 lemma dmo_if_distr:
   "do_machine_op (if A then f else g) = (if A then (do_machine_op f) else (do_machine_op g))"
-  apply simp
-  done
+  by simp
 
 lemma dmo_gets_distr:
-  "do_machine_op (gets f) = (gets (\<lambda>s. f (machine_state s)))"
-  apply (clarsimp simp: do_machine_op_def bind_assoc)
-  apply (clarsimp simp: gets_def simpler_modify_def select_f_def
-                  bind_def get_def return_def)
-  done
+  "do_machine_op (gets f) = gets (\<lambda>s. f (machine_state s))"
+  by (clarsimp simp: do_machine_op_def bind_assoc gets_def get_def
+                     simpler_modify_def select_f_def bind_def return_def)
 
 lemma dmo_modify_distr:
   "do_machine_op (modify f) = modify (machine_state_update f)"
-  apply (clarsimp simp: do_machine_op_def bind_assoc)
-  apply (clarsimp simp: gets_def simpler_modify_def select_f_def
-                  bind_def get_def return_def)
-  apply (rule ext)
+  by (fastforce simp: do_machine_op_def bind_assoc gets_def get_def
+                      simpler_modify_def select_f_def bind_def return_def)
+
+
+context Scheduler_IF_1 begin
+
+lemma get_irq_state_reads_respects_scheduler_trivial:
+  "reads_respects_scheduler aag l (domain_sep_inv False st) (get_irq_state irq)"
+  apply (simp add: get_irq_state_def)
+  apply (rule equiv_valid_guard_imp)
+   apply (rule_tac P="domain_sep_inv False st" in  gets_ev')
   apply clarsimp
+  apply (clarsimp simp: domain_sep_inv_def)
   done
 
-lemma dmo_return_distr:
-  "do_machine_op (return x) = return x"
-  apply (clarsimp simp: do_machine_op_def bind_assoc)
-  apply (clarsimp simp: gets_def simpler_modify_def select_f_def
-                  bind_def get_def return_def)
-  done
+(*FIXME: Move to scheduler_IF*)
+lemma reads_respects_only_scheduler:
+  "reads_respects_scheduler aag SilcLabel P f \<Longrightarrow> equiv_valid_inv (scheduler_equiv aag) \<top>\<top> P f"
+  by (fastforce simp: equiv_valid_def2 equiv_valid_2_def scheduler_affects_equiv_def
+                      reads_scheduler_def states_equiv_for_def equiv_for_def scheduler_equiv_def
+                      equiv_asids_def globals_equiv_scheduler_def)
 
-(*FIXME: Move to scheduler_if*)
-lemma dmo_getActive_IRQ_reads_respect_scheduler:
-  "reads_respects_scheduler aag l (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
-          (do_machine_op (getActiveIRQ in_kernel))"
-  apply (simp add: getActiveIRQ_def)
-  apply (simp add: dmo_distr dmo_if_distr dmo_gets_distr dmo_modify_distr dmo_return_distr
-             cong: if_cong)
-  apply wp
-      apply (rule ev_modify[where P=\<top>])
-      apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def
-                             globals_equiv_scheduler_def)
-      apply (clarsimp simp add: scheduler_affects_equiv_def states_equiv_for_def
-                       equiv_for_def equiv_asids_def equiv_asid_def
-                       scheduler_globals_frame_equiv_def silc_dom_equiv_def
-                       idle_equiv_def)
-     apply wp
-    apply (rule_tac P="\<lambda>s. irq_masks_of_state st = irq_masks_of_state s" in gets_ev')
-   apply wp
-  apply clarsimp
-  apply (simp add: scheduler_equiv_def)
-  done
+lemma get_tcb_scheduler_equiv:
+  "\<lbrakk> pasObjectAbs aag rv \<in> reads_scheduler aag l; scheduler_affects_equiv aag l s t \<rbrakk>
+     \<Longrightarrow> get_tcb rv s = get_tcb rv t"
+  by (clarsimp simp: get_tcb_def scheduler_affects_equiv_def states_equiv_for_def equiv_for_def
+              split: option.splits kernel_object.splits)
 
-definition idle_context
-where
-  "idle_context s = arch_tcb_context_get (tcb_arch (the (get_tcb (idle_thread s) s)))"
+end
 
-lemma thread_set_context_globals_equiv:
-  "\<lbrace>(\<lambda>s. t = idle_thread s \<longrightarrow> tc = idle_context s) and invs and globals_equiv st\<rbrace>
-     thread_set (tcb_arch_update (arch_tcb_context_set tc)) t
-   \<lbrace>\<lambda>rv. globals_equiv st\<rbrace>"
-  apply (clarsimp simp: thread_set_def)
-  apply (wpsimp wp: set_object_wp)
-  apply (subgoal_tac "t \<noteq> arm_global_pd (arch_state s)")
-   apply (clarsimp simp: idle_equiv_def globals_equiv_def tcb_at_def2 get_tcb_def idle_context_def)
-   apply (clarsimp split: option.splits kernel_object.splits)
-  apply (drule arm_global_pd_not_tcb[OF invs_valid_ko_at_arm])
-  apply clarsimp
+context Scheduler_IF_2 begin
+
+lemma handle_interrupt_reads_respects_scheduler:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows
+    "reads_respects_scheduler aag l (invs and guarded_pas_domain aag and pas_refined aag and
+                                     valid_sched and domain_sep_inv False st and K (irq \<le> maxIRQ))
+                              (handle_interrupt irq)"
+  apply (simp add: handle_interrupt_def )
+  apply (rule conjI; rule impI )
+   apply (rule gen_asm_ev)
+   apply simp
+  apply (wp modify_wp | simp )+
+       apply (rule ackInterrupt_reads_respects_scheduler)
+      apply (rule_tac Q="rv = IRQTimer \<or> rv = IRQInactive" in gen_asm_ev(2))
+      apply (elim disjE)
+       apply (wpsimp wp: timer_tick_reads_respects_scheduler ackInterrupt_reads_respects_scheduler
+                         get_irq_state_reads_respects_scheduler_trivial irq_inactive_or_timer
+                         dmo_resetTimer_reads_respects_scheduler fail_ev)+
+  apply force
   done
 
 lemma thread_set_scheduler_equiv[wp]:
   "\<lbrace>(invs and K(pasObjectAbs aag t \<noteq> SilcLabel) and
-    (\<lambda>s. t = idle_thread s \<longrightarrow> tc = idle_context s)) and scheduler_equiv aag st\<rbrace>
-     thread_set (tcb_arch_update (arch_tcb_context_set tc)) t
-   \<lbrace>\<lambda>r. scheduler_equiv aag st\<rbrace>"
+     (\<lambda>s. t = idle_thread s \<longrightarrow> tc = idle_context s)) and scheduler_equiv aag st\<rbrace>
+   thread_set (tcb_arch_update (arch_tcb_context_set tc)) t
+   \<lbrace>\<lambda>_. scheduler_equiv aag st\<rbrace>"
   apply (rule scheduler_equiv_lift')
        apply (rule globals_equiv_scheduler_inv')
-       apply (wp thread_set_context_globals_equiv | clarsimp intro!: invs_valid_ko_at_arm)+
+       apply (wpsimp wp: thread_set_context_globals_equiv | simp)+
   apply (simp add: silc_dom_equiv_def thread_set_def)
   apply (wp set_object_wp)
   apply (clarsimp simp: get_tcb_def equiv_for_def split: kernel_object.splits option.splits)
   done
 
-lemma arch_tcb_update_aux:
-  "(tcb_arch_update f t) = tcb_arch_update (\<lambda>_. f (tcb_arch t)) t"
-  by simp
-
-lemma thread_set_scheduler_affects_equiv[wp]:
-  "\<lbrace>(\<lambda>s. x \<noteq> idle_thread s \<longrightarrow> pasObjectAbs aag x \<notin> reads_scheduler aag l) and
-        (\<lambda>s. x = idle_thread s \<longrightarrow> tc = idle_context s) and scheduler_affects_equiv aag l st\<rbrace>
-     thread_set (tcb_arch_update (arch_tcb_context_set tc)) x
-   \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
-  apply (simp add: thread_set_def)
-  apply (wp set_object_wp)
-  apply (intro impI conjI)
-  apply (case_tac "x \<noteq> idle_thread s",simp_all)
-   apply (clarsimp simp: scheduler_affects_equiv_def get_tcb_def scheduler_globals_frame_equiv_def
-                  split: option.splits kernel_object.splits)
-   apply (elim states_equiv_forE equiv_forE)
-   apply (rule states_equiv_forI,simp_all add: equiv_for_def equiv_asids_def equiv_asid_def)
-   apply (clarsimp simp: obj_at_def)
-  apply (clarsimp simp: idle_context_def get_tcb_def
-                  split: option.splits kernel_object.splits)
-  apply (subst arch_tcb_update_aux)
-  apply simp
-  apply (subgoal_tac "s = (s\<lparr>kheap := kheap s(idle_thread s \<mapsto> TCB y)\<rparr>)", simp)
-  apply (rule state.equality)
-            apply (rule ext)
-            apply simp+
-  done
-
-
-lemma silc_inv_not_cur_thread:
-  "silc_inv aag st s \<Longrightarrow> invs s \<Longrightarrow> pasObjectAbs aag (cur_thread s) \<noteq> SilcLabel"
-  apply (clarsimp simp: silc_inv_def)
-  apply (drule_tac x="(cur_thread s)" in spec)
-  apply clarsimp
-  apply (clarsimp simp add: obj_at_def invs_def cur_tcb_def
-                  is_cap_table_def is_tcb_def)
-  apply (case_tac ko,simp_all)
-  done
-
-lemma get_tcb_scheduler_equiv:
-  "\<lbrakk>pasObjectAbs aag rv \<in> reads_scheduler aag l;
-    scheduler_affects_equiv aag l s t\<rbrakk> \<Longrightarrow>
-   get_tcb rv s = get_tcb rv t"
-  apply (clarsimp simp: get_tcb_def scheduler_affects_equiv_def
-                  states_equiv_for_def equiv_for_def
-                  split: option.splits kernel_object.splits)
-  done
-
-
-lemma idle_equiv_identical_kheap_updates:
-  "\<lbrakk>identical_kheap_updates s t kh kh'; idle_equiv s t\<rbrakk>
-   \<Longrightarrow> idle_equiv (s\<lparr>kheap := kh\<rparr>) (t\<lparr>kheap := kh'\<rparr>)"
-  apply (clarsimp simp add: identical_kheap_updates_def idle_equiv_def
-                  tcb_at_def2)
-  apply (drule_tac x="idle_thread t" in spec)
-  apply fastforce
-  done
-
-lemma set_object_reads_respects_scheduler[wp]:
-  "reads_respects_scheduler aag l \<top> (set_object ptr obj)"
-  unfolding equiv_valid_def2 equiv_valid_2_def
-  apply(clarsimp simp: set_object_def bind_def get_def put_def return_def
-                       get_object_def assert_def fail_def gets_def
-                       scheduler_equiv_def domain_fields_equiv_def
-                       globals_equiv_scheduler_def silc_dom_equiv_def)
-  apply (clarsimp simp: equiv_for_def scheduler_affects_equiv_def
-                        scheduler_globals_frame_equiv_def identical_kheap_updates_def
-                intro!: states_equiv_for_identical_kheap_updates
-                        idle_equiv_identical_kheap_updates)
-  apply (intro conjI impI)
-      apply (clarsimp simp: equiv_for_def scheduler_affects_equiv_def
-                            scheduler_globals_frame_equiv_def identical_kheap_updates_def
-            | rule states_equiv_for_identical_kheap_updates idle_equiv_identical_kheap_updates)+
-  done
-
 lemma sts_reads_respects_scheduler:
   "reads_respects_scheduler aag l
-     (K(pasObjectAbs aag rv \<in> reads_scheduler aag l) and
-      reads_scheduler_cur_domain aag l and
-      valid_idle and (\<lambda>s. rv \<noteq> idle_thread s))
+     (K (pasObjectAbs aag rv \<in> reads_scheduler aag l) and reads_scheduler_cur_domain aag l
+                                                      and valid_idle and (\<lambda>s. rv \<noteq> idle_thread s))
      (set_thread_state rv st)"
   apply (simp add: set_thread_state_def)
   apply (simp add: set_thread_state_ext_def)
-  apply (wp when_ev get_thread_state_reads_respects_scheduler
-            gts_wp set_object_wp)
-  apply (clarsimp simp: get_tcb_scheduler_equiv)
-  apply (clarsimp simp: valid_idle_def pred_tcb_at_def
-                        obj_at_def)
+  apply (wp when_ev get_thread_state_reads_respects_scheduler gts_wp set_object_wp)
+  apply (clarsimp simp: get_tcb_scheduler_equiv valid_idle_def pred_tcb_at_def obj_at_def)
   done
 
-
 lemma as_user_reads_respects_scheduler:
-  "reads_respects_scheduler aag l (K(pasObjectAbs aag rv \<in> reads_scheduler aag l) and
-                                   (\<lambda>s. rv \<noteq> idle_thread s) and K(det f))
-        (as_user rv f)"
+  "reads_respects_scheduler aag l (K (pasObjectAbs aag rv \<in> reads_scheduler aag l) and
+                                   (\<lambda>s. rv \<noteq> idle_thread s) and K (det f))
+                            (as_user rv f)"
   apply (rule gen_asm_ev)
   apply (simp add: as_user_def)
   apply (wp select_f_ev | wpc | simp)+
   apply (clarsimp simp: get_tcb_scheduler_equiv)
   done
 
+end
+
+
+lemma arch_tcb_update_aux:
+  "tcb_arch_update f t = tcb_arch_update (\<lambda>_. f (tcb_arch t)) t"
+  by simp
+
+lemma silc_inv_not_cur_thread:
+  "\<lbrakk> silc_inv aag st s; invs s \<rbrakk> \<Longrightarrow> pasObjectAbs aag (cur_thread s) \<noteq> SilcLabel"
+  apply (clarsimp simp: silc_inv_def)
+  apply (drule_tac x="(cur_thread s)" in spec)
+  apply clarsimp
+  apply (clarsimp simp: obj_at_def invs_def cur_tcb_def is_cap_table_def is_tcb_def)
+  apply (case_tac ko, simp_all)
+  done
+
+lemma idle_equiv_identical_kheap_updates:
+  "\<lbrakk> identical_kheap_updates s t kh kh'; idle_equiv s t \<rbrakk>
+     \<Longrightarrow> idle_equiv (s\<lparr>kheap := kh\<rparr>) (t\<lparr>kheap := kh'\<rparr>)"
+  apply (clarsimp simp: identical_kheap_updates_def idle_equiv_def tcb_at_def2)
+  apply (drule_tac x="idle_thread t" in spec)
+  apply fastforce
+  done
+
 lemma restart_not_idle:
-  "valid_idle s \<Longrightarrow> st_tcb_at ((=) Restart) t s \<Longrightarrow> t \<noteq> idle_thread s"
+  "\<lbrakk> valid_idle s; st_tcb_at ((=) Restart) t s \<rbrakk>
+     \<Longrightarrow> t \<noteq> idle_thread s"
   by (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def)
 
 lemma sts_silc_dom_equiv[wp]:
-  "\<lbrace>K(pasObjectAbs aag x \<noteq> SilcLabel) and silc_dom_equiv aag st\<rbrace>
-      set_thread_state x f
+  "\<lbrace>K (pasObjectAbs aag x \<noteq> SilcLabel) and silc_dom_equiv aag st\<rbrace>
+   set_thread_state x f
    \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
   apply (simp add: set_thread_state_def)
   apply (wp dxo_wp_weak set_object_wp | simp)+
@@ -2632,55 +2199,58 @@ lemma sts_silc_dom_equiv[wp]:
   done
 
 lemma as_user_silc_dom_equiv[wp]:
-  "\<lbrace>K(pasObjectAbs aag x \<noteq> SilcLabel) and silc_dom_equiv aag st\<rbrace>
-      as_user x f
+  "\<lbrace>K (pasObjectAbs aag x \<noteq> SilcLabel) and silc_dom_equiv aag st\<rbrace>
+   as_user x f
    \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
   apply (simp add: as_user_def)
   apply (wp dxo_wp_weak set_object_wp | wpc | simp)+
   apply (clarsimp simp: silc_dom_equiv_def equiv_for_def)
   done
 
-lemma scheduler_affects_equiv_update:
-  "\<lbrakk>get_tcb x s = Some y;
-    pasObjectAbs aag x \<notin> reads_scheduler aag l;
-    scheduler_affects_equiv aag l st s\<rbrakk>
-   \<Longrightarrow> scheduler_affects_equiv aag l st (s\<lparr>kheap := kheap s(x \<mapsto> TCB y')\<rparr>)"
-  apply (clarsimp simp: scheduler_affects_equiv_def
-                        states_equiv_for_def equiv_for_def
-                        equiv_asids_def equiv_asid_def)
-  apply (clarsimp simp: scheduler_globals_frame_equiv_def)
-  apply (clarsimp simp: obj_at_def st_tcb_at_def get_tcb_def)
-  done
-
 lemma set_scheduler_action_wp[wp]:
   "\<lbrace>\<lambda>s. P () (s\<lparr>scheduler_action := a\<rparr>)\<rbrace> set_scheduler_action a \<lbrace>P\<rbrace>"
-  apply(simp add: set_scheduler_action_def | wp)+
-  done
+  by (simp add: set_scheduler_action_def | wp)+
+
+
+context Scheduler_IF_1 begin
+
+lemma scheduler_affects_equiv_update:
+  "\<lbrakk> get_tcb x s = Some y; pasObjectAbs aag x \<notin> reads_scheduler aag l;
+     scheduler_affects_equiv aag l st s \<rbrakk>
+     \<Longrightarrow> scheduler_affects_equiv aag l st (s\<lparr>kheap := kheap s(x \<mapsto> TCB y')\<rparr>)"
+  by (clarsimp simp: scheduler_affects_equiv_def equiv_for_def equiv_asids_def
+                     states_equiv_for_def scheduler_globals_frame_equiv_def
+                     arch_scheduler_affects_equiv_update equiv_asid_equiv_update)
 
 lemma sts_scheduler_affects_equiv[wp]:
-  "\<lbrace>K(pasObjectAbs aag x \<notin> reads_scheduler aag l) and scheduler_affects_equiv aag l st\<rbrace>
-       set_thread_state x Running
+  "\<lbrace>K (pasObjectAbs aag x \<notin> reads_scheduler aag l) and scheduler_affects_equiv aag l st\<rbrace>
+   set_thread_state x Running
    \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
   apply (simp add: set_thread_state_def)
   apply (simp add: set_thread_state_ext_def)
-
   apply (wp gts_wp set_object_wp)
   apply (intro impI conjI allI)
   apply (clarsimp simp: st_tcb_at_def obj_at_def)
   apply (fastforce intro!: scheduler_affects_equiv_update)
   done
 
-
 lemma as_user_scheduler_affects_equiv[wp]:
-  "\<lbrace>K(pasObjectAbs aag x \<notin> reads_scheduler aag l) and scheduler_affects_equiv aag l st\<rbrace>
-      as_user x f
+  "\<lbrace>K (pasObjectAbs aag x \<notin> reads_scheduler aag l) and scheduler_affects_equiv aag l st\<rbrace>
+   as_user x f
    \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
   apply (simp add: as_user_def)
-
   apply (wp gts_wp set_object_wp | wpc)+
   apply (intro impI conjI allI)
   apply (fastforce intro!: scheduler_affects_equiv_update)
   done
+
+lemma SilcLabel_affects_scheduler_equiv:
+  "scheduler_equiv aag s t \<Longrightarrow> scheduler_affects_equiv aag SilcLabel s t"
+  by (simp add: scheduler_affects_equiv_def reads_scheduler_def states_equiv_for_def
+                equiv_for_def scheduler_equiv_def equiv_asids_def globals_equiv_scheduler_def)
+
+end
+
 
 (* FIXME: MOVE *)
 lemma st_tcb_at_not_idle_thread:
@@ -2688,37 +2258,6 @@ lemma st_tcb_at_not_idle_thread:
   apply (frule st_tcb_at_tcb_at)
   apply (fastforce dest: st_tcb_at_idle_thread)
   done
-
-lemma activate_thread_reads_respects_scheduler[wp]:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_scheduler aag l (invs and silc_inv aag st and guarded_pas_domain aag)
-                  activate_thread"
-  apply (simp add: activate_thread_def)
-  apply (rule reads_respects_scheduler_cases')
-     apply ((wp sts_reads_respects_scheduler get_thread_state_reads_respects_scheduler gts_wp
-               as_user_reads_respects_scheduler | wpc
-              | simp add: setNextPC_det arch_activate_idle_thread_def)+)[1]
-    apply (intro impI conjI allI
-          ; fastforce simp: getRestartPC_det guarded_pas_domain_def reads_scheduler_def
-                             restart_not_idle invs_valid_idle
-                       dest: st_tcb_at_not_idle_thread
-                             domains_distinct[THEN pas_domains_distinct_inj])
-   apply (rule reads_respects_scheduler_unobservable''
-                 [where P'="\<lambda>s. \<not> reads_scheduler_cur_domain aag l s \<and> guarded_pas_domain aag s \<and> invs s"])
-     apply ((wp scheduler_equiv_lift'[where P="invs and silc_inv aag st"]
-                globals_equiv_scheduler_inv'[where P="valid_ko_at_arm and valid_idle"]
-                set_thread_state_globals_equiv gts_wp
-            | wpc
-            | clarsimp simp: arch_activate_idle_thread_def restart_not_idle invs_valid_ko_at_arm
-                             silc_inv_not_cur_thread
-            | force)+)[1]
-    apply (wp gts_wp| wpc | simp add: arch_activate_idle_thread_def)+
-    apply (clarsimp simp add: guarded_pas_domain_def restart_not_idle
-                    invs_valid_idle)
-   apply force+
-  done
-
 
 (*A function that is agnostic of its parameter with respect
   to the state space (as is the case with thread context updates)
@@ -2728,56 +2267,38 @@ lemma agnostic_to_ev2:
   assumes ret_agnostic: "\<And>u. \<lbrace>\<top>\<rbrace> (f u) \<lbrace>\<lambda>r s. r = g u\<rbrace>"
   assumes ev: "\<And>u. equiv_valid I A B P (f u)"
   shows "equiv_valid_2 I A B (\<lambda>r r'. r = (g u) \<and> r' = (g u')) P P (f u) (f u')"
-  proof -
-    have b: "\<And>a b s u. (a,b) \<in> fst (f u s) \<Longrightarrow> a = g u"
+proof -
+  have b: "\<And>a b s u. (a,b) \<in> fst (f u s) \<Longrightarrow> a = g u"
 
-      apply (erule use_valid[OF _ ret_agnostic])
-      apply simp
-      done
-    have a: "\<And>a b u u' s. (a,b) \<in> fst (f u s) \<Longrightarrow> \<exists>a'. (a',b) \<in> fst (f u' s)"
-      apply (cut_tac P="\<lambda>sa. sa = s" and Q="\<lambda>s'. \<exists>a'. (a',s') \<in> fst (f u' s)"
-                 and u=u' and u'=u in param_agnostic[rule_format])
-      apply (clarsimp simp: valid_def)
-      apply force
-      apply (clarsimp simp: valid_def)
-      apply (drule_tac x="(a,b)" in bspec)
-       apply simp
-      apply clarsimp
-      done
+    apply (erule use_valid[OF _ ret_agnostic])
+    apply simp
+    done
+  have a: "\<And>a b u u' s. (a,b) \<in> fst (f u s) \<Longrightarrow> \<exists>a'. (a',b) \<in> fst (f u' s)"
+    apply (cut_tac P="\<lambda>sa. sa = s" and Q="\<lambda>s'. \<exists>a'. (a',s') \<in> fst (f u' s)"
+               and u=u' and u'=u in param_agnostic[rule_format])
+     apply (clarsimp simp: valid_def)
+     apply force
+    apply (clarsimp simp: valid_def)
+    apply (drule_tac x="(a,b)" in bspec)
+     apply simp
+    apply clarsimp
+    done
   show ?thesis
-  apply (cut_tac u=u in ev)
-  apply (cut_tac u=u' in ev)
-  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
-  apply (frule a[where u=u and u'=u'])
-  apply clarsimp
-  apply (frule b[where u=u])
-  apply (frule b[where u=u'])
-  apply fastforce
-  done
+    apply (cut_tac u=u in ev)
+    apply (cut_tac u=u' in ev)
+    apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+    apply (frule a[where u=u and u'=u'])
+    apply clarsimp
+    apply (frule b[where u=u])
+    apply (frule b[where u=u'])
+    apply fastforce
+    done
 qed
 
 lemma bind_return_ign:
-  "\<lbrace>P\<rbrace> (f >>= (\<lambda>_. return x)) \<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> (f >>= (\<lambda>_. return y)) \<lbrace>\<lambda>_. Q\<rbrace>"
+  "\<lbrace>P\<rbrace> (f >>= (\<lambda>_. return x)) \<lbrace>\<lambda>_. Q\<rbrace>
+   \<Longrightarrow> \<lbrace>P\<rbrace> (f >>= (\<lambda>_. return y)) \<lbrace>\<lambda>_. Q\<rbrace>"
   apply (fastforce simp: valid_def bind_def return_def)
-  done
-
-
-lemma thread_set_reads_respect_scheduler[wp]:
-  "reads_respects_scheduler aag l (invs and K(pasObjectAbs aag t \<noteq> SilcLabel)
-                                        and (\<lambda>s. t = idle_thread s \<longrightarrow> tc = idle_context s)
-                                        and guarded_pas_domain aag)
-                                  (thread_set (tcb_arch_update (arch_tcb_context_set tc)) t)"
-  apply (rule reads_respects_scheduler_cases[where P'=\<top>])
-  prefer 3
-  apply (rule reads_respects_scheduler_unobservable'')
-  apply (wp | simp | elim conjE)+
-  apply (simp add: thread_set_def)
-  apply (wp)
-  apply (fastforce simp: scheduler_affects_equiv_def get_tcb_def
-                  states_equiv_for_def equiv_for_def scheduler_equiv_def
-                  domain_fields_equiv_def
-                  equiv_asids_def equiv_asid_def split: option.splits
-                  kernel_object.splits)+
   done
 
 lemma op_eq_unit_dc:
@@ -2787,7 +2308,7 @@ lemma op_eq_unit_dc:
   done
 
 lemma cur_thread_idle':
-  "valid_idle s \<Longrightarrow> only_idle s \<Longrightarrow> ct_idle s = (cur_thread s = idle_thread s)"
+  "\<lbrakk> valid_idle s; only_idle s \<rbrakk> \<Longrightarrow> ct_idle s = (cur_thread s = idle_thread s)"
   apply (rule iffI)
   apply (clarsimp simp: only_idle_def ct_in_state_def )
   apply (clarsimp simp: valid_idle_def ct_in_state_def pred_tcb_at_def obj_at_def)
@@ -2799,33 +2320,78 @@ lemma cur_thread_idle:
   apply (simp add: invs_def valid_state_def)+
   done
 
+
+context Scheduler_IF_2 begin
+
+lemma activate_thread_reads_respects_scheduler[wp]:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects_scheduler aag l (invs and silc_inv aag st and guarded_pas_domain aag)
+                                  activate_thread"
+  apply (simp add: activate_thread_def)
+  apply (rule reads_respects_scheduler_cases')
+     apply ((wp sts_reads_respects_scheduler get_thread_state_reads_respects_scheduler
+                gts_wp as_user_reads_respects_scheduler
+             | wpc
+             | simp add: det_setNextPC)+)[1]
+    apply (intro impI conjI allI;
+           fastforce simp: det_getRestartPC guarded_pas_domain_def reads_scheduler_def
+                           restart_not_idle invs_valid_idle
+                     dest: st_tcb_at_not_idle_thread domains_distinct[THEN pas_domains_distinct_inj])
+   apply (rule reads_respects_scheduler_unobservable''
+                 [where P'="\<lambda>s. \<not> reads_scheduler_cur_domain aag l s \<and>
+                                guarded_pas_domain aag s \<and> invs s"])
+     apply ((wp scheduler_equiv_lift'[where P="invs and silc_inv aag st"]
+                globals_equiv_scheduler_inv'[where P="valid_ko_at_arch and valid_idle"]
+                set_thread_state_globals_equiv gts_wp
+             | wpc
+             | clarsimp simp: restart_not_idle invs_valid_ko_at_arch silc_inv_not_cur_thread
+             | force)+)[1]
+    apply (wp gts_wp| wpc | simp)+
+    apply (clarsimp simp: guarded_pas_domain_def restart_not_idle invs_valid_idle)
+    apply force+
+  done
+
+lemma thread_set_reads_respect_scheduler[wp]:
+  "reads_respects_scheduler aag l (invs and K(pasObjectAbs aag t \<noteq> SilcLabel)
+                                        and (\<lambda>s. t = idle_thread s \<longrightarrow> tc = idle_context s)
+                                        and guarded_pas_domain aag)
+                            (thread_set (tcb_arch_update (arch_tcb_context_set tc)) t)"
+  apply (rule reads_respects_scheduler_cases[where P'=\<top>])
+     prefer 3
+     apply (rule reads_respects_scheduler_unobservable'')
+       apply (wp | simp | elim conjE)+
+    apply (simp add: thread_set_def)
+    apply wp
+    apply (fastforce simp: scheduler_affects_equiv_def get_tcb_def states_equiv_for_def
+                           equiv_for_def scheduler_equiv_def domain_fields_equiv_def equiv_asids_def
+                    split: option.splits kernel_object.splits)+
+  done
+
 lemma context_update_cur_thread_snippit_unobservable:
   "equiv_valid_2 (scheduler_equiv aag) (scheduler_affects_equiv aag l)
-     (scheduler_affects_equiv aag l) (=)
-     (invs and silc_inv aag st and guarded_pas_domain aag and
-          (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
-          (\<lambda>s. ct_idle s \<longrightarrow> uc = idle_context s))
-     (invs and silc_inv aag st and guarded_pas_domain aag and
-          (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
-          (\<lambda>s. ct_idle s \<longrightarrow> uc' = idle_context s))
-     (gets cur_thread >>= thread_set (tcb_arch_update (arch_tcb_context_set uc)))
-     (gets cur_thread >>= thread_set (tcb_arch_update (arch_tcb_context_set uc')))"
+                 (scheduler_affects_equiv aag l) (=)
+                 (invs and silc_inv aag st and guarded_pas_domain aag
+                       and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)
+                       and (\<lambda>s. ct_idle s \<longrightarrow> uc = idle_context s))
+                 (invs and silc_inv aag st and guarded_pas_domain aag
+                       and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)
+                       and (\<lambda>s. ct_idle s \<longrightarrow> uc' = idle_context s))
+                 (gets cur_thread >>= thread_set (tcb_arch_update (arch_tcb_context_set uc)))
+                 (gets cur_thread >>= thread_set (tcb_arch_update (arch_tcb_context_set uc')))"
   apply (rule equiv_valid_2_guard_imp)
     apply (simp add: op_eq_unit_dc)
     apply (rule equiv_valid_2_unobservable)
          apply (wp | elim conjE | simp add: dc_def)+
      apply fastforce
     apply fastforce
-   apply (clarsimp simp: guarded_pas_domain_def
-                         silc_inv_not_cur_thread cur_thread_idle
-                         disjoint_iff_not_equal)+
+   apply (fastforce simp: guarded_pas_domain_def silc_inv_not_cur_thread
+                          cur_thread_idle disjoint_iff_not_equal)+
   done
 
 lemma context_update_cur_thread_snippit_cur_domain:
-  "reads_respects_scheduler aag l (\<lambda>s. reads_scheduler_cur_domain aag l s \<and> invs s \<and>
-        silc_inv aag st s \<and>
-        (ct_idle s \<longrightarrow> uc = idle_context s) \<and>
-        guarded_pas_domain aag s)
+  "reads_respects_scheduler aag l
+     (\<lambda>s. reads_scheduler_cur_domain aag l s \<and> invs s \<and> silc_inv aag st s \<and>
+          (ct_idle s \<longrightarrow> uc = idle_context s) \<and> guarded_pas_domain aag s)
      (gets cur_thread >>= thread_set (tcb_arch_update (arch_tcb_context_set uc)))"
   apply wp
   apply (clarsimp simp: cur_thread_idle silc_inv_not_cur_thread del: notI)
@@ -2836,18 +2402,16 @@ lemma context_update_cur_thread_snippit_cur_domain:
 lemma context_update_cur_thread_snippit:
   "equiv_valid_2 (scheduler_equiv aag) (scheduler_affects_equiv aag l)
      (scheduler_affects_equiv aag l) (=)
-     (invs and silc_inv aag st and guarded_pas_domain aag and
-         (\<lambda>s. reads_scheduler_cur_domain aag l s \<longrightarrow> uc = uc') and
-         (\<lambda>s. ct_idle s \<longrightarrow> uc = idle_context s))
-     (invs and silc_inv aag st and guarded_pas_domain aag and
-         (\<lambda>s. reads_scheduler_cur_domain aag l s \<longrightarrow> uc = uc') and
-         (\<lambda>s. ct_idle s \<longrightarrow> uc' = idle_context s))
+     (invs and silc_inv aag st and guarded_pas_domain aag
+           and (\<lambda>s. reads_scheduler_cur_domain aag l s \<longrightarrow> uc = uc')
+           and (\<lambda>s. ct_idle s \<longrightarrow> uc = idle_context s))
+     (invs and silc_inv aag st and guarded_pas_domain aag
+           and (\<lambda>s. reads_scheduler_cur_domain aag l s \<longrightarrow> uc = uc')
+           and (\<lambda>s. ct_idle s \<longrightarrow> uc' = idle_context s))
      (gets cur_thread >>= thread_set (tcb_arch_update (arch_tcb_context_set uc)))
      (gets cur_thread >>= thread_set (tcb_arch_update (arch_tcb_context_set uc')))"
-  apply (insert context_update_cur_thread_snippit_cur_domain[
-                             where aag=aag and l=l and uc=uc and st=st])
-  apply (insert context_update_cur_thread_snippit_unobservable[
-                             where aag=aag and l=l and uc=uc and uc'=uc' and st=st])
+  apply (insert context_update_cur_thread_snippit_cur_domain[where l=l and uc=uc and st=st])
+  apply (insert context_update_cur_thread_snippit_unobservable[where l=l and uc=uc and uc'=uc' and st=st])
   apply (clarsimp simp: equiv_valid_2_def equiv_valid_def2)
   apply (drule_tac x=s in spec)
   apply (drule_tac x=s in spec)
@@ -2857,51 +2421,8 @@ lemma context_update_cur_thread_snippit:
   apply (subgoal_tac "reads_scheduler_cur_domain aag l t = reads_scheduler_cur_domain aag l s")
    apply clarsimp
    apply (case_tac "reads_scheduler_cur_domain aag l s")
-    apply ((fastforce)+)[2]
+    apply (fastforce+)[2]
   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def)
-  done
-
-
-lemma equiv_valid_2E:
-  assumes ev: "equiv_valid_2 I A B R P P' f g"
-  assumes f: "(a,s') \<in> fst (f s)"
-  assumes g: "(b,t') \<in> fst (g t)"
-  assumes I: "I s t \<and> A s t"
-  assumes P: "P s"
-  assumes P': "P' t"
-  assumes Q: "I s' t' \<Longrightarrow> B s' t' \<Longrightarrow> R a b \<Longrightarrow> S"
-  shows S
-  apply (insert ev)
-  apply (clarsimp simp: equiv_valid_2_def)
-  apply (drule_tac x=s in spec)
-  apply (drule_tac x=t in spec)
-  apply (simp add: I P P')
-  apply (drule bspec[OF _ f],simp)
-  apply (drule bspec[OF _ g],simp)
-  apply (rule Q,simp+)
-  done
-
-lemma ev2_sym:
-  assumes
-   symI: "\<And> x y. I x y \<Longrightarrow> I y x"
-  assumes
-   symA: "\<And> x y. A x y \<Longrightarrow> A y x"
-  assumes
-   symB: "\<And> x y. B x y \<Longrightarrow> B y x"
-  assumes
-   symR: "\<And> x y. R x y \<Longrightarrow> R' y x"
-  shows
-  "equiv_valid_2 I A B R P' P f' f \<Longrightarrow>
-   equiv_valid_2 I A B R' P P' f f'"
-  apply(clarsimp simp: equiv_valid_2_def)
-  apply(blast intro: symA symB symI symR)
-  done
-
-lemma SilcLabel_affects_scheduler_equiv:
-  "scheduler_equiv aag s t \<Longrightarrow> scheduler_affects_equiv aag SilcLabel s t"
-  apply (simp add:  scheduler_affects_equiv_def reads_scheduler_def
-                   states_equiv_for_def equiv_for_def scheduler_equiv_def equiv_asids_def
-                   equiv_asid_def globals_equiv_scheduler_def)
   done
 
 end

--- a/proof/infoflow/Scheduler_IF.thy
+++ b/proof/infoflow/Scheduler_IF.thy
@@ -2341,10 +2341,10 @@ lemma activate_thread_reads_respects_scheduler[wp]:
                  [where P'="\<lambda>s. \<not> reads_scheduler_cur_domain aag l s \<and>
                                 guarded_pas_domain aag s \<and> invs s"])
      apply ((wp scheduler_equiv_lift'[where P="invs and silc_inv aag st"]
-                globals_equiv_scheduler_inv'[where P="valid_ko_at_arch and valid_idle"]
+                globals_equiv_scheduler_inv'[where P="valid_arch_state and valid_idle"]
                 set_thread_state_globals_equiv gts_wp
              | wpc
-             | clarsimp simp: restart_not_idle invs_valid_ko_at_arch silc_inv_not_cur_thread
+             | clarsimp simp: restart_not_idle silc_inv_not_cur_thread
              | force)+)[1]
     apply (wp gts_wp| wpc | simp)+
     apply (clarsimp simp: guarded_pas_domain_def restart_not_idle invs_valid_idle)

--- a/proof/infoflow/Syscall_IF.thy
+++ b/proof/infoflow/Syscall_IF.thy
@@ -6,91 +6,129 @@
 
 theory Syscall_IF
 imports
-    "PasUpdates" (*Only needed for idle thread stuff*)
-    "Tcb_IF"
-    "Interrupt_IF"
-    "Decode_IF"
-
+    "ArchPasUpdates" (*Only needed for idle thread stuff*)
+    "ArchTcb_IF"
+    "ArchInterrupt_IF"
+    "ArchDecode_IF"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+definition authorised_for_globals_inv :: "invocation \<Rightarrow> ('z::state_ext) state \<Rightarrow> bool" where
+  "authorised_for_globals_inv oper \<equiv>
+     \<lambda>s. case oper of InvokeArchObject ai \<Rightarrow> authorised_for_globals_arch_inv ai s | _ \<Rightarrow> True"
 
-crunch_ignore (add: OR_choice set_scheduler_action)
+definition authorised_invocation_extra where
+  "authorised_invocation_extra aag invo \<equiv>
+     case invo of InvokeTCB ti \<Rightarrow> authorised_tcb_inv_extra aag ti | _ \<Rightarrow> True"
 
-(* The contents of the delete_globals_equiv locale *)
-
-lemma globals_equiv_irq_state_update[simp]:
-  "globals_equiv st
-            (s\<lparr>machine_state := machine_state s
-                 \<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>) =
-          globals_equiv st s"
-  apply(auto simp: globals_equiv_def idle_equiv_def)
-  done
-
-lemma cap_revoke_globals_equiv:
-  "\<lbrace>globals_equiv st and invs\<rbrace> cap_revoke slot \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (rule hoare_strengthen_post, rule validE_valid,
-    rule cap_revoke_preservation_desc_of[where Q="\<lambda>_. emptyable"])
-     apply (wp cap_delete_globals_equiv preemption_point_inv | simp
-        | (auto simp: emptyable_def dest: reply_slot_not_descendant)[1])+
-  done
 
 lemma tcb_context_merge[simp]:
-  "arch_tcb_context_get (tcb_arch (tcb_registers_caps_merge tcb tcb'))
-    = arch_tcb_context_get (tcb_arch tcb)"
-  apply (simp add: tcb_registers_caps_merge_def)
-  done
+  "arch_tcb_context_get (tcb_arch (tcb_registers_caps_merge tcb tcb')) =
+   arch_tcb_context_get (tcb_arch tcb)"
+  by (simp add: tcb_registers_caps_merge_def)
 
-lemma thread_set_globals_equiv':
-  "\<lbrace>globals_equiv s and valid_ko_at_arm and (\<lambda>s. tptr \<noteq> idle_thread s)\<rbrace>
-     thread_set f tptr
-   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding thread_set_def
-  apply(wp set_object_globals_equiv)
-  apply simp
-  apply (intro impI conjI allI)
-  apply(fastforce simp: valid_ko_at_arm_def obj_at_def get_tcb_def)+
-  done
+crunch_ignore (add: OR_choice set_scheduler_action)
 
 crunch valid_global_objs[wp]: cap_move valid_global_objs
   (wp: cap_move_ext.valid_global_objs dxo_wp_weak)
 
+
+locale Syscall_IF_1 =
+  fixes aag :: "'a subject_label PAS"
+  assumes globals_equiv_irq_state_update[simp]:
+    "\<And>f. globals_equiv st (s\<lparr>machine_state :=
+                              machine_state s\<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>) =
+          globals_equiv st s"
+  and thread_set_globals_equiv':
+    "\<And>f. \<lbrace>globals_equiv s and valid_ko_at_arch and (\<lambda>s. tptr \<noteq> idle_thread s)\<rbrace>
+          thread_set f tptr
+          \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  and sts_authorised_for_globals_inv:
+    "\<And>f. set_thread_state d f \<lbrace>\<lambda>s :: det_state. authorised_for_globals_inv oper s\<rbrace>"
+  and arch_perform_invocation_reads_respects_g:
+    "pas_domains_distinct aag
+     \<Longrightarrow> reads_respects_g aag l (ct_active and authorised_arch_inv aag ai and valid_arch_inv ai
+                                           and authorised_for_globals_arch_inv ai and invs
+                                           and pas_refined aag and is_subject aag \<circ> cur_thread)
+                          (arch_perform_invocation ai)"
+  and dmo_maskInterrupt_globals_equiv[wp]:
+    "do_machine_op (maskInterrupt b irq) \<lbrace>globals_equiv s\<rbrace>"
+  and dmo_ackInterrupt_globals_equiv[wp]:
+    "do_machine_op (ackInterrupt irq) \<lbrace>globals_equiv s\<rbrace>"
+  and dmo_resetTimer_globals_equiv[wp]:
+    "do_machine_op resetTimer \<lbrace>globals_equiv s\<rbrace>"
+  and arch_mask_irq_signal_globals_equiv[wp]:
+    "arch_mask_irq_signal irq \<lbrace>globals_equiv st\<rbrace>"
+  and handle_reserved_irq_globals_equiv[wp]:
+    "handle_reserved_irq irq \<lbrace>globals_equiv st\<rbrace>"
+  and handle_vm_fault_reads_respects:
+    "reads_respects aag l (K (is_subject aag thread)) (handle_vm_fault thread vmfault_type)"
+  and handle_hypervisor_fault_reads_respects:
+    "reads_respects aag l \<top> (handle_hypervisor_fault thread hypfault_type)"
+  and handle_vm_fault_globals_equiv:
+    "\<lbrace>globals_equiv st and valid_ko_at_arch and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
+     handle_vm_fault thread vmfault_type
+     \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  and handle_hypervisor_fault_globals_equiv:
+    "handle_hypervisor_fault thread hypfault_type \<lbrace>globals_equiv st\<rbrace>"
+  and arch_activate_idle_thread_globals_equiv[wp]:
+    "arch_activate_idle_thread t \<lbrace>globals_equiv st\<rbrace>"
+  and select_f_setNextPC_reads_respects[wp]:
+    "reads_respects aag l \<top> (select_f (setNextPC pc f))"
+  and select_f_getRestartPC_reads_respects[wp]:
+    "reads_respects aag l \<top> (select_f (getRestartPC f))"
+  and arch_activate_idle_thread_reads_respects[wp]:
+    "reads_respects aag l \<top> (arch_activate_idle_thread t)"
+  and decode_arch_invocation_authorised_for_globals:
+    "\<lbrace>invs and cte_wp_at ((=) (ArchObjectCap acap)) slot
+           and (\<lambda>s :: det_state. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)\<rbrace>
+     arch_decode_invocation label msg x_slot slot acap excaps
+     \<lbrace>\<lambda>rv. authorised_for_globals_arch_inv rv\<rbrace>, -"
+begin
+
+lemma cap_revoke_globals_equiv:
+  "\<lbrace>globals_equiv st and invs\<rbrace>
+   cap_revoke slot
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  apply (rule hoare_strengthen_post, rule validE_valid,
+         rule cap_revoke_preservation_desc_of[where Q="\<lambda>_. emptyable"])
+  by (wp cap_delete_globals_equiv preemption_point_inv
+      | fastforce simp: emptyable_def dest: reply_slot_not_descendant)+
+
 lemma invoke_cnode_globals_equiv:
-  "\<lbrace>globals_equiv st and invs and valid_cnode_inv cinv\<rbrace> invoke_cnode cinv \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  "\<lbrace>globals_equiv st and invs and valid_cnode_inv cinv\<rbrace>
+   invoke_cnode cinv
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding invoke_cnode_def without_preemption_def fun_app_def
-  apply(rule hoare_pre)
-   apply(wp | wpc)+
-          apply(wp cap_insert_globals_equiv cap_move_globals_equiv cap_revoke_globals_equiv
-                   cap_delete_globals_equiv cap_swap_globals_equiv hoare_vcg_all_lift
-                   cancel_badged_sends_globals_equiv
-                    | wpc | wp (once) hoare_drop_imps | simp add: invs_valid_global_objs)+
-  apply (case_tac cinv)
-  apply (clarsimp simp: invs_valid_ko_at_arm | strengthen real_cte_emptyable_strg)+
-done
+  apply (wp cap_insert_globals_equiv cap_move_globals_equiv cap_revoke_globals_equiv
+            cap_delete_globals_equiv cap_swap_globals_equiv hoare_vcg_all_lift
+            cancel_badged_sends_globals_equiv
+         | wpc | wp (once) hoare_drop_imps | simp add: invs_valid_global_objs)+
+  apply (case_tac cinv; clarsimp simp: invs_valid_ko_at_arch real_cte_emptyable_strg)
+  done
+
+end
+
 
 (* The contents of the delete_confidentiality locale *)
 
 lemma cap_delete_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_f aag l (silc_inv aag st and only_timer_irq_inv irq st' and einvs
-         and simple_sched_action and emptyable slot and pas_refined aag
-         and cdt_change_allowed' aag slot)
-     (cap_delete slot)"
-  unfolding cap_delete_def by (wp rec_del_CTEDeleteCall_reads_respects_f) force
-
+  shows "reads_respects_f aag l
+           (silc_inv aag st and only_timer_irq_inv irq st' and einvs and simple_sched_action
+                            and emptyable slot and pas_refined aag and cdt_change_allowed' aag slot)
+           (cap_delete slot)"
+  unfolding cap_delete_def
+  by (wp rec_del_CTEDeleteCall_reads_respects_f) force
 
 (* FIXME move *)
 lemma spec_gen_asm:
   "(Q \<Longrightarrow> spec_equiv_valid st D A B P f) \<Longrightarrow> spec_equiv_valid st D A B (P and K Q) f"
-  apply (simp add: spec_equiv_valid_def equiv_valid_2_def)
-  done
+  by (simp add: spec_equiv_valid_def equiv_valid_2_def)
 
 (* FIXME move *)
 lemma select_ev:
   "equiv_valid_inv I A (K(S \<noteq> {} \<longrightarrow> (\<exists>x. S = {x}))) (select S)"
-  apply (clarsimp simp: equiv_valid_def spec_equiv_valid_def
-                   equiv_valid_2_def select_def)
+  apply (clarsimp simp: equiv_valid_def spec_equiv_valid_def equiv_valid_2_def select_def)
   apply blast
   done
 
@@ -100,12 +138,11 @@ lemma next_revoke_eq:
   "equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) cdt_list rv rv'
    \<Longrightarrow> is_subject aag (fst src_slot)
    \<Longrightarrow> next_revoke_cap src_slot rv = next_revoke_cap src_slot rv'"
-  apply (clarsimp simp: next_child_def equiv_for_def next_revoke_cap_def)
-  done
+  by (clarsimp simp: next_child_def equiv_for_def next_revoke_cap_def)
 
 lemma next_revoke_eq':
-  "reads_equiv_f aag s t \<Longrightarrow> is_subject aag (fst src_slot)
-   \<Longrightarrow> next_revoke_cap src_slot s = next_revoke_cap src_slot t"
+  "\<lbrakk> reads_equiv_f aag s t; is_subject aag (fst src_slot) \<rbrakk>
+     \<Longrightarrow> next_revoke_cap src_slot s = next_revoke_cap src_slot t"
   apply (rule next_revoke_eq)
    apply (fastforce simp: reads_equiv_f_def reads_equiv_def2 states_equiv_for_def equiv_for_def)
   apply simp
@@ -113,15 +150,13 @@ lemma next_revoke_eq':
 
 lemma cap_revoke_spec_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del]
-        drop_spec_ev[wp_split del] rec_del.simps[simp del]
-        split_paired_All[simp del] split_paired_Ex[simp del]
-  shows
-  "spec_reads_respects_f s aag l (silc_inv aag st and only_timer_irq_inv irq st' and einvs
-                                  and simple_sched_action and pas_refined aag
-                                  and K (is_subject aag (fst slot)))
-     (cap_revoke slot)"
-  proof (induct rule: cap_revoke.induct[where ?a1.0=s])
+  notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del] drop_spec_ev[wp_split del]
+        rec_del.simps[simp del] split_paired_All[simp del] split_paired_Ex[simp del]
+  shows "spec_reads_respects_f s aag l (silc_inv aag st and only_timer_irq_inv irq st' and einvs
+                                                        and simple_sched_action and pas_refined aag
+                                                        and K (is_subject aag (fst slot)))
+                               (cap_revoke slot)"
+proof (induct rule: cap_revoke.induct[where ?a1.0=s])
   case (1 slot s)
   show ?case
     apply (rule spec_gen_asm)
@@ -130,42 +165,37 @@ lemma cap_revoke_spec_reads_respects_f:
      apply (subst spec_equiv_valid_def2)
      apply (subst rel_sum_comb_equals[symmetric])
      apply (rule_tac R'="(=)" in spec_equiv_valid_2_inv_bindE)
-        apply(rule_tac R'="equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id"
-                    in spec_equiv_valid_2_inv_bindE)
-        apply (rule_tac R'="(=)" in spec_equiv_valid_2_inv_bindE)
-                 apply(simp add: rel_sum_comb_equals
-                            del: Inr_in_liftE_simp without_preemption_def fun_app_def)
-                 apply(rule spec_equiv_valid_2_inv_by_spec_equiv_valid[OF _ refl refl refl])
-                 apply(wp whenE_spec_ev)
-                           apply(rule "1.hyps")
-                                    apply (assumption | erule | simp)+
-                          apply(wp drop_spec_ev[OF preemption_point_reads_respects_f]
-                                   drop_spec_ev[OF cap_delete_reads_respects_f[where st=st]]
-                                   select_ext_ev
-                                   preemption_point_inv'
-                                   cap_delete_pas_refined cap_delete_silc_inv[where st=st]
-                                   cap_delete_only_timer_irq_inv[where st=st' and irq=irq]
-                                   drop_spec_ev[OF assertE_ev] drop_spec_ev[OF liftE_ev]
-                                   get_cap_wp select_wp
-                                   select_ev
-                                   drop_spec_ev2_inv[OF liftE_ev2]
-                                   reads_respects_f[OF get_cap_rev, where st=st and aag=aag]
-        | simp (no_asm) add: returnOk_def | rule next_revoke_eq'
-     | (simp add: pred_conj_def, erule conjE, assumption)
-     | (rule irq_state_independent_A_conjI, simp)+)+
-               apply (rule_tac P="K(all_children (\<lambda>x. aag_can_read aag (fst x)) rva)"
-                           and P'="K(all_children (\<lambda>x. aag_can_read aag (fst x)) rv'a)"
-                            in drop_spec_ev2_inv[OF return_ev2])
-               apply simp
-               apply (rule_tac P="\<lambda>x. aag_can_read aag (fst x)" in all_children_descendants_equal)
-               apply (frule aag_can_read_self)
-               apply (simp add: equiv_for_def split del: if_split)+
-             apply (wp drop_spec_ev2_inv[OF liftE_ev2] gets_evrv | simp)+
+        apply (rule_tac R'="equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id"
+                     in spec_equiv_valid_2_inv_bindE)
+           apply (rule_tac R'="(=)" in spec_equiv_valid_2_inv_bindE)
+              apply (simp add: rel_sum_comb_equals
+                          del: Inr_in_liftE_simp without_preemption_def fun_app_def)
+              apply (rule spec_equiv_valid_2_inv_by_spec_equiv_valid[OF _ refl refl refl])
+              apply (wp whenE_spec_ev)
+                        apply (rule "1.hyps")
+                                apply (assumption | erule | simp)+
+                       apply (wp drop_spec_ev[OF preemption_point_reads_respects_f]
+                                 drop_spec_ev[OF cap_delete_reads_respects_f[where st=st]]
+                                 select_ext_ev preemption_point_inv'
+                                 cap_delete_pas_refined cap_delete_silc_inv[where st=st]
+                                 cap_delete_only_timer_irq_inv[where st=st' and irq=irq]
+                                 drop_spec_ev[OF assertE_ev] drop_spec_ev[OF liftE_ev]
+                                 get_cap_wp select_wp select_ev drop_spec_ev2_inv[OF liftE_ev2]
+                                 reads_respects_f[OF get_cap_rev, where st=st and aag=aag]
+                              | simp (no_asm) add: returnOk_def | rule next_revoke_eq'
+                              | (simp add: pred_conj_def, erule conjE, assumption)
+                              | (rule irq_state_independent_A_conjI, simp)+)+
+           apply (rule_tac P="K(all_children (\<lambda>x. aag_can_read aag (fst x)) rva)"
+                       and P'="K(all_children (\<lambda>x. aag_can_read aag (fst x)) rv'a)"
+                        in drop_spec_ev2_inv[OF return_ev2])
+           apply simp
+           apply (rule_tac P="\<lambda>x. aag_can_read aag (fst x)" in all_children_descendants_equal)
+              apply (frule aag_can_read_self)
+              apply (simp add: equiv_for_def split del: if_split)+
+          apply (wp drop_spec_ev2_inv[OF liftE_ev2] gets_evrv | simp)+
      apply (wp drop_spec_ev2_inv[OF liftE_ev2] gets_evrv
-               reads_respects_f[OF get_cap_rev, where st=st and aag=aag and Q="\<top>",
-                                simplified equiv_valid_def2]
-           | simp)+
-    apply clarsimp
+               reads_respects_f[OF get_cap_rev, where st=st and Q=\<top>,simplified equiv_valid_def2])
+     apply clarsimp+
     apply (frule all_children_subjectReads[simplified comp_def])
     apply clarsimp
     apply (rule conjI)
@@ -173,24 +203,19 @@ lemma cap_revoke_spec_reads_respects_f:
                   elim: reads_equivE affects_equivE equiv_forD)
     apply clarsimp
     apply (rule conjI, erule(1) all_children_descendants_of, force)
-    apply (clarsimp simp:conj_comms)
-    apply (intro conjI;
-           (subst emptyable_def,
-            case_tac "next_revoke_cap slot s",
-            force dest: reply_slot_not_descendant
-           | force elim: all_children_descendants_of[OF cdt_change_allowed_all_children, rotated 2]))
-  done
+    apply (clarsimp simp: conj_comms)
+    apply (intro conjI)
+    by (case_tac "next_revoke_cap slot s", force simp: emptyable_def dest: reply_slot_not_descendant
+        | force elim: all_children_descendants_of[OF cdt_change_allowed_all_children])+
 qed
 
 lemmas cap_revoke_reads_respects_f = use_spec_ev[OF cap_revoke_spec_reads_respects_f]
 
 lemma cancel_badged_sends_reads_respects_f:
   assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects_f aag l (silc_inv aag st and pas_refined aag and invs
-                           and is_subject aag \<circ> cur_thread and
-                           K (is_subject aag ptr))
-   (cancel_badged_sends ptr badge)"
+  shows "reads_respects_f aag l (silc_inv aag st and is_subject aag \<circ> cur_thread and pas_refined aag
+                                                 and invs and K (is_subject aag ptr))
+                          (cancel_badged_sends ptr badge)"
   apply (rule equiv_valid_guard_imp)
    apply (rule reads_respects_f)
     apply (rule cancel_badged_sends_reads_respects[OF domains_distinct])
@@ -199,78 +224,91 @@ lemma cancel_badged_sends_reads_respects_f:
   done
 
 lemma cap_revoke_only_timer_irq_inv:
-  "\<lbrace>only_timer_irq_inv irq (st::det_ext state)\<rbrace>
-   cap_revoke slot \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
+  "\<lbrace>only_timer_irq_inv irq (st :: det_state)\<rbrace>
+   cap_revoke slot
+   \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
   apply (simp add: only_timer_irq_inv_def)
   apply (rule hoare_wp_simps)
   apply (rule hoare_conjI)
-   apply (wp only_timer_irq_pres[where P="\<top>"] cap_revoke_irq_masks | force simp: only_timer_irq_inv_def)+
+   apply (wp only_timer_irq_pres[where P="\<top>"] cap_revoke_irq_masks | force)+
   done
 
 lemma invoke_cnode_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_f aag l
-  (silc_inv aag st and only_timer_irq_inv irq st' and pas_refined aag and einvs
-   and simple_sched_action
-   and valid_cnode_inv ci and (\<lambda>s. is_subject aag (cur_thread s))
-   and cnode_inv_auth_derivations ci
-   and authorised_cnode_inv aag ci) (invoke_cnode ci)"
+  shows "reads_respects_f aag l
+           (silc_inv aag st and only_timer_irq_inv irq st' and pas_refined aag and einvs
+                            and simple_sched_action and valid_cnode_inv ci
+                            and (\<lambda>s. is_subject aag (cur_thread s))
+                            and cnode_inv_auth_derivations ci and authorised_cnode_inv aag ci)
+           (invoke_cnode ci)"
   unfolding invoke_cnode_def
-  apply(rule equiv_valid_guard_imp)
-  apply(wpc
-       | wp reads_respects_f[OF cap_insert_reads_respects] cap_insert_silc_inv
-            reads_respects_f[OF cap_move_reads_respects] cap_move_silc_inv
-            cap_revoke_reads_respects_f cap_delete_reads_respects_f
-            reads_respects_f[OF cap_swap_reads_respects] cap_swap_silc_inv
-            cap_move_cte_wp_at_other reads_respects_f[OF get_cap_rev] get_cap_auth_wp
-            cancel_badged_sends_reads_respects_f
-       | simp add:when_def split del: if_split
-       | elim conjE, assumption)+
+  apply (rule equiv_valid_guard_imp)
+  apply (wpc | wp reads_respects_f[OF cap_insert_reads_respects] cap_insert_silc_inv
+                  reads_respects_f[OF cap_move_reads_respects] cap_move_silc_inv get_cap_auth_wp
+                  cap_revoke_reads_respects_f cap_delete_reads_respects_f cap_swap_silc_inv
+                  reads_respects_f[OF cap_swap_reads_respects] cap_move_cte_wp_at_other
+                  reads_respects_f[OF get_cap_rev]  cancel_badged_sends_reads_respects_f
+             | simp add: when_def split del: if_split
+             | elim conjE, assumption)+
   apply (clarsimp simp: cnode_inv_auth_derivations_def authorised_cnode_inv_def)
   apply (auto intro: real_cte_emptyable_strg[rule_format]
-               simp: silc_inv_def reads_equiv_f_def requiv_cur_thread_eq
-                     aag_cap_auth_recycle_EndpointCap
-                     cte_wp_at_weak_derived_ReplyCap caps_of_state_cteD)
+               simp: silc_inv_def reads_equiv_f_def requiv_cur_thread_eq caps_of_state_cteD
+                     aag_cap_auth_recycle_EndpointCap cte_wp_at_weak_derived_ReplyCap )
   done
 
 lemma cap_swap_reads_respects_g:
-  "reads_respects_g aag l (\<lambda>s. is_subject aag (fst slot1) \<and>
-                          is_subject aag (fst slot2) \<and> valid_global_objs s)
-  (cap_swap cap1 slot1 cap2 slot2)"
-  apply(fastforce intro: equiv_valid_guard_imp[OF reads_respects_g] cap_swap_reads_respects doesnt_touch_globalsI cap_swap_globals_equiv)
-  done
+  "reads_respects_g aag l
+     (\<lambda>s. is_subject aag (fst slot1) \<and> is_subject aag (fst slot2) \<and> valid_global_objs s)
+     (cap_swap cap1 slot1 cap2 slot2)"
+  by (fastforce intro: equiv_valid_guard_imp[OF reads_respects_g] cap_swap_reads_respects
+                       doesnt_touch_globalsI cap_swap_globals_equiv)
 
 lemma cap_insert_reads_respects_g:
-  "reads_respects_g aag l (\<lambda>s. is_subject aag (fst src_slot) \<and>
-                          is_subject aag (fst dest_slot) \<and> valid_global_objs s)
-  (cap_insert new_cap src_slot dest_slot)"
-  apply(fastforce intro: equiv_valid_guard_imp[OF reads_respects_g] cap_insert_reads_respects doesnt_touch_globalsI cap_insert_globals_equiv)
-  done
+  "reads_respects_g aag l
+     (\<lambda>s. is_subject aag (fst src_slot) \<and> is_subject aag (fst dest_slot) \<and> valid_global_objs s)
+     (cap_insert new_cap src_slot dest_slot)"
+  by (fastforce intro: equiv_valid_guard_imp[OF reads_respects_g] cap_insert_reads_respects
+                       doesnt_touch_globalsI cap_insert_globals_equiv)
 
 lemma cap_move_reads_respects_g:
-  "reads_respects_g aag l (\<lambda>s. is_subject aag (fst src_slot) \<and>
-                          is_subject aag (fst dest_slot) \<and> valid_global_objs s)
-  (cap_move new_cap src_slot dest_slot)"
-  apply(fastforce intro: equiv_valid_guard_imp[OF reads_respects_g] cap_move_reads_respects doesnt_touch_globalsI cap_move_globals_equiv)
+  "reads_respects_g aag l
+     (\<lambda>s. is_subject aag (fst src_slot) \<and> is_subject aag (fst dest_slot) \<and> valid_global_objs s)
+     (cap_move new_cap src_slot dest_slot)"
+  by (fastforce intro: equiv_valid_guard_imp[OF reads_respects_g] cap_move_reads_respects
+                       doesnt_touch_globalsI cap_move_globals_equiv)
+
+(* FIXME: MOVE *)
+lemma reads_respects_f_g':
+  "\<lbrakk> reads_respects_g aag l P f; \<lbrace>silc_inv aag st and Q\<rbrace> f \<lbrace>\<lambda>_. silc_inv aag st\<rbrace> \<rbrakk>
+     \<Longrightarrow> reads_respects_f_g aag l (silc_inv aag st and P and Q) f"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def reads_equiv_f_g_def reads_equiv_g_def)
+  apply (rule conjI, fastforce)
+  apply (rule conjI, fastforce)
+  apply (rule conjI, fastforce)
+  apply (subst conj_commute, rule conjI, fastforce)
+  apply (rule silc_dom_equiv_trans)
+   apply (rule silc_dom_equiv_sym)
+   apply (rule silc_inv_silc_dom_equiv)
+   apply (erule (1) use_valid, simp)
+  apply (rule silc_inv_silc_dom_equiv)
+  apply (erule (1) use_valid, simp)
   done
 
-lemma get_cap_reads_respects_g:
-  "reads_respects_g aag l (K (is_subject aag (fst cap))) (get_cap cap)"
-using equiv_valid_guard_imp[OF reads_respects_g]
-  apply(rule_tac Q1="\<top>" in equiv_valid_guard_imp[OF reads_respects_g])
-    apply(wp get_cap_rev doesnt_touch_globalsI | simp)+
-    done
+lemma invoke_domain_reads_respects_f_g:
+  "reads_respects_f_g aag l \<bottom> (invoke_domain thread domain)"
+  by (clarsimp simp: equiv_valid_def spec_equiv_valid_def equiv_valid_2_def)
+
+
+context Syscall_IF_1 begin
 
 lemma invoke_cnode_reads_respects_f_g:
   assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects_f_g aag l
-  (silc_inv aag st and only_timer_irq_inv irq st' and pas_refined aag and einvs
-   and simple_sched_action
-   and valid_cnode_inv ci and (\<lambda>s. is_subject aag (cur_thread s))
-   and cnode_inv_auth_derivations ci
-   and authorised_cnode_inv aag ci) (invoke_cnode ci)"
+  shows "reads_respects_f_g aag l
+           (silc_inv aag st and only_timer_irq_inv irq st' and pas_refined aag and einvs
+                            and simple_sched_action and valid_cnode_inv ci
+                            and (\<lambda>s. is_subject aag (cur_thread s))
+                            and cnode_inv_auth_derivations ci and authorised_cnode_inv aag ci)
+           (invoke_cnode ci)"
   apply (rule equiv_valid_guard_imp)
    apply (rule reads_respects_f_g)
     apply (rule invoke_cnode_reads_respects_f[where st=st, OF domains_distinct])
@@ -279,325 +317,203 @@ lemma invoke_cnode_reads_respects_f_g:
    apply force+
   done
 
-
-lemma arch_perform_invocation_reads_respects_g:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects_g aag l (ct_active and authorised_arch_inv aag ai
-              and is_subject aag \<circ> cur_thread and pas_refined aag and invs
-              and authorised_for_globals_arch_inv ai and valid_arch_inv ai)
-    (arch_perform_invocation ai)"
-  apply (rule equiv_valid_guard_imp)
-   apply (rule reads_respects_g)
-    apply (rule arch_perform_invocation_reads_respects[OF domains_distinct])
-   apply (rule doesnt_touch_globalsI)
-   apply (wp arch_perform_invocation_globals_equiv)
-   apply (simp add: invs_valid_vs_lookup invs_def valid_state_def valid_pspace_def)+
-  done
-
-definition authorised_for_globals_inv :: "invocation \<Rightarrow> ('z::state_ext) state \<Rightarrow> bool" where
-  "authorised_for_globals_inv oper \<equiv> \<lambda>s. case oper of InvokeArchObject ai \<Rightarrow> authorised_for_globals_arch_inv ai s | _ \<Rightarrow> True"
-
-definition authorised_invocation_extra where
-  "authorised_invocation_extra aag invo \<equiv> case invo of InvokeTCB ti \<Rightarrow> authorised_tcb_inv_extra aag ti | _ \<Rightarrow> True"
-
-(* FIXME: MOVE *)
-lemma reads_respects_f_g':
-  "\<lbrakk>reads_respects_g aag l P f; \<lbrace>silc_inv aag st and Q\<rbrace> f \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>\<rbrakk> \<Longrightarrow>
-   reads_respects_f_g aag l (silc_inv aag st and P and Q) f"
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def reads_equiv_f_g_def reads_equiv_g_def)
-  apply(rule conjI, fastforce)
-  apply(rule conjI, fastforce)
-  apply(rule conjI, fastforce)
-  apply(subst conj_commute, rule conjI, fastforce)
-  apply(rule silc_dom_equiv_trans)
-   apply(rule silc_dom_equiv_sym)
-   apply(rule silc_inv_silc_dom_equiv)
-   apply(erule (1) use_valid, simp)
-  apply(rule silc_inv_silc_dom_equiv)
-  apply(erule (1) use_valid, simp)
-  done
-
-lemma invoke_domain_reads_respects_f_g:
-  "reads_respects_f_g aag l \<bottom> (invoke_domain thread domain)"
-by (clarsimp simp: equiv_valid_def spec_equiv_valid_def equiv_valid_2_def)
-
 lemma perform_invocation_reads_respects_f_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_f_g aag l (
-          silc_inv aag st
-          and only_timer_irq_inv irq st'
-          and pas_refined aag
-          and pas_cur_domain aag
-          and einvs and schact_is_rct and
-          valid_invocation oper and ct_active
-          and authorised_invocation aag oper
-          and is_subject aag \<circ> cur_thread
-          and authorised_for_globals_inv oper
-          and K (authorised_invocation_extra aag oper))
-    (perform_invocation blocking calling oper)"
+  shows "reads_respects_f_g aag l
+           (silc_inv aag st and only_timer_irq_inv irq st' and pas_refined aag and pas_cur_domain aag
+                            and einvs and schact_is_rct and valid_invocation oper and ct_active
+                            and authorised_invocation aag oper and is_subject aag \<circ> cur_thread
+                            and authorised_for_globals_inv oper
+                            and K (authorised_invocation_extra aag oper))
+           (perform_invocation blocking calling oper)"
 proof (cases oper)
-case InvokeUntyped
+  case InvokeUntyped
   then show ?thesis
     apply simp
     apply (rule equiv_valid_guard_imp)
-     apply (wpc
-            | simp
-            | wp reads_respects_f_g'[OF invoke_untyped_reads_respects_g]
-                 invoke_untyped_silc_inv
-           )+
+     apply (wpc | simp | wp reads_respects_f_g'[OF invoke_untyped_reads_respects_g]
+                            invoke_untyped_silc_inv)+
     by (simp add: authorised_invocation_def)
 next
   case InvokeEndpoint
   then show ?thesis
     apply simp
     apply (rule equiv_valid_guard_imp)
-     apply (wpc
-            | simp
-            | wp reads_respects_f_g'[OF send_ipc_reads_respects_g]
-                 send_ipc_silc_inv
-           )+
+     apply (wpc | simp | wp reads_respects_f_g'[OF send_ipc_reads_respects_g] send_ipc_silc_inv)+
     by (fastforce intro: read_reply_thread_read_thread_rev[OF reads_lrefl]
-                  simp: authorised_invocation_def reads_equiv_f_g_def)
+                   simp: authorised_invocation_def reads_equiv_f_g_def)
 next
   case InvokeNotification
   then show ?thesis
     apply simp
     apply (rule equiv_valid_guard_imp)
-     apply (wpc
-            | simp
-            | wp reads_respects_f_g'[OF send_signal_reads_respects_g, where Q="\<top>"]
-           )+
+     apply (wpc | simp | wp reads_respects_f_g'[OF send_signal_reads_respects_g, where Q="\<top>"])+
     by (fastforce simp: authorised_invocation_def valid_sched_def)
 next
   case InvokeReply
   then show ?thesis
     apply simp
     apply (rule equiv_valid_guard_imp)
-     apply (wpc
-            | simp
-            | wp do_reply_transfer_reads_respects_f_g
-           )+
+     apply (wpc | simp | wp do_reply_transfer_reads_respects_f_g)+
     by (fastforce intro: read_reply_thread_read_thread_rev[OF reads_lrefl] emptyable_cte_wp_atD
-                  simp: reads_equiv_f_g_def authorised_invocation_def is_cap_simps
-                  dest: emptyable_cte_wp_atD)
+                   simp: reads_equiv_f_g_def authorised_invocation_def is_cap_simps
+                   dest: emptyable_cte_wp_atD)
 next
   case InvokeTCB
   then show ?thesis
     apply simp
     apply (rule equiv_valid_guard_imp)
-     apply (wpc
-            | simp
-            | wp invoke_tcb_reads_respects_f_g
-           )+
+     apply (wpc | simp | wp invoke_tcb_reads_respects_f_g)+
     by (fastforce simp: authorised_invocation_def authorised_invocation_extra_def)
 next
   case InvokeDomain
   then show ?thesis
     apply simp
     apply (rule equiv_valid_guard_imp)
-     apply (wpc
-            | simp
-            | wp invoke_domain_reads_respects_f_g
-           )+
+     apply (wpc | simp | wp invoke_domain_reads_respects_f_g)+
     by (simp add: authorised_invocation_def)
 next
   case InvokeCNode
   then show ?thesis
     apply simp
     apply (rule equiv_valid_guard_imp)
-     apply (wpc
-            | simp
-            | wp invoke_cnode_reads_respects_f_g
-           )+
+     apply (wpc | simp | wp invoke_cnode_reads_respects_f_g)+
     by (fastforce simp: authorised_invocation_def)
 next
   case InvokeIRQControl
   then show ?thesis
     apply simp
     apply (rule equiv_valid_guard_imp)
-     apply (wpc
-            | simp
-            | wp reads_respects_f_g'[OF invoke_irq_control_reads_respects_g]
-                 invoke_irq_control_silc_inv
-           )+
+     apply (wpc | simp | wp reads_respects_f_g'[OF invoke_irq_control_reads_respects_g]
+                            invoke_irq_control_silc_inv)+
     by (simp add: invs_def valid_state_def
-                  authorised_invocation_def valid_arch_state_ko_at_arm)
+                  authorised_invocation_def valid_arch_state_ko_at_arch)
 next
   case InvokeIRQHandler
   then show ?thesis
     apply simp
     apply (rule equiv_valid_guard_imp)
-     apply (wpc
-            | simp
-            | wp invoke_irq_handler_reads_respects_f_g
-           )+
+     apply (wpc | simp | wp invoke_irq_handler_reads_respects_f_g)+
     by (fastforce simp: authorised_invocation_def)
 next
   case InvokeArchObject
   then show ?thesis
     apply simp
     apply (rule equiv_valid_guard_imp)
-     apply (wpc
-            | simp
-            | wp reads_respects_f_g'[OF arch_perform_invocation_reads_respects_g]
-                 arch_perform_invocation_silc_inv
-           )+
+     apply (wpc | simp | wp reads_respects_f_g'[OF arch_perform_invocation_reads_respects_g]
+                            arch_perform_invocation_silc_inv)+
     by (fastforce simp: authorised_invocation_def authorised_for_globals_inv_def)
 qed
 
-crunch valid_ko_at_arm[wp]: reply_from_kernel "valid_ko_at_arm" (simp: crunch_simps)
+end
+
+
+crunch valid_ko_at_arch[wp]: reply_from_kernel "valid_ko_at_arch" (simp: crunch_simps)
 
 lemma syscall_reads_respects_f_g:
   assumes reads_res_m_fault:
     "reads_respects_f_g aag l P m_fault"
   assumes reads_res_m_error:
-    "\<And> v. reads_respects_f_g aag l (Q'' v) (m_error v)"
+    "\<And>v. reads_respects_f_g aag l (Q'' v) (m_error v)"
   assumes reads_res_h_fault:
-    "\<And> v. reads_respects_f_g aag l (Q' v) (h_fault v)"
+    "\<And>v. reads_respects_f_g aag l (Q' v) (h_fault v)"
   assumes reads_res_m_finalise:
-    "\<And> v. reads_respects_f_g aag l (R'' v) (m_finalise v)"
+    "\<And>v. reads_respects_f_g aag l (R'' v) (m_finalise v)"
   assumes reads_res_h_error:
-    "\<And> v. reads_respects_f_g aag l (R' v) (h_error v)"
+    "\<And>v. reads_respects_f_g aag l (R' v) (h_error v)"
   assumes m_fault_hoare:
-    "\<lbrace> P \<rbrace> m_fault \<lbrace> case_sum Q' Q'' \<rbrace>"
+    "\<lbrace>P\<rbrace> m_fault \<lbrace>case_sum Q' Q''\<rbrace>"
   assumes m_error_hoare:
-    "\<And> v. \<lbrace> Q'' v \<rbrace> m_error v \<lbrace> case_sum R' R'' \<rbrace>"
-  shows "reads_respects_f_g aag l P (Syscall_A.syscall m_fault h_fault m_error h_error m_finalise)"
+    "\<And>v. \<lbrace>Q'' v\<rbrace> m_error v \<lbrace>case_sum R' R''\<rbrace>"
+  shows "reads_respects_f_g aag l P (syscall m_fault h_fault m_error h_error m_finalise)"
   unfolding Syscall_A.syscall_def without_preemption_def fun_app_def
-  apply (wp assms equiv_valid_guard_imp[OF liftE_bindE_ev]
-       | rule hoare_strengthen_post[OF m_error_hoare]
-       | rule hoare_strengthen_post[OF m_fault_hoare]
-       | wpc
-       | fastforce)+
-  done
+  by (wp assms equiv_valid_guard_imp[OF liftE_bindE_ev]
+      | rule hoare_strengthen_post[OF m_error_hoare]
+      | rule hoare_strengthen_post[OF m_fault_hoare]
+      | wpc
+      | fastforce)+
 
 (*FIXME: move *)
-lemma syscall_requiv_f_g: "
-  \<lbrakk>reads_respects_f_g aag l P m_fault;
- \<And>v. reads_respects_f_g aag l (R' v) (h_error v);
- \<And>v. reads_respects_f_g aag l (R'' v)
-      (m_finalise v);
-
- \<And>v. reads_respects_f_g aag l (Q'' v) (m_error v);
- \<And>v. reads_respects_f_g aag l (Q' v) (h_fault v);
-
-  \<And>v. \<lbrace>Q''' v\<rbrace> m_error v \<lbrace>R''\<rbrace>,\<lbrace>R'\<rbrace>;
- \<lbrace>P\<rbrace> m_fault \<lbrace>\<lambda>rv. Q'' rv and Q''' rv\<rbrace>,\<lbrace>Q'\<rbrace> \<rbrakk>
-\<Longrightarrow> reads_respects_f_g aag l P
-    (syscall m_fault h_fault m_error h_error m_finalise)"
+lemma syscall_requiv_f_g:
+  "\<lbrakk> reads_respects_f_g aag l P m_fault;
+     \<And>v. reads_respects_f_g aag l (R' v) (h_error v);
+     \<And>v. reads_respects_f_g aag l (R'' v) (m_finalise v);
+     \<And>v. reads_respects_f_g aag l (Q'' v) (m_error v);
+     \<And>v. reads_respects_f_g aag l (Q' v) (h_fault v);
+     \<And>v. \<lbrace>Q''' v\<rbrace> m_error v \<lbrace>R''\<rbrace>, \<lbrace>R'\<rbrace>;
+     \<lbrace>P\<rbrace> m_fault \<lbrace>\<lambda>rv. Q'' rv and Q''' rv\<rbrace>, \<lbrace>Q'\<rbrace> \<rbrakk>
+     \<Longrightarrow> reads_respects_f_g aag l P (syscall m_fault h_fault m_error h_error m_finalise)"
   apply (rule syscall_reads_respects_f_g[where Q''="\<lambda>rv. Q'' rv and Q''' rv"])
-  apply (unfold validE_def)
-  apply (assumption)+
-  apply (rule equiv_valid_guard_imp, assumption, simp)
-  apply assumption+
-  apply (rule hoare_strengthen_post)
-  apply assumption
-  apply (case_tac r)
-  apply simp
-  apply simp
+        apply (unfold validE_def)
+        apply (assumption)+
+       apply (rule equiv_valid_guard_imp, assumption, simp)
+      apply assumption+
+   apply (rule hoare_strengthen_post)
+    apply assumption
+   apply (case_tac r)
+    apply simp
+   apply simp
   apply (rule hoare_strengthen_post, rule hoare_pre)
     apply assumption
    apply simp
   apply (case_tac r)
-  apply simp+
-done
-
+   apply simp+
+  done
 
 (*FIXME: Move to base*)
-lemma requiv_g_cur_thread_eq: "reads_equiv_g aag s t \<Longrightarrow> (cur_thread s) = (cur_thread t)"
+lemma requiv_g_cur_thread_eq:
+  "reads_equiv_g aag s t \<Longrightarrow> (cur_thread s) = (cur_thread t)"
   apply (frule reads_equiv_gD)
   apply (clarsimp simp add: requiv_cur_thread_eq)
-done
+  done
 
-(*Weird hack. Not sure why this is necessary. Something is getting
-instantiated too early*)
+(* Weird hack. Not sure why this is necessary. Something is getting instantiated too early*)
 lemma lookup_cap_and_slot_reads_respects_g':
-  "
-  reads_equiv_valid_g_inv (affects_equiv aag l) aag (pas_refined aag and K (is_subject aag param_a2) and P)
-     (lookup_cap_and_slot param_a2 param_b3)"
+  "reads_equiv_valid_g_inv (affects_equiv aag l) aag
+                           (pas_refined aag and K (is_subject aag t) and P)
+                           (lookup_cap_and_slot t cptr)"
   apply (rule equiv_valid_guard_imp)
-  apply (rule lookup_cap_and_slot_reads_respects_g)
+   apply (rule lookup_cap_and_slot_reads_respects_g)
   apply simp
-done
-
-lemma sts_authorised_for_globals_inv: "\<lbrace>authorised_for_globals_inv oper\<rbrace> set_thread_state d f \<lbrace>\<lambda>r. authorised_for_globals_inv oper\<rbrace>"
-  unfolding authorised_for_globals_inv_def
-            authorised_for_globals_arch_inv_def
-            authorised_for_globals_page_table_inv_def
-            authorised_for_globals_page_inv_def
-  apply (case_tac oper)
-           apply (wp | simp)+
-  apply (rename_tac arch_invocation)
-  apply (case_tac arch_invocation)
-      apply simp
-      apply (rename_tac page_table_invocation)
-      apply (case_tac page_table_invocation)
-       apply wpsimp+
-    apply (rename_tac page_invocation)
-    apply (case_tac page_invocation)
-        apply (simp | wp hoare_ex_wp)+
   done
 
 lemma authorised_for_globals_triv:
-  "\<forall> x y. f x \<noteq> InvokeArchObject y \<Longrightarrow>
-  \<lbrace> \<top> \<rbrace> m \<lbrace> authorised_for_globals_inv \<circ> f \<rbrace>,-"
-  apply(clarsimp simp: validE_R_def validE_def valid_def authorised_for_globals_inv_def split: invocation.splits sum.splits)
-  done
-
-lemma decode_invocation_authorised_globals_inv:
-  "\<lbrace>cte_wp_at ((=) cap) slot and invs and
-    (\<lambda>s. \<forall>x\<in>set excaps.
-           cte_wp_at ((=) (fst x)) (snd x) s)\<rbrace>
-    decode_invocation info_label args ptr slot cap excaps
-   \<lbrace>\<lambda>rv. authorised_for_globals_inv rv\<rbrace>, -"
-  unfolding decode_invocation_def
-  apply (rule hoare_pre)
-   apply wpc
-              apply((wp authorised_for_globals_triv | wpc | simp add: uncurry_def)+)[11]
-   apply (simp add: authorised_for_globals_inv_def)
-   apply wp
-   apply (unfold comp_def)
-   apply simp
-   apply (wp decode_arch_invocation_authorised_for_globals)
-  apply (intro impI conjI allI | clarsimp simp add: authorised_for_globals_inv_def)+
-  apply (erule_tac x="(a, aa, b)" in ballE)
-   apply simp+
-  done
+  "\<forall>x y. f x \<noteq> InvokeArchObject y
+   \<Longrightarrow> \<lbrace>\<top>\<rbrace> m \<lbrace>authorised_for_globals_inv \<circ> f\<rbrace>, -"
+  by (clarsimp simp: validE_R_def validE_def valid_def authorised_for_globals_inv_def
+              split: invocation.splits sum.splits)
 
 lemma set_thread_state_reads_respects_g:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "reads_respects_g aag l (is_subject aag \<circ> cur_thread and valid_ko_at_arm)
-    (set_thread_state ref ts)"
+    "reads_respects_g aag (l :: 'a subject_label) (is_subject aag \<circ> cur_thread and valid_ko_at_arch)
+                      (set_thread_state ref ts)"
   apply (rule equiv_valid_guard_imp)
    apply (rule reads_respects_g)
     apply (rule set_thread_state_reads_respects[OF domains_distinct])
    apply (rule doesnt_touch_globalsI)
    apply (rule set_thread_state_globals_equiv)
   apply simp
-done
+  done
 
 lemmas get_thread_state_reads_respects_g =
-          reads_respects_g_from_inv[OF get_thread_state_rev get_thread_state_inv]
+  reads_respects_g_from_inv[OF get_thread_state_rev get_thread_state_inv]
 
 lemma decode_invocation_authorised_extra:
   "\<lbrace>K (is_subject aag (fst slot))\<rbrace>
    decode_invocation info_label args ptr slot cap excaps
-   \<lbrace>\<lambda> rv s. authorised_invocation_extra aag rv\<rbrace>,-"
+   \<lbrace>\<lambda>rv s. authorised_invocation_extra aag rv\<rbrace>,-"
   unfolding decode_invocation_def authorised_invocation_extra_def
-  apply(rule hoare_pre)
-   apply(wp decode_tcb_invocation_authorised_extra | wpc | simp add: split_def o_def uncurry_def)+
+  apply (rule hoare_pre)
+   apply (wp decode_tcb_invocation_authorised_extra | wpc | simp add: split_def o_def uncurry_def)+
   apply auto
   done
 
 lemma sts_schact_is_rct_runnable:
-  "\<lbrace>schact_is_rct and K(runnable b)\<rbrace>
-      set_thread_state a b
+  "\<lbrace>schact_is_rct and K (runnable b)\<rbrace>
+   set_thread_state a b
    \<lbrace>\<lambda>_. schact_is_rct\<rbrace>"
-  apply (simp add: set_thread_state_def
-                   set_scheduler_action_def)
+  apply (simp add: set_thread_state_def set_scheduler_action_def)
   apply (wpsimp wp: set_object_wp)
      apply (simp add: set_thread_state_ext_def)
      apply (wp modify_wp set_scheduler_action_wp gts_wp)
@@ -607,23 +523,41 @@ lemma sts_schact_is_rct_runnable:
   done
 
 lemma set_thread_state_only_timer_irq_inv:
-  "\<lbrace>only_timer_irq_inv irq (st::det_ext state)\<rbrace>
-   set_thread_state ref ts \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
+  "\<lbrace>only_timer_irq_inv irq (st :: det_state)\<rbrace>
+   set_thread_state ref ts
+   \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
   apply (simp add: only_timer_irq_inv_def)
   apply (wp only_timer_irq_pres | force)+
   done
 
+lemma ct_active_cur_thread_not_idle_thread:
+  "\<lbrakk> valid_idle s; ct_active s \<rbrakk> \<Longrightarrow> cur_thread s \<noteq> idle_thread s"
+  by (clarsimp simp: invs_def valid_idle_def ct_in_state_def pred_tcb_at_def obj_at_def)
+
+lemma ct_active_not_idle:
+  "\<lbrakk> invs s; ct_active s \<rbrakk> \<Longrightarrow> cur_thread s \<noteq> idle_thread s"
+  by (clarsimp simp: ct_active_cur_thread_not_idle_thread invs_valid_idle)
 
 
+context Syscall_IF_1 begin
 
-lemma ct_active_not_idle': "valid_idle s \<Longrightarrow> ct_active s \<Longrightarrow> cur_thread s \<noteq> idle_thread s"
-  apply (clarsimp simp: invs_def valid_idle_def ct_in_state_def
-                        pred_tcb_at_def obj_at_def)
-  done
-
-lemma ct_active_not_idle: "invs s \<Longrightarrow> ct_active s \<Longrightarrow> cur_thread s \<noteq> idle_thread s"
-  apply (rule ct_active_not_idle')
-  apply (simp add: invs_valid_idle)+
+lemma decode_invocation_authorised_globals_inv:
+  "\<lbrace>invs and cte_wp_at ((=) cap) slot
+         and (\<lambda>s :: det_state. \<forall>x\<in>set excaps. cte_wp_at ((=) (fst x)) (snd x) s)\<rbrace>
+   decode_invocation info_label args ptr slot cap excaps
+   \<lbrace>authorised_for_globals_inv\<rbrace>, -"
+  unfolding decode_invocation_def
+  apply (rule hoare_pre)
+   apply wpc
+              apply ((wp authorised_for_globals_triv | wpc | simp add: uncurry_def)+)[11]
+   apply (unfold authorised_for_globals_inv_def)
+   apply wp
+   apply (unfold comp_def)
+   apply simp
+   apply (wp decode_arch_invocation_authorised_for_globals)
+  apply (intro impI conjI allI | clarsimp simp add: authorised_for_globals_inv_def)+
+  apply (erule_tac x="(a, aa, b)" in ballE)
+   apply simp+
   done
 
 lemma handle_invocation_reads_respects_g:
@@ -631,94 +565,65 @@ lemma handle_invocation_reads_respects_g:
   notes gts_st_tcb[wp del] gts_st_tcb_at[wp del]
   notes get_message_info_reads_respects_g = reads_respects_g_from_inv[OF get_message_info_rev get_mi_inv]
   shows "reads_respects_f_g aag l
-           (silc_inv aag st and only_timer_irq_inv irq st' and einvs and schact_is_rct and ct_active and
-            pas_refined aag and pas_cur_domain aag and is_subject aag \<circ> cur_thread and
-            K (\<not> pasMaySendIrqs aag))
+           (silc_inv aag st and only_timer_irq_inv irq st' and einvs and schact_is_rct and ct_active
+                            and pas_refined aag and pas_cur_domain aag
+                            and is_subject aag \<circ> cur_thread and K (\<not> pasMaySendIrqs aag))
            (handle_invocation calling blocking)"
   apply (rule gen_asm_ev)
-  apply (simp add: handle_invocation_def fun_app_def split_def)
+  apply (simp add: handle_invocation_def split_def)
   apply (wpc | simp add: tcb_at_st_tcb_at[symmetric] split del: if_split
-            | intro impI | erule conjE
-            | rule doesnt_touch_globalsI |
-
-            (wp
-            syscall_requiv_f_g gts_inv
-            when_ev
-            reads_respects_f_g'[OF lookup_extra_caps_reads_respects_g, where Q="\<top>" and st=st]
-            reads_respects_f_g'[OF lookup_ipc_buffer_reads_respects_g, where Q="\<top>" and st=st]
-            reads_respects_f_g'[OF cap_fault_on_failure_rev_g, where Q="\<top>" and st=st]
-            valid_validE_R[OF wp_post_taut]
-            lookup_ipc_buffer_has_read_auth'
-
-            lookup_cap_and_slot_reads_respects_g' (*Weird*)
-            decode_invocation_reads_respects_f_g
-            get_mrs_reads_respects_g
-            handle_fault_reads_respects_g
-            reads_respects_f_g'[OF set_thread_state_reads_respects_g, where st=st and Q="\<top>"]
-            reads_respects_f_g'[OF get_thread_state_reads_respects_g, where st=st and Q="\<top>"]
-            reads_respects_f_g'[OF reads_respects_g[OF reply_from_kernel_reads_respects], where st=st and Q="\<top>"]
-            get_thread_state_reads_respects_g
-            perform_invocation_reads_respects_f_g
-            set_thread_state_pas_refined
-            sts_first_restart
-            set_thread_state_ct_st
-            lookup_extra_caps_authorised
-            lookup_extra_caps_auth
-
-            handle_fault_globals_equiv
-            set_thread_state_globals_equiv
-            reply_from_kernel_globals_equiv)+ | (rule hoare_drop_imps)
-        )+
-
-               apply (rule_tac Q'="\<lambda>r s. silc_inv aag st s \<and> invs s \<and> is_subject aag rv \<and> is_subject aag (cur_thread s) \<and> rv \<noteq> idle_thread s" in hoare_post_imp_R)
+             | intro impI | erule conjE | rule doesnt_touch_globalsI
+             | (wp syscall_requiv_f_g gts_inv when_ev
+                   reads_respects_f_g'[OF lookup_extra_caps_reads_respects_g, where Q="\<top>" and st=st]
+                   reads_respects_f_g'[OF lookup_ipc_buffer_reads_respects_g, where Q="\<top>" and st=st]
+                   reads_respects_f_g'[OF cap_fault_on_failure_rev_g, where Q="\<top>" and st=st]
+                   valid_validE_R[OF wp_post_taut] lookup_ipc_buffer_has_read_auth'
+                   lookup_cap_and_slot_reads_respects_g' decode_invocation_reads_respects_f_g
+                   get_mrs_reads_respects_g handle_fault_reads_respects_g
+                   reads_respects_f_g'[OF set_thread_state_reads_respects_g, where st=st and Q="\<top>"]
+                   reads_respects_f_g'[OF get_thread_state_reads_respects_g, where st=st and Q="\<top>"]
+                   reads_respects_f_g'[OF reads_respects_g[OF reply_from_kernel_reads_respects], where st=st]
+                   get_thread_state_reads_respects_g perform_invocation_reads_respects_f_g
+                   set_thread_state_pas_refined sts_first_restart set_thread_state_ct_st
+                   lookup_extra_caps_authorised lookup_extra_caps_auth handle_fault_globals_equiv
+                   set_thread_state_globals_equiv reply_from_kernel_globals_equiv)+
+             | rule hoare_drop_imps)+
+               apply (rule_tac Q'="\<lambda>r s. silc_inv aag st s \<and> invs s \<and> is_subject aag rv \<and>
+                                         is_subject aag (cur_thread s) \<and> rv \<noteq> idle_thread s"
+                            in hoare_post_imp_R)
                 apply (wp pinv_invs perform_invocation_silc_inv)
-               apply (simp add: invs_def valid_state_def valid_pspace_def valid_arch_state_ko_at_arm)
-              apply(wp reads_respects_f_g'[OF set_thread_state_reads_respects_g[OF domains_distinct], where Q="\<top>" and st=st] | simp)+
-
-             apply (simp add: o_def|
-                    wp when_ev
-                       set_thread_state_only_timer_irq_inv[where st=st']
-                       set_thread_state_reads_respects_g
-                       set_thread_state_globals_equiv
-                       sts_Restart_invs
-                       set_thread_state_pas_refined
-                       set_thread_state_ct_st
-                       set_thread_state_runnable_valid_sched
-                       sts_authorised_for_globals_inv
-                       sts_schact_is_rct_runnable
-                       decode_invocation_reads_respects_f_g
+               apply (simp add: invs_def valid_state_def valid_pspace_def valid_arch_state_ko_at_arch)
+              apply (wpsimp wp: reads_respects_f_g'
+                                set_thread_state_reads_respects_g[OF domains_distinct])
+             apply (wp when_ev set_thread_state_only_timer_irq_inv[where st=st']
+                       set_thread_state_reads_respects_g set_thread_state_globals_equiv
+                       sts_Restart_invs set_thread_state_pas_refined set_thread_state_ct_st
+                       set_thread_state_runnable_valid_sched sts_authorised_for_globals_inv
+                       sts_schact_is_rct_runnable decode_invocation_reads_respects_f_g
                        reads_respects_f_g'[OF get_mrs_reads_respects_g, where Q="\<top>" and st=st]
                        reads_respects_f_g'[OF handle_fault_reads_respects_g]
-                       decode_invocation_authorised
-                       decode_invocation_authorised_globals_inv
-                       decode_invocation_authorised_extra
-                       lec_valid_fault
-                       lookup_extra_caps_authorised
-                       lookup_extra_caps_auth
-                       lookup_ipc_buffer_has_read_auth'
-                       lookup_cap_and_slot_valid_fault3
-                       lookup_cap_and_slot_authorised
-                       lookup_cap_and_slot_cur_auth
-                       reads_respects_f_g'[OF reads_respects_g[OF as_user_reads_respects], where Q="\<top>" and st=st] as_user_silc_inv
-                       as_user_globals_equiv
-                       user_getreg_inv
+                       decode_invocation_authorised decode_invocation_authorised_globals_inv
+                       decode_invocation_authorised_extra lec_valid_fault
+                       lookup_extra_caps_authorised lookup_extra_caps_auth
+                       lookup_ipc_buffer_has_read_auth' lookup_cap_and_slot_valid_fault3
+                       lookup_cap_and_slot_authorised lookup_cap_and_slot_cur_auth as_user_silc_inv
+                       reads_respects_f_g'[OF reads_respects_g[OF as_user_reads_respects], where Q=\<top> and st=st]
                        reads_respects_f_g'[OF get_message_info_reads_respects_g, where Q="\<top>" and st=st]
-                       get_mi_inv
-                       get_mi_length
-                       get_mi_length'
-              | rule doesnt_touch_globalsI
-              | (clarify,assumption)
-              | wp (once) hoare_drop_imps
-          )+
+                       as_user_globals_equiv user_getreg_inv get_mi_inv get_mi_length get_mi_length'
+                    | simp add: o_def
+                    | rule doesnt_touch_globalsI
+                    | clarify, assumption
+                    | wp (once) hoare_drop_imps)+
   apply (rule conjI)
    apply (clarsimp simp: requiv_g_cur_thread_eq simp: reads_equiv_f_g_conj)
-  apply (clarsimp simp: getRegister_def invs_sym_refs invs_def valid_state_def valid_arch_state_ko_at_arm valid_pspace_vo valid_pspace_distinct)
+  apply (clarsimp simp: det_getRegister invs_sym_refs invs_def valid_state_def
+                        valid_arch_state_ko_at_arch valid_pspace_vo valid_pspace_distinct)
   apply (rule context_conjI)
-   apply (simp add: ct_active_not_idle')
+   apply (simp add: ct_active_cur_thread_not_idle_thread)
   apply (clarsimp simp: valid_pspace_def ct_in_state_def)
   apply (rule conjI)
-   apply(fastforce intro: reads_lrefl)
-  apply(rule conjI, fastforce)+
+   apply (fastforce intro: reads_lrefl)
+  apply (rule conjI, fastforce)+
   apply (simp add: conj_comms)
   apply (rule conjI)
    apply (clarsimp elim!: schact_is_rct_simple)
@@ -729,22 +634,23 @@ lemma handle_invocation_reads_respects_g:
   apply (force simp: only_timer_irq_inv_def runnable_eq_active)
   done
 
+end
+
+
 lemma delete_caller_cap_reads_respects_f:
   assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects_f aag l (silc_inv aag st and invs and pas_refined aag and
-         K (is_subject aag (fst (x, tcb_cnode_index 3)))) (delete_caller_cap x)"
+  shows "reads_respects_f aag l (silc_inv aag st and invs and pas_refined aag
+                                                 and K (is_subject aag (fst (x, tcb_cnode_index 3))))
+                          (delete_caller_cap x)"
   unfolding delete_caller_cap_def
-  apply (rule cap_delete_one_reads_respects_f[OF domains_distinct])
-  done
+  by (rule cap_delete_one_reads_respects_f[OF domains_distinct])
 
 lemma delete_caller_cap_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm\<rbrace> delete_caller_cap x \<lbrace>\<lambda>r. globals_equiv st\<rbrace>"
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
+   delete_caller_cap x
+   \<lbrace>\<lambda>r. globals_equiv st\<rbrace>"
   unfolding delete_caller_cap_def
-  apply (wp cap_delete_one_globals_equiv)
-  done
-
-
+  by (wp cap_delete_one_globals_equiv)
 
 lemma lookup_cap_cap_fault:
   "\<lbrace>invs\<rbrace> lookup_cap c b -, \<lbrace>\<lambda>f s. valid_fault (CapFault x y f)\<rbrace>"
@@ -762,62 +668,56 @@ lemma cap_fault_on_failure_ev':
   "equiv_valid_inv (reads_equiv_f aag) A P f \<Longrightarrow>
        equiv_valid_inv (reads_equiv_f aag) A P (cap_fault_on_failure cptr rp f)"
   unfolding cap_fault_on_failure_def handleE'_def
-  apply(wp | wpc | simp add: o_def)+
-  done
+  by (wp | wpc | simp add: o_def)+
 
-lemma delete_caller_cap_valid_ep_cap[wp]:  "\<lbrace>(\<lambda>s. s \<turnstile> (EndpointCap a b c))\<rbrace> delete_caller_cap t \<lbrace>\<lambda>rv s. s \<turnstile> EndpointCap a b c\<rbrace>"
+lemma delete_caller_cap_valid_ep_cap[wp]:
+  "delete_caller_cap t \<lbrace>\<lambda>s. s \<turnstile> EndpointCap a b c\<rbrace>"
   apply (clarsimp simp: delete_caller_cap_def valid_cap_def)
   apply (rule hoare_pre)
    apply wp
   apply clarsimp
   done
 
-
 lemma handle_recv_reads_respects_f:
   fixes st aag
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   notes mywp =
-            domains_distinct
-            cap_fault_on_failure_ev'
-            receive_ipc_silc_inv[where st=st]
-            reads_respects_f[OF receive_ipc_reads_respects, where st=st]
-            delete_caller_cap_reads_respects_f[where st=st]
-            delete_caller_cap_silc_inv[where st=st]
-            reads_respects_f_inv[OF receive_signal_reads_respects receive_signal_silc_inv,
-                                 where st=st]
-            reads_respects_f[OF lookup_slot_for_thread_rev, where st=st and Q=\<top>]
-            reads_respects_f_inv[OF get_cap_rev get_cap_inv, where st=st]
-            get_cap_auth_wp[where aag=aag]
-            reads_respects_f[OF get_simple_ko_reads_respects, where st=st and Q=\<top>]
-            lookup_slot_for_thread_authorised
-            get_simple_ko_wp
+    domains_distinct
+    cap_fault_on_failure_ev'
+    receive_ipc_silc_inv[where st=st]
+    reads_respects_f[OF receive_ipc_reads_respects, where st=st]
+    delete_caller_cap_reads_respects_f[where st=st]
+    delete_caller_cap_silc_inv[where st=st]
+    reads_respects_f_inv[OF receive_signal_reads_respects receive_signal_silc_inv, where st=st]
+    reads_respects_f[OF lookup_slot_for_thread_rev, where st=st and Q=\<top>]
+    reads_respects_f_inv[OF get_cap_rev get_cap_inv, where st=st]
+    get_cap_auth_wp[where aag=aag]
+    reads_respects_f[OF get_simple_ko_reads_respects, where st=st and Q=\<top>]
+    lookup_slot_for_thread_authorised
+    get_simple_ko_wp
   shows
-  "reads_respects_f aag l (silc_inv aag st and einvs and ct_active and
-        pas_refined aag and pas_cur_domain aag and is_subject aag \<circ> cur_thread)
-   (handle_recv is_blocking)"
+    "reads_respects_f aag l (silc_inv aag st and einvs and ct_active and pas_refined aag
+                                             and pas_cur_domain aag and is_subject aag \<circ> cur_thread)
+                      (handle_recv is_blocking)"
   apply (simp add: handle_recv_def Let_def lookup_cap_def split_def)
-
   apply (wp mywp | wpc | assumption | simp | clarsimp
-        | strengthen aag_can_read_self[where x ="fst(fst y)" for y])+
-         apply (rule_tac Q'="\<lambda>r s. silc_inv aag st s \<and> einvs s \<and> pas_refined aag s \<and>
-                                   tcb_at rv s \<and> pas_cur_domain aag s \<and>
-                                   cte_wp_at \<top> (fst r) s \<and>
-                                   is_subject aag rv \<and> is_subject aag (cur_thread s) \<and>
-                                   is_subject aag (fst (fst r))"
-                       in hoare_post_imp_R)
+                 | strengthen aag_can_read_self[where x ="fst (fst y)" for y])+
+         apply (rule_tac Q'="\<lambda>r s. silc_inv aag st s \<and> einvs s \<and> pas_refined aag s \<and> tcb_at rv s \<and>
+                                   pas_cur_domain aag s \<and> cte_wp_at \<top> (fst r) s \<and> is_subject aag rv \<and>
+                                   is_subject aag (cur_thread s) \<and> is_subject aag (fst (fst r))"
+                      in hoare_post_imp_R)
           apply ((wp lookup_slot_for_thread_authorised lookup_slot_cte_at_wp | simp)+)[1]
-        apply (clarsimp simp: silc_inv_not_subject[symmetric] invs_mdb invs_valid_objs)
-        subgoal by (auto intro: caps_of_state_valid reads_ep
-                          simp: aag_cap_auth_def cap_auth_conferred_def cap_rights_to_auth_def)
-        apply(wp reads_respects_f[OF handle_fault_reads_respects,where st=st])
-        apply (wpsimp wp: get_simple_ko_wp get_cap_wp)+
-        apply(rule VSpaceEntries_AI.hoare_vcg_all_liftE)
-           apply (rule_tac Q="\<lambda>r s. silc_inv aag st s \<and> einvs s \<and> pas_refined aag s \<and>
-                                     tcb_at rv s \<and> pas_cur_domain aag s \<and>
-                                     is_subject aag rv \<and> is_subject aag (cur_thread s) \<and>
-                                     is_subject aag (fst (fst r))"
-                        and E=E and F=E for E in hoare_post_impErr)
-              apply (wp lookup_slot_for_thread_authorised lookup_slot_for_thread_cap_fault)
+         apply (clarsimp simp: silc_inv_not_subject[symmetric] invs_mdb invs_valid_objs)
+         apply (auto intro: caps_of_state_valid reads_ep
+                      simp: aag_cap_auth_def cap_auth_conferred_def cap_rights_to_auth_def)[1]
+        apply (wp reads_respects_f[OF handle_fault_reads_respects,where st=st])
+       apply (wpsimp wp: get_simple_ko_wp get_cap_wp)+
+        apply (rule VSpaceEntries_AI.hoare_vcg_all_liftE)
+        apply (rule_tac Q="\<lambda>r s. silc_inv aag st s \<and> einvs s \<and> pas_refined aag s \<and>
+                                 tcb_at rv s \<and> pas_cur_domain aag s \<and> is_subject aag rv \<and>
+                                 is_subject aag (cur_thread s) \<and> is_subject aag (fst (fst r))"
+                     and E=E and F=E for E in hoare_post_impErr)
+          apply (wp lookup_slot_for_thread_authorised lookup_slot_for_thread_cap_fault)
          apply ((fastforce simp add:valid_fault_def)+)[3]
       apply (wp reads_respects_f[OF as_user_reads_respects,where st=st and Q=\<top>])
       apply simp
@@ -826,8 +726,8 @@ lemma handle_recv_reads_respects_f:
 
 lemma handle_recv_globals_equiv:
   "\<lbrace>globals_equiv (st :: det_state) and invs and ct_active\<rbrace>
-     handle_recv is_blocking
-   \<lbrace>\<lambda>r. globals_equiv st\<rbrace>"
+   handle_recv is_blocking
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding handle_recv_def
   apply (wp handle_fault_globals_equiv get_simple_ko_wp
         | wpc | simp add: Let_def)+
@@ -843,30 +743,29 @@ lemma handle_recv_globals_equiv:
                 | rule_tac Q="\<lambda>rv s. invs s \<and> thread \<noteq> idle_thread s \<and> globals_equiv st s"
                            in hoare_strengthen_post,
                   wp,
-                  clarsimp simp: invs_valid_objs invs_valid_global_objs invs_arch_state
-                                 invs_distinct)+
+                  clarsimp simp: invs_valid_objs invs_valid_global_objs invs_arch_state invs_distinct)+
      apply (rule_tac Q'="\<lambda>r s. invs s \<and> globals_equiv st s \<and> thread \<noteq> idle_thread s \<and>
                                tcb_at thread s \<and> cur_thread s = thread"
                   in hoare_post_imp_R)
       apply (wp as_user_globals_equiv | simp add: invs_imps valid_fault_def)+
     apply (wp delete_caller_cap_invs delete_caller_cap_globals_equiv
-          | simp add: invs_imps invs_valid_idle ct_active_not_idle)+
+           | simp add: invs_imps invs_valid_idle ct_active_not_idle)+
   done
 
 lemma handle_recv_reads_respects_f_g:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-  "reads_respects_f_g aag l (silc_inv aag st and einvs and ct_active and
-        pas_refined aag and pas_cur_domain aag and is_subject aag \<circ> cur_thread)
-     (handle_recv is_blocking)"
+    "reads_respects_f_g aag l
+       (silc_inv aag st and einvs and ct_active and pas_refined aag
+                        and pas_cur_domain aag and is_subject aag \<circ> cur_thread)
+       (handle_recv is_blocking)"
   apply (rule equiv_valid_guard_imp)
-  apply (rule reads_respects_f_g)
-  apply (wp handle_recv_reads_respects_f[where st=st, OF domains_distinct])
-  apply (rule doesnt_touch_globalsI)
-  apply (wp handle_recv_globals_equiv)
-  apply simp+
+   apply (rule reads_respects_f_g)
+    apply (wp handle_recv_reads_respects_f[where st=st, OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp handle_recv_globals_equiv)
+   apply simp+
   done
-
 
 lemma dmo_return_reads_respects:
   "reads_respects aag l \<top> (do_machine_op (return ()))"
@@ -875,22 +774,21 @@ lemma dmo_return_reads_respects:
   done
 
 lemma dmo_return_globals_equiv:
-  "\<lbrace>globals_equiv st\<rbrace> do_machine_op (return ()) \<lbrace>\<lambda>r .globals_equiv st\<rbrace>"
+  "do_machine_op (return ()) \<lbrace>globals_equiv st\<rbrace>"
   by simp
 
 lemma get_irq_slot_reads_respects':
-  "reads_respects aag l (K(aag_can_read_label aag (pasIRQAbs aag irq))) (get_irq_slot irq)"
+  "reads_respects aag l (K (aag_can_read_label aag (pasIRQAbs aag irq))) (get_irq_slot irq)"
   unfolding get_irq_slot_def
-  apply(rule equiv_valid_guard_imp)
-   apply(rule gets_ev)
-  apply(simp add: reads_equiv_def states_equiv_for_def equiv_for_def affects_equiv_def)
+  apply (rule equiv_valid_guard_imp)
+   apply (rule gets_ev)
+  apply (simp add: reads_equiv_def states_equiv_for_def equiv_for_def affects_equiv_def)
   done
 
-
 lemma get_irq_slot_can_read_from_slot:
-  "\<lbrace>K(aag_can_read_label aag (pasIRQAbs aag irq)) and pas_refined aag\<rbrace>
-     get_irq_slot irq
-   \<lbrace>\<lambda>r. K(aag_can_read_label aag (pasObjectAbs aag (fst r)))\<rbrace>"
+  "\<lbrace>K (aag_can_read_label aag (pasIRQAbs aag irq)) and pas_refined aag\<rbrace>
+   get_irq_slot irq
+   \<lbrace>\<lambda>r. K (aag_can_read_label aag (pasObjectAbs aag (fst r)))\<rbrace>"
   unfolding get_irq_slot_def
   apply (wp gets_wp)
   apply (simp add: pas_refined_def policy_wellformed_def irq_map_wellformed_aux_def)
@@ -899,80 +797,69 @@ lemma get_irq_slot_can_read_from_slot:
 lemma get_irq_state_rev':
   "reads_equiv_valid_inv A aag (K (aag_can_read_label aag (pasIRQAbs aag irq))) (get_irq_state irq)"
   unfolding get_irq_state_def
-  apply(rule equiv_valid_guard_imp[OF gets_ev])
-  apply(fastforce simp: reads_equiv_def2
-                  elim: states_equiv_forE_interrupt_states
-                 intro: aag_can_read_irq_self)
+  apply (rule equiv_valid_guard_imp[OF gets_ev])
+  apply (fastforce simp: reads_equiv_def2
+                   elim: states_equiv_forE_interrupt_states
+                  intro: aag_can_read_irq_self)
   done
 
-lemma equiv_valid_vacuous:
-  "equiv_valid_inv I A \<bottom> f"
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+lemma handle_yield_reads_respects:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows "reads_respects aag (l :: 'a subject_label) (pas_refined aag) handle_yield"
+  by (wpsimp wp: domains_distinct tcb_sched_action_reads_respects
+           simp: handle_yield_def reads_equiv_def)
+
+crunch silc_inv[wp]: handle_yield "silc_inv aag st"
+
+crunch globals_equiv[wp]: handle_yield "globals_equiv st"
+  (simp_del: reschedule_required_ext_extended.dxo_eq tcb_sched_action_extended.dxo_eq)
+
+lemma equiv_valid_hoist_guard:
+  assumes a: "Q \<Longrightarrow> equiv_valid_inv I A P f"
+  assumes b: "\<And>s. P s \<Longrightarrow> Q"
+  shows "equiv_valid_inv I A P f"
+  using assms by (fastforce simp: equiv_valid_def2 equiv_valid_2_def)
+
+lemma as_user_reads_respects_g:
+  "reads_respects_g aag k
+     (valid_ko_at_arch and (\<lambda>s. thread \<noteq> idle_thread s) and K (det f \<and> is_subject aag thread))
+     (as_user thread f)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_g)
+    apply (rule as_user_reads_respects)
+   apply (rule doesnt_touch_globalsI)
+   apply (wp as_user_globals_equiv)
+   apply simp+
   done
 
-declare gts_st_tcb_at[wp del]
+crunch globals_equiv[wp]: invoke_domain "globals_equiv st"
+  (wp: dxo_wp_weak ignore: reschedule_required set_domain
+   simp_del: set_domain_extended.dxo_eq)
+
+lemma handle_fault_globals_equiv':
+  "\<lbrace>invs and globals_equiv st and K (valid_fault ex)\<rbrace>
+   handle_fault thread ex
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+   by (wpsimp wp: handle_fault_globals_equiv simp: invs_imps)
+
+
+context Syscall_IF_1 begin
 
 lemma handle_interrupt_globals_equiv:
-  "\<lbrace>globals_equiv (st :: det_ext state) and invs\<rbrace> handle_interrupt irq \<lbrace>\<lambda>r. globals_equiv st\<rbrace>"
+  "\<lbrace>globals_equiv (st :: det_state) and invs\<rbrace>
+   handle_interrupt irq
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding handle_interrupt_def
   apply (rule hoare_if)
-  apply (wp dmo_maskInterrupt_globals_equiv
-            dmo_return_globals_equiv
-            send_signal_globals_equiv
-            dmo_ackInterrupt
-            hoare_vcg_if_lift2
-            hoare_drop_imps
-            dxo_wp_weak
-            Retype_IF.dmo_mol_globals_equiv
-            no_fail_bind
-            bind_known_operation_eq
-            dmo_mol_globals_equiv
-        | wpc
-        | simp add: dmo_bind_valid
-                    ackInterrupt_def
-                    resetTimer_def
-                    handle_reserved_irq_def
-                    invs_imps invs_valid_idle)+
-
+  apply (wp dmo_maskInterrupt_globals_equiv dmo_return_globals_equiv send_signal_globals_equiv
+            hoare_vcg_if_lift2 hoare_drop_imps dxo_wp_weak no_fail_bind bind_known_operation_eq
+         | wpc
+         | simp add: dmo_bind_valid invs_imps invs_valid_idle)+
   done
-
-end
-
-axiomatization dmo_reads_respects where
-  dmo_getDFSR_reads_respects: "reads_respects aag l \<top> (do_machine_op ARM.getDFSR)" and
-  dmo_getFAR_reads_respects: "reads_respects aag l \<top> (do_machine_op ARM.getFAR)" and
-  dmo_getIFSR_reads_respects: "reads_respects aag l \<top> (do_machine_op ARM.getIFSR)"
-
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-lemma handle_vm_fault_reads_respects:
-  "reads_respects aag l (K(is_subject aag thread)) (handle_vm_fault thread vmfault_type)"
-  apply (cases vmfault_type)
-  apply (wp dmo_getDFSR_reads_respects dmo_getFAR_reads_respects
-            dmo_getIFSR_reads_respects as_user_reads_respects
-         | simp add: getRestartPC_def getRegister_def)+
-  done
-
-lemma handle_hypervisor_fault_reads_respects:
-  "reads_respects aag l \<top> (handle_hypervisor_fault thread hypfault_type)"
-  by (cases hypfault_type; wpsimp)
-
-lemma handle_vm_fault_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
-     handle_vm_fault thread vmfault_type
-   \<lbrace>\<lambda>r. globals_equiv st\<rbrace>"
-  apply (cases vmfault_type)
-   apply (wp dmo_no_mem_globals_equiv | simp add: getDFSR_def getFAR_def getIFSR_def)+
-  done
-
-lemma handle_hypervisor_fault_globals_equiv:
-  "\<lbrace>globals_equiv st\<rbrace> handle_hypervisor_fault thread hypfault_type \<lbrace>\<lambda>r. globals_equiv st\<rbrace>"
-  by (cases hypfault_type; wpsimp)
 
 lemma handle_vm_fault_reads_respects_g:
-  "reads_respects_g aag l (K(is_subject aag thread) and (valid_ko_at_arm
-                           and (\<lambda>s. thread \<noteq> idle_thread s)))
-     (handle_vm_fault thread vmfault_type)"
+  "reads_respects_g aag l (K (is_subject aag t) and (valid_ko_at_arch and (\<lambda>s. t \<noteq> idle_thread s)))
+                    (handle_vm_fault t vmfault_type)"
   apply (rule reads_respects_g)
    apply (rule handle_vm_fault_reads_respects)
   apply (rule doesnt_touch_globalsI)
@@ -989,62 +876,38 @@ lemma handle_hypervisor_fault_reads_respects_g:
   apply simp
   done
 
-lemma irq_state_indepedent_top[simp, intro!]:
-  "irq_state_independent (\<lambda>s. True)"
-  apply(simp add: irq_state_independent_def)
-  done
-
-lemma handle_yield_reads_respects:
-  assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (pas_refined aag) handle_yield"
-  apply (simp add: handle_yield_def | wp domains_distinct tcb_sched_action_reads_respects)+
-  apply (simp add: reads_equiv_def)
-  done
-
-crunch silc_inv[wp]: handle_yield "silc_inv aag st"
-
-crunch globals_equiv[wp]: handle_yield "globals_equiv st" (wp: dxo_wp_weak ignore: reschedule_required)
-
-lemma equiv_valid_hoist_guard:
-  assumes a: "Q \<Longrightarrow> equiv_valid_inv I A P f"
-  assumes b: "\<And> s. P s \<Longrightarrow> Q"
-  shows "equiv_valid_inv I A P f"
-  using assms apply(fastforce simp: equiv_valid_def2 equiv_valid_2_def)
-  done
-
 (* we explicitly exclude the case where ev is Interrupt since this is a scheduler action *)
 lemma handle_event_reads_respects_f_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects_f_g aag l (silc_inv aag st and only_timer_irq_inv irq st' and einvs
-         and schact_is_rct and domain_sep_inv (pasMaySendIrqs aag) st'
-         and (\<lambda>s. ev \<noteq> Interrupt \<and> (ct_active s)) and pas_refined aag and pas_cur_domain aag
-         and is_subject aag \<circ> cur_thread and K (\<not> pasMaySendIrqs aag))
-     (handle_event ev)"
-  apply(rule gen_asm_ev)
-  apply(rule_tac Q="ev \<noteq> Interrupt" in equiv_valid_hoist_guard)
+  shows "reads_respects_f_g aag l (silc_inv aag st and only_timer_irq_inv irq st' and einvs
+                                                   and schact_is_rct and is_subject aag \<circ> cur_thread
+                                                   and domain_sep_inv (pasMaySendIrqs aag) st'
+                                                   and (\<lambda>s. ev \<noteq> Interrupt \<and> (ct_active s))
+                                                   and pas_refined aag and pas_cur_domain aag
+                                                   and K (\<not> pasMaySendIrqs aag))
+                            (handle_event ev)"
+  apply (rule gen_asm_ev)
+  apply (rule_tac Q="ev \<noteq> Interrupt" in equiv_valid_hoist_guard)
    prefer 2
    apply fastforce
   apply (case_tac ev; simp)
-    apply (rename_tac syscall)
-    apply (case_tac syscall, simp_all add: handle_send_def handle_call_def)
-          apply ((wp handle_invocation_reads_respects_g[simplified]
-                  handle_recv_reads_respects_f_g[where st=st]
-                  handle_reply_valid_sched
-                  reads_respects_f_g[OF reads_respects_f[where st=st and aag=aag and Q=\<top>,
-                                                         OF handle_yield_reads_respects]
-                                        doesnt_touch_globalsI]
-                  handle_reply_reads_respects_g handle_reply_silc_inv[where st=st]
-                | simp add: invs_imps | rule equiv_valid_guard_imp | force)+)[8]
+      apply (rename_tac syscall)
+      apply (case_tac syscall, simp_all add: handle_send_def handle_call_def)
+             apply ((wp handle_invocation_reads_respects_g[simplified]
+                        handle_recv_reads_respects_f_g[where st=st]
+                        handle_reply_valid_sched
+                        reads_respects_f_g[OF reads_respects_f[where st=st and aag=aag and Q=\<top>,
+                                                               OF handle_yield_reads_respects]
+                                              doesnt_touch_globalsI]
+                        handle_reply_reads_respects_g handle_reply_silc_inv[where st=st]
+                     | simp add: invs_imps | rule equiv_valid_guard_imp | force)+)[8]
      apply ((wp reads_respects_f_g'[OF handle_fault_reads_respects_g, where st=st]
-               | simp add: reads_equiv_f_g_conj
-            | clarsimp simp: invs_imps requiv_g_cur_thread_eq schact_is_rct_simple
-            | wpc | intro impI conjI allI)+)[3]
-       apply (rule equiv_valid_guard_imp)
-        apply ((wp reads_respects_f_g'[OF handle_vm_fault_reads_respects_g, where Q="\<top>" and st=st]
-                   handle_vm_fault_silc_inv
-               | simp)+)[1]
+             | clarsimp simp: reads_equiv_f_g_conj requiv_g_cur_thread_eq schact_is_rct_simple
+             | wpc | intro impI conjI allI)+)[3]
+        apply (rule equiv_valid_guard_imp)
+         apply ((wp reads_respects_f_g'[OF handle_vm_fault_reads_respects_g, where Q="\<top>" and st=st]
+                    handle_vm_fault_silc_inv
+                 | simp)+)[1]
         prefer 2
         apply ((wp reads_respects_f_g'[OF handle_fault_reads_respects_g, where st=st] | simp)+)[1]
        prefer 2
@@ -1052,190 +915,130 @@ lemma handle_event_reads_respects_f_g:
        apply (rule_tac E="\<lambda>r s. invs s \<and> is_subject aag rv \<and> is_subject aag (cur_thread s)
                               \<and> valid_fault r \<and> pas_refined aag s \<and> pas_cur_domain aag s
                               \<and> silc_inv aag st s \<and> rv \<noteq> idle_thread s"
-                   and Q="\<top>\<top>"
-                    in hoare_post_impErr)
+                   and Q="\<top>\<top>" in hoare_post_impErr)
          apply (rule hoare_vcg_E_conj)
           apply (wp hv_invs handle_vm_fault_silc_inv)+
        apply (simp add: invs_imps invs_mdb invs_valid_idle)+
-       apply wp+
+     apply wp+
    apply (clarsimp simp: requiv_g_cur_thread_eq reads_equiv_f_g_conj ct_active_not_idle)
   apply (wp reads_respects_f_g'[OF handle_fault_reads_respects_g, where st=st]
-          | simp add: reads_equiv_f_g_conj
-          | clarsimp simp: invs_imps requiv_g_cur_thread_eq schact_is_rct_simple
-          | wpc | intro impI conjI allI)+
-       apply (rule equiv_valid_guard_imp)
-        apply ((wp reads_respects_f_g'[OF handle_hypervisor_fault_reads_respects_g,
-                                       where Q="\<top>" and st=st]
-                   handle_hypervisor_fault_silc_inv
-               | simp)+)[1]
-       prefer 2
-       apply ((wp reads_respects_f_g'[OF handle_fault_reads_respects_g, where st=st] | simp)+)[1]
-      apply (simp add: validE_E_def)
-     apply (wp hv_invs handle_vm_fault_silc_inv)+
+         | clarsimp simp: reads_equiv_f_g_conj requiv_g_cur_thread_eq schact_is_rct_simple
+         | wpc | intro impI conjI allI)+
+     apply (rule equiv_valid_guard_imp)
+      apply ((wp reads_respects_f_g'[OF handle_hypervisor_fault_reads_respects_g, where Q=\<top>]
+                 handle_hypervisor_fault_silc_inv
+              | simp)+)[1]
+     prefer 2
+     apply ((wp reads_respects_f_g'[OF handle_fault_reads_respects_g, where st=st] | simp)+)[1]
+    apply (simp add: validE_E_def)
+   apply (wp hv_invs handle_vm_fault_silc_inv)+
   apply (simp add: invs_imps invs_mdb invs_valid_idle)+
-  apply (clarsimp simp: requiv_g_cur_thread_eq reads_equiv_f_g_conj ct_active_not_idle)
-  done
-
-lemma as_user_reads_respects_g:
-  "reads_respects_g aag k (valid_ko_at_arm and (\<lambda>s. thread \<noteq> idle_thread s)
-                           and K (det f \<and> is_subject aag thread))
-     (as_user thread f)"
-  apply (rule equiv_valid_guard_imp)
-   apply (rule reads_respects_g)
-    apply (rule as_user_reads_respects)
-   apply (rule doesnt_touch_globalsI)
-   apply (wp as_user_globals_equiv)
-   apply simp+
-  done
-
-lemma setNextPC_det :
-  "det (setNextPC rva)"
-  apply (auto simp: det_def setNextPC_def setRegister_def modify_def get_def put_def bind_def)
-  done
-
-
-lemma get_thread_state_reads_respects':
-  "reads_respects aag l (K(aag_can_read_label aag (pasObjectAbs aag thread))) (get_thread_state thread)"
-  unfolding get_thread_state_def thread_get_def
-  apply (wp | simp)+
-  apply clarify
-  apply (rule requiv_get_tcb_eq')
-  apply simp+
+  apply (fastforce simp: requiv_g_cur_thread_eq reads_equiv_f_g_conj ct_active_not_idle)
   done
 
 lemma activate_thread_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l (cur_tcb and (\<lambda>s. aag_can_read_label aag (pasObjectAbs aag (cur_thread s))))
-     activate_thread"
+  shows "reads_respects aag (l :: 'a subject_label)
+           (cur_tcb and (\<lambda>s. aag_can_read_label aag (pasObjectAbs aag (cur_thread s))))
+           activate_thread"
   apply (simp add: activate_thread_def)
-  apply (wp set_thread_state_runnable_reads_respects
-            get_thread_state_reads_respects'
-         | wpc
-         | simp add: arch_activate_idle_thread_def
-  )+
-               apply (unfold as_user_def)
-               apply (wp set_object_reads_respects
-                         get_thread_state_reads_respects'
-                      | simp add: setNextPC_def setRegister_def
-                                  select_f_returns getRestartPC_def
-                                  getRegister_def arch_activate_idle_thread_def
-                                  tcb_at_st_tcb_at[symmetric] cur_tcb_def
-                      | clarify
-                      | rule hoare_drop_imps conjI
-                             requiv_cur_thread_eq requiv_get_tcb_eq'
-                      | clarsimp simp: st_tcb_at_def obj_at_def is_tcb_def
-                      | simp split: Structures_A.kernel_object.split_asm)+
-  done
+  apply (wpsimp wp: set_thread_state_runnable_reads_respects get_thread_state_rev)
+  by (wp set_object_reads_respects get_thread_state_rev
+      | simp add: as_user_def select_f_returns tcb_at_st_tcb_at[symmetric] cur_tcb_def
+      | rule hoare_drop_imps conjI requiv_cur_thread_eq requiv_get_tcb_eq'
+      | clarsimp simp: st_tcb_at_def obj_at_def is_tcb_def)+
 
 lemma activate_thread_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm and valid_idle\<rbrace>
-     activate_thread
-   \<lbrace>\<lambda> r. globals_equiv st\<rbrace>"
+  "\<lbrace>globals_equiv st and valid_ko_at_arch and valid_idle\<rbrace>
+   activate_thread
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding activate_thread_def
-  by (wp set_thread_state_globals_equiv gts_wp
-     | wpc
-     | clarsimp simp add: arch_activate_idle_thread_def valid_idle_def pred_tcb_at_def obj_at_def
-     | rule hoare_vcg_conj_lift)+
+  by (wpsimp wp: set_thread_state_globals_equiv gts_wp
+           simp: valid_idle_def pred_tcb_at_def obj_at_def)
 
 lemma activate_thread_reads_respects_g:
   assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects_g aag l (invs and (\<lambda>s. aag_can_read_label aag (pasObjectAbs aag (cur_thread s))))
-     activate_thread"
+  shows "reads_respects_g aag (l :: 'a subject_label)
+           (invs and (\<lambda>s. aag_can_read_label aag (pasObjectAbs aag (cur_thread s))))
+           activate_thread"
   apply (rule equiv_valid_guard_imp)
    apply (rule reads_respects_g)
     apply (rule activate_thread_reads_respects[OF domains_distinct])
    apply (rule doesnt_touch_globalsI)
    apply (rule hoare_pre)
-   apply (rule activate_thread_globals_equiv)
+    apply (rule activate_thread_globals_equiv)
    apply (simp add: invs_imps invs_valid_idle)+
   done
 
-(*Globals equiv for top level events*)
-lemma set_thread_state_ct_st':
-  "\<lbrace>\<lambda>s. thread = cur_thread s \<and> P st\<rbrace> set_thread_state thread st \<lbrace>\<lambda>rv. ct_in_state P\<rbrace>"
-  apply (rule hoare_pre)
-   apply (rule set_thread_state_ct_st)
-  apply simp
-  done
-
-crunch globals_equiv[wp]: invoke_domain "globals_equiv st"
-  (wp: dxo_wp_weak ignore: reschedule_required set_domain)
-
 lemma perform_invocation_globals_equiv:
-  "\<lbrace>invs and ct_active and valid_invocation oper and globals_equiv (st :: det_ext state) and
-    authorised_for_globals_inv oper \<rbrace>
-    perform_invocation blocking calling oper
+  "\<lbrace>invs and ct_active and valid_invocation oper and globals_equiv (st :: det_state)
+                                                 and authorised_for_globals_inv oper\<rbrace>
+   perform_invocation blocking calling oper
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (cases oper;
-         (rule hoare_pre,
-          (wp invoke_untyped_globals_equiv
-              send_ipc_globals_equiv
-              send_signal_globals_equiv
-              do_reply_transfer_globals_equiv
-              invoke_tcb_globals_equiv
-              invoke_cnode_globals_equiv
-              invoke_irq_control_globals_equiv
-              invoke_irq_handler_globals_equiv
-              arch_perform_invocation_globals_equiv
-          | wpc | simp)+;
-          auto simp: invs_imps authorised_for_globals_inv_def))
-  done
+  by (cases oper
+      ; wpsimp wp: invoke_untyped_globals_equiv send_ipc_globals_equiv send_signal_globals_equiv
+                   arch_perform_invocation_globals_equiv do_reply_transfer_globals_equiv
+                   invoke_tcb_globals_equiv invoke_irq_control_globals_equiv
+                   invoke_cnode_globals_equiv invoke_irq_handler_globals_equiv
+      ; fastforce simp: invs_imps authorised_for_globals_inv_def)
 
 lemma handle_invocation_globals_equiv:
   "\<lbrace>invs and ct_active and globals_equiv st\<rbrace>
-      handle_invocation calling blocking
-   \<lbrace>\<lambda>_. globals_equiv (st::det_ext state)\<rbrace>"
-  apply (simp add: handle_invocation_def ts_Restart_case_helper split_def
+   handle_invocation calling blocking
+   \<lbrace>\<lambda>_. globals_equiv (st :: det_state)\<rbrace>"
+  apply (simp add: handle_invocation_def ts_Restart_case_helper
                    liftE_liftM_liftME liftME_def bindE_assoc)
-  apply (wp syscall_valid handle_fault_globals_equiv
-            reply_from_kernel_globals_equiv set_thread_state_globals_equiv
-            hoare_vcg_all_lift
-       | simp split del: if_split
-       | wp (once) hoare_drop_imps)+
-        apply (rule_tac Q="\<lambda>r. invs and globals_equiv st and (\<lambda>s. thread \<noteq> idle_thread s)"
-                    and E="\<lambda>_. globals_equiv st"
-                     in hoare_post_impErr)
-          apply (wp pinv_invs perform_invocation_globals_equiv
-                    set_thread_state_ct_st' set_thread_state_globals_equiv
-                    sts_authorised_for_globals_inv
-                    decode_invocation_authorised_globals_inv
-                | simp add: crunch_simps invs_imps)+
+  apply (wp syscall_valid handle_fault_globals_equiv reply_from_kernel_globals_equiv
+            set_thread_state_globals_equiv hoare_vcg_all_lift
+         | simp split del: if_split
+         | wp (once) hoare_drop_imps)+
+         apply (rule_tac Q="\<lambda>r. invs and globals_equiv st and (\<lambda>s. thread \<noteq> idle_thread s)"
+                     and E="\<lambda>_. globals_equiv st" in hoare_post_impErr)
+           apply (wp pinv_invs perform_invocation_globals_equiv
+                     requiv_get_tcb_eq' set_thread_state_globals_equiv
+                     sts_authorised_for_globals_inv
+                     decode_invocation_authorised_globals_inv
+                  | simp add: crunch_simps invs_imps)+
   apply (auto intro: st_tcb_ex_cap simp: ct_active_not_idle ct_in_state_def)
-  done
-
-lemma handle_fault_globals_equiv':
-  "\<lbrace>invs and globals_equiv st and K(valid_fault ex)\<rbrace>
-  handle_fault thread ex \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (rule hoare_pre)
-   apply (rule handle_fault_globals_equiv)
-  apply (simp add: invs_imps invs_valid_idle)
   done
 
 lemma handle_event_globals_equiv:
   "\<lbrace>invs and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s) and globals_equiv st\<rbrace>
-     handle_event ev
-   \<lbrace>\<lambda>_. globals_equiv (st::det_ext state)\<rbrace>"
+   handle_event ev
+   \<lbrace>\<lambda>_. globals_equiv (st :: det_state)\<rbrace>"
   apply (case_tac ev)
-      apply (rule hoare_pre)
-       apply (wp handle_invocation_globals_equiv
-                 hoare_weaken_pre[OF receive_ipc_globals_equiv,
-                       where P="globals_equiv st and invs" and st1=st]
-                 hoare_weaken_pre[OF receive_signal_globals_equiv,
-                       where P="globals_equiv st and invs" and s1=st]
-                 handle_fault_globals_equiv'
-                 handle_recv_globals_equiv
-                 handle_reply_globals_equiv
-                 handle_interrupt_globals_equiv
-                 handle_vm_fault_globals_equiv
-                 handle_hypervisor_fault_globals_equiv
-             | wpc
-             | simp add: handle_send_def handle_call_def Let_def
-             | wp (once) hoare_drop_imps
-             | clarsimp simp: invs_imps invs_valid_idle ct_active_not_idle)+
-  done
+  by (wp hoare_weaken_pre[OF receive_ipc_globals_equiv, where P="globals_equiv st and invs"]
+         hoare_weaken_pre[OF receive_signal_globals_equiv, where P="globals_equiv st and invs"]
+         handle_invocation_globals_equiv handle_fault_globals_equiv' handle_recv_globals_equiv
+         handle_reply_globals_equiv handle_interrupt_globals_equiv handle_vm_fault_globals_equiv
+         handle_hypervisor_fault_globals_equiv
+      | wpc
+      | simp add: handle_send_def handle_call_def Let_def
+      | wp (once) hoare_drop_imps
+      | clarsimp simp: invs_imps invs_valid_idle ct_active_not_idle)+
 
 end
+
+lemma dmo_ev:
+  "(\<And>s s'. equiv_valid (\<lambda>ms ms'. I (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>))
+                        (\<lambda>ms ms'. A (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>))
+                        (\<lambda>ms ms'. B (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>))
+                        (K (P s \<and> P s')) f)
+   \<Longrightarrow> equiv_valid I A B P (do_machine_op f)"
+  apply (clarsimp simp: do_machine_op_def bind_def equiv_valid_def2 equiv_valid_2_def
+                        gets_def get_def select_f_def modify_def put_def return_def split_def)
+  apply atomize
+  apply (erule_tac x=s in allE)
+  apply (erule_tac x=t in allE)
+  apply simp
+  apply (erule_tac x="machine_state s" in allE)
+  apply (erule_tac x="machine_state t" in allE)
+  apply fastforce
+  done
+
+lemma ev_modify:
+  "(\<And>s t. \<lbrakk>P s; P t; A s t; I s t\<rbrakk> \<Longrightarrow> I (f s) (f t) \<and> B (f s) (f t))
+   \<Longrightarrow> equiv_valid I A B P (modify f)"
+  by (clarsimp simp: equiv_valid_def2 equiv_valid_2_def simpler_modify_def)
 
 end

--- a/proof/infoflow/Tcb_IF.thy
+++ b/proof/infoflow/Tcb_IF.thy
@@ -5,160 +5,64 @@
  *)
 
 theory Tcb_IF
-imports    "Finalise_IF"
-
+imports ArchFinalise_IF
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-section "arm global pd"
-
-crunch arm_global_pd[wp]: set_irq_state, suspend "\<lambda>s. P (arm_global_pd (arch_state s))"
-  (wp: mapM_x_wp select_inv hoare_vcg_if_lift2 hoare_drop_imps dxo_wp_weak
-   simp: unless_def
-   ignore: empty_slot_ext reschedule_required)
-
-crunch arm_global_pd[wp]: as_user, restart "\<lambda>s. P (arm_global_pd (arch_state s))" (wp: dxo_wp_weak)
-
 
 section "valid global objs"
 
-crunch valid_global_objs[wp]: deleted_irq_handler "valid_global_objs"
-crunch valid_global_objs[wp]: cancel_ipc "valid_global_objs"
-  (wp: mapM_x_wp select_inv hoare_drop_imps hoare_vcg_if_lift2 dxo_wp_weak
-   simp: unless_def
-   ignore: empty_slot_ext)
-crunch valid_global_objs[wp]: restart "valid_global_objs" (wp: dxo_wp_weak)
-crunch valid_global_objs: cap_swap_for_delete, deleting_irq_handler, suspend "valid_global_objs"
-  (wp: dxo_wp_weak)
+crunches cancel_ipc, restart, deleting_irq_handler, suspend, cap_swap_for_delete
+  for valid_global_objs[wp]: "valid_global_objs"
+  (wp: mapM_x_wp select_inv hoare_drop_imps hoare_vcg_if_lift2 dxo_wp_weak simp: unless_def)
 
 
 section "globals equiv"
 
-(* FIXME: move *)
-lemma dmo_maskInterrupt_globals_equiv[wp]:
-  "invariant (do_machine_op (maskInterrupt b irq)) (globals_equiv s)"
-  unfolding maskInterrupt_def
-  apply(rule dmo_no_mem_globals_equiv)
-   apply(wp modify_wp | simp)+
-   done
-
-
 lemma setup_reply_master_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm\<rbrace> setup_reply_master a \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
+   setup_reply_master t
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding setup_reply_master_def
   apply (wp set_cap_globals_equiv'' set_original_globals_equiv get_cap_wp)
   apply clarsimp
-done
-
-lemma cancel_signal_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm\<rbrace> cancel_signal a b \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding cancel_signal_def
-  by (wpsimp wp: set_thread_state_globals_equiv set_notification_globals_equiv
-                 set_notification_valid_ko_at_arm hoare_drop_imps
-           simp: crunch_simps)
-
-crunch globals_equiv[wp]: cancel_ipc "globals_equiv st"
-  (wp: mapM_x_wp select_inv hoare_drop_imps hoare_vcg_if_lift2 cancel_signal_valid_ko_at_arm
-   simp: unless_def)
-
-crunch valid_ko_at_arm[wp]: setup_reply_master "valid_ko_at_arm"
-
-crunch globals_equiv[wp]: restart "globals_equiv st"
-  (wp: cancel_ipc_valid_ko_at_arm hoare_vcg_if_lift2 dxo_wp_weak hoare_drop_imps
-   ignore: reschedule_required possible_switch_to)
-
-declare as_user_globals_equiv[wp]
-
-lemma cap_ne_global_pd : "ex_nonz_cap_to word s \<Longrightarrow> valid_global_refs s \<Longrightarrow> word \<noteq> arm_global_pd (arch_state s)"
-  unfolding ex_nonz_cap_to_def
-  apply (simp only : cte_wp_at_caps_of_state zobj_refs_to_obj_refs)
-  apply (elim exE conjE)
-  apply (drule valid_global_refsD2,simp)
-  apply (unfold global_refs_def)
-  apply clarsimp
-  apply (unfold cap_range_def)
-  apply blast
   done
 
-lemma globals_equiv_ioc_update[simp]: "globals_equiv st (is_original_cap_update f s) = globals_equiv st s"
-  apply (simp add: globals_equiv_def idle_equiv_def)
-  done
+lemma restart_globals_equiv[wp]:
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
+   restart t
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding restart_def
+  by (wpsimp wp: dxo_wp_weak set_thread_state_globals_equiv setup_reply_master_globals_equiv gts_wp)
 
+lemma globals_equiv_ioc_update[simp]:
+  "globals_equiv st (is_original_cap_update f s) = globals_equiv st s"
+  by (simp add: globals_equiv_def idle_equiv_def)
 
-
-
-lemma cap_swap_for_delete_globals_equiv[wp]: "\<lbrace>globals_equiv st and valid_ko_at_arm\<rbrace> (cap_swap_for_delete a b) \<lbrace>\<lambda>_.(globals_equiv st )\<rbrace>"
+lemma cap_swap_for_delete_globals_equiv[wp]:
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
+   cap_swap_for_delete a b
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding cap_swap_for_delete_def cap_swap_def set_original_def
-  apply (wp modify_wp set_cdt_globals_equiv set_cap_globals_equiv'' dxo_wp_weak | simp)+
-done
+  by (wp modify_wp set_cdt_globals_equiv set_cap_globals_equiv'' dxo_wp_weak | simp)+
 
-(*FIXME: Lots of this stuff should be in arch *)
-crunch globals_equiv[wp]: deleting_irq_handler "globals_equiv st"
-
-lemma get_thread_state_globals_equiv[wp]:
-  "\<lbrace>globals_equiv s and valid_ko_at_arm\<rbrace> get_thread_state ref \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding get_thread_state_def
-  apply(wp set_object_globals_equiv dxo_wp_weak |simp)+
-  done
-
-lemma suspend_globals_equiv[wp]:
-  "\<lbrace>globals_equiv st and (\<lambda>s. t \<noteq> idle_thread s) and valid_ko_at_arm\<rbrace> suspend t \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding suspend_def
-  apply (wp tcb_sched_action_extended.globals_equiv dxo_wp_weak)
-       apply simp
-      apply (wp set_thread_state_globals_equiv)
-     apply wp+
-      unfolding update_restart_pc_def
-      apply wp+
-    apply clarsimp
-    apply (rule hoare_vcg_conj_lift)
-     prefer 2
-     apply (rule hoare_drop_imps)
-     apply wp+
-    apply (rule hoare_drop_imps)
-    apply wp+
-  apply auto
-  done
-
-crunch globals_equiv[wp]: prepare_thread_delete "globals_equiv st"
-  (wp: dxo_wp_weak)
-
-lemma finalise_cap_globals_equiv:
-  "\<lbrace>globals_equiv st and (\<lambda>s. \<forall>p. cap = ThreadCap p \<longrightarrow> p \<noteq> idle_thread s)
-    and valid_global_objs and valid_arch_state and pspace_aligned and valid_vspace_objs and valid_global_refs and valid_vs_lookup\<rbrace>
-    finalise_cap cap b
-   \<lbrace>\<lambda> _. globals_equiv st\<rbrace>"
-  apply (induct cap)
-             apply (simp_all)
-             apply (wp liftM_wp when_def cancel_all_ipc_globals_equiv cancel_all_ipc_valid_global_objs
-                       cancel_all_signals_globals_equiv cancel_all_signals_valid_global_objs
-                       arch_finalise_cap_globals_equiv unbind_maybe_notification_globals_equiv
-                       unbind_notification_globals_equiv
-                       | clarsimp simp add: valid_arch_state_ko_at_arm | intro impI conjI)+
-  done
-
-crunch valid_ko_at_arm[wp]: cap_swap_for_delete, restart "valid_ko_at_arm"
-  (wp: dxo_wp_weak ignore: cap_swap_ext)
+crunch valid_ko_at_arch[wp]: cap_swap_for_delete, restart "valid_ko_at_arch"
+  (wp: dxo_wp_weak simp_del: cap_swap_ext_extended.dxo_eq possible_switch_to_extended.dxo_eq)
 
 lemma rec_del_preservation2':
-  assumes finalise_cap_P: "\<And>cap final. \<lbrace>R cap and P\<rbrace> finalise_cap cap final \<lbrace>\<lambda>_.P\<rbrace>"
-  assumes set_cap_P : "\<And> cap b. \<lbrace>Q and P\<rbrace> set_cap cap b \<lbrace>\<lambda>_.P\<rbrace>"
-  assumes set_cap_Q : "\<And> cap b. \<lbrace>Q\<rbrace> set_cap cap b \<lbrace>\<lambda>_.Q\<rbrace>"
-  assumes empty_slot_P: "\<And> slot free. \<lbrace>Q and P\<rbrace> empty_slot slot free \<lbrace>\<lambda>_. P\<rbrace>"
-  assumes empty_slot_Q: "\<And> slot free. \<lbrace>Q\<rbrace> empty_slot slot free \<lbrace>\<lambda>_. Q\<rbrace>"
-  assumes cap_swap_for_delete_Q: "\<And> a b. \<lbrace>Q\<rbrace> cap_swap_for_delete a b \<lbrace>\<lambda>_. Q\<rbrace>"
-  assumes cap_swap_for_delete_P: "\<And> a b. \<lbrace>Q and P\<rbrace> cap_swap_for_delete a b \<lbrace>\<lambda>_. P\<rbrace>"
-  assumes preemption_point_Q: "\<And> a b. \<lbrace>Q\<rbrace> preemption_point \<lbrace>\<lambda>_. Q\<rbrace>"
-  assumes preemption_point_P: "\<And> a b. \<lbrace>Q and P\<rbrace> preemption_point \<lbrace>\<lambda>_. P\<rbrace>"
-  assumes invs_Q: "\<And> s. invs s \<Longrightarrow> Q s"
-  assumes invs_R: "  \<And>s slot cap. invs s \<Longrightarrow> caps_of_state s slot = Some cap \<Longrightarrow> R cap s"
-  shows
-  "s \<turnstile> \<lbrace>\<lambda>s. invs s \<and> P s \<and> Q s \<and> emptyable (slot_rdcall call) s \<and> valid_rec_del_call call s\<rbrace>
-     rec_del call
-   \<lbrace>\<lambda>rv s. P s \<and> Q s\<rbrace>,\<lbrace>\<lambda>rv s. P s \<and> Q s\<rbrace>"
-proof (induct rule: rec_del.induct,
-       simp_all only: rec_del_fails)
+  assumes finalise_cap_P: "\<And>cap final. \<lbrace>R cap and P\<rbrace> finalise_cap cap final \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes set_cap_P: "\<And>cap b. \<lbrace>Q and P\<rbrace> set_cap cap b \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes set_cap_Q: "\<And>cap b. \<lbrace>Q\<rbrace> set_cap cap b \<lbrace>\<lambda>_. Q\<rbrace>"
+  assumes empty_slot_P: "\<And>slot free. \<lbrace>Q and P\<rbrace> empty_slot slot free \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes empty_slot_Q: "\<And>slot free. \<lbrace>Q\<rbrace> empty_slot slot free \<lbrace>\<lambda>_. Q\<rbrace>"
+  assumes cap_swap_for_delete_Q: "\<And>a b. \<lbrace>Q\<rbrace> cap_swap_for_delete a b \<lbrace>\<lambda>_. Q\<rbrace>"
+  assumes cap_swap_for_delete_P: "\<And>a b. \<lbrace>Q and P\<rbrace> cap_swap_for_delete a b \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes preemption_point_Q: "\<And>a b. \<lbrace>Q\<rbrace> preemption_point \<lbrace>\<lambda>_. Q\<rbrace>"
+  assumes preemption_point_P: "\<And>a b. \<lbrace>Q and P\<rbrace> preemption_point \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes invs_Q: "\<And>s. invs s \<Longrightarrow> Q s"
+  assumes invs_R: "\<And>s slot cap. invs s \<Longrightarrow> caps_of_state s slot = Some cap \<Longrightarrow> R cap s"
+  shows "s \<turnstile> \<lbrace>\<lambda>s. invs s \<and> P s \<and> Q s \<and> emptyable (slot_rdcall call) s \<and> valid_rec_del_call call s\<rbrace>
+             rec_del call
+             \<lbrace>\<lambda>rv s :: det_state. P s \<and> Q s\<rbrace>, \<lbrace>\<lambda>rv s. P s \<and> Q s\<rbrace>"
+proof (induct rule: rec_del.induct, simp_all only: rec_del_fails)
   case (1 slot exposed s)
   show ?case
     apply (subst rec_del.simps)
@@ -169,73 +73,69 @@ proof (induct rule: rec_del.induct,
      apply (rule spec_strengthen_postE)
       apply (rule "1.hyps")
      apply auto
-done
+    done
 next
   case (2 slot exposed s)
   show ?case
     apply (subst rec_del.simps)
     apply (simp only: split_def)
     apply (rule hoare_pre_spec_validE)
-    apply wp
-     apply (wp set_cap_P set_cap_Q "2.hyps")+
-          apply ((wp preemption_point_Q preemption_point_P | simp | wp (once) preemption_point_inv)+)[1]
+     apply wp
+         apply (wp set_cap_P set_cap_Q "2.hyps")+
+          apply ((wp preemption_point_Q preemption_point_P preemption_point_inv | simp)+)[1]
          apply (simp(no_asm))
          apply (rule spec_strengthen_postE)
           apply (rule spec_valid_conj_liftE1, rule valid_validE_R, rule rec_del_invs)
           apply (rule spec_valid_conj_liftE1, rule reduce_zombie_cap_to)
           apply (rule spec_valid_conj_liftE1, rule rec_del_emptyable)
           apply (rule "2.hyps")
-         apply simp
-         apply (simp add: conj_comms)
-         apply (wp set_cap_P set_cap_Q replace_cap_invs
-                  final_cap_same_objrefs set_cap_cte_cap_wp_to
-                  set_cap_cte_wp_at hoare_vcg_const_Ball_lift static_imp_wp
-                       | rule finalise_cap_not_reply_master
-                       | simp add: in_monad)+
-         apply (rule hoare_strengthen_post)
+                apply simp
+               apply (simp add: conj_comms)
+              apply (wp set_cap_P set_cap_Q replace_cap_invs
+                        final_cap_same_objrefs set_cap_cte_cap_wp_to
+                        set_cap_cte_wp_at hoare_vcg_const_Ball_lift static_imp_wp
+                     | rule finalise_cap_not_reply_master
+                     | simp add: in_monad)+
+       apply (rule hoare_strengthen_post)
         apply (rule_tac Q="\<lambda>fin s. invs s \<and> cte_wp_at ((=) rv) slot s \<and> s \<turnstile> (fst fin)
                                           \<and> P s
                                           \<and> replaceable s slot (fst fin) rv
                                           \<and> emptyable slot s
                                           \<and> (\<forall>t\<in>obj_refs (fst fin). halted_if_tcb t s)
                                           \<and> ex_cte_cap_wp_to (appropriate_cte_cap rv) slot s"
-                   in hoare_vcg_conj_lift)
+                     in hoare_vcg_conj_lift)
          apply (wp finalise_cap_invs[where slot=slot]
                    finalise_cap_replaceable[where sl=slot]
-                   Finalise_IF.finalise_cap_makes_halted[where slot=slot]
+                   Finalise_AC_1.finalise_cap_makes_halted[where slot=slot]
                    finalise_cap_P)[1]
-
-         apply (rule finalise_cap_cases[where slot=slot])
-         apply (clarsimp simp: cte_wp_at_caps_of_state)
-         apply (frule invs_valid_global_objs)
-         apply (frule invs_Q)
-         apply (erule disjE)
-         apply clarsimp
-      apply (clarsimp simp: is_cap_simps cap_auth_conferred_def clas_no_asid aag_cap_auth_def
-                            pas_refined_all_auth_is_owns cli_no_irqs gen_obj_refs_eq)
-      apply (drule appropriate_Zombie[symmetric, THEN trans, symmetric])
-      apply clarsimp
-      apply (erule_tac s = "{r}" in subst)
-      apply simp
-     apply (simp add: is_final_cap_def)
-     apply wp
+        apply (rule finalise_cap_cases[where slot=slot])
+       apply (clarsimp simp: cte_wp_at_caps_of_state)
+       apply (frule invs_valid_global_objs)
+       apply (frule invs_Q)
+       apply (erule disjE)
+        apply clarsimp
+       apply (clarsimp simp: is_cap_simps cap_auth_conferred_def clas_no_asid aag_cap_auth_def
+                             pas_refined_all_auth_is_owns cli_no_irqs gen_obj_refs_eq)
+       apply (drule appropriate_Zombie[symmetric, THEN trans, symmetric])
+       apply clarsimp
+       apply (erule_tac s = "{r}" in subst)
+       apply simp
+      apply (simp add: is_final_cap_def)
+      apply wp
      apply (wp get_cap_wp)
-     apply (clarsimp simp: cte_wp_at_caps_of_state conj_comms)
-     apply (frule (1) caps_of_state_valid)
-    apply (clarsimp simp:   conj_comms invs_def valid_state_def valid_pspace_def valid_arch_caps_def invs_R)
+    apply (clarsimp simp: cte_wp_at_caps_of_state conj_comms)
+    apply (frule (1) caps_of_state_valid)
+    apply (clarsimp simp: conj_comms invs_def valid_state_def valid_pspace_def invs_R)
     apply (frule if_unsafe_then_capD [OF caps_of_state_cteD],clarsimp+)
-done
+    done
 next
-
   case (3 ptr bits n slot s)
   show ?case
     apply (simp add: spec_validE_def)
     apply (rule hoare_pre, wp cap_swap_for_delete_P cap_swap_for_delete_Q)
-    apply (clarsimp simp: invs_valid_ko_at_arm)
+    apply (clarsimp simp: invs_valid_ko_at_arch)
     done
-
 next
-
   case (4 ptr bits n slot s)
   show ?case
     apply (subst rec_del.simps)
@@ -243,26 +143,35 @@ next
      apply (rule split_spec_bindE)
       apply (rule split_spec_bindE[rotated])
        apply (rule "4.hyps", assumption+)
-
       apply (wp set_cap_P set_cap_Q get_cap_wp | simp)
       apply simp
-      apply simp
-      apply wp
-      apply (clarsimp simp add: zombie_is_cap_toE)
-      apply (clarsimp simp: cte_wp_at_caps_of_state zombie_ptr_emptyable)
-done
+     apply simp
+     apply wp
+    apply (clarsimp simp add: zombie_is_cap_toE)
+    apply (clarsimp simp: cte_wp_at_caps_of_state zombie_ptr_emptyable)
+    done
 qed
 
 lemma rec_del_preservation2:
-  "\<lbrakk>\<And>cap final. \<lbrace>R cap and P\<rbrace> finalise_cap cap final \<lbrace>\<lambda>_. P\<rbrace>; \<And>cap b. \<lbrace>Q and P\<rbrace> set_cap cap b \<lbrace>\<lambda>_. P\<rbrace>;
-  \<And>cap b. invariant (set_cap cap b) Q; \<And>slot free. \<lbrace>Q and P\<rbrace> empty_slot slot free \<lbrace>\<lambda>_. P\<rbrace>;
-  \<And>slot free. invariant (empty_slot slot free) Q; \<And>a b. invariant (cap_swap_for_delete a b) Q;
-  \<And>a b. \<lbrace>Q and P\<rbrace> cap_swap_for_delete a b \<lbrace>\<lambda>_. P\<rbrace>; \<And>s. invs s \<Longrightarrow> Q s;
-  \<And>s slot cap. invs s \<Longrightarrow> caps_of_state s slot = Some cap \<Longrightarrow> R cap s;
-  invariant preemption_point Q; \<lbrace>Q and P\<rbrace> preemption_point \<lbrace>\<lambda>_. P\<rbrace>\<rbrakk>
- \<Longrightarrow> \<lbrace>\<lambda>s. invs s \<and> P s \<and> emptyable (slot_rdcall call) s \<and> valid_rec_del_call call s\<rbrace> rec_del call
-    \<lbrace>\<lambda>r. P\<rbrace>"
-  apply (rule_tac Q="\<lambda>s. invs s \<and> P s \<and> Q s \<and> emptyable (slot_rdcall call) s \<and> valid_rec_del_call call s" in hoare_pre_imp)
+  assumes "\<And>cap final. \<lbrace>R cap and P\<rbrace> finalise_cap cap final \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes "\<And>cap b. \<lbrace>Q and P\<rbrace> set_cap cap b \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes "\<And>cap b. set_cap cap b \<lbrace>Q\<rbrace>"
+  assumes "\<And>slot free. \<lbrace>Q and P\<rbrace> empty_slot slot free \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes "\<And>slot free. empty_slot slot free \<lbrace>Q\<rbrace>"
+  assumes "\<And>a b. cap_swap_for_delete a b \<lbrace>Q\<rbrace>"
+  assumes "\<And>a b. \<lbrace>Q and P\<rbrace> cap_swap_for_delete a b \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes "\<And>s. invs s \<Longrightarrow> Q s"
+  assumes "\<And>s slot cap. invs s \<Longrightarrow> caps_of_state s slot = Some cap \<Longrightarrow> R cap s"
+  assumes "preemption_point \<lbrace>Q\<rbrace>"
+  assumes "\<lbrace>Q and P\<rbrace> preemption_point \<lbrace>\<lambda>_. P\<rbrace>"
+  shows
+    "\<lbrace>\<lambda>s :: det_state. invs s \<and> P s \<and> emptyable (slot_rdcall call) s \<and> valid_rec_del_call call s\<rbrace>
+     rec_del call
+     \<lbrace>\<lambda>r. P\<rbrace>"
+  apply (insert assms)
+  apply (rule_tac Q="\<lambda>s. invs s \<and> P s \<and> Q s
+                                \<and> emptyable (slot_rdcall call) s
+                                \<and> valid_rec_del_call call s" in hoare_pre_imp)
    apply simp
   apply (rule_tac Q="\<lambda>rv s. P s \<and> Q s" in hoare_strengthen_post)
    apply (rule validE_valid)
@@ -270,156 +179,88 @@ lemma rec_del_preservation2:
    apply (rule rec_del_preservation2' [where R=R],simp+)
   done
 
-lemma valid_ko_at_arm_irq_state_independent_A[simp, intro!]:
-  "irq_state_independent_A (valid_ko_at_arm)"
-  apply(auto simp: irq_state_independent_A_def valid_ko_at_arm_def)
-  done
 
-lemma no_cap_to_idle_thread'': "valid_global_refs s \<Longrightarrow> caps_of_state s ref \<noteq> Some (ThreadCap (idle_thread s))"
-  apply (clarsimp simp add: valid_global_refs_def valid_refs_def cte_wp_at_caps_of_state)
-  apply (drule_tac x="fst ref" in spec)
-  apply (drule_tac x="snd ref" in spec)
-  apply (simp add: cap_range_def global_refs_def)
-  done
+locale Tcb_IF_1 =
+  fixes aag :: "'a subject_label PAS"
+  assumes valid_ko_at_arch_irq_state_independent_A[simp, intro!]:
+    "irq_state_independent_A valid_ko_at_arch"
+  and valid_arch_caps_vs_lookup:
+    "valid_arch_caps s \<Longrightarrow> valid_vs_lookup s"
+  and no_cap_to_idle_thread':
+    "valid_global_refs s \<Longrightarrow> \<not> ex_nonz_cap_to (idle_thread s) s"
+  and no_cap_to_idle_thread'':
+    "valid_global_refs s \<Longrightarrow> caps_of_state s ref \<noteq> Some (ThreadCap (idle_thread s))"
+  and arch_post_modify_registers_globals_equiv[wp]:
+    "arch_post_modify_registers cur t \<lbrace>globals_equiv s\<rbrace>"
+  and arch_post_modify_registers_valid_ko_at_arch[wp]:
+    "arch_post_modify_registers cur t \<lbrace>valid_ko_at_arch\<rbrace>"
+  and arch_post_modify_registers_reads_respects_f[wp]:
+    "reads_respects_f aag l \<top> (arch_post_modify_registers cur t)"
+  and arch_get_sanitise_register_info_reads_respects_f[wp]:
+    "reads_respects_f aag l \<top> (arch_get_sanitise_register_info t)"
+begin
 
 lemma rec_del_globals_equiv:
-  "\<lbrace>\<lambda>s. invs s \<and> globals_equiv st s \<and> emptyable (slot_rdcall call) s
-     \<and> valid_rec_del_call call s\<rbrace>
-     rec_del call
+  "\<lbrace>\<lambda>s. invs s \<and> globals_equiv st s \<and> emptyable (slot_rdcall call) s \<and> valid_rec_del_call call s\<rbrace>
+   rec_del call
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (wp rec_del_preservation2[where Q="valid_ko_at_arm"
-            and R="\<lambda>cap s. valid_global_objs s \<and> valid_arch_state s
-                       \<and> pspace_aligned s \<and> valid_vspace_objs s
-                       \<and> valid_global_refs s  \<and> valid_vs_lookup s
-                       \<and> (\<forall>p. cap = ThreadCap p \<longrightarrow> p \<noteq> idle_thread s)
-                     "]  finalise_cap_globals_equiv)
+  apply (wp finalise_cap_globals_equiv
+            rec_del_preservation2[where Q="valid_ko_at_arch"
+                                    and R="\<lambda>cap s. valid_global_objs s \<and> valid_arch_state s
+                                                 \<and> pspace_aligned s \<and> valid_vspace_objs s
+                                                 \<and> valid_global_refs s  \<and> valid_vs_lookup s
+                                                 \<and> (\<forall>p. cap = ThreadCap p \<longrightarrow> p \<noteq> idle_thread s)"])
              apply simp
             apply (wp set_cap_globals_equiv'')
             apply simp
-           apply (wp set_cap_valid_ko_at_arm empty_slot_globals_equiv)+
+           apply (wp set_cap_valid_ko_at_arch empty_slot_globals_equiv)+
           apply simp
-         apply (wp empty_slot_valid_ko_at_arm)+
+         apply (wp empty_slot_valid_ko_at_arch)+
        apply simp
-      apply (simp add: invs_valid_ko_at_arm)
-     apply (clarsimp simp: invs_def valid_state_def valid_arch_caps_def valid_pspace_def no_cap_to_idle_thread'')
+      apply (simp add: invs_valid_ko_at_arch)
+     apply (clarsimp simp: invs_def valid_state_def valid_arch_caps_vs_lookup
+                           valid_pspace_def no_cap_to_idle_thread'')
     apply (wp preemption_point_inv | simp)+
   done
 
-lemma cap_delete_globals_equiv : "\<lbrace>globals_equiv st and invs and emptyable a\<rbrace> (cap_delete a) \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+lemma cap_delete_globals_equiv:
+  "\<lbrace>globals_equiv st and invs and emptyable a\<rbrace>
+   cap_delete a
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding cap_delete_def
   apply (wp rec_del_globals_equiv)
   apply simp
   done
 
-lemma no_cap_to_idle_thread': "valid_global_refs s \<Longrightarrow> \<not> ex_nonz_cap_to (idle_thread s) s"
-  apply (clarsimp simp add: ex_nonz_cap_to_def valid_global_refs_def valid_refs_def)
-  apply (drule_tac x=a in spec)
-  apply (drule_tac x=b in spec)
-  apply (clarsimp simp: cte_wp_at_def global_refs_def cap_range_def)
-  apply (case_tac cap,simp_all)
-  done
-
-lemma no_cap_to_idle_thread: "invs s \<Longrightarrow> \<not> ex_nonz_cap_to (idle_thread s) s"
+lemma no_cap_to_idle_thread:
+   "invs (s :: det_state) \<Longrightarrow> \<not> ex_nonz_cap_to (idle_thread s) s"
   apply (rule no_cap_to_idle_thread')
   apply clarsimp
   done
 
+end
+
+
 crunch idle_thread_inv [wp]: set_mcpriority "\<lambda>s. P (idle_thread s)"
   (wp: syscall_valid crunch_wps rec_del_preservation cap_revoke_preservation)
 
-
-(* FIXME: Pretty general. Probably belongs somewhere else *)
-lemma invoke_tcb_thread_preservation:
-  assumes cap_delete_P: "\<And>slot. \<lbrace>invs and P and emptyable slot \<rbrace> cap_delete slot \<lbrace>\<lambda>_.P\<rbrace>"
-  assumes cap_insert_P: "\<And>new_cap src dest. \<lbrace>invs and P\<rbrace> cap_insert new_cap src dest \<lbrace>\<lambda>_.P\<rbrace>"
-  assumes thread_set_P: "\<And>f ptr. \<lbrace>invs and P\<rbrace> thread_set (tcb_ipc_buffer_update f) ptr \<lbrace>\<lambda>_.P\<rbrace>"
-  assumes thread_set_P': "\<And>f ptr. \<lbrace>invs and P\<rbrace> thread_set (tcb_fault_handler_update f) ptr \<lbrace>\<lambda>_.P\<rbrace>"
-  assumes set_mcpriority_P: "\<And>mcp ptr. \<lbrace>invs and P\<rbrace> set_mcpriority ptr mcp \<lbrace>\<lambda>_.P\<rbrace>"
-  assumes set_register_P[wp]: "\<And>d. \<lbrace>P and invs and (\<lambda>s. t \<noteq> idle_thread s)\<rbrace> as_user t (setRegister TPIDRURW d) \<lbrace>\<lambda>_. P\<rbrace>"
-  assumes P_trans[simp]: "\<And>f s. P (trans_state f s) = P s"
-shows "
-   \<lbrace>P and invs and Tcb_AI.tcb_inv_wf (tcb_invocation.ThreadControl t sl ep mcp prio croot vroot buf)\<rbrace>
-     invoke_tcb (tcb_invocation.ThreadControl t sl ep mcp prio croot vroot buf)
-   \<lbrace>\<lambda>rv. P\<rbrace>"
-
-  apply (simp add: split_def cong: option.case_cong)
-
-  apply (rule hoare_vcg_precond_imp)
-   apply (rule_tac P="case ep of Some v \<Rightarrow> length v = word_bits | _ \<Rightarrow> True"
-                in hoare_gen_asm)
-   apply wp
-      apply ((simp add: conj_comms(1, 2) del: hoare_post_taut hoare_True_E_R
-        | rule wp_split_const_if wp_split_const_if_R
-                   hoare_vcg_all_lift_R
-                   hoare_vcg_E_elim hoare_vcg_const_imp_lift_R
-                   hoare_vcg_R_conj
-        | (wp
-             check_cap_inv2[where Q="\<lambda>_ s. t \<noteq> idle_thread s"]
-             out_invs_trivial case_option_wpE cap_delete_deletes
-             cap_delete_valid_cap cap_insert_valid_cap out_cte_at
-             cap_insert_cte_at cap_delete_cte_at out_valid_cap out_tcb_valid
-             hoare_vcg_const_imp_lift_R hoare_vcg_all_lift_R
-             thread_set_tcb_ipc_buffer_cap_cleared_invs
-             thread_set_invs_trivial[OF ball_tcb_cap_casesI]
-             hoare_vcg_all_lift thread_set_valid_cap out_emptyable
-             check_cap_inv [where P="valid_cap c" for c]
-             check_cap_inv [where P="tcb_cap_valid c p" for c p]
-             check_cap_inv[where P="cte_at p0" for p0]
-             check_cap_inv[where P="tcb_at p0" for p0]
-             thread_set_cte_at
-             thread_set_cte_wp_at_trivial[where Q="\<lambda>x. x", OF ball_tcb_cap_casesI]
-             thread_set_no_cap_to_trivial[OF ball_tcb_cap_casesI]
-             checked_insert_no_cap_to
-             out_no_cap_to_trivial[OF ball_tcb_cap_casesI]
-             thread_set_ipc_tcb_cap_valid
-             check_cap_inv2[where Q="\<lambda>_. P"]
-             cap_delete_P
-             cap_insert_P
-             thread_set_P thread_set_P'
-             set_mcpriority_P
-             dxo_wp_weak
-             static_imp_wp
-             set_mcpriority_idle_thread
-            )
-        | simp add: ran_tcb_cap_cases dom_tcb_cap_cases[simplified]
-                    emptyable_def
-               del: hoare_post_taut hoare_True_E_R
-        | wpc
-        | strengthen use_no_cap_to_obj_asid_strg
-                     tcb_cap_always_valid_strg[where p="tcb_cnode_index 0"]
-                     tcb_cap_always_valid_strg[where p="tcb_cnode_index (Suc 0)"])+)
-              apply (unfold option_update_thread_def)
-      apply (wp itr_wps thread_set_P thread_set_P'
-              | simp add: emptyable_def | wpc)+ (*slow*)
-  apply (clarsimp simp: tcb_at_cte_at_0 tcb_at_cte_at_1[simplified]
-                        is_cap_simps is_valid_vtable_root_def
-                        is_cnode_or_valid_arch_def tcb_cap_valid_def
-                        tcb_at_st_tcb_at[symmetric] invs_valid_objs
-                        cap_asid_def vs_cap_ref_def
-                        clas_no_asid cli_no_irqs no_cap_to_idle_thread
-                 split: option.split_asm
-       | rule conjI)+ (* also slow *)
-done
-
-crunch idle_thread'[wp]: restart "\<lambda>s. P (idle_thread s)" (wp: dxo_wp_weak)
+crunch idle_thread'[wp]: restart "\<lambda>s. P (idle_thread s)"
+  (wp: dxo_wp_weak)
 
 lemma bind_notification_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm\<rbrace>
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
    bind_notification t ntfnptr
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding bind_notification_def
-  by (wp set_bound_notification_globals_equiv set_notification_globals_equiv
-            set_notification_valid_ko_at_arm | wpc | simp)+
+  by (wp set_bound_notification_globals_equiv set_notification_globals_equiv | wpc | simp)+
 
-lemma bind_notification_valid_ko_at_arm[wp]:
-  "\<lbrace>valid_ko_at_arm\<rbrace>
-   bind_notification t ntfnptr
-   \<lbrace>\<lambda>_. valid_ko_at_arm\<rbrace>"
+lemma bind_notification_valid_ko_at_arch[wp]:
+  "bind_notification t ntfnptr \<lbrace>valid_ko_at_arch\<rbrace>"
   unfolding bind_notification_def
-  by (wp set_bound_notification_valid_ko_at_arm set_notification_valid_ko_at_arm | wpc | simp)+
+  by (wp set_bound_notification_valid_ko_at_arch | wpc | simp)+
 
 lemma invoke_tcb_NotificationControl_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_ko_at_arm\<rbrace>
+  "\<lbrace>globals_equiv st and valid_ko_at_arch\<rbrace>
    invoke_tcb (NotificationControl t ntfn)
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (case_tac ntfn, simp_all)
@@ -429,35 +270,62 @@ lemma invoke_tcb_NotificationControl_globals_equiv:
 crunch globals_equiv: set_mcpriority "globals_equiv st"
 
 lemma dxo_globals_equiv[wp]:
-  "\<lbrace>globals_equiv st\<rbrace> do_extended_op eop  \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  "do_extended_op eop \<lbrace>globals_equiv st\<rbrace>"
   by (simp | wp dxo_wp_weak)+
 
+
+definition authorised_tcb_inv_extra where
+  "authorised_tcb_inv_extra aag ti \<equiv>
+    (case ti of ThreadControl _ slot _ _ _ _ _ _ \<Rightarrow> is_subject aag (fst slot) | _ \<Rightarrow> True)"
+
+
+locale Tcb_IF_2 = Tcb_IF_1 +
+  assumes invoke_tcb_thread_preservation:
+    "\<lbrakk> \<And>slot. \<lbrace>invs and P and emptyable slot\<rbrace> cap_delete slot \<lbrace>\<lambda>_.P\<rbrace>;
+       \<And>new_cap src dest. \<lbrace>invs and P\<rbrace> cap_insert new_cap src dest \<lbrace>\<lambda>_.P\<rbrace>;
+       \<And>f ptr. \<lbrace>invs and P\<rbrace> thread_set (tcb_ipc_buffer_update f) ptr \<lbrace>\<lambda>_.P\<rbrace>;
+       \<And>f ptr. \<lbrace>invs and P\<rbrace> thread_set (tcb_fault_handler_update f) ptr \<lbrace>\<lambda>_.P\<rbrace>;
+       \<And>mcp ptr. \<lbrace>invs and P\<rbrace> set_mcpriority ptr mcp \<lbrace>\<lambda>_.P\<rbrace>;
+       \<And>f s. P (trans_state f s) = P s \<rbrakk>
+       \<Longrightarrow> \<lbrace>P and invs and tcb_inv_wf (ThreadControl t sl ep mcp prio croot vroot buf)\<rbrace>
+           invoke_tcb (ThreadControl t sl ep mcp prio croot vroot buf)
+           \<lbrace>\<lambda>rv s :: det_state. P s\<rbrace>"
+  and tc_reads_respects_f:
+    "\<lbrakk> pas_domains_distinct aag; ti = ThreadControl x41 x42 x43 x44 x45 x46 x47 x48 \<rbrakk>
+       \<Longrightarrow> reads_respects_f aag l
+             (silc_inv aag st and only_timer_irq_inv irq st' and einvs and simple_sched_action
+                              and pas_refined aag and pas_cur_domain aag and tcb_inv_wf ti
+                              and is_subject aag \<circ> cur_thread
+                              and K (authorised_tcb_inv aag ti \<and> authorised_tcb_inv_extra aag ti))
+             (invoke_tcb ti)"
+begin
+
 lemma invoke_tcb_globals_equiv:
-  "\<lbrace> invs and globals_equiv st and Tcb_AI.tcb_inv_wf ti\<rbrace>
+  "\<lbrace>invs and globals_equiv st and tcb_inv_wf ti\<rbrace>
    invoke_tcb ti
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply(case_tac ti;
-    (solves \<open>
-        (wp mapM_x_wp' as_user_globals_equiv invoke_tcb_NotificationControl_globals_equiv
-               | simp add: invs_valid_ko_at_arm
-               | intro conjI impI
-               | clarsimp simp: no_cap_to_idle_thread)+
-    \<close>)?)
-   defer
-   apply (simp del: invoke_tcb.simps Tcb_AI.tcb_inv_wf.simps )
-   apply ((wp invoke_tcb_thread_preservation cap_delete_globals_equiv
-             cap_insert_globals_equiv'' thread_set_globals_equiv
-             set_mcpriority_globals_equiv
-          | clarsimp simp add: invs_valid_ko_at_arm split del: if_split)+)[1]
-  apply wpsimp
-      apply (rename_tac word1 word2 bool1 bool2 bool3 bool4 arm_copy_register_sets)
-      apply (rule_tac Q="\<lambda>_. valid_ko_at_arm and globals_equiv st and (\<lambda>s. word1 \<noteq> idle_thread s)
-                         and (\<lambda>s. word2 \<noteq> idle_thread s)" in hoare_strengthen_post)
-       apply (wp mapM_x_wp' as_user_globals_equiv invoke_tcb_NotificationControl_globals_equiv
-               | simp add: invs_valid_ko_at_arm
-               | intro conjI impI
-               | clarsimp simp: no_cap_to_idle_thread)+
+  supply reschedule_required_ext_extended.dxo_eq[simp del]
+  apply (case_tac ti; (solves \<open>(wp mapM_x_wp' as_user_globals_equiv
+                                   invoke_tcb_NotificationControl_globals_equiv
+                                | simp add: invs_valid_ko_at_arch
+                                | intro conjI impI
+                                | clarsimp simp: no_cap_to_idle_thread)+\<close>)?)
+   apply wpsimp
+       apply (rename_tac word1 word2 bool1 bool2 bool3 bool4 arm_copy_register_sets)
+       apply (rule_tac Q="\<lambda>_. valid_ko_at_arch and globals_equiv st and
+                              (\<lambda>s. word1 \<noteq> idle_thread s) and (\<lambda>s. word2 \<noteq> idle_thread s)"
+                    in hoare_strengthen_post)
+        apply ((wp mapM_x_wp' as_user_globals_equiv invoke_tcb_NotificationControl_globals_equiv
+                | simp add: invs_valid_ko_at_arch
+                | intro conjI impI
+                | clarsimp simp: no_cap_to_idle_thread)+)[6]
+  apply (simp del: invoke_tcb.simps tcb_inv_wf.simps)
+  apply (wp invoke_tcb_thread_preservation cap_delete_globals_equiv
+            cap_insert_globals_equiv'' thread_set_globals_equiv set_mcpriority_globals_equiv
+         | clarsimp simp: invs_valid_ko_at_arch split del: if_split)+
   done
+
+end
 
 
 section "reads respects"
@@ -470,90 +338,71 @@ lemma setup_reply_master_reads_respects:
   apply clarsimp
   done
 
-(*Clagged*)
-(*
-crunch states_equiv[wp]: switch_if_required_to "states_equiv_for P Q R X st"
-*)
-
 lemmas gets_cur_thread_respects_f =
-       gets_cur_thread_ev[THEN reads_respects_f[where Q=\<top>],simplified,wp]
+  gets_cur_thread_ev[THEN reads_respects_f[where Q=\<top>],simplified,wp]
 
 lemma restart_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
-  "reads_respects_f aag l (silc_inv aag st and pas_refined aag and pas_cur_domain aag and invs
-                           and tcb_at t
-                           and (\<lambda>s. is_subject aag (cur_thread s)) and K (is_subject aag t))
-      (restart t)"
+    "reads_respects_f aag l (silc_inv aag st and pas_refined aag and pas_cur_domain aag and invs
+                                             and tcb_at t and (\<lambda>s. is_subject aag (cur_thread s))
+                                             and K (is_subject aag t)) (restart t)"
   apply (rule gen_asm_ev | elim conjE)+
   apply (simp add: restart_def when_def)
   apply (wp reads_respects_f[OF set_thread_state_reads_respects, where Q="\<top>"]
             reads_respects_f[OF setup_reply_master_reads_respects setup_reply_master_silc_inv]
-            gets_cur_thread_ev
-            set_thread_state_pas_refined
-            setup_reply_master_pas_refined
+            gets_cur_thread_ev set_thread_state_pas_refined setup_reply_master_pas_refined
             reads_respects_f[OF possible_switch_to_reads_respects, where Q="\<top>"]
             reads_respects_f[OF tcb_sched_action_reads_respects, where Q="\<top>"]
             cancel_ipc_reads_respects_f setup_reply_master_silc_inv cancel_ipc_silc_inv
-      | simp
-      | strengthen invs_mdb)+
-
+         | simp
+         | strengthen invs_mdb)+
     apply (simp add: get_thread_state_def thread_get_def)
     apply wp
    apply (wp hoare_drop_imps)
   apply clarsimp
-  apply (rule requiv_get_tcb_eq, simp+ |
-         rule conjI | assumption | clarsimp simp: reads_equiv_f_def)+
+  apply (rule requiv_get_tcb_eq | rule conjI | assumption | clarsimp simp: reads_equiv_f_def)+
   done
 
 lemma det_zipWithM:
-  assumes "\<And> x y. \<lbrakk>x \<in> set xs; y \<in> set ys\<rbrakk> \<Longrightarrow> det (f x y)"
+  assumes "\<And>x y. \<lbrakk> x \<in> set xs; y \<in> set ys \<rbrakk> \<Longrightarrow> det (f x y)"
   shows "det (zipWithM f xs ys)"
-  apply(simp add: zipWithM_mapM)
-  apply(rule det_mapM[OF _ subset_refl])
-  apply(simp add: split_def)
-  apply(case_tac x)
-  apply(clarsimp)
-  apply(erule in_set_zipE)
-  apply(erule (1) assms)
+  apply (simp add: zipWithM_mapM)
+  apply (rule det_mapM[OF _ subset_refl])
+  apply (simp add: split_def)
+  apply (case_tac x)
+  apply (clarsimp)
+  apply (erule in_set_zipE)
+  apply (erule (1) assms)
   done
 
 lemma checked_insert_reads_respects:
-  "reads_respects aag l (K (is_subject aag (fst b) \<and> is_subject aag (fst d) \<and> is_subject aag (fst e)))
+  "reads_respects aag l
+     (K (is_subject aag (fst b) \<and> is_subject aag (fst d) \<and> is_subject aag (fst e)))
      (check_cap_at a b (check_cap_at c d (cap_insert a b e)))"
-  apply(rule equiv_valid_guard_imp)
-   apply(simp add: check_cap_at_def)
+  apply (rule equiv_valid_guard_imp)
+   apply (simp add: check_cap_at_def)
    apply (wp when_ev cap_insert_reads_respects get_cap_wp get_cap_rev | simp)+
   done
 
+lemmas as_user_reads_respects_f =
+  reads_respects_f[OF as_user_reads_respects, where Q="\<top>", simplified, OF as_user_silc_inv]
 
-
-
-
-definition authorised_tcb_inv_extra where
-  "authorised_tcb_inv_extra aag ti \<equiv>
-    (case ti of ThreadControl _ slot _ _ _ _ _ _ \<Rightarrow> is_subject aag (fst slot) | _ \<Rightarrow> True)"
-
-lemmas as_user_reads_respects_f = reads_respects_f[OF as_user_reads_respects, where Q="\<top>", simplified, OF as_user_silc_inv]
-
-
-lemma ethread_set_reads_respects: "reads_respects aag l \<top>
-        (ethread_set f word)"
+lemma ethread_set_reads_respects:
+  "reads_respects aag l \<top> (ethread_set f word)"
   apply (simp add: ethread_set_def)
-  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def put_def
-                   get_def bind_def set_eobject_def return_def
-                   gets_def gets_the_def assert_opt_def
-                   get_etcb_def fail_def cong: option.case_cong split: option.splits)
-  apply (fastforce intro: equiv_forI reads_equiv_ekheap_updates affects_equiv_ekheap_update simp: reads_equiv_def2 affects_equiv_def2 elim: states_equiv_forE_ekheap)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def put_def get_def bind_def set_eobject_def
+                        return_def gets_def gets_the_def assert_opt_def get_etcb_def fail_def
+                  cong: option.case_cong split: option.splits)
+  apply (fastforce intro: equiv_forI reads_equiv_ekheap_updates affects_equiv_ekheap_update
+                    elim: states_equiv_forE_ekheap
+                    simp: reads_equiv_def2 affects_equiv_def2 )
   done
-
 
 declare gts_st_tcb_at[wp del]
 
 lemma ethread_set_priority_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace>
-     ethread_set (tcb_priority_update f) thread
-   \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
+  "ethread_set (tcb_priority_update f) thread \<lbrace>pas_refined aag\<rbrace>"
   apply (simp add: ethread_set_def set_eobject_def | wp)+
   apply (clarsimp simp: pas_refined_def tcb_domain_map_wellformed_aux_def)
   apply (erule_tac x="(a, b)" in ballE)
@@ -561,14 +410,13 @@ lemma ethread_set_priority_pas_refined[wp]:
   apply (erule notE)
   apply (erule domains_of_state_aux.cases, simp add: get_etcb_def split: if_split_asm)
    apply (force intro: domtcbs)+
-   done
+  done
 
 lemma set_priority_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l
-           (pas_refined aag and K (is_subject aag word)
-            and pas_cur_domain aag and (\<lambda>s. is_subject aag (cur_thread s)))
+  shows "reads_respects aag (l :: 'a subject_label)
+           (pas_refined aag and K (is_subject aag word) and pas_cur_domain aag
+                            and (\<lambda>s. is_subject aag (cur_thread s)))
            (set_priority word prio)"
   apply (simp add: set_priority_def thread_set_priority_def)
   apply (wp get_thread_state_rev gets_cur_thread_ev gts_wp when_ev
@@ -584,244 +432,165 @@ lemma set_priority_reads_respects:
 
 lemma set_mcpriority_reads_respects:
   assumes domains_distinct: "pas_domains_distinct aag"
-  shows
-  "reads_respects aag l \<top> (set_mcpriority x y)"
+  shows "reads_respects aag (l :: 'a subject_label) \<top> (set_mcpriority x y)"
   unfolding set_mcpriority_def
   by (rule thread_set_reads_respects[OF domains_distinct])
 
 lemma checked_cap_insert_only_timer_irq_inv:
-  "\<lbrace>only_timer_irq_inv irq (st::det_ext state)\<rbrace>
-  check_cap_at a b (check_cap_at c d (cap_insert a b e))
-   \<lbrace>\<lambda>rv. only_timer_irq_inv irq st\<rbrace>"
+  "check_cap_at a b (check_cap_at c d (cap_insert a b e)) \<lbrace>only_timer_irq_inv irq (st :: det_state)\<rbrace>"
   apply (simp add: only_timer_irq_inv_def)
   apply (wp only_timer_irq_pres checked_cap_insert_domain_sep_inv | clarsimp | simp)+
   done
 
 lemma cap_delete_only_timer_irq_inv:
-  "\<lbrace>only_timer_irq_inv irq (st::det_ext state)\<rbrace>
-   cap_delete slot
-   \<lbrace>\<lambda>rv. only_timer_irq_inv irq st\<rbrace>"
+  "cap_delete slot \<lbrace>only_timer_irq_inv irq (st :: det_state)\<rbrace>"
   apply (simp add: only_timer_irq_inv_def)
   apply (wp only_timer_irq_pres cap_delete_irq_masks | force)+
   done
 
 lemma set_priority_only_timer_irq_inv:
-  "\<lbrace>only_timer_irq_inv irq (st::det_ext state)\<rbrace>
-   set_priority t prio
-   \<lbrace>\<lambda>rv. only_timer_irq_inv irq st\<rbrace>"
+  "set_priority t prio \<lbrace>only_timer_irq_inv irq (st :: det_state)\<rbrace>"
   apply (simp add: only_timer_irq_inv_def)
   apply (wp only_timer_irq_pres | force)+
   done
 
 lemma set_mcpriority_only_timer_irq_inv:
-  "\<lbrace>only_timer_irq_inv irq (st::det_ext state)\<rbrace>
-   set_mcpriority t prio
-   \<lbrace>\<lambda>rv. only_timer_irq_inv irq st\<rbrace>"
+  "set_mcpriority t prio \<lbrace>only_timer_irq_inv irq (st :: det_state)\<rbrace>"
   apply (simp add: only_timer_irq_inv_def)
   apply (wp only_timer_irq_pres | force)+
   done
 
 lemma thread_set_tcb_fault_handler_update_only_timer_irq_inv:
-  "\<lbrace>only_timer_irq_inv irq (st::det_ext state)\<rbrace>
-   thread_set (tcb_fault_handler_update blah) t
-   \<lbrace>\<lambda>rv. only_timer_irq_inv irq st\<rbrace>"
+  "thread_set (tcb_fault_handler_update blah) t \<lbrace>only_timer_irq_inv irq (st :: det_state)\<rbrace>"
   apply (simp add: only_timer_irq_inv_def)
   apply (wp only_timer_irq_pres | force)+
   done
 
 lemma bind_notification_reads_respects:
-  "reads_respects aag l (pas_refined aag and invs and K (is_subject aag t \<and> (\<forall>auth\<in>{Receive, Reset}. (pasSubject aag, auth, pasObjectAbs aag ntfnptr) \<in> pasPolicy aag)))
-       (bind_notification t ntfnptr)"
+  "reads_respects aag l
+     (pas_refined aag and invs and
+      K (is_subject aag t \<and>
+         (\<forall>auth\<in>{Receive, Reset}. (pasSubject aag, auth, pasObjectAbs aag nptr) \<in> pasPolicy aag)))
+     (bind_notification t nptr)"
   apply (clarsimp simp: bind_notification_def)
   apply (wp set_bound_notification_owned_reads_respects set_simple_ko_reads_respects
             get_simple_ko_reads_respects get_bound_notification_reads_respects
             gbn_wp[unfolded get_bound_notification_def, simplified]
-       | wpc
-       | simp add: get_bound_notification_def)+
+         | wpc
+         | simp add: get_bound_notification_def)+
   apply (clarsimp dest!: reads_ep)
   done
 
-lemmas thread_get_reads_respects_f = reads_respects_f[OF thread_get_reads_respects, where Q="\<top>", simplified, OF thread_get_inv]
+lemmas thread_get_reads_respects_f =
+  reads_respects_f[OF thread_get_reads_respects, where Q="\<top>", simplified, OF thread_get_inv]
 
-lemmas reschedule_required_reads_respects_f = reads_respects_f[OF reschedule_required_reads_respects, where Q="\<top>", simplified, OF _ reschedule_required_ext_extended.silc_inv]
+lemmas reschedule_required_reads_respects_f =
+  reads_respects_f[OF reschedule_required_reads_respects, where Q="\<top>", simplified,
+                   OF _ reschedule_required_ext_extended.silc_inv]
+
+
+context Tcb_IF_2 begin
 
 lemma invoke_tcb_reads_respects_f:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  notes validE_valid[wp del]
-        static_imp_wp [wp]
+  notes validE_valid[wp del] static_imp_wp [wp]
   shows
-  "reads_respects_f aag l (silc_inv aag st and only_timer_irq_inv irq st' and einvs
-         and simple_sched_action and pas_refined aag and pas_cur_domain aag
-         and Tcb_AI.tcb_inv_wf ti and is_subject aag \<circ> cur_thread
-         and K (authorised_tcb_inv aag ti \<and> authorised_tcb_inv_extra aag ti))
-     (invoke_tcb ti)"
+    "reads_respects_f aag l
+       (silc_inv aag st and only_timer_irq_inv irq st' and einvs
+                        and simple_sched_action and pas_refined aag and pas_cur_domain aag
+                        and tcb_inv_wf ti and is_subject aag \<circ> cur_thread
+                        and K (authorised_tcb_inv aag ti \<and> authorised_tcb_inv_extra aag ti))
+       (invoke_tcb ti)"
   including no_pre
-  apply(case_tac ti)
-         apply(wpsimp wp: thread_get_reads_respects_f when_ev restart_reads_respects_f
-                          reschedule_required_reads_respects_f as_user_reads_respects_f
-                          static_imp_wp thread_get_wp' restart_silc_inv restart_pas_refined
-                          hoare_vcg_if_lift)+
-         apply(solves\<open>auto intro!: det_zipWithM
-                             simp: det_setRegister det_getRestartPC det_setNextPC
-                                   authorised_tcb_inv_def  reads_equiv_f_def\<close>)
-        apply(wp as_user_reads_respects_f suspend_silc_inv when_ev  suspend_reads_respects_f
-             | simp | elim conjE, assumption)+
-        apply(solves\<open>auto simp: authorised_tcb_inv_def  det_getRegister reads_equiv_f_def
-                        intro!: det_mapM[OF _ subset_refl]\<close>)
-       apply(wp when_ev mapM_x_ev'' reschedule_required_reads_respects_f[where st=st]
-                as_user_reads_respects_f[where st=st] hoare_vcg_ball_lift
-                restart_reads_respects_f restart_silc_inv hoare_vcg_if_lift
-                suspend_reads_respects_f suspend_silc_inv hoare_drop_imp
-                restart_silc_inv restart_pas_refined
-            | simp split del: if_split add: det_setRegister det_setNextPC
-            | strengthen invs_mdb
-            | (rule hoare_strengthen_post[where Q="\<lambda>_. silc_inv aag st and pas_refined aag
-                                                                       and pspace_aligned
-                                                                       and valid_vspace_objs
-                                                                       and valid_arch_state",
-                                          OF mapM_x_wp', rotated], fastforce)
-            | wp mapM_x_wp')+
-       apply(solves\<open>auto simp: authorised_tcb_inv_def
-                        idle_no_ex_cap[OF invs_valid_global_refs invs_valid_objs] det_getRestartPC
-                        det_getRegister\<close>)
+  apply (case_tac ti)
+         \<comment> \<open>WriteRegisters\<close>
+         apply (strengthen invs_mdb
+                | wpsimp wp: when_ev restart_reads_respects_f reschedule_required_reads_respects_f
+                             as_user_reads_respects_f restart_silc_inv restart_pas_refined hoare_vcg_if_lift)+
+            apply (rule hoare_strengthen_post[where Q="\<lambda>_ s. \<forall>rv. R rv s" and R=R for R, rotated])
+             apply (erule_tac x=r in allE, assumption)
+            apply wpsimp+
+         apply (solves \<open>auto intro!: det_zipWithM
+                               simp: det_setRegister det_getRestartPC det_setNextPC
+                                     authorised_tcb_inv_def reads_equiv_f_def\<close>)
+        apply (wp as_user_reads_respects_f suspend_silc_inv when_ev  suspend_reads_respects_f
+               | simp | elim conjE, assumption)+
+        apply (solves \<open>auto simp: authorised_tcb_inv_def  det_getRegister reads_equiv_f_def
+                          intro!: det_mapM[OF _ subset_refl]\<close>)
+       apply (wp when_ev mapM_x_ev'' reschedule_required_reads_respects_f[where st=st]
+                 as_user_reads_respects_f[where st=st] hoare_vcg_ball_lift
+                 restart_reads_respects_f restart_silc_inv hoare_vcg_if_lift
+                 suspend_reads_respects_f suspend_silc_inv hoare_drop_imp
+                 restart_silc_inv restart_pas_refined
+              | simp split del: if_split add: det_setRegister det_setNextPC
+              | strengthen invs_mdb
+              | (rule hoare_strengthen_post[where Q="\<lambda>_. silc_inv aag st and pas_refined aag
+                                                                         and pspace_aligned
+                                                                         and valid_vspace_objs
+                                                                         and valid_arch_state",
+                                            OF mapM_x_wp', rotated], fastforce)
+              | wp mapM_x_wp')+
+       apply (solves \<open>auto simp: authorised_tcb_inv_def det_getRestartPC det_getRegister
+                                 idle_no_ex_cap[OF invs_valid_global_refs invs_valid_objs]\<close>)
       defer
-      apply((wp suspend_reads_respects_f[where st=st] restart_reads_respects_f[where st=st]
+      apply ((wp suspend_reads_respects_f[where st=st] restart_reads_respects_f[where st=st]
               | simp add: authorised_tcb_inv_def )+)[2]
     \<comment> \<open>NotificationControl\<close>
     apply (rename_tac option)
     apply (case_tac option, simp_all)[1]
-     apply ((wp unbind_notification_is_subj_reads_respects unbind_notification_silc_inv
-           bind_notification_reads_respects
-         | clarsimp simp: authorised_tcb_inv_def
-         | rule_tac Q=\<top> and st=st in reads_respects_f)+)[2]
+     apply ((wp unbind_notification_is_subj_reads_respects
+                unbind_notification_silc_inv bind_notification_reads_respects
+             | clarsimp simp: authorised_tcb_inv_def
+             | rule_tac Q=\<top> and st=st in reads_respects_f)+)[2]
    \<comment> \<open>SetTLSBase\<close>
    apply (rename_tac tcb tls_base)
-   apply(wpsimp wp: when_ev reschedule_required_reads_respects_f
-                    as_user_reads_respects_f hoare_drop_imps)+
-   apply(auto simp: det_setRegister authorised_tcb_inv_def)[1]
+   apply (wpsimp wp: when_ev reschedule_required_reads_respects_f
+                     as_user_reads_respects_f hoare_drop_imps)+
+   apply (auto simp: det_setRegister authorised_tcb_inv_def)[1]
   \<comment> \<open>ThreadControl\<close>
-  apply (simp add: split_def cong: option.case_cong)
-  apply (wpsimp wp: set_priority_reads_respects[THEN
-                     reads_respects_f[where aag=aag and st=st and Q=\<top>]])
-                    apply (wpsimp wp: hoare_vcg_const_imp_lift_R simp: when_def | wpc)+
-                    apply (rule conjI)
-                     apply ((wpsimp wp: reschedule_required_reads_respects_f)+)[4]
-                 apply((wp reads_respects_f[OF cap_insert_reads_respects, where st=st]
-                           reads_respects_f[OF thread_set_reads_respects, where st=st and Q="\<top>"]
-                           set_priority_reads_respects[THEN
-                                               reads_respects_f[where aag=aag and st=st and Q=\<top>]]
-                           set_mcpriority_reads_respects[THEN
-                                               reads_respects_f[where aag=aag and st=st and Q=\<top>]]
-                           check_cap_inv[OF check_cap_inv[OF cap_insert_valid_list]]
-                           check_cap_inv[OF check_cap_inv[OF cap_insert_valid_sched]]
-                           check_cap_inv[OF check_cap_inv[OF cap_insert_schedact]]
-                           check_cap_inv[OF check_cap_inv[OF cap_insert_cur_domain]]
-                           check_cap_inv[OF check_cap_inv[OF cap_insert_ct]]
-                           get_thread_state_rev[THEN
-                                               reads_respects_f[where aag=aag and st=st and Q=\<top>]]
-                           hoare_vcg_all_lift_R hoare_vcg_all_lift
-                           cap_delete_reads_respects[where st=st] checked_insert_pas_refined
-                           thread_set_pas_refined
-                           reads_respects_f[OF checked_insert_reads_respects, where st=st]
-                           checked_cap_insert_silc_inv[where st=st]
-                           cap_delete_silc_inv_not_transferable[where st=st]
-                           checked_cap_insert_only_timer_irq_inv[where st=st' and irq=irq]
-                           cap_delete_only_timer_irq_inv[where st=st' and irq=irq]
-                           set_priority_only_timer_irq_inv[where st=st' and irq=irq]
-                           set_mcpriority_only_timer_irq_inv[where st=st' and irq=irq]
-                           cap_delete_deletes cap_delete_valid_cap cap_delete_cte_at
-                           cap_delete_pas_refined' itr_wps(12) itr_wps(14) cap_insert_cte_at
-                           checked_insert_no_cap_to hoare_vcg_const_imp_lift_R hoare_vcg_conj_lift
-                           as_user_reads_respects_f thread_set_mdb cap_delete_invs
-                      | wpc
-                      | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
-                                  tcb_at_st_tcb_at when_def
-                      | strengthen use_no_cap_to_obj_asid_strg invs_mdb
-                                   invs_psp_aligned invs_vspace_objs invs_arch_state
-                      | solves auto)+)[7]
-                    (* 9 subgoals here *)
-          apply ((simp add: conj_comms,
-                  strengthen imp_consequent[where Q="x = None" for x],
-                  simp cong: conj_cong)
-                | wp reads_respects_f[OF cap_insert_reads_respects, where st=st]
-                     reads_respects_f[OF thread_set_reads_respects, where st=st and Q="\<top>"]
-                     set_priority_reads_respects[THEN reads_respects_f[where aag=aag and st=st and Q=\<top>]]
-                     set_mcpriority_reads_respects[THEN reads_respects_f[where aag=aag and st=st and Q=\<top>]]
-                     check_cap_inv[OF check_cap_inv[OF cap_insert_valid_list]]
-                     check_cap_inv[OF check_cap_inv[OF cap_insert_valid_sched]]
-                     check_cap_inv[OF check_cap_inv[OF cap_insert_schedact]]
-                     check_cap_inv[OF check_cap_inv[OF cap_insert_cur_domain]]
-                     check_cap_inv[OF check_cap_inv[OF cap_insert_ct]]
-                     get_thread_state_rev[THEN reads_respects_f[where aag=aag and st=st and Q=\<top>]]
-                     hoare_vcg_all_lift_R hoare_vcg_all_lift
-                     cap_delete_reads_respects[where st=st] checked_insert_pas_refined
-                     thread_set_pas_refined reads_respects_f[OF checked_insert_reads_respects, where st=st]
-                     checked_cap_insert_silc_inv[where st=st] cap_delete_silc_inv_not_transferable[where st=st]
-                     checked_cap_insert_only_timer_irq_inv[where st=st' and irq=irq]
-                     cap_delete_only_timer_irq_inv[where st=st' and irq=irq]
-                     set_priority_only_timer_irq_inv[where st=st' and irq=irq]
-                     set_mcpriority_only_timer_irq_inv[where st=st' and irq=irq]
-                     cap_delete_deletes cap_delete_valid_cap cap_delete_cte_at
-                     cap_delete_pas_refined' itr_wps(12) itr_wps(14) cap_insert_cte_at
-                     checked_insert_no_cap_to hoare_vcg_const_imp_lift_R
-                     as_user_reads_respects_f cap_delete_invs
-                |wpc
-                |simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
-                           when_def st_tcb_at_triv
-                |strengthen use_no_cap_to_obj_asid_strg invs_mdb
-                            invs_psp_aligned invs_vspace_objs invs_arch_state
-                |wp (once) hoare_drop_imp)+
-    apply(simp add: option_update_thread_def tcb_cap_cases_def
-         | wp static_imp_wp static_imp_conj_wp reads_respects_f[OF thread_set_reads_respects, where st=st and Q="\<top>"]
-              thread_set_pas_refined | wpc)+
-   apply(wp hoare_vcg_all_lift thread_set_tcb_fault_handler_update_invs
-            thread_set_tcb_fault_handler_update_silc_inv
-            thread_set_not_state_valid_sched
-            thread_set_pas_refined thread_set_emptyable thread_set_valid_cap
-            thread_set_cte_at  thread_set_no_cap_to_trivial
-            thread_set_tcb_fault_handler_update_only_timer_irq_inv
-        | simp add: tcb_cap_cases_def | wpc | wp (once) hoare_drop_imp)+
-  apply (clarsimp simp: authorised_tcb_inv_def  authorised_tcb_inv_extra_def emptyable_def)
-  by (clarsimp simp: is_cap_simps is_cnode_or_valid_arch_def is_valid_vtable_root_def
-                     det_setRegister
-                   | intro impI
-                   | rule conjI)+
+  apply (fastforce intro: tc_reads_respects_f[OF assms])
+  done
 
 lemma invoke_tcb_reads_respects_f_g:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
-"reads_respects_f_g aag l (silc_inv aag st and only_timer_irq_inv irq st' and pas_refined aag and pas_cur_domain aag and einvs and simple_sched_action and Tcb_AI.tcb_inv_wf ti and (\<lambda>s. is_subject aag (cur_thread s)) and K (authorised_tcb_inv aag ti \<and> authorised_tcb_inv_extra aag ti))
-    (invoke_tcb ti)"
+    "reads_respects_f_g aag l
+       (silc_inv aag st and only_timer_irq_inv irq st' and pas_refined aag and pas_cur_domain aag
+                        and einvs and simple_sched_action and tcb_inv_wf ti
+                        and (\<lambda>s. is_subject aag (cur_thread s))
+                        and K (authorised_tcb_inv aag ti \<and> authorised_tcb_inv_extra aag ti))
+       (invoke_tcb ti)"
   apply (rule equiv_valid_guard_imp)
    apply (rule reads_respects_f_g)
-    apply(rule invoke_tcb_reads_respects_f[OF domains_distinct])
-   apply(rule doesnt_touch_globalsI)
-   apply(wp invoke_tcb_globals_equiv | clarsimp | assumption | force)+
-  done
-
-lemma decode_tcb_invocation_authorised_extra:
-  "\<lbrace>K (is_subject aag (fst slot))\<rbrace>
-  decode_tcb_invocation label msg (ThreadCap t) slot excaps
-  \<lbrace>\<lambda>rv s. authorised_tcb_inv_extra aag rv\<rbrace>, -"
-  apply(simp add: authorised_tcb_inv_extra_def)
-  apply(simp add: decode_tcb_invocation_def)
-  apply(rule hoare_pre)
-   apply(wp OR_choice_E_weak_wp
-            | wpc | simp add: decode_read_registers_def
-                              decode_write_registers_def
-                              decode_copy_registers_def
-                              decode_tcb_configure_def
-                              decode_set_priority_def
-                              decode_set_mcpriority_def
-                              decode_set_sched_params_def
-                              decode_set_ipc_buffer_def
-                              decode_bind_notification_def
-                              decode_unbind_notification_def
-                              decode_set_tls_base_def
-                              split_def decode_set_space_def
-                   split del: if_split)+
+    apply (rule invoke_tcb_reads_respects_f[OF domains_distinct])
+   apply (rule doesnt_touch_globalsI)
+   apply (wp invoke_tcb_globals_equiv | clarsimp | assumption | force)+
   done
 
 end
+
+
+lemma decode_tcb_invocation_authorised_extra:
+  "\<lbrace>K (is_subject aag (fst slot))\<rbrace>
+   decode_tcb_invocation label msg (ThreadCap t) slot excaps
+   \<lbrace>\<lambda>rv s. authorised_tcb_inv_extra aag rv\<rbrace>, -"
+  apply (simp add: authorised_tcb_inv_extra_def)
+  apply (simp add: decode_tcb_invocation_def)
+  apply (rule hoare_pre)
+   apply (wp OR_choice_E_weak_wp
+          | wpc | simp add: decode_read_registers_def
+                            decode_write_registers_def
+                            decode_copy_registers_def
+                            decode_tcb_configure_def
+                            decode_set_priority_def
+                            decode_set_mcpriority_def
+                            decode_set_sched_params_def
+                            decode_set_ipc_buffer_def
+                            decode_bind_notification_def
+                            decode_unbind_notification_def
+                            decode_set_tls_base_def
+                            split_def decode_set_space_def
+                 split del: if_split)+
+  done
 
 end

--- a/proof/infoflow/UserOp_IF.thy
+++ b/proof/infoflow/UserOp_IF.thy
@@ -5,10 +5,8 @@
  *)
 
 theory UserOp_IF
-imports Syscall_IF "Access.ArchADT_AC"
+imports ArchSyscall_IF "Access.ArchADT_AC"
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 text \<open>
   This theory defines an enhanced @{term do_user_op} function for the
@@ -18,984 +16,29 @@ text \<open>
   this one and remove the duplication.
 \<close>
 
-definition ptable_lift_s where
-  "ptable_lift_s s \<equiv>  ptable_lift (cur_thread s) s"
-
-definition ptable_rights_s where
-  "ptable_rights_s s \<equiv>  ptable_rights (cur_thread s) s"
-
-(* FIXME: move to ADT_AI.thy *)
-definition
-  ptable_attrs :: "obj_ref \<Rightarrow> 'z state \<Rightarrow> word32 \<Rightarrow> vm_attributes" where
- "ptable_attrs tcb s \<equiv> \<lambda>addr.
-  case_option {} (fst o snd o snd)
-     (get_page_info (\<lambda>obj. get_arch_obj (kheap s obj))
-        (get_pd_of_thread (kheap s) (arch_state s) tcb) addr)"
-
-definition
-  ptable_attrs_s :: "'z state \<Rightarrow> word32 \<Rightarrow> vm_attributes" where
- "ptable_attrs_s s \<equiv> ptable_attrs (cur_thread s) s"
-
-definition ptable_xn_s where
-  "ptable_xn_s s \<equiv>  \<lambda>addr. XNever \<in> ptable_attrs_s s addr"
-
-definition getExMonitor :: "exclusive_monitors machine_monad" where
-  "getExMonitor \<equiv> gets exclusive_state"
-
-definition setExMonitor :: "exclusive_monitors \<Rightarrow> unit machine_monad" where
-  "setExMonitor es \<equiv> modify (\<lambda>ms. ms\<lparr>exclusive_state := es\<rparr>)"
-
-definition
-  "compl (A::'a set) \<equiv> - A"
-
-definition do_user_op_if
-where
-  "do_user_op_if uop tc =
-   do
-      \<comment> \<open>Get the page rights of each address (ReadOnly, ReadWrite, None, etc).\<close>
-      pr \<leftarrow> gets ptable_rights_s;
-
-      \<comment> \<open>Fetch the 'execute never' bits of the current thread's page mappings.\<close>
-      pxn \<leftarrow> gets (\<lambda>s x. pr x \<noteq> {} \<and> ptable_xn_s s x);
-
-      \<comment> \<open>Get the mapping from virtual to physical addresses.\<close>
-      pl \<leftarrow> gets (\<lambda>s. restrict_map (ptable_lift_s s) {x. pr x \<noteq> {}});
-
-      allow_read \<leftarrow> return  {y. EX x. pl x = Some y \<and> AllowRead \<in> pr x};
-      allow_write \<leftarrow> return  {y. EX x. pl x = Some y \<and> AllowWrite \<in> pr x};
-
-      \<comment> \<open>Get the current thread.\<close>
-      t \<leftarrow> gets cur_thread;
-
-      \<comment> \<open>Generate user memory by throwing away anything from global
-         memory that the user doesn't have access to. (The user must
-         have both (1) a mapping to the page; (2) that mapping has the
-         AllowRead right.\<close>
-      um \<leftarrow> gets (\<lambda>s. (user_mem s) \<circ> ptrFromPAddr);
-      dm \<leftarrow> gets (\<lambda>s. (device_mem s) \<circ> ptrFromPAddr);
-      ds \<leftarrow> gets (device_state \<circ> machine_state);
-
-      es \<leftarrow> do_machine_op getExMonitor;
-
-      \<comment> \<open>Non-deterministically execute one of the user's operations.\<close>
-      u \<leftarrow> return (uop t pl pr pxn (tc, um|`allow_read, (ds \<circ> ptrFromPAddr)|` allow_read, es));
-      assert (u \<noteq> {});
-      (e,(tc',um',ds',es')) \<leftarrow> select u;
-
-      \<comment> \<open>Update the changes the user made to memory into our model.
-         We ignore changes that took place where they didn't have
-         write permissions. (uop shouldn't be doing that --- if it is,
-         uop isn't correctly modelling real hardware.)\<close>
-      do_machine_op (user_memory_update
-          (((um' |` allow_write) \<circ> addrFromPPtr) |` (-(dom ds))));
-
-      do_machine_op (device_memory_update
-          (((ds' |` allow_write) \<circ> addrFromPPtr) |` (dom ds)));
-
-      \<comment> \<open>Update exclusive monitor state used by the thread.\<close>
-      do_machine_op (setExMonitor es');
-
-      return (e,tc')
-   od"
-
-(* Assumptions:
- * User is deterministic based on an address being mapped with no rights or not mapped at all.
- * We implicitly assume that if you have any rights you must have at least read rights.
-*)
-
-lemma dmo_user_memory_update_reads_respects_g:
-   "reads_respects_g aag l \<top> (do_machine_op (user_memory_update um))"
-   apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
-   apply(clarsimp simp: do_machine_op_def user_memory_update_def gets_def select_f_def
-                        get_def bind_def in_monad)
-   apply(clarsimp simp: reads_equiv_g_def globals_equiv_def split: option.splits)
-   apply(subgoal_tac "reads_respects aag l \<top> (do_machine_op (user_memory_update um))")
-    apply(fastforce simp: equiv_valid_def2 equiv_valid_2_def in_monad
-                    do_machine_op_def user_memory_update_def select_f_def
-                    idle_equiv_def)
-   apply(rule use_spec_ev)
-   apply (simp add: user_memory_update_def)
-   apply(rule do_machine_op_spec_reads_respects)
-    apply(simp add: equiv_valid_def2)
-    apply(rule modify_ev2)
-    apply(fastforce intro: equiv_forI elim: equiv_forE split: option.splits)
-   apply (wp | simp)+
-   done
-
-lemma requiv_get_pd_of_thread_eq:
-  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; is_subject aag (cur_thread s);
-     pd_ref \<noteq> arm_global_pd (arch_state s);
-     pd_ref' \<noteq> arm_global_pd (arch_state s');
-     get_pd_of_thread (kheap s) (arch_state s) (cur_thread s) = pd_ref;
-     get_pd_of_thread (kheap s') (arch_state s') (cur_thread s') = pd_ref' \<rbrakk>
-   \<Longrightarrow> pd_ref = pd_ref'"
-  apply (erule reads_equivE)
-  apply (erule equiv_forE)
-  apply (subgoal_tac "aag_can_read aag (cur_thread s)")
-   apply (clarsimp simp: get_pd_of_thread_eq)
-  apply (simp add: reads_lrefl)
-  done
-
-lemma requiv_get_pt_entry_eq:
-  "\<lbrakk> reads_equiv aag s s'; is_subject aag pt \<rbrakk>
-   \<Longrightarrow> get_pt_entry (\<lambda>obj. get_arch_obj (kheap s obj)) pt x
-       = get_pt_entry (\<lambda>obj. get_arch_obj (kheap s' obj)) pt x"
-  apply (erule reads_equivE)
-  apply (erule equiv_forE)
-  apply (subgoal_tac "aag_can_read aag pt")
-   apply (simp add: get_pt_entry_def split: option.splits)
-  apply (simp add: reads_lrefl)
-  done
-
-lemma requiv_get_pt_info_eq:
-  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; is_subject aag pt \<rbrakk>
-   \<Longrightarrow> get_pt_info (\<lambda>obj. get_arch_obj (kheap s obj)) pt x
-       = get_pt_info (\<lambda>obj. get_arch_obj (kheap s' obj)) pt x"
-  apply (simp add: get_pt_info_def)
-  apply (subst requiv_get_pt_entry_eq, simp+)
-  done
-
-lemma requiv_get_pd_entry_eq:
-  "\<lbrakk> reads_equiv aag s s'; is_subject aag pd \<rbrakk>
-   \<Longrightarrow> get_pd_entry (\<lambda>obj. get_arch_obj (kheap s obj)) pd x
-       = get_pd_entry (\<lambda>obj. get_arch_obj (kheap s' obj)) pd x"
-  apply (erule reads_equivE)
-  apply (erule equiv_forE)
-  apply (subgoal_tac "aag_can_read aag pd")
-   apply (simp add: get_pd_entry_def split: option.splits)
-  apply (simp add: reads_lrefl)
-  done
-
-lemma requiv_get_page_info_eq:
-  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; is_subject aag pd;
-     x \<notin> kernel_mappings \<rbrakk>
-   \<Longrightarrow> get_page_info (\<lambda>obj. get_arch_obj (kheap s obj)) pd x
-       = get_page_info (\<lambda>obj. get_arch_obj (kheap s' obj)) pd x"
-  apply (simp add: get_page_info_def)
-  apply (subst requiv_get_pd_entry_eq[symmetric], simp+)
-  apply (clarsimp split: option.splits pde.splits)
-  apply (frule pt_in_pd_same_agent, fastforce+)
-  apply (rule requiv_get_pt_info_eq, simp+)
-  done
-
-lemma requiv_pd_of_thread_global_pd:
-  "\<lbrakk> reads_equiv aag s s'; is_subject aag (cur_thread s); invs s; pas_refined aag s;
-     get_pd_of_thread (kheap s) (arch_state s) (cur_thread s) = arm_global_pd (arch_state s) \<rbrakk>
-   \<Longrightarrow> get_pd_of_thread (kheap s') (arch_state s') (cur_thread s') = arm_global_pd (arch_state s')"
-  apply (erule reads_equivE)
-  apply (erule equiv_forE)
-  apply (subgoal_tac "aag_can_read aag (cur_thread s)")
-   prefer 2
-   apply (simp add: reads_lrefl)
-  apply (clarsimp simp: get_pd_of_thread_def2
-                  split: option.splits kernel_object.splits cap.splits arch_cap.splits)
-  apply (rename_tac tcb word word' p apool)
-  apply (subgoal_tac "aag_can_read_asid aag word'")
-   apply (subgoal_tac "s \<turnstile> ArchObjectCap (PageDirectoryCap word (Some word'))")
-    apply (clarsimp simp: equiv_asids_def equiv_asid_def valid_cap_def)
-    apply (drule_tac x=word' in spec)
-    apply (clarsimp simp: word_gt_0 typ_at_eq_kheap_obj)
-    apply (drule invs_valid_global_refs)
-    apply (drule_tac ptr="((cur_thread s), tcb_cnode_index 1)" in valid_global_refsD2[rotated])
-     apply (subst caps_of_state_tcb_cap_cases)
-       apply (simp add: get_tcb_def)
-      apply (simp add: dom_tcb_cap_cases[simplified])
-     apply simp
-    apply (simp add: cap_range_def global_refs_def)
-
-   apply (cut_tac s=s and t="cur_thread s" and tcb=tcb in objs_valid_tcb_vtable)
-     apply (fastforce simp: invs_valid_objs get_tcb_def)+
-  apply (subgoal_tac "(pasObjectAbs aag (cur_thread s), Control, pasASIDAbs aag word')
-                          \<in> state_asids_to_policy aag s")
-   apply (frule pas_refined_Control_into_is_subject_asid)
-    apply (fastforce simp: pas_refined_def)
-   apply simp
-  apply (cut_tac aag=aag and ptr="(cur_thread s, tcb_cnode_index 1)" in sata_asid)
-    prefer 3
-    apply simp
-   apply (subst caps_of_state_tcb_cap_cases)
-     apply (simp add: get_tcb_def)
-    apply (simp add: dom_tcb_cap_cases[simplified])+
-  done
-
-lemma requiv_ptable_rights_eq:
-  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; pas_refined aag s';
-     is_subject aag (cur_thread s); invs s; invs s' \<rbrakk>
-   \<Longrightarrow> ptable_rights_s s = ptable_rights_s s'"
-  apply (simp add: ptable_rights_s_def)
-  apply (rule ext)
-  apply (case_tac "x \<in> kernel_mappings")
-   apply (clarsimp simp: ptable_rights_def split: option.splits)
-   apply (rule conjI)
-    apply clarsimp
-    apply (frule some_get_page_info_kmapsD)
-       apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
-                              vspace_cap_rights_to_auth_def)+)[4]
-   apply clarsimp
-   apply (frule some_get_page_info_kmapsD)
-      apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
-                             vspace_cap_rights_to_auth_def)+)[4]
-   apply clarsimp
-   apply (rename_tac b)
-   apply (frule_tac r=b in some_get_page_info_kmapsD)
-      apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
-                             vspace_cap_rights_to_auth_def)+)[4]
-
-  apply (case_tac "get_pd_of_thread (kheap s) (arch_state s) (cur_thread s)
-                 = arm_global_pd (arch_state s)")
-   apply (frule requiv_pd_of_thread_global_pd)
-       apply (fastforce+)[4]
-   apply (clarsimp simp: ptable_rights_def split: option.splits)
-   apply (rule conjI)
-    apply clarsimp
-    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
-   apply clarsimp
-   apply (rule conjI)
-    apply clarsimp
-    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
-   apply clarsimp
-   apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-     apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
-
-  apply (case_tac "get_pd_of_thread (kheap s') (arch_state s') (cur_thread s')
-                 = arm_global_pd (arch_state s')")
-  apply (drule reads_equiv_sym)
-  apply (frule requiv_pd_of_thread_global_pd)
-       apply ((fastforce simp: reads_equiv_def)+)[5]
-
-  apply (simp add: ptable_rights_def)
-  apply (frule requiv_get_pd_of_thread_eq)
-        apply (fastforce+)[6]
-  apply (frule pd_of_thread_same_agent, simp+)
-  apply (subst requiv_get_page_info_eq, simp+)
-  done
-
-
-lemma requiv_ptable_attrs_eq:
-  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; pas_refined aag s';
-     is_subject aag (cur_thread s); invs s; invs s'; ptable_rights_s s x \<noteq> {} \<rbrakk>
-   \<Longrightarrow> ptable_attrs_s s x = ptable_attrs_s s' x"
-  apply (simp add: ptable_attrs_s_def ptable_rights_s_def)
-  apply (case_tac "x \<in> kernel_mappings")
-   apply (clarsimp simp: ptable_attrs_def split: option.splits)
-   apply (rule conjI)
-    apply clarsimp
-    apply (frule some_get_page_info_kmapsD)
-       apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
-                              vspace_cap_rights_to_auth_def ptable_rights_def)+)[4]
-   apply clarsimp
-   apply (frule some_get_page_info_kmapsD)
-      apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
-                             vspace_cap_rights_to_auth_def ptable_rights_def)+)[4]
-
-  apply (case_tac "get_pd_of_thread (kheap s) (arch_state s) (cur_thread s)
-                 = arm_global_pd (arch_state s)")
-   apply (frule requiv_pd_of_thread_global_pd)
-       apply (fastforce+)[4]
-   apply (clarsimp simp: ptable_attrs_def split: option.splits)
-   apply (rule conjI)
-    apply clarsimp
-    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
-   apply clarsimp
-   apply (rule conjI)
-    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
-   apply clarsimp
-   apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-     apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
-
-  apply (case_tac "get_pd_of_thread (kheap s') (arch_state s') (cur_thread s')
-                 = arm_global_pd (arch_state s')")
-  apply (drule reads_equiv_sym)
-  apply (frule requiv_pd_of_thread_global_pd)
-       apply ((fastforce simp: reads_equiv_def)+)[5]
-
-  apply (simp add: ptable_attrs_def)
-  apply (frule requiv_get_pd_of_thread_eq, simp+)[1]
-  apply (frule pd_of_thread_same_agent, simp+)[1]
-  apply (subst requiv_get_page_info_eq, simp+)[1]
-  done
-
-lemma requiv_ptable_lift_eq:
-  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; pas_refined aag s'; invs s;
-     invs s'; is_subject aag (cur_thread s); ptable_rights_s s x \<noteq> {} \<rbrakk>
-   \<Longrightarrow> ptable_lift_s s x = ptable_lift_s s' x"
-  apply (simp add: ptable_lift_s_def ptable_rights_s_def)
-  apply (case_tac "x \<in> kernel_mappings")
-   apply (clarsimp simp: ptable_lift_def split: option.splits)
-   apply (rule conjI)
-    apply clarsimp
-    apply (frule some_get_page_info_kmapsD)
-       apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
-                              vspace_cap_rights_to_auth_def ptable_rights_def)+)[4]
-   apply clarsimp
-   apply (frule some_get_page_info_kmapsD)
-      apply ((fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
-                             vspace_cap_rights_to_auth_def ptable_rights_def)+)[4]
-
-  apply (case_tac "get_pd_of_thread (kheap s) (arch_state s) (cur_thread s)
-                 = arm_global_pd (arch_state s)")
-   apply (frule requiv_pd_of_thread_global_pd)
-       apply (fastforce+)[4]
-   apply (clarsimp simp: ptable_lift_def split: option.splits)
-   apply (rule conjI)
-    apply clarsimp
-    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
-   apply clarsimp
-   apply (rule conjI)
-    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
-   apply clarsimp
-   apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-     apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
-
-  apply (case_tac "get_pd_of_thread (kheap s') (arch_state s') (cur_thread s')
-                 = arm_global_pd (arch_state s')")
-  apply (drule reads_equiv_sym)
-  apply (frule requiv_pd_of_thread_global_pd)
-       apply ((fastforce simp: reads_equiv_def)+)[5]
-
-  apply (simp add: ptable_lift_def)
-  apply (frule requiv_get_pd_of_thread_eq, simp+)[1]
-  apply (frule pd_of_thread_same_agent, simp+)[1]
-  apply (subst requiv_get_page_info_eq, simp+)[1]
-  done
-
-lemma requiv_ptable_xn_eq:
-  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; pas_refined aag s';
-     is_subject aag (cur_thread s); invs s; invs s'; ptable_rights_s s x \<noteq> {} \<rbrakk>
-   \<Longrightarrow> ptable_xn_s s x = ptable_xn_s s' x"
-  by (simp add: ptable_xn_s_def requiv_ptable_attrs_eq)
-
-lemma mask_shift_le:
- "z \<le> y \<Longrightarrow> (x::'a:: len word) && ~~ mask z >> y = x >> y"
-  proof -
-   assume le: "z \<le> y"
-   have shifttwice: "\<And>(x::'a:: len word). x >> y = x >> z >> y - z"
-    by (simp add: shiftr_shiftr le)
-   show ?thesis
-    apply (subst shifttwice)
-    apply simp
-    apply (simp add: shiftr_shiftr le)
-   done
-  qed
-
-
-lemma data_at_obj_range:
-  "\<lbrakk>data_at sz ptr s;pspace_aligned s;valid_objs s \<rbrakk>
-    \<Longrightarrow> ptr + (offset && mask (pageBitsForSize sz)) \<in> obj_range ptr (ArchObj (DataPage dev sz))"
-  apply (clarsimp simp: data_at_def)
-  apply (elim disjE)
-   apply (clarsimp simp: obj_at_def)
-   apply (drule(2) ptr_in_obj_range)
-   apply (clarsimp simp: obj_bits_def obj_range_def)
-   apply fastforce
-  apply (clarsimp simp: obj_at_def)
-  apply (drule(2) ptr_in_obj_range)
-  apply (clarsimp simp: obj_bits_def obj_range_def)
-  apply fastforce
-  done
-
-lemma obj_range_data_for_cong:
-  "obj_range ptr (ArchObj (DataPage dev sz'))
-  = obj_range ptr (ArchObj (DataPage False sz'))"
-  by (simp add: obj_range_def)
-
-lemma data_at_disjoint_equiv:
-  "\<lbrakk>ptr' \<noteq> ptr;data_at sz' ptr' s; data_at sz ptr s; valid_objs s; pspace_aligned s;
-    pspace_distinct s; ptr' \<in> obj_range ptr (ArchObj (DataPage dev sz)) \<rbrakk>
-  \<Longrightarrow> False"
-  apply (frule(2) data_at_obj_range[where offset = 0,simplified])
-  apply (clarsimp simp: data_at_def obj_at_def)
-  apply (elim disjE)
-    apply (clarsimp dest!: spec simp: obj_at_def pspace_distinct_def'
-      ,erule impE,erule conjI2[OF conjI2],(fastforce+)[2]
-      ,fastforce cong: obj_range_data_for_cong)+
-  done
-
-lemma data_at_aligned:
-  "\<lbrakk>data_at sz base s;pspace_aligned s\<rbrakk> \<Longrightarrow> is_aligned base (pageBitsForSize sz)"
-  apply (clarsimp simp: data_at_def)
-  apply (elim disjE)
-  apply (clarsimp simp: obj_at_def
-                 split: kernel_object.split_asm if_split_asm arch_kernel_obj.split_asm
-                 dest!: pspace_alignedD)+
-  done
-
-lemma ptrFromPAddr_mask_simp:
- "(ptrFromPAddr z && ~~ mask (pageBitsForSize l)) =
-   (ptrFromPAddr (z && ~~ mask (pageBitsForSize l)))"
-  apply (simp add: ptrFromPAddr_def field_simps)
-  apply (subst mask_out_add_aligned[OF is_aligned_pptrBaseOffset])
-  apply simp
-  done
-
-lemma pageBitsForSize_le_t24:
-  "pageBitsForSize sz \<le> 24"
-  by (cases sz, simp_all)
-
-lemma data_at_same_size:
-  assumes dat_sz': "data_at sz' (ptrFromPAddr base) s"
-      and dat_sz: "data_at sz (ptrFromPAddr (base + (x && mask (pageBitsForSize sz')))
-                                            && ~~ mask (pageBitsForSize sz)) s"
-      and vs: "pspace_distinct s" "pspace_aligned s" "valid_objs s"
-  shows "sz' = sz"
-  proof -
-    from dat_sz' and dat_sz
-    have trivial:
-      "sz' \<noteq> sz
-       \<Longrightarrow> (ptrFromPAddr (base + (x && mask (pageBitsForSize sz'))) && ~~ mask (pageBitsForSize sz))
-           \<noteq> (ptrFromPAddr base)"
-    apply (simp add: data_at_def obj_at_def)
-    apply (rule ccontr)
-    apply (auto)
-    done
-    have sz_equiv: "(pageBitsForSize sz = pageBitsForSize sz') = (sz' = sz)"
-    by (clarsimp simp: pageBitsForSize_def split: vmpage_size.splits)
-  show ?thesis
-  apply (rule sz_equiv[THEN iffD1])
-  apply (rule ccontr)
-  apply (drule neq_iff[THEN iffD1])
-  using dat_sz' dat_sz vs
-  apply (cut_tac trivial) prefer 2
-   apply (fastforce simp: sz_equiv)
-  apply (frule(1) data_at_aligned)
-  apply (elim disjE)
-   apply (erule(5) data_at_disjoint_equiv)
-   apply (unfold obj_range_def)
-   apply (rule mask_in_range[THEN iffD1])
-    apply (simp add: obj_bits_def)+
-   apply (simp add: mask_lower_twice ptrFromPAddr_mask_simp)
-   apply (rule arg_cong[where f = ptrFromPAddr])
-   apply (drule is_aligned_ptrFromPAddrD[OF _ pageBitsForSize_le_t24])
-     apply (subst neg_mask_add_aligned[OF _ and_mask_less'])
-      apply simp
-     apply (fastforce simp: pbfs_less_wb'[unfolded word_bits_def,simplified])
-   apply (simp add: is_aligned_neg_mask_eq)
-  apply (drule not_sym)
-  apply (erule(5) data_at_disjoint_equiv)
-  apply (unfold obj_range_def)
-  apply (rule mask_in_range[THEN iffD1])
-   apply (simp add: obj_bits_def is_aligned_neg_mask)+
-  apply (simp add: mask_lower_twice ptrFromPAddr_mask_simp)
-  apply (rule arg_cong[where f = ptrFromPAddr])
-  apply (drule is_aligned_ptrFromPAddrD[OF _ pageBitsForSize_le_t24])
-  apply (subst mask_lower_twice[symmetric])
-   apply (erule less_imp_le_nat)
-  apply (rule sym)
-  apply (subst mask_lower_twice[symmetric])
-   apply (erule less_imp_le_nat)
-  apply (rule arg_cong[where f = "\<lambda>x. x && ~~ mask z" for z])
-  apply (subst neg_mask_add_aligned[OF _ and_mask_less'])
-    apply simp
-   apply (fastforce simp: pbfs_less_wb'[unfolded word_bits_def,simplified])
-  apply simp
-  done
-qed
-
-lemma valid_pdpt_align_ptD:
-  "\<lbrakk>kheap s ptr = Some (ArchObj (PageTable pt));valid_pdpt_objs s; pt a = entry\<rbrakk>
-   \<Longrightarrow> is_aligned a (pte_range_sz entry)"
-  apply (drule(1) valid_pdpt_objs_ptD)
-  apply (clarsimp simp: entries_align_def)
-  done
-
-lemma valid_pdpt_align_pdD:
-  "\<lbrakk>kheap s ptr = Some (ArchObj (PageDirectory pd));valid_pdpt_objs s; pd a = entry\<rbrakk>
-   \<Longrightarrow> is_aligned a (pde_range_sz entry)"
-  apply (drule(1) valid_pdpt_objs_pdD)
-  apply (clarsimp simp: entries_align_def)
-  done
-
-lemma valid_vspace_objsD2:
-  "\<lbrakk>(\<exists>\<rhd> p) s; ko_at (ArchObj ao) p s;
-     valid_vspace_objs s\<rbrakk>
-    \<Longrightarrow> valid_vspace_obj ao s"
-  by (clarsimp simp: valid_vspace_objsD)
-
-lemma ptable_lift_data_consistant:
-  assumes vs: "valid_state s"
-          and vpdpt: "valid_pdpt_objs s"
-          and pt_lift: "ptable_lift t s x = Some ptr"
-          and dat: "data_at sz ((ptrFromPAddr ptr) && ~~ mask (pageBitsForSize sz)) s"
-          and misc: "get_pd_of_thread (kheap s) (arch_state s) t
-                 \<noteq> arm_global_pd (arch_state s)" "x \<notin> kernel_mappings"
-  shows "ptable_lift t s (x && ~~ mask (pageBitsForSize sz)) =
-         Some (ptr && ~~ mask (pageBitsForSize sz))"
-  proof -
-   have aligned_stuff:
-   "\<lbrakk>is_aligned (ucast ((x >> 12) && mask 8) :: word8) 4\<rbrakk> \<Longrightarrow>
-    (x && ~~ mask 16 >> 12) = x >> 12"
-    apply (simp add: is_aligned_mask)
-    apply word_bitwise
-    apply (simp add: mask_def)
-    done
-   have aligned_stuff':
-   "\<lbrakk>is_aligned ((ucast (x >> 20)):: 12 word) 4\<rbrakk> \<Longrightarrow>
-   (x && ~~ mask 24 >> 20) = x >> 20"
-    apply (simp add: is_aligned_mask)
-    apply word_bitwise
-    apply (simp add: mask_def)
-    done
-   have vs': "valid_objs s \<and> valid_vspace_objs s \<and> pspace_distinct s \<and> pspace_aligned s"
-    using vs
-    by (simp add: valid_state_def valid_pspace_def)
-   have x_less_kb: "x < kernel_base"
-    using misc
-    by (simp add: kernel_mappings_def) (* FIXME: any rules exists already ? *)
-
-  thus ?thesis
-  using pt_lift dat vs'
-  apply (clarsimp simp: ptable_rights_def ptable_lift_def split: option.splits)
-  apply (clarsimp simp: get_page_info_def split: option.splits)
-  apply (rename_tac base sz' attrs rights pde)
-  apply (case_tac pde,simp_all)
-    apply (clarsimp simp: get_pd_entry_def split: arch_kernel_obj.split_asm option.splits)
-    apply (clarsimp simp: get_pt_info_def get_arch_obj_def
-                          get_pt_entry_def
-                   split: option.splits arch_kernel_obj.split_asm kernel_object.splits)
-    apply (rename_tac pd_base vmattr mw pd pt)
-    apply (cut_tac get_pd_of_thread_reachable[OF misc(1)])
-    apply (frule(1) valid_vspace_objsD2[rotated,unfolded obj_at_def,simplified],simp)
-    apply (simp add:)
-    apply (drule bspec)
-    apply (rule Compl_iff[THEN iffD2])
-    apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
-    apply (clarsimp simp: valid_pde_def obj_at_def a_type_def)
-    apply (case_tac "pt (ucast ((x >> 12) && mask 8))",simp_all)
-     apply (frule valid_vspace_objsD2[
-                           where p = "ptrFromPAddr p" for p,rotated,unfolded obj_at_def,simplified],
-            simp)
-      apply (rule exI)
-      apply (erule vs_lookup_step)
-       apply (simp add: vs_lookup1_def lookup_pd_slot_def Let_def pd_shifting
-         pd_shifting_dual obj_at_def)
-       apply (rule_tac x = "VSRef (x>>20) (Some APageDirectory)" in exI)
-       apply (rule context_conjI,simp)
-      apply (erule vs_refs_pdI)
-       apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
-      apply (intro allI impI)
-      apply (simp add: nth_shiftr)
-      apply (rule bang_big[simplified])
-      apply (simp add: word_size)
-     apply (frule(1) valid_pdpt_align_ptD[OF _ vpdpt])
-     apply (simp add: )
-     apply (drule_tac x = "(ucast ((x >> 12) && mask 8))" in spec)
-      apply (frule data_at_same_size[where sz = sz and sz' = ARMLargePage,rotated,simplified],
-        clarsimp+)
-     apply (clarsimp simp: mask_shift_le get_pt_info_def get_pt_entry_def
-                           get_arch_obj_def entries_align_def aligned_stuff mask_AND_NOT_mask
-                    dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a = 16,simplified])
-     apply (simp add: neg_mask_add_aligned[OF _ and_mask_less'] is_aligned_neg_mask_eq)
-    apply (frule valid_vspace_objsD2[
-                           where p = "ptrFromPAddr p" for p,rotated,unfolded obj_at_def,simplified],
-           simp)
-     apply (rule exI)
-     apply (erule vs_lookup_step)
-      apply (simp add: vs_lookup1_def lookup_pd_slot_def Let_def pd_shifting
-        pd_shifting_dual obj_at_def)
-      apply (rule_tac x = "VSRef (x>>20) (Some APageDirectory)" in exI)
-      apply (rule context_conjI,simp)
-     apply (erule vs_refs_pdI)
-      apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
-     apply (intro allI impI)
-     apply (simp add: nth_shiftr)
-     apply (rule bang_big[simplified])
-     apply (simp add: word_size)
-    apply (frule(1) valid_pdpt_align_ptD[OF _ vpdpt])
-    apply (simp add: )
-    apply (drule_tac x = "(ucast ((x >> 12) && mask 8))" in spec)
-    apply (frule data_at_same_size[where sz = sz and sz' = ARMSmallPage,rotated,simplified],
-        clarsimp+)
-    apply (clarsimp simp: mask_shift_le get_pt_info_def get_pt_entry_def
-                          neg_mask_add_aligned[OF _ and_mask_less']
-                          is_aligned_neg_mask_eq  get_arch_obj_def entries_align_def
-                          mask_AND_NOT_mask
-                   dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a = 12,simplified])
-   apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
-                  split: arch_kernel_obj.split_asm option.splits)
-    apply (clarsimp simp: get_pt_entry_def
-                   split: option.splits arch_kernel_obj.split_asm kernel_object.splits)
-    apply (rename_tac pd_base vmattr mw pd caprights)
-    apply (cut_tac get_pd_of_thread_reachable[OF misc(1)])
-    apply (frule(1) valid_vspace_objsD2[rotated,unfolded obj_at_def,simplified],simp)
-    apply (simp add: )
-    apply (drule bspec)
-    apply (rule Compl_iff[THEN iffD2])
-    apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
-    apply (clarsimp simp: valid_pde_def obj_at_def)
-   apply (frule(1) valid_pdpt_align_pdD[OF _ vpdpt])
-   apply (frule data_at_same_size[where sz = sz and sz' = ARMSection,rotated,simplified],
-        clarsimp+)
-   apply (clarsimp simp: mask_shift_le get_pt_info_def get_pt_entry_def
-                         neg_mask_add_aligned[OF _ and_mask_less']
-                         is_aligned_neg_mask_eq  get_arch_obj_def entries_align_def
-                         mask_AND_NOT_mask
-                  dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a = 20,simplified])
-  apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
-                 split: arch_kernel_obj.split_asm option.splits)
-  apply (clarsimp simp: get_pt_entry_def
-                 split: option.splits arch_kernel_obj.split_asm kernel_object.splits)
-  apply (rename_tac pd_base vmattr rights pd)
-  apply (cut_tac get_pd_of_thread_reachable[OF misc(1)])
-  apply (frule(1) valid_vspace_objsD2[rotated,unfolded obj_at_def,simplified],simp)
-  apply (simp add: )
-  apply (drule bspec)
-  apply (rule Compl_iff[THEN iffD2])
-  apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
-  apply (clarsimp simp: valid_pde_def obj_at_def)
-  apply (frule(1) valid_pdpt_align_pdD[OF _ vpdpt])
-  apply (frule data_at_same_size[where sz = sz and sz' = ARMSuperSection,rotated,simplified],
-        clarsimp+)
-    apply (clarsimp simp: mask_shift_le get_pt_info_def get_pt_entry_def
-                          neg_mask_add_aligned[OF _ and_mask_less']
-                          is_aligned_neg_mask_eq  get_arch_obj_def entries_align_def
-                          aligned_stuff' mask_AND_NOT_mask
-                   dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a = 24,simplified])
-  done
-qed
-
-lemma ptable_rights_data_consistant:
-  assumes vs: "valid_state s"
-          and vpdpt: "valid_pdpt_objs s"
-          and pt_lift: "ptable_lift t s x = Some ptr"
-          and dat: "data_at sz ((ptrFromPAddr ptr) && ~~ mask (pageBitsForSize sz)) s"
-          and misc: "get_pd_of_thread (kheap s) (arch_state s) t
-                 \<noteq> arm_global_pd (arch_state s)" "x \<notin> kernel_mappings"
-  shows "ptable_rights t s (x && ~~ mask (pageBitsForSize sz)) = ptable_rights t s x"
-  proof -
-   have aligned_stuff:
-   "\<lbrakk>is_aligned (ucast ((x >> 12) && mask 8) :: word8) 4\<rbrakk> \<Longrightarrow>
-    (x && ~~ mask 16 >> 12) = x >> 12"
-    apply (simp add: is_aligned_mask)
-    apply word_bitwise
-    apply (simp add: mask_def)
-    done
-   have aligned_stuff':
-   "\<lbrakk>is_aligned ((ucast (x >> 20)):: 12 word) 4\<rbrakk> \<Longrightarrow>
-   (x && ~~ mask 24 >> 20) = x >> 20"
-    apply (simp add: is_aligned_mask)
-    apply word_bitwise
-    apply (simp add: mask_def)
-    done
-   have vs': "valid_objs s \<and> valid_vspace_objs s \<and> pspace_distinct s \<and> pspace_aligned s"
-    using vs
-    by (simp add: valid_state_def valid_pspace_def)
-   have x_less_kb: "x < kernel_base"
-    using misc
-    by (simp add: kernel_mappings_def) (* FIXME: any rules exists already ? *)
-
-  thus ?thesis
-  using pt_lift dat vs'
-  apply (clarsimp simp: ptable_rights_def ptable_lift_def split: option.splits)
-  apply (clarsimp simp: get_page_info_def split: option.splits)
-  apply (rename_tac base sz' attrs rights pde)
-  apply (case_tac pde,simp_all)
-    apply (clarsimp simp: get_pd_entry_def split: arch_kernel_obj.split_asm option.splits)
-    apply (clarsimp simp: get_pt_info_def get_arch_obj_def
-                          get_pt_entry_def
-                   split: option.splits arch_kernel_obj.split_asm kernel_object.splits)
-    apply (rename_tac pd_base vmattr mw pd pt)
-    apply (cut_tac get_pd_of_thread_reachable[OF misc(1)])
-    apply (frule(1) valid_vspace_objsD2[rotated,unfolded obj_at_def,simplified],simp)
-    apply (simp add: )
-    apply (drule bspec)
-    apply (rule Compl_iff[THEN iffD2])
-    apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
-    apply (clarsimp simp: valid_pde_def obj_at_def a_type_def)
-    apply (case_tac "pt (ucast ((x >> 12) && mask 8))",simp_all)
-     apply (frule valid_vspace_objsD2[
-                           where p = "ptrFromPAddr p" for p,rotated,unfolded obj_at_def,simplified],
-            simp)
-      apply (rule exI)
-      apply (erule vs_lookup_step)
-       apply (simp add: vs_lookup1_def lookup_pd_slot_def Let_def pd_shifting
-         pd_shifting_dual obj_at_def)
-       apply (rule_tac x = "VSRef (x>>20) (Some APageDirectory)" in exI)
-       apply (rule context_conjI,simp)
-      apply (erule vs_refs_pdI)
-       apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
-      apply (intro allI impI)
-      apply (simp add: nth_shiftr)
-      apply (rule bang_big[simplified])
-      apply (simp add: word_size)
-     apply (frule(1) valid_pdpt_align_ptD[OF _ vpdpt])
-     apply (simp add: )
-     apply (drule_tac x = "(ucast ((x >> 12) && mask 8))" in spec)
-     apply (frule data_at_same_size[where sz = sz and sz' = ARMLargePage,rotated,simplified],
-        clarsimp+)
-     apply (clarsimp simp: mask_shift_le get_pt_info_def get_pt_entry_def
-                           get_arch_obj_def entries_align_def aligned_stuff mask_AND_NOT_mask
-                    dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a = 16,simplified])
-    apply (frule valid_vspace_objsD2[
-                           where p = "ptrFromPAddr p" for p,rotated,unfolded obj_at_def,simplified],
-           simp)
-     apply (rule exI)
-     apply (erule vs_lookup_step)
-      apply (simp add: vs_lookup1_def lookup_pd_slot_def Let_def pd_shifting
-        pd_shifting_dual obj_at_def)
-      apply (rule_tac x = "VSRef (x>>20) (Some APageDirectory)" in exI)
-      apply (rule context_conjI,simp)
-     apply (erule vs_refs_pdI)
-      apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
-     apply (intro allI impI)
-     apply (simp add: nth_shiftr)
-     apply (rule bang_big[simplified])
-     apply (simp add: word_size)
-    apply (frule(1) valid_pdpt_align_ptD[OF _ vpdpt])
-    apply (simp add: )
-    apply (drule_tac x = "(ucast ((x >> 12) && mask 8))" in spec)
-    apply (frule data_at_same_size[where sz = sz and sz' = ARMSmallPage,rotated,simplified],
-        clarsimp+)
-    apply (clarsimp simp: mask_shift_le get_pt_info_def get_pt_entry_def
-                          neg_mask_add_aligned[OF _ and_mask_less']
-                          is_aligned_neg_mask_eq  get_arch_obj_def entries_align_def
-                          mask_AND_NOT_mask
-                          dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a = 12,simplified])
-   apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
-                  split: arch_kernel_obj.split_asm option.splits)
-    apply (clarsimp simp: get_pt_entry_def
-                   split: option.splits arch_kernel_obj.split_asm kernel_object.splits)
-    apply (rename_tac pd_base vmattr mw pd caprights)
-    apply (cut_tac get_pd_of_thread_reachable[OF misc(1)])
-    apply (frule(1) valid_vspace_objsD2[rotated,unfolded obj_at_def,simplified],simp)
-    apply (simp add: )
-    apply (drule bspec)
-    apply (rule Compl_iff[THEN iffD2])
-    apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
-    apply (clarsimp simp: valid_pde_def obj_at_def)
-   apply (frule(1) valid_pdpt_align_pdD[OF _ vpdpt])
-   apply (frule data_at_same_size[where sz = sz and sz' = ARMSection,rotated,simplified],
-        clarsimp+)
-  apply (clarsimp simp: get_pd_entry_def get_arch_obj_def
-                 split: arch_kernel_obj.split_asm option.splits)
-  apply (clarsimp simp: get_pt_entry_def
-                 split: option.splits arch_kernel_obj.split_asm kernel_object.splits)
-  apply (rename_tac pd_base vmattr rights pd)
-  apply (cut_tac get_pd_of_thread_reachable[OF misc(1)])
-  apply (frule(1) valid_vspace_objsD2[rotated,unfolded obj_at_def,simplified],simp)
-  apply (simp add: )
-  apply (drule bspec)
-  apply (rule Compl_iff[THEN iffD2])
-  apply (rule kernel_mappings_kernel_mapping_slots[OF misc(2)])
-  apply (clarsimp simp: valid_pde_def obj_at_def)
-  apply (frule(1) valid_pdpt_align_pdD[OF _ vpdpt])
-  apply (frule data_at_same_size[where sz = sz and sz' = ARMSuperSection,rotated,simplified],
-        clarsimp+)
-    apply (clarsimp simp: mask_shift_le get_pt_info_def get_pt_entry_def
-                          neg_mask_add_aligned[OF _ and_mask_less']
-                          is_aligned_neg_mask_eq  get_arch_obj_def entries_align_def
-                          aligned_stuff' mask_AND_NOT_mask
-                   dest!: data_at_aligned is_aligned_ptrFromPAddrD[where a = 24,simplified])
-  done
-qed
-
-lemma user_op_access_data_at:
-  "\<lbrakk> invs s; valid_pdpt_objs s;pas_refined aag s; is_subject aag tcb;
-     ptable_lift tcb s x = Some ptr;
-     data_at sz ((ptrFromPAddr ptr) && ~~ mask (pageBitsForSize sz)) s;
-     auth \<in> vspace_cap_rights_to_auth (ptable_rights tcb s x) \<rbrakk>
-   \<Longrightarrow> (pasObjectAbs aag tcb,
-        auth,
-        pasObjectAbs aag (ptrFromPAddr (ptr && ~~ mask (pageBitsForSize sz)))) \<in> pasPolicy aag"
-  apply (case_tac "x \<in> kernel_mappings")
-   apply (clarsimp simp: ptable_lift_def ptable_rights_def split: option.splits)
-   apply (frule some_get_page_info_kmapsD)
-      apply (fastforce simp: invs_valid_global_pd_mappings invs_equal_kernel_mappings
-                             vspace_cap_rights_to_auth_def)+
-
-  apply (case_tac "get_pd_of_thread (kheap s) (arch_state s) tcb
-                 = arm_global_pd (arch_state s)")
-   apply (clarsimp simp: ptable_lift_def ptable_rights_def split: option.splits)
-   apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-     apply (fastforce simp: invs_valid_global_objs invs_arch_state)+
-  apply (frule(3) ptable_lift_data_consistant[rotated 2])
-    apply fastforce
-   apply fastforce
-  apply (frule (3) ptable_rights_data_consistant[rotated 2])
-    apply fastforce
-   apply fastforce
-  apply (erule(3) user_op_access)
-  apply simp
-  done
-
-lemma user_frame_at_equiv:
-  "\<lbrakk>typ_at (AArch (AUserData sz)) p s ; equiv_for P kheap s s'; P p  \<rbrakk>
-  \<Longrightarrow> typ_at (AArch (AUserData sz)) p s'"
-  by (clarsimp simp: equiv_for_def obj_at_def)
-
-lemma device_frame_at_equiv:
-  "\<lbrakk>typ_at (AArch (ADeviceData sz)) p s ; equiv_for P kheap s s'; P p  \<rbrakk>
-  \<Longrightarrow> typ_at (AArch (ADeviceData sz)) p s'"
-  by (clarsimp simp: equiv_for_def obj_at_def)
-
-lemma typ_at_user_data_at:
-  "typ_at (AArch (AUserData sz)) p s \<Longrightarrow> data_at sz p s"
-  by (simp add: data_at_def)
-
-lemma typ_at_device_data_at:
-  "typ_at (AArch (ADeviceData sz)) p s \<Longrightarrow> data_at sz p s"
-  by (simp add: data_at_def)
-
 lemma equiv_symmetric:
   "equiv_for a b c d = equiv_for a b d c"
   by (auto simp: equiv_for_def)
 
-lemma requiv_device_mem_eq:
-  "\<lbrakk> reads_equiv aag s s'; globals_equiv s s'; invs s;
-     invs s'; valid_pdpt_objs s; valid_pdpt_objs s';
-     is_subject aag (cur_thread s); AllowRead \<in> ptable_rights_s s x;
-     ptable_lift_s s x = Some y; pas_refined aag s; pas_refined aag s'
-     \<rbrakk>
-   \<Longrightarrow> device_mem s (ptrFromPAddr y) = device_mem s' (ptrFromPAddr y)"
-  apply (simp add: device_mem_def)
-  apply (rule conjI)
-   apply (erule reads_equivE)
-     apply (clarsimp simp: in_device_frame_def)
-     apply (rule exI)
-     apply (rule device_frame_at_equiv)
-       apply assumption+
-     apply (erule_tac f="underlying_memory" in equiv_forE)
-     apply (frule_tac auth=Read in user_op_access_data_at[where s = s])
-        apply (fastforce simp: ptable_lift_s_def ptable_rights_s_def
-                               vspace_cap_rights_to_auth_def
-              | intro typ_at_device_data_at)+
-     apply (rule reads_read)
-     apply (fastforce simp: ptrFromPAddr_mask_simp)
-    apply clarsimp
-  apply (frule requiv_ptable_rights_eq, fastforce+)
-  apply (frule requiv_ptable_lift_eq, fastforce+)
-  apply (clarsimp simp: globals_equiv_def)
-  apply (erule notE)
-    apply (erule reads_equivE)
-    apply (clarsimp simp: in_device_frame_def)
-    apply (rule exI)
-    apply (rule device_frame_at_equiv)
-      apply assumption+
-    apply (erule_tac f="underlying_memory" in equiv_forE)
-    apply (erule equiv_symmetric[THEN iffD1])
-    apply (frule_tac auth=Read in user_op_access_data_at[where s = s'])
-       apply (fastforce simp: ptable_lift_s_def ptable_rights_s_def
-                              vspace_cap_rights_to_auth_def
-             | intro typ_at_device_data_at)+
-    apply (rule reads_read)
-    apply (fastforce simp: ptrFromPAddr_mask_simp)
-  done
-
-lemma requiv_user_mem_eq:
-  "\<lbrakk> reads_equiv aag s s'; globals_equiv s s'; invs s;
-     invs s'; valid_pdpt_objs s; valid_pdpt_objs s';
-     is_subject aag (cur_thread s); AllowRead \<in> ptable_rights_s s x;
-     ptable_lift_s s x = Some y; pas_refined aag s; pas_refined aag s'
-     \<rbrakk>
-   \<Longrightarrow> user_mem s (ptrFromPAddr y) = user_mem s' (ptrFromPAddr y)"
-  apply (simp add: user_mem_def)
-  apply (rule conjI)
-    apply clarsimp
-    apply (rule context_conjI')
-     apply (erule reads_equivE)
-     apply (clarsimp simp: in_user_frame_def)
-     apply (rule exI)
-     apply (rule user_frame_at_equiv)
-       apply assumption+
-     apply (erule_tac f="underlying_memory" in equiv_forE)
-     apply (frule_tac auth=Read in user_op_access_data_at[where s = s])
-        apply (fastforce simp: ptable_lift_s_def ptable_rights_s_def
-                               vspace_cap_rights_to_auth_def
-              | intro typ_at_user_data_at)+
-     apply (rule reads_read)
-     apply (fastforce simp: ptrFromPAddr_mask_simp)
-    apply clarsimp
-    apply (subgoal_tac "aag_can_read aag (ptrFromPAddr y)")
-     apply (erule reads_equivE)
-     apply clarsimp
-     apply (erule_tac f="underlying_memory" in equiv_forE)
-     apply simp
-    apply (frule_tac auth=Read in user_op_access)
-        apply (fastforce simp: ptable_lift_s_def ptable_rights_s_def
-                               vspace_cap_rights_to_auth_def)+
-    apply (rule reads_read)
-    apply simp
-  apply (frule requiv_ptable_rights_eq, fastforce+)
-  apply (frule requiv_ptable_lift_eq, fastforce+)
-  apply (clarsimp simp: globals_equiv_def)
-  apply (erule notE)
-    apply (erule reads_equivE)
-    apply (clarsimp simp: in_user_frame_def)
-    apply (rule exI)
-    apply (rule user_frame_at_equiv)
-      apply assumption+
-    apply (erule_tac f="underlying_memory" in equiv_forE)
-    apply (erule equiv_symmetric[THEN iffD1])
-    apply (frule_tac auth=Read in user_op_access_data_at[where s = s'])
-       apply (fastforce simp: ptable_lift_s_def ptable_rights_s_def
-                              vspace_cap_rights_to_auth_def
-             | intro typ_at_user_data_at)+
-    apply (rule reads_read)
-    apply (fastforce simp: ptrFromPAddr_mask_simp)
-  done
-
-lemma ptable_rights_imp_frameD:
-  "\<lbrakk>ptable_lift t s x = Some y;valid_state s;ptable_rights t s x \<noteq> {}\<rbrakk> \<Longrightarrow>
-         \<exists>sz. data_at sz (ptrFromPAddr y && ~~ mask (pageBitsForSize sz)) s"
-  apply (subst(asm) addrFromPPtr_ptrFromPAddr_id[symmetric])
-  apply (drule ptable_rights_imp_frame)
-     apply simp+
-   apply (rule addrFromPPtr_ptrFromPAddr_id[symmetric])
-  apply (auto simp: in_user_frame_def in_device_frame_def
-             dest!: spec typ_at_user_data_at typ_at_device_data_at)
-  done
-
-lemma requiv_user_device_eq:
-  "\<lbrakk> reads_equiv aag s s'; globals_equiv s s'; invs s;
-     invs s'; valid_pdpt_objs s; valid_pdpt_objs s';
-     is_subject aag (cur_thread s); AllowRead \<in> ptable_rights_s s x;
-     ptable_lift_s s x = Some y; pas_refined aag s; pas_refined aag s'
-     \<rbrakk>
-   \<Longrightarrow> device_state (machine_state s) (ptrFromPAddr y) =
-          device_state (machine_state s') (ptrFromPAddr y)"
-  apply (simp add: ptable_lift_s_def)
-  apply (frule ptable_rights_imp_frameD)
-    apply fastforce
-   apply (fastforce simp: ptable_rights_s_def)
-  apply (erule reads_equivE)
-  apply clarsimp
-  apply (erule_tac f="device_state" in equiv_forD)
-  apply (frule_tac auth=Read in user_op_access_data_at[where s = s])
-        apply ((fastforce simp: ptable_lift_s_def ptable_rights_s_def
-                                vspace_cap_rights_to_auth_def
-               | intro typ_at_user_data_at)+)[6]
-  apply (rule reads_read)
-    apply (frule_tac auth=Read in user_op_access)
-        apply (fastforce simp: ptable_lift_s_def ptable_rights_s_def
-                               vspace_cap_rights_to_auth_def)+
-  done
-
-
 lemma gets_ev''':
-  "equiv_valid_inv I A (\<lambda>s. P s \<and> (\<forall> t. I s t \<and> A s t \<and> P t \<longrightarrow> f s = f t)) (gets f)"
+  "equiv_valid_inv I A (\<lambda>s. P s \<and> (\<forall>t. I s t \<and> A s t \<and> P t \<longrightarrow> f s = f t)) (gets f)"
   apply (simp add: equiv_valid_def2)
   apply (auto simp: equiv_valid_2_def in_monad)
   done
 
 lemma spec_equiv_valid_add_asm:
-  "((P st) \<Longrightarrow> spec_equiv_valid_inv st I A P f) \<Longrightarrow> spec_equiv_valid_inv st I A P f"
-  apply(clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
-  done
+  "(P st \<Longrightarrow> spec_equiv_valid_inv st I A P f) \<Longrightarrow> spec_equiv_valid_inv st I A P f"
+  by (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
 
 lemma spec_equiv_valid_add_rel:
-  "\<lbrakk>spec_equiv_valid_inv st I A (P and I st) f; \<And>s. I s s\<rbrakk> \<Longrightarrow> spec_equiv_valid_inv st I A P f"
-  apply (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
-  done
+  "\<lbrakk> spec_equiv_valid_inv st I A (P and I st) f; \<And>s. I s s \<rbrakk>
+     \<Longrightarrow> spec_equiv_valid_inv st I A P f"
+  by (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
 
 lemma spec_equiv_valid_add_rel':
-  "\<lbrakk>spec_equiv_valid_inv st I A (P and A st) f; \<And>s. A s s\<rbrakk> \<Longrightarrow> spec_equiv_valid_inv st I A P f"
-  apply (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
-  done
+  "\<lbrakk> spec_equiv_valid_inv st I A (P and A st) f; \<And>s. A s s \<rbrakk>
+     \<Longrightarrow> spec_equiv_valid_inv st I A P f"
+  by (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
 
 lemma reads_equiv_g_refl:
   "reads_equiv_g aag s s"
@@ -1004,119 +47,39 @@ lemma reads_equiv_g_refl:
   apply (rule globals_equiv_refl)
   done
 
-definition context_matches_state where
-  "context_matches_state pl pr pxn um ds es s \<equiv>
-      pl = ptable_lift_s s |` {x. pr x \<noteq> {}} \<and>
-      pr = ptable_rights_s s \<and>
-      pxn = (\<lambda>x. pr x \<noteq> {} \<and> ptable_xn_s s x) \<and>
-      um = (user_mem s \<circ> ptrFromPAddr) |` {y. \<exists>x. pl x = Some y \<and> AllowRead \<in> pr x} \<and>
-      ds = (device_state (machine_state s) \<circ> ptrFromPAddr)
-                         |` {y. \<exists>x. pl x = Some y \<and> AllowRead \<in> pr x} \<and>
-      es = exclusive_state (machine_state s)"
-
-(* FIXME - move - duplicated in Schedule_IF *)
-lemma dmo_ev:
-  "(\<And>s s'. equiv_valid (\<lambda>ms ms'. I (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>))
-                   (\<lambda>ms ms'. A (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>))
-                   (\<lambda>ms ms'. B (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>))
-          (K (P s \<and> P s')) f)
-    \<Longrightarrow> equiv_valid I A B P (do_machine_op f)"
-  apply (clarsimp simp: do_machine_op_def bind_def equiv_valid_def2 equiv_valid_2_def gets_def
-                        get_def select_f_def modify_def put_def return_def split_def)
-  apply atomize
-  apply (erule_tac x=s in allE)
-  apply (erule_tac x=t in allE)
-  apply simp
-  apply (erule_tac x="machine_state s" in allE)
-  apply (erule_tac x="machine_state t" in allE)
+lemma spec_equiv_valid_inv_gets:
+  assumes proj_retain: "\<And>t. \<lbrakk> P st; P t; I st t; A st t \<rbrakk> \<Longrightarrow> proj (f st) = proj (f t)"
+  and spec_eqv_valid: "spec_equiv_valid_inv st I A P (g (proj (f st)))"
+  shows "spec_equiv_valid_inv st I A P (do r \<leftarrow> gets f; g (proj r) od)"
+  apply (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def gets_def get_def bind_def return_def)
+  apply (frule (3) proj_retain)
+  apply (cut_tac spec_eqv_valid)
+  apply (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def gets_def get_def bind_def return_def)
+  apply (drule spec)+
+  apply (erule impE)
+   apply fastforce
   apply fastforce
   done
 
-(* FIXME - move - duplicated in Schedule_IF *)
-lemma ev_modify:
-  "(\<And> s t. \<lbrakk>P s; P t; A s t; I s t\<rbrakk> \<Longrightarrow> (I (f s) (f t)) \<and> (B (f s) (f t)))
-   \<Longrightarrow> equiv_valid I A B P (modify f)"
-  apply (clarsimp simp add: equiv_valid_def2 equiv_valid_2_def simpler_modify_def)
-  done
-
-lemma dmo_setExMonitor_reads_respects_g:
-  "reads_respects_g aag l \<top> (do_machine_op (setExMonitor es))"
-  apply (simp add: setExMonitor_def)
-  apply (wp dmo_ev ev_modify)
-  apply (clarsimp simp: reads_equiv_g_def)
-  apply (clarsimp simp: reads_equiv_def affects_equiv_def states_equiv_for_def equiv_for_def
-                        equiv_asids_def equiv_asid_def globals_equiv_def idle_equiv_def
-                 split: if_splits)
-  done
-
-lemma dmo_getExMonitor_reads_respects_g:
-  "reads_respects_g aag l (\<lambda>s. cur_thread s \<noteq> idle_thread s) (do_machine_op getExMonitor)"
-  apply (simp add: getExMonitor_def)
-  apply (wp dmo_ev gets_ev'')
-  apply (clarsimp simp: reads_equiv_g_def globals_equiv_def)
-  done
-
-lemma getExMonitor_wp[wp]:
-  "\<lbrace>\<lambda>ms. P (exclusive_state ms) ms\<rbrace> getExMonitor \<lbrace>P\<rbrace>"
-  by (simp add: getExMonitor_def | wp)+
-
-lemma map_add_eq:
-  "\<lbrakk>ms x = ms' x\<rbrakk> \<Longrightarrow> (ms ++ um) x = (ms' ++ um) x"
-  by (clarsimp simp: map_add_def split: option.splits)
-
-lemma dmo_device_state_update_reads_respects_g:
-   "reads_respects_g aag l (\<lambda>s. dom um \<subseteq> device_region s) (do_machine_op (device_memory_update um))"
-   apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
-   apply (clarsimp simp: do_machine_op_def device_memory_update_def gets_def select_f_def
-                        get_def bind_def in_monad)
-   apply (clarsimp simp: reads_equiv_g_def globals_equiv_def split: option.splits)
-   apply (subgoal_tac "reads_respects aag l \<top> (do_machine_op (device_memory_update um))")
-    apply (fastforce simp: equiv_valid_def2 equiv_valid_2_def in_monad
-                          do_machine_op_def device_memory_update_def select_f_def
-                          idle_equiv_def)
-   apply (rule use_spec_ev)
-   apply (simp add: device_memory_update_def)
-   apply (rule do_machine_op_spec_reads_respects)
-    apply (simp add: equiv_valid_def2)
-    apply (rule modify_ev2)
-     apply (fastforce intro: map_add_eq equiv_forI elim: equiv_forE split: option.splits)
-   apply (wp | simp)+
-   done
-
-lemma spec_equiv_valid_inv_gets:
-  assumes proj_retain: "\<And>t. \<lbrakk>P st; P t; I st t; A st t\<rbrakk> \<Longrightarrow> proj (f st) = proj (f t)"
-      and spec_eqv_valid: "spec_equiv_valid_inv st I A P (g (proj (f st)))"
-  shows "spec_equiv_valid_inv st I A
-           P (do r \<leftarrow> gets f; g (proj r) od)"
-   apply (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def
-     gets_def get_def bind_def return_def)
-   apply (frule(3) proj_retain)
-   apply (cut_tac spec_eqv_valid)
-   apply (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def
-     gets_def get_def bind_def return_def)
-   apply (drule spec)+
-   apply (erule impE)
-    apply fastforce
-   apply fastforce
-   done
-
 lemmas spec_equiv_valid_inv_gets_more =
-   spec_equiv_valid_inv_gets[where proj = "\<lambda>x. (proj x,projsnd x)"
-     and g = "\<lambda>z. g (fst z) (snd z)"  for proj and projsnd and g,simplified]
+  spec_equiv_valid_inv_gets[where proj="\<lambda>x. (proj x, projsnd x)"
+                              and g="\<lambda>z. g (fst z) (snd z)"
+                              for proj and projsnd and g, simplified]
 
 lemmas spec_equiv_valid_inv_gets_triple =
-   spec_equiv_valid_inv_gets_more[where projsnd = "\<lambda>x. (p (projsnd x) , p' (projsnd x))"
-     and g = "\<lambda>a z. g a (fst z) (snd z)"  for projsnd and p and p' and g,simplified]
+  spec_equiv_valid_inv_gets_more[where projsnd="\<lambda>x. (p (projsnd x), p' (projsnd x))"
+                                   and g="\<lambda>a z. g a (fst z) (snd z)"
+                                   for projsnd and p and p' and g, simplified]
 
 lemma restrict_eq_imp_dom_eq:
-  "a |` r =  b|` r \<Longrightarrow> dom a \<inter> r = dom b \<inter> r"
+  "a |` r = b|` r \<Longrightarrow> dom a \<inter> r = dom b \<inter> r"
   apply (clarsimp simp: set_eq_iff restrict_map_def)
   apply (drule_tac x = x in fun_cong)
   apply fastforce
   done
 
 lemma restrict_map_eq_same_domain:
-  "\<lbrakk>\<And>x. x\<in> dom a \<Longrightarrow> b x = c x\<rbrakk> \<Longrightarrow> a |` dom b = a |` dom c"
+  "(\<And>x. x\<in> dom a \<Longrightarrow> b x = c x) \<Longrightarrow> a |` dom b = a |` dom c"
   apply (rule ext)
   apply (clarsimp simp: restrict_map_def)
   apply (intro conjI impI)
@@ -1127,7 +90,7 @@ lemma restrict_map_eq_same_domain:
   done
 
 lemma restrict_map_eq_same_domain_compl:
-  "\<lbrakk>\<And>x. x\<in> dom a \<Longrightarrow> b x = c x\<rbrakk> \<Longrightarrow> a |` (- dom b) = a |` (- dom c)"
+  "(\<And>x. x\<in> dom a \<Longrightarrow> b x = c x) \<Longrightarrow> a |` (- dom b) = a |` (- dom c)"
   apply (rule ext)
   apply (clarsimp simp: restrict_map_def)
   apply (intro conjI impI)
@@ -1137,68 +100,65 @@ lemma restrict_map_eq_same_domain_compl:
   apply fastforce
   done
 
-lemma do_user_op_reads_respects_g:
-  notes split_paired_All[simp del]
-  shows
-   "( \<forall>pl pr pxn tc um es ds s. P tc s \<and> context_matches_state pl pr pxn um ds es s
-                           \<longrightarrow> (\<exists>x. uop (cur_thread s) pl pr pxn (tc, um, ds , es) = {x}))
-   \<Longrightarrow> reads_respects_g aag l (pas_refined aag and invs and valid_pdpt_objs
-                               and is_subject aag \<circ> cur_thread
-                               and (\<lambda>s. cur_thread s \<noteq> idle_thread s) and P tc)
-                (do_user_op_if uop tc)"
-  apply (simp add: do_user_op_if_def)
-  apply (rule use_spec_ev)
-  apply (rule spec_equiv_valid_add_asm)
-  apply (rule spec_equiv_valid_add_rel[OF _ reads_equiv_g_refl])
-  apply (rule spec_equiv_valid_add_rel'[OF _ affects_equiv_refl])
-  apply (rule spec_equiv_valid_inv_gets[where proj=id,simplified])
-    apply (clarsimp simp: reads_equiv_g_def)
-    apply (rule requiv_ptable_rights_eq,simp+)[1]
-  apply (rule spec_equiv_valid_inv_gets[where proj=id,simplified])
-   apply (rule ext)
-   apply (clarsimp simp: reads_equiv_g_def)
-   apply (case_tac "ptable_rights_s st x = {}", simp)
-    apply simp
-    apply (rule requiv_ptable_xn_eq,simp+)[1]
-  apply (rule spec_equiv_valid_inv_gets[where proj=id,simplified])
-    apply (subst expand_restrict_map_eq,clarsimp)
-    apply (clarsimp simp: reads_equiv_g_def)
-    apply (rule requiv_ptable_lift_eq,simp+)[1]
-  apply (rule spec_equiv_valid_inv_gets[where proj=id,simplified])
-    apply (clarsimp simp: reads_equiv_g_def)
-    apply (rule requiv_cur_thread_eq,fastforce)
-  apply (rule spec_equiv_valid_inv_gets_more
-    [where proj = "\<lambda>m. dom m \<inter> cw" and projsnd = "\<lambda>m. m|` cr" for cr and cw])
-    apply (rule context_conjI')
-    apply (subst expand_restrict_map_eq)
-    apply (clarsimp simp: reads_equiv_g_def restrict_map_def)
-    apply (rule requiv_user_mem_eq)
-      apply simp+
-    apply fastforce
-  apply (rule spec_equiv_valid_inv_gets[where proj = "\<lambda>x. ()",simplified])
-  apply (rule spec_equiv_valid_inv_gets_more[where proj = "\<lambda>m. (m \<circ> ptrFromPAddr)|` cr" for cr])
-   apply (rule conjI)
-    apply (subst expand_restrict_map_eq)
-    apply (clarsimp simp: restrict_map_def reads_equiv_g_def)
-    apply (rule requiv_user_device_eq)
-       apply simp+
-    apply (clarsimp simp: globals_equiv_def reads_equiv_g_def)
+lemma map_add_eq:
+  "ms x = ms' x \<Longrightarrow> (ms ++ um) x = (ms' ++ um) x"
+  by (clarsimp simp: map_add_def split: option.splits)
 
-  apply (rule spec_equiv_valid_guard_imp)
-   apply (wp dmo_user_memory_update_reads_respects_g dmo_device_state_update_reads_respects_g
-     dmo_setExMonitor_reads_respects_g dmo_device_state_update_reads_respects_g
-     select_ev select_wp dmo_getExMonitor_reads_respects_g | wpc)+
-   apply (wp dmo_wp)
-   apply clarsimp
-   apply (rule conjI)
-    apply clarsimp
-    apply (drule spec)+
-    apply (erule impE)
-    prefer 2
-     apply assumption
-    apply (clarsimp simp: context_matches_state_def comp_def  reads_equiv_g_def globals_equiv_def)
-  apply (clarsimp simp: reads_equiv_g_def globals_equiv_def)
+
+locale UserOp_IF_1 =
+  assumes arch_globals_equiv_underlying_memory_update[simp]:
+    "\<And>f. arch_globals_equiv ct it kh kh' as as' (underlying_memory_update f ms) ms' =
+          arch_globals_equiv ct it kh kh' as as' ms ms'"
+    "\<And>f. arch_globals_equiv ct it kh kh' as as' ms (underlying_memory_update f ms') =
+          arch_globals_equiv ct it kh kh' as as' ms ms'"
+  and arch_globals_equiv_device_state_update[simp]:
+    "\<And>f. arch_globals_equiv ct it kh kh' as as' (device_state_update f ms) ms' =
+          arch_globals_equiv ct it kh kh' as as' ms ms'"
+    "\<And>f. arch_globals_equiv ct it kh kh' as as' ms (device_state_update f ms') =
+          arch_globals_equiv ct it kh kh' as as' ms ms'"
+begin
+
+(* Assumptions:
+ * User is deterministic based on an address being mapped with no rights or not mapped at all.
+ * We implicitly assume that if you have any rights you must have at least read rights.
+*)
+
+lemma dmo_user_memory_update_reads_respects_g:
+  "reads_respects_g aag l \<top> (do_machine_op (user_memory_update um))"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (clarsimp simp: do_machine_op_def user_memory_update_def
+                        gets_def get_def select_f_def bind_def in_monad)
+  apply (clarsimp simp: reads_equiv_g_def globals_equiv_def split: option.splits)
+  apply (subgoal_tac "reads_respects aag l \<top> (do_machine_op (user_memory_update um))")
+   apply (fastforce simp: equiv_valid_def2 equiv_valid_2_def in_monad do_machine_op_def
+                          user_memory_update_def select_f_def idle_equiv_def)
+  apply (rule use_spec_ev)
+  apply (simp add: user_memory_update_def)
+  apply (rule do_machine_op_spec_reads_respects)
+   apply (simp add: equiv_valid_def2)
+   apply (rule modify_ev2)
+   apply (fastforce intro: equiv_forI elim: equiv_forE split: option.splits)
+  apply (wp | simp)+
   done
+
+lemma dmo_device_state_update_reads_respects_g:
+  "reads_respects_g aag l (\<lambda>s. dom um \<subseteq> device_region s) (do_machine_op (device_memory_update um))"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (clarsimp simp: do_machine_op_def device_memory_update_def
+                        gets_def get_def select_f_def bind_def in_monad)
+  apply (clarsimp simp: reads_equiv_g_def globals_equiv_def split: option.splits)
+  apply (subgoal_tac "reads_respects aag l \<top> (do_machine_op (device_memory_update um))")
+   apply (fastforce simp: equiv_valid_def2 equiv_valid_2_def in_monad do_machine_op_def
+                          device_memory_update_def select_f_def idle_equiv_def)
+  apply (rule use_spec_ev)
+  apply (simp add: device_memory_update_def)
+  apply (rule do_machine_op_spec_reads_respects)
+   apply (simp add: equiv_valid_def2)
+   apply (rule modify_ev2)
+   apply (fastforce intro: map_add_eq equiv_forI elim: equiv_forE split: option.splits)
+  apply (wp | simp)+
+  done
+
 end
 
 end

--- a/proof/infoflow/refine/ADT_IF_Refine.thy
+++ b/proof/infoflow/refine/ADT_IF_Refine.thy
@@ -5,35 +5,300 @@
  *)
 
 theory ADT_IF_Refine
-imports "InfoFlow.ADT_IF" "Refine.EmptyFail_H"
+imports "InfoFlow.ArchADT_IF" "Refine.EmptyFail_H"
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 definition kernelEntry_if where
   "kernelEntry_if e tc \<equiv> do
-    t \<leftarrow> getCurThread;
-    threadSet (tcbArch_update (atcbContextSet tc)) t;
-    r \<leftarrow> handleEvent e;
-    stateAssert (\<lambda>s. valid_domain_list' s \<and>
-                     (e \<noteq> Interrupt \<longrightarrow> 0 < ksDomainTime s) \<and>
-                     (e = Interrupt \<longrightarrow> ksDomainTime s = 0 \<longrightarrow>
-                       ksSchedulerAction s = ChooseNewThread)) [];
-    return (r,tc)
-  od"
+     t \<leftarrow> getCurThread;
+     threadSet (tcbArch_update (atcbContextSet tc)) t;
+     r \<leftarrow> handleEvent e;
+     stateAssert
+       (\<lambda>s. valid_domain_list' s \<and> (e \<noteq> Interrupt \<longrightarrow> 0 < ksDomainTime s) \<and>
+            (e = Interrupt \<longrightarrow> ksDomainTime s = 0 \<longrightarrow> ksSchedulerAction s = ChooseNewThread)) [];
+     return (r,tc)
+   od"
 
 crunch (empty_fail) empty_fail: kernelEntry_if
 
-definition prod_lift where "prod_lift R r r' \<equiv> R (fst r) (fst r') \<and> (snd r) = (snd r')"
+definition kernelExit_if where
+  "kernelExit_if tc \<equiv> do
+     t' \<leftarrow> getCurThread;
+     threadGet (atcbContextGet o tcbArch) t'
+   od"
+
+definition kernelExit_H_if where
+  "kernelExit_H_if \<equiv>
+     {(s, m, s'). s' \<in> fst (split kernelExit_if s) \<and>
+                  m = (if ct_running' (snd s') then InUserMode else InIdleMode)}"
+
+definition has_srel_state where
+  "has_srel_state srel P \<equiv> {s. \<exists>s'. (s,s') \<in> srel \<and> s' \<in> P}"
+
+definition lift_fst_rel where
+  "lift_fst_rel srel \<equiv> {(r,r'). snd r = snd r' \<and> (fst r, fst r') \<in> srel}"
+
+(* Includes serializability *)
+definition step_corres where
+  "step_corres nf sr mode G G' \<equiv> \<lambda>ma mc.
+     \<forall>(s,s')\<in>sr. (s',mode) \<in> G' \<and> (s,mode) \<in> G
+                  \<longrightarrow> ((nf \<longrightarrow> (\<exists>e' t'. (s',e',t') \<in> mc)) \<and>
+                       (\<forall>e' t'. (s',e',t') \<in> mc \<longrightarrow> (\<exists>e t. (s,e,t) \<in> ma \<and> (t,t') \<in> sr \<and> e = e')))"
+
+definition lift_snd_rel where
+  "lift_snd_rel srel \<equiv> {(r,r'). fst r = fst r' \<and> (snd r, snd r') \<in> srel}"
+
+definition preserves where
+  "preserves mode mode' P f \<equiv> \<forall>(s,e,s') \<in> f. (s,mode) \<in> P \<longrightarrow> (s',mode') \<in> P"
+
+(* Special case for KernelExit *)
+definition preserves' where
+  "preserves' mode P f \<equiv> \<forall>(s,e,s') \<in> f. (s,mode) \<in> P \<longrightarrow> (s',e) \<in> P"
+
+crunch (empty_fail) empty_fail: kernelExit_if
+
+definition prod_lift where
+  "prod_lift R r r' \<equiv> R (fst r) (fst r') \<and> (snd r) = (snd r')"
+
+definition handlePreemption_if :: "user_context \<Rightarrow> user_context kernel" where
+  "handlePreemption_if tc \<equiv> do
+     irq \<leftarrow> doMachineOp (getActiveIRQ False);
+     when (irq \<noteq> None) $ handleInterrupt (the irq);
+     stateAssert
+       (\<lambda>s. (ksDomainTime s = 0 \<longrightarrow> ksSchedulerAction s = ChooseNewThread) \<and> valid_domain_list' s) [];
+     return tc
+   od"
+
+crunch (empty_fail) empty_fail: handlePreemption_if
+
+definition handlePreemption_H_if where
+  "handlePreemption_H_if \<equiv> {(s, u, s'). s' \<in> fst (split handlePreemption_if s)}"
+
+definition schedule'_if :: "user_context \<Rightarrow> user_context kernel" where
+  "schedule'_if tc \<equiv> do
+     schedule;
+     activateThread;
+     stateAssert (\<lambda>s. 0 < ksDomainTime s \<and> valid_domain_list' s) [];
+     return tc
+   od"
+
+crunch (empty_fail) empty_fail: schedule'_if
+
+definition schedule'_H_if where
+  "schedule'_H_if \<equiv> {(s, e, s'). s' \<in> fst (split schedule'_if s)}"
+
+definition checkActiveIRQ_if :: "user_context \<Rightarrow> (irq option \<times> user_context) kernel" where
+  "checkActiveIRQ_if tc \<equiv> do
+     irq \<leftarrow> doMachineOp (getActiveIRQ False);
+     return (irq, tc)
+   od"
+
+crunch (empty_fail) empty_fail: checkActiveIRQ_if
+
+definition checkActiveIRQ_H_if where
+  "checkActiveIRQ_H_if \<equiv>
+     {((tc, s), irq, (tc', s')). ((irq, tc'), s') \<in> fst (checkActiveIRQ_if tc s)}"
+
+definition kernelCall_H_if where
+  "kernelCall_H_if e \<equiv>
+     {(s, b, (tc,s')) | s b tc s' r. ((r,tc),s') \<in> fst (split (kernelEntry_if e) s) \<and>
+                                     b = (case r of Inl _ \<Rightarrow> True | Inr _ \<Rightarrow> False)}"
+
+definition
+  "ptable_rights_s' s \<equiv> ptable_rights (ksCurThread s) (absKState s)"
+
+definition
+  "ptable_lift_s' s \<equiv> ptable_lift (ksCurThread s) (absKState s)"
+
+
+lemma kernel_entry_if_domain_time_inv:
+  "\<lbrace>K (e \<noteq> Interrupt) and (\<lambda>s. P (domain_time s))\<rbrace>
+   kernel_entry_if e tc
+   \<lbrace>\<lambda>_ s. P (domain_time s) \<rbrace>"
+   unfolding kernel_entry_if_def
+   by (wp handle_event_domain_time_inv) simp
+
+lemma kernel_entry_if_valid_domain_time:
+  "\<lbrace>\<lambda>s. 0 < domain_time s\<rbrace>
+   kernel_entry_if Interrupt tc
+   \<lbrace>\<lambda>_ s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
+  unfolding kernel_entry_if_def
+  apply (rule hoare_pre)
+   apply (wp handle_interrupt_valid_domain_time
+          | clarsimp | wpc)+
+     \<comment> \<open>strengthen post of do_machine_op; we know interrupt occurred\<close>
+     apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
+     apply (wp+, simp)
+  done
+
+lemma kernel_entry_if_no_preempt:
+  "\<lbrace>\<top>\<rbrace> kernel_entry_if Interrupt ctx \<lbrace>\<lambda>(interrupt,_) _. interrupt = Inr ()\<rbrace>"
+  unfolding kernel_entry_if_def
+  by (wp | clarsimp intro!: validE_cases_valid)+
+
+lemma kernelExit_inv[wp]:
+  "kernelExit_if tc \<lbrace>P\<rbrace>"
+  by (wpsimp simp: kernelExit_if_def)
+
+lemma corres_ex_abs_lift:
+  "\<lbrakk> corres r S P' f f'; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace> \<rbrakk>
+     \<Longrightarrow> \<lbrace>ex_abs (P and S) and P'\<rbrace> f' \<lbrace>\<lambda>_. ex_abs Q\<rbrace>"
+  by (fastforce simp: corres_underlying_def valid_def ex_abs_def)
+
+lemmas schedaction_related = sched_act_rct_related
+
+lemma empty_fail_select_bind: "empty_fail (assert (S \<noteq> {}) >>= (\<lambda>_. select S))"
+  by (clarsimp simp: empty_fail_def select_def assert_def)
+
+crunch (empty_fail) empty_fail[wp]: user_memory_update
+crunch (empty_fail) empty_fail[wp]: device_memory_update
+
+lemma corres_gets_same:
+  assumes equiv: "\<And>s s'. \<lbrakk>P s; Q s'; (s, s') \<in> sr\<rbrakk>\<Longrightarrow> f s = g s'"
+  and rimp : "\<And>s. P s \<Longrightarrow> R (f s) s"
+  and corres: "\<And>r.  corres_underlying sr b c rr (P and (R r) and (\<lambda>s. r = f s)) Q (n r) (m r)"
+  shows "corres_underlying sr b c rr P Q (do r \<leftarrow> gets f; n r od) (do r \<leftarrow> gets g; m r od)"
+  apply (rule corres_guard_imp)
+    apply (rule corres_split_deprecated[where r' = "(=)"])
+       apply simp
+       apply (rule corres)
+      apply clarsimp
+      apply (rule equiv)
+        apply (wp|simp)+
+   apply (simp add: rimp)
+  apply simp
+  done
+
+lemma corres_assert_imp_r:
+  "\<lbrakk> \<And>s. P s \<Longrightarrow> Q'; corres_underlying state_relation a b rr P Q f (g ()) \<rbrakk>
+     \<Longrightarrow> corres_underlying state_relation a b rr P Q f (assert Q' >>= g)"
+  by (force simp: corres_underlying_def assert_def return_def bind_def fail_def)
+
+lemma corres_return_same_trivial:
+  "corres_underlying sr b c (=) \<top> \<top> (return a) (return a)"
+  by simp
+
+crunch (no_fail) no_fail[wp]: device_memory_update
+
+lemma corres_ex_abs_lift':
+  "\<lbrakk> corres_underlying state_relation False False r S P' f f'; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace> \<rbrakk>
+     \<Longrightarrow> \<lbrace>ex_abs (P and S) and P'\<rbrace> f' \<lbrace>\<lambda>_. ex_abs Q\<rbrace>"
+  by (fastforce simp: corres_underlying_def valid_def ex_abs_def)
+
+lemma getCurThread_corres':
+  "corres_underlying state_relation nf nf' (=) \<top> \<top> (gets cur_thread) getCurThread"
+  by (simp add: getCurThread_def curthread_relation)
+
+lemma user_mem_corres':
+  "corres_underlying state_relation nf nf' (=) invs invs'
+                     (gets (\<lambda>x. g (user_mem x))) (gets (\<lambda>x. g (user_mem' x)))"
+  by (clarsimp simp: gets_def get_def return_def bind_def invs_def invs'_def
+                     corres_underlying_def user_mem_relation)
+
+lemma corres_machine_op':
+  assumes P: "corres_underlying Id nf nf' r P Q x x'"
+  shows "corres_underlying state_relation nf nf' r (P \<circ> machine_state) (Q \<circ> ksMachineState)
+                           (do_machine_op x) (doMachineOp x')"
+  apply (rule corres_submonad3[OF submonad_do_machine_op submonad_doMachineOp _ _ _ _ P])
+  by (auto simp: state_relation_def swp_def)
+
+lemma corres_assert':
+  "corres_underlying sr nf False dc \<top> \<top> (assert P) (assert P)"
+  by (clarsimp simp: corres_underlying_def assert_def return_def fail_def)
+
+
+consts arch_extras :: "kernel_state \<Rightarrow> bool"
+
+locale ADT_IF_Refine_1 =
+  fixes doUserOp_if :: "user_transition_if \<Rightarrow> user_context \<Rightarrow> (event option \<times> user_context) kernel"
+  assumes arch_tcb_context_set_tcb_relation:
+    "tcb_relation tcb tcb'
+     \<Longrightarrow> tcb_relation (tcb\<lparr>tcb_arch := arch_tcb_context_set tc (tcb_arch tcb)\<rparr>)
+                      (tcbArch_update (atcbContextSet tc) tcb')"
+  and arch_tcb_context_get_atcbContextGet:
+    "tcb_relation tcb tcb'
+     \<Longrightarrow> (arch_tcb_context_get \<circ> tcb_arch) tcb = (atcbContextGet \<circ> tcbArch) tcb'"
+  and doUserOp_if_empty_fail:
+    "empty_fail (doUserOp_if uop tc)"
+  and do_user_op_if_corres:
+    "corres (=) (einvs and ct_running and (\<lambda>_. \<forall>t pl pr pxn tcu. f t pl pr pxn tcu \<noteq> {}))
+                (invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_running')
+                (do_user_op_if f tc) (doUserOp_if f tc)"
+  and doUserOp_if_invs'[wp]:
+    "\<lbrace>invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_running' and ex_abs (einvs)\<rbrace>
+     doUserOp_if f tc
+     \<lbrace>\<lambda>_. invs'\<rbrace>"
+  and doUserOp_arch_extras[wp]:
+    "doUserOp_if f tc \<lbrace>arch_extras\<rbrace>"
+  and doUserOp_if_schedact[wp]:
+    "\<And>P. doUserOp_if f tc \<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace>"
+  and doUserOp_if_st_tcb_at[wp]:
+    "doUserOp_if f tc \<lbrace>st_tcb_at' st t\<rbrace>"
+  and doUserOp_if_cur_thread[wp]:
+    "\<And>P. doUserOp_if f tc \<lbrace>\<lambda>s. P (ksCurThread s)\<rbrace>"
+  and do_user_op_if_corres':
+    "corres_underlying state_relation nf False (=) (einvs and ct_running)
+       (invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_running')
+       (do_user_op_if f tc) (doUserOp_if f tc)"
+  and dmo_getActiveIRQ_corres:
+    "corres (=) \<top> \<top> (do_machine_op (getActiveIRQ in_kernel)) (doMachineOp (getActiveIRQ in_kernel'))"
+  and dmo'_getActiveIRQ_wp:
+    "\<lbrace>\<lambda>s. P (irq_at (irq_state (ksMachineState s) + 1) (irq_masks (ksMachineState s)))
+            (s\<lparr>ksMachineState := (ksMachineState s\<lparr>irq_state := irq_state (ksMachineState s) + 1\<rparr>)\<rparr>)\<rbrace>
+     doMachineOp (getActiveIRQ in_kernel)
+     \<lbrace>P\<rbrace>"
+  and handlePreemption_arch_extras[wp]:
+    "handlePreemption_if tc \<lbrace>arch_extras\<rbrace>"
+  and scheduler_if'_arch_extras[wp]:
+    "\<lbrace>invs' and arch_extras\<rbrace>
+     schedule'_if tc
+     \<lbrace>\<lambda>_. arch_extras\<rbrace>"
+  and checkActiveIRQ_ksPSpace[wp]:
+    "checkActiveIRQ_if tc \<lbrace>arch_extras\<rbrace>"
+  and kernelEntry_invs'[wp]:
+    "\<lbrace>invs' and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s)
+            and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
+            and arch_extras\<rbrace>
+     kernelEntry_if e tc
+     \<lbrace>\<lambda>_. invs'\<rbrace>"
+  and kernelEntry_arch_extras[wp]:
+    "\<lbrace>invs' and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s)
+            and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
+            and arch_extras\<rbrace>
+     kernelEntry_if e tc
+     \<lbrace>\<lambda>_. arch_extras\<rbrace>"
+  and threadSet_arch_extras[wp]:
+    "threadSet a b \<lbrace>arch_extras\<rbrace>"
+  and handle_preemption_if_corres:
+    "corres (=) (einvs and valid_domain_list and (\<lambda>s. 0 < domain_time s)) (invs')
+                (handle_preemption_if tc) (handlePreemption_if tc)"
+  and doUserOp_if_ksDomainTime_inv[wp]:
+    "\<And>P. doUserOp_if uop tc \<lbrace>\<lambda>s. P (ksDomainTime s)\<rbrace>"
+  and doUserOp_if_ksDomSchedule_inv[wp]:
+    "\<And>P. doUserOp_if uop tc \<lbrace>\<lambda>s. P (ksDomSchedule s)\<rbrace>"
+  and valid_device_abs_state_eq:
+    "valid_machine_state (s :: det_state) \<Longrightarrow> abs_state s = s"
+  and doUserOp_if_no_interrupt:
+    "\<lbrace>K (uop_sane uop)\<rbrace> doUserOp_if uop tc \<lbrace>\<lambda>r s. (fst r) \<noteq> Some Interrupt\<rbrace>"
+  and handleEvent_corres_arch_extras:
+    "corres (dc \<oplus> dc)
+       (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s)
+              and (\<lambda>s. scheduler_action s = resume_cur_thread))
+       (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s)
+              and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
+              and arch_extras)
+       (handle_event event) (handleEvent event)"
+begin
 
 lemma kernel_entry_if_corres:
-  "corres (prod_lift (dc \<oplus> dc)) (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and
-                       (\<lambda>s. scheduler_action s = resume_cur_thread) and
-                       (\<lambda>s. 0 < domain_time s) and valid_domain_list)
-                      (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and
-                       (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
-                       (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
-                      (kernel_entry_if event tc) (kernelEntry_if event tc)"
+  "corres (prod_lift (dc \<oplus> dc))
+     (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s)
+            and (\<lambda>s. scheduler_action s = resume_cur_thread)
+            and (\<lambda>s. 0 < domain_time s) and valid_domain_list)
+     (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s)
+            and arch_extras
+            and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
+     (kernel_entry_if event tc) (kernelEntry_if event tc)"
   apply (simp add: kernel_entry_if_def kernelEntry_if_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ getCurThread_corres])
@@ -41,14 +306,11 @@ lemma kernel_entry_if_corres:
          prefer 2
          apply simp
          apply (rule threadset_corresT)
-            apply (simp add: tcb_relation_def
-                             arch_tcb_relation_def
-                             arch_tcb_context_set_def
-                             atcbContextSet_def)
+            apply (erule arch_tcb_context_set_tcb_relation)
            apply (clarsimp simp: tcb_cap_cases_def)
-          apply (clarsimp simp: tcb_cte_cases_def)
+          apply (rule allI[OF ball_tcb_cte_casesI]; clarsimp)
          apply (simp add: exst_same_def)
-        apply (rule corres_split_deprecated [OF _ handleEvent_corres])
+        apply (rule corres_split_deprecated [OF _ handleEvent_corres_arch_extras])
           apply (rule corres_stateAssert_assume_stronger[where Q=\<top> and
                         P="\<lambda>s. valid_domain_list s \<and>
                                (event \<noteq> Interrupt \<longrightarrow> 0 < domain_time s) \<and>
@@ -56,79 +318,20 @@ lemma kernel_entry_if_corres:
                                  scheduler_action s = choose_new_thread)"])
            apply (clarsimp simp: prod_lift_def)
           apply (clarsimp simp: state_relation_def)
-         apply (wp hoare_TrueI threadSet_invs_trivial thread_set_invs_trivial
-                   thread_set_not_state_valid_sched thread_set_ct_running threadSet_ct_running'
-                   hoare_vcg_const_imp_lift handle_event_domain_time_inv
-                   handle_interrupt_valid_domain_time
-               | simp add: tcb_cap_cases_def | wpc | wp (once) hoare_drop_imps)+
-   apply (force simp: invs_def cur_tcb_def)
+         apply (wp hoare_TrueI threadSet_invs_trivial thread_set_invs_trivial thread_set_ct_running
+                   threadSet_ct_running' thread_set_not_state_valid_sched hoare_vcg_const_imp_lift
+                   handle_event_domain_time_inv handle_interrupt_valid_domain_time
+                | simp add: tcb_cap_cases_def | wpc | wp (once) hoare_drop_imps)+
+   apply (fastforce simp: invs_def cur_tcb_def)
   apply force
   done
 
-lemma kernelEntry_invs'[wp]:
-  "\<lbrace>invs' and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s) and
-           (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
-           (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>
-    kernelEntry_if e tc \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: kernelEntry_if_def)
-  apply (wp threadSet_invs_trivial threadSet_ct_running' static_imp_wp
-         | wp (once) hoare_drop_imps
-         | clarsimp)+
-  done
-
-lemma kernelEntry_valid_duplicates[wp]:
-  "\<lbrace>invs' and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s) and
-           (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
-           (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>
-    kernelEntry_if e tc \<lbrace>\<lambda>_. (\<lambda>s. vs_valid_duplicates' (ksPSpace s))\<rbrace>"
-  apply (simp add: kernelEntry_if_def)
-  apply (wp handleEvent_valid_duplicates'
-            threadSet_invs_trivial threadSet_ct_running' static_imp_wp
-         | wp (once) hoare_drop_imps
-         | clarsimp)+
-  done
-
-
-lemma kernel_entry_if_domain_time_inv:
-  "\<lbrace> K (e \<noteq> Interrupt) and (\<lambda>s. P (domain_time s)) \<rbrace>
-   kernel_entry_if e tc
-   \<lbrace>\<lambda>_ s. P (domain_time s) \<rbrace>"
-   unfolding kernel_entry_if_def
-   by (wp handle_event_domain_time_inv) simp
-
-lemma kernel_entry_if_valid_domain_time:
-  "\<lbrace>\<lambda>s. 0 < domain_time s \<rbrace>
-   kernel_entry_if Interrupt tc
-   \<lbrace>\<lambda>_ s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread  \<rbrace>"
-   unfolding kernel_entry_if_def
-   apply (rule hoare_pre)
-    apply (wp handle_interrupt_valid_domain_time
-           | clarsimp | wpc)+
-   \<comment> \<open>strengthen post of do_machine_op; we know interrupt occurred\<close>
-   apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
-   apply (wp+, simp)
-   done
-
-lemma kernel_entry_if_no_preempt:
-  "\<lbrace> \<top> \<rbrace> kernel_entry_if Interrupt ctx \<lbrace>\<lambda>(interrupt,_) _. interrupt = Inr () \<rbrace>"
-  unfolding kernel_entry_if_def
-  by (wp | clarsimp intro!: validE_cases_valid)+
-
-lemma corres_ex_abs_lift:
-  "\<lbrakk>corres r S P' f f'; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace>\<rbrakk> \<Longrightarrow>
-   \<lbrace>ex_abs (P and S) and P'\<rbrace> f' \<lbrace>\<lambda>_. ex_abs Q\<rbrace>"
-  apply (clarsimp simp: corres_underlying_def valid_def ex_abs_def)
-  apply fastforce
-  done
-
-lemmas schedaction_related = sched_act_rct_related
-
 lemma kernelEntry_ex_abs[wp]:
   "\<lbrace>invs' and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s) and (ct_running' or ct_idle')
-      and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))
-      and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
-      and (\<lambda>s. 0 < ksDomainTime s) and valid_domain_list'
-      and ex_abs (einvs)\<rbrace>
+          and arch_extras
+          and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
+          and (\<lambda>s. 0 < ksDomainTime s) and valid_domain_list'
+          and ex_abs (einvs)\<rbrace>
    kernelEntry_if e tc
    \<lbrace>\<lambda>_. ex_abs (einvs)\<rbrace>"
   apply (rule hoare_pre)
@@ -140,552 +343,62 @@ lemma kernelEntry_ex_abs[wp]:
   by (fastforce simp: ct_running_related ct_idle_related schedaction_related
                       active_from_running' active_from_running)
 
-definition
-  kernelCall_H_if
-  where
-  "kernelCall_H_if e \<equiv>
-      {(s, b, (tc,s'))|s b tc s' r. ((r,tc),s') \<in> fst (split (kernelEntry_if e) s) \<and>
-                   b = (case r of Inl _ \<Rightarrow> True | Inr _ \<Rightarrow> False)}"
-
-definition
-  "ptable_rights_s' s \<equiv> ptable_rights (ksCurThread s) (absKState s)"
-
-definition
-  "ptable_lift_s' s \<equiv> ptable_lift (ksCurThread s) (absKState s)"
-
-definition
-  "ptable_attrs_s' s \<equiv> ptable_attrs (ksCurThread s) (absKState s)"
-
-definition
-  "ptable_xn_s' s \<equiv>  \<lambda>addr. XNever \<in> ptable_attrs_s' s addr"
-
-definition doUserOp_if :: "user_transition_if \<Rightarrow> user_context \<Rightarrow> (kernel_state, (event option \<times> user_context)) nondet_monad" where
-  "doUserOp_if uop tc \<equiv>
-  do pr \<leftarrow> gets ptable_rights_s';
-     pxn \<leftarrow> gets (\<lambda>s x. pr x \<noteq> {} \<and> ptable_xn_s' s x);
-     pl \<leftarrow> gets (\<lambda>s. ptable_lift_s' s |` {x. pr x \<noteq> {}});
-     allow_read \<leftarrow> return {y. \<exists>x. pl x = Some y \<and> AllowRead \<in> pr x};
-     allow_write \<leftarrow> return {y. \<exists>x. pl x = Some y \<and> AllowWrite \<in> pr x};
-     t \<leftarrow> getCurThread;
-     um \<leftarrow> gets (\<lambda>s. (user_mem' s \<circ> ptrFromPAddr));
-     dm \<leftarrow> gets (\<lambda>s. (device_mem' s \<circ> ptrFromPAddr));
-     ds \<leftarrow> gets (device_state \<circ> ksMachineState);
-     assert (dom (um \<circ> addrFromPPtr) \<subseteq> - dom ds);
-     assert (dom (dm \<circ> addrFromPPtr) \<subseteq> dom ds);
-     es \<leftarrow> doMachineOp getExMonitor;
-     u \<leftarrow>
-       return
-        (uop t pl pr pxn
-          (tc, um |` allow_read,
-           (ds \<circ> ptrFromPAddr) |` allow_read, es));
-     assert (u \<noteq> {});
-     (e, tc', um',ds', es') \<leftarrow> select u;
-     doMachineOp
-      (user_memory_update
-        ((um' |` allow_write \<circ> addrFromPPtr) |` (- (dom ds))));
-     doMachineOp
-      (device_memory_update
-          ((ds' |` allow_write \<circ> addrFromPPtr) |` dom ds));
-     doMachineOp (setExMonitor es');
-     return (e, tc')
-  od"
-
-lemma empty_fail_select_bind: "empty_fail (assert (S \<noteq> {}) >>= (\<lambda>_. select S))"
-  apply (clarsimp simp: empty_fail_def select_def assert_def)
-  done
-
-crunch (empty_fail) empty_fail[wp]: user_memory_update
-crunch (empty_fail) empty_fail[wp]: device_memory_update
-
-lemma getExMonitor_empty_fail[wp]:
-  "empty_fail getExMonitor"
-  by (simp add: getExMonitor_def)
-
-lemma setExMonitor_empty_fail[wp]:
-  "empty_fail (setExMonitor es)"
-  by (simp add: setExMonitor_def)
-
-lemma getExMonitor_no_fail[wp]:
-  "no_fail \<top> getExMonitor"
-  by (simp add: getExMonitor_def)
-
-lemma setExMonitor_no_fail'[wp]:
-  "no_fail \<top> (setExMonitor (x, y))"
-  by (simp add: setExMonitor_def)
-
-lemma setExMonitor_no_fail[wp]:
-  "no_fail \<top> (setExMonitor es)"
-  by (simp add: setExMonitor_def)
-
-lemma doUserOp_if_empty_fail: "empty_fail (doUserOp_if uop tc)"
-  apply (simp add: doUserOp_if_def)
-  apply (wp (once))
-   apply wp
-  apply (wp (once))
-   apply wp
-  apply (wp (once))
-   apply wp
-  apply (wp (once))
-   apply wp
-  apply (wp (once))
-   apply wp
-  apply (wp (once))
-   apply wp
-  apply (wp (once))
-   apply wp
-  apply (wp (once))
-   apply wp
-  apply (wp (once))
-   apply wp
-  apply (wp (once))
-   apply wp
-  apply (subst bind_assoc[symmetric])
-  apply (rule empty_fail_bind)
-   apply (rule empty_fail_select_bind)
-  apply (wp | wpc)+
-  done
-
-
-lemma ptable_attrs_abs_state[simp]:
-  "ptable_attrs thread (abs_state s) = ptable_attrs thread s"
-  by (simp add: ptable_attrs_def abs_state_def)
-
-lemma corres_gets_same:
-  assumes equiv: "\<And>s s'. \<lbrakk>P s; Q s'; (s, s') \<in> sr\<rbrakk>\<Longrightarrow> f s = g s'"
-     and rimp : "\<And>s. P s \<Longrightarrow> R (f s) s"
-     and corres: "\<And>r.  corres_underlying sr b c rr (P and (R r) and (\<lambda>s. r = f s)) Q (n r) (m r)"
-  shows "corres_underlying sr b c rr P Q
-  (do r \<leftarrow> gets f; n r od)
-  (do r \<leftarrow> gets g; m r od)"
-  apply (rule corres_guard_imp)
-  apply (rule corres_split_deprecated[where r' = "(=)"])
-   apply simp
-   apply (rule corres)
-   apply clarsimp
-   apply (rule equiv)
-   apply (wp|simp)+
-   apply (simp add: rimp)
-  apply simp
-  done
-
-lemma corres_assert_imp_r:
-  "\<lbrakk>\<And>s. P s\<Longrightarrow> Q' ; corres_underlying state_relation a b rr P Q f (g ())\<rbrakk>
-  \<Longrightarrow> corres_underlying state_relation a b rr P Q f (assert Q' >>= g)"
-  by (force simp: corres_underlying_def assert_def return_def bind_def fail_def)
-
-lemma corres_return_same_trivial:
-  "corres_underlying sr b c (=) \<top> \<top> (return a) (return a)"
-  by simp
-
-crunch (no_fail) no_fail[wp]: device_memory_update
-
-lemma do_user_op_if_corres:
-   "corres (=) (einvs and ct_running and (\<lambda>_. \<forall>t pl pr pxn tcu. f t pl pr pxn tcu \<noteq> {}))
-   (invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
-    ct_running')
-   (do_user_op_if f tc) (doUserOp_if f tc)"
-  apply (rule corres_gen_asm)
-  apply (simp add: do_user_op_if_def doUserOp_if_def)
-  apply (rule corres_gets_same)
-    apply (clarsimp simp: ptable_rights_s_def ptable_rights_s'_def)
-    apply (subst absKState_correct, fastforce, assumption+)
-    apply (clarsimp elim!: state_relationE)
-   apply simp
-  apply (rule corres_gets_same)
-    apply (clarsimp simp: ptable_attrs_s'_def ptable_attrs_s_def ptable_xn_s'_def ptable_xn_s_def)
-    apply (subst absKState_correct, fastforce, assumption+)
-    apply (clarsimp elim!: state_relationE)
-   apply simp
-  apply (rule corres_gets_same)
-    apply (clarsimp simp: absArchState_correct curthread_relation ptable_lift_s'_def
-                         ptable_lift_s_def)
-    apply (subst absKState_correct, fastforce, assumption+)
-    apply (clarsimp elim!: state_relationE)
-   apply simp
-  apply (simp add: getCurThread_def)
-  apply (rule corres_gets_same)
-    apply (simp add: curthread_relation)
-   apply simp
-  apply (rule corres_gets_same[where R ="\<lambda>r s. dom (r \<circ> addrFromPPtr) \<subseteq> - device_region s"])
-   apply (clarsimp simp add: user_mem_relation dest!: invs_valid_stateI invs_valid_stateI')
-   apply (clarsimp simp: invs_def valid_state_def pspace_respects_device_region_def)
-   apply fastforce
-  apply (rule corres_gets_same[where R ="\<lambda>r s. dom (r \<circ> addrFromPPtr) \<subseteq> device_region s"])
-   apply (clarsimp simp add: device_mem_relation dest!: invs_valid_stateI invs_valid_stateI')
-   apply (clarsimp simp: invs_def valid_state_def pspace_respects_device_region_def)
-   apply fastforce
-  apply (rule corres_gets_same[where R ="\<lambda>r s. dom r = device_region s"])
-    apply (clarsimp simp: state_relation_def)
-   apply simp
-  apply (rule corres_assert_imp_r)
-   apply fastforce
-  apply (rule corres_assert_imp_r)
-   apply fastforce
-  apply (rule corres_guard_imp)
-       apply (rule corres_split_deprecated[OF _ corres_machine_op,where r'="(=)"])
-         apply clarsimp
-         apply (rule corres_split_deprecated[where r'="(=)"])
-            apply clarsimp
-            apply (rule corres_split_deprecated[OF _ corres_machine_op,where r'="(=)"])
-               apply clarsimp
-               apply (rule corres_split_deprecated[OF _ corres_machine_op,where r'="(=)"])
-                  apply clarsimp
-                  apply (rule corres_split_deprecated[OF _ corres_machine_op, where r'="(=)"])
-                     apply (rule corres_return_same_trivial)
-                    apply (wp hoare_TrueI[where P = \<top>] | simp | rule corres_underlying_trivial)+
-            apply (clarsimp simp: user_memory_update_def)
-            apply (rule non_fail_modify)
-           apply clarsimp
-           apply (wp hoare_TrueI)
-          apply clarsimp
-          apply (wp hoare_TrueI)
-         apply (clarsimp simp: select_def corres_underlying_def)
-         apply (simp only: comp_def | wp hoare_TrueI)+
-      apply (rule corres_underlying_trivial)
-     apply (wp hoare_TrueI)+
-   apply clarsimp
-   apply force
-  apply force
-  done
-
-lemma dmo_getExMonitor_wp'[wp]:
-  "\<lbrace>\<lambda>s. P (exclusive_state (ksMachineState s)) s\<rbrace>
-   doMachineOp getExMonitor \<lbrace>P\<rbrace>"
-  apply(simp add: doMachineOp_def)
-  apply(wp modify_wp | wpc)+
-  apply clarsimp
-  apply(erule use_valid)
-   apply wp
-  apply simp
-  done
-
-lemma dmo_setExMonitor_wp'[wp]:
-  "\<lbrace>\<lambda>s. P (s\<lparr>ksMachineState := ksMachineState s
-             \<lparr>exclusive_state := es\<rparr>\<rparr>)\<rbrace>
-   doMachineOp (setExMonitor es) \<lbrace>\<lambda>_. P\<rbrace>"
-  apply(simp add: doMachineOp_def)
-  apply(wp modify_wp | wpc)+
-  apply clarsimp
-  apply(erule use_valid)
-   apply wp
-  apply simp
-  done
-
-lemma valid_state'_exclusive_state_update[iff]:
-  "valid_state' (s\<lparr>ksMachineState := ksMachineState s\<lparr>exclusive_state := es\<rparr>\<rparr>) = valid_state' s"
-  by (simp add: valid_state'_def valid_machine_state'_def)
-
-lemma invs'_exclusive_state_update[iff]:
-  "invs' (s\<lparr>ksMachineState := ksMachineState s\<lparr>exclusive_state := es\<rparr>\<rparr>) = invs' s"
-  by (simp add: invs'_def)
-
-lemma doUserOp_if_invs'[wp]:
-   "\<lbrace>invs'  and
-    (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
-    ct_running' and ex_abs (einvs)\<rbrace>
-   doUserOp_if f tc
-  \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: doUserOp_if_def split_def ex_abs_def)
-  apply (wp device_update_invs' dmo_setExMonitor_wp' dmo_invs' | simp)+
-         apply (clarsimp simp add: no_irq_modify user_memory_update_def)
-         apply wpsimp
-        apply (wp select_wp)+
-  apply (clarsimp simp: user_memory_update_def simpler_modify_def
-                        restrict_map_def
-                  split: option.splits)
-  apply (drule ptable_rights_imp_UserData[rotated 2], auto simp: ptable_rights_s'_def ptable_lift_s'_def)
-  done
-
-lemma doUserOp_valid_duplicates[wp]:
-  "\<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace> doUserOp_if f tc
-  \<lbrace>\<lambda>_ s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
-  apply (simp add: doUserOp_if_def split_def)
-  apply (wp dmo_setExMonitor_wp' dmo_invs' select_wp | simp)+
-  done
-
-lemma doUserOp_if_schedact[wp]:
-   "\<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace>
-      doUserOp_if f tc
-     \<lbrace>\<lambda>r s. P (ksSchedulerAction s)\<rbrace>"
-  apply (simp add: doUserOp_if_def)
-  apply (wp select_wp | wpc | simp)+
-  done
-
-lemma doUserOp_if_st_tcb_at[wp]:
-   "\<lbrace>st_tcb_at' st t\<rbrace>
-      doUserOp_if f tc
-     \<lbrace>\<lambda>_. st_tcb_at' st t\<rbrace>"
-  apply (simp add: doUserOp_if_def)
-  apply (wp select_wp | wpc | simp)+
-  done
-
-lemma doUserOp_if_cur_thread[wp]:
-  "\<lbrace>\<lambda>s. P (ksCurThread s)\<rbrace> doUserOp_if f tc
-   \<lbrace>\<lambda>r s. P (ksCurThread s)\<rbrace>"
-  apply (simp add: doUserOp_if_def)
-  apply (wp select_wp | wpc | simp)+
-  done
-
-
 lemma doUserOp_if_ct_in_state[wp]:
-  "\<lbrace>ct_in_state' st\<rbrace>
-    doUserOp_if f tc
-   \<lbrace>\<lambda>_. ct_in_state' st\<rbrace>"
-  apply (rule hoare_pre)
-   apply (rule ct_in_state_thread_state_lift')
-    apply (wp | simp)+
-  done
-
-
-lemma corres_ex_abs_lift':
-  "\<lbrakk>corres_underlying state_relation False False r S P' f f'; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace>\<rbrakk> \<Longrightarrow>
-   \<lbrace>ex_abs (P and S) and P'\<rbrace> f' \<lbrace>\<lambda>_. ex_abs Q\<rbrace>"
-  apply (clarsimp simp: corres_underlying_def valid_def ex_abs_def)
-  apply fastforce
-  done
-
-lemma getCurThread_corres': "corres_underlying state_relation nf nf' (=) \<top> \<top> (gets cur_thread) getCurThread"
-  by (simp add: getCurThread_def curthread_relation)
-
-lemma user_mem_corres':
-  "corres_underlying state_relation nf nf' (=) invs invs' (gets (\<lambda>x. g (user_mem x))) (gets (\<lambda>x. g (user_mem' x)))"
-  by (clarsimp simp add: gets_def get_def return_def bind_def
-                         invs_def invs'_def
-                         corres_underlying_def user_mem_relation)
-
-lemma corres_machine_op':
-  assumes P: "corres_underlying Id nf nf' r P Q x x'"
-  shows      "corres_underlying state_relation nf nf' r (P \<circ> machine_state) (Q \<circ> ksMachineState)
-                       (do_machine_op x) (doMachineOp x')"
-  apply (rule corres_submonad3
-              [OF submonad_do_machine_op submonad_doMachineOp _ _ _ _ P])
-   apply (simp_all add: state_relation_def swp_def)
-  done
-
-lemma corres_assert':
-  "corres_underlying sr nf False dc \<top> \<top> (assert P) (assert P)"
-  by (clarsimp simp: corres_underlying_def assert_def return_def fail_def)
-
-lemma do_user_op_if_corres':
-   "corres_underlying state_relation nf False (=) (einvs and ct_running)
-   (invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
-    ct_running')
-   (do_user_op_if f tc) (doUserOp_if f tc)"
-  apply (simp add: do_user_op_if_def doUserOp_if_def)
-  apply (rule corres_gets_same)
-    apply (clarsimp simp: ptable_rights_s_def ptable_rights_s'_def)
-    apply (subst absKState_correct, fastforce, assumption+)
-    apply (clarsimp elim!: state_relationE)
-   apply simp
-  apply (rule corres_gets_same)
-    apply (clarsimp simp: ptable_attrs_s'_def ptable_attrs_s_def ptable_xn_s'_def ptable_xn_s_def)
-    apply (subst absKState_correct, fastforce, assumption+)
-    apply (clarsimp elim!: state_relationE)
-   apply simp
-  apply (rule corres_gets_same)
-    apply (clarsimp simp: absArchState_correct curthread_relation ptable_lift_s'_def
-                         ptable_lift_s_def)
-    apply (subst absKState_correct, fastforce, assumption+)
-    apply (clarsimp elim!: state_relationE)
-   apply simp
-  apply (simp add: getCurThread_def)
-  apply (rule corres_gets_same)
-    apply (simp add: curthread_relation)
-   apply simp
-  apply (rule corres_gets_same[where R ="\<lambda>r s. dom (r \<circ> addrFromPPtr) \<subseteq> - device_region s"])
-   apply (clarsimp simp add: user_mem_relation dest!: invs_valid_stateI invs_valid_stateI')
-   apply (clarsimp simp: invs_def valid_state_def pspace_respects_device_region_def)
-   apply fastforce
-  apply (rule corres_gets_same[where R ="\<lambda>r s. dom (r \<circ> addrFromPPtr) \<subseteq> device_region s"])
-   apply (clarsimp simp add: device_mem_relation dest!: invs_valid_stateI invs_valid_stateI')
-   apply (clarsimp simp: invs_def valid_state_def pspace_respects_device_region_def dom_def)
-  apply (rule corres_gets_same[where R ="\<lambda>r s. dom r = device_region s"])
-    apply (clarsimp simp: state_relation_def)
-   apply simp
-  apply (rule corres_assert_imp_r)
-   apply fastforce
-  apply (rule corres_assert_imp_r)
-   apply fastforce
-  apply (rule corres_guard_imp)
-       apply (rule corres_split_deprecated[OF _ corres_machine_op',where r'="(=)"])
-         apply simp
-         apply (rule corres_split_deprecated[where r'="dc"])
-            apply simp
-            apply (rule corres_split_deprecated[where r'="(=)"])
-               apply clarsimp
-               apply (rule corres_split_deprecated[OF _ corres_machine_op',where r'="(=)"])
-                  apply simp
-                  apply (rule corres_split_deprecated[OF _ corres_machine_op', where r'="(=)"])
-                     apply simp
-                     apply (rule corres_split_deprecated[OF _ corres_machine_op', where r'="(=)"])
-                     apply (rule corres_return_same_trivial)
-                    apply (wp hoare_TrueI[where P = \<top>] | simp | rule corres_underlying_trivial)+
-           apply (clarsimp simp: select_def corres_underlying_def)
-           apply (simp only: comp_def | wp hoare_TrueI)+
-       apply (rule corres_assert')
-       apply (wp hoare_TrueI[where P = \<top>] | simp | rule corres_underlying_trivial)+
-   apply clarsimp
-   apply force
-  apply force
-  done
+  "doUserOp_if f tc \<lbrace>ct_in_state' st\<rbrace>"
+   by (wpsimp wp: ct_in_state_thread_state_lift')
 
 lemma doUserOp_if_ex_abs[wp]:
-   "\<lbrace>invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_running' and ex_abs (einvs)\<rbrace>
-  doUserOp_if f tc
-\<lbrace>\<lambda>_. ex_abs (einvs)\<rbrace>"
+  "\<lbrace>invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_running' and ex_abs (einvs)\<rbrace>
+   doUserOp_if f tc
+   \<lbrace>\<lambda>_. ex_abs (einvs)\<rbrace>"
   apply (rule hoare_pre)
    apply (rule corres_ex_abs_lift'[OF do_user_op_if_corres'])
-   apply (rule_tac Q="\<lambda>a . (invs and ct_running) and valid_list and valid_sched" in hoare_strengthen_post)
+   apply (rule_tac Q="\<lambda>a. invs and ct_running and valid_list and valid_sched" in hoare_strengthen_post)
     apply (wp do_user_op_if_invs)
    apply clarsimp
   apply (clarsimp simp: ex_abs_def)
   apply (rule_tac x=sa in exI)
-  apply (clarsimp simp: active_from_running ct_running_related
-                          schedaction_related)+
+  apply (clarsimp simp: active_from_running ct_running_related schedaction_related)+
   done
-
-
-
-definition
-  doUserOp_H_if
-  where
-  "doUserOp_H_if uop \<equiv> {(s,e,(tc,s'))| s e tc s'. ((e,tc),s') \<in> fst (split (doUserOp_if uop) s)}"
-
-definition checkActiveIRQ_if :: "(MachineTypes.register \<Rightarrow> 32 word) \<Rightarrow> (10 word option \<times> (MachineTypes.register \<Rightarrow> 32 word)) kernel" where
-"checkActiveIRQ_if tc \<equiv>
-do
-   irq \<leftarrow> doMachineOp (getActiveIRQ False);
-   return (irq, tc)
-od"
-
-crunch (empty_fail) empty_fail: checkActiveIRQ_if
-
-
-lemma getActiveIRQ_nf: "no_fail (\<lambda>_. True) (getActiveIRQ in_kernel)"
-  apply (simp add: getActiveIRQ_def)
-  apply (rule no_fail_pre)
-   apply (rule non_fail_gets non_fail_modify
-               no_fail_return | rule no_fail_bind | simp
-          | intro impI conjI)+
-     apply (wp del: no_irq | simp)+
-  done
-
-lemma dmo_getActiveIRQ_corres: "corres (=) \<top> \<top> (do_machine_op (getActiveIRQ in_kernel))
-     (doMachineOp (getActiveIRQ in_kernel'))"
-  apply (rule SubMonad_R.corres_machine_op)
-     apply (rule corres_Id)
-       apply (simp add: getActiveIRQ_def non_kernel_IRQs_def)
-      apply simp
-     apply (rule getActiveIRQ_nf)
-   done
 
 lemma check_active_irq_if_corres:
   "corres (=) \<top> \<top> (check_active_irq_if tc) (checkActiveIRQ_if tc)"
   apply (simp add: checkActiveIRQ_if_def check_active_irq_if_def)
   apply (rule corres_underlying_split[where r'="(=)"])
-  apply (rule dmo_getActiveIRQ_corres)
-  apply wp+
+     apply (rule dmo_getActiveIRQ_corres)
+    apply wp+
   apply clarsimp
-  done
-
-lemma dmo'_getActiveIRQ_wp:
-  "\<lbrace>\<lambda>s. P (irq_at (irq_state (ksMachineState s) + 1) (irq_masks (ksMachineState s))) (s\<lparr>ksMachineState := (ksMachineState s\<lparr>irq_state := irq_state (ksMachineState s) + 1\<rparr>)\<rparr>)\<rbrace> doMachineOp (getActiveIRQ in_kernel)\<lbrace>P\<rbrace>"
-  apply(simp add: doMachineOp_def getActiveIRQ_def non_kernel_IRQs_def)
-  apply(wp modify_wp | wpc)+
-  apply clarsimp
-  apply(erule use_valid)
-   apply (wp modify_wp)
-  apply(auto simp: irq_at_def)
   done
 
 lemma checkActiveIRQ_if_wp:
-  "\<lbrace>\<lambda>s. P ((irq_at (irq_state (ksMachineState s) + 1) (irq_masks (ksMachineState s))),tc)
-           (s\<lparr>ksMachineState := (ksMachineState s\<lparr>irq_state := irq_state (ksMachineState s) + 1\<rparr>)\<rparr>)\<rbrace> checkActiveIRQ_if tc \<lbrace>P\<rbrace>"
-  apply(simp add: checkActiveIRQ_if_def | wp dmo'_getActiveIRQ_wp)+
-  done
+  "\<lbrace>\<lambda>s. P ((irq_at (irq_state (ksMachineState s) + 1) (irq_masks (ksMachineState s))), tc)
+          (s\<lparr>ksMachineState := (ksMachineState s\<lparr>irq_state := irq_state (ksMachineState s) + 1\<rparr>)\<rparr>)\<rbrace>
+   checkActiveIRQ_if tc
+   \<lbrace>P\<rbrace>"
+  by (simp add: checkActiveIRQ_if_def | wp dmo'_getActiveIRQ_wp)+
 
-lemma checkActiveIRQ_invs'[wp]: "\<lbrace>invs'\<rbrace> checkActiveIRQ_if tc \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (wp checkActiveIRQ_if_wp)
-  apply simp
-  done
+lemma checkActiveIRQ_invs'[wp]:
+  "checkActiveIRQ_if tc \<lbrace>invs'\<rbrace>"
+  by (wpsimp wp: checkActiveIRQ_if_wp)
 
-lemma checkActiveIRQ_ct_in_state[wp]: "\<lbrace>ct_in_state' st\<rbrace> checkActiveIRQ_if tc \<lbrace>\<lambda>_. ct_in_state' st\<rbrace>"
-  apply (wp checkActiveIRQ_if_wp)
-  apply simp
-  done
+lemma checkActiveIRQ_ct_in_state[wp]:
+  "checkActiveIRQ_if tc \<lbrace>ct_in_state' st\<rbrace>"
+  by (wpsimp wp: checkActiveIRQ_if_wp)
 
-lemma checkActiveIRQ_schedact[wp]: "\<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace> checkActiveIRQ_if tc \<lbrace>\<lambda>r s. P (ksSchedulerAction s)\<rbrace>"
-  apply (wp checkActiveIRQ_if_wp)
-  apply simp
-  done
+lemma checkActiveIRQ_schedact[wp]:
+  "checkActiveIRQ_if tc \<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace>"
+  by (wpsimp wp: checkActiveIRQ_if_wp)
 
-lemma checkActiveIRQ_vs_valid_duplicates'[wp]: "\<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace> checkActiveIRQ_if tc \<lbrace>\<lambda>r s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
-  apply (wp checkActiveIRQ_if_wp)
-  apply simp
-  done
-
-
-lemma checkActiveIRQ_ex_abs[wp]: "\<lbrace>ex_abs (einvs)\<rbrace> checkActiveIRQ_if tc \<lbrace>\<lambda>_. ex_abs (einvs)\<rbrace>"
+lemma checkActiveIRQ_ex_abs[wp]:
+  "checkActiveIRQ_if tc \<lbrace>ex_abs (einvs)\<rbrace>"
   apply (rule hoare_pre)
    apply (rule corres_ex_abs_lift[OF check_active_irq_if_corres])
    apply (rule check_active_irq_if_wp)
   apply (clarsimp simp: ex_abs_def)
   done
 
-definition
-  checkActiveIRQ_H_if
-  where
-  "checkActiveIRQ_H_if \<equiv> {((tc, s), irq, (tc', s')). ((irq, tc'), s') \<in> fst (checkActiveIRQ_if tc s)}"
-
-definition
-  handlePreemption_if :: "(MachineTypes.register \<Rightarrow> 32 word) \<Rightarrow> (MachineTypes.register \<Rightarrow> 32 word) kernel" where
-  "handlePreemption_if tc \<equiv> do
-     irq \<leftarrow> doMachineOp (getActiveIRQ False);
-     when (irq \<noteq> None) $ handleInterrupt (the irq);
-     stateAssert (\<lambda>s. (ksDomainTime s = 0 \<longrightarrow> ksSchedulerAction s = ChooseNewThread) \<and>
-                       valid_domain_list' s) [];
-     return tc
-   od"
-
-crunch (empty_fail) empty_fail: handlePreemption_if
-
-lemma handle_preemption_if_corres:
- "corres (=)
-         (einvs and valid_domain_list and (\<lambda>s. 0 < domain_time s))
-         (invs')
-         (handle_preemption_if tc) (handlePreemption_if tc)"
-  apply (simp add: handlePreemption_if_def handle_preemption_if_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[where r'="(=)"])
-       apply (rule corres_split_deprecated[where r'="dc"])
-          apply (rule corres_stateAssert_assume_stronger[where Q=\<top> and
-                        P="\<lambda>s. valid_domain_list s \<and>
-                               (domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread)"])
-           apply simp
-          apply (clarsimp simp: state_relation_def)
-         apply (rule corres_when)
-          apply simp
-         apply simp
-         apply (rule handleInterrupt_corres)
-        apply (wp handle_interrupt_valid_domain_time)+
-      apply (rule dmo_getActiveIRQ_corres)
-     apply (rule dmo_getActiveIRQ_wp)
-    apply (rule dmo'_getActiveIRQ_wp)
-   apply clarsimp+
-  apply (clarsimp simp: invs'_def valid_state'_def irq_at_def invs_def
-                        Let_def valid_irq_states'_def)
-  done
-
 lemma handlePreemption_invs'[wp]:
-  "\<lbrace>invs'\<rbrace> handlePreemption_if tc \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: handlePreemption_if_def)
-  apply (wp dmo'_getActiveIRQ_wp hoare_drop_imps)
-  apply clarsimp
-  done
-
-lemma handlePreemption_if_valid_duplicates[wp]:
-  "\<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace> handlePreemption_if tc
-  \<lbrace>\<lambda>_ s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
+  "handlePreemption_if tc \<lbrace>invs'\<rbrace>"
   apply (simp add: handlePreemption_if_def)
   apply (wp dmo'_getActiveIRQ_wp hoare_drop_imps)
   apply clarsimp
@@ -698,50 +411,33 @@ lemma handlePreemption_ex_abs[wp]:
   apply (rule hoare_pre)
    apply (rule corres_ex_abs_lift[OF handle_preemption_if_corres])
    apply (wp handle_preemption_if_invs)
-  apply (auto simp: ex_abs_def non_kernel_IRQs_def domain_list_rel_eq domain_time_rel_eq)
+  apply (auto simp: ex_abs_def non_kernel_IRQs_empty domain_list_rel_eq domain_time_rel_eq)
   done
+
+end
+
 
 lemma handle_preemption_if_valid_domain_time:
   "\<lbrace>\<lambda>s. 0 < domain_time s \<rbrace>
    handle_preemption_if tc
-   \<lbrace>\<lambda>r s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread \<rbrace>"
-   unfolding handle_preemption_if_def
-   apply (rule hoare_pre)
+   \<lbrace>\<lambda>r s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
+  unfolding handle_preemption_if_def
+  apply (rule hoare_pre)
    apply (wp handle_interrupt_valid_domain_time)
    apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
    apply (wp, simp)
-   done
-
-definition
-  handlePreemption_H_if
-  where
-  "handlePreemption_H_if \<equiv>
-      {(s, u, s'). s' \<in> fst (split handlePreemption_if s)}"
-
-definition
-  schedule'_if :: "(MachineTypes.register \<Rightarrow> 32 word) \<Rightarrow> (MachineTypes.register \<Rightarrow> 32 word) kernel" where
-  "schedule'_if tc \<equiv> do
-     schedule;
-     activateThread;
-     stateAssert (\<lambda>s. 0 < ksDomainTime s \<and> valid_domain_list' s) [];
-     return tc
-   od"
-
-crunch (empty_fail) empty_fail: schedule'_if
-
+  done
 
 lemma schedule_if_corres:
- "corres (=)
-         (invs and valid_sched and valid_list and valid_domain_list and
-          (\<lambda>s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread))
-         (invs')
-         (schedule_if tc) (schedule'_if tc)"
+ "corres (=) (invs and valid_sched and valid_list and valid_domain_list
+                   and (\<lambda>s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread))
+             (invs') (schedule_if tc) (schedule'_if tc)"
   apply (simp add: schedule_if_def schedule'_if_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated[where r'="dc"])
        apply (rule corres_split_deprecated[where r'="dc"])
-          apply (rule corres_stateAssert_assume_stronger[where Q=\<top> and
-                        P="\<lambda>s. valid_domain_list s \<and> 0 < domain_time s"])
+          apply (rule corres_stateAssert_assume_stronger
+                        [where Q=\<top> and P="\<lambda>s. valid_domain_list s \<and> 0 < domain_time s"])
            apply simp
           apply (clarsimp simp: state_relation_def)
          apply (rule activateThread_corres)
@@ -758,7 +454,7 @@ lemma schedule_if'_invs'_post:
   done
 
 lemma schedule_if'_invs'[wp]:
-  "\<lbrace>invs'\<rbrace> schedule'_if tc \<lbrace>\<lambda>_. invs'\<rbrace>"
+  "schedule'_if tc \<lbrace>invs'\<rbrace>"
   apply (rule hoare_post_imp[OF _ schedule_if'_invs'_post])
   apply simp
   done
@@ -769,28 +465,28 @@ lemma schedule_if'_ct_running_or_idle[wp]:
   apply simp
   done
 
-
 lemma schedule_if'_rct[wp]:
   "\<lbrace>invs'\<rbrace> schedule'_if tc \<lbrace>\<lambda>r s. ksSchedulerAction s = ResumeCurrentThread\<rbrace>"
   apply (simp add: schedule'_if_def)
   apply (wp activate_sch_act schedule_sch hoare_drop_imps)
   done
 
+lemma nonzero_gt_zero:
+  "x \<noteq> (0 :: obj_ref) \<Longrightarrow> x > 0"
+  by (simp add: word_gt_0)
 
-lemma scheduler_if'_valid_duplicates[wp]:
-  "\<lbrace>invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))\<rbrace> schedule'_if tc
-  \<lbrace>\<lambda>_ s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
-  apply (simp add: schedule'_if_def)
-  apply (wp hoare_drop_imps | simp)+
-  done
+lemma gt_zero_nonzero:
+  "(0 :: obj_ref) < x \<Longrightarrow> x \<noteq> 0"
+  by (simp add: word_gt_0)
 
 lemma schedule_if_domain_time_left:
-  "\<lbrace>\<lambda>s. valid_domain_list s \<and> (domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread) \<rbrace>
+  "\<lbrace>\<lambda>s. valid_domain_list s \<and> (domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread)\<rbrace>
    schedule_if tc
-   \<lbrace>\<lambda>rv s. 0 < domain_time s \<rbrace>"
+   \<lbrace>\<lambda>rv s. 0 < domain_time s\<rbrace>"
   unfolding schedule_if_def schedule_det_ext_ext_def schedule_switch_thread_fastfail_def
   supply ethread_get_wp[wp del]
   supply if_split[split del]
+  supply nonzero_gt_zero[simp] gt_zero_nonzero[simp]
   apply (rule hoare_pre)
    apply (wpsimp simp: ethread_get_when_def wp: gts_wp
           | wp hoare_drop_imp[where f="ethread_get a b" for a b]
@@ -803,8 +499,8 @@ lemma sched_act_relation_ChooseNewThread[simp]:
   by (cases sca; simp)
 
 lemma scheduler'_if_ex_abs[wp]:
-  "\<lbrace>invs' and ex_abs (einvs) and valid_domain_list' and
-    (\<lambda>s. ksDomainTime s = 0 \<longrightarrow> ksSchedulerAction s = ChooseNewThread)\<rbrace>
+  "\<lbrace>invs' and ex_abs (einvs) and valid_domain_list'
+          and (\<lambda>s. ksDomainTime s = 0 \<longrightarrow> ksSchedulerAction s = ChooseNewThread)\<rbrace>
    schedule'_if tc
    \<lbrace>\<lambda>_. ex_abs (einvs)\<rbrace>"
   apply (rule hoare_pre)
@@ -815,104 +511,6 @@ lemma scheduler'_if_ex_abs[wp]:
   apply (frule state_relation_schact)
   apply (auto simp: domain_list_rel_eq domain_time_rel_eq)
   done
-
-definition
-  schedule'_H_if
-  where
-  "schedule'_H_if \<equiv>
-      {(s, e, s'). s' \<in> fst (split schedule'_if s)}"
-
-definition
-  kernelExit_if
-  where
-  "kernelExit_if tc \<equiv> do
-    t' \<leftarrow> getCurThread;
-    threadGet (atcbContextGet o tcbArch) t'
-  od"
-
-crunch (empty_fail) empty_fail: kernelExit_if
-
-lemma kernel_exit_if_corres:
- "corres (=) (invs)
-   (invs')
-   (kernel_exit_if tc) (kernelExit_if tc)"
-  apply (simp add: kernel_exit_if_def kernelExit_if_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[where r'="(=)"])
-       apply simp
-       apply (rule threadGet_corres)
-       apply (clarsimp simp: tcb_relation_def arch_tcb_relation_def
-                             arch_tcb_context_get_def atcbContextGet_def)
-      apply (rule getCurThread_corres)
-     apply wp+
-   apply clarsimp+
-  done
-
-lemma kernelExit_inv[wp]:
-  "\<lbrace>P\<rbrace> kernelExit_if tc \<lbrace>\<lambda>_. P\<rbrace>"
-  apply (simp add: kernelExit_if_def)
-  apply wp
-  done
-
-
-definition
-  kernelExit_H_if
-  where
-  "kernelExit_H_if \<equiv>
-      {(s, m, s'). s' \<in> fst (split kernelExit_if s) \<and>
-                   m = (if ct_running' (snd s') then InUserMode else InIdleMode)}"
-
-definition full_invs_if' where
-  "full_invs_if' \<equiv>
-  {s. invs' (internal_state_if s)
-      \<and> ex_abs (einvs) (internal_state_if s)
-      \<and> vs_valid_duplicates' (ksPSpace (internal_state_if s))
-      \<and> (snd s \<noteq> KernelSchedule True \<longrightarrow> ksDomainTime (internal_state_if s) > 0)
-      \<and> (ksDomainTime (internal_state_if s) = 0
-           \<longrightarrow> ksSchedulerAction (internal_state_if s) = ChooseNewThread)
-      \<and> valid_domain_list' (internal_state_if s)
-      \<and> (case (snd s)
-          of (KernelEntry e) \<Rightarrow>
-                     (e \<noteq> Interrupt \<longrightarrow> ct_running' (internal_state_if s) \<and>
-                                       ksDomainTime (internal_state_if s) \<noteq> 0) \<and>
-                     (ct_running' (internal_state_if s) \<or> ct_idle' (internal_state_if s)) \<and>
-                     ksSchedulerAction (internal_state_if s) = ResumeCurrentThread
-           | KernelExit \<Rightarrow>
-                     (ct_running' (internal_state_if s) \<or> ct_idle' (internal_state_if s)) \<and>
-                     ksSchedulerAction (internal_state_if s) = ResumeCurrentThread \<and>
-                     ksDomainTime (internal_state_if s) \<noteq> 0
-           | InUserMode \<Rightarrow>
-                     ct_running' (internal_state_if s) \<and>
-                     ksSchedulerAction (internal_state_if s) = ResumeCurrentThread
-           | InIdleMode \<Rightarrow>
-                     ct_idle' (internal_state_if s) \<and>
-                     ksSchedulerAction (internal_state_if s) = ResumeCurrentThread
-           | _ \<Rightarrow> True) }"
-
-definition has_srel_state where
-"has_srel_state srel P \<equiv> {s. \<exists>s'. (s,s') \<in> srel \<and> s' \<in> P}"
-
-definition lift_fst_rel where
-  "lift_fst_rel srel \<equiv> {(r,r'). snd r = snd r' \<and> (fst r, fst r') \<in> srel}"
-
-(*Includes serializability*)
-definition step_corres where
-  "step_corres nf srel mode G G' \<equiv>
-         \<lambda>mabs mconc. \<forall>(s,s')\<in>srel. (s',mode) \<in> G' \<and> (s,mode) \<in> G  \<longrightarrow>
-                      ((nf \<longrightarrow> (\<exists>e' t'. (s',e',t') \<in> mconc)) \<and>
-                      (\<forall>e' t'. (s',e',t') \<in> mconc \<longrightarrow>
-                         (\<exists>e t. (s,e,t) \<in> mabs \<and> (t,t') \<in> srel \<and> e = e')))"
-
-
-definition lift_snd_rel where
-  "lift_snd_rel srel \<equiv> {(r,r'). fst r = fst r' \<and> (snd r, snd r') \<in> srel}"
-
-definition preserves where
-"preserves mode mode' P f \<equiv> \<forall>(s,e,s') \<in> f. (s,mode) \<in> P \<longrightarrow> (s',mode') \<in> P"
-
-(*Special case for KernelExit*)
-definition preserves' where
-"preserves' mode P f \<equiv> \<forall>(s,e,s') \<in> f. (s,mode) \<in> P \<longrightarrow> (s',e) \<in> P"
 
 lemma preservesE:
   assumes preserves: "preserves mode mode' P f"
@@ -939,17 +537,17 @@ lemma preserves'E:
   done
 
 lemma step_corres_bothE:
-    assumes corres: "step_corres nf srel mode invs_abs invs_conc f_abs f_conc"
-    assumes preserves: "preserves mode mode' invs_conc f_conc"
-    assumes a: "(s, s') \<in> srel"
-    assumes e: "(s, mode) \<in> invs_abs"
-    assumes b: "(s', mode) \<in> invs_conc"
-    assumes c: "(s', e, t') \<in> f_conc"
-    assumes d: "\<And>t.
-             (s, e, t) \<in> f_abs \<Longrightarrow>
-             (t,mode') \<in> has_srel_state (lift_fst_rel srel) invs_conc \<Longrightarrow>
-             (t, t') \<in> srel \<Longrightarrow> P"
-    shows "P"
+  assumes corres: "step_corres nf srel mode invs_abs invs_conc f_abs f_conc"
+  assumes preserves: "preserves mode mode' invs_conc f_conc"
+  assumes a: "(s, s') \<in> srel"
+  assumes e: "(s, mode) \<in> invs_abs"
+  assumes b: "(s', mode) \<in> invs_conc"
+  assumes c: "(s', e, t') \<in> f_conc"
+  assumes d: "\<And>t. (s, e, t) \<in> f_abs
+                   \<Longrightarrow> (t, mode') \<in> has_srel_state (lift_fst_rel srel) invs_conc
+                   \<Longrightarrow> (t, t') \<in> srel
+                   \<Longrightarrow> P"
+  shows "P"
   apply (insert corres a b c e)
   apply (clarsimp simp: step_corres_def)
   apply (drule_tac x="(s,s')" in bspec,clarsimp+)
@@ -958,23 +556,23 @@ lemma step_corres_bothE:
   apply simp
   apply clarsimp
   apply (rule_tac t=t in d,simp+)
-  apply (clarsimp simp: has_srel_state_def lift_fst_rel_def)
-  apply (rule preservesE[OF preserves],assumption+)
-  apply fastforce+
-    done
+   apply (clarsimp simp: has_srel_state_def lift_fst_rel_def)
+   apply (rule preservesE[OF preserves],assumption+)
+   apply fastforce+
+  done
 
 lemma step_corres_both'E:
-    assumes corres: "step_corres nf srel mode invs_abs invs_conc f_abs f_conc"
-    assumes preserves: "preserves' mode invs_conc f_conc"
-    assumes a: "(s, s') \<in> srel"
-    assumes e: "(s, mode) \<in> invs_abs"
-    assumes b: "(s', mode) \<in> invs_conc"
-    assumes c: "(s', e, t') \<in> f_conc"
-    assumes d: "\<And>t.
-             (s, e, t) \<in> f_abs \<Longrightarrow>
-             (t,e) \<in> has_srel_state (lift_fst_rel srel) invs_conc \<Longrightarrow>
-             (t, t') \<in> srel \<Longrightarrow> P"
-    shows "P"
+  assumes corres: "step_corres nf srel mode invs_abs invs_conc f_abs f_conc"
+  assumes preserves: "preserves' mode invs_conc f_conc"
+  assumes a: "(s, s') \<in> srel"
+  assumes e: "(s, mode) \<in> invs_abs"
+  assumes b: "(s', mode) \<in> invs_conc"
+  assumes c: "(s', e, t') \<in> f_conc"
+  assumes d: "\<And>t. (s, e, t) \<in> f_abs
+                   \<Longrightarrow> (t,e) \<in> has_srel_state (lift_fst_rel srel) invs_conc
+                   \<Longrightarrow> (t, t') \<in> srel
+                   \<Longrightarrow> P"
+  shows "P"
   apply (insert corres a b c e)
   apply (clarsimp simp: step_corres_def)
   apply (drule_tac x="(s,s')" in bspec,clarsimp+)
@@ -986,29 +584,26 @@ lemma step_corres_both'E:
    apply (clarsimp simp: has_srel_state_def lift_fst_rel_def)
    apply (rule preserves'E[OF preserves],assumption+)
    apply fastforce+
-    done
+  done
 
 lemma step_corresE:
-    assumes corres: "step_corres nf srel mode invs_abs invs_conc f_abs f_conc"
-    assumes a: "(s, s') \<in> srel"
-    assumes e: "(s, mode) \<in> invs_abs"
-    assumes b: "(s', mode) \<in> invs_conc"
-    assumes c: "(s', e, t') \<in> f_conc"
-    assumes d: "\<And>t.
-             (s, e, t) \<in> f_abs \<Longrightarrow>
-             (t, t') \<in> srel \<Longrightarrow> P"
-    shows "P"
-    apply (insert corres a b c e)
-    apply (clarsimp simp: step_corres_def)
-    apply (drule_tac x="(s,s')" in bspec,clarsimp+)
-    apply (drule_tac x=e in spec)
-    apply (drule_tac x=t' in spec)
-    apply clarsimp
-    apply (rule d)
-    apply simp+
-    done
+  assumes corres: "step_corres nf srel mode invs_abs invs_conc f_abs f_conc"
+  assumes a: "(s, s') \<in> srel"
+  assumes e: "(s, mode) \<in> invs_abs"
+  assumes b: "(s', mode) \<in> invs_conc"
+  assumes c: "(s', e, t') \<in> f_conc"
+  assumes d: "\<And>t. \<lbrakk> (s, e, t) \<in> f_abs; (t, t') \<in> srel \<rbrakk> \<Longrightarrow> P"
+  shows "P"
+  apply (insert corres a b c e)
+  apply (clarsimp simp: step_corres_def)
+  apply (drule_tac x="(s,s')" in bspec,clarsimp+)
+  apply (drule_tac x=e in spec)
+  apply (drule_tac x=t' in spec)
+  apply clarsimp
+  apply (rule d)
+   apply simp+
+  done
 
-end
 
 locale global_automaton_invs =
   fixes check_active_irq
@@ -1021,126 +616,143 @@ locale global_automaton_invs =
   fixes ADT :: "(('a global_sys_state),'o, unit) data_type"
   fixes extras :: "'a global_sys_state set"
   assumes step_adt: "Step ADT =
-                     (\<lambda>u. (global_automaton_if check_active_irq do_user_op kernel_call handle_preemption schedule kernel_exit) \<inter> {(s,s'). s' \<in> extras})"
-  assumes check_active_irq_invs: "preserves InUserMode InUserMode invs check_active_irq"
-  assumes check_active_irq_idle_invs: "preserves InIdleMode InIdleMode invs check_active_irq"
-  assumes check_active_irq_invs_entry: "preserves InUserMode (KernelEntry Interrupt) invs check_active_irq"
-  assumes check_active_irq_idle_invs_entry: "preserves InIdleMode (KernelEntry Interrupt) invs check_active_irq"
-
-  assumes do_user_op_invs: "preserves InUserMode InUserMode invs do_user_op"
-  assumes do_user_op_invs_entry: "preserves InUserMode (KernelEntry e) invs do_user_op"
-  assumes kernel_call_invs: "e \<noteq> Interrupt \<Longrightarrow> preserves (KernelEntry e) KernelPreempted invs (kernel_call e)"
-  assumes kernel_call_invs_sched: "preserves (KernelEntry e) (KernelSchedule (e = Interrupt)) invs (kernel_call e)"
-  assumes handle_preemption_invs: "preserves KernelPreempted (KernelSchedule True) invs handle_preemption"
-  assumes schedule_invs: "preserves (KernelSchedule b) KernelExit invs schedule"
-  assumes kernel_exit_invs: "preserves' KernelExit invs kernel_exit"
-  assumes init_invs: "(Init ADT) s \<subseteq> invs"
-  assumes init_extras: "(Init ADT) s \<subseteq> extras"
+    (\<lambda>u. (global_automaton_if check_active_irq do_user_op kernel_call
+                              handle_preemption schedule kernel_exit) \<inter> {(s,s'). s' \<in> extras})"
+  assumes check_active_irq_invs:
+    "preserves InUserMode InUserMode invs check_active_irq"
+  assumes check_active_irq_idle_invs:
+    "preserves InIdleMode InIdleMode invs check_active_irq"
+  assumes check_active_irq_invs_entry:
+    "preserves InUserMode (KernelEntry Interrupt) invs check_active_irq"
+  assumes check_active_irq_idle_invs_entry:
+    "preserves InIdleMode (KernelEntry Interrupt) invs check_active_irq"
+  assumes do_user_op_invs:
+    "preserves InUserMode InUserMode invs do_user_op"
+  assumes do_user_op_invs_entry:
+    "preserves InUserMode (KernelEntry e) invs do_user_op"
+  assumes kernel_call_invs:
+    "e \<noteq> Interrupt
+     \<Longrightarrow> preserves (KernelEntry e) KernelPreempted invs (kernel_call e)"
+  assumes kernel_call_invs_sched:
+    "preserves (KernelEntry e) (KernelSchedule (e = Interrupt)) invs (kernel_call e)"
+  assumes handle_preemption_invs:
+    "preserves KernelPreempted (KernelSchedule True) invs handle_preemption"
+  assumes schedule_invs:
+    "preserves (KernelSchedule b) KernelExit invs schedule"
+  assumes kernel_exit_invs:
+    "preserves' KernelExit invs kernel_exit"
+  assumes init_invs:
+    "(Init ADT) s \<subseteq> invs"
+  assumes init_extras:
+    "(Init ADT) s \<subseteq> extras"
   begin
 
-  lemma ADT_extras: "ADT \<Turnstile> extras"
-    apply (rule invariantI)
-    apply (clarsimp simp: init_extras)
-    apply (clarsimp simp: step_adt)
-    done
+lemma ADT_extras: "ADT \<Turnstile> extras"
+  apply (rule invariantI)
+   apply (clarsimp simp: init_extras)
+  apply (clarsimp simp: step_adt)
+  done
 
-  lemma ADT_invs: "ADT \<Turnstile> invs"
-    apply (rule invariantI)
-    apply (intro allI)
-     apply (rule init_invs)
-    apply (clarsimp simp: step_adt global_automaton_if_def)
-    apply (elim disjE exE conjE,simp_all)
-             apply (rule preservesE[OF kernel_call_invs])
-                apply (rule preservesE[OF kernel_call_invs],assumption+)
-            apply (rule preservesE[OF kernel_call_invs_sched],assumption+)
-           apply (rule preservesE[OF handle_preemption_invs],assumption+)
-          apply (rule preservesE[OF schedule_invs],assumption+)
-         apply (rule preserves'E[OF kernel_exit_invs],assumption+)
-        apply (rule preservesE[OF check_active_irq_invs],assumption+)
-        apply (rule preservesE[OF do_user_op_invs_entry],assumption+)
-       apply (rule preservesE[OF check_active_irq_invs],assumption+)
-       apply (rule preservesE[OF do_user_op_invs],assumption+)
-      apply (rule preservesE[OF check_active_irq_invs_entry],assumption+)
-     apply (rule preservesE[OF check_active_irq_idle_invs_entry],assumption+)
-    apply (rule preservesE[OF check_active_irq_idle_invs],assumption+)
-    done
+lemma ADT_invs: "ADT \<Turnstile> invs"
+  apply (rule invariantI)
+   apply (intro allI)
+   apply (rule init_invs)
+  apply (clarsimp simp: step_adt global_automaton_if_def)
+  apply (elim disjE exE conjE,simp_all)
+           apply (rule preservesE[OF kernel_call_invs])
+              apply (rule preservesE[OF kernel_call_invs],assumption+)
+          apply (rule preservesE[OF kernel_call_invs_sched],assumption+)
+         apply (rule preservesE[OF handle_preemption_invs],assumption+)
+        apply (rule preservesE[OF schedule_invs],assumption+)
+       apply (rule preserves'E[OF kernel_exit_invs],assumption+)
+      apply (rule preservesE[OF check_active_irq_invs],assumption+)
+      apply (rule preservesE[OF do_user_op_invs_entry],assumption+)
+     apply (rule preservesE[OF check_active_irq_invs],assumption+)
+     apply (rule preservesE[OF do_user_op_invs],assumption+)
+    apply (rule preservesE[OF check_active_irq_invs_entry],assumption+)
+   apply (rule preservesE[OF check_active_irq_idle_invs_entry],assumption+)
+  apply (rule preservesE[OF check_active_irq_idle_invs],assumption+)
+  done
+
 end
 
 
-lemma invariant_holds_inter: "A \<Turnstile> I \<Longrightarrow> A \<Turnstile> S \<Longrightarrow> A \<Turnstile> (I \<inter> S)"
+lemma invariant_holds_inter:
+  "A \<Turnstile> I \<Longrightarrow> A \<Turnstile> S \<Longrightarrow> A \<Turnstile> (I \<inter> S)"
   apply (clarsimp simp: invariant_holds_def)
   apply blast
   done
 
-lemma preserves_lift_ret: "(\<And>tc. \<lbrace>\<lambda>s. ((tc,s),mode) \<in> P\<rbrace> f tc \<lbrace>\<lambda>tc' s'. ((snd tc',s'),mode') \<in> P\<rbrace>)
-      \<Longrightarrow>
-      preserves mode mode' P
-       {((tc, s), irq, tc', s').
-        ((irq, tc'), s') \<in> fst (f tc s)}"
-  apply (clarsimp simp: preserves_def valid_def)
-  apply fastforce
-  done
+lemma preserves_lift_ret:
+  "(\<And>tc. \<lbrace>\<lambda>s. ((tc,s),mode) \<in> P\<rbrace> f tc \<lbrace>\<lambda>tc' s'. ((snd tc',s'),mode') \<in> P\<rbrace>)
+   \<Longrightarrow> preserves mode mode' P {((tc, s), irq, tc', s'). ((irq, tc'), s') \<in> fst (f tc s)}"
+  by (fastforce simp: preserves_def valid_def)
 
-lemma preserves_lift: "(\<And>tc. \<lbrace>\<lambda>s. ((tc,s),mode) \<in> P\<rbrace> f tc \<lbrace>\<lambda>tc' s'. ((tc',s'),mode') \<in> P\<rbrace>)
-      \<Longrightarrow>
-      preserves mode mode' P
-       {((tc, s), irq, tc', s').
-        (tc', s') \<in> fst (f tc s)}"
-  apply (clarsimp simp: preserves_def valid_def)
-  done
+lemma preserves_lift:
+  "(\<And>tc. \<lbrace>\<lambda>s. ((tc,s),mode) \<in> P\<rbrace> f tc \<lbrace>\<lambda>tc' s'. ((tc',s'),mode') \<in> P\<rbrace>)
+   \<Longrightarrow> preserves mode mode' P {((tc, s), irq, tc', s'). (tc', s') \<in> fst (f tc s)}"
+  by (clarsimp simp: preserves_def valid_def)
 
-
-lemma preserves_lift':"(\<And>tc. \<lbrace>\<lambda>s. ((tc,s),mode) \<in> P\<rbrace> f uop tc \<lbrace>\<lambda>tc' s'. ((snd tc',s'),mode') \<in> P\<rbrace>)
-      \<Longrightarrow>
-       preserves mode mode' P
-        {((a, b), e, tc, s') |a b e tc s'.
-            ((e, tc), s') \<in> fst (f uop a b)}"
-  apply (clarsimp simp: preserves_def valid_def)
-  apply fastforce
-  done
+lemma preserves_lift':
+  "(\<And>tc. \<lbrace>\<lambda>s. ((tc,s),mode) \<in> P\<rbrace> f uop tc \<lbrace>\<lambda>tc' s'. ((snd tc',s'),mode') \<in> P\<rbrace>)
+   \<Longrightarrow> preserves mode mode' P {((a, b), e, tc, s') | a b e tc s'. ((e, tc), s') \<in> fst (f uop a b)}"
+  by (fastforce simp: preserves_def valid_def)
 
 lemma preserves_lift'':
-   "(\<And>tc. \<lbrace>\<lambda>s. ((tc,s),mode) \<in> P\<rbrace> f e tc \<lbrace>\<lambda>tc' s'. ((snd tc',s'),mode') \<in> P\<rbrace>) \<Longrightarrow>
-       preserves mode mode' P
-         {((a, b), ba, tc, s') |a b ba tc s'.
-          \<exists>r. ((r, tc), s') \<in> fst (f e a b) \<and> ba = (r \<noteq> Inr ())}"
-  apply (clarsimp simp: preserves_def valid_def)
-  apply fastforce
-  done
+   "(\<And>tc. \<lbrace>\<lambda>s. ((tc,s),mode) \<in> P\<rbrace> f e tc \<lbrace>\<lambda>tc' s'. ((snd tc',s'),mode') \<in> P\<rbrace>)
+    \<Longrightarrow> preserves mode mode' P
+         {((a, b), ba, tc, s') | a b ba tc s'.
+                                 \<exists>r. ((r, tc), s') \<in> fst (f e a b) \<and> ba = (r \<noteq> Inr ())}"
+  by (fastforce simp: preserves_def valid_def)
 
-lemma preserves_lift''': "(\<And>tc. \<lbrace>\<lambda>s. ((tc,s),mode) \<in> P\<rbrace> f tc \<lbrace>\<lambda>tc' s'. ((tc',s'),mode') \<in> P\<rbrace>)
-        \<Longrightarrow>
-        preserves mode mode' P
-           {(s, u, s'). s' \<in> fst (case s of (x, xa) \<Rightarrow> f x xa)}"
-  apply (clarsimp simp: preserves_def valid_def)
-  done
-
+lemma preserves_lift''':
+  "(\<And>tc. \<lbrace>\<lambda>s. ((tc,s),mode) \<in> P\<rbrace> f tc \<lbrace>\<lambda>tc' s'. ((tc',s'),mode') \<in> P\<rbrace>)
+   \<Longrightarrow> preserves mode mode' P {(s, u, s'). s' \<in> fst (case s of (x, xa) \<Rightarrow> f x xa)}"
+  by (clarsimp simp: preserves_def valid_def)
 
 lemma preserves'_lift:
   "(\<And>tc. \<lbrace>\<lambda>s. ((tc,s),mode) \<in> P\<rbrace> f tc \<lbrace>\<lambda>tc' s'. ((tc',s'),y s') \<in> P\<rbrace>)
-        \<Longrightarrow>
-  preserves' mode P
-        {(s, m, s').
-         s' \<in> fst (case s of (x, xa) \<Rightarrow> f x xa) \<and>
-         m = (y (snd s'))}"
-  apply (clarsimp simp: preserves'_def valid_def)
-  apply fastforce
-  done
+   \<Longrightarrow> preserves' mode P {(s, m, s'). s' \<in> fst (case s of (x, xa) \<Rightarrow> f x xa) \<and>
+                                      m = (y (snd s'))}"
+  by (fastforce simp: preserves'_def valid_def)
 
 lemmas preserves_lifts = preserves_lift_ret preserves_lift preserves_lift'
                          preserves_lift'' preserves_lift''' preserves'_lift
 
 
+definition full_invs_if' where
+  "full_invs_if' \<equiv>
+     {s. invs' (internal_state_if s)
+       \<and> ex_abs (einvs) (internal_state_if s)
+       \<and> arch_extras (internal_state_if s)
+       \<and> (snd s \<noteq> KernelSchedule True \<longrightarrow> ksDomainTime (internal_state_if s) > 0)
+       \<and> (ksDomainTime (internal_state_if s) = 0
+          \<longrightarrow> ksSchedulerAction (internal_state_if s) = ChooseNewThread)
+       \<and> valid_domain_list' (internal_state_if s)
+       \<and> (case (snd s) of
+            KernelEntry e \<Rightarrow> (e \<noteq> Interrupt
+                              \<longrightarrow> ct_running' (internal_state_if s) \<and>
+                                  ksDomainTime (internal_state_if s) \<noteq> 0) \<and>
+                             (ct_running' (internal_state_if s) \<or> ct_idle' (internal_state_if s)) \<and>
+                             ksSchedulerAction (internal_state_if s) = ResumeCurrentThread
+          | KernelExit \<Rightarrow> (ct_running' (internal_state_if s) \<or> ct_idle' (internal_state_if s)) \<and>
+                          ksSchedulerAction (internal_state_if s) = ResumeCurrentThread \<and>
+                          ksDomainTime (internal_state_if s) \<noteq> 0
+          | InUserMode \<Rightarrow> ct_running' (internal_state_if s) \<and>
+                          ksSchedulerAction (internal_state_if s) = ResumeCurrentThread
+          | InIdleMode \<Rightarrow> ct_idle' (internal_state_if s) \<and>
+                          ksSchedulerAction (internal_state_if s) = ResumeCurrentThread
+          | _ \<Rightarrow> True)}"
+
 defs step_restrict_def:
   "step_restrict \<equiv> \<lambda>s. s \<in> has_srel_state (lift_fst_rel (lift_snd_rel state_relation)) full_invs_if'"
-
-context begin interpretation Arch .
 
 lemma abstract_invs:
   "global_automaton_invs check_active_irq_A_if (do_user_op_A_if uop)
                          kernel_call_A_if kernel_handle_preemption_if
                          kernel_schedule_if kernel_exit_A_if
                          (full_invs_if) (ADT_A_if uop) {s. step_restrict s}"
+  supply nonzero_gt_zero[simp] gt_zero_nonzero[simp]
   supply conj_cong[cong]
   apply (unfold_locales)
                apply (simp add: ADT_A_if_def)
@@ -1188,7 +800,7 @@ lemma abstract_invs:
         apply (rule hoare_pre)
          apply (wp handle_preemption_if_invs)
          apply (wp handle_preemption_if_valid_domain_time)
-        apply (clarsimp simp: non_kernel_IRQs_def)
+        apply (clarsimp simp: non_kernel_IRQs_empty)
         done
      (* KernelSchedule \<rightarrow> KernelExit *)
      apply (rule preserves_lifts, simp add: full_invs_if_def)
@@ -1199,25 +811,13 @@ lemma abstract_invs:
    apply (fastforce simp: full_invs_if_def ADT_A_if_def step_restrict_def)+
   done
 
-end
-
-definition ADT_H_if where
-"ADT_H_if uop \<equiv> \<lparr>Init = \<lambda>s. ({user_context_of s} \<times> {s'. absKState s' = (internal_state_if s)}) \<times> {sys_mode_of s} \<inter> full_invs_if',
-                  Fin = \<lambda>((uc,s),m). ((uc, absKState s),m),
-                  Step = (\<lambda>u. global_automaton_if
-                              checkActiveIRQ_H_if (doUserOp_H_if uop)
-                              kernelCall_H_if handlePreemption_H_if
-                              schedule'_H_if kernelExit_H_if)\<rparr>"
-
-crunches doUserOp_if, checkActiveIRQ_if
+crunches checkActiveIRQ_if
   for ksDomainTime_inv[wp]: "\<lambda>s. P (ksDomainTime s)"
   and ksDomSchedule_inv[wp]: "\<lambda>s. P (ksDomSchedule s)"
   (wp: select_wp)
 
 lemma kernelEntry_if_valid_domain_time:
-  "e \<noteq> Interrupt \<Longrightarrow>
-   \<lbrace>\<top>\<rbrace> kernelEntry_if e tc \<lbrace>\<lambda>_ s. 0 < ksDomainTime s \<and> valid_domain_list' s\<rbrace>"
-
+  "e \<noteq> Interrupt \<Longrightarrow> \<lbrace>\<top>\<rbrace> kernelEntry_if e tc \<lbrace>\<lambda>_ s. 0 < ksDomainTime s \<and> valid_domain_list' s\<rbrace>"
   "\<lbrace>\<top>\<rbrace>
    kernelEntry_if Interrupt tc
    \<lbrace>\<lambda>_ s. (ksDomainTime s = 0 \<longrightarrow> ksSchedulerAction s = ChooseNewThread) \<and> valid_domain_list' s\<rbrace>"
@@ -1235,14 +835,30 @@ lemma schedule'_if_valid_domain_time:
   unfolding schedule'_if_def by wpsimp+
 
 lemma kernelEntry_if_no_preempt:
-  "\<lbrace> \<top> \<rbrace> kernelEntry_if Interrupt ctx \<lbrace>\<lambda>(interrupt,_) _. interrupt = Inr () \<rbrace>"
+  "\<lbrace>\<top>\<rbrace> kernelEntry_if Interrupt ctx \<lbrace>\<lambda>(interrupt,_) _. interrupt = Inr () \<rbrace>"
   unfolding kernelEntry_if_def handleEvent_def
   by (wp | clarsimp intro!: validE_cases_valid)+
+
+
+context ADT_IF_Refine_1 begin
+
+definition doUserOp_H_if where
+  "doUserOp_H_if uop \<equiv> {(s,e,(tc,s'))| s e tc s'. ((e,tc),s') \<in> fst (split (doUserOp_if uop) s)}"
+
+definition ADT_H_if where
+  "ADT_H_if uop \<equiv>
+     \<lparr>Init = \<lambda>s. ({user_context_of s} \<times> {s'. absKState s' = (internal_state_if s)})
+                                      \<times> {sys_mode_of s} \<inter> full_invs_if',
+      Fin = \<lambda>((uc,s),m). ((uc, absKState s),m),
+      Step = (\<lambda>u. global_automaton_if checkActiveIRQ_H_if (doUserOp_H_if uop)
+                                      kernelCall_H_if handlePreemption_H_if
+                                      schedule'_H_if kernelExit_H_if)\<rparr>"
 
 lemma haskell_invs:
   "global_automaton_invs checkActiveIRQ_H_if (doUserOp_H_if uop)
                          kernelCall_H_if handlePreemption_H_if
                          schedule'_H_if kernelExit_H_if full_invs_if' (ADT_H_if uop) UNIV"
+  supply nonzero_gt_zero[simp] gt_zero_nonzero[simp]
   supply conj_cong[cong]
   apply (unfold_locales)
                apply (simp add: ADT_H_if_def)
@@ -1256,7 +872,6 @@ lemma haskell_invs:
         apply (rule preserves_lifts)
         apply (simp add: full_invs_if'_def)
         apply (wp kernelEntry_if_valid_domain_time; simp)
-
      subgoal for e
        apply (rule preserves_lifts, simp add: full_invs_if'_def)
        apply wp
@@ -1278,6 +893,34 @@ lemma haskell_invs:
    apply (clarsimp simp: ADT_H_if_def)+
   done
 
+(*Unused*)
+lemma Init_Fin_ADT_H:
+  "s' \<in> full_invs_if'
+   \<Longrightarrow> s' \<in> Init (ADT_H_if uop) (Fin (ADT_H_if uop) s')"
+  apply (clarsimp simp: ADT_H_if_def)
+  apply (case_tac s')
+  apply simp
+  apply (case_tac a)
+  apply simp
+  done
+
+(*Unused*)
+lemma Fin_Init_ADT_H:
+  "s' \<in> (Init (ADT_H_if uop) s)
+   \<Longrightarrow> s' \<in> full_invs_if' \<Longrightarrow> s \<in> Fin (ADT_H_if uop) ` Init (ADT_H_if uop) s"
+  apply (clarsimp simp: ADT_H_if_def)
+  apply (case_tac s)
+  apply simp
+  apply clarsimp
+  apply (simp add: image_def)
+  apply (rule_tac x="((a,b),baa)" in bexI)
+   apply clarsimp
+  apply clarsimp
+  done
+
+end
+
+
 lemma step_corres_exE:
   assumes step: "step_corres nf srel mode invs_abs invs_conc f f'"
   assumes nf: "nf"
@@ -1293,151 +936,147 @@ lemma step_corres_exE:
   apply (drule_tac x=t' in spec)
   apply clarsimp
   apply (rule ex)
-  apply assumption+
+    apply assumption+
   done
-
 
 
 locale global_automata_refine =
-abs : global_automaton_invs check_active_irq_abs do_user_op_abs
-                      kernel_call_abs handle_preemption_abs
-                      schedule_abs kernel_exit_abs invs_abs
-                      ADT_abs extras_abs +
-conc: global_automaton_invs check_active_irq_conc do_user_op_conc
-                      kernel_call_conc handle_preemption_conc
-                      schedule_conc kernel_exit_conc invs_conc
-                      ADT_conc "UNIV"
-for                   check_active_irq_abs and
-                      do_user_op_abs and
-                      kernel_call_abs and handle_preemption_abs and
-                      schedule_abs and kernel_exit_abs and invs_abs and
-                      ADT_abs :: "(('a global_sys_state),'o, unit) data_type" and extras_abs and
-                      check_active_irq_conc and
-                      do_user_op_conc  and
-                      kernel_call_conc and handle_preemption_conc and
-                      schedule_conc and kernel_exit_conc and
-                      invs_conc and
-                      ADT_conc :: "(('c global_sys_state),'o, unit) data_type" +
+  abs: global_automaton_invs check_active_irq_abs do_user_op_abs kernel_call_abs
+                             handle_preemption_abs schedule_abs kernel_exit_abs
+                             invs_abs ADT_abs extras_abs +
+  conc: global_automaton_invs check_active_irq_conc do_user_op_conc kernel_call_conc
+                              handle_preemption_conc schedule_conc kernel_exit_conc
+                              invs_conc ADT_conc UNIV
+  for check_active_irq_abs and do_user_op_abs and kernel_call_abs and handle_preemption_abs and
+      schedule_abs and kernel_exit_abs and invs_abs and
+      ADT_abs :: "(('a global_sys_state),'o, unit) data_type" and extras_abs and
+      check_active_irq_conc and do_user_op_conc and kernel_call_conc and handle_preemption_conc and
+      schedule_conc and kernel_exit_conc and invs_conc and
+      ADT_conc :: "(('c global_sys_state),'o, unit) data_type" +
   fixes srel :: "((user_context \<times> 'a) \<times> (user_context \<times> 'c)) set"
   fixes nf :: "bool"
-  assumes extras_abs_intro: "has_srel_state (lift_fst_rel srel) invs_conc \<subseteq> extras_abs"
-  assumes srel_Fin: "(s,s') \<in> srel \<Longrightarrow> (s,mode) \<in> invs_abs \<Longrightarrow> (s',mode) \<in> invs_conc \<Longrightarrow> (Fin (ADT_conc)) (s',mode) = (Fin (ADT_abs)) (s,mode)"
-  assumes init_refinement: "((Init (ADT_conc)) a) \<subseteq> lift_fst_rel srel `` ((Init (ADT_abs)) a)"
-  assumes corres_check_active_irq: "step_corres nf srel InUserMode (invs_abs) invs_conc check_active_irq_abs check_active_irq_conc"
-  assumes corres_check_active_irq_idle: "step_corres nf srel InIdleMode (invs_abs) invs_conc check_active_irq_abs check_active_irq_conc"
-  assumes corres_do_user_op: "step_corres nf srel InUserMode (invs_abs) invs_conc (do_user_op_abs) (do_user_op_conc)"
-  assumes corres_kernel_call: "step_corres nf srel (KernelEntry e) (invs_abs) invs_conc (kernel_call_abs e) (kernel_call_conc e)"
-  assumes corres_handle_preemption: "step_corres nf srel KernelPreempted (invs_abs) invs_conc handle_preemption_abs handle_preemption_conc"
-  assumes corres_schedule: "step_corres nf srel (KernelSchedule b) (invs_abs) invs_conc schedule_abs schedule_conc"
-  assumes corres_kernel_exit: "step_corres nf srel KernelExit (invs_abs) invs_conc kernel_exit_abs kernel_exit_conc"
+  assumes extras_abs_intro:
+    "has_srel_state (lift_fst_rel srel) invs_conc \<subseteq> extras_abs"
+  assumes srel_Fin:
+    "\<lbrakk> (s,s') \<in> srel; (s,mode) \<in> invs_abs; (s',mode) \<in> invs_conc \<rbrakk>
+       \<Longrightarrow> (Fin (ADT_conc)) (s',mode) = (Fin (ADT_abs)) (s,mode)"
+  assumes init_refinement:
+    "((Init (ADT_conc)) a) \<subseteq> lift_fst_rel srel `` ((Init (ADT_abs)) a)"
+  assumes corres_check_active_irq:
+    "step_corres nf srel InUserMode (invs_abs) invs_conc check_active_irq_abs check_active_irq_conc"
+  assumes corres_check_active_irq_idle:
+    "step_corres nf srel InIdleMode (invs_abs) invs_conc check_active_irq_abs check_active_irq_conc"
+  assumes corres_do_user_op:
+    "step_corres nf srel InUserMode (invs_abs) invs_conc (do_user_op_abs) (do_user_op_conc)"
+  assumes corres_kernel_call:
+    "step_corres nf srel (KernelEntry e) (invs_abs) invs_conc (kernel_call_abs e) (kernel_call_conc e)"
+  assumes corres_handle_preemption:
+    "step_corres nf srel KernelPreempted (invs_abs) invs_conc handle_preemption_abs handle_preemption_conc"
+  assumes corres_schedule:
+    "step_corres nf srel (KernelSchedule b) (invs_abs) invs_conc schedule_abs schedule_conc"
+  assumes corres_kernel_exit:
+    "step_corres nf srel KernelExit (invs_abs) invs_conc kernel_exit_abs kernel_exit_conc"
   assumes kernel_call_no_preempt:
     "\<And>s s' b. (s, b, s') \<in> kernel_call_abs Interrupt \<Longrightarrow> b = False"
+begin
 
-  begin
-
-
-lemma extras_inter'[dest!]: "(t,mode) \<in> has_srel_state (lift_fst_rel srel) invs_conc \<Longrightarrow> (t,mode) \<in> extras_abs"
+lemma extras_inter'[dest!]:
+   "(t,mode) \<in> has_srel_state (lift_fst_rel srel) invs_conc \<Longrightarrow> (t,mode) \<in> extras_abs"
   apply (rule set_mp)
-  apply (rule extras_abs_intro)
+   apply (rule extras_abs_intro)
   apply simp
   done
 
-
-  lemma fw_sim_abs_conc:
-  "LI (ADT_abs)
-      (ADT_conc)
-      (lift_fst_rel srel)
-      (invs_abs \<times> invs_conc)"
+lemma fw_sim_abs_conc:
+  "LI (ADT_abs) (ADT_conc) (lift_fst_rel srel) (invs_abs \<times> invs_conc)"
   apply (unfold LI_def )
   apply (intro conjI allI)
-  apply (rule init_refinement)
-     apply (clarsimp simp: rel_semi_def relcomp_unfold lift_fst_rel_def
-                           abs.step_adt conc.step_adt)
-     apply (clarsimp simp: global_automaton_if_def)
-     apply (elim disjE exE conjE,simp_all)
-     apply (rule step_corres_bothE[OF  corres_kernel_call conc.kernel_call_invs],assumption+,auto)[1]
-              apply (rule step_corres_bothE[OF  corres_kernel_call conc.kernel_call_invs_sched],assumption+,auto)[1]
-            apply (rule step_corres_bothE[OF  corres_handle_preemption conc.handle_preemption_invs],assumption+,auto)[1]
-           apply (rule step_corres_bothE[OF  corres_schedule conc.schedule_invs],assumption+,auto)[1]
-          apply (rule step_corres_both'E[OF  corres_kernel_exit conc.kernel_exit_invs],assumption+,auto)[1]
-         apply (rule preservesE[OF conc.check_active_irq_invs],assumption+)
-         apply (rule step_corres_bothE[OF corres_check_active_irq conc.check_active_irq_invs],assumption+,clarsimp)
-         apply (rule preservesE[OF abs.check_active_irq_invs],assumption+)
-         apply (rule_tac s'="(ac,be)" in step_corres_bothE[OF corres_do_user_op conc.do_user_op_invs_entry],assumption+,auto)[1]
-         apply (rule preservesE[OF conc.check_active_irq_invs],assumption+)
-         apply (rule step_corres_bothE[OF corres_check_active_irq conc.check_active_irq_invs],assumption+,clarsimp)
-         apply (rule preservesE[OF abs.check_active_irq_invs],assumption+)
-         apply (rule_tac s'="(ac,be)" in step_corres_bothE[OF corres_do_user_op conc.do_user_op_invs],assumption+,auto)[1]
-         apply (rule step_corres_bothE[OF corres_check_active_irq conc.check_active_irq_invs_entry],assumption+,auto)[1]
-         apply (rule step_corres_bothE[OF corres_check_active_irq_idle conc.check_active_irq_idle_invs_entry],assumption+,auto)[1]
-        apply (rule preservesE[OF conc.check_active_irq_idle_invs],assumption+)
-        apply (rule step_corres_bothE[OF corres_check_active_irq_idle conc.check_active_irq_idle_invs],assumption+,auto)[1]
-    apply (fastforce intro!: srel_Fin simp: lift_fst_rel_def)
-    done
+    apply (rule init_refinement)
+   apply (clarsimp simp: rel_semi_def relcomp_unfold lift_fst_rel_def
+                         abs.step_adt conc.step_adt)
+   apply (clarsimp simp: global_automaton_if_def)
+   apply (elim disjE exE conjE,simp_all)
+            apply (rule step_corres_bothE[OF corres_kernel_call conc.kernel_call_invs],assumption+,auto)[1]
+           apply (rule step_corres_bothE[OF corres_kernel_call conc.kernel_call_invs_sched],assumption+,auto)[1]
+          apply (rule step_corres_bothE[OF corres_handle_preemption conc.handle_preemption_invs],assumption+,auto)[1]
+         apply (rule step_corres_bothE[OF corres_schedule conc.schedule_invs],assumption+,auto)[1]
+        apply (rule step_corres_both'E[OF corres_kernel_exit conc.kernel_exit_invs],assumption+,auto)[1]
+       apply (rule preservesE[OF conc.check_active_irq_invs],assumption+)
+       apply (rule step_corres_bothE[OF corres_check_active_irq conc.check_active_irq_invs],assumption+,clarsimp)
+       apply (rule preservesE[OF abs.check_active_irq_invs],assumption+)
+       apply (rule_tac s'="(ac,be)" in step_corres_bothE[OF corres_do_user_op conc.do_user_op_invs_entry],assumption+,auto)[1]
+      apply (rule preservesE[OF conc.check_active_irq_invs],assumption+)
+      apply (rule step_corres_bothE[OF corres_check_active_irq conc.check_active_irq_invs],assumption+,clarsimp)
+      apply (rule preservesE[OF abs.check_active_irq_invs],assumption+)
+      apply (rule_tac s'="(ac,be)" in step_corres_bothE[OF corres_do_user_op conc.do_user_op_invs],assumption+,auto)[1]
+     apply (rule step_corres_bothE[OF corres_check_active_irq conc.check_active_irq_invs_entry],assumption+,auto)[1]
+    apply (rule step_corres_bothE[OF corres_check_active_irq_idle conc.check_active_irq_idle_invs_entry],assumption+,auto)[1]
+   apply (rule preservesE[OF conc.check_active_irq_idle_invs],assumption+)
+   apply (rule step_corres_bothE[OF corres_check_active_irq_idle conc.check_active_irq_idle_invs],assumption+,auto)[1]
+  apply (fastforce intro!: srel_Fin simp: lift_fst_rel_def)
+  done
 
-  lemma fw_simulates: "ADT_conc \<sqsubseteq>\<^sub>F ADT_abs"
-    apply (rule L_invariantI)
-      apply (rule abs.ADT_invs)
-     apply (rule conc.ADT_invs)
-    apply (rule fw_sim_abs_conc)
-    done
-
-  lemma refinement: "ADT_conc \<sqsubseteq> ADT_abs"
-    apply (rule sim_imp_refines[OF fw_simulates])
-    done
-
-  lemma conc_serial:
-    assumes uop_sane: "\<And>s e t. (s,e,t) \<in> do_user_op_conc \<Longrightarrow>
-                       e \<noteq> Some Interrupt"
-    assumes no_fail: "nf"
-    shows
-    "serial_system (ADT_conc) {s'. \<exists>s. (s,s') \<in> (lift_fst_rel srel) \<and> s \<in> invs_abs \<and> s' \<in> invs_conc}"
-    apply (insert no_fail)
-    apply (unfold_locales)
-    apply (rule fw_inv_transport)
+lemma fw_simulates: "ADT_conc \<sqsubseteq>\<^sub>F ADT_abs"
+  apply (rule L_invariantI)
     apply (rule abs.ADT_invs)
-     apply (rule conc.ADT_invs)
-     apply (rule fw_sim_abs_conc)
-    apply (clarsimp simp: conc.step_adt global_automaton_if_def lift_fst_rel_def)
-    apply (case_tac ba,simp_all)
-         apply (rule step_corres_exE[OF corres_check_active_irq],assumption+)
-         apply (rule preservesE[OF conc.check_active_irq_invs],assumption+)
-         apply (rule preservesE[OF abs.check_active_irq_invs],assumption+)
-         apply (rule_tac s=t and s'=t' in step_corres_exE[OF corres_do_user_op],assumption+)
-         apply (rule_tac s=t and s'=t' in step_corresE[OF corres_do_user_op],assumption+)
-         apply clarsimp
-         apply (case_tac e)
-          apply (case_tac ea)
-           apply fastforce
-          apply simp
-          apply (frule uop_sane)
-          apply fastforce
-         apply (case_tac ea)
-          apply fastforce
-         apply fastforce
-        apply (rule step_corres_exE[OF corres_check_active_irq_idle],assumption+)
-        apply (case_tac e)
-         apply fastforce
-        apply fastforce
-       apply clarsimp
-       apply (rule step_corres_exE[OF corres_kernel_call],assumption+)
-       apply (case_tac e ; fastforce dest: kernel_call_no_preempt)
-      apply (rule step_corres_exE[OF corres_handle_preemption],assumption+)
-      apply fastforce
-     apply (rule step_corres_exE[OF corres_schedule],assumption+)
-     apply fastforce
-    apply (rule step_corres_exE[OF corres_kernel_exit],assumption+)
-    apply fastforce
-    done
+   apply (rule conc.ADT_invs)
+  apply (rule fw_sim_abs_conc)
+  done
 
-lemma abs_serial:
-  assumes constrained_B: "\<And>s. s \<in> invs_abs \<inter> extras_abs \<Longrightarrow>
-        \<exists>s'. s' \<in> invs_conc \<and> (s, s') \<in> lift_fst_rel srel"
+lemma refinement: "ADT_conc \<sqsubseteq> ADT_abs"
+  by (rule sim_imp_refines[OF fw_simulates])
+
+lemma conc_serial:
   assumes uop_sane: "\<And>s e t. (s,e,t) \<in> do_user_op_conc \<Longrightarrow>
                        e \<noteq> Some Interrupt"
   assumes no_fail: "nf"
   shows
-  "serial_system (ADT_abs) (invs_abs \<inter> extras_abs)"
+    "serial_system (ADT_conc) {s'. \<exists>s. (s,s') \<in> (lift_fst_rel srel) \<and> s \<in> invs_abs \<and> s' \<in> invs_conc}"
+  apply (insert no_fail)
+  apply (unfold_locales)
+   apply (rule fw_inv_transport)
+     apply (rule abs.ADT_invs)
+    apply (rule conc.ADT_invs)
+   apply (rule fw_sim_abs_conc)
+  apply (clarsimp simp: conc.step_adt global_automaton_if_def lift_fst_rel_def)
+  apply (case_tac ba,simp_all)
+       apply (rule step_corres_exE[OF corres_check_active_irq],assumption+)
+       apply (rule preservesE[OF conc.check_active_irq_invs],assumption+)
+       apply (rule preservesE[OF abs.check_active_irq_invs],assumption+)
+       apply (rule_tac s=t and s'=t' in step_corres_exE[OF corres_do_user_op],assumption+)
+       apply (rule_tac s=t and s'=t' in step_corresE[OF corres_do_user_op],assumption+)
+       apply clarsimp
+       apply (case_tac e)
+        apply (case_tac ea)
+         apply fastforce
+        apply simp
+        apply (frule uop_sane)
+        apply fastforce
+       apply (case_tac ea)
+        apply fastforce
+       apply fastforce
+      apply (rule step_corres_exE[OF corres_check_active_irq_idle],assumption+)
+      apply (case_tac e)
+       apply fastforce
+      apply fastforce
+     apply clarsimp
+     apply (rule step_corres_exE[OF corres_kernel_call],assumption+)
+     apply (case_tac e ; fastforce dest: kernel_call_no_preempt)
+    apply (rule step_corres_exE[OF corres_handle_preemption],assumption+)
+    apply fastforce
+   apply (rule step_corres_exE[OF corres_schedule],assumption+)
+   apply fastforce
+  apply (rule step_corres_exE[OF corres_kernel_exit],assumption+)
+  apply fastforce
+  done
+
+lemma abs_serial:
+  assumes constrained_B:
+    "\<And>s. s \<in> invs_abs \<inter> extras_abs \<Longrightarrow> \<exists>s'. s' \<in> invs_conc \<and> (s, s') \<in> lift_fst_rel srel"
+  assumes uop_sane:
+    "\<And>s e t. (s,e,t) \<in> do_user_op_conc \<Longrightarrow> e \<noteq> Some Interrupt"
+  assumes no_fail: "nf"
+  shows "serial_system (ADT_abs) (invs_abs \<inter> extras_abs)"
   apply (rule serial_system.fw_sim_serial)
        apply (rule conc_serial)
         apply (rule uop_sane,simp)
@@ -1453,46 +1092,17 @@ lemma abs_serial:
   apply auto
   done
 
-
 end
 
-(*Unused*)
-  lemma Init_Fin_ADT_H: "s' \<in> full_invs_if' \<Longrightarrow> s' \<in> Init (ADT_H_if uop) (Fin (ADT_H_if uop) s')"
-    apply (clarsimp simp: ADT_H_if_def)
-    apply (case_tac s')
-    apply simp
-    apply (case_tac a)
-    apply simp
-    done
 
-(*Unused*)
-  lemma Fin_Init_ADT_H: "s' \<in> (Init (ADT_H_if uop) s) \<Longrightarrow> s' \<in> full_invs_if' \<Longrightarrow> s \<in> Fin (ADT_H_if uop) ` Init (ADT_H_if uop) s"
-    apply (clarsimp simp: ADT_H_if_def)
-    apply (case_tac s)
-    apply simp
-    apply clarsimp
-    apply (simp add: image_def)
-    apply (rule_tac x="((a,b),baa)" in bexI)
-    apply clarsimp
-    apply clarsimp
-    done
-
-
-lemma
-  step_corres_lift:
-   "(\<And>tc. corres_underlying srel False nf (=)
-             (\<lambda>s. ((tc,s),mode) \<in> P) (\<lambda>s'. ((tc,s'),mode) \<in> P') (f tc) (f' tc)) \<Longrightarrow>
-    (\<And>tc. nf \<Longrightarrow> empty_fail (f' tc)) \<Longrightarrow>
-    step_corres nf (lift_snd_rel srel) mode P
-     P'
-     {((tc, s), irq, tc', s').
-      ((irq, tc'), s') \<in> fst (f tc s)}
-     {((tc, s), irq, tc', s').
-      ((irq, tc'), s') \<in> fst (f' tc s)}"
-  apply (clarsimp simp: corres_underlying_def step_corres_def
-                        lift_snd_rel_def empty_fail_def)
-  apply fastforce
-  done
+lemma step_corres_lift:
+  "\<lbrakk> \<And>tc. corres_underlying srel False nf (=) (\<lambda>s. ((tc,s),mode) \<in> P) (\<lambda>s'. ((tc,s'),mode) \<in> P')
+                            (f tc) (f' tc);
+     \<And>tc. nf \<Longrightarrow> empty_fail (f' tc) \<rbrakk>
+     \<Longrightarrow> step_corres nf (lift_snd_rel srel) mode P P'
+           {((tc, s), irq, tc', s'). ((irq, tc'), s') \<in> fst (f tc s)}
+           {((tc, s), irq, tc', s'). ((irq, tc'), s') \<in> fst (f' tc s)}"
+  by (fastforce simp: corres_underlying_def step_corres_def lift_snd_rel_def empty_fail_def)
 
 lemma step_corres_lift':
   "(\<And>tc. corres_underlying srel False nf (=)
@@ -1504,95 +1114,67 @@ lemma step_corres_lift':
           ((e, tc), s') \<in> fst (f u a b)}
          {((a, b), e, tc, s') |a b e tc s'.
           ((e, tc), s') \<in> fst (f' u a b)}"
-  apply (clarsimp simp: corres_underlying_def step_corres_def
-                        lift_snd_rel_def empty_fail_def)
-  apply fastforce
-  done
-
+  by (fastforce simp: corres_underlying_def step_corres_def lift_snd_rel_def empty_fail_def)
 
 lemma step_corres_lift'':
-  "(\<And>tc. corres_underlying srel False nf (\<lambda>r r'. ((fst r) = Inr ()) = ((fst r') = Inr ()) \<and> (snd r) = (snd r'))
-            (\<lambda>s. ((tc,s),mode) \<in> P) (\<lambda>s'. ((tc,s'),mode) \<in> P') (f e tc) (f' e tc)) \<Longrightarrow>
-  (\<And>tc. nf \<Longrightarrow> empty_fail (f' e tc)) \<Longrightarrow>
-  step_corres nf (lift_snd_rel srel) mode
-         P P'
-         {((a, b), ba, tc, s') |a b ba tc s'.
-          \<exists>r. ((r, tc), s') \<in> fst (f e a b) \<and>
-              ba = (r \<noteq> Inr ())}
-         {((a, b), ba, tc, s') |a b ba tc s'.
-          \<exists>r. ((r, tc), s') \<in> fst (f' e a b) \<and>
-              ba = (r \<noteq> Inr ())}"
-  apply (clarsimp simp: corres_underlying_def step_corres_def
-                        lift_snd_rel_def empty_fail_def)
-  apply fastforce
-  done
+  "\<lbrakk> \<And>tc. corres_underlying srel False nf
+            (\<lambda>r r'. ((fst r) = Inr ()) = ((fst r') = Inr ()) \<and> (snd r) = (snd r'))
+            (\<lambda>s. ((tc,s),mode) \<in> P) (\<lambda>s'. ((tc,s'),mode) \<in> P') (f e tc) (f' e tc);
+     \<And>tc. nf \<Longrightarrow> empty_fail (f' e tc) \<rbrakk>
+     \<Longrightarrow> step_corres nf (lift_snd_rel srel) mode P P'
+           {((a, b), ba, tc, s') |a b ba tc s'. \<exists>r. ((r, tc), s') \<in> fst (f e a b) \<and>
+                                                    ba = (r \<noteq> Inr ())}
+           {((a, b), ba, tc, s') |a b ba tc s'. \<exists>r. ((r, tc), s') \<in> fst (f' e a b) \<and>
+                                                    ba = (r \<noteq> Inr ())}"
+  by (fastforce simp: corres_underlying_def step_corres_def lift_snd_rel_def empty_fail_def)
 
 lemma step_corres_lift''':
-  "(\<And>tc. corres_underlying srel False nf (=) (\<lambda>s. ((tc,s),mode) \<in> P)
-            (\<lambda>s'. ((tc,s'),mode) \<in> P') (f tc) (f' tc)) \<Longrightarrow>
-   (\<And>tc. nf \<Longrightarrow> empty_fail (f' tc)) \<Longrightarrow>
-  step_corres nf (lift_snd_rel srel) mode
-     P P'
-     {(s, u, s').
-      s' \<in> fst (case s of (x, xa) \<Rightarrow> f x xa)}
-     {(s, u, s').
-      s' \<in> fst (case s of (x, xa) \<Rightarrow> f' x xa)}"
-  apply (clarsimp simp: corres_underlying_def step_corres_def
-                        lift_snd_rel_def empty_fail_def)
-  apply fastforce
-  done
+  "\<lbrakk> \<And>tc. corres_underlying srel False nf (=) (\<lambda>s. ((tc,s),mode) \<in> P)
+                            (\<lambda>s'. ((tc,s'),mode) \<in> P') (f tc) (f' tc);
+     \<And>tc. nf \<Longrightarrow> empty_fail (f' tc) \<rbrakk>
+     \<Longrightarrow> step_corres nf (lift_snd_rel srel) mode P P'
+           {(s, u, s'). s' \<in> fst (case s of (x, xa) \<Rightarrow> f x xa)}
+           {(s, u, s'). s' \<in> fst (case s of (x, xa) \<Rightarrow> f' x xa)}"
+  by (fastforce simp: corres_underlying_def step_corres_def lift_snd_rel_def empty_fail_def)
 
 lemma step_corres_lift'''':
-  "(\<And>tc. corres_underlying srel False nf (=) (\<lambda>s. ((tc,s),mode) \<in> P)
-            (\<lambda>s'. ((tc,s'),mode) \<in> P') (f tc) (f' tc)) \<Longrightarrow>
-   (\<And>tc. nf \<Longrightarrow> empty_fail (f' tc)) \<Longrightarrow>
-   (\<And>tc s s'. (s,s') \<in> srel \<Longrightarrow> S' s' \<Longrightarrow> S s \<Longrightarrow> y s = y' s') \<Longrightarrow>
-      (\<And>tc. \<lbrace>\<lambda>s'. ((tc,s'),mode) \<in> P'\<rbrace> (f' tc) \<lbrace>\<lambda>_. S'\<rbrace>) \<Longrightarrow>
-      (\<And>tc. \<lbrace>\<lambda>s'. ((tc,s'),mode) \<in> P\<rbrace> (f tc) \<lbrace>\<lambda>_. S\<rbrace>) \<Longrightarrow>
-   step_corres nf (lift_snd_rel srel) mode P
-     P'
-     {(s, m, s').
-      s' \<in> fst (case s of (x, xa) \<Rightarrow> f x xa) \<and>
-      m = (y (snd s'))}
-     {(s, m, s').
-      s' \<in> fst (case s of (x, xa) \<Rightarrow> f' x xa) \<and>
-      m = (y' (snd s'))}"
-  apply (clarsimp simp: corres_underlying_def step_corres_def
-                        lift_snd_rel_def empty_fail_def)
+  "\<lbrakk> \<And>tc. corres_underlying srel False nf (=) (\<lambda>s. ((tc,s),mode) \<in> P)
+                             (\<lambda>s'. ((tc,s'),mode) \<in> P') (f tc) (f' tc);
+     \<And>tc. nf \<Longrightarrow> empty_fail (f' tc);
+     \<And>tc s s'. (s,s') \<in> srel \<Longrightarrow> S' s' \<Longrightarrow> S s \<Longrightarrow> y s = y' s';
+     \<And>tc. \<lbrace>\<lambda>s'. ((tc,s'),mode) \<in> P'\<rbrace> (f' tc) \<lbrace>\<lambda>_. S'\<rbrace>;
+     \<And>tc. \<lbrace>\<lambda>s'. ((tc,s'),mode) \<in> P\<rbrace> (f tc) \<lbrace>\<lambda>_. S\<rbrace> \<rbrakk>
+     \<Longrightarrow> step_corres nf (lift_snd_rel srel) mode P P'
+           {(s, m, s'). s' \<in> fst (case s of (x, xa) \<Rightarrow> f x xa) \<and> m = (y (snd s'))}
+           {(s, m, s'). s' \<in> fst (case s of (x, xa) \<Rightarrow> f' x xa) \<and> m = (y' (snd s'))}"
+  apply (clarsimp simp: corres_underlying_def step_corres_def lift_snd_rel_def empty_fail_def)
   apply (clarsimp simp: valid_def)
   apply (drule_tac x=a in meta_spec)+
   apply fastforce
   done
 
+lemmas step_corres_lifts =
+  step_corres_lift step_corres_lift' step_corres_lift'' step_corres_lift''' step_corres_lift''''
 
-lemmas step_corres_lifts = step_corres_lift step_corres_lift'
-                           step_corres_lift'' step_corres_lift'''
-                           step_corres_lift''''
-
-
-lemma st_tcb_at_coerce_haskell: "\<lbrakk>st_tcb_at P t a; (a, c) \<in> state_relation; tcb_at' t c\<rbrakk>
-\<Longrightarrow> st_tcb_at' (\<lambda>st'. \<exists>st. thread_state_relation st st' \<and> P st) t c"
-  apply (clarsimp simp: state_relation_def
-                        pspace_relation_def
-                        obj_at_def st_tcb_at'_def
-
-                        st_tcb_at_def)
+lemma st_tcb_at_coerce_haskell:
+  "\<lbrakk> st_tcb_at P t a; (a, c) \<in> state_relation; tcb_at' t c \<rbrakk>
+     \<Longrightarrow> st_tcb_at' (\<lambda>st'. \<exists>st. thread_state_relation st st' \<and> P st) t c"
+  apply (clarsimp simp: state_relation_def pspace_relation_def
+                        obj_at_def st_tcb_at'_def st_tcb_at_def)
   apply (drule_tac x=t in bspec)
    apply fastforce
   apply clarsimp
   apply (simp add: other_obj_relation_def)
   apply clarsimp
-  apply (clarsimp simp: obj_at'_def)
-  apply (simp add: projectKO_eq)
-  apply (case_tac "ko",simp_all)
-  apply (simp add: project_inject)
+  apply (clarsimp simp: obj_at'_def projectKO_eq projectKO_tcb split: kernel_object.splits)
   apply (rule_tac x="tcb_state tcb" in exI)
   apply simp
   apply (simp add: tcb_relation_def)
   done
 
-
-lemma ct_running'_related: "\<lbrakk>(a, c) \<in> state_relation; invs' c; ct_running a\<rbrakk> \<Longrightarrow> ct_running' c"
+lemma ct_running'_related:
+  "\<lbrakk> (a, c) \<in> state_relation; invs' c; ct_running a \<rbrakk>
+     \<Longrightarrow> ct_running' c"
   apply (clarsimp simp: ct_in_state_def ct_in_state'_def
                         curthread_relation)
   apply (frule(1) st_tcb_at_coerce_haskell)
@@ -1601,11 +1183,12 @@ lemma ct_running'_related: "\<lbrakk>(a, c) \<in> state_relation; invs' c; ct_ru
   apply (case_tac st, simp_all)[1]
   done
 
-lemma ct_idle'_related: "\<lbrakk>(a, c) \<in> state_relation; invs' c; ct_idle a\<rbrakk> \<Longrightarrow> ct_idle' c"
-  apply (clarsimp simp: ct_in_state_def ct_in_state'_def
-                        curthread_relation)
+lemma ct_idle'_related:
+  "\<lbrakk> (a, c) \<in> state_relation; invs' c; ct_idle a \<rbrakk>
+     \<Longrightarrow> ct_idle' c"
+  apply (clarsimp simp: ct_in_state_def ct_in_state'_def curthread_relation)
   apply (frule(1) st_tcb_at_coerce_haskell)
-  apply (simp add: invs'_def cur_tcb'_def curthread_relation)
+   apply (simp add: invs'_def cur_tcb'_def curthread_relation)
   apply (erule pred_tcb'_weakenE)
   apply (case_tac st, simp_all)[1]
   done
@@ -1621,15 +1204,29 @@ lemma sched_act_cnt_related:
   by (case_tac "scheduler_action a", simp_all add: state_relation_def)
 
 
-lemma haskell_to_abs: "uop_nonempty uop \<Longrightarrow> global_automata_refine
-                               check_active_irq_A_if (do_user_op_A_if uop)
-                               kernel_call_A_if kernel_handle_preemption_if
-                               kernel_schedule_if kernel_exit_A_if
-                               full_invs_if (ADT_A_if uop) {s. step_restrict s}
-                               checkActiveIRQ_H_if (doUserOp_H_if uop)
-                               kernelCall_H_if handlePreemption_H_if
-                               schedule'_H_if kernelExit_H_if
-                               full_invs_if' (ADT_H_if uop) (lift_snd_rel state_relation) True"
+context ADT_IF_Refine_1 begin
+
+lemma kernel_exit_if_corres:
+  "corres (=) (invs) (invs') (kernel_exit_if tc) (kernelExit_if tc)"
+  apply (simp add: kernel_exit_if_def kernelExit_if_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split_deprecated[where r'="(=)"])
+       apply simp
+       apply (rule threadGet_corres)
+       apply (erule arch_tcb_context_get_atcbContextGet)
+      apply (rule getCurThread_corres)
+     apply wp+
+   apply fastforce+
+  done
+
+lemma haskell_to_abs:
+  "uop_nonempty uop
+   \<Longrightarrow> global_automata_refine check_active_irq_A_if (do_user_op_A_if uop) kernel_call_A_if
+                              kernel_handle_preemption_if kernel_schedule_if kernel_exit_A_if
+                              full_invs_if (ADT_A_if uop) {s. step_restrict s} checkActiveIRQ_H_if
+                              (doUserOp_H_if uop) kernelCall_H_if handlePreemption_H_if
+                              schedule'_H_if kernelExit_H_if full_invs_if' (ADT_H_if uop)
+                              (lift_snd_rel state_relation) True"
   apply (simp add: global_automata_refine_def)
   apply (intro conjI)
     apply (rule abstract_invs)
@@ -1644,8 +1241,7 @@ lemma haskell_to_abs: "uop_nonempty uop \<Longrightarrow> global_automata_refine
           apply (simp add: ADT_H_if_def ADT_A_if_def lift_fst_rel_def)
           apply (clarsimp simp: lift_snd_rel_def)
           apply (subgoal_tac "((a, absKState bb), ba) \<in> full_invs_if \<and> (absKState bb, bb) \<in> state_relation")
-           apply (fastforce simp: step_restrict_def has_srel_state_def
-                                  lift_fst_rel_def lift_snd_rel_def)
+           apply (fastforce simp: step_restrict_def has_srel_state_def lift_fst_rel_def lift_snd_rel_def)
           apply (simp add: full_invs_if'_def)
           apply (clarsimp simp: ex_abs_def)
           apply (frule(1) absKState_correct[rotated],simp+)
@@ -1710,22 +1306,16 @@ lemma haskell_to_abs: "uop_nonempty uop \<Longrightarrow> global_automata_refine
   apply (drule use_valid[OF _ kernel_entry_if_no_preempt]; simp)
   done
 
-lemma doUserOp_if_no_interrupt: "\<lbrace>K(uop_sane uop)\<rbrace> doUserOp_if uop tc \<lbrace>\<lambda>r s. (fst r) \<noteq> Some Interrupt\<rbrace>"
-  apply (simp add: doUserOp_if_def del: split_paired_All)
-  apply (wp select_wp | wpc)+
-  apply (clarsimp simp: uop_sane_def simp del: split_paired_All)
-  done
-
-lemma ADT_A_if_Init_Fin_serial: "uop_sane uop \<Longrightarrow>
-       Init_Fin_serial (ADT_A_if uop) s0 (full_invs_if \<inter> {s. step_restrict s})"
+lemma ADT_A_if_Init_Fin_serial:
+  "uop_sane uop \<Longrightarrow> Init_Fin_serial (ADT_A_if uop) s0 (full_invs_if \<inter> {s. step_restrict s})"
   apply (simp add: Init_Fin_serial_def)
   apply (rule conjI)
    apply (rule global_automata_refine.abs_serial[OF haskell_to_abs])
       apply (simp add: uop_sane_def uop_nonempty_def)
      apply (fastforce simp: step_restrict_def has_srel_state_def)
-   apply (clarsimp simp add: doUserOp_H_if_def)
-   apply (frule use_valid[OF _ doUserOp_if_no_interrupt])
-    apply simp+
+    apply (clarsimp simp add: doUserOp_H_if_def)
+    apply (frule use_valid[OF _ doUserOp_if_no_interrupt])
+     apply simp+
   apply (unfold_locales)
    apply (clarsimp simp: ADT_A_if_def)+
   done
@@ -1737,10 +1327,12 @@ lemma ADT_A_if_enabled:
   apply simp
   done
 
+end
+
+
 lemma (in valid_initial_state_noenabled) uop_nonempty:
   "uop_nonempty utf"
-  apply (simp add: uop_nonempty_def utf_non_empty)
-  done
+  by (simp add: uop_nonempty_def utf_non_empty)
 
 lemma (in valid_initial_state_noenabled) uop_sane:
   "uop_sane utf"
@@ -1749,12 +1341,11 @@ lemma (in valid_initial_state_noenabled) uop_sane:
   apply blast
   done
 
-sublocale valid_initial_state_noenabled \<subseteq> valid_initial_state
-     apply (unfold_locales)
-      using ADT_A_if_enabled[of utf s0, OF uop_sane]
-      apply (fastforce simp: enabled_system_def s0_def)
-     using ADT_A_if_Init_Fin_serial[OF uop_sane, of s0]
-     apply (simp only: Init_Fin_serial_def serial_system_def Init_Fin_serial_axioms_def s0_def)+
-  done
+locale ADT_valid_initial_state_noenabled = ADT_IF_Refine_1 + valid_initial_state_noenabled
+
+sublocale ADT_valid_initial_state_noenabled \<subseteq> valid_initial_state
+  using ADT_A_if_enabled[of utf s0, OF uop_sane] ADT_A_if_Init_Fin_serial[OF uop_sane, of s0]
+  by unfold_locales (fastforce simp: enabled_system_def s0_def Init_Fin_serial_def
+                                     serial_system_def Init_Fin_serial_axioms_def)+
 
 end

--- a/proof/infoflow/refine/ADT_IF_Refine_C.thy
+++ b/proof/infoflow/refine/ADT_IF_Refine_C.thy
@@ -5,21 +5,8 @@
  *)
 
 theory ADT_IF_Refine_C
-imports ADT_IF_Refine "CRefine.Refine_C"
+imports ArchADT_IF_Refine "CRefine.Refine_C"
 begin
-
-context begin interpretation Arch . (*FIXME: arch_split*)
-
-definition handleInterruptEntry_C_body_if (*:: "(globals myvars, int, l4c_errortype) com"*) where
-"handleInterruptEntry_C_body_if \<equiv> (
-      (\<acute>irq :== CALL getActiveIRQ();;
-       (Guard SignedArithmetic \<lbrace>True\<rbrace>
-         (IF (ucast \<acute>irq :: word32) \<noteq> (ucast ((ucast (-1 :: 16 word)) :: word32)) THEN
-            CALL handleInterrupt(\<acute>irq)
-          FI)));;
-       \<acute>ret__unsigned_long :== scast EXCEPTION_NONE)"
-
-
 
 definition handleSyscall_C_body_if
   where
@@ -92,9 +79,17 @@ definition handleVMFaultEvent_C_body_if
           FI;;
             \<acute>ret__unsigned_long :== scast EXCEPTION_NONE))"
 
-end
 
 context kernel_m begin
+
+definition handleInterruptEntry_C_body_if (*:: "(globals myvars, int, l4c_errortype) com"*) where
+"handleInterruptEntry_C_body_if \<equiv> (
+      (\<acute>irq :== CALL getActiveIRQ();;
+       (Guard SignedArithmetic \<lbrace>True\<rbrace>
+         (IF (ucast \<acute>irq :: obj_ref) \<noteq> (ucast irqInvalid) THEN
+            CALL handleInterrupt(\<acute>irq)
+          FI)));;
+       \<acute>ret__unsigned_long :== scast EXCEPTION_NONE)"
 
 definition
   "callKernel_C_body_if e \<equiv> case e of
@@ -105,14 +100,13 @@ definition
   | VMFaultEvent t \<Rightarrow> (handleVMFaultEvent_C_body_if (vm_fault_type_from_H t))
   | HypervisorEvent t \<Rightarrow> (SKIP ;; \<acute>ret__unsigned_long :== scast EXCEPTION_NONE)"
 
-
 definition
   kernelEntry_C_if (*::
     "bool \<Rightarrow> event \<Rightarrow> user_context \<Rightarrow> (cstate, (bool \<times> user_context)) nondet_monad"*)
   where
   "kernelEntry_C_if (fp :: bool) e tc \<equiv> do
     t \<leftarrow> gets (ksCurThread_' o globals);
-    setArchTCB_C (arch_tcb_C (to_user_context_C tc)) t;
+    setTCBContext_C (to_user_context_C tc) t;
     exec_C \<Gamma> (callKernel_C_body_if e);
     ex \<leftarrow> gets ret__unsigned_long_';
     r \<leftarrow> return (if (ex = scast EXCEPTION_NONE) then Inr () else Inl ex);
@@ -131,52 +125,126 @@ definition
       {(s, b, (tc,s'))|s b tc s' r. ((r,tc),s') \<in> fst (split (kernelEntry_C_if fp e) s) \<and>
                    b = (case r of Inl x \<Rightarrow> True | Inr x \<Rightarrow> False)}"
 
+definition
+  checkActiveIRQ_C_if :: "user_context \<Rightarrow> (cstate, irq option \<times> user_context) nondet_monad"
+  where
+  "checkActiveIRQ_C_if tc \<equiv>
+   do
+      getActiveIRQ_C;
+      irq \<leftarrow>  gets ret__unsigned_long_';
+      return (if irq = ucast irqInvalid then None else Some (ucast irq), tc)
+   od"
 
-lemma handleInterrupt_ccorres:
-  "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
-           (invs')
-           (UNIV)
-           []
-           (handleEvent Interrupt)
-           (handleInterruptEntry_C_body_if)"
-proof -
-  have ucast_not_helper_cheating_unsigned:
-    "\<And>a. ucast (a::10 word) \<noteq> (0xFFFF :: word16) \<Longrightarrow> ucast a \<noteq> (0xFFFF::32 word)"
-    by (word_bitwise)
-  show ?thesis
-  apply (rule ccorres_guard_imp2)
-   apply (simp add: handleEvent_def minus_one_norm handleInterruptEntry_C_body_if_def)
-   apply (clarsimp simp: liftE_def bind_assoc)
-   apply (rule ccorres_rhs_assoc)
-   apply (ctac (no_vcg) add: getActiveIRQ_ccorres)
-    apply (rule ccorres_Guard_Seq)
-    apply (rule_tac P="rv \<noteq> Some 0xFFFF" in ccorres_gen_asm)
-    apply wpc
-     apply (simp add: ccorres_cond_empty_iff)
-     apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
-     apply (rule allI, rule conseqPre, vcg)
-     apply (clarsimp simp: return_def)
-    apply (clarsimp simp: ucast_not_helper_cheating_unsigned ucast_helper_simps_32
-      ucast_not_helper ccorres_cond_univ_iff ucast_ucast_a is_down)
-    apply (ctac (no_vcg) add: handleInterrupt_ccorres)
-     apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
-     apply (rule allI, rule conseqPre, vcg)
-     apply (clarsimp simp: return_def)
+definition
+  check_active_irq_C_if
+  where
+  "check_active_irq_C_if \<equiv> {((tc, s), irq, (tc', s')). ((irq, tc'), s') \<in> fst (checkActiveIRQ_C_if tc s)}"
+
+lemma corres_select_f':
+  "\<lbrakk> \<And>s s'. P s \<Longrightarrow> P' s' \<Longrightarrow> \<forall>s' \<in> fst S'. \<exists>s \<in> fst S. rvr s s'; nf' \<Longrightarrow> \<not> snd S' \<rbrakk>
+      \<Longrightarrow> corres_underlying sr nf nf' rvr P P' (select_f S) (select_f S')"
+  by (clarsimp simp: select_f_def corres_underlying_def)
+
+lemma cur_thread_of_absKState[simp]:
+   "cur_thread (absKState s) = (ksCurThread s)"
+   by (clarsimp simp: cstate_relation_def Let_def absKState_def cstate_to_H_def)
+
+lemma absKState_crelation:
+  "\<lbrakk> cstate_relation s (globals s'); invs' s \<rbrakk> \<Longrightarrow>  cstate_to_A s' = absKState s"
+  apply (clarsimp simp add: cstate_to_H_correct invs'_def cstate_to_A_def)
+  apply (clarsimp simp: absKState_def absExst_def observable_memory_def)
+  apply (case_tac s)
+  apply clarsimp
+  apply (case_tac ksMachineState)
+  apply clarsimp
+  apply (rule ext)
+  by (clarsimp simp: option_to_0_def user_mem'_def pointerInUserData_def ko_wp_at'_def
+                     obj_at'_def typ_at'_def ps_clear_def
+              split: if_splits)
+
+definition
+  handlePreemption_C_if :: "user_context \<Rightarrow> (cstate,user_context) nondet_monad" where
+  "handlePreemption_C_if tc \<equiv> do (exec_C \<Gamma> handleInterruptEntry_C_body_if); return tc od"
+
+lemma handlePreemption_if_def2:
+  "handlePreemption_if tc = do
+     r \<leftarrow> handleEvent Interrupt;
+          stateAssert (\<lambda>s. (ksDomainTime s = 0 \<longrightarrow> ksSchedulerAction s = ChooseNewThread) \<and>
+                            valid_domain_list' s) [];
+          return tc
+   od"
+  apply (clarsimp simp add: handlePreemption_if_def handleEvent_def liftE_def
+                   bind_assoc)
+  apply (rule bind_eqI)
+  apply (rule ext)
+  apply (clarsimp split: option.splits)
+  done
+
+lemma handleInterrupt_no_fail:
+  "no_fail (ex_abs (einvs) and invs'
+                           and (\<lambda>s. intStateIRQTable (ksInterruptState s) a \<noteq> irqstate.IRQInactive))
+           (handleInterrupt a)"
+  apply (rule no_fail_pre)
+  apply (rule corres_nofail)
+    apply (rule handleInterrupt_corres)
+   apply (erule FalseE)
+  apply (fastforce simp: ex_abs_def)
+  done
+
+lemma handleEvent_Interrupt_no_fail: "no_fail (invs' and ex_abs einvs) (handleEvent Interrupt)"
+  apply (simp add: handleEvent_def)
+  apply (rule no_fail_pre)
+   apply wp
+    apply (rule handleInterrupt_no_fail)
+   apply (simp add: crunch_simps)
+   apply (rule_tac Q="\<lambda>r s. ex_abs (einvs) s \<and> invs' s \<and>
+                            (\<forall>irq. r = Some irq
+                                   \<longrightarrow> intStateIRQTable (ksInterruptState s) irq \<noteq> irqstate.IRQInactive)"
+                in hoare_strengthen_post)
+    apply (rule hoare_vcg_conj_lift)
+     apply (rule corres_ex_abs_lift)
+      apply (rule dmo_getActiveIRQ_corres)
+     apply wp
+     apply simp
     apply wp
-   apply (rule_tac Q="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)
-                                     \<and> rv \<noteq> Some 0xFFFF" in hoare_post_imp)
-    apply (clarsimp simp: Kernel_C.maxIRQ_def ARM.maxIRQ_def)
-   apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0xFF | simp)+
+     apply simp
+    apply (rule doMachineOp_getActiveIRQ_IRQ_active)
+   apply clarsimp
   apply (clarsimp simp: invs'_def valid_state'_def)
   done
-qed
+
+end
+
+
+locale ADT_IF_Refine_1 = kernel_m +
+  fixes doUserOp_C_if ::
+    "user_transition_if \<Rightarrow> user_context \<Rightarrow> (cstate, (event option \<times> user_context)) nondet_monad"
+  assumes do_user_op_if_C_corres:
+    "corres_underlying rf_sr False False (=) (invs' and ex_abs einvs and (\<lambda>_. uop_nonempty f))
+                       \<top> (doUserOp_if f tc) (doUserOp_C_if f tc)"
+  assumes handleInterrupt_if_ccorres:
+    "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_') (invs') (UNIV) []
+             (handleEvent Interrupt) (handleInterruptEntry_C_body_if)"
+  and handleInvocation_ccorres':
+    "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
+       (invs' and arch_extras and ct_active' and sch_act_simple
+              and (\<lambda>s. \<forall>x. ksCurThread s \<notin> set (ksReadyQueues s x)))
+       (UNIV \<inter> {s. isCall_' s = from_bool isCall} \<inter> {s. isBlocking_' s = from_bool isBlocking}) []
+       (handleInvocation isCall isBlocking) (Call handleInvocation_'proc)"
+  and check_active_irq_corres_C:
+    "corres_underlying rf_sr False False (=) \<top> \<top> (checkActiveIRQ_if tc) (checkActiveIRQ_C_if tc)"
+  and obs_cpspace_user_data_relation:
+    "\<lbrakk> pspace_aligned' bd; pspace_distinct' bd;
+       cpspace_user_data_relation (ksPSpace bd) (underlying_memory (ksMachineState bd)) hgs \<rbrakk>
+       \<Longrightarrow> cpspace_user_data_relation (ksPSpace bd)
+             (underlying_memory (observable_memory (ksMachineState bd) (user_mem' bd))) hgs"
+begin
 
 lemma handleEvent_ccorres:
   notes K_def[simp del]
   shows
   "ccorres (\<lambda>rv rv'. (rv = Inr ()) = (rv' = scast EXCEPTION_NONE)) ret__unsigned_long_'
-           (invs' and
-               (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
+           (invs' and arch_extras and
                 (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s) and
                (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
            (UNIV) []
@@ -188,59 +256,70 @@ lemma handleEvent_ccorres:
   apply (rule ccorres_guard_imp2)
    apply (simp add: handleEvent_def callKernel_C_body_if_def)
    apply (wpc, simp_all)[1]
-       apply (wpc, simp_all add: handleSyscall_C_body_if_def syscall_from_H_def liftE_def mask_def
-                                 ccorres_cond_univ_iff syscall_defs ccorres_cond_empty_iff)[1]
-              \<comment> \<open>SysCall\<close>
-              apply (simp add: handleCall_def)
-              apply (ctac (no_vcg) add: handleInvocation_ccorres)
-             \<comment> \<open>SysReplyRecv\<close>
-             apply (simp add: bind_assoc)
-             apply (rule ccorres_rhs_assoc)+
-             apply (ctac (no_vcg) add: handleReply_ccorres)
-              apply (ctac (no_vcg) add: handleRecv_ccorres)
-               apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
-               apply (rule allI, rule conseqPre, vcg)
-               apply (clarsimp simp: return_def)
-              apply wp[1]
-             apply clarsimp
-             apply wp
-             apply (rule_tac Q="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s \<and>
-                                (\<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p))"
-                   in hoare_post_imp)
-              apply (simp add: ct_in_state'_def)
-             apply (wp handleReply_sane handleReply_ct_not_ksQ)
+        apply (wpc; simp add: handleSyscall_C_body_if_def syscall_from_H_def
+                  ; simp add: syscall_defs liftE_def ccorres_cond_univ_iff ccorres_cond_empty_iff)
+               \<comment> \<open>SysCall\<close>
+               apply (simp add: handleCall_def)
+               apply (ctac (no_vcg) add: handleInvocation_ccorres')
+              \<comment> \<open>SysReplyRecv\<close>
+              apply (simp add: bind_assoc)
+              apply (rule ccorres_rhs_assoc)+
+              apply (ctac (no_vcg) add: handleReply_ccorres)
+               apply (ctac (no_vcg) add: handleRecv_ccorres)
+                apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
+                apply (rule allI, rule conseqPre, vcg)
+                apply (clarsimp simp: return_def)
+               apply wp[1]
+              apply clarsimp
+              apply wp
+              apply (rule_tac Q="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s \<and>
+                                 (\<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p))"
+                    in hoare_post_imp)
+               apply (simp add: ct_in_state'_def)
+              apply (wp handleReply_sane handleReply_ct_not_ksQ)
              \<comment> \<open>SysSend\<close>
+             apply (simp add: handleSend_def)
+             apply (ctac (no_vcg) add: handleInvocation_ccorres)
+            \<comment> \<open>SysNBSend\<close>
             apply (simp add: handleSend_def)
             apply (ctac (no_vcg) add: handleInvocation_ccorres)
-           \<comment> \<open>SysNBSend\<close>
-           apply (simp add: handleSend_def)
-           apply (ctac (no_vcg) add: handleInvocation_ccorres)
-          \<comment> \<open>SysRecv\<close>
-          apply (ctac (no_vcg) add: handleRecv_ccorres)
+           \<comment> \<open>SysRecv\<close>
+           apply (ctac (no_vcg) add: handleRecv_ccorres)
+            apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
+            apply (rule allI, rule conseqPre, vcg)
+            apply (clarsimp simp: return_def)
+           apply wp
+          \<comment> \<open>SysReply\<close>
+          apply (ctac (no_vcg) add: handleReply_ccorres)
            apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
            apply (rule allI, rule conseqPre, vcg)
            apply (clarsimp simp: return_def)
           apply wp
-         \<comment> \<open>SysReply\<close>
-         apply (ctac (no_vcg) add: handleReply_ccorres)
+         \<comment> \<open>SysYield\<close>
+         apply (ctac (no_vcg) add: handleYield_ccorres)
           apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
           apply (rule allI, rule conseqPre, vcg)
           apply (clarsimp simp: return_def)
          apply wp
-       \<comment> \<open>SysYield\<close>
-       apply (ctac (no_vcg) add: handleYield_ccorres)
-        apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
-        apply (rule allI, rule conseqPre, vcg)
-        apply (clarsimp simp: return_def)
-       apply wp
-      \<comment> \<open>SysNBRecv\<close>
-          apply (ctac (no_vcg) add: handleRecv_ccorres)
-           apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
-           apply (rule allI, rule conseqPre, vcg)
-           apply (clarsimp simp: return_def)
-          apply wp
-      \<comment> \<open>UnknownSyscall\<close>
-      apply (simp add: liftE_def bind_assoc handleUnknownSyscall_C_body_if_def)
+        \<comment> \<open>SysNBRecv\<close>
+        apply (ctac (no_vcg) add: handleRecv_ccorres)
+         apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
+         apply (rule allI, rule conseqPre, vcg)
+         apply (clarsimp simp: return_def)
+        apply wp
+       \<comment> \<open>UnknownSyscall\<close>
+       apply (simp add: liftE_def bind_assoc handleUnknownSyscall_C_body_if_def)
+       apply (rule ccorres_pre_getCurThread)
+       apply (rule ccorres_symb_exec_r)
+         apply (ctac (no_vcg) add: handleFault_ccorres)
+          apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
+          apply (rule allI, rule conseqPre, vcg)
+          apply (clarsimp simp: return_def)
+         apply wp
+        apply (clarsimp, vcg)
+       apply (clarsimp, rule conseqPre, vcg, clarsimp)
+      \<comment> \<open>UserLevelFault\<close>
+      apply (simp add: liftE_def bind_assoc handleUserLevelFault_C_body_if_def)
       apply (rule ccorres_pre_getCurThread)
       apply (rule ccorres_symb_exec_r)
         apply (ctac (no_vcg) add: handleFault_ccorres)
@@ -250,51 +329,40 @@ lemma handleEvent_ccorres:
         apply wp
        apply (clarsimp, vcg)
       apply (clarsimp, rule conseqPre, vcg, clarsimp)
-     \<comment> \<open>UserLevelFault\<close>
-     apply (simp add: liftE_def bind_assoc handleUserLevelFault_C_body_if_def)
-     apply (rule ccorres_pre_getCurThread)
-     apply (rule ccorres_symb_exec_r)
-       apply (ctac (no_vcg) add: handleFault_ccorres)
-        apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
-        apply (rule allI, rule conseqPre, vcg)
-        apply (clarsimp simp: return_def)
-       apply wp
-      apply (clarsimp, vcg)
-     apply (clarsimp, rule conseqPre, vcg, clarsimp)
-    \<comment> \<open>Interrupt\<close>
-    apply (ctac add: handleInterrupt_ccorres[unfolded handleEvent_def, simplified])
-   \<comment> \<open>VMFaultEvent\<close>
-   apply (simp add: liftE_def bind_assoc handleVMFaultEvent_C_body_if_def)
-   apply (rule ccorres_pre_getCurThread)
-   apply (simp add: catch_def)
-   apply (rule ccorres_rhs_assoc2)
-   apply (rule ccorres_split_nothrow_novcg)
-       apply (rule ccorres_split_nothrow_case_sum)
-            apply (ctac (no_vcg) add: handleVMFault_ccorres)
-           apply ceqv
+     \<comment> \<open>Interrupt\<close>
+     apply (ctac add: handleInterrupt_if_ccorres[unfolded handleEvent_def, simplified])
+    \<comment> \<open>VMFaultEvent\<close>
+    apply (simp add: liftE_def bind_assoc handleVMFaultEvent_C_body_if_def)
+    apply (rule ccorres_pre_getCurThread)
+    apply (simp add: catch_def)
+    apply (rule ccorres_rhs_assoc2)
+    apply (rule ccorres_split_nothrow_novcg)
+        apply (rule ccorres_split_nothrow_case_sum)
+             apply (ctac (no_vcg) add: handleVMFault_ccorres)
+            apply ceqv
+           apply clarsimp
           apply clarsimp
-         apply clarsimp
-         apply (rule ccorres_cond_univ)
-         apply (rule_tac P="\<lambda>s. thread = ksCurThread s" in ccorres_cross_over_guard)
-         apply (rule_tac xf'=xfdc in ccorres_call)
-            apply (ctac (no_vcg) add: handleFault_ccorres)
+          apply (rule ccorres_cond_univ)
+          apply (rule_tac P="\<lambda>s. thread = ksCurThread s" in ccorres_cross_over_guard)
+          apply (rule_tac xf'=xfdc in ccorres_call)
+             apply (ctac (no_vcg) add: handleFault_ccorres)
+            apply simp
            apply simp
           apply simp
-         apply simp
-        apply (wp hv_inv_ex')
-       apply (simp add: guard_is_UNIV_def)
-       apply (vcg exspec=handleVMFault_modifies)
-      apply ceqv
-     apply clarsimp
-     apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
-     apply (rule allI, rule conseqPre, vcg)
-     apply (clarsimp simp: return_def)
-    apply wp
-   apply (simp add: guard_is_UNIV_def)
-  apply (auto simp: ct_in_state'_def ct_not_ksQ isReply_def is_cap_fault_def
-                    cfault_rel_def seL4_Fault_UnknownSyscall_lift seL4_Fault_UserException_lift
-              elim: pred_tcb'_weakenE st_tcb_ex_cap''
-              dest: st_tcb_at_idle_thread' rf_sr_ksCurThread)
+         apply (wp hv_inv_ex')
+        apply (simp add: guard_is_UNIV_def)
+        apply (vcg exspec=handleVMFault_modifies)
+       apply ceqv
+      apply clarsimp
+      apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
+      apply (rule allI, rule conseqPre, vcg)
+      apply (clarsimp simp: return_def)
+     apply wp
+    apply (simp add: guard_is_UNIV_def)
+   apply (auto simp: ct_in_state'_def ct_not_ksQ isReply_def is_cap_fault_def
+                     cfault_rel_def seL4_Fault_UnknownSyscall_lift seL4_Fault_UserException_lift
+               elim: pred_tcb'_weakenE st_tcb_ex_cap''
+               dest: st_tcb_at_idle_thread' rf_sr_ksCurThread)
   \<comment> \<open>HypervisorEvent\<close>
   apply (simp add: liftE_def bind_assoc)
   apply (rule ccorres_guard_imp2)
@@ -308,10 +376,11 @@ lemma handleEvent_ccorres:
   done
 
 lemma kernelEntry_corres_C:
-  "corres_underlying rf_sr False False (prod_lift (\<lambda>r r'. (r = Inr ()) = (r' = Inr ()))) (
-                     all_invs' e) \<top>
-                     (kernelEntry_if e tc) (kernelEntry_C_if fp e tc)"
+  "corres_underlying rf_sr False False
+     (prod_lift (\<lambda>r r'. (r = Inr ()) = (r' = Inr ()))) (all_invs' e) \<top>
+     (kernelEntry_if e tc) (kernelEntry_C_if fp e tc)"
   using corres_nofail[OF kernel_entry_if_corres[of e tc], simplified]
+  supply nonzero_gt_zero[simp] gt_zero_nonzero[simp]
   apply (simp add: kernelEntry_if_def kernelEntry_C_if_def)
   apply (simp only: bind_assoc[symmetric])
   apply (rule corres_stateAssert_no_fail)
@@ -322,13 +391,14 @@ lemma kernelEntry_corres_C:
   apply (simp only: bind_assoc)
   apply (simp add: getCurThread_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated [where P=\<top> and P'=\<top> and r'="\<lambda>t t'. t' = tcb_ptr_to_ctcb_ptr t"])
+    apply (rule corres_split_deprecated[where P=\<top> and P'=\<top> and r'="\<lambda>t t'. t' = tcb_ptr_to_ctcb_ptr t"])
        prefer 2
        apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
       apply (rule corres_split_deprecated)
          prefer 2
          apply (subst archTcbUpdate_aux2[symmetric])
-         apply (rule setArchTCB_C_corres, simp, rule ccontext_rel_to_C)
+         apply (rule setTCBContext_C_corres)
+          apply (simp add: ccontext_rel_to_C)
          apply simp
         apply (rule corres_split_deprecated[OF _ ccorres_corres_u_xf, simplified bind_assoc])
             prefer 3
@@ -353,333 +423,20 @@ lemma kernelEntry_corres_C:
       apply simp
       apply (rule hoare_post_taut[where P=\<top>])
      apply wp+
-   apply (clarsimp simp: all_invs'_def invs'_def cur_tcb'_def)
-   apply fastforce
-  done
-
-end
-
-context state_rel
-begin
-
-definition
-  "ptable_rights_s'' s \<equiv> ptable_rights (cur_thread (cstate_to_A s)) (cstate_to_A s)"
-
-definition
-  "ptable_lift_s'' s \<equiv> ptable_lift (cur_thread (cstate_to_A s)) (cstate_to_A s)"
-
-definition
-  "ptable_attrs_s'' s \<equiv> ptable_attrs (cur_thread (cstate_to_A s)) (cstate_to_A s)"
-
-definition
-  "ptable_xn_s'' s \<equiv> \<lambda>addr. XNever \<in> ptable_attrs_s'' s addr"
-
-definition
-  doMachineOp_C :: "(machine_state, 'a) nondet_monad \<Rightarrow> (cstate, 'a) nondet_monad"
-where
- "doMachineOp_C mop \<equiv>
-  do
-    ms \<leftarrow> gets (\<lambda>s. phantom_machine_state_' (globals s));
-    (r, ms') \<leftarrow> select_f (mop ms);
-    modify (\<lambda>s. s \<lparr>globals := globals s \<lparr> phantom_machine_state_' := ms' \<rparr>\<rparr>);
-    return r
-  od"
-
-definition doUserOp_C_if
-  :: "user_transition_if \<Rightarrow> user_context \<Rightarrow> (cstate, (event option \<times> user_context)) nondet_monad"
-   where
-  "doUserOp_C_if uop tc \<equiv>
-   do
-      pr \<leftarrow> gets ptable_rights_s'';
-      pxn \<leftarrow> gets (\<lambda>s x. pr x \<noteq> {} \<and> ptable_xn_s'' s x);
-      pl \<leftarrow> gets (\<lambda>s. restrict_map (ptable_lift_s'' s) {x. pr x \<noteq> {}});
-      allow_read \<leftarrow> return {y. \<exists>x. pl x = Some y \<and> AllowRead \<in> pr x};
-      allow_write \<leftarrow> return {y. \<exists>x. pl x = Some y \<and> AllowWrite \<in> pr x};
-      t \<leftarrow> gets (\<lambda>s. cur_thread (cstate_to_A s));
-      um \<leftarrow> gets (\<lambda>s. user_mem_C (globals s) \<circ> ptrFromPAddr);
-      dm \<leftarrow> gets (\<lambda>s. device_mem_C (globals s) \<circ> ptrFromPAddr);
-      ds \<leftarrow> gets (\<lambda>s. device_state (phantom_machine_state_' (globals s)));
-      assert (dom (um \<circ> addrFromPPtr) \<subseteq> - dom ds);
-      assert (dom (dm \<circ> addrFromPPtr) \<subseteq> dom ds);
-      es \<leftarrow> doMachineOp_C getExMonitor;
-      u \<leftarrow> return (uop t pl pr pxn (tc, um |` allow_read, (ds \<circ> ptrFromPAddr)|` allow_read ,es));
-      assert (u \<noteq> {});
-      (e,(tc',um',ds',es')) \<leftarrow> select u;
-      setUserMem_C ((um' |` allow_write \<circ> addrFromPPtr) |` (- dom ds));
-      setDeviceState_C ((ds' |` allow_write \<circ> addrFromPPtr) |` dom ds);
-      doMachineOp_C (setExMonitor es');
-      return (e,tc')
-   od"
-
-
-definition
-  do_user_op_C_if
-  where
-  "do_user_op_C_if uop \<equiv> {(s,e,(tc,s'))| s e tc s'. ((e,tc),s') \<in> fst (split (doUserOp_C_if uop) s)}"
-
-end
-
-context kernel_m begin
-
-
-
-lemma corres_underlying_split5:
-    "(\<And>a b c d e. corres_underlying srel nf nf' rrel (Q a b c d e) (Q' a b c d e) (f a b c d e) (f' a b c d e)) \<Longrightarrow>
-     corres_underlying srel nf nf' rrel (case x of (a,b,c,d,e) \<Rightarrow> Q a b c d e) (case x of (a,b,c,d,e) \<Rightarrow> Q' a b c d e) (case x of (a,b,c,d,e) \<Rightarrow> f a b c d e) (case x of (a,b,c,d,e) \<Rightarrow> f' a b c d e)"
-  apply (case_tac x)
-  apply simp
-  done
-
-lemma corres_select_f':
-  "\<lbrakk> \<And>s s'. P s \<Longrightarrow> P' s' \<Longrightarrow> \<forall>s' \<in> fst S'. \<exists>s \<in> fst S. rvr s s'; nf' \<Longrightarrow> \<not> snd S' \<rbrakk>
-      \<Longrightarrow> corres_underlying sr nf nf' rvr P P' (select_f S) (select_f S')"
-  by (clarsimp simp: select_f_def corres_underlying_def)
-
-lemma corres_dmo_getExMonitor_C:
-  "corres_underlying rf_sr nf nf' (=) \<top> \<top> (doMachineOp getExMonitor) (doMachineOp_C getExMonitor)"
-  supply subst_all [simp del]
-  apply (clarsimp simp: doMachineOp_def doMachineOp_C_def)
-  apply (rule corres_guard_imp)
-    apply (rule_tac r'="\<lambda>ms ms'. exclusive_state ms = exclusive_state ms' \<and> machine_state_rest ms = machine_state_rest ms'
-      \<and> irq_masks ms = irq_masks ms' \<and> equiv_irq_state ms ms' \<and> device_state ms = device_state ms'" and P="\<top>" and P'="\<top>" in corres_split_deprecated)
-       apply (rule_tac r'="\<lambda>(r, ms) (r', ms'). r = r' \<and> ms = rv \<and> ms' = rv'" in corres_split_deprecated)
-          apply (clarsimp simp: split_def)
-          apply (rule_tac r'=dc and P="\<lambda>s. underlying_memory (snd ((aa, bb), ba)) = underlying_memory (ksMachineState s)"
-                 and P'="\<lambda>s. underlying_memory (snd ((aa, bb), bc)) = underlying_memory (phantom_machine_state_' (globals s))" in corres_split_deprecated)
-             apply clarsimp
-            apply (rule corres_modify)
-            apply (clarsimp simp: rf_sr_def cstate_relation_def carch_state_relation_def cmachine_state_relation_def Let_def)
-           apply (wp hoare_TrueI)+
-         apply (rule corres_select_f')
-          apply (clarsimp simp: getExMonitor_def machine_rest_lift_def NonDetMonad.bind_def gets_def get_def return_def modify_def put_def select_f_def)
-         apply (clarsimp simp: getExMonitor_no_fail[simplified no_fail_def])
-        apply (wp hoare_TrueI)+
-      apply (clarsimp simp: rf_sr_def cstate_relation_def cmachine_state_relation_def Let_def)
-     apply (wp hoare_TrueI)+
-  apply (rule TrueI conjI | clarsimp simp: getExMonitor_def machine_rest_lift_def NonDetMonad.bind_def gets_def get_def return_def modify_def put_def select_f_def)+
-  done
-
-lemma corres_dmo_setExMonitor_C:
-  "corres_underlying rf_sr nf nf' dc \<top> \<top> (doMachineOp (setExMonitor es)) (doMachineOp_C (setExMonitor es))"
-  apply (clarsimp simp: doMachineOp_def doMachineOp_C_def)
-  apply (rule corres_guard_imp)
-    apply (rule_tac r'="\<lambda>ms ms'. exclusive_state ms = exclusive_state ms' \<and> machine_state_rest ms = machine_state_rest ms'
-      \<and> irq_masks ms = irq_masks ms' \<and> equiv_irq_state ms ms' \<and> device_state ms = device_state ms'" and P="\<top>" and P'="\<top>" in corres_split_deprecated)
-       apply (rule_tac r'="\<lambda>(r, ms) (r', ms'). ms = rv\<lparr>exclusive_state := es\<rparr> \<and> ms' = rv'\<lparr>exclusive_state := es\<rparr>" in corres_split_deprecated)
-          apply (simp add: split_def)
-          apply (rule_tac P="\<lambda>s. underlying_memory (snd rva) = underlying_memory (ksMachineState s)"
-                 and P'="\<lambda>s. underlying_memory (snd rv'a) = underlying_memory (phantom_machine_state_' (globals s))" in corres_modify)
-          apply (clarsimp simp: rf_sr_def cstate_relation_def carch_state_relation_def cmachine_state_relation_def Let_def)
-         apply (rule corres_select_f')
-          apply (clarsimp simp: setExMonitor_def machine_rest_lift_def NonDetMonad.bind_def gets_def get_def return_def modify_def put_def select_f_def)
-         apply (clarsimp simp: setExMonitor_no_fail[simplified no_fail_def])
-        apply (wp hoare_TrueI)+
-      apply (clarsimp simp: rf_sr_def cstate_relation_def cmachine_state_relation_def Let_def)
-     apply (wp hoare_TrueI)+
-  apply (rule TrueI conjI | clarsimp simp: setExMonitor_def machine_rest_lift_def NonDetMonad.bind_def gets_def get_def return_def modify_def put_def select_f_def)+
-  done
-
-lemma dmo_getExMonitor_C_wp[wp]:
-  "\<lbrace>\<lambda>s. P (exclusive_state (phantom_machine_state_' (globals s))) s\<rbrace>
-   doMachineOp_C getExMonitor \<lbrace>P\<rbrace>"
-  apply(simp add: doMachineOp_C_def)
-  apply(wp modify_wp | wpc)+
-  apply clarsimp
-  apply(erule use_valid)
-   apply wp
-  apply simp
-  done
-
-lemma cur_thread_of_absKState[simp]:
-   "cur_thread (absKState s) = (ksCurThread s)"
-   by (clarsimp simp: cstate_relation_def Let_def absKState_def cstate_to_H_def)
-
-lemma absKState_crelation:
-  "\<lbrakk>cstate_relation s (globals s'); invs' s\<rbrakk>\<Longrightarrow>  cstate_to_A s' = absKState s"
-  apply (clarsimp simp add: cstate_to_H_correct invs'_def cstate_to_A_def)
-  apply (clarsimp simp: absKState_def absExst_def observable_memory_def)
-  apply (case_tac s)
-  apply clarsimp
-  apply (case_tac ksMachineState)
-  apply clarsimp
-  apply (rule ext)
-  by (clarsimp simp: option_to_0_def user_mem'_def pointerInUserData_def ko_wp_at'_def
-                     obj_at'_def typ_at'_def ps_clear_def
-              split: if_splits)
-
-lemma do_user_op_if_C_corres:
-   "corres_underlying rf_sr False False (=)
-   (invs' and ex_abs einvs and (\<lambda>_. uop_nonempty f)) \<top>
-   (doUserOp_if f tc) (doUserOp_C_if f tc)"
-  apply (rule corres_gen_asm)
-  apply (simp add: doUserOp_if_def doUserOp_C_if_def uop_nonempty_def del: split_paired_All)
-  apply (rule corres_gets_same)
-    apply (clarsimp simp: absKState_crelation ptable_rights_s'_def ptable_rights_s''_def
-           rf_sr_def  cstate_relation_def Let_def cstate_to_H_correct)
-   apply simp
-  apply (rule corres_gets_same)
-    apply (clarsimp simp: ptable_xn_s'_def ptable_xn_s''_def ptable_attrs_s_def
-                          absKState_crelation ptable_attrs_s'_def ptable_attrs_s''_def  rf_sr_def)
-   apply simp
-  apply (rule corres_gets_same)
-    apply (clarsimp simp: absKState_crelation curthread_relation ptable_lift_s'_def ptable_lift_s''_def
-                         ptable_lift_s_def rf_sr_def)
-   apply simp
-  apply (simp add: getCurThread_def)
-  apply (rule corres_gets_same)
-    apply (simp add: absKState_crelation rf_sr_def)
-   apply simp
-  apply (rule corres_gets_same)
-    apply (rule fun_cong[where x=ptrFromPAddr])
-    apply (rule_tac f=comp in arg_cong)
-    apply (rule user_mem_C_relation[symmetric])
-    apply (simp add: rf_sr_def cstate_relation_def Let_def
-                               cpspace_relation_def)
-    apply fastforce
-   apply simp
-  apply (rule corres_gets_same)
-    apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
-                          cpspace_relation_def)
-    apply (drule device_mem_C_relation[symmetric])
-     apply fastforce
-    apply (simp add: comp_def)
-   apply simp
-  apply (rule corres_gets_same)
-    apply (clarsimp simp: cstate_relation_def rf_sr_def
-                          Let_def cmachine_state_relation_def)
-   apply simp
-  apply (rule corres_guard_imp)
-    apply (rule_tac P=\<top> and P'=\<top> and r'="(=)" in corres_split_deprecated)
-       prefer 2
-       apply (clarsimp simp add: corres_underlying_def fail_def
-                                 assert_def return_def
-                          split: if_splits)
-      apply simp
-      apply (rule_tac P=\<top> and P'=\<top> and r'="(=)" in corres_split_deprecated)
-         prefer 2
-         apply (clarsimp simp add: corres_underlying_def fail_def
-                                   assert_def return_def
-                            split: if_splits)
-        apply simp
-        apply (rule corres_split_deprecated[OF _ corres_dmo_getExMonitor_C])
-          apply clarsimp
-          apply (rule_tac r'="(=)" in corres_split_deprecated[OF _ corres_select])
-              prefer 2
-              apply clarsimp
-             apply simp
-             apply (rule corres_underlying_split5)
-             apply (rule corres_split_deprecated[OF _ user_memory_update_corres_C])
-               apply (rule corres_split_deprecated[OF _ device_update_corres_C])
-                 apply (rule corres_split_deprecated[OF _ corres_dmo_setExMonitor_C,
-                               where R="\<top>\<top>" and R'="\<top>\<top>"])
-                        apply (wp select_wp | simp)+
-    apply (clarsimp simp:  ex_abs_def restrict_map_def invs_pspace_aligned'
-                           invs_pspace_distinct' ptable_lift_s'_def ptable_rights_s'_def
-                   split: if_splits)
-    apply (drule ptable_rights_imp_UserData[rotated -1])
-     apply ((fastforce | intro conjI)+)[4]
-    apply (clarsimp simp: user_mem'_def device_mem'_def dom_def split: if_splits)
-    apply fastforce
-   apply (clarsimp simp add: invs'_def valid_state'_def valid_pspace'_def ex_abs_def)
-   done
-
-definition
-  checkActiveIRQ_C_if :: "user_context \<Rightarrow> (cstate, irq option \<times> user_context) nondet_monad"
-  where
-  "checkActiveIRQ_C_if tc \<equiv>
-   do
-      getActiveIRQ_C;
-      irq \<leftarrow>  gets ret__unsigned_long_';
-      return (if irq = 0xFFFF then None else Some (ucast irq), tc)
-   od"
-
-definition
-  check_active_irq_C_if
-  where
-  "check_active_irq_C_if \<equiv> {((tc, s), irq, (tc', s')). ((irq, tc'), s') \<in> fst (checkActiveIRQ_C_if tc s)}"
-
-lemma check_active_irq_corres_C:
-  "corres_underlying rf_sr False False (=) \<top> \<top>
-                     (checkActiveIRQ_if tc) (checkActiveIRQ_C_if tc)"
-  apply (simp add: checkActiveIRQ_if_def checkActiveIRQ_C_if_def)
-  apply (simp add: getActiveIRQ_C_def)
-  apply (subst bind_assoc[symmetric])
-  apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[where r'="\<lambda>a c. case a of None \<Rightarrow> c = 0xFFFF | Some x \<Rightarrow> c = ucast x \<and> c \<noteq> 0xFFFF", OF _ ccorres_corres_u_xf])
-        apply (clarsimp split: if_split option.splits)
-       apply (rule ccorres_guard_imp)
-         apply (rule ccorres_rel_imp, rule ccorres_guard_imp)
-            apply (rule getActiveIRQ_ccorres)
-           apply simp+
-         apply (case_tac x; simp add: ucast_helper_simps_32)
-        apply simp+
-      apply (rule no_fail_dmo')
-      apply (rule getActiveIRQ_nf)
-     apply (rule hoare_post_taut[where P=\<top>])+
-   apply simp+
-   apply fastforce
-  done
-
-
-definition
-  handlePreemption_C_if :: "user_context \<Rightarrow> (cstate,user_context) nondet_monad" where
-  "handlePreemption_C_if tc \<equiv>
-       do (exec_C \<Gamma> handleInterruptEntry_C_body_if); return tc od"
-
-lemma handlePreemption_if_def2:
-  "handlePreemption_if tc = do
-     r \<leftarrow> handleEvent Interrupt;
-          stateAssert (\<lambda>s. (ksDomainTime s = 0 \<longrightarrow> ksSchedulerAction s = ChooseNewThread) \<and>
-                            valid_domain_list' s) [];
-          return tc
-   od"
-  apply (clarsimp simp add: handlePreemption_if_def handleEvent_def liftE_def
-                   bind_assoc)
-  apply (rule bind_eqI)
-  apply (rule ext)
-  apply (clarsimp split: option.splits)
-  done
-
-lemma handleInterrupt_no_fail: "no_fail (ex_abs (einvs) and invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) a \<noteq> irqstate.IRQInactive)) (handleInterrupt a)"
-  apply (rule no_fail_pre)
-  apply (rule corres_nofail)
-    apply (rule handleInterrupt_corres)
-   apply (erule FalseE)
-  apply (fastforce simp: ex_abs_def)
-  done
-
-lemma handleEvent_Interrupt_no_fail: "no_fail (invs' and ex_abs einvs) (handleEvent Interrupt)"
-  apply (simp add: handleEvent_def)
-  apply (rule no_fail_pre)
-   apply wp
-    apply (rule handleInterrupt_no_fail)
-   apply (simp add: crunch_simps)
-   apply (rule_tac Q="\<lambda>r s. ex_abs (einvs) s \<and>
-                      invs' s \<and> (\<forall>irq. r = Some irq \<longrightarrow> intStateIRQTable (ksInterruptState s) irq \<noteq> irqstate.IRQInactive)" in hoare_strengthen_post)
-    apply (rule hoare_vcg_conj_lift)
-     apply (rule corres_ex_abs_lift)
-      apply (rule dmo_getActiveIRQ_corres)
-     apply wp
-     apply simp
-    apply wp
-     apply simp
-    apply (rule doMachineOp_getActiveIRQ_IRQ_active)
-   apply clarsimp
-  apply (clarsimp simp: invs'_def valid_state'_def)
+   apply (clarsimp simp: all_invs'_def invs'_def cur_tcb'_def valid_state'_def)
+  apply fastforce
   done
 
 lemma handle_preemption_corres_C:
   "corres_underlying rf_sr False False (=)
-                     (invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
-                      valid_domain_list' and (\<lambda>s. 0 < ksDomainTime s) and
-                      ex_abs einvs) \<top>
-                     (handlePreemption_if tc) (handlePreemption_C_if tc)"
+     (invs' and valid_domain_list' and (\<lambda>s. 0 < ksDomainTime s) and ex_abs einvs) \<top>
+     (handlePreemption_if tc) (handlePreemption_C_if tc)"
   apply (simp add: handlePreemption_if_def2 handlePreemption_C_if_def)
   apply (rule corres_stateAssert_no_fail)
    using corres_nofail[OF handle_preemption_if_corres[of tc], simplified]
    apply (simp add: handlePreemption_if_def2)
    apply (erule no_fail_pre)
-   apply (clarsimp simp: ex_abs_underlying_def)
+   apply (clarsimp simp: ex_abs_underlying_def ex_abs_def)
    apply (rule exI, rule conjI, assumption)
    apply (clarsimp simp: domain_time_rel_eq domain_list_rel_eq)
   apply (rule corres_guard_imp)
@@ -688,7 +445,7 @@ lemma handle_preemption_corres_C:
       apply (rule ccorres_corres_u)
        apply (rule ccorres_guard_imp)
          apply (rule ccorres_rel_imp)
-          apply (rule handleInterrupt_ccorres)
+          apply (rule handleInterrupt_if_ccorres)
          apply simp
         prefer 3
         apply (rule handleEvent_Interrupt_no_fail)
@@ -698,24 +455,25 @@ lemma handle_preemption_corres_C:
    apply (fastforce simp: ex_abs_def schedaction_related)+
   done
 
+end
+
+
+context kernel_m begin
 
 definition
   handle_preemption_C_if
   where
   "handle_preemption_C_if \<equiv>
-      {(s, u, s'). s' \<in> fst (split handlePreemption_C_if s)}"
+     {(s, u, s'). s' \<in> fst (split handlePreemption_C_if s)}"
 
 definition
   schedule_C_if' :: "user_context \<Rightarrow> (cstate,user_context) nondet_monad" where
   "schedule_C_if' tc \<equiv>
-    do exec_C \<Gamma> (Call schedule_'proc); exec_C \<Gamma> (Call activateThread_'proc); return tc od"
-
+     do exec_C \<Gamma> (Call schedule_'proc); exec_C \<Gamma> (Call activateThread_'proc); return tc od"
 
 lemma ccorres_corres_u':
-  "\<lbrakk>ccorres dc xfdc P' Q' [] H C; no_fail P'' H;
-    (\<And>s. P s \<Longrightarrow> P' s \<and> P'' s);
-    (Collect Q) \<subseteq> Q'\<rbrakk> \<Longrightarrow>
-   corres_underlying rf_sr nf nf' dc P Q H (exec_C \<Gamma> C)"
+  "\<lbrakk> ccorres dc xfdc P' Q' [] H C; no_fail P'' H; (\<And>s. P s \<Longrightarrow> P' s \<and> P'' s); (Collect Q) \<subseteq> Q' \<rbrakk>
+     \<Longrightarrow> corres_underlying rf_sr nf nf' dc P Q H (exec_C \<Gamma> C)"
   apply (rule ccorres_corres_u)
    apply (rule ccorres_guard_imp)
      apply assumption
@@ -724,12 +482,11 @@ lemma ccorres_corres_u':
   apply (rule no_fail_pre,simp+)
   done
 
-
 lemma schedule_if_corres_C:
   "corres_underlying rf_sr False False (=)
-                     (invs' and ex_abs einvs and valid_domain_list' and
-                      (\<lambda>s. ksDomainTime s = 0 \<longrightarrow> ksSchedulerAction s = ChooseNewThread)) \<top>
-                     (schedule'_if tc) (schedule_C_if' tc)"
+     (invs' and ex_abs einvs and valid_domain_list'
+            and (\<lambda>s. ksDomainTime s = 0 \<longrightarrow> ksSchedulerAction s = ChooseNewThread)) \<top>
+     (schedule'_if tc) (schedule_C_if' tc)"
   apply (simp add: schedule'_if_def schedule_C_if'_def)
   apply (subst bind_assoc[symmetric], rule corres_stateAssert_no_fail)
    using corres_nofail[OF schedule_if_corres[of tc], simplified]
@@ -760,7 +517,8 @@ lemma schedule_if_corres_C:
         apply (erule FalseE)
        apply simp
       apply simp
-     apply (rule_tac Q="\<lambda>r. ct_in_state' activatable' and invs' and ex_abs(invs and ct_in_state activatable)" in hoare_strengthen_post)
+     apply (rule_tac Q="\<lambda>r. ct_in_state' activatable' and invs' and
+                            ex_abs (invs and ct_in_state activatable)" in hoare_strengthen_post)
       apply (wp schedule_invs' corres_ex_abs_lift)
        apply (rule schedule_corres)
       apply wp
@@ -771,26 +529,44 @@ lemma schedule_if_corres_C:
    apply (auto simp: ex_abs_def)
   done
 
-definition
-  schedule_C_if
-  where
-  "schedule_C_if \<equiv>
-      {(s, (e :: unit), s'). s' \<in> fst (split schedule_C_if' s)}"
 
-definition
- kernelExit_C_if :: "user_context \<Rightarrow> (cstate,user_context) nondet_monad" where
+definition schedule_C_if where
+  "schedule_C_if \<equiv> {(s, (e :: unit), s'). s' \<in> fst (split schedule_C_if' s)}"
+
+definition kernelExit_C_if :: "user_context \<Rightarrow> (cstate,user_context) nondet_monad" where
   "kernelExit_C_if tc \<equiv>
    do t \<leftarrow> gets (ksCurThread_' \<circ> globals);
       gets $ getContext_C t
    od"
 
+definition kernel_exit_C_if where
+  "kernel_exit_C_if \<equiv>
+     {(s, m, s'). s' \<in> fst (split kernelExit_C_if s) \<and>
+                  m = (if ct_running_C (snd s') then InUserMode else InIdleMode)}"
+
+end
+
+
 lemma corres_underlying_nf_imp2:
   "corres_underlying rf_sr nf True a b c d e \<Longrightarrow> corres_underlying rf_sr nf nf' a b c d e"
   by (auto simp: corres_underlying_def)
 
+lemma preserves_trivial: "preserves mode mode' UNIV f"
+  apply (simp add: preserves_def)
+  done
+
+lemma preserves'_trivial: "preserves' mode UNIV f"
+  apply (simp add: preserves'_def)
+  done
+
+
+context ADT_IF_Refine_1 begin
+
+definition do_user_op_C_if where
+  "do_user_op_C_if uop \<equiv> {(s,e,(tc,s'))| s e tc s'. ((e,tc),s') \<in> fst (split (doUserOp_C_if uop) s)}"
+
 lemma kernel_exit_corres_C:
-  "corres_underlying rf_sr False nf (=) (invs') \<top>
-                     (kernelExit_if tc) (kernelExit_C_if tc)"
+  "corres_underlying rf_sr False nf (=) (invs') \<top> (kernelExit_if tc) (kernelExit_C_if tc)"
   apply (rule corres_underlying_nf_imp2)
   apply (simp add: kernelExit_if_def kernelExit_C_if_def)
   apply (rule corres_guard_imp)
@@ -804,35 +580,6 @@ lemma kernel_exit_corres_C:
    apply clarsimp+
   done
 
-
-definition
-  kernel_exit_C_if
-  where
-  "kernel_exit_C_if \<equiv>
-      {(s, m, s'). s' \<in> fst (split kernelExit_C_if s) \<and>
-                   m = (if ct_running_C (snd s') then InUserMode else InIdleMode)}"
-
-end
-
-lemma preserves_trivial: "preserves mode mode' UNIV f"
-  apply (simp add: preserves_def)
-  done
-
-lemma preserves'_trivial: "preserves' mode UNIV f"
-  apply (simp add: preserves'_def)
-  done
-
-context kernel_m begin
-
-
-definition ADT_C_if where
-"ADT_C_if fp uop \<equiv> \<lparr>Init = \<lambda>s. ({user_context_of s} \<times> {s'. cstate_to_A s' = (internal_state_if s)}) \<times> {sys_mode_of s} \<inter> {s''. \<exists>s'. ((internal_state_if s'),(internal_state_if s'')) \<in> rf_sr \<and> s' \<in> full_invs_if' \<and> sys_mode_of s = sys_mode_of s'},
-                  Fin = \<lambda>((uc,s),m). ((uc, cstate_to_A s),m),
-                  Step = (\<lambda>(u :: unit). global_automaton_if
-                              check_active_irq_C_if (do_user_op_C_if uop)
-                              (kernel_call_C_if fp) handle_preemption_C_if
-                              schedule_C_if kernel_exit_C_if)\<rparr>"
-
 lemma full_invs_all_invs[simp]:
   "((tc,s),KernelEntry e) \<in> full_invs_if' \<Longrightarrow> all_invs' e s"
   apply (clarsimp simp: full_invs_if'_def all_invs'_def ex_abs_def)
@@ -840,44 +587,11 @@ lemma full_invs_all_invs[simp]:
   by (auto simp: ct_running_related ct_idle_related schedaction_related
                  domain_time_rel_eq domain_list_rel_eq)
 
-lemma obs_cpspace_user_data_relation:
-  "\<lbrakk>pspace_aligned' bd;pspace_distinct' bd;
-    cpspace_user_data_relation (ksPSpace bd) (underlying_memory (ksMachineState bd)) hgs\<rbrakk>
-   \<Longrightarrow> cpspace_user_data_relation (ksPSpace bd) (underlying_memory (observable_memory (ksMachineState bd) (user_mem' bd))) hgs"
-   apply (clarsimp simp: cmap_relation_def dom_heap_to_user_data)
-   apply (drule bspec,fastforce)
-   apply (clarsimp simp: cuser_user_data_relation_def observable_memory_def
-                         heap_to_user_data_def map_comp_def Let_def
-                  split: option.split_asm)
-   apply (drule_tac x = off in spec)
-   apply (subst option_to_0_user_mem')
-   apply (subst map_option_byte_to_word_heap)
-    apply (clarsimp simp: projectKO_opt_user_data pointerInUserData_def field_simps
-                   split: kernel_object.split_asm option.split_asm)
-    apply (frule(1) pspace_alignedD')
-    apply (subst neg_mask_add_aligned)
-      apply (simp add: objBits_simps)
-     apply (simp add: word_less_nat_alt)
-     apply (rule le_less_trans[OF unat_plus_gt])
-     apply (subst add.commute)
-     apply (subst unat_mult_simple)
-      apply (simp add: word_bits_def)
-      apply (rule less_le_trans[OF unat_lt2p])
-      apply simp
-     apply simp
-    apply (rule nat_add_offset_less [where n = 2, simplified])
-      apply simp
-     apply (rule unat_lt2p)
-    apply (simp add: pageBits_def objBits_simps)
-   apply (frule(1) pspace_distinctD')
-   apply (clarsimp simp: obj_at'_def typ_at'_def ko_wp_at'_def objBits_simps)
-  apply simp
-  done
-
 lemma obs_cpspace_device_data_relation:
-  "\<lbrakk>pspace_aligned' bd;pspace_distinct' bd;
-    cpspace_device_data_relation (ksPSpace bd) (underlying_memory (ksMachineState bd)) hgs\<rbrakk>
-   \<Longrightarrow> cpspace_device_data_relation (ksPSpace bd) (underlying_memory (observable_memory (ksMachineState bd) (user_mem' bd))) hgs"
+  "\<lbrakk> pspace_aligned' bd; pspace_distinct' bd;
+     cpspace_device_data_relation (ksPSpace bd) (underlying_memory (ksMachineState bd)) hgs \<rbrakk>
+     \<Longrightarrow> cpspace_device_data_relation (ksPSpace bd)
+           (underlying_memory (observable_memory (ksMachineState bd) (user_mem' bd))) hgs"
    apply (clarsimp simp: cmap_relation_def dom_heap_to_device_data)
    apply (drule bspec,fastforce)
    apply (clarsimp simp: cuser_user_data_device_relation_def observable_memory_def
@@ -886,21 +600,32 @@ lemma obs_cpspace_device_data_relation:
    done
 
 lemma cstate_relation_observable_memory:
-  "\<lbrakk>invs' bs;cstate_relation bs gs\<rbrakk>
-  \<Longrightarrow> cstate_relation (bs\<lparr>ksMachineState := observable_memory (ksMachineState bs) (user_mem' bs)\<rparr>) gs"
+  "\<lbrakk> invs' bs; cstate_relation bs gs \<rbrakk>
+     \<Longrightarrow> cstate_relation (bs\<lparr>ksMachineState := observable_memory (ksMachineState bs) (user_mem' bs)\<rparr>) gs"
   by (clarsimp simp: cstate_relation_def Let_def obs_cpspace_user_data_relation
                      obs_cpspace_device_data_relation cpspace_relation_def invs'_def
                      valid_state'_def valid_pspace'_def
                      cmachine_state_relation_def observable_memory_def)
 
 
+definition ADT_C_if where
+  "ADT_C_if fp uop \<equiv>
+     \<lparr>Init = \<lambda>s. ({user_context_of s} \<times> {s'. cstate_to_A s' = (internal_state_if s)}) \<times>
+                  {sys_mode_of s} \<inter> {s''. \<exists>s'. ((internal_state_if s'),(internal_state_if s'')) \<in> rf_sr \<and>
+                                                s' \<in> full_invs_if' \<and> sys_mode_of s = sys_mode_of s'},
+                  Fin = \<lambda>((uc,s),m). ((uc, cstate_to_A s),m),
+                  Step = (\<lambda>(u :: unit). global_automaton_if
+                              check_active_irq_C_if (do_user_op_C_if uop)
+                              (kernel_call_C_if fp) handle_preemption_C_if
+                              schedule_C_if kernel_exit_C_if)\<rparr>"
+
+
 lemma c_to_haskell:
-  "uop_nonempty uop \<Longrightarrow>
-   global_automata_refine checkActiveIRQ_H_if (doUserOp_H_if uop) kernelCall_H_if
-     handlePreemption_H_if schedule'_H_if kernelExit_H_if full_invs_if' (ADT_H_if uop) UNIV
-     check_active_irq_C_if (do_user_op_C_if uop) (kernel_call_C_if fp) handle_preemption_C_if schedule_C_if
-     kernel_exit_C_if UNIV (ADT_C_if fp uop) (lift_snd_rel rf_sr) False"
-  supply subst_all [simp del]
+  "uop_nonempty uop
+   \<Longrightarrow> global_automata_refine checkActiveIRQ_H_if (doUserOp_H_if uop) kernelCall_H_if
+         handlePreemption_H_if schedule'_H_if kernelExit_H_if full_invs_if' (ADT_H_if uop) UNIV
+         check_active_irq_C_if (do_user_op_C_if uop) (kernel_call_C_if fp) handle_preemption_C_if
+         schedule_C_if kernel_exit_C_if UNIV (ADT_C_if fp uop) (lift_snd_rel rf_sr) False"
   apply (simp add: global_automata_refine_def)
   apply (intro conjI)
     apply (rule haskell_invs)
@@ -913,7 +638,7 @@ lemma c_to_haskell:
          apply (simp add: ADT_H_if_def ADT_C_if_def lift_fst_rel_def lift_snd_rel_def)
          apply safe
          apply (clarsimp simp: absKState_crelation  rf_sr_def full_invs_if'_def)
-         apply (rule_tac x="((a,bd),ba)" in bexI)
+         apply (rule_tac x="((a,bb),ba)" in bexI)
           apply simp
          apply simp
          apply (frule cstate_to_H_correct[rotated],simp add: invs'_def)
@@ -964,6 +689,5 @@ theorem infoflow_refinement_A: "uop_nonempty uop \<Longrightarrow> ADT_C_if fp u
   done
 
 end
-
 
 end

--- a/proof/infoflow/refine/ARM/ArchADT_IF_Refine.thy
+++ b/proof/infoflow/refine/ARM/ArchADT_IF_Refine.thy
@@ -1,0 +1,480 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchADT_IF_Refine
+imports ADT_IF_Refine
+begin
+
+context Arch begin global_naming ARM
+
+named_theorems ADT_IF_Refine_assms
+
+defs arch_extras_def:
+  "arch_extras \<equiv> \<lambda>s. vs_valid_duplicates' (ksPSpace s)"
+
+declare arch_extras_def[simp]
+
+lemma kernelEntry_invs'[ADT_IF_Refine_assms, wp]:
+  "\<lbrace>invs' and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s)
+          and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
+          and arch_extras\<rbrace>
+   kernelEntry_if e tc
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  apply (simp add: kernelEntry_if_def)
+  apply (wp threadSet_invs_trivial threadSet_ct_running' static_imp_wp
+         | wp (once) hoare_drop_imps
+         | clarsimp)+
+  done
+
+lemma kernelEntry_arch_extras[ADT_IF_Refine_assms, wp]:
+  "\<lbrace>invs' and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s)
+          and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
+          and arch_extras\<rbrace>
+   kernelEntry_if e tc
+   \<lbrace>\<lambda>_. arch_extras\<rbrace>"
+  apply (simp add: kernelEntry_if_def)
+  apply (wp handleEvent_valid_duplicates' threadSet_invs_trivial threadSet_ct_running' static_imp_wp
+         | wp (once) hoare_drop_imps
+         | clarsimp)+
+  done
+
+crunches threadSet
+  for arch_extras[ADT_IF_Refine_assms, wp]: "arch_extras"
+
+lemma arch_tcb_context_set_tcb_relation[ADT_IF_Refine_assms]:
+  "tcb_relation tcb tcb'
+   \<Longrightarrow> tcb_relation (tcb\<lparr>tcb_arch := arch_tcb_context_set tc (tcb_arch tcb)\<rparr>)
+                    (tcbArch_update (atcbContextSet tc) tcb')"
+  by (simp add: tcb_relation_def arch_tcb_relation_def arch_tcb_context_set_def atcbContextSet_def)
+
+lemma arch_tcb_context_get_atcbContextGet[ADT_IF_Refine_assms]:
+  "tcb_relation tcb tcb'
+   \<Longrightarrow> (arch_tcb_context_get \<circ> tcb_arch) tcb = (atcbContextGet \<circ> tcbArch) tcb'"
+  by (simp add: tcb_relation_def arch_tcb_relation_def arch_tcb_context_get_def atcbContextGet_def)
+
+definition
+  "ptable_attrs_s' s \<equiv> ptable_attrs (ksCurThread s) (absKState s)"
+
+definition
+  "ptable_xn_s' s \<equiv>  \<lambda>addr. XNever \<in> ptable_attrs_s' s addr"
+
+definition doUserOp_if ::
+  "user_transition_if \<Rightarrow> user_context \<Rightarrow> (event option \<times> user_context) kernel" where
+  "doUserOp_if uop tc \<equiv>
+  do pr \<leftarrow> gets ptable_rights_s';
+     pxn \<leftarrow> gets (\<lambda>s x. pr x \<noteq> {} \<and> ptable_xn_s' s x);
+     pl \<leftarrow> gets (\<lambda>s. ptable_lift_s' s |` {x. pr x \<noteq> {}});
+     allow_read \<leftarrow> return {y. \<exists>x. pl x = Some y \<and> AllowRead \<in> pr x};
+     allow_write \<leftarrow> return {y. \<exists>x. pl x = Some y \<and> AllowWrite \<in> pr x};
+     t \<leftarrow> getCurThread;
+     um \<leftarrow> gets (\<lambda>s. (user_mem' s \<circ> ptrFromPAddr));
+     dm \<leftarrow> gets (\<lambda>s. (device_mem' s \<circ> ptrFromPAddr));
+     ds \<leftarrow> gets (device_state \<circ> ksMachineState);
+     assert (dom (um \<circ> addrFromPPtr) \<subseteq> - dom ds);
+     assert (dom (dm \<circ> addrFromPPtr) \<subseteq> dom ds);
+     es \<leftarrow> doMachineOp getExMonitor;
+     u \<leftarrow>
+       return
+        (uop t pl pr pxn
+          (tc, um |` allow_read,
+           (ds \<circ> ptrFromPAddr) |` allow_read, es));
+     assert (u \<noteq> {});
+     (e, tc', um',ds', es') \<leftarrow> select u;
+     doMachineOp
+      (user_memory_update
+        ((um' |` allow_write \<circ> addrFromPPtr) |` (- (dom ds))));
+     doMachineOp
+      (device_memory_update
+          ((ds' |` allow_write \<circ> addrFromPPtr) |` dom ds));
+     doMachineOp (setExMonitor es');
+     return (e, tc')
+  od"
+
+lemma getExMonitor_empty_fail[wp]:
+  "empty_fail getExMonitor"
+  by (simp add: getExMonitor_def)
+
+lemma setExMonitor_empty_fail[wp]:
+  "empty_fail (setExMonitor es)"
+  by (simp add: setExMonitor_def)
+
+lemma getExMonitor_no_fail[wp]:
+  "no_fail \<top> getExMonitor"
+  by (simp add: getExMonitor_def)
+
+lemma setExMonitor_no_fail'[wp]:
+  "no_fail \<top> (setExMonitor (x, y))"
+  by (simp add: setExMonitor_def)
+
+lemma setExMonitor_no_fail[wp]:
+  "no_fail \<top> (setExMonitor es)"
+  by (simp add: setExMonitor_def)
+
+lemma ptable_attrs_abs_state[simp]:
+  "ptable_attrs thread (abs_state s) = ptable_attrs thread s"
+  by (simp add: ptable_attrs_def abs_state_def)
+
+lemma doUserOp_if_empty_fail[ADT_IF_Refine_assms]:
+  "empty_fail (doUserOp_if uop tc)"
+  apply (simp add: doUserOp_if_def)
+  apply (wp (once))
+   apply wp
+  apply (wp (once))
+   apply wp
+  apply (wp (once))
+   apply wp
+  apply (wp (once))
+   apply wp
+  apply (wp (once))
+   apply wp
+  apply (wp (once))
+   apply wp
+  apply (wp (once))
+   apply wp
+  apply (wp (once))
+   apply wp
+  apply (wp (once))
+   apply wp
+  apply (wp (once))
+   apply wp
+  apply (subst bind_assoc[symmetric])
+  apply (rule empty_fail_bind)
+   apply (rule empty_fail_select_bind)
+  apply (wp | wpc)+
+  done
+
+lemma do_user_op_if_corres[ADT_IF_Refine_assms]:
+  "corres (=) (einvs and ct_running and (\<lambda>_. \<forall>t pl pr pxn tcu. f t pl pr pxn tcu \<noteq> {}))
+              (invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_running')
+              (do_user_op_if f tc) (doUserOp_if f tc)"
+  apply (rule corres_gen_asm)
+  apply (simp add: do_user_op_if_def doUserOp_if_def)
+  apply (rule corres_gets_same)
+    apply (clarsimp simp: ptable_rights_s_def ptable_rights_s'_def)
+    apply (subst absKState_correct, fastforce, assumption+)
+    apply (clarsimp elim!: state_relationE)
+   apply simp
+  apply (rule corres_gets_same)
+    apply (clarsimp simp: ptable_attrs_s'_def ptable_attrs_s_def ptable_xn_s'_def ptable_xn_s_def)
+    apply (subst absKState_correct, fastforce, assumption+)
+    apply (clarsimp elim!: state_relationE)
+   apply simp
+  apply (rule corres_gets_same)
+    apply (clarsimp simp: absArchState_correct curthread_relation ptable_lift_s'_def
+                         ptable_lift_s_def)
+    apply (subst absKState_correct, fastforce, assumption+)
+    apply (clarsimp elim!: state_relationE)
+   apply simp
+  apply (simp add: getCurThread_def)
+  apply (rule corres_gets_same)
+    apply (simp add: curthread_relation)
+   apply simp
+  apply (rule corres_gets_same[where R ="\<lambda>r s. dom (r \<circ> addrFromPPtr) \<subseteq> - device_region s"])
+   apply (clarsimp simp add: user_mem_relation dest!: invs_valid_stateI invs_valid_stateI')
+   apply (clarsimp simp: invs_def valid_state_def pspace_respects_device_region_def)
+   apply fastforce
+  apply (rule corres_gets_same[where R ="\<lambda>r s. dom (r \<circ> addrFromPPtr) \<subseteq> device_region s"])
+   apply (clarsimp simp add: device_mem_relation dest!: invs_valid_stateI invs_valid_stateI')
+   apply (clarsimp simp: invs_def valid_state_def pspace_respects_device_region_def)
+   apply fastforce
+  apply (rule corres_gets_same[where R ="\<lambda>r s. dom r = device_region s"])
+    apply (clarsimp simp: state_relation_def)
+   apply simp
+  apply (rule corres_assert_imp_r)
+   apply fastforce
+  apply (rule corres_assert_imp_r)
+   apply fastforce
+  apply (rule corres_guard_imp)
+       apply (rule corres_split_deprecated[OF _ corres_machine_op,where r'="(=)"])
+         apply clarsimp
+         apply (rule corres_split_deprecated[where r'="(=)"])
+            apply clarsimp
+            apply (rule corres_split_deprecated[OF _ corres_machine_op,where r'="(=)"])
+               apply clarsimp
+               apply (rule corres_split_deprecated[OF _ corres_machine_op,where r'="(=)"])
+                  apply clarsimp
+                  apply (rule corres_split_deprecated[OF _ corres_machine_op, where r'="(=)"])
+                     apply (rule corres_return_same_trivial)
+                    apply (wp hoare_TrueI[where P = \<top>] | simp | rule corres_underlying_trivial)+
+            apply (clarsimp simp: user_memory_update_def)
+            apply (rule non_fail_modify)
+           apply clarsimp
+           apply (wp hoare_TrueI)
+          apply clarsimp
+          apply (wp hoare_TrueI)
+         apply (clarsimp simp: select_def corres_underlying_def)
+         apply (simp only: comp_def | wp hoare_TrueI)+
+      apply (rule corres_underlying_trivial)
+     apply (wp hoare_TrueI)+
+   apply clarsimp
+   apply force
+  apply force
+  done
+
+lemma dmo_getExMonitor_wp'[wp]:
+  "\<lbrace>\<lambda>s. P (exclusive_state (ksMachineState s)) s\<rbrace>
+   doMachineOp getExMonitor
+   \<lbrace>P\<rbrace>"
+  apply(simp add: doMachineOp_def)
+  apply(wp modify_wp | wpc)+
+  apply clarsimp
+  apply(erule use_valid)
+   apply wp
+  apply simp
+  done
+
+lemma dmo_setExMonitor_wp'[wp]:
+  "\<lbrace>\<lambda>s. P (s\<lparr>ksMachineState := ksMachineState s\<lparr>exclusive_state := es\<rparr>\<rparr>)\<rbrace>
+   doMachineOp (setExMonitor es)
+   \<lbrace>\<lambda>_. P\<rbrace>"
+  apply(simp add: doMachineOp_def)
+  apply(wp modify_wp | wpc)+
+  apply clarsimp
+  apply(erule use_valid)
+   apply wp
+  apply simp
+  done
+
+lemma valid_state'_exclusive_state_update[iff]:
+  "valid_state' (s\<lparr>ksMachineState := ksMachineState s\<lparr>exclusive_state := es\<rparr>\<rparr>) = valid_state' s"
+  by (simp add: valid_state'_def valid_machine_state'_def)
+
+lemma invs'_exclusive_state_update[iff]:
+  "invs' (s\<lparr>ksMachineState := ksMachineState s\<lparr>exclusive_state := es\<rparr>\<rparr>) = invs' s"
+  by (simp add: invs'_def)
+
+lemma doUserOp_if_invs'[ADT_IF_Refine_assms, wp]:
+  "\<lbrace>invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_running' and ex_abs (einvs)\<rbrace>
+   doUserOp_if f tc
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  apply (simp add: doUserOp_if_def split_def ex_abs_def)
+  apply (wp device_update_invs' dmo_setExMonitor_wp' dmo_invs' | simp)+
+         apply (clarsimp simp add: no_irq_modify user_memory_update_def)
+         apply wpsimp
+        apply (wp select_wp)+
+  apply (clarsimp simp: user_memory_update_def simpler_modify_def
+                        restrict_map_def
+                 split: option.splits)
+  apply (auto dest: ptable_rights_imp_UserData[rotated 2]
+              simp: ptable_rights_s'_def ptable_lift_s'_def)
+  done
+
+lemma doUserOp_valid_duplicates[ADT_IF_Refine_assms, wp]:
+  "doUserOp_if f tc \<lbrace>arch_extras\<rbrace>"
+  apply (simp add: doUserOp_if_def split_def)
+  apply (wp dmo_setExMonitor_wp' dmo_invs' select_wp | simp)+
+  done
+
+lemma doUserOp_if_schedact[ADT_IF_Refine_assms, wp]:
+  "doUserOp_if f tc \<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace>"
+  apply (simp add: doUserOp_if_def)
+  apply (wp select_wp | wpc | simp)+
+  done
+
+lemma doUserOp_if_st_tcb_at[ADT_IF_Refine_assms, wp]:
+   "doUserOp_if f tc \<lbrace>st_tcb_at' st t\<rbrace>"
+  apply (simp add: doUserOp_if_def)
+  apply (wp select_wp | wpc | simp)+
+  done
+
+lemma doUserOp_if_cur_thread[ADT_IF_Refine_assms, wp]:
+  "doUserOp_if f tc \<lbrace>\<lambda>s. P (ksCurThread s)\<rbrace>"
+  apply (simp add: doUserOp_if_def)
+  apply (wp select_wp | wpc | simp)+
+  done
+
+lemma do_user_op_if_corres'[ADT_IF_Refine_assms]:
+  "corres_underlying state_relation nf False (=) (einvs and ct_running)
+     (invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_running')
+     (do_user_op_if f tc) (doUserOp_if f tc)"
+  apply (simp add: do_user_op_if_def doUserOp_if_def)
+  apply (rule corres_gets_same)
+    apply (clarsimp simp: ptable_rights_s_def ptable_rights_s'_def)
+    apply (subst absKState_correct, fastforce, assumption+)
+    apply (clarsimp elim!: state_relationE)
+   apply simp
+  apply (rule corres_gets_same)
+    apply (clarsimp simp: ptable_attrs_s'_def ptable_attrs_s_def ptable_xn_s'_def ptable_xn_s_def)
+    apply (subst absKState_correct, fastforce, assumption+)
+    apply (clarsimp elim!: state_relationE)
+   apply simp
+  apply (rule corres_gets_same)
+    apply (clarsimp simp: absArchState_correct curthread_relation ptable_lift_s'_def
+                         ptable_lift_s_def)
+    apply (subst absKState_correct, fastforce, assumption+)
+    apply (clarsimp elim!: state_relationE)
+   apply simp
+  apply (simp add: getCurThread_def)
+  apply (rule corres_gets_same)
+    apply (simp add: curthread_relation)
+   apply simp
+  apply (rule corres_gets_same[where R ="\<lambda>r s. dom (r \<circ> addrFromPPtr) \<subseteq> - device_region s"])
+   apply (clarsimp simp add: user_mem_relation dest!: invs_valid_stateI invs_valid_stateI')
+   apply (clarsimp simp: invs_def valid_state_def pspace_respects_device_region_def)
+   apply fastforce
+  apply (rule corres_gets_same[where R ="\<lambda>r s. dom (r \<circ> addrFromPPtr) \<subseteq> device_region s"])
+   apply (clarsimp simp add: device_mem_relation dest!: invs_valid_stateI invs_valid_stateI')
+   apply (clarsimp simp: invs_def valid_state_def pspace_respects_device_region_def dom_def)
+  apply (rule corres_gets_same[where R ="\<lambda>r s. dom r = device_region s"])
+    apply (clarsimp simp: state_relation_def)
+   apply simp
+  apply (rule corres_assert_imp_r)
+   apply fastforce
+  apply (rule corres_assert_imp_r)
+   apply fastforce
+  apply (rule corres_guard_imp)
+       apply (rule corres_split_deprecated[OF _ corres_machine_op',where r'="(=)"])
+         apply simp
+         apply (rule corres_split_deprecated[where r'="dc"])
+            apply simp
+            apply (rule corres_split_deprecated[where r'="(=)"])
+               apply clarsimp
+               apply (rule corres_split_deprecated[OF _ corres_machine_op',where r'="(=)"])
+                  apply simp
+                  apply (rule corres_split_deprecated[OF _ corres_machine_op', where r'="(=)"])
+                     apply simp
+                     apply (rule corres_split_deprecated[OF _ corres_machine_op', where r'="(=)"])
+                     apply (rule corres_return_same_trivial)
+                    apply (wp hoare_TrueI[where P = \<top>] | simp | rule corres_underlying_trivial)+
+           apply (clarsimp simp: select_def corres_underlying_def)
+           apply (simp only: comp_def | wp hoare_TrueI)+
+       apply (rule corres_assert')
+       apply (wp hoare_TrueI[where P = \<top>] | simp | rule corres_underlying_trivial)+
+   apply clarsimp
+   apply force
+  apply force
+  done
+
+lemma getActiveIRQ_nf:
+  "no_fail (\<lambda>_. True) (getActiveIRQ in_kernel)"
+  apply (simp add: getActiveIRQ_def)
+  apply (rule no_fail_pre)
+   apply (rule non_fail_gets non_fail_modify
+               no_fail_return | rule no_fail_bind | simp
+          | intro impI conjI)+
+     apply (wp del: no_irq | simp)+
+  done
+
+lemma dmo_getActiveIRQ_corres[ADT_IF_Refine_assms]:
+  "corres (=) \<top> \<top> (do_machine_op (getActiveIRQ in_kernel)) (doMachineOp (getActiveIRQ in_kernel'))"
+  apply (rule SubMonad_R.corres_machine_op)
+  apply (rule corres_Id)
+    apply (simp add: getActiveIRQ_def non_kernel_IRQs_def)
+   apply simp
+  apply (rule getActiveIRQ_nf)
+  done
+
+lemma dmo'_getActiveIRQ_wp[ADT_IF_Refine_assms]:
+  "\<lbrace>\<lambda>s. P (irq_at (irq_state (ksMachineState s) + 1) (irq_masks (ksMachineState s)))
+          (s\<lparr>ksMachineState := (ksMachineState s\<lparr>irq_state := irq_state (ksMachineState s) + 1\<rparr>)\<rparr>)\<rbrace>
+   doMachineOp (getActiveIRQ in_kernel)
+   \<lbrace>P\<rbrace>"
+  apply(simp add: doMachineOp_def getActiveIRQ_def non_kernel_IRQs_def)
+  apply(wp modify_wp | wpc)+
+  apply clarsimp
+  apply(erule use_valid)
+   apply (wp modify_wp)
+  apply(auto simp: irq_at_def)
+  done
+
+lemma scheduler_if'_arch_extras[ADT_IF_Refine_assms, wp]:
+  "\<lbrace>invs' and arch_extras\<rbrace>
+   schedule'_if tc
+   \<lbrace>\<lambda>_. arch_extras\<rbrace>"
+  apply (simp add: schedule'_if_def)
+  apply (wp hoare_drop_imps | simp)+
+  done
+
+lemma handlePreemption_if_arch_extras[ADT_IF_Refine_assms, wp]:
+  "handlePreemption_if tc \<lbrace>arch_extras\<rbrace>"
+  apply (simp add: handlePreemption_if_def)
+  apply (wp dmo'_getActiveIRQ_wp hoare_drop_imps)
+  apply clarsimp
+  done
+
+lemma handle_preemption_if_corres[ADT_IF_Refine_assms]:
+  "corres (=) (einvs and valid_domain_list and (\<lambda>s. 0 < domain_time s))
+              (invs') (handle_preemption_if tc) (handlePreemption_if tc)"
+  apply (simp add: handlePreemption_if_def handle_preemption_if_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split_deprecated[where r'="(=)"])
+       apply (rule corres_split_deprecated[where r'="dc"])
+          apply (rule corres_stateAssert_assume_stronger[where Q=\<top> and
+                        P="\<lambda>s. valid_domain_list s \<and>
+                               (domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread)"])
+           apply simp
+          apply (clarsimp simp: state_relation_def)
+         apply (rule corres_when)
+          apply simp
+         apply simp
+         apply (rule handleInterrupt_corres)
+        apply (wp handle_interrupt_valid_domain_time)+
+      apply (rule dmo_getActiveIRQ_corres)
+     apply (rule dmo_getActiveIRQ_wp)
+    apply (rule dmo'_getActiveIRQ_wp)
+   apply clarsimp+
+  apply (clarsimp simp: invs'_def valid_state'_def irq_at_def invs_def
+                        Let_def valid_irq_states'_def)
+  done
+
+crunches doUserOp_if
+  for ksDomainTime_inv[ADT_IF_Refine_assms, wp]: "\<lambda>s. P (ksDomainTime s)"
+  and ksDomSchedule_inv[ADT_IF_Refine_assms, wp]: "\<lambda>s. P (ksDomSchedule s)"
+  (wp: select_wp)
+
+crunches checkActiveIRQ_if
+  for arch_extras[ADT_IF_Refine_assms, wp]: arch_extras
+
+lemma valid_device_abs_state_eq[ADT_IF_Refine_assms]:
+  "valid_machine_state s \<Longrightarrow> abs_state s = s"
+  apply (simp add: abs_state_def observable_memory_def)
+  apply (case_tac s)
+  apply clarsimp
+  apply (case_tac machine_state)
+  apply clarsimp
+  apply (rule ext)
+  apply (fastforce simp: user_mem_def option_to_0_def valid_machine_state_def)
+  done
+
+lemma doUserOp_if_no_interrupt[ADT_IF_Refine_assms]:
+  "\<lbrace>K (uop_sane uop)\<rbrace>
+   doUserOp_if uop tc
+   \<lbrace>\<lambda>r s. (fst r) \<noteq> Some Interrupt\<rbrace>"
+  apply (simp add: doUserOp_if_def del: split_paired_All)
+  apply (wp select_wp | wpc)+
+  apply (clarsimp simp: uop_sane_def simp del: split_paired_All)
+  done
+
+lemma handleEvent_corres_arch_extras[ADT_IF_Refine_assms]:
+    "corres (dc \<oplus> dc)
+       (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s)
+              and (\<lambda>s. scheduler_action s = resume_cur_thread))
+       (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s)
+              and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
+              and arch_extras)
+       (handle_event event) (handleEvent event)"
+  by (fastforce intro: corres_guard2_imp[OF handleEvent_corres])
+
+end
+
+requalify_consts
+  ARM.doUserOp_if
+
+
+global_interpretation ADT_IF_Refine_1?: ADT_IF_Refine_1 doUserOp_if
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact ADT_IF_Refine_assms)?)
+qed
+
+
+sublocale valid_initial_state_noenabled \<subseteq> valid_initial_state_noenabled?:
+  ADT_valid_initial_state_noenabled doUserOp_if ..
+
+sublocale valid_initial_state_noenabled \<subseteq> valid_initial_state ..
+
+end

--- a/proof/infoflow/refine/ARM/ArchADT_IF_Refine_C.thy
+++ b/proof/infoflow/refine/ARM/ArchADT_IF_Refine_C.thy
@@ -1,0 +1,333 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchADT_IF_Refine_C
+imports ADT_IF_Refine_C
+begin
+
+context kernel_m begin
+
+named_theorems ADT_IF_Refine_assms
+
+lemma irqInvalid_def2:
+  "irqInvalid = 0xFFFF"
+  by (clarsimp simp: irqInvalid_def mask_def)
+
+lemma handleInterrupt_ccorres[ADT_IF_Refine_assms]:
+  "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_') (invs') (UNIV) []
+           (handleEvent Interrupt) (handleInterruptEntry_C_body_if)"
+proof -
+  show ?thesis
+  apply (rule ccorres_guard_imp2)
+   apply (simp add: handleEvent_def minus_one_norm handleInterruptEntry_C_body_if_def irqInvalid_def2)
+   apply (clarsimp simp: liftE_def bind_assoc)
+   apply (rule ccorres_rhs_assoc)
+   apply (ctac (no_vcg) add: getActiveIRQ_ccorres)
+    apply (rule ccorres_Guard_Seq)
+    apply (rule_tac P="rv \<noteq> Some 0xFFFF" in ccorres_gen_asm)
+    apply wpc
+     apply (simp add: ccorres_cond_empty_iff)
+     apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
+     apply (rule allI, rule conseqPre, vcg)
+     apply (clarsimp simp: return_def)
+    apply (clarsimp simp: ucast_helper_simps_32 ucast_not_helper ccorres_cond_univ_iff ucast_ucast_a is_down)
+    apply (ctac (no_vcg) add: handleInterrupt_ccorres)
+     apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
+     apply (rule allI, rule conseqPre, vcg)
+     apply (clarsimp simp: return_def)
+    apply wp
+   apply (rule_tac Q="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)
+                                     \<and> rv \<noteq> Some 0xFFFF" in hoare_post_imp)
+    apply (clarsimp simp: Kernel_C.maxIRQ_def ARM.maxIRQ_def)
+   apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0xFF | simp)+
+  apply (clarsimp simp: invs'_def valid_state'_def)
+  done
+qed
+
+lemma handleInvocation_ccorres'[ADT_IF_Refine_assms]:
+  "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
+       (invs' and arch_extras and
+        ct_active' and sch_act_simple and
+        (\<lambda>s. \<forall>x. ksCurThread s \<notin> set (ksReadyQueues s x)))
+       (UNIV \<inter> {s. isCall_' s = from_bool isCall}
+             \<inter> {s. isBlocking_' s = from_bool isBlocking}) []
+       (handleInvocation isCall isBlocking) (Call handleInvocation_'proc)"
+  apply (simp only: arch_extras_def)
+  apply (rule handleInvocation_ccorres)
+  done
+
+definition
+  "ptable_rights_s'' s \<equiv> ptable_rights (cur_thread (cstate_to_A s)) (cstate_to_A s)"
+
+definition
+  "ptable_lift_s'' s \<equiv> ptable_lift (cur_thread (cstate_to_A s)) (cstate_to_A s)"
+
+definition
+  "ptable_attrs_s'' s \<equiv> ptable_attrs (cur_thread (cstate_to_A s)) (cstate_to_A s)"
+
+definition
+  "ptable_xn_s'' s \<equiv> \<lambda>addr. XNever \<in> ptable_attrs_s'' s addr"
+
+definition doMachineOp_C :: "(machine_state, 'a) nondet_monad \<Rightarrow> (cstate, 'a) nondet_monad" where
+ "doMachineOp_C mop \<equiv>
+  do
+    ms \<leftarrow> gets (\<lambda>s. phantom_machine_state_' (globals s));
+    (r, ms') \<leftarrow> select_f (mop ms);
+    modify (\<lambda>s. s \<lparr>globals := globals s \<lparr> phantom_machine_state_' := ms' \<rparr>\<rparr>);
+    return r
+  od"
+
+definition doUserOp_C_if ::
+  "user_transition_if \<Rightarrow> user_context \<Rightarrow> (cstate, (event option \<times> user_context)) nondet_monad" where
+  "doUserOp_C_if uop tc \<equiv>
+   do
+      pr \<leftarrow> gets ptable_rights_s'';
+      pxn \<leftarrow> gets (\<lambda>s x. pr x \<noteq> {} \<and> ptable_xn_s'' s x);
+      pl \<leftarrow> gets (\<lambda>s. restrict_map (ptable_lift_s'' s) {x. pr x \<noteq> {}});
+      allow_read \<leftarrow> return {y. \<exists>x. pl x = Some y \<and> AllowRead \<in> pr x};
+      allow_write \<leftarrow> return {y. \<exists>x. pl x = Some y \<and> AllowWrite \<in> pr x};
+      t \<leftarrow> gets (\<lambda>s. cur_thread (cstate_to_A s));
+      um \<leftarrow> gets (\<lambda>s. user_mem_C (globals s) \<circ> ptrFromPAddr);
+      dm \<leftarrow> gets (\<lambda>s. device_mem_C (globals s) \<circ> ptrFromPAddr);
+      ds \<leftarrow> gets (\<lambda>s. device_state (phantom_machine_state_' (globals s)));
+      assert (dom (um \<circ> addrFromPPtr) \<subseteq> - dom ds);
+      assert (dom (dm \<circ> addrFromPPtr) \<subseteq> dom ds);
+      es \<leftarrow> doMachineOp_C getExMonitor;
+      u \<leftarrow> return (uop t pl pr pxn (tc, um |` allow_read, (ds \<circ> ptrFromPAddr)|` allow_read ,es));
+      assert (u \<noteq> {});
+      (e,(tc',um',ds',es')) \<leftarrow> select u;
+      setUserMem_C ((um' |` allow_write \<circ> addrFromPPtr) |` (- dom ds));
+      setDeviceState_C ((ds' |` allow_write \<circ> addrFromPPtr) |` dom ds);
+      doMachineOp_C (setExMonitor es');
+      return (e,tc')
+   od"
+
+lemma corres_dmo_getExMonitor_C:
+  "corres_underlying rf_sr nf nf' (=) \<top> \<top> (doMachineOp getExMonitor) (doMachineOp_C getExMonitor)"
+  apply (clarsimp simp: doMachineOp_def doMachineOp_C_def)
+  apply (rule corres_guard_imp)
+    apply (rule_tac r'="\<lambda>ms ms'. exclusive_state ms = exclusive_state ms' \<and>
+                                 machine_state_rest ms = machine_state_rest ms' \<and>
+                                 irq_masks ms = irq_masks ms' \<and> equiv_irq_state ms ms' \<and>
+                                 device_state ms = device_state ms'"
+                and P="\<top>" and P'="\<top>" in corres_split_deprecated)
+       apply (rule_tac r'="\<lambda>(r, ms) (r', ms'). r = r' \<and> ms = rv \<and> ms' = rv'" in corres_split_deprecated)
+          apply (clarsimp simp: split_def)
+          apply (rule_tac r'=dc and P="\<lambda>s. underlying_memory (snd ((aa, b), ba)) =
+                                           underlying_memory (ksMachineState s)"
+                                and P'="\<lambda>s. underlying_memory (snd ((aa, b), bc)) =
+                                            underlying_memory (phantom_machine_state_' (globals s))"
+                                 in corres_split_deprecated)
+             apply clarsimp
+            apply (rule corres_modify)
+            apply (clarsimp simp: rf_sr_def cstate_relation_def carch_state_relation_def
+                                  cmachine_state_relation_def Let_def)
+           apply (wp hoare_TrueI)+
+         apply (rule corres_select_f')
+          apply (clarsimp simp: getExMonitor_def machine_rest_lift_def NonDetMonad.bind_def gets_def
+                                get_def return_def modify_def put_def select_f_def)
+         apply (clarsimp simp: getExMonitor_no_fail[simplified no_fail_def])
+        apply (wp hoare_TrueI)+
+      apply (clarsimp simp: rf_sr_def cstate_relation_def cmachine_state_relation_def Let_def)
+     apply (wp hoare_TrueI)+
+  apply (rule TrueI conjI | clarsimp simp: getExMonitor_def machine_rest_lift_def NonDetMonad.bind_def
+                                           gets_def get_def return_def modify_def put_def select_f_def)+
+  done
+
+lemma corres_dmo_setExMonitor_C:
+  "corres_underlying rf_sr nf nf' dc \<top> \<top> (doMachineOp (setExMonitor es)) (doMachineOp_C (setExMonitor es))"
+  apply (clarsimp simp: doMachineOp_def doMachineOp_C_def)
+  apply (rule corres_guard_imp)
+    apply (rule_tac r'="\<lambda>ms ms'. exclusive_state ms = exclusive_state ms' \<and>
+                                 machine_state_rest ms = machine_state_rest ms' \<and>
+                                 irq_masks ms = irq_masks ms' \<and> equiv_irq_state ms ms' \<and>
+                                 device_state ms = device_state ms'"
+                and P="\<top>" and P'="\<top>" in corres_split_deprecated)
+       apply (rule_tac r'="\<lambda>(r, ms) (r', ms'). ms = rv\<lparr>exclusive_state := es\<rparr> \<and>
+                                               ms' = rv'\<lparr>exclusive_state := es\<rparr>" in corres_split_deprecated)
+          apply (simp add: split_def)
+          apply (rule_tac P="\<lambda>s. underlying_memory (snd rva) =
+                                 underlying_memory (ksMachineState s)"
+                      and P'="\<lambda>s. underlying_memory (snd rv'a) =
+                                  underlying_memory (phantom_machine_state_' (globals s))"
+                       in corres_modify)
+          apply (clarsimp simp: rf_sr_def cstate_relation_def carch_state_relation_def
+                                cmachine_state_relation_def Let_def)
+         apply (rule corres_select_f')
+          apply (clarsimp simp: setExMonitor_def machine_rest_lift_def NonDetMonad.bind_def gets_def
+                                get_def return_def modify_def put_def select_f_def)
+         apply (clarsimp simp: setExMonitor_no_fail[simplified no_fail_def])
+        apply (wp hoare_TrueI)+
+      apply (clarsimp simp: rf_sr_def cstate_relation_def cmachine_state_relation_def Let_def)
+     apply (wp hoare_TrueI)+
+  apply (rule TrueI conjI | clarsimp simp: setExMonitor_def machine_rest_lift_def NonDetMonad.bind_def
+                                           gets_def get_def return_def modify_def put_def select_f_def)+
+  done
+
+lemma dmo_getExMonitor_C_wp[wp]:
+  "\<lbrace>\<lambda>s. P (exclusive_state (phantom_machine_state_' (globals s))) s\<rbrace>
+   doMachineOp_C getExMonitor
+   \<lbrace>P\<rbrace>"
+  apply (simp add: doMachineOp_C_def)
+  apply (wp modify_wp | wpc)+
+  apply clarsimp
+  apply (erule use_valid)
+   apply wp
+  apply simp
+  done
+
+lemma corres_underlying_split5:
+  "(\<And>a b c d e. corres_underlying srel nf nf' rrel (Q a b c d e) (Q' a b c d e) (f a b c d e) (f' a b c d e))
+   \<Longrightarrow> corres_underlying srel nf nf' rrel (case x of (a,b,c,d,e) \<Rightarrow> Q a b c d e)
+                                          (case x of (a,b,c,d,e) \<Rightarrow> Q' a b c d e)
+                                          (case x of (a,b,c,d,e) \<Rightarrow> f a b c d e)
+                                          (case x of (a,b,c,d,e) \<Rightarrow> f' a b c d e)"
+  by (cases x; simp)
+
+lemma do_user_op_if_C_corres[ADT_IF_Refine_assms]:
+   "corres_underlying rf_sr False False (=)
+   (invs' and ex_abs einvs and (\<lambda>_. uop_nonempty f)) \<top>
+   (doUserOp_if f tc) (doUserOp_C_if f tc)"
+  apply (rule corres_gen_asm)
+  apply (simp add: doUserOp_if_def doUserOp_C_if_def uop_nonempty_def del: split_paired_All)
+  apply (rule corres_gets_same)
+    apply (clarsimp simp: absKState_crelation ptable_rights_s'_def ptable_rights_s''_def
+           rf_sr_def  cstate_relation_def Let_def cstate_to_H_correct)
+   apply simp
+  apply (rule corres_gets_same)
+    apply (clarsimp simp: ptable_xn_s'_def ptable_xn_s''_def ptable_attrs_s_def
+                          absKState_crelation ptable_attrs_s'_def ptable_attrs_s''_def  rf_sr_def)
+   apply simp
+  apply (rule corres_gets_same)
+    apply (clarsimp simp: absKState_crelation curthread_relation ptable_lift_s'_def ptable_lift_s''_def
+                         ptable_lift_s_def rf_sr_def)
+   apply simp
+  apply (simp add: getCurThread_def)
+  apply (rule corres_gets_same)
+    apply (simp add: absKState_crelation rf_sr_def)
+   apply simp
+  apply (rule corres_gets_same)
+    apply (rule fun_cong[where x=ptrFromPAddr])
+    apply (rule_tac f=comp in arg_cong)
+    apply (rule user_mem_C_relation[symmetric])
+     apply (simp add: rf_sr_def cstate_relation_def Let_def cpspace_relation_def)
+    apply fastforce
+   apply simp
+  apply (rule corres_gets_same)
+    apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
+                          cpspace_relation_def)
+    apply (drule device_mem_C_relation[symmetric])
+     apply fastforce
+    apply (simp add: comp_def)
+   apply simp
+  apply (rule corres_gets_same)
+    apply (clarsimp simp: cstate_relation_def rf_sr_def
+                          Let_def cmachine_state_relation_def)
+   apply simp
+  apply (rule corres_guard_imp)
+    apply (rule_tac P=\<top> and P'=\<top> and r'="(=)" in corres_split_deprecated)
+       prefer 2
+       apply (clarsimp simp add: corres_underlying_def fail_def
+                                 assert_def return_def
+                          split: if_splits)
+      apply simp
+      apply (rule_tac P=\<top> and P'=\<top> and r'="(=)" in corres_split_deprecated)
+         prefer 2
+         apply (clarsimp simp add: corres_underlying_def fail_def
+                                   assert_def return_def
+                            split: if_splits)
+        apply simp
+        apply (rule corres_split_deprecated[OF _ corres_dmo_getExMonitor_C])
+          apply clarsimp
+          apply (rule_tac r'="(=)" in corres_split_deprecated[OF _ corres_select])
+             prefer 2
+             apply clarsimp
+            apply simp
+            apply (rule corres_underlying_split5)
+            apply (rule corres_split_deprecated[OF _ user_memory_update_corres_C])
+              apply (rule corres_split_deprecated[OF _ device_update_corres_C])
+                apply (rule corres_split_deprecated[OF _ corres_dmo_setExMonitor_C,
+                              where R="\<top>\<top>" and R'="\<top>\<top>"])
+                  apply (wp select_wp | simp)+
+   apply (clarsimp simp:  ex_abs_def restrict_map_def invs_pspace_aligned'
+                          invs_pspace_distinct' ptable_lift_s'_def ptable_rights_s'_def
+                  split: if_splits)
+   apply (drule ptable_rights_imp_UserData[rotated -1])
+       apply ((fastforce | intro conjI)+)[4]
+   apply (clarsimp simp: user_mem'_def device_mem'_def dom_def split: if_splits)
+   apply fastforce
+  apply (clarsimp simp add: invs'_def valid_state'_def valid_pspace'_def ex_abs_def)
+  done
+
+lemma check_active_irq_corres_C[ADT_IF_Refine_assms]:
+  "corres_underlying rf_sr False False (=) \<top> \<top> (checkActiveIRQ_if tc) (checkActiveIRQ_C_if tc)"
+  apply (simp add: checkActiveIRQ_if_def checkActiveIRQ_C_if_def)
+  apply (simp add: getActiveIRQ_C_def)
+  apply (subst bind_assoc[symmetric])
+  apply (rule corres_guard_imp)
+    apply (rule corres_split_deprecated[where r'="\<lambda>a c. case a of None \<Rightarrow> c = ucast irqInvalid
+                                                                | Some x \<Rightarrow> c = ucast x \<and> c \<noteq> ucast irqInvalid",
+                                        OF _ ccorres_corres_u_xf])
+        apply (clarsimp split: if_split option.splits)
+       apply (rule ccorres_guard_imp)
+         apply (rule ccorres_rel_imp, rule ccorres_guard_imp)
+            apply (rule getActiveIRQ_ccorres)
+           apply simp+
+         apply (case_tac x; simp add: ucast_helper_simps_32 irqInvalid_def2)
+        apply simp+
+      apply (rule no_fail_dmo')
+      apply (rule getActiveIRQ_nf)
+     apply (rule hoare_post_taut[where P=\<top>])+
+   apply simp+
+  apply fastforce
+  done
+
+lemma obs_cpspace_user_data_relation[ADT_IF_Refine_assms]:
+  "\<lbrakk> pspace_aligned' bd; pspace_distinct' bd;
+     cpspace_user_data_relation (ksPSpace bd) (underlying_memory (ksMachineState bd)) hgs \<rbrakk>
+     \<Longrightarrow> cpspace_user_data_relation (ksPSpace bd)
+           (underlying_memory (observable_memory (ksMachineState bd) (user_mem' bd))) hgs"
+   apply (clarsimp simp: cmap_relation_def dom_heap_to_user_data)
+   apply (drule bspec, fastforce)
+   apply (clarsimp simp: cuser_user_data_relation_def observable_memory_def
+                         heap_to_user_data_def map_comp_def Let_def
+                  split: option.split_asm)
+   apply (drule_tac x = off in spec)
+   apply (subst option_to_0_user_mem')
+   apply (subst map_option_byte_to_word_heap)
+    apply (clarsimp simp: projectKO_opt_user_data pointerInUserData_def field_simps
+                   split: kernel_object.split_asm option.split_asm)
+    apply (frule(1) pspace_alignedD')
+    apply (subst neg_mask_add_aligned)
+      apply (simp add: objBits_simps)
+     apply (simp add: word_less_nat_alt)
+     apply (rule le_less_trans[OF unat_plus_gt])
+     apply (subst add.commute)
+     apply (subst unat_mult_simple)
+      apply (simp add: word_bits_def)
+      apply (rule less_le_trans[OF unat_lt2p])
+      apply simp
+     apply simp
+    apply (rule nat_add_offset_less [where n = 2, simplified])
+      apply simp
+     apply (rule unat_lt2p)
+    apply (simp add: pageBits_def objBits_simps)
+   apply (frule(1) pspace_distinctD')
+   apply (clarsimp simp: obj_at'_def typ_at'_def ko_wp_at'_def objBits_simps)
+  apply simp
+  done
+
+end
+
+
+sublocale kernel_m \<subseteq> ADT_IF_Refine_1?: ADT_IF_Refine_1 _ _ _ doUserOp_C_if
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact ADT_IF_Refine_assms)?)
+qed
+
+end

--- a/proof/infoflow/refine/ARM/Example_Valid_StateH.thy
+++ b/proof/infoflow/refine/ARM/Example_Valid_StateH.thy
@@ -5,7 +5,7 @@
  *)
 
 theory Example_Valid_StateH
-imports "InfoFlow.Example_Valid_State" ADT_IF_Refine
+imports "InfoFlow.Example_Valid_State" ArchADT_IF_Refine
 begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)
@@ -2553,7 +2553,7 @@ lemma sameRegionAs_s0H:
       apply (rule s0_ptrs_aligned)
      apply simp
     apply clarsimp
-   apply (clarsimp simp: kh0H_all_obj_def' s0_ptr_defs split: if_split_asm)
+   apply (clarsimp simp: kh0H_all_obj_def' split: if_split_asm)
   apply (clarsimp simp: kh0H_all_obj_def' split: if_split_asm)
      apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
      apply (elim disjE, simp_all add: sameRegionAs_def isCap_simps)[1]
@@ -2570,7 +2570,7 @@ lemma sameRegionAs_s0H:
     apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
     apply (elim disjE, simp_all add: sameRegionAs_def ARM_H.sameRegionAs_def isCap_simps)[1]
         apply (clarsimp simp: kh0H_all_obj_def' cte_level_bits_def to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3 s0_ptrs_aligned split: if_split_asm)
-       apply (clarsimp simp: kh0H_all_obj_def' s0_ptr_defs split: if_split_asm)
+       apply (clarsimp simp: kh0H_all_obj_def' split: if_split_asm)
       apply (clarsimp simp: kh0H_all_obj_def' cte_level_bits_def to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3 s0_ptrs_aligned split: if_split_asm)
      apply (clarsimp simp: kh0H_all_obj_def' cte_level_bits_def to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3 s0_ptrs_aligned ARM_H.sameRegionAs_def isCap_simps split: if_split_asm)
     apply (clarsimp simp: kh0H_all_obj_def' cte_level_bits_def to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3 s0_ptrs_aligned split: if_split_asm)
@@ -2584,7 +2584,7 @@ lemma sameRegionAs_s0H:
    apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
    apply (elim disjE, simp_all add: sameRegionAs_def isCap_simps)[1]
       apply (clarsimp simp: kh0H_all_obj_def' cte_level_bits_def to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_2 s0_ptrs_aligned split: if_split_asm)
-     apply (clarsimp simp: kh0H_all_obj_def' s0_ptr_defs split: if_split_asm)
+     apply (clarsimp simp: kh0H_all_obj_def' split: if_split_asm)
     apply (clarsimp simp: kh0H_all_obj_def' cte_level_bits_def to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_2 s0_ptrs_aligned split: if_split_asm)
    apply (clarsimp simp: kh0H_all_obj_def' cte_level_bits_def to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_2 s0_ptrs_aligned split: if_split_asm)
    apply (drule(2) ucast_shiftr_2)
@@ -3050,6 +3050,7 @@ lemma kh0_pspace_dom:
              pd_offs_range Low_pd_ptr \<union>
              pt_offs_range High_pt_ptr \<union>
              pt_offs_range Low_pt_ptr"
+  supply nonzero_gt_zero[simp] gt_zero_nonzero[simp]
   apply (rule equalityI)
    apply (simp add: dom_def pspace_dom_def)
    apply clarsimp
@@ -3383,14 +3384,15 @@ lemma step_restrict_s0:
   done
 
 lemma Sys1_valid_initial_state_noenabled:
-  assumes utf_det: "\<forall>pl pr pxn tc um ds es s. det_inv InUserMode tc s \<and> einvs s \<and> context_matches_state pl pr pxn um ds es s \<and> ct_running s
-                   \<longrightarrow> (\<exists>x. utf (cur_thread s) pl pr pxn (tc, um, ds, es) = {x})"
-  assumes utf_non_empty: "\<forall>t pl pr pxn tc um ds es. utf t pl pr pxn (tc, um, ds, es) \<noteq> {}"
-  assumes utf_non_interrupt: "\<forall>t pl pr pxn tc um ds es e f g. (e,f,g) \<in> utf t pl pr pxn (tc, um, ds, es) \<longrightarrow> e \<noteq> Some Interrupt"
+  assumes utf_det: "\<forall>pl pr pxn tc ms s. det_inv InUserMode tc s \<and> einvs s \<and> context_matches_state pl pr pxn ms s \<and> ct_running s
+                   \<longrightarrow> (\<exists>x. utf (cur_thread s) pl pr pxn (tc, ms) = {x})"
+  assumes utf_non_empty: "\<forall>t pl pr pxn tc ms. utf t pl pr pxn (tc, ms) \<noteq> {}"
+  assumes utf_non_interrupt: "\<forall>t pl pr pxn tc ms e f g. (e,f,g) \<in> utf t pl pr pxn (tc, ms) \<longrightarrow> e \<noteq> Some Interrupt"
   assumes det_inv_invariant: "invariant_over_ADT_if det_inv utf"
   assumes det_inv_s0: "det_inv KernelExit (cur_context s0_internal) s0_internal"
   shows "valid_initial_state_noenabled det_inv utf s0_internal Sys1PAS timer_irq s0_context"
   by (rule Sys1_valid_initial_state_noenabled[OF step_restrict_s0 utf_det utf_non_empty utf_non_interrupt det_inv_invariant det_inv_s0])
+
 end
 
 end

--- a/proof/infoflow/refine/Noninterference_Refinement.thy
+++ b/proof/infoflow/refine/Noninterference_Refinement.thy
@@ -6,15 +6,13 @@
 
 theory Noninterference_Refinement
 imports
-  "InfoFlow.Noninterference"
-  "ADT_IF_Refine_C"
+  "InfoFlow.ArchNoninterference"
+  "ArchADT_IF_Refine_C"
   "InfoFlow.Noninterference_Base_Refinement"
 begin
 
 (* FIXME: fp is currently ignored by ADT_C_if *)
 consts fp :: bool
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma internal_R_ADT_A_if:
   "internal_R (ADT_A_if uop) R = R"
@@ -46,8 +44,6 @@ lemma LI_trans:
   apply simp
   done
 
-end
-
 context kernel_m begin
 
 definition big_step_ADT_C_if where
@@ -67,8 +63,6 @@ lemma big_step_ADT_C_if_big_step_ADT_A_if_refines:
   done
 
 end
-
-context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma LI_sub_big_steps':
   "\<lbrakk>(s',as) \<in> sub_big_steps C (internal_R C R) s;
@@ -108,6 +102,7 @@ lemma LI_sub_big_steps':
    done
 
 lemma LI_rel_terminate:
+  fixes s0
   assumes ex_abs: "\<And>s'. s' \<in> Ic \<Longrightarrow> (\<exists>s. s \<in> Ia \<and> (s, s') \<in> S)"
   assumes rel_correct: "\<And>s s' s0''. \<lbrakk>(internal_R C R)\<^sup>+\<^sup>+ s0'' s'; s0''\<in>Init C s0; (s, s') \<in> S\<rbrakk> \<Longrightarrow> \<exists>s0'\<in>Init A s0. (internal_R A R)\<^sup>+\<^sup>+ s0' s"
   assumes init_rel_correct: "\<And>s0''. s0'' \<in> Init C s0 \<Longrightarrow> \<exists>s0' \<in> Init A s0. (s0', s0'') \<in> S"
@@ -191,7 +186,6 @@ lemma LI_rel_terminate:
   apply simp
   done
 
-end
 
 locale valid_initial_state_C = valid_initial_state + kernel_m +
   assumes ADT_C_if_serial:

--- a/proof/infoflow/refine/base/Include_IF_C.thy
+++ b/proof/infoflow/refine/base/Include_IF_C.thy
@@ -6,7 +6,7 @@
 
 theory Include_IF_C
 imports
-    "InfoFlow.Noninterference"
+    "InfoFlow.ArchNoninterference"
     "InfoFlow.Noninterference_Base_Refinement"
     "InfoFlow.Example_Valid_State"
 begin

--- a/proof/invariant-abstract/ARM/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchAcc_AI.thy
@@ -3214,11 +3214,12 @@ proof -
     done
 qed
 
-lemma user_getreg_inv[wp]:
-  "\<lbrace>P\<rbrace> as_user t (getRegister r) \<lbrace>\<lambda>x. P\<rbrace>"
-  apply (rule as_user_inv)
-  apply (simp add: getRegister_def)
-  done
+
+crunches getRegister
+  for inv[wp]: P
+  (simp: getRegister_def)
+
+lemmas user_getreg_inv[wp] = as_user_inv[OF getRegister_inv]
 
 end
 

--- a/proof/invariant-abstract/ARM/Machine_AI.thy
+++ b/proof/invariant-abstract/ARM/Machine_AI.thy
@@ -773,4 +773,14 @@ lemmas msgRegisters_A_unfold
 
 end
 
+context begin interpretation Arch .
+
+requalify_facts
+  det_getRegister
+  det_setRegister
+  det_getRestartPC
+  det_setNextPC
+
+end
+
 end

--- a/proof/invariant-abstract/ARM_HYP/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchAcc_AI.thy
@@ -3207,11 +3207,11 @@ proof -
     done
 qed
 
-lemma user_getreg_inv[wp]:
-  "\<lbrace>P\<rbrace> as_user t (getRegister r) \<lbrace>\<lambda>x. P\<rbrace>"
-  apply (rule as_user_inv)
-  apply (simp add: getRegister_def)
-  done
+crunches getRegister
+  for inv[wp]: P
+  (simp: getRegister_def)
+
+lemmas user_getreg_inv[wp] = as_user_inv[OF getRegister_inv]
 
 end
 

--- a/proof/invariant-abstract/ARM_HYP/Machine_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/Machine_AI.thy
@@ -881,4 +881,14 @@ lemma empty_fail_clearMemory [simp, intro!]:
 end
 end
 
+context begin interpretation Arch .
+
+requalify_facts
+  det_getRegister
+  det_setRegister
+  det_getRestartPC
+  det_setNextPC
+
+end
+
 end

--- a/proof/invariant-abstract/IpcCancel_AI.thy
+++ b/proof/invariant-abstract/IpcCancel_AI.thy
@@ -11,6 +11,7 @@ begin
 context begin interpretation Arch .
 
 requalify_facts
+  arch_stit_invs
   arch_post_cap_deletion_pred_tcb_at
 
 end

--- a/proof/invariant-abstract/RISCV64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchAcc_AI.thy
@@ -2912,11 +2912,11 @@ proof -
     done
 qed
 
-lemma user_getreg_inv[wp]:
-  "\<lbrace>P\<rbrace> as_user t (getRegister r) \<lbrace>\<lambda>x. P\<rbrace>"
-  apply (rule as_user_inv)
-  apply (simp add: getRegister_def)
-  done
+crunches getRegister
+  for inv[wp]: P
+  (simp: getRegister_def)
+
+lemmas user_getreg_inv[wp] = as_user_inv[OF getRegister_inv]
 
 lemma dmo_read_stval_inv[wp]:
   "do_machine_op read_stval \<lbrace>P\<rbrace>"

--- a/proof/invariant-abstract/RISCV64/Machine_AI.thy
+++ b/proof/invariant-abstract/RISCV64/Machine_AI.thy
@@ -362,4 +362,14 @@ lemma empty_fail_clearMemory [simp, intro!]:
 end
 end
 
+context begin interpretation Arch .
+
+requalify_facts
+  det_getRegister
+  det_setRegister
+  det_getRestartPC
+  det_setNextPC
+
+end
+
 end

--- a/proof/invariant-abstract/TcbAcc_AI.thy
+++ b/proof/invariant-abstract/TcbAcc_AI.thy
@@ -13,6 +13,7 @@ context begin interpretation Arch .
 requalify_facts
   valid_arch_arch_tcb_context_set
   as_user_inv
+  getRegister_inv
   user_getreg_inv
 
 declare user_getreg_inv[wp]

--- a/proof/invariant-abstract/X64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/X64/ArchAcc_AI.thy
@@ -2836,11 +2836,11 @@ lemma as_user_inv:
     done
 qed
 
-lemma user_getreg_inv[wp]:
-  "\<lbrace>P\<rbrace> as_user t (getRegister r) \<lbrace>\<lambda>x. P\<rbrace>"
-  apply (rule as_user_inv)
-  apply (simp add: getRegister_def)
-  done
+crunches getRegister
+  for inv[wp]: P
+  (simp: getRegister_def)
+
+lemmas user_getreg_inv[wp] = as_user_inv[OF getRegister_inv]
 
 end
 

--- a/proof/invariant-abstract/X64/Machine_AI.thy
+++ b/proof/invariant-abstract/X64/Machine_AI.thy
@@ -464,4 +464,14 @@ lemma out32_ef[simp,wp]: "empty_fail (out32 port dat)"
 end
 end
 
+context begin interpretation Arch .
+
+requalify_facts
+  det_getRegister
+  det_setRegister
+  det_getRestartPC
+  det_setNextPC
+
+end
+
 end


### PR DESCRIPTION
Split the information flow proofs into generic and arch-specific theories. Commits have been structured according to the files that were split. New FIXMEs have been annotated "FIXME IF".