### PR TITLE
prove `invokeSchedContext_corres`

### DIFF
--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -16760,7 +16760,7 @@ lemma handle_invocation_cur_sc_chargeable:
      apply (rule validE_cases_valid, clarsimp)
      apply (subst validE_R_def[symmetric])
      apply wpsimp+
-  apply (clarsimp simp: ct_in_state_def pred_tcb_at_def obj_at_def)
+  apply (clarsimp simp: ct_in_state_def pred_tcb_at_def obj_at_def is_tcb invs_valid_objs)
   done
 
 crunches check_domain_time
@@ -18929,11 +18929,7 @@ lemma handle_invocation_scheduler_act_sane[wp]:
      apply (rule validE_cases_valid, clarsimp)
      apply (subst validE_R_def[symmetric])
      apply wpsimp+
-  apply (intro conjI)
-     apply (erule schact_is_rct_sane)
-    apply (erule schact_is_rct_simple)
-   apply (simp add: pred_tcb_at_def obj_at_def ct_in_state_def)
-  apply (erule invs_valid_objs)
+  apply (fastforce simp: ct_in_state_def)
   done
 
 lemma postpone_not_in_release_q_other:
@@ -20380,7 +20376,7 @@ lemma handle_invocation_ct_not_blocked[wp]:
                   ex_cte_cap_wp_to (\<lambda>_. True) (snd r) s \<and>
                   real_cte_at (snd r) s \<and>
                   (\<forall>r\<in>zobj_refs (fst r). ex_nonz_cap_to r s) \<and> invs s" in hoare_post_imp_R[rotated])
-      apply (clarsimp simp: ct_in_state_def cong: conj_cong)
+      apply (clarsimp simp: ct_in_state_def invs_valid_objs cong: conj_cong)
       apply wpsimp+
   done
 

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -15639,9 +15639,6 @@ lemma sched_context_yield_to_valid_sched:
   unfolding sched_context_yield_to_def assert_opt_def
   apply (rule hoare_seq_ext[OF _ gscyf_sp])
   apply (rule hoare_seq_ext[OF _ sched_context_yield_to_valid_sched_helper], simp)
-  apply (rule hoare_seq_ext[OF _ gsct_sp])
-  apply (case_tac sc_tcb_opt; clarsimp)
-  apply (rename_tac tcb_ptr)
 
   apply (rule hoare_seq_ext_skip)
    apply ((wpsimp wp: sched_context_resume_schedulable_imp_ready
@@ -15651,6 +15648,10 @@ lemma sched_context_yield_to_valid_sched:
            | wps)+)[1]
    apply (frule invs_sym_refs)
    apply (clarsimp simp: sc_at_pred_n_def obj_at_def)
+
+  apply (rule hoare_seq_ext[OF _ gsct_sp])
+  apply (case_tac sc_tcb_opt; clarsimp)
+  apply (rename_tac tcb_ptr)
 
   apply (rule hoare_seq_ext[OF _ is_schedulable_sp'])
   apply (clarsimp simp: is_schedulable_bool_def2)
@@ -18441,8 +18442,6 @@ lemma sched_context_yield_to_scheduler_act_sane[wp]:
                 simp: set_consumed_def)
    apply (wpsimp wp: set_object_wp update_sched_context_wp
                simp: set_tcb_obj_ref_def)
-  apply (rule hoare_seq_ext[OF _ gsct_sp], rename_tac sc_tcb_opt)
-  apply (case_tac sc_tcb_opt; clarsimp?)
   apply (rule hoare_seq_ext_skip)
    apply ((wpsimp wp:sched_context_resume_sc_tcb_sc_at | wps)+)[1]
   by (wpsimp wp: set_scheduler_action_wp hoare_vcg_all_lift hoare_drop_imps
@@ -22702,13 +22701,11 @@ lemma sched_context_yield_to_cur_sc_in_release_q_imp_zero_consumed[wp]:
    apply (wpsimp simp: get_sc_obj_ref_def complete_yield_to_def set_tcb_obj_ref_def
                    wp: update_sched_context_wp set_object_wp hoare_drop_imps)
   apply clarsimp
-  apply (rule hoare_seq_ext_skip, wpsimp)
-  apply (rule hoare_seq_ext_skip, wpsimp)
   apply (rule_tac B="\<lambda>_ s. cur_sc_in_release_q_imp_zero_consumed s" in hoare_seq_ext[rotated])
    apply (wpsimp wp: sched_context_resume_cur_sc_in_release_q_imp_zero_consumed)
    apply (clarsimp simp: heap_refs_inv_def cur_sc_more_than_ready_def)
    using strengthen_cur_sc_offset_ready strengthen_cur_sc_offset_sufficient apply blast
-  apply (rule hoare_seq_ext_skip, wpsimp)
+  apply (rule hoare_seq_ext_skip, wpsimp)+
   apply (rule hoare_if; (solves \<open>wpsimp\<close>)?)
   done
 

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -15648,6 +15648,7 @@ lemma sched_context_yield_to_valid_sched:
            | wps)+)[1]
    apply (frule invs_sym_refs)
    apply (clarsimp simp: sc_at_pred_n_def obj_at_def)
+   apply (rule_tac B="\<lambda>_. valid_sched" in hoare_seq_ext[rotated]; (solves \<open>wpsimp\<close>)?)
 
   apply (rule hoare_seq_ext[OF _ gsct_sp])
   apply (case_tac sc_tcb_opt; clarsimp)
@@ -18444,6 +18445,7 @@ lemma sched_context_yield_to_scheduler_act_sane[wp]:
                simp: set_tcb_obj_ref_def)
   apply (rule hoare_seq_ext_skip)
    apply ((wpsimp wp:sched_context_resume_sc_tcb_sc_at | wps)+)[1]
