### PR TITLE
github: changed AutoCorresSEL4 default

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -24,7 +24,6 @@ jobs:
       with:
         L4V_ARCH: ${{ matrix.arch }}
         manifest: default.xml
-        session: '-v'  # non-empty argument to `./run-tests` to not exclude AutoCorresSEL4
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -43,7 +43,6 @@ jobs:
       with:
         L4V_ARCH: ${{ matrix.arch }}
         xml: ${{ needs.code.outputs.xml }}
-        session: '-v'  # non-empty argument to `./run-tests` to not exclude AutoCorresSEL4
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -33,6 +33,7 @@ jobs:
       uses: seL4/ci-actions/aws-proofs@master
       with:
         L4V_ARCH: ${{ matrix.arch }}
+        session: '-x AutoCorresSEL4' # exclude large AutoCorresSEL4 session for PRs
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
`ci-actions/aws-proofs` no longer excludes the AutoCorresSEL4 session by default, so we no longer need to provide a fake argument to the session parameter to not exclude it.

This is significant, because we now want the default to be non-verbose since we're running multiple sessions in parallel.
