### PR TITLE
Current thread activatable

### DIFF
--- a/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
@@ -312,7 +312,7 @@ lemma arch_perform_invocation_cur_sc_in_release_q_imp_zero_consumed [wp, DetSche
   by (cases iv; wpsimp wp: hoare_drop_imps)
 
 crunches arch_invoke_irq_handler, arch_mask_irq_signal, handle_reserved_irq
-  for ct_active[wp]: ct_active
+  for ct_in_state[wp]: "ct_in_state P"
 
 lemma arch_invoke_irq_handler_valid_sched_pred_strong[wp]:
   "arch_invoke_irq_handler i \<lbrace> valid_sched_pred_strong P \<rbrace>"
@@ -324,6 +324,10 @@ lemma arch_mask_irq_signal_valid_sched_pred_strong[wp]:
 
 crunches arch_switch_to_thread, arch_switch_to_idle_thread
 for cdt_cdt_list_exst [wp]:  "\<lambda>s. P (cdt s) (cdt_list_internal (exst s))"
+
+lemma handle_hyp_fault_trivial[wp]:
+  "handle_hypervisor_fault t fault \<lbrace>Q\<rbrace>"
+  by (cases fault; wpsimp)
 
 end
 
@@ -340,10 +344,6 @@ global_interpretation DetSchedSchedule_AI_det_ext?: DetSchedSchedule_AI_det_ext
 qed
 
 context Arch begin global_naming ARM
-
-lemma handle_hyp_fault_trivial[wp]:
-  "handle_hypervisor_fault t fault \<lbrace>Q\<rbrace>"
-  by (cases fault; wpsimp)
 
 lemma handle_reserved_irq_trivial[wp]:
   "handle_reserved_irq irq \<lbrace>Q\<rbrace>"

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -2327,9 +2327,9 @@ locale DetSchedSchedule_AI =
   assumes arch_invoke_irq_handler_ct_active[wp]:
     "\<And>i. arch_invoke_irq_handler i \<lbrace>ct_active::'state_ext state \<Rightarrow> _\<rbrace>"
   assumes handle_reserved_irq_ct_active[wp]:
-    "\<And>i. handle_reserved_irq i \<lbrace>ct_active::'state_ext state \<Rightarrow> _\<rbrace>"
-  assumes arch_mask_irq_signal_ct_active[wp]:
-    "\<And>i. arch_mask_irq_signal i \<lbrace>ct_active::'state_ext state \<Rightarrow> _\<rbrace>"
+    "\<And>i P. handle_reserved_irq i \<lbrace>ct_in_state P :: 'state_ext state \<Rightarrow> _\<rbrace>"
+  assumes arch_mask_irq_signal_ct_in_state[wp]:
+    "\<And>i P. arch_mask_irq_signal i \<lbrace>ct_in_state P :: 'state_ext state \<Rightarrow> _\<rbrace>"
   assumes prepare_thread_delete_current_time_bounded[wp]: (* need to give a concrete n? *)
     "\<And>t n. prepare_thread_delete t \<lbrace>current_time_bounded n :: 'state_ext state \<Rightarrow> _\<rbrace>"
   assumes arch_post_cap_deletion_current_time_bounded[wp] :
@@ -2342,6 +2342,10 @@ locale DetSchedSchedule_AI =
     "\<And>c P. arch_post_cap_deletion c \<lbrace>\<lambda>s :: 'state_ext state. P (tcb_scps_of s)\<rbrace>"
   assumes arch_finalise_cap_tcb_scps_of[wp]:
     "\<And>cap final P. arch_finalise_cap cap final \<lbrace>\<lambda>s :: 'state_ext state. P (tcb_scps_of s)\<rbrace>"
+  assumes handle_hypervisor_fault_ct_in_state[wp]:
+     "\<And>t fault P. handle_hypervisor_fault t fault \<lbrace>ct_in_state P :: 'state_ext state \<Rightarrow> _\<rbrace>"
+   assumes handle_hypervisor_fault_scheduler_action[wp]:
+     "\<And>t fault P. handle_hypervisor_fault t fault \<lbrace>\<lambda>s :: 'state_ext state. P (scheduler_action s)\<rbrace>"
 
 locale DetSchedSchedule_AI_det_ext = DetSchedSchedule_AI "TYPE(det_ext)" +
   assumes arch_activate_idle_thread_valid_list'[wp]:

--- a/proof/invariant-abstract/Ipc_AI.thy
+++ b/proof/invariant-abstract/Ipc_AI.thy
@@ -2900,9 +2900,18 @@ lemma ep_ntfn_cap_case_helper:
       R)"
   by (cases x, simp_all)
 
