### PR TITLE
Remove parameter from `current_time_bounded`

### DIFF
--- a/proof/invariant-abstract/AInvs.thy
+++ b/proof/invariant-abstract/AInvs.thy
@@ -635,7 +635,7 @@ lemma schedule_cur_sc_active:
 lemma call_kernel_cur_sc_active:
   "\<lbrace>\<lambda>s. cur_sc_active s \<and> invs s \<and> schact_is_rct s \<and> valid_sched s \<and> ct_not_in_release_q s
         \<and> (ct_running s \<or> ct_idle s) \<and> (e \<noteq> Interrupt \<longrightarrow> ct_running s)
-        \<and> cur_sc_offset_ready (consumed_time s) s \<and> current_time_bounded 5 s
+        \<and> cur_sc_offset_ready (consumed_time s) s \<and> current_time_bounded s
         \<and> valid_machine_time s \<and> consumed_time_bounded s\<rbrace>
    call_kernel e
    \<lbrace>\<lambda>_ s :: det_state. cur_sc_active s\<rbrace>"
@@ -1263,7 +1263,7 @@ lemma schedule_ct_not_in_release_q:
 lemma call_kernel_ct_not_in_release_q:
   "\<lbrace>\<lambda>s. ct_not_in_release_q s \<and> cur_sc_active s \<and> invs s \<and> schact_is_rct s \<and> valid_sched s
         \<and> (ct_running s \<or> ct_idle s) \<and> (e \<noteq> Interrupt \<longrightarrow> ct_running s)
-        \<and> cur_sc_offset_ready (consumed_time s) s \<and> current_time_bounded 5 s
+        \<and> cur_sc_offset_ready (consumed_time s) s \<and> current_time_bounded s
         \<and> valid_machine_time s \<and> consumed_time_bounded s\<rbrace>
    call_kernel e
    \<lbrace>\<lambda>_ s :: det_state. ct_not_in_release_q s\<rbrace>"
@@ -1328,7 +1328,7 @@ lemma schedule_schact_is_rct[wp]:
 lemma call_kernel_schact_is_rct:
   "\<lbrace>\<lambda>s. schact_is_rct s \<and> invs s \<and> valid_sched s \<and> cur_sc_active s \<and> ct_not_in_release_q s
         \<and> (ct_running s \<or> ct_idle s) \<and> (e \<noteq> Interrupt \<longrightarrow> ct_running s)
-        \<and> cur_sc_offset_ready (consumed_time s) s \<and> current_time_bounded 5 s
+        \<and> cur_sc_offset_ready (consumed_time s) s \<and> current_time_bounded s
         \<and> valid_machine_time s \<and> consumed_time_bounded s\<rbrace>
    call_kernel e
    \<lbrace>\<lambda>_ s :: det_state. schact_is_rct s\<rbrace>"
@@ -2074,7 +2074,7 @@ lemma is_refill_ready_imp_cur_sc_offset_ready_zero:
 
 lemma commit_time_cur_sc_offset_ready_and_sufficient_consumed_time:
   "\<lbrace>\<lambda>s. cur_sc_offset_ready (consumed_time s) s \<and> cur_sc_offset_sufficient (consumed_time s) s
-        \<and> current_time_bounded 5 s \<and> active_sc_valid_refills s\<rbrace>
+        \<and> current_time_bounded s \<and> active_sc_valid_refills s\<rbrace>
    commit_time
    \<lbrace>\<lambda>_ s. cur_sc_offset_ready (consumed_time s) s \<and> cur_sc_offset_sufficient (consumed_time s) s\<rbrace>"
   apply (clarsimp simp: commit_time_def)
@@ -2153,7 +2153,7 @@ lemma switch_sched_context_cur_sc_offset_ready_and_sufficient_consumed_time:
          \<longrightarrow> cur_sc_offset_ready (consumed_time s) s \<and> cur_sc_offset_sufficient (consumed_time s) s)
         \<and> (cur_thread s \<noteq> idle_thread s \<longrightarrow> ct_released s)
         \<and> valid_idle s
-        \<and> current_time_bounded 5 s
+        \<and> current_time_bounded s
         \<and> active_sc_valid_refills s\<rbrace>
    switch_sched_context
    \<lbrace>\<lambda>_ s :: det_state. cur_sc_offset_ready (consumed_time s) s \<and> cur_sc_offset_sufficient (consumed_time s) s\<rbrace>"
@@ -2224,7 +2224,7 @@ lemma switch_sched_context_cur_sc_offset_ready_and_sufficient_consumed_time:
          \<longrightarrow> cur_sc_offset_ready (consumed_time s) s \<and> cur_sc_offset_sufficient (consumed_time s) s)
         \<and> (cur_thread s \<noteq> idle_thread s \<longrightarrow> ct_released s)
         \<and> valid_idle s
-        \<and> current_time_bounded 5 s
+        \<and> current_time_bounded s
         \<and> active_sc_valid_refills s\<rbrace>
    sc_and_timer
    \<lbrace>\<lambda>_ s :: det_state. cur_sc_offset_ready (consumed_time s) s \<and> cur_sc_offset_sufficient (consumed_time s) s\<rbrace>"
@@ -2261,7 +2261,7 @@ lemma switch_to_thread_cur_sc_offset_ready_and_sufficient:
 
 lemma choose_thread_cur_sc_offset_ready_and_sufficient:
   "\<lbrace>\<lambda>s. cur_sc_more_than_ready s \<and> valid_ready_qs s \<and> active_sc_valid_refills s \<and> invs s
-        \<and> current_time_bounded 5 s\<rbrace>
+        \<and> current_time_bounded s\<rbrace>
    choose_thread
    \<lbrace>\<lambda>_ s. cur_sc_tcb_are_bound s \<and> cur_thread s \<noteq> idle_thread s
           \<longrightarrow> cur_sc_offset_ready (consumed_time s) s \<and> cur_sc_offset_sufficient (consumed_time s) s\<rbrace>"
@@ -2281,7 +2281,7 @@ lemma choose_thread_cur_sc_offset_ready_and_sufficient:
 
 lemma schedule_choose_new_thread_cur_sc_offset_ready_and_sufficient:
   "\<lbrace>\<lambda>s. cur_sc_more_than_ready s \<and> valid_ready_qs s \<and> active_sc_valid_refills s
-        \<and> invs s \<and> current_time_bounded 5 s \<rbrace>
+        \<and> invs s \<and> current_time_bounded s \<rbrace>
    schedule_choose_new_thread
    \<lbrace>\<lambda>_ s. cur_sc_tcb_are_bound s \<and> cur_thread s \<noteq> idle_thread s
           \<longrightarrow> cur_sc_offset_ready (consumed_time s) s \<and> cur_sc_offset_sufficient (consumed_time s) s\<rbrace>"
@@ -2296,14 +2296,14 @@ lemma schedule_choose_new_thread_cur_sc_offset_ready_and_sufficient:
 lemma schedule_switch_thread_branch_cur_sc_offset_ready_and_sufficient:
   "\<lbrace>\<lambda>s. cur_sc_more_than_ready s \<and> ct_ready_if_schedulable s
         \<and> valid_ready_qs s \<and> active_sc_valid_refills s \<and> valid_sched_action s
-        \<and> invs s \<and> current_time_bounded 5 s
+        \<and> invs s \<and> current_time_bounded s
         \<and> cur_thread s = ct \<and> ct_schdble = ct_schedulable s
         \<and> scheduler_action s = switch_thread candidate\<rbrace>
    schedule_switch_thread_branch candidate ct ct_schdble
    \<lbrace>\<lambda>_ s. cur_sc_tcb_are_bound s \<and> cur_thread s \<noteq> idle_thread s
           \<longrightarrow> cur_sc_offset_ready (consumed_time s) s \<and> cur_sc_offset_sufficient (consumed_time s) s\<rbrace>"
   apply (rule_tac B="\<lambda>_ s. cur_sc_more_than_ready s \<and> valid_ready_qs s \<and> active_sc_valid_refills s
-                           \<and> valid_sched_action s \<and> invs s \<and> current_time_bounded 5 s
+                           \<and> valid_sched_action s \<and> invs s \<and> current_time_bounded s
                            \<and> scheduler_action s = switch_thread candidate"
                in hoare_seq_ext[rotated])
    apply wpsimp
@@ -2371,8 +2371,7 @@ lemma schedule_choose_new_thread_ct_not_idle_imp_ct_released:
 lemma schedule_switch_thread_branch_ct_not_idle_imp_ct_released:
   "\<lbrace>\<lambda>s. ct_ready_if_schedulable s \<and> ct_schdble = schedulable ct s
         \<and> valid_ready_qs s \<and> active_sc_valid_refills s \<and> valid_sched_action s
-        \<and> (schact_is_rct s \<longrightarrow> cur_sc_active s)
-        \<and> current_time_bounded 5 s
+        \<and> current_time_bounded s
         \<and> cur_thread s = ct \<and> scheduler_action s = switch_thread candidate\<rbrace>
    schedule_switch_thread_branch candidate ct ct_schdble
    \<lbrace>\<lambda>_ s. cur_thread s \<noteq> idle_thread s \<longrightarrow> ct_released s\<rbrace>"
@@ -2408,7 +2407,7 @@ lemma schedule_cur_sc_offset_ready_and_sufficient:
         \<and> (schact_is_rct s \<longrightarrow> cur_sc_active s)
         \<and> (schact_is_rct s \<longrightarrow> ct_not_in_release_q s)
         \<and> (schact_is_rct s \<longrightarrow> ct_in_state activatable s)
-        \<and> invs s \<and> valid_sched s \<and> current_time_bounded 5 s\<rbrace>
+        \<and> invs s \<and> valid_sched s \<and> current_time_bounded s\<rbrace>
    schedule
    \<lbrace>\<lambda>_ s :: det_state. cur_sc_offset_ready (consumed_time s) s
                        \<and> cur_sc_offset_sufficient (consumed_time s) s\<rbrace>"
@@ -2511,7 +2510,7 @@ lemma call_kernel_cur_sc_offset_ready_and_sufficient:
         \<and> cur_sc_active s \<and> ct_not_in_release_q s
         \<and> (ct_running s \<or> ct_idle s) \<and> (e \<noteq> Interrupt \<longrightarrow> ct_running s)
         \<and> invs s \<and> schact_is_rct s \<and> valid_sched s
-        \<and> current_time_bounded 5 s \<and> valid_machine_time s \<and> consumed_time_bounded s\<rbrace>
+        \<and> current_time_bounded s \<and> valid_machine_time s \<and> consumed_time_bounded s\<rbrace>
    call_kernel e
    \<lbrace>\<lambda>_ s :: det_state. cur_sc_offset_ready (consumed_time s) s
                        \<and> cur_sc_offset_sufficient (consumed_time s) s\<rbrace>"
@@ -2554,7 +2553,7 @@ lemma call_kernel_cur_sc_offset_ready_and_sufficient:
   done
 
 crunches call_kernel
-  for current_time_bounded_5: "\<lambda>s :: det_state. current_time_bounded 5 s"
+  for current_time_bounded: "\<lambda>s :: det_state. current_time_bounded s"
   (wp: crunch_wps)
 
 crunches schedule, activate_thread

