### PR TITLE
“add refill_unblock_check” spec update, part II

### DIFF
--- a/proof/invariant-abstract/Deterministic_AI.thy
+++ b/proof/invariant-abstract/Deterministic_AI.thy
@@ -4176,6 +4176,8 @@ crunch valid_list[wp]: sched_context_resume,suspend "valid_list"
 crunch valid_list[wp]: sched_context_bind_ntfn valid_list
 crunch valid_list[wp]: sched_context_yield_to valid_list
   (wp: hoare_drop_imps crunch_wps simp: crunch_simps)
+crunch valid_list[wp]: refill_unblock_check valid_list
+  (wp: hoare_drop_imps crunch_wps simp: crunch_simps is_round_robin_def)
 crunch valid_list[wp]: invoke_sched_context valid_list
 
 crunch valid_list[wp]: refill_update,refill_new valid_list (wp: hoare_drop_imp)
@@ -4200,8 +4202,6 @@ lemma delete_objects_valid_list[wp]: "\<lbrace>valid_list\<rbrace> delete_object
 
 lemmas mapM_x_def_bak = mapM_x_def[symmetric]
 
-crunch valid_list[wp]: refill_unblock_check valid_list
-  (wp: hoare_drop_imps crunch_wps simp: crunch_simps is_round_robin_def)
 crunch valid_list[wp]: maybe_donate_sc valid_list (wp: maybeM_inv)
 
 locale Deterministic_AI_2 = Deterministic_AI_1 +

--- a/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
@@ -160,7 +160,7 @@ lemma invoke_cnode_valid_vspace_objs'[wp]:
   done
 
 crunch valid_vspace_objs'[wp]: invoke_tcb "valid_vspace_objs'"
-  (wp: check_cap_inv crunch_wps simp: crunch_simps
+  (wp: check_cap_inv crunch_wps simp: crunch_simps is_round_robin_def
        ignore: check_cap_at update_sk_obj_ref)
 
 crunch valid_vspace_objs'[wp]: invoke_domain "valid_vspace_objs'"

--- a/proof/invariant-abstract/SchedContext_AI.thy
+++ b/proof/invariant-abstract/SchedContext_AI.thy
@@ -581,7 +581,7 @@ crunches refill_budget_check, if_cond_refill_unblock_check
   and valid_objs[wp]: valid_objs
   and state_refs_of[wp]: "\<lambda>s. P (state_refs_of s)"
   and ex_cap[wp]: "ex_nonz_cap_to p"
-  and valid_replies[wp]: valid_replies
+  and valid_replies[wp]: "\<lambda>s. P (valid_replies s)"
   and valid_idle[wp]: valid_idle
   and valid_ioports[wp]: valid_ioports
   (simp: Let_def is_round_robin_def wp: crunch_wps hoare_vcg_if_lift2
@@ -1221,7 +1221,7 @@ lemma set_tcb_queue_valid_replies[wp]:
 
 crunches sched_context_bind_tcb, update_sk_obj_ref
   for arch_state[wp]: "\<lambda>s. P (arch_state s)"
-  (wp: crunch_wps)
+  (wp: crunch_wps simp: is_round_robin_def crunch_simps)
 
 crunches get_tcb_queue, get_sc_time, get_sc_obj_ref
   for inv[wp]: "P"

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -1382,7 +1382,8 @@ crunches check_budget_restart
    simp: crunch_simps)
 
 crunches
-  possible_switch_to, do_ipc_transfer, maybe_donate_sc, handle_fault_reply, postpone
+  possible_switch_to, do_ipc_transfer, maybe_donate_sc, handle_fault_reply, postpone,
+  if_cond_refill_unblock_check
   for ct_in_state[wp]: "ct_in_state P :: 'state_ext state \<Rightarrow> _"
   (rule: ct_in_state_thread_state_lift wp: crunch_wps simp: crunch_simps)
 
@@ -1511,9 +1512,8 @@ lemma invoke_untyped_ct_active[wp]:
             empty_descendants_range_in)+))
   done
 
-crunches test_possible_switch_to, sched_context_resume
+crunches test_possible_switch_to, sched_context_resume, if_cond_refill_unblock_check
   for cur_thread[wp]: "\<lambda>s :: 'state_ext state. P (cur_thread s)"
-  and pred_tcb_at[wp]: "\<lambda>s :: 'state_ext state. pred_tcb_at proj' P t s"
   (wp: crunch_wps simp: crunch_simps)
 
 crunches

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -2083,6 +2083,7 @@ lemma tc_caps_valid_duplicates':
 
 crunches schedContextBindTCB
   for valid_duplicates'[wp]: "(\<lambda>s. vs_valid_duplicates' (ksPSpace s))"
+  (simp: crunch_simps)
 
 lemma tc_sched_valid_duplicates':
   "\<lbrace>invs' and sch_act_simple and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and

--- a/spec/abstract/SchedContext_A.thy
+++ b/spec/abstract/SchedContext_A.thy
@@ -381,6 +381,7 @@ where
   "sched_context_bind_tcb sc_ptr tcb_ptr = do
     set_tcb_obj_ref tcb_sched_context_update tcb_ptr (Some sc_ptr);
     set_sc_obj_ref sc_tcb_update sc_ptr (Some tcb_ptr);
+    if_sporadic_active_cur_sc_test_refill_unblock_check (Some sc_ptr);
     sched_context_resume sc_ptr;
     sched <- is_schedulable tcb_ptr;
     when sched $ do

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -430,6 +430,7 @@ This module uses the C preprocessor to select a target architecture.
 >     sc <- getSchedContext scPtr
 >     threadSet (\tcb -> tcb { tcbSchedContext = Just scPtr }) tcbPtr
 >     setSchedContext scPtr $ sc { scTCB = Just tcbPtr }
+>     ifCondRefillUnblockCheck (Just scPtr) (Just True) (Just False)
 >     schedContextResume scPtr
 >     schedulable <- isSchedulable tcbPtr
 >     when schedulable $ do


### PR DESCRIPTION
This PR completes the `refill_unblock_check` spec change for `sched_context_bind_tcb`.