### PR TITLE
Sorry `Detype_C`

### DIFF
--- a/proof/crefine/RISCV64/SR_lemmas_C.thy
+++ b/proof/crefine/RISCV64/SR_lemmas_C.thy
@@ -2176,5 +2176,10 @@ lemma unat_scast_numDomains:
   "unat (SCAST(32 signed \<rightarrow> machine_word_len) Kernel_C.numDomains) = unat Kernel_C.numDomains"
   by (simp add: scast_eq sint_numDomains_to_H unat_numDomains_to_H numDomains_machine_word_safe)
 
+(* Sanity check for hard coded sizeof_sched_context_t *)
+lemma sizeof_sched_context_t_eq:
+  "sizeof_sched_context_t = size_of TYPE(sched_context_C)"
+  by (simp add: sizeof_sched_context_t_def word_size_def)
+
 end
 end

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -106,12 +106,17 @@ defs cNodePartialOverlap_def:
       \<or> (\<not> {p .. p + 2 ^ (cte_level_bits + n) - 1} \<subseteq> {p. inRange p}
         \<and> \<not> {p .. p + 2 ^ (cte_level_bits + n) - 1} \<subseteq> {p. \<not> inRange p}))"
 
+defs release_q_runnable_asrt_def:
+  "release_q_runnable_asrt \<equiv>
+     \<lambda>s. \<forall>p. p \<in> set (ksReleaseQueue s) \<longrightarrow> obj_at' (runnable' \<circ> tcbState) p s"
+
 (* FIXME: move *)
 lemma deleteObjects_def2:
   "is_aligned ptr bits \<Longrightarrow>
    deleteObjects ptr bits = do
      stateAssert sym_refs_asrt [];
      stateAssert valid_idle'_asrt [];
+     stateAssert release_q_runnable_asrt [];
      stateAssert (deletionIsSafe ptr bits) [];
      doMachineOp (freeMemory ptr bits);
      stateAssert (\<lambda>s. \<not> cNodePartialOverlap (gsCNodes s) (\<lambda>x. x \<in> {ptr .. ptr + 2 ^ bits - 1})) [];
@@ -145,6 +150,7 @@ lemma deleteObjects_def3:
    do
      stateAssert sym_refs_asrt [];
      stateAssert valid_idle'_asrt [];
+     stateAssert release_q_runnable_asrt [];
      assert (is_aligned ptr bits);
      stateAssert (deletionIsSafe ptr bits) [];
      doMachineOp (freeMemory ptr bits);
@@ -887,19 +893,16 @@ lemma deleteObjects_corres:
            \<and> s' \<turnstile>' (UntypedCap d base magnitude idx))
       (delete_objects base magnitude) (deleteObjects base magnitude)"
     (is "_ \<Longrightarrow> _ \<Longrightarrow> corres _ _ ?conc_guard _ _")
