### PR TITLE
lib: fix crunch to only apply attributes once

### DIFF
--- a/lib/crunch-cmd.ML
+++ b/lib/crunch-cmd.ML
@@ -271,7 +271,7 @@ fun maybe_thms thy name = get_thms thy name handle ERROR _ => []
 fun thy_maybe_thms thy name = Global_Theory.get_thms thy name handle ERROR _ => []
 
 fun add_thm thm atts name ctxt =
-  Local_Theory.notes [((Binding.name name, atts), [([thm], atts)])] ctxt |> #2
+  Local_Theory.notes [((Binding.name name, atts), [([thm], [])])] ctxt |> #2
 
 fun get_thm_name (cfg : crunch_cfg) const_name
   = if read_const (#ctxt cfg) (Long_Name.base_name const_name)

--- a/proof/invariant-abstract/RISCV64/Machine_AI.thy
+++ b/proof/invariant-abstract/RISCV64/Machine_AI.thy
@@ -210,9 +210,7 @@ lemma machine_rest_lift_no_irq:
   apply simp
   done
 
-crunch (no_irq) no_irq[wp]: machine_op_lift
-
-declare machine_op_lift_no_irq[simp] (* avoids crunch warning *)
+crunch (no_irq) no_irq[wp, simp]: machine_op_lift
 
 lemma no_irq:
   "no_irq f \<Longrightarrow> \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks s)\<rbrace>"


### PR DESCRIPTION
I wasn't sure whether to put more tags on this commit. I changed one line in `invariant-abstract` which I already knew was explicitly due to this issue, but I'm sure that there are others that I don't know about and I don't want to go looking for them. Should I add `ainvs` to the tag?