### PR TITLE
`schedule_corres`

### DIFF
--- a/proof/invariant-abstract/ARM/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchSchedule_AI.thy
@@ -51,6 +51,12 @@ lemma arch_stt_tcb [wp,Schedule_AI_asms]:
   apply (wp)
   done
 
+lemma arch_stt_sc_at[wp,Schedule_AI_asms]:
+  "arch_switch_to_thread t' \<lbrace>sc_at sc_ptr\<rbrace>"
+  apply (simp add: arch_switch_to_thread_def)
+  apply wp
+  done
+
 lemma arch_stt_runnable[Schedule_AI_asms]:
   "\<lbrace>st_tcb_at Q t\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>r . st_tcb_at Q t\<rbrace>"
   apply (simp add: arch_switch_to_thread_def)
@@ -71,7 +77,12 @@ crunches set_vm_root
   for ct[wp]:  "\<lambda>s. P (cur_thread s)"
   and st_tcb_at[wp]: "\<lambda>s. P (st_tcb_at Q t s)"
   and scheduler_action[wp]: "\<lambda>s. P (scheduler_action s)"
-  (wp: crunch_wps simp: crunch_simps)
+
+lemma arch_stit_sc_at[wp, Schedule_AI_asms]:
+  "arch_switch_to_idle_thread \<lbrace>sc_at sc_ptr\<rbrace>"
+  apply (simp add: arch_switch_to_idle_thread_def)
+  apply wp
+  done
 
 lemma arch_stit_activatable[wp, Schedule_AI_asms]:
   "\<lbrace>ct_in_state activatable\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>rv . ct_in_state activatable\<rbrace>"

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -4388,6 +4388,10 @@ lemma refill_unblock_check_valid_refills[wp]:
   apply (case_tac "sc_refills sc"; clarsimp)
   done
 
+crunches if_cond_refill_unblock_check
+  for valid_refills[wp]: "valid_refills sc_ptr"
+  (simp: crunch_simps)
+
 lemma refill_unblock_check_active_sc_valid_refills:
   "\<lbrace>active_sc_valid_refills
     and current_time_bounded 2\<rbrace>

--- a/proof/invariant-abstract/Invariants_AI.thy
+++ b/proof/invariant-abstract/Invariants_AI.thy
@@ -4593,6 +4593,12 @@ lemma valid_mask_vm_rights[simp]:
   "mask_vm_rights V R \<in> valid_vm_rights"
   by (simp add: mask_vm_rights_def)
 
+lemma cur_sc_tcb_sc_at_cur_sc:
+  "\<lbrakk>valid_objs s; cur_sc_tcb s\<rbrakk> \<Longrightarrow> sc_at (cur_sc s) s"
+  apply (fastforce intro: valid_objs_valid_sched_context_size
+                    simp: cur_sc_tcb_def sc_at_pred_n_def obj_at_def is_sc_obj_def)
+  done
+
 lemmas invs_implies =
   invs_equal_kernel_mappings
   invs_arch_state

--- a/proof/invariant-abstract/RISCV64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchSchedule_AI.thy
@@ -44,6 +44,12 @@ lemma arch_stt_tcb [wp,Schedule_AI_asms]:
   apply (wp)
   done
 
+lemma arch_stt_sc_at[wp,Schedule_AI_asms]:
+  "arch_switch_to_thread t' \<lbrace>sc_at sc_ptr\<rbrace>"
+  apply (simp add: arch_switch_to_thread_def)
+  apply wp
+  done
+
 lemma arch_stt_runnable[Schedule_AI_asms]:
   "\<lbrace>st_tcb_at Q t\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>r . st_tcb_at Q t\<rbrace>"
   apply (simp add: arch_switch_to_thread_def)
@@ -58,6 +64,12 @@ lemma arch_stit_tcb_at[wp, Schedule_AI_asms]:
   "\<lbrace>tcb_at t\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>r. tcb_at t\<rbrace>"
   apply (simp add: arch_switch_to_idle_thread_def )
   apply (wp tcb_at_typ_at)
+  done
+
+lemma arch_stit_sc_at[wp, Schedule_AI_asms]:
+  "arch_switch_to_idle_thread \<lbrace>sc_at sc_ptr\<rbrace>"
+  apply (simp add: arch_switch_to_idle_thread_def)
+  apply wp
   done
 
 crunches set_vm_root

--- a/proof/invariant-abstract/Schedule_AI.thy
+++ b/proof/invariant-abstract/Schedule_AI.thy
@@ -19,6 +19,8 @@ locale Schedule_AI =
       "\<And>t'. \<lbrace>invs\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. (invs :: 'a state \<Rightarrow> bool)\<rbrace>"
     assumes arch_stt_tcb [wp]:
       "\<And>t'. \<lbrace>tcb_at t'\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. (tcb_at t' :: 'a state \<Rightarrow> bool)\<rbrace>"
