### PR TITLE
lib: add a crunch option for naming schemes

### DIFF
--- a/lib/BCorres_UL.thy
+++ b/lib/BCorres_UL.thy
@@ -271,6 +271,7 @@ ML \<open>
 structure CrunchBCorresInstance : CrunchInstance =
 struct
   val name = "bcorres";
+  val prefix_name_scheme = false;
   type extra = term;
   val eq_extra = ae_conv;
   fun parse_extra ctxt extra

--- a/lib/Crunch_Instances_NonDet.thy
+++ b/lib/Crunch_Instances_NonDet.thy
@@ -26,6 +26,7 @@ fun get_nondet_monad_state_type
 structure CrunchValidInstance : CrunchInstance =
 struct
   val name = "valid";
+  val prefix_name_scheme = false;
   type extra = term;
   val eq_extra = ae_conv;
   fun parse_extra ctxt extra
@@ -55,6 +56,7 @@ structure CrunchValid : CRUNCH = Crunch(CrunchValidInstance);
 structure CrunchNoFailInstance : CrunchInstance =
 struct
   val name = "no_fail";
+  val prefix_name_scheme = false;
   type extra = unit;
   val eq_extra = op =;
   fun parse_extra ctxt extra
@@ -83,6 +85,7 @@ structure CrunchNoFail : CRUNCH = Crunch(CrunchNoFailInstance);
 structure CrunchEmptyFailInstance : CrunchInstance =
 struct
   val name = "empty_fail";
+  val prefix_name_scheme = false;
   type extra = unit;
   val eq_extra = op =;
   fun parse_extra ctxt extra
@@ -109,6 +112,7 @@ structure CrunchEmptyFail : CRUNCH = Crunch(CrunchEmptyFailInstance);
 structure CrunchValidEInstance : CrunchInstance =
 struct
   val name = "valid_E";
+  val prefix_name_scheme = false;
   type extra = term * term;
   fun eq_extra ((a, b), (c, d)) = (ae_conv (a, c) andalso ae_conv (b, d));
   fun parse_extra ctxt extra

--- a/lib/Crunch_Instances_NonDet.thy
+++ b/lib/Crunch_Instances_NonDet.thy
@@ -56,7 +56,7 @@ structure CrunchValid : CRUNCH = Crunch(CrunchValidInstance);
 structure CrunchNoFailInstance : CrunchInstance =
 struct
   val name = "no_fail";
-  val prefix_name_scheme = false;
+  val prefix_name_scheme = true;
   type extra = unit;
   val eq_extra = op =;
   fun parse_extra ctxt extra

--- a/lib/Crunch_Instances_Trace.thy
+++ b/lib/Crunch_Instances_Trace.thy
@@ -25,6 +25,7 @@ fun get_trace_monad_state_type
 structure CrunchValidInstance : CrunchInstance =
 struct
   val name = "valid";
+  val prefix_name_scheme = false;
   type extra = term;
   val eq_extra = ae_conv;
   fun parse_extra ctxt extra
@@ -54,6 +55,7 @@ structure CrunchValid : CRUNCH = Crunch(CrunchValidInstance);
 structure CrunchNoFailInstance : CrunchInstance =
 struct
   val name = "no_fail";
+  val prefix_name_scheme = true;
   type extra = unit;
   val eq_extra = op =;
   fun parse_extra ctxt extra
@@ -82,6 +84,7 @@ structure CrunchNoFail : CRUNCH = Crunch(CrunchNoFailInstance);
 structure CrunchValidEInstance : CrunchInstance =
 struct
   val name = "valid_E";
+  val prefix_name_scheme = false;
   type extra = term * term;
   fun eq_extra ((a, b), (c, d)) = (ae_conv (a, c) andalso ae_conv (b, d));
   fun parse_extra ctxt extra
@@ -111,6 +114,7 @@ structure CrunchValidE : CRUNCH = Crunch(CrunchValidEInstance);
 structure CrunchPrefixClosedInstance : CrunchInstance =
 struct
   val name = "prefix_closed";
