### PR TITLE
"add refill_unblock_check” spec update, part IV

### DIFF
--- a/lib/Monad_WP/NonDetMonadVCG.thy
+++ b/lib/Monad_WP/NonDetMonadVCG.thy
@@ -211,6 +211,13 @@ lemma pred_conj_comm:
   "(P and Q) = (Q and P)"
   by (auto simp: pred_conj_def)
 
+lemma
+  pred_conj_disj_distribL: "(P and (Q or R)) = (P and Q or P and R)" and
+  pred_conj_disj_distribR: "((P or Q) and R) = (P and R or Q and R)" and
+  pred_disj_conj_distribL: "(P or (Q and R)) = ((P or Q) and (P or R))" and
+  pred_disj_conj_distribR: "((P and Q) or R) = ((P or R) and (Q or R))"
+  by (fastforce simp: pred_conj_def pred_disj_def)+
+
 subsection "Hoare Logic Rules"
 
 lemma validE_def2:

--- a/proof/invariant-abstract/AInvs.thy
+++ b/proof/invariant-abstract/AInvs.thy
@@ -979,17 +979,6 @@ crunches receive_ipc, handle_fault
   for ct_not_in_release_q[wp]: ct_not_in_release_q
   (wp: crunch_wps simp: crunch_simps)
 
-lemma maybe_donate_sc_ct_not_in_release_q_thread_bound:
-  "\<lbrace>\<lambda>s. ct_not_in_release_q s \<and> thread = cur_thread s \<and> bound_sc_tcb_at bound (cur_thread s) s\<rbrace>
-   maybe_donate_sc thread sc_ptr
-   \<lbrace>\<lambda>_. ct_not_in_release_q\<rbrace>"
-  apply (clarsimp simp: maybe_donate_sc_def)
-  apply (rule hoare_seq_ext[OF _ gsc_sp])
-  apply (rule hoare_when_cases, simp)
-  apply (wpsimp wp: hoare_pre_cont)
-  apply (clarsimp simp: pred_tcb_at_def obj_at_def)
-  done
-
 lemma receive_signal_schact_is_rct_imp_ct_not_in_release_q:
   "\<lbrace>\<lambda>s. (schact_is_rct s \<longrightarrow> ct_not_in_release_q s) \<and> invs s \<and> thread = cur_thread s\<rbrace>
    receive_signal thread cap is_blocking