+  apply (rule_tac B="\<lambda>_. scheduler_act_sane" in hoare_seq_ext[rotated]; (solves \<open>wpsimp\<close>)?)
   by (wpsimp wp: set_scheduler_action_wp hoare_vcg_all_lift hoare_drop_imps
            simp: sc_at_pred_n_def obj_at_def scheduler_act_not_def
           split: if_splits
@@ -22704,9 +22706,11 @@ lemma sched_context_yield_to_cur_sc_in_release_q_imp_zero_consumed[wp]:
   apply (rule_tac B="\<lambda>_ s. cur_sc_in_release_q_imp_zero_consumed s" in hoare_seq_ext[rotated])
    apply (wpsimp wp: sched_context_resume_cur_sc_in_release_q_imp_zero_consumed)
    apply (clarsimp simp: heap_refs_inv_def cur_sc_more_than_ready_def)
-   using strengthen_cur_sc_offset_ready strengthen_cur_sc_offset_sufficient apply blast
-  apply (rule hoare_seq_ext_skip, wpsimp)+
-  apply (rule hoare_if; (solves \<open>wpsimp\<close>)?)
+  using strengthen_cur_sc_offset_ready strengthen_cur_sc_offset_sufficient apply blast
+  apply (rule hoare_seq_ext_skip)
+   apply (rule hoare_seq_ext_skip, wpsimp)+
+   apply (rule hoare_if; (solves \<open>wpsimp\<close>)?)
+  apply wpsimp
   done
 
 lemma sched_context_unbind_tcb_cur_sc_not_in_release_q[wp]:

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -18410,6 +18410,15 @@ lemma sched_context_bind_ntfn_valid_sched_pred_strong[wp]:
   unfolding sched_context_bind_ntfn_def
   by wpsimp
 
+crunches sched_context_cancel_yield_to
+  for sc_tcb_sc_at[wp]: "sc_tcb_sc_at P scp"
+  (wp: get_tcb_obj_ref_wp)
+
+lemma sched_context_cancel_yield_to_sc_tcb_sc_at_not_ct[wp]:
+  "sched_context_cancel_yield_to sp \<lbrace> \<lambda> s. sc_tcb_sc_at (\<lambda>sctcb. \<exists>t. sctcb = Some t \<and> t \<noteq> cur_thread s) scp s\<rbrace>"
+  apply (simp add: sched_context_cancel_yield_to_def)
+  by (wpsimp wp: hoare_drop_imp)
+
 lemma sched_context_yield_to_scheduler_act_sane[wp]:
   "\<lbrace>scheduler_act_sane
     and (\<lambda>s. sc_tcb_sc_at (\<lambda>sctcb. \<exists>t. sctcb = Some t \<and> t \<noteq> cur_thread s) scptr s)\<rbrace>
@@ -18426,12 +18435,12 @@ lemma sched_context_yield_to_scheduler_act_sane[wp]:
    apply (clarsimp simp: bind_assoc assert_opt_def)
    apply (rule hoare_seq_ext_skip, wpsimp)
    apply (rule hoare_seq_ext_skip, wpsimp)
+   apply (rule hoare_seq_ext_skip, wpsimp)
    apply (rule hoare_seq_ext_skip)
     apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_ex_lift hoare_vcg_imp_lift'
                 simp: set_consumed_def)
    apply (wpsimp wp: set_object_wp update_sched_context_wp
                simp: set_tcb_obj_ref_def)
-   apply (fastforce simp: sc_at_pred_n_def get_tcb_def obj_at_def split: if_splits)
   apply (rule hoare_seq_ext[OF _ gsct_sp], rename_tac sc_tcb_opt)
   apply (case_tac sc_tcb_opt; clarsimp?)
   apply (rule hoare_seq_ext_skip)

--- a/proof/invariant-abstract/Finalise_AI.thy
+++ b/proof/invariant-abstract/Finalise_AI.thy
@@ -1051,19 +1051,19 @@ crunch valid_objs[wp]: set_consumed valid_objs
   (wp: crunch_wps simp: crunch_simps ignore: update_sched_context)
 
 lemma sched_context_cancel_yield_to_valid_objs[wp]:
-  "\<lbrace>valid_objs\<rbrace> sched_context_cancel_yield_to t \<lbrace>\<lambda>rv. valid_objs\<rbrace>"
+  "sched_context_cancel_yield_to t \<lbrace>valid_objs\<rbrace>"
   by (wpsimp simp: sched_context_cancel_yield_to_def | wp (once) hoare_drop_imps)+
 
 lemma complete_yield_to_valid_objs[wp]:
-  "\<lbrace>valid_objs\<rbrace> complete_yield_to t \<lbrace>\<lambda>rv. valid_objs\<rbrace>"
+  "complete_yield_to t \<lbrace>valid_objs\<rbrace>"
   by (wpsimp simp: complete_yield_to_def | wp (once) hoare_drop_imps)+
 
 lemma sched_context_unbind_tcb_valid_objs[wp]:
-  "\<lbrace>valid_objs\<rbrace> sched_context_unbind_tcb t \<lbrace>\<lambda>rv. valid_objs\<rbrace>"
+  "sched_context_unbind_tcb t \<lbrace>valid_objs\<rbrace>"
   by (wpsimp simp: sched_context_unbind_tcb_def | wp (once) hoare_drop_imps)+
 
 lemma unbind_from_sc_valid_objs[wp]:
-  "\<lbrace>valid_objs\<rbrace> unbind_from_sc t \<lbrace>\<lambda>rv. valid_objs\<rbrace>"
+  "unbind_from_sc t \<lbrace>valid_objs\<rbrace>"
   by (wpsimp simp: unbind_from_sc_def wp: maybeM_inv)
 
 lemma unbind_from_sc_invs[wp]:
@@ -1720,38 +1720,38 @@ lemma set_tcb_yt_update_bound_tcb_at[wp]:
   by (wpsimp simp: set_tcb_obj_ref_def pred_tcb_at_def obj_at_def get_tcb_rev wp: set_object_wp)
 
 lemma sched_context_cancel_yield_to_bound_tcb_at[wp]:
-  "\<lbrace>bound_tcb_at P t\<rbrace> sched_context_cancel_yield_to scptr \<lbrace>\<lambda>rv. bound_tcb_at P t\<rbrace>"
+  "sched_context_cancel_yield_to scptr \<lbrace>bound_tcb_at P t\<rbrace>"
   by (wpsimp simp: sched_context_cancel_yield_to_def wp: hoare_drop_imp)
 
 lemma complete_yield_to_bound_tcb_at[wp]:
