### PR TITLE
lib: add syntax to crunch_ignore multiple instances

### DIFF
--- a/lib/Crunch.ML
+++ b/lib/Crunch.ML
@@ -117,21 +117,25 @@ val crunch_ignoreP =
     Outer_Syntax.local_theory
          @{command_keyword "crunch_ignore"}
         "add to and delete from list of things that crunch should ignore in finding prerequisites"
-        ((Scan.optional (P.$$$ "(" |-- P.name --| P.$$$ ")") "" -- Scan.optional
+        ((Scan.optional (P.$$$ "(" |-- P.list1 P.name --| P.$$$ ")") [""] -- Scan.optional
           (P.$$$ "(" |-- read_sections [add_sect, del_sect] --| P.$$$ ")")
-          []
-        )
-        >> (fn (crunch_instance, wpigs) => fn lthy =>
+          [])
+         >> (fn (crunch_instances, wpigs) => fn lthy =>
                let fun const_name const = dest_Const (read_const lthy const) |> #1;
                    val add = wpigs |> filter (fn (s,_) => s = #1 add_sect) |> map #2 |> constants
                                    |> map const_name;
                    val del = wpigs |> filter (fn (s,_) => s = #1 del_sect) |> map #2 |> constants
                                    |> map const_name;
-                   val crunch_ignore_add_del = (case get_crunch_instance crunch_instance (Proof_Context.theory_of lthy) of
-                     NONE => error ("Crunch has not been defined for " ^ crunch_instance)
-                   | SOME x => snd x);
+                   fun crunch_ignore_add_del inst =
+                     (case get_crunch_instance inst (Proof_Context.theory_of lthy) of
+                        NONE => error ("Crunch has not been defined for " ^ inst)
+                      | SOME x => snd x);
+                   val crunch_ignore_add_dels =
+                     map (fn inst => crunch_ignore_add_del inst add del) crunch_instances
+                   val crunch_ignore_add_dels' =
+                     fold (curry (op #>)) (tl crunch_ignore_add_dels) (hd crunch_ignore_add_dels)
                in
-                  Local_Theory.raw_theory (crunch_ignore_add_del add del) lthy
+                  Local_Theory.raw_theory crunch_ignore_add_dels' lthy
                end));
 
 end;

--- a/lib/test/Crunch_Test_NonDet.thy
+++ b/lib/test/Crunch_Test_NonDet.thy
@@ -26,13 +26,14 @@ definition
     crunch_foo1 13
   od"
 
+crunch_ignore (valid, empty_fail, no_fail) (add: bind)
+
 crunch (empty_fail) empty_fail: crunch_foo2
-  (ignore: modify bind)
 
 crunch_ignore (add: crunch_foo1)
 
 crunch gt: crunch_foo2 "\<lambda>x. x > y"
-  (ignore: modify bind ignore_del: crunch_foo1)
+  (ignore_del: crunch_foo1)
 
 crunch_ignore (del: crunch_foo1)
 
@@ -56,24 +57,22 @@ lemma crunch_foo1_no_fail:
   done
 
 crunch (no_fail) no_fail: crunch_foo2
-  (ignore: modify bind wp: crunch_foo1_at_2[simplified])
+  (wp: crunch_foo1_at_2[simplified])
 
 crunch (valid) at_2: crunch_foo2 "crunch_always_true 2"
-  (ignore: modify bind wp: crunch_foo1_at_2[simplified])
+  (wp: crunch_foo1_at_2[simplified])
 
 fun crunch_foo3 :: "nat => nat => 'a => (nat,unit) nondet_monad" where
   "crunch_foo3 0 x _ = crunch_foo1 x"
 | "crunch_foo3 (Suc n) x y = crunch_foo3 n x y"
 
 crunch gt2: crunch_foo3 "\<lambda>x. x > y"
-  (ignore: modify bind)
 
 crunch (empty_fail) empty_fail2: crunch_foo3
-  (ignore: modify bind)
 
 (* check that simp rules can be used to solve a goal without crunching *)
 crunch (empty_fail) empty_fail: crunch_foo3
-  (ignore: modify bind ignore: crunch_foo1 simp: crunch_foo3_empty_fail2)
+  (ignore: crunch_foo1 simp: crunch_foo3_empty_fail2)
 
 class foo_class =
   fixes stuff :: 'a
@@ -96,21 +95,21 @@ lemma crunch_foo4_alt:
 
 (* prove rules about crunch_foo4 with and without the alternative definition *)
 crunch gt3: crunch_foo4 "\<lambda>x. x > y"
-  (ignore: modify bind)
 
 crunch (no_fail) no_fail2: crunch_foo4
-  (rule: crunch_foo4_alt ignore: modify bind)
+  (rule: crunch_foo4_alt)
 
 crunch gt3': crunch_foo4 "\<lambda>x. x > y"
-  (rule: crunch_foo4_alt ignore: modify bind)
+  (rule: crunch_foo4_alt)
 
 crunch gt4: crunch_foo5 "\<lambda>x. x > y"
-  (ignore: modify bind)
 
 (* Test cases for crunch in locales *)
 
 definition
   "crunch_foo6 \<equiv> return () >>= (\<lambda>_. return ())"
+
+crunch_ignore (del: bind)
 
 locale test_locale =
 fixes fixed_return_unit :: "(unit, unit) nondet_monad"
@@ -192,7 +191,7 @@ crunch test: foo_const P
 
 crunches crunch_foo3, crunch_foo4, crunch_foo5
   for silly: "\<lambda>s. True \<noteq> False" and (no_fail)nf and (empty_fail)ef
-  (ignore: modify bind rule: crunch_foo4_alt wp_del: hoare_vcg_prop)
+  (rule: crunch_foo4_alt wp_del: hoare_vcg_prop)
 
 (* check that crunch can use wps to lift sub-predicates
    (and also that top-level constants can be ignored) *)


### PR DESCRIPTION
Add support to crunch_ignore so that multiple instances can be added to and removed from simultaneously.

There is an example in [lib/test/Crunch_Test_NonDet.thy](https://github.com/seL4/l4v/compare/master...corlewis:master#diff-a70563cedfb16fff3aebf5def8732ad4a8133223084b0330635b1b4b907a41f7) of this being used.