### PR TITLE
Weaken `akernel_invs` precondition

### DIFF
--- a/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
@@ -1602,9 +1602,9 @@ lemma set_thread_state_duplicates_valid[wp]:
 lemma handle_invocation_valid_pdpt[wp]:
   "\<lbrace>\<lambda>s. valid_pdpt_objs s \<and> invs s \<and> ct_active s \<and>
         scheduler_action s = resume_cur_thread \<and>
-        is_schedulable_bool (cur_thread s) s\<rbrace>
-     handle_invocation calling blocking can_donate first_phase cptr
-   \<lbrace>\<lambda>rv. valid_pdpt_objs::det_state \<Rightarrow> _\<rbrace>"
+        ct_schedulable s\<rbrace>
+   handle_invocation calling blocking can_donate first_phase cptr
+   \<lbrace>\<lambda>_. valid_pdpt_objs::det_state \<Rightarrow> _\<rbrace>"
   apply (simp add: handle_invocation_def)
   apply (wp syscall_valid set_thread_state_ct_st sts_schedulable_scheduler_action
          | simp add: split_def cong: conj_cong | wpc
@@ -1648,7 +1648,7 @@ crunches check_domain_time
 lemma call_kernel_valid_pdpt[wp]:
   "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s) and valid_pdpt_objs
      and (\<lambda>s. scheduler_action s = resume_cur_thread)
-     and (\<lambda>s. is_schedulable_bool (cur_thread s) s)\<rbrace>
+     and ct_schedulable\<rbrace>
    call_kernel e
    \<lbrace>\<lambda>_ s :: det_state. valid_pdpt_objs s\<rbrace>"
   apply (cases e, simp_all add: call_kernel_def preemption_path_def)
@@ -1658,13 +1658,13 @@ lemma call_kernel_valid_pdpt[wp]:
          apply (rule_tac B="\<lambda>_. invs and ct_running and
            (\<lambda>s. \<forall>x\<in>ran (kheap s). obj_valid_pdpt x) and
            (\<lambda>s. scheduler_action s = resume_cur_thread) and
-           (\<lambda>s. is_schedulable_bool (cur_thread s) s)" in seqE)
+           ct_schedulable" in seqE)
           apply (rule liftE_wp)
           apply (wpsimp wp: hoare_vcg_ex_lift)
          apply (rule_tac B="\<lambda>rv. invs and (\<lambda>s. rv \<longrightarrow> ct_running s) and
            (\<lambda>s. \<forall>x\<in>ran (kheap s). obj_valid_pdpt x) and
            (\<lambda>s. rv \<longrightarrow> scheduler_action s = resume_cur_thread) and
-           (\<lambda>s. rv \<longrightarrow> (is_schedulable_bool (cur_thread s) s))" in seqE)
+           (\<lambda>s. rv \<longrightarrow> ct_schedulable s)" in seqE)
           apply (rule liftE_wp)
           apply (wpsimp wp: check_budget_restart_true)
          apply (rule valid_validE)
@@ -1680,7 +1680,7 @@ lemma call_kernel_valid_pdpt[wp]:
            (\<lambda>s. \<forall>x\<in>ran (kheap s). obj_valid_pdpt x) and
            (\<lambda>s. bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s)" in hoare_seq_ext[rotated])
         apply wpsimp
-        apply (clarsimp simp: pred_tcb_at_def obj_at_def is_schedulable_bool_def')
+        apply (clarsimp simp: pred_tcb_at_def obj_at_def schedulable_def')
        apply (rule_tac B="\<lambda>rv. invs and (\<lambda>s. rv \<longrightarrow> ct_running s) and
            (\<lambda>s. \<forall>x\<in>ran (kheap s). obj_valid_pdpt x)" in hoare_seq_ext[rotated])
         apply (wpsimp wp: check_budget_restart_true)
@@ -1693,7 +1693,7 @@ lemma call_kernel_valid_pdpt[wp]:
            (\<lambda>s. \<forall>x\<in>ran (kheap s). obj_valid_pdpt x) and
            (\<lambda>s. bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s)" in hoare_seq_ext[rotated])
        apply wpsimp
-       apply (clarsimp simp: pred_tcb_at_def obj_at_def is_schedulable_bool_def')
+       apply (clarsimp simp: pred_tcb_at_def obj_at_def schedulable_def')
       apply (rule_tac B="\<lambda>rv. invs and (\<lambda>s. rv \<longrightarrow> ct_running s) and
            (\<lambda>s. \<forall>x\<in>ran (kheap s). obj_valid_pdpt x)" in hoare_seq_ext[rotated])
        apply (wpsimp wp: check_budget_restart_true)
@@ -1708,7 +1708,7 @@ lemma call_kernel_valid_pdpt[wp]:
            (\<lambda>s. \<forall>x\<in>ran (kheap s). obj_valid_pdpt x) and
            (\<lambda>s. bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s)" in hoare_seq_ext[rotated])
      apply wpsimp
-     apply (clarsimp simp: pred_tcb_at_def obj_at_def is_schedulable_bool_def')
+     apply (clarsimp simp: pred_tcb_at_def obj_at_def schedulable_def')
     apply (rule_tac B="\<lambda>rv. invs and (\<lambda>s. rv \<longrightarrow> ct_running s) and
            (\<lambda>s. \<forall>x\<in>ran (kheap s). obj_valid_pdpt x)" in hoare_seq_ext[rotated])
      apply (wpsimp wp: check_budget_restart_true)

--- a/proof/invariant-abstract/DetSchedAux_AI.thy
+++ b/proof/invariant-abstract/DetSchedAux_AI.thy
@@ -1438,20 +1438,20 @@ lemma valid_blocked_except_cur_thread[simp]:
   using valid_blocked_defs by simp
 
 lemma valid_blocked_except_set_not_schedulable:
-  "\<lbrakk>valid_blocked_except tcbptr s; \<not> is_schedulable_bool tcbptr s\<rbrakk> \<Longrightarrow> valid_blocked s"
-  apply (clarsimp simp: valid_blocked_defs is_schedulable_bool_def2)
+  "\<lbrakk>valid_blocked_except tcbptr s; \<not> schedulable tcbptr s\<rbrakk> \<Longrightarrow> valid_blocked s"
+  apply (clarsimp simp: valid_blocked_defs schedulable_def2)
   apply (case_tac "t = tcbptr"; drule_tac x=t in spec; simp add: tcb_at_kh_simps runnable_eq_active)
   done
 
 lemma shows
-  not_runnable_not_schedulable: "\<not> st_tcb_at runnable t s \<Longrightarrow> \<not> is_schedulable_bool t s" and
-  not_active_sc_not_schedulable: "\<not> active_sc_tcb_at t s \<Longrightarrow> \<not> is_schedulable_bool t s" and
-  in_release_q_not_schedulable: "in_release_q t s \<Longrightarrow> \<not> is_schedulable_bool t s"
-  by (clarsimp simp: is_schedulable_bool_def2)+
+  not_runnable_not_schedulable: "\<not> st_tcb_at runnable t s \<Longrightarrow> \<not> schedulable t s" and
+  not_active_sc_not_schedulable: "\<not> active_sc_tcb_at t s \<Longrightarrow> \<not> schedulable t s" and
+  in_release_q_not_schedulable: "in_release_q t s \<Longrightarrow> \<not> schedulable t s"
+  by (clarsimp simp: schedulable_def2)+
 
 lemma no_bound_sc_not_schedulable:
-  "bound_sc_tcb_at ((=) None) t s \<Longrightarrow> \<not> is_schedulable_bool t s"
-  by (clarsimp simp: is_schedulable_bool_def2 active_sc_tcb_at_def2 pred_tcb_at_def obj_at_def)
+  "bound_sc_tcb_at ((=) None) t s \<Longrightarrow> \<not> schedulable t s"
+  by (clarsimp simp: schedulable_def2 active_sc_tcb_at_def2 pred_tcb_at_def obj_at_def)
 
 lemmas valid_blocked_except_set_in_release_q =
          valid_blocked_except_set_not_schedulable[OF _ in_release_q_not_schedulable]

--- a/proof/invariant-abstract/DetSchedInvs_AI.thy
+++ b/proof/invariant-abstract/DetSchedInvs_AI.thy
@@ -1609,10 +1609,9 @@ lemma is_schedulable_opt_Some:
   by (clarsimp simp: is_schedulable_opt_def vs_all_heap_simps obj_at_kh_kheap_simps
               split: option.splits)
 
-lemma is_schedulable_bool_def2:
-  "is_schedulable_bool t s = (st_tcb_at runnable t s \<and> active_sc_tcb_at t s
-                               \<and> \<not> (in_release_queue t s))"
-  by (clarsimp simp: is_schedulable_bool_def vs_all_heap_simps obj_at_kh_kheap_simps
+lemma schedulable_def2:
+  "schedulable t s = (st_tcb_at runnable t s \<and> active_sc_tcb_at t s \<and> \<not> (in_release_queue t s))"
+  by (clarsimp simp: schedulable_def vs_all_heap_simps obj_at_kh_kheap_simps
               split: option.splits)
 
 \<comment> \<open>Like refill_ready', but using unat addition to avoid the need to reason about overflow.\<close>

--- a/proof/invariant-abstract/KHeap_AI.thy
+++ b/proof/invariant-abstract/KHeap_AI.thy
@@ -2251,12 +2251,12 @@ lemma assert_get_tcb_ko':
 
 (* is_schedulable lemmas *)
 lemma is_schedulable_wp:
-  "\<lbrace>\<lambda>s. \<forall>t. is_schedulable_bool tcb_ptr s = t \<longrightarrow> P t s\<rbrace> is_schedulable tcb_ptr \<lbrace>P\<rbrace>"
+  "\<lbrace>\<lambda>s. \<forall>t. schedulable tcb_ptr s = t \<longrightarrow> P t s\<rbrace> is_schedulable tcb_ptr \<lbrace>P\<rbrace>"
   apply (clarsimp simp: is_schedulable_def)
   apply (rule hoare_seq_ext[OF _ assert_get_tcb_ko'])
   apply (case_tac "tcb_sched_context tcb"; clarsimp)
-   apply (wpsimp simp: is_schedulable_bool_def obj_at_def get_tcb_rev)
-  by (wpsimp simp: is_schedulable_bool_def obj_at_def get_tcb_rev is_sc_active_def
+   apply (wpsimp simp: schedulable_def obj_at_def get_tcb_rev)
+  by (wpsimp simp: schedulable_def obj_at_def get_tcb_rev is_sc_active_def
                wp: get_sched_context_wp)
 
 lemma is_schedulable_sp:
@@ -2268,13 +2268,8 @@ lemma is_schedulable_sp:
   by (clarsimp simp: is_schedulable_opt_def get_tcb_def is_sc_active_def split: option.splits)
 
 lemma is_schedulable_sp':
-  "\<lbrace>P\<rbrace> is_schedulable tp \<lbrace>\<lambda>rv. (\<lambda>s. rv = is_schedulable_bool tp s) and P\<rbrace>"
-  apply (clarsimp simp: is_schedulable_def)
-  apply (wpsimp simp: hoare_vcg_if_lift2 obj_at_def is_tcb wp: get_sched_context_wp)
-  apply(rule conjI)
-   apply (clarsimp simp: Option.is_none_def is_schedulable_bool_def get_tcb_def)
-  by (clarsimp simp: is_schedulable_bool_def get_tcb_def is_sc_active_def
-              split: option.splits)
+  "\<lbrace>P\<rbrace> is_schedulable tp \<lbrace>\<lambda>rv. (\<lambda>s. rv = schedulable tp s) and P\<rbrace>"
+  by (wpsimp wp: is_schedulable_wp)
 
 lemma schedulable_unfold:
   "tcb_at tp s  \<Longrightarrow>
@@ -2292,12 +2287,12 @@ lemma is_sc_active_def2:
   apply (case_tac x2; simp)
   done
 
-lemma is_schedulable_bool_def':
-  "is_schedulable_bool t s = ((\<exists>scp. bound_sc_tcb_at (\<lambda>x. x = Some scp) t s
-                                   \<and> sc_at_pred sc_active scp s)
-                                  \<and> st_tcb_at active t s
-                                  \<and> \<not>(in_release_queue t s))"
-  unfolding is_schedulable_bool_def
+lemma schedulable_def':
+  "schedulable t s = ((\<exists>scp. bound_sc_tcb_at (\<lambda>x. x = Some scp) t s
+                             \<and> sc_at_pred sc_active scp s)
+                             \<and> st_tcb_at active t s
+                             \<and> \<not>(in_release_queue t s))"
+  unfolding schedulable_def
   apply (rule iffI)
    apply (clarsimp simp: pred_tcb_at_def obj_at_def is_sc_active_def2 active_sc_def sc_at_pred_n_def
                          runnable_eq_active split: option.splits

--- a/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
@@ -317,7 +317,7 @@ crunch valid_vspace_objs'[wp]: handle_fault, reply_from_kernel "valid_vspace_obj
 
 lemma handle_invocation_valid_vspace_objs'[wp]:
   "\<lbrace>\<lambda>s. valid_vspace_objs' s \<and> invs s \<and> ct_active s \<and>
-        scheduler_action s = resume_cur_thread \<and> is_schedulable_bool (cur_thread s) s\<rbrace>
+        scheduler_action s = resume_cur_thread \<and> ct_schedulable s\<rbrace>
    handle_invocation calling blocking can_donate first_phase cptr
    \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
   apply (simp add: handle_invocation_def)
@@ -346,7 +346,7 @@ lemma schedule_valid_vspace_objs'[wp]:
 (* FIXME RT: clean up the duplication here (also in ARM); factor out handle_event? *)
 lemma call_kernel_valid_vspace_objs'[wp]:
   "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s) and valid_vspace_objs' and
-    (\<lambda>s. scheduler_action s = resume_cur_thread) and (\<lambda>s. is_schedulable_bool (cur_thread s) s)\<rbrace>
+    (\<lambda>s. scheduler_action s = resume_cur_thread) and ct_schedulable\<rbrace>
       (call_kernel e) :: (unit,unit) s_monad
    \<lbrace>\<lambda>_. valid_vspace_objs'\<rbrace>"
   apply (cases e, simp_all add: call_kernel_def preemption_path_def)
@@ -355,13 +355,13 @@ lemma call_kernel_valid_vspace_objs'[wp]:
         apply (rule_tac Q="\<lambda>_. valid_vspace_objs'" in handleE_wp[rotated])
          apply (rule_tac B="\<lambda>_. invs and ct_running and valid_vspace_objs' and
            (\<lambda>s. scheduler_action s = resume_cur_thread) and
-           (\<lambda>s. is_schedulable_bool (cur_thread s) s)" in seqE)
+           ct_schedulable" in seqE)
           apply (rule liftE_wp)
           apply (wpsimp wp: hoare_vcg_ex_lift)
          apply (rule_tac B="\<lambda>rv. invs and (\<lambda>s. rv \<longrightarrow> ct_running s) and
            valid_vspace_objs' and
            (\<lambda>s. rv \<longrightarrow> scheduler_action s = resume_cur_thread) and
-           (\<lambda>s. rv \<longrightarrow> (is_schedulable_bool (cur_thread s) s))" in seqE)
+           (\<lambda>s. rv \<longrightarrow> ct_schedulable s)" in seqE)
           apply (rule liftE_wp)
           apply (wpsimp wp: check_budget_restart_true)
          apply (rule valid_validE)
@@ -377,7 +377,7 @@ lemma call_kernel_valid_vspace_objs'[wp]:
            valid_vspace_objs' and
            (\<lambda>s. bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s)" in hoare_seq_ext[rotated])
         apply wpsimp
-        apply (clarsimp simp: pred_tcb_at_def obj_at_def is_schedulable_bool_def')
+        apply (clarsimp simp: pred_tcb_at_def obj_at_def schedulable_def')
        apply (rule_tac B="\<lambda>rv. invs and (\<lambda>s. rv \<longrightarrow> ct_running s) and valid_vspace_objs'"
                        in hoare_seq_ext[rotated])
         apply (wpsimp wp: check_budget_restart_true)
@@ -390,7 +390,7 @@ lemma call_kernel_valid_vspace_objs'[wp]:
            valid_vspace_objs' and
            (\<lambda>s. bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s)" in hoare_seq_ext[rotated])
        apply wpsimp
-       apply (clarsimp simp: pred_tcb_at_def obj_at_def is_schedulable_bool_def')
+       apply (clarsimp simp: pred_tcb_at_def obj_at_def schedulable_def')
       apply (rule_tac B="\<lambda>rv. invs and (\<lambda>s. rv \<longrightarrow> ct_running s) and valid_vspace_objs'"
                       in hoare_seq_ext[rotated])
        apply (wpsimp wp: check_budget_restart_true)
@@ -405,7 +405,7 @@ lemma call_kernel_valid_vspace_objs'[wp]:
            valid_vspace_objs' and
            (\<lambda>s. bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) (cur_thread s) s)" in hoare_seq_ext[rotated])
      apply wpsimp
-     apply (clarsimp simp: pred_tcb_at_def obj_at_def is_schedulable_bool_def')
+     apply (clarsimp simp: pred_tcb_at_def obj_at_def schedulable_def')
     apply (rule_tac B="\<lambda>rv. invs and (\<lambda>s. rv \<longrightarrow> ct_running s) and
            valid_vspace_objs'" in hoare_seq_ext[rotated])
      apply (wpsimp wp: check_budget_restart_true)

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -1524,7 +1524,7 @@ lemma charge_budget_invs[wp]:
   apply (rule hoare_seq_ext[OF _ get_sched_context_sp])
   apply (wpsimp wp: end_timeslice_invs assert_inv hoare_vcg_if_lift2 gts_wp is_schedulable_wp)
      apply (rule_tac Q="\<lambda>_. invs" in hoare_strengthen_post[rotated])
-      apply (clarsimp simp: ct_in_state_def runnable_eq pred_tcb_at_def obj_at_def is_schedulable_bool_def
+      apply (clarsimp simp: ct_in_state_def runnable_eq pred_tcb_at_def obj_at_def schedulable_def
                      split: option.splits)
       apply (subgoal_tac "cur_tcb s")
        apply (clarsimp simp: get_tcb_def cur_tcb_def tcb_at_def is_tcb split: option.splits kernel_object.splits)

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -1566,8 +1566,8 @@ lemma he_invs[wp]:
   "\<And>e.
     \<lbrace>\<lambda>s. invs s \<and> (e \<noteq> Interrupt \<longrightarrow> ct_running s) \<and>
          scheduler_action s = resume_cur_thread \<and>
-         is_schedulable_bool (cur_thread s) s\<rbrace>
-      handle_event e
+         (ct_running s \<longrightarrow> ct_schedulable s)\<rbrace>
+    handle_event e
     \<lbrace>\<lambda>_. invs :: 'state_ext state \<Rightarrow> bool\<rbrace>"
   apply (case_tac e, simp_all)
        apply (rename_tac syscall)

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -2998,7 +2998,7 @@ lemma schedContextResume_corres:
 
     apply (intro conjI; (clarsimp simp: invs_def valid_state_def; fail)?)
      apply (fastforce simp: invs_def valid_state_def valid_pspace_def valid_obj_def)
-    apply (clarsimp simp: is_schedulable_bool_def get_tcb_def obj_at_kh_kheap_simps)
+    apply (clarsimp simp: schedulable_def get_tcb_def obj_at_kh_kheap_simps)
     apply (rename_tac t; prop_tac "budget_sufficient t s")
      apply (erule active_valid_budget_sufficient)
      apply (clarsimp simp: vs_all_heap_simps)

--- a/proof/refine/ARM/Refine.thy
+++ b/proof/refine/ARM/Refine.thy
@@ -631,7 +631,7 @@ lemma entry_corres:
               | simp add: tcb_cap_cases_def ct_in_state'_def thread_set_no_change_tcb_state
               | (wps, wp threadSet_st_tcb_at2) )+
    apply (clarsimp simp: invs_def cur_tcb_def)
-  sorry (* FIXME: akernel_invs wants is_schedulable_bool, which is too strong for kernel entry
+  sorry (*
   apply (clarsimp simp: ct_in_state'_def)
   done *)
 

--- a/proof/refine/ARM/SchedContextInv_R.thy
+++ b/proof/refine/ARM/SchedContextInv_R.thy
@@ -542,7 +542,7 @@ lemma schedContextYieldTo_corres:
                    apply (rule corres_when, simp)
                    apply (rule setConsumed_corres)
                   apply (rule_tac P="?abs_buf and sc_yf_sc_at ((=) None) scp and ?ct and ?scp
-                                     and (\<lambda>s. sched = is_schedulable_bool tp s) and tcb_at tp
+                                     and (\<lambda>s. sched = schedulable tp s) and tcb_at tp
                                      and sc_tcb_sc_at ((=) (Some tp)) scp"
                              and P'="?con_buf and cur_tcb' and tcb_at' tp and ko_at' sc0' scp
                                      and (\<lambda>s. scTCBs_of s scp = Some tp)"
@@ -630,7 +630,7 @@ lemma schedContextYieldTo_corres:
                       apply wpsimp
                      apply wpsimp
                     apply (rule_tac P="?abs_buf and sc_yf_sc_at ((=) None) scp and ?scp
-                                       and (\<lambda>s. sched = is_schedulable_bool tp s)"
+                                       and (\<lambda>s. sched = schedulable tp s)"
                                 and P'="?con_buf and cur_tcb' and ko_at' sc0' scp"
                            in corres_inst)
                     apply simp

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -1178,7 +1178,7 @@ lemma handleInvocation_corres:
    apply (erule st_tcb_ex_cap, clarsimp+)
    apply fastforce
   apply (clarsimp cong: conj_cong)
-  apply (subgoal_tac "is_schedulable_bool (cur_thread s) s")
+  apply (subgoal_tac "ct_schedulable s")
    apply (clarsimp simp: invs'_def valid_pspace'_def cur_tcb'_def)
    apply (frule valid_objs'_valid_tcbs')
    apply (frule ct_active_cross, fastforce, fastforce, simp)
@@ -1192,7 +1192,7 @@ lemma handleInvocation_corres:
    apply (frule curthread_relation, simp)
    apply (frule_tac t1="cur_thread s" in cross_relF[OF _ isSchedulable_bool_cross_rel];
           simp add: invs_def valid_state_def valid_pspace_def)
-  apply (clarsimp simp: is_schedulable_bool_def2 ct_in_state_def runnable_eq_active)
+  apply (clarsimp simp: schedulable_def2 ct_in_state_def runnable_eq_active)
   done
 
 lemma ts_Restart_case_helper':

--- a/proof/refine/Move_R.thy
+++ b/proof/refine/Move_R.thy
@@ -390,11 +390,11 @@ lemma thread_set_valid_tcb[wp]:
 
 (* FIXME RT: improve the existing sts_schedulable_scheduler_action *)
 lemma sts_schedulable_scheduler_action2:
-  "\<lbrace>\<lambda>s. P (scheduler_action s) \<and> is_schedulable_bool thread s \<and> runnable st\<rbrace>
+  "\<lbrace>\<lambda>s. P (scheduler_action s) \<and> schedulable thread s \<and> runnable st\<rbrace>
    set_thread_state thread st
   \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
   apply (wpsimp wp: stsa_schedulable_scheduler_action set_object_wp simp: set_thread_state_def)
-  apply (clarsimp simp: is_schedulable_bool_def is_sc_active_def get_tcb_def
+  apply (clarsimp simp: schedulable_def is_sc_active_def get_tcb_def
                         in_release_queue_def
                  split: option.splits kernel_object.splits)
   apply (rename_tac ko ko' ko'')
@@ -404,12 +404,12 @@ lemma sts_schedulable_scheduler_action2:
 lemma activate_thread_sched_act:
   "\<lbrace>(\<lambda>s. P (scheduler_action s)) and
     ct_in_state activatable and
-    (\<lambda>s. is_schedulable_bool (cur_thread s) s) \<rbrace>
+    ct_schedulable\<rbrace>
    activate_thread
    \<lbrace>\<lambda>_. \<lambda>s. P (scheduler_action s)\<rbrace>"
   unfolding activate_thread_def
   by (wpsimp wp: sts_schedulable_scheduler_action2 gts_wp hoare_drop_imp hoare_vcg_all_lift
-           simp: is_schedulable_bool_def2)
+           simp: schedulable_def2)
 
 crunches sc_and_timer
   for scheduler_action[wp]: "\<lambda>s. P (scheduler_action s)"

--- a/spec/abstract/KHeap_A.thy
+++ b/spec/abstract/KHeap_A.thy
@@ -338,15 +338,18 @@ where
             \<and> \<not>(in_release_queue tcb_ptr s)))"
 
 definition
-  is_schedulable_bool :: "obj_ref \<Rightarrow> 'z::state_ext state \<Rightarrow> bool"
+  schedulable :: "obj_ref \<Rightarrow> 'z::state_ext state \<Rightarrow> bool"
 where
-  "is_schedulable_bool tcb_ptr \<equiv> \<lambda>s.
+  "schedulable tcb_ptr \<equiv> \<lambda>s.
      case get_tcb tcb_ptr s of None \<Rightarrow> False
      | Some tcb \<Rightarrow>
        (case tcb_sched_context tcb of None => False
         | Some sc_ptr =>
             (runnable (tcb_state tcb) \<and> (is_sc_active sc_ptr s)
               \<and> \<not>(in_release_queue tcb_ptr s)))"
+
+abbreviation ct_schedulable where
+  "ct_schedulable s \<equiv> schedulable (cur_thread s) s"
 
 (* refill checks *)
 

--- a/spec/abstract/Schedule_A.thy
+++ b/spec/abstract/Schedule_A.thy
@@ -212,8 +212,8 @@ where
 abbreviation (input)
   schedule_switch_thread_branch :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> bool \<Rightarrow> (unit, 'z::state_ext) s_monad"
 where
-  "schedule_switch_thread_branch candidate ct ct_schedulable \<equiv> do
-     when ct_schedulable (tcb_sched_action tcb_sched_enqueue ct); \<comment> \<open>schedulable\<close>
+  "schedule_switch_thread_branch candidate ct ct_schdble \<equiv> do
+     when ct_schdble (tcb_sched_action tcb_sched_enqueue ct); \<comment> \<open>schedulable\<close>
 
      it \<leftarrow> gets idle_thread;
      target_prio \<leftarrow> thread_get tcb_priority candidate;
@@ -232,7 +232,7 @@ where
                 set_scheduler_action choose_new_thread;
                 schedule_choose_new_thread
              od
-        else if ct_schedulable \<and> ct_prio = target_prio
+        else if ct_schdble \<and> ct_prio = target_prio
                 then do \<comment> \<open>Current thread was runnable and candidate is not strictly better
                             want current thread to run next, so append the candidate to end of queue
                             and choose again\<close>
@@ -251,15 +251,15 @@ definition
      awaken;
      check_domain_time;
      ct \<leftarrow> gets cur_thread;
-     ct_schedulable \<leftarrow> is_schedulable ct;
+     ct_schdble \<leftarrow> is_schedulable ct;
      action \<leftarrow> gets scheduler_action;
      (case action
        of resume_cur_thread \<Rightarrow> return ()
         | choose_new_thread \<Rightarrow> do
-            when ct_schedulable (tcb_sched_action tcb_sched_enqueue ct); \<comment> \<open>schedulable\<close>
+            when ct_schdble (tcb_sched_action tcb_sched_enqueue ct); \<comment> \<open>schedulable\<close>
             schedule_choose_new_thread
           od
-        | switch_thread candidate \<Rightarrow> schedule_switch_thread_branch candidate ct ct_schedulable);
+        | switch_thread candidate \<Rightarrow> schedule_switch_thread_branch candidate ct ct_schdble);
      sc_and_timer
    od"
 


### PR DESCRIPTION
This weakens the precondition of `akernel_invs` as described in VER-1301. This also renames `is_schedulable_bool` to `schedulable`, and introduces the abbreviation `ct_schedulable`.

I will continue on with the remainder of VER-1301, namely proving a Hoare triple for `call_kernel` with postcondition `ct_running s --> ct_schedulable s`