+  val prefix_name_scheme = false;
   type extra = unit;
   val eq_extra = op =;
   fun parse_extra ctxt extra

--- a/lib/crunch-cmd.ML
+++ b/lib/crunch-cmd.ML
@@ -109,6 +109,8 @@ signature CrunchInstance =
 sig
     (* The name of the property. *)
     val name : string;
+    (* Which naming scheme to use - true for prefix, false for suffix*)
+    val prefix_name_scheme : bool
     (* The type of any parameters of the property beyond a (optional) precondition
        and the function being crunched. *)
     type extra;
@@ -143,11 +145,12 @@ end
 signature CRUNCH =
 sig
     type extra;
-    (* Crunch configuration: theory, naming scheme, name space, wp rules, wps_rules,
-    constants to ignore, simp rules, constants to not ignore, unfold rules*)
-    type crunch_cfg = {ctxt: local_theory, prp_name: string, nmspce: string option,
-        wp_rules: (string * thm) list, wps_rules: thm list, igs: string list, simps: thm list,
-        ig_dels: string list, rules: thm list};
+    (* Crunch configuration: theory, property name, name space, wp rules, wps_rules,
+       constants to ignore, simp rules, constants to not ignore, unfold rules *)
+    type crunch_cfg =
+      {ctxt: local_theory, prp_name: string, nmspce: string option,
+       wp_rules: (string * thm) list, wps_rules: thm list, igs: string list,
+       simps: thm list, ig_dels: string list, rules: thm list};
 
     (* Crunch takes a configuration, a precondition, any extra information needed, a debug stack,
     a constant name, and a list of previously proven theorems, and returns a theorem for
@@ -171,9 +174,10 @@ struct
 
 type extra = Instance.extra;
 
-type crunch_cfg = {ctxt: local_theory, prp_name: string, nmspce: string option,
-    wp_rules: (string * thm) list, wps_rules: thm list, igs: string list, simps: thm list,
-    ig_dels: string list, rules: thm list};
+type crunch_cfg =
+  {ctxt: local_theory, prp_name: string, nmspce: string option,
+   wp_rules: (string * thm) list, wps_rules: thm list, igs: string list,
+   simps: thm list, ig_dels: string list, rules: thm list};
 
 structure CrunchIgnore = Theory_Data
 (struct
@@ -273,11 +277,17 @@ fun thy_maybe_thms thy name = Global_Theory.get_thms thy name handle ERROR _ => 
 fun add_thm thm atts name ctxt =
   Local_Theory.notes [((Binding.name name, atts), [([thm], [])])] ctxt |> #2
 
-fun get_thm_name (cfg : crunch_cfg) const_name
-  = if read_const (#ctxt cfg) (Long_Name.base_name const_name)
+fun get_thm_name (cfg : crunch_cfg) const_name =
+  let val const_name' =
+    if read_const (#ctxt cfg) (Long_Name.base_name const_name)
          = read_const (#ctxt cfg) const_name
-      then Long_Name.base_name const_name ^ "_" ^ (#prp_name cfg)
-      else space_implode "_" (space_explode "." const_name @ [#prp_name cfg])
+    then Long_Name.base_name const_name
+    else space_implode "_" (space_explode "." const_name)
+  in
+    if Instance.prefix_name_scheme
+    then (#prp_name cfg) ^ "_" ^ const_name'
+    else const_name' ^ "_" ^ (#prp_name cfg)
+  end;
 
 fun get_stored cfg n = get_thm (#ctxt cfg) (get_thm_name cfg n)
 
@@ -882,10 +892,12 @@ fun crunch_x atts extra prp_name wpigs consts ctxt =
 
         val ctxt'' = ctxt' delsimps simp_dels;
 
-        val (_, thms) = funkyfold (crunch {ctxt = ctxt'', prp_name = prp_name, nmspce = nmspce,
-              wp_rules = wp_rules, wps_rules = wps_rules, igs = igs, simps = simps,
-              ig_dels = ig_dels, rules = rules} pre' extra' [])
-            full_const_names [];
+        val crunch_cfg =
+          {ctxt = ctxt'', prp_name = prp_name, nmspce = nmspce, wp_rules = wp_rules,
+           wps_rules = wps_rules, igs = igs, simps = simps, ig_dels = ig_dels,
+           rules = rules}
+        val (_, thms) =
+          funkyfold (crunch crunch_cfg pre' extra' []) full_const_names [];
         val _ = if null thms then warning "crunch: no theorems proven" else ();
 
         val atts' = map (Attrib.check_src ctxt) atts;

--- a/lib/test/Crunch_Test_NonDet.thy
+++ b/lib/test/Crunch_Test_NonDet.thy
@@ -49,7 +49,7 @@ lemma crunch_foo1_at_3[wp]:
   "\<lbrace>crunch_always_true 3\<rbrace> crunch_foo1 x \<lbrace>\<lambda>rv. crunch_always_true 3\<rbrace>"
   by (simp add: crunch_always_true_def, wp)
 
-lemma crunch_foo1_no_fail:
+lemma no_fail_crunch_foo1:
   "True \<Longrightarrow> no_fail (crunch_always_true 2 and crunch_always_true 3) (crunch_foo1 x)"
   apply (simp add:crunch_always_true_def crunch_foo1_def)
   apply (rule no_fail_pre)
@@ -190,7 +190,9 @@ crunch test: foo_const P
 (* check that the grid-style crunch is working *)
 
 crunches crunch_foo3, crunch_foo4, crunch_foo5
-  for silly: "\<lambda>s. True \<noteq> False" and (no_fail)nf and (empty_fail)ef
+  for silly: "\<lambda>s. True \<noteq> False"
+  and (no_fail) nf
+  and (empty_fail) ef
   (rule: crunch_foo4_alt wp_del: hoare_vcg_prop)
 
 (* check that crunch can use wps to lift sub-predicates
@@ -225,7 +227,7 @@ lemma do_nat_op_ef:
               simp: mk_ef_def)
   done
 
-lemma do_nat_op_nf:
+lemma nf_do_nat_op:
   "no_fail P f \<Longrightarrow> empty_fail f \<Longrightarrow> no_fail (P \<circ> state') (do_nat_op f)"
   unfolding do_nat_op_def
   apply wpsimp
@@ -247,7 +249,7 @@ definition do_extended_op :: "(nat state, unit) nondet_monad \<Rightarrow> ('a s
 
 axiomatization
   where do_extended_op_ef[wp]: "empty_fail f \<Longrightarrow> empty_fail (do_extended_op f)"
-  and do_extended_op_nf[wp]: "no_fail P f \<Longrightarrow> empty_fail f \<Longrightarrow> no_fail (P \<circ> unwrap_ext) (do_extended_op f)"
+  and nf_do_extended_op[wp]: "no_fail P f \<Longrightarrow> empty_fail f \<Longrightarrow> no_fail (P \<circ> unwrap_ext) (do_extended_op f)"
 
 definition
   "crunch_foo12_ext (x :: nat) = modify (ext_update ((+) x))"
@@ -269,7 +271,7 @@ definition crunch_foo13_pre :: "('a state,unit) nondet_monad" where
   "crunch_foo13_pre \<equiv> return ()"
 
 axiomatization
-  where crunch_foo13_pre_nf[wp]: "no_fail (crunch_always_true 0) crunch_foo13_pre"
+  where nf_crunch_foo13_pre[wp]: "no_fail (crunch_always_true 0) crunch_foo13_pre"
 
 definition
   "crunch_foo13 x \<equiv>

--- a/lib/test/Crunch_Test_Trace.thy
+++ b/lib/test/Crunch_Test_Trace.thy
@@ -44,7 +44,7 @@ lemma crunch_foo1_at_3[wp]:
   "\<lbrace>crunch_always_true 3\<rbrace> crunch_foo1 x \<lbrace>\<lambda>rv. crunch_always_true 3\<rbrace>"
   by (simp add: crunch_always_true_def, wp)
 
-lemma crunch_foo1_no_fail:
+lemma no_fail_crunch_foo1:
   "True \<Longrightarrow> no_fail (crunch_always_true 2 and crunch_always_true 3) (crunch_foo1 x)"
   apply (simp add:crunch_always_true_def crunch_foo1_def)
   apply (rule no_fail_pre)
@@ -179,7 +179,8 @@ crunch test: foo_const P
 (* check that the grid-style crunch is working *)
 
 crunches crunch_foo3, crunch_foo4, crunch_foo5
-  for silly: "\<lambda>s. True \<noteq> False" and (no_fail)nf
+  for silly: "\<lambda>s. True \<noteq> False"
+  and (no_fail) nf
   (ignore: modify bind rule: crunch_foo4_alt wp_del: hoare_vcg_prop)
 
 end

--- a/proof/invariant-abstract/ARM/Machine_AI.thy
+++ b/proof/invariant-abstract/ARM/Machine_AI.thy
@@ -26,6 +26,7 @@ ML \<open>
 structure CrunchNoIrqInstance : CrunchInstance =
 struct
   val name = "no_irq";
+  val prefix_name_scheme = false;
   type extra = unit;
   val eq_extra = op =;
   fun parse_extra ctxt extra

--- a/proof/invariant-abstract/ARM/Machine_AI.thy
+++ b/proof/invariant-abstract/ARM/Machine_AI.thy
@@ -26,7 +26,7 @@ ML \<open>
 structure CrunchNoIrqInstance : CrunchInstance =
 struct
   val name = "no_irq";
-  val prefix_name_scheme = false;
+  val prefix_name_scheme = true;
   type extra = unit;
   val eq_extra = op =;
   fun parse_extra ctxt extra
@@ -347,7 +347,7 @@ lemma no_irq_use:
   apply fastforce
   done
 
-lemma machine_rest_lift_no_irq:
+lemma no_irq_machine_rest_lift:
   "no_irq (machine_rest_lift f)"
   apply (clarsimp simp: no_irq_def machine_rest_lift_def split_def)
   apply wp

--- a/proof/invariant-abstract/ARM_HYP/Machine_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/Machine_AI.thy
@@ -26,6 +26,7 @@ ML \<open>
 structure CrunchNoIrqInstance : CrunchInstance =
 struct
   val name = "no_irq";
+  val prefix_name_scheme = false;
   type extra = unit;
   val eq_extra = op =;
   fun parse_extra ctxt extra

--- a/proof/invariant-abstract/ARM_HYP/Machine_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/Machine_AI.thy
@@ -26,7 +26,7 @@ ML \<open>
 structure CrunchNoIrqInstance : CrunchInstance =
 struct
   val name = "no_irq";
-  val prefix_name_scheme = false;
+  val prefix_name_scheme = true;
   type extra = unit;
   val eq_extra = op =;
   fun parse_extra ctxt extra
@@ -356,7 +356,7 @@ lemma no_irq_use:
   apply fastforce
   done
 
-lemma machine_rest_lift_no_irq:
+lemma no_irq_machine_rest_lift:
   "no_irq (machine_rest_lift f)"
   apply (clarsimp simp: no_irq_def machine_rest_lift_def split_def)
   apply wp
@@ -469,7 +469,7 @@ lemma no_irq_writeContextIDAndPD: "no_irq (writeContextIDAndPD asid w)"
 lemma no_irq_addressTranslateS1CPR: "no_irq (addressTranslateS1CPR w)"
   apply (clarsimp simp add: addressTranslateS1CPR_def no_irq_def, wp)
   apply (simp only: atomize_all)
-  apply (wp machine_op_lift_no_irq[simplified no_irq_def], simp)
+  apply (wp no_irq_machine_op_lift[simplified no_irq_def], simp)
   done
 
 lemma no_irq_setHCR: "no_irq (setHCR w)"
@@ -502,7 +502,7 @@ lemma no_irq_set_gic_vcpu_ctrl_apr: "no_irq (set_gic_vcpu_ctrl_apr w)"
 lemma no_irq_get_gic_vcpu_ctrl_lr: "no_irq (get_gic_vcpu_ctrl_lr n)"
   apply (clarsimp simp add: get_gic_vcpu_ctrl_lr_def no_irq_def, wp)
   apply (simp only: atomize_all)
-  apply (wp machine_op_lift_no_irq[simplified no_irq_def], simp)
+  apply (wp no_irq_machine_op_lift[simplified no_irq_def], simp)
   done
 
 lemma no_irq_set_gic_vcpu_ctrl_lr: "no_irq (set_gic_vcpu_ctrl_lr n w)"

--- a/proof/invariant-abstract/RISCV64/Machine_AI.thy
+++ b/proof/invariant-abstract/RISCV64/Machine_AI.thy
@@ -26,6 +26,7 @@ ML \<open>
 structure CrunchNoIrqInstance : CrunchInstance =
 struct
   val name = "no_irq";
+  val prefix_name_scheme = false;
   type extra = unit;
   val eq_extra = op =;
   fun parse_extra ctxt extra

--- a/proof/invariant-abstract/RISCV64/Machine_AI.thy
+++ b/proof/invariant-abstract/RISCV64/Machine_AI.thy
@@ -26,7 +26,7 @@ ML \<open>
 structure CrunchNoIrqInstance : CrunchInstance =
 struct
   val name = "no_irq";
-  val prefix_name_scheme = false;
+  val prefix_name_scheme = true;
   type extra = unit;
   val eq_extra = op =;
   fun parse_extra ctxt extra
@@ -204,7 +204,7 @@ lemma no_irq_use:
   apply fastforce
   done
 
-lemma machine_rest_lift_no_irq:
+lemma no_irq_machine_rest_lift:
   "no_irq (machine_rest_lift f)"
   apply (clarsimp simp: no_irq_def machine_rest_lift_def split_def)
   apply wp

--- a/proof/invariant-abstract/X64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/X64/ArchVSpace_AI.thy
@@ -15,7 +15,7 @@ begin
 context Arch begin global_naming X64
 
 (* FIXME: should go in Machine_AI, but needs dmo_invs from KHeap_AI. *)
-lemmas machine_op_lift_irq_masks = no_irq[OF machine_op_lift_no_irq]
+lemmas machine_op_lift_irq_masks = no_irq[OF no_irq_machine_op_lift]
 
 lemma machine_op_lift_underlying_memory:
   "\<lbrace>\<lambda>m'. underlying_memory m' p = um\<rbrace> machine_op_lift m \<lbrace>\<lambda>_ m'. underlying_memory m' p = um\<rbrace>"

--- a/proof/invariant-abstract/X64/Machine_AI.thy
+++ b/proof/invariant-abstract/X64/Machine_AI.thy
@@ -26,6 +26,7 @@ ML \<open>
 structure CrunchNoIrqInstance : CrunchInstance =
 struct
   val name = "no_irq";
+  val prefix_name_scheme = false;
   type extra = unit;
   val eq_extra = op =;
   fun parse_extra ctxt extra

--- a/proof/invariant-abstract/X64/Machine_AI.thy
+++ b/proof/invariant-abstract/X64/Machine_AI.thy
@@ -26,7 +26,7 @@ ML \<open>
 structure CrunchNoIrqInstance : CrunchInstance =
 struct
   val name = "no_irq";
-  val prefix_name_scheme = false;
+  val prefix_name_scheme = true;
   type extra = unit;
   val eq_extra = op =;
   fun parse_extra ctxt extra
@@ -204,7 +204,7 @@ lemma no_irq_use:
   apply fastforce
   done
 
-lemma machine_rest_lift_no_irq:
+lemma no_irq_machine_rest_lift:
   "no_irq (machine_rest_lift f)"
   apply (clarsimp simp: no_irq_def machine_rest_lift_def split_def)
   apply wp

--- a/proof/refine/ARM_HYP/CNodeInv_R.thy
+++ b/proof/refine/ARM_HYP/CNodeInv_R.thy
@@ -8965,7 +8965,7 @@ crunches
   vcpuUpdate, vgicUpdateLR, vcpuSave
   for irq_states' [wp]: valid_irq_states'
   (wp: crunch_wps maskInterrupt_irq_states'[where b=True, simplified] no_irq no_irq_mapM_x
-   simp: crunch_simps
+   simp: crunch_simps no_irq_isb no_irq_dsb
          set_gic_vcpu_ctrl_hcr_def setSCTLR_def setHCR_def get_gic_vcpu_ctrl_hcr_def
          getSCTLR_def get_gic_vcpu_ctrl_lr_def get_gic_vcpu_ctrl_apr_def
          get_gic_vcpu_ctrl_vmcr_def

--- a/proof/refine/ARM_HYP/Ipc_R.thy
+++ b/proof/refine/ARM_HYP/Ipc_R.thy
@@ -1563,8 +1563,8 @@ lemma makeArchFaultMessage_corres:
     apply (rule corres_split_eqr[OF _ asUser_getRestartPC_corres])
       apply (rule corres_split_eqr[OF _ corres_machine_op])
          apply (rule corres_trivial, simp)
-        apply (rule corres_underlying_trivial[OF addressTranslateS1CPR_no_fail])
-       apply (wp+, auto)
+        apply (rule corres_underlying_trivial)
+        apply (wp+, auto)
   done
 
 lemma makeFaultMessage_corres:

--- a/proof/refine/ARM_HYP/VSpace_R.thy
+++ b/proof/refine/ARM_HYP/VSpace_R.thy
@@ -3842,7 +3842,7 @@ lemma saveVirtTimer_invs_no_cicd'[wp]:
 
 lemma set_cntv_off_64_invs_no_cicd'[wp]:
   "\<lbrace>invs_no_cicd'\<rbrace> doMachineOp (set_cntv_off_64 v) \<lbrace>\<lambda>rv. invs_no_cicd'\<rbrace>"
-  apply (wpsimp wp: dmo_invs_no_cicd' set_cntv_off_64_no_irq no_irq)
+  apply (wpsimp wp: dmo_invs_no_cicd' no_irq)
   apply (drule_tac Q="\<lambda>_ m'. underlying_memory m' p = underlying_memory m p"
          in use_valid)
   apply (wpsimp simp: machine_op_lift_def set_cntv_off_64_def
@@ -3851,7 +3851,7 @@ lemma set_cntv_off_64_invs_no_cicd'[wp]:
 
 lemma set_cntv_cval_64_invs_no_cicd'[wp]:
   "\<lbrace>invs_no_cicd'\<rbrace> doMachineOp (set_cntv_cval_64 v) \<lbrace>\<lambda>rv. invs_no_cicd'\<rbrace>"
-  apply (wpsimp wp: dmo_invs_no_cicd' set_cntv_cval_64_no_irq no_irq)
+  apply (wpsimp wp: dmo_invs_no_cicd' no_irq)
   apply (drule_tac Q="\<lambda>_ m'. underlying_memory m' p = underlying_memory m p"
          in use_valid)
   apply (wpsimp simp: machine_op_lift_def set_cntv_cval_64_def


### PR DESCRIPTION
Some properties that crunch can be used for have different legacy naming schemes. This commit makes it possible for different instances of crunch to be configured for either prefix or suffix naming.