### PR TITLE
Hy_invs'

### DIFF
--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -305,9 +305,8 @@ crunch domain_list_inv[wp]: handle_invocation,receive_ipc,receive_signal "\<lamb
 lemma handle_recv_domain_list_inv[wp]:
   "\<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace>
   handle_recv is_blocking can_reply \<lbrace>\<lambda>rv s. P (domain_list s)\<rbrace>"
-  apply (wpsimp simp: handle_recv_def Let_def whenE_def get_sk_obj_ref_def
-                split_del: if_split wp: hoare_drop_imps)
-  by (rule_tac Q'="\<lambda>_ s. P (domain_list s)" in hoare_post_imps(1))  wpsimp+
+  by (wpsimp simp: handle_recv_def Let_def whenE_def get_sk_obj_ref_def
+        split_del: if_split wp: hoare_drop_imps)
 
 crunches
   handle_yield, handle_call, handle_vm_fault, handle_hypervisor_fault, check_domain_time

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -4655,11 +4655,10 @@ lemma receiveIPC_corres:
               and st_tcb_at active thread
               and not_queued thread and not_in_release_q thread and scheduler_act_not thread
               and tcb_at thread and ex_nonz_cap_to thread
-              and cte_wp_at (\<lambda>c. c = cap.NullCap) (thread, tcb_cnode_index 3)
               and (\<lambda>s. \<forall>r\<in>zobj_refs reply_cap. ex_nonz_cap_to r s))
              (invs' and tcb_at' thread and valid_cap' cap' and valid_cap' replyCap)
              (receive_ipc thread cap isBlocking reply_cap) (receiveIPC thread cap' isBlocking replyCap)"
-    (is "corres _ (_ and ?tat and ?tex and ?slot3 and ?rrefs) _ _ _")
+    (is "corres _ (_ and ?tat and ?tex and ?rrefs) _ _ _")
   apply add_sch_act_wf
   apply add_valid_idle'
   apply add_cur_tcb'
@@ -4696,7 +4695,7 @@ lemma receiveIPC_corres:
              apply (rule corres_split[where r'=dc])
                 apply (rule corres_when; simp)
                 apply (rule maybeReturnSc_corres)
-               apply (rule_tac P="einvs and ?tat and ?slot3 and ?tex and ep_at epptr
+               apply (rule_tac P="einvs and ?tat and ?tex and ep_at epptr
                         and valid_ep ep and ko_at (Endpoint ep) epptr
                         and current_time_bounded 2
                         and receive_ipc_preamble_rv reply_cap replyOpt and ?rrefs" and
@@ -4759,7 +4758,7 @@ lemma receiveIPC_corres:
                                                   and (\<lambda>s. sym_refs (\<lambda>p. if p = sender
                                                                          then tcb_non_st_state_refs_of s sender
                                                                          else state_refs_of s p))
-                                                  and ?rrefs and ?slot3"
+                                                  and ?rrefs"
                                            and P'="tcb_at' sender and tcb_at' thread and cur_tcb'
                                                    and valid_queues
                                                    and valid_queues'
@@ -4821,7 +4820,6 @@ lemma receiveIPC_corres:
                                                                then tcb_non_st_state_refs_of s sender
                                                                else state_refs_of s p))
                                                  and valid_bound_obj (\<lambda>r s. r \<notin> fst ` replies_with_sc s) replyOpt
-                                                 and cte_wp_at (\<lambda>c. c = cap.NullCap) (thread, tcb_cnode_index 3)
                                                  and receive_ipc_preamble_rv reply_cap replyOpt"
                                 in hoare_strengthen_post[rotated])
                           apply (clarsimp simp: valid_sched_active_sc_valid_refills)
@@ -4856,7 +4854,6 @@ lemma receiveIPC_corres:
                                                              then tcb_non_st_state_refs_of s sender
                                                              else state_refs_of s p))
                                                and valid_bound_obj (\<lambda>r s. r \<notin> fst ` replies_with_sc s) replyOpt
-                                               and cte_wp_at (\<lambda>c. c = cap.NullCap) (thread, tcb_cnode_index 3)
                                                and receive_ipc_preamble_rv reply_cap replyOpt"
                               in hoare_strengthen_post[rotated])
                         apply (clarsimp simp: valid_sched_active_sc_valid_refills)
@@ -4921,7 +4918,7 @@ lemma receiveIPC_corres:
                apply (clarsimp simp: invs'_def valid_pspace'_def valid_ep'_def)
                apply fastforce
               \<comment> \<open> end of ep cases \<close>
-              apply (rule_tac Q="\<lambda>_. einvs and ?tat and ?slot3 and ?tex and
+              apply (rule_tac Q="\<lambda>_. einvs and ?tat and ?tex and
                                ko_at (Endpoint ep) epptr and current_time_bounded 2 and
                                receive_ipc_preamble_rv reply_cap replyOpt and ?rrefs"
                      in hoare_strengthen_post[rotated])
@@ -4943,7 +4940,7 @@ lemma receiveIPC_corres:
       apply simp
       apply (rule_tac Q="\<lambda>r. invs and ep_at epptr and valid_list and current_time_bounded 2
                              and scheduler_act_not thread and (\<lambda>s. thread \<noteq> idle_thread s)
-                             and valid_sched and ?tat and ?tex and ?slot3
+                             and valid_sched and ?tat and ?tex
                              and receive_ipc_preamble_rv reply_cap r
                              and not_queued thread and not_in_release_q thread and ?rrefs"
              in hoare_strengthen_post[rotated])

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -2202,7 +2202,7 @@ lemma hs_valid_duplicates'[wp]:
   "\<lbrace>invs' and ct_active' and sch_act_simple and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))\<rbrace>
   handleSend blocking \<lbrace>\<lambda>r s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (rule validE_valid)
-  apply (simp add: handleSend_def getCapReg_def)
+  apply (simp add: handleSend_def)
   apply (wp | simp)+
   done
 
@@ -2213,8 +2213,7 @@ lemma hc_valid_duplicates'[wp]:
   apply (clarsimp simp: handleCall_def)
   apply (rule validE_valid)
   apply (rule hoare_vcg_seqE[OF _ stateAssertE_sp])
-  apply (wpsimp simp: getCapReg_def)
-  apply (clarsimp simp: cur_tcb'_def cur_tcb'_asrt_def)
+  apply wpsimp
   done
 
 lemma handleRecv_valid_duplicates'[wp]:

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -1612,7 +1612,6 @@ lemma hw_invs'[wp]:
   apply (rule hoare_seq_ext[OF _ getCurThread_sp])
   apply (rule hoare_seq_ext_skip)
    apply (wpsimp simp: getCapReg_def)
-   apply (fastforce simp: ct_in_state'_def)
   apply (rule catch_wp; (solves wpsimp)?)
   apply (rule_tac A=A and
                   B="\<lambda>rv. A and (\<lambda>s. \<forall>r\<in>zobj_refs' rv. ex_nonz_cap_to' r s)
@@ -1622,14 +1621,13 @@ lemma hw_invs'[wp]:
    apply wpsimp
    apply (fastforce simp: ct_in_state'_def)
   apply (rename_tac epCap)
-  apply (case_tac epCap; clarsimp?, (solves wpsimp)?)
-   apply (wpsimp wp: getNotification_wp)
+  apply (case_tac epCap; clarsimp split del: if_split; (wpsimp; fail)?)
+   apply (rename_tac readright; case_tac readright; (wp getNotification_wp |simp)+)
    apply (clarsimp simp: obj_at_simps isNotificationCap_def)
-  apply (intro conjI impI; (solves wpsimp)?)
   by (wpsimp simp: lookupReply_def getCapReg_def
                wp: hoare_vcg_conj_liftE
       | wp (once) hoare_drop_imps)+
-     (clarsimp simp: obj_at_simps ct_in_state'_def pred_tcb_at'_def) \<comment> \<open>takes 30 seconds\<close>
+     (clarsimp simp: obj_at_simps ct_in_state'_def pred_tcb_at'_def)
 
 lemma setSchedulerAction_obj_at'[wp]:
   "\<lbrace>obj_at' P p\<rbrace> setSchedulerAction sa \<lbrace>\<lambda>rv. obj_at' P p\<rbrace>"

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -1522,72 +1522,179 @@ crunch sch_act_sane[wp]: cteDeleteOne sch_act_sane
    simp: crunch_simps unless_def
    rule: sch_act_sane_lift)
 
+lemma getCapReg_corres_gen:
+  "corres (\<lambda>x y. x = to_bl y) cur_tcb cur_tcb'
+          (get_cap_reg rg) (getCapReg rg)"
+  apply (simp add: get_cap_reg_def getCapReg_def cap_register_def capRegister_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF getCurThread_corres], simp)
+      apply (rule corres_rel_imp)
+       apply (rule asUser_getRegister_corres)
+      apply (wpsimp simp: cur_tcb_def cur_tcb'_def)+
+  done
+
+lemma lookupReply_corres:
+  "corres (fr \<oplus> cap_relation)
+     (cur_tcb and valid_objs and pspace_aligned)
+     (cur_tcb' and valid_objs' and pspace_aligned' and pspace_distinct')
+     lookup_reply lookupReply"
+  unfolding lookup_reply_def lookupReply_def withoutFailure_def
+  apply simp
+  apply (rule corres_rel_imp)
+   apply (rule corres_guard_imp)
+     apply (rule corres_split_liftEE[OF getCapReg_corres_gen])
+       apply (rule corres_split_liftEE[OF getCurThread_corres])
+         apply simp
+         apply (rule corres_splitEE[OF _ corres_cap_fault[OF lookupCap_corres]])
+           apply (rename_tac cref cref' ct ct' cap cap')
+           apply (rule corres_if2)
+             apply (case_tac cap; case_tac cap'; clarsimp simp: is_reply_cap_def isReplyCap_def)
+            apply (rule corres_returnOk[where r=cap_relation])
+            apply simp
+           apply (simp add: lookup_failure_map_def)
+          apply wpsimp+
+     apply (wpsimp simp: getCapReg_def)
+    apply (clarsimp simp: cur_tcb_def, simp)
+   apply (clarsimp simp: cur_tcb'_def)
+  apply assumption
+  done
+
+lemma lookup_reply_valid [wp]:
+  "\<lbrace> valid_objs \<rbrace> lookup_reply \<lbrace> valid_cap \<rbrace>, -"
+  unfolding lookup_reply_def get_cap_reg_def
+  apply (wpsimp wp: get_cap_wp hoare_vcg_imp_lift_R)
+       apply (rule hoare_FalseE_R)
+      apply wpsimp+
+  done
+
+lemma lookup_reply_is_reply_cap [wp]:
+  "\<lbrace> valid_objs \<rbrace> lookup_reply \<lbrace>\<lambda>rv s. is_reply_cap rv \<rbrace>, -"
+  unfolding lookup_reply_def lookup_cap_def
+  by (wpsimp wp: get_cap_wp)
+
+crunches lookupReply
+  for inv[wp]: "P"
+  (simp: crunch_simps wp: crunch_wps)
+
+crunches lookup_reply
+  for valid_cap[wp]: "valid_cap c"
+  and cte_wp_at[wp]: "\<lambda>s. Q (cte_wp_at P p s)"
+
+lemma lookupReply_valid [wp]:
+  "\<lbrace> valid_objs' \<rbrace> lookupReply \<lbrace> valid_cap' \<rbrace>, -"
+  unfolding lookupReply_def getCapReg_def
+  apply (wpsimp wp: get_cap_wp hoare_vcg_imp_lift_R)
+       apply (rule hoare_FalseE_R)
+      apply wpsimp+
+  done
+
+lemma getBoundNotification_corres:
+  "corres (=) (ntfn_at nptr) (ntfn_at' nptr)
+          (get_ntfn_obj_ref ntfn_bound_tcb nptr) (liftM ntfnBoundTCB (getNotification nptr))"
+  apply (simp add: get_sk_obj_ref_def)
+  apply (rule corres_bind_return2)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF getNotification_corres])
+      apply (simp add: ntfn_relation_def)
+     apply wpsimp+
+  done
+
 lemma handleRecv_isBlocking_corres':
-   "corres dc (einvs and ct_in_state active
-                    and (\<lambda>s. ex_nonz_cap_to (cur_thread s) s))
+   "corres dc (einvs and ct_in_state active and current_time_bounded 2
+               and scheduler_act_sane and ct_not_queued and ct_not_in_release_q
+               and (\<lambda>s. ex_nonz_cap_to (cur_thread s) s))
               (invs' and ct_in_state' simple'
                      and sch_act_sane
                      and (\<lambda>s. \<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p))
                      and (\<lambda>s. ex_nonz_cap_to' (ksCurThread s) s))
                     (handle_recv isBlocking canReply) (handleRecv isBlocking canReply)"
   (is "corres dc (?pre1) (?pre2) (handle_recv _ _) (handleRecv _ _)")
-  apply (simp add: handle_recv_def handleRecv_def liftM_bind Let_def
-                   cap_register_def capRegister_def
-             cong: if_cong cap.case_cong capability.case_cong bool.case_cong split del: if_split)
-  sorry (*
+  unfolding handle_recv_def handleRecv_def Let_def
+  apply add_cur_tcb'
+  apply (rule_tac Q="ct_active'" in corres_cross_add_guard)
+   apply (fastforce elim!: ct_active_cross dest: invs_psp_aligned invs_distinct)
+  apply (simp add: cap_register_def capRegister_def liftM_bind
+             cong: if_cong cap.case_cong capability.case_cong split del: if_split)
   apply (rule corres_guard_imp)
     apply (rule corres_split_eqr [OF _ getCurThread_corres])
       apply (rule corres_split_eqr [OF _ asUser_getRegister_corres])
         apply (rule corres_split_catch)
            apply (erule handleFault_corres)
-          apply (rule corres_cap_fault)
-          apply (rule corres_splitEE [OF _ lookupCap_corres])
+          apply (rule corres_splitEE [OF _ corres_cap_fault[OF lookupCap_corres]])
             apply (rule_tac P="?pre1 and tcb_at thread
                                and (\<lambda>s. (cur_thread s) = thread  )
                                and valid_cap rv"
-                       and P'="?pre2 and tcb_at' thread and valid_cap' rv'" in corres_inst)
+                       and P'="?pre2 and cur_tcb' and tcb_at' thread and valid_cap' epCap" in corres_inst)
             apply (clarsimp split: cap_relation_split_asm arch_cap.split_asm split del: if_split
                              simp: lookup_failure_map_def whenE_def)
+             apply (rename_tac rights)
+             apply (case_tac "AllowRead \<in> rights \<and> canReply")
+              apply clarsimp
+              apply (rule corres_guard_imp)
+                apply (rule corres_splitEE[OF _ lookupReply_corres])
+                  apply (rule_tac Q="\<lambda>_. is_reply_cap reply_cap" in corres_inst_add)
+                  apply (rule corres_gen_asm)
+                  apply simp
+                  apply (rule corres_guard_imp)
+                    apply (rule receiveIPC_corres)
+                       apply simp
+                      apply (clarsimp simp: cap_relation_def)
+                     apply simp+
+                 apply (wpsimp wp: typ_at_lifts)+
+               apply (clarsimp simp: ct_in_state_def invs_def valid_state_def valid_pspace_def)
+              apply (simp add: invs'_def valid_pspace'_def)
+             apply (clarsimp simp: lookup_failure_map_def)
              apply (rule corres_guard_imp)
-               apply (rename_tac rights)
-                apply (case_tac "AllowRead \<in> rights"; simp)
-                 apply (rule corres_split_nor[OF _ deleteCallerCap_corres])
-                   apply (rule receiveIPC_corres)
-                    apply (clarsimp)+
-                  apply (wp delete_caller_cap_nonz_cap delete_caller_cap_valid_ep_cap)+
-                apply (clarsimp)+
-                apply (clarsimp simp: lookup_failure_map_def)+
-             apply (clarsimp simp: valid_cap'_def capAligned_def)
-            apply (rule corres_guard_imp)
-              apply (rename_tac rights)
-              apply (case_tac "AllowRead \<in> rights"; simp)
-               apply (rule_tac r'=ntfn_relation in corres_splitEE)
-                  apply (rule corres_if)
-                    apply (clarsimp simp: ntfn_relation_def)
-                   apply (clarsimp, rule receiveSignal_corres)
-                    prefer 3
-                    apply (rule corres_trivial)
-                    apply (clarsimp simp: lookup_failure_map_def)+
-                 apply (rule getNotification_corres)
-                apply (wp get_simple_ko_wp getNotification_wp | wpcw | simp)+
-              apply (clarsimp simp: lookup_failure_map_def)
-             apply (clarsimp simp: valid_cap_def ct_in_state_def)
-            apply (clarsimp simp: valid_cap'_def capAligned_def)
-           apply (wp get_simple_ko_wp | wpcw | simp)+
-         apply (rule hoare_vcg_E_elim)
-          apply (simp add: lookup_cap_def lookup_slot_for_thread_def)
-          apply wp
-           apply (simp add: split_def)
-           apply (wp resolve_address_bits_valid_fault2)+
-         apply (wp getNotification_wp | wpcw | simp add: valid_fault_def whenE_def split del: if_split)+
-  apply (clarsimp simp add: ct_in_state_def  ct_in_state'_def conj_comms invs_valid_tcb_ctable
-                            invs_valid_objs tcb_at_invs invs_psp_aligned invs_cur)
-  apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
-                        ct_in_state'_def sch_act_sane_not)
-  done *)
+               apply (rule receiveIPC_corres)
+                  apply ((clarsimp simp: cap_relation_def ct_in_state_def)+)[6]
+            apply (rename_tac rights)
+            apply (simp add: bool.case_eq_if if_swap[where P="AllowRead \<in> x" for x, symmetric] split del: if_split)
+            apply (case_tac "AllowRead \<in> rights")
+             apply clarsimp
+             apply (rule stronger_corres_guard_imp)
+               apply (rule corres_split_liftEE[OF getBoundNotification_corres])
+                 apply (case_tac "rv = Some thread \<or> rv = None")
+                  apply simp
+                  apply (rule receiveSignal_corres)
+                   apply simp
+                  apply (clarsimp simp: cap_relation_def)
+                 apply (clarsimp simp: lookup_failure_map_def)
+                apply (wpsimp wp: get_sk_obj_ref_wp getNotification_wp)+
+              apply (clarsimp simp: valid_cap_def valid_sched_def valid_sched_action_def
+                                    current_time_bounded_def ct_in_state_def)
+             apply (clarsimp simp: valid_cap_def valid_cap'_def dest!: state_relationD)
+            apply (clarsimp simp: lookup_failure_map_def)
+           apply (wpsimp wp: get_sk_obj_ref_wp)+
+         apply (rule_tac Q="\<lambda>_. ?pre1 and (\<lambda>s. cur_thread s = thread)
+                                 and K (valid_fault (ExceptionTypes_A.fault.CapFault x True
+                                        (ExceptionTypes_A.lookup_failure.MissingCapability 0)))"
+                     and E=E and F=E for E
+                in hoare_post_impErr[rotated])
+           apply (fastforce simp: valid_sched_valid_sched_action valid_sched_active_sc_valid_refills ct_in_state_def)
+          apply simp
+         apply (wpsimp wp: resolve_address_bits_valid_fault2 simp: lookup_cap_def lookup_cap_and_slot_def lookup_slot_for_thread_def)
+        apply wp
+         apply (case_tac epCap; simp split del: if_split)
+                      apply wpsimp
+                     apply wpsimp
+                    apply (rename_tac readright; case_tac readright; simp)
+                     apply wp
+                       apply simp
+                       apply wp
+                      apply (wp getNotification_wp)
+                     apply clarsimp
+                    apply (wpsimp wp: hoare_vcg_imp_lift' simp: valid_fault_def)+
+   apply (clarsimp simp: invs_def cur_tcb_def valid_state_def valid_pspace_def ct_in_state_def
+                         valid_sched_valid_sched_action valid_sched_active_sc_valid_refills
+                  dest!: get_tcb_SomeD)
+   apply (erule (1) valid_objsE)
+   apply (clarsimp simp: valid_obj_def valid_tcb_def tcb_cap_cases_def)
+  apply (clarsimp simp: invs'_def cur_tcb'_def valid_pspace'_def sch_act_sane_def ct_in_state'_def)
+  done
 
 lemma handleRecv_isBlocking_corres:
-  "corres dc (einvs and ct_active)
+  "corres dc (einvs and ct_active and scheduler_act_sane and current_time_bounded 2
+              and ct_not_queued and ct_not_in_release_q)
              (invs' and ct_active' and sch_act_sane and
                     (\<lambda>s. \<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p)))
             (handle_recv isBlocking canReply) (handleRecv isBlocking canReply)"
@@ -1610,8 +1717,7 @@ lemma hw_invs'[wp]:
    \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (simp add: handleRecv_def cong: if_cong split del: if_split)
   apply (rule hoare_seq_ext[OF _ getCurThread_sp])
-  apply (rule hoare_seq_ext_skip)
-   apply (wpsimp simp: getCapReg_def)
+  apply (rule hoare_seq_ext_skip, wpsimp)
   apply (rule catch_wp; (solves wpsimp)?)
   apply (rule_tac A=A and
                   B="\<lambda>rv. A and (\<lambda>s. \<forall>r\<in>zobj_refs' rv. ex_nonz_cap_to' r s)
@@ -2145,8 +2251,7 @@ lemma handleCall_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getCapReg_corres])
       apply (simp, rule handleInvocation_corres; simp)
-     apply (wpsimp simp: getCapReg_def)+
-  apply (clarsimp simp: cur_tcb'_def)
+     apply wpsimp+
   done
 
 lemma hc_invs'[wp]:
@@ -2158,8 +2263,7 @@ lemma hc_invs'[wp]:
   apply (clarsimp simp: handleCall_def)
   apply (rule validE_valid)
   apply (rule hoare_vcg_seqE[OF _ stateAssertE_sp])
-  apply (wpsimp simp: getCapReg_def)
-  apply (clarsimp simp: cur_tcb'_def cur_tcb'_asrt_def)
+  apply wpsimp
   done
 
 lemma cteInsert_sane[wp]:
@@ -2199,7 +2303,9 @@ lemma handleEvent_corres:
 proof -
   have hw:
     "\<And>isBlocking canGrant.
-     corres dc (einvs and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread))
+     corres dc (einvs and ct_running and valid_machine_time and current_time_bounded 2
+                and ct_released and (\<lambda>s. scheduler_action s = resume_cur_thread)
+                and ct_not_in_release_q and ct_not_queued)
                (invs' and ct_running'
                       and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
                (handle_recv isBlocking canGrant) (handleRecv isBlocking canGrant)"
@@ -2213,7 +2319,6 @@ proof -
     show ?thesis
       apply (case_tac event)
           apply (simp_all add: handleEvent_def)
-
           apply (rename_tac syscall)
           apply (case_tac syscall)
           apply (auto intro: corres_guard_imp[OF handleSend_corres]

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -1887,12 +1887,47 @@ lemma end_timeslice_valid_sched_action:
   apply (clarsimp simp: active_sc_tcb_at_def2)
   done
 
+lemma sendFaultIPC_invs':
+  "\<lbrace>invs' and valid_idle' and st_tcb_at' active' t
+          and (\<lambda>s. canDonate \<longrightarrow> bound_sc_tcb_at' bound t s)
+          and ex_nonz_cap_to' t
+          and (\<lambda>s. \<exists>n\<in>dom tcb_cte_cases. \<exists>cte. cte_wp_at' (\<lambda>cte. cteCap cte = cap) (t + n) s)\<rbrace>
+   sendFaultIPC t cap f canDonate
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  apply (simp add: sendFaultIPC_def)
+  apply (wp threadSet_invs_trivial threadSet_pred_tcb_no_state
+            threadSet_cap_to' threadSet_idle'
+           | wpc | simp)+
+  apply (intro conjI impI allI; (fastforce simp: inQ_def)?)
+   apply (clarsimp simp: invs'_def valid_release_queue'_def obj_at'_def)
+  apply (fastforce simp: ex_nonz_cap_to'_def cte_wp_at'_def)
+  done
+
+lemma handleTimeout_Timeout_invs':
+  "\<lbrace>invs' and st_tcb_at' active' tptr\<rbrace>
+   handleTimeout tptr (Timeout badge)
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  apply (clarsimp simp: handleTimeout_def)
+  apply (wpsimp wp: sendFaultIPC_invs' set_tcb'.getObject_wp' simp: isValidTimeoutHandler_def)
+  apply (clarsimp simp: valid_idle'_asrt_def)
+  apply (rule conjI; clarsimp simp: obj_at'_real_def projectKOs pred_tcb_at'_def)
+   apply (drule invs_iflive')
+   apply (erule (1) if_live_then_nonz_capD')
+   apply (fastforce simp: live_def)
+  apply (clarsimp simp: ko_wp_at'_def projectKOs opt_map_red)
+  apply (rule_tac x="0x40" in bexI)
+   apply (clarsimp simp: cte_wp_at_cases')
+   apply (drule_tac x="0x40" in spec)
+   apply (clarsimp simp: objBits_simps)
+   apply fastforce+
+  done
+
 lemma endTimeslice_invs'[wp]:
-  "\<lbrace>invs' and ct_active' and sch_act_sane\<rbrace>
+  "\<lbrace>invs' and ct_active'\<rbrace>
    endTimeslice timeout
    \<lbrace>\<lambda>_. invs'\<rbrace>"
   unfolding endTimeslice_def
-  apply (wpsimp wp: handleTimeout_invs' isValidTimeoutHandler_inv hoare_drop_imp)
+  apply (wpsimp wp: handleTimeout_Timeout_invs' isValidTimeoutHandler_inv hoare_drop_imp)
   apply (clarsimp simp: runnable_eq_active')
   apply (frule (1) active_ex_cap'[OF _ invs_iflive'])
   apply (clarsimp simp: ct_in_state'_def sch_act_sane_def)
@@ -1923,9 +1958,7 @@ global_interpretation refillResetRR: typ_at_all_props' "refillResetRR scPtr"
 context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma refillResetRR_invs'[wp]:
-  "\<lbrace>invs' and ct_active' and sch_act_sane\<rbrace>
-   refillResetRR scp
-   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  "refillResetRR scp \<lbrace>invs'\<rbrace>"
   unfolding refillResetRR_def
   apply (wpsimp wp: updateSchedContext_invs')
   apply (intro conjI; clarsimp elim!: live_sc'_ex_cap[OF invs_iflive'])
@@ -2170,17 +2203,23 @@ lemma handleYield_corres:
   apply clarsimp
   done
 
+lemma chargeBudget_invs'[wp]:
+  "chargeBudget consumed canTimeout Flag \<lbrace>invs'\<rbrace>"
+  unfolding chargeBudget_def ifM_def bind_assoc
+  apply (rule hoare_seq_ext[OF _ getCurSc_sp])
+  apply (wpsimp wp: isSchedulable_wp)
+     apply (rule hoare_strengthen_post[where Q="\<lambda>_. invs'"])
+      apply wpsimp
+     apply (clarsimp simp: isSchedulable_bool_def obj_at'_def projectKOs
+                           pred_map_def ct_in_state'_def pred_tcb_at'_def runnable_eq_active')
+  by (wpsimp wp: hoare_drop_imp updateSchedContext_invs'
+      | strengthen live_sc'_ex_cap[OF invs_iflive'] valid_sc_strengthen[OF invs_valid_objs'])+
+
 lemma hy_invs':
-  "\<lbrace>invs' and ct_active'\<rbrace> handleYield \<lbrace>\<lambda>r. invs' and ct_active'\<rbrace>"
+  "handleYield \<lbrace>invs'\<rbrace>"
   apply (simp add: handleYield_def)
-  apply (wp ct_in_state_thread_state_lift'
-            rescheduleRequired_invs'
-            tcbSchedAppend_invs' | simp)+
-  apply (clarsimp simp add: invs'_def ct_in_state'_def sch_act_wf_weak cur_tcb'_def
-                   valid_pspace_valid_objs' valid_objs'_maxDomain tcb_in_cur_domain'_def)
-  sorry (*
-  apply (simp add:ct_active_runnable'[unfolded ct_in_state'_def])
-  done *)
+  by (wpsimp wp: updateSchedContext_invs' ct_in_state_thread_state_lift'
+    | strengthen live_sc'_ex_cap[OF invs_iflive'] valid_sc_strengthen[OF invs_valid_objs'])+
 
 lemma getDFSR_invs'[wp]:
   "valid invs' (doMachineOp getDFSR) (\<lambda>_. invs')"

--- a/spec/abstract/Syscall_A.thy
+++ b/spec/abstract/Syscall_A.thy
@@ -316,11 +316,13 @@ definition
         let flt = throwError $ CapFault (of_bl ep_cptr) True (MissingCapability 0)
         in
         case ep_cap
-          of EndpointCap ref badge rights \<Rightarrow> doE
-               whenE (AllowRecv \<notin> rights) flt;
-               reply_cap \<leftarrow> if can_reply then lookup_reply else returnOk NullCap;
-               liftE $ receive_ipc thread ep_cap is_blocking reply_cap
-             odE
+          of EndpointCap ref badge rights \<Rightarrow>
+               if AllowRecv \<in> rights
+               then doE
+                 reply_cap \<leftarrow> if can_reply then lookup_reply else returnOk NullCap;
+                 liftE $ receive_ipc thread ep_cap is_blocking reply_cap
+               odE
+               else flt
            | NotificationCap ref badge rights \<Rightarrow>
              (if AllowRecv \<in> rights
               then doE

--- a/spec/design/skel/Syscall_H.thy
+++ b/spec/design/skel/Syscall_H.thy
@@ -18,7 +18,7 @@ begin
 defs handleRecv_def:
 "handleRecv isBlocking canReply\<equiv> (do
     thread \<leftarrow> getCurThread;
-    epCptr \<leftarrow> getCapReg capRegister;
+    epCptr \<leftarrow> asUser thread $ liftM CPtr $ getRegister capRegister;
     ((doE
         epCap \<leftarrow> capFaultOnFailure epCptr True (lookupCap thread epCptr);
         exc \<leftarrow> returnOk ( CapFault epCptr True (MissingCapability 0));
@@ -28,8 +28,7 @@ defs handleRecv_def:
                 withoutFailure $ receiveIPC thread epCap isBlocking replyCap
               odE)
             | NotificationCap ntfnPtr _ _ True \<Rightarrow>   (doE
-                ntfn \<leftarrow> withoutFailure $ getNotification ntfnPtr;
-                boundTCB \<leftarrow> returnOk $ ntfnBoundTCB ntfn;
+                boundTCB \<leftarrow> withoutFailure $ liftM ntfnBoundTCB $ getNotification ntfnPtr;
                 if boundTCB = Just thread \<or> boundTCB = Nothing
                     then withoutFailure $ receiveSignal thread epCap isBlocking
                     else throw exc

--- a/spec/haskell/src/SEL4/API/Syscall.lhs
+++ b/spec/haskell/src/SEL4/API/Syscall.lhs
@@ -196,7 +196,7 @@ The "Recv" system call blocks waiting to receive a message through a specified e
 > handleRecv :: Bool -> Bool -> Kernel ()
 > handleRecv isBlocking canReply = do
 >     thread <- getCurThread
->     epCptr <- getCapReg capRegister
+>     epCptr <- asUser thread $ liftM CPtr $ getRegister capRegister
 >     (do
 >         epCap <- capFaultOnFailure epCptr True (lookupCap thread epCptr)
 >         let exc = CapFault epCptr True (MissingCapability 0)
@@ -205,8 +205,7 @@ The "Recv" system call blocks waiting to receive a message through a specified e
 >                 replyCap <- if canReply then lookupReply else return NullCap
 >                 withoutFailure $ receiveIPC thread epCap isBlocking replyCap
 >             NotificationCap { capNtfnCanReceive = True, capNtfnPtr = ntfnPtr } -> do
->                 ntfn <- withoutFailure $ getNotification ntfnPtr
->                 boundTCB <- return $ ntfnBoundTCB ntfn
+>                 boundTCB <- withoutFailure $ liftM ntfnBoundTCB $ getNotification ntfnPtr
 >                 if boundTCB == Just thread || boundTCB == Nothing
 >                     then withoutFailure $ receiveSignal thread epCap isBlocking
 >                     else throw exc


### PR DESCRIPTION
This PR proves `hy_invs’` and `handleRecv_isBlocking_corres’` (-2 sorries).

Also:
- removes an unnecessary precondition from receiveIPC_corres
- tweaks `handle_recv` and `handleRecv` spec