+    assumes arch_stt_sc_at[wp]:
+      "\<And>t' sc_ptr. arch_switch_to_thread t' \<lbrace>(sc_at sc_ptr :: 'a state \<Rightarrow> bool)\<rbrace>"
     assumes arch_stt_runnable:
       "\<And>t. \<lbrace>st_tcb_at Q t\<rbrace> arch_switch_to_thread t
             \<lbrace>\<lambda>r . (st_tcb_at Q t :: 'a state \<Rightarrow> bool)\<rbrace>"
@@ -29,6 +31,8 @@ locale Schedule_AI =
       "\<And>t'. \<lbrace>invs\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_. (invs :: 'a state \<Rightarrow> bool)\<rbrace>"
     assumes arch_stit_tcb [wp]:
       "\<And>t'. \<lbrace>tcb_at t\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_. (tcb_at t :: 'a state \<Rightarrow> bool)\<rbrace>"
+    assumes arch_stit_sc_at [wp]:
+      "\<And>sc_ptr. arch_switch_to_idle_thread \<lbrace>(sc_at sc_ptr :: 'a state \<Rightarrow> bool)\<rbrace>"
     assumes arch_stit_scheduler_action:
       "\<And>t'. \<lbrace>\<lambda>s::'a state. P (scheduler_action s)\<rbrace>
              arch_switch_to_idle_thread \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"

--- a/proof/refine/ARM/EmptyFail_H.thy
+++ b/proof/refine/ARM/EmptyFail_H.thy
@@ -300,7 +300,7 @@ lemma awaken_empty_fail[intro!, wp, simp]:
 
 lemma ThreadDecls_H_schedule_empty_fail[intro!, wp, simp]:
   "empty_fail schedule"
-  apply (simp add: schedule_def checkDomainTime_def)
+  apply (simp add: schedule_def scAndTimer_def checkDomainTime_def)
   apply (clarsimp simp: scheduleChooseNewThread_def split: if_split | wp | wpc)+
   done
 

--- a/proof/refine/ARM/InvariantUpdates_H.thy
+++ b/proof/refine/ARM/InvariantUpdates_H.thy
@@ -383,6 +383,11 @@ lemma ksDomainTime_invs[simp]:
                 valid_machine_state'_def ct_not_inQ_def
                 ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def valid_dom_schedule'_def)
 
+lemma ksSchedulerAction_invs'[simp]:
+  "invs' (ksSchedulerAction_update f s) = invs' s"
+  by (auto simp: invs'_def valid_release_queue_def valid_release_queue'_def
+                 valid_machine_state'_def  valid_irq_node'_def valid_dom_schedule'_def)
+
 lemma valid_machine_state'_ksDomainTime[simp]:
   "valid_machine_state' (ksDomainTime_update f s) = valid_machine_state' s"
   by (simp add:valid_machine_state'_def)

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -3974,6 +3974,10 @@ lemma getReprogramTimer_sp:
   "\<lbrace>P\<rbrace> getReprogramTimer \<lbrace>\<lambda>rv. P and (\<lambda>s. rv = ksReprogramTimer s)\<rbrace>"
   by (wpsimp simp: getReprogramTimer_def)
 
+lemma getIdleThread_sp:
+  "\<lbrace>P\<rbrace> getIdleThread \<lbrace>\<lambda>rv. P and (\<lambda>s. rv = ksIdleThread s)\<rbrace>"
+  by wpsimp
+
 lemma getReprogramTimer_wp[wp]:
   "\<lbrace>\<lambda>s. P (ksReprogramTimer s) s\<rbrace> getReprogramTimer \<lbrace>P\<rbrace>"
   by (wpsimp simp: getReprogramTimer_def)
@@ -3999,6 +4003,10 @@ lemma getCurTime_wp[wp]:
 lemma curDomain_wp[wp]:
   "\<lbrace>\<lambda>s. P (ksCurDomain s) s\<rbrace> curDomain \<lbrace>P\<rbrace>"
   unfolding curDomain_def
+  by wpsimp
+
+lemma curDomain_sp:
+  "\<lbrace>P\<rbrace> curDomain \<lbrace>\<lambda>rv. P and (\<lambda>s. rv = ksCurDomain s)\<rbrace>"
   by wpsimp
 
 lemma getReleaseQueue_wp[wp]:

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -28,7 +28,7 @@ crunches tcbReleaseDequeue
   for sc_at'_n[wp]: "\<lambda>s. Q (sc_at'_n n p s)"
   (simp: crunch_simps wp: crunch_wps)
 
-crunches refillUnblockCheck, refillBudgetCheck
+crunches refillUnblockCheck, refillBudgetCheck, refillBudgetCheckRoundRobin
   for valid_queues[wp]: valid_queues
   and valid_queues'[wp]: valid_queues'
   and valid_release_queue[wp]: valid_release_queue
@@ -56,6 +56,7 @@ crunches refillUnblockCheck, refillBudgetCheck
   and cur_tcb'[wp]: cur_tcb'
   and ct_not_inQ[wp]: ct_not_inQ
   and valid_dom_schedule'[wp]: valid_dom_schedule'
+  and ksCurSc[wp]: "\<lambda>s. P (ksCurSc s)"
   (wp: crunch_wps valid_dom_schedule'_lift simp: crunch_simps refillSingle_def)
 
 end
@@ -88,6 +89,12 @@ global_interpretation setRefillHd: typ_at_all_props' "setRefillHd scPtr v"
   by typ_at_props'
 
 global_interpretation nonOverlappingMergeRefills: typ_at_all_props' "nonOverlappingMergeRefills scPtr"
+  by typ_at_props'
+
+global_interpretation refillBudgetCheck: typ_at_all_props' "refillBudgetCheck usage"
+  by typ_at_props'
+
+global_interpretation refillBudgetCheckRoundRobin: typ_at_all_props' "refillBudgetCheckRoundRobin usage"
   by typ_at_props'
 
 context begin interpretation Arch . (*FIXME: arch_split*)
@@ -872,7 +879,7 @@ crunches switchToIdleThread
                        st_tcb_at' runnable' t s"
 
 lemma switchToIdleThread_corres:
-  "corres dc (invs and valid_sched) invs' switch_to_idle_thread switchToIdleThread"
+  "corres dc (invs and valid_ready_qs) invs' switch_to_idle_thread switchToIdleThread"
   apply add_ready_qs_runnable
   apply add_valid_idle'
   apply (simp add: switch_to_idle_thread_def Thread_H.switchToIdleThread_def)
@@ -1594,7 +1601,7 @@ lemmas tcb_at'_example = corres_cross[where Q' = "tcb_at' t" for t, OF tcb_at'_c
 
 lemma guarded_switch_to_chooseThread_fragment_corres:
   "corres dc
-    (P and is_schedulable_bool t and invs and valid_sched)
+    (P and is_schedulable_bool t and invs and valid_ready_qs)
     (P' and invs' and tcb_at' t)
           (guarded_switch_to t)
           (do schedulable \<leftarrow> isSchedulable t;
@@ -1653,7 +1660,7 @@ lemma ksReadyQueuesL1Bitmap_st_tcb_at':
   done
 
 lemma chooseThread_corres:
-  "corres dc (invs and valid_sched) invs'
+  "corres dc (invs and valid_ready_qs and ready_or_release) invs'
      choose_thread chooseThread" (is "corres _ ?PREI ?PREH _ _")
   apply add_ready_qs_runnable
   unfolding choose_thread_def chooseThread_def numDomains_def
@@ -1764,7 +1771,9 @@ lemma nextDomain_invs':
   done
 
 lemma scheduleChooseNewThread_fragment_corres:
-  "corres dc (invs and valid_sched and (\<lambda>s. scheduler_action s = choose_new_thread)) (invs' and (\<lambda>s. ksSchedulerAction s = ChooseNewThread))
+  "corres dc (invs and valid_ready_qs and ready_or_release
+              and (\<lambda>s. scheduler_action s = choose_new_thread))
+             (invs' and (\<lambda>s. ksSchedulerAction s = ChooseNewThread))
      (do _ \<leftarrow> when (domainTime = 0) next_domain;
          choose_thread
       od)
@@ -1839,7 +1848,7 @@ lemma setSchedulerAction_invs': (* not in wp set, clobbered by ssa_wp *)
 
 lemma scheduleChooseNewThread_corres:
   "corres dc
-    (\<lambda>s. invs s \<and> valid_sched s \<and> scheduler_action s = choose_new_thread)
+    (\<lambda>s. invs s \<and> valid_ready_qs s \<and> ready_or_release s \<and> scheduler_action s = choose_new_thread)
     (\<lambda>s. invs' s \<and> ksSchedulerAction s = ChooseNewThread)
            schedule_choose_new_thread scheduleChooseNewThread"
   unfolding schedule_choose_new_thread_def scheduleChooseNewThread_def
@@ -1849,7 +1858,6 @@ lemma scheduleChooseNewThread_corres:
         apply (rule setSchedulerAction_corres)
         apply (wp | simp)+
     apply (wp | simp add: getDomainTime_def)+
-   apply auto
   done
 
 lemma ssa_ct_not_inQ:
@@ -2842,9 +2850,9 @@ crunches checkDomainTime
 lemma schedule_invs':
   "schedule \<lbrace>invs'\<rbrace>"
   supply if_split [split del]
-  apply (simp add: schedule_def)
+  apply (simp add: schedule_def scAndTimer_def cur_tcb'_asrt_def)
   apply (intro hoare_seq_ext[OF _ stateAssert_sp])
-  apply (clarsimp simp: sch_act_wf_asrt_def cur_tcb'_asrt_def)
+  apply (clarsimp simp: sch_act_wf_asrt_def)
   apply (rule_tac hoare_seq_ext, rename_tac t)
    apply (rule_tac Q="invs' and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and cur_tcb'" in hoare_weaken_pre)
     apply (rule hoare_seq_ext_skip, wpsimp)
@@ -2923,7 +2931,7 @@ crunches switchSchedContext, setNextInterrupt
 
 lemma schedule_sch:
   "\<lbrace>\<top>\<rbrace> schedule \<lbrace>\<lambda>rv s. ksSchedulerAction s = ResumeCurrentThread\<rbrace>"
-  unfolding schedule_def
+  unfolding schedule_def scAndTimer_def
   by (wpsimp wp: setSchedulerAction_direct simp: getReprogramTimer_def scheduleChooseNewThread_def)
 
 lemma schedule_sch_act_simple:
@@ -3551,7 +3559,7 @@ lemma setDeadline_corres:
 (* This is not particularly insightful, it just shortens setNextInterrupt_corres *)
 lemma setNextInterrupt_corres_helper:
   "\<lbrakk>valid_objs' s'; (s, s') \<in> state_relation; active_sc_tcb_at t s;
-    valid_objs s; active_sc_valid_refills s; pspace_aligned s; pspace_distinct s\<rbrakk>
+    valid_objs s; pspace_aligned s; pspace_distinct s\<rbrakk>
     \<Longrightarrow> \<exists>tcb. ko_at' tcb t s' \<and> sc_at' (the (tcbSchedContext tcb)) s' \<and>
         (\<forall>ko. ko_at' ko (the (tcbSchedContext tcb)) s' \<longrightarrow> sc_valid_refills' ko)"
   apply (subgoal_tac "\<exists>tcb'. ko_at' (tcb'  :: tcb) t s'", clarsimp)
@@ -3579,8 +3587,9 @@ lemma setNextInterrupt_corres_helper:
   done
 
 lemma setNextInterrupt_corres:
-  "corres dc ((\<lambda>s. active_sc_tcb_at (cur_thread s) s) and valid_release_q and valid_objs
-              and active_sc_valid_refills and pspace_aligned and pspace_distinct)
+  "corres dc ((\<lambda>s. active_sc_tcb_at (cur_thread s) s)
+              and (\<lambda>s. \<forall>t \<in> set (release_queue s). active_sc_tcb_at t s)
+              and valid_objs and pspace_aligned and pspace_distinct)
              valid_objs'
              set_next_interrupt
              setNextInterrupt"
@@ -3625,11 +3634,10 @@ lemma setNextInterrupt_corres:
          apply (wpsimp wp: get_tcb_obj_ref_wp)
         apply (wpsimp wp: threadGet_wp)
        apply wpsimp+
-   apply (subgoal_tac "release_queue s \<noteq> [] \<longrightarrow> active_sc_tcb_at (hd (release_queue s)) s")
-    apply (fastforce simp: cur_tcb_def pred_tcb_at_def vs_all_heap_simps obj_at_def is_sc_obj is_tcb
-                     elim: valid_sched_context_size_objsI)
-   apply (clarsimp simp: valid_release_q_def)
-  apply simp
+   apply (fastforce intro!: valid_sched_context_size_objsI
+                      dest: list.set_sel(1)
+                      simp: vs_all_heap_simps obj_at_def is_tcb_def is_sc_obj_def)
+  apply (clarsimp simp: valid_release_q_def)
   apply (subgoal_tac "(\<exists>tcb. ko_at' tcb (ksCurThread s') s' \<and>
                     sc_at' (the (tcbSchedContext tcb)) s' \<and>
                     (\<forall>ko. ko_at' ko (the (tcbSchedContext tcb)) s' \<longrightarrow> sc_valid_refills' ko)) \<and> (ksReleaseQueue s' \<noteq> [] \<longrightarrow> (\<exists>tcb. ko_at' tcb (hd (ksReleaseQueue s')) s' \<and>
@@ -3637,14 +3645,13 @@ lemma setNextInterrupt_corres:
                     (\<forall>ko. ko_at' ko (the (tcbSchedContext tcb)) s' \<longrightarrow> sc_valid_refills' ko)))")
    apply (safe, blast, blast)[1]
    apply (rule_tac x=tcb in exI, simp, safe, blast)[1]
-  apply (intro conjI; clarsimp)
    apply (prop_tac "ksCurThread s' = cur_thread s", clarsimp simp: state_relation_def, simp)
-   apply (rule setNextInterrupt_corres_helper; simp)
   apply (subgoal_tac "(ksReleaseQueue s') = release_queue s", simp)
-   apply (subgoal_tac "active_sc_tcb_at (hd (release_queue s)) s")
+   apply (intro conjI impI)
     apply (rule setNextInterrupt_corres_helper; simp)
-   apply (clarsimp simp: valid_release_q_def)
-  apply (clarsimp simp: state_relation_def release_queue_relation_def)
+   apply (clarsimp simp: state_relation_def release_queue_relation_def)
+   apply (rule setNextInterrupt_corres_helper; simp?)
+   apply (clarsimp simp: state_relation_def release_queue_relation_def)+
   done
 
 (* refillUnblockCheck_corres *)
@@ -4862,136 +4869,432 @@ lemma refillBudgetCheck_corres:
 
 (* schedule_corres *)
 
-lemma schedule_corres:
-  "corres dc (invs and valid_sched and valid_list) invs' (Schedule_A.schedule) ThreadDecls_H.schedule"
-  supply tcbSchedEnqueue_invs'[wp del]
-  supply setSchedulerAction_direct[wp]
-  supply if_split[split del]
-  apply (clarsimp simp: Schedule_A.schedule_def Thread_H.schedule_def)
-  sorry (* schedule_corres *) (*
-  apply (subst thread_get_test)
-  apply (subst thread_get_comm)
-  apply (subst schact_bind_inside)
+crunches setReprogramTimer
+  for valid_tcbs'[wp]: valid_tcbs'
+  and valid_refills'[wp]: "valid_refills' scPtr"
+  and ksCurSc[wp]: "\<lambda>s. P (ksCurSc s)"
+  (simp: valid_refills'_def)
+
+lemma checkDomainTime_corres:
+  "corres dc (valid_tcbs and weak_valid_sched_action and active_sc_valid_refills and pspace_aligned
+              and pspace_distinct)
+             (valid_tcbs' and valid_queues and valid_queues' and valid_release_queue_iff)
+             check_domain_time
+             checkDomainTime"
+  apply (clarsimp simp: check_domain_time_def checkDomainTime_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_split[OF _ getCurThread_corres[THEN corres_rel_imp[where r="\<lambda>x y. y = x"],simplified]])
-        apply (rule corres_split[OF _ getSchedulerAction_corres])
-          apply (rule corres_split_sched_act,assumption)
-            apply (rule_tac P="tcb_at ct" in corres_symb_exec_l')
-              apply (rule_tac corres_symb_exec_l)
-                apply simp
-                apply (rule corres_assert_ret)
-               apply ((wpsimp wp: thread_get_wp' gets_exs_valid)+)
-         prefer 2
-         (* choose thread *)
-         apply clarsimp
-          apply (rule corres_split[OF _ thread_get_isRunnable_corres])
-            apply (rule corres_split[OF _ corres_when])
-             apply (rule scheduleChooseNewThread_corres, simp)
-              apply (rule tcbSchedEnqueue_corres, simp)
-           apply (wp thread_get_wp' tcbSchedEnqueue_invs' hoare_vcg_conj_lift hoare_drop_imps
-                  | clarsimp)+
-        (* switch to thread *)
-        apply (rule corres_split[OF _ thread_get_isRunnable_corres],
-                rename_tac was_running wasRunning)
-          apply (rule corres_split[OF _ corres_when])
-              apply (rule corres_split[OF _ bindNotification_corres], rename_tac it it')
-                apply (rule_tac F="was_running \<longrightarrow> ct \<noteq> it" in corres_gen_asm)
-                apply (rule corres_split[OF _ ethreadget_corres[where r="(=)"]],
-                       rename_tac tp tp')
-                   apply (rule corres_split[OF _ ethread_get_when_corres[where r="(=)"]],
-                           rename_tac cp cp')
-                      apply (rule corres_split[OF _ scheduleSwitchThreadFastfail_corres])
-                           apply (rule corres_split[OF _ curDomain_corres])
-                             apply (rule corres_split[OF _ isHighestPrio_corres]; simp only:)
-                               apply (rule corres_if, simp)
-                                apply (rule corres_split[OF _ tcbSchedEnqueue_corres])
-                                  apply (simp, fold dc_def)
-                                  apply (rule corres_split[OF _ setSchedulerAction_corres])
-                                     apply (rule scheduleChooseNewThread_corres, simp)
+    apply (rule corres_split[OF isCurDomainExpired_corres])
+      apply (rule corres_when)
+       apply simp
+      apply (rule corres_split[OF setReprogramTimer_corres])
+        apply (rule rescheduleRequired_corres)
+       apply (wpsimp wp: hoare_drop_imps
+                   simp: isCurDomainExpired_def)+
+  done
 
-                                   apply (wp | simp)+
-                                   apply (simp add: valid_sched_def)
-                                   apply wp
-                                   apply (rule hoare_vcg_conj_lift)
-                                    apply (rule_tac t=t in set_scheduler_action_cnt_valid_blocked')
-                                   apply (wpsimp wp: setSchedulerAction_invs')+
-                                 apply (wp tcb_sched_action_enqueue_valid_blocked hoare_vcg_all_lift enqueue_thread_queued)
-                                apply (wp tcbSchedEnqueue_invs'_not_ResumeCurrentThread)
+crunches refill_budget_check_round_robin
+  for sc_at[wp]: "sc_at sc_ptr"
+  and valid_objs[wp]: valid_objs
+  and pspace_aligned[wp]: pspace_aligned
+  and pspace_distinct[wp]: pspace_distinct
 
-                               apply (rule corres_if, fastforce)
+lemma commitTime_corres:
+  "corres dc (\<lambda>s. sc_at (cur_sc s) s \<and> valid_objs s \<and> pspace_aligned s \<and> pspace_distinct s
+                  \<and> (cur_sc_active s \<longrightarrow> valid_refills (cur_sc s) s))
+             (\<lambda>s'. is_active_sc' (ksCurSc s') s' \<longrightarrow> valid_refills' (ksCurSc s') s')
+             commit_time
+             commitTime"
+  supply if_split[split del]
+  apply (rule_tac Q="\<lambda>s'. sc_at' (ksCurSc s') s'" in corres_cross_add_guard)
+   apply (fastforce intro: sc_at_cross simp: state_relation_def)
+  apply (clarsimp simp: commit_time_def commitTime_def liftM_def)
+  apply (rule corres_split'[rotated 2, OF gets_sp getCurSc_sp])
+   apply (corressimp corres: getCurSc_corres)
+  apply clarsimp
+  apply (rule corres_split'[rotated 2, OF get_sched_context_sp get_sc_sp'])
+   apply (corressimp corres: get_sc_corres)
+  apply (rule corres_split'[rotated, where r'=dc])
+     apply (rule setConsumedTime_corres)
+     apply simp
+    apply wpsimp
+   apply wpsimp
+  apply (clarsimp simp: when_def)
+  apply (rule corres_if_split; fastforce?)
+   apply (clarsimp simp: sc_relation_def active_sc_def)
+  apply (rule corres_split'[rotated 2, OF gets_sp getConsumedTime_sp])
+   apply corressimp
+  apply clarsimp
+  apply (rename_tac consumed)
+  apply (rule_tac Q="\<lambda>_ s. sc_at (cur_sc s) s \<and> csc = cur_sc s"
+              and Q'="\<lambda>_ s'. sc_at' (ksCurSc s') s' \<and> csc = ksCurSc s'"
+              and r'=dc
+               in corres_split'[rotated])
+     apply (clarsimp simp: updateSchedContext_def)
+     apply (rule corres_symb_exec_r[rotated, OF get_sc_sp'])
+       apply wpsimp
+      apply wpsimp
+     apply (rename_tac sc')
+     apply (prop_tac "(\<lambda>sc. sc\<lparr>sc_consumed := sc_consumed sc + consumed\<rparr>)
+                      = sc_consumed_update (\<lambda>c. c + consumed)")
+      apply force
+     apply (prop_tac "scConsumed_update (\<lambda>_. scConsumed sc' + consumed) sc'
+                      = scConsumed_update (\<lambda>c. c + consumed) sc'")
+      apply (fastforce intro: sched_context.expand)
+     apply (rule_tac P="\<lambda>t. corres dc _ _ (update_sched_context csc t) _" in subst[OF sym])
+      apply assumption
+     apply (rule_tac P="\<lambda>t. corres dc _ _ _ (setSchedContext csc t)" in subst[OF sym])
+      apply assumption
+     apply (rule corres_guard_imp)
+       apply (rule_tac f="\<lambda>c. c + consumed" and f'="\<lambda>c. c + consumed" in scConsumed_update_corres)
+       apply (clarsimp simp: sc_relation_def opt_map_red opt_map_def active_sc_def)
+      apply fastforce
+     apply (wpsimp simp: isRoundRobin_def | wps)+
+  apply (clarsimp simp: ifM_def split: if_split)
+  apply (rule corres_split'[rotated 2, OF is_round_robin_sp isRoundRobin_sp])
+   apply (corressimp corres: isRoundRobin_corres)
+  apply (corressimp corres: refillBudgetCheckRoundRobin_corres refillBudgetCheck_corres)
+  apply (fastforce simp: obj_at_def vs_all_heap_simps is_sc_obj_def obj_at_simps sc_relation_def
+                         is_active_sc'_def opt_map_red active_sc_def)
+  done
 
-                                apply (rule corres_split[OF _ tcbSchedAppend_corres])
-                                  apply (simp, fold dc_def)
-                                  apply (rule corres_split[OF _ setSchedulerAction_corres])
-                                     apply (rule scheduleChooseNewThread_corres, simp)
+crunches ifCondRefillUnblockCheck
+  for valid_objs'[wp]: valid_objs'
+  (simp: crunch_simps)
 
-                                   apply (wp | simp)+
-                                   apply (simp add: valid_sched_def)
-                                   apply wp
-                                   apply (rule hoare_vcg_conj_lift)
-                                    apply (rule_tac t=t in set_scheduler_action_cnt_valid_blocked')
-                                   apply (wpsimp wp: setSchedulerAction_invs')+
-                                 apply (wp tcb_sched_action_append_valid_blocked hoare_vcg_all_lift append_thread_queued)
-                                apply (wp tcbSchedAppend_invs'_not_ResumeCurrentThread)
+lemma switchSchedContext_corres:
+  "corres dc (\<lambda>s. valid_state s \<and> cur_tcb s \<and> sc_at (cur_sc s) s  \<and> active_sc_valid_refills s
+                  \<and> current_time_bounded 1 s \<and> active_sc_tcb_at (cur_thread s) s)
+             valid_objs'
+             switch_sched_context
+             switchSchedContext"
+  apply (clarsimp simp: valid_state_def)
+  apply add_cur_tcb'
+  apply (clarsimp simp: switch_sched_context_def switchSchedContext_def)
+  apply (rule corres_split'[rotated 2, OF gets_sp getCurSc_sp])
+   apply (corressimp corres: getCurSc_corres)
+  apply (clarsimp, rename_tac curScPtr)
+  apply (rule corres_split'[rotated 2, OF gets_sp getCurThread_sp])
+   apply corressimp
+  apply (clarsimp, rename_tac ct)
+  apply (rule corres_split'[rotated 2, OF gsc_sp threadGet_sp, where r'="(=)"])
+   apply (rule corres_guard_imp)
+     apply (rule get_tcb_obj_ref_corres)
+     apply (fastforce simp: tcb_relation_def)
+    apply (fastforce simp: cur_tcb_def)
+   apply (fastforce simp: cur_tcb'_def)
+  apply (clarsimp, rename_tac ctScOpt)
+  apply (rule corres_symb_exec_l[rotated, OF _ assert_opt_sp])
+    apply wpsimp
+    apply (fastforce simp: obj_at_def pred_tcb_at_def vs_all_heap_simps)
+   apply wpsimp
+   apply (fastforce simp: obj_at_def pred_tcb_at_def vs_all_heap_simps)
+  apply (rename_tac scp)
+  apply (rule corres_symb_exec_l[rotated, OF _ get_sched_context_sp])
+    apply (rule get_sched_context_exs_valid)
+    apply (clarsimp simp: sc_at_pred_n_def obj_at_def is_sc_obj_def)
+    apply (rename_tac ko n, case_tac ko; clarsimp)
+   apply wpsimp
+   apply (clarsimp simp: sc_at_pred_n_def obj_at_def is_sc_obj_def)
+  apply (rename_tac ko n, case_tac ko; clarsimp)
+  apply (rule_tac F="the ctScOpt = scp" in corres_req, simp)
+  apply (rule_tac Q="\<lambda>_ s. sc_at (cur_sc s) s \<and> valid_objs s \<and> pspace_aligned s \<and> pspace_distinct s
+                           \<and> (cur_sc_active s \<longrightarrow> valid_refills (cur_sc s) s)"
+              and Q'="\<lambda>_. valid_objs'"
+              and r'=dc
+               in corres_split';
+         (solves wpsimp)?)
+    apply (clarsimp simp: when_def)
+    apply (rule corres_split_skip; (solves \<open>wpsimp wp: hoare_vcg_ex_lift\<close>)?)
+     apply (corressimp corres: setReprogramTimer_corres)
+    apply (corressimp corres: ifCondRefillUnblockCheck_corres)
+    apply (fastforce intro: valid_objs'_valid_refills' sc_at_cross is_active_sc'2_cross
+                            valid_sched_context_size_objsI
+                      simp: obj_at_def pred_tcb_at_def vs_all_heap_simps is_sc_obj_def opt_map_red)
+   apply (rule corres_split_skip; (solves wpsimp)?)
+    apply (corressimp corres: getReprogramTimer_corres)
+   apply (rule_tac Q="\<top>\<top>" and Q'="\<top>\<top>" and r'=dc in corres_split'; (solves wpsimp)?)
+    apply (corressimp corres: commitTime_corres)
+    apply (fastforce intro!: valid_objs'_valid_refills' sc_at_cross
+                       simp: state_relation_def)
+   apply (corressimp corres: setCurSc_corres)
+  apply (wpsimp wp: hoare_vcg_imp_lift' | wps)+
+  apply (fastforce intro: valid_sched_context_size_objsI active_sc_valid_refillsE
+                    simp: obj_at_def is_sc_obj_def)
+  done
 
-                               apply (rule corres_split[OF _ guarded_switch_to_corres], simp)
-                                 apply (rule setSchedulerAction_corres[simplified dc_def])
-                                 apply (wp | simp)+
+lemma commit_time_active_sc_tcb_at[wp]:
+  "commit_time \<lbrace>active_sc_tcb_at t\<rbrace>"
+  by (wpsimp simp: commit_time_def)
 
-                             (* isHighestPrio *)
-                             apply (clarsimp simp: if_apply_def2)
-                             apply ((wp (once) hoare_drop_imp)+)[1]
-                            apply (simp add: if_apply_def2)
-                             apply ((wp (once) hoare_drop_imp)+)[1]
-                           apply wpsimp+
-                     apply (wpsimp simp: etcb_relation_def)+
-            apply (rule tcbSchedEnqueue_corres)
-           apply wpsimp+
+crunches switch_sched_context
+  for active_sc_tcb_at[wp]: "active_sc_tcb_at t"
+  and not_in_release_q[wp]: "\<lambda>s. t \<notin> set (release_queue s)"
+  and pspace_aligned[wp]: pspace_aligned
+  and pspace_distinct[wp]: pspace_distinct
+  (wp: crunch_wps simp: crunch_simps)
 
-           apply (clarsimp simp: conj_ac cong: conj_cong)
-           apply wp
-           apply (rule_tac Q="\<lambda>_ s. valid_blocked_except t s \<and> scheduler_action s = switch_thread t"
-                    in hoare_post_imp, fastforce)
-           apply (wp add: tcb_sched_action_enqueue_valid_blocked_except
-                          tcbSchedEnqueue_invs'_not_ResumeCurrentThread thread_get_wp
-                     del: gets_wp)+
-       apply (clarsimp simp: conj_ac if_apply_def2 cong: imp_cong conj_cong del: hoare_gets)
-       apply (wp gets_wp)+
+crunches schedule_choose_new_thread
+  for sc_at[wp]: "sc_at sc_ptr"
+  (wp: crunch_wps dxo_wp_weak simp: crunch_simps)
 
-   (* abstract final subgoal *)
+lemma scAndTimer_corres:
+  "corres dc (\<lambda>s. valid_state s \<and> cur_tcb s \<and> sc_at (cur_sc s) s
+                  \<and> active_sc_valid_refills s \<and> valid_release_q s
+                  \<and> current_time_bounded 1 s \<and> active_sc_tcb_at (cur_thread s) s)
+             invs'
+             sc_and_timer
+             scAndTimer"
+  apply (clarsimp simp: sc_and_timer_def scAndTimer_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF switchSchedContext_corres])
+      apply (rule corres_split[OF getReprogramTimer_corres])
+        apply (clarsimp simp: when_def)
+        apply (rule corres_split[OF setNextInterrupt_corres])
+          apply (rule setReprogramTimer_corres)
+         apply (wpsimp wp: hoare_vcg_ball_lift2| wps)+
+     apply (rule_tac Q="\<lambda>_.invs" in hoare_post_imp, fastforce)
+     apply wpsimp+
+    apply (rule_tac Q="\<lambda>_. invs'" in hoare_post_imp, fastforce)
+    apply (wpsimp wp: switchSchedContext_invs')
+   apply (clarsimp simp: valid_state_def valid_release_q_def)
+  apply fastforce
+  done
+
+lemma tcb_sched_action_valid_state[wp]:
+  "tcb_sched_action action thread \<lbrace>valid_state\<rbrace>"
+  by (wpsimp simp: tcb_sched_action_def set_tcb_queue_def get_tcb_queue_def valid_state_def
+               wp: hoare_drop_imps hoare_vcg_all_lift)
+
+crunches setQueue, addToBitmap
+  for isSchedulable_bool[wp]: "isSchedulable_bool tcbPtr"
+  (simp: bitmap_fun_defs isSchedulable_bool_def isScActive_def)
+
+lemma tcbSchedEnqueue_isSchedulable_bool[wp]:
+  "tcbSchedEnqueue tcbPtr \<lbrace>isSchedulable_bool tcbPtr'\<rbrace>"
+  apply (clarsimp simp: tcbSchedEnqueue_def unless_def)
+  apply (rule hoare_seq_ext_skip, wpsimp)+
+  apply (rule hoare_when_cases, simp)
+  apply (rule hoare_seq_ext_skip, wpsimp)+
+  apply (wpsimp wp: threadSet_wp)
+  apply (fastforce simp: obj_at_simps isSchedulable_bool_def pred_map_simps opt_map_def
+                         isScActive_def
+                  split: option.splits)
+  done
+
+lemma schedule_switch_thread_branch_sc_at_cur_sc:
+  "\<lbrace>valid_objs and cur_sc_tcb\<rbrace>
+   schedule_switch_thread_branch candidate ct ct_schedulable
+   \<lbrace>\<lambda>_ s. sc_at (cur_sc s) s\<rbrace>"
+  apply (rule hoare_weaken_pre)
+   apply (rule_tac f=cur_sc in hoare_lift_Pf2)
+    apply (wpsimp simp: schedule_switch_thread_fastfail_def wp: hoare_drop_imps)+
+  apply (fastforce intro: cur_sc_tcb_sc_at_cur_sc)
+  done
+
+lemma schedule_switch_thread_branch_valid_state_and_cur_tcb:
+  "\<lbrace>\<lambda>s. invs s \<and> scheduler_action s = switch_thread candidate\<rbrace>
+   schedule_switch_thread_branch candidate ct ct_schedulable
+   \<lbrace>\<lambda>_ s. valid_state s \<and> cur_tcb s\<rbrace>"
+  apply (wpsimp simp: schedule_switch_thread_fastfail_def set_scheduler_action_def
+                  wp: switch_to_thread_invs thread_get_inv hoare_drop_imps)
+  done
+
+lemma schedule_corres:
+  "corres dc (invs and valid_sched and current_time_bounded 1 and ct_ready_if_schedulable
+              and (\<lambda>s. schact_is_rct s \<longrightarrow> cur_sc_active s))
+             invs'
+             (Schedule_A.schedule)
+             schedule"
+  apply add_sch_act_wf
+  apply add_cur_tcb'
+  apply (clarsimp simp: Schedule_A.schedule_def schedule_def sch_act_wf_asrt_def cur_tcb'_asrt_def)
+  apply (rule corres_stateAssert_add_assertion[rotated], simp)+
+  apply (rule corres_split_skip)
+     apply (wpsimp wp: awaken_valid_sched hoare_vcg_imp_lift')
+     apply fastforce
+    apply (wpsimp wp: awaken_invs')
+   apply (corressimp corres: awaken_corres)
+   apply (fastforce intro: weak_sch_act_wf_at_cross
+                     simp: invs_def valid_state_def)
+  apply (rule corres_split_skip)
+     apply (wpsimp wp: hoare_vcg_imp_lift' cur_sc_active_lift)
+    apply wpsimp
+   apply (corressimp corres: checkDomainTime_corres)
+   apply (fastforce intro: weak_sch_act_wf_at_cross
+                     simp: invs_def valid_state_def)
+  apply (rule corres_split'[rotated 2, OF gets_sp getCurThread_sp])
+   apply corressimp
+  apply (rule corres_split'[rotated 2, OF is_schedulable_sp' isSchedulable_sp])
+   apply (corressimp corres: isSchedulable_corres)
+   apply (fastforce intro: weak_sch_act_wf_at_cross
+                     simp: invs_def valid_state_def state_relation_def cur_tcb_def)
+  apply (rule corres_split'[rotated 2, OF gets_sp getSchedulerAction_sp])
+   apply (corressimp corres: getSchedulerAction_corres)
+
+  apply (case_tac "action = resume_cur_thread"; clarsimp)
+   apply (corressimp corres: scAndTimer_corres)
+   subgoal by (fastforce intro: valid_sched_context_size_objsI
+                          dest: schat_is_rct_ct_active_sc
+                          simp: invs_def cur_sc_tcb_def sc_at_pred_n_def obj_at_def is_sc_obj_def
+                                valid_state_def valid_sched_def)
+
+  apply (case_tac "action = choose_new_thread")
+   apply (clarsimp simp: bind_assoc)
+   apply (rule corres_guard_imp)
+     apply (rule corres_split[OF corres_when])
+         apply simp
+        apply (rule tcbSchedEnqueue_corres)
+       apply (rule corres_split[OF scheduleChooseNewThread_corres])
+         apply (rule scAndTimer_corres)
+        apply (subst conj_assoc[symmetric])
+        apply ((wpsimp wp: schedule_choose_new_thread_valid_state_cur_tcb
+                           schedule_choose_new_thread_active_sc_tcb_at_cur_thread
+               | rule_tac f=cur_sc in hoare_lift_Pf2
+               | rule_tac f=cur_thread in hoare_lift_Pf2)+)[1]
+       apply (wpsimp wp: scheduleChooseNewThread_invs')
+      apply (wpsimp | wps)+
+    subgoal by (fastforce intro!: cur_sc_tcb_sc_at_cur_sc valid_sched_context_size_objsI
+                            simp: is_schedulable_bool_def2 pred_tcb_at_def obj_at_def get_tcb_def
+                                  invs_def cur_tcb_def is_tcb_def ct_ready_if_schedulable_def
+                                  vs_all_heap_simps valid_sched_def)
+   apply (fastforce simp: invs'_def isSchedulable_bool_def st_tcb_at'_def pred_map_simps
+                          obj_at_simps cur_tcb'_def)
+
+  apply (case_tac action; clarsimp)
+  apply (rule corres_split'[OF _ scAndTimer_corres, where r'=dc])
+
+    apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>" for P f Q  \<Rightarrow> -\<close>)
+    apply (subst bind_dummy_ret_val)+
+    apply (subst conj_assoc[symmetric])
+    apply (rule hoare_vcg_conj_lift_pre_fix)
+     apply (wpsimp wp: schedule_switch_thread_branch_valid_state_and_cur_tcb)
+    apply (intro hoare_vcg_conj_lift_pre_fix;
+           (solves \<open>wpsimp simp: schedule_switch_thread_fastfail_def
+                             wp: thread_get_inv hoare_drop_imps\<close>)?)
+     apply (wpsimp wp: schedule_switch_thread_branch_sc_at_cur_sc)
+     apply fastforce
+    apply (wpsimp wp: schedule_switch_thread_branch_active_sc_tcb_at_cur_thread)
+    apply (fastforce simp: valid_sched_def valid_sched_action_def weak_valid_sched_action_def
+                           vs_all_heap_simps)
+
+   apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>" for P f Q  \<Rightarrow> -\<close>)
+   apply (rename_tac target)
+   apply (rule_tac B="\<lambda>_ s. invs' s \<and> curThread = ksCurThread s \<and> st_tcb_at' runnable' target s"
+                in hoare_seq_ext[rotated])
+    apply wpsimp
+    apply (clarsimp simp: invs'_def isSchedulable_bool_def st_tcb_at'_def pred_map_simps
+                          obj_at_simps cur_tcb'_def sch_act_wf_cases
+                   split: scheduler_action.splits)
+   apply (rule hoare_seq_ext_skip, solves wpsimp)+
+   apply (wpsimp wp: scheduleChooseNewThread_invs' ksReadyQueuesL1Bitmap_return_wp
+               simp: isHighestPrio_def scheduleSwitchThreadFastfail_def)
+
+  apply (rename_tac candidate)
+  apply (rule corres_split_skip[where r'="(=)"])
+     apply wpsimp
+     apply (clarsimp simp: is_schedulable_bool_def2 pred_tcb_at_def obj_at_def valid_sched_def
+                           ct_ready_if_schedulable_def vs_all_heap_simps)
+    apply wpsimp
+    apply (clarsimp simp: invs'_def isSchedulable_bool_def st_tcb_at'_def pred_map_simps
+                          obj_at_simps vs_all_heap_simps cur_tcb'_def)
+   apply (corressimp corres: tcbSchedEnqueue_corres)
+   apply (fastforce dest: invs_cur
+                    simp: cur_tcb_def)
+
+  apply (rule corres_split'[rotated 2, OF gets_sp getIdleThread_sp])
+   apply corressimp
+  apply (rule corres_split'[rotated 2, OF thread_get_sp threadGet_sp, where r'="(=)"])
+   apply (rule corres_guard_imp)
+     apply (rule threadGet_corres)
+     apply (clarsimp simp: tcb_relation_def)
+    apply (fastforce simp: valid_sched_def valid_sched_action_def weak_valid_sched_action_def
+                           vs_all_heap_simps obj_at_def is_tcb_def)
+   apply (clarsimp simp: sch_act_wf_cases split: scheduler_action.splits)
+
+  apply (rule_tac Q="\<lambda>_ s. invs s \<and> valid_ready_qs s \<and> ready_or_release s
+                           \<and> pred_map runnable (tcb_sts_of s) candidate
+                           \<and> released_sc_tcb_at candidate s \<and> not_in_release_q candidate s"
+              and Q'="\<lambda>_ s. invs' s \<and> cur_tcb' s \<and> curThread = ksCurThread s
+                            \<and> st_tcb_at' runnable' candidate s"
+              and r'="(=)"
+               in corres_split')
+     apply clarsimp
+     apply (rule corres_guard_imp)
+       apply (rule threadGet_corres)
+       apply (clarsimp simp: tcb_relation_def)
+      apply clarsimp
+     apply (clarsimp simp: cur_tcb'_def)
+
+    apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>" for P f Q  \<Rightarrow> -\<close>)
+    apply (wpsimp wp: thread_get_wp)
+    apply (clarsimp simp: valid_sched_def valid_sched_action_def weak_valid_sched_action_def
+                          in_queue_2_def)
+
+   apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>" for P f Q  \<Rightarrow> -\<close>)
+   apply (wpsimp wp: threadGet_wp)
+   apply (clarsimp simp: cur_tcb'_def obj_at_simps sch_act_wf_cases
+                  split: scheduler_action.splits)
+
+  apply (rule corres_split'[rotated 2, OF schedule_switch_thread_fastfail_inv
+                                          scheduleSwitchThreadFastfail_inv])
+   apply (corressimp corres: scheduleSwitchThreadFastfail_corres)
+   apply (fastforce dest: invs_cur
+                    simp: cur_tcb_def obj_at_def is_tcb_def state_relation_def cur_tcb'_def)
+  apply (rule corres_split'[rotated 2, OF gets_sp curDomain_sp])
+   apply (corressimp corres: curDomain_corres)
+  apply (clarsimp simp: isHighestPrio_def' split del: if_split)
+
+  apply (rule corres_split'[rotated 2, OF gets_sp gets_sp, where r'="(=)"])
+   apply (corressimp corres: isHighestPrio_corres)
+   apply (clarsimp simp: is_highest_prio_def)
+   apply (subst bitmapL1_zero_ksReadyQueues)
+     apply (fastforce dest: invs_queues simp: valid_queues_def)
+    apply (fastforce dest: invs_queues simp: valid_queues_def)
+   apply (rule disj_cong)
+    apply (fastforce simp: ready_queues_relation_def dest!: state_relationD)
    apply clarsimp
+   apply (subst lookupBitmapPriority_Max_eqI)
+      apply (fastforce dest: invs_queues simp: valid_queues_def)
+     apply (fastforce dest: invs_queues simp: valid_queues_def)
+    apply (subst bitmapL1_zero_ksReadyQueues)
+      apply (fastforce dest: invs_queues simp: valid_queues_def)
+     apply (fastforce dest: invs_queues simp: valid_queues_def)
+    apply (fastforce simp: ready_queues_relation_def dest!: state_relationD)
+   apply (clarsimp simp: ready_queues_relation_def dest!: state_relationD)
 
-   subgoal for s
-     apply (clarsimp split: Deterministic_A.scheduler_action.splits
-                     simp: invs_psp_aligned invs_distinct invs_valid_objs invs_arch_state
-                           invs_vspace_objs[simplified] tcb_at_invs)
-     apply (rule conjI, clarsimp)
-      apply (fastforce simp: invs_def
-                            valid_sched_def valid_sched_action_def is_activatable_def
-                            st_tcb_at_def obj_at_def valid_state_def only_idle_def
-                            )
-     apply (rule conjI, clarsimp)
-      subgoal for candidate
-        apply (clarsimp simp: valid_sched_def invs_def valid_state_def cur_tcb_def
-                               valid_arch_caps_def valid_sched_action_def
-                               weak_valid_sched_action_def tcb_at_is_etcb_at
-                               tcb_at_is_etcb_at[OF st_tcb_at_tcb_at[rotated]]
-                               valid_blocked_except_def valid_blocked_def)
-        apply (clarsimp simp add: pred_tcb_at_def obj_at_def is_tcb valid_idle_def)
-        done
-     (* choose new thread case *)
-     apply (intro impI conjI allI tcb_at_invs
-            | fastforce simp: invs_def cur_tcb_def valid_etcbs_def
-                              valid_sched_def  st_tcb_at_def obj_at_def valid_state_def
-                              weak_valid_sched_action_def not_cur_thread_def)+
-     apply (simp add: valid_sched_def valid_blocked_def valid_blocked_except_def)
-     done
+  apply (rule corres_if_split; (solves simp)?)
+   apply (rule corres_guard_imp)
+     apply (rule corres_split[OF tcbSchedEnqueue_corres])
+       apply clarsimp
+       apply (rule corres_split[OF setSchedulerAction_corres])
+          apply (clarsimp simp: sched_act_relation_def)
+         apply (rule scheduleChooseNewThread_corres)
+        apply wpsimp+
+    apply (fastforce simp: obj_at_def vs_all_heap_simps is_tcb_def pred_tcb_at_def)
+   apply fastforce
 
-  (* haskell final subgoal *)
-  apply (clarsimp simp: if_apply_def2 invs'_def valid_state'_def
-                  cong: imp_cong  split: scheduler_action.splits)
-  apply (fastforce simp: cur_tcb'_def valid_pspace'_def)
-  done *)
+  apply (rule corres_if_split; (solves simp)?)
+   apply (rule corres_guard_imp)
+     apply (rule corres_split[OF tcbSchedAppend_corres])
+       apply clarsimp
+       apply (rule corres_split[OF setSchedulerAction_corres])
+          apply (clarsimp simp: sched_act_relation_def)
+         apply (rule scheduleChooseNewThread_corres)
+        apply wpsimp+
+    apply (fastforce simp: obj_at_def vs_all_heap_simps is_tcb_def pred_tcb_at_def)
+   apply fastforce
+
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF switchToThread_corres])
+      apply clarsimp
+      apply (rule setSchedulerAction_corres)
+      apply (clarsimp simp: sched_act_relation_def)
+     apply wpsimp
+    apply wpsimp
+   apply (clarsimp simp: pred_conj_def)
+   apply (fastforce simp: obj_at_def vs_all_heap_simps pred_tcb_at_def)
+  apply fastforce
+  done
 
 end
 

--- a/spec/haskell/src/SEL4/Kernel/Thread.lhs
+++ b/spec/haskell/src/SEL4/Kernel/Thread.lhs
@@ -347,6 +347,14 @@ has the highest runnable priority in the system on kernel entry (unless idle).
 >           setReprogramTimer True
 >           rescheduleRequired
 
+> scAndTimer :: Kernel ()
+> scAndTimer = do
+>     switchSchedContext
+>     reprogram <- getReprogramTimer
+>     when reprogram $ do
+>         setNextInterrupt
+>         setReprogramTimer False
+
 > schedule :: Kernel ()
 > schedule = do
 >     stateAssert sch_act_wf_asrt
@@ -397,12 +405,9 @@ If the current thread is no longer runnable, has used its entire timeslice, an I
 >         ChooseNewThread -> do
 >             when isSchedulable $ tcbSchedEnqueue curThread
 >             scheduleChooseNewThread
->
->     switchSchedContext
->     reprogram <- getReprogramTimer
->     when reprogram $ do
->         setNextInterrupt
->         setReprogramTimer False
+
+>     scAndTimer
+
 
 
 


### PR DESCRIPTION
If everyone is happy with the (input) abbreviation `schedule_switch_thread_branch`, then I could use it for the `cur_sc_active` work, and use `schedule_switch_thread_branch_active_sc_tcb_at_cur_thread` in `schedule_cur_sc_active`.

`corres_fail'` should probably be moved to `Corres_UL.thy`. `corres_fail` there can be strengthen, too. So I could do that separately in another PR if people would like