### PR TITLE
AArch64 Abstract Invariant Proofs: initial setup + sorrying run

### DIFF
--- a/camkes/Makefile
+++ b/camkes/Makefile
@@ -9,8 +9,6 @@ images: Camkes
 default: images test
 test:
 all: images test
-report-regression:
-	@echo Camkes
 
 #
 # Setup heaps.

--- a/lib/Monad_WP/OptionMonad.thy
+++ b/lib/Monad_WP/OptionMonad.thy
@@ -167,6 +167,10 @@ lemma opt_predE:
   "\<lbrakk>(P |< proj) x; \<And>y. \<lbrakk>proj x = Some y; P y\<rbrakk> \<Longrightarrow> R\<rbrakk> \<Longrightarrow> R"
   by (clarsimp split: option.splits)
 
+lemma in_opt_pred:
+  "(P |< f) p = (\<exists>v. f p = Some v \<and> P v)"
+  by (auto dest: opt_predD)
+
 lemma opt_pred_unfold_map:
   "(P |< (f |> g)) = ((P |< g) |< f)"
   by (fastforce simp: opt_map_def split: option.splits)

--- a/lib/Monad_WP/OptionMonad.thy
+++ b/lib/Monad_WP/OptionMonad.thy
@@ -201,6 +201,9 @@ definition
 definition oapply :: "'a \<Rightarrow> ('a \<Rightarrow> 'b option) \<Rightarrow> 'b option" where
   "oapply x \<equiv> \<lambda>s. s x"
 
+definition oapply2 :: "'a \<Rightarrow> 'b \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> 'c option) \<Rightarrow> 'c option" where
+  "oapply2 x y \<equiv> \<lambda>s. s x y"
+
 definition oliftM :: "('a \<Rightarrow> 'b) \<Rightarrow> ('s,'a) lookup \<Rightarrow> ('s,'b) lookup" where
   "oliftM f m \<equiv> do { x \<leftarrow> m; oreturn (f x) }"
 
@@ -432,6 +435,10 @@ lemma oreturn_apply[simp]:
 lemma oapply_apply[simp]:
   "oapply x s = s x"
   by (simp add: oapply_def)
+
+lemma oapply2_apply[simp]:
+  "oapply2 x y s = s x y"
+  by (simp add: oapply2_def)
 
 lemma obind_comp_dist:
   "obind f g o h = obind (f o h) (\<lambda>x. g x o h)"

--- a/lib/Monad_WP/OptionMonadND.thy
+++ b/lib/Monad_WP/OptionMonadND.thy
@@ -125,7 +125,7 @@ lemmas omonad_simps [simp] =
   gets_the_throwError gets_the_assert gets_the_Some
   gets_the_oapply_comp
 
-lemmas in_omonad = bind_eq_Some_conv in_obind_eq in_opt_map_eq Let_def
+lemmas in_omonad = bind_eq_Some_conv in_obind_eq in_opt_map_eq in_opt_pred Let_def
 
 
 section "Relation between option monad loops and non-deterministic monad loops."

--- a/proof/Makefile
+++ b/proof/Makefile
@@ -10,6 +10,11 @@ default: images test
 test:
 all: images test
 
+# Allow sorry command in AARCH64 AInvs during development:
+ifeq "$(L4V_ARCH)" "AARCH64"
+  export AINVS_QUICK_AND_DIRTY=1
+endif
+
 #
 # Setup heaps.
 #

--- a/proof/Makefile
+++ b/proof/Makefile
@@ -9,10 +9,6 @@ images: BaseRefine CBaseRefine Refine CRefine
 default: images test
 test:
 all: images test
-report-regression:
-	@echo Refine Access CBaseRefine CRefine \
-	      DRefine InfoFlow InfoFlowCBase InfoFlowC DPolicy \
-		  DSpecProofs Bisim
 
 #
 # Setup heaps.

--- a/proof/invariant-abstract/AARCH64/ArchADT_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchADT_AI.thy
@@ -1,0 +1,131 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+chapter \<open>RISCV64-specific definitions for abstract datatype for the abstract specification\<close>
+
+theory ArchADT_AI
+imports
+  "Lib.Simulation"
+  Invariants_AI
+begin
+context Arch begin global_naming RISCV64
+
+subsection \<open>Constructing a virtual-memory view\<close>
+
+text \<open>
+  This function is used below for helpers that expect a full state, but depend
+  only on the heap and arch state.
+\<close>
+definition state_from_arch :: "kheap \<Rightarrow> arch_state \<Rightarrow> det_ext state" where
+  "state_from_arch kh as \<equiv> undefined \<lparr> kheap := kh, arch_state := as \<rparr>"
+
+text \<open>
+  Function @{text get_vspace_of_thread} takes three parameters:
+  the kernel heap, the architecture-specific state, and
+  a thread identifier.
+  It returns the identifier of the corresponding virtual address space.
+  Note that this function is total.
+  If the traversal stops before a page directory can be found
+  (e.g. because the VTable entry is not set or a reference has been invalid),
+  the function returns the global kernel mapping.
+
+  Looking up the address space for a thread reference involves the following
+  steps:
+
+  At first, we check that the reference actually points to a TCB object in
+  the kernel heap.
+  If so, we check whether the vtable entry of the TCB contains a capability
+  to an address space with valid mapping data.
+  Note that the mapping data might become stale.
+  Hence, we have to follow the mapping data through the ASID table.
+\<close>
+definition
+  get_vspace_of_thread :: "kheap \<Rightarrow> arch_state \<Rightarrow> obj_ref \<Rightarrow> obj_ref"
+where
+  get_vspace_of_thread_def:
+  "get_vspace_of_thread khp astate tcb_ref \<equiv>
+   case khp tcb_ref of Some (TCB tcb) \<Rightarrow>
+     (case tcb_vtable tcb of
+        ArchObjectCap (PageTableCap pt (Some (asid, _))) \<Rightarrow>
+          (case vspace_for_asid asid (state_from_arch khp astate) of
+             Some pt' \<Rightarrow> if pt' = pt then pt else riscv_global_pt astate
+           | _ \<Rightarrow> riscv_global_pt astate)
+        | _ \<Rightarrow>  riscv_global_pt astate)
+   | _ \<Rightarrow>  riscv_global_pt astate"
+
+
+lemma the_arch_cap_simp[simp]: "the_arch_cap (ArchObjectCap x) = x"
+  by (simp add: the_arch_cap_def)
+
+lemma vspace_for_asid_state_from_arch[simp]:
+  "vspace_for_asid a (state_from_arch (kheap s) (arch_state s)) = vspace_for_asid a s"
+  by (simp add: vspace_for_asid_def pool_for_asid_def obind_def state_from_arch_def
+         split: option.splits)
+
+(* NOTE: This statement would clearly be nicer for a partial function
+         but later on, we really want the function to be total. *)
+lemma get_vspace_of_thread_eq:
+  "pt_ref \<noteq> riscv_global_pt (arch_state s) \<Longrightarrow>
+   get_vspace_of_thread (kheap s) (arch_state s) tcb_ref = pt_ref \<longleftrightarrow>
+   (\<exists>tcb. kheap s tcb_ref = Some (TCB tcb) \<and>
+          (\<exists>asid vref. tcb_vtable tcb = ArchObjectCap (PageTableCap pt_ref (Some (asid,vref))) \<and>
+                       vspace_for_asid asid s = Some pt_ref))"
+  unfolding get_vspace_of_thread_def
+  by (auto split: option.splits kernel_object.splits cap.splits arch_cap.splits)
+
+
+text \<open>
+  The following function is used to extract the architecture-specific objects from the kernel heap.
+\<close>
+
+definition pte_info :: "vm_level \<Rightarrow> pte \<rightharpoonup> (machine_word \<times> nat \<times> vm_attributes \<times> vm_rights)" where
+  "pte_info level pte \<equiv>
+    case pte of
+      PagePTE ppn attrs rights \<Rightarrow> Some (addr_from_ppn ppn, pt_bits_left level, attrs, rights)
+    | _ \<Rightarrow> None"
+
+text \<open>
+  @{text get_page_info} takes the architecture-specific part of the kernel heap,
+  a reference to the page directory, and a virtual memory address.
+  It returns a tuple containing
+  (a) the physical address, where the associated page starts,
+  (b) the page table's size in bits, and
+  (c) the page attributes (cachable, XNever, etc)
+  (d) the access rights (a subset of @{term "{AllowRead, AllowWrite}"}).
+\<close>
+definition
+  get_page_info :: "(obj_ref \<rightharpoonup> arch_kernel_obj) \<Rightarrow> obj_ref \<Rightarrow> vspace_ref \<rightharpoonup>
+                    (machine_word \<times> nat \<times> vm_attributes \<times> vm_rights)"
+where
+  "get_page_info aobjs pt_ref vptr \<equiv> (do {
+      oassert (canonical_address vptr);
+      (level, slot) \<leftarrow> pt_lookup_slot pt_ref vptr;
+      pte \<leftarrow> oapply slot;
+      K $ pte_info level pte
+    }) (\<lambda>p. pte_of p (aobjs |> pt_of))"
+
+text \<open>
+  Both functions, @{text ptable_lift} and @{text vm_rights},
+  take a kernel state and a virtual address.
+  The former returns the physical address, the latter the associated rights.
+\<close>
+definition ptable_lift :: "obj_ref \<Rightarrow> 'z::state_ext state \<Rightarrow> machine_word \<rightharpoonup> machine_word" where
+  "ptable_lift tcb s \<equiv> \<lambda>addr.
+   case_option None (\<lambda>(base, bits, rights). Some (base + (addr && mask bits)))
+     (get_page_info (aobjs_of s) (get_vspace_of_thread (kheap s) (arch_state s) tcb) addr)"
+
+definition ptable_rights :: "obj_ref \<Rightarrow> 'z::state_ext state \<Rightarrow> machine_word \<Rightarrow> vm_rights" where
+  "ptable_rights tcb s \<equiv> \<lambda>addr.
+   case_option {} (snd o snd o snd)
+      (get_page_info (aobjs_of s) (get_vspace_of_thread (kheap s) (arch_state s) tcb) addr)"
+
+lemma ptable_lift_Some_canonical_addressD:
+  "ptable_lift t s vptr = Some p \<Longrightarrow> canonical_address vptr"
+  by (clarsimp simp: ptable_lift_def get_page_info_def below_user_vtop_canonical
+              split: if_splits option.splits)
+
+end
+end

--- a/proof/invariant-abstract/AARCH64/ArchADT_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchADT_AI.thy
@@ -48,7 +48,6 @@ definition
 where
   get_vspace_of_thread_def:
   "get_vspace_of_thread khp astate tcb_ref \<equiv> undefined"
-  (* FIXME AARCH64: needs redefinition
   "get_vspace_of_thread khp astate tcb_ref \<equiv>
    case khp tcb_ref of Some (TCB tcb) \<Rightarrow>
      (case tcb_vtable tcb of

--- a/proof/invariant-abstract/AARCH64/ArchAInvsPre.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAInvsPre.thy
@@ -1,0 +1,275 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchAInvsPre
+imports AInvsPre
+begin
+
+unbundle l4v_word_context
+
+context Arch begin
+
+global_naming RISCV64
+
+lemma canonical_not_kernel_is_user:
+  "\<lbrakk> v \<notin> kernel_mappings; canonical_address v \<rbrakk> \<Longrightarrow> v \<in> user_region "
+  by (simp add: kernel_mappings_def not_le canonical_below_pptr_base_user)
+
+lemma no_user_region_kernel_mappings:
+  "\<lbrakk> p \<in> user_region; p \<in> kernel_mappings \<rbrakk> \<Longrightarrow> False"
+  using kernel_mappings_user_region by blast
+
+lemma kernel_mappings_slots_eq:
+  "canonical_address p \<Longrightarrow>
+   ucast (p >> pt_bits_left max_pt_level) \<in> kernel_mapping_slots \<longleftrightarrow> p \<in> kernel_mappings"
+  apply (simp add: kernel_mappings_def kernel_mapping_slots_def ucast_mask_drop canonical_address_range)
+  apply word_bitwise
+  by (auto simp: canonical_bit_def word_bits_def pt_bits_left_def bit_simps level_defs word_size
+                 rev_bl_order_simps)
+
+lemma ucast_ucast_mask_low: "(ucast (x && mask asid_low_bits) :: asid_low_index) = ucast x"
+  by (rule ucast_mask_drop, simp add: asid_low_bits_def)
+
+lemma valid_global_table_rights:
+  "\<lbrakk> pt_ptr \<in> riscv_global_pts (arch_state s) level;
+     valid_global_tables s; valid_global_arch_objs s \<rbrakk> \<Longrightarrow>
+   \<exists>pt. pts_of s pt_ptr = Some pt \<and> (\<forall>idx. pte_rights_of (pt idx) = vm_kernel_only)"
+  by (frule (1) global_pts_ofD) (clarsimp simp: valid_global_tables_def Let_def)
+
+lemma ptes_of_idx:
+  "\<lbrakk> ptes_of s (pt_slot_offset level pt_ptr p) = Some pte;
+     pts_of s pt_ptr = Some pt; pspace_aligned s \<rbrakk> \<Longrightarrow>
+   \<exists>idx. pt idx = pte"
+  apply (drule_tac pt_ptr=pt_ptr in pspace_aligned_pts_ofD, simp)
+  apply (fastforce simp: pte_of_def)
+  done
+
+lemma valid_global_arch_objs_global_ptD:
+  "valid_global_arch_objs s \<Longrightarrow>
+   riscv_global_pt (arch_state s) \<in> riscv_global_pts (arch_state s) max_pt_level"
+  by (auto simp: valid_global_arch_objs_def Let_def riscv_global_pt_def)
+
+lemma equal_kernel_mappingsD:
+  "\<lbrakk> vspace_for_asid asid s = Some pt_ptr; pts_of s pt_ptr = Some pt;
+     equal_kernel_mappings s \<rbrakk> \<Longrightarrow> has_kernel_mappings pt s"
+  by (simp add: equal_kernel_mappings_def)
+
+lemma has_kernel_mappingsD:
+  "\<lbrakk> has_kernel_mappings pt s; valid_global_arch_objs s; idx \<in> kernel_mapping_slots;
+     pte = pt idx \<rbrakk> \<Longrightarrow>
+   \<exists>pt'. pts_of s (riscv_global_pt (arch_state s)) = Some pt' \<and> pte = pt' idx"
+  unfolding has_kernel_mappings_def
+  by (fastforce simp: pt_at_eq dest: valid_global_arch_objs_pt_at)
+
+lemma pte_rights_of_kernel:
+  "\<lbrakk> p \<in> kernel_mappings; canonical_address p; valid_global_vspace_mappings s;
+     equal_kernel_mappings s; valid_global_tables s; valid_global_arch_objs s; valid_vspace_objs s;
+     valid_asid_table s; valid_uses s; pspace_aligned s;
+     (\<exists>asid. vspace_for_asid asid s = Some pt_ref) \<or> pt_ref = riscv_global_pt (arch_state s);
+     pt_lookup_slot pt_ref p (ptes_of s) = Some (level, slot); ptes_of s slot = Some pte \<rbrakk>
+   \<Longrightarrow> pte_rights_of pte = vm_kernel_only"
+  apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def)
+  apply (rename_tac pt_ptr)
+  apply (erule disjE; clarsimp)
+   apply (subgoal_tac "is_aligned pt_ref pt_bits")
+    prefer 2
+    apply (drule (2) vspace_for_asid_valid_pt)
+    apply clarsimp
+    apply (erule pspace_aligned_pts_ofD)
+    apply simp
+   apply (cases "level = max_pt_level")
+    apply (drule pt_walk_level)
+    apply (clarsimp simp flip: kernel_mappings_slots_eq)
+    apply (clarsimp simp: ptes_of_def table_index_offset_pt_bits_left)
+    apply (drule (2) equal_kernel_mappingsD)
+    apply (drule (3) has_kernel_mappingsD)
+    apply clarsimp
+    apply (frule valid_global_arch_objs_global_ptD)
+    apply (drule (2) valid_global_table_rights)
+    apply fastforce
+   apply (drule pt_walk_equal_top_slot_Some[where pt_ptr'="riscv_global_pt (arch_state s)", rotated])
+    apply (erule (7) equal_mappings_pt_slot_offset)
+   apply clarsimp
+   apply (frule (1) valid_global_tablesD, simp)
+   apply (fastforce dest!: ptes_of_idx valid_global_table_rights)
+  apply (frule (1) valid_global_tablesD, simp)
+  apply (fastforce dest!: ptes_of_idx valid_global_table_rights)
+  done
+
+
+lemma some_get_page_info_kmapsD:
+  "\<lbrakk> get_page_info (aobjs_of s) pt_ref p = Some (b, a, attr, r);
+     p \<in> kernel_mappings; canonical_address p; valid_global_vspace_mappings s;
+     equal_kernel_mappings s; valid_global_tables s; valid_global_arch_objs s;
+     valid_vspace_objs s; valid_asid_table s; valid_uses s; pspace_aligned s;
+     (\<exists>asid. vspace_for_asid asid s = Some pt_ref) \<or> pt_ref = riscv_global_pt (arch_state s) \<rbrakk>
+   \<Longrightarrow> (\<exists>sz. pageBitsForSize sz = a) \<and> r = {}"
+  apply (clarsimp simp: get_page_info_def in_omonad)
+  apply (rename_tac level slot pte)
+  apply (frule (12) pte_rights_of_kernel, simp add: vm_kernel_only_def)
+  apply (clarsimp simp: pte_info_def split: pte.splits)
+  apply (drule pt_lookup_slot_max_pt_level)
+  apply (rule_tac x="vmpage_size_of_level level" in exI)
+  apply simp
+  done
+
+lemma pte_info_not_InvalidPTE:
+  "pte_info level pte = Some (b, a, attr, r) \<Longrightarrow> pte \<noteq> InvalidPTE"
+  by (simp add: pte_info_def split: pte.splits)
+
+lemma valid_global_tables_toplevel_pt:
+  "\<lbrakk> pts_of s (riscv_global_pt (arch_state s)) = Some pt; valid_global_tables s \<rbrakk> \<Longrightarrow>
+   \<forall>idx\<in>- kernel_mapping_slots. pt idx = InvalidPTE"
+  by (simp add: valid_global_tables_def Let_def riscv_global_pt_def)
+
+lemma global_pt_not_invalid_kernel:
+  "\<lbrakk> ptes_of s (pt_slot_offset max_pt_level (riscv_global_pt (arch_state s)) p) = Some pte;
+     pte \<noteq> InvalidPTE; canonical_address p; valid_global_tables s;
+     is_aligned (riscv_global_pt (arch_state s)) pt_bits\<rbrakk>
+   \<Longrightarrow> p \<in> kernel_mappings"
+  apply (clarsimp simp: pte_of_def table_index_offset_pt_bits_left)
+  apply (fastforce simp flip: kernel_mappings_slots_eq dest: valid_global_tables_toplevel_pt)
+  done
+
+lemma get_page_info_gpd_kmaps:
+  "\<lbrakk> valid_global_vspace_mappings s; valid_arch_state s;
+     get_page_info (aobjs_of s) (riscv_global_pt (arch_state s)) p = Some (b, a, attr, r) \<rbrakk>
+     \<Longrightarrow> p \<in> kernel_mappings"
+  apply (clarsimp simp: get_page_info_def in_omonad pt_lookup_slot_def pt_lookup_slot_from_level_def)
+  apply (subst (asm) pt_walk.simps)
+  apply (fastforce dest: pte_info_not_InvalidPTE global_pt_not_invalid_kernel
+                   simp: valid_arch_state_def in_omonad)
+  done
+
+lemma get_vspace_of_thread_reachable:
+  "\<lbrakk> get_vspace_of_thread (kheap s) (arch_state s) t \<noteq> riscv_global_pt (arch_state s);
+     valid_uses s \<rbrakk>
+   \<Longrightarrow> (\<exists>\<rhd> (max_pt_level, get_vspace_of_thread (kheap s) (arch_state s) t)) s"
+  by (auto simp: get_vspace_of_thread_def
+          split: option.splits cap.splits kernel_object.splits arch_cap.splits if_split_asm
+          intro: vspace_for_asid_vs_lookup)
+
+lemma data_at_aligned:
+  "\<lbrakk> data_at sz p s; pspace_aligned s\<rbrakk> \<Longrightarrow> is_aligned p (pageBitsForSize sz)"
+  unfolding data_at_def by (auto simp: obj_at_def dest: pspace_alignedD)
+
+lemma is_aligned_ptrFromPAddr_n_eq:
+  "sz \<le> canonical_bit \<Longrightarrow> is_aligned (ptrFromPAddr x) sz = is_aligned x sz"
+  apply (rule iffI)
+   apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def paddrBase_def canonical_bit_def)
+   apply (drule is_aligned_addD2)
+    apply (erule is_aligned_weaken[rotated])
+    apply (simp add: is_aligned_def)
+   apply assumption
+  apply (erule (1) is_aligned_ptrFromPAddr_n)
+  done
+
+lemma some_get_page_info_umapsD:
+  "\<lbrakk>get_page_info (aobjs_of s) pt_ref p = Some (b, a, attr, r);
+    \<exists>\<rhd> (max_pt_level, pt_ref) s; p \<in> user_region; valid_vspace_objs s; pspace_aligned s;
+    canonical_address p;
+    valid_asid_table s; valid_objs s\<rbrakk>
+   \<Longrightarrow> \<exists>sz. pageBitsForSize sz = a \<and> is_aligned b a \<and> data_at sz (ptrFromPAddr b) s"
+  apply (clarsimp simp: get_page_info_def vs_lookup_table_def)
+  apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def)
+  apply (frule pt_walk_max_level)
+  apply (drule pt_walk_level)
+  apply (rename_tac pte asid pool_ptr vref level pt_ptr')
+  apply (subgoal_tac "vs_lookup_table level asid p s = Some (level, pt_ptr')")
+   prefer 2
+   apply (clarsimp simp: vs_lookup_table_def in_omonad)
+   apply (drule (2) valid_vspace_objs_strongD; assumption?)
+   apply (clarsimp simp: pte_info_def split: pte.splits)
+   apply (rename_tac ppn pt)
+   apply (frule pspace_aligned_pts_ofD, fastforce)
+   apply (drule_tac x="table_index (pt_slot_offset level pt_ptr' p)" in bspec)
+   apply (clarsimp simp: table_index_offset_pt_bits_left simp: kernel_mappings_slots_eq)
+   apply (erule (1) no_user_region_kernel_mappings)
+  apply (clarsimp simp: pte_of_def)
+  apply (subgoal_tac "valid_pte level (PagePTE ppn attr r) s")
+   prefer 2
+   apply simp
+  apply (subst (asm) valid_pte.simps)
+  apply clarsimp
+  apply (rule_tac x="vmpage_size_of_level level" in exI)
+  apply (clarsimp simp: obj_at_def)
+  apply (drule (1) data_at_aligned)
+  apply (simp add: pt_bits_left_le_canonical is_aligned_ptrFromPAddr_n_eq)
+  done
+
+lemma user_mem_dom_cong:
+  "kheap s = kheap s' \<Longrightarrow> dom (user_mem s) = dom (user_mem s')"
+  by (simp add: user_mem_def in_user_frame_def dom_def obj_at_def)
+
+lemma device_mem_dom_cong:
+  "kheap s = kheap s' \<Longrightarrow> dom (device_mem s) = dom (device_mem s')"
+  by (simp add: device_mem_def in_device_frame_def dom_def obj_at_def)
+
+lemma device_frame_in_device_region:
+  "\<lbrakk>in_device_frame p s; pspace_respects_device_region s\<rbrakk>
+  \<Longrightarrow> device_state (machine_state s) p \<noteq> None"
+  by (auto simp add: pspace_respects_device_region_def dom_def device_mem_def)
+
+global_naming Arch
+named_theorems AInvsPre_asms
+
+lemma get_vspace_of_thread_asid_or_global_pt:
+  "(\<exists>asid. vspace_for_asid asid s = Some (get_vspace_of_thread (kheap s) (arch_state s) t))
+    \<or> get_vspace_of_thread (kheap s) (arch_state s) t = riscv_global_pt (arch_state s)"
+  by (auto simp: get_vspace_of_thread_def
+           split: option.split kernel_object.split cap.split arch_cap.split)
+
+lemma ptable_rights_imp_frame[AInvsPre_asms]:
+  assumes "valid_state s"
+  shows "\<lbrakk> ptable_rights t s x \<noteq> {}; ptable_lift t s x = Some (addrFromPPtr y) \<rbrakk> \<Longrightarrow>
+         in_user_frame y s \<or> in_device_frame y s"
+  apply (rule ccontr, frule ptable_lift_Some_canonical_addressD)
+  using assms get_vspace_of_thread_asid_or_global_pt[of s t]
+  apply (clarsimp simp: ptable_lift_def ptable_rights_def in_user_frame_def in_device_frame_def
+                 split: option.splits)
+  apply (case_tac "x \<in> kernel_mappings")
+   apply (frule (2) some_get_page_info_kmapsD;
+            fastforce simp: valid_state_def valid_arch_state_def valid_pspace_def)
+  apply (frule some_get_page_info_umapsD)
+         apply (rule get_vspace_of_thread_reachable)
+          apply clarsimp
+          apply (frule get_page_info_gpd_kmaps[rotated 2])
+            apply (simp_all add: valid_state_def valid_pspace_def valid_arch_state_def)
+   apply (clarsimp simp: data_at_def canonical_not_kernel_is_user)
+  apply clarsimp
+  apply (drule_tac x=sz in spec)+
+  apply (rename_tac p_addr attr rghts sz)
+  apply (frule is_aligned_add_helper[OF _ and_mask_less', THEN conjunct2, of _ _ x])
+   apply (simp only: pbfs_less_wb'[simplified word_bits_def])
+  apply (clarsimp simp: data_at_def ptrFromPAddr_def addrFromPPtr_def field_simps)
+  apply (subgoal_tac "p_addr + (pptrBaseOffset + (x && mask (pageBitsForSize sz)))
+                        && ~~ mask (pageBitsForSize sz) = p_addr + pptrBaseOffset")
+   apply simp
+  apply (subst add.assoc[symmetric])
+  apply (subst is_aligned_add_helper)
+    apply (erule aligned_add_aligned)
+     apply (case_tac sz; simp add: is_aligned_def pptrBaseOffset_def pptrBase_def paddrBase_def
+                                   canonical_bit_def bit_simps)
+    apply simp
+   apply (rule and_mask_less')
+   apply (case_tac sz; simp add: bit_simps)
+  apply simp
+  done
+
+end
+
+interpretation AInvsPre?: AInvsPre
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; (unfold_locales; fact AInvsPre_asms)?)
+  qed
+
+requalify_facts
+  RISCV64.user_mem_dom_cong
+  RISCV64.device_mem_dom_cong
+  RISCV64.device_frame_in_device_region
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchAInvsPre.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAInvsPre.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -12,8 +13,9 @@ unbundle l4v_word_context
 
 context Arch begin
 
-global_naming RISCV64
+global_naming AARCH64
 
+(* FIXME AARCH64
 lemma canonical_not_kernel_is_user:
   "\<lbrakk> v \<notin> kernel_mappings; canonical_address v \<rbrakk> \<Longrightarrow> v \<in> user_region "
   by (simp add: kernel_mappings_def not_le canonical_below_pptr_base_user)
@@ -29,16 +31,19 @@ lemma kernel_mappings_slots_eq:
   apply word_bitwise
   by (auto simp: canonical_bit_def word_bits_def pt_bits_left_def bit_simps level_defs word_size
                  rev_bl_order_simps)
+*)
 
 lemma ucast_ucast_mask_low: "(ucast (x && mask asid_low_bits) :: asid_low_index) = ucast x"
   by (rule ucast_mask_drop, simp add: asid_low_bits_def)
 
+(* FIXME AARCH64
 lemma valid_global_table_rights:
   "\<lbrakk> pt_ptr \<in> riscv_global_pts (arch_state s) level;
      valid_global_tables s; valid_global_arch_objs s \<rbrakk> \<Longrightarrow>
    \<exists>pt. pts_of s pt_ptr = Some pt \<and> (\<forall>idx. pte_rights_of (pt idx) = vm_kernel_only)"
-  by (frule (1) global_pts_ofD) (clarsimp simp: valid_global_tables_def Let_def)
+  by (frule (1) global_pts_ofD) (clarsimp simp: valid_global_tables_def Let_def) *)
 
+(* FIXME AARCH64
 lemma ptes_of_idx:
   "\<lbrakk> ptes_of s (pt_slot_offset level pt_ptr p) = Some pte;
      pts_of s pt_ptr = Some pt; pspace_aligned s \<rbrakk> \<Longrightarrow>
@@ -99,7 +104,6 @@ lemma pte_rights_of_kernel:
   apply (fastforce dest!: ptes_of_idx valid_global_table_rights)
   done
 
-
 lemma some_get_page_info_kmapsD:
   "\<lbrakk> get_page_info (aobjs_of s) pt_ref p = Some (b, a, attr, r);
      p \<in> kernel_mappings; canonical_address p; valid_global_vspace_mappings s;
@@ -151,6 +155,7 @@ lemma get_vspace_of_thread_reachable:
   by (auto simp: get_vspace_of_thread_def
           split: option.splits cap.splits kernel_object.splits arch_cap.splits if_split_asm
           intro: vspace_for_asid_vs_lookup)
+ *)
 
 lemma data_at_aligned:
   "\<lbrakk> data_at sz p s; pspace_aligned s\<rbrakk> \<Longrightarrow> is_aligned p (pageBitsForSize sz)"
@@ -163,9 +168,10 @@ lemma is_aligned_ptrFromPAddr_n_eq:
    apply (drule is_aligned_addD2)
     apply (erule is_aligned_weaken[rotated])
     apply (simp add: is_aligned_def)
+  sorry (* FIXME AARCH64
    apply assumption
   apply (erule (1) is_aligned_ptrFromPAddr_n)
-  done
+  done *)
 
 lemma some_get_page_info_umapsD:
   "\<lbrakk>get_page_info (aobjs_of s) pt_ref p = Some (b, a, attr, r);
@@ -174,6 +180,7 @@ lemma some_get_page_info_umapsD:
     valid_asid_table s; valid_objs s\<rbrakk>
    \<Longrightarrow> \<exists>sz. pageBitsForSize sz = a \<and> is_aligned b a \<and> data_at sz (ptrFromPAddr b) s"
   apply (clarsimp simp: get_page_info_def vs_lookup_table_def)
+  sorry (* FIXME AARCH64
   apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def)
   apply (frule pt_walk_max_level)
   apply (drule pt_walk_level)
@@ -198,7 +205,7 @@ lemma some_get_page_info_umapsD:
   apply (clarsimp simp: obj_at_def)
   apply (drule (1) data_at_aligned)
   apply (simp add: pt_bits_left_le_canonical is_aligned_ptrFromPAddr_n_eq)
-  done
+  done *)
 
 lemma user_mem_dom_cong:
   "kheap s = kheap s' \<Longrightarrow> dom (user_mem s) = dom (user_mem s')"
@@ -219,8 +226,9 @@ named_theorems AInvsPre_asms
 lemma get_vspace_of_thread_asid_or_global_pt:
   "(\<exists>asid. vspace_for_asid asid s = Some (get_vspace_of_thread (kheap s) (arch_state s) t))
     \<or> get_vspace_of_thread (kheap s) (arch_state s) t = riscv_global_pt (arch_state s)"
+  sorry (* FIXME AARCH64
   by (auto simp: get_vspace_of_thread_def
-           split: option.split kernel_object.split cap.split arch_cap.split)
+           split: option.split kernel_object.split cap.split arch_cap.split) *)
 
 lemma ptable_rights_imp_frame[AInvsPre_asms]:
   assumes "valid_state s"
@@ -231,6 +239,7 @@ lemma ptable_rights_imp_frame[AInvsPre_asms]:
   apply (clarsimp simp: ptable_lift_def ptable_rights_def in_user_frame_def in_device_frame_def
                  split: option.splits)
   apply (case_tac "x \<in> kernel_mappings")
+  sorry (* FIXME AARCH64
    apply (frule (2) some_get_page_info_kmapsD;
             fastforce simp: valid_state_def valid_arch_state_def valid_pspace_def)
   apply (frule some_get_page_info_umapsD)
@@ -257,7 +266,7 @@ lemma ptable_rights_imp_frame[AInvsPre_asms]:
    apply (rule and_mask_less')
    apply (case_tac sz; simp add: bit_simps)
   apply simp
-  done
+  done *)
 
 end
 
@@ -268,8 +277,8 @@ interpretation AInvsPre?: AInvsPre
   qed
 
 requalify_facts
-  RISCV64.user_mem_dom_cong
-  RISCV64.device_mem_dom_cong
-  RISCV64.device_frame_in_device_region
+  AARCH64.user_mem_dom_cong
+  AARCH64.device_mem_dom_cong
+  AARCH64.device_frame_in_device_region
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchAInvsPre.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAInvsPre.thy
@@ -15,153 +15,35 @@ context Arch begin
 
 global_naming AARCH64
 
-(* FIXME AARCH64
-lemma canonical_not_kernel_is_user:
-  "\<lbrakk> v \<notin> kernel_mappings; canonical_address v \<rbrakk> \<Longrightarrow> v \<in> user_region "
-  by (simp add: kernel_mappings_def not_le canonical_below_pptr_base_user)
-
-lemma no_user_region_kernel_mappings:
-  "\<lbrakk> p \<in> user_region; p \<in> kernel_mappings \<rbrakk> \<Longrightarrow> False"
-  using kernel_mappings_user_region by blast
-
-lemma kernel_mappings_slots_eq:
-  "canonical_address p \<Longrightarrow>
-   ucast (p >> pt_bits_left max_pt_level) \<in> kernel_mapping_slots \<longleftrightarrow> p \<in> kernel_mappings"
-  apply (simp add: kernel_mappings_def kernel_mapping_slots_def ucast_mask_drop canonical_address_range)
-  apply word_bitwise
-  by (auto simp: canonical_bit_def word_bits_def pt_bits_left_def bit_simps level_defs word_size
-                 rev_bl_order_simps)
-*)
-
 lemma ucast_ucast_mask_low: "(ucast (x && mask asid_low_bits) :: asid_low_index) = ucast x"
   by (rule ucast_mask_drop, simp add: asid_low_bits_def)
 
-(* FIXME AARCH64
-lemma valid_global_table_rights:
-  "\<lbrakk> pt_ptr \<in> riscv_global_pts (arch_state s) level;
-     valid_global_tables s; valid_global_arch_objs s \<rbrakk> \<Longrightarrow>
-   \<exists>pt. pts_of s pt_ptr = Some pt \<and> (\<forall>idx. pte_rights_of (pt idx) = vm_kernel_only)"
-  by (frule (1) global_pts_ofD) (clarsimp simp: valid_global_tables_def Let_def) *)
-
-(* FIXME AARCH64
 lemma ptes_of_idx:
-  "\<lbrakk> ptes_of s (pt_slot_offset level pt_ptr p) = Some pte;
+  "\<lbrakk> ptes_of s (pt_type pt) (pt_slot_offset level pt_ptr p) = Some pte;
      pts_of s pt_ptr = Some pt; pspace_aligned s \<rbrakk> \<Longrightarrow>
-   \<exists>idx. pt idx = pte"
+   \<exists>idx. pt_apply pt idx = pte"
   apply (drule_tac pt_ptr=pt_ptr in pspace_aligned_pts_ofD, simp)
-  apply (fastforce simp: pte_of_def)
-  done
-
-lemma valid_global_arch_objs_global_ptD:
-  "valid_global_arch_objs s \<Longrightarrow>
-   riscv_global_pt (arch_state s) \<in> riscv_global_pts (arch_state s) max_pt_level"
-  by (auto simp: valid_global_arch_objs_def Let_def riscv_global_pt_def)
-
-lemma equal_kernel_mappingsD:
-  "\<lbrakk> vspace_for_asid asid s = Some pt_ptr; pts_of s pt_ptr = Some pt;
-     equal_kernel_mappings s \<rbrakk> \<Longrightarrow> has_kernel_mappings pt s"
-  by (simp add: equal_kernel_mappings_def)
-
-lemma has_kernel_mappingsD:
-  "\<lbrakk> has_kernel_mappings pt s; valid_global_arch_objs s; idx \<in> kernel_mapping_slots;
-     pte = pt idx \<rbrakk> \<Longrightarrow>
-   \<exists>pt'. pts_of s (riscv_global_pt (arch_state s)) = Some pt' \<and> pte = pt' idx"
-  unfolding has_kernel_mappings_def
-  by (fastforce simp: pt_at_eq dest: valid_global_arch_objs_pt_at)
-
-lemma pte_rights_of_kernel:
-  "\<lbrakk> p \<in> kernel_mappings; canonical_address p; valid_global_vspace_mappings s;
-     equal_kernel_mappings s; valid_global_tables s; valid_global_arch_objs s; valid_vspace_objs s;
-     valid_asid_table s; valid_uses s; pspace_aligned s;
-     (\<exists>asid. vspace_for_asid asid s = Some pt_ref) \<or> pt_ref = riscv_global_pt (arch_state s);
-     pt_lookup_slot pt_ref p (ptes_of s) = Some (level, slot); ptes_of s slot = Some pte \<rbrakk>
-   \<Longrightarrow> pte_rights_of pte = vm_kernel_only"
-  apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def)
-  apply (rename_tac pt_ptr)
-  apply (erule disjE; clarsimp)
-   apply (subgoal_tac "is_aligned pt_ref pt_bits")
-    prefer 2
-    apply (drule (2) vspace_for_asid_valid_pt)
-    apply clarsimp
-    apply (erule pspace_aligned_pts_ofD)
-    apply simp
-   apply (cases "level = max_pt_level")
-    apply (drule pt_walk_level)
-    apply (clarsimp simp flip: kernel_mappings_slots_eq)
-    apply (clarsimp simp: ptes_of_def table_index_offset_pt_bits_left)
-    apply (drule (2) equal_kernel_mappingsD)
-    apply (drule (3) has_kernel_mappingsD)
-    apply clarsimp
-    apply (frule valid_global_arch_objs_global_ptD)
-    apply (drule (2) valid_global_table_rights)
-    apply fastforce
-   apply (drule pt_walk_equal_top_slot_Some[where pt_ptr'="riscv_global_pt (arch_state s)", rotated])
-    apply (erule (7) equal_mappings_pt_slot_offset)
-   apply clarsimp
-   apply (frule (1) valid_global_tablesD, simp)
-   apply (fastforce dest!: ptes_of_idx valid_global_table_rights)
-  apply (frule (1) valid_global_tablesD, simp)
-  apply (fastforce dest!: ptes_of_idx valid_global_table_rights)
-  done
-
-lemma some_get_page_info_kmapsD:
-  "\<lbrakk> get_page_info (aobjs_of s) pt_ref p = Some (b, a, attr, r);
-     p \<in> kernel_mappings; canonical_address p; valid_global_vspace_mappings s;
-     equal_kernel_mappings s; valid_global_tables s; valid_global_arch_objs s;
-     valid_vspace_objs s; valid_asid_table s; valid_uses s; pspace_aligned s;
-     (\<exists>asid. vspace_for_asid asid s = Some pt_ref) \<or> pt_ref = riscv_global_pt (arch_state s) \<rbrakk>
-   \<Longrightarrow> (\<exists>sz. pageBitsForSize sz = a) \<and> r = {}"
-  apply (clarsimp simp: get_page_info_def in_omonad)
-  apply (rename_tac level slot pte)
-  apply (frule (12) pte_rights_of_kernel, simp add: vm_kernel_only_def)
-  apply (clarsimp simp: pte_info_def split: pte.splits)
-  apply (drule pt_lookup_slot_max_pt_level)
-  apply (rule_tac x="vmpage_size_of_level level" in exI)
-  apply simp
-  done
+  sorry (* FIXME AARCH64
+  apply (fastforce simp: level_pte_of_def in_omonad)
+  done *)
 
 lemma pte_info_not_InvalidPTE:
   "pte_info level pte = Some (b, a, attr, r) \<Longrightarrow> pte \<noteq> InvalidPTE"
   by (simp add: pte_info_def split: pte.splits)
 
-lemma valid_global_tables_toplevel_pt:
-  "\<lbrakk> pts_of s (riscv_global_pt (arch_state s)) = Some pt; valid_global_tables s \<rbrakk> \<Longrightarrow>
-   \<forall>idx\<in>- kernel_mapping_slots. pt idx = InvalidPTE"
-  by (simp add: valid_global_tables_def Let_def riscv_global_pt_def)
-
-lemma global_pt_not_invalid_kernel:
-  "\<lbrakk> ptes_of s (pt_slot_offset max_pt_level (riscv_global_pt (arch_state s)) p) = Some pte;
-     pte \<noteq> InvalidPTE; canonical_address p; valid_global_tables s;
-     is_aligned (riscv_global_pt (arch_state s)) pt_bits\<rbrakk>
-   \<Longrightarrow> p \<in> kernel_mappings"
-  apply (clarsimp simp: pte_of_def table_index_offset_pt_bits_left)
-  apply (fastforce simp flip: kernel_mappings_slots_eq dest: valid_global_tables_toplevel_pt)
-  done
-
-lemma get_page_info_gpd_kmaps:
-  "\<lbrakk> valid_global_vspace_mappings s; valid_arch_state s;
-     get_page_info (aobjs_of s) (riscv_global_pt (arch_state s)) p = Some (b, a, attr, r) \<rbrakk>
-     \<Longrightarrow> p \<in> kernel_mappings"
-  apply (clarsimp simp: get_page_info_def in_omonad pt_lookup_slot_def pt_lookup_slot_from_level_def)
-  apply (subst (asm) pt_walk.simps)
-  apply (fastforce dest: pte_info_not_InvalidPTE global_pt_not_invalid_kernel
-                   simp: valid_arch_state_def in_omonad)
-  done
-
 lemma get_vspace_of_thread_reachable:
-  "\<lbrakk> get_vspace_of_thread (kheap s) (arch_state s) t \<noteq> riscv_global_pt (arch_state s);
+  "\<lbrakk> get_vspace_of_thread (kheap s) (arch_state s) t \<noteq> global_pt s;
      valid_uses s \<rbrakk>
    \<Longrightarrow> (\<exists>\<rhd> (max_pt_level, get_vspace_of_thread (kheap s) (arch_state s) t)) s"
   by (auto simp: get_vspace_of_thread_def
-          split: option.splits cap.splits kernel_object.splits arch_cap.splits if_split_asm
+          split: option.splits cap.splits kernel_object.splits arch_cap.splits if_split_asm pt_type.splits
           intro: vspace_for_asid_vs_lookup)
- *)
 
 lemma data_at_aligned:
   "\<lbrakk> data_at sz p s; pspace_aligned s\<rbrakk> \<Longrightarrow> is_aligned p (pageBitsForSize sz)"
   unfolding data_at_def by (auto simp: obj_at_def dest: pspace_alignedD)
 
-lemma is_aligned_ptrFromPAddr_n_eq:
+lemma is_aligned_ptrFromPAddr_n_eq:  (* FIXME AARCH64: might need a different precondition *)
   "sz \<le> canonical_bit \<Longrightarrow> is_aligned (ptrFromPAddr x) sz = is_aligned x sz"
   apply (rule iffI)
    apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def paddrBase_def canonical_bit_def)
@@ -225,10 +107,9 @@ named_theorems AInvsPre_asms
 
 lemma get_vspace_of_thread_asid_or_global_pt:
   "(\<exists>asid. vspace_for_asid asid s = Some (get_vspace_of_thread (kheap s) (arch_state s) t))
-    \<or> get_vspace_of_thread (kheap s) (arch_state s) t = riscv_global_pt (arch_state s)"
-  sorry (* FIXME AARCH64
+    \<or> get_vspace_of_thread (kheap s) (arch_state s) t = global_pt s"
   by (auto simp: get_vspace_of_thread_def
-           split: option.split kernel_object.split cap.split arch_cap.split) *)
+           split: option.split kernel_object.split cap.split arch_cap.split pt_type.splits)
 
 lemma ptable_rights_imp_frame[AInvsPre_asms]:
   assumes "valid_state s"
@@ -238,8 +119,8 @@ lemma ptable_rights_imp_frame[AInvsPre_asms]:
   using assms get_vspace_of_thread_asid_or_global_pt[of s t]
   apply (clarsimp simp: ptable_lift_def ptable_rights_def in_user_frame_def in_device_frame_def
                  split: option.splits)
-  apply (case_tac "x \<in> kernel_mappings")
   sorry (* FIXME AARCH64
+  apply (case_tac "x \<in> kernel_mappings")
    apply (frule (2) some_get_page_info_kmapsD;
             fastforce simp: valid_state_def valid_arch_state_def valid_pspace_def)
   apply (frule some_get_page_info_umapsD)

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -947,6 +947,12 @@ lemma set_pt_valid_global:
   \<lbrace>\<lambda>_ s. valid_global_refs s\<rbrace>"
   by (wp valid_global_refs_cte_lift)
 
+(* FIXME AARCH64: use vcpus_of instead *)
+lemma set_pt_no_vcpu[wp]:
+  "\<lbrace>obj_at (is_vcpu and P) p'\<rbrace> set_pt p pt \<lbrace>\<lambda>_. obj_at (is_vcpu and P) p'\<rbrace>"
+  unfolding set_pt_def
+  by (wpsimp wp: set_object_wp_strong simp: obj_at_def is_vcpu_def a_type_def)
+
 lemma set_pt_cur:
   "\<lbrace>\<lambda>s. cur_tcb s\<rbrace>
   set_pt p pt

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -1,0 +1,2926 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(*
+Lemmas on arch get/set object etc
+*)
+
+theory ArchAcc_AI
+imports SubMonad_AI "Lib.Crunch_Instances_NonDet"
+begin
+
+context non_vspace_op
+begin
+
+lemma valid_vso_at[wp]:"\<lbrace>valid_vso_at level p\<rbrace> f \<lbrace>\<lambda>_. valid_vso_at level p\<rbrace>"
+  by (rule valid_vso_at_lift_aobj_at; wp vsobj_at; simp)
+
+end
+
+context Arch begin global_naming RISCV64
+
+(* Is there a lookup that leads to a page table at (level, p)? *)
+locale_abbrev ex_vs_lookup_table ::
+  "vm_level \<Rightarrow> obj_ref \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" ("\<exists>\<rhd> '(_, _')" [0,0] 1000) where
+  "ex_vs_lookup_table level p s \<equiv>
+     \<exists>asid vref. vs_lookup_table level asid vref s = Some (level, p) \<and> vref \<in> user_region"
+
+bundle unfold_objects =
+  obj_at_def[simp]
+  kernel_object.splits[split]
+  arch_kernel_obj.splits[split]
+  get_object_wp [wp]
+
+bundle unfold_objects_asm =
+  obj_at_def[simp]
+  kernel_object.split_asm[split]
+  arch_kernel_obj.split_asm[split]
+
+lemma invs_valid_asid_table [elim!]:
+  "invs s \<Longrightarrow> valid_asid_table s"
+  by (simp add: invs_def valid_state_def valid_arch_state_def)
+
+lemma ptes_of_wellformed_pte:
+  "\<lbrakk> ptes_of s p = Some pte; valid_objs s \<rbrakk> \<Longrightarrow> wellformed_pte pte"
+  apply (clarsimp simp: ptes_of_def in_omonad)
+  apply (erule (1) valid_objsE)
+  apply (clarsimp simp: valid_obj_def)
+  done
+
+lemma vs_lookup_table_target:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p); level \<le> max_pt_level \<rbrakk> \<Longrightarrow>
+   vs_lookup_target (level + 1) asid (vref_for_level vref level) s = Some (level + 1, p)"
+  apply (simp add: vs_lookup_target_def vs_lookup_slot_def vs_lookup_table_def obind_assoc)
+  apply (subgoal_tac "level \<noteq> asid_pool_level"; clarsimp)
+  apply (cases "level = max_pt_level", clarsimp simp: max_pt_level_plus_one in_omonad)
+  apply (subgoal_tac "level + 1 \<noteq> asid_pool_level")
+   prefer 2
+   apply (metis max_pt_level_plus_one add.right_cancel)
+  apply (clarsimp simp: obind_assoc simp del: asid_pool_level_neq)
+  apply (subst (asm) pt_walk_split_Some[where level'="level + 1"]; simp add: less_imp_le)
+  apply (subst (asm) (2) pt_walk.simps)
+  apply (subgoal_tac "level + 1 \<noteq> asid_pool_level")
+   prefer 2
+   apply (metis max_pt_level_plus_one add.right_cancel)
+  apply (clarsimp simp: in_omonad simp del: asid_pool_level_neq cong: conj_cong)
+  apply (rule_tac x="level + 1" in exI)
+  apply (subst pt_walk_vref_for_level; simp add: less_imp_le)
+  apply (clarsimp simp: is_PageTablePTE_def pptr_from_pte_def split: if_split_asm)
+  done
+
+lemma vs_lookup_table_targetD:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p); level \<le> max_pt_level \<rbrakk>
+   \<Longrightarrow> \<exists>p'. vs_lookup_target (level+1) asid vref s = Some (level+1, p')"
+  apply (case_tac "level < max_pt_level")
+   apply (clarsimp dest!: vs_lookup_table_split_last_Some)
+   apply (clarsimp simp: vs_lookup_target_def vs_lookup_slot_def in_omonad pte_ref_def)
+   apply (fastforce dest: vm_level_less_plus_1_mono split: pte.splits)
+  apply (clarsimp simp: max_pt_level_plus_one vs_lookup_target_def vs_lookup_slot_def in_omonad
+                         pte_ref_def pool_for_asid_vs_lookup)
+  apply (fastforce dest!: vs_lookup_table_max_pt_level_SomeD)
+  done
+
+lemma valid_vs_lookupD:
+  "\<lbrakk> vs_lookup_target bot_level asid vref s = Some (level, p) ;
+     vref \<in> user_region; valid_vs_lookup s \<rbrakk>
+   \<Longrightarrow> asid \<noteq> 0
+      \<and> (\<exists>cptr cap. caps_of_state s cptr = Some cap \<and> obj_refs cap = {p}
+                    \<and> vs_cap_ref cap = Some (asid, vref_for_level vref level))"
+  unfolding valid_vs_lookup_def
+  by auto
+
+lemma vs_lookup_table_valid_cap:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p); vref \<in> user_region;
+     valid_vs_lookup s; valid_asid_pool_caps s \<rbrakk> \<Longrightarrow>
+   (\<exists>p' cap. caps_of_state s p' = Some cap \<and> obj_refs cap = {p} \<and>
+             vs_cap_ref cap = Some (asid_for_level asid level,
+                                    vref_for_level vref (if level=asid_pool_level
+                                                         then asid_pool_level else level + 1)))"
+  apply (cases "level \<le> max_pt_level")
+   apply (drule (1) vs_lookup_table_target)
+   apply (drule valid_vs_lookupD, erule vref_for_level_user_region, assumption)
+   apply (fastforce simp: asid_for_level_def)
+  apply (simp add: not_le)
+  apply (clarsimp simp: vs_lookup_table_def pool_for_asid_def valid_asid_pool_caps_def)
+  apply (erule allE)+
+  apply (erule (1) impE)
+  apply clarsimp
+  apply (rule exI)+
+  apply (rule conjI, assumption)
+  apply (simp add: asid_for_level_def vref_for_level_asid_pool user_region_def)
+  apply (simp add: asid_high_bits_of_def)
+  apply (word_eqI_solve simp: asid_low_bits_def)
+  done
+
+lemma invs_valid_asid_pool_caps[elim!]:
+  "invs s \<Longrightarrow> valid_asid_pool_caps s"
+  by (simp add: invs_def valid_state_def valid_arch_caps_def)
+
+lemma vs_lookup_table_asid_not_0:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p); level \<le> max_pt_level;
+     vref \<in> user_region; valid_vs_lookup s \<rbrakk>
+   \<Longrightarrow> asid \<noteq> 0"
+  by (fastforce dest!: vs_lookup_table_targetD valid_vs_lookupD)
+
+lemma vspace_for_asid_from_lookup_target:
+  "\<lbrakk> vs_lookup_target asid_pool_level asid vref s = Some (asid_pool_level, pt_ptr);
+     vref \<in> user_region; valid_vs_lookup s \<rbrakk>
+   \<Longrightarrow> vspace_for_asid asid s = Some pt_ptr"
+  apply (frule valid_vs_lookupD; clarsimp?)
+  apply (clarsimp simp: vs_lookup_target_def in_omonad word_neq_0_conv
+                        vs_lookup_slot_def pool_for_asid_vs_lookup asid_pool_level_eq[symmetric]
+                        vspace_for_asid_def
+                  split: if_splits)
+  done
+
+lemma unique_table_refsD:
+  "\<lbrakk> caps_of_state s p = Some cap; caps_of_state s p' = Some cap';
+     unique_table_refs s; obj_refs cap' = obj_refs cap \<rbrakk>
+   \<Longrightarrow> table_cap_ref cap' = table_cap_ref cap"
+  unfolding unique_table_refs_def by blast
+
+lemma table_cap_ref_vs_cap_ref:
+  "\<lbrakk> table_cap_ref cap' = table_cap_ref cap; is_pt_cap cap; is_pt_cap cap' \<rbrakk>
+   \<Longrightarrow> vs_cap_ref cap' = vs_cap_ref cap"
+  apply (clarsimp simp: table_cap_ref_def vs_cap_ref_def arch_cap_fun_lift_def split: cap.splits)
+  apply (clarsimp simp: vs_cap_ref_arch_def table_cap_ref_arch_def split: arch_cap.splits)
+  done
+
+(* FIXME MOVE, these should be abbreviations *)
+lemma is_ko_to_discs:
+  "is_ep = is_Endpoint"
+  "is_ntfn = is_Notification"
+  "is_tcb = is_TCB"
+  apply (all \<open>rule ext, simp add: is_ep_def is_ntfn_def is_tcb_def split: kernel_object.splits\<close>)
+  done
+
+lemma cap_to_pt_is_pt_cap:
+  "\<lbrakk> obj_refs cap = {p}; caps_of_state s cptr = Some cap; pts_of s p \<noteq> None;
+     valid_caps (caps_of_state s) s \<rbrakk>
+   \<Longrightarrow> is_pt_cap cap"
+  by (drule (1) valid_capsD)
+     (auto simp: pts_of_ko_at is_pt_cap_def arch_cap_fun_lift_def arch_cap.disc_eq_case(4)
+                 valid_cap_def obj_at_def is_ko_to_discs is_cap_table_def
+           split: if_splits arch_cap.split cap.splits option.splits)
+
+lemma unique_vs_lookup_table:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p);
+     vs_lookup_table level' asid' vref' s = Some (level', p');
+     p' = p; level \<le> max_pt_level; level' \<le> max_pt_level;
+     vref \<in> user_region; vref' \<in> user_region;
+     unique_table_refs s; valid_vs_lookup s;
+     valid_vspace_objs s; valid_asid_table s; pspace_aligned s;
+     valid_caps (caps_of_state s) s \<rbrakk>
+   \<Longrightarrow> asid' = asid \<and>
+       vref_for_level vref' (level'+1) = vref_for_level vref (level+1)"
+  supply valid_vspace_obj.simps[simp del]
+  apply (frule (5) valid_vspace_objs_strongD)
+  apply (frule (5) valid_vspace_objs_strongD[where pt_ptr=p'])
+  apply (drule (1) vs_lookup_table_target)+
+  apply (drule valid_vs_lookupD, erule vref_for_level_user_region, assumption)+
+  apply (elim conjE exE)
+  apply (rename_tac pt pt' cptr cptr' cap cap')
+  apply simp
+  apply (subgoal_tac "is_pt_cap cap \<and> is_pt_cap cap'")
+   prefer 2
+   apply (simp add: cap_to_pt_is_pt_cap)
+  apply (drule (2) unique_table_refsD, simp)
+  apply (drule table_cap_ref_vs_cap_ref; simp)
+  done
+
+lemma vref_for_level_pt_index_idem:
+  assumes "level' \<le> max_pt_level" and "level'' \<le> level'"
+  shows "vref_for_level
+           (vref_for_level vref (level'' + 1) || (pt_index level vref' << pt_bits_left level''))
+           (level' + 1)
+         = vref_for_level vref (level' + 1)"
+proof -
+  have dist_zero_right':
+    "\<And>w x y. \<lbrakk> (w::('a::len) word) = y; x = 0\<rbrakk> \<Longrightarrow> w || x = y"
+    by auto
+  show ?thesis using assms
+    unfolding vref_for_level_def pt_index_def
+    apply (subst word_ao_dist)
+    apply (rule dist_zero_right')
+    apply (subst mask_lower_twice)
+   apply (rule pt_bits_left_mono, erule (1) vm_level_le_plus_1_mono, rule refl)
+  apply (simp add: mask_shifl_overlap_zero pt_bits_left_def)
+  done
+qed
+
+lemma pt_slot_offset_vref_for_level_idem:
+  "\<lbrakk> is_aligned p pt_bits; level' \<le> max_pt_level \<rbrakk>
+   \<Longrightarrow> pt_slot_offset level' p
+            (vref_for_level vref (level' + 1) || (pt_index level vref << pt_bits_left level'))
+   = pt_slot_offset level p vref"
+  apply (simp add: pt_slot_offset_or_def)
+  apply (rule arg_cong[where f="\<lambda>x. p || x"])
+  apply (rule arg_cong[where f="\<lambda>x. x << pte_bits"])
+  apply (simp add: pt_index_def pt_bits_left_def)
+  apply (drule max_pt_level_enum)
+  apply word_eqI
+  apply (auto simp: bit_simps pt_bits_left_def)
+  done
+
+lemma pt_walk_loop_last_level_ptpte_helper:
+  "\<lbrakk> pt_walk level level' p vref ptes = Some (level', p); level \<le> max_pt_level; level > level';
+     is_aligned p pt_bits \<rbrakk>
+   \<Longrightarrow> \<exists>p' vref'. (pt_walk level 0 p vref' ptes = Some (0, p'))
+                 \<and> (\<exists>pte level. ptes (pt_slot_offset level p' vref') = Some pte \<and> is_PageTablePTE pte)
+                 \<and> vref_for_level vref' (level' + 1) = vref_for_level vref (level' + 1)"
+  supply vm_level_less_le_1[simp]
+  apply (induct level arbitrary: p level' vref; clarsimp)
+  apply (subst (asm) (3) pt_walk.simps)
+  apply (clarsimp simp: in_omonad split: if_split_asm)
+  apply (erule disjE; clarsimp)
+  apply (rename_tac pte)
+  apply (case_tac "level' = 0")
+   apply clarsimp
+   apply (subst pt_walk.simps)
+   apply (clarsimp simp: in_omonad)
+   apply (rule_tac x=p in exI)
+   apply (clarsimp simp: in_omonad)
+   apply (rule_tac x=vref in exI)
+   apply (clarsimp simp: in_omonad)
+   apply (rule conjI)
+    apply fastforce
+   apply blast
+  (* set up assumption of IH *)
+  apply (subgoal_tac
+           "pt_walk (level - 1) (level' - 1) (pptr_from_pte pte)
+                    (vref_for_level vref (level'+1) || (pt_index level vref << pt_bits_left level'))
+                    ptes
+            = Some (level' - 1, pptr_from_pte pte)")
+   apply (drule meta_spec, drule meta_spec, drule meta_spec, drule (1) meta_mp, drule meta_mp)
+    using pt_walk_max_level less_linear
+    apply fastforce
+   apply clarsimp
+   apply (subst pt_walk.simps)
+   apply (clarsimp simp: in_omonad)
+   apply (rule_tac x=p' in exI)
+   apply (rule_tac x=vref' in exI)
+   apply (rule conjI)
+    (* walk to level 0 *)
+    apply (rule_tac x=pte in exI)
+    apply clarsimp
+    apply (subgoal_tac "pt_slot_offset level p vref' = pt_slot_offset level p vref")
+     prefer 2
+     apply (rule vref_for_level_pt_slot_offset)
+     apply (rule_tac level="level'+1" in  vref_for_level_eq_mono)
+      apply (drule_tac level'="level'+1" in  vref_for_level_eq_mono
+             ; fastforce intro: vref_for_level_pt_index_idem)
+     apply (erule bit0.plus_one_leq)
+    apply simp
+   apply (rule conjI, blast)
+   apply (drule_tac level'="level'+1" in  vref_for_level_eq_mono
+          ; fastforce intro: vref_for_level_pt_index_idem)
+  (* show assumption used for IH earlier *)
+  apply (rule_tac pt_walk_split_Some[where level'="level" and level="level - 1" for level,
+                                     THEN iffD2])
+    apply (fastforce dest!: vm_level_not_less_zero intro: less_imp_le)
+   apply (meson bit0.leq_minus1_less bit0.not_less_zero_bit0 le_less less_linear less_trans)
+  apply (subgoal_tac
+           "pt_walk (level - 1) level' (pptr_from_pte pte)
+                    (vref_for_level vref (level' + 1) || (pt_index level vref << pt_bits_left level'))
+            = pt_walk (level - 1) level' (pptr_from_pte pte) vref")
+   prefer 2
+   apply (rule pt_walk_vref_for_level_eq)
+    apply (subst vref_for_level_pt_index_idem, simp+)
+   apply (meson bit0.leq_minus1_less bit0.not_less_zero_bit0 le_less less_linear less_trans)
+  apply clarsimp
+  apply (subst pt_walk.simps)
+  apply clarsimp
+  apply (frule vm_level_not_less_zero)
+  apply (clarsimp simp: in_omonad)
+  apply (rule_tac x=pte in exI)
+  apply (clarsimp simp add: pt_slot_offset_vref_for_level_idem)
+  done
+
+(* if you can walk the page tables and get back to a page table you have already visited,
+   then you can create a lookup path such that you end up with a PT PTE at the bottom-most level *)
+lemma pt_walk_loop_last_level_ptpte:
+  "\<lbrakk> pt_walk level level' p vref ptes = Some (level', p); level \<le> max_pt_level; level > level';
+     is_aligned p pt_bits \<rbrakk>
+   \<Longrightarrow> \<exists>p' vref'. (pt_walk level 0 p vref' ptes = Some (0, p'))
+                 \<and> (\<exists>pte. ptes (pt_slot_offset 0 p' vref') = Some pte \<and> is_PageTablePTE pte)
+                 \<and> vref_for_level vref' (level' + 1) = vref_for_level vref (level' + 1)"
+  apply (drule pt_walk_loop_last_level_ptpte_helper; simp)
+  apply clarsimp
+  apply (rule_tac x=p' in exI)
+  apply (rule_tac x="vref_for_level vref' 1 || (pt_index levela vref' << pt_bits_left 0)" in exI)
+  apply (rule conjI)
+   apply (subst pt_walk_vref_for_level_eq; assumption?)
+    apply simp
+    apply (rule vref_for_level_pt_index_idem[where level''=0 and level'=0, simplified])
+   apply simp
+  apply (rule conjI)
+   apply (rule_tac x=pte in exI)
+   apply clarsimp
+   apply (subst pt_slot_offset_vref_for_level_idem[where level'=0, simplified])
+    apply (erule (2) pt_walk_is_aligned)
+  apply (subst vref_for_level_pt_index_idem[where level''=0, simplified]; simp)
+  done
+
+(* If when performing page table walks to two different depths we arrive at the same page table,
+   then we can construct a complete walk ending on a PT PTE at the bottom level.
+   This is significant, because validity of PTEs requires that only pages are mapped at the
+   deepest PT level.
+   Note: we are looking up vref in both cases, but as we stop early we observe that only
+         vref_for_level bits of vref are used, for the level before we stopped.
+   *)
+lemma pt_walk_same_for_different_levels:
+  "\<lbrakk> pt_walk top_level level' ptptr vref ptes = Some (level', p);
+     pt_walk top_level level ptptr vref ptes = Some (level, p);
+     level' < level; top_level \<le> max_pt_level; is_aligned ptptr pt_bits \<rbrakk>
+   \<Longrightarrow> \<exists>vref'' ptptr'. pt_walk top_level 0 ptptr vref'' ptes = Some (0, ptptr') \<and>
+                      (\<exists>pte. ptes (pt_slot_offset 0 ptptr' vref'') = Some pte \<and> is_PageTablePTE pte) \<and>
+                      vref_for_level vref'' (level' + 1) = vref_for_level vref (level' + 1)"
+  apply (subgoal_tac "level \<le> top_level")
+   prefer 2
+   apply (fastforce simp: pt_walk_max_level)
+  apply (subst (asm) pt_walk_split_Some[where level'=level], simp+)
+  apply (drule pt_walk_loop_last_level_ptpte; (simp add: pt_walk_is_aligned)?)
+  apply clarsimp
+  apply (subst pt_walk_split_Some[where level'=level], simp+)
+  apply (rule_tac x="vref'" in exI)
+  apply (rule_tac x="p'" in exI)
+  apply (rule conjI)
+   apply (rule_tac x="p" in exI)
+   apply simp
+   apply (subst pt_walk_vref_for_level_eq; assumption?)
+   apply (fastforce elim: vref_for_level_eq_mono  simp: vm_level_le_plus_1_mono)
+  apply fastforce
+  done
+
+lemma vs_lookup_table_same_for_different_levels:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p);
+     vs_lookup_table level' asid vref' s = Some (level', p);
+     vref_for_level vref (level+1) = vref_for_level vref' (level+1);
+     vref \<in> user_region; level' < level; level \<le> max_pt_level;
+     valid_vspace_objs s; valid_asid_table s; pspace_aligned s \<rbrakk>
+   \<Longrightarrow> \<exists>vref'' p' pte. vs_lookup_slot 0 asid vref'' s = Some (0, p') \<and> ptes_of s p' = Some pte \<and>
+                      is_PageTablePTE pte \<and>
+                      vref_for_level vref'' (level' + 1) = vref_for_level vref' (level' + 1)"
+  apply (subst (asm) vs_lookup_vref_for_level1[where level=level, symmetric], blast)
+  apply (subst (asm) vs_lookup_vref_for_level1[where level=level', symmetric], blast)
+  apply (clarsimp simp: vs_lookup_table_def in_omonad asid_pool_level_eq)
+  apply (subgoal_tac "level' \<le> max_pt_level")
+   prefer 2
+   apply simp
+  apply (simp add: in_omonad pt_walk_vref_for_level1)
+  apply (simp add: vs_lookup_slot_def in_omonad vs_lookup_table_def cong: conj_cong)
+  apply (drule pt_walk_same_for_different_levels; simp?)
+  apply (erule vspace_for_pool_is_aligned; simp)
+  by force
+
+lemma no_loop_vs_lookup_table_helper:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p);
+     vs_lookup_table level' asid vref' s = Some (level', p);
+     vref_for_level vref' (max (level+1) (level'+1)) = vref_for_level vref (max (level+1) (level'+1));
+     vref \<in> user_region; vref' \<in> user_region;
+     level \<le> max_pt_level; level' \<le> max_pt_level; level' < level;
+     unique_table_refs s; valid_vs_lookup s;
+     valid_vspace_objs s; valid_asid_table s; pspace_aligned s;
+     valid_caps (caps_of_state s) s \<rbrakk>
+    \<Longrightarrow> level' = level"
+   apply (drule (1) vs_lookup_table_same_for_different_levels; simp?)
+    apply (frule (1) vm_level_less_plus_1_mono)
+    apply (simp add: max_absorb1)
+   apply (frule (1) vm_level_less_plus_1_mono)
+   apply (simp add: max_absorb1)
+   apply (clarsimp simp: vs_lookup_slot_def in_omonad, clarsimp split: if_splits)
+   apply (rename_tac pt_ptr)
+   (* the goal is to derive a contradiction: we have a walk down to the last level;
+      if we can show the pte we found is valid, it can't be a PT pte *)
+   apply (subgoal_tac "valid_pte 0 pte s")
+    apply (blast dest: ptpte_level_0_valid_pte)
+   apply (subgoal_tac "vref'' \<in> user_region")
+    prefer 2
+    apply (frule_tac vref=vref' and level="level'+1" in vref_for_level_user_region)
+    apply (rule vref_for_level_user_regionD[where level="level'+1"]; simp?)
+    apply (erule vm_level_less_max_pt_level)
+   apply (subgoal_tac "is_aligned pt_ptr pt_bits")
+    prefer 2
+    apply (fastforce elim!: vs_lookup_table_is_aligned)
+   apply (drule_tac pt_ptr=pt_ptr in valid_vspace_objs_strongD, assumption; simp?)
+   apply (fastforce simp: pte_of_def in_omonad is_aligned_pt_slot_offset_pte)
+  done
+
+lemma no_loop_vs_lookup_table:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p);
+     vs_lookup_table level' asid vref' s = Some (level', p);
+     vref_for_level vref' (max (level+1) (level'+1)) = vref_for_level vref (max (level+1) (level'+1));
+     vref \<in> user_region; vref' \<in> user_region;
+     unique_table_refs s; valid_vs_lookup s;
+     valid_vspace_objs s; valid_asid_table s; pspace_aligned s;
+     valid_caps (caps_of_state s) s \<rbrakk>
+    \<Longrightarrow> level' = level"
+  apply (case_tac "level = asid_pool_level"; simp)
+   apply (case_tac "level' = asid_pool_level"; simp)
+   apply (frule (5) valid_vspace_objs_strongD[where bot_level=level' and level=level'])
+   apply (fastforce dest!: vs_lookup_table_no_asid_pt)
+  apply (case_tac "level' = asid_pool_level"; simp)
+   apply (frule (5) valid_vspace_objs_strongD[where bot_level=level and level=level])
+   apply (fastforce dest!: vs_lookup_table_no_asid_pt)
+  apply (case_tac "level' = level"; clarsimp)
+  (* reduce to two cases with identical proofs, either level' < level or vice-versa *)
+  apply (case_tac "level' < level"; (clarsimp dest!: leI dual_order.not_eq_order_implies_strict)?)
+   apply (drule no_loop_vs_lookup_table_helper[where level'=level' and level=level])
+                 apply assumption+
+   apply simp
+  apply (drule no_loop_vs_lookup_table_helper[where level'=level and level=level']; assumption?)
+   apply (simp add: max.commute)+
+  done
+
+(* We can never find the same table/pool object at different levels.
+   When combined with unique_vs_lookup_table, shows there exists
+   only one path from the ASID table to any asid_pool / page table in the system *)
+lemma ex_vs_lookup_level:
+  "\<lbrakk> \<exists>\<rhd> (level, p) s;  \<exists>\<rhd> (level', p) s;
+     unique_table_refs s; valid_vs_lookup s;
+     valid_vspace_objs s; valid_asid_table s; pspace_aligned s;
+     valid_caps (caps_of_state s) s \<rbrakk>
+   \<Longrightarrow> level' = level"
+  apply clarsimp
+  (* FIXME RISCV no_loop_vs_lookup_table can deal with asid_pool_level, but unique_vs_lookup_table
+     can't, else we could get rid of this whole preamble *)
+  apply (rename_tac asid' vref vref')
+  apply (case_tac "level = asid_pool_level"; simp)
+   apply (case_tac "level' = asid_pool_level"; simp)
+   apply (frule (5) valid_vspace_objs_strongD[where bot_level=level' and level=level'])
+   apply (fastforce dest!: vs_lookup_table_no_asid_pt)
+  apply (case_tac "level' = asid_pool_level"; simp)
+   apply (frule (5) valid_vspace_objs_strongD[where bot_level=level and level=level])
+   apply (fastforce dest!: vs_lookup_table_no_asid_pt)
+  apply (frule_tac asid=asid and asid'=asid' in unique_vs_lookup_table, assumption; simp)
+  apply (drule_tac level=level and level'=level' and vref'=vref' in no_loop_vs_lookup_table
+         ; fastforce dest: vref_for_level_eq_max_mono simp: max.commute)
+  done
+
+lemma valid_objs_caps:
+  "valid_objs s \<Longrightarrow> valid_caps (caps_of_state s) s"
+  apply (clarsimp simp: valid_caps_def)
+  apply (erule (1) caps_of_state_valid_cap)
+  done
+
+(* invs could be relaxed; lemma so far only needed when invs is present *)
+lemma vs_lookup_table_unique_level:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p);
+     vs_lookup_table level' asid' vref' s = Some (level', p');
+     p' = p;
+     level \<le> max_pt_level; level' \<le> max_pt_level; vref \<in> user_region; vref' \<in> user_region;
+     invs s\<rbrakk>
+  \<Longrightarrow> level' = level \<and> asid' = asid \<and>
+      vref_for_level vref' (level+1) = vref_for_level vref (level+1)"
+  apply (frule (1) unique_vs_lookup_table[where level'=level']; (clarsimp intro!: valid_objs_caps)?)
+  apply (drule (1) no_loop_vs_lookup_table; (clarsimp intro!: valid_objs_caps)?)
+  apply (thin_tac "p' = p")
+  apply (drule arg_cong[where f="\<lambda>vref. vref_for_level vref (level + 1)"])
+  apply (drule arg_cong[where f="\<lambda>vref. vref_for_level vref (level' + 1)"])
+  apply (auto simp: max_def split: if_split_asm)
+  done
+
+(* invs could be relaxed; lemma so far only needed when invs is present *)
+lemma vs_lookup_slot_table_base:
+  "\<lbrakk> vs_lookup_slot level asid vref s = Some (level, slot); vref \<in> user_region;
+     level \<le> max_pt_level; invs s \<rbrakk> \<Longrightarrow>
+   vs_lookup_table level asid vref s = Some (level, table_base slot)"
+  apply (clarsimp simp: vs_lookup_slot_def split: if_split_asm)
+  apply (drule vs_lookup_table_is_aligned; clarsimp)
+  done
+
+(* invs could be relaxed; lemma so far only needed when invs is present *)
+lemma vs_lookup_slot_table_unfold:
+  "\<lbrakk> level \<le> max_pt_level; vref \<in> user_region; invs s \<rbrakk> \<Longrightarrow>
+   vs_lookup_slot level asid vref s = Some (level, pt_slot) =
+   (vs_lookup_table level asid vref s = Some (level, table_base pt_slot) \<and>
+    pt_slot = pt_slot_offset level (table_base pt_slot) vref)"
+  apply (rule iffI)
+   apply (frule (3) vs_lookup_slot_table_base)
+   apply (clarsimp simp: vs_lookup_slot_def in_omonad split: if_split_asm)
+  apply (clarsimp simp: vs_lookup_slot_def in_omonad)
+  done
+
+lemma pt_slot_offset_vref_for_level:
+  "\<lbrakk> vref_for_level vref' (level + 1) = vref_for_level vref (level + 1);
+     pt_slot_offset level p vref = pt_slot_offset level p vref';
+     is_aligned p pt_bits; level \<le> max_pt_level \<rbrakk>
+    \<Longrightarrow> vref_for_level vref' level = vref_for_level vref level"
+  apply (clarsimp simp: pt_slot_offset_def vref_for_level_def pt_index_def)
+  apply (drule shiftl_inj; (clarsimp simp: le_mask_iff, word_eqI, simp add: bit_simps)?)
+  apply word_eqI
+  apply (case_tac "pt_bits_left level \<le> n"; simp)
+  apply (case_tac "pt_bits_left (level + 1) \<le> n", fastforce)
+  apply (clarsimp simp: not_le pt_bits_left_plus1)
+  apply (thin_tac "All P" for P)
+  apply (thin_tac "All P" for P)
+  apply (erule_tac x="n - pt_bits_left level" in allE)
+  by fastforce
+
+(* invs could be relaxed; lemma so far only needed when invs is present *)
+lemma vs_lookup_slot_unique_level:
+  "\<lbrakk> vs_lookup_slot level asid vref s = Some (level, p);
+     vs_lookup_slot level' asid' vref' s = Some (level', p');
+     p' = p;
+     level \<le> max_pt_level; level' \<le> max_pt_level; vref \<in> user_region; vref' \<in> user_region;
+     invs s\<rbrakk>
+  \<Longrightarrow> level' = level \<and> asid' = asid \<and> vref_for_level vref' level = vref_for_level vref level"
+  apply (clarsimp simp: vs_lookup_slot_table_unfold)
+  apply (drule (1) vs_lookup_table_unique_level; clarsimp)
+  apply (drule pt_slot_offset_vref_for_level[where p="table_base p"]; clarsimp)
+  done
+
+lemma get_asid_pool_wp [wp]:
+  "\<lbrace>\<lambda>s. \<forall>pool. ko_at (ArchObj (ASIDPool pool)) p s \<longrightarrow> Q pool s\<rbrace>
+  get_asid_pool p
+  \<lbrace>Q\<rbrace>"
+  by (wpsimp simp: obj_at_def in_opt_map_eq)
+
+
+lemma set_asid_pool_typ_at [wp]:
+  "\<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> set_asid_pool ptr pool \<lbrace>\<lambda>_ s. P (typ_at T p s)\<rbrace>"
+  including unfold_objects
+  by (wpsimp simp: set_asid_pool_def wp: set_object_wp)
+
+lemmas set_asid_pool_typ_ats [wp] = abs_typ_at_lifts [OF set_asid_pool_typ_at]
+
+bundle pagebits =
+  pt_bits_def[simp]
+  pageBits_def[simp] mask_lower_twice[simp]
+  and.assoc[where ?'a = \<open>'a::len word\<close>,symmetric,simp] obj_at_def[simp]
+  pte.splits[split]
+
+
+lemma get_pt_wp[wp]:
+  "\<lbrace>\<lambda>s. \<forall>pt. ko_at (ArchObj (PageTable pt)) p s \<longrightarrow> Q pt s\<rbrace> get_pt p \<lbrace>Q\<rbrace>"
+  by (wpsimp simp: obj_at_def in_opt_map_eq)
+
+
+lemma get_pte_wp:
+  "\<lbrace>\<lambda>s. \<forall>pt. ko_at (ArchObj (PageTable pt)) (p && ~~mask pt_bits) s \<longrightarrow>
+        Q (pt (ucast (p && mask pt_bits >> pte_bits))) s\<rbrace>
+  get_pte p
+  \<lbrace>Q\<rbrace>"
+  by (wpsimp simp: ptes_of_Some in_opt_map_eq obj_at_def)
+
+lemma get_pte_inv[wp]:
+  "\<lbrace>P\<rbrace> get_pte p \<lbrace>\<lambda>_. P\<rbrace>"
+  by (wpsimp wp: get_pte_wp)
+
+lemmas store_pte_typ_ats [wp] = abs_typ_at_lifts [OF store_pte_typ_at]
+
+crunch cte_wp_at[wp]: set_irq_state "\<lambda>s. P (cte_wp_at P' p s)"
+
+lemma set_pt_cte_wp_at:
+  "\<lbrace>\<lambda>s. P (cte_wp_at P' p s)\<rbrace>
+     set_pt ptr val
+   \<lbrace>\<lambda>rv s. P (cte_wp_at P' p s)\<rbrace>"
+  apply (simp add: set_pt_def set_object_def get_object_def)
+  apply wp
+  including unfold_objects_asm
+  by (clarsimp elim!: rsubst[where P=P]
+               simp: cte_wp_at_after_update)
+
+lemma set_asid_pool_cte_wp_at:
+  "\<lbrace>\<lambda>s. P (cte_wp_at P' p s)\<rbrace>
+     set_asid_pool ptr val
+   \<lbrace>\<lambda>rv s. P (cte_wp_at P' p s)\<rbrace>"
+  apply (simp add: set_asid_pool_def set_object_def get_object_def)
+  apply wp
+  including unfold_objects_asm
+  by (clarsimp elim!: rsubst[where P=P]
+             simp: cte_wp_at_after_update)
+
+lemma set_pt_pred_tcb_at[wp]:
+  "\<lbrace>pred_tcb_at proj P t\<rbrace> set_pt ptr val \<lbrace>\<lambda>_. pred_tcb_at proj P t\<rbrace>"
+  apply (simp add: set_pt_def set_object_def)
+  apply (wpsimp wp: get_object_wp simp: pred_tcb_at_def obj_at_def)
+  done
+
+
+lemma set_asid_pool_pred_tcb_at[wp]:
+  "\<lbrace>pred_tcb_at proj P t\<rbrace> set_asid_pool ptr val \<lbrace>\<lambda>_. pred_tcb_at proj P t\<rbrace>"
+  apply (simp add: set_asid_pool_def set_object_def)
+  apply (wpsimp wp: get_object_wp simp: pred_tcb_at_def obj_at_def)
+  done
+
+lemma mask_pt_bits_inner_beauty:
+  "is_aligned p pte_bits \<Longrightarrow>
+  (p && ~~ mask pt_bits) + (ucast ((ucast (p && mask pt_bits >> pte_bits))::pt_index) << pte_bits) = (p::machine_word)"
+  by (rule mask_split_aligned; simp add: bit_simps)
+
+lemma more_pt_inner_beauty:
+  fixes x :: pt_index
+  fixes p :: machine_word
+  assumes x: "x \<noteq> ucast (p && mask pt_bits >> pte_bits)"
+  shows "(p && ~~ mask pt_bits) + (ucast x << pte_bits) = p \<Longrightarrow> False"
+  by (rule mask_split_aligned_neg[OF _ _ x]; simp add: bit_simps)
+
+
+lemmas undefined_validE_R = hoare_FalseE_R[where f=undefined]
+
+
+lemma arch_derive_cap_valid_cap:
+  "\<lbrace>valid_cap (cap.ArchObjectCap arch_cap)\<rbrace>
+  arch_derive_cap arch_cap
+  \<lbrace>valid_cap\<rbrace>, -"
+  apply(simp add: arch_derive_cap_def)
+  apply(cases arch_cap, simp_all add: arch_derive_cap_def o_def)
+      apply(rule hoare_pre, wpc?, wp+;
+            clarsimp simp add: cap_aligned_def valid_cap_def split: option.splits)+
+  done
+
+
+lemma arch_derive_cap_inv:
+  "\<lbrace>P\<rbrace> arch_derive_cap arch_cap \<lbrace>\<lambda>rv. P\<rbrace>"
+  unfolding arch_derive_cap_def by (cases arch_cap; wpsimp)
+
+definition
+  "valid_mapping_entries m \<equiv> case m of
+    (InvalidPTE, _) \<Rightarrow> \<top>
+  | (PagePTE _ _ _, p) \<Rightarrow> pte_at p
+  | (PageTablePTE _ _, _) \<Rightarrow> \<bottom>"
+
+definition
+  "invalid_pte_at p \<equiv> \<lambda>s. ptes_of s p = Some InvalidPTE"
+
+definition
+  "valid_slots \<equiv> \<lambda>(pte, p) s. wellformed_pte pte \<and>
+     (\<forall>level. \<exists>\<rhd>(level, p && ~~ mask pt_bits) s \<longrightarrow> pte_at p s \<and> valid_pte level pte s)"
+
+
+lemma ucast_mask_asid_low_bits [simp]:
+  "ucast ((asid::machine_word) && mask asid_low_bits) = (ucast asid :: asid_low_index)"
+  by (word_eqI simp: asid_low_bits_def)
+
+lemma ucast_ucast_asid_high_bits [simp]:
+  "ucast (ucast (asid_high_bits_of asid)::machine_word) = asid_high_bits_of asid"
+  by word_eqI_solve
+
+lemma mask_asid_low_bits_ucast_ucast:
+  "((asid::machine_word) && mask asid_low_bits) = ucast (ucast asid :: asid_low_index)"
+  by (word_eqI_solve simp: asid_low_bits_def)
+
+lemma set_asid_pool_cur [wp]:
+  "\<lbrace>\<lambda>s. P (cur_thread s)\<rbrace> set_asid_pool p a \<lbrace>\<lambda>_ s. P (cur_thread s)\<rbrace>"
+  unfolding set_asid_pool_def by (wpsimp wp: get_object_wp)
+
+lemma set_asid_pool_cur_tcb [wp]:
+  "\<lbrace>\<lambda>s. cur_tcb s\<rbrace> set_asid_pool p a \<lbrace>\<lambda>_ s. cur_tcb s\<rbrace>"
+  unfolding cur_tcb_def
+  by (rule hoare_lift_Pf [where f=cur_thread]; wp)
+
+crunch arch [wp]: set_asid_pool "\<lambda>s. P (arch_state s)"
+  (wp: get_object_wp)
+
+lemma set_asid_pool_pts_of [wp]:
+  "set_asid_pool p a \<lbrace>\<lambda>s. P (pts_of s)\<rbrace>"
+  unfolding set_asid_pool_def
+  apply (wpsimp wp: set_object_wp)
+  apply (erule_tac P=P in subst[rotated])
+  apply (rule ext)
+  apply (clarsimp simp: opt_map_def obj_at_def split: option.splits)
+  done
+
+lemma set_asid_pool_valid_arch [wp]:
+  "\<lbrace>valid_arch_state\<rbrace> set_asid_pool p a \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
+  by (rule valid_arch_state_lift_arch; wp set_asid_pool_typ_at)
+
+lemma set_asid_pool_valid_objs [wp]:
+  "\<lbrace>valid_objs\<rbrace> set_asid_pool p a \<lbrace>\<lambda>_. valid_objs\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  apply (wp set_object_valid_objs get_object_wp)
+  including unfold_objects
+  by (clarsimp simp: a_type_def valid_obj_def)
+
+
+lemma invs_valid_global_arch_objs:
+  "invs s \<Longrightarrow> valid_global_arch_objs s"
+  by (clarsimp simp: invs_def valid_state_def valid_arch_state_def)
+
+lemma is_aligned_pt:
+  "\<lbrakk> pt_at pt s; pspace_aligned s \<rbrakk> \<Longrightarrow> is_aligned pt pt_bits"
+  apply (clarsimp simp: obj_at_def)
+  apply (drule(1) pspace_alignedD)
+  apply (simp add: pt_bits_def pageBits_def)
+  done
+
+lemma is_aligned_global_pt:
+  "\<lbrakk>pt \<in> riscv_global_pts (arch_state s) level; pspace_aligned s; valid_arch_state s\<rbrakk>
+   \<Longrightarrow> is_aligned pt pt_bits"
+  by (fastforce simp: valid_arch_state_def valid_global_arch_objs_def intro: is_aligned_pt)
+
+lemma page_table_pte_atI:
+  "\<lbrakk> pt_at p s; x < 2^(pt_bits - pte_bits); pspace_aligned s \<rbrakk> \<Longrightarrow> pte_at (p + (x << pte_bits)) s"
+  apply (clarsimp simp: obj_at_def pte_at_def)
+  apply (drule (1) pspace_alignedD[rotated])
+  apply (clarsimp simp: a_type_def
+                 split: kernel_object.splits arch_kernel_obj.splits if_split_asm)
+  apply (simp add: aligned_add_aligned is_aligned_shiftl_self word_bits_conv bit_simps)
+  apply (subgoal_tac "p = (p + (x << pte_bits) && ~~ mask pt_bits)")
+   subgoal by (auto simp: bit_simps)
+  apply (rule sym, rule add_mask_lower_bits)
+   apply (simp add: bit_simps)
+  apply (simp del: bit_shiftl_iff bit_shiftl_word_iff)
+  apply (subst upper_bits_unset_is_l2p_64[unfolded word_bits_conv])
+   apply (simp add: bit_simps)
+  apply (rule shiftl_less_t2n)
+   apply (simp add: bit_simps)
+  apply (simp add: bit_simps)
+  done
+
+lemma page_table_pte_at_diffE:
+  "\<lbrakk> pt_at p s; q - p = x << pte_bits;
+    x < 2^(pt_bits - pte_bits); pspace_aligned s \<rbrakk> \<Longrightarrow> pte_at q s"
+  apply (clarsimp simp: diff_eq_eq add.commute)
+  apply (erule(2) page_table_pte_atI)
+  done
+
+lemma vs_lookup_table_extend:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, pt);
+    pt_walk level bot_level pt vref (ptes_of s) = Some (bot_level, p);
+    level \<le> max_pt_level\<rbrakk>
+   \<Longrightarrow> vs_lookup_table bot_level asid vref s = Some (bot_level, p)"
+  by (rule vs_lookup_split_Some[THEN iffD2] ; fastforce intro!: pt_walk_max_level)
+
+lemma pt_walk_pt_at:
+  "\<lbrakk> pt_walk level bot_level pt_ptr vptr (ptes_of s) = Some (level', p);
+     vs_lookup_table level asid vptr s = Some (level, pt_ptr); level \<le> max_pt_level;
+     vptr \<in> user_region; valid_vspace_objs s; valid_asid_table s; pspace_aligned s \<rbrakk>
+   \<Longrightarrow> pt_at p s"
+  apply (drule pt_walk_level)
+  apply (frule pt_walk_max_level)
+  apply (drule vs_lookup_table_extend ; assumption?)
+  apply (fastforce dest!: valid_vspace_objs_strongD simp: pt_at_eq)
+  done
+
+lemma vs_lookup_table_pt_at:
+  "\<lbrakk> vs_lookup_table level asid vptr s = Some (level, pt_ptr); level \<le> max_pt_level;
+     vptr \<in> user_region; valid_vspace_objs s; valid_asid_table s; pspace_aligned s \<rbrakk>
+   \<Longrightarrow> pt_at pt_ptr s"
+  apply (subst (asm) vs_lookup_split_max_pt_level_Some, clarsimp+)
+  apply (drule (1) pt_walk_pt_at; simp)
+  done
+
+lemma pt_lookup_slot_from_level_pte_at:
+  "\<lbrakk> pt_lookup_slot_from_level level bot_level pt_ptr vptr (ptes_of s) = Some (level', p);
+     vs_lookup_table level asid vptr s = Some (level, pt_ptr); level \<le> max_pt_level;
+     vptr \<in> user_region; valid_vspace_objs s; valid_asid_table s; pspace_aligned s \<rbrakk>
+  \<Longrightarrow> pte_at p s"
+  unfolding pt_lookup_slot_from_level_def
+  apply (clarsimp simp add: oreturn_def obind_def split: option.splits)
+  apply (rename_tac pt_ptr')
+  apply (frule pt_walk_pt_at; assumption?)
+  apply (fastforce simp: pte_at_def is_aligned_pt_slot_offset_pte is_aligned_pt)
+  done
+
+lemma set_pt_distinct [wp]:
+  "\<lbrace>pspace_distinct\<rbrace> set_pt p pt \<lbrace>\<lambda>_. pspace_distinct\<rbrace>"
+  apply (simp add: set_pt_def)
+  apply (wp set_object_distinct get_object_wp)
+  apply (clarsimp simp: obj_at_def a_type_def
+                split: kernel_object.splits arch_kernel_obj.splits)
+  done
+
+crunches store_pte
+  for arch[wp]: "\<lambda>s. P (arch_state s)"
+  and "distinct"[wp]: pspace_distinct
+
+lemma store_pt_asid_pools_of[wp]:
+  "set_pt p pt \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
+  unfolding set_pt_def
+  apply (wpsimp wp: set_object_wp)
+  apply (auto simp: obj_at_def opt_map_def elim!: rsubst[where P=P])
+  done
+
+lemma store_pte_asid_pools_of[wp]:
+  "store_pte p pte \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
+  unfolding store_pte_def by wpsimp
+
+lemma store_pte_vspace_at_asid:
+  "store_pte p pte \<lbrace>vspace_at_asid asid pt\<rbrace>"
+  unfolding vspace_at_asid_def by (wp vspace_for_asid_lift)
+
+(* FIXME MOVE *)
+lemma ko_at_kheap:
+  "ko_at ko p s \<Longrightarrow> kheap s p = Some ko"
+  unfolding obj_at_def by simp
+
+lemma store_pte_valid_objs [wp]:
+  "\<lbrace>(\<lambda>s. wellformed_pte pte) and valid_objs\<rbrace> store_pte p pte \<lbrace>\<lambda>_. valid_objs\<rbrace>"
+  apply (simp add: store_pte_def set_pt_def bind_assoc set_object_def get_object_def)
+  apply (wpsimp simp_del: fun_upd_apply)
+  apply (clarsimp simp: valid_objs_def dom_def simp del: fun_upd_apply)
+  apply (frule ko_at_kheap)
+  apply (fastforce intro!: valid_obj_same_type simp: valid_obj_def split: if_split_asm)
+  done
+
+lemma set_pt_caps_of_state [wp]:
+  "\<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace> set_pt p pt \<lbrace>\<lambda>_ s. P (caps_of_state s)\<rbrace>"
+  apply (simp add: set_pt_def get_object_def bind_assoc set_object_def)
+  apply (wpsimp)
+  apply (subst caps_of_state_after_update, auto elim: obj_at_weakenE)
+  done
+
+lemma store_pte_aligned [wp]:
+  "\<lbrace>pspace_aligned\<rbrace> store_pte pt p \<lbrace>\<lambda>_. pspace_aligned\<rbrace>"
+  apply (simp add: store_pte_def set_pt_def)
+  apply (wp set_object_aligned get_object_wp)
+  including unfold_objects
+  by (clarsimp simp: a_type_def)
+
+
+lemma set_asid_pool_aligned [wp]:
+  "\<lbrace>pspace_aligned\<rbrace> set_asid_pool p ptr \<lbrace>\<lambda>_. pspace_aligned\<rbrace>"
+  apply (simp add: set_asid_pool_def get_object_def)
+  apply (wp set_object_aligned|wpc)+
+  including unfold_objects
+  apply clarsimp
+  done
+
+lemma set_asid_pool_distinct [wp]:
+  "\<lbrace>pspace_distinct\<rbrace> set_asid_pool p ptr \<lbrace>\<lambda>_. pspace_distinct\<rbrace>"
+  apply (simp add: set_asid_pool_def get_object_def)
+  apply (wp set_object_distinct|wpc)+
+  including unfold_objects
+  apply clarsimp
+  done
+
+
+lemma store_pte_valid_pte [wp]:
+  "\<lbrace>valid_pte level pt\<rbrace> store_pte p pte \<lbrace>\<lambda>_. valid_pte level pt\<rbrace>"
+  by (wp valid_pte_lift store_pte_typ_at)
+
+lemma global_refs_kheap [simp]:
+  "global_refs (kheap_update f s) = global_refs s"
+  by (simp add: global_refs_def)
+
+
+lemma set_pt_valid_objs:
+  "\<lbrace>(\<lambda>s. \<forall>i. wellformed_pte (pt i)) and valid_objs\<rbrace>
+   set_pt p pt
+   \<lbrace>\<lambda>_. valid_objs\<rbrace>"
+  apply (simp add: set_pt_def)
+  apply (wp get_object_wp set_object_valid_objs)
+  apply (clarsimp simp: valid_obj_def obj_at_def split: kernel_object.splits arch_kernel_obj.splits)
+  done
+
+
+lemma set_pt_iflive:
+  "\<lbrace>\<lambda>s. if_live_then_nonz_cap s\<rbrace>
+  set_pt p pt
+  \<lbrace>\<lambda>_ s. if_live_then_nonz_cap s\<rbrace>"
+  unfolding set_pt_def including unfold_objects
+  by (wpsimp simp: set_pt_def live_def hyp_live_def arch_live_def wp: get_object_wp set_object_iflive)
+
+
+lemma set_pt_zombies:
+  "\<lbrace>\<lambda>s. zombies_final s\<rbrace>
+  set_pt p pt
+  \<lbrace>\<lambda>_ s. zombies_final s\<rbrace>"
+  unfolding set_pt_def including unfold_objects
+  by (wpsimp wp: get_object_wp)
+
+
+lemma set_pt_zombies_state_refs:
+  "\<lbrace>\<lambda>s. P (state_refs_of s)\<rbrace>
+  set_pt p pt
+  \<lbrace>\<lambda>_ s. P (state_refs_of s)\<rbrace>"
+  unfolding set_pt_def set_object_def including unfold_objects
+  apply wpsimp
+  apply (erule rsubst [where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: state_refs_of_def split: option.splits)
+  done
+
+lemma set_pt_zombies_state_hyp_refs:
+  "\<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>
+  set_pt p pt
+  \<lbrace>\<lambda>_ s. P (state_hyp_refs_of s)\<rbrace>"
+  apply (clarsimp simp: set_pt_def set_object_def)
+  apply (wp get_object_wp)
+  apply (clarsimp split: kernel_object.splits arch_kernel_obj.splits)
+  apply (erule rsubst [where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: obj_at_def state_hyp_refs_of_def split: option.splits)
+  done
+
+lemma set_pt_cdt:
+  "\<lbrace>\<lambda>s. P (cdt s)\<rbrace> set_pt p pt \<lbrace>\<lambda>_ s. P (cdt s)\<rbrace>"
+  unfolding set_pt_def including unfold_objects by wpsimp
+
+
+lemma set_pt_valid_mdb:
+  "\<lbrace>\<lambda>s. valid_mdb s\<rbrace> set_pt p pt \<lbrace>\<lambda>_ s. valid_mdb s\<rbrace>"
+  including unfold_objects
+  by (wpsimp wp: set_pt_cdt valid_mdb_lift simp: set_pt_def set_object_def)
+
+lemma set_pt_valid_idle:
+  "\<lbrace>\<lambda>s. valid_idle s\<rbrace> set_pt p pt \<lbrace>\<lambda>_ s. valid_idle s\<rbrace>"
+  including unfold_objects
+  by (wpsimp wp: valid_idle_lift simp: set_pt_def)
+
+lemma set_pt_ifunsafe:
+  "\<lbrace>\<lambda>s. if_unsafe_then_cap s\<rbrace> set_pt p pt \<lbrace>\<lambda>_ s. if_unsafe_then_cap s\<rbrace>"
+  including unfold_objects by (wpsimp simp: set_pt_def)
+
+lemma set_pt_reply_caps:
+  "\<lbrace>\<lambda>s. valid_reply_caps s\<rbrace> set_pt p pt \<lbrace>\<lambda>_ s. valid_reply_caps s\<rbrace>"
+  by (wp valid_reply_caps_st_cte_lift)
+
+lemma set_pt_reply_masters:
+  "\<lbrace>valid_reply_masters\<rbrace>  set_pt p pt  \<lbrace>\<lambda>_. valid_reply_masters\<rbrace>"
+  by (wp valid_reply_masters_cte_lift)
+
+crunches set_pt
+  for global_ref[wp]: "\<lambda>s. P (global_refs s)"
+  and idle[wp]: "\<lambda>s. P (idle_thread s)"
+  and irq[wp]: "\<lambda>s. P (interrupt_irq_node s)"
+  (wp: crunch_wps)
+
+lemma set_pt_valid_global:
+  "\<lbrace>\<lambda>s. valid_global_refs s\<rbrace>
+  set_pt p pt
+  \<lbrace>\<lambda>_ s. valid_global_refs s\<rbrace>"
+  by (wp valid_global_refs_cte_lift)
+
+lemma set_pt_cur:
+  "\<lbrace>\<lambda>s. cur_tcb s\<rbrace>
+  set_pt p pt
+  \<lbrace>\<lambda>_ s. cur_tcb s\<rbrace>"
+  apply (simp add: cur_tcb_def set_pt_def set_object_def)
+  apply (wp get_object_wp)
+  apply (clarsimp simp: obj_at_def is_tcb_def)
+  done
+
+
+lemma set_pt_aligned [wp]:
+  "\<lbrace>pspace_aligned\<rbrace> set_pt p pt \<lbrace>\<lambda>_. pspace_aligned\<rbrace>"
+  apply (simp add: set_pt_def)
+  apply (wp get_object_wp set_object_aligned)
+  apply (clarsimp simp: a_type_def obj_at_def
+                  split: kernel_object.splits arch_kernel_obj.splits)
+  done
+
+
+crunch interrupt_states[wp]: set_pt "\<lambda>s. P (interrupt_states s)"
+  (wp: crunch_wps)
+
+lemma unique_table_caps_ptD:
+  "\<lbrakk> cs p = Some cap; vs_cap_ref cap = None;
+     cs p' = Some cap'; is_pt_cap cap; is_pt_cap cap';
+     obj_refs cap' = obj_refs cap;
+     unique_table_caps_2 cs\<rbrakk>
+  \<Longrightarrow> p = p'"
+  unfolding unique_table_caps_2_def by fastforce
+
+lemma set_pt_table_caps[wp]:
+  "\<lbrace>valid_table_caps and (\<lambda>s. valid_caps (caps_of_state s) s) and
+    (\<lambda>s. (\<forall>slot asidopt. caps_of_state s slot = Some (ArchObjectCap (PageTableCap p asidopt))
+                         \<longrightarrow> asidopt = None \<longrightarrow> pt = empty_pt)) \<rbrace>
+   set_pt p pt
+   \<lbrace>\<lambda>rv. valid_table_caps\<rbrace>"
+  unfolding valid_table_caps_def set_pt_def
+  supply fun_upd_apply[simp del]
+  apply (wpsimp wp: set_object_wp)
+  apply (rename_tac ref slot)
+  apply (subst (asm) caps_of_state_after_update[simplified fun_upd_apply[symmetric]])
+   apply (clarsimp simp: obj_at_def)
+  apply (drule_tac x=r in spec, erule impE, fastforce)
+  apply (clarsimp simp: opt_map_def fun_upd_apply split: option.splits)
+  done
+
+lemma store_pte_valid_table_caps:
+  "\<lbrace> valid_table_caps and (\<lambda>s. valid_caps (caps_of_state s) s) and
+     (\<lambda>s. (\<forall>slot asidopt. caps_of_state s slot = Some (ArchObjectCap (PageTableCap (table_base p) asidopt))
+                          \<longrightarrow> asidopt = None \<longrightarrow> pte = InvalidPTE)) \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>rv. valid_table_caps\<rbrace>"
+  unfolding store_pte_def
+  by wpsimp
+     (fastforce simp: valid_table_caps_def pts_of_ko_at obj_at_def)
+
+lemma set_object_caps_of_state:
+  "\<lbrace>(\<lambda>s. \<not>tcb_at p s \<and> \<not>(\<exists>n. cap_table_at n p s)) and
+    K ((\<forall>x y. obj \<noteq> CNode x y) \<and> (\<forall>x. obj \<noteq> TCB x)) and
+    (\<lambda>s. P (caps_of_state s))\<rbrace>
+   set_object p obj
+   \<lbrace>\<lambda>_ s. P (caps_of_state s)\<rbrace>"
+  apply (wpsimp wp: set_object_wp_strong)
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (simp add: caps_of_state_cte_wp_at obj_at_def is_cap_table_def
+                   is_tcb_def)
+  apply (auto simp: cte_wp_at_cases)
+  done
+
+lemma set_pt_aobjs_of:
+  "\<lbrace>\<lambda>s. aobjs_of s p \<noteq> None \<longrightarrow> P (aobjs_of s(p \<mapsto> PageTable pt)) \<rbrace> set_pt p pt \<lbrace>\<lambda>_ s. P (aobjs_of s)\<rbrace>"
+  unfolding set_pt_def
+  supply fun_upd_apply[simp del]
+  by (wpsimp wp: set_object_wp)
+     (simp add: obj_at_def opt_map_def)
+
+lemma set_pt_asid_pool_caps[wp]:
+  "set_pt p pt \<lbrace>valid_asid_pool_caps\<rbrace>"
+  unfolding valid_asid_pool_caps_def
+  by (rule hoare_lift_Pf[where f=caps_of_state]; wp)
+
+lemma valid_global_refsD2:
+  "\<lbrakk> caps_of_state s ptr = Some cap; valid_global_refs s \<rbrakk>
+      \<Longrightarrow> global_refs s \<inter> cap_range cap = {}"
+  by (cases ptr,
+      simp add: valid_global_refs_def valid_refs_def
+                cte_wp_at_caps_of_state)
+
+
+lemma valid_global_refsD:
+  "\<lbrakk> valid_global_refs s; cte_wp_at ((=) cap) ptr s;
+         r \<in> global_refs s \<rbrakk>
+        \<Longrightarrow> r \<notin> cap_range cap"
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (drule(1) valid_global_refsD2)
+  apply fastforce
+  done
+
+
+lemma set_pt_global_objs [wp]:
+  "\<lbrace>\<top>\<rbrace> set_pt p pt \<lbrace>\<lambda>rv. valid_global_objs\<rbrace>"
+  unfolding valid_global_objs_def by wp
+
+
+crunch v_ker_map[wp]: set_pt "valid_kernel_mappings"
+  (ignore: set_object wp: set_object_v_ker_map crunch_wps)
+
+
+lemma set_pt_asid_map [wp]:
+  "\<lbrace>valid_asid_map\<rbrace> set_pt p pt \<lbrace>\<lambda>_. valid_asid_map\<rbrace>"
+  apply (simp add: valid_asid_map_def vspace_at_asid_def)
+  apply (rule hoare_lift_Pf2 [where f="arch_state"])
+   apply wp+
+  done
+
+lemma set_pt_only_idle [wp]:
+  "\<lbrace>only_idle\<rbrace> set_pt p pt \<lbrace>\<lambda>_. only_idle\<rbrace>"
+  by (wp only_idle_lift)
+
+lemma pts_of_upd_idem:
+  "obj_ref \<noteq> pt_ptr \<Longrightarrow> pts_of (s\<lparr> kheap := (kheap s)(obj_ref := Some ko)\<rparr>) pt_ptr = pts_of s pt_ptr"
+  unfolding pt_of_def
+  by (clarsimp simp: opt_map_def split: option.splits)
+
+lemma pt_walk_eqI:
+  "\<lbrakk> \<forall>level' pt_ptr'.
+       level < level'
+       \<longrightarrow> pt_walk top_level level' pt_ptr vptr (\<lambda>p. pte_of p pts) = Some (level', pt_ptr')
+       \<longrightarrow> pts' pt_ptr' = pts pt_ptr';
+     is_aligned pt_ptr pt_bits \<rbrakk>
+   \<Longrightarrow> pt_walk top_level level pt_ptr vptr (\<lambda>p. pte_of p pts')
+      = pt_walk top_level level pt_ptr vptr (\<lambda>p. pte_of p pts)"
+  apply (induct top_level arbitrary: pt_ptr; clarsimp)
+  apply (subst pt_walk.simps)
+  apply (subst (2) pt_walk.simps)
+  apply clarsimp
+  apply (rule obind_eqI)
+   apply (simp (no_asm) add: pte_of_def)
+   apply (fastforce simp: obind_def split: option.split)
+  apply clarsimp
+  apply (rename_tac pte)
+  apply (drule_tac x="pptr_from_pte pte" in meta_spec)
+  apply (erule meta_impE; simp?)
+  apply clarsimp
+  apply (subgoal_tac "is_aligned pt_ptr pt_bits \<and> pts' pt_ptr = pts pt_ptr")
+   prefer 2
+   subgoal by simp
+  apply (erule_tac x=level' in allE, simp)
+  apply (erule_tac x=pt_ptr' in allE)
+  apply (erule impE; assumption?)
+  apply (subst pt_walk.simps)
+  apply (subgoal_tac "level' < top_level")
+   prefer 2
+   apply (fastforce dest!: pt_walk_max_level simp: le_less_trans)
+  apply (fastforce simp: pte_of_def in_omonad)
+  done
+
+lemma valid_vspace_obj_valid_pte_upd:
+  "\<lbrakk> valid_vspace_obj level (PageTable pt) s; valid_pte level pte s \<rbrakk>
+   \<Longrightarrow> valid_vspace_obj level (PageTable (pt(idx := pte))) s"
+  by (clarsimp simp: valid_vspace_obj_def split: if_splits)
+
+lemma pte_of_pt_slot_offset_of_empty_pt:
+  "\<lbrakk> pts pt_ptr = Some empty_pt; is_aligned pt_ptr pt_bits \<rbrakk>
+   \<Longrightarrow> pte_of (pt_slot_offset level pt_ptr vref) pts = Some InvalidPTE"
+  by (clarsimp simp: pte_of_def obind_def is_aligned_pt_slot_offset_pte)
+
+lemma pt_walk_non_empty_ptD:
+  "\<lbrakk> pt_walk level bot_level pt_ptr vref (\<lambda>pt. pte_of pt pts) = Some (level', p);
+     pts pt_ptr = Some pt; is_aligned pt_ptr pt_bits \<rbrakk>
+   \<Longrightarrow> (pt \<noteq> empty_pt \<or> (level' = level \<and> p = pt_ptr))"
+  apply (subst (asm) pt_walk.simps)
+  apply (case_tac "bot_level < level")
+   apply (clarsimp simp: in_omonad)
+   apply (prop_tac "v' = InvalidPTE")
+    apply (drule_tac vref=vref and level=level in pte_of_pt_slot_offset_of_empty_pt, clarsimp+)
+  done
+
+lemma pt_walk_pt_upd_idem:
+  "\<lbrakk> \<forall>level' pt_ptr'.
+       level < level'
+       \<longrightarrow> pt_walk top_level level' pt_ptr vptr (\<lambda>p. pte_of p pts) = Some (level', pt_ptr')
+       \<longrightarrow> pt_ptr' \<noteq> obj_ref;
+     is_aligned pt_ptr pt_bits \<rbrakk>
+   \<Longrightarrow> pt_walk top_level level pt_ptr vptr (\<lambda>p. pte_of p (pts(obj_ref := pt)))
+      = pt_walk top_level level pt_ptr vptr (\<lambda>p. pte_of p pts)"
+  by (rule pt_walk_eqI; auto)
+
+lemma pt_walk_upd_idem:
+  "\<lbrakk> \<forall>level' pt_ptr'.
+       level < level'
+       \<longrightarrow> pt_walk top_level level' pt_ptr vptr (ptes_of s) = Some (level', pt_ptr')
+       \<longrightarrow> pt_ptr' \<noteq> obj_ref;
+     is_aligned pt_ptr pt_bits \<rbrakk>
+   \<Longrightarrow> pt_walk top_level level pt_ptr vptr (ptes_of (s\<lparr>kheap := kheap s(obj_ref \<mapsto> ko)\<rparr>))
+      = pt_walk top_level level pt_ptr vptr (ptes_of s)"
+  by (rule pt_walk_eqI; simp split del: if_split)
+     (clarsimp simp: opt_map_def split: option.splits)
+
+lemma pt_walk_pt_None_updD:
+  "\<lbrakk> pt_walk top_level level pt_ptr vref (\<lambda>pa. pte_of pa ((pts_of s)(p := None))) =
+        Some (level', table_ptr) \<rbrakk>
+       \<Longrightarrow> pt_walk top_level level pt_ptr vref (ptes_of s) = Some (level', table_ptr)"
+  apply (induct top_level arbitrary: pt_ptr, clarsimp)
+  apply (subst pt_walk.simps)
+  apply (subst (asm) (3) pt_walk.simps)
+  apply (clarsimp simp: in_omonad split: if_splits)
+  apply (erule disjE; clarsimp?)
+   apply (rule_tac x=v' in exI; clarsimp)
+   apply (subst (asm) (3) pte_of_def)
+   apply (clarsimp simp: in_omonad split: if_splits)
+   apply (simp (no_asm) add: ptes_of_def in_monad obind_def)
+   apply (clarsimp split: option.splits simp: pts_of_ko_at obj_at_def)
+  apply (drule meta_spec)
+  apply (fastforce simp: pte_of_def in_omonad split: if_splits)
+  done
+
+lemma ptes_of_pt_None_updD:
+  "\<lbrakk> pte_of p' ((pts_of s)(p := None)) = Some pte \<rbrakk>
+   \<Longrightarrow> ptes_of s p' = Some pte"
+  by (clarsimp simp: opt_map_def pte_of_def in_omonad split: option.splits if_splits)
+
+lemma vs_lookup_table_eqI:
+  fixes s :: "'z::state_ext state"
+  fixes s' :: "'z::state_ext state"
+  shows
+  "\<lbrakk> \<forall>level p. bot_level < level
+               \<longrightarrow> vs_lookup_table level asid vref s = Some (level, p)
+               \<longrightarrow> (if level \<le> max_pt_level
+                   then pts_of s' p = pts_of s p
+                   else asid_pools_of s' p = asid_pools_of s p);
+     asid_table s' (asid_high_bits_of asid) = asid_table s (asid_high_bits_of asid);
+     pspace_aligned s; valid_vspace_objs s; valid_asid_table s \<rbrakk>
+   \<Longrightarrow> vs_lookup_table bot_level asid vref s' = vs_lookup_table bot_level asid vref s"
+  apply (case_tac "bot_level \<le> max_pt_level")
+   prefer 2
+   apply (clarsimp simp: asid_pool_level_eq[symmetric] vs_lookup_table_def in_omonad
+                         pool_for_asid_def)
+   apply (rule obind_eqI; fastforce simp: pool_for_asid_def)
+  apply (simp (no_asm) add: vs_lookup_table_def in_omonad)
+  apply (rule obind_eqI_full; simp add: pool_for_asid_def)
+  apply (rename_tac pool_ptr)
+  apply (rule obind_eqI_full; clarsimp)
+   apply (erule_tac x=asid_pool_level in allE)
+   apply (fastforce simp: pool_for_asid_vs_lookup pool_for_asid_def vspace_for_pool_def obind_def
+                          order.not_eq_order_implies_strict)
+  apply (rename_tac root)
+  apply (rule pt_walk_eqI)
+   apply clarsimp
+   apply (frule pt_walk_max_level)
+   apply (fastforce simp add: vs_lookup_table_def in_omonad asid_pool_level_eq pool_for_asid_def)
+  apply (rule vspace_for_pool_is_aligned; fastforce simp add: pool_for_asid_def)
+  done
+
+lemma vs_lookup_table_upd_idem:
+  "\<lbrakk> \<forall>level' p'.
+       level < level'
+       \<longrightarrow> vs_lookup_table  level' asid vref s = Some (level', p')
+       \<longrightarrow> p' \<noteq> obj_ref;
+     pspace_aligned s; valid_vspace_objs s; valid_asid_table s \<rbrakk>
+   \<Longrightarrow> vs_lookup_table level asid vref (s\<lparr>kheap := kheap s(obj_ref \<mapsto> ko)\<rparr>)
+      = vs_lookup_table level asid vref s"
+  by (rule vs_lookup_table_eqI; simp split del: if_split)
+     (clarsimp simp: opt_map_def split: option.splits)
+
+lemma vs_lookup_table_Some_upd_idem:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, obj_ref);
+     vref \<in> user_region; pspace_aligned s; valid_vspace_objs s; valid_asid_table s;
+     unique_table_refs s; valid_vs_lookup s; valid_caps (caps_of_state s) s \<rbrakk>
+   \<Longrightarrow> vs_lookup_table level asid vref (s\<lparr>kheap := kheap s(obj_ref \<mapsto> ko)\<rparr>)
+      = vs_lookup_table level asid vref s"
+  by (subst vs_lookup_table_upd_idem; simp?)
+     (fastforce dest: no_loop_vs_lookup_table)
+
+lemma ex_vs_lookup_upd_idem:
+  "\<lbrakk> \<exists>\<rhd> (level, p) s;
+     pspace_aligned s; valid_vspace_objs s; valid_asid_table s; unique_table_refs s;
+     valid_vs_lookup s; valid_caps (caps_of_state s) s \<rbrakk>
+   \<Longrightarrow> \<exists>\<rhd> (level, p) (s\<lparr>kheap := kheap s(p \<mapsto> ko)\<rparr>) = \<exists>\<rhd> (level, p) s"
+  apply (rule iffI; clarsimp)
+  apply (rule_tac x=asid in exI)
+  apply (rule_tac x=vref in exI)
+  apply (subst vs_lookup_table_Some_upd_idem; fastforce)
+  done
+
+lemma pt_lookup_target_translate_address_upd_eq:
+  "\<lbrakk> pt_lookup_target 0 pt_ptr vref ptes' = pt_lookup_target 0 pt_ptr vref ptes \<rbrakk>
+   \<Longrightarrow> translate_address pt_ptr vref ptes' = translate_address pt_ptr vref ptes"
+  unfolding translate_address_def
+  by (simp add: obind_def split: option.splits)
+
+lemma pt_lookup_target_slot_from_level_eq:
+  "\<lbrakk> pt_lookup_slot_from_level max_pt_level level pt_ptr vref ptes'
+     = pt_lookup_slot_from_level max_pt_level level pt_ptr vref ptes;
+     \<And>level' slot. pt_lookup_slot_from_level max_pt_level level pt_ptr vref ptes = Some (level', slot)
+                   \<Longrightarrow> (ptes' |> pte_ref) slot = (ptes |> pte_ref) slot \<rbrakk>
+   \<Longrightarrow> pt_lookup_target level pt_ptr vref ptes' = pt_lookup_target level pt_ptr vref ptes"
+  unfolding pt_lookup_target_def
+  by (fastforce simp: obind_def opt_map_def split: option.splits)
+
+lemma pt_walk_Some_finds_pt:
+  "\<lbrakk> pt_walk top_level level pt_ptr vptr (\<lambda>p. pte_of p pts) = Some (level, pt_ptr');
+     level < top_level; is_aligned pt_ptr pt_bits \<rbrakk>
+   \<Longrightarrow> pts pt_ptr \<noteq> None"
+  apply (subst (asm) pt_walk.simps)
+  apply (clarsimp simp add: in_omonad split: if_splits)
+  apply (fastforce simp: is_PageTablePTE_def pte_of_def in_omonad split: if_splits)
+  done
+
+lemma pte_of_pt_slot_offset_upd_idem:
+  "\<lbrakk> is_aligned pt_ptr pt_bits; obj_ref \<noteq> pt_ptr \<rbrakk>
+   \<Longrightarrow> pte_of (pt_slot_offset level pt_ptr vptr) (pts(obj_ref := pt'))
+      = pte_of (pt_slot_offset level pt_ptr vptr) pts"
+  unfolding pte_of_def
+  by (rule obind_eqI; clarsimp simp: in_omonad)+
+
+lemma pt_lookup_target_pt_eqI:
+  "\<lbrakk> \<forall>level' pt_ptr'.
+       pt_walk max_pt_level level' pt_ptr vptr (\<lambda>p. pte_of p pts) = Some (level', pt_ptr')
+       \<longrightarrow> pts' pt_ptr' = pts pt_ptr';
+     is_aligned pt_ptr pt_bits; level \<le> max_pt_level \<rbrakk>
+   \<Longrightarrow> pt_lookup_target level pt_ptr vptr (\<lambda>p. pte_of p pts')
+      = pt_lookup_target level pt_ptr vptr (\<lambda>p. pte_of p pts)"
+  apply (simp (no_asm) add: pt_lookup_target_def pt_lookup_slot_from_level_def obind_assoc)
+  apply (subgoal_tac "pt_walk max_pt_level level pt_ptr vptr (\<lambda>p. pte_of p pts')
+                      = pt_walk max_pt_level level pt_ptr vptr (\<lambda>p. pte_of p pts)")
+   prefer 2
+   apply (rule pt_walk_eqI; assumption?)
+   apply (intro allI impI)
+   apply (erule_tac x=level' in allE)
+   apply fastforce
+  apply (rule obind_eqI, assumption)
+  apply (rule obind_eqI; clarsimp)
+  apply (rule obind_eqI; clarsimp)
+   apply (rename_tac level'' pt_ptr'')
+   apply (drule sym)
+   apply (frule pt_walk_level)
+   apply (erule_tac x=level'' in allE)
+   apply (erule_tac x=pt_ptr'' in allE)
+   apply clarsimp
+   apply (subst pte_of_def)+
+   apply (clarsimp simp: obind_def pt_walk_is_aligned split: option.splits)
+  apply (rule obind_eqI; clarsimp)
+  done
+
+lemma pt_lookup_target_pt_upd_eq:
+  "\<lbrakk> \<forall>level' pt_ptr'.
+       pt_walk max_pt_level level' pt_ptr vptr (\<lambda>p. pte_of p pts) = Some (level', pt_ptr')
+       \<longrightarrow> pt_ptr' \<noteq> obj_ref;
+     is_aligned pt_ptr pt_bits; level \<le> max_pt_level \<rbrakk>
+   \<Longrightarrow> pt_lookup_target level pt_ptr vptr (\<lambda>p. pte_of p (pts(obj_ref := pt')))
+      = pt_lookup_target level pt_ptr vptr (\<lambda>p. pte_of p pts)"
+  by (rule pt_lookup_target_pt_eqI; clarsimp)
+
+lemma kheap_pt_upd_simp[simp]:
+  "(kheap s(p \<mapsto> ArchObj (PageTable pt)) |> aobj_of |> pt_of)
+   = (kheap s |> aobj_of |> pt_of)(p \<mapsto> pt)"
+  unfolding aobj_of_def opt_map_def
+  by (auto split: kernel_object.split)
+
+lemma valid_global_tablesD:
+  "\<lbrakk> valid_global_tables s;
+     pt_walk max_pt_level bot_level (riscv_global_pt (arch_state s)) vref (ptes_of s)
+     = Some (level, pt_ptr) \<rbrakk>
+   \<Longrightarrow> vref \<in> kernel_mappings \<longrightarrow> pt_ptr \<in> riscv_global_pts (arch_state s) level"
+  unfolding valid_global_tables_def by (simp add: Let_def riscv_global_pt_def)
+
+lemma riscv_global_pt_aligned[simp]:
+  "\<lbrakk> pspace_aligned s ; valid_global_arch_objs s \<rbrakk>
+   \<Longrightarrow> is_aligned (riscv_global_pt (arch_state s)) pt_bits"
+  apply (clarsimp simp add: valid_global_arch_objs_def)
+  apply (rule is_aligned_pt; assumption?)
+  apply (fastforce simp: riscv_global_pt_def)
+  done
+
+lemma riscv_global_pt_in_global_refs[simp]:
+  "valid_global_arch_objs s \<Longrightarrow> riscv_global_pt (arch_state s) \<in> global_refs s"
+  unfolding riscv_global_pt_def global_refs_def valid_global_arch_objs_def
+  by fastforce
+
+lemma kernel_regionsI:
+  "p \<in> kernel_elf_window s \<Longrightarrow> p \<in> kernel_regions s"
+  "p \<in> kernel_window s \<Longrightarrow> p \<in> kernel_regions s"
+  "p \<in> kernel_device_window s \<Longrightarrow> p \<in> kernel_regions s"
+  unfolding kernel_regions_def
+  by auto
+
+lemma riscv_global_pts_aligned:
+  "\<lbrakk> pt_ptr \<in> riscv_global_pts (arch_state s) level; pspace_aligned s; valid_global_arch_objs s \<rbrakk>
+   \<Longrightarrow> is_aligned pt_ptr pt_bits"
+  unfolding valid_global_arch_objs_def
+  by (fastforce dest: pspace_aligned_pts_ofD simp: pt_at_eq)
+
+(* FIXME MOVE, might break proofs elsewhere *)
+lemma if_Some_Some[simp]:
+  "((if P then Some v else None) = Some v) = P"
+  by simp
+
+lemma user_region_canonical_pptr_base:
+  "\<lbrakk> p \<notin> user_region; canonical_address p \<rbrakk> \<Longrightarrow> pptr_base \<le> p"
+  using canonical_below_pptr_base_canonical_user word_le_not_less
+  by (auto simp add: user_region_def not_le)
+
+lemma kernel_regions_pptr_base:
+  "\<lbrakk> p \<in> kernel_regions s; valid_uses s \<rbrakk> \<Longrightarrow> pptr_base \<le> p"
+  apply (rule user_region_canonical_pptr_base)
+   apply (simp add: valid_uses_def window_defs)
+   apply (erule_tac x=p in allE)
+   apply auto[1]
+  apply (simp add: valid_uses_def window_defs)
+  apply (erule_tac x=p in allE)
+  apply auto[1]
+  done
+
+lemma kernel_regions_in_mappings:
+  "\<lbrakk> p \<in> kernel_regions s; valid_uses s \<rbrakk> \<Longrightarrow> p \<in> kernel_mappings"
+  apply (frule (1) kernel_regions_pptr_base)
+  unfolding kernel_regions_def kernel_elf_window_def valid_uses_def kernel_device_window_def
+            kernel_mappings_def kernel_window_def
+  by (erule_tac x=p in allE) (auto simp: not_le canonical_below_pptr_base_canonical_user)
+
+lemma set_pt_valid_global_vspace_mappings:
+  "\<lbrace>\<lambda>s. valid_global_vspace_mappings s \<and> valid_global_tables s \<and> p \<notin> global_refs s
+        \<and> pspace_aligned s \<and> valid_global_arch_objs s \<and> valid_uses s \<rbrace>
+   set_pt p pt
+   \<lbrace>\<lambda>rv. valid_global_vspace_mappings\<rbrace>"
+  apply (simp add: set_pt_def)
+  apply (wpsimp wp: set_object_wp)
+  unfolding valid_global_vspace_mappings_def Let_def
+  apply (safe; clarsimp; drule (1) bspec; thin_tac "Ball _ _")
+   (* we don't care about whether we're in kernel window or kernel_elf_window *)
+   apply (all \<open>drule kernel_regionsI, erule option_Some_value_independent\<close>)
+   apply (distinct_subgoals)
+  apply (subst pt_lookup_target_translate_address_upd_eq; assumption?)
+  apply (clarsimp simp: translate_address_def in_omonad)
+  apply (rename_tac level p')
+  apply (subst pt_lookup_target_pt_upd_eq)
+     apply clarsimp
+     apply (frule valid_global_tablesD)
+      apply assumption
+     apply (clarsimp simp: kernel_regions_in_mappings)
+     apply (clarsimp simp: global_refs_def)
+    apply (fastforce dest: riscv_global_pts_aligned)
+   apply fastforce
+  apply fastforce
+  done
+
+lemma store_pte_valid_global_vspace_mappings:
+  "\<lbrace>\<lambda>s. valid_global_vspace_mappings s \<and> valid_global_tables s \<and> table_base p \<notin> global_refs s
+        \<and> pspace_aligned s \<and> valid_global_arch_objs s \<and> valid_uses s \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>rv. valid_global_vspace_mappings\<rbrace>"
+  unfolding store_pte_def
+  by (wpsimp wp: set_pt_valid_global_vspace_mappings)
+
+lemma set_pt_kernel_window[wp]:
+  "\<lbrace>pspace_in_kernel_window\<rbrace> set_pt p pt \<lbrace>\<lambda>rv. pspace_in_kernel_window\<rbrace>"
+  apply (simp add: set_pt_def)
+  apply (wp set_object_pspace_in_kernel_window get_object_wp)
+  apply (clarsimp simp: obj_at_def a_type_def
+                 split: kernel_object.split_asm
+                        arch_kernel_obj.split_asm)
+  done
+
+lemma set_pt_respects_device_region[wp]:
+  "\<lbrace>pspace_respects_device_region\<rbrace> set_pt p pt \<lbrace>\<lambda>rv. pspace_respects_device_region\<rbrace>"
+  apply (simp add: set_pt_def)
+  apply (wp set_object_pspace_respects_device_region get_object_wp)
+  apply (clarsimp simp: obj_at_def a_type_def
+                 split: Structures_A.kernel_object.split_asm
+                        arch_kernel_obj.split_asm)
+  done
+
+lemma set_pt_caps_in_kernel_window[wp]:
+  "\<lbrace>cap_refs_in_kernel_window\<rbrace> set_pt p pt \<lbrace>\<lambda>rv. cap_refs_in_kernel_window\<rbrace>"
+  apply (simp add: set_pt_def)
+  apply (wp set_object_cap_refs_in_kernel_window get_object_wp)
+  apply (clarsimp simp: obj_at_def a_type_def
+                 split: kernel_object.split_asm
+                        arch_kernel_obj.split_asm)
+  done
+
+lemma set_pt_caps_respects_device_region[wp]:
+  "\<lbrace>cap_refs_respects_device_region\<rbrace> set_pt p pt \<lbrace>\<lambda>rv. cap_refs_respects_device_region\<rbrace>"
+  apply (simp add: set_pt_def)
+  apply (wp set_object_cap_refs_respects_device_region get_object_wp)
+  apply (clarsimp simp: obj_at_def a_type_def
+                 split: Structures_A.kernel_object.split_asm
+                        arch_kernel_obj.split_asm)
+  done
+
+
+lemma set_pt_valid_ioc[wp]:
+  "\<lbrace>valid_ioc\<rbrace> set_pt p pt \<lbrace>\<lambda>_. valid_ioc\<rbrace>"
+  apply (simp add: set_pt_def)
+  apply (wp set_object_valid_ioc_no_caps get_object_wp)
+  by (clarsimp simp: a_type_simps obj_at_def is_tcb is_cap_table
+              split: kernel_object.splits arch_kernel_obj.splits)
+
+
+
+lemma valid_machine_stateE:
+  assumes vm: "valid_machine_state s"
+  assumes e: "\<lbrakk>in_user_frame p s
+    \<or> underlying_memory (machine_state s) p = 0 \<rbrakk> \<Longrightarrow> E "
+  shows E
+  using vm
+  apply (clarsimp simp: valid_machine_state_def)
+  apply (drule_tac x = p in spec)
+  apply (rule e)
+  apply auto
+  done
+
+lemma in_user_frame_same_type_upd:
+  "\<lbrakk>typ_at type p s; type = a_type obj; in_user_frame q s\<rbrakk>
+    \<Longrightarrow> in_user_frame q (s\<lparr>kheap := kheap s(p \<mapsto> obj)\<rparr>)"
+  apply (clarsimp simp: in_user_frame_def obj_at_def)
+  apply (rule_tac x=sz in exI)
+  apply (auto simp: a_type_simps)
+  done
+
+lemma in_device_frame_same_type_upd:
+  "\<lbrakk>typ_at type p s; type = a_type obj ; in_device_frame q s\<rbrakk>
+    \<Longrightarrow> in_device_frame q (s\<lparr>kheap := kheap s(p \<mapsto> obj)\<rparr>)"
+  apply (clarsimp simp: in_device_frame_def obj_at_def)
+  apply (rule_tac x=sz in exI)
+  apply (auto simp: a_type_simps)
+  done
+
+lemma store_word_offs_in_user_frame[wp]:
+  "\<lbrace>\<lambda>s. in_user_frame p s\<rbrace> store_word_offs a x w \<lbrace>\<lambda>_ s. in_user_frame p s\<rbrace>"
+  unfolding in_user_frame_def
+  by (wp hoare_vcg_ex_lift)
+
+lemma store_word_offs_in_device_frame[wp]:
+  "\<lbrace>\<lambda>s. in_device_frame p s\<rbrace> store_word_offs a x w \<lbrace>\<lambda>_ s. in_device_frame p s\<rbrace>"
+  unfolding in_device_frame_def
+  by (wp hoare_vcg_ex_lift)
+
+
+lemma as_user_in_user_frame[wp]:
+  "\<lbrace>\<lambda>s. in_user_frame p s\<rbrace> as_user t m \<lbrace>\<lambda>_ s. in_user_frame p s\<rbrace>"
+  unfolding in_user_frame_def
+  by (wp hoare_vcg_ex_lift)
+
+lemma as_user_in_device_frame[wp]:
+  "\<lbrace>\<lambda>s. in_device_frame p s\<rbrace> as_user t m \<lbrace>\<lambda>_ s. in_device_frame p s\<rbrace>"
+  unfolding in_device_frame_def
+  by (wp hoare_vcg_ex_lift)
+
+crunch obj_at[wp]: load_word_offs "\<lambda>s. P (obj_at Q p s)"
+
+lemma load_word_offs_in_user_frame[wp]:
+  "\<lbrace>\<lambda>s. in_user_frame p s\<rbrace> load_word_offs a x \<lbrace>\<lambda>_ s. in_user_frame p s\<rbrace>"
+  unfolding in_user_frame_def
+  by (wp hoare_vcg_ex_lift)
+
+lemma valid_machine_state_heap_updI:
+assumes vm : "valid_machine_state s"
+assumes tyat : "typ_at type p s"
+shows
+  " a_type obj = type \<Longrightarrow> valid_machine_state (s\<lparr>kheap := kheap s(p \<mapsto> obj)\<rparr>)"
+  apply (clarsimp simp: valid_machine_state_def)
+  subgoal for p
+   apply (rule valid_machine_stateE[OF vm,where p = p])
+   apply (elim disjE,simp_all)
+   apply (drule(1) in_user_frame_same_type_upd[OF tyat])
+    apply simp+
+   done
+  done
+
+lemma set_pt_vms[wp]:
+  "\<lbrace>valid_machine_state\<rbrace> set_pt p pt \<lbrace>\<lambda>_. valid_machine_state\<rbrace>"
+  apply (simp add: set_pt_def set_object_def)
+  apply (wp get_object_wp)
+  apply clarify
+  apply (erule valid_machine_state_heap_updI)
+   apply (fastforce simp: obj_at_def a_type_def
+                   split: kernel_object.splits arch_kernel_obj.splits)+
+  done
+
+crunch valid_irq_states[wp]: set_pt "valid_irq_states"
+  (wp: crunch_wps)
+
+
+(* FIXME: move to ArchInvariants_A *)
+lemma valid_asid_table_ran:
+  "valid_asid_table s \<Longrightarrow> \<forall>p\<in>ran (asid_table s). asid_pool_at p s"
+  unfolding invs_def valid_state_def valid_arch_state_def valid_asid_table_def
+  by (fastforce simp: opt_map_def obj_at_def split: option.splits)
+
+lemmas invs_ran_asid_table = invs_valid_asid_table[THEN valid_asid_table_ran]
+
+
+lemma set_asid_pool_iflive [wp]:
+  "\<lbrace>\<lambda>s. if_live_then_nonz_cap s\<rbrace>
+  set_asid_pool p ap
+  \<lbrace>\<lambda>_ s. if_live_then_nonz_cap s\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  apply (wp get_object_wp set_object_iflive)
+  apply (clarsimp split: kernel_object.splits arch_kernel_obj.splits)
+  apply (clarsimp simp: obj_at_def live_def hyp_live_def)
+  done
+
+
+lemma set_asid_pool_zombies [wp]:
+  "\<lbrace>\<lambda>s. zombies_final s\<rbrace>
+  set_asid_pool p ap
+  \<lbrace>\<lambda>_ s. zombies_final s\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  apply (wp get_object_wp set_object_zombies)
+  apply (clarsimp split: kernel_object.splits arch_kernel_obj.splits)
+  apply (clarsimp simp: obj_at_def)
+  done
+
+
+lemma set_asid_pool_zombies_state_refs [wp]:
+  "\<lbrace>\<lambda>s. P (state_refs_of s)\<rbrace>
+  set_asid_pool p ap
+  \<lbrace>\<lambda>_ s. P (state_refs_of s)\<rbrace>"
+  apply (clarsimp simp: set_asid_pool_def set_object_def)
+  apply (wp get_object_wp)
+  apply (clarsimp split: kernel_object.splits arch_kernel_obj.splits)
+  apply (erule rsubst [where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: obj_at_def state_refs_of_def split: option.splits)
+  done
+
+lemma set_asid_pool_zombies_state_hyp_refs [wp]:
+  "\<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>
+  set_asid_pool p ap
+  \<lbrace>\<lambda>_ s. P (state_hyp_refs_of s)\<rbrace>"
+  apply (wpsimp simp: set_asid_pool_def wp: get_object_wp set_object_wp)
+  apply (erule rsubst [where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: obj_at_def state_hyp_refs_of_def split: option.splits)
+  done
+
+lemma set_asid_pool_cdt [wp]:
+  "\<lbrace>\<lambda>s. P (cdt s)\<rbrace>
+  set_asid_pool p ap
+  \<lbrace>\<lambda>_ s. P (cdt s)\<rbrace>"
+  unfolding set_asid_pool_def including unfold_objects
+  by wpsimp
+
+lemma set_asid_pool_caps_of_state [wp]:
+  "\<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace> set_asid_pool p ap \<lbrace>\<lambda>_ s. P (caps_of_state s)\<rbrace>"
+  unfolding set_asid_pool_def set_object_def including unfold_objects
+  apply wpsimp
+  apply (subst cte_wp_caps_of_lift)
+   prefer 2
+   apply assumption
+  subgoal for _ _ y by (cases y, auto simp: cte_wp_at_cases)
+  done
+
+lemma set_asid_pool_valid_mdb [wp]:
+  "\<lbrace>\<lambda>s. valid_mdb s\<rbrace>
+  set_asid_pool p ap
+  \<lbrace>\<lambda>_ s. valid_mdb s\<rbrace>"
+  including unfold_objects
+  by (wpsimp wp: valid_mdb_lift simp: set_asid_pool_def set_object_def)
+
+
+lemma set_asid_pool_valid_idle [wp]:
+  "\<lbrace>\<lambda>s. valid_idle s\<rbrace>
+  set_asid_pool p ap
+  \<lbrace>\<lambda>_ s. valid_idle s\<rbrace>"
+  including unfold_objects
+  by (wpsimp wp: valid_idle_lift simp: set_asid_pool_def)
+
+
+lemma set_asid_pool_ifunsafe [wp]:
+  "\<lbrace>\<lambda>s. if_unsafe_then_cap s\<rbrace>
+  set_asid_pool p ap
+  \<lbrace>\<lambda>_ s. if_unsafe_then_cap s\<rbrace>"
+  including unfold_objects
+  by (wpsimp simp: set_asid_pool_def)
+
+
+lemma set_asid_pool_reply_caps [wp]:
+  "\<lbrace>\<lambda>s. valid_reply_caps s\<rbrace>
+  set_asid_pool p ap
+  \<lbrace>\<lambda>_ s. valid_reply_caps s\<rbrace>"
+  by (wp valid_reply_caps_st_cte_lift)
+
+
+lemma set_asid_pool_reply_masters [wp]:
+  "\<lbrace>valid_reply_masters\<rbrace>
+   set_asid_pool p ap
+   \<lbrace>\<lambda>_. valid_reply_masters\<rbrace>"
+  by (wp valid_reply_masters_cte_lift)
+
+
+crunch global_ref [wp]: set_asid_pool "\<lambda>s. P (global_refs s)"
+  (wp: crunch_wps)
+
+
+crunch idle [wp]: set_asid_pool "\<lambda>s. P (idle_thread s)"
+  (wp: crunch_wps)
+
+
+crunch irq [wp]: set_asid_pool "\<lambda>s. P (interrupt_irq_node s)"
+  (wp: crunch_wps)
+
+crunch valid_irq_states[wp]: set_asid_pool "valid_irq_states"
+  (wp: crunch_wps)
+
+lemma set_asid_pool_valid_global [wp]:
+  "\<lbrace>\<lambda>s. valid_global_refs s\<rbrace>
+  set_asid_pool p ap
+  \<lbrace>\<lambda>_ s. valid_global_refs s\<rbrace>"
+  by (wp valid_global_refs_cte_lift)
+
+
+crunch interrupt_states[wp]: set_asid_pool "\<lambda>s. P (interrupt_states s)"
+  (wp: crunch_wps)
+
+lemma vs_lookup_table_unreachable_upd_idem:
+  "\<lbrakk> \<forall>level. vs_lookup_table level asid vref s \<noteq> Some (level, obj_ref);
+     vref \<in> user_region; pspace_aligned s; valid_vspace_objs s; valid_asid_table s \<rbrakk>
+   \<Longrightarrow> vs_lookup_table level asid vref (s\<lparr>kheap := kheap s(obj_ref \<mapsto> ko)\<rparr>)
+      = vs_lookup_table level asid vref s"
+  apply (subst vs_lookup_table_upd_idem; fastforce)
+  done
+
+lemma vs_lookup_table_unreachable_upd_idem':
+  "\<lbrakk> \<not>(\<exists>level. \<exists>\<rhd> (level, obj_ref) s);
+     vref \<in> user_region; pspace_aligned s; valid_vspace_objs s; valid_asid_table s \<rbrakk>
+   \<Longrightarrow> vs_lookup_table level asid vref (s\<lparr>kheap := kheap s(obj_ref \<mapsto> ko)\<rparr>)
+      = vs_lookup_table level asid vref s"
+  by (rule vs_lookup_table_unreachable_upd_idem; fastforce)
+
+lemma vs_lookup_target_unreachable_upd_idem:
+  "\<lbrakk> \<forall>level. vs_lookup_table level asid vref s \<noteq> Some (level, obj_ref);
+     vref \<in> user_region; pspace_aligned s; valid_vspace_objs s; valid_asid_table s \<rbrakk>
+   \<Longrightarrow> vs_lookup_target level asid vref (s\<lparr>kheap := kheap s(obj_ref \<mapsto> ko)\<rparr>)
+      = vs_lookup_target level asid vref s"
+  supply fun_upd_apply[simp del]
+  apply (clarsimp simp: vs_lookup_target_def vs_lookup_slot_def obind_assoc)
+  apply (rule obind_eqI_full)
+   apply (subst vs_lookup_table_upd_idem; fastforce)
+  apply (clarsimp split del: if_split)
+  apply (rename_tac level' p)
+  apply (rule obind_eqI, fastforce)
+  apply (clarsimp split del: if_split)
+  apply (rule obind_eqI[rotated], fastforce)
+  apply (clarsimp split: if_splits)
+   (* level' = asid_pool_level *)
+   apply (rename_tac pool_ptr)
+   apply (drule vs_lookup_level, drule vs_lookup_level)
+   apply (clarsimp simp: pool_for_asid_vs_lookup vspace_for_pool_def in_omonad)
+   apply (rule obind_eqI[rotated], fastforce)
+   apply (case_tac "pool_ptr = obj_ref"; clarsimp)
+    apply (erule_tac x=asid_pool_level in allE)
+    apply (fastforce simp: pool_for_asid_vs_lookup)
+   apply (fastforce simp: fun_upd_def opt_map_def split: option.splits)
+  (* level' \<le> max_pt_level *)
+  apply (rule conjI, clarsimp)
+  apply (rename_tac pt_ptr level')
+   apply (case_tac "pt_ptr = obj_ref")
+    apply (fastforce dest: vs_lookup_level)
+   apply (rule pte_refs_of_eqI, rule ptes_of_eqI)
+   apply (prop_tac "is_aligned pt_ptr pt_bits")
+    apply (erule vs_lookup_table_is_aligned; fastforce)
+   apply (clarsimp simp: fun_upd_def opt_map_def split: option.splits)
+  done
+
+lemma vs_lookup_target_unreachable_upd_idem':
+  "\<lbrakk> \<not>(\<exists>level. \<exists>\<rhd> (level, obj_ref) s);
+     vref \<in> user_region; pspace_aligned s; valid_vspace_objs s; valid_asid_table s \<rbrakk>
+   \<Longrightarrow> vs_lookup_target level asid vref (s\<lparr>kheap := kheap s(obj_ref \<mapsto> ko)\<rparr>)
+      = vs_lookup_target level asid vref s"
+   by (rule vs_lookup_target_unreachable_upd_idem; fastforce)
+
+lemma vs_lookup_table_fun_upd_deep_idem:
+  "\<lbrakk> vs_lookup_table level asid vref (s\<lparr>kheap := kheap s(p \<mapsto> ko)\<rparr>) = Some (level, p');
+     vs_lookup_table level' asid vref s = Some (level', p);
+     level' \<le> level; vref \<in> user_region; unique_table_refs s; valid_vs_lookup s;
+     valid_vspace_objs s; valid_asid_table s; pspace_aligned s; valid_caps (caps_of_state s) s \<rbrakk>
+   \<Longrightarrow> vs_lookup_table level asid vref s = Some (level, p')"
+  apply (case_tac "level=asid_pool_level")
+   apply (simp add: pool_for_asid_vs_lookup pool_for_asid_def)
+  apply clarsimp
+  apply (subst (asm) vs_lookup_table_upd_idem; simp?)
+  apply clarsimp
+  apply (drule (1) no_loop_vs_lookup_table; simp?)
+  done
+
+lemma set_asid_pool_vspace_objs_unmap':
+  "\<lbrace>valid_vspace_objs and
+    (\<lambda>s. (\<exists>\<rhd> (asid_pool_level, p) s \<longrightarrow> valid_vspace_obj asid_pool_level (ASIDPool ap) s)) and
+    obj_at (\<lambda>ko. \<exists>ap'. ko = ArchObj (ASIDPool ap') \<and> graph_of ap \<subseteq> graph_of ap') p and
+    valid_asid_table and pspace_aligned \<rbrace>
+  set_asid_pool p ap \<lbrace>\<lambda>_. valid_vspace_objs\<rbrace>"
+  unfolding valid_vspace_objs_def set_asid_pool_def
+  supply fun_upd_apply[simp del]
+  apply (wp set_object_wp)
+  apply (clarsimp simp: obj_at_def)
+  apply (rename_tac pt_ptr ao)
+  apply (subgoal_tac "vs_lookup_table bot_level asid vref s = Some (level, pt_ptr)")
+   apply (prop_tac "valid_vspace_objs s", fastforce simp: valid_vspace_objs_def)
+   apply (erule_tac x=bot_level in allE)
+   apply (erule_tac x=asid in allE)
+   apply (erule_tac x=vref in allE)
+   apply clarsimp
+   apply (case_tac "level = asid_pool_level")
+    apply (clarsimp simp: aobjs_of_ako_at_Some obj_at_def fun_upd_apply)
+    apply (clarsimp split: if_splits)
+     (* pt_ptr = p *)
+     apply (drule vs_lookup_level, drule vs_lookup_level)
+     apply (fastforce simp: aobjs_of_ako_at_Some obj_at_def fun_upd_apply)
+    (* pt_ptr \<noteq> p *)
+    apply (clarsimp simp: aobjs_of_ako_at_Some obj_at_def fun_upd_apply)
+    apply (erule (1) valid_vspace_obj_same_type, simp)
+   (* level \<le> max_pt_level *)
+   apply clarsimp
+   apply (drule vs_lookup_level, drule vs_lookup_level)
+   apply (drule (5) vs_lookup_table_pt_at)
+   apply (case_tac "pt_ptr = p"; simp add: aobjs_of_ako_at_Some)
+    apply (clarsimp simp: aobjs_of_ako_at_Some obj_at_def fun_upd_apply fun_upd_def)
+   apply (clarsimp simp: fun_upd_apply split: if_splits)
+   apply (clarsimp simp: aobjs_of_ako_at_Some obj_at_def fun_upd_apply
+                    simp del: valid_vspace_obj.simps)
+   apply (erule (1) valid_vspace_obj_same_type, simp)
+  apply (case_tac "bot_level = asid_pool_level")
+   apply (clarsimp simp: pool_for_asid_vs_lookup pool_for_asid_def)
+  apply (clarsimp simp: vs_lookup_table_def in_omonad asid_pool_level_neq[THEN iffD2] pool_for_asid_def)
+  apply (drule pt_walk_pt_None_updD)
+  apply (rename_tac pool_ptr root)
+  apply (clarsimp simp: vspace_for_pool_def in_omonad fun_upd_apply)
+  apply (case_tac "pool_ptr = p"; clarsimp simp: asid_pools_of_ko_at obj_at_def)
+   apply (fastforce elim: graph_of_SomeD)
+  done
+
+lemma set_asid_pool_vspace_objs_unmap:
+  "\<lbrace>valid_vspace_objs and ko_at (ArchObj (ASIDPool ap)) p and
+    valid_asid_table and pspace_aligned\<rbrace>
+  set_asid_pool p (ap |` S)  \<lbrace>\<lambda>_. valid_vspace_objs\<rbrace>"
+  apply (wp set_asid_pool_vspace_objs_unmap')
+  apply (clarsimp simp: obj_at_def graph_of_restrict_map)
+  apply (drule valid_vspace_objsD, assumption, assumption, simp add: obj_at_def in_opt_map_eq)
+  by (auto simp: obj_at_def dest!: ran_restrictD)
+
+lemma set_asid_pool_table_caps[wp]:
+  "\<lbrace>valid_table_caps\<rbrace> set_asid_pool p ap \<lbrace>\<lambda>_. valid_table_caps\<rbrace>"
+  apply (simp add: valid_table_caps_def)
+  apply (rule hoare_lift_Pf2 [where f=caps_of_state];wp?)
+  done
+
+lemma vs_lookup_target_asid_pool_levelI:
+  "\<lbrakk> pool_for_asid asid s = Some pool; ako_at (ASIDPool ap) pool s;
+     ap (asid_low_bits_of asid) = Some pt_ptr \<rbrakk>
+   \<Longrightarrow> vs_lookup_target asid_pool_level asid vref s = Some (asid_pool_level, pt_ptr)"
+  apply (clarsimp simp: vs_lookup_target_def in_omonad)
+  apply (clarsimp simp: pool_for_asid_vs_lookup vspace_for_pool_def vs_lookup_slot_def in_omonad)
+  apply (rule_tac x=ap in exI)
+  apply (fastforce simp: obj_at_def)
+  done
+
+lemma vs_lookup_target_pt_levelI:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, pt_ptr);
+     pte_refs_of s (pt_slot_offset level pt_ptr vref) = Some target;
+     level \<le> max_pt_level \<rbrakk>
+   \<Longrightarrow> vs_lookup_target level asid vref s = Some (level, target)"
+  by (clarsimp simp: vs_lookup_target_def in_omonad vs_lookup_slot_def asid_pool_level_neq[THEN iffD2])
+
+lemma vs_lookup_target_asid_pool_level_upd_helper:
+  "\<lbrakk> graph_of ap \<subseteq> graph_of ap'; kheap s p = Some (ArchObj (ASIDPool ap')); vref \<in> user_region;
+     vspace_for_pool pool_ptr asid (asid_pools_of s(p \<mapsto> ap)) = Some pt_ptr;
+     pool_for_asid asid (s\<lparr>kheap := kheap s(p \<mapsto> ArchObj (ASIDPool ap))\<rparr>) = Some pool_ptr\<rbrakk>
+   \<Longrightarrow> vs_lookup_target asid_pool_level asid vref s = Some (asid_pool_level, pt_ptr)"
+  apply (clarsimp simp: pool_for_asid_vs_lookup vspace_for_pool_def in_omonad)
+  apply (clarsimp split: if_splits)
+   apply (rule vs_lookup_target_asid_pool_levelI)
+   apply (fastforce simp: pool_for_asid_def obj_at_def dest: graph_of_SomeD)+
+  apply (rule vs_lookup_target_asid_pool_levelI
+         ; fastforce simp: pool_for_asid_def obj_at_def vs_lookup_target_def in_omonad)
+  done
+
+lemma vs_lookup_target_None_upd_helper:
+  "\<lbrakk> vs_lookup_table level asid vref (s\<lparr>kheap := kheap s(p \<mapsto> ArchObj (ASIDPool ap))\<rparr>) =
+        Some (level, table_ptr);
+     ((\<lambda>pa. pte_of pa ((pts_of s)(p := None))) |> pte_ref) (pt_slot_offset level table_ptr vref)
+       = Some target;
+     kheap s p = Some (ArchObj (ASIDPool ap')); graph_of ap \<subseteq> graph_of ap';
+     level \<le> max_pt_level \<rbrakk>
+   \<Longrightarrow> vs_lookup_target level asid vref s = Some (level, target)"
+  apply (subst (asm) vs_lookup_split_max_pt_level_Some, assumption)
+  apply (clarsimp dest!: vs_lookup_max_pt_levelD)
+  apply (clarsimp simp: vs_lookup_target_def in_omonad vs_lookup_slot_def)
+  apply (clarsimp simp: asid_pool_level_neq[THEN iffD2])
+  apply (rule_tac x="pt_slot_offset level table_ptr vref" in exI)
+  apply (rule conjI[rotated], fastforce dest: ptes_of_pt_None_updD)
+  apply (rule_tac x=level in exI)
+  apply (clarsimp simp: asid_pool_level_neq[THEN iffD2])
+  apply (subst vs_lookup_split_max_pt_level_Some, assumption)
+  apply (rule_tac x=table_ptr in exI)
+  apply simp
+  apply (rule_tac x=pt in exI)
+  apply (rule conjI)
+   apply (rule_tac pool_ptr=pool_ptr in vs_lookup_max_pt_levelI)
+    apply (fastforce simp: pool_for_asid_def)
+   apply (fastforce simp: asid_pools_of_ko_at obj_at_def  vspace_for_pool_def in_omonad
+                    dest!: graph_of_SomeD pt_walk_pt_None_updD
+                    split: if_splits)+
+  done
+
+lemma set_asid_pool_vs_lookup_unmap':
+  "\<lbrace> valid_vs_lookup and
+     obj_at (\<lambda>ko. \<exists>ap'. ko = ArchObj (ASIDPool ap') \<and> graph_of ap \<subseteq> graph_of ap') p \<rbrace>
+   set_asid_pool p ap
+   \<lbrace>\<lambda>_. valid_vs_lookup\<rbrace>"
+  supply fun_upd_apply[simp del]
+  apply (simp add: valid_vs_lookup_def pred_conj_def)
+  apply (rule hoare_lift_Pf2 [where f=caps_of_state];wp?)
+  apply (simp add: set_asid_pool_def)
+  apply (wp get_object_wp set_object_wp)
+  apply (clarsimp simp: obj_at_def)
+  apply (rename_tac target)
+  (* unfold vs_lookup_target on updated state and clean up *)
+  apply (subst (asm) (2) vs_lookup_target_def)
+  apply (clarsimp simp: in_omonad)
+  apply (rename_tac slot_ptr)
+  apply (clarsimp simp: vs_lookup_slot_def)
+  apply (rename_tac level' table_ptr)
+  apply (drule_tac bot_level=bot_level in vs_lookup_level)
+  apply (prop_tac "level' = level", fastforce split: if_splits)
+  apply clarsimp
+
+  apply (case_tac "level = asid_pool_level")
+   apply (clarsimp simp: pool_for_asid_vs_lookup)
+   apply (rename_tac root pool_ptr)
+   apply (subgoal_tac "vs_lookup_target asid_pool_level asid vref s = Some (asid_pool_level, root)"
+          , fastforce)
+   apply (erule vs_lookup_target_asid_pool_level_upd_helper; simp)
+  apply clarsimp
+  apply (subgoal_tac "vs_lookup_target level asid vref s = Some (level, target)", fastforce)
+  apply (erule vs_lookup_target_None_upd_helper; simp)
+  done
+
+lemma set_asid_pool_vs_lookup_unmap:
+  "\<lbrace>valid_vs_lookup and ko_at (ArchObj (ASIDPool ap)) p\<rbrace>
+  set_asid_pool p (ap |` S) \<lbrace>\<lambda>_. valid_vs_lookup\<rbrace>"
+  apply (wp set_asid_pool_vs_lookup_unmap')
+  by (clarsimp simp: obj_at_def
+                 elim!: subsetD [OF graph_of_restrict_map])
+
+lemma valid_pte_typ_at:
+  "(\<And>T p. typ_at (AArch T) p s = typ_at (AArch T) p s') \<Longrightarrow>
+   valid_pte level pte s = valid_pte level pte s'"
+  by (case_tac pte, auto simp add: data_at_def)
+
+lemma set_asid_pool_global_objs [wp]:
+  "set_asid_pool p ap \<lbrace>valid_global_objs\<rbrace>"
+  by (clarsimp simp: valid_global_objs_def) wp
+
+crunch v_ker_map[wp]: set_asid_pool "valid_kernel_mappings"
+  (ignore: set_object wp: set_object_v_ker_map crunch_wps)
+
+lemma set_asid_pool_vspace_objs_unmap_single:
+  "\<lbrace>valid_vspace_objs and ko_at (ArchObj (ASIDPool ap)) p and
+    valid_asid_table and pspace_aligned\<rbrace>
+       set_asid_pool p (ap(x := None)) \<lbrace>\<lambda>_. valid_vspace_objs\<rbrace>"
+  using set_asid_pool_vspace_objs_unmap[where S="- {x}"]
+  by (simp add: restrict_map_def fun_upd_def if_flip)
+
+lemma set_asid_pool_only_idle [wp]:
+  "\<lbrace>only_idle\<rbrace> set_asid_pool p ap \<lbrace>\<lambda>_. only_idle\<rbrace>"
+  by (wp only_idle_lift set_asid_pool_typ_at)
+
+lemma set_asid_pool_equal_mappings[wp]:
+  "\<lbrace>equal_kernel_mappings and
+    (\<lambda>s. \<forall>p pt. p \<in> ran ap \<longrightarrow> pts_of s p = Some pt \<longrightarrow> has_kernel_mappings pt s)\<rbrace>
+    set_asid_pool p ap
+   \<lbrace>\<lambda>rv. equal_kernel_mappings\<rbrace>"
+  unfolding set_asid_pool_def
+  apply (wpsimp wp: set_object_wp)
+  apply (clarsimp simp: equal_kernel_mappings_def)
+  apply (drule vspace_for_asid_SomeD)
+  apply clarsimp
+  apply (case_tac "p = pool_ptr")
+  apply (clarsimp simp: equal_kernel_mappings_def has_kernel_mappings_def obj_at_def  opt_map_def
+                  split: option.splits if_splits)
+   apply (subgoal_tac "pt_ptr \<in> ran ap")
+    apply fastforce+
+  (* p \<noteq> pool_ptr *)
+  apply (clarsimp simp: equal_kernel_mappings_def has_kernel_mappings_def obj_at_def  opt_map_def
+                  split: option.splits if_splits)
+  apply (subgoal_tac "vspace_for_asid asid s = Some pt_ptr")
+   apply (fastforce elim: vspace_for_asid_SomeI simp: opt_map_def)+
+  done
+
+lemma translate_address_asid_pool_upd:
+  "pts_of s p = None
+   \<Longrightarrow> translate_address pt_ptr vref
+        (\<lambda>pa. pte_of pa (kheap s(p \<mapsto> ArchObj (ASIDPool ap)) |> aobj_of |> pt_of))
+      = translate_address pt_ptr vref (ptes_of s)"
+  by simp
+
+lemma ko_atasid_pool_pts_None:
+  "ako_at (ASIDPool pool) p s \<Longrightarrow> pts_of s p = None"
+  by (clarsimp simp: opt_map_def obj_at_def split: option.splits)
+
+lemma set_asid_pool_valid_global_vspace_mappings[wp]:
+  "\<lbrace>valid_global_vspace_mappings\<rbrace>
+   set_asid_pool p ap
+   \<lbrace>\<lambda>rv. valid_global_vspace_mappings\<rbrace>"
+  unfolding set_asid_pool_def
+  apply (wpsimp wp: set_object_wp)
+  apply (simp only: valid_global_vspace_mappings_def Let_def) (* prevent simp loop *)
+  apply (clarsimp simp: translate_address_asid_pool_upd ko_atasid_pool_pts_None)
+  done
+
+lemma set_asid_pool_kernel_window[wp]:
+  "\<lbrace>pspace_in_kernel_window\<rbrace> set_asid_pool p ap \<lbrace>\<lambda>rv. pspace_in_kernel_window\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  apply (wp set_object_pspace_in_kernel_window get_object_wp)
+  including unfold_objects_asm
+  by (clarsimp simp: a_type_def)
+
+lemma set_asid_pool_pspace_respects_device_region[wp]:
+  "\<lbrace>pspace_respects_device_region\<rbrace> set_asid_pool p ap \<lbrace>\<lambda>rv. pspace_respects_device_region\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  apply (wp set_object_pspace_respects_device_region get_object_wp)
+  including unfold_objects_asm
+  by (clarsimp simp: a_type_def)
+
+
+lemma set_asid_pool_caps_kernel_window[wp]:
+  "\<lbrace>cap_refs_in_kernel_window\<rbrace> set_asid_pool p ap \<lbrace>\<lambda>rv. cap_refs_in_kernel_window\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  apply (wp set_object_cap_refs_in_kernel_window get_object_wp)
+  including unfold_objects_asm
+  by clarsimp
+
+lemma set_asid_pool_caps_respects_device_region[wp]:
+  "\<lbrace>cap_refs_respects_device_region\<rbrace> set_asid_pool p ap \<lbrace>\<lambda>rv. cap_refs_respects_device_region\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  apply (wp set_object_cap_refs_respects_device_region get_object_wp)
+  including unfold_objects_asm
+  by clarsimp
+
+
+lemma set_asid_pool_valid_ioc[wp]:
+  "\<lbrace>valid_ioc\<rbrace> set_asid_pool p ap \<lbrace>\<lambda>_. valid_ioc\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  apply (wp set_object_valid_ioc_no_caps get_object_inv)
+  including unfold_objects
+  by (clarsimp simp: valid_def get_object_def simpler_gets_def assert_def
+          return_def fail_def bind_def
+          a_type_simps is_tcb is_cap_table)
+
+
+lemma set_asid_pool_vms[wp]:
+  "\<lbrace>valid_machine_state\<rbrace> set_asid_pool p S \<lbrace>\<lambda>_. valid_machine_state\<rbrace>"
+  apply (simp add: set_asid_pool_def set_object_def)
+  apply (wp get_object_wp)
+  apply clarify
+  apply (erule valid_machine_state_heap_updI)
+  apply (fastforce simp: a_type_def obj_at_def
+                  split: kernel_object.splits arch_kernel_obj.splits)+
+  done
+
+(* FIXME: example of crunch not being helpful *)
+lemma set_asid_pool_valid_asid_pool_caps[wp]:
+  "set_asid_pool p ap \<lbrace>valid_asid_pool_caps\<rbrace>"
+  unfolding valid_asid_pool_caps_def
+  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')
+
+lemma set_asid_pool_invs_restrict:
+  "\<lbrace>invs and ko_at (ArchObj (ASIDPool ap)) p and (\<lambda>s. \<exists>a. asid_table s a = Some p) and
+    valid_asid_table and pspace_aligned\<rbrace>
+   set_asid_pool p (ap |` S)
+   \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (simp add: invs_def valid_state_def valid_pspace_def
+                   valid_arch_caps_def valid_asid_map_def)
+  apply (wp valid_irq_node_typ set_asid_pool_typ_at
+            set_asid_pool_vspace_objs_unmap  valid_irq_handlers_lift
+            set_asid_pool_vs_lookup_unmap)
+  apply (clarsimp simp: equal_kernel_mappings_def)
+  apply (rename_tac s pt_ptr hi_bits pt)
+  apply (clarsimp dest!: ran_restrictD)
+  apply (rename_tac lo_bits)
+  (* we can build an asid that resolves to pt_ptr, vref is irrelevant for asid_pool_level *)
+  apply (prop_tac "vs_lookup_target asid_pool_level
+                      ((ucast hi_bits << asid_low_bits) || ucast lo_bits)
+                      0 s = Some (asid_pool_level, pt_ptr)")
+   apply (clarsimp simp: vs_lookup_target_def in_omonad)
+   apply (rule_tac x=p in exI)
+   apply (clarsimp simp: vspace_for_pool_def vs_lookup_slot_def in_omonad obj_at_def
+                         pool_for_asid_vs_lookup pool_for_asid_def
+                         constructed_asid_high_bits_of constructed_asid_low_bits_of)
+  apply (drule vspace_for_asid_from_lookup_target; simp)
+  done
+
+lemmas set_asid_pool_cte_wp_at1[wp]
+    = hoare_cte_wp_caps_of_state_lift [OF set_asid_pool_caps_of_state]
+
+
+lemma mdb_cte_at_set_asid_pool[wp]:
+  "\<lbrace>\<lambda>s. mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s)\<rbrace>
+   set_asid_pool y pool
+   \<lbrace>\<lambda>r s. mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s)\<rbrace>"
+  apply (clarsimp simp:mdb_cte_at_def)
+  apply (simp only: imp_conv_disj)
+  apply (wp hoare_vcg_disj_lift hoare_vcg_all_lift)
+done
+
+lemma set_asid_pool_invs_unmap:
+  "\<lbrace>invs and ko_at (ArchObj (ASIDPool ap)) p and (\<lambda>s. \<exists>a. asid_table s a = Some p) and
+    valid_asid_table and pspace_aligned\<rbrace>
+       set_asid_pool p (ap(x := None)) \<lbrace>\<lambda>_. invs\<rbrace>"
+  using set_asid_pool_invs_restrict[where S="- {x}"]
+  by (simp add: restrict_map_def fun_upd_def if_flip)
+
+lemma pte_at_typ_at_lift:
+  assumes aa_type: "\<And>T p. f \<lbrace>typ_at (AArch T) p\<rbrace>"
+  shows "f \<lbrace>pte_at p\<rbrace>"
+  unfolding pte_at_def
+  by (wpsimp wp: aa_type)
+
+lemma valid_slots_typ_at:
+  assumes x: "\<And>T p. f \<lbrace>typ_at (AArch T) p\<rbrace>"
+  assumes y: "\<And>P. f \<lbrace> \<lambda>s. P (vs_lookup s) \<rbrace>"
+  shows "\<lbrace>valid_slots m\<rbrace> f \<lbrace>\<lambda>rv. valid_slots m\<rbrace>"
+  unfolding valid_slots_def
+  apply (cases m; clarsimp)
+  apply (wpsimp wp: hoare_vcg_ex_lift hoare_vcg_all_lift hoare_vcg_imp_lift' assms
+                    valid_pte_lift pte_at_typ_at_lift)
+  apply fastforce
+  done
+
+lemma pool_for_asid_arch_update[simp]:
+  "riscv_asid_table (f (arch_state s)) = riscv_asid_table (arch_state s) \<Longrightarrow>
+  pool_for_asid asid (arch_state_update f s) = pool_for_asid asid s"
+  by (simp add: pool_for_asid_def obind_def split: option.splits)
+
+lemma vs_lookup_table_arch_update[simp]:
+  "riscv_asid_table (f (arch_state s)) = riscv_asid_table (arch_state s) \<Longrightarrow>
+   vs_lookup_table level asid vref (arch_state_update f s) = vs_lookup_table level asid vref s"
+  by (simp add: vs_lookup_table_def obind_def split: option.splits)
+
+lemma vs_lookup_arch_update[simp]:
+  "riscv_asid_table (f (arch_state s)) = riscv_asid_table (arch_state s) \<Longrightarrow>
+   vs_lookup (arch_state_update f s) = vs_lookup s"
+  by (rule ext)+ simp
+
+lemma vs_lookup_slot_arch_update[simp]:
+  "riscv_asid_table (f (arch_state s)) = riscv_asid_table (arch_state s) \<Longrightarrow>
+   vs_lookup_slot level asid vref (arch_state_update f s) = vs_lookup_slot level asid vref s"
+  by (simp add: vs_lookup_slot_def obind_def split: option.splits)
+
+lemma vs_lookup_target_arch_update[simp]:
+  "riscv_asid_table (f (arch_state s)) = riscv_asid_table (arch_state s) \<Longrightarrow>
+   vs_lookup_target level asid vref (arch_state_update f s) = vs_lookup_target level asid vref  s"
+  by (simp add: vs_lookup_target_def obind_def split: option.splits)
+
+lemma vs_lookup_pages_arch_update[simp]:
+  "riscv_asid_table (f (arch_state s)) = riscv_asid_table (arch_state s) \<Longrightarrow>
+   vs_lookup_pages (arch_state_update f s) = vs_lookup_pages s"
+  by (rule ext)+ simp
+
+lemma unique_table_caps_ptE:
+  "\<lbrakk> unique_table_caps_2 cs; cs p = Some cap; vs_cap_ref cap = None;
+     cs p' = Some cap'; vs_cap_ref cap' = Some v; is_pt_cap cap;
+     is_pt_cap cap'; obj_refs cap' = obj_refs cap \<rbrakk>
+       \<Longrightarrow> P"
+  apply (frule(6) unique_table_caps_ptD[where cs=cs])
+  apply simp
+  done
+
+lemma set_pt_mappings[wp]:
+  "\<lbrace>\<top>\<rbrace> set_pt p pt \<lbrace>\<lambda>_. valid_kernel_mappings\<rbrace>"
+  by (simp add: valid_kernel_mappings_def) wp
+
+lemma set_pt_has_kernel_mappings:
+  "\<lbrace>\<lambda>s. p \<noteq> riscv_global_pt (arch_state s) \<and> has_kernel_mappings pt s \<rbrace>
+   set_pt p pt'
+   \<lbrace>\<lambda>_. has_kernel_mappings pt \<rbrace>"
+  unfolding has_kernel_mappings_def
+  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift)
+    apply (rule hoare_lift_Pf2[where f="\<lambda>s. riscv_global_pt (arch_state s)"])
+     apply (wpsimp wp: set_pt_pts_of)+
+  done
+
+lemma set_pt_equal_kernel_mappings:
+  "\<lbrace>\<lambda>s. equal_kernel_mappings s
+        \<and> ((\<exists>asid. vspace_for_asid asid s = Some p) \<longrightarrow> has_kernel_mappings pt s)
+        \<and> p \<noteq> riscv_global_pt (arch_state s) \<rbrace>
+   set_pt p pt
+   \<lbrace>\<lambda>rv. equal_kernel_mappings\<rbrace>"
+  unfolding equal_kernel_mappings_def
+  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' vspace_for_asid_lift set_pt_pts_of
+                 set_pt_has_kernel_mappings)
+
+lemma has_kernel_mappings_index_upd_idem:
+  "\<lbrakk> has_kernel_mappings pt s; idx \<notin> kernel_mapping_slots \<rbrakk>
+   \<Longrightarrow> has_kernel_mappings (pt(idx := pte)) s"
+  unfolding has_kernel_mappings_def
+  by auto
+
+(* We only affect kernel mapping slots of not-yet-mapped page tables, in particular when copying
+   global mappings for a root page table. For preserving validity of mapped tables, we use this
+   form. *)
+lemma store_pte_equal_kernel_mappings_no_kernel_slots:
+  "\<lbrace>\<lambda>s. equal_kernel_mappings s
+        \<and> ((\<exists>asid. vspace_for_asid asid s = Some (table_base p))
+                   \<longrightarrow> table_index p \<notin> kernel_mapping_slots)
+        \<and> table_base p \<noteq> riscv_global_pt (arch_state s) \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>rv. equal_kernel_mappings\<rbrace>"
+  unfolding store_pte_def
+  supply fun_upd_apply[simp del]
+  apply (wpsimp wp: set_pt_equal_kernel_mappings)
+  apply (fastforce simp: obj_at_def equal_kernel_mappings_def pts_of_ko_at
+                   intro: has_kernel_mappings_index_upd_idem)
+  done
+
+lemma store_pte_state_refs_of[wp]:
+  "store_pte ptr val \<lbrace>\<lambda>s. P (state_refs_of s)\<rbrace>"
+  unfolding store_pte_def set_pt_def
+  apply (wp get_object_wp set_object_wp)
+  apply (clarsimp elim!: rsubst[where P=P])
+  apply (rule ext, clarsimp simp: state_refs_of_def obj_at_def)
+  done
+
+lemma store_pte_state_hyp_refs_of[wp]:
+  "store_pte ptr val \<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>"
+  unfolding store_pte_def set_pt_def
+  apply (wp get_object_wp set_object_wp)
+  apply (clarsimp elim!: rsubst[where P=P])
+  apply (rule ext, clarsimp simp: state_hyp_refs_of_def obj_at_def)
+  done
+
+lemma asid_pools_of_pt_None_upd_idem:
+  "pt_at p s \<Longrightarrow> (asid_pools_of s)(p := None) = (asid_pools_of s)"
+  by (rule ext)
+     (clarsimp simp: opt_map_def obj_at_def )
+
+lemma store_pte_valid_asid_table[wp]:
+  "\<lbrace> valid_asid_table \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_. valid_asid_table \<rbrace>"
+  supply fun_upd_apply[simp del]
+  unfolding store_pte_def set_pt_def
+  apply (wpsimp wp: set_object_wp hoare_vcg_imp_lift' hoare_vcg_all_lift)
+  apply (subst asid_pools_of_pt_None_upd_idem, auto simp: obj_at_def)
+  done
+
+crunches store_pte
+  for iflive[wp]: if_live_then_nonz_cap
+  and zombies_final[wp]: zombies_final
+  and valid_mdb[wp]: valid_mdb
+  and valid_ioc[wp]: valid_ioc
+  and valid_idle[wp]: valid_idle
+  and only_idle[wp]: only_idle
+  and if_unsafe_then_cap[wp]: if_unsafe_then_cap
+  and valid_reply_caps[wp]: valid_reply_caps
+  and valid_reply_masters[wp]: valid_reply_masters
+  and valid_global_refs[wp]: valid_global_refs
+  and valid_irq_node[wp]: valid_irq_node
+  and valid_irq_handlers[wp]: valid_irq_handlers
+  and valid_irq_states[wp]: valid_irq_states
+  and valid_machine_state[wp]: valid_machine_state
+  and valid_global_objs[wp]: valid_global_objs
+  and valid_kernel_mappings[wp]: valid_kernel_mappings
+  and valid_asid_map[wp]: valid_asid_map
+  and pspace_in_kernel_window[wp]: pspace_in_kernel_window
+  and cap_refs_in_kernel_window[wp]: cap_refs_in_kernel_window
+  and pspace_respects_device_region[wp]: pspace_respects_device_region
+  and cap_refs_respects_device_region[wp]: cap_refs_respects_device_region
+  and cur_tcb[wp]: cur_tcb
+  (wp: set_pt_zombies set_pt_ifunsafe set_pt_reply_caps set_pt_reply_masters
+       set_pt_valid_global valid_irq_node_typ valid_irq_handlers_lift set_pt_cur)
+
+lemma store_pte_valid_global_tables:
+  "\<lbrace> valid_global_tables and valid_global_arch_objs and valid_global_vspace_mappings
+     and (\<lambda>s. table_base p \<notin> global_refs s) \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_. valid_global_tables \<rbrace>"
+  unfolding store_pte_def set_pt_def
+  supply fun_upd_apply[simp del]
+  apply (wpsimp wp: set_object_wp)
+  apply (simp (no_asm) add: valid_global_tables_def Let_def)
+  apply (rule conjI)
+   apply clarsimp
+   apply (subst (asm) pt_walk_pt_upd_idem)
+     apply (fastforce simp: global_refs_def dest: valid_global_tablesD[simplified riscv_global_pt_def])
+    apply (fastforce dest: valid_global_vspace_mappings_aligned[simplified riscv_global_pt_def])
+   apply (fastforce simp: valid_global_tables_def Let_def)
+  apply (clarsimp simp: valid_global_tables_def Let_def fun_upd_apply split: if_splits)
+  apply (fastforce dest: riscv_global_pt_in_global_refs simp: riscv_global_pt_def global_refs_def)
+  done
+
+lemma store_pte_valid_global_arch_objs[wp]:
+  "store_pte p pte \<lbrace> valid_global_arch_objs \<rbrace>"
+  unfolding store_pte_def set_pt_def
+  by (wpsimp wp: set_object_wp)
+     (clarsimp simp: valid_global_arch_objs_def obj_at_def)
+
+lemma store_pte_unique_table_refs[wp]:
+  "store_pte p pte \<lbrace> unique_table_refs \<rbrace>"
+  unfolding store_pte_def set_pt_def
+  apply (wpsimp wp: set_object_wp)
+  apply (clarsimp simp: unique_table_refs_def)
+  apply (subst (asm) caps_of_state_after_update[folded fun_upd_def], simp add: obj_at_def)+
+  apply blast
+  done
+
+lemma store_pte_unique_table_caps[wp]:
+  "store_pte p pte \<lbrace> unique_table_caps \<rbrace>"
+  unfolding store_pte_def set_pt_def
+  apply (wpsimp wp: set_object_wp)
+  apply (clarsimp simp: unique_table_caps_def)
+  apply (subst (asm) caps_of_state_after_update[folded fun_upd_def], fastforce simp: obj_at_def)+
+  apply blast
+  done
+
+lemma store_pte_valid_asid_pool_caps[wp]:
+  "store_pte p pte \<lbrace> valid_asid_pool_caps \<rbrace>"
+  unfolding store_pte_def set_pt_def
+  apply (wpsimp wp: set_object_wp)
+  apply (subst caps_of_state_after_update[folded fun_upd_def], fastforce simp: obj_at_def)+
+  apply assumption
+  done
+
+lemma store_pte_PagePTE_valid_vspace_objs:
+  "\<lbrace> valid_vspace_objs and pspace_aligned and valid_asid_table
+     and K (pte = PagePTE ppn attr rights)
+     and (\<lambda>s. \<forall>level. \<exists>\<rhd> (level, table_base p) s \<longrightarrow> valid_pte level pte s)\<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_. valid_vspace_objs\<rbrace>"
+  unfolding valid_vspace_objs_def
+  supply valid_pte.simps[simp del]
+  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' valid_vspace_obj_lift
+                    store_pte_non_PageTablePTE_vs_lookup)
+  apply (rule conjI; clarsimp)
+   apply (rename_tac level' slot pte' ao pt)
+   apply (drule (1) level_of_slotI)
+   apply (case_tac "slot = table_base p"; clarsimp simp del: valid_vspace_obj.simps)
+   apply (drule vs_lookup_level)
+   apply (clarsimp)
+   apply (prop_tac "valid_vspace_obj level' (PageTable pt) s")
+    apply fastforce
+   apply fastforce
+  apply (rename_tac level' slot pte' ao pt)
+  apply (clarsimp simp: vs_lookup_slot_def)
+  apply (case_tac "slot = table_base p"; clarsimp simp del: valid_vspace_obj.simps)
+  apply (drule vs_lookup_level)
+  apply (clarsimp)
+  apply (prop_tac "valid_vspace_obj level' (PageTable pt) s")
+   apply fastforce
+  apply fastforce
+  done
+
+lemma store_pte_InvalidPTE_valid_vs_lookup:
+  "\<lbrace> valid_vs_lookup
+     and pspace_aligned and valid_vspace_objs and valid_asid_table and unique_table_refs
+     and (\<lambda>s. valid_caps (caps_of_state s) s)
+     and K (pte = InvalidPTE) \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_. valid_vs_lookup \<rbrace>"
+  unfolding store_pte_def set_pt_def
+  supply fun_upd_apply[simp del]
+  apply (wpsimp wp: set_object_wp)
+  apply (simp (no_asm) add: valid_vs_lookup_def)
+  apply clarsimp
+  apply (subst caps_of_state_after_update[folded fun_upd_def], simp add: obj_at_def)
+  apply (rename_tac obj_ref)
+  (* interesting case is if table_base p was reachable before the update *)
+  apply (case_tac "\<forall>level. vs_lookup_table level asid vref s \<noteq> Some (level, table_base p)")
+   apply (clarsimp simp: valid_vs_lookup_def)
+   apply (subst (asm) vs_lookup_target_unreachable_upd_idem; fastforce)
+  apply clarsimp
+  apply (rename_tac level')
+
+  apply (prop_tac "level' \<le> max_pt_level \<longrightarrow> asid \<noteq> 0")
+   apply (fastforce dest: vs_lookup_table_asid_not_0)
+
+  (* unfold vs_lookup_target on updated state and clean up *)
+  apply (subst (asm) vs_lookup_target_def)
+  apply (clarsimp simp: in_omonad)
+  apply (rename_tac slot_ptr)
+  apply (clarsimp simp: vs_lookup_slot_def)
+  apply (rename_tac level'' table_ptr)
+  apply (drule_tac bot_level=bot_level in vs_lookup_level)
+  apply (prop_tac "level'' = level", fastforce split: if_splits)
+  apply clarsimp
+  (* the interesting operations all happen when level \<le> max_pt_level; get asid_pool_level out of
+     the way first *)
+  apply (prop_tac "level' \<le> max_pt_level")
+   apply (rule ccontr, clarsimp simp: not_le)
+   apply (frule (1) vs_lookup_asid_pool)
+   apply (clarsimp simp: asid_pools_of_ko_at)
+   apply (fastforce simp: obj_at_def)
+  apply (case_tac "level = asid_pool_level")
+   apply clarsimp
+   (* FIXME RISCV there is a property hidden in here about vs_lookup_target for asid_pool_level,
+      repeating some of the pattern seen in vs_lookup_target_unreachable_upd_idem *)
+   apply (clarsimp simp: pool_for_asid_vs_lookup vspace_for_pool_def in_omonad)
+   apply (rename_tac pool_ptr pool)
+   apply (clarsimp simp: fun_upd_apply split: if_splits)
+   apply (prop_tac "pool_for_asid asid s = Some pool_ptr")
+    apply (fastforce simp: pool_for_asid_def)
+   apply (prop_tac "vs_lookup_target asid_pool_level asid vref s = Some (asid_pool_level, obj_ref)")
+    apply (clarsimp simp: vs_lookup_target_def in_omonad)
+    apply (rule_tac x=pool_ptr in exI)
+    apply (fastforce simp: pool_for_asid_vs_lookup vspace_for_pool_def vs_lookup_slot_def in_omonad)
+   apply (fastforce dest: valid_vs_lookupD simp: valid_vs_lookup_def)
+  apply clarsimp
+  (* now we are looking at page tables only; we can extend or truncate our previous lookup,
+     but nowhere in seL4 do we do both in one step
+     we also now know asid \<noteq> 0 *)
+
+  (* updating deeper than where we can find table_base p has no effect *)
+  apply (case_tac "level' \<le> level")
+   apply (drule vs_lookup_level, drule (3) vs_lookup_table_fun_upd_deep_idem; assumption?)
+   apply (prop_tac "is_aligned table_ptr pt_bits")
+    apply (fastforce elim!: vs_lookup_table_is_aligned)
+   apply (clarsimp simp: in_omonad fun_upd_apply pte_of_def split: if_splits)
+    (* miss on pte *)
+    apply (prop_tac "level' = level")
+     apply (drule no_loop_vs_lookup_table; simp?; blast)
+    apply clarsimp
+    apply (drule vs_lookup_target_pt_levelI; assumption?)
+     apply (fastforce simp: in_omonad ptes_of_def obj_at_def)
+    apply (fastforce dest!: valid_vs_lookupD)
+   (* miss on table_base p *)
+    apply (drule_tac level=level in vs_lookup_target_pt_levelI; assumption?)
+     apply (fastforce simp: in_omonad ptes_of_def obj_at_def)
+    apply (fastforce dest!: valid_vs_lookupD)
+  (* we are updating at table_base p, which is within the original lookup path *)
+  apply (clarsimp simp: not_le)
+
+  (* split both lookups down to table_base p *)
+  apply (drule_tac level=level and level'=level' in vs_lookup_splitD)
+    apply simp
+   apply (fastforce intro: less_imp_le)
+  apply clarsimp
+  apply (rename_tac pt_ptr)
+  (* update now occurs in pt_walk stage *)
+  apply (drule (1) vs_lookup_table_fun_upd_deep_idem; assumption?; simp)
+  apply clarsimp
+  (* handle the actual update, happening on next step of pt_walk *)
+  apply (subst (asm) pt_walk.simps, clarsimp simp: in_omonad split: if_splits)
+  apply (rename_tac pte')
+  apply (erule disjE; clarsimp)
+  apply (subst (asm) (2) pte_of_def)
+  apply (clarsimp simp: in_omonad)
+  apply (rename_tac pt')
+  apply (clarsimp simp: fun_upd_apply)
+  apply (case_tac "table_index (pt_slot_offset level' (table_base p) vref) = table_index p"; clarsimp)
+   (* staying on old path; we can't hit table_base p again *)
+   (* this transform copied from elsewhere, FIXME RISCV might be useful to extract *)
+   apply (subst (asm) pt_walk_pt_upd_idem; simp?)
+    apply clarsimp
+    apply (rename_tac level'')
+    apply (prop_tac "pt_walk level' level'' (table_base p) vref (ptes_of s) = Some (level'', table_base p)")
+     apply (subst pt_walk.simps)
+     apply clarsimp
+     apply (prop_tac "level'' < level'")
+      apply (drule pt_walk_max_level)
+      apply (simp add: bit0.leq_minus1_less)
+     apply (clarsimp simp: in_omonad obj_at_def)
+     apply (rule_tac x="(pt (table_index (pt_slot_offset level' (table_base p) vref)))" in exI)
+     apply clarsimp
+     apply (clarsimp simp: ptes_of_def in_omonad)
+    apply (prop_tac "level'' < level'")
+     apply (drule pt_walk_max_level)
+     apply (simp add: bit0.leq_minus1_less)
+    apply (prop_tac "vs_lookup_table level'' asid vref s = Some (level'', table_base p)")
+     apply (erule (2) vs_lookup_table_extend)
+    apply (drule (1) no_loop_vs_lookup_table; simp?)
+   (* pt_walk is now on pts_of s, can stitch it back together into a vs_lookup_table *)
+   (* FIXME RISCV again useful transform from elsewhere *)
+   apply (prop_tac "pt_walk level' level (table_base p) vref (ptes_of s) = Some (level, table_ptr)")
+    apply (subst pt_walk.simps)
+    apply clarsimp
+    apply (clarsimp simp: in_omonad obj_at_def)
+    apply (rule_tac x="(pt (table_index (pt_slot_offset level' (table_base p) vref)))" in exI)
+    apply clarsimp
+    apply (clarsimp simp: ptes_of_def in_omonad)
+   apply (prop_tac "vs_lookup_table level asid vref s = Some (level, table_ptr)")
+    apply (erule (2) vs_lookup_table_extend)
+   (* now specifically to vs_lookup_target reconstruction, we get through pte_of ref_of stuff *)
+   apply (subst (asm) pte_of_def)
+   apply (clarsimp simp: in_omonad fun_upd_apply)
+   apply (prop_tac "is_aligned table_ptr pt_bits")
+    apply (fastforce elim!: vs_lookup_table_is_aligned)
+   apply (clarsimp split: if_splits)
+    apply (prop_tac "level' = level")
+     apply (drule no_loop_vs_lookup_table; simp?; blast)
+    apply clarsimp
+    apply (drule_tac level=level in vs_lookup_target_pt_levelI; assumption?)
+     apply (fastforce simp: in_omonad ptes_of_def obj_at_def)
+    apply (drule valid_vs_lookupD; assumption?; clarsimp)
+  done
+
+lemma table_index_slot_offset_inj:
+  "\<lbrakk> table_index (pt_slot_offset level (table_base p) vref) = table_index p;
+     level \<le> max_pt_level; is_aligned p pte_bits \<rbrakk>
+   \<Longrightarrow> pt_slot_offset level (table_base p) vref = p"
+  apply (simp add: pt_slot_offset_def is_aligned_nth)
+  apply (prop_tac "table_base p && (pt_index level vref << pte_bits) = 0")
+   apply word_bitwise
+   apply (simp add: bit_simps pt_index_def word_size)
+  apply (simp add: word_plus_and_or_coroll)
+  apply word_bitwise
+  apply (drule max_pt_level_enum)
+  by (auto simp: pt_bits_left_def pt_index_def word_size bit_simps)
+
+lemma store_pte_non_InvalidPTE_valid_vs_lookup:
+  "\<lbrace> valid_vs_lookup
+     and pspace_aligned and valid_vspace_objs and valid_asid_table and unique_table_refs
+     and (\<lambda>s. valid_caps (caps_of_state s) s)
+     and (\<lambda>s. \<forall>level asid vref.
+                 vs_lookup_table level asid vref s = Some (level, table_base p)
+                      \<longrightarrow> vref \<in> user_region
+                      \<longrightarrow> pt_slot_offset level (table_base p) vref = p
+                      \<longrightarrow> (is_PageTablePTE pte \<longrightarrow> pts_of s (the (pte_ref pte)) = Some empty_pt)
+                         \<and> the (pte_ref pte) \<noteq> table_base p
+                         \<and> (\<exists>p' cap. caps_of_state s p' = Some cap \<and>
+                                     obj_refs cap = {the (pte_ref pte)} \<and>
+                                     vs_cap_ref cap = Some (asid, vref_for_level vref level))) \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_. valid_vs_lookup \<rbrace>"
+  unfolding store_pte_def set_pt_def
+  supply fun_upd_apply[simp del]
+  apply (wpsimp wp: set_object_wp)
+  apply (simp (no_asm) add: valid_vs_lookup_def)
+  apply clarsimp
+  apply (subst caps_of_state_after_update[folded fun_upd_def], simp add: obj_at_def)
+  apply (rename_tac obj_ref)
+  (* interesting case is if table_base p was reachable before the update *)
+  apply (case_tac "\<forall>level. vs_lookup_table level asid vref s \<noteq> Some (level, table_base p)")
+   apply (clarsimp simp: valid_vs_lookup_def)
+   apply (subst (asm) vs_lookup_target_unreachable_upd_idem; fastforce)
+  apply clarsimp
+  apply (rename_tac level')
+
+  apply (prop_tac "level' \<le> max_pt_level \<longrightarrow> asid \<noteq> 0")
+   apply (fastforce dest: vs_lookup_table_asid_not_0)
+
+  (* unfold vs_lookup_target on updated state and clean up *)
+  apply (subst (asm) vs_lookup_target_def)
+  apply (clarsimp simp: in_omonad)
+  apply (rename_tac slot_ptr)
+  apply (clarsimp simp: vs_lookup_slot_def)
+  apply (rename_tac level'' table_ptr)
+  apply (drule_tac bot_level=bot_level in vs_lookup_level)
+  apply (prop_tac "level'' = level", fastforce split: if_splits)
+  apply clarsimp
+  (* the interesting operations all happen when level \<le> max_pt_level; get asid_pool_level out of
+     the way first *)
+  apply (prop_tac "level' \<le> max_pt_level")
+   apply (rule ccontr, clarsimp simp: not_le)
+   apply (frule (1) vs_lookup_asid_pool)
+   apply (clarsimp simp: asid_pools_of_ko_at)
+   apply (fastforce simp: obj_at_def)
+  apply (case_tac "level = asid_pool_level")
+   apply clarsimp
+   (* FIXME RISCV there is a property hidden in here about vs_lookup_target for asid_pool_level,
+      repeating some of the pattern seen in vs_lookup_target_unreachable_upd_idem *)
+   apply (clarsimp simp: pool_for_asid_vs_lookup vspace_for_pool_def in_omonad)
+   apply (rename_tac pool_ptr pool)
+   apply (clarsimp simp: fun_upd_apply split: if_splits)
+   apply (prop_tac "pool_for_asid asid s = Some pool_ptr")
+    apply (fastforce simp: pool_for_asid_def)
+   apply (prop_tac "vs_lookup_target asid_pool_level asid vref s = Some (asid_pool_level, obj_ref)")
+    apply (clarsimp simp: vs_lookup_target_def in_omonad)
+    apply (rule_tac x=pool_ptr in exI)
+    apply (fastforce simp: pool_for_asid_vs_lookup vspace_for_pool_def vs_lookup_slot_def in_omonad)
+   apply (fastforce dest: valid_vs_lookupD simp: valid_vs_lookup_def)
+  apply clarsimp
+  (* now we are looking at page tables only; we can extend or truncate our previous lookup,
+     but nowhere in seL4 do we do both in one step
+     we also now know asid \<noteq> 0 *)
+
+  (* updating deeper than where we can find table_base p has no effect *)
+  apply (case_tac "level' \<le> level")
+   apply (drule vs_lookup_level, drule (3) vs_lookup_table_fun_upd_deep_idem; assumption?)
+   apply (prop_tac "is_aligned table_ptr pt_bits")
+    apply (fastforce elim!: vs_lookup_table_is_aligned)
+   apply (clarsimp simp: in_omonad fun_upd_apply pte_of_def split: if_splits)
+     apply (drule (2) table_index_slot_offset_inj, simp)
+    (* miss on pte *)
+    apply (prop_tac "level' = level")
+     apply (drule no_loop_vs_lookup_table; simp?; blast)
+    apply clarsimp
+    apply (drule vs_lookup_target_pt_levelI; assumption?)
+     apply (fastforce simp: in_omonad ptes_of_def obj_at_def)
+    apply (fastforce dest!: valid_vs_lookupD)
+   (* miss on table_base p *)
+    apply (drule_tac level=level in vs_lookup_target_pt_levelI; assumption?)
+     apply (fastforce simp: in_omonad ptes_of_def obj_at_def)
+    apply (fastforce dest!: valid_vs_lookupD)
+  (* we are updating at table_base p, which is within the original lookup path *)
+  apply (clarsimp simp: not_le)
+
+  (* split both lookups down to table_base p *)
+  apply (drule_tac level=level and level'=level' in vs_lookup_splitD)
+    apply simp
+   apply (fastforce intro: less_imp_le)
+  apply clarsimp
+  apply (rename_tac pt_ptr)
+  (* update now occurs in pt_walk stage *)
+  apply (drule (1) vs_lookup_table_fun_upd_deep_idem; assumption?; simp)
+  (* can now show there's a cap to the (pte_ref pte) at level' *)
+  apply ((erule allE)+, erule (1) impE)
+  apply clarsimp
+  (* handle the actual update, happening on next step of pt_walk *)
+  apply (subst (asm) pt_walk.simps, clarsimp simp: in_omonad split: if_splits)
+  apply (rename_tac pte')
+  apply (erule disjE; clarsimp)
+  apply (subst (asm) (2) pte_of_def)
+  apply (clarsimp simp: in_omonad)
+  apply (rename_tac pt')
+  apply (clarsimp simp: fun_upd_apply)
+  apply (case_tac "table_index (pt_slot_offset level' (table_base p) vref) = table_index p"; clarsimp)
+   prefer 2
+   (* staying on old path; we can't hit table_base p again *)
+   (* this transform copied from elsewhere, FIXME RISCV might be useful to extract *)
+   apply (subst (asm) pt_walk_pt_upd_idem; simp?)
+    apply clarsimp
+    apply (rename_tac level'')
+    apply (prop_tac "pt_walk level' level'' (table_base p) vref (ptes_of s) = Some (level'', table_base p)")
+     apply (subst pt_walk.simps)
+     apply clarsimp
+     apply (prop_tac "level'' < level'")
+      apply (drule pt_walk_max_level)
+      apply (simp add: bit0.leq_minus1_less)
+     apply (clarsimp simp: in_omonad obj_at_def)
+     apply (rule_tac x="(pt (table_index (pt_slot_offset level' (table_base p) vref)))" in exI)
+     apply clarsimp
+     apply (clarsimp simp: ptes_of_def in_omonad)
+    apply (prop_tac "level'' < level'")
+     apply (drule pt_walk_max_level)
+     apply (simp add: bit0.leq_minus1_less)
+    apply (prop_tac "vs_lookup_table level'' asid vref s = Some (level'', table_base p)")
+     apply (erule (2) vs_lookup_table_extend)
+    apply (drule (1) no_loop_vs_lookup_table; simp?)
+   (* pt_walk is now on pts_of s, can stitch it back together into a vs_lookup_table *)
+   (* FIXME RISCV again useful transform from elsewhere *)
+   apply (prop_tac "pt_walk level' level (table_base p) vref (ptes_of s) = Some (level, table_ptr)")
+    apply (subst pt_walk.simps)
+    apply clarsimp
+    apply (clarsimp simp: in_omonad obj_at_def)
+    apply (rule_tac x="(pt (table_index (pt_slot_offset level' (table_base p) vref)))" in exI)
+    apply clarsimp
+    apply (clarsimp simp: ptes_of_def in_omonad)
+   apply (prop_tac "vs_lookup_table level asid vref s = Some (level, table_ptr)")
+    apply (erule (2) vs_lookup_table_extend)
+   (* now specifically to vs_lookup_target reconstruction, we get through pte_of ref_of stuff *)
+   apply (subst (asm) pte_of_def)
+   apply (clarsimp simp: in_omonad fun_upd_apply)
+   apply (prop_tac "is_aligned table_ptr pt_bits")
+    apply (fastforce elim!: vs_lookup_table_is_aligned)
+   apply (clarsimp split: if_splits)
+    apply (prop_tac "level' = level")
+     apply (drule no_loop_vs_lookup_table; simp?; blast)
+    apply clarsimp
+   apply (drule_tac level=level in vs_lookup_target_pt_levelI; assumption?)
+    apply (fastforce simp: in_omonad ptes_of_def obj_at_def)
+   apply (drule valid_vs_lookupD; assumption?; clarsimp)
+  (* we could not have arrived at our new empty table through a non-empty table and from
+     precondition, we are not creating a loop *)
+  apply (drule_tac pt=empty_pt in pt_walk_non_empty_ptD; simp add: in_omonad fun_upd_apply)
+   apply (cases pte; clarsimp simp: pptr_from_pte_def)
+   apply (drule (2) table_index_slot_offset_inj, simp)
+  apply (clarsimp simp: in_omonad pte_of_def)
+  apply (cases pte; clarsimp)
+  apply (fastforce simp: pptr_from_pte_def in_omonad fun_upd_apply
+                   intro!: table_index_slot_offset_inj)
+  done
+
+(* NOTE: should be able to derive the (pte_ref pte) \<noteq> table_base p) from
+   the (pte_ref pte) being unreachable anywhere in the original state
+   (this should come from having an unmapped cap to it) *)
+lemma store_pte_PageTablePTE_valid_vspace_objs:
+  "\<lbrace> valid_vspace_objs
+     and pspace_aligned and valid_asid_table and unique_table_refs and valid_vs_lookup
+     and (\<lambda>s. valid_caps (caps_of_state s) s)
+     and K (is_PageTablePTE pte)
+     and (\<lambda>s. \<forall>level. \<exists>\<rhd> (level, table_base p) s
+                      \<longrightarrow> valid_pte level pte s \<and> pts_of s (the (pte_ref pte)) = Some empty_pt
+                         \<and> the (pte_ref pte) \<noteq> table_base p) \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>s. valid_vspace_objs \<rbrace>"
+  supply fun_upd_apply[simp del]
+  apply (wpsimp simp: store_pte_def set_pt_def wp: set_object_wp)
+  apply (subst valid_vspace_objs_def)
+  apply (clarsimp split del: if_split)
+  apply (rename_tac p' ao)
+  (* focus on valid_vspace_obj level ao s  *)
+  apply (rule valid_vspace_obj_same_type; simp?)
+    defer
+    apply (fastforce simp: obj_at_def)
+   apply simp
+  apply (drule vs_lookup_level)
+  (* if table_base p is unreachable, we are not updating anything relevant *)
+  apply (case_tac "\<forall>level. vs_lookup_table level asid vref s \<noteq> Some (level, table_base p)")
+   apply (subst (asm) vs_lookup_table_unreachable_upd_idem; simp?)
+   apply (fastforce simp: fun_upd_apply valid_vspace_objs_def split: if_splits)
+  (* we are changing the reachable page table at table_base p *)
+  supply valid_vspace_obj.simps[simp del]
+  apply clarsimp
+  apply (rename_tac level')
+  apply (prop_tac "valid_pte level' pte s", fastforce)
+  (* updating deeper than where we can find table_base p has no effect *)
+  apply (case_tac "level' \<le> level")
+   apply (drule vs_lookup_level, drule (3) vs_lookup_table_fun_upd_deep_idem; assumption?)
+   apply (clarsimp simp: fun_upd_apply split: if_splits)
+    apply (prop_tac "level' = level", fastforce dest: no_loop_vs_lookup_table)
+    apply (rule valid_vspace_obj_valid_pte_upd; simp?)
+    apply (clarsimp simp: valid_vspace_objs_def aobjs_of_ako_at_Some)
+   apply (clarsimp simp: valid_vspace_objs_def aobjs_of_ako_at_Some)
+  (* we are updating at table_base p, which is within the original lookup path *)
+  apply (clarsimp simp: not_le)
+  (* to use vs_lookup_splitD, need asid_pool_level taken care of *)
+  apply (case_tac "level' = asid_pool_level")
+   apply (clarsimp simp: pool_for_asid_vs_lookup)
+   apply (drule (1) pool_for_asid_validD)
+   apply (clarsimp simp: asid_pools_of_ko_at obj_at_def)
+  apply clarsimp
+  (* split both lookups down to table_base p *)
+  apply (drule vs_lookup_level)
+  apply (drule_tac level=level in vs_lookup_splitD; simp?)
+   apply (fastforce intro: less_imp_le)
+  apply clarsimp
+  apply (rename_tac pt_ptr)
+  (* update now occurs in pt_walk stage *)
+  apply (drule (1) vs_lookup_table_fun_upd_deep_idem; assumption?; simp)
+  apply (prop_tac "valid_pte level' pte s \<and> pts_of s (the (pte_ref pte)) = Some empty_pt
+                   \<and> the (pte_ref pte) \<noteq> table_base p", fastforce)
+  (* handle the actual update, happening on next step of pt_walk *)
+  apply (subst (asm) pt_walk.simps, clarsimp simp: in_omonad split: if_splits)
+  apply (rename_tac pte')
+  apply (erule disjE; clarsimp)
+  apply (clarsimp simp: fun_upd_apply)
+  apply (subst (asm) pte_of_def)
+  apply (clarsimp simp: in_omonad)
+  apply (rename_tac pt')
+  apply (clarsimp simp: fun_upd_apply)
+  apply (case_tac "table_index (pt_slot_offset level' (table_base p) vref) = table_index p"; clarsimp)
+   prefer 2
+   (* staying on old path; we can't hit table_base p again *)
+   (* this transform copied from elsewhere, FIXME RISCV might be useful to extract *)
+   apply (subst (asm) pt_walk_pt_upd_idem; simp?)
+    apply clarsimp
+    apply (rename_tac level'')
+    apply (prop_tac "pt_walk level' level'' (table_base p) vref (ptes_of s) = Some (level'', table_base p)")
+     apply (subst pt_walk.simps)
+     apply clarsimp
+     apply (prop_tac "level'' < level'")
+      apply (drule pt_walk_max_level)
+      apply (simp add: bit0.leq_minus1_less)
+     apply (clarsimp simp: in_omonad obj_at_def)
+     apply (rule_tac x="(pt (table_index (pt_slot_offset level' (table_base p) vref)))" in exI)
+     apply clarsimp
+     apply (clarsimp simp: ptes_of_def in_omonad)
+    apply (prop_tac "level'' < level'")
+     apply (drule pt_walk_max_level)
+     apply (simp add: bit0.leq_minus1_less)
+    apply (prop_tac "vs_lookup_table level'' asid vref s = Some (level'', table_base p)")
+     apply (erule (2) vs_lookup_table_extend)
+    apply (drule (1) no_loop_vs_lookup_table; simp?)
+   (* pt_walk is now on pts_of s, can stitch it back together into a vs_lookup_table *)
+   (* FIXME RISCV again useful transform from elsewhere *)
+   apply (prop_tac "pt_walk level' level (table_base p) vref (ptes_of s) = Some (level, p')")
+    apply (subst pt_walk.simps)
+    apply clarsimp
+    apply (clarsimp simp: in_omonad obj_at_def)
+    apply (rule_tac x="(pt (table_index (pt_slot_offset level' (table_base p) vref)))" in exI)
+    apply clarsimp
+    apply (clarsimp simp: ptes_of_def in_omonad)
+   apply (prop_tac "vs_lookup_table level asid vref s = Some (level, p')")
+    apply (erule (2) vs_lookup_table_extend)
+   (* p' can't equal table_base p since we see it earlier in the lookup *)
+   apply (prop_tac "p' \<noteq> table_base p")
+    apply clarsimp
+    apply (drule (1) no_loop_vs_lookup_table, simp+)
+   (* finally can use valid_vspace_objs *)
+   apply (clarsimp simp: valid_vspace_objs_def)
+  (* we could not have arrived at our new empty table through a non-empty table and from
+     precondition, we are not creating a loop *)
+  apply (drule_tac pt=empty_pt in pt_walk_non_empty_ptD; simp add: in_omonad fun_upd_apply)
+   apply (cases pte; clarsimp simp: pptr_from_pte_def)
+  apply clarsimp
+  apply (cases pte; clarsimp simp: pptr_from_pte_def in_omonad valid_vspace_obj.simps)
+  done
+
+lemma store_pte_valid_vspace_objs:
+  "\<lbrace> valid_vspace_objs
+     and pspace_aligned and valid_asid_table and unique_table_refs and valid_vs_lookup
+     and (\<lambda>s. valid_caps (caps_of_state s) s)
+     and (\<lambda>s. \<forall>level. \<exists>\<rhd> (level, table_base p) s
+                      \<longrightarrow> valid_pte level pte s
+                         \<and> (is_PageTablePTE pte \<longrightarrow> pts_of s (the (pte_ref pte)) = Some empty_pt
+                                                   \<and> the (pte_ref pte) \<noteq> table_base p)) \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_. valid_vspace_objs \<rbrace>"
+  apply (case_tac pte; clarsimp)
+    (* InvalidPTE *)
+    apply wpsimp
+   (* PagePTE *)
+   apply (wpsimp wp: store_pte_PagePTE_valid_vspace_objs)
+   apply fastforce
+  (* PageTablePTE *)
+  apply (wp store_pte_PageTablePTE_valid_vspace_objs, clarsimp)
+  done
+
+
+lemma store_pte_valid_vs_lookup:
+  "\<lbrace> valid_vs_lookup
+     and pspace_aligned and valid_vspace_objs and valid_asid_table and unique_table_refs
+     and (\<lambda>s. valid_caps (caps_of_state s) s)
+     and (\<lambda>s. pte \<noteq> InvalidPTE
+              \<longrightarrow> (\<forall>level asid vref.
+                     vs_lookup_table level asid vref s = Some (level, table_base p)
+                     \<longrightarrow> vref \<in> user_region
+                     \<longrightarrow> pt_slot_offset level (table_base p) vref = p
+                     \<longrightarrow> (is_PageTablePTE pte \<longrightarrow> pts_of s (the (pte_ref pte)) = Some empty_pt)
+                         \<and> the (pte_ref pte) \<noteq> table_base p
+                         \<and> (\<exists>p' cap. caps_of_state s p' = Some cap \<and>
+                                     obj_refs cap = {the (pte_ref pte)} \<and>
+                                     vs_cap_ref cap = Some (asid, vref_for_level vref level)))) \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_. valid_vs_lookup \<rbrace>"
+  apply (case_tac pte; clarsimp)
+    apply (wpsimp wp: store_pte_InvalidPTE_valid_vs_lookup)
+   apply (wpsimp wp: store_pte_non_InvalidPTE_valid_vs_lookup)+
+  done
+
+lemma store_pte_valid_arch_caps:
+  "\<lbrace> valid_arch_caps
+     and pspace_aligned and valid_vspace_objs and valid_asid_table
+     and (\<lambda>s. valid_caps (caps_of_state s) s)
+     and (\<lambda>s. (\<forall>slot asidopt. caps_of_state s slot = Some (ArchObjectCap (PageTableCap (table_base p) asidopt))
+                              \<longrightarrow> asidopt = None \<longrightarrow> pte = InvalidPTE))
+     and (\<lambda>s. pte \<noteq> InvalidPTE
+              \<longrightarrow> (\<forall>level asid vref.
+                     vs_lookup_table level asid vref s = Some (level, table_base p)
+                     \<longrightarrow> vref \<in> user_region
+                     \<longrightarrow> pt_slot_offset level (table_base p) vref = p
+                     \<longrightarrow> (is_PageTablePTE pte \<longrightarrow> pts_of s (the (pte_ref pte)) = Some empty_pt)
+                         \<and> the (pte_ref pte) \<noteq> table_base p
+                         \<and> (\<exists>p' cap. caps_of_state s p' = Some cap \<and>
+                                     obj_refs cap = {the (pte_ref pte)} \<and>
+                                     vs_cap_ref cap = Some (asid, vref_for_level vref level)))) \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_. valid_arch_caps \<rbrace>"
+  unfolding valid_arch_caps_def
+  by (wpsimp wp: store_pte_valid_vs_lookup store_pte_valid_table_caps)
+
+lemma store_pte_invs:
+  "\<lbrace> invs
+     and (\<lambda>s. table_base p \<notin> global_refs s)
+     and K (wellformed_pte pte)
+     and (\<lambda>s. \<forall>level. \<exists>\<rhd> (level, table_base p) s
+                      \<longrightarrow> valid_pte level pte s
+                         \<and> (is_PageTablePTE pte \<longrightarrow> pts_of s (the (pte_ref pte)) = Some empty_pt
+                                                   \<and> the (pte_ref pte) \<noteq> table_base p))
+     and (\<lambda>s. (\<forall>slot asidopt. caps_of_state s slot = Some (ArchObjectCap (PageTableCap (table_base p) asidopt))
+                              \<longrightarrow> asidopt = None \<longrightarrow> pte = InvalidPTE))
+     and (\<lambda>s. ((\<exists>asid. vspace_for_asid asid s = Some (table_base p))
+                       \<longrightarrow> table_index p \<notin> kernel_mapping_slots))
+     and (\<lambda>s. pte \<noteq> InvalidPTE
+              \<longrightarrow> (\<forall>level asid vref.
+                     vs_lookup_table level asid vref s = Some (level, table_base p)
+                     \<longrightarrow> vref \<in> user_region
+                     \<longrightarrow> pt_slot_offset level (table_base p) vref = p
+                     \<longrightarrow> (is_PageTablePTE pte \<longrightarrow> pts_of s (the (pte_ref pte)) = Some empty_pt)
+                         \<and> the (pte_ref pte) \<noteq> table_base p
+                         \<and> (\<exists>p' cap. caps_of_state s p' = Some cap \<and>
+                                     obj_refs cap = {the (pte_ref pte)} \<and>
+                                     vs_cap_ref cap = Some (asid, vref_for_level vref level)))) \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_. invs \<rbrace>"
+  apply (simp add: invs_def valid_state_def valid_pspace_def valid_arch_state_def)
+  apply (wpsimp wp: store_pte_valid_global_vspace_mappings store_pte_valid_global_tables
+                    store_pte_valid_vspace_objs store_pte_valid_arch_caps
+                    store_pte_equal_kernel_mappings_no_kernel_slots)
+  apply (clarsimp simp: valid_objs_caps valid_arch_caps_def)
+  done
+
+lemma store_pte_invs_unmap:
+  "\<lbrace>invs and
+    (\<lambda>s. \<exists>slot ref. caps_of_state s slot = Some (ArchObjectCap (PageTableCap (table_base p) ref))) and
+    (\<lambda>s. (\<exists>asid. vspace_for_asid asid s = Some (table_base p)) \<longrightarrow> table_index p \<notin> kernel_mapping_slots) and
+    (\<lambda>s. table_base p \<notin> global_refs s) and K (pte = InvalidPTE)\<rbrace>
+  store_pte p pte \<lbrace>\<lambda>_. invs\<rbrace>"
+  by (wpsimp wp: store_pte_invs simp: wellformed_pte_def)
+
+
+lemma vs_lookup_table_vspace:
+  "\<lbrakk> vs_lookup_table level asid vptr s = Some (level, pt_ptr);
+     vspace_for_asid asid' s = Some pt_ptr; vptr \<in> user_region; invs s \<rbrakk>
+   \<Longrightarrow> asid' = asid \<and> level = max_pt_level"
+  apply (cases "level = asid_pool_level"; clarsimp)
+   apply (clarsimp simp: vs_lookup_table_def)
+   apply (drule pool_for_asid_validD; clarsimp)
+   apply (drule vspace_for_asid_valid_pt; clarsimp)
+   apply (fastforce simp: in_omonad)
+  apply (drule vspace_for_asid_vs_lookup)
+  apply (frule_tac level=level and level'=max_pt_level in unique_vs_lookup_table, assumption; clarsimp?)
+   apply (fastforce intro: valid_objs_caps)
+  apply (drule (1) no_loop_vs_lookup_table; clarsimp?)
+   apply (rule vref_for_level_eq_max_mono[symmetric], simp)
+  apply (fastforce intro: valid_objs_caps)
+  done
+
+lemma pspace_respects_device_region_dmo:
+  assumes valid_f: "\<And>P. f \<lbrace>\<lambda>ms. P (device_state ms)\<rbrace>"
+  shows "do_machine_op f \<lbrace>pspace_respects_device_region\<rbrace>"
+  apply (clarsimp simp: do_machine_op_def gets_def select_f_def simpler_modify_def bind_def valid_def
+                        get_def return_def)
+  apply (drule_tac P1 = "(=) (device_state (machine_state s))" in use_valid[OF _ valid_f])
+  apply auto
+  done
+
+lemma cap_refs_respects_device_region_dmo:
+  assumes valid_f: "\<And>P. f \<lbrace>\<lambda>ms. P (device_state ms)\<rbrace>"
+  shows "do_machine_op f \<lbrace>cap_refs_respects_device_region\<rbrace>"
+  apply (clarsimp simp: do_machine_op_def gets_def select_f_def simpler_modify_def bind_def valid_def
+                        get_def return_def)
+  apply (drule_tac P1 = "(=) (device_state (machine_state s))" in use_valid[OF _ valid_f])
+  apply auto
+  done
+
+lemma machine_op_lift_device_state[wp]:
+  "machine_op_lift f \<lbrace>\<lambda>ms. P (device_state ms)\<rbrace>"
+  by (clarsimp simp: machine_op_lift_def NonDetMonad.valid_def bind_def
+                     machine_rest_lift_def gets_def simpler_modify_def get_def return_def
+                     select_def ignore_failure_def select_f_def
+              split: if_splits)
+
+crunch device_state_inv[wp]: sfence "\<lambda>ms. P (device_state ms)"
+crunch device_state_inv[wp]: hwASIDFlush "\<lambda>ms. P (device_state ms)"
+crunch device_state_inv[wp]: setVSpaceRoot "\<lambda>ms. P (device_state ms)"
+
+lemma as_user_inv:
+  assumes x: "\<And>P. \<lbrace>P\<rbrace> f \<lbrace>\<lambda>x. P\<rbrace>"
+  shows      "\<lbrace>P\<rbrace> as_user t f \<lbrace>\<lambda>x. P\<rbrace>"
+proof -
+  have P: "\<And>a b input. (a, b) \<in> fst (f input) \<Longrightarrow> b = input"
+    by (rule use_valid [OF _ x], assumption, rule refl)
+  have Q: "\<And>s ps. ps (kheap s) = kheap s \<Longrightarrow> kheap_update ps s = s"
+    by simp
+  show ?thesis
+    apply (simp add: as_user_def gets_the_def assert_opt_def set_object_def get_object_def split_def)
+    apply wp
+    apply (clarsimp dest!: P)
+    apply (subst Q)
+     prefer 2
+     apply assumption
+    apply (rule ext)
+    apply (simp add: get_tcb_def)
+    apply (case_tac "kheap s t"; simp)
+    apply (case_tac a; simp)
+    apply (clarsimp simp: arch_tcb_context_set_def arch_tcb_context_get_def)
+    done
+qed
+
+crunches getRegister
+  for inv[wp]: P
+  (simp: getRegister_def)
+
+lemmas user_getreg_inv[wp] = as_user_inv[OF getRegister_inv]
+
+lemma dmo_read_stval_inv[wp]:
+  "do_machine_op read_stval \<lbrace>P\<rbrace>"
+  by (rule dmo_inv) (simp add: read_stval_def)
+
+end
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -13,11 +13,6 @@ theory ArchAcc_AI
 imports SubMonad_AI "Lib.Crunch_Instances_NonDet"
 begin
 
-(* FIXME MOVE, might break proofs elsewhere *)
-lemma if_Some_Some[simp]:
-  "((if P then Some v else None) = Some v) = P"
-  by simp
-
 context non_vspace_op
 begin
 

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -20,7 +21,7 @@ lemma valid_vso_at[wp]:"\<lbrace>valid_vso_at level p\<rbrace> f \<lbrace>\<lamb
 
 end
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 (* Is there a lookup that leads to a page table at (level, p)? *)
 locale_abbrev ex_vs_lookup_table ::
@@ -43,12 +44,13 @@ lemma invs_valid_asid_table [elim!]:
   "invs s \<Longrightarrow> valid_asid_table s"
   by (simp add: invs_def valid_state_def valid_arch_state_def)
 
+(* FIXME AARCH64
 lemma ptes_of_wellformed_pte:
   "\<lbrakk> ptes_of s p = Some pte; valid_objs s \<rbrakk> \<Longrightarrow> wellformed_pte pte"
   apply (clarsimp simp: ptes_of_def in_omonad)
   apply (erule (1) valid_objsE)
   apply (clarsimp simp: valid_obj_def)
-  done
+  done *)
 
 lemma vs_lookup_table_target:
   "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p); level \<le> max_pt_level \<rbrakk> \<Longrightarrow>
@@ -60,6 +62,7 @@ lemma vs_lookup_table_target:
    prefer 2
    apply (metis max_pt_level_plus_one add.right_cancel)
   apply (clarsimp simp: obind_assoc simp del: asid_pool_level_neq)
+  sorry (* FIXME AARCH64
   apply (subst (asm) pt_walk_split_Some[where level'="level + 1"]; simp add: less_imp_le)
   apply (subst (asm) (2) pt_walk.simps)
   apply (subgoal_tac "level + 1 \<noteq> asid_pool_level")
@@ -69,7 +72,7 @@ lemma vs_lookup_table_target:
   apply (rule_tac x="level + 1" in exI)
   apply (subst pt_walk_vref_for_level; simp add: less_imp_le)
   apply (clarsimp simp: is_PageTablePTE_def pptr_from_pte_def split: if_split_asm)
-  done
+  done *)
 
 lemma vs_lookup_table_targetD:
   "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p); level \<le> max_pt_level \<rbrakk>
@@ -134,7 +137,8 @@ lemma vspace_for_asid_from_lookup_target:
                         vs_lookup_slot_def pool_for_asid_vs_lookup asid_pool_level_eq[symmetric]
                         vspace_for_asid_def
                   split: if_splits)
-  done
+  sorry (* FIXME AARCH64
+  done *)
 
 lemma unique_table_refsD:
   "\<lbrakk> caps_of_state s p = Some cap; caps_of_state s p' = Some cap';
@@ -208,9 +212,11 @@ proof -
     apply (subst mask_lower_twice)
    apply (rule pt_bits_left_mono, erule (1) vm_level_le_plus_1_mono, rule refl)
   apply (simp add: mask_shifl_overlap_zero pt_bits_left_def)
-  done
+  sorry (* FIXME AARCH64
+  done *)
 qed
 
+(* FIXME AARCH64
 lemma pt_slot_offset_vref_for_level_idem:
   "\<lbrakk> is_aligned p pt_bits; level' \<le> max_pt_level \<rbrakk>
    \<Longrightarrow> pt_slot_offset level' p
@@ -375,6 +381,7 @@ lemma vs_lookup_table_same_for_different_levels:
   apply (drule pt_walk_same_for_different_levels; simp?)
   apply (erule vspace_for_pool_is_aligned; simp)
   by force
+*)
 
 lemma no_loop_vs_lookup_table_helper:
   "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p);
@@ -386,6 +393,7 @@ lemma no_loop_vs_lookup_table_helper:
      valid_vspace_objs s; valid_asid_table s; pspace_aligned s;
      valid_caps (caps_of_state s) s \<rbrakk>
     \<Longrightarrow> level' = level"
+  sorry (* FIXME AARCH64
    apply (drule (1) vs_lookup_table_same_for_different_levels; simp?)
     apply (frule (1) vm_level_less_plus_1_mono)
     apply (simp add: max_absorb1)
@@ -407,7 +415,7 @@ lemma no_loop_vs_lookup_table_helper:
     apply (fastforce elim!: vs_lookup_table_is_aligned)
    apply (drule_tac pt_ptr=pt_ptr in valid_vspace_objs_strongD, assumption; simp?)
    apply (fastforce simp: pte_of_def in_omonad is_aligned_pt_slot_offset_pte)
-  done
+  done *)
 
 lemma no_loop_vs_lookup_table:
   "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p);
@@ -483,6 +491,7 @@ lemma vs_lookup_table_unique_level:
   apply (auto simp: max_def split: if_split_asm)
   done
 
+(* FIXME AARCH64
 (* invs could be relaxed; lemma so far only needed when invs is present *)
 lemma vs_lookup_slot_table_base:
   "\<lbrakk> vs_lookup_slot level asid vref s = Some (level, slot); vref \<in> user_region;
@@ -519,6 +528,7 @@ lemma pt_slot_offset_vref_for_level:
   apply (thin_tac "All P" for P)
   apply (erule_tac x="n - pt_bits_left level" in allE)
   by fastforce
+*)
 
 (* invs could be relaxed; lemma so far only needed when invs is present *)
 lemma vs_lookup_slot_unique_level:
@@ -528,10 +538,11 @@ lemma vs_lookup_slot_unique_level:
      level \<le> max_pt_level; level' \<le> max_pt_level; vref \<in> user_region; vref' \<in> user_region;
      invs s\<rbrakk>
   \<Longrightarrow> level' = level \<and> asid' = asid \<and> vref_for_level vref' level = vref_for_level vref level"
+  sorry (* FIXME AARCH64
   apply (clarsimp simp: vs_lookup_slot_table_unfold)
   apply (drule (1) vs_lookup_table_unique_level; clarsimp)
   apply (drule pt_slot_offset_vref_for_level[where p="table_base p"]; clarsimp)
-  done
+  done *)
 
 lemma get_asid_pool_wp [wp]:
   "\<lbrace>\<lambda>s. \<forall>pool. ko_at (ArchObj (ASIDPool pool)) p s \<longrightarrow> Q pool s\<rbrace>
@@ -559,16 +570,18 @@ lemma get_pt_wp[wp]:
   by (wpsimp simp: obj_at_def in_opt_map_eq)
 
 
+(* FIXME AARCH64
 lemma get_pte_wp:
   "\<lbrace>\<lambda>s. \<forall>pt. ko_at (ArchObj (PageTable pt)) (p && ~~mask pt_bits) s \<longrightarrow>
         Q (pt (ucast (p && mask pt_bits >> pte_bits))) s\<rbrace>
   get_pte p
   \<lbrace>Q\<rbrace>"
-  by (wpsimp simp: ptes_of_Some in_opt_map_eq obj_at_def)
+  by (wpsimp simp: ptes_of_Some in_opt_map_eq obj_at_def) *)
 
+(* FIXME AARCH64
 lemma get_pte_inv[wp]:
   "\<lbrace>P\<rbrace> get_pte p \<lbrace>\<lambda>_. P\<rbrace>"
-  by (wpsimp wp: get_pte_wp)
+  by (wpsimp wp: get_pte_wp) *)
 
 lemmas store_pte_typ_ats [wp] = abs_typ_at_lifts [OF store_pte_typ_at]
 
@@ -607,6 +620,7 @@ lemma set_asid_pool_pred_tcb_at[wp]:
   apply (wpsimp wp: get_object_wp simp: pred_tcb_at_def obj_at_def)
   done
 
+(* FIXME AARCH64
 lemma mask_pt_bits_inner_beauty:
   "is_aligned p pte_bits \<Longrightarrow>
   (p && ~~ mask pt_bits) + (ucast ((ucast (p && mask pt_bits >> pte_bits))::pt_index) << pte_bits) = (p::machine_word)"
@@ -618,7 +632,7 @@ lemma more_pt_inner_beauty:
   assumes x: "x \<noteq> ucast (p && mask pt_bits >> pte_bits)"
   shows "(p && ~~ mask pt_bits) + (ucast x << pte_bits) = p \<Longrightarrow> False"
   by (rule mask_split_aligned_neg[OF _ _ x]; simp add: bit_simps)
-
+*)
 
 lemmas undefined_validE_R = hoare_FalseE_R[where f=undefined]
 
@@ -638,6 +652,7 @@ lemma arch_derive_cap_inv:
   "\<lbrace>P\<rbrace> arch_derive_cap arch_cap \<lbrace>\<lambda>rv. P\<rbrace>"
   unfolding arch_derive_cap_def by (cases arch_cap; wpsimp)
 
+(* FIXME AARCH64
 definition
   "valid_mapping_entries m \<equiv> case m of
     (InvalidPTE, _) \<Rightarrow> \<top>
@@ -650,7 +665,7 @@ definition
 definition
   "valid_slots \<equiv> \<lambda>(pte, p) s. wellformed_pte pte \<and>
      (\<forall>level. \<exists>\<rhd>(level, p && ~~ mask pt_bits) s \<longrightarrow> pte_at p s \<and> valid_pte level pte s)"
-
+*)
 
 lemma ucast_mask_asid_low_bits [simp]:
   "ucast ((asid::machine_word) && mask asid_low_bits) = (ucast asid :: asid_low_index)"
@@ -687,7 +702,8 @@ lemma set_asid_pool_pts_of [wp]:
 
 lemma set_asid_pool_valid_arch [wp]:
   "\<lbrace>valid_arch_state\<rbrace> set_asid_pool p a \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  by (rule valid_arch_state_lift_arch; wp set_asid_pool_typ_at)
+  sorry (* FIXME AARCH64
+  by (rule valid_arch_state_lift_arch; wp set_asid_pool_typ_at) *)
 
 lemma set_asid_pool_valid_objs [wp]:
   "\<lbrace>valid_objs\<rbrace> set_asid_pool p a \<lbrace>\<lambda>_. valid_objs\<rbrace>"
@@ -696,7 +712,7 @@ lemma set_asid_pool_valid_objs [wp]:
   including unfold_objects
   by (clarsimp simp: a_type_def valid_obj_def)
 
-
+(* FIXME AARCH64
 lemma invs_valid_global_arch_objs:
   "invs s \<Longrightarrow> valid_global_arch_objs s"
   by (clarsimp simp: invs_def valid_state_def valid_arch_state_def)
@@ -738,6 +754,7 @@ lemma page_table_pte_at_diffE:
   apply (clarsimp simp: diff_eq_eq add.commute)
   apply (erule(2) page_table_pte_atI)
   done
+*)
 
 lemma vs_lookup_table_extend:
   "\<lbrakk> vs_lookup_table level asid vref s = Some (level, pt);
@@ -746,6 +763,7 @@ lemma vs_lookup_table_extend:
    \<Longrightarrow> vs_lookup_table bot_level asid vref s = Some (bot_level, p)"
   by (rule vs_lookup_split_Some[THEN iffD2] ; fastforce intro!: pt_walk_max_level)
 
+(* FIXME AARCH64
 lemma pt_walk_pt_at:
   "\<lbrakk> pt_walk level bot_level pt_ptr vptr (ptes_of s) = Some (level', p);
      vs_lookup_table level asid vptr s = Some (level, pt_ptr); level \<le> max_pt_level;
@@ -776,7 +794,7 @@ lemma pt_lookup_slot_from_level_pte_at:
   apply (frule pt_walk_pt_at; assumption?)
   apply (fastforce simp: pte_at_def is_aligned_pt_slot_offset_pte is_aligned_pt)
   done
-
+*)
 lemma set_pt_distinct [wp]:
   "\<lbrace>pspace_distinct\<rbrace> set_pt p pt \<lbrace>\<lambda>_. pspace_distinct\<rbrace>"
   apply (simp add: set_pt_def)
@@ -796,6 +814,7 @@ lemma store_pt_asid_pools_of[wp]:
   apply (auto simp: obj_at_def opt_map_def elim!: rsubst[where P=P])
   done
 
+(* FIXME AARCH64
 lemma store_pte_asid_pools_of[wp]:
   "store_pte p pte \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
   unfolding store_pte_def by wpsimp
@@ -803,12 +822,14 @@ lemma store_pte_asid_pools_of[wp]:
 lemma store_pte_vspace_at_asid:
   "store_pte p pte \<lbrace>vspace_at_asid asid pt\<rbrace>"
   unfolding vspace_at_asid_def by (wp vspace_for_asid_lift)
+*)
 
 (* FIXME MOVE *)
 lemma ko_at_kheap:
   "ko_at ko p s \<Longrightarrow> kheap s p = Some ko"
   unfolding obj_at_def by simp
 
+(* FIXME AARCH64
 lemma store_pte_valid_objs [wp]:
   "\<lbrace>(\<lambda>s. wellformed_pte pte) and valid_objs\<rbrace> store_pte p pte \<lbrace>\<lambda>_. valid_objs\<rbrace>"
   apply (simp add: store_pte_def set_pt_def bind_assoc set_object_def get_object_def)
@@ -816,7 +837,7 @@ lemma store_pte_valid_objs [wp]:
   apply (clarsimp simp: valid_objs_def dom_def simp del: fun_upd_apply)
   apply (frule ko_at_kheap)
   apply (fastforce intro!: valid_obj_same_type simp: valid_obj_def split: if_split_asm)
-  done
+  done *)
 
 lemma set_pt_caps_of_state [wp]:
   "\<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace> set_pt p pt \<lbrace>\<lambda>_ s. P (caps_of_state s)\<rbrace>"
@@ -825,12 +846,13 @@ lemma set_pt_caps_of_state [wp]:
   apply (subst caps_of_state_after_update, auto elim: obj_at_weakenE)
   done
 
+(* FIXME AARCH64
 lemma store_pte_aligned [wp]:
   "\<lbrace>pspace_aligned\<rbrace> store_pte pt p \<lbrace>\<lambda>_. pspace_aligned\<rbrace>"
   apply (simp add: store_pte_def set_pt_def)
   apply (wp set_object_aligned get_object_wp)
   including unfold_objects
-  by (clarsimp simp: a_type_def)
+  by (clarsimp simp: a_type_def) *)
 
 
 lemma set_asid_pool_aligned [wp]:
@@ -850,15 +872,17 @@ lemma set_asid_pool_distinct [wp]:
   done
 
 
+(* FIXME AARCH64
 lemma store_pte_valid_pte [wp]:
   "\<lbrace>valid_pte level pt\<rbrace> store_pte p pte \<lbrace>\<lambda>_. valid_pte level pt\<rbrace>"
-  by (wp valid_pte_lift store_pte_typ_at)
+  by (wp valid_pte_lift store_pte_typ_at) *)
 
 lemma global_refs_kheap [simp]:
   "global_refs (kheap_update f s) = global_refs s"
   by (simp add: global_refs_def)
 
 
+(* FIXME AARCH64
 lemma set_pt_valid_objs:
   "\<lbrace>(\<lambda>s. \<forall>i. wellformed_pte (pt i)) and valid_objs\<rbrace>
    set_pt p pt
@@ -866,7 +890,7 @@ lemma set_pt_valid_objs:
   apply (simp add: set_pt_def)
   apply (wp get_object_wp set_object_valid_objs)
   apply (clarsimp simp: valid_obj_def obj_at_def split: kernel_object.splits arch_kernel_obj.splits)
-  done
+  done *)
 
 
 lemma set_pt_iflive:
@@ -977,6 +1001,7 @@ lemma unique_table_caps_ptD:
   \<Longrightarrow> p = p'"
   unfolding unique_table_caps_2_def by fastforce
 
+(* FIXME AARCH64
 lemma set_pt_table_caps[wp]:
   "\<lbrace>valid_table_caps and (\<lambda>s. valid_caps (caps_of_state s) s) and
     (\<lambda>s. (\<forall>slot asidopt. caps_of_state s slot = Some (ArchObjectCap (PageTableCap p asidopt))
@@ -1002,6 +1027,7 @@ lemma store_pte_valid_table_caps:
   unfolding store_pte_def
   by wpsimp
      (fastforce simp: valid_table_caps_def pts_of_ko_at obj_at_def)
+*)
 
 lemma set_object_caps_of_state:
   "\<lbrace>(\<lambda>s. \<not>tcb_at p s \<and> \<not>(\<exists>n. cap_table_at n p s)) and
@@ -1072,6 +1098,7 @@ lemma pts_of_upd_idem:
   unfolding pt_of_def
   by (clarsimp simp: opt_map_def split: option.splits)
 
+(* FIXME AARCH64
 lemma pt_walk_eqI:
   "\<lbrakk> \<forall>level' pt_ptr'.
        level < level'
@@ -1146,6 +1173,7 @@ lemma pt_walk_upd_idem:
       = pt_walk top_level level pt_ptr vptr (ptes_of s)"
   by (rule pt_walk_eqI; simp split del: if_split)
      (clarsimp simp: opt_map_def split: option.splits)
+*)
 
 lemma pt_walk_pt_None_updD:
   "\<lbrakk> pt_walk top_level level pt_ptr vref (\<lambda>pa. pte_of pa ((pts_of s)(p := None))) =
@@ -1157,18 +1185,20 @@ lemma pt_walk_pt_None_updD:
   apply (clarsimp simp: in_omonad split: if_splits)
   apply (erule disjE; clarsimp?)
    apply (rule_tac x=v' in exI; clarsimp)
+   sorry (* FIXME AARCH64
    apply (subst (asm) (3) pte_of_def)
    apply (clarsimp simp: in_omonad split: if_splits)
    apply (simp (no_asm) add: ptes_of_def in_monad obind_def)
    apply (clarsimp split: option.splits simp: pts_of_ko_at obj_at_def)
   apply (drule meta_spec)
   apply (fastforce simp: pte_of_def in_omonad split: if_splits)
-  done
+  done *)
 
+(* FIXME AARCH64
 lemma ptes_of_pt_None_updD:
   "\<lbrakk> pte_of p' ((pts_of s)(p := None)) = Some pte \<rbrakk>
    \<Longrightarrow> ptes_of s p' = Some pte"
-  by (clarsimp simp: opt_map_def pte_of_def in_omonad split: option.splits if_splits)
+  by (clarsimp simp: opt_map_def pte_of_def in_omonad split: option.splits if_splits) *)
 
 lemma vs_lookup_table_eqI:
   fixes s :: "'z::state_ext state"
@@ -1192,6 +1222,7 @@ lemma vs_lookup_table_eqI:
   apply (rename_tac pool_ptr)
   apply (rule obind_eqI_full; clarsimp)
    apply (erule_tac x=asid_pool_level in allE)
+   sorry (* FIXME AARCH64
    apply (fastforce simp: pool_for_asid_vs_lookup pool_for_asid_def vspace_for_pool_def obind_def
                           order.not_eq_order_implies_strict)
   apply (rename_tac root)
@@ -1200,7 +1231,7 @@ lemma vs_lookup_table_eqI:
    apply (frule pt_walk_max_level)
    apply (fastforce simp add: vs_lookup_table_def in_omonad asid_pool_level_eq pool_for_asid_def)
   apply (rule vspace_for_pool_is_aligned; fastforce simp add: pool_for_asid_def)
-  done
+  done *)
 
 lemma vs_lookup_table_upd_idem:
   "\<lbrakk> \<forall>level' p'.
@@ -1239,6 +1270,7 @@ lemma pt_lookup_target_translate_address_upd_eq:
   unfolding translate_address_def
   by (simp add: obind_def split: option.splits)
 
+(* FIXME AARCH64
 lemma pt_lookup_target_slot_from_level_eq:
   "\<lbrakk> pt_lookup_slot_from_level max_pt_level level pt_ptr vref ptes'
      = pt_lookup_slot_from_level max_pt_level level pt_ptr vref ptes;
@@ -1301,6 +1333,7 @@ lemma pt_lookup_target_pt_upd_eq:
    \<Longrightarrow> pt_lookup_target level pt_ptr vptr (\<lambda>p. pte_of p (pts(obj_ref := pt')))
       = pt_lookup_target level pt_ptr vptr (\<lambda>p. pte_of p pts)"
   by (rule pt_lookup_target_pt_eqI; clarsimp)
+*)
 
 lemma kheap_pt_upd_simp[simp]:
   "(kheap s(p \<mapsto> ArchObj (PageTable pt)) |> aobj_of |> pt_of)
@@ -1308,6 +1341,7 @@ lemma kheap_pt_upd_simp[simp]:
   unfolding aobj_of_def opt_map_def
   by (auto split: kernel_object.split)
 
+(* FIXME AARCH64
 lemma valid_global_tablesD:
   "\<lbrakk> valid_global_tables s;
      pt_walk max_pt_level bot_level (riscv_global_pt (arch_state s)) vref (ptes_of s)
@@ -1340,19 +1374,22 @@ lemma riscv_global_pts_aligned:
    \<Longrightarrow> is_aligned pt_ptr pt_bits"
   unfolding valid_global_arch_objs_def
   by (fastforce dest: pspace_aligned_pts_ofD simp: pt_at_eq)
+*)
 
 (* FIXME MOVE, might break proofs elsewhere *)
 lemma if_Some_Some[simp]:
   "((if P then Some v else None) = Some v) = P"
   by simp
 
+(* FIXME AARCH64
 lemma user_region_canonical_pptr_base:
   "\<lbrakk> p \<notin> user_region; canonical_address p \<rbrakk> \<Longrightarrow> pptr_base \<le> p"
   using canonical_below_pptr_base_canonical_user word_le_not_less
-  by (auto simp add: user_region_def not_le)
+  by (auto simp add: user_region_def not_le) *)
 
 lemma kernel_regions_pptr_base:
   "\<lbrakk> p \<in> kernel_regions s; valid_uses s \<rbrakk> \<Longrightarrow> pptr_base \<le> p"
+  sorry (* FIXME AARCH64
   apply (rule user_region_canonical_pptr_base)
    apply (simp add: valid_uses_def window_defs)
    apply (erule_tac x=p in allE)
@@ -1360,8 +1397,9 @@ lemma kernel_regions_pptr_base:
   apply (simp add: valid_uses_def window_defs)
   apply (erule_tac x=p in allE)
   apply auto[1]
-  done
+  done *)
 
+(* FIXME AARCH64
 lemma kernel_regions_in_mappings:
   "\<lbrakk> p \<in> kernel_regions s; valid_uses s \<rbrakk> \<Longrightarrow> p \<in> kernel_mappings"
   apply (frule (1) kernel_regions_pptr_base)
@@ -1411,6 +1449,7 @@ lemma set_pt_kernel_window[wp]:
                  split: kernel_object.split_asm
                         arch_kernel_obj.split_asm)
   done
+*)
 
 lemma set_pt_respects_device_region[wp]:
   "\<lbrace>pspace_respects_device_region\<rbrace> set_pt p pt \<lbrace>\<lambda>rv. pspace_respects_device_region\<rbrace>"
@@ -1444,8 +1483,9 @@ lemma set_pt_valid_ioc[wp]:
   "\<lbrace>valid_ioc\<rbrace> set_pt p pt \<lbrace>\<lambda>_. valid_ioc\<rbrace>"
   apply (simp add: set_pt_def)
   apply (wp set_object_valid_ioc_no_caps get_object_wp)
+  sorry (* FIXME AARCH64
   by (clarsimp simp: a_type_simps obj_at_def is_tcb is_cap_table
-              split: kernel_object.splits arch_kernel_obj.splits)
+              split: kernel_object.splits arch_kernel_obj.splits) *)
 
 
 
@@ -1550,7 +1590,8 @@ lemma set_asid_pool_iflive [wp]:
   apply (wp get_object_wp set_object_iflive)
   apply (clarsimp split: kernel_object.splits arch_kernel_obj.splits)
   apply (clarsimp simp: obj_at_def live_def hyp_live_def)
-  done
+  sorry (* FIXME AARCH64
+  done *)
 
 
 lemma set_asid_pool_zombies [wp]:
@@ -1700,6 +1741,7 @@ lemma vs_lookup_target_unreachable_upd_idem:
    apply (drule vs_lookup_level, drule vs_lookup_level)
    apply (clarsimp simp: pool_for_asid_vs_lookup vspace_for_pool_def in_omonad)
    apply (rule obind_eqI[rotated], fastforce)
+   sorry (* FIXME AARCH64
    apply (case_tac "pool_ptr = obj_ref"; clarsimp)
     apply (erule_tac x=asid_pool_level in allE)
     apply (fastforce simp: pool_for_asid_vs_lookup)
@@ -1713,7 +1755,7 @@ lemma vs_lookup_target_unreachable_upd_idem:
    apply (prop_tac "is_aligned pt_ptr pt_bits")
     apply (erule vs_lookup_table_is_aligned; fastforce)
    apply (clarsimp simp: fun_upd_def opt_map_def split: option.splits)
-  done
+  done *)
 
 lemma vs_lookup_target_unreachable_upd_idem':
   "\<lbrakk> \<not>(\<exists>level. \<exists>\<rhd> (level, obj_ref) s);
@@ -1765,6 +1807,7 @@ lemma set_asid_pool_vspace_objs_unmap':
    (* level \<le> max_pt_level *)
    apply clarsimp
    apply (drule vs_lookup_level, drule vs_lookup_level)
+   sorry (* FIXME AARCH64
    apply (drule (5) vs_lookup_table_pt_at)
    apply (case_tac "pt_ptr = p"; simp add: aobjs_of_ako_at_Some)
     apply (clarsimp simp: aobjs_of_ako_at_Some obj_at_def fun_upd_apply fun_upd_def)
@@ -1780,7 +1823,7 @@ lemma set_asid_pool_vspace_objs_unmap':
   apply (clarsimp simp: vspace_for_pool_def in_omonad fun_upd_apply)
   apply (case_tac "pool_ptr = p"; clarsimp simp: asid_pools_of_ko_at obj_at_def)
    apply (fastforce elim: graph_of_SomeD)
-  done
+  done *)
 
 lemma set_asid_pool_vspace_objs_unmap:
   "\<lbrace>valid_vspace_objs and ko_at (ArchObj (ASIDPool ap)) p and
@@ -1797,6 +1840,7 @@ lemma set_asid_pool_table_caps[wp]:
   apply (rule hoare_lift_Pf2 [where f=caps_of_state];wp?)
   done
 
+(* FIXME AARCH64
 lemma vs_lookup_target_asid_pool_levelI:
   "\<lbrakk> pool_for_asid asid s = Some pool; ako_at (ASIDPool ap) pool s;
      ap (asid_low_bits_of asid) = Some pt_ptr \<rbrakk>
@@ -1813,6 +1857,7 @@ lemma vs_lookup_target_pt_levelI:
      level \<le> max_pt_level \<rbrakk>
    \<Longrightarrow> vs_lookup_target level asid vref s = Some (level, target)"
   by (clarsimp simp: vs_lookup_target_def in_omonad vs_lookup_slot_def asid_pool_level_neq[THEN iffD2])
+*)
 
 lemma vs_lookup_target_asid_pool_level_upd_helper:
   "\<lbrakk> graph_of ap \<subseteq> graph_of ap'; kheap s p = Some (ArchObj (ASIDPool ap')); vref \<in> user_region;
@@ -1820,12 +1865,13 @@ lemma vs_lookup_target_asid_pool_level_upd_helper:
      pool_for_asid asid (s\<lparr>kheap := kheap s(p \<mapsto> ArchObj (ASIDPool ap))\<rparr>) = Some pool_ptr\<rbrakk>
    \<Longrightarrow> vs_lookup_target asid_pool_level asid vref s = Some (asid_pool_level, pt_ptr)"
   apply (clarsimp simp: pool_for_asid_vs_lookup vspace_for_pool_def in_omonad)
+  sorry (* FIXME AARCH64
   apply (clarsimp split: if_splits)
    apply (rule vs_lookup_target_asid_pool_levelI)
    apply (fastforce simp: pool_for_asid_def obj_at_def dest: graph_of_SomeD)+
   apply (rule vs_lookup_target_asid_pool_levelI
          ; fastforce simp: pool_for_asid_def obj_at_def vs_lookup_target_def in_omonad)
-  done
+  done *)
 
 lemma vs_lookup_target_None_upd_helper:
   "\<lbrakk> vs_lookup_table level asid vref (s\<lparr>kheap := kheap s(p \<mapsto> ArchObj (ASIDPool ap))\<rparr>) =
@@ -1840,6 +1886,7 @@ lemma vs_lookup_target_None_upd_helper:
   apply (clarsimp simp: vs_lookup_target_def in_omonad vs_lookup_slot_def)
   apply (clarsimp simp: asid_pool_level_neq[THEN iffD2])
   apply (rule_tac x="pt_slot_offset level table_ptr vref" in exI)
+  sorry (* FIXME AARCH64
   apply (rule conjI[rotated], fastforce dest: ptes_of_pt_None_updD)
   apply (rule_tac x=level in exI)
   apply (clarsimp simp: asid_pool_level_neq[THEN iffD2])
@@ -1853,7 +1900,7 @@ lemma vs_lookup_target_None_upd_helper:
    apply (fastforce simp: asid_pools_of_ko_at obj_at_def  vspace_for_pool_def in_omonad
                     dest!: graph_of_SomeD pt_walk_pt_None_updD
                     split: if_splits)+
-  done
+  done *)
 
 lemma set_asid_pool_vs_lookup_unmap':
   "\<lbrace> valid_vs_lookup and
@@ -1918,6 +1965,7 @@ lemma set_asid_pool_only_idle [wp]:
   "\<lbrace>only_idle\<rbrace> set_asid_pool p ap \<lbrace>\<lambda>_. only_idle\<rbrace>"
   by (wp only_idle_lift set_asid_pool_typ_at)
 
+(* FIXME AARCH64
 lemma set_asid_pool_equal_mappings[wp]:
   "\<lbrace>equal_kernel_mappings and
     (\<lambda>s. \<forall>p pt. p \<in> ran ap \<longrightarrow> pts_of s p = Some pt \<longrightarrow> has_kernel_mappings pt s)\<rbrace>
@@ -1938,14 +1986,15 @@ lemma set_asid_pool_equal_mappings[wp]:
                   split: option.splits if_splits)
   apply (subgoal_tac "vspace_for_asid asid s = Some pt_ptr")
    apply (fastforce elim: vspace_for_asid_SomeI simp: opt_map_def)+
-  done
+  done *)
 
 lemma translate_address_asid_pool_upd:
   "pts_of s p = None
    \<Longrightarrow> translate_address pt_ptr vref
         (\<lambda>pa. pte_of pa (kheap s(p \<mapsto> ArchObj (ASIDPool ap)) |> aobj_of |> pt_of))
       = translate_address pt_ptr vref (ptes_of s)"
-  by simp
+  sorry (* FIXME AARCH64
+  by simp *)
 
 lemma ko_atasid_pool_pts_None:
   "ako_at (ASIDPool pool) p s \<Longrightarrow> pts_of s p = None"
@@ -1958,8 +2007,9 @@ lemma set_asid_pool_valid_global_vspace_mappings[wp]:
   unfolding set_asid_pool_def
   apply (wpsimp wp: set_object_wp)
   apply (simp only: valid_global_vspace_mappings_def Let_def) (* prevent simp loop *)
+  sorry (* FIXME AARCH64
   apply (clarsimp simp: translate_address_asid_pool_upd ko_atasid_pool_pts_None)
-  done
+  done *)
 
 lemma set_asid_pool_kernel_window[wp]:
   "\<lbrace>pspace_in_kernel_window\<rbrace> set_asid_pool p ap \<lbrace>\<lambda>rv. pspace_in_kernel_window\<rbrace>"
@@ -2028,6 +2078,7 @@ lemma set_asid_pool_invs_restrict:
             set_asid_pool_vspace_objs_unmap  valid_irq_handlers_lift
             set_asid_pool_vs_lookup_unmap)
   apply (clarsimp simp: equal_kernel_mappings_def)
+  sorry (* FIXME AARCH64
   apply (rename_tac s pt_ptr hi_bits pt)
   apply (clarsimp dest!: ran_restrictD)
   apply (rename_tac lo_bits)
@@ -2041,7 +2092,7 @@ lemma set_asid_pool_invs_restrict:
                          pool_for_asid_vs_lookup pool_for_asid_def
                          constructed_asid_high_bits_of constructed_asid_low_bits_of)
   apply (drule vspace_for_asid_from_lookup_target; simp)
-  done
+  done *)
 
 lemmas set_asid_pool_cte_wp_at1[wp]
     = hoare_cte_wp_caps_of_state_lift [OF set_asid_pool_caps_of_state]
@@ -2063,6 +2114,7 @@ lemma set_asid_pool_invs_unmap:
   using set_asid_pool_invs_restrict[where S="- {x}"]
   by (simp add: restrict_map_def fun_upd_def if_flip)
 
+(* FIXME AARCH64
 lemma pte_at_typ_at_lift:
   assumes aa_type: "\<And>T p. f \<lbrace>typ_at (AArch T) p\<rbrace>"
   shows "f \<lbrace>pte_at p\<rbrace>"
@@ -2079,34 +2131,35 @@ lemma valid_slots_typ_at:
                     valid_pte_lift pte_at_typ_at_lift)
   apply fastforce
   done
+*)
 
 lemma pool_for_asid_arch_update[simp]:
-  "riscv_asid_table (f (arch_state s)) = riscv_asid_table (arch_state s) \<Longrightarrow>
+  "arm_asid_table (f (arch_state s)) = arm_asid_table (arch_state s) \<Longrightarrow>
   pool_for_asid asid (arch_state_update f s) = pool_for_asid asid s"
   by (simp add: pool_for_asid_def obind_def split: option.splits)
 
 lemma vs_lookup_table_arch_update[simp]:
-  "riscv_asid_table (f (arch_state s)) = riscv_asid_table (arch_state s) \<Longrightarrow>
+  "arm_asid_table (f (arch_state s)) = arm_asid_table (arch_state s) \<Longrightarrow>
    vs_lookup_table level asid vref (arch_state_update f s) = vs_lookup_table level asid vref s"
   by (simp add: vs_lookup_table_def obind_def split: option.splits)
 
 lemma vs_lookup_arch_update[simp]:
-  "riscv_asid_table (f (arch_state s)) = riscv_asid_table (arch_state s) \<Longrightarrow>
+  "arm_asid_table (f (arch_state s)) = arm_asid_table (arch_state s) \<Longrightarrow>
    vs_lookup (arch_state_update f s) = vs_lookup s"
   by (rule ext)+ simp
 
 lemma vs_lookup_slot_arch_update[simp]:
-  "riscv_asid_table (f (arch_state s)) = riscv_asid_table (arch_state s) \<Longrightarrow>
+  "arm_asid_table (f (arch_state s)) = arm_asid_table (arch_state s) \<Longrightarrow>
    vs_lookup_slot level asid vref (arch_state_update f s) = vs_lookup_slot level asid vref s"
   by (simp add: vs_lookup_slot_def obind_def split: option.splits)
 
 lemma vs_lookup_target_arch_update[simp]:
-  "riscv_asid_table (f (arch_state s)) = riscv_asid_table (arch_state s) \<Longrightarrow>
+  "arm_asid_table (f (arch_state s)) = arm_asid_table (arch_state s) \<Longrightarrow>
    vs_lookup_target level asid vref (arch_state_update f s) = vs_lookup_target level asid vref  s"
   by (simp add: vs_lookup_target_def obind_def split: option.splits)
 
 lemma vs_lookup_pages_arch_update[simp]:
-  "riscv_asid_table (f (arch_state s)) = riscv_asid_table (arch_state s) \<Longrightarrow>
+  "arm_asid_table (f (arch_state s)) = arm_asid_table (arch_state s) \<Longrightarrow>
    vs_lookup_pages (arch_state_update f s) = vs_lookup_pages s"
   by (rule ext)+ simp
 
@@ -2123,6 +2176,7 @@ lemma set_pt_mappings[wp]:
   "\<lbrace>\<top>\<rbrace> set_pt p pt \<lbrace>\<lambda>_. valid_kernel_mappings\<rbrace>"
   by (simp add: valid_kernel_mappings_def) wp
 
+(* FIXME AARCH64
 lemma set_pt_has_kernel_mappings:
   "\<lbrace>\<lambda>s. p \<noteq> riscv_global_pt (arch_state s) \<and> has_kernel_mappings pt s \<rbrace>
    set_pt p pt'
@@ -2196,6 +2250,7 @@ lemma store_pte_valid_asid_table[wp]:
   apply (wpsimp wp: set_object_wp hoare_vcg_imp_lift' hoare_vcg_all_lift)
   apply (subst asid_pools_of_pt_None_upd_idem, auto simp: obj_at_def)
   done
+*)
 
 crunches store_pte
   for iflive[wp]: if_live_then_nonz_cap
@@ -2223,6 +2278,7 @@ crunches store_pte
   (wp: set_pt_zombies set_pt_ifunsafe set_pt_reply_caps set_pt_reply_masters
        set_pt_valid_global valid_irq_node_typ valid_irq_handlers_lift set_pt_cur)
 
+(* FIXME AARCH64
 lemma store_pte_valid_global_tables:
   "\<lbrace> valid_global_tables and valid_global_arch_objs and valid_global_vspace_mappings
      and (\<lambda>s. table_base p \<notin> global_refs s) \<rbrace>
@@ -2759,7 +2815,6 @@ lemma store_pte_valid_vspace_objs:
   apply (wp store_pte_PageTablePTE_valid_vspace_objs, clarsimp)
   done
 
-
 lemma store_pte_valid_vs_lookup:
   "\<lbrace> valid_vs_lookup
      and pspace_aligned and valid_vspace_objs and valid_asid_table and unique_table_refs
@@ -2840,6 +2895,7 @@ lemma store_pte_invs_unmap:
     (\<lambda>s. table_base p \<notin> global_refs s) and K (pte = InvalidPTE)\<rbrace>
   store_pte p pte \<lbrace>\<lambda>_. invs\<rbrace>"
   by (wpsimp wp: store_pte_invs simp: wellformed_pte_def)
+*)
 
 
 lemma vs_lookup_table_vspace:
@@ -2884,8 +2940,10 @@ lemma machine_op_lift_device_state[wp]:
                      select_def ignore_failure_def select_f_def
               split: if_splits)
 
+(* FIXME AARCH64
 crunch device_state_inv[wp]: sfence "\<lambda>ms. P (device_state ms)"
 crunch device_state_inv[wp]: hwASIDFlush "\<lambda>ms. P (device_state ms)"
+*)
 crunch device_state_inv[wp]: setVSpaceRoot "\<lambda>ms. P (device_state ms)"
 
 lemma as_user_inv:
@@ -2919,7 +2977,8 @@ lemmas user_getreg_inv[wp] = as_user_inv[OF getRegister_inv]
 
 lemma dmo_read_stval_inv[wp]:
   "do_machine_op read_stval \<lbrace>P\<rbrace>"
-  by (rule dmo_inv) (simp add: read_stval_def)
+  sorry (* FIXME AARCH64
+  by (rule dmo_inv) (simp add: read_stval_def) *)
 
 end
 

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -663,8 +663,8 @@ definition
   "invalid_pte_at pt_t p \<equiv> \<lambda>s. ptes_of s pt_t p = Some InvalidPTE"
 
 definition
-  "valid_slots \<equiv> \<lambda>(pte, p) s. wellformed_pte pte \<and>
-     (\<forall>level. \<exists>\<rhd>(level, p && ~~ mask (pt_bits level)) s \<longrightarrow> pte_at level p s \<and> valid_pte level pte s)"
+  "valid_slots \<equiv> \<lambda>(pte, p, level) s. wellformed_pte pte \<and>
+     (\<exists>\<rhd>(level, p && ~~ mask (pt_bits level)) s \<longrightarrow> pte_at level p s \<and> valid_pte level pte s)"
 
 lemma ucast_mask_asid_low_bits [simp]:
   "ucast ((asid::machine_word) && mask asid_low_bits) = (ucast asid :: asid_low_index)"
@@ -2013,7 +2013,6 @@ lemma valid_slots_typ_at:
   apply (cases m; clarsimp)
   apply (wpsimp wp: hoare_vcg_ex_lift hoare_vcg_all_lift hoare_vcg_imp_lift' assms
                     valid_pte_lift pte_at_typ_lift)
-  apply fastforce
   done
 
 lemma pool_for_asid_arch_update[simp]:

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -1091,7 +1091,8 @@ lemma set_pt_asid_map [wp]:
 
 lemma set_pt_only_idle [wp]:
   "\<lbrace>only_idle\<rbrace> set_pt p pt \<lbrace>\<lambda>_. only_idle\<rbrace>"
-  by (wp only_idle_lift)
+  sorry (* FIXME AARCH64
+  by (wp only_idle_lift) *)
 
 lemma pts_of_upd_idem:
   "obj_ref \<noteq> pt_ptr \<Longrightarrow> pts_of (s\<lparr> kheap := (kheap s)(obj_ref := Some ko)\<rparr>) pt_ptr = pts_of s pt_ptr"
@@ -2006,8 +2007,8 @@ lemma set_asid_pool_valid_global_vspace_mappings[wp]:
    \<lbrace>\<lambda>rv. valid_global_vspace_mappings\<rbrace>"
   unfolding set_asid_pool_def
   apply (wpsimp wp: set_object_wp)
-  apply (simp only: valid_global_vspace_mappings_def Let_def) (* prevent simp loop *)
   sorry (* FIXME AARCH64
+  apply (simp only: valid_global_vspace_mappings_def Let_def) (* prevent simp loop *)
   apply (clarsimp simp: translate_address_asid_pool_upd ko_atasid_pool_pts_None)
   done *)
 
@@ -2252,6 +2253,10 @@ lemma store_pte_valid_asid_table[wp]:
   done
 *)
 
+lemma store_pte_valid_irq_node[wp]:
+  "store_pte pt_t p pte \<lbrace>valid_irq_node\<rbrace>"
+  sorry
+
 crunches store_pte
   for iflive[wp]: if_live_then_nonz_cap
   and zombies_final[wp]: zombies_final
@@ -2263,7 +2268,6 @@ crunches store_pte
   and valid_reply_caps[wp]: valid_reply_caps
   and valid_reply_masters[wp]: valid_reply_masters
   and valid_global_refs[wp]: valid_global_refs
-  and valid_irq_node[wp]: valid_irq_node
   and valid_irq_handlers[wp]: valid_irq_handlers
   and valid_irq_states[wp]: valid_irq_states
   and valid_machine_state[wp]: valid_machine_state

--- a/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
@@ -1,0 +1,1332 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchArch_AI
+imports Arch_AI
+begin
+
+unbundle l4v_word_context
+
+context Arch begin global_naming RISCV64
+
+definition
+  "valid_aci aci \<equiv> case aci of MakePool frame slot parent base \<Rightarrow>
+     \<lambda>s. cte_wp_at (\<lambda>c. c = NullCap) slot s \<and> real_cte_at slot s \<and>
+         ex_cte_cap_wp_to is_cnode_cap slot s \<and>
+         slot \<noteq> parent \<and>
+         cte_wp_at (\<lambda>cap. \<exists>idx. cap = UntypedCap False frame pageBits idx) parent s \<and>
+         descendants_of parent (cdt s) = {} \<and>
+         is_aligned base asid_low_bits \<and>
+         asid_table s (asid_high_bits_of base) = None"
+
+lemma safe_parent_strg:
+  "cte_wp_at (\<lambda>cap. cap = UntypedCap False frame pageBits idx) p s \<and>
+   descendants_of p (cdt s) = {} \<and>
+   valid_objs s
+  \<longrightarrow>
+  cte_wp_at (safe_parent_for (cdt s) p
+             (ArchObjectCap (ASIDPoolCap frame base)))
+             p s"
+  apply (clarsimp simp: cte_wp_at_caps_of_state safe_parent_for_def is_physical_def arch_is_physical_def)
+  apply (rule is_aligned_no_overflow)
+  apply (drule (1) caps_of_state_valid_cap)
+  apply (clarsimp simp: valid_cap_def cap_aligned_def)
+  done
+
+lemma range_cover_full:
+  "\<lbrakk>is_aligned ptr sz; sz<word_bits\<rbrakk> \<Longrightarrow> range_cover (ptr::machine_word) sz sz (Suc 0)"
+   by (clarsimp simp:range_cover_def unat_eq_0 le_mask_iff[symmetric] word_and_le1 word_bits_def)
+
+
+definition
+  valid_arch_inv :: "arch_invocation \<Rightarrow> 'z::state_ext state \<Rightarrow> bool"
+where
+  "valid_arch_inv ai \<equiv> case ai of
+     InvokePageTable pti \<Rightarrow> valid_pti pti
+   | InvokePage pgi \<Rightarrow> valid_page_inv pgi
+   | InvokeASIDControl aci \<Rightarrow> valid_aci aci
+   | InvokeASIDPool api \<Rightarrow> valid_apinv api"
+
+lemma check_vp_wpR [wp]:
+  "\<lbrace>\<lambda>s. vmsz_aligned w sz \<longrightarrow> P () s\<rbrace>
+  check_vp_alignment sz w \<lbrace>P\<rbrace>, -"
+  apply (simp add: check_vp_alignment_def unlessE_whenE cong: vmpage_size.case_cong)
+  apply (rule hoare_pre)
+   apply (wp hoare_whenE_wp|wpc)+
+  apply (simp add: vmsz_aligned_def)
+  done
+
+
+lemma check_vp_inv: "\<lbrace>P\<rbrace> check_vp_alignment sz w \<lbrace>\<lambda>_. P\<rbrace>"
+  apply (simp add: check_vp_alignment_def unlessE_whenE cong: vmpage_size.case_cong)
+  apply (rule hoare_pre)
+   apply (wp hoare_whenE_wp|wpc)+
+  apply simp
+  done
+
+
+lemma p2_low_bits_max:
+  "(2 ^ asid_low_bits - 1) = (max_word :: asid_low_index)"
+  by (simp add: asid_low_bits_def)
+
+lemma dom_ucast_eq:
+  "is_aligned y asid_low_bits \<Longrightarrow>
+   (- dom (\<lambda>a::asid_low_index. p (ucast a :: machine_word)) \<inter> {x. ucast x + (y::RISCV64_A.asid) \<noteq> 0} = {}) =
+   (- dom p \<inter> {x. x \<le> 2 ^ asid_low_bits - 1 \<and> x + ucast y \<noteq> 0} = {})"
+  apply safe
+   apply clarsimp
+   apply (rule ccontr)
+   apply (erule_tac x="ucast x" in in_emptyE)
+   apply (clarsimp simp: p2_low_bits_max)
+   apply (rule conjI)
+    apply (clarsimp simp: ucast_ucast_mask)
+    apply (subst (asm) less_mask_eq)
+    apply (rule word_less_sub_le [THEN iffD1])
+      apply (simp add: word_bits_def)
+     apply (simp add: asid_low_bits_def)
+    apply simp
+   apply (clarsimp simp: mask_2pm1[symmetric] ucast_ucast_mask2 is_down is_aligned_mask)
+   apply (frule and_mask_eq_iff_le_mask[THEN iffD2])
+   apply (simp add: asid_low_bits_def)
+   apply (erule notE)
+   apply (subst word_plus_and_or_coroll)
+    apply word_eqI_solve
+   apply (subst (asm) word_plus_and_or_coroll; word_bitwise, clarsimp simp: word_size)
+  apply (clarsimp simp: p2_low_bits_max)
+  apply (rule ccontr)
+  apply simp
+  apply (erule_tac x="ucast x" in in_emptyE)
+  apply clarsimp
+  apply (rule conjI, blast)
+  apply (rule conjI)
+   apply (rule word_less_sub_1)
+   apply (rule order_less_le_trans)
+    apply (rule ucast_less, simp)
+   apply (simp add: asid_low_bits_def)
+  apply clarsimp
+  apply (erule notE)
+  apply (simp add: is_aligned_mask asid_low_bits_def)
+  apply (subst word_plus_and_or_coroll)
+   apply word_eqI_solve
+  apply (subst (asm) word_plus_and_or_coroll)
+   apply (word_bitwise, clarsimp simp: word_size)
+  apply (word_bitwise)
+  done
+
+
+lemma asid_high_bits_max_word:
+  "(2 ^ asid_high_bits - 1) = (max_word :: asid_high_index)"
+  by (simp add: asid_high_bits_def)
+
+
+lemma dom_ucast_eq_8:
+  "(- dom (\<lambda>a::asid_high_index. p (ucast a::machine_word)) = {}) =
+   (- dom p \<inter> {x. x \<le> 2 ^ asid_high_bits - 1} = {})"
+  apply safe
+   apply clarsimp
+   apply (rule ccontr)
+   apply (erule_tac x="ucast x" in in_emptyE)
+   apply (clarsimp simp: asid_high_bits_max_word)
+   apply (clarsimp simp: ucast_ucast_mask)
+   apply (subst (asm) less_mask_eq)
+   apply (rule word_less_sub_le [THEN iffD1])
+     apply (simp add: word_bits_def)
+    apply (simp add: asid_high_bits_def)
+   apply simp
+  apply (clarsimp simp: asid_high_bits_max_word)
+  apply (rule ccontr)
+  apply simp
+  apply (erule_tac x="ucast x" in in_emptyE)
+  apply clarsimp
+  apply (rule conjI, blast)
+  apply (rule word_less_sub_1)
+  apply (rule order_less_le_trans)
+  apply (rule ucast_less, simp)
+  apply (simp add: asid_high_bits_def)
+  done
+
+
+lemma ucast_fst_hd_assocs:
+  assumes "- dom (\<lambda>x::asid_low_index. pool (ucast x)) \<inter> {x. ucast x + (a::RISCV64_A.asid) \<noteq> 0} \<noteq> {}"
+  assumes "is_aligned a asid_low_bits"
+  shows
+    "fst (hd [(x, y) \<leftarrow> assocs pool. x \<le> 2 ^ asid_low_bits - 1 \<and> x + ucast a \<noteq> 0 \<and> y = None]) +
+           (ucast a :: machine_word) =
+       ucast (UCAST(asid_low_len \<rightarrow> asid_len)
+         (fst (hd [(x, y) \<leftarrow> assocs (\<lambda>a. pool (ucast a)). ucast x + a \<noteq> 0 \<and> y = None])) + a)"
+proof -
+  have [unfolded word_bits_def, simplified, simp]: "asid_low_bits < word_bits"
+    by (simp add: asid_low_bits_def word_bits_def)
+  have [unfolded asid_low_bits_def, simplified, simp]:
+    "x && mask asid_low_bits = x"
+    if "x < 2^asid_low_bits" for x::machine_word
+    using that by (simp add: le_mask_iff_lt_2n[THEN iffD1, symmetric] word_le_mask_eq)
+  have [unfolded asid_bits_def asid_low_bits_def, simplified, simp]:
+    "x && mask asid_bits = x"
+    if "x < 2^asid_low_bits" for x::machine_word
+  proof -
+    have "mask asid_low_bits \<le> (mask asid_bits :: machine_word)"
+      by (simp add: mask_def asid_low_bits_def asid_bits_def)
+    with that show ?thesis
+      by (simp add: le_mask_iff_lt_2n[THEN iffD1, symmetric] word_le_mask_eq)
+  qed
+  have [unfolded asid_bits_def asid_low_bits_def, simplified, simp]:
+    "(x + ucast a \<noteq> 0) = (ucast x + a \<noteq> 0)"
+    if "x < 2^asid_low_bits" for x::machine_word
+  proof -
+    from that have "x \<le> mask asid_low_bits" by (simp add: le_mask_iff_lt_2n[THEN iffD1, symmetric])
+    with `is_aligned a asid_low_bits`
+    show ?thesis
+      apply (subst word_and_or_mask_aligned2; simp add: is_aligned_ucastI)
+      apply (subst word_and_or_mask_aligned2, assumption, erule ucast_le_maskI)
+      apply (simp add: asid_low_bits_def)
+      apply word_bitwise
+      apply simp
+      done
+  qed
+
+  from assms show ?thesis
+    apply (simp add: ucast_assocs[unfolded o_def])
+    apply (simp add: filter_map split_def)
+    apply (simp cong: conj_cong add: ucast_ucast_mask2 is_down)
+    apply (simp add: asid_low_bits_def minus_one_norm)
+    apply (subgoal_tac "P" for P)  (* cut_tac but more awesome *)
+     apply (subst hd_map, assumption)
+     apply (simp add: ucast_ucast_mask2 is_down)
+     apply (drule hd_in_set)
+     apply clarsimp
+     apply (subst ucast_add_mask_aligned; assumption?)
+      apply (rule ucast_le_maskI)
+      apply (simp add: mask_def word_le_make_less)
+     apply (simp add: ucast_ucast_mask cong: conj_cong)
+    apply (simp add: assocs_empty_dom_comp null_def split_def)
+    apply (simp add: ucast_assocs[unfolded o_def] filter_map split_def)
+    apply (simp cong: conj_cong add: ucast_ucast_mask2 is_down)
+    done
+qed
+
+
+crunch typ_at [wp]:
+  perform_page_table_invocation, perform_page_invocation, perform_asid_pool_invocation
+  "\<lambda>s. P (typ_at T p s)"
+  (wp: crunch_wps)
+
+lemmas perform_page_table_invocation_typ_ats [wp] =
+  abs_typ_at_lifts [OF perform_page_table_invocation_typ_at]
+
+lemmas perform_page_invocation_typ_ats [wp] =
+  abs_typ_at_lifts [OF perform_page_invocation_typ_at]
+
+lemmas perform_asid_pool_invocation_typ_ats [wp] =
+  abs_typ_at_lifts [OF perform_asid_pool_invocation_typ_at]
+
+lemma perform_asid_control_invocation_tcb_at:
+  "\<lbrace>invs and valid_aci aci and st_tcb_at active p and
+    K (\<forall>w a b c. aci = asid_control_invocation.MakePool w a b c \<longrightarrow> w \<noteq> p)\<rbrace>
+  perform_asid_control_invocation aci
+  \<lbrace>\<lambda>rv. tcb_at p\<rbrace>"
+  apply (simp add: perform_asid_control_invocation_def)
+  apply (cases aci)
+  apply clarsimp
+  apply (wp |simp)+
+    apply (wp obj_at_delete_objects retype_region_obj_at_other2  hoare_vcg_const_imp_lift|assumption)+
+  apply (intro impI conjI)
+    apply (clarsimp simp: retype_addrs_def obj_bits_api_def default_arch_object_def image_def ptr_add_def)
+   apply (clarsimp simp: st_tcb_at_tcb_at)+
+  apply (frule st_tcb_ex_cap)
+    apply fastforce
+   apply (clarsimp split: Structures_A.thread_state.splits)
+   apply auto[1]
+  apply (clarsimp simp: ex_nonz_cap_to_def valid_aci_def)
+  apply (frule invs_untyped_children)
+  apply (clarsimp simp:cte_wp_at_caps_of_state)
+  apply (erule_tac ptr="(aa,ba)" in untyped_children_in_mdbE[where P="\<lambda>c. t \<in> zobj_refs c" for t])
+      apply (simp add: cte_wp_at_caps_of_state)
+     apply simp
+    apply (simp add:cte_wp_at_caps_of_state)
+    apply fastforce
+   apply (clarsimp simp: zobj_refs_to_obj_refs)
+   apply (erule(1) in_empty_interE)
+    apply (clarsimp simp:page_bits_def)
+  apply simp
+  done
+
+
+lemma ucast_asid_high_btis_of_le [simp]:
+  "ucast (asid_high_bits_of w) \<le> (2 ^ asid_high_bits - 1 :: machine_word)"
+  apply (simp add: asid_high_bits_of_def)
+  apply (rule word_less_sub_1)
+  apply (rule order_less_le_trans)
+  apply (rule ucast_less)
+   apply simp
+  apply (simp add: asid_high_bits_def)
+  done
+
+
+lemma invoke_arch_tcb:
+  "\<lbrace>invs and valid_arch_inv ai and st_tcb_at active tptr\<rbrace>
+  arch_perform_invocation ai
+  \<lbrace>\<lambda>rv. tcb_at tptr\<rbrace>"
+  apply (simp add: arch_perform_invocation_def)
+  apply (cases ai; simp; (wp; clarsimp simp add: st_tcb_at_tcb_at)?)
+  apply (wp perform_asid_control_invocation_tcb_at)
+  apply (clarsimp simp add: valid_arch_inv_def)
+  apply (clarsimp simp: valid_aci_def)
+  apply (frule st_tcb_ex_cap)
+    apply fastforce
+   apply (clarsimp split: Structures_A.thread_state.splits)
+   apply auto[1]
+  apply (clarsimp simp: ex_nonz_cap_to_def)
+  apply (frule invs_untyped_children)
+  apply (clarsimp simp:cte_wp_at_caps_of_state)
+  apply (erule_tac ptr="(aa,ba)" in untyped_children_in_mdbE[where P="\<lambda>c. t \<in> zobj_refs c" for t])
+      apply (simp add: cte_wp_at_caps_of_state)+
+    apply fastforce
+   apply (clarsimp simp: zobj_refs_to_obj_refs cte_wp_at_caps_of_state)
+   apply (drule_tac p="(aa,ba)" in caps_of_state_valid_cap, fastforce)
+   apply (clarsimp simp: valid_cap_def cap_aligned_def)
+   apply (drule_tac x=tptr in base_member_set, simp)
+    apply (simp add: pageBits_def field_simps del: atLeastAtMost_iff)
+   apply (metis (no_types) orthD1 x_power_minus_1)
+  apply simp
+  done
+
+end
+
+
+locale asid_update = Arch +
+  fixes ap asid_hi s s'
+  assumes ko: "asid_pools_of s ap = Some Map.empty"
+  assumes empty: "asid_table s asid_hi = None"
+  defines "s' \<equiv> s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := (asid_table s)(asid_hi \<mapsto> ap)\<rparr>\<rparr>"
+begin
+
+lemma aobjs_of[simp]:
+  "aobjs_of s' = aobjs_of s"
+  unfolding s'_def by simp
+
+lemma vspace_for_pool_ap[simp]:
+  "vspace_for_pool ap asid (asid_pools_of s) = None"
+  using ko by (simp add: vspace_for_pool_def obind_def)
+
+lemma asid_hi_pool_for_asid:
+  "asid_high_bits_of asid = asid_hi \<Longrightarrow> pool_for_asid asid s = None"
+  using empty by (simp add: pool_for_asid_def)
+
+lemma asid_hi_pool_for_asid':
+  "asid_high_bits_of asid = asid_hi \<Longrightarrow> pool_for_asid asid s' = Some ap"
+  by (simp add: pool_for_asid_def s'_def)
+
+lemma asid_hi_vs_lookup_table:
+  "asid_high_bits_of asid = asid_hi \<Longrightarrow> vs_lookup_table asid_pool_level asid vref s = None"
+  by (simp add: asid_hi_pool_for_asid vs_lookup_table_def obind_def)
+
+lemma vs_lookup_table:
+  "vs_lookup_table level asid vref s' =
+     (if asid_high_bits_of asid = asid_hi \<and> level = asid_pool_level
+      then Some (asid_pool_level, ap)
+      else vs_lookup_table level asid vref s)"
+  apply clarsimp
+  apply (rule conjI; clarsimp)
+   apply (clarsimp simp: vs_lookup_table_def in_omonad asid_hi_pool_for_asid')
+  apply (clarsimp simp: vs_lookup_table_def)
+  apply (cases "asid_high_bits_of asid = asid_hi"; simp)
+   apply (clarsimp simp: obind_def asid_hi_pool_for_asid' asid_hi_pool_for_asid)
+  apply (rule obind_eqI)
+   apply (simp add: s'_def pool_for_asid_def)
+  apply (clarsimp simp: obind_def split: option.splits)
+  done
+
+lemma vs_lookup_slot:
+  "vs_lookup_slot level asid vref s' =
+     (if asid_high_bits_of asid = asid_hi \<and> level = asid_pool_level
+      then Some (asid_pool_level, ap)
+      else vs_lookup_slot level asid vref s)"
+  apply (simp add: vs_lookup_slot_def)
+  apply (rule conjI; clarsimp)
+   apply (clarsimp simp: obind_def vs_lookup_table)
+  apply (rule obind_eqI)
+   apply (clarsimp simp: vs_lookup_table)
+  apply (clarsimp simp: obind_def split: option.splits)
+  done
+
+lemma vs_lookup_target[simp]:
+  "vs_lookup_target level asid vref s' = vs_lookup_target level asid vref s"
+  apply (cases "asid_high_bits_of asid = asid_hi \<and> level = asid_pool_level")
+   apply (simp add: vs_lookup_target_def vs_lookup_slot_def obind_def vs_lookup_table
+                    asid_hi_vs_lookup_table
+               split: option.splits)
+  apply (clarsimp simp: vs_lookup_target_def)
+  apply (rule obind_eqI)
+   apply (clarsimp simp: vs_lookup_slot)
+  apply (clarsimp simp: obind_def split: option.splits)
+  done
+
+lemma obj_at [simp]:
+  "obj_at P p s' = obj_at P p s"
+  by (simp add: s'_def)
+
+lemma valid_pte[simp]:
+  "valid_pte level pte s' = valid_pte level pte s"
+  by (cases pte; simp add: data_at_def)
+
+lemma valid_vspace_obj[simp]:
+  "valid_vspace_obj level ao s' = valid_vspace_obj level ao s"
+  by (cases ao; simp)
+
+lemma vspace_objs':
+  "valid_vspace_objs s \<Longrightarrow> valid_vspace_objs s'"
+  using ko
+  apply (clarsimp simp: valid_vspace_objs_def vs_lookup_table)
+  apply (clarsimp simp: in_omonad)
+  done
+
+lemma global_objs':
+  "valid_global_objs s \<Longrightarrow> valid_global_objs s'"
+  by (simp add: valid_global_objs_def)
+
+lemma caps_of_state_s':
+  "caps_of_state s' = caps_of_state s"
+  by (rule caps_of_state_pspace, simp add: s'_def)
+
+lemma valid_vs_lookup[simp]:
+  "valid_vs_lookup s' = valid_vs_lookup s"
+  by (clarsimp simp: valid_vs_lookup_def caps_of_state_s')
+
+lemma valid_table_caps':
+  "valid_table_caps s \<Longrightarrow> valid_table_caps s'"
+  by (simp add: valid_table_caps_def caps_of_state_s' s'_def)
+
+lemma valid_asid_pool_caps':
+  "\<lbrakk> valid_asid_pool_caps s;
+     \<exists>ptr cap. caps_of_state s ptr = Some cap
+     \<and> obj_refs cap = {ap} \<and> vs_cap_ref cap = Some (ucast asid_hi << asid_low_bits, 0) \<rbrakk>
+  \<Longrightarrow> valid_asid_pool_caps s'"
+  unfolding valid_asid_pool_caps_def by (clarsimp simp: s'_def)
+
+lemma valid_arch_caps:
+  "\<lbrakk> valid_arch_caps s;
+     \<exists>ptr cap. caps_of_state s ptr = Some cap
+     \<and> obj_refs cap = {ap} \<and> vs_cap_ref cap = Some (ucast asid_hi << asid_low_bits, 0) \<rbrakk>
+  \<Longrightarrow> valid_arch_caps s'"
+  apply (simp add: valid_arch_caps_def valid_table_caps' valid_asid_pool_caps')
+  apply (simp add: caps_of_state_s')
+  done
+
+lemma valid_asid_map':
+  "valid_asid_map s \<Longrightarrow> valid_asid_map s'"
+  by (clarsimp simp: valid_asid_map_def)
+
+lemma vspace_for_asid[simp]:
+  "vspace_for_asid asid s' = vspace_for_asid asid s"
+  using ko empty
+  by (clarsimp simp: vspace_for_asid_def obind_def pool_for_asid_def s'_def vspace_for_pool_def
+               split: option.splits)
+
+lemma global_pt[simp]:
+  "global_pt s' = global_pt s"
+  by (simp add: s'_def)
+
+lemma equal_kernel_mappings:
+  "equal_kernel_mappings s' = equal_kernel_mappings s"
+  by (simp add: equal_kernel_mappings_def has_kernel_mappings_def)
+
+end
+
+
+context Arch begin global_naming RISCV64
+
+lemma valid_arch_state_strg:
+  "valid_arch_state s \<and> ap \<notin> ran (asid_table s) \<and> asid_pool_at ap s \<longrightarrow>
+   valid_arch_state (s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := riscv_asid_table (arch_state s)(asid \<mapsto> ap)\<rparr>\<rparr>)"
+  apply (clarsimp simp: valid_arch_state_def)
+  apply (clarsimp simp: valid_asid_table_def ran_def)
+  apply (fastforce intro!: inj_on_fun_updI simp: asid_pools_at_eq)
+  done
+
+
+lemma valid_vs_lookup_at_upd_strg:
+  "valid_vs_lookup s \<and>
+   asid_pools_of s ap = Some Map.empty \<and>
+   asid_table s asid = None
+   \<longrightarrow>
+   valid_vs_lookup (s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := (asid_table s)(asid \<mapsto> ap)\<rparr>\<rparr>)"
+  apply clarsimp
+  apply (prop_tac "asid_update ap asid s", (unfold_locales; assumption))
+  apply (simp add: asid_update.valid_vs_lookup)
+  done
+
+lemma valid_asid_pool_caps_upd_strg:
+  "valid_asid_pool_caps s \<and>
+   asid_pools_of s ap = Some Map.empty \<and>
+   asid_table s asid = None \<and>
+   (\<exists>ptr cap. caps_of_state s ptr = Some cap
+     \<and> obj_refs cap = {ap} \<and> vs_cap_ref cap = Some (ucast asid << asid_low_bits, 0))
+   \<longrightarrow>
+   valid_asid_pool_caps_2 (caps_of_state s) (asid_table s(asid \<mapsto> ap))"
+  apply clarsimp
+  apply (prop_tac "asid_update ap asid s", (unfold_locales; assumption))
+  apply (fastforce dest: asid_update.valid_asid_pool_caps')
+  done
+
+lemma retype_region_ap[wp]:
+  "\<lbrace>\<top>\<rbrace>
+  retype_region ap (Suc 0) 0 (ArchObject ASIDPoolObj) dev
+  \<lbrace>\<lambda>_ s. asid_pools_of s ap = Some Map.empty\<rbrace>"
+  apply (rule hoare_post_imp)
+   prefer 2
+   apply (rule retype_region_obj_at)
+    apply simp
+   apply simp
+  apply (clarsimp simp: retype_addrs_def obj_bits_api_def default_arch_object_def)
+  apply (clarsimp simp: obj_at_def default_object_def default_arch_object_def in_omonad)
+  done
+
+
+lemma retype_region_ako[wp]:
+  "\<lbrace>\<top>\<rbrace> retype_region ap (Suc 0) 0 (ArchObject ASIDPoolObj) dev \<lbrace>\<lambda>_. ako_at (ASIDPool Map.empty) ap\<rbrace>"
+  apply (rule hoare_strengthen_post, rule retype_region_ap)
+  apply (simp add: obj_at_def in_omonad)
+  done
+
+lemma retype_region_ap':
+  "\<lbrace>\<top>\<rbrace> retype_region ap (Suc 0) 0 (ArchObject ASIDPoolObj) dev \<lbrace>\<lambda>rv. asid_pool_at ap\<rbrace>"
+  apply (rule hoare_strengthen_post, rule retype_region_ap)
+  apply (simp add: asid_pools_at_eq)
+  done
+
+
+lemma no_cap_to_obj_with_diff_ref_null_filter:
+  "no_cap_to_obj_with_diff_ref cap S
+     = (\<lambda>s. \<forall>c \<in> ran (null_filter (caps_of_state s) |` (- S)).
+             obj_refs c = obj_refs cap
+                 \<longrightarrow> table_cap_ref c = table_cap_ref cap)"
+  apply (simp add: no_cap_to_obj_with_diff_ref_def
+                   ball_ran_eq cte_wp_at_caps_of_state)
+  apply (simp add: Ball_def)
+  apply (intro iff_allI ext)
+  apply (simp add: restrict_map_def null_filter_def)
+  apply (auto dest!: obj_ref_none_no_asid[rule_format]
+               simp: table_cap_ref_def)
+  done
+
+
+lemma retype_region_no_cap_to_obj:
+  "\<lbrace>valid_pspace and valid_mdb
+             and caps_overlap_reserved {ptr..ptr + 2 ^ obj_bits_api ty us - 1}
+             and caps_no_overlap ptr sz
+             and pspace_no_overlap_range_cover ptr sz
+             and no_cap_to_obj_with_diff_ref cap S
+             and (\<lambda>s. \<exists>slot. cte_wp_at (\<lambda>c. up_aligned_area ptr sz \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s)
+             and K (ty = CapTableObject \<longrightarrow> 0 < us)
+             and K (range_cover ptr sz (obj_bits_api ty us) 1) \<rbrace>
+     retype_region ptr 1 us ty dev
+   \<lbrace>\<lambda>rv. no_cap_to_obj_with_diff_ref cap S\<rbrace>"
+  apply (rule hoare_gen_asm)+
+  apply (simp add: no_cap_to_obj_with_diff_ref_null_filter)
+  apply (wp retype_region_caps_of | simp)+
+  apply fastforce
+  done
+
+
+lemma valid_table_caps_asid_upd [iff]:
+  "valid_table_caps (s\<lparr>arch_state := (riscv_asid_table_update f (arch_state s))\<rparr>) =
+   valid_table_caps s"
+  by (simp add: valid_table_caps_def second_level_tables_def)
+
+lemma set_cap_reachable_pg_cap:
+  "set_cap cap' slot \<lbrace>\<lambda>s. P (reachable_frame_cap cap s)\<rbrace>"
+  unfolding reachable_frame_cap_def reachable_target_def vs_lookup_target_def
+  apply (clarsimp simp: in_omonad vs_lookup_slot_def vs_lookup_table_def)
+  apply (wp_pre, wps, wp)
+  apply simp
+  done
+
+lemma set_cap_reachable_target[wp]:
+  "set_cap cap slot \<lbrace>\<lambda>s. P (reachable_target ref p s)\<rbrace>"
+  apply (clarsimp simp: reachable_target_def split_def)
+  apply (wp_pre, wps, wp)
+  apply simp
+  done
+
+lemma cap_insert_simple_arch_caps_ap:
+  "\<lbrace>valid_arch_caps and (\<lambda>s. cte_wp_at (safe_parent_for (cdt s) src cap) src s)
+     and no_cap_to_obj_with_diff_ref cap {dest}
+     and (\<lambda>s. asid_table s (asid_high_bits_of asid) = None \<and> asid_pools_of s ap = Some Map.empty)
+     and K (cap = ArchObjectCap (ASIDPoolCap ap asid) \<and> is_aligned asid asid_low_bits) \<rbrace>
+     cap_insert cap src dest
+   \<lbrace>\<lambda>rv s. valid_arch_caps (s\<lparr>arch_state := arch_state s
+                       \<lparr>riscv_asid_table := riscv_asid_table (arch_state s)(asid_high_bits_of asid \<mapsto> ap)\<rparr>\<rparr>)\<rbrace>"
+  apply (simp add: cap_insert_def update_cdt_def set_cdt_def valid_arch_caps_def
+                   set_untyped_cap_as_full_def bind_assoc)
+  apply (strengthen valid_vs_lookup_at_upd_strg valid_asid_pool_caps_upd_strg)
+  apply (wp get_cap_wp set_cap_valid_vs_lookup set_cap_arch_obj
+            set_cap_valid_table_caps hoare_vcg_all_lift
+          | simp split del: if_split)+
+       apply (simp add: F)
+       apply (rule_tac P = "cte_wp_at ((=) src_cap) src" in set_cap_orth)
+       apply (wp hoare_vcg_imp_lift hoare_vcg_ball_lift set_free_index_final_cap hoare_vcg_all_lift
+                 hoare_vcg_disj_lift set_cap_reachable_pg_cap set_cap.vs_lookup_pages
+              | clarsimp)+
+      apply (wp set_cap_arch_obj set_cap_valid_table_caps hoare_vcg_ball_lift
+                get_cap_wp static_imp_wp)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps)
+  apply (rule conjI)
+   apply (clarsimp simp: vs_cap_ref_def)
+   apply (rule_tac x="fst dest" in exI)
+   apply (rule_tac x="snd dest" in exI)
+   apply (simp add: asid_high_bits_shl)
+  apply (rule conjI)
+   apply (simp add: unique_table_caps_def is_cap_simps)
+  apply (subst unique_table_refs_def)
+  apply (intro allI impI)
+  apply (simp split: if_split_asm)
+    apply (simp add: no_cap_to_obj_with_diff_ref_def cte_wp_at_caps_of_state)
+   apply (simp add: no_cap_to_obj_with_diff_ref_def cte_wp_at_caps_of_state)
+  apply (erule (3) unique_table_refsD)
+  done
+
+lemma valid_asid_map_asid_upd_strg:
+  "valid_asid_map s \<and>
+   asid_pools_of s ap = Some Map.empty \<and>
+   asid_table s asid = None \<longrightarrow>
+   valid_asid_map (asid_table_update asid ap s)"
+  by (simp add: valid_asid_map_def)
+
+lemma valid_vspace_objs_asid_upd_strg:
+  "valid_vspace_objs s \<and>
+   asid_pools_of s ap = Some Map.empty \<and>
+   asid_table s asid = None \<longrightarrow>
+   valid_vspace_objs (asid_table_update asid ap s)"
+  apply clarsimp
+  apply (prop_tac "asid_update ap asid s", (unfold_locales; assumption))
+  apply (erule (1) asid_update.vspace_objs')
+  done
+
+lemma valid_global_objs_asid_upd_strg:
+  "valid_global_objs s \<and>
+   asid_pools_of s ap = Some Map.empty \<and>
+   asid_table s asid = None \<longrightarrow>
+   valid_global_objs (asid_table_update asid ap s)"
+  by (clarsimp simp: valid_global_objs_def)
+
+lemma equal_kernel_mappings_asid_upd_strg:
+  "equal_kernel_mappings s \<and>
+   asid_pools_of s ap = Some Map.empty \<and>
+   asid_table s asid = None \<longrightarrow>
+   equal_kernel_mappings (asid_table_update asid ap s)"
+  apply clarsimp
+  apply (prop_tac "asid_update ap asid s", (unfold_locales; assumption))
+  apply (simp add: asid_update.equal_kernel_mappings)
+  done
+
+lemma safe_parent_cap_is_device:
+  "safe_parent_for m p cap pcap \<Longrightarrow> cap_is_device cap = cap_is_device pcap"
+  by (simp add: safe_parent_for_def)
+
+lemma cap_insert_ioports_ap:
+  "\<lbrace>valid_ioports and (\<lambda>s. cte_wp_at (\<lambda>cap'. safe_ioport_insert cap cap' s) dest s) and
+        K (is_ap_cap cap)\<rbrace>
+     cap_insert cap src dest
+   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
+  by wpsimp
+
+crunches cap_insert
+  for aobjs_of[wp]: "\<lambda>s. P (aobjs_of s)"
+  (wp: crunch_wps)
+
+lemma cap_insert_ap_invs:
+  "\<lbrace>invs and valid_cap cap and tcb_cap_valid cap dest and
+    ex_cte_cap_wp_to (appropriate_cte_cap cap) dest and
+    cte_wp_at (\<lambda>c. c = NullCap) dest and
+    no_cap_to_obj_with_diff_ref cap {dest} and
+    (\<lambda>s. cte_wp_at (safe_parent_for (cdt s) src cap) src s) and
+    K (cap = ArchObjectCap (ASIDPoolCap ap asid)) and
+   (\<lambda>s. \<forall>irq \<in> cap_irqs cap. irq_issued irq s) and
+   ko_at (ArchObj (ASIDPool Map.empty)) ap and
+   (\<lambda>s. ap \<notin> ran (riscv_asid_table (arch_state s)) \<and>
+        asid_table s (asid_high_bits_of asid) = None)\<rbrace>
+  cap_insert cap src dest
+  \<lbrace>\<lambda>rv s. invs (s\<lparr>arch_state := arch_state s
+                       \<lparr>riscv_asid_table := (riscv_asid_table \<circ> arch_state) s(asid_high_bits_of asid \<mapsto> ap)\<rparr>\<rparr>)\<rbrace>"
+  apply (simp add: invs_def valid_state_def valid_pspace_def)
+  apply (strengthen valid_arch_state_strg valid_vspace_objs_asid_upd_strg
+                    equal_kernel_mappings_asid_upd_strg valid_asid_map_asid_upd_strg
+                    valid_global_objs_asid_upd_strg)
+  apply (simp cong: conj_cong)
+  apply (rule hoare_pre)
+   apply (wp cap_insert_simple_mdb cap_insert_iflive
+             cap_insert_zombies cap_insert_ifunsafe cap_insert_ioports_ap
+             cap_insert_valid_global_refs cap_insert_idle
+             valid_irq_node_typ cap_insert_simple_arch_caps_ap)
+  apply (clarsimp simp: is_simple_cap_def cte_wp_at_caps_of_state is_cap_simps)
+  apply (frule safe_parent_cap_is_device)
+  apply (drule safe_parent_cap_range)
+  apply (simp add: is_simple_cap_arch_def)
+  apply (rule conjI)
+   prefer 2
+   apply (clarsimp simp: obj_at_def a_type_def in_omonad)
+   apply (clarsimp simp: valid_cap_def)
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (drule_tac p="(a,b)" in caps_of_state_valid_cap, fastforce)
+  apply (auto simp: obj_at_def is_tcb_def is_cap_table_def
+                    valid_cap_def [where c="cap.Zombie a b x" for a b x]
+              dest: obj_ref_is_tcb obj_ref_is_cap_table split: option.splits)
+  done
+
+lemma max_index_upd_no_cap_to:
+  "\<lbrace>\<lambda>s. no_cap_to_obj_with_diff_ref cap {slot} s \<and>
+        cte_wp_at ((=) ucap) cref s \<and> is_untyped_cap ucap\<rbrace>
+   set_cap (max_free_index_update ucap) cref
+   \<lbrace>\<lambda>rv s. no_cap_to_obj_with_diff_ref cap {slot} s \<rbrace>"
+  apply (clarsimp simp:no_cap_to_obj_with_diff_ref_def)
+  apply (wp hoare_vcg_ball_lift set_cap_cte_wp_at_neg)
+  apply (clarsimp simp:cte_wp_at_caps_of_state free_index_update_def is_cap_simps)
+  apply (drule_tac x = cref in bspec)
+   apply clarsimp
+  apply (clarsimp simp:table_cap_ref_def)
+  done
+
+lemma perform_asid_control_invocation_pred_tcb_at:
+  "\<lbrace>\<lambda>s. pred_tcb_at proj Q t s \<and> st_tcb_at ((Not \<circ> inactive) and (Not \<circ> idle)) t s
+        \<and> ct_active s \<and> invs s \<and> valid_aci aci s\<rbrace>
+   perform_asid_control_invocation aci
+   \<lbrace>\<lambda>_. pred_tcb_at proj Q t\<rbrace>"
+  supply
+    is_aligned_neg_mask_eq[simp del]
+    is_aligned_neg_mask_weaken[simp del]
+  apply (clarsimp simp: perform_asid_control_invocation_def split: asid_control_invocation.splits)
+  apply (rename_tac word1 a b aa ba word2)
+  apply (rule hoare_name_pre_state)
+  apply (subgoal_tac "is_aligned word1 page_bits")
+   prefer 2
+   apply (clarsimp simp: valid_aci_def cte_wp_at_caps_of_state)
+   apply (drule(1) caps_of_state_valid[rotated])+
+   apply (simp add:valid_cap_simps cap_aligned_def page_bits_def)
+  apply (subst delete_objects_rewrite)
+     apply (simp add:page_bits_def word_bits_def pageBits_def word_size_bits_def)+
+   apply (simp add:is_aligned_neg_mask_eq)
+  apply (wp hoare_vcg_const_imp_lift retype_region_st_tcb_at[where sz=page_bits] set_cap_no_overlap|simp)+
+     apply (strengthen invs_valid_objs invs_psp_aligned)
+     apply (clarsimp simp:conj_comms)
+     apply (wp max_index_upd_invs_simple get_cap_wp)+
+  apply (clarsimp simp: valid_aci_def)
+  apply (frule intvl_range_conv)
+   apply (simp add:word_bits_def page_bits_def pageBits_def)
+  apply (clarsimp simp:detype_clear_um_independent page_bits_def is_aligned_neg_mask_eq)
+  apply (rule conjI)
+  apply (clarsimp simp:cte_wp_at_caps_of_state)
+   apply (simp only: field_simps)
+   apply (rule pspace_no_overlap_detype')
+     apply (rule caps_of_state_valid_cap)
+      apply (simp add:page_bits_def)+
+    apply (simp add:invs_valid_objs invs_psp_aligned)+
+  apply (rule conjI)
+   apply (frule st_tcb_ex_cap)
+     apply clarsimp
+    apply (clarsimp split: Structures_A.thread_state.splits)
+   apply (clarsimp simp: ex_nonz_cap_to_def)
+   apply (frule invs_untyped_children)
+   apply (clarsimp simp:cte_wp_at_caps_of_state)
+   apply (erule_tac ptr="(aa,ba)" in untyped_children_in_mdbE[where P="\<lambda>c. t \<in> zobj_refs c" for t])
+       apply (simp add: cte_wp_at_caps_of_state)+
+      apply fastforce
+    apply (clarsimp simp: zobj_refs_to_obj_refs)
+    apply (fastforce simp:page_bits_def)
+   apply simp
+  apply (clarsimp simp:obj_bits_api_def arch_kobj_size_def cte_wp_at_caps_of_state
+    default_arch_object_def empty_descendants_range_in)
+  apply (frule_tac cap = "(cap.UntypedCap False word1 pageBits idx)"
+    in detype_invariants[rotated 3],clarsimp+)
+    apply (simp add:cte_wp_at_caps_of_state
+      empty_descendants_range_in descendants_range_def2)+
+  apply (thin_tac "x = Some cap.NullCap" for x)+
+  apply (drule(1) caps_of_state_valid_cap[OF _ invs_valid_objs])
+  apply (intro conjI)
+    apply (clarsimp simp:valid_cap_def cap_aligned_def range_cover_full
+     invs_psp_aligned invs_valid_objs page_bits_def)
+   apply (erule pspace_no_overlap_detype)
+  apply (auto simp:page_bits_def detype_clear_um_independent)
+  done
+
+lemma perform_asid_control_invocation_st_tcb_at:
+  "\<lbrace>st_tcb_at (P and (Not \<circ> inactive) and (Not \<circ> idle)) t
+    and ct_active and invs and valid_aci aci\<rbrace>
+   perform_asid_control_invocation aci
+   \<lbrace>\<lambda>_. st_tcb_at P t\<rbrace>"
+  apply (wpsimp wp: perform_asid_control_invocation_pred_tcb_at)
+  apply (fastforce simp: pred_tcb_at_def obj_at_def)
+  done
+
+lemma set_cap_idx_up_aligned_area:
+  "\<lbrace>K (\<exists>idx. pcap = UntypedCap dev ptr pageBits idx) and cte_wp_at ((=) pcap) slot
+      and valid_objs\<rbrace> set_cap (max_free_index_update pcap) slot
+  \<lbrace>\<lambda>rv s. (\<exists>slot. cte_wp_at (\<lambda>c. up_aligned_area ptr pageBits \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s)\<rbrace>"
+  apply (rule hoare_pre)
+  apply (wp hoare_vcg_ex_lift set_cap_cte_wp_at)
+  apply (rule_tac x = slot in exI)
+  apply clarsimp
+  apply (frule(1) cte_wp_valid_cap)
+  apply (clarsimp simp: cte_wp_at_caps_of_state p_assoc_help valid_cap_def valid_untyped_def
+                        cap_aligned_def)
+  done
+
+primrec(nonexhaustive)
+  get_untyped_cap_idx :: "cap \<Rightarrow> nat"
+where
+  "get_untyped_cap_idx (UntypedCap dev ref sz idx) = idx"
+
+lemma aci_invs':
+  assumes Q_ignores_arch[simp]: "\<And>f s. Q (arch_state_update f s) = Q s"
+  assumes Q_ignore_machine_state[simp]: "\<And>f s. Q (machine_state_update f s) = Q s"
+  assumes Q_detype[simp]: "\<And>f s. Q (detype f s) = Q s"
+  assumes cap_insert_Q: "\<And>cap src dest. \<lbrace>Q and invs and K (src \<noteq> dest)\<rbrace>
+                            cap_insert cap src dest
+                           \<lbrace>\<lambda>_.Q\<rbrace>"
+  assumes retype_region_Q[wp]:"\<And>a b c d e. \<lbrace>Q\<rbrace> retype_region a b c d e \<lbrace>\<lambda>_.Q\<rbrace>"
+  assumes set_cap_Q[wp]: "\<And>a b. \<lbrace>Q\<rbrace> set_cap a b \<lbrace>\<lambda>_.Q\<rbrace>"
+  shows "\<lbrace>invs and Q and ct_active and valid_aci aci\<rbrace> perform_asid_control_invocation aci \<lbrace>\<lambda>y s. invs s \<and> Q s\<rbrace>"
+proof -
+  have cap_insert_invsQ:
+       "\<And>cap src dest ap asid.
+        \<lbrace>Q and (invs and valid_cap cap and tcb_cap_valid cap dest and
+         ex_cte_cap_wp_to (appropriate_cte_cap cap) dest and
+         cte_wp_at (\<lambda>c. c = NullCap) dest and
+         no_cap_to_obj_with_diff_ref cap {dest} and
+         (\<lambda>s. cte_wp_at (safe_parent_for (cdt s) src cap) src s) and
+         K (cap = ArchObjectCap (ASIDPoolCap ap asid)) and
+         (\<lambda>s. \<forall>irq\<in>cap_irqs cap. irq_issued irq s) and
+         ko_at (ArchObj (ASIDPool Map.empty)) ap and
+         (\<lambda>s. ap \<notin> ran (asid_table s) \<and> asid_table s (asid_high_bits_of asid) = None))\<rbrace>
+         cap_insert cap src dest
+        \<lbrace>\<lambda>rv s.
+           invs
+             (s\<lparr>arch_state := arch_state s
+                 \<lparr>riscv_asid_table := (riscv_asid_table \<circ> arch_state) s
+                    (asid_high_bits_of asid \<mapsto> ap)\<rparr>\<rparr>) \<and>
+           Q
+             (s\<lparr>arch_state := arch_state s
+                 \<lparr>riscv_asid_table := (riscv_asid_table \<circ> arch_state) s
+                    (asid_high_bits_of asid \<mapsto> ap)\<rparr>\<rparr>)\<rbrace>"
+    apply (wp cap_insert_ap_invs)
+     apply simp
+     apply (rule hoare_pre)
+      apply (rule cap_insert_Q, assumption)
+    apply (auto simp: cte_wp_at_caps_of_state)
+    done
+  show ?thesis
+    apply (clarsimp simp: perform_asid_control_invocation_def valid_aci_def
+                    split: asid_control_invocation.splits)
+    apply (rename_tac word1 a b aa ba word2)
+    apply (rule hoare_pre)
+     apply (wp hoare_vcg_const_imp_lift)
+         apply (wp cap_insert_invsQ hoare_vcg_ex_lift | simp)+
+        apply (simp add: valid_cap_def |
+               strengthen real_cte_tcb_valid safe_parent_strg
+                          invs_vobjs_strgs
+                          ex_cte_cap_to_cnode_always_appropriate_strg)+
+        apply (wp hoare_vcg_const_imp_lift set_free_index_invs
+                  retype_region_plain_invs[where sz = pageBits]
+                  retype_cte_wp_at[where sz = pageBits] hoare_vcg_ex_lift
+                  retype_region_obj_at_other3[where P="is_cap_table n" and sz = pageBits for n]
+                  retype_region_ex_cte_cap_to[where sz = pageBits]
+                  retype_region_ap[simplified]
+                  retype_region_ap'[simplified]
+                  retype_region_no_cap_to_obj[where sz = pageBits,simplified]
+               | simp del: split_paired_Ex)+
+       apply (strengthen invs_valid_objs invs_psp_aligned
+              invs_mdb invs_valid_pspace
+              exI[where x="case aci of MakePool frame slot parent base \<Rightarrow> parent"]
+              exI[where x="case aci of MakePool frame slot parent base \<Rightarrow> parent",
+                simplified]
+              caps_region_kernel_window_imp[where
+                p = "case aci of MakePool frame slot parent base \<Rightarrow> parent"]
+              invs_cap_refs_in_kernel_window)+
+       apply (wp set_cap_caps_no_overlap set_cap_no_overlap get_cap_wp
+                 max_index_upd_caps_overlap_reserved max_index_upd_invs_simple
+                 set_cap_cte_cap_wp_to set_cap_cte_wp_at max_index_upd_no_cap_to
+              | simp split del: if_split | wp (once) hoare_vcg_ex_lift)+
+     apply (rule_tac P = "is_aligned word1 page_bits" in hoare_gen_asm)
+     apply (subst delete_objects_rewrite)
+        apply (simp add:page_bits_def pageBits_def word_size_bits_def)
+       apply (simp add:page_bits_def pageBits_def word_bits_def)
+      apply (simp add: page_bits_def)
+     apply wp
+    apply (clarsimp simp: cte_wp_at_caps_of_state if_option_Some
+               split del: if_split)
+    apply (frule_tac cap = "(cap.UntypedCap False word1 pageBits idx)"
+                     in detype_invariants[rotated 3],clarsimp+)
+       apply (simp add:cte_wp_at_caps_of_state)+
+     apply (simp add:descendants_range_def2 empty_descendants_range_in)
+    apply (simp add:invs_mdb invs_valid_pspace invs_psp_aligned invs_valid_objs)
+    apply (clarsimp dest!:caps_of_state_cteD)
+    apply (frule(1) unsafe_protected[where p=t and p'=t for t])
+        apply (simp add:empty_descendants_range_in)+
+      apply fastforce
+     apply clarsimp
+    apply (frule_tac p = "(aa,ba)" in cte_wp_valid_cap)
+     apply fastforce
+    apply (clarsimp simp: detype_clear_um_independent obj_bits_api_def arch_kobj_size_def
+                          default_arch_object_def conj_comms)
+    apply (rule conjI)
+     apply (clarsimp simp:valid_cap_simps cap_aligned_def page_bits_def not_le)
+    apply (simp add:empty_descendants_range_in)
+    apply (frule valid_cap_aligned)
+    apply (clarsimp simp: cap_aligned_def)
+    apply (subst caps_no_overlap_detype[OF descendants_range_caps_no_overlapI],
+           assumption, simp,
+           simp add: empty_descendants_range_in)
+    apply (frule pspace_no_overlap_detype, clarify+)
+    apply (frule intvl_range_conv[where bits = pageBits])
+     apply (simp add:pageBits_def word_bits_def)
+    apply (clarsimp simp: page_bits_def)
+    apply (frule(1) ex_cte_cap_protects)
+        apply (simp add:empty_descendants_range_in)
+       apply fastforce
+      apply (rule subset_refl)
+     apply fastforce
+    apply (clarsimp simp: field_simps)
+    apply (intro conjI impI;
+           simp add: free_index_of_def valid_cap_simps valid_untyped_def
+                     empty_descendants_range_in range_cover_full clear_um_def max_free_index_def;
+           clarsimp simp:valid_untyped_def valid_cap_simps)
+       apply (clarsimp simp: cte_wp_at_caps_of_state)
+      apply (erule(1) cap_to_protected)
+       apply (simp add:empty_descendants_range_in descendants_range_def2)+
+     apply (drule invs_arch_state)+
+     apply (clarsimp simp: valid_arch_state_def valid_asid_table_def)
+     apply (drule (1) subsetD)+
+     apply (clarsimp simp: in_opt_map_eq)
+     apply (erule notE, erule is_aligned_no_overflow)
+    apply (clarsimp simp: no_cap_to_obj_with_diff_ref_def)
+    apply (thin_tac "cte_wp_at ((=) cap.NullCap) p s" for p s)
+    apply (subst(asm) eq_commute,
+           erule(1) untyped_children_in_mdbE[where cap="cap.UntypedCap dev p bits idx" for dev p bits idx,
+                                             simplified, rotated])
+      apply (simp add: is_aligned_no_overflow)
+     apply simp
+    apply clarsimp
+  done
+
+qed
+
+
+lemmas aci_invs[wp] =
+  aci_invs'[where Q=\<top>,simplified hoare_post_taut, OF refl refl refl TrueI TrueI TrueI,simplified]
+
+lemma invoke_arch_invs[wp]:
+  "\<lbrace>invs and ct_active and valid_arch_inv ai\<rbrace>
+   arch_perform_invocation ai
+   \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (cases ai, simp_all add: valid_arch_inv_def arch_perform_invocation_def)
+  apply (wp|simp)+
+  done
+
+lemma sts_aobjs_of[wp]:
+  "set_thread_state t st \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
+  unfolding set_thread_state_def
+  apply (wpsimp wp: set_object_wp)
+  apply (erule rsubst[where P=P])
+  apply (auto dest!: get_tcb_SomeD simp: opt_map_def split: option.splits)
+  done
+
+crunches set_thread_state
+  for pool_for_asid[wp]: "\<lambda>s. P (pool_for_asid asid s)"
+  (wp: assert_inv)
+
+lemma sts_vspace_for_asid[wp]:
+  "set_thread_state t st \<lbrace>\<lambda>s. P (vspace_for_asid asid s)\<rbrace>"
+  apply (simp add: vspace_for_asid_def obind_def split: option.splits)
+  apply (rule conjI; wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift)
+  done
+
+lemma sts_vspace_at_asid[wp]:
+  "set_thread_state t st \<lbrace>vspace_at_asid asid pd\<rbrace>"
+  unfolding vspace_at_asid_def by wpsimp
+
+lemma sts_valid_slots_inv[wp]:
+  "set_thread_state t st \<lbrace>valid_slots m\<rbrace>"
+  unfolding valid_slots_def
+  apply (cases m)
+  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' sts_typ_ats)
+  apply fastforce
+  done
+
+lemma sts_same_ref[wp]:
+  "set_thread_state t st \<lbrace>\<lambda>s. P (same_ref ref cap s)\<rbrace>"
+  unfolding same_ref_def by (cases ref) (wpsimp simp: vs_lookup_slot_def in_omonad)
+
+lemma sts_valid_page_inv[wp]:
+  "set_thread_state t st \<lbrace>valid_page_inv page_invocation\<rbrace>"
+  unfolding valid_page_inv_def
+  apply (cases page_invocation)
+    apply (wpsimp wp: sts_typ_ats hoare_vcg_ex_lift hoare_vcg_disj_lift | wps)+
+  done
+
+crunch global_refs_inv[wp]: set_thread_state "\<lambda>s. P (global_refs s)"
+
+lemma sts_vs_lookup_slot[wp]:
+  "set_thread_state t st \<lbrace>\<lambda>s. P (vs_lookup_slot level asid vref s)\<rbrace>"
+  by (simp add: vs_lookup_slot_def obind_def split: option.splits) wpsimp
+
+lemma sts_valid_vspace_table_inv[wp]:
+  "set_thread_state t st \<lbrace>valid_pti i\<rbrace>"
+  unfolding valid_pti_def
+  by (cases i; wpsimp wp: sts_typ_ats hoare_vcg_ex_lift hoare_vcg_all_lift
+                      simp: invalid_pte_at_def aobjs_of_ako_at_Some[symmetric])
+
+lemma sts_valid_arch_inv:
+  "set_thread_state t st \<lbrace>valid_arch_inv ai\<rbrace>"
+  apply (cases ai; simp add: valid_arch_inv_def; wp?)
+   apply (rename_tac asid_control_invocation)
+   apply (case_tac asid_control_invocation)
+   apply (clarsimp simp: valid_aci_def cte_wp_at_caps_of_state)
+   apply (rule hoare_pre, wp hoare_vcg_ex_lift cap_table_at_typ_at)
+   apply clarsimp
+  apply (clarsimp simp: valid_apinv_def split: asid_pool_invocation.splits)
+  apply (rule hoare_pre)
+   apply (wp hoare_vcg_ex_lift set_thread_state_ko)
+  apply (clarsimp simp: is_tcb_def)
+  done
+
+
+crunch_ignore (add: select_ext find_vspace_for_asid)
+
+
+crunch inv [wp]: arch_decode_invocation "P"
+  (wp: crunch_wps select_wp select_ext_weak_wp simp: crunch_simps)
+
+
+declare lookup_slot_for_cnode_op_cap_to [wp]
+
+
+lemma shiftr_irrelevant:
+  "x < 2 ^ asid_low_bits \<Longrightarrow> is_aligned (y :: machine_word) asid_low_bits \<Longrightarrow>
+    x + y >> asid_low_bits = y >> asid_low_bits"
+  apply (subst word_plus_and_or_coroll)
+   apply (rule word_eqI)
+   apply (clarsimp simp: is_aligned_nth)
+   apply (drule(1) nth_bounded)
+    apply (simp add: asid_low_bits_def word_bits_def)
+   apply simp
+  apply (rule word_eqI)
+  apply (simp add: nth_shiftr)
+  apply safe
+  apply (drule(1) nth_bounded)
+   apply (simp add: asid_low_bits_def word_bits_def)
+  apply simp
+  done
+
+
+declare mask_shift [simp]
+declare word_less_sub_le [simp del]
+declare ptrFormPAddr_addFromPPtr [simp]
+
+
+lemma le_user_vtop_less_pptr_base[simp]:
+  "x \<le> user_vtop \<Longrightarrow> x < pptr_base"
+  using dual_order.strict_trans2 by blast
+
+lemmas le_user_vtop_canonical_address = below_user_vtop_canonical[simp]
+
+lemma ptrFromPAddr_addr_from_ppn:
+  "is_aligned pt_ptr table_size \<Longrightarrow>
+   ptrFromPAddr (addr_from_ppn (ucast (addrFromPPtr pt_ptr >> pageBits))) = pt_ptr"
+  apply (simp add: addr_from_ppn_def ucast_ucast_mask bit_simps)
+  apply (frule is_aligned_addrFromPPtr[simplified bit_simps])
+  apply (simp add: aligned_shiftr_mask_shiftl mask_len_id[where 'a=machine_word_len, simplified])
+  done
+
+lemma ptrFromPAddr_addr_from_ppn':
+  "is_aligned pt_ptr pt_bits \<Longrightarrow>
+   ptrFromPAddr (addr_from_ppn (ucast (addrFromPPtr pt_ptr >> pt_bits))) = pt_ptr"
+  using ptrFromPAddr_addr_from_ppn by (simp add: bit_simps)
+
+lemma is_aligned_pageBitsForSize_table_size:
+  "is_aligned p (pageBitsForSize vmpage_size) \<Longrightarrow> is_aligned p table_size"
+  apply (erule is_aligned_weaken)
+  apply (simp add: pbfs_atleast_pageBits[unfolded bit_simps] bit_simps)
+  done
+
+lemma vmsz_aligned_vref_for_level:
+  "\<lbrakk> vmsz_aligned vref sz; pt_bits_left level = pageBitsForSize sz \<rbrakk> \<Longrightarrow>
+   vref_for_level vref level = vref"
+  by (simp add: vref_for_level_def vmsz_aligned_def)
+
+lemma vs_lookup_slot_pte_at:
+  "\<lbrakk> vs_lookup_slot level asid vref s = Some (level, pt_slot);
+     vref \<in> user_region; level \<le> max_pt_level; invs s \<rbrakk> \<Longrightarrow>
+   pte_at pt_slot s"
+  apply (clarsimp simp: pte_at_eq vs_lookup_slot_table_unfold in_omonad)
+  apply (drule valid_vspace_objs_strongD[rotated]; clarsimp)
+  apply (clarsimp simp: ptes_of_def in_omonad)
+ (* pt_slot equation does not want to substitute in clarsimp, because rhs mentions pt_slot *)
+  apply (rule subst[where P="\<lambda>pt_slot. is_aligned pt_slot pte_bits"], rule sym, assumption)
+  apply (thin_tac "pt_slot = t" for t)
+  apply (clarsimp simp: pt_slot_offset_def)
+  apply (rule is_aligned_add; simp add: is_aligned_shift)
+  done
+
+lemma vmpage_size_of_level_pt_bits_left:
+  "\<lbrakk> pt_bits_left level = pageBitsForSize vmpage_size; level \<le> max_pt_level \<rbrakk> \<Longrightarrow>
+   vmpage_size_of_level level = vmpage_size"
+  by (cases vmpage_size; simp add: vmpage_size_of_level_def pt_bits_left_def bit_simps) auto
+
+lemma is_PagePTE_make_user[simp]:
+  "is_PagePTE (make_user_pte p attr R) \<or> make_user_pte p attr R = InvalidPTE"
+  by (auto simp: is_PagePTE_def make_user_pte_def)
+
+lemma decode_fr_inv_map_wf[wp]:
+  "arch_cap = FrameCap p rights vmpage_size dev option \<Longrightarrow>
+   \<lbrace>invs and valid_cap (ArchObjectCap arch_cap) and
+    cte_wp_at ((=) (ArchObjectCap arch_cap)) slot and
+    (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at ((=) (fst x)) (snd x) s)\<rbrace>
+   decode_fr_inv_map label args slot arch_cap excaps
+   \<lbrace>valid_arch_inv\<rbrace>,-"
+  unfolding decode_fr_inv_map_def Let_def
+  apply (wpsimp wp: check_vp_wpR split_del: if_split)
+  apply (clarsimp simp: valid_arch_inv_def valid_page_inv_def neq_Nil_conv)
+  apply (rename_tac s pt_ptr asid vref ab ba ys pt_slot level)
+  apply (prop_tac "args!0 \<in> user_region")
+   apply (clarsimp simp: user_region_def not_le)
+   apply (rule user_vtop_canonical_user)
+   apply (erule aligned_add_mask_lessD)
+   apply (simp add: vmsz_aligned_def)
+  apply (clarsimp simp: cte_wp_at_caps_of_state is_arch_update_def is_cap_simps cap_master_cap_simps)
+  apply (thin_tac "Ball S P" for S P)
+  apply (frule (1) pt_lookup_slot_vs_lookup_slotI, clarsimp)
+  apply (clarsimp simp: valid_arch_cap_def valid_cap_def cap_aligned_def wellformed_mapdata_def)
+  apply (frule is_aligned_pageBitsForSize_table_size)
+  apply (frule (3) vs_lookup_slot_table_base)
+  apply (clarsimp simp: same_ref_def make_user_pte_def ptrFromPAddr_addr_from_ppn)
+  (* FIXME RISCV: remove duplication due to PagePTE/InvalidPTE cases: *)
+  apply (rule conjI; clarsimp)
+   apply (rule strengthen_imp_same_first_conj[OF conjI])
+    apply (rule_tac x=level in exI)
+    apply (rule_tac x="args!0" in exI)
+    apply (fastforce simp: vmsz_aligned_vref_for_level)
+   apply (rule strengthen_imp_same_first_conj[OF conjI])
+    apply (clarsimp simp: valid_slots_def make_user_pte_def wellformed_pte_def
+                          ptrFromPAddr_addr_from_ppn)
+    apply (rename_tac level' asid' vref')
+    apply (frule (3) vs_lookup_slot_table_base)
+    apply (prop_tac "level' \<le> max_pt_level")
+     apply (drule_tac level=level in valid_vspace_objs_strongD[rotated]; clarsimp)
+     apply (rule ccontr, clarsimp simp: not_le)
+     apply (drule vs_lookup_asid_pool; clarsimp)
+     apply (clarsimp simp: in_omonad)
+    apply (drule (1) vs_lookup_table_unique_level; clarsimp)
+    apply (simp add: vs_lookup_slot_pte_at data_at_def vmpage_size_of_level_pt_bits_left
+              split: if_split_asm)
+   apply (rule strengthen_imp_same_first_conj[OF conjI])
+    apply (clarsimp simp: wellformed_mapdata_def vspace_for_asid_def)
+   apply (clarsimp simp: parent_for_refs_def)
+   apply (frule (3) vs_lookup_slot_table_base)
+   apply (frule (2) valid_vspace_objs_strongD[rotated]; clarsimp)
+   apply (drule (1) vs_lookup_table_target)
+   apply (drule valid_vs_lookupD; clarsimp simp: vmsz_aligned_vref_for_level)
+   apply (subgoal_tac "is_pt_cap cap")
+    apply (force simp: is_cap_simps)
+   apply (fastforce dest: cap_to_pt_is_pt_cap intro: valid_objs_caps)
+  apply (rule strengthen_imp_same_first_conj[OF conjI])
+   apply (rule_tac x=level in exI)
+   apply (rule_tac x="args!0" in exI)
+   apply (fastforce simp: vmsz_aligned_vref_for_level)
+  apply (rule strengthen_imp_same_first_conj[OF conjI])
+   apply (clarsimp simp: valid_slots_def make_user_pte_def wellformed_pte_def
+                         ptrFromPAddr_addr_from_ppn)
+   apply (rename_tac level' asid' vref')
+   apply (frule (3) vs_lookup_slot_table_base)
+   apply (prop_tac "level' \<le> max_pt_level")
+    apply (drule_tac level=level in valid_vspace_objs_strongD[rotated]; clarsimp)
+    apply (rule ccontr, clarsimp simp: not_le)
+    apply (drule vs_lookup_asid_pool; clarsimp)
+    apply (clarsimp simp: in_omonad)
+   apply (drule (1) vs_lookup_table_unique_level; clarsimp)
+   apply (simp add: vs_lookup_slot_pte_at data_at_def vmpage_size_of_level_pt_bits_left
+             split: if_split_asm)
+  apply (rule strengthen_imp_same_first_conj[OF conjI])
+   apply (clarsimp simp: wellformed_mapdata_def vspace_for_asid_def)
+  apply (clarsimp simp: parent_for_refs_def)
+  apply (frule (3) vs_lookup_slot_table_base)
+  apply (frule (2) valid_vspace_objs_strongD[rotated]; clarsimp)
+  apply (drule (1) vs_lookup_table_target)
+  apply (drule valid_vs_lookupD; clarsimp simp: vmsz_aligned_vref_for_level)
+  apply (subgoal_tac "is_pt_cap cap")
+   apply (force simp: is_cap_simps)
+  apply (fastforce dest: cap_to_pt_is_pt_cap intro: valid_objs_caps)
+  done
+
+lemma decode_frame_invocation_wf[wp]:
+  "arch_cap = FrameCap word rights vmpage_size dev option \<Longrightarrow>
+   \<lbrace>invs and valid_cap (ArchObjectCap arch_cap) and
+    cte_wp_at ((=) (ArchObjectCap arch_cap)) slot and
+    (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at ((=) (fst x)) (snd x) s)\<rbrace>
+   decode_frame_invocation label args slot arch_cap excaps
+   \<lbrace>valid_arch_inv\<rbrace>,-"
+  unfolding decode_frame_invocation_def
+  by (wpsimp simp: valid_arch_inv_def valid_page_inv_def cte_wp_at_caps_of_state
+                   is_cap_simps valid_arch_cap_def valid_cap_def
+                   valid_unmap_def wellformed_mapdata_def vmsz_aligned_def
+            split: option.split)
+
+lemma neg_mask_user_region:
+  "p \<in> user_region \<Longrightarrow> p && ~~mask n \<in> user_region"
+  apply (simp add: user_region_def canonical_user_def bit.conj_ac
+              flip: and_mask_0_iff_le_mask)
+  apply (subst bit.conj_assoc[symmetric])
+  apply simp
+  done
+
+lemma decode_pt_inv_map_wf[wp]:
+  "arch_cap = PageTableCap pt_ptr pt_map_data \<Longrightarrow>
+   \<lbrace>invs and valid_cap (ArchObjectCap arch_cap) and
+    cte_wp_at ((=) (ArchObjectCap arch_cap)) slot and
+    (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at ((=) (fst x)) (snd x) s)\<rbrace>
+    decode_pt_inv_map label args slot arch_cap excaps
+   \<lbrace>valid_arch_inv\<rbrace>,-"
+  unfolding decode_pt_inv_map_def Let_def
+  apply wpsimp
+  apply (clarsimp simp: valid_arch_inv_def valid_pti_def pte_at_eq invalid_pte_at_def
+                        wellformed_pte_def valid_cap_def cte_wp_at_caps_of_state)
+  apply (rename_tac p level)
+  apply (prop_tac "args!0 \<in> user_region")
+   apply (simp add: wellformed_mapdata_def user_region_def user_vtop_canonical_user)
+  apply (rule conjI, clarsimp simp: valid_arch_cap_def wellformed_mapdata_def vspace_for_asid_def
+                                    neg_mask_user_region)
+  apply (rule conjI, clarsimp simp: is_arch_update_def is_cap_simps cap_master_cap_simps)
+  apply (simp add: ptrFromPAddr_addr_from_ppn cap_aligned_def)
+  apply (drule (1) pt_lookup_slot_vs_lookup_slotI)
+  apply (rule_tac x=level in exI, simp add: vm_level_not_less_zero)
+  apply (clarsimp simp: obj_at_def)
+  apply (rule conjI, clarsimp)
+  apply (drule valid_table_caps_pdD, clarsimp)
+  apply (clarsimp simp: in_omonad)
+  apply (rule_tac x="args!0" in exI)
+  apply (simp add: vref_for_level_def)
+  done
+
+lemma decode_page_table_invocation_wf[wp]:
+  "arch_cap = PageTableCap pt_ptr pt_map_data \<Longrightarrow>
+   \<lbrace>invs and valid_cap (ArchObjectCap arch_cap) and
+    cte_wp_at ((=) (ArchObjectCap arch_cap)) slot and real_cte_at slot and
+    (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at ((=) (fst x)) (snd x) s)\<rbrace>
+    decode_page_table_invocation label args slot arch_cap excaps
+   \<lbrace>valid_arch_inv\<rbrace>,-"
+  unfolding decode_page_table_invocation_def is_final_cap_def
+  apply (wpsimp simp: valid_arch_inv_def valid_pti_def valid_arch_cap_def valid_cap_def
+                      cte_wp_at_caps_of_state is_cap_simps)
+  apply (rule conjI; clarsimp)
+  done
+
+lemma cte_wp_at_eq_simp:
+  "cte_wp_at ((=) cap) = cte_wp_at (\<lambda>c. c = cap)"
+  by (force intro: arg_cong [where f=cte_wp_at])
+
+lemma asid_low_hi_cast:
+  "is_aligned asid_hi asid_low_bits \<Longrightarrow>
+   ucast (ucast asid_low + (asid_hi::asid)) = (asid_low :: asid_low_index)"
+  apply (simp add: is_aligned_nth asid_low_bits_def)
+  apply (subst word_plus_and_or_coroll; word_eqI_solve)
+  done
+
+lemma decode_asid_pool_invocation_wf[wp]:
+  "arch_cap = ASIDPoolCap ap asid \<Longrightarrow>
+   \<lbrace>invs and valid_cap (ArchObjectCap arch_cap) and
+    cte_wp_at ((=) (ArchObjectCap arch_cap)) slot and
+    (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at ((=) (fst x)) (snd x) s) and
+    (\<lambda>s. \<forall>x \<in> set excaps. s \<turnstile> (fst x))\<rbrace>
+   decode_asid_pool_invocation label args slot arch_cap excaps
+   \<lbrace>valid_arch_inv\<rbrace>, -"
+  unfolding decode_asid_pool_invocation_def Let_def
+  apply wpsimp
+  apply (rule ccontr, erule notE[where P="valid_arch_inv i s" for i s])
+  apply (clarsimp simp: valid_arch_inv_def valid_apinv_def pool_for_asid_def word_neq_0_conv
+                        cte_wp_at_caps_of_state neq_Nil_conv obj_at_def in_omonad valid_cap_def
+                        asid_low_hi_cast asid_high_bits_of_add_ucast)
+  done
+
+lemma decode_asid_control_invocation_wf[wp]:
+  "arch_cap = ASIDControlCap \<Longrightarrow>
+   \<lbrace>invs and valid_cap (ArchObjectCap arch_cap) and
+    cte_wp_at ((=) (ArchObjectCap arch_cap)) slot and
+    (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at ((=) (fst x)) (snd x) s) and
+    (\<lambda>s. \<forall>x \<in> set excaps. s \<turnstile> (fst x))\<rbrace>
+   decode_asid_control_invocation label args slot ASIDControlCap excaps
+   \<lbrace>valid_arch_inv\<rbrace>, -"
+  unfolding decode_asid_control_invocation_def valid_arch_inv_def
+  apply (simp add: Let_def split_def cong: if_cong split del: if_split)
+  apply ((wp whenE_throwError_wp check_vp_wpR ensure_empty_stronger
+         | wpc | simp add: valid_arch_inv_def valid_aci_def is_aligned_shiftl_self)+)[1]
+          apply (rule_tac Q'= "\<lambda>rv. real_cte_at rv
+                                     and ex_cte_cap_wp_to is_cnode_cap rv
+                                     and (\<lambda>s. descendants_of (snd (excaps!0)) (cdt s) = {})
+                                     and cte_wp_at (\<lambda>c. \<exists>idx. c = UntypedCap False frame pageBits idx) (snd (excaps!0))
+                                     and (\<lambda>s. riscv_asid_table (arch_state s) free = None)"
+                  in hoare_post_imp_R)
+           apply (simp add: lookup_target_slot_def)
+           apply wp
+          apply (clarsimp simp: cte_wp_at_def)
+         apply (wpsimp wp: ensure_no_children_sp select_ext_weak_wp select_wp whenE_throwError_wp)+
+  apply (rule conjI, fastforce)
+  apply (cases excaps, simp)
+  apply (case_tac list, simp)
+  apply clarsimp
+  apply (rule conjI)
+   apply clarsimp
+   apply (simp add: ex_cte_cap_wp_to_def)
+   apply (rule_tac x=ac in exI)
+   apply (rule_tac x=ba in exI)
+   apply (clarsimp simp add: cte_wp_at_caps_of_state)
+  apply (clarsimp simp add: cte_wp_at_caps_of_state)
+  done
+
+lemma arch_decode_inv_wf[wp]:
+  "\<lbrace>invs and valid_cap (ArchObjectCap arch_cap) and
+    cte_wp_at ((=) (ArchObjectCap arch_cap)) slot and real_cte_at slot and
+    (\<lambda>s. \<forall>x \<in> set excaps. cte_wp_at ((=) (fst x)) (snd x) s) and
+    (\<lambda>s. \<forall>x \<in> set excaps. s \<turnstile> (fst x))\<rbrace>
+     arch_decode_invocation label args x_slot slot arch_cap excaps
+   \<lbrace>valid_arch_inv\<rbrace>,-"
+  unfolding arch_decode_invocation_def by wpsimp fastforce
+
+declare word_less_sub_le [simp]
+
+crunch pred_tcb_at [wp]:
+  perform_page_table_invocation, perform_page_invocation, perform_asid_pool_invocation
+  "pred_tcb_at proj P t"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma arch_pinv_st_tcb_at:
+  "\<lbrace>invs and valid_arch_inv ai and ct_active and
+    st_tcb_at (P and (Not \<circ> inactive) and (Not \<circ> idle)) t\<rbrace>
+     arch_perform_invocation ai
+   \<lbrace>\<lambda>rv. st_tcb_at P t\<rbrace>"
+  apply (cases ai; simp add: arch_perform_invocation_def valid_arch_inv_def)
+  apply (wp perform_asid_control_invocation_st_tcb_at; fastforce elim!: pred_tcb_weakenE)+
+  done
+
+end
+
+
+context begin interpretation Arch .
+
+requalify_consts
+  valid_arch_inv
+
+requalify_facts
+  invoke_arch_tcb
+  invoke_arch_invs
+  sts_valid_arch_inv
+  arch_decode_inv_wf
+  arch_pinv_st_tcb_at
+
+end
+
+declare invoke_arch_invs[wp]
+declare arch_decode_inv_wf[wp]
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBCorres2_AI.thy
@@ -1,0 +1,159 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchBCorres2_AI
+imports
+  BCorres2_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems BCorres2_AI_assms
+
+crunch (bcorres)bcorres[wp, BCorres2_AI_assms]: invoke_cnode truncate_state
+  (simp: swp_def ignore: clearMemory without_preemption filterM ethread_set)
+
+crunch (bcorres)bcorres[wp]: create_cap,init_arch_objects,retype_region,delete_objects truncate_state
+  (ignore: freeMemory clearMemory retype_region_ext)
+
+crunch (bcorres)bcorres[wp]: set_extra_badge,derive_cap truncate_state (ignore: storeWord)
+
+crunch (bcorres)bcorres[wp]: invoke_untyped truncate_state
+  (ignore: sequence_x)
+
+crunch (bcorres)bcorres[wp]: set_mcpriority truncate_state
+
+crunch (bcorres)bcorres[wp, BCorres2_AI_assms]: arch_get_sanitise_register_info, arch_post_modify_registers truncate_state
+
+lemma invoke_tcb_bcorres[wp]:
+  fixes a
+  shows "bcorres (invoke_tcb a) (invoke_tcb a)"
+  apply (cases a)
+        apply (wp | wpc | simp add: set_mcpriority_def)+
+  apply (rename_tac option)
+  apply (case_tac option)
+   apply (wp | wpc | simp)+
+  done
+
+lemma transfer_caps_loop_bcorres[wp]:
+ "bcorres (transfer_caps_loop ep buffer n caps slots mi) (transfer_caps_loop ep buffer n caps slots mi)"
+  apply (induct caps arbitrary: slots n mi ep)
+   apply simp
+   apply wp
+  apply (case_tac a)
+  apply simp
+  apply (intro impI conjI)
+             apply (wp | simp)+
+  done
+
+lemma invoke_irq_control_bcorres[wp]: "bcorres (invoke_irq_control a) (invoke_irq_control a)"
+  apply (cases a)
+   apply wpsimp
+  apply (rename_tac acap)
+  apply (case_tac acap)
+  apply wpsimp
+  done
+
+lemma invoke_irq_handler_bcorres[wp]: "bcorres (invoke_irq_handler a) (invoke_irq_handler a)"
+  by (cases a; wpsimp)
+
+lemma make_arch_fault_msg_bcorres[wp,BCorres2_AI_assms]:
+  "bcorres (make_arch_fault_msg a b) (make_arch_fault_msg a b)"
+  by (cases a; simp ; wp)
+
+lemma  handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
+  "bcorres ( handle_arch_fault_reply a b c d) (handle_arch_fault_reply a b c d)"
+  by (cases a; simp add: handle_arch_fault_reply_def; wp)
+
+crunch (bcorres)bcorres[wp, BCorres2_AI_assms]:
+    arch_switch_to_thread,arch_switch_to_idle_thread truncate_state
+
+end
+
+interpretation BCorres2_AI?: BCorres2_AI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact BCorres2_AI_assms)?)
+  qed
+
+lemmas schedule_bcorres[wp] = schedule_bcorres1[OF BCorres2_AI_axioms]
+
+context Arch begin global_naming RISCV64
+
+crunch (bcorres)bcorres[wp]: send_ipc,send_signal,do_reply_transfer,arch_perform_invocation truncate_state
+  (simp: gets_the_def swp_def
+   ignore: freeMemory clearMemory loadWord cap_fault_on_failure
+           storeWord lookup_error_on_failure getRestartPC getRegister mapME )
+
+lemma perform_invocation_bcorres[wp]: "bcorres (perform_invocation a b c) (perform_invocation a b c)"
+  apply (cases c)
+  apply (wp | wpc | simp)+
+  done
+
+lemma decode_cnode_invocation[wp]: "bcorres (decode_cnode_invocation a b c d) (decode_cnode_invocation a b c d)"
+  apply (simp add: decode_cnode_invocation_def)
+  apply (wp | wpc | simp add: split_def | intro impI conjI)+
+  done
+
+crunch (bcorres)bcorres[wp]:
+  decode_set_ipc_buffer, decode_set_space, decode_set_priority,
+  decode_set_mcpriority, decode_set_sched_params, decode_bind_notification,
+  decode_unbind_notification, decode_set_tls_base truncate_state
+
+lemma decode_tcb_configure_bcorres[wp]:
+  "bcorres (decode_tcb_configure b (ThreadCap c) d e)
+           (decode_tcb_configure b (ThreadCap c) d e)"
+  apply (simp add: decode_tcb_configure_def | wp)+
+  done
+
+lemma decode_tcb_invocation_bcorres[wp]:
+  "bcorres (decode_tcb_invocation a b (ThreadCap c) d e)
+           (decode_tcb_invocation a b (ThreadCap c) d e)"
+  unfolding decode_tcb_invocation_def by wpsimp
+
+crunch (bcorres)bcorres[wp]: arch_decode_invocation truncate_state
+  (simp: crunch_simps)
+
+crunch (bcorres) bcorres[wp]: handle_invocation truncate_state
+  (simp: syscall_def Let_def gets_the_def
+   ignore: syscall cap_fault_on_failure without_preemption const_on_failure
+           decode_tcb_invocation)
+
+crunch (bcorres)bcorres[wp]: receive_ipc,receive_signal,delete_caller_cap truncate_state
+
+lemma handle_vm_fault_bcorres[wp]: "bcorres (handle_vm_fault a b) (handle_vm_fault a b)"
+  unfolding handle_vm_fault_def by (cases b; wpsimp)
+
+lemma handle_hypervisor_fault_bcorres[wp]: "bcorres (handle_hypervisor_fault a b) (handle_hypervisor_fault a b)"
+  by (cases b) wpsimp
+
+
+lemma handle_event_bcorres[wp]: "bcorres (handle_event e) (handle_event e)"
+  apply (cases e)
+  apply (simp add: handle_send_def handle_call_def handle_recv_def handle_reply_def handle_yield_def
+                   handle_interrupt_def Let_def handle_reserved_irq_def arch_mask_irq_signal_def
+         | intro impI conjI allI | wp | wpc)+
+  done
+
+crunch (bcorres)bcorres[wp]: guarded_switch_to,switch_to_idle_thread truncate_state (ignore: storeWord)
+
+lemma choose_switch_or_idle:
+  "((), s') \<in> fst (choose_thread s) \<Longrightarrow>
+       (\<exists>word. ((),s') \<in> fst (guarded_switch_to word s)) \<or>
+       ((),s') \<in> fst (switch_to_idle_thread s)"
+  apply (simp add: choose_thread_def)
+  apply (clarsimp simp add: switch_to_idle_thread_def bind_def gets_def
+                   arch_switch_to_idle_thread_def in_monad
+                   return_def get_def modify_def put_def
+                    get_thread_state_def
+                   thread_get_def
+                   split: if_split_asm)
+  apply force
+  done
+
+end
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBCorres2_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -127,17 +128,28 @@ crunch (bcorres)bcorres[wp]: receive_ipc,receive_signal,delete_caller_cap trunca
 lemma handle_vm_fault_bcorres[wp]: "bcorres (handle_vm_fault a b) (handle_vm_fault a b)"
   unfolding handle_vm_fault_def by (cases b; wpsimp)
 
-lemma handle_hypervisor_fault_bcorres[wp]: "bcorres (handle_hypervisor_fault a b) (handle_hypervisor_fault a b)"
-  by (cases b) wpsimp
+lemma vgic_maintenance_bcorres[wp]:
+  "bcorres vgic_maintenance vgic_maintenance"
+  unfolding vgic_maintenance_def
+  by (wpsimp simp: vgic_update_lr_bcorres)
 
+lemma vppi_event_bcorres[wp]:
+  "bcorres (vppi_event irq) (vppi_event irq)"
+  unfolding vppi_event_def
+  by wpsimp
+
+lemma handle_reserved_irq_bcorres[wp]: "bcorres (handle_reserved_irq a) (handle_reserved_irq a)"
+  unfolding handle_reserved_irq_def by wpsimp
+
+lemma handle_hypervisor_fault_bcorres[wp]: "bcorres (handle_hypervisor_fault a b) (handle_hypervisor_fault a b)"
+  by (cases b; wpsimp)
 
 lemma handle_event_bcorres[wp]: "bcorres (handle_event e) (handle_event e)"
   apply (cases e)
   apply (simp add: handle_send_def handle_call_def handle_recv_def handle_reply_def handle_yield_def
                    handle_interrupt_def Let_def handle_reserved_irq_def arch_mask_irq_signal_def
          | intro impI conjI allI | wp | wpc)+
-  sorry (* FIXME AARCH64 VCPU vppi_event
-  done *)
+  done
 
 crunch (bcorres)bcorres[wp]: guarded_switch_to,switch_to_idle_thread truncate_state (ignore: storeWord)
 

--- a/proof/invariant-abstract/AARCH64/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBCorres2_AI.thy
@@ -9,7 +9,7 @@ imports
   BCorres2_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems BCorres2_AI_assms
 
@@ -81,7 +81,7 @@ interpretation BCorres2_AI?: BCorres2_AI
 
 lemmas schedule_bcorres[wp] = schedule_bcorres1[OF BCorres2_AI_axioms]
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 crunch (bcorres)bcorres[wp]: send_ipc,send_signal,do_reply_transfer,arch_perform_invocation truncate_state
   (simp: gets_the_def swp_def
@@ -136,7 +136,8 @@ lemma handle_event_bcorres[wp]: "bcorres (handle_event e) (handle_event e)"
   apply (simp add: handle_send_def handle_call_def handle_recv_def handle_reply_def handle_yield_def
                    handle_interrupt_def Let_def handle_reserved_irq_def arch_mask_irq_signal_def
          | intro impI conjI allI | wp | wpc)+
-  done
+  sorry (* FIXME AARCH64 VCPU vppi_event
+  done *)
 
 crunch (bcorres)bcorres[wp]: guarded_switch_to,switch_to_idle_thread truncate_state (ignore: storeWord)
 

--- a/proof/invariant-abstract/AARCH64/ArchBCorres_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBCorres_AI.thy
@@ -1,6 +1,6 @@
 (*
- * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  * Copyright 2022, Proofcraft Pty Ltd
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)

--- a/proof/invariant-abstract/AARCH64/ArchBits_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBits_AI.thy
@@ -1,0 +1,64 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchBits_AI
+imports Invariants_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+lemma invs_unique_table_caps[elim!]:
+  "invs s \<Longrightarrow> unique_table_caps s"
+  by (clarsimp simp: invs_def valid_state_def valid_arch_caps_def)
+
+lemma invs_unique_refs[elim!]:
+  "invs s \<Longrightarrow> unique_table_refs s"
+  by (simp add: invs_def valid_state_def valid_arch_caps_def)
+
+lemma invs_valid_table_caps[elim!]:
+  "invs s \<Longrightarrow> valid_table_caps s"
+  by (clarsimp simp: invs_def valid_state_def valid_arch_caps_def)
+
+lemma invs_valid_vs_lookup[elim!]:
+  "invs s \<Longrightarrow> valid_vs_lookup s "
+  by (clarsimp simp: invs_def valid_state_def valid_arch_caps_def)
+
+lemma pbfs_atleast_pageBits:
+  "pageBits \<le> pageBitsForSize sz"
+  by (cases sz) (auto simp: pageBits_def)
+
+lemmas valid_cap_def = valid_cap_def[simplified valid_arch_cap_def]
+
+lemmas valid_cap_simps =
+  valid_cap_def[split_simps cap.split arch_cap.split, simplified wellformed_mapdata_def]
+
+definition is_ap_cap :: "cap \<Rightarrow> bool" where
+  "is_ap_cap cap \<equiv> arch_cap_fun_lift is_ASIDPoolCap False cap"
+
+lemmas is_ap_cap_simps[simp] =
+  is_ap_cap_def[unfolded arch_cap_fun_lift_def, split_simps cap.split arch_cap.split]
+
+lemma is_ap_cap_eq:
+  "is_ap_cap cap = (\<exists>p m. cap = ArchObjectCap (ASIDPoolCap p m))"
+  by (auto simp: is_ap_cap_def is_ASIDPoolCap_def)
+
+definition is_frame_cap :: "cap \<Rightarrow> bool" where
+  "is_frame_cap cap \<equiv> arch_cap_fun_lift is_FrameCap False cap"
+
+lemmas is_frame_cap_simps[simp] =
+  is_frame_cap_def[unfolded arch_cap_fun_lift_def, split_simps cap.split arch_cap.split]
+
+lemma is_frame_cap_eq:
+  "is_frame_cap cap = (\<exists>p R sz dev m. cap = ArchObjectCap (FrameCap p R sz dev m))"
+  by (auto simp: is_frame_cap_def is_FrameCap_def)
+
+lemmas is_arch_cap_simps = is_pt_cap_eq is_ap_cap_eq is_frame_cap_eq
+
+lemmas is_cap_simps = is_cap_simps is_arch_cap_simps
+
+end
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchBits_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBits_AI.thy
@@ -8,7 +8,7 @@ theory ArchBits_AI
 imports Invariants_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 lemma invs_unique_table_caps[elim!]:
   "invs s \<Longrightarrow> unique_table_caps s"

--- a/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
@@ -1,0 +1,1009 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchCNodeInv_AI
+imports CNodeInv_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems CNodeInv_AI_assms
+
+lemma valid_cnode_capI:
+  "\<lbrakk>cap_table_at n w s; valid_objs s; pspace_aligned s; n > 0; length g \<le> 64\<rbrakk>
+   \<Longrightarrow> s \<turnstile> CNodeCap w n g"
+  apply (simp add: valid_cap_def cap_aligned_def)
+  apply (rule conjI)
+   apply (clarsimp simp add: pspace_aligned_def obj_at_def)
+   apply (drule bspec, fastforce)
+   apply (clarsimp simp: is_obj_defs wf_obj_bits)
+  apply (clarsimp simp add: obj_at_def is_obj_defs valid_objs_def dom_def)
+  apply (erule allE, erule impE, blast)
+  apply (simp add: valid_obj_def valid_cs_def valid_cs_size_def)
+  apply (simp add: word_bits_def cte_level_bits_def)
+  done
+
+lemma derive_cap_objrefs [CNodeInv_AI_assms]:
+  "\<lbrace>\<lambda>s. P (obj_refs cap)\<rbrace> derive_cap slot cap \<lbrace>\<lambda>rv s. rv \<noteq> NullCap \<longrightarrow> P (obj_refs rv)\<rbrace>,-"
+  apply (cases cap, simp_all add: derive_cap_def)
+          apply ((wp ensure_no_children_inv | simp add: o_def | rule hoare_pre)+)[11]
+  apply (rename_tac arch_cap)
+  apply (case_tac arch_cap, simp_all add: arch_derive_cap_def)
+         by (wp | wpc |simp add: o_def)+
+
+lemma derive_cap_zobjrefs [CNodeInv_AI_assms]:
+  "\<lbrace>\<lambda>s. P (zobj_refs cap)\<rbrace> derive_cap slot cap \<lbrace>\<lambda>rv s. rv \<noteq> NullCap \<longrightarrow> P (zobj_refs rv)\<rbrace>,-"
+  apply (cases cap, simp_all add: derive_cap_def is_zombie_def)
+          apply ((wp ensure_no_children_inv | simp add: o_def | rule hoare_pre)+)[11]
+  apply (rename_tac arch_cap)
+  apply (case_tac arch_cap, simp_all add: arch_derive_cap_def)
+         by (wp | wpc |simp add: o_def)+
+
+lemma update_cap_objrefs [CNodeInv_AI_assms]:
+  "\<lbrakk> update_cap_data P dt cap \<noteq> NullCap \<rbrakk> \<Longrightarrow>
+     obj_refs (update_cap_data P dt cap) = obj_refs cap"
+  by (case_tac cap,
+      simp_all add: update_cap_data_closedform arch_update_cap_data_def Let_def
+             split: if_split_asm arch_cap.splits)
+
+
+lemma update_cap_zobjrefs [CNodeInv_AI_assms]:
+  "\<lbrakk> update_cap_data P dt cap \<noteq> cap.NullCap \<rbrakk> \<Longrightarrow>
+     zobj_refs (update_cap_data P dt cap) = zobj_refs cap"
+  apply (case_tac cap,
+      simp_all add: update_cap_data_closedform arch_update_cap_data_def Let_def
+             split: if_split_asm arch_cap.splits)
+  done
+
+
+lemma copy_mask [simp, CNodeInv_AI_assms]:
+  "copy_of (mask_cap R c) = copy_of c"
+  apply (rule ext)
+  apply (auto simp: copy_of_def is_cap_simps mask_cap_def
+                    cap_rights_update_def same_object_as_def
+                    bits_of_def acap_rights_update_def
+         split: cap.splits arch_cap.splits bool.splits)
+  done
+
+lemma update_cap_data_mask_Null [simp, CNodeInv_AI_assms]:
+  "(update_cap_data P x (mask_cap m c) = NullCap) = (update_cap_data P x c = NullCap)"
+  unfolding update_cap_data_def mask_cap_def
+  apply (cases c)
+  apply (clarsimp simp: is_cap_simps cap_rights_update_def badge_update_def split: if_splits)+
+  apply (rename_tac arch_cap)
+  apply (case_tac arch_cap; clarsimp simp: arch_update_cap_data_def acap_rights_update_def split: if_splits)
+  done
+
+lemma cap_master_update_cap_data [CNodeInv_AI_assms]:
+  "\<lbrakk> update_cap_data P x c \<noteq> NullCap \<rbrakk>
+        \<Longrightarrow> cap_master_cap (update_cap_data P x c) = cap_master_cap c"
+  apply (simp add: update_cap_data_def split del: if_split split: if_split_asm)
+  apply (auto simp: is_cap_simps Let_def the_cnode_cap_def cap_master_cap_def
+                    badge_update_def arch_update_cap_data_def
+             split: arch_cap.split)
+  done
+
+lemma same_object_as_def2:
+  "same_object_as cp cp' = (cap_master_cap cp = cap_master_cap cp'
+                                \<and> \<not> cp = NullCap \<and> \<not> is_untyped_cap cp
+                                \<and> \<not> is_zombie cp
+                                \<and> (is_arch_cap cp \<longrightarrow>
+                                     (case the_arch_cap cp of
+                                         FrameCap x rs sz d v \<Rightarrow> x \<le> x + 2 ^ pageBitsForSize sz - 1
+                                       | _ \<Rightarrow> True)))"
+  apply (simp add: same_object_as_def is_cap_simps split: cap.split)
+  apply (auto simp: cap_master_cap_def bits_of_def is_cap_simps
+             split: arch_cap.splits)
+  done
+
+lemma same_object_as_cap_master [CNodeInv_AI_assms]:
+  "same_object_as cap cap' \<Longrightarrow> cap_master_cap cap = cap_master_cap cap'"
+  by (simp add: same_object_as_def2)
+
+lemma weak_derived_cap_is_device[CNodeInv_AI_assms]:
+  "\<lbrakk>weak_derived c' c\<rbrakk> \<Longrightarrow>  cap_is_device c = cap_is_device c'"
+  apply (auto simp: weak_derived_def copy_of_def is_cap_simps
+                    same_object_as_def2
+             split: if_split_asm
+             dest!: master_cap_eq_is_device_cap_eq)
+  done
+
+lemma cap_asid_update_cap_data [CNodeInv_AI_assms]:
+  "update_cap_data P x c \<noteq> NullCap
+         \<Longrightarrow> cap_asid (update_cap_data P x c) = cap_asid c"
+  apply (simp add: update_cap_data_def split del: if_split split: if_split_asm)
+  apply (auto simp: is_cap_simps Let_def the_cnode_cap_def cap_master_cap_def
+                    badge_update_def arch_update_cap_data_def cap_asid_def
+             split: arch_cap.split)
+  done
+
+lemma cap_vptr_update_cap_data [CNodeInv_AI_assms]:
+  "update_cap_data P x c \<noteq> NullCap
+         \<Longrightarrow> cap_vptr (update_cap_data P x c) = cap_vptr c"
+  apply (simp add: update_cap_data_def split del: if_split split: if_split_asm)
+  apply (auto simp: is_cap_simps Let_def the_cnode_cap_def cap_master_cap_def
+                    badge_update_def arch_update_cap_data_def
+             split: arch_cap.split)
+  done
+
+lemma cap_asid_base_update_cap_data [CNodeInv_AI_assms]:
+  "update_cap_data P x c \<noteq> NullCap
+         \<Longrightarrow> cap_asid_base (update_cap_data P x c) = cap_asid_base c"
+  apply (simp add: update_cap_data_def split del: if_split split: if_split_asm)
+  apply (auto simp: is_cap_simps Let_def the_cnode_cap_def cap_master_cap_def
+                    badge_update_def arch_update_cap_data_def
+             split: arch_cap.split)
+  done
+
+lemma same_object_as_update_cap_data [CNodeInv_AI_assms]:
+  "\<lbrakk> update_cap_data P x c \<noteq> NullCap; same_object_as c' c \<rbrakk> \<Longrightarrow>
+  same_object_as c' (update_cap_data P x c)"
+  apply (clarsimp simp: same_object_as_def is_cap_simps
+                  split: cap.split_asm arch_cap.splits if_split_asm)
+  apply (auto simp: update_cap_data_def badge_update_def cap_rights_update_def is_cap_simps
+                   arch_update_cap_data_def
+                   Let_def split_def the_cnode_cap_def bits_of_def
+              split: if_split_asm cap.splits)
+  done
+
+lemma is_reply_update_cap_data[simp]:
+  "is_reply_cap (update_cap_data P x c) = is_reply_cap c"
+  by (simp add:is_reply_cap_def update_cap_data_def arch_update_cap_data_def the_cnode_cap_def
+               is_arch_cap_def badge_update_def split:cap.split)
+
+lemma is_master_reply_update_cap_data[simp]:
+  "is_master_reply_cap (update_cap_data P x c) = is_master_reply_cap c"
+  by (simp add:is_master_reply_cap_def update_cap_data_def arch_update_cap_data_def
+               the_cnode_cap_def is_arch_cap_def badge_update_def split:cap.split)
+
+lemma weak_derived_update_cap_data [CNodeInv_AI_assms]:
+  "\<lbrakk>update_cap_data P x c \<noteq> NullCap; weak_derived c c'\<rbrakk>
+  \<Longrightarrow> weak_derived (update_cap_data P x c) c'"
+  apply (simp add: weak_derived_def copy_of_def
+                   cap_master_update_cap_data cap_asid_update_cap_data
+                   cap_asid_base_update_cap_data
+                   cap_vptr_update_cap_data
+              split del: if_split cong: if_cong)
+  apply (erule disjE)
+   apply (clarsimp split: if_split_asm)
+     apply (clarsimp simp: is_cap_simps)
+     apply (simp add: update_cap_data_def arch_update_cap_data_def is_cap_simps)
+   apply (erule (1) same_object_as_update_cap_data)
+  apply clarsimp
+  apply (rule conjI, clarsimp simp: is_cap_simps update_cap_data_def split del: if_split)+
+  apply clarsimp
+  apply (clarsimp simp: same_object_as_def is_cap_simps
+                 split: cap.split_asm arch_cap.splits if_split_asm)
+  apply (auto simp: update_cap_data_def badge_update_def cap_rights_update_def is_cap_simps
+                    arch_update_cap_data_def
+                    Let_def split_def the_cnode_cap_def bits_of_def
+             split: if_split_asm cap.splits arch_cap.splits)
+  done
+
+lemma cap_badge_update_cap_data [CNodeInv_AI_assms]:
+  "update_cap_data False x c \<noteq> NullCap \<and> (bdg, cap_badge c) \<in> capBadge_ordering False
+       \<longrightarrow> (bdg, cap_badge (update_cap_data False x c)) \<in> capBadge_ordering False"
+  apply clarsimp
+  apply (erule capBadge_ordering_trans)
+  apply (simp add: update_cap_data_def split del: if_split split: if_split_asm)
+  apply (auto simp: is_cap_simps Let_def the_cnode_cap_def cap_master_cap_def
+                    badge_update_def arch_update_cap_data_def
+             split: arch_cap.split)
+  done
+
+
+lemma cap_vptr_rights_update[simp, CNodeInv_AI_assms]:
+  "cap_vptr (cap_rights_update f c) = cap_vptr c"
+  by (simp add: cap_vptr_def cap_rights_update_def acap_rights_update_def
+           split: cap.splits arch_cap.splits bool.splits)
+
+lemma cap_vptr_mask[simp, CNodeInv_AI_assms]:
+  "cap_vptr (mask_cap m c) = cap_vptr c"
+  by (simp add: mask_cap_def)
+
+lemma cap_asid_base_rights [simp, CNodeInv_AI_assms]:
+  "cap_asid_base (cap_rights_update R c) = cap_asid_base c"
+  by (auto simp add: cap_rights_update_def acap_rights_update_def
+           split: cap.splits arch_cap.splits bool.splits)
+
+lemma cap_asid_base_mask[simp, CNodeInv_AI_assms]:
+  "cap_asid_base (mask_cap m c) = cap_asid_base c"
+  by (simp add: mask_cap_def)
+
+lemma weak_derived_mask [CNodeInv_AI_assms]:
+  "\<lbrakk> weak_derived c c'; cap_aligned c \<rbrakk> \<Longrightarrow> weak_derived (mask_cap m c) c'"
+  unfolding weak_derived_def
+  apply simp
+  apply (erule disjE)
+   apply simp
+  apply (simp add: mask_cap_def cap_rights_update_def
+                   copy_of_def same_object_as_def bits_of_def
+                   is_cap_simps acap_rights_update_def
+            split: cap.split arch_cap.split)+
+  apply (clarsimp simp: cap_aligned_def
+                        is_aligned_no_overflow)
+  done
+
+
+lemma vs_cap_ref_update_cap_data[simp, CNodeInv_AI_assms]:
+  "vs_cap_ref (update_cap_data P d cap) = vs_cap_ref cap"
+  by (simp add: vs_cap_ref_def update_cap_data_closedform
+                arch_update_cap_data_def Let_def
+         split: arch_cap.splits cap.split if_splits)
+
+
+lemmas [CNodeInv_AI_assms] = invs_irq_state_independent
+
+lemma cte_at_nat_to_cref_zbits [CNodeInv_AI_assms]:
+  "\<lbrakk> s \<turnstile> Zombie oref zb n; m < n \<rbrakk>
+     \<Longrightarrow> cte_at (oref, nat_to_cref (zombie_cte_bits zb) m) s"
+  apply (subst(asm) valid_cap_def)
+  apply (cases zb, simp_all add: valid_cap_def)
+   apply (clarsimp simp: obj_at_def is_tcb)
+   apply (drule(1) tcb_cap_cases_lt [OF order_less_le_trans])
+   apply clarsimp
+   apply (rule cte_wp_at_tcbI, fastforce+)
+  apply (clarsimp elim!: cap_table_at_cte_at simp: cap_aligned_def)
+  apply (simp add: nat_to_cref_def word_bits_conv)
+  done
+
+
+lemma copy_of_cap_range [CNodeInv_AI_assms]:
+  "copy_of cap cap' \<Longrightarrow> cap_range cap = cap_range cap'"
+  apply (clarsimp simp: copy_of_def split: if_split_asm)
+  apply (cases cap', simp_all add: same_object_as_def)
+       apply (clarsimp simp: is_cap_simps bits_of_def cap_range_def
+                      split: cap.split_asm)+
+  apply (rename_tac acap' acap)
+   apply (case_tac acap, simp_all)
+       apply (clarsimp split: arch_cap.split_asm cap.split_asm)+
+  done
+
+
+lemma copy_of_zobj_refs [CNodeInv_AI_assms]:
+  "copy_of cap cap' \<Longrightarrow> zobj_refs cap = zobj_refs cap'"
+  apply (clarsimp simp: copy_of_def split: if_split_asm)
+  apply (cases cap', simp_all add: same_object_as_def)
+       apply (clarsimp simp: is_cap_simps bits_of_def
+                      split: cap.split_asm)+
+  apply (rename_tac acap' acap)
+   apply (case_tac acap, simp_all)
+       apply (clarsimp split: arch_cap.split_asm cap.split_asm)+
+  done
+
+
+lemma vs_cap_ref_master [CNodeInv_AI_assms]:
+  "\<lbrakk> cap_master_cap cap = cap_master_cap cap';
+           cap_asid cap = cap_asid cap';
+           cap_asid_base cap = cap_asid_base cap';
+           cap_vptr cap = cap_vptr cap' \<rbrakk>
+        \<Longrightarrow> vs_cap_ref cap = vs_cap_ref cap'"
+  apply (rule ccontr)
+  apply (clarsimp simp: vs_cap_ref_def vs_cap_ref_arch_def cap_master_cap_def
+                 split: cap.split_asm)
+  apply (clarsimp simp: cap_asid_def split: arch_cap.split_asm option.split_asm)
+  done
+
+lemma weak_derived_vs_cap_ref [CNodeInv_AI_assms]:
+  "weak_derived c c' \<Longrightarrow> vs_cap_ref c = vs_cap_ref c'"
+  by (auto simp: weak_derived_def copy_of_def
+                 same_object_as_def2
+          split: if_split_asm elim: vs_cap_ref_master[OF sym])
+
+lemma weak_derived_table_cap_ref [CNodeInv_AI_assms]:
+  "weak_derived c c' \<Longrightarrow> table_cap_ref c = table_cap_ref c'"
+  apply (clarsimp simp: weak_derived_def copy_of_def same_object_as_def2
+                  split: if_split_asm)
+   apply (elim disjE,simp_all add:is_cap_simps)
+  apply (elim disjE,simp_all)
+  apply clarsimp
+  apply (frule vs_cap_ref_master[OF sym],simp+)
+  apply (drule vs_cap_ref_eq_imp_table_cap_ref_eq'; simp)
+  done
+
+
+lemma weak_derived_vspace_asid:
+  "weak_derived c c' \<Longrightarrow> cap_asid c = cap_asid c' \<and> is_pt_cap c = is_pt_cap c'"
+  by (auto simp: weak_derived_def copy_of_def is_cap_simps
+                 same_object_as_def2 is_pt_cap_def
+                 cap_master_cap_simps
+          split: if_split_asm
+          dest!: cap_master_cap_eqDs)
+
+lemma weak_derived_ASIDPool1:
+  "weak_derived (cap.ArchObjectCap (ASIDPoolCap ap asid)) cap =
+  (cap = cap.ArchObjectCap (ASIDPoolCap ap asid))"
+  apply (rule iffI)
+   prefer 2
+   apply simp
+  apply (clarsimp simp: weak_derived_def copy_of_def split: if_split_asm)
+  apply (clarsimp simp: same_object_as_def2 cap_master_cap_simps dest!: cap_master_cap_eqDs)
+  done
+
+lemma weak_derived_ASIDPool2:
+  "weak_derived cap (ArchObjectCap (ASIDPoolCap ap asid)) =
+  (cap = ArchObjectCap (ASIDPoolCap ap asid))"
+  apply (rule iffI)
+   prefer 2
+   apply simp
+  apply (clarsimp simp: weak_derived_def copy_of_def split: if_split_asm)
+  apply (auto simp: same_object_as_def2 cap_master_cap_simps dest!: cap_master_cap_eqDs)
+  done
+
+lemmas weak_derived_ASIDPool [simp] =
+  weak_derived_ASIDPool1 weak_derived_ASIDPool2
+
+lemmas cap_asid_simps[simp] =
+  cap_asid_def[THEN fun_cong,
+               unfolded arch_cap_fun_lift_def cap_asid_arch_def,
+               split_simps cap.split arch_cap.split]
+
+lemma weak_derived_Page1[simp]:
+  "weak_derived (ArchObjectCap (PageTableCap p ref)) cap = (cap = ArchObjectCap (PageTableCap p ref))"
+  by (auto simp: weak_derived_def copy_of_def is_cap_simps cap_master_cap_simps
+           dest!: same_object_as_cap_master cap_master_cap_eqDs split: option.splits)
+
+
+lemma swap_of_caps_valid_arch_caps [CNodeInv_AI_assms]:
+  "\<lbrace>valid_arch_caps and
+    cte_wp_at (weak_derived c) a and
+    cte_wp_at (weak_derived c') b\<rbrace>
+   do
+     y \<leftarrow> set_cap c b;
+     set_cap c' a
+   od
+   \<lbrace>\<lambda>rv. valid_arch_caps\<rbrace>"
+  supply split_paired_Ex[simp del] split_paired_All[simp del] imp_disjL[simp del]
+  apply (rule hoare_pre)
+   apply (simp add: valid_arch_caps_def valid_asid_pool_caps_def
+                    valid_vs_lookup_def valid_table_caps_def pred_conj_def)
+   apply (wp hoare_vcg_all_lift hoare_convert_imp[OF set_cap.vs_lookup_pages]
+             hoare_vcg_disj_lift hoare_convert_imp[OF set_cap_caps_of_state]
+             hoare_use_eq[OF set_cap_arch set_cap_obj_at_impossible[where P="\<lambda>x. x"]]
+             hoare_vcg_imp_lift')
+  apply (clarsimp simp: valid_arch_caps_def cte_wp_at_caps_of_state)
+  apply (frule weak_derived_obj_refs[where dcap=c])
+  apply (frule weak_derived_obj_refs[where dcap=c'])
+  apply (frule weak_derived_vspace_asid[where c=c])
+  apply (frule weak_derived_vspace_asid[where c=c'])
+  apply (frule weak_derived_vspace_asid[where c=c])
+  apply (frule weak_derived_vs_cap_ref[where c=c])
+  apply (frule weak_derived_vs_cap_ref[where c=c'])
+  apply (intro conjI)
+      apply (simp add: valid_vs_lookup_def)
+      apply (elim allEI)
+      apply (intro impI disjCI2)
+      apply simp
+      apply (elim conjE)
+      apply (erule exfEI[where f="id (a := b, b := a)"])
+      subgoal by (clarsimp dest!: weak_derived_vs_cap_ref, intro conjI; clarsimp)
+     apply (clarsimp simp: valid_asid_pool_caps_def)
+     apply (elim allE, erule (1) impE)
+     apply (erule exfEI[where f="id (a := b, b := a)"])
+     apply (erule exE, elim conjE)
+     apply simp
+     apply (rule conjI; clarsimp)
+    apply (intro allI impI)
+    apply (elim exE conjE)
+    subgoal for _ _ _ _ p
+      by (case_tac "p=b"; case_tac "p=a";
+            fastforce simp add: valid_table_caps_def empty_table_caps_of)
+   apply (simp add: unique_table_caps_def split del: if_split)
+   apply (erule allfEI[where f="id (a := b, b := a)"])
+   apply (erule allfEI[where f="id (a := b, b := a)"])
+   apply (clarsimp split del: if_split split: if_split_asm)
+  apply (simp add: unique_table_refs_def split del: if_split)
+  apply (erule allfEI[where f="id (a := b, b := a)"])
+  apply (erule allfEI[where f="id (a := b, b := a)"])
+  apply (clarsimp split del: if_split split: if_split_asm dest!:vs_cap_ref_to_table_cap_ref
+                      dest!: weak_derived_table_cap_ref)
+  done
+
+
+lemma cap_swap_asid_map[wp, CNodeInv_AI_assms]:
+  "\<lbrace>valid_asid_map and
+    cte_wp_at (weak_derived c) a and
+    cte_wp_at (weak_derived c') b\<rbrace>
+     cap_swap c a c' b \<lbrace>\<lambda>rv. valid_asid_map\<rbrace>"
+  apply (simp add: cap_swap_def set_cdt_def valid_asid_map_def vspace_at_asid_def)
+  apply (rule hoare_pre)
+   apply (wp set_cap.vs_lookup|simp
+          |rule hoare_lift_Pf [where f=arch_state])+
+  done
+
+
+lemma cap_swap_cap_refs_in_kernel_window[wp, CNodeInv_AI_assms]:
+  "\<lbrace>cap_refs_in_kernel_window and
+    cte_wp_at (weak_derived c) a and
+    cte_wp_at (weak_derived c') b\<rbrace>
+     cap_swap c a c' b \<lbrace>\<lambda>rv. cap_refs_in_kernel_window\<rbrace>"
+  apply (simp add: cap_swap_def)
+  apply (rule hoare_pre)
+   apply (wp | simp split del: if_split)+
+  apply (auto dest!: cap_refs_in_kernel_windowD
+               simp: cte_wp_at_caps_of_state weak_derived_cap_range)
+  done
+
+
+lemma cap_swap_ioports[wp, CNodeInv_AI_assms]:
+  "\<lbrace>valid_ioports and cte_wp_at (weak_derived c) a and cte_wp_at (weak_derived c') b\<rbrace>
+     cap_swap c a c' b
+   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
+  by wpsimp
+
+lemma cap_swap_vms[wp, CNodeInv_AI_assms]:
+  "\<lbrace>valid_machine_state\<rbrace>  cap_swap c a c' b \<lbrace>\<lambda>rv. valid_machine_state\<rbrace>"
+  apply (simp add: valid_machine_state_def in_user_frame_def)
+  apply (wp cap_swap_typ_at
+            hoare_vcg_all_lift hoare_vcg_ex_lift hoare_vcg_disj_lift)
+  done
+
+lemma unat_of_bl_nat_to_cref[CNodeInv_AI_assms]:
+  "\<lbrakk> n < 2 ^ len; len < word_bits \<rbrakk>
+    \<Longrightarrow> unat (of_bl (nat_to_cref len n) :: machine_word) = n"
+  apply (simp add: nat_to_cref_def word_bits_conv of_drop_to_bl
+                   word_size)
+  apply (subst less_mask_eq)
+   apply (rule order_less_le_trans)
+    apply (erule of_nat_mono_maybe[rotated])
+    apply (rule power_strict_increasing)
+     apply simp
+    apply simp
+   apply simp
+  apply (rule unat_of_nat_eq[where 'a=machine_word_len, unfolded word_bits_len_of])
+  apply (erule order_less_trans)
+  apply (rule power_strict_increasing)
+   apply (simp add: word_bits_conv)
+  apply simp
+  done
+
+lemma zombie_is_cap_toE_pre[CNodeInv_AI_assms]:
+  "\<lbrakk> s \<turnstile> Zombie ptr zbits n; invs s; m < n \<rbrakk>
+     \<Longrightarrow> (ptr, nat_to_cref (zombie_cte_bits zbits) m) \<in> cte_refs (Zombie ptr zbits n) irqn"
+  apply (clarsimp simp add: valid_cap_def cap_aligned_def)
+  apply (clarsimp split: option.split_asm)
+   apply (simp add: unat_of_bl_nat_to_cref)
+   apply (simp add: nat_to_cref_def word_bits_conv)
+  apply (simp add: unat_of_bl_nat_to_cref)
+  apply (simp add: nat_to_cref_def word_bits_conv)
+  done
+
+crunch st_tcb_at_halted[wp]: prepare_thread_delete "st_tcb_at halted t"
+
+lemma finalise_cap_makes_halted_proof[CNodeInv_AI_assms]:
+  "\<lbrace>invs and valid_cap cap and (\<lambda>s. ex = is_final_cap' cap s)
+         and cte_wp_at ((=) cap) slot\<rbrace>
+    finalise_cap cap ex
+   \<lbrace>\<lambda>rv s. \<forall>t \<in> obj_refs (fst rv). halted_if_tcb t s\<rbrace>"
+  apply (case_tac cap, simp_all)
+            apply (wp unbind_notification_valid_objs
+                   | clarsimp simp: o_def valid_cap_def cap_table_at_typ
+                                    is_tcb obj_at_def
+                   | clarsimp simp: halted_if_tcb_def
+                             split: option.split
+                   | intro impI conjI
+                   | rule hoare_drop_imp)+
+  apply (drule_tac final_zombie_not_live; (assumption | simp add: invs_iflive)?)
+   apply (clarsimp simp: pred_tcb_at_def is_tcb obj_at_def live_def, elim disjE)
+    apply (clarsimp; case_tac "tcb_state tcb"; simp)+
+  apply (rename_tac arch_cap)
+  apply (case_tac arch_cap, simp_all add: arch_finalise_cap_def)
+      apply (wp
+             | clarsimp simp: valid_cap_def obj_at_def is_tcb_def is_cap_table_def
+                        split: option.splits bool.split
+             | intro impI conjI)+
+  done
+
+lemmas finalise_cap_makes_halted = finalise_cap_makes_halted_proof
+
+crunch emptyable[wp,CNodeInv_AI_assms]: finalise_cap "\<lambda>s. emptyable sl s"
+  (simp: crunch_simps rule: emptyable_lift
+     wp: crunch_wps suspend_emptyable unbind_notification_invs unbind_maybe_notification_invs)
+
+
+lemma finalise_cap_not_reply_master_unlifted [CNodeInv_AI_assms]:
+  "(rv, s') \<in> fst (finalise_cap cap sl s) \<Longrightarrow>
+   \<not> is_master_reply_cap (fst rv)"
+  by (case_tac cap, auto simp: is_cap_simps in_monad liftM_def
+                               arch_finalise_cap_def
+                        split: if_split_asm arch_cap.split_asm bool.split_asm option.split_asm)
+
+
+lemma nat_to_cref_0_replicate [CNodeInv_AI_assms]:
+  "\<And>n. n < word_bits \<Longrightarrow> nat_to_cref n 0 = replicate n False"
+  apply (subgoal_tac "nat_to_cref n (unat (of_bl (replicate n False))) = replicate n False")
+   apply simp
+  apply (rule nat_to_cref_unat_of_bl')
+   apply (simp add: word_bits_def)
+  apply simp
+  done
+
+lemma prepare_thread_delete_thread_cap [CNodeInv_AI_assms]:
+  "\<lbrace>\<lambda>s. caps_of_state s x = Some (cap.ThreadCap p)\<rbrace>
+    prepare_thread_delete t
+   \<lbrace>\<lambda>rv s. caps_of_state s x = Some (cap.ThreadCap p)\<rbrace>"
+  by (wpsimp simp: prepare_thread_delete_def)
+
+end
+
+
+global_interpretation CNodeInv_AI?: CNodeInv_AI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact CNodeInv_AI_assms)?)
+  qed
+
+
+termination rec_del by (rule rec_del_termination)
+
+
+context Arch begin global_naming RISCV64
+
+lemma post_cap_delete_pre_is_final_cap':
+  "\<And>s.
+       \<lbrakk>valid_ioports s; caps_of_state s slot = Some cap; is_final_cap' cap s; cap_cleanup_opt cap \<noteq> NullCap\<rbrakk>
+       \<Longrightarrow> post_cap_delete_pre (cap_cleanup_opt cap) (caps_of_state s(slot \<mapsto> NullCap))"
+  apply (clarsimp simp: cap_cleanup_opt_def cte_wp_at_def post_cap_delete_pre_def
+                      split: cap.split_asm if_split_asm
+                      elim!: ranE dest!: caps_of_state_cteD)
+   apply (drule(2) final_cap_duplicate_irq; simp)
+   apply simp
+  apply (clarsimp simp: arch_cap_cleanup_opt_def arch_post_cap_delete_pre_def)
+  done
+
+lemma rec_del_invs'':
+  notes Inr_in_liftE_simp[simp del]
+  assumes set_cap_Q[wp]: "\<And>cap p. \<lbrace>Q and invs\<rbrace> set_cap cap p \<lbrace>\<lambda>_.Q\<rbrace>"
+  assumes empty_slot_Q[wp]: "\<And>slot free_irq. \<lbrace>Q and invs\<rbrace> empty_slot slot free_irq\<lbrace>\<lambda>_.Q\<rbrace>"
+  assumes finalise_cap_Q[wp]: "\<And>cap final. \<lbrace>Q and invs\<rbrace> finalise_cap cap final \<lbrace>\<lambda>_.Q\<rbrace>"
+  assumes cap_swap_for_delete_Q[wp]: "\<And>a b. \<lbrace>Q and invs and cte_at a and cte_at b and K (a \<noteq> b)\<rbrace>
+                                              cap_swap_for_delete a b
+                                             \<lbrace>\<lambda>_.Q\<rbrace>"
+  assumes preemption_point_Q: "\<And>cap final. \<lbrace>Q and invs\<rbrace> preemption_point \<lbrace>\<lambda>_.Q\<rbrace>"
+  shows
+  "s \<turnstile> \<lbrace>Q and invs and valid_rec_del_call call
+           and (\<lambda>s. \<not> exposed_rdcall call
+                       \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {})
+                                (slot_rdcall call) s)
+           and emptyable (slot_rdcall call)
+           and (\<lambda>s. case call of ReduceZombieCall cap sl ex \<Rightarrow>
+                               \<not> cap_removeable cap sl
+                               \<and> (\<forall>t\<in>obj_refs cap. halted_if_tcb t s)
+                        | _ \<Rightarrow> True)\<rbrace>
+         rec_del call
+       \<lbrace>\<lambda>rv s. Q s \<and> invs s \<and>
+               (case call of FinaliseSlotCall sl x \<Rightarrow>
+                             ((fst rv \<or> x) \<longrightarrow> cte_wp_at (replaceable s sl cap.NullCap) sl s)
+                             \<and> (snd rv \<noteq> NullCap \<longrightarrow>
+                                   post_cap_delete_pre (snd rv) ((caps_of_state s) (sl \<mapsto> cap.NullCap)))
+                          | ReduceZombieCall cap sl x \<Rightarrow>
+                             (\<not> x \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) sl s)
+                          | _ \<Rightarrow> True) \<and>
+               emptyable (slot_rdcall call) s\<rbrace>,
+       \<lbrace>\<lambda>rv. Q and invs\<rbrace>"
+proof (induct rule: rec_del.induct,
+       simp_all only: rec_del_fails)
+  case (1 slot exposed s)
+  show ?case
+    apply (subst rec_del.simps)
+    apply (simp only: split_def)
+    apply wp
+     apply (simp(no_asm))
+     apply (wp empty_slot_invs empty_slot_emptyable)[1]
+    apply (rule hoare_pre_spec_validE)
+     apply (rule spec_strengthen_postE, unfold slot_rdcall.simps)
+      apply (rule "1.hyps"[simplified rec_del_call.simps slot_rdcall.simps])
+     apply clarsimp
+     apply (auto simp: cte_wp_at_caps_of_state)
+    done
+next
+  case (2 slot exposed s)
+  show ?case
+    apply (subst rec_del.simps)
+    apply (simp only: split_def)
+    apply (rule split_spec_bindE[rotated])
+     apply (rule drop_spec_validE, simp)
+     apply (rule get_cap_sp)
+    apply (rule hoare_pre_spec_validE)
+     apply (wp replace_cap_invs | simp)+
+        apply (erule finalise_cap_not_reply_master)
+       apply (wp "2.hyps")
+         apply (wp preemption_point_Q | simp)+
+         apply (wp preemption_point_inv, simp+)
+         apply (wp preemption_point_Q)
+         apply ((wp preemption_point_inv irq_state_independent_A_conjI irq_state_independent_AI
+                    emptyable_irq_state_independent invs_irq_state_independent
+               | simp add: valid_rec_del_call_def irq_state_independent_A_def)+)[1]
+        apply (simp(no_asm))
+        apply (rule spec_strengthen_postE)
+        apply (rule "2.hyps"[simplified rec_del_call.simps slot_rdcall.simps conj_assoc], assumption+)
+       apply (simp add: cte_wp_at_eq_simp
+                | wp replace_cap_invs set_cap_sets final_cap_same_objrefs
+                     set_cap_cte_cap_wp_to static_imp_wp
+                | erule finalise_cap_not_reply_master)+
+       apply (wp hoare_vcg_const_Ball_lift)+
+      apply (rule hoare_strengthen_post)
+       apply (rule_tac Q="\<lambda>fin s. Q s \<and> invs s \<and> replaceable s slot (fst fin) rv
+                                 \<and> cte_wp_at ((=) rv) slot s \<and> s \<turnstile> (fst fin)
+                                 \<and> ex_cte_cap_wp_to (appropriate_cte_cap rv) slot s
+                                 \<and> emptyable slot s
+                                 \<and> (\<forall>t\<in>obj_refs (fst fin). halted_if_tcb t s)"
+                  in hoare_vcg_conj_lift)
+        apply (wp finalise_cap_invs[where slot=slot]
+                  finalise_cap_replaceable[where sl=slot]
+                  finalise_cap_makes_halted[where slot=slot])[1]
+       apply (rule finalise_cap_cases[where slot=slot])
+      apply (clarsimp simp: cte_wp_at_caps_of_state)
+      apply (erule disjE)
+       apply clarsimp
+       apply (rule post_cap_delete_pre_is_final_cap', clarsimp+)
+      apply (rule conjI)
+       apply clarsimp
+       apply (subst replaceable_def)
+       apply (clarsimp simp: is_cap_simps tcb_cap_valid_NullCapD
+                             no_cap_to_obj_with_diff_ref_Null gen_obj_refs_eq
+                        del: disjCI)
+       apply (thin_tac "appropriate_cte_cap a = appropriate_cte_cap b" for a b)
+       apply (rule conjI)
+        apply (clarsimp simp: replaceable_def)
+        apply (erule disjE)
+         apply (simp only: zobj_refs.simps mem_simps)
+        apply clarsimp+
+       subgoal
+         apply (drule sym, simp)
+         apply (drule sym, simp)
+         apply clarsimp
+         apply (simp add: unat_eq_0)
+         apply (drule of_bl_eq_0)
+          apply (drule zombie_cte_bits_less, simp add: word_bits_def)
+         by (clarsimp simp: cte_wp_at_caps_of_state)
+      apply (drule_tac s="appropriate_cte_cap c" for c in sym)
+      apply (clarsimp simp: is_cap_simps appropriate_Zombie gen_obj_refs_eq)
+     apply (simp add: is_final_cap_def)
+     apply wp
+    apply (clarsimp simp: cte_wp_at_eq_simp)
+    apply (rule conjI)
+     apply (clarsimp simp: cte_wp_at_caps_of_state replaceable_def)
+    apply (frule cte_wp_at_valid_objs_valid_cap, clarsimp+)
+    apply (frule invs_valid_asid_table)
+    apply (frule invs_sym_refs)
+    apply (clarsimp simp: invs_def valid_state_def
+                          invs_valid_objs invs_psp_aligned)
+    apply (drule(1) if_unsafe_then_capD, clarsimp+)
+    done
+next
+  have replicate_helper:
+    "\<And>x n. True \<in> set x \<Longrightarrow> replicate n False \<noteq> x"
+   by (clarsimp simp: replicate_not_True)
+  case (3 ptr bits n slot s)
+  show ?case
+    apply simp
+    apply wp+
+    apply clarsimp
+    apply (rule context_conjI')
+     apply (rule context_conjI')
+      apply (rule conjI)
+       apply (erule zombie_is_cap_toE2)
+        apply simp+
+      apply (clarsimp simp: halted_emptyable)
+      apply (rule conjI, clarsimp simp: cte_wp_at_caps_of_state)
+       apply (erule tcb_valid_nonspecial_cap)
+         apply fastforce
+        apply (clarsimp simp: ran_tcb_cap_cases is_cap_simps
+                       split: Structures_A.thread_state.splits)
+       apply (clarsimp simp: is_cap_simps)
+      apply (rule conjI)
+       apply (drule cte_wp_valid_cap, clarsimp)
+       apply (frule cte_at_nat_to_cref_zbits [where m=0], simp)
+       apply (rule cte_wp_at_not_reply_master)
+          apply (simp add: replicate_helper tcb_cnode_index_def)
+         apply (subst(asm) nat_to_cref_0_replicate)
+          apply (simp add: zombie_cte_bits_less)
+         apply assumption
+        apply clarsimp
+       apply (simp add: invs_def valid_state_def)
+      apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps)
+     apply (erule cte_wp_at_weakenE | clarsimp)+
+    done
+next
+  have nat_helper:
+    "\<And>x n. \<lbrakk> x < Suc n; x \<noteq> n \<rbrakk> \<Longrightarrow> x < n"
+    by (simp add: le_simps)
+  case (4 ptr bits n slot s)
+  show ?case
+    apply simp
+    apply (rule hoare_pre_spec_validE)
+     apply (wp replace_cap_invs | simp add: is_cap_simps)+
+      apply (rule_tac Q="\<lambda>rv s. Q s \<and> invs s \<and> cte_wp_at (\<lambda>cap. cap = rv) slot s
+                             \<and> cte_wp_at (\<lambda>cap. cap = cap.NullCap
+                                        \<or> \<not> False \<and> is_zombie cap
+                                            \<and> (ptr, nat_to_cref (zombie_cte_bits bits) n)
+                                                 \<in> fst_cte_ptrs cap)
+                                    (ptr, nat_to_cref (zombie_cte_bits bits) n) s
+                             \<and> \<not> cap_removeable (cap.Zombie ptr bits (Suc n)) slot"
+                  in hoare_post_imp)
+       apply (thin_tac "(a, b) \<in> fst c" for a b c)
+       apply clarsimp
+       apply (frule cte_wp_at_emptyableD, clarsimp, assumption)
+       apply (rule conjI[rotated], (clarsimp simp: is_cap_simps)+)
+       apply (frule cte_wp_at_valid_objs_valid_cap, clarsimp+)
+       apply (frule if_unsafe_then_capD, clarsimp+)
+       apply (rule conjI)
+        apply (frule zombies_finalD, (clarsimp simp: is_cap_simps)+)
+        apply (clarsimp simp: cte_wp_at_caps_of_state)
+        apply (erule disjE[where P="val = cap.NullCap" for val])
+         apply (clarsimp simp: replaceable_def cap_range_def is_cap_simps
+                               gen_obj_refs_subset vs_cap_ref_def)
+         apply (rule conjI[rotated])
+          apply (rule conjI)
+           apply (rule mp [OF tcb_cap_valid_imp'])
+           apply (fastforce simp: ran_tcb_cap_cases is_cap_simps
+                                 is_pt_cap_def vs_cap_ref_def
+                                 valid_ipc_buffer_cap_def
+                          split: Structures_A.thread_state.splits)
+          apply (drule unique_table_refs_no_cap_asidD)
+           apply (simp add: invs_def valid_state_def valid_arch_caps_def)
+          apply (simp add: no_cap_to_obj_with_diff_ref_def Ball_def
+                           table_cap_ref_def)
+         apply clarsimp
+         apply (rule ccontr, erule notE, erule nat_helper)
+         apply clarsimp
+         apply (erule disjE[where Q="val = slot" for val])
+          apply (clarsimp simp: cte_wp_at_caps_of_state)
+          apply (erule notE[rotated, where P="val = Some cap.NullCap" for val])
+          apply (drule sym, simp, subst nat_to_cref_unat_of_bl)
+           apply (drule zombie_cte_bits_less, simp add: word_bits_def)
+          apply assumption
+         apply clarsimp
+         apply (drule sym, simp)
+         apply (subst(asm) nat_to_cref_unat_of_bl)
+          apply (drule zombie_cte_bits_less, simp add: word_bits_conv)
+         apply simp
+        apply (clarsimp simp: is_final_cap'_def3 simp del: split_paired_All)
+        apply (frule_tac x=slot in spec)
+        apply (drule_tac x="(ptr, nat_to_cref (zombie_cte_bits bits) n)" in spec)
+        apply (clarsimp simp: cte_wp_at_caps_of_state fst_cte_ptrs_def
+                              gen_obj_refs_Int)
+        apply (drule(1) nat_to_cref_replicate_Zombie[OF sym])
+         apply simp
+        apply simp
+       apply (clarsimp simp: valid_cap_def cap_aligned_def is_cap_simps
+                             cte_wp_at_cte_at appropriate_Zombie
+                      split: option.split_asm)
+      apply (wp get_cap_cte_wp_at)[1]
+     apply simp
+     apply (subst conj_assoc[symmetric])
+     apply (rule spec_valid_conj_liftE2)
+      apply (wp rec_del_delete_cases[where ex=False, simplified])[1]
+     apply (rule spec_strengthen_postE)
+      apply (rule "4.hyps"[simplified rec_del_call.simps slot_rdcall.simps simp_thms pred_conj_def])
+      apply (simp add: in_monad)
+     apply simp
+    apply (clarsimp simp: halted_emptyable)
+    apply (erule(1) zombie_is_cap_toE)
+     apply simp
+    apply simp
+    done
+qed
+
+
+lemmas rec_del_invs'[CNodeInv_AI_assms] = rec_del_invs'' [where Q=\<top>,
+  simplified hoare_post_taut pred_conj_def simp_thms, OF TrueI TrueI TrueI TrueI, simplified]
+
+end
+
+
+global_interpretation CNodeInv_AI_2?: CNodeInv_AI_2
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact CNodeInv_AI_assms)?)
+  qed
+
+
+context Arch begin global_naming RISCV64
+
+lemma finalise_cap_rvk_prog [CNodeInv_AI_assms]:
+   "\<lbrace>\<lambda>s. revoke_progress_ord m (\<lambda>x. map_option cap_to_rpo (caps_of_state s x))\<rbrace>
+   finalise_cap a b
+   \<lbrace>\<lambda>_ s. revoke_progress_ord m (\<lambda>x. map_option cap_to_rpo (caps_of_state s x))\<rbrace>"
+  apply (case_tac a,simp_all add:liftM_def)
+    apply (wp suspend_rvk_prog deleting_irq_handler_rvk_prog
+      | clarsimp simp:is_final_cap_def comp_def)+
+  done
+
+
+lemma rec_del_rvk_prog [CNodeInv_AI_assms]:
+  "st \<turnstile> \<lbrace>\<lambda>s. revoke_progress_ord m (option_map cap_to_rpo \<circ> caps_of_state s)
+          \<and> (case args of ReduceZombieCall cap sl ex \<Rightarrow>
+               cte_wp_at (\<lambda>c. c = cap) sl s \<and> is_final_cap' cap s
+             | _ \<Rightarrow> True)\<rbrace>
+     rec_del args
+   \<lbrace>\<lambda>rv s. revoke_progress_ord m (option_map cap_to_rpo \<circ> caps_of_state s)\<rbrace>,\<lbrace>\<top>\<top>\<rbrace>"
+proof (induct rule: rec_del.induct,
+       simp_all only: rec_del_fails)
+  case (1 slot exposed s)
+  note wp = "1.hyps"[simplified rdcall_simps simp_thms]
+  show ?case
+    apply (subst rec_del.simps)
+    apply (simp only: rdcall_simps simp_thms split_def)
+    apply wp
+     apply (simp(no_asm) del: o_apply)
+     apply (wp empty_slot_rvk_prog)[1]
+    apply (simp del: o_apply)
+    apply (rule wp)
+    done
+next
+  case (2 sl exp s)
+  note wp = "2.hyps" [simplified rdcall_simps simp_thms]
+  show ?case
+    apply (subst rec_del.simps)
+    apply (simp only: rdcall_simps simp_thms split_def)
+    apply (rule hoare_pre_spec_validE)
+     apply wp
+         apply ((wp | simp)+)[1]
+        apply (wp wp)
+          apply ((wp preemption_point_inv | simp)+)[1]
+         apply (simp(no_asm))
+         apply (rule wp, assumption+)
+        apply (wp final_cap_same_objrefs
+                  set_cap_cte_wp_at_cases
+                   | simp)+
+       apply (rule hoare_strengthen_post)
+        apply (rule_tac Q="\<lambda>fc s. cte_wp_at ((=) rv) sl s
+                              \<and> revoke_progress_ord m (option_map cap_to_rpo \<circ> caps_of_state s)"
+                 in hoare_vcg_conj_lift)
+         apply (wp finalise_cap_rvk_prog[folded o_def])[1]
+        apply (rule finalise_cap_cases[where slot=sl])
+       apply (clarsimp simp: o_def)
+       apply (strengthen rvk_prog_update_strg[unfolded fun_upd_def o_def])
+       apply (clarsimp simp: cte_wp_at_caps_of_state)
+       apply (erule disjE)
+        apply clarsimp
+       apply (clarsimp simp: is_cap_simps)
+       apply (case_tac "is_zombie rv")
+        apply (clarsimp simp: cap_to_rpo_def is_cap_simps fst_cte_ptrs_def)
+        apply (simp add: is_final_cap'_def)
+       apply (case_tac rv, simp_all add: cap_to_rpo_def is_cap_simps gen_obj_refs_eq)[1]
+       apply (rename_tac arch_cap)
+       apply (case_tac arch_cap, simp_all)[1]
+      apply (simp add: is_final_cap_def, wp)
+     apply (simp, wp get_cap_wp)
+    apply (clarsimp simp: o_def)
+    done
+next
+  case (3 ptr bits n slot s)
+  show ?case
+    apply simp
+    apply (fold o_def)
+    apply (rule hoare_pre_spec_validE)
+     apply (simp del: o_apply | wp (once) cap_swap_fd_rvk_prog)+
+    apply (clarsimp simp: cte_wp_at_caps_of_state cap_to_rpo_def)
+    done
+next
+  case (4 ptr zb znum sl s)
+  note wp = "4.hyps"[simplified rdcall_simps]
+  show ?case
+    apply (subst rec_del.simps)
+    apply wp
+        apply (wp | simp)+
+      apply (wp get_cap_wp)[1]
+     apply (rule spec_strengthen_postE)
+      apply (rule wp, assumption+)
+     apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_defs)
+     apply (strengthen rvk_prog_update_strg[unfolded fun_upd_def o_def])
+     apply (clarsimp simp: cte_wp_at_caps_of_state cap_to_rpo_def)
+    apply (wp | simp add: o_def)+
+    done
+qed
+
+end
+
+
+global_interpretation CNodeInv_AI_3?: CNodeInv_AI_3
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact CNodeInv_AI_assms)?)
+  qed
+
+
+termination cap_revoke by (rule cap_revoke_termination)
+
+declare cap_revoke.simps[simp del]
+
+
+context Arch begin global_naming RISCV64
+
+crunch typ_at[wp, CNodeInv_AI_assms]: finalise_slot "\<lambda>s. P (typ_at T p s)"
+  (wp: crunch_wps simp: crunch_simps filterM_mapM unless_def
+   ignore: without_preemption filterM set_object clearMemory)
+
+
+lemma weak_derived_appropriate [CNodeInv_AI_assms]:
+  "weak_derived cap cap' \<Longrightarrow> appropriate_cte_cap cap = appropriate_cte_cap cap'"
+  by (auto simp: weak_derived_def copy_of_def same_object_as_def2
+                 appropriate_cte_master
+          split: if_split_asm
+          dest!: arg_cong[where f=appropriate_cte_cap])
+
+end
+
+
+global_interpretation CNodeInv_AI_4?: CNodeInv_AI_4
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact CNodeInv_AI_assms)?)
+  qed
+
+
+context Arch begin global_naming RISCV64
+
+lemma cap_move_ioports:
+  "\<lbrace>valid_ioports and cte_wp_at ((=) cap.NullCap) ptr'
+         and cte_wp_at (weak_derived cap) ptr
+         and cte_wp_at (\<lambda>c. c \<noteq> cap.NullCap) ptr and K (ptr \<noteq> ptr')\<rbrace>
+     cap_move cap ptr ptr'
+   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
+  by wpsimp
+
+lemma cap_move_invs[wp, CNodeInv_AI_assms]:
+  "\<lbrace>invs and valid_cap cap and cte_wp_at ((=) cap.NullCap) ptr'
+         and tcb_cap_valid cap ptr'
+         and cte_wp_at (weak_derived cap) ptr
+         and cte_wp_at (\<lambda>c. c \<noteq> cap.NullCap) ptr
+         and ex_cte_cap_wp_to (appropriate_cte_cap cap) ptr' and K (ptr \<noteq> ptr')
+         and K (\<not> is_master_reply_cap cap)\<rbrace>
+     cap_move cap ptr ptr'
+   \<lbrace>\<lambda>rv. invs\<rbrace>"
+  unfolding invs_def valid_state_def valid_pspace_def
+  apply (simp add: pred_conj_def conj_comms [where Q = "valid_mdb S" for S])
+  apply wp
+   apply (wpe cap_move_zombies_final)
+   apply (wpe cap_move_if_live)
+   apply (wpe cap_move_if_unsafe)
+   apply (wpe cap_move_irq_handlers)
+   apply (wpe cap_move_replies)
+   apply (wpe cap_move_valid_arch_caps)
+   apply (wpe cap_move_valid_ioc)
+   apply (wpe cap_move_ioports)
+   apply (simp add: cap_move_def set_cdt_def)
+   apply (rule hoare_pre)
+    apply (wp set_cap_valid_objs set_cap_idle set_cap_typ_at
+              cap_table_at_lift_irq tcb_at_typ_at
+              hoare_vcg_disj_lift hoare_vcg_all_lift
+              set_cap_cap_refs_respects_device_region_NullCap
+            | wp set_cap_cap_refs_respects_device_region_spec[where ptr=ptr]
+            | simp del: split_paired_Ex split_paired_All
+            | simp add: valid_irq_node_def valid_machine_state_def
+                   del: split_paired_All split_paired_Ex)+
+   apply (clarsimp simp: tcb_cap_valid_def cte_wp_at_caps_of_state)
+   apply (frule(1) valid_global_refsD2[where ptr=ptr])
+   apply (frule(1) cap_refs_in_kernel_windowD[where ptr=ptr])
+   apply (frule weak_derived_cap_range)
+   apply (frule weak_derived_is_reply_master)
+   apply (simp add: cap_range_NullCap valid_ipc_buffer_cap_def[where c=cap.NullCap])
+   apply (simp add: is_cap_simps)
+   apply (subgoal_tac "tcb_cap_valid cap.NullCap ptr s")
+    apply (simp add: tcb_cap_valid_def weak_derived_cap_is_device)
+   apply (rule tcb_cap_valid_NullCapD)
+    apply (erule(1) tcb_cap_valid_caps_of_stateD)
+   apply (simp add: is_cap_simps)
+   done
+
+lemma arch_derive_is_arch:
+  "\<lbrace>\<top>\<rbrace> arch_derive_cap c \<lbrace>\<lambda>rv s. rv \<noteq> NullCap \<longrightarrow> is_arch_cap rv\<rbrace>,-"
+  by (wpsimp simp: is_arch_cap_def arch_derive_cap_def)
+
+end
+
+
+global_interpretation CNodeInv_AI_5?: CNodeInv_AI_5
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact CNodeInv_AI_assms)?)
+  qed
+
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
@@ -473,8 +473,8 @@ lemma zombie_is_cap_toE_pre[CNodeInv_AI_assms]:
   apply (simp add: nat_to_cref_def word_bits_conv)
   done
 
-(* FIXME AARCH64 FPU/VCPU
-crunch st_tcb_at_halted[wp]: prepare_thread_delete "st_tcb_at halted t" *)
+crunch st_tcb_at_halted[wp]: prepare_thread_delete "st_tcb_at halted t"
+  (wp: dissociate_vcpu_tcb_pred_tcb_at)
 
 lemma finalise_cap_makes_halted_proof[CNodeInv_AI_assms]:
   "\<lbrace>invs and valid_cap cap and (\<lambda>s. ex = is_final_cap' cap s)

--- a/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
@@ -98,8 +98,7 @@ lemma same_object_as_def2:
   apply (simp add: same_object_as_def is_cap_simps split: cap.split)
   apply (auto simp: cap_master_cap_def bits_of_def is_cap_simps
              split: arch_cap.splits)
-  sorry (* FIXME AARCH64
-  done *)
+  done
 
 lemma same_object_as_cap_master [CNodeInv_AI_assms]:
   "same_object_as cap cap' \<Longrightarrow> cap_master_cap cap = cap_master_cap cap'"

--- a/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -8,7 +9,7 @@ theory ArchCNodeInv_AI
 imports CNodeInv_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems CNodeInv_AI_assms
 
@@ -97,7 +98,8 @@ lemma same_object_as_def2:
   apply (simp add: same_object_as_def is_cap_simps split: cap.split)
   apply (auto simp: cap_master_cap_def bits_of_def is_cap_simps
              split: arch_cap.splits)
-  done
+  sorry (* FIXME AARCH64
+  done *)
 
 lemma same_object_as_cap_master [CNodeInv_AI_assms]:
   "same_object_as cap cap' \<Longrightarrow> cap_master_cap cap = cap_master_cap cap'"
@@ -342,7 +344,7 @@ lemmas cap_asid_simps[simp] =
                split_simps cap.split arch_cap.split]
 
 lemma weak_derived_Page1[simp]:
-  "weak_derived (ArchObjectCap (PageTableCap p ref)) cap = (cap = ArchObjectCap (PageTableCap p ref))"
+  "weak_derived (ArchObjectCap (PageTableCap p pt_t ref)) cap = (cap = ArchObjectCap (PageTableCap p pt_t ref))"
   by (auto simp: weak_derived_def copy_of_def is_cap_simps cap_master_cap_simps
            dest!: same_object_as_cap_master cap_master_cap_eqDs split: option.splits)
 
@@ -388,6 +390,7 @@ lemma swap_of_caps_valid_arch_caps [CNodeInv_AI_assms]:
      apply (rule conjI; clarsimp)
     apply (intro allI impI)
     apply (elim exE conjE)
+    sorry (* FIXME AARCH64
     subgoal for _ _ _ _ p
       by (case_tac "p=b"; case_tac "p=a";
             fastforce simp add: valid_table_caps_def empty_table_caps_of)
@@ -400,7 +403,7 @@ lemma swap_of_caps_valid_arch_caps [CNodeInv_AI_assms]:
   apply (erule allfEI[where f="id (a := b, b := a)"])
   apply (clarsimp split del: if_split split: if_split_asm dest!:vs_cap_ref_to_table_cap_ref
                       dest!: weak_derived_table_cap_ref)
-  done
+  done *)
 
 
 lemma cap_swap_asid_map[wp, CNodeInv_AI_assms]:
@@ -471,7 +474,8 @@ lemma zombie_is_cap_toE_pre[CNodeInv_AI_assms]:
   apply (simp add: nat_to_cref_def word_bits_conv)
   done
 
-crunch st_tcb_at_halted[wp]: prepare_thread_delete "st_tcb_at halted t"
+(* FIXME AARCH64 FPU/VCPU
+crunch st_tcb_at_halted[wp]: prepare_thread_delete "st_tcb_at halted t" *)
 
 lemma finalise_cap_makes_halted_proof[CNodeInv_AI_assms]:
   "\<lbrace>invs and valid_cap cap and (\<lambda>s. ex = is_final_cap' cap s)
@@ -486,6 +490,7 @@ lemma finalise_cap_makes_halted_proof[CNodeInv_AI_assms]:
                              split: option.split
                    | intro impI conjI
                    | rule hoare_drop_imp)+
+  sorry (* FIXME AARCH64
   apply (drule_tac final_zombie_not_live; (assumption | simp add: invs_iflive)?)
    apply (clarsimp simp: pred_tcb_at_def is_tcb obj_at_def live_def, elim disjE)
     apply (clarsimp; case_tac "tcb_state tcb"; simp)+
@@ -495,21 +500,23 @@ lemma finalise_cap_makes_halted_proof[CNodeInv_AI_assms]:
              | clarsimp simp: valid_cap_def obj_at_def is_tcb_def is_cap_table_def
                         split: option.splits bool.split
              | intro impI conjI)+
-  done
+  done *)
 
 lemmas finalise_cap_makes_halted = finalise_cap_makes_halted_proof
 
+(* FIXME AARCH64 VCPU/FPU
 crunch emptyable[wp,CNodeInv_AI_assms]: finalise_cap "\<lambda>s. emptyable sl s"
   (simp: crunch_simps rule: emptyable_lift
-     wp: crunch_wps suspend_emptyable unbind_notification_invs unbind_maybe_notification_invs)
+     wp: crunch_wps suspend_emptyable unbind_notification_invs unbind_maybe_notification_invs) *)
 
 
 lemma finalise_cap_not_reply_master_unlifted [CNodeInv_AI_assms]:
   "(rv, s') \<in> fst (finalise_cap cap sl s) \<Longrightarrow>
    \<not> is_master_reply_cap (fst rv)"
+  sorry (* FIXME AARCH64
   by (case_tac cap, auto simp: is_cap_simps in_monad liftM_def
                                arch_finalise_cap_def
-                        split: if_split_asm arch_cap.split_asm bool.split_asm option.split_asm)
+                        split: if_split_asm arch_cap.split_asm bool.split_asm option.split_asm) *)
 
 
 lemma nat_to_cref_0_replicate [CNodeInv_AI_assms]:
@@ -525,7 +532,8 @@ lemma prepare_thread_delete_thread_cap [CNodeInv_AI_assms]:
   "\<lbrace>\<lambda>s. caps_of_state s x = Some (cap.ThreadCap p)\<rbrace>
     prepare_thread_delete t
    \<lbrace>\<lambda>rv s. caps_of_state s x = Some (cap.ThreadCap p)\<rbrace>"
-  by (wpsimp simp: prepare_thread_delete_def)
+  sorry (* FIXME AARCH64 VCPU
+  by (wpsimp simp: prepare_thread_delete_def) *)
 
 end
 
@@ -533,14 +541,14 @@ end
 global_interpretation CNodeInv_AI?: CNodeInv_AI
   proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact CNodeInv_AI_assms)?)
+  case 1 show ?case sorry (* FIXME AARCH64 by (unfold_locales; (fact CNodeInv_AI_assms)?) *)
   qed
 
 
 termination rec_del by (rule rec_del_termination)
 
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 lemma post_cap_delete_pre_is_final_cap':
   "\<And>s.
@@ -803,7 +811,7 @@ global_interpretation CNodeInv_AI_2?: CNodeInv_AI_2
   qed
 
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 lemma finalise_cap_rvk_prog [CNodeInv_AI_assms]:
    "\<lbrace>\<lambda>s. revoke_progress_ord m (\<lambda>x. map_option cap_to_rpo (caps_of_state s x))\<rbrace>
@@ -812,7 +820,8 @@ lemma finalise_cap_rvk_prog [CNodeInv_AI_assms]:
   apply (case_tac a,simp_all add:liftM_def)
     apply (wp suspend_rvk_prog deleting_irq_handler_rvk_prog
       | clarsimp simp:is_final_cap_def comp_def)+
-  done
+  sorry (* FIXME AARCH64 probably VCPU
+  done *)
 
 
 lemma rec_del_rvk_prog [CNodeInv_AI_assms]:
@@ -914,7 +923,7 @@ termination cap_revoke by (rule cap_revoke_termination)
 declare cap_revoke.simps[simp del]
 
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 crunch typ_at[wp, CNodeInv_AI_assms]: finalise_slot "\<lambda>s. P (typ_at T p s)"
   (wp: crunch_wps simp: crunch_simps filterM_mapM unless_def
@@ -938,7 +947,7 @@ global_interpretation CNodeInv_AI_4?: CNodeInv_AI_4
   qed
 
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 lemma cap_move_ioports:
   "\<lbrace>valid_ioports and cte_wp_at ((=) cap.NullCap) ptr'

--- a/proof/invariant-abstract/AARCH64/ArchCSpaceInvPre_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpaceInvPre_AI.thy
@@ -1,0 +1,414 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(*
+CSpace invariants
+*)
+
+theory ArchCSpaceInvPre_AI
+imports CSpaceInvPre_AI
+begin
+
+
+context Arch begin global_naming RISCV64
+
+lemma aobj_ref_acap_rights_update[simp]:
+  "aobj_ref (acap_rights_update f x) = aobj_ref x"
+  by (cases x; simp add: acap_rights_update_def)
+
+lemma arch_obj_size_acap_rights_update[simp]:
+  "arch_obj_size (acap_rights_update f x) = arch_obj_size x"
+  by (cases x; simp add: acap_rights_update_def)
+
+lemma valid_arch_cap_acap_rights_update[intro]:
+  "valid_arch_cap x s \<Longrightarrow> valid_arch_cap (acap_rights_update f x) s"
+  by (cases x; simp add: acap_rights_update_def valid_arch_cap_def)
+
+definition cap_master_arch_cap :: "arch_cap \<Rightarrow> arch_cap" where
+  "cap_master_arch_cap acap \<equiv>
+     (case acap of
+           ASIDPoolCap pool asid \<Rightarrow> ASIDPoolCap pool 0
+         | FrameCap ptr R sz dev _ \<Rightarrow> FrameCap ptr UNIV sz dev None
+         | PageTableCap ptr _ \<Rightarrow> PageTableCap ptr None
+         | _ \<Rightarrow> acap)"
+
+lemma cap_master_arch_cap_eqDs1:
+  "cap_master_arch_cap cap = ASIDPoolCap pool asid
+     \<Longrightarrow> asid = 0 \<and> (\<exists>asid. cap = ASIDPoolCap pool asid)"
+  "cap_master_arch_cap cap = ASIDControlCap \<Longrightarrow> cap = ASIDControlCap"
+  "cap_master_arch_cap cap = FrameCap ptr R sz dev map_data
+     \<Longrightarrow> R = UNIV \<and> map_data = None
+          \<and> (\<exists>R map_data. cap = FrameCap ptr R sz dev map_data)"
+  "cap_master_arch_cap cap = PageTableCap ptr data
+     \<Longrightarrow> data = None \<and> (\<exists>data. cap = PageTableCap ptr data)"
+  by (clarsimp simp: cap_master_arch_cap_def split: arch_cap.split_asm)+
+
+lemma cap_master_arch_inv[simp]:
+  "cap_master_arch_cap (cap_master_arch_cap ac) = cap_master_arch_cap ac"
+  by (cases ac; simp add: cap_master_arch_cap_def)
+
+definition
+  "reachable_target \<equiv> \<lambda>(asid, vref) p s.
+     \<exists>level. vs_lookup_target level asid vref s = Some (level, p) \<or>
+             pool_for_asid asid s = Some p"
+
+definition
+  "reachable_frame_cap cap \<equiv> \<lambda>s.
+     is_frame_cap cap \<and> (\<exists>ref. vs_cap_ref cap = Some ref \<and> reachable_target ref (obj_ref_of cap) s)"
+
+(* The conditions under which it is legal to immediately replace an arch_cap
+   cap with newcap at slot sl, assuming cap is final. *)
+definition
+  replaceable_final_arch_cap :: "'z::state_ext state \<Rightarrow> cslot_ptr \<Rightarrow> cap \<Rightarrow> cap \<Rightarrow> bool"
+where
+ "replaceable_final_arch_cap s sl newcap \<equiv> \<lambda>cap.
+    \<comment> \<open>Don't leave dangling vspace references. That is, if cap points to a mapped vspace object,\<close>
+    (\<forall>ref. vs_cap_ref cap = Some ref
+             \<comment> \<open> then either newcap maintains the same vs_refs \<close>
+            \<longrightarrow> (vs_cap_ref newcap = Some ref \<and> obj_refs newcap = obj_refs cap)
+             \<comment> \<open> or the object pointed to by cap is not currently mapped. \<close>
+              \<or> (\<forall>oref \<in> obj_refs cap. \<not> reachable_target ref oref s))
+    \<comment> \<open> Don't introduce duplicate caps to vspace table objects with different vs_refs. \<close>
+  \<and> no_cap_to_obj_with_diff_ref newcap {sl} s
+    \<comment> \<open> Don't introduce non-empty unmapped table objects. \<close>
+  \<and> (is_pt_cap newcap
+      \<longrightarrow> cap_asid newcap = None
+      \<longrightarrow> (\<forall>r \<in> obj_refs newcap. pts_of s r = Some empty_pt))
+    \<comment> \<open> If newcap is vspace table cap such that either:
+         - newcap and cap have different types or different obj_refs, or
+         - newcap is unmapped while cap is mapped, \<close>
+  \<and> (is_pt_cap newcap
+         \<longrightarrow> (is_pt_cap cap
+                  \<longrightarrow> (cap_asid newcap = None \<longrightarrow> cap_asid cap = None)
+                  \<longrightarrow> obj_refs cap \<noteq> obj_refs newcap)
+    \<comment> \<open>then, aside from sl, there is no other slot with a cap that
+         - has the same obj_refs and type as newcap, and
+         - is unmapped if newcap is mapped. \<close>
+         \<longrightarrow> (\<forall>sl'. cte_wp_at (\<lambda>cap'. obj_refs cap' = obj_refs newcap
+                     \<and> is_pt_cap cap'
+                     \<and> (cap_asid newcap = None \<or> cap_asid cap' = None)) sl' s \<longrightarrow> sl' = sl))
+  \<comment> \<open>Don't replace with an ASID pool. \<close>
+  \<and> \<not>is_ap_cap newcap"
+
+definition
+  replaceable_non_final_arch_cap :: "'z::state_ext state \<Rightarrow> cslot_ptr \<Rightarrow> cap \<Rightarrow> cap \<Rightarrow> bool"
+where
+ "replaceable_non_final_arch_cap s sl newcap \<equiv> \<lambda>cap. \<not> reachable_frame_cap cap s"
+
+declare
+  replaceable_final_arch_cap_def[simp]
+  replaceable_non_final_arch_cap_def[simp]
+
+lemma unique_table_refsD:
+  "\<lbrakk> unique_table_refs_2 cps; cps p = Some cap; cps p' = Some cap';
+     obj_refs cap = obj_refs cap'\<rbrakk>
+     \<Longrightarrow> table_cap_ref cap = table_cap_ref cap'"
+  unfolding unique_table_refs_def
+  by blast
+
+lemma table_cap_ref_vs_cap_ref_Some:
+  "table_cap_ref x = Some y \<Longrightarrow> vs_cap_ref x = Some y"
+  by (clarsimp simp: table_cap_ref_def vs_cap_ref_def table_cap_ref_arch_def vs_cap_ref_arch_def
+               simp del: arch_cap_fun_lift_Some
+               split: cap.splits arch_cap.splits)
+
+lemma set_cap_aobjs_of[wp]:
+  "set_cap cap ptr \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
+  unfolding set_cap_def
+  apply (wpsimp wp: set_object_wp get_object_wp)
+  apply (auto simp: opt_map_def obj_at_def split: option.splits elim!: rsubst[where P=P])
+  done
+
+lemma set_cap_pool_for_asid[wp]:
+  "set_cap cap ptr \<lbrace>\<lambda>s. P (pool_for_asid asid s)\<rbrace>"
+  unfolding pool_for_asid_def by wpsimp
+
+lemma set_cap_valid_vs_lookup:
+  "\<lbrace>\<lambda>s. valid_vs_lookup s
+      \<and> (\<forall>vref cap'. caps_of_state s ptr = Some cap'
+                \<longrightarrow> vs_cap_ref cap' = Some vref
+                \<longrightarrow> (vs_cap_ref cap = Some vref \<and> obj_refs cap = obj_refs cap')
+                 \<or> (\<not> is_final_cap' cap' s \<and> \<not> reachable_frame_cap cap' s)
+                 \<or> (\<forall>oref. oref \<in> obj_refs cap' \<longrightarrow> \<not> reachable_target vref oref s))
+      \<and> unique_table_refs s\<rbrace>
+     set_cap cap ptr
+   \<lbrace>\<lambda>rv. valid_vs_lookup\<rbrace>"
+  supply split_paired_All[simp del] split_paired_Ex[simp del]
+  apply (wpsimp wp: hoare_vcg_all_lift hoare_convert_imp vs_lookup_target_lift hoare_vcg_disj_lift
+              simp: valid_vs_lookup_def)
+  apply (drule vs_lookup_target_level)
+  apply (rename_tac level' level asid vref p)
+  apply (erule allE, erule allE, erule allE, erule allE, erule allE, erule (1) impE)
+  apply (erule (1) impE)
+  apply (elim exE conjE)
+  apply (case_tac "p' = ptr")
+   apply clarsimp
+   apply (elim disjE impCE)
+     apply fastforce
+    apply clarsimp
+    apply (drule (1) not_final_another_caps)
+     apply (rule obj_ref_is_gen_obj_ref)
+     apply simp
+    apply (simp, elim exEI, clarsimp simp: gen_obj_refs_eq)
+    apply (drule_tac cap=cap' and cap'=cap in unique_table_refsD; simp?)
+    apply (clarsimp simp: reachable_frame_cap_def)
+    apply (case_tac cap, simp_all)[1]
+    apply (rename_tac arch_cap)
+    apply (case_tac arch_cap, simp_all)[1]
+      apply (clarsimp dest!: table_cap_ref_vs_cap_ref_Some)
+     apply (clarsimp simp: reachable_target_def)
+     apply (erule_tac x=level in allE)
+     apply (clarsimp)
+    apply (clarsimp dest!: table_cap_ref_vs_cap_ref_Some)
+   apply (clarsimp simp: reachable_target_def)
+   apply (erule_tac x=level in allE)
+   apply (clarsimp)
+  apply fastforce
+  done
+
+lemma set_cap_valid_table_caps:
+  "\<lbrace>\<lambda>s. valid_table_caps s \<and>
+        (is_pt_cap cap \<longrightarrow> cap_asid cap = None \<longrightarrow> (\<forall>r \<in> obj_refs cap. pts_of s r = Some empty_pt))\<rbrace>
+     set_cap cap ptr
+   \<lbrace>\<lambda>rv. valid_table_caps\<rbrace>"
+  supply split_paired_All[simp del] split_paired_Ex[simp del]
+  apply (simp add: valid_table_caps_def)
+  apply (wp hoare_vcg_all_lift
+            hoare_vcg_disj_lift hoare_convert_imp[OF set_cap_caps_of_state]
+            hoare_use_eq[OF set_cap_arch set_cap_obj_at_impossible])
+  apply (fastforce simp: cap_asid_def split: if_split_asm)
+  done
+
+lemma cap_asid_vs_cap_ref_None:
+  "is_pt_cap cap \<Longrightarrow> (cap_asid cap = None) = (vs_cap_ref cap = None)"
+  by (clarsimp simp: is_pt_cap_def is_PageTableCap_def cap_asid_def split: option.splits)
+
+lemma cap_asid_vs_cap_ref_Some:
+  "is_pt_cap cap \<Longrightarrow> (cap_asid cap = Some asid) = (\<exists>vref. vs_cap_ref cap = Some (asid, vref))"
+  by (clarsimp simp: is_pt_cap_def is_PageTableCap_def cap_asid_def split: option.splits)
+
+lemma set_cap_unique_table_caps:
+  "\<lbrace>\<lambda>s. unique_table_caps s
+      \<and> (is_pt_cap cap
+             \<longrightarrow> (\<forall>oldcap. caps_of_state s ptr = Some oldcap
+                    \<longrightarrow> is_pt_cap oldcap
+                    \<longrightarrow> (cap_asid cap = None \<longrightarrow> cap_asid oldcap = None)
+                    \<longrightarrow> obj_refs oldcap \<noteq> obj_refs cap)
+             \<longrightarrow> (\<forall>ptr'. cte_wp_at (\<lambda>cap'. obj_refs cap' = obj_refs cap
+                                              \<and> is_pt_cap cap'
+                                              \<and> (cap_asid cap = None \<or> cap_asid cap' = None)) ptr' s \<longrightarrow> ptr' = ptr))\<rbrace>
+     set_cap cap ptr
+   \<lbrace>\<lambda>_. unique_table_caps\<rbrace>"
+  supply split_paired_All[simp del] split_paired_Ex[simp del]
+  supply cap_asid_vs_cap_ref_None[simp] cap_asid_vs_cap_ref_Some[simp]
+  apply wp
+  apply (simp only: unique_table_caps_def cte_wp_at_caps_of_state)
+  apply (elim conjE)
+  apply (erule impCE, clarsimp)
+  apply (erule impCE)
+   prefer 2
+   apply (simp del: imp_disjL)
+   apply (thin_tac "\<forall>a b. P a b" for P)
+   subgoal by fastforce
+  apply (clarsimp simp del: imp_disjL del: allI)
+  apply (case_tac "cap_asid cap \<noteq> None")
+   apply (clarsimp del: allI)
+   apply (elim allEI | rule impI)+
+   subgoal by auto
+  apply (elim allEI)
+  apply (intro conjI impI)
+   apply (elim allEI)
+   subgoal by auto
+  apply auto
+  done
+
+lemma set_cap_unique_table_refs[wp]:
+  "\<lbrace> unique_table_refs and no_cap_to_obj_with_diff_ref cap {ptr} \<rbrace>
+   set_cap cap ptr
+   \<lbrace>\<lambda>rv. unique_table_refs\<rbrace>"
+  apply wp
+  apply clarsimp
+  apply (simp add: unique_table_refs_def
+              split del: if_split del: split_paired_All)
+  apply (erule allEI, erule allEI)
+  apply (clarsimp split del: if_split)
+  apply (clarsimp simp: no_cap_to_obj_with_diff_ref_def
+                        cte_wp_at_caps_of_state
+                 split: if_split_asm)
+  done
+
+lemma table_cap_ref_vs_ref_or_frame:
+  "\<lbrakk> table_cap_ref cap = table_cap_ref cap'; vs_cap_ref cap = Some x \<rbrakk>
+   \<Longrightarrow> vs_cap_ref cap' = Some x \<or> is_frame_cap cap"
+  by (simp add: vs_cap_ref_def table_cap_ref_def arch_cap_fun_lift_def vs_cap_ref_arch_def
+                table_cap_ref_arch_def
+         split: cap.splits arch_cap.splits)
+
+lemma obj_refs_obj_ref_of:
+  "obj_refs cap = {p} \<Longrightarrow> obj_ref_of cap = p"
+  by (cases cap; simp) (rename_tac acap, case_tac acap; simp)
+
+lemma set_cap_valid_asid_pool_caps[wp]:
+  "\<lbrace>\<lambda>s. valid_asid_pool_caps s
+      \<and> (\<forall>vref cap'. caps_of_state s ptr = Some cap'
+                \<longrightarrow> vs_cap_ref cap' = Some vref
+                \<longrightarrow> (vs_cap_ref cap = Some vref \<and> obj_refs cap = obj_refs cap')
+                 \<or> (\<not> is_final_cap' cap' s \<and> \<not> reachable_frame_cap cap' s)
+                 \<or> (\<forall>oref. oref \<in> obj_refs cap' \<longrightarrow> \<not> reachable_target vref oref s))
+      \<and> unique_table_refs s\<rbrace>
+   set_cap cap ptr
+   \<lbrace>\<lambda>_. valid_asid_pool_caps\<rbrace>"
+  apply (wp_pre, wps, wp)
+  supply split_paired_Ex[simp del] split_paired_All[simp del]
+  apply (clarsimp simp: valid_asid_pool_caps_def simp del: fun_upd_apply)
+  apply (erule allE, erule allE, erule (1) impE)
+  apply (elim exE conjE)
+  apply (case_tac "ptr \<noteq> cptr", fastforce)
+  apply simp
+  apply (erule disjE, rule_tac x=cptr in exI, fastforce)
+  apply (erule disjE)
+   apply (erule conjE)
+   apply (drule (1) not_final_another_caps)
+    apply (rule obj_ref_is_gen_obj_ref, simp)
+   apply (simp add: gen_obj_refs_eq)
+   apply (elim exE conjE)
+   apply (rule_tac x=p' in exI)
+   apply simp
+   apply (drule_tac cap=cap and cap'=cap' in unique_table_refsD; simp?)
+   apply (drule (1) table_cap_ref_vs_ref_or_frame)
+   apply (erule disjE, simp)
+   apply (simp add: reachable_frame_cap_def)
+   apply (clarsimp simp: reachable_target_def pool_for_asid_def obj_refs_obj_ref_of)
+  apply (rule_tac x=cptr in exI)
+  apply (clarsimp simp: reachable_target_def pool_for_asid_def)
+  done
+
+lemma set_cap_valid_arch_caps:
+  "\<lbrace>\<lambda>s. valid_arch_caps s
+      \<and> (\<forall>vref cap'. cte_wp_at ((=) cap') ptr s
+                \<longrightarrow> vs_cap_ref cap' = Some vref
+                \<longrightarrow> (vs_cap_ref cap = Some vref \<and> obj_refs cap = obj_refs cap')
+                 \<or> (\<not> is_final_cap' cap' s \<and> \<not> reachable_frame_cap cap' s)
+                 \<or> (\<forall>oref \<in> obj_refs cap'. \<not> reachable_target vref oref s))
+      \<and> no_cap_to_obj_with_diff_ref cap {ptr} s
+      \<and> (is_pt_cap cap \<longrightarrow> cap_asid cap = None
+            \<longrightarrow> (\<forall>r \<in> obj_refs cap. pts_of s r = Some empty_pt))
+      \<and> (is_pt_cap cap
+             \<longrightarrow> (\<forall>oldcap. caps_of_state s ptr = Some oldcap \<longrightarrow>
+                  is_pt_cap oldcap
+                    \<longrightarrow> (cap_asid cap = None \<longrightarrow> cap_asid oldcap = None)
+                    \<longrightarrow> obj_refs oldcap \<noteq> obj_refs cap)
+             \<longrightarrow> (\<forall>ptr'. cte_wp_at (\<lambda>cap'. obj_refs cap' = obj_refs cap
+                     \<and> is_pt_cap cap'
+                     \<and> (cap_asid cap = None \<or> cap_asid cap' = None)) ptr' s \<longrightarrow> ptr' = ptr))\<rbrace>
+     set_cap cap ptr
+   \<lbrace>\<lambda>rv. valid_arch_caps\<rbrace>"
+  unfolding valid_arch_caps_def
+  by (wpsimp wp: set_cap_valid_vs_lookup set_cap_valid_table_caps set_cap_unique_table_caps
+           simp: cte_wp_at_caps_of_state)
+
+lemma valid_table_capsD:
+  "\<lbrakk> cte_wp_at ((=) cap) ptr s; valid_table_caps s; is_pt_cap cap; cap_asid cap = None \<rbrakk>
+   \<Longrightarrow> \<forall>r \<in> obj_refs cap. pts_of s r = Some empty_pt"
+  apply (clarsimp simp: cte_wp_at_caps_of_state valid_table_caps_def is_pt_cap_def
+                        is_PageTableCap_def cap_asid_def
+                 split: option.splits)
+   apply (cases ptr, fastforce)+
+  done
+
+lemma pt_caps_asid_vsref:
+  "is_pt_cap cap \<Longrightarrow> (cap_asid cap = None) = (vs_cap_ref cap = None)"
+  apply (cases cap; simp)
+  apply (rename_tac acap, case_tac acap; simp add: cap_asid_def split: option.splits)
+  done
+
+lemma unique_table_capsD:
+  "\<lbrakk> unique_table_caps_2 cps; cps ptr = Some cap; cps ptr' = Some cap';
+     obj_refs cap = obj_refs cap'; vs_cap_ref cap = None \<or> vs_cap_ref cap' = None;
+     is_pt_cap cap; is_pt_cap cap' \<rbrakk>
+     \<Longrightarrow> ptr = ptr'"
+  unfolding unique_table_caps_def
+  by blast
+
+lemma valid_refs_def2:
+  "valid_refs R s = (\<forall>p c. caps_of_state s p = Some c \<longrightarrow> cap_range c \<inter> R = {})"
+  by (auto simp: valid_refs_def cte_wp_at_caps_of_state)
+
+lemma set_cap_cap_refs_in_kernel_window[wp]:
+  "\<lbrace>cap_refs_in_kernel_window and (\<lambda>s. \<forall>ref \<in> cap_range cap. ref \<in> kernel_window s)\<rbrace>
+     set_cap cap p
+   \<lbrace>\<lambda>rv. cap_refs_in_kernel_window\<rbrace>"
+  apply (simp add: cap_refs_in_kernel_window_def valid_refs_def2 pred_conj_def)
+  apply (wp_pre, wps, wp)
+  apply (clarsimp simp: not_kernel_window_def)
+  apply fastforce
+  done
+
+lemma cap_refs_in_kernel_windowD:
+  "\<lbrakk> caps_of_state s ptr = Some cap; cap_refs_in_kernel_window s \<rbrakk>
+   \<Longrightarrow> \<forall>ref \<in> cap_range cap. ref \<in> kernel_window s"
+  apply (clarsimp simp: cap_refs_in_kernel_window_def valid_refs_def cte_wp_at_caps_of_state
+                        not_kernel_window_def)
+  apply (cases ptr, fastforce)
+  done
+
+lemma valid_cap_imp_valid_vm_rights:
+  "valid_cap (ArchObjectCap (FrameCap p rs sz dev m)) s \<Longrightarrow> rs \<in> valid_vm_rights"
+  by (simp add: valid_cap_def valid_vm_rights_def)
+
+lemma acap_rights_update_idem [simp]:
+  "acap_rights_update R (acap_rights_update R' cap) = acap_rights_update R cap"
+  by (simp add: acap_rights_update_def split: arch_cap.splits)
+
+lemma cap_master_arch_cap_rights [simp]:
+  "cap_master_arch_cap (acap_rights_update R cap) = cap_master_arch_cap cap"
+  by (simp add: cap_master_arch_cap_def acap_rights_update_def
+           split: arch_cap.splits)
+
+lemma acap_rights_update_id [intro!, simp]:
+  "valid_arch_cap ac s \<Longrightarrow> acap_rights_update (acap_rights ac) ac = ac"
+  unfolding acap_rights_update_def acap_rights_def valid_arch_cap_def
+  by (cases ac; simp)
+
+lemma obj_ref_none_no_asid:
+  "{} = obj_refs new_cap \<longrightarrow> None = table_cap_ref new_cap"
+  "obj_refs new_cap = {} \<longrightarrow> table_cap_ref new_cap = None"
+  by (simp add: table_cap_ref_def table_cap_ref_arch_def arch_cap_fun_lift_def
+         split: cap.split arch_cap.split)+
+
+lemma set_cap_hyp_refs_of [wp]:
+ "\<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>
+  set_cap cp p
+  \<lbrace>\<lambda>rv s. P (state_hyp_refs_of s)\<rbrace>"
+  apply (simp add: set_cap_def set_object_def split_def)
+  apply (wp get_object_wp | wpc)+
+  by (force elim!: rsubst[where P=P]
+            simp: state_hyp_refs_of_def obj_at_def
+            split: if_split_asm)
+
+lemmas state_hyp_refs_of_revokable = state_hyp_refs_update
+
+lemma is_valid_vtable_root_is_arch_cap:
+  "is_valid_vtable_root cap \<Longrightarrow> is_arch_cap cap"
+  by (clarsimp simp: is_valid_vtable_root_def is_arch_cap_def split: cap.splits)
+
+lemma unique_table_refs_no_cap_asidE:
+  "\<lbrakk>caps_of_state s p = Some cap; unique_table_refs s\<rbrakk>
+   \<Longrightarrow> no_cap_to_obj_with_diff_ref cap S s"
+  apply (clarsimp simp: no_cap_to_obj_with_diff_ref_def
+                        cte_wp_at_caps_of_state)
+  apply (unfold unique_table_refs_def)
+  apply (drule_tac x=p in spec, drule_tac x="(a,b)" in spec)
+  apply (drule spec)+
+  apply (erule impE, assumption)+
+  apply (clarsimp simp: is_cap_simps)
+  done
+
+lemmas unique_table_refs_no_cap_asidD
+     = unique_table_refs_no_cap_asidE[where S="{}"]
+
+end
+end

--- a/proof/invariant-abstract/AARCH64/ArchCSpaceInvPre_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpaceInvPre_AI.thy
@@ -171,10 +171,12 @@ lemma set_cap_valid_vs_lookup:
   apply fastforce
   done *)
 
-(* FIXME AARCH64
+abbreviation
+  "cap_pt_type cap \<equiv> acap_pt_type (the_arch_cap cap)"
+
 lemma set_cap_valid_table_caps:
   "\<lbrace>\<lambda>s. valid_table_caps s \<and>
-        (is_pt_cap cap \<longrightarrow> cap_asid cap = None \<longrightarrow> (\<forall>r \<in> obj_refs cap. pts_of s r = Some empty_pt))\<rbrace>
+        (is_pt_cap cap \<longrightarrow> cap_asid cap = None \<longrightarrow> (\<forall>r \<in> obj_refs cap. pts_of s r = Some (empty_pt (cap_pt_type cap))))\<rbrace>
      set_cap cap ptr
    \<lbrace>\<lambda>rv. valid_table_caps\<rbrace>"
   supply split_paired_All[simp del] split_paired_Ex[simp del]
@@ -182,6 +184,7 @@ lemma set_cap_valid_table_caps:
   apply (wp hoare_vcg_all_lift
             hoare_vcg_disj_lift hoare_convert_imp[OF set_cap_caps_of_state]
             hoare_use_eq[OF set_cap_arch set_cap_obj_at_impossible])
+  sorry (* FIXME AARCH64
   apply (fastforce simp: cap_asid_def split: if_split_asm)
   done *)
 
@@ -314,13 +317,13 @@ lemma set_cap_valid_arch_caps:
   by (wpsimp wp: set_cap_valid_vs_lookup set_cap_valid_table_caps set_cap_unique_table_caps
            simp: cte_wp_at_caps_of_state) *)
 
-(* FIXME AARCH64
 lemma valid_table_capsD:
   "\<lbrakk> cte_wp_at ((=) cap) ptr s; valid_table_caps s; is_pt_cap cap; cap_asid cap = None \<rbrakk>
-   \<Longrightarrow> \<forall>r \<in> obj_refs cap. pts_of s r = Some empty_pt"
+   \<Longrightarrow> \<forall>r \<in> obj_refs cap. pts_of s r = Some (empty_pt (cap_pt_type cap))"
   apply (clarsimp simp: cte_wp_at_caps_of_state valid_table_caps_def is_pt_cap_def
                         is_PageTableCap_def cap_asid_def
                  split: option.splits)
+  sorry (* FIXME AARCH64
    apply (cases ptr, fastforce)+
   done *)
 

--- a/proof/invariant-abstract/AARCH64/ArchCSpaceInvPre_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpaceInvPre_AI.thy
@@ -301,7 +301,7 @@ lemma set_cap_valid_arch_caps:
                  \<or> (\<forall>oref \<in> obj_refs cap'. \<not> reachable_target vref oref s))
       \<and> no_cap_to_obj_with_diff_ref cap {ptr} s
       \<and> (is_pt_cap cap \<longrightarrow> cap_asid cap = None
-            \<longrightarrow> (\<forall>r \<in> obj_refs cap. pts_of s r = Some (empty_pt FIXME)))
+            \<longrightarrow> (\<forall>r \<in> obj_refs cap. pts_of s r = Some (empty_pt (cap_pt_type cap))))
       \<and> (is_pt_cap cap
              \<longrightarrow> (\<forall>oldcap. caps_of_state s ptr = Some oldcap \<longrightarrow>
                   is_pt_cap oldcap
@@ -313,9 +313,8 @@ lemma set_cap_valid_arch_caps:
      set_cap cap ptr
    \<lbrace>\<lambda>rv. valid_arch_caps\<rbrace>"
   unfolding valid_arch_caps_def
-  sorry (*
   by (wpsimp wp: set_cap_valid_vs_lookup set_cap_valid_table_caps set_cap_unique_table_caps
-           simp: cte_wp_at_caps_of_state) *)
+           simp: cte_wp_at_caps_of_state)
 
 lemma valid_table_capsD:
   "\<lbrakk> cte_wp_at ((=) cap) ptr s; valid_table_caps s; is_pt_cap cap; cap_asid cap = None \<rbrakk>

--- a/proof/invariant-abstract/AARCH64/ArchCSpaceInv_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpaceInv_AI.thy
@@ -1,0 +1,217 @@
+(*
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(*
+CSpace invariants
+*)
+
+theory ArchCSpaceInv_AI
+imports CSpaceInv_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+definition
+   safe_ioport_insert :: "cap \<Rightarrow> cap \<Rightarrow> 'a::state_ext state \<Rightarrow> bool"
+where
+  "safe_ioport_insert newcap oldcap \<equiv> \<lambda>_. True"
+
+lemma safe_ioport_insert_triv:
+  "\<not>is_arch_cap newcap \<Longrightarrow> safe_ioport_insert newcap oldcap s"
+  by (clarsimp simp: safe_ioport_insert_def)
+
+lemma set_cap_ioports':
+ "\<lbrace>\<lambda>s. valid_ioports s \<and> cte_wp_at (\<lambda>cap'. safe_ioport_insert cap cap' s) ptr s\<rbrace>
+    set_cap cap ptr
+  \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
+  by wpsimp
+
+lemma replace_cap_invs:
+  "\<lbrace>\<lambda>s. invs s \<and> cte_wp_at (replaceable s p cap) p s
+        \<and> cap \<noteq> cap.NullCap
+        \<and> ex_cte_cap_wp_to (appropriate_cte_cap cap) p s
+        \<and> s \<turnstile> cap\<rbrace>
+     set_cap cap p
+   \<lbrace>\<lambda>rv s. invs s\<rbrace>"
+  apply (simp add: invs_def valid_state_def valid_mdb_def2 valid_arch_mdb_def)
+  apply (rule hoare_pre)
+   apply (wp replace_cap_valid_pspace
+             set_cap_caps_of_state2 set_cap_idle
+             replace_cap_ifunsafe valid_irq_node_typ
+             set_cap_typ_at set_cap_irq_handlers
+             set_cap_valid_arch_caps
+             set_cap_cap_refs_respects_device_region_replaceable)
+  apply (clarsimp simp: valid_pspace_def cte_wp_at_caps_of_state
+                        replaceable_def)
+  apply (rule conjI)
+   apply (fastforce simp: tcb_cap_valid_def
+                  dest!: cte_wp_tcb_cap_valid [OF caps_of_state_cteD])
+  apply (rule conjI)
+   apply (erule_tac P="\<lambda>cps. mdb_cte_at cps (cdt s)" in rsubst)
+   apply (rule ext)
+   apply (safe del: disjE)[1]
+    apply (simp add: gen_obj_refs_empty final_NullCap)+
+  apply (rule conjI)
+   apply (simp add: untyped_mdb_def is_cap_simps)
+   apply (erule disjE)
+    apply (clarsimp, rule conjI, clarsimp+)[1]
+   apply (erule allEI, erule allEI)
+   apply (drule_tac x="fst p" in spec, drule_tac x="snd p" in spec)
+   apply (clarsimp simp: gen_obj_refs_subset)
+   apply (drule(1) disjoint_subset, erule (1) notE)
+  apply (rule conjI)
+   apply (erule descendants_inc_minor)
+    apply simp
+   apply (elim disjE)
+    apply clarsimp
+   apply clarsimp
+  apply (rule conjI)
+   apply (erule disjE)
+    apply (simp add: fun_upd_def[symmetric] fun_upd_idem)
+   apply (simp add: untyped_inc_def not_is_untyped_no_range)
+  apply (rule conjI)
+   apply (erule disjE)
+    apply (simp add: fun_upd_def[symmetric] fun_upd_idem)
+   apply (simp add: ut_revocable_def)
+  apply (rule conjI)
+   apply (erule disjE)
+    apply (clarsimp simp: irq_revocable_def)
+   apply clarsimp
+   apply (clarsimp simp: irq_revocable_def)
+  apply (rule conjI)
+   apply (erule disjE)
+    apply (simp add: fun_upd_def[symmetric] fun_upd_idem)
+   apply (simp add: reply_master_revocable_def)
+  apply (rule conjI)
+   apply (erule disjE)
+    apply (simp add: fun_upd_def[symmetric] fun_upd_idem)
+   apply (clarsimp simp add: reply_mdb_def)
+   apply (thin_tac "\<forall>a b. (a, b) \<in> cte_refs cp nd \<and> Q a b\<longrightarrow> R a b" for cp nd Q R)
+   apply (thin_tac "is_pt_cap cap \<longrightarrow> P" for cap P)+
+   apply (rule conjI)
+    apply (unfold reply_caps_mdb_def)[1]
+    apply (erule allEI, erule allEI)
+    apply (clarsimp split: if_split simp add: is_cap_simps
+                 simp del: split_paired_Ex split_paired_All)
+    apply (rename_tac ptra ptrb rights')
+    apply (rule_tac x="(ptra,ptrb)" in exI)
+    apply fastforce
+   apply (unfold reply_masters_mdb_def)[1]
+   apply (erule allEI, erule allEI)
+   subgoal by (fastforce split: if_split_asm simp: is_cap_simps)
+  apply (rule conjI)
+   apply (erule disjE)
+    apply (clarsimp simp add: is_reply_cap_to_def)
+    apply (drule caps_of_state_cteD)
+    apply (subgoal_tac "cte_wp_at (is_reply_cap_to t) p s")
+     apply (erule(1) valid_reply_capsD [OF has_reply_cap_cte_wpD])
+    apply (erule cte_wp_at_lift)
+    apply (fastforce simp add:is_reply_cap_to_def)
+   apply (simp add: is_cap_simps)
+  apply (frule(1) valid_global_refsD2)
+  apply (frule(1) cap_refs_in_kernel_windowD)
+  apply (rule conjI)
+   apply (erule disjE)
+    apply (clarsimp simp: valid_reply_masters_def cte_wp_at_caps_of_state)
+    apply (cases p, fastforce simp:is_master_reply_cap_to_def)
+   apply (simp add: is_cap_simps)
+  apply (elim disjE)
+   apply simp
+   apply (clarsimp simp: valid_table_capsD[OF caps_of_state_cteD]
+                    valid_arch_caps_def unique_table_refs_no_cap_asidE)
+  apply (rule conjI, clarsimp)
+  apply (rule conjI, rule Ball_emptyI, simp add: gen_obj_refs_subset)
+  by clarsimp
+
+definition
+  "is_simple_cap_arch cap \<equiv> \<not>is_pt_cap cap"
+
+lemma is_simple_cap_arch:
+  "\<not>is_arch_cap cap \<Longrightarrow> is_simple_cap_arch cap"
+  by (simp add: is_cap_simps is_simple_cap_arch_def)
+
+(* True when cap' is derived from cap. *)
+definition
+  "is_derived_arch cap' cap \<equiv>
+    (is_pt_cap cap' \<longrightarrow> cap_asid cap = cap_asid cap' \<and> cap_asid cap' \<noteq> None) \<and>
+    (vs_cap_ref cap = vs_cap_ref cap' \<or> is_frame_cap cap)"
+
+lemma is_derived_arch_non_arch:
+  "\<lbrakk> \<not> is_arch_cap cap; \<not> is_arch_cap cap' \<rbrakk> \<Longrightarrow> is_derived_arch cap cap'"
+  unfolding is_derived_arch_def vs_cap_ref_def is_arch_cap_def is_pt_cap_def
+  by (auto split: cap.splits)
+
+lemmas cap_master_arch_cap_simps = cap_master_arch_cap_def[split_simps arch_cap.split]
+
+lemmas cap_master_cap_def = cap_master_cap_def[simplified cap_master_arch_cap_def]
+
+lemma same_master_cap_same_types:
+  "cap_master_cap cap = cap_master_cap cap' \<Longrightarrow>
+     is_pt_cap cap = is_pt_cap cap' \<and>
+     is_frame_cap cap = is_frame_cap cap' \<and>
+     is_ap_cap cap = is_ap_cap cap'"
+  by (clarsimp simp: cap_master_cap_def is_cap_simps split: cap.splits arch_cap.splits)
+
+lemma is_derived_cap_arch_asid_issues:
+  "\<lbrakk> is_derived_arch cap cap'; cap_master_cap cap = cap_master_cap cap' \<rbrakk>
+   \<Longrightarrow> (is_pt_cap cap \<longrightarrow> cap_asid cap \<noteq> None) \<and>
+       (is_frame_cap cap \<or> (vs_cap_ref cap = vs_cap_ref cap'))"
+  apply (simp add: is_derived_arch_def)
+  by (auto simp: cap_master_cap_def is_cap_simps cap_asid_def
+          split: cap.splits arch_cap.splits option.splits)
+
+lemma is_derived_cap_arch_asid:
+  "\<lbrakk> is_derived_arch cap cap'; cap_master_cap cap = cap_master_cap cap'; is_pt_cap cap' \<rbrakk>
+   \<Longrightarrow> cap_asid cap = cap_asid cap'"
+  unfolding is_derived_arch_def
+  apply (cases cap; cases cap'; simp)
+  by (auto simp: is_cap_simps cap_master_cap_def split: arch_cap.splits)
+
+definition safe_parent_for_arch :: "cap \<Rightarrow> cap \<Rightarrow> bool" where
+  "safe_parent_for_arch cap parent \<equiv> False"
+
+lemma safe_parent_for_arch_not_arch:
+  "\<not>is_arch_cap cap \<Longrightarrow> \<not>safe_parent_for_arch cap p"
+  by (clarsimp simp: safe_parent_for_arch_def is_cap_simps)
+
+lemma safe_parent_cap_range_arch:
+  "safe_parent_for_arch cap pcap \<Longrightarrow> cap_range cap \<subseteq> cap_range pcap"
+  by (clarsimp simp: safe_parent_for_arch_def cap_range_def)
+
+definition
+  "cap_asid_base_arch cap \<equiv> case cap of
+     ASIDPoolCap _ asid \<Rightarrow> Some asid
+  | _ \<Rightarrow> None"
+
+declare cap_asid_base_arch_def[abs_def, simp]
+
+definition cap_asid_base :: "cap \<Rightarrow> asid option" where
+  "cap_asid_base cap \<equiv> arch_cap_fun_lift cap_asid_base_arch None cap"
+
+lemmas cap_asid_base_simps [simp] =
+  cap_asid_base_def [simplified, split_simps cap.split arch_cap.split]
+
+definition
+  "cap_vptr_arch acap \<equiv> case acap of
+     (FrameCap _ _ _ _  (Some (_, vptr))) \<Rightarrow> Some vptr
+  |  (PageTableCap _ (Some (_, vptr))) \<Rightarrow> Some vptr
+  | _ \<Rightarrow> None"
+
+definition
+  "cap_vptr cap \<equiv> arch_cap_fun_lift cap_vptr_arch None cap"
+
+declare cap_vptr_arch_def[abs_def, simp]
+
+lemmas cap_vptr_simps [simp] =
+  cap_vptr_def [simplified, split_simps cap.split arch_cap.split option.split prod.split]
+
+end
+
+context begin interpretation Arch .
+requalify_facts replace_cap_invs
+end
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchCSpaceInv_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpaceInv_AI.thy
@@ -12,7 +12,7 @@ theory ArchCSpaceInv_AI
 imports CSpaceInv_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 definition
    safe_ioport_insert :: "cap \<Rightarrow> cap \<Rightarrow> 'a::state_ext state \<Rightarrow> bool"
@@ -120,11 +120,12 @@ lemma replace_cap_invs:
    apply (simp add: is_cap_simps)
   apply (elim disjE)
    apply simp
+   sorry (* FIXME AARCH64
    apply (clarsimp simp: valid_table_capsD[OF caps_of_state_cteD]
                     valid_arch_caps_def unique_table_refs_no_cap_asidE)
   apply (rule conjI, clarsimp)
   apply (rule conjI, rule Ball_emptyI, simp add: gen_obj_refs_subset)
-  by clarsimp
+  by clarsimp *)
 
 definition
   "is_simple_cap_arch cap \<equiv> \<not>is_pt_cap cap"
@@ -197,7 +198,7 @@ lemmas cap_asid_base_simps [simp] =
 definition
   "cap_vptr_arch acap \<equiv> case acap of
      (FrameCap _ _ _ _  (Some (_, vptr))) \<Rightarrow> Some vptr
-  |  (PageTableCap _ (Some (_, vptr))) \<Rightarrow> Some vptr
+  |  (PageTableCap _ _ (Some (_, vptr))) \<Rightarrow> Some vptr
   | _ \<Rightarrow> None"
 
 definition

--- a/proof/invariant-abstract/AARCH64/ArchCSpacePre_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpacePre_AI.thy
@@ -1,0 +1,247 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(*
+RISCV64-specific CSpace invariants
+*)
+
+theory ArchCSpacePre_AI
+imports CSpacePre_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+lemmas typ_at_eq_kheap_obj = typ_at_eq_kheap_obj atyp_at_eq_kheap_obj
+
+lemmas set_cap_atyp_ats[wp] = abs_atyp_at_lifts[OF set_cap_typ_at]
+
+definition
+  "final_matters_arch ac \<equiv>
+     (case ac of
+         ASIDPoolCap r as \<Rightarrow> True
+       | ASIDControlCap \<Rightarrow> False
+       | FrameCap r rghts sz dev mapdata \<Rightarrow> False
+       | PageTableCap r mapdata \<Rightarrow> True)"
+
+lemma pageBitsForSize_eq[simp]:
+  "(pageBitsForSize sz = pageBitsForSize sz') = (sz = sz')"
+  by (cases sz; cases sz'; simp add: pageBits_def ptTranslationBits_def)
+
+lemma aobj_ref_cases':
+  "aobj_ref acap = (case acap of ASIDControlCap \<Rightarrow> aobj_ref acap
+                                | _ \<Rightarrow> aobj_ref acap)"
+  by (simp split: arch_cap.split)
+
+lemma aobj_ref_cases:
+  "aobj_ref acap =
+  (case acap of
+    ASIDPoolCap w _ \<Rightarrow> Some w
+  | ASIDControlCap \<Rightarrow> None
+  | FrameCap w _ _ _ _ \<Rightarrow> Some w
+  | PageTableCap w _ \<Rightarrow> Some w)"
+  apply (subst aobj_ref_cases')
+  apply (clarsimp cong: arch_cap.case_cong)
+  done
+
+definition
+  "ups_of_heap h \<equiv> \<lambda>p.
+   case h p of Some (ArchObj (DataPage dev sz)) \<Rightarrow> Some sz | _ \<Rightarrow> None"
+
+lemma ups_of_heap_typ_at:
+  "ups_of_heap (kheap s) p = Some sz \<longleftrightarrow> data_at sz p s"
+  by (auto simp: typ_at_eq_kheap_obj ups_of_heap_def data_at_def
+          split: option.splits Structures_A.kernel_object.splits
+                 arch_kernel_obj.splits)
+
+lemma ups_of_heap_typ_at_def:
+  "ups_of_heap (kheap s) \<equiv> \<lambda>p.
+   if \<exists>!sz. data_at sz p s
+     then Some (THE sz. data_at sz p s)
+     else None"
+  apply (rule eq_reflection)
+  apply (rule ext)
+  apply (clarsimp simp: ups_of_heap_typ_at)
+  apply (intro conjI impI)
+   apply (frule (1) theI')
+  apply safe
+   apply (fastforce simp: ups_of_heap_typ_at)
+  by (auto simp: obj_at_def data_at_def)
+
+lemma ups_of_heap_non_arch_upd:
+  "h x = Some ko \<Longrightarrow> non_arch_obj ko \<Longrightarrow> non_arch_obj ko' \<Longrightarrow> ups_of_heap (h(x \<mapsto> ko')) = ups_of_heap h"
+  by (rule ext) (auto simp add: ups_of_heap_def non_arch_obj_def split: kernel_object.splits)
+
+crunch inv[wp]: lookup_ipc_buffer "I"
+
+lemma vs_cap_ref_to_table_cap_ref:
+  "\<not> is_frame_cap cap \<Longrightarrow> vs_cap_ref cap = table_cap_ref cap"
+  by (simp add: is_frame_cap_def table_cap_ref_def vs_cap_ref_def
+                arch_cap_fun_lift_def vs_cap_ref_arch_def is_FrameCap_def
+         split: cap.splits arch_cap.splits)
+
+
+lemma cap_master_cap_frame_cap:
+ "\<lbrakk>cap_master_cap cap = cap_master_cap cap'\<rbrakk>
+  \<Longrightarrow> is_frame_cap cap = is_frame_cap cap'"
+  by (clarsimp simp: cap_master_cap_def is_cap_simps
+              split: cap.splits arch_cap.splits dest!:cap_master_cap_eqDs)
+
+lemma master_arch_cap_obj_refs:
+  "cap_master_arch_cap c = cap_master_arch_cap c' \<Longrightarrow> aobj_ref c = aobj_ref c'"
+  by (simp add: cap_master_arch_cap_def split: arch_cap.splits)
+
+lemma master_arch_cap_cap_class:
+  "cap_master_arch_cap c = cap_master_arch_cap c' \<Longrightarrow> acap_class c = acap_class c'"
+  by (simp add: cap_master_arch_cap_def split: arch_cap.splits)
+
+lemma is_cap_free_index_update[simp]:
+  "is_frame_cap (src_cap\<lparr>free_index := a\<rparr>) = is_frame_cap src_cap"
+  "is_ap_cap (src_cap\<lparr>free_index := a\<rparr>) = is_ap_cap src_cap"
+  "is_pt_cap (src_cap\<lparr>free_index := a\<rparr>) = is_pt_cap src_cap"
+  by (simp add:is_cap_simps free_index_update_def split:cap.splits)+
+
+lemma masked_as_full_test_function_stuff[simp]:
+  "is_pt_cap (masked_as_full a cap) = is_pt_cap a"
+  "vs_cap_ref (masked_as_full a cap) = vs_cap_ref a"
+  by (auto simp:masked_as_full_def)
+
+lemma same_aobject_as_commute:
+  "same_aobject_as x y \<Longrightarrow> same_aobject_as y x"
+  by (cases x; cases y; clarsimp)
+
+lemmas wellformed_cap_simps = wellformed_cap_def
+  [simplified wellformed_acap_def, split_simps cap.split arch_cap.split]
+
+lemma unique_table_caps_upd_eqD:
+  "\<lbrakk>ms a = Some b; vs_cap_ref b = vs_cap_ref b'; obj_refs b = obj_refs b';
+    is_pt_cap b = is_pt_cap b'\<rbrakk>
+   \<Longrightarrow> unique_table_caps_2 (ms (a \<mapsto> b')) = unique_table_caps_2 ms"
+  unfolding unique_table_caps_def
+  apply (rule iffI)
+  apply (intro allI impI,elim allE)
+    apply (erule impE)
+    apply (rule_tac p = p in fun_upd_Some)
+    apply assumption
+      apply (erule impE)
+      apply (rule_tac p = p' in fun_upd_Some)
+      apply simp
+    subgoal by (fastforce simp: is_pt_cap_eq split:if_splits)
+  apply (intro allI impI,elim allE)
+    apply (erule impE)
+    apply (rule_tac p = p in fun_upd_Some_rev)
+      apply simp+
+  apply (erule impE)
+    apply (rule_tac p = p' in fun_upd_Some_rev)
+    apply simp+
+  apply (simp add: if_distrib split:if_splits)
+  done
+
+lemma arch_derived_is_device:
+  "\<lbrakk>cap_master_arch_cap c = cap_master_arch_cap c';
+        is_derived_arch (ArchObjectCap c) (ArchObjectCap c')\<rbrakk>
+       \<Longrightarrow> arch_cap_is_device c' = arch_cap_is_device c"
+  apply (case_tac c)
+  apply (clarsimp simp: is_derived_arch_def
+    cap_range_def is_cap_simps cap_master_cap_def cap_master_arch_cap_def
+              split: if_split_asm cap.splits arch_cap.splits)+
+  done
+
+lemma valid_arch_mdb_simple:
+  "\<lbrakk> valid_arch_mdb (is_original_cap s) (caps_of_state s);
+     is_simple_cap cap; caps_of_state s src = Some capa\<rbrakk> \<Longrightarrow>
+   valid_arch_mdb ((is_original_cap s) (dest := is_cap_revocable cap capa)) (caps_of_state s(dest \<mapsto> cap))"
+  by (auto simp: valid_arch_mdb_def is_cap_revocable_def arch_is_cap_revocable_def
+                 is_simple_cap_def safe_parent_for_def is_cap_simps)
+
+lemma valid_arch_mdb_free_index_update:
+  "\<lbrakk>m src = Some capa;m' = m (src\<mapsto> capa\<lparr>free_index :=x\<rparr>) \<rbrakk> \<Longrightarrow>
+   valid_arch_mdb c (m') = valid_arch_mdb c (m)"
+  by (clarsimp simp:valid_arch_mdb_def)
+
+lemma set_cap_update_free_index_valid_arch_mdb:
+  "\<lbrace>\<lambda>s. valid_arch_mdb (is_original_cap s) (caps_of_state s) \<and> is_untyped_cap src_cap\<rbrace>
+         set_cap (free_index_update f src_cap) src
+   \<lbrace>\<lambda>rv s. valid_arch_mdb (is_original_cap s) (caps_of_state s)\<rbrace>"
+  by (wpsimp simp: valid_arch_mdb_def)
+
+lemma set_untyped_cap_as_full_valid_arch_mdb:
+  "\<lbrace>\<lambda>s. valid_arch_mdb (is_original_cap s) (caps_of_state s)\<rbrace>
+            set_untyped_cap_as_full src_cap c src
+   \<lbrace>\<lambda>rv s. valid_arch_mdb (is_original_cap s) (caps_of_state s)\<rbrace>"
+  by (wpsimp wp: set_cap_update_free_index_valid_arch_mdb
+           simp: set_untyped_cap_as_full_def)
+
+lemma valid_arch_mdb_not_arch_cap_update:
+     "\<And>s cap capa. \<lbrakk>\<not>is_arch_cap cap; valid_arch_mdb (is_original_cap s) (caps_of_state s)\<rbrakk>
+       \<Longrightarrow> valid_arch_mdb ((is_original_cap s)(dest := True))
+            (caps_of_state s(src \<mapsto> cap, dest\<mapsto>capa))"
+  by (auto simp: valid_arch_mdb_def)
+
+lemma valid_arch_mdb_derived_cap_update:
+  "\<And>s capa. \<lbrakk>valid_arch_mdb (is_original_cap s) (caps_of_state s);
+             is_derived (cdt s) src cap capa\<rbrakk> \<Longrightarrow>
+           valid_arch_mdb ((is_original_cap s)(dest := is_cap_revocable cap capa))
+                           (caps_of_state s(dest \<mapsto> cap))"
+  by (clarsimp simp: valid_arch_mdb_def)
+
+lemma valid_arch_mdb_free_index_update':
+  "\<And>s capa. \<lbrakk>valid_arch_mdb (is_original_cap s) (caps_of_state s); caps_of_state s src = Some capa;
+                   is_untyped_cap cap\<rbrakk> \<Longrightarrow>
+           valid_arch_mdb ((is_original_cap s) (dest := is_cap_revocable cap capa))
+            (caps_of_state s(dest \<mapsto> cap, src \<mapsto> max_free_index_update capa))"
+  by (auto simp: valid_arch_mdb_def)
+
+lemma valid_arch_mdb_weak_derived_update:
+  "\<And>s capa. \<lbrakk>valid_arch_mdb (is_original_cap s) (caps_of_state s);
+                      caps_of_state s src = Some capa; weak_derived cap capa\<rbrakk> \<Longrightarrow>
+        valid_arch_mdb ((is_original_cap s) (dest := is_original_cap s src, src := False))
+            (caps_of_state s(dest \<mapsto> cap, src \<mapsto> NullCap))"
+  by (auto simp: valid_arch_mdb_def)
+
+lemma valid_arch_mdb_tcb_cnode_update:
+  "valid_arch_mdb (is_original_cap s) (caps_of_state s) \<Longrightarrow>
+           valid_arch_mdb ((is_original_cap s) ((t, tcb_cnode_index 2) := True))
+              (caps_of_state s((t, tcb_cnode_index 2) \<mapsto> ReplyCap t True canReplyGrant))"
+  by (clarsimp simp: valid_arch_mdb_def)
+
+lemmas valid_arch_mdb_updates = valid_arch_mdb_free_index_update valid_arch_mdb_not_arch_cap_update
+                                valid_arch_mdb_derived_cap_update valid_arch_mdb_free_index_update'
+                                valid_arch_mdb_weak_derived_update valid_arch_mdb_tcb_cnode_update
+
+lemma safe_parent_for_arch_not_arch':
+  "\<not>is_arch_cap cap \<Longrightarrow> \<not>safe_parent_for_arch c cap"
+  by (clarsimp simp: safe_parent_for_arch_def is_cap_simps)
+
+lemma safe_parent_arch_is_parent:
+  "\<lbrakk>safe_parent_for_arch cap pcap; caps_of_state s p = Some pcap;
+      valid_arch_mdb (is_original_cap s) (caps_of_state s)\<rbrakk> \<Longrightarrow>
+    should_be_parent_of pcap (is_original_cap s p) cap f"
+  by (clarsimp simp: safe_parent_for_arch_def)
+
+lemma safe_parent_for_arch_no_obj_refs:
+  "safe_parent_for_arch cap c \<Longrightarrow> obj_refs cap = {}"
+  by (clarsimp simp: safe_parent_for_arch_def)
+
+lemma valid_arch_mdb_same_master_cap:
+  "\<lbrakk>valid_arch_mdb ioc cs; cs sl = Some cap; cap_master_cap cap' = cap_master_cap cap\<rbrakk> \<Longrightarrow>
+  valid_arch_mdb ioc (cs(sl\<mapsto>cap'))"
+  by (clarsimp simp: valid_arch_mdb_def)
+
+lemma valid_arch_mdb_null_filter:
+  "valid_arch_mdb (is_original_cap s) (null_filter (caps_of_state s)) = valid_arch_mdb (is_original_cap s) (caps_of_state s)"
+  by (clarsimp simp: valid_arch_mdb_def)
+
+lemma valid_arch_mdb_untypeds:
+  "\<And>s. valid_arch_mdb (is_original_cap s) (caps_of_state s)
+       \<Longrightarrow> valid_arch_mdb (\<lambda>x. x \<noteq> cref \<longrightarrow> is_original_cap s x)
+            (caps_of_state s(cref \<mapsto> default_cap tp oref sz dev))"
+  "\<And>s. valid_arch_mdb (is_original_cap s) (caps_of_state s)
+       \<Longrightarrow> valid_arch_mdb (is_original_cap s)
+            (caps_of_state s(cref \<mapsto> UntypedCap dev ptr sz idx))"
+  by (clarsimp simp: valid_arch_mdb_def)+
+
+end
+end

--- a/proof/invariant-abstract/AARCH64/ArchCSpacePre_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpacePre_AI.thy
@@ -5,14 +5,14 @@
  *)
 
 (*
-RISCV64-specific CSpace invariants
+AARCH64-specific CSpace invariants
 *)
 
 theory ArchCSpacePre_AI
 imports CSpacePre_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 lemmas typ_at_eq_kheap_obj = typ_at_eq_kheap_obj atyp_at_eq_kheap_obj
 
@@ -24,7 +24,7 @@ definition
          ASIDPoolCap r as \<Rightarrow> True
        | ASIDControlCap \<Rightarrow> False
        | FrameCap r rghts sz dev mapdata \<Rightarrow> False
-       | PageTableCap r mapdata \<Rightarrow> True)"
+       | PageTableCap r pt_t mapdata \<Rightarrow> True)"
 
 lemma pageBitsForSize_eq[simp]:
   "(pageBitsForSize sz = pageBitsForSize sz') = (sz = sz')"
@@ -41,10 +41,11 @@ lemma aobj_ref_cases:
     ASIDPoolCap w _ \<Rightarrow> Some w
   | ASIDControlCap \<Rightarrow> None
   | FrameCap w _ _ _ _ \<Rightarrow> Some w
-  | PageTableCap w _ \<Rightarrow> Some w)"
+  | PageTableCap w _ _ \<Rightarrow> Some w)"
   apply (subst aobj_ref_cases')
+  sorry (* FIXME AARCH64 VCPU
   apply (clarsimp cong: arch_cap.case_cong)
-  done
+  done *)
 
 definition
   "ups_of_heap h \<equiv> \<lambda>p.

--- a/proof/invariant-abstract/AARCH64/ArchCSpacePre_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpacePre_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -41,11 +42,11 @@ lemma aobj_ref_cases:
     ASIDPoolCap w _ \<Rightarrow> Some w
   | ASIDControlCap \<Rightarrow> None
   | FrameCap w _ _ _ _ \<Rightarrow> Some w
-  | PageTableCap w _ _ \<Rightarrow> Some w)"
+  | PageTableCap w _ _ \<Rightarrow> Some w
+  | VCPUCap v \<Rightarrow> Some v)"
   apply (subst aobj_ref_cases')
-  sorry (* FIXME AARCH64 VCPU
   apply (clarsimp cong: arch_cap.case_cong)
-  done *)
+  done
 
 definition
   "ups_of_heap h \<equiv> \<lambda>p.
@@ -149,6 +150,13 @@ lemma arch_derived_is_device:
     cap_range_def is_cap_simps cap_master_cap_def cap_master_arch_cap_def
               split: if_split_asm cap.splits arch_cap.splits)+
   done
+
+(* FIXME AARCH64: use vcpus_of instead *)
+lemma set_cap_no_vcpu[wp]:
+  "\<lbrace>obj_at (is_vcpu and P) p\<rbrace> set_cap cap cref \<lbrace>\<lambda>_. obj_at (is_vcpu and P) p\<rbrace>"
+  unfolding set_cap_def2 split_def
+  by (wpsimp wp: set_object_wp get_object_wp get_cap_wp)
+     (auto simp: obj_at_def is_vcpu_def)
 
 lemma valid_arch_mdb_simple:
   "\<lbrakk> valid_arch_mdb (is_original_cap s) (caps_of_state s);

--- a/proof/invariant-abstract/AARCH64/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpace_AI.thy
@@ -1,0 +1,610 @@
+(*
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(*
+Architecture-specific CSpace invariants
+*)
+
+theory ArchCSpace_AI
+imports CSpace_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems CSpace_AI_assms
+
+lemma unique_table_refs_upd_eqD:
+  "\<lbrakk>ms a = Some b; obj_refs b = obj_refs b'; table_cap_ref b = table_cap_ref b'\<rbrakk>
+   \<Longrightarrow> unique_table_refs_2 (ms (a \<mapsto> b')) = unique_table_refs_2 ms"
+  unfolding unique_table_refs_def
+  (* match up p and p' on both sides of equality *)
+  apply (rule all_cong[where Q=\<top>, simplified])
+  apply (rule all_cong[where Q=\<top>, simplified])
+  by auto
+
+lemma cte_at_length_limit:
+  "\<lbrakk> cte_at p s; valid_objs s \<rbrakk> \<Longrightarrow> length (snd p) < word_bits - cte_level_bits"
+  apply (simp add: cte_at_cases)
+  apply (erule disjE)
+   apply clarsimp
+   apply (erule(1) valid_objsE)
+   apply (clarsimp simp: valid_obj_def well_formed_cnode_n_def valid_cs_def valid_cs_size_def
+                         length_set_helper)
+   apply (drule arg_cong[where f="\<lambda>S. snd p \<in> S"])
+   apply (simp add: domI)
+  apply (clarsimp simp add: tcb_cap_cases_length word_bits_conv cte_level_bits_def)
+  done
+
+(* FIXME: move? *)
+lemma getActiveIRQ_wp [CSpace_AI_assms]:
+  "irq_state_independent_A P \<Longrightarrow>
+   valid P (do_machine_op (getActiveIRQ in_kernel)) (\<lambda>_. P)"
+  apply (simp add: getActiveIRQ_def do_machine_op_def split_def exec_gets
+                   select_f_select[simplified liftM_def]
+                   select_modify_comm gets_machine_state_modify)
+  apply wp
+  apply (clarsimp simp: irq_state_independent_A_def in_monad return_def split: if_splits)
+  done
+
+lemma weak_derived_valid_cap [CSpace_AI_assms]:
+  "\<lbrakk> s \<turnstile> c; wellformed_cap c'; weak_derived c' c\<rbrakk> \<Longrightarrow> s \<turnstile> c'"
+  apply (case_tac "c = c'", simp)
+  apply (clarsimp simp: weak_derived_def)
+  apply (clarsimp simp: copy_of_def split: if_split_asm)
+  apply (auto simp: is_cap_simps same_object_as_def wellformed_cap_simps
+                    valid_cap_def cap_aligned_def bits_of_def
+                    aobj_ref_cases Let_def cap_asid_def
+             split: cap.splits arch_cap.splits option.splits)
+  done
+
+lemma copy_obj_refs [CSpace_AI_assms]:
+  "copy_of cap cap' \<Longrightarrow> obj_refs cap' = obj_refs cap"
+  apply (cases cap)
+  apply (auto simp: copy_of_def same_object_as_def is_cap_simps
+                    aobj_ref_cases
+             split: if_split_asm cap.splits arch_cap.splits)
+  done
+
+lemma weak_derived_cap_class[simp, CSpace_AI_assms]:
+  "weak_derived cap src_cap \<Longrightarrow> cap_class cap = cap_class src_cap"
+  apply (simp add:weak_derived_def)
+  apply (auto simp:copy_of_def same_object_as_def is_cap_simps cap_asid_base_def
+    split:if_splits cap.splits arch_cap.splits)
+  done
+
+lemma weak_derived_obj_refs [CSpace_AI_assms]:
+  "weak_derived dcap cap \<Longrightarrow> obj_refs dcap = obj_refs cap"
+  by (cases dcap, auto simp: is_cap_simps weak_derived_def copy_of_def
+                             same_object_as_def aobj_ref_cases
+                       split: if_split_asm cap.splits arch_cap.splits)
+
+lemma weak_derived_obj_ref_of [CSpace_AI_assms]:
+  "weak_derived dcap cap \<Longrightarrow> obj_ref_of dcap = obj_ref_of cap"
+  by (cases dcap, auto simp: is_cap_simps weak_derived_def copy_of_def
+                             same_object_as_def aobj_ref_cases
+                       split: if_split_asm cap.splits arch_cap.splits)
+
+lemma set_free_index_invs [CSpace_AI_assms]:
+  "\<lbrace>\<lambda>s. (free_index_of cap \<le> idx \<and> is_untyped_cap cap \<and> idx \<le> 2^cap_bits cap) \<and>
+        invs s \<and> cte_wp_at ((=) cap ) cref s\<rbrace>
+   set_cap (free_index_update (\<lambda>_. idx) cap) cref
+   \<lbrace>\<lambda>rv s'. invs s'\<rbrace>"
+  apply (rule hoare_grab_asm)+
+  apply (simp add:invs_def valid_state_def)
+  apply (rule hoare_pre)
+  apply (wp set_free_index_valid_pspace[where cap = cap] set_free_index_valid_mdb
+    set_cap_idle update_cap_ifunsafe)
+  apply (simp add:valid_irq_node_def)
+  apply wps
+
+  apply (wp hoare_vcg_all_lift set_cap_irq_handlers set_cap_valid_arch_caps
+    set_cap_irq_handlers cap_table_at_lift_valid set_cap_typ_at
+    set_cap_cap_refs_respects_device_region_spec[where ptr = cref])
+  apply (clarsimp simp:cte_wp_at_caps_of_state)
+  apply (rule conjI,simp add:valid_pspace_def)
+  apply (rule conjI,clarsimp simp:is_cap_simps)
+  apply (rule conjI,rule ext,clarsimp simp: is_cap_simps)
+  apply (clarsimp simp:is_cap_simps appropriate_cte_cap_def)
+  apply (intro conjI)
+       apply (clarsimp split:cap.splits)
+      apply (drule(1) if_unsafe_then_capD[OF caps_of_state_cteD])
+       apply clarsimp
+      apply (simp add:ex_cte_cap_wp_to_def appropriate_cte_cap_def)
+     apply (clarsimp dest!:valid_global_refsD2 simp:cap_range_def)
+    apply (simp add:valid_irq_node_def)
+   apply clarsimp
+   apply (clarsimp simp:valid_irq_node_def)
+   apply (clarsimp simp:no_cap_to_obj_with_diff_ref_def cte_wp_at_caps_of_state vs_cap_ref_def)
+   apply (case_tac capa)
+    apply (simp_all add:table_cap_ref_def)
+    apply (rename_tac arch_cap)
+    apply (case_tac arch_cap)
+    apply simp_all
+  apply (clarsimp simp:cap_refs_in_kernel_window_def
+              valid_refs_def simp del:split_paired_All)
+  apply (drule_tac x = cref in spec)
+  apply (clarsimp simp:cte_wp_at_caps_of_state)
+  apply (drule_tac x = ref in orthD2[rotated])
+   apply (simp add:cap_range_def)
+  apply (simp add: not_kernel_window_def)
+  done
+
+lemma set_untyped_cap_as_full_valid_arch_caps [CSpace_AI_assms]:
+  "\<lbrace>valid_arch_caps and cte_wp_at ((=) src_cap) src\<rbrace>
+   set_untyped_cap_as_full src_cap cap src
+   \<lbrace>\<lambda>ya. valid_arch_caps\<rbrace>"
+  supply if_split[split del]
+  apply (clarsimp simp: valid_arch_caps_def set_untyped_cap_as_full_def)
+  apply (wpsimp wp: set_cap_valid_vs_lookup set_cap_valid_table_caps
+                simp_del: fun_upd_apply simp: cte_wp_at_caps_of_state)
+  apply (fastforce simp: unique_table_refs_upd_eqD unique_table_caps_upd_eqD
+                         is_cap_simps cte_wp_at_caps_of_state)
+  done
+
+lemma set_untyped_cap_as_full[wp, CSpace_AI_assms]:
+  "\<lbrace>\<lambda>s. no_cap_to_obj_with_diff_ref a b s \<and> cte_wp_at ((=) src_cap) src s\<rbrace>
+   set_untyped_cap_as_full src_cap cap src
+   \<lbrace>\<lambda>rv s. no_cap_to_obj_with_diff_ref a b s\<rbrace>"
+  apply (clarsimp simp:no_cap_to_obj_with_diff_ref_def)
+  apply (wp hoare_vcg_ball_lift set_untyped_cap_as_full_cte_wp_at_neg)
+  apply (clarsimp simp:cte_wp_at_caps_of_state)
+  apply (drule_tac x=src in bspec, simp)
+  apply (erule_tac x=src_cap in allE)
+  by (auto simp: table_cap_ref_def masked_as_full_def arch_cap_fun_lift_def
+          split: Structures_A.cap.splits arch_cap.splits option.splits
+                 vmpage_size.splits)
+
+lemma is_derived_is_cap:
+  "is_derived m p cap cap' \<Longrightarrow>
+    (is_frame_cap cap = is_frame_cap cap')
+  \<and> (is_pt_cap cap = is_pt_cap cap')
+  \<and> (is_ap_cap cap = is_ap_cap cap')
+  \<and> (is_ep_cap cap = is_ep_cap cap')
+  \<and> (is_ntfn_cap cap = is_ntfn_cap cap')
+  \<and> (is_cnode_cap cap = is_cnode_cap cap')
+  \<and> (is_thread_cap cap = is_thread_cap cap')
+  \<and> (is_zombie cap = is_zombie cap')
+  \<and> (is_arch_cap cap = is_arch_cap cap')
+  \<and> (cap_is_device cap = cap_is_device cap')"
+  apply (clarsimp simp: is_derived_def is_derived_arch_def split: if_split_asm)
+  by (clarsimp simp: cap_master_cap_def is_cap_simps
+              split: cap.splits arch_cap.splits)+
+
+lemma vs_lookup_pages_non_aobj_upd:
+  "\<lbrakk> kheap s p = Some ko; \<not> is_ArchObj ko; \<not> is_ArchObj ko' \<rbrakk>
+   \<Longrightarrow> vs_lookup_pages (s\<lparr>kheap := kheap s(p \<mapsto> ko')\<rparr>) = vs_lookup_pages s"
+  unfolding vs_lookup_target_def vs_lookup_slot_def
+  apply (frule aobjs_of_non_aobj_upd[where ko'=ko'], simp+)
+  apply (rule ext)+
+  apply (simp add: obind_assoc)
+  apply (rule obind_eqI)
+   apply (rule vs_lookup_table_eq_lift; simp)
+  apply (clarsimp split del: if_split)
+  apply (rule obind_eqI, clarsimp)
+  apply (clarsimp split del: if_split)
+  apply (rule obind_eqI; clarsimp)
+  done
+
+lemma vs_lookup_target_non_aobj_upd:
+  "\<lbrakk> kheap s p = Some ko; \<not> is_ArchObj ko; \<not> is_ArchObj ko' \<rbrakk>
+   \<Longrightarrow> vs_lookup_target level asid vref (s\<lparr>kheap := kheap s(p \<mapsto> ko')\<rparr>)
+      = vs_lookup_target level asid vref s"
+  by (drule vs_lookup_pages_non_aobj_upd[where ko'=ko'], auto dest: fun_cong)
+
+lemma set_untyped_cap_as_full_not_reachable_pg_cap[wp]:
+  "\<lbrace>\<lambda>s. \<not> reachable_frame_cap cap' s\<rbrace>
+   set_untyped_cap_as_full src_cap cap src
+   \<lbrace>\<lambda>rv s. \<not> reachable_frame_cap cap' s\<rbrace>"
+  apply (clarsimp simp: set_untyped_cap_as_full_def set_cap_def split_def
+                        set_object_def)
+  apply (wpsimp wp: get_object_wp simp_del: fun_upd_apply)
+  apply (auto simp: obj_at_def reachable_frame_cap_def is_cap_simps
+                    reachable_target_def vs_lookup_target_non_aobj_upd)
+  done
+
+lemma table_cap_ref_eq_rewrite:
+  "\<lbrakk>cap_master_cap cap = cap_master_cap capa; (is_frame_cap cap \<or> vs_cap_ref cap = vs_cap_ref capa)\<rbrakk>
+   \<Longrightarrow> table_cap_ref cap = table_cap_ref capa"
+  apply (frule cap_master_cap_frame_cap)
+  apply (case_tac "is_frame_cap cap")
+    apply (clarsimp simp:is_cap_simps table_cap_ref_def vs_cap_ref_to_table_cap_ref cap_master_cap_frame_cap)+
+  done
+
+lemma is_derived_cap_asid_issues:
+  "is_derived m p cap cap'
+   \<Longrightarrow> (is_pt_cap cap \<longrightarrow> cap_asid cap \<noteq> None) \<and>
+       (is_frame_cap cap \<or> vs_cap_ref cap = vs_cap_ref cap')"
+  unfolding is_derived_def
+  apply (cases "is_derived_arch cap cap'")
+   apply (erule is_derived_cap_arch_asid_issues)
+   apply (clarsimp split: if_split_asm)+
+  done
+
+lemma set_untyped_cap_as_full_reachable_target[wp]:
+  "\<lbrace>\<lambda>s. P (reachable_target avref p s)\<rbrace>
+   set_untyped_cap_as_full src_cap cap src
+   \<lbrace>\<lambda>r s. P (reachable_target avref p s)\<rbrace>"
+  unfolding reachable_target_def
+  apply (cases avref, clarsimp)
+  apply (rule hoare_lift_Pf[where f="pool_for_asid asid" for asid])
+  apply (clarsimp simp: set_untyped_cap_as_full_def, wp)+
+  done
+
+(* FIXME this is generic *)
+crunches set_untyped_cap_as_full
+  for aobjs_of[wp]: "\<lambda>s. P (aobjs_of s)"
+
+lemma is_derived_is_pt:
+  "is_derived m p cap cap' \<Longrightarrow> (is_pt_cap cap = is_pt_cap cap')"
+  apply (clarsimp simp: is_derived_def split: if_split_asm)
+  apply (clarsimp simp: cap_master_cap_def is_pt_cap_def split: cap.splits arch_cap.splits)+
+  done
+
+lemma cap_insert_valid_arch_caps [CSpace_AI_assms]:
+  "\<lbrace>valid_arch_caps and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
+     cap_insert cap src dest
+   \<lbrace>\<lambda>rv. valid_arch_caps\<rbrace>"
+  apply (simp add: cap_insert_def)
+  apply (rule hoare_pre)
+   apply (wp set_cap_valid_arch_caps get_cap_wp set_untyped_cap_as_full_valid_arch_caps
+               | simp split del: if_split)+
+      apply (wp hoare_vcg_all_lift hoare_vcg_imp_lift set_untyped_cap_as_full_cte_wp_at_neg
+                set_untyped_cap_as_full_is_final_cap'_neg set_untyped_cap_as_full_cte_wp_at hoare_vcg_ball_lift
+                hoare_vcg_ex_lift hoare_vcg_disj_lift | wps)+
+       apply (rule hoare_strengthen_post)
+        prefer 2
+        apply (erule iffD2[OF caps_of_state_cteD'])
+       apply (wp set_untyped_cap_as_full_cte_wp_at hoare_vcg_all_lift hoare_vcg_imp_lift
+                 set_untyped_cap_as_full_cte_wp_at_neg hoare_vcg_ex_lift | clarsimp)+
+     apply (wp get_cap_wp)+
+  apply (intro conjI allI impI disj_subst)
+       apply simp
+      apply clarsimp
+      defer
+      apply (clarsimp simp: valid_arch_caps_def cte_wp_at_caps_of_state)
+      apply (drule(1) unique_table_refs_no_cap_asidD)
+      apply (frule is_derived_obj_refs)
+      apply (frule is_derived_cap_asid_issues)
+      apply (frule is_derived_is_cap)
+      apply (clarsimp simp: no_cap_to_obj_with_diff_ref_def Ball_def
+                      del: disjCI dest!: derived_cap_master_cap_eq)
+      apply (drule table_cap_ref_eq_rewrite)
+       apply clarsimp
+      apply (erule_tac x=a in allE, erule_tac x=b in allE)
+      apply simp+
+    apply (clarsimp simp: obj_at_def is_cap_simps valid_arch_caps_def)
+    apply (frule(1) valid_table_capsD)
+      apply (clarsimp simp: cte_wp_at_caps_of_state)
+      apply (drule is_derived_is_pt)
+      apply (clarsimp simp: is_derived_def is_cap_simps)
+     apply (clarsimp simp: cte_wp_at_caps_of_state)
+     apply (frule is_derived_cap_asid_issues)
+     apply (clarsimp simp: is_cap_simps)
+    apply (clarsimp simp: cte_wp_at_caps_of_state)
+    apply (frule is_derived_obj_refs)
+    apply (drule_tac x=p in bspec)
+     apply fastforce
+    apply (clarsimp simp: obj_at_def empty_table_caps_of)
+   apply (clarsimp simp: is_cap_simps cte_wp_at_caps_of_state)
+   apply (frule is_derived_is_pt)
+   apply (frule is_derived_obj_refs)
+   apply (frule is_derived_cap_asid_issues)
+   apply (clarsimp simp: is_cap_simps is_derived_def valid_arch_caps_def cap_master_cap_def)
+   apply (drule_tac ptr=src and ptr'="(x,xa)" in unique_table_capsD)
+         apply (fastforce simp: cap_asid_def is_cap_simps)+
+  apply (auto simp: cte_wp_at_caps_of_state)
+  done
+
+end
+
+
+global_interpretation cap_insert_crunches?: cap_insert_crunches .
+
+
+context Arch begin global_naming RISCV64
+
+lemma cap_insert_cap_refs_in_kernel_window[wp, CSpace_AI_assms]:
+  "\<lbrace>cap_refs_in_kernel_window
+          and cte_wp_at (\<lambda>c. cap_range cap \<subseteq> cap_range c) src\<rbrace>
+     cap_insert cap src dest
+   \<lbrace>\<lambda>rv. cap_refs_in_kernel_window\<rbrace>"
+  apply (simp add: cap_insert_def set_untyped_cap_as_full_def)
+  apply (wp get_cap_wp | simp split del: if_split)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state is_derived_def)
+  apply (frule(1) cap_refs_in_kernel_windowD[where ptr=src])
+  apply auto
+  done
+
+
+lemma mask_cap_valid[simp, CSpace_AI_assms]:
+  "s \<turnstile> c \<Longrightarrow> s \<turnstile> mask_cap R c"
+  apply (cases c, simp_all add: valid_cap_def mask_cap_def
+                             cap_rights_update_def
+                             cap_aligned_def
+                             acap_rights_update_def split:bool.splits)
+  using valid_validate_vm_rights[simplified valid_vm_rights_def]
+  apply (rename_tac arch_cap)
+  by (case_tac arch_cap, simp_all)
+
+lemma mask_cap_objrefs[simp, CSpace_AI_assms]:
+  "obj_refs (mask_cap rs cap) = obj_refs cap"
+  by (cases cap, simp_all add: mask_cap_def cap_rights_update_def
+                               acap_rights_update_def
+                        split: arch_cap.split bool.splits)
+
+
+lemma mask_cap_zobjrefs[simp, CSpace_AI_assms]:
+  "zobj_refs (mask_cap rs cap) = zobj_refs cap"
+  by (cases cap, simp_all add: mask_cap_def cap_rights_update_def
+                               acap_rights_update_def
+                        split: arch_cap.split bool.splits)
+
+
+lemma derive_cap_valid_cap [CSpace_AI_assms]:
+  "\<lbrace>valid_cap cap\<rbrace> derive_cap slot cap \<lbrace>valid_cap\<rbrace>,-"
+  apply (simp add: derive_cap_def)
+  apply (rule hoare_pre)
+   apply (wpc, (wp arch_derive_cap_valid_cap | simp)+)
+  apply auto
+  done
+
+
+lemma valid_cap_update_rights[simp, CSpace_AI_assms]:
+  "valid_cap cap s \<Longrightarrow> valid_cap (cap_rights_update cr cap) s"
+  apply (case_tac cap,
+         simp_all add: cap_rights_update_def valid_cap_def cap_aligned_def
+                       acap_rights_update_def split:bool.splits)
+  using valid_validate_vm_rights[simplified valid_vm_rights_def]
+  apply (rename_tac arch_cap)
+  apply (case_tac arch_cap, simp_all)
+  done
+
+
+lemma update_cap_data_validI [CSpace_AI_assms]:
+  "s \<turnstile> cap \<Longrightarrow> s \<turnstile> update_cap_data p d cap"
+  apply (cases cap)
+  apply (simp_all add: is_cap_defs update_cap_data_def Let_def split_def)
+     apply (simp add: valid_cap_def cap_aligned_def)
+    apply (simp add: valid_cap_def cap_aligned_def)
+   apply (simp add: the_cnode_cap_def valid_cap_def cap_aligned_def word_bits_def)
+  apply (rename_tac arch_cap)
+  apply (case_tac arch_cap)
+      apply (simp_all add: is_cap_defs arch_update_cap_data_def)
+  done
+
+
+lemma tcb_cnode_index_def2 [CSpace_AI_assms]:
+  "tcb_cnode_index n = nat_to_cref 3 n"
+  apply (simp add: tcb_cnode_index_def nat_to_cref_def)
+  apply (rule nth_equalityI)
+   apply (simp add: word_bits_def)
+  apply (fastforce simp: to_bl_nth word_size word_bits_def)
+  done
+
+
+lemma ex_nonz_tcb_cte_caps [CSpace_AI_assms]:
+  "\<lbrakk>ex_nonz_cap_to t s; tcb_at t s; valid_objs s; ref \<in> dom tcb_cap_cases\<rbrakk>
+   \<Longrightarrow> ex_cte_cap_wp_to (appropriate_cte_cap cp) (t, ref) s"
+  apply (clarsimp simp: ex_nonz_cap_to_def ex_cte_cap_wp_to_def
+                        cte_wp_at_caps_of_state)
+  apply (subgoal_tac "s \<turnstile> cap")
+   apply (rule_tac x=a in exI, rule_tac x=ba in exI)
+   apply (clarsimp simp: valid_cap_def obj_at_def wellformed_acap_def
+                         is_obj_defs dom_def
+                         appropriate_cte_cap_def
+                  split: cap.splits arch_cap.split_asm if_splits)
+  apply (clarsimp simp: caps_of_state_valid_cap)
+  done
+
+
+lemma no_cap_to_obj_with_diff_ref_triv:
+  "\<lbrakk> valid_objs s; valid_cap cap s; \<not> is_pt_cap cap; table_cap_ref cap = None \<rbrakk>
+      \<Longrightarrow> no_cap_to_obj_with_diff_ref cap S s"
+  apply (clarsimp simp add: no_cap_to_obj_with_diff_ref_def)
+  apply (drule(1) cte_wp_at_valid_objs_valid_cap)
+  apply (clarsimp simp: table_cap_ref_def table_cap_ref_arch_def valid_cap_def
+                        obj_at_def is_ep is_ntfn is_tcb is_cap_table
+                        a_type_def is_cap_simps
+                 split: cap.split_asm arch_cap.split_asm
+                        if_split_asm option.split_asm)
+  done
+
+
+lemma setup_reply_master_arch_caps[wp, CSpace_AI_assms]:
+  "\<lbrace>valid_arch_caps and tcb_at t and valid_objs and pspace_aligned\<rbrace>
+     setup_reply_master t
+   \<lbrace>\<lambda>rv. valid_arch_caps\<rbrace>"
+  apply (simp add: setup_reply_master_def)
+  apply (wp set_cap_valid_arch_caps get_cap_wp)
+  apply (clarsimp simp: cte_wp_at_caps_of_state
+                        is_pt_cap_def vs_cap_ref_def)
+  apply (rule no_cap_to_obj_with_diff_ref_triv,
+         simp_all add: is_cap_simps table_cap_ref_def)
+  apply (simp add: valid_cap_def cap_aligned_def word_bits_def)
+  apply (clarsimp simp: obj_at_def is_tcb dest!: pspace_alignedD)
+  done
+
+
+lemma setup_reply_master_cap_refs_in_kernel_window[wp, CSpace_AI_assms]:
+  "\<lbrace>cap_refs_in_kernel_window and tcb_at t and pspace_in_kernel_window\<rbrace>
+      setup_reply_master t
+   \<lbrace>\<lambda>rv. cap_refs_in_kernel_window\<rbrace>"
+  apply (simp add: setup_reply_master_def)
+  apply (wp get_cap_wp)
+  apply (clarsimp simp: pspace_in_kernel_window_def obj_at_def
+                        cap_range_def)
+  done
+
+
+(* FIXME: prove same_region_as_def2 instead or change def *)
+lemma same_region_as_Untyped2 [CSpace_AI_assms]:
+  "\<lbrakk> is_untyped_cap pcap; same_region_as pcap cap \<rbrakk> \<Longrightarrow>
+  (is_physical cap \<and> cap_range cap \<noteq> {} \<and> cap_range cap \<subseteq> cap_range pcap)"
+  by (fastforce simp: is_cap_simps cap_range_def is_physical_def arch_is_physical_def
+               split: cap.splits arch_cap.splits)
+
+
+lemma same_region_as_cap_class [CSpace_AI_assms]:
+  shows "same_region_as a b \<Longrightarrow> cap_class a = cap_class b"
+  apply (case_tac a)
+   apply (fastforce simp: cap_range_def arch_is_physical_def is_cap_simps
+     is_physical_def split:cap.splits arch_cap.splits)+
+ apply (clarsimp split: arch_cap.splits cap.splits)
+ apply (rename_tac arch_cap arch_capa)
+ apply (case_tac arch_cap)
+  apply (case_tac arch_capa,clarsimp+)+
+ done
+
+
+lemma cap_insert_simple_arch_caps_no_ap:
+  "\<lbrace>valid_arch_caps and (\<lambda>s. cte_wp_at (safe_parent_for (cdt s) src cap) src s)
+             and no_cap_to_obj_with_diff_ref cap {dest} and K (is_simple_cap cap \<and> \<not>is_ap_cap cap)\<rbrace>
+     cap_insert cap src dest
+   \<lbrace>\<lambda>rv. valid_arch_caps\<rbrace>"
+  apply (simp add: cap_insert_def)
+  apply (wp set_cap_valid_arch_caps set_untyped_cap_as_full_valid_arch_caps get_cap_wp
+    | simp split del: if_split)+
+  apply (wp hoare_vcg_all_lift hoare_vcg_conj_lift hoare_vcg_imp_lift hoare_vcg_ball_lift hoare_vcg_disj_lift
+    set_untyped_cap_as_full_cte_wp_at_neg set_untyped_cap_as_full_is_final_cap'_neg
+    set_untyped_cap_as_full_empty_table_at hoare_vcg_ex_lift
+    set_untyped_cap_as_full_caps_of_state_diff[where dest=dest]
+    | wps)+
+      apply (wp get_cap_wp)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (intro conjI impI allI)
+  by (auto simp:is_simple_cap_def[simplified is_simple_cap_arch_def] is_cap_simps)
+
+lemma setup_reply_master_ioports[wp, CSpace_AI_assms]:
+  "\<lbrace>valid_ioports\<rbrace> setup_reply_master c \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
+  by wpsimp
+
+lemma cap_insert_derived_ioports[CSpace_AI_assms]:
+  "\<lbrace>valid_ioports and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
+     cap_insert cap src dest
+   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
+  by wpsimp
+
+end
+
+global_interpretation CSpace_AI?: CSpace_AI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact CSpace_AI_assms)?)
+  qed
+
+
+context Arch begin global_naming RISCV64
+
+lemma is_cap_simps':
+  "is_cnode_cap cap = (\<exists>r bits g. cap = cap.CNodeCap r bits g)"
+  "is_thread_cap cap = (\<exists>r. cap = cap.ThreadCap r)"
+  "is_domain_cap cap = (cap = cap.DomainCap)"
+  "is_untyped_cap cap = (\<exists>dev r bits f. cap = cap.UntypedCap dev r bits f)"
+  "is_ep_cap cap = (\<exists>r b R. cap = cap.EndpointCap r b R)"
+  "is_ntfn_cap cap = (\<exists>r b R. cap = cap.NotificationCap r b R)"
+  "is_zombie cap = (\<exists>r b n. cap = cap.Zombie r b n)"
+  "is_arch_cap cap = (\<exists>a. cap = cap.ArchObjectCap a)"
+  "is_reply_cap cap = (\<exists>x R. cap = cap.ReplyCap x False R)"
+  "is_master_reply_cap cap = (\<exists>x R. cap = cap.ReplyCap x True R)"
+  "is_nondevice_page_cap cap = (\<exists> u v w x. cap = ArchObjectCap (FrameCap u v w False x))"
+  by (cases cap, auto simp: is_zombie_def is_arch_cap_def is_nondevice_page_cap_def
+                            is_reply_cap_def is_master_reply_cap_def is_FrameCap_def
+                     split: cap.splits arch_cap.splits)+
+
+lemma cap_insert_simple_invs:
+  "\<lbrace>invs and valid_cap cap and tcb_cap_valid cap dest and
+    ex_cte_cap_wp_to (appropriate_cte_cap cap) dest and
+    cte_wp_at (\<lambda>c. is_untyped_cap c \<longrightarrow> usable_untyped_range c = {}) src and
+    cte_wp_at (\<lambda>c. c = cap.NullCap) dest and
+    no_cap_to_obj_with_diff_ref cap {dest} and
+    (\<lambda>s. cte_wp_at (safe_parent_for (cdt s) src cap) src s) and
+    K (is_simple_cap cap \<and> \<not>is_ap_cap cap) and (\<lambda>s. \<forall>irq \<in> cap_irqs cap. irq_issued irq s)\<rbrace>
+  cap_insert cap src dest \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (simp add: invs_def valid_state_def valid_pspace_def)
+  apply (rule hoare_pre)
+   apply (wp cap_insert_simple_mdb cap_insert_iflive
+             cap_insert_zombies cap_insert_ifunsafe
+             cap_insert_valid_global_refs cap_insert_idle
+             valid_irq_node_typ cap_insert_simple_arch_caps_no_ap)
+  apply (clarsimp simp: is_simple_cap_def cte_wp_at_caps_of_state)
+  apply (frule safe_parent_cap_range)
+  apply simp
+  apply (rule conjI)
+   prefer 2
+   apply (clarsimp simp: is_cap_simps safe_parent_for_def)
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (drule_tac p="(a,b)" in caps_of_state_valid_cap, fastforce)
+  apply (clarsimp dest!: is_cap_simps' [THEN iffD1])
+  apply (auto simp add: valid_cap_def [where c="cap.Zombie a b x" for a b x]
+              dest: obj_ref_is_tcb obj_ref_is_cap_table split: option.splits)
+  done
+
+lemmas is_derived_def = is_derived_def[simplified is_derived_arch_def]
+
+crunches arch_post_cap_deletion
+  for pred_tcb_at[wp]: "pred_tcb_at proj P t"
+  and valid_objs[wp]: valid_objs
+  and cte_wp_at[wp]: "\<lambda>s. P (cte_wp_at P' p s)"
+  and caps_of_state[wp]: "\<lambda>s. P (caps_of_state s)"
+  and irq_node[wp]: "\<lambda>s. P (interrupt_irq_node s)"
+  and invs_no_pre[wp]: invs
+  and cur_thread[wp]:  "\<lambda>s. P (cur_thread s)"
+  and state_refs_of[wp]: "\<lambda>s. P (state_refs_of s)"
+  and mdb_inv[wp]: "\<lambda>s. P (cdt s)"
+  and valid_list[wp]: valid_list
+
+definition
+  "arch_post_cap_delete_pre \<equiv> \<lambda>_ _. True"
+
+lemma arch_post_cap_deletion_invs:
+  "\<lbrace>invs and (\<lambda>s. arch_post_cap_delete_pre (ArchObjectCap c) (caps_of_state s))\<rbrace> arch_post_cap_deletion c \<lbrace>\<lambda>rv. invs\<rbrace>"
+  by (wpsimp simp: arch_post_cap_delete_pre_def)
+
+lemma set_cap_valid_arch_caps_simple:
+  "\<lbrace>\<lambda>s. valid_arch_caps s
+      \<and> valid_objs s
+      \<and> cte_wp_at (Not o is_arch_cap) ptr s
+      \<and> (obj_refs cap \<noteq> {} \<longrightarrow> s \<turnstile> cap)
+      \<and> \<not> (is_arch_cap cap)\<rbrace>
+     set_cap cap ptr
+   \<lbrace>\<lambda>rv. valid_arch_caps\<rbrace>"
+  apply (wp set_cap_valid_arch_caps)
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (frule(1) caps_of_state_valid_cap)
+  apply (rename_tac cap')
+  apply (subgoal_tac "\<forall>x \<in> {cap, cap'}. \<not> is_pt_cap x")
+   apply simp
+   apply (rule conjI)
+    apply (clarsimp simp: vs_cap_ref_def is_cap_simps)
+   apply (erule impCE)
+    apply (clarsimp simp: no_cap_to_obj_with_diff_ref_def
+                          cte_wp_at_caps_of_state
+                          obj_ref_none_no_asid)
+   apply (rule no_cap_to_obj_with_diff_ref_triv, simp_all)
+   apply (rule ccontr, clarsimp simp: table_cap_ref_def is_cap_simps)
+  apply (auto simp: is_cap_simps)
+  done
+
+lemma set_cap_kernel_window_simple:
+  "\<lbrace>\<lambda>s. cap_refs_in_kernel_window s
+      \<and> cte_wp_at (\<lambda>cap'. cap_range cap' = cap_range cap) ptr s\<rbrace>
+     set_cap cap ptr
+   \<lbrace>\<lambda>rv. cap_refs_in_kernel_window\<rbrace>"
+  apply (wp set_cap_cap_refs_in_kernel_window)
+  apply (clarsimp simp: cte_wp_at_caps_of_state cap_refs_in_kernel_windowD)
+  done
+
+end
+
+context begin interpretation Arch .
+
+requalify_facts
+  set_cap_valid_arch_caps_simple
+  set_cap_kernel_window_simple
+
+end
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpace_AI.thy
@@ -12,7 +12,7 @@ theory ArchCSpace_AI
 imports CSpace_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems CSpace_AI_assms
 
@@ -58,7 +58,8 @@ lemma weak_derived_valid_cap [CSpace_AI_assms]:
                     valid_cap_def cap_aligned_def bits_of_def
                     aobj_ref_cases Let_def cap_asid_def
              split: cap.splits arch_cap.splits option.splits)
-  done
+  sorry (* FIXME AARCH64
+  done *)
 
 lemma copy_obj_refs [CSpace_AI_assms]:
   "copy_of cap cap' \<Longrightarrow> obj_refs cap' = obj_refs cap"
@@ -138,11 +139,12 @@ lemma set_untyped_cap_as_full_valid_arch_caps [CSpace_AI_assms]:
    \<lbrace>\<lambda>ya. valid_arch_caps\<rbrace>"
   supply if_split[split del]
   apply (clarsimp simp: valid_arch_caps_def set_untyped_cap_as_full_def)
+  sorry (* FIXME AARCH64
   apply (wpsimp wp: set_cap_valid_vs_lookup set_cap_valid_table_caps
                 simp_del: fun_upd_apply simp: cte_wp_at_caps_of_state)
   apply (fastforce simp: unique_table_refs_upd_eqD unique_table_caps_upd_eqD
                          is_cap_simps cte_wp_at_caps_of_state)
-  done
+  done *)
 
 lemma set_untyped_cap_as_full[wp, CSpace_AI_assms]:
   "\<lbrace>\<lambda>s. no_cap_to_obj_with_diff_ref a b s \<and> cte_wp_at ((=) src_cap) src s\<rbrace>
@@ -276,6 +278,7 @@ lemma cap_insert_valid_arch_caps [CSpace_AI_assms]:
       apply (erule_tac x=a in allE, erule_tac x=b in allE)
       apply simp+
     apply (clarsimp simp: obj_at_def is_cap_simps valid_arch_caps_def)
+    sorry (* FIXME AARCH64
     apply (frule(1) valid_table_capsD)
       apply (clarsimp simp: cte_wp_at_caps_of_state)
       apply (drule is_derived_is_pt)
@@ -296,7 +299,7 @@ lemma cap_insert_valid_arch_caps [CSpace_AI_assms]:
    apply (drule_tac ptr=src and ptr'="(x,xa)" in unique_table_capsD)
          apply (fastforce simp: cap_asid_def is_cap_simps)+
   apply (auto simp: cte_wp_at_caps_of_state)
-  done
+  done *)
 
 end
 
@@ -304,7 +307,7 @@ end
 global_interpretation cap_insert_crunches?: cap_insert_crunches .
 
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 lemma cap_insert_cap_refs_in_kernel_window[wp, CSpace_AI_assms]:
   "\<lbrace>cap_refs_in_kernel_window
@@ -492,11 +495,12 @@ end
 global_interpretation CSpace_AI?: CSpace_AI
   proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact CSpace_AI_assms)?)
+  case 1 show ?case sorry (* FIXME AARCH64
+by (unfold_locales; (fact CSpace_AI_assms)?) *)
   qed
 
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 lemma is_cap_simps':
   "is_cnode_cap cap = (\<exists>r bits g. cap = cap.CNodeCap r bits g)"

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
@@ -8,7 +8,7 @@ theory ArchDetSchedAux_AI
 imports DetSchedAux_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems DetSchedAux_AI_assms
 
@@ -138,7 +138,7 @@ crunch valid_sched[wp]: init_arch_objects valid_sched (wp: valid_sched_lift)
 end
 
 lemmas tcb_sched_action_valid_idle_etcb
-    = RISCV64.tcb_sched_action_valid_idle_etcb
+    = AARCH64.tcb_sched_action_valid_idle_etcb
 
 global_interpretation DetSchedAux_AI_det_ext?: DetSchedAux_AI_det_ext
   proof goal_cases

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
@@ -1,0 +1,155 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchDetSchedAux_AI
+imports DetSchedAux_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems DetSchedAux_AI_assms
+
+crunches init_arch_objects
+  for exst[wp]: "\<lambda>s. P (exst s)"
+  and ct[wp]: "\<lambda>s. P (cur_thread s)"
+  and valid_etcbs[wp, DetSchedAux_AI_assms]: valid_etcbs
+  (wp: crunch_wps hoare_unless_wp valid_etcbs_lift)
+
+crunch ct[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (cur_thread s)"
+  (wp: crunch_wps dxo_wp_weak preemption_point_inv mapME_x_inv_wp
+   simp: crunch_simps do_machine_op_def detype_def mapM_x_defsym unless_def
+   ignore: freeMemory retype_region_ext)
+crunch ready_queues[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (ready_queues s)"
+  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
+   simp: detype_def detype_ext_def crunch_simps
+          wrap_ext_det_ext_ext_def mapM_x_defsym
+   ignore: freeMemory)
+crunch scheduler_action[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (scheduler_action s)"
+  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
+   simp: detype_def detype_ext_def crunch_simps
+         wrap_ext_det_ext_ext_def mapM_x_defsym
+   ignore: freeMemory)
+crunch cur_domain[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (cur_domain s)"
+  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
+   simp: detype_def detype_ext_def crunch_simps
+         wrap_ext_det_ext_ext_def mapM_x_defsym
+   ignore: freeMemory)
+crunch idle_thread[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (idle_thread s)"
+  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv dxo_wp_weak
+   simp: detype_def detype_ext_def crunch_simps
+         wrap_ext_det_ext_ext_def mapM_x_defsym
+   ignore: freeMemory retype_region_ext)
+
+lemma tcb_sched_action_valid_idle_etcb:
+  "\<lbrace>valid_idle_etcb\<rbrace>
+     tcb_sched_action foo thread
+   \<lbrace>\<lambda>_. valid_idle_etcb\<rbrace>"
+  apply (rule valid_idle_etcb_lift)
+  apply (simp add: tcb_sched_action_def set_tcb_queue_def)
+  apply (wp | simp)+
+  done
+
+crunch ekheap[wp]: do_machine_op "\<lambda>s. P (ekheap s)"
+
+lemma delete_objects_etcb_at[wp, DetSchedAux_AI_assms]:
+  "\<lbrace>\<lambda>s::det_ext state. etcb_at P t s\<rbrace> delete_objects a b \<lbrace>\<lambda>r s. etcb_at P t s\<rbrace>"
+  apply (simp add: delete_objects_def)
+  apply (simp add: detype_def detype_ext_def wrap_ext_det_ext_ext_def etcb_at_def|wp)+
+  done
+
+crunch etcb_at[wp]: reset_untyped_cap "etcb_at P t"
+  (wp: preemption_point_inv' mapME_x_inv_wp crunch_wps
+    simp: unless_def)
+
+crunch valid_etcbs[wp]: reset_untyped_cap "valid_etcbs"
+  (wp: preemption_point_inv' mapME_x_inv_wp crunch_wps
+    simp: unless_def)
+
+lemma invoke_untyped_etcb_at [DetSchedAux_AI_assms]:
+  "\<lbrace>(\<lambda>s :: det_ext state. etcb_at P t s) and valid_etcbs\<rbrace> invoke_untyped ui \<lbrace>\<lambda>r s. st_tcb_at (Not o inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
+  apply (cases ui)
+  apply (simp add: mapM_x_def[symmetric] invoke_untyped_def whenE_def
+           split del: if_split)
+  apply (wp retype_region_etcb_at mapM_x_wp'
+            create_cap_no_pred_tcb_at typ_at_pred_tcb_at_lift
+            hoare_convert_imp[OF create_cap_no_pred_tcb_at]
+            hoare_convert_imp[OF _ init_arch_objects_exst]
+      | simp
+      | (wp (once) hoare_drop_impE_E))+
+  done
+
+
+crunch valid_blocked[wp, DetSchedAux_AI_assms]: init_arch_objects valid_blocked
+  (wp: valid_blocked_lift set_cap_typ_at)
+
+lemma perform_asid_control_etcb_at:"\<lbrace>(\<lambda>s. etcb_at P t s) and valid_etcbs\<rbrace>
+          perform_asid_control_invocation aci
+          \<lbrace>\<lambda>r s. st_tcb_at (Not \<circ> inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
+  apply (simp add: perform_asid_control_invocation_def)
+  apply (rule hoare_pre)
+   apply (wp | wpc | simp)+
+       apply (wp hoare_imp_lift_something typ_at_pred_tcb_at_lift)[1]
+      apply (rule hoare_drop_imps)
+      apply (wp retype_region_etcb_at)+
+  apply simp
+  done
+
+crunch ct[wp]: perform_asid_control_invocation "\<lambda>s. P (cur_thread s)"
+
+crunch idle_thread[wp]: perform_asid_control_invocation "\<lambda>s. P (idle_thread s)"
+
+crunch valid_etcbs[wp]: perform_asid_control_invocation valid_etcbs (wp: static_imp_wp)
+
+crunch valid_blocked[wp]: perform_asid_control_invocation valid_blocked (wp: static_imp_wp)
+
+crunch schedact[wp]: perform_asid_control_invocation "\<lambda>s :: det_ext state. P (scheduler_action s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
+
+crunch rqueues[wp]: perform_asid_control_invocation "\<lambda>s :: det_ext state. P (ready_queues s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
+
+crunch cur_domain[wp]: perform_asid_control_invocation "\<lambda>s :: det_ext state. P (cur_domain s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
+
+lemma perform_asid_control_invocation_valid_sched:
+  "\<lbrace>ct_active and invs and valid_aci aci and valid_sched and valid_idle\<rbrace>
+     perform_asid_control_invocation aci
+   \<lbrace>\<lambda>_. valid_sched\<rbrace>"
+  apply (rule hoare_pre)
+   apply (rule_tac I="invs and ct_active and valid_aci aci" in valid_sched_tcb_state_preservation)
+          apply (wp perform_asid_control_invocation_st_tcb_at)
+          apply simp
+         apply (wp perform_asid_control_etcb_at)+
+    apply (rule hoare_strengthen_post, rule aci_invs)
+    apply (simp add: invs_def valid_state_def)
+   apply (rule hoare_lift_Pf[where f="\<lambda>s. scheduler_action s"])
+    apply (rule hoare_lift_Pf[where f="\<lambda>s. cur_domain s"])
+     apply (rule hoare_lift_Pf[where f="\<lambda>s. idle_thread s"])
+      apply wp+
+  apply simp
+  done
+
+crunch valid_queues[wp]: init_arch_objects valid_queues (wp: valid_queues_lift)
+
+crunch valid_sched_action[wp]: init_arch_objects valid_sched_action (wp: valid_sched_action_lift)
+
+crunch valid_sched[wp]: init_arch_objects valid_sched (wp: valid_sched_lift)
+
+end
+
+lemmas tcb_sched_action_valid_idle_etcb
+    = RISCV64.tcb_sched_action_valid_idle_etcb
+
+global_interpretation DetSchedAux_AI_det_ext?: DetSchedAux_AI_det_ext
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact DetSchedAux_AI_assms)?)
+  qed
+
+global_interpretation DetSchedAux_AI?: DetSchedAux_AI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact DetSchedAux_AI_assms)?)
+  qed
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -134,6 +135,10 @@ crunch valid_queues[wp]: init_arch_objects valid_queues (wp: valid_queues_lift)
 crunch valid_sched_action[wp]: init_arch_objects valid_sched_action (wp: valid_sched_action_lift)
 
 crunch valid_sched[wp]: init_arch_objects valid_sched (wp: valid_sched_lift)
+
+(* FIXME AARCH64 issue with crunch ordering, ArchVCPU_AI gets there first rather than some crunch
+   that does this declaration *)
+declare invoke_untyped_cur_thread[DetSchedAux_AI_assms]
 
 end
 

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
@@ -1,0 +1,109 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchDetSchedDomainTime_AI
+imports DetSchedDomainTime_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems DetSchedDomainTime_AI_assms
+
+crunch domain_list_inv [wp, DetSchedDomainTime_AI_assms]: arch_finalise_cap "\<lambda>s. P (domain_list s)"
+  (wp: hoare_drop_imps mapM_wp subset_refl simp: crunch_simps)
+
+crunch domain_list_inv [wp, DetSchedDomainTime_AI_assms]:
+  arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread,
+  handle_arch_fault_reply,
+  arch_invoke_irq_control, arch_get_sanitise_register_info,
+  prepare_thread_delete, handle_hypervisor_fault, make_arch_fault_msg,
+  arch_post_modify_registers, arch_post_cap_deletion, handle_vm_fault,
+  arch_invoke_irq_handler
+  "\<lambda>s. P (domain_list s)"
+  (simp: crunch_simps)
+
+crunch domain_time_inv [wp, DetSchedDomainTime_AI_assms]: arch_finalise_cap "\<lambda>s. P (domain_time s)"
+  (wp: hoare_drop_imps mapM_wp subset_refl simp: crunch_simps)
+
+crunch domain_time_inv [wp, DetSchedDomainTime_AI_assms]:
+  arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread,
+  handle_arch_fault_reply, init_arch_objects,
+  arch_invoke_irq_control, arch_get_sanitise_register_info,
+  prepare_thread_delete, handle_hypervisor_fault, handle_vm_fault,
+  arch_post_modify_registers, arch_post_cap_deletion, make_arch_fault_msg,
+  arch_invoke_irq_handler
+  "\<lambda>s. P (domain_time s)"
+  (simp: crunch_simps)
+
+crunches do_machine_op
+  for exst[wp]: "\<lambda>s. P (exst s)"
+
+declare init_arch_objects_exst[DetSchedDomainTime_AI_assms]
+
+end
+
+global_interpretation DetSchedDomainTime_AI?: DetSchedDomainTime_AI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact DetSchedDomainTime_AI_assms)?)
+  qed
+
+context Arch begin global_naming RISCV64
+
+crunch domain_time_inv [wp, DetSchedDomainTime_AI_assms]: arch_perform_invocation "\<lambda>s. P (domain_time s)"
+  (wp: crunch_wps check_cap_inv)
+
+crunch domain_list_inv [wp, DetSchedDomainTime_AI_assms]: arch_perform_invocation "\<lambda>s. P (domain_list s)"
+  (wp: crunch_wps check_cap_inv)
+
+lemma timer_tick_valid_domain_time:
+  "\<lbrace> \<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>
+   timer_tick
+   \<lbrace>\<lambda>x s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>" (is "\<lbrace> ?dtnot0 \<rbrace> _ \<lbrace> _ \<rbrace>")
+  unfolding timer_tick_def
+  supply if_split[split del]
+  supply ethread_get_wp[wp del]
+  supply if_apply_def2[simp]
+  apply (wpsimp
+           wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
+               (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
+                  postcondition once we hit thread_set_time_slice *)
+               hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+                                and a="thread_set_time_slice t ts" for X t ts]
+               hoare_drop_imp[where f="ethread_get t f" for t f])
+  apply fastforce
+  done
+
+lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
+  "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>
+   handle_interrupt i
+   \<lbrace>\<lambda>rv s.  domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread \<rbrace>" (is "\<lbrace> ?dtnot0 \<rbrace> _ \<lbrace> _ \<rbrace>")
+  unfolding handle_interrupt_def
+  apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
+  apply clarsimp
+  apply (wpsimp simp: arch_mask_irq_signal_def)
+        apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply wpsimp
+       apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+      apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
+     apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+   apply wpsimp+
+  done
+
+crunches handle_reserved_irq, arch_mask_irq_signal
+  for domain_time_inv [wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"
+  and domain_list_inv [wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_list s)"
+  (wp: crunch_wps mapM_wp subset_refl simp: crunch_simps)
+
+end
+
+global_interpretation DetSchedDomainTime_AI_2?: DetSchedDomainTime_AI_2
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact DetSchedDomainTime_AI_assms)?)
+  qed
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
@@ -84,6 +84,32 @@ crunch domain_time_inv [wp, DetSchedDomainTime_AI_assms]: arch_perform_invocatio
 crunch domain_list_inv [wp, DetSchedDomainTime_AI_assms]: arch_perform_invocation "\<lambda>s. P (domain_list s)"
   (wp: crunch_wps check_cap_inv simp: if_apply_def2)
 
+lemma vgic_maintenance_valid_domain_time:
+  "\<lbrace>\<lambda>s. 0 < domain_time s\<rbrace>
+    vgic_maintenance \<lbrace>\<lambda>y s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
+  unfolding vgic_maintenance_def
+  apply (rule hoare_strengthen_post [where Q="\<lambda>_ s. 0 < domain_time s"])
+   apply (wpsimp wp: handle_fault_domain_time_inv hoare_drop_imps)
+  apply clarsimp
+  done
+
+lemma vppi_event_valid_domain_time:
+  "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s\<rbrace>
+    vppi_event irq \<lbrace>\<lambda>y s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
+  unfolding vppi_event_def
+  apply (rule hoare_strengthen_post [where Q="\<lambda>_ s. 0 < domain_time s"])
+   apply (wpsimp wp: handle_fault_domain_time_inv hoare_drop_imps)
+  apply clarsimp
+  done
+
+lemma handle_reserved_irq_valid_domain_time:
+  "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s\<rbrace>
+     handle_reserved_irq i \<lbrace>\<lambda>y s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
+  unfolding handle_reserved_irq_def when_def
+  supply if_split[split del]
+  by (wpsimp wp: vppi_event_valid_domain_time vgic_maintenance_valid_domain_time
+                 hoare_drop_imp[where R="\<lambda>_ _. irq_vppi_event_index _ = _"])
+
 lemma timer_tick_valid_domain_time:
   "\<lbrace> \<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>
    timer_tick

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -8,10 +9,11 @@ theory ArchDetSchedSchedule_AI
 imports DetSchedSchedule_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems DetSchedSchedule_AI_assms
 
+(* FIXME AARCH64 VCPU
 crunch  prepare_thread_delete_idle_thread[wp, DetSchedSchedule_AI_assms]:
   prepare_thread_delete "\<lambda>(s:: det_ext state). P (idle_thread s)"
 
@@ -26,6 +28,7 @@ crunch valid_queues [wp, DetSchedSchedule_AI_assms]:
 crunch weak_valid_sched_action [wp, DetSchedSchedule_AI_assms]:
   switch_to_idle_thread, switch_to_thread, set_vm_root, arch_get_sanitise_register_info, arch_post_modify_registers "weak_valid_sched_action"
   (simp: crunch_simps)
+*)
 
 crunch ct_not_in_q[wp]: set_vm_root "ct_not_in_q"
   (wp: crunch_wps simp: crunch_simps)
@@ -39,13 +42,15 @@ lemma switch_to_idle_thread_ct_not_in_q [wp, DetSchedSchedule_AI_assms]:
   apply wp
    apply (simp add: arch_switch_to_idle_thread_def)
    apply wp+
+  sorry (* FIXME AARCH64 VCPU
   apply (fastforce simp: valid_queues_def ct_not_in_q_def not_queued_def
                          valid_idle_def pred_tcb_at_def obj_at_def)
-  done
+  done *)
 
+(* FIXME AARCH64 VCPU
 crunch valid_sched_action'[wp]: set_vm_root "\<lambda>s. valid_sched_action_2 (scheduler_action s)
                                                  (ekheap s) (kheap s) thread (cur_domain s)"
-  (wp: crunch_wps simp: crunch_simps)
+  (wp: crunch_wps simp: crunch_simps) *)
 
 lemma switch_to_idle_thread_valid_sched_action [wp, DetSchedSchedule_AI_assms]:
   "\<lbrace>valid_sched_action and valid_idle\<rbrace>
@@ -57,7 +62,8 @@ lemma switch_to_idle_thread_valid_sched_action [wp, DetSchedSchedule_AI_assms]:
    apply wp+
   apply (clarsimp simp: valid_sched_action_def valid_idle_def is_activatable_def
                         pred_tcb_at_def obj_at_def)
-  done
+  sorry (* FIXME AARCH64 global vspace
+  done *)
 
 crunch ct_in_cur_domain'[wp]: set_vm_root "\<lambda>s. ct_in_cur_domain_2 t (idle_thread s)
                                                    (scheduler_action s) (cur_domain s) (ekheap s)"
@@ -65,14 +71,16 @@ crunch ct_in_cur_domain'[wp]: set_vm_root "\<lambda>s. ct_in_cur_domain_2 t (idl
 
 lemma switch_to_idle_thread_ct_in_cur_domain [wp, DetSchedSchedule_AI_assms]:
   "\<lbrace>\<top>\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>_. ct_in_cur_domain\<rbrace>"
+  sorry (* FIXME AARCH64 VCPU
   by (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def do_machine_op_def
                 split_def
       | wp
-      | simp add: ct_in_cur_domain_def)+
+      | simp add: ct_in_cur_domain_def)+ *)
 
 crunch ct_not_in_q [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers ct_not_in_q
   (simp: crunch_simps wp: crunch_wps)
 
+(* FIXME AARCH64 VCPU
 crunch is_activatable [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers "is_activatable t"
   (simp: crunch_simps)
 
@@ -81,10 +89,11 @@ crunch valid_sched_action [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread
 
 crunch valid_sched [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers valid_sched
   (simp: crunch_simps)
-
+*)
 crunch exst[wp]: set_vm_root "\<lambda>s. P (exst s)"
   (wp: crunch_wps hoare_whenE_wp simp: crunch_simps)
 
+(* FIXME AARCH64
 crunch ct_in_cur_domain_2 [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread
   "\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (ekheap s)"
   (simp: crunch_simps wp: assert_inv)
@@ -96,20 +105,24 @@ crunch ct_in_q[wp]: set_vm_root ct_in_q
   (simp: crunch_simps)
 
 crunch etcb_at [wp, DetSchedSchedule_AI_assms]: switch_to_thread "etcb_at P t"
+*)
 
 crunch valid_idle [wp, DetSchedSchedule_AI_assms]:
   arch_switch_to_idle_thread "valid_idle"
   (wp: crunch_wps simp: crunch_simps)
 
+(* FIXME AARCH64 VCPU
 crunch etcb_at [wp, DetSchedSchedule_AI_assms]: arch_switch_to_idle_thread "etcb_at P t"
 
 crunch scheduler_action [wp, DetSchedSchedule_AI_assms]:
   arch_switch_to_idle_thread, next_domain "\<lambda>s. P (scheduler_action s)"
   (simp: Let_def)
+*)
 
 lemma set_vm_root_valid_blocked_ct_in_q [wp]:
   "\<lbrace>valid_blocked and ct_in_q\<rbrace> set_vm_root p \<lbrace>\<lambda>_. valid_blocked and ct_in_q\<rbrace>"
-  by (wp | wpc | auto)+
+  sorry (* FIXME AARCH64 vm root
+  by (wp | wpc | auto)+ *)
 
 
 lemma as_user_ct_in_q[wp]:
@@ -120,7 +133,8 @@ lemma as_user_ct_in_q[wp]:
 
 lemma arch_switch_to_thread_valid_blocked [wp, DetSchedSchedule_AI_assms]:
   "\<lbrace>valid_blocked and ct_in_q\<rbrace> arch_switch_to_thread thread \<lbrace>\<lambda>_. valid_blocked and ct_in_q\<rbrace>"
-  by (wpsimp simp: arch_switch_to_thread_def)
+  sorry (* FIXME AARCH64
+  by (wpsimp simp: arch_switch_to_thread_def) *)
 
 lemma switch_to_idle_thread_ct_not_queued [wp, DetSchedSchedule_AI_assms]:
   "\<lbrace>valid_queues and valid_etcbs and valid_idle\<rbrace>
@@ -128,31 +142,37 @@ lemma switch_to_idle_thread_ct_not_queued [wp, DetSchedSchedule_AI_assms]:
    \<lbrace>\<lambda>rv s. not_queued (cur_thread s) s\<rbrace>"
   apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def
                    tcb_sched_action_def | wp)+
+  sorry (* FIXME AARCH64 VCPU
   apply (fastforce simp: valid_sched_2_def valid_queues_2_def valid_idle_def
                          pred_tcb_at_def obj_at_def not_queued_def)
-  done
+  done *)
 
+(* FIXME AARCH64
 crunch valid_blocked_2[wp]: set_vm_root "\<lambda>s.
            valid_blocked_2 (ready_queues s) (kheap s)
             (scheduler_action s) thread"
-  (wp: crunch_wps simp: crunch_simps)
+  (wp: crunch_wps simp: crunch_simps) *)
 
 lemma switch_to_idle_thread_valid_blocked [wp, DetSchedSchedule_AI_assms]:
   "\<lbrace>valid_blocked and ct_in_q\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv. valid_blocked\<rbrace>"
   apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def do_machine_op_def | wp | wpc)+
+  sorry (* FIXME AARCH64 global vspace
   apply clarsimp
   apply (drule(1) ct_in_q_valid_blocked_ct_upd)
   apply simp
-  done
+  done *)
 
+(* FIXME AARCH64 VCPU
 crunch exst [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread "\<lambda>s. P (exst s :: det_ext)"
 
 crunch cur_thread[wp]: arch_switch_to_idle_thread "\<lambda>s. P (cur_thread s)"
+*)
 
 lemma astit_st_tcb_at[wp]:
   "\<lbrace>st_tcb_at P t\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>rv. st_tcb_at P t\<rbrace>"
   apply (simp add: arch_switch_to_idle_thread_def)
-  by (wpsimp)
+  sorry (* FIXME AARCH64 VCPU
+  by (wpsimp) *)
 
 lemma stit_activatable' [DetSchedSchedule_AI_assms]:
   "\<lbrace>valid_idle\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv . ct_in_state activatable\<rbrace>"
@@ -163,7 +183,8 @@ lemma stit_activatable' [DetSchedSchedule_AI_assms]:
 
 lemma switch_to_idle_thread_cur_thread_idle_thread [wp, DetSchedSchedule_AI_assms]:
   "\<lbrace>\<top>\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>_ s. cur_thread s = idle_thread s\<rbrace>"
-  by (wp | simp add:switch_to_idle_thread_def arch_switch_to_idle_thread_def)+
+  sorry (* FIXME AARCH64 VCPU
+  by (wp | simp add:switch_to_idle_thread_def arch_switch_to_idle_thread_def)+ *)
 
 lemma set_pt_valid_etcbs[wp]:
   "\<lbrace>valid_etcbs\<rbrace> set_pt ptr pt \<lbrace>\<lambda>rv. valid_etcbs\<rbrace>"
@@ -186,20 +207,22 @@ crunch ct_not_in_q [wp, DetSchedSchedule_AI_assms]:
   (wp: crunch_wps hoare_drop_imps hoare_unless_wp select_inv mapM_wp
        subset_refl if_fun_split simp: crunch_simps ignore: tcb_sched_action)
 
+(* FIXME AARCH64 VCPU
 crunch valid_etcbs [wp, DetSchedSchedule_AI_assms]:
   arch_finalise_cap, prepare_thread_delete valid_etcbs
   (wp: hoare_drop_imps hoare_unless_wp select_inv mapM_x_wp mapM_wp subset_refl
-       if_fun_split simp: crunch_simps ignore: set_object thread_set)
+       if_fun_split simp: crunch_simps ignore: set_object thread_set) *)
 
 crunch simple_sched_action [wp, DetSchedSchedule_AI_assms]:
   arch_finalise_cap, prepare_thread_delete simple_sched_action
   (wp: hoare_drop_imps mapM_x_wp mapM_wp select_wp subset_refl
    simp: unless_def if_fun_split)
 
+(* FIXME AARCH64 VCPU
 crunch valid_sched [wp, DetSchedSchedule_AI_assms]:
   arch_finalise_cap, prepare_thread_delete, arch_invoke_irq_handler, arch_mask_irq_signal
   "valid_sched"
-  (ignore: set_object wp: crunch_wps subset_refl simp: if_fun_split)
+  (ignore: set_object wp: crunch_wps subset_refl simp: if_fun_split) *)
 
 lemma activate_thread_valid_sched [DetSchedSchedule_AI_assms]:
   "\<lbrace>valid_sched\<rbrace> activate_thread \<lbrace>\<lambda>_. valid_sched\<rbrace>"
@@ -208,10 +231,11 @@ lemma activate_thread_valid_sched [DetSchedSchedule_AI_assms]:
   apply (force elim: st_tcb_weakenE)
   done
 
+(* FIXME AARCH64 unmap_page
 crunch valid_sched[wp]:
   perform_page_invocation, perform_page_table_invocation, perform_asid_pool_invocation
   valid_sched
-  (wp: mapM_x_wp' mapM_wp' crunch_wps)
+  (wp: mapM_x_wp' mapM_wp' crunch_wps) *)
 
 lemma arch_perform_invocation_valid_sched [wp, DetSchedSchedule_AI_assms]:
   "\<lbrace>invs and valid_sched and ct_active and valid_arch_inv a\<rbrace>
@@ -220,7 +244,8 @@ lemma arch_perform_invocation_valid_sched [wp, DetSchedSchedule_AI_assms]:
   apply (cases a, simp_all add: arch_perform_invocation_def)
      apply (wp perform_asid_control_invocation_valid_sched | wpc |
             simp add: valid_arch_inv_def invs_valid_idle)+
-  done
+  sorry (* FIXME AARCH64 perform_vspace_invocation
+  done *)
 
 crunch valid_sched [wp, DetSchedSchedule_AI_assms]:
   handle_arch_fault_reply, handle_vm_fault valid_sched
@@ -247,8 +272,9 @@ lemma handle_vm_fault_st_tcb_cur_thread [wp, DetSchedSchedule_AI_assms]:
 
 crunch valid_sched [wp, DetSchedSchedule_AI_assms]: arch_invoke_irq_control "valid_sched"
 
+(* FIXME AARCH64 VCPU
 crunch valid_list [wp, DetSchedSchedule_AI_assms]:
-  arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread "valid_list"
+  arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread "valid_list" *)
 
 crunch cur_tcb [wp, DetSchedSchedule_AI_assms]:
   handle_arch_fault_reply, handle_vm_fault, arch_get_sanitise_register_info, arch_post_modify_registers
@@ -261,7 +287,8 @@ crunch scheduler_action [wp, DetSchedSchedule_AI_assms]: arch_get_sanitise_regis
 
 lemma make_arch_fault_msg_inv:
   "make_arch_fault_msg f t \<lbrace>P\<rbrace>"
-  by (cases f) wpsimp
+  sorry (* FIXME AARCH64 VCPU
+  by (cases f) wpsimp *)
 
 declare make_arch_fault_msg_inv[DetSchedSchedule_AI_assms]
 
@@ -293,10 +320,10 @@ end
 global_interpretation DetSchedSchedule_AI?: DetSchedSchedule_AI
   proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact DetSchedSchedule_AI_assms)?)
+  case 1 show ?case sorry (*FIXME AARCH64 by (unfold_locales; (fact DetSchedSchedule_AI_assms)?) *)
   qed
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 lemma handle_hyp_fault_valid_sched[wp]:
   "\<lbrace>valid_sched and invs and st_tcb_at active t and not_queued t and scheduler_act_not t
@@ -307,7 +334,8 @@ lemma handle_hyp_fault_valid_sched[wp]:
 lemma handle_reserved_irq_valid_sched:
   "\<lbrace>valid_sched and invs and (\<lambda>s. irq \<in> non_kernel_IRQs \<longrightarrow>  scheduler_act_sane s \<and> ct_not_queued s)\<rbrace>
   handle_reserved_irq irq \<lbrace>\<lambda>rv. valid_sched\<rbrace>"
-  unfolding handle_reserved_irq_def by (wpsimp simp: non_kernel_IRQs_def)
+  sorry (* FIXME AARCH64 VCPU vppi
+  unfolding handle_reserved_irq_def by (wpsimp simp: non_kernel_IRQs_def) *)
 
 end
 

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
@@ -261,14 +261,14 @@ crunch sched_act_not [wp, DetSchedSchedule_AI_assms]:
 
 lemma hvmf_st_tcb_at [wp, DetSchedSchedule_AI_assms]:
   "\<lbrace>st_tcb_at P t' \<rbrace> handle_vm_fault t w \<lbrace>\<lambda>rv. st_tcb_at P t' \<rbrace>"
-  unfolding handle_vm_fault_def by (cases w; wpsimp)
+  unfolding handle_vm_fault_def sorry (* FIXME AARCH64 by (cases w; wpsimp) *)
 
 lemma handle_vm_fault_st_tcb_cur_thread [wp, DetSchedSchedule_AI_assms]:
   "\<lbrace> \<lambda>s. st_tcb_at P (cur_thread s) s \<rbrace> handle_vm_fault t f \<lbrace>\<lambda>_ s. st_tcb_at P (cur_thread s) s \<rbrace>"
   unfolding handle_vm_fault_def
   apply (fold ct_in_state_def)
   apply (rule ct_in_state_thread_state_lift; cases f; wpsimp)
-  done
+  sorry (* FIXME AARCH64 *)
 
 crunch valid_sched [wp, DetSchedSchedule_AI_assms]: arch_invoke_irq_control "valid_sched"
 
@@ -279,7 +279,7 @@ crunch valid_list [wp, DetSchedSchedule_AI_assms]:
 crunch cur_tcb [wp, DetSchedSchedule_AI_assms]:
   handle_arch_fault_reply, handle_vm_fault, arch_get_sanitise_register_info, arch_post_modify_registers
   cur_tcb
-  (simp: crunch_simps)
+  (simp: crunch_simps dmo_inv)
 
 crunch not_cur_thread [wp, DetSchedSchedule_AI_assms]: arch_get_sanitise_register_info, arch_post_modify_registers "not_cur_thread t'"
 crunch ready_queues   [wp, DetSchedSchedule_AI_assms]: arch_get_sanitise_register_info, arch_post_modify_registers "\<lambda>s. P (ready_queues s)"

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
@@ -1,0 +1,320 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchDetSchedSchedule_AI
+imports DetSchedSchedule_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems DetSchedSchedule_AI_assms
+
+crunch  prepare_thread_delete_idle_thread[wp, DetSchedSchedule_AI_assms]:
+  prepare_thread_delete "\<lambda>(s:: det_ext state). P (idle_thread s)"
+
+crunch valid_etcbs [wp, DetSchedSchedule_AI_assms]:
+  arch_switch_to_idle_thread, arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers valid_etcbs
+  (simp: crunch_simps)
+
+crunch valid_queues [wp, DetSchedSchedule_AI_assms]:
+  switch_to_idle_thread, switch_to_thread, set_vm_root, arch_get_sanitise_register_info, arch_post_modify_registers valid_queues
+  (simp: crunch_simps ignore: set_tcb_queue tcb_sched_action)
+
+crunch weak_valid_sched_action [wp, DetSchedSchedule_AI_assms]:
+  switch_to_idle_thread, switch_to_thread, set_vm_root, arch_get_sanitise_register_info, arch_post_modify_registers "weak_valid_sched_action"
+  (simp: crunch_simps)
+
+crunch ct_not_in_q[wp]: set_vm_root "ct_not_in_q"
+  (wp: crunch_wps simp: crunch_simps)
+
+crunch ct_not_in_q'[wp]: set_vm_root "\<lambda>s. ct_not_in_q_2 (ready_queues s) (scheduler_action s) t"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma switch_to_idle_thread_ct_not_in_q [wp, DetSchedSchedule_AI_assms]:
+  "\<lbrace>valid_queues and valid_idle\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>_. ct_not_in_q\<rbrace>"
+  apply (simp add: switch_to_idle_thread_def)
+  apply wp
+   apply (simp add: arch_switch_to_idle_thread_def)
+   apply wp+
+  apply (fastforce simp: valid_queues_def ct_not_in_q_def not_queued_def
+                         valid_idle_def pred_tcb_at_def obj_at_def)
+  done
+
+crunch valid_sched_action'[wp]: set_vm_root "\<lambda>s. valid_sched_action_2 (scheduler_action s)
+                                                 (ekheap s) (kheap s) thread (cur_domain s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma switch_to_idle_thread_valid_sched_action [wp, DetSchedSchedule_AI_assms]:
+  "\<lbrace>valid_sched_action and valid_idle\<rbrace>
+     switch_to_idle_thread
+   \<lbrace>\<lambda>_. valid_sched_action\<rbrace>"
+  apply (simp add: switch_to_idle_thread_def)
+  apply wp
+   apply (simp add: arch_switch_to_idle_thread_def do_machine_op_def split_def)
+   apply wp+
+  apply (clarsimp simp: valid_sched_action_def valid_idle_def is_activatable_def
+                        pred_tcb_at_def obj_at_def)
+  done
+
+crunch ct_in_cur_domain'[wp]: set_vm_root "\<lambda>s. ct_in_cur_domain_2 t (idle_thread s)
+                                                   (scheduler_action s) (cur_domain s) (ekheap s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma switch_to_idle_thread_ct_in_cur_domain [wp, DetSchedSchedule_AI_assms]:
+  "\<lbrace>\<top>\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>_. ct_in_cur_domain\<rbrace>"
+  by (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def do_machine_op_def
+                split_def
+      | wp
+      | simp add: ct_in_cur_domain_def)+
+
+crunch ct_not_in_q [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers ct_not_in_q
+  (simp: crunch_simps wp: crunch_wps)
+
+crunch is_activatable [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers "is_activatable t"
+  (simp: crunch_simps)
+
+crunch valid_sched_action [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers valid_sched_action
+  (simp: crunch_simps)
+
+crunch valid_sched [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers valid_sched
+  (simp: crunch_simps)
+
+crunch exst[wp]: set_vm_root "\<lambda>s. P (exst s)"
+  (wp: crunch_wps hoare_whenE_wp simp: crunch_simps)
+
+crunch ct_in_cur_domain_2 [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread
+  "\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (ekheap s)"
+  (simp: crunch_simps wp: assert_inv)
+
+crunch valid_blocked[wp]: set_vm_root valid_blocked
+  (simp: crunch_simps)
+
+crunch ct_in_q[wp]: set_vm_root ct_in_q
+  (simp: crunch_simps)
+
+crunch etcb_at [wp, DetSchedSchedule_AI_assms]: switch_to_thread "etcb_at P t"
+
+crunch valid_idle [wp, DetSchedSchedule_AI_assms]:
+  arch_switch_to_idle_thread "valid_idle"
+  (wp: crunch_wps simp: crunch_simps)
+
+crunch etcb_at [wp, DetSchedSchedule_AI_assms]: arch_switch_to_idle_thread "etcb_at P t"
+
+crunch scheduler_action [wp, DetSchedSchedule_AI_assms]:
+  arch_switch_to_idle_thread, next_domain "\<lambda>s. P (scheduler_action s)"
+  (simp: Let_def)
+
+lemma set_vm_root_valid_blocked_ct_in_q [wp]:
+  "\<lbrace>valid_blocked and ct_in_q\<rbrace> set_vm_root p \<lbrace>\<lambda>_. valid_blocked and ct_in_q\<rbrace>"
+  by (wp | wpc | auto)+
+
+
+lemma as_user_ct_in_q[wp]:
+  "as_user tp S \<lbrace>ct_in_q\<rbrace>"
+  apply (wpsimp simp: as_user_def set_object_def get_object_def)
+  apply (clarsimp simp: ct_in_q_def st_tcb_at_def obj_at_def dest!: get_tcb_SomeD)
+  done
+
+lemma arch_switch_to_thread_valid_blocked [wp, DetSchedSchedule_AI_assms]:
+  "\<lbrace>valid_blocked and ct_in_q\<rbrace> arch_switch_to_thread thread \<lbrace>\<lambda>_. valid_blocked and ct_in_q\<rbrace>"
+  by (wpsimp simp: arch_switch_to_thread_def)
+
+lemma switch_to_idle_thread_ct_not_queued [wp, DetSchedSchedule_AI_assms]:
+  "\<lbrace>valid_queues and valid_etcbs and valid_idle\<rbrace>
+     switch_to_idle_thread
+   \<lbrace>\<lambda>rv s. not_queued (cur_thread s) s\<rbrace>"
+  apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def
+                   tcb_sched_action_def | wp)+
+  apply (fastforce simp: valid_sched_2_def valid_queues_2_def valid_idle_def
+                         pred_tcb_at_def obj_at_def not_queued_def)
+  done
+
+crunch valid_blocked_2[wp]: set_vm_root "\<lambda>s.
+           valid_blocked_2 (ready_queues s) (kheap s)
+            (scheduler_action s) thread"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma switch_to_idle_thread_valid_blocked [wp, DetSchedSchedule_AI_assms]:
+  "\<lbrace>valid_blocked and ct_in_q\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv. valid_blocked\<rbrace>"
+  apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def do_machine_op_def | wp | wpc)+
+  apply clarsimp
+  apply (drule(1) ct_in_q_valid_blocked_ct_upd)
+  apply simp
+  done
+
+crunch exst [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread "\<lambda>s. P (exst s :: det_ext)"
+
+crunch cur_thread[wp]: arch_switch_to_idle_thread "\<lambda>s. P (cur_thread s)"
+
+lemma astit_st_tcb_at[wp]:
+  "\<lbrace>st_tcb_at P t\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>rv. st_tcb_at P t\<rbrace>"
+  apply (simp add: arch_switch_to_idle_thread_def)
+  by (wpsimp)
+
+lemma stit_activatable' [DetSchedSchedule_AI_assms]:
+  "\<lbrace>valid_idle\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv . ct_in_state activatable\<rbrace>"
+  apply (simp add: switch_to_idle_thread_def ct_in_state_def do_machine_op_def split_def)
+  apply wpsimp
+  apply (clarsimp simp: valid_idle_def ct_in_state_def pred_tcb_at_def obj_at_def)
+  done
+
+lemma switch_to_idle_thread_cur_thread_idle_thread [wp, DetSchedSchedule_AI_assms]:
+  "\<lbrace>\<top>\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>_ s. cur_thread s = idle_thread s\<rbrace>"
+  by (wp | simp add:switch_to_idle_thread_def arch_switch_to_idle_thread_def)+
+
+lemma set_pt_valid_etcbs[wp]:
+  "\<lbrace>valid_etcbs\<rbrace> set_pt ptr pt \<lbrace>\<lambda>rv. valid_etcbs\<rbrace>"
+  by (wp hoare_drop_imps valid_etcbs_lift | simp add: set_pt_def)+
+
+lemma set_asid_pool_valid_etcbs[wp]:
+  "\<lbrace>valid_etcbs\<rbrace> set_asid_pool ptr pool \<lbrace>\<lambda>rv. valid_etcbs\<rbrace>"
+  by (wp hoare_drop_imps valid_etcbs_lift | simp add: set_asid_pool_def)+
+
+lemma set_pt_valid_sched[wp]:
+  "\<lbrace>valid_sched\<rbrace> set_pt ptr pt \<lbrace>\<lambda>rv. valid_sched\<rbrace>"
+  by (wp hoare_drop_imps valid_sched_lift | simp add: set_pt_def)+
+
+lemma set_asid_pool_valid_sched[wp]:
+  "\<lbrace>valid_sched\<rbrace> set_asid_pool ptr pool \<lbrace>\<lambda>rv. valid_sched\<rbrace>"
+  by (wp hoare_drop_imps valid_sched_lift | simp add: set_asid_pool_def)+
+
+crunch ct_not_in_q [wp, DetSchedSchedule_AI_assms]:
+  arch_finalise_cap, prepare_thread_delete ct_not_in_q
+  (wp: crunch_wps hoare_drop_imps hoare_unless_wp select_inv mapM_wp
+       subset_refl if_fun_split simp: crunch_simps ignore: tcb_sched_action)
+
+crunch valid_etcbs [wp, DetSchedSchedule_AI_assms]:
+  arch_finalise_cap, prepare_thread_delete valid_etcbs
+  (wp: hoare_drop_imps hoare_unless_wp select_inv mapM_x_wp mapM_wp subset_refl
+       if_fun_split simp: crunch_simps ignore: set_object thread_set)
+
+crunch simple_sched_action [wp, DetSchedSchedule_AI_assms]:
+  arch_finalise_cap, prepare_thread_delete simple_sched_action
+  (wp: hoare_drop_imps mapM_x_wp mapM_wp select_wp subset_refl
+   simp: unless_def if_fun_split)
+
+crunch valid_sched [wp, DetSchedSchedule_AI_assms]:
+  arch_finalise_cap, prepare_thread_delete, arch_invoke_irq_handler, arch_mask_irq_signal
+  "valid_sched"
+  (ignore: set_object wp: crunch_wps subset_refl simp: if_fun_split)
+
+lemma activate_thread_valid_sched [DetSchedSchedule_AI_assms]:
+  "\<lbrace>valid_sched\<rbrace> activate_thread \<lbrace>\<lambda>_. valid_sched\<rbrace>"
+  apply (simp add: activate_thread_def)
+  apply (wp set_thread_state_runnable_valid_sched gts_wp | wpc | simp add: arch_activate_idle_thread_def)+
+  apply (force elim: st_tcb_weakenE)
+  done
+
+crunch valid_sched[wp]:
+  perform_page_invocation, perform_page_table_invocation, perform_asid_pool_invocation
+  valid_sched
+  (wp: mapM_x_wp' mapM_wp' crunch_wps)
+
+lemma arch_perform_invocation_valid_sched [wp, DetSchedSchedule_AI_assms]:
+  "\<lbrace>invs and valid_sched and ct_active and valid_arch_inv a\<rbrace>
+     arch_perform_invocation a
+   \<lbrace>\<lambda>_.valid_sched\<rbrace>"
+  apply (cases a, simp_all add: arch_perform_invocation_def)
+     apply (wp perform_asid_control_invocation_valid_sched | wpc |
+            simp add: valid_arch_inv_def invs_valid_idle)+
+  done
+
+crunch valid_sched [wp, DetSchedSchedule_AI_assms]:
+  handle_arch_fault_reply, handle_vm_fault valid_sched
+  (simp: crunch_simps)
+
+crunch not_queued [wp, DetSchedSchedule_AI_assms]:
+  handle_vm_fault, handle_arch_fault_reply "not_queued t"
+  (simp: crunch_simps)
+
+crunch sched_act_not [wp, DetSchedSchedule_AI_assms]:
+  handle_arch_fault_reply, handle_vm_fault "scheduler_act_not t"
+  (simp: crunch_simps)
+
+lemma hvmf_st_tcb_at [wp, DetSchedSchedule_AI_assms]:
+  "\<lbrace>st_tcb_at P t' \<rbrace> handle_vm_fault t w \<lbrace>\<lambda>rv. st_tcb_at P t' \<rbrace>"
+  unfolding handle_vm_fault_def by (cases w; wpsimp)
+
+lemma handle_vm_fault_st_tcb_cur_thread [wp, DetSchedSchedule_AI_assms]:
+  "\<lbrace> \<lambda>s. st_tcb_at P (cur_thread s) s \<rbrace> handle_vm_fault t f \<lbrace>\<lambda>_ s. st_tcb_at P (cur_thread s) s \<rbrace>"
+  unfolding handle_vm_fault_def
+  apply (fold ct_in_state_def)
+  apply (rule ct_in_state_thread_state_lift; cases f; wpsimp)
+  done
+
+crunch valid_sched [wp, DetSchedSchedule_AI_assms]: arch_invoke_irq_control "valid_sched"
+
+crunch valid_list [wp, DetSchedSchedule_AI_assms]:
+  arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread "valid_list"
+
+crunch cur_tcb [wp, DetSchedSchedule_AI_assms]:
+  handle_arch_fault_reply, handle_vm_fault, arch_get_sanitise_register_info, arch_post_modify_registers
+  cur_tcb
+  (simp: crunch_simps)
+
+crunch not_cur_thread [wp, DetSchedSchedule_AI_assms]: arch_get_sanitise_register_info, arch_post_modify_registers "not_cur_thread t'"
+crunch ready_queues   [wp, DetSchedSchedule_AI_assms]: arch_get_sanitise_register_info, arch_post_modify_registers "\<lambda>s. P (ready_queues s)"
+crunch scheduler_action [wp, DetSchedSchedule_AI_assms]: arch_get_sanitise_register_info, arch_post_modify_registers "\<lambda>s. P (scheduler_action s)"
+
+lemma make_arch_fault_msg_inv:
+  "make_arch_fault_msg f t \<lbrace>P\<rbrace>"
+  by (cases f) wpsimp
+
+declare make_arch_fault_msg_inv[DetSchedSchedule_AI_assms]
+
+lemma arch_post_modify_registers_not_idle_thread[DetSchedSchedule_AI_assms]:
+  "\<lbrace>\<lambda>s::det_ext state. t \<noteq> idle_thread s\<rbrace> arch_post_modify_registers c t \<lbrace>\<lambda>_ s. t \<noteq> idle_thread s\<rbrace>"
+  by (wpsimp simp: arch_post_modify_registers_def)
+
+crunches arch_post_cap_deletion
+  for valid_sched[wp, DetSchedSchedule_AI_assms]: valid_sched
+  and valid_etcbs[wp, DetSchedSchedule_AI_assms]: valid_etcbs
+  and ct_not_in_q[wp, DetSchedSchedule_AI_assms]: ct_not_in_q
+  and simple_sched_action[wp, DetSchedSchedule_AI_assms]: simple_sched_action
+  and not_cur_thread[wp, DetSchedSchedule_AI_assms]: "not_cur_thread t"
+  and is_etcb_at[wp, DetSchedSchedule_AI_assms]: "is_etcb_at t"
+  and not_queued[wp, DetSchedSchedule_AI_assms]: "not_queued t"
+  and sched_act_not[wp, DetSchedSchedule_AI_assms]: "scheduler_act_not t"
+  and weak_valid_sched_action[wp, DetSchedSchedule_AI_assms]: weak_valid_sched_action
+  and valid_idle[wp, DetSchedSchedule_AI_assms]: valid_idle
+
+crunch delete_asid_pool[wp]: delete_asid_pool "\<lambda>(s:: det_ext state). P (idle_thread s)"
+ (wp: crunch_wps simp: if_apply_def2)
+
+crunch arch_finalise_cap[wp, DetSchedSchedule_AI_assms]:
+  arch_finalise_cap "\<lambda>(s:: det_ext state). P (idle_thread s)"
+  (wp: crunch_wps simp: if_fun_split)
+
+end
+
+global_interpretation DetSchedSchedule_AI?: DetSchedSchedule_AI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact DetSchedSchedule_AI_assms)?)
+  qed
+
+context Arch begin global_naming RISCV64
+
+lemma handle_hyp_fault_valid_sched[wp]:
+  "\<lbrace>valid_sched and invs and st_tcb_at active t and not_queued t and scheduler_act_not t
+      and (ct_active or ct_idle)\<rbrace>
+    handle_hypervisor_fault t fault \<lbrace>\<lambda>_. valid_sched\<rbrace>"
+  by (cases fault; wpsimp wp: handle_fault_valid_sched simp: valid_fault_def)
+
+lemma handle_reserved_irq_valid_sched:
+  "\<lbrace>valid_sched and invs and (\<lambda>s. irq \<in> non_kernel_IRQs \<longrightarrow>  scheduler_act_sane s \<and> ct_not_queued s)\<rbrace>
+  handle_reserved_irq irq \<lbrace>\<lambda>rv. valid_sched\<rbrace>"
+  unfolding handle_reserved_irq_def by (wpsimp simp: non_kernel_IRQs_def)
+
+end
+
+global_interpretation DetSchedSchedule_AI_handle_hypervisor_fault?: DetSchedSchedule_AI_handle_hypervisor_fault
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact handle_hyp_fault_valid_sched handle_reserved_irq_valid_sched)?)
+  qed
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDeterministic_AI.thy
@@ -1,16 +1,31 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
 theory ArchDeterministic_AI
-imports Deterministic_AI
+imports Deterministic_AI ArchVCPU_AI
 begin
+
+declare dxo_wp_weak[wp del]
 
 context Arch begin global_naming AARCH64
 
 named_theorems Deterministic_AI_assms
+
+crunch valid_list[wp, Deterministic_AI_assms]:
+ vcpu_save, vcpu_enable, vcpu_disable, vcpu_restore, arch_get_sanitise_register_info, arch_post_modify_registers valid_list
+  (wp: crunch_wps simp: unless_def crunch_simps)
+
+(* FIXME AARCH64: crunchable? If not, rename param_a *)
+lemma vcpu_switch_valid_list[wp, Deterministic_AI_assms]:
+  "\<lbrace>valid_list\<rbrace> vcpu_switch param_a \<lbrace>\<lambda>_. valid_list\<rbrace>"
+  apply (simp add: vcpu_switch_def)
+  apply (rule hoare_pre)
+    apply(wpsimp)+
+  done
 
 crunch valid_list[wp, Deterministic_AI_assms]:
   cap_swap_for_delete,set_cap,finalise_cap,arch_get_sanitise_register_info,
@@ -52,7 +67,7 @@ lemma perform_page_invocation_valid_list[wp]:
   done *)
 
 crunch valid_list[wp]: perform_invocation valid_list
-  (wp: crunch_wps simp: crunch_simps ignore: without_preemption)
+  (wp: crunch_wps simp: crunch_simps ignore: without_preemption as_user)
 
 crunch valid_list[wp, Deterministic_AI_assms]: handle_invocation valid_list
   (wp: crunch_wps syscall_valid simp: crunch_simps
@@ -65,14 +80,17 @@ lemma handle_vm_fault_valid_list[wp, Deterministic_AI_assms]:
   "handle_vm_fault thread fault \<lbrace>valid_list\<rbrace>"
   unfolding handle_vm_fault_def by (cases fault; wpsimp)
 
+crunches vgic_maintenance, vppi_event
+  for valid_list[wp]: valid_list
+  (wp: hoare_drop_imps)
+
 lemma handle_interrupt_valid_list[wp, Deterministic_AI_assms]:
   "\<lbrace>valid_list\<rbrace> handle_interrupt irq \<lbrace>\<lambda>_.valid_list\<rbrace>"
   unfolding handle_interrupt_def ackInterrupt_def
   apply (rule hoare_pre)
-  sorry (* FIXME AARCH64 vvpi_event
    by (wp get_cap_wp  do_machine_op_valid_list
        | wpc | simp add: get_irq_slot_def handle_reserved_irq_def arch_mask_irq_signal_def
-       | wp (once) hoare_drop_imps)+ *)
+       | wp (once) hoare_drop_imps)+
 
 crunch valid_list[wp, Deterministic_AI_assms]: handle_send,handle_reply valid_list
 

--- a/proof/invariant-abstract/AARCH64/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDeterministic_AI.thy
@@ -1,0 +1,87 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchDeterministic_AI
+imports Deterministic_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems Deterministic_AI_assms
+
+crunch valid_list[wp, Deterministic_AI_assms]:
+  cap_swap_for_delete,set_cap,finalise_cap,arch_get_sanitise_register_info,
+  arch_post_modify_registers valid_list
+  (wp: crunch_wps simp: unless_def crunch_simps)
+declare get_cap_inv[Deterministic_AI_assms]
+
+end
+
+global_interpretation Deterministic_AI_1?: Deterministic_AI_1
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact Deterministic_AI_assms)?)
+  qed
+
+context Arch begin global_naming RISCV64
+
+crunch valid_list[wp,Deterministic_AI_assms]: arch_invoke_irq_handler valid_list
+
+crunch valid_list[wp]: invoke_untyped valid_list
+  (wp: crunch_wps preemption_point_inv' hoare_unless_wp mapME_x_wp'
+   simp: mapM_x_def_bak crunch_simps)
+
+crunch valid_list[wp]: invoke_irq_control valid_list
+
+lemma perform_page_table_invocation_valid_list[wp]:
+  "\<lbrace>valid_list\<rbrace> perform_page_table_invocation a \<lbrace>\<lambda>_.valid_list\<rbrace>"
+  unfolding perform_page_table_invocation_def
+  by (wpsimp wp: mapM_x_wp' simp: perform_pt_inv_map_def perform_pt_inv_unmap_def)
+
+lemma perform_page_invocation_valid_list[wp]:
+  "\<lbrace>valid_list\<rbrace> perform_page_invocation a \<lbrace>\<lambda>_.valid_list\<rbrace>"
+  apply (simp add: perform_page_invocation_def)
+  apply (cases a, simp_all add: perform_pg_inv_map_def perform_pg_inv_unmap_def
+                                perform_pg_inv_get_addr_def split_def)
+    apply (wp mapM_x_wp' mapM_wp' crunch_wps | intro impI conjI allI | wpc
+           | simp add: set_message_info_def set_mrs_def split: cap.splits arch_cap.splits)+
+  done
+
+crunch valid_list[wp]: perform_invocation valid_list
+  (wp: crunch_wps simp: crunch_simps ignore: without_preemption)
+
+crunch valid_list[wp, Deterministic_AI_assms]: handle_invocation valid_list
+  (wp: crunch_wps syscall_valid simp: crunch_simps
+   ignore: without_preemption syscall)
+
+crunch valid_list[wp, Deterministic_AI_assms]: handle_recv, handle_yield, handle_call valid_list
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma handle_vm_fault_valid_list[wp, Deterministic_AI_assms]:
+  "handle_vm_fault thread fault \<lbrace>valid_list\<rbrace>"
+  unfolding handle_vm_fault_def by (cases fault; wpsimp)
+
+lemma handle_interrupt_valid_list[wp, Deterministic_AI_assms]:
+  "\<lbrace>valid_list\<rbrace> handle_interrupt irq \<lbrace>\<lambda>_.valid_list\<rbrace>"
+  unfolding handle_interrupt_def ackInterrupt_def
+  apply (rule hoare_pre)
+   by (wp get_cap_wp  do_machine_op_valid_list
+       | wpc | simp add: get_irq_slot_def handle_reserved_irq_def arch_mask_irq_signal_def
+       | wp (once) hoare_drop_imps)+
+
+crunch valid_list[wp, Deterministic_AI_assms]: handle_send,handle_reply valid_list
+
+crunch valid_list[wp, Deterministic_AI_assms]: handle_hypervisor_fault valid_list
+
+end
+
+global_interpretation Deterministic_AI_2?: Deterministic_AI_2
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact Deterministic_AI_assms)?)
+  qed
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDeterministic_AI.thy
@@ -8,7 +8,7 @@ theory ArchDeterministic_AI
 imports Deterministic_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems Deterministic_AI_assms
 
@@ -26,7 +26,7 @@ global_interpretation Deterministic_AI_1?: Deterministic_AI_1
   case 1 show ?case by (unfold_locales; (fact Deterministic_AI_assms)?)
   qed
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 crunch valid_list[wp,Deterministic_AI_assms]: arch_invoke_irq_handler valid_list
 
@@ -48,7 +48,8 @@ lemma perform_page_invocation_valid_list[wp]:
                                 perform_pg_inv_get_addr_def split_def)
     apply (wp mapM_x_wp' mapM_wp' crunch_wps | intro impI conjI allI | wpc
            | simp add: set_message_info_def set_mrs_def split: cap.splits arch_cap.splits)+
-  done
+  sorry (* FIXME AARCH64 perform_flush
+  done *)
 
 crunch valid_list[wp]: perform_invocation valid_list
   (wp: crunch_wps simp: crunch_simps ignore: without_preemption)
@@ -68,9 +69,10 @@ lemma handle_interrupt_valid_list[wp, Deterministic_AI_assms]:
   "\<lbrace>valid_list\<rbrace> handle_interrupt irq \<lbrace>\<lambda>_.valid_list\<rbrace>"
   unfolding handle_interrupt_def ackInterrupt_def
   apply (rule hoare_pre)
+  sorry (* FIXME AARCH64 vvpi_event
    by (wp get_cap_wp  do_machine_op_valid_list
        | wpc | simp add: get_irq_slot_def handle_reserved_irq_def arch_mask_irq_signal_def
-       | wp (once) hoare_drop_imps)+
+       | wp (once) hoare_drop_imps)+ *)
 
 crunch valid_list[wp, Deterministic_AI_assms]: handle_send,handle_reply valid_list
 

--- a/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
@@ -1,0 +1,633 @@
+(*
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchDetype_AI
+imports Detype_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems Detype_AI_asms
+
+lemma valid_globals_irq_node[Detype_AI_asms]:
+    "\<lbrakk> valid_global_refs s; cte_wp_at ((=) cap) ptr s \<rbrakk>
+          \<Longrightarrow> interrupt_irq_node s irq \<notin> cap_range cap"
+    apply (erule(1) valid_global_refsD)
+    apply (simp add: global_refs_def)
+    done
+
+lemma caps_of_state_ko[Detype_AI_asms]:
+  "valid_cap cap s
+   \<Longrightarrow> is_untyped_cap cap \<or>
+       cap_range cap = {} \<or>
+       (\<forall>ptr \<in> cap_range cap. \<exists>ko. kheap s ptr = Some ko)"
+  apply (case_tac cap)
+    apply (clarsimp simp: cap_range_def valid_cap_def obj_at_def is_cap_simps
+                   split: option.splits)+
+  apply (rename_tac arch_cap ptr)
+  apply (case_tac arch_cap)
+    apply (fastforce simp: cap_range_def obj_at_def is_cap_simps
+                    split: option.splits if_splits)+
+  done
+
+lemma mapM_x_storeWord[Detype_AI_asms]:
+(* FIXME: taken from Retype_C.thy and adapted wrt. the missing intvl syntax. *)
+  assumes al: "is_aligned ptr word_size_bits"
+  shows "mapM_x (\<lambda>x. storeWord (ptr + of_nat x * word_size) 0) [0..<n]
+  = modify (underlying_memory_update
+             (\<lambda>m x. if \<exists>k. x = ptr + of_nat k \<and> k < n * word_size then 0 else m x))"
+proof (induct n)
+  case 0
+  thus ?case
+    apply (rule ext)
+    apply (simp add: mapM_x_mapM mapM_def sequence_def
+                     modify_def get_def put_def bind_def return_def)
+    done
+next
+  case (Suc n')
+
+  have b: "\<And>i. word_rsplit (0 :: machine_word) ! (7 - i) = (0 :: 8 word)"
+    apply (simp add: word_rsplit_0 word_bits_def)
+    apply (case_tac i; simp; rename_tac i)+
+    done
+
+  have k: "\<And>k. (k < word_size + n' * word_size)
+                  = (k < n' * word_size \<or> k = n' * word_size
+                        \<or> (\<exists>i \<in> {1,2,3,4,5,6,7}. k = n' * word_size + i))"
+    by (auto simp: word_size_def)
+
+  have x: "\<And>x. (\<exists>k. x = ptr + of_nat k \<and> k < word_size + n' * word_size)
+                  = ((\<exists>k. x = ptr + of_nat k \<and> k < n' * word_size)
+                       \<or> (\<exists>i \<in> {0,1,2,3,4,5,6,7}. x = ptr + of_nat n' * word_size + i))"
+    unfolding k by (simp add: word_size_def conj_disj_distribL ex_disj_distrib field_simps)
+
+  from al have "is_aligned (ptr + of_nat n' * word_size) word_size_bits"
+    apply (rule aligned_add_aligned)
+    apply (rule is_aligned_mult_triv2 [of _ word_size_bits, simplified word_size_size_bits_word])
+    apply (rule order_refl)
+    done
+
+  thus ?case
+    apply (simp add: mapM_x_append bind_assoc Suc.hyps mapM_x_singleton)
+    apply (simp add: storeWord_def b assert_def is_aligned_mask modify_modify
+                     comp_def word_size_bits_def)
+    apply (rule arg_cong[where f=modify])
+    apply (rule arg_cong[where f=underlying_memory_update])
+    apply (rule ext, rule ext, rule sym)
+    apply (simp add: x upto0_7_def)
+    done
+qed
+
+lemma empty_fail_freeMemory [Detype_AI_asms]: "empty_fail (freeMemory ptr bits)"
+  by (simp add: freeMemory_def mapM_x_mapM ef_storeWord)
+
+
+lemma region_in_kernel_window_detype[simp]:
+  "region_in_kernel_window S (detype S' s)
+      = region_in_kernel_window S s"
+  by (simp add: region_in_kernel_window_def detype_def)
+
+
+lemma region_in_kernel_window_machine_state_update[simp]:
+  "region_in_kernel_window S (machine_state_update f s) =
+   region_in_kernel_window S s"
+  by (simp add: region_in_kernel_window_def)
+
+
+lemma region_in_kernel_window_delete_objects[wp]:
+  "\<lbrace>region_in_kernel_window S\<rbrace>
+   delete_objects ptr bits
+   \<lbrace>\<lambda>_. region_in_kernel_window S\<rbrace>"
+  by (wp | simp add: delete_objects_def do_machine_op_def split_def)+
+
+lemma state_hyp_refs_of_detype:
+  "state_hyp_refs_of (detype S s) = (\<lambda>x. if x \<in> S then {} else state_hyp_refs_of s x)"
+  by (rule ext, simp add: state_hyp_refs_of_def detype_def)
+
+lemma valid_ioports_detype[Detype_AI_asms]:
+  "valid_ioports s \<Longrightarrow> valid_ioports (detype (untyped_range cap) s)"
+  by simp
+
+end
+
+interpretation Detype_AI?: Detype_AI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+  by (intro_locales; (unfold_locales; fact Detype_AI_asms)?)
+  qed
+
+context detype_locale_arch begin
+
+named_theorems detype_invs_proofs
+
+lemma state_hyp_refs: "state_hyp_refs_of (detype (untyped_range cap) s) = state_hyp_refs_of s"
+  apply (rule ext, clarsimp simp add: state_hyp_refs_of_detype)
+  apply (rule sym, rule equals0I, drule state_hyp_refs_of_elemD)
+  apply (drule live_okE, rule hyp_refs_of_live, clarsimp)
+  apply simp
+  done
+
+lemma hyp_refsym : "sym_refs (state_hyp_refs_of s)"
+  using invs by (simp add: invs_def valid_state_def valid_pspace_def)
+
+lemma hyp_refs_of: "\<And>obj p. \<lbrakk> ko_at obj p s \<rbrakk> \<Longrightarrow> hyp_refs_of obj \<subseteq> (UNIV - untyped_range cap \<times> UNIV)"
+  by (fastforce intro: hyp_refs_of_live dest!: hyp_sym_refs_ko_atD[OF _ hyp_refsym] live_okE)
+
+lemma arch_valid_obj[detype_invs_proofs]:
+    "\<And>p ao. \<lbrakk>ko_at (ArchObj ao) p s; arch_valid_obj ao s\<rbrakk>
+       \<Longrightarrow> arch_valid_obj ao (detype (untyped_range cap) s)"
+  by simp
+
+lemma sym_hyp_refs_detype[detype_invs_proofs]:
+  "sym_refs (state_hyp_refs_of (detype (untyped_range cap) s))"
+  using hyp_refsym by (simp add: state_hyp_refs)
+
+lemma valid_cap[detype_invs_proofs]:
+    "\<And>cap'. \<lbrakk> s \<turnstile> cap'; obj_reply_refs cap' \<subseteq> (UNIV - untyped_range cap) \<rbrakk>
+      \<Longrightarrow> detype (untyped_range cap) s \<turnstile> cap'"
+  by (auto simp: valid_cap_def valid_untyped_def obj_reply_refs_def valid_arch_cap_ref_def
+          split: cap.split_asm option.splits if_splits
+                 arch_cap.split_asm bool.split_asm )
+
+lemma glob_det[detype_invs_proofs]: "\<And>r. global_refs (detype r s) = global_refs s"
+    by (simp add: global_refs_def detype_def)
+
+lemma valid_idle_detype[detype_invs_proofs]: "valid_idle (detype (untyped_range cap) s)"
+    proof -
+    have "valid_idle s" using invs by (simp add: invs_def valid_state_def)
+    thus ?thesis using valid_global_refsD [OF globals cap]
+    by (fastforce simp add: valid_idle_def state_refs idle cap_range_def
+                            global_refs_def)
+    qed
+
+lemma valid_vs_lookup: "valid_vs_lookup s"
+    using valid_arch_caps by (simp add: valid_arch_caps_def)
+
+lemma hyp_live_strg:
+  "hyp_live ko \<Longrightarrow> live ko"
+  by (cases ko; simp add: live_def hyp_live_def)
+
+lemma obj_at_hyp_live_strg:
+  "obj_at hyp_live p s \<Longrightarrow> obj_at live p s"
+  by (erule obj_at_weakenE, rule hyp_live_strg)
+
+lemma tcb_arch_detype[detype_invs_proofs]:
+  "\<lbrakk>ko_at (TCB t) p s; valid_arch_tcb (tcb_arch t) s\<rbrakk>
+      \<Longrightarrow> valid_arch_tcb (tcb_arch t) (detype (untyped_range cap) s)"
+  apply (clarsimp simp: valid_arch_tcb_def)
+  done
+
+declare arch_state_det[simp]
+
+lemma aobjs_of_detype[simp]:
+  "(aobjs_of (detype S s) p = Some aobj) = (p \<notin> S \<and> aobjs_of s p = Some aobj)"
+  by (simp add: in_omonad detype_def)
+
+lemma pts_of_detype[simp]:
+  "(pts_of (detype S s) p = Some pt) = (p \<notin> S \<and> pts_of s p = Some pt)"
+  by (simp add: in_omonad detype_def)
+
+lemma ptes_of_detype_Some[simp]:
+  "(ptes_of (detype S s) p = Some pte) = (table_base p \<notin> S \<and> ptes_of s p = Some pte)"
+  by (simp add: in_omonad ptes_of_def detype_def)
+
+lemma asid_pools_of_detype:
+  "asid_pools_of (detype S s) = (\<lambda>p. if p\<in>S then None else asid_pools_of s p)"
+  by (rule ext) (simp add: detype_def opt_map_def)
+
+lemma asid_pools_of_detype_Some[simp]:
+  "(asid_pools_of (detype S s) p = Some ap) = (p \<notin> S \<and> asid_pools_of s p = Some ap)"
+  by (simp add: in_omonad detype_def)
+
+lemma pool_for_asid_detype_Some[simp]:
+  "(pool_for_asid asid (detype S s) = Some p) = (pool_for_asid asid s = Some p)"
+  by (simp add: pool_for_asid_def)
+
+lemma vspace_for_pool_detype_Some[simp]:
+  "(vspace_for_pool ap asid (\<lambda>p. if p \<in> S then None else pools p) = Some p) =
+   (ap \<notin> S \<and> vspace_for_pool ap asid pools = Some p)"
+  by (simp add: vspace_for_pool_def obind_def split: option.splits)
+
+lemma vspace_for_asid_detype_Some[simp]:
+  "(vspace_for_asid asid (detype S s) = Some p) =
+   ((\<exists>ap. pool_for_asid asid s = Some ap \<and> ap \<notin> S) \<and> vspace_for_asid asid s = Some p)"
+  apply (simp add: vspace_for_asid_def obind_def asid_pools_of_detype split: option.splits)
+  apply (auto simp: pool_for_asid_def)
+  done
+
+lemma pt_walk_detype:
+  "pt_walk level bot_level pt_ptr vref (ptes_of (detype S s)) = Some (bot_level, p) \<Longrightarrow>
+   pt_walk level bot_level pt_ptr vref (ptes_of s) = Some (bot_level, p)"
+  apply (induct level arbitrary: pt_ptr)
+   apply (simp add: pt_walk.simps)
+  apply (subst pt_walk.simps)
+  apply (subst (asm) (3) pt_walk.simps)
+  apply (clarsimp simp: in_omonad split: if_split_asm)
+  apply (erule disjE; clarsimp)
+  apply (drule meta_spec, drule (1) meta_mp)
+  apply fastforce
+  done
+
+lemma vs_lookup_table:
+  "vs_lookup_table level asid vref (detype S s) = Some (level, p) \<Longrightarrow>
+   vs_lookup_table level asid vref s = Some (level, p)"
+  by (fastforce simp: vs_lookup_table_def in_omonad asid_pools_of_detype pt_walk_detype
+               split: if_split_asm)
+
+lemma vs_lookup_slot:
+  "(vs_lookup_slot level asid vref (detype S s) = Some (level, p)) \<Longrightarrow>
+   (vs_lookup_slot level asid vref s = Some (level, p))"
+  by (fastforce simp: vs_lookup_slot_def in_omonad asid_pools_of_detype
+                split: if_split_asm
+                dest!: vs_lookup_table)
+
+lemma vs_lookup_target:
+  "(vs_lookup_target level asid vref (detype S s) = Some (level, p)) \<Longrightarrow>
+   (vs_lookup_target level asid vref s = Some (level, p))"
+  by (fastforce simp: vs_lookup_target_def in_omonad asid_pools_of_detype
+                split: if_split_asm
+                dest!: vs_lookup_slot)
+
+lemma vs_lookup_target_preserved:
+  "\<lbrakk> x \<in> untyped_range cap; vs_lookup_target level asid vref s = Some (level', x);
+     vref \<in> user_region \<rbrakk> \<Longrightarrow> False"
+  apply (drule (1) valid_vs_lookupD[OF _ _ valid_vs_lookup])
+  apply (fastforce intro: no_obj_refs)
+  done
+
+lemma valid_asid_table:
+  "valid_asid_table (detype (untyped_range cap) s)"
+  using valid_arch_state
+  apply (clarsimp simp: valid_asid_table_def valid_arch_state_def)
+  apply (drule (1) subsetD)
+  apply (clarsimp simp: ran_def)
+  apply (subgoal_tac "valid_asid_pool_caps s")
+   prefer 2
+   using invs
+   apply (clarsimp simp: invs_def valid_state_def valid_arch_caps_def)
+  apply (simp add: valid_asid_pool_caps_def)
+  apply (erule allE, erule allE, erule (1) impE)
+  apply clarsimp
+  apply (drule no_obj_refs; simp)
+  done
+
+lemma valid_global_arch_objs:
+  "valid_global_arch_objs (detype (untyped_range cap) s)"
+  using valid_arch_state
+  by (fastforce dest!: riscv_global_pts_global_ref valid_global_refsD[OF globals cap]
+                simp: cap_range_def valid_global_arch_objs_def valid_arch_state_def)
+
+lemma valid_global_tables:
+  "valid_global_tables (detype (untyped_range cap) s)"
+  using valid_arch_state
+  by (fastforce dest: pt_walk_level pt_walk_detype
+                simp: valid_global_tables_def valid_arch_state_def Let_def)
+
+lemma valid_arch_state_detype[detype_invs_proofs]:
+  "valid_arch_state (detype (untyped_range cap) s)"
+  using valid_vs_lookup valid_arch_state ut_mdb valid_global_refsD [OF globals cap] cap
+  unfolding valid_arch_state_def pred_conj_def
+  by (simp only: valid_asid_table valid_global_arch_objs valid_global_tables) simp
+
+lemma vs_lookup_asid_pool_level:
+  assumes lookup: "vs_lookup_table level asid vref s = Some (level, p)" "vref \<in> user_region"
+  assumes ap: "asid_pools_of s p = Some ap"
+  shows "level = asid_pool_level"
+proof (rule ccontr)
+  have "valid_vspace_objs s" using invs by fastforce
+  moreover
+  note lookup
+  moreover
+  assume "level \<noteq> asid_pool_level"
+  then have "level \<le> max_pt_level" by simp
+  moreover
+  have "valid_asid_table s" "pspace_aligned s"
+    using invs by (auto simp: invs_def valid_state_def valid_arch_state_def)
+  ultimately
+  have "\<exists>pt. pts_of s p = Some pt \<and> valid_vspace_obj level (PageTable pt) s"
+    by (rule valid_vspace_objs_strongD)
+  with ap
+  show False by (clarsimp simp: in_omonad)
+qed
+
+lemma vs_lookup_pt_level:
+  assumes lookup: "vs_lookup_table level asid vref s = Some (level, p)" "vref \<in> user_region"
+  assumes pt: "pts_of s p = Some pt"
+  shows "level \<le> max_pt_level"
+proof (rule ccontr)
+  assume "\<not>level \<le> max_pt_level"
+  then
+  have "level = asid_pool_level" by (simp add: not_le)
+  with lookup
+  have "pool_for_asid asid s = Some p" by (auto simp: vs_lookup_table_def)
+  moreover
+  have "valid_asid_table s" using invs by (fastforce)
+  ultimately
+  have "asid_pools_of s p \<noteq> None" by (fastforce simp: pool_for_asid_def valid_asid_table_def)
+  with pt
+  show False by (simp add: in_omonad)
+qed
+
+lemma data_at_detype[simp]:
+  "data_at sz p (detype S s) = (p \<notin> S \<and> data_at sz p s)"
+  by (auto simp: data_at_def)
+
+lemma valid_vspace_obj:
+  "\<lbrakk> valid_vspace_obj level ao s; aobjs_of s p = Some ao; \<exists>\<rhd>(level,p) s \<rbrakk> \<Longrightarrow>
+     valid_vspace_obj level ao (detype (untyped_range cap) s)"
+  using invs
+  apply (cases ao; clarsimp split del: if_split)
+   apply (frule (1) vs_lookup_asid_pool_level, simp add: in_omonad)
+   apply simp
+   apply (drule vs_lookup_table_ap_step, simp add: in_omonad, assumption)
+   apply clarsimp
+   apply (erule (2) vs_lookup_target_preserved)
+  apply (rename_tac pt idx asid vref)
+  apply (case_tac "pt idx"; simp)
+   apply (frule_tac idx=idx in vs_lookup_table_pt_step; simp add: in_omonad)
+       apply (frule pspace_alignedD, fastforce)
+       apply (simp add: bit_simps)
+      apply (erule (1) vs_lookup_pt_level, simp add: in_omonad)
+     apply simp
+    apply fastforce
+   apply (fastforce elim: vs_lookup_target_preserved)
+  apply (frule_tac idx=idx in vs_lookup_table_pt_step; simp add: in_omonad)
+      apply (frule pspace_alignedD, fastforce)
+      apply (simp add: bit_simps)
+     apply (erule (1) vs_lookup_pt_level, simp add: in_omonad)
+    apply simp
+   apply fastforce
+  apply (fastforce elim: vs_lookup_target_preserved)
+  done
+
+lemma valid_vspace_obj_detype[detype_invs_proofs]: "valid_vspace_objs (detype (untyped_range cap) s)"
+proof -
+  have "valid_vspace_objs s"
+    using invs by fastforce
+  thus ?thesis
+    unfolding valid_vspace_objs_def
+    apply clarsimp
+    apply (drule vs_lookup_level, drule vs_lookup_table)
+    apply (fastforce intro: valid_vspace_obj)
+    done
+qed
+
+lemma unique_table_caps:
+  "unique_table_caps s \<Longrightarrow> unique_table_caps (detype (untyped_range cap) s)"
+  by (simp add: unique_table_caps_def)
+
+end
+
+
+sublocale detype_locale < detype_locale_gen_1
+proof goal_cases
+  interpret detype_locale_arch ..
+  case 1 show ?case by (unfold_locales; fact detype_invs_proofs)
+qed
+
+
+context detype_locale_arch begin
+
+lemma valid_vs_lookup':
+  "valid_vs_lookup s \<Longrightarrow> valid_vs_lookup (detype (untyped_range cap) s)"
+  apply (simp add: valid_vs_lookup_def del: split_paired_Ex)
+  apply (intro allI impI)
+  apply (drule vs_lookup_target_level, drule vs_lookup_target)
+  apply (elim allE, (erule (1) impE)+)
+  apply (elim conjE exE)
+  apply (frule non_null_caps, clarsimp)
+  apply fastforce
+  done
+
+lemma valid_table_caps:
+  "valid_table_caps s \<Longrightarrow> valid_table_caps (detype (untyped_range cap) s)"
+  apply (simp add: valid_table_caps_def del: imp_disjL)
+  apply (elim allEI | rule impI)+
+  apply (fastforce dest: no_obj_refs)
+  done
+
+lemma unique_table_refs:
+  "unique_table_refs s \<Longrightarrow> unique_table_refs (detype (untyped_range cap) s)"
+  apply (simp only: unique_table_refs_def option.simps simp_thms caps_of_state_detype split: if_split)
+  apply blast
+  done
+
+lemma valid_asid_pools_caps:
+  "valid_asid_pool_caps s \<Longrightarrow> valid_asid_pool_caps (detype (untyped_range cap) s)"
+  by (fastforce simp: valid_asid_pool_caps_def dest: non_null_caps)
+
+lemma valid_arch_caps_detype[detype_invs_proofs]: "valid_arch_caps (detype (untyped_range cap) s)"
+  using valid_arch_caps
+  by (simp add: valid_arch_caps_def unique_table_caps valid_vs_lookup' unique_table_refs
+                valid_table_caps valid_asid_pools_caps
+           del: caps_of_state_detype arch_state_det)
+
+lemma valid_global_objs_detype[detype_invs_proofs]:
+  "valid_global_objs (detype (untyped_range cap) s)"
+  using valid_global_objs valid_global_refsD [OF globals cap]
+  by (simp add: valid_global_objs_def valid_vso_at_def)
+
+lemma valid_kernel_mappings_detype[detype_invs_proofs]:
+  "valid_kernel_mappings (detype (untyped_range cap) s)"
+proof -
+  have "valid_kernel_mappings s"
+    using invs by (simp add: invs_def valid_state_def)
+  thus ?thesis by (simp add: valid_kernel_mappings_def detype_def ball_ran_eq)
+qed
+
+lemma valid_asid_map_detype[detype_invs_proofs]: "valid_asid_map (detype (untyped_range cap) s)"
+  by (simp add: valid_asid_map_def)
+
+lemma has_kernel_mappings:
+  "valid_global_arch_objs s \<Longrightarrow>
+   has_kernel_mappings pt (detype (untyped_range cap) s) = has_kernel_mappings pt s"
+  by (auto dest!: riscv_global_pt_in_global_refs valid_global_refsD [OF globals cap]
+           simp: cap_range_def has_kernel_mappings_def )
+
+lemma equal_kernel_mappings_detype[detype_invs_proofs]:
+  "equal_kernel_mappings (detype (untyped_range cap) s)"
+proof -
+  have "equal_kernel_mappings s"
+    using invs by (simp add: invs_def valid_state_def)
+  moreover
+  have "valid_global_arch_objs s"
+    using invs by (simp add: invs_def valid_state_def valid_arch_state_def)
+  ultimately
+  show ?thesis
+    by (clarsimp simp: equal_kernel_mappings_def has_kernel_mappings)
+qed
+
+lemma valid_global_mappings_detype[detype_invs_proofs]:
+  "valid_global_vspace_mappings (detype (untyped_range cap) s)"
+proof -
+  have "valid_global_vspace_mappings s"
+       "valid_global_tables s"
+       "valid_global_arch_objs s"
+       "pspace_aligned s"
+       "valid_uses s"
+    using invs by (auto simp: invs_def valid_state_def valid_arch_state_def)
+  then show ?thesis
+    unfolding valid_global_vspace_mappings_def
+    apply (clarsimp simp: Let_def)
+    apply (safe; drule (1) bspec; thin_tac "Ball _ _")
+     apply (all \<open>drule kernel_regionsI, erule option_Some_value_independent\<close>)
+     apply (distinct_subgoals)
+    apply (subst pt_lookup_target_translate_address_upd_eq; assumption?)
+    apply (rule pt_lookup_target_pt_eqI; clarsimp)
+    apply (drule (1) valid_global_tablesD, simp add: kernel_regions_in_mappings)
+    apply (drule riscv_global_pts_global_ref)
+    apply (drule valid_global_refsD[OF globals cap])
+    apply (clarsimp simp: cap_range_def opt_map_def detype_def split: option.splits)
+    done
+qed
+
+lemma pspace_in_kernel_window_detype[detype_invs_proofs]:
+  "pspace_in_kernel_window (detype (untyped_range cap) s)"
+proof -
+  have "pspace_in_kernel_window s"
+    using invs by (simp add: invs_def valid_state_def)
+  thus ?thesis
+    by (simp add: pspace_in_kernel_window_def)
+qed
+
+lemma in_user_frame_eq:
+  notes [simp del] = atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+                     Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
+                     order_class.Icc_eq_Icc
+    and [simp] = p2pm1_to_mask
+  shows "p \<notin> untyped_range cap \<Longrightarrow> in_user_frame p
+              (trans_state (\<lambda>_. detype_ext (untyped_range cap) (exst s)) s
+               \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
+         = in_user_frame p s"
+    using cap_is_valid untyped
+    apply (cases cap; simp add: in_user_frame_def valid_untyped_def valid_cap_def obj_at_def)
+    apply (rule iffI; erule exEI; elim conjE exE; simp)
+    subgoal for dev ptr n f sz ko
+      apply (elim allE; erule (1) impE)
+      apply (drule valid_pspace_aligned[OF valid_pspace])
+      apply (clarsimp simp: obj_range_def)
+      apply (erule impE)
+       apply (erule not_emptyI[rotated])
+       apply (rule mask_in_range[THEN iffD1, simplified])
+        apply (simp add: is_aligned_neg_mask)
+       apply (simp add: mask_lower_twice)
+      apply (cut_tac mask_in_range[THEN iffD1, simplified, OF is_aligned_neg_mask[OF le_refl] refl])
+      apply fastforce
+      done
+    done
+
+lemma in_device_frame_eq:
+  notes blah[simp del] =  atLeastAtMost_iff
+          atLeastatMost_subset_iff atLeastLessThan_iff
+          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
+          order_class.Icc_eq_Icc
+     and  p2pm1[simp] = p2pm1_to_mask
+  shows "p \<notin> untyped_range cap
+       \<Longrightarrow> in_device_frame p
+              (trans_state (\<lambda>_. detype_ext (untyped_range cap) (exst s)) s
+               \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
+         = in_device_frame p s"
+    using cap_is_valid untyped
+    unfolding in_device_frame_def
+    apply (cases cap; simp add: in_device_frame_def valid_untyped_def valid_cap_def obj_at_def)
+    apply (rule iffI; erule exEI; elim conjE exE; simp)
+    subgoal for dev ptr n f sz ko
+      apply (elim allE; erule (1) impE)
+      apply (drule valid_pspace_aligned[OF valid_pspace])
+      apply (clarsimp simp: obj_range_def)
+      apply (erule impE)
+       apply (erule not_emptyI[rotated])
+       apply (rule mask_in_range[THEN iffD1, simplified])
+        apply (simp add: is_aligned_neg_mask)
+       apply (simp add: mask_lower_twice)
+      apply (cut_tac mask_in_range[THEN iffD1, simplified, OF is_aligned_neg_mask[OF le_refl] refl])
+      apply fastforce
+      done
+    done
+
+lemma pspace_respects_device_region_detype[detype_invs_proofs]:
+  "pspace_respects_device_region (clear_um (untyped_range cap) (detype (untyped_range cap) s))"
+  proof -
+  have "pspace_respects_device_region s"
+    using invs by (simp add: invs_def valid_state_def)
+  thus ?thesis
+    apply (intro pspace_respects_device_regionI)
+    using pspace_aligned_detype valid_objs_detype invs
+    apply (simp_all add: clear_um.pspace detype_def dom_def clear_um_def
+                  split: if_split_asm )
+       apply (drule pspace_respects_device_regionD[rotated -1],auto)+
+    done
+  qed
+
+lemma cap_refs_respects_device_region_detype[detype_invs_proofs]:
+  "cap_refs_respects_device_region (clear_um (untyped_range cap) (detype (untyped_range cap) s))"
+  proof -
+  have "cap_refs_respects_device_region s"
+    using invs by (simp add: invs_def valid_state_def)
+  thus ?thesis
+    apply (clarsimp simp: clear_um_def cap_refs_respects_device_region_def
+                simp del: split_paired_All split_paired_Ex)
+    apply (drule_tac x = "(a,b)" in spec)
+    apply (clarsimp simp: cte_wp_at_caps_of_state cap_range_respects_device_region_def detype_def)
+    done
+  qed
+
+lemma valid_machine_state_detype[detype_invs_proofs]:
+    "valid_machine_state (clear_um (untyped_range cap) (detype (untyped_range cap) s))"
+  proof -
+    have "valid_machine_state s" using invs by (simp add: invs_def valid_state_def)
+    thus ?thesis
+    using untyped cap_is_valid
+    by (clarsimp simp: valid_machine_state_def clear_um_def
+      detype_def in_user_frame_eq in_device_frame_eq)
+  qed
+
+end
+
+sublocale detype_locale < detype_locale_gen_2
+ proof goal_cases
+  interpret detype_locale_arch ..
+  case 1 show ?case
+  by (intro_locales; (unfold_locales; fact detype_invs_proofs)?)
+  qed
+
+context detype_locale begin
+  lemmas invariants = invariants
+  lemmas non_filter_detype = non_filter_detype
+  lemmas valid_cap = valid_cap
+  lemmas non_null_present = non_null_present
+end
+
+interpretation Detype_AI_2
+  using detype_locale.invariants[simplified detype_locale_def]
+        Detype_AI_2.intro
+        by blast
+
+context begin interpretation Arch .
+lemma delete_objects_invs[wp]:
+  "\<lbrace>(\<lambda>s. \<exists>slot. cte_wp_at ((=) (cap.UntypedCap dev ptr bits f)) slot s
+    \<and> descendants_range (cap.UntypedCap dev ptr bits f) slot s) and
+    invs and ct_active\<rbrace>
+    delete_objects ptr bits \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (simp add: delete_objects_def)
+  apply (simp add: freeMemory_def word_size_def bind_assoc ef_storeWord)
+   apply (rule hoare_pre)
+   apply (rule_tac G="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
+                in hoare_grab_asm)
+   apply (simp add: mapM_storeWord_clear_um[unfolded word_size_def]
+                    intvl_range_conv[where 'a=machine_word_len, folded word_bits_def])
+   apply wp
+  apply clarsimp
+  apply (frule invs_untyped_children)
+  apply (frule detype_invariants, clarsimp+)
+  apply (drule invs_valid_objs)
+  apply (drule (1) cte_wp_valid_cap)
+  apply (simp add: valid_cap_def cap_aligned_def word_size_bits_def untyped_min_bits_def)
+  done
+end
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -8,7 +9,7 @@ theory ArchDetype_AI
 imports Detype_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems Detype_AI_asms
 
@@ -140,7 +141,8 @@ lemma hyp_refs_of: "\<And>obj p. \<lbrakk> ko_at obj p s \<rbrakk> \<Longrightar
 lemma arch_valid_obj[detype_invs_proofs]:
     "\<And>p ao. \<lbrakk>ko_at (ArchObj ao) p s; arch_valid_obj ao s\<rbrakk>
        \<Longrightarrow> arch_valid_obj ao (detype (untyped_range cap) s)"
-  by simp
+  sorry (* FIXME AARCH64
+  by simp *)
 
 lemma sym_hyp_refs_detype[detype_invs_proofs]:
   "sym_refs (state_hyp_refs_of (detype (untyped_range cap) s))"
@@ -179,7 +181,8 @@ lemma tcb_arch_detype[detype_invs_proofs]:
   "\<lbrakk>ko_at (TCB t) p s; valid_arch_tcb (tcb_arch t) s\<rbrakk>
       \<Longrightarrow> valid_arch_tcb (tcb_arch t) (detype (untyped_range cap) s)"
   apply (clarsimp simp: valid_arch_tcb_def)
-  done
+  sorry (* FIXME AARCH64
+  done *)
 
 declare arch_state_det[simp]
 
@@ -192,8 +195,9 @@ lemma pts_of_detype[simp]:
   by (simp add: in_omonad detype_def)
 
 lemma ptes_of_detype_Some[simp]:
-  "(ptes_of (detype S s) p = Some pte) = (table_base p \<notin> S \<and> ptes_of s p = Some pte)"
-  by (simp add: in_omonad ptes_of_def detype_def)
+  "(ptes_of (detype S s) pt_t p = Some pte) = (table_base pt_t p \<notin> S \<and> ptes_of s pt_t p = Some pte)"
+  sorry (* FIXME AARCH64
+  by (simp add: in_omonad ptes_of_def detype_def) *)
 
 lemma asid_pools_of_detype:
   "asid_pools_of (detype S s) = (\<lambda>p. if p\<in>S then None else asid_pools_of s p)"
@@ -210,14 +214,16 @@ lemma pool_for_asid_detype_Some[simp]:
 lemma vspace_for_pool_detype_Some[simp]:
   "(vspace_for_pool ap asid (\<lambda>p. if p \<in> S then None else pools p) = Some p) =
    (ap \<notin> S \<and> vspace_for_pool ap asid pools = Some p)"
-  by (simp add: vspace_for_pool_def obind_def split: option.splits)
+  sorry (* FIXME AARCH64
+  by (simp add: vspace_for_pool_def obind_def split: option.splits) *)
 
 lemma vspace_for_asid_detype_Some[simp]:
   "(vspace_for_asid asid (detype S s) = Some p) =
    ((\<exists>ap. pool_for_asid asid s = Some ap \<and> ap \<notin> S) \<and> vspace_for_asid asid s = Some p)"
   apply (simp add: vspace_for_asid_def obind_def asid_pools_of_detype split: option.splits)
   apply (auto simp: pool_for_asid_def)
-  done
+  sorry (* FIXME AARCH64
+  done *)
 
 lemma pt_walk_detype:
   "pt_walk level bot_level pt_ptr vref (ptes_of (detype S s)) = Some (bot_level, p) \<Longrightarrow>
@@ -229,8 +235,9 @@ lemma pt_walk_detype:
   apply (clarsimp simp: in_omonad split: if_split_asm)
   apply (erule disjE; clarsimp)
   apply (drule meta_spec, drule (1) meta_mp)
+  sorry (* FIXME AARCH64
   apply fastforce
-  done
+  done *)
 
 lemma vs_lookup_table:
   "vs_lookup_table level asid vref (detype S s) = Some (level, p) \<Longrightarrow>
@@ -248,9 +255,10 @@ lemma vs_lookup_slot:
 lemma vs_lookup_target:
   "(vs_lookup_target level asid vref (detype S s) = Some (level, p)) \<Longrightarrow>
    (vs_lookup_target level asid vref s = Some (level, p))"
+  sorry (* FIXME AARCH64
   by (fastforce simp: vs_lookup_target_def in_omonad asid_pools_of_detype
                 split: if_split_asm
-                dest!: vs_lookup_slot)
+                dest!: vs_lookup_slot) *)
 
 lemma vs_lookup_target_preserved:
   "\<lbrakk> x \<in> untyped_range cap; vs_lookup_target level asid vref s = Some (level', x);
@@ -275,6 +283,7 @@ lemma valid_asid_table:
   apply (drule no_obj_refs; simp)
   done
 
+(* FIXME AARCH64
 lemma valid_global_arch_objs:
   "valid_global_arch_objs (detype (untyped_range cap) s)"
   using valid_arch_state
@@ -286,12 +295,14 @@ lemma valid_global_tables:
   using valid_arch_state
   by (fastforce dest: pt_walk_level pt_walk_detype
                 simp: valid_global_tables_def valid_arch_state_def Let_def)
+*)
 
 lemma valid_arch_state_detype[detype_invs_proofs]:
   "valid_arch_state (detype (untyped_range cap) s)"
   using valid_vs_lookup valid_arch_state ut_mdb valid_global_refsD [OF globals cap] cap
   unfolding valid_arch_state_def pred_conj_def
-  by (simp only: valid_asid_table valid_global_arch_objs valid_global_tables) simp
+  sorry (* FIXME AARCH64
+  by (simp only: valid_asid_table valid_global_arch_objs valid_global_tables) simp *)
 
 lemma vs_lookup_asid_pool_level:
   assumes lookup: "vs_lookup_table level asid vref s = Some (level, p)" "vref \<in> user_region"
@@ -309,7 +320,8 @@ proof (rule ccontr)
     using invs by (auto simp: invs_def valid_state_def valid_arch_state_def)
   ultimately
   have "\<exists>pt. pts_of s p = Some pt \<and> valid_vspace_obj level (PageTable pt) s"
-    by (rule valid_vspace_objs_strongD)
+    sorry (* FIXME AARCH64
+    by (rule valid_vspace_objs_strongD) *)
   with ap
   show False by (clarsimp simp: in_omonad)
 qed
@@ -343,6 +355,7 @@ lemma valid_vspace_obj:
   apply (cases ao; clarsimp split del: if_split)
    apply (frule (1) vs_lookup_asid_pool_level, simp add: in_omonad)
    apply simp
+  sorry (* FIXME AARCH64
    apply (drule vs_lookup_table_ap_step, simp add: in_omonad, assumption)
    apply clarsimp
    apply (erule (2) vs_lookup_target_preserved)
@@ -362,7 +375,7 @@ lemma valid_vspace_obj:
     apply simp
    apply fastforce
   apply (fastforce elim: vs_lookup_target_preserved)
-  done
+  done *)
 
 lemma valid_vspace_obj_detype[detype_invs_proofs]: "valid_vspace_objs (detype (untyped_range cap) s)"
 proof -
@@ -442,6 +455,7 @@ qed
 lemma valid_asid_map_detype[detype_invs_proofs]: "valid_asid_map (detype (untyped_range cap) s)"
   by (simp add: valid_asid_map_def)
 
+(* FIXME AARCH64
 lemma has_kernel_mappings:
   "valid_global_arch_objs s \<Longrightarrow>
    has_kernel_mappings pt (detype (untyped_range cap) s) = has_kernel_mappings pt s"
@@ -484,6 +498,7 @@ proof -
     apply (clarsimp simp: cap_range_def opt_map_def detype_def split: option.splits)
     done
 qed
+*)
 
 lemma pspace_in_kernel_window_detype[detype_invs_proofs]:
   "pspace_in_kernel_window (detype (untyped_range cap) s)"
@@ -592,7 +607,8 @@ sublocale detype_locale < detype_locale_gen_2
  proof goal_cases
   interpret detype_locale_arch ..
   case 1 show ?case
-  by (intro_locales; (unfold_locales; fact detype_invs_proofs)?)
+  sorry (* FIXME AARCH64
+  by (intro_locales; (unfold_locales; fact detype_invs_proofs)?) *)
   qed
 
 context detype_locale begin

--- a/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
@@ -83,7 +83,7 @@ next
 qed
 
 lemma empty_fail_freeMemory [Detype_AI_asms]: "empty_fail (freeMemory ptr bits)"
-  by (simp add: freeMemory_def mapM_x_mapM ef_storeWord)
+  by (simp add: freeMemory_def mapM_x_mapM)
 
 
 lemma region_in_kernel_window_detype[simp]:
@@ -591,7 +591,7 @@ lemma delete_objects_invs[wp]:
     invs and ct_active\<rbrace>
     delete_objects ptr bits \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: delete_objects_def)
-  apply (simp add: freeMemory_def word_size_def bind_assoc ef_storeWord)
+  apply (simp add: freeMemory_def word_size_def bind_assoc)
    apply (rule hoare_pre)
    apply (rule_tac G="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
                 in hoare_grab_asm)

--- a/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
@@ -1,0 +1,205 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchEmptyFail_AI
+imports EmptyFail_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems EmptyFail_AI_assms
+
+crunch_ignore (empty_fail)
+  (add: setVSpaceRoot_impl sfence_impl hwASIDFlush_impl read_stval resetTimer_impl stval_val
+        pt_lookup_from_level setIRQTrigger_impl plic_complete_claim_impl)
+
+crunch (empty_fail) empty_fail[wp, EmptyFail_AI_assms]:
+  loadWord, load_word_offs, storeWord, getRestartPC, get_mrs
+
+end
+
+global_interpretation EmptyFail_AI_load_word?: EmptyFail_AI_load_word
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
+  qed
+
+context Arch begin global_naming RISCV64
+
+crunch (empty_fail) empty_fail[wp, EmptyFail_AI_assms]: handle_fault
+  (simp: kernel_object.splits option.splits arch_cap.splits cap.splits endpoint.splits
+         bool.splits list.splits thread_state.splits split_def catch_def sum.splits
+         Let_def wp: zipWithM_x_empty_fail)
+
+crunch (empty_fail) empty_fail[wp]:
+  decode_tcb_configure, decode_bind_notification, decode_unbind_notification,
+  decode_set_priority, decode_set_mcpriority, decode_set_sched_params,
+  decode_set_tls_base
+  (simp: cap.splits arch_cap.splits split_def)
+
+lemma decode_tcb_invocation_empty_fail[wp]:
+  "empty_fail (decode_tcb_invocation a b (ThreadCap p) d e)"
+  by (simp add: decode_tcb_invocation_def split: gen_invocation_labels.splits invocation_label.splits
+      | wp | intro conjI impI)+
+
+crunch (empty_fail) empty_fail[wp]: find_vspace_for_asid, check_vp_alignment, check_slot
+
+lemma arch_decode_RISCVASIDControlMakePool_empty_fail:
+  "invocation_type label = ArchInvocationLabel RISCVASIDControlMakePool
+    \<Longrightarrow> empty_fail (arch_decode_invocation label b c d e f)"
+  apply (wpsimp simp: arch_decode_invocation_def decode_asid_pool_invocation_def)
+    apply (simp add: decode_asid_control_invocation_def)
+    apply (intro impI conjI allI)
+    apply (simp add: split_def)
+    apply wp
+     apply simp
+    apply (subst bindE_assoc[symmetric])
+    apply (rule empty_fail_bindE)
+     subgoal by (fastforce simp: empty_fail_def whenE_def throwError_def select_ext_def bindE_def
+                                 bind_def return_def returnOk_def lift_def liftE_def fail_def
+                                 gets_def get_def assert_def select_def
+                          split: if_split_asm)
+    apply wpsimp
+   apply (wpsimp simp: decode_frame_invocation_def)
+  apply (wpsimp simp: decode_page_table_invocation_def)
+  done
+
+lemma arch_decode_RISCVASIDPoolAssign_empty_fail:
+  "invocation_type label = ArchInvocationLabel RISCVASIDPoolAssign
+    \<Longrightarrow> empty_fail (arch_decode_invocation label b c d e f)"
+  unfolding arch_decode_invocation_def decode_page_table_invocation_def decode_frame_invocation_def
+            decode_asid_control_invocation_def
+  apply (wpsimp; wpsimp?)
+  apply (simp add: decode_asid_pool_invocation_def)
+  apply (intro impI allI conjI)
+  apply (simp add: arch_decode_invocation_def split_def Let_def
+            split: arch_cap.splits cap.splits option.splits | intro impI allI)+
+  apply clarsimp
+  apply (rule empty_fail_bindE, simp)
+  apply (rule empty_fail_bindE, wpsimp)
+  apply (rule empty_fail_bindE, wpsimp)
+  apply (rule empty_fail_bindE, wpsimp)
+  apply (subst bindE_assoc[symmetric])
+  apply (rule empty_fail_bindE)
+   subgoal by (fastforce simp: empty_fail_def whenE_def throwError_def select_def bindE_def
+                               bind_def return_def returnOk_def lift_def liftE_def select_ext_def
+                               gets_def get_def assert_def fail_def)
+  apply wpsimp
+  done
+
+lemma arch_decode_invocation_empty_fail[wp]:
+  "empty_fail (arch_decode_invocation label b c d e f)"
+  apply (case_tac "invocation_type label")
+  apply (find_goal \<open>match premises in "_ = ArchInvocationLabel _" \<Rightarrow> \<open>-\<close>\<close>)
+  apply (rename_tac alabel)
+  apply (case_tac alabel; simp)
+  apply (find_goal \<open>succeeds \<open>erule arch_decode_RISCVASIDControlMakePool_empty_fail\<close>\<close>)
+  apply (find_goal \<open>succeeds \<open>erule arch_decode_RISCVASIDPoolAssign_empty_fail\<close>\<close>)
+  apply ((simp add: arch_decode_RISCVASIDControlMakePool_empty_fail
+                    arch_decode_RISCVASIDPoolAssign_empty_fail)+)[2]
+  by (all \<open>(wpsimp simp: arch_decode_invocation_def decode_asid_pool_invocation_def
+                         decode_asid_control_invocation_def decode_frame_invocation_def
+                         decode_page_table_invocation_def decode_pt_inv_map_def
+                         decode_fr_inv_map_def Let_def)\<close>) (* 15s *)
+
+end
+
+global_interpretation EmptyFail_AI_derive_cap?: EmptyFail_AI_derive_cap
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
+  qed
+
+context Arch begin global_naming RISCV64
+
+lemma empty_fail_pt_lookup_from_level[wp]:
+  "empty_fail (pt_lookup_from_level level pt_ptr vptr target_pt_ptr)"
+  apply (induct level arbitrary: pt_ptr)
+   apply (subst pt_lookup_from_level_simps, simp)
+  apply (subst pt_lookup_from_level_simps)
+  apply wpsimp
+  done
+
+crunch (empty_fail) empty_fail[wp, EmptyFail_AI_assms]: maskInterrupt, empty_slot,
+    finalise_cap, preemption_point,
+    cap_swap_for_delete, decode_invocation
+  (simp: Let_def catch_def split_def OR_choiceE_def mk_ef_def option.splits endpoint.splits
+         notification.splits thread_state.splits sum.splits cap.splits arch_cap.splits
+         kernel_object.splits vmpage_size.splits pte.splits bool.splits list.splits)
+
+crunch (empty_fail) empty_fail[wp, EmptyFail_AI_assms]: setRegister, setNextPC
+
+end
+
+global_interpretation EmptyFail_AI_rec_del?: EmptyFail_AI_rec_del
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
+  qed
+
+context Arch begin global_naming RISCV64
+crunch (empty_fail) empty_fail[wp, EmptyFail_AI_assms]:
+  cap_delete, choose_thread
+end
+
+global_interpretation EmptyFail_AI_schedule_unit?: EmptyFail_AI_schedule_unit
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
+  qed
+
+global_interpretation EmptyFail_AI_schedule_det?: EmptyFail_AI_schedule_det
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
+  qed
+
+global_interpretation EmptyFail_AI_schedule?: EmptyFail_AI_schedule
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
+  qed
+
+context Arch begin global_naming RISCV64
+
+crunch (empty_fail) empty_fail[wp]: read_stval
+  (ignore_del: read_stval)
+
+lemma plic_complete_claim_empty_fail[wp, EmptyFail_AI_assms]:
+  "empty_fail (plic_complete_claim irq)"
+  by (clarsimp simp: plic_complete_claim_def)
+
+crunches possible_switch_to, handle_event, activate_thread
+  for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
+  (simp: cap.splits arch_cap.splits split_def invocation_label.splits Let_def
+         kernel_object.splits arch_kernel_obj.splits option.splits pte.splits
+         bool.splits apiobject_type.splits aobject_type.splits notification.splits
+         thread_state.splits endpoint.splits catch_def sum.splits cnode_invocation.splits
+         page_table_invocation.splits page_invocation.splits asid_control_invocation.splits
+         asid_pool_invocation.splits arch_invocation.splits irq_state.splits syscall.splits
+   ignore_del: possible_switch_to)
+
+end
+
+global_interpretation EmptyFail_AI_call_kernel_unit?: EmptyFail_AI_call_kernel_unit
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
+  qed
+
+global_interpretation EmptyFail_AI_call_kernel_det?: EmptyFail_AI_call_kernel_det
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
+  qed
+
+global_interpretation EmptyFail_AI_call_kernel?: EmptyFail_AI_call_kernel
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
+  qed
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
@@ -72,7 +72,7 @@ lemma arch_decode_ARMASIDControlMakePool_empty_fail:
                           split: if_split_asm)
     apply wpsimp
    apply (wpsimp simp: decode_frame_invocation_def)
-  sorry (* FIXME AARCH64
+  sorry (* FIXME AARCH64 VCPU and PageFlush invocations
   apply (wpsimp simp: decode_page_table_invocation_def)
   done *)
 

--- a/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
@@ -14,18 +14,12 @@ context Arch begin global_naming AARCH64
 named_theorems EmptyFail_AI_assms
 
 crunch_ignore (empty_fail)
-  (add: setVSpaceRoot_impl resetTimer_impl
-        addressTranslateS1_impl fpuThreadDeleteOp_impl dsb_impl isb_impl
-        pt_lookup_from_level setIRQTrigger_impl plic_complete_claim_impl
-        set_gic_vcpu_ctrl_hcr_impl setSCTLR_impl setHCR_impl enableFpuEL01_impl
-        writeVCPUHardwareReg_impl check_export_arch_timer_impl invalidateTranslationASID_impl
-        cleanByVA_PoU_impl invalidateTranslationSingle_impl set_gic_vcpu_ctrl_vmcr_impl
-        set_gic_vcpu_ctrl_apr_impl set_gic_vcpu_ctrl_lr_impl get_gic_vcpu_ctrl_lr_impl
-        cleanCacheRange_RAM_impl invalidateCacheRange_RAM_impl cleanCacheRange_PoU_impl
-        invalidateCacheRange_I_impl branchFlushRange_impl)
+  (add: pt_lookup_from_level)
 
 crunch (empty_fail) empty_fail[wp, EmptyFail_AI_assms]:
-  loadWord, load_word_offs, storeWord, getRestartPC, get_mrs
+  load_word_offs, get_mrs
+
+declare loadWord_empty_fail[EmptyFail_AI_assms]
 
 end
 

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -1,0 +1,1387 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchFinalise_AI
+imports Finalise_AI
+begin
+
+context Arch begin
+
+named_theorems Finalise_AI_asms
+
+crunch caps_of_state[wp]: prepare_thread_delete "\<lambda>s. P (caps_of_state s)"
+  (wp: crunch_wps)
+
+declare prepare_thread_delete_caps_of_state [Finalise_AI_asms]
+
+global_naming RISCV64
+
+lemma valid_global_refs_asid_table_udapte [iff]:
+  "valid_global_refs (s\<lparr>arch_state := riscv_asid_table_update f (arch_state s)\<rparr>) =
+  valid_global_refs s"
+  by (simp add: valid_global_refs_def global_refs_def)
+
+lemma nat_to_cref_unat_of_bl':
+  "\<lbrakk> length xs < 64; n = length xs \<rbrakk> \<Longrightarrow>
+   nat_to_cref n (unat (of_bl xs :: machine_word)) = xs"
+  apply (simp add: nat_to_cref_def word_bits_def)
+  apply (rule nth_equalityI)
+   apply simp
+  apply clarsimp
+  apply (subst to_bl_nth)
+   apply (simp add: word_size)
+  apply (simp add: word_size)
+  apply (simp add: test_bit_of_bl rev_nth)
+  apply fastforce
+  done
+
+lemmas nat_to_cref_unat_of_bl = nat_to_cref_unat_of_bl' [OF _ refl]
+
+lemma riscv_global_pt_asid_table_update[simp]:
+  "riscv_global_pt (arch_state s\<lparr>riscv_asid_table := atable\<rparr>) = riscv_global_pt (arch_state s)"
+  by (simp add: riscv_global_pt_def)
+
+lemma equal_kernel_mappings_asid_table_unmap:
+  "equal_kernel_mappings s
+   \<Longrightarrow> equal_kernel_mappings (s\<lparr>arch_state := arch_state s
+                                \<lparr>riscv_asid_table := (asid_table s)(i := None)\<rparr>\<rparr>)"
+  unfolding equal_kernel_mappings_def
+  apply clarsimp
+  apply (erule_tac x=asid in allE)
+  apply (erule_tac x=pt_ptr in allE)
+  apply (clarsimp simp: fun_upd_def)
+  apply (erule impE)
+   subgoal by (clarsimp simp: vspace_for_asid_def in_omonad pool_for_asid_def split: if_splits)
+  apply (clarsimp simp: has_kernel_mappings_def)
+  done
+
+lemma invs_riscv_asid_table_unmap:
+  "invs s \<and> is_aligned base asid_low_bits
+       \<and> tab = riscv_asid_table (arch_state s)
+     \<longrightarrow> invs (s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := tab(asid_high_bits_of base := None)\<rparr>\<rparr>)"
+  apply (clarsimp simp: invs_def valid_state_def valid_arch_caps_def)
+  apply (strengthen valid_asid_map_unmap valid_vspace_objs_unmap_strg
+                    valid_vs_lookup_unmap_strg valid_arch_state_unmap_strg)
+  apply (simp add: valid_irq_node_def valid_kernel_mappings_def)
+  apply (simp add: valid_table_caps_def valid_machine_state_def valid_global_objs_def
+                   valid_asid_pool_caps_def equal_kernel_mappings_asid_table_unmap)
+  done
+
+lemma delete_asid_pool_invs[wp]:
+  "delete_asid_pool base pptr \<lbrace>invs\<rbrace>"
+  unfolding delete_asid_pool_def
+  supply fun_upd_apply[simp del]
+  apply wpsimp
+  apply (strengthen invs_riscv_asid_table_unmap)
+  apply (simp add: asid_low_bits_of_def asid_low_bits_def ucast_zero_is_aligned)
+  done
+
+lemma do_machine_op_pool_for_asid[wp]:
+  "do_machine_op f \<lbrace>\<lambda>s. P (pool_for_asid asid s)\<rbrace>"
+  by (wpsimp simp: pool_for_asid_def)
+
+lemma do_machine_op_vspace_for_asid[wp]:
+  "do_machine_op f \<lbrace>\<lambda>s. P (vspace_for_asid asid s)\<rbrace>"
+  by (wpsimp simp: vspace_for_asid_def obind_def
+             wp: conjI hoare_vcg_all_lift hoare_vcg_imp_lift'
+             split: option.splits)
+
+lemma set_vm_root_pool_for_asid[wp]:
+  "set_vm_root pt \<lbrace>\<lambda>s. P (pool_for_asid asid s)\<rbrace>"
+  by (wpsimp simp: set_vm_root_def wp: get_cap_wp)
+
+lemma set_vm_root_vspace_for_asid[wp]:
+  "set_vm_root pt \<lbrace> \<lambda>s. P (vspace_for_asid asid s) \<rbrace>"
+  by (wpsimp simp: set_vm_root_def wp: get_cap_wp)
+
+lemma clearExMonitor_invs[wp]:
+  "\<lbrace>invs\<rbrace> do_machine_op (hwASIDFlush a) \<lbrace>\<lambda>_. invs\<rbrace>"
+  by (wpsimp wp: dmo_invs
+             simp: hwASIDFlush_def machine_op_lift_def
+                   machine_rest_lift_def in_monad select_f_def)
+
+lemma delete_asid_invs[wp]:
+  "\<lbrace> invs and valid_asid_table and pspace_aligned \<rbrace>delete_asid asid pd \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (simp add: delete_asid_def cong: option.case_cong)
+  apply (wpsimp wp: set_asid_pool_invs_unmap)
+  apply blast
+  done
+
+lemma delete_asid_pool_unmapped[wp]:
+  "\<lbrace>\<lambda>s. True \<rbrace>
+     delete_asid_pool asid poolptr
+   \<lbrace>\<lambda>_ s. pool_for_asid asid s \<noteq> Some poolptr \<rbrace>"
+  unfolding delete_asid_pool_def
+  by (wpsimp simp: pool_for_asid_def)
+
+lemma set_asid_pool_unmap:
+  "\<lbrace>\<lambda>s. pool_for_asid asid s = Some poolptr \<rbrace>
+   set_asid_pool poolptr (pool(asid_low_bits_of asid := None))
+   \<lbrace>\<lambda>rv s. vspace_for_asid asid s = None \<rbrace>"
+  unfolding set_asid_pool_def
+  apply (wpsimp wp: set_object_wp)
+  by (simp add: pool_for_asid_def vspace_for_asid_def vspace_for_pool_def obind_def in_omonad
+         split: option.splits)
+
+lemma delete_asid_unmapped:
+  "\<lbrace>\<lambda>s. vspace_for_asid asid s = Some pt\<rbrace>
+   delete_asid asid pt
+   \<lbrace>\<lambda>_ s. vspace_for_asid asid s = None\<rbrace>"
+  unfolding delete_asid_def
+  apply (simp cong: option.case_cong)
+  apply (wpsimp wp: set_asid_pool_unmap)
+  apply (clarsimp simp: vspace_for_asid_def pool_for_asid_def vspace_for_pool_def
+                        obind_def in_omonad obj_at_def
+                 split: option.splits)
+  done
+
+lemma set_pt_tcb_at:
+  "\<lbrace>\<lambda>s. P (ko_at (TCB tcb) t s)\<rbrace> set_pt a b \<lbrace>\<lambda>_ s. P (ko_at (TCB tcb) t s)\<rbrace>"
+  by (wpsimp simp: set_pt_def obj_at_def wp: set_object_wp)
+
+crunch tcb_at_arch: unmap_page "\<lambda>s. P (ko_at (TCB tcb) t s)"
+    (simp: crunch_simps wp: crunch_wps set_pt_tcb_at ignore: set_object)
+
+lemmas unmap_page_tcb_at = unmap_page_tcb_at_arch
+
+lemma unmap_page_tcb_cap_valid:
+  "\<lbrace>\<lambda>s. tcb_cap_valid cap r s\<rbrace>
+    unmap_page sz asid vaddr pptr
+   \<lbrace>\<lambda>rv s. tcb_cap_valid cap r s\<rbrace>"
+  apply (rule tcb_cap_valid_typ_st)
+    apply wp
+   apply (simp add: pred_tcb_at_def2)
+  apply (wp unmap_page_tcb_at hoare_vcg_ex_lift hoare_vcg_all_lift)+
+  done
+
+
+global_naming Arch
+
+lemma (* replaceable_cdt_update *)[simp,Finalise_AI_asms]:
+  "replaceable (cdt_update f s) = replaceable s"
+  by (fastforce simp: replaceable_def tcb_cap_valid_def
+                      reachable_frame_cap_def reachable_target_def)
+
+lemma (* replaceable_revokable_update *)[simp,Finalise_AI_asms]:
+  "replaceable (is_original_cap_update f s) = replaceable s"
+  by (fastforce simp: replaceable_def is_final_cap'_def2 tcb_cap_valid_def
+                      reachable_frame_cap_def reachable_target_def)
+
+lemma (* replaceable_more_update *) [simp,Finalise_AI_asms]:
+  "replaceable (trans_state f s) sl cap cap' = replaceable s sl cap cap'"
+  by (simp add: replaceable_def reachable_frame_cap_def reachable_target_def)
+
+lemma reachable_target_trans_state[simp]:
+  "reachable_target ref p (trans_state f s) = reachable_target ref p s"
+  by (clarsimp simp: reachable_target_def split_def)
+
+lemma reachable_frame_cap_trans_state[simp]:
+  "reachable_frame_cap cap (trans_state f s) = reachable_frame_cap cap s"
+  by (simp add: reachable_frame_cap_def)
+
+lemmas [Finalise_AI_asms] = obj_refs_obj_ref_of (* used under name obj_ref_ofI *)
+
+lemma (* empty_slot_invs *) [Finalise_AI_asms]:
+  "\<lbrace>\<lambda>s. invs s \<and> cte_wp_at (replaceable s sl cap.NullCap) sl s \<and>
+        emptyable sl s \<and>
+        (info \<noteq> NullCap \<longrightarrow> post_cap_delete_pre info ((caps_of_state s) (sl \<mapsto> NullCap)))\<rbrace>
+     empty_slot sl info
+   \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (simp add: empty_slot_def set_cdt_def bind_assoc cong: if_cong)
+  apply (wp post_cap_deletion_invs)
+        apply (simp add: invs_def valid_state_def valid_mdb_def2)
+        apply (wp replace_cap_valid_pspace set_cap_caps_of_state2
+                  replace_cap_ifunsafe get_cap_wp
+                  set_cap_idle valid_irq_node_typ set_cap_typ_at
+                  set_cap_irq_handlers set_cap_valid_arch_caps
+                  set_cap_cap_refs_respects_device_region_NullCap
+               | simp add: trans_state_update[symmetric]
+                      del: trans_state_update fun_upd_apply
+                      split del: if_split)+
+  apply (clarsimp simp: is_final_cap'_def2 simp del: fun_upd_apply)
+  apply (clarsimp simp: conj_comms invs_def valid_state_def valid_mdb_def2)
+  apply (subgoal_tac "mdb_empty_abs s")
+   prefer 2
+   apply (rule mdb_empty_abs.intro)
+   apply (rule vmdb_abs.intro)
+   apply (simp add: valid_mdb_def swp_def cte_wp_at_caps_of_state conj_comms)
+  apply (clarsimp simp: untyped_mdb_def mdb_empty_abs.descendants mdb_empty_abs.no_mloop_n
+                        valid_pspace_def cap_range_def)
+  apply (clarsimp simp: untyped_inc_def mdb_empty_abs.descendants mdb_empty_abs.no_mloop_n)
+  apply (simp add: ut_revocable_def cur_tcb_def valid_irq_node_def
+                   no_cap_to_obj_with_diff_ref_Null)
+  apply (rule conjI)
+   apply (clarsimp simp: cte_wp_at_cte_at)
+  apply (rule conjI)
+   apply (clarsimp simp: valid_arch_mdb_def)
+  apply (rule conjI)
+   apply (clarsimp simp: irq_revocable_def)
+  apply (rule conjI)
+   apply (clarsimp simp: reply_master_revocable_def)
+  apply (thin_tac "info \<noteq> NullCap \<longrightarrow> P info" for P)
+  apply (rule conjI)
+   apply (clarsimp simp: valid_machine_state_def)
+  apply (rule conjI)
+   apply (clarsimp simp:descendants_inc_def mdb_empty_abs.descendants)
+  apply (rule conjI)
+   apply (clarsimp simp: reply_mdb_def)
+   apply (rule conjI)
+    apply (unfold reply_caps_mdb_def)[1]
+    apply (rule allEI, assumption)
+    apply (fold reply_caps_mdb_def)[1]
+    apply (case_tac "sl = ptr", simp)
+    apply (simp add: fun_upd_def split del: if_split del: split_paired_Ex)
+    apply (erule allEI, rule impI, erule(1) impE)
+    apply (erule exEI)
+    apply (simp, rule ccontr)
+    apply (erule(5) emptyable_no_reply_cap)
+    apply simp
+   apply (unfold reply_masters_mdb_def)[1]
+   apply (elim allEI)
+   apply (clarsimp simp: mdb_empty_abs.descendants)
+  apply (rule conjI)
+   apply (simp add: valid_ioc_def)
+  apply (rule conjI)
+   apply (clarsimp simp: tcb_cap_valid_def
+                  dest!: emptyable_valid_NullCapD)
+  apply (rule conjI)
+   apply (clarsimp simp: mdb_cte_at_def cte_wp_at_caps_of_state)
+   apply (cases sl)
+   apply (rule conjI, clarsimp)
+    apply (subgoal_tac "cdt s \<Turnstile> (ab,bb) \<rightarrow> (ab,bb)")
+     apply (simp add: no_mloop_def)
+    apply (rule r_into_trancl)
+    apply (simp add: cdt_parent_of_def)
+   apply fastforce
+  apply (clarsimp simp: cte_wp_at_caps_of_state replaceable_def
+                        reachable_frame_cap_def reachable_target_def
+                   del: allI)
+  apply (case_tac "is_final_cap' cap s")
+   apply auto[1]
+  apply (simp add: is_final_cap'_def2 cte_wp_at_caps_of_state)
+  by fastforce
+
+lemma dom_tcb_cap_cases_lt_ARCH [Finalise_AI_asms]:
+  "dom tcb_cap_cases = {xs. length xs = 3 \<and> unat (of_bl xs :: machine_word) < 5}"
+  apply (rule set_eqI, rule iffI)
+   apply clarsimp
+   apply (simp add: tcb_cap_cases_def tcb_cnode_index_def to_bl_1 split: if_split_asm)
+  apply clarsimp
+  apply (frule tcb_cap_cases_lt)
+  apply (clarsimp simp: nat_to_cref_unat_of_bl')
+  done
+
+lemma (* unbind_notification_final *) [wp,Finalise_AI_asms]:
+  "\<lbrace>is_final_cap' cap\<rbrace> unbind_notification t \<lbrace> \<lambda>rv. is_final_cap' cap\<rbrace>"
+  unfolding unbind_notification_def
+  apply (wp final_cap_lift thread_set_caps_of_state_trivial hoare_drop_imps
+       | wpc | simp add: tcb_cap_cases_def)+
+  done
+
+lemma arch_thread_set_caps_of_state[wp]:
+  "arch_thread_set v t \<lbrace>\<lambda>s. P (caps_of_state s) \<rbrace>"
+  apply (wpsimp simp: arch_thread_set_def wp: set_object_wp)
+  apply (clarsimp simp: fun_upd_def)
+  apply (frule get_tcb_ko_atD)
+  apply (auto simp: caps_of_state_after_update obj_at_def tcb_cap_cases_def)
+  done
+
+lemma arch_thread_set_final_cap[wp]:
+  "\<lbrace>is_final_cap' cap\<rbrace> arch_thread_set v t \<lbrace>\<lambda>rv. is_final_cap' cap\<rbrace>"
+  by (wpsimp simp: is_final_cap'_def2 cte_wp_at_caps_of_state)
+
+lemma arch_thread_get_final_cap[wp]:
+  "\<lbrace>is_final_cap' cap\<rbrace> arch_thread_get v t \<lbrace>\<lambda>rv. is_final_cap' cap\<rbrace>"
+  apply (simp add: arch_thread_get_def is_final_cap'_def2 cte_wp_at_caps_of_state, wp)
+  apply auto
+  done
+
+lemma prepare_thread_delete_final[wp]:
+  "\<lbrace>is_final_cap' cap\<rbrace> prepare_thread_delete t \<lbrace> \<lambda>rv. is_final_cap' cap\<rbrace>"
+  unfolding prepare_thread_delete_def by wp
+
+lemma length_and_unat_of_bl_length:
+  "(length xs = x \<and> unat (of_bl xs :: 'a::len word) < 2 ^ x) = (length xs = x)"
+  by (auto simp: unat_of_bl_length)
+
+lemma (* finalise_cap_cases1 *)[Finalise_AI_asms]:
+  "\<lbrace>\<lambda>s. final \<longrightarrow> is_final_cap' cap s
+         \<and> cte_wp_at ((=) cap) slot s\<rbrace>
+     finalise_cap cap final
+   \<lbrace>\<lambda>rv s. fst rv = cap.NullCap
+         \<and> snd rv = (if final then cap_cleanup_opt cap else NullCap)
+         \<and> (snd rv \<noteq> NullCap \<longrightarrow> is_final_cap' cap s)
+     \<or>
+       is_zombie (fst rv) \<and> is_final_cap' cap s
+        \<and> snd rv = NullCap
+        \<and> appropriate_cte_cap (fst rv) = appropriate_cte_cap cap
+        \<and> cte_refs (fst rv) = cte_refs cap
+        \<and> gen_obj_refs (fst rv) = gen_obj_refs cap
+        \<and> obj_size (fst rv) = obj_size cap
+        \<and> fst_cte_ptrs (fst rv) = fst_cte_ptrs cap
+        \<and> vs_cap_ref cap = None\<rbrace>"
+  apply (cases cap, simp_all split del: if_split cong: if_cong)
+            apply ((wp suspend_final_cap[where sl=slot]
+                      deleting_irq_handler_final[where slot=slot]
+                      | simp add: o_def is_cap_simps fst_cte_ptrs_def
+                                  dom_tcb_cap_cases_lt_ARCH tcb_cnode_index_def
+                                  can_fast_finalise_def length_and_unat_of_bl_length
+                                  appropriate_cte_cap_def gen_obj_refs_def
+                                  vs_cap_ref_def cap_cleanup_opt_def
+                      | intro impI TrueI ext conjI)+)[11]
+  apply (simp add: arch_finalise_cap_def split del: if_split)
+  apply (wpsimp simp: cap_cleanup_opt_def arch_cap_cleanup_opt_def)
+  done
+
+crunch typ_at_arch [wp]: arch_thread_set "\<lambda>s. P (typ_at T p s)"
+  (wp: crunch_wps set_object_typ_at)
+
+crunch typ_at[wp,Finalise_AI_asms]: arch_finalise_cap "\<lambda>s. P (typ_at T p s)"
+  (wp: crunch_wps simp: crunch_simps unless_def assertE_def
+        ignore: maskInterrupt set_object)
+
+crunch typ_at[wp,Finalise_AI_asms]: prepare_thread_delete "\<lambda>s. P (typ_at T p s)"
+
+crunch tcb_at[wp]: arch_thread_set "\<lambda>s. tcb_at p s"
+  (ignore: set_object)
+
+crunch tcb_at[wp]: arch_thread_get "\<lambda>s. tcb_at p s"
+
+crunch tcb_at[wp]: prepare_thread_delete "\<lambda>s. tcb_at p s"
+
+lemma (* finalise_cap_new_valid_cap *)[wp,Finalise_AI_asms]:
+  "\<lbrace>valid_cap cap\<rbrace> finalise_cap cap x \<lbrace>\<lambda>rv. valid_cap (fst rv)\<rbrace>"
+  apply (cases cap; simp)
+            apply (wp suspend_valid_cap prepare_thread_delete_typ_at
+                     | simp add: o_def valid_cap_def cap_aligned_def
+                                 valid_cap_Null_ext
+                           split del: if_split
+                     | clarsimp | rule conjI)+
+  (* ArchObjectCap *)
+  apply (wpsimp wp: o_def valid_cap_def cap_aligned_def
+                 split_del: if_split
+         | clarsimp simp: arch_finalise_cap_def)+
+  done
+
+crunch inv[wp]: arch_thread_get "P"
+
+lemma hoare_split: "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>r. Q r and Q' r\<rbrace>"
+  by (auto simp: valid_def)
+
+sublocale
+  arch_thread_set: non_aobj_non_cap_non_mem_op "arch_thread_set f v"
+  by (unfold_locales;
+        ((wpsimp)?;
+        wpsimp wp: set_object_non_arch simp: non_arch_objs arch_thread_set_def)?)
+
+(* arch_thread_set invariants *)
+lemma arch_thread_set_cur_tcb[wp]: "\<lbrace>cur_tcb\<rbrace> arch_thread_set p v \<lbrace>\<lambda>_. cur_tcb\<rbrace>"
+  unfolding cur_tcb_def[abs_def]
+  apply (rule hoare_lift_Pf [where f=cur_thread])
+   apply (simp add: tcb_at_typ)
+   apply wp
+  apply (simp add: arch_thread_set_def)
+  apply (wp hoare_drop_imp)
+  apply simp
+  done
+
+lemma cte_wp_at_update_some_tcb:
+  "\<lbrakk>kheap s v = Some (TCB tcb) ; tcb_cnode_map tcb = tcb_cnode_map (f tcb)\<rbrakk>
+  \<Longrightarrow> cte_wp_at P p (s\<lparr>kheap := kheap s (v \<mapsto> TCB (f tcb))\<rparr>) = cte_wp_at P p s"
+  apply (clarsimp simp: cte_wp_at_cases2 dest!: get_tcb_SomeD)
+  done
+
+lemma arch_thread_set_cap_refs_respects_device_region[wp]:
+  "\<lbrace>cap_refs_respects_device_region\<rbrace>
+     arch_thread_set p v
+   \<lbrace>\<lambda>s. cap_refs_respects_device_region\<rbrace>"
+  apply (simp add: arch_thread_set_def set_object_def get_object_def)
+  apply wp
+  apply (clarsimp dest!: get_tcb_SomeD simp del: fun_upd_apply)
+  apply (subst get_tcb_rev, assumption, subst option.sel)+
+  apply (subst cap_refs_respects_region_cong)
+    prefer 3
+    apply assumption
+   apply (rule cte_wp_caps_of_lift)
+   apply (subst arch_tcb_update_aux3)
+   apply (rule_tac cte_wp_at_update_some_tcb, assumption)
+   apply (simp add: tcb_cnode_map_def)+
+  done
+
+lemma arch_thread_set_pspace_respects_device_region[wp]:
+  "\<lbrace>pspace_respects_device_region\<rbrace>
+     arch_thread_set p v
+   \<lbrace>\<lambda>s. pspace_respects_device_region\<rbrace>"
+  apply (simp add: arch_thread_set_def)
+  apply (wp get_object_wp set_object_pspace_respects_device_region)
+  apply clarsimp
+  done
+
+lemma arch_thread_set_cap_refs_in_kernel_window[wp]:
+  "\<lbrace>cap_refs_in_kernel_window\<rbrace> arch_thread_set p v \<lbrace>\<lambda>_. cap_refs_in_kernel_window\<rbrace>"
+  unfolding cap_refs_in_kernel_window_def[abs_def]
+  apply (rule hoare_lift_Pf [where f="\<lambda>s. not_kernel_window s"])
+  apply (rule valid_refs_cte_lift)
+  apply wp+
+  done
+
+crunch valid_irq_states[wp]: arch_thread_set valid_irq_states
+  (wp: crunch_wps simp: crunch_simps)
+
+crunch interrupt_state[wp]: arch_thread_set "\<lambda>s. P (interrupt_states s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemmas arch_thread_set_valid_irq_handlers[wp] = valid_irq_handlers_lift[OF arch_thread_set.caps arch_thread_set_interrupt_state]
+
+crunch interrupt_irq_node[wp]: arch_thread_set "\<lambda>s. P (interrupt_irq_node s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemmas arch_thread_set_valid_irq_node[wp] = valid_irq_node_typ[OF arch_thread_set_typ_at_arch arch_thread_set_interrupt_irq_node]
+
+crunch idle_thread[wp]: arch_thread_set "\<lambda>s. P (idle_thread s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma arch_thread_set_valid_global_refs[wp]:
+  "\<lbrace>valid_global_refs\<rbrace> arch_thread_set p v \<lbrace>\<lambda>rv. valid_global_refs\<rbrace>"
+  by (rule valid_global_refs_cte_lift) wp+
+
+lemma arch_thread_set_valid_reply_masters[wp]:
+  "\<lbrace>valid_reply_masters\<rbrace> arch_thread_set p v \<lbrace>\<lambda>rv. valid_reply_masters\<rbrace>"
+  by (rule valid_reply_masters_cte_lift) wp
+
+lemma arch_thread_set_pred_tcb_at[wp_unsafe]:
+  "\<lbrace>pred_tcb_at proj P t and K (proj_not_field proj tcb_arch_update)\<rbrace>
+     arch_thread_set p v
+   \<lbrace>\<lambda>rv. pred_tcb_at proj P t\<rbrace>"
+  apply (simp add: arch_thread_set_def set_object_def get_object_def)
+  apply wp
+  apply (clarsimp simp: pred_tcb_at_def obj_at_def get_tcb_rev
+                  dest!: get_tcb_SomeD)
+  done
+
+lemma arch_thread_set_valid_reply_caps[wp]:
+  "\<lbrace>valid_reply_caps\<rbrace> arch_thread_set p v \<lbrace>\<lambda>rv. valid_reply_caps\<rbrace>"
+  by (rule valid_reply_caps_st_cte_lift)
+     (wpsimp wp: arch_thread_set_pred_tcb_at)+
+
+lemma arch_thread_set_if_unsafe_then_cap[wp]:
+  "\<lbrace>if_unsafe_then_cap\<rbrace> arch_thread_set p v \<lbrace>\<lambda>rv. if_unsafe_then_cap\<rbrace>"
+  apply (simp add: arch_thread_set_def)
+  apply (wp get_object_wp set_object_ifunsafe)
+  apply (clarsimp split: kernel_object.splits arch_kernel_obj.splits
+                  dest!: get_tcb_SomeD)
+  apply (subst get_tcb_rev)
+  apply assumption
+  apply simp
+  apply (subst get_tcb_rev, assumption, simp)+
+  apply (clarsimp simp: obj_at_def tcb_cap_cases_def)
+  done
+
+lemma arch_thread_set_only_idle[wp]:
+  "\<lbrace>only_idle\<rbrace> arch_thread_set p v \<lbrace>\<lambda>rv. only_idle\<rbrace>"
+  by (wpsimp wp: only_idle_lift set_asid_pool_typ_at
+                 arch_thread_set_pred_tcb_at)
+
+lemma arch_thread_set_valid_idle[wp]:
+  "arch_thread_set f t \<lbrace>valid_idle\<rbrace>"
+  by (wpsimp simp: arch_thread_set_def set_object_def get_object_def valid_idle_def
+                   valid_arch_idle_def get_tcb_def pred_tcb_at_def obj_at_def pred_neg_def)
+
+lemma arch_thread_set_valid_ioc[wp]:
+  "\<lbrace>valid_ioc\<rbrace> arch_thread_set p v \<lbrace>\<lambda>rv. valid_ioc\<rbrace>"
+  apply (simp add: arch_thread_set_def set_object_def get_object_def)
+  apply (wp set_object_valid_ioc_caps)
+  apply (clarsimp simp add: valid_ioc_def
+                  simp del: fun_upd_apply
+                  split: kernel_object.splits arch_kernel_obj.splits
+                  dest!: get_tcb_SomeD)
+  apply (subst get_tcb_rev, assumption, subst option.sel)+
+  apply (subst arch_tcb_update_aux3)
+  apply (subst cte_wp_at_update_some_tcb,assumption)
+   apply (clarsimp simp: tcb_cnode_map_def)+
+  done
+
+lemma arch_thread_set_valid_mdb[wp]: "\<lbrace>valid_mdb\<rbrace> arch_thread_set p v \<lbrace>\<lambda>rv. valid_mdb\<rbrace>"
+  by (wpsimp wp: valid_mdb_lift get_object_wp simp: arch_thread_set_def set_object_def)
+
+lemma arch_thread_set_zombies_final[wp]: "\<lbrace>zombies_final\<rbrace> arch_thread_set p v \<lbrace>\<lambda>rv. zombies_final\<rbrace>"
+  apply (simp add: arch_thread_set_def)
+  apply (wp get_object_wp set_object_zombies)
+  apply (clarsimp split: kernel_object.splits arch_kernel_obj.splits
+                  dest!: get_tcb_SomeD)
+  apply (subst get_tcb_rev)
+  apply assumption
+  apply simp
+  apply (subst get_tcb_rev, assumption, simp)+
+  apply (clarsimp simp: obj_at_def tcb_cap_cases_def)
+  done
+
+lemma arch_thread_set_pspace_in_kernel_window[wp]:
+  "\<lbrace>pspace_in_kernel_window\<rbrace> arch_thread_set f v \<lbrace>\<lambda>_.pspace_in_kernel_window\<rbrace>"
+  by (rule pspace_in_kernel_window_atyp_lift, wp+)
+
+lemma arch_thread_set_pspace_distinct[wp]: "\<lbrace>pspace_distinct\<rbrace>arch_thread_set f v\<lbrace>\<lambda>_. pspace_distinct\<rbrace>"
+  apply (simp add: arch_thread_set_def)
+  apply (wp set_object_distinct)
+  apply (clarsimp simp: get_object_def obj_at_def
+                  dest!: get_tcb_SomeD)
+  done
+
+lemma arch_thread_set_pspace_aligned[wp]:
+  "\<lbrace>pspace_aligned\<rbrace> arch_thread_set f v \<lbrace>\<lambda>_. pspace_aligned\<rbrace>"
+  apply (simp add: arch_thread_set_def)
+  apply (wp set_object_aligned)
+  apply (clarsimp simp: obj_at_def get_object_def
+                  dest!: get_tcb_SomeD)
+  done
+
+lemma arch_thread_set_valid_objs_context[wp]:
+  "arch_thread_set (tcb_context_update f) v \<lbrace>valid_objs\<rbrace>"
+  apply (simp add: arch_thread_set_def)
+  apply (wp set_object_valid_objs)
+  apply (clarsimp simp: Ball_def obj_at_def valid_objs_def dest!: get_tcb_SomeD)
+  apply (erule_tac x=v in allE)
+  apply (clarsimp simp: dom_def)
+  apply (subst get_tcb_rev, assumption, subst option.sel)+
+  apply (clarsimp simp:valid_obj_def valid_tcb_def tcb_cap_cases_def)
+  done
+
+lemma sym_refs_update_some_tcb:
+  "\<lbrakk>kheap s v = Some (TCB tcb) ; refs_of (TCB tcb) = refs_of (TCB (f tcb))\<rbrakk>
+  \<Longrightarrow> sym_refs (state_refs_of (s\<lparr>kheap := kheap s (v \<mapsto> TCB (f tcb))\<rparr>)) = sym_refs (state_refs_of s)"
+  apply (rule_tac f=sym_refs in arg_cong)
+  apply (rule all_ext)
+  apply (clarsimp simp: sym_refs_def state_refs_of_def)
+  done
+
+lemma arch_thread_sym_refs[wp]:
+  "\<lbrace>\<lambda>s. sym_refs (state_refs_of s)\<rbrace> arch_thread_set f p \<lbrace>\<lambda>rv s. sym_refs (state_refs_of s)\<rbrace>"
+  apply (simp add: arch_thread_set_def set_object_def get_object_def)
+  apply wp
+  apply (clarsimp simp del: fun_upd_apply dest!: get_tcb_SomeD)
+  apply (subst get_tcb_rev, assumption, subst option.sel)+
+  apply (subst arch_tcb_update_aux3)
+  apply (subst sym_refs_update_some_tcb[where f="tcb_arch_update f"])
+    apply assumption
+   apply (clarsimp simp: refs_of_def)
+  apply assumption
+  done
+
+lemma as_user_unlive_hyp[wp]:
+  "\<lbrace>obj_at (Not \<circ> hyp_live) vr\<rbrace> as_user t f \<lbrace>\<lambda>_. obj_at (Not \<circ> hyp_live) vr\<rbrace>"
+  unfolding as_user_def
+  apply (wpsimp wp: set_object_wp)
+  by (clarsimp simp: obj_at_def hyp_live_def arch_tcb_context_set_def)
+
+lemma as_user_unlive0[wp]:
+  "\<lbrace>obj_at (Not \<circ> live0) vr\<rbrace> as_user t f \<lbrace>\<lambda>_. obj_at (Not \<circ> live0) vr\<rbrace>"
+  unfolding as_user_def
+  apply (wpsimp wp: set_object_wp)
+  by (clarsimp simp: obj_at_def arch_tcb_context_set_def dest!: get_tcb_SomeD)
+
+lemma o_def_not: "obj_at (\<lambda>a. \<not> P a) t s =  obj_at (Not o P) t s"
+  by (simp add: obj_at_def)
+
+lemma arch_thread_set_if_live_then_nonz_cap':
+  "\<forall>y. hyp_live (TCB (y\<lparr>tcb_arch := p (tcb_arch y)\<rparr>)) \<longrightarrow> hyp_live (TCB y) \<Longrightarrow>
+   \<lbrace>if_live_then_nonz_cap\<rbrace> arch_thread_set p v \<lbrace>\<lambda>rv. if_live_then_nonz_cap\<rbrace>"
+  apply (simp add: arch_thread_set_def)
+  apply (wp set_object_iflive)
+  apply (clarsimp simp: ex_nonz_cap_to_def if_live_then_nonz_cap_def
+                  dest!: get_tcb_SomeD)
+  apply (subst get_tcb_rev, assumption, subst option.sel)+
+  apply (clarsimp simp: obj_at_def tcb_cap_cases_def)
+  apply (erule_tac x=v in allE, drule mp; assumption?)
+  apply (clarsimp simp: live_def)
+  done
+
+lemma same_caps_tcb_arch_update[simp]:
+  "same_caps (TCB (tcb_arch_update f tcb)) = same_caps (TCB tcb)"
+  by (rule ext) (clarsimp simp: tcb_cap_cases_def)
+
+lemma as_user_valid_irq_node[wp]:
+  "\<lbrace>valid_irq_node\<rbrace> as_user t f \<lbrace>\<lambda>_. valid_irq_node\<rbrace>"
+  unfolding as_user_def
+  apply (wpsimp wp: set_object_wp)
+  apply (clarsimp simp: valid_irq_node_def obj_at_def is_cap_table dest!: get_tcb_SomeD)
+  by (metis kernel_object.distinct(1) option.inject)
+
+lemma dmo_machine_state_lift:
+  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>s. P (machine_state s)\<rbrace> do_machine_op f \<lbrace>\<lambda>rv s. Q rv (machine_state s)\<rbrace>"
+  unfolding do_machine_op_def by wpsimp (erule use_valid; assumption)
+
+lemma as_user_valid_irq_states[wp]:
+  "\<lbrace>valid_irq_states\<rbrace> as_user t f \<lbrace>\<lambda>rv. valid_irq_states\<rbrace>"
+  unfolding as_user_def
+  by (wpsimp wp: set_object_wp simp: obj_at_def valid_irq_states_def)
+
+lemma as_user_ioc[wp]:
+  "\<lbrace>\<lambda>s. P (is_original_cap s)\<rbrace> as_user t f \<lbrace>\<lambda>rv s. P (is_original_cap s)\<rbrace>"
+  unfolding as_user_def by (wpsimp wp: set_object_wp)
+
+lemma as_user_valid_ioc[wp]:
+  "\<lbrace>valid_ioc\<rbrace> as_user t f \<lbrace>\<lambda>rv. valid_ioc\<rbrace>"
+  unfolding valid_ioc_def by (wpsimp wp: hoare_vcg_imp_lift hoare_vcg_all_lift)
+
+lemma arch_finalise_cap_invs' [wp,Finalise_AI_asms]:
+  "\<lbrace>invs and valid_cap (ArchObjectCap cap)\<rbrace>
+     arch_finalise_cap cap final
+   \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (simp add: arch_finalise_cap_def)
+  apply (rule hoare_pre)
+   apply (wp unmap_page_invs | wpc)+
+  apply (clarsimp simp: valid_cap_def cap_aligned_def)
+  apply (auto simp: mask_def vmsz_aligned_def wellformed_mapdata_def)
+  done
+
+lemma as_user_unlive[wp]:
+  "\<lbrace>obj_at (Not \<circ> live) vr\<rbrace> as_user t f \<lbrace>\<lambda>_. obj_at (Not \<circ> live) vr\<rbrace>"
+  unfolding as_user_def
+  apply (wpsimp wp: set_object_wp)
+  by (clarsimp simp: obj_at_def live_def hyp_live_def arch_tcb_context_set_def dest!: get_tcb_SomeD)
+
+lemma obj_at_not_live_valid_arch_cap_strg [Finalise_AI_asms]:
+  "(s \<turnstile> ArchObjectCap cap \<and> aobj_ref cap = Some r)
+        \<longrightarrow> obj_at (\<lambda>ko. \<not> live ko) r s"
+  by (clarsimp simp: valid_cap_def obj_at_def valid_arch_cap_ref_def
+                     a_type_arch_live live_def hyp_live_def
+              split: arch_cap.split_asm if_splits)
+
+crunches set_vm_root
+  for ptes_of[wp]: "\<lambda>s. P (ptes_of s)"
+  and asid_pools_of[wp]: "\<lambda>s. P (asid_pools_of s)"
+  and asid_table[wp]: "\<lambda>s. P (asid_table s)"
+  (simp: crunch_simps)
+
+lemma set_vm_root_vs_lookup_target[wp]:
+  "set_vm_root tcb \<lbrace>\<lambda>s. P (vs_lookup_target level asid vref s)\<rbrace>"
+  by (wpsimp wp: vs_lookup_target_lift)
+
+lemma vs_lookup_target_no_asid_pool:
+  "\<lbrakk>asid_pool_at ptr s; valid_vspace_objs s; valid_asid_table s; pspace_aligned s;
+    vs_lookup_target level asid 0 s = Some (level, ptr)\<rbrakk>
+   \<Longrightarrow> False"
+  apply (clarsimp simp: vs_lookup_target_def split: if_split_asm)
+   apply (clarsimp simp: vs_lookup_slot_def vs_lookup_table_def obj_at_def)
+   apply (frule (1) pool_for_asid_validD, clarsimp)
+   apply (subst (asm) pool_for_asid_vs_lookup[symmetric, where vref=0 and level=asid_pool_level, simplified])
+   apply (drule (1) valid_vspace_objsD; simp add: in_omonad)
+   apply (fastforce simp: vspace_for_pool_def in_omonad obj_at_def ran_def)
+  apply (rename_tac pt_ptr)
+  apply (clarsimp simp: vs_lookup_slot_def obj_at_def split: if_split_asm)
+  apply (clarsimp simp: in_omonad)
+  apply (frule (1) vs_lookup_table_is_aligned; clarsimp?)
+  apply (clarsimp simp: ptes_of_def)
+  apply (drule (1) valid_vspace_objsD; simp add: in_omonad)
+  apply (simp add: is_aligned_mask)
+  apply (drule_tac x=0 in bspec)
+   apply (clarsimp simp: kernel_mapping_slots_def pptr_base_def pptrBase_def pt_bits_left_def
+                         bit_simps level_defs canonical_bit_def)
+  apply (clarsimp simp: pte_ref_def data_at_def obj_at_def split: pte.splits)
+  done
+
+
+lemma delete_asid_pool_not_target[wp]:
+  "\<lbrace>asid_pool_at ptr and valid_vspace_objs and valid_asid_table and pspace_aligned\<rbrace>
+   delete_asid_pool asid ptr
+   \<lbrace>\<lambda>rv s. vs_lookup_target level asid 0 s \<noteq> Some (level, ptr)\<rbrace>"
+  unfolding delete_asid_pool_def
+  supply fun_upd_apply[simp del]
+  apply wpsimp
+  apply (rule conjI; clarsimp)
+   apply (frule vs_lookup_target_no_asid_pool[of _ _ level asid]; assumption?)
+   apply (erule vs_lookup_target_clear_asid_table)
+  apply (erule (4) vs_lookup_target_no_asid_pool)
+  done
+
+lemma delete_asid_pool_not_reachable[wp]:
+  "\<lbrace>asid_pool_at ptr and valid_vspace_objs and valid_asid_table and pspace_aligned\<rbrace>
+   delete_asid_pool asid ptr
+   \<lbrace>\<lambda>rv s. \<not> reachable_target (asid, 0) ptr s\<rbrace>"
+  unfolding reachable_target_def by (wpsimp wp: hoare_vcg_all_lift)
+
+lemmas reachable_frame_cap_simps =
+  reachable_frame_cap_def[unfolded is_frame_cap_def arch_cap_fun_lift_def, split_simps cap.split]
+
+lemma vs_lookup_slot_non_PageTablePTE:
+  "\<lbrakk> ptes_of s p \<noteq> None; ptes_of s' = ptes_of s(p \<mapsto> pte); \<not> is_PageTablePTE pte;
+     asid_pools_of s' = asid_pools_of s;
+     asid_table s' = asid_table s; valid_asid_table s; pspace_aligned s\<rbrakk>
+  \<Longrightarrow> vs_lookup_slot level asid vref s' =
+      (if \<exists>level'. vs_lookup_slot level' asid vref s = Some (level', p) \<and> level < level'
+       then vs_lookup_slot (level_of_slot asid vref p s) asid vref s
+       else vs_lookup_slot level asid vref s)"
+  apply clarsimp
+  apply (rule conjI; clarsimp;
+           (simp (no_asm) add: vs_lookup_slot_def obind_def,
+            (subst vs_lookup_non_PageTablePTE; simp),
+            fastforce split: option.splits))
+  done
+
+lemma unmap_page_table_pool_for_asid[wp]:
+  "unmap_page_table asid vref pt \<lbrace>\<lambda>s. P (pool_for_asid asid s)\<rbrace>"
+  unfolding unmap_page_table_def by (wpsimp simp: pool_for_asid_def)
+
+lemma unmap_page_table_unreachable:
+  "\<lbrace> pt_at pt and valid_asid_table and valid_vspace_objs and pspace_aligned
+     and unique_table_refs and valid_vs_lookup and (\<lambda>s. valid_caps (caps_of_state s) s)
+     and K (0 < asid \<and> vref \<in> user_region)
+     and (\<lambda>s. vspace_for_asid asid s \<noteq> Some pt) \<rbrace>
+   unmap_page_table asid vref pt
+   \<lbrace>\<lambda>_ s. \<not> reachable_target (asid, vref) pt s\<rbrace>"
+  unfolding reachable_target_def
+  apply (wpsimp wp: hoare_vcg_all_lift unmap_page_table_not_target)
+  apply (drule (1) pool_for_asid_validD)
+  apply (clarsimp simp: obj_at_def in_omonad)
+  done
+
+lemma unmap_page_unreachable:
+  "\<lbrace> data_at pgsz pptr and valid_asid_table and valid_vspace_objs and pspace_aligned
+     and unique_table_refs and valid_vs_lookup and (\<lambda>s. valid_caps (caps_of_state s) s)
+     and K (0 < asid \<and> vref \<in> user_region) \<rbrace>
+   unmap_page pgsz asid vref pptr
+   \<lbrace>\<lambda>rv s. \<not> reachable_target (asid, vref) pptr s\<rbrace>"
+  unfolding reachable_target_def
+  apply (wpsimp wp: hoare_vcg_all_lift unmap_page_not_target)
+  apply (drule (1) pool_for_asid_validD)
+  apply (clarsimp simp: obj_at_def data_at_def in_omonad)
+  done
+
+lemma set_asid_pool_pool_for_asid[wp]:
+  "set_asid_pool ptr pool \<lbrace>\<lambda>s. P (pool_for_asid asid' s)\<rbrace>"
+  unfolding pool_for_asid_def by wpsimp
+
+lemma delete_asid_pool_for_asid[wp]:
+  "delete_asid asid pt \<lbrace>\<lambda>s. P (pool_for_asid asid' s)\<rbrace>"
+  unfolding delete_asid_def by wpsimp
+
+lemma delete_asid_no_vs_lookup_target:
+  "\<lbrace>\<lambda>s. vspace_for_asid asid s = Some pt\<rbrace>
+   delete_asid asid pt
+   \<lbrace>\<lambda>rv s. vs_lookup_target level asid vref s \<noteq> Some (level, pt)\<rbrace>"
+  apply (rule hoare_assume_pre)
+  apply (prop_tac "0 < asid")
+   apply (clarsimp simp: vspace_for_asid_def)
+  apply (rule hoare_strengthen_post, rule delete_asid_unmapped)
+  apply (clarsimp simp: vs_lookup_target_def split: if_split_asm)
+   apply (clarsimp simp: vs_lookup_slot_def vs_lookup_table_def split: if_split_asm)
+   apply (clarsimp simp: vspace_for_asid_def obind_def)
+  apply (clarsimp simp: vs_lookup_slot_def vs_lookup_table_def split: if_split_asm)
+  apply (clarsimp simp: vspace_for_asid_def obind_def)
+  done
+
+lemma delete_asid_unreachable:
+  "\<lbrace>\<lambda>s. vspace_for_asid asid s = Some pt \<and> pt_at pt s \<and> valid_asid_table s \<rbrace>
+   delete_asid asid pt
+   \<lbrace>\<lambda>_ s. \<not> reachable_target (asid, vref) pt s\<rbrace>"
+  unfolding reachable_target_def
+  apply (wpsimp wp: hoare_vcg_all_lift delete_asid_no_vs_lookup_target)
+  apply (drule (1) pool_for_asid_validD)
+  apply (clarsimp simp: obj_at_def in_omonad)
+  done
+
+lemma arch_finalise_cap_replaceable:
+  notes strg = tcb_cap_valid_imp_NullCap
+               obj_at_not_live_valid_arch_cap_strg[where cap=cap]
+  notes simps = replaceable_def and_not_not_or_imp
+                is_cap_simps vs_cap_ref_def
+                no_cap_to_obj_with_diff_ref_Null o_def
+                reachable_frame_cap_simps
+  notes wps = hoare_drop_imp[where R="%_. is_final_cap' cap" for cap]
+              valid_cap_typ
+              unmap_page_unreachable unmap_page_table_unreachable
+              delete_asid_unreachable
+  shows
+    "\<lbrace>\<lambda>s. s \<turnstile> ArchObjectCap cap \<and>
+          x = is_final_cap' (ArchObjectCap cap) s \<and>
+          pspace_aligned s \<and> valid_vspace_objs s \<and> valid_objs s \<and> valid_asid_table s \<and>
+          valid_arch_caps s\<rbrace>
+     arch_finalise_cap cap x
+     \<lbrace>\<lambda>rv s. replaceable s sl (fst rv) (ArchObjectCap cap)\<rbrace>"
+  apply (simp add: arch_finalise_cap_def valid_arch_caps_def)
+  apply (wpsimp simp: simps valid_objs_caps wp: wps | strengthen strg)+
+  apply (rule conjI, clarsimp)
+   apply (clarsimp simp: valid_cap_def)
+  apply (rule conjI; clarsimp)
+   apply (rule conjI; clarsimp simp: valid_cap_def wellformed_mapdata_def data_at_def split: if_split_asm)
+  apply (rule conjI; clarsimp)
+  apply (clarsimp simp: valid_cap_def wellformed_mapdata_def cap_aligned_def)
+  done
+
+
+global_naming Arch
+lemma (* deleting_irq_handler_slot_not_irq_node *)[Finalise_AI_asms]:
+  "\<lbrace>if_unsafe_then_cap and valid_global_refs
+           and cte_wp_at (\<lambda>cp. cap_irqs cp \<noteq> {}) sl\<rbrace>
+     deleting_irq_handler irq
+   \<lbrace>\<lambda>rv s. (interrupt_irq_node s irq, []) \<noteq> sl\<rbrace>"
+  apply (simp add: deleting_irq_handler_def)
+  apply wp
+  apply clarsimp
+  apply (drule(1) if_unsafe_then_capD)
+   apply clarsimp
+  apply (clarsimp simp: ex_cte_cap_wp_to_def cte_wp_at_caps_of_state)
+  apply (drule cte_refs_obj_refs_elem)
+  apply (erule disjE)
+   apply simp
+   apply (drule(1) valid_global_refsD[OF _ caps_of_state_cteD])
+    prefer 2
+    apply (erule notE, simp add: cap_range_def, erule disjI2)
+   apply (simp add: global_refs_def)
+  apply (clarsimp simp: appropriate_cte_cap_def split: cap.split_asm)
+  done
+
+lemma no_cap_to_obj_with_diff_ref_finalI_ARCH[Finalise_AI_asms]:
+  "\<lbrakk> cte_wp_at ((=) cap) p s; is_final_cap' cap s;
+            obj_refs cap' = obj_refs cap \<rbrakk>
+      \<Longrightarrow> no_cap_to_obj_with_diff_ref cap' {p} s"
+  apply (case_tac "obj_refs cap = {}")
+   apply (case_tac "cap_irqs cap = {}")
+    apply (case_tac "arch_gen_refs cap = {}")
+     apply (simp add: is_final_cap'_def)
+     apply (case_tac cap, simp_all add: gen_obj_refs_def)
+    apply ((clarsimp simp add: no_cap_to_obj_with_diff_ref_def
+                              cte_wp_at_caps_of_state
+                              vs_cap_ref_def
+                       dest!: obj_ref_none_no_asid[rule_format])+)[2]
+  apply (clarsimp simp: no_cap_to_obj_with_diff_ref_def
+                        is_final_cap'_def2
+              simp del: split_paired_All)
+  apply (frule_tac x=p in spec)
+  apply (drule_tac x="(a, b)" in spec)
+  apply (clarsimp simp: cte_wp_at_caps_of_state
+                        gen_obj_refs_Int)
+  done
+
+lemma (* suspend_no_cap_to_obj_ref *)[wp,Finalise_AI_asms]:
+  "\<lbrace>no_cap_to_obj_with_diff_ref cap S\<rbrace>
+     suspend t
+   \<lbrace>\<lambda>rv. no_cap_to_obj_with_diff_ref cap S\<rbrace>"
+  apply (simp add: no_cap_to_obj_with_diff_ref_def
+                   cte_wp_at_caps_of_state)
+  apply (wp suspend_caps_of_state)
+  apply (clarsimp dest!: obj_ref_none_no_asid[rule_format])
+  done
+
+lemma prepare_thread_delete_no_cap_to_obj_ref[wp]:
+  "\<lbrace>no_cap_to_obj_with_diff_ref cap S\<rbrace>
+     prepare_thread_delete t
+   \<lbrace>\<lambda>rv. no_cap_to_obj_with_diff_ref cap S\<rbrace>"
+  unfolding prepare_thread_delete_def by wpsimp
+
+lemma prepare_thread_delete_unlive_hyp:
+  "\<lbrace>obj_at \<top> ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> hyp_live) ptr\<rbrace>"
+  apply (simp add: prepare_thread_delete_def)
+  apply (wpsimp simp: obj_at_def is_tcb_def hyp_live_def)
+  done
+
+lemma prepare_thread_delete_unlive0:
+  "\<lbrace>obj_at (Not \<circ> live0) ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> live0) ptr\<rbrace>"
+  by (simp add: prepare_thread_delete_def)
+
+lemma prepare_thread_delete_unlive[wp]:
+  "\<lbrace>obj_at (Not \<circ> live0) ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> live) ptr\<rbrace>"
+  apply (rule_tac Q="\<lambda>rv. obj_at (Not \<circ> live0) ptr and obj_at (Not \<circ> hyp_live) ptr" in hoare_strengthen_post)
+  apply (wpsimp wp: hoare_vcg_conj_lift prepare_thread_delete_unlive_hyp prepare_thread_delete_unlive0)
+   apply (clarsimp simp: obj_at_def)
+  apply (clarsimp simp: obj_at_def, case_tac ko, simp_all add: is_tcb_def live_def)
+  done
+
+lemma finalise_cap_replaceable [Finalise_AI_asms]:
+  "\<lbrace>\<lambda>s. s \<turnstile> cap \<and> x = is_final_cap' cap s \<and> valid_mdb s
+        \<and> cte_wp_at ((=) cap) sl s \<and> valid_objs s \<and> sym_refs (state_refs_of s)
+        \<and> (cap_irqs cap \<noteq> {} \<longrightarrow> if_unsafe_then_cap s \<and> valid_global_refs s)
+        \<and> (is_arch_cap cap \<longrightarrow> pspace_aligned s \<and>
+                               valid_vspace_objs s \<and>
+                               valid_arch_state s \<and>
+                               valid_arch_caps s)\<rbrace>
+     finalise_cap cap x
+   \<lbrace>\<lambda>rv s. replaceable s sl (fst rv) cap\<rbrace>"
+  apply (cases "is_arch_cap cap")
+   apply (clarsimp simp: is_cap_simps)
+   apply (wp arch_finalise_cap_replaceable)
+   apply (clarsimp simp: replaceable_def reachable_frame_cap_def
+                         o_def cap_range_def valid_arch_state_def
+                         ran_tcb_cap_cases is_cap_simps
+                         gen_obj_refs_subset vs_cap_ref_def
+                         all_bool_eq)
+  apply (cases cap;
+           simp add: replaceable_def reachable_frame_cap_def is_arch_cap_def
+                split del: if_split;
+           ((wp suspend_unlive[unfolded o_def]
+                suspend_final_cap[where sl=sl]
+                prepare_thread_delete_unlive[unfolded o_def]
+                unbind_maybe_notification_not_bound
+                get_simple_ko_ko_at unbind_notification_valid_objs
+             | clarsimp simp: o_def dom_tcb_cap_cases_lt_ARCH
+                              ran_tcb_cap_cases is_cap_simps
+                              cap_range_def unat_of_bl_length
+                              can_fast_finalise_def
+                              gen_obj_refs_subset
+                              vs_cap_ref_def
+                              valid_ipc_buffer_cap_def
+                        dest!: tcb_cap_valid_NullCapD
+                        split: Structures_A.thread_state.split_asm
+             | simp cong: conj_cong
+             | simp cong: rev_conj_cong add: no_cap_to_obj_with_diff_ref_Null
+             | (strengthen tcb_cap_valid_imp_NullCap tcb_cap_valid_imp', wp)
+             | rule conjI
+             | erule cte_wp_at_weakenE tcb_cap_valid_imp'[rule_format, rotated -1]
+             | erule(1) no_cap_to_obj_with_diff_ref_finalI_ARCH
+             | (wp (once) hoare_drop_imps,
+                        wp (once) cancel_all_ipc_unlive[unfolded o_def]
+                       cancel_all_signals_unlive[unfolded o_def])
+             | ((wp (once) hoare_drop_imps)?,
+                (wp (once) hoare_drop_imps)?,
+                wp (once) deleting_irq_handler_empty)
+             | wpc
+             | simp add: valid_cap_simps is_nondevice_page_cap_simps)+))
+  done
+
+lemma (* deleting_irq_handler_cte_preserved *)[Finalise_AI_asms]:
+  assumes x: "\<And>cap. P cap \<Longrightarrow> \<not> can_fast_finalise cap"
+  shows "\<lbrace>cte_wp_at P p\<rbrace> deleting_irq_handler irq \<lbrace>\<lambda>rv. cte_wp_at P p\<rbrace>"
+  apply (simp add: deleting_irq_handler_def)
+  apply (wp cap_delete_one_cte_wp_at_preserved | simp add: x)+
+  done
+
+lemma arch_thread_set_cte_wp_at[wp]:
+  "\<lbrace>\<lambda>s. P (cte_wp_at P' p s)\<rbrace> arch_thread_set f t \<lbrace> \<lambda>_ s. P (cte_wp_at P' p s)\<rbrace>"
+  apply (simp add: arch_thread_set_def)
+  apply (wp set_object_wp)
+  apply (clarsimp dest!: get_tcb_SomeD simp del: fun_upd_apply)
+  apply (subst get_tcb_rev, assumption, subst option.sel)+
+  apply (subst arch_tcb_update_aux3)
+  apply (subst cte_wp_at_update_some_tcb[where f="tcb_arch_update f"])
+    apply (clarsimp simp: tcb_cnode_map_def)+
+  done
+
+crunch cte_wp_at[wp,Finalise_AI_asms]: prepare_thread_delete "\<lambda>s. P (cte_wp_at P' p s)"
+
+crunch cte_wp_at[wp,Finalise_AI_asms]: arch_finalise_cap "\<lambda>s. P (cte_wp_at P' p s)"
+  (simp: crunch_simps assertE_def wp: crunch_wps set_object_cte_at
+   ignore: arch_thread_set)
+end
+
+interpretation Finalise_AI_1?: Finalise_AI_1
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; (unfold_locales; fact Finalise_AI_asms)?)
+  qed
+
+context Arch begin global_naming RISCV64
+
+lemma fast_finalise_replaceable[wp]:
+  "\<lbrace>\<lambda>s. s \<turnstile> cap \<and> x = is_final_cap' cap s
+     \<and> cte_wp_at ((=) cap) sl s \<and> valid_asid_table s
+     \<and> valid_mdb s \<and> valid_objs s \<and> sym_refs (state_refs_of s)\<rbrace>
+     fast_finalise cap x
+   \<lbrace>\<lambda>rv s. cte_wp_at (replaceable s sl cap.NullCap) sl s\<rbrace>"
+  apply (cases "cap_irqs cap = {}")
+   apply (simp add: fast_finalise_def2)
+   apply wp
+    apply (rule hoare_strengthen_post)
+     apply (rule hoare_vcg_conj_lift)
+      apply (rule finalise_cap_replaceable[where sl=sl])
+     apply (rule finalise_cap_equal_cap[where sl=sl])
+    apply (clarsimp simp: cte_wp_at_caps_of_state)
+   apply wp
+   apply (clarsimp simp: is_cap_simps can_fast_finalise_def)
+  apply (clarsimp simp: cap_irqs_def cap_irq_opt_def split: cap.split_asm)
+  done
+
+global_naming Arch
+lemma (* cap_delete_one_invs *) [Finalise_AI_asms,wp]:
+  "\<lbrace>invs and emptyable ptr\<rbrace> cap_delete_one ptr \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (simp add: cap_delete_one_def unless_def is_final_cap_def)
+  apply (rule hoare_pre)
+  apply (wp empty_slot_invs get_cap_wp)
+  apply clarsimp
+  apply (drule cte_wp_at_valid_objs_valid_cap, fastforce+)
+  done
+
+end
+
+interpretation Finalise_AI_2?: Finalise_AI_2
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; (unfold_locales; fact Finalise_AI_asms)?)
+  qed
+
+context Arch begin global_naming RISCV64
+
+crunch irq_node[Finalise_AI_asms,wp]: prepare_thread_delete "\<lambda>s. P (interrupt_irq_node s)"
+
+crunch irq_node[wp]: arch_finalise_cap "\<lambda>s. P (interrupt_irq_node s)"
+  (simp: crunch_simps wp: crunch_wps)
+
+crunch pred_tcb_at[wp]:
+  delete_asid_pool, delete_asid, unmap_page_table, unmap_page
+  "pred_tcb_at proj P t"
+  (simp: crunch_simps wp: crunch_wps test)
+
+crunch pred_tcb_at[wp_unsafe]: arch_finalise_cap "pred_tcb_at proj P t"
+  (simp: crunch_simps wp: crunch_wps)
+
+definition
+  replaceable_or_arch_update :: "'z::state_ext state \<Rightarrow> cslot_ptr \<Rightarrow> cap \<Rightarrow> cap \<Rightarrow> bool" where
+  "replaceable_or_arch_update \<equiv> \<lambda>s slot cap cap'.
+   if is_frame_cap cap
+   then is_arch_update cap cap' \<and>
+        (\<forall>asid vref. vs_cap_ref cap' = Some (asid,vref) \<longrightarrow>
+           vs_cap_ref cap = Some (asid,vref) \<and>
+           obj_refs cap = obj_refs cap' \<or>
+           (\<forall>oref\<in>obj_refs cap'. \<forall>level. vs_lookup_target level asid vref s \<noteq> Some (level, oref)))
+   else replaceable s slot cap cap'"
+
+lemma is_final_cap_pt_asid_eq:
+  "is_final_cap' (ArchObjectCap (PageTableCap p y)) s \<Longrightarrow>
+   is_final_cap' (ArchObjectCap (PageTableCap p x)) s"
+  apply (clarsimp simp: is_final_cap'_def gen_obj_refs_def)
+  done
+
+lemma is_final_cap_pd_asid_eq:
+  "is_final_cap' (ArchObjectCap (PageTableCap p y)) s \<Longrightarrow>
+   is_final_cap' (ArchObjectCap (PageTableCap p x)) s"
+  by (rule is_final_cap_pt_asid_eq)
+
+lemma cte_wp_at_obj_refs_singleton_page_table:
+  "\<lbrakk>cte_wp_at
+      (\<lambda>cap'. obj_refs cap' = {p}
+            \<and> (\<exists>p asid. cap' = ArchObjectCap (PageTableCap p asid)))
+      (a, b) s\<rbrakk> \<Longrightarrow>
+   \<exists>asid. cte_wp_at ((=) (ArchObjectCap (PageTableCap p asid))) (a,b) s"
+  apply (clarsimp simp: cte_wp_at_def)
+  done
+
+lemma final_cap_pt_slot_eq:
+  "\<lbrakk>is_final_cap' (ArchObjectCap (PageTableCap p asid)) s;
+    cte_wp_at ((=) (ArchObjectCap (PageTableCap p asid'))) slot s;
+    cte_wp_at ((=) (ArchObjectCap (PageTableCap p asid''))) slot' s\<rbrakk> \<Longrightarrow>
+   slot' = slot"
+  apply (clarsimp simp:is_final_cap'_def2)
+  apply (case_tac "(a,b) = slot'")
+   apply (case_tac "(a,b) = slot")
+    apply simp
+   apply (erule_tac x="fst slot" in allE)
+   apply (erule_tac x="snd slot" in allE)
+   apply (clarsimp simp: gen_obj_refs_def cap_irqs_def cte_wp_at_def)
+  apply (erule_tac x="fst slot'" in allE)
+  apply (erule_tac x="snd slot'" in allE)
+  apply (clarsimp simp: gen_obj_refs_def cap_irqs_def cte_wp_at_def)
+  done
+
+lemma is_arch_update_reset_page:
+  "is_arch_update
+     (ArchObjectCap (FrameCap p r sz dev m))
+     (ArchObjectCap (FrameCap p r' sz dev m'))"
+  apply (simp add: is_arch_update_def is_arch_cap_def cap_master_cap_def)
+  done
+
+crunch caps_of_state [wp]: arch_finalise_cap "\<lambda>s. P (caps_of_state s)"
+   (wp: crunch_wps simp: crunch_simps)
+
+lemma set_vm_root_empty[wp]:
+  "\<lbrace>\<lambda>s. P (obj_at (empty_table S) p s)\<rbrace> set_vm_root v \<lbrace>\<lambda>_ s. P (obj_at (empty_table S) p s) \<rbrace>"
+  apply (simp add: set_vm_root_def)
+  apply (wpsimp wp: get_cap_wp)
+  done
+
+lemma set_asid_pool_empty[wp]:
+  "\<lbrace>obj_at (empty_table S) word\<rbrace> set_asid_pool x2 pool' \<lbrace>\<lambda>xb. obj_at (empty_table S) word\<rbrace>"
+  by (wpsimp wp: set_object_wp simp: set_asid_pool_def obj_at_def empty_table_def)
+
+lemma delete_asid_empty_table_pt[wp]:
+  "delete_asid a word \<lbrace>\<lambda>s. obj_at (empty_table S) word s\<rbrace>"
+   apply (simp add: delete_asid_def)
+   apply wpsimp
+   done
+
+lemma ucast_less_shiftl_helper3:
+  "\<lbrakk> len_of TYPE('b) + 3 < len_of TYPE('a); 2 ^ (len_of TYPE('b) + 3) \<le> n\<rbrakk>
+    \<Longrightarrow> (ucast (x :: 'b::len word) << 3) < (n :: 'a::len word)"
+  apply (erule order_less_le_trans[rotated])
+  using ucast_less[where x=x and 'a='a]
+  apply (simp only: shiftl_t2n field_simps)
+  apply (rule word_less_power_trans2; simp)
+  done
+
+lemma caps_of_state_aligned_page_table:
+  "\<lbrakk>caps_of_state s slot = Some (ArchObjectCap (PageTableCap word option)); invs s\<rbrakk>
+  \<Longrightarrow> is_aligned word pt_bits"
+  apply (frule caps_of_state_valid)
+  apply (frule invs_valid_objs, assumption)
+  apply (frule valid_cap_aligned)
+  apply (simp add: cap_aligned_def pt_bits_def pageBits_def)
+  done
+
+end
+
+lemma invs_valid_arch_capsI:
+  "invs s \<Longrightarrow> valid_arch_caps s"
+  by (simp add: invs_def valid_state_def)
+
+context Arch begin global_naming RISCV64 (*FIXME: arch_split*)
+
+lemma do_machine_op_reachable_pg_cap[wp]:
+  "\<lbrace>\<lambda>s. P (reachable_frame_cap cap s)\<rbrace>
+   do_machine_op mo
+   \<lbrace>\<lambda>rv s. P (reachable_frame_cap cap s)\<rbrace>"
+  apply (simp add:reachable_frame_cap_def reachable_target_def)
+  apply (wp_pre, wps dmo.vs_lookup_pages, wpsimp)
+  apply simp
+  done
+
+lemma replaceable_or_arch_update_pg:
+  " (case (vs_cap_ref (ArchObjectCap (FrameCap word fun vm_pgsz dev y))) of None \<Rightarrow> True | Some (asid,vref) \<Rightarrow>
+     \<forall>level. vs_lookup_target level asid vref s \<noteq> Some (level, word))
+  \<longrightarrow> replaceable_or_arch_update s slot (ArchObjectCap (FrameCap word fun vm_pgsz dev None))
+                (ArchObjectCap (FrameCap word fun vm_pgsz dev y))"
+  unfolding replaceable_or_arch_update_def
+  apply (auto simp: is_cap_simps is_arch_update_def cap_master_cap_simps)
+  done
+
+
+global_naming Arch
+
+crunch invs[wp]: prepare_thread_delete invs
+  (ignore: set_object)
+
+lemma (* finalise_cap_invs *)[Finalise_AI_asms]:
+  shows "\<lbrace>invs and cte_wp_at ((=) cap) slot\<rbrace> finalise_cap cap x \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (cases cap, simp_all split del: if_split)
+         apply (wp cancel_all_ipc_invs cancel_all_signals_invs unbind_notification_invs
+                   unbind_maybe_notification_invs
+                  | simp add: o_def split del: if_split cong: if_cong
+                  | wpc )+
+      apply clarsimp (* thread *)
+      apply (frule cte_wp_at_valid_objs_valid_cap, clarsimp)
+      apply (clarsimp simp: valid_cap_def)
+      apply (frule(1) valid_global_refsD[OF invs_valid_global_refs])
+       apply (simp add: global_refs_def, rule disjI1, rule refl)
+      apply (simp add: cap_range_def)
+     apply (wp deleting_irq_handler_invs  | simp | intro conjI impI)+
+  apply (auto dest: cte_wp_at_valid_objs_valid_cap)
+  done
+
+lemma (* finalise_cap_irq_node *)[Finalise_AI_asms]:
+"\<lbrace>\<lambda>s. P (interrupt_irq_node s)\<rbrace> finalise_cap a b \<lbrace>\<lambda>_ s. P (interrupt_irq_node s)\<rbrace>"
+  apply (case_tac a,simp_all)
+  apply (wp | clarsimp)+
+  done
+
+lemmas (*arch_finalise_cte_irq_node *) [wp,Finalise_AI_asms]
+    = hoare_use_eq_irq_node [OF arch_finalise_cap_irq_node arch_finalise_cap_cte_wp_at]
+
+lemma (* deleting_irq_handler_st_tcb_at *) [Finalise_AI_asms]:
+  "\<lbrace>st_tcb_at P t and K (\<forall>st. simple st \<longrightarrow> P st)\<rbrace>
+     deleting_irq_handler irq
+   \<lbrace>\<lambda>rv. st_tcb_at P t\<rbrace>"
+  apply (simp add: deleting_irq_handler_def)
+  apply (wp cap_delete_one_st_tcb_at)
+  apply simp
+  done
+
+lemma irq_node_global_refs_ARCH [Finalise_AI_asms]:
+  "interrupt_irq_node s irq \<in> global_refs s"
+  by (simp add: global_refs_def)
+
+lemma (* get_irq_slot_fast_finalisable *)[wp,Finalise_AI_asms]:
+  "\<lbrace>invs\<rbrace> get_irq_slot irq \<lbrace>cte_wp_at can_fast_finalise\<rbrace>"
+  apply (simp add: get_irq_slot_def)
+  apply wp
+  apply (clarsimp simp: invs_def valid_state_def valid_irq_node_def)
+  apply (drule spec[where x=irq], drule cap_table_at_cte_at[where offset="[]"])
+   apply simp
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (case_tac "cap = cap.NullCap")
+   apply (simp add: can_fast_finalise_def)
+  apply (frule(1) if_unsafe_then_capD [OF caps_of_state_cteD])
+   apply simp
+  apply (clarsimp simp: ex_cte_cap_wp_to_def)
+  apply (drule cte_wp_at_norm, clarsimp)
+  apply (drule(1) valid_global_refsD [OF _ _ irq_node_global_refs_ARCH[where irq=irq]])
+  apply (case_tac c, simp_all)
+     apply (clarsimp simp: cap_range_def)
+    apply (clarsimp simp: cap_range_def)
+   apply (clarsimp simp: appropriate_cte_cap_def can_fast_finalise_def split: cap.split_asm)
+  apply (clarsimp simp: cap_range_def)
+  done
+
+lemma (* replaceable_or_arch_update_same *) [Finalise_AI_asms]:
+  "replaceable_or_arch_update s slot cap cap"
+  by (clarsimp simp: replaceable_or_arch_update_def
+                replaceable_def is_arch_update_def is_cap_simps)
+
+lemma (* replace_cap_invs_arch_update *)[Finalise_AI_asms]:
+  "\<lbrace>\<lambda>s. cte_wp_at (replaceable_or_arch_update s p cap) p s
+        \<and> invs s
+        \<and> cap \<noteq> cap.NullCap
+        \<and> ex_cte_cap_wp_to (appropriate_cte_cap cap) p s
+        \<and> s \<turnstile> cap\<rbrace>
+     set_cap cap p
+   \<lbrace>\<lambda>rv s. invs s\<rbrace>"
+  apply (simp add:replaceable_or_arch_update_def)
+  apply (cases "is_frame_cap cap")
+   apply (wp hoare_pre_disj[OF arch_update_cap_invs_unmap_page arch_update_cap_invs_map])
+   apply (simp add:replaceable_or_arch_update_def replaceable_def cte_wp_at_caps_of_state)
+   apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps gen_obj_refs_def
+                         cap_master_cap_simps is_arch_update_def)
+  apply (wp replace_cap_invs)
+  apply simp
+  done
+
+lemma dmo_pred_tcb_at[wp]:
+  "do_machine_op mop \<lbrace>\<lambda>s. P (pred_tcb_at f Q t s)\<rbrace>"
+  apply (simp add: do_machine_op_def split_def)
+  apply (wp select_wp)
+  apply (clarsimp simp: pred_tcb_at_def obj_at_def)
+  done
+
+lemma dmo_tcb_cap_valid_ARCH [Finalise_AI_asms]:
+  "do_machine_op mop \<lbrace>\<lambda>s. P (tcb_cap_valid cap ptr s)\<rbrace>"
+  apply (simp add: tcb_cap_valid_def no_cap_to_obj_with_diff_ref_def)
+  apply (wp_pre, wps, rule hoare_vcg_prop)
+  apply simp
+  done
+
+lemma dmo_vs_lookup_target[wp]:
+  "do_machine_op mop \<lbrace>\<lambda>s. P (vs_lookup_target level asid vref s)\<rbrace>"
+  by (rule dmo.vs_lookup_pages)
+
+lemma dmo_reachable_target[wp]:
+  "do_machine_op mop \<lbrace>\<lambda>s. P (reachable_target ref p s)\<rbrace>"
+  apply (simp add: reachable_target_def split_def)
+  apply (wp_pre, wps, wp)
+  apply simp
+  done
+
+lemma (* dmo_replaceable_or_arch_update *) [Finalise_AI_asms,wp]:
+  "\<lbrace>\<lambda>s. replaceable_or_arch_update s slot cap cap'\<rbrace>
+    do_machine_op mo
+  \<lbrace>\<lambda>r s. replaceable_or_arch_update s slot cap cap'\<rbrace>"
+  unfolding replaceable_or_arch_update_def replaceable_def no_cap_to_obj_with_diff_ref_def
+            replaceable_final_arch_cap_def replaceable_non_final_arch_cap_def
+  apply (wp_pre, wps dmo_tcb_cap_valid_ARCH do_machine_op_reachable_pg_cap)
+   apply (rule hoare_vcg_prop)
+  apply simp
+  done
+
+end
+
+context begin interpretation Arch .
+requalify_consts replaceable_or_arch_update
+end
+
+interpretation Finalise_AI_3?: Finalise_AI_3
+  where replaceable_or_arch_update = replaceable_or_arch_update
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; (unfold_locales; fact Finalise_AI_asms)?)
+  qed
+
+context Arch begin global_naming RISCV64
+
+lemma typ_at_data_at_wp:
+  assumes typ_wp: "\<And>a.\<lbrace>typ_at a p \<rbrace> g \<lbrace>\<lambda>s. typ_at a p\<rbrace>"
+  shows "\<lbrace>data_at b p\<rbrace> g \<lbrace>\<lambda>s. data_at b p\<rbrace>"
+  apply (simp add: data_at_def)
+  apply (wp typ_wp hoare_vcg_disj_lift)
+  done
+
+end
+
+interpretation Finalise_AI_4?: Finalise_AI_4
+  where replaceable_or_arch_update = replaceable_or_arch_update
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; (unfold_locales; fact Finalise_AI_asms)?)
+  qed
+
+context Arch begin global_naming RISCV64
+
+lemma set_asid_pool_obj_at_ptr:
+  "\<lbrace>\<lambda>s. P (ArchObj (arch_kernel_obj.ASIDPool mp))\<rbrace>
+     set_asid_pool ptr mp
+   \<lbrace>\<lambda>rv s. obj_at P ptr s\<rbrace>"
+  apply (simp add: set_asid_pool_def set_object_def)
+  apply (wp get_object_wp)
+  apply (clarsimp simp: obj_at_def)
+  done
+
+locale_abbrev
+  "asid_table_update asid ap s \<equiv>
+     s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := riscv_asid_table (arch_state s)(asid \<mapsto> ap)\<rparr>\<rparr>"
+
+lemma valid_table_caps_table [simp]:
+  "valid_table_caps (s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := table'\<rparr>\<rparr>) = valid_table_caps s"
+  by (simp add: valid_table_caps_def)
+
+lemma valid_kernel_mappings [iff]:
+  "valid_kernel_mappings (s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := table'\<rparr>\<rparr>) = valid_kernel_mappings s"
+  by (simp add: valid_kernel_mappings_def)
+
+crunches unmap_page_table, store_pte, delete_asid_pool, copy_global_mappings
+  for valid_cap[wp]: "valid_cap c"
+  (wp: mapM_wp_inv mapM_x_wp' simp: crunch_simps)
+
+lemmas delete_asid_typ_ats[wp] = abs_typ_at_lifts [OF delete_asid_typ_at]
+
+lemma arch_finalise_cap_valid_cap[wp]:
+  "arch_finalise_cap cap b \<lbrace>valid_cap c\<rbrace>"
+  unfolding arch_finalise_cap_def
+  by (wpsimp split: arch_cap.split option.split bool.split)
+
+global_naming Arch
+
+lemmas clearMemory_invs[wp,Finalise_AI_asms] = clearMemory_invs
+
+lemma valid_idle_has_null_cap_ARCH[Finalise_AI_asms]:
+  "\<lbrakk> if_unsafe_then_cap s; valid_global_refs s; valid_idle s; valid_irq_node s;
+    caps_of_state s (idle_thread s, v) = Some cap \<rbrakk>
+   \<Longrightarrow> cap = NullCap"
+  apply (rule ccontr)
+  apply (drule(1) if_unsafe_then_capD[OF caps_of_state_cteD])
+   apply clarsimp
+  apply (clarsimp simp: ex_cte_cap_wp_to_def cte_wp_at_caps_of_state)
+  apply (frule(1) valid_global_refsD2)
+  apply (case_tac capa, simp_all add: cap_range_def global_refs_def)[1]
+  apply (clarsimp simp: valid_irq_node_def valid_idle_def pred_tcb_at_def
+                        obj_at_def is_cap_table_def)
+  apply (rename_tac word tcb)
+  apply (drule_tac x=word in spec, simp)
+  done
+
+lemma (* zombie_cap_two_nonidles *)[Finalise_AI_asms]:
+  "\<lbrakk> caps_of_state s ptr = Some (Zombie ptr' zbits n); invs s \<rbrakk>
+       \<Longrightarrow> fst ptr \<noteq> idle_thread s \<and> ptr' \<noteq> idle_thread s"
+  apply (frule valid_global_refsD2, clarsimp+)
+  apply (simp add: cap_range_def global_refs_def)
+  apply (cases ptr, auto dest: valid_idle_has_null_cap_ARCH[rotated -1])[1]
+  done
+
+crunches empty_slot, finalise_cap, send_ipc, receive_ipc
+  for ioports[wp]: valid_ioports
+  (wp: crunch_wps valid_ioports_lift simp: crunch_simps ignore: set_object)
+
+lemma arch_derive_cap_notzombie[wp]:
+  "\<lbrace>\<top>\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv s. \<not> is_zombie rv\<rbrace>, -"
+  by (cases acap; wpsimp simp: arch_derive_cap_def is_zombie_def o_def)
+
+lemma arch_derive_cap_notIRQ[wp]:
+  "\<lbrace>\<top>\<rbrace> arch_derive_cap cap \<lbrace>\<lambda>rv s. rv \<noteq> cap.IRQControlCap\<rbrace>,-"
+  by (cases cap; wpsimp simp: arch_derive_cap_def o_def)
+
+end
+
+interpretation Finalise_AI_5?: Finalise_AI_5
+  where replaceable_or_arch_update = replaceable_or_arch_update
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; (unfold_locales; fact Finalise_AI_asms)?)
+  qed
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -12,17 +13,20 @@ context Arch begin
 
 named_theorems Finalise_AI_asms
 
+(* FIXME AARCH64 VCPU/FPU?
 crunch caps_of_state[wp]: prepare_thread_delete "\<lambda>s. P (caps_of_state s)"
   (wp: crunch_wps)
 
 declare prepare_thread_delete_caps_of_state [Finalise_AI_asms]
+*)
 
-global_naming RISCV64
+global_naming AARCH64
 
+(* FIXME AARCH64
 lemma valid_global_refs_asid_table_udapte [iff]:
-  "valid_global_refs (s\<lparr>arch_state := riscv_asid_table_update f (arch_state s)\<rparr>) =
+  "valid_global_refs (s\<lparr>arch_state := arm_asid_table_update f (arch_state s)\<rparr>) =
   valid_global_refs s"
-  by (simp add: valid_global_refs_def global_refs_def)
+  by (simp add: valid_global_refs_def global_refs_def) *)
 
 lemma nat_to_cref_unat_of_bl':
   "\<lbrakk> length xs < 64; n = length xs \<rbrakk> \<Longrightarrow>
@@ -40,44 +44,48 @@ lemma nat_to_cref_unat_of_bl':
 
 lemmas nat_to_cref_unat_of_bl = nat_to_cref_unat_of_bl' [OF _ refl]
 
+(* FIXME AARCH64
 lemma riscv_global_pt_asid_table_update[simp]:
-  "riscv_global_pt (arch_state s\<lparr>riscv_asid_table := atable\<rparr>) = riscv_global_pt (arch_state s)"
-  by (simp add: riscv_global_pt_def)
+  "riscv_global_pt (arch_state s\<lparr>arm_asid_table := atable\<rparr>) = riscv_global_pt (arch_state s)"
+  by (simp add: riscv_global_pt_def) *)
 
 lemma equal_kernel_mappings_asid_table_unmap:
   "equal_kernel_mappings s
    \<Longrightarrow> equal_kernel_mappings (s\<lparr>arch_state := arch_state s
-                                \<lparr>riscv_asid_table := (asid_table s)(i := None)\<rparr>\<rparr>)"
+                                \<lparr>arm_asid_table := (asid_table s)(i := None)\<rparr>\<rparr>)"
   unfolding equal_kernel_mappings_def
   apply clarsimp
+  sorry (* FIXME AARCH64
   apply (erule_tac x=asid in allE)
   apply (erule_tac x=pt_ptr in allE)
   apply (clarsimp simp: fun_upd_def)
   apply (erule impE)
    subgoal by (clarsimp simp: vspace_for_asid_def in_omonad pool_for_asid_def split: if_splits)
   apply (clarsimp simp: has_kernel_mappings_def)
-  done
+  done *)
 
-lemma invs_riscv_asid_table_unmap:
+lemma invs_arm_asid_table_unmap:
   "invs s \<and> is_aligned base asid_low_bits
-       \<and> tab = riscv_asid_table (arch_state s)
-     \<longrightarrow> invs (s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := tab(asid_high_bits_of base := None)\<rparr>\<rparr>)"
+       \<and> tab = arm_asid_table (arch_state s)
+     \<longrightarrow> invs (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := tab(asid_high_bits_of base := None)\<rparr>\<rparr>)"
   apply (clarsimp simp: invs_def valid_state_def valid_arch_caps_def)
+  sorry (* FIXME AARCH64
   apply (strengthen valid_asid_map_unmap valid_vspace_objs_unmap_strg
                     valid_vs_lookup_unmap_strg valid_arch_state_unmap_strg)
   apply (simp add: valid_irq_node_def valid_kernel_mappings_def)
   apply (simp add: valid_table_caps_def valid_machine_state_def valid_global_objs_def
                    valid_asid_pool_caps_def equal_kernel_mappings_asid_table_unmap)
-  done
+  done *)
 
 lemma delete_asid_pool_invs[wp]:
   "delete_asid_pool base pptr \<lbrace>invs\<rbrace>"
   unfolding delete_asid_pool_def
   supply fun_upd_apply[simp del]
   apply wpsimp
-  apply (strengthen invs_riscv_asid_table_unmap)
+  apply (strengthen invs_arm_asid_table_unmap)
   apply (simp add: asid_low_bits_of_def asid_low_bits_def ucast_zero_is_aligned)
-  done
+  sorry (* FIXME AARCH64
+  done *)
 
 lemma do_machine_op_pool_for_asid[wp]:
   "do_machine_op f \<lbrace>\<lambda>s. P (pool_for_asid asid s)\<rbrace>"
@@ -91,24 +99,28 @@ lemma do_machine_op_vspace_for_asid[wp]:
 
 lemma set_vm_root_pool_for_asid[wp]:
   "set_vm_root pt \<lbrace>\<lambda>s. P (pool_for_asid asid s)\<rbrace>"
-  by (wpsimp simp: set_vm_root_def wp: get_cap_wp)
+  sorry (* FIXME AARCH64
+  by (wpsimp simp: set_vm_root_def wp: get_cap_wp) *)
 
 lemma set_vm_root_vspace_for_asid[wp]:
   "set_vm_root pt \<lbrace> \<lambda>s. P (vspace_for_asid asid s) \<rbrace>"
-  by (wpsimp simp: set_vm_root_def wp: get_cap_wp)
+  sorry (* FIXME AARCH64
+  by (wpsimp simp: set_vm_root_def wp: get_cap_wp) *)
 
 lemma clearExMonitor_invs[wp]:
   "\<lbrace>invs\<rbrace> do_machine_op (hwASIDFlush a) \<lbrace>\<lambda>_. invs\<rbrace>"
+  sorry (* FIXME AARCH64
   by (wpsimp wp: dmo_invs
              simp: hwASIDFlush_def machine_op_lift_def
-                   machine_rest_lift_def in_monad select_f_def)
+                   machine_rest_lift_def in_monad select_f_def) *)
 
 lemma delete_asid_invs[wp]:
   "\<lbrace> invs and valid_asid_table and pspace_aligned \<rbrace>delete_asid asid pd \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: delete_asid_def cong: option.case_cong)
   apply (wpsimp wp: set_asid_pool_invs_unmap)
+  sorry (* FIXME AARCH64
   apply blast
-  done
+  done *)
 
 lemma delete_asid_pool_unmapped[wp]:
   "\<lbrace>\<lambda>s. True \<rbrace>
@@ -123,8 +135,9 @@ lemma set_asid_pool_unmap:
    \<lbrace>\<lambda>rv s. vspace_for_asid asid s = None \<rbrace>"
   unfolding set_asid_pool_def
   apply (wpsimp wp: set_object_wp)
+  sorry (* FIXME AARCH64
   by (simp add: pool_for_asid_def vspace_for_asid_def vspace_for_pool_def obind_def in_omonad
-         split: option.splits)
+         split: option.splits) *)
 
 lemma delete_asid_unmapped:
   "\<lbrace>\<lambda>s. vspace_for_asid asid s = Some pt\<rbrace>
@@ -132,11 +145,12 @@ lemma delete_asid_unmapped:
    \<lbrace>\<lambda>_ s. vspace_for_asid asid s = None\<rbrace>"
   unfolding delete_asid_def
   apply (simp cong: option.case_cong)
+  sorry (* FIXME AARCH64
   apply (wpsimp wp: set_asid_pool_unmap)
   apply (clarsimp simp: vspace_for_asid_def pool_for_asid_def vspace_for_pool_def
                         obind_def in_omonad obj_at_def
                  split: option.splits)
-  done
+  done *)
 
 lemma set_pt_tcb_at:
   "\<lbrace>\<lambda>s. P (ko_at (TCB tcb) t s)\<rbrace> set_pt a b \<lbrace>\<lambda>_ s. P (ko_at (TCB tcb) t s)\<rbrace>"
@@ -301,7 +315,8 @@ lemma arch_thread_get_final_cap[wp]:
 
 lemma prepare_thread_delete_final[wp]:
   "\<lbrace>is_final_cap' cap\<rbrace> prepare_thread_delete t \<lbrace> \<lambda>rv. is_final_cap' cap\<rbrace>"
-  unfolding prepare_thread_delete_def by wp
+  sorry (* FIXME AARCH64 FPU/VCPU
+  unfolding prepare_thread_delete_def by wp *)
 
 lemma length_and_unat_of_bl_length:
   "(length xs = x \<and> unat (of_bl xs :: 'a::len word) < 2 ^ x) = (length xs = x)"
@@ -350,7 +365,8 @@ crunch tcb_at[wp]: arch_thread_set "\<lambda>s. tcb_at p s"
 
 crunch tcb_at[wp]: arch_thread_get "\<lambda>s. tcb_at p s"
 
-crunch tcb_at[wp]: prepare_thread_delete "\<lambda>s. tcb_at p s"
+(* FIXME AARCH64 FPU/VCPU
+crunch tcb_at[wp]: prepare_thread_delete "\<lambda>s. tcb_at p s" *)
 
 lemma (* finalise_cap_new_valid_cap *)[wp,Finalise_AI_asms]:
   "\<lbrace>valid_cap cap\<rbrace> finalise_cap cap x \<lbrace>\<lambda>rv. valid_cap (fst rv)\<rbrace>"
@@ -361,10 +377,11 @@ lemma (* finalise_cap_new_valid_cap *)[wp,Finalise_AI_asms]:
                            split del: if_split
                      | clarsimp | rule conjI)+
   (* ArchObjectCap *)
+  sorry (* FIXME AARCH64 FPU/VCPU
   apply (wpsimp wp: o_def valid_cap_def cap_aligned_def
                  split_del: if_split
          | clarsimp simp: arch_finalise_cap_def)+
-  done
+  done *)
 
 crunch inv[wp]: arch_thread_get "P"
 
@@ -487,8 +504,9 @@ lemma arch_thread_set_only_idle[wp]:
 
 lemma arch_thread_set_valid_idle[wp]:
   "arch_thread_set f t \<lbrace>valid_idle\<rbrace>"
+  sorry (* FIXME AARCH64 VCPU
   by (wpsimp simp: arch_thread_set_def set_object_def get_object_def valid_idle_def
-                   valid_arch_idle_def get_tcb_def pred_tcb_at_def obj_at_def pred_neg_def)
+                   valid_arch_idle_def get_tcb_def pred_tcb_at_def obj_at_def pred_neg_def) *)
 
 lemma arch_thread_set_valid_ioc[wp]:
   "\<lbrace>valid_ioc\<rbrace> arch_thread_set p v \<lbrace>\<lambda>rv. valid_ioc\<rbrace>"
@@ -574,7 +592,8 @@ lemma as_user_unlive_hyp[wp]:
   "\<lbrace>obj_at (Not \<circ> hyp_live) vr\<rbrace> as_user t f \<lbrace>\<lambda>_. obj_at (Not \<circ> hyp_live) vr\<rbrace>"
   unfolding as_user_def
   apply (wpsimp wp: set_object_wp)
-  by (clarsimp simp: obj_at_def hyp_live_def arch_tcb_context_set_def)
+  sorry (* FIXME AARCH64 VCPU
+  by (clarsimp simp: obj_at_def hyp_live_def arch_tcb_context_set_def) *)
 
 lemma as_user_unlive0[wp]:
   "\<lbrace>obj_at (Not \<circ> live0) vr\<rbrace> as_user t f \<lbrace>\<lambda>_. obj_at (Not \<circ> live0) vr\<rbrace>"
@@ -635,7 +654,8 @@ lemma arch_finalise_cap_invs' [wp,Finalise_AI_asms]:
    apply (wp unmap_page_invs | wpc)+
   apply (clarsimp simp: valid_cap_def cap_aligned_def)
   apply (auto simp: mask_def vmsz_aligned_def wellformed_mapdata_def)
-  done
+  sorry (* FIXME AARCH64 FPU/VCPU
+  done *)
 
 lemma as_user_unlive[wp]:
   "\<lbrace>obj_at (Not \<circ> live) vr\<rbrace> as_user t f \<lbrace>\<lambda>_. obj_at (Not \<circ> live) vr\<rbrace>"
@@ -646,19 +666,21 @@ lemma as_user_unlive[wp]:
 lemma obj_at_not_live_valid_arch_cap_strg [Finalise_AI_asms]:
   "(s \<turnstile> ArchObjectCap cap \<and> aobj_ref cap = Some r)
         \<longrightarrow> obj_at (\<lambda>ko. \<not> live ko) r s"
+  sorry (* FIXME AARCH64 FPU/VCPU
   by (clarsimp simp: valid_cap_def obj_at_def valid_arch_cap_ref_def
                      a_type_arch_live live_def hyp_live_def
-              split: arch_cap.split_asm if_splits)
+              split: arch_cap.split_asm if_splits) *)
 
 crunches set_vm_root
   for ptes_of[wp]: "\<lambda>s. P (ptes_of s)"
-  and asid_pools_of[wp]: "\<lambda>s. P (asid_pools_of s)"
+  (* FIXME AARCH64 and asid_pools_of[wp]: "\<lambda>s. P (asid_pools_of s)" *)
   and asid_table[wp]: "\<lambda>s. P (asid_table s)"
   (simp: crunch_simps)
 
 lemma set_vm_root_vs_lookup_target[wp]:
   "set_vm_root tcb \<lbrace>\<lambda>s. P (vs_lookup_target level asid vref s)\<rbrace>"
-  by (wpsimp wp: vs_lookup_target_lift)
+  sorry (* FIXME AARCH64
+  by (wpsimp wp: vs_lookup_target_lift) *)
 
 lemma vs_lookup_target_no_asid_pool:
   "\<lbrakk>asid_pool_at ptr s; valid_vspace_objs s; valid_asid_table s; pspace_aligned s;
@@ -669,6 +691,7 @@ lemma vs_lookup_target_no_asid_pool:
    apply (frule (1) pool_for_asid_validD, clarsimp)
    apply (subst (asm) pool_for_asid_vs_lookup[symmetric, where vref=0 and level=asid_pool_level, simplified])
    apply (drule (1) valid_vspace_objsD; simp add: in_omonad)
+  sorry (* FIXME AARCH64
    apply (fastforce simp: vspace_for_pool_def in_omonad obj_at_def ran_def)
   apply (rename_tac pt_ptr)
   apply (clarsimp simp: vs_lookup_slot_def obj_at_def split: if_split_asm)
@@ -681,7 +704,7 @@ lemma vs_lookup_target_no_asid_pool:
    apply (clarsimp simp: kernel_mapping_slots_def pptr_base_def pptrBase_def pt_bits_left_def
                          bit_simps level_defs canonical_bit_def)
   apply (clarsimp simp: pte_ref_def data_at_def obj_at_def split: pte.splits)
-  done
+  done *)
 
 
 lemma delete_asid_pool_not_target[wp]:
@@ -691,11 +714,12 @@ lemma delete_asid_pool_not_target[wp]:
   unfolding delete_asid_pool_def
   supply fun_upd_apply[simp del]
   apply wpsimp
+  sorry (* FIXME AARCH64
   apply (rule conjI; clarsimp)
    apply (frule vs_lookup_target_no_asid_pool[of _ _ level asid]; assumption?)
    apply (erule vs_lookup_target_clear_asid_table)
   apply (erule (4) vs_lookup_target_no_asid_pool)
-  done
+  done *)
 
 lemma delete_asid_pool_not_reachable[wp]:
   "\<lbrace>asid_pool_at ptr and valid_vspace_objs and valid_asid_table and pspace_aligned\<rbrace>
@@ -707,7 +731,7 @@ lemmas reachable_frame_cap_simps =
   reachable_frame_cap_def[unfolded is_frame_cap_def arch_cap_fun_lift_def, split_simps cap.split]
 
 lemma vs_lookup_slot_non_PageTablePTE:
-  "\<lbrakk> ptes_of s p \<noteq> None; ptes_of s' = ptes_of s(p \<mapsto> pte); \<not> is_PageTablePTE pte;
+  "\<lbrakk> ptes_of s pt_t p \<noteq> None; ptes_of s' pt_t = (ptes_of s pt_t)(p \<mapsto> pte); \<not> is_PageTablePTE pte;
      asid_pools_of s' = asid_pools_of s;
      asid_table s' = asid_table s; valid_asid_table s; pspace_aligned s\<rbrakk>
   \<Longrightarrow> vs_lookup_slot level asid vref s' =
@@ -715,18 +739,20 @@ lemma vs_lookup_slot_non_PageTablePTE:
        then vs_lookup_slot (level_of_slot asid vref p s) asid vref s
        else vs_lookup_slot level asid vref s)"
   apply clarsimp
+  sorry (* FIXME AARCH64 check statement
   apply (rule conjI; clarsimp;
            (simp (no_asm) add: vs_lookup_slot_def obind_def,
             (subst vs_lookup_non_PageTablePTE; simp),
             fastforce split: option.splits))
-  done
+  done *)
 
 lemma unmap_page_table_pool_for_asid[wp]:
   "unmap_page_table asid vref pt \<lbrace>\<lambda>s. P (pool_for_asid asid s)\<rbrace>"
-  unfolding unmap_page_table_def by (wpsimp simp: pool_for_asid_def)
+  sorry (* FIXME AARCH64
+  unfolding unmap_page_table_def by (wpsimp simp: pool_for_asid_def) *)
 
 lemma unmap_page_table_unreachable:
-  "\<lbrace> pt_at pt and valid_asid_table and valid_vspace_objs and pspace_aligned
+  "\<lbrace> pt_at pt_t pt and valid_asid_table and valid_vspace_objs and pspace_aligned
      and unique_table_refs and valid_vs_lookup and (\<lambda>s. valid_caps (caps_of_state s) s)
      and K (0 < asid \<and> vref \<in> user_region)
      and (\<lambda>s. vspace_for_asid asid s \<noteq> Some pt) \<rbrace>
@@ -734,9 +760,10 @@ lemma unmap_page_table_unreachable:
    \<lbrace>\<lambda>_ s. \<not> reachable_target (asid, vref) pt s\<rbrace>"
   unfolding reachable_target_def
   apply (wpsimp wp: hoare_vcg_all_lift unmap_page_table_not_target)
+  sorry (* FIXME AARCH64
   apply (drule (1) pool_for_asid_validD)
   apply (clarsimp simp: obj_at_def in_omonad)
-  done
+  done *)
 
 lemma unmap_page_unreachable:
   "\<lbrace> data_at pgsz pptr and valid_asid_table and valid_vspace_objs and pspace_aligned
@@ -756,7 +783,8 @@ lemma set_asid_pool_pool_for_asid[wp]:
 
 lemma delete_asid_pool_for_asid[wp]:
   "delete_asid asid pt \<lbrace>\<lambda>s. P (pool_for_asid asid' s)\<rbrace>"
-  unfolding delete_asid_def by wpsimp
+  sorry (* FIXME AARCH64
+  unfolding delete_asid_def by wpsimp *)
 
 lemma delete_asid_no_vs_lookup_target:
   "\<lbrace>\<lambda>s. vspace_for_asid asid s = Some pt\<rbrace>
@@ -765,23 +793,25 @@ lemma delete_asid_no_vs_lookup_target:
   apply (rule hoare_assume_pre)
   apply (prop_tac "0 < asid")
    apply (clarsimp simp: vspace_for_asid_def)
+  sorry (* FIXME AARCH64
   apply (rule hoare_strengthen_post, rule delete_asid_unmapped)
   apply (clarsimp simp: vs_lookup_target_def split: if_split_asm)
    apply (clarsimp simp: vs_lookup_slot_def vs_lookup_table_def split: if_split_asm)
    apply (clarsimp simp: vspace_for_asid_def obind_def)
   apply (clarsimp simp: vs_lookup_slot_def vs_lookup_table_def split: if_split_asm)
   apply (clarsimp simp: vspace_for_asid_def obind_def)
-  done
+  done *)
 
 lemma delete_asid_unreachable:
-  "\<lbrace>\<lambda>s. vspace_for_asid asid s = Some pt \<and> pt_at pt s \<and> valid_asid_table s \<rbrace>
+  "\<lbrace>\<lambda>s. vspace_for_asid asid s = Some pt \<and> pt_at pt_t pt s \<and> valid_asid_table s \<rbrace>
    delete_asid asid pt
    \<lbrace>\<lambda>_ s. \<not> reachable_target (asid, vref) pt s\<rbrace>"
   unfolding reachable_target_def
+  sorry (* FIXME AARCH64
   apply (wpsimp wp: hoare_vcg_all_lift delete_asid_no_vs_lookup_target)
   apply (drule (1) pool_for_asid_validD)
   apply (clarsimp simp: obj_at_def in_omonad)
-  done
+  done *)
 
 lemma arch_finalise_cap_replaceable:
   notes strg = tcb_cap_valid_imp_NullCap
@@ -790,10 +820,11 @@ lemma arch_finalise_cap_replaceable:
                 is_cap_simps vs_cap_ref_def
                 no_cap_to_obj_with_diff_ref_Null o_def
                 reachable_frame_cap_simps
+  (* FIXME AARCH64
   notes wps = hoare_drop_imp[where R="%_. is_final_cap' cap" for cap]
               valid_cap_typ
               unmap_page_unreachable unmap_page_table_unreachable
-              delete_asid_unreachable
+              delete_asid_unreachable *)
   shows
     "\<lbrace>\<lambda>s. s \<turnstile> ArchObjectCap cap \<and>
           x = is_final_cap' (ArchObjectCap cap) s \<and>
@@ -801,6 +832,7 @@ lemma arch_finalise_cap_replaceable:
           valid_arch_caps s\<rbrace>
      arch_finalise_cap cap x
      \<lbrace>\<lambda>rv s. replaceable s sl (fst rv) (ArchObjectCap cap)\<rbrace>"
+  sorry (* FIXME AARCH64
   apply (simp add: arch_finalise_cap_def valid_arch_caps_def)
   apply (wpsimp simp: simps valid_objs_caps wp: wps | strengthen strg)+
   apply (rule conjI, clarsimp)
@@ -809,7 +841,7 @@ lemma arch_finalise_cap_replaceable:
    apply (rule conjI; clarsimp simp: valid_cap_def wellformed_mapdata_def data_at_def split: if_split_asm)
   apply (rule conjI; clarsimp)
   apply (clarsimp simp: valid_cap_def wellformed_mapdata_def cap_aligned_def)
-  done
+  done *)
 
 
 global_naming Arch
@@ -870,25 +902,29 @@ lemma prepare_thread_delete_no_cap_to_obj_ref[wp]:
   "\<lbrace>no_cap_to_obj_with_diff_ref cap S\<rbrace>
      prepare_thread_delete t
    \<lbrace>\<lambda>rv. no_cap_to_obj_with_diff_ref cap S\<rbrace>"
-  unfolding prepare_thread_delete_def by wpsimp
+  sorry (* FIXME AARCH64 VCPU/FPU
+  unfolding prepare_thread_delete_def by wpsimp *)
 
 lemma prepare_thread_delete_unlive_hyp:
   "\<lbrace>obj_at \<top> ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> hyp_live) ptr\<rbrace>"
   apply (simp add: prepare_thread_delete_def)
   apply (wpsimp simp: obj_at_def is_tcb_def hyp_live_def)
-  done
+  sorry (* FIXME AARCH64 VCPU
+  done *)
 
 lemma prepare_thread_delete_unlive0:
   "\<lbrace>obj_at (Not \<circ> live0) ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> live0) ptr\<rbrace>"
-  by (simp add: prepare_thread_delete_def)
+  sorry (* FIXME AARCH64 VCPU/FPU
+  by (simp add: prepare_thread_delete_def) *)
 
 lemma prepare_thread_delete_unlive[wp]:
   "\<lbrace>obj_at (Not \<circ> live0) ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> live) ptr\<rbrace>"
   apply (rule_tac Q="\<lambda>rv. obj_at (Not \<circ> live0) ptr and obj_at (Not \<circ> hyp_live) ptr" in hoare_strengthen_post)
+  sorry (* FIXME AARCH64 VCPU/FPU
   apply (wpsimp wp: hoare_vcg_conj_lift prepare_thread_delete_unlive_hyp prepare_thread_delete_unlive0)
    apply (clarsimp simp: obj_at_def)
   apply (clarsimp simp: obj_at_def, case_tac ko, simp_all add: is_tcb_def live_def)
-  done
+  done *)
 
 lemma finalise_cap_replaceable [Finalise_AI_asms]:
   "\<lbrace>\<lambda>s. s \<turnstile> cap \<and> x = is_final_cap' cap s \<and> valid_mdb s
@@ -959,20 +995,23 @@ lemma arch_thread_set_cte_wp_at[wp]:
     apply (clarsimp simp: tcb_cnode_map_def)+
   done
 
-crunch cte_wp_at[wp,Finalise_AI_asms]: prepare_thread_delete "\<lambda>s. P (cte_wp_at P' p s)"
+(* FIXME AARCH64 VCPU/FPU
+crunch cte_wp_at[wp,Finalise_AI_asms]: prepare_thread_delete "\<lambda>s. P (cte_wp_at P' p s)" *)
 
+(* FIXME AARCH64 VCPU/FPU
 crunch cte_wp_at[wp,Finalise_AI_asms]: arch_finalise_cap "\<lambda>s. P (cte_wp_at P' p s)"
   (simp: crunch_simps assertE_def wp: crunch_wps set_object_cte_at
-   ignore: arch_thread_set)
+   ignore: arch_thread_set) *)
 end
 
 interpretation Finalise_AI_1?: Finalise_AI_1
   proof goal_cases
   interpret Arch .
-  case 1 show ?case by (intro_locales; (unfold_locales; fact Finalise_AI_asms)?)
+  case 1 show ?case sorry (* FIXME AARCH64
+    by (intro_locales; (unfold_locales; fact Finalise_AI_asms)?) *)
   qed
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 lemma fast_finalise_replaceable[wp]:
   "\<lbrace>\<lambda>s. s \<turnstile> cap \<and> x = is_final_cap' cap s
@@ -1011,9 +1050,10 @@ interpretation Finalise_AI_2?: Finalise_AI_2
   case 1 show ?case by (intro_locales; (unfold_locales; fact Finalise_AI_asms)?)
   qed
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
-crunch irq_node[Finalise_AI_asms,wp]: prepare_thread_delete "\<lambda>s. P (interrupt_irq_node s)"
+(* FIXME AARCH64 VCPU/FPU
+crunch irq_node[Finalise_AI_asms,wp]: prepare_thread_delete "\<lambda>s. P (interrupt_irq_node s)" *)
 
 crunch irq_node[wp]: arch_finalise_cap "\<lambda>s. P (interrupt_irq_node s)"
   (simp: crunch_simps wp: crunch_wps)
@@ -1023,8 +1063,9 @@ crunch pred_tcb_at[wp]:
   "pred_tcb_at proj P t"
   (simp: crunch_simps wp: crunch_wps test)
 
+(* FIXME AARCH64 VCPU
 crunch pred_tcb_at[wp_unsafe]: arch_finalise_cap "pred_tcb_at proj P t"
-  (simp: crunch_simps wp: crunch_wps)
+  (simp: crunch_simps wp: crunch_wps) *)
 
 definition
   replaceable_or_arch_update :: "'z::state_ext state \<Rightarrow> cslot_ptr \<Rightarrow> cap \<Rightarrow> cap \<Rightarrow> bool" where
@@ -1038,29 +1079,29 @@ definition
    else replaceable s slot cap cap'"
 
 lemma is_final_cap_pt_asid_eq:
-  "is_final_cap' (ArchObjectCap (PageTableCap p y)) s \<Longrightarrow>
-   is_final_cap' (ArchObjectCap (PageTableCap p x)) s"
+  "is_final_cap' (ArchObjectCap (PageTableCap p pt_t y)) s \<Longrightarrow>
+   is_final_cap' (ArchObjectCap (PageTableCap p pt_t x)) s"
   apply (clarsimp simp: is_final_cap'_def gen_obj_refs_def)
   done
 
 lemma is_final_cap_pd_asid_eq:
-  "is_final_cap' (ArchObjectCap (PageTableCap p y)) s \<Longrightarrow>
-   is_final_cap' (ArchObjectCap (PageTableCap p x)) s"
+  "is_final_cap' (ArchObjectCap (PageTableCap p pt_t y)) s \<Longrightarrow>
+   is_final_cap' (ArchObjectCap (PageTableCap p pt_t x)) s"
   by (rule is_final_cap_pt_asid_eq)
 
 lemma cte_wp_at_obj_refs_singleton_page_table:
   "\<lbrakk>cte_wp_at
       (\<lambda>cap'. obj_refs cap' = {p}
-            \<and> (\<exists>p asid. cap' = ArchObjectCap (PageTableCap p asid)))
+            \<and> (\<exists>p pt_t asid. cap' = ArchObjectCap (PageTableCap p pt_t asid)))
       (a, b) s\<rbrakk> \<Longrightarrow>
-   \<exists>asid. cte_wp_at ((=) (ArchObjectCap (PageTableCap p asid))) (a,b) s"
+   \<exists>asid pt_t. cte_wp_at ((=) (ArchObjectCap (PageTableCap p pt_t asid))) (a,b) s"
   apply (clarsimp simp: cte_wp_at_def)
   done
 
 lemma final_cap_pt_slot_eq:
-  "\<lbrakk>is_final_cap' (ArchObjectCap (PageTableCap p asid)) s;
-    cte_wp_at ((=) (ArchObjectCap (PageTableCap p asid'))) slot s;
-    cte_wp_at ((=) (ArchObjectCap (PageTableCap p asid''))) slot' s\<rbrakk> \<Longrightarrow>
+  "\<lbrakk>is_final_cap' (ArchObjectCap (PageTableCap p pt_t asid)) s;
+    cte_wp_at ((=) (ArchObjectCap (PageTableCap p pt_t asid'))) slot s;
+    cte_wp_at ((=) (ArchObjectCap (PageTableCap p pt_t asid''))) slot' s\<rbrakk> \<Longrightarrow>
    slot' = slot"
   apply (clarsimp simp:is_final_cap'_def2)
   apply (case_tac "(a,b) = slot'")
@@ -1081,14 +1122,16 @@ lemma is_arch_update_reset_page:
   apply (simp add: is_arch_update_def is_arch_cap_def cap_master_cap_def)
   done
 
+(* FIXME AARCH64 VCPU
 crunch caps_of_state [wp]: arch_finalise_cap "\<lambda>s. P (caps_of_state s)"
-   (wp: crunch_wps simp: crunch_simps)
+   (wp: crunch_wps simp: crunch_simps) *)
 
 lemma set_vm_root_empty[wp]:
   "\<lbrace>\<lambda>s. P (obj_at (empty_table S) p s)\<rbrace> set_vm_root v \<lbrace>\<lambda>_ s. P (obj_at (empty_table S) p s) \<rbrace>"
   apply (simp add: set_vm_root_def)
   apply (wpsimp wp: get_cap_wp)
-  done
+  sorry (* FIXME AARCH64
+  done *)
 
 lemma set_asid_pool_empty[wp]:
   "\<lbrace>obj_at (empty_table S) word\<rbrace> set_asid_pool x2 pool' \<lbrace>\<lambda>xb. obj_at (empty_table S) word\<rbrace>"
@@ -1098,7 +1141,8 @@ lemma delete_asid_empty_table_pt[wp]:
   "delete_asid a word \<lbrace>\<lambda>s. obj_at (empty_table S) word s\<rbrace>"
    apply (simp add: delete_asid_def)
    apply wpsimp
-   done
+   sorry (* FIXME AARCH64
+   done *)
 
 lemma ucast_less_shiftl_helper3:
   "\<lbrakk> len_of TYPE('b) + 3 < len_of TYPE('a); 2 ^ (len_of TYPE('b) + 3) \<le> n\<rbrakk>
@@ -1110,8 +1154,8 @@ lemma ucast_less_shiftl_helper3:
   done
 
 lemma caps_of_state_aligned_page_table:
-  "\<lbrakk>caps_of_state s slot = Some (ArchObjectCap (PageTableCap word option)); invs s\<rbrakk>
-  \<Longrightarrow> is_aligned word pt_bits"
+  "\<lbrakk>caps_of_state s slot = Some (ArchObjectCap (PageTableCap word pt_t option)); invs s\<rbrakk>
+  \<Longrightarrow> is_aligned word (pt_bits pt_t)"
   apply (frule caps_of_state_valid)
   apply (frule invs_valid_objs, assumption)
   apply (frule valid_cap_aligned)
@@ -1124,7 +1168,7 @@ lemma invs_valid_arch_capsI:
   "invs s \<Longrightarrow> valid_arch_caps s"
   by (simp add: invs_def valid_state_def)
 
-context Arch begin global_naming RISCV64 (*FIXME: arch_split*)
+context Arch begin global_naming AARCH64 (*FIXME: arch_split*)
 
 lemma do_machine_op_reachable_pg_cap[wp]:
   "\<lbrace>\<lambda>s. P (reachable_frame_cap cap s)\<rbrace>
@@ -1147,8 +1191,9 @@ lemma replaceable_or_arch_update_pg:
 
 global_naming Arch
 
+(* FIXME AARCH64 FPU
 crunch invs[wp]: prepare_thread_delete invs
-  (ignore: set_object)
+  (ignore: set_object) *)
 
 lemma (* finalise_cap_invs *)[Finalise_AI_asms]:
   shows "\<lbrace>invs and cte_wp_at ((=) cap) slot\<rbrace> finalise_cap cap x \<lbrace>\<lambda>rv. invs\<rbrace>"
@@ -1157,6 +1202,7 @@ lemma (* finalise_cap_invs *)[Finalise_AI_asms]:
                    unbind_maybe_notification_invs
                   | simp add: o_def split del: if_split cong: if_cong
                   | wpc )+
+  sorry (* FIXME AARCH64 FPU/VCPU
       apply clarsimp (* thread *)
       apply (frule cte_wp_at_valid_objs_valid_cap, clarsimp)
       apply (clarsimp simp: valid_cap_def)
@@ -1165,13 +1211,14 @@ lemma (* finalise_cap_invs *)[Finalise_AI_asms]:
       apply (simp add: cap_range_def)
      apply (wp deleting_irq_handler_invs  | simp | intro conjI impI)+
   apply (auto dest: cte_wp_at_valid_objs_valid_cap)
-  done
+  done *)
 
 lemma (* finalise_cap_irq_node *)[Finalise_AI_asms]:
 "\<lbrace>\<lambda>s. P (interrupt_irq_node s)\<rbrace> finalise_cap a b \<lbrace>\<lambda>_ s. P (interrupt_irq_node s)\<rbrace>"
   apply (case_tac a,simp_all)
   apply (wp | clarsimp)+
-  done
+  sorry (* FIXME AARCH64 FPU/VCPU
+  done *)
 
 lemmas (*arch_finalise_cte_irq_node *) [wp,Finalise_AI_asms]
     = hoare_use_eq_irq_node [OF arch_finalise_cap_irq_node arch_finalise_cap_cte_wp_at]
@@ -1280,10 +1327,11 @@ interpretation Finalise_AI_3?: Finalise_AI_3
   where replaceable_or_arch_update = replaceable_or_arch_update
   proof goal_cases
   interpret Arch .
-  case 1 show ?case by (intro_locales; (unfold_locales; fact Finalise_AI_asms)?)
+  case 1 show ?case  sorry (* FIXME AARCH64
+    by (intro_locales; (unfold_locales; fact Finalise_AI_asms)?) *)
   qed
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 lemma typ_at_data_at_wp:
   assumes typ_wp: "\<And>a.\<lbrace>typ_at a p \<rbrace> g \<lbrace>\<lambda>s. typ_at a p\<rbrace>"
@@ -1301,7 +1349,7 @@ interpretation Finalise_AI_4?: Finalise_AI_4
   case 1 show ?case by (intro_locales; (unfold_locales; fact Finalise_AI_asms)?)
   qed
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 lemma set_asid_pool_obj_at_ptr:
   "\<lbrace>\<lambda>s. P (ArchObj (arch_kernel_obj.ASIDPool mp))\<rbrace>
@@ -1314,17 +1362,17 @@ lemma set_asid_pool_obj_at_ptr:
 
 locale_abbrev
   "asid_table_update asid ap s \<equiv>
-     s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := riscv_asid_table (arch_state s)(asid \<mapsto> ap)\<rparr>\<rparr>"
+     s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := arm_asid_table (arch_state s)(asid \<mapsto> ap)\<rparr>\<rparr>"
 
 lemma valid_table_caps_table [simp]:
-  "valid_table_caps (s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := table'\<rparr>\<rparr>) = valid_table_caps s"
+  "valid_table_caps (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := table'\<rparr>\<rparr>) = valid_table_caps s"
   by (simp add: valid_table_caps_def)
 
 lemma valid_kernel_mappings [iff]:
-  "valid_kernel_mappings (s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := table'\<rparr>\<rparr>) = valid_kernel_mappings s"
+  "valid_kernel_mappings (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := table'\<rparr>\<rparr>) = valid_kernel_mappings s"
   by (simp add: valid_kernel_mappings_def)
 
-crunches unmap_page_table, store_pte, delete_asid_pool, copy_global_mappings
+crunches unmap_page_table, store_pte, delete_asid_pool(* FIXME AARCH64 , copy_global_mappings *)
   for valid_cap[wp]: "valid_cap c"
   (wp: mapM_wp_inv mapM_x_wp' simp: crunch_simps)
 
@@ -1333,7 +1381,8 @@ lemmas delete_asid_typ_ats[wp] = abs_typ_at_lifts [OF delete_asid_typ_at]
 lemma arch_finalise_cap_valid_cap[wp]:
   "arch_finalise_cap cap b \<lbrace>valid_cap c\<rbrace>"
   unfolding arch_finalise_cap_def
-  by (wpsimp split: arch_cap.split option.split bool.split)
+  sorry (* FIXME AARCH64 VCPU
+  by (wpsimp split: arch_cap.split option.split bool.split) *)
 
 global_naming Arch
 

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -22,11 +22,10 @@ declare prepare_thread_delete_caps_of_state [Finalise_AI_asms]
 
 global_naming AARCH64
 
-(* FIXME AARCH64
 lemma valid_global_refs_asid_table_udapte [iff]:
   "valid_global_refs (s\<lparr>arch_state := arm_asid_table_update f (arch_state s)\<rparr>) =
   valid_global_refs s"
-  by (simp add: valid_global_refs_def global_refs_def) *)
+  by (simp add: valid_global_refs_def global_refs_def)
 
 lemma nat_to_cref_unat_of_bl':
   "\<lbrakk> length xs < 64; n = length xs \<rbrakk> \<Longrightarrow>
@@ -44,38 +43,27 @@ lemma nat_to_cref_unat_of_bl':
 
 lemmas nat_to_cref_unat_of_bl = nat_to_cref_unat_of_bl' [OF _ refl]
 
-(* FIXME AARCH64
-lemma riscv_global_pt_asid_table_update[simp]:
-  "riscv_global_pt (arch_state s\<lparr>arm_asid_table := atable\<rparr>) = riscv_global_pt (arch_state s)"
-  by (simp add: riscv_global_pt_def) *)
+lemma global_pt_asid_table_update[simp]:
+  "arm_us_global_vspace (arch_state s\<lparr>arm_asid_table := atable\<rparr>) = global_pt s"
+  by simp
 
 lemma equal_kernel_mappings_asid_table_unmap:
   "equal_kernel_mappings s
    \<Longrightarrow> equal_kernel_mappings (s\<lparr>arch_state := arch_state s
                                 \<lparr>arm_asid_table := (asid_table s)(i := None)\<rparr>\<rparr>)"
-  unfolding equal_kernel_mappings_def
-  apply clarsimp
-  sorry (* FIXME AARCH64
-  apply (erule_tac x=asid in allE)
-  apply (erule_tac x=pt_ptr in allE)
-  apply (clarsimp simp: fun_upd_def)
-  apply (erule impE)
-   subgoal by (clarsimp simp: vspace_for_asid_def in_omonad pool_for_asid_def split: if_splits)
-  apply (clarsimp simp: has_kernel_mappings_def)
-  done *)
+  unfolding equal_kernel_mappings_def by simp
 
 lemma invs_arm_asid_table_unmap:
   "invs s \<and> is_aligned base asid_low_bits
        \<and> tab = arm_asid_table (arch_state s)
      \<longrightarrow> invs (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := tab(asid_high_bits_of base := None)\<rparr>\<rparr>)"
   apply (clarsimp simp: invs_def valid_state_def valid_arch_caps_def)
-  sorry (* FIXME AARCH64
   apply (strengthen valid_asid_map_unmap valid_vspace_objs_unmap_strg
                     valid_vs_lookup_unmap_strg valid_arch_state_unmap_strg)
   apply (simp add: valid_irq_node_def valid_kernel_mappings_def)
   apply (simp add: valid_table_caps_def valid_machine_state_def valid_global_objs_def
                    valid_asid_pool_caps_def equal_kernel_mappings_asid_table_unmap)
-  done *)
+  done
 
 lemma delete_asid_pool_invs[wp]:
   "delete_asid_pool base pptr \<lbrace>invs\<rbrace>"
@@ -803,15 +791,14 @@ lemma delete_asid_no_vs_lookup_target:
   done *)
 
 lemma delete_asid_unreachable:
-  "\<lbrace>\<lambda>s. vspace_for_asid asid s = Some pt \<and> pt_at pt_t pt s \<and> valid_asid_table s \<rbrace>
+  "\<lbrace>\<lambda>s. vspace_for_asid asid s = Some pt \<and> pt_at VSRootPT_T pt s \<and> valid_asid_table s \<rbrace>
    delete_asid asid pt
    \<lbrace>\<lambda>_ s. \<not> reachable_target (asid, vref) pt s\<rbrace>"
   unfolding reachable_target_def
-  sorry (* FIXME AARCH64
   apply (wpsimp wp: hoare_vcg_all_lift delete_asid_no_vs_lookup_target)
   apply (drule (1) pool_for_asid_validD)
   apply (clarsimp simp: obj_at_def in_omonad)
-  done *)
+  done
 
 lemma arch_finalise_cap_replaceable:
   notes strg = tcb_cap_valid_imp_NullCap
@@ -1372,7 +1359,7 @@ lemma valid_kernel_mappings [iff]:
   "valid_kernel_mappings (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := table'\<rparr>\<rparr>) = valid_kernel_mappings s"
   by (simp add: valid_kernel_mappings_def)
 
-crunches unmap_page_table, store_pte, delete_asid_pool(* FIXME AARCH64 , copy_global_mappings *)
+crunches unmap_page_table, store_pte, delete_asid_pool
   for valid_cap[wp]: "valid_cap c"
   (wp: mapM_wp_inv mapM_x_wp' simp: crunch_simps)
 

--- a/proof/invariant-abstract/AARCH64/ArchInterruptAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInterruptAcc_AI.thy
@@ -1,0 +1,38 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(*
+ Arch-specific interrupt invariants
+*)
+
+theory ArchInterruptAcc_AI
+imports InterruptAcc_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems InterruptAcc_AI_assms
+
+lemma dmo_maskInterrupt_invs [InterruptAcc_AI_assms]:
+  "\<lbrace>all_invs_but_valid_irq_states_for irq and (\<lambda>s. state = interrupt_states s irq)\<rbrace>
+   do_machine_op (maskInterrupt (state = IRQInactive) irq)
+   \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (simp add: do_machine_op_def split_def maskInterrupt_def)
+  apply wp
+  apply (clarsimp simp: in_monad invs_def valid_state_def all_invs_but_valid_irq_states_for_def
+                        valid_irq_states_but_def valid_irq_masks_but_def valid_machine_state_def
+                        cur_tcb_def valid_irq_states_def valid_irq_masks_def)
+  done
+
+end
+
+global_interpretation InterruptAcc_AI?: InterruptAcc_AI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; fact InterruptAcc_AI_assms)
+  qed
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchInterruptAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInterruptAcc_AI.thy
@@ -12,7 +12,7 @@ theory ArchInterruptAcc_AI
 imports InterruptAcc_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems InterruptAcc_AI_assms
 

--- a/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
@@ -1,0 +1,272 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchInterrupt_AI
+imports Interrupt_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+primrec arch_irq_control_inv_valid_real ::
+  "arch_irq_control_invocation \<Rightarrow> 'a::state_ext state \<Rightarrow> bool"
+  where
+  "arch_irq_control_inv_valid_real (RISCVIRQControlInvocation irq dest_slot src_slot trigger) =
+     (cte_wp_at ((=) cap.NullCap) dest_slot and
+      cte_wp_at ((=) cap.IRQControlCap) src_slot and
+      ex_cte_cap_wp_to is_cnode_cap dest_slot and
+      real_cte_at dest_slot and
+      K (irq \<le> maxIRQ \<and> irq \<noteq> irqInvalid))"
+
+defs arch_irq_control_inv_valid_def:
+  "arch_irq_control_inv_valid \<equiv> arch_irq_control_inv_valid_real"
+
+named_theorems Interrupt_AI_asms
+
+lemma (* decode_irq_control_invocation_inv *)[Interrupt_AI_asms]:
+  "\<lbrace>P\<rbrace> decode_irq_control_invocation label args slot caps \<lbrace>\<lambda>rv. P\<rbrace>"
+  apply (simp add: decode_irq_control_invocation_def Let_def arch_check_irq_def
+                   arch_decode_irq_control_invocation_def whenE_def, safe)
+  apply (wp | simp)+
+  done
+
+lemma decode_irq_control_valid [Interrupt_AI_asms]:
+  "\<lbrace>\<lambda>s. invs s \<and> (\<forall>cap \<in> set caps. s \<turnstile> cap)
+        \<and> (\<forall>cap \<in> set caps. is_cnode_cap cap \<longrightarrow>
+                (\<forall>r \<in> cte_refs cap (interrupt_irq_node s). ex_cte_cap_wp_to is_cnode_cap r s))
+        \<and> cte_wp_at ((=) cap.IRQControlCap) slot s\<rbrace>
+     decode_irq_control_invocation label args slot caps
+   \<lbrace>irq_control_inv_valid\<rbrace>,-"
+  apply (simp add: decode_irq_control_invocation_def Let_def split_def
+                   whenE_def arch_check_irq_def
+                   arch_decode_irq_control_invocation_def
+                 split del: if_split cong: if_cong)
+  apply (wpsimp wp: ensure_empty_stronger simp: cte_wp_at_eq_simp arch_irq_control_inv_valid_def
+         | wp (once) hoare_drop_imps)+
+  apply (clarsimp simp: linorder_not_less word_le_nat_alt unat_ucast maxIRQ_def)
+  apply (cases caps; clarsimp simp: cte_wp_at_eq_simp)
+  apply (intro conjI impI; clarsimp)
+  apply (drule ucast_ucast_mask_eq)
+   apply (subst and_mask_eq_iff_le_mask)
+   apply (simp add: mask_def word_le_nat_alt)
+  apply fast
+  done
+
+lemma get_irq_slot_different_ARCH[Interrupt_AI_asms]:
+  "\<lbrace>\<lambda>s. valid_global_refs s \<and> ex_cte_cap_wp_to is_cnode_cap ptr s\<rbrace>
+      get_irq_slot irq
+   \<lbrace>\<lambda>rv s. rv \<noteq> ptr\<rbrace>"
+  apply (simp add: get_irq_slot_def)
+  apply wp
+  apply (clarsimp simp: valid_global_refs_def valid_refs_def
+                        ex_cte_cap_wp_to_def)
+  apply (elim allE, erule notE, erule cte_wp_at_weakenE)
+  apply (clarsimp simp: global_refs_def is_cap_simps cap_range_def)
+  done
+
+lemma is_derived_use_interrupt_ARCH[Interrupt_AI_asms]:
+  "(is_ntfn_cap cap \<and> interrupt_derived cap cap') \<longrightarrow> (is_derived m p cap cap')"
+  apply (clarsimp simp: is_cap_simps)
+  apply (clarsimp simp: interrupt_derived_def is_derived_def)
+  apply (clarsimp simp: cap_master_cap_def split: cap.split_asm)
+  apply (simp add: is_cap_simps is_pt_cap_def vs_cap_ref_def)
+  done
+
+lemma maskInterrupt_invs_ARCH[Interrupt_AI_asms]:
+  "\<lbrace>invs and (\<lambda>s. \<not>b \<longrightarrow> interrupt_states s irq \<noteq> IRQInactive)\<rbrace>
+   do_machine_op (maskInterrupt b irq)
+   \<lbrace>\<lambda>rv. invs\<rbrace>"
+   apply (simp add: do_machine_op_def split_def maskInterrupt_def)
+   apply wp
+   apply (clarsimp simp: in_monad invs_def valid_state_def all_invs_but_valid_irq_states_for_def
+                         valid_irq_states_but_def valid_irq_masks_but_def valid_machine_state_def
+                         cur_tcb_def valid_irq_states_def valid_irq_masks_def)
+  done
+
+crunch device_state_inv[wp]: plic_complete_claim "\<lambda>ms. P (device_state ms)"
+
+lemma dmo_plic_complete_claim[wp]:
+  "do_machine_op (plic_complete_claim irq) \<lbrace>invs\<rbrace>"
+  apply (wp dmo_invs)
+  apply (auto simp: plic_complete_claim_def machine_op_lift_def machine_rest_lift_def in_monad select_f_def)
+  done
+
+lemma no_cap_to_obj_with_diff_IRQHandler_ARCH[Interrupt_AI_asms]:
+  "no_cap_to_obj_with_diff_ref (IRQHandlerCap irq) S = \<top>"
+  by (rule ext, simp add: no_cap_to_obj_with_diff_ref_def
+                          cte_wp_at_caps_of_state
+                          obj_ref_none_no_asid)
+
+lemma (* set_irq_state_valid_cap *)[Interrupt_AI_asms]:
+  "\<lbrace>valid_cap cap\<rbrace> set_irq_state IRQSignal irq \<lbrace>\<lambda>rv. valid_cap cap\<rbrace>"
+  apply (clarsimp simp: set_irq_state_def)
+  apply (wp do_machine_op_valid_cap)
+  apply (auto simp: valid_cap_def valid_untyped_def
+             split: cap.splits option.splits arch_cap.splits
+         split del: if_split)
+  done
+
+crunch valid_global_refs[Interrupt_AI_asms]: set_irq_state "valid_global_refs"
+
+lemma invoke_irq_handler_invs'[Interrupt_AI_asms]:
+  assumes dmo_ex_inv[wp]: "\<And>f. \<lbrace>invs and ex_inv\<rbrace> do_machine_op f \<lbrace>\<lambda>rv::unit. ex_inv\<rbrace>"
+  assumes cap_insert_ex_inv[wp]: "\<And>cap src dest.
+  \<lbrace>ex_inv and invs and K (src \<noteq> dest)\<rbrace>
+      cap_insert cap src dest
+  \<lbrace>\<lambda>_.ex_inv\<rbrace>"
+  assumes cap_delete_one_ex_inv[wp]: "\<And>cap.
+   \<lbrace>ex_inv and invs\<rbrace> cap_delete_one cap \<lbrace>\<lambda>_.ex_inv\<rbrace>"
+ shows
+  "\<lbrace>invs and ex_inv and irq_handler_inv_valid i\<rbrace> invoke_irq_handler i \<lbrace>\<lambda>rv s. invs s \<and> ex_inv s\<rbrace>"
+ proof -
+   have
+   cap_insert_invs_ex_invs[wp]: "\<And>cap src dest. \<lbrace>ex_inv and (invs  and cte_wp_at (\<lambda>c. c = NullCap) dest and valid_cap cap and
+   tcb_cap_valid cap dest and
+   ex_cte_cap_wp_to (appropriate_cte_cap cap) dest and
+   (\<lambda>s. \<forall>r\<in>obj_refs cap.
+           \<forall>p'. dest \<noteq> p' \<and> cte_wp_at (\<lambda>cap'. r \<in> obj_refs cap') p' s \<longrightarrow>
+                cte_wp_at (Not \<circ> is_zombie) p' s \<and> \<not> is_zombie cap) and
+   (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s) and
+   (\<lambda>s. cte_wp_at (\<lambda>cap'. \<forall>irq\<in>cap_irqs cap - cap_irqs cap'. irq_issued irq s)
+         src s) and
+   (\<lambda>s. \<forall>t R. cap = ReplyCap t False R \<longrightarrow>
+            st_tcb_at awaiting_reply t s \<and> \<not> has_reply_cap t s) and
+   K (\<not> is_master_reply_cap cap))\<rbrace>
+  cap_insert cap src dest \<lbrace>\<lambda>rv s. invs s \<and> ex_inv s\<rbrace>"
+   apply wp
+   apply (auto simp: cte_wp_at_caps_of_state)
+   done
+  show ?thesis
+  apply (cases i, simp_all)
+    apply (wp dmo_plic_complete_claim)
+    apply simp+
+   apply (rename_tac irq cap prod)
+   apply (rule hoare_pre)
+    apply (wp valid_cap_typ [OF cap_delete_one_typ_at])
+     apply (strengthen real_cte_tcb_valid)
+     apply (wp real_cte_at_typ_valid [OF cap_delete_one_typ_at])
+     apply (rule_tac Q="\<lambda>rv s. is_ntfn_cap cap \<and> invs s
+                              \<and> cte_wp_at (is_derived (cdt s) prod cap) prod s"
+                in hoare_post_imp)
+      apply (clarsimp simp: is_cap_simps is_derived_def cte_wp_at_caps_of_state)
+      apply (simp split: if_split_asm)
+      apply (simp add: cap_master_cap_def split: cap.split_asm)
+      apply (drule cte_wp_valid_cap [OF caps_of_state_cteD] | clarsimp)+
+      apply (clarsimp simp: cap_master_cap_simps valid_cap_def obj_at_def is_ntfn is_tcb is_cap_table
+                     split: option.split_asm dest!:cap_master_cap_eqDs)
+     apply (wp cap_delete_one_still_derived)
+    apply simp
+        apply (wp get_irq_slot_ex_cte get_irq_slot_different_ARCH hoare_drop_imps)
+      apply (clarsimp simp: valid_state_def invs_def appropriate_cte_cap_def
+                            is_cap_simps)
+      apply (erule cte_wp_at_weakenE, simp add: is_derived_use_interrupt_ARCH)
+     apply (wp| simp add: )+
+  done
+qed
+
+lemma (* invoke_irq_control_invs *) [Interrupt_AI_asms]:
+  "\<lbrace>invs and irq_control_inv_valid i\<rbrace> invoke_irq_control i \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (cases i, simp_all)
+   apply (wp cap_insert_simple_invs
+          | simp add: IRQHandler_valid is_cap_simps  no_cap_to_obj_with_diff_IRQHandler_ARCH
+          | strengthen real_cte_tcb_valid)+
+   apply (clarsimp simp: cte_wp_at_caps_of_state
+                         is_simple_cap_def is_cap_simps is_pt_cap_def
+                         safe_parent_for_def is_simple_cap_arch_def
+                         ex_cte_cap_to_cnode_always_appropriate_strg)
+  apply (rename_tac irq_control, case_tac irq_control)
+  apply (simp add: arch_irq_control_inv_valid_def)
+  apply (wp cap_insert_simple_invs
+         | simp add: IRQHandler_valid is_cap_simps  no_cap_to_obj_with_diff_IRQHandler_ARCH
+         | strengthen real_cte_tcb_valid)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state is_simple_cap_def is_simple_cap_arch_def
+                        is_cap_simps is_pt_cap_def safe_parent_for_def
+                        ex_cte_cap_to_cnode_always_appropriate_strg)
+  done
+
+
+crunch device_state_inv[wp]: resetTimer "\<lambda>ms. P (device_state ms)"
+
+lemma resetTimer_invs_ARCH[Interrupt_AI_asms]:
+  "\<lbrace>invs\<rbrace> do_machine_op resetTimer \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (wp dmo_invs)
+  apply safe
+   apply (drule_tac Q="%_ b. underlying_memory b p = underlying_memory m p"
+                 in use_valid)
+     apply (simp add: resetTimer_def
+                      machine_op_lift_def machine_rest_lift_def split_def)
+     apply wp
+    apply (clarsimp+)[2]
+  apply(erule use_valid, wp no_irq_resetTimer no_irq, assumption)
+  done
+
+lemma empty_fail_ackInterrupt_ARCH[Interrupt_AI_asms]:
+  "empty_fail (ackInterrupt irq)"
+  by (wp | simp add: ackInterrupt_def)+
+
+lemma empty_fail_maskInterrupt_ARCH[Interrupt_AI_asms]:
+  "empty_fail (maskInterrupt f irq)"
+  by (wp | simp add: maskInterrupt_def)+
+
+lemma dmo_st_tcb_cur[wp]:
+  "\<lbrace>\<lambda>s. st_tcb_at P (cur_thread s) s\<rbrace> do_machine_op f \<lbrace>\<lambda>rv s. st_tcb_at P (cur_thread s) s\<rbrace>"
+  by (rule hoare_lift_Pf[where f=cur_thread]; wp)
+
+lemma dmo_ex_nonz_cap_to[wp]:
+  "\<lbrace>\<lambda>s. ex_nonz_cap_to (cur_thread s) s\<rbrace> do_machine_op f \<lbrace>\<lambda>rv s. ex_nonz_cap_to (cur_thread s) s\<rbrace>"
+  by (rule hoare_lift_Pf[where f=cur_thread]; wp)
+
+lemma conj_imp_strg:
+  "P \<Longrightarrow> (A \<longrightarrow> P) \<and> (B \<longrightarrow> P)" by simp
+
+lemma runnable_eq:
+  "runnable st = (st = Running \<or> st = Restart)"
+  by (cases st; simp)
+
+lemma halted_eq:
+  "halted st = (st = Inactive \<or> st = IdleThreadState)"
+  by (cases st; simp)
+
+lemma handle_reserved_irq_invs[wp]:
+  "\<lbrace>invs\<rbrace> handle_reserved_irq irq \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding handle_reserved_irq_def by (wpsimp simp: non_kernel_IRQs_def)
+
+lemma (* handle_interrupt_invs *) [Interrupt_AI_asms]:
+  "\<lbrace>invs\<rbrace> handle_interrupt irq \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (simp add: handle_interrupt_def)
+  apply (rule conjI; rule impI)
+  apply (simp add: do_machine_op_bind empty_fail_ackInterrupt_ARCH empty_fail_maskInterrupt_ARCH)
+     apply (wpsimp wp: dmo_maskInterrupt_invs maskInterrupt_invs_ARCH dmo_ackInterrupt
+                      send_signal_interrupt_states simp: arch_mask_irq_signal_def)+
+     apply (wp get_cap_wp send_signal_interrupt_states )
+    apply (rule_tac Q="\<lambda>rv. invs and (\<lambda>s. st = interrupt_states s irq)" in hoare_post_imp)
+     apply (clarsimp simp: ex_nonz_cap_to_def invs_valid_objs)
+     apply (intro allI exI, erule cte_wp_at_weakenE)
+     apply (clarsimp simp: is_cap_simps)
+    apply (wpsimp wp: hoare_drop_imps resetTimer_invs_ARCH
+                simp: get_irq_state_def
+           | rule conjI)+
+ done
+
+lemma sts_arch_irq_control_inv_valid[wp, Interrupt_AI_asms]:
+  "\<lbrace>arch_irq_control_inv_valid i\<rbrace>
+       set_thread_state t st
+   \<lbrace>\<lambda>rv. arch_irq_control_inv_valid i\<rbrace>"
+  apply (simp add: arch_irq_control_inv_valid_def)
+  apply (cases i, simp)
+  apply (wpsimp wp: ex_cte_cap_to_pres simp: cap_table_at_typ)
+  done
+
+crunch typ_at[wp]: arch_invoke_irq_handler "\<lambda>s. P (typ_at T p s)"
+
+end
+
+interpretation Interrupt_AI?: Interrupt_AI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; (unfold_locales, simp_all add: Interrupt_AI_asms)?)
+  qed
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
@@ -269,7 +269,7 @@ end
 interpretation Interrupt_AI?: Interrupt_AI
   proof goal_cases
   interpret Arch .
-  case 1 show ?case sorry (* FIXME AARCH64 by (intro_locales; (unfold_locales, simp_all add: Interrupt_AI_asms)?) *)
+  case 1 show ?case by (intro_locales; (unfold_locales, simp_all add: Interrupt_AI_asms)?)
   qed
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
@@ -304,16 +304,14 @@ fun valid_vspace_obj :: "vm_level \<Rightarrow> arch_kernel_obj \<Rightarrow> 'z
 | "valid_vspace_obj _ (DataPage _ _) = \<top>" (* already covered by valid_pte *)
 | "valid_vspace_obj _ (VCPU _ ) = \<top>" (* not a vspace obj *)
 
-fun
-  is_vspace_typ :: "a_type \<Rightarrow> bool"
-where
-  "is_vspace_typ (AArch AVCPU) = False"
-| "is_vspace_typ (AArch  _)    = True"
-| "is_vspace_typ  _            = False"
+definition vspace_obj_of :: "arch_kernel_obj \<Rightarrow> arch_kernel_obj option" where
+  "vspace_obj_of ao \<equiv> if is_VCPU ao then None else Some ao"
+
+locale_abbrev vspace_objs_of :: "'z::state_ext state \<Rightarrow> obj_ref \<Rightarrow> arch_kernel_obj option" where
+  "vspace_objs_of \<equiv> \<lambda>s. aobjs_of s |> vspace_obj_of"
 
 definition valid_vso_at :: "vm_level \<Rightarrow> obj_ref \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
-  "valid_vso_at level p \<equiv> \<lambda>s. \<exists>ao. aobjs_of s p = Some ao \<and> valid_vspace_obj level ao s
-                                   \<and> is_vspace_typ (AArch (aa_type ao))"
+  "valid_vso_at level p \<equiv> \<lambda>s. \<exists>ao. vspace_objs_of s p = Some ao \<and> valid_vspace_obj level ao s"
 
 definition wellformed_pte :: "pte \<Rightarrow> bool" where
   "wellformed_pte pte \<equiv> is_PagePTE pte \<longrightarrow> pte_rights pte \<in> valid_vm_rights"

--- a/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
@@ -304,8 +304,16 @@ fun valid_vspace_obj :: "vm_level \<Rightarrow> arch_kernel_obj \<Rightarrow> 'z
 | "valid_vspace_obj _ (DataPage _ _) = \<top>" (* already covered by valid_pte *)
 | "valid_vspace_obj _ (VCPU _ ) = \<top>" (* not a vspace obj *)
 
+fun
+  is_vspace_typ :: "a_type \<Rightarrow> bool"
+where
+  "is_vspace_typ (AArch AVCPU) = False"
+| "is_vspace_typ (AArch  _)    = True"
+| "is_vspace_typ  _            = False"
+
 definition valid_vso_at :: "vm_level \<Rightarrow> obj_ref \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
-  "valid_vso_at level p \<equiv> \<lambda>s. \<exists>ao. aobjs_of s p = Some ao \<and> valid_vspace_obj level ao s"
+  "valid_vso_at level p \<equiv> \<lambda>s. \<exists>ao. aobjs_of s p = Some ao \<and> valid_vspace_obj level ao s
+                                   \<and> is_vspace_typ (AArch (aa_type ao))"
 
 definition wellformed_pte :: "pte \<Rightarrow> bool" where
   "wellformed_pte pte \<equiv> is_PagePTE pte \<longrightarrow> pte_rights pte \<in> valid_vm_rights"

--- a/proof/invariant-abstract/AARCH64/ArchIpcCancel_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchIpcCancel_AI.thy
@@ -1,0 +1,29 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchIpcCancel_AI
+imports IpcCancel_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems IpcCancel_AI_asms
+
+crunches arch_post_cap_deletion
+  for typ_at[wp, IpcCancel_AI_asms]: "\<lambda>s. P (typ_at T p s)"
+  and idle_thread[wp, IpcCancel_AI_asms]: "\<lambda>s. P (idle_thread s)"
+
+end
+
+interpretation IpcCancel_AI?: IpcCancel_AI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+  by (intro_locales; (unfold_locales; fact IpcCancel_AI_asms)?)
+  qed
+
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchIpcCancel_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchIpcCancel_AI.thy
@@ -8,7 +8,7 @@ theory ArchIpcCancel_AI
 imports IpcCancel_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems IpcCancel_AI_asms
 

--- a/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
@@ -1,0 +1,505 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchIpc_AI
+imports Ipc_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems Ipc_AI_assms
+
+lemma cap_asid_PageCap_None[simp]:
+  "cap_asid (ArchObjectCap (FrameCap r R pgsz dev None)) = None"
+  by (simp add: cap_asid_def)
+
+lemma arch_derive_cap_is_derived:
+  "\<lbrace>\<lambda>s. cte_wp_at (\<lambda>cap . cap_master_cap cap =
+                          cap_master_cap (ArchObjectCap c') \<and>
+                          cap_aligned cap \<and>
+                          cap_asid cap = cap_asid (ArchObjectCap c') \<and>
+                          vs_cap_ref cap = vs_cap_ref (ArchObjectCap c')) p s\<rbrace>
+     arch_derive_cap c'
+   \<lbrace>\<lambda>rv s. cte_wp_at (is_derived (cdt s) p rv) p s\<rbrace>, -"
+  unfolding arch_derive_cap_def
+  apply(cases c', simp_all add: is_cap_simps cap_master_cap_def)
+      apply((wp throwError_validE_R
+             | clarsimp simp: is_derived_def
+                              is_cap_simps cap_master_cap_def
+                              cap_aligned_def is_aligned_no_overflow is_pt_cap_def
+                              cap_asid_def vs_cap_ref_def vs_cap_ref_arch_def
+             | erule cte_wp_at_weakenE
+             | simp split: arch_cap.split_asm cap.split_asm option.splits
+             | rule conjI)+)
+  done
+
+lemma derive_cap_is_derived [Ipc_AI_assms]:
+  "\<lbrace>\<lambda>s. c'\<noteq> cap.NullCap \<longrightarrow> cte_wp_at (\<lambda>cap. cap_master_cap cap = cap_master_cap c'
+                     \<and> (cap_badge cap, cap_badge c') \<in> capBadge_ordering False
+                     \<and> cap_asid cap = cap_asid c'
+                     \<and> vs_cap_ref cap = vs_cap_ref c') slot s
+       \<and> valid_objs s\<rbrace>
+  derive_cap slot c'
+  \<lbrace>\<lambda>rv s. rv \<noteq> cap.NullCap \<longrightarrow>
+          cte_wp_at (is_derived (cdt s) slot rv) slot s\<rbrace>, -"
+  unfolding derive_cap_def
+  apply (cases c', simp_all add: is_cap_simps)
+          apply ((wp ensure_no_children_wp
+                    | clarsimp simp: is_derived_def is_cap_simps
+                                     cap_master_cap_def bits_of_def
+                                     same_object_as_def is_pt_cap_def
+                                     cap_asid_def
+                    | fold validE_R_def
+                    | erule cte_wp_at_weakenE
+                    | simp split: cap.split_asm)+)[11]
+  including no_pre
+  apply(rule hoare_pre, wp hoare_drop_imps arch_derive_cap_is_derived)
+  apply(clarify, drule cte_wp_at_norm, clarify)
+  apply(frule(1) cte_wp_at_valid_objs_valid_cap)
+  apply(erule cte_wp_at_weakenE)
+  apply(clarsimp simp: valid_cap_def)
+  done
+
+lemma is_derived_cap_rights [simp, Ipc_AI_assms]:
+  "is_derived m p (cap_rights_update R c) = is_derived m p c"
+  apply (rule ext)
+  apply (simp add: cap_rights_update_def is_derived_def is_cap_simps)
+  apply (case_tac x, simp_all)
+  by (auto simp: cap_master_cap_def bits_of_def is_cap_simps
+                     vs_cap_ref_def is_frame_cap_def
+                     acap_rights_update_def is_pt_cap_def
+           cong: arch_cap.case_cong
+           split: arch_cap.split cap.split bool.splits)
+
+
+lemma data_to_message_info_valid [Ipc_AI_assms]:
+  "valid_message_info (data_to_message_info w)"
+  by (simp add: valid_message_info_def data_to_message_info_def  word_and_le1 msg_max_length_def
+                msg_max_extra_caps_def Let_def not_less mask_def)
+
+lemma get_extra_cptrs_length[wp, Ipc_AI_assms]:
+  "\<lbrace>\<lambda>s . valid_message_info mi\<rbrace>
+   get_extra_cptrs buf mi
+   \<lbrace>\<lambda>rv s. length rv \<le> msg_max_extra_caps\<rbrace>"
+  apply (cases buf)
+   apply (simp, wp, simp)
+  apply (simp add: msg_max_length_def)
+  apply (subst hoare_liftM_subst, simp add: o_def)
+  apply (rule hoare_pre)
+   apply (rule mapM_length, simp)
+  apply (clarsimp simp: valid_message_info_def msg_max_extra_caps_def
+                        word_le_nat_alt
+                 intro: length_upt)
+  done
+
+lemma cap_asid_rights_update [simp, Ipc_AI_assms]:
+  "cap_asid (cap_rights_update R c) = cap_asid c"
+  by (simp add: cap_rights_update_def acap_rights_update_def cap_asid_def
+         split: cap.splits arch_cap.splits)
+
+lemma cap_rights_update_vs_cap_ref[simp, Ipc_AI_assms]:
+  "vs_cap_ref (cap_rights_update rs cap) = vs_cap_ref cap"
+  by (simp add: vs_cap_ref_def vs_cap_ref_arch_def cap_rights_update_def acap_rights_update_def
+         split: cap.split arch_cap.split)
+
+lemma is_derived_cap_rights2[simp, Ipc_AI_assms]:
+  "is_derived m p c (cap_rights_update R c') = is_derived m p c c'"
+  apply (case_tac c'; simp add: cap_rights_update_def)
+     apply (clarsimp simp: is_derived_def is_cap_simps cap_master_cap_def vs_cap_ref_def
+                    split: cap.splits)+
+  apply (rename_tac acap1 acap2)
+  apply (case_tac acap1)
+  by (auto simp: acap_rights_update_def)
+
+lemma cap_range_update [simp, Ipc_AI_assms]:
+  "cap_range (cap_rights_update R cap) = cap_range cap"
+  by (simp add: cap_range_def cap_rights_update_def acap_rights_update_def
+         split: cap.splits arch_cap.splits)
+
+lemma derive_cap_idle[wp, Ipc_AI_assms]:
+  "\<lbrace>\<lambda>s. global_refs s \<inter> cap_range cap = {}\<rbrace>
+   derive_cap slot cap
+  \<lbrace>\<lambda>c s. global_refs s \<inter> cap_range c = {}\<rbrace>, -"
+  apply (simp add: derive_cap_def)
+  apply (rule hoare_pre)
+   apply (wpc| wp | simp add: arch_derive_cap_def)+
+  apply (case_tac cap, simp_all add: cap_range_def)
+  apply (rename_tac arch_cap)
+  apply (case_tac arch_cap, simp_all)
+  done
+
+lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_assms]:
+  "\<lbrace>\<lambda>s . P (set_option (aobj_ref cap)) False s\<rbrace>
+     arch_derive_cap cap
+   \<lbrace>\<lambda>rv s. rv \<noteq> NullCap \<longrightarrow> P (obj_refs rv) (is_zombie rv) s\<rbrace>,-"
+  apply(cases cap, simp_all add: is_zombie_def arch_derive_cap_def)
+      apply(rule hoare_pre, wpsimp+)+
+  done
+
+lemma obj_refs_remove_rights[simp, Ipc_AI_assms]:
+  "obj_refs (remove_rights rs cap) = obj_refs cap"
+  by (auto simp add: remove_rights_def cap_rights_update_def
+                acap_rights_update_def
+         split: cap.splits arch_cap.splits bool.splits)
+
+lemma storeWord_um_inv:
+  "\<lbrace>\<lambda>s. underlying_memory s = um\<rbrace>
+   storeWord a v
+   \<lbrace>\<lambda>_ s. is_aligned a 3 \<and> x \<in> {a,a+1,a+2,a+3,a+4,a+5,a+6,a+7} \<or> underlying_memory s x = um x\<rbrace>"
+  by (wpsimp simp: upto.simps storeWord_def is_aligned_mask)
+
+lemma store_word_offs_vms[wp, Ipc_AI_assms]:
+  "\<lbrace>valid_machine_state\<rbrace> store_word_offs ptr offs v \<lbrace>\<lambda>_. valid_machine_state\<rbrace>"
+proof -
+  have aligned_offset_ignore:
+    "\<And>(l::machine_word) (p::machine_word) sz. l<8 \<Longrightarrow> p && mask 3 = 0 \<Longrightarrow>
+       p+l && ~~ mask (pageBitsForSize sz) = p && ~~ mask (pageBitsForSize sz)"
+  proof -
+    fix l::machine_word and p::machine_word and sz
+    assume al: "p && mask 3 = 0"
+    assume "l < 8" hence less: "l<2^3" by simp
+    have le: "3 \<le> pageBitsForSize sz" by (case_tac sz; simp add: bit_simps)
+    show "?thesis l p sz"
+      by (rule is_aligned_add_helper[simplified is_aligned_mask,
+          THEN conjunct2, THEN mask_out_first_mask_some,
+          where n=3, OF al less le])
+  qed
+
+  show ?thesis
+    apply (simp add: valid_machine_state_def store_word_offs_def
+                     do_machine_op_def split_def)
+    apply wp
+    apply clarsimp
+    apply (drule_tac use_valid)
+    apply (rule_tac x=p in storeWord_um_inv, simp+)
+    apply (drule_tac x=p in spec)
+    apply (erule disjE, simp)
+    apply (erule disjE, simp_all)
+    apply (erule conjE)
+    apply (erule disjE, simp)
+    apply (simp add: in_user_frame_def word_size_def)
+    apply (erule exEI)
+    apply (subgoal_tac "(ptr + of_nat offs * 8) && ~~ mask (pageBitsForSize x) =
+                        p && ~~ mask (pageBitsForSize x)", simp)
+    apply (simp only: is_aligned_mask[of _ 3])
+    apply (elim disjE, simp_all)
+    apply (rule aligned_offset_ignore[symmetric], simp+)+
+    done
+qed
+
+lemma is_zombie_update_cap_data[simp, Ipc_AI_assms]:
+  "is_zombie (update_cap_data P data cap) = is_zombie cap"
+  by (simp add: update_cap_data_closedform arch_update_cap_data_def is_zombie_def
+         split: cap.splits)
+
+lemma valid_msg_length_strengthen [Ipc_AI_assms]:
+  "valid_message_info mi \<longrightarrow> unat (mi_length mi) \<le> msg_max_length"
+  apply (clarsimp simp: valid_message_info_def)
+  apply (subgoal_tac "unat (mi_length mi) \<le> unat (of_nat msg_max_length :: machine_word)")
+   apply (clarsimp simp: unat_of_nat msg_max_length_def)
+  apply (clarsimp simp: un_ui_le word_le_def)
+  done
+
+lemma copy_mrs_in_user_frame[wp, Ipc_AI_assms]:
+  "\<lbrace>in_user_frame p\<rbrace> copy_mrs t buf t' buf' n \<lbrace>\<lambda>rv. in_user_frame p\<rbrace>"
+  by (simp add: in_user_frame_def) (wp hoare_vcg_ex_lift)
+
+lemma as_user_getRestart_invs[wp]: "\<lbrace>P\<rbrace> as_user t getRestartPC \<lbrace>\<lambda>_. P\<rbrace>"
+  by (simp add: getRestartPC_def, rule user_getreg_inv)
+
+lemma make_arch_fault_msg_invs[wp, Ipc_AI_assms]: "make_arch_fault_msg f t \<lbrace>invs\<rbrace>"
+  by (cases f; wpsimp)
+
+lemma make_fault_message_inv[wp, Ipc_AI_assms]:
+  "make_fault_msg ft t \<lbrace>invs\<rbrace>"
+  apply (cases ft, simp_all split del: if_split)
+     apply (wp as_user_inv getRestartPC_inv mapM_wp'
+              | simp add: getRegister_def)+
+  done
+
+crunch tcb_at[wp]: make_fault_msg "tcb_at t"
+
+lemma do_fault_transfer_invs[wp, Ipc_AI_assms]:
+  "\<lbrace>invs and tcb_at receiver\<rbrace>
+      do_fault_transfer badge sender receiver recv_buf
+   \<lbrace>\<lambda>rv. invs\<rbrace>"
+  by (simp add: do_fault_transfer_def split_def | wp
+    | clarsimp split: option.split)+
+
+lemma lookup_ipc_buffer_in_user_frame[wp, Ipc_AI_assms]:
+  "\<lbrace>valid_objs and tcb_at t\<rbrace> lookup_ipc_buffer b t
+   \<lbrace>case_option (\<lambda>_. True) in_user_frame\<rbrace>"
+  apply (simp add: lookup_ipc_buffer_def)
+  apply (wp get_cap_wp thread_get_wp | wpc | simp)+
+  apply (clarsimp simp add: obj_at_def is_tcb)
+  apply (rename_tac p R sz dev m)
+  apply (subgoal_tac "in_user_frame (p + (tcb_ipc_buffer tcb && mask (pageBitsForSize sz))) s",
+         simp)
+  apply (frule (1) cte_wp_valid_cap)
+  apply (clarsimp simp: valid_cap_def cap_aligned_def in_user_frame_def)
+  apply (thin_tac "case_option a b c" for a b c)
+  apply (rule_tac x=sz in exI)
+  apply (subst is_aligned_add_helper[THEN conjunct2])
+    apply simp
+   apply (rule and_mask_less')
+   apply (rule pageBitsForSize_bounded[unfolded word_bits_def])
+  apply simp
+  done
+
+lemma transfer_caps_loop_cte_wp_at:
+  assumes imp: "\<And>cap. P cap \<Longrightarrow> \<not> is_untyped_cap cap"
+  shows "\<lbrace>cte_wp_at P sl and K (sl \<notin> set slots) and (\<lambda>s. \<forall>x \<in> set slots. cte_at x s)\<rbrace>
+   transfer_caps_loop ep buffer n caps slots mi
+   \<lbrace>\<lambda>rv. cte_wp_at P sl\<rbrace>"
+  apply (induct caps arbitrary: slots n mi)
+   apply (simp, wp, simp)
+  apply (clarsimp simp: Let_def split_def whenE_def
+                  cong: if_cong list.case_cong
+             split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp hoare_vcg_const_imp_lift hoare_vcg_const_Ball_lift
+              derive_cap_is_derived_foo
+             hoare_drop_imps
+        | assumption | simp split del: if_split)+
+      apply (wp hoare_vcg_conj_lift cap_insert_weak_cte_wp_at2)
+       apply (erule imp)
+      by (wp hoare_vcg_ball_lift
+             | clarsimp simp: is_cap_simps split del:if_split
+             | unfold derive_cap_def arch_derive_cap_def
+             | wpc
+             | rule conjI
+             | case_tac slots)+
+
+lemma transfer_caps_tcb_caps:
+  fixes P t ref mi caps ep receiver recv_buf
+  assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
+  shows
+  "\<lbrace>valid_objs and cte_wp_at P (t, ref) and tcb_at t\<rbrace>
+     transfer_caps mi caps ep receiver recv_buf
+   \<lbrace>\<lambda>rv. cte_wp_at P (t, ref)\<rbrace>"
+  apply (simp add: transfer_caps_def)
+  apply (wp hoare_vcg_const_Ball_lift hoare_vcg_const_imp_lift
+            transfer_caps_loop_cte_wp_at
+         | wpc | simp)+
+    apply (erule imp)
+   apply (wp hoare_vcg_conj_lift hoare_vcg_const_imp_lift hoare_vcg_all_lift)
+    apply (rule_tac Q = "\<lambda>rv s. (\<forall>x\<in>set rv. real_cte_at x s) \<and> cte_wp_at P (t, ref) s \<and> tcb_at t s"
+                    in hoare_strengthen_post)
+     apply (wp get_rs_real_cte_at)
+    apply clarsimp
+    apply (drule(1) bspec)
+    apply (clarsimp simp:obj_at_def is_tcb is_cap_table)
+   apply (rule hoare_post_imp)
+    apply (rule_tac Q="\<lambda>x. real_cte_at x s" in ballEI, assumption)
+    apply (erule real_cte_at_cte)
+   apply (rule get_rs_real_cte_at)
+  apply clarsimp
+ done
+
+lemma transfer_caps_non_null_cte_wp_at:
+  assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
+  shows  "\<lbrace>valid_objs and cte_wp_at (P and ((\<noteq>) cap.NullCap)) ptr\<rbrace>
+     transfer_caps mi caps ep receiver recv_buf
+   \<lbrace>\<lambda>_. cte_wp_at (P and ((\<noteq>) cap.NullCap)) ptr\<rbrace>"
+  unfolding transfer_caps_def
+  apply simp
+  apply (rule hoare_pre)
+   apply (wp hoare_vcg_ball_lift transfer_caps_loop_cte_wp_at static_imp_wp
+     | wpc | clarsimp simp:imp)+
+   apply (rule hoare_strengthen_post
+            [where Q="\<lambda>rv s'. (cte_wp_at ((\<noteq>) cap.NullCap) ptr) s'
+                      \<and> (\<forall>x\<in>set rv. cte_wp_at ((=) cap.NullCap) x s')",
+             rotated])
+    apply (clarsimp)
+    apply  (rule conjI)
+     apply (erule contrapos_pn)
+     apply (drule_tac x=ptr in bspec, assumption)
+     apply (clarsimp elim!: cte_wp_at_orth)
+    apply (rule ballI)
+    apply (drule(1) bspec)
+    apply (erule cte_wp_cte_at)
+   apply (wp)
+  apply (auto simp: cte_wp_at_caps_of_state)
+  done
+
+crunch cte_wp_at[wp,Ipc_AI_assms]: do_fault_transfer "cte_wp_at P p"
+
+lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_assms]:
+  assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
+  shows  "\<lbrace>valid_objs and cte_wp_at (P and ((\<noteq>) cap.NullCap)) ptr\<rbrace>
+   do_normal_transfer st send_buffer ep b gr rt recv_buffer
+   \<lbrace>\<lambda>_. cte_wp_at (P and ((\<noteq>) cap.NullCap)) ptr\<rbrace>"
+  unfolding do_normal_transfer_def
+  apply simp
+  apply (wp transfer_caps_non_null_cte_wp_at
+    | clarsimp simp:imp)+
+  done
+
+lemma is_derived_ReplyCap [simp, Ipc_AI_assms]:
+  "\<And>m p R. is_derived m p (cap.ReplyCap t False R) = (\<lambda>c. is_master_reply_cap c \<and> obj_ref_of c = t)"
+  apply (subst fun_eq_iff)
+  apply clarsimp
+  apply (case_tac x, simp_all add: is_derived_def is_cap_simps
+                                   cap_master_cap_def conj_comms is_pt_cap_def
+                                   vs_cap_ref_def)
+  done
+
+lemma do_normal_transfer_tcb_caps:
+  assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
+  shows
+  "\<lbrace>valid_objs and cte_wp_at P (t, ref) and tcb_at t\<rbrace>
+   do_normal_transfer st sb ep badge grant rt rb
+   \<lbrace>\<lambda>rv. cte_wp_at P (t, ref)\<rbrace>"
+  apply (simp add: do_normal_transfer_def)
+  apply (rule hoare_pre)
+   apply (wp hoare_drop_imps transfer_caps_tcb_caps
+     | simp add:imp)+
+  done
+
+lemma do_ipc_transfer_tcb_caps [Ipc_AI_assms]:
+  assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
+  shows
+  "\<lbrace>valid_objs and cte_wp_at P (t, ref) and tcb_at t\<rbrace>
+   do_ipc_transfer st ep b gr rt
+   \<lbrace>\<lambda>rv. cte_wp_at P (t, ref)\<rbrace>"
+  apply (simp add: do_ipc_transfer_def)
+  apply (rule hoare_pre)
+  apply (wp do_normal_transfer_tcb_caps hoare_drop_imps
+       | wpc | simp add:imp)+
+  done
+
+lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_assms]:
+  "\<lbrace>valid_global_objs\<rbrace> setup_caller_cap send recv grant \<lbrace>\<lambda>rv. valid_global_objs\<rbrace>"
+  apply (simp add: valid_global_objs_def)
+  unfolding setup_caller_cap_def
+   apply (wp sts_obj_at_impossible | simp add: tcb_not_empty_table)+
+  done
+
+crunch inv[Ipc_AI_assms]: handle_arch_fault_reply, arch_get_sanitise_register_info P
+
+lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_assms]:
+  "\<lbrace>valid_vspace_objs\<rbrace>
+      transfer_caps_loop ep buffer n caps slots mi
+    \<lbrace>\<lambda>rv. valid_vspace_objs\<rbrace>"
+  apply (induct caps arbitrary: slots n mi, simp)
+  apply (clarsimp simp: Let_def split_def whenE_def
+                  cong: if_cong list.case_cong
+             split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp hoare_vcg_const_imp_lift hoare_vcg_const_Ball_lift
+              derive_cap_is_derived_foo
+             hoare_drop_imps
+        | assumption | simp split del: if_split)+
+  done
+
+crunch aligned                   [wp, Ipc_AI_assms]:  make_arch_fault_msg "pspace_aligned"
+crunch distinct                  [wp, Ipc_AI_assms]:  make_arch_fault_msg "pspace_distinct"
+crunch vmdb                      [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_mdb"
+crunch ifunsafe                  [wp, Ipc_AI_assms]:  make_arch_fault_msg "if_unsafe_then_cap"
+crunch iflive                    [wp, Ipc_AI_assms]:  make_arch_fault_msg "if_live_then_nonz_cap"
+crunch state_refs_of             [wp, Ipc_AI_assms]:  make_arch_fault_msg "\<lambda>s. P (state_refs_of s)"
+crunch ct                        [wp, Ipc_AI_assms]:  make_arch_fault_msg "cur_tcb"
+crunch zombies                   [wp, Ipc_AI_assms]:  make_arch_fault_msg "zombies_final"
+crunch it                        [wp, Ipc_AI_assms]:  make_arch_fault_msg "\<lambda>s. P (idle_thread s)"
+crunch valid_globals             [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_global_refs"
+crunch reply_masters             [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_reply_masters"
+crunch valid_idle                [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_idle"
+crunch arch                      [wp, Ipc_AI_assms]:  make_arch_fault_msg "\<lambda>s. P (arch_state s)"
+crunch typ_at                    [wp, Ipc_AI_assms]:  make_arch_fault_msg "\<lambda>s. P (typ_at T p s)"
+crunch irq_node                  [wp, Ipc_AI_assms]:  make_arch_fault_msg "\<lambda>s. P (interrupt_irq_node s)"
+crunch valid_reply               [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_reply_caps"
+crunch irq_handlers              [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_irq_handlers"
+crunch vspace_objs               [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_vspace_objs"
+crunch global_objs               [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_global_objs"
+crunch global_vspace_mapping     [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_global_vspace_mappings"
+crunch arch_caps                 [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_arch_caps"
+crunch v_ker_map                 [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_kernel_mappings"
+crunch eq_ker_map                [wp, Ipc_AI_assms]:  make_arch_fault_msg "equal_kernel_mappings"
+crunch asid_map                  [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_asid_map"
+crunch only_idle                 [wp, Ipc_AI_assms]:  make_arch_fault_msg "only_idle"
+crunch pspace_in_kernel_window   [wp, Ipc_AI_assms]:  make_arch_fault_msg "pspace_in_kernel_window"
+crunch cap_refs_in_kernel_window [wp, Ipc_AI_assms]:  make_arch_fault_msg "cap_refs_in_kernel_window"
+crunch valid_objs                [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_objs"
+crunch valid_ioc                 [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_ioc"
+crunch pred_tcb                  [wp, Ipc_AI_assms]:  make_arch_fault_msg "pred_tcb_at proj P t"
+crunch cap_to                    [wp, Ipc_AI_assms]:  make_arch_fault_msg "ex_nonz_cap_to p"
+
+crunch obj_at[wp, Ipc_AI_assms]:  make_arch_fault_msg "\<lambda>s. P (obj_at P' pd s)"
+  (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def)
+
+crunch vms[wp, Ipc_AI_assms]: make_arch_fault_msg valid_machine_state
+  (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
+
+crunch valid_irq_states[wp, Ipc_AI_assms]: make_arch_fault_msg "valid_irq_states"
+  (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
+
+crunch cap_refs_respects_device_region[wp, Ipc_AI_assms]: make_arch_fault_msg "cap_refs_respects_device_region"
+  (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
+
+end
+
+interpretation Ipc_AI?: Ipc_AI
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_assms)?)
+qed
+
+context Arch begin global_naming RISCV64
+
+named_theorems Ipc_AI_cont_assms
+
+crunch pspace_respects_device_region[wp]: make_fault_msg "pspace_respects_device_region"
+  (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
+
+crunch pspace_respects_device_region[wp, Ipc_AI_cont_assms]: do_ipc_transfer "pspace_respects_device_region"
+  (wp: crunch_wps ignore: const_on_failure simp: crunch_simps)
+
+lemma do_ipc_transfer_respects_device_region[Ipc_AI_cont_assms]:
+  "\<lbrace>cap_refs_respects_device_region and tcb_at t and  valid_objs and valid_mdb\<rbrace>
+   do_ipc_transfer t ep bg grt r
+   \<lbrace>\<lambda>rv. cap_refs_respects_device_region\<rbrace>"
+  apply (wpsimp simp: do_ipc_transfer_def do_normal_transfer_def transfer_caps_def bind_assoc
+                wp: hoare_vcg_all_lift hoare_drop_imps)+
+         apply (simp only: ball_conj_distrib[where P="\<lambda>x. real_cte_at x s" for s])
+         apply (wpsimp wp: get_rs_cte_at2 thread_get_wp static_imp_wp grs_distinct
+                           hoare_vcg_ball_lift hoare_vcg_all_lift hoare_vcg_conj_lift
+                       simp: obj_at_def is_tcb_def)+
+   apply (simp split: kernel_object.split_asm)
+   done
+
+lemma set_mrs_state_hyp_refs_of[wp]:
+  "\<lbrace>\<lambda> s. P (state_hyp_refs_of s)\<rbrace> set_mrs thread buf msgs \<lbrace>\<lambda>_ s. P (state_hyp_refs_of s)\<rbrace>"
+  by (wp set_mrs_thread_set_dmo thread_set_hyp_refs_trivial | simp)+
+
+crunch state_hyp_refs_of[wp, Ipc_AI_cont_assms]: do_ipc_transfer "\<lambda> s. P (state_hyp_refs_of s)"
+  (wp: crunch_wps simp: zipWithM_x_mapM)
+
+lemma arch_derive_cap_untyped:
+  "\<lbrace>\<lambda>s. P (untyped_range (ArchObjectCap cap))\<rbrace>
+   arch_derive_cap cap
+   \<lbrace>\<lambda>rv s. rv \<noteq> cap.NullCap \<longrightarrow> P (untyped_range rv)\<rbrace>,-"
+  by (wpsimp simp: arch_derive_cap_def)
+
+lemma valid_arch_mdb_cap_swap:
+  "\<And>s cap capb.
+       \<lbrakk>valid_arch_mdb (is_original_cap s) (caps_of_state s);
+        weak_derived c cap; caps_of_state s a = Some cap;
+        is_untyped_cap cap \<longrightarrow> cap = c; a \<noteq> b;
+        weak_derived c' capb; caps_of_state s b = Some capb\<rbrakk>
+       \<Longrightarrow> valid_arch_mdb
+            ((is_original_cap s)
+             (a := is_original_cap s b, b := is_original_cap s a))
+            (caps_of_state s(a \<mapsto> c', b \<mapsto> c))"
+  by (auto simp: valid_arch_mdb_def)
+
+end
+
+interpretation Ipc_AI_cont?: Ipc_AI_cont
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales;(fact Ipc_AI_cont_assms)?)
+  qed
+end

--- a/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
@@ -431,11 +431,23 @@ crunch cap_to                    [wp, Ipc_AI_assms]:  make_arch_fault_msg "ex_no
 crunch obj_at[wp, Ipc_AI_assms]:  make_arch_fault_msg "\<lambda>s. P (obj_at P' pd s)"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def)
 
+lemma dmo_addressTranslateS1_valid_machine_state[wp]:
+  "do_machine_op (addressTranslateS1 addr) \<lbrace> valid_machine_state \<rbrace>"
+  sorry (* FIXME AARCH64 *)
+
 crunch vms[wp, Ipc_AI_assms]: make_arch_fault_msg valid_machine_state
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
+lemma dmo_addressTranslateS1_valid_irq_states[wp]:
+  "do_machine_op (addressTranslateS1 addr) \<lbrace> valid_irq_states \<rbrace>"
+  sorry (* FIXME AARCH64 *)
+
 crunch valid_irq_states[wp, Ipc_AI_assms]: make_arch_fault_msg "valid_irq_states"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
+
+lemma dmo_addressTranslateS1_cap_refs_respects_device_region[wp]:
+  "do_machine_op (addressTranslateS1 addr) \<lbrace> cap_refs_respects_device_region \<rbrace>"
+  sorry (* FIXME AARCH64 *)
 
 crunch cap_refs_respects_device_region[wp, Ipc_AI_assms]: make_arch_fault_msg "cap_refs_respects_device_region"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
@@ -451,6 +463,10 @@ qed
 context Arch begin global_naming AARCH64
 
 named_theorems Ipc_AI_cont_assms
+
+lemma dmo_addressTranslateS1_pspace_respects_device_region[wp]:
+  "do_machine_op (addressTranslateS1 addr) \<lbrace> pspace_respects_device_region \<rbrace>"
+  sorry (* FIXME AARCH64 *)
 
 crunch pspace_respects_device_region[wp]: make_fault_msg "pspace_respects_device_region"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)

--- a/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
@@ -416,8 +416,6 @@ crunch vspace_objs               [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid
 crunch global_objs               [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_global_objs"
 crunch global_vspace_mapping     [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_global_vspace_mappings"
 crunch arch_caps                 [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_arch_caps"
-(* FIXME AARCH64: addressTranslateS1
-crunch v_ker_map                 [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_kernel_mappings" *)
 crunch eq_ker_map                [wp, Ipc_AI_assms]:  make_arch_fault_msg "equal_kernel_mappings"
 crunch asid_map                  [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_asid_map"
 crunch only_idle                 [wp, Ipc_AI_assms]:  make_arch_fault_msg "only_idle"
@@ -427,6 +425,9 @@ crunch valid_objs                [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid
 crunch valid_ioc                 [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_ioc"
 crunch pred_tcb                  [wp, Ipc_AI_assms]:  make_arch_fault_msg "pred_tcb_at proj P t"
 crunch cap_to                    [wp, Ipc_AI_assms]:  make_arch_fault_msg "ex_nonz_cap_to p"
+
+crunch v_ker_map                 [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_kernel_mappings"
+ (simp: valid_kernel_mappings_def)
 
 crunch obj_at[wp, Ipc_AI_assms]:  make_arch_fault_msg "\<lambda>s. P (obj_at P' pd s)"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def)
@@ -457,7 +458,7 @@ end
 interpretation Ipc_AI?: Ipc_AI
 proof goal_cases
   interpret Arch .
-  case 1 show ?case sorry (* FIXME AARCH64 by (unfold_locales; (fact Ipc_AI_assms)?) *)
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_assms)?)
 qed
 
 context Arch begin global_naming AARCH64

--- a/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
@@ -8,7 +8,7 @@ theory ArchIpc_AI
 imports Ipc_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems Ipc_AI_assms
 
@@ -416,7 +416,8 @@ crunch vspace_objs               [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid
 crunch global_objs               [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_global_objs"
 crunch global_vspace_mapping     [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_global_vspace_mappings"
 crunch arch_caps                 [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_arch_caps"
-crunch v_ker_map                 [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_kernel_mappings"
+(* FIXME AARCH64: addressTranslateS1
+crunch v_ker_map                 [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_kernel_mappings" *)
 crunch eq_ker_map                [wp, Ipc_AI_assms]:  make_arch_fault_msg "equal_kernel_mappings"
 crunch asid_map                  [wp, Ipc_AI_assms]:  make_arch_fault_msg "valid_asid_map"
 crunch only_idle                 [wp, Ipc_AI_assms]:  make_arch_fault_msg "only_idle"
@@ -444,10 +445,10 @@ end
 interpretation Ipc_AI?: Ipc_AI
 proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact Ipc_AI_assms)?)
+  case 1 show ?case sorry (* FIXME AARCH64 by (unfold_locales; (fact Ipc_AI_assms)?) *)
 qed
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems Ipc_AI_cont_assms
 

--- a/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
@@ -1,0 +1,799 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchKHeap_AI
+imports KHeapPre_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+definition "non_vspace_obj \<equiv> non_arch_obj"
+definition "vspace_obj_pred \<equiv> arch_obj_pred"
+
+end
+
+locale vspace_only_obj_pred = Arch +
+  fixes P :: "kernel_object \<Rightarrow> bool"
+  assumes vspace_only: "vspace_obj_pred P"
+
+sublocale vspace_only_obj_pred < arch_only_obj_pred
+  using vspace_only[unfolded vspace_obj_pred_def] by unfold_locales
+
+context Arch begin global_naming RISCV64
+
+lemma valid_vspace_obj_lift:
+  assumes "\<And>T p. f \<lbrace>typ_at (AArch T) p\<rbrace>"
+  shows "f \<lbrace>valid_vspace_obj level obj\<rbrace>"
+  by ((cases obj; simp),
+      safe; wpsimp wp: assms hoare_vcg_ball_lift hoare_vcg_all_lift valid_pte_lift)
+
+lemma aobjs_of_atyp_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (typ_at (AArch T) p s)\<rbrace>"
+  by (wpsimp simp: typ_at_aobjs wp: assms)
+
+lemma valid_vspace_objs_lift_vs_lookup:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (vs_lookup s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_kernel_vspace (arch_state s)) \<rbrace>"
+  shows   "\<lbrace>valid_vspace_objs\<rbrace> f \<lbrace>\<lambda>rv. valid_vspace_objs\<rbrace>"
+  unfolding valid_vspace_objs_def
+  apply (wp hoare_vcg_all_lift)
+   apply (rule hoare_lift_Pf[where f="aobjs_of"])
+    apply (rule hoare_lift_Pf[where f="\<lambda>s. riscv_kernel_vspace (arch_state s)"])
+     apply (rule_tac f="vs_lookup" in hoare_lift_Pf)
+      apply (wpsimp wp: assms hoare_vcg_imp_lift valid_vspace_obj_lift aobjs_of_atyp_lift)+
+  done
+
+lemma vspace_obj_imp:
+  "non_arch_obj ko \<Longrightarrow> non_vspace_obj ko"
+  unfolding non_vspace_obj_def by assumption
+
+lemma non_vspace_objs[intro!]:
+  "non_vspace_obj (Endpoint ep)"
+  "non_vspace_obj (CNode sz cnode_contents)"
+  "non_vspace_obj (TCB tcb)"
+  "non_vspace_obj (Notification notification)"
+  by (auto simp: non_vspace_obj_def)
+
+lemma vspace_obj_predE:
+  "\<lbrakk>vspace_obj_pred P; non_vspace_obj ko; non_vspace_obj ko'\<rbrakk> \<Longrightarrow> P ko = P ko'"
+  unfolding  vspace_obj_pred_def non_vspace_obj_def by (rule arch_obj_predE)
+
+lemmas vspace_obj_pred_defs = non_vspace_objs vspace_obj_pred_def
+
+lemma vspace_pred_imp:
+  "vspace_obj_pred P \<Longrightarrow> arch_obj_pred P"
+  using vspace_obj_pred_def by simp
+
+lemma vspace_obj_pred_a_type[intro!, simp]:
+  "vspace_obj_pred (\<lambda>ko. a_type ko = AArch T)"
+  by (auto simp: vspace_obj_pred_def)
+
+lemma vspace_obj_pred_arch_obj_l[intro!, simp]:
+  "vspace_obj_pred (\<lambda>ko. ArchObj ako = ko)"
+  by (auto simp: vspace_obj_pred_def)
+
+lemma vspace_obj_pred_arch_obj_r[intro!, simp]:
+  "vspace_obj_pred (\<lambda>ko. ko = ArchObj ako)"
+  by (auto simp: vspace_obj_pred_def)
+
+lemma vspace_obj_pred_const_conjI[intro]:
+  "\<lbrakk> vspace_obj_pred P; vspace_obj_pred P' \<rbrakk> \<Longrightarrow> vspace_obj_pred (\<lambda>ko. P ko \<and> P' ko)"
+  unfolding vspace_obj_pred_def by blast
+
+lemma vspace_obj_pred_fI:
+  "(\<And>x. vspace_obj_pred (P x)) \<Longrightarrow> vspace_obj_pred (\<lambda>ko. f (\<lambda>x. P x ko))"
+  by (simp only: vspace_obj_pred_def arch_obj_pred_fI)
+
+lemmas [intro!] = vspace_obj_pred_fI[where f=All] vspace_obj_pred_fI[where f=Ex]
+
+lemma kheap_typ_only:
+  "(\<forall>p ko. kheap s p = Some ko \<longrightarrow> P p (a_type ko)) = (\<forall>p T. typ_at T p s \<longrightarrow> P p T)"
+  by (auto simp: obj_at_def)
+
+lemma pspace_in_kernel_window_atyp_lift_strong:
+  assumes "\<And>P p T. f \<lbrace>\<lambda>s. P (typ_at T p s) \<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_kernel_vspace (arch_state s))\<rbrace>"
+  shows      "\<lbrace>\<lambda>s. pspace_in_kernel_window s\<rbrace> f \<lbrace>\<lambda>rv s. pspace_in_kernel_window s\<rbrace>"
+  unfolding pspace_in_kernel_window_def obj_bits_T
+  apply (rule hoare_lift_Pf[where f="\<lambda>s. riscv_kernel_vspace (arch_state s)"])
+   apply (subst kheap_typ_only)+
+   apply (wpsimp wp: hoare_vcg_all_lift wp: assms)+
+  done
+
+lemma pspace_in_kernel_window_atyp_lift:
+  assumes "\<And>P p T. \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>"
+  assumes "\<And>P. \<lbrace>\<lambda>s. P (arch_state s)\<rbrace> f \<lbrace>\<lambda>r s. P (arch_state s)\<rbrace>"
+  shows "\<lbrace>\<lambda>s. pspace_in_kernel_window s\<rbrace> f \<lbrace>\<lambda>rv s. pspace_in_kernel_window s\<rbrace>"
+  by (rule pspace_in_kernel_window_atyp_lift_strong[OF assms])
+
+lemma cap_refs_in_kernel_window_arch_update[simp]:
+  "riscv_kernel_vspace (f (arch_state s)) = riscv_kernel_vspace (arch_state s)
+   \<Longrightarrow> cap_refs_in_kernel_window (arch_state_update f s) = cap_refs_in_kernel_window s"
+  by (simp add: cap_refs_in_kernel_window_def)
+
+lemma in_user_frame_obj_pred_lift:
+  assumes "\<And>P P' p. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' p s)\<rbrace>"
+  shows "f \<lbrace>in_user_frame p\<rbrace> "
+  unfolding in_user_frame_def
+  by (wpsimp wp: hoare_vcg_ex_lift assms simp: vspace_obj_pred_def)
+
+lemma pool_for_asid_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (pool_for_asid asid s)\<rbrace>"
+  by (wpsimp simp: pool_for_asid_def wp: assms)
+
+lemma vs_lookup_table_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (ptes_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (vs_lookup_table level asid vref s)\<rbrace>"
+  apply (simp add: vs_lookup_table_def obind_def split: option.splits)
+  apply (wpsimp wp: assms hoare_vcg_all_lift hoare_vcg_ex_lift hoare_vcg_imp_lift' pool_for_asid_lift
+                simp: not_le)
+  done
+
+lemma vs_lookup_slot_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (ptes_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (vs_lookup_slot level asid vref s)\<rbrace>"
+  apply (simp add: vs_lookup_slot_def obind_def split: option.splits)
+  apply (wpsimp wp: assms hoare_vcg_all_lift hoare_vcg_ex_lift hoare_vcg_imp_lift' pool_for_asid_lift
+                    vs_lookup_table_lift
+                simp: not_le)
+  done
+
+lemma vs_lookup_target_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (ptes_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (vs_lookup_target level asid vref s)\<rbrace>"
+  apply (simp add: vs_lookup_target_def obind_def split: option.splits)
+  apply (wpsimp wp: assms hoare_vcg_all_lift hoare_vcg_ex_lift hoare_vcg_imp_lift' pool_for_asid_lift
+                    vs_lookup_slot_lift
+                simp: not_le)
+  done
+
+lemma vs_lookup_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (ptes_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (vs_lookup s)\<rbrace>"
+  apply (rule_tac P=P in hoare_liftP_ext)+
+  apply (rename_tac P asid)
+  apply (rule_tac P=P in hoare_liftP_ext)
+  by (rule vs_lookup_table_lift; rule assms)
+
+lemma vs_lookup_vspace_aobjs_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows " f \<lbrace>\<lambda>s. P (vs_lookup s)\<rbrace>"
+  by (rule vs_lookup_lift; rule assms)
+
+lemma valid_vspace_objs_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows   "f \<lbrace>valid_vspace_objs\<rbrace>"
+  by (rule valid_vspace_objs_lift_vs_lookup, rule vs_lookup_lift; rule assms)
+
+lemma aobjs_of_ako_at_Some:
+  "(aobjs_of s p = Some ao) = ako_at ao p s"
+  by (simp add: obj_at_def in_opt_map_eq)
+
+lemma aobjs_of_ako_at_None:
+  "(aobjs_of s p = None) = (\<not> obj_at (\<lambda>obj. \<exists>ao. obj = ArchObj ao) p s)"
+  apply (clarsimp simp: obj_at_def opt_map_def split: option.splits)
+  apply (rename_tac ao, case_tac ao; simp)
+  done
+
+(* The only arch objects on RISC-V are vspace_objs *)
+lemma vspace_obj_pred_aobjs:
+  assumes "\<And>P P' p. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' p s)\<rbrace>"
+  shows "\<And>P. f \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (erule_tac P=P in rsubst)
+  apply (rule ext, rename_tac s' p)
+  apply (case_tac "aobjs_of s p")
+   apply (simp add: aobjs_of_ako_at_None)
+   apply (drule use_valid)
+     prefer 2
+     apply assumption
+    apply (rule assms)
+    apply (clarsimp simp: vspace_obj_pred_def arch_obj_pred_def non_arch_obj_def)
+   apply (simp flip: aobjs_of_ako_at_None)
+  apply (simp add: aobjs_of_ako_at_Some)
+  apply (drule use_valid)
+    prefer 2
+    apply assumption
+   apply (rule assms)
+   apply simp
+  apply (simp flip: aobjs_of_ako_at_Some)
+  done
+
+lemma pts_of_lift:
+  assumes aobj_at: "\<And>P P' p. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' p s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (pts_of s)\<rbrace>"
+  by (rule hoare_lift_Pf2[where f=aobjs_of], (wp vspace_obj_pred_aobjs aobj_at)+)
+
+lemma ptes_of_lift:
+  assumes aobj_at: "\<And>P P' p. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' p s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (ptes_of s)\<rbrace>"
+  by (rule hoare_lift_Pf2[where f=aobjs_of], (wp vspace_obj_pred_aobjs aobj_at)+)
+
+lemma asid_pools_of_lift:
+  assumes aobj_at: "\<And>P P' p. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' p s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
+  by (rule hoare_lift_Pf2[where f=aobjs_of], (wp vspace_obj_pred_aobjs aobj_at)+)
+
+lemma vs_lookup_vspace_obj_at_lift:
+  assumes "\<And>P P' p. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' p s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (vs_lookup s)\<rbrace>"
+  by (rule vs_lookup_vspace_aobjs_lift, rule vspace_obj_pred_aobjs; rule assms)
+
+lemma vs_lookup_arch_obj_at_lift:
+  assumes "\<And>P P' p. arch_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' p s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (vs_lookup s)\<rbrace>"
+  by (intro vs_lookup_vspace_obj_at_lift assms vspace_pred_imp)
+
+lemma vs_lookup_pages_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (ptes_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (vs_lookup_pages s)\<rbrace>"
+  apply (rule_tac P=P in hoare_liftP_ext)+
+  apply (rename_tac P asid)
+  apply (rule_tac P=P in hoare_liftP_ext)
+  by (rule vs_lookup_target_lift; fact)
+
+lemma vs_lookup_pages_vspace_aobjs_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (vs_lookup_pages s)\<rbrace>"
+  by (wpsimp wp: vs_lookup_pages_lift assms)
+
+lemma vs_lookup_pages_vspace_obj_at_lift:
+  assumes "\<And>P P' p. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' p s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (vs_lookup_pages s)\<rbrace>"
+  by (rule vs_lookup_pages_vspace_aobjs_lift, rule vspace_obj_pred_aobjs; rule assms)
+
+lemma vs_lookup_pages_arch_obj_at_lift:
+  assumes "\<And>P P' p. arch_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' p s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (vs_lookup_pages s)\<rbrace>"
+  by (intro vs_lookup_pages_vspace_obj_at_lift assms vspace_pred_imp)
+
+lemma valid_vspace_objs_lift_weak:
+  assumes "\<And>P P' p. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' p s)\<rbrace>"
+  assumes "\<And>P. \<lbrace>\<lambda>s. P (arch_state s)\<rbrace> f \<lbrace>\<lambda>r s. P (arch_state s)\<rbrace>"
+  shows "\<lbrace>valid_vspace_objs\<rbrace> f \<lbrace>\<lambda>_. valid_vspace_objs\<rbrace>"
+  by (rule valid_vspace_objs_lift, rule vspace_obj_pred_aobjs; rule assms)
+
+lemma translate_address_lift_weak:
+  assumes aobj_at: "\<And>P P' p. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' p s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (translate_address pt_root vref (ptes_of s)) \<rbrace>"
+  unfolding translate_address_def pt_lookup_target_def
+  apply (clarsimp simp: comp_def obind_def)
+  apply (rule hoare_lift_Pf2[where f=ptes_of, OF _ ptes_of_lift[OF aobj_at]]; simp)
+   apply (clarsimp split: option.splits)
+   apply (rule hoare_lift_Pf2[where f=pte_refs_of])
+   apply (rule hoare_lift_Pf2[where f=aobjs_of], (wp vspace_obj_pred_aobjs aobj_at)+)
+  done
+
+lemma set_pt_pts_of:
+  "\<lbrace>\<lambda>s. pts_of s p \<noteq> None \<longrightarrow> P (pts_of s (p \<mapsto> pt)) \<rbrace> set_pt p pt \<lbrace>\<lambda>_ s. P (pts_of s)\<rbrace>"
+  unfolding set_pt_def
+  by (wpsimp wp: set_object_wp)
+     (auto elim!: rsubst[where P=P] simp: opt_map_def split: option.splits)
+
+lemma pte_ptr_eq:
+  "\<lbrakk> (ucast (p && mask pt_bits >> pte_bits) :: pt_index) =
+     (ucast (p' && mask pt_bits >> pte_bits) :: pt_index);
+     p && ~~ mask pt_bits = p' && ~~ mask pt_bits;
+     is_aligned p pte_bits; is_aligned p' pte_bits \<rbrakk>
+   \<Longrightarrow> p = p'"
+  apply (simp add: ucast_eq_mask)
+  apply (rule word_eqI)
+  apply (clarsimp simp: word_size is_aligned_nth)
+  apply (case_tac "n < pte_bits", simp)
+  apply (drule_tac x="n-pte_bits" in word_eqD)
+  apply (drule_tac x="n" in word_eqD)
+  apply (simp add: word_size neg_mask_test_bit nth_shiftr not_less)
+  apply (case_tac "pt_bits \<le> n", simp)
+  by (fastforce simp: not_le bit_simps)
+
+lemma store_pte_ptes_of:
+  "\<lbrace>\<lambda>s. ptes_of s p \<noteq> None \<longrightarrow> P (ptes_of s (p \<mapsto> pte)) \<rbrace> store_pte p pte \<lbrace>\<lambda>_ s. P (ptes_of s)\<rbrace>"
+  unfolding store_pte_def pte_of_def
+  apply (wpsimp wp: set_pt_pts_of simp: in_omonad)
+  by (auto simp: obind_def opt_map_def split: option.splits dest!: pte_ptr_eq elim!: rsubst[where P=P])
+
+lemma vspace_for_pool_not_pte:
+  "\<lbrakk> vspace_for_pool p asid (asid_pools_of s) = Some p';
+     ptes_of s p = Some pte; pspace_aligned s \<rbrakk>
+   \<Longrightarrow> False"
+  by (fastforce simp: in_omonad ptes_of_def bit_simps vspace_for_pool_def dest: pspace_alignedD)
+
+definition level_of_slot :: "asid \<Rightarrow> vspace_ref \<Rightarrow> obj_ref \<Rightarrow> 'z::state_ext state \<Rightarrow> vm_level"
+  where
+  "level_of_slot asid vref p s \<equiv>
+     GREATEST level. vs_lookup_slot level asid vref s = Some (level, p)"
+
+lemma level_of_slotI:
+  "\<lbrakk> vs_lookup_slot level' asid vref s = Some (level', p); level < level'\<rbrakk>
+   \<Longrightarrow> vs_lookup_slot (level_of_slot asid vref p s) asid vref s = Some (level_of_slot asid vref p s, p)
+       \<and> level < level_of_slot asid vref p s"
+  by (auto simp: level_of_slot_def dest: bit0.GreatestI bit0.Greatest_le)
+
+lemma pool_for_asid_no_pt:
+  "\<lbrakk> pool_for_asid asid s = Some p; pts_of s p = Some pte; valid_asid_table s; pspace_aligned s \<rbrakk>
+   \<Longrightarrow> False"
+  unfolding pool_for_asid_def
+  by (fastforce dest: pspace_alignedD dest!: valid_asid_tableD
+                simp: bit_simps obj_at_def ptes_of_Some in_omonad)
+
+lemma pool_for_asid_no_pte:
+  "\<lbrakk> pool_for_asid asid s = Some p; ptes_of s p = Some pte; valid_asid_table s; pspace_aligned s \<rbrakk>
+   \<Longrightarrow> False"
+  unfolding pool_for_asid_def
+  by (fastforce dest: pspace_alignedD dest!: valid_asid_tableD
+                simp: bit_simps obj_at_def ptes_of_Some in_omonad)
+
+lemma vs_lookup_table_no_asid:
+  "\<lbrakk> vs_lookup_table asid_pool_level asid vref s = Some (asid_pool_level, p);
+     ptes_of s p = Some pte; valid_asid_table s; pspace_aligned s \<rbrakk>
+  \<Longrightarrow> False"
+  unfolding vs_lookup_table_def
+  by (fastforce dest: pool_for_asid_no_pte simp: in_omonad)
+
+lemma vs_lookup_table_no_asid_pt:
+  "\<lbrakk> vs_lookup_table asid_pool_level asid vref s = Some (asid_pool_level, p);
+     pts_of s p = Some pte; valid_asid_table s; pspace_aligned s \<rbrakk>
+  \<Longrightarrow> False"
+  unfolding vs_lookup_table_def
+  by (fastforce dest: pool_for_asid_no_pt simp: in_omonad)
+
+lemma vs_lookup_slot_no_asid:
+  "\<lbrakk> vs_lookup_slot asid_pool_level asid vref s = Some (asid_pool_level, p);
+     ptes_of s p = Some pte; valid_asid_table s; pspace_aligned s \<rbrakk>
+  \<Longrightarrow> False"
+  unfolding vs_lookup_slot_def vs_lookup_table_def
+  by (fastforce dest: pool_for_asid_no_pte simp: in_omonad)
+
+(* Removing a page table pte entry at p will cause lookups to stop at higher levels than requested.
+   If performing a shallower lookup than the one requested results in p, then any deeper lookup
+   in the updated state will return a higher level result along the original path. *)
+lemma vs_lookup_non_PageTablePTE:
+  "\<lbrakk> ptes_of s p \<noteq> None; ptes_of s' = ptes_of s (p \<mapsto> pte);
+     \<not> is_PageTablePTE pte;
+     asid_pools_of s' = asid_pools_of s;
+     asid_table s' = asid_table s;
+     valid_asid_table s; pspace_aligned s \<rbrakk> \<Longrightarrow>
+   vs_lookup_table level asid vref s' =
+     (if \<exists>level'. vs_lookup_slot level' asid vref s = Some (level', p) \<and> level < level'
+      then vs_lookup_table (level_of_slot asid vref p s) asid vref s
+      else vs_lookup_table level asid vref s)"
+  apply (induct level rule: bit0.from_top_full_induct[where y=max_pt_level])
+   apply (clarsimp simp: geq_max_pt_level)
+   apply (erule disjE; clarsimp)
+    apply (rule conjI; clarsimp)
+     apply (fastforce dest!: vs_lookup_slot_no_asid)
+    apply (simp add: vs_lookup_table_def pool_for_asid_def obind_def split: option.splits)
+   apply (simp add: vs_lookup_table_def pool_for_asid_def obind_def split: option.splits)
+  apply clarsimp
+  apply (rule conjI; clarsimp)
+   apply (drule (1) level_of_slotI, clarsimp)
+   apply (subst vs_lookup_split[where level'="level_of_slot asid vref p s"], simp)
+    apply (rule ccontr)
+    apply (fastforce dest!: vs_lookup_slot_no_asid simp: not_le)
+   apply (clarsimp simp: vs_lookup_slot_def in_obind_eq)
+   apply (simp split: if_split_asm)
+    apply (fastforce dest!: vs_lookup_table_no_asid)
+   apply (subst pt_walk.simps)
+   apply (simp add: in_obind_eq)
+  subgoal for x y
+  apply (subst vs_lookup_split[where level'="x+1"])
+    apply (simp add: less_imp_le)
+   apply (simp add: bit0.plus_one_leq)
+  apply (subst (2) vs_lookup_split[where level'="x+1"])
+    apply (simp add: less_imp_le)
+   apply (simp add: bit0.plus_one_leq)
+  apply (erule_tac x="x+1" in allE)
+  apply (simp add: less_imp_le)
+  apply (simp  split: if_split_asm)
+   apply (erule_tac x="level'" in allE, simp)
+   apply (meson max_pt_level_less_Suc less_imp_le less_trans)
+  apply (clarsimp simp: obind_def split: option.splits)
+  apply (subst pt_walk.simps)
+  apply (subst (2) pt_walk.simps)
+  apply (simp add: less_imp_le cong: if_cong)
+  apply (subgoal_tac "(ptes_of s(p \<mapsto> pte)) (pt_slot_offset (x + 1) b vref)
+                      = ptes_of s (pt_slot_offset (x + 1) b vref)")
+   apply (simp add: obind_def split: option.splits)
+  apply clarsimp
+  apply (subgoal_tac "vs_lookup_slot (x+1) asid vref s = Some (x+1, p)")
+   apply fastforce
+  apply (clarsimp simp: vs_lookup_slot_def in_obind_eq)
+  using bit0.plus_one_leq by fastforce
+  done
+
+lemma set_pt_typ_at[wp]:
+  "set_pt p pt \<lbrace>\<lambda>s. P (typ_at T p' s)\<rbrace>"
+  unfolding set_pt_def
+  by (wpsimp wp: set_object_wp simp: in_opt_map_eq obj_at_def)
+
+crunches store_pte
+  for kernel_vspace[wp]: "\<lambda>s. P (riscv_kernel_vspace (arch_state s))"
+  and typ_at[wp]: "\<lambda>s. P (typ_at T p s)"
+  (wp: hoare_drop_imps)
+
+lemma store_pte_non_PageTablePTE_vs_lookup:
+  "\<lbrace>\<lambda>s. (ptes_of s p \<noteq> None \<longrightarrow>
+         P (if \<exists>level'. vs_lookup_slot level' asid vref s = Some (level', p) \<and> level < level'
+            then vs_lookup_table (level_of_slot asid vref p s) asid vref s
+            else vs_lookup_table level asid vref s)) \<and> pspace_aligned s \<and> valid_asid_table s
+        \<and> \<not> is_PageTablePTE pte \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_ s. P (vs_lookup_table level asid vref s)\<rbrace>"
+  unfolding store_pte_def set_pt_def
+  apply (wpsimp wp: set_object_wp simp: in_opt_map_eq ptes_of_Some)
+  apply (erule rsubst[where P=P])
+  apply (subst (3) vs_lookup_non_PageTablePTE)
+      apply (fastforce simp: in_omonad pte_of_def)
+     apply (fastforce simp: pte_of_def obind_def opt_map_def split: option.splits dest!: pte_ptr_eq)
+    apply (fastforce simp: opt_map_def)+
+  done
+
+lemma store_pte_not_ao[wp]:
+  "\<lbrace>\<lambda>s. \<forall>pt. aobjs_of s (p && ~~mask pt_bits) = Some (PageTable pt) \<longrightarrow>
+             P (aobjs_of s (p && ~~mask pt_bits \<mapsto>
+                              PageTable (pt (ucast (p && mask pt_bits >> pte_bits) := pte))))\<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_ s. P (aobjs_of s)\<rbrace>"
+  unfolding store_pte_def set_pt_def
+  apply (wpsimp wp: set_object_wp simp: in_opt_map_eq)
+  apply (fastforce simp: opt_map_def elim!: rsubst[where P=P])
+  done
+
+lemma valid_vspace_obj_PT_invalidate:
+  "valid_vspace_obj level (PageTable pt) s \<Longrightarrow>
+   valid_vspace_obj level (PageTable (pt(i := InvalidPTE))) s"
+  by clarsimp
+
+lemma store_pte_InvalidPTE_valid_vspace_objs[wp]:
+  "\<lbrace>valid_vspace_objs and pspace_aligned and valid_asid_table\<rbrace>
+   store_pte p InvalidPTE
+   \<lbrace>\<lambda>_. valid_vspace_objs\<rbrace>"
+  unfolding valid_vspace_objs_def
+  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' valid_vspace_obj_lift
+                    store_pte_non_PageTablePTE_vs_lookup)
+  apply (rule conjI; clarsimp)
+   apply (rename_tac level slot pte ao pt)
+   apply (drule (1) level_of_slotI)
+   apply (case_tac "slot = table_base p"; clarsimp simp del: valid_vspace_obj.simps)
+   apply (fastforce intro!: valid_vspace_obj_PT_invalidate)
+  apply (rename_tac s bot_level vref asid level slot pte ao pt)
+  apply (clarsimp simp: vs_lookup_slot_def)
+  apply (case_tac "slot = table_base p"; clarsimp simp del: valid_vspace_obj.simps)
+  apply (fastforce intro!: valid_vspace_obj_PT_invalidate)
+  done
+
+lemma set_object_valid_kernel_mappings:
+  "set_object ptr ko \<lbrace>valid_kernel_mappings\<rbrace>"
+  unfolding set_object_def
+  by (wpsimp simp: valid_kernel_mappings_def split: if_split_asm)
+
+(* interface lemma *)
+lemmas set_object_v_ker_map = set_object_valid_kernel_mappings
+
+lemma valid_vs_lookup_lift:
+  assumes lookup: "\<And>P. f \<lbrace>\<lambda>s. P (vs_lookup_pages s)\<rbrace>"
+  assumes cap: "\<And>P. f \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace>"
+  assumes archvspace: "\<And>P. f \<lbrace>\<lambda>s. P (riscv_kernel_vspace (arch_state s))\<rbrace>"
+  shows "f \<lbrace>valid_vs_lookup\<rbrace>"
+  unfolding valid_vs_lookup_def
+  apply clarsimp
+  apply (rule hoare_lift_Pf [where f=vs_lookup_pages])
+   apply (rule hoare_lift_Pf [where f="\<lambda>s. (caps_of_state s)"])
+    apply (rule hoare_lift_Pf [where f="\<lambda>s. (riscv_kernel_vspace (arch_state s))"])
+     apply (wpsimp wp: lookup cap archvspace)+
+  done
+
+lemma valid_arch_caps_lift:
+  assumes lookup: "\<And>P. \<lbrace>\<lambda>s. P (vs_lookup_pages s)\<rbrace> f \<lbrace>\<lambda>_ s. P (vs_lookup_pages s)\<rbrace>"
+  assumes cap: "\<And>P. \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (caps_of_state s)\<rbrace>"
+  assumes pts: "\<And>P. f \<lbrace>\<lambda>s. P (pts_of s)\<rbrace>"
+  assumes archvspace: "\<And>P. f \<lbrace>\<lambda>s. P (riscv_kernel_vspace (arch_state s))\<rbrace>"
+  assumes asidtable: "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  shows "\<lbrace>valid_arch_caps\<rbrace> f \<lbrace>\<lambda>_. valid_arch_caps\<rbrace>"
+  unfolding valid_arch_caps_def
+  apply (wpsimp wp: valid_vs_lookup_lift lookup cap archvspace)
+   apply (rule hoare_lift_Pf2[where f="\<lambda>s. (caps_of_state s)"])
+    apply (wpsimp wp: cap archvspace asidtable pts)+
+  done
+
+context
+  fixes f :: "'a::state_ext state \<Rightarrow> ('b \<times> 'a state) set \<times> bool"
+  assumes arch: "\<And>P. \<lbrace>\<lambda>s. P (arch_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (arch_state s)\<rbrace>"
+begin
+
+context
+  assumes aobj_at:
+    "\<And>P P' pd. vspace_obj_pred P' \<Longrightarrow> \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> f \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
+begin
+
+lemma valid_global_vspace_mappings_lift:
+  "f \<lbrace>valid_global_vspace_mappings\<rbrace>"
+  unfolding valid_global_vspace_mappings_def
+  supply validNF_prop[wp_unsafe del]
+  by (rule hoare_lift_Pf2[where f=arch_state, OF _ arch])
+     (wpsimp simp: Let_def wp: hoare_vcg_ball_lift translate_address_lift_weak aobj_at)
+
+lemma valid_arch_caps_lift_weak:
+  assumes cap: "(\<And>P. f \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace>)"
+  shows "f \<lbrace>valid_arch_caps\<rbrace>"
+  supply validNF_prop[wp_unsafe del]
+  by (rule valid_arch_caps_lift)
+     (wpsimp wp: vs_lookup_pages_vspace_obj_at_lift[OF aobj_at] pts_of_lift[OF aobj_at]
+                 arch cap)+
+
+lemma valid_global_objs_lift_weak:
+  "\<lbrace>valid_global_objs\<rbrace> f \<lbrace>\<lambda>rv. valid_global_objs\<rbrace>"
+  unfolding valid_global_objs_def by wp
+
+lemma valid_asid_map_lift:
+    "\<lbrace>valid_asid_map\<rbrace> f \<lbrace>\<lambda>rv. valid_asid_map\<rbrace>"
+  by (wpsimp simp: valid_asid_map_def)
+
+lemma valid_kernel_mappings_lift:
+    "\<lbrace>valid_kernel_mappings\<rbrace> f \<lbrace>\<lambda>rv. valid_kernel_mappings\<rbrace>"
+  unfolding valid_kernel_mappings_def by wp
+
+end
+
+context
+  assumes aobj_at: "\<And>P P' pd. arch_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace>"
+begin
+
+lemma aobjs_of_lift_aobj_at:
+  "f \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (erule_tac P=P in rsubst)
+  apply (rule ext, rename_tac s' p)
+  apply (case_tac "aobjs_of s p")
+   apply (simp add: aobjs_of_ako_at_None)
+   apply (drule use_valid)
+     prefer 2
+     apply assumption
+    apply (rule aobj_at)
+    apply (clarsimp simp: arch_obj_pred_def non_arch_obj_def)
+   apply (simp flip: aobjs_of_ako_at_None)
+  apply (simp add: aobjs_of_ako_at_Some)
+  apply (drule use_valid)
+    prefer 2
+    apply assumption
+   apply (rule aobj_at)
+   apply simp
+  apply (simp flip: aobjs_of_ako_at_Some)
+  done
+
+lemma valid_arch_state_lift_aobj_at:
+  "f \<lbrace>valid_arch_state\<rbrace>"
+  unfolding valid_arch_state_def valid_asid_table_def valid_global_arch_objs_def pt_at_eq
+  apply (wp_pre, wps arch aobjs_of_lift_aobj_at)
+   apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_ball_lift)
+  apply simp
+  done
+
+end
+end
+
+lemma equal_kernel_mappings_lift:
+  assumes aobj_at: "\<And>P P' pd. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace>"
+  assumes [wp]: "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows "f \<lbrace>equal_kernel_mappings\<rbrace>"
+proof -
+  have [wp]: "\<And>P. f \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
+    by (rule vspace_obj_pred_aobjs[OF aobj_at])
+  show ?thesis
+    unfolding equal_kernel_mappings_def has_kernel_mappings_def
+    apply (wp_pre, wps, wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' vspace_for_asid_lift)
+    apply simp
+    done
+qed
+
+lemma valid_machine_state_lift:
+  assumes memory: "\<And>P. \<lbrace>\<lambda>s. P (underlying_memory (machine_state s))\<rbrace> f \<lbrace>\<lambda>_ s. P (underlying_memory (machine_state s))\<rbrace>"
+  assumes aobj_at: "\<And>P' pd. arch_obj_pred P' \<Longrightarrow> \<lbrace>obj_at P' pd\<rbrace> f \<lbrace>\<lambda>r s. obj_at P' pd s\<rbrace>"
+  shows "\<lbrace>valid_machine_state\<rbrace> f \<lbrace>\<lambda>_. valid_machine_state\<rbrace>"
+  unfolding valid_machine_state_def
+  apply (rule hoare_lift_Pf[where f="\<lambda>s. underlying_memory (machine_state s)", OF _ memory])
+  apply (rule hoare_vcg_all_lift)
+  apply (rule hoare_vcg_disj_lift[OF _ hoare_vcg_prop])
+  apply (rule in_user_frame_lift)
+  apply (wp aobj_at; simp)
+  done
+
+lemma valid_vso_at_lift:
+  assumes z: "\<And>P p T. \<lbrace>\<lambda>s. P (typ_at (AArch T) p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at (AArch T) p s)\<rbrace>"
+      and y: "\<And>ao. \<lbrace>\<lambda>s. ko_at (ArchObj ao) p s\<rbrace> f \<lbrace>\<lambda>rv s. ko_at (ArchObj ao) p s\<rbrace>"
+  shows      "\<lbrace>valid_vso_at level p\<rbrace> f \<lbrace>\<lambda>rv. valid_vso_at level p\<rbrace>"
+  unfolding valid_vso_at_def
+  by (wpsimp wp: hoare_vcg_ex_lift y valid_vspace_obj_typ z simp: aobjs_of_ako_at_Some)
+
+lemma valid_vso_at_lift_aobj_at:
+  assumes [wp]: "\<And>P' pd. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>obj_at P' pd\<rbrace>"
+  shows "f \<lbrace>valid_vso_at level p\<rbrace>"
+  unfolding valid_vso_at_def
+  by (wpsimp wp: hoare_vcg_ex_lift valid_vspace_obj_typ simp: aobjs_of_ako_at_Some)
+
+lemma valid_global_vspace_mappings_arch_update[simp]:
+  "\<lbrakk> riscv_global_pt (arch_state (f s)) = riscv_global_pt (arch_state s);
+     riscv_kernel_vspace (arch_state (f s)) = riscv_kernel_vspace (arch_state s);
+     ptes_of (f s) = ptes_of s \<rbrakk>
+     \<Longrightarrow> valid_global_vspace_mappings (f s) = valid_global_vspace_mappings s"
+  unfolding valid_global_vspace_mappings_def
+  by simp
+
+lemma valid_table_caps_ptD:
+  "\<lbrakk> caps_of_state s p = Some (ArchObjectCap (PageTableCap p' None));
+     valid_table_caps s \<rbrakk> \<Longrightarrow>
+   \<exists>pt. pts_of s p' = Some pt \<and> valid_vspace_obj level (PageTable pt) s"
+  by (fastforce simp: valid_table_caps_def simp del: split_paired_Ex)
+
+lemma store_pde_pred_tcb_at:
+  "\<lbrace>pred_tcb_at proj P t\<rbrace> store_pte ptr val \<lbrace>\<lambda>rv. pred_tcb_at proj P t\<rbrace>"
+  apply (wpsimp simp: store_pte_def set_pt_def wp: set_object_wp)
+  apply (clarsimp simp: pred_tcb_at_def obj_at_def in_opt_map_eq)
+  done
+
+lemma in_user_frame_obj_upd:
+  "\<lbrakk>kheap s p = Some ko; a_type k = a_type ko\<rbrakk> \<Longrightarrow>
+   in_user_frame x (s\<lparr>kheap := \<lambda>a. if a = p then Some k else kheap s a\<rparr>)
+   = in_user_frame x s"
+  apply (rule iffI)
+  apply (clarsimp simp: in_user_frame_def obj_at_def split: if_split_asm)
+   apply (elim disjE)
+    apply clarsimp
+    apply (intro exI)
+    apply (rule conjI,assumption)
+    apply (simp add: a_type_def)
+   apply (fastforce simp: a_type_def)
+  apply (clarsimp simp: in_user_frame_def obj_at_def split: if_split_asm)
+  apply (rule_tac x = sz in exI)
+  apply (intro conjI impI)
+    apply (fastforce simp: a_type_def)+
+  done
+
+lemma user_mem_obj_upd_dom:
+  "\<lbrakk>kheap s p = Some ko; a_type k = a_type ko\<rbrakk> \<Longrightarrow>
+   dom (user_mem (s\<lparr>kheap := \<lambda>a. if a = p then Some k else kheap s a\<rparr>))
+   = dom (user_mem s)"
+  by (clarsimp simp: user_mem_def in_user_frame_obj_upd dom_def)
+
+lemma in_device_frame_obj_upd:
+  "\<lbrakk>kheap s p = Some ko; a_type k = a_type ko\<rbrakk> \<Longrightarrow>
+   in_device_frame x (s\<lparr>kheap := \<lambda>a. if a = p then Some k else kheap s a\<rparr>)
+   = in_device_frame x s"
+  apply (rule iffI)
+  apply (clarsimp simp: in_device_frame_def obj_at_def split: if_split_asm)
+   apply (elim disjE)
+    apply clarsimp
+    apply (intro exI)
+    apply (rule conjI,assumption)
+    apply (simp add: a_type_def)
+   apply (fastforce simp: a_type_def)
+  apply (clarsimp simp: in_device_frame_def obj_at_def split: if_split_asm)
+  apply (rule_tac x = sz in exI)
+  apply (intro conjI impI)
+    apply (fastforce simp: a_type_def)+
+  done
+
+lemma device_mem_obj_upd_dom:
+  "\<lbrakk>kheap s p = Some ko; a_type k = a_type ko\<rbrakk> \<Longrightarrow>
+   dom (device_mem (s\<lparr>kheap := \<lambda>a. if a = p then Some k else kheap s a\<rparr>))
+   = dom (device_mem s)"
+  by (clarsimp simp: device_mem_def in_device_frame_obj_upd dom_def)
+
+lemma pspace_respects_region_cong[cong]:
+  "\<lbrakk>kheap a  = kheap b; device_state (machine_state a) = device_state (machine_state b)\<rbrakk>
+  \<Longrightarrow> pspace_respects_device_region a = pspace_respects_device_region b"
+  by (simp add: pspace_respects_device_region_def device_mem_def user_mem_def in_device_frame_def
+    in_user_frame_def obj_at_def dom_def)
+
+definition "obj_is_device tp dev \<equiv>
+  case tp of Untyped \<Rightarrow> dev
+    | _ \<Rightarrow>(case (default_object tp dev 0) of (ArchObj (DataPage dev _)) \<Rightarrow> dev
+          | _ \<Rightarrow> False)"
+
+lemma cap_is_device_obj_is_device[simp]:
+  "cap_is_device (default_cap tp a sz dev) = obj_is_device tp dev"
+  by (simp add: default_cap_def arch_default_cap_def obj_is_device_def
+                default_object_def  default_arch_object_def
+         split: apiobject_type.splits aobject_type.splits)
+
+crunch device_state_inv: storeWord "\<lambda>ms. P (device_state ms)"
+  (ignore_del: storeWord)
+
+(* some hyp_ref invariants *)
+
+lemma state_hyp_refs_of_ep_update: "\<And>s ep val. typ_at AEndpoint ep s \<Longrightarrow>
+       state_hyp_refs_of (s\<lparr>kheap := kheap s(ep \<mapsto> Endpoint val)\<rparr>) = state_hyp_refs_of s"
+  apply (rule all_ext)
+  apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def hyp_refs_of_def)
+  done
+
+lemma state_hyp_refs_of_ntfn_update: "\<And>s ep val. typ_at ANTFN ep s \<Longrightarrow>
+       state_hyp_refs_of (s\<lparr>kheap := kheap s(ep \<mapsto> Notification val)\<rparr>) = state_hyp_refs_of s"
+  apply (rule all_ext)
+  apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def hyp_refs_of_def)
+  done
+
+lemma state_hyp_refs_of_tcb_bound_ntfn_update:
+       "kheap s t = Some (TCB tcb) \<Longrightarrow>
+          state_hyp_refs_of (s\<lparr>kheap := kheap s(t \<mapsto> TCB (tcb\<lparr>tcb_bound_notification := ntfn\<rparr>))\<rparr>)
+            = state_hyp_refs_of s"
+  apply (rule all_ext)
+  apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
+  done
+
+lemma state_hyp_refs_of_tcb_state_update:
+       "kheap s t = Some (TCB tcb) \<Longrightarrow>
+          state_hyp_refs_of (s\<lparr>kheap := kheap s(t \<mapsto> TCB (tcb\<lparr>tcb_state := ts\<rparr>))\<rparr>)
+            = state_hyp_refs_of s"
+  apply (rule all_ext)
+  apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
+  done
+
+lemma default_arch_object_not_live[simp]: "\<not> live (ArchObj (default_arch_object aty dev us))"
+  by (clarsimp simp: default_arch_object_def live_def hyp_live_def arch_live_def
+               split: aobject_type.splits)
+
+lemma default_tcb_not_live[simp]: "\<not> live (TCB default_tcb)"
+  by (clarsimp simp: default_tcb_def default_arch_tcb_def live_def hyp_live_def)
+
+lemma valid_arch_tcb_same_type:
+  "\<lbrakk> valid_arch_tcb t s; valid_obj p k s; kheap s p = Some ko; a_type k = a_type ko \<rbrakk>
+   \<Longrightarrow> valid_arch_tcb t (s\<lparr>kheap := kheap s(p \<mapsto> k)\<rparr>)"
+  by (auto simp: valid_arch_tcb_def obj_at_def)
+
+
+(* interface lemma *)
+lemma valid_ioports_lift:
+  assumes x: "\<And>P. f \<lbrace>\<lambda>rv. P (caps_of_state s)\<rbrace>"
+  assumes y: "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows      "f \<lbrace>valid_ioports\<rbrace>"
+  by wpsimp
+
+(* interface lemma *)
+lemma valid_arch_mdb_lift:
+  assumes c: "\<And>P. f \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace>"
+  assumes r: "\<And>P. f \<lbrace>\<lambda>s. P (is_original_cap s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. valid_arch_mdb (is_original_cap s) (caps_of_state s)\<rbrace>"
+  by (wpsimp simp: valid_arch_mdb_def)
+
+(* interface lemma *)
+lemma arch_valid_obj_same_type:
+  "\<lbrakk> arch_valid_obj ao s; kheap s p = Some ko; a_type k = a_type ko \<rbrakk>
+   \<Longrightarrow> arch_valid_obj ao (s\<lparr>kheap := kheap s(p \<mapsto> k)\<rparr>)"
+  by simp
+
+lemma valid_vspace_obj_same_type:
+  "\<lbrakk>valid_vspace_obj l ao s;  kheap s p = Some ko; a_type ko' = a_type ko\<rbrakk>
+  \<Longrightarrow> valid_vspace_obj l ao (s\<lparr>kheap := kheap s(p \<mapsto> ko')\<rparr>)"
+    apply (rule hoare_to_pure_kheap_upd[OF valid_vspace_obj_typ])
+    by (auto simp: obj_at_def)
+
+lemma invs_valid_uses[elim!]:
+  "invs s \<Longrightarrow> valid_uses s"
+  by (simp add: invs_def valid_state_def valid_arch_state_def)
+
+end
+end

--- a/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -8,7 +9,7 @@ theory ArchKHeap_AI
 imports KHeapPre_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 definition "non_vspace_obj \<equiv> non_arch_obj"
 definition "vspace_obj_pred \<equiv> arch_obj_pred"
@@ -22,13 +23,14 @@ locale vspace_only_obj_pred = Arch +
 sublocale vspace_only_obj_pred < arch_only_obj_pred
   using vspace_only[unfolded vspace_obj_pred_def] by unfold_locales
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 lemma valid_vspace_obj_lift:
   assumes "\<And>T p. f \<lbrace>typ_at (AArch T) p\<rbrace>"
   shows "f \<lbrace>valid_vspace_obj level obj\<rbrace>"
+  sorry (* FIXME AARCH64
   by ((cases obj; simp),
-      safe; wpsimp wp: assms hoare_vcg_ball_lift hoare_vcg_all_lift valid_pte_lift)
+      safe; wpsimp wp: assms hoare_vcg_ball_lift hoare_vcg_all_lift valid_pte_lift) *)
 
 lemma aobjs_of_atyp_lift:
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
@@ -103,18 +105,21 @@ lemma pspace_in_kernel_window_atyp_lift_strong:
   apply (rule hoare_lift_Pf[where f="\<lambda>s. riscv_kernel_vspace (arch_state s)"])
    apply (subst kheap_typ_only)+
    apply (wpsimp wp: hoare_vcg_all_lift wp: assms)+
-  done
+  sorry (* FIXME AARCH64
+  done *)
 
 lemma pspace_in_kernel_window_atyp_lift:
   assumes "\<And>P p T. \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>"
   assumes "\<And>P. \<lbrace>\<lambda>s. P (arch_state s)\<rbrace> f \<lbrace>\<lambda>r s. P (arch_state s)\<rbrace>"
   shows "\<lbrace>\<lambda>s. pspace_in_kernel_window s\<rbrace> f \<lbrace>\<lambda>rv s. pspace_in_kernel_window s\<rbrace>"
-  by (rule pspace_in_kernel_window_atyp_lift_strong[OF assms])
+  sorry (* FIXME AARCH64
+  by (rule pspace_in_kernel_window_atyp_lift_strong[OF assms]) *)
 
+(* FIXME AARCH64
 lemma cap_refs_in_kernel_window_arch_update[simp]:
   "riscv_kernel_vspace (f (arch_state s)) = riscv_kernel_vspace (arch_state s)
    \<Longrightarrow> cap_refs_in_kernel_window (arch_state_update f s) = cap_refs_in_kernel_window s"
-  by (simp add: cap_refs_in_kernel_window_def)
+  by (simp add: cap_refs_in_kernel_window_def) *)
 
 lemma in_user_frame_obj_pred_lift:
   assumes "\<And>P P' p. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' p s)\<rbrace>"
@@ -122,15 +127,16 @@ lemma in_user_frame_obj_pred_lift:
   unfolding in_user_frame_def
   by (wpsimp wp: hoare_vcg_ex_lift assms simp: vspace_obj_pred_def)
 
+(* FIXME AARCH64: the riscv_* don't exist on AArch64
 lemma pool_for_asid_lift:
-  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arm_asid_table (arch_state s))\<rbrace>"
   shows "f \<lbrace>\<lambda>s. P (pool_for_asid asid s)\<rbrace>"
   by (wpsimp simp: pool_for_asid_def wp: assms)
 
 lemma vs_lookup_table_lift:
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (ptes_of s)\<rbrace>"
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
-  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arm_asid_table (arch_state s))\<rbrace>"
   shows "f \<lbrace>\<lambda>s. P (vs_lookup_table level asid vref s)\<rbrace>"
   apply (simp add: vs_lookup_table_def obind_def split: option.splits)
   apply (wpsimp wp: assms hoare_vcg_all_lift hoare_vcg_ex_lift hoare_vcg_imp_lift' pool_for_asid_lift
@@ -140,7 +146,7 @@ lemma vs_lookup_table_lift:
 lemma vs_lookup_slot_lift:
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (ptes_of s)\<rbrace>"
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
-  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arm_asid_table (arch_state s))\<rbrace>"
   shows "f \<lbrace>\<lambda>s. P (vs_lookup_slot level asid vref s)\<rbrace>"
   apply (simp add: vs_lookup_slot_def obind_def split: option.splits)
   apply (wpsimp wp: assms hoare_vcg_all_lift hoare_vcg_ex_lift hoare_vcg_imp_lift' pool_for_asid_lift
@@ -151,7 +157,7 @@ lemma vs_lookup_slot_lift:
 lemma vs_lookup_target_lift:
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (ptes_of s)\<rbrace>"
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
-  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arm_asid_table (arch_state s))\<rbrace>"
   shows "f \<lbrace>\<lambda>s. P (vs_lookup_target level asid vref s)\<rbrace>"
   apply (simp add: vs_lookup_target_def obind_def split: option.splits)
   apply (wpsimp wp: assms hoare_vcg_all_lift hoare_vcg_ex_lift hoare_vcg_imp_lift' pool_for_asid_lift
@@ -162,24 +168,27 @@ lemma vs_lookup_target_lift:
 lemma vs_lookup_lift:
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (ptes_of s)\<rbrace>"
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
-  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arm_asid_table (arch_state s))\<rbrace>"
   shows "f \<lbrace>\<lambda>s. P (vs_lookup s)\<rbrace>"
   apply (rule_tac P=P in hoare_liftP_ext)+
   apply (rename_tac P asid)
   apply (rule_tac P=P in hoare_liftP_ext)
   by (rule vs_lookup_table_lift; rule assms)
+*)
 
 lemma vs_lookup_vspace_aobjs_lift:
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
   shows " f \<lbrace>\<lambda>s. P (vs_lookup s)\<rbrace>"
-  by (rule vs_lookup_lift; rule assms)
+  sorry (* FIXME AARCH64
+  by (rule vs_lookup_lift; rule assms) *)
 
 lemma valid_vspace_objs_lift:
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
   shows   "f \<lbrace>valid_vspace_objs\<rbrace>"
-  by (rule valid_vspace_objs_lift_vs_lookup, rule vs_lookup_lift; rule assms)
+  sorry (* FIXME AARCH64
+  by (rule valid_vspace_objs_lift_vs_lookup, rule vs_lookup_lift; rule assms) *)
 
 lemma aobjs_of_ako_at_Some:
   "(aobjs_of s p = Some ao) = ako_at ao p s"
@@ -242,21 +251,23 @@ lemma vs_lookup_arch_obj_at_lift:
   shows "f \<lbrace>\<lambda>s. P (vs_lookup s)\<rbrace>"
   by (intro vs_lookup_vspace_obj_at_lift assms vspace_pred_imp)
 
+(* FIXME AARCH64
 lemma vs_lookup_pages_lift:
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (ptes_of s)\<rbrace>"
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
-  assumes "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arm_asid_table (arch_state s))\<rbrace>"
   shows "f \<lbrace>\<lambda>s. P (vs_lookup_pages s)\<rbrace>"
   apply (rule_tac P=P in hoare_liftP_ext)+
   apply (rename_tac P asid)
   apply (rule_tac P=P in hoare_liftP_ext)
-  by (rule vs_lookup_target_lift; fact)
+  by (rule vs_lookup_target_lift; fact) *)
 
 lemma vs_lookup_pages_vspace_aobjs_lift:
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
   shows "f \<lbrace>\<lambda>s. P (vs_lookup_pages s)\<rbrace>"
-  by (wpsimp wp: vs_lookup_pages_lift assms)
+  sorry (* FIXME AARCH64
+  by (wpsimp wp: vs_lookup_pages_lift assms) *)
 
 lemma vs_lookup_pages_vspace_obj_at_lift:
   assumes "\<And>P P' p. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' p s)\<rbrace>"
@@ -283,9 +294,10 @@ lemma translate_address_lift_weak:
   apply (clarsimp simp: comp_def obind_def)
   apply (rule hoare_lift_Pf2[where f=ptes_of, OF _ ptes_of_lift[OF aobj_at]]; simp)
    apply (clarsimp split: option.splits)
+  sorry (* FIXME AARCH64
    apply (rule hoare_lift_Pf2[where f=pte_refs_of])
    apply (rule hoare_lift_Pf2[where f=aobjs_of], (wp vspace_obj_pred_aobjs aobj_at)+)
-  done
+  done *)
 
 lemma set_pt_pts_of:
   "\<lbrace>\<lambda>s. pts_of s p \<noteq> None \<longrightarrow> P (pts_of s (p \<mapsto> pt)) \<rbrace> set_pt p pt \<lbrace>\<lambda>_ s. P (pts_of s)\<rbrace>"
@@ -293,6 +305,7 @@ lemma set_pt_pts_of:
   by (wpsimp wp: set_object_wp)
      (auto elim!: rsubst[where P=P] simp: opt_map_def split: option.splits)
 
+(* FIXME AARCH64
 lemma pte_ptr_eq:
   "\<lbrakk> (ucast (p && mask pt_bits >> pte_bits) :: pt_index) =
      (ucast (p' && mask pt_bits >> pte_bits) :: pt_index);
@@ -320,6 +333,7 @@ lemma vspace_for_pool_not_pte:
      ptes_of s p = Some pte; pspace_aligned s \<rbrakk>
    \<Longrightarrow> False"
   by (fastforce simp: in_omonad ptes_of_def bit_simps vspace_for_pool_def dest: pspace_alignedD)
+*)
 
 definition level_of_slot :: "asid \<Rightarrow> vspace_ref \<Rightarrow> obj_ref \<Rightarrow> 'z::state_ext state \<Rightarrow> vm_level"
   where
@@ -330,7 +344,8 @@ lemma level_of_slotI:
   "\<lbrakk> vs_lookup_slot level' asid vref s = Some (level', p); level < level'\<rbrakk>
    \<Longrightarrow> vs_lookup_slot (level_of_slot asid vref p s) asid vref s = Some (level_of_slot asid vref p s, p)
        \<and> level < level_of_slot asid vref p s"
-  by (auto simp: level_of_slot_def dest: bit0.GreatestI bit0.Greatest_le)
+  sorry (* FIXME AARCH64
+  by (auto simp: level_of_slot_def dest: bit0.GreatestI bit0.Greatest_le) *)
 
 lemma pool_for_asid_no_pt:
   "\<lbrakk> pool_for_asid asid s = Some p; pts_of s p = Some pte; valid_asid_table s; pspace_aligned s \<rbrakk>
@@ -339,6 +354,7 @@ lemma pool_for_asid_no_pt:
   by (fastforce dest: pspace_alignedD dest!: valid_asid_tableD
                 simp: bit_simps obj_at_def ptes_of_Some in_omonad)
 
+(* FIXME AARCH64
 lemma pool_for_asid_no_pte:
   "\<lbrakk> pool_for_asid asid s = Some p; ptes_of s p = Some pte; valid_asid_table s; pspace_aligned s \<rbrakk>
    \<Longrightarrow> False"
@@ -352,7 +368,7 @@ lemma vs_lookup_table_no_asid:
   \<Longrightarrow> False"
   unfolding vs_lookup_table_def
   by (fastforce dest: pool_for_asid_no_pte simp: in_omonad)
-
+*)
 lemma vs_lookup_table_no_asid_pt:
   "\<lbrakk> vs_lookup_table asid_pool_level asid vref s = Some (asid_pool_level, p);
      pts_of s p = Some pte; valid_asid_table s; pspace_aligned s \<rbrakk>
@@ -360,6 +376,7 @@ lemma vs_lookup_table_no_asid_pt:
   unfolding vs_lookup_table_def
   by (fastforce dest: pool_for_asid_no_pt simp: in_omonad)
 
+(* FIXME AARCH64
 lemma vs_lookup_slot_no_asid:
   "\<lbrakk> vs_lookup_slot asid_pool_level asid vref s = Some (asid_pool_level, p);
      ptes_of s p = Some pte; valid_asid_table s; pspace_aligned s \<rbrakk>
@@ -423,17 +440,20 @@ lemma vs_lookup_non_PageTablePTE:
   apply (clarsimp simp: vs_lookup_slot_def in_obind_eq)
   using bit0.plus_one_leq by fastforce
   done
+*)
 
 lemma set_pt_typ_at[wp]:
   "set_pt p pt \<lbrace>\<lambda>s. P (typ_at T p' s)\<rbrace>"
   unfolding set_pt_def
-  by (wpsimp wp: set_object_wp simp: in_opt_map_eq obj_at_def)
+  sorry (* FIXME AARCH64
+  by (wpsimp wp: set_object_wp simp: in_opt_map_eq obj_at_def) *)
 
 crunches store_pte
   for kernel_vspace[wp]: "\<lambda>s. P (riscv_kernel_vspace (arch_state s))"
   and typ_at[wp]: "\<lambda>s. P (typ_at T p s)"
   (wp: hoare_drop_imps)
 
+(* FIXME AARCH64
 lemma store_pte_non_PageTablePTE_vs_lookup:
   "\<lbrace>\<lambda>s. (ptes_of s p \<noteq> None \<longrightarrow>
          P (if \<exists>level'. vs_lookup_slot level' asid vref s = Some (level', p) \<and> level < level'
@@ -483,7 +503,7 @@ lemma store_pte_InvalidPTE_valid_vspace_objs[wp]:
   apply (clarsimp simp: vs_lookup_slot_def)
   apply (case_tac "slot = table_base p"; clarsimp simp del: valid_vspace_obj.simps)
   apply (fastforce intro!: valid_vspace_obj_PT_invalidate)
-  done
+  done *)
 
 lemma set_object_valid_kernel_mappings:
   "set_object ptr ko \<lbrace>valid_kernel_mappings\<rbrace>"
@@ -511,13 +531,14 @@ lemma valid_arch_caps_lift:
   assumes cap: "\<And>P. \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (caps_of_state s)\<rbrace>"
   assumes pts: "\<And>P. f \<lbrace>\<lambda>s. P (pts_of s)\<rbrace>"
   assumes archvspace: "\<And>P. f \<lbrace>\<lambda>s. P (riscv_kernel_vspace (arch_state s))\<rbrace>"
-  assumes asidtable: "\<And>P. f \<lbrace>\<lambda>s. P (riscv_asid_table (arch_state s))\<rbrace>"
+  assumes asidtable: "\<And>P. f \<lbrace>\<lambda>s. P (arm_asid_table (arch_state s))\<rbrace>"
   shows "\<lbrace>valid_arch_caps\<rbrace> f \<lbrace>\<lambda>_. valid_arch_caps\<rbrace>"
   unfolding valid_arch_caps_def
   apply (wpsimp wp: valid_vs_lookup_lift lookup cap archvspace)
    apply (rule hoare_lift_Pf2[where f="\<lambda>s. (caps_of_state s)"])
+  sorry (* FIXME AARCH64
     apply (wpsimp wp: cap archvspace asidtable pts)+
-  done
+  done *)
 
 context
   fixes f :: "'a::state_ext state \<Rightarrow> ('b \<times> 'a state) set \<times> bool"
@@ -533,16 +554,18 @@ lemma valid_global_vspace_mappings_lift:
   "f \<lbrace>valid_global_vspace_mappings\<rbrace>"
   unfolding valid_global_vspace_mappings_def
   supply validNF_prop[wp_unsafe del]
+  sorry (* FIXME AARCH64
   by (rule hoare_lift_Pf2[where f=arch_state, OF _ arch])
-     (wpsimp simp: Let_def wp: hoare_vcg_ball_lift translate_address_lift_weak aobj_at)
+     (wpsimp simp: Let_def wp: hoare_vcg_ball_lift translate_address_lift_weak aobj_at) *)
 
 lemma valid_arch_caps_lift_weak:
   assumes cap: "(\<And>P. f \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace>)"
   shows "f \<lbrace>valid_arch_caps\<rbrace>"
   supply validNF_prop[wp_unsafe del]
+  sorry (* FIXME AARCH64
   by (rule valid_arch_caps_lift)
      (wpsimp wp: vs_lookup_pages_vspace_obj_at_lift[OF aobj_at] pts_of_lift[OF aobj_at]
-                 arch cap)+
+                 arch cap)+ *)
 
 lemma valid_global_objs_lift_weak:
   "\<lbrace>valid_global_objs\<rbrace> f \<lbrace>\<lambda>rv. valid_global_objs\<rbrace>"
@@ -586,11 +609,12 @@ lemma aobjs_of_lift_aobj_at:
 
 lemma valid_arch_state_lift_aobj_at:
   "f \<lbrace>valid_arch_state\<rbrace>"
+  sorry (* FIXME AARCH64
   unfolding valid_arch_state_def valid_asid_table_def valid_global_arch_objs_def pt_at_eq
   apply (wp_pre, wps arch aobjs_of_lift_aobj_at)
    apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_ball_lift)
   apply simp
-  done
+  done *)
 
 end
 end
@@ -603,10 +627,11 @@ proof -
   have [wp]: "\<And>P. f \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
     by (rule vspace_obj_pred_aobjs[OF aobj_at])
   show ?thesis
-    unfolding equal_kernel_mappings_def has_kernel_mappings_def
+    unfolding equal_kernel_mappings_def
+    sorry (* FIXME AARCH64
     apply (wp_pre, wps, wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' vspace_for_asid_lift)
     apply simp
-    done
+    done *)
 qed
 
 lemma valid_machine_state_lift:
@@ -634,6 +659,7 @@ lemma valid_vso_at_lift_aobj_at:
   unfolding valid_vso_at_def
   by (wpsimp wp: hoare_vcg_ex_lift valid_vspace_obj_typ simp: aobjs_of_ako_at_Some)
 
+(* FIXME AARCH64
 lemma valid_global_vspace_mappings_arch_update[simp]:
   "\<lbrakk> riscv_global_pt (arch_state (f s)) = riscv_global_pt (arch_state s);
      riscv_kernel_vspace (arch_state (f s)) = riscv_kernel_vspace (arch_state s);
@@ -653,6 +679,7 @@ lemma store_pde_pred_tcb_at:
   apply (wpsimp simp: store_pte_def set_pt_def wp: set_object_wp)
   apply (clarsimp simp: pred_tcb_at_def obj_at_def in_opt_map_eq)
   done
+*)
 
 lemma in_user_frame_obj_upd:
   "\<lbrakk>kheap s p = Some ko; a_type k = a_type ko\<rbrakk> \<Longrightarrow>
@@ -753,8 +780,9 @@ lemma state_hyp_refs_of_tcb_state_update:
   done
 
 lemma default_arch_object_not_live[simp]: "\<not> live (ArchObj (default_arch_object aty dev us))"
+  sorry (*
   by (clarsimp simp: default_arch_object_def live_def hyp_live_def arch_live_def
-               split: aobject_type.splits)
+               split: aobject_type.splits) *)
 
 lemma default_tcb_not_live[simp]: "\<not> live (TCB default_tcb)"
   by (clarsimp simp: default_tcb_def default_arch_tcb_def live_def hyp_live_def)
@@ -783,7 +811,8 @@ lemma valid_arch_mdb_lift:
 lemma arch_valid_obj_same_type:
   "\<lbrakk> arch_valid_obj ao s; kheap s p = Some ko; a_type k = a_type ko \<rbrakk>
    \<Longrightarrow> arch_valid_obj ao (s\<lparr>kheap := kheap s(p \<mapsto> k)\<rparr>)"
-  by simp
+  sorry (* FIXME AARCH64
+  by simp *)
 
 lemma valid_vspace_obj_same_type:
   "\<lbrakk>valid_vspace_obj l ao s;  kheap s p = Some ko; a_type ko' = a_type ko\<rbrakk>

--- a/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
@@ -9,6 +9,12 @@ theory ArchKHeap_AI
 imports KHeapPre_AI
 begin
 
+(* FIXME MOVE, might break proofs elsewhere *)
+lemma if_Some_Some[simp]:
+  "((if P then Some v else None) = Some v) = P"
+  "((if P then None else Some v) = Some v) = (\<not>P)"
+  by auto
+
 context Arch begin global_naming AARCH64
 
 definition "non_vspace_obj \<equiv> non_arch_obj"

--- a/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
@@ -1,0 +1,526 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchKernelInit_AI
+imports
+  ADT_AI
+  Tcb_AI
+  Arch_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+text \<open>
+  Showing that there is a state that satisfies the abstract invariants.
+\<close>
+
+lemmas ptr_defs = idle_thread_ptr_def init_irq_node_ptr_def riscv_global_pt_ptr_def
+lemmas state_defs = init_A_st_def init_kheap_def init_arch_state_def init_global_pt_def
+                    init_vspace_uses_def ptr_defs
+
+lemma is_tcb_TCB[simp]: "is_tcb (TCB t)" by (simp add: is_tcb_def)
+
+lemma ran_empty_cnode[simp]: "ran (empty_cnode n) = {NullCap}"
+  apply (rule equalityI; clarsimp simp: ran_def empty_cnode_def)
+  apply (rule_tac x="replicate n False" in exI)
+  apply simp
+  done
+
+lemma empty_cnode_apply[simp]:
+  "(empty_cnode n xs = Some cap) = (length xs = n \<and> cap = NullCap)"
+  by (auto simp add: empty_cnode_def)
+
+lemma valid_cs_size_empty[simp]:
+  "valid_cs_size n (empty_cnode n) = (n < word_bits - cte_level_bits)"
+  using wf_empty_bits [of n] by (simp add: valid_cs_size_def)
+
+lemma init_cdt [simp]:
+  "cdt init_A_st = init_cdt"
+  by (simp add: state_defs)
+
+lemma mdp_parent_empty[simp]:
+  "\<not>Map.empty \<Turnstile> x \<rightarrow> y"
+  by (auto simp: cdt_parent_of_def dest: tranclD)
+
+lemma descendants_empty[simp]:
+  "descendants_of x Map.empty = {}"
+  by (clarsimp simp: descendants_of_def)
+
+lemma is_reply_cap_NullCap[simp]: "\<not>is_reply_cap NullCap"
+  by (simp add: is_reply_cap_def)
+
+declare cap_range_NullCap [simp]
+
+lemma pptr_base_num:
+  "pptr_base = 0xFFFFFFC000000000"
+  by (simp add: pptr_base_def pptrBase_def canonical_bit_def)
+
+(* IRQ nodes occupy 11 bits of address space in this RISCV example state:
+   6 for irq number, 5 for cte_level_bits. *)
+lemma init_irq_ptrs_ineqs:
+  "init_irq_node_ptr + (ucast (irq :: irq) << cte_level_bits) \<ge> init_irq_node_ptr"
+  "init_irq_node_ptr + (ucast (irq :: irq) << cte_level_bits) + mask cte_level_bits
+                \<le> init_irq_node_ptr + mask 11"
+  "init_irq_node_ptr + (ucast (irq :: irq) << cte_level_bits)
+                \<le> init_irq_node_ptr + mask 11"
+proof -
+  have P: "ucast irq < (2 ^ (11 - cte_level_bits) :: machine_word)"
+    apply (rule order_le_less_trans[OF
+        ucast_le_ucast[where 'a=6 and 'b=64, simplified, THEN iffD2, OF word_n1_ge]])
+    apply (simp add: cte_level_bits_def minus_one_norm)
+    done
+  show "init_irq_node_ptr + (ucast (irq :: irq) << cte_level_bits) \<ge> init_irq_node_ptr"
+    apply (rule is_aligned_no_wrap'[where sz=11])
+     apply (simp add: is_aligned_def init_irq_node_ptr_def pptr_base_num)
+    apply (rule shiftl_less_t2n[OF P])
+    apply simp
+    done
+  show Q: "init_irq_node_ptr + (ucast (irq :: irq) << cte_level_bits) + mask cte_level_bits
+                \<le> init_irq_node_ptr + mask 11"
+    apply (simp only: add_diff_eq[symmetric] add.assoc)
+    apply (rule word_add_le_mono2)
+     apply (simp only: trans [OF shiftl_t2n mult.commute] mask_def mult_1)
+     apply (rule nasty_split_lt[OF P])
+      apply (auto simp: cte_level_bits_def init_irq_node_ptr_def mask_def pptr_base_num)
+    done
+  show "init_irq_node_ptr + (ucast (irq :: irq) << cte_level_bits)
+                \<le> init_irq_node_ptr + mask 11"
+    apply (simp only: add_diff_eq[symmetric] mask_def mult_1 shiftl_t2n mult.commute)
+    apply (rule word_add_le_mono2)
+     apply (rule word_le_minus_one_leq)
+     apply (rule shiftl_less_t2n[OF P, simplified shiftl_t2n mult.commute])
+     apply simp
+    apply (simp add: cte_level_bits_def init_irq_node_ptr_def pptr_base_num)
+    done
+qed
+
+lemmas init_irq_ptrs_less_ineqs
+   = init_irq_ptrs_ineqs(1)[THEN order_less_le_trans[rotated]]
+     init_irq_ptrs_ineqs(2-3)[THEN order_le_less_trans]
+
+lemmas init_irq_ptrs_all_ineqs[unfolded init_irq_node_ptr_def cte_level_bits_def]
+   = init_irq_ptrs_ineqs(1)[THEN order_trans[rotated]]
+     init_irq_ptrs_ineqs(2-3)[THEN order_trans]
+     init_irq_ptrs_less_ineqs
+     init_irq_ptrs_less_ineqs[THEN less_imp_neq]
+     init_irq_ptrs_less_ineqs[THEN less_imp_neq, THEN not_sym]
+
+lemma init_irq_ptrs_eq:
+  "((ucast irq << cte_level_bits) = (ucast (irq' :: irq) << cte_level_bits :: machine_word))
+   = (irq = irq')"
+  by word_bitwise (clarsimp simp: cte_level_bits_def)
+
+lemma pspace_aligned_init_A:
+  "pspace_aligned init_A_st"
+  apply (clarsimp simp: pspace_aligned_def state_defs wf_obj_bits [OF wf_empty_bits]
+                        dom_if_Some cte_level_bits_def bit_simps pptr_base_num kernel_elf_base_def)
+  apply (safe intro!: aligned_add_aligned[OF _ is_aligned_shiftl_self order_refl],
+           simp_all add: is_aligned_def word_bits_def)[1]
+  done
+
+lemma pspace_distinct_init_A: "pspace_distinct init_A_st"
+  unfolding pspace_distinct_def
+  apply (clarsimp simp: state_defs bit_simps empty_cnode_bits kernel_elf_base_def
+                        cte_level_bits_def linorder_not_le cong: if_cong)
+  apply (safe; simp add: pptr_base_num init_irq_ptrs_all_ineqs[simplified pptr_base_num mask_def, simplified])
+  apply (cut_tac x="init_irq_node_ptr + (ucast irq << cte_level_bits)"
+             and y="init_irq_node_ptr + (ucast irqa << cte_level_bits)"
+             and sz=cte_level_bits in aligned_neq_into_no_overlap;
+         simp add: init_irq_node_ptr_def pptr_base_num cte_level_bits_def)
+    apply (rule aligned_add_aligned[OF _ is_aligned_shiftl_self order_refl])
+    apply (simp add: is_aligned_def)
+   apply (rule aligned_add_aligned[OF _ is_aligned_shiftl_self order_refl])
+   apply (simp add: is_aligned_def)
+  apply (simp add: linorder_not_le)
+  done
+
+lemma caps_of_state_init_A_st_Null:
+  "caps_of_state (init_A_st::'z::state_ext state) x
+     = (if cte_at x (init_A_st::'z::state_ext state) then Some NullCap else None)"
+  apply (subgoal_tac "\<not> cte_wp_at ((\<noteq>) NullCap) x init_A_st")
+   apply (auto simp add: cte_wp_at_caps_of_state)[1]
+  apply (clarsimp, erule cte_wp_atE)
+   apply (auto simp add: state_defs tcb_cap_cases_def split: if_split_asm)
+  done
+
+lemma cte_wp_at_init_A_st_Null:
+  "cte_wp_at P p init_A_st \<Longrightarrow> P cap.NullCap"
+  apply (subst(asm) cte_wp_at_caps_of_state)
+  apply (simp add:caps_of_state_init_A_st_Null split: if_splits)
+  done
+
+lemmas cte_wp_at_caps_of_state_eq
+    = cte_wp_at_caps_of_state[where P="(=) cap" for cap]
+
+declare ptrFormPAddr_addFromPPtr[simp]
+
+lemma pspace_respects_device_region_init[simp]:
+  "pspace_respects_device_region init_A_st"
+   apply (clarsimp simp: pspace_respects_device_region_def state_defs init_machine_state_def
+                         device_mem_def in_device_frame_def obj_at_def a_type_def)
+   apply (rule ext)
+   apply clarsimp
+   done
+
+lemma cap_refs_respects_device_region_init[simp]:
+  "cap_refs_respects_device_region init_A_st"
+   apply (clarsimp simp: cap_refs_respects_device_region_def)
+   apply (frule cte_wp_at_caps_of_state[THEN iffD1])
+   apply clarsimp
+   apply (subst(asm) caps_of_state_init_A_st_Null)
+   apply (clarsimp simp: cte_wp_at_caps_of_state cap_range_respects_device_region_def)
+   done
+
+lemma kernel_mapping_slot: "0x1FF \<in> kernel_mapping_slots"
+  by (clarsimp simp: kernel_mapping_slots_def pptr_base_def pptrBase_def canonical_bit_def
+                     pt_bits_left_def bit_simps level_defs)
+
+lemma pool_for_asid_init_A_st[simp]:
+  "pool_for_asid asid init_A_st = None"
+  by (simp add: pool_for_asid_def state_defs)
+
+lemma vspace_for_asid_init_A_st[simp]:
+  "vspace_for_asid asid init_A_st = None"
+  by (simp add: vspace_for_asid_def obind_def)
+
+lemma global_pt_init_A_st[simp]:
+  "global_pt init_A_st = riscv_global_pt_ptr"
+  by (simp add: state_defs riscv_global_pt_def)
+
+lemma is_aligned_riscv_global_pt_ptr[simp]:
+  "is_aligned riscv_global_pt_ptr pt_bits"
+  by (simp add: riscv_global_pt_ptr_def pptr_base_num bit_simps is_aligned_def)
+
+lemma ptes_of_init_A_st_global:
+  "ptes_of init_A_st =
+   (\<lambda>p. if table_base p = riscv_global_pt_ptr \<and> is_aligned p pte_bits then
+        Some ((un_PageTable (the_arch_obj init_global_pt)) (table_index p)) else None)"
+  by (auto simp add: state_defs pte_of_def obind_def opt_map_def split: option.splits)
+
+lemma pt_walk_init_A_st[simp]:
+  "pt_walk max_pt_level level riscv_global_pt_ptr vref (ptes_of init_A_st) =
+   Some (max_pt_level, riscv_global_pt_ptr)"
+  apply (subst pt_walk.simps)
+  apply (simp add: in_omonad ptes_of_init_A_st_global init_global_pt_def
+                   is_aligned_pt_slot_offset_pte global_pte_def)
+  done
+
+lemma table_index_riscv_global_pt_ptr:
+  "table_index (pt_slot_offset max_pt_level riscv_global_pt_ptr vref) =
+  ucast ((vref >> ptTranslationBits * 2 + pageBits) && mask ptTranslationBits)"
+  apply (simp add: pt_slot_offset_def pt_index_def pt_bits_left_def bit_simps level_defs
+                   riscv_global_pt_ptr_def pptr_base_def pptrBase_def canonical_bit_def)
+  apply (subst word_plus_and_or_coroll)
+   apply word_bitwise
+   apply simp
+  apply word_bitwise
+  apply (clarsimp simp: word_size)
+  done
+
+lemma kernel_window_1G:
+  "\<lbrakk> pptr_base \<le> vref; vref < pptr_base + (1 << 30) \<rbrakk> \<Longrightarrow>
+    table_index (pt_slot_offset max_pt_level riscv_global_pt_ptr vref) = 0x100"
+  apply (simp add: table_index_riscv_global_pt_ptr)
+  apply (simp add: bit_simps pptr_base_def pptrBase_def neg_mask_le_high_bits word_size flip: NOT_mask)
+  apply (subst (asm) mask_def)
+  apply (simp add: canonical_bit_def)
+  apply word_bitwise
+  apply (clarsimp simp: word_size)
+  done
+
+lemma kernel_mapping_slots_0x100[simp]:
+  "0x100 \<in> kernel_mapping_slots"
+  by (simp add: kernel_mapping_slots_def pptr_base_def bit_simps pt_bits_left_def level_defs
+                pptrBase_def canonical_bit_def)
+
+lemma translate_address_kernel_window:
+  "\<lbrakk> pptr_base \<le> vref; vref < pptr_base + (1 << 30) \<rbrakk>\<Longrightarrow>
+   translate_address riscv_global_pt_ptr vref (ptes_of init_A_st) = Some (addrFromPPtr vref)"
+  apply (clarsimp simp: translate_address_def in_omonad pt_lookup_target_def
+                        pt_lookup_slot_from_level_def)
+  apply (simp add: ptes_of_init_A_st_global[THEN fun_cong] init_global_pt_def global_pte_def pte_ref_def)
+  apply (simp add: kernel_window_1G is_aligned_pt_slot_offset_pte)
+  apply (simp add: bit_simps addr_from_ppn_def shiftl_shiftl)
+  apply (simp add: ptrFromPAddr_def addrFromPPtr_def)
+  apply (simp add: pptrBaseOffset_def paddrBase_def)
+  apply (simp add: pt_bits_left_def bit_simps level_defs)
+  apply (rule conjI)
+   apply (rule is_aligned_add)
+    apply (simp add: mask_def)
+   apply (simp add: pptrBase_def canonical_bit_def is_aligned_def)
+  apply (simp add: pptr_base_def)
+  apply (simp add: pptrBase_def neg_mask_le_high_bits flip: NOT_mask)
+  apply (subst word_plus_and_or_coroll; simp add: canonical_bit_def word_size mask_def)
+  apply word_bitwise
+  apply clarsimp
+  done
+
+lemma elf_window_1M:
+  "\<lbrakk> kernel_elf_base \<le> vref; vref < kernel_elf_base + (1 << 20) \<rbrakk> \<Longrightarrow>
+    table_index (pt_slot_offset max_pt_level riscv_global_pt_ptr vref) = 0x1FE"
+  apply (simp add: table_index_riscv_global_pt_ptr)
+  apply (simp add: bit_simps kernel_elf_base_def kernelELFBase_def)
+  apply word_bitwise
+  apply (clarsimp simp: word_size)
+  done
+
+lemma kernel_mapping_slots_0x1FE[simp]:
+  "0x1FE \<in> kernel_mapping_slots"
+  by (simp add: kernel_mapping_slots_def pptr_base_def bit_simps pt_bits_left_def level_defs
+                pptrBase_def canonical_bit_def)
+
+lemma translate_address_kernel_elf_window:
+  "\<lbrakk> kernel_elf_base \<le> vref; vref < kernel_elf_base + (1 << 20) \<rbrakk> \<Longrightarrow>
+   translate_address riscv_global_pt_ptr vref (ptes_of init_A_st) = Some (addrFromKPPtr vref)"
+  apply (clarsimp simp: translate_address_def in_omonad pt_lookup_target_def
+                        pt_lookup_slot_from_level_def)
+  apply (simp add: ptes_of_init_A_st_global[THEN fun_cong] init_global_pt_def global_pte_def pte_ref_def)
+  apply (simp add: elf_window_1M is_aligned_pt_slot_offset_pte)
+  apply (simp add: bit_simps addr_from_ppn_def shiftl_shiftl)
+  apply (simp add: ptrFromPAddr_def addrFromPPtr_def)
+  apply (simp add: addrFromKPPtr_def kernelELFBaseOffset_def kernelELFPAddrBase_def kernelELFBase_def)
+  apply (simp add: pt_bits_left_def bit_simps level_defs)
+  apply (rule conjI)
+   apply (simp add: pptrBase_def pptrBaseOffset_def paddrBase_def canonical_bit_def is_aligned_def)
+  apply (simp add: kernel_elf_base_def kernelELFBase_def)
+  apply (subst word_plus_and_or_coroll)
+   apply (simp add: canonical_bit_def word_size mask_def)
+   apply word_bitwise
+  apply (simp add: canonical_bit_def word_size mask_def)
+  apply word_bitwise
+  apply clarsimp
+  done
+
+lemma kernel_window_init_st:
+  "kernel_window init_A_st = { pptr_base ..< pptr_base + (1 << 30) }"
+  by (auto simp: state_defs kernel_window_def)
+
+lemma kernel_elf_window_init_st:
+  "kernel_elf_window init_A_st = { kernel_elf_base ..< kernel_elf_base + (1 << 20) }"
+  apply (clarsimp simp: state_defs kernel_elf_window_def kernel_elf_base_def kernelELFBase_def
+                        pptr_base_def pptrBase_def canonical_bit_def)
+  apply (rule set_eqI, clarsimp)
+  apply (rule iffI)
+   apply auto[1]
+  apply clarsimp
+  apply word_bitwise
+  apply clarsimp
+  done
+
+lemma valid_global_vspace_mappings_init_A_st[simp]:
+  "valid_global_vspace_mappings init_A_st"
+  unfolding valid_global_vspace_mappings_def
+  by (simp add: translate_address_kernel_window kernel_window_init_st
+                translate_address_kernel_elf_window kernel_elf_window_init_st)
+
+lemma valid_uses_init_A_st[simp]: "valid_uses_2 init_vspace_uses"
+proof -
+  note canonical_bit_def[simp]
+  have [simp]: "pptr_base < pptr_base + 0x40000000"
+    by (simp add: pptr_base_def pptrBase_def)
+  have [simp]: "p \<le> canonical_user \<Longrightarrow> \<not> pptr_base \<le> p" for p
+    by (rule notI, drule (1) order_trans)
+       (simp add: canonical_user_def mask_def pptr_base_def pptrBase_def)
+  have [simp]: "p \<le> canonical_user \<Longrightarrow> \<not> kernel_elf_base \<le> p" for p
+    by (rule notI, drule (1) order_trans)
+       (simp add: canonical_user_def mask_def kernel_elf_base_def kernelELFBase_def)
+  have [simp]: "p \<le> canonical_user \<Longrightarrow> \<not> kdev_base \<le> p" for p
+    by (rule notI, drule (1) order_trans)
+       (simp add: canonical_user_def mask_def kdev_base_def kdevBase_def)
+  have [simp]: "kernel_elf_base \<le> p \<Longrightarrow> \<not> p < pptr_base + 0x40000000" for p
+    by (rule notI, drule (1) order_le_less_trans)
+       (simp add: kernel_elf_base_def kernelELFBase_def pptr_base_def pptrBase_def)
+  have [simp]: "kdev_base \<le> p \<Longrightarrow> \<not> p < kernel_elf_base + 0x100000" for p
+    by (rule notI, drule (1) order_le_less_trans)
+       (simp add: kernel_elf_base_def kernelELFBase_def kdev_base_def kdevBase_def)
+  have "pptr_base + 0x40000000 < kernel_elf_base + 0x100000"
+    by (simp add: kernel_elf_base_def kernelELFBase_def pptr_base_def pptrBase_def)
+  thus ?thesis
+    using canonical_user_pptr_base pptr_base_kernel_elf_base
+    unfolding valid_uses_2_def init_vspace_uses_def window_defs
+    by (auto simp: canonical_user_canonical above_pptr_base_canonical)
+qed
+
+lemma valid_global_arch_objs_init_A_st[simp]:
+  "valid_global_arch_objs init_A_st"
+  by (simp add: valid_global_arch_objs_def state_defs level_defs obj_at_def)
+
+lemma valid_global_tables_init_A_st[simp]:
+  "valid_global_tables init_A_st"
+  apply (simp add: valid_global_tables_def Let_def riscv_global_pt_def[symmetric])
+  apply (clarsimp simp: state_defs pte_rights_of_def vm_kernel_only_def global_pte_def)
+  done
+
+lemma vspace_for_pool_init_A_st[simp]:
+  "vspace_for_pool ap asid (asid_pools_of init_A_st) = None"
+  by (clarsimp simp: vspace_for_pool_def obind_def in_opt_map_eq state_defs split: option.splits)
+
+lemma user_region_vs_lookup_target_init_A_st[simp]:
+  "vref \<in> user_region \<Longrightarrow> vs_lookup_target bot_level asid vref init_A_st = None"
+  by (clarsimp simp: vs_lookup_target_def obind_def vs_lookup_slot_def vs_lookup_table_def
+               split: option.splits)
+
+lemma valid_vs_lookup_init_A_st[simp]:
+  "valid_vs_lookup init_A_st"
+  by (clarsimp simp: valid_vs_lookup_def)
+
+lemma valid_vspace_objs_init_A_st[simp]:
+  "valid_vspace_objs init_A_st"
+  by (clarsimp simp: valid_vspace_objs_def in_omonad vs_lookup_table_def)
+
+lemma global_pt_kernel_window_init_arch_state[simp]:
+  "obj_addrs init_global_pt riscv_global_pt_ptr \<subseteq>
+     kernel_window_2 (riscv_kernel_vspace init_arch_state)"
+  apply (clarsimp simp: state_defs pptr_base_num bit_simps kernel_window_def kernel_elf_base_def)
+  apply (rule conjI; unat_arith)
+  done
+
+lemma idle_thread_in_kernel_window_init_arch_state[simp]:
+  "{idle_thread_ptr..0x3FF + idle_thread_ptr} \<subseteq>
+     kernel_window_2 (riscv_kernel_vspace init_arch_state)"
+  apply (clarsimp simp: state_defs pptr_base_num bit_simps kernel_window_def kernel_elf_base_def)
+  apply (rule conjI; unat_arith)
+  done
+
+lemma irq_node_pptr_base_kernel_elf_base:
+  "\<lbrakk>x \<le> pptr_base + (m + (mask cte_level_bits + 0x3000)); m \<le> mask (size irq) << cte_level_bits \<rbrakk>
+   \<Longrightarrow> \<not> kernel_elf_base \<le> x" for irq::irq
+  apply (simp add: word_size cte_level_bits_def mask_def pptr_base_def pptrBase_def
+                   kernel_elf_base_def kernelELFBase_def canonical_bit_def not_le)
+  apply unat_arith
+  done
+
+lemma irq_node_in_kernel_window_init_arch_state':
+  "\<lbrakk> init_irq_node_ptr + m \<le> x; x \<le> init_irq_node_ptr + m + mask cte_level_bits;
+     m \<le> mask (size (irq::irq)) << cte_level_bits\<rbrakk>
+   \<Longrightarrow> x \<in> kernel_window_2 (riscv_kernel_vspace init_arch_state)"
+  apply (clarsimp simp: kernel_window_def init_vspace_uses_def init_arch_state_def)
+  apply (rule conjI)
+   apply (clarsimp simp: state_defs)
+   apply (rule ccontr, simp add:not_le)
+   apply (drule(1) le_less_trans)
+   apply (cut_tac is_aligned_no_wrap'[where ptr=pptr_base
+                                      and off="0x3000 + m"
+                                      and sz=canonical_bit, simplified])
+     apply (simp add: add_ac)
+     apply (auto simp: pptr_base_kernel_elf_base irq_node_pptr_base_kernel_elf_base)[1]
+    apply (simp add: pptr_base_num canonical_bit_def is_aligned_def)
+   apply (simp add: pptr_base_num cte_level_bits_def canonical_bit_def mask_def word_size)
+   apply unat_arith
+  apply (simp add: kernel_elf_base_def kernelELFBase_def cte_level_bits_def canonical_bit_def
+                   mask_def init_irq_node_ptr_def pptr_base_num word_size)
+  apply unat_arith
+  apply clarsimp
+  done
+
+lemma irq_node_in_kernel_window_init_arch_state[simp]:
+  "\<lbrakk> init_irq_node_ptr + (ucast (irq::irq) << cte_level_bits) \<le> x;
+     x \<le> init_irq_node_ptr + (ucast irq << cte_level_bits) + 2 ^ cte_level_bits - 1 \<rbrakk>
+   \<Longrightarrow> x \<in> kernel_window_2 (riscv_kernel_vspace init_arch_state)"
+  apply (erule irq_node_in_kernel_window_init_arch_state')
+   apply (simp add: mask_def add_diff_eq)
+  apply (simp add: word_size mask_def cte_level_bits_def)
+  apply (thin_tac P for P)
+  apply word_bitwise
+  done
+
+lemma invs_A:
+  "invs init_A_st" (is "invs ?st")
+  supply is_aligned_def[THEN iffD2, simp]
+  supply image_cong_simp [cong del]
+  supply pptr_base_num[simp] kernel_elf_base_def[simp]
+  apply (simp add: invs_def)
+  apply (rule conjI)
+   prefer 2
+   apply (simp add: cur_tcb_def state_defs obj_at_def)
+  apply (simp add: valid_state_def)
+  apply (rule conjI)
+   apply (simp add: valid_pspace_def)
+   apply (rule conjI)
+    apply (clarsimp simp: valid_objs_def state_defs wellformed_pte_def global_pte_def
+                          valid_obj_def valid_vm_rights_def vm_kernel_only_def
+                          dom_if_Some cte_level_bits_def)
+    apply (clarsimp simp: valid_tcb_def tcb_cap_cases_def is_master_reply_cap_def
+                          valid_cap_def obj_at_def valid_tcb_state_def valid_arch_tcb_def
+                          cap_aligned_def word_bits_def valid_ipc_buffer_cap_simps)+
+    apply (clarsimp simp: valid_cs_def word_bits_def cte_level_bits_def
+                          init_irq_ptrs_all_ineqs valid_tcb_def
+                   split: if_split_asm)
+    apply auto[1]
+   apply (simp add: pspace_aligned_init_A pspace_distinct_init_A)
+   apply (rule conjI)
+    apply (clarsimp simp: if_live_then_nonz_cap_def obj_at_def state_defs live_def hyp_live_def)
+   apply (rule conjI)
+    apply (clarsimp simp: zombies_final_def cte_wp_at_cases state_defs
+                          tcb_cap_cases_def is_zombie_def)
+   apply (clarsimp simp: sym_refs_def state_refs_of_def state_defs state_hyp_refs_of_def)
+  apply (rule conjI)
+   apply (clarsimp simp: valid_mdb_def init_cdt_def no_mloop_def
+                         mdb_cte_at_def)
+   apply (clarsimp simp: untyped_mdb_def caps_of_state_init_A_st_Null
+                         untyped_inc_def ut_revocable_def
+                         irq_revocable_def reply_master_revocable_def
+                         reply_mdb_def reply_caps_mdb_def
+                         reply_masters_mdb_def valid_arch_mdb_def)
+   apply (simp add:descendants_inc_def)
+  apply (rule conjI)
+   apply (simp add: valid_ioc_def init_A_st_def init_ioc_def cte_wp_at_cases2)
+   apply (intro allI impI, elim exE conjE)
+   apply (case_tac obj, simp_all add: cap_of_def)
+   apply (clarsimp simp: init_kheap_def init_global_pt_def split: if_split_asm)
+  apply (rule conjI)
+   apply (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def state_defs valid_arch_idle_def)
+  apply (rule conjI, clarsimp simp: only_idle_def pred_tcb_at_def obj_at_def state_defs)
+  apply (rule conjI, clarsimp simp: if_unsafe_then_cap_def caps_of_state_init_A_st_Null)
+  apply (subgoal_tac "valid_reply_caps ?st \<and> valid_reply_masters ?st \<and> valid_global_refs ?st")
+   prefer 2
+   subgoal
+     using cte_wp_at_init_A_st_Null
+     by (fastforce simp: valid_reply_caps_def unique_reply_caps_def
+                         has_reply_cap_def is_reply_cap_to_def pred_tcb_at_def obj_at_def
+                         caps_of_state_init_A_st_Null is_master_reply_cap_to_def
+                         valid_reply_masters_def valid_global_refs_def
+                         valid_refs_def[unfolded cte_wp_at_caps_of_state])
+  apply (clarsimp, (thin_tac "_")+) (* use new proven assumptions, then drop them *)
+  apply (rule conjI)
+   apply (clarsimp simp: valid_arch_state_def)
+   apply (rule conjI)
+    apply (clarsimp simp: valid_asid_table_def state_defs)
+   apply (simp add: valid_arch_state_def state_defs obj_at_def a_type_def)
+  apply (rule conjI)
+   apply (clarsimp simp: valid_irq_node_def obj_at_def state_defs
+                         is_cap_table_def wf_empty_bits
+                         init_irq_ptrs_all_ineqs cte_level_bits_def
+                         init_irq_ptrs_eq[unfolded cte_level_bits_def])
+   apply (intro conjI)
+    apply (rule inj_onI)
+    apply (simp add: init_irq_ptrs_eq[unfolded cte_level_bits_def])
+   apply (clarsimp; word_bitwise)
+  apply (simp add: valid_irq_handlers_def caps_of_state_init_A_st_Null
+                   ran_def cong: rev_conj_cong)
+  apply (rule conjI)
+   apply (clarsimp simp: valid_irq_states_def state_defs init_machine_state_def
+                         valid_irq_masks_def init_irq_masks_def)
+  apply (rule conjI)
+   apply (clarsimp simp: valid_machine_state_def state_defs
+                         init_machine_state_def init_underlying_memory_def)
+  apply (rule conjI)
+   apply (clarsimp simp: valid_arch_caps_def valid_asid_pool_caps_def unique_table_caps_def
+                         caps_of_state_init_A_st_Null valid_table_caps_def unique_table_refs_def)
+   apply (clarsimp simp: state_defs)
+  apply (clarsimp simp: valid_global_objs_def valid_kernel_mappings_def valid_asid_map_def)
+  apply (rule conjI)
+   apply (clarsimp simp: equal_kernel_mappings_def)
+  apply (rule conjI)
+   apply (clarsimp simp: pspace_in_kernel_window_def init_A_st_def init_kheap_def)
+  apply (simp add: cap_refs_in_kernel_window_def caps_of_state_init_A_st_Null
+                  valid_refs_def[unfolded cte_wp_at_caps_of_state])
+  done
+
+
+end
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
@@ -11,14 +11,14 @@ imports
   Arch_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 text \<open>
   Showing that there is a state that satisfies the abstract invariants.
 \<close>
 
-lemmas ptr_defs = idle_thread_ptr_def init_irq_node_ptr_def riscv_global_pt_ptr_def
-lemmas state_defs = init_A_st_def init_kheap_def init_arch_state_def init_global_pt_def
+lemmas ptr_defs = idle_thread_ptr_def init_irq_node_ptr_def (* FIXME AARCH64 riscv_global_pt_ptr_def *)
+lemmas state_defs = init_A_st_def init_kheap_def init_arch_state_def (* FIXME AARCH64 init_global_pt_def *)
                     init_vspace_uses_def ptr_defs
 
 lemma is_tcb_TCB[simp]: "is_tcb (TCB t)" by (simp add: is_tcb_def)
@@ -55,7 +55,7 @@ lemma is_reply_cap_NullCap[simp]: "\<not>is_reply_cap NullCap"
 declare cap_range_NullCap [simp]
 
 lemma pptr_base_num:
-  "pptr_base = 0xFFFFFFC000000000"
+  "pptr_base = 0x8000000000"
   by (simp add: pptr_base_def pptrBase_def canonical_bit_def)
 
 (* IRQ nodes occupy 11 bits of address space in this RISCV example state:
@@ -66,6 +66,7 @@ lemma init_irq_ptrs_ineqs:
                 \<le> init_irq_node_ptr + mask 11"
   "init_irq_node_ptr + (ucast (irq :: irq) << cte_level_bits)
                 \<le> init_irq_node_ptr + mask 11"
+sorry (* FIXME AARCH64
 proof -
   have P: "ucast irq < (2 ^ (11 - cte_level_bits) :: machine_word)"
     apply (rule order_le_less_trans[OF
@@ -95,7 +96,7 @@ proof -
      apply simp
     apply (simp add: cte_level_bits_def init_irq_node_ptr_def pptr_base_num)
     done
-qed
+qed *)
 
 lemmas init_irq_ptrs_less_ineqs
    = init_irq_ptrs_ineqs(1)[THEN order_less_le_trans[rotated]]
@@ -174,14 +175,16 @@ lemma cap_refs_respects_device_region_init[simp]:
    apply (clarsimp simp: cte_wp_at_caps_of_state cap_range_respects_device_region_def)
    done
 
+(* FIXME AARCH64
 lemma kernel_mapping_slot: "0x1FF \<in> kernel_mapping_slots"
   by (clarsimp simp: kernel_mapping_slots_def pptr_base_def pptrBase_def canonical_bit_def
-                     pt_bits_left_def bit_simps level_defs)
+                     pt_bits_left_def bit_simps level_defs) *)
 
 lemma pool_for_asid_init_A_st[simp]:
   "pool_for_asid asid init_A_st = None"
   by (simp add: pool_for_asid_def state_defs)
 
+(* FIXME AARCH64
 lemma vspace_for_asid_init_A_st[simp]:
   "vspace_for_asid asid init_A_st = None"
   by (simp add: vspace_for_asid_def obind_def)
@@ -426,6 +429,7 @@ lemma irq_node_in_kernel_window_init_arch_state[simp]:
   apply (thin_tac P for P)
   apply word_bitwise
   done
+*)
 
 lemma invs_A:
   "invs init_A_st" (is "invs ?st")
@@ -436,6 +440,8 @@ lemma invs_A:
   apply (rule conjI)
    prefer 2
    apply (simp add: cur_tcb_def state_defs obj_at_def)
+  sorry (* FIXME AARCH64 rest of proof won't make sense until example state is tweaked from RISCV64
+                         version
   apply (simp add: valid_state_def)
   apply (rule conjI)
    apply (simp add: valid_pspace_def)
@@ -518,7 +524,7 @@ lemma invs_A:
    apply (clarsimp simp: pspace_in_kernel_window_def init_A_st_def init_kheap_def)
   apply (simp add: cap_refs_in_kernel_window_def caps_of_state_init_A_st_Null
                   valid_refs_def[unfolded cte_wp_at_caps_of_state])
-  done
+  done  *)
 
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
@@ -1,0 +1,1051 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(*
+ Arch-specific retype invariants
+*)
+
+theory ArchRetype_AI
+imports Retype_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems Retype_AI_assms
+
+lemma arch_kobj_size_cong[Retype_AI_assms]:
+"\<lbrakk>a = a1; c=c1\<rbrakk> \<Longrightarrow> arch_kobj_size (default_arch_object a b c)
+  = arch_kobj_size (default_arch_object a1 b1 c1)"
+  by (simp add: default_arch_object_def split: aobject_type.splits)
+
+
+lemma clearMemoryVM_return[simp, Retype_AI_assms]:
+  "clearMemoryVM a b = return ()"
+  by (simp add: clearMemoryVM_def)
+
+lemma slot_bits_def2 [Retype_AI_assms]: "slot_bits = cte_level_bits"
+  by (simp add: slot_bits_def cte_level_bits_def)
+
+definition
+  "no_gs_types \<equiv> UNIV - {CapTableObject,
+                         ArchObject SmallPageObj, ArchObject LargePageObj, ArchObject HugePageObj}"
+
+lemma no_gs_types_simps [simp, Retype_AI_assms]:
+  "Untyped \<in> no_gs_types"
+  "TCBObject \<in> no_gs_types"
+  "EndpointObject \<in> no_gs_types"
+  "NotificationObject \<in> no_gs_types"
+  "ArchObject PageTableObj \<in> no_gs_types"
+  "ArchObject ASIDPoolObj \<in> no_gs_types"
+  by (simp_all add: no_gs_types_def)
+
+lemma retype_region_ret_folded [Retype_AI_assms]:
+  "\<lbrace>\<top>\<rbrace> retype_region y n bits ty dev
+   \<lbrace>\<lambda>r s. r = retype_addrs y ty n bits\<rbrace>"
+  unfolding retype_region_def
+  apply (simp add: pageBits_def)
+  apply wp
+   apply (simp add:retype_addrs_def)
+  done
+
+crunches init_arch_objects
+  for pspace_aligned[wp]:  "pspace_aligned"
+  and pspace_distinct[wp]: "pspace_distinct"
+  and mdb_inv[wp]: "\<lambda>s. P (cdt s)"
+  and valid_mdb[wp]: "valid_mdb"
+  and cte_wp_at[wp]: "\<lambda>s. P (cte_wp_at P' p s)"
+  and typ_at[wp]: "\<lambda>s. P (typ_at T p s)"
+  (ignore: clearMemory wp: crunch_wps)
+
+crunch mdb_inv[wp]: store_pte "\<lambda>s. P (cdt s)"
+  (ignore: clearMemory wp: crunch_wps)
+
+lemma valid_vspace_objs_pte:
+  "\<lbrakk> ptes_of s p = Some pte; valid_vspace_objs s; \<exists>\<rhd> (level, table_base p) s \<rbrakk>
+   \<Longrightarrow> valid_pte level pte s \<or> level = max_pt_level \<and> table_index p \<in> kernel_mapping_slots"
+  apply (clarsimp simp: ptes_of_def in_opt_map_eq)
+  apply (drule (2) valid_vspace_objsD)
+   apply (fastforce simp: in_opt_map_eq)
+  apply simp
+  done
+
+lemma get_pte_valid[wp]:
+  "\<lbrace>valid_vspace_objs and \<exists>\<rhd> (level, table_base p) and
+    K (level = max_pt_level \<longrightarrow> table_index p \<notin> kernel_mapping_slots)\<rbrace>
+   get_pte p
+   \<lbrace>valid_pte level\<rbrace>"
+  by wpsimp (fastforce dest: valid_vspace_objs_pte)
+
+lemma get_pte_wellformed[wp]:
+  "\<lbrace>valid_objs\<rbrace> get_pte p \<lbrace>\<lambda>rv _. wellformed_pte rv\<rbrace>"
+  apply wpsimp
+  apply (fastforce simp: valid_objs_def dom_def valid_obj_def ptes_of_def in_opt_map_eq)
+  done
+
+crunch valid_objs[wp]: init_arch_objects "valid_objs"
+  (ignore: clearMemory wp: crunch_wps)
+
+crunch valid_arch_state[wp]: init_arch_objects "valid_arch_state"
+  (ignore: clearMemory set_object wp: crunch_wps)
+
+lemmas init_arch_objects_valid_cap[wp] = valid_cap_typ [OF init_arch_objects_typ_at]
+
+lemmas init_arch_objects_cap_table[wp] = cap_table_at_lift_valid [OF init_arch_objects_typ_at]
+
+crunch device_state_inv[wp]: clearMemory "\<lambda>ms. P (device_state ms)"
+  (wp: mapM_x_wp ignore_del: clearMemory)
+
+crunch pspace_respects_device_region[wp]: reserve_region pspace_respects_device_region
+crunch cap_refs_respects_device_region[wp]: reserve_region cap_refs_respects_device_region
+
+crunch invs [wp]: reserve_region "invs"
+
+crunch iflive[wp]: copy_global_mappings "if_live_then_nonz_cap"
+  (wp: crunch_wps)
+
+crunch zombies[wp]: copy_global_mappings "zombies_final"
+  (wp: crunch_wps)
+
+crunch state_refs_of[wp]: copy_global_mappings "\<lambda>s. P (state_refs_of s)"
+  (wp: crunch_wps)
+
+crunch valid_idle[wp]: copy_global_mappings "valid_idle"
+  (wp: crunch_wps)
+
+crunch only_idle[wp]: copy_global_mappings "only_idle"
+  (wp: crunch_wps)
+
+crunch ifunsafe[wp]: copy_global_mappings "if_unsafe_then_cap"
+  (wp: crunch_wps)
+
+crunch reply_caps[wp]: copy_global_mappings "valid_reply_caps"
+  (wp: crunch_wps)
+
+crunch reply_masters[wp]: copy_global_mappings "valid_reply_masters"
+  (wp: crunch_wps)
+
+crunch valid_global[wp]: copy_global_mappings "valid_global_refs"
+  (wp: crunch_wps)
+
+crunch irq_node[wp]: copy_global_mappings "\<lambda>s. P (interrupt_irq_node s)"
+  (wp: crunch_wps)
+
+crunch irq_states[wp]: copy_global_mappings "\<lambda>s. P (interrupt_states s)"
+  (wp: crunch_wps)
+
+crunch caps_of_state[wp]: copy_global_mappings "\<lambda>s. P (caps_of_state s)"
+  (wp: crunch_wps)
+
+crunch pspace_in_kernel_window[wp]: copy_global_mappings "pspace_in_kernel_window"
+  (wp: crunch_wps)
+
+crunch cap_refs_in_kernel_window[wp]: copy_global_mappings "cap_refs_in_kernel_window"
+  (wp: crunch_wps)
+
+crunch pspace_respects_device_region[wp]: copy_global_mappings "pspace_respects_device_region"
+  (wp: crunch_wps)
+
+crunch cap_refs_respects_device_region[wp]: copy_global_mappings "cap_refs_respects_device_region"
+  (wp: crunch_wps)
+
+lemma dmo_eq_kernel_restricted [wp, Retype_AI_assms]:
+  "\<lbrace>\<lambda>s. equal_kernel_mappings (kheap_update (f (kheap s)) s)\<rbrace>
+       do_machine_op m
+   \<lbrace>\<lambda>rv s. equal_kernel_mappings (kheap_update (f (kheap s)) s)\<rbrace>"
+  unfolding do_machine_op_def equal_kernel_mappings_def has_kernel_mappings_def
+  by (wpsimp simp: in_omonad vspace_for_asid_def pool_for_asid_def)
+
+definition
+  "post_retype_invs_check tp \<equiv> False"
+
+declare post_retype_invs_check_def[simp]
+
+end
+
+
+context begin interpretation Arch .
+requalify_consts post_retype_invs_check
+end
+
+definition
+  post_retype_invs :: "apiobject_type \<Rightarrow> obj_ref list \<Rightarrow> 'z::state_ext state \<Rightarrow> bool"
+where
+    "post_retype_invs tp refs \<equiv>
+      if post_retype_invs_check tp
+        then all_invs_but_equal_kernel_mappings_restricted (set refs)
+        else invs"
+
+global_interpretation Retype_AI_post_retype_invs?: Retype_AI_post_retype_invs
+  where post_retype_invs_check = post_retype_invs_check
+    and post_retype_invs = post_retype_invs
+  by (unfold_locales; fact post_retype_invs_def)
+
+
+context Arch begin global_naming RISCV64
+
+lemma init_arch_objects_invs_from_restricted:
+  "\<lbrace>post_retype_invs new_type refs
+         and (\<lambda>s. global_refs s \<inter> set refs = {})
+         and K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api new_type obj_sz))\<rbrace>
+     init_arch_objects new_type ptr bits obj_sz refs
+   \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (simp add: init_arch_objects_def split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp hoare_vcg_const_Ball_lift
+             valid_irq_node_typ
+                  | wpc)+
+  apply (auto simp: post_retype_invs_def)
+  done
+
+
+lemma obj_bits_api_neq_0 [Retype_AI_assms]:
+  "ty \<noteq> Untyped \<Longrightarrow> 0 < obj_bits_api ty us"
+  unfolding obj_bits_api_def
+  by (clarsimp simp: slot_bits_def default_arch_object_def bit_simps
+               split: apiobject_type.splits aobject_type.splits)
+
+end
+
+
+global_interpretation Retype_AI_slot_bits?: Retype_AI_slot_bits
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; fact Retype_AI_assms)
+  qed
+
+
+context Arch begin global_naming RISCV64
+
+lemma valid_untyped_helper [Retype_AI_assms]:
+  assumes valid_c : "s  \<turnstile> c"
+  and   cte_at  : "cte_wp_at ((=) c) q s"
+  and     tyunt: "ty \<noteq> Structures_A.apiobject_type.Untyped"
+  and   cover  : "range_cover ptr sz (obj_bits_api ty us) n"
+  and   range  : "is_untyped_cap c \<Longrightarrow> usable_untyped_range c \<inter> {ptr..ptr + of_nat (n * 2 ^ (obj_bits_api ty us)) - 1} = {}"
+  and     pn   : "pspace_no_overlap_range_cover ptr sz s"
+  and     cn   : "caps_no_overlap ptr sz s"
+  and     vp   : "valid_pspace s"
+  shows "valid_cap c
+           (s\<lparr>kheap := \<lambda>x. if x \<in> set (retype_addrs ptr ty n us) then Some (default_object ty dev us) else kheap s x\<rparr>)"
+  (is "valid_cap c ?ns")
+  proof -
+  have obj_at_pres: "\<And>P x. obj_at P x s \<Longrightarrow> obj_at P x ?ns"
+  by (clarsimp simp: obj_at_def dest: domI)
+   (erule pspace_no_overlapC [OF pn _ _ cover vp])
+  note blah[simp del] = atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+        Int_atLeastAtMost atLeastatMost_empty_iff
+  have cover':"range_cover ptr sz (obj_bits (default_object ty dev us)) n"
+    using cover tyunt
+    by (clarsimp simp:obj_bits_dev_irr)
+
+  show ?thesis
+  using cover valid_c range usable_range_emptyD[where cap = c] cte_at
+  apply (clarsimp simp: valid_cap_def valid_arch_cap_ref_def elim!: obj_at_pres
+                 split: cap.splits option.splits arch_cap.splits)
+    defer
+    apply (fastforce elim!: obj_at_pres)
+   apply (fastforce elim!: obj_at_pres)
+  apply (rename_tac word nat1 nat2)
+  apply (clarsimp simp:valid_untyped_def is_cap_simps obj_at_def split:if_split_asm)
+   apply (thin_tac "\<forall>x. Q x" for Q)
+   apply (frule retype_addrs_obj_range_subset_strong[where dev=dev, OF _ _ tyunt])
+    apply (simp add: obj_bits_dev_irr tyunt)
+   apply (frule usable_range_subseteq)
+    apply (simp add:is_cap_simps)
+   apply (clarsimp simp:cap_aligned_def split:if_split_asm)
+   apply (frule aligned_ranges_subset_or_disjoint)
+    apply (erule retype_addrs_aligned[where sz = sz])
+      apply (simp add: range_cover_def)
+     apply (simp add: range_cover_def word_bits_def)
+    apply (simp add: range_cover_def)
+   apply (clarsimp simp: default_obj_range Int_ac tyunt
+                  split: if_split_asm)
+   apply (elim disjE)
+    apply (drule(2) subset_trans[THEN disjoint_subset2])
+    apply (drule Int_absorb2)+
+    apply (simp add:is_cap_simps free_index_of_def)
+   apply simp
+   apply (drule(1) disjoint_subset2[rotated])
+   apply (simp add:Int_ac)
+  apply (thin_tac "\<forall>x. Q x" for Q)
+  apply (frule retype_addrs_obj_range_subset[OF _ cover' tyunt])
+  apply (clarsimp simp:cap_aligned_def)
+  apply (frule aligned_ranges_subset_or_disjoint)
+   apply (erule retype_addrs_aligned[where sz = sz])
+     apply (simp add: range_cover_def)
+    apply (simp add: range_cover_def word_bits_def)
+   apply (simp add: range_cover_def)
+  apply (clarsimp simp: default_obj_range Int_ac tyunt
+                 split: if_split_asm)
+  apply (erule disjE)
+   apply (simp add: cte_wp_at_caps_of_state)
+   apply (drule cn[unfolded caps_no_overlap_def,THEN bspec,OF ranI])
+   apply (simp add: p_assoc_help[symmetric])
+   apply (erule impE)
+    apply blast (* set arith *)
+   apply blast (* set arith *)
+  apply blast (* set arith  *)
+  done
+  qed
+
+lemma valid_default_arch_tcb:
+  "\<And>s. valid_arch_tcb default_arch_tcb s"
+  by (simp add: default_arch_tcb_def valid_arch_tcb_def)
+
+end
+
+
+global_interpretation Retype_AI_valid_untyped_helper?: Retype_AI_valid_untyped_helper
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; fact Retype_AI_assms)
+  qed
+
+
+locale retype_region_proofs_arch
+  = retype_region_proofs s ty us ptr sz n ps s' dev
+  + Arch
+  for s :: "'state_ext :: state_ext state"
+  and ty us ptr sz n ps s' dev
+
+
+context retype_region_proofs begin
+
+interpretation Arch .
+
+lemma valid_cap:
+  assumes cap:
+    "(s::'state_ext state) \<turnstile> cap \<and> untyped_range cap \<inter> {ptr .. (ptr && ~~ mask sz) + 2 ^ sz - 1} = {}"
+  shows "s' \<turnstile> cap"
+  proof -
+  note blah[simp del] = atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+        Int_atLeastAtMost atLeastatMost_empty_iff
+  have cover':"range_cover ptr sz (obj_bits (default_object ty dev us)) n"
+    using cover tyunt
+    by (clarsimp simp: obj_bits_dev_irr)
+  show ?thesis
+    unfolding valid_cap_def
+    using cap
+    apply (case_tac cap)
+               apply (simp_all add: valid_cap_def obj_at_pres cte_at_pres valid_arch_cap_ref_def
+                               split: option.split_asm arch_cap.split_asm option.splits)
+    apply (clarsimp simp add: valid_untyped_def ps_def s'_def)
+    apply (rule conjI)
+     apply clarsimp
+     apply (drule disjoint_subset [OF retype_addrs_obj_range_subset [OF _ cover' tyunt]])
+      apply (simp add: Int_ac p_assoc_help[symmetric])
+     apply simp
+    apply clarsimp
+    apply (drule disjoint_subset [OF retype_addrs_obj_range_subset [OF _ cover' tyunt]])
+     apply (simp add: Int_ac p_assoc_help[symmetric])
+    apply simp
+    done
+  qed
+
+lemma valid_global_refs:
+  "valid_global_refs s \<Longrightarrow> valid_global_refs s'"
+  apply (simp add: valid_global_refs_def valid_refs_def global_refs_def idle_s')
+  apply (simp add: cte_retype cap_range_def)
+  done
+
+lemma asid_pools:
+  "asid_pools_of s p = Some pool \<Longrightarrow> asid_pools_of s' p = Some pool"
+  by (clarsimp simp: in_opt_map_eq s'_def ps_def)
+     (erule pspace_no_overlapC [OF orth _ _ cover vp])
+
+lemma pts_of:
+  "pts_of s p = Some pt \<Longrightarrow> pts_of s' p = Some pt"
+  by (clarsimp simp: in_opt_map_eq s'_def ps_def)
+     (erule pspace_no_overlapC [OF orth _ _ cover vp])
+
+lemma pts_of':
+  "pts_of s' p = Some pt \<Longrightarrow>
+   pts_of s p = Some pt \<or> pt = empty_pt \<and> p \<in> set (retype_addrs ptr ty n us)"
+  apply (clarsimp simp: in_opt_map_eq s'_def ps_def split: if_split_asm)
+  apply (simp add: default_object_def default_arch_object_def tyunt
+              split: apiobject_type.splits aobject_type.splits)
+  done
+
+lemma valid_asid_table:
+  "valid_asid_table s \<Longrightarrow> valid_asid_table s'"
+  unfolding valid_asid_table_def by (auto simp: asid_pools)
+
+lemma valid_global_arch_objs:
+  "valid_global_arch_objs s \<Longrightarrow> valid_global_arch_objs s'"
+  by (fastforce simp: valid_global_arch_objs_def pt_at_eq pts_of)
+
+lemma ptes_of:
+  "ptes_of s p = Some pte \<Longrightarrow> ptes_of s' p = Some pte"
+  by (simp add: pte_of_def obind_def pts_of split: option.splits)
+
+lemma default_empty:
+  "default_object ty dev us = ArchObj (PageTable pt) \<Longrightarrow> pt = empty_pt"
+  by (simp add: default_object_def default_arch_object_def tyunt
+           split: apiobject_type.splits aobject_type.splits)
+
+lemma ptes_of':
+  "ptes_of s' p = Some pte \<Longrightarrow> ptes_of s p = Some pte \<or> pte = InvalidPTE"
+  by (fastforce simp: ptes_of_def in_omonad s'_def ps_def split: if_splits dest: default_empty)
+
+lemma pt_walk:
+  "pt_walk top_level bot_level pt vref (ptes_of s) = Some (level, p) \<Longrightarrow>
+   pt_walk top_level bot_level pt vref (ptes_of s') = Some (level, p)"
+  apply (induct top_level arbitrary: pt)
+   apply simp
+  apply (subst (asm) (3) pt_walk.simps)
+  apply (clarsimp simp: in_omonad split: if_splits)
+   prefer 2
+   apply (subst pt_walk.simps)
+   apply (simp add: in_omonad)
+  apply (erule disjE; clarsimp)
+   prefer 2
+   apply (subst pt_walk.simps)
+   apply (simp add: in_omonad)
+   apply (rule_tac x=v' in exI)
+   apply (simp add: ptes_of)
+  apply (drule ptes_of)
+  apply (subst pt_walk.simps)
+  apply (simp add: in_omonad)
+  done
+
+lemma pt_walk':
+  "pt_walk top_level level pt vref (ptes_of s') = Some (level, p) \<Longrightarrow>
+   pt_walk top_level level pt vref (ptes_of s) = Some (level, p)"
+  apply (induct top_level arbitrary: pt)
+   apply simp
+  apply (subst (asm) (3) pt_walk.simps)
+  apply (clarsimp simp: in_omonad split: if_splits)
+  apply (erule disjE; clarsimp)
+  apply (drule ptes_of')
+  apply (subst pt_walk.simps)
+  apply (fastforce simp add: in_omonad)
+  done
+
+lemma pt_walk_eq[simp]:
+  "(pt_walk top_level level pt_ptr vptr (ptes_of s') = Some (level, p)) =
+   (pt_walk top_level level pt_ptr vptr (ptes_of s) = Some (level, p))"
+  apply (rule iffI)
+   apply (erule pt_walk')
+  apply (erule pt_walk)
+  done
+
+lemma global_no_retype:
+  "\<lbrakk> pt_ptr \<in> global_refs s; valid_global_refs s \<rbrakk> \<Longrightarrow> pt_ptr \<notin> set (retype_addrs ptr ty n us)"
+  using dev retype_addrs_subset_ptr_bits[OF cover]
+  by (fastforce simp: valid_global_refs_def valid_refs_def cte_wp_at_caps_of_state)
+
+lemma global_pts_no_retype:
+  "\<lbrakk> pt_ptr \<in> riscv_global_pts (arch_state s) level; valid_global_refs s \<rbrakk> \<Longrightarrow>
+   pt_ptr \<notin> set (retype_addrs ptr ty n us)"
+  by (drule riscv_global_pts_global_ref, erule global_no_retype)
+
+lemma valid_global_tables:
+  "valid_global_tables s \<Longrightarrow> valid_global_tables s'"
+  apply (clarsimp simp: valid_global_tables_def Let_def)
+  apply (fold riscv_global_pt_def)
+  apply (intro conjI; clarsimp)
+     apply (drule pt_walk_level)
+     apply fastforce
+    apply (drule pts_of', fastforce)
+   apply (drule pts_of', fastforce)
+  apply (drule pts_of', fastforce simp: vm_kernel_only_def pte_rights_of_def)
+  done
+
+lemma valid_arch_state:
+  "valid_arch_state s \<Longrightarrow> valid_arch_state s'"
+  apply (simp add: valid_arch_state_def valid_asid_table valid_global_arch_objs valid_global_tables
+              del: arch_state)
+  apply simp
+  done
+
+lemma vspace_for_pool1:
+  "(vspace_for_pool asid p (asid_pools_of s) = Some pt) \<Longrightarrow>
+   vspace_for_pool asid p (asid_pools_of s') = Some pt"
+  by (simp add: vspace_for_pool_def asid_pools obind_def split: option.splits)
+
+lemma vspace_for_pool2:
+  "vspace_for_pool asid p (asid_pools_of s') = Some pt \<Longrightarrow>
+   vspace_for_pool asid p (asid_pools_of s) = Some pt"
+  apply (clarsimp simp: vspace_for_pool_def in_omonad s'_def ps_def split: if_split_asm)
+  apply (clarsimp simp: default_object_def default_arch_object_def tyunt
+                  split: apiobject_type.splits aobject_type.splits)
+  done
+
+lemma vspace_for_pool[simp]:
+  "(vspace_for_pool asid p (asid_pools_of s') = Some pt) =
+   (vspace_for_pool asid p (asid_pools_of s) = Some pt)"
+  by (rule iffI, erule vspace_for_pool2, erule vspace_for_pool1)
+
+lemma vs_lookup_table':
+  "(vs_lookup_table level asid vref s' = Some (level, p)) =
+   (vs_lookup_table level asid vref s = Some (level, p))"
+  by (fastforce simp: vs_lookup_table_def in_omonad pool_for_asid_def split: if_split_asm)
+
+lemma vs_lookup_target':
+  "(vs_lookup_target level asid vref s' = Some (level,p)) =
+   (vs_lookup_target level asid vref s = Some (level,p))"
+  unfolding vs_lookup_target_def vs_lookup_slot_def
+  supply vs_lookup_table'[simp]
+  apply (clarsimp simp: in_omonad)
+  apply (cases "level = asid_pool_level"; clarsimp)
+   apply fastforce
+  apply (rule iffI; clarsimp simp: asid_pool_level_eq)
+   apply (fastforce dest: ptes_of')
+  apply (fastforce dest: ptes_of)
+  done
+
+lemma wellformed_default_obj[Retype_AI_assms]:
+   "\<lbrakk> ptra \<notin> set (retype_addrs ptr ty n us);
+        kheap s ptra = Some (ArchObj ao); arch_valid_obj ao s\<rbrakk> \<Longrightarrow>
+          arch_valid_obj ao s'"
+  apply (clarsimp elim!:obj_at_pres
+                  split: arch_kernel_obj.splits option.splits)
+  done
+
+end
+
+
+context retype_region_proofs_arch begin
+
+lemma hyp_refs_eq:
+  "state_hyp_refs_of s' = state_hyp_refs_of s"
+  unfolding s'_def ps_def
+  by (rule ext) (clarsimp simp: state_hyp_refs_of_def split: option.splits)
+
+
+lemma obj_at_valid_pte:
+  "\<lbrakk>valid_pte level pte s; \<And>P p. obj_at P p s \<Longrightarrow> obj_at P p s'\<rbrakk>
+   \<Longrightarrow> valid_pte level pte s'"
+  apply (cases pte, simp_all add: valid_pte_def data_at_def)
+  apply (clarsimp | elim disjE)+
+  done
+
+lemma pt_lookup_slot_from_level:
+  "\<lbrakk> vref \<in> kernel_mappings; valid_global_tables s; valid_global_arch_objs s; pspace_aligned s;
+     valid_global_refs s \<rbrakk> \<Longrightarrow>
+   (pt_lookup_slot_from_level max_pt_level 0 (riscv_global_pt (arch_state s)) vref (ptes_of s')
+    = Some (level, p)) =
+   (pt_lookup_slot_from_level max_pt_level 0 (riscv_global_pt (arch_state s)) vref (ptes_of s)
+    = Some (level, p))"
+  apply (simp add: pt_lookup_slot_from_level_def in_omonad)
+  apply (subst pt_walk_eqI; simp)
+  apply clarsimp
+  apply (drule (1) valid_global_tablesD, simp)
+  apply (frule (1) global_pts_no_retype)
+  apply (simp add: opt_map_def s'_def ps_def split: option.splits)
+  done
+
+lemma translate_address:
+  "\<lbrakk> vref \<in> kernel_mappings; valid_global_tables s; valid_global_arch_objs s; pspace_aligned s;
+     valid_global_refs s \<rbrakk> \<Longrightarrow>
+   (translate_address (riscv_global_pt (arch_state s)) vref (ptes_of s') = Some p) =
+   (translate_address (riscv_global_pt (arch_state s)) vref (ptes_of s) = Some p)"
+  apply (simp add: translate_address_def in_omonad)
+  apply (simp add: pt_lookup_target_def in_omonad)
+  apply (auto simp: pt_lookup_slot_from_level dest: ptes_of' ptes_of)
+  done
+
+lemma valid_global_vspace_mappings:
+  "\<lbrakk> valid_global_vspace_mappings s; valid_global_tables s; valid_global_arch_objs s;
+     pspace_aligned s; valid_global_refs s; valid_uses s \<rbrakk>
+   \<Longrightarrow> valid_global_vspace_mappings s'"
+  unfolding valid_global_vspace_mappings_def Let_def
+  apply simp
+  apply (rule conjI; clarsimp)
+   apply (subst translate_address; assumption?)
+    apply (fastforce simp: kernel_regions_def translate_address intro!: kernel_regions_in_mappings)
+   apply simp
+  apply (subst translate_address; assumption?)
+   apply (fastforce simp: kernel_regions_def intro!: kernel_regions_in_mappings)
+  apply simp
+  done
+
+end
+
+
+context retype_region_proofs begin
+
+interpretation retype_region_proofs_arch ..
+
+lemma valid_vspace_obj_pres:
+  "valid_vspace_obj level ao s \<Longrightarrow> valid_vspace_obj level ao s'"
+  by (cases ao; simp add: obj_at_pres)
+     (fastforce intro: obj_at_valid_pte simp: obj_at_pres)
+
+lemma valid_vspace_objs':
+  assumes va: "valid_vspace_objs s"
+  shows "valid_vspace_objs s'"
+proof
+  fix level p ao asid vref
+  assume p: "vs_lookup_table level asid (vref_for_level vref (level + 1)) s' = Some (level, p)"
+  assume vref: "vref \<in> user_region"
+  assume "aobjs_of s' p = Some ao"
+  hence "aobjs_of s p = Some ao \<or> ArchObj ao = default_object ty dev us"
+    by (simp add: ps_def obj_at_def s'_def in_opt_map_eq split: if_split_asm)
+  moreover
+  { assume "ArchObj ao = default_object ty dev us" with tyunt
+    have "valid_vspace_obj level ao s'" by (rule valid_vspace_obj_default)
+  }
+  moreover
+  { assume "aobjs_of s p = Some ao"
+    with va p vref
+    have "valid_vspace_obj level ao s"
+      by (auto simp: vs_lookup_table' vref_for_level_user_region elim: valid_vspace_objsD)
+    hence "valid_vspace_obj level ao s'"
+      by (rule valid_vspace_obj_pres)
+  }
+  ultimately
+  show "valid_vspace_obj level ao s'" by blast
+qed
+
+
+sublocale retype_region_proofs_gen?: retype_region_proofs_gen
+  by (unfold_locales,
+        auto simp: hyp_refs_eq[simplified s'_def ps_def]
+                  wellformed_default_obj[simplified s'_def ps_def]
+                  valid_default_arch_tcb)
+
+end
+
+
+context Arch begin global_naming RISCV64
+
+lemma unique_table_caps_null:
+  "unique_table_caps_2 (null_filter caps)
+       = unique_table_caps_2 caps"
+  apply (simp add: unique_table_caps_def)
+  apply (intro iff_allI)
+  apply (clarsimp simp: null_filter_def)
+  done
+
+
+lemma unique_table_refs_null:
+  "unique_table_refs_2 (null_filter caps)
+       = unique_table_refs_2 caps"
+  apply (simp only: unique_table_refs_def)
+  apply (intro iff_allI)
+  apply (clarsimp simp: null_filter_def)
+  apply (auto dest!: obj_ref_none_no_asid[rule_format]
+               simp: table_cap_ref_def)
+  done
+
+
+definition
+  region_in_kernel_window :: "obj_ref set \<Rightarrow> 'z::state_ext state \<Rightarrow> bool"
+where
+ "region_in_kernel_window S \<equiv> \<lambda>s. S \<subseteq> kernel_window s"
+
+lemma pspace_respects_device_regionI:
+  assumes uat: "\<And>ptr sz. kheap s ptr = Some (ArchObj (DataPage False sz))
+                \<Longrightarrow> obj_range ptr (ArchObj $ DataPage False sz) \<subseteq> - device_region s"
+      and dat: "\<And>ptr sz. kheap s ptr = Some (ArchObj (DataPage True sz))
+                \<Longrightarrow> obj_range ptr (ArchObj $ DataPage True sz) \<subseteq> device_region s"
+      and inv:  "pspace_aligned s" "valid_objs s"
+  shows "pspace_respects_device_region s"
+
+  apply (simp add: pspace_respects_device_region_def,intro conjI)
+  apply (rule subsetI)
+   apply (clarsimp simp: dom_def user_mem_def obj_at_def in_user_frame_def split: if_split_asm)
+   apply (frule uat)
+   apply (cut_tac ko = "(ArchObj (DataPage False sz))" in p_in_obj_range_internal[OF _ inv])
+    prefer 2
+    apply (fastforce simp: obj_bits_def)
+   apply simp
+  apply (rule subsetI)
+  apply (clarsimp simp: dom_def device_mem_def obj_at_def in_device_frame_def split: if_split_asm)
+  apply (frule dat)
+  apply (cut_tac ko = "(ArchObj (DataPage True sz))" in p_in_obj_range_internal[OF _ inv])
+  prefer 2
+   apply (fastforce simp: obj_bits_def)
+  apply simp
+  done
+
+lemma obj_range_respect_device_range:
+  "\<lbrakk>kheap s ptr = Some (ArchObj (DataPage dev sz));pspace_aligned s\<rbrakk> \<Longrightarrow>
+  obj_range ptr (ArchObj $ DataPage dev sz) \<subseteq> (if dev then dom (device_mem s) else dom (user_mem s))"
+  apply (drule(1) pspace_alignedD[rotated])
+  apply (clarsimp simp: user_mem_def in_user_frame_def obj_at_def obj_range_def device_mem_def in_device_frame_def)
+  apply (intro impI conjI)
+   apply clarsimp
+   apply (rule exI[where x = sz])
+   apply (simp add: mask_in_range[symmetric,THEN iffD1] a_type_def)
+  apply clarsimp
+  apply (rule exI[where x = sz])
+  apply (simp add: mask_in_range[symmetric,THEN iffD1] a_type_def)
+  done
+
+lemma pspace_respects_device_regionD:
+  assumes inv:  "pspace_aligned s" "valid_objs s" "pspace_respects_device_region s"
+  shows uat: "\<And>ptr sz. kheap s ptr = Some (ArchObj (DataPage False sz))
+                \<Longrightarrow> obj_range ptr (ArchObj $ DataPage False sz) \<subseteq> - device_region s"
+      and dat: "\<And>ptr sz. kheap s ptr = Some (ArchObj (DataPage True sz))
+                \<Longrightarrow> obj_range ptr (ArchObj $ DataPage True sz) \<subseteq> device_region s"
+  using inv
+  apply (simp_all add: pspace_respects_device_region_def)
+  apply (rule subsetI)
+   apply (drule obj_range_respect_device_range[OF _ inv(1)])
+   apply (clarsimp split: if_splits)
+   apply (drule(1) subsetD[rotated])
+   apply (drule(1) subsetD[rotated])
+   apply (simp add: dom_def)
+  apply (rule subsetI)
+  apply (drule obj_range_respect_device_range[OF _ inv(1)])
+  apply (clarsimp split: if_splits)
+  apply (drule(1) subsetD[rotated])
+  apply (drule(1) subsetD[rotated])
+   apply (simp add: dom_def)
+  done
+
+
+lemma default_obj_dev:
+  "\<lbrakk>ty \<noteq> Untyped;default_object ty dev us = ArchObj (DataPage dev' sz)\<rbrakk> \<Longrightarrow> dev = dev'"
+  by (clarsimp simp: default_object_def default_arch_object_def
+              split: apiobject_type.split_asm aobject_type.split_asm)
+
+end
+
+
+lemma cap_range_respects_device_region_cong[cong]:
+  "device_state (machine_state s) = device_state (machine_state s')
+  \<Longrightarrow> cap_range_respects_device_region cap s = cap_range_respects_device_region cap s'"
+  by (clarsimp simp: cap_range_respects_device_region_def)
+
+
+context begin interpretation Arch .
+requalify_consts region_in_kernel_window
+end
+
+
+context retype_region_proofs_arch begin
+
+lemmas unique_table_caps_eq
+    = arg_cong[where f=unique_table_caps_2, OF null_filter,
+               simplified unique_table_caps_null]
+
+lemmas unique_table_refs_eq
+    = arg_cong[where f=unique_table_refs_2, OF null_filter,
+               simplified unique_table_refs_null]
+
+lemma valid_table_caps:
+  "valid_table_caps s \<Longrightarrow> valid_table_caps s'"
+  unfolding valid_table_caps_def
+  by (fastforce dest: caps_retype[rotated] intro: pts_of)
+
+lemma caps_of_state':
+  "caps_of_state s p = Some cap \<Longrightarrow> caps_of_state s' p = Some cap"
+  by (fastforce simp: F cte_wp_at_cases s'_def ps_def orthr)
+
+lemma valid_vs_lookup:
+  "valid_vs_lookup s \<Longrightarrow> valid_vs_lookup s'"
+  unfolding valid_vs_lookup_def
+  apply clarsimp
+  apply (drule vs_lookup_target_level)
+  by (fastforce simp: vs_lookup_target' intro: caps_of_state')
+
+lemma valid_asid_pool_caps:
+  "valid_asid_pool_caps s \<Longrightarrow> valid_asid_pool_caps s'"
+  by (fastforce intro: caps_of_state' simp: valid_asid_pool_caps_def)
+
+lemma valid_arch_caps:
+  "valid_arch_caps s \<Longrightarrow> valid_arch_caps s'"
+  by (clarsimp simp add: valid_arch_caps_def null_filter valid_table_caps valid_vs_lookup
+                         vs_lookup_target' unique_table_caps_eq unique_table_refs_eq
+                         valid_asid_pool_caps
+               simp del: arch_state)
+
+lemma valid_kernel_mappings:
+  "valid_kernel_mappings s \<Longrightarrow> valid_kernel_mappings s'"
+  by (simp add: valid_kernel_mappings_def s'_def ball_ran_eq ps_def)
+
+lemma valid_asid_map:
+  "valid_asid_map s \<Longrightarrow> valid_asid_map s'"
+  by (clarsimp simp: valid_asid_map_def)
+
+lemma vspace_for_asid:
+  "vspace_for_asid asid s' = Some pt \<Longrightarrow> vspace_for_asid asid s = Some pt"
+  by (clarsimp simp: vspace_for_asid_def in_omonad pool_for_asid_def)
+
+lemma has_kernel_mappings:
+  "\<lbrakk> has_kernel_mappings pt s; valid_global_arch_objs s; valid_global_refs s \<rbrakk> \<Longrightarrow> has_kernel_mappings pt s'"
+  unfolding has_kernel_mappings_def
+  apply clarsimp
+  apply (drule pts_of')
+  apply (erule disjE; clarsimp)
+  apply (drule riscv_global_pt_in_global_refs)
+  apply (drule (1) global_no_retype)
+  apply simp
+  done
+
+lemma equal_kernel_mappings:
+  "\<lbrakk> equal_kernel_mappings s; valid_vspace_objs s; valid_asid_table s; valid_global_arch_objs s;
+     valid_global_refs s \<rbrakk> \<Longrightarrow> equal_kernel_mappings s'"
+  apply (simp add: equal_kernel_mappings_def)
+  apply clarsimp
+  apply (drule vspace_for_asid)
+  apply (rule has_kernel_mappings; assumption?)
+  apply (frule (2) vspace_for_asid_valid_pt)
+  apply clarsimp
+  apply (elim allE, erule (1) impE)+
+  apply (drule pts_of)
+  apply simp
+  done
+
+lemma pspace_in_kernel_window:
+  "\<lbrakk> pspace_in_kernel_window (s :: 'state_ext state);
+     region_in_kernel_window {ptr .. (ptr &&~~ mask sz) + 2 ^ sz - 1} s \<rbrakk>
+          \<Longrightarrow> pspace_in_kernel_window s'"
+  apply (simp add: pspace_in_kernel_window_def s'_def ps_def)
+  apply (clarsimp simp: region_in_kernel_window_def
+                   del: ballI)
+  apply (drule retype_addrs_mem_subset_ptr_bits[OF cover tyunt])
+  apply (fastforce simp: field_simps obj_bits_dev_irr tyunt)
+  done
+
+lemma pspace_respects_device_region:
+  assumes psp_resp_dev: "pspace_respects_device_region s"
+      and cap_refs_resp_dev: "cap_refs_respects_device_region s"
+  shows "pspace_respects_device_region s'"
+  proof -
+    note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff
+          atLeastatMost_subset_iff atLeastLessThan_iff
+          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
+  show ?thesis
+  apply (cut_tac vp)
+  apply (rule pspace_respects_device_regionI)
+     apply (clarsimp simp add: pspace_respects_device_region_def s'_def ps_def
+                        split: if_split_asm )
+      apply (drule retype_addrs_obj_range_subset[OF _ _ tyunt])
+       using cover tyunt
+       apply (simp add: obj_bits_api_def3 split: if_splits)
+      apply (frule default_obj_dev[OF tyunt],simp)
+      apply (drule(1) subsetD)
+      apply (rule exE[OF dev])
+      apply (drule cap_refs_respects_device_region_cap_range[OF _ cap_refs_resp_dev])
+      apply (fastforce split: if_splits)
+     apply (drule pspace_respects_device_regionD[OF _ _ psp_resp_dev, rotated -1])
+       apply fastforce
+      apply fastforce
+     apply fastforce
+    apply (clarsimp simp add: pspace_respects_device_region_def s'_def ps_def
+                       split: if_split_asm )
+     apply (drule retype_addrs_obj_range_subset[OF _ _ tyunt])
+      using cover tyunt
+      apply (simp add: obj_bits_api_def4 split: if_splits)
+     apply (frule default_obj_dev[OF tyunt],simp)
+      apply (drule(1) subsetD)
+      apply (rule exE[OF dev])
+      apply (drule cap_refs_respects_device_region_cap_range[OF _ cap_refs_resp_dev])
+      apply (fastforce split: if_splits)
+     apply (drule pspace_respects_device_regionD[OF _ _ psp_resp_dev, rotated -1])
+       apply fastforce
+      apply fastforce
+     apply fastforce
+  using valid_pspace
+  apply fastforce+
+  done
+qed
+
+
+
+lemma cap_refs_respects_device_region:
+  assumes psp_resp_dev: "pspace_respects_device_region s"
+      and cap_refs_resp_dev: "cap_refs_respects_device_region s"
+  shows "cap_refs_respects_device_region s'"
+  using cap_refs_resp_dev
+  apply (clarsimp simp: cap_refs_respects_device_region_def
+              simp del: split_paired_All split_paired_Ex)
+  apply (drule_tac x = "(a,b)" in spec)
+  apply (erule notE)
+  apply (subst(asm) cte_retype)
+   apply (simp add: cap_range_respects_device_region_def cap_range_def)
+  apply (clarsimp simp: cte_wp_at_caps_of_state s'_def dom_def)
+  done
+
+
+lemma vms:
+  "valid_machine_state s \<Longrightarrow> valid_machine_state s'"
+  apply (simp add: s'_def ps_def valid_machine_state_def in_user_frame_def)
+  apply (rule allI, erule_tac x=p in allE, clarsimp)
+  apply (rule_tac x=sz in exI, clarsimp simp: obj_at_def orthr)
+  done
+
+end
+
+
+context retype_region_proofs begin
+
+interpretation retype_region_proofs_arch ..
+
+lemma post_retype_invs:
+  "\<lbrakk> invs s; region_in_kernel_window {ptr .. (ptr && ~~ mask sz) + 2 ^ sz - 1} s \<rbrakk>
+        \<Longrightarrow> post_retype_invs ty (retype_addrs ptr ty n us) s'"
+  using equal_kernel_mappings valid_global_vspace_mappings
+  apply (clarsimp simp: invs_def post_retype_invs_def valid_state_def
+                     unsafe_rep2 null_filter valid_idle
+                     valid_reply_caps valid_reply_masters
+                     valid_global_refs valid_arch_state
+                     valid_irq_node_def obj_at_pres
+                     valid_arch_caps valid_global_objs_def
+                     valid_vspace_objs' valid_irq_handlers
+                     valid_mdb_rep2 mdb_and_revokable
+                     valid_pspace cur_tcb only_idle
+                     valid_kernel_mappings valid_asid_map
+                     valid_ioc vms
+                     pspace_in_kernel_window
+                     pspace_respects_device_region
+                     cap_refs_respects_device_region
+                     cap_refs_in_kernel_window valid_irq_states
+               split: if_split_asm)
+  apply (simp add: valid_arch_state_def valid_pspace_def)
+  done
+
+(* ML \<open>val pre_ctxt_1 = @{context}\<close> *)
+
+sublocale retype_region_proofs_invs?: retype_region_proofs_invs
+  where region_in_kernel_window = region_in_kernel_window
+    and post_retype_invs_check = post_retype_invs_check
+    and post_retype_invs = post_retype_invs
+  using post_retype_invs valid_cap valid_global_refs valid_arch_state valid_vspace_objs'
+  by unfold_locales (auto simp: s'_def ps_def)
+
+(* local_setup \<open>note_new_facts pre_ctxt_1\<close> *)
+
+lemmas post_retype_invs_axioms = retype_region_proofs_invs_axioms
+
+end
+
+
+context Arch begin global_naming RISCV64
+
+named_theorems Retype_AI_assms'
+
+lemma invs_post_retype_invs [Retype_AI_assms']:
+  "invs s \<Longrightarrow> post_retype_invs ty refs s"
+  by (clarsimp simp: post_retype_invs_def)
+
+lemmas equal_kernel_mappings_trans_state
+  = more_update.equal_kernel_mappings_update
+
+lemmas retype_region_proofs_assms [Retype_AI_assms']
+  = retype_region_proofs.post_retype_invs_axioms
+
+end
+
+
+global_interpretation Retype_AI?: Retype_AI
+  where no_gs_types = RISCV64.no_gs_types
+    and post_retype_invs_check = post_retype_invs_check
+    and post_retype_invs = post_retype_invs
+    and region_in_kernel_window = region_in_kernel_window
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+  by (intro_locales; (unfold_locales; fact Retype_AI_assms)?)
+     (simp add: Retype_AI_axioms_def Retype_AI_assms')
+  qed
+
+
+context Arch begin global_naming RISCV64
+
+lemma retype_region_plain_invs:
+  "\<lbrace>invs and caps_no_overlap ptr sz and pspace_no_overlap_range_cover ptr sz
+      and caps_overlap_reserved {ptr..ptr + of_nat n * 2 ^ obj_bits_api ty us - 1}
+      and region_in_kernel_window {ptr .. (ptr &&~~ mask sz) + 2 ^ sz - 1}
+      and (\<lambda>s. \<exists>slot. cte_wp_at (\<lambda>c.  {ptr..(ptr && ~~ mask sz) + (2 ^ sz - 1)} \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s)
+      and K (ty = Structures_A.CapTableObject \<longrightarrow> 0 < us)
+      and K (range_cover ptr sz (obj_bits_api ty us) n)\<rbrace>
+      retype_region ptr n us ty dev \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (rule hoare_strengthen_post[OF retype_region_post_retype_invs])
+  apply (simp add: post_retype_invs_def)
+  done
+
+
+lemma storeWord_um_eq_0:
+  "storeWord x 0 \<lbrace>\<lambda>m. underlying_memory m p = 0\<rbrace>"
+  by (wpsimp simp: storeWord_def word_rsplit_0 upto_rec1 word_bits_def)
+
+lemma clearMemory_um_eq_0:
+  "\<lbrace>\<lambda>m. underlying_memory m p = 0\<rbrace>
+    clearMemory ptr bits
+   \<lbrace>\<lambda>_ m. underlying_memory m p = 0\<rbrace>"
+  apply (clarsimp simp: clearMemory_def)
+  including no_pre apply (wpsimp wp: mapM_x_wp_inv)
+  apply (rule hoare_pre)
+   apply (wp hoare_drop_imps storeWord_um_eq_0)
+  apply (fastforce simp: ignore_failure_def split: if_split_asm)
+  done
+
+lemma invs_irq_state_independent:
+  "invs (s\<lparr>machine_state := machine_state s\<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>)
+   = invs s"
+  by (clarsimp simp: irq_state_independent_A_def invs_def
+                     valid_state_def valid_pspace_def valid_mdb_def valid_ioc_def valid_idle_def
+                     only_idle_def if_unsafe_then_cap_def valid_reply_caps_def
+                     valid_reply_masters_def valid_global_refs_def valid_arch_state_def
+                     valid_irq_node_def valid_irq_handlers_def valid_machine_state_def
+                     valid_vspace_objs_def valid_arch_caps_def
+                     valid_kernel_mappings_def equal_kernel_mappings_def
+                     valid_asid_map_def vspace_at_asid_def
+                     pspace_in_kernel_window_def cap_refs_in_kernel_window_def
+                     cur_tcb_def sym_refs_def state_refs_of_def state_hyp_refs_of_def
+                     swp_def valid_irq_states_def
+              split: option.split)
+
+crunch irq_masks_inv[wp]: storeWord, clearMemory "\<lambda>s. P (irq_masks s)"
+  (wp: crunch_wps ignore_del: storeWord clearMemory)
+
+crunch underlying_mem_0[wp]: clearMemory "\<lambda>s. underlying_memory s p = 0"
+  (wp: crunch_wps storeWord_um_eq_0 ignore_del: clearMemory)
+
+lemma clearMemory_invs:
+  "\<lbrace>invs\<rbrace> do_machine_op (clearMemory w sz) \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (wp dmo_invs1)
+  apply clarsimp
+  apply (intro conjI impI allI)
+   apply (clarsimp simp: invs_def valid_state_def)
+   apply (erule_tac p=p in valid_machine_stateE)
+   apply (clarsimp simp: use_valid[OF _ clearMemory_underlying_mem_0])
+  apply (clarsimp simp: use_valid[OF _ clearMemory_irq_masks_inv[where P="(=) v" for v], OF _ refl])
+  done
+
+lemma caps_region_kernel_window_imp:
+  "caps_of_state s p = Some cap
+    \<Longrightarrow> cap_refs_in_kernel_window s
+    \<Longrightarrow> S \<subseteq> cap_range cap
+    \<Longrightarrow> region_in_kernel_window S s"
+  apply (simp add: region_in_kernel_window_def)
+  apply (drule(1) cap_refs_in_kernel_windowD)
+  apply blast
+  done
+
+crunch irq_node[wp]: init_arch_objects "\<lambda>s. P (interrupt_irq_node s)"
+  (wp: crunch_wps)
+
+lemma init_arch_objects_excap:
+  "\<lbrace>ex_cte_cap_wp_to P p\<rbrace>
+      init_arch_objects tp ptr bits us refs
+   \<lbrace>\<lambda>rv s. ex_cte_cap_wp_to P p s\<rbrace>"
+  by (wp ex_cte_cap_to_pres)
+
+crunch pred_tcb_at[wp]: init_arch_objects "pred_tcb_at proj P t"
+  (wp: crunch_wps)
+
+lemma valid_arch_mdb_detype:
+  "valid_arch_mdb (is_original_cap s) (caps_of_state s) \<Longrightarrow>
+            valid_arch_mdb (is_original_cap (detype (untyped_range cap) s))
+         (\<lambda>p. if fst p \<in> untyped_range cap then None else caps_of_state s p)"
+  by (auto simp: valid_arch_mdb_def)
+
+lemmas init_arch_objects_wps
+    = init_arch_objects_cte_wp_at
+      init_arch_objects_valid_cap
+      init_arch_objects_cap_table
+      init_arch_objects_excap
+      init_arch_objects_pred_tcb_at
+
+end
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
@@ -472,8 +472,15 @@ lemma hyp_refs_eq:
   "state_hyp_refs_of s' = state_hyp_refs_of s"
   unfolding s'_def ps_def
   sorry (* FIXME AARCH64 VCPU
-  by (rule ext) (clarsimp simp: state_hyp_refs_of_def split: option.splits) *)
-
+  apply (rule ext)
+  apply (clarsimp simp: state_hyp_refs_of_def orthr split: option.splits)
+  apply (cases ty; simp add: tyunt default_object_def default_tcb_def hyp_refs_of_def tcb_hyp_refs_def
+                             default_arch_tcb_def)
+  apply (rename_tac ao)
+  apply (clarsimp simp: refs_of_a_def ARM_HYP.vcpu_tcb_refs_def default_arch_object_def
+                        ARM_A.default_vcpu_def
+                  split: aobject_type.splits)
+  done *)
 
 lemma obj_at_valid_pte:
   "\<lbrakk>valid_pte level pte s; \<And>P p. obj_at P p s \<Longrightarrow> obj_at P p s'\<rbrakk>

--- a/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
@@ -1,0 +1,120 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchSchedule_AI
+imports Schedule_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems Schedule_AI_asms
+
+lemma dmo_mapM_storeWord_0_invs[wp,Schedule_AI_asms]:
+  "do_machine_op (mapM (\<lambda>p. storeWord p 0) S) \<lbrace>invs\<rbrace>"
+  apply (simp add: dom_mapM ef_storeWord)
+  apply (rule mapM_UNIV_wp)
+  apply (simp add: do_machine_op_def split_def)
+  apply wp
+  apply (clarsimp simp: invs_def valid_state_def cur_tcb_def
+                        valid_machine_state_def)
+  apply (rule conjI)
+   apply(erule use_valid[OF _ storeWord_valid_irq_states], simp)
+  apply (erule use_valid)
+   apply (simp add: storeWord_def word_rsplit_0)
+   apply wp
+  by (simp add: upto.simps word_bits_def)
+
+global_naming Arch
+
+lemma arch_stt_invs [wp,Schedule_AI_asms]:
+  "\<lbrace>invs\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (simp add: arch_switch_to_thread_def)
+  apply wp
+  done
+
+lemma arch_stt_tcb [wp,Schedule_AI_asms]:
+  "\<lbrace>tcb_at t'\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. tcb_at t'\<rbrace>"
+  apply (simp add: arch_switch_to_thread_def)
+  apply (wp)
+  done
+
+lemma arch_stt_runnable[Schedule_AI_asms]:
+  "\<lbrace>st_tcb_at runnable t\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>r . st_tcb_at runnable t\<rbrace>"
+  apply (simp add: arch_switch_to_thread_def)
+  apply wp
+  done
+
+lemma idle_strg:
+  "thread = idle_thread s \<and> invs s \<Longrightarrow> invs (s\<lparr>cur_thread := thread\<rparr>)"
+  by (clarsimp simp: invs_def valid_state_def valid_idle_def cur_tcb_def
+                     pred_tcb_at_def valid_machine_state_def obj_at_def is_tcb_def)
+
+lemma arch_stit_invs[wp, Schedule_AI_asms]:
+  "\<lbrace>invs\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>r. invs\<rbrace>"
+  by (wpsimp simp: arch_switch_to_idle_thread_def)
+
+lemma arch_stit_tcb_at[wp]:
+  "\<lbrace>tcb_at t\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>r. tcb_at t\<rbrace>"
+  apply (simp add: arch_switch_to_idle_thread_def )
+  apply (wp tcb_at_typ_at)
+  done
+
+crunches set_vm_root
+  for ct[wp]: "\<lambda>s. P (cur_thread s)"
+  and it[wp]: "\<lambda>s. P (idle_thread s)"
+  (simp: crunch_simps wp: hoare_drop_imps)
+
+lemma arch_stit_activatable[wp, Schedule_AI_asms]:
+  "\<lbrace>ct_in_state activatable\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>rv . ct_in_state activatable\<rbrace>"
+  apply (clarsimp simp: arch_switch_to_idle_thread_def)
+  apply (wpsimp simp: ct_in_state_def wp: ct_in_state_thread_state_lift)
+  done
+
+lemma stit_invs [wp,Schedule_AI_asms]:
+  "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def)
+  apply (wpsimp|strengthen idle_strg)+
+  done
+
+lemma stit_activatable[Schedule_AI_asms]:
+  "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv . ct_in_state activatable\<rbrace>"
+  apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def)
+  apply (wp | simp add: ct_in_state_def)+
+  apply (clarsimp simp: invs_def valid_state_def cur_tcb_def valid_idle_def
+                 elim!: pred_tcb_weaken_strongerE)
+  done
+
+lemma stt_invs [wp,Schedule_AI_asms]:
+  "\<lbrace>invs\<rbrace> switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (simp add: switch_to_thread_def)
+  apply wp
+     apply (simp add: trans_state_update[symmetric] del: trans_state_update)
+    apply (rule_tac Q="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
+    apply (clarsimp simp: invs_def valid_state_def valid_idle_def
+                          valid_irq_node_def valid_machine_state_def)
+    apply (fastforce simp: cur_tcb_def obj_at_def
+                     elim: valid_pspace_eqI ifunsafe_pspaceI)
+   apply wp+
+  apply clarsimp
+  apply (simp add: is_tcb_def)
+  done
+end
+
+interpretation Schedule_AI_U?: Schedule_AI_U
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+  by (intro_locales; (unfold_locales; fact Schedule_AI_asms)?)
+  qed
+
+interpretation Schedule_AI?: Schedule_AI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+  by (intro_locales; (unfold_locales; fact Schedule_AI_asms)?)
+  qed
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -8,7 +9,7 @@ theory ArchSchedule_AI
 imports Schedule_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems Schedule_AI_asms
 
@@ -33,19 +34,22 @@ lemma arch_stt_invs [wp,Schedule_AI_asms]:
   "\<lbrace>invs\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: arch_switch_to_thread_def)
   apply wp
-  done
+  sorry (* FIXME AARCH64 VCPU
+  done *)
 
 lemma arch_stt_tcb [wp,Schedule_AI_asms]:
   "\<lbrace>tcb_at t'\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. tcb_at t'\<rbrace>"
   apply (simp add: arch_switch_to_thread_def)
   apply (wp)
-  done
+  sorry (* FIXME AARCH64 VCPU
+  done *)
 
 lemma arch_stt_runnable[Schedule_AI_asms]:
   "\<lbrace>st_tcb_at runnable t\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>r . st_tcb_at runnable t\<rbrace>"
   apply (simp add: arch_switch_to_thread_def)
   apply wp
-  done
+  sorry (* FIXME AARCH64 VCPU
+  done *)
 
 lemma idle_strg:
   "thread = idle_thread s \<and> invs s \<Longrightarrow> invs (s\<lparr>cur_thread := thread\<rparr>)"
@@ -54,13 +58,15 @@ lemma idle_strg:
 
 lemma arch_stit_invs[wp, Schedule_AI_asms]:
   "\<lbrace>invs\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>r. invs\<rbrace>"
-  by (wpsimp simp: arch_switch_to_idle_thread_def)
+  sorry (* FIXME AARCH64 VSpace & VCPU
+  by (wpsimp simp: arch_switch_to_idle_thread_def) *)
 
 lemma arch_stit_tcb_at[wp]:
   "\<lbrace>tcb_at t\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>r. tcb_at t\<rbrace>"
   apply (simp add: arch_switch_to_idle_thread_def )
   apply (wp tcb_at_typ_at)
-  done
+  sorry (* FIXME AARCH64 VSpace & VCPU
+  done *)
 
 crunches set_vm_root
   for ct[wp]: "\<lambda>s. P (cur_thread s)"
@@ -71,21 +77,24 @@ lemma arch_stit_activatable[wp, Schedule_AI_asms]:
   "\<lbrace>ct_in_state activatable\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>rv . ct_in_state activatable\<rbrace>"
   apply (clarsimp simp: arch_switch_to_idle_thread_def)
   apply (wpsimp simp: ct_in_state_def wp: ct_in_state_thread_state_lift)
-  done
+  sorry (* FIXME AARCH64 VCPU
+  done *)
 
 lemma stit_invs [wp,Schedule_AI_asms]:
   "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv. invs\<rbrace>"
   apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def)
   apply (wpsimp|strengthen idle_strg)+
-  done
+  sorry (* FIXME AARCH64 VSpace & VCPU
+  done *)
 
 lemma stit_activatable[Schedule_AI_asms]:
   "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv . ct_in_state activatable\<rbrace>"
   apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def)
   apply (wp | simp add: ct_in_state_def)+
+  sorry (* FIXME AARCH64 VCPU
   apply (clarsimp simp: invs_def valid_state_def cur_tcb_def valid_idle_def
                  elim!: pred_tcb_weaken_strongerE)
-  done
+  done *)
 
 lemma stt_invs [wp,Schedule_AI_asms]:
   "\<lbrace>invs\<rbrace> switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"

--- a/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
@@ -15,7 +15,7 @@ named_theorems Schedule_AI_asms
 
 lemma dmo_mapM_storeWord_0_invs[wp,Schedule_AI_asms]:
   "do_machine_op (mapM (\<lambda>p. storeWord p 0) S) \<lbrace>invs\<rbrace>"
-  apply (simp add: dom_mapM ef_storeWord)
+  apply (simp add: dom_mapM)
   apply (rule mapM_UNIV_wp)
   apply (simp add: do_machine_op_def split_def)
   apply wp

--- a/proof/invariant-abstract/AARCH64/ArchSyscall_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSyscall_AI.thy
@@ -1,0 +1,95 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(*
+Refinement for handleEvent and syscalls
+*)
+
+theory ArchSyscall_AI
+imports
+  Syscall_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems Syscall_AI_assms
+
+declare arch_get_sanitise_register_info_invs[Syscall_AI_assms]
+crunch pred_tcb_at[wp,Syscall_AI_assms]: handle_arch_fault_reply, arch_get_sanitise_register_info "pred_tcb_at proj P t"
+crunch invs[wp,Syscall_AI_assms]: handle_arch_fault_reply "invs"
+crunch cap_to[wp,Syscall_AI_assms]: handle_arch_fault_reply, arch_get_sanitise_register_info "ex_nonz_cap_to c"
+crunch it[wp,Syscall_AI_assms]: handle_arch_fault_reply, arch_get_sanitise_register_info "\<lambda>s. P (idle_thread s)"
+crunch caps[wp,Syscall_AI_assms]: handle_arch_fault_reply, arch_get_sanitise_register_info "\<lambda>s. P (caps_of_state s)"
+crunch cur_thread[wp,Syscall_AI_assms]: handle_arch_fault_reply, make_fault_msg, arch_get_sanitise_register_info "\<lambda>s. P (cur_thread s)"
+crunch valid_objs[wp,Syscall_AI_assms]: handle_arch_fault_reply, arch_get_sanitise_register_info "valid_objs"
+crunch cte_wp_at[wp,Syscall_AI_assms]: handle_arch_fault_reply, arch_get_sanitise_register_info "\<lambda>s. P (cte_wp_at P' p s)"
+
+crunch typ_at[wp, Syscall_AI_assms]: invoke_irq_control "\<lambda>s. P (typ_at T p s)"
+
+lemma obj_refs_cap_rights_update[simp, Syscall_AI_assms]:
+  "obj_refs (cap_rights_update rs cap) = obj_refs cap"
+  by (simp add: cap_rights_update_def acap_rights_update_def
+         split: cap.split arch_cap.split)
+
+(* FIXME: move to TCB *)
+lemma table_cap_ref_mask_cap [Syscall_AI_assms]:
+  "table_cap_ref (mask_cap R cap) = table_cap_ref cap"
+  by (clarsimp simp add:mask_cap_def table_cap_ref_def acap_rights_update_def
+    cap_rights_update_def split:cap.splits arch_cap.splits)
+
+lemma eq_no_cap_to_obj_with_diff_ref [Syscall_AI_assms]:
+  "\<lbrakk> cte_wp_at ((=) cap) p s; valid_arch_caps s \<rbrakk>
+      \<Longrightarrow> no_cap_to_obj_with_diff_ref cap S s"
+  apply (clarsimp simp: cte_wp_at_caps_of_state valid_arch_caps_def)
+  apply (frule(1) unique_table_refs_no_cap_asidD)
+  apply (clarsimp simp add: no_cap_to_obj_with_diff_ref_def
+                            table_cap_ref_mask_cap Ball_def)
+  done
+
+lemma hv_invs[wp, Syscall_AI_assms]: "\<lbrace>invs\<rbrace> handle_vm_fault t' flt \<lbrace>\<lambda>r. invs\<rbrace>"
+  unfolding handle_vm_fault_def by (cases flt; wpsimp)
+
+crunch inv[wp]: getRegister, read_stval "P"
+  (ignore_del: getRegister)
+
+lemma hv_inv_ex [Syscall_AI_assms]:
+  "\<lbrace>P\<rbrace> handle_vm_fault t vp \<lbrace>\<lambda>_ _. True\<rbrace>, \<lbrace>\<lambda>_. P\<rbrace>"
+  unfolding handle_vm_fault_def
+  by (cases vp; wpsimp wp: dmo_inv getRestartPC_inv det_getRestartPC as_user_inv)
+
+lemma handle_vm_fault_valid_fault[wp, Syscall_AI_assms]:
+  "\<lbrace>\<top>\<rbrace> handle_vm_fault thread ft -,\<lbrace>\<lambda>rv s. valid_fault rv\<rbrace>"
+  unfolding handle_vm_fault_def
+  apply (cases ft, simp_all)
+   apply (wp | simp add: valid_fault_def)+
+  done
+
+
+lemma hvmf_active [Syscall_AI_assms]:
+  "\<lbrace>st_tcb_at active t\<rbrace> handle_vm_fault t w \<lbrace>\<lambda>rv. st_tcb_at active t\<rbrace>"
+  unfolding handle_vm_fault_def by (cases w; wpsimp)
+
+lemma hvmf_ex_cap[wp, Syscall_AI_assms]:
+  "\<lbrace>ex_nonz_cap_to p\<rbrace> handle_vm_fault t b \<lbrace>\<lambda>rv. ex_nonz_cap_to p\<rbrace>"
+  unfolding handle_vm_fault_def by (cases b; wpsimp)
+
+declare arch_get_sanitise_register_info_ex_nonz_cap_to[Syscall_AI_assms]
+
+lemma hh_invs[wp, Syscall_AI_assms]:
+  "\<lbrace>invs and ct_active and st_tcb_at active thread and ex_nonz_cap_to_thread\<rbrace>
+     handle_hypervisor_fault thread fault
+   \<lbrace>\<lambda>rv. invs\<rbrace>"
+  by (cases fault) wpsimp
+
+end
+
+global_interpretation Syscall_AI?: Syscall_AI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact Syscall_AI_assms)?)
+  qed
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchSyscall_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSyscall_AI.thy
@@ -13,7 +13,7 @@ imports
   Syscall_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems Syscall_AI_assms
 
@@ -52,13 +52,14 @@ lemma eq_no_cap_to_obj_with_diff_ref [Syscall_AI_assms]:
 lemma hv_invs[wp, Syscall_AI_assms]: "\<lbrace>invs\<rbrace> handle_vm_fault t' flt \<lbrace>\<lambda>r. invs\<rbrace>"
   unfolding handle_vm_fault_def by (cases flt; wpsimp)
 
-crunch inv[wp]: getRegister, read_stval "P"
+crunch inv[wp]: getRegister "P"
   (ignore_del: getRegister)
 
 lemma hv_inv_ex [Syscall_AI_assms]:
   "\<lbrace>P\<rbrace> handle_vm_fault t vp \<lbrace>\<lambda>_ _. True\<rbrace>, \<lbrace>\<lambda>_. P\<rbrace>"
   unfolding handle_vm_fault_def
-  by (cases vp; wpsimp wp: dmo_inv getRestartPC_inv det_getRestartPC as_user_inv)
+  sorry (* FIXME AARCH64 addressTranslateS1
+  by (cases vp; wpsimp wp: dmo_inv getRestartPC_inv det_getRestartPC as_user_inv) *)
 
 lemma handle_vm_fault_valid_fault[wp, Syscall_AI_assms]:
   "\<lbrace>\<top>\<rbrace> handle_vm_fault thread ft -,\<lbrace>\<lambda>rv s. valid_fault rv\<rbrace>"
@@ -82,7 +83,8 @@ lemma hh_invs[wp, Syscall_AI_assms]:
   "\<lbrace>invs and ct_active and st_tcb_at active thread and ex_nonz_cap_to_thread\<rbrace>
      handle_hypervisor_fault thread fault
    \<lbrace>\<lambda>rv. invs\<rbrace>"
-  by (cases fault) wpsimp
+  sorry (* FIXME AARCH64 ARMVCPUFault
+  by (cases fault) wpsimp *)
 
 end
 

--- a/proof/invariant-abstract/AARCH64/ArchSyscall_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSyscall_AI.thy
@@ -49,11 +49,23 @@ lemma eq_no_cap_to_obj_with_diff_ref [Syscall_AI_assms]:
                             table_cap_ref_mask_cap Ball_def)
   done
 
+crunches getDFSR, getFAR,getIFSR
+  for inv[wp]: "P"
+
+lemma do_machine_op_getDFSR_inv[wp]:
+  "do_machine_op getDFSR \<lbrace>P\<rbrace>"
+  by (rule dmo_inv) wp
+
+lemma do_machine_op_getFAR_inv[wp]:
+  "do_machine_op getFAR \<lbrace>P\<rbrace>"
+  by (rule dmo_inv) wp
+
+lemma do_machine_op_getIFSR_inv[wp]:
+  "do_machine_op getIFSR \<lbrace>P\<rbrace>"
+  by (rule dmo_inv) wp
+
 lemma hv_invs[wp, Syscall_AI_assms]: "\<lbrace>invs\<rbrace> handle_vm_fault t' flt \<lbrace>\<lambda>r. invs\<rbrace>"
   unfolding handle_vm_fault_def by (cases flt; wpsimp)
-
-crunch inv[wp]: getRegister "P"
-  (ignore_del: getRegister)
 
 lemma hv_inv_ex [Syscall_AI_assms]:
   "\<lbrace>P\<rbrace> handle_vm_fault t vp \<lbrace>\<lambda>_ _. True\<rbrace>, \<lbrace>\<lambda>_. P\<rbrace>"

--- a/proof/invariant-abstract/AARCH64/ArchTcbAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcbAcc_AI.thy
@@ -1,0 +1,173 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchTcbAcc_AI
+imports TcbAcc_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems TcbAcc_AI_assms
+
+lemmas cap_master_cap_simps =
+  cap_master_cap_def[simplified cap_master_arch_cap_def, split_simps cap.split arch_cap.split]
+
+lemma cap_master_cap_arch_eqDs:
+  "cap_master_cap cap = ArchObjectCap (FrameCap ref rghts sz dev mapdata)
+     \<Longrightarrow> rghts = UNIV \<and> mapdata = None
+          \<and> (\<exists>rghts mapdata. cap = cap.ArchObjectCap (FrameCap ref rghts sz dev mapdata))"
+  "cap_master_cap cap = ArchObjectCap ASIDControlCap
+     \<Longrightarrow> cap = ArchObjectCap ASIDControlCap"
+  "cap_master_cap cap = ArchObjectCap (ASIDPoolCap pool asid)
+     \<Longrightarrow> asid = 0 \<and> (\<exists>asid. cap = ArchObjectCap (ASIDPoolCap pool asid))"
+  "cap_master_cap cap = ArchObjectCap (PageTableCap ptr data)
+     \<Longrightarrow> data = None \<and> (\<exists>data. cap = ArchObjectCap (PageTableCap ptr data))"
+  by (clarsimp simp: cap_master_cap_def
+              split: cap.split_asm arch_cap.split_asm)+
+
+lemmas cap_master_cap_eqDs =
+  cap_master_cap_eqDs1 cap_master_cap_arch_eqDs
+  cap_master_cap_eqDs1 [OF sym] cap_master_cap_arch_eqDs[OF sym]
+
+
+lemma vm_sets_diff[simp]:
+  "vm_read_only \<noteq> vm_read_write"
+  by (simp add: vm_read_write_def vm_read_only_def)
+
+
+lemmas vm_sets_diff2[simp] = not_sym[OF vm_sets_diff]
+
+lemma cap_master_cap_tcb_cap_valid_arch:
+  "\<lbrakk> cap_master_cap c = cap_master_cap c'; is_arch_cap c' ;
+     is_valid_vtable_root c \<Longrightarrow> is_valid_vtable_root c' ; tcb_cap_valid c p s \<rbrakk> \<Longrightarrow>
+   tcb_cap_valid c' p s"
+  (* slow: 5 to 10s *)
+  by (auto simp: cap_master_cap_def tcb_cap_valid_def tcb_cap_cases_def
+                 valid_ipc_buffer_cap_def  is_cap_simps
+           elim: pred_tcb_weakenE
+          split: option.splits cap.splits arch_cap.splits
+                 Structures_A.thread_state.splits)
+
+lemma storeWord_invs[wp, TcbAcc_AI_assms]:
+  "\<lbrace>in_user_frame p and invs\<rbrace> do_machine_op (storeWord p w) \<lbrace>\<lambda>rv. invs\<rbrace>"
+proof -
+  have aligned_offset_ignore:
+    "\<And>l sz. l<8 \<Longrightarrow> p && mask 3 = 0 \<Longrightarrow>
+       p+l && ~~ mask (pageBitsForSize sz) = p && ~~ mask (pageBitsForSize sz)"
+  proof -
+    fix l sz
+    assume al: "p && mask 3 = 0"
+    assume "(l::machine_word) < 8" hence less: "l<2^3" by simp
+    have le: "3 \<le> pageBitsForSize sz"
+      by (case_tac sz, simp_all add: pageBits_def ptTranslationBits_def)
+    show "?thesis l sz"
+      by (rule is_aligned_add_helper[simplified is_aligned_mask,
+          THEN conjunct2, THEN mask_out_first_mask_some,
+          where n=3, OF al less le])
+  qed
+
+  show ?thesis
+    apply (wp dmo_invs)
+    apply (clarsimp simp: storeWord_def invs_def valid_state_def upto0_7_def)
+    apply (fastforce simp: valid_machine_state_def in_user_frame_def
+               assert_def simpler_modify_def fail_def bind_def return_def
+               pageBits_def aligned_offset_ignore
+             split: if_split_asm)
+    done
+qed
+
+lemma valid_ipc_buffer_cap_0[simp, TcbAcc_AI_assms]:
+  "valid_ipc_buffer_cap cap a \<Longrightarrow> valid_ipc_buffer_cap cap 0"
+  by (auto simp add: valid_ipc_buffer_cap_def case_bool_If
+    split: cap.split arch_cap.split)
+
+lemma thread_set_hyp_refs_trivial [TcbAcc_AI_assms]:
+  assumes x: "\<And>tcb. tcb_state  (f tcb) = tcb_state  tcb"
+  assumes y: "\<And>tcb. tcb_arch_ref (f tcb) = tcb_arch_ref tcb"
+  shows      "\<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace> thread_set f t \<lbrace>\<lambda>rv s. P (state_hyp_refs_of s)\<rbrace>"
+  apply (simp add: thread_set_def set_object_def get_object_def)
+  apply wp
+  apply (clarsimp dest!: get_tcb_SomeD)
+  apply (clarsimp elim!: rsubst[where P=P])
+  apply (rule all_ext;
+         clarsimp simp: state_hyp_refs_of_def hyp_refs_of_def tcb_hyp_refs_def get_tcb_def x y[simplified tcb_arch_ref_def])
+  done
+
+lemma mab_pb [simp]:
+  "msg_align_bits \<le> pageBits"
+  unfolding msg_align_bits pageBits_def by simp
+
+lemma mab_wb [simp]:
+  "msg_align_bits < word_bits"
+  unfolding msg_align_bits word_bits_conv by simp
+
+
+lemma get_cap_valid_ipc [TcbAcc_AI_assms]:
+  "\<lbrace>valid_objs and obj_at (\<lambda>ko. \<exists>tcb. ko = TCB tcb \<and> tcb_ipc_buffer tcb = v) t\<rbrace>
+     get_cap (t, tcb_cnode_index 4)
+   \<lbrace>\<lambda>rv s. valid_ipc_buffer_cap rv v\<rbrace>"
+  apply (wp get_cap_wp)
+  apply clarsimp
+  apply (drule(1) cte_wp_tcb_cap_valid)
+  apply (clarsimp simp add: tcb_cap_valid_def obj_at_def)
+  apply (simp add: valid_ipc_buffer_cap_def mask_cap_def cap_rights_update_def
+                   acap_rights_update_def is_tcb
+            split: cap.split_asm arch_cap.split_asm)
+  done
+
+
+
+lemma pred_tcb_cap_wp_at [TcbAcc_AI_assms]:
+  "\<lbrakk>pred_tcb_at proj P t s; valid_objs s;
+    ref \<in> dom tcb_cap_cases;
+    \<forall>cap. (pred_tcb_at proj P t s \<and> tcb_cap_valid cap (t, ref) s) \<longrightarrow> Q cap\<rbrakk> \<Longrightarrow>
+   cte_wp_at Q (t, ref) s"
+  apply (clarsimp simp: cte_wp_at_cases tcb_at_def dest!: get_tcb_SomeD)
+  apply (rename_tac getF setF restr)
+  apply (clarsimp simp: tcb_cap_valid_def pred_tcb_at_def obj_at_def)
+  apply (erule(1) valid_objsE)
+  apply (clarsimp simp add: valid_obj_def valid_tcb_def)
+  apply (erule_tac x="(getF, setF, restr)" in ballE)
+   apply fastforce+
+  done
+
+lemma as_user_hyp_refs_of[wp, TcbAcc_AI_assms]:
+  "\<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>
+     as_user t m
+   \<lbrace>\<lambda>rv s. P (state_hyp_refs_of s)\<rbrace>"
+  apply (wp as_user_wp_thread_set_helper
+            thread_set_hyp_refs_trivial | simp)+
+  done
+
+lemmas sts_typ_ats = sts_typ_ats abs_atyp_at_lifts [OF set_thread_state_typ_at]
+
+lemma arch_tcb_context_set_eq_RISCV64[TcbAcc_AI_assms]: "arch_tcb_context_set (arch_tcb_context_get t) t = t"
+  unfolding arch_tcb_context_get_def arch_tcb_context_set_def
+  by simp
+
+lemma arch_tcb_context_get_eq_RISCV64[TcbAcc_AI_assms]: "arch_tcb_context_get (arch_tcb_context_set uc t) = uc"
+  unfolding arch_tcb_context_get_def arch_tcb_context_set_def
+  by simp
+
+lemma arch_tcb_update_aux2: "(\<lambda>tcb. tcb\<lparr> tcb_arch := f (tcb_arch tcb) \<rparr>)  = tcb_arch_update f"
+  by (rule ext, simp)
+
+lemma arch_tcb_update_aux3: "tcb\<lparr>tcb_arch := f (tcb_arch tcb)\<rparr>  = tcb_arch_update f tcb"
+  by(simp)
+
+lemma tcb_context_update_aux: "arch_tcb_context_set (P (arch_tcb_context_get atcb)) atcb
+                               = tcb_context_update (\<lambda>ctx. P ctx) atcb"
+  by (simp add: arch_tcb_context_set_def arch_tcb_context_get_def)
+
+end
+
+global_interpretation TcbAcc_AI?: TcbAcc_AI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact TcbAcc_AI_assms)?)
+  qed
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchTcbAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcbAcc_AI.thy
@@ -8,7 +8,7 @@ theory ArchTcbAcc_AI
 imports TcbAcc_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems TcbAcc_AI_assms
 
@@ -23,8 +23,8 @@ lemma cap_master_cap_arch_eqDs:
      \<Longrightarrow> cap = ArchObjectCap ASIDControlCap"
   "cap_master_cap cap = ArchObjectCap (ASIDPoolCap pool asid)
      \<Longrightarrow> asid = 0 \<and> (\<exists>asid. cap = ArchObjectCap (ASIDPoolCap pool asid))"
-  "cap_master_cap cap = ArchObjectCap (PageTableCap ptr data)
-     \<Longrightarrow> data = None \<and> (\<exists>data. cap = ArchObjectCap (PageTableCap ptr data))"
+  "cap_master_cap cap = ArchObjectCap (PageTableCap ptr pt_t data)
+     \<Longrightarrow> data = None \<and> (\<exists>data. cap = ArchObjectCap (PageTableCap ptr pt_t data))"
   by (clarsimp simp: cap_master_cap_def
               split: cap.split_asm arch_cap.split_asm)+
 
@@ -144,11 +144,11 @@ lemma as_user_hyp_refs_of[wp, TcbAcc_AI_assms]:
 
 lemmas sts_typ_ats = sts_typ_ats abs_atyp_at_lifts [OF set_thread_state_typ_at]
 
-lemma arch_tcb_context_set_eq_RISCV64[TcbAcc_AI_assms]: "arch_tcb_context_set (arch_tcb_context_get t) t = t"
+lemma arch_tcb_context_set_eq_AARCH64[TcbAcc_AI_assms]: "arch_tcb_context_set (arch_tcb_context_get t) t = t"
   unfolding arch_tcb_context_get_def arch_tcb_context_set_def
   by simp
 
-lemma arch_tcb_context_get_eq_RISCV64[TcbAcc_AI_assms]: "arch_tcb_context_get (arch_tcb_context_set uc t) = uc"
+lemma arch_tcb_context_get_eq_AARCH64[TcbAcc_AI_assms]: "arch_tcb_context_get (arch_tcb_context_set uc t) = uc"
   unfolding arch_tcb_context_get_def arch_tcb_context_set_def
   by simp
 

--- a/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
@@ -158,10 +158,10 @@ global_interpretation Tcb_AI_1?: Tcb_AI_1
   and is_cnode_or_valid_arch = is_cnode_or_valid_arch
   proof goal_cases
     interpret Arch .
-    case 1 show ?case sorry (* FIXME AARCH64 by (unfold_locales; (fact Tcb_AI_asms)?) *)
+    case 1 show ?case by (unfold_locales; (fact Tcb_AI_asms)?)
   qed
 
-context Arch begin global_naming RISVB64
+context Arch begin global_naming AARCH64
 
 lemma use_no_cap_to_obj_asid_strg: (* arch specific *)
   "(cte_at p s \<and> no_cap_to_obj_dr_emp cap s \<and> valid_cap cap s \<and> invs s)

--- a/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
@@ -1,0 +1,392 @@
+(*
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchTcb_AI
+imports Tcb_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems Tcb_AI_asms
+
+
+lemma activate_idle_invs[Tcb_AI_asms]:
+  "\<lbrace>invs and ct_idle\<rbrace>
+     arch_activate_idle_thread thread
+   \<lbrace>\<lambda>rv. invs and ct_idle\<rbrace>"
+  by (simp add: arch_activate_idle_thread_def)
+
+
+lemma empty_fail_getRegister [intro!, simp, Tcb_AI_asms]:
+  "empty_fail (getRegister r)"
+  by (simp add: getRegister_def)
+
+
+lemma same_object_also_valid:  (* arch specific *)
+  "\<lbrakk> same_object_as cap cap'; s \<turnstile> cap'; wellformed_cap cap;
+     cap_asid cap = None \<or> (\<exists>asid. cap_asid cap = Some asid \<and> 0 < asid \<and> asid \<le> 2^asid_bits - 1);
+     cap_vptr cap = None; cap_asid_base cap = None \<rbrakk>
+     \<Longrightarrow> s \<turnstile> cap"
+  apply (cases cap,
+         (clarsimp simp: same_object_as_def is_cap_simps cap_asid_def
+                         wellformed_cap_def wellformed_acap_def
+                         valid_cap_def bits_of_def cap_aligned_def
+                   split: cap.split_asm arch_cap.split_asm option.splits)+)
+  done
+
+lemma same_object_obj_refs[Tcb_AI_asms]:
+  "\<lbrakk> same_object_as cap cap' \<rbrakk>
+     \<Longrightarrow> obj_refs cap = obj_refs cap'"
+  apply (cases cap, simp_all add: same_object_as_def)
+       apply (clarsimp simp: is_cap_simps bits_of_def split: cap.split_asm)+
+  by (cases "the_arch_cap cap"; cases "the_arch_cap cap'"; simp)
+
+definition
+  is_cnode_or_valid_arch :: "cap \<Rightarrow> bool"
+where
+ "is_cnode_or_valid_arch cap \<equiv>
+    is_cnode_cap cap \<or> is_arch_cap cap \<and> (is_pt_cap cap \<longrightarrow> cap_asid cap \<noteq> None)"
+
+
+definition (* arch specific *)
+  "vspace_asid cap \<equiv> case cap of
+    ArchObjectCap (PageTableCap _ (Some (asid, _))) \<Rightarrow> Some asid
+  | _ \<Rightarrow> None"
+
+lemmas vspace_asid_simps [simp] = (* arch specific *)
+  vspace_asid_def [split_simps cap.split arch_cap.split option.split prod.split]
+
+lemma checked_insert_is_derived: (* arch specific *)
+  "\<lbrakk> same_object_as new_cap old_cap; is_cnode_or_valid_arch new_cap;
+     obj_refs new_cap = obj_refs old_cap
+         \<longrightarrow> table_cap_ref old_cap = table_cap_ref new_cap
+            \<and> vspace_asid old_cap = vspace_asid new_cap\<rbrakk>
+     \<Longrightarrow> is_derived m slot new_cap old_cap"
+  apply (cases slot)
+  apply (frule same_object_as_cap_master)
+  apply (frule master_cap_obj_refs)
+  apply (frule cap_master_eq_badge_none)
+  apply (frule same_master_cap_same_types)
+  apply (simp add: is_derived_def)
+  apply clarsimp
+  by (auto simp: is_cap_simps cap_master_cap_def
+                 is_cnode_or_valid_arch_def vs_cap_ref_def
+                 table_cap_ref_def vspace_asid_def up_ucast_inj_eq
+          split: cap.split_asm arch_cap.split_asm
+                 option.split_asm)[1]
+
+lemma is_cnode_or_valid_arch_cap_asid: (* arch specific *)
+  "is_cnode_or_valid_arch cap \<Longrightarrow> (is_pt_cap cap \<longrightarrow> cap_asid cap \<noteq> None)"
+  by (auto simp add: is_cnode_or_valid_arch_def is_cap_simps)
+
+lemma checked_insert_tcb_invs[wp]: (* arch specific *)
+  "\<lbrace>invs and cte_wp_at (\<lambda>c. c = cap.NullCap) (target, ref)
+        and K (is_cnode_or_valid_arch new_cap) and valid_cap new_cap
+        and tcb_cap_valid new_cap (target, ref)
+        and K (is_pt_cap new_cap \<longrightarrow> cap_asid new_cap \<noteq> None)
+        and (cte_wp_at (\<lambda>c. obj_refs c = obj_refs new_cap
+                              \<longrightarrow> table_cap_ref c = table_cap_ref new_cap \<and>
+                                 vspace_asid c = vspace_asid new_cap) src_slot)\<rbrace>
+     check_cap_at new_cap src_slot
+      (check_cap_at (ThreadCap target) slot
+       (cap_insert new_cap src_slot (target, ref))) \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (simp add: check_cap_at_def)
+  apply (rule hoare_pre)
+   apply (wp get_cap_wp)
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (frule caps_of_state_valid_cap[where p=src_slot], fastforce)
+  apply (frule caps_of_state_valid_cap[where p=slot], fastforce)
+  apply (rule conjI, simp only: ex_cte_cap_wp_to_def)
+   apply (rule_tac x=slot in exI)
+   apply (clarsimp simp: cte_wp_at_caps_of_state same_object_as_cte_refs)
+   apply (clarsimp simp: same_object_as_def2 cap_master_cap_simps
+                  dest!: cap_master_cap_eqDs)
+   apply (clarsimp simp: valid_cap_def[where c="cap.ThreadCap x" for x])
+   apply (erule cte_wp_atE[OF caps_of_state_cteD])
+    apply (fastforce simp: obj_at_def is_obj_defs)
+   apply clarsimp
+  apply (rule conjI)
+   apply clarsimp
+   apply (subgoal_tac "\<not> is_zombie new_cap")
+    apply (simp add: same_object_zombies same_object_obj_refs)
+    apply (erule(2) zombies_final_helperE)
+      apply fastforce
+     apply (fastforce simp add: cte_wp_at_caps_of_state)
+    apply assumption
+   apply (clarsimp simp: is_cnode_or_valid_arch_def is_cap_simps
+                         is_valid_vtable_root_def)
+  apply (rule conjI)
+   apply (erule(1) checked_insert_is_derived, simp+)
+  apply (auto simp: is_cnode_or_valid_arch_def is_cap_simps)
+  done
+
+crunch tcb_at[wp, Tcb_AI_asms]: arch_get_sanitise_register_info, arch_post_modify_registers "tcb_at a"
+crunch invs[wp, Tcb_AI_asms]: arch_get_sanitise_register_info, arch_post_modify_registers "invs"
+crunch ex_nonz_cap_to[wp, Tcb_AI_asms]: arch_get_sanitise_register_info, arch_post_modify_registers "ex_nonz_cap_to a"
+
+lemma finalise_cap_not_cte_wp_at[Tcb_AI_asms]:
+  assumes x: "P cap.NullCap"
+  shows      "\<lbrace>\<lambda>s. \<forall>cp \<in> ran (caps_of_state s). P cp\<rbrace>
+                finalise_cap cap fin
+              \<lbrace>\<lambda>rv s. \<forall>cp \<in> ran (caps_of_state s). P cp\<rbrace>"
+  apply (cases cap, simp_all)
+       apply (wp suspend_caps_of_state hoare_vcg_all_lift
+            | simp
+            | rule impI
+            | rule hoare_drop_imps)+
+     apply (clarsimp simp: ball_ran_eq x)
+    apply (wp delete_one_caps_of_state
+         | rule impI
+         | simp add: deleting_irq_handler_def get_irq_slot_def x ball_ran_eq)+
+    done
+
+
+lemma table_cap_ref_max_free_index_upd[simp,Tcb_AI_asms]:
+  "table_cap_ref (max_free_index_update cap) = table_cap_ref cap"
+  by (simp add:free_index_update_def table_cap_ref_def split:cap.splits)
+
+end
+
+global_interpretation Tcb_AI_1?: Tcb_AI_1
+  where state_ext_t = state_ext_t
+  and is_cnode_or_valid_arch = is_cnode_or_valid_arch
+  proof goal_cases
+    interpret Arch .
+    case 1 show ?case by (unfold_locales; (fact Tcb_AI_asms)?)
+  qed
+
+context Arch begin global_naming RISVB64
+
+lemma use_no_cap_to_obj_asid_strg: (* arch specific *)
+  "(cte_at p s \<and> no_cap_to_obj_dr_emp cap s \<and> valid_cap cap s \<and> invs s)
+         \<longrightarrow> cte_wp_at (\<lambda>c. obj_refs c = obj_refs cap
+                              \<longrightarrow> table_cap_ref c = table_cap_ref cap \<and>
+                                  vspace_asid c = vspace_asid cap) p s"
+  apply (clarsimp simp: cte_wp_at_caps_of_state
+                     no_cap_to_obj_with_diff_ref_def
+           simp del: split_paired_All)
+  apply (frule caps_of_state_valid_cap, fastforce)
+  apply (erule allE)+
+  apply (erule (1) impE)+
+  by (fastforce simp: table_cap_ref_def vspace_asid_def valid_cap_simps obj_at_def
+                split: cap.splits arch_cap.splits option.splits prod.splits)
+
+lemma cap_delete_no_cap_to_obj_asid[wp, Tcb_AI_asms]:
+  "\<lbrace>no_cap_to_obj_dr_emp cap\<rbrace>
+     cap_delete slot
+   \<lbrace>\<lambda>rv. no_cap_to_obj_dr_emp cap\<rbrace>"
+  apply (simp add: cap_delete_def
+                   no_cap_to_obj_with_diff_ref_ran_caps_form)
+  apply wp
+  apply simp
+  apply (rule use_spec)
+  apply (rule rec_del_all_caps_in_range)
+     apply (simp | rule obj_ref_none_no_asid)+
+  done
+
+lemma as_user_valid_cap[wp]:
+  "as_user t f \<lbrace>valid_cap cap\<rbrace>"
+  by (wp valid_cap_typ)
+
+lemma as_user_ipc_tcb_cap_valid4[wp]:
+  "as_user t f \<lbrace>tcb_cap_valid cap (t, tcb_cnode_index 4)\<rbrace>"
+  apply (simp add: as_user_def set_object_def)
+  apply (wp assert_inv | wpc | simp)+
+  apply (clarsimp simp: tcb_cap_valid_def obj_at_def
+                        pred_tcb_at_def is_tcb
+                 dest!: get_tcb_SomeD)
+  apply (clarsimp simp: get_tcb_def)
+  done
+
+lemma is_nondevice_page_cap_simp[simp]:
+  "is_nondevice_page_cap (ArchObjectCap (FrameCap p q s False t))"
+  by (subst is_nondevice_page_cap) simp
+
+lemma option_case_eq_None:
+  "((case m of None \<Rightarrow> None | Some (a,b) \<Rightarrow> Some a) = None) = (m = None)"
+  by (clarsimp split: option.splits)
+
+lemma tc_invs[Tcb_AI_asms]:
+  "\<lbrace>invs and tcb_at a
+       and (case_option \<top> (valid_cap o fst) e)
+       and (case_option \<top> (valid_cap o fst) f)
+       and (case_option \<top> (case_option \<top> (valid_cap o fst) o snd) g)
+       and (case_option \<top> (cte_at o snd) e)
+       and (case_option \<top> (cte_at o snd) f)
+       and (case_option \<top> (case_option \<top> (cte_at o snd) o snd) g)
+       and (case_option \<top> (no_cap_to_obj_dr_emp o fst) e)
+       and (case_option \<top> (no_cap_to_obj_dr_emp o fst) f)
+       and (case_option \<top> (case_option \<top> (no_cap_to_obj_dr_emp o fst) o snd) g)
+       \<comment> \<open>only set prio \<le> mcp of authorising thread\<close>
+       and (\<lambda>s. case_option True (\<lambda>(pr, auth). mcpriority_tcb_at (\<lambda>mcp. pr \<le> mcp) auth s) pr)
+       \<comment> \<open>only set mcp \<le> mcp of authorising thread\<close>
+       and (\<lambda>s. case_option True (\<lambda>(mcp, auth). mcpriority_tcb_at (\<lambda>m. mcp \<le> m) auth s) mcp)
+       and K (case_option True (is_cnode_cap o fst) e)
+       and K (case_option True (is_valid_vtable_root o fst) f)
+       and K (case_option True (\<lambda>v. case_option True
+                          ((swp valid_ipc_buffer_cap (fst v)
+                             and is_arch_cap and is_cnode_or_valid_arch)
+                                o fst) (snd v)) g)
+       and K (case_option True (\<lambda>bl. length bl = word_bits) b)\<rbrace>
+      invoke_tcb (ThreadControl a sl b mcp pr e f g)
+   \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (rule hoare_gen_asm)+
+  apply (simp add: split_def set_mcpriority_def cong: option.case_cong)
+  apply (rule hoare_vcg_precond_imp)
+   apply wp
+      apply ((simp only: simp_thms
+        | (simp add: conj_comms del: hoare_True_E_R,
+                  strengthen imp_consequent[where Q="x = None" for x], simp cong: conj_cong)
+        | rule wp_split_const_if wp_split_const_if_R
+                   hoare_vcg_all_lift_R
+                   hoare_vcg_E_elim hoare_vcg_const_imp_lift_R
+                   hoare_vcg_R_conj
+        | (wp out_invs_trivial case_option_wpE cap_delete_deletes
+             cap_delete_valid_cap cap_insert_valid_cap out_cte_at
+             cap_insert_cte_at cap_delete_cte_at out_valid_cap
+             hoare_vcg_const_imp_lift_R hoare_vcg_all_lift_R
+             thread_set_tcb_ipc_buffer_cap_cleared_invs
+             thread_set_invs_trivial[OF ball_tcb_cap_casesI]
+             hoare_vcg_all_lift thread_set_valid_cap out_emptyable
+             check_cap_inv [where P="valid_cap c" for c]
+             check_cap_inv [where P="tcb_cap_valid c p" for c p]
+             check_cap_inv[where P="cte_at p0" for p0]
+             check_cap_inv[where P="tcb_at p0" for p0]
+             thread_set_cte_at
+             thread_set_cte_wp_at_trivial[where Q="\<lambda>x. x", OF ball_tcb_cap_casesI]
+             thread_set_no_cap_to_trivial[OF ball_tcb_cap_casesI]
+             checked_insert_no_cap_to
+             out_no_cap_to_trivial[OF ball_tcb_cap_casesI]
+             thread_set_ipc_tcb_cap_valid
+             static_imp_wp static_imp_conj_wp)[1]
+        | simp add: ran_tcb_cap_cases dom_tcb_cap_cases[simplified]
+                    emptyable_def
+               del: hoare_True_E_R
+        | wpc
+        | strengthen use_no_cap_to_obj_asid_strg use_no_cap_to_obj_asid_strg[simplified conj_comms]
+                     tcb_cap_always_valid_strg[where p="tcb_cnode_index 0"]
+                     tcb_cap_always_valid_strg[where p="tcb_cnode_index (Suc 0)"])+)
+  apply (intro conjI impI; clarsimp?;
+     (clarsimp simp: tcb_at_cte_at_0 tcb_at_cte_at_1[simplified]
+                        is_cap_simps is_valid_vtable_root_def
+                        is_cnode_or_valid_arch_def tcb_cap_valid_def
+                        invs_valid_objs cap_asid_def vs_cap_ref_def
+                        case_bool_If valid_ipc_buffer_cap_def option_case_eq_None
+                       | split cap.splits arch_cap.splits if_splits)+)
+  apply (simp split: option.splits)
+  done
+
+lemma check_valid_ipc_buffer_inv: (* arch_specific *)
+  "\<lbrace>P\<rbrace> check_valid_ipc_buffer vptr cap \<lbrace>\<lambda>rv. P\<rbrace>"
+  apply (simp add: check_valid_ipc_buffer_def whenE_def
+             cong: cap.case_cong arch_cap.case_cong
+             split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp | simp add: if_apply_def2 split del: if_split | wpcw)+
+  done
+
+lemma check_valid_ipc_buffer_wp[Tcb_AI_asms]:
+  "\<lbrace>\<lambda>(s::'state_ext::state_ext state). is_arch_cap cap \<and> is_cnode_or_valid_arch cap
+          \<and> valid_ipc_buffer_cap cap vptr
+          \<and> is_aligned vptr msg_align_bits
+             \<longrightarrow> P s\<rbrace>
+     check_valid_ipc_buffer vptr cap
+   \<lbrace>\<lambda>rv. P\<rbrace>,-"
+  apply (simp add: check_valid_ipc_buffer_def whenE_def
+             cong: cap.case_cong arch_cap.case_cong
+             split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp | simp add: whenE_def split del: if_split | wpc)+
+  apply (clarsimp simp: is_cap_simps is_cnode_or_valid_arch_def
+                        valid_ipc_buffer_cap_def)
+  done
+
+lemma derive_no_cap_asid[wp,Tcb_AI_asms]:
+  "\<lbrace>(no_cap_to_obj_with_diff_ref cap S)::'state_ext::state_ext state\<Rightarrow>bool\<rbrace>
+     derive_cap slot cap
+   \<lbrace>\<lambda>rv. no_cap_to_obj_with_diff_ref rv S\<rbrace>,-"
+  apply (simp add: derive_cap_def arch_derive_cap_def
+             cong: cap.case_cong)
+  apply (rule hoare_pre)
+   apply (wp | simp | wpc)+
+  apply (auto simp add: no_cap_to_obj_with_diff_ref_Null,
+         auto simp add: no_cap_to_obj_with_diff_ref_def
+                        table_cap_ref_def)
+  done
+
+
+lemma decode_set_ipc_inv[wp,Tcb_AI_asms]:
+  "\<lbrace>P::'state_ext::state_ext state \<Rightarrow> bool\<rbrace> decode_set_ipc_buffer args cap slot excaps \<lbrace>\<lambda>rv. P\<rbrace>"
+  apply (simp   add: decode_set_ipc_buffer_def whenE_def
+                     split_def
+          split del: if_split)
+  apply (rule hoare_pre, wp check_valid_ipc_buffer_inv)
+  apply simp
+  done
+
+lemma no_cap_to_obj_with_diff_ref_update_cap_data[Tcb_AI_asms]:
+  "no_cap_to_obj_with_diff_ref c S s \<longrightarrow>
+    no_cap_to_obj_with_diff_ref (update_cap_data P x c) S s"
+  apply (case_tac "update_cap_data P x c = NullCap")
+   apply (simp add: no_cap_to_obj_with_diff_ref_Null)
+  apply (subgoal_tac "vs_cap_ref (update_cap_data P x c)
+                                 = vs_cap_ref c")
+   apply (simp add: no_cap_to_obj_with_diff_ref_def
+                    update_cap_objrefs)
+  apply (clarsimp simp: update_cap_data_closedform
+                        table_cap_ref_def Let_def
+                        arch_update_cap_data_def
+                 split: cap.split arch_cap.splits)
+  apply simp
+  done
+
+
+lemma update_cap_valid[Tcb_AI_asms]:
+  "valid_cap cap (s::'state_ext::state_ext state) \<Longrightarrow>
+   valid_cap (case capdata of
+              None \<Rightarrow> cap_rights_update rs cap
+            | Some x \<Rightarrow> update_cap_data p x
+                     (cap_rights_update rs cap)) s"
+  apply (case_tac capdata, simp_all)[1]
+  apply (case_tac cap,
+         simp_all add: update_cap_data_def cap_rights_update_def
+                       is_cap_defs Let_def split_def valid_cap_def
+                       badge_update_def the_cnode_cap_def cap_aligned_def
+                       arch_update_cap_data_def
+            split del: if_split)
+     apply (simp add: badge_update_def cap_rights_update_def)
+    apply (simp add: badge_update_def)
+   apply (simp add: word_bits_def)
+  apply (rename_tac arch_cap)
+  using valid_validate_vm_rights[simplified valid_vm_rights_def]
+  apply (case_tac arch_cap, simp_all add: acap_rights_update_def Let_def
+                                     split: option.splits prod.splits)
+  done
+
+
+crunch pred_tcb_at: switch_to_thread "pred_tcb_at proj P t"
+  (wp: crunch_wps simp: crunch_simps)
+
+crunch typ_at[wp]: invoke_tcb "\<lambda>s. P (typ_at T p s)"
+  (ignore: check_cap_at setNextPC zipWithM
+       wp: hoare_drop_imps mapM_x_wp' check_cap_inv
+     simp: crunch_simps)
+
+end
+
+context begin interpretation Arch .
+requalify_consts is_cnode_or_valid_arch
+requalify_facts invoke_tcb_typ_at
+end
+
+global_interpretation Tcb_AI?: Tcb_AI
+  where is_cnode_or_valid_arch = RISCV64.is_cnode_or_valid_arch
+  proof goal_cases
+    interpret Arch .
+    case 1 show ?case by (unfold_locales; (fact Tcb_AI_asms)?)
+  qed
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -8,7 +9,7 @@ theory ArchTcb_AI
 imports Tcb_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems Tcb_AI_asms
 
@@ -30,12 +31,13 @@ lemma same_object_also_valid:  (* arch specific *)
      cap_asid cap = None \<or> (\<exists>asid. cap_asid cap = Some asid \<and> 0 < asid \<and> asid \<le> 2^asid_bits - 1);
      cap_vptr cap = None; cap_asid_base cap = None \<rbrakk>
      \<Longrightarrow> s \<turnstile> cap"
+  sorry (* FIXME AARCH64
   apply (cases cap,
          (clarsimp simp: same_object_as_def is_cap_simps cap_asid_def
                          wellformed_cap_def wellformed_acap_def
                          valid_cap_def bits_of_def cap_aligned_def
                    split: cap.split_asm arch_cap.split_asm option.splits)+)
-  done
+  done *)
 
 lemma same_object_obj_refs[Tcb_AI_asms]:
   "\<lbrakk> same_object_as cap cap' \<rbrakk>
@@ -53,7 +55,7 @@ where
 
 definition (* arch specific *)
   "vspace_asid cap \<equiv> case cap of
-    ArchObjectCap (PageTableCap _ (Some (asid, _))) \<Rightarrow> Some asid
+    ArchObjectCap (PageTableCap _ _ (Some (asid, _))) \<Rightarrow> Some asid
   | _ \<Rightarrow> None"
 
 lemmas vspace_asid_simps [simp] = (* arch specific *)
@@ -138,10 +140,11 @@ lemma finalise_cap_not_cte_wp_at[Tcb_AI_asms]:
             | rule impI
             | rule hoare_drop_imps)+
      apply (clarsimp simp: ball_ran_eq x)
+    sorry (* FIXME AARCH64 VCPU
     apply (wp delete_one_caps_of_state
          | rule impI
          | simp add: deleting_irq_handler_def get_irq_slot_def x ball_ran_eq)+
-    done
+    done *)
 
 
 lemma table_cap_ref_max_free_index_upd[simp,Tcb_AI_asms]:
@@ -155,7 +158,7 @@ global_interpretation Tcb_AI_1?: Tcb_AI_1
   and is_cnode_or_valid_arch = is_cnode_or_valid_arch
   proof goal_cases
     interpret Arch .
-    case 1 show ?case by (unfold_locales; (fact Tcb_AI_asms)?)
+    case 1 show ?case sorry (* FIXME AARCH64 by (unfold_locales; (fact Tcb_AI_asms)?) *)
   qed
 
 context Arch begin global_naming RISVB64
@@ -276,8 +279,9 @@ lemma tc_invs[Tcb_AI_asms]:
                         invs_valid_objs cap_asid_def vs_cap_ref_def
                         case_bool_If valid_ipc_buffer_cap_def option_case_eq_None
                        | split cap.splits arch_cap.splits if_splits)+)
+  sorry (* FIXME AARCH64
   apply (simp split: option.splits)
-  done
+  done *)
 
 lemma check_valid_ipc_buffer_inv: (* arch_specific *)
   "\<lbrace>P\<rbrace> check_valid_ipc_buffer vptr cap \<lbrace>\<lambda>rv. P\<rbrace>"
@@ -367,8 +371,9 @@ lemma update_cap_valid[Tcb_AI_asms]:
   done
 
 
+(* FIXME AARCH64 VCPU
 crunch pred_tcb_at: switch_to_thread "pred_tcb_at proj P t"
-  (wp: crunch_wps simp: crunch_simps)
+  (wp: crunch_wps simp: crunch_simps) *)
 
 crunch typ_at[wp]: invoke_tcb "\<lambda>s. P (typ_at T p s)"
   (ignore: check_cap_at setNextPC zipWithM
@@ -383,7 +388,7 @@ requalify_facts invoke_tcb_typ_at
 end
 
 global_interpretation Tcb_AI?: Tcb_AI
-  where is_cnode_or_valid_arch = RISCV64.is_cnode_or_valid_arch
+  where is_cnode_or_valid_arch = AARCH64.is_cnode_or_valid_arch
   proof goal_cases
     interpret Arch .
     case 1 show ?case by (unfold_locales; (fact Tcb_AI_asms)?)

--- a/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
@@ -1,0 +1,373 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchUntyped_AI
+imports Untyped_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+named_theorems Untyped_AI_assms
+
+lemma of_bl_nat_to_cref[Untyped_AI_assms]:
+    "\<lbrakk> x < 2 ^ bits; bits < word_bits \<rbrakk>
+      \<Longrightarrow> (of_bl (nat_to_cref bits x) :: word64) = of_nat x"
+  apply (clarsimp intro!: less_mask_eq
+                  simp: nat_to_cref_def of_drop_to_bl
+                        word_size word_less_nat_alt word_bits_def)
+  by (metis add_lessD1 le_unat_uoi nat_le_iff_add nat_le_linear)
+
+
+lemma cnode_cap_ex_cte[Untyped_AI_assms]:
+  "\<lbrakk> is_cnode_cap cap; cte_wp_at (\<lambda>c. \<exists>m. cap = mask_cap m c) p s;
+     (s::'state_ext::state_ext state) \<turnstile> cap; valid_objs s; pspace_aligned s \<rbrakk> \<Longrightarrow>
+    ex_cte_cap_wp_to is_cnode_cap (obj_ref_of cap, nat_to_cref (bits_of cap) x) s"
+  apply (simp only: ex_cte_cap_wp_to_def)
+  apply (rule exI, erule cte_wp_at_weakenE)
+  apply (clarsimp simp: is_cap_simps bits_of_def)
+  apply (case_tac c, simp_all add: mask_cap_def cap_rights_update_def split:bool.splits)
+  apply (clarsimp simp: nat_to_cref_def word_bits_def)
+  apply (erule(2) valid_CNodeCapE)
+  apply (simp add: word_bits_def cte_level_bits_def)
+  done
+
+
+
+lemma inj_on_nat_to_cref[Untyped_AI_assms]:
+  "bits < word_bits \<Longrightarrow> inj_on (nat_to_cref bits) {..< 2 ^ bits}"
+  apply (rule inj_onI)
+  apply (drule arg_cong[where f="\<lambda>x. replicate (64 - bits) False @ x"])
+  apply (subst(asm) word_bl.Abs_inject[where 'a=64, symmetric])
+    apply (simp add: nat_to_cref_def word_bits_def)
+   apply (simp add: nat_to_cref_def word_bits_def)
+  apply (simp add: of_bl_rep_False of_bl_nat_to_cref)
+  apply (erule word_unat.Abs_eqD)
+   apply (simp only: unats_def mem_simps)
+   apply (erule order_less_le_trans)
+   apply (rule power_increasing, (simp add: word_bits_def) +)
+  apply (simp only: unats_def mem_simps)
+  apply (erule order_less_le_trans)
+  apply (rule power_increasing, simp+)
+  done
+
+
+lemma data_to_obj_type_sp[Untyped_AI_assms]:
+  "\<lbrace>P\<rbrace> data_to_obj_type x \<lbrace>\<lambda>ts (s::'state_ext::state_ext state). ts \<noteq> ArchObject ASIDPoolObj \<and> P s\<rbrace>, -"
+  unfolding data_to_obj_type_def
+  apply (rule hoare_pre)
+   apply (wp|wpc)+
+  apply clarsimp
+  apply (simp add: arch_data_to_obj_type_def split: if_split_asm)
+  done
+
+lemma dui_inv_wf[wp, Untyped_AI_assms]:
+  "\<lbrace>invs and cte_wp_at ((=) (cap.UntypedCap dev w sz idx)) slot
+     and (\<lambda>s. \<forall>cap \<in> set cs. is_cnode_cap cap
+                      \<longrightarrow> (\<forall>r\<in>cte_refs cap (interrupt_irq_node s). ex_cte_cap_wp_to is_cnode_cap r s))
+    and (\<lambda>s. \<forall>x \<in> set cs. s \<turnstile> x)\<rbrace>
+     decode_untyped_invocation label args slot (cap.UntypedCap dev w sz idx) cs
+   \<lbrace>valid_untyped_inv\<rbrace>,-"
+proof -
+  have inj: "\<And>node_cap s. \<lbrakk>is_cnode_cap node_cap;
+    unat (args ! 5) \<le> 2 ^ bits_of node_cap - unat (args ! 4);valid_cap node_cap s\<rbrakk> \<Longrightarrow>
+    inj_on (Pair (obj_ref_of node_cap) \<circ> nat_to_cref (bits_of node_cap))
+                      {unat (args ! 4)..<unat (args ! 4) + unat (args ! 5)}"
+    apply (simp add: comp_def)
+    apply (rule inj_on_split)
+    apply (rule subset_inj_on [OF inj_on_nat_to_cref])
+     apply (clarsimp simp: is_cap_simps bits_of_def valid_cap_def
+                           word_bits_def cap_aligned_def)
+    apply clarsimp
+    apply (rule less_le_trans)
+     apply assumption
+    apply (simp add:le_diff_conv2)
+    done
+  have nasty_strengthen:
+    "\<And>S a f s. (\<forall>x\<in>S. cte_wp_at ((=) cap.NullCap) (a, f x) s)
+    \<Longrightarrow> cte_wp_at (\<lambda>c. c \<noteq> cap.NullCap) slot s
+    \<longrightarrow> slot \<notin> (Pair a \<circ> f) ` S"
+    by (auto simp:cte_wp_at_caps_of_state)
+  show ?thesis
+    apply (simp add: decode_untyped_invocation_def unlessE_def[symmetric]
+                     unlessE_whenE
+          split del: if_split)
+    apply (rule validE_R_sp[OF whenE_throwError_sp]
+                validE_R_sp[OF data_to_obj_type_sp]
+                validE_R_sp[OF dui_sp_helper] validE_R_sp[OF map_ensure_empty])+
+     apply clarsimp
+    apply (rule hoare_pre)
+     apply (wp whenE_throwError_wp[THEN validE_validE_R] check_children_wp
+               map_ensure_empty_wp)
+    apply (clarsimp simp: distinct_map cases_imp_eq)
+    apply (subgoal_tac "s \<turnstile> node_cap")
+     prefer 2
+     apply (erule disjE)
+      apply (drule bspec [where x = "cs ! 0"],clarsimp)+
+      apply fastforce
+     apply clarsimp
+     apply (clarsimp simp: cte_wp_at_caps_of_state)
+     apply (drule(1) caps_of_state_valid[rotated])+
+     apply assumption
+    apply (subgoal_tac "\<forall>r\<in>cte_refs node_cap (interrupt_irq_node s). ex_cte_cap_wp_to is_cnode_cap r s")
+     apply (clarsimp simp: cte_wp_at_caps_of_state)
+     apply (frule(1) caps_of_state_valid[rotated])
+     apply (clarsimp simp: not_less)
+     apply (frule(2) inj)
+     apply (clarsimp simp: comp_def)
+     apply (frule(1) caps_of_state_valid)
+     apply (simp add: nasty_strengthen[unfolded o_def] cte_wp_at_caps_of_state)
+     apply (intro conjI)
+      apply (intro impI)
+      apply (frule range_cover_stuff[where w=w and rv = 0 and sz = sz], simp_all)[1]
+        apply (clarsimp simp: valid_cap_simps cap_aligned_def)+
+      apply (frule alignUp_idem[OF is_aligned_weaken,where a = w])
+        apply (erule range_cover.sz)
+       apply (simp add: range_cover_def)
+      apply (clarsimp simp: get_free_ref_def empty_descendants_range_in)
+      apply (rule conjI[rotated], blast, clarsimp)
+      apply (drule_tac x = "(obj_ref_of node_cap, nat_to_cref (bits_of node_cap) slota)" in bspec)
+       apply (clarsimp simp: is_cap_simps nat_to_cref_def word_bits_def bits_of_def valid_cap_simps
+                             cap_aligned_def)+
+     apply (simp add: free_index_of_def)
+     apply (frule(1) range_cover_stuff[where sz = sz])
+        apply (clarsimp dest!: valid_cap_aligned simp: cap_aligned_def word_bits_def)+
+      apply simp+
+     apply (clarsimp simp: get_free_ref_def)
+    apply (erule disjE)
+     apply (drule_tac x= "cs!0" in bspec, clarsimp)
+     apply simp
+    apply (clarsimp simp: cte_wp_at_caps_of_state ex_cte_cap_wp_to_def)
+    apply (rule_tac x=aa in exI, rule exI, rule exI)
+    apply simp
+    done
+qed
+
+lemma asid_bits_ge_0:
+  "(0::word32) < 2 ^ asid_bits" by (simp add: asid_bits_def)
+
+lemma retype_ret_valid_caps_captable[Untyped_AI_assms]:
+  "\<lbrakk>pspace_no_overlap_range_cover ptr sz (s::'state_ext::state_ext state) \<and> 0 < us
+      \<and> range_cover ptr sz (obj_bits_api CapTableObject us) n \<and> ptr \<noteq> 0
+       \<rbrakk>
+         \<Longrightarrow> \<forall>y\<in>{0..<n}. s
+                \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object CapTableObject dev us)) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api CapTableObject us)) [0..<n])
+                           (kheap s)\<rparr> \<turnstile> CNodeCap (ptr_add ptr (y * 2 ^ obj_bits_api CapTableObject us)) us []"
+by ((clarsimp simp:valid_cap_def default_object_def cap_aligned_def
+        cte_level_bits_def is_obj_defs well_formed_cnode_n_def empty_cnode_def
+        dom_def arch_default_cap_def ptr_add_def | rule conjI | intro conjI obj_at_foldr_intro imageI
+      | rule is_aligned_add_multI[OF _ le_refl],
+        (simp add:range_cover_def word_bits_def obj_bits_api_def slot_bits_def)+)+)[1]
+
+lemma retype_ret_valid_caps_aobj[Untyped_AI_assms]:
+  "\<And>ptr sz (s::'state_ext::state_ext state) x6 us n.
+  \<lbrakk>pspace_no_overlap_range_cover ptr sz s \<and> x6 \<noteq> ASIDPoolObj \<and>
+  range_cover ptr sz (obj_bits_api (ArchObject x6) us) n \<and> ptr \<noteq> 0\<rbrakk>
+            \<Longrightarrow> \<forall>y\<in>{0..<n}. s
+                   \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object (ArchObject x6) dev us)) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api (ArchObject x6) us)) [0..<n])
+                              (kheap s)\<rparr> \<turnstile> ArchObjectCap (arch_default_cap x6 (ptr_add ptr (y * 2 ^ obj_bits_api (ArchObject x6) us)) us dev)"
+  apply (rename_tac aobject_type us n)
+  apply (case_tac aobject_type)
+  by (clarsimp simp: valid_cap_def default_object_def cap_aligned_def
+                     cte_level_bits_def is_obj_defs well_formed_cnode_n_def empty_cnode_def
+                     dom_def arch_default_cap_def ptr_add_def
+      | intro conjI obj_at_foldr_intro
+        imageI valid_vm_rights_def
+      | rule is_aligned_add_multI[OF _ le_refl]
+      | fastforce simp:range_cover_def obj_bits_api_def
+        default_arch_object_def valid_vm_rights_def  word_bits_def a_type_def)+
+
+
+
+lemma cap_refs_in_kernel_windowD2:
+  "\<lbrakk> cte_wp_at P p (s::'state_ext::state_ext state); cap_refs_in_kernel_window s \<rbrakk>
+       \<Longrightarrow> \<exists>cap. P cap \<and> region_in_kernel_window (cap_range cap) s"
+  apply (clarsimp simp: cte_wp_at_caps_of_state region_in_kernel_window_def)
+  apply (drule(1) cap_refs_in_kernel_windowD)
+  apply fastforce
+  done
+
+lemma init_arch_objects_descendants_range[wp,Untyped_AI_assms]:
+  "\<lbrace>\<lambda>(s::'state_ext::state_ext state). descendants_range x cref s \<rbrace>
+   init_arch_objects ty ptr n us y
+   \<lbrace>\<lambda>rv s. descendants_range x cref s\<rbrace>"
+  unfolding init_arch_objects_def by wp
+
+lemma init_arch_objects_caps_overlap_reserved[wp,Untyped_AI_assms]:
+  "\<lbrace>\<lambda>(s::'state_ext::state_ext state). caps_overlap_reserved S s\<rbrace>
+   init_arch_objects ty ptr n us y
+   \<lbrace>\<lambda>rv s. caps_overlap_reserved S s\<rbrace>"
+  unfolding init_arch_objects_def by wp
+
+lemma set_untyped_cap_invs_simple[Untyped_AI_assms]:
+  "\<lbrace>\<lambda>s. descendants_range_in {ptr .. ptr+2^sz - 1} cref s \<and> pspace_no_overlap_range_cover ptr sz s \<and> invs s
+  \<and> cte_wp_at (\<lambda>c. is_untyped_cap c \<and> cap_bits c = sz \<and> obj_ref_of c = ptr \<and> cap_is_device c = dev) cref s \<and> idx \<le> 2^ sz\<rbrace>
+  set_cap (cap.UntypedCap dev ptr sz idx) cref
+ \<lbrace>\<lambda>rv s. invs s\<rbrace>"
+  apply (rule hoare_name_pre_state)
+  apply (clarsimp simp: cte_wp_at_caps_of_state invs_def valid_state_def)
+  apply (rule hoare_pre)
+  apply (wp set_free_index_valid_pspace_simple set_cap_valid_mdb_simple
+    set_cap_idle update_cap_ifunsafe)
+  apply (simp add:valid_irq_node_def)
+  apply wps
+  apply (wp hoare_vcg_all_lift set_cap_irq_handlers set_cap_valid_arch_caps
+    set_cap_irq_handlers cap_table_at_lift_valid set_cap_typ_at
+    set_untyped_cap_refs_respects_device_simple)
+  apply (clarsimp simp:cte_wp_at_caps_of_state is_cap_simps)
+  apply (intro conjI,clarsimp)
+        apply (rule ext,clarsimp simp:is_cap_simps)
+       apply (clarsimp split:cap.splits simp:is_cap_simps appropriate_cte_cap_def)
+      apply (drule(1) if_unsafe_then_capD[OF caps_of_state_cteD])
+       apply clarsimp
+      apply (clarsimp simp:is_cap_simps ex_cte_cap_wp_to_def appropriate_cte_cap_def cte_wp_at_caps_of_state)
+     apply (clarsimp dest!:valid_global_refsD2 simp:cap_range_def)
+    apply (simp add:valid_irq_node_def)
+   apply (clarsimp simp:valid_irq_node_def)
+  apply (clarsimp simp:no_cap_to_obj_with_diff_ref_def cte_wp_at_caps_of_state vs_cap_ref_def)
+  apply (case_tac cap)
+   apply (simp_all add:vs_cap_ref_def table_cap_ref_def)
+  apply (rename_tac arch_cap)
+  apply (case_tac arch_cap)
+   apply simp_all
+  apply (clarsimp simp:cap_refs_in_kernel_window_def
+              valid_refs_def simp del:split_paired_All)
+  apply (drule_tac x = cref in spec)
+  apply (clarsimp simp:cte_wp_at_caps_of_state)
+  apply (fastforce simp: not_kernel_window_def)
+  done
+
+
+lemmas pbfs_less_wb' = pageBitsForSize_bounded
+
+lemma delete_objects_rewrite[Untyped_AI_assms]:
+  "\<lbrakk> word_size_bits \<le> sz; sz\<le> word_bits;ptr && ~~ mask sz = ptr\<rbrakk> \<Longrightarrow> delete_objects ptr sz =
+    do y \<leftarrow> modify (clear_um {ptr + of_nat k |k. k < 2 ^ sz});
+    modify (detype {ptr && ~~ mask sz..ptr + 2 ^ sz - 1})
+    od"
+  apply (clarsimp simp:delete_objects_def freeMemory_def word_size_def word_size_bits_def)
+  apply (subgoal_tac "is_aligned (ptr &&~~ mask sz) sz")
+  apply (subst mapM_storeWord_clear_um[simplified word_size_def word_size_bits_def])
+  apply (simp)
+  apply simp
+  apply (simp add:range_cover_def)
+  apply clarsimp
+  apply (rule is_aligned_neg_mask)
+  apply simp
+  done
+
+declare store_pde_pred_tcb_at [wp]
+
+(* nonempty_table *)
+definition
+  nonempty_table :: "machine_word set \<Rightarrow> Structures_A.kernel_object \<Rightarrow> bool"
+where
+ "nonempty_table S ko \<equiv> a_type ko = AArch APageTable \<and> ko \<noteq> ArchObj (PageTable empty_pt)"
+
+lemma reachable_target_trans[simp]:
+  "reachable_target ref p (trans_state f s) = reachable_target ref p s"
+  by (simp add: reachable_target_def split: prod.split)
+
+lemma reachable_pg_cap_exst_update[simp]:
+  "reachable_frame_cap x (trans_state f (s::'state_ext::state_ext state)) = reachable_frame_cap x s"
+  by (simp add: reachable_frame_cap_def obj_at_def)
+
+lemma create_cap_valid_arch_caps[wp, Untyped_AI_assms]:
+  "\<lbrace>valid_arch_caps
+      and valid_cap (default_cap tp oref sz dev)
+      and (\<lambda>(s::'state_ext::state_ext state). \<forall>r\<in>obj_refs (default_cap tp oref sz dev).
+                (\<forall>p'. \<not> cte_wp_at (\<lambda>cap. r \<in> obj_refs cap) p' s)
+              \<and> \<not> obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)
+      and cte_wp_at ((=) cap.NullCap) cref
+      and K (tp \<noteq> ArchObject ASIDPoolObj)\<rbrace>
+     create_cap tp sz p dev (cref, oref) \<lbrace>\<lambda>rv. valid_arch_caps\<rbrace>"
+  apply (simp add: create_cap_def set_cdt_def)
+  apply (wp set_cap_valid_arch_caps)
+  apply (simp add: trans_state_update[symmetric] del: trans_state_update)
+  apply (wp hoare_vcg_disj_lift hoare_vcg_conj_lift hoare_vcg_all_lift hoare_vcg_imp_lift | simp)+
+
+  apply (clarsimp simp del: split_paired_All split_paired_Ex
+                            imp_disjL
+                      simp: cte_wp_at_caps_of_state)
+  apply (rule conjI)
+   apply (clarsimp simp: no_cap_to_obj_with_diff_ref_def
+                         cte_wp_at_caps_of_state)
+   apply (case_tac "\<exists>x. x \<in> obj_refs cap")
+    apply (clarsimp dest!: obj_ref_elemD)
+    apply (case_tac cref, fastforce)
+   apply (simp add: obj_ref_none_no_asid)
+  apply (rule conjI)
+   apply (auto simp: is_cap_simps valid_cap_def second_level_tables_def
+                     obj_at_def nonempty_table_def a_type_simps in_omonad)[1]
+  apply (clarsimp simp del: imp_disjL)
+  apply (case_tac "\<exists>x. x \<in> obj_refs cap")
+   apply (clarsimp dest!: obj_ref_elemD)
+   apply fastforce
+  apply (auto simp: is_cap_simps)[1]
+  done
+
+
+lemma create_cap_cap_refs_in_kernel_window[wp, Untyped_AI_assms]:
+  "\<lbrace>cap_refs_in_kernel_window and cte_wp_at (\<lambda>c. cap_range (default_cap tp oref sz dev) \<subseteq> cap_range c) p\<rbrace>
+     create_cap tp sz p dev (cref, oref) \<lbrace>\<lambda>rv. cap_refs_in_kernel_window\<rbrace>"
+  apply (simp add: create_cap_def)
+  apply (wp | simp)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (drule(1) cap_refs_in_kernel_windowD)
+  apply blast
+  done
+
+lemma create_cap_ioports[wp, Untyped_AI_assms]:
+  "\<lbrace>valid_ioports and cte_wp_at (\<lambda>_. True) cref\<rbrace> create_cap tp sz p dev (cref,oref) \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
+  by wpsimp
+
+lemma init_arch_objects_nonempty_table[Untyped_AI_assms, wp]:
+  "\<lbrace>(\<lambda>s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)
+         \<and> valid_global_objs s \<and> valid_arch_state s \<and> pspace_aligned s) and
+    K (\<forall>ref\<in>set refs. is_aligned ref (obj_bits_api tp us))\<rbrace>
+        init_arch_objects tp ptr bits us refs
+   \<lbrace>\<lambda>rv s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)\<rbrace>"
+  unfolding init_arch_objects_def by wpsimp
+
+lemma nonempty_table_caps_of[Untyped_AI_assms]:
+  "nonempty_table S ko \<Longrightarrow> caps_of ko = {}"
+  by (auto simp: caps_of_def cap_of_def nonempty_table_def a_type_def
+          split: Structures_A.kernel_object.split if_split_asm)
+
+
+lemma nonempty_default[simp, Untyped_AI_assms]:
+  "tp \<noteq> Untyped \<Longrightarrow> \<not> nonempty_table S (default_object tp dev us)"
+  apply (case_tac tp, simp_all add: default_object_def nonempty_table_def a_type_def)
+  apply (rename_tac aobject_type)
+  apply (case_tac aobject_type; simp add: default_arch_object_def)
+  done
+
+crunch cte_wp_at_iin[wp]: init_arch_objects "\<lambda>s. P (cte_wp_at (P' (interrupt_irq_node s)) p s)"
+
+lemmas init_arch_objects_ex_cte_cap_wp_to = init_arch_objects_excap
+
+lemma obj_is_device_vui_eq[Untyped_AI_assms]:
+  "valid_untyped_inv ui s
+      \<Longrightarrow> case ui of Retype slot reset ptr_base ptr tp us slots dev
+          \<Rightarrow> obj_is_device tp dev = dev"
+  apply (cases ui, clarsimp)
+  apply (clarsimp simp: obj_is_device_def
+                 split: apiobject_type.split)
+  apply (intro impI conjI allI, simp_all add: is_frame_type_def default_object_def)
+  apply (simp add: default_arch_object_def split: aobject_type.split)
+  apply (auto simp: arch_is_frame_type_def)
+  done
+
+end
+
+global_interpretation Untyped_AI? : Untyped_AI
+  where nonempty_table = RISCV64.nonempty_table
+  proof goal_cases
+    interpret Arch .
+    case 1 show ?case
+    by (unfold_locales; (fact Untyped_AI_assms)?)
+  qed
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -8,7 +9,7 @@ theory ArchUntyped_AI
 imports Untyped_AI
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems Untyped_AI_assms
 
@@ -258,13 +259,15 @@ lemma delete_objects_rewrite[Untyped_AI_assms]:
   apply simp
   done
 
-declare store_pde_pred_tcb_at [wp]
+(* FIXME AARCH64
+declare store_pde_pred_tcb_at [wp] *)
 
 (* nonempty_table *)
 definition
   nonempty_table :: "machine_word set \<Rightarrow> Structures_A.kernel_object \<Rightarrow> bool"
 where
- "nonempty_table S ko \<equiv> a_type ko = AArch APageTable \<and> ko \<noteq> ArchObj (PageTable empty_pt)"
+ (* FIXME AARCH64 check *)
+ "nonempty_table S ko \<equiv> \<forall>pt_t. a_type ko = AArch (APageTable pt_t) \<and> ko \<noteq> ArchObj (PageTable (empty_pt pt_t))"
 
 lemma reachable_target_trans[simp]:
   "reachable_target ref p (trans_state f s) = reachable_target ref p s"
@@ -301,12 +304,13 @@ lemma create_cap_valid_arch_caps[wp, Untyped_AI_assms]:
   apply (rule conjI)
    apply (auto simp: is_cap_simps valid_cap_def second_level_tables_def
                      obj_at_def nonempty_table_def a_type_simps in_omonad)[1]
+  sorry (* FIXME AARCH64
   apply (clarsimp simp del: imp_disjL)
   apply (case_tac "\<exists>x. x \<in> obj_refs cap")
    apply (clarsimp dest!: obj_ref_elemD)
    apply fastforce
   apply (auto simp: is_cap_simps)[1]
-  done
+  done *)
 
 
 lemma create_cap_cap_refs_in_kernel_window[wp, Untyped_AI_assms]:
@@ -342,7 +346,8 @@ lemma nonempty_default[simp, Untyped_AI_assms]:
   apply (case_tac tp, simp_all add: default_object_def nonempty_table_def a_type_def)
   apply (rename_tac aobject_type)
   apply (case_tac aobject_type; simp add: default_arch_object_def)
-  done
+  sorry (* FIXME AARCH64
+  done *)
 
 crunch cte_wp_at_iin[wp]: init_arch_objects "\<lambda>s. P (cte_wp_at (P' (interrupt_irq_node s)) p s)"
 
@@ -358,16 +363,18 @@ lemma obj_is_device_vui_eq[Untyped_AI_assms]:
   apply (intro impI conjI allI, simp_all add: is_frame_type_def default_object_def)
   apply (simp add: default_arch_object_def split: aobject_type.split)
   apply (auto simp: arch_is_frame_type_def)
-  done
+  sorry (* FIXME AARCH64
+  done *)
 
 end
 
 global_interpretation Untyped_AI? : Untyped_AI
-  where nonempty_table = RISCV64.nonempty_table
+  where nonempty_table = AARCH64.nonempty_table
   proof goal_cases
     interpret Arch .
     case 1 show ?case
-    by (unfold_locales; (fact Untyped_AI_assms)?)
+    sorry (* FIXME AARCH64
+    by (unfold_locales; (fact Untyped_AI_assms)?) *)
   qed
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
@@ -259,15 +259,10 @@ lemma delete_objects_rewrite[Untyped_AI_assms]:
   apply simp
   done
 
-(* FIXME AARCH64
-declare store_pde_pred_tcb_at [wp] *)
+declare store_pte_pred_tcb_at [wp]
 
-(* nonempty_table *)
-definition
-  nonempty_table :: "machine_word set \<Rightarrow> Structures_A.kernel_object \<Rightarrow> bool"
-where
- (* FIXME AARCH64 check *)
- "nonempty_table S ko \<equiv> \<forall>pt_t. a_type ko = AArch (APageTable pt_t) \<and> ko \<noteq> ArchObj (PageTable (empty_pt pt_t))"
+definition nonempty_table :: "obj_ref set \<Rightarrow> kernel_object \<Rightarrow> bool" where
+ "nonempty_table S ko \<equiv> \<exists>pt_t. a_type ko = AArch (APageTable pt_t) \<and> ko \<noteq> ArchObj (PageTable (empty_pt pt_t))"
 
 lemma reachable_target_trans[simp]:
   "reachable_target ref p (trans_state f s) = reachable_target ref p s"
@@ -373,8 +368,7 @@ global_interpretation Untyped_AI? : Untyped_AI
   proof goal_cases
     interpret Arch .
     case 1 show ?case
-    sorry (* FIXME AARCH64
-    by (unfold_locales; (fact Untyped_AI_assms)?) *)
+    by (unfold_locales; (fact Untyped_AI_assms)?)
   qed
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
@@ -1,0 +1,674 @@
+(*
+ * Copyright 2022, Proofcraft Pty Ltd
+ * Copyright 2022, UNSW (ABN 57 195 873 197)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchVCPU_AI
+imports AInvs
+begin
+
+context Arch begin global_naming ARM_HYP (*FIXME: arch_split*)
+
+(* FIXME AARCH64: move to ArchInvariants_AI and use there *)
+definition active_cur_vcpu_of :: "'z state \<Rightarrow> obj_ref option" where
+  "active_cur_vcpu_of s \<equiv> case arm_current_vcpu (arch_state s) of Some (vr, True) \<Rightarrow> Some vr
+                                                                 | _  \<Rightarrow> None"
+
+definition valid_cur_vcpu :: "'z::state_ext state \<Rightarrow> bool" where
+  "valid_cur_vcpu s \<equiv> arch_tcb_at (\<lambda>itcb. itcb_vcpu itcb = active_cur_vcpu_of s) (cur_thread s) s"
+
+lemma valid_cur_vcpu_lift_ct_Q:
+  assumes arch_tcb_of_cur_thread: "\<And>P. \<lbrace>\<lambda>s. arch_tcb_at P (cur_thread s) s \<and> Q s\<rbrace>
+                                        f \<lbrace>\<lambda>_ s. arch_tcb_at P (cur_thread s) s\<rbrace>"
+  and active_cur_vcpu_of: "\<And>P. \<lbrace>\<lambda>s. P (active_cur_vcpu_of s) \<and> Q s\<rbrace>
+                                f \<lbrace>\<lambda>_ s. P (active_cur_vcpu_of s)\<rbrace>"
+  shows "\<lbrace>\<lambda>s. valid_cur_vcpu s \<and> Q s\<rbrace> f \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  unfolding valid_cur_vcpu_def valid_def
+  using use_valid[OF _ active_cur_vcpu_of] use_valid[OF _ arch_tcb_of_cur_thread]
+  by (fastforce simp: active_cur_vcpu_of_def)
+
+lemmas valid_cur_vcpu_lift_ct = valid_cur_vcpu_lift_ct_Q[where Q=\<top>, simplified]
+
+lemma valid_cur_vcpu_lift:
+  "\<lbrakk>\<And>P. f \<lbrace>\<lambda>s. P (active_cur_vcpu_of s)\<rbrace>; \<And>P t. f \<lbrace>\<lambda>s. arch_tcb_at P t s\<rbrace>;
+    \<And>P. f \<lbrace>\<lambda>s. P (cur_thread s)\<rbrace>\<rbrakk> \<Longrightarrow>
+   f \<lbrace>valid_cur_vcpu\<rbrace>"
+  apply (rule valid_cur_vcpu_lift_ct)
+   apply (rule_tac f=cur_thread in hoare_lift_Pf3)
+   apply fastforce+
+  done
+
+lemma valid_cur_vcpu_lift_weak:
+  "\<lbrakk>\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>; \<And>P t. f \<lbrace>\<lambda>s. arch_tcb_at P t s\<rbrace>;
+    \<And>P. f \<lbrace>\<lambda>s. P (cur_thread s)\<rbrace>\<rbrakk> \<Longrightarrow>
+   f \<lbrace>valid_cur_vcpu\<rbrace>"
+  apply (rule valid_cur_vcpu_lift_ct)
+   apply (rule_tac f=cur_thread in hoare_lift_Pf3)
+   apply fastforce+
+  apply (clarsimp simp: valid_cur_vcpu_def valid_def)
+  by (fastforce simp: active_cur_vcpu_of_def)
+
+lemma valid_cur_vcpu_lift_cur_thread_update:
+  assumes arch_tcb_at: "\<And>P. f \<lbrace>arch_tcb_at P t\<rbrace>"
+  and active_cur_vcpu_of: "\<And>P. f \<lbrace>\<lambda>s. P (active_cur_vcpu_of s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. valid_cur_vcpu (s\<lparr>cur_thread := t\<rparr>)\<rbrace>"
+  unfolding valid_cur_vcpu_def valid_def
+  using use_valid[OF _ active_cur_vcpu_of] use_valid[OF _ arch_tcb_at]
+  by (fastforce simp: active_cur_vcpu_of_def)
+
+crunches as_user
+  for active_cur_vcpu_of[wp]: "\<lambda>s. P (active_cur_vcpu_of s)"
+  (wp: crunch_wps simp: active_cur_vcpu_of_def)
+
+lemma as_user_valid_cur_vcpu[wp]:
+  "as_user tptr f \<lbrace>valid_cur_vcpu\<rbrace>"
+  by (rule valid_cur_vcpu_lift; wpsimp wp: as_user_pred_tcb_at)
+
+lemma machine_state_update_active_cur_vcpu_of[simp]:
+  "P (active_cur_vcpu_of (s\<lparr>machine_state := ms\<rparr>)) = P (active_cur_vcpu_of s)"
+  by (fastforce simp: active_cur_vcpu_of_def)
+
+crunches do_machine_op
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  and valid_cur_vcpu_cur_thread_update[wp]: "\<lambda>s. valid_cur_vcpu (s\<lparr>cur_thread := t\<rparr>)"
+  (wp: valid_cur_vcpu_lift_cur_thread_update valid_cur_vcpu_lift crunch_wps)
+
+lemma valid_cur_vcpu_vcpu_update[simp]:
+  "vcpu_at v s \<Longrightarrow> valid_cur_vcpu (s\<lparr>kheap := kheap s(v \<mapsto> ArchObj (VCPU vcpu))\<rparr>) = valid_cur_vcpu s"
+  by (clarsimp simp: valid_cur_vcpu_def active_cur_vcpu_of_def pred_tcb_at_def obj_at_def)
+
+crunches vcpu_save_reg, vcpu_write_reg, save_virt_timer, vgic_update, vcpu_disable
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (wp: set_vcpu_wp)
+
+lemma set_vcpu_arch_tcb_at_cur_thread[wp]:
+  "set_vcpu ptr vcpu \<lbrace>\<lambda>s. arch_tcb_at P (cur_thread s) s\<rbrace>"
+  apply (wpsimp wp: set_vcpu_wp get_vcpu_wp)
+  apply (clarsimp simp: pred_tcb_at_def obj_at_def)
+  done
+
+crunches vcpu_disable, vcpu_restore, vcpu_save, set_vm_root
+  for arch_tcb_at_cur_thread[wp]: "\<lambda>s. arch_tcb_at P (cur_thread s) s"
+  (wp: crunch_wps ignore: set_object) (* FIXME AARCH64: set_object shouldn't be here *)
+
+lemma invalidate_asid_active_cur_vcpu_of[wp]:
+  "\<lbrace>\<lambda>s. P (active_cur_vcpu_of s)\<rbrace> invalidate_asid param_a \<lbrace>\<lambda>_ s. P (active_cur_vcpu_of s)\<rbrace>"
+  sorry (* FIXME AARCH64: crunch was able to deal with this on ARM_HYP with old defs *)
+
+crunches vcpu_update, do_machine_op, invalidate_asid
+  for active_cur_vcpu_of[wp]: "\<lambda>s. P (active_cur_vcpu_of s)"
+  (simp: active_cur_vcpu_of_def)
+
+lemma vcpu_save_reg_active_cur_vcpu_of[wp]:
+  "vcpu_save_reg vr reg \<lbrace>\<lambda>s. P (active_cur_vcpu_of s)\<rbrace>"
+  by (wpsimp simp: vcpu_save_reg_def)
+
+crunches vcpu_restore, do_machine_op, vcpu_save_reg, vgic_update, save_virt_timer,
+         vcpu_save_reg_range, vgic_update_lr, vcpu_enable, vcpu_save, set_vcpu
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (wp: valid_cur_vcpu_lift crunch_wps simp: active_cur_vcpu_of_def)
+
+lemma switch_vcpu_valid_cur_vcpu_cur_thread_update[wp]:
+  "\<lbrace>arch_tcb_at (\<lambda>itcb. itcb_vcpu itcb = v) t\<rbrace>
+   vcpu_switch v
+   \<lbrace>\<lambda>_ s. valid_cur_vcpu (s\<lparr>cur_thread := t\<rparr>)\<rbrace>"
+  unfolding vcpu_switch_def
+  apply (wpsimp simp: valid_cur_vcpu_def active_cur_vcpu_of_def)
+  by fastforce
+
+lemma switch_vcpu_valid_cur_vcpu[wp]:
+  "\<lbrace>\<lambda>s. arch_tcb_at (\<lambda>itcb. itcb_vcpu itcb = v) (cur_thread s) s\<rbrace>
+   vcpu_switch v
+   \<lbrace>\<lambda>_ s. valid_cur_vcpu s\<rbrace>"
+  unfolding vcpu_switch_def
+  apply (wpsimp simp: valid_cur_vcpu_def active_cur_vcpu_of_def)
+  by (clarsimp simp: pred_tcb_at_def obj_at_def)
+
+lemma active_cur_vcpu_of_arm_vmid_table_upd[simp]:
+  "active_cur_vcpu_of (s\<lparr>arch_state := arch_state s \<lparr>arm_vmid_table := x \<rparr>\<rparr>) = active_cur_vcpu_of s"
+  by (clarsimp simp: active_cur_vcpu_of_def pred_tcb_at_def obj_at_def valid_cur_vcpu_def)
+
+lemma valid_cur_vcpu_arm_vmid_table_upd[simp]:
+  "valid_cur_vcpu (s\<lparr>arch_state := arch_state s \<lparr>arm_vmid_table := x \<rparr>\<rparr>) = valid_cur_vcpu s"
+  by (clarsimp simp: valid_cur_vcpu_def)
+
+lemma get_vmid_active_cur_vcpu_of[wp]:
+  "get_vmid asid \<lbrace>\<lambda>s. P (active_cur_vcpu_of s)\<rbrace>"
+  unfolding get_vmid_def
+  sorry (* FIXME AARCH64 crunches/vmid? *)
+
+lemma store_vmid_active_cur_vcpu_of[wp]:
+  "store_vmid asid p \<lbrace>\<lambda>s. P (active_cur_vcpu_of s)\<rbrace>"
+  unfolding store_vmid_def
+  sorry (* FIXME AARCH64 crunches/vmid? *)
+
+lemma arm_context_switch_active_cur_vcpu_of[wp]:
+  "arm_context_switch pd asid \<lbrace>\<lambda>s. P (active_cur_vcpu_of s)\<rbrace>"
+  unfolding arm_context_switch_def get_vmid_def
+  apply (wpsimp wp: load_vmid_wp)
+  sorry (* FIXME AARCH64 crunches/vmid? *)
+
+lemma set_vm_root_active_cur_vcpu_of[wp]:
+  "set_vm_root tcb \<lbrace>\<lambda>s. P (active_cur_vcpu_of s)\<rbrace>"
+  sorry (* FIXME AARCH64 missing crunches
+  by (wpsimp simp: set_vm_root_def wp: get_cap_wp) *)
+
+crunches set_vm_root
+  for valid_cur_vcpu_cur_thread_update[wp]: "\<lambda>s. valid_cur_vcpu (s\<lparr>cur_thread := t\<rparr>)"
+  (wp: valid_cur_vcpu_lift_cur_thread_update)
+
+lemma arch_switch_to_thread_valid_cur_vcpu_cur_thread_update[wp]:
+  "\<lbrace>valid_cur_vcpu\<rbrace>
+   arch_switch_to_thread t
+   \<lbrace>\<lambda>_ s. valid_cur_vcpu (s\<lparr>cur_thread := t\<rparr>)\<rbrace>"
+  unfolding arch_switch_to_thread_def
+  apply wpsimp
+  by (fastforce simp: active_cur_vcpu_of_def pred_tcb_at_def obj_at_def get_tcb_def
+               split: option.splits kernel_object.splits)
+
+lemma switch_to_thread_valid_cur_vcpu[wp]:
+  "switch_to_thread t \<lbrace>valid_cur_vcpu\<rbrace>"
+  unfolding switch_to_thread_def
+  by (wpsimp simp: valid_cur_vcpu_def active_cur_vcpu_of_def)
+
+lemma arch_switch_to_idle_thread_valid_cur_vcpu_cur_thread_update[wp]:
+  "\<lbrace>\<lambda>s. valid_cur_vcpu s \<and> valid_idle s \<and> t = idle_thread s\<rbrace>
+   arch_switch_to_idle_thread
+   \<lbrace>\<lambda>_ s. valid_cur_vcpu (s\<lparr>cur_thread := t\<rparr>)\<rbrace>"
+  unfolding arch_switch_to_idle_thread_def
+  apply wpsimp
+  sorry (* FIXME AARCH64
+  by (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def valid_arch_idle_def) *)
+
+lemma switch_to_idle_thread_valid_cur_vcpu[wp]:
+  "\<lbrace>valid_cur_vcpu and valid_idle\<rbrace>
+   switch_to_idle_thread
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  sorry (* FIXME AARCH64 arch_switch_to_idle_thread
+  by (wpsimp simp: switch_to_idle_thread_def) *)
+
+lemma tcb_vcpu_update_empty_valid_cur_vcpu[wp]:
+  "\<lbrace>\<lambda>s. if t = cur_thread s
+        then arm_current_vcpu (arch_state s) = None
+        else valid_cur_vcpu s\<rbrace>
+   arch_thread_set (tcb_vcpu_update Map.empty) t
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  apply (wpsimp wp: arch_thread_set_wp)
+  by (clarsimp simp: valid_cur_vcpu_def pred_tcb_at_def active_cur_vcpu_of_def obj_at_def)
+
+lemma vcpu_invalidate_active_valid_cur_vcpu[wp]:
+  "\<lbrace>\<lambda>s. arm_current_vcpu (arch_state s) \<noteq> None
+        \<and> arch_tcb_at (\<lambda>itcb. itcb_vcpu itcb = None) (cur_thread s) s\<rbrace>
+   vcpu_invalidate_active
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  unfolding vcpu_invalidate_active_def
+  by (wpsimp simp: valid_cur_vcpu_def active_cur_vcpu_of_def)
+
+lemma vcpu_invalid_active_arm_current_vcpu_None[wp]:
+  "\<lbrace>\<top>\<rbrace> vcpu_invalidate_active \<lbrace>\<lambda>_ s. arm_current_vcpu (arch_state s) = None\<rbrace>"
+  unfolding vcpu_invalidate_active_def
+  by wpsimp
+
+lemma dissociate_vcpu_tcb_valid_cur_vcpu[wp]:
+  "\<lbrace>\<lambda>s. valid_cur_vcpu s \<and> sym_refs (state_hyp_refs_of s)\<rbrace>
+   dissociate_vcpu_tcb vr t
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  unfolding dissociate_vcpu_tcb_def
+  apply (wpsimp wp: hoare_vcg_imp_lift' arch_thread_get_wp get_vcpu_wp)
+  by (fastforce simp: valid_cur_vcpu_def pred_tcb_at_def obj_at_def active_cur_vcpu_of_def
+                      sym_refs_def state_hyp_refs_of_def
+               split: bool.splits option.splits)
+
+lemma associate_vcpu_tcb_valid_cur_vcpu:
+  "\<lbrace>\<lambda>s. valid_cur_vcpu s \<and> sym_refs (state_hyp_refs_of s)\<rbrace>
+   associate_vcpu_tcb vr t
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  unfolding associate_vcpu_tcb_def
+  sorry (* FIXME AARCH64 something going on with _2 rephrase of valid_cur_vcpu
+  apply (wpsimp wp: hoare_vcg_imp_lift')
+        apply (wpsimp wp: arch_thread_set_wp)
+       apply (wpsimp wp: arch_thread_set_wp)
+      apply (rule_tac Q="\<lambda>_ s. valid_cur_vcpu s \<and> sym_refs (state_hyp_refs_of s)" in hoare_post_imp)
+       apply (clarsimp simp: pred_tcb_at_def obj_at_def valid_cur_vcpu_def active_cur_vcpu_of_def)
+      by (wpsimp wp: get_vcpu_wp hoare_drop_imps)+ *)
+
+lemma set_thread_state_arch_tcb_at[wp]:
+  "set_thread_state ts ref \<lbrace>arch_tcb_at P t\<rbrace>"
+  unfolding set_thread_state_def
+  apply (wpsimp wp: set_object_wp)
+  by (clarsimp simp: pred_tcb_at_def obj_at_def get_tcb_def)
+
+crunches set_thread_state
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (wp: valid_cur_vcpu_lift_weak)
+
+crunches activate_thread
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+
+crunches tcb_sched_action
+  for arch_tcb_at[wp]: "arch_tcb_at P t"
+  (simp: tcb_sched_action_def set_tcb_queue_def get_tcb_queue_def)
+
+crunches tcb_sched_action
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (wp: valid_cur_vcpu_lift_weak)
+
+crunches schedule_choose_new_thread
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (simp: crunch_simps valid_cur_vcpu_def active_cur_vcpu_of_def wp: crunch_wps)
+
+lemma schedule_valid_cur_vcpu_det_ext[wp]:
+  "\<lbrace>valid_cur_vcpu and valid_idle\<rbrace>
+   (schedule :: (unit, det_ext) s_monad)
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  unfolding schedule_def schedule_switch_thread_fastfail_def ethread_get_when_def ethread_get_def
+  by (wpsimp wp: hoare_drop_imps gts_wp)
+
+lemma schedule_valid_cur_vcpu[wp]:
+  "\<lbrace>valid_cur_vcpu and valid_idle\<rbrace>
+   (schedule :: (unit, unit) s_monad)
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  unfolding schedule_def allActiveTCBs_def
+  by (wpsimp wp: alternative_wp select_wp)
+
+crunches cancel_all_ipc, blocked_cancel_ipc, unbind_maybe_notification, cancel_all_signals,
+         bind_notification, fast_finalise, deleted_irq_handler, post_cap_deletion, cap_delete_one,
+         reply_cancel_ipc, cancel_ipc, update_waiting_ntfn, send_signal, send_ipc, send_fault_ipc,
+         receive_ipc, handle_fault, handle_interrupt, handle_vm_fault, handle_hypervisor_fault,
+         send_signal, do_reply_transfer, unbind_notification, suspend, cap_swap, bind_notification,
+         restart, reschedule_required, possible_switch_to, thread_set_priority, reply_from_kernel
+  for arch_state[wp]: "\<lambda>s. P (arch_state s)"
+  and cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
+  (wp: mapM_x_wp_inv thread_set.arch_state select_wp crunch_wps
+   simp: crunch_simps possible_switch_to_def reschedule_required_def)
+
+lemma do_unbind_notification_arch_tcb_at[wp]:
+  "do_unbind_notification ntfnptr ntfn tcbptr \<lbrace>arch_tcb_at P t\<rbrace>"
+  unfolding set_bound_notification_def set_simple_ko_def
+  apply (wpsimp wp: set_object_wp get_object_wp get_simple_ko_wp thread_get_wp)
+  by (fastforce simp: pred_tcb_at_def obj_at_def get_tcb_def)
+
+lemma unbind_notification_arch_tcb_at[wp]:
+  "unbind_notification tcb \<lbrace>arch_tcb_at P t\<rbrace>"
+  unfolding unbind_notification_def
+  by wpsimp
+
+lemma bind_notification_arch_tcb_at[wp]:
+  "bind_notification tcbptr ntfnptr \<lbrace>arch_tcb_at P t\<rbrace>"
+  unfolding bind_notification_def set_bound_notification_def set_simple_ko_def
+  apply (wpsimp wp: set_object_wp get_object_wp get_simple_ko_wp)
+  by (fastforce simp: pred_tcb_at_def obj_at_def get_tcb_def)
+
+lemma unbind_maybe_notification_arch_tcb_at[wp]:
+  "unbind_maybe_notification ntfnptr \<lbrace>arch_tcb_at P t\<rbrace>"
+  unfolding unbind_maybe_notification_def
+  by wpsimp
+
+crunches blocked_cancel_ipc, cap_delete_one, cancel_signal
+  for arch_tcb_at[wp]: "arch_tcb_at P t"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma reply_cancel_ipc_arch_tcb_at[wp]:
+  "reply_cancel_ipc ntfnptr \<lbrace>arch_tcb_at P t\<rbrace>"
+  unfolding reply_cancel_ipc_def thread_set_def
+  apply (wpsimp wp: set_object_wp select_wp)
+  by (clarsimp simp: pred_tcb_at_def obj_at_def get_tcb_def)
+
+crunches cancel_ipc, send_ipc, receive_ipc
+  for arch_tcb_at[wp]: "arch_tcb_at P t"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma send_fault_ipc_arch_tcb_at[wp]:
+  "send_fault_ipc tptr fault \<lbrace>arch_tcb_at P t\<rbrace>"
+  unfolding send_fault_ipc_def thread_set_def Let_def
+  by (wpsimp wp: set_object_wp hoare_drop_imps hoare_vcg_all_lift_R
+           simp: pred_tcb_at_def obj_at_def get_tcb_def)
+
+crunches handle_fault, handle_interrupt, handle_vm_fault, handle_hypervisor_fault, send_signal
+  for arch_tcb_at[wp]: "arch_tcb_at P t"
+  (wp: mapM_x_wp_inv crunch_wps)
+
+crunches reschedule_required, set_scheduler_action, tcb_sched_action
+  for arch_tcb_at[wp]: "arch_tcb_at P t"
+  (simp: reschedule_required_def set_scheduler_action_def tcb_sched_action_def set_tcb_queue_def
+         get_tcb_queue_def)
+
+lemma thread_set_fault_arch_tcb_at[wp]:
+  "thread_set (tcb_fault_update f) r \<lbrace>arch_tcb_at P t\<rbrace>"
+  unfolding thread_set_def
+  by (wpsimp wp: set_object_wp simp: pred_tcb_at_def obj_at_def get_tcb_def)
+
+lemma do_reply_transfer_arch_tcb_at[wp]:
+  "do_reply_transfer sender receiver slot grant \<lbrace>arch_tcb_at P t\<rbrace>"
+  unfolding do_reply_transfer_def
+  by (wpsimp wp: gts_wp split_del: if_split)
+
+crunches send_ipc, send_fault_ipc, receive_ipc, handle_fault, handle_interrupt, handle_vm_fault,
+         handle_hypervisor_fault, send_signal, do_reply_transfer, cancel_all_ipc,
+         cancel_all_signals, unbind_maybe_notification, suspend, deleting_irq_handler,
+         unbind_notification
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (wp: valid_cur_vcpu_lift_weak crunch_wps)
+
+crunches init_arch_objects, reset_untyped_cap
+  for arch_state[wp]: "\<lambda>s. P (arch_state s)"
+  (wp: crunch_wps preemption_point_inv hoare_unless_wp mapME_x_wp'
+   simp: crunch_simps)
+
+crunches invoke_untyped
+  for cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
+  and active_cur_vcpu_of[wp]: "\<lambda>s. P (active_cur_vcpu_of s)"
+  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv
+   simp: crunch_simps mapM_x_def[symmetric] active_cur_vcpu_of_def)
+
+lemma invoke_untyped_valid_cur_vcpu:
+  "\<lbrace>valid_cur_vcpu and invs and valid_untyped_inv ui and ct_active\<rbrace>
+   invoke_untyped ui
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  apply (rule hoare_weaken_pre)
+   apply (rule valid_cur_vcpu_lift_ct_Q)
+    apply (rule_tac f=cur_thread in hoare_lift_Pf2)
+     apply (rule invoke_untyped_pred_tcb_at)
+    apply clarsimp
+    apply wpsimp
+   apply wpsimp
+  apply (fastforce simp: pred_tcb_at_def obj_at_def ct_in_state_def)
+  done
+
+lemma valid_cur_vcpu_is_original_cap_update[simp]:
+  "valid_cur_vcpu (is_original_cap_update f s) = valid_cur_vcpu s"
+  by (clarsimp simp: valid_cur_vcpu_def pred_tcb_at_def obj_at_def active_cur_vcpu_of_def)
+
+lemma active_cur_vcpu_of_arm_asid_table_update[simp]:
+  "P (active_cur_vcpu_of (s\<lparr>arch_state := arm_asid_table_update f (arch_state s)\<rparr>))
+   = P (active_cur_vcpu_of s)"
+  by (clarsimp simp: active_cur_vcpu_of_def)
+
+crunches cap_insert, cap_move
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (wp: valid_cur_vcpu_lift_weak)
+
+crunches suspend, unbind_notification, cap_swap_for_delete
+  for state_hyp_refs_of[wp]: "\<lambda>s. P (state_hyp_refs_of s)"
+  (wp: crunch_wps thread_set_hyp_refs_trivial select_wp simp: crunch_simps)
+
+lemma prepare_thread_delete_valid_cur_vcpu[wp]:
+  "\<lbrace>\<lambda>s. valid_cur_vcpu s \<and> sym_refs (state_hyp_refs_of s)\<rbrace>
+   prepare_thread_delete p
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  unfolding prepare_thread_delete_def arch_thread_get_def
+  sorry (* FIXME AARCH64 FPU
+  by (wpsimp wp: dissociate_vcpu_tcb_valid_cur_vcpu) *)
+
+crunches delete_asid_pool
+  for active_cur_vcpu_of[wp]: "\<lambda>s. P (active_cur_vcpu_of s)"
+  and cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+crunches store_pte, set_asid_pool
+  for active_cur_vcpu_of[wp]: "\<lambda>s. P (active_cur_vcpu_of s)"
+  and cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
+  (wp: crunch_wps simp: crunch_simps active_cur_vcpu_of_def)
+
+(* FIXME AARCH64 PTs
+crunches unmap_page, unmap_page_table, delete_asid
+  for active_cur_vcpu_of[wp]: "\<lambda>s. P (active_cur_vcpu_of s)"
+  and cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
+  (wp: crunch_wps valid_cur_vcpu_lift) *)
+
+(* FIXME AARCH64 invalidate_tlb_by_asid_va
+crunches delete_asid_pool, unmap_page, unmap_page_table, delete_asid
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (wp: valid_cur_vcpu_lift) *)
+
+(* FIXME AARCH64
+crunches vcpu_finalise, arch_finalise_cap, finalise_cap
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (simp: crunch_simps) *)
+
+crunches prepare_thread_delete, deleting_irq_handler, delete_asid_pool
+  for sym_refs_state_hyp_refs_of[wp]: "\<lambda>s. sym_refs (state_hyp_refs_of s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemmas store_pte_state_hyp_refs_of[wp] = store_pte_state_hyp_refs_of
+
+lemma unmap_page_state_hyp_refs_of[wp]:
+  "unmap_page pgsz asid vptr pptr \<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>"
+  unfolding unmap_page_def sorry (* FIXME AARCH64 lookup_pt_slot_def find_pd_for_asid_def
+  by (wpsimp wp: hoare_drop_imps mapM_wp_inv get_pde_wp store_pde_state_hyp_refs_of) *)
+
+crunches delete_asid, vcpu_finalise, unmap_page_table, finalise_cap
+  for state_hyp_refs_of[wp]: "\<lambda>s. sym_refs (state_hyp_refs_of s)"
+
+lemma preemption_point_state_hyp_refs_of[wp]:
+  "preemption_point \<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>"
+  by (wpsimp wp: preemption_point_inv)
+
+lemma preemption_point_valid_cur_vcpu[wp]:
+  "preemption_point \<lbrace>valid_cur_vcpu\<rbrace>"
+  apply (wpsimp wp: preemption_point_inv)
+    by (clarsimp simp: valid_cur_vcpu_def pred_tcb_at_def obj_at_def active_cur_vcpu_of_def)+
+
+crunches cap_swap_for_delete, empty_slot
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (wp: valid_cur_vcpu_lift_weak)
+
+lemma rec_del_sym_refs_state_hyp_refs_of[wp]:
+  "rec_del call \<lbrace>\<lambda>s. sym_refs (state_hyp_refs_of s)\<rbrace>"
+  by (rule rec_del_preservation; wpsimp)
+
+crunches cap_delete
+  for state_hyp_refs_of[wp]: "\<lambda>s. sym_refs (state_hyp_refs_of s)"
+
+lemma rec_del_valid_cur_vcpu[wp]:
+  "\<lbrace>\<lambda>s. valid_cur_vcpu s \<and> sym_refs (state_hyp_refs_of s)\<rbrace>
+   rec_del call
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
+  apply (rule_tac Q="\<lambda>_. ?pre" in hoare_post_imp, fastforce)
+  sorry (* FIXME AARCH64
+  by (rule rec_del_preservation; wpsimp) *)
+
+crunches cap_delete
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+
+lemma cap_revoke_valid_cur_vcpu[wp]:
+  "\<lbrace>\<lambda>s. valid_cur_vcpu s \<and> sym_refs (state_hyp_refs_of s)\<rbrace>
+   cap_revoke slot
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
+  apply (rule_tac Q="\<lambda>_. ?pre" in hoare_post_imp, fastforce)
+  by (wpsimp wp: cap_revoke_preservation)
+
+crunches cancel_badged_sends, invoke_irq_control, invoke_irq_handler
+  for arch_tcb_at[wp]: "arch_tcb_at P t"
+  and cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
+  and arch_state[wp]: "\<lambda>s. P (arch_state s)"
+  (wp: filterM_preserved)
+
+crunches store_pte, set_cap, set_mrs
+  for active_cur_vcpu_of[wp]: "\<lambda>s. P (active_cur_vcpu_of s)"
+  (simp: active_cur_vcpu_of_def)
+
+crunches perform_page_table_invocation, perform_page_invocation,
+         perform_asid_pool_invocation, invoke_vcpu_inject_irq, invoke_vcpu_read_register,
+         invoke_vcpu_write_register, invoke_vcpu_ack_vppi
+  for arch_tcb_at[wp]: "arch_tcb_at P t"
+  and cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
+  and active_cur_vcpu_of[wp]: "\<lambda>s. P (active_cur_vcpu_of s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+crunches cancel_badged_sends, invoke_irq_control, invoke_irq_handler, invoke_vcpu_inject_irq,
+         bind_notification
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (wp: valid_cur_vcpu_lift_weak)
+
+crunches perform_asid_pool_invocation, perform_page_table_invocation,
+         perform_page_invocation, invoke_vcpu_read_register,
+         invoke_vcpu_write_register, invoke_vcpu_ack_vppi
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (wp: valid_cur_vcpu_lift)
+
+lemma invoke_cnode_valid_cur_vcpu[wp]:
+  "\<lbrace>\<lambda>s. valid_cur_vcpu s \<and> sym_refs (state_hyp_refs_of s)\<rbrace>
+   invoke_cnode i
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  unfolding invoke_cnode_def
+  by (wpc | wpsimp wp: hoare_drop_imps hoare_vcg_all_lift)+
+
+lemma valid_cur_vcpu_trans_state[simp]:
+  "valid_cur_vcpu (trans_state f s) = valid_cur_vcpu s"
+  by (clarsimp simp: valid_cur_vcpu_def pred_tcb_at_def obj_at_def active_cur_vcpu_of_def)
+
+crunches restart, reschedule_required, possible_switch_to, thread_set_priority
+  for arch_tcb_at[wp]: "arch_tcb_at P t"
+  (simp: possible_switch_to_def set_tcb_queue_def get_tcb_queue_def)
+
+crunches restart, reschedule_required, possible_switch_to, thread_set_priority
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (wp: valid_cur_vcpu_lift_weak)
+
+crunches restart, arch_post_modify_registers, arch_get_sanitise_register_info
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+
+lemma thread_set_valid_cur_vcpu:
+  "(\<And>tcb. tcb_arch (f tcb) = tcb_arch tcb) \<Longrightarrow> thread_set f tptr \<lbrace>valid_cur_vcpu\<rbrace>"
+  apply (rule valid_cur_vcpu_lift_weak; (solves wpsimp)?)
+  unfolding thread_set_def
+  apply (wpsimp wp: set_object_wp)
+  apply (fastforce simp: pred_tcb_at_def obj_at_def get_tcb_def)
+  done
+
+lemma fault_handler_update_valid_cur_vcpu[wp]:
+  "option_update_thread thread (tcb_fault_handler_update \<circ> f) opt \<lbrace>valid_cur_vcpu\<rbrace>"
+  unfolding option_update_thread_def
+  by (wpsimp wp: thread_set_valid_cur_vcpu)
+
+lemma fault_handler_update_state_hyp_refs_of[wp]:
+  "option_update_thread thread (tcb_fault_handler_update \<circ> f) opt \<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>"
+  unfolding option_update_thread_def
+  by (fastforce intro: thread_set_hyp_refs_trivial split: option.splits)
+
+crunches set_mcpriority, set_priority
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (simp: set_priority_def)
+
+lemma ethread_set_state_hyp_refs_of[wp]:
+  "ethread_set f t \<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>"
+  unfolding ethread_set_def set_eobject_def
+  apply wp
+  apply (clarsimp dest!: get_tcb_SomeD)
+  done
+
+crunches tcb_sched_action, possible_switch_to, set_scheduler_action, reschedule_required
+  for state_hyp_refs_of[wp]: "\<lambda>s. P (state_hyp_refs_of s)"
+  (simp: tcb_sched_action_def set_tcb_queue_def get_tcb_queue_def possible_switch_to_def
+         reschedule_required_def set_scheduler_action_def)
+
+crunches set_mcpriority, set_priority
+  for state_hyp_refs_of[wp]: "\<lambda>s. P (state_hyp_refs_of s)"
+  (wp: thread_set_hyp_refs_trivial simp: set_priority_def thread_set_priority_def)
+
+lemma invoke_tcb_valid_cur_vcpu[wp]:
+  "\<lbrace>\<lambda>s. valid_cur_vcpu s \<and> sym_refs (state_hyp_refs_of s)\<rbrace>
+   invoke_tcb iv
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  apply (cases iv; clarsimp; (solves \<open>wpsimp wp: mapM_x_wp_inv\<close>)?)
+   defer
+   subgoal for tcb_ptr ntfn_ptr_opt
+     by (case_tac ntfn_ptr_opt; wpsimp)
+  \<comment> \<open>ThreadControl\<close>
+  apply (forward_inv_step wp: check_cap_inv)+
+  by (wpsimp wp: check_cap_inv hoare_drop_imps thread_set_hyp_refs_trivial thread_set_valid_cur_vcpu)
+
+crunches invoke_domain
+  for arch_state[wp]: "\<lambda>s. P (arch_state s)"
+  and arch_tcb_at[wp]: "arch_tcb_at P t"
+  and cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
+  and valid_cur_vcpu[wp]: valid_cur_vcpu
+  (wp: valid_cur_vcpu_lift_weak)
+
+crunches perform_asid_control_invocation
+  for cur_thread[wp]: "\<lambda>s. P (cur_thread s )"
+  and active_cur_vcpu_of[wp]: "\<lambda>s. P (active_cur_vcpu_of s)"
+  (simp: active_cur_vcpu_of_def)
+
+lemma perform_asid_control_invocation_valid_cur_vcpu:
+  "\<lbrace>valid_cur_vcpu and invs and valid_aci iv and ct_active\<rbrace>
+   perform_asid_control_invocation iv
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  apply (rule hoare_weaken_pre)
+   apply (rule valid_cur_vcpu_lift_ct_Q)
+    apply (rule_tac f=cur_thread in hoare_lift_Pf2)
+     apply (rule perform_asid_control_invocation_pred_tcb_at)
+    apply wpsimp
+   apply wpsimp
+  apply (fastforce simp: pred_tcb_at_def obj_at_def ct_in_state_def)
+  done
+
+lemma perform_vcpu_invocation_valid_cur_vcpu:
+  "\<lbrace>valid_cur_vcpu and invs\<rbrace> perform_vcpu_invocation iv \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  unfolding perform_vcpu_invocation_def
+  by (wpsimp wp: associate_vcpu_tcb_valid_cur_vcpu)
+
+lemma perform_invocation_valid_cur_vcpu[wp]:
+  "\<lbrace>valid_cur_vcpu and invs and valid_invocation iv and ct_active\<rbrace>
+   perform_invocation blocking call iv
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  apply (case_tac iv, simp_all; (solves wpsimp)?)
+   apply (wpsimp wp: invoke_untyped_valid_cur_vcpu)
+  unfolding arch_perform_invocation_def
+  apply (wpsimp wp: perform_vcpu_invocation_valid_cur_vcpu
+                    perform_asid_control_invocation_valid_cur_vcpu)
+  sorry (* FIXME AARCH64 not all invocations go through, likely missing crunches
+  apply (fastforce simp: valid_arch_inv_def)
+  done *)
+
+crunches reply_from_kernel, receive_signal
+  for valid_cur_vcpu[wp]: valid_cur_vcpu
+  (wp: valid_cur_vcpu_lift_weak)
+
+lemma handle_invocation_valid_cur_vcpu[wp]:
+  "\<lbrace>valid_cur_vcpu and invs and ct_active\<rbrace> handle_invocation calling blocking \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  unfolding handle_invocation_def
+  by (wp syscall_valid set_thread_state_ct_st
+      | simp add: split_def | wpc
+      | wp (once) hoare_drop_imps)+
+     (auto simp: ct_in_state_def elim: st_tcb_ex_cap)
+
+lemma handle_recv_valid_cur_vcpu[wp]:
+  "handle_recv is_blocking \<lbrace>valid_cur_vcpu\<rbrace>"
+  unfolding handle_recv_def Let_def ep_ntfn_cap_case_helper delete_caller_cap_def
+  by (wpsimp wp: hoare_drop_imps)
+
+lemma handle_event_valid_cur_vcpu:
+  "\<lbrace>valid_cur_vcpu and invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
+   handle_event e
+   \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
+  apply (cases e; clarsimp; (solves wpsimp)?)
+  unfolding handle_call_def handle_send_def handle_reply_def handle_yield_def
+  by (wpsimp wp: get_cap_wp)+
+
+lemma call_kernel_valid_cur_vcpu:
+  "\<lbrace>valid_cur_vcpu and invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
+   (call_kernel e) :: (unit, unit) s_monad
+   \<lbrace>\<lambda>_ . valid_cur_vcpu\<rbrace>"
+  unfolding call_kernel_def
+  apply (simp flip: bind_assoc)
+  by (wpsimp wp: handle_event_valid_cur_vcpu hoare_vcg_if_lift2 hoare_drop_imps
+      | strengthen invs_valid_idle)+
+
+lemma call_kernel_valid_cur_vcpu_det_ext:
+  "\<lbrace>valid_cur_vcpu and invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
+   (call_kernel e) :: (unit, det_ext) s_monad
+   \<lbrace>\<lambda>_ . valid_cur_vcpu\<rbrace>"
+  unfolding call_kernel_def
+  apply (simp flip: bind_assoc)
+  by (wpsimp wp: handle_event_valid_cur_vcpu hoare_vcg_if_lift2 hoare_drop_imps
+      | strengthen invs_valid_idle)+
+
+end
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpaceEntries_AI.thy
@@ -47,6 +47,17 @@ lemma set_object_valid_vspace_objs'[wp]:
 crunch valid_vspace_objs'[wp]: cap_insert, cap_swap_for_delete,empty_slot "valid_vspace_objs'"
   (wp: crunch_wps simp: crunch_simps ignore:set_object)
 
+crunches
+  vcpu_save, vcpu_restore, vcpu_enable, get_vcpu, set_vcpu, vcpu_disable, vcpu_read_reg,
+  read_vcpu_register,write_vcpu_register
+  for valid_vspace_objs'[wp]: "valid_vspace_objs'"
+  (wp: crunch_wps simp: crunch_simps ignore: set_object do_machine_op)
+
+lemma vcpu_switch_valid_vspace_objs'[wp]:
+  "vcpu_switch v \<lbrace> valid_vspace_objs'\<rbrace>"
+  unfolding vcpu_switch_def
+  by wpsimp
+
 lemma valid_pt_entries_invalid[simp]:
   "valid_pt_entries (\<lambda>x. InvalidPTE)"
    by (simp add:valid_entries_def)
@@ -195,6 +206,16 @@ lemma invoke_untyped_valid_vspace_objs'[wp]:
 
 crunches store_asid_pool_entry
   for valid_vspace_objs'[wp]: "valid_vspace_objs'"
+
+crunch valid_vspace_objs'[wp]: perform_vcpu_invocation "valid_vspace_objs'"
+  (ignore: delete_objects wp: hoare_drop_imps)
+
+lemma decode_vcpu_invocation_valid_vspace_objs'[wp]:
+  "\<lbrace> valid_vspace_objs' \<rbrace>
+     decode_vcpu_invocation label args vcap excaps
+   \<lbrace>\<lambda>_. valid_vspace_objs' \<rbrace>, -"
+  unfolding decode_vcpu_invocation_def
+  by (wpsimp wp: get_cap_wp)
 
 lemma perform_asid_pool_invocation_valid_vspace_objs'[wp]:
   "\<lbrace> valid_vspace_objs' and valid_arch_state and pspace_aligned and

--- a/proof/invariant-abstract/AARCH64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpaceEntries_AI.thy
@@ -1,0 +1,343 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchVSpaceEntries_AI
+imports VSpaceEntries_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+primrec pte_range :: "pte \<Rightarrow> pt_index \<Rightarrow> pt_index set" where
+  "pte_range (InvalidPTE) p = {}"
+| "pte_range (PagePTE ptr x y) p = {p}"
+| "pte_range (PageTablePTE ptr x) p = {p}"
+
+abbreviation "valid_pt_entries \<equiv> \<lambda>pt. valid_entries pte_range pt"
+
+definition obj_valid_vspace :: "kernel_object \<Rightarrow> bool" where
+ "obj_valid_vspace obj \<equiv> case obj of
+    ArchObj (PageTable pt) \<Rightarrow> valid_pt_entries pt
+  | _ \<Rightarrow> True"
+
+lemmas obj_valid_vspace_simps[simp]
+    = obj_valid_vspace_def
+        [split_simps Structures_A.kernel_object.split
+                     arch_kernel_obj.split]
+
+abbreviation
+  valid_vspace_objs' :: "'z state \<Rightarrow> bool"
+where
+ "valid_vspace_objs' s \<equiv> \<forall>x \<in> ran (kheap s). obj_valid_vspace x"
+
+lemma set_object_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs' and K (obj_valid_vspace obj)\<rbrace>
+      set_object ptr obj
+   \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  apply (simp add: set_object_def, wp assert_inv)
+  apply (auto simp: fun_upd_def[symmetric] del: ballI elim: ball_ran_updI)
+  done
+
+crunch valid_vspace_objs'[wp]: cap_insert, cap_swap_for_delete,empty_slot "valid_vspace_objs'"
+  (wp: crunch_wps simp: crunch_simps ignore:set_object)
+
+lemma mapM_x_store_pte_updates:
+  "\<forall>x \<in> set xs. f x && ~~ mask pt_bits = p \<Longrightarrow>
+   \<lbrace>\<lambda>s. (\<not> pt_at p s \<longrightarrow> Q s) \<and>
+        (\<forall>pt. ko_at (ArchObj (PageTable pt)) p s
+           \<longrightarrow> Q (s \<lparr> kheap := (kheap s) (p := Some (ArchObj (PageTable (\<lambda>y. if y \<in> (\<lambda>x.
+         ucast (f x && mask pt_bits >> pte_bits)) ` set xs then pte else pt y)))) \<rparr>))\<rbrace>
+     mapM_x (\<lambda>x. store_pte (f x) pte) xs
+   \<lbrace>\<lambda>_. Q\<rbrace>"
+  apply (induct xs)
+   apply (simp add: mapM_x_Nil)
+   apply wp
+   apply (clarsimp simp: obj_at_def fun_upd_idem)
+  apply (simp add: mapM_x_Cons)
+  apply (rule hoare_seq_ext, assumption)
+  apply (thin_tac "valid P f Q" for P f Q)
+  apply (simp add: store_pte_def set_pt_def set_object_def word_size_bits_def)
+  apply (wp get_pt_wp get_object_wp)
+  apply (clarsimp simp: obj_at_def a_type_simps)
+  apply (erule rsubst[where P=Q])
+  apply (rule abstract_state.fold_congs[OF refl refl])
+  apply (rule ext, clarsimp)
+  apply (rule ext, clarsimp)
+  done
+
+lemma valid_pt_entries_invalid[simp]:
+  "valid_pt_entries (\<lambda>x. InvalidPTE)"
+   by (simp add:valid_entries_def)
+
+lemma valid_vspace_objs'_ptD:
+  "\<lbrakk>valid_vspace_objs' s;
+    kheap s ptr = Some (ArchObj (arch_kernel_obj.PageTable pt))\<rbrakk>
+   \<Longrightarrow> valid_pt_entries pt"
+  by (fastforce simp:ran_def)
+
+lemma store_pte_valid_vspace_objs'[wp]:
+  "store_pte p pte \<lbrace>valid_vspace_objs'\<rbrace>"
+  apply (simp add: store_pte_def set_pt_def, wp get_object_wp)
+  apply (clarsimp simp: obj_at_def)
+  apply (rule valid_entries_overwrite_0)
+   apply (fastforce simp:ran_def)
+  apply (drule bspec)
+   apply fastforce
+  apply (case_tac "pt pa"; case_tac pte; simp)
+  done
+
+lemma unmap_page_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs'\<rbrace> unmap_page sz asid vptr pptr \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  apply (simp add: unmap_page_def mapM_discarded
+             cong: vmpage_size.case_cong)
+  apply (wpsimp wp: store_pte_valid_vspace_objs')
+  done
+
+lemma unmap_page_table_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs'\<rbrace> unmap_page_table asid vptr pt \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  apply (simp add: unmap_page_table_def)
+  apply (wp get_object_wp store_pte_valid_vspace_objs' | wpc)+
+  apply (simp add: obj_at_def)
+  done
+
+crunch valid_vspace_objs'[wp]: set_simple_ko "valid_vspace_objs'"
+  (wp: crunch_wps)
+
+crunch valid_vspace_objs'[wp]: finalise_cap, cap_swap_for_delete, empty_slot "valid_vspace_objs'"
+  (wp: crunch_wps select_wp preemption_point_inv simp: crunch_simps unless_def ignore:set_object)
+
+lemma preemption_point_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs'\<rbrace> preemption_point \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  by (wp preemption_point_inv | simp)+
+
+lemmas cap_revoke_preservation_valid_vspace_objs = cap_revoke_preservation[OF _,
+                                                          where E=valid_vspace_objs',
+                                                          simplified, THEN validE_valid]
+
+lemmas rec_del_preservation_valid_vspace_objs = rec_del_preservation[OF _ _ _ _,
+                                                    where P=valid_vspace_objs', simplified]
+
+crunch valid_vspace_objs'[wp]: cap_delete, cap_revoke "valid_vspace_objs'"
+  (rule: cap_revoke_preservation_valid_vspace_objs)
+
+lemma copy_global_mappings_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs' and valid_arch_state and pspace_aligned
+            and K (is_aligned p pt_bits)\<rbrace>
+       copy_global_mappings p \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  unfolding copy_global_mappings_def
+  by (wpsimp wp: mapM_x_wp')
+
+lemma in_pte_rangeD:
+  "x \<in> pte_range v y \<Longrightarrow> x = y"
+  by (case_tac v,simp_all split:if_splits)
+
+lemma non_invalid_in_pte_range:
+  "pte \<noteq> InvalidPTE
+  \<Longrightarrow> x \<in> pte_range pte x"
+  by (case_tac pte,simp_all)
+
+crunch valid_vspace_objs'[wp]: cancel_badged_sends "valid_vspace_objs'"
+  (simp: crunch_simps filterM_mapM wp: crunch_wps ignore: filterM)
+
+crunch valid_vspace_objs'[wp]: cap_move, cap_insert "valid_vspace_objs'"
+
+lemma invoke_cnode_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs' and invs and valid_cnode_inv i\<rbrace> invoke_cnode i \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  apply (simp add: invoke_cnode_def)
+  apply (rule hoare_pre)
+   apply (wp get_cap_wp | wpc | simp split del: if_split)+
+  done
+
+crunch valid_vspace_objs'[wp]: invoke_tcb "valid_vspace_objs'"
+  (wp: check_cap_inv crunch_wps simp: crunch_simps
+       ignore: check_cap_at)
+
+lemma invoke_domain_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs'\<rbrace> invoke_domain t d \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  by (simp add: invoke_domain_def | wp)+
+
+crunch valid_vspace_objs'[wp]: set_extra_badge, transfer_caps_loop "valid_vspace_objs'"
+  (rule: transfer_caps_loop_pres)
+
+crunch valid_vspace_objs'[wp]: send_ipc, send_signal,
+    do_reply_transfer, invoke_irq_control, invoke_irq_handler "valid_vspace_objs'"
+  (wp: crunch_wps simp: crunch_simps
+         ignore: clearMemory const_on_failure set_object)
+
+lemma valid_vspace_objs'_trans_state[simp]: "valid_vspace_objs' (trans_state f s) = valid_vspace_objs' s"
+  apply (simp add: obj_valid_vspace_def)
+  done
+
+lemma retype_region_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs'\<rbrace> retype_region ptr bits o_bits type dev \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  apply (simp add: retype_region_def split del: if_split)
+  apply (wp | simp only: valid_vspace_objs'_trans_state trans_state_update[symmetric])+
+  apply (clarsimp simp: retype_addrs_fold foldr_upd_app_if ranI
+                 elim!: ranE split: if_split_asm simp del:fun_upd_apply)
+  apply (simp add: default_object_def default_arch_object_def
+            split: Structures_A.kernel_object.splits
+    Structures_A.apiobject_type.split aobject_type.split)+
+  done
+
+lemma detype_valid_vspace[elim!]:
+  "valid_vspace_objs' s \<Longrightarrow> valid_vspace_objs' (detype S s)"
+  by (auto simp add: detype_def ran_def)
+
+crunch valid_vspace_objs'[wp]: create_cap "valid_vspace_objs'"
+  (ignore: clearMemory simp: crunch_simps)
+
+lemma init_arch_objects_valid_vspace:
+  "\<lbrace>valid_vspace_objs' and pspace_aligned and valid_arch_state
+           and K (orefs = retype_addrs ptr type n us)
+           and K (range_cover ptr sz (obj_bits_api type us) n)\<rbrace>
+     init_arch_objects type ptr n obj_sz orefs
+   \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  unfolding init_arch_objects_def by wpsimp
+
+lemma delete_objects_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs'\<rbrace> delete_objects ptr bits \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  by (rule delete_objects_reduct) (wp detype_valid_vspace)
+
+crunch valid_vspace_objs'[wp]: reset_untyped_cap "valid_vspace_objs'"
+  (wp: mapME_x_inv_wp crunch_wps simp: crunch_simps unless_def)
+
+lemma invoke_untyped_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs' and invs and ct_active
+          and valid_untyped_inv ui\<rbrace>
+       invoke_untyped ui
+   \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  apply (rule hoare_pre, rule invoke_untyped_Q)
+      apply (wp init_arch_objects_valid_vspace | simp)+
+     apply (auto simp: post_retype_invs_def split: if_split_asm)[1]
+    apply (wp | simp)+
+  done
+
+crunches store_asid_pool_entry
+  for valid_vspace_objs'[wp]: "valid_vspace_objs'"
+
+lemma perform_asid_pool_invocation_valid_vspace_objs'[wp]:
+  "\<lbrace> valid_vspace_objs' and valid_arch_state and pspace_aligned and
+     (\<lambda>s. valid_caps (caps_of_state s) s) \<rbrace>
+   perform_asid_pool_invocation iv
+   \<lbrace> \<lambda>_. valid_vspace_objs' \<rbrace>"
+  apply (simp add: perform_asid_pool_invocation_def)
+  apply (wpsimp wp: get_cap_wp)
+  apply (simp add: cte_wp_at_caps_of_state)
+  apply (drule (1) valid_capsD)
+  apply (clarsimp simp: is_ArchObjectCap_def is_PageTableCap_def valid_cap_def)
+  apply (erule (1) is_aligned_pt)
+  done
+
+crunch valid_vspace_objs'[wp]: perform_asid_pool_invocation,
+     perform_asid_control_invocation "valid_vspace_objs'"
+  (ignore: delete_objects set_object
+       wp: static_imp_wp select_wp crunch_wps
+     simp: crunch_simps unless_def)
+
+lemma pte_range_interD:
+ "pte_range pte p \<inter> pte_range pte' p' \<noteq> {}
+  \<Longrightarrow> pte \<noteq> InvalidPTE \<and> pte' \<noteq> InvalidPTE
+      \<and> p = p'"
+  apply (drule int_not_emptyD)
+  apply (case_tac pte,simp_all split:if_splits)
+   apply (case_tac pte',simp_all split:if_splits)
+  apply (case_tac pte',simp_all split:if_splits)
+  done
+
+lemma perform_page_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs' and valid_page_inv pinv\<rbrace>
+        perform_page_invocation pinv \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  apply (simp add: perform_page_invocation_def)
+  apply (cases pinv,
+         simp_all add: mapM_discarded
+                split: sum.split arch_cap.split option.split,
+         safe intro!: hoare_gen_asm hoare_gen_asm[unfolded K_def],
+         simp_all add: mapM_x_Nil mapM_x_Cons mapM_x_map)
+    apply (wp store_pte_valid_vspace_objs' hoare_vcg_imp_lift[OF set_cap_arch_obj_neg]
+              hoare_vcg_all_lift
+           | clarsimp simp: cte_wp_at_weakenE[OF _ TrueI] obj_at_def swp_def valid_page_inv_def
+                            valid_slots_def perform_pg_inv_map_def perform_pg_inv_unmap_def
+                            perform_pg_inv_get_addr_def
+                     split: pte.splits
+           | wpc
+           | wp (once) hoare_drop_imps)+
+  done
+
+lemma perform_page_table_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs' and valid_pti pinv\<rbrace>
+      perform_page_table_invocation pinv \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  apply (simp add: perform_page_table_invocation_def split_def perform_pt_inv_map_def
+                   perform_pt_inv_unmap_def
+             cong: page_table_invocation.case_cong
+                   option.case_cong cap.case_cong arch_cap.case_cong)
+  apply (rule hoare_pre)
+   apply (wp hoare_vcg_ex_lift store_pte_valid_vspace_objs'
+             set_cap_arch_obj hoare_vcg_all_lift mapM_x_wp'
+              | wpc
+              | simp add: swp_def
+              | strengthen all_imp_ko_at_from_ex_strg
+              | wp (once) hoare_drop_imps)+
+  done
+
+lemma perform_invocation_valid_vspace_objs'[wp]:
+  "\<lbrace>invs and ct_active and valid_invocation i and valid_vspace_objs'\<rbrace>
+      perform_invocation blocking call i
+         \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  apply (cases i, simp_all)
+  apply (wp send_signal_interrupt_states | simp)+
+  apply (clarsimp simp:)
+  apply (wp | wpc | simp)+
+  apply (simp add: arch_perform_invocation_def)
+  apply (wp | wpc | simp)+
+  apply (auto simp: valid_arch_inv_def intro: valid_objs_caps)
+  done
+
+crunch valid_vspace_objs'[wp]: handle_fault, reply_from_kernel "valid_vspace_objs'"
+  (simp: crunch_simps wp: crunch_wps)
+
+lemma handle_invocation_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs' and invs and ct_active\<rbrace>
+        handle_invocation calling blocking \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  apply (simp add: handle_invocation_def)
+  apply (wp syscall_valid set_thread_state_ct_st
+               | simp add: split_def | wpc
+               | wp (once) hoare_drop_imps)+
+  apply (auto simp: ct_in_state_def elim: st_tcb_ex_cap)
+  done
+
+
+crunch valid_vspace_objs'[wp]: activate_thread,switch_to_thread, handle_hypervisor_fault,
+       switch_to_idle_thread, handle_call, handle_recv, handle_reply,
+       handle_send, handle_yield, handle_interrupt "valid_vspace_objs'"
+  (simp: crunch_simps wp: crunch_wps alternative_valid select_wp OR_choice_weak_wp select_ext_weak_wp
+      ignore: without_preemption getActiveIRQ resetTimer ackInterrupt
+              OR_choice set_scheduler_action)
+
+lemma handle_event_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs' and invs and ct_active\<rbrace> handle_event e \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
+  by (case_tac e; simp) (wpsimp simp: Let_def handle_vm_fault_def | wp (once) hoare_drop_imps)+
+
+lemma schedule_valid_vspace_objs'[wp]:
+  "\<lbrace>valid_vspace_objs'\<rbrace> schedule :: (unit,unit) s_monad \<lbrace>\<lambda>_. valid_vspace_objs'\<rbrace>"
+  apply (simp add: schedule_def allActiveTCBs_def)
+  apply (wp alternative_wp select_wp)
+  apply simp
+  done
+
+lemma call_kernel_valid_vspace_objs'[wp]:
+  "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s) and valid_vspace_objs'\<rbrace>
+      (call_kernel e) :: (unit,unit) s_monad
+   \<lbrace>\<lambda>_. valid_vspace_objs'\<rbrace>"
+  apply (cases e, simp_all add: call_kernel_def)
+      apply (rule hoare_pre)
+       apply (wp | simp add: Let_def handle_vm_fault_def | wpc
+                 | rule conjI | clarsimp simp: ct_in_state_def
+                 | erule pred_tcb_weakenE
+                 | wp (once) hoare_drop_imps)+
+  done
+
+end
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
@@ -1,0 +1,1972 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(*
+RISCV-specific VSpace invariants
+*)
+
+theory ArchVSpace_AI
+imports VSpacePre_AI
+begin
+
+context Arch begin global_naming RISCV64
+
+definition kernel_mappings_only :: "(pt_index \<Rightarrow> pte) \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
+  "kernel_mappings_only pt s \<equiv>
+     has_kernel_mappings pt s \<and> (\<forall>idx. idx \<notin> kernel_mapping_slots \<longrightarrow> pt idx = InvalidPTE)"
+
+lemma find_vspace_for_asid_wp[wp]:
+  "\<lbrace>\<lambda>s. (vspace_for_asid asid s = None \<longrightarrow> E InvalidRoot s) \<and>
+        (\<forall>pt. vspace_for_asid asid s = Some pt \<longrightarrow> Q pt s) \<rbrace>
+   find_vspace_for_asid asid \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  unfolding find_vspace_for_asid_def
+  by wpsimp
+
+crunch pspace_in_kernel_window[wp]: perform_page_invocation "pspace_in_kernel_window"
+  (simp: crunch_simps wp: crunch_wps)
+
+lemma asid_word_bits [simp]: "asid_bits < word_bits"
+  by (simp add: asid_bits_def word_bits_def)
+
+lemma vspace_at_asid_vs_lookup:
+  "vspace_at_asid asid pt s \<Longrightarrow>
+   vs_lookup_table max_pt_level asid 0 s = Some (max_pt_level, pt)"
+  by (simp add: vs_lookup_table_def vspace_at_asid_def vspace_for_asid_def in_omonad)
+
+lemma pt_at_asid_unique:
+  "\<lbrakk> vspace_at_asid asid pt s; vspace_at_asid asid' pt s;
+     unique_table_refs s;
+     valid_vs_lookup s; valid_vspace_objs s; valid_asid_table s;
+     pspace_aligned s; valid_caps (caps_of_state s) s \<rbrakk>
+       \<Longrightarrow> asid = asid'"
+  by (drule vspace_at_asid_vs_lookup)+ (drule (1) unique_vs_lookup_table; simp)
+
+lemma pt_at_asid_unique2:
+  "\<lbrakk> vspace_at_asid asid pt s; vspace_at_asid asid pt' s \<rbrakk> \<Longrightarrow> pt = pt'"
+  by (clarsimp simp: vspace_at_asid_def)
+
+lemma dmo_pt_at_asid[wp]:
+  "do_machine_op f \<lbrace>vspace_at_asid a pt\<rbrace>"
+  by (wpsimp simp: do_machine_op_def vspace_at_asid_def)
+
+crunch valid_vs_lookup[wp]: do_machine_op "valid_vs_lookup"
+
+lemmas ackInterrupt_irq_masks = no_irq[OF no_irq_ackInterrupt]
+
+crunches sfence, hwASIDFlush, setVSpaceRoot
+  for underlying_memory_inv[wp]: "\<lambda>ms. P (underlying_memory ms)"
+
+
+lemma ucast_ucast_low_bits:
+  fixes x :: machine_word
+  shows "x \<le> 2^asid_low_bits - 1 \<Longrightarrow> ucast (ucast x:: asid_low_index) = x"
+  apply (simp add: ucast_ucast_mask)
+  apply (rule less_mask_eq)
+  apply (subst (asm) word_less_sub_le)
+   apply (simp add: asid_low_bits_def word_bits_def)
+  apply (simp add: asid_low_bits_def)
+  done
+
+lemma asid_high_bits_of_or:
+  "x \<le> 2^asid_low_bits - 1 \<Longrightarrow> asid_high_bits_of (base || x) = asid_high_bits_of base"
+  apply (rule word_eqI)
+  apply (drule le_2p_upper_bits)
+   apply (simp add: asid_low_bits_def word_bits_def)
+  apply (simp add: asid_high_bits_of_def word_size nth_ucast nth_shiftr asid_low_bits_def word_bits_def)
+  done
+
+lemma vs_lookup_clear_asid_table:
+  "vs_lookup_table bot_level asid vref (s\<lparr>arch_state := arch_state s \<lparr>riscv_asid_table :=
+                                            (riscv_asid_table (arch_state s)) (pptr := None)\<rparr>\<rparr>)
+     = Some (level, p)
+   \<Longrightarrow> vs_lookup_table bot_level asid vref s = Some (level, p)"
+  by (fastforce simp: vs_lookup_table_def in_omonad pool_for_asid_def split: if_split_asm)
+
+lemma vs_lookup_target_clear_asid_table:
+  "vs_lookup_target bot_level asid vref (s\<lparr>arch_state := arch_state s \<lparr>riscv_asid_table :=
+                                            (riscv_asid_table (arch_state s)) (pptr := None)\<rparr>\<rparr>)
+     = Some (level, p)
+  \<Longrightarrow> vs_lookup_target bot_level asid vref s = Some (level, p)"
+  apply (clarsimp simp: vs_lookup_target_def in_omonad vs_lookup_slot_def split: if_split_asm)
+   apply (fastforce dest!: vs_lookup_clear_asid_table)
+  apply (erule disjE, fastforce dest!: vs_lookup_clear_asid_table)
+  apply clarify
+  apply (drule vs_lookup_clear_asid_table)
+  apply simp
+  apply blast
+  done
+
+lemma valid_arch_state_unmap_strg:
+  "valid_arch_state s \<longrightarrow>
+   valid_arch_state(s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := (riscv_asid_table (arch_state s))(ptr := None)\<rparr>\<rparr>)"
+  apply (clarsimp simp: valid_arch_state_def valid_asid_table_def)
+  apply (rule conjI)
+   apply (clarsimp simp add: ran_def)
+   apply blast
+  apply (clarsimp simp: inj_on_def)
+  done
+
+
+lemma valid_vspace_objs_unmap_strg:
+  "valid_vspace_objs s \<longrightarrow>
+   valid_vspace_objs(s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := (riscv_asid_table (arch_state s))(ptr := None)\<rparr>\<rparr>)"
+  apply (clarsimp simp: valid_vspace_objs_def)
+  apply (blast dest: vs_lookup_clear_asid_table)
+  done
+
+
+lemma valid_vs_lookup_unmap_strg:
+  "valid_vs_lookup s \<longrightarrow>
+   valid_vs_lookup(s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := (riscv_asid_table (arch_state s))(ptr := None)\<rparr>\<rparr>)"
+  apply (clarsimp simp: valid_vs_lookup_def)
+  apply (blast dest: vs_lookup_target_clear_asid_table)
+  done
+
+lemma asid_high_bits_shl:
+  "is_aligned base asid_low_bits \<Longrightarrow> ucast (asid_high_bits_of base) << asid_low_bits = base"
+  unfolding asid_high_bits_of_def asid_low_bits_def is_aligned_mask
+  by word_eqI_solve
+
+lemma valid_asid_map_unmap:
+  "valid_asid_map s \<and> is_aligned base asid_low_bits \<longrightarrow>
+   valid_asid_map(s\<lparr>arch_state := arch_state s\<lparr>riscv_asid_table := (riscv_asid_table (arch_state s))(asid_high_bits_of base := None)\<rparr>\<rparr>)"
+  by (clarsimp simp: valid_asid_map_def)
+
+lemma asid_low_bits_word_bits:
+  "asid_low_bits < word_bits"
+  by (simp add: asid_low_bits_def word_bits_def)
+
+lemma valid_vs_lookup_arch_update:
+  "riscv_asid_table (f (arch_state s)) = riscv_asid_table (arch_state s) \<and>
+   riscv_kernel_vspace (f (arch_state s)) = riscv_kernel_vspace (arch_state s)
+     \<Longrightarrow> valid_vs_lookup (arch_state_update f s) = valid_vs_lookup s"
+  by (simp add: valid_vs_lookup_def)
+
+definition valid_unmap :: "vmpage_size \<Rightarrow> asid * vspace_ref \<Rightarrow> bool" where
+  "valid_unmap sz \<equiv> \<lambda>(asid, vptr). 0 < asid \<and> is_aligned vptr (pageBitsForSize sz)"
+
+definition
+  "parent_for_refs \<equiv> \<lambda>(_, slot) cap.
+     \<exists>m. cap = ArchObjectCap (PageTableCap (table_base slot) m) \<and> m \<noteq> None"
+
+definition
+  "same_ref \<equiv> \<lambda>(pte, slot) cap s.
+     ((\<exists>p. pte_ref pte = Some p \<and> obj_refs cap = {p}) \<or> pte = InvalidPTE) \<and>
+     (\<exists>level asid vref. vs_cap_ref cap = Some (asid, vref_for_level vref level) \<and>
+                        vs_lookup_slot level asid vref s = Some (level, slot) \<and>
+                        vref \<in> user_region \<and> level \<le> max_pt_level)"
+
+definition
+  "valid_page_inv pg_inv \<equiv> case pg_inv of
+    PageMap acap ptr m \<Rightarrow>
+      cte_wp_at (is_arch_update (ArchObjectCap acap)) ptr
+      and (cte_wp_at (\<lambda>c. vs_cap_ref c = None) ptr or (\<lambda>s. cte_wp_at (\<lambda>c. same_ref m c s) ptr s))
+      and cte_wp_at is_frame_cap ptr
+      and same_ref m (ArchObjectCap acap)
+      and valid_slots m
+      and valid_arch_cap acap
+      and K (is_PagePTE (fst m) \<or> fst m = InvalidPTE)
+      and (\<lambda>s. \<exists>slot. cte_wp_at (parent_for_refs m) slot s)
+  | PageUnmap acap cslot \<Rightarrow>
+     \<lambda>s. \<exists>dev r R sz m.
+            acap = FrameCap r R sz dev m \<and>
+            case_option True (valid_unmap sz) m \<and>
+            cte_wp_at ((=) (ArchObjectCap acap)) cslot s \<and>
+            valid_arch_cap acap s
+  | PageGetAddr ptr \<Rightarrow> \<top>"
+
+definition
+  "valid_pti pti \<equiv> case pti of
+     PageTableMap acap cslot pte pt_slot \<Rightarrow>
+       pte_at pt_slot and K (wellformed_pte pte \<and> is_PageTablePTE pte) and
+       valid_arch_cap acap and
+       cte_wp_at (\<lambda>c. is_arch_update (ArchObjectCap acap) c \<and> cap_asid c = None) cslot and
+       invalid_pte_at pt_slot and
+       (\<lambda>s. \<exists>p' level asid vref.
+                vs_cap_ref_arch acap = Some (asid, vref_for_level vref level)
+                \<and> vs_lookup_slot level asid vref s = Some (level, pt_slot)
+                \<and> valid_pte level pte s
+                \<and> pte_ref pte = Some p' \<and> obj_refs (ArchObjectCap acap) = {p'}
+                \<and> (\<exists>ao. ko_at (ArchObj ao) p' s \<and> valid_vspace_obj (level-1) ao s)
+                \<and> pts_of s p' = Some empty_pt
+                \<and> vref \<in> user_region) and
+       K (is_PageTableCap acap \<and> cap_asid_arch acap \<noteq> None)
+   | PageTableUnmap acap cslot \<Rightarrow>
+       cte_wp_at ((=) (ArchObjectCap acap)) cslot
+       and real_cte_at cslot
+       and valid_arch_cap acap
+       and is_final_cap' (ArchObjectCap acap)
+       and K (is_PageTableCap acap)
+       and (\<lambda>s. \<forall>asid vref. vs_cap_ref_arch acap = Some (asid, vref) \<longrightarrow>
+                            vspace_for_asid asid s \<noteq> aobj_ref acap)"
+
+crunches unmap_page
+  for aligned [wp]: pspace_aligned
+  and "distinct" [wp]: pspace_distinct
+  and valid_objs[wp]: valid_objs
+  and caps_of_state[wp]: "\<lambda>s. P (caps_of_state s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma set_cap_valid_slots[wp]:
+  "set_cap cap p \<lbrace>valid_slots slots\<rbrace>"
+  apply (cases slots, clarsimp simp: valid_slots_def)
+  apply (wpsimp wp: hoare_vcg_ball_lift hoare_vcg_all_lift hoare_vcg_imp_lift')
+  apply blast
+  done
+
+lemma pt_lookup_from_level_inv[wp]:
+  "\<lbrace>Q and E\<rbrace> pt_lookup_from_level level pt_ptr vptr target_pt_ptr \<lbrace>\<lambda>_. Q\<rbrace>,\<lbrace>\<lambda>_. E\<rbrace>"
+proof (induct level arbitrary: pt_ptr)
+  case 0
+  then show ?case by (wpsimp simp: pt_lookup_from_level_simps)
+next
+  case (minus level)
+  note IH = minus(1)
+  from \<open>0 < level\<close>  show ?case by (subst pt_lookup_from_level_simps) (wpsimp wp: IH)
+qed
+
+crunches unmap_page_table
+  for aligned[wp]: pspace_aligned
+  and valid_objs[wp]: valid_objs
+  and "distinct"[wp]: pspace_distinct
+  and caps_of_state[wp]: "\<lambda>s. P (caps_of_state s)"
+  and typ_at[wp]: "\<lambda>s. P (typ_at T p s)"
+  (wp: crunch_wps)
+
+
+definition
+  "valid_apinv ap \<equiv> case ap of
+    Assign asid p slot \<Rightarrow>
+      (\<lambda>s. \<exists>pool. asid_pools_of s p = Some pool \<and> pool (ucast asid) = None)
+      and cte_wp_at (\<lambda>cap. is_pt_cap cap \<and> cap_asid cap = None) slot
+      and K (0 < asid)
+      and (\<lambda>s. pool_for_asid asid s = Some p)"
+
+crunch device_state_inv[wp]: ackInterrupt "\<lambda>ms. P (device_state ms)"
+
+lemmas setIRQTrigger_irq_masks = no_irq[OF no_irq_setIRQTrigger]
+
+lemma dmo_setIRQTrigger_invs[wp]: "\<lbrace>invs\<rbrace> do_machine_op (setIRQTrigger irq b) \<lbrace>\<lambda>y. invs\<rbrace>"
+  apply (wp dmo_invs)
+   apply (simp add: machine_op_lift_device_state setIRQTrigger_def)
+  apply safe
+   apply (drule_tac Q="\<lambda>_ m'. underlying_memory m' p = underlying_memory m p" in use_valid)
+     apply ((wpsimp simp: setIRQTrigger_def machine_op_lift_def machine_rest_lift_def split_def)+)[3]
+  apply (erule (1) use_valid[OF _ setIRQTrigger_irq_masks])
+  done
+
+lemma dmo_ackInterrupt[wp]: "\<lbrace>invs\<rbrace> do_machine_op (ackInterrupt irq) \<lbrace>\<lambda>y. invs\<rbrace>"
+  apply (wp dmo_invs)
+  apply safe
+   apply (drule_tac Q="\<lambda>_ m'. underlying_memory m' p = underlying_memory m p" in use_valid)
+     apply ((clarsimp simp: ackInterrupt_def machine_op_lift_def
+                            machine_rest_lift_def split_def | wp)+)[3]
+  apply(erule (1) use_valid[OF _ ackInterrupt_irq_masks])
+  done
+
+lemma dmo_setVMRoot[wp]:
+  "do_machine_op (setVSpaceRoot pt asid) \<lbrace>invs\<rbrace>"
+  apply (wp dmo_invs)
+  apply (auto simp: setVSpaceRoot_def machine_op_lift_def machine_rest_lift_def in_monad select_f_def)
+  done
+
+lemma dmo_sfence[wp]:
+  "do_machine_op sfence \<lbrace>invs\<rbrace>"
+  apply (wp dmo_invs)
+  apply (auto simp: sfence_def machine_op_lift_def machine_rest_lift_def in_monad select_f_def)
+  done
+
+lemma find_vspace_for_asid_inv[wp]:
+  "\<lbrace>P and Q\<rbrace> find_vspace_for_asid asid \<lbrace>\<lambda>_. P\<rbrace>, \<lbrace>\<lambda>_. Q\<rbrace>"
+  unfolding find_vspace_for_asid_def by wpsimp
+
+lemma set_vm_root_typ_at[wp]:
+  "set_vm_root t \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace>"
+  unfolding set_vm_root_def
+  by (wpsimp simp: if_distribR wp: get_cap_wp)
+
+lemma set_vm_root_invs[wp]:
+  "set_vm_root t \<lbrace>invs\<rbrace>"
+  unfolding set_vm_root_def
+  by (wpsimp simp: if_distribR wp: get_cap_wp)
+
+crunch pred_tcb_at[wp]: set_vm_root "pred_tcb_at proj P t"
+  (simp: crunch_simps)
+
+lemmas set_vm_root_typ_ats [wp] = abs_typ_at_lifts [OF set_vm_root_typ_at]
+
+lemma valid_pte_lift3:
+  assumes x: "(\<And>P T p. \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>)"
+  shows "\<lbrace>\<lambda>s. P (valid_pte level pte s)\<rbrace> f \<lbrace>\<lambda>rv s. P (valid_pte level pte s)\<rbrace>"
+  apply (insert bool_function_four_cases[where f=P])
+  apply (erule disjE)
+   apply (cases pte)
+     apply (simp add: data_at_def | wp hoare_vcg_const_imp_lift hoare_vcg_disj_lift x)+
+  apply (erule disjE)
+   apply (cases pte)
+     apply (simp add: data_at_def | wp hoare_vcg_disj_lift hoare_vcg_const_imp_lift x)+
+  apply (erule disjE)
+   apply (simp | wp)+
+  done
+
+
+lemma set_cap_valid_pte_stronger:
+  "set_cap cap p \<lbrace>\<lambda>s. P (valid_pte level pte s)\<rbrace>"
+  by (wp valid_pte_lift3 set_cap_typ_at)
+
+
+(* FIXME: move *)
+lemma valid_cap_to_pt_cap:
+  "\<lbrakk>valid_cap c s; obj_refs c = {p}; pt_at p s\<rbrakk> \<Longrightarrow> is_pt_cap c"
+  by (clarsimp simp: valid_cap_def obj_at_def is_obj_defs is_pt_cap_def valid_arch_cap_ref_def
+              split: cap.splits option.splits arch_cap.splits if_splits)
+
+lemma set_cap_invalid_pte[wp]:
+  "set_cap cap p' \<lbrace>invalid_pte_at p\<rbrace>"
+  unfolding invalid_pte_at_def by wpsimp
+
+lemma valid_cap_obj_ref_pt:
+  "\<lbrakk> s \<turnstile> cap; s \<turnstile> cap'; obj_refs cap = obj_refs cap' \<rbrakk>
+       \<Longrightarrow> is_pt_cap cap \<longrightarrow> is_pt_cap cap'"
+  by (auto simp: is_cap_simps valid_cap_def valid_arch_cap_ref_def
+                 obj_at_def is_ep is_ntfn is_cap_table is_tcb a_type_def
+          split: cap.split_asm if_split_asm arch_cap.split_asm option.split_asm)
+
+lemma is_pt_cap_asid_None_table_ref:
+  "is_pt_cap cap \<Longrightarrow> (table_cap_ref cap = None) = (cap_asid cap = None)"
+  by (auto simp: is_cap_simps table_cap_ref_def cap_asid_def
+          split: option.split_asm)
+
+lemma no_cap_to_obj_with_diff_ref_map:
+  "\<lbrakk> caps_of_state s p = Some cap; is_pt_cap cap;
+     table_cap_ref cap = None;
+     unique_table_caps s;
+     valid_objs s; obj_refs cap = obj_refs cap' \<rbrakk>
+       \<Longrightarrow> no_cap_to_obj_with_diff_ref cap' {p} s"
+  apply (clarsimp simp: no_cap_to_obj_with_diff_ref_def
+                        cte_wp_at_caps_of_state)
+  apply (frule(1) caps_of_state_valid_cap[where p=p])
+  apply (frule(1) caps_of_state_valid_cap[where p="(a, b)" for a b])
+  apply (drule(1) valid_cap_obj_ref_pt, simp)
+  apply (drule(1) unique_table_capsD[rotated, where cps="caps_of_state s"]; simp?)
+  apply (simp add: vs_cap_ref_table_cap_ref_eq)
+  done
+
+lemmas store_pte_cte_wp_at1[wp]
+    = hoare_cte_wp_caps_of_state_lift [OF store_pte_caps_of_state]
+
+lemma mdb_cte_at_store_pte[wp]:
+  "store_pte y pte \<lbrace>\<lambda>s. mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s)\<rbrace>"
+  apply (clarsimp simp:mdb_cte_at_def)
+  apply (simp only: imp_conv_disj)
+  apply (wpsimp wp: hoare_vcg_disj_lift hoare_vcg_all_lift simp: store_pte_def set_pt_def)
+  done
+
+crunches store_pte
+  for global_refs[wp]: "\<lambda>s. P (global_refs s)"
+
+(* FIXME: move *)
+lemma vs_cap_ref_table_cap_ref_None:
+  "vs_cap_ref x = None \<Longrightarrow> table_cap_ref x = None"
+  by (simp add: vs_cap_ref_def arch_cap_fun_lift_def vs_cap_ref_arch_def
+         split: cap.splits arch_cap.splits)
+
+(* FIXME: move *)
+lemma master_cap_eq_is_device_cap_eq:
+  "cap_master_cap c = cap_master_cap d \<Longrightarrow> cap_is_device c = cap_is_device d"
+  by (simp add: cap_master_cap_def
+         split: cap.splits arch_cap.splits)
+
+lemma vs_cap_ref_eq_imp_table_cap_ref_eq':
+  "\<lbrakk> vs_cap_ref cap = vs_cap_ref cap'; cap_master_cap cap = cap_master_cap cap' \<rbrakk>
+   \<Longrightarrow> table_cap_ref cap = table_cap_ref cap'"
+  by (simp add: vs_cap_ref_def vs_cap_ref_arch_def arch_cap_fun_lift_def cap_master_cap_def
+           split: cap.splits arch_cap.splits option.splits prod.splits)
+
+lemma arch_update_cap_invs_map:
+  "\<lbrace>cte_wp_at (is_arch_update cap and
+               (\<lambda>c. \<forall>r. vs_cap_ref c = Some r \<longrightarrow> vs_cap_ref cap = Some r)) p
+             and invs and valid_cap cap\<rbrace>
+  set_cap cap p
+  \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (simp add: invs_def valid_state_def)
+  apply (rule hoare_pre)
+   apply (wp arch_update_cap_pspace arch_update_cap_valid_mdb set_cap_idle
+             update_cap_ifunsafe valid_irq_node_typ set_cap_typ_at
+             set_cap_irq_handlers set_cap_valid_arch_caps
+             set_cap_cap_refs_respects_device_region_spec[where ptr = p])
+  apply (clarsimp simp: cte_wp_at_caps_of_state
+              simp del: imp_disjL)
+  apply (frule(1) valid_global_refsD2)
+  apply (frule(1) cap_refs_in_kernel_windowD)
+  apply (clarsimp simp: is_cap_simps is_arch_update_def
+              simp del: imp_disjL)
+  apply (frule master_cap_cap_range, simp del: imp_disjL)
+  apply (thin_tac "cap_range a = cap_range b" for a b)
+  apply (rule conjI)
+   apply (clarsimp simp: is_valid_vtable_root_def vs_cap_ref_def vs_cap_ref_arch_def split: cap.splits)
+   apply (simp split: arch_cap.splits option.splits;
+          clarsimp simp: cap_master_cap_simps vs_cap_ref_arch_def)
+  apply (rule conjI)
+   apply (rule ext)
+   apply (simp add: cap_master_cap_def split: cap.splits arch_cap.splits)
+  apply (rule context_conjI)
+   apply (simp add: appropriate_cte_cap_irqs)
+   apply (clarsimp simp: cap_irqs_def cap_irq_opt_def cap_master_cap_def
+                  split: cap.split)
+  apply (rule conjI)
+   apply (drule(1) if_unsafe_then_capD [OF caps_of_state_cteD])
+    apply (clarsimp simp: cap_master_cap_def)
+   apply (erule ex_cte_cap_wp_to_weakenE)
+   apply (clarsimp simp: appropriate_cte_cap_def cap_master_cap_def
+                  split: cap.split_asm)
+  apply (rule conjI)
+   apply (frule master_cap_obj_refs)
+   apply simp
+  apply (rule conjI)
+   apply (frule master_cap_obj_refs)
+   apply (case_tac "table_cap_ref capa =
+                    table_cap_ref (ArchObjectCap a)")
+    apply (frule unique_table_refs_no_cap_asidE[where S="{p}"])
+     apply (simp add: valid_arch_caps_def)
+    apply (simp add: no_cap_to_obj_with_diff_ref_def Ball_def)
+   apply (case_tac "table_cap_ref capa")
+    apply clarsimp
+    apply (erule no_cap_to_obj_with_diff_ref_map,
+           simp_all)[1]
+      apply (clarsimp simp: table_cap_ref_def cap_master_cap_simps
+                            is_cap_simps table_cap_ref_arch_def
+                     split: cap.split_asm arch_cap.split_asm
+                     dest!: cap_master_cap_eqDs)
+     apply (simp add: valid_arch_caps_def)
+    apply (simp add: valid_pspace_def)
+   apply (erule swap)
+   apply (rule vs_cap_ref_eq_imp_table_cap_ref_eq')
+    apply (frule table_cap_ref_vs_cap_ref_Some)
+    apply fastforce
+   apply fastforce
+  apply (rule conjI)
+   apply (clarsimp simp del: imp_disjL)
+   apply (clarsimp simp: is_pt_cap_def cap_master_cap_simps
+                         cap_asid_def vs_cap_ref_def
+                  dest!: cap_master_cap_eqDs split: option.split_asm prod.split_asm)
+   apply (drule valid_table_capsD[OF caps_of_state_cteD])
+      apply (clarsimp simp: invs_def valid_state_def valid_arch_caps_def)
+     apply (simp add: is_pt_cap_def)
+    apply (simp add: cap_asid_def split: option.splits)
+   apply simp
+  apply (clarsimp simp: is_cap_simps is_pt_cap_def cap_master_cap_simps
+                        cap_asid_def vs_cap_ref_def ranI
+                 dest!: cap_master_cap_eqDs split: option.split_asm if_split_asm
+                 elim!: ranE cong: master_cap_eq_is_device_cap_eq
+             | rule conjI)+
+  apply (clarsimp dest!: master_cap_eq_is_device_cap_eq)
+  done
+
+lemma pool_for_asid_ap_at:
+  "\<lbrakk> pool_for_asid asid s = Some p; valid_arch_state s \<rbrakk> \<Longrightarrow> asid_pool_at p s"
+  by (fastforce dest!: pool_for_asid_validD simp: valid_arch_state_def asid_pools_at_eq)
+
+lemma arch_update_cap_invs_unmap_page:
+  "\<lbrace>(\<lambda>s. \<exists>cap'.
+             caps_of_state s p = Some cap' \<and>
+             (\<forall>p'\<in>obj_refs cap'.
+                 \<forall>asid vref.
+                    vs_cap_ref cap' = Some (asid, vref) \<longrightarrow>
+                    (\<forall>level. vs_lookup_target level asid vref s \<noteq> Some (level, p'))) \<and>
+             is_arch_update cap cap')
+             and invs and valid_cap cap
+             and K (is_frame_cap cap)\<rbrace>
+  set_cap cap p
+  \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (simp add: cte_wp_at_caps_of_state)
+  apply (simp add: invs_def valid_state_def)
+  apply (rule hoare_pre)
+   apply (wp arch_update_cap_pspace arch_update_cap_valid_mdb set_cap_idle
+             update_cap_ifunsafe valid_irq_node_typ set_cap_typ_at
+             set_cap_irq_handlers set_cap_valid_arch_caps
+             set_cap_cap_refs_respects_device_region_spec[where ptr = p])
+  apply clarsimp
+  apply (clarsimp simp: cte_wp_at_caps_of_state is_arch_update_def
+                        is_cap_simps cap_master_cap_simps
+                        fun_eq_iff appropriate_cte_cap_irqs
+                        is_pt_cap_def is_valid_vtable_root_def
+                 dest!: cap_master_cap_eqDs
+              simp del: imp_disjL)
+  apply (rule conjI)
+   apply (drule(1) if_unsafe_then_capD [OF caps_of_state_cteD])
+    apply (clarsimp simp: cap_master_cap_def)
+   apply (erule ex_cte_cap_wp_to_weakenE)
+   apply (clarsimp simp: appropriate_cte_cap_def)
+  apply (rule conjI)
+   apply (drule valid_global_refsD2, clarsimp)
+   subgoal by (simp add: cap_range_def)
+  apply (rule conjI)
+   apply (clarsimp simp: reachable_target_def reachable_frame_cap_def)
+   apply (drule (1) pool_for_asid_ap_at)
+   apply (clarsimp simp: valid_cap_def obj_at_def split: if_split_asm)
+  apply (rule conjI[rotated])
+   apply (frule(1) cap_refs_in_kernel_windowD)
+   apply (simp add: cap_range_def)
+  apply (drule unique_table_refs_no_cap_asidE[where S="{p}"])
+   apply (simp add: valid_arch_caps_def)
+  apply (simp add: no_cap_to_obj_with_diff_ref_def table_cap_ref_def Ball_def)
+  done
+
+lemma mask_cap_PageTableCap[simp]:
+  "mask_cap R (ArchObjectCap (PageTableCap p data)) = ArchObjectCap (PageTableCap p data)"
+  by (clarsimp simp: mask_cap_def cap_rights_update_def acap_rights_update_def)
+
+lemma arch_update_cap_pspace':
+  "\<lbrace>cte_wp_at (is_arch_update cap) p and real_cte_at p and valid_pspace and valid_cap cap\<rbrace>
+   set_cap cap p
+   \<lbrace>\<lambda>_. valid_pspace\<rbrace>"
+  apply (simp add: valid_pspace_def)
+  apply (rule hoare_pre)
+   apply (wp set_cap_valid_objs update_cap_iflive arch_update_cap_zombies)
+  apply clarsimp
+  apply (clarsimp simp: cte_wp_at_caps_of_state is_arch_update_def)
+  apply (frule cap_master_cap_zobj_refs)
+  apply clarsimp
+  apply (drule caps_of_state_cteD)
+  apply (drule (1) cte_wp_tcb_cap_valid)
+  apply (erule real_cte_tcb_valid[rule_format])
+  done
+
+lemma arch_update_cap_invs_unmap_page_table:
+  "\<lbrace>cte_wp_at (is_arch_update cap) p
+             and real_cte_at p
+             and invs and valid_cap cap
+             and (\<lambda>s. cte_wp_at (\<lambda>c. is_final_cap' c s) p s)
+             and (\<lambda>s. pts_of s (obj_ref_of cap) = Some empty_pt)
+             and (\<lambda>s. cte_wp_at (\<lambda>c. \<forall>asid vref level. vs_cap_ref c = Some (asid, vref)
+                                \<longrightarrow> vs_lookup_target level asid vref s \<noteq> Some (level, obj_ref_of cap)) p s)
+             and K (is_pt_cap cap \<and> vs_cap_ref cap = None)\<rbrace>
+  set_cap cap p
+  \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (simp add: invs_def valid_state_def)
+  apply (rule hoare_pre)
+   apply (wp arch_update_cap_pspace' arch_update_cap_valid_mdb set_cap_idle
+             update_cap_ifunsafe valid_irq_node_typ set_cap_typ_at
+             set_cap_irq_handlers set_cap_valid_arch_caps
+             set_cap_cap_refs_respects_device_region_spec[where ptr = p])
+  apply (simp add: final_cap_at_eq)
+  apply (clarsimp simp: cte_wp_at_caps_of_state is_arch_update_def
+                        is_cap_simps cap_master_cap_simps is_valid_vtable_root_def
+                        appropriate_cte_cap_irqs is_pt_cap_def
+                        fun_eq_iff[where f="cte_refs cap" for cap]
+                 dest!: cap_master_cap_eqDs
+              simp del: imp_disjL)
+  apply (rule conjI)
+   apply (drule(1) if_unsafe_then_capD [OF caps_of_state_cteD])
+    apply (clarsimp simp: cap_master_cap_def)
+   apply (erule ex_cte_cap_wp_to_weakenE)
+   apply (clarsimp simp: appropriate_cte_cap_def)
+  apply (rule conjI)
+   apply (drule valid_global_refsD2, clarsimp)
+   apply (simp add: cap_range_def)
+  apply (frule(1) cap_refs_in_kernel_windowD)
+  apply (simp add: cap_range_def gen_obj_refs_def image_def)
+  apply (rule conjI)
+   apply (clarsimp simp: reachable_target_def reachable_frame_cap_def)
+   apply (drule (1) pool_for_asid_ap_at)
+   apply (clarsimp simp: valid_cap_def obj_at_def split: if_split_asm)
+  apply (intro conjI)
+    apply (clarsimp simp: no_cap_to_obj_with_diff_ref_def
+                          cte_wp_at_caps_of_state)
+    apply fastforce
+   apply (clarsimp simp: obj_at_def empty_table_def in_omonad)
+  apply fastforce
+  done
+
+lemma global_refs_arch_update_eq:
+  "riscv_global_pts (f (arch_state s)) = riscv_global_pts (arch_state s) \<Longrightarrow>
+   global_refs (arch_state_update f s) = global_refs s"
+  by (simp add: global_refs_def)
+
+lemma not_in_global_refs_vs_lookup:
+  "(\<exists>\<rhd> (level,p)) s \<and> valid_vs_lookup s \<and> valid_global_refs s
+            \<and> valid_arch_state s \<and> valid_global_objs s
+            \<and> pt_at p s
+        \<longrightarrow> p \<notin> global_refs s"
+  apply clarsimp
+  apply (cases "level = asid_pool_level"; simp)
+   apply (simp add: vs_lookup_table_def in_omonad)
+   apply (drule (1) pool_for_asid_ap_at)
+   apply (clarsimp simp: obj_at_def)
+  apply (drule (1) vs_lookup_table_target)
+  apply (drule valid_vs_lookupD; clarsimp simp: vref_for_level_user_region)
+  apply (drule(1) valid_global_refsD2)
+  apply (simp add: cap_range_def)
+  done
+
+lemma no_irq_sfence[wp,intro!]: "no_irq sfence"
+  by (wpsimp simp: sfence_def no_irq_def machine_op_lift_def machine_rest_lift_def)
+
+lemma pt_lookup_from_level_wp:
+  "\<lbrace>\<lambda>s. (\<forall>level pt' pte.
+            pt_walk top_level level top_level_pt vref (ptes_of s) = Some (level, pt') \<longrightarrow>
+            ptes_of s (pt_slot_offset level pt' vref) = Some pte \<longrightarrow>
+            is_PageTablePTE pte \<longrightarrow>
+            pte_ref pte = Some pt \<longrightarrow>
+            Q (pt_slot_offset level pt' vref) s) \<and>
+        ((\<forall>level < top_level.
+            pt_walk top_level level top_level_pt vref (ptes_of s) \<noteq> Some (level, pt)) \<longrightarrow>
+            E InvalidRoot s)\<rbrace>
+  pt_lookup_from_level top_level top_level_pt vref pt
+  \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+proof (induct top_level arbitrary: top_level_pt)
+  case 0
+  then show ?case
+    by (wpsimp simp: pt_lookup_from_level_simps)
+next
+  case (minus top_level)
+  note IH=minus(1)
+  from \<open>0 < top_level\<close>
+  show ?case
+    apply (subst pt_lookup_from_level_simps)
+    apply (wpsimp wp: IH)
+    apply (rule conjI; clarsimp)
+     prefer 2
+     apply (subst (asm) (2) pt_walk.simps)
+     apply (clarsimp)
+    apply (rule conjI; clarsimp)
+     apply (erule_tac x="top_level" in allE)
+     apply (clarsimp simp: in_omonad is_PageTablePTE_def pptr_from_pte_def)
+    apply (rule conjI; clarsimp)
+     apply (rename_tac pt' pte)
+     apply (frule pt_walk_max_level)
+     apply (erule_tac x=level in allE)
+     apply (erule_tac x=pt' in allE)
+     apply simp
+     apply (erule mp)
+     apply (subst pt_walk.simps)
+     apply (simp add: in_omonad bit0.leq_minus1_less)
+    apply (subst (asm) (3) pt_walk.simps)
+    apply (case_tac "level = top_level - 1"; clarsimp)
+    apply (subgoal_tac "level < top_level - 1", fastforce)
+    apply (frule bit0.zero_least)
+    apply (subst (asm) bit0.leq_minus1_less[symmetric], assumption)
+    apply simp
+    done
+qed
+
+(* weaker than pspace_aligned_pts_ofD, but still sometimes useful because it matches better *)
+lemma pts_of_Some_alignedD:
+  "\<lbrakk> pts_of s p = Some pt; pspace_aligned s \<rbrakk> \<Longrightarrow> is_aligned p pt_bits"
+  by (drule pspace_aligned_pts_ofD; simp)
+
+lemma vs_lookup_target_not_global:
+  "\<lbrakk> vs_lookup_target level asid vref s = Some (level, pt); vref \<in> user_region; invs s \<rbrakk>
+   \<Longrightarrow> pt \<notin> global_refs s"
+  apply (drule (1) valid_vs_lookupD; clarsimp)
+  apply (drule valid_global_refsD2; clarsimp)
+  apply (simp add: cap_range_def)
+  done
+
+lemma reachable_page_table_not_global:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, p); level \<le> max_pt_level;
+     vref \<in> user_region; invs s\<rbrakk>
+   \<Longrightarrow> p \<notin> global_refs s"
+  apply (drule (1) vs_lookup_table_target)
+  apply (erule vs_lookup_target_not_global)
+   apply (erule vref_for_level_user_region)
+  apply assumption
+  done
+
+lemma unmap_page_table_invs[wp]:
+  "\<lbrace>invs and K (vaddr \<in> user_region)\<rbrace>
+     unmap_page_table asid vaddr pt
+   \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (simp add: unmap_page_table_def)
+  apply (rule hoare_pre)
+   apply (wp dmo_invs | wpc | simp)+
+     apply (rule_tac Q="\<lambda>_. invs" in hoare_post_imp)
+      apply safe
+       apply (drule_tac Q="\<lambda>_ m'. underlying_memory m' p =
+                                  underlying_memory m p" in use_valid)
+         apply ((wp | simp)+)[3]
+      apply(erule use_valid, wp no_irq, assumption)
+     apply (wpsimp wp: store_pte_invs_unmap pt_lookup_from_level_wp)+
+  apply (frule pt_walk_max_level)
+  apply (drule (2) pt_lookup_vs_lookupI)
+  apply (frule (2) valid_vspace_objs_strongD[rotated]; clarsimp)
+  apply (frule pts_of_Some_alignedD; clarsimp)
+  apply (rule conjI)
+   apply (drule (1) vs_lookup_table_target)
+   apply (drule valid_vs_lookupD, erule vref_for_level_user_region, clarsimp)
+   apply clarsimp
+   apply (frule (1) cap_to_pt_is_pt_cap; clarsimp?)
+    apply (fastforce intro: valid_objs_caps)
+   apply (fastforce simp: is_cap_simps)
+  apply (rule conjI; clarsimp?)
+   apply (drule (3) vs_lookup_table_vspace)
+   apply (simp add: table_index_max_level_slots)
+  apply (drule (1) vs_lookup_table_target)
+  apply (drule vs_lookup_target_not_global, erule vref_for_level_user_region; simp)
+  done
+
+lemma final_cap_lift:
+  assumes x: "\<And>P. \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace> f \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
+  shows      "\<lbrace>\<lambda>s. P (is_final_cap' cap s)\<rbrace> f \<lbrace>\<lambda>rv s. P (is_final_cap' cap s)\<rbrace>"
+  by (simp add: is_final_cap'_def2 cte_wp_at_caps_of_state, rule x)
+
+lemmas dmo_final_cap[wp] = final_cap_lift [OF do_machine_op_caps_of_state]
+lemmas store_pte_final_cap[wp] = final_cap_lift [OF store_pte_caps_of_state]
+lemmas unmap_page_table_final_cap[wp] = final_cap_lift [OF unmap_page_table_caps_of_state]
+
+lemma store_pte_vspace_for_asid[wp]:
+  "store_pte p pte \<lbrace>\<lambda>s. P (vspace_for_asid asid s)\<rbrace>"
+  by (wp vspace_for_asid_lift)
+
+lemma mapM_swp_store_pte_invs_unmap:
+  "\<lbrace>invs and
+    (\<lambda>s. \<forall>sl\<in>set slots. table_base sl \<notin> global_refs s \<and>
+                        (\<forall>asid. vspace_for_asid asid s \<noteq> Some (table_base sl))) and
+    K (pte = InvalidPTE)\<rbrace>
+  mapM (swp store_pte pte) slots \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (rule hoare_post_imp)
+   prefer 2
+   apply (rule mapM_wp')
+   apply simp
+   apply (wp store_pte_invs hoare_vcg_const_Ball_lift hoare_vcg_ex_lift hoare_vcg_all_lift)
+   apply (clarsimp simp: wellformed_pte_def)
+  apply simp
+  done
+
+lemma mapM_x_swp_store_pte_invs_unmap:
+  "\<lbrace>invs and (\<lambda>s. \<forall>sl \<in> set slots. table_base sl \<notin> global_refs s \<and>
+                                    (\<forall>asid. vspace_for_asid asid s \<noteq> Some (table_base sl))) and
+    K (pte = InvalidPTE)\<rbrace>
+  mapM_x (swp store_pte pte) slots \<lbrace>\<lambda>_. invs\<rbrace>"
+  by (simp add: mapM_x_mapM | wp mapM_swp_store_pte_invs_unmap)+
+
+lemma vs_lookup_table_step:
+  "\<lbrakk> vs_lookup_table level asid vref s = Some (level, pt'); level \<le> max_pt_level; 0 < level;
+     ptes_of s (pt_slot_offset level pt' vref) = Some pte; is_PageTablePTE pte;
+     pte_ref pte = Some pt \<rbrakk> \<Longrightarrow>
+    vs_lookup_table (level-1) asid vref s = Some (level-1, pt)"
+  apply (subst vs_lookup_split_Some[where level'=level]; assumption?)
+   apply (simp add: order_less_imp_le)
+  apply (subst pt_walk.simps)
+  apply (clarsimp simp: in_omonad is_PageTablePTE_def pptr_from_pte_def)
+  done
+
+lemma pte_ref_Some_cases:
+  "(pte_ref pte = Some ref) = ((is_PageTablePTE pte \<or> is_PagePTE pte) \<and> ref = pptr_from_pte pte)"
+  by (cases pte) (auto simp: pptr_from_pte_def)
+
+lemma max_pt_level_eq_minus_one:
+  "level - 1 = max_pt_level \<Longrightarrow> level = asid_pool_level"
+  unfolding level_defs by auto
+
+lemma store_pte_invalid_vs_lookup_target_unmap:
+  "\<lbrace>\<lambda>s. (\<exists>level'. vs_lookup_slot level' asid vref s = Some (level', p) \<and>
+                  pte_refs_of s p = Some p') \<and>
+         vref \<in> user_region \<and>
+         pspace_aligned s \<and> valid_asid_table s \<and> valid_vspace_objs s \<and>
+         unique_table_refs s \<and> valid_vs_lookup s \<and> valid_caps (caps_of_state s) s \<rbrace>
+   store_pte p InvalidPTE
+   \<lbrace>\<lambda>_ s. vs_lookup_target level asid vref s \<noteq> Some (level, p')\<rbrace>"
+  unfolding store_pte_def set_pt_def
+  supply fun_upd_apply[simp del]
+  apply (wpsimp wp: set_object_wp simp: obj_at_def)
+  apply (prop_tac "level' \<le> max_pt_level")
+   apply (clarsimp simp: vs_lookup_slot_def pool_for_asid_vs_lookup split: if_split_asm)
+   apply (drule (1) pool_for_asid_validD)
+   apply (clarsimp simp: obj_at_def in_omonad)
+   apply (frule_tac p=p in pspace_alignedD, assumption)
+   apply (simp add: bit_simps)
+  apply (frule (5) valid_vspace_objs_strong_slotD)
+  apply (clarsimp simp: vs_lookup_slot_def split: if_split_asm)
+  apply (clarsimp simp: in_omonad pte_ref_Some_cases)
+  apply (rename_tac pt_ptr pte)
+  apply (frule (5) vs_lookup_table_is_aligned)
+  apply clarsimp
+  apply (clarsimp simp: vs_lookup_target_def vs_lookup_slot_def pool_for_asid_vs_lookup
+                  split: if_split_asm)
+   apply (prop_tac "asid_pools_of s pt_ptr = None")
+    apply (clarsimp simp: opt_map_def)
+   apply simp
+   apply (prop_tac "vs_lookup_table max_pt_level asid vref s = Some (max_pt_level, p')")
+    apply (clarsimp simp: vs_lookup_table_def in_omonad)
+   apply (erule disjE)
+    (* PageTablePTE: level' would have to be asid_pool_level, contradiction *)
+    apply (drule (1) vs_lookup_table_step; simp?)
+      apply (rule ccontr)
+      apply (clarsimp simp flip: bit0.neq_0_conv simp: is_PageTablePTE_def)
+     apply (fastforce simp: pte_ref_Some_cases)
+    apply (drule (1) no_loop_vs_lookup_table; simp?)
+   (* PagePTE *)
+   apply (prop_tac "\<exists>sz. data_at sz p' s")
+    apply (fastforce simp: is_PagePTE_def pptr_from_pte_def)
+   apply clarsimp
+   apply (drule (2) valid_vspace_objs_strongD[where level=max_pt_level]; clarsimp)
+   apply (fastforce simp: data_at_def obj_at_def in_omonad)
+  apply (clarsimp simp: in_omonad)
+  apply (rename_tac pt_ptr' pte')
+  apply (case_tac "level' \<le> level")
+   apply (drule (9) vs_lookup_table_fun_upd_deep_idem)
+   apply (frule (5) vs_lookup_table_is_aligned[where bot_level=level])
+   apply (clarsimp simp: ptes_of_def fun_upd_apply in_omonad split: if_split_asm)
+    apply (drule (1) no_loop_vs_lookup_table; simp)
+   apply (rename_tac pt')
+   apply (case_tac "level' = level", simp)
+   apply (prop_tac "valid_pte level (pt' (table_index (pt_slot_offset level pt_ptr' vref))) s")
+    apply (drule (2) valid_vspace_objsD[where bot_level=level])
+     apply (simp add: in_omonad)
+    apply simp
+    apply (drule_tac x="table_index (pt_slot_offset level pt_ptr' vref)" in bspec)
+     apply (fastforce dest: table_index_max_level_slots)
+    apply fastforce
+   apply (erule disjE)
+    (* PageTablePTE *)
+    apply (prop_tac "is_PageTablePTE (pt' (table_index (pt_slot_offset level pt_ptr' vref)))")
+     apply (case_tac "pt' (table_index (pt_slot_offset level pt_ptr' vref))"; simp)
+     apply (clarsimp simp: is_PageTablePTE_def obj_at_def data_at_def pptr_from_pte_def)
+    apply (drule (1) vs_lookup_table_step; simp?)
+      apply (rule ccontr)
+      apply (clarsimp simp flip: bit0.neq_0_conv simp: is_PageTablePTE_def)
+     apply (clarsimp simp: ptes_of_def in_omonad)
+    apply (drule (1) vs_lookup_table_step)
+           apply (rule ccontr)
+           apply (clarsimp simp flip: bit0.neq_0_conv simp: is_PageTablePTE_def)
+          apply (clarsimp simp: ptes_of_def in_omonad)
+          apply (rule refl)
+         apply simp
+        apply (simp add: pte_ref_Some_cases)
+    apply (simp add: pte_ref_Some_cases)
+    apply (drule (1) no_loop_vs_lookup_table; simp)
+   apply (prop_tac "\<not>is_PageTablePTE (pt' (table_index (pt_slot_offset level pt_ptr' vref)))")
+     apply (case_tac "pt' (table_index (pt_slot_offset level pt_ptr' vref))"; simp)
+     apply (clarsimp simp: is_PagePTE_def obj_at_def data_at_def pptr_from_pte_def)
+   apply (drule_tac level=level' and level'=level in vs_lookup_splitD; clarsimp)
+   apply (subst (asm) pt_walk.simps)
+   apply (clarsimp simp: in_omonad ptes_of_def split: if_split_asm)
+  apply (simp add: not_le)
+   apply (drule_tac level=level and level'=level' in vs_lookup_splitD; simp?)
+  apply clarsimp
+  apply (drule (1) vs_lookup_table_fun_upd_deep_idem; simp)
+  apply (subst (asm) pt_walk.simps)
+  apply (clarsimp simp: in_omonad)
+  apply (subst (asm) (3) pte_of_def)
+  apply (clarsimp simp: in_omonad fun_upd_apply split: if_split_asm)
+  done
+
+lemma pt_lookup_from_level_wrp:
+  "\<lbrace>\<lambda>s. \<exists>asid. vspace_for_asid asid s = Some top_level_pt \<and>
+               (\<forall>level slot pte.
+                   vs_lookup_slot level asid vref s = Some (level, slot) \<longrightarrow>
+                   ptes_of s slot = Some pte \<longrightarrow>
+                   is_PageTablePTE pte \<longrightarrow>
+                   pte_ref pte = Some pt \<longrightarrow>
+                   Q slot s) \<and>
+               ((\<forall>level<max_pt_level. vs_lookup_table level asid vref s \<noteq> Some (level, pt)) \<longrightarrow>
+                   E InvalidRoot s)\<rbrace>
+   pt_lookup_from_level max_pt_level top_level_pt vref pt
+   \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>"
+  apply (wp pt_lookup_from_level_wp)
+  apply (clarsimp simp: vspace_for_asid_def)
+  apply (rule conjI; clarsimp)
+   apply (frule pt_walk_max_level)
+   apply (erule_tac x=level in allE)
+   apply (erule allE, erule impE[where P="f = Some x" for f x])
+    apply (clarsimp simp: vs_lookup_slot_def vs_lookup_table_def in_omonad)
+    apply fastforce
+   apply simp
+  apply (erule allE, erule (1) impE)
+  apply (clarsimp simp: vs_lookup_table_def split: if_split_asm)
+  done
+
+lemma unmap_page_table_not_target:
+  "\<lbrace>\<lambda>s. pt_at pt s \<and> pspace_aligned s \<and> valid_asid_table s \<and> valid_vspace_objs s \<and>
+        unique_table_refs s \<and> valid_vs_lookup s \<and> valid_caps (caps_of_state s) s \<and>
+        0 < asid \<and> vref \<in> user_region \<and> vspace_for_asid asid s \<noteq> Some pt \<and>
+        asid' = asid \<and> pt' = pt \<and> vref' = vref \<rbrace>
+   unmap_page_table asid vref pt
+   \<lbrace>\<lambda>_ s. vs_lookup_target level asid' vref' s \<noteq> Some (level, pt')\<rbrace>"
+  unfolding unmap_page_table_def
+  apply (wpsimp wp: store_pte_invalid_vs_lookup_target_unmap pt_lookup_from_level_wrp)
+  apply (rule conjI; clarsimp)
+   apply (clarsimp simp: vs_lookup_target_def vs_lookup_slot_def vs_lookup_table_def
+                   split: if_split_asm;
+          clarsimp simp: vspace_for_asid_def obind_def)
+  apply (rule exI, rule conjI, assumption)
+  apply (rule conjI; clarsimp)
+   apply (fastforce simp: in_omonad)
+  apply (clarsimp simp: vs_lookup_target_def split: if_split_asm)
+   apply (clarsimp simp: pool_for_asid_vs_lookup vs_lookup_slot_def vspace_for_asid_def
+                   split: if_split_asm)
+  apply (rename_tac slot)
+  apply (clarsimp simp: in_omonad)
+  apply (rename_tac pte)
+  apply (prop_tac "0 < level \<and> is_PageTablePTE pte")
+   apply (drule (5) valid_vspace_objs_strong_slotD)
+   apply clarsimp
+   apply (case_tac pte; clarsimp simp: pte_ref_def)
+   apply (clarsimp simp: data_at_def obj_at_def)
+  apply (clarsimp simp: vs_lookup_slot_def split: if_split_asm)
+  apply (drule (4) vs_lookup_table_step, simp)
+  apply (prop_tac "level - 1 < max_pt_level", erule (1) bit0.minus_one_leq_less)
+  apply fastforce
+  done
+
+lemma is_final_cap_caps_of_state_2D:
+  "\<lbrakk> caps_of_state s p = Some cap; caps_of_state s p' = Some cap';
+     is_final_cap' cap'' s; gen_obj_refs cap \<inter> gen_obj_refs cap'' \<noteq> {};
+     gen_obj_refs cap' \<inter> gen_obj_refs cap'' \<noteq> {} \<rbrakk>
+       \<Longrightarrow> p = p'"
+  apply (clarsimp simp: is_final_cap'_def3)
+  apply (frule_tac x="fst p" in spec)
+  apply (drule_tac x="snd p" in spec)
+  apply (drule_tac x="fst p'" in spec)
+  apply (drule_tac x="snd p'" in spec)
+  apply (clarsimp simp: cte_wp_at_caps_of_state Int_commute
+                        prod_eqI)
+  done
+
+crunch underlying_memory[wp]: ackInterrupt, hwASIDFlush, read_stval, setVSpaceRoot, sfence
+  "\<lambda>m'. underlying_memory m' p = um"
+  (simp: cache_machine_op_defs machine_op_lift_def machine_rest_lift_def split_def)
+
+crunches storeWord, ackInterrupt, hwASIDFlush, read_stval, setVSpaceRoot, sfence
+  for device_state_inv[wp]: "\<lambda>ms. P (device_state ms)"
+  (simp: crunch_simps)
+
+crunch pspace_respects_device_region[wp]: perform_page_invocation "pspace_respects_device_region"
+  (simp: crunch_simps wp: crunch_wps set_object_pspace_respects_device_region
+         pspace_respects_device_region_dmo)
+
+lemma mapM_x_store_pte_caps_of_state[wp]:
+  "mapM_x (swp store_pte InvalidPTE) slots \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace>"
+  by (wpsimp wp: mapM_x_wp')
+
+lemma mapM_x_store_pte_valid_cap[wp]:
+  "mapM_x (swp store_pte InvalidPTE) slots \<lbrace>valid_cap cap\<rbrace>"
+  by (wpsimp wp: mapM_x_wp')
+
+lemma mapM_x_store_pte_final_cap[wp]:
+  "mapM_x (swp store_pte InvalidPTE) slots \<lbrace>is_final_cap' cap\<rbrace>"
+  by (wpsimp wp: final_cap_lift)
+
+lemma mapM_x_store_pte_empty[wp]:
+  "\<lbrace> \<lambda>s. slots = [p , p + (1 << pte_bits) .e. p + (1 << pt_bits) - 1] \<and>
+         is_aligned p pt_bits \<and> pt_at p s \<rbrace>
+   mapM_x (swp store_pte InvalidPTE) slots
+   \<lbrace> \<lambda>_ s. pts_of s p = Some empty_pt \<rbrace>"
+  apply wp_pre
+   apply (rule_tac I="\<lambda>s. slots = [p , p + (1 << pte_bits) .e. p + (1 << pt_bits) - 1] \<and>
+                          is_aligned p pt_bits \<and> pt_at p s" and
+                   V="\<lambda>xs s. \<forall>p' \<in> set slots - set xs. ptes_of s p' = Some InvalidPTE"
+                   in mapM_x_inv_wp2)
+    apply (clarsimp simp: obj_at_def in_omonad)
+    apply (rule ext)
+    apply (rename_tac idx)
+    apply (clarsimp simp: ptes_of_def in_omonad)
+    apply (prop_tac "p + (ucast idx << pte_bits) \<in> set slots")
+     apply clarsimp
+     apply (subst upto_enum_step_shift_red, simp)
+       apply (simp add: bit_simps)
+      apply (simp add: bit_simps)
+     apply (clarsimp simp: image_iff)
+     apply (rule_tac x="unat idx" in bexI)
+      apply (clarsimp simp: ucast_nat_def shiftl_t2n)
+     apply (clarsimp simp: bit_simps)
+     apply unat_arith
+     apply fastforce
+    apply (fastforce simp: table_index_plus_ucast table_base_plus_ucast)
+   apply (wpsimp wp: store_pte_ptes_of)
+  apply simp
+  done
+
+lemma vs_lookup_slot_pool_for_asid:
+  "(vs_lookup_slot asid_pool_level asid vref s = Some (level, slot)) =
+   (pool_for_asid asid s = Some slot \<and> level = asid_pool_level)"
+  by (auto simp: vs_lookup_slot_def vs_lookup_table_def in_omonad)
+
+lemma ptes_of_upd:
+  "\<lbrakk> pts (table_base p) = Some pt; is_aligned p pte_bits \<rbrakk> \<Longrightarrow>
+   (\<lambda>p'. pte_of p' (pts(table_base p \<mapsto> pt(table_index p := pte)))) =
+   ((\<lambda>p'. pte_of p' pts)(p \<mapsto> pte))"
+  by (rule ext) (auto simp: pte_of_def obind_def split: option.splits dest: pte_ptr_eq)
+
+lemma pt_walk_upd_Invalid:
+  "pt_walk top_level level pt_ptr vref (ptes(p \<mapsto> InvalidPTE)) = Some (level, p') \<Longrightarrow>
+   pt_walk top_level level pt_ptr vref ptes = Some (level, p')"
+  apply (induct top_level arbitrary: pt_ptr, simp)
+  apply (subst (asm) (3) pt_walk.simps)
+  apply (clarsimp simp: in_omonad split: if_split_asm)
+  apply (erule disjE; clarsimp)
+  apply (subst pt_walk.simps)
+  apply (clarsimp simp: in_omonad)
+  done
+
+lemma store_pte_unreachable:
+  "store_pte p InvalidPTE \<lbrace>\<lambda>s. vs_lookup_target level asid vref s \<noteq> Some (level, p')\<rbrace>"
+  unfolding store_pte_def set_pt_def
+  supply fun_upd_apply[simp del] vs_lookup_slot_pool_for_asid[simp]
+  apply (wpsimp wp: set_object_wp simp: obj_at_def)
+  apply (prop_tac "asid_pools_of s (table_base p) = None", clarsimp simp: opt_map_def)
+  apply (erule notE)
+  apply (cases "level = asid_pool_level"; clarsimp simp: vs_lookup_target_def in_omonad)
+  apply (clarsimp simp: in_omonad vs_lookup_slot_def simp flip: asid_pool_level_neq
+                  split: if_split_asm)
+  apply (rename_tac pt_ptr)
+  apply (clarsimp simp: in_omonad vs_lookup_table_def ptes_of_upd split: if_split_asm)
+  apply (drule pt_walk_upd_Invalid)
+  apply (clarsimp cong: conj_cong)
+  apply (rule conjI, clarsimp)
+  apply (clarsimp simp: ptes_of_def in_omonad fun_upd_apply split: if_split_asm)
+  done
+
+lemma mapM_x_store_pte_unreachable:
+  "mapM_x (swp store_pte InvalidPTE) slots
+   \<lbrace>\<lambda>s. vs_lookup_target level asid vref s \<noteq> Some (level, p)\<rbrace>"
+  by (wpsimp wp: mapM_x_wp' store_pte_unreachable)
+
+lemma mapM_x_typ_at[wp]:
+  "mapM_x (swp store_pte InvalidPTE) slots \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace>"
+  by (wpsimp wp: mapM_x_wp')
+
+crunches unmap_page_table
+  for global_refs[wp]: "\<lambda>s. P (global_refs s)"
+  and vspace_for_asid[wp]: "\<lambda>s. P (vspace_for_asid asid s)"
+  and valid_cap[wp]: "valid_cap cap"
+
+lemma vspace_for_asid_target:
+  "vspace_for_asid asid s = Some pt \<Longrightarrow>
+   vs_lookup_target asid_pool_level asid 0 s = Some (asid_pool_level, pt)"
+  by (clarsimp simp: vs_lookup_target_def vs_lookup_slot_pool_for_asid vspace_for_asid_def in_omonad)
+
+lemma perform_pt_inv_unmap_invs[wp]:
+  "\<lbrace>invs and valid_pti (PageTableUnmap cap ct_slot)\<rbrace> perform_pt_inv_unmap cap ct_slot \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding perform_pt_inv_unmap_def
+  apply (wpsimp wp: arch_update_cap_invs_unmap_page_table get_cap_wp hoare_vcg_ex_lift
+                    hoare_vcg_all_lift hoare_vcg_imp_lift' mapM_x_swp_store_pte_invs_unmap
+                    mapM_x_store_pte_unreachable hoare_vcg_ball_lift
+                    unmap_page_table_not_target real_cte_at_typ_valid
+                simp: cte_wp_at_caps_of_state)
+  apply (clarsimp simp: valid_pti_def cte_wp_at_caps_of_state)
+  apply (clarsimp simp: is_arch_update_def is_cap_simps is_PageTableCap_def
+                        update_map_data_def valid_cap_def valid_arch_cap_def cap_aligned_def)
+  apply (frule caps_of_state_valid_cap, clarsimp)
+  apply (rule conjI; clarsimp)
+   apply (simp add: valid_cap_def cap_aligned_def)
+   apply (erule valid_table_caps_pdD, fastforce)
+  apply (rename_tac p asid vref)
+  apply (clarsimp simp: wellformed_mapdata_def valid_cap_def cap_aligned_def cap_master_cap_simps)
+  apply (rule conjI)
+   apply clarsimp
+   apply (prop_tac "is_aligned p pt_bits", simp add: bit_simps)
+   apply (subst (asm) upto_enum_step_shift_red; simp?)
+     apply (simp add: bit_simps)
+    apply (simp add: bit_simps)
+   apply clarsimp
+   apply (subst table_base_plus[simplified shiftl_t2n mult_ac], assumption)
+    apply (simp add: mask_def bit_simps)
+    apply unat_arith
+    apply (subst (asm) unat_of_nat, simp)
+   apply (subst table_base_plus[simplified shiftl_t2n mult_ac], assumption)
+    apply (simp add: mask_def bit_simps)
+    apply unat_arith
+    apply (subst (asm) unat_of_nat, simp)
+   apply (rule conjI; clarsimp)
+    apply (drule valid_global_refsD2, clarsimp)
+    apply (simp add: cap_range_def)
+   apply (frule vspace_for_asid_target)
+   apply (drule valid_vs_lookupD; clarsimp)
+   apply (frule (1) cap_to_pt_is_pt_cap, clarsimp simp: in_omonad obj_at_def)
+    apply (fastforce intro: valid_objs_caps)
+   apply (drule (1) unique_table_refsD[rotated]; clarsimp)
+   apply (clarsimp simp: is_cap_simps)
+  apply (fastforce intro: valid_objs_caps simp: bit_simps)
+  done
+
+lemma set_cap_vspace_for_asid[wp]:
+  "set_cap p cap \<lbrace>\<lambda>s. P (vspace_for_asid asid s)\<rbrace>"
+  by (wpsimp wp: vspace_for_asid_lift)
+
+lemma cap_asid_None_pt:
+  "(cap_asid (ArchObjectCap (PageTableCap p m)) = None) = (m = None)"
+  by (cases m; clarsimp simp: cap_asid_def)
+
+lemma perform_pt_inv_map_invs[wp]:
+  "\<lbrace>invs and valid_pti (PageTableMap cap ct_slot pte slot)\<rbrace>
+   perform_pt_inv_map cap ct_slot pte slot
+   \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding perform_pt_inv_map_def
+  apply (wpsimp wp: store_pte_invs arch_update_cap_invs_map hoare_vcg_all_lift hoare_vcg_imp_lift')
+  apply (clarsimp simp: valid_pti_def cte_wp_at_caps_of_state is_arch_update_def is_cap_simps
+                        is_PageTableCap_def cap_master_cap_simps invalid_pte_at_def)
+  apply (rename_tac cap' p' level vref asid ao)
+  apply (prop_tac "is_pt_cap cap'")
+   apply (case_tac cap'; simp add: cap_master_cap_simps)
+   apply (rename_tac acap, case_tac acap; simp add: cap_master_cap_simps)
+  apply (clarsimp simp: is_cap_simps cap_master_cap_simps cap_asid_None_pt)
+  apply (frule caps_of_state_valid_cap, fastforce)
+  apply (clarsimp simp: vs_lookup_slot_def pool_for_asid_vs_lookup split: if_split_asm)
+   apply (drule pool_for_asid_validD, clarsimp)
+   apply (clarsimp simp: pte_at_def obj_at_def in_omonad)
+   apply (frule_tac p=slot in pspace_alignedD, clarsimp)
+   apply (prop_tac "is_aligned slot pt_bits", simp add: bit_simps)
+   apply fastforce
+  apply clarsimp
+  apply (rename_tac pt_ptr)
+  apply (prop_tac "is_aligned pt_ptr pt_bits", fastforce dest!: vs_lookup_table_is_aligned)
+  apply clarsimp
+  apply (rule conjI)
+   apply (clarsimp simp: valid_cap_def cap_aligned_def valid_arch_cap_def)
+  apply (rule conjI)
+   apply (erule (3) reachable_page_table_not_global)
+  apply (rule conjI, clarsimp)
+   apply (rename_tac level' asid' vref')
+   apply (prop_tac "level' \<le> max_pt_level")
+    apply (frule (2) valid_vspace_objs_strongD[rotated]; clarsimp)
+    apply (clarsimp simp: vs_lookup_table_def simp flip: asid_pool_level_neq)
+    apply (drule_tac p=pt_ptr in pool_for_asid_validD, clarsimp)
+    apply (clarsimp simp: in_omonad)
+   apply (drule (1) vs_lookup_table_unique_level; simp)
+   apply clarsimp
+   apply (drule (1) vs_lookup_table_target)
+   apply (drule valid_vs_lookupD, erule vref_for_level_user_region; clarsimp)
+   apply (frule (1) cap_to_pt_is_pt_cap, simp, fastforce intro: valid_objs_caps)
+   apply (clarsimp simp: is_cap_simps)
+   apply (drule (1) unique_table_refsD[rotated]; clarsimp)
+  apply (rule conjI, clarsimp)
+   apply (frule (2) valid_vspace_objs_strongD[rotated]; clarsimp)
+   apply (drule (1) vs_lookup_table_target)
+   apply (drule valid_vs_lookupD, erule vref_for_level_user_region; clarsimp)
+   apply (frule (1) cap_to_pt_is_pt_cap, simp, fastforce intro: valid_objs_caps)
+   apply (clarsimp simp: is_cap_simps)
+   apply (thin_tac "caps_of_state s ct_slot = Some cap" for cap)
+   apply (drule (1) unique_table_refsD[rotated]; clarsimp)
+  apply (rule conjI, clarsimp) (* top-level table, kernel_mapping_slots *)
+   apply (drule vspace_for_asid_vs_lookup)
+   apply (drule (1) vs_lookup_table_unique_level; clarsimp)
+   apply (drule (1) table_index_max_level_slots, simp)
+  apply clarsimp
+  apply (rename_tac level' asid' vref')
+  apply (prop_tac "level' \<le> max_pt_level")
+   apply (frule (2) valid_vspace_objs_strongD[rotated]; clarsimp)
+   apply (clarsimp simp: vs_lookup_table_def simp flip: asid_pool_level_neq)
+   apply (drule_tac p=pt_ptr in pool_for_asid_validD, clarsimp)
+   apply (clarsimp simp: in_omonad)
+  apply (frule_tac level'=level' in vs_lookup_table_unique_level, assumption; clarsimp)
+  apply (rule conjI, clarsimp) (* p \<noteq> pt_ptr *)
+   apply (drule (1) vs_lookup_table_target)
+   apply (drule valid_vs_lookupD, erule vref_for_level_user_region; clarsimp)
+   apply (frule (1) cap_to_pt_is_pt_cap, simp, fastforce intro: valid_objs_caps)
+   apply (clarsimp simp: is_cap_simps)
+   apply (drule (1) unique_table_refsD[rotated]; clarsimp)
+  apply (frule pt_slot_offset_vref_for_level; simp)
+  apply (cases ct_slot, fastforce)
+  done
+
+lemma perform_page_table_invocation_invs[wp]:
+  "\<lbrace>invs and valid_pti pti\<rbrace> perform_page_table_invocation pti \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding perform_page_table_invocation_def by (cases pti; wpsimp)
+
+crunch cte_wp_at [wp]: unmap_page "\<lambda>s. P (cte_wp_at P' p s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+crunch typ_at [wp]: unmap_page "\<lambda>s. P (typ_at T p s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemmas unmap_page_typ_ats [wp] = abs_typ_at_lifts [OF unmap_page_typ_at]
+
+lemma pt_lookup_slot_cap_to:
+  "\<lbrakk> invs s; \<exists>\<rhd>(max_pt_level, pt) s; is_aligned pt pt_bits; vptr \<in> user_region;
+     pt_lookup_slot pt vptr (ptes_of s) = Some (level, slot) \<rbrakk>
+   \<Longrightarrow> \<exists>p cap. caps_of_state s p = Some cap \<and> is_pt_cap cap \<and> obj_refs cap = {table_base slot} \<and>
+               s \<turnstile> cap \<and> cap_asid cap \<noteq> None"
+  apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def)
+  apply (frule pt_walk_max_level)
+  apply (rename_tac pt_ptr asid vref)
+  apply (subgoal_tac "vs_lookup_table level asid vptr s = Some (level, pt_ptr)")
+   prefer 2
+   apply (drule pt_walk_level)
+   apply (clarsimp simp: vs_lookup_table_def in_omonad)
+  apply (frule_tac level=level in valid_vspace_objs_strongD[rotated]; clarsimp)
+  apply (drule vs_lookup_table_target[where level=level], simp)
+  apply (drule valid_vs_lookupD, erule vref_for_level_user_region; clarsimp)
+  apply (frule (1) cap_to_pt_is_pt_cap, simp)
+   apply (fastforce intro: valid_objs_caps)
+  apply (frule pts_of_Some_alignedD, fastforce)
+  apply (frule caps_of_state_valid, fastforce)
+  apply (fastforce simp: cap_asid_def is_cap_simps)
+  done
+
+lemma find_vspace_for_asid_cap_to:
+  "\<lbrace>invs\<rbrace>
+   find_vspace_for_asid asid
+   \<lbrace>\<lambda>rv s.  \<exists>a b cap. caps_of_state s (a, b) = Some cap \<and> obj_refs cap = {rv} \<and>
+                      is_pt_cap cap \<and> s \<turnstile> cap \<and> is_aligned rv pt_bits\<rbrace>, -"
+  apply wpsimp
+  apply (drule vspace_for_asid_vs_lookup)
+  apply (frule valid_vspace_objs_strongD[rotated]; clarsimp)
+  apply (frule pts_of_Some_alignedD, fastforce)
+  apply simp
+  apply (drule vs_lookup_table_target, simp)
+  apply (drule valid_vs_lookupD; clarsimp simp: vref_for_level_def)
+  apply (frule (1) cap_to_pt_is_pt_cap, simp)
+   apply (fastforce intro: valid_objs_caps)
+  apply (fastforce intro: caps_of_state_valid cap_to_pt_is_pt_cap)
+  done
+
+lemma ex_pt_cap_eq:
+  "(\<exists>ref cap. caps_of_state s ref = Some cap \<and> obj_refs cap = {p} \<and> is_pt_cap cap) =
+   (\<exists>ref asid. caps_of_state s ref = Some (ArchObjectCap (PageTableCap p asid)))"
+  by (fastforce simp add: is_pt_cap_def obj_refs_def is_PageTableCap_def)
+
+lemma pt_bits_left_not_asid_pool_size:
+  "pt_bits_left asid_pool_level \<noteq> pageBitsForSize sz"
+  by (cases sz; simp add: pt_bits_left_def bit_simps asid_pool_level_size)
+
+lemma unmap_page_invs:
+  "\<lbrace>invs and K (vptr \<in> user_region \<and> vmsz_aligned vptr sz)\<rbrace>
+   unmap_page sz asid vptr pptr
+   \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding unmap_page_def
+  apply (wpsimp wp: store_pte_invs_unmap)
+  apply (rule conjI; clarsimp)
+  apply (frule (1) pt_lookup_slot_vs_lookup_slotI)
+  apply (clarsimp simp: vs_lookup_slot_def split: if_split_asm)
+  apply (rename_tac level pte pt_ptr)
+  apply (drule vs_lookup_level)
+  apply (frule (2) valid_vspace_objs_strongD[rotated]; clarsimp)
+  apply (frule vs_lookup_table_target, simp)
+  apply (frule pts_of_Some_alignedD, clarsimp)
+  apply (frule vref_for_level_user_region)
+  apply (frule (2) vs_lookup_target_not_global)
+  apply simp
+  apply (frule (1) valid_vs_lookupD; clarsimp)
+  apply (frule (1) cap_to_pt_is_pt_cap; (clarsimp intro!: valid_objs_caps)?)
+  apply (rule conjI, fastforce simp: is_cap_simps)
+  apply clarsimp
+  apply (drule (3) vs_lookup_table_vspace)
+  apply (simp add: table_index_max_level_slots)
+  done
+
+lemma set_mi_invs[wp]: "\<lbrace>invs\<rbrace> set_message_info t a \<lbrace>\<lambda>x. invs\<rbrace>"
+  by (simp add: set_message_info_def, wp)
+
+lemma data_at_orth:
+  "data_at a p s
+   \<Longrightarrow> \<not> ep_at p s \<and> \<not> ntfn_at p s \<and> \<not> cap_table_at sz p s \<and> \<not> tcb_at p s \<and> \<not> asid_pool_at p s
+         \<and> \<not> pt_at p s \<and> \<not> asid_pool_at p s"
+  apply (clarsimp simp: data_at_def obj_at_def a_type_def)
+  apply (case_tac "kheap s p",simp)
+  subgoal for ko by (case_tac ko,auto simp add: is_ep_def is_ntfn_def is_cap_table_def is_tcb_def)
+  done
+
+lemma data_at_frame_cap:
+  "\<lbrakk>data_at sz p s; valid_cap cap s; p \<in> obj_refs cap\<rbrakk> \<Longrightarrow> is_frame_cap cap"
+  by (cases cap; clarsimp simp: is_frame_cap_def valid_cap_def valid_arch_cap_ref_def data_at_orth
+                         split: option.splits arch_cap.splits)
+
+lemma perform_pg_inv_get_addr[wp]:
+  "\<lbrace>invs and valid_page_inv (PageGetAddr ptr)\<rbrace> perform_pg_inv_get_addr ptr \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding perform_pg_inv_get_addr_def by wpsimp
+
+lemma unmap_page_pool_for_asid[wp]:
+  "unmap_page pgsz asid vref pt \<lbrace>\<lambda>s. P (pool_for_asid asid s)\<rbrace>"
+  unfolding unmap_page_def by (wpsimp simp: pool_for_asid_def)
+
+lemma data_at_level:
+  "\<lbrakk> data_at pgsz p s; data_at (vmpage_size_of_level level) p s;
+     pt_bits_left level' = pageBitsForSize pgsz; level \<le> max_pt_level \<rbrakk> \<Longrightarrow>
+   level = level'"
+  by (fastforce simp: data_at_def obj_at_def)
+
+lemma pt_lookup_slot_vs_lookup_slotI0:
+  "\<lbrakk> vspace_for_asid asid s = Some pt_ptr;
+     pt_lookup_slot pt_ptr vref (ptes_of s) = Some (level, slot) \<rbrakk>
+   \<Longrightarrow> vs_lookup_slot 0 asid vref s = Some (level, slot)"
+  unfolding pt_lookup_slot_def pt_lookup_slot_from_level_def vs_lookup_slot_def
+  apply (clarsimp simp: in_omonad)
+  apply (drule (1) pt_lookup_vs_lookupI, simp)
+  apply (rule_tac x=level in exI)
+  apply clarsimp
+  apply (drule vs_lookup_level)
+  apply (fastforce dest: pt_walk_max_level)
+  done
+
+lemma unmap_page_not_target:
+  "\<lbrace> data_at pgsz pptr and valid_asid_table and valid_vspace_objs and pspace_aligned
+     and unique_table_refs and valid_vs_lookup and (\<lambda>s. valid_caps (caps_of_state s) s)
+     and K (0 < asid \<and> vref \<in> user_region \<and> pptr' = pptr \<and> asid' = asid \<and> vref' = vref) \<rbrace>
+   unmap_page pgsz asid vref pptr
+   \<lbrace>\<lambda>_ s. vs_lookup_target level asid' vref' s \<noteq> Some (level, pptr')\<rbrace>"
+  unfolding unmap_page_def
+  supply pt_bits_left_not_asid_pool_size[simp]
+         vs_lookup_slot_pool_for_asid[simp]
+         pool_for_asid_vs_lookup[simp]
+  apply (wpsimp wp: store_pte_invalid_vs_lookup_target_unmap)
+  apply (rule conjI; clarsimp)
+   apply (clarsimp simp: vs_lookup_target_def vspace_for_asid_def obind_def vs_lookup_slot_def
+                         vs_lookup_table_def
+                   split: if_split_asm option.splits)
+  apply (frule (1) pt_lookup_slot_vs_lookup_slotI0)
+  apply (rule conjI; clarsimp simp: in_omonad)
+   apply (drule vs_lookup_slot_level)
+   apply (rename_tac slot level' pte)
+   apply (rule conjI; clarsimp)
+    apply (rule conjI, fastforce)
+    apply (clarsimp simp: pte_ref_def is_PagePTE_def pptr_from_pte_def)
+   apply (rule conjI; clarsimp)
+   apply (clarsimp simp: vs_lookup_target_def split: if_split_asm)
+    apply (prop_tac "vs_lookup_table max_pt_level asid vref s = Some (max_pt_level, pptr)")
+     apply (clarsimp simp: vs_lookup_table_def in_omonad)
+    apply (drule (2) valid_vspace_objs_strongD; clarsimp)
+    apply (clarsimp simp: data_at_def in_omonad obj_at_def)
+   apply (clarsimp simp: in_omonad)
+   apply (rename_tac pte')
+   apply (frule (5) valid_vspace_objs_strong_slotD[where level=level])
+   apply (clarsimp simp: vs_lookup_slot_def split: if_split_asm)
+   apply (rename_tac pt_ptr pt_ptr')
+   apply (prop_tac "is_PagePTE pte'")
+    apply (case_tac pte'; clarsimp simp: obj_at_def data_at_def)
+   apply (case_tac "level = level'", simp add: pte_ref_Some_cases)
+   apply (clarsimp simp: is_PagePTE_def)
+   apply (drule (3) data_at_level, simp)
+  (* lookup has stopped at wrong level for pgsz *)
+  apply (rename_tac level')
+  apply (clarsimp simp: vs_lookup_target_def split: if_split_asm)
+   apply (prop_tac "vs_lookup_table max_pt_level asid vref s = Some (max_pt_level, pptr)")
+    apply (clarsimp simp: vs_lookup_table_def in_omonad)
+   apply (drule (2) valid_vspace_objs_strongD; clarsimp)
+   apply (clarsimp simp: data_at_def in_omonad obj_at_def)
+  apply (prop_tac "level' \<le> max_pt_level")
+   apply (clarsimp simp: vs_lookup_slot_def vs_lookup_table_def split: if_split_asm)
+   apply (drule pt_walk_max_level, simp)
+  apply (clarsimp simp: in_omonad)
+  apply (rename_tac pte)
+  apply (frule (5) valid_vspace_objs_strong_slotD[where level=level], clarsimp)
+  apply (prop_tac "is_PagePTE pte \<and> pgsz = vmpage_size_of_level level")
+   apply (case_tac pte; fastforce simp: data_at_def obj_at_def)
+  apply (clarsimp simp: vs_lookup_slot_def split: if_split_asm)
+  apply (rename_tac pt_ptr' pt_ptr)
+  apply (case_tac "level' \<le> level")
+   apply (drule vs_lookup_level)
+   apply (drule_tac level'=level and level=level' in vs_lookup_splitD; assumption?)
+   apply clarsimp
+   apply (subst (asm) pt_walk.simps)
+   apply (clarsimp simp: is_PagePTE_def split: if_split_asm)
+  apply (simp add: not_le)
+  apply (prop_tac "level' \<noteq> 0", clarsimp)
+  apply (frule vs_lookup_table_stopped; clarsimp)
+  apply (drule_tac level'=level' in vs_lookup_splitD; simp?)
+  apply (drule vs_lookup_level)
+  apply clarsimp
+  apply (subst (asm) pt_walk.simps)
+  apply clarsimp
+  done
+
+lemma perform_pg_inv_unmap[wp]:
+  "\<lbrace>invs and valid_page_inv (PageUnmap cap ct_slot)\<rbrace> perform_pg_inv_unmap cap ct_slot \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding perform_pg_inv_unmap_def
+  apply (wpsimp wp: arch_update_cap_invs_unmap_page hoare_vcg_ex_lift hoare_vcg_ball_lift
+                    hoare_vcg_all_lift hoare_vcg_const_imp_lift get_cap_wp unmap_page_cte_wp_at
+                    hoare_vcg_imp_lift'
+                    unmap_page_not_target unmap_page_invs)
+  apply (clarsimp simp: valid_page_inv_def cte_wp_at_caps_of_state is_cap_simps is_arch_update_def
+                        update_map_data_def cap_master_cap_simps)
+  apply (frule caps_of_state_valid, clarsimp)
+  apply (case_tac m; simp)
+   apply (clarsimp simp: valid_cap_def valid_arch_cap_def cap_aligned_def cap_master_cap_simps)
+  apply (clarsimp simp: valid_unmap_def cap_master_cap_simps valid_cap_def wellformed_mapdata_def
+                        cap_aligned_def)
+  apply (fastforce simp: data_at_def split: if_split_asm intro: valid_objs_caps)
+  done
+
+lemma perform_pg_inv_map_invs[wp]:
+  "\<lbrace>invs and valid_page_inv (PageMap cap ct_slot (pte, slot))\<rbrace>
+   perform_pg_inv_map cap ct_slot pte slot
+   \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding perform_pg_inv_map_def
+  apply (wpsimp wp: store_pte_invs arch_update_cap_invs_map hoare_vcg_all_lift hoare_vcg_imp_lift')
+  apply (clarsimp simp: valid_page_inv_def cte_wp_at_caps_of_state is_arch_update_def is_cap_simps
+                        cap_master_cap_simps parent_for_refs_def valid_slots_def same_ref_def)
+  apply (rename_tac cref cidx asid vref)
+  apply (frule caps_of_state_valid, clarsimp)
+  apply (prop_tac "is_FrameCap cap")
+   apply (cases cap; simp add: cap_master_cap_simps)
+  apply (intro conjI)
+  using vs_lookup_slot_unique_level apply blast
+       apply (clarsimp simp: is_FrameCap_def cap_master_cap_simps valid_cap_def cap_aligned_def
+                             valid_arch_cap_def)
+  using reachable_page_table_not_global vs_lookup_slot_table_unfold apply blast
+     apply (auto simp: is_PagePTE_def)[1]
+    apply (clarsimp simp: is_FrameCap_def)
+    apply (drule (1) unique_table_refsD[rotated], solves \<open>simp\<close>; clarsimp)
+   apply (clarsimp simp: vs_lookup_slot_def split: if_split_asm)
+   apply (rename_tac pt_ptr)
+   apply (frule vs_lookup_table_is_aligned; clarsimp)
+   apply (drule vspace_for_asid_vs_lookup)
+   apply (drule (1) vs_lookup_table_unique_level; clarsimp)
+   apply (drule (1) table_index_max_level_slots, simp)
+  apply clarsimp
+  apply (rule conjI, clarsimp simp: is_PagePTE_def)
+  apply (rule conjI)
+   apply (erule allE, erule impE, fastforce)
+   apply (clarsimp simp: is_PagePTE_def)
+   apply (drule_tac p="(cref,cidx)" in caps_of_state_valid, clarsimp)
+   apply (clarsimp simp: valid_cap_def obj_at_def data_at_def)
+  apply (rename_tac level' asid' vref' p')
+  apply (prop_tac "level' \<le> max_pt_level")
+   apply (clarsimp simp flip: asid_pool_level_neq simp: pool_for_asid_vs_lookup)
+   apply (drule pool_for_asid_validD, clarsimp)
+   apply (drule_tac p="(cref,cidx)" in caps_of_state_valid, clarsimp)
+   apply (clarsimp simp: valid_cap_def obj_at_def in_omonad)
+  apply (clarsimp simp: vs_lookup_slot_def split: if_split_asm)
+  apply (rename_tac pt_ptr)
+  apply (frule_tac bot_level=level in vs_lookup_table_is_aligned; clarsimp)
+  apply (drule (1) vs_lookup_table_unique_level; clarsimp)
+  apply (drule (1) pt_slot_offset_vref_for_level; simp)
+  apply (cases ct_slot)
+  apply fastforce
+  done
+
+lemma perform_page_invs [wp]:
+  "\<lbrace>invs and valid_page_inv pg_inv\<rbrace> perform_page_invocation pg_inv \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding perform_page_invocation_def
+  by (cases pg_inv; wpsimp)
+
+lemma asid_high_low:
+  "\<lbrakk> asid_high_bits_of asid = asid_high_bits_of asid';
+     asid_low_bits_of asid = asid_low_bits_of asid' \<rbrakk> \<Longrightarrow>
+   asid = asid'"
+  unfolding asid_high_bits_of_def asid_low_bits_of_def asid_high_bits_def asid_low_bits_def
+  by word_bitwise simp
+
+end
+
+locale asid_pool_map = Arch +
+  fixes s ap pool asid ptp pt and s' :: "'a::state_ext state"
+  defines "s' \<equiv> s\<lparr>kheap := kheap s(ap \<mapsto> ArchObj (ASIDPool (pool(asid_low_bits_of asid \<mapsto> ptp))))\<rparr>"
+  assumes ap:  "asid_pools_of s ap = Some pool"
+  assumes new: "pool (asid_low_bits_of asid) = None"
+  assumes pt:  "pts_of s ptp = Some pt"
+  assumes empty: "kernel_mappings_only pt s"
+  assumes lookup: "pool_for_asid asid s = Some ap"
+  assumes valid_vspace_objs: "valid_vspace_objs s"
+  assumes valid_asids: "valid_asid_table s"
+  assumes aligned: "is_aligned ptp pt_bits"
+begin
+
+lemma arch_state[simp]:
+  "arch_state s' = arch_state s"
+  by (simp add: s'_def)
+
+lemma pool_for_asid[simp]:
+  "pool_for_asid a s' = pool_for_asid a s"
+  by (simp add: pool_for_asid_def)
+
+lemma asid_pools_of[simp]:
+  "asid_pools_of s' = (asid_pools_of s)(ap \<mapsto> pool(asid_low_bits_of asid \<mapsto> ptp))"
+  by (simp add: s'_def)
+
+lemma pts_of[simp]:
+  "pts_of s' = pts_of s"
+proof -
+  from ap
+  have "pts_of s ap = None" by (simp add: opt_map_def split: option.splits)
+  thus ?thesis by (simp add: s'_def)
+qed
+
+lemma empty_for_user:
+  "vref \<in> user_region \<Longrightarrow>
+   pt (table_index (pt_slot_offset max_pt_level ptp vref)) = InvalidPTE"
+  using empty aligned
+  by (clarsimp simp: kernel_mappings_only_def table_index_max_level_slots)
+
+lemma vs_lookup_table:
+  "vref \<in> user_region \<Longrightarrow>
+   vs_lookup_table level asid' vref s' =
+     (if asid' = asid \<and> level \<le> max_pt_level
+      then Some (max_pt_level, ptp)
+      else vs_lookup_table level asid' vref s)"
+  apply clarsimp
+  apply (rule conjI; clarsimp)
+   using lookup
+   apply (clarsimp simp: vs_lookup_table_def vspace_for_pool_def in_omonad pool_for_asid_def)
+   apply (rule conjI, clarsimp)
+   apply (subst pt_walk.simps)
+   using pt aligned
+   apply (clarsimp simp: obind_def ptes_of_def empty_for_user)
+   apply (simp add: pt_slot_offset_def)
+   apply (erule notE)
+   apply (rule is_aligned_add)
+    apply (erule is_aligned_weaken)
+    apply (simp add: bit_simps)
+   apply (rule is_aligned_shift)
+  apply (clarsimp simp: vs_lookup_table_def)
+  apply (rule obind_eqI, simp)
+  apply clarsimp
+  using ap lookup new
+  apply (clarsimp simp: obind_def split: option.splits)
+  apply (rule conjI; clarsimp)
+   apply (clarsimp simp: vspace_for_pool_def obind_def split: option.splits if_split_asm)
+  apply (rule conjI; clarsimp)
+   apply (clarsimp simp: vspace_for_pool_def obind_def split: option.splits if_split_asm)
+   apply (clarsimp simp: pool_for_asid_def)
+   using valid_asids
+   apply (clarsimp simp: valid_asid_table_def)
+   apply (drule (2) inj_on_domD[rotated])
+   apply (drule (1) asid_high_low)
+   apply clarsimp
+  apply (clarsimp simp: vspace_for_pool_def split: if_split_asm)
+  done
+
+lemma vs_lookup_slot:
+  "vref \<in> user_region \<Longrightarrow>
+   vs_lookup_slot level asid' vref s' =
+     (if asid' = asid \<and> level \<le> max_pt_level
+      then Some (max_pt_level, pt_slot_offset max_pt_level ptp vref)
+      else vs_lookup_slot level asid' vref s)"
+  apply (simp add: vs_lookup_slot_def)
+  apply (rule conjI; clarsimp)
+   apply (clarsimp simp: in_omonad vs_lookup_table)
+  apply (rule obind_eqI; clarsimp simp: vs_lookup_table)
+  done
+
+lemma pte_refs_of_None:
+  "vref \<in> user_region \<Longrightarrow> pte_refs_of s (pt_slot_offset max_pt_level ptp vref) = None"
+  using aligned pt
+  by (clarsimp simp: ptes_of_def obind_def opt_map_def empty_for_user split: option.splits)
+
+lemma vs_lookup_table_None:
+  "level \<le> max_pt_level \<Longrightarrow> vs_lookup_table level asid vref s = None"
+  using lookup new ap
+  by (clarsimp simp: vs_lookup_table_def obind_def pool_for_asid_def vspace_for_pool_def
+               split: option.splits)
+
+lemma vs_lookup_slot_None:
+  "level \<le> max_pt_level \<Longrightarrow> vs_lookup_slot level asid vref s = None"
+  by (clarsimp simp: vs_lookup_slot_def obind_def vs_lookup_table_None)
+
+lemma vs_lookup_target:
+  "vref \<in> user_region \<Longrightarrow>
+   vs_lookup_target level asid' vref s' =
+     (if asid' = asid \<and> level = asid_pool_level
+      then Some (level, ptp)
+      else vs_lookup_target level asid' vref s)"
+  apply clarsimp
+  apply (rule conjI; clarsimp)
+   apply (clarsimp simp: vs_lookup_target_def in_omonad vs_lookup_slot)
+   apply (clarsimp simp: vs_lookup_slot_def vs_lookup_table_def in_omonad)
+   using lookup
+   apply (simp add: pool_for_asid_def vspace_for_pool_def in_omonad)
+  apply (cases "asid' = asid")
+   apply clarsimp
+   apply (clarsimp simp: vs_lookup_target_def)
+   apply (clarsimp simp: obind_def vs_lookup_slot_None vs_lookup_slot pte_refs_of_None)
+  apply clarsimp
+  apply (simp add: vs_lookup_target_def obind_def)
+  apply (clarsimp simp: vs_lookup_slot)
+  apply (cases "vs_lookup_slot level asid' vref s"; clarsimp)
+  apply (rule conjI; clarsimp)
+   prefer 2
+   apply (simp split: option.splits)
+  apply (clarsimp simp: vs_lookup_slot_def split: if_split_asm)
+  apply (clarsimp simp: vs_lookup_table_def in_omonad split: if_split_asm)
+  apply (erule disjE; clarsimp)
+   apply (drule pt_walk_max_level, simp)
+  apply (rename_tac ap')
+  apply (subgoal_tac "ap' \<noteq> ap \<or> asid_low_bits_of asid' \<noteq> asid_low_bits_of asid")
+   using ap
+   apply (simp add: vspace_for_pool_def obind_def split: option.splits)
+  using lookup valid_asids
+  apply (clarsimp simp: valid_asid_table_def pool_for_asid_def)
+  apply (drule (2) inj_on_domD[rotated])
+  apply (drule (1) asid_high_low)
+  apply clarsimp
+  done
+
+lemma valid_pool:
+  "valid_vspace_obj asid_pool_level (ASIDPool pool) s"
+proof -
+  from lookup
+  have "vs_lookup_table asid_pool_level asid 0 s = Some (asid_pool_level, ap)"
+    by (clarsimp simp: vs_lookup_table_def in_omonad)
+  with valid_vspace_objs ap
+  show ?thesis by (fastforce dest: valid_vspace_objsD simp: in_omonad)
+qed
+
+lemma valid_pte:
+  "valid_pte level pte s \<Longrightarrow> valid_pte level pte s'"
+  using ap
+  apply (cases pte; simp add: pt_at_eq)
+  apply (clarsimp simp: data_at_def obj_at_def s'_def in_omonad)
+  done
+
+lemma valid_vspace_obj:
+  "valid_vspace_obj level ao s \<Longrightarrow> valid_vspace_obj level ao s'"
+  by (cases ao; simp add: pt_at_eq valid_pte)
+
+end
+
+context Arch begin global_naming RISCV64
+
+lemma set_asid_pool_arch_objs_map:
+  "\<lbrace>valid_vspace_objs and valid_arch_state and valid_global_objs and
+    valid_kernel_mappings and pspace_aligned and
+    (\<lambda>s. asid_pools_of s ap = Some pool) and
+    K (pool (asid_low_bits_of asid) = None) and
+    (\<lambda>s. pool_for_asid asid s = Some ap) and
+    (\<lambda>s. \<exists>pt. pts_of s pt_ptr = Some pt \<and> kernel_mappings_only pt s) \<rbrace>
+  set_asid_pool ap (pool(asid_low_bits_of asid \<mapsto> pt_ptr))
+  \<lbrace>\<lambda>rv. valid_vspace_objs\<rbrace>"
+  unfolding set_asid_pool_def
+  supply fun_upd_apply[simp del]
+  apply (wpsimp wp: set_object_wp)
+  apply (frule (5) asid_pool_map.intro)
+    apply (clarsimp simp: valid_arch_state_def)
+   apply (erule pspace_aligned_pts_ofD, simp)
+  apply (subst valid_vspace_objs_def)
+  apply (clarsimp simp: asid_pool_map.vs_lookup_table split: if_split_asm)
+   apply (clarsimp simp: in_omonad fun_upd_apply kernel_mappings_only_def split: if_split_asm)
+  apply (clarsimp simp: in_omonad fun_upd_apply split: if_split_asm)
+   prefer 2
+   apply (frule (2) valid_vspace_objsD)
+    apply (simp add: in_omonad)
+   apply (simp add: asid_pool_map.valid_vspace_obj)
+  apply (clarsimp simp: obj_at_def fun_upd_apply)
+  apply (rule conjI; clarsimp)
+  apply (frule asid_pool_map.valid_pool)
+  apply (fastforce simp: obj_at_def)
+  done
+
+lemma caps_of_state_fun_upd:
+  "obj_at (same_caps val) p s \<Longrightarrow>
+   (caps_of_state (s\<lparr>kheap := (kheap s) (p \<mapsto> val)\<rparr>)) = caps_of_state s"
+  apply (drule caps_of_state_after_update)
+  apply (simp add: fun_upd_def)
+  done
+
+lemma set_asid_pool_valid_arch_caps_map:
+  "\<lbrace>valid_arch_caps and valid_arch_state and valid_global_objs and valid_objs
+    and valid_vspace_objs and pspace_aligned and
+    (\<lambda>s. asid_pools_of s ap = Some pool \<and> pool_for_asid asid s = Some ap \<and>
+         (\<exists>ptr cap. caps_of_state s ptr = Some cap \<and> obj_refs cap = {pt_ptr} \<and>
+                    vs_cap_ref cap = Some (asid, 0)))
+    and (\<lambda>s. \<exists>pt. pts_of s pt_ptr = Some pt \<and> kernel_mappings_only pt s)
+    and K (pool (asid_low_bits_of asid) = None \<and> 0 < asid)\<rbrace>
+  set_asid_pool ap (pool(asid_low_bits_of asid \<mapsto> pt_ptr))
+  \<lbrace>\<lambda>rv. valid_arch_caps\<rbrace>"
+  unfolding set_asid_pool_def
+  supply fun_upd_apply[simp del]
+  apply (wpsimp wp: set_object_wp)
+  apply (frule (5) asid_pool_map.intro)
+    apply (clarsimp simp: valid_arch_state_def)
+   apply (erule pspace_aligned_pts_ofD, simp)
+  apply (clarsimp simp: valid_arch_caps_def)
+  apply (simp add: caps_of_state_fun_upd obj_at_def)
+  apply (subgoal_tac "pts_of s ap = None")
+   prefer 2
+   apply (clarsimp simp: opt_map_def)
+  apply simp
+  apply (clarsimp simp: valid_vs_lookup_def caps_of_state_fun_upd obj_at_def)
+  apply (clarsimp simp: asid_pool_map.vs_lookup_target split: if_split_asm)
+  by (fastforce simp: vref_for_level_asid_pool user_region_def)
+
+lemma kernel_mappings_only_has:
+  "kernel_mappings_only pt s \<Longrightarrow> has_kernel_mappings pt s"
+  by (simp add: kernel_mappings_only_def)
+
+lemma toplevel_pt_has_kernel_mappings:
+  assumes ap: "pool_for_asid asid s = Some ap"
+  assumes pool: "asid_pools_of s ap = Some pool"
+  assumes p: "p \<in> ran pool"
+  assumes pt: "pts_of s p = Some pt"
+  assumes km: "equal_kernel_mappings s"
+  assumes vsl: "valid_vs_lookup s"
+  shows "has_kernel_mappings pt s"
+proof -
+  from ap
+  have "vs_lookup_table asid_pool_level asid 0 s = Some (asid_pool_level, ap)"
+    by (simp add: vs_lookup_table_def in_omonad)
+  with pool p
+  obtain asid' where
+    vs_target: "vs_lookup_target asid_pool_level asid' 0 s = Some (asid_pool_level, p)"
+    by (auto dest: vs_lookup_table_ap_step)
+  with vsl
+  have "asid' \<noteq> 0" by (fastforce simp add: valid_vs_lookup_def)
+  with vs_target
+  have "vspace_for_asid asid' s = Some p"
+    by (clarsimp simp: vspace_for_pool_def in_omonad vs_lookup_target_def vs_lookup_slot_def
+                       vs_lookup_table_def vspace_for_asid_def word_neq_0_conv)
+  with km pt
+  show ?thesis by (simp add: equal_kernel_mappings_def)
+qed
+
+lemma set_asid_pool_invs_map:
+  "\<lbrace>invs and
+    (\<lambda>s. asid_pools_of s ap = Some pool \<and> pool_for_asid asid s = Some ap \<and>
+         (\<exists>ptr cap. caps_of_state s ptr = Some cap \<and> obj_refs cap = {pt_ptr} \<and>
+                    vs_cap_ref cap = Some (asid, 0)))
+    and (\<lambda>s. \<exists>pt. pts_of s pt_ptr = Some pt \<and> kernel_mappings_only pt s)
+    and K (pool (asid_low_bits_of asid) = None \<and> 0 < asid)\<rbrace>
+  set_asid_pool ap (pool(asid_low_bits_of asid \<mapsto> pt_ptr))
+  \<lbrace>\<lambda>rv. invs\<rbrace>"
+  apply (simp add: invs_def valid_state_def valid_pspace_def valid_asid_map_def)
+  apply (wpsimp wp: valid_irq_node_typ set_asid_pool_typ_at set_asid_pool_arch_objs_map
+                    valid_irq_handlers_lift set_asid_pool_valid_arch_caps_map)
+  apply (erule disjE, clarsimp simp: kernel_mappings_only_has)
+  apply (erule (4) toplevel_pt_has_kernel_mappings)
+  apply (simp add: valid_arch_caps_def)
+  done
+
+lemma ako_asid_pools_of:
+  "ako_at (ASIDPool pool) ap s = (asid_pools_of s ap = Some pool)"
+  by (clarsimp simp: obj_at_def in_omonad)
+
+lemma copy_global_mappings_asid_pools[wp]:
+  "copy_global_mappings pt_ptr \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
+  unfolding copy_global_mappings_def by (wpsimp wp: mapM_x_wp')
+
+lemma copy_global_mappings_pool_for_asid[wp]:
+  "copy_global_mappings pt_ptr \<lbrace>\<lambda>s. P (pool_for_asid asid s)\<rbrace>"
+  unfolding copy_global_mappings_def by (wpsimp wp: mapM_x_wp' simp: pool_for_asid_def)
+
+lemma copy_global_mappings_caps_of_state[wp]:
+  "copy_global_mappings pt_ptr \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace>"
+  unfolding copy_global_mappings_def by (wpsimp wp: mapM_x_wp')
+
+lemma store_pte_vs_lookup_target_unreachable:
+  "\<lbrace>\<lambda>s. (\<forall>level. \<not> \<exists>\<rhd> (level, table_base p) s) \<and>
+        vref \<in> user_region \<and>
+        vs_lookup_target bot_level asid vref s \<noteq> Some (level, p') \<and>
+        pspace_aligned s \<and> valid_vspace_objs s \<and> valid_asid_table s \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>rv s. vs_lookup_target bot_level asid vref s \<noteq> Some (level, p')\<rbrace>"
+  unfolding store_pte_def set_pt_def
+  apply (wpsimp wp: set_object_wp)
+  apply (subst (asm) vs_lookup_target_unreachable_upd_idem; clarsimp)
+  done
+
+lemma store_pte_vs_lookup_table_unreachable:
+  "\<lbrace>\<lambda>s. (\<forall>level. \<not> \<exists>\<rhd> (level, table_base p) s) \<and>
+        vref \<in> user_region \<and>
+        vs_lookup_table bot_level asid vref s \<noteq> Some (level, p') \<and>
+        pspace_aligned s \<and> valid_vspace_objs s \<and> valid_asid_table s \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>rv s. vs_lookup_table bot_level asid vref s \<noteq> Some (level, p')\<rbrace>"
+  unfolding store_pte_def set_pt_def
+  apply (wpsimp wp: set_object_wp)
+  apply (subst (asm) vs_lookup_table_unreachable_upd_idem'; clarsimp)
+  done
+
+lemma store_pte_valid_arch_state_unreachable:
+  "\<lbrace>valid_arch_state and valid_global_vspace_mappings and (\<lambda>s. table_base p \<notin> global_refs s) \<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
+  unfolding valid_arch_state_def by (wpsimp wp: store_pte_valid_global_tables)
+
+lemma store_pte_valid_vs_lookup_unreachable:
+  "\<lbrace>valid_vs_lookup and pspace_aligned and valid_vspace_objs and valid_asid_table and
+    (\<lambda>s. \<forall>level. \<not> \<exists>\<rhd> (level, table_base p) s)\<rbrace>
+   store_pte p pte
+   \<lbrace>\<lambda>_. valid_vs_lookup\<rbrace>"
+  unfolding valid_vs_lookup_def
+  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' store_pte_vs_lookup_target_unreachable)
+  apply (erule disjE; clarsimp)
+  done
+
+lemma store_pte_valid_arch_caps_unreachable:
+  "\<lbrace> invs and
+     (\<lambda>s. \<forall>level. \<not> \<exists>\<rhd> (level, table_base p) s) and
+     (\<lambda>s. \<forall>slot asidopt. caps_of_state s slot = Some (ArchObjectCap (PageTableCap (table_base p) asidopt))
+                          \<longrightarrow> asidopt \<noteq> None) and
+     (\<lambda>s. table_base p \<notin> global_refs s) \<rbrace>
+   store_pte p pte
+   \<lbrace> \<lambda>_. valid_arch_caps \<rbrace>"
+  unfolding valid_arch_caps_def
+  apply (wpsimp wp: store_pte_valid_vs_lookup_unreachable store_pte_valid_table_caps)
+  by (fastforce simp: invs_def valid_state_def valid_arch_caps_def intro: valid_objs_caps)
+
+lemma store_pte_invs_unreachable:
+  "\<lbrace>invs and
+    (\<lambda>s. \<forall>level. \<not> \<exists>\<rhd> (level, table_base p) s) and
+    K (wellformed_pte pte) and
+    (\<lambda>s. \<forall>slot asidopt. caps_of_state s slot = Some (ArchObjectCap (PageTableCap (table_base p) asidopt))
+                         \<longrightarrow> asidopt \<noteq> None) and
+    (\<lambda>s. table_base p \<notin> global_refs s) \<rbrace>
+  store_pte p pte \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding invs_def valid_state_def valid_pspace_def
+  apply (wpsimp wp: store_pte_valid_arch_state_unreachable store_pte_valid_arch_caps_unreachable
+                    store_pte_equal_kernel_mappings_no_kernel_slots
+                    store_pte_valid_global_vspace_mappings
+                    store_pte_valid_vspace_objs)
+  apply (simp add: invs_def valid_state_def valid_pspace_def valid_arch_state_def
+                   valid_arch_caps_def valid_objs_caps
+              cong: conj_cong)
+  apply (rule conjI, fastforce dest!: vspace_for_asid_vs_lookup)
+  apply (fastforce simp: valid_arch_state_def dest: riscv_global_pt_in_global_refs)
+  done
+
+lemma invs_valid_global_vspace_mappings[elim!]:
+  "invs s \<Longrightarrow> valid_global_vspace_mappings s"
+  by (clarsimp simp: invs_def valid_state_def)
+
+lemma is_aligned_pte_offset:
+  "is_aligned pt_ptr pt_bits \<Longrightarrow>
+   is_aligned (pt_ptr + (i << pte_bits)) pte_bits"
+  apply (rule is_aligned_add)
+   apply (erule is_aligned_weaken, simp add: bit_simps)
+  apply (simp add: is_aligned_shiftl)
+  done
+
+lemma ptes_of_from_pt:
+  "\<lbrakk> pts pt_ptr = Some pt; is_aligned pt_ptr pt_bits; i \<le> mask ptTranslationBits \<rbrakk> \<Longrightarrow>
+   pte_of (pt_ptr + (i << pte_bits)) pts = Some (pt (ucast i))"
+  by (clarsimp simp: ptes_of_def in_omonad table_base_plus table_index_plus is_aligned_pte_offset)
+
+lemma ptes_of_from_pt_ucast:
+  "\<lbrakk> pts_of s pt_ptr = Some pt; is_aligned pt_ptr pt_bits \<rbrakk> \<Longrightarrow>
+   ptes_of s (pt_ptr + (ucast (i::pt_index) << pte_bits)) = Some (pt i)"
+  apply (drule (1) ptes_of_from_pt[where i="ucast i"])
+   apply (rule ucast_leq_mask, simp add: bit_simps)
+  apply (simp add: is_down_def target_size_def source_size_def word_size ucast_down_ucast_id)
+  done
+
+lemma copy_global_mappings_copies[wp]:
+  "\<lbrace>invs and (\<lambda>s. pts_of s pt_ptr = Some empty_pt \<and> pt_ptr \<notin> global_refs s)\<rbrace>
+   copy_global_mappings pt_ptr
+   \<lbrace>\<lambda>_ s. \<exists>pt. pts_of s pt_ptr = Some pt \<and> kernel_mappings_only pt s\<rbrace>"
+  unfolding copy_global_mappings_def
+  apply wp
+      apply (rule hoare_strengthen_post)
+       apply (rule_tac I="\<lambda>s. (\<exists>pt. pts_of s pt_ptr = Some pt \<and>
+                                    (\<forall>idx. idx \<notin> kernel_mapping_slots \<longrightarrow> pt idx = InvalidPTE)) \<and>
+                              pt_at (riscv_global_pt (arch_state s)) s \<and>
+                              pt_ptr \<noteq> riscv_global_pt (arch_state s) \<and>
+                              is_aligned pt_ptr pt_bits \<and>
+                              is_aligned global_pt pt_bits \<and>
+                              global_pt = riscv_global_pt (arch_state s) \<and>
+                              base = pt_index max_pt_level pptr_base \<and>
+                              pt_size = 1 << ptTranslationBits" and
+                       V="\<lambda>xs s. \<forall>i \<in> set xs. ptes_of s (pt_ptr + (i << pte_bits)) =
+                                              ptes_of s (global_pt + (i << pte_bits))"
+                       in mapM_x_inv_wp3)
+        apply (wp store_pte_typ_ats|wps)+
+       apply (clarsimp simp del: fun_upd_apply)
+       apply (fold mask_2pm1)[1]
+       apply (drule word_enum_decomp)
+       apply (clarsimp simp: table_base_plus table_index_plus in_omonad)
+       apply (subgoal_tac "ucast a \<in> kernel_mapping_slots")
+        prefer 2
+        apply (clarsimp simp: kernel_mapping_slots_def pt_index_def)
+        apply (drule ucast_mono_le[where x="a && b" and 'b=pt_index_len for a b])
+         apply (simp add: bit_simps mask_def)
+         apply unat_arith
+        apply (simp add: ucast_mask_drop bit_simps)
+       apply (clarsimp simp: pt_at_eq ptes_of_from_pt)
+       apply (drule (1) bspec)
+       apply (clarsimp simp: ptes_of_from_pt in_omonad)
+      apply (clarsimp simp: kernel_mappings_only_def)
+      apply (clarsimp simp: has_kernel_mappings_def)
+      apply (thin_tac "\<forall>idx. idx \<notin> kernel_mapping_slots \<longrightarrow> P idx" for P)
+      apply (erule_tac x="ucast i" in allE)
+      apply (erule impE)
+       apply (simp add: kernel_mapping_slots_def pt_index_def)
+       apply word_bitwise
+       subgoal
+         by (clarsimp simp: word_size bit_simps word_bits_def canonical_bit_def pt_bits_left_def
+                            level_defs rev_bl_order_simps)
+      apply (clarsimp simp: ptes_of_from_pt_ucast)
+     apply wp+
+   apply (fastforce elim!: pts_of_Some_alignedD
+                    intro: invs_valid_global_arch_objs valid_global_arch_objs_pt_at
+                           riscv_global_pt_in_global_refs valid_global_vspace_mappings_aligned)
+  done
+
+lemma copy_global_mappings_invs:
+  "\<lbrace> invs and K (is_aligned pt_ptr pt_bits) and
+     (\<lambda>s. \<forall>level. \<not> \<exists>\<rhd> (level, pt_ptr) s) and
+     (\<lambda>s. \<forall>slot asidopt. caps_of_state s slot = Some (ArchObjectCap (PageTableCap pt_ptr asidopt))
+                           \<longrightarrow> asidopt \<noteq> None) and
+     (\<lambda>s. pt_ptr \<notin> global_refs s)\<rbrace>
+   copy_global_mappings pt_ptr
+   \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding copy_global_mappings_def
+  apply wp
+      apply (rule hoare_strengthen_post)
+       apply (rule_tac P="invs and K (is_aligned pt_ptr pt_bits) and
+                          (\<lambda>s. \<forall>level. \<not> \<exists>\<rhd> (level, pt_ptr) s) and
+                          (\<lambda>s. \<forall>slot asidopt. caps_of_state s slot =
+                                                Some (ArchObjectCap (PageTableCap pt_ptr asidopt))
+                                                  \<longrightarrow> asidopt \<noteq> None) and
+                          (\<lambda>s. pt_ptr \<notin> global_refs s \<and>
+                               base = pt_index max_pt_level pptr_base \<and>
+                               pt_size = 1 << ptTranslationBits)" in mapM_x_wp')
+       apply (wpsimp wp: store_pte_invs_unreachable hoare_vcg_all_lift hoare_vcg_imp_lift'
+                         store_pte_vs_lookup_table_unreachable)
+       apply (fold mask_2pm1)[1]
+       apply (clarsimp simp: table_base_plus table_index_plus)
+       apply (rule conjI, erule ptes_of_wellformed_pte, clarsimp)
+       apply clarsimp
+       apply (frule invs_valid_asid_table)
+       apply simp
+       apply (erule impE, fastforce)+
+       apply fastforce
+      apply fastforce
+     apply wp+
+  apply clarsimp
+  done
+
+lemma cap_asid_pt_None[simp]:
+  "(cap_asid (ArchObjectCap (PageTableCap p m)) = None) = (m = None)"
+  by (simp add: cap_asid_def split: option.splits)
+
+lemma perform_asid_pool_invs [wp]:
+  "\<lbrace>invs and valid_apinv api\<rbrace> perform_asid_pool_invocation api \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (clarsimp simp: perform_asid_pool_invocation_def store_asid_pool_entry_def
+                  split: asid_pool_invocation.splits)
+  apply (wpsimp wp: set_asid_pool_invs_map hoare_vcg_all_lift hoare_vcg_imp_lift'
+                    copy_global_mappings_invs arch_update_cap_invs_map get_cap_wp set_cap_typ_at
+                simp: ako_asid_pools_of
+         | wp (once) hoare_vcg_ex_lift)+
+  apply (clarsimp simp: cte_wp_at_caps_of_state valid_apinv_def cong: conj_cong)
+  apply (rename_tac asid pool_ptr slot_ptr slot_idx s pool cap)
+  apply (clarsimp simp: is_cap_simps update_map_data_def is_arch_update_def is_arch_cap_def
+                        cap_master_cap_simps asid_low_bits_of_def)
+  apply (frule caps_of_state_valid, clarsimp)
+  apply (clarsimp simp: valid_cap_def cap_aligned_def wellformed_mapdata_def bit_simps)
+  apply (frule valid_table_caps_pdD, fastforce)
+  apply (frule valid_global_refsD2, fastforce)
+  apply (clarsimp simp: cap_range_def)
+  apply (rule conjI, clarsimp)
+   apply (drule (1) vs_lookup_table_valid_cap; clarsimp)
+   apply (frule (1) cap_to_pt_is_pt_cap, simp, fastforce intro: valid_objs_caps)
+   apply (drule (1) unique_table_refsD[rotated]; clarsimp)
+   apply (clarsimp simp: is_cap_simps)
+  apply (rule conjI, clarsimp)
+   apply (drule (1) unique_table_capsD[rotated]; clarsimp)
+  apply fastforce
+  done
+
+lemma invs_aligned_pdD:
+  "\<lbrakk> pspace_aligned s; valid_arch_state s \<rbrakk> \<Longrightarrow> is_aligned (riscv_global_pt (arch_state s)) pt_bits"
+  by (clarsimp simp: valid_arch_state_def)
+
+lemma do_machine_op_valid_kernel_mappings:
+  "do_machine_op f \<lbrace>valid_kernel_mappings\<rbrace>"
+  unfolding valid_kernel_mappings_def by wp
+
+lemma valid_vspace_obj_default:
+  assumes tyunt: "ty \<noteq> Structures_A.apiobject_type.Untyped"
+  shows "ArchObj ao = default_object ty dev us \<Longrightarrow> valid_vspace_obj level ao s'"
+  by (cases ty; simp add: default_object_def tyunt)
+
+end
+
+context begin interpretation Arch .
+requalify_facts
+  do_machine_op_valid_kernel_mappings
+end
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
@@ -543,7 +543,7 @@ lemma arch_update_cap_invs_unmap_page_table:
              and real_cte_at p
              and invs and valid_cap cap
              and (\<lambda>s. cte_wp_at (\<lambda>c. is_final_cap' c s) p s)
-             and (\<lambda>s. pts_of s (obj_ref_of cap) = Some (empty_pt FIXME_level))
+             and (\<lambda>s. pts_of s (obj_ref_of cap) = Some (empty_pt (cap_pt_type cap)))
              and (\<lambda>s. cte_wp_at (\<lambda>c. \<forall>asid vref level. vs_cap_ref c = Some (asid, vref)
                                 \<longrightarrow> vs_lookup_target level asid vref s \<noteq> Some (level, obj_ref_of cap)) p s)
              and K (is_pt_cap cap \<and> vs_cap_ref cap = None)\<rbrace>
@@ -581,9 +581,8 @@ lemma arch_update_cap_invs_unmap_page_table:
                           cte_wp_at_caps_of_state)
     apply fastforce
    apply (clarsimp simp: obj_at_def empty_table_def in_omonad)
-  sorry (* FIXME AARCH64
   apply fastforce
-  done *)
+  done
 
 lemma global_refs_arch_update_eq:
   "arm_us_global_vspace (f (arch_state s)) = arm_us_global_vspace (arch_state s) \<Longrightarrow>
@@ -1061,6 +1060,7 @@ lemma perform_pt_inv_unmap_invs[wp]:
                     mapM_x_store_pte_unreachable hoare_vcg_ball_lift
                     unmap_page_table_not_target real_cte_at_typ_valid
                 simp: cte_wp_at_caps_of_state)
+  sorry (* FIXME AARCH64
   apply (clarsimp simp: valid_pti_def cte_wp_at_caps_of_state)
   apply (clarsimp simp: is_arch_update_def is_cap_simps is_PageTableCap_def
                         update_map_data_def valid_cap_def valid_arch_cap_def cap_aligned_def)
@@ -1072,7 +1072,6 @@ lemma perform_pt_inv_unmap_invs[wp]:
   apply (clarsimp simp: wellformed_mapdata_def valid_cap_def cap_aligned_def cap_master_cap_simps)
   apply (rule conjI)
    apply clarsimp
-  sorry (* FIXME AARCH64
    apply (prop_tac "is_aligned p pt_bits", simp add: bit_simps)
    apply (subst (asm) upto_enum_step_shift_red; simp?)
      apply (simp add: bit_simps)

--- a/proof/invariant-abstract/AARCH64/Machine_AI.thy
+++ b/proof/invariant-abstract/AARCH64/Machine_AI.thy
@@ -1,0 +1,382 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(*
+Properties of machine operations.
+*)
+
+theory Machine_AI
+imports Bits_AI
+begin
+
+
+definition
+  "no_irq f \<equiv> \<forall>P. \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks s)\<rbrace>"
+
+lemma wpc_helper_no_irq:
+  "no_irq f \<Longrightarrow>  wpc_helper (P, P') (Q, Q') (no_irq f)"
+  by (simp add: wpc_helper_def)
+
+wpc_setup "\<lambda>m. no_irq m" wpc_helper_no_irq
+
+ML \<open>
+structure CrunchNoIrqInstance : CrunchInstance =
+struct
+  val name = "no_irq";
+  val prefix_name_scheme = true;
+  type extra = unit;
+  val eq_extra = op =;
+  fun parse_extra ctxt extra
+        = case extra of
+            "" => (Syntax.parse_term ctxt "%_. True", ())
+          | _ => error "no_irq does not need a precondition";
+  val has_preconds = false;
+  fun mk_term _ body _ =
+    (Syntax.parse_term @{context} "no_irq") $ body;
+  fun dest_term (Const (@{const_name no_irq}, _) $ body)
+    = SOME (Term.dummy, body, ())
+    | dest_term _ = NONE;
+  fun put_precond _ _ = error "crunch no_irq should not be calling put_precond";
+  val pre_thms = [];
+  val wpc_tactic = wp_cases_tactic_weak;
+  fun wps_tactic _ _ _ = no_tac;
+  val magic = Syntax.parse_term @{context}
+    "\<lambda>mapp_lambda_ignore. no_irq mapp_lambda_ignore";
+  val get_monad_state_type = get_nondet_monad_state_type;
+end;
+
+structure CrunchNoIrq : CRUNCH = Crunch(CrunchNoIrqInstance);
+\<close>
+
+setup \<open>
+  add_crunch_instance "no_irq" (CrunchNoIrq.crunch_x, CrunchNoIrq.crunch_ignore_add_dels)
+\<close>
+
+crunch_ignore (no_irq) (add:
+  NonDetMonad.bind return "when" get gets fail
+  assert put modify unless select
+  alternative assert_opt gets_the
+  returnOk throwError lift bindE
+  liftE whenE unlessE throw_opt
+  assertE liftM liftME sequence_x
+  zipWithM_x mapM_x sequence mapM sequenceE_x
+  mapME_x catch select_f
+  handleE' handleE handle_elseE forM forM_x
+  zipWithM ignore_failure)
+
+context Arch begin
+
+lemma det_getRegister: "det (getRegister x)"
+  by (simp add: getRegister_def)
+
+lemma det_setRegister: "det (setRegister x w)"
+  by (simp add: setRegister_def det_def modify_def get_def put_def bind_def)
+
+
+lemma det_getRestartPC: "det getRestartPC"
+  by (simp add: getRestartPC_def det_getRegister)
+
+
+lemma det_setNextPC: "det (setNextPC p)"
+  by (simp add: setNextPC_def det_setRegister)
+
+
+lemma ef_loadWord: "empty_fail (loadWord x)"
+  by (simp add: loadWord_def)
+
+
+lemma ef_storeWord: "empty_fail (storeWord x y)"
+  by (simp add: storeWord_def)
+
+
+lemma no_fail_getRestartPC: "no_fail \<top> getRestartPC"
+  by (simp add: getRestartPC_def getRegister_def)
+
+
+lemma no_fail_loadWord [wp]: "no_fail (\<lambda>_. is_aligned p 3) (loadWord p)"
+  apply (simp add: loadWord_def is_aligned_mask [symmetric])
+  apply (rule no_fail_pre)
+   apply wp
+  apply simp
+  done
+
+
+lemma no_fail_storeWord: "no_fail (\<lambda>_. is_aligned p 3) (storeWord p w)"
+  apply (simp add: storeWord_def is_aligned_mask [symmetric])
+  apply (rule no_fail_pre)
+   apply (wp)
+  apply simp
+  done
+
+
+lemma no_fail_machine_op_lift [simp]:
+  "no_fail \<top> (machine_op_lift f)"
+  by (simp add: machine_op_lift_def)
+
+
+lemma ef_machine_op_lift [simp]:
+  "empty_fail (machine_op_lift f)"
+  by (simp add: machine_op_lift_def)
+
+
+
+lemma no_fail_setNextPC: "no_fail \<top> (setNextPC pc)"
+  by (simp add: setNextPC_def setRegister_def)
+
+
+lemma no_fail_initL2Cache: "no_fail \<top> initL2Cache"
+  by (simp add: initL2Cache_def)
+
+lemma no_fail_resetTimer[wp]: "no_fail \<top> resetTimer"
+  by (simp add: resetTimer_def)
+
+
+lemma loadWord_inv: "\<lbrace>P\<rbrace> loadWord x \<lbrace>\<lambda>x. P\<rbrace>"
+  apply (simp add: loadWord_def)
+  apply wp
+  apply simp
+  done
+
+
+lemma getRestartPC_inv: "\<lbrace>P\<rbrace> getRestartPC \<lbrace>\<lambda>rv. P\<rbrace>"
+  by (simp add: getRestartPC_def getRegister_def)
+
+
+
+lemma no_fail_clearMemory[simp, wp]:
+  "no_fail (\<lambda>_. is_aligned p 3) (clearMemory p b)"
+  apply (simp add: clearMemory_def mapM_x_mapM)
+  apply (rule no_fail_pre)
+   apply (wp no_fail_mapM' no_fail_storeWord )
+  apply (clarsimp simp: upto_enum_step_def)
+  apply (erule aligned_add_aligned)
+   apply (simp add: word_size_def)
+   apply (rule is_aligned_mult_triv2 [where n = 3, simplified])
+  apply simp
+  done
+
+lemma no_fail_freeMemory[simp, wp]:
+  "no_fail (\<lambda>_. is_aligned p 3) (freeMemory p b)"
+  apply (simp add: freeMemory_def mapM_x_mapM)
+  apply (rule no_fail_pre)
+  apply (wp no_fail_mapM' no_fail_storeWord)
+  apply (clarsimp simp: upto_enum_step_def)
+  apply (erule aligned_add_aligned)
+   apply (simp add: word_size_def)
+   apply (rule is_aligned_mult_triv2 [where n = 3, simplified])
+  apply simp
+  done
+
+
+lemma no_fail_getActiveIRQ[wp]:
+  "no_fail \<top> (getActiveIRQ in_kernel)"
+  apply (simp add: getActiveIRQ_def)
+  apply (rule no_fail_pre)
+   apply (wp non_fail_select)
+  apply simp
+  done
+
+definition "irq_state_independent P \<equiv> \<forall>f s. P s \<longrightarrow> P (irq_state_update f s)"
+
+lemma getActiveIRQ_inv [wp]:
+  "\<lbrakk>irq_state_independent P\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> getActiveIRQ in_kernel \<lbrace>\<lambda>rv. P\<rbrace>"
+  apply (simp add: getActiveIRQ_def)
+  apply (wp alternative_wp select_wp)
+  apply (simp add: irq_state_independent_def)
+  done
+
+lemma no_fail_ackInterrupt[wp]: "no_fail \<top> (ackInterrupt irq)"
+  by (simp add: ackInterrupt_def)
+
+
+lemma no_fail_maskInterrupt[wp]: "no_fail \<top> (maskInterrupt irq bool)"
+  by (simp add: maskInterrupt_def)
+
+
+
+lemma no_irq_use:
+  "\<lbrakk> no_irq f; (rv,s') \<in> fst (f s) \<rbrakk> \<Longrightarrow> irq_masks s' = irq_masks s"
+  apply (simp add: no_irq_def valid_def)
+  apply (erule_tac x="\<lambda>x. x = irq_masks s" in allE)
+  apply fastforce
+  done
+
+lemma no_irq_machine_rest_lift:
+  "no_irq (machine_rest_lift f)"
+  apply (clarsimp simp: no_irq_def machine_rest_lift_def split_def)
+  apply wp
+  apply simp
+  done
+
+crunch (no_irq) no_irq[wp, simp]: machine_op_lift
+
+lemma no_irq:
+  "no_irq f \<Longrightarrow> \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks s)\<rbrace>"
+  by (simp add: no_irq_def)
+
+lemma no_irq_initL2Cache: "no_irq  initL2Cache"
+  by (simp add: initL2Cache_def)
+
+lemma no_irq_gets [simp]:
+  "no_irq (gets f)"
+  by (simp add: no_irq_def)
+
+
+lemma no_irq_resetTimer: "no_irq resetTimer"
+  by (simp add: resetTimer_def)
+
+
+lemma no_irq_debugPrint: "no_irq (debugPrint $ xs)"
+  by (simp add: no_irq_def)
+
+context notes no_irq[wp] begin
+
+lemma no_irq_ackInterrupt: "no_irq (ackInterrupt irq)"
+  by (wp | clarsimp simp: no_irq_def ackInterrupt_def)+
+
+lemma no_irq_setIRQTrigger: "no_irq (setIRQTrigger irq bool)"
+  by (wp | clarsimp simp: no_irq_def setIRQTrigger_def)+
+
+lemma no_irq_loadWord: "no_irq (loadWord x)"
+  apply (clarsimp simp: no_irq_def)
+  apply (rule loadWord_inv)
+  done
+
+
+lemma no_irq_getActiveIRQ: "no_irq (getActiveIRQ in_kernel)"
+  apply (clarsimp simp: no_irq_def)
+  apply (rule getActiveIRQ_inv)
+  apply (simp add: irq_state_independent_def)
+  done
+
+
+lemma no_irq_mapM:
+  "(\<And>x. x \<in> set xs \<Longrightarrow> no_irq (f x)) \<Longrightarrow> no_irq (mapM f xs)"
+  apply (subst no_irq_def)
+  apply clarify
+  apply (rule mapM_wp)
+   prefer 2
+   apply (rule order_refl)
+  apply (wp; simp)
+  done
+
+
+lemma no_irq_mapM_x:
+  "(\<And>x. x \<in> set xs \<Longrightarrow> no_irq (f x)) \<Longrightarrow> no_irq (mapM_x f xs)"
+  apply (subst no_irq_def)
+  apply clarify
+  apply (rule mapM_x_wp)
+   prefer 2
+   apply (rule order_refl)
+  apply (wp; simp)
+  done
+
+
+lemma no_irq_swp:
+  "no_irq (f y x) \<Longrightarrow> no_irq (swp f x y)"
+  by (simp add: swp_def)
+
+
+lemma no_irq_seq [wp]:
+  "\<lbrakk> no_irq f; \<And>x. no_irq (g x) \<rbrakk> \<Longrightarrow> no_irq (f >>= g)"
+  apply (subst no_irq_def)
+  apply clarsimp
+  apply (rule hoare_seq_ext)
+  apply (wp|simp)+
+  done
+
+lemma no_irq_return [simp, wp]: "no_irq (return v)"
+  unfolding no_irq_def return_def
+  by (rule allI, simp add: valid_def)
+
+
+lemma no_irq_fail [simp, wp]: "no_irq fail"
+  unfolding no_irq_def fail_def
+  by (rule allI, simp add: valid_def)
+
+
+
+lemma no_irq_assert [simp, wp]: "no_irq (assert P)"
+  unfolding assert_def by simp
+
+lemma no_irq_modify:
+  "(\<And>s. irq_masks (f s) = irq_masks s) \<Longrightarrow> no_irq (modify f)"
+  unfolding modify_def no_irq_def
+  apply (rule allI, simp add: valid_def put_def get_def)
+  apply (clarsimp simp: in_monad)
+  done
+
+lemma no_irq_storeWord: "no_irq (storeWord w p)"
+  apply (simp add: storeWord_def)
+  apply (wp no_irq_modify)
+  apply simp
+  done
+
+lemma no_irq_when:
+  "\<lbrakk>P \<Longrightarrow> no_irq f\<rbrakk> \<Longrightarrow> no_irq (when P f)"
+  by (simp add: when_def)
+
+lemma no_irq_clearMemory: "no_irq (clearMemory a b)"
+  apply (simp add: clearMemory_def)
+  apply (wp no_irq_mapM_x no_irq_storeWord)
+  done
+
+lemma getActiveIRQ_le_maxIRQ':
+  "\<lbrace>\<lambda>s. \<forall>irq > maxIRQ. irq_masks s irq\<rbrace>
+    getActiveIRQ in_kernel
+   \<lbrace>\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ\<rbrace>"
+  apply (simp add: getActiveIRQ_def)
+  apply (wp alternative_wp select_wp)
+  apply clarsimp
+  apply (rule ccontr)
+  apply (simp add: linorder_not_le)
+  done
+
+lemma getActiveIRQ_neq_non_kernel:
+  "\<lbrace>\<top>\<rbrace> getActiveIRQ True \<lbrace>\<lambda>rv s. rv \<notin> Some ` non_kernel_IRQs \<rbrace>"
+  apply (simp add: getActiveIRQ_def)
+  apply (wp alternative_wp select_wp)
+  apply auto
+  done
+
+lemma dmo_getActiveIRQ_non_kernel[wp]:
+  "\<lbrace>\<top>\<rbrace> do_machine_op (getActiveIRQ True)
+   \<lbrace>\<lambda>rv s. \<forall>irq. rv = Some irq \<longrightarrow> irq \<in> non_kernel_IRQs \<longrightarrow> P irq s\<rbrace>"
+  unfolding do_machine_op_def
+  apply wpsimp
+  apply (drule use_valid, rule getActiveIRQ_neq_non_kernel, rule TrueI)
+  apply clarsimp
+  done
+
+lemma empty_fail_initL2Cache: "empty_fail initL2Cache"
+  by (simp add: initL2Cache_def)
+
+lemma empty_fail_clearMemory [simp, intro!]:
+  "\<And>a b. empty_fail (clearMemory a b)"
+  by (simp add: clearMemory_def mapM_x_mapM ef_storeWord)
+
+lemma no_irq_setVSpaceRoot:
+  "no_irq (setVSpaceRoot r a)"
+  unfolding setVSpaceRoot_def by wpsimp
+
+lemma no_irq_hwASIDFlush:
+  "no_irq (hwASIDFlush r)"
+  unfolding hwASIDFlush_def by wpsimp
+
+end
+end
+
+context begin interpretation Arch .
+
+requalify_facts
+  det_getRegister
+  det_setRegister
+  det_getRestartPC
+  det_setNextPC
+
+end
+
+end

--- a/proof/invariant-abstract/AARCH64/Machine_AI.thy
+++ b/proof/invariant-abstract/AARCH64/Machine_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -236,17 +237,23 @@ lemma no_irq_resetTimer: "no_irq resetTimer"
 lemma no_irq_debugPrint: "no_irq (debugPrint $ xs)"
   by (simp add: no_irq_def)
 
+crunch_ignore (add: dsb_impl)
+
 (* hyp-related machine op no_irq/no_fail/empty_fail rules
    FIXME: names are not in legacy no_irq_* form, so relying on adding them to relevant sets *)
 
 crunch_ignore (empty_fail)
   (add: writeVCPUHardwareReg_impl set_gic_vcpu_ctrl_vmcr_impl set_gic_vcpu_ctrl_apr_impl
         set_gic_vcpu_ctrl_lr_impl get_gic_vcpu_ctrl_lr_impl set_gic_vcpu_ctrl_hcr_impl
-        setSCTLR_impl addressTranslateS1_impl)
+        setSCTLR_impl setHCR_impl addressTranslateS1_impl)
 crunch_ignore (no_fail)
   (add: writeVCPUHardwareReg_impl set_gic_vcpu_ctrl_vmcr_impl set_gic_vcpu_ctrl_apr_impl
         set_gic_vcpu_ctrl_lr_impl get_gic_vcpu_ctrl_lr_impl set_gic_vcpu_ctrl_hcr_impl
-        setSCTLR_impl addressTranslateS1_impl)
+        setSCTLR_impl setHCR_impl addressTranslateS1_impl)
+crunch_ignore
+  (add: writeVCPUHardwareReg_impl set_gic_vcpu_ctrl_vmcr_impl set_gic_vcpu_ctrl_apr_impl
+        set_gic_vcpu_ctrl_lr_impl get_gic_vcpu_ctrl_lr_impl set_gic_vcpu_ctrl_hcr_impl
+        setSCTLR_impl setHCR_impl addressTranslateS1_impl)
 
 crunches getSCTLR, setSCTLR, addressTranslateS1,
          readVCPUHardwareReg, writeVCPUHardwareReg,

--- a/proof/invariant-abstract/AARCH64/Machine_AI.thy
+++ b/proof/invariant-abstract/AARCH64/Machine_AI.thy
@@ -362,9 +362,10 @@ lemma no_irq_setVSpaceRoot:
   "no_irq (setVSpaceRoot r a)"
   unfolding setVSpaceRoot_def by wpsimp
 
+(* FIXME AARCH64
 lemma no_irq_hwASIDFlush:
   "no_irq (hwASIDFlush r)"
-  unfolding hwASIDFlush_def by wpsimp
+  unfolding hwASIDFlush_def by wpsimp *)
 
 end
 end

--- a/run_tests
+++ b/run_tests
@@ -64,7 +64,6 @@ EXCLUDE["RISCV64"]=[
 EXCLUDE["AARCH64"]=[
     # To be eliminated/refined as development progresses
     "ASepSpec",
-    "AInvs",
     "CKernel",
 
     # Tools and unrelated content, removed for development

--- a/run_tests
+++ b/run_tests
@@ -65,6 +65,8 @@ EXCLUDE["AARCH64"]=[
     # To be eliminated/refined as development progresses
     "ASepSpec",
     "CKernel",
+    "BaseRefine",
+    "Access",
 
     # Tools and unrelated content, removed for development
     "CParser",
@@ -74,6 +76,7 @@ EXCLUDE["AARCH64"]=[
     "Concurrency",
     "EVTutorial",
     "TakeGrant",
+    "Bisim",
 
     # Longer-term exclusions
     "AutoCorresSEL4",

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -14,9 +14,6 @@ L4V_ARCH?=ARM
 images: ASpec CKernel
 default: images test
 all: images test
-report-regression:
-	@echo ASpec ExecSpec DSpec TakeGrant CKernel CSpec \
-	      binary-verification-input
 
 #
 # Setup heaps.

--- a/spec/abstract/AARCH64/ArchCSpace_A.thy
+++ b/spec/abstract/AARCH64/ArchCSpace_A.thy
@@ -46,7 +46,7 @@ fun arch_same_region_as :: "arch_cap \<Rightarrow> arch_cap \<Rightarrow> bool" 
         topA = r + (1 << pageBitsForSize sz) - 1;
         topB = r' + (1 << pageBitsForSize sz') - 1
       in r \<le> r' \<and> topA \<ge> topB \<and> r' \<le> topB))"
-| "arch_same_region_as (PageTableCap r _ _) c' = (\<exists>r' t' d'. c' = PageTableCap r' t' d' \<and> r = r')"
+| "arch_same_region_as (PageTableCap r pt_t _) c' = (\<exists>r' d'. c' = PageTableCap r' pt_t d' \<and> r = r')"
 | "arch_same_region_as ASIDControlCap c' = (c' = ASIDControlCap)"
 | "arch_same_region_as (ASIDPoolCap r _) c' = (\<exists>r' d'. c' = ASIDPoolCap r' d' \<and> r = r')"
 | "arch_same_region_as (VCPUCap r) c' = (\<exists>r'. c' = VCPUCap r' \<and> r = r')"

--- a/spec/abstract/AARCH64/ArchDecode_A.thy
+++ b/spec/abstract/AARCH64/ArchDecode_A.thy
@@ -174,7 +174,7 @@ definition decode_pt_inv_map :: "'z::state_ext arch_decoder" where
            (level, slot) \<leftarrow> liftE $ gets_the $ pt_lookup_slot pt vaddr \<circ> ptes_of;
            old_pte \<leftarrow> liftE $ get_pte (level_type level) slot;
            whenE (pt_bits_left level = pageBits \<or> old_pte \<noteq> InvalidPTE) $ throwError DeleteFirst;
-           pte \<leftarrow> returnOk $ PageTablePTE (addrFromPPtr p);
+           pte \<leftarrow> returnOk $ PageTablePTE (ppn_from_pptr p);
            cap' <- returnOk $ PageTableCap p t $ Some (asid, vaddr && ~~mask (pt_bits_left level));
            returnOk $ InvokePageTable $ PageTableMap cap' cte pte slot level
          odE

--- a/spec/abstract/AARCH64/ArchInvocation_A.thy
+++ b/spec/abstract/AARCH64/ArchInvocation_A.thy
@@ -37,6 +37,7 @@ datatype page_table_invocation =
       (pt_inv_cslot : cslot_ptr)
       (pt_map_pte : pte)
       (pt_map_slot : obj_ref)
+      (pt_map_level : vm_level)
   | PageTableUnmap
       (pt_inv_cap : arch_cap)
       (pt_inv_cslot : cslot_ptr)
@@ -51,7 +52,7 @@ datatype page_invocation =
     PageMap
       (pg_inv_cap : arch_cap)
       (pg_inv_cslot : cslot_ptr)
-      (pg_inv_entries : "pte \<times> obj_ref")
+      (pg_inv_entries : "pte \<times> obj_ref \<times> vm_level")
   | PageUnmap
       (pg_inv_cap : arch_cap)
       (pg_inv_cslot : cslot_ptr)

--- a/spec/abstract/AARCH64/ArchVSpaceAcc_A.thy
+++ b/spec/abstract/AARCH64/ArchVSpaceAcc_A.thy
@@ -131,7 +131,7 @@ definition pt_bits_left :: "vm_level \<Rightarrow> nat" where
 
 definition pt_index :: "vm_level \<Rightarrow> vspace_ref \<Rightarrow> machine_word" where
   "pt_index level vptr \<equiv>
-     (vptr >> pt_bits_left level) && mask (ptTranslationBits (level_type level))"
+     (vptr >> pt_bits_left level) && mask (ptTranslationBits level)"
 
 
 locale_abbrev global_pt :: "'z state \<Rightarrow> obj_ref" where
@@ -192,7 +192,7 @@ fun pt_lookup_from_level ::
   "pt_lookup_from_level level pt_ptr vptr target_pt_ptr s = (doE
      unlessE (0 < level) $ throwError InvalidRoot;
      slot <- returnOk $ pt_slot_offset level pt_ptr vptr;
-     pte <- liftE $ gets_the $ oapply slot o swp ptes_of (level_type level);
+     pte <- liftE $ gets_the $ oapply slot o swp ptes_of level;
      unlessE (is_PageTablePTE pte) $ throwError InvalidRoot;
      ptr <- returnOk (pptr_from_pte pte);
      if ptr = target_pt_ptr

--- a/spec/abstract/AARCH64/ArchVSpaceAcc_A.thy
+++ b/spec/abstract/AARCH64/ArchVSpaceAcc_A.thy
@@ -125,13 +125,13 @@ section "Basic Operations"
 definition pt_bits_left :: "vm_level \<Rightarrow> nat" where
   "pt_bits_left level =
     (if level = asid_pool_level
-     then ptTranslationBits True + ptTranslationBits False * size max_pt_level
-     else ptTranslationBits False * size level)
+     then ptTranslationBits VSRootPT_T + ptTranslationBits NormalPT_T * size max_pt_level
+     else ptTranslationBits NormalPT_T * size level)
     + pageBits"
 
 definition pt_index :: "vm_level \<Rightarrow> vspace_ref \<Rightarrow> machine_word" where
   "pt_index level vptr \<equiv>
-     (vptr >> pt_bits_left level) && mask (ptTranslationBits (level = max_pt_level))"
+     (vptr >> pt_bits_left level) && mask (ptTranslationBits (level_type level))"
 
 
 locale_abbrev global_pt :: "'z state \<Rightarrow> obj_ref" where

--- a/spec/abstract/AARCH64/ArchVSpace_A.thy
+++ b/spec/abstract/AARCH64/ArchVSpace_A.thy
@@ -319,9 +319,9 @@ definition unmap_page :: "vmpage_size \<Rightarrow> asid \<Rightarrow> vspace_re
      top_level_pt \<leftarrow> find_vspace_for_asid asid;
      (lev, slot) \<leftarrow> liftE $ gets_the $ pt_lookup_slot top_level_pt vptr \<circ> ptes_of;
      unlessE (pt_bits_left lev = pageBitsForSize pgsz) $ throwError InvalidRoot;
-     pte \<leftarrow> liftE $ get_pte (level_type lev) slot;
+     pte \<leftarrow> liftE $ get_pte lev slot;
      unlessE (is_PagePTE pte \<and> pptr_from_pte pte = pptr) $ throwError InvalidRoot;
-     liftE $ store_pte (level_type lev) slot InvalidPTE;
+     liftE $ store_pte lev slot InvalidPTE;
      liftE $ do_machine_op $ cleanByVA_PoU slot (addrFromPPtr slot);
      liftE $ invalidate_tlb_by_asid_va asid vptr
    odE <catch> (K $ return ())"

--- a/spec/abstract/AARCH64/Arch_A.thy
+++ b/spec/abstract/AARCH64/Arch_A.thy
@@ -92,9 +92,9 @@ definition perform_pg_inv_unmap :: "arch_cap \<Rightarrow> cslot_ptr \<Rightarro
 definition perform_pg_inv_map ::
   "arch_cap \<Rightarrow> cslot_ptr \<Rightarrow> pte \<Rightarrow> obj_ref \<Rightarrow> vm_level \<Rightarrow> (unit,'z::state_ext) s_monad" where
   "perform_pg_inv_map cap ct_slot pte slot level \<equiv> do
-     old_pte \<leftarrow> get_pte (level_type level) slot;
+     old_pte \<leftarrow> get_pte level slot;
      set_cap (ArchObjectCap cap) ct_slot;
-     store_pte (level_type level) slot pte;
+     store_pte level slot pte;
      when (old_pte \<noteq> InvalidPTE) $ do
         (asid, vaddr) \<leftarrow> assert_opt $ acap_map_data cap;
         invalidate_tlb_by_asid_va asid vaddr
@@ -150,7 +150,7 @@ definition perform_pt_inv_map ::
   "arch_cap \<Rightarrow> cslot_ptr \<Rightarrow> pte \<Rightarrow> obj_ref \<Rightarrow> vm_level \<Rightarrow> (unit,'z::state_ext) s_monad" where
   "perform_pt_inv_map cap ct_slot pte slot level = do
      set_cap (ArchObjectCap cap) ct_slot;
-     store_pte (level_type level) slot pte;
+     store_pte level slot pte;
      do_machine_op $ cleanByVA_PoU slot (addrFromPPtr slot)
    od"
 

--- a/spec/abstract/AARCH64/Arch_Structs_A.thy
+++ b/spec/abstract/AARCH64/Arch_Structs_A.thy
@@ -29,8 +29,6 @@ text \<open>
   along with capabilities for virtual memory mappings.
 \<close>
 
-datatype pt_type = VSRoot_T | Normal_T
-
 datatype arch_cap =
     ASIDPoolCap
       (acap_obj : obj_ref)
@@ -121,11 +119,11 @@ lemma length_vs_index_len[simp]:
   by (simp add: len_of_vs_index_len type_definition.card[OF type_definition_vs_index_len])
 
 lemma vs_index_ptTranslationBits:
-  "ptTranslationBits True = LENGTH(vs_index_len)"
+  "ptTranslationBits VSRootPT_T = LENGTH(vs_index_len)"
   by (simp add: ptTranslationBits_def vs_index_bits_def)
 
 lemma pt_index_ptTranslationBits:
-  "ptTranslationBits False = LENGTH(pt_index_len)"
+  "ptTranslationBits NormalPT_T = LENGTH(pt_index_len)"
   by (simp add: ptTranslationBits_def)
 
 (* This could also be a record, but we expect further alternatives to be added for SMMU *)
@@ -205,7 +203,7 @@ definition pte_bits :: nat where
   "pte_bits = word_size_bits"
 
 definition table_size :: "pt_type \<Rightarrow> nat" where
-  "table_size pt_t = ptTranslationBits (pt_t = VSRoot_T) + pte_bits" (* FIXME AARCH64: introduce levels in Haskell, include from there *)
+  "table_size pt_t = ptTranslationBits pt_t + pte_bits"
 
 definition pt_bits :: "pt_type \<Rightarrow> nat" where
   "pt_bits pt_t \<equiv> table_size pt_t"

--- a/spec/abstract/AARCH64/Arch_Structs_A.thy
+++ b/spec/abstract/AARCH64/Arch_Structs_A.thy
@@ -310,6 +310,9 @@ definition max_pt_level :: vm_level where
 definition level_type :: "vm_level \<Rightarrow> pt_type" where
   "level_type level \<equiv> if level = max_pt_level then VSRootPT_T else NormalPT_T"
 
+declare [[coercion_enabled]]
+declare [[coercion level_type]]
+
 end
 
 qualify AARCH64_A (in Arch)

--- a/spec/abstract/AARCH64/Init_A.thy
+++ b/spec/abstract/AARCH64/Init_A.thy
@@ -28,9 +28,6 @@ definition arm_global_pt_ptr :: obj_ref where
 definition init_irq_node_ptr :: obj_ref where
   "init_irq_node_ptr = pptr_base + 0x3000"
 
-definition ipa_size :: nat where
-  "ipa_size \<equiv> if config_ARM_PA_SIZE_BITS_40 then 40 else 44"
-
 (* The highest user-virtual address that is still canonical.
    It can be larger than user_vtop, which is the highest address we allow to be mapped.
    For AArch64-hyp, user-virtual addresses are IPAs and since there is no sign extension,

--- a/spec/abstract/MiscMachine_A.thy
+++ b/spec/abstract/MiscMachine_A.thy
@@ -85,4 +85,7 @@ lemma asid_bits_len_checks:
   "asid_bits \<le> LENGTH(asid_rep_len)"
   unfolding asid_bits_defs by auto
 
+definition ipa_size :: nat where
+  "ipa_size \<equiv> if config_ARM_PA_SIZE_BITS_40 then 40 else 44"
+
 end

--- a/spec/design/m-skel/AARCH64/MachineTypes.thy
+++ b/spec/design/m-skel/AARCH64/MachineTypes.thy
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-chapter "RISCV 64bit Machine Types"
+chapter "AARCH64 Machine Types"
 
 theory MachineTypes
 imports
@@ -113,6 +113,7 @@ definition
                          machine_state_rest = undefined \<rparr>"
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/AARCH64.hs CONTEXT AARCH64 ONLY \
+  PT_Type \
   VMFaultType HypFaultType vmFaultTypeFSR VMPageSize pageBits ptTranslationBits \
   pageBitsForSize \
   hcrVCPU hcrNative vgicHCREN sctlrDefault sctlrEL1VM actlrDefault gicVCPUMaxNumLR \

--- a/spec/design/skel/AARCH64/ArchIntermediate_H.thy
+++ b/spec/design/skel/AARCH64/ArchIntermediate_H.thy
@@ -41,16 +41,16 @@ defs Arch_createNewCaps_def:
         | SmallPageObject \<Rightarrow>
             createNewFrameCaps regionBase numObjects dev 0 ARMSmallPage
         | LargePageObject \<Rightarrow>
-            createNewFrameCaps regionBase numObjects dev (ptTranslationBits False) ARMLargePage
+            createNewFrameCaps regionBase numObjects dev (ptTranslationBits NormalPT_T) ARMLargePage
         | HugePageObject \<Rightarrow>
-            createNewFrameCaps regionBase numObjects dev (ptTranslationBits False + ptTranslationBits False) ARMHugePage
+            createNewFrameCaps regionBase numObjects dev (2 * ptTranslationBits NormalPT_T) ARMHugePage
         | VSpaceObject \<Rightarrow>
-            createNewTableCaps regionBase numObjects (ptBits True) (makeObject::pte)
-              (\<lambda>base addr. PageTableCap base True addr)
+            createNewTableCaps regionBase numObjects (ptBits VSRootPT_T) (makeObject::pte)
+              (\<lambda>base addr. PageTableCap base VSRootPT_T addr)
               (\<lambda>pts. return ())
         | PageTableObject \<Rightarrow>
-            createNewTableCaps regionBase numObjects (ptBits False) (makeObject::pte)
-              (\<lambda>base addr. PageTableCap base False addr)
+            createNewTableCaps regionBase numObjects (ptBits NormalPT_T) (makeObject::pte)
+              (\<lambda>base addr. PageTableCap base NormalPT_T addr)
               (\<lambda>pts. return ())
         | VCPUObject \<Rightarrow> (do
             addrs \<leftarrow> createObjects regionBase numObjects (injectKO (makeObject :: vcpu)) 0;

--- a/spec/design/skel/AARCH64/Hardware_H.thy
+++ b/spec/design/skel/AARCH64/Hardware_H.thy
@@ -14,7 +14,7 @@ begin
 context Arch begin global_naming AARCH64_H
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/AARCH64.hs Platform=Platform.AARCH64 CONTEXT AARCH64_H \
-  NOT plic_complete_claim getMemoryRegions getDeviceRegions getKernelDevices \
+  NOT PT_Type plic_complete_claim getMemoryRegions getDeviceRegions getKernelDevices \
   loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt \
   configureTimer resetTimer debugPrint getRestartPC setNextPC clearMemory \
   clearMemoryVM initMemory freeMemory setHardwareASID wordFromPDE wordFromPTE \

--- a/spec/haskell/src/SEL4/API/Types/AARCH64.hs
+++ b/spec/haskell/src/SEL4/API/Types/AARCH64.hs
@@ -75,8 +75,8 @@ apiGetObjectSize NotificationObject _ = ntfnSizeBits
 apiGetObjectSize CapTableObject size = cteSizeBits + size
 
 getObjectSize :: ObjectType -> Int -> Int
-getObjectSize PageTableObject _ = ptBits False
-getObjectSize VSpaceObject _ = ptBits True
+getObjectSize PageTableObject _ = ptBits NormalPT_T
+getObjectSize VSpaceObject _ = ptBits VSRootPT_T
 getObjectSize SmallPageObject _ = pageBitsForSize ARMSmallPage
 getObjectSize LargePageObject _ = pageBitsForSize ARMLargePage
 getObjectSize HugePageObject _ = pageBitsForSize ARMHugePage

--- a/spec/haskell/src/SEL4/Machine/Hardware/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Machine/Hardware/AARCH64.hs
@@ -48,6 +48,9 @@ data VMPageSize
     | ARMHugePage
     deriving (Show, Eq, Ord, Enum, Bounded)
 
+data PT_Type = VSRootPT_T | NormalPT_T
+    deriving (Show, Eq)
+
 data VMFaultType
     = ARMDataAbort
     | ARMPrefetchAbort
@@ -108,21 +111,21 @@ pageBits = 12
 -- 2^3 bytes, thus occupying one small page, apart from top-level tables which
 -- contain twice as many entries if config_ARM_PA_SIZE_BITS_40 is set.
 
-ptTranslationBits :: Bool -> Int
-ptTranslationBits isVSpace =
-    if isVSpace && config_ARM_PA_SIZE_BITS_40 then 10 else 9
+ptTranslationBits :: PT_Type -> Int
+ptTranslationBits pt_t =
+    if pt_t == VSRootPT_T && config_ARM_PA_SIZE_BITS_40 then 10 else 9
 
 pteBits :: Int
 pteBits = 3
 
-ptBits :: Bool -> Int
-ptBits isVSpace = ptTranslationBits isVSpace + pteBits
+ptBits :: PT_Type -> Int
+ptBits pt_t = ptTranslationBits pt_t + pteBits
 
--- The top-level table cannot contain frame PTEs, so isVSpace is False
+-- The top-level table cannot contain frame PTEs, so only NormalPT_T
 pageBitsForSize :: VMPageSize -> Int
 pageBitsForSize ARMSmallPage = pageBits
-pageBitsForSize ARMLargePage = pageBits + ptTranslationBits False
-pageBitsForSize ARMHugePage = pageBits + ptTranslationBits False + ptTranslationBits False
+pageBitsForSize ARMLargePage = pageBits + ptTranslationBits NormalPT_T
+pageBitsForSize ARMHugePage = pageBits + ptTranslationBits NormalPT_T + ptTranslationBits NormalPT_T
 
 vcpuBits :: Int
 vcpuBits = 12

--- a/spec/haskell/src/SEL4/Object/ObjectType/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Object/ObjectType/AARCH64.hs
@@ -128,7 +128,7 @@ sameRegionAs (a@FrameCap {}) (b@FrameCap {}) =
         topA = botA + mask (pageBitsForSize $ capFSize a)
         topB = botB + mask (pageBitsForSize $ capFSize b)
 sameRegionAs (a@PageTableCap {}) (b@PageTableCap {}) =
-    capPTBasePtr a == capPTBasePtr b
+    capPTBasePtr a == capPTBasePtr b && capPTType a == capPTType b
 sameRegionAs ASIDControlCap ASIDControlCap = True
 sameRegionAs (a@ASIDPoolCap {}) (b@ASIDPoolCap {}) =
     capASIDPool a == capASIDPool b

--- a/spec/haskell/src/SEL4/Object/Structures/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Object/Structures/AARCH64.hs
@@ -38,7 +38,7 @@ data ArchCapability
         capFMappedAddress :: Maybe (ASID, VPtr) }
     | PageTableCap {
         capPTBasePtr :: PPtr PTE,
-        capPTisVSpace :: Bool,
+        capPTType :: PT_Type,
         capPTMappedAddress :: Maybe (ASID, VPtr) }
     | VCPUCap {
         capVCPUPtr :: PPtr VCPU }

--- a/sys-init/Makefile
+++ b/sys-init/Makefile
@@ -9,8 +9,6 @@ images: SysInit
 default: images test
 test:
 all: images test
-report-regression:
-	@echo SysInitExamples
 
 #
 # Setup heaps.

--- a/tools/asmrefine/Makefile
+++ b/tools/asmrefine/Makefile
@@ -8,9 +8,6 @@ default: AsmRefineTest
 
 all: AsmRefine AsmRefineTest
 
-report-regression:
-	@echo AsmRefine AsmRefineTest
-
 HEAPS += AsmRefine AsmRefineTest
 
 include ../../misc/isa-common.mk

--- a/tools/autocorres/Makefile
+++ b/tools/autocorres/Makefile
@@ -8,9 +8,6 @@ default: AutoCorresTest
 
 all: AutoCorres AutoCorresTest AutoCorresSEL4 AutoCorresDoc
 
-report-regression:
-	@echo AutoCorres AutoCorresTest AutoCorresDoc AutoCorresSEL4
-
 PARSE_TESTS_C := $(wildcard tests/parse-tests/*.c)
 PARSE_TESTS_THY := $(patsubst %.c,%.thy,$(PARSE_TESTS_C))
 

--- a/tools/c-parser/Makefile
+++ b/tools/c-parser/Makefile
@@ -77,10 +77,6 @@ GRAMMAR_PRODUCTS = StrictC.lex.sml StrictC.grm.sig StrictC.grm.sml
 .PHONY: c-parser-deps
 c-parser-deps: $(GRAMMAR_PRODUCTS)
 
-# Regression targets.
-report-regression: .FORCE
-	@echo CParser cparser_test cparser_tools
-
 .PHONY: .FORCE
 .FORCE:
 

--- a/tools/haskell-translator/caseconvs
+++ b/tools/haskell-translator/caseconvs
@@ -2049,26 +2049,6 @@ case \x of ((a@FrameCap {}), (b@FrameCap {})) -> ((a@PageTableCap {}), (b@PageTa
   then ->5
   else ->6
 
-case \x of cap@(PageTableCap { capPTisVSpace = True }) -> _ ->  ---> let cap = \x in
-  if isPageTableCap cap \<and> capPTisVSpace cap
-  then ->1
-  else ->2
-
-case \x of cap@(FrameCap {}) -> cap@(PageTableCap { capPTisVSpace = False }) -> cap@(PageTableCap { capPTisVSpace = True }) -> cap@(ASIDControlCap {}) -> cap@(ASIDPoolCap {}) -> (VCPUCap {}) ->  ---> let cap = \x in
-  if isFrameCap cap
-  then ->1
-  else if isPageTableCap cap \<and> \<not> capPTisVSpace cap
-  then ->2
-  else if isPageTableCap cap \<and> capPTisVSpace cap
-  then ->3
-  else if isASIDControlCap cap
-  then ->4
-  else if isASIDPoolCap cap
-  then ->5
-  else if isVCPUCap cap
-  then ->6
-  else undefined
-
 case \x of (c@PageTableCap { capPTMappedAddress = Just _ }) -> (PageTableCap { capPTMappedAddress = Nothing }) -> (c@FrameCap {}) -> c@ASIDControlCap -> (c@ASIDPoolCap {}) -> (c@VCPUCap {}) ->  ---> let c = \x in
   if isPageTableCap c \<and> capPTMappedAddress c \<noteq> None
   then ->1
@@ -2081,6 +2061,26 @@ case \x of (c@PageTableCap { capPTMappedAddress = Just _ }) -> (PageTableCap { c
   else if isASIDPoolCap c
   then ->5
   else if isVCPUCap c
+  then ->6
+  else undefined
+
+case \x of cap@(PageTableCap { capPTType = VSRootPT_T }) -> _ ->  ---> let cap = \x in
+  if isPageTableCap cap \<and> capPTType cap = VSRootPT_T
+  then ->1
+  else ->2
+
+case \x of cap@(FrameCap {}) -> cap@(PageTableCap { capPTType = NormalPT_T }) -> cap@(PageTableCap { capPTType = VSRootPT_T }) -> cap@(ASIDControlCap {}) -> cap@(ASIDPoolCap {}) -> (VCPUCap {}) ->  ---> let cap = \x in
+  if isFrameCap cap
+  then ->1
+  else if isPageTableCap cap \<and> capPTType cap = NormalPT_T
+  then ->2
+  else if isPageTableCap cap \<and> capPTType cap = VSRootPT_T
+  then ->3
+  else if isASIDControlCap cap
+  then ->4
+  else if isASIDPoolCap cap
+  then ->5
+  else if isVCPUCap cap
   then ->6
   else undefined
 

--- a/tools/haskell-translator/lhs_pars.py
+++ b/tools/haskell-translator/lhs_pars.py
@@ -903,7 +903,7 @@ def named_constructor_translation(name, map, header):
         l = l + '(' + type + ') \<Rightarrow> '
     l = l + '%s" ("%s\'_ \<lparr> %s= _' % (header, name, map[0][0])
     for n, type in map[1:]:
-        l = l + ', %s= _' % n
+        l = l + ', %s= _' % n.replace("_", "'_")
     l = l + ' \<rparr>")'
     lines.append(l)
     lines.append('where')


### PR DESCRIPTION
The goal of this chunk of work is to:
* add the rest of the RISC-V abstract invariant proofs
* updates them for AArch64's new page table setup (started previously)
* the hyp/VCPU proofs/definitions/theories from ARM_HYP
* improve definitions and lemmas farther in the direction of using projections

This results in AInvs building (with `quick_and_dirty`) and a realistic overview of work required remaining: at this time we count 458 instances of `FIXME AARCH64` and 368 of `sorry`. There is some overlap between these.

Note: not all desired cleanup was possible during this run. In particular, uses of `crunch/crunches` can't be cleaned up and consolidated until they work.