-  "\<lbrace>bound_tcb_at P t\<rbrace> complete_yield_to scptr \<lbrace>\<lambda>rv. bound_tcb_at P t\<rbrace>"
+  "complete_yield_to scptr \<lbrace>bound_tcb_at P t\<rbrace>"
   by (wpsimp simp: complete_yield_to_def wp: hoare_drop_imp)
 
 lemma sched_context_cancel_yield_to_bound_sc_tcb_at[wp]:
-  "\<lbrace>bound_sc_tcb_at P t\<rbrace> sched_context_cancel_yield_to scptr \<lbrace>\<lambda>rv. bound_sc_tcb_at P t\<rbrace>"
+  "sched_context_cancel_yield_to scptr \<lbrace>bound_sc_tcb_at P t\<rbrace>"
   by (wpsimp simp: sched_context_cancel_yield_to_def wp: hoare_drop_imp)
 
 lemma complete_yield_to_bound_sc_tcb_at[wp]:
-  "\<lbrace>bound_sc_tcb_at P t\<rbrace> complete_yield_to scptr \<lbrace>\<lambda>rv. bound_sc_tcb_at P t\<rbrace>"
+  "complete_yield_to scptr \<lbrace>bound_sc_tcb_at P t\<rbrace>"
   by (wpsimp simp: complete_yield_to_def wp: hoare_drop_imp)
 
 lemma ssc_bound_yt_tcb_at[wp]:
-  "\<lbrace>bound_yt_tcb_at P t\<rbrace> set_tcb_obj_ref tcb_sched_context_update tcb ntfn \<lbrace>\<lambda>_. bound_yt_tcb_at P t\<rbrace>"
+  "set_tcb_obj_ref tcb_sched_context_update tcb ntfn \<lbrace>bound_yt_tcb_at P t\<rbrace>"
   apply (simp add: set_tcb_obj_ref_def)
   apply (wp set_object_wp)
   apply (auto simp: pred_tcb_at_def obj_at_def get_tcb_def)
   done
 
 lemma sched_context_unbind_tcb_bound_tcb_at[wp]:
-  "\<lbrace>bound_tcb_at P t\<rbrace> sched_context_unbind_tcb a \<lbrace>\<lambda>y. bound_tcb_at P t\<rbrace>"
+  "sched_context_unbind_tcb a \<lbrace>bound_tcb_at P t\<rbrace>"
   by (wpsimp simp: sched_context_unbind_tcb_def wp: get_sched_context_wp)
 
 lemma sched_context_unbind_tcb_bound_yt_tcb_at[wp]:
-  "\<lbrace>bound_yt_tcb_at P t\<rbrace> sched_context_unbind_tcb a \<lbrace>\<lambda>y. bound_yt_tcb_at P t\<rbrace>"
+  "sched_context_unbind_tcb a \<lbrace>bound_yt_tcb_at P t\<rbrace>"
   by (wpsimp simp: sched_context_unbind_tcb_def wp: get_sched_context_wp)
 
 lemma unbind_from_sc_bound_tcb_at[wp]:
-  "\<lbrace>bound_tcb_at P t\<rbrace> unbind_from_sc x \<lbrace>\<lambda>rv. bound_tcb_at P t\<rbrace>"
+  "unbind_from_sc x \<lbrace>bound_tcb_at P t\<rbrace>"
   by (wpsimp simp: unbind_from_sc_def wp: hoare_drop_imps hoare_vcg_all_lift)
 
 lemma sched_context_unbind_tcb_bound_sc_tcb_at_None:
@@ -1779,7 +1779,7 @@ lemma unbind_from_sc_bound_sc_tcb_at:
 
 lemma sched_context_cancel_yield_to_unbinds:
   "\<lbrace>tcb_at t\<rbrace>
-     sched_context_cancel_yield_to t
+   sched_context_cancel_yield_to t
    \<lbrace>\<lambda>rv. bound_yt_tcb_at ((=) None) t\<rbrace>"
   apply (clarsimp simp: sched_context_cancel_yield_to_def)
   apply (wpsimp wp: syt_bound_tcb_at' maybeM_wp gbn_wp)
@@ -1788,7 +1788,7 @@ lemma sched_context_cancel_yield_to_unbinds:
 
 lemma complete_yield_to_unbinds:
   "\<lbrace>tcb_at t\<rbrace>
-     complete_yield_to t
+   complete_yield_to t
    \<lbrace>\<lambda>rv. bound_yt_tcb_at ((=) None) t\<rbrace>"
   unfolding complete_yield_to_def
   apply (wpsimp wp: sched_context_cancel_yield_to_unbinds gbn_wp set_consumed_obj_at_trivial)
@@ -1818,7 +1818,7 @@ lemma set_sc_obj_ref_not_live:
   "\<lbrace>obj_at (\<lambda>ko. \<exists>sc n. ko = SchedContext sc n \<and> sc_tcb sc = None
                         \<and> sc_ntfn sc = None \<and> sc_replies sc = []) sc
     and K (t = sc)\<rbrace>
-     set_sc_obj_ref sc_yield_from_update t None
+   set_sc_obj_ref sc_yield_from_update t None
    \<lbrace>\<lambda>_. obj_at (Not \<circ> live) sc\<rbrace>"
   by (wpsimp simp: update_sched_context_def set_object_def
                    get_sched_context_def obj_at_def live_def live_sc_def
@@ -1828,7 +1828,7 @@ lemma sched_context_cancel_yield_to_not_live:
   "\<lbrace>obj_at (\<lambda>ko. \<exists>sc n. ko = SchedContext sc n \<and> sc_yield_from sc = Some tcb
                         \<and> sc_tcb sc = None \<and> sc_ntfn sc = None \<and> sc_replies sc = []) sc
     and valid_objs and (\<lambda>s. sym_refs (state_refs_of s))\<rbrace>