--- a/proof/invariant-abstract/DetSchedInvs_AI.thy
+++ b/proof/invariant-abstract/DetSchedInvs_AI.thy
@@ -1637,24 +1637,22 @@ abbreviation consumed_time_bounded :: "'z::state_ext state \<Rightarrow> bool" w
 lemmas consumed_time_bounded_def = consumed_time_bounded_2_def
 
 definition current_time_bounded_2 where
-  "current_time_bounded_2 k curtime \<equiv>
-   unat curtime + unat kernelWCET_ticks + k * unat MAX_PERIOD \<le> unat max_time"
+  "current_time_bounded_2 curtime \<equiv>
+   unat curtime + unat kernelWCET_ticks + time_buffer_const * unat MAX_PERIOD \<le> unat max_time"
 
-abbreviation current_time_bounded :: "nat \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
-  "current_time_bounded k s \<equiv> current_time_bounded_2 k (cur_time s)"
+abbreviation current_time_bounded :: "'z::state_ext state \<Rightarrow> bool" where
+  "current_time_bounded s \<equiv> current_time_bounded_2 (cur_time s)"
 
 lemmas current_time_bounded_def = current_time_bounded_2_def
-
-(* unat (cur_time s) + unat kernelWCET_ticks + 2 * unat MAX_SC_PERIOD \<le> unat max_time) *)
-
-\<comment> \<open>A predicate over all the components of state that determine scheduler validity.
-    Many operations will preserve all of these.\<close>
 
 abbreviation last_machine_time_of :: "'z state \<Rightarrow> time" where
   "last_machine_time_of s \<equiv> last_machine_time (machine_state s)"
 
 abbreviation time_state_of :: "'z state \<Rightarrow> nat" where
   "time_state_of s \<equiv> time_state (machine_state s)"
+
+\<comment> \<open>A predicate over all the components of state that determine scheduler validity.
+    Many operations will preserve all of these.\<close>
 
 type_synonym valid_sched_t
   = "time

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -6968,7 +6968,7 @@ lemma rec_del_corres:
                                                            \<and> cap_relation (snd r) (snd r') )
                           | _ \<Rightarrow> dc))
       (einvs and valid_machine_time and simple_sched_action
-            and valid_rec_del_call args and current_time_bounded 2
+            and valid_rec_del_call args and current_time_bounded
             and cte_at (slot_rdcall args)
             and (\<lambda>s. \<not> exposed_rdcall args \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) (slot_rdcall args) s)
             and (\<lambda>s. case args of ReduceZombieCall cap sl ex \<Rightarrow>
@@ -7105,7 +7105,7 @@ next
            apply (wp | simp)+
            apply (rule hoare_strengthen_post)
             apply (rule_tac Q="\<lambda>fin s. einvs s \<and> valid_machine_time s  \<and> simple_sched_action s
-                                      \<and> replaceable s slot (fst fin) rv \<and> current_time_bounded 2 s
+                                      \<and> replaceable s slot (fst fin) rv \<and> current_time_bounded s
                                       \<and> cte_wp_at ((=) rv) slot s \<and> s \<turnstile> fst fin
                                       \<and> (\<forall>t\<in>obj_refs (fst fin). halted_if_tcb t s)"
                        in hoare_vcg_conj_lift)
@@ -7382,7 +7382,7 @@ qed
 lemma cteDelete_corres:
   "corres (dc \<oplus> dc)
       (einvs and valid_machine_time and simple_sched_action
-       and current_time_bounded 2 and cte_at ptr)
+       and current_time_bounded and cte_at ptr)
       (invs' and sch_act_simple and cte_at' (cte_map ptr))
       (cap_delete ptr) (cteDelete (cte_map ptr) True)"
   unfolding cap_delete_def
@@ -7628,7 +7628,7 @@ lemma cap_revoke_mdb_stuff4:
 
 lemma cteRevoke_corres':
   "spec_corres s (dc \<oplus> dc)
-      (einvs and valid_machine_time and simple_sched_action and cte_at ptr and current_time_bounded 2)
+      (einvs and valid_machine_time and simple_sched_action and cte_at ptr and current_time_bounded)
       (invs' and sch_act_simple and cte_at' (cte_map ptr))
       (cap_revoke ptr) (\<lambda>s. cteRevoke (cte_map ptr) s)"
 proof (induct rule: cap_revoke.induct)
