### PR TITLE
C parser tweaks

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -130,7 +130,7 @@ These commands perform the following steps:
 * build basic Isabelle images to ensure that
   the installation works. This may take a few minutes.
 
-Alternatively, it is possible to use the official Isabelle2020 release
+Alternatively, it is possible to use the official Isabelle2021 release
 bundle for your platform from the [Isabelle website][isabelle]. In this case, the
 installation steps above can be skipped, and you would replace the directory
 `verification/isabelle/` with a symbolic link to the Isabelle home directory

--- a/tools/autocorres/README.md
+++ b/tools/autocorres/README.md
@@ -35,7 +35,7 @@ Contents of this README
 Installation
 ------------
 
-AutoCorres is packaged as a theory for Isabelle2020:
+AutoCorres is packaged as a theory for Isabelle2021:
 
     https://isabelle.in.tum.de
 
@@ -89,14 +89,15 @@ the tutorial.
 Development and reporting bugs
 ------------------------------
 
-AutoCorres is currently maintained by
-Matthew Brecknell <Matthew.Brecknell@data61.csiro.au>.
+AutoCorres is currently maintained by the seL4 Foundation.
 
 Additionally, the latest development version is available on GitHub
 as part of the L4.verified project:
 
-    https://github.com/seL4/l4v (in tools/autocorres)
+  <https://github.com/seL4/l4v> (in tools/autocorres)
 
+Please use the tracker on the GitHub address above for reporting issues
+with the tool.
 
 
 Options

--- a/tools/autocorres/tools/release_files/ChangeLog
+++ b/tools/autocorres/tools/release_files/ChangeLog
@@ -1,3 +1,8 @@
+AutoCorres 1.8 (31 October 2021)
+--------------
+
+	* Isabelle2021 edition of both AutoCorres and the C parser.
+
 AutoCorres 1.7 (2 November 2020)
 --------------
 

--- a/tools/autocorres/tools/release_files/README
+++ b/tools/autocorres/tools/release_files/README
@@ -28,7 +28,7 @@ Contents of this README
 Installation
 ------------
 
-AutoCorres is packaged as a theory for Isabelle2020:
+AutoCorres is packaged as a theory for Isabelle2021:
 
     https://isabelle.in.tum.de
 
@@ -50,7 +50,7 @@ For RISCV64:
   - 32 bits: int
   - 16 bits: short
 
-To build or use AutoCorres, you must set the L4V_ARCH evironment variable
+To build or use AutoCorres, you must set the L4V_ARCH environment variable
 according to your choice of platform.
 
 To build AutoCorres for ARM, type the following in the root of this release:
@@ -81,14 +81,15 @@ The accompanying theory files can be found in autocorres/doc/quickstart.
 Development and reporting bugs
 ------------------------------
 
-AutoCorres is currently maintained by
-Matthew Brecknell <Matthew.Brecknell@data61.csiro.au>.
+AutoCorres is currently maintained by the seL4 Foundation.
 
 Additionally, the latest development version is available on GitHub
 as part of the L4.verified project:
 
-    https://github.com/seL4/l4v (in tools/autocorres)
+  <https://github.com/seL4/l4v> (in tools/autocorres)
 
+Please use the tracker on the GitHub address above for reporting issues
+with the tool.
 
 
 Package contents

--- a/tools/c-parser/INSTALL.md
+++ b/tools/c-parser/INSTALL.md
@@ -9,7 +9,7 @@
 NB: These instructions apply to the stand-alone release of the C parser.
 If this is in an L4.verified checkout, see the top-level README.md instead.
 
-This code requires Isabelle2020 and the MLton SML compiler.
+This code requires Isabelle2021 and the MLton SML compiler.
 
 The C parser supports multiple target architectures:
 

--- a/tools/c-parser/RELEASES.md
+++ b/tools/c-parser/RELEASES.md
@@ -4,24 +4,31 @@
   SPDX-License-Identifier: BSD-2-Clause
 -->
 
-0.1: Disentangle c-parser tech from seL4 verification effort.
+# StrictC Releases
+
+## 0.1 Disentangle c-parser tech from seL4 verification effort.
+
 - In particular, use standard word types from HOL-Word rather than seL4-specific word types.
 
-0.2: First public release
+## 0.2: First public release
 
-0.3:
+## 0.3
+
 - Fix for bug in guards attached to switch statement expressions.
 - Dependency files (with .d extension) don't include references to /home/michaeln
 
-0.4:
+## 0.4
+
 - All files should now be labelled with correct copyright/licence information.
 
-0.5:
+## 0.5
+
 - The types of C arrays now have size types that are numerals rather
   than ugly `tycopy<n>` names.  Unfortunately, the size 8192 has to be
   an exception to this; the corresponding type is called "ty8192".
 
-0.6:
+## 0.6
+
 - More (all?) files appropriately labelled with copyright/licence information.
 - Better introduction to using the system in INSTALL/MANIFEST/README
 - Some cleanups in the ctranslation document
@@ -39,21 +46,25 @@
 
   returns 0, rather than being undefined behaviour.
 
-0.7:
+## 0.7
+
 - Correct bug caused by pathological programs that have no local
   variables, parameters or returns with attached expressions (every
   function is of type taking-void-returning-void).
 