-     sched_context_cancel_yield_to tcb
+   sched_context_cancel_yield_to tcb
    \<lbrace>\<lambda>yc a. obj_at (Not \<circ> live) sc a\<rbrace>"
   apply (clarsimp simp: sched_context_cancel_yield_to_def get_tcb_obj_ref_def)
   apply (wpsimp wp: thread_get_wp' set_sc_obj_ref_not_live

--- a/proof/invariant-abstract/InvariantsPre_AI.thy
+++ b/proof/invariant-abstract/InvariantsPre_AI.thy
@@ -302,6 +302,9 @@ lemma delta_sym_refs_insert_only:
 abbreviation (input)
   "bound a \<equiv> \<exists>y. a = Some y"
 
+lemma neq_None_bound: "((\<noteq>) None) = bound"
+  using option.exhaust_sel by auto
+
 lemma inj_ObjRef[simp]: "inj ObjRef" by (auto intro!: injI)
 lemma inj_IRQRef[simp]: "inj IRQRef" by (auto intro!: injI)
 lemma inj_ArchRef[simp]: "inj ArchRef" by (auto intro!: injI)

--- a/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
@@ -527,11 +527,6 @@ lemma arch_thread_sym_refs[wp]:
   apply (simp add: arch_thread_set_def set_object_def get_object_def)
   apply wp
   apply (clarsimp simp del: fun_upd_apply dest!: get_tcb_SomeD)
-  apply (subst arch_tcb_update_aux3)
-  apply (subst sym_refs_update_some_tcb[where f="tcb_arch_update f"])
-    apply assumption
-   apply (clarsimp simp: refs_of_def)
-  apply assumption
   done
 
 lemma as_user_unlive_hyp[wp]:

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -484,8 +484,8 @@ lemma sched_context_yield_to_invs:
            split_del: if_split
                   wp: valid_irq_node_typ hoare_vcg_if_lift2 thread_get_inv hoare_drop_imp
                       valid_ioports_lift update_sched_context_valid_idle)
-  apply (intro conjI)
-     apply (clarsimp simp: cur_tcb_def)
+  apply (clarsimp cong: conj_cong)
+  apply (intro conjI; clarsimp simp: cur_tcb_def)
     apply (clarsimp simp: sc_at_pred_n_def obj_at_def is_sc_obj_def)
     apply (fastforce dest!: valid_objs_valid_sched_context_size)
    apply (erule delta_sym_refs)
@@ -497,7 +497,8 @@ lemma sched_context_yield_to_invs:
                    split: option.splits)
    apply (clarsimp simp: sc_at_pred_n_def obj_at_def state_refs_of_def refs_of_def get_refs_def
                   split: option.splits)
-  apply (clarsimp simp: sc_at_pred_n_def obj_at_def valid_idle_def pred_tcb_at_def)
+  apply (clarsimp simp: sc_at_pred_n_def obj_at_def in_state_refs_of_iff pred_tcb_at_def
+                        refs_of_simps get_refs_def2)
   apply (clarsimp dest!: idle_sc_no_ex_cap)
   done
 

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -507,7 +507,7 @@ primrec
   valid_sched_context_inv :: "sched_context_invocation \<Rightarrow> 'z::state_ext state \<Rightarrow> bool"
 where
     "valid_sched_context_inv (InvokeSchedContextConsumed scptr args)
