### PR TITLE
"add refill_unblock_check” spec update, part VI

### DIFF
--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -12049,6 +12049,16 @@ lemma refill_unblock_check_cur_sc_more_than_ready[wp]:
   apply clarsimp
   done
 
+lemma if_cond_refill_unblock_check_cur_sc_more_than_ready[wp]:
+  "\<lbrace>cur_sc_more_than_ready and (\<lambda>s. \<forall>scp. scopt = Some scp \<longrightarrow> scp \<noteq> cur_sc s)\<rbrace>
+   if_cond_refill_unblock_check scopt act ast
+   \<lbrace>\<lambda>_. cur_sc_more_than_ready\<rbrace>"
+  apply (wpsimp wp: hoare_vcg_imp_lift' simp: cur_sc_more_than_ready_def)
+   apply (wps, wpsimp wp: refill_unblock_check_refill_ready_no_overflow_sc ruc_is_refill_sufficient_indep
+                    simp: if_cond_refill_unblock_check_def)+
+  apply clarsimp
+  done
+
 lemma cur_tcb_sc_at:
   "\<lbrakk>valid_objs s; cur_tcb s; bound_sc_tcb_at ((=) (Some sc_ptr)) (cur_thread s) s\<rbrakk>
    \<Longrightarrow> sc_at sc_ptr s"
@@ -15596,12 +15606,28 @@ lemma receive_signal_valid_sched:
   apply (cases cap; clarsimp)
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
   apply (rename_tac ntfn)
-  apply (case_tac "ntfn_obj ntfn"; clarsimp)
+  apply (case_tac "ntfn_obj ntfn"; clarsimp simp: if_cond_refill_unblock_check_def)
     apply (wpsimp wp: set_thread_state_valid_sched)
     apply (clarsimp simp: valid_sched_def)
    apply (wpsimp wp: set_thread_state_valid_sched)
    apply (clarsimp simp: valid_sched_def)
-  apply (wpsimp wp: maybe_donate_sc_valid_sched simp: valid_ntfn_def)
+  apply (wpsimp wp: maybe_donate_sc_valid_sched hoare_vcg_if_lift2
+                    refill_unblock_check_valid_sched get_tcb_obj_ref_wp
+              simp: valid_ntfn_def)
+     apply (rule_tac Q="\<lambda>_ s. valid_sched s \<and> heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s)
+                              \<and> current_time_bounded 2 s
+                              \<and> (in_release_q thread s
+                                  \<longrightarrow> active_sc_tcb_at thread s \<longrightarrow> (\<not> budget_ready thread s))"
+            in hoare_strengthen_post[rotated])
+      apply (clarsimp simp: pred_neg_def obj_at_def tcb_at_kh_simps)
+      apply (rename_tac tcb scp sc n t)
+      apply (prop_tac "heap_ref_eq scp thread (tcb_scps_of s)")
+       apply (clarsimp simp: obj_at_def vs_all_heap_simps)
+      apply (clarsimp simp: heap_refs_inv_def2 pred_map_eq)
+      apply (prop_tac "pred_map (\<lambda>a. \<exists>y. a = Some y) (tcb_scps_of s) thread")
+       apply (clarsimp simp: vs_all_heap_simps tcb_at_kh_simps)
+      apply (fastforce simp: budget_ready_def2 tcb_at_kh_simps vs_all_heap_simps)
+     apply (wpsimp wp: maybe_donate_sc_valid_sched maybe_donate_sc_in_release_q_imp_not_ready)+
   done
 
 crunches restart_thread_if_no_fault
@@ -22158,9 +22184,13 @@ lemma receive_ipc_cur_sc_more_than_ready[wp]:
   apply (wpsimp wp: hoare_drop_imp hoare_vcg_all_lift)+
   done
 
+lemma receive_signal_cur_sc_more_than_ready[wp]:
+  "receive_signal thread cap is_blocking \<lbrace>cur_sc_more_than_ready :: det_state \<Rightarrow> _\<rbrace>"
+  unfolding receive_signal_def by (wpsimp wp: hoare_drop_imp)
+
 crunches handle_recv
   for cur_sc_more_than_ready[wp]: "cur_sc_more_than_ready :: det_state \<Rightarrow> _"
-  (wp: crunch_wps simp: crunch_simps ignore: set_object update_sched_context)
+  (wp: crunch_wps hoare_vcg_all_lift simp: crunch_simps ignore: set_object)
 
 lemma charge_budget_cur_sc_more_than_ready[wp]:
   "\<lbrace>\<top>\<rbrace> charge_budget consumed canTimeout \<lbrace>\<lambda>_. cur_sc_more_than_ready :: det_state \<Rightarrow> _\<rbrace>"
@@ -25586,10 +25616,10 @@ lemma receive_signal_ct_ready_if_schedulable:
         \<and> heap_refs_inv (sc_tcbs_of s) (tcb_scps_of s)\<rbrace>
    receive_signal thread cap is_blocking
    \<lbrace>\<lambda>_. ct_ready_if_schedulable :: det_state \<Rightarrow> _\<rbrace>"
-  unfolding receive_signal_def
+  unfolding receive_signal_def if_cond_refill_unblock_check_def
   apply (wpsimp wp: set_thread_state_ct_ready_if_schedulable_strong get_simple_ko_wp
-                    maybe_donate_sc_ct_ready_if_schedulable_two
-                    thread_get_wp')
+                    maybe_donate_sc_ct_ready_if_schedulable_two hoare_drop_imp
+                    thread_get_wp' get_tcb_obj_ref_wp hoare_vcg_all_lift)
   done
 
 lemma handle_recv_ct_ready_if_schedulable[wp]:

--- a/proof/invariant-abstract/IpcDet_AI.thy
+++ b/proof/invariant-abstract/IpcDet_AI.thy
@@ -2523,6 +2523,7 @@ lemma rai_invs':
   assumes schedule_tcb_Q[wp]: "\<And>t. \<lbrace>Q\<rbrace> schedule_tcb t \<lbrace>\<lambda>_. Q\<rbrace>"
   assumes maybe_return_sc[wp]: "\<And>ntfn t. \<lbrace>Q\<rbrace> maybe_return_sc ntfn t \<lbrace>\<lambda>_. Q\<rbrace>"
   assumes maybe_donate_sc[wp]: "\<And>t ntfn. \<lbrace>Q\<rbrace> maybe_donate_sc t ntfn \<lbrace>\<lambda>_. Q\<rbrace>"
+  assumes refill_unblock_check[wp]: "\<And>scp. \<lbrace>Q\<rbrace> refill_unblock_check scp \<lbrace>\<lambda>_. Q\<rbrace>"
   shows
   "\<lbrace>invs and Q and st_tcb_at active t and ex_nonz_cap_to t
          and (\<lambda>s. \<forall>r\<in>zobj_refs cap. ex_nonz_cap_to r s)
@@ -2585,7 +2586,7 @@ lemma rai_invs':
     apply (fastforce simp: idle_no_ex_cap obj_at_def st_tcb_at_def get_refs_def2
                     dest!: sym_refs_ko_atD bspec)
    apply (wpsimp simp: do_nbrecv_failed_transfer_def wp: valid_irq_node_typ)
-  apply wpsimp
+  apply (wpsimp simp: if_cond_refill_unblock_check_def wp: hoare_vcg_all_lift hoare_drop_imp)
     apply (wpsimp simp: invs_def valid_state_def valid_pspace_def wp: valid_ioports_lift)
    apply (wpsimp simp: valid_ntfn_def tcb_at_typ wp: static_imp_wp valid_irq_node_typ valid_ioports_lift)
   apply (fastforce simp: invs_def valid_state_def valid_pspace_def state_refs_of_def valid_obj_def

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -469,7 +469,9 @@ lemma do_reply_invs[wp]:
                                  get_simple_ko_wp thread_get_fault_wp
                                  hoare_vcg_all_lift
                            simp: ran_tcb_cap_cases)+
-        apply (simp flip: cases_imp_eq imp_conjL not_None_eq)
+          apply (simp flip: cases_imp_eq imp_conjL not_None_eq)
+          apply (wpsimp wp: hoare_drop_imps)
+         apply wpsimp
         apply (wpsimp wp: hoare_drop_imps reply_remove_invs)
        apply (clarsimp cong: conj_cong)
        apply (wpsimp wp: gts_wp get_simple_ko_wp)+

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -3460,15 +3460,28 @@ lemma sendSignal_corres:
               apply (rule corres_split_deprecated[OF _ asUser_setRegister_corres])
                 apply (rule corres_split_deprecated[OF _ maybeDonateSc_corres])
                   apply (rule corres_split_deprecated[OF _ isSchedulable_corres])
-                    apply (rule corres_when, simp)
-                    apply (rule possibleSwitchTo_corres; (solves simp)?)
-                   apply ((wpsimp wp: hoare_drop_imp)+)[2]
-                 apply (clarsimp simp: pred_conj_def, strengthen valid_objs_valid_tcbs)
-                 apply (wpsimp wp: maybe_donate_sc_valid_sched_action abs_typ_at_lifts)
-                apply (clarsimp simp: pred_conj_def, strengthen valid_objs'_valid_tcbs')
-                apply (wpsimp+)[3]
-             apply (clarsimp simp: thread_state_relation_def)
-            apply (simp add: pred_conj_def)
+                    apply (rule corres_split[OF corres_when], simp)
+                       apply (rule possibleSwitchTo_corres; (solves simp)?)
+                      apply (rule corres_split_eqr[OF _ get_tcb_obj_ref_corres])
+                         apply (rule ifCondRefillUnblockCheck_corres)
+                        apply (clarsimp simp: tcb_relation_def)
+                       apply (wpsimp wp: get_tcb_obj_ref_wp)
+                      apply (wpsimp wp: threadGet_wp)
+                     apply (rule_tac Q="\<lambda>_. tcb_at a and active_sc_valid_refills and pspace_aligned
+                                            and pspace_distinct and valid_objs"
+                            in hoare_strengthen_post[rotated])
+                      apply (clarsimp, drule (1) valid_objs_ko_at)
+                      apply (fastforce simp: valid_tcb_def obj_at_def is_sc_obj opt_map_def valid_obj_def
+                                      split: option.split)
+                     apply wpsimp
+                    apply (rule_tac Q="\<lambda>_. tcb_at' a and valid_objs'" in hoare_strengthen_post[rotated])
+                     apply (clarsimp simp: obj_at'_def split: option.split)
+                    apply wpsimp
+                   apply (wpsimp wp: is_schedulable_wp)
+                  apply (wpsimp wp: isSchedulable_wp)
+                 apply (wpsimp wp: hoare_drop_imp maybe_donate_sc_valid_sched_action abs_typ_at_lifts
+                      | strengthen valid_objs_valid_tcbs)+
+                apply(wpsimp wp: hoare_drop_imp | strengthen valid_objs'_valid_tcbs')+
             apply (strengthen valid_sched_action_weak_valid_sched_action)
             apply (wpsimp wp: sts_cancel_ipc_Running_invs set_thread_state_valid_sched_action
                               set_thread_state_valid_ready_qs
@@ -3530,15 +3543,28 @@ lemma sendSignal_corres:
            apply (rule corres_split_deprecated [OF _ asUser_setRegister_corres])
              apply (rule corres_split_deprecated[OF _ maybeDonateSc_corres])
                apply (rule corres_split_deprecated[OF _ isSchedulable_corres])
-                 apply (rule corres_when, simp)
-                 apply (rule possibleSwitchTo_corres; (solves simp)?)
-                apply ((wpsimp wp: hoare_drop_imp)+)[2]
-              apply (clarsimp simp: pred_conj_def, strengthen valid_objs_valid_tcbs)
-              apply (wpsimp wp: maybe_donate_sc_valid_sched_action abs_typ_at_lifts)
-             apply (clarsimp simp: pred_conj_def, strengthen valid_objs'_valid_tcbs')
-             apply (wpsimp+)[3]
-          apply (clarsimp simp: thread_state_relation_def)
-         apply (simp add: pred_conj_def)
+                 apply (rule corres_split[OF corres_when], simp)
+                    apply (rule possibleSwitchTo_corres; (solves simp)?)
+                   apply (rule corres_split_eqr[OF _ get_tcb_obj_ref_corres])
+                      apply (rule ifCondRefillUnblockCheck_corres)
+                     apply (clarsimp simp: tcb_relation_def)
+                    apply (wpsimp wp: get_tcb_obj_ref_wp)
+                   apply (wpsimp wp: threadGet_wp)
+                  apply (rule_tac Q="\<lambda>_. tcb_at (hd list) and active_sc_valid_refills and pspace_aligned
+                                         and pspace_distinct and valid_objs"
+                         in hoare_strengthen_post[rotated])
+                   apply (clarsimp, drule (1) valid_objs_ko_at)
+                   apply (fastforce simp: valid_tcb_def obj_at_def is_sc_obj opt_map_def valid_obj_def
+                                   split: option.split)
+                  apply wpsimp
+                 apply (rule_tac Q="\<lambda>_. tcb_at' (hd list) and valid_objs'" in hoare_strengthen_post[rotated])
+                  apply (clarsimp simp: obj_at'_def split: option.split)
+                 apply wpsimp
+                apply (wpsimp wp: is_schedulable_wp)
+               apply (wpsimp wp: isSchedulable_wp)
+              apply (wpsimp wp: hoare_drop_imp maybe_donate_sc_valid_sched_action abs_typ_at_lifts
+                   | strengthen valid_objs_valid_tcbs)+
+             apply(wpsimp wp: hoare_drop_imp | strengthen valid_objs'_valid_tcbs')+
          apply (strengthen valid_sched_action_weak_valid_sched_action)
          apply (wpsimp simp: invs_def valid_state_def valid_pspace_def
                          wp: sts_valid_replies sts_only_idle sts_fault_tcbs_valid_states

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -5070,12 +5070,27 @@ lemma receiveSignal_corres:
     apply (clarsimp simp: badge_register_def badgeRegister_def)
     apply (rule corres_split_deprecated[OF _ asUser_setRegister_corres])
       apply (rule corres_split_deprecated[OF _ setNotification_corres])
-         apply (rule maybeDonateSc_corres)
+         apply (rule corres_split[OF maybeDonateSc_corres])
+              apply (rule corres_split_eqr[OF _ get_tcb_obj_ref_corres])
+                 apply (rule ifCondRefillUnblockCheck_corres)
+             apply (clarsimp simp: tcb_relation_def)
+            apply (wpsimp wp: get_tcb_obj_ref_wp)
+           apply (wpsimp wp: threadGet_wp)
+          apply (rule_tac Q="\<lambda>_. tcb_at thread and active_sc_valid_refills and pspace_distinct
+                                 and pspace_aligned and valid_objs"
+                 in hoare_strengthen_post[rotated])
+           apply (clarsimp simp: obj_at_def is_tcb)
+           apply (erule (1) valid_objsE)
+           apply (fastforce simp: valid_obj_def valid_tcb_def obj_at_def opt_map_def is_sc_obj
+                           split: option.splits)
+          apply (wpsimp wp: abs_typ_at_lifts)
+         apply (rule_tac Q="\<lambda>_. tcb_at' thread and valid_objs'" in hoare_strengthen_post[rotated])
+          apply (clarsimp simp: obj_at'_def projectKOs split: option.split)
+         apply wpsimp
         apply (clarsimp simp: ntfn_relation_def)
        apply (wpsimp wp: set_ntfn_minor_invs)
       apply (wpsimp wp: set_ntfn_minor_invs')
-     apply (wpsimp wp: hoare_vcg_imp_lift'
-                 simp: valid_ntfn_def)
+     apply (wpsimp wp: hoare_vcg_imp_lift' simp: valid_ntfn_def)
     apply (wpsimp wp: hoare_vcg_imp_lift')
    apply (clarsimp simp: invs_def valid_state_def valid_pspace_def)
    apply (clarsimp simp: obj_at_def live_def live_ntfn_def valid_ntfn_def)

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -6378,75 +6378,77 @@ lemma doReplyTransfer_corres:
       apply (rule stronger_corres_guard_imp)
         apply (rule corres_assert_assume_l)
         apply (rule corres_split [OF replyRemove_corres], (rule refl)+)
-          apply (rule corres_split [OF threadget_fault_corres])
-            apply (rule corres_split)
-               apply (rule_tac P="tcb_at sender and tcb_at recvr and valid_objs and pspace_aligned and
-                                  valid_list and pspace_distinct and valid_mdb and cur_tcb
-                                  and current_time_bounded 2" and
-                               P'="tcb_at' sender and tcb_at' recvr and valid_pspace' and cur_tcb' and
-                                   valid_release_queue and valid_release_queue'"
-                      in corres_guard_imp)
-                 apply (simp add: fault_rel_optionation_def)
-                 apply (rule corres_option_split; simp)
-                  apply (rule corres_split [OF doIPCTransfer_corres setThreadState_corres])
-                    apply (clarsimp simp: thread_state_relation_def)
-                   prefer 3
-                   apply (rule corres_split_mapr [OF _ getMessageInfo_corres])
-                     apply (rule corres_split_eqr [OF _ lookupIPCBuffer_corres'])
-                       apply (rule corres_split_eqr [OF _ getMRs_corres])
-                          apply (simp (no_asm) del: dc_simp)
-                          apply (rule corres_split_eqr [OF _ handleFaultReply_corres])
-                             apply (rule corres_split [OF threadset_corresT setThreadState_corres])
-                                  apply (clarsimp simp: tcb_relation_def fault_rel_optionation_def)
-                                 apply (clarsimp simp: tcb_cap_cases_def)
-                                apply (clarsimp simp: tcb_cte_cases_def)
-                               apply (clarsimp simp: thread_state_relation_def split: if_split)
-                              (* solving hoare_triples *)
-                              apply (clarsimp simp: valid_tcb_state_def)
-                              apply (rule_tac Q="\<lambda>_. valid_objs and pspace_aligned and
-                                                     pspace_distinct and tcb_at recvr
-                                                     and current_time_bounded 2" in
-                                      hoare_strengthen_post[rotated])
-                               apply (clarsimp simp: valid_objs_valid_tcbs)
-                              apply (wpsimp wp: thread_set_fault_valid_objs)
-                             apply (wpsimp wp: threadSet_valid_tcbs' threadSet_valid_release_queue_inv
-                                               threadSet_valid_release_queue'_inv)
-                            apply simp
-                           apply (clarsimp simp: pred_conj_def cong: conj_cong)
-                           apply wpsimp+
-                          apply (strengthen valid_objs'_valid_tcbs')
-                          apply wpsimp+
-                  apply (strengthen valid_objs_valid_tcbs)
-                  apply wpsimp+
-                 apply (strengthen valid_objs'_valid_tcbs')
-                 apply wpsimp
-                apply (clarsimp split: option.splits)
-               apply (clarsimp split: option.splits simp: valid_pspace'_def)
-              apply (clarsimp simp: isRunnable_def get_tcb_obj_ref_def)
-              (* solve remaining corres goals *)
-              apply (rule corres_split [OF getThreadState_corres])
-                apply (rule corres_split [OF threadGet_corres[where r="(=)"]])
-                   apply (simp add: tcb_relation_def)
-                  apply (rename_tac scopt scopt')
-                  apply (rule corres_when)
-                   apply (case_tac state; simp add: thread_state_relation_def)
-                  apply (rule corres_assert_opt_assume_l)
-                  apply (rule_tac Q="valid_sched_action and tcb_at recvr
-                                     and sc_tcb_sc_at (\<lambda>a. a \<noteq> None) (the scopt) and
-                                     active_sc_at (the scopt) and valid_refills (the scopt) and
-                                     valid_release_q and active_sc_valid_refills and
-                                     (\<lambda>s. sc_tcb_sc_at (\<lambda>sc. \<exists>t. sc = Some t \<and> not_queued t s) (the scopt) s) and
-                                     invs and valid_list and scheduler_act_not recvr
-                                     and current_time_bounded 2 and st_tcb_at active recvr"
-                              and Q'="invs' and tcb_at' recvr and sc_at' (the scopt) and cur_tcb'"
-                              and P'="invs' and sc_at' (the scopt') and tcb_at' recvr and cur_tcb'"
-                              and P="valid_sched_action and tcb_at recvr and current_time_bounded 2 and
-                                     sc_tcb_sc_at (\<lambda>a. a \<noteq> None) (the scopt) and
-                                     active_sc_at (the scopt) and valid_refills (the scopt) and
-                                     valid_release_q and active_sc_valid_refills and
-                                     (\<lambda>s. sc_tcb_sc_at (\<lambda>sc. \<exists>t. sc = Some t \<and> not_queued t s) (the scopt) s) and
-                                     invs and valid_list and scheduler_act_not recvr and st_tcb_at active recvr"
-                         in stronger_corres_guard_imp)
+          apply (rule corres_split_eqr [OF _ get_tcb_obj_ref_corres])
+             apply (rule corres_split [OF ifCondRefillUnblockCheck_corres])
+               apply (rule corres_split [OF threadget_fault_corres])
+                 apply (rule corres_split)
+                    apply (rule_tac P="tcb_at sender and tcb_at recvr and valid_objs and pspace_aligned and
+                                       valid_list and pspace_distinct and valid_mdb and cur_tcb
+                                       and current_time_bounded 2" and
+                                    P'="tcb_at' sender and tcb_at' recvr and valid_pspace' and cur_tcb' and
+                                        valid_release_queue and valid_release_queue'"
+                           in corres_guard_imp)
+                      apply (simp add: fault_rel_optionation_def)
+                      apply (rule corres_option_split; simp)
+                       apply (rule corres_split [OF doIPCTransfer_corres setThreadState_corres])
+                         apply (clarsimp simp: thread_state_relation_def)
+                        prefer 3
+                        apply (rule corres_split_mapr [OF _ getMessageInfo_corres])
+                          apply (rule corres_split_eqr [OF _ lookupIPCBuffer_corres'])
+                            apply (rule corres_split_eqr [OF _ getMRs_corres])
+                               apply (simp (no_asm) del: dc_simp)
+                               apply (rule corres_split_eqr [OF _ handleFaultReply_corres])
+                                  apply (rule corres_split [OF threadset_corresT setThreadState_corres])
+                                       apply (clarsimp simp: tcb_relation_def fault_rel_optionation_def)
+                                      apply (clarsimp simp: tcb_cap_cases_def)
+                                     apply (clarsimp simp: tcb_cte_cases_def)
+                                    apply (clarsimp simp: thread_state_relation_def split: if_split)
+                                   (* solving hoare_triples *)
+                                   apply (clarsimp simp: valid_tcb_state_def)
+                                   apply (rule_tac Q="\<lambda>_. valid_objs and pspace_aligned and
+                                                          pspace_distinct and tcb_at recvr
+                                                          and current_time_bounded 2" in
+                                           hoare_strengthen_post[rotated])
+                                    apply (clarsimp simp: valid_objs_valid_tcbs)
+                                   apply (wpsimp wp: thread_set_fault_valid_objs)
+                                  apply (wpsimp wp: threadSet_valid_tcbs' threadSet_valid_release_queue_inv
+                                                    threadSet_valid_release_queue'_inv)
+                                 apply simp
+                                apply (clarsimp simp: pred_conj_def cong: conj_cong)
+                                apply wpsimp+
+                               apply (strengthen valid_objs'_valid_tcbs')
+                               apply wpsimp+
+                       apply (strengthen valid_objs_valid_tcbs)
+                       apply wpsimp+
+                      apply (strengthen valid_objs'_valid_tcbs')
+                      apply wpsimp
+                     apply (clarsimp split: option.splits)
+                    apply (clarsimp split: option.splits simp: valid_pspace'_def)
+                   apply (clarsimp simp: isRunnable_def get_tcb_obj_ref_def)
+                   (* solve remaining corres goals *)
+                   apply (rule corres_split [OF getThreadState_corres])
+                     apply (rule corres_split [OF threadGet_corres[where r="(=)"]])
+                        apply (simp add: tcb_relation_def)
+                       apply (rename_tac scopt scopt')
+                       apply (rule corres_when)
+                        apply (case_tac state; simp add: thread_state_relation_def)
+                       apply (rule corres_assert_opt_assume_l)
+                       apply (rule_tac Q="valid_sched_action and tcb_at recvr
+                                          and sc_tcb_sc_at (\<lambda>a. a \<noteq> None) (the scopt) and
+                                          active_sc_at (the scopt) and valid_refills (the scopt) and
+                                          valid_release_q and active_sc_valid_refills and
+                                          (\<lambda>s. sc_tcb_sc_at (\<lambda>sc. \<exists>t. sc = Some t \<and> not_queued t s) (the scopt) s) and
+                                          invs and valid_list and scheduler_act_not recvr
+                                          and current_time_bounded 2 and st_tcb_at active recvr"
+                                   and Q'="invs' and tcb_at' recvr and sc_at' (the scopt) and cur_tcb'"
+                                   and P'="invs' and sc_at' (the scopt') and tcb_at' recvr and cur_tcb'"
+                                   and P="valid_sched_action and tcb_at recvr and current_time_bounded 2 and
+                                          sc_tcb_sc_at (\<lambda>a. a \<noteq> None) (the scopt) and
+                                          active_sc_at (the scopt) and valid_refills (the scopt) and
+                                          valid_release_q and active_sc_valid_refills and
+                                          (\<lambda>s. sc_tcb_sc_at (\<lambda>sc. \<exists>t. sc = Some t \<and> not_queued t s) (the scopt) s) and
+                                          invs and valid_list and scheduler_act_not recvr and st_tcb_at active recvr"
+                              in stronger_corres_guard_imp)
 
                     (* this next section by somewhat complicated symbolic executions *)
                     apply (rule corres_symb_exec_l [OF _ _ get_sched_context_sp], rename_tac sc)
@@ -6488,133 +6490,151 @@ lemma doReplyTransfer_corres:
                                             apply (clarsimp simp: invs'_def valid_pspace'_def)
                                             apply (auto simp: is_timeout_fault_def fault_map_def split: ExceptionTypes_A.fault.splits)[1]
 
-                                           (* solve final hoare triple goals *)
-                                           apply wpsimp
-                                          apply wpsimp
-                                         apply (wpsimp wp: hoare_drop_imp simp: isValidTimeoutHandler_def)
-                                        apply (wpsimp simp: isValidTimeoutHandler_def)
-                                       apply (clarsimp split: if_split simp: valid_fault_def invs_def valid_state_def valid_pspace_def)
-                                       apply (clarsimp simp: tcb_cnode_map_def obj_at_def TCB_cte_wp_at_obj_at)
-                                      apply (clarsimp simp: obj_at_def)
-                                      apply (frule (1) pspace_relation_absD[OF _ state_relation_pspace_relation])
-                                      apply (clarsimp simp: other_obj_relation_def obj_at'_def projectKOs tcb_relation_def)
-                                      apply (case_tac "cteCap (tcbTimeoutHandler ko)";
-                                             case_tac "tcb_timeout_handler tcb"; simp)
-                                     apply (wpsimp simp: tcb_at_def)
-                                    apply (wpsimp simp: tcb_at_def)
-                                   apply (assumption)
-                                  apply clarsimp
-                                  apply (subgoal_tac "invs' s \<and> tcb_at' recvr s \<and> cur_tcb' s
-                                                      \<and> obj_at' (\<lambda>sc'. sc_badge sc = scBadge sc') (the scopt') s")
-                                   apply (clarsimp simp: obj_at'_def)
-                                  apply (assumption)
-                                 apply (clarsimp simp: obj_at'_def)
-                                apply wpsimp
-                               apply wpsimp
+                                                (* solve final hoare triple goals *)
+                                                apply wpsimp
+                                               apply wpsimp
+                                              apply (wpsimp wp: hoare_drop_imp simp: isValidTimeoutHandler_def)
+                                             apply (wpsimp simp: isValidTimeoutHandler_def)
+                                            apply (clarsimp split: if_split simp: valid_fault_def invs_def valid_state_def valid_pspace_def)
+                                            apply (clarsimp simp: tcb_cnode_map_def obj_at_def TCB_cte_wp_at_obj_at)
+                                           apply (clarsimp simp: obj_at_def)
+                                           apply (frule (1) pspace_relation_absD[OF _ state_relation_pspace_relation])
+                                           apply (clarsimp simp: other_obj_relation_def obj_at'_def projectKOs tcb_relation_def)
+                                           apply (case_tac "cteCap (tcbTimeoutHandler ko)";
+                                                  case_tac "tcb_timeout_handler tcb"; simp)
+                                          apply (wpsimp simp: tcb_at_def)
+                                         apply (wpsimp simp: tcb_at_def)
+                                        apply (assumption)
+                                       apply clarsimp
+                                       apply (subgoal_tac "invs' s \<and> tcb_at' recvr s \<and> cur_tcb' s
+                                                           \<and> obj_at' (\<lambda>sc'. sc_badge sc = scBadge sc') (the scopt') s")
+                                        apply (clarsimp simp: obj_at'_def)
+                                       apply (assumption)
+                                      apply (clarsimp simp: obj_at'_def)
+                                     apply wpsimp
+                                    apply wpsimp
 
-                              apply (clarsimp simp: invs_def valid_state_def valid_pspace_def active_sc_at_equiv
-                                             split: if_split)
-                             apply (clarsimp simp: invs_def valid_state_def valid_pspace_def invs'_def
-                                                   valid_pspace'_def
-                                            split: if_split)
-                             apply (frule (1) valid_objs_ko_at, clarsimp simp: valid_obj_def)
-                             apply (clarsimp simp: obj_at_def)
-                             apply (frule (1) pspace_relation_absD[OF _ state_relation_pspace_relation])
-                             apply (clarsimp simp: other_obj_relation_def obj_at'_def projectKOs sc_relation_def)
-                            apply (clarsimp simp: invs_def valid_state_def valid_pspace_def invs'_def valid_pspace'_def)
-                            apply (frule (1) valid_objs_ko_at, clarsimp simp: valid_obj_def)
-                            apply (prop_tac "sc_relation sc n ko")
-                             apply (clarsimp simp: obj_at_def)
-                             apply (frule (1) pspace_relation_absD[OF _ state_relation_pspace_relation])
-                             apply (clarsimp simp: other_obj_relation_def obj_at'_def projectKOs )
-                            apply (frule (1) sc_ko_at_valid_objs_valid_sc', clarsimp)
-                            apply (subgoal_tac "0 < scRefillMax ko")
-                             apply (subgoal_tac "sc_valid_refills sc")
-                              apply (prop_tac "koa=ko", erule (1) ko_at'_inj, simp only:)
-                              apply (subgoal_tac "sc_valid_refills' ko")
-                               apply (simp add: sc_refill_ready_relation sc_refill_sufficient_relation state_relation_def active_sc_at_equiv)
-                              apply (metis valid_sched_context'_def sc_valid_refills_scRefillCount)
-                             apply (subst (asm) active_sc_at_equiv)
-                             apply (frule (1) active_sc_valid_refillsE)
-                             apply (clarsimp simp: valid_refills_def2 obj_at_def)
-                            apply (clarsimp simp: obj_at_def vs_all_heap_simps active_sc_def
-                                                  sc_relation_def)
-                           apply wpsimp
-                          apply (wpsimp simp: refillSufficient_def getRefills_def obj_at'_def)
-                         apply (wpsimp simp: refillReady_wp)
-                        apply (simp add: refillReady_def, rule no_ofail_gets_the)
-                        apply wpsimp
-                       apply wpsimp
-                      apply (clarsimp simp: obj_at_def sc_at_pred_n_def get_sched_context_exs_valid)
-                     apply (rule get_sched_context_exs_valid)
-                     apply (clarsimp simp: sc_at_pred_n_def obj_at_def)
-                    apply ((wpsimp simp: obj_at_def is_sc_obj_def
-                           | clarsimp split: Structures_A.kernel_object.splits)+)[1]
-                   apply simp
-                  apply clarsimp
-                 apply (wpsimp wp: thread_get_wp')
-                apply (wpsimp wp: threadGet_wp)
-               apply (wpsimp wp: gts_wp)
-              apply (wpsimp wp: gts_wp')
-             apply (rule_tac Q="\<lambda>_. tcb_at recvr and valid_sched_action and invs and valid_list
-                                    and valid_release_q and scheduler_act_not recvr
-                                    and active_sc_valid_refills and current_time_bounded 2
-                                    and active_if_bound_sc_tcb_at recvr
-                                    and not_queued recvr"
-                    in hoare_strengthen_post[rotated])
-              apply (clarsimp simp: obj_at_def is_tcb)
-              apply (subgoal_tac "pred_map (\<lambda>a. a = Some y) (tcb_scps_of s) recvr")
-               apply (subgoal_tac "pred_map (\<lambda>a. a = Some recvr) (sc_tcbs_of s) y")
-                apply (intro conjI)
-                    apply (clarsimp simp: vs_all_heap_simps sc_at_kh_simps)
+                                   apply (clarsimp simp: invs_def valid_state_def valid_pspace_def active_sc_at_equiv
+                                                  split: if_split)
+                                  apply (clarsimp simp: invs_def valid_state_def valid_pspace_def invs'_def
+                                                        valid_pspace'_def
+                                                 split: if_split)
+                                  apply (frule (1) valid_objs_ko_at, clarsimp simp: valid_obj_def)
+                                  apply (clarsimp simp: obj_at_def)
+                                  apply (frule (1) pspace_relation_absD[OF _ state_relation_pspace_relation])
+                                  apply (clarsimp simp: other_obj_relation_def obj_at'_def projectKOs sc_relation_def)
+                                 apply (clarsimp simp: invs_def valid_state_def valid_pspace_def invs'_def valid_pspace'_def)
+                                 apply (frule (1) valid_objs_ko_at, clarsimp simp: valid_obj_def)
+                                 apply (prop_tac "sc_relation sc n ko")
+                                  apply (clarsimp simp: obj_at_def)
+                                  apply (frule (1) pspace_relation_absD[OF _ state_relation_pspace_relation])
+                                  apply (clarsimp simp: other_obj_relation_def obj_at'_def projectKOs )
+                                 apply (frule (1) sc_ko_at_valid_objs_valid_sc', clarsimp)
+                                 apply (subgoal_tac "0 < scRefillMax ko")
+                                  apply (subgoal_tac "sc_valid_refills sc")
+                                   apply (prop_tac "koa=ko", erule (1) ko_at'_inj, simp only:)
+                                   apply (subgoal_tac "sc_valid_refills' ko")
+                                    apply (simp add: sc_refill_ready_relation sc_refill_sufficient_relation state_relation_def active_sc_at_equiv)
+                                   apply (metis valid_sched_context'_def sc_valid_refills_scRefillCount)
+                                  apply (subst (asm) active_sc_at_equiv)
+                                  apply (frule (1) active_sc_valid_refillsE)
+                                  apply (clarsimp simp: valid_refills_def2 obj_at_def)
+                                 apply (clarsimp simp: obj_at_def vs_all_heap_simps active_sc_def
+                                                       sc_relation_def)
+                                apply wpsimp
+                               apply (wpsimp simp: refillSufficient_def getRefills_def obj_at'_def)
+                              apply (wpsimp simp: refillReady_wp)
+                             apply (simp add: refillReady_def, rule no_ofail_gets_the)
+                             apply wpsimp
+                            apply wpsimp
+                           apply (clarsimp simp: obj_at_def sc_at_pred_n_def get_sched_context_exs_valid)
+                          apply (rule get_sched_context_exs_valid)
+                          apply (clarsimp simp: sc_at_pred_n_def obj_at_def)
+                         apply ((wpsimp simp: obj_at_def is_sc_obj_def
+                                | clarsimp split: Structures_A.kernel_object.splits)+)[1]
+                        apply simp
+                       apply clarsimp
+                      apply (wpsimp wp: thread_get_wp')
+                     apply (wpsimp wp: threadGet_wp)
+                    apply (wpsimp wp: gts_wp)
+                   apply (wpsimp wp: gts_wp')
+                  apply (rule_tac Q="\<lambda>_. tcb_at recvr and valid_sched_action and invs and valid_list
+                                         and valid_release_q and scheduler_act_not recvr
+                                         and active_sc_valid_refills and current_time_bounded 2
+                                         and active_if_bound_sc_tcb_at recvr
+                                         and not_queued recvr"
+                         in hoare_strengthen_post[rotated])
+                   apply (clarsimp simp: obj_at_def is_tcb)
+                   apply (subgoal_tac "pred_map (\<lambda>a. a = Some y) (tcb_scps_of s) recvr")
+                    apply (subgoal_tac "pred_map (\<lambda>a. a = Some recvr) (sc_tcbs_of s) y")
+                     apply (intro conjI)
+                         apply (clarsimp simp: vs_all_heap_simps sc_at_kh_simps)
+                        apply (clarsimp simp: vs_all_heap_simps)
+                       apply (erule active_sc_valid_refillsE[rotated], clarsimp simp: vs_all_heap_simps)
+                      apply (clarsimp simp: vs_all_heap_simps sc_at_kh_simps)
+                     apply (clarsimp simp: vs_all_heap_simps pred_tcb_at_def obj_at_def runnable_eq)
+                    apply (simp add: sc_at_kh_simps pred_map_eq_normalise heap_refs_inv_def2)
+                    apply (erule heap_refs_retractD[rotated], clarsimp)
                    apply (clarsimp simp: vs_all_heap_simps)
-                  apply (erule active_sc_valid_refillsE[rotated], clarsimp simp: vs_all_heap_simps)
-                 apply (clarsimp simp: vs_all_heap_simps sc_at_kh_simps)
-                apply (clarsimp simp: vs_all_heap_simps pred_tcb_at_def obj_at_def runnable_eq)
-               apply (simp add: sc_at_kh_simps pred_map_eq_normalise heap_refs_inv_def2)
-               apply (erule heap_refs_retractD[rotated], clarsimp)
-              apply (clarsimp simp: vs_all_heap_simps)
-             apply (wpsimp wp: set_thread_state_valid_sched_action set_thread_state_valid_release_q
-                               sts_invs_minor2)
-                 apply (rule_tac Q="\<lambda>_ s.
-                           st_tcb_at inactive recvr s \<and>
-                           invs s \<and> valid_list s \<and> scheduler_act_not recvr s \<and>
-                           ex_nonz_cap_to recvr s \<and> current_time_bounded 2 s \<and>
-                           recvr \<noteq> idle_thread s \<and>
-                           fault_tcb_at ((=) None) recvr s \<and>
-                           valid_release_q s \<and>
-                           active_sc_valid_refills s \<and>
-                           heap_refs_inv (sc_tcbs_of s) (tcb_scps_of s) \<and>
-                           (pred_map_eq None (tcb_scps_of s) recvr \<or> active_sc_tcb_at recvr s) \<and>
-                           not_queued recvr s \<and> not_in_release_q recvr s"
-                        in hoare_strengthen_post[rotated])
-                  apply (clarsimp split: if_split simp: pred_tcb_at_def obj_at_def)
-                 apply (wpsimp wp: thread_set_no_change_tcb_state thread_set_cap_to
-                                   thread_set_no_change_tcb_state
-                                   thread_set_pred_tcb_at_sets_true simp: ran_tcb_cap_cases)
-                apply simp
-                apply (wpsimp wp: hoare_drop_imp)
-               apply wpsimp
-              apply wpsimp
-             apply wpsimp
-            apply (rule_tac Q="\<lambda>_. tcb_at' recvr and invs' and cur_tcb'" in hoare_strengthen_post[rotated])
-             apply (clarsimp simp: tcb_at'_ex_eq_all invs'_def valid_pspace'_def)
-             apply (frule (1) tcb_ko_at_valid_objs_valid_tcb', clarsimp simp: valid_tcb'_def)
-            apply (wpsimp wp: sts_invs')
-             apply (rule_tac Q="\<lambda>_. invs' and ex_nonz_cap_to' recvr and tcb_at' recvr
-                                    and (st_tcb_at' (\<lambda>st. st = Inactive) recvr) and cur_tcb'"
+                  apply (wpsimp wp: set_thread_state_valid_sched_action set_thread_state_valid_release_q
+                                    sts_invs_minor2)
+                      apply (rule_tac Q="\<lambda>_ s.
+                                st_tcb_at inactive recvr s \<and>
+                                invs s \<and> valid_list s \<and> scheduler_act_not recvr s \<and>
+                                ex_nonz_cap_to recvr s \<and> current_time_bounded 2 s \<and>
+                                recvr \<noteq> idle_thread s \<and>
+                                fault_tcb_at ((=) None) recvr s \<and>
+                                valid_release_q s \<and>
+                                active_sc_valid_refills s \<and>
+                                heap_refs_inv (sc_tcbs_of s) (tcb_scps_of s) \<and>
+                                (pred_map_eq None (tcb_scps_of s) recvr \<or> active_sc_tcb_at recvr s) \<and>
+                                not_queued recvr s \<and> not_in_release_q recvr s"
+                             in hoare_strengthen_post[rotated])
+                       apply (clarsimp split: if_split simp: pred_tcb_at_def obj_at_def)
+                      apply (wpsimp wp: thread_set_no_change_tcb_state thread_set_cap_to
+                                        thread_set_no_change_tcb_state
+                                        thread_set_pred_tcb_at_sets_true simp: ran_tcb_cap_cases)
+                     apply simp
+                     apply (wpsimp wp: hoare_drop_imp)
+                    apply wpsimp
+                   apply wpsimp
+                  apply wpsimp
+                 apply (rule_tac Q="\<lambda>_. tcb_at' recvr and invs' and cur_tcb'" in hoare_strengthen_post[rotated])
+                  apply (clarsimp simp: tcb_at'_ex_eq_all invs'_def valid_pspace'_def)
+                  apply (frule (1) tcb_ko_at_valid_objs_valid_tcb', clarsimp simp: valid_tcb'_def)
+                 apply (wpsimp wp: sts_invs')
+                  apply (rule_tac Q="\<lambda>_. invs' and ex_nonz_cap_to' recvr and tcb_at' recvr
+                                         and (st_tcb_at' (\<lambda>st. st = Inactive) recvr) and cur_tcb'"
+                         in hoare_strengthen_post[rotated])
+                   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs)
+                  apply wpsimp
+                 apply (wpsimp wp: sts_invs')
+                     apply (rule_tac Q="\<lambda>_. invs' and sch_act_not recvr and ex_nonz_cap_to' recvr and tcb_at' recvr
+                                            and (st_tcb_at' (\<lambda>st. st = Inactive) recvr) and cur_tcb'"
+                            in hoare_strengthen_post[rotated])
+                      apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs)
+                      apply (fastforce dest: global'_no_ex_cap simp: invs'_def split: if_split)
+                     apply (wpsimp wp: threadSet_fault_invs' threadSet_pred_tcb_no_state threadSet_cur)
+                    apply wpsimp+
+                apply (wpsimp wp: thread_get_wp')
+               apply (wpsimp wp: threadGet_wp)
+              apply (rule_tac Q="\<lambda>_. tcb_at sender and tcb_at recvr and invs and valid_list and
+                        valid_sched and scheduler_act_not recvr and not_in_release_q recvr and
+                        active_if_bound_sc_tcb_at recvr and st_tcb_at inactive recvr and
+                        ex_nonz_cap_to recvr and not_queued recvr and current_time_bounded 2"
+                     in hoare_strengthen_post[rotated])
+               apply (clarsimp simp: valid_sched_def invs_def valid_state_def valid_pspace_def
+                                     pred_tcb_at_def obj_at_def
+                              dest!: idle_no_ex_cap)
+              apply (wpsimp wp: refill_unblock_check_valid_sched
+                          simp: if_cond_refill_unblock_check_def)
+             apply (rule_tac Q="\<lambda>_. tcb_at' recvr and invs' and cur_tcb' and tcb_at' sender
+             and ex_nonz_cap_to' recvr and sch_act_not recvr and st_tcb_at' ((=) Inactive) recvr"
                     in hoare_strengthen_post[rotated])
-              apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs)
+              apply (clarsimp simp: op_equal invs'_def obj_at'_def)
              apply wpsimp
-            apply (wpsimp wp: sts_invs')
-                apply (rule_tac Q="\<lambda>_. invs' and sch_act_not recvr and ex_nonz_cap_to' recvr and tcb_at' recvr
-                                       and (st_tcb_at' (\<lambda>st. st = Inactive) recvr) and cur_tcb'"
-                       in hoare_strengthen_post[rotated])
-                 apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs)
-                 apply (fastforce dest: global'_no_ex_cap simp: invs'_def split: if_split)
-                apply (wpsimp wp: threadSet_fault_invs' threadSet_pred_tcb_no_state threadSet_cur)
-               apply wpsimp+
-           apply (wpsimp wp: thread_get_wp')
+            apply (clarsimp simp: tcb_relation_def)
+           apply (wpsimp wp: get_tcb_obj_ref_wp)
           apply (wpsimp wp: threadGet_wp)
          apply (rule_tac Q="\<lambda>_. tcb_at sender and tcb_at recvr and invs and valid_list and
                    valid_sched and scheduler_act_not recvr and not_in_release_q recvr and
@@ -6622,13 +6642,21 @@ lemma doReplyTransfer_corres:
                    ex_nonz_cap_to recvr and not_queued recvr and current_time_bounded 2"
                 in hoare_strengthen_post[rotated])
           apply (clarsimp simp: valid_sched_def invs_def valid_state_def valid_pspace_def
-                                pred_tcb_at_def obj_at_def
                          dest!: idle_no_ex_cap)
+          apply (erule disjE; clarsimp simp: vs_all_heap_simps obj_at_def is_sc_obj opt_map_red)
+          apply (rule conjI)
+           apply (erule (1) valid_sched_context_size_objsI)
+          apply (clarsimp split: if_split)
+          apply (drule sym_refs_inv_tcb_scps, rename_tac scp sc n t tcb')
+          apply (prop_tac "heap_ref_eq scp t (tcb_scps_of s) \<and> heap_ref_eq scp recvr (tcb_scps_of s)")
+           apply (clarsimp simp: vs_all_heap_simps)
+          apply (clarsimp simp: heap_refs_inv_def2 vs_all_heap_simps)
+
          apply (wpsimp wp: reply_remove_valid_sched reply_remove_active_if_bound_sc_tcb_at reply_remove_invs)
         apply (rule_tac Q="\<lambda>_. tcb_at' sender and invs' and sch_act_not recvr and ex_nonz_cap_to' recvr and tcb_at' recvr
                                and st_tcb_at' (\<lambda>a. a = Structures_H.thread_state.Inactive) recvr and cur_tcb'"
                in hoare_strengthen_post[rotated])
-         apply (clarsimp simp: obj_at'_def invs'_def valid_pspace'_def)
+         apply (clarsimp simp: obj_at'_def invs'_def valid_pspace'_def op_equal split: option.split)
         apply (wpsimp simp: valid_pspace'_def wp: replyRemove_invs')
        apply (clarsimp simp: invs_def valid_state_def valid_pspace_def valid_sched_def
                              valid_sched_action_weak_valid_sched_action

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -3916,7 +3916,7 @@ lemma refillHeadOverlappingLoop_corres:
   apply (fastforce intro!: mergeRefills_terminates)
   done
 
-lemma refillUnblockCheck_corres':
+lemma refillUnblockCheck_corres:
   "corres dc
      (sc_at scp and pspace_aligned and pspace_distinct
       and (\<lambda>s. ((\<lambda>sc. 0 < length (sc_refills sc)) |< scs_of2 s) scp))
@@ -3962,7 +3962,7 @@ lemma ifCondRefillUnblockCheck_corres:
        apply (clarsimp simp: active_sc_def sc_relation_def case_bool_if option.case_eq_if)
       apply (rule corres_when)
        apply fastforce
-      apply (rule refillUnblockCheck_corres')
+      apply (rule refillUnblockCheck_corres)
      apply wpsimp+
    apply (drule_tac scp=scp in active_sc_valid_refillsE[rotated, simplified is_active_sc_rewrite];
           clarsimp simp: case_bool_if option.case_eq_if opt_map_red obj_at_def is_active_sc2_def

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -768,6 +768,10 @@ lemma handleTimeout_invs':
 crunches isValidTimeoutHandler
   for inv[wp]: P
 
+crunches ifCondRefillUnblockCheck
+  for sch_act_simple[wp]: sch_act_simple
+  (simp: crunch_simps sch_act_simple_def)
+
 lemma doReplyTransfer_invs'[wp]:
   "\<lbrace>invs' and tcb_at' sender and reply_at' replyPtr and sch_act_simple\<rbrace>
    doReplyTransfer sender replyPtr grant
@@ -788,6 +792,9 @@ lemma doReplyTransfer_invs'[wp]:
    apply (fastforce intro: if_live_then_nonz_capE'
                      simp: ko_wp_at'_def obj_at'_def projectKOs isReply_def)
   apply simp
+  apply (rule hoare_seq_ext[OF _ threadGet_sp])
+  apply (rule_tac B="\<lambda>_. ?pre and st_tcb_at' ((=) Inactive) receiver and tcb_at' receiver and ex_nonz_cap_to' receiver"
+         in hoare_seq_ext[rotated], wpsimp)
   apply (rule hoare_seq_ext[OF _ threadGet_sp], rename_tac fault)
   apply (rule_tac B="\<lambda>_. ?pre and tcb_at' receiver and ex_nonz_cap_to' receiver"
          in hoare_seq_ext)

--- a/spec/abstract/Ipc_A.thy
+++ b/spec/abstract/Ipc_A.thy
@@ -454,7 +454,9 @@ where
      as_user dest $ setRegister badge_register badge;
      maybe_donate_sc dest ntfnptr;
      schedulable <- is_schedulable dest;
-     when (schedulable) $ possible_switch_to dest
+     when schedulable $ possible_switch_to dest;
+     scopt \<leftarrow> get_tcb_obj_ref tcb_sched_context dest;
+     if_sporadic_active_cur_sc_assert_refill_unblock_check scopt
    od"
 
 text \<open>Handle a message send operation performed on a notification object.
@@ -484,7 +486,9 @@ where
                       as_user tcb $ setRegister badge_register badge;
                       maybe_donate_sc tcb ntfnptr;
                       schedulable <- is_schedulable tcb;
-                      when (schedulable) $ possible_switch_to tcb
+                      when schedulable $ possible_switch_to tcb;
+                      scopt \<leftarrow> get_tcb_obj_ref tcb_sched_context tcb;
+                      if_sporadic_active_cur_sc_assert_refill_unblock_check scopt
                     od
                   else set_notification ntfnptr $ ntfn_obj_update (K (ActiveNtfn badge)) ntfn
             od

--- a/spec/abstract/Ipc_A.thy
+++ b/spec/abstract/Ipc_A.thy
@@ -599,6 +599,8 @@ where
         BlockedOnReply r \<Rightarrow> do
           assert (r = reply);
           reply_remove receiver reply;
+          sc_opt \<leftarrow> get_tcb_obj_ref tcb_sched_context receiver;
+          if_sporadic_active_cur_sc_test_refill_unblock_check sc_opt;
           fault \<leftarrow> thread_get tcb_fault receiver;
           case fault of
             None \<Rightarrow> do

--- a/spec/abstract/Ipc_A.thy
+++ b/spec/abstract/Ipc_A.thy
@@ -528,7 +528,9 @@ where
        | ActiveNtfn badge \<Rightarrow> do
                      as_user thread $ setRegister badge_register badge;
                      set_notification ntfnptr $ ntfn_obj_update (K IdleNtfn) ntfn;
-                     maybe_donate_sc thread ntfnptr
+                     maybe_donate_sc thread ntfnptr;
+                     sc_ptr \<leftarrow> get_tcb_obj_ref tcb_sched_context thread;
+                     if_sporadic_cur_sc_test_refill_unblock_check sc_ptr
                    od
     od"
 

--- a/spec/haskell/src/SEL4/Kernel/Thread.lhs
+++ b/spec/haskell/src/SEL4/Kernel/Thread.lhs
@@ -200,6 +200,8 @@ Replies sent by the "Reply" and "ReplyRecv" system calls can either be normal IP
 >                 then return ()
 >                 else do
 >                     replyRemove reply receiver
+>                     scOpt <- threadGet tcbSchedContext receiver
+>                     ifCondRefillUnblockCheck scOpt (Just True) (Just False)
 >                     faultOpt <- threadGet tcbFault receiver
 >                     case faultOpt of
 >                         Nothing -> do

--- a/spec/haskell/src/SEL4/Object/Notification.lhs
+++ b/spec/haskell/src/SEL4/Object/Notification.lhs
@@ -144,6 +144,8 @@ If the notification object is active, the badge of the invoked notification obje
 >                 asUser thread $ setRegister badgeRegister badge
 >                 setNotification ntfnPtr $ ntfn {ntfnObj = IdleNtfn }
 >                 maybeDonateSc thread ntfnPtr
+>                 scOpt <- threadGet tcbSchedContext thread
+>                 ifCondRefillUnblockCheck scOpt (Just False) (Just False)
 
 \subsection{Delete Operation}
 

--- a/spec/haskell/src/SEL4/Object/Notification.lhs
+++ b/spec/haskell/src/SEL4/Object/Notification.lhs
@@ -70,6 +70,8 @@ mark the notification object as active.
 >                         maybeDonateSc tcb ntfnPtr
 >                         schedulable <- isSchedulable tcb
 >                         when schedulable $ possibleSwitchTo tcb
+>                         scOpt <- threadGet tcbSchedContext tcb
+>                         ifCondRefillUnblockCheck scOpt (Just True) (Just True)
 >                       else
 >                         setNotification ntfnPtr $ nTFN { ntfnObj = ActiveNtfn badge }
 >             (IdleNtfn, Nothing) -> setNotification ntfnPtr $ nTFN { ntfnObj = ActiveNtfn badge }
@@ -87,6 +89,8 @@ If the notification object is waiting, a thread is removed from its queue and th
 >                 maybeDonateSc dest ntfnPtr
 >                 schedulable <- isSchedulable dest
 >                 when schedulable $ possibleSwitchTo dest
+>                 scOpt <- threadGet tcbSchedContext dest
+>                 ifCondRefillUnblockCheck scOpt (Just True) (Just True)
 >             (WaitingNtfn [], _) -> fail "WaitingNtfn Notification must have non-empty queue"
 
 If the notification object is active, new values are calculated and stored in the notification object. The calculation is done by a bitwise OR operation of the currently stored, and the newly sent values.


### PR DESCRIPTION
This is the last PR for the “add refill_unblock_check” spec update.

This adds `refill_unblock_check` via `if_cond_refill_unblock_check` in `send_signal`,  `receive_ipc`, and `do_reply_transfer`.