### PR TITLE
replyRemove_corres and replyPop_corres

### DIFF
--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -1679,4 +1679,35 @@ lemma corres_symb_exec_r_sr:
   apply (drule_tac x="(s, t')" in bspec, simp)
   by clarsimp
 
+lemma corres_symb_exec_r_sr_strong:
+  assumes z: "corres_underlying sr nf nf' r P Q' x y"
+  assumes sr: "sr_inv_ul sr P P' m"
+  assumes ex: "\<And>s. P s \<Longrightarrow> \<lbrace> \<lambda>s'. (s, s') \<in> sr \<and> P' s' \<rbrace> m \<lbrace>\<lambda>_. Q'\<rbrace>"
+  assumes nf: "\<And>s. \<lbrakk> P s; nf' \<rbrakk> \<Longrightarrow> no_fail (\<lambda>s'. (s, s') \<in> sr \<and> P' s') m"
+  shows "corres_underlying sr nf nf' r P P' x (m >>= (\<lambda>_. y))"
+  using sr z ex nf
+  unfolding corres_underlying_def sr_inv_ul_def
+  apply (clarsimp simp: corres_underlying_def bind_def)
+  apply (rename_tac s s')
+  apply (rule conjI; clarsimp simp: in_monad)
+   apply (drule_tac x=s and y=s' in spec2, clarsimp)
+   apply (rename_tac t' rv' s'')
+   apply (drule_tac x="(s, t')" in bspec, simp)
+   apply clarsimp
+   apply (drule use_valid[OF _ ex], simp)
+   apply clarsimp
+   apply clarsimp
+   apply (drule_tac x="(rv', s'')" in bspec, simp)
+   apply simp
+  apply (drule_tac x=s and y=s' in spec2, clarsimp simp: no_failD[OF nf] valid_def)
+  apply (rename_tac t')
+  apply (drule_tac x=s in meta_spec)
+  apply (drule_tac x=s in meta_spec)
+  apply (drule_tac x=t' in spec, clarsimp)
+  apply (drule_tac x=s' in spec, clarsimp)
+  apply (drule bspec[of "fst _"], simp)
+  apply clarsimp
+  apply (drule_tac x="(s, t')" in bspec, simp)
+  by clarsimp
+
 end

--- a/proof/invariant-abstract/IpcDet_AI.thy
+++ b/proof/invariant-abstract/IpcDet_AI.thy
@@ -812,7 +812,9 @@ lemma set_reply_sc_valid_replies_already_BlockedOnReply:
   by wpsimp
 
 lemma reply_sc_update_None_reply_sc_reply_at_None[wp]:
-  "set_reply_obj_ref reply_sc_update t None \<lbrace>reply_sc_reply_at (\<lambda>sc. sc = None) reply_ptr\<rbrace>"
+  "\<lbrace>\<lambda>s. rp \<noteq> reply_ptr \<longrightarrow> reply_sc_reply_at ((=) None) reply_ptr s\<rbrace>
+   set_reply_obj_ref reply_sc_update rp None
+   \<lbrace>\<lambda>_. reply_sc_reply_at ((=) None) reply_ptr\<rbrace>"
   apply (wpsimp wp: update_sk_obj_ref_wp)
   apply (clarsimp simp: reply_sc_reply_at_def obj_at_def)
   done

--- a/proof/refine/ARM/InvariantUpdates_H.thy
+++ b/proof/refine/ARM/InvariantUpdates_H.thy
@@ -473,4 +473,8 @@ lemma valid_obj'_scPeriod_update[simp]:
   "valid_obj' (KOSchedContext (scPeriod_update (\<lambda>_. period) sc')) = valid_obj' (KOSchedContext sc')"
   by (fastforce simp: valid_obj'_def valid_sched_context'_def valid_sched_context_size'_def objBits_simps)
 
+lemma valid_sched_context_size'_scReply_update[simp]:
+  "valid_sched_context_size' (scReply_update f sc) = valid_sched_context_size' sc"
+  by (clarsimp simp: valid_sched_context_size'_def objBits_simps)
+
 end

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -983,6 +983,437 @@ lemma replyRemoveTCB_corres:
   apply (case_tac "tcbState tcb"; simp)
   done
 
+lemma setSchedContext_pop_head_corres:
+  "\<lbrakk> replyNext reply' = Some (Head ptr)  \<rbrakk> \<Longrightarrow>
+   corres dc ((\<lambda>s. (sc_replies_of s |> hd_opt) ptr = Some rp) and valid_objs
+               and pspace_aligned and pspace_distinct and (\<lambda>s. sym_refs (state_refs_of s)))
+             (ko_at' reply' rp)
+          (update_sched_context ptr (sc_replies_update tl))
+         (do sc' \<leftarrow> getSchedContext ptr;
+            setSchedContext ptr (scReply_update (\<lambda>_. replyPrev reply') sc')
+          od)"
+  apply (rule_tac Q="sc_at' ptr" in corres_cross_add_guard)
+   apply (fastforce dest!: state_relationD simp: obj_at_def is_sc_obj_def vs_heap_simps
+                    elim!: sc_at_cross valid_objs_valid_sched_context_size)
+  apply add_sym_refs
+  apply (rule_tac Q="pspace_aligned' and pspace_distinct'" in corres_cross_add_guard)
+   apply (fastforce dest!: state_relationD elim!: pspace_aligned_cross pspace_distinct_cross)
+  apply (rule_tac Q="\<lambda>s'. scReplies_of s' ptr = Some rp" in corres_cross_add_guard)
+   apply (fastforce dest!: state_relationD simp: sc_replies_relation_scReply_cross vs_heap_simps)
+  apply (rule corres_symb_exec_r)
+     apply (rule_tac P'="ko_at' sc' ptr and ko_at' reply' rp and (\<lambda>s'. sym_refs (state_refs_of' s'))
+                         and pspace_aligned' and pspace_distinct' and  K (scReply sc' = Some rp)" in corres_inst)
+     apply (rule corres_gen_asm2')
+     apply (rule_tac Q="sc_obj_at (objBits sc' - minSchedContextBits) ptr" in corres_cross_add_abs_guard)
+      apply (fastforce dest!: state_relationD ko_at'_cross)
+     apply (rule corres_guard_imp)
+       apply (rule_tac P="(\<lambda>s. (sc_replies_of s |> hd_opt) ptr = Some rp)
+                          and sc_obj_at (objBits sc' - minSchedContextBits) ptr"
+                  and n1="objBits sc' - minSchedContextBits"
+                            in monadic_rewrite_corres[OF _ update_sched_context_rewrite])
+       apply (rule corres_symb_exec_l)
+          apply (rule corres_guard_imp)
+            apply (rule_tac P="(\<lambda>s. kheap s ptr =
+                                       Some (kernel_object.SchedContext sc (objBits sc' - minSchedContextBits)))
+                               and K (rp = hd (sc_replies sc))"
+                        and P'="ko_at' sc' ptr and ko_at' reply' rp and (\<lambda>s'. sym_refs (state_refs_of' s'))
+                               and pspace_distinct' and pspace_aligned'"  in corres_inst)
+            apply (rule corres_gen_asm')
+            apply (rule stronger_corres_guard_imp)
+              apply (rule_tac sc=sc and sc'=sc' in setSchedContext_update_corres; simp?)
+               apply (clarsimp simp: sc_relation_def objBits_simps)+
+            apply (clarsimp simp: obj_at'_def projectKOs)
+            apply (prop_tac "heap_ls (replyPrevs_of s') (Some rp) (sc_replies sc)")
+             apply (drule state_relation_sc_replies_relation)
+             apply (drule (2) sc_replies_relation_prevs_list, simp)
+            apply (case_tac "sc_replies sc"; clarsimp simp: opt_map_left_Some)
+           apply simp
+          apply simp
+         apply (wpsimp wp: get_sched_context_exs_valid simp: is_sc_obj_def obj_at_def)
+          apply (rename_tac ko xs; case_tac ko; clarsimp)
+         apply simp
+        apply (wpsimp simp: obj_at_def is_sc_obj_def vs_heap_simps)
+       apply (wpsimp wp: get_sched_context_no_fail)
+      apply (clarsimp simp: obj_at_def is_sc_obj_def)
+     apply simp
+    apply (wpsimp simp: projectKOs obj_at'_def)+
+  done
+
+lemma replyPop_corres:
+  "\<lbrakk>st = Structures_A.thread_state.BlockedOnReply rp;
+        st' = Structures_H.thread_state.BlockedOnReply (Some rp);
+        reply_relation reply reply'; replyTCB reply' = Some t;
+        replyNext reply' = Some (Head scp); rp \<in> set (sc_replies sc); hd (sc_replies sc) = rp\<rbrakk> \<Longrightarrow>
+   corres dc
+     (valid_objs and pspace_aligned and pspace_distinct and valid_replies
+      and st_tcb_at ((=) (Structures_A.thread_state.BlockedOnReply rp)) t
+      and (\<lambda>s. sym_refs (state_refs_of s))
+      and (\<lambda>s. sc_with_reply rp s = Some scp)
+      and obj_at (\<lambda>ko. \<exists>n. ko = kernel_object.SchedContext sc n) scp
+      and bound_sc_tcb_at ((=) tcbsc) t
+      and ko_at (Structures_A.Reply reply) rp
+      and reply_sc_reply_at ((=) (Some scp)) rp)
+     (valid_objs' and valid_release_queue_iff
+      and (\<lambda>s'. sym_refs (list_refs_of_replies' s'))
+      and ko_at' reply' rp
+      and ((\<lambda>s'. scReplies_of s' scp = hd_opt (sc_replies sc))
+      and  sc_at' scp))
+     (do x <- reply_unlink_sc scp rp;
+         y <- when (tcbsc = None) (sched_context_donate scp t);
+         reply_unlink_tcb t rp
+      od)
+     (replyPop rp t)"
+  (is "\<lbrakk> _ ; _ ; _; _; _; _; _\<rbrakk> \<Longrightarrow> corres _ ?abs_guard ?conc_guard _ _")
+  apply add_sym_refs
+  apply (rule_tac Q="st_tcb_at' ((=) st') t" in corres_cross_add_guard)
+   apply (fastforce dest!: st_tcb_at_coerce_concrete elim!: pred_tcb'_weakenE)
+  apply (simp add: reply_unlink_sc_def replyPop_def bind_assoc liftM_def)
+                      apply (rule_tac Q="\<lambda>rv. ?abs_guard and K (rv = sc)" in corres_symb_exec_l)
+                         apply (rule corres_gen_asm', simp add: bind_assoc split del: if_split)
+  apply (rule corres_guard_imp)
+       apply (rule corres_split[OF get_reply_corres])
+         apply (rename_tac r r')
+         apply (rule_tac P="?abs_guard and K (r = reply)"
+                     and P'="?conc_guard and (\<lambda>s. sym_refs (state_refs_of' s)) and st_tcb_at' ((=) st') t
+                             and K (r' = reply')"
+                in corres_inst)
+         apply (rule corres_gen_asm')
+         apply (rule corres_gen_asm2')
+         apply simp
+         apply (rule corres_guard_imp)
+           apply (rule corres_symb_exec_l)
+              apply (rule corres_guard_imp)
+
+                apply (rule corres_symb_exec_r)
+                   apply (rename_tac state)
+                   apply (rule_tac P="?abs_guard and reply_sc_reply_at ((=) None) rp"
+                               and P'="?conc_guard and (\<lambda>s. sym_refs (state_refs_of' s)) and st_tcb_at' ((=) st') t
+                                       and K (state = st')"
+                          in corres_inst)
+                   apply (rule corres_gen_asm2')
+                   apply (simp add: bind_assoc isReply_def isHead_def)
+                   apply (subst bind_assoc[symmetric, where m="getSchedContext _"])
+                   apply (rule corres_guard_imp)
+                     apply (rule corres_split[OF setSchedContext_pop_head_corres])
+                        apply simp
+                       apply (case_tac "sc_replies sc"; simp)
+                       apply (rename_tac list; case_tac list; simp)
+
+(*
+        apply (prop_tac "reply_sc reply = replySc reply'")
+         apply (clarsimp simp: reply_relation_def)
+*)
+(*
+        apply (rule_tac P="?abs_guard "
+                    and P'="?conc_guard and (\<lambda>s. sym_refs (state_refs_of' s)) and st_tcb_at' ((=) st') t
+                            and ko_at' reply' rp"
+               in corres_inst)
+        apply (rule_tac Q'="\<lambda>rv'. ?conc_guard and st_tcb_at' ((=) st') t and (\<lambda>s'. sym_refs (state_refs_of' s'))
+                             and K (rv' = st')"
+               in corres_symb_exec_r)
+           apply (rename_tac rv')
+           apply (rule corres_gen_asm2', simp only:)
+           apply (rule corres_guard_imp)
+             apply (rule corres_assert_gen_asm2; simp add: bind_assoc isHead_def isReply_def split del: if_split)
+*)
+  sorry
+
+lemma get_tcb_obj_ref_exs_valid[wp]:
+  "\<exists>tcb. kheap s tp = Some (Structures_A.TCB tcb)
+   \<Longrightarrow> \<lbrace>(=) s\<rbrace> get_tcb_obj_ref f tp \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
+  by (clarsimp simp: get_tcb_obj_ref_def thread_get_def gets_the_def get_tcb_def bind_def
+                     gets_def get_def return_def exs_valid_def
+              split: Structures_A.kernel_object.splits)
+
+lemma replyRemove_corres:
+  "\<lbrakk> st = Structures_A.thread_state.BlockedOnReply rp;
+     thread_state_relation st st' \<rbrakk> \<Longrightarrow>
+   corres dc (valid_objs and pspace_aligned and pspace_distinct and valid_replies
+              and st_tcb_at ((=) st) t and (\<lambda>s. sym_refs (state_refs_of s)))
+             (valid_objs' and valid_release_queue_iff and (\<lambda>s'. sym_refs (list_refs_of_replies' s')))
+                (reply_remove t rp) (replyRemove rp t)"
+  (is "\<lbrakk> _ ; _ \<rbrakk> \<Longrightarrow> corres _ ?abs_guard ?conc_guard _ _")
+  apply add_sym_refs
+  apply (rule_tac Q="st_tcb_at' ((=) st') t" in corres_cross_add_guard)
+   apply (fastforce dest!: st_tcb_at_coerce_concrete elim!: pred_tcb'_weakenE)
+  apply (clarsimp simp: reply_remove_def replyRemove_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF get_reply_corres])
+      apply (rename_tac reply reply')
+      apply (rule_tac P="?abs_guard and ko_at (Structures_A.Reply reply) rp"
+                  and P'="?conc_guard and (\<lambda>s. sym_refs (state_refs_of' s)) and st_tcb_at' ((=) st') t
+                          and ko_at' reply' rp"
+             in corres_inst)
+      apply (rule corres_guard_imp)
+        apply (rule corres_assert_gen_asm_l)
+        apply (prop_tac "reply_tcb reply = replyTCB reply'")
+         apply (clarsimp simp: reply_relation_def)
+        apply (clarsimp simp: assert_opt_def isReply_def split del: if_split)
+        apply (rule_tac P="?abs_guard and ko_at (Structures_A.Reply reply) rp"
+                    and P'="?conc_guard and (\<lambda>s. sym_refs (state_refs_of' s)) and st_tcb_at' ((=) st') t
+                            and ko_at' reply' rp"
+               in corres_inst)
+        apply (rule_tac Q'="\<lambda>rv'. ?conc_guard and st_tcb_at' ((=) st') t and (\<lambda>s'. sym_refs (state_refs_of' s'))
+                             and ko_at' reply' rp and K (rv' = st')"
+               in corres_symb_exec_r)
+           apply (rename_tac rv')
+           apply (rule corres_gen_asm2')
+           apply (simp only:)
+           apply (rule corres_guard_imp)
+             apply (rule corres_assert_gen_asm2; simp split del: if_split)
+
+             (* get sc_with_reply *)
+             apply (rule corres_symb_exec_l)
+                apply (rename_tac sc_opt)
+                apply (rule_tac P="?abs_guard and (\<lambda>s. sc_with_reply rp s = sc_opt) and  ko_at (Structures_A.Reply reply) rp"
+                            and P'="?conc_guard and (\<lambda>s. sym_refs (state_refs_of' s)) and ko_at' reply' rp"
+                       in corres_inst)
+                apply (rule_tac Q="(\<lambda>s'. sc_with_reply' rp s' = sc_opt) and pspace_aligned' and pspace_distinct'"
+                       in corres_cross_add_guard)
+                 apply (fastforce simp: sc_replies_relation_sc_with_reply_cross_eq
+                                 dest!: state_relationD pspace_distinct_cross dest: pspace_aligned_cross)
+                apply (case_tac sc_opt; simp split del: if_split add: bind_assoc)
+
+                 (** sc_with_reply rp s = None **)
+                 apply (rule_tac F="replySc reply' = None" in corres_req)
+                  apply (fastforce dest!: sc_with_reply_None_reply_sc_reply_at replySCs_of_cross
+                                   elim!: obj_at_weakenE simp: is_reply obj_at'_def projectKOs opt_map_left_Some)
+                 apply (clarsimp simp: replySc_None_not_head)
+  subgoal for reply reply'
+    apply (simp only: bind_assoc[symmetric])
+    apply (rule corres_symb_exec_r_sr)
+       apply (rule corres_guard_imp)
+         apply (rule reply_unlink_tcb_corres[simplified dc_def])
+         apply (rule disjI2, simp)
+        apply (fastforce dest: valid_objs_valid_tcbs st_tcb_reply_state_refs
+                         simp: obj_at_def is_reply reply_tcb_reply_at_def)
+       apply simp
+      apply (rule sr_inv_imp)
+        apply (erule sr_inv_sc_with_reply_None_helper)
+       apply (fastforce elim!: obj_at_weakenE simp: is_reply)
+      apply simp
+     apply (wpsimp wp: updateReply_valid_objs' simp: valid_reply'_def obj_at'_def)
+     apply (fastforce elim!: reply_ko_at_valid_objs_valid_reply')
+    apply (erule no_fail_sc_wtih_reply_None_helper)
+    done
+
+                (** sc_with_reply \<noteq> None : rp is in a reply stack **)
+                apply (rename_tac scp)
+                apply (rule_tac F="replyNext reply' \<noteq> None" in corres_req)
+                 apply clarsimp
+                 apply (prop_tac "sc_at scp s")
+                  apply (fastforce dest!: sc_with_reply_SomeD1
+                                    simp: sc_replies_sc_at_def obj_at_def is_sc_obj_def
+                                    elim: valid_sched_context_size_objsI)
+                 apply (prop_tac "sc_at' scp s'")
+                  apply (fastforce dest!: state_relationD sc_at_cross)
+                 apply (drule sc_with_reply'_SomeD, clarsimp)
+                 apply (case_tac "hd xs = rp")
+                  apply (drule heap_path_head, clarsimp)
+                  apply (drule (3) sym_refs_replySCs_of_scReplies_of[THEN iffD2, rotated])
+                  apply (clarsimp simp: obj_at'_def projectKOs)
+                 apply (frule (1) heap_path_takeWhile_lookup_next)
+                 apply (frule heap_path_head, clarsimp)
+                 apply (prop_tac "takeWhile ((\<noteq>) rp) xs = hd xs # tl (takeWhile ((\<noteq>) rp) xs)")
+                  apply (case_tac xs; simp)
+                 apply (simp del: heap_path.simps)
+                 apply (drule_tac p1="hd xs" and ps1="tl (takeWhile ((\<noteq>) rp) xs)"
+                        in sym_refs_reply_heap_path_doubly_linked_Nexts_rev[where p'=rp, THEN iffD1])
+                  apply clarsimp
+                 apply (case_tac "rev (tl (takeWhile ((\<noteq>) rp) xs))"; clarsimp simp: obj_at'_def projectKOs)
+                apply (clarsimp simp: liftM_def bind_assoc split del: if_split)
+                apply (rename_tac next_reply)
+                apply (rule_tac Q="\<lambda>x. ?abs_guard
+                                   and (\<lambda>s. \<exists>n. kheap s scp = Some (Structures_A.SchedContext x n))
+                                   and (\<lambda>s. sc_with_reply rp s = Some scp)
+                                   and ko_at (Structures_A.Reply reply) rp
+                                   and  K (rp \<in> set (sc_replies x))"
+                       in corres_symb_exec_l)
+                   apply (rename_tac sc)
+                   apply (rule_tac Q="(\<lambda>s'. scReplies_of s' scp = hd_opt (sc_replies sc)) and sc_at' scp"
+                          in corres_cross_add_guard)
+                    apply (clarsimp; rule conjI)
+                     apply (fastforce dest!: state_relationD sc_replies_relation_scReply_cross)
+                    apply (fastforce dest!: state_relation_pspace_relation sc_at_cross
+                                            valid_objs_valid_sched_context_size
+                                      simp: obj_at_def is_sc_obj)
+
+                   apply (rule corres_gen_asm')
+                   apply (rule corres_symb_exec_l)
+                      apply (rename_tac tcbsc)
+                      apply (rule_tac P="?abs_guard and (\<lambda>s. sc_with_reply rp s = Some scp)
+                                         and obj_at (\<lambda>ko. \<exists>n. ko = Structures_A.SchedContext sc n) scp
+                                         and bound_sc_tcb_at ((=) tcbsc) t
+                                         and ko_at (Structures_A.Reply reply) rp
+                                         and reply_sc_reply_at
+                                                  (\<lambda>ko. (hd (sc_replies sc) = rp \<longrightarrow> Some scp = ko)
+                                                      \<and> (hd (sc_replies sc) \<noteq> rp \<longrightarrow> None = ko)) rp"
+                             in corres_inst)
+                      apply (rule_tac F="(hd (sc_replies sc) = rp \<longrightarrow> replySc reply' = Some scp)
+                                          \<and> (hd (sc_replies sc) \<noteq> rp \<longrightarrow> replySc reply' = None)"
+                             in corres_req, clarsimp)
+                       apply (drule (1) replySCs_of_cross)
+                       apply (clarsimp simp: obj_at'_def opt_map_left_Some projectKOs getHeadScPtr_def
+                                      split: reply_next.splits)
+                      apply (case_tac "hd (sc_replies sc) = rp"; simp add: bind_assoc split del: if_split)
+
+                      (* hd (sc_replies sc) = rp & replysc = Some scp: rp is at the head of the queue *)
+                      (* i.e. replyNext reply'  *)
+                       apply (simp add: isHead_def)
+                       apply (rule corres_guard_imp)
+                         apply (rule replyPop_corres[simplified dc_def]; simp)
+                        apply simp
+                       apply simp
+
+                     (* rp is in the middle of the reply stack *)
+                     (* hd (sc_replies sc) \<noteq> rp & rp \<in> set (sc_replies sc) *)
+                      apply (simp add: reply_unlink_sc_def bind_assoc liftM_def split del: if_split)
+                      apply (rule_tac Q="\<lambda>rv. ?abs_guard and (\<lambda>s. sc_with_reply rp s = Some scp) and
+                                   obj_at (\<lambda>ko. \<exists>n. ko = kernel_object.SchedContext sc n) scp and
+                                   bound_sc_tcb_at ((=) tcbsc) t and ko_at (Structures_A.Reply reply) rp and
+                                   reply_sc_reply_at ((=) None) rp and K (rv = sc)" in corres_symb_exec_l)
+                         apply (rule corres_gen_asm', simp split del: if_split)
+                         apply (rule_tac Q="\<lambda>rv. ?abs_guard and (\<lambda>s. sc_with_reply rp s = Some scp) and
+                                      obj_at (\<lambda>ko. \<exists>n. ko = kernel_object.SchedContext sc n) scp and
+                                      bound_sc_tcb_at ((=) tcbsc) t and ko_at (Structures_A.Reply reply) rp and
+                                      reply_sc_reply_at ((=) None) rp and K (rv = reply)" in corres_symb_exec_l)
+                            apply (rule corres_gen_asm')
+                            apply (simp split del: if_split add: bind_assoc)
+                            apply (rule corres_guard_imp)
+                              apply (rule_tac Q="?conc_guard and ko_at' reply' rp and sc_at' scp
+                                                 and (\<lambda>s'. sym_refs (state_refs_of' s'))
+                                                 and (\<lambda>s'. sc_with_reply' rp s' = Some scp)
+                                                 and (\<lambda>s'. scReplies_of s' scp = hd_opt (sc_replies sc))
+                                                 and (\<lambda>s'. \<forall>prp. replyPrev reply' = Some prp
+                                                                 \<longrightarrow> replyNexts_of s' prp = Some rp)"
+                                     in corres_assert_gen_asm_l)
+                              apply (clarsimp simp: getHeadScPtr_def isHead_def neq_conv[symmetric]
+                                             split: reply_next.splits)
+                              apply (rename_tac nxt_rp)
+                              apply (rule stronger_corres_guard_imp)
+                                apply (rule corres_split_deprecated
+                                              [OF _ updateReply_replyPrev_takeWhile_middle_corres])
+                                    apply (rule_tac P ="?abs_guard and reply_sc_reply_at ((=) None) rp
+                                                         and ko_at (Structures_A.Reply reply) rp
+                                                         and bound_sc_tcb_at ((=) tcbsc) t" and
+                                                    Q ="\<lambda>s. sc_with_reply rp s = None" and
+                                                    P'="valid_objs' and valid_release_queue_iff
+                                                        and ko_at' reply' rp and sc_at' scp" and
+                                                    Q'="(\<lambda>s'. \<forall>prp. replyPrev reply' = Some prp
+                                                                    \<longrightarrow> replyNexts_of s' prp = Some rp)"
+                                          in corres_inst_add)
+                                    apply (rule corres_symb_exec_r_sr)
+                                       apply (rule corres_symb_exec_r_sr)
+                                          apply (rule corres_guard_imp)
+                                            apply (rule reply_unlink_tcb_corres[simplified dc_def])
+                                            apply (rule disjI2, simp)
+                                           apply (fastforce dest: valid_objs_valid_tcbs st_tcb_reply_state_refs
+                                                            simp: obj_at_def is_reply reply_tcb_reply_at_def)
+                                          apply simp
+                                         apply (rule sr_inv_imp)
+                                           apply (rule cleanReply_sr_inv)
+                                          apply simp
+                                         apply simp
+                                        apply wpsimp
+                                       apply wpsimp
+                                       apply (clarsimp dest!: state_relationD simp: reply_sc_reply_at_def)
+                                       apply (fastforce intro!: reply_at_cross elim!: obj_at_weakenE simp: is_reply)
+                                      apply (clarsimp cong: conj_cong)
+                                      apply (case_tac "replyPrev reply'"; simp)
+                                      apply (rename_tac prev_rp)
+                                      apply (rule sr_inv_imp)
+                                        apply (rule_tac P =\<top> and
+                                                        P'=" (\<lambda>s'. \<forall>prp. replyPrev reply' = Some prp
+                                                                         \<longrightarrow> replyNexts_of s' prev_rp = Some rp)"
+                                               in updateReply_sr_inv)
+                                         apply (clarsimp simp: reply_relation_def projectKOs obj_at'_def obj_at_def)
+                                        apply clarsimp
+                                        apply (drule_tac rp=prev_rp in sc_replies_relation_replyNext_update, simp)
+                                        apply simp
+                                       apply simp
+                                      apply clarsimp
+                                     apply wpsimp
+                                    apply wpsimp
+                                    apply (clarsimp dest!: reply_ko_at_valid_objs_valid_reply'
+                                                     simp: valid_reply'_def)
+                                   apply simp
+                                  apply simp
+                                 apply (wpsimp wp: sc_replies_update_takeWhile_sc_with_reply
+                                                   sc_replies_update_takeWhile_middle_sym_refs
+                                                   sc_replies_update_takeWhile_valid_replies')
+                                apply (wpsimp wp: updateReply_valid_objs' updateReply_ko_at'_other)
+                               apply (clarsimp cong: conj_cong)
+                               apply simp
+                              apply (clarsimp simp: valid_reply'_def)
+                              apply (rule context_conjI)
+                               apply (clarsimp simp: obj_at'_def projectKOs opt_map_left_Some)
+                              apply (clarsimp simp: obj_at_def del: opt_mapE)
+                              apply (frule (1) valid_sched_context_objsI)
+                              apply (clarsimp simp: valid_sched_context_def del: opt_mapE)
+                              apply (frule (4) next_reply_in_sc_replies[OF state_relation_sc_replies_relation])
+                                apply (fastforce dest!: state_relationD pspace_aligned_cross pspace_distinct_cross)
+                               apply (fastforce dest!: state_relationD pspace_distinct_cross)
+                              apply (clarsimp simp: obj_at'_def)
+                              apply (clarsimp simp: vs_heap_simps)
+                             apply clarsimp
+                             apply (rule conjI)
+                              apply (clarsimp simp: list_all_iff dest!: set_takeWhileD)
+                             apply (clarsimp simp: reply_relation_def)
+                            apply (fastforce elim!: sym_refs_replyNext_replyPrev_sym[THEN iffD2]
+                                              simp: opt_map_left_Some obj_at'_def projectKOs)
+                           apply (wpsimp simp: get_sk_obj_ref_def wp: get_reply_exs_valid)
+                            apply (fastforce dest!: Reply_or_Receive_reply_at[rotated]
+                                              simp: obj_at_def is_reply)
+                           apply simp
+                          apply (wpsimp wp: get_simple_ko_wp)
+                          apply (clarsimp simp: obj_at_def reply_sc_reply_at_def)
+                         apply (wpsimp simp: get_sk_obj_ref_def get_simple_ko_def obj_at_def
+                                         wp: get_object_wp)
+                         apply (fastforce simp: obj_at_def is_reply partial_inv_def a_type_def)
+                        apply (wpsimp wp: get_sched_context_exs_valid)
+                         apply (drule sc_with_reply_SomeD)
+                         apply clarsimp+
+                       apply (wpsimp simp: obj_at_def)
+                      apply (wpsimp wp: get_sched_context_no_fail)
+                      apply (fastforce elim!: valid_sched_context_size_objsI simp: obj_at_def is_sc_obj_def)
+                     apply (wpsimp simp: pred_tcb_at_def obj_at_def)
+                    apply (wpsimp wp: gbsc_bound_tcb simp: obj_at_def)
+                    apply (clarsimp simp: obj_at_def reply_sc_reply_at_def is_reply)
+                    apply (case_tac "sc_replies sc"; simp)
+                    apply (intro conjI impI)
+                     apply (fastforce dest!: sym_refs_reply_sc_reply_at
+                                       simp: sc_replies_sc_at_def obj_at_def reply_sc_reply_at_def)
+                    apply (fastforce dest!: sc_replies_middle_reply_sc_None
+                                      simp: vs_heap_simps obj_at_def is_sc_obj is_reply reply_sc_reply_at_def
+                                     elim!: valid_sched_context_size_objsI)
+                   apply (wpsimp simp: get_tcb_obj_ref_def thread_get_def st_tcb_def2)
+                  apply (wpsimp wp: get_sched_context_exs_valid)
+                   apply (fastforce dest!: sc_with_reply_SomeD1 simp: sc_replies_sc_at_def obj_at_def)
+                  apply simp
+                 apply wpsimp
+                 apply (fastforce dest!: sc_with_reply_SomeD1 simp: sc_replies_sc_at_def obj_at_def)
+                apply (wpsimp wp: get_sched_context_no_fail)
+                apply (fastforce dest!: sc_with_reply_SomeD1 simp: sc_replies_sc_at_def is_sc_obj obj_at_def
+                                 elim!: obj_at_weakenE valid_sched_context_size_objsI)
+               apply wpsimp
+              apply wpsimp
+             apply wpsimp
+            apply simp
+           apply (fastforce dest!: st_tcb_at_valid_st2 simp: valid_tcb_state_def)
+          apply clarsimp
+          apply (wpsimp simp: op_equal)
+         apply wpsimp
+        apply wpsimp
+       apply (fastforce dest: valid_objs_valid_tcbs st_tcb_reply_state_refs
+                         simp: obj_at_def is_reply reply_tcb_reply_at_def)
+      apply clarsimp
+     apply (wpsimp wp: get_simple_ko_ko_at)
+    apply wpsimp
+   apply clarsimp
+   apply (fastforce dest!: st_tcb_at_valid_st2 simp: valid_tcb_state_def)
+  apply (fastforce dest: tcb_in_valid_state' simp: valid_tcb_state'_def)
+  done
+
 lemma cancel_ipc_corres:
   "corres dc (invs and valid_ready_qs and tcb_at t) invs'
       (cancel_ipc t) (cancelIPC t)"

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -6074,7 +6074,7 @@ lemma doReplyTransfer_corres:
       apply (case_tac ts; simp add: isReply_def)
       apply (rule stronger_corres_guard_imp)
         apply (rule corres_assert_assume_l)
-        apply (rule corres_split [OF replyRemove_corres])
+        apply (rule corres_split [OF replyRemove_corres], (rule refl)+)
           apply (rule corres_split [OF threadget_fault_corres])
             apply (rule corres_split)
                apply (rule_tac P="tcb_at sender and tcb_at recvr and valid_objs and pspace_aligned and
@@ -6325,7 +6325,9 @@ lemma doReplyTransfer_corres:
                in hoare_strengthen_post[rotated])
          apply (clarsimp simp: obj_at'_def invs'_def valid_pspace'_def)
         apply (wpsimp simp: valid_pspace'_def wp: replyRemove_invs')
-       apply (clarsimp simp: invs_def valid_state_def valid_pspace_def valid_sched_def cong: conj_cong)
+       apply (clarsimp simp: invs_def valid_state_def valid_pspace_def valid_sched_def
+                             valid_sched_action_weak_valid_sched_action
+                       cong: conj_cong)
        apply (rename_tac recvr ts_reply s s')
        apply (subgoal_tac "ts_reply = reply", simp)
         apply (rule conjI, fastforce)

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -3590,6 +3590,23 @@ lemma st_tcb_at_runnable_cross:
   apply (drule (3) st_tcb_at_coerce_concrete)
   by (clarsimp simp: pred_tcb_at'_def obj_at'_def sts_rel_runnable)
 
+lemma bound_sc_tcb_at_cross:
+  assumes t: "bound_sc_tcb_at P t s"
+  assumes sr: "(s, s') \<in> state_relation" "pspace_aligned s" "pspace_distinct s"
+  shows "tcb_at' t s' \<and> P (tcbSCs_of s' t)"
+  using assms
+  apply (clarsimp simp: state_relation_def pred_tcb_at_def obj_at_def projectKOs)
+  apply (frule (1) pspace_distinct_cross, fastforce simp: state_relation_def)
+  apply (frule pspace_aligned_cross, fastforce simp: state_relation_def)
+  apply (prop_tac "tcb_at t s", clarsimp simp: obj_at_def is_tcb)
+  apply (drule (2) tcb_at_cross[rotated], fastforce simp: state_relation_def)
+  apply (clarsimp simp: state_relation_def pred_tcb_at'_def obj_at'_def projectKOs opt_map_red)
+  apply (erule (1) pspace_dom_relatedE)
+  apply (erule (1) obj_relation_cutsE, simp_all)
+   apply (clarsimp simp: st_tcb_at'_def obj_at'_def other_obj_relation_def tcb_relation_def
+                  split: Structures_A.kernel_object.split_asm if_split_asm)+
+  done
+
 lemma cur_tcb_cross:
   "\<lbrakk> cur_tcb s; pspace_aligned s; pspace_distinct s; (s,s') \<in> state_relation \<rbrakk> \<Longrightarrow> cur_tcb' s'"
   apply (clarsimp simp: cur_tcb'_def cur_tcb_def state_relation_def)

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -927,6 +927,35 @@ lemma ghost_relation_typ_at:
 
 (* more replyNext/replyPrev related lemmas *)
 
+lemma sc_replies_relation_replyNext_None:
+  "\<lbrakk>sc_replies_relation s s'; reply_at rp s; replies_of' s' rp \<noteq> None;
+    \<forall>p'. replyPrevs_of s' p' \<noteq> Some rp; \<forall>p'. scReplies_of s' p' \<noteq> Some rp\<rbrakk>
+     \<Longrightarrow> sc_replies_relation s (s'\<lparr>ksPSpace := (ksPSpace s')(rp \<mapsto> KOReply r)\<rparr>)"
+  apply (clarsimp simp: sc_replies_relation_def)
+  apply (rename_tac scp replies)
+  apply (drule_tac x=scp and y=replies in spec2)
+  apply simp
+  apply (clarsimp simp: projectKO_opts_defs obj_at'_def opt_map_red obj_at_def is_reply vs_all_heap_simps)
+  apply (rename_tac ko scp sc reply n)
+  apply (case_tac ko; clarsimp)
+  apply (intro conjI; clarsimp)
+  apply (rename_tac sc reply n)
+  apply (rule heap_path_heap_upd_not_in, simp)
+  apply clarsimp
+  apply (frule split_list)
+  apply (elim exE)
+  apply (simp only:)
+  apply (case_tac ys; simp only:)
+   apply (clarsimp simp: opt_map_red)
+  apply (prop_tac "\<exists>ls x. a # list = ls @ [x]")
+   using append_butlast_last_id apply fastforce
+  apply (elim exE conjE, simp only:)
+  apply (prop_tac "(ls @ [x]) @ rp # zs = ls @ x # rp # zs", simp)
+  apply (simp only:)
+  apply (frule_tac z=x in heap_path_non_nil_lookup_next)
+  apply (clarsimp simp: opt_map_red)
+  done
+
 lemma sc_replies_relation_scReplies_of:
   "\<lbrakk>sc_replies_relation s s'; sc_at sc_ptr s; bound (scs_of' s' sc_ptr)\<rbrakk>
    \<Longrightarrow> (sc_replies_of s |> hd_opt) sc_ptr = scReplies_of s' sc_ptr"


### PR DESCRIPTION
This proves `replyRemove_corres` and `replyPop_corres`.

These proofs are rather verbose. Both of them have a similar structure as that of `replyRemoveTCB_corres`, but, while it is probably not impossible to abstract the similarity and make use of it one way or another, it is quite fiddly to make everything work in details and I concluded that it is not a worthwhile investment at this point. Replacing the sorried version with the proved lemma with new preconditions went pretty smoothly.