### PR TITLE
ci proof-deploy: save C graph-lang

### DIFF
--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -48,6 +48,12 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_SSH: ${{ secrets.AWS_SSH }}
+    - name: Upload C graph-lang
+      uses: actions/upload-artifact@v2
+      with:
+        name: c-graph-lang-${{ matrix.arch }}
+        path: artifacts/CFunctions.txt.xz
+        if-no-files-found: ignore
     - name: Upload logs
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -60,10 +60,44 @@ jobs:
         name: logs-${{ matrix.arch }}
         path: logs.tar.xz
 
+  mcs-export:
+    name: MCS
+    needs: code
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ARM, RISCV64]
+    # test only most recent push:
+    concurrency: l4v-regression-${{ github.ref }}-${{ strategy.job-index }}-mcs
+    steps:
+    - name: SimplExport
+      uses: seL4/ci-actions/aws-proofs@master
+      with:
+        L4V_ARCH: ${{ matrix.arch }}
+        L4V_FEATURES: MCS
+        xml: ${{ needs.code.outputs.xml }}
+        session: SimplExportAndRefine
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_SSH: ${{ secrets.AWS_SSH }}
+    - name: Upload C graph-lang
+      uses: actions/upload-artifact@v2
+      with:
+        name: c-graph-lang-${{ matrix.arch }}-MCS
+        path: artifacts/CFunctions.txt.xz
+        if-no-files-found: ignore
+    - name: Upload logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: logs-${{ matrix.arch }}-MCS
+        path: logs.tar.xz
+
   deploy:
     name: Deploy manifest
     runs-on: ubuntu-latest
-    needs: [code, proofs]
+    needs: [code, proofs, mcs-export]
     steps:
     - uses: seL4/ci-actions/l4v-deploy@master
       with:


### PR DESCRIPTION
In the l4v proof-deploy workflow, export the C graph-lang produced by SimplExportAndRefine. In the near future, this will feed into binary verification. Also add a new job matrix to produce C graph-lang for MCS configurations supported by binary verification.