-crunches complete_signal, update_sk_obj_ref, do_nbrecv_failed_transfer
+crunches complete_signal, do_nbrecv_failed_transfer
   for pred_tcb_at[wp]: "\<lambda>s. P (pred_tcb_at proj P' t s)"
   (wp: crunch_wps hoare_vcg_all_lift)
+
+lemma complete_signal_st_tcb_at[wp]:
+  "complete_signal ntfnptr tptr \<lbrace>\<lambda>s. Q (st_tcb_at P t s)\<rbrace>"
+  apply (clarsimp simp: complete_signal_def)
+  apply (rule hoare_seq_ext_skip, solves wpsimp)
+  apply (case_tac "ntfn_obj ntfn"; clarsimp)
+  apply (rule hoare_seq_ext_skip, solves wpsimp)+
+  apply wpsimp
+  done
 
 lemmas thread_set_Pmdb = thread_set_no_cdt
 

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedSchedule_AI.thy
@@ -290,7 +290,7 @@ lemma arch_perform_invocation_cur_sc_in_release_q_imp_zero_consumed [wp, DetSche
   by (cases iv; wpsimp wp: hoare_drop_imps)
 
 crunches arch_invoke_irq_handler, arch_mask_irq_signal, handle_reserved_irq
-  for ct_active[wp]: ct_active
+  for ct_in_state[wp]: "ct_in_state P"
 
 lemma arch_invoke_irq_handler_valid_sched_pred_strong[wp]:
   "arch_invoke_irq_handler i \<lbrace> valid_sched_pred_strong P \<rbrace>"
@@ -305,6 +305,10 @@ for cdt_cdt_list_exst [wp]:  "\<lambda>s. P (cdt s) (cdt_list_internal (exst s))
 
 crunches make_arch_fault_msg
   for valid_sched_pred_strong[wp,DetSchedSchedule_AI_assms]: "valid_sched_pred_strong P"
+
+lemma handle_hyp_fault_trivial[wp]:
+  "handle_hypervisor_fault t fault \<lbrace>Q\<rbrace>"
+  by (cases fault; wpsimp)
 
 end
 
@@ -321,10 +325,6 @@ proof goal_cases
 qed
 
 context Arch begin global_naming RISCV64
-
-lemma handle_hyp_fault_trivial[wp]:
-  "handle_hypervisor_fault t fault \<lbrace>Q\<rbrace>"
-  by (cases fault; wpsimp)
 
 lemma handle_reserved_irq_trivial[wp]:
   "handle_reserved_irq irq \<lbrace>Q\<rbrace>"


### PR DESCRIPTION
This shows that after `handle_event` and `preemption_path`, if the scheduler action is resume current thread, then the current thread is activatable. This will be important in showing that `cur_sc_offset_ready (consumed_timed s) s` and `cur_sc_offset_sufficient (consumed_time s) s` are true after `call_kernel`.

Many of the proofs are much more manual than I would have liked. I think this is because the statement is an implication, and because so many functions can potentially change the thread state of the current thread. `crunches` was unfortunately not very helpful at all. If anyone has any ideas on how to make these proofs less manual, please let me know.