### PR TITLE
update to ghc 9.0.2

### DIFF
--- a/spec/haskell/.gitignore
+++ b/spec/haskell/.gitignore
@@ -8,6 +8,8 @@
 
 **.lhs-boot
 /dist/
+/dist-newstyle/
+/cabal.project.local*
 
 # cabal dependencies
 

--- a/spec/haskell/Makefile
+++ b/spec/haskell/Makefile
@@ -19,11 +19,12 @@ CUSTOM_BOOT_FILES = src/SEL4/Object/Structures.lhs-boot
 # GHC_PACKAGE_PATH first.
 CABAL=stack exec -- ./stack-path cabal
 
-CABAL_CONFIGURE=$(CABAL) v1-configure
-CABAL_BUILD=$(CABAL) v1-build
-CABAL_SANDBOX=$(CABAL) v1-sandbox
-CABAL_UPDATE=$(CABAL) v1-update
-CABAL_INSTALL=$(CABAL) v1-install
+CABAL_CONFIGURE=$(CABAL) v2-configure
+CABAL_BUILD=$(CABAL) v2-build
+CABAL_UPDATE=$(CABAL) v2-update
+CABAL_INSTALL=$(CABAL) v2-install
+
+RM_BACKUP=rm -f cabal.project.local~*
 
 # warnings that are useless during large Haskell updates
 GHC_DEV_OPTS=--ghc-options=""
@@ -31,44 +32,47 @@ GHC_DEV_OPTS=--ghc-options=""
 all: build-aarch64 build-riscv build-arm build-arm-hyp-nosmmu build-x64
 
 sandbox: .stack-work
-	$(CABAL_SANDBOX) init
-	$(CABAL_UPDATE)
-	$(CABAL_INSTALL) --dependencies-only
 
 build-arm: sandbox $(BOOT_FILES)
 	$(CABAL_CONFIGURE) --configure-option="arm-kzm" \
 	    --flags="ArchArm" \
 	    --builddir="dist/arm"
+	$(RM_BACKUP)
 	$(CABAL_BUILD) --builddir="dist/arm"
 
 build-arm-hyp: sandbox $(BOOT_FILES) $(CUSTOM_BOOT_FILES)
 	$(CABAL_CONFIGURE) --configure-option="arm-tk1" \
 	    --flags="ArchArmHyp -FFI" \
 	    --builddir="dist/arm-hyp"
+	$(RM_BACKUP)
 	$(CABAL_BUILD) --builddir="dist/arm-hyp"
 
 build-arm-hyp-nosmmu: sandbox $(BOOT_FILES) $(CUSTOM_BOOT_FILES)
 	$(CABAL_CONFIGURE) --configure-option="arm-tk1-nosmmu" \
 	    --flags="ArchArmHyp -FFI" \
 	    --builddir="dist/arm-hyp-nosmmu"
+	$(RM_BACKUP)
 	$(CABAL_BUILD) --builddir="dist/arm-hyp-nosmmu"
 
 build-x64: sandbox $(BOOT_FILES)
 	$(CABAL_CONFIGURE) --configure-option="x64-pc99" \
 	    --flags="ArchX64 -FFI" \
 	    --builddir="dist/x64"
+	$(RM_BACKUP)
 	$(CABAL_BUILD) --builddir="dist/x64"
 
 build-riscv: sandbox $(BOOT_FILES)
 	$(CABAL_CONFIGURE) --configure-option="riscv-hifive" \
 	    --flags="ArchRiscV -FFI" \
 	    --builddir="dist/riscv"
+	$(RM_BACKUP)
 	$(CABAL_BUILD) --builddir="dist/riscv"
 
 build-aarch64: sandbox $(BOOT_FILES)
 	$(CABAL_CONFIGURE) --configure-option="aarch64-tx2" \
 	    --flags="ArchAArch64 -FFI" \
 	    --builddir="dist/aarch64"
+	$(RM_BACKUP)
 	$(CABAL_BUILD) --builddir="dist/aarch64"
 
 # We assume that if the .stack-work directory exists,
@@ -82,6 +86,7 @@ build-aarch64: sandbox $(BOOT_FILES)
 .stack-work:
 	mkdir -p ~/.stack
 	stack --install-ghc build cabal-install
+	$(CABAL_UPDATE)
 
 $(CUSTOM_BOOT_FILES):
 	echo "never run mkhsboot for hand-crafted lhs-boot files"

