### PR TITLE
riscv haskell+proofs: fix PageTablePTE encoding

### DIFF
--- a/proof/crefine/RISCV64/Arch_C.thy
+++ b/proof/crefine/RISCV64/Arch_C.thy
@@ -1514,7 +1514,7 @@ lemma list_3_collapse:
   done
 
 lemma pde_case_isPageTablePDE:
-  "(case pte of PageTablePTE _ _ _ \<Rightarrow> P | _ \<Rightarrow> Q)
+  "(case pte of PageTablePTE _ _ \<Rightarrow> P | _ \<Rightarrow> Q)
        = (if isPageTablePTE pte then P else Q)"
   by (clarsimp simp: isPageTablePTE_def split: pte.splits)
 

--- a/proof/crefine/RISCV64/StateRelation_C.thy
+++ b/proof/crefine/RISCV64/StateRelation_C.thy
@@ -445,14 +445,14 @@ where
         pte_CL.write_CL = writable_from_vm_rights rights,
         pte_CL.read_CL = readable_from_vm_rights rights,
         pte_CL.valid_CL = 1 \<rparr> \<and> \<not>(rights = VMKernelOnly  \<and> \<not>execute)
-  | PageTablePTE ppn global user \<Rightarrow>
+  | PageTablePTE ppn global \<Rightarrow>
       cpte' =  \<lparr>
         pte_CL.ppn_CL = ucast ppn,
         pte_CL.sw_CL = 0,
-        pte_CL.dirty_CL = 1,
-        pte_CL.accessed_CL = 1,
+        pte_CL.dirty_CL = 0,
+        pte_CL.accessed_CL = 0,
         pte_CL.global_CL = of_bool global,
-        pte_CL.user_CL = of_bool user,
+        pte_CL.user_CL = 0,
         pte_CL.execute_CL = 0,
         pte_CL.write_CL = 0,
         pte_CL.read_CL = 0,

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -347,7 +347,7 @@ lemma corres_symb_exec_unknown_r:
   done
 
 lemma isPageTablePTE_def2:
-  "isPageTablePTE pte = (\<exists>ppn global user. pte = PageTablePTE ppn global user)"
+  "isPageTablePTE pte = (\<exists>ppn global. pte = PageTablePTE ppn global)"
   by (simp add: isPageTablePTE_def split: pte.splits)
 
 lemma getPPtrFromHWPTE_spec':

--- a/proof/infoflow/refine/RISCV64/Example_Valid_StateH.thy
+++ b/proof/infoflow/refine/RISCV64/Example_Valid_StateH.thy
@@ -160,7 +160,7 @@ definition Low_ptH :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> kernel_object
 definition Low_pd'H :: "pt_index \<Rightarrow> pte" where
   "Low_pd'H \<equiv>
      global_pteH
-       (0 := PageTablePTE (addrFromPPtr Low_pt_ptr >> pt_bits) False False)"
+       (0 := PageTablePTE (addrFromPPtr Low_pt_ptr >> pt_bits) False)"
 
 definition Low_pdH :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> kernel_object option" where
   "Low_pdH \<equiv>
@@ -185,7 +185,7 @@ definition High_ptH :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> kernel_objec
 definition High_pd'H :: "pt_index \<Rightarrow> pte" where
   "High_pd'H \<equiv>
      global_pteH
-       (0 := PageTablePTE (addrFromPPtr High_pt_ptr >> pt_bits) False False)"
+       (0 := PageTablePTE (addrFromPPtr High_pt_ptr >> pt_bits) False)"
 
 definition High_pdH :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> kernel_object option" where
   "High_pdH \<equiv>

--- a/proof/refine/RISCV64/ADT_H.thy
+++ b/proof/refine/RISCV64/ADT_H.thy
@@ -69,9 +69,9 @@ definition absPageTable0 ::
        then Some (RISCV64_A.PagePTE (ucast p) {x. g \<and> x=Global \<or> u \<and> x = User \<or> e \<and> x = Execute}
                                     (vm_rights_of rights))
        else None
-   | Some (KOArch (KOPTE (PageTablePTE p g u))) \<Rightarrow>
+   | Some (KOArch (KOPTE (PageTablePTE p g))) \<Rightarrow>
        if p \<le> mask ppn_len
-       then Some (RISCV64_A.PageTablePTE (ucast p) {x. g \<and> x=Global \<or> u \<and> x = User})
+       then Some (RISCV64_A.PageTablePTE (ucast p) {x. g \<and> x=Global})
        else None
    | _ \<Rightarrow> None"
 

--- a/proof/refine/RISCV64/StateRelation.thy
+++ b/proof/refine/RISCV64/StateRelation.thy
@@ -170,7 +170,7 @@ primrec pte_relation' :: "RISCV64_A.pte \<Rightarrow> RISCV64_H.pte \<Rightarrow
   "pte_relation' RISCV64_A.InvalidPTE x =
      (x = RISCV64_H.InvalidPTE)"
 | "pte_relation' (RISCV64_A.PageTablePTE ppn atts) x =
-     (x = RISCV64_H.PageTablePTE (ucast ppn) (Global \<in> atts) (User \<in> atts) \<and> Execute \<notin> atts)"
+     (x = RISCV64_H.PageTablePTE (ucast ppn) (Global \<in> atts) \<and> Execute \<notin> atts \<and> User \<notin> atts)"
 | "pte_relation' (RISCV64_A.PagePTE ppn atts rghts) x =
      (x = RISCV64_H.PagePTE (ucast ppn) (Global \<in> atts) (User \<in> atts) (Execute \<in> atts)
                             (vmrights_map rghts))"

--- a/spec/haskell/src/SEL4/Kernel/VSpace/RISCV64.hs
+++ b/spec/haskell/src/SEL4/Kernel/VSpace/RISCV64.hs
@@ -395,8 +395,7 @@ decodeRISCVPageTableInvocationMap cte cap vptr attr vspaceCap = do
     when (bitsLeft == pageBits || oldPTE /= InvalidPTE) $ throw DeleteFirst
     let pte = PageTablePTE {
             ptePPN = addrFromPPtr (capPTBasePtr cap) `shiftR` pageBits,
-            pteGlobal = False,
-            pteUser = False }
+            pteGlobal = False }
     let vptr = vptr .&. complement (mask bitsLeft)
     return $ InvokePageTable $ PageTableMap {
         ptMapCap = ArchObjectCap $ cap { capPTMappedAddress = Just (asid, vptr) },

--- a/spec/haskell/src/SEL4/Machine/Hardware/RISCV64.hs
+++ b/spec/haskell/src/SEL4/Machine/Hardware/RISCV64.hs
@@ -263,8 +263,7 @@ data PTE
         pteRights :: VMRights }
     | PageTablePTE {
         ptePPN :: PAddr,
-        pteGlobal :: Bool,
-        pteUser :: Bool }
+        pteGlobal :: Bool }
     deriving (Show, Eq)
 
 {- Simulator callbacks -}


### PR DESCRIPTION
According to the RISC-V spec, PageTablePTEs must have the access,
dirty, and user bits set to 0. This means that

- there is no user attribute that can be set on PageTablePTEs
  (removed from Haskell spec)
- the encoding for PageTablePTEs in C must have 0 in these fields
  instead of 1.

See PR seL4/seL4#880 for discussion and corresponding C changes.

Test with seL4/seL4#880