### PR TITLE
crefine: remove duplicate lemma

### DIFF
--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -4617,7 +4617,7 @@ lemma sendIPC_enqueue_ccorres_helper:
           apply (rule cnotification_relation_ep_queue, assumption+)
             apply (simp add: isSendEP_def isRecvEP_def)
            apply simp
-          apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
           apply (erule(2) map_to_ko_at_updI')
            apply (simp only:projectKOs injectKO_ep objBits_simps)
            apply clarsimp
@@ -4659,7 +4659,7 @@ lemma sendIPC_enqueue_ccorres_helper:
          apply (rule cnotification_relation_ep_queue, assumption+)
            apply (simp add: isSendEP_def isRecvEP_def)
           apply simp
-         apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+         apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
          apply (erule(2) map_to_ko_at_updI')
           apply (clarsimp simp: objBitsKO_def)
          apply (clarsimp simp: obj_at'_def projectKOs)
@@ -5019,7 +5019,7 @@ lemma receiveIPC_enqueue_ccorres_helper:
           apply (rule cnotification_relation_ep_queue, assumption+)
             apply (simp add: isSendEP_def isRecvEP_def)
            apply simp
-          apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
           apply (erule(2) map_to_ko_at_updI')
            apply (clarsimp simp: objBitsKO_def)
           apply (clarsimp simp: obj_at'_def projectKOs)
@@ -5057,7 +5057,7 @@ lemma receiveIPC_enqueue_ccorres_helper:
          apply (rule cnotification_relation_ep_queue, assumption+)
            apply (simp add: isSendEP_def isRecvEP_def)
           apply simp
-         apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+         apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
          apply (erule(2) map_to_ko_at_updI')
           apply (clarsimp simp: objBitsKO_def)
          apply (clarsimp simp: obj_at'_def projectKOs)
@@ -6107,7 +6107,7 @@ lemma receiveSignal_enqueue_ccorres_helper:
            apply (rule cendpoint_relation_ntfn_queue, assumption+)
              apply (simp add: isWaitingNtfn_def)
             apply simp
-           apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+           apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
            apply (erule(2) map_to_ko_at_updI')
             apply (clarsimp simp: objBitsKO_def)
            apply (clarsimp simp: obj_at'_def projectKOs)
@@ -6148,7 +6148,7 @@ lemma receiveSignal_enqueue_ccorres_helper:
           apply (rule cendpoint_relation_ntfn_queue, assumption+)
             apply (simp add: isWaitingNtfn_def)
            apply simp
-          apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
           apply (erule(2) map_to_ko_at_updI')
            apply (clarsimp simp: objBitsKO_def)
           apply (clarsimp simp: obj_at'_def projectKOs)

--- a/proof/crefine/ARM/Recycle_C.thy
+++ b/proof/crefine/ARM/Recycle_C.thy
@@ -757,14 +757,14 @@ lemma cancelBadgedSends_ccorres:
                      apply (rule cendpoint_relation_q_cong)
                      apply (rule sym, erule restrict_map_eqI)
                      apply (clarsimp simp: image_iff)
-                     apply (drule(2) map_to_ko_atI2)
+                     apply (drule(2) map_to_ko_atI)
                      apply (drule ko_at_state_refs_ofD')
                      apply clarsimp
                      apply (drule_tac x=p in spec)
                      subgoal by fastforce
                     apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
                     apply clarsimp
-                    apply (drule(2) map_to_ko_atI2, drule ko_at_state_refs_ofD')
+                    apply (drule(2) map_to_ko_atI, drule ko_at_state_refs_ofD')
 
                     apply (rule cnotification_relation_q_cong)
                     apply (rule sym, erule restrict_map_eqI)

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -2620,13 +2620,6 @@ lemma tcb_queue_update_other':
   unfolding tcb_queue_relation'_def
   by (simp add: tcb_queue_update_other)
 
-lemma map_to_ko_atI2:
-  "\<lbrakk>(projectKO_opt \<circ>\<^sub>m (ksPSpace s)) x = Some v; pspace_aligned' s; pspace_distinct' s\<rbrakk> \<Longrightarrow> ko_at' v x s"
-  apply (clarsimp simp: map_comp_Some_iff)
-  apply (erule (2) aligned_distinct_obj_atI')
-  apply (simp add: project_inject)
-  done
-
 lemma c_guard_tcb:
   assumes al: "is_aligned (ctcb_ptr_to_tcb_ptr p) tcbBlockSizeBits"
   and   ptr0: "ctcb_ptr_to_tcb_ptr p \<noteq> 0"
@@ -3009,7 +3002,7 @@ proof -
        \<Longrightarrow> ctcb_ptr_to_tcb_ptr p \<notin> set list"
     using symref pks pal pds
     apply -
-    apply (frule map_to_ko_atI2)
+    apply (frule map_to_ko_atI)
       apply simp
      apply simp
     apply (drule (1) sym_refs_ko_atD')
@@ -3022,7 +3015,7 @@ proof -
        \<Longrightarrow> ctcb_ptr_to_tcb_ptr p \<notin> set list"
     using symref pks pal pds
     apply -
-    apply (frule map_to_ko_atI2)
+    apply (frule map_to_ko_atI)
       apply simp
      apply simp
     apply (drule (1) sym_refs_ko_atD')
@@ -3035,7 +3028,7 @@ proof -
        \<Longrightarrow> ctcb_ptr_to_tcb_ptr p \<notin> set list"
     using symref pks pal pds
     apply -
-    apply (frule map_to_ko_atI2)
+    apply (frule map_to_ko_atI)
       apply simp
      apply simp
     apply (drule (1) sym_refs_ko_atD')

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -5165,7 +5165,7 @@ lemma sendIPC_enqueue_ccorres_helper:
           apply (rule cnotification_relation_ep_queue, assumption+)
             apply (simp add: isSendEP_def isRecvEP_def)
            apply simp
-          apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
           apply (erule(2) map_to_ko_at_updI')
            apply (simp only:projectKOs injectKO_ep objBits_simps)
            apply clarsimp
@@ -5207,7 +5207,7 @@ lemma sendIPC_enqueue_ccorres_helper:
          apply (rule cnotification_relation_ep_queue, assumption+)
            apply (simp add: isSendEP_def isRecvEP_def)
           apply simp
-         apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+         apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
          apply (erule(2) map_to_ko_at_updI')
           apply (clarsimp simp: objBitsKO_def)
          apply (clarsimp simp: obj_at'_def projectKOs)
@@ -5566,7 +5566,7 @@ lemma receiveIPC_enqueue_ccorres_helper:
           apply (rule cnotification_relation_ep_queue, assumption+)
             apply (simp add: isSendEP_def isRecvEP_def)
            apply simp
-          apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
           apply (erule(2) map_to_ko_at_updI')
            apply (clarsimp simp: objBitsKO_def)
           apply (clarsimp simp: obj_at'_def projectKOs)
@@ -5604,7 +5604,7 @@ lemma receiveIPC_enqueue_ccorres_helper:
          apply (rule cnotification_relation_ep_queue, assumption+)
            apply (simp add: isSendEP_def isRecvEP_def)
           apply simp
-         apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+         apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
          apply (erule(2) map_to_ko_at_updI')
           apply (clarsimp simp: objBitsKO_def)
          apply (clarsimp simp: obj_at'_def projectKOs)
@@ -6657,7 +6657,7 @@ lemma receiveSignal_enqueue_ccorres_helper:
            apply (rule cendpoint_relation_ntfn_queue, assumption+)
              apply (simp add: isWaitingNtfn_def)
             apply simp
-           apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+           apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
            apply (erule(2) map_to_ko_at_updI')
             apply (clarsimp simp: objBitsKO_def)
            apply (clarsimp simp: obj_at'_def projectKOs)
@@ -6698,7 +6698,7 @@ lemma receiveSignal_enqueue_ccorres_helper:
           apply (rule cendpoint_relation_ntfn_queue, assumption+)
             apply (simp add: isWaitingNtfn_def)
            apply simp
-          apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
           apply (erule(2) map_to_ko_at_updI')
            apply (clarsimp simp: objBitsKO_def)
           apply (clarsimp simp: obj_at'_def projectKOs)

--- a/proof/crefine/ARM_HYP/Recycle_C.thy
+++ b/proof/crefine/ARM_HYP/Recycle_C.thy
@@ -1096,7 +1096,7 @@ lemma cancelBadgedSends_ccorres:
                      apply (rule cendpoint_relation_q_cong)
                      apply (rule sym, erule restrict_map_eqI)
                      apply (clarsimp simp: image_iff)
-                     apply (drule(2) map_to_ko_atI2)
+                     apply (drule(2) map_to_ko_atI)
                      apply (drule ko_at_state_refs_ofD')
                      apply clarsimp
                      apply (drule_tac x=p in spec)
@@ -1104,7 +1104,7 @@ lemma cancelBadgedSends_ccorres:
 
                     apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
                     apply clarsimp
-                    apply (drule(2) map_to_ko_atI2, drule ko_at_state_refs_ofD')
+                    apply (drule(2) map_to_ko_atI, drule ko_at_state_refs_ofD')
 
                     apply (rule cnotification_relation_q_cong)
                     apply (rule sym, erule restrict_map_eqI)

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -3532,7 +3532,7 @@ proof -
        \<Longrightarrow> ctcb_ptr_to_tcb_ptr p \<notin> set list"
     using symref pks pal pds
     apply -
-    apply (frule map_to_ko_atI2)
+    apply (frule map_to_ko_atI)
       apply simp
      apply simp
     apply (drule (1) sym_refs_ko_atD')
@@ -3545,7 +3545,7 @@ proof -
        \<Longrightarrow> ctcb_ptr_to_tcb_ptr p \<notin> set list"
     using symref pks pal pds
     apply -
-    apply (frule map_to_ko_atI2)
+    apply (frule map_to_ko_atI)
       apply simp
      apply simp
     apply (drule (1) sym_refs_ko_atD')
@@ -3558,7 +3558,7 @@ proof -
        \<Longrightarrow> ctcb_ptr_to_tcb_ptr p \<notin> set list"
     using symref pks pal pds
     apply -
-    apply (frule map_to_ko_atI2)
+    apply (frule map_to_ko_atI)
       apply simp
      apply simp
     apply (drule (1) sym_refs_ko_atD')

--- a/proof/crefine/Move_C.thy
+++ b/proof/crefine/Move_C.thy
@@ -571,14 +571,6 @@ lemma map_to_ko_atI':
   apply (simp add: project_inject)
   done
 
-(* FIXME: move up to SR_lemmas_C *)
-lemma map_to_ko_atI2:
-  "\<lbrakk>(projectKO_opt \<circ>\<^sub>m (ksPSpace s)) x = Some v; pspace_aligned' s; pspace_distinct' s\<rbrakk> \<Longrightarrow> ko_at' v x s"
-  apply (clarsimp simp: map_comp_Some_iff)
-  apply (erule (2) aligned_distinct_obj_atI')
-  apply (simp add: project_inject)
-  done
-
 lemma map_to_ko_at_updI':
   "\<And>x x' y y' y''.
    \<lbrakk> (projectKO_opt \<circ>\<^sub>m (ksPSpace s)) x = Some y;
@@ -586,7 +578,7 @@ lemma map_to_ko_at_updI':
      objBitsKO (injectKO y') = objBitsKO y''; x \<noteq> x' \<rbrakk> \<Longrightarrow>
    ko_at' y x (s\<lparr>ksPSpace := ksPSpace s(x' \<mapsto> y'')\<rparr>)"
   by (fastforce simp: obj_at'_def projectKOs objBitsKO_def ps_clear_upd
-               dest: map_to_ko_atI2)
+               dest: map_to_ko_atI)
 
 lemma ps_clear_upd_None:
   "ksPSpace s y = None \<Longrightarrow>

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -4891,7 +4891,7 @@ lemma sendIPC_enqueue_ccorres_helper:
           apply (rule cnotification_relation_ep_queue, assumption+)
             apply (simp add: isSendEP_def isRecvEP_def)
            apply simp
-          apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
           apply (erule(2) map_to_ko_at_updI')
            apply (simp only:projectKOs injectKO_ep objBits_simps)
            apply clarsimp
@@ -4944,7 +4944,7 @@ lemma sendIPC_enqueue_ccorres_helper:
          apply (rule cnotification_relation_ep_queue, assumption+)
            apply (simp add: isSendEP_def isRecvEP_def)
           apply simp
-         apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+         apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
          apply (erule(2) map_to_ko_at_updI')
           apply (clarsimp simp: objBitsKO_def)
          apply (clarsimp simp: obj_at'_def projectKOs)
@@ -5320,7 +5320,7 @@ lemma receiveIPC_enqueue_ccorres_helper:
           apply (rule cnotification_relation_ep_queue, assumption+)
             apply (simp add: isSendEP_def isRecvEP_def)
            apply simp
-          apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
           apply (erule(2) map_to_ko_at_updI')
            apply (clarsimp simp: objBitsKO_def)
           apply (clarsimp simp: obj_at'_def projectKOs)
@@ -5364,7 +5364,7 @@ lemma receiveIPC_enqueue_ccorres_helper:
          apply (rule cnotification_relation_ep_queue, assumption+)
            apply (simp add: isSendEP_def isRecvEP_def)
           apply simp
-         apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+         apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
          apply (erule(2) map_to_ko_at_updI')
           apply (clarsimp simp: objBitsKO_def)
          apply (clarsimp simp: obj_at'_def projectKOs)
@@ -6423,7 +6423,7 @@ lemma receiveSignal_enqueue_ccorres_helper:
            apply (rule cendpoint_relation_ntfn_queue, assumption+)
              apply (simp add: isWaitingNtfn_def)
             apply simp
-           apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+           apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
            apply (erule(2) map_to_ko_at_updI')
             apply (clarsimp simp: objBitsKO_def)
            apply (clarsimp simp: obj_at'_def projectKOs)
@@ -6470,7 +6470,7 @@ lemma receiveSignal_enqueue_ccorres_helper:
           apply (rule cendpoint_relation_ntfn_queue, assumption+)
             apply (simp add: isWaitingNtfn_def)
            apply simp
-          apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
           apply (erule(2) map_to_ko_at_updI')
            apply (clarsimp simp: objBitsKO_def)
           apply (clarsimp simp: obj_at'_def projectKOs)

--- a/proof/crefine/RISCV64/Recycle_C.thy
+++ b/proof/crefine/RISCV64/Recycle_C.thy
@@ -982,7 +982,7 @@ lemma cancelBadgedSends_ccorres:
                      apply (rule cendpoint_relation_q_cong)
                      apply (rule sym, erule restrict_map_eqI)
                      apply (clarsimp simp: image_iff)
-                     apply (drule(2) map_to_ko_atI2)
+                     apply (drule(2) map_to_ko_atI)
                      apply (drule ko_at_state_refs_ofD')
                      apply clarsimp
                      apply (drule_tac x=p in spec)
@@ -990,7 +990,7 @@ lemma cancelBadgedSends_ccorres:
 
                     apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
                     apply clarsimp
-                    apply (drule(2) map_to_ko_atI2, drule ko_at_state_refs_ofD')
+                    apply (drule(2) map_to_ko_atI, drule ko_at_state_refs_ofD')
 
                     apply (rule cnotification_relation_q_cong)
                     apply (rule sym, erule restrict_map_eqI)

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -3423,7 +3423,7 @@ proof -
        \<Longrightarrow> ctcb_ptr_to_tcb_ptr p \<notin> set list"
     using symref pks pal pds
     apply -
-    apply (frule map_to_ko_atI2)
+    apply (frule map_to_ko_atI)
       apply simp
      apply simp
     apply (drule (1) sym_refs_ko_atD')
@@ -3436,7 +3436,7 @@ proof -
        \<Longrightarrow> ctcb_ptr_to_tcb_ptr p \<notin> set list"
     using symref pks pal pds
     apply -
-    apply (frule map_to_ko_atI2)
+    apply (frule map_to_ko_atI)
       apply simp
      apply simp
     apply (drule (1) sym_refs_ko_atD')
@@ -3449,7 +3449,7 @@ proof -
        \<Longrightarrow> ctcb_ptr_to_tcb_ptr p \<notin> set list"
     using symref pks pal pds
     apply -
-    apply (frule map_to_ko_atI2)
+    apply (frule map_to_ko_atI)
       apply simp
      apply simp
     apply (drule (1) sym_refs_ko_atD')

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -4909,7 +4909,7 @@ lemma sendIPC_enqueue_ccorres_helper:
           apply (rule cnotification_relation_ep_queue, assumption+)
             apply (simp add: isSendEP_def isRecvEP_def)
            apply simp
-          apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
           apply (erule(2) map_to_ko_at_updI')
            apply (simp only:projectKOs injectKO_ep objBits_simps)
            apply clarsimp
@@ -4964,7 +4964,7 @@ lemma sendIPC_enqueue_ccorres_helper:
          apply (rule cnotification_relation_ep_queue, assumption+)
            apply (simp add: isSendEP_def isRecvEP_def)
           apply simp
-         apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+         apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
          apply (erule(2) map_to_ko_at_updI')
           apply (clarsimp simp: objBitsKO_def)
          apply (clarsimp simp: obj_at'_def projectKOs)
@@ -5341,7 +5341,7 @@ lemma receiveIPC_enqueue_ccorres_helper:
           apply (rule cnotification_relation_ep_queue, assumption+)
             apply (simp add: isSendEP_def isRecvEP_def)
            apply simp
-          apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
           apply (erule(2) map_to_ko_at_updI')
            apply (clarsimp simp: objBitsKO_def)
           apply (clarsimp simp: obj_at'_def projectKOs)
@@ -5387,7 +5387,7 @@ lemma receiveIPC_enqueue_ccorres_helper:
          apply (rule cnotification_relation_ep_queue, assumption+)
            apply (simp add: isSendEP_def isRecvEP_def)
           apply simp
-         apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+         apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
          apply (erule(2) map_to_ko_at_updI')
           apply (clarsimp simp: objBitsKO_def)
          apply (clarsimp simp: obj_at'_def projectKOs)
@@ -6465,7 +6465,7 @@ lemma receiveSignal_enqueue_ccorres_helper:
            apply (rule cendpoint_relation_ntfn_queue, assumption+)
              apply (simp add: isWaitingNtfn_def)
             apply simp
-           apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+           apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
            apply (erule(2) map_to_ko_at_updI')
             apply (clarsimp simp: objBitsKO_def)
            apply (clarsimp simp: obj_at'_def projectKOs)
@@ -6515,7 +6515,7 @@ lemma receiveSignal_enqueue_ccorres_helper:
           apply (rule cendpoint_relation_ntfn_queue, assumption+)
             apply (simp add: isWaitingNtfn_def)
            apply simp
-          apply (frule_tac x=p in map_to_ko_atI2, clarsimp, clarsimp)
+          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
           apply (erule(2) map_to_ko_at_updI')
            apply (clarsimp simp: objBitsKO_def)
           apply (clarsimp simp: obj_at'_def projectKOs)

--- a/proof/crefine/X64/Recycle_C.thy
+++ b/proof/crefine/X64/Recycle_C.thy
@@ -1081,7 +1081,7 @@ lemma cancelBadgedSends_ccorres:
                      apply (rule cendpoint_relation_q_cong)
                      apply (rule sym, erule restrict_map_eqI)
                      apply (clarsimp simp: image_iff)
-                     apply (drule(2) map_to_ko_atI2)
+                     apply (drule(2) map_to_ko_atI)
                      apply (drule ko_at_state_refs_ofD')
                      apply clarsimp
                      apply (drule_tac x=p in spec)
@@ -1089,7 +1089,7 @@ lemma cancelBadgedSends_ccorres:
 
                     apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
                     apply clarsimp
-                    apply (drule(2) map_to_ko_atI2, drule ko_at_state_refs_ofD')
+                    apply (drule(2) map_to_ko_atI, drule ko_at_state_refs_ofD')
 
                     apply (rule cnotification_relation_q_cong)
                     apply (rule sym, erule restrict_map_eqI)

--- a/proof/crefine/X64/Retype_C.thy
+++ b/proof/crefine/X64/Retype_C.thy
@@ -4018,7 +4018,7 @@ proof -
        \<Longrightarrow> ctcb_ptr_to_tcb_ptr p \<notin> set list"
     using symref pks pal pds
     apply -
-    apply (frule map_to_ko_atI2)
+    apply (frule map_to_ko_atI)
       apply simp
      apply simp
     apply (drule (1) sym_refs_ko_atD')
@@ -4031,7 +4031,7 @@ proof -
        \<Longrightarrow> ctcb_ptr_to_tcb_ptr p \<notin> set list"
     using symref pks pal pds
     apply -
-    apply (frule map_to_ko_atI2)
+    apply (frule map_to_ko_atI)
       apply simp
      apply simp
     apply (drule (1) sym_refs_ko_atD')
@@ -4044,7 +4044,7 @@ proof -
        \<Longrightarrow> ctcb_ptr_to_tcb_ptr p \<notin> set list"
     using symref pks pal pds
     apply -
-    apply (frule map_to_ko_atI2)
+    apply (frule map_to_ko_atI)
       apply simp
      apply simp
     apply (drule (1) sym_refs_ko_atD')


### PR DESCRIPTION
The lemma map_to_ko_atI2 was exactly the same as map_to_ko_atI.