--- a/spec/haskell/SEL4.cabal
+++ b/spec/haskell/SEL4.cabal
@@ -1,3 +1,5 @@
+cabal-version:          3.0
+
 --
 -- Copyright 2014, General Dynamics C4 Systems
 --
@@ -5,13 +7,18 @@
 --
 
 name:                   SEL4
-version:                1.5
-cabal-version:          1.18
+version:                13
 build-type:             Custom
-license:                GPL
+license:                GPL-2.0-only
 author:                 Philip Derrin et. al., NICTA
 synopsis:               Executable specification for the seL4 Kernel
-tested-with:            GHC == 7.8.3
+tested-with:            GHC == 9.0.2
+homepage:               http://sel4.systems/
+
+custom-setup
+  setup-depends:
+    base  == 4.15.*,
+    Cabal == 3.4.1.0
 
 Flag FFI
     description:        Include the C language bindings
@@ -40,7 +47,7 @@ Flag ArchAArch64
 Library
     exposed-modules:        SEL4
                             SEL4.Machine.Target
-    build-depends:          mtl==2.2.*, base==4.12.*, array, containers, transformers
+    build-depends:          mtl==2.2.*, base==4.15.*, array, containers, transformers
 
     if flag(FFI)
     -- FFIBindings currently relies on POSIX signal handlers.  This could
@@ -49,7 +56,6 @@ Library
         exposed-modules:    Simulation.FFIBindings
         include-dirs:       include
         install-includes:   sel4model.h gic.h
-                            dist/build/Simulation/FFIBindings_stub.h
     else
         build-depends:      unix
         include-dirs:       include

--- a/spec/haskell/src/Data/BinaryTree.hs
+++ b/spec/haskell/src/Data/BinaryTree.hs
@@ -35,7 +35,7 @@ findWithDefault d (True:a) (Node { btTrue = t }) = findWithDefault d a t
 findWithDefault d (False:a) (Node { btFalse = t }) = findWithDefault d a t
 findWithDefault d a _ = (a,d)
 
-lookup :: Monad m => [Bool] -> BinaryTree a -> m ([Bool],a)
+lookup :: MonadFail m => [Bool] -> BinaryTree a -> m ([Bool],a)
 lookup a (Leaf v) = return (a,v)
 lookup (True:a) (Node { btTrue = t }) = Data.BinaryTree.lookup a t
 lookup (False:a) (Node { btFalse = t }) = Data.BinaryTree.lookup a t
@@ -59,7 +59,7 @@ adjust f (True:a) n@(Node {}) = n { btTrue = adjust f a $ btTrue n }
 adjust f (False:a) n@(Node {}) = n { btFalse = adjust f a $ btFalse n }
 adjust _ _ _ = error "BinaryTree.adjust: object not found"
 
-adjustM :: Monad m => ([Bool] -> a -> m a) -> [Bool] -> BinaryTree a -> m (BinaryTree a)
+adjustM :: MonadFail m => ([Bool] -> a -> m a) -> [Bool] -> BinaryTree a -> m (BinaryTree a)
 adjustM f a (Leaf v) = f a v >>= return . Leaf
 adjustM f (True:a) n@(Node {}) = do { v <- adjustM f a $ btTrue n
                                     ; return $ n { btTrue = v }}

