### PR TITLE
github: use PR number to distinguish pull requests

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         arch: [ARM, ARM_HYP, RISCV64, X64]
     # test only most recent push to PR:
-    concurrency: l4v-pr-${{ github.ref }}-${{ strategy.job-index }}
+    concurrency: l4v-pr-${{ github.event.number }}-idx-${{ strategy.job-index }}
     steps:
     - name: Proofs
       uses: seL4/ci-actions/aws-proofs@master


### PR DESCRIPTION
${{github.ref}} will resolve to the base branch of the PR, not the
PR branch, so it is not useful for distinguishing PRs. The pull request
number will do the job.
