### PR TITLE
add missing Makefile dependencies

### DIFF
--- a/proof/Makefile
+++ b/proof/Makefile
@@ -41,7 +41,9 @@ HEAPS += SepTactics
 
 # Additional dependencies
 
-BaseRefine Refine DBaseRefine DRefine: design-spec
+AInvs: design-spec ASpec-files
+
+BaseRefine Refine DBaseRefine DRefine: design-spec ASpec-files
 
 # CKernel uses the `machinety=machine_state` option for `install_C_file`,
 # and therefore depends on `design-spec`.


### PR DESCRIPTION
Both `AInvs` and the refinement chain need the generated files necessary for `ASpec` and `ExecSpec`. We could depend on `ASpec` directly, but that would mess with Isabelle being able to schedule sessions as it wants them, and depending on all of `ExecSpec` is too much for `AInvs`.