--- a/spec/haskell/src/SEL4/Machine/RegisterSet/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Machine/RegisterSet/AARCH64.hs
@@ -135,6 +135,6 @@ newContext = UC ((funArray $ const 0)//initContext) newFPUState
 
 -- Functions are provided to get and set a single register.
 
-getRegister r = gets $ (!r) . fromUC
+getRegister r = gets $ (! r) . fromUC
 
 setRegister r v = modify (\ uc -> UC (fromUC uc //[(r, v)]) (fpuState uc))

--- a/spec/haskell/src/SEL4/Machine/RegisterSet/ARM.lhs
+++ b/spec/haskell/src/SEL4/Machine/RegisterSet/ARM.lhs
@@ -119,7 +119,7 @@ A new user-level context is a list of values for the machine's registers. Regist
 
 Functions are provided to get and set a single register.
 
-> getRegister r = gets $ (!r) . fromUC
+> getRegister r = gets $ (! r) . fromUC
 
 > setRegister r v = modify $ UC . (//[(r, v)]) . fromUC
 

--- a/spec/haskell/src/SEL4/Machine/RegisterSet/RISCV64.hs
+++ b/spec/haskell/src/SEL4/Machine/RegisterSet/RISCV64.hs
@@ -84,6 +84,6 @@ newContext = UC $ (funArray $ const 0)//initContext
 
 -- Functions are provided to get and set a single register.
 
-getRegister r = gets $ (!r) . fromUC
+getRegister r = gets $ (! r) . fromUC
 
 setRegister r v = modify $ UC . (//[(r, v)]) . fromUC

--- a/spec/haskell/src/SEL4/Machine/RegisterSet/X64.lhs
+++ b/spec/haskell/src/SEL4/Machine/RegisterSet/X64.lhs
@@ -100,7 +100,7 @@ initialised to 0.
 
 Functions are provided to get and set a single register.
 
-> getRegister r = gets $ (!r) . fromUC
+> getRegister r = gets $ (! r) . fromUC
 
 > setRegister r v = modify (\ uc -> UC (fromUC uc //[(r, v)]) (fpuState uc))
 

--- a/spec/haskell/src/SEL4/Model/StateData.lhs
+++ b/spec/haskell/src/SEL4/Model/StateData.lhs
@@ -259,7 +259,7 @@ The following function allows the machine monad to be directly accessed from ker
 
 The function "assert" is used to state that a predicate must be true at a given point. If it is not, the behaviour of the kernel is undefined. The Haskell model will not terminate in this case.
 
-> assert :: Monad m => Bool -> String -> m ()
+> assert :: MonadFail m => Bool -> String -> m ()
 > assert p e = if p then return () else fail $ "Assertion failed: " ++ e
 
 The function "stateAssert" is similar to "assert", except that it reads the current state. This is typically used for more complex assertions that cannot be easily expressed in Haskell; in this case, the asserted function is "const True" in Haskell but is replaced with something stronger in the Isabelle translation.

--- a/spec/haskell/src/SEL4/Object/CNode.lhs
+++ b/spec/haskell/src/SEL4/Object/CNode.lhs
@@ -697,11 +697,11 @@ ghost state. This check is skipped for the CNode within TCBs.
 >         locateSlotBasic cnode offset
 
 > locateSlotCap :: Capability -> Word -> Kernel (PPtr CTE)
-> locateSlotCap (cap @ (CNodeCap {})) offset
+> locateSlotCap cap@(CNodeCap {}) offset
 >     = locateSlotCNode (capCNodePtr cap) (capCNodeBits cap) offset
-> locateSlotCap (cap @ (ThreadCap {})) offset
+> locateSlotCap cap@(ThreadCap {}) offset
 >     = locateSlotTCB (capTCBPtr cap) offset
-> locateSlotCap (cap @ (Zombie {})) offset = case capZombieType cap of
+> locateSlotCap cap@(Zombie {}) offset = case capZombieType cap of
 >     ZombieTCB -> locateSlotTCB (PPtr $ fromPPtr $ capZombiePtr cap) offset
 >     ZombieCNode bits -> locateSlotCNode (capZombiePtr cap) bits offset
 > locateSlotCap _ _ = fail "locateSlotCap: not a cap with slots"

--- a/spec/haskell/src/SEL4/Object/CNode.lhs
+++ b/spec/haskell/src/SEL4/Object/CNode.lhs
@@ -95,13 +95,13 @@ Rights may be masked for the "Copy" and "Mint" operations. The capability data i
 >             (rights, capData) <-
 >               case (inv, args) of
 >                 (CNodeCopy, rights:_) ->
->                     return $! (rightsFromWord rights, Nothing)
+>                     return $ (rightsFromWord rights, Nothing)
 >                 (CNodeMint, rights:newData:_) ->
->                     return $! (rightsFromWord rights, Just newData)
+>                     return $ (rightsFromWord rights, Just newData)
 >                 (CNodeMove, _) ->
->                     return $! (allRights, Nothing)
+>                     return $ (allRights, Nothing)
 >                 (CNodeMutate, newData:_) ->
->                     return $! (allRights, Just newData)
+>                     return $ (allRights, Just newData)
 >                 _ -> throw TruncatedMessage
 
 The moving system calls, "Move" and "Mutate", are differentiated from the copying system calls, "Copy" and "Mint".
@@ -117,7 +117,7 @@ The rights and capability data word are applied to the source capability to crea
 >                 Nothing -> srcCap
 >             when (isNullCap newCap) $ throw IllegalOperation
 >
->             return $!
+>             return $
 >                 (if isMove then Move else Insert) newCap srcSlot destSlot
 
 The "Revoke", "Delete", "SaveCaller" and "CancelBadgedSends" operations have no additional arguments. The "SaveCaller" call requires the target slot to be empty.
@@ -178,7 +178,7 @@ The moved capabilities must not be null.
 >             when (isNullCap newSrcCap) $ throw IllegalOperation
 >             when (isNullCap newPivotCap) $ throw IllegalOperation
 
->             return $! Rotate newSrcCap newPivotCap srcSlot pivotSlot destSlot
+>             return $ Rotate newSrcCap newPivotCap srcSlot pivotSlot destSlot
 
 Otherwise, the message was too short.
 
@@ -748,7 +748,7 @@ When deleting a capability, it is necessary to determine whether it is the only 
 >         then return False
 >         else do
 >             prev <- getCTE (mdbPrev mdb)
->             return $! sameObjectAs (cteCap prev) (cteCap cte)
+>             return $ sameObjectAs (cteCap prev) (cteCap cte)
 >     if prevIsSameObject
 >         then return False
 >         else if mdbNext mdb == nullPointer

--- a/spec/haskell/src/SEL4/Object/Interrupt.lhs
+++ b/spec/haskell/src/SEL4/Object/Interrupt.lhs
@@ -208,7 +208,7 @@ The following functions are used within this module to access the global interru
 >     doMachineOp $ maskInterrupt (irqState==IRQInactive) irq
 
 > getIRQState :: IRQ -> Kernel IRQState
-> getIRQState irq = liftM ((!irq) . intStateIRQTable) getInterruptState
+> getIRQState irq = liftM ((! irq) . intStateIRQTable) getInterruptState
 
 > getIRQSlot :: IRQ -> Kernel (PPtr CTE)
 > getIRQSlot irq = do

--- a/spec/haskell/src/SEL4/Object/ObjectType.lhs
+++ b/spec/haskell/src/SEL4/Object/ObjectType.lhs
@@ -361,23 +361,23 @@ New threads are placed in the current security domain, which must be the domain 
 >             curdom <- curDomain
 >             threadSet (\t -> t { tcbDomain = curdom })
 >                 (PPtr $ fromPPtr regionBase)
->             return $! ThreadCap (PPtr $ fromPPtr regionBase)
+>             return $ ThreadCap (PPtr $ fromPPtr regionBase)
 >         Just EndpointObject -> do
 >             placeNewObject regionBase (makeObject :: Endpoint) 0
->             return $! EndpointCap (PPtr $ fromPPtr regionBase) 0 True True True True
+>             return $ EndpointCap (PPtr $ fromPPtr regionBase) 0 True True True True
 >         Just NotificationObject -> do
 >             placeNewObject (PPtr $ fromPPtr regionBase) (makeObject :: Notification) 0
->             return $! NotificationCap (PPtr $ fromPPtr regionBase) 0 True True
+>             return $ NotificationCap (PPtr $ fromPPtr regionBase) 0 True True
 >         Just CapTableObject -> do
 >             placeNewObject (PPtr $ fromPPtr regionBase) (makeObject :: CTE) userSize
 >             modify (\ks -> ks { gsCNodes =
 >               funupd (gsCNodes ks) (fromPPtr regionBase) (Just userSize)})
->             return $! CNodeCap (PPtr $ fromPPtr regionBase) userSize 0 0
+>             return $ CNodeCap (PPtr $ fromPPtr regionBase) userSize 0 0
 >         Just Untyped ->
->             return $! UntypedCap isDevice (PPtr $ fromPPtr regionBase) userSize 0
+>             return $ UntypedCap isDevice (PPtr $ fromPPtr regionBase) userSize 0
 >         Nothing -> do
 >             archCap <- Arch.createObject t regionBase userSize isDevice
->             return $! ArchObjectCap archCap
+>             return $ ArchObjectCap archCap
 
 \subsection{Invoking Objects}
 
@@ -440,41 +440,41 @@ This function just dispatches invocations to the type-specific invocation functi
 >
 > performInvocation _ _ (InvokeUntyped invok) = do
 >     invokeUntyped invok
->     return $! []
+>     return $ []
 >
 > performInvocation block call (InvokeEndpoint ep badge canGrant canGrantReply) =
 >   withoutPreemption $ do
 >     thread <- getCurThread
 >     sendIPC block call badge canGrant canGrantReply thread ep
->     return $! []
+>     return $ []
 >
 > performInvocation _ _ (InvokeNotification ep badge) = do
 >     withoutPreemption $ sendSignal ep badge
->     return $! []
+>     return $ []
 >
 > performInvocation _ _ (InvokeReply thread slot canGrant) =
 >   withoutPreemption $ do
 >     sender <- getCurThread
 >     doReplyTransfer sender thread slot canGrant
->     return $! []
+>     return $ []
 >
 > performInvocation _ _ (InvokeTCB invok) = invokeTCB invok
 >
 > performInvocation _ _ (InvokeDomain thread domain) = withoutPreemption $ do
 >     setDomain thread domain
->     return $! []
+>     return $ []
 >
 > performInvocation _ _ (InvokeCNode invok) = do
 >     invokeCNode invok
->     return $! []
+>     return $ []
 >
 > performInvocation _ _ (InvokeIRQControl invok) = do
 >     performIRQControl invok
->     return $! []
+>     return $ []
 >
 > performInvocation _ _ (InvokeIRQHandler invok) = do
 >     withoutPreemption $ invokeIRQHandler invok
->     return $! []
+>     return $ []
 >
 > performInvocation _ _ (InvokeArchObject invok) = Arch.performInvocation invok
 

--- a/spec/haskell/src/SEL4/Object/ObjectType/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Object/ObjectType/AARCH64.hs
@@ -170,33 +170,33 @@ createObject t regionBase _ isDevice =
             modify (\ks -> ks { gsUserPages =
               funupd (gsUserPages ks)
                      (fromPPtr regionBase) (Just ARMSmallPage)})
-            return $! FrameCap (pointerCast regionBase)
+            return $ FrameCap (pointerCast regionBase)
                   VMReadWrite ARMSmallPage isDevice Nothing
         Arch.Types.LargePageObject -> do
             placeNewDataObject regionBase (ptTranslationBits NormalPT_T) isDevice
             modify (\ks -> ks { gsUserPages =
               funupd (gsUserPages ks)
                      (fromPPtr regionBase) (Just ARMLargePage)})
-            return $! FrameCap (pointerCast regionBase)
+            return $ FrameCap (pointerCast regionBase)
                   VMReadWrite ARMLargePage isDevice Nothing
         Arch.Types.HugePageObject -> do
             placeNewDataObject regionBase (2*ptTranslationBits NormalPT_T) isDevice
             modify (\ks -> ks { gsUserPages =
               funupd (gsUserPages ks)
                      (fromPPtr regionBase) (Just ARMHugePage)})
-            return $! FrameCap (pointerCast regionBase)
+            return $ FrameCap (pointerCast regionBase)
                   VMReadWrite ARMHugePage isDevice Nothing
         Arch.Types.PageTableObject -> do
             let ptSize = ptBits NormalPT_T - objBits (makeObject :: PTE)
             placeNewObject regionBase (makeObject :: PTE) ptSize
-            return $! PageTableCap (pointerCast regionBase) NormalPT_T Nothing
+            return $ PageTableCap (pointerCast regionBase) NormalPT_T Nothing
         Arch.Types.VSpaceObject -> do
             let ptSize = ptBits VSRootPT_T - objBits (makeObject :: PTE)
             placeNewObject regionBase (makeObject :: PTE) ptSize
-            return $! PageTableCap (pointerCast regionBase) VSRootPT_T Nothing
+            return $ PageTableCap (pointerCast regionBase) VSRootPT_T Nothing
         Arch.Types.VCPUObject -> do
             placeNewObject regionBase (makeObject :: VCPU) 0
-            return $! VCPUCap (PPtr $ fromPPtr regionBase)
+            return $ VCPUCap (PPtr $ fromPPtr regionBase)
 
 {- Capability Invocation -}
 

--- a/spec/haskell/src/SEL4/Object/ObjectType/ARM.lhs
+++ b/spec/haskell/src/SEL4/Object/ObjectType/ARM.lhs
@@ -218,13 +218,13 @@ Create an architecture-specific object.
 >             modify (\ks -> ks { gsUserPages =
 >               funupd (gsUserPages ks)
 >                      (fromPPtr regionBase) (Just ARMSmallPage)})
->             return $! mkPageCap ARMSmallPage
+>             return $ mkPageCap ARMSmallPage
 >         Arch.Types.LargePageObject -> do
 >             placeNewDataObject regionBase 4 isDevice
 >             modify (\ks -> ks { gsUserPages =
 >               funupd (gsUserPages ks)
 >                      (fromPPtr regionBase) (Just ARMLargePage)})
->             return $! mkPageCap ARMLargePage
+>             return $ mkPageCap ARMLargePage
 >         Arch.Types.SectionObject -> do
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 >             placeNewDataObject regionBase 9 isDevice
@@ -234,7 +234,7 @@ Create an architecture-specific object.
 >             modify (\ks -> ks { gsUserPages =
 >               funupd (gsUserPages ks)
 >                      (fromPPtr regionBase) (Just ARMSection)})
->             return $! mkPageCap ARMSection
+>             return $ mkPageCap ARMSection
 >         Arch.Types.SuperSectionObject -> do
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 >             placeNewDataObject regionBase 13 isDevice
@@ -244,11 +244,11 @@ Create an architecture-specific object.
 >             modify (\ks -> ks { gsUserPages =
 >               funupd (gsUserPages ks)
 >                      (fromPPtr regionBase) (Just ARMSuperSection)})
->             return $! mkPageCap ARMSuperSection
+>             return $ mkPageCap ARMSuperSection
 >         Arch.Types.PageTableObject -> do
 >             let ptSize = ptBits - objBits (makeObject :: PTE)
 >             placeNewObject regionBase (makeObject :: PTE) ptSize
->             return $! PageTableCap (pointerCast regionBase) Nothing
+>             return $ PageTableCap (pointerCast regionBase) Nothing
 >         Arch.Types.PageDirectoryObject -> do
 >             let pdSize = pdBits - objBits (makeObject :: PDE)
 >             let regionSize = (1 `shiftL` pdBits)
@@ -258,11 +258,11 @@ Create an architecture-specific object.
 >                 cleanCacheRange_PoU (VPtr $ fromPPtr regionBase)
 >                       (VPtr $ fromPPtr regionBase + regionSize - 1)
 >                       (addrFromPPtr regionBase)
->             return $! PageDirectoryCap (pointerCast regionBase) Nothing
+>             return $ PageDirectoryCap (pointerCast regionBase) Nothing
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 >         Arch.Types.VCPUObject -> do
 >             placeNewObject regionBase (makeObject :: VCPU) 0
->             return $! VCPUCap (PPtr $ fromPPtr regionBase)
+>             return $ VCPUCap (PPtr $ fromPPtr regionBase)
 #endif
 #ifdef CONFIG_ARM_SMMU
 >         Arch.Types.IOPageTableObject -> do

--- a/spec/haskell/src/SEL4/Object/ObjectType/RISCV64.hs
+++ b/spec/haskell/src/SEL4/Object/ObjectType/RISCV64.hs
@@ -153,26 +153,26 @@ createObject t regionBase _ isDevice =
             modify (\ks -> ks { gsUserPages =
               funupd (gsUserPages ks)
                      (fromPPtr regionBase) (Just RISCVSmallPage)})
-            return $! FrameCap (pointerCast regionBase)
+            return $ FrameCap (pointerCast regionBase)
                   VMReadWrite RISCVSmallPage isDevice Nothing
         Arch.Types.LargePageObject -> do
             placeNewDataObject regionBase ptTranslationBits isDevice
             modify (\ks -> ks { gsUserPages =
               funupd (gsUserPages ks)
                      (fromPPtr regionBase) (Just RISCVLargePage)})
-            return $! FrameCap (pointerCast regionBase)
+            return $ FrameCap (pointerCast regionBase)
                   VMReadWrite RISCVLargePage isDevice Nothing
         Arch.Types.HugePageObject -> do
             placeNewDataObject regionBase (ptTranslationBits+ptTranslationBits) isDevice
             modify (\ks -> ks { gsUserPages =
               funupd (gsUserPages ks)
                      (fromPPtr regionBase) (Just RISCVHugePage)})
-            return $! FrameCap (pointerCast regionBase)
+            return $ FrameCap (pointerCast regionBase)
                   VMReadWrite RISCVHugePage isDevice Nothing
         Arch.Types.PageTableObject -> do
             let ptSize = ptBits - objBits (makeObject :: PTE)
             placeNewObject regionBase (makeObject :: PTE) ptSize
-            return $! PageTableCap (pointerCast regionBase) Nothing
+            return $ PageTableCap (pointerCast regionBase) Nothing
 
 {- Capability Invocation -}
 

--- a/spec/haskell/src/SEL4/Object/ObjectType/X64.lhs
+++ b/spec/haskell/src/SEL4/Object/ObjectType/X64.lhs
@@ -299,39 +299,39 @@ Create an architecture-specific object.
 >             modify (\ks -> ks { gsUserPages =
 >               funupd (gsUserPages ks)
 >                      (fromPPtr regionBase) (Just X64SmallPage)})
->             return $! PageCap (pointerCast regionBase)
+>             return $ PageCap (pointerCast regionBase)
 >                   VMReadWrite VMNoMap X64SmallPage isDevice Nothing
 >         Arch.Types.LargePageObject -> do
 >             placeNewDataObject regionBase ptTranslationBits isDevice
 >             modify (\ks -> ks { gsUserPages =
 >               funupd (gsUserPages ks)
 >                      (fromPPtr regionBase) (Just X64LargePage)})
->             return $! PageCap (pointerCast regionBase)
+>             return $ PageCap (pointerCast regionBase)
 >                   VMReadWrite VMNoMap X64LargePage isDevice Nothing
 >         Arch.Types.HugePageObject -> do
 >             placeNewDataObject regionBase (ptTranslationBits + ptTranslationBits) isDevice
 >             modify (\ks -> ks { gsUserPages =
 >               funupd (gsUserPages ks)
 >                      (fromPPtr regionBase) (Just X64HugePage)})
->             return $! PageCap (pointerCast regionBase)
+>             return $ PageCap (pointerCast regionBase)
 >                   VMReadWrite VMNoMap X64HugePage isDevice Nothing
 >         Arch.Types.PageTableObject -> do
 >             let ptSize = ptBits - objBits (makeObject :: PTE)
 >             placeNewObject regionBase (makeObject :: PTE) ptSize
->             return $! PageTableCap (pointerCast regionBase) Nothing
+>             return $ PageTableCap (pointerCast regionBase) Nothing
 >         Arch.Types.PageDirectoryObject -> do
 >             let pdSize = pdBits - objBits (makeObject :: PDE)
 >             placeNewObject regionBase (makeObject :: PDE) pdSize
->             return $! PageDirectoryCap (pointerCast regionBase) Nothing
+>             return $ PageDirectoryCap (pointerCast regionBase) Nothing
 >         Arch.Types.PDPointerTableObject -> do
 >             let pdptSize = pdptBits - objBits (makeObject :: PDPTE)
 >             placeNewObject regionBase (makeObject :: PDPTE) pdptSize
->             return $! PDPointerTableCap (pointerCast regionBase) Nothing
+>             return $ PDPointerTableCap (pointerCast regionBase) Nothing
 >         Arch.Types.PML4Object -> do
 >             let pml4Size = pml4Bits - objBits (makeObject :: PML4E)
 >             placeNewObject regionBase (makeObject :: PML4E) pml4Size
 >             copyGlobalMappings (pointerCast regionBase)
->             return $! PML4Cap (pointerCast regionBase) Nothing
+>             return $ PML4Cap (pointerCast regionBase) Nothing
 
 \subsection{Capability Invocation}
 

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -74,8 +74,8 @@ There are eleven types of invocation for a thread control block. All require wri
 >         TCBReadRegisters -> decodeReadRegisters args cap
 >         TCBWriteRegisters -> decodeWriteRegisters args cap
 >         TCBCopyRegisters -> decodeCopyRegisters args cap $ map fst extraCaps
->         TCBSuspend -> return $! Suspend (capTCBPtr cap)
->         TCBResume -> return $! Resume (capTCBPtr cap)
+>         TCBSuspend -> return $ Suspend (capTCBPtr cap)
+>         TCBResume -> return $ Resume (capTCBPtr cap)
 >         TCBConfigure -> decodeTCBConfigure args cap slot extraCaps
 >         TCBSetPriority -> decodeSetPriority args cap extraCaps
 >         TCBSetMCPriority -> decodeSetMCPriority args cap extraCaps
@@ -208,7 +208,7 @@ Setting the thread's priority is only allowed if the new priority is lower than 
 >         ThreadCap { capTCBPtr = tcbPtr } -> return tcbPtr
 >         _ -> throw $ InvalidCapability 1
 >     checkPrio newPrio authTCB
->     return $! ThreadControl {
+>     return $ ThreadControl {
 >         tcThread = capTCBPtr cap,
 >--       tcThreadCapSlot = error "tcThreadCapSlot unused", In theory tcThreadCapSlot should never been evaluated by lazy evaluation. However, it was evaluated when running sel4 haskell kernel. So it is wired. Thus I change this to 0. I hope this can be changed back once we find out why this is evaluated. (by Xin)
 >         tcThreadCapSlot = 0,
@@ -227,7 +227,7 @@ Setting the thread's priority is only allowed if the new priority is lower than 
 >         ThreadCap { capTCBPtr = tcbPtr } -> return tcbPtr
 >         _ -> throw $ InvalidCapability 1
 >     checkPrio newMCP authTCB
->     return $! ThreadControl {
+>     return $ ThreadControl {
 >         tcThread = capTCBPtr cap,
 >         tcThreadCapSlot = 0,
 >         tcNewFaultEP = Nothing,
@@ -248,7 +248,7 @@ The "SetSchedParams" call sets both the priority and the MCP in a single call.
 >         _ -> throw $ InvalidCapability 1
 >     checkPrio newMCP authTCB
 >     checkPrio newPrio authTCB
->     return $! ThreadControl {
+>     return $ ThreadControl {
 >         tcThread = capTCBPtr cap,
 >         tcThreadCapSlot = 0,
 >         tcNewFaultEP = Nothing,

--- a/spec/haskell/src/SEL4/Object/Untyped.lhs
+++ b/spec/haskell/src/SEL4/Object/Untyped.lhs
@@ -152,7 +152,7 @@ Align up the free region pointer to ensure that created objects are aligned to t
 
 >     let alignedFreeRef = PPtr $ alignUp (fromPPtr freeRef) objectSize
 
->     return $! Retype {
+>     return $ Retype {
 >         retypeSource = slot,
 >         retypeResetUntyped = reset,
 >         retypeRegionBase = capPtr cap,

--- a/spec/haskell/src/Simulation/FFIBindings.hs
+++ b/spec/haskell/src/Simulation/FFIBindings.hs
@@ -314,7 +314,7 @@ runStateFromC f = do
         sptr' <- newStablePtr (st', md)
         return (a, sptr')
     put sptr'
-    return $! a
+    return $ a
 
 -- Flag any SIGINT that we receive.
 handleBreak :: Ptr CInt -> IO ()

--- a/spec/haskell/stack.yaml
+++ b/spec/haskell/stack.yaml
@@ -4,7 +4,11 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-resolver: lts-13.15
+# We use `stack` only to install GHC and cabal-install, not to build the project.
+# The rest of the build works via cabal
+
+# Stackage LTS Haskell 19.12 (ghc-9.0.2)
+resolver: lts-19.12
 
 packages: []
 extra-deps: []

--- a/tools/haskell-translator/caseconvs
+++ b/tools/haskell-translator/caseconvs
@@ -1557,7 +1557,7 @@ case \x of cap@(IOPortCap {}) -> IOPortControlCap -> _ ->  ---> let cap = \x in
     then ->2
     else ->3
 
-case \x of (cap @ (CNodeCap {})) -> (cap @ (ThreadCap {})) -> (cap @ (Zombie {})) -> _ ->  ---> let cap = \x in
+case \x of cap@(CNodeCap {}) -> cap@(ThreadCap {}) -> cap@(Zombie {}) -> _ ->  ---> let cap = \x in
     if isCNodeCap cap
     then ->1
     else if isThreadCap cap

--- a/tools/haskell-translator/lhs_pars.py
+++ b/tools/haskell-translator/lhs_pars.py
@@ -2152,7 +2152,7 @@ regexes = [
     (re.compile(r" \. "), r" \<circ> "),
     (re.compile('-1'), '- 1'),
     (re.compile('-2'), '- 2'),
-    (re.compile(r"\(!(\w+)\)"), r"(flip id \1)"),
+    (re.compile(r"\(![ ]*(\w+)\)"), r"(flip id \1)"),
     (re.compile(r"\(\+(\w+)\)"), r"(\<lambda> x. x + \1)"),
     (re.compile(r"\\([^<].*?)\s*->"), r"\<lambda> \1."),
     (re.compile('}'), r"\<rparr>"),


### PR DESCRIPTION
This is mostly to reduce build time/cache size for docker images.

Main change with ghc 9.0.2 is that `fail` now requires the class `MonadFail` instead of just `Monad` and a few small surface syntax tweaks. As far as I can see, there is no impact on the Isabelle side.