@@ -999,7 +988,7 @@ lemma receive_signal_schact_is_rct_imp_ct_not_in_release_q:
   apply (case_tac "ntfn_obj ntfn"; clarsimp?, (solves \<open>wpsimp wp: hoare_vcg_imp_lift'\<close>)?)
   apply (rule hoare_vcg_imp_lift_pre_add; (solves wpsimp)?)
   apply (rule hoare_seq_ext_skip, solves wpsimp)
-  apply (wpsimp wp: maybe_donate_sc_ct_not_in_release_q_thread_bound set_simple_ko_wp)
+  apply (wpsimp wp: set_simple_ko_wp)
   apply (fastforce dest: invs_strengthen_cur_sc_tcb_are_bound
                    simp: obj_at_def pred_tcb_at_def vs_all_heap_simps sk_obj_at_pred_def)
   done

--- a/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
@@ -439,7 +439,8 @@ crunch valid_pdpt_objs[wp]: send_signal, send_ipc "valid_pdpt_objs"
 crunch valid_pdpt_objs[wp]: cancel_all_ipc, cancel_all_signals, unbind_maybe_notification,
   sched_context_maybe_unbind_ntfn, reply_unlink_tcb,
   sched_context_unbind_all_tcbs, sched_context_unbind_ntfn "valid_pdpt_objs"
-  (wp: maybeM_inv hoare_drop_imp mapM_x_wp' ignore: tcb_release_remove)
+  (wp: maybeM_inv hoare_drop_imp mapM_x_wp' whileLoop_wp' ignore: tcb_release_remove
+   simp: crunch_simps is_round_robin_def)
 
 crunch valid_pdpt_objs[wp]:
 sched_context_unbind_yield_from "valid_pdpt_objs"

--- a/proof/invariant-abstract/BCorres_AI.thy
+++ b/proof/invariant-abstract/BCorres_AI.thy
@@ -59,7 +59,7 @@ crunch_ignore (bcorres)
   (add: NonDetMonad.bind gets modify get put do_extended_op empty_slot_ext mapM_x "when"
         select unless mapM catch bindE liftE whenE alternative cap_swap_ext
         cap_insert_ext cap_move_ext liftM create_cap_ext
-        lookup_error_on_failure getActiveIRQ
+        lookup_error_on_failure getActiveIRQ maybeM
         gets_the liftME zipWithM_x unlessE mapME_x handleE forM_x)
 
 lemma bcorres_select_ext[wp]:
@@ -151,6 +151,14 @@ lemma get_sc_refill_ready_bcorres[wp]:
   "bcorres (get_sc_refill_ready scp) (get_sc_refill_ready scp)"
   by (wpsimp simp: get_sc_refill_ready_def gets_the_def)
 
+lemma refill_head_overlapping_truncate[simp]:
+  "refill_head_overlapping a (truncate_state s) = refill_head_overlapping a s"
+  by (simp add: refill_head_overlapping_def obind_def omonad_defs)
+
+crunch (bcorres)bcorres[wp]:
+  refill_unblock_check
+  truncate_state
+
 crunch (bcorres)bcorres[wp]:
   cancel_all_ipc, bind_notification, cancel_all_signals
   truncate_state
@@ -160,11 +168,11 @@ crunch (bcorres)bcorres[wp]: get_tcb_obj_ref, get_sk_obj_ref truncate_state
 
 lemma unbind_maybe_notification_bcorres[wp]:
   "bcorres (unbind_maybe_notification a) (unbind_maybe_notification a)"
-  by (wpsimp simp: unbind_maybe_notification_def maybeM_def)
+  by (wpsimp simp: unbind_maybe_notification_def)
 
 lemma unbind_notification_bcorres[wp]:
   "bcorres (unbind_notification a) (unbind_notification a)"
-  by (wpsimp simp: unbind_notification_def maybeM_def)
+  by (wpsimp simp: unbind_notification_def)
 
 (*
 lemma fast_finalise_bcorres[wp]:

--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -110,7 +110,7 @@ crunch domain_list_inv[wp]: reply_remove, sched_context_unbind_tcb, sched_contex
   (wp: hoare_drop_imps get_simple_ko_wp)
 
 crunch domain_list_inv[wp]: cancel_all_ipc, cancel_all_signals "\<lambda>s. P (domain_list s)"
-  (wp: hoare_drop_imps mapM_x_wp')
+  (wp: hoare_drop_imps mapM_x_wp' whileLoop_wp')
 
 crunch domain_list_inv[wp]: finalise_cap "\<lambda>s::det_state. P (domain_list s)"
   (wp: crunch_wps hoare_unless_wp maybeM_inv dxo_wp_weak select_inv simp: crunch_simps)

--- a/proof/invariant-abstract/Deterministic_AI.thy
+++ b/proof/invariant-abstract/Deterministic_AI.thy
@@ -3958,7 +3958,7 @@ crunches
   sched_context_unbind_ntfn, sched_context_maybe_unbind_ntfn,
   sched_context_unbind_yield_from, cancel_all_ipc, thread_set, reply_remove_tcb
   for valid_list[wp]: valid_list
-  (wp: mapM_x_wp' hoare_drop_imp)
+  (wp: mapM_x_wp' hoare_drop_imp whileLoop_wp' simp: is_round_robin_def crunch_simps)
 
 crunch all_but_exst[wp]: update_work_units "all_but_exst P"
 

--- a/proof/invariant-abstract/SchedContextInv_AI.thy
+++ b/proof/invariant-abstract/SchedContextInv_AI.thy
@@ -1210,7 +1210,7 @@ text \<open>invocation related lemmas\<close>
 lemma sched_context_bind_tcb_typ_at[wp]:
   "\<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace>
       sched_context_bind_tcb sc tcb \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>"
-  by (wpsimp simp: sched_context_bind_tcb_def)
+  by (wpsimp simp: sched_context_bind_tcb_def wp: hoare_drop_imps)
 
 lemma sched_context_yield_to_typ_at[wp]:
   "\<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace>

--- a/proof/invariant-abstract/Tcb_AI.thy
+++ b/proof/invariant-abstract/Tcb_AI.thy
@@ -1845,7 +1845,7 @@ lemma set_simple_ko_sc_at_pred_n[wp]:
 crunches cancel_all_ipc
   for sc_tcb_sc_at[wp]: "\<lambda>s. Q (sc_tcb_sc_at P p s)"
   and ex_nonz_cap_to[wp]: "ex_nonz_cap_to t"
-  (wp: crunch_wps simp: crunch_simps)
+  (wp: crunch_wps simp: crunch_simps is_round_robin_def)
 
 lemma valid_cap_not_ep_at_not_ep_cap:
   "\<lbrakk> r \<in> obj_refs cap; \<not> ep_at r s; s \<turnstile> cap \<rbrakk>

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -6966,7 +6966,7 @@ lemma rec_del_corres:
                                                            \<and> cap_relation (snd r) (snd r') )
                           | _ \<Rightarrow> dc))
       (einvs and valid_machine_time and simple_sched_action
-            and valid_rec_del_call args
+            and valid_rec_del_call args and current_time_bounded 2
             and cte_at (slot_rdcall args)
             and (\<lambda>s. \<not> exposed_rdcall args \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) (slot_rdcall args) s)
             and (\<lambda>s. case args of ReduceZombieCall cap sl ex \<Rightarrow>
@@ -7103,7 +7103,7 @@ next
            apply (wp | simp)+
            apply (rule hoare_strengthen_post)
             apply (rule_tac Q="\<lambda>fin s. einvs s \<and> valid_machine_time s  \<and> simple_sched_action s
-                                      \<and> replaceable s slot (fst fin) rv
+                                      \<and> replaceable s slot (fst fin) rv \<and> current_time_bounded 2 s
                                       \<and> cte_wp_at ((=) rv) slot s \<and> s \<turnstile> fst fin
                                       \<and> (\<forall>t\<in>obj_refs (fst fin). halted_if_tcb t s)"
                        in hoare_vcg_conj_lift)
@@ -7379,7 +7379,8 @@ qed
 
 lemma cteDelete_corres:
   "corres (dc \<oplus> dc)
-      (einvs and valid_machine_time and simple_sched_action and cte_at ptr)
+      (einvs and valid_machine_time and simple_sched_action
+       and current_time_bounded 2 and cte_at ptr)
       (invs' and sch_act_simple and cte_at' (cte_map ptr))
       (cap_delete ptr) (cteDelete (cte_map ptr) True)"
   unfolding cap_delete_def
@@ -7625,7 +7626,7 @@ lemma cap_revoke_mdb_stuff4:
 
 lemma cteRevoke_corres':
   "spec_corres s (dc \<oplus> dc)
-      (einvs and valid_machine_time and simple_sched_action and cte_at ptr)
+      (einvs and valid_machine_time and simple_sched_action and cte_at ptr and current_time_bounded 2)
       (invs' and sch_act_simple and cte_at' (cte_map ptr))
       (cap_revoke ptr) (\<lambda>s. cteRevoke (cte_map ptr) s)"
 proof (induct rule: cap_revoke.induct)
@@ -8648,7 +8649,8 @@ declare corres_False' [simp]
 lemma invokeCNode_corres:
   "cnodeinv_relation ci ci' \<Longrightarrow>
    corres (dc \<oplus> dc)
-     (einvs and valid_machine_time and simple_sched_action and valid_cnode_inv ci)
+     (einvs and valid_machine_time and simple_sched_action and valid_cnode_inv ci
+      and current_time_bounded 2)
      (invs' and sch_act_simple and valid_cnode_inv' ci')
      (invoke_cnode ci) (invokeCNode ci')"
   apply (simp add: invoke_cnode_def invokeCNode_def)

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -3818,7 +3818,7 @@ lemma rescheduleRequired_oa_queued':
 
 crunches cancelAllIPC, cancelAllSignals, unbindMaybeNotification
   for tcbDomain_obj_at': "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'"
-  (wp: crunch_wps)
+  (wp: crunch_wps simp: crunch_simps)
 
 lemma cancelAllIPC_valid_queues[wp]:
   "\<lbrace>valid_queues and valid_tcbs'\<rbrace>
@@ -4337,7 +4337,9 @@ lemma interrupt_cap_null_or_ntfn:
   done
 
 lemma (in delete_one) deletingIRQHandler_corres:
-  "corres dc (einvs and simple_sched_action) (invs')
+  "corres dc
+          (einvs and simple_sched_action and current_time_bounded 2)
+          invs'
           (deleting_irq_handler irq) (deletingIRQHandler irq)"
   apply (simp add: deleting_irq_handler_def deletingIRQHandler_def)
   apply (rule corres_guard_imp)
@@ -4346,7 +4348,7 @@ lemma (in delete_one) deletingIRQHandler_corres:
       apply (rule_tac P'="cte_at' (cte_map slot)" in corres_symb_exec_r_conj)
          apply (rule_tac F="isNotificationCap rv \<or> rv = capability.NullCap"
              and P="cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) slot
-                 and einvs and simple_sched_action"
+                 and einvs and simple_sched_action and current_time_bounded 2"
              and P'="invs' and cte_wp_at' (\<lambda>cte. cteCap cte = rv)
                  (cte_map slot)" in corres_req)
           apply (clarsimp simp: cte_wp_at_caps_of_state state_relation_def)
@@ -4593,7 +4595,7 @@ lemma fast_finaliseCap_corres:
   "\<lbrakk> final_matters' cap' \<longrightarrow> final = final'; cap_relation cap cap';
      can_fast_finalise cap \<rbrakk>
    \<Longrightarrow> corres dc
-           (\<lambda>s. invs s \<and> valid_sched s \<and> s \<turnstile> cap
+           (\<lambda>s. invs s \<and> valid_sched s \<and> s \<turnstile> cap \<and> current_time_bounded 2 s
                        \<and> cte_wp_at ((=) cap) sl s)
            (\<lambda>s. invs' s \<and> s \<turnstile>' cap')
            (fast_finalise cap final)
@@ -4652,7 +4654,9 @@ lemma finaliseCap_true_removable[wp]:
   by (cases cap; wpsimp simp: finaliseCap_def isCap_simps capRemovable_def)
 
 lemma cap_delete_one_corres:
-  "corres dc (einvs and simple_sched_action and cte_wp_at can_fast_finalise slot)
+  "corres dc
+        (einvs and simple_sched_action and cte_wp_at can_fast_finalise slot
+         and current_time_bounded 2)
         (invs' and cte_at' (cte_map slot))
         (cap_delete_one slot) (cteDeleteOne (cte_map slot))"
   apply (simp add: cap_delete_one_def cteDeleteOne_def'
@@ -4925,7 +4929,8 @@ lemma finaliseCap_corres:
           flag \<longrightarrow> can_fast_finalise cap \<rbrakk>
      \<Longrightarrow> corres (\<lambda>x y. cap_relation (fst x) (fst y) \<and> cap_relation (snd x) (snd y))
            (\<lambda>s. einvs s \<and> s \<turnstile> cap \<and> (final_matters cap \<longrightarrow> final = is_final_cap' cap s)
-                       \<and> cte_wp_at ((=) cap) sl s \<and> simple_sched_action s)
+                \<and> cte_wp_at ((=) cap) sl s \<and> simple_sched_action s
+                \<and> current_time_bounded 2 s)
            (\<lambda>s. invs' s \<and> s \<turnstile>' cap'
                    \<and> (final_matters' cap' \<longrightarrow>
                         final' = isFinal cap' (cte_map sl) (cteCaps_of s))

--- a/proof/refine/ARM/Interrupt_R.thy
+++ b/proof/refine/ARM/Interrupt_R.thy
@@ -358,7 +358,7 @@ lemma arch_invokeIRQHandler_corres:
 
 lemma invokeIRQHandler_corres:
   "irq_handler_inv_relation i i' \<Longrightarrow>
-   corres dc (einvs and irq_handler_inv_valid i and simple_sched_action)
+   corres dc (einvs and irq_handler_inv_valid i and simple_sched_action and current_time_bounded 2)
              (invs' and irq_handler_inv_valid' i' and sch_act_simple)
      (invoke_irq_handler i)
      (InterruptDecls_H.invokeIRQHandler i')"
@@ -373,7 +373,7 @@ lemma invokeIRQHandler_corres:
        apply (rule corres_split_nor [OF _ cap_delete_one_corres])
          apply (rule cteInsert_corres, simp+)
         apply (rule_tac Q="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
-                                  \<and> (a, b) \<noteq> irq_slot
+                                  \<and> (a, b) \<noteq> irq_slot \<and> current_time_bounded 2 s
                                   \<and> cte_wp_at (is_derived (cdt s) (a, b) cap) (a, b) s"
                       in hoare_post_imp)
          apply fastforce

--- a/proof/refine/ARM/Reply_R.thy
+++ b/proof/refine/ARM/Reply_R.thy
@@ -1576,27 +1576,6 @@ lemma sc_replies_update_takeWhile_sc_with_reply:
   apply (clarsimp simp add: the_pred_option_def Ex1_def)
   by (fastforce dest!: valid_replies_sc_replies_unique simp: obj_at_def sc_replies_sc_at_def)+
 
-(* FIXME RT: maybe move *)
-lemma update_sched_context_not_tcb_at[wp]:
-  "update_sched_context ref f \<lbrace>\<lambda>s. P (ko_at (TCB tcb) t s)\<rbrace>"
-  apply (clarsimp simp: update_sched_context_def)
-  apply (wpsimp wp: set_object_wp get_object_wp)
-  apply (clarsimp simp: obj_at_def sk_obj_at_pred_def pred_neg_def split: if_splits)
-  done
-
-lemma update_sched_context_valid_tcb[wp]:
-  "update_sched_context scp f \<lbrace>valid_tcb ptr tcb\<rbrace>"
-  apply (clarsimp simp: update_sched_context_def)
-  apply (wpsimp wp: set_object_typ_ats get_object_wp)
-  done
-
-lemma update_sched_context_valid_tcbs[wp]:
-  "update_sched_context ref f \<lbrace>valid_tcbs\<rbrace>"
-  unfolding valid_tcbs_def
-  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')
-  done
-(* end: maybe move *)
-
 lemma sc_replies_update_takeWhile_middle_sym_refs:
   "\<lbrakk> hd (sc_replies sc) \<noteq> rp; rp \<in> set (sc_replies sc) \<rbrakk> \<Longrightarrow>
    \<lbrace>\<lambda>s. P (state_refs_of s) \<and> obj_at (\<lambda>ko. \<exists>n. ko = kernel_object.SchedContext sc n) scp s\<rbrace>

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -28,7 +28,7 @@ crunches tcbReleaseDequeue
   for sc_at'_n[wp]: "\<lambda>s. Q (sc_at'_n n p s)"
   (simp: crunch_simps wp: crunch_wps)
 
-crunches refillUnblockCheck, refillBudgetCheck, refillBudgetCheckRoundRobin
+crunches refillUnblockCheck, refillBudgetCheck, ifCondRefillUnblockCheck, refillBudgetCheckRoundRobin
   for valid_queues[wp]: valid_queues
   and valid_queues'[wp]: valid_queues'
   and valid_release_queue[wp]: valid_release_queue
@@ -2376,7 +2376,7 @@ lemma refillUnblockCheck_valid_machine_state'[wp]:
   done
 
 lemma refillUnblockCheck_list_refs_of_replies'[wp]:
-  "refillUnblockCheck scPtr \<lbrace>\<lambda>s. sym_refs (list_refs_of_replies' s)\<rbrace>"
+  "refillUnblockCheck scPtr \<lbrace>\<lambda>s. P (list_refs_of_replies' s)\<rbrace>"
   apply (clarsimp simp: refillUnblockCheck_def valid_mdb'_def refillHeadOverlappingLoop_def
                         mergeRefills_def updateRefillHd_def refillPopHead_def updateSchedContext_def
                         setReprogramTimer_def refillReady_def isRoundRobin_def)

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -292,6 +292,17 @@ lemma valid_objs'_valid_refills':
   by (clarsimp simp: valid_refills'_def valid_obj'_def valid_sched_context'_def
                      is_active_sc'_def opt_map_red projectKO_opt_sc)
 
+lemma
+  valid_refills'_ksSchedulerAction_update[simp]:
+  "valid_refills' scp (ksSchedulerAction_update g s) = valid_refills' scp s" and
+  valid_refills'_ksReadyQueues_update[simp]:
+  "valid_refills' scp (ksReadyQueues_update f s) = valid_refills' scp s" and
+  valid_refills'_ksReadyQueuesL1Bitmap_update[simp]:
+  "valid_refills' scp (ksReadyQueuesL1Bitmap_update f' s) = valid_refills' scp s" and
+  valid_refills'_ksReadyQueuesL2Bitmap_update[simp]:
+  "valid_refills' scp (ksReadyQueuesL2Bitmap_update f'' s) = valid_refills' scp s"
+  by (clarsimp simp: valid_refills'_def)+
+
 lemma maxReleaseTime_equiv:
   "maxReleaseTime = MAX_RELEASE_TIME"
   apply (clarsimp simp: maxReleaseTime_def MAX_RELEASE_TIME_def maxBound_max_word maxPeriodUs_def

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -307,8 +307,28 @@ lemma possible_switch_to_valid_tcbs[wp]:
               simp: set_scheduler_action_def get_tcb_obj_ref_def)+
   done
 
-crunches restart_thread_if_no_fault
+lemma update_sched_context_ko_at_TCB[wp]:
+  "update_sched_context ref f \<lbrace>\<lambda>s. P (ko_at (TCB tcb) t s)\<rbrace>"
+  apply (clarsimp simp: update_sched_context_def)
+  apply (wpsimp wp: set_object_wp get_object_wp)
+  apply (clarsimp simp: obj_at_def sk_obj_at_pred_def pred_neg_def split: if_splits)
+  done
+
+lemma update_sched_context_valid_tcb[wp]:
+  "update_sched_context scp f \<lbrace>valid_tcb ptr tcb\<rbrace>"
+  apply (clarsimp simp: update_sched_context_def)
+  apply (wpsimp wp: set_object_typ_ats get_object_wp)
+  done
+
+lemma update_sched_context_valid_tcbs[wp]:
+  "update_sched_context ref f \<lbrace>valid_tcbs\<rbrace>"
+  unfolding valid_tcbs_def
+  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')
+  done
+
+crunches refill_unblock_check, restart_thread_if_no_fault
   for valid_tcbs[wp]: valid_tcbs
+  (simp: is_round_robin_def crunch_simps wp: whileLoop_wp)
 
 definition valid_tcbs' :: "kernel_state \<Rightarrow> bool" where
   "valid_tcbs' s' \<equiv> \<forall>ptr tcb. ksPSpace s' ptr = Some (KOTCB tcb) \<longrightarrow> valid_tcb' tcb s'"

--- a/spec/abstract/IpcCancel_A.thy
+++ b/spec/abstract/IpcCancel_A.thy
@@ -419,6 +419,8 @@ where
      if fault = None
      then do
        set_thread_state t Restart;
+       sc_opt \<leftarrow> get_tcb_obj_ref tcb_sched_context t;
+       if_sporadic_cur_sc_assert_refill_unblock_check sc_opt;
        possible_switch_to t
      od
      else set_thread_state t Inactive
@@ -523,6 +525,8 @@ where
      case ntfn_obj ntfn of WaitingNtfn queue \<Rightarrow> do
                       _ \<leftarrow> set_notification ntfnptr $ ntfn_obj_update (K IdleNtfn) ntfn;
                       mapM_x (\<lambda>t. do set_thread_state t Restart;
+                                     sc_opt \<leftarrow> get_tcb_obj_ref tcb_sched_context t;
+                                     if_sporadic_cur_sc_assert_refill_unblock_check sc_opt;
                                      possible_switch_to t od) queue;
                       reschedule_required
                      od

--- a/spec/haskell/src/SEL4/Object/Endpoint.lhs
+++ b/spec/haskell/src/SEL4/Object/Endpoint.lhs
@@ -323,6 +323,8 @@ If a badged endpoint is recycled, then cancel every pending send operation using
 >                         if isNothing fault
 >                             then do
 >                                 setThreadState Restart t
+>                                 scOpt <- threadGet tcbSchedContext t
+>                                 ifCondRefillUnblockCheck scOpt (Just False) (Just True)
 >                                 possibleSwitchTo t
 >                             else setThreadState Inactive t
 >                         return False

--- a/spec/haskell/src/SEL4/Object/Endpoint.lhs
+++ b/spec/haskell/src/SEL4/Object/Endpoint.lhs
@@ -295,6 +295,8 @@ If an endpoint is deleted, then every pending IPC operation using it must be can
 >                     if isNothing fault
 >                         then do
 >                             setThreadState Restart t
+>                             scOpt <- threadGet tcbSchedContext t
+>                             ifCondRefillUnblockCheck scOpt (Just False) (Just True)
 >                             possibleSwitchTo t
 >                         else setThreadState Inactive t)
 >                 rescheduleRequired

--- a/spec/haskell/src/SEL4/Object/Notification.lhs
+++ b/spec/haskell/src/SEL4/Object/Notification.lhs
@@ -159,6 +159,8 @@ If a notification object is deleted, then pending receive operations must be can
 >                 setNotification ntfnPtr (ntfn { ntfnObj = IdleNtfn })
 >                 forM_ queue (\t -> do
 >                     setThreadState Restart t
+>                     scOpt <- threadGet tcbSchedContext t
+>                     ifCondRefillUnblockCheck scOpt (Just False) (Just True)
 >                     possibleSwitchTo t)
 >                 rescheduleRequired
 >             _ -> return ()


### PR DESCRIPTION
This adds a call to `refill_unblock_check` in `cancel_all_ipc` and `cancel_badged_sends` (via `restart_thread_if_no_fault` for the abstract spec), as well as in `cancel_all_signals`.

Also includes:
- bcorres rules for `maybeM` and `whileLoop`
- distribution rules for `pred_conj` and `pred_disj`