### PR TITLE
Remove "is_active_sc" variants from preconditions / remove haskell assert

### DIFF
--- a/proof/refine/ARM/SchedContext_R.thy
+++ b/proof/refine/ARM/SchedContext_R.thy
@@ -910,17 +910,15 @@ lemma sc_relation_updateRefillHd:
 lemma updateRefillHd_corres:
   "\<lbrakk>sc_ptr = scPtr; \<forall>refill refill'. refill = refill_map refill' \<longrightarrow> f refill = (refill_map (f' refill'))\<rbrakk>
    \<Longrightarrow> corres dc
-        (sc_at sc_ptr and is_active_sc2 sc_ptr)
+        (sc_at sc_ptr)
         (valid_refills' sc_ptr and sc_at' sc_ptr)
         (update_refill_hd sc_ptr f)
         (updateRefillHd scPtr f')"
   supply projection_rewrites[simp]
-  apply (rule_tac Q="is_active_sc' scPtr" in corres_cross_add_guard)
-   apply (fastforce dest!: is_active_sc'_cross[OF state_relation_pspace_relation])
   apply (clarsimp simp: update_refill_hd_def updateRefillHd_def)
   apply (rule corres_guard_imp)
     apply (rule updateSchedContext_corres_gen[where P=\<top>
-      and P'="valid_refills' sc_ptr and is_active_sc' scPtr"])
+      and P'="valid_refills' sc_ptr"])
       apply (clarsimp, drule (2) state_relation_sc_relation)
       apply (fastforce simp: is_sc_obj obj_at_simps is_active_sc'_def opt_map_red valid_refills'_def
                       elim!: sc_relation_updateRefillHd)
@@ -963,16 +961,14 @@ lemma updateRefillTl_corres:
   "\<lbrakk>sc_ptr = scPtr;
     \<forall>refill refill'. refill = refill_map refill' \<longrightarrow> f refill = (refill_map (f' refill'))\<rbrakk>
    \<Longrightarrow> corres dc
-              (sc_at sc_ptr and is_active_sc2 sc_ptr)
+              (sc_at sc_ptr)
               (sc_at' scPtr and valid_refills' scPtr)
               (update_refill_tl sc_ptr f)
               (updateRefillTl scPtr f')"
   supply projection_rewrites[simp]
-  apply (rule_tac Q="is_active_sc' scPtr" in corres_cross_add_guard)
-   apply (fastforce dest!: is_active_sc'_cross[OF state_relation_pspace_relation])
   apply (clarsimp simp: update_refill_tl_def updateRefillTl_def)
   apply (rule corres_guard_imp)
-    apply (rule updateSchedContext_corres_gen[where P=\<top> and P'="valid_refills' scPtr and is_active_sc' scPtr"])
+    apply (rule updateSchedContext_corres_gen[where P=\<top> and P'="valid_refills' scPtr"])
       apply (clarsimp, drule (2) state_relation_sc_relation)
       apply (clarsimp simp: is_sc_obj obj_at_simps is_active_sc'_def valid_refills'_def)
       apply (clarsimp simp: sc_relation_updateRefillTl opt_map_red)

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -2368,18 +2368,25 @@ lemma whileM_wp_gen:
   using termin
   by (wpsimp wp: whileLoop_wp[where I=I])
 
-crunches refillHeadOverlappingLoop, headInsufficientLoop
+crunches refillBudgetCheck, refillUnblockCheck
   for valid_queues[wp]: valid_queues
   and valid_queues'[wp]: valid_queues'
   and valid_release_queue[wp]: valid_release_queue
   and valid_release_queue'[wp]: valid_release_queue'
   and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   and sc_at'_n[wp]: "\<lambda>s. P (sc_at'_n T p s)"
+  and active_sc_at'[wp]: "active_sc_at' scPtr"
   (wp: crunch_wps)
 
 end
 
-global_interpretation refillPopHead: typ_at_all_props' "refillPopHead scPtr"
+global_interpretation refillPopHead: typ_at_all_props' "refillPopHead scPtr" by typ_at_props'
+global_interpretation mergeRefills: typ_at_all_props' "mergeRefills scPtr" by typ_at_props'
+global_interpretation scheduleUsed: typ_at_all_props' "scheduleUsed scPtr new" by typ_at_props'
+global_interpretation updateRefillHd: typ_at_all_props' "updateRefillHd scPtr v" by typ_at_props'
+global_interpretation setRefillHd: typ_at_all_props' "setRefillHd scPtr v" by typ_at_props'
+global_interpretation handleOverrunLoop: typ_at_all_props' "handleOverrunLoop v" by typ_at_props'
+global_interpretation nonOverlappingMergeRefills: typ_at_all_props' "nonOverlappingMergeRefills scPtr"
   by typ_at_props'
 
 context begin interpretation Arch . (*FIXME: arch_split*)
@@ -2397,11 +2404,6 @@ lemma mergeRefills_valid_objs':
                         valid_sched_context_size'_def opt_map_red
                  dest!: sc_ko_at_valid_objs_valid_sc')
   done
-
-crunches mergeRefills, nonOverlappingMergeRefills, scheduleUsed
-  for active_sc_at'[wp]: "active_sc_at' scPtr"
-  and sc_at'[wp]: "\<lambda>s. P (sc_at' scPtr s)"
-  (simp: objBits_simps)
 
 lemma no_ofail_refillHeadOverlapping:
   "no_ofail (sc_at' scp) (refillHeadOverlapping scp)"
@@ -2459,13 +2461,7 @@ lemma refillUnblockCheck_valid_objs'[wp]:
   done
 
 crunches refillUnblockCheck, refillBudgetCheck
-  for valid_queues[wp]: valid_queues
-  and valid_queues'[wp]: valid_queues'
-  and valid_release_queue[wp]: valid_release_queue
-  and valid_release_queue'[wp]: valid_release_queue'
-  and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  and sc_at'_n[wp]: "\<lambda>s. Q (sc_at'_n n p s)"
-  and pspace_aligned'[wp]: pspace_aligned'
+  for pspace_aligned'[wp]: pspace_aligned'
   and pspace_distinct'[wp]: pspace_distinct'
   and no_0_obj'[wp]: no_0_obj'
   and ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
@@ -2669,10 +2665,6 @@ lemma handleOverrunLoop_valid_objs':
     apply (rule_tac f=ksCurSc in hoare_lift_Pf3)
      apply wpsimp+
   done
-
-crunches handleOverrunLoop, setRefillHd
-  for sc_at'[wp]: "sc_at' scPtr"
-  (wp: crunch_wps simp: objBits_simps)
 
 lemma refillBudgetCheck_valid_objs':
   "refillBudgetCheck usage \<lbrace>valid_objs'\<rbrace>"

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -385,8 +385,6 @@ This module uses the C preprocessor to select a target architecture.
 
 > refillUnblockCheck :: PPtr SchedContext -> Kernel ()
 > refillUnblockCheck scPtr = do
->       scactive <- scActive scPtr
->       assert scactive "scPtr should be active"
 >       roundRobin <- isRoundRobin scPtr
 >       ready <- refillReady scPtr
 >       when ((not roundRobin) && ready) $ do


### PR DESCRIPTION
Working on Refine fix for "add refill_unblock_check everywhere" change, I started to find the "is_active_sc2" precondition of the refill_unblock_check corres rule rather difficult to deal with. So, I had a look, and it turned out that we don't need it. The haskell assert is also removed.

This also contains a small cleanup in Schedule_R that removes duplications about `tcbReleaseDequeue`.