-  apply (rule corres_cross_over_guard
-                 [where Q="?conc_guard
-                           and (\<lambda>s'. \<forall>p. p \<in> set (ksReleaseQueue s')
-                                         \<longrightarrow> obj_at' (runnable' \<circ> tcbState) p s')"])
-   apply (simp add: pred_conj_def)
-   apply (erule ksReleaseQueue_runnable_thread_state; fastforce?)
   apply add_sym_refs
   apply add_valid_idle'
+  apply add_release_q_runnable
   apply (simp add: deleteObjects_def2)
   apply (rule corres_stateAssert_add_assertion[rotated])
    apply (clarsimp simp: sym_refs_asrt_def)
   apply (rule corres_stateAssert_add_assertion[rotated])
    apply (clarsimp simp: valid_idle'_asrt_def)
+  apply (rule corres_stateAssert_add_assertion[rotated])
+   apply (clarsimp simp: release_q_runnable_asrt_def)
   apply (rule corres_stateAssert_add_assertion)
    prefer 2
    apply clarsimp

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -5089,6 +5089,19 @@ lemma is_active_sc'2_cross:
                         active_sc_def opt_map_red StateRelation.is_active_sc'_def)
   done
 
+lemma release_q_runnable_cross:
+  "\<lbrakk>(s,s') \<in> state_relation; valid_release_q s; pspace_aligned s; pspace_distinct s\<rbrakk> \<Longrightarrow>
+   \<forall>p. p \<in> set (ksReleaseQueue s') \<longrightarrow> obj_at' (runnable' \<circ> tcbState) p s'"
+  apply (frule state_relation_release_queue_relation)
+  apply (clarsimp simp: valid_release_q_def obj_at'_def release_queue_relation_def)
+  apply (drule_tac x=p in bspec, blast)
+  apply (clarsimp simp: vs_all_heap_simps)
+  apply (frule_tac t=p in st_tcb_at_coerce_concrete[rotated, where P=runnable], simp, simp)
+   apply (clarsimp simp: pred_tcb_at_def obj_at_def)
+  apply (clarsimp simp: pred_tcb_at'_def obj_at'_def sts_rel_runnable)
+  done
+
+
 \<comment> \<open>Some methods to add invariants to the concrete guard of a corres proof. Often used for properties
     that are asserted to hold in the Haskell definition.\<close>
 
@@ -5120,6 +5133,13 @@ method add_ready_qs_runnable =
   (clarsimp simp: pred_conj_def)?,
   (frule valid_sched_valid_ready_qs)?, (frule invs_psp_aligned)?, (frule invs_distinct)?,
   fastforce dest: ready_qs_runnable_cross
+
+method add_release_q_runnable =
+  rule_tac Q="\<lambda>s'. \<forall>p. p \<in> set (ksReleaseQueue s') \<longrightarrow> obj_at' (runnable' \<circ> tcbState) p s'"
+        in corres_cross_add_guard,
+  (simp only: pred_conj_def)?,
+  (frule valid_sched_valid_release_q)?, (frule invs_psp_aligned)?, (frule invs_distinct)?,
+  fastforce dest: release_q_runnable_cross
 
 method add_valid_replies for rptr uses simp =
   rule_tac Q="\<lambda>s. valid_replies'_sc_asrt rptr s" in corres_cross_add_guard,

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -1323,19 +1323,16 @@ lemma valid_duplicates_deleteObjects_helper:
   done
 
 lemma deleteObjects_valid_duplicates'[wp]:
-  notes [simp del] =  atLeastAtMost_simps
+  notes [simp del] = atLeastAtMost_simps
   shows
-  "\<lbrace>(\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
-      K (is_aligned ptr sz)
-   \<rbrace> deleteObjects ptr sz
-   \<lbrace>\<lambda>r s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
+  "\<lbrace>(\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and K (is_aligned ptr sz)\<rbrace>
+   deleteObjects ptr sz
+   \<lbrace>\<lambda>_ s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (clarsimp simp: deleteObjects_def2)
-  apply (rule hoare_seq_ext_skip, wpsimp)
-  apply (rule hoare_seq_ext_skip, wpsimp)
-  apply (wp hoare_drop_imps|simp)+
-  apply clarsimp
-  apply (simp add:deletionIsSafe_def)
+  apply (intro hoare_seq_ext[OF _ stateAssert_sp])
+  apply (wpsimp wp: hoare_drop_imps)
+  apply (clarsimp simp: deletionIsSafe_def)
   apply (erule valid_duplicates_deleteObjects_helper)
    apply fastforce
   apply simp

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -1047,6 +1047,7 @@ lemma sc_const_eq:
   "schedContextStructSize = sizeof_sched_context_t"
   "minSchedContextBits = min_sched_context_bits"
   by (auto simp: refillSizeBytes_def refill_size_bytes_def minSchedContextBits_def
+                 wordSize_def wordBits_def' word_size_def
                  sizeof_sched_context_t_def min_sched_context_bits_def schedContextStructSize_def)
 
 lemma max_num_refills_eq_refillAbsoluteMax':
@@ -1194,11 +1195,13 @@ qed
 
 lemma min_sched_context_bits_cond:
   "sizeof_sched_context_t + refill_size_bytes < (2::nat) ^ (min_sched_context_bits - 1)"
-   by (clarsimp simp: sizeof_sched_context_t_def refill_size_bytes_def min_sched_context_bits_def)
+   by (clarsimp simp: sizeof_sched_context_t_def refill_size_bytes_def min_sched_context_bits_def
+                      word_size_def)
 
 lemma minSchedContextBits_cond:
   "sizeof_sched_context_t + refill_size_bytes < (2::nat) ^ (minSchedContextBits - 1)"
-   by (clarsimp simp: sizeof_sched_context_t_def refill_size_bytes_def minSchedContextBits_def)
+   by (clarsimp simp: sizeof_sched_context_t_def refill_size_bytes_def minSchedContextBits_def
+                      word_size_def)
 
 lemma scBits_inverse_us:
   notes sc_const_eq[simp]
@@ -1229,7 +1232,8 @@ lemma scBits_inverse_sc:
 
 lemma minRefillLength_ARM: "minRefillLength = 12"
   by (auto simp: minRefillLength_def minSchedContextBits_def refillAbsoluteMax'_def
-                 schedContextStructSize_def refillSizeBytes_def shiftL_nat)
+                 schedContextStructSize_def refillSizeBytes_def shiftL_nat wordSize_def
+                 wordBits_def')
 
 lemma minRefillLength_minSchedContextBits[simp]:
   "scBitsFromRefillLength' minRefillLength = minSchedContextBits"
@@ -1268,7 +1272,7 @@ proof -
     by (simp add: ceil_log_le_mono)
   moreover have "ceil_log (sizeof_sched_context_t) = 6"
     apply (simp add: sc_const_eq(2)[symmetric, simplified schedContextStructSize_def, simplified] ceil_log_def)
-    by (fastforce intro!: discrete_log_eqI)
+    by (fastforce intro!: discrete_log_eqI simp: wordSize_def wordBits_def')
   ultimately show ?thesis
     by (clarsimp simp: scBitsFromRefillLength'_def max_num_refills_def)
 qed

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -4561,18 +4561,6 @@ lemma tcbReleaseRemove_pred_tcb_at'[wp]:
 crunches tcbReleaseRemove
   for weak_sch_act_wf[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
 
-lemma ksReleaseQueue_runnable_thread_state:
-  "\<lbrakk>(s,s') \<in> state_relation; valid_release_q s; pspace_aligned s; pspace_distinct s\<rbrakk>
-   \<Longrightarrow>  \<forall>p. p \<in> set (ksReleaseQueue s') \<longrightarrow> obj_at' (runnable' \<circ> tcbState) p s'"
-  apply (frule state_relation_release_queue_relation)
-  apply (clarsimp simp: valid_release_q_def obj_at'_def release_queue_relation_def)
-  apply (drule_tac x=p in bspec, blast)
-  apply (clarsimp simp: vs_all_heap_simps)
-  apply (frule_tac t=p in st_tcb_at_coerce_concrete[rotated, where P=runnable], simp, simp)
-   apply (clarsimp simp: pred_tcb_at_def obj_at_def)
-  apply (clarsimp simp: pred_tcb_at'_def obj_at'_def sts_rel_runnable)
-  done
-
 lemma sts_st_tcb':
   "\<lbrace>if t = t' then K (P st) else st_tcb_at' P t\<rbrace>
   setThreadState st t'

--- a/proof/refine/RISCV64/KHeap_R.thy
+++ b/proof/refine/RISCV64/KHeap_R.thy
@@ -5005,6 +5005,18 @@ lemma is_active_sc'2_cross:
                         active_sc_def opt_map_red StateRelation.is_active_sc'_def)
   done
 
+lemma release_q_runnable_cross:
+  "\<lbrakk>(s,s') \<in> state_relation; valid_release_q s; pspace_aligned s; pspace_distinct s\<rbrakk> \<Longrightarrow>
+   \<forall>p. p \<in> set (ksReleaseQueue s') \<longrightarrow> obj_at' (runnable' \<circ> tcbState) p s'"
+  apply (frule state_relation_release_queue_relation)
+  apply (clarsimp simp: valid_release_q_def obj_at'_def release_queue_relation_def)
+  apply (drule_tac x=p in bspec, blast)
+  apply (clarsimp simp: vs_all_heap_simps)
+  apply (frule_tac t=p in st_tcb_at_coerce_concrete[rotated, where P=runnable], simp, simp)
+   apply (clarsimp simp: pred_tcb_at_def obj_at_def)
+  apply (clarsimp simp: pred_tcb_at'_def obj_at'_def sts_rel_runnable)
+  done
+
 \<comment> \<open>Some methods to add invariants to the concrete guard of a corres proof. Often used for properties
     that are asserted to hold in the Haskell definition.\<close>
 
@@ -5036,6 +5048,13 @@ method add_ready_qs_runnable =
   (clarsimp simp: pred_conj_def)?,
   (frule valid_sched_valid_ready_qs)?, (frule invs_psp_aligned)?, (frule invs_distinct)?,
   fastforce dest: ready_qs_runnable_cross
+
+method add_release_q_runnable =
+  rule_tac Q="\<lambda>s'. \<forall>p. p \<in> set (ksReleaseQueue s') \<longrightarrow> obj_at' (runnable' \<circ> tcbState) p s'"
+        in corres_cross_add_guard,
+  (simp only: pred_conj_def)?,
+  (frule valid_sched_valid_release_q)?, (frule invs_psp_aligned)?, (frule invs_distinct)?,
+  fastforce dest: release_q_runnable_cross
 
 method add_valid_replies for rptr uses simp =
   rule_tac Q="\<lambda>s. valid_replies'_sc_asrt rptr s" in corres_cross_add_guard,

--- a/proof/refine/RISCV64/StateRelation.thy
+++ b/proof/refine/RISCV64/StateRelation.thy
@@ -893,6 +893,7 @@ lemma sc_const_eq:
   "schedContextStructSize = sizeof_sched_context_t"
   "minSchedContextBits = min_sched_context_bits"
   by (auto simp: refillSizeBytes_def refill_size_bytes_def minSchedContextBits_def
+                 wordSize_def wordBits_def' word_size_def
                  sizeof_sched_context_t_def min_sched_context_bits_def schedContextStructSize_def)
 
 lemma max_num_refills_eq_refillAbsoluteMax':
@@ -1040,11 +1041,13 @@ qed
 
 lemma min_sched_context_bits_cond:
   "sizeof_sched_context_t + refill_size_bytes < (2::nat) ^ (min_sched_context_bits - 1)"
-  by (clarsimp simp: sizeof_sched_context_t_def refill_size_bytes_def min_sched_context_bits_def)
+  by (clarsimp simp: sizeof_sched_context_t_def refill_size_bytes_def min_sched_context_bits_def
+                     word_size_def)
 
 lemma minSchedContextBits_cond:
   "sizeof_sched_context_t + refill_size_bytes < (2::nat) ^ (minSchedContextBits - 1)"
-  by (clarsimp simp: sizeof_sched_context_t_def refill_size_bytes_def minSchedContextBits_def)
+  by (clarsimp simp: sizeof_sched_context_t_def refill_size_bytes_def minSchedContextBits_def
+                     word_size_def)
 
 lemma scBits_inverse_us:
   notes sc_const_eq[simp]
@@ -1073,9 +1076,10 @@ lemma scBits_inverse_sc:
   apply (rule scBits_inverse_us)
   by (simp add: sc_const_eq)
 
-lemma minRefillLength_ARM: "minRefillLength = 12"
+lemma minRefillLength_ARM: "minRefillLength = 10"
   by (auto simp: minRefillLength_def minSchedContextBits_def refillAbsoluteMax'_def
-                 schedContextStructSize_def refillSizeBytes_def shiftL_nat)
+                 schedContextStructSize_def refillSizeBytes_def shiftL_nat wordSize_def
+                 wordBits_def')
 
 lemma minRefillLength_minSchedContextBits[simp]:
   "scBitsFromRefillLength' minRefillLength = minSchedContextBits"
@@ -1104,16 +1108,17 @@ lemma MIN_REFILLS_le_minRefillLength:
 
 lemmas scBits_simps = scBits_inverse_us refillAbsoluteMax_def sc_size_bounds_def sc_const_conc
 
-lemma scBits_at_least_6:
-  "6 \<le> scBitsFromRefillLength' us"
+lemma scBits_at_least_7:
+  "7 \<le> scBitsFromRefillLength' us"
 proof -
   note sc_const_eq[simp]
   have "ceil_log (sizeof_sched_context_t)
            \<le> ceil_log (us * refill_size_bytes + sizeof_sched_context_t)"
     apply (simp only: sc_const_eq(2)[symmetric, simplified schedContextStructSize_def, simplified])
     by (simp add: ceil_log_le_mono)
-  moreover have "ceil_log (sizeof_sched_context_t) = 6"
+  moreover have "ceil_log (sizeof_sched_context_t) = 7"
     apply (simp add: sc_const_eq(2)[symmetric, simplified schedContextStructSize_def, simplified] ceil_log_def)
+    apply (clarsimp simp: wordSize_def wordBits_def')
     by (fastforce intro!: discrete_log_eqI)
   ultimately show ?thesis
     by (clarsimp simp: scBitsFromRefillLength'_def max_num_refills_def)
@@ -1121,7 +1126,7 @@ qed
 
 lemma scBits_pos'[simp]:
   "0 < scBitsFromRefillLength' us"
-  using scBits_at_least_6
+  using scBits_at_least_7
   by (metis gr0I not_numeral_le_zero)
 
 lemma scBits_pos_power2:

--- a/proof/refine/RISCV64/TcbAcc_R.thy
+++ b/proof/refine/RISCV64/TcbAcc_R.thy
@@ -4565,18 +4565,6 @@ lemma tcbReleaseRemove_pred_tcb_at'[wp]:
 crunches tcbReleaseRemove
   for weak_sch_act_wf[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
 
-lemma ksReleaseQueue_runnable_thread_state:
-  "\<lbrakk>(s,s') \<in> state_relation; valid_release_q s; pspace_aligned s; pspace_distinct s\<rbrakk>
-   \<Longrightarrow>  \<forall>p. p \<in> set (ksReleaseQueue s') \<longrightarrow> obj_at' (runnable' \<circ> tcbState) p s'"
-  apply (frule state_relation_release_queue_relation)
-  apply (clarsimp simp: valid_release_q_def obj_at'_def release_queue_relation_def)
-  apply (drule_tac x=p in bspec, blast)
-  apply (clarsimp simp: vs_all_heap_simps)
-  apply (frule_tac t=p in st_tcb_at_coerce_concrete[rotated, where P=runnable], simp, simp)
-   apply (clarsimp simp: pred_tcb_at_def obj_at_def)
-  apply (clarsimp simp: pred_tcb_at'_def obj_at'_def sts_rel_runnable)
-  done
-
 lemma sts_st_tcb':
   "\<lbrace>if t = t' then K (P st) else st_tcb_at' P t\<rbrace>
   setThreadState st t'

--- a/spec/abstract/Structures_A.thy
+++ b/spec/abstract/Structures_A.thy
@@ -551,10 +551,11 @@ lemma MIN_BUDGET_le_MAX_PERIOD':
 
 definition "min_sched_context_bits = 8"
 
-(* RT : size of sched_context struct in C, excluding refills
-   numbers are from MCS C: (9 * sizeof(word_t)) + (3 * sizeof(ticks_t)) for aarch32 *)
+(* RT : size of sched_context struct in C (excluding refills)
+   numbers are from MCS C: (9 * sizeof(word_t)) + (3 * sizeof(ticks_t))
+   See GitHub issue 501. *)
 definition sizeof_sched_context_t :: nat where
-  "sizeof_sched_context_t = (9 * 4) + (3 * 8)"
+  "sizeof_sched_context_t = (9 * word_size) + (3 * 8)"
 
 (* (2 * sizeof(ticks_t)) *)
 definition "refill_size_bytes = 16"

--- a/spec/design/skel/KernelStateData_H.thy
+++ b/spec/design/skel/KernelStateData_H.thy
@@ -99,7 +99,7 @@ where
     return r
   od"
 
-#INCLUDE_HASKELL SEL4/Model/StateData.lhs decls_only ONLY capHasProperty sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2 ct_not_inQ_asrt sch_act_wf_asrt valid_idle'_asrt cur_tcb'_asrt sch_act_sane_asrt ct_not_ksQ_asrt ct_active'_asrt rct_imp_activatable'_asrt
-#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue ReaderM Kernel KernelR getsJust assert stateAssert funOfM condition whileLoop findM funArray newKernelState capHasProperty ifM whenM whileM andM orM sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2 ct_not_inQ_asrt sch_act_wf_asrt valid_idle'_asrt cur_tcb'_asrt sch_act_sane_asrt ct_not_ksQ_asrt ct_active'_asrt rct_imp_activatable'_asrt
+#INCLUDE_HASKELL SEL4/Model/StateData.lhs decls_only ONLY capHasProperty sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2 ct_not_inQ_asrt sch_act_wf_asrt valid_idle'_asrt cur_tcb'_asrt sch_act_sane_asrt ct_not_ksQ_asrt ct_active'_asrt rct_imp_activatable'_asrt release_q_runnable_asrt
+#INCLUDE_HASKELL SEL4/Model/StateData.lhs NOT doMachineOp KernelState ReadyQueue ReaderM Kernel KernelR getsJust assert stateAssert funOfM condition whileLoop findM funArray newKernelState capHasProperty ifM whenM whileM andM orM sym_refs_asrt valid_replies'_sc_asrt ready_qs_runnable tcs_cross_asrt1 tcs_cross_asrt2 ct_not_inQ_asrt sch_act_wf_asrt valid_idle'_asrt cur_tcb'_asrt sch_act_sane_asrt ct_not_ksQ_asrt ct_active'_asrt rct_imp_activatable'_asrt release_q_runnable_asrt
 
 end

--- a/spec/haskell/src/SEL4/Model/PSpace.lhs
+++ b/spec/haskell/src/SEL4/Model/PSpace.lhs
@@ -238,6 +238,8 @@ No type checks are performed when deleting objects; "deleteObjects" simply delet
 >             "Assert that `sym_refs (state_refs_of' s)` holds"
 >         stateAssert valid_idle'_asrt
 >             "Assert that `valid_idle' s` holds"
+>         stateAssert release_q_runnable_asrt
+>             "Assert that threads in the release queue are runnable'"
 >         unless (fromPPtr ptr .&. mask bits == 0) $
 >             alignError bits
 >         stateAssert (deletionIsSafe ptr bits)

--- a/spec/haskell/src/SEL4/Model/StateData.lhs
+++ b/spec/haskell/src/SEL4/Model/StateData.lhs
@@ -469,3 +469,9 @@ Used in callKernel.
 
 > rct_imp_activatable'_asrt :: KernelState -> Bool
 > rct_imp_activatable'_asrt _ = True
+
+For deleteObjects, we would like to be able to use the fact that threads in the
+release queue have runnable' thread state. We add an assertion that it does hold.
+
+> release_q_runnable_asrt :: KernelState -> Bool
+> release_q_runnable_asrt _ = True

--- a/spec/haskell/src/SEL4/Object/Structures.lhs
+++ b/spec/haskell/src/SEL4/Object/Structures.lhs
@@ -216,9 +216,9 @@ list of pointers to waiting threads;
 >     scRefillCount :: Int,
 >     scRefills :: [Refill]}
 
-> -- numbers from MCS C: (9 * sizeof(word_t)) + (3 * sizeof(ticks_t)) for aarch32
+> -- numbers from MCS C: (9 * sizeof(word_t)) + (3 * sizeof(ticks_t))
 > schedContextStructSize :: Int
-> schedContextStructSize = (9 * 4) + (3 * 8)
+> schedContextStructSize = (9 * wordSize) + (3 * 8)
 
 > -- similarly, (2 * sizeof(ticks_t))
 > refillSizeBytes :: Int


### PR DESCRIPTION
This sorries `Detype_C.thy`, adding one sorry related to `refill_buffer_relation`.

The size of the scheduling context structs is updated in the abstract spec and the Haskell.

An assert was added to `deleteObjects` to help resolves an assumption in the `delete_locale` locale.