### PR TITLE
docs: split_simps and case over fun/primrec

### DIFF
--- a/docs/ROOT
+++ b/docs/ROOT
@@ -12,5 +12,7 @@
 chapter Docs
 
 session Docs = HOL +
+  sessions
+    Lib
   theories
     "Style"


### PR DESCRIPTION
Document that and why we should prefer `case` over `primrec`/`fun` for non-recursive definitions with pattern matching.