### PR TITLE
fewer haskell translator warnings

### DIFF
--- a/tools/haskell-translator/lhs_pars.py
+++ b/tools/haskell-translator/lhs_pars.py
@@ -702,12 +702,28 @@ def newtype_transform(d):
         return named_newtype_transform(line, header, d)
 
 
+# parameterised types of which we know that they are already defined in Isabelle
+known_type_assignments = [
+    'domain_schedule',
+    'kernel',
+    'kernel_f',
+    'kernel_f f',  # there is a KernelF instance that gets transformed into this
+    'kernel_init',
+    'kernel_init_state',
+    'machine_data',
+    'machine_monad',
+    'ready_queue',
+    'user_monad'
+]
+
+
 def typename_transform(line, header, d):
     try:
         [oldtype] = line.split()
     except:
-        warning('type assignment with parameters not supported %s' % d.body)
-        call.bad_type_assignment = True
+        if header not in known_type_assignments:
+            warning('type assignment with parameters not supported %s' % d.body)
+            call.bad_type_assignment = True
         return
     if oldtype.startswith('Data.Word.Word'):
         # take off the prefix, leave Word32 or Word64 etc

--- a/tools/haskell-translator/lhs_pars.py
+++ b/tools/haskell-translator/lhs_pars.py
@@ -6,7 +6,6 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
-import braces
 import re
 import sys
 import os
@@ -16,31 +15,8 @@ from six.moves import range
 from six.moves import zip
 from functools import reduce
 
-ANSI_RESET = "\033[0m"
-ANSI_RED = "\033[31;1m"
-ANSI_YELLOW = "\033[33m"
-
-
-def running_on_github():
-    return os.environ.get("GITHUB_REPOSITORY") != None
-
-
-def output_color(color, s, github=running_on_github()):
-    """Wrap the given string in the given color."""
-    if sys.stderr.isatty() or github:
-        return color + s + ANSI_RESET
-    return s
-
-
-def warning(msg: str):
-    w = output_color(ANSI_YELLOW, 'Warning:')
-    sys.stderr.write(f'{w} {msg}\n')
-
-
-def error(msg: str):
-    e = output_color(ANSI_RED, 'Fatal error:')
-    sys.stderr.write(f'{e} {msg}\n')
-
+import braces
+from msgs import error, warning
 
 class Call(object):
 

--- a/tools/haskell-translator/make_spec.sh
+++ b/tools/haskell-translator/make_spec.sh
@@ -81,6 +81,10 @@ function cpp_opts () {
         AARCH64)
             L4CPP="-DPLATFORM=TX2 -DPLATFORM_TX2 -DTARGET=AARCH64 -DTARGET_AARCH64"
             ;;
+        X64)
+            # this space intentionally left blank:
+            L4CPP=""
+            ;;
         *)
             echo "Warning: No CPP configuration for achitecture ${1}"
             L4CPP=""

--- a/tools/haskell-translator/msgs.py
+++ b/tools/haskell-translator/msgs.py
@@ -1,0 +1,68 @@
+#
+# Copyright 2022, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+"""Error, warning, and status message handling."""
+
+import os
+import sys
+
+ANSI_RESET = "\033[0m"
+ANSI_RED = "\033[31;1m"
+ANSI_YELLOW = "\033[33m"
+
+tty_status_line = [""]
+
+
+def running_on_github():
+    """Return True if we're running on GitHub Actions."""
+    return os.environ.get("GITHUB_REPOSITORY") != None
+
+
+def output_color(color, s, github=running_on_github()):
+    """Wrap the given string in the given colour."""
+    if sys.stderr.isatty() or github:
+        return color + s + ANSI_RESET
+    return s
+
+
+def wipe_tty_status():
+    """Clear the tty status line if it exists."""
+    if sys.stdout.isatty() and tty_status_line[0]:
+        print(" " * len(tty_status_line[0]) + "\r", end="")
+        sys.stdout.flush()
+        tty_status_line[0] = ""
+
+
+def status(msg: str):
+    """Print a status message to a tty status line or stdout."""
+    wipe_tty_status()
+    tty_status_line[0] = msg
+    end = "\r" if sys.stdout.isatty() else "\n"
+    print(tty_status_line[0], end=end)
+    sys.stdout.flush()
+
+
+def pos_str(file, line):
+    """Return a string indicating a file position."""
+    if file is None:
+        return ""
+    if line is None:
+        return f" [{file}]"
+    return f" [{file}:{line}]"
+
+
+def warning(msg: str, file=None, line=None):
+    """Print a warning message to stderr."""
+    wipe_tty_status()
+    w = output_color(ANSI_YELLOW, 'Warning:')
+    sys.stderr.write(f'{w} {msg}{pos_str(file,line)}\n')
+
+
+def error(msg: str, file=None, line=None):
+    """Print an error message to stderr."""
+    wipe_tty_status()
+    e = output_color(ANSI_RED, 'Fatal error:')
+    sys.stderr.write(f'{e} {msg}{pos_str(file,line)}\n')

