### PR TITLE
cspec: enable preprocess test for AArch64

### DIFF
--- a/spec/cspec/c/kernel.mk
+++ b/spec/cspec/c/kernel.mk
@@ -37,6 +37,8 @@ ifndef TOOLPREFIX
       TRY_TOOLPREFIX := arm-none-eabi- arm-linux-gnueabi-
     else ifeq (${L4V_ARCH},RISCV64)
       TRY_TOOLPREFIX := riscv64-unknown-linux-gnu- riscv64-linux-gnu- riscv64-unknown-elf-
+    else ifeq (${L4V_ARCH},AARCH64)
+      TRY_TOOLPREFIX := aarch64-unknown-linux-gnu- aarch64-linux-gnu-
     endif
   endif
   ifdef TRY_TOOLPREFIX


### PR DESCRIPTION
This commit adds compiler prefixes for AArch64 so that the preprocess test finds the right cross compilers for this architecture.