-     = (sc_at scptr and ex_nonz_cap_to scptr)"
+     = (sc_at scptr and ex_nonz_cap_to scptr and case_option \<top> in_user_frame args)"
   | "valid_sched_context_inv (InvokeSchedContextBind scptr cap)
      = (ex_nonz_cap_to scptr and valid_cap cap and
           (case cap of ThreadCap t \<Rightarrow>
@@ -531,6 +531,7 @@ where
   | "valid_sched_context_inv (InvokeSchedContextYieldTo scptr args)
      = (\<lambda>s. ex_nonz_cap_to scptr s
             \<and> bound_yt_tcb_at ((=) None) (cur_thread s) s
+            \<and> case_option \<top> in_user_frame args s
             \<and> sc_tcb_sc_at (\<lambda>sctcb. \<exists>t. sctcb = Some t \<and> t \<noteq> cur_thread s) scptr s)"
 
 definition
@@ -1644,6 +1645,7 @@ lemma decode_sched_control_inv_inv:
 
 lemma decode_sched_context_inv_wf:
   "\<lbrace>invs and sc_at sc_ptr and ex_nonz_cap_to sc_ptr and
+     case_option \<top> in_user_frame args and
      (\<lambda>s. \<forall>x\<in>set excaps. s \<turnstile> x) and
      (\<lambda>s. \<forall>x\<in>set excaps. \<forall>r\<in>zobj_refs x. ex_nonz_cap_to r s)\<rbrace>
      decode_sched_context_invocation label sc_ptr excaps args

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -645,13 +645,11 @@ lemma sts_valid_sched_context_inv[wp]:
   "\<lbrace>valid_sched_context_inv i and K (\<not> ipc_queued_thread_state st)\<rbrace>
    set_thread_state t st
    \<lbrace>\<lambda>rv. valid_sched_context_inv i\<rbrace>"
-  by (cases i
-      ; wpsimp split: cap.splits
-      ; intro conjI
-      ; (wpsimp wp: sts_obj_at_impossible set_thread_state_bound_sc_tcb_at hoare_vcg_imp_lift
-                    sts_st_tcb_at_cases_strong
-              simp: pred_conj_def
-         | wps)+)
+  apply (cases i; wpsimp split: cap.splits; (intro conjI)?)
+  by (wpsimp wp: sts_obj_at_impossible set_thread_state_bound_sc_tcb_at hoare_vcg_imp_lift
+                    sts_st_tcb_at_cases_strong hoare_case_option_wp
+           simp: pred_conj_def
+    | wps)+
 
 lemma sts_valid_cnode_inv[wp]:
   "\<lbrace>valid_cnode_inv i\<rbrace> set_thread_state t st \<lbrace>\<lambda>rv. valid_cnode_inv i\<rbrace>"
@@ -718,6 +716,7 @@ lemma decode_inv_wf[wp]:
   "\<lbrace>valid_cap cap and invs and cte_wp_at ((=) cap) slot
            and real_cte_at slot
            and ex_cte_cap_to slot
+           and case_option \<top> in_user_frame buffer
            and (\<lambda>s::'state_ext state. \<forall>r\<in>zobj_refs cap. ex_nonz_cap_to r s)
            and (\<lambda>s. \<forall>cap \<in> set excaps. \<forall>r\<in>cte_refs (fst cap) (interrupt_irq_node s). ex_cte_cap_to r s)
            and (\<lambda>s. \<forall>x \<in> set excaps. s \<turnstile> (fst x))

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -4210,12 +4210,9 @@ lemma schedContextZeroRefillMax_invs'[wp]:
   done
 
 lemma schedContextUnbindYieldFrom_invs'[wp]:
-  "\<lbrace>invs' and sch_act_simple\<rbrace>
-   schedContextUnbindYieldFrom scPtr
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  "schedContextUnbindYieldFrom scPtr \<lbrace>invs'\<rbrace>"
   apply (clarsimp simp: schedContextUnbindYieldFrom_def)
   apply wpsimp
-  apply (fastforce dest: invs'_ko_at_valid_sched_context' simp: valid_sched_context'_def)
   done
 
 lemma schedContextUnbindReply_invs'[wp]:

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -4692,7 +4692,7 @@ global_interpretation delete_one
   done
 
 lemma schedContextUnbindTCB_corres:
-  "corres dc (einvs and sc_tcb_sc_at bound sc_ptr)
+  "corres dc (invs and valid_sched and sc_tcb_sc_at bound sc_ptr)
              (invs' and obj_at' (\<lambda>sc. bound (scTCB sc)) sc_ptr)
           (sched_context_unbind_tcb sc_ptr) (schedContextUnbindTCB sc_ptr)"
   apply (clarsimp simp: sched_context_unbind_tcb_def schedContextUnbindTCB_def

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -4751,7 +4751,7 @@ lemma unbindFromSC_corres:
            apply (rule corres_when2; clarsimp simp: sc_relation_def)
            apply (case_tac rv, case_tac rv', simp)
            apply (wpfix add: Structures_A.sched_context.select_convs sched_context.sel)
-           apply (rule complete_yield_to_corres)
+           apply (rule schedContextCompleteYieldTo_corres)
           apply (wpsimp wp: abs_typ_at_lifts)+
         apply (rule_tac Q="\<lambda>_. invs" in hoare_post_imp)
          apply (auto simp: valid_obj_def valid_sched_context_def
@@ -4876,7 +4876,7 @@ lemma schedContextUnbindYieldFrom_corres:
        apply (wpfix add: sched_context.sel)
        apply (rule corres_when)
         apply (clarsimp simp: sc_relation_def)
-       apply (rule complete_yield_to_corres)
+       apply (rule schedContextCompleteYieldTo_corres)
       apply wpsimp+
     apply (fastforce dest!: invs_valid_objs valid_objs_ko_at
                       simp: valid_obj_def valid_sched_context_def)

--- a/proof/refine/ARM/InvariantUpdates_H.thy
+++ b/proof/refine/ARM/InvariantUpdates_H.thy
@@ -482,4 +482,14 @@ lemma valid_sched_context_size'_scReply_update[simp]:
   "valid_sched_context_size' (scReply_update f sc) = valid_sched_context_size' sc"
   by (clarsimp simp: valid_sched_context_size'_def objBits_simps)
 
+lemma valid_tcb_yield_to_update[elim!]:
+  "valid_tcb tp tcb s \<Longrightarrow> sc_at scp s \<Longrightarrow> valid_tcb tp (tcb_yield_to_update (\<lambda>_. Some scp) tcb) s"
+  by (auto simp: valid_tcb_def tcb_cap_cases_def)
+
+lemma valid_ipc_buffer_ptr'_ks_updates[simp]:
+  "valid_ipc_buffer_ptr' buf (ksSchedulerAction_update f s) = valid_ipc_buffer_ptr' buf s"
+  "valid_ipc_buffer_ptr' buf (ksReprogramTimer_update g s) = valid_ipc_buffer_ptr' buf s"
+  "valid_ipc_buffer_ptr' buf (ksReleaseQueue_update h s) = valid_ipc_buffer_ptr' buf s"
+  by (simp add: valid_ipc_buffer_ptr'_def)+
+
 end

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -2452,7 +2452,7 @@ lemma (in delete_one) suspend_corres:
              apply (rule corres_split_deprecated[OF _ setThreadState_corres])
                 apply (rule corres_split_deprecated[OF _ tcbSchedDequeue_corres'])
                   apply (rule corres_split_deprecated[OF _ tcb_release_remove_corres])
-                    apply (rule sched_context_cancel_yield_to_corres)
+                    apply (rule schedContextCancelYieldTo_corres)
                    apply wpsimp+
             apply (case_tac state; clarsimp?)
            apply (clarsimp simp: update_restart_pc_def updateRestartPC_def)

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -2429,44 +2429,6 @@ lemma asUser_valid_inQ_queues[wp]:
   apply wp
   done
 
-lemma sc_relation_tcb_yield_to_update:
-  "sc_relation sc n sc'
-   \<Longrightarrow> sc_relation (sc_yield_from_update Map.empty (sc)) n (scYieldFrom_update Map.empty sc')"
-  by (clarsimp simp: sc_relation_def)
-
-lemma sched_context_cancel_yield_to_corres:
-  "corres dc
-          (pspace_aligned and pspace_distinct and valid_objs and tcb_at t)
-          \<top>
-          (sched_context_cancel_yield_to t)
-          (schedContextCancelYieldTo t)" (is "corres _ ?abs_guard _ _ _")
-  apply (rule_tac Q="tcb_at' t" in corres_cross_add_guard)
-   apply (fastforce dest!: state_relationD elim!: tcb_at_cross)
-  apply (clarsimp simp: sched_context_cancel_yield_to_def schedContextCancelYieldTo_def maybeM_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ get_tcb_yield_to_corres gyt_sp threadGet_sp
-                             , where Q="?abs_guard"])
-    defer
-    apply (simp add: obj_at_def is_tcb_def)
-   apply simp
-  apply (case_tac scPtrOpt; clarsimp?)
-  apply (rule corres_guard_imp)
-    apply (subst bind_assoc[symmetric])
-    apply (rule corres_split_deprecated[OF _ update_sc_no_reply_stack_update_corres])
-         apply (rule tcb_yield_to_update_corres)
-         apply (simp add: sc_relation_tcb_yield_to_update)
-        apply simp
-       apply (clarsimp simp: objBits_simps')
-      apply simp
-     apply wpsimp
-    apply wpsimp
-   apply (clarsimp simp: valid_objs_def obj_at_def is_tcb_def)
-   apply (fastforce simp: valid_obj_def valid_tcb_def valid_bound_obj_def pred_tcb_at_def obj_at_def
-                   dest!: bspec
-                   split: option.splits)
-  apply clarsimp
-  done
-
 crunches ThreadDecls_H.suspend
   (* FIXME RT: VER-1016 *)
   for tcb_at'_better[wp]: "\<lambda>s. P (tcb_at' t s)"

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -3607,6 +3607,39 @@ lemma bound_sc_tcb_at_cross:
                   split: Structures_A.kernel_object.split_asm if_split_asm)+
   done
 
+lemma bound_yt_tcb_at_cross:
+  assumes t: "bound_yt_tcb_at P t s"
+  assumes sr: "(s, s') \<in> state_relation" "pspace_aligned s" "pspace_distinct s"
+  shows "obj_at' (\<lambda>tcb'. \<exists>tcb. tcb_relation tcb tcb' \<and> P (tcb_yield_to tcb)) t s'"
+  using assms
+  apply (clarsimp simp: state_relation_def pred_tcb_at_def obj_at_def projectKOs)
+  apply (frule (1) pspace_distinct_cross, fastforce simp: state_relation_def)
+  apply (frule pspace_aligned_cross, fastforce simp: state_relation_def)
+  apply (prop_tac "tcb_at t s", clarsimp simp: st_tcb_at_def obj_at_def is_tcb)
+  apply (drule (2) tcb_at_cross[rotated], fastforce simp: state_relation_def)
+  apply (clarsimp simp: state_relation_def pred_tcb_at'_def obj_at'_def projectKOs)
+  apply (erule (1) pspace_dom_relatedE)
+  apply (erule (1) obj_relation_cutsE, simp_all)
+   apply (clarsimp simp: st_tcb_at'_def obj_at'_def other_obj_relation_def tcb_relation_def
+                  split: Structures_A.kernel_object.split_asm if_split_asm)+
+  apply fastforce
+  done
+
+lemma sc_tcb_sc_at_bound_cross:
+  "\<lbrakk>pspace_relation (kheap s) (ksPSpace s'); valid_objs s; pspace_aligned s; pspace_distinct s;
+    sc_tcb_sc_at ((\<noteq>) None) scp s\<rbrakk>
+  \<Longrightarrow> obj_at' (\<lambda>sc. \<exists>y. scTCB sc = Some y) scp s'"
+  apply (clarsimp simp: obj_at_def sc_tcb_sc_at_def)
+  apply (frule (1) pspace_relation_absD)
+  apply clarsimp
+  apply (prop_tac "valid_sched_context_size n")
+   apply (erule (1) valid_sched_context_size_objsI)
+  apply (clarsimp simp: if_split_asm)
+  apply (rename_tac z; case_tac z; simp)
+  apply (drule (3) aligned_distinct_ko_at'I[where 'a=sched_context], simp)
+  apply (clarsimp simp: obj_at'_def sc_relation_def projectKOs)
+  by (metis not_None_eq)
+
 lemma cur_tcb_cross:
   "\<lbrakk> cur_tcb s; pspace_aligned s; pspace_distinct s; (s,s') \<in> state_relation \<rbrakk> \<Longrightarrow> cur_tcb' s'"
   apply (clarsimp simp: cur_tcb'_def cur_tcb_def state_relation_def)

--- a/proof/refine/ARM/SchedContext_R.thy
+++ b/proof/refine/ARM/SchedContext_R.thy
@@ -441,9 +441,7 @@ global_interpretation schedContextCancelYieldTo: typ_at_all_props' "schedContext
   by typ_at_props'
 
 lemma schedContextCancelYieldTo_invs':
-  "\<lbrace>invs' and tcb_at' t\<rbrace>
-   schedContextCancelYieldTo t
-   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  "schedContextCancelYieldTo t \<lbrace>invs'\<rbrace>"
   apply (simp add: invs'_def valid_pspace'_def setSchedContext_def valid_dom_schedule'_def)
   apply (wpsimp wp: valid_irq_node_lift valid_irq_handlers_lift'' irqs_masked_lift
                     untyped_ranges_zero_lift
@@ -469,9 +467,7 @@ lemma setConsumed_invs':
   done
 
 lemma schedContextCompleteYieldTo_invs'[wp]:
-  "\<lbrace>invs' and tcb_at' thread\<rbrace>
-   schedContextCompleteYieldTo thread
-   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  "schedContextCompleteYieldTo thread \<lbrace>invs'\<rbrace>"
   unfolding schedContextCompleteYieldTo_def
   by (wpsimp wp: schedContextCancelYieldTo_invs' setConsumed_invs'
                  hoare_drop_imp hoare_vcg_if_lift2

--- a/proof/refine/ARM/SchedContext_R.thy
+++ b/proof/refine/ARM/SchedContext_R.thy
@@ -519,7 +519,7 @@ lemma sc_relation_tcb_yield_to_update:
    \<Longrightarrow> sc_relation (sc_yield_from_update Map.empty (sc)) n (scYieldFrom_update Map.empty sc')"
   by (clarsimp simp: sc_relation_def)
 
-lemma sched_context_cancel_yield_to_corres:
+lemma schedContextCancelYieldTo_corres:
   "corres dc
           (pspace_aligned and pspace_distinct and valid_objs and tcb_at t)
           \<top>
@@ -552,7 +552,7 @@ lemma sched_context_cancel_yield_to_corres:
   apply clarsimp
   done
 
-lemma complete_yield_to_corres:
+lemma schedContextCompleteYieldTo_corres:
   "corres dc (invs and tcb_at thread) (invs' and tcb_at' thread)
     (complete_yield_to thread) (schedContextCompleteYieldTo thread)"
   apply add_cur_tcb'
@@ -564,7 +564,7 @@ lemma complete_yield_to_corres:
       apply (clarsimp, wpfix)
       apply (rule corres_split_deprecated[OF _ lookupIPCBuffer_corres], simp)
         apply (rule corres_split_deprecated[OF _ setConsumed_corres])
-          apply (rule sched_context_cancel_yield_to_corres[simplified dc_def])
+          apply (rule schedContextCancelYieldTo_corres[simplified dc_def])
          apply wpsimp
         apply wpsimp
        apply wpsimp

--- a/proof/refine/ARM/SchedContext_R.thy
+++ b/proof/refine/ARM/SchedContext_R.thy
@@ -514,6 +514,44 @@ lemma tcb_yield_to_update_corres:
    apply simp+
   done
 
+lemma sc_relation_tcb_yield_to_update:
+  "sc_relation sc n sc'
+   \<Longrightarrow> sc_relation (sc_yield_from_update Map.empty (sc)) n (scYieldFrom_update Map.empty sc')"
+  by (clarsimp simp: sc_relation_def)
+
+lemma sched_context_cancel_yield_to_corres:
+  "corres dc
+          (pspace_aligned and pspace_distinct and valid_objs and tcb_at t)
+          \<top>
+          (sched_context_cancel_yield_to t)
+          (schedContextCancelYieldTo t)" (is "corres _ ?abs_guard _ _ _")
+  apply (rule_tac Q="tcb_at' t" in corres_cross_add_guard)
+   apply (fastforce dest!: state_relationD elim!: tcb_at_cross)
+  apply (clarsimp simp: sched_context_cancel_yield_to_def schedContextCancelYieldTo_def maybeM_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split_deprecated[OF _ get_tcb_yield_to_corres gyt_sp threadGet_sp
+                             , where Q="?abs_guard"])
+    defer
+    apply (simp add: obj_at_def is_tcb_def)
+   apply simp
+  apply (case_tac scPtrOpt; clarsimp?)
+  apply (rule corres_guard_imp)
+    apply (subst bind_assoc[symmetric])
+    apply (rule corres_split_deprecated[OF _ update_sc_no_reply_stack_update_corres])
+         apply (rule tcb_yield_to_update_corres)
+         apply (simp add: sc_relation_tcb_yield_to_update)
+        apply simp
+       apply (clarsimp simp: objBits_simps')
+      apply simp
+     apply wpsimp
+    apply wpsimp
+   apply (clarsimp simp: valid_objs_def obj_at_def is_tcb_def)
+   apply (fastforce simp: valid_obj_def valid_tcb_def valid_bound_obj_def pred_tcb_at_def obj_at_def
+                   dest!: bspec
+                   split: option.splits)
+  apply clarsimp
+  done
+
 lemma complete_yield_to_corres:
   "corres dc (invs and tcb_at thread) (invs' and tcb_at' thread)
     (complete_yield_to thread) (schedContextCompleteYieldTo thread)"
@@ -526,22 +564,8 @@ lemma complete_yield_to_corres:
       apply (clarsimp, wpfix)
       apply (rule corres_split_deprecated[OF _ lookupIPCBuffer_corres], simp)
         apply (rule corres_split_deprecated[OF _ setConsumed_corres])
-          apply (clarsimp simp: schedContextCancelYieldTo_def)
-          apply (rule corres_symb_exec_r'[where Q'=\<top>])
-             apply (rule_tac F="scPtrOpt = Some y" in corres_gen_asm2)
-             apply simp
-             apply (subst dc_def[symmetric])
-             apply (subst bind_assoc[symmetric])
-             apply (rule corres_split_deprecated[OF tcb_yield_to_update_corres update_sc_no_reply_stack_update_corres])
-                  apply (clarsimp simp: sc_relation_def objBits_def objBitsKO_def)+
-              apply (wpsimp wp: threadGet_wp)+
-           apply (clarsimp simp: obj_at'_def)
-          apply wpsimp
-         apply (wpsimp wp: sc_at_typ_at)
-        apply (clarsimp cong: conj_cong)
-        apply (rule_tac Q="\<lambda>rv. pred_tcb_at' itcbYieldTo ((=) (Some y)) thread"
-               in hoare_strengthen_post[rotated])
-         apply (clarsimp simp: pred_tcb_at'_def obj_at'_def)
+          apply (rule sched_context_cancel_yield_to_corres[simplified dc_def])
+         apply wpsimp
         apply wpsimp
        apply wpsimp
       apply wpsimp

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -461,7 +461,7 @@ lemma performInvocation_corres:
          apply (rule corres_splitEE)
             prefer 2
             apply (simp)
-            apply (erule invoke_sched_context_corres)
+            apply (erule invokeSchedContext_corres)
            apply (rule corres_trivial, simp add: returnOk_def)
           apply (wpsimp+)[4]
       \<comment> \<open>SchedControl\<close>

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -2259,25 +2259,6 @@ crunches schedContextYieldTo, schedContextCompleteYieldTo
   for tcb_at'[wp]: "tcb_at' tcbPtr"
   (wp: crunch_wps)
 
-(* RT FIXME : Move *)
-lemma neq_None_bound: "((\<noteq>) None) = bound"
-  using cases_simp_option option.simps(3) by metis
-
-(* RT FIXME : Move *)
-lemma sc_tcb_sc_at_bound_cross:
-  "\<lbrakk>pspace_relation (kheap s) (ksPSpace s'); valid_objs s; pspace_aligned s; pspace_distinct s;
-    sc_tcb_sc_at ((\<noteq>) None) scp s\<rbrakk>
-  \<Longrightarrow> obj_at' (\<lambda>sc. \<exists>y. scTCB sc = Some y) scp s'"
-  apply (clarsimp simp: obj_at_def sc_tcb_sc_at_def)
-  apply (frule (1) pspace_relation_absD)
-  apply clarsimp
-  apply (prop_tac "valid_sched_context_size n", fastforce simp: valid_obj_def)
-  apply (clarsimp simp: if_split_asm)
-  apply (rename_tac z; case_tac z; simp)
-  apply (drule (3) aligned_distinct_ko_at'I[where 'a=sched_context], simp)
-  apply (clarsimp simp: obj_at'_def sc_relation_def projectKOs)
-  by (metis not_None_eq)
-
 lemma schedContextUnbindTCB_corres':
   "corres dc (invs and valid_sched and sc_tcb_sc_at ((\<noteq>) None) scp) invs'
              (sched_context_unbind_tcb scp) (schedContextUnbindTCB scp)"

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -56,7 +56,7 @@ lemma activateThread_corres:
       apply (rule corres_split_deprecated [OF _ get_tcb_yield_to_corres])
         apply (rule corres_split_deprecated[OF _ corres_when, rotated])
             apply clarsimp
-           apply (rule complete_yield_to_corres)
+           apply (rule schedContextCompleteYieldTo_corres)
           prefer 3
           apply (rule_tac R="\<lambda>ts s. (activatable ts) \<and> invs s \<and> st_tcb_at ((=) ts) thread s"
                       and R'="\<lambda>ts s. (activatable' ts) \<and> invs' s \<and> st_tcb_at' (\<lambda>ts'. ts' = ts) thread s"

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -112,7 +112,6 @@ lemma activate_invs':
   apply (simp add: activateThread_def)
   apply (wpsimp wp: activateIdle_invs' sts_invs_minor' schedContextCompleteYieldTo_invs'
                     hoare_vcg_imp_lift')
-     apply (wpsimp wp: threadGet_wp gts_wp')+
   by (fastforce simp: pred_tcb_at'_def obj_at'_real_def ko_wp_at'_def sch_act_simple_def)
 
 declare not_psubset_eq[dest!] (* FIXME: remove, not a good dest rule *)

--- a/spec/abstract/SchedContext_A.thy
+++ b/spec/abstract/SchedContext_A.thy
@@ -345,6 +345,17 @@ where
 text \<open>yield\_to related functions\<close>
 
 definition
+  sched_context_cancel_yield_to :: "obj_ref \<Rightarrow> (unit, 'z::state_ext) s_monad"
+where
+  "sched_context_cancel_yield_to thread \<equiv> do
+     yt_opt \<leftarrow> get_tcb_obj_ref tcb_yield_to thread;
+     maybeM (\<lambda>sc_ptr. do
+       set_sc_obj_ref sc_yield_from_update sc_ptr None;
+       set_tcb_obj_ref tcb_yield_to_update thread None
+     od) yt_opt
+   od"
+
+definition
   complete_yield_to :: "obj_ref \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
   "complete_yield_to tcb_ptr \<equiv> do
@@ -352,8 +363,7 @@ where
      maybeM (\<lambda>sc_ptr. do
          buf \<leftarrow> lookup_ipc_buffer True tcb_ptr;
          set_consumed sc_ptr buf;
-         set_sc_obj_ref sc_yield_from_update sc_ptr None;
-         set_tcb_obj_ref tcb_yield_to_update tcb_ptr None
+         sched_context_cancel_yield_to tcb_ptr
        od) yt_opt
     od"
 
@@ -479,17 +489,6 @@ where
   "update_restart_pc thread_ptr =
         as_user thread_ptr (getRegister nextInstructionRegister
                             >>= setRegister faultRegister)"
-
-definition
-  sched_context_cancel_yield_to :: "obj_ref \<Rightarrow> (unit, 'z::state_ext) s_monad"
-where
-  "sched_context_cancel_yield_to thread \<equiv> do
-     yt_opt \<leftarrow> get_tcb_obj_ref tcb_yield_to thread;
-     maybeM (\<lambda>sc_ptr. do
-       set_sc_obj_ref sc_yield_from_update sc_ptr None;
-       set_tcb_obj_ref tcb_yield_to_update thread None
-     od) yt_opt
-   od"
 
 text \<open>Suspend a thread, cancelling any pending operations and preventing it
 from further execution by setting it to the Inactive state.\<close>

--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -284,10 +284,11 @@ where
       assert (sc_yf_opt = None)
     od;
 
+    sched_context_resume sc_ptr;
+
     sc_tcb_opt \<leftarrow> get_sc_obj_ref sc_tcb sc_ptr;
     tcb_ptr \<leftarrow> assert_opt sc_tcb_opt;
 
-    sched_context_resume sc_ptr;
     schedulable <- is_schedulable tcb_ptr;
     if schedulable then do
       sc \<leftarrow> get_sched_context sc_ptr;

--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -292,9 +292,6 @@ where
 
       schedulable <- is_schedulable tcb_ptr;
       if schedulable then do
-        sc \<leftarrow> get_sched_context sc_ptr;
-        curtime \<leftarrow> gets cur_time;
-        assert (sc_refill_ready curtime sc \<and> sc_refill_sufficient 0 sc);
         ct_ptr \<leftarrow> gets cur_thread;
         prios \<leftarrow> thread_get tcb_priority tcb_ptr;
         ct_prios \<leftarrow> thread_get tcb_priority ct_ptr;

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -568,8 +568,8 @@ This module uses the C preprocessor to select a target architecture.
 >     if schedulable
 >         then do
 >             ctPtr <- getCurThread
->             curprio <- threadGet tcbPriority ctPtr
 >             prio <- threadGet tcbPriority tptr
+>             curprio <- threadGet tcbPriority ctPtr
 >             if prio < curprio
 >                 then do
 >                     tcbSchedDequeue tptr

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -609,12 +609,7 @@ This module uses the C preprocessor to select a target architecture.
 >     InvokeSchedContextUnbind scPtr -> do
 >         schedContextUnbindAllTCBs scPtr
 >         schedContextUnbindNtfn scPtr
->         sc <- getSchedContext scPtr
->         let replyPtrOpt = scReply sc
->         when (replyPtrOpt /= Nothing) $ do
->             let replyPtr = fromJust replyPtrOpt
->             updateReply replyPtr (\reply -> reply { replyNext = Nothing })
->             setSchedContext scPtr $ sc { scReply = Nothing }
+>         schedContextUnbindReply scPtr
 >     InvokeSchedContextYieldTo scPtr buffer -> do
 >         schedContextYieldTo scPtr buffer
 


### PR DESCRIPTION
- also includes proofs for `schedContextBindNtfn` and `schedContextYieldTo_corres`
- resolves the issue of IPC buffer preconditions for `setConsumed_corres`