### PR TITLE
add sorry + FIXME count scripts

### DIFF
--- a/misc/stats/fixme-count.sh
+++ b/misc/stats/fixme-count.sh
@@ -15,6 +15,12 @@ usage()
     echo "$0 AARCH64"
 }
 
+fail()
+{
+    echo "$@"
+    exit 1
+}
+
 count() {
     D="$1"
     TAG="$2"
@@ -33,6 +39,7 @@ count() {
     rm "${TMP}"
 }
 
+git rev-parse --show-toplevel 2> /dev/null || fail "Must be run inside l4v repo."
 cd "$(git rev-parse --show-toplevel)"
 
 if [ "$#" -lt 1 ]; then

--- a/misc/stats/fixme-count.sh
+++ b/misc/stats/fixme-count.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Copyright 2022 Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# Count number of FIXMEs with provided tag.
+
+usage()
+{
+    echo "$0 TAG: Count number of FIXMEs with provided tag."
+    echo
+    echo "Example:"
+    echo "$0 AARCH64"
+}
+
+count() {
+    D="$1"
+    TAG="$2"
+    TMP=`mktemp -q` || exit 1
+    git grep "FIXME ${TAG}" -- "${D}" > "${TMP}"
+    if [ "$?" = "0" ]
+    then
+        FIXMES=$(wc -l < "${TMP}" | sed -e 's/^[[:space:]]*//')
+        if [ "$D" = "." ]; then
+          DIR="total"
+        else
+          DIR="${D}"
+        fi
+        echo "FIXME ${TAG} in ${DIR}: ${FIXMES}"
+    fi
+    rm "${TMP}"
+}
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [ "$#" -lt 1 ]; then
+    usage && exit 1
+fi
+
+TAG=$1
+
+TOP_DIRS="lib sys-init camkes"
+SND_DIRS="spec proof"
+
+for D in ${TOP_DIRS}; do count "$D" "$TAG"; done
+
+for L1 in ${SND_DIRS}; do
+    for D in $(find ${L1} -maxdepth 1 -mindepth 1 -type d); do count "$D" "$TAG"; done
+done
+
+count "." "$TAG"
+
+cd - > /dev/null

--- a/misc/stats/sorry-count.sh
+++ b/misc/stats/sorry-count.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright 2021 ProofCraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# Count number of sorries per major proof directory
+
+count() {
+    D="$1"
+    TMP=`mktemp -q` || exit 1
+    git grep -w sorry -- "${D}" > "${TMP}"
+    if [ "$?" = "0" ]
+    then
+        SORRIES=$(wc -l < "${TMP}")
+        echo "Sorries in ${D}: ${SORRIES}"
+    fi
+    rm "${TMP}"
+}
+
+TOP_DIRS="lib sys-init camkes"
+SND_DIRS="spec proof"
+
+for D in ${TOP_DIRS}; do count "$D"; done
+
+for L1 in ${SND_DIRS}; do
+    for D in $(find ${L1} -maxdepth 1 -mindepth 1 -type d); do count "$D"; done
+done

--- a/misc/stats/sorry-count.sh
+++ b/misc/stats/sorry-count.sh
@@ -19,6 +19,7 @@ count() {
     rm "${TMP}"
 }
 
+git rev-parse --show-toplevel 2> /dev/null || fail "Must be run inside l4v repo."
 cd "$(git rev-parse --show-toplevel)"
 
 TOP_DIRS="lib sys-init camkes"

--- a/misc/stats/sorry-count.sh
+++ b/misc/stats/sorry-count.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2021 ProofCraft Pty Ltd
+# Copyright 2022 Proofcraft Pty Ltd
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
@@ -19,6 +19,8 @@ count() {
     rm "${TMP}"
 }
 
+cd "$(git rev-parse --show-toplevel)"
+
 TOP_DIRS="lib sys-init camkes"
 SND_DIRS="spec proof"
 
@@ -27,3 +29,5 @@ for D in ${TOP_DIRS}; do count "$D"; done
 for L1 in ${SND_DIRS}; do
     for D in $(find ${L1} -maxdepth 1 -mindepth 1 -type d); do count "$D"; done
 done
+
+cd - > /dev/null


### PR DESCRIPTION
The sorry-count script used to live in ci-actions/aws-proofs and still needs to be removed there. The FIXME count script is new.

Both start counting at the repo root and report per major interesting directory (e.g. `spec/abstract` or `proof/refine`). The FiXME count includes a total over the entire repo.
