### PR TITLE
Prove `he_invs’`

### DIFF
--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -1452,6 +1452,12 @@ definition
 defs cur_tcb'_asrt_def:
   "cur_tcb'_asrt \<equiv> \<lambda>s. cur_tcb' s"
 
+defs sch_act_sane_asrt_def:
+  "sch_act_sane_asrt \<equiv> \<lambda>s. sch_act_sane s"
+
+defs ct_not_ksQ_asrt_def:
+  "ct_not_ksQ_asrt \<equiv> \<lambda>s. \<forall>pd. ksCurThread s \<notin> set (ksReadyQueues s pd)"
+
 subsection "Derived concepts"
 
 abbreviation
@@ -1506,6 +1512,9 @@ abbreviation
 
 abbreviation
   "ct_running' \<equiv> ct_in_state' (\<lambda>st. st = Structures_H.Running)"
+
+defs ct_active'_asrt_def:
+  "ct_active'_asrt \<equiv> ct_active'"
 
 end
 

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -2277,9 +2277,7 @@ lemma updateTimeStamp_sch_act_simple[wp]:
   by (wpsimp wp: dmo_invs'_simple simp: setCurTime_def)
 
 crunches updateTimeStamp
-  for ksCurThread[wp]: "\<lambda>s. P (ksCurThread s)"
-  and pred_tcb_at'[wp]: "pred_tcb_at' p P t"
-  and ksPSpace[wp]: "\<lambda>s. P (ksPSpace s)"
+  for ksPSpace[wp]: "\<lambda>s. P (ksPSpace s)"
   and tcb_at'[wp]: "tcb_at' t"
 
 crunches getCapReg, refillCapacity
@@ -2292,9 +2290,8 @@ lemma handleEvent_valid_duplicates':
    \<lbrace>\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   supply if_cong[cong]
   apply (case_tac e; simp add: handleEvent_def)
-       apply (rename_tac syscall, case_tac syscall)
-  by (wpsimp wp: checkBudgetRestart_gen ct_in_state_thread_state_lift' |
-      erule active_from_running')+
+       apply (rename_tac syscall, case_tac syscall; simp)
+  by (wpsimp wp: checkBudgetRestart_gen stateAssertE_inv active_from_running')+
 
 lemma callKernel_valid_duplicates':
   "\<lbrace>invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -2573,7 +2573,7 @@ crunches check_budget
   for cur_tcb[wp]: cur_tcb
   and pspace_aligned[wp]: pspace_aligned
   and pspace_distinct[wp]: pspace_distinct
-  (wp: crunch_wps)
+  (wp: crunch_wps simp: crunch_simps)
 
 crunches checkBudgetRestart
   for valid_duplicates''[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -1755,7 +1755,7 @@ lemma valid_sc_strengthen:
 lemma endTimeslice_corres:
   "corres dc
      (invs and valid_list and valid_sched_action and active_sc_valid_refills and valid_release_q
-      and valid_ready_qs and scheduler_act_sane and (\<lambda>s. cte_wp_at is_ep_cap (cur_thread s, tcb_cnode_index 4) s)
+      and valid_ready_qs and scheduler_act_sane
       and cur_sc_active and ct_active and schact_is_rct and current_time_bounded 2)
      invs'
      (end_timeslice canTimeout) (endTimeslice canTimeout)"
@@ -1808,7 +1808,7 @@ lemma endTimeslice_corres:
                                clarsimp simp: cap_relation_def isEndpointCap_def)
                        apply (rule corres_symb_exec_r)
                           apply (rule_tac P="?pre and (\<lambda>s. ct = cur_thread s) and (\<lambda>s. sc_ptr = cur_sc s)
-                                             and (\<lambda>s. ready = is_refill_ready sc_ptr s)
+                                             and (\<lambda>s. ready = is_refill_ready sc_ptr s) and ko_at (TCB tcb) ct
                                              and (\<lambda>s. sufficient = is_refill_sufficient 0 sc_ptr s)"
                                      and P'="?pre' and cur_tcb' and (\<lambda>s. ct = ksCurThread s)
                                              and (\<lambda>s. sc_at' (ksCurSc s) s) and (\<lambda>s. is_active_sc' (ksCurSc s) s) and (\<lambda>s. sc_ptr = ksCurSc s) and
@@ -1825,10 +1825,16 @@ lemma endTimeslice_corres:
                             apply (rule corres_if2, simp)
                              apply (rule tcbSchedAppend_corres)
                             apply (rule postpone_corres)
+                           apply (clarsimp cong: conj_cong imp_cong)
                            apply (clarsimp simp: invs_def valid_state_def valid_pspace_def valid_sched_def
                                                  valid_fault_def valid_fault_handler_def)
-                           apply (clarsimp simp: ct_in_state_def)
-                           apply (clarsimp simp: cur_sc_tcb_def
+                           apply (rule conjI impI; clarsimp)
+                            apply (clarsimp simp: ct_in_state_def cte_wp_at_def cur_tcb_def)
+                            apply (rule_tac x="tcb_timeout_handler tcb" in exI)
+                            apply (clarsimp simp: get_cap_caps_of_state obj_at_def is_tcb
+                                                  caps_of_state_tcb_index_trans[OF get_tcb_rev]
+                                                  tcb_cnode_map_def)
+                           apply (clarsimp simp: cur_sc_tcb_def invs_def valid_pspace_def
                                           dest!: active_sc_valid_refillsE valid_refills_refill_sufficient)
                            apply (drule schact_is_rct, simp)
                            apply (drule (1) sym_refs_bound_sc_tcb_iff_sc_tcb_sc_at[OF refl refl, THEN iffD2])
@@ -1838,6 +1844,7 @@ lemma endTimeslice_corres:
                            apply (clarsimp simp: sc_tcb_sc_at_def obj_at_def)
                           apply (clarsimp simp: invs'_def valid_pspace'_def cur_tcb'_def)
                          apply (wpsimp wp: getTCB_wp)+
+                    apply (clarsimp dest!: invs_cur simp: cur_tcb_def)
                    apply (clarsimp simp: cur_tcb'_def isEndpointCap_def)
                   apply simp
                  apply (wpsimp wp: get_sc_refill_sufficient_wp)+
@@ -1978,7 +1985,7 @@ crunches setConsumedTime, refillResetRR
 lemma chargeBudget_corres:
   "corres dc
      (invs and valid_list and valid_sched_action and active_sc_valid_refills and valid_release_q
-      and valid_ready_qs and (\<lambda>s. cte_wp_at is_ep_cap (cur_thread s, tcb_cnode_index 4) s)
+      and valid_ready_qs and scheduler_act_sane
       and released_ipc_queues and cur_sc_active and ct_active and schact_is_rct
       and current_time_bounded 5
       and ct_not_queued and ct_not_in_release_q
@@ -2103,9 +2110,8 @@ lemma chargeBudget_corres:
   done
 
 lemma checkBudget_corres:
-  "corres dc
-     (einvs and scheduler_act_sane and (\<lambda>s. cte_wp_at is_ep_cap (cur_thread s, tcb_cnode_index 4) s)
-      and current_time_bounded 5 and cur_sc_offset_ready 0
+  "corres (=)
+     (einvs and current_time_bounded 5 and cur_sc_offset_ready 0
       and cur_sc_active and ct_active and schact_is_rct and current_time_bounded 2
       and ct_not_queued and ct_not_in_release_q)
      invs'
@@ -2135,7 +2141,6 @@ lemma checkBudget_corres:
 lemma handleYield_corres:
   "corres dc
      (einvs and ct_active and cur_sc_active and scheduler_act_sane and schact_is_rct
-      and (\<lambda>s. cte_wp_at is_ep_cap (cur_thread s, tcb_cnode_index 4) s)
       and current_time_bounded 5 and cur_sc_offset_ready 0
       and ct_not_queued and ct_not_in_release_q and current_time_bounded 2)
      invs'

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -1755,8 +1755,7 @@ lemma valid_sc_strengthen:
 lemma endTimeslice_corres:
   "corres dc
      (invs and valid_list and valid_sched_action and active_sc_valid_refills and valid_release_q
-      and valid_ready_qs and scheduler_act_sane
-      and cur_sc_active and ct_active and schact_is_rct and current_time_bounded 2)
+      and valid_ready_qs and cur_sc_active and ct_active and schact_is_rct and current_time_bounded 2)
      invs'
      (end_timeslice canTimeout) (endTimeslice canTimeout)"
   (is "corres _ ?pre ?pre' _ _")
@@ -1830,7 +1829,6 @@ lemma endTimeslice_corres:
                                                  valid_fault_def valid_fault_handler_def)
                            apply (rule conjI impI; clarsimp)
                             apply (clarsimp simp: ct_in_state_def cte_wp_at_def cur_tcb_def)
-                            apply (rule_tac x="tcb_timeout_handler tcb" in exI)
                             apply (clarsimp simp: get_cap_caps_of_state obj_at_def is_tcb
                                                   caps_of_state_tcb_index_trans[OF get_tcb_rev]
                                                   tcb_cnode_map_def)
@@ -1985,8 +1983,7 @@ crunches setConsumedTime, refillResetRR
 lemma chargeBudget_corres:
   "corres dc
      (invs and valid_list and valid_sched_action and active_sc_valid_refills and valid_release_q
-      and valid_ready_qs and scheduler_act_sane
-      and released_ipc_queues and cur_sc_active and ct_active and schact_is_rct
+      and valid_ready_qs and released_ipc_queues and cur_sc_active and ct_active and schact_is_rct
       and current_time_bounded 5
       and ct_not_queued and ct_not_in_release_q
       and cur_sc_offset_ready 0)
@@ -1994,10 +1991,6 @@ lemma chargeBudget_corres:
      (charge_budget consumed canTimeout) (chargeBudget consumed canTimeout True)"
   (is "corres _ (?pred and cur_sc_offset_ready 0) _ _ _")
   unfolding chargeBudget_def charge_budget_def ifM_def bind_assoc
-  apply (rule_tac Q=sch_act_sane in corres_cross_add_guard)
-   apply (clarsimp simp: sch_act_sane_def scheduler_act_sane_def sched_act_relation_def
-                  dest!: state_relationD)
-   apply (case_tac "scheduler_action s"; simp add: schact_is_rct_def)
   apply (rule_tac Q=ct_active' in corres_cross_add_guard)
    apply (fastforce intro!: ct_active_cross simp: invs_def valid_state_def valid_pspace_def)
   apply (rule_tac Q="\<lambda>s. obj_at' (\<lambda>sc. scTCB sc = Some (ksCurThread s)) (ksCurSc s) s" in corres_cross_add_guard)
@@ -2015,7 +2008,7 @@ lemma chargeBudget_corres:
   apply (rule_tac F="idle_sc_ptr = idleSCPtr" in corres_req)
    apply (clarsimp simp: state_relation_def)
   apply (rule_tac Q="\<lambda>_. ?pred"
-              and Q'="\<lambda>_. invs' and sch_act_sane and cur_tcb'"
+              and Q'="\<lambda>_. invs' and cur_tcb'"
                in corres_split')
      apply (clarsimp simp: when_def split del: if_split)
      apply (rule corres_if_split; (solves corressimp)?)
@@ -2140,7 +2133,7 @@ lemma checkBudget_corres:
 
 lemma handleYield_corres:
   "corres dc
-     (einvs and ct_active and cur_sc_active and scheduler_act_sane and schact_is_rct
+     (einvs and ct_active and cur_sc_active and schact_is_rct
       and current_time_bounded 5 and cur_sc_offset_ready 0
       and ct_not_queued and ct_not_in_release_q and current_time_bounded 2)
      invs'

--- a/spec/design/skel/KernelStateData_H.thy
+++ b/spec/design/skel/KernelStateData_H.thy
@@ -99,7 +99,7 @@ where
     return r
   od"
 
-#INCLUDE_HASKELL SEL4/Model/StateData.lhs decls_only ONLY capHasProperty sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2 ct_not_inQ_asrt sch_act_wf_asrt valid_idle'_asrt cur_tcb'_asrt
-#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue ReaderM Kernel KernelR getsJust assert stateAssert funOfM condition whileLoop findM funArray newKernelState capHasProperty ifM whenM whileM andM orM maybeToMonad sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2 ct_not_inQ_asrt sch_act_wf_asrt valid_idle'_asrt cur_tcb'_asrt
+#INCLUDE_HASKELL SEL4/Model/StateData.lhs decls_only ONLY capHasProperty sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2 ct_not_inQ_asrt sch_act_wf_asrt valid_idle'_asrt cur_tcb'_asrt sch_act_sane_asrt ct_not_ksQ_asrt ct_active'_asrt
+#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue ReaderM Kernel KernelR getsJust assert stateAssert funOfM condition whileLoop findM funArray newKernelState capHasProperty ifM whenM whileM andM orM maybeToMonad sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2 ct_not_inQ_asrt sch_act_wf_asrt valid_idle'_asrt cur_tcb'_asrt sch_act_sane_asrt ct_not_ksQ_asrt ct_active'_asrt
 
 end

--- a/spec/haskell/src/SEL4/API/Syscall.lhs
+++ b/spec/haskell/src/SEL4/API/Syscall.lhs
@@ -91,10 +91,10 @@ System call events are dispatched here to the appropriate system call handlers, 
 >         SysCall -> handleCall
 >         SysRecv -> withoutPreemption $ handleRecv True True
 >         SysYield -> withoutPreemption handleYield
->         SysReplyRecv -> withoutPreemption $ do
->             replyCptr <- getCapReg replyRegister
->             return $ handleInvocation False False True True replyCptr
->             handleRecv True True
+>         SysReplyRecv -> do
+>             replyCptr <- withoutPreemption $ getCapReg replyRegister
+>             handleInvocation False False True True replyCptr
+>             withoutPreemption $ handleRecv True True
 >         SysNBSendRecv -> do
 >             dest <- withoutPreemption $ getCapReg nbsendRecvDest
 >             handleInvocation False False True True dest

--- a/spec/haskell/src/SEL4/API/Syscall.lhs
+++ b/spec/haskell/src/SEL4/API/Syscall.lhs
@@ -94,14 +94,23 @@ System call events are dispatched here to the appropriate system call handlers, 
 >         SysReplyRecv -> do
 >             replyCptr <- withoutPreemption $ getCapReg replyRegister
 >             handleInvocation False False True True replyCptr
+>             stateAssert sch_act_sane_asrt "Assert sch_act_sane"
+>             stateAssert ct_not_ksQ_asrt "Assert ksCurThread notin ksReadyQueues"
+>             stateAssert ct_active'_asrt "Assert ct_active'"
 >             withoutPreemption $ handleRecv True True
 >         SysNBSendRecv -> do
 >             dest <- withoutPreemption $ getCapReg nbsendRecvDest
 >             handleInvocation False False True True dest
+>             stateAssert sch_act_sane_asrt "Assert sch_act_sane"
+>             stateAssert ct_not_ksQ_asrt "Assert ksCurThread notin ksReadyQueues"
+>             stateAssert ct_active'_asrt "Assert ct_active'"
 >             withoutPreemption $ handleRecv True True
 >         SysNBSendWait -> do
 >             replyCptr <- withoutPreemption $ getCapReg replyRegister
 >             handleInvocation False False True True replyCptr
+>             stateAssert sch_act_sane_asrt "Assert sch_act_sane"
+>             stateAssert ct_not_ksQ_asrt "Assert ksCurThread notin ksReadyQueues"
+>             stateAssert ct_active'_asrt "Assert ct_active'"
 >             withoutPreemption $ handleRecv True False
 >         SysWait -> withoutPreemption $ handleRecv True False
 >         SysNBWait -> withoutPreemption $ handleRecv False False

--- a/spec/haskell/src/SEL4/Model/StateData.lhs
+++ b/spec/haskell/src/SEL4/Model/StateData.lhs
@@ -456,3 +456,14 @@ is true using the rule cur_tcb'_cross.
 
 > cur_tcb'_asrt :: KernelState -> Bool
 > cur_tcb'_asrt _ = True
+
+Asserts for first phase, non-blocking, non-calling handle_invocation.
+
+> sch_act_sane_asrt :: KernelState -> Bool
+> sch_act_sane_asrt _ = True
+
+> ct_not_ksQ_asrt :: KernelState -> Bool
+> ct_not_ksQ_asrt _ = True
+
+> ct_active'_asrt :: KernelState -> Bool
+> ct_active'_asrt _ = True

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -1039,10 +1039,9 @@ On some architectures, the thread context may include registers that may be modi
 
 > checkBudgetRestart :: Kernel Bool
 > checkBudgetRestart = do
+>     result <- checkBudget
 >     ct <- getCurThread
 >     runnable <- isRunnable ct
->     assert runnable "current thread should be runnbale"
->     result <- checkBudget
 >     when (not result && runnable) $ do
 >         setThreadState Restart ct
 >     return result


### PR DESCRIPTION
This proves `he_invs’` (`invs’` for `handleEvent`).

This also introduces three asserts for the properties we want to have in `handleEvent`, after the calls to first phase `handleInvocation` prior to `handleRecv`. In the proof for `handleEvent_corres` (which will be in a separate PR after this), we can validate these asserted properties by crossing over from the abstract side. For the proof in this PR, only one of the three asserts is needed (`ct_active’`).