### PR TITLE
rt run_tests: make sure L4V_FEATURES is set

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -14,6 +14,10 @@ import subprocess
 L4V_ARCH_DEFAULT="ARM"
 L4V_ARCH_LIST=["ARM","ARM_HYP","X64","RISCV64"]
 
+# Set MCS for this branch by default
+L4V_FEATURES=os.environ.get("L4V_FEATURES", "MCS")
+os.environ["L4V_FEATURES"]=L4V_FEATURES
+
 # Fetch directory this script is stored in.
 DIR=os.path.dirname(os.path.realpath(__file__))
 

--- a/run_tests
+++ b/run_tests
@@ -14,10 +14,6 @@ import subprocess
 L4V_ARCH_DEFAULT="ARM"
 L4V_ARCH_LIST=["ARM","ARM_HYP","X64","RISCV64"]
 
-# Set MCS for this branch by default
-L4V_FEATURES=os.environ.get("L4V_FEATURES", "MCS")
-os.environ["L4V_FEATURES"]=L4V_FEATURES
-
 # Fetch directory this script is stored in.
 DIR=os.path.dirname(os.path.realpath(__file__))
 

--- a/spec/cspec/c/Makefile
+++ b/spec/cspec/c/Makefile
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
+# default to MCS on this branch if L4V_FEATURES is unset
+export L4V_FEATURES ?= MCS
+
 # For kernel builds (CSpec and binary verificaiton):
 KERNEL_BUILD_ROOT := build/${L4V_ARCH}
 


### PR DESCRIPTION
If L4V_FEATURES is not already set to something specific, set it to
MCS so we don't accidentally run the wrong configuration.
