### PR TITLE
numdomains: make proofs work with any number of domains

### DIFF
--- a/lib/NICTATools.thy
+++ b/lib/NICTATools.thy
@@ -22,6 +22,7 @@ imports
   ShowTypes
   AutoLevity_Hooks
   Locale_Abbrev
+  Value_Type
 begin
 
 section "Detect unused meta-forall"

--- a/lib/ROOT
+++ b/lib/ROOT
@@ -83,6 +83,7 @@ session Lib (lib) = Word_Lib +
     Guess_ExI
     GenericTag
     ML_Goal_Test
+    Value_Type
 
     (* should really be a separate session, but too entangled atm: *)
     NonDetMonadLemmaBucket
@@ -162,6 +163,7 @@ session LibTest (lib) in test = Refine +
     Local_Method_Tests
     Qualify_Test
     Locale_Abbrev_Test
+    Value_Type_Test
   (* use virtual memory function as an example, only makes sense on ARM: *)
   theories [condition = "L4V_ARCH_IS_ARM"]
     Corres_Test

--- a/lib/Value_Type.thy
+++ b/lib/Value_Type.thy
@@ -1,0 +1,105 @@
+(*
+ * Copyright 2021, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *)
+
+theory Value_Type
+imports "HOL-Library.Numeral_Type"
+keywords "value_type" :: thy_decl
+begin
+
+(*
+   Define a type synonym from a term that evaluates to a numeral.
+
+   Examples:
+
+      value_type num_queues = "num_prio * num_domains"
+      value_type num_something = "10 * num_domains"
+*)
+
+text \<open>See theory @{file "test/Value_Type_Test.thy"} for further example/demo.\<close>
+
+ML \<open>
+
+local
+
+fun get_term_numeral (Const (@{const_name numeral}, Type ("fun", _)) $ n) = SOME n
+  | get_term_numeral (Const (@{const_name "Groups.one"}, _))  = SOME @{term "Num.One"}
+  | get_term_numeral (Const (@{const_name "Groups.zero"}, _)) = SOME @{term "0"}
+  | get_term_numeral _ = NONE
+
+fun typ_of_num (Const (\<^const_name>\<open>Num.Bit0\<close>, _) $ t) = Type (@{type_name "bit0"}, [typ_of_num t])
+  | typ_of_num (Const (\<^const_name>\<open>Num.Bit1\<close>, _) $ t) = Type (@{type_name "bit1"}, [typ_of_num t])
+  | typ_of_num (Const (\<^const_name>\<open>Num.One\<close>, _))      = Type (@{type_name "num1"}, [])
+  | typ_of_num (Const (\<^const_name>\<open>Groups.zero\<close>, _))  = Type (@{type_name "num0"}, [])
+  | typ_of_num t = raise TERM ("type_of_num: number expected", [t]);
+
+fun force_nat_numeral (Const (@{const_name numeral}, Type ("fun", [num, _])) $ n) =
+      Const (@{const_name numeral}, Type ("fun", [num, @{typ nat}])) $ n
+  | force_nat_numeral (Const (@{const_name "Groups.one"}, _))  = @{term "1::nat"}
+  | force_nat_numeral (Const (@{const_name "Groups.zero"}, _)) = @{term "0::nat"}
+  | force_nat_numeral t = raise TERM ("force_nat_numeral: number expected", [t])
+
+fun make_type binding v lthy =
+  let
+    val n = case get_term_numeral v of
+              SOME n => n
+            | NONE => raise TERM ("make_type: numeral expected", [v])
+    val typ = typ_of_num n
+  in
+    lthy |> Typedecl.abbrev (binding, [], Mixfix.NoSyn) typ |> #2
+  end
+
+fun make_def binding v lthy =
+  let
+    val mk_eq = HOLogic.mk_Trueprop o HOLogic.mk_eq
+    val def_t = mk_eq (Free (Binding.name_of binding, @{typ nat}), force_nat_numeral v)
+  in
+    lthy |> Specification.definition NONE [] [] (Binding.empty_atts, def_t) |> #2
+  end
+
+in
+
+fun value_type_cmd no_def binding t lthy =
+  let
+    val t' = Syntax.read_term lthy t
+    val v = case get_term_numeral t' of SOME _ => t' | NONE => Value_Command.value lthy t'
+  in
+    lthy
+    |> make_type binding v
+    |> (if no_def then I else make_def binding v)
+  end
+
+val no_def_option =
+  Scan.optional
+    (Args.parens (Parse.!!! (Parse.reserved "no_def" >> K true)))
+    false;
+
+val _ =
+  Outer_Syntax.local_theory \<^command_keyword>\<open>value_type\<close>
+    "Declare a type synonym from a term that evaluates to a numeral"
+    (no_def_option -- Parse.binding -- (\<^keyword>\<open>=\<close> |-- Parse.term)
+      >> (fn ((no_def, n), t) => value_type_cmd no_def n t))
+
+end
+\<close>
+
+(*
+Potential extension idea for the future:
+
+It may be possible to generalise this command to non-numeral types -- as long as the RHS can
+be interpreted as some nat n, we can in theory always define a type with n elements, and instantiate
+that type into class finite. Might have to present a goal to the user that RHS evaluates > 0 in nat.
+
+There are a few wrinkles with that, because currently you can use any type on the RHS without
+complications. Requiring nat for the RHS term would not be great, because we often have word there.
+We could add coercion to nat for word and int, though, that would cover all current use cases.
+
+The benefit of defining a new type instead of a type synonym for a numeral type is that type
+checking is now more meaningful and we do get some abstraction over the actual value, which would
+help make proofs more generic.
+*)
+
+
+end

--- a/lib/test/Value_Type_Test.thy
+++ b/lib/test/Value_Type_Test.thy
@@ -1,0 +1,73 @@
+(*
+ * Copyright 2021, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *)
+
+theory Value_Type_Test
+imports Lib.Value_Type
+begin
+
+(*
+   Define a type synonym from a term that evaluates to a numeral.
+*)
+
+definition num_domains :: int where
+  "num_domains = 16"
+
+definition num_prio :: int where
+  "num_prio = 256"
+
+text \<open>The RHS does not have to be of type nat, it just has to evaluate to any numeral:\<close>
+value_type num_queues = "num_prio * num_domains"
+
+text \<open>This produces a type of the specified size and a constant of type nat:\<close>
+typ num_queues
+term num_queues
+thm num_queues_def
+
+text \<open>You can leave out the constant definition, and just define the type:\<close>
+value_type (no_def) num_something = "10 * num_domains"
+
+typ num_something
+
+
+text \<open>
+  @{command value_type} uses @{command value} in the background, so all of this also works in
+  anonymous local contexts, provided they don't have assumptions (so that @{command value} can
+  produce code)
+
+  Example:
+\<close>
+context
+begin
+
+definition X::int where "X = 10"
+
+value_type x_t = X
+
+typ x_t
+term x_t
+thm x_t_def
+
+end
+
+text \<open>The following does not work, because @{command value} can't find code equations:\<close>
+
+locale y
+begin
+
+definition Y::int where "Y = 10"
+
+(* will fail:
+value_type y_t = Y
+*)
+
+end
+
+text \<open>But it will work outside the locale after interpretation:\<close>
+
+interpretation y .
+value_type y_t = Y
+
+end

--- a/proof/crefine/ARM/ADT_C.thy
+++ b/proof/crefine/ARM/ADT_C.thy
@@ -639,28 +639,9 @@ lemma tcb_queue_rel'_unique:
   apply (erule(2) tcb_queue_rel_unique)
   done
 
