### PR TITLE
testboardpush: fix URL processing

### DIFF
--- a/misc/testboard/testboardpush
+++ b/misc/testboard/testboardpush
@@ -61,7 +61,7 @@ def subprocess_output(*args, **kwargs):
 # to be public.
 def fixup_github(remote):
     git_url = 'git@github.com:'
-    ssh_url = 'ssh://' + git_url
+    ssh_url = 'ssh://' + git_url[:-1] + '/'
     https_url = 'https://github.com/'
     url, repo = remote
     if url.startswith(git_url):


### PR DESCRIPTION
Had missed the `:` suffix in the git URL, so the ssh URL test would never succeed.

This is a fix for my prevision commit ce302e0c6586dedfc09d740e3b2c58ee37c77099 which didn't quite achieve what it promised.