### PR TITLE
prove handleEvent_corres + fix sorries in Refine.thy

### DIFF
--- a/proof/refine/ARM/EmptyFail_H.thy
+++ b/proof/refine/ARM/EmptyFail_H.thy
@@ -313,8 +313,15 @@ crunch (empty_fail) empty_fail: callKernel
 
 theorem call_kernel_serial:
   "\<lbrakk> (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and (ct_running or ct_idle) and
-              (\<lambda>s. scheduler_action s = resume_cur_thread) and
-              (\<lambda>s. 0 < domain_time s \<and> valid_domain_list s)) s;
+                (\<lambda>s. scheduler_action s = resume_cur_thread) and
+                current_time_bounded 5 and
+                consumed_time_bounded and
+                valid_machine_time and
+                ct_not_in_release_q and
+                cur_sc_active and
+                (\<lambda>s. cur_sc_offset_ready (consumed_time s) s) and
+                (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s) and
+                (\<lambda>s. 0 < domain_time s \<and> valid_domain_list s)) s;
        \<exists>s'. (s, s') \<in> state_relation \<and>
             (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and (ct_running' or ct_idle') and
               (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -1206,6 +1206,10 @@ abbreviation
 abbreviation
   "activatable' st \<equiv> runnable' st \<or> idle' st"
 
+defs rct_imp_activatable'_asrt_def:
+  "rct_imp_activatable'_asrt \<equiv> \<lambda>s. ksSchedulerAction s = ResumeCurrentThread \<longrightarrow>
+                                         ct_in_state' activatable' s"
+
 primrec
   sch_act_wf :: "scheduler_action \<Rightarrow> kernel_state \<Rightarrow> bool"
 where

--- a/proof/refine/ARM/Refine.thy
+++ b/proof/refine/ARM/Refine.thy
@@ -499,18 +499,29 @@ lemma akernel_invariant:
   done
 
 lemma ckernel_invs:
-  "\<lbrace>invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
-               (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s) and
-               (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>
+  "\<lbrace>invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))
+    and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s) and (ct_running' or ct_idle')
+    and (\<lambda>s. is_active_sc' (ksCurSc s) s) and sym_heap_tcbSCs
+    and (\<lambda>s. obj_at' (\<lambda>sc. scTCB sc = Some (ksCurThread s)) (ksCurSc s) s)
+    and (\<lambda>s. pred_map (\<lambda>tcb. \<not> tcbInReleaseQueue tcb) (tcbs_of' s) (ksCurThread s))
+    and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>
    callKernel e
    \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: callKernel_def)
+  apply (simp add: callKernel_def mcsPreemptionPoint_def)
   apply (rule hoare_pre)
-   apply (wp activate_invs'  schedule_sch
-             schedule_sch_act_simple he_invs' schedule_invs'
-             hoare_drop_imp[where R="\<lambda>_. kernelExitAssertions"]
-          | simp add: no_irq_getActiveIRQ)+
-  sorry
+   apply (wpsimp wp: hoare_drop_imp[where R="\<lambda>_. kernelExitAssertions"] activate_invs')
+     apply (rule hoare_drop_imp)
+     apply (wpsimp wp: schedule_invs')
+    apply (wpsimp wp: stateAssert_wp)
+   apply (wpsimp wp: isSchedulable_wp hoare_drop_imp)
+    apply (intro iffI; clarsimp simp: isScActive_def isSchedulable_bool_def)
+   apply (rule hoare_post_impErr[where E="\<lambda>_. invs'" and Q=Q and R=Q for Q])
+     apply wpsimp
+    apply (clarsimp simp: active_from_running')+
+  apply (clarsimp simp: sym_heap_def pred_map_def)
+  apply (rule_tac x="ksCurSc s" in exI)
+  apply (clarsimp simp: obj_at_simps is_active_sc'_def isScActive_def opt_map_red pred_map_def)
+  done
 
 (* abstract and haskell have identical domain list fields *)
 abbreviation valid_domain_list' :: "'a kernel_state_scheme \<Rightarrow> bool" where
@@ -525,23 +536,47 @@ lemma callKernel_domain_time_left:
   "\<lbrace> \<top> \<rbrace> callKernel e \<lbrace>\<lambda>_ s. 0 < ksDomainTime s \<and> valid_domain_list' s \<rbrace>"
   unfolding callKernel_def kernelExitAssertions_def by wpsimp
 
+lemma threadSet_is_active_sc'[wp]:
+  "threadSet f tp \<lbrace>\<lambda>s. is_active_sc' scp s\<rbrace>"
+  by (wpsimp simp: is_active_sc'_def)
+
+lemma threadSet_sym_heap_tcbSCs:
+  "\<forall>x. tcbSchedContext (f x) = tcbSchedContext x \<Longrightarrow>
+  threadSet f t \<lbrace>\<lambda>s. P (tcbSCs_of s) (scTCBs_of s)\<rbrace>"
+  unfolding threadSet_def
+  apply (rule hoare_seq_ext[OF _ get_tcb_sp'])
+  apply (wpsimp wp: setObject_tcb_tcbs_of' | wps)+
+  apply (prop_tac "((\<lambda>a. if a = t then Some (f tcb) else tcbs_of' s a) |>
+              tcbSchedContext) = tcbSCs_of s")
+   apply (rule ext)
+   apply (clarsimp simp: obj_at'_def projectKOs opt_map_def)
+  apply simp
+  done
+
 lemma kernelEntry_invs':
-  "\<lbrace> invs' and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s) and
-           (ct_running' or ct_idle') and
-           (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
-           (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
-           (\<lambda>s. 0 < ksDomainTime s) and valid_domain_list' \<rbrace>
+  "\<lbrace> invs' and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s)
+    and (ct_running' or ct_idle')
+    and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))
+    and (\<lambda>s. is_active_sc' (ksCurSc s) s) and sym_heap_tcbSCs
+    and (\<lambda>s. obj_at' (\<lambda>sc. scTCB sc = Some (ksCurThread s)) (ksCurSc s) s)
+    and (\<lambda>s. pred_map (\<lambda>tcb. \<not> tcbInReleaseQueue tcb) (tcbs_of' s) (ksCurThread s))
+    and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
+    and (\<lambda>s. 0 < ksDomainTime s) and valid_domain_list' \<rbrace>
   kernelEntry e tc
   \<lbrace>\<lambda>_. invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))\<rbrace>"
+  apply (rule_tac R1="\<lambda>s. obj_at' (\<lambda>tcb. tcbSchedContext tcb = Some (ksCurSc s)) (ksCurThread s) s"
+         in hoare_pre_add[THEN iffD2])
+   apply (clarsimp simp: obj_at'_tcb_scs_of_equiv obj_at'_sc_tcbs_of_equiv sym_heap_def)
+   apply (fastforce simp: ct_in_state'_def pred_tcb_at'_def obj_at'_def)
   apply (simp add: kernelEntry_def)
-  apply (wp ckernel_invs callKernel_valid_duplicates' callKernel_domain_time_left
-            threadSet_invs_trivial threadSet_ct_running' select_wp
-            TcbAcc_R.dmo_invs' static_imp_wp
-            callKernel_domain_time_left
-         | clarsimp simp: user_memory_update_def no_irq_def
-                          valid_domain_list'_def valid_release_queue'_def
-                    dest!: invs_valid_release_queue'
-         | fastforce simp: obj_at'_def)+
+  apply (wpsimp wp: ckernel_invs callKernel_valid_duplicates' threadSet_invs_trivial
+                    threadSet_ct_in_state' static_imp_wp hoare_vcg_disj_lift threadSet_sym_heap_tcbSCs
+         | wps)+
+    apply (rule hoare_vcg_conj_lift)
+     apply (wpsimp wp: threadSet_wp)
+    apply (wpsimp wp: threadSet_invs_trivial; simp?)
+    apply (wpsimp wp: threadSet_ct_running' static_imp_wp)+
+  apply (fastforce simp: obj_at'_def projectKOs  pred_map_def opt_map_red)
   done
 
 lemma absKState_correct':
@@ -617,11 +652,180 @@ lemma doUserOp_valid_duplicates':
   apply clarsimp
   done
 
+(* FIXME RT: generalise similar lemmas in InterruptAcc_R with this one *)
+lemma ct_in_state_irq_state_independent[intro!, simp]:
+  "ct_in_state P (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
+   = ct_in_state P s"
+  by (simp add: ct_in_state_def)
+
+(* FIXME RT: move *)
+lemma valid_tcbs_machine_state_update[iff]:
+  "valid_tcbs (machine_state_update f s) = valid_tcbs s"
+  by (rule iffI;
+      clarsimp simp: valid_tcbs_def valid_tcb_def valid_bound_obj_def valid_tcb_state_def
+                     valid_arch_tcb_def obj_at_def;
+      rename_tac ptr tcb; drule_tac x=ptr and y=tcb in spec2; clarsimp;
+      case_tac "tcb_state tcb"; clarsimp split: option.splits)
+
 text \<open>The top-level correspondence\<close>
+
+(* FIXME RT: move to DetSchedInvs *)
+lemma active_sc_tcb_at_ct_cur_sc_active:
+  "cur_sc_tcb_are_bound s \<Longrightarrow> cur_sc_active s \<longleftrightarrow> active_sc_tcb_at (cur_thread s) s"
+   by (clarsimp simp: vs_all_heap_simps)
+
+lemma kernel_preemption_corres:
+  "corres (dc \<oplus> dc)
+     (einvs and current_time_bounded 5 and scheduler_act_sane
+      and (\<lambda>s. schact_is_rct s \<longrightarrow> cur_sc_active s)
+      and (\<lambda>s. schact_is_rct s \<longrightarrow> ct_in_state activatable s)
+      and cur_sc_chargeable and ct_not_blocked
+      and (\<lambda>s. cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s) and ct_not_queued
+      and current_time_bounded 2 and consumed_time_bounded and ct_not_in_release_q)
+      invs'
+     (liftE preemption_path)
+     (liftE (do irq_opt <- doMachineOp (getActiveIRQ True);
+                   _ <- mcsPreemptionPoint irq_opt;
+                   when (\<exists>y. irq_opt = Some y) (handleInterrupt (the irq_opt))
+                od))" (is "corres _ ?P ?P' _ _")
+  apply (rule_tac Q="\<lambda>s. sc_at' (ksCurSc s) s" in corres_cross_add_guard)
+   apply clarsimp
+   apply (frule (1) cur_sc_tcb_sc_at_cur_sc[OF invs_valid_objs invs_cur_sc_tcb])
+   apply (drule state_relationD, clarsimp)
+   apply (erule sc_at_cross; fastforce simp: invs_def valid_state_def valid_pspace_def)
+  apply (rule corres_guard_imp)
+    apply (simp add: preemption_path_def mcsPreemptionPoint_def bind_assoc)
+    apply (rule corres_split[OF corres_machine_op])
+       apply (rule corres_underlying_trivial)
+       apply (rule no_fail_getActiveIRQ)
+      apply (clarsimp simp: dc_def[symmetric])
+      apply (rule corres_split_eqr[OF _ getCurThread_corres])
+        apply (rule corres_split_eqr[OF _ isSchedulable_corres])
+          apply (rename_tac irq ct sched)
+          apply (rule corres_split[OF corres_if2])
+               apply simp
+              apply (rule_tac P="?P and (\<lambda>s. ct = cur_thread s) and (\<lambda>s. sched = schedulable ct s)
+                                 and K sched"
+                         and P'="?P' and (\<lambda>s. ct = ksCurThread s)
+                                 and (\<lambda>s. sched = isSchedulable_bool ct s)"
+                     in corres_inst)
+              apply (rule corres_gen_asm')
+              apply(rule corres_guard_imp)
+                apply (rule corres_split_eqr[OF _ checkBudget_corres])
+                  apply (simp only: K_bind_def)
+                  apply (rule corres_return_trivial)
+                 apply wpsimp
+                apply wpsimp
+               apply (clarsimp simp: valid_sched_def current_time_bounded_strengthen runnable_eq_active
+                                     schedulable_def2 active_sc_tcb_at_def2 tcb_at_kh_simps[symmetric]
+                                     pred_tcb_at_def obj_at_def)
+               apply (rename_tac scp tcb)
+               apply (prop_tac "cur_sc_tcb_are_bound s \<and> scp = cur_sc s")
+                apply (clarsimp simp: cur_sc_chargeable_def)
+                apply (drule_tac x=scp in spec, clarsimp simp: vs_all_heap_simps)
+               apply clarsimp
+              apply simp
+             apply (simp add: get_sc_active_def active_sc_def dc_def[symmetric])
+             apply (rule corres_split_eqr[OF _ getCurSc_corres])
+               apply (rule corres_split[OF get_sc_corres])
+                 apply (rename_tac csc sc sc')
+                 apply (rule corres_if2)
+                   apply (clarsimp simp: sc_relation_def)
+                  apply (rule_tac P="?P and (\<lambda>s. ct = cur_thread s) and (\<lambda>s. sched = schedulable ct s)
+                                     and (\<lambda>s. \<exists>n. ko_at (Structures_A.SchedContext sc n) (cur_sc s) s)
+                                     and K (\<not>sched) and K (0 < sc_refill_max sc)"
+                             and P'="?P' and (\<lambda>s. ct = ksCurThread s)
+                                     and (\<lambda>s. sched = isSchedulable_bool ct s)"
+                         in corres_inst)
+                  apply(rule corres_guard_imp)
+                    apply (rule corres_split_eqr[OF _ getConsumedTime_corres])
+                      apply (rule chargeBudget_corres)
+                     apply wpsimp
+                    apply wpsimp
+                   apply (prop_tac "cur_sc_active s")
+                    apply (clarsimp simp: obj_at_def is_sc_active_kh_simp[symmetric]
+                                          is_sc_active_def2)
+                    apply (clarsimp simp: active_sc_def)
+                   apply (clarsimp simp: valid_sched_def)
+                   apply clarsimp
+                 apply (rule setConsumedTime_corres)
+                 apply simp
+                apply wpsimp
+               apply wpsimp
+              apply wpsimp
+             apply wpsimp
+            apply (rule_tac x=irq in option_corres)
+              apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
+              apply (simp add: when_def)
+             apply (rule corres_when, simp)
+             apply simp
+             apply (rule handleInterrupt_corres)
+            apply simp
+           apply (rule hoare_vcg_if_split)
+            apply (wpsimp wp: check_budget_valid_sched hoare_vcg_imp_lift')
+           apply (wpsimp wp: hoare_vcg_if_split)
+               apply (wpsimp wp: charge_budget_valid_sched hoare_vcg_imp_lift')
+              apply wpsimp
+             apply wpsimp
+            apply wpsimp
+           apply wpsimp
+          apply (rule_tac Q="\<lambda>_ s. bound irq \<longrightarrow> invs' s \<and> (intStateIRQTable (ksInterruptState s) (the irq) \<noteq>
+                                   irqstate.IRQInactive)"
+                 in hoare_strengthen_post[rotated])
+           apply clarsimp
+          apply (wpsimp wp: hoare_vcg_imp_lift')
+         apply clarsimp
+         apply (wpsimp wp: is_schedulable_wp')
+        apply (wpsimp wp: isSchedulable_wp cong: conj_cong imp_cong)
+       apply wpsimp
+      apply wpsimp
+     apply (rule_tac Q="\<lambda>_ s. invs s \<and>  valid_sched s \<and> valid_list s \<and> scheduler_act_sane s \<and>
+                              consumed_time_bounded s \<and> ct_not_blocked s \<and> ct_not_in_release_q s \<and>
+                              current_time_bounded 5 s \<and> cur_sc_chargeable s \<and>
+                              (cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s) \<and>
+                              (schact_is_rct s \<longrightarrow> cur_sc_active s) \<and> ct_not_queued s \<and>
+                              (schact_is_rct s \<longrightarrow> ct_in_state activatable s)"
+            in hoare_strengthen_post[rotated])
+      apply clarsimp
+      apply (frule ct_not_blocked_cur_sc_not_blocked, clarsimp)
+      apply clarsimp
+      apply (clarsimp simp: invs_def valid_state_def valid_pspace_def valid_objs_valid_tcbs
+                            valid_sched_def cur_tcb_def ct_in_state_kh_simp[symmetric])
+      apply (intro conjI; clarsimp simp: schedulable_def2 ct_in_state_def)
+         apply (clarsimp simp: current_time_bounded_def)
+        apply (rule context_conjI)
+         apply (clarsimp simp: cur_sc_tcb_def sc_tcb_sc_at_def obj_at_def is_sc_obj)
+         apply (erule (1) valid_sched_context_size_objsI)
+        apply clarsimp
+        apply (rule conjI, clarsimp simp: current_time_bounded_strengthen)
+        apply clarsimp
+       apply (frule (1) cur_sc_chargeable_when_ct_active_sc)
+       apply (frule (1) active_sc_tcb_at_ct_cur_sc_active[THEN iffD2])
+       apply (clarsimp simp: current_time_bounded_def)
+      apply (rule conjI; clarsimp simp: current_time_bounded_strengthen)
+      apply (rule context_conjI)
+       apply (clarsimp simp: vs_all_heap_simps obj_at_def)
+      apply (drule consumed_time_bounded_helper)
+       apply (clarsimp simp: current_time_bounded_strengthen[of 5])
+      apply clarsimp
+     apply wpsimp
+    apply (rule_tac Q="\<lambda>irq s. invs' s \<and> sc_at' (ksCurSc s) s \<and>
+                               (\<forall>irq'. irq = Some irq' \<longrightarrow>
+                                         intStateIRQTable (ksInterruptState s ) irq' \<noteq> IRQInactive)"
+           in hoare_post_imp)
+     apply (clarsimp simp: invs'_def valid_pspace'_def valid_objs'_valid_tcbs')
+    apply ((wp doMachineOp_getActiveIRQ_IRQ_active  | simp)+)[1]
+   apply clarsimp
+  apply (clarsimp simp: invs'_def)
+  done
 
 lemma kernel_corres':
   "corres dc (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and (ct_running or ct_idle)
-               and (\<lambda>s. scheduler_action s = resume_cur_thread))
+              and current_time_bounded 5 and consumed_time_bounded and valid_machine_time
+              and ct_not_in_release_q and cur_sc_active
+              and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s)
+              and (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s)
+              and (\<lambda>s. scheduler_action s = resume_cur_thread))
              (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and (ct_running' or ct_idle') and
               (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
               (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
@@ -630,59 +834,154 @@ lemma kernel_corres':
                       handleEvent event `~catchError~`
                         (\<lambda>_. withoutPreemption $ do
                                irq_opt <- doMachineOp (getActiveIRQ True);
-                               mcsPreemptionPoint irq_opt;
+                               _ \<leftarrow> mcsPreemptionPoint irq_opt;
                                when (isJust irq_opt) $ handleInterrupt (fromJust irq_opt)
                              od);
+                 _ \<leftarrow> stateAssert rct_imp_activatable'_asrt [];
                  _ \<leftarrow> ThreadDecls_H.schedule;
+                 _ \<leftarrow> stateAssert rct_imp_activatable'_asrt [];
                  activateThread
-              od)"
-  unfolding call_kernel_def callKernel_def
-  sorry (*
+              od)" (is "corres _ ?P ?P' _ _")
+  unfolding call_kernel_def
+  apply add_cur_tcb'
+  apply (rule_tac Q="\<lambda>s. obj_at' (\<lambda>sc. scTCB sc = Some (ksCurThread s)) (ksCurSc s) s" in corres_cross_add_guard)
+   apply (fastforce simp: invs_def valid_state_def valid_pspace_def intro!: cur_sc_tcb_cross)
+  apply (rule_tac Q="\<lambda>s'. pred_map (\<lambda>tcb. \<not> tcbInReleaseQueue tcb) (tcbs_of' s') (ksCurThread s')"
+         in corres_cross_add_guard)
+   apply (clarsimp, frule tcb_at_invs)
+   apply (fastforce simp: not_in_release_q_def release_queue_relation_def pred_map_def opt_map_red obj_at'_def
+                          invs'_def valid_pspace'_def projectKOs valid_release_queue'_def cur_tcb'_def
+                   dest!: state_relationD)
+  apply (rule_tac Q="\<lambda>s'. pred_map (\<lambda>scPtr. isScActive scPtr s') (tcbSCs_of s') (ksCurThread s')"
+         in corres_cross_add_guard)
+   apply clarsimp
+   apply (frule invs_cur_sc_tcb_symref, clarsimp simp: schact_is_rct)
+   apply (prop_tac "sc_at (cur_sc s) s")
+    apply (frule invs_cur_sc_tcb)
+    apply (clarsimp simp: cur_sc_tcb_def sc_tcb_sc_at_def obj_at_def is_sc_obj)
+    apply (erule (1) valid_sched_context_size_objsI[OF invs_valid_objs])
+   apply (frule (4) active_sc_at'_cross[OF _ invs_psp_aligned invs_distinct])
+   apply (clarsimp simp: active_sc_at'_def obj_at'_def projectKOs cur_tcb'_def pred_tcb_at_def
+                         is_sc_obj obj_at_def  pred_map_def isScActive_def
+                  dest!: state_relationD)
+   apply (rule_tac x="cur_sc s" in exI, clarsimp simp: opt_map_red)
+   apply (frule_tac x="ksCurThread s'" in pspace_relation_absD, simp)
+   apply (fastforce simp: other_obj_relation_def tcb_relation_def)
+  apply simp
   apply (rule corres_guard_imp)
-    apply (rule corres_split_deprecated)
-       prefer 2
+    apply (rule corres_split)
        apply (rule corres_split_handle [OF _ handleEvent_corres])
+         (* handle *)
+         apply (rule kernel_preemption_corres)
+        apply (rule_tac E="\<lambda>_ s. einvs s \<and> scheduler_act_sane s \<and> cur_sc_chargeable s \<and>
+                                 (schact_is_rct s \<longrightarrow> cur_sc_active s) \<and> ct_not_queued s \<and>
+                                 (schact_is_rct s \<longrightarrow> ct_in_state activatable s) \<and>
+                                 (cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s) \<and>
+                                 ct_not_blocked s \<and> current_time_bounded 5 s \<and>
+                                 ct_not_in_release_q s \<and> consumed_time_bounded s"
+               in hoare_post_impErr[where Q=Q and R=Q for Q])
+          apply (wpsimp wp: handle_event_schact_is_rct_imp_ct_activatable
+                            handle_event_schact_is_rct_imp_cur_sc_active call_kernel_schact_is_rct
+                            handle_event_scheduler_act_sane handle_event_ct_not_queuedE_E
+                            handle_event_cur_sc_chargeable handle_event_cur_sc_more_than_ready
+                            handle_event_valid_sched)
          apply simp
-         apply (rule corres_split_deprecated [OF _ corres_machine_op])
-            prefer 2
-            apply (rule corres_underlying_trivial)
-            apply (rule no_fail_getActiveIRQ)
-           apply clarsimp
-           apply (rule_tac x=irq in option_corres)
-            apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
-            apply (simp add: when_def)
-           apply (rule corres_when[simplified dc_def], simp)
-           apply simp
-           apply (rule handleInterrupt_corres[simplified dc_def])
-          apply simp
-          apply (wp hoare_drop_imps hoare_vcg_all_lift)[1]
-         apply simp
-         apply (rule_tac Q="\<lambda>irq s. invs' s \<and>
-                              (\<forall>irq'. irq = Some irq' \<longrightarrow>
-                                 intStateIRQTable (ksInterruptState s ) irq' \<noteq>
-                                 IRQInactive)"
-                      in hoare_post_imp)
-          apply simp
-         apply (wp doMachineOp_getActiveIRQ_IRQ_active handle_event_valid_sched | simp)+
+        apply (clarsimp simp: current_time_bounded_strengthen cur_sc_chargeable_def)
        apply (rule_tac Q="\<lambda>_. \<top>" and E="\<lambda>_. invs'" in hoare_post_impErr)
          apply wpsimp+
-       apply (simp add: invs'_def valid_state'_def)
-      apply (rule corres_split_deprecated [OF _ schedule_corres])
-        apply (rule activateThread_corres)
-       apply (wp handle_interrupt_valid_sched[unfolded non_kernel_IRQs_def, simplified]
-                 schedule_invs' hoare_vcg_if_lift2 hoare_drop_imps |simp)+
-     apply (rule_tac Q="\<lambda>_. valid_sched and invs and valid_list" and
-                     E="\<lambda>_. valid_sched and invs and valid_list"
-            in hoare_post_impErr)
-       apply (wp handle_event_valid_sched hoare_vcg_imp_lift' |simp)+
-   apply (clarsimp simp: active_from_running)
+      apply (rule_tac P="invs and valid_sched and current_time_bounded 5
+                         and ct_ready_if_schedulable and scheduler_act_sane
+                         and (\<lambda>s. schact_is_rct s \<longrightarrow> cur_sc_active s)
+                         and (\<lambda>s. schact_is_rct s \<longrightarrow> ct_in_state activatable s)
+                         and (\<lambda>s. schact_is_rct s \<longrightarrow> ct_not_in_release_q s)
+                         and cur_sc_more_than_ready and consumed_time_bounded
+                         and cur_sc_in_release_q_imp_zero_consumed"
+                  and P'=invs' in corres_inst)
+      apply (rule corres_stateAssert_add_assertion)
+       apply (simp add: rct_imp_activatable'_asrt_def)
+       apply (rule corres_guard_imp)
+         apply (rule corres_split_deprecated [OF _ schedule_corres])
+           apply (rule_tac P="invs and valid_sched and current_time_bounded 5
+                              and cur_sc_active and schact_is_rct
+                              and ct_in_state activatable
+                              and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s \<and>
+                                       cur_sc_offset_sufficient (consumed_time s) s)"
+                       and P'="invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)"
+                  in corres_inst)
+           apply (rule corres_stateAssert_add_assertion)
+            apply (rule corres_guard_imp)
+              apply (rule activateThread_corres)
+             apply simp
+            apply simp
+           apply (clarsimp simp: ct_in_state_def ct_in_state'_def)
+           apply (drule (3) st_tcb_at_coerce_concrete[OF _ _ invs_psp_aligned invs_distinct])
+           apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs state_relation_def)
+           apply (rename_tac st; case_tac st; clarsimp)
+          apply (wpsimp wp: schedule_valid_sched
+                            schedule_cur_sc_active schedule_ct_activateable
+                            schedule_cur_sc_offset_ready_and_sufficient)
+         apply (wpsimp wp: schedule_invs' schedule_sch)
+        apply (clarsimp simp: current_time_bounded_strengthen)
+       apply clarsimp
+      apply (clarsimp simp: rct_imp_activatable'_asrt_def)
+      apply (clarsimp simp: ct_in_state_def ct_in_state'_def)
+      apply (prop_tac "schact_is_rct s")
+       apply (clarsimp simp: state_relation_def schact_is_rct_def sched_act_relation_def)
+       apply (case_tac "scheduler_action s"; clarsimp)
+      apply (drule schact_is_rct, clarsimp)
+      apply (frule (3) st_tcb_at_coerce_concrete[OF _ _ invs_psp_aligned invs_distinct])
+      apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs state_relation_def)
+      apply (rename_tac st; case_tac st; clarsimp)
+     apply wpsimp
+      apply (wpsimp wp: preemption_path_valid_sched
+                        preemption_path_current_time_bounded_5
+                        preemption_point_scheduler_act_sane
+                        preemption_path_schact_is_rct_imp_ct_not_in_release_q
+                        preemption_path_cur_sc_more_than_ready
+                        preemption_path_consumed_time_bounded
+                        preemption_path_cur_sc_in_release_q_imp_zero_consumed
+                        preemption_path_ct_ready_if_schedulable)
+     apply ((wpsimp wp: he_invs handle_event_valid_sched handle_event_scheduler_act_sane
+                        handle_event_cur_sc_chargeable handle_event_schact_is_rct_imp_cur_sc_active
+                        handle_event_schact_is_rct_imp_ct_activatable
+                        handle_event_schact_is_rct_imp_ct_not_in_release_q
+                        handle_event_cur_sc_in_release_q_imp_zero_consumed
+             | strengthen ct_not_blocked_imp_ct_not_blocked_on_receive
+                          ct_not_blocked_imp_ct_not_blocked_on_ntfn)+)[1]
+    apply (wpsimp wp: he_invs')
+      apply (wpsimp simp: mcsPreemptionPoint_def wp: isSchedulable_wp)
+     apply (wpsimp wp: dmo_getirq_inv)
+     apply (clarsimp simp: isSchedulable_bool_def isScActive_def)
+    apply (rule_tac Q="\<lambda>_. invs'" and E="\<lambda>_. invs'" in hoare_post_impErr)
+      apply (wpsimp wp: he_invs')
+     apply simp
+    apply clarsimp
+   apply (clarsimp  cong: conj_cong)
+   apply (intro conjI, clarsimp simp: active_from_running)
+        apply (rule valid_sched_ct_not_queued; clarsimp?)
+       apply (erule (2) cur_sc_active_ct_not_in_release_q_imp_ct_running_imp_ct_schedulable, clarsimp)
+      apply (clarsimp simp: ct_in_state_def pred_tcb_at_def obj_at_def cur_tcb_def is_tcb
+                     dest!: invs_cur)
+     apply (clarsimp simp: invs_def valid_state_def valid_pspace_def
+                           invs_strengthen_cur_sc_tcb_are_bound)
+    apply (fastforce simp: ct_in_state_def pred_tcb_at_def obj_at_def cur_tcb_def is_tcb
+                    dest!: invs_cur)
+   apply (clarsimp, rule schact_is_rct_ct_released; simp?)
+   apply (frule (1) cur_sc_not_idle_sc_ptr')
+    apply (clarsimp simp: invs_def valid_state_def valid_pspace_def
+                          invs_strengthen_cur_sc_tcb_are_bound)
+   apply simp
   apply (clarsimp simp: active_from_running')
-  done *)
+  done
 
 lemma kernel_corres:
-  "corres dc (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and (ct_running or ct_idle) and
-              (\<lambda>s. scheduler_action s = resume_cur_thread) and
-              (\<lambda>s. 0 < domain_time s \<and> valid_domain_list s))
+  "corres dc (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and (ct_running or ct_idle)
+              and current_time_bounded 5 and consumed_time_bounded and valid_machine_time
+              and ct_not_in_release_q and cur_sc_active
+              and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s)
+              and (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s)
+              and (\<lambda>s. scheduler_action s = resume_cur_thread)
+              and (\<lambda>s. 0 < domain_time s \<and> valid_domain_list s))
              (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and (ct_running' or ct_idle') and
               (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
               (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
@@ -698,12 +997,12 @@ lemma kernel_corres:
         apply simp
        apply (simp add: kernelExitAssertions_def state_relation_def)
       apply (simp only: bind_assoc)
-  sorry (* FIXME RT: call_kernel_domain_time_inv_det_ext in DetSchedDomainTime_AI
+      apply (rule kernel_corres')
      apply (wp call_kernel_domain_time_inv_det_ext call_kernel_domain_list_inv_det_ext)
-    apply wp
+    apply wpsimp
    apply clarsimp
   apply clarsimp
-  done *)
+  done
 
 lemma user_mem_corres:
   "corres (=) invs invs' (gets (\<lambda>x. g (user_mem x))) (gets (\<lambda>x. g (user_mem' x)))"
@@ -717,30 +1016,40 @@ lemma device_mem_corres:
                          invs_def invs'_def
                          corres_underlying_def device_mem_relation)
 
+crunch domain_time_inv[wp]: thread_set "\<lambda>s. P (domain_time s)"
+
 lemma entry_corres:
-  "corres (=) (\<lambda>s. mcs_invs s \<and> (event \<noteq> Interrupt \<longrightarrow> ct_running s))
-              (invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
-          (kernel_entry event tc) (kernelEntry event tc)"
+  "corres (=)
+      (\<lambda>s. mcs_invs s \<and> (ct_running s \<or> ct_idle s) \<and> (event \<noteq> Interrupt \<longrightarrow> ct_running s))
+      (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and (ct_running' or ct_idle')
+       and (\<lambda>s. 0 < ksDomainTime s) and valid_domain_list'
+       and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
+       and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
+      (kernel_entry event tc) (kernelEntry event tc)"
   apply (simp add: kernel_entry_def kernelEntry_def)
+  apply add_cur_tcb'
   apply (rule corres_guard_imp)
     apply (rule corres_split_deprecated [OF _ getCurThread_corres])
-      apply (rule corres_split_deprecated)
-         prefer 2
+      apply (rule corres_split)
          apply simp
          apply (rule threadset_corresT)
            apply (simp add: tcb_relation_def arch_tcb_relation_def
                             arch_tcb_context_set_def atcbContextSet_def)
           apply (clarsimp simp: tcb_cap_cases_def)
          apply (clarsimp simp: tcb_cte_cases_def)
-        apply (rule corres_split_deprecated [OF _ kernel_corres])
-          apply (rule corres_split_eqr [OF _ getCurThread_corres])
-            apply (rule threadGet_corres)
-            apply (simp add: tcb_relation_def arch_tcb_relation_def
-                             arch_tcb_context_get_def atcbContextGet_def)
-           apply wp+
-  sorry (*
-         apply (rule hoare_strengthen_post, rule akernel_invs, simp add: invs_def cur_tcb_def)
-        apply (rule hoare_strengthen_post, rule ckernel_invs, simp add: invs'_def cur_tcb'_def)
+        apply (rule corres_split [OF kernel_corres])
+          apply (rule_tac P=invs and P'=\<top> in corres_inst)
+          apply add_cur_tcb'
+          apply (rule corres_guard_imp)
+            apply (rule corres_split_eqr [OF _ getCurThread_corres])
+              apply (rule threadGet_corres)
+              apply (simp add: tcb_relation_def arch_tcb_relation_def
+                               arch_tcb_context_get_def atcbContextGet_def)
+             apply wp+
+           apply clarsimp
+          apply (clarsimp simp: cur_tcb'_def)
+         apply (rule hoare_strengthen_post, rule akernel_invs_det_ext, simp add: invs_def cur_tcb_def)
+        apply wpsimp
        apply (wp thread_set_invs_trivial
                  threadSet_invs_trivial threadSet_ct_running'
                  select_wp thread_set_not_state_valid_sched static_imp_wp
@@ -748,8 +1057,9 @@ lemma entry_corres:
               | simp add: tcb_cap_cases_def ct_in_state'_def thread_set_no_change_tcb_state
               | (wps, wp threadSet_st_tcb_at2) )+
    apply (clarsimp simp: invs_def cur_tcb_def)
-  apply (clarsimp simp: ct_in_state'_def)
-  done *)
+  apply (clarsimp simp: ct_in_state'_def cur_tcb'_def invs'_def valid_release_queue'_def
+                        projectKOs obj_at'_def)
+  done
 
 lemma corres_gets_machine_state:
   "corres (=) \<top> \<top> (gets (f \<circ> machine_state)) (gets (f \<circ> ksMachineState))"
@@ -981,16 +1291,34 @@ lemma ckernel_invariant:
      apply (rule hoare_weaken_pre)
       apply (rule kernelEntry_invs')
      apply clarsimp
-     apply (intro conjI)
-       subgoal by (fastforce intro: ct_running_cross)
-      apply (rule ct_running_or_idle_cross)
-         apply force
-        apply fastforce
-       apply fastforce
-      apply fastforce
-     subgoal by (fastforce intro!: resume_cur_thread_cross)
-    apply (rule_tac x=abs_state in exI)
+     apply (rename_tac s' s; intro conjI)
+        apply (prop_tac "cur_sc s = ksCurSc s'", fastforce dest!: state_relationD)
+        apply (prop_tac "sc_at (cur_sc s) s")
+         apply (rule cur_sc_tcb_sc_at_cur_sc[OF invs_valid_objs invs_cur_sc_tcb]; simp)
+        apply (prop_tac "sc_at' (ksCurSc s') s'")
+         apply (rule sc_at_cross[OF state_relation_pspace_relation invs_psp_aligned invs_distinct]; simp)
+        apply (prop_tac "is_active_sc' (ksCurSc s') s'")
+         apply (rule is_active_sc'2_cross[OF _ invs_psp_aligned invs_distinct], simp+)
+
+       apply (clarsimp simp: invs'_def valid_pspace'_def, rule sym_refs_tcbSCs; simp?)
+       apply (clarsimp simp: invs_def valid_state_def valid_pspace_def state_refs_of_cross_eq)
+      apply (fastforce dest!: cur_sc_tcb_cross[simplified schact_is_rct_def]
+                        simp: invs_def valid_state_def valid_pspace_def)
+     apply (clarsimp simp: invs'_def valid_release_queue'_def)
+     apply (prop_tac "cur_tcb' s'")
+      apply (rule cur_tcb_cross[OF invs_cur invs_psp_aligned invs_distinct]; simp?)
+     apply (clarsimp simp: cur_tcb'_def)
+     apply (clarsimp simp: pred_map_def obj_at'_def projectKOs opt_map_red not_in_release_q_def
+                           release_queue_relation_def
+                    dest!: state_relationD)
+
     apply clarsimp
+    apply (rule_tac x=abs_state in exI)
+    apply (intro conjI; (clarsimp; fail)?)
+      subgoal by (fastforce intro: ct_running_cross)
+     apply (rule ct_running_or_idle_cross; simp?; fastforce)
+    subgoal by (fastforce intro!: resume_cur_thread_cross)
+
    apply clarsimp
    apply (intro conjI impI)
      apply metis
@@ -1099,17 +1427,24 @@ lemma fw_sim_A_H:
     apply (clarsimp simp: corres_underlying_def)
     apply (drule_tac x="(abs_state, conc_state)" in bspec, blast)
     apply clarsimp
+    apply (frule (1) ct_running_or_idle_cross; clarsimp)
+    apply (prop_tac "event \<noteq> Interrupt \<longrightarrow> ct_running' conc_state", fastforce dest!: ct_running_cross)
+    apply (prop_tac "0 < ksDomainTime conc_state \<and>
+            valid_domain_list' conc_state \<and> ksSchedulerAction conc_state = ResumeCurrentThread")
+     apply (clarsimp simp: state_relation_def)
+    apply clarsimp
     apply (drule_tac x="(uc', conc_state')" in bspec, blast)
     apply clarsimp
     apply (frule use_valid[OF _ kernel_entry_invs])
      apply force
     apply (rename_tac abs_state')
-    apply (intro conjI impI allI)
+    apply (intro conjI impI allI; simp)
      apply (rule_tac x=abs_state' in exI)
-     subgoal by (fastforce intro: ct_running_related)
+     apply (prop_tac "ct_running abs_state'", rule ct_running_related; simp)
+    apply clarsimp
     apply (rule_tac x=abs_state' in exI)
-    subgoal by (fastforce dest: ct_running_cross)
-
+    apply clarsimp
+    apply (drule_tac a=abs_state' in ct_running_cross; clarsimp)
    apply (erule_tac P="a \<and> b" for a b in disjE)
     apply (clarsimp simp: do_user_op_H_def do_user_op_A_def monad_to_transition_def)
     apply (rule rev_mp, rule_tac tc1=tc and f1=uop and P="ct_running and einvs" in corres_guard_imp2[OF do_user_op_corres])
@@ -1143,7 +1478,7 @@ lemma fw_sim_A_H:
    apply (clarsimp simp: check_active_irq_H_def check_active_irq_A_def)
    apply (rule rev_mp, rule checkActiveIRQ_corres')
    apply (clarsimp simp: corres_underlying_def)
-    apply fastforce
+   apply fastforce
 
   apply (clarsimp simp: absKState_correct dest!: lift_state_relationD)
   done

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -1980,25 +1980,32 @@ crunches setConsumedTime, refillResetRR
   for cur_tcb'[wp]: cur_tcb'
   (simp: cur_tcb'_def)
 
+lemma cur_sc_not_idle_imp_ct_not_idle:
+  "\<lbrakk>invs s; schact_is_rct s; cur_sc s \<noteq> idle_sc_ptr\<rbrakk> \<Longrightarrow> \<not> ct_idle s"
+  apply (clarsimp simp: invs_def valid_state_def cur_sc_tcb_def ct_in_state_def valid_pspace_def
+                 dest!: schact_is_rct only_idleD)
+  apply (clarsimp simp: pred_tcb_at_def obj_at_def valid_idle_def sc_tcb_sc_at_def)
+  apply (fastforce dest!: sym_ref_sc_tcb)
+  done
+
 lemma chargeBudget_corres:
   "corres dc
      (invs and valid_list and valid_sched_action and active_sc_valid_refills and valid_release_q
-      and valid_ready_qs and released_ipc_queues and cur_sc_active and ct_active and schact_is_rct
-      and current_time_bounded 5
+      and valid_ready_qs and released_ipc_queues and cur_sc_active
+      and current_time_bounded 5 and schact_is_rct
       and ct_not_queued and ct_not_in_release_q
+      and (ct_active or ct_idle)
       and cur_sc_offset_ready 0)
      invs'
      (charge_budget consumed canTimeout) (chargeBudget consumed canTimeout True)"
-  (is "corres _ (?pred and cur_sc_offset_ready 0) _ _ _")
+  (is "corres _ (?pred and _ and cur_sc_offset_ready 0) _ _ _")
   unfolding chargeBudget_def charge_budget_def ifM_def bind_assoc
-  apply (rule_tac Q=ct_active' in corres_cross_add_guard)
-   apply (fastforce intro!: ct_active_cross simp: invs_def valid_state_def valid_pspace_def)
   apply (rule_tac Q="\<lambda>s. obj_at' (\<lambda>sc. scTCB sc = Some (ksCurThread s)) (ksCurSc s) s" in corres_cross_add_guard)
    apply (fastforce simp: invs_def valid_state_def valid_pspace_def intro!: cur_sc_tcb_cross)
   apply (rule_tac Q="\<lambda>s. is_active_sc' (ksCurSc s) s" in corres_cross_add_guard)
-  apply (fastforce intro: valid_objs_valid_sched_context_size
-                    simp: sc_at_pred_n_def obj_at_def is_sc_obj_def state_relation_def vs_all_heap_simps
-                   intro: is_active_sc'2_cross)
+   apply (fastforce intro: valid_objs_valid_sched_context_size
+                     simp: sc_at_pred_n_def obj_at_def is_sc_obj_def state_relation_def vs_all_heap_simps
+                    intro: is_active_sc'2_cross)
   apply (rule_tac Q="\<lambda>s. sc_at (cur_sc s) s" in corres_cross_add_abs_guard)
    apply (fastforce intro: cur_sc_tcb_sc_at_cur_sc)
   apply add_cur_tcb'
@@ -2007,105 +2014,106 @@ lemma chargeBudget_corres:
   apply (rule corres_symb_exec_r[rotated, OF getIdleSC_sp]; wpsimp simp: getIdleSC_def)
   apply (rule_tac F="idle_sc_ptr = idleSCPtr" in corres_req)
    apply (clarsimp simp: state_relation_def)
-  apply (rule_tac Q="\<lambda>_. ?pred"
+  apply (rule_tac Q="\<lambda>_. ?pred and (ct_active or ct_idle)"
               and Q'="\<lambda>_. invs' and cur_tcb'"
                in corres_split')
      apply (clarsimp simp: when_def split del: if_split)
      apply (rule corres_if_split; (solves corressimp)?)
-     apply (rule corres_split'[rotated 2, OF is_round_robin_sp isRoundRobin_sp])
-      apply (corressimp corres: isRoundRobin_corres)
-     apply (rule_tac Q="\<lambda>_ s. sc_at (cur_sc s) s \<and> cur_sc s = scPtr"
-                 and Q'="\<lambda>_ s'. sc_at' (ksCurSc s') s' \<and> ksCurSc s' = scPtr"
-                 and r'=dc
-                  in corres_split')
-        apply (rule corres_if_split; (solves simp)?)
-         apply (corressimp corres: refillResetRR_corres)
-         apply (fastforce intro!: active_sc_valid_refillsE)
-        apply (corressimp corres: refillBudgetCheck_corres)
-        apply (fastforce intro!: active_sc_valid_refillsE valid_objs'_valid_refills')
-       apply (rule corres_guard_imp)
-         apply (rule updateSchedContext_corres)
-           apply (fastforce simp: sc_relation_def obj_at_simps is_sc_obj opt_map_red
-                           dest!: state_relation_sc_relation)
-          apply (fastforce simp: sc_relation_def obj_at_simps is_sc_obj opt_map_red
-                          dest!: state_relation_sc_replies_relation
-                           elim: sc_replies_relation_prevs_list)
-         apply (clarsimp simp: objBits_simps)
-        apply simp
-       apply simp
-      apply ((wpsimp | wps)+)[1]
-     apply ((wpsimp | wps)+)[1]
-    apply (rule corres_split_skip)
-       apply wpsimp
-      apply wpsimp
-     apply (corressimp corres: setConsumedTime_corres)
-    apply (clarsimp simp: andM_def ifM_def whenM_def when_def bind_assoc)
-    apply (rule corres_split'[rotated 2, OF gets_sp getCurThread_sp])
-     apply corressimp
-    apply (rule corres_split'[rotated 2, OF is_schedulable_sp' isSchedulable_sp])
-     apply (corressimp corres: isSchedulable_corres)
-     apply (fastforce dest: invs_cur simp: cur_tcb_def)
-    apply (rule corres_if_split; (solves simp)?)
+     apply (rule corres_guard_imp)
+       apply (rule corres_split_eqr[OF _ isRoundRobin_corres])
+         apply (rule corres_split[OF corres_if2], simp)
+             apply (rule refillResetRR_corres)
+            apply (rule refillBudgetCheck_corres, simp)
+           apply (rule updateSchedContext_corres)
+             apply (fastforce simp: sc_relation_def obj_at'_def projectKOs obj_at_def is_sc_obj opt_map_red
+                             dest!: state_relation_sc_relation)
+            apply (fastforce simp: sc_relation_def obj_at'_def projectKOs obj_at_def is_sc_obj opt_map_red
+                            dest!: state_relation_sc_replies_relation elim: sc_replies_relation_prevs_list)
+           apply (clarsimp simp: objBits_simps)
+          apply (wpsimp wp: is_round_robin_wp isRoundRobin_wp)+
+      apply (clarsimp simp: invs_def valid_state_def valid_pspace_def)
+      apply (drule (1) active_sc_valid_refillsE, clarsimp)
+      apply (clarsimp simp: round_robin_def vs_all_heap_simps obj_at_def)
+     apply (clarsimp simp: obj_at'_def projectKOs invs'_def valid_pspace'_def elim!: valid_objs'_valid_refills')
     apply (rule corres_guard_imp)
-      apply (rule corres_split[OF endTimeslice_corres])
-        apply (rule corres_split[OF rescheduleRequired_corres])
-          apply (rule setReprogramTimer_corres)
-         apply wpsimp+
-       apply (rule hoare_strengthen_post [where Q="\<lambda>_. invs and active_sc_valid_refills
-                                                       and valid_sched_action", rotated])
-        apply (clarsimp simp: invs_def valid_state_def valid_pspace_def valid_objs_valid_tcbs
-                              valid_sched_action_def)
-       apply (wpsimp wp: end_timeslice_invs end_timeslice_valid_sched_action)
-      apply (rule hoare_strengthen_post[where Q="\<lambda>_. invs'", rotated])
-       apply (clarsimp simp: invs'_def valid_pspace'_def)
+      apply (rule corres_split[OF setConsumedTime_corres], simp)
+        apply (simp add: andM_def whenM_def ifM_def when_def[symmetric] bind_assoc)
+        apply (rule corres_split_eqr[OF _ getCurThread_corres gets_sp getCurThread_sp])
+        apply (rule corres_guard_imp)
+          apply (rule corres_split_eqr[OF _ isSchedulable_corres is_schedulable_sp' isSchedulable_sp])
+          apply (rename_tac sched)
+          apply (rule corres_guard_imp)
+            apply (rule corres_when2, simp)
+            apply (rule corres_split[OF endTimeslice_corres])
+              apply (rule corres_split[OF rescheduleRequired_corres])
+                apply (rule setReprogramTimer_corres)
+               apply wpsimp
+              apply wpsimp
+             apply (rule hoare_strengthen_post
+                              [where Q="\<lambda>_. invs and active_sc_valid_refills
+                                            and valid_sched_action", rotated])
+              apply (clarsimp simp: invs_def valid_state_def valid_pspace_def valid_objs_valid_tcbs
+                                    valid_sched_action_def)
+             apply (wpsimp wp: end_timeslice_invs end_timeslice_valid_sched_action)
+            apply (rule hoare_strengthen_post[where Q="\<lambda>_. invs'", rotated])
+             apply (clarsimp simp: invs'_def valid_pspace'_def)
+            apply wpsimp
+           apply simp+
+       apply wpsimp
+      apply (rule hoare_strengthen_post
+                     [where Q="\<lambda>_. invs' and cur_tcb'", rotated])
+       apply (clarsimp simp: invs'_def valid_pspace'_def valid_objs'_valid_tcbs' cur_tcb'_def
+                             isSchedulable_bool_def runnable_eq_active' pred_map_def
+                             obj_at'_def projectKOs pred_tcb_at'_def ct_in_state'_def)
       apply wpsimp
-     apply (fastforce simp: current_time_bounded_def)
-    apply (fastforce dest: isSchedulable_bool_runnableE
-                     simp: cur_tcb'_def ct_in_state'_def runnable_eq_active')
-   apply wps_conj_solves
-        apply (wpsimp wp: sc_consumed_add_invs refill_budget_check_invs)
-       apply (wpsimp wp: refill_reset_rr_valid_sched_action
-                         refill_budget_check_valid_sched_action_act_not is_round_robin_wp)
-       apply (fastforce dest: schact_is_rct)
-      apply (wpsimp wp: refill_budget_check_active_sc_valid_refills is_round_robin_wp)
-      apply (clarsimp simp: obj_at_def vs_all_heap_simps)
-     apply (wpsimp wp: refill_budget_check_valid_release_q is_round_robin_wp)
-     apply (fastforce dest!: cur_sc_chargeable_sc_not_in_release_q invs_cur_sc_chargeableE
-                             active_sc_valid_refillsE
-                       simp: vs_all_heap_simps sc_at_pred_n_def obj_at_def valid_refills_def
-                             rr_valid_refills_def)
-    apply (wpsimp wp: refill_budget_check_valid_ready_qs_not_queued is_round_robin_wp)
-    apply (fastforce simp: sc_tcb_sc_at_def invs_def valid_state_def valid_pspace_def
-                           vs_all_heap_simps obj_at_def cur_sc_tcb_def
-                    dest!: sym_ref_tcb_sc schact_is_rct active_sc_valid_refillsE)
-   apply (wpsimp wp: refill_budget_check_released_ipc_queues is_round_robin_wp)
+     apply (clarsimp simp: schedulable_def2 ct_in_state_def runnable_eq_active current_time_bounded_def
+                           invs_def valid_state_def valid_pspace_def cur_tcb_def
+                           valid_objs_valid_tcbs state_refs_of_def)
+    apply clarsimp
+   apply wpsimp
+      apply (clarsimp simp: consumed_time_update_arch.state_refs_update sc_consumed_update_eq[symmetric])
+      apply (wpsimp wp: hoare_vcg_conj_lift; (solves wpsimp)?
+             | strengthen valid_objs_valid_tcbs | wps)+
+      apply (wpsimp wp: hoare_vcg_disj_lift)
+     apply (wpsimp wp: sc_at_typ_at refill_reset_rr_valid_sched_action hoare_vcg_disj_lift
+                       refill_budget_check_valid_sched_action_act_not
+                       refill_budget_check_active_sc_valid_refills
+                        refill_budget_check_valid_release_q
+                        refill_budget_check_valid_ready_qs_not_queued)
+     apply (wpsimp wp: refill_budget_check_released_ipc_queues
+            | strengthen live_sc'_ex_cap[OF invs_iflive'] valid_sc_strengthen[OF invs_valid_objs'])+
+     apply (wpsimp wp: hoare_vcg_disj_lift)
+    apply (wpsimp wp: is_round_robin_wp isRoundRobin_wp)+
    apply (frule invs_cur_sc_tcb)
    apply (frule invs_valid_objs)
-   apply (rule context_conjI)
-    apply (fastforce simp: obj_at_def vs_all_heap_simps
-                    dest!: active_sc_valid_refillsE)
-   apply (clarsimp simp: cur_sc_tcb_def schact_is_rct_def)
-   apply (frule ct_runnable_ct_not_blocked)
+   apply (rule conjI; clarsimp)
+   apply (frule (2) cur_sc_not_idle_imp_ct_not_idle)
+   apply (intro conjI; clarsimp; frule invs_cur)
+    apply (drule (1) active_sc_valid_refillsE, clarsimp)
+    apply (clarsimp simp: vs_all_heap_simps cur_tcb_def obj_at_def is_tcb)
+    apply (clarsimp simp: sc_refills_sc_at_def obj_at_def cur_sc_tcb_def
+                          sc_valid_refills_def rr_valid_refills_def
+                   dest!: schact_is_rct)
+   apply (intro conjI;
+          clarsimp simp: cur_sc_tcb_def tcb_at_kh_simps vs_all_heap_simps
+                  dest!: schact_is_rct)
+     apply ((fastforce simp: sc_tcb_sc_at_def obj_at_def dest!: sym_ref_tcb_sc[OF invs_sym_refs])+)[2]
+   apply (drule ct_runnable_ct_not_blocked)
    apply (clarsimp simp: cur_sc_not_blocked_def)
-   apply (prop_tac "cur_sc_tcb_are_bound s")
-    apply (fastforce intro: invs_strengthen_cur_sc_tcb_are_bound)
-   apply (clarsimp simp: vs_all_heap_simps ct_in_state_def pred_tcb_at_def obj_at_def sc_at_pred_n_def)
-   apply (frule sym_ref_tcb_sc[rotated], fastforce+)
-  apply wps_conj_solves
-  apply (rule hoare_when_cases, simp)
-  apply (rule hoare_seq_ext[OF _ isRoundRobin_sp])
-  apply (rule_tac B="\<lambda>_. invs'" in hoare_seq_ext[rotated])
-   apply wpsimp
+   apply (prop_tac "heap_ref_eq (cur_sc s) (cur_thread s) (tcb_scps_of s)")
+    apply (frule (1) sym_refs_bound_sc_tcb_iff_sc_tcb_sc_at[symmetric, OF refl refl invs_sym_refs, THEN iffD1])
+    apply (clarsimp simp: vs_all_heap_simps tcb_at_kh_simps)
+   apply (drule sym_refs_inv_tcb_scps[OF invs_sym_refs])
+   apply (clarsimp simp: heap_refs_inv_def2 vs_all_heap_simps ct_in_state_def pred_tcb_at_def obj_at_def)
   apply (wpsimp wp: updateSchedContext_invs')
-  apply (fastforce dest: invs'_ko_at_valid_sched_context'
-                  intro: if_live_then_nonz_capE'
-                   simp: ko_wp_at'_def obj_at_simps)
+     apply (wpsimp wp: typ_at_lifts
+           | strengthen live_sc'_ex_cap[OF invs_iflive'] valid_sc_strengthen[OF invs_valid_objs'])+
   done
 
 lemma checkBudget_corres:
   "corres (=)
      (einvs and current_time_bounded 5 and cur_sc_offset_ready 0
-      and cur_sc_active and ct_active and schact_is_rct and current_time_bounded 2
+      and cur_sc_active and (ct_active or ct_idle) and schact_is_rct and current_time_bounded 2
       and ct_not_queued and ct_not_in_release_q)
      invs'
      check_budget checkBudget"
@@ -2327,118 +2335,6 @@ lemma handleHypervisorFault_corres:
           (handleHypervisorFault w fault)"
   apply (cases fault; clarsimp simp add: handleHypervisorFault_def returnOk_def2)
   done
-
-(* FIXME: move *)
-lemma handleEvent_corres:
-  "corres (dc \<oplus> dc) (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and
-                       (\<lambda>s. scheduler_action s = resume_cur_thread))
-                      (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and
-                       (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
-                       (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
-                      (handle_event event) (handleEvent event)"
-  (is "?handleEvent_corres")
-proof -
-  have hw:
-    "\<And>isBlocking canGrant.
-     corres dc (einvs and ct_running and valid_machine_time and current_time_bounded 2
-                and ct_released and (\<lambda>s. scheduler_action s = resume_cur_thread)
-                and ct_not_in_release_q and ct_not_queued)
-               (invs' and ct_running'
-                      and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
-               (handle_recv isBlocking canGrant) (handleRecv isBlocking canGrant)"
-    apply add_cur_tcb'
-    apply add_ct_not_inQ
-    apply (rule corres_guard_imp [OF handleRecv_isBlocking_corres])
-     apply (fastforce simp: ct_in_state_def ct_in_state'_def
-                     elim!: st_tcb_weakenE pred_tcb'_weakenE
-                      dest: ct_not_ksQ)+
-    done
-    show ?thesis
-      apply (case_tac event)
-          apply (simp_all add: handleEvent_def)
-          apply (rename_tac syscall)
-          apply (case_tac syscall)
-          apply (auto intro: corres_guard_imp[OF handleSend_corres]
-                             corres_guard_imp[OF hw]
-                             corres_guard_imp[OF handleCall_corres]
-                             corres_guard_imp[OF handleYield_corres]
-                             active_from_running active_from_running'
-                      simp: simple_sane_strg)[8]
-  sorry (*
-         apply (rule corres_split')
-            apply (rule corres_guard_imp[OF getCurThread_corres], simp+)
-           apply (rule handleFault_corres)
-           apply simp
-          apply (simp add: valid_fault_def)
-          apply wp
-          apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE
-                           simp: ct_in_state_def)
-         apply wp
-         apply (clarsimp)
-         apply (frule(1) ct_not_ksQ)
-         apply (auto simp: ct_in_state'_def sch_act_simple_def
-                           sch_act_sane_def
-                     elim: pred_tcb'_weakenE st_tcb_ex_cap'')[1]
-        apply (rule corres_split')
-           apply (rule corres_guard_imp, rule getCurThread_corres, simp+)
-          apply (rule handleFault_corres)
-          apply (simp add: valid_fault_def)
-         apply wp
-         apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE
-                          simp: ct_in_state_def valid_fault_def)
-        apply wp
-        apply clarsimp
-        apply (frule(1) ct_not_ksQ)
-        apply (auto simp: ct_in_state'_def sch_act_simple_def
-                          sch_act_sane_def
-                    elim: pred_tcb'_weakenE st_tcb_ex_cap'')[1]
-       apply (rule corres_guard_imp)
-         apply (rule corres_split_eqr[where R="\<lambda>rv. einvs"
-                                      and R'="\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> R'' x s"
-                                      for R''])
-            apply (case_tac rv, simp_all add: doMachineOp_return)[1]
-            apply (rule handleInterrupt_corres)
-           apply (rule corres_machine_op)
-           apply (rule corres_Id, simp+)
-           apply (wp hoare_vcg_all_lift
-                     doMachineOp_getActiveIRQ_IRQ_active'
-                    | simp
-                    | simp add: imp_conjR | wp (once) hoare_drop_imps)+
-        apply force
-       apply simp
-       apply (simp add: invs'_def valid_state'_def)
-      apply (rule_tac corres_split')
-         apply (rule corres_guard_imp, rule getCurThread_corres, simp+)
-        apply (rule corres_split_catch)
-           apply (erule handleFault_corres)
-          apply (rule handleVMFault_corres)
-         apply (rule hoare_elim_pred_conjE2)
-         apply (rule hoare_vcg_E_conj, rule valid_validE_E, wp)
-         apply (wp handle_vm_fault_valid_fault)
-        apply (rule hv_inv_ex')
-       apply wp
-       apply (clarsimp simp: simple_from_running tcb_at_invs)
-       apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE simp: ct_in_state_def)
-      apply wp
-      apply (clarsimp)
-      apply (frule(1) ct_not_ksQ)
-      apply (fastforce simp: simple_sane_strg sch_act_simple_def ct_in_state'_def
-                  elim: st_tcb_ex_cap'' pred_tcb'_weakenE)
-         apply (rule corres_split')
-            apply (rule corres_guard_imp[OF getCurThread_corres], simp+)
-           apply (rule handleHypervisorFault_corres)
-          apply (simp add: valid_fault_def)
-          apply wp
-          apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE
-                           simp: ct_in_state_def)
-         apply wp
-         apply (clarsimp)
-         apply (frule(1) ct_not_ksQ)
-         apply (auto simp: ct_in_state'_def sch_act_simple_def
-                           sch_act_sane_def
-                     elim: pred_tcb'_weakenE st_tcb_ex_cap'')[1]
-      done *)
-  qed
 
 crunches handleVMFault,handleHypervisorFault
   for st_tcb_at'[wp]: "st_tcb_at' P t"
@@ -2677,6 +2573,387 @@ proof -
     done
 qed
 
+lemma released_imp_active_sc_tcb_at:
+  "released_sc_tcb_at t s \<Longrightarrow> active_sc_tcb_at t s"
+  by (clarsimp simp: vs_all_heap_simps)
+
+lemma checkBudgetRestart_corres:
+  "corres (=)
+     (einvs and current_time_bounded 5 and cur_sc_offset_ready 0
+      and cur_sc_active and (ct_active or ct_idle) and schact_is_rct
+      and ct_not_queued and ct_not_in_release_q and current_time_bounded 2)
+     invs'
+     check_budget_restart checkBudgetRestart"
+  unfolding check_budget_restart_def checkBudgetRestart_def
+  apply (rule corres_guard_imp)
+    apply (rule corres_split_eqr[OF _ checkBudget_corres])
+      apply (rule corres_split_eqr[OF _ getCurThread_corres])
+        apply (rule corres_split[OF isRunnable_corres'])
+           apply simp
+          apply (clarsimp simp add: when_def)
+          apply (rule corres_split[OF setThreadState_corres])
+             apply clarsimp
+            apply clarsimp
+           apply ((wpsimp simp: cur_tcb_def[symmetric] cong: conj_cong | strengthen valid_objs_valid_tcbs)+)[6]
+     apply (rule hoare_strengthen_post[where Q="\<lambda>_. invs and cur_tcb"])
+      apply wpsimp
+     apply (clarsimp simp: cur_tcb_def invs_def valid_state_def valid_pspace_def)
+    apply (rule hoare_strengthen_post[where Q="\<lambda>_. invs'"])
+     apply wpsimp
+    apply (clarsimp simp: invs'_def valid_pspace'_def valid_objs'_valid_tcbs')+
+  done
+
+lemma handleInv_handleRecv_corres:
+  "corres (dc \<oplus> dc)
+     (einvs and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread) and
+      valid_machine_time and
+      current_time_bounded 5 and
+      consumed_time_bounded and
+      cur_sc_active and
+      ct_released and
+      ct_not_in_release_q and
+      ct_not_queued and
+      (\<lambda>s. cur_sc_offset_ready (consumed_time s) s) and
+      (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s))
+     (invs' and ct_running' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
+      (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
+     (doE reply_cptr <- liftE (get_cap_reg reg);
+          y <- handle_invocation False False True True reply_cptr;
+          liftE (handle_recv True canReply)
+      odE)
+     (doE replyCptr <- liftE (getCapReg reg);
+          y <- handleInvocation False False True True replyCptr;
+          y \<leftarrow> stateAssertE sch_act_sane_asrt [];
+          y \<leftarrow> stateAssertE ct_not_ksQ_asrt [];
+          y \<leftarrow> stateAssertE ct_active'_asrt [];
+          liftE (handleRecv True canReply)
+      odE)"
+  apply add_cur_tcb'
+  apply (rule_tac Q="\<lambda>s'. pred_map (\<lambda>scPtr. isScActive scPtr s') (tcbSCs_of s') (ksCurThread s')"
+         in corres_cross_add_guard)
+   apply (clarsimp simp: released_sc_tcb_at_def active_sc_tcb_at_def2)
+   apply (prop_tac "scp = cur_sc s")
+    apply (drule invs_cur_sc_tcb_symref, clarsimp simp: schact_is_rct_def)
+    apply (clarsimp simp: pred_tcb_at_def obj_at_def)
+   apply (prop_tac "sc_at (cur_sc s) s")
+    apply (frule invs_cur_sc_tcb)
+    apply (fastforce simp: cur_sc_tcb_def sc_tcb_sc_at_def obj_at_def is_sc_obj
+                     dest: valid_sched_context_size_objsI[OF invs_valid_objs])
+   apply (frule (4) active_sc_at'_cross[OF _ invs_psp_aligned invs_distinct])
+   apply (clarsimp simp: active_sc_at'_def obj_at'_def projectKOs cur_tcb'_def pred_tcb_at_def
+                         is_sc_obj obj_at_def)
+   apply (clarsimp simp: pred_map_def isScActive_def)
+   apply (rule_tac x="cur_sc s" in exI)
+   apply (clarsimp simp: opt_map_red dest!: state_relationD)
+   apply (frule_tac x="ksCurThread s'" in pspace_relation_absD, simp)
+   apply (fastforce simp: other_obj_relation_def tcb_relation_def)
+  apply (rule_tac Q="\<lambda>s'. pred_map (\<lambda>tcb. \<not> tcbInReleaseQueue tcb) (tcbs_of' s') (ksCurThread s')"
+         in corres_cross_add_guard)
+   apply (clarsimp, frule tcb_at_invs)
+   apply (fastforce simp: not_in_release_q_def release_queue_relation_def pred_map_def opt_map_red obj_at'_def
+                          invs'_def valid_pspace'_def projectKOs valid_release_queue'_def cur_tcb'_def
+                   dest!: state_relationD)
+  apply (rule corres_rel_imp)
+   apply (rule corres_guard_imp)
+     apply (rule corres_split_liftEE[OF getCapReg_corres_gen])
+       apply (rule corres_splitEE[OF _ handleInvocation_corres])
+           apply (rule_tac P="(einvs and ct_active and scheduler_act_sane and current_time_bounded 2
+                         and ct_not_queued and ct_not_in_release_q)"
+                      and P'="(invs')"
+                  in corres_inst)
+           apply (rule corres_stateAssertE_add_assertion)
+            apply simp
+            apply (rule corres_stateAssertE_add_assertion)
+             apply (rule corres_stateAssertE_add_assertion)
+              apply simp
+              apply (clarsimp simp: sch_act_sane_asrt_def ct_not_ksQ_asrt_def ct_active'_asrt_def)
+              apply (rule corres_guard_imp)
+                apply (rule handleRecv_isBlocking_corres)
+               apply simp
+              apply simp
+             apply (fastforce simp: ct_active'_asrt_def invs_psp_aligned invs_distinct
+                             dest!: ct_active_cross)
+            apply (clarsimp simp: ct_not_ksQ_asrt_def not_queued_2_def ready_queues_relation_def
+                           dest!: state_relationD)
+           apply (clarsimp simp: sch_act_sane_asrt_def scheduler_act_not_def sch_act_sane_def sched_act_relation_def
+                           dest!: state_relationD)
+           apply (case_tac "scheduler_action s"; simp)
+          apply simp
+         apply simp
+        apply ((wpsimp wp: handle_invocation_valid_sched
+              | strengthen current_time_bounded_strengthen[where k=5])+)[1]
+       apply wpsimp
+      apply wpsimp
+     apply wpsimp
+    apply (clarsimp simp: invs_def valid_state_def valid_pspace_def active_from_running
+                          schedulable_def2 released_sc_tcb_at_def)
+    apply (clarsimp simp: ct_in_state_def st_tcb_weakenE)
+   apply (clarsimp simp: active_from_running')
+  apply simp
+  done
+
+(* these two appreviations are for the two helper lemmas below, which should be identical
+   except that they are in different monads *)
+abbreviation (input)
+  "a_pre \<equiv> (einvs and ct_running and
+         (\<lambda>s. scheduler_action s = resume_cur_thread) and
+         valid_machine_time and
+         current_time_bounded 5 and
+         consumed_time_bounded and
+         cur_sc_active and (ct_active or ct_idle) and
+         ct_released and
+         ct_not_in_release_q and
+         ct_not_queued and
+         (\<lambda>s. cur_sc_offset_ready (consumed_time s) s) and
+         (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s))"
+
+abbreviation (input)
+  "c_pre \<equiv> (invs' and ct_running' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
+         (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))"
+
+lemma updateTimeStamp_checkBudgetRestart_helper:
+  assumes H: "corres dc a_pre c_pre f f'"
+  shows "corres dc a_pre c_pre
+           (do y <- update_time_stamp;
+               restart <- check_budget_restart;
+               when restart f
+            od)
+           (do y <- updateTimeStamp;
+               restart <- checkBudgetRestart;
+               when restart f'
+            od)"
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF updateTimeStamp_corres])
+      apply (rule_tac P="\<lambda> s. (cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s)
+                               \<and> cur_sc_active s \<and> ct_running s \<and> valid_machine_time s
+                               \<and> ct_released s \<and> ct_not_in_release_q s \<and> ct_not_queued s
+                               \<and> current_time_bounded 5 s \<and> consumed_time_bounded s \<and> einvs s
+                               \<and> scheduler_action s = resume_cur_thread"
+                 and P'=c_pre in corres_inst)
+      apply (rule corres_guard_imp)
+        apply (rule corres_split[OF checkBudgetRestart_corres])
+          apply (simp add: when_def split del: if_split)
+          apply (rule corres_if2)
+            apply simp
+           apply (rule_tac P="\<lambda>s. (cur_sc_offset_ready (consumed_time s) s \<and> einvs s
+                                   \<and> cur_sc_active s \<and> valid_machine_time s \<and> ct_running s
+                                   \<and> ct_released s \<and> ct_not_in_release_q s \<and> ct_not_queued s
+                                   \<and> current_time_bounded 5 s \<and> consumed_time_bounded s
+                                   \<and> scheduler_action s = resume_cur_thread)
+                                   \<and> cur_sc_offset_sufficient (consumed_time s) s"
+                      and P'=c_pre in corres_inst)
+           apply (rule corres_guard_imp)
+             apply (rule H)
+            apply (clarsimp simp: active_from_running)
+           apply simp
+          apply (simp add: corres_return[where P=cur_sc_more_than_ready])
+         apply (wpsimp wp: check_budget_restart_false check_budget_restart_true')
+        apply (wpsimp wp: checkBudgetRestart_false checkBudgetRestart_true)
+       apply (clarsimp dest!: active_from_running
+                        simp: cur_sc_offset_ready_def current_time_bounded_strengthen pred_map_def)
+      apply clarsimp
+     apply (wpsimp wp: update_time_stamp_current_time_bounded_5
+                       update_time_stamp_cur_sc_offset_ready_cs)
+    apply wpsimp
+   apply clarsimp+
+  done
+
+lemma updateTimeStamp_checkBudgetRestart_helperE:
+  assumes H: "corres (dc \<oplus> dc) a_pre c_pre f f'"
+  shows "corres (dc \<oplus> dc) a_pre c_pre
+           (doE y <- liftE update_time_stamp;
+               restart <- liftE check_budget_restart;
+               whenE restart f
+            odE)
+           (doE y <- liftE updateTimeStamp;
+               restart <- liftE checkBudgetRestart;
+               whenE restart f'
+            odE)"
+  apply (rule corres_guard_imp)
+    apply (rule corres_split_liftEE[OF updateTimeStamp_corres])
+      apply (rule_tac P="\<lambda> s. (cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s)
+                               \<and> cur_sc_active s \<and> ct_running s \<and> valid_machine_time s
+                               \<and> ct_released s \<and> ct_not_in_release_q s \<and> ct_not_queued s
+                               \<and> current_time_bounded 5 s \<and> consumed_time_bounded s \<and> einvs s
+                               \<and> scheduler_action s = resume_cur_thread"
+                 and P'=c_pre in corres_inst)
+      apply (rule corres_guard_imp)
+        apply (rule corres_split_liftEE[OF checkBudgetRestart_corres])
+          apply (simp add: whenE_def split del: if_split)
+          apply (rule corres_if2)
+            apply simp
+           apply (rule_tac P="\<lambda>s. (cur_sc_offset_ready (consumed_time s) s \<and> einvs s
+                                   \<and> cur_sc_active s \<and> valid_machine_time s \<and> ct_running s
+                                   \<and> ct_released s \<and> ct_not_in_release_q s \<and> ct_not_queued s
+                                   \<and> current_time_bounded 5 s \<and> consumed_time_bounded s
+                                   \<and> scheduler_action s = resume_cur_thread)
+                                   \<and> cur_sc_offset_sufficient (consumed_time s) s"
+                      and P'=c_pre in corres_inst)
+           apply (rule corres_guard_imp)
+             apply (rule H)
+            apply (clarsimp simp: active_from_running)
+           apply simp
+          apply (rule corres_returnOk[where P=cur_sc_more_than_ready])
+          apply simp
+         apply (wpsimp wp: check_budget_restart_false check_budget_restart_true')
+        apply (wpsimp wp: checkBudgetRestart_false checkBudgetRestart_true)
+       apply (clarsimp dest!: active_from_running
+                        simp: cur_sc_offset_ready_def current_time_bounded_strengthen pred_map_def)
+      apply clarsimp
+     apply (wpsimp wp: update_time_stamp_current_time_bounded_5
+                       update_time_stamp_cur_sc_offset_ready_cs)
+    apply wpsimp
+   apply clarsimp+
+  done
+
+lemma handleEvent_corres:
+  "corres (dc \<oplus> dc)
+     (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s)
+      and (\<lambda>s. scheduler_action s = resume_cur_thread)
+      and valid_machine_time and current_time_bounded 5
+      and consumed_time_bounded and cur_sc_active and (ct_active or ct_idle)
+      and ct_released and ct_not_in_release_q and ct_not_queued
+      and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s)
+      and (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s))
+     (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and
+      (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
+      (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
+     (handle_event event) (handleEvent event)"
+  (is "corres _ (?P and ?ready and _) ?P' _ _")
+proof -
+  have hw:
+    "\<And>isBlocking canGrant.
+     corres dc (einvs and ct_running and valid_machine_time and current_time_bounded 2
+                and ct_released and (\<lambda>s. scheduler_action s = resume_cur_thread)
+                and ct_not_in_release_q and ct_not_queued)
+               (invs' and ct_running'
+                      and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
+               (handle_recv isBlocking canGrant) (handleRecv isBlocking canGrant)"
+    apply add_cur_tcb'
+    apply add_ct_not_inQ
+    apply (rule corres_guard_imp [OF handleRecv_isBlocking_corres])
+     apply (fastforce simp: ct_in_state_def ct_in_state'_def
+                     elim!: st_tcb_weakenE pred_tcb'_weakenE
+                      dest: ct_not_ksQ)+
+    done
+  show ?thesis
+    apply (case_tac event)
+         apply (simp_all add: handleEvent_def)
+         apply (rename_tac syscall)
+         apply (rule updateTimeStamp_checkBudgetRestart_helperE)
+         apply (case_tac syscall; simp)
+                   apply (auto intro: corres_guard_imp[OF handleSend_corres]
+                                      corres_guard_imp[OF hw]
+                                      corres_guard_imp[OF handleCall_corres]
+                                      corres_guard_imp[OF handleInv_handleRecv_corres]
+                                      corres_guard_imp[OF handleYield_corres]
+                                      active_from_running active_from_running' released_imp_active_sc_tcb_at
+                               simp: simple_sane_strg current_time_bounded_strengthen
+         dest!: schact_is_rct)[11]
+        apply (rule updateTimeStamp_checkBudgetRestart_helper)
+        apply (rule corres_split')
+           apply (rule corres_guard_imp[OF getCurThread_corres], simp+)
+          apply (rule handleFault_corres)
+          apply simp
+         apply wpsimp
+         apply (clarsimp simp: valid_fault_def valid_sched_def current_time_bounded_def
+                        dest!: active_from_running)
+         apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE simp: ct_in_state_def)
+        apply wp
+        apply (fastforce simp: ct_in_state'_def sch_act_simple_def
+                         elim: pred_tcb'_weakenE st_tcb_ex_cap'')
+
+       apply (rule updateTimeStamp_checkBudgetRestart_helper)
+       apply (rule corres_split')
+          apply (rule corres_guard_imp[OF getCurThread_corres], simp+)
+         apply (rule handleFault_corres)
+         apply simp
+        apply wpsimp
+        apply (clarsimp simp: valid_fault_def valid_sched_def current_time_bounded_def
+                       dest!: active_from_running)
+        apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE simp: ct_in_state_def)
+       apply wp
+       apply (fastforce simp: ct_in_state'_def sch_act_simple_def
+                        elim: pred_tcb'_weakenE st_tcb_ex_cap'')
+      apply (rule corres_guard_imp)
+        apply (rule corres_split_eqr[OF _ corres_machine_op])
+           apply (rule corres_split[OF updateTimeStamp_corres])
+             apply (rule_tac P="\<lambda> s. (cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s)
+                                      \<and> cur_sc_active s \<and> valid_machine_time s \<and> (ct_active s \<or> ct_idle s)
+                                      \<and> ct_released s \<and> ct_not_in_release_q s \<and> ct_not_queued s
+                                      \<and> current_time_bounded 5 s \<and> consumed_time_bounded s \<and> einvs s
+                                      \<and> scheduler_action s = resume_cur_thread"
+                        and P'="(invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
+                                 (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)) and
+                                 (\<lambda>s. \<forall>x. active = Some x \<longrightarrow>
+                                             intStateIRQTable (ksInterruptState s) x \<noteq> irqstate.IRQInactive)"
+                    in corres_inst)
+             apply (rule corres_guard_imp)
+               apply (rule corres_split[OF checkBudget_corres])
+                 apply (rule_tac P="einvs and current_time_bounded 0"
+                            and P'="invs' and (\<lambda>s. \<forall>x. active = Some x \<longrightarrow> intStateIRQTable (ksInterruptState s) x \<noteq> irqstate.IRQInactive)"
+                        in corres_inst)
+                 apply (case_tac active; simp)
+                 apply (rule handleInterrupt_corres)
+                apply (wpsimp wp: check_budget_valid_sched)
+               apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift)
+              apply (wpsimp wp: update_time_stamp_current_time_bounded_5 hoare_vcg_disj_lift
+                                update_time_stamp_cur_sc_offset_ready_cs)
+              apply (clarsimp simp: cur_sc_offset_ready_weaken_zero active_from_running current_time_bounded_def)
+              apply (frule invs_cur_sc_chargeableE)
+               apply (clarsimp simp: schact_is_rct_def)
+              apply clarsimp
+              apply (rule conjI)
+               apply (erule cur_sc_offset_ready_weaken_zero)
+              apply (erule ct_not_blocked_cur_sc_not_blocked)
+              apply (rule ct_activatable_ct_not_blocked)
+              apply (fastforce simp: ct_in_state_def pred_tcb_at_def obj_at_def dest!: active_activatable)
+             apply clarsimp
+            apply (wpsimp wp: update_time_stamp_current_time_bounded_5 hoare_vcg_disj_lift
+                              update_time_stamp_cur_sc_offset_ready_cs)
+           apply wpsimp
+          apply (rule corres_Id, simp+)
+          apply wp
+         apply wpsimp
+         apply (clarsimp simp: ct_in_state_def)
+        apply (wpsimp wp: doMachineOp_getActiveIRQ_IRQ_active' hoare_vcg_all_lift)
+       apply (clarsimp elim!: active_from_running)
+      apply clarsimp
+      apply (simp add: invs'_def)
+     apply (rule updateTimeStamp_checkBudgetRestart_helper)
+     apply (rule corres_split')
+        apply (rule corres_guard_imp[OF getCurThread_corres], simp+)
+       apply (rule corres_split_catch)
+          apply (erule handleFault_corres)
+         apply (rule handleVMFault_corres)
+        apply (rule hoare_elim_pred_conjE2)
+        apply (rule hoare_vcg_E_conj, rule valid_validE_E, wp)
+        apply (wpsimp wp: handle_vm_fault_valid_fault)
+       apply (rule hv_inv_ex')
+      apply wp
+      apply (clarsimp simp: active_from_running tcb_at_invs valid_sched_def current_time_bounded_def)
+      apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE simp: ct_in_state_def)
+     apply wp
+     apply clarsimp
+     apply (fastforce simp: simple_sane_strg sch_act_simple_def ct_in_state'_def
+                 elim: st_tcb_ex_cap'' pred_tcb'_weakenE)
+    apply add_ct_not_inQ
+    apply (rule corres_split')
+       apply (rule corres_guard_imp[OF getCurThread_corres], simp+)
+      apply (rule handleHypervisorFault_corres)
+     apply (simp add: valid_fault_def)
+     apply wp
+     apply clarsimp
+     apply (fastforce elim!: st_tcb_ex_cap st_tcb_weakenE
+                      simp: ct_in_state_def)
+    apply wp
+    apply (clarsimp simp: active_from_running' invs'_def valid_pspace'_def)
+    apply (frule (2) ct_not_ksQ)
+    apply (fastforce simp: ct_in_state'_def sch_act_simple_def
+                           sch_act_sane_def
+                     elim: pred_tcb'_weakenE st_tcb_ex_cap'')
+    done
+  qed
 
 end
 

--- a/spec/design/skel/KernelStateData_H.thy
+++ b/spec/design/skel/KernelStateData_H.thy
@@ -99,7 +99,7 @@ where
     return r
   od"
 
-#INCLUDE_HASKELL SEL4/Model/StateData.lhs decls_only ONLY capHasProperty sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2 ct_not_inQ_asrt sch_act_wf_asrt valid_idle'_asrt cur_tcb'_asrt sch_act_sane_asrt ct_not_ksQ_asrt ct_active'_asrt
-#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue ReaderM Kernel KernelR getsJust assert stateAssert funOfM condition whileLoop findM funArray newKernelState capHasProperty ifM whenM whileM andM orM maybeToMonad sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2 ct_not_inQ_asrt sch_act_wf_asrt valid_idle'_asrt cur_tcb'_asrt sch_act_sane_asrt ct_not_ksQ_asrt ct_active'_asrt
+#INCLUDE_HASKELL SEL4/Model/StateData.lhs decls_only ONLY capHasProperty sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2 ct_not_inQ_asrt sch_act_wf_asrt valid_idle'_asrt cur_tcb'_asrt sch_act_sane_asrt ct_not_ksQ_asrt ct_active'_asrt rct_imp_activatable'_asrt
+#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue ReaderM Kernel KernelR getsJust assert stateAssert funOfM condition whileLoop findM funArray newKernelState capHasProperty ifM whenM whileM andM orM maybeToMonad sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2 ct_not_inQ_asrt sch_act_wf_asrt valid_idle'_asrt cur_tcb'_asrt sch_act_sane_asrt ct_not_ksQ_asrt ct_active'_asrt rct_imp_activatable'_asrt
 
 end

--- a/spec/haskell/src/SEL4.lhs
+++ b/spec/haskell/src/SEL4.lhs
@@ -22,7 +22,7 @@ This is the top-level module; it defines the interface between the kernel and th
 > import SEL4.API.Types
 > import SEL4.Kernel.CSpace(lookupCap)
 > import SEL4.Kernel.Thread(schedule, activateThread)
-> import SEL4.Model.StateData(KernelState, Kernel, getCurThread, doMachineOp, stateAssert)
+> import SEL4.Model.StateData(KernelState, Kernel, getCurThread, doMachineOp, stateAssert, rct_imp_activatable'_asrt)
 > import SEL4.Model.Preemption(withoutPreemption)
 > import SEL4.Object.Structures
 > import SEL4.Object.TCB(asUser, mcsPreemptionPoint)
@@ -44,7 +44,9 @@ faults, and system calls; the set of possible events is defined in
 >                       irq_opt <- doMachineOp (getActiveIRQ True)
 >                       mcsPreemptionPoint irq_opt
 >                       when (isJust irq_opt) $ handleInterrupt (fromJust irq_opt))
+>     stateAssert rct_imp_activatable'_asrt "Assert that RCT sched action implies ct activatable'"
 >     schedule
+>     stateAssert rct_imp_activatable'_asrt "Assert that RCT sched action implies ct activatable'"
 >     activateThread
 >     stateAssert kernelExitAssertions "Kernel exit conditions must hold"
 

--- a/spec/haskell/src/SEL4/Model/StateData.lhs
+++ b/spec/haskell/src/SEL4/Model/StateData.lhs
@@ -457,7 +457,9 @@ is true using the rule cur_tcb'_cross.
 > cur_tcb'_asrt :: KernelState -> Bool
 > cur_tcb'_asrt _ = True
 
-Asserts for first phase, non-blocking, non-calling handle_invocation.
+Asserts used for first phase, non-blocking, non-calling handle_invocation.
+Each stating that `sch_act_sane`, `!pd. ksCurThread s notin set (ksReadyQueues s pd)`,
+and `ct_active' s` holds.
 
 > sch_act_sane_asrt :: KernelState -> Bool
 > sch_act_sane_asrt _ = True
@@ -467,3 +469,9 @@ Asserts for first phase, non-blocking, non-calling handle_invocation.
 
 > ct_active'_asrt :: KernelState -> Bool
 > ct_active'_asrt _ = True
+
+Assert stating that, when scheduler action is resume, the current thread is activatable.
+Used in callKernel.
+
+> rct_imp_activatable'_asrt :: KernelState -> Bool
+> rct_imp_activatable'_asrt _ = True


### PR DESCRIPTION
This removes the last sorry in Syscal_R.thy.

The main proof and its helper lemmas make use of the asserts added in https://github.com/seL4/l4v/pull/409.

Update: this PR now contains #416 , which removes all the remaining sorries in Refine. Since this PR touches quite a lot of places in Syscall_R, it should make sense to review the two together rather than one after the other.


