### PR TITLE
run_tests: HaskellKernel and C config

### DIFF
--- a/spec/tests.xml
+++ b/spec/tests.xml
@@ -37,7 +37,7 @@
 
     <set>
         <!-- Build Haskell kernel code. -->
-        <test name="HaskellKernel" cwd="haskell" cpu-timeout="2700">make</test>
+        <test name="HaskellKernel" cwd="haskell" cpu-timeout="3600">make</test>
     </set>
 
 </testsuite>

--- a/spec/tests.xml
+++ b/spec/tests.xml
@@ -17,7 +17,7 @@
 
     <!-- Run the haskell translator. -->
     <set>
-        <test name="haskell-translator" cwd="design" cpu-timeout="600">make design</test>
+        <test name="haskell-translator" cpu-timeout="600">make design-spec</test>
     </set>
 
     <set depends="isabelle Lib">


### PR DESCRIPTION
-  give more time for downloading and compiling dependencies for runs  where these are not cached.
 
-   make sure we're catching all dependencies that are declared for `design-spec` in the top-level Makefile. In particular, we want `c-config` to run at least once before either `ASpec` or `ExecSpec` run it, to make sure these two are not racing on config generation in `-j 2`.
  