### PR TITLE
arm+arm-hyp machine: align platform constants to C

### DIFF
--- a/spec/machine/ARM/Platform.thy
+++ b/spec/machine/ARM/Platform.thy
@@ -48,11 +48,11 @@ definition physBase :: word32 where
 definition pptrBaseOffset :: word32 where
   "pptrBaseOffset \<equiv> pptrBase - physBase"
 
-definition kernelELFBase :: word32 where
-  "kernelELFBase \<equiv> pptrBase + (physBase && mask 22)"
-
 definition kernelELFPAddrBase :: word32 where
-  "kernelELFPAddrBase \<equiv> 0x10000000"
+  "kernelELFPAddrBase \<equiv> physBase"
+
+definition kernelELFBase :: word32 where
+  "kernelELFBase \<equiv> pptrBase + (kernelELFPAddrBase && mask 22)"
 
 definition kernelELFBaseOffset :: word32 where
   "kernelELFBaseOffset \<equiv> kernelELFBase - kernelELFPAddrBase"

--- a/spec/machine/ARM_HYP/Platform.thy
+++ b/spec/machine/ARM_HYP/Platform.thy
@@ -56,11 +56,11 @@ definition paddrTop :: "32 word" where
 definition pptrBaseOffset :: word32 where
   "pptrBaseOffset \<equiv> pptrBase - physBase"
 
-definition kernelELFBase :: word32 where
-  "kernelELFBase \<equiv> pptrBase + (physBase && mask 22)"
-
 definition kernelELFPAddrBase :: word32 where
-  "kernelELFPAddrBase \<equiv> 0x80000000"
+  "kernelELFPAddrBase \<equiv> physBase"
+
+definition kernelELFBase :: word32 where
+  "kernelELFBase \<equiv> pptrBase + (kernelELFPAddrBase && mask 22)"
 
 definition kernelELFBaseOffset :: word32 where
   "kernelELFBaseOffset \<equiv> kernelELFBase - kernelELFPAddrBase"


### PR DESCRIPTION
This matches the C code, as seen at https://github.com/seL4/seL4/blob/master/include/arch/arm/arch/32/mode/hardware.h#L72.

I explored aligning more of the platform constants, both for ARM and the other architectures, but it very rapidly became more work than what seemed worthwhile.