### PR TITLE
Sorrying till `CSpace_C.thy`

### DIFF
--- a/proof/crefine/Move_C.thy
+++ b/proof/crefine/Move_C.thy
@@ -1151,19 +1151,6 @@ lemma ctes_of_valid_strengthen:
   apply fastforce
   done
 
-lemma finaliseCap_Reply:
-  "\<lbrace>Q (NullCap,NullCap) and K (isReplyCap cap)\<rbrace> finaliseCapTrue_standin cap is_final \<lbrace>Q\<rbrace>"
-  apply (rule NonDetMonadVCG.hoare_gen_asm)
-  apply (wpsimp simp: finaliseCapTrue_standin_def isCap_simps)
-  done
-
-lemma cteDeleteOne_Reply:
-  "\<lbrace>st_tcb_at' P t and cte_wp_at' (isReplyCap o cteCap) slot\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>_. st_tcb_at' P t\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def split_def)
-  apply (wp finaliseCap_Reply isFinalCapability_inv getCTE_wp')
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  done
-
 lemma cancelSignal_st_tcb':
   "\<lbrace>\<lambda>s. t\<noteq>t' \<and> st_tcb_at' P t' s\<rbrace> cancelSignal t ntfn \<lbrace>\<lambda>_. st_tcb_at' P t'\<rbrace>"
   apply (simp add: cancelSignal_def Let_def)
@@ -1172,26 +1159,14 @@ lemma cancelSignal_st_tcb':
   apply clarsimp
   done
 
-lemma cancelIPC_st_tcb_at':
-  "\<lbrace>\<lambda>s. t\<noteq>t' \<and> st_tcb_at' P t' s\<rbrace> cancelIPC t \<lbrace>\<lambda>_. st_tcb_at' P t'\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def getThreadReplySlot_def locateSlot_conv)
-  apply (wp sts_pred_tcb_neq' getEndpoint_wp cteDeleteOne_Reply getCTE_wp' | wpc)+
-          apply (rule hoare_strengthen_post [where Q="\<lambda>_. st_tcb_at' P t'"])
-           apply (wp threadSet_st_tcb_at2)
-           apply simp
-          apply (clarsimp simp: cte_wp_at_ctes_of capHasProperty_def)
-         apply (wp cancelSignal_st_tcb' sts_pred_tcb_neq' getEndpoint_wp gts_wp' | wpc)+
-  apply clarsimp
-  done
-
 lemma suspend_st_tcb_at':
-  "\<lbrace>\<lambda>s. (t\<noteq>t' \<longrightarrow> st_tcb_at' P t' s) \<and> (t=t' \<longrightarrow> P Inactive)\<rbrace>
-  suspend t
-  \<lbrace>\<lambda>_. st_tcb_at' P t'\<rbrace>"
+  "\<lbrace>\<lambda>s. (t \<noteq> t' \<longrightarrow> st_tcb_at' P t' s) \<and> (t = t' \<longrightarrow> P Inactive)\<rbrace>
+   suspend t
+   \<lbrace>\<lambda>_. st_tcb_at' P t'\<rbrace>"
   apply (simp add: suspend_def unless_def)
   unfolding updateRestartPC_def
-  apply (cases "t=t'")
-   apply (simp | wp cancelIPC_st_tcb_at' sts_st_tcb')+
+  apply (cases "t = t'")
+   apply (wpsimp wp: cancelIPC_st_tcb_at' sts_st_tcb' hoare_drop_imp)+
   done
 
 lemma typ_at'_no_0_objD:
@@ -1206,26 +1181,11 @@ lemma ko_at'_not_NULL:
 crunch ksReadyQueuesL1Bitmap[wp]: setQueue "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
 
 lemma sts_running_ksReadyQueuesL1Bitmap[wp]:
-  "\<lbrace>\<lambda>s. P (ksReadyQueuesL1Bitmap s)\<rbrace>
-   setThreadState Structures_H.thread_state.Running t
-   \<lbrace>\<lambda>_ s. P (ksReadyQueuesL1Bitmap s)\<rbrace>"
-  unfolding setThreadState_def
-  apply wp
-       apply (rule hoare_pre_cont)
-      apply (wpsimp simp: if_apply_def2
-                    wp: hoare_drop_imps hoare_vcg_disj_lift threadSet_tcbState_st_tcb_at')+
-  done
-
-lemma sts_running_ksReadyQueuesL2Bitmap[wp]:
-  "\<lbrace>\<lambda>s. P (ksReadyQueuesL2Bitmap s)\<rbrace>
-   setThreadState Structures_H.thread_state.Running t
-   \<lbrace>\<lambda>_ s. P (ksReadyQueuesL2Bitmap s)\<rbrace>"
-  unfolding setThreadState_def
-  apply wp
-       apply (rule hoare_pre_cont)
-      apply (wpsimp simp: if_apply_def2
-                    wp: hoare_drop_imps hoare_vcg_disj_lift threadSet_tcbState_st_tcb_at')+
-  done
+  "setThreadState Running t \<lbrace>\<lambda>s. P (ksReadyQueuesL1Bitmap s)\<rbrace>"
+  unfolding setThreadState_def scheduleTCB_def rescheduleRequired_def
+  apply wpsimp
+         apply (rule hoare_pre_cont)
+        by (wpsimp wp: hoare_drop_imps isSchedulable_wp)+
 
 lemma asUser_obj_at_not_queued[wp]:
   "\<lbrace>obj_at' (\<lambda>tcb. \<not> tcbQueued tcb) p\<rbrace> asUser t m \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. \<not> tcbQueued tcb) p\<rbrace>"

--- a/proof/crefine/RISCV64/Ctac_lemmas_C.thy
+++ b/proof/crefine/RISCV64/Ctac_lemmas_C.thy
@@ -47,15 +47,14 @@ lemma rf_sr_tcb_ctes_array_assertion':
   "\<lbrakk> (s, s') \<in> rf_sr; tcb_at' (ctcb_ptr_to_tcb_ptr tcb) s \<rbrakk>
     \<Longrightarrow> array_assertion (cte_Ptr (ptr_val tcb && ~~mask tcbBlockSizeBits))
         (unat tcbCNodeEntries) (hrs_htd (t_hrs_' (globals s')))"
-  apply (rule h_t_array_valid_array_assertion, simp_all add: tcbCNodeEntries_def)
+  apply (rule h_t_array_valid_array_assertion)
   apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                         cvariable_array_map_relation_def
                         cpspace_relation_def)
   apply (drule obj_at_ko_at', clarsimp)
   apply (drule spec, drule mp, rule exI, erule ko_at_projectKO_opt)
   apply (frule ptr_val_tcb_ptr_mask)
-  apply (simp add: mask_def)
-  done
+   by (fastforce simp add: mask_def tcbCNodeEntries_def)+
 
 lemmas rf_sr_tcb_ctes_array_assertion
   = rf_sr_tcb_ctes_array_assertion'[simplified objBits_defs mask_def, simplified]

--- a/proof/crefine/RISCV64/StateRelation_C.thy
+++ b/proof/crefine/RISCV64/StateRelation_C.thy
@@ -651,7 +651,7 @@ abbreviation
 abbreviation
   "tcb_cte_array_relation astate cstate
     \<equiv> cvariable_array_map_relation (map_to_tcbs (ksPSpace astate))
-        (\<lambda>x. 6) cte_Ptr (hrs_htd (t_hrs_' cstate))"
+        (\<lambda>x. unat tcbCNodeEntries) cte_Ptr (hrs_htd (t_hrs_' cstate))"
 
 fun
   irqstate_to_C :: "irqstate \<Rightarrow> machine_word"

--- a/proof/refine/RISCV64/KHeap_R.thy
+++ b/proof/refine/RISCV64/KHeap_R.thy
@@ -949,6 +949,11 @@ proof -
                   elim: cte_wp_atE' canonical_address_add)
 qed
 
+lemma obj_at'_is_canonical:
+  "\<lbrakk>pspace_canonical' s; obj_at' P t s\<rbrakk> \<Longrightarrow> canonical_address t"
+  apply (clarsimp simp: obj_at'_def pspace_canonical'_def)
+  by (drule_tac x=t in bspec) clarsimp+
+
 (* FIXME rt merge: move to Word_lib *)
 lemma max_word_minus_1[simp]: "0xFFFFFFFFFFFFFFFF + 2^x = (2^x - 1::64 word)"
   by simp


### PR DESCRIPTION
This sorries until the beginning of `CSpace_C.thy`. In fact, only one sorry is added, namely `setCurThread_isolatable`, which is probably no longer true (if people think it is preferable, I can simply remove this lemma).

Many lemmas involving `setObject` and `getObject` have been updated now that they involve the reader monad.