### PR TITLE
github: run AWS proofs only on most recent push

### DIFF
--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -35,6 +35,8 @@ jobs:
       fail-fast: false
       matrix:
         arch: [ARM, ARM_HYP, RISCV64, X64]
+    # test only most recent push:
+    concurrency: l4v-regression-${{ github.ref }}-${{ strategy.job-index }}
     steps:
     - name: Proofs
       uses: seL4/ci-actions/aws-proofs@master

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -26,6 +26,8 @@ jobs:
       fail-fast: false
       matrix:
         arch: [ARM, ARM_HYP, RISCV64, X64]
+    # test only most recent push to PR:
+    concurrency: l4v-pr-${{ github.ref }}-${{ strategy.job-index }}
     steps:
     - name: Proofs
       uses: seL4/ci-actions/aws-proofs@master


### PR DESCRIPTION
By default GitHub spawns a new test for each push event. To avoid hitting the maximum number of AWS instances too quickly, we run the PR and master proof tests only on the most recent push since the last test finished.

The concurrency exclusion is per git ref, i.e. separate PRs and separate branches still run tests concurrently.