--- a/tools/haskell-translator/pars_skl.py
+++ b/tools/haskell-translator/pars_skl.py
@@ -9,10 +9,11 @@ by inserting parsed Haskell."""
 from __future__ import print_function
 from __future__ import absolute_import
 import sys
-import lhs_pars
 import os
 import os.path
-import msgs
+
+import lhs_pars
+from msgs import error, warning, status
 
 
 def create_find_source():
@@ -96,7 +97,7 @@ for line in instructions:
             try:
                 parsed = lhs_pars.parse(call)
             except:
-                print("%s -X-> %s" % (input, output))
+                warning("%s -X-> %s" % (input, output), input)
                 raise
 
             bad_type_assignment |= call.bad_type_assignment
@@ -115,7 +116,7 @@ for line in instructions:
 
     # at this point, output_tmp should exist, but output might not exist
     if not os.path.exists(output_tmp):
-        print('Error: {} did not generate correctly'.format(output_tmp))
+        error('{} did not generate correctly'.format(output_tmp))
         sys.exit(1)
 
     if os.path.exists(output):
@@ -124,15 +125,15 @@ for line in instructions:
             lines2 = [line for line in open(output)]
             changed = not (lines1 == lines2)
         except IOError as e:
-            print("IOError comparing {} and {}:\n{}".format(output_tmp, output, e))
+            error("IOError comparing {} and {}:\n{}".format(output_tmp, output, e))
             sys.exit(1)
     else:
-        #print('Warning: {} does not exist, assuming changed'.format(output))
+        #warning('{} does not exist, assuming changed'.format(output))
         changed = 1
 
     if changed:
         if not quiet:
-            msgs.status(instruct)
+            status(instruct)
         try:
             os.unlink(output)
         except:
@@ -140,12 +141,12 @@ for line in instructions:
         try:
             os.rename(output_tmp, output)
         except IOError as e:
-            print("IOError moving {} -> {}:\n{}".format(output_tmp, output, e))
+            error("IOError moving {} -> {}:\n{}".format(output_tmp, output, e))
             sys.exit(1)
     else:
         os.unlink(output_tmp)
 
-msgs.status("")
+status("")
 
 if bad_type_assignment and not quiet:
     print("Note: for type assignments with parameters, define "

--- a/tools/haskell-translator/pars_skl.py
+++ b/tools/haskell-translator/pars_skl.py
@@ -12,6 +12,7 @@ import sys
 import lhs_pars
 import os
 import os.path
+import msgs
 
 
 def create_find_source():
@@ -131,7 +132,7 @@ for line in instructions:
 
     if changed:
         if not quiet:
-            print(instruct)
+            msgs.status(instruct)
         try:
             os.unlink(output)
         except:
@@ -143,6 +144,8 @@ for line in instructions:
             sys.exit(1)
     else:
         os.unlink(output_tmp)
+
+msgs.status("")
 
 if bad_type_assignment and not quiet:
     print("Note: for type assignments with parameters, define "


### PR DESCRIPTION
This is the second round of improvements for error/warning reporting in the Haskell translator:

- suppress warnings for types we know about
- remove warnings for intentionally missing X64 CPP setup
- use a status line for file progress output when running in a terminal. This should reduce clutter when run interactively.
- provide file name for warnings and errors