-0.7.1
+## 0.7.1
+
 - Correct bug in Makefile controlling build of standalone parser tool.
 
-0.7.2
+# 0.7.2
+
 - Adjust source code to be better compatible with Isabelle 2011, removing
   deprecated commands such as "axclass".
 - Ensure that tokenizer tool (in standalone-parser directory) builds
   with Poly as well as mlton.
 
-1.0
+# 1.0
+
 - Builds with isabelle-2011-1 (VER 109)
 - Other minor fixes
   - allow break statements within switch statements even if they don't
@@ -68,17 +79,21 @@
   - generate correct guards for double pointer deref (VER 152)
   - use "type_synonym" rather than "types"
 
-1.12.0
+## 1.12.0
+
 - Builds with isabelle-2012 (VER 192)
 
-1.12.1
+## 1.12.1
+
 - Fixes a problem with non-ASCII #include filenames (VER 224)
 
-1.13.0
+## 1.13.0
+
 - Builds with isabelle-2013 (VER 247)
 - Implements the C99 _Bool type (VER 254)
 
-1.13.1
+## 1.13.1
+
 - Builds with isabelle-2013-{1,2} (VER 331)
 - Handles filenames including spaces (VER 307)
 - Allows the const keyword in more places (and completely ignores it) (VER 315)
@@ -87,30 +102,36 @@
 - Allows identifiers with leading underscores if the allow_underscore_idents configuration option is set.  This latter can be done with a line like
 
       declare [[allow_underscore_idents=true]]
+
 - Fixes guards for some nested pointer-dereferences (VER 345)
 
-1.14
+## 1.14
+
 - Builds with Isabelle2017
 - avoid complex call lvals
 - add x64 definitions and support for multiple architectures
 - improved performance of automatic modifies-proofs
 - improved tracing
 
-1.15
+## 1.15
+
 - Builds with Isabelle2018
 - update documentation
 - always attach GCC attributes to vars in the AST
 
-1.16
+## 1.16
+
 - Builds with Isabelle2019
 - added syntax for displaying pointer types (PTR and PTR_COERCE)
 - always emit long (type-wrangled) variable names,
   provide short names as abbreviation
 
-1.16.1
+## 1.16.1
+
 - Correct license for shorten_names.ML. No code changes.
 
-1.17
+## 1.17
+
 - Builds with Isabelle2020
 - Faster automation for proving packed_type class instances
 - Remove unused assumptions from field_lookup rules

--- a/tools/c-parser/RELEASES.md
+++ b/tools/c-parser/RELEASES.md
@@ -137,3 +137,11 @@
 - Remove unused assumptions from field_lookup rules
 - Use python3 in scripts
 - Use SPDX identifiers for licensing information
+
+## 1.18
+
+- Builds with Isabelle2021
+- improve inline assembly support in modifies proofs
+- always use fresh names for generated temporary variables.
+  This fixes a problem that could make some function call expressions unprovable. (VER-1389)
+- improve compile time performance for functional record update definitions

--- a/tools/c-parser/mkrelease
+++ b/tools/c-parser/mkrelease
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
 #

--- a/tools/c-parser/mkrelease
+++ b/tools/c-parser/mkrelease
@@ -12,7 +12,7 @@
 set -e
 
 case $(uname) in
-  Darwin* ) TAR=gnutar ; SEDIOPT="-i ''" ;;
+  Darwin* ) TAR=gtar ; SEDIOPT="-i ''" ;;
   * ) TAR=tar ; SEDIOPT=-i ;;
 esac
 
@@ -88,7 +88,7 @@ git -C "${TOPLEVEL_DIR}" ls-files -z | tr '\0' '\n' |
   (cd "$outputdir/src" ; tar xf -)
 
 echo "Getting theory dependencies"
-CPARSER_DEPS=$(tempfile)
+CPARSER_DEPS=$(mktemp)
 for ARCH in $RELEASE_ARCHS; do
     L4V_ARCH=$ARCH misc/scripts/thydeps -I ./isabelle -d . -b . -r CParser
 done |
@@ -100,13 +100,15 @@ if grep -q -vE '^(lib/|tools/c-parser/)' "$CPARSER_DEPS"; then
     exit 1
 fi
 
-echo "Copying misc files"
-grep '^lib/' "$CPARSER_DEPS" |
-    xargs '-d\n' cp -v --parents -t "$outputdir/src"
+echo "Copying lib files"
+for f in $(grep '^lib/' "$CPARSER_DEPS")
+do
+    mkdir -p "$(dirname "$outputdir/src/$f")"
+    cp -v $f "$outputdir/src/$f"
+done
 
 # other misc files
-cp -v --parents -t "$outputdir/src" \
-   lib/Word_Lib/ROOT
+cp -v lib/Word_Lib/ROOT "$outputdir/src/lib/Word_Lib/"
 
 echo "Creating ROOTS file"
 cat >"$outputdir/src/ROOTS" <<EOF


### PR DESCRIPTION
- add release notes for C Parser 1.18 and Autocorres 1.8
- bump Isabelle2020 -> Isabelle2021 in docs and release notes
- adjust release scripts to work on MacOS and python3