@@ -8652,7 +8652,7 @@ lemma invokeCNode_corres:
   "cnodeinv_relation ci ci' \<Longrightarrow>
    corres (dc \<oplus> dc)
      (einvs and valid_machine_time and simple_sched_action and valid_cnode_inv ci
-      and current_time_bounded 2)
+      and current_time_bounded)
      (invs' and sch_act_simple and valid_cnode_inv' ci')
      (invoke_cnode ci) (invokeCNode ci')"
   apply (simp add: invoke_cnode_def invokeCNode_def)

--- a/proof/refine/ARM/EmptyFail_H.thy
+++ b/proof/refine/ARM/EmptyFail_H.thy
@@ -314,7 +314,7 @@ crunch (empty_fail) empty_fail: callKernel
 theorem call_kernel_serial:
   "\<lbrakk> (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and (ct_running or ct_idle) and
                 (\<lambda>s. scheduler_action s = resume_cur_thread) and
-                current_time_bounded 5 and
+                current_time_bounded and
                 consumed_time_bounded and
                 valid_machine_time and
                 ct_not_in_release_q and

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -4338,7 +4338,7 @@ lemma interrupt_cap_null_or_ntfn:
 
 lemma (in delete_one) deletingIRQHandler_corres:
   "corres dc
-          (einvs and simple_sched_action and current_time_bounded 2)
+          (einvs and simple_sched_action and current_time_bounded)
           invs'
           (deleting_irq_handler irq) (deletingIRQHandler irq)"
   apply (simp add: deleting_irq_handler_def deletingIRQHandler_def)
@@ -4348,7 +4348,7 @@ lemma (in delete_one) deletingIRQHandler_corres:
       apply (rule_tac P'="cte_at' (cte_map slot)" in corres_symb_exec_r_conj)
          apply (rule_tac F="isNotificationCap rv \<or> rv = capability.NullCap"
              and P="cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) slot
-                 and einvs and simple_sched_action and current_time_bounded 2"
+                 and einvs and simple_sched_action and current_time_bounded"
              and P'="invs' and cte_wp_at' (\<lambda>cte. cteCap cte = rv)
                  (cte_map slot)" in corres_req)
           apply (clarsimp simp: cte_wp_at_caps_of_state state_relation_def)
@@ -4595,7 +4595,7 @@ lemma fast_finaliseCap_corres:
   "\<lbrakk> final_matters' cap' \<longrightarrow> final = final'; cap_relation cap cap';
      can_fast_finalise cap \<rbrakk>
    \<Longrightarrow> corres dc
-           (\<lambda>s. invs s \<and> valid_sched s \<and> s \<turnstile> cap \<and> current_time_bounded 2 s
+           (\<lambda>s. invs s \<and> valid_sched s \<and> s \<turnstile> cap \<and> current_time_bounded s
                        \<and> cte_wp_at ((=) cap) sl s)
            (\<lambda>s. invs' s \<and> s \<turnstile>' cap')
            (fast_finalise cap final)
@@ -4656,7 +4656,7 @@ lemma finaliseCap_true_removable[wp]:
 lemma cap_delete_one_corres:
   "corres dc
         (einvs and simple_sched_action and cte_wp_at can_fast_finalise slot
-         and current_time_bounded 2)
+         and current_time_bounded)
         (invs' and cte_at' (cte_map slot))
         (cap_delete_one slot) (cteDeleteOne (cte_map slot))"
   apply (simp add: cap_delete_one_def cteDeleteOne_def'
@@ -4931,7 +4931,7 @@ lemma finaliseCap_corres:
      \<Longrightarrow> corres (\<lambda>x y. cap_relation (fst x) (fst y) \<and> cap_relation (snd x) (snd y))
            (\<lambda>s. einvs s \<and> s \<turnstile> cap \<and> (final_matters cap \<longrightarrow> final = is_final_cap' cap s)
                 \<and> cte_wp_at ((=) cap) sl s \<and> simple_sched_action s
-                \<and> current_time_bounded 2 s)
+                \<and> current_time_bounded s)
            (\<lambda>s. invs' s \<and> s \<turnstile>' cap'
                    \<and> (final_matters' cap' \<longrightarrow>
                         final' = isFinal cap' (cte_map sl) (cteCaps_of s))

--- a/proof/refine/ARM/Interrupt_R.thy
+++ b/proof/refine/ARM/Interrupt_R.thy
@@ -358,7 +358,7 @@ lemma arch_invokeIRQHandler_corres:
 
 lemma invokeIRQHandler_corres:
   "irq_handler_inv_relation i i' \<Longrightarrow>
-   corres dc (einvs and irq_handler_inv_valid i and simple_sched_action and current_time_bounded 2)
+   corres dc (einvs and irq_handler_inv_valid i and simple_sched_action and current_time_bounded)
              (invs' and irq_handler_inv_valid' i' and sch_act_simple)
      (invoke_irq_handler i)
      (InterruptDecls_H.invokeIRQHandler i')"
@@ -373,7 +373,7 @@ lemma invokeIRQHandler_corres:
        apply (rule corres_split_nor [OF _ cap_delete_one_corres])
          apply (rule cteInsert_corres, simp+)
         apply (rule_tac Q="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
-                                  \<and> (a, b) \<noteq> irq_slot \<and> current_time_bounded 2 s
+                                  \<and> (a, b) \<noteq> irq_slot \<and> current_time_bounded s
                                   \<and> cte_wp_at (is_derived (cdt s) (a, b) cap) (a, b) s"
                       in hoare_post_imp)
          apply fastforce
@@ -635,7 +635,7 @@ lemma doMachineOp_ackDeadlineIRQ_invs'[wp]:
 
 lemma handleInterrupt_corres:
   "corres dc
-     (einvs and current_time_bounded 0) (invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive))
+     (einvs and current_time_bounded) (invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive))
      (handle_interrupt irq) (handleInterrupt irq)"
   (is "corres dc ?Q ?P' ?f ?g")
   apply (simp add: handle_interrupt_def handleInterrupt_def )

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -508,7 +508,7 @@ locale delete_one = delete_one_conc + delete_one_abs +
   assumes delete_one_corres:
     "corres dc
           (einvs and simple_sched_action and cte_wp_at can_fast_finalise ptr
-           and current_time_bounded 2)
+           and current_time_bounded)
           (invs' and cte_at' (cte_map ptr))
           (cap_delete_one ptr) (cteDeleteOne (cte_map ptr))"
 
@@ -2753,7 +2753,7 @@ crunches ifCondRefillUnblockCheck
 
 lemma restart_thread_if_no_fault_corres:
   "corres dc (valid_sched_action and tcb_at t and pspace_aligned and pspace_distinct
-              and valid_tcbs and active_sc_valid_refills and current_time_bounded 2)
+              and valid_tcbs and active_sc_valid_refills and current_time_bounded)
              (valid_queues and valid_queues' and valid_release_queue_iff and valid_objs')
              (restart_thread_if_no_fault t)
              (restartThreadIfNoFault t)"
@@ -2778,7 +2778,7 @@ lemma restart_thread_if_no_fault_corres:
           apply (rule_tac Q="\<lambda>scopt s. case_option True (\<lambda>p. sc_at p s) scopt \<and>
                                        tcb_at t s \<and> valid_sched_action s \<and>
                                        pspace_aligned s \<and> pspace_distinct s \<and> valid_tcbs s \<and>
-                                       active_sc_valid_refills s \<and> current_time_bounded 2 s"
+                                       active_sc_valid_refills s \<and> current_time_bounded s"
                  in hoare_strengthen_post[rotated])
            apply (fastforce split: option.splits simp: obj_at_def is_sc_obj opt_map_red)
           apply (wpsimp wp: thread_get_wp' simp: get_tcb_obj_ref_def)
@@ -2787,7 +2787,7 @@ lemma restart_thread_if_no_fault_corres:
         apply (clarsimp simp: fault_rel_optionation_def)
        apply (rule_tac Q="\<lambda>scopt s. tcb_at t s \<and> valid_sched_action s \<and>
                                     pspace_aligned s \<and> pspace_distinct s \<and> valid_tcbs s \<and>
-                                    active_sc_valid_refills s \<and> current_time_bounded 2 s"
+                                    active_sc_valid_refills s \<and> current_time_bounded s"
               in hoare_strengthen_post[rotated])
         apply (fastforce split: option.split simp: valid_tcbs_def valid_tcb_def valid_bound_obj_def)
        apply (wpsimp wp: sts_typ_ats set_thread_state_valid_sched_action)
@@ -2948,7 +2948,7 @@ lemma cancelAllIPC_corres_helper:
           ((\<lambda>s. \<forall>t \<in> set list. blocked_on_send_recv_tcb_at t s \<and> t \<noteq> idle_thread s
                                \<and> reply_unlink_ts_pred t s)
             and (valid_sched and valid_tcbs and pspace_aligned and pspace_distinct
-                 and current_time_bounded 2 and (\<lambda>s. heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s))))
+                 and current_time_bounded and (\<lambda>s. heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s))))
           ((\<lambda>s. \<forall>t \<in> set list. tcb_at' t s)
             and (valid_queues and valid_queues' and valid_objs' and valid_release_queue_iff))
      (mapM_x cancel_all_ipc_loop_body list)
@@ -2962,7 +2962,7 @@ lemma cancelAllIPC_corres_helper:
               apply (rule_tac P="\<lambda>s. blocked_on_send_recv_tcb_at t s \<and> t \<noteq> idle_thread s
                                      \<and> reply_unlink_ts_pred t s \<and> valid_sched s \<and> valid_tcbs s
                                      \<and> pspace_aligned s \<and> pspace_distinct s
-                                     \<and> st_tcb_at ((=) st) t s \<and> current_time_bounded 2 s"
+                                     \<and> st_tcb_at ((=) st) t s \<and> current_time_bounded s"
                           and P'="\<lambda>s. valid_queues s \<and> valid_queues' s \<and> valid_objs' s
                                       \<and> valid_release_queue_iff s"
                            in corres_inst)
@@ -3023,7 +3023,7 @@ lemma in_send_ep_queue_TCBBlockedSend:
   done
 
 lemma cancelAllIPC_corres:
-  "corres dc (invs and valid_sched and ep_at ep_ptr and current_time_bounded 2)
+  "corres dc (invs and valid_sched and ep_at ep_ptr and current_time_bounded)
              (invs' and ep_at' ep_ptr)
              (cancel_all_ipc ep_ptr) (cancelAllIPC ep_ptr)"
 proof -
@@ -3033,7 +3033,7 @@ proof -
           ((\<lambda>s. \<forall>t \<in> set list. blocked_on_send_recv_tcb_at t s \<and> t \<noteq> idle_thread s
                                \<and> reply_unlink_ts_pred t s)
             and (valid_sched and valid_tcbs and pspace_aligned and pspace_distinct and ep_at ep_ptr
-                 and current_time_bounded 2 and (\<lambda>s. heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s))))
+                 and current_time_bounded and (\<lambda>s. heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s))))
           ((\<lambda>s. \<forall>t \<in> set list. tcb_at' t s)
             and (valid_queues and valid_queues' and valid_objs' and valid_release_queue_iff
                  and ep_at' ep_ptr))
@@ -3131,7 +3131,7 @@ lemma ntfn_cancel_corres_helper:
            and valid_objs
            and pspace_aligned
            and pspace_distinct and (\<lambda>s. heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s))
-           and cur_tcb and current_time_bounded 2
+           and cur_tcb and current_time_bounded
            and K (distinct list))
           ((\<lambda>s. \<forall>t \<in> set list. tcb_at' t s)
            and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)
@@ -3171,7 +3171,7 @@ lemma ntfn_cancel_corres_helper:
                apply (wpsimp wp: get_tcb_obj_ref_wp)
               apply (wpsimp wp: threadGet_wp)
              apply (clarsimp cong: conj_cong imp_cong all_cong)
-             apply (rule_tac Q="\<lambda>_. pspace_aligned and pspace_distinct and current_time_bounded 2
+             apply (rule_tac Q="\<lambda>_. pspace_aligned and pspace_distinct and current_time_bounded
                                     and active_sc_valid_refills and valid_tcbs
                                     and valid_sched_action and tcb_at tp"
                     in hoare_strengthen_post[rotated])
@@ -3194,7 +3194,7 @@ lemma ntfn_cancel_corres_helper:
        apply (wpsimp wp: get_tcb_obj_ref_wp possible_switch_to_valid_sched_weak hoare_vcg_imp_lift')
         apply (rule_tac Q="\<lambda>_ s. tcb_at tp s \<longrightarrow>
                                    (bound (tcb_scps_of s tp) \<longrightarrow>  not_in_release_q tp s)
-                                   \<and> current_time_bounded 2 s
+                                   \<and> current_time_bounded s
                                    \<and> heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s)
                                    \<and> (pred_map (\<lambda>a. \<exists>y. a = Some y) (tcb_scps_of s) tp
                                        \<and> not_in_release_q tp s
@@ -3245,7 +3245,7 @@ crunches if_cond_refill_unblock_check
   (simp: crunch_simps)
 
 lemma cancelAllSignals_corres:
-  "corres dc (invs and valid_sched and ntfn_at ntfn and current_time_bounded 2)
+  "corres dc (invs and valid_sched and ntfn_at ntfn and current_time_bounded)
              (invs' and ntfn_at' ntfn)
              (cancel_all_signals ntfn) (cancelAllSignals ntfn)"
   apply add_sch_act_wf
@@ -3263,7 +3263,7 @@ lemma cancelAllSignals_corres:
           apply (simp add: dc_def)
           apply (rename_tac list)
           apply (rule_tac R="\<lambda>_ s. (\<forall>x\<in>set list. released_if_bound_sc_tcb_at x s)
-                                   \<and> current_time_bounded 2 s"
+                                   \<and> current_time_bounded s"
                  in hoare_post_add)
           apply (rule mapM_x_wp')
           apply wpsimp
@@ -4086,7 +4086,7 @@ lemma cancelBadgedSends_invs'[wp]:
 
 lemma restart_thread_if_no_fault_valid_sched_blocked_on_send:
   "\<lbrace>\<lambda>s. valid_sched s \<and> tcb_at t s \<and> heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s)
-        \<and> current_time_bounded 2 s
+        \<and> current_time_bounded s
         \<and> (epptr, TCBBlockedSend) \<in> state_refs_of s t \<and> t \<noteq> idle_thread s\<rbrace>
    restart_thread_if_no_fault t
    \<lbrace>\<lambda>_. valid_sched\<rbrace>"
@@ -4117,7 +4117,7 @@ lemma in_send_ep_queue_TCBBlockedSend':
   done
 
 lemma cancelBadgedSends_corres:
-  "corres dc (invs and valid_sched and ep_at epptr and current_time_bounded 2)
+  "corres dc (invs and valid_sched and ep_at epptr and current_time_bounded)
              (invs' and ep_at' epptr)
          (cancel_badged_sends epptr bdg) (cancelBadgedSends epptr bdg)"
   apply add_sym_refs
@@ -4129,7 +4129,7 @@ lemma cancelBadgedSends_corres:
    apply (clarsimp simp: sch_act_wf_asrt_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated[OF _ getEndpoint_corres get_simple_ko_sp get_ep_sp'
-                             , where Q="invs and valid_sched and current_time_bounded 2"
+                             , where Q="invs and valid_sched and current_time_bounded"
                                  and Q'="invs' and (\<lambda>s. sym_refs (state_refs_of' s))
                                          and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"])
     apply simp_all
@@ -4145,7 +4145,7 @@ lemma cancelBadgedSends_corres:
             apply (simp split: list.split add: ep_relation_def)
            apply (wp weak_sch_act_wf_lift_linear)+
          apply (rule_tac P="\<lambda>s. valid_sched s \<and> pspace_aligned s \<and> pspace_distinct s \<and> valid_tcbs s
-                                \<and> heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s) \<and> current_time_bounded 2 s"
+                                \<and> heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s) \<and> current_time_bounded s"
                      and Q="\<lambda>t s. tcb_at t s \<and> (epptr, TCBBlockedSend) \<in> state_refs_of s t
                                   \<and> t \<noteq> idle_thread s"
                      and P'="\<lambda>s. valid_objs' s \<and> weak_sch_act_wf (ksSchedulerAction s) s \<and> valid_queues s
@@ -4193,7 +4193,7 @@ lemma cancelBadgedSends_corres:
         apply (rule_tac Q="\<lambda>_ s. valid_tcbs s \<and> pspace_aligned s \<and> pspace_distinct s
                                  \<and> ep_at epptr s \<and> valid_sched s
                                  \<and> heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s)
-                                 \<and> current_time_bounded 2 s"
+                                 \<and> current_time_bounded s"
                      in hoare_strengthen_post)
          apply (rule_tac Q="\<lambda>t s. tcb_at t s \<and> (epptr, TCBBlockedSend) \<in> state_refs_of s t
                                   \<and> t \<noteq> idle_thread s"

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -2441,7 +2441,7 @@ lemma sendIPC_corres:
   assumes "call \<longrightarrow> bl"
   shows
   "corres dc (all_invs_but_fault_tcbs and fault_tcbs_valid_states_except_set {t} and valid_list
-              and active_sc_valid_refills and current_time_bounded 2
+              and active_sc_valid_refills and current_time_bounded
               and valid_sched_action and ep_at ep and ex_nonz_cap_to t and st_tcb_at active t
               and scheduler_act_not t and (\<lambda>s. cd \<longrightarrow> bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) t s))
              invs'
@@ -2460,7 +2460,7 @@ lemma sendIPC_corres:
              R="\<lambda>rv. all_invs_but_fault_tcbs and valid_list and st_tcb_at active t
                      and ep_at ep and valid_sched_action and active_sc_valid_refills
                      and valid_ep rv and obj_at (\<lambda>ob. ob = Endpoint rv) ep
-                     and ex_nonz_cap_to t and scheduler_act_not t and current_time_bounded 2
+                     and ex_nonz_cap_to t and scheduler_act_not t and current_time_bounded
                      and (\<lambda>s. cd \<longrightarrow> bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) t s)"
              and
              R'="\<lambda>rv'. invs' and cur_tcb' and tcb_at' t and sch_act_not t
@@ -2543,7 +2543,7 @@ lemma sendIPC_corres:
                                                     and pspace_distinct
                                                     and valid_tcbs
                                                     and active_sc_valid_refills
-                                                    and current_time_bounded 2"
+                                                    and current_time_bounded"
                                     in hoare_strengthen_post[rotated])
                               apply (case_tac r; clarsimp simp: pred_tcb_at_def obj_at_def is_tcb option.case_eq_if)
                               apply (drule sym[of "Some _"])
@@ -2557,7 +2557,7 @@ lemma sendIPC_corres:
                                                   and pspace_distinct
                                                   and valid_tcbs
                                                   and active_sc_valid_refills
-                                                  and current_time_bounded 2"
+                                                  and current_time_bounded"
                                   in hoare_strengthen_post[rotated])
                             apply (clarsimp simp: pred_tcb_at_def obj_at_def)
                            apply (wpsimp wp: set_thread_state_valid_sched_action)
@@ -2570,7 +2570,7 @@ lemma sendIPC_corres:
                         apply (wpsimp wp: threadGet_wp)
                        apply (rule_tac Q="\<lambda>_. valid_objs and pspace_aligned and pspace_distinct
                                               and tcb_at t' and active_sc_valid_refills
-                                              and valid_sched_action and current_time_bounded 2"
+                                              and valid_sched_action and current_time_bounded"
                               in hoare_strengthen_post[rotated])
                         apply clarsimp
                        apply (wpsimp wp: set_thread_state_valid_sched_action sched_context_donate_valid_sched_action
@@ -2593,7 +2593,7 @@ lemma sendIPC_corres:
                                reply_sc_reply_at (\<lambda>tptr. tptr = None) (the reply_opt) s \<and>
                                the reply_opt \<notin> fst ` replies_with_sc s \<and>
                                sym_refs (state_refs_of s)) and
-                          K (t \<noteq> idle_thread_ptr) and current_time_bounded 2 and
+                          K (t \<noteq> idle_thread_ptr) and current_time_bounded and
                           (\<lambda>s. cd \<longrightarrow> bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) t s) and valid_idle"
                         in hoare_strengthen_post[rotated])
                   apply (prop_tac "reply_opt \<noteq> None
@@ -2642,7 +2642,7 @@ lemma sendIPC_corres:
                         scheduler_act_not t and valid_sched_action
                         and st_tcb_at active t and tcb_at t' and
                         if_live_then_nonz_cap and scheduler_act_not t' and
-                        K (t \<noteq> idle_thread_ptr) and current_time_bounded 2 and
+                        K (t \<noteq> idle_thread_ptr) and current_time_bounded and
                         (\<lambda>s. cd \<longrightarrow> bound_sc_tcb_at (\<lambda>a. \<exists>y. a = Some y) t s) and
                         (\<lambda>s. reply_opt \<noteq> None
                           \<longrightarrow> st_tcb_at ((=) (Structures_A.thread_state.BlockedOnReceive ep reply_opt pl)) t' s
@@ -3417,7 +3417,7 @@ lemma cancelIPC_valid_idle'[wp]:
   done
 
 lemma sendSignal_corres:
-  "corres dc (einvs and ntfn_at ep and current_time_bounded 0) (invs' and ntfn_at' ep)
+  "corres dc (einvs and ntfn_at ep and current_time_bounded) (invs' and ntfn_at' ep)
              (send_signal ep bg) (sendSignal ep bg)"
   apply (simp add: send_signal_def sendSignal_def Let_def)
   apply add_sym_refs
@@ -3428,7 +3428,7 @@ lemma sendSignal_corres:
                  where
                  R  = "\<lambda>rv. einvs and ntfn_at ep and valid_ntfn rv and
                             ko_at (Structures_A.Notification rv) ep
-                            and current_time_bounded 0" and
+                            and current_time_bounded" and
                  R' = "\<lambda>rv'. invs' and valid_idle' and ntfn_at' ep and
                              valid_ntfn' rv' and ko_at' rv' ep"])
        defer
@@ -3491,7 +3491,7 @@ lemma sendSignal_corres:
                       (=) Structures_A.thread_state.IdleThreadState) tptr and
                    ex_nonz_cap_to tptr and fault_tcb_at ((=) None) tptr and
                    valid_sched and scheduler_act_not tptr and active_sc_valid_refills
-                   and current_time_bounded 0"
+                   and current_time_bounded"
                  in hoare_strengthen_post[rotated])
            apply (clarsimp simp: invs_def valid_state_def valid_pspace_def valid_sched_def pred_disj_def)
            apply (rule conjI, fastforce)
@@ -4110,7 +4110,7 @@ lemma completeSignal_corres:
   "corres dc
       (ntfn_at ntfnptr and tcb_at tcb and valid_objs and pspace_aligned and pspace_distinct
        and (\<lambda>s. sym_refs (state_refs_of s)) and (\<lambda>s. (Ipc_A.isActive |< ntfns_of s) ntfnptr)
-       and valid_sched and current_time_bounded 0)
+       and valid_sched and current_time_bounded)
       (ntfn_at' ntfnptr and tcb_at' tcb and invs' and obj_at' isActive ntfnptr)
       (complete_signal ntfnptr tcb) (completeSignal ntfnptr tcb)"
   apply (simp add: complete_signal_def completeSignal_def)
@@ -4650,7 +4650,7 @@ lemma receiveIPC_corres:
   assumes "is_ep_cap cap" and "cap_relation cap cap'" and "cap_relation reply_cap replyCap"
     and "is_reply_cap reply_cap \<or> (reply_cap = cap.NullCap)"
   shows
-    "corres dc (einvs and valid_cap cap and current_time_bounded 2
+    "corres dc (einvs and valid_cap cap and current_time_bounded
               and valid_cap reply_cap
               and st_tcb_at active thread
               and not_queued thread and not_in_release_q thread and scheduler_act_not thread
@@ -4697,7 +4697,7 @@ lemma receiveIPC_corres:
                 apply (rule maybeReturnSc_corres)
                apply (rule_tac P="einvs and ?tat and ?tex and ep_at epptr
                         and valid_ep ep and ko_at (Endpoint ep) epptr
-                        and current_time_bounded 2
+                        and current_time_bounded
                         and receive_ipc_preamble_rv reply_cap replyOpt and ?rrefs" and
                       P'="invs' and valid_idle' and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)
                           and cur_tcb' and tcb_at' thread and ep_at' epptr
@@ -4750,7 +4750,7 @@ lemma receiveIPC_corres:
                                apply (fold dc_def)[1]
                                apply (rule_tac P="valid_objs and valid_mdb and valid_list
                                                   and valid_sched and valid_replies and valid_idle
-                                                  and cur_tcb and current_time_bounded 2
+                                                  and cur_tcb and current_time_bounded
                                                   and pspace_aligned and pspace_distinct
                                                   and st_tcb_at is_blocked_on_send sender and ?tat
                                                   and receive_ipc_preamble_rv reply_cap replyOpt
@@ -4811,7 +4811,7 @@ lemma receiveIPC_corres:
                            apply (wpsimp wp: valid_bound_obj'_lift valid_replies'_sc_asrt_lift)
                           apply (clarsimp simp: tcb_relation_def)
                          apply (rule_tac Q="\<lambda>rv. all_invs_but_sym_refs and valid_sched
-                                                 and current_time_bounded 2 and tcb_at sender
+                                                 and current_time_bounded and tcb_at sender
                                                  and tcb_at thread and st_tcb_at is_blocked_on_send sender
                                                  and (\<lambda>s. \<forall>r\<in>zobj_refs reply_cap. ex_nonz_cap_to r s)
                                                  and valid_list and bound_sc_tcb_at ((=) rv) sender
@@ -4846,7 +4846,7 @@ lemma receiveIPC_corres:
                          apply (wpsimp wp: thread_get_wp')
                         apply (wpsimp wp: threadGet_wp)
                        apply (rule_tac Q="\<lambda>rv. all_invs_but_sym_refs and valid_sched and valid_list
-                                               and current_time_bounded 2 and tcb_at sender
+                                               and current_time_bounded and tcb_at sender
                                                and tcb_at thread and st_tcb_at is_blocked_on_send sender
                                                and (\<lambda>s. \<forall>r\<in>zobj_refs reply_cap. ex_nonz_cap_to r s)
                                                and (\<lambda>s. sym_refs
@@ -4919,7 +4919,7 @@ lemma receiveIPC_corres:
                apply fastforce
               \<comment> \<open> end of ep cases \<close>
               apply (rule_tac Q="\<lambda>_. einvs and ?tat and ?tex and
-                               ko_at (Endpoint ep) epptr and current_time_bounded 2 and
+                               ko_at (Endpoint ep) epptr and current_time_bounded and
                                receive_ipc_preamble_rv reply_cap replyOpt and ?rrefs"
                      in hoare_strengthen_post[rotated])
                apply (clarsimp, intro conjI)
@@ -4938,7 +4938,7 @@ lemma receiveIPC_corres:
         apply (wpsimp wp: get_simple_ko_wp)
        apply (wpsimp wp: getEndpoint_wp)
       apply simp
-      apply (rule_tac Q="\<lambda>r. invs and ep_at epptr and valid_list and current_time_bounded 2
+      apply (rule_tac Q="\<lambda>r. invs and ep_at epptr and valid_list and current_time_bounded
                              and scheduler_act_not thread and (\<lambda>s. thread \<noteq> idle_thread s)
                              and valid_sched and ?tat and ?tex
                              and receive_ipc_preamble_rv reply_cap r
@@ -5017,7 +5017,7 @@ lemma receiveSignal_corres:
  "\<lbrakk> is_ntfn_cap cap; cap_relation cap cap' \<rbrakk> \<Longrightarrow>
   corres dc ((invs and weak_valid_sched_action and scheduler_act_not thread and valid_ready_qs
                    and st_tcb_at active thread and active_sc_valid_refills and valid_release_q
-                   and current_time_bounded 0 and (\<lambda>s. thread = cur_thread s) and not_queued thread
+                   and current_time_bounded and (\<lambda>s. thread = cur_thread s) and not_queued thread
                    and not_in_release_q thread and ex_nonz_cap_to thread) and valid_cap cap)
             (invs' and tcb_at' thread and ex_nonz_cap_to' thread and valid_cap' cap')
             (receive_signal thread cap isBlocking) (receiveSignal thread cap' isBlocking)"
@@ -5145,7 +5145,7 @@ lemma sendFaultIPC_corres:
   "corres (fr \<oplus> (=))
           (invs and valid_list and valid_sched_action and active_sc_valid_refills
                 and st_tcb_at active thread and scheduler_act_not thread
-                and current_time_bounded 2
+                and current_time_bounded
                 and (\<lambda>s. can_donate \<longrightarrow> bound_sc_tcb_at (\<lambda>sc. sc \<noteq> None) thread s)
                 and valid_cap cap and K (valid_fault_handler cap) and K (valid_fault f))
           (invs' and valid_cap' cap')
@@ -6218,7 +6218,7 @@ lemma sfi_invs_plus':
 lemma handleFault_corres:
   assumes "fr f f'"
   shows "corres dc (invs and valid_list and valid_sched_action and active_sc_valid_refills
-                         and scheduler_act_not t and st_tcb_at active t and current_time_bounded 2
+                         and scheduler_act_not t and st_tcb_at active t and current_time_bounded
                          and ex_nonz_cap_to t and K (valid_fault f))
                    (invs' and sch_act_not t and st_tcb_at' active' t and ex_nonz_cap_to' t)
                    (handle_fault t f) (handleFault t f')"
@@ -6271,7 +6271,7 @@ lemma handleFault_corres:
 lemma handleTimeout_corres:
   assumes "fr f f'"
   shows "corres dc (invs and valid_list and valid_sched_action and active_sc_valid_refills
-                         and scheduler_act_not t and st_tcb_at active t and current_time_bounded 2
+                         and scheduler_act_not t and st_tcb_at active t and current_time_bounded
                          and cte_wp_at is_ep_cap (t,tcb_cnode_index 4) and K (valid_fault f))
                    invs'
                    (handle_timeout t f) (handleTimeout t f')"
@@ -6359,7 +6359,7 @@ lemma handleFaultReply_invs[wp]:
 
 lemma doReplyTransfer_corres:
   "corres dc
-     (einvs and reply_at reply and tcb_at sender and current_time_bounded 2)
+     (einvs and reply_at reply and tcb_at sender and current_time_bounded)
      invs'
      (do_reply_transfer sender reply grant)
      (doReplyTransfer sender reply grant)"
@@ -6371,7 +6371,7 @@ lemma doReplyTransfer_corres:
       apply (simp add: maybeM_def)
       apply (rule corres_option_split [OF refl corres_return_trivial])
       apply (rename_tac recv_opt receiverOpt recvr)
-      apply (rule_tac Q="\<lambda>s. einvs s \<and> tcb_at sender s \<and> tcb_at recvr s \<and> current_time_bounded 2 s \<and>
+      apply (rule_tac Q="\<lambda>s. einvs s \<and> tcb_at sender s \<and> tcb_at recvr s \<and> current_time_bounded s \<and>
                              reply_tcb_reply_at (\<lambda>xa. xa = Some recvr) reply s" and
                       Q'="invs' and cur_tcb'"
              in corres_split [OF _ _ gts_sp gts_sp' ])
@@ -6386,7 +6386,7 @@ lemma doReplyTransfer_corres:
                  apply (rule corres_split)
                     apply (rule_tac P="tcb_at sender and tcb_at recvr and valid_objs and pspace_aligned and
                                        valid_list and pspace_distinct and valid_mdb and cur_tcb
-                                       and current_time_bounded 2" and
+                                       and current_time_bounded" and
                                     P'="tcb_at' sender and tcb_at' recvr and valid_pspace' and cur_tcb' and
                                         valid_release_queue and valid_release_queue'"
                            in corres_guard_imp)
@@ -6409,7 +6409,7 @@ lemma doReplyTransfer_corres:
                                    apply (clarsimp simp: valid_tcb_state_def)
                                    apply (rule_tac Q="\<lambda>_. valid_objs and pspace_aligned and
                                                           pspace_distinct and tcb_at recvr
-                                                          and current_time_bounded 2" in
+                                                          and current_time_bounded" in
                                            hoare_strengthen_post[rotated])
                                     apply (clarsimp simp: valid_objs_valid_tcbs)
                                    apply (wpsimp wp: thread_set_fault_valid_objs)
@@ -6441,10 +6441,10 @@ lemma doReplyTransfer_corres:
                                           valid_release_q and active_sc_valid_refills and
                                           (\<lambda>s. sc_tcb_sc_at (\<lambda>sc. \<exists>t. sc = Some t \<and> not_queued t s) (the scopt) s) and
                                           invs and valid_list and scheduler_act_not recvr
-                                          and current_time_bounded 2 and st_tcb_at active recvr"
+                                          and current_time_bounded and st_tcb_at active recvr"
                                    and Q'="invs' and tcb_at' recvr and sc_at' (the scopt) and cur_tcb'"
                                    and P'="invs' and sc_at' (the scopt') and tcb_at' recvr and cur_tcb'"
-                                   and P="valid_sched_action and tcb_at recvr and current_time_bounded 2 and
+                                   and P="valid_sched_action and tcb_at recvr and current_time_bounded and
                                           sc_tcb_sc_at (\<lambda>a. a \<noteq> None) (the scopt) and
                                           active_sc_at (the scopt) and valid_refills (the scopt) and
                                           valid_release_q and active_sc_valid_refills and
@@ -6466,7 +6466,7 @@ lemma doReplyTransfer_corres:
                                  apply (rule_tac Q="\<lambda>_. sc_badge sc = scBadge sc'" in corres_cross_add_guard[rotated])
                                   apply (rule_tac corres_gen_asm2)
                                   apply (rule_tac Q="\<lambda>s. active_sc_valid_refills s \<and>
-                                           is_active_sc (the scopt') s \<and> current_time_bounded 2 s \<and>
+                                           is_active_sc (the scopt') s \<and> current_time_bounded s \<and>
                                            sc_tcb_sc_at (\<lambda>sc. \<exists>t. sc = Some t \<and> not_queued t s) (the scopt) s \<and>
                                            invs s \<and> valid_release_q s \<and> tcb_at recvr s \<and>
                                            valid_list s \<and> valid_sched_action s \<and>
@@ -6562,7 +6562,7 @@ lemma doReplyTransfer_corres:
                    apply (wpsimp wp: gts_wp')
                   apply (rule_tac Q="\<lambda>_. tcb_at recvr and valid_sched_action and invs and valid_list
                                          and valid_release_q and scheduler_act_not recvr
-                                         and active_sc_valid_refills and current_time_bounded 2
+                                         and active_sc_valid_refills and current_time_bounded
                                          and active_if_bound_sc_tcb_at recvr
                                          and not_queued recvr"
                          in hoare_strengthen_post[rotated])
@@ -6583,7 +6583,7 @@ lemma doReplyTransfer_corres:
                       apply (rule_tac Q="\<lambda>_ s.
                                 st_tcb_at inactive recvr s \<and>
                                 invs s \<and> valid_list s \<and> scheduler_act_not recvr s \<and>
-                                ex_nonz_cap_to recvr s \<and> current_time_bounded 2 s \<and>
+                                ex_nonz_cap_to recvr s \<and> current_time_bounded s \<and>
                                 recvr \<noteq> idle_thread s \<and>
                                 fault_tcb_at ((=) None) recvr s \<and>
                                 valid_release_q s \<and>
@@ -6623,7 +6623,7 @@ lemma doReplyTransfer_corres:
               apply (rule_tac Q="\<lambda>_. tcb_at sender and tcb_at recvr and invs and valid_list and
                         valid_sched and scheduler_act_not recvr and not_in_release_q recvr and
                         active_if_bound_sc_tcb_at recvr and st_tcb_at inactive recvr and
-                        ex_nonz_cap_to recvr and not_queued recvr and current_time_bounded 2"
+                        ex_nonz_cap_to recvr and not_queued recvr and current_time_bounded"
                      in hoare_strengthen_post[rotated])
                apply (clarsimp simp: valid_sched_def invs_def valid_state_def valid_pspace_def
                                      pred_tcb_at_def obj_at_def
@@ -6641,7 +6641,7 @@ lemma doReplyTransfer_corres:
          apply (rule_tac Q="\<lambda>_. tcb_at sender and tcb_at recvr and invs and valid_list and
                    valid_sched and scheduler_act_not recvr and not_in_release_q recvr and
                    active_if_bound_sc_tcb_at recvr and st_tcb_at inactive recvr and
-                   ex_nonz_cap_to recvr and not_queued recvr and current_time_bounded 2"
+                   ex_nonz_cap_to recvr and not_queued recvr and current_time_bounded"
                 in hoare_strengthen_post[rotated])
           apply (clarsimp simp: valid_sched_def invs_def valid_state_def valid_pspace_def
                          dest!: idle_no_ex_cap)

--- a/proof/refine/ARM/SchedContextInv_R.thy
+++ b/proof/refine/ARM/SchedContextInv_R.thy
@@ -702,7 +702,7 @@ lemma invokeSchedContext_corres:
   "sc_inv_rel sc_inv sc_inv' \<Longrightarrow>
    corres (=)
           (einvs and valid_sched_context_inv sc_inv and simple_sched_action
-           and current_time_bounded 2)
+           and current_time_bounded)
           (invs' and sch_act_simple and valid_sc_inv' sc_inv')
           (invoke_sched_context sc_inv)
           (invokeSchedContext sc_inv')"
@@ -1255,7 +1255,7 @@ lemma invokeSchedControlConfigureFlags_corres:
    corres dc
           (einvs and valid_sched_control_inv sc_inv and cur_sc_active and schact_is_rct
            and ct_not_in_release_q and ct_active
-           and current_time_bounded 5 and consumed_time_bounded
+           and current_time_bounded and consumed_time_bounded
            and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s)
            and (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s))
           (invs' and sch_act_simple and valid_sc_ctrl_inv' sc_inv' and ct_active')
@@ -1363,7 +1363,7 @@ lemma invokeSchedControlConfigureFlags_corres:
                      simp: sc_const_eq)
 
   apply (rename_tac sc')
-  apply (rule_tac Q="\<lambda>_ s. invs s \<and> schact_is_rct s \<and> current_time_bounded 5 s
+  apply (rule_tac Q="\<lambda>_ s. invs s \<and> schact_is_rct s \<and> current_time_bounded s
                            \<and> valid_sched_action s \<and> active_sc_valid_refills s
                            \<and> valid_ready_qs s \<and> valid_release_q s
                            \<and> sc_at (cur_sc s) s
@@ -1473,7 +1473,7 @@ lemma invokeSchedControlConfigureFlags_corres:
    apply (wps_conj_solves wp: commitTime_invs' tcbReleaseRemove_invs'
                         simp: active_sc_at'_rewrite)
 
-  apply (rule_tac Q="\<lambda>_ s. invs s \<and> schact_is_rct s \<and> current_time_bounded 5 s
+  apply (rule_tac Q="\<lambda>_ s. invs s \<and> schact_is_rct s \<and> current_time_bounded s
                            \<and> valid_sched_action s \<and> active_sc_valid_refills s
                            \<and> valid_ready_qs s \<and> valid_release_q s
                            \<and> sc_at (cur_sc s) s

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -5010,7 +5010,7 @@ crunches ifCondRefillUnblockCheck
 
 lemma switchSchedContext_corres:
   "corres dc (\<lambda>s. valid_state s \<and> cur_tcb s \<and> sc_at (cur_sc s) s  \<and> active_sc_valid_refills s
-                  \<and> current_time_bounded 1 s \<and> active_sc_tcb_at (cur_thread s) s)
+                  \<and> current_time_bounded s \<and> active_sc_tcb_at (cur_thread s) s)
              valid_objs'
              switch_sched_context
              switchSchedContext"
@@ -5087,7 +5087,7 @@ crunches schedule_choose_new_thread
 lemma scAndTimer_corres:
   "corres dc (\<lambda>s. valid_state s \<and> cur_tcb s \<and> sc_at (cur_sc s) s
                   \<and> active_sc_valid_refills s \<and> valid_release_q s
-                  \<and> current_time_bounded 1 s \<and> active_sc_tcb_at (cur_thread s) s)
+                  \<and> current_time_bounded s \<and> active_sc_tcb_at (cur_thread s) s)
              invs'
              sc_and_timer
              scAndTimer"
@@ -5147,7 +5147,7 @@ lemma schedule_switch_thread_branch_valid_state_and_cur_tcb:
   done
 
 lemma schedule_corres:
-  "corres dc (invs and valid_sched and current_time_bounded 1 and ct_ready_if_schedulable
+  "corres dc (invs and valid_sched and current_time_bounded and ct_ready_if_schedulable
               and (\<lambda>s. schact_is_rct s \<longrightarrow> cur_sc_active s))
              invs'
              (Schedule_A.schedule)

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -391,17 +391,16 @@ lemma performInvocation_corres:
    corres (dc \<oplus> (=))
      (einvs and valid_machine_time and valid_invocation i
             and schact_is_rct
-            and current_time_bounded 2
+            and current_time_bounded
             and ct_active
             and ct_released
             and ct_not_in_release_q
             and (\<lambda>s. (\<exists>w w2 b c. i = Invocations_A.InvokeEndpoint w w2 b c) \<longrightarrow> st_tcb_at simple (cur_thread s) s)
-            and cur_sc_active and current_time_bounded 5 and consumed_time_bounded
+            and cur_sc_active and current_time_bounded and consumed_time_bounded
             and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s)
             and (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s))
      (invs' and sch_act_simple and valid_invocation' i' and ct_active' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
      (perform_invocation block call can_donate i) (performInvocation block call can_donate i')"
-  supply current_time_bounded_strengthen[of 2 _ 0, elim!]
   apply (simp add: performInvocation_def)
   apply add_sym_refs
   apply (case_tac i)
@@ -1279,7 +1278,7 @@ lemma handleInvocation_corres:
    corres (dc \<oplus> dc)
           (einvs and valid_machine_time and schact_is_rct and ct_active and ct_released
            and (\<lambda>s. active_sc_tcb_at (cur_thread s) s) and ct_not_in_release_q
-           and cur_sc_active and current_time_bounded 5 and consumed_time_bounded
+           and cur_sc_active and current_time_bounded and consumed_time_bounded
            and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s)
            and (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s))
           (invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
@@ -1338,7 +1337,7 @@ lemma handleInvocation_corres:
                                  and (\<lambda>s. thread = cur_thread s)
                                  and st_tcb_at active thread
                                  and ct_not_in_release_q and ct_released
-                                 and cur_sc_active and current_time_bounded 5
+                                 and cur_sc_active and current_time_bounded
                                  and consumed_time_bounded
                                  and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s)
                                  and (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s)"
@@ -1474,7 +1473,7 @@ lemma handleSend_corres:
   "corres (dc \<oplus> dc)
           (einvs and valid_machine_time and schact_is_rct and ct_active
            and ct_released and (\<lambda>s. active_sc_tcb_at (cur_thread s) s)
-           and ct_not_in_release_q and cur_sc_active and current_time_bounded 5
+           and ct_not_in_release_q and cur_sc_active and current_time_bounded
            and  consumed_time_bounded and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s)
            and (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s))
           (invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
@@ -1600,7 +1599,7 @@ lemma getBoundNotification_corres:
   done
 
 lemma handleRecv_isBlocking_corres':
-   "corres dc (einvs and ct_in_state active and current_time_bounded 2
+   "corres dc (einvs and ct_in_state active and current_time_bounded
                and scheduler_act_sane and ct_not_queued and ct_not_in_release_q
                and (\<lambda>s. ex_nonz_cap_to (cur_thread s) s))
               (invs' and ct_in_state' simple'
@@ -1693,7 +1692,7 @@ lemma handleRecv_isBlocking_corres':
   done
 
 lemma handleRecv_isBlocking_corres:
-  "corres dc (einvs and ct_active and scheduler_act_sane and current_time_bounded 2
+  "corres dc (einvs and ct_active and scheduler_act_sane and current_time_bounded
               and ct_not_queued and ct_not_in_release_q)
              (invs' and ct_active' and sch_act_sane and
                     (\<lambda>s. \<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p)))
@@ -1761,7 +1760,7 @@ lemma cur_sc_tcb_are_bound_sym:
 lemma endTimeslice_corres: (* called when ct_schedulable *)
   "corres dc
      (invs and valid_list and valid_sched_action and active_sc_valid_refills and valid_release_q
-      and valid_ready_qs and cur_sc_active and ct_active and current_time_bounded 2
+      and valid_ready_qs and cur_sc_active and ct_active and current_time_bounded
       and ct_not_queued
       and cur_sc_tcb_are_bound and scheduler_act_sane)
      invs'
@@ -1990,7 +1989,7 @@ lemma chargeBudget_corres:
   "corres dc
      (invs and valid_list and valid_sched_action and active_sc_valid_refills and valid_release_q
       and valid_ready_qs and released_ipc_queues and cur_sc_active
-      and current_time_bounded 5 and cur_sc_chargeable and scheduler_act_sane
+      and current_time_bounded and cur_sc_chargeable and scheduler_act_sane
       and ct_not_queued and ct_not_in_release_q and ct_not_blocked
       and cur_sc_offset_ready 0)
      invs'
@@ -2130,8 +2129,8 @@ lemma chargeBudget_corres:
 
 lemma checkBudget_corres: (* called when ct_schedulable or in checkBudgetRestart *)
   "corres (=)
-     (einvs and current_time_bounded 5 and cur_sc_offset_ready 0 and cur_sc_chargeable
-      and cur_sc_active and ct_not_blocked and current_time_bounded 2
+     (einvs and current_time_bounded and cur_sc_offset_ready 0 and cur_sc_chargeable
+      and cur_sc_active and ct_not_blocked
       and ct_not_queued and ct_not_in_release_q and scheduler_act_sane)
      invs'
      check_budget checkBudget"
@@ -2159,8 +2158,8 @@ lemma checkBudget_corres: (* called when ct_schedulable or in checkBudgetRestart
 lemma handleYield_corres:
   "corres dc
      (einvs and ct_active and cur_sc_active and schact_is_rct and scheduler_act_sane
-      and current_time_bounded 5 and cur_sc_offset_ready 0
-      and ct_not_queued and ct_not_in_release_q and current_time_bounded 2)
+      and current_time_bounded and cur_sc_offset_ready 0
+      and ct_not_queued and ct_not_in_release_q)
      invs'
      handle_yield handleYield"
   (is "corres _ ?pre ?pre' _ _")
@@ -2302,7 +2301,7 @@ lemmas cteDeleteOne_st_tcb_at_simple'[wp] =
 lemma handleCall_corres:
   "corres (dc \<oplus> dc) (einvs and valid_machine_time and schact_is_rct and ct_active
                      and ct_released and (\<lambda>s. active_sc_tcb_at (cur_thread s) s)
-                     and ct_not_in_release_q and cur_sc_active and current_time_bounded 5
+                     and ct_not_in_release_q and cur_sc_active and current_time_bounded
                      and consumed_time_bounded
                      and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s)
                      and (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s))
@@ -2600,9 +2599,9 @@ lemma released_imp_active_sc_tcb_at:
 
 lemma checkBudgetRestart_corres:
   "corres (=)
-     (einvs and current_time_bounded 5 and cur_sc_offset_ready 0
+     (einvs and current_time_bounded and cur_sc_offset_ready 0
       and cur_sc_active and ct_in_state activatable and schact_is_rct
-      and ct_not_queued and ct_not_in_release_q and current_time_bounded 2)
+      and ct_not_queued and ct_not_in_release_q)
      invs'
      check_budget_restart checkBudgetRestart"
   unfolding check_budget_restart_def checkBudgetRestart_def
@@ -2630,7 +2629,7 @@ lemma handleInv_handleRecv_corres:
   "corres (dc \<oplus> dc)
      (einvs and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread) and
       valid_machine_time and
-      current_time_bounded 5 and
+      current_time_bounded and
       consumed_time_bounded and
       cur_sc_active and
       ct_released and
@@ -2680,7 +2679,7 @@ lemma handleInv_handleRecv_corres:
    apply (rule corres_guard_imp)
      apply (rule corres_split_liftEE[OF getCapReg_corres_gen])
        apply (rule corres_splitEE[OF _ handleInvocation_corres])
-           apply (rule_tac P="(einvs and ct_active and scheduler_act_sane and current_time_bounded 2
+           apply (rule_tac P="(einvs and ct_active and scheduler_act_sane and current_time_bounded
                               and ct_not_queued and ct_not_in_release_q)"
                       and P'="(invs')"
                   in corres_inst)
@@ -2703,8 +2702,7 @@ lemma handleInv_handleRecv_corres:
            apply (case_tac "scheduler_action s"; simp)
           apply simp
          apply simp
-        apply ((wpsimp wp: handle_invocation_valid_sched
-              | strengthen current_time_bounded_strengthen[where k=5])+)[1]
+        apply (wpsimp wp: handle_invocation_valid_sched)
        apply wpsimp
       apply wpsimp
      apply wpsimp
@@ -2721,7 +2719,7 @@ abbreviation (input)
   "a_pre \<equiv> (einvs and ct_running and
          (\<lambda>s. scheduler_action s = resume_cur_thread) and
          valid_machine_time and
-         current_time_bounded 5 and
+         current_time_bounded and
          consumed_time_bounded and
          cur_sc_active and (ct_active or ct_idle) and
          ct_not_in_release_q and
@@ -2750,7 +2748,7 @@ lemma updateTimeStamp_checkBudgetRestart_helper:
       apply (rule_tac P="\<lambda> s. (cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s)
                                \<and> cur_sc_active s \<and> ct_running s \<and> valid_machine_time s
                                \<and> ct_released s \<and> ct_not_in_release_q s \<and> ct_not_queued s
-                               \<and> current_time_bounded 5 s \<and> consumed_time_bounded s \<and> einvs s
+                               \<and> current_time_bounded s \<and> consumed_time_bounded s \<and> einvs s
                                \<and> scheduler_action s = resume_cur_thread"
                  and P'=c_pre in corres_inst)
       apply (rule corres_guard_imp)
@@ -2761,7 +2759,7 @@ lemma updateTimeStamp_checkBudgetRestart_helper:
            apply (rule_tac P="\<lambda>s. (cur_sc_offset_ready (consumed_time s) s \<and> einvs s
                                    \<and> cur_sc_active s \<and> valid_machine_time s \<and> ct_running s
                                    \<and> ct_released s \<and> ct_not_in_release_q s \<and> ct_not_queued s
-                                   \<and> current_time_bounded 5 s \<and> consumed_time_bounded s
+                                   \<and> current_time_bounded s \<and> consumed_time_bounded s
                                    \<and> scheduler_action s = resume_cur_thread)
                                    \<and> cur_sc_offset_sufficient (consumed_time s) s"
                       and P'=c_pre in corres_inst)
@@ -2773,10 +2771,10 @@ lemma updateTimeStamp_checkBudgetRestart_helper:
          apply (wpsimp wp: check_budget_restart_false check_budget_restart_true')
         apply (wpsimp wp: checkBudgetRestart_false checkBudgetRestart_true)
        apply (clarsimp dest!: active_from_running
-                        simp: cur_sc_offset_ready_def current_time_bounded_strengthen pred_map_def
+                        simp: cur_sc_offset_ready_def pred_map_def
                               ct_in_state_weaken[OF _ active_activatable])
       apply clarsimp
-     apply (wpsimp wp: update_time_stamp_current_time_bounded_5
+     apply (wpsimp wp: update_time_stamp_current_time_bounded
                        update_time_stamp_cur_sc_offset_ready_cs)
     apply wpsimp
    apply clarsimp+
@@ -2798,7 +2796,7 @@ lemma updateTimeStamp_checkBudgetRestart_helperE:
       apply (rule_tac P="\<lambda> s. (cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s)
                                \<and> cur_sc_active s \<and> ct_running s \<and> valid_machine_time s
                                \<and> ct_released s \<and> ct_not_in_release_q s \<and> ct_not_queued s
-                               \<and> current_time_bounded 5 s \<and> consumed_time_bounded s \<and> einvs s
+                               \<and> current_time_bounded s \<and> consumed_time_bounded s \<and> einvs s
                                \<and> scheduler_action s = resume_cur_thread"
                  and P'=c_pre in corres_inst)
       apply (rule corres_guard_imp)
@@ -2809,7 +2807,7 @@ lemma updateTimeStamp_checkBudgetRestart_helperE:
            apply (rule_tac P="\<lambda>s. (cur_sc_offset_ready (consumed_time s) s \<and> einvs s
                                    \<and> cur_sc_active s \<and> valid_machine_time s \<and> ct_running s
                                    \<and> ct_released s \<and> ct_not_in_release_q s \<and> ct_not_queued s
-                                   \<and> current_time_bounded 5 s \<and> consumed_time_bounded s
+                                   \<and> current_time_bounded s \<and> consumed_time_bounded s
                                    \<and> scheduler_action s = resume_cur_thread)
                                    \<and> cur_sc_offset_sufficient (consumed_time s) s"
                       and P'=c_pre in corres_inst)
@@ -2822,10 +2820,10 @@ lemma updateTimeStamp_checkBudgetRestart_helperE:
          apply (wpsimp wp: check_budget_restart_false check_budget_restart_true')
         apply (wpsimp wp: checkBudgetRestart_false checkBudgetRestart_true)
        apply (clarsimp dest!: active_from_running
-                        simp: cur_sc_offset_ready_def current_time_bounded_strengthen pred_map_def
+                        simp: cur_sc_offset_ready_def pred_map_def
                               ct_in_state_weaken[OF _ active_activatable])
       apply clarsimp
-     apply (wpsimp wp: update_time_stamp_current_time_bounded_5
+     apply (wpsimp wp: update_time_stamp_current_time_bounded
                        update_time_stamp_cur_sc_offset_ready_cs)
     apply wpsimp
    apply clarsimp+
@@ -2835,7 +2833,7 @@ lemma handleEvent_corres:
   "corres (dc \<oplus> dc)
      (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s)
       and (\<lambda>s. scheduler_action s = resume_cur_thread)
-      and valid_machine_time and current_time_bounded 5
+      and valid_machine_time and current_time_bounded
       and consumed_time_bounded and cur_sc_active and (ct_active or ct_idle)
       and ct_not_in_release_q and ct_not_queued
       and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s)
@@ -2848,7 +2846,7 @@ lemma handleEvent_corres:
 proof -
   have hw:
     "\<And>isBlocking canGrant.
-     corres dc (einvs and ct_running and valid_machine_time and current_time_bounded 2
+     corres dc (einvs and ct_running and valid_machine_time and current_time_bounded
                 and ct_released and (\<lambda>s. scheduler_action s = resume_cur_thread)
                 and ct_not_in_release_q and ct_not_queued)
                (invs' and ct_running'
@@ -2880,7 +2878,7 @@ proof -
                                       corres_guard_imp[OF handleInv_handleRecv_corres]
                                       corres_guard_imp[OF handleYield_corres]
                                       active_from_running active_from_running' released_imp_active_sc_tcb_at
-                               simp: simple_sane_strg current_time_bounded_strengthen
+                               simp: simple_sane_strg
                               dest!: schact_is_rct)[11]
         apply (rule updateTimeStamp_checkBudgetRestart_helper)
         apply (rule corres_split')
@@ -2915,7 +2913,7 @@ proof -
              apply (rule_tac P="\<lambda> s. (cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s)
                                       \<and> cur_sc_active s \<and> valid_machine_time s \<and> (ct_active s \<or> ct_idle s)
                                       \<and> ct_not_in_release_q s \<and> ct_not_queued s
-                                      \<and> current_time_bounded 5 s \<and> consumed_time_bounded s \<and> einvs s
+                                      \<and> current_time_bounded s \<and> consumed_time_bounded s \<and> einvs s
                                       \<and> scheduler_action s = resume_cur_thread"
                         and P'="(invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
                                  (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)) and
@@ -2924,14 +2922,14 @@ proof -
                     in corres_inst)
              apply (rule corres_guard_imp)
                apply (rule corres_split[OF checkBudget_corres])
-                 apply (rule_tac P="einvs and current_time_bounded 0"
+                 apply (rule_tac P="einvs and current_time_bounded"
                             and P'="invs' and (\<lambda>s. \<forall>x. active = Some x \<longrightarrow> intStateIRQTable (ksInterruptState s) x \<noteq> irqstate.IRQInactive)"
                         in corres_inst)
                  apply (case_tac active; simp)
                  apply (rule handleInterrupt_corres)
                 apply (wpsimp wp: check_budget_valid_sched)
                apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift)
-              apply (wpsimp wp: update_time_stamp_current_time_bounded_5 hoare_vcg_disj_lift
+              apply (wpsimp wp: update_time_stamp_current_time_bounded hoare_vcg_disj_lift
                                 update_time_stamp_cur_sc_offset_ready_cs)
               apply (clarsimp simp: cur_sc_offset_ready_weaken_zero active_from_running current_time_bounded_def)
               apply (frule invs_cur_sc_chargeableE)
@@ -2945,7 +2943,7 @@ proof -
               apply (rule ct_activatable_ct_not_blocked)
               apply (fastforce simp: ct_in_state_def pred_tcb_at_def obj_at_def dest!: active_activatable)
              apply clarsimp
-            apply (wpsimp wp: update_time_stamp_current_time_bounded_5 hoare_vcg_disj_lift
+            apply (wpsimp wp: update_time_stamp_current_time_bounded hoare_vcg_disj_lift
                               update_time_stamp_cur_sc_offset_ready_cs)
            apply wpsimp
           apply (rule corres_Id, simp+)

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -170,7 +170,7 @@ crunches cancel_ipc
 
 lemma restart_corres:
   "corres dc
-          (einvs and tcb_at t and ex_nonz_cap_to t and current_time_bounded 2)
+          (einvs and tcb_at t and ex_nonz_cap_to t and current_time_bounded)
           (invs' and tcb_at' t and ex_nonz_cap_to' t)
           (Tcb_A.restart t) (ThreadDecls_H.restart t)"
   apply (simp add: Tcb_A.restart_def Thread_H.restart_def test_possible_switch_to_def
@@ -202,7 +202,7 @@ lemma restart_corres:
                  apply wpsimp
                 apply (fastforce simp: invs'_def sch_act_wf_weak valid_pspace'_def)
                apply (rule_tac Q="\<lambda>rv. invs and valid_ready_qs and valid_release_q
-                                            and current_time_bounded 2
+                                            and current_time_bounded
                                             and (\<lambda>s. \<exists>scp. scOpt = Some scp \<longrightarrow> sc_not_in_release_q scp s)
                                             and active_sc_valid_refills and valid_sched_action
                                             and scheduler_act_not t and bound_sc_tcb_at ((=) scOpt) t"
@@ -222,7 +222,7 @@ lemma restart_corres:
                               wp: refillUnblockCheck_invs')
              apply (clarsimp simp: thread_state_relation_def)
             apply (rule_tac Q="\<lambda>rv. invs and valid_ready_qs and valid_release_q
-                                         and current_time_bounded 2
+                                         and current_time_bounded
                                          and (\<lambda>s. \<forall>scp. scOpt = Some scp \<longrightarrow> sc_not_in_release_q scp s)
                                          and active_sc_valid_refills and valid_sched_action
                                          and scheduler_act_not t and bound_sc_tcb_at ((=) scOpt) t"
@@ -241,7 +241,7 @@ lemma restart_corres:
             apply (clarsimp simp: invs'_def valid_pspace'_def o_def)
            apply (wpsimp wp: setThreadState_Restart_invs' hoare_drop_imps)
           apply (rule_tac Q="\<lambda>rv. invs and valid_sched and valid_sched_action and tcb_at t
-                                       and current_time_bounded 2
+                                       and current_time_bounded
                                        and (\<lambda>s. \<forall>scp. scOpt = Some scp \<longrightarrow> sc_not_in_release_q scp s)
                                        and fault_tcb_at ((=) None) t and bound_sc_tcb_at ((=) scOpt) t
                                        and st_tcb_at (\<lambda>st'. tcb_st_refs_of st' = {}) t
@@ -381,7 +381,7 @@ crunches restart
 lemma invokeTCB_WriteRegisters_corres:
   "corres (dc \<oplus> (=))
           (einvs and simple_sched_action and tcb_at dest and ex_nonz_cap_to dest
-           and current_time_bounded 2)
+           and current_time_bounded)
           (invs' and tcb_at' dest and ex_nonz_cap_to' dest)
           (invoke_tcb (tcb_invocation.WriteRegisters dest resume values arch))
           (invokeTCB (tcbinvocation.WriteRegisters dest resume values arch'))"
@@ -449,7 +449,7 @@ lemma asUser_valid_tcbs' [wp]:
 lemma invokeTCB_CopyRegisters_corres:
   "corres (dc \<oplus> (=))
         (einvs and simple_sched_action and tcb_at dest and tcb_at src and ex_nonz_cap_to src and
-          ex_nonz_cap_to dest and current_time_bounded 2)
+          ex_nonz_cap_to dest and current_time_bounded)
         (invs' and sch_act_simple and tcb_at' dest and tcb_at' src
           and ex_nonz_cap_to' src and ex_nonz_cap_to' dest)
         (invoke_tcb (tcb_invocation.CopyRegisters dest src susp resume frames ints arch))
@@ -531,7 +531,7 @@ proof -
             apply (wp mapM_x_wp' static_imp_wp restart_valid_sched | simp)+
          apply ((wp static_imp_wp restart_invs' | wpc | clarsimp simp add: if_apply_def2)+)[2]
        apply (rule_tac Q="\<lambda>_. einvs and tcb_at dest and tcb_at src and ex_nonz_cap_to dest
-                              and simple_sched_action and current_time_bounded 2"
+                              and simple_sched_action and current_time_bounded"
               in hoare_strengthen_post[rotated])
         apply (clarsimp simp: invs_def valid_sched_weak_strg valid_sched_def valid_state_def
                               valid_pspace_def valid_idle_def
@@ -1665,7 +1665,7 @@ lemma installTCBCap_corres:
   "\<lbrakk> newroot_rel slot_opt slot_opt'; slot_opt \<noteq> None \<longrightarrow> slot' = cte_map slot; n \<in> {0,1,3,4} \<rbrakk> \<Longrightarrow>
      corres (dc \<oplus> dc)
             (\<lambda>s. einvs s \<and> valid_machine_time s \<and> simple_sched_action s
-                 \<and> cte_at (target, tcb_cnode_index n) s \<and> current_time_bounded 2 s \<and>
+                 \<and> cte_at (target, tcb_cnode_index n) s \<and> current_time_bounded s \<and>
                  (\<forall>new_cap src_slot.
                    slot_opt = Some (new_cap, src_slot) \<longrightarrow>
                    (is_cnode_or_valid_arch new_cap \<or> valid_fault_handler new_cap) \<and>
@@ -1794,7 +1794,7 @@ lemma installThreadBuffer_corres:
   and     "g \<noteq> None \<longrightarrow> sl' = cte_map slot"
   shows "corres (dc \<oplus> dc)
          (einvs and valid_machine_time and simple_sched_action and tcb_at a
-                and (case_option \<top> (\<lambda>(_,sl). cte_at slot and current_time_bounded 2 and
+                and (case_option \<top> (\<lambda>(_,sl). cte_at slot and current_time_bounded and
                         (case_option \<top> (\<lambda>(newCap,srcSlot). cte_at srcSlot and valid_cap newCap and
                                                             no_cap_to_obj_dr_emp newCap) sl)) g)
                 and K (case_option True (\<lambda>(x,v).
@@ -1915,7 +1915,7 @@ lemma tc_corres_caps:
   shows
     "corres (dc \<oplus> (=))
     (einvs and valid_machine_time and simple_sched_action and active_sc_valid_refills
-     and tcb_at t and tcb_inv_wf tc_caps_inv and current_time_bounded 2)
+     and tcb_at t and tcb_inv_wf tc_caps_inv and current_time_bounded)
     (invs' and sch_act_simple and tcb_inv_wf' tc_caps_inv')
     (invoke_tcb tc_caps_inv)
     (invokeTCB tc_caps_inv')"
@@ -1991,7 +1991,7 @@ lemma setSchedContext_scTCB_update_valid_refills[wp]:
 lemma schedContextBindTCB_corres:
   "corres dc (valid_objs and pspace_aligned and pspace_distinct and (\<lambda>s. sym_refs (state_refs_of s))
               and valid_sched and simple_sched_action and bound_sc_tcb_at ((=) None) t
-              and current_time_bounded 2
+              and current_time_bounded
               and active_sc_valid_refills and sc_tcb_sc_at ((=) None) ptr and ex_nonz_cap_to t and ex_nonz_cap_to ptr)
              (invs' and ex_nonz_cap_to' t and ex_nonz_cap_to' ptr)
              (sched_context_bind_tcb ptr t) (schedContextBindTCB ptr t)"
@@ -2016,14 +2016,14 @@ lemma schedContextBindTCB_corres:
                  apply (rule schedContextResume_corres)
                 apply (rule_tac Q="\<lambda>rv. valid_objs and pspace_aligned and pspace_distinct and (\<lambda>s. sym_refs (state_refs_of s)) and
                                         weak_valid_sched_action and active_sc_valid_refills and
-                                        sc_tcb_sc_at ((=) (Some t)) ptr and current_time_bounded 2 and
+                                        sc_tcb_sc_at ((=) (Some t)) ptr and current_time_bounded and
                                         bound_sc_tcb_at (\<lambda>sc. sc = Some ptr) t"
                              in hoare_strengthen_post[rotated], fastforce)
                 apply (wp sched_context_resume_weak_valid_sched_action sched_context_resume_pred_tcb_at)
                apply (rule_tac Q="\<lambda>_. invs'" in hoare_strengthen_post[rotated], fastforce)
                apply wp
               apply (rule_tac Q="\<lambda>_. valid_objs and pspace_aligned and pspace_distinct and
-                                     (\<lambda>s. sym_refs (state_refs_of s)) and current_time_bounded 2 and
+                                     (\<lambda>s. sym_refs (state_refs_of s)) and current_time_bounded and
                                      valid_ready_qs and valid_release_q and weak_valid_sched_action and
                                      active_sc_valid_refills and scheduler_act_not t and
                                      sc_tcb_sc_at ((=) (Some t)) ptr and
@@ -2044,7 +2044,7 @@ lemma schedContextBindTCB_corres:
                                   (\<lambda>s. sym_refs (state_refs_of s)) and
                                   valid_ready_qs and valid_release_q and active_sc_valid_refills and
                                   sc_tcb_sc_at (\<lambda>sc. sc \<noteq> None) ptr and
-                                  (\<lambda>s. (weak_valid_sched_action s \<and> current_time_bounded 2 s \<and>
+                                  (\<lambda>s. (weak_valid_sched_action s \<and> current_time_bounded s \<and>
                                         (\<forall>ya. sc_tcb_sc_at ((=) (Some ya)) ptr s \<longrightarrow>
                                               not_in_release_q ya s \<and> scheduler_act_not ya s)) \<and>
                                        active_sc_valid_refills s \<and>
@@ -2279,7 +2279,7 @@ lemma tc_corres_sched:
   shows
     "corres (dc \<oplus> (=))
     (einvs and valid_machine_time and simple_sched_action and tcb_inv_wf tc_inv_sched
-           and ct_released and ct_active and ct_not_in_release_q and current_time_bounded 2)
+           and ct_released and ct_active and ct_not_in_release_q and current_time_bounded)
     (invs' and sch_act_simple and tcb_inv_wf' tc_inv_sched')
     (invoke_tcb tc_inv_sched)
     (invokeTCB tc_inv_sched')"
@@ -2318,7 +2318,7 @@ lemma tc_corres_sched:
                 apply wpfix
                 apply (rule setPriority)
                apply (rule_tac Q="\<lambda>_ s. invs s \<and> valid_machine_time s \<and> valid_sched s
-                                        \<and> simple_sched_action s \<and> current_time_bounded 2 s \<and>
+                                        \<and> simple_sched_action s \<and> current_time_bounded s \<and>
                                         tcb_at t s \<and> ex_nonz_cap_to t s \<and>
                                         (\<forall>scPtr. sc_opt = Some (Some scPtr) \<longrightarrow>
                                                    ex_nonz_cap_to scPtr s \<and>
@@ -2375,7 +2375,7 @@ lemma tc_corres_sched:
        apply (rule installTCBCap_corres; clarsimp)
       apply (rule_tac Q="\<lambda>_ s. einvs s \<and> valid_machine_time s \<and> simple_sched_action s \<and> tcb_at t s
                                \<and> ex_nonz_cap_to t s \<and> ct_active s \<and> ct_released s
-                               \<and> ct_not_in_release_q s \<and> current_time_bounded 2 s \<and>
+                               \<and> ct_not_in_release_q s \<and> current_time_bounded s \<and>
                                (\<forall>scp. sc_opt = Some (Some scp) \<longrightarrow> ex_nonz_cap_to scp s \<and>
                                                                    sc_tcb_sc_at ((=) None) scp s \<and>
                                                                    bound_sc_tcb_at ((=) None) t s)"
@@ -2604,10 +2604,9 @@ lemma invokeTCB_corres:
  "tcbinv_relation ti ti' \<Longrightarrow>
   corres (dc \<oplus> (=))
          (einvs and valid_machine_time and simple_sched_action and Tcb_AI.tcb_inv_wf ti
-                and current_time_bounded 2 and ct_released and ct_active and ct_not_in_release_q)
+                and current_time_bounded and ct_released and ct_active and ct_not_in_release_q)
          (invs' and sch_act_simple and tcb_inv_wf' ti')
          (invoke_tcb ti) (invokeTCB ti')"
-  using current_time_bounded_strengthen[of 2 _ 1, elim!]
   apply (case_tac ti, simp_all only: tcbinv_relation.simps valid_tcb_invocation_def)
           apply (rule corres_guard_imp[OF invokeTCB_WriteRegisters_corres], fastforce+)[1]
          apply (rule corres_guard_imp[OF invokeTCB_ReadRegisters_corres], simp+)[1]

--- a/spec/machine/ARM/MachineOps.thy
+++ b/spec/machine/ARM/MachineOps.thy
@@ -257,8 +257,19 @@ context Arch begin global_naming ARM
 definition
   "kernelWCET_ticks = us_to_ticks (kernelWCET_us)"
 
+text \<open>
+  It is crucial that time does not overflow, and that overflow does not occur when performing any
+  operation which modifies the refill lists. We therefore impose a cap on the time that can be
+  returned by getCurrentTime, namely getCurrentTime_buffer. This is chosen to be the greatest word
+  t such that if a refill list has its head r_time at t, and satisfies valid_refills, then
+  when performing any function which does modify the refill list, overflow does not occur. The
+  choice depends heavily on the implementation of refill_budget_check.
+ \<close>
+
+abbreviation time_buffer_const where "time_buffer_const \<equiv> 5"
+
 abbreviation (input) getCurrentTime_buffer where
-  "getCurrentTime_buffer \<equiv> kernelWCET_ticks + 5 * MAX_PERIOD"
+  "getCurrentTime_buffer \<equiv> kernelWCET_ticks + time_buffer_const * MAX_PERIOD"
 
 lemma replicate_no_overflow:
   "n * unat (a :: ticks) \<le> unat (upper_bound :: ticks)

--- a/spec/machine/MachineExports.thy
+++ b/spec/machine/MachineExports.thy
@@ -67,6 +67,7 @@ requalify_consts
   timerPrecision
   max_time
   getCurrentTime_buffer
+  time_buffer_const
   \<mu>s_in_ms
 
 requalify_facts

--- a/spec/machine/RISCV64/MachineOps.thy
+++ b/spec/machine/RISCV64/MachineOps.thy
@@ -222,8 +222,19 @@ context Arch begin global_naming RISCV64
 definition
   "kernelWCET_ticks = us_to_ticks (kernelWCET_us)"
 
+text \<open>
+  It is crucial that time does not overflow, and that overflow does not occur when performing any
+  operation which modifies the refill lists. We therefore impose a cap on the time that can be
+  returned by getCurrentTime, namely getCurrentTime_buffer. This is chosen to be the greatest word
+  t such that if a refill list has its head r_time at t, and satisfies valid_refills, then
+  when performing any function which does modify the refill list, overflow does not occur. The
+  choice depends heavily on the implementation of refill_budget_check.
+ \<close>
+
+abbreviation time_buffer_const where "time_buffer_const \<equiv> 5"
+
 abbreviation (input) getCurrentTime_buffer where
-  "getCurrentTime_buffer \<equiv> kernelWCET_ticks + 5 * MAX_PERIOD"
+  "getCurrentTime_buffer \<equiv> kernelWCET_ticks + time_buffer_const * MAX_PERIOD"
 
 lemma replicate_no_overflow:
   "n * unat (a :: ticks) \<le> unat (upper_bound :: ticks)


### PR DESCRIPTION
Most of the diff is entirely uninteresting - you can probably just ignore `DetSchedSchedule_AI.thy`. Apart from removing the various numbers, several lemmas which are now unnecessary have also been removed