-lemma cqueues_unique:
-  "h_tcb NULL = None \<Longrightarrow>
-   cready_queues_relation h_tcb cs as \<Longrightarrow>
-   cready_queues_relation h_tcb cs as' \<Longrightarrow> as' = as"
-oops (*
- apply (clarsimp simp add: cready_queues_relation_def Let_def fun_eq_iff)
-  apply (rename_tac qdom prio)
-  apply (erule_tac x=qdom in allE)
-  apply (erule_tac x=qdom in allE)
-  apply (erule_tac x=prio in allE)+
-  apply clarsimp
-  apply (cut_tac w=qdom in word_le_p2m1)
-  apply (cut_tac w=prio in word_le_p2m1, simp add: seL4_MinPrio_def seL4_MaxPrio_def minus_one_norm)
-  apply (cut_tac w=prio in word_le_p2m1)
-  apply (simp add: seL4_MinPrio_def seL4_MaxPrio_def minDom_def maxDom_def minus_one_norm)
-  apply (clarsimp simp add: tcb_queue_relation'_def tcb_queue_rel_unique)
-  done
-*)
-
 definition
   cready_queues_to_H
-  :: "(tcb_C ptr \<rightharpoonup> tcb_C) \<Rightarrow> (tcb_queue_C[4096]) \<Rightarrow> word8 \<times> word8 \<Rightarrow> word32 list"
+  :: "(tcb_C ptr \<rightharpoonup> tcb_C) \<Rightarrow> (tcb_queue_C[num_tcb_queues]) \<Rightarrow> word8 \<times> word8 \<Rightarrow> word32 list"
   where
   "cready_queues_to_H h_tcb cs \<equiv> \<lambda>(qdom, prio). if ucast minDom \<le> qdom \<and> qdom \<le> ucast maxDom
               \<and> ucast seL4_MinPrio \<le> prio \<and> prio \<le> ucast seL4_MaxPrio
@@ -1256,12 +1237,12 @@ lemma (in kernel_m) cDomSchedule_to_H_correct:
   done
 
 definition
-  cbitmap_L1_to_H :: "32 word[16] \<Rightarrow> (8 word \<Rightarrow> 32 word)"
+  cbitmap_L1_to_H :: "32 word[num_domains] \<Rightarrow> (domain \<Rightarrow> 32 word)"
 where
   "cbitmap_L1_to_H l1 \<equiv> \<lambda>d. if d \<le> maxDomain then l1.[unat d] else 0"
 
 definition
-  cbitmap_L2_to_H :: "32 word[8][16] \<Rightarrow> (8 word \<times> nat \<Rightarrow> 32 word)"
+  cbitmap_L2_to_H :: "32 word[8][num_domains] \<Rightarrow> (domain \<times> nat \<Rightarrow> 32 word)"
 where
   "cbitmap_L2_to_H l2 \<equiv> \<lambda>(d, i).
     if d \<le> maxDomain \<and> i < l2BitmapSize

--- a/proof/crefine/ARM/Fastpath_C.thy
+++ b/proof/crefine/ARM/Fastpath_C.thy
@@ -240,6 +240,15 @@ lemma st_tcb_at_tcbs_of:
   "st_tcb_at' P t s = (EX tcb. tcbs_of s t = Some tcb & P (tcbState tcb))"
   by (simp add: st_tcb_at'_def obj_at_tcbs_of)
 
+lemma tcbs_of_ko_at':
+  "\<lbrakk> tcbs_of s p = Some tcb \<rbrakk> \<Longrightarrow> ko_at' tcb p s"
+  by (simp add: obj_at_tcbs_of)
+
+lemma tcbs_of_valid_tcb':
+  "\<lbrakk> valid_objs' s; tcbs_of s p = Some tcb \<rbrakk> \<Longrightarrow> valid_tcb' tcb s"
+  by (frule tcbs_of_ko_at')
+     (drule (1) ko_at_valid_objs', auto simp: projectKOs valid_obj'_def)
+
 end
 
 context kernel_m begin
@@ -2040,8 +2049,8 @@ proof -
              apply (rule stored_hw_asid_get_ccorres_split[where P=\<top>], ceqv)
              apply (rule ccorres_abstract_ksCurThread, ceqv)
              apply (rename_tac ksCurThread_x)
-             apply (simp add: maxDom_def del: Collect_const)
-               apply (ctac add: getCurDomain_ccorres_dom_')
+             apply (simp del: Collect_const)
+               apply (ctac add: getCurDomain_maxDom_ccorres_dom_')
                  apply (rename_tac curDom curDom')
                  apply (rule ccorres_move_c_guard_tcb ccorres_move_const_guard)+
                  apply (simp add: prio_and_dom_limit_helpers del: Collect_const)
@@ -2161,15 +2170,22 @@ proof -
                   apply (rule ccorres_move_c_guard_tcb ccorres_move_const_guard)+
                    apply (rule ccorres_pre_threadGet)
                     apply (rename_tac destDom)
+                    (* The C does not compare domains when maxDomain is 0, since then both threads
+                       will be in the current domain. Since we can show both threads must be
+                       \<le> maxDomain, we can rewrite this test to only comparing domains even when
+                       maxDomain is 0, making the check identical to the Haskell. *)
                     apply (rule_tac C'="{s. destDom \<noteq> curDom}"
                               and Q="obj_at' ((=) destDom \<circ> tcbDomain) (hd (epQueue send_ep))
-                                       and (\<lambda>s. ksCurDomain s = curDom)"
+                                       and (\<lambda>s. ksCurDomain s = curDom \<and> curDom \<le> maxDomain
+                                                \<and> destDom \<le> maxDomain)"
                               and Q'=UNIV in ccorres_rewrite_cond_sr_Seq)
                      apply (simp add: Collect_const_mem from_bool_eq_if from_bool_eq_if' from_bool_0 if_1_0_0 ccorres_IF_True del: Collect_const)
                      apply clarsimp
                       apply (drule(1) obj_at_cslift_tcb)+
                       apply (clarsimp simp: typ_heap_simps' rf_sr_ksCurDomain)
-                      apply (drule ctcb_relation_tcbDomain[symmetric], fastforce)
+                      apply (drule ctcb_relation_tcbDomain[symmetric])
+                      apply (case_tac "0 < maxDomain"
+                             ; solves \<open>clarsimp simp: maxDom_sgt_0_maxDomain not_less\<close>)
                     apply (rule ccorres_seq_cond_raise[THEN iffD2])
                     apply (rule_tac R=\<top> in ccorres_cond2', blast)
                      apply (rule ccorres_split_throws)
@@ -2520,6 +2536,10 @@ proof -
                          capAligned_def objBits_simps)
    apply (simp cong: conj_cong)
    apply (clarsimp simp add: invs_ksCurDomain_maxDomain')
+   apply (rule conjI)
+    subgoal (* dest thread domain \<le> maxDomain *)
+     by (drule (1) tcbs_of_valid_tcb'[OF invs_valid_objs'], solves \<open>clarsimp simp: valid_tcb'_def\<close>)
+   apply clarsimp
    apply (rule conjI) (* isReceive on queued tcb state *)
     apply (fastforce simp: st_tcb_at_tcbs_of isBlockedOnReceive_def isReceive_def)
    apply clarsimp
@@ -2932,8 +2952,8 @@ lemma fastpath_reply_recv_ccorres:
                           |  rule ccorres_flip_Guard2, rule ccorres_Guard_True_Seq)+
                    apply (rule stored_hw_asid_get_ccorres_split[where P=\<top>], ceqv)
 
-                   apply (simp add: maxDom_def del: Collect_const)
-                   apply (ctac add: getCurDomain_ccorres_dom_')
+                   apply (simp del: Collect_const)
+                   apply (ctac add: getCurDomain_maxDom_ccorres_dom_')
                      apply (rename_tac curDom curDom')
                      apply (rule_tac P="curDom \<le> maxDomain" in ccorres_gen_asm)
                      apply (simp add: prio_and_dom_limit_helpers del: Collect_const)
@@ -2973,16 +2993,22 @@ lemma fastpath_reply_recv_ccorres:
                    apply (rule ccorres_symb_exec_l3[OF _ threadGet_inv _ empty_fail_threadGet])
                     apply (rename_tac destDom)
 
+                    (* The C does not compare domains when maxDomain is 0, since then both threads
+                       will be in the current domain. Since we can show both threads must be
+                       \<le> maxDomain, we can rewrite this test to only comparing domains even when
+                       maxDomain is 0, making the check identical to the Haskell. *)
                     apply (rule ccorres_seq_cond_raise[THEN iffD2])
                     apply (rule_tac R="obj_at' ((=) destDom \<circ> tcbDomain)
                                                   (capTCBPtr (cteCap caller_cap))
-                                        and (\<lambda>s. ksCurDomain s = curDom)"
+                                        and (\<lambda>s. ksCurDomain s = curDom \<and> curDom \<le> maxDomain
+                                                 \<and> destDom \<le> maxDomain)"
                                    in ccorres_cond2')
                       apply clarsimp
                       apply (drule(1) obj_at_cslift_tcb)+
                       apply (clarsimp simp: typ_heap_simps' rf_sr_ksCurDomain)
                       apply (drule ctcb_relation_tcbDomain[symmetric])
-                      apply (clarsimp simp: up_ucast_inj_eq[symmetric] maxDom_def)
+                      apply (case_tac "0 < maxDomain"
+                             ; solves \<open>clarsimp simp: maxDom_sgt_0_maxDomain not_less\<close>)
 
                      apply simp
                      apply (rule ccorres_split_throws)
@@ -3253,6 +3279,7 @@ lemma fastpath_reply_recv_ccorres:
                            invs_valid_pde_mappings' obj_at_tcbs_of
                     dest!: isValidVTableRootD)
      apply (frule invs_mdb')
+
      apply (clarsimp simp: cte_wp_at_ctes_of tcbSlots cte_level_bits_def
                            makeObject_cte isValidVTableRoot_def
                            ARM_H.isValidVTableRoot_def
@@ -3260,6 +3287,10 @@ lemma fastpath_reply_recv_ccorres:
                            valid_mdb'_def valid_tcb_state'_def
                            word_le_nat_alt[symmetric] length_msgRegisters)
      apply (frule ko_at_valid_ep', fastforce)
+     apply (rule conjI)
+      subgoal (* dest thread domain \<le> maxDomain *)
+       by (drule (1) tcbs_of_valid_tcb'[OF invs_valid_objs'], solves \<open>clarsimp simp: valid_tcb'_def\<close>)
+     apply clarsimp
      apply (safe del: notI disjE)[1]
        apply (simp add: isSendEP_def valid_ep'_def tcb_at_invs'
                  split: Structures_H.endpoint.split_asm)

--- a/proof/crefine/ARM/Finalise_C.thy
+++ b/proof/crefine/ARM/Finalise_C.thy
@@ -23,9 +23,9 @@ definition
 
 lemma tcbSchedEnqueue_cslift_spec:
   "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> \<lbrace>s. \<exists>d v. option_map2 tcbPriority_C (cslift s) \<acute>tcb = Some v
-                       \<and> v \<le> ucast maxPrio
+                       \<and> unat v \<le> numPriorities
                        \<and> option_map2 tcbDomain_C (cslift s) \<acute>tcb = Some d
-                       \<and> d \<le> ucast maxDom
+                       \<and> unat d < Kernel_Config.numDomains
                        \<and> (end_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))) \<noteq> NULL
                            \<longrightarrow> option_map2 tcbPriority_C (cslift s)
                                    (head_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))))
@@ -43,6 +43,10 @@ lemma tcbSchedEnqueue_cslift_spec:
   apply (clarsimp simp: option_map2_def fun_eq_iff h_t_valid_clift
                         h_t_valid_field[OF h_t_valid_clift])
   apply (rule conjI)
+   apply (clarsimp simp: typ_heap_simps le_maxDomain_eq_less_numDomains)
+   apply unat_arith
+  apply clarsimp
+  apply (rule conjI)
    apply (clarsimp simp: typ_heap_simps cong: if_cong)
    apply (simp split: if_split)
   apply (clarsimp simp: typ_heap_simps if_Some_helper cong: if_cong)
@@ -52,9 +56,9 @@ lemma setThreadState_cslift_spec:
   "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> \<lbrace>s. s \<Turnstile>\<^sub>c \<acute>tptr \<and> (\<forall>x. ksSchedulerAction_' (globals s) = tcb_Ptr x
                  \<and> x \<noteq> 0 \<and> x \<noteq> 1
               \<longrightarrow> (\<exists>d v. option_map2 tcbPriority_C (cslift s) (tcb_Ptr x) = Some v
-                       \<and> v \<le> ucast maxPrio
+                       \<and> unat v \<le> numPriorities
                        \<and> option_map2 tcbDomain_C (cslift s) (tcb_Ptr x) = Some d
-                       \<and> d \<le> ucast maxDom
+                       \<and> unat d < Kernel_Config.numDomains
                        \<and> (end_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))) \<noteq> NULL
                            \<longrightarrow> option_map2 tcbPriority_C (cslift s)
                                    (head_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))))
@@ -127,32 +131,27 @@ lemma ctcb_relation_tcbPriority:
   "ctcb_relation tcb tcb' \<Longrightarrow> ucast (tcbPriority tcb) = tcbPriority_C tcb'"
   by (simp add: ctcb_relation_def)
 
-lemma ctcb_relation_tcbDomain_maxDom:
-  "\<lbrakk> ctcb_relation tcb tcb'; tcbDomain tcb \<le> maxDomain \<rbrakk> \<Longrightarrow> tcbDomain_C tcb' \<le> ucast maxDom"
+lemma ctcb_relation_tcbDomain_maxDomain_numDomains:
+  "\<lbrakk> ctcb_relation tcb tcb'; tcbDomain tcb \<le> maxDomain \<rbrakk>
+   \<Longrightarrow> unat (tcbDomain_C tcb') < Kernel_Config.numDomains"
   apply (subst ctcb_relation_tcbDomain[symmetric], simp)
-  apply (subst ucast_le_migrate)
-    apply ((simp add:maxDom_def word_size)+)[2]
-  apply (simp add: ucast_up_ucast is_up_def source_size_def word_size target_size_def)
-  apply (simp add: maxDom_to_H)
+  apply (simp add: le_maxDomain_eq_less_numDomains)
   done
 
-lemma ctcb_relation_tcbPriority_maxPrio:
+lemma ctcb_relation_tcbPriority_maxPriority_numPriorities:
   "\<lbrakk> ctcb_relation tcb tcb'; tcbPriority tcb \<le> maxPriority \<rbrakk>
-    \<Longrightarrow> tcbPriority_C tcb' \<le> ucast maxPrio"
+    \<Longrightarrow> unat (tcbPriority_C tcb') < numPriorities"
   apply (subst ctcb_relation_tcbPriority[symmetric], simp)
-  apply (subst ucast_le_migrate)
-    apply ((simp add: seL4_MaxPrio_def word_size)+)[2]
-  apply (simp add: ucast_up_ucast is_up_def source_size_def word_size target_size_def)
-  apply (simp add: maxPrio_to_H)
+  apply (simp add: maxPriority_def numPriorities_def word_le_nat_alt)
   done
 
 lemma tcbSchedEnqueue_cslift_precond_discharge:
   "\<lbrakk> (s, s') \<in> rf_sr; obj_at' (P :: tcb \<Rightarrow> bool) x s;
         valid_queues s; valid_objs' s \<rbrakk> \<Longrightarrow>
    (\<exists>d v. option_map2 tcbPriority_C (cslift s') (tcb_ptr_to_ctcb_ptr x) = Some v
-        \<and> v \<le> ucast maxPrio
+        \<and> unat v < numPriorities
         \<and> option_map2 tcbDomain_C (cslift s') (tcb_ptr_to_ctcb_ptr x) = Some d
-        \<and> d \<le> ucast maxDom
+        \<and> unat d < Kernel_Config.numDomains
         \<and> (end_C (index (ksReadyQueues_' (globals s')) (unat (d*0x100 + v))) \<noteq> NULL
                 \<longrightarrow> option_map2 tcbPriority_C (cslift s')
                      (head_C (index (ksReadyQueues_' (globals s')) (unat (d*0x100 + v))))
@@ -166,12 +165,12 @@ lemma tcbSchedEnqueue_cslift_precond_discharge:
   apply (frule_tac t=x in valid_objs'_maxDomain, fastforce simp: obj_at'_def)
   apply (drule_tac P="\<lambda>tcb. tcbPriority tcb \<le> maxPriority" in obj_at_ko_at2', simp)
   apply (drule_tac P="\<lambda>tcb. tcbDomain tcb \<le> maxDomain" in obj_at_ko_at2', simp)
-
-  apply (simp add: ctcb_relation_tcbDomain_maxDom ctcb_relation_tcbPriority_maxPrio)
+  apply (simp add: ctcb_relation_tcbDomain_maxDomain_numDomains
+                   ctcb_relation_tcbPriority_maxPriority_numPriorities)
   apply (frule_tac d="tcbDomain ko" and p="tcbPriority ko"
               in rf_sr_sched_queue_relation)
     apply (simp add: maxDom_to_H maxPrio_to_H)+
-  apply (simp add: cready_queues_index_to_C_def2 numPriorities_def)
+  apply (simp add: cready_queues_index_to_C_def2 numPriorities_def le_maxDomain_eq_less_numDomains)
   apply (clarsimp simp: ctcb_relation_def)
   apply (frule arg_cong[where f=unat], subst(asm) unat_ucast_8_32)
   apply (frule tcb_queue'_head_end_NULL)

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -133,14 +133,15 @@ lemma decodeDomainInvocation_ccorres:
    apply (rule ccorres_add_return)
    apply (rule ccorres_rhs_assoc)+
    apply (ctac add: getSyscallArg_ccorres_foo[where args=args and n=0 and buffer=buffer])
-     apply (simp add: numDomains_def hd_conv_nth word_le_nat_alt)
+     apply (simp add: hd_conv_nth word_le_nat_alt)
+     apply (simp add: unat_scast_numDomains)
      apply (rule ccorres_Cond_rhs_Seq)
-      apply (simp add: throwError_bind invocationCatch_def numDomains_def
-                       hd_conv_nth word_le_nat_alt
+      apply (simp add: throwError_bind invocationCatch_def
+                       hd_conv_nth word_le_nat_alt unat_numDomains_to_H
                  cong: StateSpace.state.fold_congs globals.fold_congs)
       apply (rule syscall_error_throwError_ccorres_n)
       apply (simp add: syscall_error_to_H_cases)
-     apply (simp add: null_def excaps_map_def)
+     apply (simp add: null_def excaps_map_def unat_numDomains_to_H)
      apply (rule ccorres_Cond_rhs_Seq)
       apply (simp add: throwError_bind invocationCatch_def
                        interpret_excaps_test_null
@@ -190,11 +191,11 @@ lemma decodeDomainInvocation_ccorres:
    apply clarsimp
    apply (vcg exspec=getSyscallArg_modifies)
 
+  including no_take_bit
   apply (clarsimp simp: valid_tcb_state'_def invs_valid_queues' invs_valid_objs'
                         invs_queues invs_sch_act_wf' ct_in_state'_def pred_tcb_at'
                         rf_sr_ksCurThread word_sle_def word_sless_def sysargs_rel_to_n
-                        mask_eq_iff_w2p mask_eq_iff_w2p word_size "StrictC'_thread_state_defs"
-                        maxDomain_def numDomains_def)
+                        mask_eq_iff_w2p mask_eq_iff_w2p word_size "StrictC'_thread_state_defs")
   apply (rule conjI)
    apply (clarsimp simp: linorder_not_le isCap_simps)
    apply (rule conjI, clarsimp simp: unat32_eq_of_nat)
@@ -204,9 +205,11 @@ lemma decodeDomainInvocation_ccorres:
    apply (clarsimp simp: valid_cap_simps' pred_tcb'_weakenE active_runnable')
    apply (rule conjI)
     apply (fastforce simp: tcb_st_refs_of'_def elim:pred_tcb'_weakenE)
-   apply (simp add: word_le_nat_alt unat_ucast)
-  apply (clarsimp simp: ucast_ucast_len word_less_nat_alt
-                        ccap_relation_def cap_to_H_simps cap_thread_cap_lift)
+   apply (simp add: word_le_nat_alt unat_ucast unat_numDomains_to_H le_maxDomain_eq_less_numDomains)
+  apply (clarsimp simp: ccap_relation_def cap_to_H_simps cap_thread_cap_lift)
+  subgoal (* args ! 0 can be contained in a domain-sized word *)
+    by (clarsimp simp: not_le unat_numDomains_to_H ucast_ucast_len[simplified word_less_nat_alt]
+                 dest!: less_numDomains_is_domain)
   done
 
 (************************************************************************)

--- a/proof/crefine/ARM/IpcCancel_C.thy
+++ b/proof/crefine/ARM/IpcCancel_C.thy
@@ -15,21 +15,21 @@ declare ctcb_size_bits_ge_4[simp]
 
 lemma cready_queues_index_to_C_in_range':
   assumes prems: "qdom \<le> ucast maxDom" "prio \<le> ucast maxPrio"
-  shows "cready_queues_index_to_C qdom prio < numDomains * numPriorities"
+  shows "cready_queues_index_to_C qdom prio < num_tcb_queues"
 proof -
   have P: "unat prio < numPriorities"
     using prems
     by (simp add: numPriorities_def seL4_MaxPrio_def Suc_le_lessD unat_le_helper)
   have Q: "unat qdom < numDomains"
     using prems
-    by (simp add: numDomains_def maxDom_def Suc_le_lessD unat_le_helper)
+    by (simp add: maxDom_to_H le_maxDomain_eq_less_numDomains word_le_nat_alt)
   show ?thesis
     using mod_lemma[OF _ P, where q="unat qdom" and c=numDomains] Q
-    by (clarsimp simp: cready_queues_index_to_C_def field_simps numDomains_def)
+    by (clarsimp simp: num_tcb_queues_calculation cready_queues_index_to_C_def field_simps)
 qed
 
-lemmas cready_queues_index_to_C_in_range
-            = cready_queues_index_to_C_in_range'[unfolded numPriorities_def numDomains_def, simplified]
+lemmas cready_queues_index_to_C_in_range =
+  cready_queues_index_to_C_in_range'[simplified num_tcb_queues_def]
 
 lemma cready_queues_index_to_C_inj:
   "\<lbrakk> cready_queues_index_to_C qdom prio = cready_queues_index_to_C qdom' prio';
@@ -621,8 +621,7 @@ lemma state_relation_queue_update_helper':
      apply simp
      apply (erule cnotification_relation_upd_tcb_no_queues, simp+)
     \<comment> \<open>ready queues\<close>
-    apply (simp add: cready_queues_relation_def Let_def
-                     cready_queues_index_to_C_in_range
+    apply (simp add: cready_queues_relation_def Let_def cready_queues_index_to_C_in_range
                      seL4_MinPrio_def minDom_def)
     apply clarsimp
     apply (frule cready_queues_index_to_C_distinct, assumption+)
@@ -686,31 +685,23 @@ lemmas queue_in_range = of_nat_mono_maybe[OF _ cready_queues_index_to_C_in_range
         where 'a="32 signed", unfolded cready_queues_index_to_C_def numPriorities_def,
         simplified, unfolded ucast_nat_def]
 
-lemma cready_queues_index_to_C_def2':
-  "\<lbrakk> qdom \<le> ucast maxDom; prio \<le> ucast maxPrio \<rbrakk>
+lemma cready_queues_index_to_C_def2:
+  "\<lbrakk> qdom \<le> maxDomain; prio \<le> maxPriority \<rbrakk>
    \<Longrightarrow> cready_queues_index_to_C qdom prio
-             = unat (ucast qdom * of_nat numPriorities + ucast prio :: 32 word)"
-  apply (simp add: cready_queues_index_to_C_def numPriorities_def)
+             = unat (ucast qdom * of_nat numPriorities + ucast prio :: machine_word)"
+  including no_take_bit
+  using numPriorities_machine_word_safe
+  apply -
+  apply (frule (1) cready_queues_index_to_C_in_range[simplified maxDom_to_H maxPrio_to_H])
   apply (subst unat_add_lem[THEN iffD1])
-   apply (frule cready_queues_index_to_C_in_range, simp)
-   apply (simp add: cready_queues_index_to_C_def numPriorities_def)
-   apply (subst unat_mult_simple)
-    apply (simp add: word_bits_def maxDom_def)
-   apply simp
-  apply (subst unat_mult_simple)
-   apply (simp add: word_bits_def maxDom_def)
-   apply (subst (asm) word_le_nat_alt)
-   apply simp
-  apply simp
+   apply (auto simp: unat_mult_simple cready_queues_index_to_C_def)
   done
 
-lemmas cready_queues_index_to_C_def2
-           = cready_queues_index_to_C_def2'[simplified maxDom_to_H maxPrio_to_H]
-
 lemma ready_queues_index_spec:
-  "\<forall>s. \<Gamma> \<turnstile> {s} Call ready_queues_index_'proc
+  "\<forall>s. \<Gamma> \<turnstile> {s'. s' = s \<and> (Kernel_Config.numDomains \<le> 1 \<longrightarrow> dom_' s' = 0)}
+       Call ready_queues_index_'proc
        \<lbrace>\<acute>ret__unsigned_long = (dom_' s) * 0x100 + (prio_' s)\<rbrace>"
-  by vcg (simp add: word_sless_alt)
+  by vcg (simp add: numDomains_sge_1_simp)
 
 lemma prio_to_l1index_spec:
   "\<forall>s. \<Gamma> \<turnstile> {s} Call prio_to_l1index_'proc
@@ -765,7 +756,7 @@ lemma cready_queues_index_to_C_ucast_helper:
   fixes p :: priority
   fixes d :: domain
   shows "unat (ucast d * 0x100 + ucast p :: machine_word) = unat d * 256 + unat p"
-  unfolding tcb_queue_relation'_def maxPriority_def maxDomain_def numDomains_def numPriorities_def
+  unfolding tcb_queue_relation'_def maxPriority_def numPriorities_def
   using unat_lt2p[where x=p] unat_lt2p[where x=d]
   by (clarsimp simp: cready_queues_index_to_C_def word_le_nat_alt unat_word_ariths)
 
@@ -774,7 +765,6 @@ lemmas prio_and_dom_limit_helpers =
   prio_ucast_shiftr_wordRadix_helper'
   prio_ucast_shiftr_wordRadix_helper2
   prio_unat_shiftr_wordRadix_helper'
-  dom_less_0x10_helper
   cready_queues_index_to_C_ucast_helper
   unat_ucast_prio_L1_cmask_simp
   machine_word_and_1F_less_20
@@ -789,7 +779,6 @@ lemma rf_sr_cbitmap_L2_relation[intro]:
   "(\<sigma>, x) \<in> rf_sr \<Longrightarrow> cbitmap_L2_relation (ksReadyQueuesL2Bitmap_' (globals x)) (ksReadyQueuesL2Bitmap \<sigma>)"
   by (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
 
-
 lemma cbitmap_L1_relation_bit_set:
   fixes p :: priority
   shows
@@ -799,8 +788,10 @@ lemma cbitmap_L1_relation_bit_set:
            (Arrays.update (ksReadyQueuesL1Bitmap_' (globals x)) (unat d)
              (ksReadyQueuesL1Bitmap_' (globals x).[unat d] || 2 ^ unat (p >> wordRadix)))
            ((ksReadyQueuesL1Bitmap \<sigma>)(d := ksReadyQueuesL1Bitmap \<sigma> d || 2 ^ prioToL1Index p))"
+  including no_take_bit
   apply (unfold cbitmap_L1_relation_def)
-  apply (clarsimp simp: prioToL1Index_def wordRadix_def' maxDomain_def numDomains_def word_le_nat_alt)
+  apply (clarsimp simp: le_maxDomain_eq_less_numDomains word_le_nat_alt prioToL1Index_def
+                        num_domains_index_updates)
   done
 
 lemma cbitmap_L2_relation_bit_set:
@@ -822,8 +813,8 @@ lemma cbitmap_L2_relation_bit_set:
   unfolding cbitmap_L2_relation_def numPriorities_def wordBits_def word_size l2BitmapSize_def'
   apply (clarsimp simp: word_size prioToL1Index_def wordRadix_def mask_def
                         invertL1Index_def l2BitmapSize_def'
-                        maxDomain_def numDomains_def word_le_nat_alt)
-  apply (case_tac "da = d" ; clarsimp)
+                        le_maxDomain_eq_less_numDomains word_le_nat_alt)
+  apply (case_tac "da = d" ; clarsimp simp: num_domains_index_updates)
   done
 
 lemma t_hrs_ksReadyQueues_upd_absorb:
@@ -882,6 +873,10 @@ lemma tcbSchedEnqueue_ccorres:
 proof -
   note prio_and_dom_limit_helpers[simp] word_sle_def[simp] maxDom_to_H[simp] maxPrio_to_H[simp]
   note invert_prioToL1Index_c_simp[simp]
+
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  note word_less_1[simp del]
 
   show ?thesis
   apply (cinit lift: tcb_')
@@ -957,6 +952,9 @@ proof -
                         (globals x).[cready_queues_index_to_C (tcbDomain tcb) (tcbPriority tcb)]) = NULL")
              prefer 2
              apply (frule_tac s=\<sigma> in tcb_queue'_head_end_NULL[symmetric]; simp add: valid_queues_valid_q)
+            apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                      unat_trans_ucast_helper\<close>)
+            apply (frule maxDomain_le_unat_ucast_explicit)
             apply (clarsimp simp: cready_queues_index_to_C_def numPriorities_def)
             apply (clarsimp simp: h_val_field_clift' h_t_valid_clift)
              apply (simp add: t_hrs_ksReadyQueues_upd_absorb)
@@ -981,7 +979,9 @@ proof -
                                   t_hrs_ksReadyQueues_upd_absorb upd_unless_null_def
                                   typ_heap_simps)[1]
                apply (fastforce simp: tcb_null_sched_ptrs_def elim: obj_at'_weaken)+
-
+           apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                     unat_trans_ucast_helper\<close>)
+           apply clarsimp
            apply (rule conjI; clarsimp simp: queue_in_range)
             (* invalid, disagreement between C and Haskell on emptiness of queue *)
             apply (drule (1) obj_at_cslift_tcb)
@@ -1156,9 +1156,10 @@ lemma cbitmap_L1_relation_bit_clear:
            (Arrays.update (ksReadyQueuesL1Bitmap_' (globals x)) (unat d)
              (ksReadyQueuesL1Bitmap_' (globals x).[unat d] && ~~ 2 ^ unat (p >> wordRadix)))
            ((ksReadyQueuesL1Bitmap \<sigma>)(d := ksReadyQueuesL1Bitmap \<sigma> d && ~~ 2 ^ prioToL1Index p))"
-  apply (unfold cbitmap_L1_relation_def)
-  apply (clarsimp simp: prioToL1Index_def wordRadix_def' maxDomain_def numDomains_def word_le_nat_alt)
-  done
+  unfolding cbitmap_L1_relation_def numPriorities_def wordBits_def word_size l2BitmapSize_def'
+  by (clarsimp simp: word_size prioToL1Index_def wordRadix_def mask_def
+                     invertL1Index_def l2BitmapSize_def'
+                     le_maxDomain_eq_less_numDomains word_le_nat_alt num_domains_index_updates)
 
 lemma cready_queues_relation_empty_queue_helper:
   "\<lbrakk> tcbDomain ko \<le> maxDomain ; tcbPriority ko \<le> maxPriority ;
@@ -1206,8 +1207,8 @@ lemma cbitmap_L2_relation_bit_clear:
   unfolding cbitmap_L2_relation_def numPriorities_def wordBits_def word_size l2BitmapSize_def'
   apply (clarsimp simp: word_size prioToL1Index_def wordRadix_def mask_def
                         invertL1Index_def l2BitmapSize_def'
-                        maxDomain_def numDomains_def word_le_nat_alt)
-  apply (case_tac "da = d" ; clarsimp)
+                        le_maxDomain_eq_less_numDomains word_le_nat_alt)
+  apply (case_tac "da = d" ; clarsimp simp: num_domains_index_updates)
   done
 
 lemma tcbSchedDequeue_ccorres':
@@ -1222,6 +1223,10 @@ lemma tcbSchedDequeue_ccorres':
 proof -
 
   note prio_and_dom_limit_helpers[simp] word_sle_def[simp]
+
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  include no_less_1_simps
 
   have ksQ_tcb_at': "\<And>s ko d p.
     \<forall>d p. (\<forall>t\<in>set (ksReadyQueues s (d, p)). obj_at' (inQ d p) t s)
@@ -1300,6 +1305,9 @@ proof -
              apply (frule_tac s=\<sigma> in tcb_queue_relation_prev_next'; (fastforce simp: ksQ_tcb_at')?)
              apply (drule_tac s=\<sigma> in tcbSchedDequeue_update, assumption,
                      simp_all add: remove1_filter ksQ_tcb_at')[1]
+             apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                       unat_trans_ucast_helper\<close>)
+             apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
              apply (intro conjI ;
                      clarsimp simp: h_val_field_clift'
                                     h_t_valid_clift[THEN h_t_valid_field] h_t_valid_clift)+
@@ -1314,11 +1322,12 @@ proof -
                 apply (frule rf_sr_cbitmap_L2_relation)
                 apply (clarsimp simp: cbitmap_L2_relation_def
                                       word_size prioToL1Index_def wordRadix_def mask_def
-                                      maxDomain_def numDomains_def word_le_nat_alt
+                                      word_le_nat_alt
                                       numPriorities_def wordBits_def l2BitmapSize_def'
-                                      invertL1Index_def)
-                apply (case_tac "d = tcbDomain ko" ; fastforce)
-
+                                      invertL1Index_def numDomains_less_numeric_explicit)
+                apply (case_tac "d = tcbDomain ko"
+                       ; fastforce simp: le_maxDomain_eq_less_numDomains
+                                         numDomains_less_numeric_explicit)
                apply (drule (1) obj_at_cslift_tcb, clarsimp simp: inQ_def)
                apply (frule_tac d="tcbDomain ko" and p="tcbPriority ko"
                         in rf_sr_sched_queue_relation)
@@ -1338,8 +1347,8 @@ proof -
                apply (erule (2) cready_queues_relation_empty_queue_helper)
               (* impossible case, C L2 update disagrees with Haskell update *)
               apply (simp add: invert_prioToL1Index_c_simp)
-              apply (subst (asm) Arrays.index_update)
-               subgoal by (simp add: maxDomain_def numDomains_def word_le_nat_alt)
+              apply (subst (asm) num_domains_index_updates)
+               subgoal by (simp add: le_maxDomain_eq_less_numDomains word_le_nat_alt)
               apply (subst (asm) Arrays.index_update)
                apply (simp add: invert_l1_index_limit)
 
@@ -1368,6 +1377,9 @@ proof -
             apply (drule_tac s=\<sigma> in tcbSchedDequeue_update, assumption,
                    simp_all add: remove1_filter ksQ_tcb_at')[1]
             apply (clarsimp simp:  filter_noteq_op upd_unless_null_def)
+            apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                      unat_trans_ucast_helper\<close>)
+            apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
             apply (rule conjI, clarsimp)
              apply (clarsimp simp: h_val_field_clift'
                                    h_t_valid_clift[THEN h_t_valid_field] h_t_valid_clift)
@@ -1434,6 +1446,9 @@ proof -
             apply (drule_tac s=\<sigma> in tcbSchedDequeue_update, assumption,
                    simp_all add: remove1_filter ksQ_tcb_at')[1]
             apply (clarsimp simp:  filter_noteq_op upd_unless_null_def)
+            apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                      unat_trans_ucast_helper\<close>)
+            apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
             apply (rule conjI; clarsimp)
              apply (clarsimp simp: h_val_field_clift'
                                    h_t_valid_clift[THEN h_t_valid_field] h_t_valid_clift)
@@ -1444,8 +1459,8 @@ proof -
              apply (fastforce simp: c_invert_assist l2BitmapSize_def' wordRadix_def)
             apply (rule conjI; clarsimp)
              (* impossible case, C L2 update disagrees with Haskell update *)
-             apply (subst (asm) Arrays.index_update)
-              apply (simp add: maxDomain_def numDomains_def word_le_nat_alt)
+             apply (subst (asm) num_domains_index_updates)
+              apply (simp add: le_maxDomain_eq_less_numDomains word_le_nat_alt)
              apply (subst (asm) Arrays.index_update)
               subgoal using invert_l1_index_limit
                 by (fastforce simp add: invert_prioToL1Index_c_simp intro: nat_Suc_less_le_imp)
@@ -1479,6 +1494,9 @@ proof -
            apply (drule_tac s=\<sigma> in tcbSchedDequeue_update, assumption,
                   simp_all add: remove1_filter ksQ_tcb_at')[1]
            apply (clarsimp simp: filter_noteq_op upd_unless_null_def)
+           apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                     unat_trans_ucast_helper\<close>)
+           apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
            apply (rule conjI, clarsimp)
             apply (clarsimp simp: h_val_field_clift'
                                   h_t_valid_clift[THEN h_t_valid_field] h_t_valid_clift)
@@ -1618,6 +1636,10 @@ lemma tcbSchedAppend_ccorres:
 proof -
   note prio_and_dom_limit_helpers[simp] word_sle_def[simp] maxDom_to_H[simp] maxPrio_to_H[simp]
 
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  include no_less_1_simps
+
   show ?thesis
   apply (cinit lift: tcb_')
    apply (rule_tac r'="\<lambda>rv rv'. rv = to_bool rv'"
@@ -1687,6 +1709,9 @@ proof -
              apply (rule tcb_at_not_NULL, erule obj_at'_weakenE, simp)
             apply (clarsimp simp: h_val_field_clift' h_t_valid_clift)
             apply (simp add: invert_prioToL1Index_c_simp)
+            apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                      unat_trans_ucast_helper\<close>)
+            apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
             apply (rule conjI; clarsimp)
              apply (rule conjI)
               apply (fastforce simp: c_invert_assist l2BitmapSize_def' wordRadix_def)
@@ -1701,6 +1726,9 @@ proof -
                                   typ_heap_simps)[1]
                apply (fastforce simp: tcb_null_sched_ptrs_def elim: obj_at'_weaken)+
             apply (clarsimp simp: upd_unless_null_def cready_queues_index_to_C_def numPriorities_def)
+           apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                     unat_trans_ucast_helper\<close>)
+           apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
            apply (rule conjI; clarsimp simp: queue_in_range)
             apply (drule (1) obj_at_cslift_tcb)
             apply clarsimp
@@ -2008,6 +2036,10 @@ proof -
     apply (simp add: unat_of_nat_eq)
     done
 
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  include no_less_1_simps
+
   show ?thesis
   including no_take_bit
   apply (cinit lift: dom_')
@@ -2045,7 +2077,7 @@ proof -
     prefer 2
     subgoal by (fastforce simp: cbitmap_L1_relation_def)
 
-   apply (clarsimp simp: signed_word_log2 cbitmap_L1_relation_def)
+   apply (clarsimp simp: signed_word_log2 cbitmap_L1_relation_def maxDomain_le_unat_ucast_explicit)
    apply (frule bitmapQ_no_L1_orphansD, erule word_log2_nth_same)
    apply (rule conjI, fastforce simp: invertL1Index_def l2BitmapSize_def')
    apply (rule conjI, fastforce)
@@ -2097,6 +2129,17 @@ lemma getCurDomain_ccorres_dom_':
        \<top> UNIV hs curDomain (\<acute>dom :== \<acute>ksCurDomain)"
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
+  apply (clarsimp simp: curDomain_def simpler_gets_def
+                        rf_sr_ksCurDomain)
+  done
+
+lemma getCurDomain_maxDom_ccorres_dom_':
+  "ccorres (\<lambda>rv rv'. rv' = ucast rv) dom_'
+     (\<lambda>s. ksCurDomain s \<le> maxDomain) UNIV hs
+     curDomain (\<acute>dom :== (if maxDom \<noteq> 0 then \<acute>ksCurDomain else 0))"
+  apply (rule ccorres_from_vcg)
+  apply (rule allI, rule conseqPre, vcg)
+  using maxDom_to_H
   apply (clarsimp simp: curDomain_def simpler_gets_def
                         rf_sr_ksCurDomain)
   done

--- a/proof/crefine/ARM/SR_lemmas_C.thy
+++ b/proof/crefine/ARM/SR_lemmas_C.thy
@@ -2184,6 +2184,17 @@ lemma rf_sr_sched_action_relation:
    \<Longrightarrow> cscheduler_action_relation (ksSchedulerAction s) (ksSchedulerAction_' (globals s'))"
   by (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
 
+lemma numDomains_sge_1_simp:
+  "1 <s Kernel_C.numDomains \<longleftrightarrow> Suc 0 < Kernel_Config.numDomains"
+  apply (simp add: word_sless_alt sint_numDomains_to_H)
+  apply (subst nat_less_as_int, simp)
+  done
+
+lemma unat_scast_numDomains:
+  "unat (SCAST(32 signed \<rightarrow> machine_word_len) Kernel_C.numDomains) = unat Kernel_C.numDomains"
+  including no_take_bit
+  by (simp add: scast_eq sint_numDomains_to_H unat_numDomains_to_H numDomains_machine_word_safe)
+
 end
 end
 

--- a/proof/crefine/ARM/Schedule_C.thy
+++ b/proof/crefine/ARM/Schedule_C.thy
@@ -165,13 +165,6 @@ lemma ceqv_remove_tail_Guard_Skip:
   apply (case_tac s', auto intro: exec.intros elim!: exec_Normal_elim_cases)[1]
   done
 
-lemma queue_in_range_pre:
-  "\<lbrakk> (qdom :: word32) \<le> ucast maxDom; prio \<le> ucast maxPrio \<rbrakk>
-    \<Longrightarrow> qdom * of_nat numPriorities + prio < of_nat (numDomains * numPriorities)"
-  by (clarsimp simp: cready_queues_index_to_C_def word_less_nat_alt
-                     word_le_nat_alt unat_ucast maxDom_def seL4_MaxPrio_def
-                     numPriorities_def unat_word_ariths numDomains_def)
-
 lemma switchToThread_ccorres':
   "ccorres (\<lambda>_ _. True) xfdc
            (all_invs_but_ct_idle_or_in_cur_domain' and tcb_at' t)
@@ -190,73 +183,99 @@ proof -
 
   note prio_and_dom_limit_helpers [simp]
   note Collect_const_mem [simp]
+  note Collect_const [simp del]
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  include no_less_1_simps
 
   have invs_no_cicd'_max_CurDomain[intro]:
     "\<And>s. invs_no_cicd' s \<Longrightarrow> ksCurDomain s \<le> maxDomain"
     by (simp add: invs_no_cicd'_def)
 
   show ?thesis
-  apply (cinit)
-   apply (simp add: numDomains_def word_sless_alt word_sle_def)
-   apply (ctac (no_vcg) add: getCurDomain_ccorres_dom_')
-     apply clarsimp
-     apply (rename_tac curdom)
-     apply (rule_tac P="curdom \<le> maxDomain" in ccorres_cross_over_guard_no_st)
-     apply (rule ccorres_Guard)
-     apply (rule ccorres_pre_getReadyQueuesL1Bitmap)
-     apply (rename_tac l1)
-     apply (rule_tac R="\<lambda>s. l1 = ksReadyQueuesL1Bitmap s curdom \<and> curdom \<le> maxDomain"
-              in ccorres_cond)
-       subgoal by (fastforce dest!: rf_sr_cbitmap_L1_relation simp: cbitmap_L1_relation_def)
-      prefer 2 \<comment> \<open>switchToIdleThread\<close>
-      apply (ctac(no_vcg) add: switchToIdleThread_ccorres)
-     apply clarsimp
-     apply (rule ccorres_rhs_assoc)+
-
-     apply (rule ccorres_split_nothrow_novcg)
-         apply (rule_tac xf'=prio_' in ccorres_call)
-            apply (rule getHighestPrio_ccorres[simplified getHighestPrio_def'])
-           apply simp+
+    supply if_split[split del]
+    apply (cinit)
+     apply (simp add: numDomains_sge_1_simp)
+     apply (rule_tac xf'=dom_' and r'="\<lambda>rv rv'. rv' = ucast rv" in ccorres_split_nothrow_novcg)
+         apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
+         apply clarsimp
+         apply (rule conseqPre, vcg)
+         apply (rule Collect_mono)
+         apply (clarsimp split: prod.split)
+         apply (clarsimp simp: curDomain_def simpler_gets_def return_def rf_sr_ksCurDomain)
         apply ceqv
        apply clarsimp
-       apply (rename_tac prio)
+       apply (rename_tac curdom)
        apply (rule_tac P="curdom \<le> maxDomain" in ccorres_cross_over_guard_no_st)
-       apply (rule_tac P="prio \<le> maxPriority" in ccorres_cross_over_guard_no_st)
-       apply (rule ccorres_pre_getQueue)
-       apply (rule_tac P="queue \<noteq> []" in ccorres_cross_over_guard_no_st)
-       apply (rule ccorres_symb_exec_l)
-          apply (rule ccorres_assert)
-          apply csymbr
-          apply (rule ccorres_Guard_Seq)+
-          apply (rule ccorres_symb_exec_r)
-            apply (simp only: ccorres_seq_skip)
-            apply (rule ccorres_call[OF switchToThread_ccorres']; simp)
-           apply vcg
-          apply (rule conseqPre, vcg)
-          apply clarsimp
-         apply (wp isRunnable_wp)+
-       apply (simp add: isRunnable_def)
-      apply wp
-     apply (clarsimp simp: Let_def guard_is_UNIV_def)
-     apply (drule invs_no_cicd'_queues)
-     apply (case_tac queue, simp)
-     apply (clarsimp simp: tcb_queue_relation'_def cready_queues_index_to_C_def
-                            numPriorities_def )
-     apply (simp add: word_less_nat_alt word_le_nat_alt)
-     apply (rule_tac x="unat curdom * 256" and xmax="unat maxDomain * 256" in nat_add_less_by_max)
-      subgoal by (simp add: word_le_nat_alt[symmetric])
-     subgoal by (simp add: maxDomain_def numDomains_def maxPriority_def numPriorities_def)
-    apply wp
-   apply clarsimp
-  apply (frule invs_no_cicd'_queues)
-  apply (frule invs_no_cicd'_max_CurDomain)
-  apply (frule invs_no_cicd'_queues)
-  apply (clarsimp simp: valid_queues_def lookupBitmapPriority_le_maxPriority)
-  apply (intro conjI impI)
-      apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
-     apply (fastforce dest: lookupBitmapPriority_obj_at'
-                      simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
-  done
+       apply (rule ccorres_Guard)
+       apply (rule ccorres_pre_getReadyQueuesL1Bitmap)
+       apply (rename_tac l1)
+       apply (rule_tac R="\<lambda>s. l1 = ksReadyQueuesL1Bitmap s curdom \<and> curdom \<le> maxDomain"
+                in ccorres_cond)
+         subgoal by (fastforce dest!: rf_sr_cbitmap_L1_relation simp: cbitmap_L1_relation_def)
+        prefer 2 \<comment> \<open>switchToIdleThread\<close>
+        apply (ctac(no_vcg) add: switchToIdleThread_ccorres)
+       apply clarsimp
+       apply (rule ccorres_rhs_assoc)+
+       apply (rule ccorres_split_nothrow_novcg)
+           apply (rule_tac xf'=prio_' in ccorres_call)
+              apply (rule getHighestPrio_ccorres[simplified getHighestPrio_def'])
+             apply simp+
+          apply ceqv
+         apply clarsimp
+         apply (rename_tac prio)
+         apply (rule_tac P="curdom \<le> maxDomain" in ccorres_cross_over_guard_no_st)
+         apply (rule_tac P="prio \<le> maxPriority" in ccorres_cross_over_guard_no_st)
+         apply (rule ccorres_pre_getQueue)
+         apply (rule_tac P="queue \<noteq> []" in ccorres_cross_over_guard_no_st)
+         apply (rule ccorres_symb_exec_l)
+            apply (rule ccorres_assert)
+            apply (rule ccorres_symb_exec_r)
+              apply (rule ccorres_Guard_Seq)+
+              apply (rule ccorres_symb_exec_r)
+                apply (simp only: ccorres_seq_skip)
+                apply (rule ccorres_call[OF switchToThread_ccorres']; simp)
+               apply vcg
+              apply (rule conseqPre, vcg)
+              apply clarsimp
+             apply clarsimp
+             apply (rule conseqPre, vcg)
+             apply (rule Collect_mono)
+             apply clarsimp
+             apply (strengthen queue_in_range)
+             apply assumption
+            apply clarsimp
+            apply (rule conseqPre, vcg)
+            apply clarsimp
+           apply (wp isRunnable_wp)+
+         apply (simp add: isRunnable_def)
+        apply wp
+       apply (clarsimp simp: Let_def guard_is_UNIV_def)
+       apply (drule invs_no_cicd'_queues)
+       apply (case_tac queue, simp)
+       apply (clarsimp simp: tcb_queue_relation'_def cready_queues_index_to_C_def numPriorities_def)
+       apply (clarsimp simp add: maxDom_to_H maxPrio_to_H
+                                 queue_in_range[where qdom=0, simplified, simplified maxPrio_to_H])
+       apply (clarsimp simp: le_maxDomain_eq_less_numDomains unat_trans_ucast_helper )
+      apply wpsimp
+     apply (clarsimp simp: guard_is_UNIV_def le_maxDomain_eq_less_numDomains word_less_nat_alt
+                           numDomains_less_numeric_explicit)
+    apply (frule invs_no_cicd'_queues)
+    apply (frule invs_no_cicd'_max_CurDomain)
+    apply (frule invs_no_cicd'_queues)
+    apply (clarsimp simp: valid_queues_def lookupBitmapPriority_le_maxPriority)
+    apply (intro conjI impI)
+       apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
+      apply (fastforce dest: lookupBitmapPriority_obj_at'
+                       simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+     apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
+    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    apply (clarsimp simp: not_less le_maxDomain_eq_less_numDomains)
+    apply (prop_tac "ksCurDomain s = 0")
+     using unsigned_eq_0_iff apply force
+    apply (cut_tac s=s in lookupBitmapPriority_obj_at'; simp?)
+    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    done
 qed
 
 lemma ksDomSched_length_dom_relation[simp]:
@@ -338,6 +357,9 @@ lemma isHighestPrio_ccorres:
   supply from_bool_eq_if[simp] from_bool_eq_if'[simp] from_bool_0[simp] if_1_0_0[simp]
           ccorres_IF_True[simp]
   supply if_weak_cong[cong]
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  including no_less_1_simps
   apply (cinit lift: dom_' prio_')
    apply clarsimp
    apply (rule ccorres_move_const_guard)
@@ -363,7 +385,8 @@ lemma isHighestPrio_ccorres:
       apply (rule ccorres_return_C, simp, simp, simp)
      apply (rule wp_post_taut)
     apply (vcg exspec=getHighestPrio_modifies)+
-  apply (clarsimp simp: word_le_nat_alt true_def to_bool_def split: if_splits)
+  apply (clarsimp simp: word_le_nat_alt true_def to_bool_def maxDomain_le_unat_ucast_explicit
+                  split: if_splits)
   done
 
 lemma schedule_ccorres:
@@ -555,7 +578,7 @@ lemma schedule_ccorres:
                      apply (wpsimp simp: cscheduler_action_relation_def)+
                    apply (vcg exspec=scheduleChooseNewThread_modifies)
                   apply (wp add: setSchedulerAction_invs' setSchedulerAction_direct del: ssa_wp)
-                 apply (clarsimp | vcg exspec=tcbSchedEnqueue_modifies | wp wp_post_taut)+
+                 apply (clarsimp | vcg exspec=tcbSchedAppend_modifies | wp wp_post_taut)+
               (* candidate is best, switch to it *)
               apply (ctac add: switchToThread_ccorres)
                 apply clarsimp
@@ -701,7 +724,9 @@ lemma timerTick_ccorres:
              apply (vcg exspec=tcbSchedDequeue_modifies)
         apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip[unfolded dc_def])+
         apply ceqv
-       apply (simp add: when_def numDomains_def decDomainTime_def)
+       apply (clarsimp simp: decDomainTime_def numDomains_sge_1_simp)
+       apply (rule ccorres_when[where R=\<top>])
+        apply (solves \<open>clarsimp split: if_split\<close>)
        apply (rule ccorres_split_nothrow_novcg)
            apply (rule_tac rrel=dc and xf=xfdc and P=\<top> and P'=UNIV in ccorres_from_vcg)
            apply (rule allI, rule conseqPre, vcg)
@@ -709,6 +734,7 @@ lemma timerTick_ccorres:
            apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                  carch_state_relation_def cmachine_state_relation_def)
           apply ceqv
+         apply (fold dc_def)
          apply (rule ccorres_pre_getDomainTime)
          apply (rename_tac rva rv'a rvb)
          apply (rule_tac P'="{s. ksDomainTime_' (globals s) = rvb}" in ccorres_inst, simp)

--- a/proof/crefine/ARM/StateRelation_C.thy
+++ b/proof/crefine/ARM/StateRelation_C.thy
@@ -567,8 +567,8 @@ definition
 where
   "cready_queues_index_to_C qdom prio \<equiv> (unat qdom) * numPriorities + (unat prio)"
 
-definition
-  cready_queues_relation :: "tcb_C typ_heap \<Rightarrow> (tcb_queue_C[4096]) \<Rightarrow> (domain \<times> priority \<Rightarrow> ready_queue) \<Rightarrow> bool"
+definition cready_queues_relation ::
+  "tcb_C typ_heap \<Rightarrow> (tcb_queue_C[num_tcb_queues]) \<Rightarrow> (domain \<times> priority \<Rightarrow> ready_queue) \<Rightarrow> bool"
 where
   "cready_queues_relation h_tcb queues aqueues \<equiv>
      \<forall>qdom prio. ((qdom \<ge> ucast minDom \<and> qdom \<le> ucast maxDom \<and>

--- a/proof/crefine/ARM/Wellformed_C.thy
+++ b/proof/crefine/ARM/Wellformed_C.thy
@@ -404,13 +404,113 @@ lemma ptr_val_tcb_ptr_mask2:
   apply (simp add: is_aligned_add_helper ctcb_offset_defs objBits_simps')
   done
 
+section \<open>Domains\<close>
+
+text \<open>
+  seL4's build system allows configuration of the number of domains. This means the proofs have to
+  work for any number of domains provided it fits into the hard limit of a 8-bit word.
+
+  In the C code, we have the enumerated constant numDomains, one greater than maxDom. In the
+  abstract specs, we have the corresponding Platform_Config.numDomains and maxDomain.
+
+  To keep the proofs as general as possible, we avoid unfolding definitions of:
+  maxDom, maxDomain, numDomains except in this theory where we need to establish basic properties.
+
+  Unfortunately, array bounds checks coming from the C code use numerical values, meaning we might
+  get 0x10 instead of the number of domains, or 0x1000 for numDomains * numPriorities. To solve
+  these, the "explicit" lemmas expose direct numbers. They are more risky to deploy, as one could
+  prove that 0x5 is less than the number of domains when that's the case, and then the proof will
+  break upon reconfiguration.
+\<close>
+
+text \<open>The @{text num_domains} enumerated type and constant represent the number of domains.\<close>
+
+value_type num_domains = "numDomains"
+
+context includes no_less_1_simps begin
+
+(* The proofs expect the minimum priority and minimum domain to be zero.
+   Note that minDom is unused in the C code. *)
+lemma min_prio_dom_sanity:
+  "seL4_MinPrio = 0"
+  "Kernel_C.minDom = 0"
+  by (auto simp: seL4_MinPrio_def minDom_def)
+
+lemma less_numDomains_is_domain[simplified word_size, simplified]:
+  "x < numDomains \<Longrightarrow> x < 2 ^ size (y::domain)"
+  unfolding Kernel_Config.numDomains_def
+  by (simp add: word_size)
+
+lemma sint_numDomains_to_H:
+  "sint Kernel_C.numDomains = int Kernel_Config.numDomains"
+  by (clarsimp simp: Kernel_C.numDomains_def Kernel_Config.numDomains_def)
+
+lemma unat_numDomains_to_H:
+  "unat Kernel_C.numDomains = Kernel_Config.numDomains"
+  by (clarsimp simp: Kernel_C.numDomains_def Kernel_Config.numDomains_def)
+
 lemma maxDom_to_H:
   "ucast maxDom = maxDomain"
-  by (simp add: maxDomain_def maxDom_def numDomains_def)
+  by (simp add: maxDomain_def Kernel_C.maxDom_def Kernel_Config.numDomains_def)
+
+lemma maxDom_sgt_0_maxDomain:
+  "0 <s maxDom \<longleftrightarrow> 0 < maxDomain"
+  unfolding Kernel_C.maxDom_def maxDomain_def Kernel_Config.numDomains_def
+  by clarsimp
+
+lemma num_domains_calculation:
+  "num_domains = numDomains"
+  unfolding num_domains_def by eval
+
+private lemma num_domains_card_explicit:
+  "num_domains = CARD(num_domains)"
+  by (simp add: num_domains_def)
+
+lemmas num_domains_index_updates =
+  index_update[where 'b=num_domains, folded num_domains_card_explicit num_domains_def,
+               simplified num_domains_calculation]
+  index_update2[where 'b=num_domains, folded num_domains_card_explicit num_domains_def,
+                simplified num_domains_calculation]
+
+(* C ArrayGuards will throw these at us and there is no way to avoid a proof of being less than a
+   specific number expressed as a word, so we must introduce these. However, being explicit means
+   lack of discipline can lead to a violation. *)
+lemma numDomains_less_numeric_explicit[simplified num_domains_def One_nat_def]:
+  "x < Kernel_Config.numDomains \<Longrightarrow> x < num_domains"
+  by (simp add: num_domains_calculation)
+
+lemma numDomains_less_unat_ucast_explicit[simplified num_domains_def]:
+  "unat x < Kernel_Config.numDomains \<Longrightarrow> (ucast (x::domain) :: machine_word) < of_nat num_domains"
+  apply (rule word_less_nat_alt[THEN iffD2])
+  apply transfer
+  apply simp
+  apply (drule numDomains_less_numeric_explicit, simp add: num_domains_def)
+  done
+
+lemmas maxDomain_le_unat_ucast_explicit =
+  numDomains_less_unat_ucast_explicit[simplified le_maxDomain_eq_less_numDomains(2)[symmetric],
+                                      simplified]
+
+end (* numDomain abstraction definitions and lemmas *)
+
+
+text \<open>Priorities - not expected to be configurable\<close>
 
 lemma maxPrio_to_H:
   "ucast seL4_MaxPrio = maxPriority"
   by (simp add: maxPriority_def seL4_MaxPrio_def numPriorities_def)
+
+
+text \<open>TCB scheduling queues\<close>
+
+(* establish and sanity-check relationship between the calculation of the number of TCB queues and
+   the size of the array in C *)
+value_type num_tcb_queues = "numDomains * numPriorities"
+
+lemma num_tcb_queues_calculation:
+  "num_tcb_queues = numDomains * numPriorities"
+  unfolding num_tcb_queues_def by eval
+
 
 abbreviation(input)
   NotificationObject :: sword32

--- a/proof/crefine/ARM_HYP/ADT_C.thy
+++ b/proof/crefine/ARM_HYP/ADT_C.thy
@@ -664,7 +664,7 @@ lemma tcb_queue_rel'_unique:
 
 definition
   cready_queues_to_H
-  :: "(tcb_C ptr \<rightharpoonup> tcb_C) \<Rightarrow> (tcb_queue_C[4096]) \<Rightarrow> word8 \<times> word8 \<Rightarrow> word32 list"
+  :: "(tcb_C ptr \<rightharpoonup> tcb_C) \<Rightarrow> (tcb_queue_C[num_tcb_queues]) \<Rightarrow> word8 \<times> word8 \<Rightarrow> word32 list"
   where
   "cready_queues_to_H h_tcb cs \<equiv> \<lambda>(qdom, prio). if ucast minDom \<le> qdom \<and> qdom \<le> ucast maxDom
               \<and> ucast seL4_MinPrio \<le> prio \<and> prio \<le> ucast seL4_MaxPrio
@@ -1414,12 +1414,12 @@ lemma (in kernel_m) cDomSchedule_to_H_correct:
   done
 
 definition
-  cbitmap_L1_to_H :: "32 word[16] \<Rightarrow> (8 word \<Rightarrow> 32 word)"
+  cbitmap_L1_to_H :: "32 word[num_domains] \<Rightarrow> (domain \<Rightarrow> 32 word)"
 where
   "cbitmap_L1_to_H l1 \<equiv> \<lambda>d. if d \<le> maxDomain then l1.[unat d] else 0"
 
 definition
-  cbitmap_L2_to_H :: "32 word[8][16] \<Rightarrow> (8 word \<times> nat \<Rightarrow> 32 word)"
+  cbitmap_L2_to_H :: "32 word[8][num_domains] \<Rightarrow> (domain \<times> nat \<Rightarrow> 32 word)"
 where
   "cbitmap_L2_to_H l2 \<equiv> \<lambda>(d, i).
     if d \<le> maxDomain \<and> i < l2BitmapSize

--- a/proof/crefine/ARM_HYP/Finalise_C.thy
+++ b/proof/crefine/ARM_HYP/Finalise_C.thy
@@ -23,9 +23,9 @@ definition
 
 lemma tcbSchedEnqueue_cslift_spec:
   "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> \<lbrace>s. \<exists>d v. option_map2 tcbPriority_C (cslift s) \<acute>tcb = Some v
-                       \<and> v \<le> ucast maxPrio
+                       \<and> unat v \<le> numPriorities
                        \<and> option_map2 tcbDomain_C (cslift s) \<acute>tcb = Some d
-                       \<and> d \<le> ucast maxDom
+                       \<and> unat d < Kernel_Config.numDomains
                        \<and> (end_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))) \<noteq> NULL
                            \<longrightarrow> option_map2 tcbPriority_C (cslift s)
                                    (head_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))))
@@ -43,6 +43,10 @@ lemma tcbSchedEnqueue_cslift_spec:
   apply (clarsimp simp: option_map2_def fun_eq_iff h_t_valid_clift
                         h_t_valid_field[OF h_t_valid_clift])
   apply (rule conjI)
+   apply (clarsimp simp: typ_heap_simps le_maxDomain_eq_less_numDomains)
+   apply unat_arith
+  apply clarsimp
+  apply (rule conjI)
    apply (clarsimp simp: typ_heap_simps cong: if_cong)
    apply (simp split: if_split)
   apply (clarsimp simp: typ_heap_simps if_Some_helper cong: if_cong)
@@ -52,9 +56,9 @@ lemma setThreadState_cslift_spec:
   "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> \<lbrace>s. s \<Turnstile>\<^sub>c \<acute>tptr \<and> (\<forall>x. ksSchedulerAction_' (globals s) = tcb_Ptr x
                  \<and> x \<noteq> 0 \<and> x \<noteq> 1
               \<longrightarrow> (\<exists>d v. option_map2 tcbPriority_C (cslift s) (tcb_Ptr x) = Some v
-                       \<and> v \<le> ucast maxPrio
+                       \<and> unat v \<le> numPriorities
                        \<and> option_map2 tcbDomain_C (cslift s) (tcb_Ptr x) = Some d
-                       \<and> d \<le> ucast maxDom
+                       \<and> unat d < Kernel_Config.numDomains
                        \<and> (end_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))) \<noteq> NULL
                            \<longrightarrow> option_map2 tcbPriority_C (cslift s)
                                    (head_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))))
@@ -127,32 +131,27 @@ lemma ctcb_relation_tcbPriority:
   "ctcb_relation tcb tcb' \<Longrightarrow> ucast (tcbPriority tcb) = tcbPriority_C tcb'"
   by (simp add: ctcb_relation_def)
 
-lemma ctcb_relation_tcbDomain_maxDom:
-  "\<lbrakk> ctcb_relation tcb tcb'; tcbDomain tcb \<le> maxDomain \<rbrakk> \<Longrightarrow> tcbDomain_C tcb' \<le> ucast maxDom"
+lemma ctcb_relation_tcbDomain_maxDomain_numDomains:
+  "\<lbrakk> ctcb_relation tcb tcb'; tcbDomain tcb \<le> maxDomain \<rbrakk>
+   \<Longrightarrow> unat (tcbDomain_C tcb') < Kernel_Config.numDomains"
   apply (subst ctcb_relation_tcbDomain[symmetric], simp)
-  apply (subst ucast_le_migrate)
-    apply ((simp add:maxDom_def word_size)+)[2]
-  apply (simp add: ucast_up_ucast is_up_def source_size_def word_size target_size_def)
-  apply (simp add: maxDom_to_H)
+  apply (simp add: le_maxDomain_eq_less_numDomains)
   done
 
-lemma ctcb_relation_tcbPriority_maxPrio:
+lemma ctcb_relation_tcbPriority_maxPriority_numPriorities:
   "\<lbrakk> ctcb_relation tcb tcb'; tcbPriority tcb \<le> maxPriority \<rbrakk>
-    \<Longrightarrow> tcbPriority_C tcb' \<le> ucast maxPrio"
+    \<Longrightarrow> unat (tcbPriority_C tcb') < numPriorities"
   apply (subst ctcb_relation_tcbPriority[symmetric], simp)
-  apply (subst ucast_le_migrate)
-    apply ((simp add: seL4_MaxPrio_def word_size)+)[2]
-  apply (simp add: ucast_up_ucast is_up_def source_size_def word_size target_size_def)
-  apply (simp add: maxPrio_to_H)
+  apply (simp add: maxPriority_def numPriorities_def word_le_nat_alt)
   done
 
 lemma tcbSchedEnqueue_cslift_precond_discharge:
   "\<lbrakk> (s, s') \<in> rf_sr; obj_at' (P :: tcb \<Rightarrow> bool) x s;
         valid_queues s; valid_objs' s \<rbrakk> \<Longrightarrow>
    (\<exists>d v. option_map2 tcbPriority_C (cslift s') (tcb_ptr_to_ctcb_ptr x) = Some v
-        \<and> v \<le> ucast maxPrio
+        \<and> unat v < numPriorities
         \<and> option_map2 tcbDomain_C (cslift s') (tcb_ptr_to_ctcb_ptr x) = Some d
-        \<and> d \<le> ucast maxDom
+        \<and> unat d < Kernel_Config.numDomains
         \<and> (end_C (index (ksReadyQueues_' (globals s')) (unat (d*0x100 + v))) \<noteq> NULL
                 \<longrightarrow> option_map2 tcbPriority_C (cslift s')
                      (head_C (index (ksReadyQueues_' (globals s')) (unat (d*0x100 + v))))
@@ -166,12 +165,12 @@ lemma tcbSchedEnqueue_cslift_precond_discharge:
   apply (frule_tac t=x in valid_objs'_maxDomain, fastforce simp: obj_at'_def)
   apply (drule_tac P="\<lambda>tcb. tcbPriority tcb \<le> maxPriority" in obj_at_ko_at2', simp)
   apply (drule_tac P="\<lambda>tcb. tcbDomain tcb \<le> maxDomain" in obj_at_ko_at2', simp)
-
-  apply (simp add: ctcb_relation_tcbDomain_maxDom ctcb_relation_tcbPriority_maxPrio)
+  apply (simp add: ctcb_relation_tcbDomain_maxDomain_numDomains
+                   ctcb_relation_tcbPriority_maxPriority_numPriorities)
   apply (frule_tac d="tcbDomain ko" and p="tcbPriority ko"
               in rf_sr_sched_queue_relation)
     apply (simp add: maxDom_to_H maxPrio_to_H)+
-  apply (simp add: cready_queues_index_to_C_def2 numPriorities_def)
+  apply (simp add: cready_queues_index_to_C_def2 numPriorities_def le_maxDomain_eq_less_numDomains)
   apply (clarsimp simp: ctcb_relation_def)
   apply (frule arg_cong[where f=unat], subst(asm) unat_ucast_8_32)
   apply (frule tcb_queue'_head_end_NULL)

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -133,14 +133,15 @@ lemma decodeDomainInvocation_ccorres:
    apply (rule ccorres_add_return)
    apply (rule ccorres_rhs_assoc)+
    apply (ctac add: getSyscallArg_ccorres_foo[where args=args and n=0 and buffer=buffer])
-     apply (simp add: numDomains_def hd_conv_nth word_le_nat_alt)
+     apply (simp add: hd_conv_nth word_le_nat_alt)
+     apply (simp add: unat_scast_numDomains)
      apply (rule ccorres_Cond_rhs_Seq)
-      apply (simp add: throwError_bind invocationCatch_def numDomains_def
-                       hd_conv_nth word_le_nat_alt
+      apply (simp add: throwError_bind invocationCatch_def
+                       hd_conv_nth word_le_nat_alt unat_numDomains_to_H
                  cong: StateSpace.state.fold_congs globals.fold_congs)
       apply (rule syscall_error_throwError_ccorres_n)
       apply (simp add: syscall_error_to_H_cases)
-     apply (simp add: null_def excaps_map_def)
+     apply (simp add: null_def excaps_map_def unat_numDomains_to_H)
      apply (rule ccorres_Cond_rhs_Seq)
       apply (simp add: throwError_bind invocationCatch_def
                        interpret_excaps_test_null
@@ -190,11 +191,11 @@ lemma decodeDomainInvocation_ccorres:
    apply clarsimp
    apply (vcg exspec=getSyscallArg_modifies)
 
+  including no_take_bit
   apply (clarsimp simp: valid_tcb_state'_def invs_valid_queues' invs_valid_objs'
                         invs_queues invs_sch_act_wf' ct_in_state'_def pred_tcb_at'
                         rf_sr_ksCurThread word_sle_def word_sless_def sysargs_rel_to_n
-                        mask_eq_iff_w2p mask_eq_iff_w2p word_size "StrictC'_thread_state_defs"
-                        maxDomain_def numDomains_def)
+                        mask_eq_iff_w2p mask_eq_iff_w2p word_size "StrictC'_thread_state_defs")
   apply (rule conjI)
    apply (clarsimp simp: linorder_not_le isCap_simps)
    apply (rule conjI, clarsimp simp: unat32_eq_of_nat)
@@ -204,9 +205,11 @@ lemma decodeDomainInvocation_ccorres:
    apply (clarsimp simp: valid_cap_simps' pred_tcb'_weakenE active_runnable')
    apply (rule conjI)
     apply (fastforce simp: tcb_st_refs_of'_def elim:pred_tcb'_weakenE)
-   apply (simp add: word_le_nat_alt unat_ucast)
-  apply (clarsimp simp: ucast_ucast_len word_less_nat_alt
-                        ccap_relation_def cap_to_H_simps cap_thread_cap_lift)
+   apply (simp add: word_le_nat_alt unat_ucast unat_numDomains_to_H le_maxDomain_eq_less_numDomains)
+  apply (clarsimp simp: ccap_relation_def cap_to_H_simps cap_thread_cap_lift)
+  subgoal (* args ! 0 can be contained in a domain-sized word *)
+    by (clarsimp simp: not_le unat_numDomains_to_H ucast_ucast_len[simplified word_less_nat_alt]
+                 dest!: less_numDomains_is_domain)
   done
 
 (************************************************************************)

--- a/proof/crefine/ARM_HYP/IpcCancel_C.thy
+++ b/proof/crefine/ARM_HYP/IpcCancel_C.thy
@@ -15,21 +15,21 @@ declare ctcb_size_bits_ge_4[simp]
 
 lemma cready_queues_index_to_C_in_range':
   assumes prems: "qdom \<le> ucast maxDom" "prio \<le> ucast maxPrio"
-  shows "cready_queues_index_to_C qdom prio < numDomains * numPriorities"
+  shows "cready_queues_index_to_C qdom prio < num_tcb_queues"
 proof -
   have P: "unat prio < numPriorities"
     using prems
     by (simp add: numPriorities_def seL4_MaxPrio_def Suc_le_lessD unat_le_helper)
   have Q: "unat qdom < numDomains"
     using prems
-    by (simp add: numDomains_def maxDom_def Suc_le_lessD unat_le_helper)
+    by (simp add: maxDom_to_H le_maxDomain_eq_less_numDomains word_le_nat_alt)
   show ?thesis
     using mod_lemma[OF _ P, where q="unat qdom" and c=numDomains] Q
-    by (clarsimp simp: cready_queues_index_to_C_def field_simps numDomains_def)
+    by (clarsimp simp: num_tcb_queues_calculation cready_queues_index_to_C_def field_simps)
 qed
 
-lemmas cready_queues_index_to_C_in_range
-            = cready_queues_index_to_C_in_range'[unfolded numPriorities_def numDomains_def, simplified]
+lemmas cready_queues_index_to_C_in_range =
+  cready_queues_index_to_C_in_range'[simplified num_tcb_queues_def]
 
 lemma cready_queues_index_to_C_inj:
   "\<lbrakk> cready_queues_index_to_C qdom prio = cready_queues_index_to_C qdom' prio';
@@ -737,8 +737,7 @@ lemma state_relation_queue_update_helper':
      apply simp
      apply (erule cnotification_relation_upd_tcb_no_queues, simp+)
     \<comment> \<open>ready queues\<close>
-    apply (simp add: cready_queues_relation_def Let_def
-                     cready_queues_index_to_C_in_range
+    apply (simp add: cready_queues_relation_def Let_def cready_queues_index_to_C_in_range
                      seL4_MinPrio_def minDom_def)
     apply clarsimp
     apply (frule cready_queues_index_to_C_distinct, assumption+)
@@ -820,31 +819,23 @@ lemmas queue_in_range = of_nat_mono_maybe[OF _ cready_queues_index_to_C_in_range
         where 'a="32 signed", unfolded cready_queues_index_to_C_def numPriorities_def,
         simplified, unfolded ucast_nat_def]
 
-lemma cready_queues_index_to_C_def2':
-  "\<lbrakk> qdom \<le> ucast maxDom; prio \<le> ucast maxPrio \<rbrakk>
+lemma cready_queues_index_to_C_def2:
+  "\<lbrakk> qdom \<le> maxDomain; prio \<le> maxPriority \<rbrakk>
    \<Longrightarrow> cready_queues_index_to_C qdom prio
-             = unat (ucast qdom * of_nat numPriorities + ucast prio :: 32 word)"
-  apply (simp add: cready_queues_index_to_C_def numPriorities_def)
+             = unat (ucast qdom * of_nat numPriorities + ucast prio :: machine_word)"
+  including no_take_bit
+  using numPriorities_machine_word_safe
+  apply -
+  apply (frule (1) cready_queues_index_to_C_in_range[simplified maxDom_to_H maxPrio_to_H])
   apply (subst unat_add_lem[THEN iffD1])
-   apply (frule cready_queues_index_to_C_in_range, simp)
-   apply (simp add: cready_queues_index_to_C_def numPriorities_def)
-   apply (subst unat_mult_simple)
-    apply (simp add: word_bits_def maxDom_def)
-   apply simp
-  apply (subst unat_mult_simple)
-   apply (simp add: word_bits_def maxDom_def)
-   apply (subst (asm) word_le_nat_alt)
-   apply simp
-  apply simp
+   apply (auto simp: unat_mult_simple cready_queues_index_to_C_def)
   done
 
-lemmas cready_queues_index_to_C_def2
-           = cready_queues_index_to_C_def2'[simplified maxDom_to_H maxPrio_to_H]
-
 lemma ready_queues_index_spec:
-  "\<forall>s. \<Gamma> \<turnstile> {s} Call ready_queues_index_'proc
+  "\<forall>s. \<Gamma> \<turnstile> {s'. s' = s \<and> (Kernel_Config.numDomains \<le> 1 \<longrightarrow> dom_' s' = 0)}
+       Call ready_queues_index_'proc
        \<lbrace>\<acute>ret__unsigned_long = (dom_' s) * 0x100 + (prio_' s)\<rbrace>"
-  by vcg (simp add: word_sless_alt)
+  by vcg (simp add: numDomains_sge_1_simp)
 
 lemma prio_to_l1index_spec:
   "\<forall>s. \<Gamma> \<turnstile> {s} Call prio_to_l1index_'proc
@@ -878,7 +869,7 @@ lemma cready_queues_index_to_C_ucast_helper:
   fixes p :: priority
   fixes d :: domain
   shows "unat (ucast d * 0x100 + ucast p :: machine_word) = unat d * 256 + unat p"
-  unfolding tcb_queue_relation'_def maxPriority_def maxDomain_def numDomains_def numPriorities_def
+  unfolding tcb_queue_relation'_def maxPriority_def numPriorities_def
   using unat_lt2p[where x=p] unat_lt2p[where x=d]
   by (clarsimp simp: cready_queues_index_to_C_def word_le_nat_alt unat_word_ariths)
 
@@ -887,7 +878,6 @@ lemmas prio_and_dom_limit_helpers =
   prio_ucast_shiftr_wordRadix_helper'
   prio_ucast_shiftr_wordRadix_helper2
   prio_unat_shiftr_wordRadix_helper'
-  dom_less_0x10_helper
   cready_queues_index_to_C_ucast_helper
   unat_ucast_prio_L1_cmask_simp
   machine_word_and_1F_less_20
@@ -902,7 +892,6 @@ lemma rf_sr_cbitmap_L2_relation[intro]:
   "(\<sigma>, x) \<in> rf_sr \<Longrightarrow> cbitmap_L2_relation (ksReadyQueuesL2Bitmap_' (globals x)) (ksReadyQueuesL2Bitmap \<sigma>)"
   by (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
 
-
 lemma cbitmap_L1_relation_bit_set:
   fixes p :: priority
   shows
@@ -912,8 +901,10 @@ lemma cbitmap_L1_relation_bit_set:
            (Arrays.update (ksReadyQueuesL1Bitmap_' (globals x)) (unat d)
              (ksReadyQueuesL1Bitmap_' (globals x).[unat d] || 2 ^ unat (p >> wordRadix)))
            ((ksReadyQueuesL1Bitmap \<sigma>)(d := ksReadyQueuesL1Bitmap \<sigma> d || 2 ^ prioToL1Index p))"
+  including no_take_bit
   apply (unfold cbitmap_L1_relation_def)
-  apply (clarsimp simp: prioToL1Index_def wordRadix_def' maxDomain_def numDomains_def word_le_nat_alt)
+  apply (clarsimp simp: le_maxDomain_eq_less_numDomains word_le_nat_alt prioToL1Index_def
+                        num_domains_index_updates)
   done
 
 lemma cbitmap_L2_relation_bit_set:
@@ -935,8 +926,8 @@ lemma cbitmap_L2_relation_bit_set:
   unfolding cbitmap_L2_relation_def numPriorities_def wordBits_def word_size l2BitmapSize_def'
   apply (clarsimp simp: word_size prioToL1Index_def wordRadix_def mask_def
                         invertL1Index_def l2BitmapSize_def'
-                        maxDomain_def numDomains_def word_le_nat_alt)
-  apply (case_tac "da = d" ; clarsimp)
+                        le_maxDomain_eq_less_numDomains word_le_nat_alt)
+  apply (case_tac "da = d" ; clarsimp simp: num_domains_index_updates)
   done
 
 lemma carch_state_relation_enqueue_simp:
@@ -1014,6 +1005,10 @@ proof -
   note prio_and_dom_limit_helpers[simp] word_sle_def[simp] maxDom_to_H[simp] maxPrio_to_H[simp]
   note invert_prioToL1Index_c_simp[simp]
 
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  note word_less_1[simp del]
+
   show ?thesis
   apply (cinit lift: tcb_')
    apply (rule_tac r'="\<lambda>rv rv'. rv = to_bool rv'"
@@ -1088,6 +1083,9 @@ proof -
                         (globals x).[cready_queues_index_to_C (tcbDomain tcb) (tcbPriority tcb)]) = NULL")
              prefer 2
              apply (frule_tac s=\<sigma> in tcb_queue'_head_end_NULL[symmetric]; simp add: valid_queues_valid_q)
+            apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                      unat_trans_ucast_helper\<close>)
+            apply (frule maxDomain_le_unat_ucast_explicit)
             apply (clarsimp simp: cready_queues_index_to_C_def numPriorities_def)
             apply (clarsimp simp: h_val_field_clift' h_t_valid_clift)
              apply (simp add: t_hrs_ksReadyQueues_upd_absorb)
@@ -1113,7 +1111,9 @@ proof -
                                   typ_heap_simps)[1]
                apply (fastforce simp: tcb_null_sched_ptrs_def typ_heap_simps c_guard_clift
                                 elim: obj_at'_weaken)+
-
+           apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                     unat_trans_ucast_helper\<close>)
+           apply clarsimp
            apply (rule conjI; clarsimp simp: queue_in_range)
             (* invalid, disagreement between C and Haskell on emptiness of queue *)
             apply (drule (1) obj_at_cslift_tcb)
@@ -1289,9 +1289,10 @@ lemma cbitmap_L1_relation_bit_clear:
            (Arrays.update (ksReadyQueuesL1Bitmap_' (globals x)) (unat d)
              (ksReadyQueuesL1Bitmap_' (globals x).[unat d] && ~~ 2 ^ unat (p >> wordRadix)))
            ((ksReadyQueuesL1Bitmap \<sigma>)(d := ksReadyQueuesL1Bitmap \<sigma> d && ~~ 2 ^ prioToL1Index p))"
-  apply (unfold cbitmap_L1_relation_def)
-  apply (clarsimp simp: prioToL1Index_def wordRadix_def' maxDomain_def numDomains_def word_le_nat_alt)
-  done
+  unfolding cbitmap_L1_relation_def numPriorities_def wordBits_def word_size l2BitmapSize_def'
+  by (clarsimp simp: word_size prioToL1Index_def wordRadix_def mask_def
+                     invertL1Index_def l2BitmapSize_def'
+                     le_maxDomain_eq_less_numDomains word_le_nat_alt num_domains_index_updates)
 
 lemma cready_queues_relation_empty_queue_helper:
   "\<lbrakk> tcbDomain ko \<le> maxDomain ; tcbPriority ko \<le> maxPriority ;
@@ -1339,8 +1340,8 @@ lemma cbitmap_L2_relation_bit_clear:
   unfolding cbitmap_L2_relation_def numPriorities_def wordBits_def word_size l2BitmapSize_def'
   apply (clarsimp simp: word_size prioToL1Index_def wordRadix_def mask_def
                         invertL1Index_def l2BitmapSize_def'
-                        maxDomain_def numDomains_def word_le_nat_alt)
-  apply (case_tac "da = d" ; clarsimp)
+                        le_maxDomain_eq_less_numDomains word_le_nat_alt)
+  apply (case_tac "da = d" ; clarsimp simp: num_domains_index_updates)
   done
 
 lemma tcbSchedDequeue_ccorres':
@@ -1355,6 +1356,10 @@ lemma tcbSchedDequeue_ccorres':
 proof -
 
   note prio_and_dom_limit_helpers[simp] word_sle_def[simp]
+
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  include no_less_1_simps
 
   have ksQ_tcb_at': "\<And>s ko d p.
     \<forall>d p. (\<forall>t\<in>set (ksReadyQueues s (d, p)). obj_at' (inQ d p) t s)
@@ -1433,6 +1438,9 @@ proof -
              apply (frule_tac s=\<sigma> in tcb_queue_relation_prev_next'; (fastforce simp: ksQ_tcb_at')?)
              apply (drule_tac s=\<sigma> in tcbSchedDequeue_update, assumption,
                      simp_all add: remove1_filter ksQ_tcb_at')[1]
+             apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                       unat_trans_ucast_helper\<close>)
+             apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
              apply (intro conjI ;
                      clarsimp simp: h_val_field_clift'
                                     h_t_valid_clift[THEN h_t_valid_field] h_t_valid_clift)+
@@ -1447,11 +1455,12 @@ proof -
                 apply (frule rf_sr_cbitmap_L2_relation)
                 apply (clarsimp simp: cbitmap_L2_relation_def
                                       word_size prioToL1Index_def wordRadix_def mask_def
-                                      maxDomain_def numDomains_def word_le_nat_alt
+                                      word_le_nat_alt
                                       numPriorities_def wordBits_def l2BitmapSize_def'
-                                      invertL1Index_def)
-                apply (case_tac "d = tcbDomain ko" ; fastforce)
-
+                                      invertL1Index_def numDomains_less_numeric_explicit)
+                apply (case_tac "d = tcbDomain ko"
+                       ; fastforce simp: le_maxDomain_eq_less_numDomains
+                                         numDomains_less_numeric_explicit)
                apply (drule (1) obj_at_cslift_tcb, clarsimp simp: inQ_def)
                apply (frule_tac d="tcbDomain ko" and p="tcbPriority ko"
                         in rf_sr_sched_queue_relation)
@@ -1471,8 +1480,8 @@ proof -
                apply (erule (2) cready_queues_relation_empty_queue_helper)
               (* impossible case, C L2 update disagrees with Haskell update *)
               apply (simp add: invert_prioToL1Index_c_simp)
-              apply (subst (asm) Arrays.index_update)
-               subgoal by (simp add: maxDomain_def numDomains_def word_le_nat_alt)
+              apply (subst (asm) num_domains_index_updates)
+               subgoal by (simp add: le_maxDomain_eq_less_numDomains word_le_nat_alt)
               apply (subst (asm) Arrays.index_update)
                apply (simp add: invert_l1_index_limit)
 
@@ -1501,6 +1510,9 @@ proof -
             apply (drule_tac s=\<sigma> in tcbSchedDequeue_update, assumption,
                    simp_all add: remove1_filter ksQ_tcb_at')[1]
             apply (clarsimp simp:  filter_noteq_op upd_unless_null_def)
+            apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                      unat_trans_ucast_helper\<close>)
+            apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
             apply (rule conjI, clarsimp)
              apply (clarsimp simp: h_val_field_clift'
                                    h_t_valid_clift[THEN h_t_valid_field] h_t_valid_clift)
@@ -1567,6 +1579,9 @@ proof -
             apply (drule_tac s=\<sigma> in tcbSchedDequeue_update, assumption,
                    simp_all add: remove1_filter ksQ_tcb_at')[1]
             apply (clarsimp simp:  filter_noteq_op upd_unless_null_def)
+            apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                      unat_trans_ucast_helper\<close>)
+            apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
             apply (rule conjI; clarsimp)
              apply (clarsimp simp: h_val_field_clift'
                                    h_t_valid_clift[THEN h_t_valid_field] h_t_valid_clift)
@@ -1577,8 +1592,8 @@ proof -
              apply (fastforce simp: c_invert_assist l2BitmapSize_def' wordRadix_def)
             apply (rule conjI; clarsimp)
              (* impossible case, C L2 update disagrees with Haskell update *)
-             apply (subst (asm) Arrays.index_update)
-              apply (simp add: maxDomain_def numDomains_def word_le_nat_alt)
+             apply (subst (asm) num_domains_index_updates)
+              apply (simp add: le_maxDomain_eq_less_numDomains word_le_nat_alt)
              apply (subst (asm) Arrays.index_update)
               subgoal using invert_l1_index_limit
                 by (fastforce simp add: invert_prioToL1Index_c_simp intro: nat_Suc_less_le_imp)
@@ -1612,6 +1627,9 @@ proof -
            apply (drule_tac s=\<sigma> in tcbSchedDequeue_update, assumption,
                   simp_all add: remove1_filter ksQ_tcb_at')[1]
            apply (clarsimp simp: filter_noteq_op upd_unless_null_def)
+           apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                     unat_trans_ucast_helper\<close>)
+           apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
            apply (rule conjI, clarsimp)
             apply (clarsimp simp: h_val_field_clift'
                                   h_t_valid_clift[THEN h_t_valid_field] h_t_valid_clift)
@@ -1755,6 +1773,10 @@ lemma tcbSchedAppend_ccorres:
 proof -
   note prio_and_dom_limit_helpers[simp] word_sle_def[simp] maxDom_to_H[simp] maxPrio_to_H[simp]
 
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  include no_less_1_simps
+
   show ?thesis
   apply (cinit lift: tcb_')
    apply (rule_tac r'="\<lambda>rv rv'. rv = to_bool rv'"
@@ -1824,6 +1846,9 @@ proof -
              apply (rule tcb_at_not_NULL, erule obj_at'_weakenE, simp)
             apply (clarsimp simp: h_val_field_clift' h_t_valid_clift)
             apply (simp add: invert_prioToL1Index_c_simp)
+            apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                      unat_trans_ucast_helper\<close>)
+            apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
             apply (rule conjI; clarsimp)
              apply (rule conjI)
               apply (fastforce simp: c_invert_assist l2BitmapSize_def' wordRadix_def)
@@ -1840,6 +1865,9 @@ proof -
               apply (fastforce simp: typ_heap_simps c_guard_clift)
              apply (fastforce simp: tcb_null_sched_ptrs_def elim: obj_at'_weaken)
             apply (clarsimp simp: upd_unless_null_def cready_queues_index_to_C_def numPriorities_def)
+           apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                     unat_trans_ucast_helper\<close>)
+           apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
            apply (rule conjI; clarsimp simp: queue_in_range)
             apply (drule (1) obj_at_cslift_tcb)
             apply clarsimp
@@ -2188,6 +2216,10 @@ proof -
     apply (simp add: unat_of_nat_eq)
     done
 
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  include no_less_1_simps
+
   show ?thesis
   including no_take_bit
   apply (cinit lift: dom_')
@@ -2225,7 +2257,7 @@ proof -
     prefer 2
     subgoal by (fastforce simp: cbitmap_L1_relation_def)
 
-   apply (clarsimp simp: signed_word_log2 cbitmap_L1_relation_def)
+   apply (clarsimp simp: signed_word_log2 cbitmap_L1_relation_def maxDomain_le_unat_ucast_explicit)
    apply (frule bitmapQ_no_L1_orphansD, erule word_log2_nth_same)
    apply (rule conjI, fastforce simp: invertL1Index_def l2BitmapSize_def')
    apply (rule conjI, fastforce)
@@ -2277,6 +2309,17 @@ lemma getCurDomain_ccorres_dom_':
        \<top> UNIV hs curDomain (\<acute>dom :== \<acute>ksCurDomain)"
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
+  apply (clarsimp simp: curDomain_def simpler_gets_def
+                        rf_sr_ksCurDomain)
+  done
+
+lemma getCurDomain_maxDom_ccorres_dom_':
+  "ccorres (\<lambda>rv rv'. rv' = ucast rv) dom_'
+     (\<lambda>s. ksCurDomain s \<le> maxDomain) UNIV hs
+     curDomain (\<acute>dom :== (if maxDom \<noteq> 0 then \<acute>ksCurDomain else 0))"
+  apply (rule ccorres_from_vcg)
+  apply (rule allI, rule conseqPre, vcg)
+  using maxDom_to_H
   apply (clarsimp simp: curDomain_def simpler_gets_def
                         rf_sr_ksCurDomain)
   done

--- a/proof/crefine/ARM_HYP/SR_lemmas_C.thy
+++ b/proof/crefine/ARM_HYP/SR_lemmas_C.thy
@@ -2489,5 +2489,16 @@ lemma unat_scast_seL4_VCPUReg_ACTLR_simp[simp]:
   including no_take_bit
   by (simp add: vcpureg_eq_use_types[where reg=VCPURegACTLR, simplified, symmetric])
 
+lemma numDomains_sge_1_simp:
+  "1 <s Kernel_C.numDomains \<longleftrightarrow> Suc 0 < Kernel_Config.numDomains"
+  apply (simp add: word_sless_alt sint_numDomains_to_H)
+  apply (subst nat_less_as_int, simp)
+  done
+
+lemma unat_scast_numDomains:
+  "unat (SCAST(32 signed \<rightarrow> machine_word_len) Kernel_C.numDomains) = unat Kernel_C.numDomains"
+  including no_take_bit
+  by (simp add: scast_eq sint_numDomains_to_H unat_numDomains_to_H numDomains_machine_word_safe)
+
 end
 end

--- a/proof/crefine/ARM_HYP/Schedule_C.thy
+++ b/proof/crefine/ARM_HYP/Schedule_C.thy
@@ -215,15 +215,6 @@ lemma ceqv_remove_tail_Guard_Skip:
 lemmas ccorres_remove_tail_Guard_Skip
     = ccorres_abstract[where xf'="\<lambda>_. ()", OF ceqv_remove_tail_Guard_Skip]
 
-lemma queue_in_range_pre:
-  "\<lbrakk> (qdom :: word32) \<le> ucast maxDom; prio \<le> ucast maxPrio \<rbrakk>
-    \<Longrightarrow> qdom * of_nat numPriorities + prio < of_nat (numDomains * numPriorities)"
-  by (clarsimp simp: cready_queues_index_to_C_def word_less_nat_alt
-                     word_le_nat_alt unat_ucast maxDom_def seL4_MaxPrio_def
-                     numPriorities_def unat_word_ariths numDomains_def)
-
-lemmas queue_in_range' = queue_in_range_pre[unfolded numDomains_def numPriorities_def, simplified]
-
 lemma switchToThread_ccorres':
   "ccorres (\<lambda>_ _. True) xfdc
            (all_invs_but_ct_idle_or_in_cur_domain' and tcb_at' t)
@@ -243,73 +234,98 @@ proof -
   note prio_and_dom_limit_helpers [simp]
   note ksReadyQueuesL2Bitmap_nonzeroI [simp]
   note Collect_const_mem [simp]
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  include no_less_1_simps
 
   have invs_no_cicd'_max_CurDomain[intro]:
     "\<And>s. invs_no_cicd' s \<Longrightarrow> ksCurDomain s \<le> maxDomain"
     by (simp add: invs_no_cicd'_def)
 
   show ?thesis
-  apply (cinit)
-   apply (simp add: numDomains_def word_sless_alt word_sle_def)
-   apply (ctac (no_vcg) add: getCurDomain_ccorres_dom_')
-     apply clarsimp
-     apply (rename_tac curdom)
-     apply (rule_tac P="curdom \<le> maxDomain" in ccorres_cross_over_guard_no_st)
-     apply (rule ccorres_Guard)
-     apply (rule ccorres_pre_getReadyQueuesL1Bitmap)
-     apply (rename_tac l1)
-     apply (rule_tac R="\<lambda>s. l1 = ksReadyQueuesL1Bitmap s curdom \<and> curdom \<le> maxDomain"
-              in ccorres_cond)
-       subgoal by (fastforce dest!: rf_sr_cbitmap_L1_relation simp: cbitmap_L1_relation_def)
-      prefer 2 \<comment> \<open>switchToIdleThread\<close>
-      apply (ctac(no_vcg) add: switchToIdleThread_ccorres)
-     apply clarsimp
-     apply (rule ccorres_rhs_assoc)+
-
-     apply (rule ccorres_split_nothrow_novcg)
-         apply (rule_tac xf'=prio_' in ccorres_call)
-            apply (rule getHighestPrio_ccorres[simplified getHighestPrio_def'])
-           apply simp+
+    supply if_split[split del]
+    apply (cinit)
+     apply (simp add: numDomains_sge_1_simp)
+     apply (rule_tac xf'=dom_' and r'="\<lambda>rv rv'. rv' = ucast rv" in ccorres_split_nothrow_novcg)
+         apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
+         apply clarsimp
+         apply (rule conseqPre, vcg)
+         apply (rule Collect_mono)
+         apply (clarsimp split: prod.split)
+         apply (clarsimp simp: curDomain_def simpler_gets_def return_def rf_sr_ksCurDomain)
         apply ceqv
        apply clarsimp
-       apply (rename_tac prio)
+       apply (rename_tac curdom)
        apply (rule_tac P="curdom \<le> maxDomain" in ccorres_cross_over_guard_no_st)
-       apply (rule_tac P="prio \<le> maxPriority" in ccorres_cross_over_guard_no_st)
-       apply (rule ccorres_pre_getQueue)
-       apply (rule_tac P="queue \<noteq> []" in ccorres_cross_over_guard_no_st)
-       apply (rule ccorres_symb_exec_l)
-          apply (rule ccorres_assert)
-          apply csymbr
-          apply (rule ccorres_Guard_Seq)+
-          apply (rule ccorres_symb_exec_r)
-            apply (simp only: ccorres_seq_skip)
-            apply (rule ccorres_call[OF switchToThread_ccorres']; simp)
-           apply vcg
-          apply (rule conseqPre, vcg)
-          apply clarsimp
-         apply (wp isRunnable_wp)+
-       apply (simp add: isRunnable_def)
-      apply wp
-     apply (clarsimp simp: Let_def guard_is_UNIV_def)
-     apply (drule invs_no_cicd'_queues)
-     apply (case_tac queue, simp)
-     apply (clarsimp simp: tcb_queue_relation'_def cready_queues_index_to_C_def
-                            numPriorities_def )
-     apply (simp add: word_less_nat_alt word_le_nat_alt)
-     apply (rule_tac x="unat curdom * 256" and xmax="unat maxDomain * 256" in nat_add_less_by_max)
-      subgoal by (simp add: word_le_nat_alt[symmetric])
-     subgoal by (simp add: maxDomain_def numDomains_def maxPriority_def numPriorities_def)
-    apply wp
-   apply clarsimp
-  apply (frule invs_no_cicd'_queues)
-  apply (frule invs_no_cicd'_max_CurDomain)
-  apply (frule invs_no_cicd'_queues)
-  apply (clarsimp simp: valid_queues_def lookupBitmapPriority_le_maxPriority)
-  apply (intro conjI impI)
-      apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
-     apply (fastforce dest: lookupBitmapPriority_obj_at'
-                      simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
-  done
+       apply (rule ccorres_Guard)
+       apply (rule ccorres_pre_getReadyQueuesL1Bitmap)
+       apply (rename_tac l1)
+       apply (rule_tac R="\<lambda>s. l1 = ksReadyQueuesL1Bitmap s curdom \<and> curdom \<le> maxDomain"
+                in ccorres_cond)
+         subgoal by (fastforce dest!: rf_sr_cbitmap_L1_relation simp: cbitmap_L1_relation_def)
+        prefer 2 \<comment> \<open>switchToIdleThread\<close>
+        apply (ctac(no_vcg) add: switchToIdleThread_ccorres)
+       apply clarsimp
+       apply (rule ccorres_rhs_assoc)+
+       apply (rule ccorres_split_nothrow_novcg)
+           apply (rule_tac xf'=prio_' in ccorres_call)
+              apply (rule getHighestPrio_ccorres[simplified getHighestPrio_def'])
+             apply simp+
+          apply ceqv
+         apply clarsimp
+         apply (rename_tac prio)
+         apply (rule_tac P="curdom \<le> maxDomain" in ccorres_cross_over_guard_no_st)
+         apply (rule_tac P="prio \<le> maxPriority" in ccorres_cross_over_guard_no_st)
+         apply (rule ccorres_pre_getQueue)
+         apply (rule_tac P="queue \<noteq> []" in ccorres_cross_over_guard_no_st)
+         apply (rule ccorres_symb_exec_l)
+            apply (rule ccorres_assert)
+            apply (rule ccorres_symb_exec_r)
+              apply (rule ccorres_Guard_Seq)+
+              apply (rule ccorres_symb_exec_r)
+                apply (simp only: ccorres_seq_skip)
+                apply (rule ccorres_call[OF switchToThread_ccorres']; simp)
+               apply vcg
+              apply (rule conseqPre, vcg)
+              apply clarsimp
+             apply clarsimp
+             apply (rule conseqPre, vcg)
+             apply (rule Collect_mono)
+             apply clarsimp
+             apply (strengthen queue_in_range)
+             apply assumption
+            apply clarsimp
+            apply (rule conseqPre, vcg)
+            apply clarsimp
+           apply (wp isRunnable_wp)+
+         apply (simp add: isRunnable_def)
+        apply wp
+       apply (clarsimp simp: Let_def guard_is_UNIV_def)
+       apply (drule invs_no_cicd'_queues)
+       apply (case_tac queue, simp)
+       apply (clarsimp simp: tcb_queue_relation'_def cready_queues_index_to_C_def numPriorities_def)
+       apply (clarsimp simp add: maxDom_to_H maxPrio_to_H
+                                 queue_in_range[where qdom=0, simplified, simplified maxPrio_to_H])
+       apply (clarsimp simp: le_maxDomain_eq_less_numDomains unat_trans_ucast_helper )
+      apply wpsimp
+     apply (clarsimp simp: guard_is_UNIV_def le_maxDomain_eq_less_numDomains word_less_nat_alt
+                           numDomains_less_numeric_explicit)
+    apply (frule invs_no_cicd'_queues)
+    apply (frule invs_no_cicd'_max_CurDomain)
+    apply (frule invs_no_cicd'_queues)
+    apply (clarsimp simp: valid_queues_def lookupBitmapPriority_le_maxPriority)
+    apply (intro conjI impI)
+       apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
+      apply (fastforce dest: lookupBitmapPriority_obj_at'
+                       simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+     apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
+    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    apply (clarsimp simp: not_less le_maxDomain_eq_less_numDomains)
+    apply (prop_tac "ksCurDomain s = 0")
+     using unsigned_eq_0_iff apply force
+    apply (cut_tac s=s in lookupBitmapPriority_obj_at'; simp?)
+    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    done
 qed
 
 lemma ksDomSched_length_relation[simp]:
@@ -395,6 +411,9 @@ lemma isHighestPrio_ccorres:
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
   supply from_bool_eq_if[simp] from_bool_eq_if'[simp] from_bool_0[simp]
           ccorres_IF_True[simp] if_cong[cong]
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  including no_less_1_simps
   apply (cinit lift: dom_' prio_')
    apply clarsimp
    apply (rule ccorres_move_const_guard)
@@ -420,7 +439,8 @@ lemma isHighestPrio_ccorres:
       apply (rule ccorres_return_C, simp, simp, simp)
      apply (rule wp_post_taut)
     apply (vcg exspec=getHighestPrio_modifies)+
-  apply (clarsimp simp: word_le_nat_alt true_def to_bool_def split: if_splits)
+  apply (clarsimp simp: word_le_nat_alt true_def to_bool_def maxDomain_le_unat_ucast_explicit
+                  split: if_splits)
   done
 
 lemma schedule_ccorres:
@@ -612,7 +632,7 @@ lemma schedule_ccorres:
                      apply (wpsimp simp: cscheduler_action_relation_def)+
                    apply (vcg exspec=scheduleChooseNewThread_modifies)
                   apply (wp add: setSchedulerAction_invs' setSchedulerAction_direct del: ssa_wp)
-                 apply (clarsimp | vcg exspec=tcbSchedEnqueue_modifies | wp wp_post_taut)+
+                 apply (clarsimp | vcg exspec=tcbSchedAppend_modifies | wp wp_post_taut)+
               (* candidate is best, switch to it *)
               apply (ctac add: switchToThread_ccorres)
                 apply clarsimp
@@ -758,7 +778,9 @@ lemma timerTick_ccorres:
              apply (vcg exspec=tcbSchedDequeue_modifies)
         apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip[unfolded dc_def])+
         apply ceqv
-       apply (simp add: when_def numDomains_def decDomainTime_def)
+       apply (clarsimp simp: decDomainTime_def numDomains_sge_1_simp)
+       apply (rule ccorres_when[where R=\<top>])
+        apply (solves \<open>clarsimp split: if_split\<close>)
        apply (rule ccorres_split_nothrow_novcg)
            apply (rule_tac rrel=dc and xf=xfdc and P=\<top> and P'=UNIV in ccorres_from_vcg)
            apply (rule allI, rule conseqPre, vcg)
@@ -766,6 +788,7 @@ lemma timerTick_ccorres:
            apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                  carch_state_relation_def cmachine_state_relation_def)
           apply ceqv
+         apply (fold dc_def)
          apply (rule ccorres_pre_getDomainTime)
          apply (rename_tac rva rv'a rvb)
          apply (rule_tac P'="{s. ksDomainTime_' (globals s) = rvb}" in ccorres_inst, simp)

--- a/proof/crefine/ARM_HYP/StateRelation_C.thy
+++ b/proof/crefine/ARM_HYP/StateRelation_C.thy
@@ -600,8 +600,8 @@ definition
 where
   "cready_queues_index_to_C qdom prio \<equiv> (unat qdom) * numPriorities + (unat prio)"
 
-definition
-  cready_queues_relation :: "tcb_C typ_heap \<Rightarrow> (tcb_queue_C[4096]) \<Rightarrow> (domain \<times> priority \<Rightarrow> ready_queue) \<Rightarrow> bool"
+definition cready_queues_relation ::
+  "tcb_C typ_heap \<Rightarrow> (tcb_queue_C[num_tcb_queues]) \<Rightarrow> (domain \<times> priority \<Rightarrow> ready_queue) \<Rightarrow> bool"
 where
   "cready_queues_relation h_tcb queues aqueues \<equiv>
      \<forall>qdom prio. ((qdom \<ge> ucast minDom \<and> qdom \<le> ucast maxDom \<and>

--- a/proof/crefine/Move_C.thy
+++ b/proof/crefine/Move_C.thy
@@ -961,11 +961,6 @@ lemma threadGet_wp'':
   apply (clarsimp simp: obj_at'_def)
   done
 
-lemma dom_less_0x10_helper:
-  "d \<le> maxDomain \<Longrightarrow> (ucast d :: machine_word) < 0x10"
-  unfolding maxDomain_def numDomains_def
-  by (clarsimp simp add: word_less_nat_alt unat_ucast_upcast is_up word_le_nat_alt)
-
 lemma filter_empty_unfiltered_contr:
   "\<lbrakk> [x\<leftarrow>xs . x \<noteq> y] = [] ; x' \<in> set xs ; x' \<noteq> y \<rbrakk> \<Longrightarrow> False"
   by (induct xs, auto split: if_split_asm)
@@ -1357,5 +1352,27 @@ lemma word_ctz_0[simp]:
   "word_ctz (0::32 word) = 32"
   "word_ctz (0::64 word) = 64"
   by (clarsimp simp: word_ctz_def to_bl_def)+
+
+(* FIXME move to Word_Lib *)
+lemma unat_trans_ucast_helper:
+  "\<lbrakk> unat x < n ; n \<le> Suc 0 \<rbrakk> \<Longrightarrow> ucast x = 0"
+  by (simp add: le_Suc_eq unsigned_eq_0_iff)
+
+lemma numPriorities_machine_word_safe:
+  "unat (of_nat numPriorities :: machine_word) = numPriorities"
+  by (simp add: numPriorities_def)
+
+(* needed consequence of word_less_1 when word_less_1 isn't safe, e.g. when
+   using no_less_1_simps; otherwise you'll be able to prove that 0 < 300, but
+   not that 0 < 1 *)
+lemma word_zero_less_one[simp]:
+  "0 < (1::'a::len word)"
+  by (simp add: word_less_1)
+
+bundle no_less_1_simps
+begin
+  declare word_less_1[simp del]
+  declare less_Suc0[iff del]
+end
 
 end

--- a/proof/crefine/RISCV64/ADT_C.thy
+++ b/proof/crefine/RISCV64/ADT_C.thy
@@ -592,7 +592,7 @@ lemma tcb_queue_rel'_unique:
 
 definition
   cready_queues_to_H
-  :: "(tcb_C ptr \<rightharpoonup> tcb_C) \<Rightarrow> (tcb_queue_C[4096]) \<Rightarrow> word8 \<times> word8 \<Rightarrow> machine_word list"
+  :: "(tcb_C ptr \<rightharpoonup> tcb_C) \<Rightarrow> (tcb_queue_C[num_tcb_queues]) \<Rightarrow> word8 \<times> word8 \<Rightarrow> machine_word list"
   where
   "cready_queues_to_H h_tcb cs \<equiv> \<lambda>(qdom, prio). if ucast minDom \<le> qdom \<and> qdom \<le> ucast maxDom
               \<and> ucast seL4_MinPrio \<le> prio \<and> prio \<le> ucast seL4_MaxPrio
@@ -1217,12 +1217,12 @@ lemma cDomSchedule_to_H_correct:
   done
 
 definition
-  cbitmap_L1_to_H :: "machine_word[16] \<Rightarrow> (8 word \<Rightarrow> machine_word)"
+  cbitmap_L1_to_H :: "machine_word[num_domains] \<Rightarrow> (8 word \<Rightarrow> machine_word)"
 where
   "cbitmap_L1_to_H l1 \<equiv> \<lambda>d. if d \<le> maxDomain then l1.[unat d] else 0"
 
 definition
-  cbitmap_L2_to_H :: "machine_word[4][16] \<Rightarrow> (8 word \<times> nat \<Rightarrow> machine_word)"
+  cbitmap_L2_to_H :: "machine_word[4][num_domains] \<Rightarrow> (8 word \<times> nat \<Rightarrow> machine_word)"
 where
   "cbitmap_L2_to_H l2 \<equiv> \<lambda>(d, i).
     if d \<le> maxDomain \<and> i < l2BitmapSize

--- a/proof/crefine/RISCV64/Finalise_C.thy
+++ b/proof/crefine/RISCV64/Finalise_C.thy
@@ -41,9 +41,9 @@ definition
 
 lemma tcbSchedEnqueue_cslift_spec:
   "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> \<lbrace>s. \<exists>d v. option_map2 tcbPriority_C (cslift s) \<acute>tcb = Some v
-                       \<and> v \<le> ucast maxPrio
+                       \<and> unat v \<le> numPriorities
                        \<and> option_map2 tcbDomain_C (cslift s) \<acute>tcb = Some d
-                       \<and> d \<le> ucast maxDom
+                       \<and> unat d < Kernel_Config.numDomains
                        \<and> (end_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))) \<noteq> NULL
                            \<longrightarrow> option_map2 tcbPriority_C (cslift s)
                                    (head_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))))
@@ -61,6 +61,10 @@ lemma tcbSchedEnqueue_cslift_spec:
   apply (clarsimp simp: option_map2_def fun_eq_iff h_t_valid_clift
                         h_t_valid_field[OF h_t_valid_clift])
   apply (rule conjI)
+   apply (clarsimp simp: typ_heap_simps le_maxDomain_eq_less_numDomains)
+   apply unat_arith
+  apply clarsimp
+  apply (rule conjI)
    apply (clarsimp simp: typ_heap_simps cong: if_cong)
    apply (simp split: if_split)
   apply (clarsimp simp: typ_heap_simps if_Some_helper cong: if_cong)
@@ -70,9 +74,9 @@ lemma setThreadState_cslift_spec:
   "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> \<lbrace>s. s \<Turnstile>\<^sub>c \<acute>tptr \<and> (\<forall>x. ksSchedulerAction_' (globals s) = tcb_Ptr x
                  \<and> x \<noteq> 0 \<and> x \<noteq> 1
               \<longrightarrow> (\<exists>d v. option_map2 tcbPriority_C (cslift s) (tcb_Ptr x) = Some v
-                       \<and> v \<le> ucast maxPrio
+                       \<and> unat v \<le> numPriorities
                        \<and> option_map2 tcbDomain_C (cslift s) (tcb_Ptr x) = Some d
-                       \<and> d \<le> ucast maxDom
+                       \<and> unat d < Kernel_Config.numDomains
                        \<and> (end_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))) \<noteq> NULL
                            \<longrightarrow> option_map2 tcbPriority_C (cslift s)
                                    (head_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))))
@@ -145,32 +149,27 @@ lemma ctcb_relation_tcbPriority:
   "ctcb_relation tcb tcb' \<Longrightarrow> ucast (tcbPriority tcb) = tcbPriority_C tcb'"
   by (simp add: ctcb_relation_def)
 
-lemma ctcb_relation_tcbDomain_maxDom:
-  "\<lbrakk> ctcb_relation tcb tcb'; tcbDomain tcb \<le> maxDomain \<rbrakk> \<Longrightarrow> tcbDomain_C tcb' \<le> ucast maxDom"
+lemma ctcb_relation_tcbDomain_maxDomain_numDomains:
+  "\<lbrakk> ctcb_relation tcb tcb'; tcbDomain tcb \<le> maxDomain \<rbrakk>
+   \<Longrightarrow> unat (tcbDomain_C tcb') < Kernel_Config.numDomains"
   apply (subst ctcb_relation_tcbDomain[symmetric], simp)
-  apply (subst ucast_le_migrate)
-    apply ((simp add:maxDom_def word_size)+)[2]
-  apply (simp add: ucast_up_ucast is_up_def source_size_def word_size target_size_def)
-  apply (simp add: maxDom_to_H)
+  apply (simp add: le_maxDomain_eq_less_numDomains)
   done
 
-lemma ctcb_relation_tcbPriority_maxPrio:
+lemma ctcb_relation_tcbPriority_maxPriority_numPriorities:
   "\<lbrakk> ctcb_relation tcb tcb'; tcbPriority tcb \<le> maxPriority \<rbrakk>
-    \<Longrightarrow> tcbPriority_C tcb' \<le> ucast maxPrio"
+    \<Longrightarrow> unat (tcbPriority_C tcb') < numPriorities"
   apply (subst ctcb_relation_tcbPriority[symmetric], simp)
-  apply (subst ucast_le_migrate)
-    apply ((simp add: seL4_MaxPrio_def word_size)+)[2]
-  apply (simp add: ucast_up_ucast is_up_def source_size_def word_size target_size_def)
-  apply (simp add: maxPrio_to_H)
+  apply (simp add: maxPriority_def numPriorities_def word_le_nat_alt)
   done
 
 lemma tcbSchedEnqueue_cslift_precond_discharge:
   "\<lbrakk> (s, s') \<in> rf_sr; obj_at' (P :: tcb \<Rightarrow> bool) x s;
         valid_queues s; valid_objs' s \<rbrakk> \<Longrightarrow>
    (\<exists>d v. option_map2 tcbPriority_C (cslift s') (tcb_ptr_to_ctcb_ptr x) = Some v
-        \<and> v \<le> ucast maxPrio
+        \<and> unat v < numPriorities
         \<and> option_map2 tcbDomain_C (cslift s') (tcb_ptr_to_ctcb_ptr x) = Some d
-        \<and> d \<le> ucast maxDom
+        \<and> unat d < Kernel_Config.numDomains
         \<and> (end_C (index (ksReadyQueues_' (globals s')) (unat (d*0x100 + v))) \<noteq> NULL
                 \<longrightarrow> option_map2 tcbPriority_C (cslift s')
                      (head_C (index (ksReadyQueues_' (globals s')) (unat (d*0x100 + v))))
@@ -184,12 +183,12 @@ lemma tcbSchedEnqueue_cslift_precond_discharge:
   apply (frule_tac t=x in valid_objs'_maxDomain, fastforce simp: obj_at'_def)
   apply (drule_tac P="\<lambda>tcb. tcbPriority tcb \<le> maxPriority" in obj_at_ko_at2', simp)
   apply (drule_tac P="\<lambda>tcb. tcbDomain tcb \<le> maxDomain" in obj_at_ko_at2', simp)
-
-  apply (simp add: ctcb_relation_tcbDomain_maxDom ctcb_relation_tcbPriority_maxPrio)
+  apply (simp add: ctcb_relation_tcbDomain_maxDomain_numDomains
+                   ctcb_relation_tcbPriority_maxPriority_numPriorities)
   apply (frule_tac d="tcbDomain ko" and p="tcbPriority ko"
               in rf_sr_sched_queue_relation)
     apply (simp add: maxDom_to_H maxPrio_to_H)+
-  apply (simp add: cready_queues_index_to_C_def2 numPriorities_def)
+  apply (simp add: cready_queues_index_to_C_def2 numPriorities_def le_maxDomain_eq_less_numDomains)
   apply (clarsimp simp: ctcb_relation_def)
   apply (frule arg_cong[where f=unat], subst(asm) unat_ucast_up_simp, simp)
   apply (frule tcb_queue'_head_end_NULL)

--- a/proof/crefine/RISCV64/Invoke_C.thy
+++ b/proof/crefine/RISCV64/Invoke_C.thy
@@ -134,14 +134,15 @@ lemma decodeDomainInvocation_ccorres:
    apply (rule ccorres_add_return)
    apply (rule ccorres_rhs_assoc)+
    apply (ctac add: getSyscallArg_ccorres_foo[where args=args and n=0 and buffer=buffer])
-     apply (simp add: numDomains_def hd_conv_nth word_le_nat_alt)
+     apply (simp add: hd_conv_nth word_le_nat_alt)
+     apply (simp add: unat_scast_numDomains)
      apply (rule ccorres_Cond_rhs_Seq)
-      apply (simp add: throwError_bind invocationCatch_def numDomains_def
-                       hd_conv_nth word_le_nat_alt
+      apply (simp add: throwError_bind invocationCatch_def
+                       hd_conv_nth word_le_nat_alt unat_numDomains_to_H
                  cong: StateSpace.state.fold_congs globals.fold_congs)
       apply (rule syscall_error_throwError_ccorres_n)
       apply (simp add: syscall_error_to_H_cases)
-     apply (simp add: null_def excaps_map_def)
+     apply (simp add: null_def excaps_map_def unat_numDomains_to_H)
      apply (rule ccorres_Cond_rhs_Seq)
       apply (simp add: throwError_bind invocationCatch_def
                        interpret_excaps_test_null
@@ -191,11 +192,11 @@ lemma decodeDomainInvocation_ccorres:
    apply clarsimp
    apply (vcg exspec=getSyscallArg_modifies)
 
+  including no_take_bit
   apply (clarsimp simp: valid_tcb_state'_def invs_valid_queues' invs_valid_objs'
                         invs_queues invs_sch_act_wf' ct_in_state'_def pred_tcb_at'
                         rf_sr_ksCurThread word_sle_def word_sless_def sysargs_rel_to_n
-                        mask_eq_iff_w2p mask_eq_iff_w2p word_size "StrictC'_thread_state_defs"
-                        maxDomain_def numDomains_def)
+                        mask_eq_iff_w2p mask_eq_iff_w2p word_size "StrictC'_thread_state_defs")
   apply (rule conjI)
    apply (clarsimp simp: linorder_not_le isCap_simps)
    apply (rule conjI, clarsimp simp: unat64_eq_of_nat)
@@ -205,9 +206,11 @@ lemma decodeDomainInvocation_ccorres:
    apply (clarsimp simp: valid_cap_simps' pred_tcb'_weakenE active_runnable')
    apply (rule conjI)
     apply (fastforce simp: tcb_st_refs_of'_def elim:pred_tcb'_weakenE)
-   apply (simp add: word_le_nat_alt unat_ucast)
-  apply (clarsimp simp: ucast_ucast_len word_less_nat_alt
-                        ccap_relation_def cap_to_H_simps cap_thread_cap_lift)
+   apply (simp add: word_le_nat_alt unat_ucast unat_numDomains_to_H le_maxDomain_eq_less_numDomains)
+  apply (clarsimp simp: ccap_relation_def cap_to_H_simps cap_thread_cap_lift)
+  subgoal (* args ! 0 can be contained in a domain-sized word *)
+    by (clarsimp simp: not_le unat_numDomains_to_H ucast_ucast_len[simplified word_less_nat_alt]
+                 dest!: less_numDomains_is_domain)
   done
 
 (************************************************************************)

--- a/proof/crefine/RISCV64/SR_lemmas_C.thy
+++ b/proof/crefine/RISCV64/SR_lemmas_C.thy
@@ -2163,5 +2163,16 @@ lemmas h_t_valid_fields_clift =
   h_t_valid_nested_fields[OF h_t_valid_clift]
   h_t_valid_clift
 
+lemma numDomains_sge_1_simp:
+  "1 <s Kernel_C.numDomains \<longleftrightarrow> Suc 0 < Kernel_Config.numDomains"
+  apply (simp add: word_sless_alt sint_numDomains_to_H)
+  apply (subst nat_less_as_int, simp)
+  done
+
+lemma unat_scast_numDomains:
+  "unat (SCAST(32 signed \<rightarrow> machine_word_len) Kernel_C.numDomains) = unat Kernel_C.numDomains"
+  including no_take_bit
+  by (simp add: scast_eq sint_numDomains_to_H unat_numDomains_to_H numDomains_machine_word_safe)
+
 end
 end

--- a/proof/crefine/RISCV64/StateRelation_C.thy
+++ b/proof/crefine/RISCV64/StateRelation_C.thy
@@ -545,8 +545,8 @@ definition
 where
   "cready_queues_index_to_C qdom prio \<equiv> (unat qdom) * numPriorities + (unat prio)"
 
-definition
-  cready_queues_relation :: "tcb_C typ_heap \<Rightarrow> (tcb_queue_C[4096]) \<Rightarrow> (domain \<times> priority \<Rightarrow> ready_queue) \<Rightarrow> bool"
+definition cready_queues_relation ::
+  "tcb_C typ_heap \<Rightarrow> (tcb_queue_C[num_tcb_queues]) \<Rightarrow> (domain \<times> priority \<Rightarrow> ready_queue) \<Rightarrow> bool"
 where
   "cready_queues_relation h_tcb queues aqueues \<equiv>
      \<forall>qdom prio. ((qdom \<ge> ucast minDom \<and> qdom \<le> ucast maxDom \<and>

--- a/proof/crefine/RISCV64/Wellformed_C.thy
+++ b/proof/crefine/RISCV64/Wellformed_C.thy
@@ -430,13 +430,113 @@ lemma ptr_val_tcb_ptr_mask2:
   apply (simp add: is_aligned_add_helper ctcb_offset_defs objBits_simps')
   done
 
+section \<open>Domains\<close>
+
+text \<open>
+  seL4's build system allows configuration of the number of domains. This means the proofs have to
+  work for any number of domains provided it fits into the hard limit of a 8-bit word.
+
+  In the C code, we have the enumerated constant numDomains, one greater than maxDom. In the
+  abstract specs, we have the corresponding Platform_Config.numDomains and maxDomain.
+
+  To keep the proofs as general as possible, we avoid unfolding definitions of:
+  maxDom, maxDomain, numDomains except in this theory where we need to establish basic properties.
+
+  Unfortunately, array bounds checks coming from the C code use numerical values, meaning we might
+  get 0x10 instead of the number of domains, or 0x1000 for numDomains * numPriorities. To solve
+  these, the "explicit" lemmas expose direct numbers. They are more risky to deploy, as one could
+  prove that 0x5 is less than the number of domains when that's the case, and then the proof will
+  break upon reconfiguration.
+\<close>
+
+text \<open>The @{text num_domains} enumerated type and constant represent the number of domains.\<close>
+
+value_type num_domains = "numDomains"
+
+context includes no_less_1_simps begin
+
+(* The proofs expect the minimum priority and minimum domain to be zero.
+   Note that minDom is unused in the C code. *)
+lemma min_prio_dom_sanity:
+  "seL4_MinPrio = 0"
+  "Kernel_C.minDom = 0"
+  by (auto simp: seL4_MinPrio_def minDom_def)
+
+lemma less_numDomains_is_domain[simplified word_size, simplified]:
+  "x < numDomains \<Longrightarrow> x < 2 ^ size (y::domain)"
+  unfolding Kernel_Config.numDomains_def
+  by (simp add: word_size)
+
+lemma sint_numDomains_to_H:
+  "sint Kernel_C.numDomains = int Kernel_Config.numDomains"
+  by (clarsimp simp: Kernel_C.numDomains_def Kernel_Config.numDomains_def)
+
+lemma unat_numDomains_to_H:
+  "unat Kernel_C.numDomains = Kernel_Config.numDomains"
+  by (clarsimp simp: Kernel_C.numDomains_def Kernel_Config.numDomains_def)
+
 lemma maxDom_to_H:
   "ucast maxDom = maxDomain"
-  by (simp add: maxDomain_def maxDom_def numDomains_def)
+  by (simp add: maxDomain_def Kernel_C.maxDom_def Kernel_Config.numDomains_def)
+
+lemma maxDom_sgt_0_maxDomain:
+  "0 <s maxDom \<longleftrightarrow> 0 < maxDomain"
+  unfolding Kernel_C.maxDom_def maxDomain_def Kernel_Config.numDomains_def
+  by clarsimp
+
+lemma num_domains_calculation:
+  "num_domains = numDomains"
+  unfolding num_domains_def by eval
+
+private lemma num_domains_card_explicit:
+  "num_domains = CARD(num_domains)"
+  by (simp add: num_domains_def)
+
+lemmas num_domains_index_updates =
+  index_update[where 'b=num_domains, folded num_domains_card_explicit num_domains_def,
+               simplified num_domains_calculation]
+  index_update2[where 'b=num_domains, folded num_domains_card_explicit num_domains_def,
+                simplified num_domains_calculation]
+
+(* C ArrayGuards will throw these at us and there is no way to avoid a proof of being less than a
+   specific number expressed as a word, so we must introduce these. However, being explicit means
+   lack of discipline can lead to a violation. *)
+lemma numDomains_less_numeric_explicit[simplified num_domains_def One_nat_def]:
+  "x < Kernel_Config.numDomains \<Longrightarrow> x < num_domains"
+  by (simp add: num_domains_calculation)
+
+lemma numDomains_less_unat_ucast_explicit[simplified num_domains_def]:
+  "unat x < Kernel_Config.numDomains \<Longrightarrow> (ucast (x::domain) :: machine_word) < of_nat num_domains"
+  apply (rule word_less_nat_alt[THEN iffD2])
+  apply transfer
+  apply simp
+  apply (drule numDomains_less_numeric_explicit, simp add: num_domains_def)
+  done
+
+lemmas maxDomain_le_unat_ucast_explicit =
+  numDomains_less_unat_ucast_explicit[simplified le_maxDomain_eq_less_numDomains(2)[symmetric],
+                                      simplified]
+
+end (* numDomain abstraction definitions and lemmas *)
+
+
+text \<open>Priorities - not expected to be configurable\<close>
 
 lemma maxPrio_to_H:
   "ucast seL4_MaxPrio = maxPriority"
   by (simp add: maxPriority_def seL4_MaxPrio_def numPriorities_def)
+
+
+text \<open>TCB scheduling queues\<close>
+
+(* establish and sanity-check relationship between the calculation of the number of TCB queues and
+   the size of the array in C *)
+value_type num_tcb_queues = "numDomains * numPriorities"
+
+lemma num_tcb_queues_calculation:
+  "num_tcb_queues = numDomains * numPriorities"
+  unfolding num_tcb_queues_def by eval
+
 
 (* Input abbreviations for API object types *)
 (* disambiguates names *)

--- a/proof/crefine/X64/ADT_C.thy
+++ b/proof/crefine/X64/ADT_C.thy
@@ -621,7 +621,7 @@ lemma tcb_queue_rel'_unique:
 
 definition
   cready_queues_to_H
-  :: "(tcb_C ptr \<rightharpoonup> tcb_C) \<Rightarrow> (tcb_queue_C[4096]) \<Rightarrow> word8 \<times> word8 \<Rightarrow> machine_word list"
+  :: "(tcb_C ptr \<rightharpoonup> tcb_C) \<Rightarrow> (tcb_queue_C[num_tcb_queues]) \<Rightarrow> word8 \<times> word8 \<Rightarrow> machine_word list"
   where
   "cready_queues_to_H h_tcb cs \<equiv> \<lambda>(qdom, prio). if ucast minDom \<le> qdom \<and> qdom \<le> ucast maxDom
               \<and> ucast seL4_MinPrio \<le> prio \<and> prio \<le> ucast seL4_MaxPrio
@@ -1360,12 +1360,12 @@ lemma cDomSchedule_to_H_correct:
   done
 
 definition
-  cbitmap_L1_to_H :: "machine_word[16] \<Rightarrow> (8 word \<Rightarrow> machine_word)"
+  cbitmap_L1_to_H :: "machine_word[num_domains] \<Rightarrow> (8 word \<Rightarrow> machine_word)"
 where
   "cbitmap_L1_to_H l1 \<equiv> \<lambda>d. if d \<le> maxDomain then l1.[unat d] else 0"
 
 definition
-  cbitmap_L2_to_H :: "machine_word[4][16] \<Rightarrow> (8 word \<times> nat \<Rightarrow> machine_word)"
+  cbitmap_L2_to_H :: "machine_word[4][num_domains] \<Rightarrow> (8 word \<times> nat \<Rightarrow> machine_word)"
 where
   "cbitmap_L2_to_H l2 \<equiv> \<lambda>(d, i).
     if d \<le> maxDomain \<and> i < l2BitmapSize

--- a/proof/crefine/X64/Finalise_C.thy
+++ b/proof/crefine/X64/Finalise_C.thy
@@ -23,9 +23,9 @@ definition
 
 lemma tcbSchedEnqueue_cslift_spec:
   "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> \<lbrace>s. \<exists>d v. option_map2 tcbPriority_C (cslift s) \<acute>tcb = Some v
-                       \<and> v \<le> ucast maxPrio
+                       \<and> unat v \<le> numPriorities
                        \<and> option_map2 tcbDomain_C (cslift s) \<acute>tcb = Some d
-                       \<and> d \<le> ucast maxDom
+                       \<and> unat d < Kernel_Config.numDomains
                        \<and> (end_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))) \<noteq> NULL
                            \<longrightarrow> option_map2 tcbPriority_C (cslift s)
                                    (head_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))))
@@ -43,6 +43,10 @@ lemma tcbSchedEnqueue_cslift_spec:
   apply (clarsimp simp: option_map2_def fun_eq_iff h_t_valid_clift
                         h_t_valid_field[OF h_t_valid_clift])
   apply (rule conjI)
+   apply (clarsimp simp: typ_heap_simps le_maxDomain_eq_less_numDomains)
+   apply unat_arith
+  apply clarsimp
+  apply (rule conjI)
    apply (clarsimp simp: typ_heap_simps cong: if_cong)
    apply (simp split: if_split)
   apply (clarsimp simp: typ_heap_simps if_Some_helper cong: if_cong)
@@ -52,9 +56,9 @@ lemma setThreadState_cslift_spec:
   "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> \<lbrace>s. s \<Turnstile>\<^sub>c \<acute>tptr \<and> (\<forall>x. ksSchedulerAction_' (globals s) = tcb_Ptr x
                  \<and> x \<noteq> 0 \<and> x \<noteq> 1
               \<longrightarrow> (\<exists>d v. option_map2 tcbPriority_C (cslift s) (tcb_Ptr x) = Some v
-                       \<and> v \<le> ucast maxPrio
+                       \<and> unat v \<le> numPriorities
                        \<and> option_map2 tcbDomain_C (cslift s) (tcb_Ptr x) = Some d
-                       \<and> d \<le> ucast maxDom
+                       \<and> unat d < Kernel_Config.numDomains
                        \<and> (end_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))) \<noteq> NULL
                            \<longrightarrow> option_map2 tcbPriority_C (cslift s)
                                    (head_C (index \<acute>ksReadyQueues (unat (d*0x100 + v))))
@@ -127,32 +131,27 @@ lemma ctcb_relation_tcbPriority:
   "ctcb_relation tcb tcb' \<Longrightarrow> ucast (tcbPriority tcb) = tcbPriority_C tcb'"
   by (simp add: ctcb_relation_def)
 
-lemma ctcb_relation_tcbDomain_maxDom:
-  "\<lbrakk> ctcb_relation tcb tcb'; tcbDomain tcb \<le> maxDomain \<rbrakk> \<Longrightarrow> tcbDomain_C tcb' \<le> ucast maxDom"
+lemma ctcb_relation_tcbDomain_maxDomain_numDomains:
+  "\<lbrakk> ctcb_relation tcb tcb'; tcbDomain tcb \<le> maxDomain \<rbrakk>
+   \<Longrightarrow> unat (tcbDomain_C tcb') < Kernel_Config.numDomains"
   apply (subst ctcb_relation_tcbDomain[symmetric], simp)
-  apply (subst ucast_le_migrate)
-    apply ((simp add:maxDom_def word_size)+)[2]
-  apply (simp add: ucast_up_ucast is_up_def source_size_def word_size target_size_def)
-  apply (simp add: maxDom_to_H)
+  apply (simp add: le_maxDomain_eq_less_numDomains)
   done
 
-lemma ctcb_relation_tcbPriority_maxPrio:
+lemma ctcb_relation_tcbPriority_maxPriority_numPriorities:
   "\<lbrakk> ctcb_relation tcb tcb'; tcbPriority tcb \<le> maxPriority \<rbrakk>
-    \<Longrightarrow> tcbPriority_C tcb' \<le> ucast maxPrio"
+    \<Longrightarrow> unat (tcbPriority_C tcb') < numPriorities"
   apply (subst ctcb_relation_tcbPriority[symmetric], simp)
-  apply (subst ucast_le_migrate)
-    apply ((simp add: seL4_MaxPrio_def word_size)+)[2]
-  apply (simp add: ucast_up_ucast is_up_def source_size_def word_size target_size_def)
-  apply (simp add: maxPrio_to_H)
+  apply (simp add: maxPriority_def numPriorities_def word_le_nat_alt)
   done
 
 lemma tcbSchedEnqueue_cslift_precond_discharge:
   "\<lbrakk> (s, s') \<in> rf_sr; obj_at' (P :: tcb \<Rightarrow> bool) x s;
         valid_queues s; valid_objs' s \<rbrakk> \<Longrightarrow>
    (\<exists>d v. option_map2 tcbPriority_C (cslift s') (tcb_ptr_to_ctcb_ptr x) = Some v
-        \<and> v \<le> ucast maxPrio
+        \<and> unat v < numPriorities
         \<and> option_map2 tcbDomain_C (cslift s') (tcb_ptr_to_ctcb_ptr x) = Some d
-        \<and> d \<le> ucast maxDom
+        \<and> unat d < Kernel_Config.numDomains
         \<and> (end_C (index (ksReadyQueues_' (globals s')) (unat (d*0x100 + v))) \<noteq> NULL
                 \<longrightarrow> option_map2 tcbPriority_C (cslift s')
                      (head_C (index (ksReadyQueues_' (globals s')) (unat (d*0x100 + v))))
@@ -166,12 +165,12 @@ lemma tcbSchedEnqueue_cslift_precond_discharge:
   apply (frule_tac t=x in valid_objs'_maxDomain, fastforce simp: obj_at'_def)
   apply (drule_tac P="\<lambda>tcb. tcbPriority tcb \<le> maxPriority" in obj_at_ko_at2', simp)
   apply (drule_tac P="\<lambda>tcb. tcbDomain tcb \<le> maxDomain" in obj_at_ko_at2', simp)
-
-  apply (simp add: ctcb_relation_tcbDomain_maxDom ctcb_relation_tcbPriority_maxPrio)
+  apply (simp add: ctcb_relation_tcbDomain_maxDomain_numDomains
+                   ctcb_relation_tcbPriority_maxPriority_numPriorities)
   apply (frule_tac d="tcbDomain ko" and p="tcbPriority ko"
               in rf_sr_sched_queue_relation)
     apply (simp add: maxDom_to_H maxPrio_to_H)+
-  apply (simp add: cready_queues_index_to_C_def2 numPriorities_def)
+  apply (simp add: cready_queues_index_to_C_def2 numPriorities_def le_maxDomain_eq_less_numDomains)
   apply (clarsimp simp: ctcb_relation_def)
   apply (frule arg_cong[where f=unat], subst(asm) unat_ucast_up_simp, simp)
   apply (frule tcb_queue'_head_end_NULL)

--- a/proof/crefine/X64/Invoke_C.thy
+++ b/proof/crefine/X64/Invoke_C.thy
@@ -133,14 +133,15 @@ lemma decodeDomainInvocation_ccorres:
    apply (rule ccorres_add_return)
    apply (rule ccorres_rhs_assoc)+
    apply (ctac add: getSyscallArg_ccorres_foo[where args=args and n=0 and buffer=buffer])
-     apply (simp add: numDomains_def hd_conv_nth word_le_nat_alt)
+     apply (simp add: hd_conv_nth word_le_nat_alt)
+     apply (simp add: unat_scast_numDomains)
      apply (rule ccorres_Cond_rhs_Seq)
-      apply (simp add: throwError_bind invocationCatch_def numDomains_def
-                       hd_conv_nth word_le_nat_alt
+      apply (simp add: throwError_bind invocationCatch_def
+                       hd_conv_nth word_le_nat_alt unat_numDomains_to_H
                  cong: StateSpace.state.fold_congs globals.fold_congs)
       apply (rule syscall_error_throwError_ccorres_n)
       apply (simp add: syscall_error_to_H_cases)
-     apply (simp add: null_def excaps_map_def)
+     apply (simp add: null_def excaps_map_def unat_numDomains_to_H)
      apply (rule ccorres_Cond_rhs_Seq)
       apply (simp add: throwError_bind invocationCatch_def
                        interpret_excaps_test_null
@@ -190,11 +191,11 @@ lemma decodeDomainInvocation_ccorres:
    apply clarsimp
    apply (vcg exspec=getSyscallArg_modifies)
 
+  including no_take_bit
   apply (clarsimp simp: valid_tcb_state'_def invs_valid_queues' invs_valid_objs'
                         invs_queues invs_sch_act_wf' ct_in_state'_def pred_tcb_at'
                         rf_sr_ksCurThread word_sle_def word_sless_def sysargs_rel_to_n
-                        mask_eq_iff_w2p mask_eq_iff_w2p word_size "StrictC'_thread_state_defs"
-                        maxDomain_def numDomains_def)
+                        mask_eq_iff_w2p mask_eq_iff_w2p word_size "StrictC'_thread_state_defs")
   apply (rule conjI)
    apply (clarsimp simp: linorder_not_le isCap_simps)
    apply (rule conjI, clarsimp simp: unat64_eq_of_nat)
@@ -204,9 +205,11 @@ lemma decodeDomainInvocation_ccorres:
    apply (clarsimp simp: valid_cap_simps' pred_tcb'_weakenE active_runnable')
    apply (rule conjI)
     apply (fastforce simp: tcb_st_refs_of'_def elim:pred_tcb'_weakenE)
-   apply (simp add: word_le_nat_alt unat_ucast)
-  apply (clarsimp simp: ucast_ucast_len word_less_nat_alt
-                        ccap_relation_def cap_to_H_simps cap_thread_cap_lift)
+   apply (simp add: word_le_nat_alt unat_ucast unat_numDomains_to_H le_maxDomain_eq_less_numDomains)
+  apply (clarsimp simp: ccap_relation_def cap_to_H_simps cap_thread_cap_lift)
+  subgoal (* args ! 0 can be contained in a domain-sized word *)
+    by (clarsimp simp: not_le unat_numDomains_to_H ucast_ucast_len[simplified word_less_nat_alt]
+                 dest!: less_numDomains_is_domain)
   done
 
 (************************************************************************)

--- a/proof/crefine/X64/IpcCancel_C.thy
+++ b/proof/crefine/X64/IpcCancel_C.thy
@@ -13,21 +13,21 @@ begin
 
 lemma cready_queues_index_to_C_in_range':
   assumes prems: "qdom \<le> ucast maxDom" "prio \<le> ucast maxPrio"
-  shows "cready_queues_index_to_C qdom prio < numDomains * numPriorities"
+  shows "cready_queues_index_to_C qdom prio < num_tcb_queues"
 proof -
   have P: "unat prio < numPriorities"
     using prems
     by (simp add: numPriorities_def seL4_MaxPrio_def Suc_le_lessD unat_le_helper)
   have Q: "unat qdom < numDomains"
     using prems
-    by (simp add: numDomains_def maxDom_def Suc_le_lessD unat_le_helper)
+    by (simp add: maxDom_to_H le_maxDomain_eq_less_numDomains word_le_nat_alt)
   show ?thesis
     using mod_lemma[OF _ P, where q="unat qdom" and c=numDomains] Q
-    by (clarsimp simp: cready_queues_index_to_C_def field_simps numDomains_def)
+    by (clarsimp simp: num_tcb_queues_calculation cready_queues_index_to_C_def field_simps)
 qed
 
-lemmas cready_queues_index_to_C_in_range
-            = cready_queues_index_to_C_in_range'[unfolded numPriorities_def numDomains_def, simplified]
+lemmas cready_queues_index_to_C_in_range =
+  cready_queues_index_to_C_in_range'[simplified num_tcb_queues_def]
 
 lemma cready_queues_index_to_C_inj:
   "\<lbrakk> cready_queues_index_to_C qdom prio = cready_queues_index_to_C qdom' prio';
@@ -748,8 +748,7 @@ lemma state_relation_queue_update_helper':
      apply simp
      apply (erule cnotification_relation_upd_tcb_no_queues, simp+)
     \<comment> \<open>ready queues\<close>
-    apply (simp add: cready_queues_relation_def Let_def
-                     cready_queues_index_to_C_in_range
+    apply (simp add: cready_queues_relation_def Let_def cready_queues_index_to_C_in_range
                      seL4_MinPrio_def minDom_def)
     apply clarsimp
     apply (frule cready_queues_index_to_C_distinct, assumption+)
@@ -833,31 +832,23 @@ lemmas queue_in_range = of_nat_mono_maybe[OF _ cready_queues_index_to_C_in_range
         where 'a=64, unfolded cready_queues_index_to_C_def numPriorities_def,
         simplified, unfolded ucast_nat_def]
 
-lemma cready_queues_index_to_C_def2':
-  "\<lbrakk> qdom \<le> ucast maxDom; prio \<le> ucast maxPrio \<rbrakk>
+lemma cready_queues_index_to_C_def2:
+  "\<lbrakk> qdom \<le> maxDomain; prio \<le> maxPriority \<rbrakk>
    \<Longrightarrow> cready_queues_index_to_C qdom prio
              = unat (ucast qdom * of_nat numPriorities + ucast prio :: machine_word)"
-  apply (simp add: cready_queues_index_to_C_def numPriorities_def)
+  including no_take_bit
+  using numPriorities_machine_word_safe
+  apply -
+  apply (frule (1) cready_queues_index_to_C_in_range[simplified maxDom_to_H maxPrio_to_H])
   apply (subst unat_add_lem[THEN iffD1])
-   apply (frule cready_queues_index_to_C_in_range, simp)
-   apply (simp add: cready_queues_index_to_C_def numPriorities_def)
-   apply (subst unat_mult_simple)
-    apply (simp add: word_bits_def maxDom_def)
-   apply simp
-  apply (subst unat_mult_simple)
-   apply (simp add: word_bits_def maxDom_def)
-   apply (subst (asm) word_le_nat_alt)
-   apply simp
-  apply simp
+   apply (auto simp: unat_mult_simple cready_queues_index_to_C_def)
   done
 
-lemmas cready_queues_index_to_C_def2
-           = cready_queues_index_to_C_def2'[simplified maxDom_to_H maxPrio_to_H]
-
 lemma ready_queues_index_spec:
-  "\<forall>s. \<Gamma> \<turnstile> {s} Call ready_queues_index_'proc
+  "\<forall>s. \<Gamma> \<turnstile> {s'. s' = s \<and> (Kernel_Config.numDomains \<le> 1 \<longrightarrow> dom_' s' = 0)}
+       Call ready_queues_index_'proc
        \<lbrace>\<acute>ret__unsigned_long = (dom_' s) * 0x100 + (prio_' s)\<rbrace>"
-  by vcg (simp add: word_sless_alt)
+  by vcg (simp add: numDomains_sge_1_simp)
 
 lemma prio_to_l1index_spec:
   "\<forall>s. \<Gamma> \<turnstile> {s} Call prio_to_l1index_'proc
@@ -891,7 +882,7 @@ lemma cready_queues_index_to_C_ucast_helper:
   fixes p :: priority
   fixes d :: domain
   shows "unat (ucast d * 0x100 + ucast p :: machine_word) = unat d * 256 + unat p"
-  unfolding tcb_queue_relation'_def maxPriority_def maxDomain_def numDomains_def numPriorities_def
+  unfolding tcb_queue_relation'_def maxPriority_def numPriorities_def
   using unat_lt2p[where x=p] unat_lt2p[where x=d]
   by (clarsimp simp: cready_queues_index_to_C_def word_le_nat_alt unat_word_ariths)
 
@@ -901,7 +892,6 @@ lemmas prio_and_dom_limit_helpers =
   prio_ucast_shiftr_wordRadix_helper2
   prio_ucast_shiftr_wordRadix_helper3
   prio_unat_shiftr_wordRadix_helper'
-  dom_less_0x10_helper
   cready_queues_index_to_C_ucast_helper
   unat_ucast_prio_L1_cmask_simp
   machine_word_and_3F_less_40
@@ -925,8 +915,10 @@ lemma cbitmap_L1_relation_bit_set:
            (Arrays.update (ksReadyQueuesL1Bitmap_' (globals x)) (unat d)
              (ksReadyQueuesL1Bitmap_' (globals x).[unat d] || 2 ^ unat (p >> wordRadix)))
            ((ksReadyQueuesL1Bitmap \<sigma>)(d := ksReadyQueuesL1Bitmap \<sigma> d || 2 ^ prioToL1Index p))"
+  including no_take_bit
   apply (unfold cbitmap_L1_relation_def)
-  apply (clarsimp simp: prioToL1Index_def wordRadix_def' maxDomain_def numDomains_def word_le_nat_alt)
+  apply (clarsimp simp: le_maxDomain_eq_less_numDomains word_le_nat_alt prioToL1Index_def
+                        num_domains_index_updates)
   done
 
 lemma cbitmap_L2_relation_bit_set:
@@ -948,8 +940,8 @@ lemma cbitmap_L2_relation_bit_set:
   unfolding cbitmap_L2_relation_def numPriorities_def wordBits_def word_size l2BitmapSize_def'
   apply (clarsimp simp: word_size prioToL1Index_def wordRadix_def mask_def
                         invertL1Index_def l2BitmapSize_def'
-                        maxDomain_def numDomains_def word_le_nat_alt)
-  apply (case_tac "da = d" ; clarsimp)
+                        le_maxDomain_eq_less_numDomains word_le_nat_alt)
+  apply (case_tac "da = d" ; clarsimp simp: num_domains_index_updates)
   done
 
 lemma carch_state_relation_enqueue_simp:
@@ -1026,6 +1018,10 @@ proof -
   note prio_and_dom_limit_helpers[simp] word_sle_def[simp] maxDom_to_H[simp] maxPrio_to_H[simp]
   note invert_prioToL1Index_c_simp[simp]
 
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  note word_less_1[simp del]
+
   show ?thesis
     apply (cinit lift: tcb_')
      apply (rule_tac r'="\<lambda>rv rv'. rv = to_bool rv'" and xf'="ret__unsigned_longlong_'"
@@ -1098,6 +1094,9 @@ proof -
                           .[cready_queues_index_to_C (tcbDomain tcb) (tcbPriority tcb)]) = NULL")
                prefer 2
                apply (frule_tac s=\<sigma> in tcb_queue'_head_end_NULL[symmetric]; simp add: valid_queues_valid_q)
+              apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                        unat_trans_ucast_helper\<close>)
+              apply (frule maxDomain_le_unat_ucast_explicit)
               apply (clarsimp simp: cready_queues_index_to_C_def numPriorities_def)
               apply (clarsimp simp: h_val_field_clift' h_t_valid_clift)
               apply (simp add: t_hrs_ksReadyQueues_upd_absorb)
@@ -1121,7 +1120,9 @@ proof -
                                    typ_heap_simps)[1]
                apply (fastforce simp: tcb_null_sched_ptrs_def typ_heap_simps c_guard_clift
                                 elim: obj_at'_weaken)+
-
+             apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                       unat_trans_ucast_helper\<close>)
+             apply clarsimp
              apply (rule conjI; clarsimp simp: queue_in_range)
               (* invalid, disagreement between C and Haskell on emptiness of queue *)
               apply (drule (1) obj_at_cslift_tcb)
@@ -1298,9 +1299,10 @@ lemma cbitmap_L1_relation_bit_clear:
            (Arrays.update (ksReadyQueuesL1Bitmap_' (globals x)) (unat d)
              (ksReadyQueuesL1Bitmap_' (globals x).[unat d] && ~~ 2 ^ unat (p >> wordRadix)))
            ((ksReadyQueuesL1Bitmap \<sigma>)(d := ksReadyQueuesL1Bitmap \<sigma> d && ~~ 2 ^ prioToL1Index p))"
-  apply (unfold cbitmap_L1_relation_def)
-  apply (clarsimp simp: prioToL1Index_def wordRadix_def' maxDomain_def numDomains_def word_le_nat_alt)
-  done
+  unfolding cbitmap_L1_relation_def numPriorities_def wordBits_def word_size l2BitmapSize_def'
+  by (clarsimp simp: word_size prioToL1Index_def wordRadix_def mask_def
+                     invertL1Index_def l2BitmapSize_def'
+                     le_maxDomain_eq_less_numDomains word_le_nat_alt num_domains_index_updates)
 
 lemma cready_queues_relation_empty_queue_helper:
   "\<lbrakk> tcbDomain ko \<le> maxDomain ; tcbPriority ko \<le> maxPriority ;
@@ -1348,8 +1350,8 @@ lemma cbitmap_L2_relation_bit_clear:
   unfolding cbitmap_L2_relation_def numPriorities_def wordBits_def word_size l2BitmapSize_def'
   apply (clarsimp simp: word_size prioToL1Index_def wordRadix_def mask_def
                         invertL1Index_def l2BitmapSize_def'
-                        maxDomain_def numDomains_def word_le_nat_alt)
-  apply (case_tac "da = d" ; clarsimp)
+                        le_maxDomain_eq_less_numDomains word_le_nat_alt)
+  apply (case_tac "da = d" ; clarsimp simp: num_domains_index_updates)
   done
 
 lemma tcbSchedDequeue_ccorres':
@@ -1364,6 +1366,10 @@ lemma tcbSchedDequeue_ccorres':
 proof -
 
   note prio_and_dom_limit_helpers[simp] word_sle_def[simp]
+
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  include no_less_1_simps
 
   have ksQ_tcb_at': "\<And>s ko d p.
     \<forall>d p. (\<forall>t\<in>set (ksReadyQueues s (d, p)). obj_at' (inQ d p) t s)
@@ -1439,6 +1445,9 @@ proof -
              apply (frule_tac s=\<sigma> in tcb_queue_relation_prev_next'; (fastforce simp: ksQ_tcb_at')?)
              apply (drule_tac s=\<sigma> in tcbSchedDequeue_update, assumption,
                     simp_all add: remove1_filter ksQ_tcb_at')[1]
+             apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                       unat_trans_ucast_helper\<close>)
+             apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
              apply (intro conjI;
                     clarsimp simp: h_val_field_clift'
                                    h_t_valid_clift[THEN h_t_valid_field] h_t_valid_clift)+
@@ -1453,11 +1462,12 @@ proof -
                 apply (frule rf_sr_cbitmap_L2_relation)
                 apply (clarsimp simp: cbitmap_L2_relation_def
                                       word_size prioToL1Index_def wordRadix_def mask_def
-                                      maxDomain_def numDomains_def word_le_nat_alt
+                                      word_le_nat_alt
                                       numPriorities_def wordBits_def l2BitmapSize_def'
-                                      invertL1Index_def)
-                apply (case_tac "d = tcbDomain ko" ; fastforce)
-
+                                      invertL1Index_def numDomains_less_numeric_explicit)
+                apply (case_tac "d = tcbDomain ko"
+                       ; fastforce simp: le_maxDomain_eq_less_numDomains
+                                         numDomains_less_numeric_explicit)
                apply (drule (1) obj_at_cslift_tcb, clarsimp simp: inQ_def)
                apply (frule_tac d="tcbDomain ko" and p="tcbPriority ko"
                         in rf_sr_sched_queue_relation)
@@ -1477,8 +1487,8 @@ proof -
                apply (erule (2) cready_queues_relation_empty_queue_helper)
               (* impossible case, C L2 update disagrees with Haskell update *)
               apply (simp add: invert_prioToL1Index_c_simp)
-              apply (subst (asm) Arrays.index_update)
-               subgoal by (simp add: maxDomain_def numDomains_def word_le_nat_alt)
+              apply (subst (asm) num_domains_index_updates)
+               subgoal by (simp add: le_maxDomain_eq_less_numDomains word_le_nat_alt)
               apply (subst (asm) Arrays.index_update)
                apply (simp add: invert_l1_index_limit)
 
@@ -1507,6 +1517,9 @@ proof -
             apply (drule_tac s=\<sigma> in tcbSchedDequeue_update, assumption,
                    simp_all add: remove1_filter ksQ_tcb_at')[1]
             apply (clarsimp simp:  filter_noteq_op upd_unless_null_def)
+            apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                      unat_trans_ucast_helper\<close>)
+            apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
             apply (rule conjI, clarsimp)
              apply (clarsimp simp: h_val_field_clift'
                                    h_t_valid_clift[THEN h_t_valid_field] h_t_valid_clift)
@@ -1576,6 +1589,9 @@ proof -
             apply (drule_tac s=\<sigma> in tcbSchedDequeue_update, assumption,
                    simp_all add: remove1_filter ksQ_tcb_at')[1]
             apply (clarsimp simp:  filter_noteq_op upd_unless_null_def)
+            apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                      unat_trans_ucast_helper\<close>)
+            apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
             apply (rule conjI; clarsimp)
              apply (clarsimp simp: h_val_field_clift'
                                    h_t_valid_clift[THEN h_t_valid_field] h_t_valid_clift)
@@ -1586,8 +1602,8 @@ proof -
              apply (fastforce simp: c_invert_assist l2BitmapSize_def' wordRadix_def)
             apply (rule conjI; clarsimp)
              (* impossible case, C L2 update disagrees with Haskell update *)
-             apply (subst (asm) Arrays.index_update)
-              apply (simp add: maxDomain_def numDomains_def word_le_nat_alt)
+             apply (subst (asm) num_domains_index_updates)
+              apply (simp add: le_maxDomain_eq_less_numDomains word_le_nat_alt)
              apply (subst (asm) Arrays.index_update)
               subgoal using invert_l1_index_limit
                 by (fastforce simp add: invert_prioToL1Index_c_simp intro: nat_Suc_less_le_imp)
@@ -1621,6 +1637,9 @@ proof -
            apply (drule_tac s=\<sigma> in tcbSchedDequeue_update, assumption,
                   simp_all add: remove1_filter ksQ_tcb_at')[1]
            apply (clarsimp simp: filter_noteq_op upd_unless_null_def)
+           apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                     unat_trans_ucast_helper\<close>)
+           apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
            apply (rule conjI, clarsimp)
             apply (clarsimp simp: h_val_field_clift'
                                   h_t_valid_clift[THEN h_t_valid_field] h_t_valid_clift)
@@ -1765,6 +1784,10 @@ lemma tcbSchedAppend_ccorres:
 proof -
   note prio_and_dom_limit_helpers[simp] word_sle_def[simp] maxDom_to_H[simp] maxPrio_to_H[simp]
 
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  include no_less_1_simps
+
   show ?thesis
   apply (cinit lift: tcb_')
    apply (rule_tac r'="\<lambda>rv rv'. rv = to_bool rv'"
@@ -1834,6 +1857,9 @@ proof -
              apply (rule tcb_at_not_NULL, erule obj_at'_weakenE, simp)
             apply (clarsimp simp: h_val_field_clift' h_t_valid_clift)
             apply (simp add: invert_prioToL1Index_c_simp)
+            apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                      unat_trans_ucast_helper\<close>)
+            apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
             apply (rule conjI; clarsimp)
              apply (rule conjI)
               apply (fastforce simp: c_invert_assist l2BitmapSize_def' wordRadix_def)
@@ -1849,6 +1875,9 @@ proof -
                apply (fastforce simp: tcb_null_sched_ptrs_def elim: obj_at'_weaken)
              apply (fastforce simp: tcb_null_sched_ptrs_def elim: obj_at'_weaken)
             apply (clarsimp simp: upd_unless_null_def cready_queues_index_to_C_def numPriorities_def)
+           apply (rule conjI, solves \<open>clarsimp simp: le_maxDomain_eq_less_numDomains
+                                                     unat_trans_ucast_helper\<close>)
+           apply (clarsimp simp: maxDomain_le_unat_ucast_explicit)
            apply (rule conjI; clarsimp simp: queue_in_range)
             apply (drule (1) obj_at_cslift_tcb)
             apply clarsimp
@@ -2200,6 +2229,10 @@ proof -
     apply (simp add: unat_of_nat_eq)
     done
 
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  include no_less_1_simps
+
   show ?thesis
   including no_take_bit
   apply (cinit lift: dom_')
@@ -2237,7 +2270,7 @@ proof -
     prefer 2
     subgoal by (fastforce simp: cbitmap_L1_relation_def)
 
-   apply (clarsimp simp: signed_word_log2 cbitmap_L1_relation_def)
+   apply (clarsimp simp: signed_word_log2 cbitmap_L1_relation_def maxDomain_le_unat_ucast_explicit)
    apply (frule bitmapQ_no_L1_orphansD, erule word_log2_nth_same)
    apply simp
    apply (rule conjI, fastforce simp: invertL1Index_def l2BitmapSize_def')
@@ -2288,6 +2321,17 @@ lemma getCurDomain_ccorres_dom_':
        \<top> UNIV hs curDomain (\<acute>dom :== \<acute>ksCurDomain)"
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
+  apply (clarsimp simp: curDomain_def simpler_gets_def
+                        rf_sr_ksCurDomain)
+  done
+
+lemma getCurDomain_maxDom_ccorres_dom_':
+  "ccorres (\<lambda>rv rv'. rv' = ucast rv) dom_'
+     (\<lambda>s. ksCurDomain s \<le> maxDomain) UNIV hs
+     curDomain (\<acute>dom :== (if maxDom \<noteq> 0 then \<acute>ksCurDomain else 0))"
+  apply (rule ccorres_from_vcg)
+  apply (rule allI, rule conseqPre, vcg)
+  using maxDom_to_H
   apply (clarsimp simp: curDomain_def simpler_gets_def
                         rf_sr_ksCurDomain)
   done

--- a/proof/crefine/X64/SR_lemmas_C.thy
+++ b/proof/crefine/X64/SR_lemmas_C.thy
@@ -2556,5 +2556,16 @@ lemmas global_ioport_bitmap_heap_update_tag_disj_simps =
 lemmas fpu_null_state_heap_update_tag_disj_simps =
   h_t_valid_fields_clift[THEN fpu_null_state_heap_update_tag_disj'[OF _ tag_disj_via_td_name]]
 
+lemma numDomains_sge_1_simp:
+  "1 <s Kernel_C.numDomains \<longleftrightarrow> Suc 0 < Kernel_Config.numDomains"
+  apply (simp add: word_sless_alt sint_numDomains_to_H)
+  apply (subst nat_less_as_int, simp)
+  done
+
+lemma unat_scast_numDomains:
+  "unat (SCAST(32 signed \<rightarrow> machine_word_len) Kernel_C.numDomains) = unat Kernel_C.numDomains"
+  including no_take_bit
+  by (simp add: scast_eq sint_numDomains_to_H unat_numDomains_to_H numDomains_machine_word_safe)
+
 end
 end

--- a/proof/crefine/X64/Schedule_C.thy
+++ b/proof/crefine/X64/Schedule_C.thy
@@ -180,16 +180,6 @@ lemma ceqv_remove_tail_Guard_Skip:
 lemmas ccorres_remove_tail_Guard_Skip
     = ccorres_abstract[where xf'="\<lambda>_. ()", OF ceqv_remove_tail_Guard_Skip]
 
-(* FIXME x64: does this need machine_word? *)
-lemma queue_in_range_pre:
-  "\<lbrakk> (qdom :: word32) \<le> ucast maxDom; prio \<le> ucast maxPrio \<rbrakk>
-    \<Longrightarrow> qdom * of_nat numPriorities + prio < of_nat (numDomains * numPriorities)"
-  by (clarsimp simp: cready_queues_index_to_C_def word_less_nat_alt
-                     word_le_nat_alt unat_ucast maxDom_def seL4_MaxPrio_def
-                     numPriorities_def unat_word_ariths numDomains_def)
-
-lemmas queue_in_range' = queue_in_range_pre[unfolded numDomains_def numPriorities_def, simplified]
-
 lemma switchToThread_ccorres':
   "ccorres (\<lambda>_ _. True) xfdc
            (all_invs_but_ct_idle_or_in_cur_domain' and tcb_at' t)
@@ -211,73 +201,98 @@ proof -
   note prio_and_dom_limit_helpers [simp]
   note ksReadyQueuesL2Bitmap_nonzeroI [simp]
   note Collect_const_mem [simp]
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  include no_less_1_simps
 
   have invs_no_cicd'_max_CurDomain[intro]:
     "\<And>s. invs_no_cicd' s \<Longrightarrow> ksCurDomain s \<le> maxDomain"
     by (simp add: invs_no_cicd'_def)
 
   show ?thesis
-  apply (cinit)
-   apply (simp add: numDomains_def word_sless_alt word_sle_def)
-   apply (ctac (no_vcg) add: getCurDomain_ccorres_dom_')
-     apply clarsimp
-     apply (rename_tac curdom)
-     apply (rule_tac P="curdom \<le> maxDomain" in ccorres_cross_over_guard_no_st)
-     apply (rule ccorres_Guard)
-     apply (rule ccorres_pre_getReadyQueuesL1Bitmap)
-     apply (rename_tac l1)
-     apply (rule_tac R="\<lambda>s. l1 = ksReadyQueuesL1Bitmap s curdom \<and> curdom \<le> maxDomain"
-              in ccorres_cond)
-       subgoal by (fastforce dest!: rf_sr_cbitmap_L1_relation simp: cbitmap_L1_relation_def)
-      prefer 2 \<comment> \<open>switchToIdleThread\<close>
-      apply (ctac(no_vcg) add: switchToIdleThread_ccorres)
-     apply clarsimp
-     apply (rule ccorres_rhs_assoc)+
-
-     apply (rule ccorres_split_nothrow_novcg)
-         apply (rule_tac xf'=prio_' in ccorres_call)
-            apply (rule getHighestPrio_ccorres[simplified getHighestPrio_def'])
-           apply simp+
+    supply if_split[split del]
+    apply (cinit)
+     apply (simp add: numDomains_sge_1_simp)
+     apply (rule_tac xf'=dom_' and r'="\<lambda>rv rv'. rv' = ucast rv" in ccorres_split_nothrow_novcg)
+         apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
+         apply clarsimp
+         apply (rule conseqPre, vcg)
+         apply (rule Collect_mono)
+         apply (clarsimp split: prod.split)
+         apply (clarsimp simp: curDomain_def simpler_gets_def return_def rf_sr_ksCurDomain)
         apply ceqv
        apply clarsimp
-       apply (rename_tac prio)
+       apply (rename_tac curdom)
        apply (rule_tac P="curdom \<le> maxDomain" in ccorres_cross_over_guard_no_st)
-       apply (rule_tac P="prio \<le> maxPriority" in ccorres_cross_over_guard_no_st)
-       apply (rule ccorres_pre_getQueue)
-       apply (rule_tac P="queue \<noteq> []" in ccorres_cross_over_guard_no_st)
-       apply (rule ccorres_symb_exec_l)
-          apply (rule ccorres_assert)
-          apply csymbr
-          apply (rule ccorres_Guard_Seq)+
-          apply (rule ccorres_symb_exec_r)
-            apply (simp only: ccorres_seq_skip)
-            apply (rule ccorres_call[OF switchToThread_ccorres']; simp)
-           apply vcg
-          apply (rule conseqPre, vcg)
-          apply clarsimp
-         apply (wp isRunnable_wp)+
-       apply (simp add: isRunnable_def)
-      apply wp
-     apply (clarsimp simp: Let_def guard_is_UNIV_def)
-     apply (drule invs_no_cicd'_queues)
-     apply (case_tac queue, simp)
-     apply (clarsimp simp: tcb_queue_relation'_def cready_queues_index_to_C_def
-                            numPriorities_def )
-     apply (simp add: word_less_nat_alt word_le_nat_alt)
-     apply (rule_tac x="unat curdom * 256" and xmax="unat maxDomain * 256" in nat_add_less_by_max)
-      subgoal by (simp add: word_le_nat_alt[symmetric])
-     subgoal by (simp add: maxDomain_def numDomains_def maxPriority_def numPriorities_def)
-    apply wp
-   apply clarsimp
-  apply (frule invs_no_cicd'_queues)
-  apply (frule invs_no_cicd'_max_CurDomain)
-  apply (frule invs_no_cicd'_queues)
-  apply (clarsimp simp: valid_queues_def lookupBitmapPriority_le_maxPriority)
-  apply (intro conjI impI)
-      apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
-     apply (fastforce dest: lookupBitmapPriority_obj_at'
-                      simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
-  done
+       apply (rule ccorres_Guard)
+       apply (rule ccorres_pre_getReadyQueuesL1Bitmap)
+       apply (rename_tac l1)
+       apply (rule_tac R="\<lambda>s. l1 = ksReadyQueuesL1Bitmap s curdom \<and> curdom \<le> maxDomain"
+                in ccorres_cond)
+         subgoal by (fastforce dest!: rf_sr_cbitmap_L1_relation simp: cbitmap_L1_relation_def)
+        prefer 2 \<comment> \<open>switchToIdleThread\<close>
+        apply (ctac(no_vcg) add: switchToIdleThread_ccorres)
+       apply clarsimp
+       apply (rule ccorres_rhs_assoc)+
+       apply (rule ccorres_split_nothrow_novcg)
+           apply (rule_tac xf'=prio_' in ccorres_call)
+              apply (rule getHighestPrio_ccorres[simplified getHighestPrio_def'])
+             apply simp+
+          apply ceqv
+         apply clarsimp
+         apply (rename_tac prio)
+         apply (rule_tac P="curdom \<le> maxDomain" in ccorres_cross_over_guard_no_st)
+         apply (rule_tac P="prio \<le> maxPriority" in ccorres_cross_over_guard_no_st)
+         apply (rule ccorres_pre_getQueue)
+         apply (rule_tac P="queue \<noteq> []" in ccorres_cross_over_guard_no_st)
+         apply (rule ccorres_symb_exec_l)
+            apply (rule ccorres_assert)
+            apply (rule ccorres_symb_exec_r)
+              apply (rule ccorres_Guard_Seq)+
+              apply (rule ccorres_symb_exec_r)
+                apply (simp only: ccorres_seq_skip)
+                apply (rule ccorres_call[OF switchToThread_ccorres']; simp)
+               apply vcg
+              apply (rule conseqPre, vcg)
+              apply clarsimp
+             apply clarsimp
+             apply (rule conseqPre, vcg)
+             apply (rule Collect_mono)
+             apply clarsimp
+             apply (strengthen queue_in_range)
+             apply assumption
+            apply clarsimp
+            apply (rule conseqPre, vcg)
+            apply clarsimp
+           apply (wp isRunnable_wp)+
+         apply (simp add: isRunnable_def)
+        apply wp
+       apply (clarsimp simp: Let_def guard_is_UNIV_def)
+       apply (drule invs_no_cicd'_queues)
+       apply (case_tac queue, simp)
+       apply (clarsimp simp: tcb_queue_relation'_def cready_queues_index_to_C_def numPriorities_def)
+       apply (clarsimp simp add: maxDom_to_H maxPrio_to_H
+                                 queue_in_range[where qdom=0, simplified, simplified maxPrio_to_H])
+       apply (clarsimp simp: le_maxDomain_eq_less_numDomains unat_trans_ucast_helper )
+      apply wpsimp
+     apply (clarsimp simp: guard_is_UNIV_def le_maxDomain_eq_less_numDomains word_less_nat_alt
+                           numDomains_less_numeric_explicit)
+    apply (frule invs_no_cicd'_queues)
+    apply (frule invs_no_cicd'_max_CurDomain)
+    apply (frule invs_no_cicd'_queues)
+    apply (clarsimp simp: valid_queues_def lookupBitmapPriority_le_maxPriority)
+    apply (intro conjI impI)
+       apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
+      apply (fastforce dest: lookupBitmapPriority_obj_at'
+                       simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+     apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
+    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    apply (clarsimp simp: not_less le_maxDomain_eq_less_numDomains)
+    apply (prop_tac "ksCurDomain s = 0")
+     using unsigned_eq_0_iff apply force
+    apply (cut_tac s=s in lookupBitmapPriority_obj_at'; simp?)
+    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    done
 qed
 
 lemma ksDomSched_length_relation[simp]:
@@ -363,6 +378,9 @@ lemma isHighestPrio_ccorres:
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
   supply from_bool_eq_if[simp] from_bool_eq_if'[simp] from_bool_0[simp]
           ccorres_IF_True[simp] if_cong[cong]
+  (* when numDomains = 1, array bounds checks would become _ = 0 rather than _ < 1, changing the
+     shape of the proof compared to when numDomains > 1 *)
+  including no_less_1_simps
   apply (cinit lift: dom_' prio_')
    apply clarsimp
    apply (rule ccorres_move_const_guard)
@@ -388,7 +406,8 @@ lemma isHighestPrio_ccorres:
       apply (rule ccorres_return_C, simp, simp, simp)
      apply (rule wp_post_taut)
     apply (vcg exspec=getHighestPrio_modifies)+
-  apply (clarsimp simp: word_le_nat_alt true_def to_bool_def split: if_splits)
+  apply (clarsimp simp: word_le_nat_alt true_def to_bool_def maxDomain_le_unat_ucast_explicit
+                  split: if_splits)
   done
 
 lemma schedule_ccorres:
@@ -580,7 +599,7 @@ lemma schedule_ccorres:
                      apply (wpsimp simp: cscheduler_action_relation_def)+
                    apply (vcg exspec=scheduleChooseNewThread_modifies)
                   apply (wp add: setSchedulerAction_invs' setSchedulerAction_direct del: ssa_wp)
-                 apply (clarsimp | vcg exspec=tcbSchedEnqueue_modifies | wp wp_post_taut)+
+                 apply (clarsimp | vcg exspec=tcbSchedAppend_modifies | wp wp_post_taut)+
               (* candidate is best, switch to it *)
               apply (ctac add: switchToThread_ccorres)
                 apply clarsimp
@@ -727,7 +746,9 @@ lemma timerTick_ccorres:
              apply (vcg exspec=tcbSchedDequeue_modifies)
         apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip[unfolded dc_def])+
         apply ceqv
-       apply (simp add: when_def numDomains_def decDomainTime_def)
+       apply (clarsimp simp: decDomainTime_def numDomains_sge_1_simp)
+       apply (rule ccorres_when[where R=\<top>])
+        apply (solves \<open>clarsimp split: if_split\<close>)
        apply (rule ccorres_split_nothrow_novcg)
            apply (rule_tac rrel=dc and xf=xfdc and P=\<top> and P'=UNIV in ccorres_from_vcg)
            apply (rule allI, rule conseqPre, vcg)
@@ -735,6 +756,7 @@ lemma timerTick_ccorres:
            apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                  carch_state_relation_def cmachine_state_relation_def)
           apply ceqv
+         apply (fold dc_def)
          apply (rule ccorres_pre_getDomainTime)
          apply (rename_tac rva rv'a rvb)
          apply (rule_tac P'="{s. ksDomainTime_' (globals s) = rvb}" in ccorres_inst, simp)

--- a/proof/crefine/X64/StateRelation_C.thy
+++ b/proof/crefine/X64/StateRelation_C.thy
@@ -776,8 +776,8 @@ definition
 where
   "cready_queues_index_to_C qdom prio \<equiv> (unat qdom) * numPriorities + (unat prio)"
 
-definition
-  cready_queues_relation :: "tcb_C typ_heap \<Rightarrow> (tcb_queue_C[4096]) \<Rightarrow> (domain \<times> priority \<Rightarrow> ready_queue) \<Rightarrow> bool"
+definition cready_queues_relation ::
+  "tcb_C typ_heap \<Rightarrow> (tcb_queue_C[num_tcb_queues]) \<Rightarrow> (domain \<times> priority \<Rightarrow> ready_queue) \<Rightarrow> bool"
 where
   "cready_queues_relation h_tcb queues aqueues \<equiv>
      \<forall>qdom prio. ((qdom \<ge> ucast minDom \<and> qdom \<le> ucast maxDom \<and>

--- a/proof/crefine/X64/Wellformed_C.thy
+++ b/proof/crefine/X64/Wellformed_C.thy
@@ -473,13 +473,113 @@ lemma ptr_val_tcb_ptr_mask2:
   apply (simp add: is_aligned_add_helper ctcb_offset_defs objBits_simps')
   done
 
+section \<open>Domains\<close>
+
+text \<open>
+  seL4's build system allows configuration of the number of domains. This means the proofs have to
+  work for any number of domains provided it fits into the hard limit of a 8-bit word.
+
+  In the C code, we have the enumerated constant numDomains, one greater than maxDom. In the
+  abstract specs, we have the corresponding Platform_Config.numDomains and maxDomain.
+
+  To keep the proofs as general as possible, we avoid unfolding definitions of:
+  maxDom, maxDomain, numDomains except in this theory where we need to establish basic properties.
+
+  Unfortunately, array bounds checks coming from the C code use numerical values, meaning we might
+  get 0x10 instead of the number of domains, or 0x1000 for numDomains * numPriorities. To solve
+  these, the "explicit" lemmas expose direct numbers. They are more risky to deploy, as one could
+  prove that 0x5 is less than the number of domains when that's the case, and then the proof will
+  break upon reconfiguration.
+\<close>
+
+text \<open>The @{text num_domains} enumerated type and constant represent the number of domains.\<close>
+
+value_type num_domains = "numDomains"
+
+context includes no_less_1_simps begin
+
+(* The proofs expect the minimum priority and minimum domain to be zero.
+   Note that minDom is unused in the C code. *)
+lemma min_prio_dom_sanity:
+  "seL4_MinPrio = 0"
+  "Kernel_C.minDom = 0"
+  by (auto simp: seL4_MinPrio_def minDom_def)
+
+lemma less_numDomains_is_domain[simplified word_size, simplified]:
+  "x < numDomains \<Longrightarrow> x < 2 ^ size (y::domain)"
+  unfolding Kernel_Config.numDomains_def
+  by (simp add: word_size)
+
+lemma sint_numDomains_to_H:
+  "sint Kernel_C.numDomains = int Kernel_Config.numDomains"
+  by (clarsimp simp: Kernel_C.numDomains_def Kernel_Config.numDomains_def)
+
+lemma unat_numDomains_to_H:
+  "unat Kernel_C.numDomains = Kernel_Config.numDomains"
+  by (clarsimp simp: Kernel_C.numDomains_def Kernel_Config.numDomains_def)
+
 lemma maxDom_to_H:
   "ucast maxDom = maxDomain"
-  by (simp add: maxDomain_def maxDom_def numDomains_def)
+  by (simp add: maxDomain_def Kernel_C.maxDom_def Kernel_Config.numDomains_def)
+
+lemma maxDom_sgt_0_maxDomain:
+  "0 <s maxDom \<longleftrightarrow> 0 < maxDomain"
+  unfolding Kernel_C.maxDom_def maxDomain_def Kernel_Config.numDomains_def
+  by clarsimp
+
+lemma num_domains_calculation:
+  "num_domains = numDomains"
+  unfolding num_domains_def by eval
+
+private lemma num_domains_card_explicit:
+  "num_domains = CARD(num_domains)"
+  by (simp add: num_domains_def)
+
+lemmas num_domains_index_updates =
+  index_update[where 'b=num_domains, folded num_domains_card_explicit num_domains_def,
+               simplified num_domains_calculation]
+  index_update2[where 'b=num_domains, folded num_domains_card_explicit num_domains_def,
+                simplified num_domains_calculation]
+
+(* C ArrayGuards will throw these at us and there is no way to avoid a proof of being less than a
+   specific number expressed as a word, so we must introduce these. However, being explicit means
+   lack of discipline can lead to a violation. *)
+lemma numDomains_less_numeric_explicit[simplified num_domains_def One_nat_def]:
+  "x < Kernel_Config.numDomains \<Longrightarrow> x < num_domains"
+  by (simp add: num_domains_calculation)
+
+lemma numDomains_less_unat_ucast_explicit[simplified num_domains_def]:
+  "unat x < Kernel_Config.numDomains \<Longrightarrow> (ucast (x::domain) :: machine_word) < of_nat num_domains"
+  apply (rule word_less_nat_alt[THEN iffD2])
+  apply transfer
+  apply simp
+  apply (drule numDomains_less_numeric_explicit, simp add: num_domains_def)
+  done
+
+lemmas maxDomain_le_unat_ucast_explicit =
+  numDomains_less_unat_ucast_explicit[simplified le_maxDomain_eq_less_numDomains(2)[symmetric],
+                                      simplified]
+
+end (* numDomain abstraction definitions and lemmas *)
+
+
+text \<open>Priorities - not expected to be configurable\<close>
 
 lemma maxPrio_to_H:
   "ucast seL4_MaxPrio = maxPriority"
   by (simp add: maxPriority_def seL4_MaxPrio_def numPriorities_def)
+
+
+text \<open>TCB scheduling queues\<close>
+
+(* establish and sanity-check relationship between the calculation of the number of TCB queues and
+   the size of the array in C *)
+value_type num_tcb_queues = "numDomains * numPriorities"
+
+lemma num_tcb_queues_calculation:
+  "num_tcb_queues = numDomains * numPriorities"
+  unfolding num_tcb_queues_def by eval
+
 
 (* Input abbreviations for API object types *)
 (* disambiguates names *)

--- a/proof/infoflow/ARM/Example_Valid_State.thy
+++ b/proof/infoflow/ARM/Example_Valid_State.thy
@@ -1820,32 +1820,31 @@ lemma Sys1_valid_initial_state_noenabled:
   assumes det_inv_s0: "det_inv KernelExit (cur_context s0_internal) s0_internal"
   shows "valid_initial_state_noenabled det_inv utf s0_internal Sys1PAS timer_irq s0_context"
   apply (unfold_locales, simp_all only: pasMaySendIrqs_Sys1PAS)
-                      apply (insert det_inv_invariant)[9]
-                      apply (erule(2) invariant_over_ADT_if.det_inv_abs_state)
-                     apply ((erule invariant_over_ADT_if.det_inv_abs_state
-                                   invariant_over_ADT_if.check_active_irq_if_Idle_det_inv
-                                   invariant_over_ADT_if.check_active_irq_if_User_det_inv
-                                   invariant_over_ADT_if.do_user_op_if_det_inv
-                                   invariant_over_ADT_if.handle_preemption_if_det_inv
-                                   invariant_over_ADT_if.kernel_entry_if_Interrupt_det_inv
-                                   invariant_over_ADT_if.kernel_entry_if_det_inv
-                                   invariant_over_ADT_if.kernel_exit_if_det_inv
-                                   invariant_over_ADT_if.schedule_if_det_inv)+)[8]
-             apply (rule Sys1_pas_cur_domain)
-            apply (rule Sys1_pas_wellformed_noninterference)
-           apply (simp only: einvs_s0)
-           apply (simp add: Sys1_current_subject_idemp)
-           apply (simp add: only_timer_irq_inv_s0 silc_inv_s0 Sys1_pas_cur_domain
-                            domain_sep_inv_s0 Sys1_pas_refined Sys1_guarded_pas_domain
-                            idle_equiv_refl)
-           apply (clarsimp simp: obj_valid_pdpt_kh0 valid_domain_list_2_def s0_internal_def exst0_def)
-          apply (simp add: det_inv_s0)
-         apply (simp add: s0_internal_def exst0_def)
-        apply (simp add: ct_in_state_def st_tcb_at_tcb_states_of_state_eq
-                         identity_eq[symmetric] tcb_states_of_state_s0)
-        apply (simp add: s0_ptr_defs s0_internal_def)
-       apply (simp add: s0_internal_def exst0_def)
-      apply (simp add: num_domains_def)
+                     apply (insert det_inv_invariant)[9]
+                     apply (erule(2) invariant_over_ADT_if.det_inv_abs_state)
+                    apply ((erule invariant_over_ADT_if.det_inv_abs_state
+                                  invariant_over_ADT_if.check_active_irq_if_Idle_det_inv
+                                  invariant_over_ADT_if.check_active_irq_if_User_det_inv
+                                  invariant_over_ADT_if.do_user_op_if_det_inv
+                                  invariant_over_ADT_if.handle_preemption_if_det_inv
+                                  invariant_over_ADT_if.kernel_entry_if_Interrupt_det_inv
+                                  invariant_over_ADT_if.kernel_entry_if_det_inv
+                                  invariant_over_ADT_if.kernel_exit_if_det_inv
+                                  invariant_over_ADT_if.schedule_if_det_inv)+)[8]
+            apply (rule Sys1_pas_cur_domain)
+           apply (rule Sys1_pas_wellformed_noninterference)
+          apply (simp only: einvs_s0)
+          apply (simp add: Sys1_current_subject_idemp)
+          apply (simp add: only_timer_irq_inv_s0 silc_inv_s0 Sys1_pas_cur_domain
+                           domain_sep_inv_s0 Sys1_pas_refined Sys1_guarded_pas_domain
+                           idle_equiv_refl)
+          apply (clarsimp simp: obj_valid_pdpt_kh0 valid_domain_list_2_def s0_internal_def exst0_def)
+         apply (simp add: det_inv_s0)
+        apply (simp add: s0_internal_def exst0_def)
+       apply (simp add: ct_in_state_def st_tcb_at_tcb_states_of_state_eq
+                        identity_eq[symmetric] tcb_states_of_state_s0)
+       apply (simp add: s0_ptr_defs s0_internal_def)
+      apply (simp add: s0_internal_def exst0_def)
      apply (rule utf_det)
     apply (rule utf_non_empty)
    apply (rule utf_non_interrupt)

--- a/proof/infoflow/RISCV64/Example_Valid_State.thy
+++ b/proof/infoflow/RISCV64/Example_Valid_State.thy
@@ -2042,21 +2042,20 @@ lemma Sys1_valid_initial_state_noenabled:
                                    invariant_over_ADT_if.kernel_entry_if_det_inv
                                    invariant_over_ADT_if.kernel_exit_if_det_inv
                                    invariant_over_ADT_if.schedule_if_det_inv)+)[8]
-             apply (rule Sys1_pas_cur_domain)
-            apply (rule Sys1_pas_wellformed_noninterference)
-           apply (simp only: einvs_s0)
-           apply (simp add: Sys1_current_subject_idemp)
-           apply (simp add: only_timer_irq_inv_s0 silc_inv_s0 Sys1_pas_cur_domain
-                            domain_sep_inv_s0 Sys1_pas_refined Sys1_guarded_pas_domain
-                            idle_equiv_refl)
-           apply (clarsimp simp:  valid_domain_list_2_def s0_internal_def exst0_def)
-          apply (simp add: det_inv_s0)
-         apply (simp add: s0_internal_def exst0_def)
-        apply (simp add: ct_in_state_def st_tcb_at_tcb_states_of_state_eq
-                         identity_eq[symmetric] tcb_states_of_state_s0)
-        apply (simp add: s0_ptr_defs s0_internal_def)
-       apply (simp add: s0_internal_def exst0_def)
-      apply (simp add: num_domains_def)
+            apply (rule Sys1_pas_cur_domain)
+           apply (rule Sys1_pas_wellformed_noninterference)
+          apply (simp only: einvs_s0)
+          apply (simp add: Sys1_current_subject_idemp)
+          apply (simp add: only_timer_irq_inv_s0 silc_inv_s0 Sys1_pas_cur_domain
+                           domain_sep_inv_s0 Sys1_pas_refined Sys1_guarded_pas_domain
+                           idle_equiv_refl)
+          apply (clarsimp simp: valid_domain_list_2_def s0_internal_def exst0_def)
+         apply (simp add: det_inv_s0)
+        apply (simp add: s0_internal_def exst0_def)
+       apply (simp add: ct_in_state_def st_tcb_at_tcb_states_of_state_eq
+                        identity_eq[symmetric] tcb_states_of_state_s0)
+       apply (simp add: s0_ptr_defs s0_internal_def)
+      apply (simp add: s0_internal_def exst0_def)
      apply (rule utf_det)
     apply (rule utf_non_empty)
    apply (rule utf_non_interrupt)

--- a/proof/infoflow/Scheduler_IF.thy
+++ b/proof/infoflow/Scheduler_IF.thy
@@ -1939,7 +1939,7 @@ lemma timer_tick_snippit:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows "reads_respects_scheduler aag l (pas_refined aag and valid_queues and valid_etcbs
                                                          and valid_sched_action)
-                                 (when (Suc 0 < num_domains)
+                                 (when (Suc 0 < numDomains)
                                     (do x \<leftarrow> dec_domain_time;
                                         dom_time \<leftarrow> gets domain_time;
                                         when (dom_time = 0) reschedule_required

--- a/proof/infoflow/refine/ARM/Example_Valid_StateH.thy
+++ b/proof/infoflow/refine/ARM/Example_Valid_StateH.thy
@@ -2141,18 +2141,22 @@ lemma valid_caps_s0H[simp]:
           rule pspace_distinctD'[OF _ s0H_pspace_distinct', simplified s0H_internal_def],
           simp)+
 
+text \<open>We can only instantiate our example state (featuring high and low domains) if the number
+  of configured domains is > 1, i.e. that maxDomain is 1 or greater. When seL4 is configured for a
+  single domain only, none of the state instantiation proofs below are relevant.\<close>
+
 lemma s0H_valid_objs':
-  "valid_objs' s0H_internal"
+  "1 \<le> maxDomain \<Longrightarrow> valid_objs' s0H_internal"
   supply objBits_defs[simp]
   apply (clarsimp simp: valid_objs'_def ran_def)
   apply (drule kh0H_SomeD)
   apply (elim disjE)
                 apply clarsimp
                apply (clarsimp simp: valid_obj'_def valid_tcb'_def kh0H_obj_def valid_tcb_state'_def
-                                     default_domain_def maxDomain_def numDomains_def minBound_word
+                                     default_domain_def minBound_word
                                      default_priority_def tcb_cte_cases_def)
               apply (clarsimp simp: valid_obj'_def valid_tcb'_def kh0H_obj_def valid_tcb_state'_def
-                                    High_domain_def maxDomain_def numDomains_def minBound_word
+                                    High_domain_def minBound_word
                                     High_mcp_def High_prio_def maxPriority_def numPriorities_def
                                     tcb_cte_cases_def High_capsH_def obj_at'_def projectKO_eq
                                     project_inject)
@@ -2161,7 +2165,7 @@ lemma s0H_valid_objs':
               apply (rule pspace_distinctD'[OF _ s0H_pspace_distinct'])
               apply (simp add: ntfnH_def)
              apply (clarsimp simp: valid_obj'_def valid_tcb'_def kh0H_obj_def valid_tcb_state'_def
-                                   Low_domain_def maxDomain_def numDomains_def minBound_word
+                                   Low_domain_def minBound_word
                                    Low_mcp_def Low_prio_def maxPriority_def numPriorities_def
                                    tcb_cte_cases_def Low_capsH_def)
             apply (clarsimp simp: valid_obj'_def ntfnH_def valid_ntfn'_def obj_at'_def projectKO_eq
@@ -2618,7 +2622,9 @@ lemma mdb_nextI:
 
 lemma s0H_valid_pspace':
   notes pdeBits_def[simp] pteBits_def[simp] objBits_defs[simp]
+  assumes "1 \<le> maxDomain"
   shows "valid_pspace' s0H_internal"
+  using assms
   supply option.case_cong[cong] if_cong[cong]
   apply (clarsimp simp: valid_pspace'_def s0H_pspace_distinct' s0H_valid_objs')
   apply (intro conjI)
@@ -2792,9 +2798,10 @@ axiomatization  where
 context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma s0H_invs:
+  assumes "1 \<le> maxDomain"
   notes pdeBits_def[simp] pteBits_def[simp] objBits_defs[simp]
-  shows
-  "invs' s0H_internal"
+  shows "invs' s0H_internal"
+  using assms
   supply option.case_cong[cong] if_cong[cong]
   apply (clarsimp simp: invs'_def valid_state'_def s0H_valid_pspace')
   apply (rule conjI)
@@ -3031,7 +3038,7 @@ lemma s0H_invs:
   (* unfold s0H_internal for remaining goals *)
   apply (clarsimp simp: s0H_internal_def cteCaps_of_def
                         untyped_ranges_zero_inv_def
-                        maxDomain_def numDomains_def dschDomain_def dschLength_def)
+                        dschDomain_def dschLength_def)
   apply (clarsimp simp: newKernelState_def newKSDomSched)
   apply (clarsimp simp: cur_tcb'_def obj_at'_def projectKO_eq project_inject s0H_internal_def objBitsKO_def s0_ptrs_aligned)
   apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct', simplified s0H_internal_def])
@@ -3237,7 +3244,8 @@ lemma subtree_node_Some:
   "m \<turnstile> a \<rightarrow> b \<Longrightarrow> m a \<noteq> None"
   by (erule subtree.cases) (auto simp: parentOf_def)
 
-lemma s0_srel: "(s0_internal, s0H_internal) \<in> state_relation"
+lemma s0_srel:
+  "1 \<le> maxDomain \<Longrightarrow> (s0_internal, s0H_internal) \<in> state_relation"
   apply (simp add: state_relation_def)
   apply (intro conjI)
                    apply (simp add: s0_pspace_rel)
@@ -3315,7 +3323,8 @@ lemma s0_srel: "(s0_internal, s0H_internal) \<in> state_relation"
               apply (drule subtree_mdb_next)
               apply (case_tac "x = 0")
                apply (cut_tac s0H_valid_pspace')
-               apply (simp add: valid_pspace'_def valid_mdb'_def valid_mdb_ctes_def parentOf_def isMDBParentOf_def kh0H_all_obj_def')
+                apply (simp add: valid_pspace'_def valid_mdb'_def valid_mdb_ctes_def parentOf_def isMDBParentOf_def kh0H_all_obj_def')
+               apply simp
               apply (clarsimp simp: mdb_next_trancl_s0H)
               apply (elim disjE, (clarsimp simp: parentOf_def isMDBParentOf_def kh0H_all_obj_def')+)[1]
              apply (clarsimp simp: cdt_list_relation_def s0_internal_def exst0_def split: option.splits)
@@ -3331,9 +3340,9 @@ lemma s0_srel: "(s0_internal, s0H_internal) \<in> state_relation"
             apply clarsimp
             apply (elim disjE)
                            apply (clarsimp simp: cte_map_def s0H_internal_def s0_internal_def kh0H_all_obj_def' cte_level_bits_def split: if_split_asm)+
-                apply (clarsimp simp: tcb_cnode_index_def ucast_bl[symmetric] Low_tcb_cte_def Low_tcbH_def High_tcb_cte_def High_tcbH_def)
-               apply ((clarsimp simp: cte_map_def' s0H_internal_def s0_internal_def,
-                      clarsimp simp: tcb_cnode_index_def ucast_bl[symmetric] Low_tcb_cte_def Low_tcbH_def High_tcb_cte_def High_tcbH_def)+)[5]
+                 apply (clarsimp simp: tcb_cnode_index_def ucast_bl[symmetric] Low_tcb_cte_def Low_tcbH_def High_tcb_cte_def High_tcbH_def)
+                apply ((clarsimp simp: cte_map_def' s0H_internal_def s0_internal_def,
+                       clarsimp simp: tcb_cnode_index_def ucast_bl[symmetric] Low_tcb_cte_def Low_tcbH_def High_tcb_cte_def High_tcbH_def)+)[5]
            apply (clarsimp simp: s0_internal_def s0H_internal_def arch_state_relation_def arch_state0_def arch_state0H_def)
           apply (clarsimp simp: s0_internal_def exst0_def s0H_internal_def interrupt_state_relation_def irq_state_relation_def)
          apply (clarsimp simp: s0_internal_def exst0_def s0H_internal_def)+
@@ -3343,7 +3352,7 @@ definition
   "s0H \<equiv> ((if ct_idle' s0H_internal then idle_context s0_internal else s0_context,s0H_internal),KernelExit)"
 
 lemma step_restrict_s0:
-  "step_restrict s0"
+  "1 \<le> maxDomain \<Longrightarrow> step_restrict s0"
   supply option.case_cong[cong] if_cong[cong]
   apply (clarsimp simp: step_restrict_def has_srel_state_def)
   apply (rule_tac x="fst (fst s0H)" in exI)
@@ -3354,11 +3363,9 @@ lemma step_restrict_s0:
    apply (clarsimp split: if_split_asm)
    apply (rule conjI)
     apply clarsimp
-    apply (drule ct_idle'_related[OF s0_srel s0H_invs])
-    apply simp
+    apply (frule ct_idle'_related[OF s0_srel s0H_invs]; solves simp)
    apply clarsimp
-   apply (drule ct_idle_related[OF s0_srel])
-   apply simp
+   apply (drule ct_idle_related[OF s0_srel]; simp)
   apply (clarsimp simp: full_invs_if'_def s0H_invs)
   apply (rule conjI)
    apply (simp only: ex_abs_def)
@@ -3384,6 +3391,7 @@ lemma step_restrict_s0:
   done
 
 lemma Sys1_valid_initial_state_noenabled:
+  assumes domains: "1 \<le> maxDomain"
   assumes utf_det: "\<forall>pl pr pxn tc ms s. det_inv InUserMode tc s \<and> einvs s \<and> context_matches_state pl pr pxn ms s \<and> ct_running s
                    \<longrightarrow> (\<exists>x. utf (cur_thread s) pl pr pxn (tc, ms) = {x})"
   assumes utf_non_empty: "\<forall>t pl pr pxn tc ms. utf t pl pr pxn (tc, ms) \<noteq> {}"
@@ -3391,7 +3399,10 @@ lemma Sys1_valid_initial_state_noenabled:
   assumes det_inv_invariant: "invariant_over_ADT_if det_inv utf"
   assumes det_inv_s0: "det_inv KernelExit (cur_context s0_internal) s0_internal"
   shows "valid_initial_state_noenabled det_inv utf s0_internal Sys1PAS timer_irq s0_context"
-  by (rule Sys1_valid_initial_state_noenabled[OF step_restrict_s0 utf_det utf_non_empty utf_non_interrupt det_inv_invariant det_inv_s0])
+  by (rule Sys1_valid_initial_state_noenabled[OF step_restrict_s0 utf_det utf_non_empty
+                                                 utf_non_interrupt det_inv_invariant det_inv_s0
+                                                 ],
+      rule domains)
 
 end
 

--- a/proof/infoflow/refine/RISCV64/Example_Valid_StateH.thy
+++ b/proof/infoflow/refine/RISCV64/Example_Valid_StateH.thy
@@ -2422,9 +2422,12 @@ lemma valid_caps_s0H[simp]:
       simp add: objBitsKO_def s0_ptrs_aligned mask_def,
       rule pspace_distinctD'[OF _ s0H_pspace_distinct', simplified s0H_internal_def], simp)+
 
+text \<open>We can only instantiate our example state (featuring high and low domains) if the number
+  of configured domains is > 1, i.e. that maxDomain is 1 or greater. When seL4 is configured for a
+  single domain only, none of the state instantiation proofs below are relevant.\<close>
 
 lemma s0H_valid_objs':
-  "valid_objs' s0H_internal"
+  "1 \<le> maxDomain \<Longrightarrow> valid_objs' s0H_internal"
   supply objBits_defs[simp]
   apply (clarsimp simp: valid_objs'_def ran_def)
   apply (drule kh0H_SomeD)
@@ -2434,18 +2437,18 @@ lemma s0H_valid_objs':
                    apply (clarsimp simp: is_aligned_def s0_ptr_defs objBitsKO_def)
                   apply (clarsimp simp: pspace_distinctD'[OF _ s0H_pspace_distinct'])
                  apply (clarsimp simp: valid_obj'_def valid_tcb'_def valid_tcb_state'_def
-                                       Low_domain_def maxDomain_def numDomains_def minBound_word
+                                       Low_domain_def minBound_word
                                        Low_mcp_def Low_prio_def maxPriority_def numPriorities_def
                                        tcb_cte_cases_def Low_capsH_def kh0H_obj_def)
                 apply (clarsimp simp: valid_obj'_def valid_tcb'_def  valid_tcb_state'_def
-                                      High_domain_def maxDomain_def numDomains_def minBound_word
+                                      High_domain_def minBound_word
                                       High_mcp_def High_prio_def maxPriority_def numPriorities_def
                                       tcb_cte_cases_def High_capsH_def obj_at'_def kh0H_obj_def)
                 apply (rule conjI)
                  apply (simp add: is_aligned_def s0_ptr_defs objBitsKO_def)
                 apply (clarsimp simp: ntfnH_def pspace_distinctD'[OF _ s0H_pspace_distinct'])
                apply (clarsimp simp: valid_obj'_def valid_tcb'_def kh0H_obj_def valid_tcb_state'_def
-                                     default_domain_def maxDomain_def numDomains_def minBound_word
+                                     default_domain_def minBound_word
                                      default_priority_def tcb_cte_cases_def)
               defer 2
               apply (auto simp: is_aligned_def addrFromPPtr_def ptrFromPAddr_def pptrBaseOffset_def
@@ -3027,7 +3030,9 @@ lemma mdb_nextI:
 
 lemma s0H_valid_pspace':
   notes pteBits_def[simp] objBits_defs[simp]
+  assumes "1 \<le> maxDomain"
   shows "valid_pspace' s0H_internal"
+  using assms
   supply option.case_cong[cong] if_cong[cong]
   apply (clarsimp simp: valid_pspace'_def s0H_pspace_distinct' s0H_valid_objs')
   apply (intro conjI)
@@ -3237,9 +3242,10 @@ lemma valid_arch_state_s0H:
   done
 
 lemma s0H_invs:
+  assumes "1 \<le> maxDomain"
   notes pteBits_def[simp] objBits_defs[simp]
-  shows
-  "invs' s0H_internal"
+  shows "invs' s0H_internal"
+  using assms
   supply option.case_cong[cong] if_cong[cong]
   apply (clarsimp simp: invs'_def valid_state'_def s0H_valid_pspace')
   apply (rule conjI)
@@ -3431,7 +3437,7 @@ lemma s0H_invs:
   apply (rule conjI)
    apply (clarsimp simp: kdr_pspace_domain_valid) (* use axiomatization for now *)
   apply (clarsimp simp: s0H_internal_def cteCaps_of_def untyped_ranges_zero_inv_def
-                        maxDomain_def numDomains_def dschDomain_def dschLength_def)
+                        dschDomain_def dschLength_def)
   apply (clarsimp simp: newKernelState_def newKSDomSched)
   apply (clarsimp simp: cur_tcb'_def obj_at'_def  s0H_internal_def objBitsKO_def s0_ptrs_aligned)
   apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct', simplified s0H_internal_def])
@@ -3637,7 +3643,8 @@ lemma subtree_node_Some:
   "m \<turnstile> a \<rightarrow> b \<Longrightarrow> m a \<noteq> None"
   by (erule subtree.cases) (auto simp: parentOf_def)
 
-lemma s0_srel: "(s0_internal, s0H_internal) \<in> state_relation"
+lemma s0_srel:
+  "1 \<le> maxDomain \<Longrightarrow> (s0_internal, s0H_internal) \<in> state_relation"
   apply (simp add: state_relation_def)
   apply (intro conjI)
                    apply (simp add: s0_pspace_rel)
@@ -3717,8 +3724,9 @@ lemma s0_srel: "(s0_internal, s0H_internal) \<in> state_relation"
               apply (drule subtree_mdb_next)
               apply (case_tac "x = 0")
                apply (cut_tac s0H_valid_pspace')
-               apply (simp add: valid_pspace'_def valid_mdb'_def valid_mdb_ctes_def
-                                parentOf_def isMDBParentOf_def kh0H_all_obj_def')
+                apply (simp add: valid_pspace'_def valid_mdb'_def valid_mdb_ctes_def
+                                 parentOf_def isMDBParentOf_def kh0H_all_obj_def')
+               apply simp
               apply (clarsimp simp: mdb_next_trancl_s0H)
               apply (elim disjE, (clarsimp simp: parentOf_def isMDBParentOf_def kh0H_all_obj_def')+)[1]
              apply (clarsimp simp: cdt_list_relation_def s0_internal_def exst0_def split: option.splits)
@@ -3763,7 +3771,7 @@ definition
   "s0H \<equiv> ((if ct_idle' s0H_internal then idle_context s0_internal else s0_context, s0H_internal), KernelExit)"
 
 lemma step_restrict_s0:
-  "step_restrict s0"
+  "1 \<le> maxDomain \<Longrightarrow> step_restrict s0"
   supply option.case_cong[cong] if_cong[cong]
   apply (clarsimp simp: step_restrict_def has_srel_state_def)
   apply (rule_tac x="fst (fst s0H)" in exI)
@@ -3774,11 +3782,9 @@ lemma step_restrict_s0:
    apply (clarsimp split: if_split_asm)
    apply (rule conjI)
     apply clarsimp
-    apply (drule ct_idle'_related[OF s0_srel s0H_invs])
-    apply simp
+    apply (frule ct_idle'_related[OF s0_srel s0H_invs]; solves simp)
    apply clarsimp
-   apply (drule ct_idle_related[OF s0_srel])
-   apply simp
+   apply (drule ct_idle_related[OF s0_srel]; simp)
   apply (clarsimp simp: full_invs_if'_def s0H_invs)
   apply (rule conjI)
    apply (simp only: ex_abs_def)
@@ -3792,6 +3798,7 @@ lemma step_restrict_s0:
   done
 
 lemma Sys1_valid_initial_state_noenabled:
+  assumes domains: "1 \<le> maxDomain"
   assumes utf_det: "\<forall>pl pr pxn tc ms s. det_inv InUserMode tc s \<and> einvs s \<and> context_matches_state pl pr pxn ms s \<and> ct_running s
                                         \<longrightarrow> (\<exists>x. utf (cur_thread s) pl pr pxn (tc, ms) = {x})"
   assumes utf_non_empty: "\<forall>t pl pr pxn tc ms. utf t pl pr pxn (tc, ms) \<noteq> {}"
@@ -3799,7 +3806,10 @@ lemma Sys1_valid_initial_state_noenabled:
   assumes det_inv_invariant: "invariant_over_ADT_if det_inv utf"
   assumes det_inv_s0: "det_inv KernelExit (cur_context s0_internal) s0_internal"
   shows "valid_initial_state_noenabled det_inv utf s0_internal Sys1PAS timer_irq s0_context"
-  by (rule Sys1_valid_initial_state_noenabled[OF step_restrict_s0 utf_det utf_non_empty utf_non_interrupt det_inv_invariant det_inv_s0])
+  by (rule Sys1_valid_initial_state_noenabled[OF step_restrict_s0 utf_det utf_non_empty
+                                                 utf_non_interrupt det_inv_invariant det_inv_s0
+                                                 ],
+      rule domains)
 
 end
 

--- a/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
@@ -56,25 +56,39 @@ crunch domain_time_inv [wp, DetSchedDomainTime_AI_assms]: arch_perform_invocatio
 crunch domain_list_inv [wp, DetSchedDomainTime_AI_assms]: arch_perform_invocation "\<lambda>s. P (domain_list s)"
   (wp: crunch_wps check_cap_inv)
 
+lemma timer_tick_valid_domain_time:
+  "\<lbrace> \<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>
+   timer_tick
+   \<lbrace>\<lambda>x s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>" (is "\<lbrace> ?dtnot0 \<rbrace> _ \<lbrace> _ \<rbrace>")
+  unfolding timer_tick_def
+  supply if_split[split del]
+  supply ethread_get_wp[wp del]
+  supply if_apply_def2[simp]
+  apply (wpsimp
+           wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
+               (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
+                  postcondition once we hit thread_set_time_slice *)
+               hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+                                and a="thread_set_time_slice t ts" for X t ts]
+               hoare_drop_imp[where f="ethread_get t f" for t f])
+  apply fastforce
+  done
+
 lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
-  "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace> handle_interrupt i
-   \<lbrace>\<lambda>rv s.  domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread \<rbrace>"
-   apply (unfold handle_interrupt_def)
-   apply (case_tac "maxIRQ < i"; simp)
-    subgoal by (wp hoare_false_imp, simp)
-   apply (rule hoare_pre)
-    apply (wp do_machine_op_exst | simp add: arch_mask_irq_signal_def | wpc)+
-       apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
-       apply wp
-      apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
-      apply wp+
-     apply simp (* dxo_eq *)
-     apply (clarsimp simp: timer_tick_def num_domains_def)
-     apply (wp reschedule_required_valid_domain_time
-           | simp add: handle_reserved_irq_def
-           | wp (once) hoare_drop_imp)+
-    apply clarsimp
-   done
+  "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>
+   handle_interrupt i
+   \<lbrace>\<lambda>rv s.  domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread \<rbrace>" (is "\<lbrace> ?dtnot0 \<rbrace> _ \<lbrace> _ \<rbrace>")
+  unfolding handle_interrupt_def
+  apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
+  apply clarsimp
+  apply (wpsimp simp: arch_mask_irq_signal_def)
+        apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply wpsimp
+       apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+      apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
+     apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+   apply wpsimp+
+  done
 
 crunch domain_time_inv [wp, DetSchedDomainTime_AI_assms]: handle_reserved_irq "\<lambda>s. P (domain_time s)"
   (wp: crunch_wps mapM_wp subset_refl simp: crunch_simps)

--- a/proof/invariant-abstract/ARM_HYP/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDetSchedDomainTime_AI.thy
@@ -105,24 +105,45 @@ lemma handle_reserved_irq_valid_domain_time:
   unfolding handle_reserved_irq_def
   by (wpsimp wp: vgic_maintenance_valid_domain_time vppi_event_valid_domain_time)
 
+lemma timer_tick_valid_domain_time:
+  "\<lbrace> \<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>
+   timer_tick
+   \<lbrace>\<lambda>x s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>" (is "\<lbrace> ?dtnot0 \<rbrace> _ \<lbrace> _ \<rbrace>")
+  unfolding timer_tick_def
+  supply if_split[split del]
+  supply ethread_get_wp[wp del]
+  supply if_apply_def2[simp]
+  apply (wpsimp
+           wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
+               (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
+                  postcondition once we hit thread_set_time_slice *)
+               hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+                                and a="thread_set_time_slice t ts" for X t ts]
+               hoare_drop_imp[where f="ethread_get t f" for t f])
+  apply fastforce
+  done
+
 lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
-  "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace> handle_interrupt i
-   \<lbrace>\<lambda>rv s.  domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread \<rbrace>"
-   apply (unfold handle_interrupt_def)
-   apply (case_tac "maxIRQ < i"; simp)
-    subgoal by (wp hoare_false_imp, simp)
-   apply (rule hoare_pre)
-    apply (wp do_machine_op_exst | simp add: arch_mask_irq_signal_def | wpc)+
-       apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
-       apply wp
-      apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
-      apply wp+
-     apply simp (* dxo_eq *)
-     apply (clarsimp simp: timer_tick_def num_domains_def)
-     apply (wp reschedule_required_valid_domain_time handle_reserved_irq_valid_domain_time
-           | simp
-           | wp (once) hoare_drop_imp)+
-   done
+  "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>
+   handle_interrupt i
+   \<lbrace>\<lambda>rv s.  domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread \<rbrace>" (is "\<lbrace> ?dtnot0 \<rbrace> _ \<lbrace> _ \<rbrace>")
+  unfolding handle_interrupt_def
+  supply if_split[split del]
+  supply if_apply_def2[simp]
+  apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
+  apply clarsimp
+  apply (wpsimp simp: arch_mask_irq_signal_def)
+        apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply wpsimp
+       apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+       apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
+     apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="vgic_maintenance"], fastforce)
+     apply wpsimp+
+     apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="vppi_event i" for i], fastforce)
+     apply wpsimp+
+   apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+   apply wpsimp+
+  done
 
 
 end

--- a/proof/invariant-abstract/DetSchedAux_AI.thy
+++ b/proof/invariant-abstract/DetSchedAux_AI.thy
@@ -341,6 +341,8 @@ crunch valid_sched_action[wp]: create_cap,cap_insert valid_sched_action
 crunch valid_sched[wp]: create_cap,cap_insert valid_sched
   (wp: valid_sched_lift)
 
+crunch scheduler_action [wp]: thread_set_time_slice, dec_domain_time "\<lambda>s. P (scheduler_action s)"
+
 crunch inv[wp]: get_tcb_queue "\<lambda>s. P s"
 
 lemma ethread_get_when_wp:

--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -259,7 +259,7 @@ crunch domain_time_inv[wp]: do_user_op "(\<lambda>s. P (domain_time s))"
 context DetSchedDomainTime_AI begin
 
 crunch domain_time_inv[wp]:
-  get_cap, activate_thread, set_scheduler_action, tcb_sched_action
+  get_cap, activate_thread, set_scheduler_action, tcb_sched_action, thread_set_time_slice
   "\<lambda>s. P (domain_time s)"
 
 crunch domain_time_inv[wp]: guarded_switch_to "\<lambda>s. P (domain_time s)"
@@ -425,11 +425,16 @@ lemma schedule_domain_time_left:
   done
 end
 
+lemma reschedule_required_choose_new_thread[wp]:
+  "\<lbrace> \<top> \<rbrace> reschedule_required
+   \<lbrace>\<lambda>x s. scheduler_action s = choose_new_thread\<rbrace>"
+  unfolding reschedule_required_def set_scheduler_action_def
+  by (wp hoare_vcg_imp_lift | simp | wpc)+
+
 lemma reschedule_required_valid_domain_time:
   "\<lbrace> \<top> \<rbrace> reschedule_required
    \<lbrace>\<lambda>x s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
-  unfolding reschedule_required_def set_scheduler_action_def
-  by (wp hoare_vcg_imp_lift | simp | wpc)+
+  by (wpsimp wp: hoare_drop_imp reschedule_required_choose_new_thread)
 
 (* FIXME: move to where hoare_drop_imp is, add E/R variants etc *)
 lemma hoare_false_imp:

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedDomainTime_AI.thy
@@ -59,25 +59,39 @@ crunch domain_time_inv [wp, DetSchedDomainTime_AI_assms]: arch_perform_invocatio
 crunch domain_list_inv [wp, DetSchedDomainTime_AI_assms]: arch_perform_invocation "\<lambda>s. P (domain_list s)"
   (wp: crunch_wps check_cap_inv)
 
+lemma timer_tick_valid_domain_time:
+  "\<lbrace> \<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>
+   timer_tick
+   \<lbrace>\<lambda>x s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>" (is "\<lbrace> ?dtnot0 \<rbrace> _ \<lbrace> _ \<rbrace>")
+  unfolding timer_tick_def
+  supply if_split[split del]
+  supply ethread_get_wp[wp del]
+  supply if_apply_def2[simp]
+  apply (wpsimp
+           wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
+               (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
+                  postcondition once we hit thread_set_time_slice *)
+               hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+                                and a="thread_set_time_slice t ts" for X t ts]
+               hoare_drop_imp[where f="ethread_get t f" for t f])
+  apply fastforce
+  done
+
 lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
-  "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace> handle_interrupt i
-   \<lbrace>\<lambda>rv s.  domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread \<rbrace>"
-   apply (unfold handle_interrupt_def)
-   apply (case_tac "maxIRQ < i"; simp)
-    subgoal by (wp hoare_false_imp, simp)
-   apply (rule hoare_pre)
-    apply (wp do_machine_op_exst | simp add: arch_mask_irq_signal_def | wpc)+
-       apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
-       apply wp
-      apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
-      apply wp+
-     apply simp (* dxo_eq *)
-     apply (clarsimp simp: timer_tick_def num_domains_def)
-     apply (wp reschedule_required_valid_domain_time
-           | simp add: handle_reserved_irq_def
-           | wp (once) hoare_drop_imp)+
-    apply clarsimp
-   done
+  "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>
+   handle_interrupt i
+   \<lbrace>\<lambda>rv s.  domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread \<rbrace>" (is "\<lbrace> ?dtnot0 \<rbrace> _ \<lbrace> _ \<rbrace>")
+  unfolding handle_interrupt_def
+  apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
+  apply clarsimp
+  apply (wpsimp simp: arch_mask_irq_signal_def)
+        apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply wpsimp
+       apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+      apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
+     apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+   apply wpsimp+
+  done
 
 crunches handle_reserved_irq, arch_mask_irq_signal
   for domain_time_inv [wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"

--- a/proof/invariant-abstract/X64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetSchedDomainTime_AI.thy
@@ -69,25 +69,38 @@ crunch exst[wp]: do_machine_op "\<lambda>s. P (exst s)"
 
 crunch inv[wp]: get_irq_slot P
 
+lemma timer_tick_valid_domain_time:
+  "\<lbrace> \<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>
+   timer_tick
+   \<lbrace>\<lambda>x s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>" (is "\<lbrace> ?dtnot0 \<rbrace> _ \<lbrace> _ \<rbrace>")
+  unfolding timer_tick_def
+  supply if_split[split del]
+  supply ethread_get_wp[wp del]
+  supply if_apply_def2[simp]
+  apply (wpsimp
+           wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
+               (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
+                  postcondition once we hit thread_set_time_slice *)
+               hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+                                and a="thread_set_time_slice t ts" for X t ts]
+               hoare_drop_imp[where f="ethread_get t f" for t f])
+  apply fastforce
+  done
+
 lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
-  "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace> handle_interrupt i
-   \<lbrace>\<lambda>rv s.  domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread \<rbrace>"
-  apply (unfold handle_interrupt_def)
-  apply (case_tac "maxIRQ < i"; simp)
-    subgoal by (wp hoare_false_imp, simp)
-  apply (rule hoare_pre)
-   apply (wp do_machine_op_exst | simp add: arch_mask_irq_signal_def | wpc)+
-      apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
-      apply wp
-     apply (wp get_cap_wp)
-     apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
-     apply wp+
-    apply simp (* dxo_eq *)
-    apply (clarsimp simp: timer_tick_def num_domains_def)
-    apply (wp reschedule_required_valid_domain_time
-          | simp add: handle_reserved_irq_def
-          | wp (once) hoare_drop_imp)+
-   apply clarsimp
+  "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>
+   handle_interrupt i
+   \<lbrace>\<lambda>rv s.  domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread \<rbrace>" (is "\<lbrace> ?dtnot0 \<rbrace> _ \<lbrace> _ \<rbrace>")
+  unfolding handle_interrupt_def
+  apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
+  apply clarsimp
+  apply (wpsimp simp: arch_mask_irq_signal_def)
+        apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply wpsimp
+       apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+      apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
+     apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+   apply wpsimp+
   done
 
 end

--- a/proof/refine/ARM/Interrupt_R.thy
+++ b/proof/refine/ARM/Interrupt_R.thy
@@ -607,11 +607,6 @@ lemma getIRQState_prop:
   apply simp
   done
 
-lemma num_domains[simp]:
-  "num_domains = numDomains"
-  apply(simp add: num_domains_def numDomains_def)
-  done
-
 lemma decDomainTime_corres:
   "corres dc \<top> \<top> dec_domain_time decDomainTime"
   apply (simp add:dec_domain_time_def corres_underlying_def
@@ -830,17 +825,16 @@ crunch cur_tcb'[wp]: tcbSchedAppend cur_tcb'
 
 lemma timerTick_invs'[wp]:
   "\<lbrace>invs'\<rbrace> timerTick \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: numDomains_def timerTick_def)
-  apply (wp threadSet_invs_trivial threadSet_pred_tcb_no_state
-            rescheduleRequired_all_invs_but_ct_not_inQ
-            tcbSchedAppend_invs_but_ct_not_inQ'
-       | simp add: tcb_cte_cases_def numDomains_def
-       | wpc)+
-      apply (simp add:decDomainTime_def)
-      apply wp
-     apply simp
+  apply (simp add: timerTick_def)
+  apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state
+                    rescheduleRequired_all_invs_but_ct_not_inQ
+                    tcbSchedAppend_invs_but_ct_not_inQ'
+                simp: tcb_cte_cases_def)
      apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
      apply (clarsimp simp add:invs'_def valid_state'_def)
+      apply (simp add: decDomainTime_def)
+      apply wp
+     apply simp
      apply wpc
           apply (wp add: threadGet_wp threadSet_cur threadSet_timeslice_invs
                                rescheduleRequired_all_invs_but_ct_not_inQ
@@ -852,7 +846,7 @@ lemma timerTick_invs'[wp]:
                              threadSet_valid_objs' threadSet_timeslice_invs)+
        apply (wp threadGet_wp)
       apply (wp gts_wp')+
-  apply (clarsimp simp: invs'_def st_tcb_at'_def obj_at'_def valid_state'_def numDomains_def)
+  apply (clarsimp simp: invs'_def st_tcb_at'_def obj_at'_def valid_state'_def)
   done
 
 lemma resetTimer_invs'[wp]:

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -31,6 +31,21 @@ end
 
 end
 
+section "Relationship of Executable Spec to Kernel Configuration"
+
+text \<open>
+  Some values are set per kernel configuration (e.g. number of domains), but other related
+  values (e.g. maximum domain) are derived from storage constraints (e.g. bytes used).
+  To relate the two, we must look at the values of kernel configuration constants.
+  To allow the proofs to work for all permitted values of these constants, their definitions
+  should only be unfolded in this section, and the derived properties kept to a minimum.\<close>
+
+lemma le_maxDomain_eq_less_numDomains:
+  shows "x \<le> unat maxDomain \<longleftrightarrow> x < Kernel_Config.numDomains"
+        "y \<le> maxDomain \<longleftrightarrow> unat y < Kernel_Config.numDomains"
+  by (auto simp: Kernel_Config.numDomains_def maxDomain_def word_le_nat_alt)
+
+
 context begin interpretation Arch . (*FIXME: arch_split*)
 \<comment> \<open>---------------------------------------------------------------------------\<close>
 section "Invariants on Executable Spec"
@@ -3377,4 +3392,5 @@ end
 add_upd_simps "invs' (gsUntypedZeroRanges_update f s)"
   (obj_at'_real_def)
 declare upd_simps[simp]
+
 end

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -108,8 +108,7 @@ lemma valid_obj_makeObject_cte [simp]:
 lemma valid_obj_makeObject_tcb [simp]:
   "valid_obj' (KOTCB makeObject) s"
   unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def
-  by (clarsimp simp: makeObject_tcb makeObject_cte
-                     tcb_cte_cases_def maxDomain_def numDomains_def maxPriority_def numPriorities_def minBound_word)
+  by (clarsimp simp: makeObject_tcb makeObject_cte tcb_cte_cases_def minBound_word)
 
 lemma valid_obj_makeObject_endpoint [simp]:
   "valid_obj' (KOEndpoint makeObject) s"

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -1415,7 +1415,8 @@ lemma switchToIdleThread_curr_is_idle:
 
 lemma chooseThread_it[wp]:
   "\<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace> chooseThread \<lbrace>\<lambda>_ s. P (ksIdleThread s)\<rbrace>"
-  by (wp|clarsimp simp: chooseThread_def curDomain_def numDomains_def bitmap_fun_defs|assumption)+
+  supply if_split[split del]
+  by (wpsimp simp: chooseThread_def curDomain_def bitmap_fun_defs)
 
 lemma threadGet_inv [wp]: "\<lbrace>P\<rbrace> threadGet f t \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (simp add: threadGet_def)
@@ -1503,6 +1504,16 @@ abbreviation "enumPrio \<equiv> [0.e.maxPriority]"
 lemma curDomain_corres: "corres (=) \<top> \<top> (gets cur_domain) (curDomain)"
   by (simp add: curDomain_def state_relation_def)
 
+lemma curDomain_corres':
+  "corres (=) \<top> (\<lambda>s. ksCurDomain s \<le> maxDomain)
+    (gets cur_domain) (if 1 < numDomains then curDomain else return 0)"
+  apply (case_tac "1 < numDomains"; simp)
+   apply (rule corres_guard_imp[OF curDomain_corres]; solves simp)
+  (* if we have only one domain, then we are in it *)
+  apply (clarsimp simp: return_def simpler_gets_def bind_def maxDomain_def
+                        state_relation_def corres_underlying_def)
+  done
+
 lemma lookupBitmapPriority_Max_eqI:
   "\<lbrakk> valid_bitmapQ s ; bitmapQ_no_L1_orphans s ; ksReadyQueuesL1Bitmap s d \<noteq> 0 \<rbrakk>
    \<Longrightarrow> lookupBitmapPriority d s = (Max {prio. ksReadyQueues s (d, prio) \<noteq> []})"
@@ -1569,18 +1580,27 @@ lemma ksReadyQueuesL1Bitmap_st_tcb_at':
    apply simp
    done
 
+lemma curDomain_or_return_0:
+  "\<lbrakk> \<lbrace>P\<rbrace> curDomain \<lbrace>\<lambda>rv s. Q rv s \<rbrace>; \<And>s. P s \<Longrightarrow> ksCurDomain s \<le> maxDomain \<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace> if 1 < numDomains then curDomain else return 0 \<lbrace>\<lambda>rv s. Q rv s \<rbrace>"
+  apply (case_tac "1 < numDomains"; simp)
+  apply (simp add: valid_def curDomain_def simpler_gets_def return_def maxDomain_def)
+  done
+
+lemma invs_no_cicd_ksCurDomain_maxDomain':
+  "invs_no_cicd' s \<Longrightarrow> ksCurDomain s \<le> maxDomain"
+  unfolding invs_no_cicd'_def by simp
+
 lemma chooseThread_corres:
   "corres dc (invs and valid_sched) (invs_no_cicd')
      choose_thread chooseThread" (is "corres _ ?PREI ?PREH _ _")
 proof -
   show ?thesis
-  unfolding choose_thread_def chooseThread_def numDomains_def
-  apply (simp only: numDomains_def return_bind Let_def)
-  apply (simp cong: if_cong) (* clean up if 1 < numDomains *)
+  unfolding choose_thread_def chooseThread_def
+  apply (simp only: return_bind Let_def)
   apply (subst if_swap[where P="_ \<noteq> 0"]) (* put switchToIdleThread on first branch*)
-  apply (rule corres_name_pre)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ curDomain_corres])
+    apply (rule corres_split[OF curDomain_corres'])
       apply clarsimp
       apply (rule corres_split_deprecated[OF _ corres_gets_queues_getReadyQueuesL1Bitmap])
         apply (erule corres_if2[OF sym])
@@ -1603,15 +1623,17 @@ proof -
                apply (wp | clarsimp simp: getQueue_def getReadyQueuesL2Bitmap_def)+
       apply (clarsimp simp: if_apply_def2)
       apply (wp hoare_vcg_conj_lift hoare_vcg_imp_lift ksReadyQueuesL1Bitmap_return_wp)
-     apply (simp add: curDomain_def, wp)+
+     apply (wpsimp wp: curDomain_or_return_0 simp: curDomain_def)+
+    apply (fastforce simp: invs_no_cicd'_def)
    apply (clarsimp simp: valid_sched_def DetSchedInvs_AI.valid_queues_def max_non_empty_queue_def)
-   apply (erule_tac x="cur_domain sa" in allE)
-   apply (erule_tac x="Max {prio. ready_queues sa (cur_domain sa) prio \<noteq> []}" in allE)
-   apply (case_tac "ready_queues sa (cur_domain sa) (Max {prio. ready_queues sa (cur_domain sa) prio \<noteq> []})")
+   apply (erule_tac x="cur_domain s" in allE)
+   apply (erule_tac x="Max {prio. ready_queues s (cur_domain s) prio \<noteq> []}" in allE)
+   apply (case_tac "ready_queues s (cur_domain s) (Max {prio. ready_queues s (cur_domain s) prio \<noteq> []})")
     apply (clarsimp)
     apply (subgoal_tac
-             "ready_queues sa (cur_domain sa) (Max {prio. ready_queues sa (cur_domain sa) prio \<noteq> []}) \<noteq> []")
+             "ready_queues s (cur_domain s) (Max {prio. ready_queues s (cur_domain s) prio \<noteq> []}) \<noteq> []")
      apply (fastforce elim!: setcomp_Max_has_prop)+
+  apply (simp add: invs_no_cicd_ksCurDomain_maxDomain')
   apply (clarsimp dest!: invs_no_cicd'_queues)
   apply (fastforce intro: ksReadyQueuesL1Bitmap_st_tcb_at')
   done
@@ -2012,9 +2034,15 @@ proof -
   note switchToThread_invs_no_cicd'[wp del]
   note switchToThread_lookupBitmapPriority_wp[wp]
   note assert_wp[wp del]
+  note if_split[split del]
+
+  (* if we only have one domain, we are in it *)
+  have one_domain_case:
+    "\<And>s. \<lbrakk> invs_no_cicd' s; numDomains \<le> 1 \<rbrakk> \<Longrightarrow> ksCurDomain s = 0"
+    by (simp add: all_invs_but_ct_idle_or_in_cur_domain'_def maxDomain_def)
 
   show ?thesis
-    unfolding chooseThread_def Let_def numDomains_def curDomain_def
+    unfolding chooseThread_def Let_def curDomain_def
     apply (simp only: return_bind, simp)
     apply (rule hoare_seq_ext[where B="\<lambda>rv s. invs_no_cicd' s \<and> rv = ksCurDomain s"])
      apply (rule_tac B="\<lambda>rv s. invs_no_cicd' s \<and> curdom = ksCurDomain s \<and>
@@ -2038,7 +2066,7 @@ proof -
       apply (drule (3) lookupBitmapPriority_obj_at')
       apply normalise_obj_at'
       apply (fastforce simp: tcb_in_cur_domain'_def inQ_def elim: obj_at'_weaken)
-     apply (wp | simp add: bitmap_fun_defs curDomain_def)+
+     apply (wpsimp simp: bitmap_fun_defs curDomain_def one_domain_case)+
     done
 qed
 
@@ -2064,10 +2092,19 @@ proof -
   note switchToThread_invs_no_cicd'[wp del]
   note switchToThread_lookupBitmapPriority_wp[wp]
   note assert_wp[wp del]
+  note if_split[split del]
+
+  (* if we only have one domain, we are in it *)
+  have one_domain_case:
+    "\<And>s. \<lbrakk> invs_no_cicd' s; numDomains \<le> 1 \<rbrakk> \<Longrightarrow> ksCurDomain s = 0"
+    by (simp add: all_invs_but_ct_idle_or_in_cur_domain'_def maxDomain_def)
+
+  (* NOTE: do *not* unfold numDomains in the rest of the proof,
+           it should work for any number *)
 
   (* FIXME this is almost identical to the chooseThread_invs_no_cicd'_posts proof, can generalise? *)
   show ?thesis
-    unfolding chooseThread_def Let_def numDomains_def curDomain_def
+    unfolding chooseThread_def Let_def curDomain_def
     apply (simp only: return_bind, simp)
     apply (rule hoare_seq_ext[where B="\<lambda>rv s. invs_no_cicd' s \<and> rv = ksCurDomain s"])
      apply (rule_tac B="\<lambda>rv s. invs_no_cicd' s \<and> curdom = ksCurDomain s \<and>
@@ -2081,7 +2118,7 @@ proof -
       apply (wp assert_inv)
       apply (clarsimp dest!: invs_no_cicd'_queues simp: valid_queues_def)
       apply (fastforce elim: bitmapQ_from_bitmap_lookup simp: lookupBitmapPriority_def)
-     apply (wp | simp add: bitmap_fun_defs curDomain_def)+
+     apply (wpsimp simp: bitmap_fun_defs curDomain_def one_domain_case)+
     done
 qed
 
@@ -2156,7 +2193,8 @@ lemma chooseThread_nosch:
   "\<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace>
   chooseThread
   \<lbrace>\<lambda>rv s. P (ksSchedulerAction s)\<rbrace>"
-  unfolding chooseThread_def Let_def numDomains_def curDomain_def
+  unfolding chooseThread_def Let_def curDomain_def
+  supply if_split[split del]
   apply (simp only: return_bind, simp)
   apply (wp findM_inv | simp)+
   apply (case_tac queue)

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -606,7 +606,7 @@ lemma dec_dom_inv_wf[wp]:
   apply (simp add:not_le)
   apply (simp del: Word.of_nat_unat flip: ucast_nat_def)
   apply (rule word_of_nat_le)
-  apply (simp add:numDomains_def maxDomain_def)
+  apply (simp add: le_maxDomain_eq_less_numDomains)
   done
 
 lemma decode_inv_wf'[wp]:

--- a/proof/refine/ARM_HYP/Interrupt_R.thy
+++ b/proof/refine/ARM_HYP/Interrupt_R.thy
@@ -594,11 +594,6 @@ lemma getIRQState_prop:
   apply simp
   done
 
-lemma num_domains[simp]:
-  "num_domains = numDomains"
-  apply(simp add: num_domains_def numDomains_def)
-  done
-
 lemma decDomainTime_corres:
   "corres dc \<top> \<top> dec_domain_time decDomainTime"
   apply (simp add:dec_domain_time_def corres_underlying_def
@@ -1106,17 +1101,16 @@ crunch cur_tcb'[wp]: tcbSchedAppend cur_tcb'
 
 lemma timerTick_invs'[wp]:
   "\<lbrace>invs'\<rbrace> timerTick \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: numDomains_def timerTick_def)
-  apply (wp threadSet_invs_trivial threadSet_pred_tcb_no_state
-            rescheduleRequired_all_invs_but_ct_not_inQ
-            tcbSchedAppend_invs_but_ct_not_inQ'
-       | simp add: tcb_cte_cases_def numDomains_def
-       | wpc)+
-      apply (simp add:decDomainTime_def)
-      apply wp
-     apply simp
+  apply (simp add: timerTick_def)
+  apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state
+                    rescheduleRequired_all_invs_but_ct_not_inQ
+                    tcbSchedAppend_invs_but_ct_not_inQ'
+                simp: tcb_cte_cases_def)
      apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
      apply (clarsimp simp add:invs'_def valid_state'_def)
+      apply (simp add: decDomainTime_def)
+      apply wp
+     apply simp
      apply wpc
           apply (wp add: threadGet_wp threadSet_cur threadSet_timeslice_invs
                                rescheduleRequired_all_invs_but_ct_not_inQ
@@ -1128,7 +1122,7 @@ lemma timerTick_invs'[wp]:
                              threadSet_valid_objs' threadSet_timeslice_invs)+
        apply (wp threadGet_wp)
       apply (wp gts_wp')+
-  apply (clarsimp simp: invs'_def st_tcb_at'_def obj_at'_def valid_state'_def numDomains_def)
+  apply (clarsimp simp: invs'_def st_tcb_at'_def obj_at'_def valid_state'_def)
   done
 
 lemma resetTimer_invs'[wp]:

--- a/proof/refine/ARM_HYP/Invariants_H.thy
+++ b/proof/refine/ARM_HYP/Invariants_H.thy
@@ -31,6 +31,21 @@ end
 
 end
 
+section "Relationship of Executable Spec to Kernel Configuration"
+
+text \<open>
+  Some values are set per kernel configuration (e.g. number of domains), but other related
+  values (e.g. maximum domain) are derived from storage constraints (e.g. bytes used).
+  To relate the two, we must look at the values of kernel configuration constants.
+  To allow the proofs to work for all permitted values of these constants, their definitions
+  should only be unfolded in this section, and the derived properties kept to a minimum.\<close>
+
+lemma le_maxDomain_eq_less_numDomains:
+  shows "x \<le> unat maxDomain \<longleftrightarrow> x < Kernel_Config.numDomains"
+        "y \<le> maxDomain \<longleftrightarrow> unat y < Kernel_Config.numDomains"
+  by (auto simp: Kernel_Config.numDomains_def maxDomain_def word_le_nat_alt)
+
+
 context begin interpretation Arch . (*FIXME: arch_split*)
 \<comment> \<open>---------------------------------------------------------------------------\<close>
 section "Invariants on Executable Spec"

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -113,8 +113,7 @@ lemma valid_obj_makeObject_cte [simp]:
 lemma valid_obj_makeObject_tcb [simp]:
   "valid_obj' (KOTCB makeObject) s"
   unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def valid_arch_tcb'_def
-  by (clarsimp simp: makeObject_tcb makeObject_cte newArchTCB_def
-                     tcb_cte_cases_def maxDomain_def numDomains_def maxPriority_def numPriorities_def minBound_word)
+  by (clarsimp simp: makeObject_tcb makeObject_cte tcb_cte_cases_def minBound_word newArchTCB_def)
 
 lemma valid_obj_makeObject_endpoint [simp]:
   "valid_obj' (KOEndpoint makeObject) s"

--- a/proof/refine/ARM_HYP/Schedule_R.thy
+++ b/proof/refine/ARM_HYP/Schedule_R.thy
@@ -1565,7 +1565,8 @@ lemma switchToIdleThread_curr_is_idle:
 
 lemma chooseThread_it[wp]:
   "\<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace> chooseThread \<lbrace>\<lambda>_ s. P (ksIdleThread s)\<rbrace>"
-  by (wp|clarsimp simp: chooseThread_def curDomain_def numDomains_def bitmap_fun_defs|assumption)+
+  supply if_split[split del]
+  by (wpsimp simp: chooseThread_def curDomain_def bitmap_fun_defs)
 
 lemma threadGet_inv [wp]: "\<lbrace>P\<rbrace> threadGet f t \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (simp add: threadGet_def)
@@ -1679,6 +1680,16 @@ lemma enumPrio_word_div:
 lemma curDomain_corres: "corres (=) \<top> \<top> (gets cur_domain) (curDomain)"
   by (simp add: curDomain_def state_relation_def)
 
+lemma curDomain_corres':
+  "corres (=) \<top> (\<lambda>s. ksCurDomain s \<le> maxDomain)
+    (gets cur_domain) (if 1 < numDomains then curDomain else return 0)"
+  apply (case_tac "1 < numDomains"; simp)
+   apply (rule corres_guard_imp[OF curDomain_corres]; solves simp)
+  (* if we have only one domain, then we are in it *)
+  apply (clarsimp simp: return_def simpler_gets_def bind_def maxDomain_def
+                        state_relation_def corres_underlying_def)
+  done
+
 lemma lookupBitmapPriority_Max_eqI:
   "\<lbrakk> valid_bitmapQ s ; bitmapQ_no_L1_orphans s ; ksReadyQueuesL1Bitmap s d \<noteq> 0 \<rbrakk>
    \<Longrightarrow> lookupBitmapPriority d s = (Max {prio. ksReadyQueues s (d, prio) \<noteq> []})"
@@ -1745,18 +1756,27 @@ lemma ksReadyQueuesL1Bitmap_st_tcb_at':
    apply simp
    done
 
+lemma curDomain_or_return_0:
+  "\<lbrakk> \<lbrace>P\<rbrace> curDomain \<lbrace>\<lambda>rv s. Q rv s \<rbrace>; \<And>s. P s \<Longrightarrow> ksCurDomain s \<le> maxDomain \<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace> if 1 < numDomains then curDomain else return 0 \<lbrace>\<lambda>rv s. Q rv s \<rbrace>"
+  apply (case_tac "1 < numDomains"; simp)
+  apply (simp add: valid_def curDomain_def simpler_gets_def return_def maxDomain_def)
+  done
+
+lemma invs_no_cicd_ksCurDomain_maxDomain':
+  "invs_no_cicd' s \<Longrightarrow> ksCurDomain s \<le> maxDomain"
+  unfolding invs_no_cicd'_def by simp
+
 lemma chooseThread_corres:
   "corres dc (invs and valid_sched) (invs_no_cicd')
      choose_thread chooseThread" (is "corres _ ?PREI ?PREH _ _")
 proof -
   show ?thesis
-  unfolding choose_thread_def chooseThread_def numDomains_def
-  apply (simp only: numDomains_def return_bind Let_def)
-  apply (simp cong: if_cong) (* clean up if 1 < numDomains *)
+  unfolding choose_thread_def chooseThread_def
+  apply (simp only: return_bind Let_def)
   apply (subst if_swap[where P="_ \<noteq> 0"]) (* put switchToIdleThread on first branch*)
-  apply (rule corres_name_pre)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ curDomain_corres])
+    apply (rule corres_split[OF curDomain_corres'])
       apply clarsimp
       apply (rule corres_split_deprecated[OF _ corres_gets_queues_getReadyQueuesL1Bitmap])
         apply (erule corres_if2[OF sym])
@@ -1779,15 +1799,17 @@ proof -
                apply (wpsimp simp: getQueue_def getReadyQueuesL2Bitmap_def)+
       apply (clarsimp simp: if_apply_def2)
       apply (wp hoare_vcg_conj_lift hoare_vcg_imp_lift ksReadyQueuesL1Bitmap_return_wp)
-     apply (simp add: curDomain_def, wp)+
+     apply (wpsimp wp: curDomain_or_return_0 simp: curDomain_def)+
+    apply (fastforce simp: invs_no_cicd'_def)
    apply (clarsimp simp: valid_sched_def DetSchedInvs_AI.valid_queues_def max_non_empty_queue_def)
-   apply (erule_tac x="cur_domain sa" in allE)
-   apply (erule_tac x="Max {prio. ready_queues sa (cur_domain sa) prio \<noteq> []}" in allE)
-   apply (case_tac "ready_queues sa (cur_domain sa) (Max {prio. ready_queues sa (cur_domain sa) prio \<noteq> []})")
+   apply (erule_tac x="cur_domain s" in allE)
+   apply (erule_tac x="Max {prio. ready_queues s (cur_domain s) prio \<noteq> []}" in allE)
+   apply (case_tac "ready_queues s (cur_domain s) (Max {prio. ready_queues s (cur_domain s) prio \<noteq> []})")
     apply (clarsimp)
     apply (subgoal_tac
-             "ready_queues sa (cur_domain sa) (Max {prio. ready_queues sa (cur_domain sa) prio \<noteq> []}) \<noteq> []")
+             "ready_queues s (cur_domain s) (Max {prio. ready_queues s (cur_domain s) prio \<noteq> []}) \<noteq> []")
      apply (fastforce elim!: setcomp_Max_has_prop)+
+  apply (simp add: invs_no_cicd_ksCurDomain_maxDomain')
   apply (clarsimp dest!: invs_no_cicd'_queues)
   apply (fastforce intro: ksReadyQueuesL1Bitmap_st_tcb_at')
   done
@@ -2192,9 +2214,15 @@ proof -
   note switchToThread_invs_no_cicd'[wp del]
   note switchToThread_lookupBitmapPriority_wp[wp]
   note assert_wp[wp del]
+  note if_split[split del]
+
+  (* if we only have one domain, we are in it *)
+  have one_domain_case:
+    "\<And>s. \<lbrakk> invs_no_cicd' s; numDomains \<le> 1 \<rbrakk> \<Longrightarrow> ksCurDomain s = 0"
+    by (simp add: all_invs_but_ct_idle_or_in_cur_domain'_def maxDomain_def)
 
   show ?thesis
-    unfolding chooseThread_def Let_def numDomains_def curDomain_def
+    unfolding chooseThread_def Let_def curDomain_def
     apply (simp only: return_bind, simp)
     apply (rule hoare_seq_ext[where B="\<lambda>rv s. invs_no_cicd' s \<and> rv = ksCurDomain s"])
      apply (rule_tac B="\<lambda>rv s. invs_no_cicd' s \<and> curdom = ksCurDomain s \<and>
@@ -2218,7 +2246,7 @@ proof -
       apply (drule (3) lookupBitmapPriority_obj_at')
       apply normalise_obj_at'
       apply (fastforce simp: tcb_in_cur_domain'_def inQ_def elim: obj_at'_weaken)
-     apply (wp | simp add: bitmap_fun_defs curDomain_def)+
+     apply (wpsimp simp: bitmap_fun_defs curDomain_def one_domain_case)+
     done
 qed
 
@@ -2244,10 +2272,19 @@ proof -
   note switchToThread_invs_no_cicd'[wp del]
   note switchToThread_lookupBitmapPriority_wp[wp]
   note assert_wp[wp del]
+  note if_split[split del]
+
+  (* if we only have one domain, we are in it *)
+  have one_domain_case:
+    "\<And>s. \<lbrakk> invs_no_cicd' s; numDomains \<le> 1 \<rbrakk> \<Longrightarrow> ksCurDomain s = 0"
+    by (simp add: all_invs_but_ct_idle_or_in_cur_domain'_def maxDomain_def)
+
+  (* NOTE: do *not* unfold numDomains in the rest of the proof,
+           it should work for any number *)
 
   (* FIXME this is almost identical to the chooseThread_invs_no_cicd'_posts proof, can generalise? *)
   show ?thesis
-    unfolding chooseThread_def Let_def numDomains_def curDomain_def
+    unfolding chooseThread_def Let_def curDomain_def
     apply (simp only: return_bind, simp)
     apply (rule hoare_seq_ext[where B="\<lambda>rv s. invs_no_cicd' s \<and> rv = ksCurDomain s"])
      apply (rule_tac B="\<lambda>rv s. invs_no_cicd' s \<and> curdom = ksCurDomain s \<and>
@@ -2261,7 +2298,7 @@ proof -
       apply (wp assert_inv)
       apply (clarsimp dest!: invs_no_cicd'_queues simp: valid_queues_def)
       apply (fastforce elim: bitmapQ_from_bitmap_lookup simp: lookupBitmapPriority_def)
-     apply (wp | simp add: bitmap_fun_defs curDomain_def)+
+     apply (wpsimp simp: bitmap_fun_defs curDomain_def one_domain_case)+
     done
 qed
 

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -616,7 +616,7 @@ lemma dec_dom_inv_wf[wp]:
   apply (simp add:not_le)
   apply (simp del: Word.of_nat_unat flip: ucast_nat_def)
   apply (rule word_of_nat_le)
-  apply (simp add:numDomains_def maxDomain_def)
+  apply (simp add: le_maxDomain_eq_less_numDomains)
   done
 
 lemma decode_inv_wf'[wp]:

--- a/proof/refine/RISCV64/Interrupt_R.thy
+++ b/proof/refine/RISCV64/Interrupt_R.thy
@@ -602,11 +602,6 @@ lemma getIRQState_prop:
   apply simp
   done
 
-lemma num_domains[simp]:
-  "num_domains = numDomains"
-  apply(simp add: num_domains_def numDomains_def)
-  done
-
 lemma decDomainTime_corres:
   "corres dc \<top> \<top> dec_domain_time decDomainTime"
   apply (simp add:dec_domain_time_def corres_underlying_def decDomainTime_def simpler_modify_def)
@@ -795,17 +790,16 @@ crunches tcbSchedAppend
 
 lemma timerTick_invs'[wp]:
   "\<lbrace>invs'\<rbrace> timerTick \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: numDomains_def timerTick_def)
-  apply (wp threadSet_invs_trivial threadSet_pred_tcb_no_state
-            rescheduleRequired_all_invs_but_ct_not_inQ
-            tcbSchedAppend_invs_but_ct_not_inQ'
-       | simp add: tcb_cte_cases_def numDomains_def
-       | wpc)+
-      apply (simp add:decDomainTime_def)
-      apply wp
-     apply simp
+  apply (simp add: timerTick_def)
+  apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state
+                    rescheduleRequired_all_invs_but_ct_not_inQ
+                    tcbSchedAppend_invs_but_ct_not_inQ'
+                simp: tcb_cte_cases_def)
      apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
      apply (clarsimp simp add:invs'_def valid_state'_def)
+      apply (simp add: decDomainTime_def)
+      apply wp
+     apply simp
      apply wpc
           apply (wp add: threadGet_wp threadSet_cur threadSet_timeslice_invs
                                rescheduleRequired_all_invs_but_ct_not_inQ
@@ -817,7 +811,7 @@ lemma timerTick_invs'[wp]:
                              threadSet_valid_objs' threadSet_timeslice_invs)+
        apply (wp threadGet_wp)
       apply (wp gts_wp')+
-  apply (clarsimp simp: invs'_def st_tcb_at'_def obj_at'_def valid_state'_def numDomains_def)
+  apply (clarsimp simp: invs'_def st_tcb_at'_def obj_at'_def valid_state'_def)
   done
 
 lemma resetTimer_invs'[wp]:

--- a/proof/refine/RISCV64/Invariants_H.thy
+++ b/proof/refine/RISCV64/Invariants_H.thy
@@ -2674,6 +2674,21 @@ lemma ex_cte_cap_to'_pres:
   apply simp
   done
 
+section "Relationship of Executable Spec to Kernel Configuration"
+
+text \<open>
+  Some values are set per kernel configuration (e.g. number of domains), but other related
+  values (e.g. maximum domain) are derived from storage constraints (e.g. bytes used).
+  To relate the two, we must look at the values of kernel configuration constants.
+  To allow the proofs to work for all permitted values of these constants, their definitions
+  should only be unfolded in this section, and the derived properties kept to a minimum.\<close>
+
+lemma le_maxDomain_eq_less_numDomains:
+  shows "x \<le> unat maxDomain \<longleftrightarrow> x < Kernel_Config.numDomains"
+        "y \<le> maxDomain \<longleftrightarrow> unat y < Kernel_Config.numDomains"
+  by (auto simp: Kernel_Config.numDomains_def maxDomain_def word_le_nat_alt)
+
+
 context begin interpretation Arch . (*FIXME: arch_split*)
 
 lemma page_table_pte_atI':

--- a/proof/refine/RISCV64/Retype_R.thy
+++ b/proof/refine/RISCV64/Retype_R.thy
@@ -102,9 +102,7 @@ lemma valid_obj_makeObject_cte [simp]:
 lemma valid_obj_makeObject_tcb [simp]:
   "valid_obj' (KOTCB makeObject) s"
   unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def
-  by (clarsimp simp: makeObject_tcb makeObject_cte cteSizeBits_def
-                     tcb_cte_cases_def maxDomain_def numDomains_def maxPriority_def
-                     numPriorities_def minBound_word)
+  by (clarsimp simp: makeObject_tcb makeObject_cte tcb_cte_cases_def minBound_word cteSizeBits_def)
 
 lemma valid_obj_makeObject_endpoint [simp]:
   "valid_obj' (KOEndpoint makeObject) s"

--- a/proof/refine/RISCV64/Schedule_R.thy
+++ b/proof/refine/RISCV64/Schedule_R.thy
@@ -1379,7 +1379,8 @@ lemma switchToIdleThread_curr_is_idle:
 
 lemma chooseThread_it[wp]:
   "\<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace> chooseThread \<lbrace>\<lambda>_ s. P (ksIdleThread s)\<rbrace>"
-  by (wp|clarsimp simp: chooseThread_def curDomain_def numDomains_def bitmap_fun_defs|assumption)+
+  supply if_split[split del]
+  by (wpsimp simp: chooseThread_def curDomain_def bitmap_fun_defs)
 
 lemma threadGet_inv [wp]: "\<lbrace>P\<rbrace> threadGet f t \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (simp add: threadGet_def)
@@ -1492,6 +1493,16 @@ lemma enumPrio_word_div:
 lemma curDomain_corres: "corres (=) \<top> \<top> (gets cur_domain) (curDomain)"
   by (simp add: curDomain_def state_relation_def)
 
+lemma curDomain_corres':
+  "corres (=) \<top> (\<lambda>s. ksCurDomain s \<le> maxDomain)
+    (gets cur_domain) (if 1 < numDomains then curDomain else return 0)"
+  apply (case_tac "1 < numDomains"; simp)
+   apply (rule corres_guard_imp[OF curDomain_corres]; solves simp)
+  (* if we have only one domain, then we are in it *)
+  apply (clarsimp simp: return_def simpler_gets_def bind_def maxDomain_def
+                        state_relation_def corres_underlying_def)
+  done
+
 lemma lookupBitmapPriority_Max_eqI:
   "\<lbrakk> valid_bitmapQ s ; bitmapQ_no_L1_orphans s ; ksReadyQueuesL1Bitmap s d \<noteq> 0 \<rbrakk>
    \<Longrightarrow> lookupBitmapPriority d s = (Max {prio. ksReadyQueues s (d, prio) \<noteq> []})"
@@ -1558,18 +1569,27 @@ lemma ksReadyQueuesL1Bitmap_st_tcb_at':
    apply simp
    done
 
+lemma curDomain_or_return_0:
+  "\<lbrakk> \<lbrace>P\<rbrace> curDomain \<lbrace>\<lambda>rv s. Q rv s \<rbrace>; \<And>s. P s \<Longrightarrow> ksCurDomain s \<le> maxDomain \<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace> if 1 < numDomains then curDomain else return 0 \<lbrace>\<lambda>rv s. Q rv s \<rbrace>"
+  apply (case_tac "1 < numDomains"; simp)
+  apply (simp add: valid_def curDomain_def simpler_gets_def return_def maxDomain_def)
+  done
+
+lemma invs_no_cicd_ksCurDomain_maxDomain':
+  "invs_no_cicd' s \<Longrightarrow> ksCurDomain s \<le> maxDomain"
+  unfolding invs_no_cicd'_def by simp
+
 lemma chooseThread_corres:
   "corres dc (invs and valid_sched) (invs_no_cicd')
      choose_thread chooseThread" (is "corres _ ?PREI ?PREH _ _")
 proof -
   show ?thesis
-  unfolding choose_thread_def chooseThread_def numDomains_def
-  apply (simp only: numDomains_def return_bind Let_def)
-  apply (simp cong: if_cong) (* clean up if 1 < numDomains *)
+  unfolding choose_thread_def chooseThread_def
+  apply (simp only: return_bind Let_def)
   apply (subst if_swap[where P="_ \<noteq> 0"]) (* put switchToIdleThread on first branch*)
-  apply (rule corres_name_pre)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ curDomain_corres])
+    apply (rule corres_split[OF curDomain_corres'])
       apply clarsimp
       apply (rule corres_split_deprecated[OF _ corres_gets_queues_getReadyQueuesL1Bitmap])
         apply (erule corres_if2[OF sym])
@@ -1592,15 +1612,17 @@ proof -
                apply (wpsimp simp: getQueue_def getReadyQueuesL2Bitmap_def)+
       apply (clarsimp simp: if_apply_def2)
       apply (wp hoare_vcg_conj_lift hoare_vcg_imp_lift ksReadyQueuesL1Bitmap_return_wp)
-     apply (simp add: curDomain_def, wp)+
+     apply (wpsimp wp: curDomain_or_return_0 simp: curDomain_def)+
+    apply (fastforce simp: invs_no_cicd'_def)
    apply (clarsimp simp: valid_sched_def DetSchedInvs_AI.valid_queues_def max_non_empty_queue_def)
-   apply (erule_tac x="cur_domain sa" in allE)
-   apply (erule_tac x="Max {prio. ready_queues sa (cur_domain sa) prio \<noteq> []}" in allE)
-   apply (case_tac "ready_queues sa (cur_domain sa) (Max {prio. ready_queues sa (cur_domain sa) prio \<noteq> []})")
+   apply (erule_tac x="cur_domain s" in allE)
+   apply (erule_tac x="Max {prio. ready_queues s (cur_domain s) prio \<noteq> []}" in allE)
+   apply (case_tac "ready_queues s (cur_domain s) (Max {prio. ready_queues s (cur_domain s) prio \<noteq> []})")
     apply (clarsimp)
     apply (subgoal_tac
-             "ready_queues sa (cur_domain sa) (Max {prio. ready_queues sa (cur_domain sa) prio \<noteq> []}) \<noteq> []")
+             "ready_queues s (cur_domain s) (Max {prio. ready_queues s (cur_domain s) prio \<noteq> []}) \<noteq> []")
      apply (fastforce elim!: setcomp_Max_has_prop)+
+  apply (simp add: invs_no_cicd_ksCurDomain_maxDomain')
   apply (clarsimp dest!: invs_no_cicd'_queues)
   apply (fastforce intro: ksReadyQueuesL1Bitmap_st_tcb_at')
   done
@@ -1999,9 +2021,15 @@ proof -
   note switchToThread_invs_no_cicd'[wp del]
   note switchToThread_lookupBitmapPriority_wp[wp]
   note assert_wp[wp del]
+  note if_split[split del]
+
+  (* if we only have one domain, we are in it *)
+  have one_domain_case:
+    "\<And>s. \<lbrakk> invs_no_cicd' s; numDomains \<le> 1 \<rbrakk> \<Longrightarrow> ksCurDomain s = 0"
+    by (simp add: all_invs_but_ct_idle_or_in_cur_domain'_def maxDomain_def)
 
   show ?thesis
-    unfolding chooseThread_def Let_def numDomains_def curDomain_def
+    unfolding chooseThread_def Let_def curDomain_def
     apply (simp only: return_bind, simp)
     apply (rule hoare_seq_ext[where B="\<lambda>rv s. invs_no_cicd' s \<and> rv = ksCurDomain s"])
      apply (rule_tac B="\<lambda>rv s. invs_no_cicd' s \<and> curdom = ksCurDomain s \<and>
@@ -2025,7 +2053,7 @@ proof -
       apply (drule (3) lookupBitmapPriority_obj_at')
       apply normalise_obj_at'
       apply (fastforce simp: tcb_in_cur_domain'_def inQ_def elim: obj_at'_weaken)
-     apply (wp | simp add: bitmap_fun_defs curDomain_def)+
+     apply (wpsimp simp: bitmap_fun_defs curDomain_def one_domain_case)+
     done
 qed
 
@@ -2051,10 +2079,19 @@ proof -
   note switchToThread_invs_no_cicd'[wp del]
   note switchToThread_lookupBitmapPriority_wp[wp]
   note assert_wp[wp del]
+  note if_split[split del]
+
+  (* if we only have one domain, we are in it *)
+  have one_domain_case:
+    "\<And>s. \<lbrakk> invs_no_cicd' s; numDomains \<le> 1 \<rbrakk> \<Longrightarrow> ksCurDomain s = 0"
+    by (simp add: all_invs_but_ct_idle_or_in_cur_domain'_def maxDomain_def)
+
+  (* NOTE: do *not* unfold numDomains in the rest of the proof,
+           it should work for any number *)
 
   (* FIXME this is almost identical to the chooseThread_invs_no_cicd'_posts proof, can generalise? *)
   show ?thesis
-    unfolding chooseThread_def Let_def numDomains_def curDomain_def
+    unfolding chooseThread_def Let_def curDomain_def
     apply (simp only: return_bind, simp)
     apply (rule hoare_seq_ext[where B="\<lambda>rv s. invs_no_cicd' s \<and> rv = ksCurDomain s"])
      apply (rule_tac B="\<lambda>rv s. invs_no_cicd' s \<and> curdom = ksCurDomain s \<and>
@@ -2068,7 +2105,7 @@ proof -
       apply (wp assert_inv)
       apply (clarsimp dest!: invs_no_cicd'_queues simp: valid_queues_def)
       apply (fastforce elim: bitmapQ_from_bitmap_lookup simp: lookupBitmapPriority_def)
-     apply (wp | simp add: bitmap_fun_defs curDomain_def)+
+     apply (wpsimp simp: bitmap_fun_defs curDomain_def one_domain_case)+
     done
 qed
 

--- a/proof/refine/RISCV64/Syscall_R.thy
+++ b/proof/refine/RISCV64/Syscall_R.thy
@@ -613,7 +613,7 @@ lemma dec_dom_inv_wf[wp]:
   apply (simp add:not_le)
   apply (simp del: Word.of_nat_unat flip: ucast_nat_def)
   apply (rule word_of_nat_le)
-  apply (simp add:numDomains_def maxDomain_def)
+  apply (simp add: le_maxDomain_eq_less_numDomains)
   done
 
 lemma decode_inv_wf'[wp]:

--- a/proof/refine/RISCV64/orphanage/Orphanage.thy
+++ b/proof/refine/RISCV64/orphanage/Orphanage.thy
@@ -783,7 +783,8 @@ lemma chooseThread_no_orphans [wp]:
    chooseThread
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
   (is "\<lbrace>?PRE\<rbrace> _ \<lbrace>_\<rbrace>")
-  unfolding chooseThread_def Let_def numDomains_def curDomain_def
+  unfolding chooseThread_def Let_def
+  supply if_split[split del]
   apply (simp only: return_bind, simp)
   apply (rule hoare_seq_ext[where B="\<lambda>rv s. ?PRE s \<and> rv = ksCurDomain s"])
    apply (rule_tac B="\<lambda>rv s. ?PRE s \<and> curdom = ksCurDomain s \<and>
@@ -799,7 +800,9 @@ lemma chooseThread_no_orphans [wp]:
                           valid_queues_def st_tcb_at'_def)
     apply (fastforce dest!: lookupBitmapPriority_obj_at' elim: obj_at'_weaken
                      simp: all_active_tcb_ptrs_def)
-   apply (simp add: bitmap_fun_defs | wp)+
+   apply (wpsimp simp: bitmap_fun_defs)
+  apply (wp curDomain_or_return_0[simplified])
+    apply (wpsimp simp: curDomain_def simp: invs_no_cicd_ksCurDomain_maxDomain')+
   done
 
 lemma valid_queues'_ko_atD:
@@ -1024,7 +1027,8 @@ lemma chooseThread_nosch:
   "\<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace>
   chooseThread
   \<lbrace>\<lambda>rv s. P (ksSchedulerAction s)\<rbrace>"
-  unfolding chooseThread_def Let_def numDomains_def curDomain_def
+  unfolding chooseThread_def Let_def curDomain_def
+  supply if_split[split del]
   apply (simp only: return_bind, simp)
   apply (wp findM_inv | simp)+
   apply (case_tac queue)
@@ -1243,18 +1247,20 @@ lemma timerTick_no_orphans [wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<rbrace>
    timerTick
    \<lbrace> \<lambda>_ s. no_orphans s \<rbrace>"
-  unfolding timerTick_def getDomainTime_def numDomains_def
-  apply (rule hoare_pre)
-   apply (wp hoare_drop_imps | clarsimp)+
-   apply (wp threadSet_valid_queues' tcbSchedAppend_almost_no_orphans threadSet_sch_act
-             threadSet_almost_no_orphans threadSet_no_orphans tcbSchedAppend_sch_act_wf
-             | wpc | clarsimp
-             | strengthen sch_act_wf_weak)+
-         apply (rule_tac Q="\<lambda>rv s. no_orphans s \<and> valid_queues' s \<and> tcb_at' thread s
-                                 \<and> sch_act_wf  (ksSchedulerAction s) s" in hoare_post_imp)
-          apply (clarsimp simp: inQ_def)
-         apply (wp hoare_drop_imps | clarsimp)+
-  apply auto
+  unfolding timerTick_def getDomainTime_def
+  supply if_split[split del]
+  apply (subst threadState_case_if)
+  apply (wpsimp wp: threadSet_no_orphans threadSet_valid_queues'
+                    threadSet_valid_queues' tcbSchedAppend_almost_no_orphans threadSet_sch_act
+                    threadSet_almost_no_orphans threadSet_no_orphans tcbSchedAppend_sch_act_wf
+                    hoare_drop_imp
+                simp: if_apply_def2
+         | strengthen sch_act_wf_weak)+
+      apply (rule_tac Q="\<lambda>rv s. no_orphans s \<and> valid_queues' s \<and> tcb_at' thread s
+                                \<and> sch_act_wf  (ksSchedulerAction s) s" in hoare_post_imp)
+       apply (clarsimp simp: inQ_def)
+      apply (wp hoare_drop_imps | clarsimp)+
+  apply (auto split: if_split)
   done
 
 

--- a/proof/refine/X64/Interrupt_R.thy
+++ b/proof/refine/X64/Interrupt_R.thy
@@ -651,11 +651,6 @@ lemma getIRQState_prop:
   apply simp
   done
 
-lemma num_domains[simp]:
-  "num_domains = numDomains"
-  apply(simp add: num_domains_def numDomains_def)
-  done
-
 lemma decDomainTime_corres:
   "corres dc \<top> \<top> dec_domain_time decDomainTime"
   apply (simp add:dec_domain_time_def corres_underlying_def
@@ -865,17 +860,16 @@ crunch cur_tcb'[wp]: tcbSchedAppend cur_tcb'
 
 lemma timerTick_invs'[wp]:
   "\<lbrace>invs'\<rbrace> timerTick \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: numDomains_def timerTick_def)
-  apply (wp threadSet_invs_trivial threadSet_pred_tcb_no_state
-            rescheduleRequired_all_invs_but_ct_not_inQ
-            tcbSchedAppend_invs_but_ct_not_inQ'
-       | simp add: tcb_cte_cases_def numDomains_def
-       | wpc)+
-      apply (simp add:decDomainTime_def)
-      apply wp
-     apply simp
+  apply (simp add: timerTick_def)
+  apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state
+                    rescheduleRequired_all_invs_but_ct_not_inQ
+                    tcbSchedAppend_invs_but_ct_not_inQ'
+                simp: tcb_cte_cases_def)
      apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
      apply (clarsimp simp add:invs'_def valid_state'_def)
+      apply (simp add: decDomainTime_def)
+      apply wp
+     apply simp
      apply wpc
           apply (wp add: threadGet_wp threadSet_cur threadSet_timeslice_invs
                                rescheduleRequired_all_invs_but_ct_not_inQ
@@ -887,7 +881,7 @@ lemma timerTick_invs'[wp]:
                              threadSet_valid_objs' threadSet_timeslice_invs)+
        apply (wp threadGet_wp)
       apply (wp gts_wp')+
-  apply (clarsimp simp: invs'_def st_tcb_at'_def obj_at'_def valid_state'_def numDomains_def)
+  apply (clarsimp simp: invs'_def st_tcb_at'_def obj_at'_def valid_state'_def)
   done
 
 lemma resetTimer_invs'[wp]:

--- a/proof/refine/X64/Invariants_H.thy
+++ b/proof/refine/X64/Invariants_H.thy
@@ -31,6 +31,21 @@ end
 
 end
 
+section "Relationship of Executable Spec to Kernel Configuration"
+
+text \<open>
+  Some values are set per kernel configuration (e.g. number of domains), but other related
+  values (e.g. maximum domain) are derived from storage constraints (e.g. bytes used).
+  To relate the two, we must look at the values of kernel configuration constants.
+  To allow the proofs to work for all permitted values of these constants, their definitions
+  should only be unfolded in this section, and the derived properties kept to a minimum.\<close>
+
+lemma le_maxDomain_eq_less_numDomains:
+  shows "x \<le> unat maxDomain \<longleftrightarrow> x < Kernel_Config.numDomains"
+        "y \<le> maxDomain \<longleftrightarrow> unat y < Kernel_Config.numDomains"
+  by (auto simp: Kernel_Config.numDomains_def maxDomain_def word_le_nat_alt)
+
+
 context begin interpretation Arch . (*FIXME: arch_split*)
 \<comment> \<open>---------------------------------------------------------------------------\<close>
 section "Invariants on Executable Spec"

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -111,8 +111,7 @@ lemma valid_obj_makeObject_cte [simp]:
 lemma valid_obj_makeObject_tcb [simp]:
   "valid_obj' (KOTCB makeObject) s"
   unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def
-  by (clarsimp simp: makeObject_tcb makeObject_cte
-                     tcb_cte_cases_def maxDomain_def numDomains_def maxPriority_def numPriorities_def minBound_word)
+  by (clarsimp simp: makeObject_tcb makeObject_cte tcb_cte_cases_def minBound_word)
 
 lemma valid_obj_makeObject_endpoint [simp]:
   "valid_obj' (KOEndpoint makeObject) s"

--- a/proof/refine/X64/Schedule_R.thy
+++ b/proof/refine/X64/Schedule_R.thy
@@ -1399,7 +1399,8 @@ lemma switchToIdleThread_curr_is_idle:
 
 lemma chooseThread_it[wp]:
   "\<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace> chooseThread \<lbrace>\<lambda>_ s. P (ksIdleThread s)\<rbrace>"
-  by (wp|clarsimp simp: chooseThread_def curDomain_def numDomains_def bitmap_fun_defs|assumption)+
+  supply if_split[split del]
+  by (wpsimp simp: chooseThread_def curDomain_def bitmap_fun_defs)
 
 lemma threadGet_inv [wp]: "\<lbrace>P\<rbrace> threadGet f t \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (simp add: threadGet_def)
@@ -1513,6 +1514,16 @@ lemma enumPrio_word_div:
 lemma curDomain_corres: "corres (=) \<top> \<top> (gets cur_domain) (curDomain)"
   by (simp add: curDomain_def state_relation_def)
 
+lemma curDomain_corres':
+  "corres (=) \<top> (\<lambda>s. ksCurDomain s \<le> maxDomain)
+    (gets cur_domain) (if 1 < numDomains then curDomain else return 0)"
+  apply (case_tac "1 < numDomains"; simp)
+   apply (rule corres_guard_imp[OF curDomain_corres]; solves simp)
+  (* if we have only one domain, then we are in it *)
+  apply (clarsimp simp: return_def simpler_gets_def bind_def maxDomain_def
+                        state_relation_def corres_underlying_def)
+  done
+
 lemma lookupBitmapPriority_Max_eqI:
   "\<lbrakk> valid_bitmapQ s ; bitmapQ_no_L1_orphans s ; ksReadyQueuesL1Bitmap s d \<noteq> 0 \<rbrakk>
    \<Longrightarrow> lookupBitmapPriority d s = (Max {prio. ksReadyQueues s (d, prio) \<noteq> []})"
@@ -1579,18 +1590,27 @@ lemma ksReadyQueuesL1Bitmap_st_tcb_at':
    apply simp
    done
 
+lemma curDomain_or_return_0:
+  "\<lbrakk> \<lbrace>P\<rbrace> curDomain \<lbrace>\<lambda>rv s. Q rv s \<rbrace>; \<And>s. P s \<Longrightarrow> ksCurDomain s \<le> maxDomain \<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace> if 1 < numDomains then curDomain else return 0 \<lbrace>\<lambda>rv s. Q rv s \<rbrace>"
+  apply (case_tac "1 < numDomains"; simp)
+  apply (simp add: valid_def curDomain_def simpler_gets_def return_def maxDomain_def)
+  done
+
+lemma invs_no_cicd_ksCurDomain_maxDomain':
+  "invs_no_cicd' s \<Longrightarrow> ksCurDomain s \<le> maxDomain"
+  unfolding invs_no_cicd'_def by simp
+
 lemma chooseThread_corres:
   "corres dc (invs and valid_sched) (invs_no_cicd')
      choose_thread chooseThread" (is "corres _ ?PREI ?PREH _ _")
 proof -
   show ?thesis
-  unfolding choose_thread_def chooseThread_def numDomains_def
-  apply (simp only: numDomains_def return_bind Let_def)
-  apply (simp cong: if_cong) (* clean up if 1 < numDomains *)
+  unfolding choose_thread_def chooseThread_def
+  apply (simp only: return_bind Let_def)
   apply (subst if_swap[where P="_ \<noteq> 0"]) (* put switchToIdleThread on first branch*)
-  apply (rule corres_name_pre)
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated[OF _ curDomain_corres])
+    apply (rule corres_split[OF curDomain_corres'])
       apply clarsimp
       apply (rule corres_split_deprecated[OF _ corres_gets_queues_getReadyQueuesL1Bitmap])
         apply (erule corres_if2[OF sym])
@@ -1613,15 +1633,17 @@ proof -
                apply (wpsimp simp: getQueue_def getReadyQueuesL2Bitmap_def)+
       apply (clarsimp simp: if_apply_def2)
       apply (wp hoare_vcg_conj_lift hoare_vcg_imp_lift ksReadyQueuesL1Bitmap_return_wp)
-     apply (simp add: curDomain_def, wp)+
+     apply (wpsimp wp: curDomain_or_return_0 simp: curDomain_def)+
+    apply (fastforce simp: invs_no_cicd'_def)
    apply (clarsimp simp: valid_sched_def DetSchedInvs_AI.valid_queues_def max_non_empty_queue_def)
-   apply (erule_tac x="cur_domain sa" in allE)
-   apply (erule_tac x="Max {prio. ready_queues sa (cur_domain sa) prio \<noteq> []}" in allE)
-   apply (case_tac "ready_queues sa (cur_domain sa) (Max {prio. ready_queues sa (cur_domain sa) prio \<noteq> []})")
+   apply (erule_tac x="cur_domain s" in allE)
+   apply (erule_tac x="Max {prio. ready_queues s (cur_domain s) prio \<noteq> []}" in allE)
+   apply (case_tac "ready_queues s (cur_domain s) (Max {prio. ready_queues s (cur_domain s) prio \<noteq> []})")
     apply (clarsimp)
     apply (subgoal_tac
-             "ready_queues sa (cur_domain sa) (Max {prio. ready_queues sa (cur_domain sa) prio \<noteq> []}) \<noteq> []")
+             "ready_queues s (cur_domain s) (Max {prio. ready_queues s (cur_domain s) prio \<noteq> []}) \<noteq> []")
      apply (fastforce elim!: setcomp_Max_has_prop)+
+  apply (simp add: invs_no_cicd_ksCurDomain_maxDomain')
   apply (clarsimp dest!: invs_no_cicd'_queues)
   apply (fastforce intro: ksReadyQueuesL1Bitmap_st_tcb_at')
   done
@@ -2023,9 +2045,15 @@ proof -
   note switchToThread_invs_no_cicd'[wp del]
   note switchToThread_lookupBitmapPriority_wp[wp]
   note assert_wp[wp del]
+  note if_split[split del]
+
+  (* if we only have one domain, we are in it *)
+  have one_domain_case:
+    "\<And>s. \<lbrakk> invs_no_cicd' s; numDomains \<le> 1 \<rbrakk> \<Longrightarrow> ksCurDomain s = 0"
+    by (simp add: all_invs_but_ct_idle_or_in_cur_domain'_def maxDomain_def)
 
   show ?thesis
-    unfolding chooseThread_def Let_def numDomains_def curDomain_def
+    unfolding chooseThread_def Let_def curDomain_def
     apply (simp only: return_bind, simp)
     apply (rule hoare_seq_ext[where B="\<lambda>rv s. invs_no_cicd' s \<and> rv = ksCurDomain s"])
      apply (rule_tac B="\<lambda>rv s. invs_no_cicd' s \<and> curdom = ksCurDomain s \<and>
@@ -2049,7 +2077,7 @@ proof -
       apply (drule (3) lookupBitmapPriority_obj_at')
       apply normalise_obj_at'
       apply (fastforce simp: tcb_in_cur_domain'_def inQ_def elim: obj_at'_weaken)
-     apply (wp | simp add: bitmap_fun_defs curDomain_def)+
+     apply (wpsimp simp: bitmap_fun_defs curDomain_def one_domain_case)+
     done
 qed
 
@@ -2075,10 +2103,19 @@ proof -
   note switchToThread_invs_no_cicd'[wp del]
   note switchToThread_lookupBitmapPriority_wp[wp]
   note assert_wp[wp del]
+  note if_split[split del]
+
+  (* if we only have one domain, we are in it *)
+  have one_domain_case:
+    "\<And>s. \<lbrakk> invs_no_cicd' s; numDomains \<le> 1 \<rbrakk> \<Longrightarrow> ksCurDomain s = 0"
+    by (simp add: all_invs_but_ct_idle_or_in_cur_domain'_def maxDomain_def)
+
+  (* NOTE: do *not* unfold numDomains in the rest of the proof,
+           it should work for any number *)
 
   (* FIXME this is almost identical to the chooseThread_invs_no_cicd'_posts proof, can generalise? *)
   show ?thesis
-    unfolding chooseThread_def Let_def numDomains_def curDomain_def
+    unfolding chooseThread_def Let_def curDomain_def
     apply (simp only: return_bind, simp)
     apply (rule hoare_seq_ext[where B="\<lambda>rv s. invs_no_cicd' s \<and> rv = ksCurDomain s"])
      apply (rule_tac B="\<lambda>rv s. invs_no_cicd' s \<and> curdom = ksCurDomain s \<and>
@@ -2092,7 +2129,7 @@ proof -
       apply (wp assert_inv)
       apply (clarsimp dest!: invs_no_cicd'_queues simp: valid_queues_def)
       apply (fastforce elim: bitmapQ_from_bitmap_lookup simp: lookupBitmapPriority_def)
-     apply (wp | simp add: bitmap_fun_defs curDomain_def)+
+     apply (wpsimp simp: bitmap_fun_defs curDomain_def one_domain_case)+
     done
 qed
 

--- a/proof/refine/X64/Syscall_R.thy
+++ b/proof/refine/X64/Syscall_R.thy
@@ -616,7 +616,7 @@ lemma dec_dom_inv_wf[wp]:
   apply (simp add:not_le)
   apply (simp del: Word.of_nat_unat flip: ucast_nat_def)
   apply (rule word_of_nat_le)
-  apply (simp add:numDomains_def maxDomain_def)
+  apply (simp add: le_maxDomain_eq_less_numDomains)
   done
 
 lemma decode_inv_wf'[wp]:

--- a/spec/abstract/ARM/Arch_Structs_A.thy
+++ b/spec/abstract/ARM/Arch_Structs_A.thy
@@ -15,6 +15,7 @@ imports
   "ExecSpec.Arch_Structs_B"
   ExceptionTypes_A
   VMRights_A
+  ExecSpec.Kernel_Config
 begin
 
 context Arch begin global_naming ARM_A

--- a/spec/abstract/ARM_HYP/Arch_Structs_A.thy
+++ b/spec/abstract/ARM_HYP/Arch_Structs_A.thy
@@ -15,6 +15,7 @@ imports
   "ExecSpec.Arch_Structs_B"
   ExceptionTypes_A
   VMRights_A
+  ExecSpec.Kernel_Config
 begin
 
 context Arch begin global_naming ARM_A

--- a/spec/abstract/Decode_A.thy
+++ b/spec/abstract/Decode_A.thy
@@ -417,7 +417,7 @@ where
      whenE (gen_invocation_type label \<noteq> DomainSetSet) $ throwError IllegalOperation;
      domain \<leftarrow> (case args of
        x # xs \<Rightarrow> doE
-         whenE (unat x \<ge> num_domains) $ throwError $ InvalidArgument 0;
+         whenE (unat x \<ge> numDomains) $ throwError $ InvalidArgument 0;
          returnOk (ucast x)
        odE
        | _ \<Rightarrow> throwError TruncatedMessage);

--- a/spec/abstract/Deterministic_A.thy
+++ b/spec/abstract/Deterministic_A.thy
@@ -117,9 +117,6 @@ record etcb =
  tcb_time_slice :: "nat"
  tcb_domain :: "domain"
 
-definition num_domains :: nat where
-  "num_domains \<equiv> 16"
-
 definition time_slice :: "nat" where
   "time_slice \<equiv> 5"
 

--- a/spec/abstract/Interrupt_A.thy
+++ b/spec/abstract/Interrupt_A.thy
@@ -74,7 +74,7 @@ definition timer_tick :: "unit det_ext_monad" where
        od
      od
      | _ \<Rightarrow> return ();
-     when (num_domains > 1) (do
+     when (numDomains > 1) (do
        dec_domain_time;
        dom_time \<leftarrow> gets domain_time;
        when (dom_time = 0) reschedule_required

--- a/spec/abstract/RISCV64/Arch_Structs_A.thy
+++ b/spec/abstract/RISCV64/Arch_Structs_A.thy
@@ -11,6 +11,7 @@ imports
   "ExecSpec.Arch_Structs_B"
   ExceptionTypes_A
   VMRights_A
+  ExecSpec.Kernel_Config
 begin
 
 context Arch begin global_naming RISCV64_A

--- a/spec/abstract/X64/Arch_Structs_A.thy
+++ b/spec/abstract/X64/Arch_Structs_A.thy
@@ -11,6 +11,7 @@ imports
   "ExecSpec.Arch_Structs_B"
   ExceptionTypes_A
   VMRights_A
+  ExecSpec.Kernel_Config
 begin
 
 context Arch begin global_naming X64_A

--- a/spec/design/skel/Config_H.thy
+++ b/spec/design/skel/Config_H.thy
@@ -5,9 +5,9 @@
  *)
 
 theory Config_H
-imports Types_H
+imports Types_H Kernel_Config
 begin
 
-#INCLUDE_HASKELL SEL4/Config.lhs
+#INCLUDE_HASKELL SEL4/Config.lhs NOT numDomains
 
 end

--- a/spec/haskell/src/SEL4/Config.lhs
+++ b/spec/haskell/src/SEL4/Config.lhs
@@ -38,7 +38,7 @@ The default number of timer ticks between scheduling and preemption. Note that t
 The default number of security domains.
 
 > numDomains :: Int
-> numDomains = 16
+> numDomains = error "see Kernel_Config.thy for definition"
 
 The number of priority levels per domain. There is one ready queue per domain and per priority.
 

--- a/spec/machine/Kernel_Config.thy
+++ b/spec/machine/Kernel_Config.thy
@@ -1,0 +1,39 @@
+(*
+ * Copyright 2021, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+chapter "Kernel Configuration"
+
+theory Kernel_Config
+imports Platform
+begin
+
+text \<open>
+  seL4's build system allows configuration of some architecture-independent variables, such as the
+  number of domains.
+
+  This theory contains shared definitions used by both the abstract and design specifications,
+  to prevent multiple points of update.
+
+  The long-term goal is to make the proofs resilient in the face of changes of these configuration
+  options, possibly loading their values directly from the build system configuration. For this
+  reason, definitions of variables used here should remain hidden, and their unfolding should be
+  avoided whenever possible.\<close>
+
+definition numDomains :: nat where
+  "numDomains \<equiv> 16"
+
+lemma numDomains_not_zero:
+  "numDomains > 0"
+  unfolding Kernel_Config.numDomains_def
+  by simp
+
+lemma numDomains_machine_word_safe:
+  "unat (of_nat numDomains :: machine_word) = numDomains"
+  unfolding Kernel_Config.numDomains_def by simp
+
+hide_fact (open) numDomains_def
+
+end


### PR DESCRIPTION
Test with seL4/seL4#713

This is still limited to 256 domains because domain type is word 8 and quite hardcoded in the abstract specs/proofs. Please see commit messages for detailed observations on how this was accomplished, and caveats.

The default regression test will check with numDomains=16, and I've been running tests with numDomains=1 which was the most difficult to deal with due to "clever" simplification of edge cases spat out via ArrayGuards.
