### PR TITLE
ci: add binary verification workflow

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -1,0 +1,320 @@
+# Copyright 2022 Kry10 Limited
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: Prepare binary verification
+
+on:
+  repository_dispatch:
+    types:
+      - binary-verification
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Repository'
+        required: true
+        default: 'seL4/l4v'
+      run_id:
+        description: 'Workflow run ID'
+        required: true
+
+jobs:
+  artifacts:
+    name: Initialise artifacts
+    runs-on: ubuntu-latest
+    outputs:
+      enabled_configs: ${{ steps.prepare.outputs.enabled_configs }}
+      sel4_commit: ${{ steps.prepare.outputs.sel4_commit }}
+      graph_refine_commit: ${{ steps.prepare.outputs.graph_refine_commit }}
+      isabelle_commit: ${{ steps.prepare.outputs.isabelle_commit }}
+    steps:
+      - name: Retrieve artifacts
+        id: retrieve
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.PRIV_REPO_TOKEN }}
+          script: |
+            const inputs = (function() {
+              if ("${{ github.event_name }}" === "repository_dispatch") {
+                return { repo: "${{ github.event.client_payload.repo }}",
+                         run_id: "${{ github.event.client_payload.run_id }}" };
+              } else {
+                return { repo: "${{ github.event.inputs.repo }}",
+                         run_id: "${{ github.event.inputs.run_id }}" };
+              }
+            })();
+            console.log(`Triggered by ${inputs.repo} run_id ${inputs.run_id}`)
+            console.log(`::set-output name=trigger_repo::${inputs.repo}`)
+            console.log(`::set-output name=trigger_run_id::${inputs.run_id}`)
+            const repo_parts = inputs.repo.split("/");
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: repo_parts[0],
+               repo: repo_parts[1],
+               run_id: inputs.run_id,
+            });
+            const bv_artifacts = artifacts.data.artifacts.filter((artifact) => {
+              const name = artifact.name;
+              return name == "manifest" || name == "c-graph-lang";
+            });
+            const fs = require('fs/promises');
+            const files = bv_artifacts.map(async function(artifact) {
+              let download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id,
+                archive_format: 'zip',
+              });
+              return await fs.writeFile(
+                `${process.env.GITHUB_WORKSPACE}/${artifact.name}.zip`,
+                Buffer.from(download.data),
+              );
+            });
+            await Promise.all(files);
+      - name: Checkout graph-refine
+        uses: actions/checkout@v3
+        with:
+          repository: seL4/graph-refine
+          # We currently use the ci-riscv64 branch for decompiling both ARM and RISCV64.
+          # We checkout here just to ensure that all matrix jobs use the same graph-refine commit.
+          ref: ci-riscv64
+          path: graph-refine
+      - name: Prepare graph-refine job structure
+        id: prepare
+        env:
+          L4V_COMMIT: ${{ github.sha }}
+          TRIGGER_REPO: ${{ steps.retrieve.outputs.trigger_repo }}
+          TRIGGER_RUN_ID: ${{ steps.retrieve.outputs.trigger_run_id }}
+          WORKFLOW_REPO: ${{ github.repository }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+        run: |
+          # Unpack and reorganise artifacts fetched from the triggering workflow.
+          unzip -q manifest.zip
+          # Freeze the seL4 and graph-refine commits for all matrix jobs.
+          # TODO; Freeze the version of the decompiler Docker image used.
+          sudo apt-get update && sudo apt-get install libxml2-utils
+          SEL4_COMMIT=$(xmllint --xpath 'string(//project[@name="seL4"]/@revision)' verification-manifest.xml)
+          ISA_COMMIT=$(xmllint --xpath 'string(//project[@name="isabelle"]/@revision)' verification-manifest.xml)
+          GRAPH_REFINE_COMMIT=$(git -C graph-refine rev-parse --verify HEAD)
+          echo "::set-output name=sel4_commit::${SEL4_COMMIT}"
+          echo "::set-output name=graph_refine_commit::${GRAPH_REFINE_COMMIT}"
+          echo "::set-output name=isabelle_commit::${ISA_COMMIT}"
+          (
+            echo "triggered-by:"
+            echo "  repo: ${TRIGGER_REPO}"
+            echo "  run_id: ${TRIGGER_RUN_ID}"
+            echo "workflow:"
+            echo "  repo: ${WORKFLOW_REPO}"
+            echo "  run_id: ${WORKFLOW_RUN_ID}"
+            echo "commits:"
+            echo "  graph-refine: ${GRAPH_REFINE_COMMIT}"
+            echo "  l4v: ${L4V_COMMIT}"
+          ) > decompile-manifest.yaml
+          # Check if we got any C graph-lang from the triggering workflow.
+          if [ -f c-graph-lang.zip ]; then
+            unzip -q -d simpl-export c-graph-lang.zip
+            # Filter out any configurations that we won't attempt to run,
+            # and reorganise into the shape that graph-refine expects.
+            for ARCH in ARM RISCV64; do
+              for API in "" MCS; do
+                ARCH_API="${ARCH}${API:+-${API}}"
+                C_FUNCTIONS="simpl-export/CFunctions-${ARCH_API}.txt"
+                if [ -f "${C_FUNCTIONS}" ]; then
+                  mkdir -p "config-list/${ARCH_API}"
+                  for OPT in O1 O2; do
+                    TARGET="configs/${ARCH_API}-${OPT}/target"
+                    mkdir -p "${TARGET}"
+                    cp "${C_FUNCTIONS}" "${TARGET}/CFunctions.txt"
+                  done
+                fi
+              done
+            done
+            if [ -d config-list ]; then
+              ENABLED_CONFIGS=$(ls config-list | perl -pe 's/%/%25/g; s/\n/%0A/g')
+              echo "::set-output name=enabled_configs::${ENABLED_CONFIGS}"
+            fi
+          fi
+          if [ -n "${ENABLED_CONFIGS}" ]; then
+            echo "C graph-lang found for configs:" $(ls config-list)
+          else
+            echo "No C graph-lang found, nothing to do"
+          fi
+      - name: Initialise output artifact
+        if: ${{ steps.prepare.outputs.enabled_configs }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: graph-refine-targets
+          path: |
+            decompile-manifest.yaml
+            verification-manifest.xml
+            configs
+      # This workflow uses `nix-shell` to run commands in an environment
+      # specified by `shell.nix` in the root of the graph-refine repo
+      # (ci-riscv64 branch). That environment provides the tools needed to run
+      # the commands in this workflow. `nix-shell` will download and install
+      # packages to create the environment, building any packages that are not
+      # present in a binary package cache. `nix-shell` is part of the Nix
+      # package manager (nixos.org). `install-nix-action` installs the Nix
+      # package manager, and configures it to use the `nixpkgs` collection of
+      # packages and the nixos.org binary package cache. `cachix-action` sets
+      # up an additional custom package cache provided by cachix.org, so that
+      # any packages built by `nix-shell` are saved for future `nix-shell`
+      # invocations. The following steps prime the cache, so that any package
+      # builds are peformed once here instead of in every parallel matrix job.
+      # In a future iteration, it would be good to pull this out into a
+      # separate workflow that builds a Docker image with all the tools needed
+      # for this workflow, and have this workflow use the Docker image without
+      # `nix-shell`.
+      - name: Install Nix
+        if: ${{ steps.prepare.outputs.enabled_configs }}
+        uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Install Cachix
+        if: ${{ steps.prepare.outputs.enabled_configs }}
+        uses: cachix/cachix-action@v10
+        with:
+          name: sel4-bv
+          authToken: ${{ secrets.BV_CACHIX_AUTH_TOKEN }}
+      - name: Prime the Nix cache
+        working-directory: graph-refine
+        run: nix-shell --run 'echo "Nix cache is primed"'
+
+  decompilation:
+    name: Decompile
+    needs: artifacts
+    runs-on: ubuntu-latest
+    # `if` applies to the whole matrix, not to individual jobs within the matrix.
+    if: ${{ needs.artifacts.outputs.enabled_configs }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ARM, RISCV64]
+        features: ["", MCS]
+        optimise: ["-O1", "-O2"]
+    steps:
+      # It would be nice if there was a way to prevent the job from starting.
+      - name: Check enabled
+        id: enabled
+        shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
+          FEATURES: ${{ matrix.features }}
+          OPTIMISE: ${{ matrix.optimise }}
+          ENABLED: ${{ needs.artifacts.outputs.enabled_configs }}
+        run: |
+          # Check whether this configuration is enabled
+          CONFIG="${ARCH}${FEATURES:+-${FEATURES}}"
+          if grep -qx "${CONFIG}" <<< "${ENABLED}"; then
+            echo "C graph-lang found for ${CONFIG}, proceeding with decompilation"
+            echo "::set-output name=config::${CONFIG}"
+            echo "::set-output name=target::${CONFIG}${OPTIMISE}"
+          else
+            echo "No C graph-lang found for ${CONFIG}, skipping decompilation"
+          fi
+      - name: Checkout l4v
+        uses: actions/checkout@v3
+        # We use the ref on which this workflow was triggered,
+        # not the one that caused the trigger.
+        with:
+          path: l4v
+      - name: Checkout Isabelle
+        uses: actions/checkout@v3
+        with:
+          repository: seL4/isabelle
+          ref: ${{ needs.artifacts.outputs.isabelle_commit }}
+          path: isabelle
+      - name: Checkout seL4
+        uses: actions/checkout@v3
+        with:
+          repository: seL4/seL4
+          ref: ${{ needs.artifacts.outputs.sel4_commit }}
+          path: seL4
+      - name: Checkout graph-refine
+        uses: actions/checkout@v3
+        with:
+          repository: seL4/graph-refine
+          ref: ${{ needs.artifacts.outputs.graph_refine_commit }}
+          path: graph-refine
+      - name: Install Nix
+        if: steps.enabled.outputs.config
+        uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Install Cachix
+        if: steps.enabled.outputs.config
+        uses: cachix/cachix-action@v10
+        with:
+          name: sel4-bv
+          authToken: ${{ secrets.BV_CACHIX_AUTH_TOKEN }}
+      - name: Disable function clones
+        # TODO: Upstream this change to seL4.
+        # This disables some -O2 interprocedural optimisations that
+        # binary verificaation can't handle.
+        working-directory: seL4
+        run: |
+          # Add compile options to gcc.cmake
+          ( echo
+            echo "# Binary verification cannot handle cloned functions."
+            echo "if(KernelVerificationBuild)"
+            echo "    add_compile_options(-fno-partial-inlining -fno-ipa-cp -fno-ipa-sra)"
+            echo "endif()"
+          ) >> gcc.cmake
+      - name: Build target
+        if: steps.enabled.outputs.config
+        working-directory: graph-refine
+        shell: nix-shell --run "bash -eo pipefail {0}"
+        env:
+          L4V_ARCH: ${{ matrix.arch }}
+          L4V_FEATURES: ${{ matrix.features }}
+          CONFIG_OPTIMISATION_LEVEL: ${{ matrix.optimise }}
+          # upload-artifact will strip the `out` prefix.
+          TARGET_DIR: ${{ github.workspace }}/out/configs/${{ steps.enabled.outputs.target }}/target
+        run: |
+          # Build the graph-refine target
+          decompiler/setup-decompiler.py docker
+          make -C seL4-example ci_target
+      - name: Upload target
+        if: steps.enabled.outputs.config
+        uses: actions/upload-artifact@v3
+        with:
+          name: graph-refine-targets
+          path: out
+
+  submission:
+    name: Submit graph-refine job
+    needs: [artifacts, decompilation]
+    if: ${{ needs.artifacts.outputs.enabled_configs }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout graph-refine
+        uses: actions/checkout@v3
+        with:
+          repository: seL4/graph-refine
+          ref: ${{ needs.artifacts.outputs.graph_refine_commit }}
+          path: graph-refine
+      - name: Fetch targets
+        uses: actions/download-artifact@v3
+        with:
+          name: graph-refine-targets
+          path: out
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Finalise graph-refine job
+        run: |
+          # Generate function lists.
+          for TARGET in out/configs/*/target; do
+            graph-refine/scripts/list_functions.py "${TARGET}" > "${TARGET}/functions.txt"
+          done
+      - name: Save final artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: graph-refine-targets
+          path: out
+      - name: Submit graph-refine job
+        env:
+          BV_SSH_CONFIG: ${{ secrets.BV_SSH_CONFIG }}
+          BV_SSH_KEY: ${{ secrets.BV_SSH_KEY }}
+          BV_SSH_KNOWN_HOSTS: ${{ secrets.BV_SSH_KNOWN_HOSTS }}
+          BV_CI_JOB_DIR: graph-refine-work
+        shell: bash
+        run: graph-refine/scripts/ci-submit out

--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -49,13 +49,13 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_SSH: ${{ secrets.AWS_SSH }}
     - name: Upload C graph-lang
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
-        name: c-graph-lang-${{ matrix.arch }}
-        path: artifacts/CFunctions.txt.xz
+        name: c-graph-lang
+        path: artifacts/simpl-export
         if-no-files-found: ignore
     - name: Upload logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: logs-${{ matrix.arch }}
         path: logs.tar.xz
@@ -83,13 +83,13 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_SSH: ${{ secrets.AWS_SSH }}
     - name: Upload C graph-lang
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
-        name: c-graph-lang-${{ matrix.arch }}-MCS
-        path: artifacts/CFunctions.txt.xz
+        name: c-graph-lang
+        path: artifacts/simpl-export
         if-no-files-found: ignore
     - name: Upload logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: logs-${{ matrix.arch }}-MCS
         path: logs.tar.xz

--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -104,3 +104,44 @@ jobs:
         xml: ${{ needs.code.outputs.xml }}
       env:
         GH_SSH: ${{ secrets.CI_SSH }}
+
+  binary-verification:
+    name: Trigger binary verification
+    runs-on: ubuntu-latest
+    needs: [code, proofs, mcs-export]
+    steps:
+    # download-artifact doesn't have an option to ignore missing artifacts,
+    # so we download them all to test if c-graph-lang exists.
+    - name: Fetch artifacts
+      uses: actions/download-artifact@v3
+      with:
+        path: artifacts
+    - name: Check for C graph-lang artifacts
+      id: enabled
+      env:
+        MANIFEST: ${{ needs.code.outputs.xml }}
+      run: |
+        # Check if there are any C graph-lang artifacts
+        if [ -e artifacts/c-graph-lang ]; then
+          echo "C graph-lang artifacts found, will trigger binary verification"
+          echo -n "${MANIFEST}" > verification-manifest.xml
+          echo "::set-output name=enabled::true"
+        else
+          echo "No C graph-lang artifacts found, will not trigger binary verification"
+        fi
+    - name: Upload manifest
+      if: steps.enabled.outputs.enabled
+      uses: actions/upload-artifact@v3
+      with:
+        name: manifest
+        path: verification-manifest.xml
+    - name: Trigger binary verification
+      if: steps.enabled.outputs.enabled
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.PRIV_REPO_TOKEN }}
+        repository: ${{ github.repository }}
+        event-type: binary-verification
+        # binary-verification uses the run_id to retrieve this workflow's artifacts.
+        client-payload: |
+          { "repo": "${{ github.repository }}", "run_id": "${{ github.run_id }}" }

--- a/spec/cspec/c/kernel.mk
+++ b/spec/cspec/c/kernel.mk
@@ -49,9 +49,7 @@ ifndef TOOLPREFIX
   endif
 endif
 
-ifndef OBJDUMP
-  OBJDUMP := ${TOOLPREFIX}objdump
-endif
+OBJDUMP := ${TOOLPREFIX}objdump
 
 ifndef UMM_TYPES
   UMM_TYPES := ${KERNEL_BUILD_ROOT}/umm_types.txt

--- a/spec/cspec/c/kernel.mk
+++ b/spec/cspec/c/kernel.mk
@@ -50,6 +50,7 @@ ifndef TOOLPREFIX
 endif
 
 OBJDUMP := ${TOOLPREFIX}objdump
+CPP := ${TOOLPREFIX}cpp
 
 ifndef UMM_TYPES
   UMM_TYPES := ${KERNEL_BUILD_ROOT}/umm_types.txt
@@ -91,8 +92,8 @@ ${KERNEL_BUILD_ROOT}/kernel.elf.symtab: ${KERNEL_BUILD_ROOT}/kernel.elf
 	${OBJDUMP} -t $^ > $@
 
 ${KERNEL_BUILD_ROOT}/kernel.sigs: ${KERNEL_BUILD_ROOT}/kernel_all.c_pp
-	MAKEFILES= make -C ${PARSERPATH} standalone-cparser
-	${PARSERPATH}/c-parser ${L4V_ARCH} --underscore_idents --mmbytes $^ > $@.tmp
+	MAKEFILES= make -C ${PARSERPATH} ${PARSERPATH}/${L4V_ARCH}/c-parser
+	${PARSERPATH}/${L4V_ARCH}/c-parser --cpp=${CPP} --underscore_idents --mmbytes $^ > $@.tmp
 	mv $@.tmp $@
 
 # Initialize the CMake build. We purge the build directory and start again


### PR DESCRIPTION
This adds a workflow that prepares the inputs needed by graph-refine. It is triggered at the end of a proof-deploy workflow. It collects C graph-lang artifacts from the proof-deploy workflow, and runs the decompiler to generate ASM graph-lang. Finally, it submits a job to a graph-refine back end over SSH.

Depends on https://github.com/seL4/ci-actions/pull/204.