### PR TITLE
Monadic_Rewrite overhaul

### DIFF
--- a/lib/Monad_WP/NonDetMonadVCG.thy
+++ b/lib/Monad_WP/NonDetMonadVCG.thy
@@ -207,6 +207,10 @@ lemma pred_conj_assoc:
   "(P and Q and R) = (P and (Q and R))"
   unfolding pred_conj_def by simp
 
+lemma pred_conj_comm:
+  "(P and Q) = (Q and P)"
+  by (auto simp: pred_conj_def)
+
 subsection "Hoare Logic Rules"
 
 lemma validE_def2:

--- a/lib/MonadicRewrite.thy
+++ b/lib/MonadicRewrite.thy
@@ -225,7 +225,7 @@ lemma monadic_rewrite_modify_noop:
 text \<open>Symbolic execution\<close>
 
 lemma monadic_rewrite_symb_exec_pre:
-  assumes inv: "\<And>s. g \<lbrace> (=) s\<rbrace>"
+  assumes inv: "\<And>P. g \<lbrace>P\<rbrace>"
        and ef: "empty_fail g"
        and rv: "\<lbrace>P\<rbrace> g \<lbrace>\<lambda>y s. y \<in> S\<rbrace>"
        and h': "\<And>rv. rv \<in> S \<longrightarrow> h rv = h'"
@@ -261,7 +261,7 @@ lemmas monadic_rewrite_symb_exec2
                                   simplified, THEN monadic_rewrite_trans]
 
 lemma monadic_rewrite_symb_exec_r:
-  "\<lbrakk> \<And>s. m \<lbrace>(=) s\<rbrace>; no_fail P' m;
+  "\<lbrakk> \<And>P. m \<lbrace>P\<rbrace>; no_fail P' m;
      \<And>rv. monadic_rewrite F False (Q rv) x (y rv);
      \<lbrace>P\<rbrace> m \<lbrace>Q\<rbrace> \<rbrakk>
    \<Longrightarrow> monadic_rewrite F False (P and P') x (m >>= (\<lambda>rv. y rv))"
@@ -276,7 +276,7 @@ lemma monadic_rewrite_symb_exec_r:
   done
 
 lemma monadic_rewrite_symb_exec_r':
-  "\<lbrakk> \<And>s. m \<lbrace>(=) s\<rbrace>; no_fail P m;
+  "\<lbrakk> \<And>P. m \<lbrace>P\<rbrace>; no_fail P m;
      \<And>rv. monadic_rewrite F False (Q rv) x (y rv);
      \<lbrace>P\<rbrace> m \<lbrace>Q\<rbrace> \<rbrakk>
    \<Longrightarrow> monadic_rewrite F False P x (m >>= (\<lambda>rv. y rv))"
@@ -286,7 +286,7 @@ lemma monadic_rewrite_symb_exec_r':
   done
 
 lemma monadic_rewrite_symb_exec_l'':
-  "\<lbrakk> \<And>s. m \<lbrace>(=) s\<rbrace>; empty_fail m;
+  "\<lbrakk> \<And>P. m \<lbrace>P\<rbrace>; empty_fail m;
      \<not> F \<longrightarrow> no_fail P' m;
      \<And>rv. monadic_rewrite F False (Q rv) (x rv) y;
      \<lbrace>P\<rbrace> m \<lbrace>Q\<rbrace> \<rbrakk>
@@ -338,7 +338,7 @@ lemmas monadic_rewrite_symb_exec_l
     monadic_rewrite_symb_exec_l''[where F=False, simplified simp_thms]
 
 lemma monadic_rewrite_symb_exec_l_known:
-  "\<lbrakk> \<And>s. m \<lbrace>(=) s\<rbrace>; empty_fail m;
+  "\<lbrakk> \<And>P. m \<lbrace>P\<rbrace>; empty_fail m;
      monadic_rewrite True False Q (x rv) y;
      \<lbrace>P\<rbrace> m \<lbrace>\<lambda>rv' s. rv' = rv \<and> Q s\<rbrace> \<rbrakk>
    \<Longrightarrow> monadic_rewrite True False P (m >>= x) y"
@@ -435,7 +435,7 @@ lemma monadic_rewrite_alternatives:
   by (auto simp: monadic_rewrite_def alternative_def)
 
 lemma monadic_rewrite_rdonly_bind:
-  "\<lbrakk> \<And>s. f \<lbrace>(=) s\<rbrace> \<rbrakk>
+  "\<lbrakk> \<And>P. f \<lbrace>P\<rbrace> \<rbrakk>
    \<Longrightarrow> monadic_rewrite F False \<top> (alternative (f >>= (\<lambda>x. g x)) h)
                                 (f >>= (\<lambda>x. alternative (g x) h))"
   apply (clarsimp simp: monadic_rewrite_def bind_def
@@ -444,6 +444,7 @@ lemma monadic_rewrite_rdonly_bind:
    apply (simp add: image_image split_def cong: image_cong)
    apply fastforce
   apply clarsimp
+  apply (drule hoare_eq_P)
   apply (frule use_valid, (assumption | rule refl | simp)+)
   done
 

--- a/proof/crefine/ARM/Fastpath_C.thy
+++ b/proof/crefine/ARM/Fastpath_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/crefine/ARM/Fastpath_C.thy
+++ b/proof/crefine/ARM/Fastpath_C.thy
@@ -656,15 +656,12 @@ lemma armv_contextSwitch_HWASID_fp_rewrite:
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_gets_l)
    apply (rule monadic_rewrite_symb_exec_l)
-      apply (wpsimp)+
-     apply (simp add: empty_fail_findPDForASID empty_fail_catch)
-    apply (rule monadic_rewrite_assert monadic_rewrite_gets_l)+
-    apply (rule_tac P="asidMap asid \<noteq> None \<and> fst (the (asidMap asid)) = the (pde_stored_asid v)"
-        in monadic_rewrite_gen_asm)
-    apply (simp only: case_option_If2 simp_thms if_True if_False
-                      split_def, simp)
-    apply (rule monadic_rewrite_refl)
-   apply (wp findPDForASID_pd_at_wp | simp only: const_def)+
+      apply (rule monadic_rewrite_assert monadic_rewrite_gets_l)+
+      apply (rule_tac P="asidMap asid \<noteq> None \<and> fst (the (asidMap asid)) = the (pde_stored_asid v)"
+               in monadic_rewrite_gen_asm)
+      apply (simp add: case_option_If2 split_def)
+      apply (rule monadic_rewrite_refl)
+     apply (wpsimp wp: findPDForASID_pd_at_wp simp: empty_fail_catch)+
   apply (clarsimp simp: pd_has_hwasid_def cte_level_bits_def
                         field_simps cte_wp_at_ctes_of
                         word_0_sle_from_less

--- a/proof/crefine/ARM/Fastpath_C.thy
+++ b/proof/crefine/ARM/Fastpath_C.thy
@@ -653,7 +653,7 @@ lemma armv_contextSwitch_HWASID_fp_rewrite:
                         checkPDAt_def checkPDUniqueToASID_def
                         checkPDASIDMapMembership_def
                         stateAssert_def2[folded assert_def])
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_gets_l)
    apply (rule monadic_rewrite_symb_exec_l)
       apply (wpsimp)+

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -479,7 +479,7 @@ lemma monadic_rewrite_threadGet:
    apply (rule monadic_rewrite_symb_exec_l' | wp | rule empty_fail_getObject getObject_inv)+
      apply (clarsimp; rule no_fail_getObject_tcb)
     apply (simp only: exec_gets)
-    apply (rule_tac P = "(\<lambda>s. (f x)=v) and tcb_at' t" in monadic_rewrite_pre_imp_refl)
+    apply (rule_tac P = "(\<lambda>s. (f x)=v) and tcb_at' t" in monadic_rewrite_pre_imp_eq)
     apply (simp add:)
    apply (wp OMG_getObject_tcb | wpc)+
   apply (auto intro: obj_tcb_at')
@@ -880,7 +880,7 @@ lemma receiveIPC_simple_rewrite:
         apply (rule hoare_pre, wpc, wp+, simp)
        apply (simp split: option.split)
       apply (rule monadic_rewrite_trans, rule monadic_rewrite_if_known[where X=False], simp)
-      apply (rule monadic_rewrite_pre_imp_refl[where P=\<top>])
+      apply (rule monadic_rewrite_pre_imp_eq[where P=\<top>])
       apply (cases ep, simp_all add: isSendEP_def)[1]
      apply (wp getNotification_wp gbn_wp' getEndpoint_wp | wpc)+
   apply (clarsimp simp: obj_at'_def projectKOs pred_tcb_at'_def)
@@ -1139,7 +1139,7 @@ lemma setEndpoint_setCTE_pivot[unfolded K_bind_def]:
                      | simp)+
       apply (rule_tac P="\<lambda>s. epat = ep_at' p s \<and> cteat = real_cte_at' slot s
                            \<and> tcbat = (tcb_at' (slot && ~~ mask 9) and (%y. slot && mask 9 : dom tcb_cte_cases)) s"
-                   in monadic_rewrite_pre_imp_refl)
+                   in monadic_rewrite_pre_imp_eq)
       apply (simp add: setEndpoint_def setObject_modify_assert bind_assoc
                        exec_gets assert_def exec_modify
                 split: if_split)

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -1,6 +1,6 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
- * Copyright 2020, Proofcraft Pty Ltd
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -318,21 +318,12 @@ lemma possibleSwitchTo_rewrite:
     (possibleSwitchTo t) (setSchedulerAction (SwitchToThread t))"
   supply if_split[split del]
   apply (simp add: possibleSwitchTo_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_symb_exec_l'[OF threadGet_inv empty_fail_threadGet,
-                                               where P'=\<top>], simp)
-      apply (rule monadic_rewrite_bind_tail)
-       apply (rule_tac P="targetDom = curDom" in monadic_rewrite_gen_asm)
-       apply simp
-       apply (rule_tac P="action = ResumeCurrentThread" in monadic_rewrite_gen_asm)
-       apply simp
-       apply (rule monadic_rewrite_refl)
-      apply (wp threadGet_wp cd_wp |simp add: bitmap_fun_defs)+
+  (* under current preconditions both branch conditions are false *)
+  apply (monadic_rewrite_l monadic_rewrite_if_l_False \<open>wpsimp wp: threadGet_wp cd_wp\<close>)
+   apply (monadic_rewrite_l monadic_rewrite_if_l_False \<open>wpsimp wp: threadGet_wp cd_wp\<close>)
+   (* discard unused getters before setSchedulerAction *)
    apply (simp add: getCurThread_def curDomain_def gets_bind_ign getSchedulerAction_def)
-   apply (rule monadic_rewrite_refl)
-  apply clarsimp
+   apply (monadic_rewrite_symb_exec_l_drop, rule monadic_rewrite_refl)
   apply (auto simp: obj_at'_def)
   done
 
@@ -401,6 +392,15 @@ lemma fastpathBestSwitchCandidate_ksSchedulerAction_simp[simp]:
   unfolding fastpathBestSwitchCandidate_def lookupBitmapPriority_def
   by simp
 
+lemma sched_act_SwitchToThread_rewrite:
+  "\<lbrakk> sa = SwitchToThread t \<Longrightarrow> monadic_rewrite F E Q (m_sw t) f \<rbrakk>
+   \<Longrightarrow> monadic_rewrite F E ((\<lambda>_. sa = SwitchToThread t) and Q)
+       (case_scheduler_action m_res m_ch (\<lambda>t. m_sw t) sa) f"
+  apply (cases sa; simp add: monadic_rewrite_impossible)
+  apply (rename_tac t')
+  apply (case_tac "t' = t"; simp add: monadic_rewrite_impossible)
+  done
+
 lemma schedule_rewrite_ct_not_runnable':
   "monadic_rewrite True True
             (\<lambda>s. ksSchedulerAction s = SwitchToThread t \<and> ct_in_state' (Not \<circ> runnable') s
@@ -410,42 +410,31 @@ lemma schedule_rewrite_ct_not_runnable':
             (do setSchedulerAction ResumeCurrentThread; switchToThread t od)"
   supply subst_all [simp del]
   apply (simp add: schedule_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_bind_tail)
-      apply (rule_tac P="action = SwitchToThread t" in monadic_rewrite_gen_asm, simp)
-      apply (rule monadic_rewrite_bind_tail)
-       apply (rule_tac P="\<not> wasRunnable \<and> action = SwitchToThread t"
-              in monadic_rewrite_gen_asm,simp)
-       apply (rule monadic_rewrite_bind_tail, rename_tac idleThread)
-        apply (rule monadic_rewrite_bind_tail, rename_tac targetPrio)
-         apply (rule monadic_rewrite_bind_tail, rename_tac curPrio)
-          apply (rule monadic_rewrite_bind_tail, rename_tac fastfail)
-           apply (rule monadic_rewrite_bind_tail, rename_tac curDom)
-            apply (rule monadic_rewrite_bind_tail, rename_tac highest)
-             apply (rule_tac P="\<not> (fastfail \<and> \<not> highest)" in monadic_rewrite_gen_asm, simp only:)
-             apply simp
-             apply (rule monadic_rewrite_refl)
-            apply (wpsimp wp: hoare_vcg_imp_lift)
-            apply (simp add: isHighestPrio_def')
-            apply wp+
-          apply (wp hoare_vcg_disj_lift)
-           apply (wp scheduleSwitchThreadFastfail_False_wp)
-          apply (wp hoare_vcg_disj_lift threadGet_wp'' | simp add: comp_def)+
-   (* remove no-ops, somewhat by magic *)
-   apply (rule monadic_rewrite_symb_exec_l'_TT, solves wp,
-          wpsimp wp: empty_fail_isRunnable simp: isHighestPrio_def')+
-            apply (simp add: setSchedulerAction_def)
-            apply (subst oblivious_modify_swap[symmetric], rule oblivious_switchToThread_schact)
-            apply (rule monadic_rewrite_refl)
-           apply wp+
-  apply (clarsimp simp: ct_in_state'_def)
-  apply (strengthen not_pred_tcb_at'_strengthen, simp)
+  (* switching to t *)
+  apply (monadic_rewrite_l sched_act_SwitchToThread_rewrite[where t=t])
+   (* not wasRunnable, skip enqueue *)
+   apply (simp add: when_def)
+   apply (monadic_rewrite_l monadic_rewrite_if_l_False)
+   (* fastpath: \<not> (fastfail \<and> \<not> highest) *)
+   apply (monadic_rewrite_l monadic_rewrite_if_l_False
+            \<open>wpsimp simp: isHighestPrio_def'
+                    wp: hoare_vcg_imp_lift hoare_vcg_disj_lift threadGet_wp''
+                        scheduleSwitchThreadFastfail_False_wp\<close>)
+   (* fastpath: no scheduleChooseNewThread *)
+   apply (monadic_rewrite_l monadic_rewrite_if_l_False
+            \<open>wpsimp simp: isHighestPrio_def'
+                    wp: hoare_vcg_imp_lift hoare_vcg_disj_lift threadGet_wp''
+                        scheduleSwitchThreadFastfail_False_wp\<close>)
+   (* remove no-ops *)
+   apply (repeat 10 monadic_rewrite_symb_exec_l) (* until switchToThread *)
+              apply (simp add: setSchedulerAction_def)
+              apply (subst oblivious_modify_swap[symmetric],
+                     rule oblivious_switchToThread_schact)
+              apply (rule monadic_rewrite_refl)
+             apply (wpsimp wp: empty_fail_isRunnable simp: isHighestPrio_def')+
+  apply (clarsimp simp: ct_in_state'_def not_pred_tcb_at'_strengthen
+                        fastpathBestSwitchCandidate_def)
   apply normalise_obj_at'
-  apply (simp add: fastpathBestSwitchCandidate_def)
-  apply (erule_tac x="tcbPriority ko" in allE)
-  apply (erule impE, normalise_obj_at'+)
   done
 
 lemma resolveAddressBits_points_somewhere:
@@ -471,18 +460,12 @@ lemmas cteInsert_obj_at'_not_queued =  cteInsert_obj_at'_queued[of "\<lambda>a. 
 lemma monadic_rewrite_threadGet:
   "monadic_rewrite E F (obj_at' (\<lambda>tcb. f tcb = v) t)
     (threadGet f t) (return v)"
-  unfolding getThreadState_def
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans[rotated])
-    apply (rule monadic_rewrite_gets_known)
-   apply (unfold threadGet_def liftM_def fun_app_def)
-   apply (rule monadic_rewrite_symb_exec_l' | wp | rule empty_fail_getObject getObject_inv)+
-     apply (clarsimp; rule no_fail_getObject_tcb)
-    apply (simp only: exec_gets)
-    apply (rule_tac P = "(\<lambda>s. (f x)=v) and tcb_at' t" in monadic_rewrite_pre_imp_eq)
-    apply (simp add:)
-   apply (wp OMG_getObject_tcb | wpc)+
-  apply (auto intro: obj_tcb_at')
+  unfolding getThreadState_def threadGet_def
+  apply (simp add: liftM_def)
+  apply monadic_rewrite_symb_exec_l
+    apply (rule_tac P="\<lambda>_. f x = v" in monadic_rewrite_pre_imp_eq)
+    apply blast
+   apply (wpsimp wp: OMG_getObject_tcb simp: obj_tcb_at')+
   done
 
 lemma monadic_rewrite_getThreadState:
@@ -521,15 +504,20 @@ lemma setThreadState_runnable_bitmap_inv:
     \<lbrace> \<lambda>s. Q (ksReadyQueuesL2Bitmap s) \<rbrace> setThreadState ts t \<lbrace>\<lambda>rv s. Q (ksReadyQueuesL2Bitmap s) \<rbrace>"
    by (simp_all add: setThreadState_runnable_simp, wp+)
 
+(* FIXME move *)
+crunches curDomain
+  for (no_fail) no_fail[intro!, wp, simp]
+
 lemma fastpath_callKernel_SysCall_corres:
   "monadic_rewrite True False
          (invs' and ct_in_state' ((=) Running)
                 and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
                 and (\<lambda>s. ksDomainTime s \<noteq> 0))
      (callKernel (SyscallEvent SysCall)) (fastpaths SysCall)"
-  supply if_split[split del] if_cong[cong]
-  apply (rule monadic_rewrite_introduce_alternative)
-   apply (simp add: callKernel_def)
+  supply if_cong[cong] option.case_cong[cong] if_split[split del]
+  supply empty_fail_getMRs[wp] (* FIXME *)
+  supply empty_fail_getEndpoint[wp] (* FIXME *)
+  apply (rule monadic_rewrite_introduce_alternative[OF callKernel_def[simplified atomize_eq]])
   apply (rule monadic_rewrite_guard_imp)
    apply (simp add: handleEvent_def handleCall_def
                     handleInvocation_def liftE_bindE_handle
@@ -539,19 +527,18 @@ lemma fastpath_callKernel_SysCall_corres:
                     getMessageInfo_def alternative_bind
                     fastpaths_def
               cong: if_cong)
-   apply (rule monadic_rewrite_rdonly_bind_l, wp)
+   apply (rule monadic_rewrite_bind_alternative_l, wp)
    apply (rule monadic_rewrite_bind_tail)
-    apply (rule monadic_rewrite_rdonly_bind_l, wp)
+    apply (rule monadic_rewrite_bind_alternative_l, wp)
     apply (rule monadic_rewrite_bind_tail)
      apply (rename_tac msgInfo)
-     apply (rule monadic_rewrite_rdonly_bind_l, wp)
+     apply (rule monadic_rewrite_bind_alternative_l, wp)
      apply (rule monadic_rewrite_bind_tail)
-      apply (rule monadic_rewrite_symb_exec_r
-                     [OF threadGet_inv no_fail_threadGet])
-       apply (rename_tac thread msgInfo ptr tcbFault)
-       apply (rule monadic_rewrite_alternative_rhs[rotated])
+      apply monadic_rewrite_symb_exec_r
+       apply (rename_tac tcbFault)
+       apply (rule monadic_rewrite_alternative_r[rotated])
         apply (rule monadic_rewrite_alternative_l)
-       apply (rule monadic_rewrite_if_rhs[rotated])
+       apply (rule monadic_rewrite_if_r[rotated])
         apply (rule monadic_rewrite_alternative_l)
        apply (simp add: split_def Syscall_H.syscall_def
                         liftE_bindE_handle bind_assoc
@@ -565,210 +552,204 @@ lemma fastpath_callKernel_SysCall_corres:
                         returnOk_liftE[symmetric] const_def
                         getSlotCap_def)
        apply (simp only: liftE_bindE_assoc)
-       apply (rule monadic_rewrite_rdonly_bind_l, wp)
+       apply (rule monadic_rewrite_bind_alternative_l, wp)
        apply (rule monadic_rewrite_bind_tail)
-        apply (rule monadic_rewrite_rdonly_bind_l)
+        apply (rule monadic_rewrite_bind_alternative_l)
          apply (wp | simp)+
         apply (rule_tac fn="case_sum Inl (Inr \<circ> fst)" in monadic_rewrite_split_fn)
           apply (simp add: liftME_liftM[symmetric] liftME_def bindE_assoc)
           apply (rule monadic_rewrite_refl)
-         apply (rule monadic_rewrite_if_rhs[rotated])
+         apply (rule monadic_rewrite_if_r[rotated])
           apply (rule monadic_rewrite_alternative_l)
          apply (simp add: isRight_right_map isRight_case_sum)
-         apply (rule monadic_rewrite_if_rhs[rotated])
+         apply (rule monadic_rewrite_if_r[rotated])
           apply (rule monadic_rewrite_alternative_l)
-         apply (rule monadic_rewrite_rdonly_bind_l[OF lookupIPC_inv])
-         apply (rule monadic_rewrite_symb_exec_l[OF lookupIPC_inv empty_fail_lookupIPCBuffer])
+         apply (rule monadic_rewrite_bind_alternative_l[OF lookupIPC_inv])
+         apply monadic_rewrite_symb_exec_l
           apply (simp add: lookupExtraCaps_null returnOk_bind liftE_bindE_handle
                            bind_assoc liftE_bindE_assoc
                            decodeInvocation_def Let_def from_bool_0
                            performInvocation_def liftE_handle
                            liftE_bind)
-          apply (rule monadic_rewrite_symb_exec_r [OF getEndpoint_inv no_fail_getEndpoint])
+          apply monadic_rewrite_symb_exec_r
            apply (rename_tac "send_ep")
-           apply (rule monadic_rewrite_if_rhs[rotated])
+           apply (rule monadic_rewrite_if_r[rotated])
             apply (rule monadic_rewrite_alternative_l)
            apply (simp add: getThreadVSpaceRoot_def locateSlot_conv)
-           apply (rule monadic_rewrite_symb_exec_r [OF getCTE_inv no_fail_getCTE])
+           apply monadic_rewrite_symb_exec_r
             apply (rename_tac "pdCapCTE")
-            apply (rule monadic_rewrite_if_rhs[rotated])
+            apply (rule monadic_rewrite_if_r[rotated])
              apply (rule monadic_rewrite_alternative_l)
-            apply (rule monadic_rewrite_symb_exec_r[OF curDomain_inv],
-                   simp only: curDomain_def, rule non_fail_gets)
-             apply (rename_tac "curDom")
-             apply (rule monadic_rewrite_symb_exec_r [OF threadGet_inv no_fail_threadGet])+
-               apply (rename_tac curPrio destPrio)
+            apply monadic_rewrite_symb_exec_r
+             apply monadic_rewrite_symb_exec_r
+              apply monadic_rewrite_symb_exec_r
                apply (simp add: isHighestPrio_def')
-               apply (rule monadic_rewrite_symb_exec_r [OF gets_inv non_fail_gets])
-                apply (rename_tac highest)
-                apply (rule monadic_rewrite_if_rhs[rotated])
+               apply monadic_rewrite_symb_exec_r
+                apply (rule monadic_rewrite_if_r[rotated])
                  apply (rule monadic_rewrite_alternative_l)
-                apply (rule monadic_rewrite_if_rhs[rotated])
+                apply (rule monadic_rewrite_if_r[rotated])
                  apply (rule monadic_rewrite_alternative_l)
-                apply (rule monadic_rewrite_symb_exec_r [OF gets_inv non_fail_gets])
-                 apply (rename_tac asidMap)
-                 apply (rule monadic_rewrite_if_rhs[rotated])
+                apply monadic_rewrite_symb_exec_r
+                 apply (rule monadic_rewrite_if_r[rotated])
                   apply (rule monadic_rewrite_alternative_l)
-
-                 apply (rule monadic_rewrite_symb_exec_r[OF threadGet_inv no_fail_threadGet])
-                  apply (rename_tac "destDom")
-                  apply (rule monadic_rewrite_if_rhs[rotated])
+                 apply monadic_rewrite_symb_exec_r
+                  apply (rule monadic_rewrite_if_r[rotated])
                    apply (rule monadic_rewrite_alternative_l)
                   apply (rule monadic_rewrite_trans,
                          rule monadic_rewrite_pick_alternative_1)
-                  apply (rule monadic_rewrite_symb_exec_l[OF get_mrs_inv' empty_fail_getMRs])
+                  apply monadic_rewrite_symb_exec_l
                    (* now committed to fastpath *)
                    apply (rule monadic_rewrite_trans)
                     apply (rule_tac F=True and E=True in monadic_rewrite_weaken_flags)
                     apply simp
                     apply (rule monadic_rewrite_bind_tail)
-                     apply (rule_tac x=thread in monadic_rewrite_symb_exec,
-                            (wp empty_fail_getCurThread)+)
+                     apply (monadic_rewrite_symb_exec_l_known thread)
                      apply (simp add: sendIPC_def bind_assoc)
-                     apply (rule_tac x=send_ep in monadic_rewrite_symb_exec,
-                            (wp empty_fail_getEndpoint getEndpoint_obj_at')+)
+                     apply (monadic_rewrite_symb_exec_l_known send_ep)
                      apply (rule_tac P="epQueue send_ep \<noteq> []" in monadic_rewrite_gen_asm)
                      apply (simp add: isRecvEP_endpoint_case list_case_helper bind_assoc)
                      apply (rule monadic_rewrite_bind_tail)
                       apply (elim conjE)
                       apply (rule monadic_rewrite_bind_tail, rename_tac dest_st)
-                      apply (rule_tac P="\<exists>gr. dest_st = BlockedOnReceive (capEPPtr (fst (theRight rv))) gr"
-                               in monadic_rewrite_gen_asm)
-                      apply (rule monadic_rewrite_symb_exec_drop, (wp | simp)+)
-                      apply (rule monadic_rewrite_bind)
-                        apply clarsimp
-                        apply (rule_tac msgInfo=msgInfo in doIPCTransfer_simple_rewrite)
-                       apply (rule monadic_rewrite_bind_tail)
-                        apply (rule monadic_rewrite_bind)
-                          apply (rule_tac destPrio=destPrio
-                                   and curDom=curDom and destDom=destDom and thread=thread
-                                   in possibleSwitchTo_rewrite)
+                       apply (rule_tac P="\<exists>gr. dest_st = BlockedOnReceive (capEPPtr (fst (theRight rv))) gr"
+                                in monadic_rewrite_gen_asm)
+                       apply monadic_rewrite_symb_exec_l_drop
+                       apply (rule monadic_rewrite_bind)
+                         apply clarsimp
+                         apply (rule_tac msgInfo=msgInfo in doIPCTransfer_simple_rewrite)
+                        apply (rule monadic_rewrite_bind_tail)
                          apply (rule monadic_rewrite_bind)
+                           apply (rule_tac destPrio=destPrio
+                                    and curDom=curDom and destDom=destDom and thread=thread
+                                    in possibleSwitchTo_rewrite)
+                          apply (rule monadic_rewrite_bind)
+                            apply (rule monadic_rewrite_trans)
+                             apply (rule setupCallerCap_rewrite)
+                            apply (rule monadic_rewrite_bind_head)
+                            apply (rule setThreadState_rewrite_simple, simp)
                            apply (rule monadic_rewrite_trans)
-                            apply (rule setupCallerCap_rewrite)
-                           apply (rule monadic_rewrite_bind_head)
-                           apply (rule setThreadState_rewrite_simple, simp)
-                          apply (rule monadic_rewrite_trans)
-                           apply (rule_tac x=BlockedOnReply in monadic_rewrite_symb_exec,
-                                  (wp empty_fail_getThreadState)+)
-                           apply simp
-                           apply (rule monadic_rewrite_refl)
-                          apply (rule monadic_rewrite_trans)
-                           apply (rule monadic_rewrite_bind_head)
-                           apply (rule_tac t="hd (epQueue send_ep)"
-                                    in schedule_rewrite_ct_not_runnable')
-                          apply (simp add: bind_assoc)
-                          apply (rule monadic_rewrite_bind_tail)
-                           apply (rule monadic_rewrite_bind)
-                             apply (rule switchToThread_rewrite)
+                            apply (monadic_rewrite_symb_exec_l_known BlockedOnReply)
+                            apply simp
+                            apply (rule monadic_rewrite_refl)
+                            apply wpsimp (* FIXME indentation *)
+                           apply (rule monadic_rewrite_trans)
+                            apply (rule monadic_rewrite_bind_head)
+                            apply (rule_tac t="hd (epQueue send_ep)"
+                                     in schedule_rewrite_ct_not_runnable')
+                           apply (simp add: bind_assoc)
+                           apply (rule monadic_rewrite_bind_tail)
                             apply (rule monadic_rewrite_bind)
-                              apply (rule activateThread_simple_rewrite)
-                             apply (rule monadic_rewrite_refl)
-                            apply wp
-                           apply (wp setCurThread_ct_in_state)
-                          apply (simp only: st_tcb_at'_def[symmetric])
-                          apply (wp, clarsimp simp: cur_tcb'_def ct_in_state'_def)
-                         apply (simp add: getThreadCallerSlot_def getThreadReplySlot_def
-                                          locateSlot_conv ct_in_state'_def cur_tcb'_def)
+                              apply (rule switchToThread_rewrite)
+                             apply (rule monadic_rewrite_bind)
+                               apply (rule activateThread_simple_rewrite)
+                              apply (rule monadic_rewrite_refl)
+                             apply wp
+                            apply (wp setCurThread_ct_in_state)
+                           apply (simp only: st_tcb_at'_def[symmetric])
+                           apply (wp, clarsimp simp: cur_tcb'_def ct_in_state'_def)
+                          apply (simp add: getThreadCallerSlot_def getThreadReplySlot_def
+                                           locateSlot_conv ct_in_state'_def cur_tcb'_def)
 
-                         apply ((wp assert_inv threadSet_pred_tcb_at_state
-                                    cteInsert_obj_at'_not_queued
-                                 | wps)+)[1]
+                          apply ((wp assert_inv threadSet_pred_tcb_at_state
+                                     cteInsert_obj_at'_not_queued
+                                  | wps)+)[1]
 
-                            apply (wp fastpathBestSwitchCandidate_lift[where f="cteInsert c w w'" for c w w'])
+                             apply (wp fastpathBestSwitchCandidate_lift[where f="cteInsert c w w'" for c w w'])
+                             apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
                             apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
                            apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
                           apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
-                         apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
-                         apply (wp fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t])
-                          apply simp
-                         apply ((wp assert_inv threadSet_pred_tcb_at_state
-                                    cteInsert_obj_at'_not_queued
-                                 | wps)+)[1]
-                        apply (simp add: setSchedulerAction_def)
-                        apply wp[1]
-                       apply (simp cong: if_cong HOL.conj_cong add: if_bool_simps)
-                       apply (simp_all only:)[5]
-                       apply ((wp setThreadState_oa_queued[of _ "\<lambda>a _ _. \<not> a"]
-                                  setThreadState_obj_at_unchanged
-                                  asUser_obj_at_unchanged mapM_x_wp'
-                                  sts_st_tcb_at'_cases
-                                  setThreadState_no_sch_change
-                                  setEndpoint_obj_at_tcb'
-                                  fastpathBestSwitchCandidate_lift[where f="setThreadState f t" for f t]
-                                  setThreadState_oa_queued
-                                  fastpathBestSwitchCandidate_lift[where f="asUser t f" for f t]
-                                  fastpathBestSwitchCandidate_lift[where f="setEndpoint a b" for a b]
-                                  lookupBitmapPriority_lift
-                                  setThreadState_runnable_bitmap_inv
-                                | simp add: setMessageInfo_def
-                                | wp (once) hoare_vcg_disj_lift)+)
+                          apply (wp fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t])
+                           apply simp
+                          apply ((wp assert_inv threadSet_pred_tcb_at_state
+                                     cteInsert_obj_at'_not_queued
+                                  | wps)+)[1]
+                         apply (simp add: setSchedulerAction_def)
+                         apply wp[1]
+                        apply (simp cong: if_cong HOL.conj_cong add: if_bool_simps)
+                        apply (simp_all only:)[5]
+                        apply ((wp setThreadState_oa_queued[of _ "\<lambda>a _ _. \<not> a"]
+                                   setThreadState_obj_at_unchanged
+                                   asUser_obj_at_unchanged mapM_x_wp'
+                                   sts_st_tcb_at'_cases
+                                   setThreadState_no_sch_change
+                                   setEndpoint_obj_at_tcb'
+                                   fastpathBestSwitchCandidate_lift[where f="setThreadState f t" for f t]
+                                   setThreadState_oa_queued
+                                   fastpathBestSwitchCandidate_lift[where f="asUser t f" for f t]
+                                   fastpathBestSwitchCandidate_lift[where f="setEndpoint a b" for a b]
+                                   lookupBitmapPriority_lift
+                                   setThreadState_runnable_bitmap_inv
+                                   getEndpoint_obj_at'
+                                 | simp add: setMessageInfo_def
+                                 | wp (once) hoare_vcg_disj_lift)+)
 
                    apply (simp add: setThreadState_runnable_simp
                                     getThreadCallerSlot_def getThreadReplySlot_def
                                     locateSlot_conv bind_assoc)
-                  apply (rule_tac P="\<lambda>v.  obj_at' (%tcb. tcbIPCBuffer tcb = v) (hd (epQueue send_ep))"
-                          in monadic_rewrite_exists_v)
-                  apply (rename_tac ipcBuffer)
-                  apply (rule_tac P="\<lambda>v.  obj_at' (\<lambda>tcb. tcbState tcb = v) (hd (epQueue send_ep))"
-                          in monadic_rewrite_exists_v)
-                  apply (rename_tac destState)
+                   apply (rule_tac P="\<lambda>v.  obj_at' (%tcb. tcbIPCBuffer tcb = v) (hd (epQueue send_ep))"
+                           in monadic_rewrite_exists_v)
+                   apply (rename_tac ipcBuffer)
 
-                 apply (simp add: switchToThread_def bind_assoc)
+                   apply (rule_tac P="\<lambda>v.  obj_at' (\<lambda>tcb. tcbState tcb = v) (hd (epQueue send_ep))"
+                           in monadic_rewrite_exists_v)
+                   apply (rename_tac destState)
+
+                   apply (simp add: ARM_H.switchToThread_def bind_assoc)
                  (* retrieving state or thread registers is not thread_action_isolatable,
                      translate into return with suitable precondition  *)
-                 apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
-                   apply (rule_tac v=destState in monadic_rewrite_getThreadState
-                          | rule monadic_rewrite_bind monadic_rewrite_refl)+
-                                 apply (wp mapM_x_wp' getObject_inv | wpc | simp | wp (once) hoare_drop_imps)+
-                  apply (rule_tac v=destState in monadic_rewrite_getThreadState
-                          | rule monadic_rewrite_bind monadic_rewrite_refl)+
-                            apply (wp mapM_x_wp' getObject_inv | wpc | simp | wp (once) hoare_drop_imps)+
+                   apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
+                     apply (rule_tac v=destState in monadic_rewrite_getThreadState
+                            | rule monadic_rewrite_bind monadic_rewrite_refl)+
+                                     apply (wp mapM_x_wp' getObject_inv | wpc | simp | wp (once) hoare_drop_imps)+
+                    apply (rule_tac v=destState in monadic_rewrite_getThreadState
+                           | rule monadic_rewrite_bind monadic_rewrite_refl)+
+                                apply (wp mapM_x_wp' getObject_inv | wpc | simp | wp (once) hoare_drop_imps)+
 
-                  apply (rule_tac P="inj (case_bool thread (hd (epQueue send_ep)))"
-                                 in monadic_rewrite_gen_asm)
-                  apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
-                    apply (rule monadic_rewrite_weaken_flags[where F=False and E=True], simp)
-                    apply (rule isolate_thread_actions_rewrite_bind
-                                  fastpath_isolate_rewrites fastpath_isolatables
-                                  bool.simps setRegister_simple
-                                  setVMRoot_isolatable[THEN thread_actions_isolatableD] setVMRoot_isolatable
-                                  doMachineOp_isolatable[THEN thread_actions_isolatableD] doMachineOp_isolatable
-                                  kernelExitAssertions_isolatable[THEN thread_actions_isolatableD]
-                                  kernelExitAssertions_isolatable
-                                  zipWithM_setRegister_simple
-                                  thread_actions_isolatable_bind
+                   apply (rule_tac P="inj (case_bool thread (hd (epQueue send_ep)))"
+                            in monadic_rewrite_gen_asm)
+                   apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
+                     apply (rule monadic_rewrite_weaken_flags[where F=False and E=True], simp)
+                     apply (rule isolate_thread_actions_rewrite_bind
+                                 fastpath_isolate_rewrites fastpath_isolatables
+                                 bool.simps setRegister_simple
+                                 setVMRoot_isolatable[THEN thread_actions_isolatableD] setVMRoot_isolatable
+                                 doMachineOp_isolatable[THEN thread_actions_isolatableD] doMachineOp_isolatable
+                                 kernelExitAssertions_isolatable[THEN thread_actions_isolatableD]
+                                 kernelExitAssertions_isolatable
+                                 zipWithM_setRegister_simple
+                                 thread_actions_isolatable_bind
                               | assumption
                               | wp assert_inv)+
-                  apply (rule_tac P="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
-                                      \<and> tcb_at' thread s"
-                             and F=True and E=False in monadic_rewrite_weaken_flags)
-                  apply simp
-                  apply (rule monadic_rewrite_isolate_final)
-                    apply (simp add: isRight_case_sum cong: list.case_cong)
-                   apply (clarsimp simp: fun_eq_iff if_flip
-                                  cong: if_cong)
-                   apply (drule obj_at_ko_at', clarsimp)
-                   apply (frule get_tcb_state_regs_ko_at')
-                   apply (clarsimp simp: zip_map2 zip_same_conv_map foldl_map
-                                        foldl_fun_upd
-                                        foldr_copy_register_tsrs
-                                        isRight_case_sum
-                                  cong: if_cong)
-                   apply (simp add: upto_enum_def fromEnum_def
-                                   enum_register  toEnum_def
-                                   msgRegisters_unfold
-                              cong: if_cong)
-                   apply (clarsimp split: if_split)
-                   apply (rule ext)
-                   apply (simp add: badgeRegister_def msgInfoRegister_def
-                                   ARM.badgeRegister_def
-                                   ARM.msgInfoRegister_def
-                            split: if_split)
-                  apply simp
-                 apply (wp | simp cong: if_cong bool.case_cong
-                           | rule getCTE_wp' gts_wp' threadGet_wp
-                                 getEndpoint_wp)+
+                   apply (rule_tac P="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+                                       \<and> tcb_at' thread s"
+                              and F=True and E=False in monadic_rewrite_weaken_flags)
+                   apply simp
+                   apply (rule monadic_rewrite_isolate_final)
+                     apply (simp add: isRight_case_sum cong: list.case_cong)
+                    apply (clarsimp simp: fun_eq_iff if_flip
+                                   cong: if_cong)
+                    apply (drule obj_at_ko_at', clarsimp)
+                    apply (frule get_tcb_state_regs_ko_at')
+                    apply (clarsimp simp: zip_map2 zip_same_conv_map foldl_map
+                                         foldl_fun_upd
+                                         foldr_copy_register_tsrs
+                                         isRight_case_sum
+                                   cong: if_cong)
+                    apply (simp add: upto_enum_def fromEnum_def
+                                    enum_register  toEnum_def
+                                    msgRegisters_unfold
+                               cong: if_cong)
+                    apply (clarsimp split: if_split)
+                    apply (rule ext)
+                    apply (simp add: badgeRegister_def msgInfoRegister_def
+                                    ARM.badgeRegister_def
+                                    ARM.msgInfoRegister_def
+                             split: if_split)
+                   apply simp
+                  apply (wp | simp cong: if_cong bool.case_cong
+                            | rule getCTE_wp' gts_wp' threadGet_wp
+                                  getEndpoint_wp)+
         apply (rule validE_cases_valid)
         apply (simp add: isRight_def getSlotCap_def)
         apply (wp getCTE_wp')
@@ -816,9 +797,9 @@ lemma fastpath_callKernel_SysCall_corres:
    apply (rule_tac ttcb=tcbb and ctcb=tcb in fastpathBestSwitchCandidateI)
      apply (solves \<open>simp only: disj_ac\<close>)
     apply simp+
-  apply (clarsimp simp: st_tcb_at'_def obj_at'_def objBits_simps projectKOs
-      valid_mdb'_def valid_mdb_ctes_def inj_case_bool
-      split: bool.split)+
+  apply (clarsimp simp: st_tcb_at'_def obj_at'_def objBits_simps projectKOs valid_mdb'_def
+                        valid_mdb_ctes_def inj_case_bool
+                 split: bool.split)+
   done
 
 lemma capability_case_Null_ReplyCap:
@@ -854,11 +835,9 @@ lemma doReplyTransfer_simple:
          od)"
   apply (simp add: doReplyTransfer_def liftM_def nullPointer_def getSlotCap_def)
   apply (rule monadic_rewrite_bind_tail)+
-        apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_threadGet)+)
-         apply (rule_tac P="rv = None" in monadic_rewrite_gen_asm, simp)
-         apply (rule monadic_rewrite_refl)
-        apply (wp threadGet_const gts_wp' getCTE_wp')+
-  apply (simp add: o_def)
+        apply (monadic_rewrite_symb_exec_l_known None, simp)
+           apply (rule monadic_rewrite_refl)
+          apply (wpsimp wp: threadGet_const gts_wp' getCTE_wp' simp: o_def)+
   done
 
 lemma receiveIPC_simple_rewrite:
@@ -870,19 +849,16 @@ lemma receiveIPC_simple_rewrite:
        setThreadState (BlockedOnReceive (capEPPtr ep_cap) (capEPCanGrant ep_cap)) thread;
        setEndpoint (capEPPtr ep_cap) (RecvEP (case ep of RecvEP q \<Rightarrow> (q @ [thread]) | _ \<Rightarrow> [thread]))
       od)"
+  supply empty_fail_getEndpoint[wp]
   apply (rule monadic_rewrite_gen_asm)
   apply (simp add: receiveIPC_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule_tac rv=ep in monadic_rewrite_symb_exec_l_known,
-          (wp empty_fail_getEndpoint)+)
-    apply (rule monadic_rewrite_symb_exec_l, (wp | simp add: getBoundNotification_def)+)
-     apply (rule monadic_rewrite_symb_exec_l)
-        apply (rule hoare_pre, wpc, wp+, simp)
-       apply (simp split: option.split)
-      apply (rule monadic_rewrite_trans, rule monadic_rewrite_if_known[where X=False], simp)
-      apply (rule monadic_rewrite_pre_imp_eq[where P=\<top>])
-      apply (cases ep, simp_all add: isSendEP_def)[1]
-     apply (wp getNotification_wp gbn_wp' getEndpoint_wp | wpc)+
+   apply (monadic_rewrite_symb_exec_l_known ep)
+      apply monadic_rewrite_symb_exec_l+
+            apply (monadic_rewrite_l monadic_rewrite_if_l_False)
+            apply (rule monadic_rewrite_is_refl)
+            apply (cases ep; simp add: isSendEP_def)
+           apply (wpsimp wp: getNotification_wp gbn_wp' getEndpoint_wp
+                         simp: getBoundNotification_def)+
   apply (clarsimp simp: obj_at'_def projectKOs pred_tcb_at'_def)
   done
 
@@ -895,19 +871,17 @@ lemma cteDeleteOne_replycap_rewrite:
      (cte_wp_at' (\<lambda>cte. isReplyCap (cteCap cte)) slot)
      (cteDeleteOne slot)
      (emptySlot slot NullCap)"
+  supply isFinalCapability_inv[wp] empty_fail_isFinalCapability[wp] (* FIXME *)
   apply (simp add: cteDeleteOne_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_getCTE)+)
-    apply (rule_tac P="cteCap rv \<noteq> NullCap \<and> isReplyCap (cteCap rv)
-                          \<and> \<not> isEndpointCap (cteCap rv)
-                          \<and> \<not> isNotificationCap (cteCap rv)"
-             in monadic_rewrite_gen_asm)
-    apply (simp add: finaliseCapTrue_standin_def
-                     capRemovable_def)
-    apply (rule monadic_rewrite_symb_exec_l,
-           (wp isFinalCapability_inv empty_fail_isFinalCapability)+)
-     apply (rule monadic_rewrite_refl)
-    apply (wp getCTE_wp')+
+  apply (rule monadic_rewrite_symb_exec_l)
+     apply (rule_tac P="cteCap cte \<noteq> NullCap \<and> isReplyCap (cteCap cte)
+                        \<and> \<not> isEndpointCap (cteCap cte)
+                        \<and> \<not> isNotificationCap (cteCap cte)"
+              in monadic_rewrite_gen_asm)
+     apply (simp add: finaliseCapTrue_standin_def capRemovable_def)
+     apply monadic_rewrite_symb_exec_l
+      apply (rule monadic_rewrite_refl)
+     apply (wpsimp wp: getCTE_wp')+
   apply (clarsimp simp: cte_wp_at_ctes_of isCap_simps)
   done
 
@@ -916,14 +890,10 @@ lemma cteDeleteOne_nullcap_rewrite:
      (cte_wp_at' (\<lambda>cte. cteCap cte = NullCap) slot)
      (cteDeleteOne slot)
      (return ())"
-  apply (simp add: cteDeleteOne_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_getCTE)+)
-    apply (rule_tac P="cteCap rv = NullCap" in monadic_rewrite_gen_asm)
-    apply simp
-    apply (rule monadic_rewrite_refl)
-   apply (wp getCTE_wp')
-  apply (clarsimp simp: cte_wp_at_ctes_of)
+  apply (simp add: cteDeleteOne_def unless_def when_def)
+  apply (monadic_rewrite_l monadic_rewrite_if_l_False \<open>wpsimp wp: getCTE_wp'\<close>)
+   apply (monadic_rewrite_symb_exec_l, rule monadic_rewrite_refl)
+     apply (wpsimp wp: getCTE_wp' simp: cte_wp_at_ctes_of)+
   done
 
 lemma deleteCallerCap_nullcap_rewrite:
@@ -933,12 +903,9 @@ lemma deleteCallerCap_nullcap_rewrite:
      (return ())"
   apply (simp add: deleteCallerCap_def getThreadCallerSlot_def locateSlot_conv
                    getSlotCap_def)
-  apply (rule monadic_rewrite_guard_imp)
-  apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_getCTE)+)
-    apply (rule monadic_rewrite_assert)
-    apply (rule cteDeleteOne_nullcap_rewrite)
-   apply (wp getCTE_wp)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
+  apply (monadic_rewrite_l cteDeleteOne_nullcap_rewrite \<open>wpsimp wp: getCTE_wp\<close>)
+   apply (monadic_rewrite_symb_exec_l+, rule monadic_rewrite_refl)
+    apply (wpsimp simp: cte_wp_at_ctes_of)+
   done
 
 lemma emptySlot_cnode_caps:
@@ -989,20 +956,13 @@ crunch tcbContext[wp]: possibleSwitchTo "obj_at' (\<lambda>tcb. P ( (atcbContext
 crunch only_cnode_caps[wp]: doFaultTransfer "\<lambda>s. P (only_cnode_caps (ctes_of s))"
   (wp: crunch_wps simp: crunch_simps)
 
-lemma tcbSchedDequeue_rewrite_not_queued: "monadic_rewrite True False (tcb_at' t and obj_at' (Not \<circ> tcbQueued) t) (tcbSchedDequeue t) (return ())"
-  apply (simp add: tcbSchedDequeue_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule_tac P="\<not> queued" in monadic_rewrite_gen_asm)
-     apply (simp add: when_def)
-     apply (rule monadic_rewrite_refl)
-    apply (wp threadGet_const)
-
-   apply (rule monadic_rewrite_symb_exec_l)
-      apply wp+
-    apply (rule monadic_rewrite_refl)
-   apply (wp)
+lemma tcbSchedDequeue_rewrite_not_queued:
+  "monadic_rewrite True False (tcb_at' t and obj_at' (Not \<circ> tcbQueued) t)
+     (tcbSchedDequeue t) (return ())"
+  apply (simp add: tcbSchedDequeue_def when_def)
+  apply (monadic_rewrite_l monadic_rewrite_if_l_False \<open>wp threadGet_const\<close>)
+   apply (monadic_rewrite_symb_exec_l, rule monadic_rewrite_refl)
+     apply wp+
   apply (clarsimp simp: o_def obj_at'_def)
   done
 
@@ -1022,60 +982,31 @@ lemma schedule_known_rewrite:
   supply subst_all[simp del] if_split[split del]
   apply (simp add: schedule_def)
   apply (simp only: Thread_H.switchToThread_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_bind_tail)
-      apply (rule_tac P="action = SwitchToThread t" in monadic_rewrite_gen_asm, simp)
-      apply (rule monadic_rewrite_bind_tail)
-       apply (rule_tac P="\<not> wasRunnable \<and> action = SwitchToThread t" in monadic_rewrite_gen_asm,simp)
-       apply (rule monadic_rewrite_bind_tail, rename_tac idleThread)
-        apply (rule monadic_rewrite_bind_tail, rename_tac targetPrio)
-        apply (rule monadic_rewrite_bind_tail, rename_tac curPrio)
-         apply (rule monadic_rewrite_bind_tail, rename_tac fastfail)
-          apply (rule monadic_rewrite_bind_tail, rename_tac curDom)
-           apply (rule monadic_rewrite_bind_tail, rename_tac highest)
-            apply (rule_tac P="\<not> (fastfail \<and> \<not> highest)" in monadic_rewrite_gen_asm, simp only:)
-            apply simp
-            apply (simp add: bind_assoc)
-            apply (rule monadic_rewrite_bind_tail)
-             apply (rule monadic_rewrite_bind)
-               apply (rule monadic_rewrite_trans)
-                apply (rule tcbSchedDequeue_rewrite_not_queued)
-               apply (rule monadic_rewrite_refl)
-              apply (rule monadic_rewrite_bind_tail)
-               apply (rule monadic_rewrite_refl)
-              apply (wpsimp wp: Arch_switchToThread_obj_at_pre)+
-           apply (wp hoare_vcg_imp_lift)+
-            apply (simp add: isHighestPrio_def')
-            apply wp+
-         apply (wp hoare_vcg_disj_lift)
-           apply (wp scheduleSwitchThreadFastfail_False_wp)
-          apply wp+
-        apply (wp hoare_vcg_disj_lift threadGet_wp'')
-        apply (wp hoare_vcg_disj_lift threadGet_wp'')
-       apply clarsimp
-       apply wp
-      apply (simp add: comp_def)
-      apply wp
-     apply wp
-    apply wp
-   (* remove no-ops, somewhat by magic *)
-   apply (rule monadic_rewrite_symb_exec_l'_TT, solves wp,
-      wpsimp wp: empty_fail_isRunnable simp: isHighestPrio_def')+
-           apply (rule monadic_rewrite_trans)
-            apply (rule monadic_rewrite_bind_tail)
-             apply (rule monadic_rewrite_symb_exec_l)
-                apply simp+
-              apply (rule monadic_rewrite_refl)
-             apply wp+
-           apply (rule monadic_rewrite_refl)
-          apply wp+
-  apply (clarsimp simp: ct_in_state'_def)
-  apply (rule conjI)
-   apply (rule not_pred_tcb_at'_strengthen, assumption)
-  apply normalise_obj_at'
-  apply (simp add: fastpathBestSwitchCandidate_def)
+  (* switching to t *)
+  apply (monadic_rewrite_l sched_act_SwitchToThread_rewrite[where t=t])
+   (* not wasRunnable, skip enqueue *)
+   apply (simp add: when_def)
+   apply (monadic_rewrite_l monadic_rewrite_if_l_False)
+   (* fastpath: \<not> (fastfail \<and> \<not> highest) *)
+   apply (monadic_rewrite_l monadic_rewrite_if_l_False
+            \<open>wpsimp simp: isHighestPrio_def'
+                    wp: hoare_vcg_imp_lift hoare_vcg_disj_lift threadGet_wp''
+                        scheduleSwitchThreadFastfail_False_wp\<close>)
+   (* fastpath: no scheduleChooseNewThread *)
+   apply (monadic_rewrite_l monadic_rewrite_if_l_False
+            \<open>wpsimp simp: isHighestPrio_def'
+                    wp: hoare_vcg_imp_lift hoare_vcg_disj_lift threadGet_wp''
+                        scheduleSwitchThreadFastfail_False_wp\<close>)
+   apply (simp add: bind_assoc)
+   apply (monadic_rewrite_l tcbSchedDequeue_rewrite_not_queued
+                            \<open>wpsimp wp: Arch_switchToThread_obj_at_pre\<close>)
+   (* remove no-ops *)
+   apply simp
+   apply (repeat 9 \<open>rule monadic_rewrite_symb_exec_l\<close>) (* until switchToThread *)
+                              apply (rule monadic_rewrite_refl)
+                             apply (wpsimp simp: isHighestPrio_def')+
+  apply (clarsimp simp: ct_in_state'_def not_pred_tcb_at'_strengthen
+                        fastpathBestSwitchCandidate_def)
   apply normalise_obj_at'
   done
 
@@ -1209,17 +1140,12 @@ lemma emptySlot_setEndpoint_pivot[unfolded K_bind_def]:
 lemma set_getCTE[unfolded K_bind_def]:
   "do setCTE p cte; v <- getCTE p; f v od
       = do setCTE p cte; f cte od"
-  apply simp
+  apply (simp add: getCTE_assert_opt bind_assoc)
   apply (rule monadic_rewrite_to_eq)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_bind_tail)
-    apply (simp add: getCTE_assert_opt bind_assoc)
-    apply (rule monadic_rewrite_trans,
-           rule_tac rv="Some cte" in monadic_rewrite_gets_known)
-    apply (simp add: assert_opt_def)
-    apply (rule monadic_rewrite_refl)
-   apply wp
-  apply simp
+  apply (rule monadic_rewrite_bind_tail)
+   apply (monadic_rewrite_symb_exec_l)
+    apply (monadic_rewrite_symb_exec_l_known cte, rule monadic_rewrite_refl)
+    apply (wpsimp simp: assert_opt_def wp: gets_wp)+
   done
 
 lemma set_setCTE[unfolded K_bind_def]:
@@ -1286,13 +1212,9 @@ lemma clearUntypedFreeIndex_simple_rewrite:
   apply (simp add: clearUntypedFreeIndex_def getSlotCap_def)
   apply (rule monadic_rewrite_name_pre)
   apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule_tac rv=cte in monadic_rewrite_symb_exec_l_known, wp+)
-    apply (simp split: capability.split,
-      strengthen monadic_rewrite_refl, simp)
-    apply clarsimp
-   apply (wp getCTE_wp')
-  apply (clarsimp simp: cte_wp_at_ctes_of)
+  apply (monadic_rewrite_symb_exec_l_known cte)
+    apply (simp split: capability.split, strengthen monadic_rewrite_refl)
+    apply (wpsimp wp: getCTE_wp' simp: cte_wp_at_ctes_of)+
   done
 
 lemma emptySlot_replymaster_rewrite[OF refl]:
@@ -1314,24 +1236,21 @@ lemma emptySlot_replymaster_rewrite[OF refl]:
   supply if_split[split del]
   apply (rule monadic_rewrite_gen_asm)+
   apply (rule monadic_rewrite_guard_imp)
-   apply (rule_tac P="slot \<noteq> 0" in monadic_rewrite_gen_asm)
+    apply (rule_tac P="slot \<noteq> 0" in monadic_rewrite_gen_asm)
    apply (clarsimp simp: emptySlot_def setCTE_updateCapMDB)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_head)
-    apply (rule clearUntypedFreeIndex_simple_rewrite)
-   apply simp
-   apply (rule_tac rv=cte in monadic_rewrite_symb_exec_l_known, (wp empty_fail_getCTE)+)
-    apply (simp add: updateMDB_def Let_def bind_assoc makeObject_cte case_Null_If)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_bind)
-       apply (rule_tac P="mdbFirstBadged (cteMDBNode ctea) \<and> mdbRevocable (cteMDBNode ctea)"
-                   in monadic_rewrite_gen_asm)
-       apply (rule monadic_rewrite_is_refl)
-       apply (case_tac ctea, rename_tac mdbnode, case_tac mdbnode)
-       apply simp
-      apply (simp add: Retype_H.postCapDeletion_def)
-      apply (rule monadic_rewrite_refl)
-     apply (wp getCTE_wp')+
+   apply (monadic_rewrite_l clearUntypedFreeIndex_simple_rewrite, simp)
+   apply (monadic_rewrite_symb_exec_l_known cte)
+      apply (simp add: updateMDB_def Let_def bind_assoc makeObject_cte case_Null_If)
+      apply (rule monadic_rewrite_bind_tail)
+       apply (rule monadic_rewrite_bind)
+         apply (rule_tac P="mdbFirstBadged (cteMDBNode ctea) \<and> mdbRevocable (cteMDBNode ctea)"
+                     in monadic_rewrite_gen_asm)
+         apply (rule monadic_rewrite_is_refl)
+         apply (case_tac ctea, rename_tac mdbnode, case_tac mdbnode)
+         apply simp
+        apply (simp add: Retype_H.postCapDeletion_def)
+        apply (rule monadic_rewrite_refl)
+       apply (solves wp | wp getCTE_wp')+
   apply (clarsimp simp: cte_wp_at_ctes_of reply_masters_rvk_fb_def)
   apply (fastforce simp: isCap_simps)
   done
@@ -1434,17 +1353,20 @@ end
 crunch obj_at'_tcbIPCBuffer[wp]: emptySlot "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"
   (wp: crunch_wps)
 
+(* FIXME move *)
+crunches getBoundNotification
+  for (no_fail) no_fail[intro!, wp, simp]
+
 lemma fastpath_callKernel_SysReplyRecv_corres:
   "monadic_rewrite True False
      (invs' and ct_in_state' ((=) Running) and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
          and cnode_caps_gsCNodes')
      (callKernel (SyscallEvent SysReplyRecv)) (fastpaths SysReplyRecv)"
   including no_pre
-  supply option.case_cong_weak[cong del]
-  supply if_cong[cong]
+  supply if_cong[cong] option.case_cong[cong]
   supply if_split[split del]
-  apply (rule monadic_rewrite_introduce_alternative)
-   apply (simp add: callKernel_def)
+  supply user_getreg_inv[wp] (* FIXME *)
+  apply (rule monadic_rewrite_introduce_alternative[OF callKernel_def[simplified atomize_eq]])
   apply (rule monadic_rewrite_guard_imp)
    apply (simp add: handleEvent_def handleReply_def
                     handleRecv_def liftE_bindE_handle liftE_handle
@@ -1456,16 +1378,16 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                     locateSlot_conv capability_case_Null_ReplyCap
                     getThreadCSpaceRoot_def
               cong: if_cong)
-   apply (rule monadic_rewrite_rdonly_bind_l, wp)
+   apply (rule monadic_rewrite_bind_alternative_l, wp)
    apply (rule monadic_rewrite_bind_tail)
-    apply (rule monadic_rewrite_symb_exec_r, wp+)
-     apply (rename_tac thread msgInfo)
-     apply (rule monadic_rewrite_symb_exec_r, wp+)
-      apply (rule monadic_rewrite_symb_exec_r[OF threadGet_inv no_fail_threadGet])
+    apply monadic_rewrite_symb_exec_r
+     apply (rename_tac msgInfo)
+     apply monadic_rewrite_symb_exec_r
+      apply monadic_rewrite_symb_exec_r
        apply (rename_tac tcbFault)
-       apply (rule monadic_rewrite_alternative_rhs[rotated])
+       apply (rule monadic_rewrite_alternative_r[rotated])
         apply (rule monadic_rewrite_alternative_l)
-       apply (rule monadic_rewrite_if_rhs[rotated])
+       apply (rule monadic_rewrite_if_r[rotated])
         apply (rule monadic_rewrite_alternative_l)
        apply (simp add: lookupCap_def liftME_def lookupCapAndSlot_def
                         lookupSlotForThread_def bindE_assoc
@@ -1479,13 +1401,11 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                         isRight_def[where x="Inr v" for v]
                         isRight_def[where x="Inl v" for v]
                   cong: if_cong)
-       apply (rule monadic_rewrite_symb_exec_r, wp+)
+       apply monadic_rewrite_symb_exec_r
         apply (rename_tac "cTableCTE")
-
         apply (rule monadic_rewrite_transverse,
-               rule monadic_rewrite_bind_head,
-               rule resolveAddressBitsFn_eq)
-        apply (rule monadic_rewrite_symb_exec_r, (wp | simp)+)
+               monadic_rewrite_l resolveAddressBitsFn_eq wpsimp, rule monadic_rewrite_refl)
+        apply monadic_rewrite_symb_exec_r
          apply (rename_tac "rab_ret")
 
          apply (rule_tac P="isRight rab_ret" in monadic_rewrite_cases[rotated])
@@ -1494,67 +1414,59 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
          apply clarsimp
          apply (simp add: isRight_case_sum liftE_bind
                           isRight_def[where x="Inr v" for v])
-         apply (rule monadic_rewrite_symb_exec_r, wp+)
+         apply monadic_rewrite_symb_exec_r
           apply (rename_tac ep_cap)
-          apply (rule monadic_rewrite_if_rhs[rotated])
+          apply (rule monadic_rewrite_if_r[rotated])
            apply (rule monadic_rewrite_alternative_l)
-            apply (rule monadic_rewrite_symb_exec_r[OF _ _ _ active_ntfn_check_wp, unfolded bind_assoc fun_app_def])
-            apply (rule hoare_pre, (wp | wpc | simp)+)[1]
-           apply (unfold getBoundNotification_def)[1]
-           apply (wp threadGet_wp)
+          apply (monadic_rewrite_symb_exec
+                   \<open>rule monadic_rewrite_symb_exec_r_nE[OF _ _ _ active_ntfn_check_wp, unfolded bind_assoc fun_app_def]\<close>
+                   \<open>wpsimp simp: getBoundNotification_def wp: threadGet_wp\<close>)
           apply (rename_tac ep)
-          apply (rule monadic_rewrite_if_rhs[rotated])
+          apply (rule monadic_rewrite_if_r[rotated])
            apply (rule monadic_rewrite_alternative_l)
-          apply (rule monadic_rewrite_symb_exec_r, wp+)
+          apply monadic_rewrite_symb_exec_r
            apply (rename_tac ep)
-           apply (rule monadic_rewrite_if_rhs[rotated])
+           apply (rule monadic_rewrite_if_r[rotated])
             apply (rule monadic_rewrite_alternative_l)
-           apply (rule monadic_rewrite_rdonly_bind_l, wp)
+           apply (rule monadic_rewrite_bind_alternative_l, wp)
            apply (rule monadic_rewrite_bind_tail)
             apply (rename_tac replyCTE)
-            apply (rule monadic_rewrite_if_rhs[rotated])
+            apply (rule monadic_rewrite_if_r[rotated])
              apply (rule monadic_rewrite_alternative_l)
             apply (simp add: bind_assoc)
-            apply (rule monadic_rewrite_rdonly_bind_l, wp assert_inv)
+            apply (rule monadic_rewrite_bind_alternative_l, wp assert_inv)
             apply (rule monadic_rewrite_assert)
-            apply (rule monadic_rewrite_symb_exec_r, wp+)
-             apply (rename_tac callerFault)
-             apply (rule monadic_rewrite_if_rhs[rotated])
+            apply monadic_rewrite_symb_exec_r
+             apply (rule monadic_rewrite_if_r[rotated])
               apply (rule monadic_rewrite_alternative_l)
              apply (simp add: getThreadVSpaceRoot_def locateSlot_conv)
-             apply (rule monadic_rewrite_symb_exec_r, wp+)
+             apply monadic_rewrite_symb_exec_r
               apply (rename_tac vTableCTE)
-              apply (rule monadic_rewrite_if_rhs[rotated])
+              apply (rule monadic_rewrite_if_r[rotated])
                apply (rule monadic_rewrite_alternative_l)
 
-                apply (rule monadic_rewrite_symb_exec_r[OF curDomain_inv],
-                        simp only: curDomain_def, rule non_fail_gets)
-                 apply (rename_tac "curDom")
-                apply (rule monadic_rewrite_symb_exec_r
-                         [OF threadGet_inv no_fail_threadGet])
-                apply (rename_tac callerPrio)
+              apply monadic_rewrite_symb_exec_r
+               apply monadic_rewrite_symb_exec_r
                 apply (simp add: isHighestPrio_def')
-               apply (rule monadic_rewrite_symb_exec_r [OF gets_inv non_fail_gets])
-               apply (rename_tac highest)
-           apply (rule monadic_rewrite_if_rhs[rotated])
-            apply (rule monadic_rewrite_alternative_l)
+                apply monadic_rewrite_symb_exec_r
+                 apply (rule monadic_rewrite_if_r[rotated])
+                  apply (rule monadic_rewrite_alternative_l)
 
-              apply (rule monadic_rewrite_symb_exec_r, wp+)
-                apply (rename_tac asidMap)
-              apply (rule monadic_rewrite_if_rhs[rotated])
-               apply (rule monadic_rewrite_alternative_l)
-                  apply (rule monadic_rewrite_symb_exec_r[OF threadGet_inv no_fail_threadGet])
-                   apply (rename_tac "callerDom")
-                   apply (rule monadic_rewrite_if_rhs[rotated])
+                 apply monadic_rewrite_symb_exec_r
+                  apply (rule monadic_rewrite_if_r[rotated])
+                   apply (rule monadic_rewrite_alternative_l)
+                  apply monadic_rewrite_symb_exec_r
+                   apply (rule monadic_rewrite_if_r[rotated])
                     apply (rule monadic_rewrite_alternative_l)
                    apply (rule monadic_rewrite_trans,
                               rule monadic_rewrite_pick_alternative_1)
-                    apply (rule_tac P="\<lambda>v.  obj_at' (%tcb. tcbIPCBuffer tcb = v) (capTCBPtr (cteCap replyCTE))"
-                          in monadic_rewrite_exists_v)
-                    apply (rename_tac ipcBuffer)
+                   (* now committed to fastpath *)
+                   apply (rule_tac P="\<lambda>v.  obj_at' (%tcb. tcbIPCBuffer tcb = v) (capTCBPtr (cteCap replyCTE))"
+                         in monadic_rewrite_exists_v)
+                   apply (rename_tac ipcBuffer)
 
-                    apply (simp add: switchToThread_def bind_assoc)
-                    apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
+                   apply (simp add: ARM_H.switchToThread_def bind_assoc)
+                   apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
 
                       apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
                       apply (wp mapM_x_wp' getObject_inv | wpc | simp add:
@@ -1581,35 +1493,33 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                                 setThreadState_obj_at_unchanged
                                 asUser_obj_at_unchanged
                                 hoare_strengthen_post[OF _ obj_at_conj'[simplified atomize_conjL], rotated]
-                                lookupBitmapPriority_lift
-                                setThreadState_runnable_bitmap_inv
+                                 lookupBitmapPriority_lift
+                                 setThreadState_runnable_bitmap_inv
                            | simp add: setMessageInfo_def setThreadState_runnable_simp
                            | wp (once) hoare_vcg_disj_lift)+)[1]
                     apply (simp add: setMessageInfo_def)
                     apply (rule monadic_rewrite_bind_tail)
-                    apply (rename_tac unblocked)
-                     apply (rule_tac rv=thread in monadic_rewrite_symb_exec_l_known,
-                                       (wp empty_fail_getCurThread)+)
-                      apply (rule_tac rv=cptr in monadic_rewrite_symb_exec_l_known,
-                                       (wp empty_fail_asUser empty_fail_getRegister)+)
+                     apply (rename_tac unblocked)
+                     apply (monadic_rewrite_symb_exec_l_known thread)
+                      apply (monadic_rewrite_symb_exec_l_known cptr)
                        apply (rule monadic_rewrite_bind)
                          apply (rule monadic_rewrite_catch[OF _ monadic_rewrite_refl True_E_E])
-                         apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_getCTE)+)
+                         apply monadic_rewrite_symb_exec_l
                           apply (rename_tac cTableCTE2,
                                  rule_tac P="cteCap cTableCTE2 = cteCap cTableCTE"
-                                           in monadic_rewrite_gen_asm)
+                                   in monadic_rewrite_gen_asm)
                           apply simp
                           apply (rule monadic_rewrite_trans,
                                  rule monadic_rewrite_bindE[OF _ monadic_rewrite_refl])
                             apply (rule_tac slot="\<lambda>s. ksCurThread s + 2 ^ cte_level_bits * tcbCTableSlot"
-                                in resolveAddressBitsFn_eq_name_slot)
+                                     in resolveAddressBitsFn_eq_name_slot)
                            apply wp
                           apply (rule monadic_rewrite_trans)
                            apply (rule_tac rv=rab_ret
-                                 in monadic_rewrite_gets_known[where m="NonDetMonad.lift f"
+                                    in monadic_rewrite_gets_known[where m="NonDetMonad.lift f"
                                     for f, folded bindE_def])
                           apply (simp add: NonDetMonad.lift_def isRight_case_sum)
-                          apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_getCTE)+)
+                          apply monadic_rewrite_symb_exec_l
                            apply (rename_tac ep_cap2)
                            apply (rule_tac P="cteCap ep_cap2 = cteCap ep_cap" in monadic_rewrite_gen_asm)
                            apply (simp add: cap_case_EndpointCap_NotificationCap)
@@ -1639,23 +1549,27 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                          apply ((wp setCurThread_ct_in_state[folded st_tcb_at'_def]
                                     Arch_switchToThread_pred_tcb')+)[2]
                        apply (simp add: catch_liftE)
-                       apply (wp setEndpoint_obj_at_tcb' threadSet_pred_tcb_at_state[unfolded if_bool_eq_conj])
-
-                       apply (wp setEndpoint_obj_at_tcb'
-                                 threadSet_pred_tcb_at_state[unfolded if_bool_eq_conj]
-                                 fastpathBestSwitchCandidate_lift[where f="setEndpoint a b" for a b]
-                                 fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t]
-                              | simp
-                              | rule hoare_lift_Pf2[where f=ksCurThread, OF _ setEndpoint_ct']
-                                     hoare_lift_Pf2[where f=ksCurThread, OF _ threadSet_ct])+
-
-                      apply (simp cong: rev_conj_cong)
+                       apply ((wpsimp wp: user_getreg_rv setEndpoint_obj_at_tcb'
+                                          threadSet_pred_tcb_at_state[unfolded if_bool_eq_conj]
+                                          fastpathBestSwitchCandidate_lift[where f="setEndpoint a b" for a b]
+                                          fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t]
+                               | wps)+)[3]
+                    apply (simp cong: rev_conj_cong)
+                    apply (wpsimp wp: seThreadState_tcbContext[simplified comp_apply]
+                                      setThreadState_oa_queued user_getreg_rv
+                                      setThreadState_no_sch_change setThreadState_obj_at_unchanged
+                                      sts_st_tcb_at'_cases sts_bound_tcb_at'
+                                      fastpathBestSwitchCandidate_lift[where f="setThreadState s t" for s t]
+                                      static_imp_wp hoare_vcg_all_lift hoare_vcg_imp_lift
+                                      static_imp_wp cnode_caps_gsCNodes_lift
+                                      hoare_vcg_ex_lift
+                          | wps)+
                       apply (strengthen imp_consequent[where Q="tcb_at' t s" for t s])
-                      apply (unfold setSchedulerAction_def)[3]
                       apply ((wp setThreadState_oa_queued user_getreg_rv setThreadState_no_sch_change
                                  setThreadState_obj_at_unchanged
                                  sts_st_tcb_at'_cases sts_bound_tcb_at'
-                                 emptySlot_obj_at'_not_queued
+                                 emptySlot_obj_at'_not_queued emptySlot_obj_at_ep
+                                 emptySlot_tcbContext[simplified comp_apply]
                                  emptySlot_cte_wp_at_cteCap
                                  emptySlot_cnode_caps
                                  user_getreg_inv asUser_typ_ats
@@ -1663,42 +1577,27 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                                  static_imp_wp hoare_vcg_all_lift hoare_vcg_imp_lift
                                  static_imp_wp cnode_caps_gsCNodes_lift
                                  hoare_vcg_ex_lift
-                             | simp del: comp_apply
-                             | clarsimp simp: obj_at'_weakenE[OF _ TrueI])+)
+                                 fastpathBestSwitchCandidate_lift[where f="emptySlot a b" for a b]
+                              | simp del: comp_apply
+                              | clarsimp simp: obj_at'_weakenE[OF _ TrueI]
+                              | wps)+)
 
-                          apply (rule hoare_lift_Pf2[where f=ksCurThread, OF _ setThreadState_ct'])
-                          apply (wp setThreadState_oa_queued
-                                    fastpathBestSwitchCandidate_lift[where f="setThreadState f t" for f t])
-                          apply (simp add: setThreadState_runnable_simp)
-                          apply (wp threadSet_tcbState_st_tcb_at')
-                         apply (clarsimp simp del: comp_apply)
-                         apply (wp emptySlot_obj_at_ep)+
+                            apply (wpsimp wp: fastpathBestSwitchCandidate_lift[where f="asUser a b" for a b])+
+                           apply (clarsimp cong: conj_cong)
+                           apply ((wp user_getreg_inv asUser_typ_ats
+                                      asUser_obj_at_not_queued asUser_obj_at' mapM_x_wp'
+                                      static_imp_wp hoare_vcg_all_lift hoare_vcg_imp_lift
+                                      static_imp_wp cnode_caps_gsCNodes_lift
+                                      hoare_vcg_ex_lift
+                                   | clarsimp simp: obj_at'_weakenE[OF _ TrueI]
+                                   | solves \<open>
+                                       wp fastpathBestSwitchCandidate_lift[where f="asUser a b" for a b]
+                                       \<close>)+)
 
-                         apply ((wp setThreadState_oa_queued user_getreg_rv
-                                    setThreadState_no_sch_change
-                                    setThreadState_obj_at_unchanged
-                                    sts_st_tcb_at'_cases sts_bound_tcb_at'
-                                    emptySlot_obj_at'_not_queued
-                                    emptySlot_cte_wp_at_cteCap
-                                    emptySlot_cnode_caps
-                                    user_getreg_inv asUser_typ_ats
-                                    asUser_obj_at_not_queued asUser_obj_at' mapM_x_wp'
-                                    static_imp_wp hoare_vcg_all_lift hoare_vcg_imp_lift
-                                    static_imp_wp cnode_caps_gsCNodes_lift
-                                    hoare_vcg_ex_lift
-                                | simp del: comp_apply
-                                | clarsimp simp: obj_at'_weakenE[OF _ TrueI]
-                                | solves \<open>
-                                    rule hoare_lift_Pf2[where f=ksCurThread, OF _ emptySlot_ct]
-                                         hoare_lift_Pf2[where f=ksCurThread, OF _ asUser_ct],
-                                    wp fastpathBestSwitchCandidate_lift[where f="emptySlot a b" for a b]
-                                       fastpathBestSwitchCandidate_lift[where f="asUser a b" for a b]
-                                       user_getreg_inv asUser_typ_ats\<close>)+)
+                          apply (clarsimp | wp getCTE_wp' gts_imp')+
 
-                        apply (clarsimp | wp getCTE_wp' gts_imp')+
-
-                    apply (simp add: switchToThread_def bind_assoc)
-                    apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
+                   apply (simp add: ARM_H.switchToThread_def bind_assoc)
+                   apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
 
                       apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
                       apply (wp mapM_x_wp' handleFault_obj_at'_tcbIPCBuffer getObject_inv | wpc | simp
@@ -1710,7 +1609,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                    apply (simp add: bind_assoc catch_liftE
                                     receiveIPC_def Let_def liftM_def
                                     setThreadState_runnable_simp)
-                   apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_getThreadState)+)
+                   apply monadic_rewrite_symb_exec_l
                     apply (rule monadic_rewrite_assert)
 
                     apply (rule_tac P="inj (case_bool thread (capTCBPtr (cteCap replyCTE)))"
@@ -1740,18 +1639,16 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                                 and F=True and E=False in monadic_rewrite_weaken_flags)
                     apply (rule monadic_rewrite_isolate_final2)
                        apply simp
-                       apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_getCTE)+)
+                       apply monadic_rewrite_symb_exec_l
                         apply (rename_tac callerCTE)
                         apply (rule monadic_rewrite_assert)
-                        apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_getCTE)+)
+                        apply monadic_rewrite_symb_exec_l
                          apply (rule monadic_rewrite_assert)
                          apply (simp add: emptySlot_setEndpoint_pivot)
                          apply (rule monadic_rewrite_bind)
                            apply (rule monadic_rewrite_is_refl)
                            apply (clarsimp simp: isSendEP_def split: Structures_H.endpoint.split)
-                          apply (rule_tac Q="\<lambda>rv. (\<lambda>_. rv = callerCTE) and Q'" for Q'
-                                              in monadic_rewrite_symb_exec_r, wp+)
-                           apply (rule monadic_rewrite_gen_asm, simp)
+                          apply (monadic_rewrite_symb_exec_r_known callerCTE)
                            apply (rule monadic_rewrite_trans, rule monadic_rewrite_bind_head,
                                        rule_tac cte=callerCTE in emptySlot_replymaster_rewrite)
                            apply (simp add: bind_assoc o_def)
@@ -1788,13 +1685,13 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                                           map_to_ctes_partial_overwrite)
                     apply (simp add: valid_mdb'_def valid_mdb_ctes_def)
                    apply simp
-                 apply (simp cong: if_cong bool.case_cong
-                                 | rule getCTE_wp' gts_wp' threadGet_wp
-                                        getEndpoint_wp gets_wp
-                                        user_getreg_wp
-                                        gets_the_wp gct_wp getNotification_wp
-                                        return_wp liftM_wp gbn_wp'
-                                 | (simp only: curDomain_def, wp)[1])+
+                   apply (simp cong: if_cong bool.case_cong
+                          | rule getCTE_wp' gts_wp' threadGet_wp
+                                 getEndpoint_wp gets_wp
+                                 user_getreg_wp
+                                 gets_the_wp gct_wp getNotification_wp
+                                 return_wp liftM_wp gbn_wp'
+                          | (simp only: curDomain_def, wp)[1])+
 
   apply clarsimp
   apply (subgoal_tac "ksCurThread s \<noteq> ksIdleThread s")
@@ -1823,6 +1720,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
   apply (subst tcb_at_cte_at_offset,
          assumption, simp add: tcb_cte_cases_def cte_level_bits_def tcbSlots)
   apply (clarsimp simp: inj_case_bool cte_wp_at_ctes_of
+                        length_msgRegisters
                         order_less_imp_le
                         tcb_at_invs' invs_mdb'
                  split: bool.split)
@@ -1836,8 +1734,8 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
    prefer 2
    apply normalise_obj_at'
    apply (rule_tac ttcb=tcba and ctcb=tcb in fastpathBestSwitchCandidateI)
-      apply (erule disjE, blast, blast)
-     apply simp+
+     apply (erule disjE, blast, blast)
+    apply simp+
 
   apply (clarsimp simp: obj_at_tcbs_of tcbSlots
                         cte_level_bits_def)

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -121,10 +121,6 @@ lemmas valid_cnode_cap_cte_at''
 
 declare of_int_sint_scast[simp]
 
-lemma isCNodeCap_capUntypedPtr_capCNodePtr:
-  "isCNodeCap c \<Longrightarrow> capUntypedPtr c = capCNodePtr c"
-  by (clarsimp simp: isCap_simps)
-
 lemma of_bl_from_bool:
   "of_bl [x] = from_bool x"
   by (cases x, simp_all add: from_bool_def)
@@ -137,8 +133,7 @@ lemma dmo_clearExMonitor_setCurThread_swap:
             doMachineOp ARM.clearExMonitor od)"
   apply (simp add: setCurThread_def doMachineOp_def split_def)
   apply (rule oblivious_modify_swap[symmetric])
-  apply (intro oblivious_bind,
-         simp_all add: select_f_oblivious)
+  apply (intro oblivious_bind, simp_all)
   done
 
 lemma pd_at_asid_inj':
@@ -447,15 +442,11 @@ lemma schedule_rewrite_ct_not_runnable':
            apply wp+
   apply (clarsimp simp: ct_in_state'_def)
   apply (strengthen not_pred_tcb_at'_strengthen, simp)
-  supply word_neq_0_conv[simp del]
   apply normalise_obj_at'
   apply (simp add: fastpathBestSwitchCandidate_def)
   apply (erule_tac x="tcbPriority ko" in allE)
   apply (erule impE, normalise_obj_at'+)
   done
-
-crunch tcb2[wp]: "Arch.switchToThread" "tcb_at' t"
-  (ignore: ARM.clearExMonitor)
 
 lemma resolveAddressBits_points_somewhere:
   "\<lbrace>\<lambda>s. \<forall>slot. Q slot s\<rbrace> resolveAddressBits cp cptr bits \<lbrace>Q\<rbrace>,-"
@@ -513,9 +504,6 @@ crunches cteInsert, asUser
   (wp: setCTE_obj_at'_queued crunch_wps threadSet_obj_at'_really_strongest)
 end
 
-crunch ksReadyQueues_inv[wp]: cteInsert "\<lambda>s. P (ksReadyQueues s)"
-  (wp: hoare_drop_imps)
-
 crunches cteInsert, threadSet, asUser, emptySlot
   for ksReadyQueuesL1Bitmap_inv[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
   and ksReadyQueuesL2Bitmap_inv[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
@@ -570,7 +558,7 @@ lemma fastpath_callKernel_SysCall_corres:
                         capFaultOnFailure_def)
        apply (simp only: bindE_bind_linearise[where f="rethrowFailure fn f'" for fn f']
                          bind_case_sum_rethrow)
-       apply (simp add: lookupCapAndSlot_def lookupSlotForThread_def
+       apply (simp add: lookupCapAndSlot_def
                         lookupSlotForThread_def bindE_assoc
                         liftE_bind_return_bindE_returnOk split_def
                         getThreadCSpaceRoot_def locateSlot_conv
@@ -961,7 +949,7 @@ lemma emptySlot_cnode_caps:
                    o_assoc[symmetric] cteCaps_of_def[symmetric])
   apply (wp emptySlot_cteCaps_of)
   apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of
-                 elim!: rsubst[where P=P] intro!: ext
+                 elim!: rsubst[where P=P] del: ext intro!: ext
                  split: if_split)
   done
 
@@ -991,14 +979,9 @@ lemma setCTE_obj_at_ntfn[wp]:
 
 crunch obj_at_ep[wp]: emptySlot "obj_at' (P :: endpoint \<Rightarrow> bool) p"
 
-crunch nosch[wp]: emptySlot "\<lambda>s. P (ksSchedulerAction s)"
-
 crunches emptySlot, asUser
   for gsCNodes[wp]: "\<lambda>s. P (gsCNodes s)"
   (wp: crunch_wps)
-
-crunch cte_wp_at'[wp]: possibleSwitchTo "cte_wp_at' P p"
-  (wp: hoare_drop_imps)
 
 crunch tcbContext[wp]: possibleSwitchTo "obj_at' (\<lambda>tcb. P ( (atcbContextGet o tcbArch) tcb)) t"
   (wp: crunch_wps simp_del: comp_apply)
@@ -1117,7 +1100,6 @@ lemma emptySlot_cte_wp_at_cteCap:
 lemma setEndpoint_getCTE_pivot[unfolded K_bind_def]:
   "do setEndpoint p val; v <- getCTE slot; f v od
      = do v <- getCTE slot; setEndpoint p val; f v od"
-  supply word_neq_0_conv[simp del]
   apply (simp add: getCTE_assert_opt setEndpoint_def
                    setObject_modify_assert
                    fun_eq_iff bind_assoc)
@@ -1162,6 +1144,7 @@ lemma setEndpoint_setCTE_pivot[unfolded K_bind_def]:
                        exec_gets assert_def exec_modify
                 split: if_split)
       apply (auto split: if_split simp: obj_at'_def projectKOs objBits_defs
+                    del: ext
                  intro!: arg_cong[where f=f] ext kernel_state.fold_congs)[1]
      apply wp+
   apply (simp add: objBits_defs)
@@ -1273,6 +1256,7 @@ lemma set_setCTE[unfolded K_bind_def]:
        apply (rule monadic_rewrite_refl2)
        apply (simp add: exec_modify split: if_split)
        apply (auto simp: simpler_modify_def projectKO_opt_tcb objBits_defs
+                    del: ext
                  intro!: kernel_state.fold_congs ext
                   split: if_split)[1]
       apply wp+
@@ -1283,7 +1267,7 @@ lemma set_setCTE[unfolded K_bind_def]:
 lemma setCTE_updateCapMDB:
   "p \<noteq> 0 \<Longrightarrow>
    setCTE p cte = do updateCap p (cteCap cte); updateMDB p (const (cteMDBNode cte)) od"
-  supply if_split[split del] word_neq_0_conv[simp del]
+  supply if_split[split del]
   apply (simp add: updateCap_def updateMDB_def bind_assoc set_getCTE
                    cte_overwrite set_setCTE)
   apply (simp add: getCTE_assert_opt setCTE_assert_modify bind_assoc)
@@ -1327,7 +1311,7 @@ lemma emptySlot_replymaster_rewrite[OF refl]:
                                               o mdbRevocable_update (K True));
          setCTE slot makeObject
       od)"
-  supply if_split[split del] word_neq_0_conv[simp del]
+  supply if_split[split del]
   apply (rule monadic_rewrite_gen_asm)+
   apply (rule monadic_rewrite_guard_imp)
    apply (rule_tac P="slot \<noteq> 0" in monadic_rewrite_gen_asm)
@@ -1458,7 +1442,6 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
   including no_pre
   supply option.case_cong_weak[cong del]
   supply if_cong[cong]
-  supply word_neq_0_conv[simp del]
   supply if_split[split del]
   apply (rule monadic_rewrite_introduce_alternative)
    apply (simp add: callKernel_def)
@@ -1478,7 +1461,6 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
     apply (rule monadic_rewrite_symb_exec_r, wp+)
      apply (rename_tac thread msgInfo)
      apply (rule monadic_rewrite_symb_exec_r, wp+)
-      apply (rename_tac cptr)
       apply (rule monadic_rewrite_symb_exec_r[OF threadGet_inv no_fail_threadGet])
        apply (rename_tac tcbFault)
        apply (rule monadic_rewrite_alternative_rhs[rotated])

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -479,7 +479,7 @@ lemma monadic_rewrite_threadGet:
    apply (rule monadic_rewrite_symb_exec_l' | wp | rule empty_fail_getObject getObject_inv)+
      apply (clarsimp; rule no_fail_getObject_tcb)
     apply (simp only: exec_gets)
-    apply (rule_tac P = "(\<lambda>s. (f x)=v) and tcb_at' t" in monadic_rewrite_refl3)
+    apply (rule_tac P = "(\<lambda>s. (f x)=v) and tcb_at' t" in monadic_rewrite_pre_imp_refl)
     apply (simp add:)
    apply (wp OMG_getObject_tcb | wpc)+
   apply (auto intro: obj_tcb_at')
@@ -634,7 +634,7 @@ lemma fastpath_callKernel_SysCall_corres:
                       apply (rule monadic_rewrite_bind_tail, rename_tac dest_st)
                       apply (rule_tac P="\<exists>gr. dest_st = BlockedOnReceive (capEPPtr (fst (theRight rv))) gr"
                                in monadic_rewrite_gen_asm)
-                      apply (rule monadic_rewrite_symb_exec2, (wp | simp)+)
+                      apply (rule monadic_rewrite_symb_exec_drop, (wp | simp)+)
                       apply (rule monadic_rewrite_bind)
                         apply clarsimp
                         apply (rule_tac msgInfo=msgInfo in doIPCTransfer_simple_rewrite)
@@ -880,7 +880,7 @@ lemma receiveIPC_simple_rewrite:
         apply (rule hoare_pre, wpc, wp+, simp)
        apply (simp split: option.split)
       apply (rule monadic_rewrite_trans, rule monadic_rewrite_if_known[where X=False], simp)
-      apply (rule monadic_rewrite_refl3[where P=\<top>])
+      apply (rule monadic_rewrite_pre_imp_refl[where P=\<top>])
       apply (cases ep, simp_all add: isSendEP_def)[1]
      apply (wp getNotification_wp gbn_wp' getEndpoint_wp | wpc)+
   apply (clarsimp simp: obj_at'_def projectKOs pred_tcb_at'_def)
@@ -1139,7 +1139,7 @@ lemma setEndpoint_setCTE_pivot[unfolded K_bind_def]:
                      | simp)+
       apply (rule_tac P="\<lambda>s. epat = ep_at' p s \<and> cteat = real_cte_at' slot s
                            \<and> tcbat = (tcb_at' (slot && ~~ mask 9) and (%y. slot && mask 9 : dom tcb_cte_cases)) s"
-                   in monadic_rewrite_refl3)
+                   in monadic_rewrite_pre_imp_refl)
       apply (simp add: setEndpoint_def setObject_modify_assert bind_assoc
                        exec_gets assert_def exec_modify
                 split: if_split)
@@ -1253,7 +1253,7 @@ lemma set_setCTE[unfolded K_bind_def]:
                                  (\<exists> getF setF. tcb_cte_cases (p && mask 9) = Some (getF, setF)
                                         \<and> (\<forall> f g tcb. setF f (setF g tcb) = setF (f o g) tcb)))"
                    in monadic_rewrite_gen_asm)
-       apply (rule monadic_rewrite_refl2)
+       apply (rule monadic_rewrite_is_refl[OF ext])
        apply (simp add: exec_modify split: if_split)
        apply (auto simp: simpler_modify_def projectKO_opt_tcb objBits_defs
                     del: ext
@@ -1326,7 +1326,7 @@ lemma emptySlot_replymaster_rewrite[OF refl]:
      apply (rule monadic_rewrite_bind)
        apply (rule_tac P="mdbFirstBadged (cteMDBNode ctea) \<and> mdbRevocable (cteMDBNode ctea)"
                    in monadic_rewrite_gen_asm)
-       apply (rule monadic_rewrite_refl2)
+       apply (rule monadic_rewrite_is_refl)
        apply (case_tac ctea, rename_tac mdbnode, case_tac mdbnode)
        apply simp
       apply (simp add: Retype_H.postCapDeletion_def)
@@ -1747,7 +1747,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                          apply (rule monadic_rewrite_assert)
                          apply (simp add: emptySlot_setEndpoint_pivot)
                          apply (rule monadic_rewrite_bind)
-                           apply (rule monadic_rewrite_refl2)
+                           apply (rule monadic_rewrite_is_refl)
                            apply (clarsimp simp: isSendEP_def split: Structures_H.endpoint.split)
                           apply (rule_tac Q="\<lambda>rv. (\<lambda>_. rv = callerCTE) and Q'" for Q'
                                               in monadic_rewrite_symb_exec_r, wp+)

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -41,8 +41,8 @@ lemma tcbSchedEnqueue_tcbContext[wp]:
 
 lemma setCTE_tcbContext:
   "\<lbrace>obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>
-  setCTE slot cte
-  \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>"
+   setCTE slot cte
+   \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>"
   apply (simp add: setCTE_def)
   apply (rule setObject_cte_obj_at_tcb', simp_all)
   done
@@ -342,7 +342,7 @@ lemma lookupBitmapPriority_lift:
   unfolding lookupBitmapPriority_def
   apply (rule hoare_pre)
    apply (wps prqL1 prqL2)
-  apply wpsimp+
+   apply wpsimp+
   done
 
 (* slow path additionally requires current thread not idle *)
@@ -604,85 +604,85 @@ lemma fastpath_callKernel_SysCall_corres:
                     apply simp
                     apply (rule monadic_rewrite_bind_tail)
                      apply (monadic_rewrite_symb_exec_l_known thread)
-                     apply (simp add: sendIPC_def bind_assoc)
-                     apply (monadic_rewrite_symb_exec_l_known send_ep)
-                     apply (rule_tac P="epQueue send_ep \<noteq> []" in monadic_rewrite_gen_asm)
-                     apply (simp add: isRecvEP_endpoint_case list_case_helper bind_assoc)
-                     apply (rule monadic_rewrite_bind_tail)
-                      apply (elim conjE)
-                      apply (rule monadic_rewrite_bind_tail, rename_tac dest_st)
-                       apply (rule_tac P="\<exists>gr. dest_st = BlockedOnReceive (capEPPtr (fst (theRight rv))) gr"
-                                in monadic_rewrite_gen_asm)
-                       apply monadic_rewrite_symb_exec_l_drop
-                       apply (rule monadic_rewrite_bind)
-                         apply clarsimp
-                         apply (rule_tac msgInfo=msgInfo in doIPCTransfer_simple_rewrite)
-                        apply (rule monadic_rewrite_bind_tail)
+                      apply (simp add: sendIPC_def bind_assoc)
+                      apply (monadic_rewrite_symb_exec_l_known send_ep)
+                       apply (rule_tac P="epQueue send_ep \<noteq> []" in monadic_rewrite_gen_asm)
+                       apply (simp add: isRecvEP_endpoint_case list_case_helper bind_assoc)
+                       apply (rule monadic_rewrite_bind_tail)
+                        apply (elim conjE)
+                        apply (rule monadic_rewrite_bind_tail, rename_tac dest_st)
+                         apply (rule_tac P="\<exists>gr. dest_st = BlockedOnReceive (capEPPtr (fst (theRight rv))) gr"
+                                  in monadic_rewrite_gen_asm)
+                         apply monadic_rewrite_symb_exec_l_drop
                          apply (rule monadic_rewrite_bind)
-                           apply (rule_tac destPrio=destPrio
-                                    and curDom=curDom and destDom=destDom and thread=thread
-                                    in possibleSwitchTo_rewrite)
-                          apply (rule monadic_rewrite_bind)
-                            apply (rule monadic_rewrite_trans)
-                             apply (rule setupCallerCap_rewrite)
-                            apply (rule monadic_rewrite_bind_head)
-                            apply (rule setThreadState_rewrite_simple, simp)
-                           apply (rule monadic_rewrite_trans)
-                            apply (monadic_rewrite_symb_exec_l_known BlockedOnReply)
-                            apply simp
-                            apply (rule monadic_rewrite_refl)
-                            apply wpsimp (* FIXME indentation *)
-                           apply (rule monadic_rewrite_trans)
-                            apply (rule monadic_rewrite_bind_head)
-                            apply (rule_tac t="hd (epQueue send_ep)"
-                                     in schedule_rewrite_ct_not_runnable')
-                           apply (simp add: bind_assoc)
-                           apply (rule monadic_rewrite_bind_tail)
+                           apply clarsimp
+                           apply (rule_tac msgInfo=msgInfo in doIPCTransfer_simple_rewrite)
+                          apply (rule monadic_rewrite_bind_tail)
+                           apply (rule monadic_rewrite_bind)
+                             apply (rule_tac destPrio=destPrio
+                                      and curDom=curDom and destDom=destDom and thread=thread
+                                      in possibleSwitchTo_rewrite)
                             apply (rule monadic_rewrite_bind)
-                              apply (rule switchToThread_rewrite)
-                             apply (rule monadic_rewrite_bind)
-                               apply (rule activateThread_simple_rewrite)
-                              apply (rule monadic_rewrite_refl)
-                             apply wp
-                            apply (wp setCurThread_ct_in_state)
-                           apply (simp only: st_tcb_at'_def[symmetric])
-                           apply (wp, clarsimp simp: cur_tcb'_def ct_in_state'_def)
-                          apply (simp add: getThreadCallerSlot_def getThreadReplySlot_def
-                                           locateSlot_conv ct_in_state'_def cur_tcb'_def)
+                              apply (rule monadic_rewrite_trans)
+                               apply (rule setupCallerCap_rewrite)
+                              apply (rule monadic_rewrite_bind_head)
+                              apply (rule setThreadState_rewrite_simple, simp)
+                             apply (rule monadic_rewrite_trans)
+                              apply (monadic_rewrite_symb_exec_l_known BlockedOnReply)
+                               apply simp
+                               apply (rule monadic_rewrite_refl)
+                              apply wpsimp
+                             apply (rule monadic_rewrite_trans)
+                              apply (rule monadic_rewrite_bind_head)
+                              apply (rule_tac t="hd (epQueue send_ep)"
+                                       in schedule_rewrite_ct_not_runnable')
+                             apply (simp add: bind_assoc)
+                             apply (rule monadic_rewrite_bind_tail)
+                              apply (rule monadic_rewrite_bind)
+                                apply (rule switchToThread_rewrite)
+                               apply (rule monadic_rewrite_bind)
+                                 apply (rule activateThread_simple_rewrite)
+                                apply (rule monadic_rewrite_refl)
+                               apply wp
+                              apply (wp setCurThread_ct_in_state)
+                             apply (simp only: st_tcb_at'_def[symmetric])
+                             apply (wp, clarsimp simp: cur_tcb'_def ct_in_state'_def)
+                            apply (simp add: getThreadCallerSlot_def getThreadReplySlot_def
+                                             locateSlot_conv ct_in_state'_def cur_tcb'_def)
 
-                          apply ((wp assert_inv threadSet_pred_tcb_at_state
-                                     cteInsert_obj_at'_not_queued
-                                  | wps)+)[1]
+                            apply ((wp assert_inv threadSet_pred_tcb_at_state
+                                       cteInsert_obj_at'_not_queued
+                                    | wps)+)[1]
 
-                             apply (wp fastpathBestSwitchCandidate_lift[where f="cteInsert c w w'" for c w w'])
+                               apply (wp fastpathBestSwitchCandidate_lift[where f="cteInsert c w w'" for c w w'])
+                               apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
+                              apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
                              apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
                             apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
-                           apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
-                          apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
-                          apply (wp fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t])
-                           apply simp
-                          apply ((wp assert_inv threadSet_pred_tcb_at_state
-                                     cteInsert_obj_at'_not_queued
-                                  | wps)+)[1]
-                         apply (simp add: setSchedulerAction_def)
-                         apply wp[1]
-                        apply (simp cong: if_cong HOL.conj_cong add: if_bool_simps)
-                        apply (simp_all only:)[5]
-                        apply ((wp setThreadState_oa_queued[of _ "\<lambda>a _ _. \<not> a"]
-                                   setThreadState_obj_at_unchanged
-                                   asUser_obj_at_unchanged mapM_x_wp'
-                                   sts_st_tcb_at'_cases
-                                   setThreadState_no_sch_change
-                                   setEndpoint_obj_at_tcb'
-                                   fastpathBestSwitchCandidate_lift[where f="setThreadState f t" for f t]
-                                   setThreadState_oa_queued
-                                   fastpathBestSwitchCandidate_lift[where f="asUser t f" for f t]
-                                   fastpathBestSwitchCandidate_lift[where f="setEndpoint a b" for a b]
-                                   lookupBitmapPriority_lift
-                                   setThreadState_runnable_bitmap_inv
-                                   getEndpoint_obj_at'
-                                 | simp add: setMessageInfo_def
-                                 | wp (once) hoare_vcg_disj_lift)+)
+                            apply (wp fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t])
+                             apply simp
+                            apply ((wp assert_inv threadSet_pred_tcb_at_state
+                                       cteInsert_obj_at'_not_queued
+                                    | wps)+)[1]
+                           apply (simp add: setSchedulerAction_def)
+                           apply wp[1]
+                          apply (simp cong: if_cong HOL.conj_cong add: if_bool_simps)
+                          apply (simp_all only:)[5]
+                          apply ((wp setThreadState_oa_queued[of _ "\<lambda>a _ _. \<not> a"]
+                                     setThreadState_obj_at_unchanged
+                                     asUser_obj_at_unchanged mapM_x_wp'
+                                     sts_st_tcb_at'_cases
+                                     setThreadState_no_sch_change
+                                     setEndpoint_obj_at_tcb'
+                                     fastpathBestSwitchCandidate_lift[where f="setThreadState f t" for f t]
+                                     setThreadState_oa_queued
+                                     fastpathBestSwitchCandidate_lift[where f="asUser t f" for f t]
+                                     fastpathBestSwitchCandidate_lift[where f="setEndpoint a b" for a b]
+                                     lookupBitmapPriority_lift
+                                     setThreadState_runnable_bitmap_inv
+                                     getEndpoint_obj_at'
+                                   | simp add: setMessageInfo_def
+                                   | wp (once) hoare_vcg_disj_lift)+)
 
                    apply (simp add: setThreadState_runnable_simp
                                     getThreadCallerSlot_def getThreadReplySlot_def
@@ -696,15 +696,15 @@ lemma fastpath_callKernel_SysCall_corres:
                    apply (rename_tac destState)
 
                    apply (simp add: ARM_H.switchToThread_def bind_assoc)
-                 (* retrieving state or thread registers is not thread_action_isolatable,
+                  (* retrieving state or thread registers is not thread_action_isolatable,
                      translate into return with suitable precondition  *)
                    apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
                      apply (rule_tac v=destState in monadic_rewrite_getThreadState
                             | rule monadic_rewrite_bind monadic_rewrite_refl)+
-                                     apply (wp mapM_x_wp' getObject_inv | wpc | simp | wp (once) hoare_drop_imps)+
+                                    apply (wp mapM_x_wp' getObject_inv | wpc | simp | wp (once) hoare_drop_imps)+
                     apply (rule_tac v=destState in monadic_rewrite_getThreadState
                            | rule monadic_rewrite_bind monadic_rewrite_refl)+
-                                apply (wp mapM_x_wp' getObject_inv | wpc | simp | wp (once) hoare_drop_imps)+
+                               apply (wp mapM_x_wp' getObject_inv | wpc | simp | wp (once) hoare_drop_imps)+
 
                    apply (rule_tac P="inj (case_bool thread (hd (epQueue send_ep)))"
                             in monadic_rewrite_gen_asm)
@@ -836,8 +836,8 @@ lemma doReplyTransfer_simple:
   apply (simp add: doReplyTransfer_def liftM_def nullPointer_def getSlotCap_def)
   apply (rule monadic_rewrite_bind_tail)+
         apply (monadic_rewrite_symb_exec_l_known None, simp)
-           apply (rule monadic_rewrite_refl)
-          apply (wpsimp wp: threadGet_const gts_wp' getCTE_wp' simp: o_def)+
+         apply (rule monadic_rewrite_refl)
+        apply (wpsimp wp: threadGet_const gts_wp' getCTE_wp' simp: o_def)+
   done
 
 lemma receiveIPC_simple_rewrite:
@@ -852,13 +852,13 @@ lemma receiveIPC_simple_rewrite:
   supply empty_fail_getEndpoint[wp]
   apply (rule monadic_rewrite_gen_asm)
   apply (simp add: receiveIPC_def)
-   apply (monadic_rewrite_symb_exec_l_known ep)
-      apply monadic_rewrite_symb_exec_l+
-            apply (monadic_rewrite_l monadic_rewrite_if_l_False)
-            apply (rule monadic_rewrite_is_refl)
-            apply (cases ep; simp add: isSendEP_def)
-           apply (wpsimp wp: getNotification_wp gbn_wp' getEndpoint_wp
-                         simp: getBoundNotification_def)+
+  apply (monadic_rewrite_symb_exec_l_known ep)
+    apply monadic_rewrite_symb_exec_l+
+       apply (monadic_rewrite_l monadic_rewrite_if_l_False)
+       apply (rule monadic_rewrite_is_refl)
+       apply (cases ep; simp add: isSendEP_def)
+      apply (wpsimp wp: getNotification_wp gbn_wp' getEndpoint_wp
+                    simp: getBoundNotification_def)+
   apply (clarsimp simp: obj_at'_def projectKOs pred_tcb_at'_def)
   done
 
@@ -893,7 +893,7 @@ lemma cteDeleteOne_nullcap_rewrite:
   apply (simp add: cteDeleteOne_def unless_def when_def)
   apply (monadic_rewrite_l monadic_rewrite_if_l_False \<open>wpsimp wp: getCTE_wp'\<close>)
    apply (monadic_rewrite_symb_exec_l, rule monadic_rewrite_refl)
-     apply (wpsimp wp: getCTE_wp' simp: cte_wp_at_ctes_of)+
+   apply (wpsimp wp: getCTE_wp' simp: cte_wp_at_ctes_of)+
   done
 
 lemma deleteCallerCap_nullcap_rewrite:
@@ -962,7 +962,7 @@ lemma tcbSchedDequeue_rewrite_not_queued:
   apply (simp add: tcbSchedDequeue_def when_def)
   apply (monadic_rewrite_l monadic_rewrite_if_l_False \<open>wp threadGet_const\<close>)
    apply (monadic_rewrite_symb_exec_l, rule monadic_rewrite_refl)
-     apply wp+
+   apply wp+
   apply (clarsimp simp: o_def obj_at'_def)
   done
 
@@ -1134,7 +1134,7 @@ lemma emptySlot_setEndpoint_pivot[unfolded K_bind_def]:
                    case_Null_If Retype_H.postCapDeletion_def
                    setEndpoint_clearUntypedFreeIndex_pivot
             split: if_split
-              | rule bind_apply_cong[OF refl])+
+         | rule bind_apply_cong[OF refl])+
   done
 
 lemma set_getCTE[unfolded K_bind_def]:
@@ -1236,28 +1236,28 @@ lemma emptySlot_replymaster_rewrite[OF refl]:
   supply if_split[split del]
   apply (rule monadic_rewrite_gen_asm)+
   apply (rule monadic_rewrite_guard_imp)
-    apply (rule_tac P="slot \<noteq> 0" in monadic_rewrite_gen_asm)
+   apply (rule_tac P="slot \<noteq> 0" in monadic_rewrite_gen_asm)
    apply (clarsimp simp: emptySlot_def setCTE_updateCapMDB)
    apply (monadic_rewrite_l clearUntypedFreeIndex_simple_rewrite, simp)
    apply (monadic_rewrite_symb_exec_l_known cte)
-      apply (simp add: updateMDB_def Let_def bind_assoc makeObject_cte case_Null_If)
-      apply (rule monadic_rewrite_bind_tail)
-       apply (rule monadic_rewrite_bind)
-         apply (rule_tac P="mdbFirstBadged (cteMDBNode ctea) \<and> mdbRevocable (cteMDBNode ctea)"
-                     in monadic_rewrite_gen_asm)
-         apply (rule monadic_rewrite_is_refl)
-         apply (case_tac ctea, rename_tac mdbnode, case_tac mdbnode)
-         apply simp
-        apply (simp add: Retype_H.postCapDeletion_def)
-        apply (rule monadic_rewrite_refl)
-       apply (solves wp | wp getCTE_wp')+
+    apply (simp add: updateMDB_def Let_def bind_assoc makeObject_cte case_Null_If)
+    apply (rule monadic_rewrite_bind_tail)
+     apply (rule monadic_rewrite_bind)
+       apply (rule_tac P="mdbFirstBadged (cteMDBNode ctea) \<and> mdbRevocable (cteMDBNode ctea)"
+                in monadic_rewrite_gen_asm)
+       apply (rule monadic_rewrite_is_refl)
+       apply (case_tac ctea, rename_tac mdbnode, case_tac mdbnode)
+       apply simp
+      apply (simp add: Retype_H.postCapDeletion_def)
+      apply (rule monadic_rewrite_refl)
+     apply (solves wp | wp getCTE_wp')+
   apply (clarsimp simp: cte_wp_at_ctes_of reply_masters_rvk_fb_def)
   apply (fastforce simp: isCap_simps)
   done
 
 lemma all_prio_not_inQ_not_tcbQueued: "\<lbrakk> obj_at' (\<lambda>a. (\<forall>d p. \<not> inQ d p a)) t s \<rbrakk> \<Longrightarrow> obj_at' (\<lambda>a. \<not> tcbQueued a) t s"
   apply (clarsimp simp: obj_at'_def inQ_def)
-done
+  done
 
 crunches setThreadState, emptySlot, asUser
   for ntfn_obj_at[wp]: "obj_at' (P::(Structures_H.notification \<Rightarrow> bool)) ntfnptr"
@@ -1276,11 +1276,11 @@ lemma st_tcb_at_is_Reply_imp_not_tcbQueued: "\<And>s t.\<lbrakk> invs' s; st_tcb
    apply (case_tac "tcbState obj")
           apply ((clarsimp simp: inQ_def)+)[8]
   apply (clarsimp simp: valid_queues'_def obj_at'_def)
-done
+  done
 
 lemma valid_objs_ntfn_at_tcbBoundNotification:
   "ko_at' tcb t s \<Longrightarrow> valid_objs' s \<Longrightarrow> tcbBoundNotification tcb \<noteq> None
-    \<Longrightarrow> ntfn_at' (the (tcbBoundNotification tcb)) s"
+   \<Longrightarrow> ntfn_at' (the (tcbBoundNotification tcb)) s"
   apply (drule(1) ko_at_valid_objs', simp add: projectKOs)
   apply (simp add: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def)
   apply clarsimp
@@ -1468,13 +1468,13 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                    apply (simp add: ARM_H.switchToThread_def bind_assoc)
                    apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
 
-                      apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
-                      apply (wp mapM_x_wp' getObject_inv | wpc | simp add:
-                        | wp (once) hoare_drop_imps )+
+                     apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
+                          apply (wp mapM_x_wp' getObject_inv | wpc | simp add:
+                            | wp (once) hoare_drop_imps )+
 
-                      apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
-                      apply (wp setCTE_obj_at'_tcbIPCBuffer assert_inv mapM_x_wp' getObject_inv | wpc | simp
-                        | wp (once) hoare_drop_imps )+
+                    apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
+                               apply (wp setCTE_obj_at'_tcbIPCBuffer assert_inv mapM_x_wp' getObject_inv | wpc | simp
+                                 | wp (once) hoare_drop_imps )+
 
                    apply (rule monadic_rewrite_trans)
                     apply (rule monadic_rewrite_trans)
@@ -1564,23 +1564,23 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                                       static_imp_wp cnode_caps_gsCNodes_lift
                                       hoare_vcg_ex_lift
                           | wps)+
-                      apply (strengthen imp_consequent[where Q="tcb_at' t s" for t s])
-                      apply ((wp setThreadState_oa_queued user_getreg_rv setThreadState_no_sch_change
-                                 setThreadState_obj_at_unchanged
-                                 sts_st_tcb_at'_cases sts_bound_tcb_at'
-                                 emptySlot_obj_at'_not_queued emptySlot_obj_at_ep
-                                 emptySlot_tcbContext[simplified comp_apply]
-                                 emptySlot_cte_wp_at_cteCap
-                                 emptySlot_cnode_caps
-                                 user_getreg_inv asUser_typ_ats
-                                 asUser_obj_at_not_queued asUser_obj_at' mapM_x_wp'
-                                 static_imp_wp hoare_vcg_all_lift hoare_vcg_imp_lift
-                                 static_imp_wp cnode_caps_gsCNodes_lift
-                                 hoare_vcg_ex_lift
-                                 fastpathBestSwitchCandidate_lift[where f="emptySlot a b" for a b]
-                              | simp del: comp_apply
-                              | clarsimp simp: obj_at'_weakenE[OF _ TrueI]
-                              | wps)+)
+                           apply (strengthen imp_consequent[where Q="tcb_at' t s" for t s])
+                           apply ((wp setThreadState_oa_queued user_getreg_rv setThreadState_no_sch_change
+                                      setThreadState_obj_at_unchanged
+                                      sts_st_tcb_at'_cases sts_bound_tcb_at'
+                                      emptySlot_obj_at'_not_queued emptySlot_obj_at_ep
+                                      emptySlot_tcbContext[simplified comp_apply]
+                                      emptySlot_cte_wp_at_cteCap
+                                      emptySlot_cnode_caps
+                                      user_getreg_inv asUser_typ_ats
+                                      asUser_obj_at_not_queued asUser_obj_at' mapM_x_wp'
+                                      static_imp_wp hoare_vcg_all_lift hoare_vcg_imp_lift
+                                      static_imp_wp cnode_caps_gsCNodes_lift
+                                      hoare_vcg_ex_lift
+                                      fastpathBestSwitchCandidate_lift[where f="emptySlot a b" for a b]
+                                   | simp del: comp_apply
+                                   | clarsimp simp: obj_at'_weakenE[OF _ TrueI]
+                                   | wps)+)
 
                             apply (wpsimp wp: fastpathBestSwitchCandidate_lift[where f="asUser a b" for a b])+
                            apply (clarsimp cong: conj_cong)
@@ -1599,12 +1599,12 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                    apply (simp add: ARM_H.switchToThread_def bind_assoc)
                    apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
 
-                      apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
-                      apply (wp mapM_x_wp' handleFault_obj_at'_tcbIPCBuffer getObject_inv | wpc | simp
-                        | wp (once) hoare_drop_imps )+
-                      apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
-                      apply (wp setCTE_obj_at'_tcbIPCBuffer assert_inv mapM_x_wp' getObject_inv | wpc | simp
-                        | wp (once) hoare_drop_imps )+
+                     apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
+                                     apply (wp mapM_x_wp' handleFault_obj_at'_tcbIPCBuffer getObject_inv | wpc | simp
+                                       | wp (once) hoare_drop_imps )+
+                    apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
+                               apply (wp setCTE_obj_at'_tcbIPCBuffer assert_inv mapM_x_wp' getObject_inv | wpc | simp
+                                 | wp (once) hoare_drop_imps )+
 
                    apply (simp add: bind_assoc catch_liftE
                                     receiveIPC_def Let_def liftM_def

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -3287,16 +3287,14 @@ shows
     apply (rule_tac isBlocking=isBlocking and isCall=isCall and buffer=buffer
                 in decodeUntypedInvocation_ccorres_helper[unfolded K_def])
     apply assumption
-   apply (rule monadic_rewrite_transverse)
+   apply (rule monadic_rewrite_trans[rotated])
     apply (rule monadic_rewrite_bind_head)
-    apply (rule monadic_rewrite_bindE[OF monadic_rewrite_refl])
-     apply (simp add: liftE_bindE stateAssert_def2 bind_assoc)
-     apply (rule monadic_rewrite_bind_tail)
-      apply (rule_tac P=x in monadic_rewrite_gen_asm)
-      apply simp
+    apply (simp add: liftE_bindE stateAssert_def2 bind_assoc)
+    apply (monadic_rewrite_r monadic_rewrite_if_r_True)
+    apply (monadic_rewrite_r_method monadic_rewrite_symb_exec_r_drop wpsimp)
       apply (rule monadic_rewrite_refl)
-     apply (wp | simp)+
-   apply (simp add: gets_bind_ign)
+     apply wpsimp
+    apply (rule monadic_rewrite_refl)
    apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: ex_cte_cap_wp_to'_def excaps_in_mem_def)
   apply (drule(1) bspec)+

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -438,6 +438,19 @@ end
 
 context kernel_m begin interpretation Arch .
 
+lemma asUser_mapMloadWordUser_threadGet_comm:
+  "do
+     ra \<leftarrow> mapM loadWordUser xs;
+     rb \<leftarrow> threadGet fb b;
+     c ra rb
+   od = do
+     rb \<leftarrow> threadGet fb b;
+     ra \<leftarrow> mapM loadWordUser xs;
+     c ra rb
+   od"
+  by (rule bind_inv_inv_comm, auto; wp mapM_wp')
+
+
 lemma handleFaultReply':
   notes option.case_cong_weak [cong] wordSize_def'[simp] take_append[simp del]
   assumes neq: "s \<noteq> r"
@@ -461,32 +474,32 @@ lemma handleFaultReply':
                             zip_Cons ARM_H.exceptionMessage_def
                             ARM.exceptionMessage_def
                             mapM_x_Cons mapM_x_Nil)
-      apply (rule monadic_rewrite_symb_exec_l, wp+)
-       apply (rule_tac P="tcb_at' s and tcb_at' r" in monadic_rewrite_inst)
-       apply (case_tac rv; (case_tac "msgLength tag < scast n_msgRegisters",
-               (erule disjE[OF word_less_cases],
-                 ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
-                                  mapM_x_Cons mapM_x_Nil bind_assoc
-                                  asUser_getRegister_discarded
-                                  asUser_getRegister_getSanitiseRegisterInfo_comm
-                                  asUser_mapMloadWordUser_getSanitiseRegisterInfo_comm
-                                  asUser_comm[OF neq]
-                                  bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
-                                  word_le_nat_alt[of 4, simplified linorder_not_less[symmetric, of 4]]
-                                  asUser_return submonad_asUser.fn_stateAssert
-                 | rule monadic_rewrite_bind_tail monadic_rewrite_refl
-                        monadic_rewrite_symb_exec_l[OF stateAssert_inv]
-                        monadic_rewrite_symb_exec_l[OF mapM_x_mapM_valid[OF mapM_x_wp']]
-                 | wp lookupIPCBuffer_inv )+)+))
-      apply wp
+      apply (rule monadic_rewrite_symb_exec_l)
+         apply (rule_tac P="tcb_at' s and tcb_at' r" in monadic_rewrite_inst)
+         apply (case_tac sb; (case_tac "msgLength tag < scast n_msgRegisters",
+                 (erule disjE[OF word_less_cases],
+                   ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
+                                    mapM_x_Cons mapM_x_Nil bind_assoc
+                                    asUser_mapMloadWordUser_getSanitiseRegisterInfo_comm
+                                    asUser_getRegister_getSanitiseRegisterInfo_comm
+                                    asUser_getRegister_discarded asUser_mapMloadWordUser_threadGet_comm
+                                    asUser_comm[OF neq] asUser_getRegister_threadGet_comm
+                                    bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
+                                    word_le_nat_alt[of 4, simplified linorder_not_less[symmetric, of 4]]
+                                    asUser_return submonad_asUser.fn_stateAssert
+                   | rule monadic_rewrite_bind_tail monadic_rewrite_refl
+                          monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
+                          monadic_rewrite_symb_exec_l[OF _ mapM_x_mapM_valid[OF mapM_x_wp']]
+                   | wp)+)+))
+        apply wp+
      (* capFault *)
-     apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_asUser empty_fail_getRegister)+)+
-          apply(case_tac rv)
-          apply (clarsimp
-                | rule monadic_rewrite_bind_tail monadic_rewrite_refl
-                       monadic_rewrite_symb_exec_l[OF mapM_x_mapM_valid[OF mapM_x_wp']]
-                | wp mapM_x_mapM_valid[OF mapM_x_wp'[OF loadWordUser_inv]]
-                     empty_fail_loadWordUser)+
+     apply (repeat 5 \<open>rule monadic_rewrite_symb_exec_l\<close>) (* until case sb *)
+                    apply (case_tac sb)
+                     apply (clarsimp
+                           | rule monadic_rewrite_bind_tail monadic_rewrite_refl
+                                  monadic_rewrite_symb_exec_l[OF _ mapM_x_mapM_valid[OF mapM_x_wp']]
+                           | wp mapM_x_mapM_valid[OF mapM_x_wp'[OF loadWordUser_inv]]
+                                empty_fail_loadWordUser)+
     (* UnknownSyscallExceptio *)
     apply (simp add: zip_append2 mapM_x_append asUser_bind_distrib split_def bind_assoc)
     apply (rule monadic_rewrite_guard_imp)
@@ -515,78 +528,78 @@ lemma handleFaultReply':
                             upto_enum_word mapM_x_Cons mapM_x_Nil)
      apply (simp add: getSanitiseRegisterInfo_moreMapM_comm asUser_getRegister_getSanitiseRegisterInfo_comm getSanitiseRegisterInfo_lookupIPCBuffer_comm)
      apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_bind_tail [where Q="\<lambda>_. tcb_at' r"])
-      apply (case_tac sb)
+      apply (rule monadic_rewrite_bind_tail [where Q="\<lambda>_. tcb_at' r"])
+       apply (case_tac sb)
+        apply (case_tac "msgLength tag < scast n_msgRegisters")
+         apply (erule disjE[OF word_less_cases],
+                  ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
+                                   mapM_x_Cons mapM_x_Nil bind_assoc
+                                   asUser_getRegister_discarded
+                                   asUser_comm[OF neq] take_zip
+                                   word_le_nat_alt[of 4, simplified linorder_not_less[symmetric, of 4]]
+                                   asUser_return submonad_asUser.fn_stateAssert
+                  | rule monadic_rewrite_bind_tail monadic_rewrite_refl
+                         monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
+                  | wp)+)+
        apply (case_tac "msgLength tag < scast n_msgRegisters")
         apply (erule disjE[OF word_less_cases],
-                 ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
-                                  mapM_x_Cons mapM_x_Nil bind_assoc
-                                  asUser_getRegister_discarded
-                                  asUser_comm[OF neq] take_zip
-                                  word_le_nat_alt[of 4, simplified linorder_not_less[symmetric, of 4]]
-                                  asUser_return submonad_asUser.fn_stateAssert
-                 | rule monadic_rewrite_bind_tail monadic_rewrite_refl
-                        monadic_rewrite_symb_exec_l[OF stateAssert_inv]
-                 | wp)+)+
-      apply (case_tac "msgLength tag < scast n_msgRegisters")
-       apply (erule disjE[OF word_less_cases],
-                 ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
-                                  mapM_x_Cons mapM_x_Nil bind_assoc
-                                  zipWithM_x_Nil
-                                  asUser_getRegister_discarded
-                                  asUser_comm[OF neq] take_zip
-                                  bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
-                                  asUser_return submonad_asUser.fn_stateAssert
-                 | rule monadic_rewrite_bind_tail monadic_rewrite_refl
-                        monadic_rewrite_symb_exec_l[OF mapM_x_mapM_valid[OF mapM_x_wp']]
-                        monadic_rewrite_symb_exec_l[OF stateAssert_inv]
-                 | wp mapM_wp')+)+
-      apply (simp add: n_msgRegisters_def word_le_nat_alt n_syscallMessage_def
-                       linorder_not_less syscallMessage_unfold)
-      apply (clarsimp | frule neq0_conv[THEN iffD2, THEN not0_implies_Suc,
-                                        OF order_less_le_trans, rotated])+
-      apply (subgoal_tac "\<forall>n :: word32. n \<le> scast n_syscallMessage \<longrightarrow> [n .e. msgMaxLength]
-                                = [n .e. scast n_syscallMessage]
-                                    @ [scast n_syscallMessage + 1 .e. msgMaxLength]")
-       apply (simp only: upto_enum_word[where y="scast n_syscallMessage :: word32"]
-                         upto_enum_word[where y="scast n_syscallMessage + 1 :: word32"])
-       apply (clarsimp simp: bind_assoc asUser_bind_distrib
-                             mapM_x_Cons mapM_x_Nil
-                             asUser_comm [OF neq] asUser_getRegister_discarded
-                             submonad_asUser.fn_stateAssert take_zip
-                             bind_subst_lift [OF submonad_asUser.stateAssert_fn]
-                             word_less_nat_alt ARM_H.sanitiseRegister_def
-                             split_def n_msgRegisters_def msgMaxLength_def
-                             bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
-                             word_size msgLengthBits_def n_syscallMessage_def
-                  split del: if_split
-                       cong: if_weak_cong)
-       apply (rule monadic_rewrite_bind_tail)+
-               apply (subst (2) upto_enum_word)
-               apply (case_tac "ma < unat n_syscallMessage - 4")
-                apply (erule disjE[OF nat_less_cases'],
-                       ( clarsimp simp: n_syscallMessage_def bind_assoc asUser_bind_distrib
-                                        mapM_x_Cons mapM_x_Nil zipWithM_x_mapM_x mapM_Cons
-                                        bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
-                                        asUser_loadWordUser_comm loadWordUser_discarded asUser_return
-                                        zip_take_triv2 msgMaxLength_def
-                                  cong: if_weak_cong
-                       | simp
-                       | rule monadic_rewrite_bind_tail
-                              monadic_rewrite_refl
-                              monadic_rewrite_symb_exec_l[OF stateAssert_inv]
-                              monadic_rewrite_symb_exec_l[OF mapM_x_mapM_valid[OF mapM_x_wp']]
-                       | wp empty_fail_loadWordUser)+)+
-      apply (clarsimp simp: upto_enum_word word_le_nat_alt simp del: upt.simps cong: if_weak_cong)
-      apply (cut_tac i="unat n" and j="Suc (unat (scast n_syscallMessage :: word32))"
-                                and k="Suc msgMaxLength" in upt_add_eq_append')
-        apply (simp add: n_syscallMessage_def)
-       apply (simp add: n_syscallMessage_def msgMaxLength_unfold)
-      apply (simp add: n_syscallMessage_def msgMaxLength_def
-                       msgLengthBits_def shiftL_nat
-                  del: upt.simps upt_rec_numeral)
-      apply (simp add: upto_enum_word cong: if_weak_cong)
-     apply wp+
+                  ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
+                                   mapM_x_Cons mapM_x_Nil bind_assoc
+                                   zipWithM_x_Nil
+                                   asUser_getRegister_discarded
+                                   asUser_comm[OF neq] take_zip
+                                   bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
+                                   asUser_return submonad_asUser.fn_stateAssert
+                  | rule monadic_rewrite_bind_tail monadic_rewrite_refl
+                         monadic_rewrite_symb_exec_l[OF _ mapM_x_mapM_valid[OF mapM_x_wp']]
+                         monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
+                  | wp mapM_wp')+)+
+       apply (simp add: n_msgRegisters_def word_le_nat_alt n_syscallMessage_def
+                        linorder_not_less syscallMessage_unfold)
+       apply (clarsimp | frule neq0_conv[THEN iffD2, THEN not0_implies_Suc,
+                                         OF order_less_le_trans, rotated])+
+       apply (subgoal_tac "\<forall>n :: word32. n \<le> scast n_syscallMessage \<longrightarrow> [n .e. msgMaxLength]
+                                 = [n .e. scast n_syscallMessage]
+                                     @ [scast n_syscallMessage + 1 .e. msgMaxLength]")
+        apply (simp only: upto_enum_word[where y="scast n_syscallMessage :: word32"]
+                          upto_enum_word[where y="scast n_syscallMessage + 1 :: word32"])
+        apply (clarsimp simp: bind_assoc asUser_bind_distrib
+                              mapM_x_Cons mapM_x_Nil
+                              asUser_comm [OF neq] asUser_getRegister_discarded
+                              submonad_asUser.fn_stateAssert take_zip
+                              bind_subst_lift [OF submonad_asUser.stateAssert_fn]
+                              word_less_nat_alt ARM_H.sanitiseRegister_def
+                              split_def n_msgRegisters_def msgMaxLength_def
+                              bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
+                              word_size msgLengthBits_def n_syscallMessage_def
+                   split del: if_split
+                        cong: if_weak_cong)
+        apply (rule monadic_rewrite_bind_tail)+
+                apply (subst (2) upto_enum_word)
+                apply (case_tac "ma < unat n_syscallMessage - 4")
+                 apply (erule disjE[OF nat_less_cases'],
+                        ( clarsimp simp: n_syscallMessage_def bind_assoc asUser_bind_distrib
+                                         mapM_x_Cons mapM_x_Nil zipWithM_x_mapM_x mapM_Cons
+                                         bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
+                                         asUser_loadWordUser_comm loadWordUser_discarded asUser_return
+                                         zip_take_triv2 msgMaxLength_def
+                                   cong: if_weak_cong
+                        | simp
+                        | rule monadic_rewrite_bind_tail
+                               monadic_rewrite_refl
+                               monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
+                               monadic_rewrite_symb_exec_l[OF _ mapM_x_mapM_valid[OF mapM_x_wp']]
+                        | wp empty_fail_loadWordUser)+)+
+       apply (clarsimp simp: upto_enum_word word_le_nat_alt simp del: upt.simps cong: if_weak_cong)
+       apply (cut_tac i="unat n" and j="Suc (unat (scast n_syscallMessage :: word32))"
+                                 and k="Suc msgMaxLength" in upt_add_eq_append')
+         apply (simp add: n_syscallMessage_def)
+        apply (simp add: n_syscallMessage_def msgMaxLength_unfold)
+       apply (simp add: n_syscallMessage_def msgMaxLength_def
+                        msgLengthBits_def shiftL_nat
+                   del: upt.simps upt_rec_numeral)
+       apply (simp add: upto_enum_word cong: if_weak_cong)
+      apply wp+
     (* ArchFault *)
     apply (simp add: neq inj_case_bool split: bool.split)
    apply (rule monadic_rewrite_guard_imp)

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -489,13 +489,13 @@ lemma handleFaultReply':
                      empty_fail_loadWordUser)+
     (* UnknownSyscallExceptio *)
     apply (simp add: zip_append2 mapM_x_append asUser_bind_distrib split_def bind_assoc)
-    apply (rule monadic_rewrite_imp)
+    apply (rule monadic_rewrite_guard_imp)
      apply (rule monadic_rewrite_trans[rotated])
       apply (rule monadic_rewrite_do_flip)
       apply (rule monadic_rewrite_bind_tail)
        apply (rule_tac P="inj (case_bool s r)" in monadic_rewrite_gen_asm)
        apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
-         apply (rule monadic_rewrite_weaken[where F=False and E=True], simp)
+         apply (rule monadic_rewrite_weaken_flags[where F=False and E=True], simp)
          apply (rule isolate_thread_actions_rewrite_bind
                      bool.simps setRegister_simple
                      zipWithM_setRegister_simple
@@ -589,7 +589,7 @@ lemma handleFaultReply':
      apply wp+
     (* ArchFault *)
     apply (simp add: neq inj_case_bool split: bool.split)
-   apply (rule monadic_rewrite_imp)
+   apply (rule monadic_rewrite_guard_imp)
     apply (rule monadic_rewrite_is_refl)
     apply (rule ext)
     apply (unfold handleArchFaultReply'[symmetric] getMRs_def msgMaxLength_def

--- a/proof/crefine/ARM/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM/IsolatedThreadAction.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/crefine/ARM/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM/IsolatedThreadAction.thy
@@ -674,10 +674,9 @@ lemma transferCaps_simple_rewrite:
    (return (mi \<lparr> msgExtraCaps := 0, msgCapsUnwrapped := 0 \<rparr>))"
   including no_pre
   apply (rule monadic_rewrite_gen_asm)
+  apply (simp add: transferCaps_simple)
   apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (simp add: transferCaps_simple, rule monadic_rewrite_refl)
-   apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getReceiveSlots)+)
+   apply (rule monadic_rewrite_symb_exec_drop[OF _ empty_fail_getReceiveSlots], wp+)
    apply (rule monadic_rewrite_refl)
   apply simp
   done
@@ -1195,17 +1194,12 @@ lemma switchToThread_rewrite:
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
   apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_bind)
-     apply (rule tcbSchedDequeue_rewrite)
-      apply (rule monadic_rewrite_refl)
-     apply (wp Arch_switchToThread_obj_at_pre)+
    apply (rule monadic_rewrite_bind_tail)
-    apply (rule monadic_rewrite_symb_exec)
-       apply (wp+, simp)
+    apply (rule monadic_rewrite_trans)
+     apply (rule monadic_rewrite_bind_head[OF tcbSchedDequeue_rewrite])
+    apply (rule monadic_rewrite_symb_exec_drop, wp+)
     apply (rule monadic_rewrite_refl)
-   apply (wp)
+   apply (wp Arch_switchToThread_obj_at_pre)+
   apply (clarsimp simp: comp_def)
   done
 

--- a/proof/crefine/ARM/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM/IsolatedThreadAction.thy
@@ -496,7 +496,7 @@ lemma thread_actions_isolatable_bind:
        \<And>t. \<lbrace>tcb_at' t\<rbrace> f \<lbrace>\<lambda>rv. tcb_at' t\<rbrace> \<rbrakk>
      \<Longrightarrow> thread_actions_isolatable idx (f >>= g)"
   apply (clarsimp simp: thread_actions_isolatable_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (erule monadic_rewrite_bind2, assumption)
     apply (rule hoare_vcg_all_lift, assumption)
@@ -569,7 +569,7 @@ lemma select_f_isolatable:
   apply (clarsimp simp: thread_actions_isolatable_def
                         isolate_thread_actions_def
                         split_def select_f_selects liftM_def bind_assoc)
-  apply (rule monadic_rewrite_imp, rule monadic_rewrite_transverse)
+  apply (rule monadic_rewrite_guard_imp, rule monadic_rewrite_transverse)
     apply (rule monadic_rewrite_drop_modify monadic_rewrite_bind_tail)+
        apply wp+
    apply (simp add: gets_bind_ign getSchedulerAction_def)
@@ -674,7 +674,7 @@ lemma transferCaps_simple_rewrite:
    (return (mi \<lparr> msgExtraCaps := 0, msgCapsUnwrapped := 0 \<rparr>))"
   including no_pre
   apply (rule monadic_rewrite_gen_asm)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (simp add: transferCaps_simple, rule monadic_rewrite_refl)
    apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getReceiveSlots)+)
@@ -729,7 +729,7 @@ lemma doIPCTransfer_simple_rewrite:
   apply (simp add: doIPCTransfer_def bind_assoc doNormalTransfer_def
                    getMessageInfo_def
              cong: option.case_cong)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)+
       apply (rule_tac P="fault = None" in monadic_rewrite_gen_asm, simp)
@@ -777,7 +777,7 @@ lemma setupCallerCap_rewrite:
   apply (simp add: setupCallerCap_def getThreadCallerSlot_def
                    getThreadReplySlot_def locateSlot_conv
                    getSlotCap_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_bind_tail)+
      apply (rule monadic_rewrite_assert)+
      apply (rule_tac P="mdbFirstBadged (cteMDBNode masterCTE)
@@ -871,7 +871,7 @@ lemma activateThread_simple_rewrite:
   "monadic_rewrite True True (ct_in_state' ((=) Running))
        (activateThread) (return ())"
   apply (simp add: activateThread_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans, rule monadic_rewrite_bind_tail)+
        apply (rule_tac P="state = Running" in monadic_rewrite_gen_asm)
        apply simp
@@ -1175,7 +1175,7 @@ lemma thread_actions_isolatableD:
 lemma tcbSchedDequeue_rewrite:
   "monadic_rewrite True True (obj_at' (Not \<circ> tcbQueued) t) (tcbSchedDequeue t) (return ())"
   apply (simp add: tcbSchedDequeue_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule_tac P="\<not> queued" in monadic_rewrite_gen_asm)
@@ -1194,7 +1194,7 @@ lemma switchToThread_rewrite:
        (switchToThread t)
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule monadic_rewrite_bind)
@@ -1274,7 +1274,7 @@ lemma isolate_thread_actions_rewrite_bind:
     \<Longrightarrow> monadic_rewrite False True (\<lambda>s. \<forall>x. tcb_at' (idx x) s)
                (f >>= g) (isolate_thread_actions idx
                                   (f' >>= g') (g'' o f'') (g''' o f'''))"
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind, assumption+)
     apply (wp isolate_thread_actions_tcbs_at)
@@ -1356,7 +1356,7 @@ lemma monadic_rewrite_isolate_final2:
          (isolate_thread_actions idx f f' f'')
          (isolate_thread_actions idx g g' g'')"
   apply (simp add: isolate_thread_actions_def split_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_bind_tail)+
       apply (rule_tac P="\<lambda> s'. Q s" in monadic_rewrite_bind)
         apply (insert mr)[1]
@@ -1391,7 +1391,7 @@ lemma copy_registers_isolate_general:
                          select_f_returns o_def ksPSpace_update_partial_id)
    apply (simp add: return_def simpler_modify_def)
   apply (simp add: mapM_x_Cons)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule isolate_thread_actions_rewrite_bind, assumption)
         apply (rule copy_register_isolate, assumption+)
@@ -1486,7 +1486,7 @@ lemma setThreadState_rewrite_simple:
      (threadSet (tcbState_update (\<lambda>_. st)) t)"
   supply if_split[split del]
   apply (simp add: setThreadState_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule monadic_rewrite_trans)

--- a/proof/crefine/ARM/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM/IsolatedThreadAction.thy
@@ -8,25 +8,8 @@ theory IsolatedThreadAction
 imports ArchMove_C
 begin
 
-datatype tcb_state_regs = TCBStateRegs "thread_state" "MachineTypes.register \<Rightarrow> machine_word"
-
-definition
- "tsrContext tsr \<equiv> case tsr of TCBStateRegs ts regs \<Rightarrow> regs"
-
-definition
- "tsrState tsr \<equiv> case tsr of TCBStateRegs ts regs \<Rightarrow> ts"
-
-lemma accessors_TCBStateRegs[simp]:
-  "TCBStateRegs (tsrState v) (tsrContext v) = v"
-  by (cases v, simp add: tsrState_def tsrContext_def)
-
-lemma tsrContext_simp[simp]:
-  "tsrContext (TCBStateRegs st con) = con"
-  by (simp add: tsrContext_def)
-
-lemma tsrState_simp[simp]:
-  "tsrState (TCBStateRegs st con) = st"
-  by (simp add: tsrState_def)
+datatype tcb_state_regs =
+  TCBStateRegs (tsrState : thread_state) (tsrContext : "MachineTypes.register \<Rightarrow> machine_word")
 
 definition
   get_tcb_state_regs :: "kernel_object option \<Rightarrow> tcb_state_regs"

--- a/proof/crefine/ARM/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM/IsolatedThreadAction.thy
@@ -676,9 +676,8 @@ lemma transferCaps_simple_rewrite:
   apply (rule monadic_rewrite_gen_asm)
   apply (simp add: transferCaps_simple)
   apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_drop[OF _ empty_fail_getReceiveSlots], wp+)
-   apply (rule monadic_rewrite_refl)
-  apply simp
+   apply (rule monadic_rewrite_symb_exec_l_drop[OF monadic_rewrite_refl _ empty_fail_getReceiveSlots])
+   apply wpsimp+
   done
 
 lemma lookupExtraCaps_simple_rewrite:
@@ -691,7 +690,8 @@ lemma lookupExtraCaps_simple_rewrite:
 lemma lookupIPC_inv: "\<lbrace>P\<rbrace> lookupIPCBuffer f t \<lbrace>\<lambda>rv. P\<rbrace>"
   by wp
 
-lemmas empty_fail_user_getreg = empty_fail_asUser[OF empty_fail_getRegister]
+(* FIXME move *)
+lemmas empty_fail_user_getreg[intro!, wp, simp] = empty_fail_asUser[OF empty_fail_getRegister]
 
 lemma copyMRs_simple:
   "msglen \<le> of_nat (length msgRegisters) \<longrightarrow>
@@ -733,20 +733,18 @@ lemma doIPCTransfer_simple_rewrite:
     apply (rule monadic_rewrite_bind_tail)+
       apply (rule_tac P="fault = None" in monadic_rewrite_gen_asm, simp)
       apply (rule monadic_rewrite_bind_tail)
-       apply (rule_tac x=msgInfo in monadic_rewrite_symb_exec,
-              (wp empty_fail_user_getreg user_getreg_rv)+)
-       apply (simp add: lookupExtraCaps_simple_rewrite returnOk_catch_bind)
-       apply (rule monadic_rewrite_bind)
-         apply (rule monadic_rewrite_from_simple, rule copyMRs_simple)
-        apply (rule monadic_rewrite_bind_head)
-        apply (rule transferCaps_simple_rewrite)
-       apply (wp threadGet_const)+
+       apply (rule_tac rv=msgInfo in monadic_rewrite_symb_exec_l_known_F)
+          apply (simp add: lookupExtraCaps_simple_rewrite returnOk_catch_bind)
+          apply (rule monadic_rewrite_bind)
+            apply (rule monadic_rewrite_from_simple, rule copyMRs_simple)
+           apply (rule monadic_rewrite_bind_head)
+           apply (rule transferCaps_simple_rewrite)
+          apply (wp threadGet_const user_getreg_rv asUser_inv)+
    apply (simp add: bind_assoc)
-   apply (rule monadic_rewrite_symb_exec_drop[OF lookupIPC_inv empty_fail_lookupIPCBuffer]
-               monadic_rewrite_symb_exec_drop[OF threadGet_inv empty_fail_threadGet]
-               monadic_rewrite_symb_exec_drop[OF user_getreg_inv' empty_fail_user_getreg]
-               monadic_rewrite_bind_head monadic_rewrite_bind_tail
-                  | wp)+
+   apply (rule monadic_rewrite_symb_exec_l_drop[OF _ lookupIPC_inv empty_fail_lookupIPCBuffer]
+               monadic_rewrite_symb_exec_l_drop[OF _ threadGet_inv empty_fail_threadGet]
+               monadic_rewrite_symb_exec_l_drop[OF _ user_getreg_inv' empty_fail_user_getreg]
+               monadic_rewrite_bind_head monadic_rewrite_bind_tail)+
     apply (case_tac "messageInfoFromWord msgInfo")
     apply simp
     apply (rule monadic_rewrite_refl)
@@ -755,7 +753,8 @@ lemma doIPCTransfer_simple_rewrite:
   apply (auto elim!: obj_at'_weakenE)
   done
 
-lemma empty_fail_isRunnable:
+(* FIXME move *)
+lemma empty_fail_isRunnable[intro!, wp, simp]:
   "empty_fail (isRunnable t)"
   by (simp add: isRunnable_def isStopped_def)
 
@@ -785,12 +784,12 @@ lemma setupCallerCap_rewrite:
      apply simp
      apply (rule monadic_rewrite_trans)
       apply (rule monadic_rewrite_bind_tail)
-       apply (rule monadic_rewrite_symb_exec_drop, (wp | simp)+)+
+       apply (rule monadic_rewrite_symb_exec_l_drop)+
+         apply (rule monadic_rewrite_refl)
+        apply wpsimp+
+     apply (rule monadic_rewrite_symb_exec_l_drop)+
        apply (rule monadic_rewrite_refl)
-      apply wp+
-     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getCTE)+)+
-     apply (rule monadic_rewrite_refl)
-    apply (wp getCTE_wp' | simp add: cte_wp_at_ctes_of)+
+      apply (wp getCTE_wp' | simp add: cte_wp_at_ctes_of)+
   apply (clarsimp simp: reply_masters_rvk_fb_def)
   apply fastforce
   done
@@ -864,8 +863,10 @@ lemma oblivious_switchToThread_schact:
   by (safe intro!: oblivious_bind
               | simp_all add: oblivious_setVMRoot_schact)+
 
-lemma empty_fail_getCurThread[iff]:
+(* FIXME move *)
+lemma empty_fail_getCurThread[intro!, wp, simp]:
   "empty_fail getCurThread" by (simp add: getCurThread_def)
+
 lemma activateThread_simple_rewrite:
   "monadic_rewrite True True (ct_in_state' ((=) Running))
        (activateThread) (return ())"
@@ -876,10 +877,10 @@ lemma activateThread_simple_rewrite:
        apply simp
        apply (rule monadic_rewrite_refl)
       apply wp
-     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getThreadState)+)
-     apply (rule monadic_rewrite_refl)
-    apply wp
-   apply (rule monadic_rewrite_symb_exec_drop,
+     apply (rule monadic_rewrite_symb_exec_l_drop)
+       apply (rule monadic_rewrite_refl)
+      apply (wp empty_fail_getThreadState)+
+   apply (rule monadic_rewrite_symb_exec_l_drop,
           simp_all add: getCurThread_def)
    apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: ct_in_state'_def elim!: pred_tcb'_weakenE)
@@ -1181,9 +1182,9 @@ lemma tcbSchedDequeue_rewrite:
      apply (simp add: when_def)
      apply (rule monadic_rewrite_refl)
     apply (wp threadGet_const)
-   apply (rule monadic_rewrite_symb_exec_drop)
-      apply wp+
-   apply (rule monadic_rewrite_refl)
+   apply (rule monadic_rewrite_symb_exec_l_drop)
+     apply (rule monadic_rewrite_refl)
+    apply wp+
   apply (clarsimp)
   done
 
@@ -1197,9 +1198,9 @@ lemma switchToThread_rewrite:
    apply (rule monadic_rewrite_bind_tail)
     apply (rule monadic_rewrite_trans)
      apply (rule monadic_rewrite_bind_head[OF tcbSchedDequeue_rewrite])
-    apply (rule monadic_rewrite_symb_exec_drop, wp+)
-    apply (rule monadic_rewrite_refl)
-   apply (wp Arch_switchToThread_obj_at_pre)+
+    apply (rule monadic_rewrite_symb_exec_l_drop)
+      apply (rule monadic_rewrite_refl)
+     apply (wp Arch_switchToThread_obj_at_pre)+
   apply (clarsimp simp: comp_def)
   done
 
@@ -1358,7 +1359,7 @@ lemma monadic_rewrite_isolate_final2:
         apply auto[1]
        apply (rule_tac P="P and (\<lambda>s. tcbs = get_tcb_state_regs o ksPSpace s o idx
                                              \<and> sa = ksSchedulerAction s)"
-                    in monadic_rewrite_pre_imp_refl)
+                    in monadic_rewrite_pre_imp_eq)
        apply (clarsimp simp: exec_modify eqs return_def)
       apply wp+
   apply (clarsimp simp: o_def eqs)
@@ -1479,27 +1480,18 @@ lemma setThreadState_rewrite_simple:
      (setThreadState st t)
      (threadSet (tcbState_update (\<lambda>_. st)) t)"
   supply if_split[split del]
-  apply (simp add: setThreadState_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_trans)
-      apply (rule monadic_rewrite_bind_tail)+
-         apply (simp add: when_def)
-         apply (rule monadic_rewrite_gen_asm)
-         apply (subst if_not_P)
-          apply assumption
-         apply (rule monadic_rewrite_refl)
-        apply wp+
-     apply (rule monadic_rewrite_symb_exec_drop,
-            (wp  empty_fail_isRunnable
-               | (simp only: getCurThread_def getSchedulerAction_def
-                      , rule empty_fail_gets))+)+
-     apply (rule monadic_rewrite_refl)
-    apply (simp add: conj_comms, wp hoare_vcg_imp_lift threadSet_tcbState_st_tcb_at')
-     apply (clarsimp simp: obj_at'_def sch_act_simple_def st_tcb_at'_def)
+  apply (simp add: setThreadState_def when_def)
+  apply (monadic_rewrite_l
+           \<open>wpsimp wp: hoare_vcg_disj_lift hoare_vcg_imp_lift' threadSet_tcbState_st_tcb_at'\<close>
+           r: monadic_rewrite_if_l_False)
+   (* take the threadSet, drop everything until return () *)
+   apply (rule monadic_rewrite_trans[OF monadic_rewrite_bind_tail])
+     apply (rule monadic_rewrite_symb_exec_l_drop)+
+           apply (rule monadic_rewrite_refl)
+          apply (wpsimp simp: getCurThread_def
+                        wp: hoare_vcg_disj_lift hoare_vcg_imp_lift' threadSet_tcbState_st_tcb_at')+
    apply (rule monadic_rewrite_refl)
-  apply clarsimp
+  apply (clarsimp simp: obj_at'_def sch_act_simple_def st_tcb_at'_def)
   done
 
 end

--- a/proof/crefine/ARM/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM/IsolatedThreadAction.thy
@@ -498,13 +498,13 @@ lemma thread_actions_isolatable_bind:
   apply (clarsimp simp: thread_actions_isolatable_def)
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
-    apply (erule monadic_rewrite_bind2, assumption)
+    apply (erule monadic_rewrite_bind_l, assumption)
     apply (rule hoare_vcg_all_lift, assumption)
    apply (subst isolate_thread_actions_wrap_bind, simp)
    apply simp
    apply (rule monadic_rewrite_in_isolate_thread_actions, assumption)
    apply (rule monadic_rewrite_transverse)
-    apply (erule monadic_rewrite_bind2, assumption)
+    apply (erule monadic_rewrite_bind_l, assumption)
     apply (rule hoare_vcg_all_lift, assumption)
    apply (simp add: bind_assoc id_def)
    apply (rule monadic_rewrite_refl)
@@ -677,7 +677,7 @@ lemma transferCaps_simple_rewrite:
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (simp add: transferCaps_simple, rule monadic_rewrite_refl)
-   apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getReceiveSlots)+)
+   apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getReceiveSlots)+)
    apply (rule monadic_rewrite_refl)
   apply simp
   done
@@ -743,9 +743,9 @@ lemma doIPCTransfer_simple_rewrite:
         apply (rule transferCaps_simple_rewrite)
        apply (wp threadGet_const)+
    apply (simp add: bind_assoc)
-   apply (rule monadic_rewrite_symb_exec2[OF lookupIPC_inv empty_fail_lookupIPCBuffer]
-               monadic_rewrite_symb_exec2[OF threadGet_inv empty_fail_threadGet]
-               monadic_rewrite_symb_exec2[OF user_getreg_inv' empty_fail_user_getreg]
+   apply (rule monadic_rewrite_symb_exec_drop[OF lookupIPC_inv empty_fail_lookupIPCBuffer]
+               monadic_rewrite_symb_exec_drop[OF threadGet_inv empty_fail_threadGet]
+               monadic_rewrite_symb_exec_drop[OF user_getreg_inv' empty_fail_user_getreg]
                monadic_rewrite_bind_head monadic_rewrite_bind_tail
                   | wp)+
     apply (case_tac "messageInfoFromWord msgInfo")
@@ -786,10 +786,10 @@ lemma setupCallerCap_rewrite:
      apply simp
      apply (rule monadic_rewrite_trans)
       apply (rule monadic_rewrite_bind_tail)
-       apply (rule monadic_rewrite_symb_exec2, (wp | simp)+)+
+       apply (rule monadic_rewrite_symb_exec_drop, (wp | simp)+)+
        apply (rule monadic_rewrite_refl)
       apply wp+
-     apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getCTE)+)+
+     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getCTE)+)+
      apply (rule monadic_rewrite_refl)
     apply (wp getCTE_wp' | simp add: cte_wp_at_ctes_of)+
   apply (clarsimp simp: reply_masters_rvk_fb_def)
@@ -877,10 +877,10 @@ lemma activateThread_simple_rewrite:
        apply simp
        apply (rule monadic_rewrite_refl)
       apply wp
-     apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getThreadState)+)
+     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getThreadState)+)
      apply (rule monadic_rewrite_refl)
     apply wp
-   apply (rule monadic_rewrite_symb_exec2,
+   apply (rule monadic_rewrite_symb_exec_drop,
           simp_all add: getCurThread_def)
    apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: ct_in_state'_def elim!: pred_tcb'_weakenE)
@@ -1182,7 +1182,7 @@ lemma tcbSchedDequeue_rewrite:
      apply (simp add: when_def)
      apply (rule monadic_rewrite_refl)
     apply (wp threadGet_const)
-   apply (rule monadic_rewrite_symb_exec2)
+   apply (rule monadic_rewrite_symb_exec_drop)
       apply wp+
    apply (rule monadic_rewrite_refl)
   apply (clarsimp)
@@ -1282,7 +1282,7 @@ lemma isolate_thread_actions_rewrite_bind:
    apply (subst isolate_thread_actions_wrap_bind, assumption)
    apply (rule monadic_rewrite_in_isolate_thread_actions, assumption)
    apply (rule monadic_rewrite_transverse)
-    apply (rule monadic_rewrite_bind2)
+    apply (rule monadic_rewrite_bind_l)
       apply (erule(1) thread_actions_isolatableD)
      apply (rule thread_actions_isolatableD, assumption+)
     apply (rule hoare_vcg_all_lift, assumption)
@@ -1364,14 +1364,14 @@ lemma monadic_rewrite_isolate_final2:
         apply auto[1]
        apply (rule_tac P="P and (\<lambda>s. tcbs = get_tcb_state_regs o ksPSpace s o idx
                                              \<and> sa = ksSchedulerAction s)"
-                    in monadic_rewrite_refl3)
+                    in monadic_rewrite_pre_imp_refl)
        apply (clarsimp simp: exec_modify eqs return_def)
       apply wp+
   apply (clarsimp simp: o_def eqs)
   done
 
 lemmas monadic_rewrite_isolate_final
-    = monadic_rewrite_isolate_final2[where R=\<top>, OF monadic_rewrite_refl2, simplified]
+    = monadic_rewrite_isolate_final2[where R=\<top>, OF monadic_rewrite_is_refl, simplified]
 
 lemma copy_registers_isolate_general:
   "\<lbrakk> inj idx; idx x = t; idx y = t' \<rbrakk> \<Longrightarrow>
@@ -1497,7 +1497,7 @@ lemma setThreadState_rewrite_simple:
           apply assumption
          apply (rule monadic_rewrite_refl)
         apply wp+
-     apply (rule monadic_rewrite_symb_exec2,
+     apply (rule monadic_rewrite_symb_exec_drop,
             (wp  empty_fail_isRunnable
                | (simp only: getCurThread_def getSchedulerAction_def
                       , rule empty_fail_gets))+)+

--- a/proof/crefine/ARM/Refine_C.thy
+++ b/proof/crefine/ARM/Refine_C.thy
@@ -1115,7 +1115,7 @@ lemma kernel_all_subset_kernel:
                     check_active_irq_H_def checkActiveIRQ_def)
        apply clarsimp
        apply (erule in_monad_imp_rewriteE[where F=True])
-        apply (rule monadic_rewrite_imp)
+        apply (rule monadic_rewrite_guard_imp)
          apply (rule monadic_rewrite_bind_tail)+
            apply (rule monadic_rewrite_bind_head[where P=\<top>])
            apply (simp add: callKernel_C_def callKernel_withFastpath_C_def

--- a/proof/crefine/ARM/Schedule_C.thy
+++ b/proof/crefine/ARM/Schedule_C.thy
@@ -248,8 +248,6 @@ proof -
             apply (rule conseqPre, vcg)
             apply clarsimp
            apply (wp isRunnable_wp)+
-         apply (simp add: isRunnable_def)
-        apply wp
        apply (clarsimp simp: Let_def guard_is_UNIV_def)
        apply (drule invs_no_cicd'_queues)
        apply (case_tac queue, simp)

--- a/proof/crefine/ARM_HYP/ArchMove_C.thy
+++ b/proof/crefine/ARM_HYP/ArchMove_C.thy
@@ -530,6 +530,12 @@ lemma placeNewObject_creates_object_vcpu:
   apply (fastforce intro: ps_clear_entire_slotI simp add: field_simps)
   done
 
+(* FIXME would be interesting to generalise these kinds of lemmas to other KOs *)
+lemma placeNewObject_object_at_vcpu:
+  "\<lbrace> \<top> \<rbrace> placeNewObject v (vcpu::vcpu) 0 \<lbrace> \<lambda>_. vcpu_at' v \<rbrace>"
+  by (rule hoare_post_imp[OF _ placeNewObject_creates_object_vcpu])
+     (fastforce simp: ko_at_vcpu_at'D)
+
 lemma valid_untyped':
   notes usableUntypedRange.simps[simp del]
   assumes pspace_distinct': "pspace_distinct' s" and

--- a/proof/crefine/ARM_HYP/Fastpath_C.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/crefine/ARM_HYP/Fastpath_C.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_C.thy
@@ -655,15 +655,12 @@ lemma armv_contextSwitch_HWASID_fp_rewrite:
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_gets_l)
    apply (rule monadic_rewrite_symb_exec_l)
-      apply (wpsimp)+
-     apply (simp add: empty_fail_findPDForASID empty_fail_catch)
-    apply (rule monadic_rewrite_assert monadic_rewrite_gets_l)+
-    apply (rule_tac P="asidMap asid \<noteq> None \<and> fst (the (asidMap asid)) = the (pde_stored_asid v)"
-        in monadic_rewrite_gen_asm)
-    apply (simp only: case_option_If2 simp_thms if_True if_False
-                      split_def, simp)
-    apply (rule monadic_rewrite_refl)
-   apply (wp findPDForASID_pd_at_wp | simp only: const_def)+
+      apply (rule monadic_rewrite_assert monadic_rewrite_gets_l)+
+      apply (rule_tac P="asidMap asid \<noteq> None \<and> fst (the (asidMap asid)) = the (pde_stored_asid v)"
+               in monadic_rewrite_gen_asm)
+      apply (simp add: case_option_If2 split_def)
+      apply (rule monadic_rewrite_refl)
+     apply (wpsimp wp: findPDForASID_pd_at_wp simp: empty_fail_catch)+
   apply (clarsimp simp: pd_has_hwasid_def cte_level_bits_def
                         field_simps cte_wp_at_ctes_of
                         word_0_sle_from_less

--- a/proof/crefine/ARM_HYP/Fastpath_C.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_C.thy
@@ -652,7 +652,7 @@ lemma armv_contextSwitch_HWASID_fp_rewrite:
                         checkPDAt_def checkPDUniqueToASID_def
                         checkPDASIDMapMembership_def
                         stateAssert_def2[folded assert_def])
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_gets_l)
    apply (rule monadic_rewrite_symb_exec_l)
       apply (wpsimp)+

--- a/proof/crefine/ARM_HYP/Fastpath_C.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_C.thy
@@ -652,10 +652,7 @@ lemma armv_contextSwitch_HWASID_fp_rewrite:
                         checkPDAt_def checkPDUniqueToASID_def
                         checkPDASIDMapMembership_def
                         stateAssert_def2[folded assert_def])
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_gets_l)
-   apply (rule monadic_rewrite_symb_exec_l)
-      apply (rule monadic_rewrite_assert monadic_rewrite_gets_l)+
+  apply (wp_pre, repeat 9 monadic_rewrite_symb_exec_l) (* until hwasid <- *)
       apply (rule_tac P="asidMap asid \<noteq> None \<and> fst (the (asidMap asid)) = the (pde_stored_asid v)"
                in monadic_rewrite_gen_asm)
       apply (simp add: case_option_If2 split_def)

--- a/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
@@ -479,7 +479,7 @@ lemma monadic_rewrite_threadGet:
    apply (rule monadic_rewrite_symb_exec_l' | wp | rule empty_fail_getObject getObject_inv)+
      apply (clarsimp; rule no_fail_getObject_tcb)
     apply (simp only: exec_gets)
-    apply (rule_tac P = "(\<lambda>s. (f x)=v) and tcb_at' t" in monadic_rewrite_refl3)
+    apply (rule_tac P = "(\<lambda>s. (f x)=v) and tcb_at' t" in monadic_rewrite_pre_imp_refl)
     apply (simp add:)
    apply (wp OMG_getObject_tcb | wpc)+
   apply (auto intro: obj_tcb_at')
@@ -634,7 +634,7 @@ lemma fastpath_callKernel_SysCall_corres:
                       apply (rule monadic_rewrite_bind_tail, rename_tac dest_st)
                        apply (rule_tac P="\<exists>gr. dest_st = BlockedOnReceive (capEPPtr (fst (theRight rv))) gr"
                                 in monadic_rewrite_gen_asm)
-                       apply (rule monadic_rewrite_symb_exec2, (wp | simp)+)
+                       apply (rule monadic_rewrite_symb_exec_drop, (wp | simp)+)
                        apply (rule monadic_rewrite_bind)
                          apply clarsimp
                          apply (rule_tac msgInfo=msgInfo in doIPCTransfer_simple_rewrite)
@@ -884,7 +884,7 @@ lemma receiveIPC_simple_rewrite:
         apply (rule hoare_pre, wpc, wp+, simp)
        apply (simp split: option.split)
       apply (rule monadic_rewrite_trans, rule monadic_rewrite_if_known[where X=False], simp)
-      apply (rule monadic_rewrite_refl3[where P=\<top>])
+      apply (rule monadic_rewrite_pre_imp_refl[where P=\<top>])
       apply (cases ep, simp_all add: isSendEP_def)[1]
      apply (wp getNotification_wp gbn_wp' getEndpoint_wp | wpc)+
   apply (clarsimp simp: obj_at'_def projectKOs pred_tcb_at'_def)
@@ -1143,7 +1143,7 @@ lemma setEndpoint_setCTE_pivot[unfolded K_bind_def]:
                      | simp)+
       apply (rule_tac P="\<lambda>s. epat = ep_at' p s \<and> cteat = real_cte_at' slot s
                            \<and> tcbat = (tcb_at' (slot && ~~ mask 9) and (%y. slot && mask 9 : dom tcb_cte_cases)) s"
-                   in monadic_rewrite_refl3)
+                   in monadic_rewrite_pre_imp_refl)
       apply (simp add: setEndpoint_def setObject_modify_assert bind_assoc
                        exec_gets assert_def exec_modify
                 split: if_split)
@@ -1257,7 +1257,7 @@ lemma set_setCTE[unfolded K_bind_def]:
                                  (\<exists> getF setF. tcb_cte_cases (p && mask 9) = Some (getF, setF)
                                         \<and> (\<forall> f g tcb. setF f (setF g tcb) = setF (f o g) tcb)))"
                    in monadic_rewrite_gen_asm)
-       apply (rule monadic_rewrite_refl2)
+       apply (rule monadic_rewrite_is_refl[OF ext])
        apply (simp add: exec_modify split: if_split)
        apply (auto simp: simpler_modify_def projectKO_opt_tcb objBits_defs
                     del: ext
@@ -1330,7 +1330,7 @@ lemma emptySlot_replymaster_rewrite[OF refl]:
      apply (rule monadic_rewrite_bind)
        apply (rule_tac P="mdbFirstBadged (cteMDBNode ctea) \<and> mdbRevocable (cteMDBNode ctea)"
                    in monadic_rewrite_gen_asm)
-       apply (rule monadic_rewrite_refl2)
+       apply (rule monadic_rewrite_is_refl)
        apply (case_tac ctea, rename_tac mdbnode, case_tac mdbnode)
        apply simp
       apply (simp add: Retype_H.postCapDeletion_def)
@@ -1753,7 +1753,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                          apply (rule monadic_rewrite_assert)
                          apply (simp add: emptySlot_setEndpoint_pivot)
                          apply (rule monadic_rewrite_bind)
-                           apply (rule monadic_rewrite_refl2)
+                           apply (rule monadic_rewrite_is_refl)
                            apply (clarsimp simp: isSendEP_def split: Structures_H.endpoint.split)
                           apply (rule_tac Q="\<lambda>rv. (\<lambda>_. rv = callerCTE) and Q'" for Q'
                                               in monadic_rewrite_symb_exec_r, wp+)

--- a/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
@@ -479,7 +479,7 @@ lemma monadic_rewrite_threadGet:
    apply (rule monadic_rewrite_symb_exec_l' | wp | rule empty_fail_getObject getObject_inv)+
      apply (clarsimp; rule no_fail_getObject_tcb)
     apply (simp only: exec_gets)
-    apply (rule_tac P = "(\<lambda>s. (f x)=v) and tcb_at' t" in monadic_rewrite_pre_imp_refl)
+    apply (rule_tac P = "(\<lambda>s. (f x)=v) and tcb_at' t" in monadic_rewrite_pre_imp_eq)
     apply (simp add:)
    apply (wp OMG_getObject_tcb | wpc)+
   apply (auto intro: obj_tcb_at')
@@ -884,7 +884,7 @@ lemma receiveIPC_simple_rewrite:
         apply (rule hoare_pre, wpc, wp+, simp)
        apply (simp split: option.split)
       apply (rule monadic_rewrite_trans, rule monadic_rewrite_if_known[where X=False], simp)
-      apply (rule monadic_rewrite_pre_imp_refl[where P=\<top>])
+      apply (rule monadic_rewrite_pre_imp_eq[where P=\<top>])
       apply (cases ep, simp_all add: isSendEP_def)[1]
      apply (wp getNotification_wp gbn_wp' getEndpoint_wp | wpc)+
   apply (clarsimp simp: obj_at'_def projectKOs pred_tcb_at'_def)
@@ -1143,7 +1143,7 @@ lemma setEndpoint_setCTE_pivot[unfolded K_bind_def]:
                      | simp)+
       apply (rule_tac P="\<lambda>s. epat = ep_at' p s \<and> cteat = real_cte_at' slot s
                            \<and> tcbat = (tcb_at' (slot && ~~ mask 9) and (%y. slot && mask 9 : dom tcb_cte_cases)) s"
-                   in monadic_rewrite_pre_imp_refl)
+                   in monadic_rewrite_pre_imp_eq)
       apply (simp add: setEndpoint_def setObject_modify_assert bind_assoc
                        exec_gets assert_def exec_modify
                 split: if_split)

--- a/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
@@ -313,8 +313,6 @@ lemma threadSet_tcbState_valid_objs:
   apply (clarsimp simp: valid_tcb'_def tcb_cte_cases_def)
   done
 
-lemmas monadic_rewrite_symb_exec_l' = monadic_rewrite_symb_exec_l'_preserve_names
-
 lemma possibleSwitchTo_rewrite:
   "monadic_rewrite True True
           (\<lambda>s. obj_at' (\<lambda>tcb. tcbPriority tcb = destPrio \<and> tcbDomain tcb = destDom) t s
@@ -325,7 +323,7 @@ lemma possibleSwitchTo_rewrite:
     (possibleSwitchTo t) (setSchedulerAction (SwitchToThread t))"
   supply if_split[split del]
   apply (simp add: possibleSwitchTo_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule monadic_rewrite_symb_exec_l'[OF threadGet_inv empty_fail_threadGet,
@@ -417,7 +415,7 @@ lemma schedule_rewrite_ct_not_runnable':
             (do setSchedulerAction ResumeCurrentThread; switchToThread t od)"
   supply subst_all [simp del]
   apply (simp add: schedule_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule monadic_rewrite_bind_tail)
@@ -483,7 +481,7 @@ lemma monadic_rewrite_threadGet:
   "monadic_rewrite E F (obj_at' (\<lambda>tcb. f tcb = v) t)
     (threadGet f t) (return v)"
   unfolding getThreadState_def
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans[rotated])
     apply (rule monadic_rewrite_gets_known)
    apply (unfold threadGet_def liftM_def fun_app_def)
@@ -544,7 +542,7 @@ lemma fastpath_callKernel_SysCall_corres:
   supply if_cong[cong] option.case_cong[cong] if_split[split del]
   apply (rule monadic_rewrite_introduce_alternative)
    apply (simp add: callKernel_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (simp add: handleEvent_def handleCall_def
                     handleInvocation_def liftE_bindE_handle
                     bind_assoc getMessageInfo_def)
@@ -633,7 +631,7 @@ lemma fastpath_callKernel_SysCall_corres:
                   apply (rule monadic_rewrite_symb_exec_l[OF get_mrs_inv' empty_fail_getMRs])
                    (* now committed to fastpath *)
                    apply (rule monadic_rewrite_trans)
-                    apply (rule_tac F=True and E=True in monadic_rewrite_weaken)
+                    apply (rule_tac F=True and E=True in monadic_rewrite_weaken_flags)
                     apply simp
                     apply (rule monadic_rewrite_bind_tail)
                      apply (rule_tac x=thread in monadic_rewrite_symb_exec,
@@ -743,7 +741,7 @@ lemma fastpath_callKernel_SysCall_corres:
                    apply (rule_tac P="inj (case_bool thread (hd (epQueue send_ep)))"
                             in monadic_rewrite_gen_asm)
                    apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
-                     apply (rule monadic_rewrite_weaken[where F=False and E=True], simp)
+                     apply (rule monadic_rewrite_weaken_flags[where F=False and E=True], simp)
                      apply (rule isolate_thread_actions_rewrite_bind
                                  fastpath_isolate_rewrites fastpath_isolatables
                                  bool.simps setRegister_simple
@@ -760,7 +758,7 @@ lemma fastpath_callKernel_SysCall_corres:
                               | wp assert_inv)+
                    apply (rule_tac P="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                                        \<and> tcb_at' thread s"
-                              and F=True and E=False in monadic_rewrite_weaken)
+                              and F=True and E=False in monadic_rewrite_weaken_flags)
                    apply simp
                    apply (rule monadic_rewrite_isolate_final)
                      apply (simp add: isRight_case_sum cong: list.case_cong)
@@ -890,7 +888,7 @@ lemma receiveIPC_simple_rewrite:
       od)"
   apply (rule monadic_rewrite_gen_asm)
   apply (simp add: receiveIPC_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule_tac rv=ep in monadic_rewrite_symb_exec_l_known,
           (wp empty_fail_getEndpoint)+)
     apply (rule monadic_rewrite_symb_exec_l, (wp | simp add: getBoundNotification_def)+)
@@ -914,7 +912,7 @@ lemma cteDeleteOne_replycap_rewrite:
      (cteDeleteOne slot)
      (emptySlot slot NullCap)"
   apply (simp add: cteDeleteOne_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_getCTE)+)
     apply (rule_tac P="cteCap rv \<noteq> NullCap \<and> isReplyCap (cteCap rv)
                           \<and> \<not> isEndpointCap (cteCap rv)
@@ -935,7 +933,7 @@ lemma cteDeleteOne_nullcap_rewrite:
      (cteDeleteOne slot)
      (return ())"
   apply (simp add: cteDeleteOne_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_getCTE)+)
     apply (rule_tac P="cteCap rv = NullCap" in monadic_rewrite_gen_asm)
     apply simp
@@ -951,7 +949,7 @@ lemma deleteCallerCap_nullcap_rewrite:
      (return ())"
   apply (simp add: deleteCallerCap_def getThreadCallerSlot_def locateSlot_conv
                    getSlotCap_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
   apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_getCTE)+)
     apply (rule monadic_rewrite_assert)
     apply (rule cteDeleteOne_nullcap_rewrite)
@@ -1014,7 +1012,7 @@ crunch only_cnode_caps[wp]: doFaultTransfer "\<lambda>s. P (only_cnode_caps (cte
 
 lemma tcbSchedDequeue_rewrite_not_queued: "monadic_rewrite True False (tcb_at' t and obj_at' (Not \<circ> tcbQueued) t) (tcbSchedDequeue t) (return ())"
   apply (simp add: tcbSchedDequeue_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule_tac P="\<not> queued" in monadic_rewrite_gen_asm)
@@ -1045,7 +1043,7 @@ lemma schedule_known_rewrite:
   supply subst_all[simp del] if_split[split del]
   apply (simp add: schedule_def)
   apply (simp only: Thread_H.switchToThread_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule monadic_rewrite_bind_tail)
@@ -1138,7 +1136,7 @@ lemma setEndpoint_setCTE_pivot[unfolded K_bind_def]:
   supply if_split[split del]
   apply (rule monadic_rewrite_to_eq)
   apply simp
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans,
           rule_tac f="ep_at' p" in monadic_rewrite_add_gets)
    apply (rule monadic_rewrite_transverse, rule monadic_rewrite_add_gets,
@@ -1234,7 +1232,7 @@ lemma set_getCTE[unfolded K_bind_def]:
       = do setCTE p cte; f cte od"
   apply simp
   apply (rule monadic_rewrite_to_eq)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_bind_tail)
     apply (simp add: getCTE_assert_opt bind_assoc)
     apply (rule monadic_rewrite_trans,
@@ -1250,7 +1248,7 @@ lemma set_setCTE[unfolded K_bind_def]:
   supply if_split[split del]
   apply simp
   apply (rule monadic_rewrite_to_eq)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans,
           rule_tac f="real_cte_at' p" in monadic_rewrite_add_gets)
    apply (rule monadic_rewrite_transverse, rule monadic_rewrite_add_gets,
@@ -1308,7 +1306,7 @@ lemma clearUntypedFreeIndex_simple_rewrite:
   apply (simp add: clearUntypedFreeIndex_def getSlotCap_def)
   apply (rule monadic_rewrite_name_pre)
   apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule_tac rv=cte in monadic_rewrite_symb_exec_l_known, wp+)
     apply (simp split: capability.split,
       strengthen monadic_rewrite_refl, simp)
@@ -1335,7 +1333,7 @@ lemma emptySlot_replymaster_rewrite[OF refl]:
       od)"
   supply if_split[split del] word_neq_0_conv[simp del]
   apply (rule monadic_rewrite_gen_asm)+
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule_tac P="slot \<noteq> 0" in monadic_rewrite_gen_asm)
    apply (clarsimp simp: emptySlot_def setCTE_updateCapMDB)
    apply (rule monadic_rewrite_trans)
@@ -1407,7 +1405,7 @@ lemma resolveAddressBitsFn_eq_name_slot:
         \<and> valid_objs' s \<and> cnode_caps_gsCNodes' s)
     (resolveAddressBits cap capptr bits)
     (gets (resolveAddressBitsFn cap capptr bits o only_cnode_caps o ctes_of))"
-  apply (rule monadic_rewrite_imp, rule resolveAddressBitsFn_eq)
+  apply (rule monadic_rewrite_guard_imp, rule resolveAddressBitsFn_eq)
   apply auto
   done
 
@@ -1467,7 +1465,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
   supply if_split[split del]
   apply (rule monadic_rewrite_introduce_alternative)
    apply ( simp add: callKernel_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (simp add: handleEvent_def handleReply_def
                     handleRecv_def liftE_bindE_handle liftE_handle
                     bind_assoc getMessageInfo_def liftE_bind)
@@ -1593,7 +1591,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                      apply (rule monadic_rewrite_trans)
                       apply (rule doReplyTransfer_simple)
                      apply simp
-                     apply (((rule monadic_rewrite_weaken2,
+                     apply (((rule monadic_rewrite_weaken_flags',
                              (rule_tac msgInfo=msgInfo in doIPCTransfer_simple_rewrite
                            | rule_tac destPrio=callerPrio
                                             and curDom=curDom and destDom=callerDom
@@ -1644,7 +1642,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                             apply (wp, simp)
                            apply (rule monadic_rewrite_bind_head)
 
-                           apply (rule monadic_rewrite_weaken[where E=True and F=True], simp)
+                           apply (rule monadic_rewrite_weaken_flags[where E=True and F=True], simp)
                            apply (rule setThreadState_rewrite_simple)
                           apply clarsimp
                           apply (wp getCTE_known_cap)+
@@ -1652,7 +1650,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                           apply (rule_tac t="capTCBPtr (cteCap replyCTE)"
                                       and t'=thread
                                        in schedule_known_rewrite)
-                         apply (rule monadic_rewrite_weaken[where E=True and F=True], simp)
+                         apply (rule monadic_rewrite_weaken_flags[where E=True and F=True], simp)
                          apply (rule monadic_rewrite_bind)
                            apply (rule activateThread_simple_rewrite)
                           apply (rule monadic_rewrite_refl)
@@ -1739,7 +1737,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                     apply (rule_tac P="inj (case_bool thread (capTCBPtr (cteCap replyCTE)))"
                                     in monadic_rewrite_gen_asm)
                     apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
-                      apply (rule monadic_rewrite_weaken[where F=False and E=True], simp)
+                      apply (rule monadic_rewrite_weaken_flags[where F=False and E=True], simp)
                       apply (rule isolate_thread_actions_rewrite_bind
                                   fastpath_isolate_rewrites fastpath_isolatables
                                   bool.simps setRegister_simple
@@ -1763,7 +1761,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                                                 (thread + 2 ^ cte_level_bits * tcbCallerSlot)
                                        and (\<lambda>s. \<forall>x. tcb_at' (case_bool thread (capTCBPtr (cteCap replyCTE)) x) s)
                                        and valid_mdb')"
-                                and F=True and E=False in monadic_rewrite_weaken)
+                                and F=True and E=False in monadic_rewrite_weaken_flags)
                     apply (rule monadic_rewrite_isolate_final2)
                        apply simp
                        apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_getCTE)+)

--- a/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
@@ -1,6 +1,6 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
- * Copyright 2020, Proofcraft Pty Ltd
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)

--- a/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
@@ -41,8 +41,8 @@ lemma tcbSchedEnqueue_tcbContext[wp]:
 
 lemma setCTE_tcbContext:
   "\<lbrace>obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>
-  setCTE slot cte
-  \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>"
+   setCTE slot cte
+   \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>"
   apply (simp add: setCTE_def)
   apply (rule setObject_cte_obj_at_tcb', simp_all)
   done
@@ -342,7 +342,7 @@ lemma lookupBitmapPriority_lift:
   unfolding lookupBitmapPriority_def
   apply (rule hoare_pre)
    apply (wps prqL1 prqL2)
-  apply wpsimp+
+   apply wpsimp+
   done
 
 (* slow path additionally requires current thread not idle *)
@@ -604,85 +604,85 @@ lemma fastpath_callKernel_SysCall_corres:
                     apply simp
                     apply (rule monadic_rewrite_bind_tail)
                      apply (monadic_rewrite_symb_exec_l_known thread)
-                     apply (simp add: sendIPC_def bind_assoc)
-                     apply (monadic_rewrite_symb_exec_l_known send_ep)
-                     apply (rule_tac P="epQueue send_ep \<noteq> []" in monadic_rewrite_gen_asm)
-                     apply (simp add: isRecvEP_endpoint_case list_case_helper bind_assoc)
-                     apply (rule monadic_rewrite_bind_tail)
-                      apply (elim conjE)
-                      apply (rule monadic_rewrite_bind_tail, rename_tac dest_st)
-                       apply (rule_tac P="\<exists>gr. dest_st = BlockedOnReceive (capEPPtr (fst (theRight rv))) gr"
-                                in monadic_rewrite_gen_asm)
-                       apply monadic_rewrite_symb_exec_l_drop
-                       apply (rule monadic_rewrite_bind)
-                         apply clarsimp
-                         apply (rule_tac msgInfo=msgInfo in doIPCTransfer_simple_rewrite)
-                        apply (rule monadic_rewrite_bind_tail)
+                      apply (simp add: sendIPC_def bind_assoc)
+                      apply (monadic_rewrite_symb_exec_l_known send_ep)
+                       apply (rule_tac P="epQueue send_ep \<noteq> []" in monadic_rewrite_gen_asm)
+                       apply (simp add: isRecvEP_endpoint_case list_case_helper bind_assoc)
+                       apply (rule monadic_rewrite_bind_tail)
+                        apply (elim conjE)
+                        apply (rule monadic_rewrite_bind_tail, rename_tac dest_st)
+                         apply (rule_tac P="\<exists>gr. dest_st = BlockedOnReceive (capEPPtr (fst (theRight rv))) gr"
+                                  in monadic_rewrite_gen_asm)
+                         apply monadic_rewrite_symb_exec_l_drop
                          apply (rule monadic_rewrite_bind)
-                           apply (rule_tac destPrio=destPrio
-                                    and curDom=curDom and destDom=destDom and thread=thread
-                                    in possibleSwitchTo_rewrite)
-                          apply (rule monadic_rewrite_bind)
-                            apply (rule monadic_rewrite_trans)
-                             apply (rule setupCallerCap_rewrite)
-                            apply (rule monadic_rewrite_bind_head)
-                            apply (rule setThreadState_rewrite_simple, simp)
-                           apply (rule monadic_rewrite_trans)
-                            apply (monadic_rewrite_symb_exec_l_known BlockedOnReply)
-                            apply simp
-                            apply (rule monadic_rewrite_refl)
-                            apply wpsimp (* FIXME indentation *)
-                           apply (rule monadic_rewrite_trans)
-                            apply (rule monadic_rewrite_bind_head)
-                            apply (rule_tac t="hd (epQueue send_ep)"
-                                     in schedule_rewrite_ct_not_runnable')
-                           apply (simp add: bind_assoc)
-                           apply (rule monadic_rewrite_bind_tail)
+                           apply clarsimp
+                           apply (rule_tac msgInfo=msgInfo in doIPCTransfer_simple_rewrite)
+                          apply (rule monadic_rewrite_bind_tail)
+                           apply (rule monadic_rewrite_bind)
+                             apply (rule_tac destPrio=destPrio
+                                      and curDom=curDom and destDom=destDom and thread=thread
+                                      in possibleSwitchTo_rewrite)
                             apply (rule monadic_rewrite_bind)
-                              apply (rule switchToThread_rewrite)
-                             apply (rule monadic_rewrite_bind)
-                               apply (rule activateThread_simple_rewrite)
-                              apply (rule monadic_rewrite_refl)
-                             apply wp
-                            apply (wp setCurThread_ct_in_state)
-                           apply (simp only: st_tcb_at'_def[symmetric])
-                           apply (wp, clarsimp simp: cur_tcb'_def ct_in_state'_def)
-                          apply (simp add: getThreadCallerSlot_def getThreadReplySlot_def
-                                           locateSlot_conv ct_in_state'_def cur_tcb'_def)
+                              apply (rule monadic_rewrite_trans)
+                               apply (rule setupCallerCap_rewrite)
+                              apply (rule monadic_rewrite_bind_head)
+                              apply (rule setThreadState_rewrite_simple, simp)
+                             apply (rule monadic_rewrite_trans)
+                              apply (monadic_rewrite_symb_exec_l_known BlockedOnReply)
+                               apply simp
+                               apply (rule monadic_rewrite_refl)
+                              apply wpsimp
+                             apply (rule monadic_rewrite_trans)
+                              apply (rule monadic_rewrite_bind_head)
+                              apply (rule_tac t="hd (epQueue send_ep)"
+                                       in schedule_rewrite_ct_not_runnable')
+                             apply (simp add: bind_assoc)
+                             apply (rule monadic_rewrite_bind_tail)
+                              apply (rule monadic_rewrite_bind)
+                                apply (rule switchToThread_rewrite)
+                               apply (rule monadic_rewrite_bind)
+                                 apply (rule activateThread_simple_rewrite)
+                                apply (rule monadic_rewrite_refl)
+                               apply wp
+                              apply (wp setCurThread_ct_in_state)
+                             apply (simp only: st_tcb_at'_def[symmetric])
+                             apply (wp, clarsimp simp: cur_tcb'_def ct_in_state'_def)
+                            apply (simp add: getThreadCallerSlot_def getThreadReplySlot_def
+                                             locateSlot_conv ct_in_state'_def cur_tcb'_def)
 
-                          apply ((wp assert_inv threadSet_pred_tcb_at_state
-                                     cteInsert_obj_at'_not_queued
-                                  | wps)+)[1]
+                            apply ((wp assert_inv threadSet_pred_tcb_at_state
+                                       cteInsert_obj_at'_not_queued
+                                    | wps)+)[1]
 
-                             apply (wp fastpathBestSwitchCandidate_lift[where f="cteInsert c w w'" for c w w'])
+                               apply (wp fastpathBestSwitchCandidate_lift[where f="cteInsert c w w'" for c w w'])
+                               apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
+                              apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
                              apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
                             apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
-                           apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
-                          apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
-                          apply (wp fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t])
-                           apply simp
-                          apply ((wp assert_inv threadSet_pred_tcb_at_state
-                                     cteInsert_obj_at'_not_queued
-                                  | wps)+)[1]
-                         apply (simp add: setSchedulerAction_def)
-                         apply wp[1]
-                        apply (simp cong: if_cong HOL.conj_cong add: if_bool_simps)
-                        apply (simp_all only:)[5]
-                        apply ((wp setThreadState_oa_queued[of _ "\<lambda>a _ _. \<not> a"]
-                                   setThreadState_obj_at_unchanged
-                                   asUser_obj_at_unchanged mapM_x_wp'
-                                   sts_st_tcb_at'_cases
-                                   setThreadState_no_sch_change
-                                   setEndpoint_obj_at_tcb'
-                                   fastpathBestSwitchCandidate_lift[where f="setThreadState f t" for f t]
-                                   setThreadState_oa_queued
-                                   fastpathBestSwitchCandidate_lift[where f="asUser t f" for f t]
-                                   fastpathBestSwitchCandidate_lift[where f="setEndpoint a b" for a b]
-                                   lookupBitmapPriority_lift
-                                   setThreadState_runnable_bitmap_inv
-                                   getEndpoint_obj_at'
-                                 | simp add: setMessageInfo_def
-                                 | wp (once) hoare_vcg_disj_lift)+)
+                            apply (wp fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t])
+                             apply simp
+                            apply ((wp assert_inv threadSet_pred_tcb_at_state
+                                       cteInsert_obj_at'_not_queued
+                                    | wps)+)[1]
+                           apply (simp add: setSchedulerAction_def)
+                           apply wp[1]
+                          apply (simp cong: if_cong HOL.conj_cong add: if_bool_simps)
+                          apply (simp_all only:)[5]
+                          apply ((wp setThreadState_oa_queued[of _ "\<lambda>a _ _. \<not> a"]
+                                     setThreadState_obj_at_unchanged
+                                     asUser_obj_at_unchanged mapM_x_wp'
+                                     sts_st_tcb_at'_cases
+                                     setThreadState_no_sch_change
+                                     setEndpoint_obj_at_tcb'
+                                     fastpathBestSwitchCandidate_lift[where f="setThreadState f t" for f t]
+                                     setThreadState_oa_queued
+                                     fastpathBestSwitchCandidate_lift[where f="asUser t f" for f t]
+                                     fastpathBestSwitchCandidate_lift[where f="setEndpoint a b" for a b]
+                                     lookupBitmapPriority_lift
+                                     setThreadState_runnable_bitmap_inv
+                                     getEndpoint_obj_at'
+                                   | simp add: setMessageInfo_def
+                                   | wp (once) hoare_vcg_disj_lift)+)
 
                    apply (simp add: setThreadState_runnable_simp
                                     getThreadCallerSlot_def getThreadReplySlot_def
@@ -696,15 +696,15 @@ lemma fastpath_callKernel_SysCall_corres:
                    apply (rename_tac destState)
 
                    apply (simp add: ARM_HYP_H.switchToThread_def getTCB_threadGet bind_assoc)
-                 (* retrieving state or thread registers is not thread_action_isolatable,
-                     translate into return with suitable precondition  *)
+                   (* retrieving state or thread registers is not thread_action_isolatable,
+                      translate into return with suitable precondition  *)
                    apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
                      apply (rule_tac v=destState in monadic_rewrite_getThreadState
                             | rule monadic_rewrite_bind monadic_rewrite_refl)+
-                                     apply (wp mapM_x_wp' getObject_inv | wpc | simp | wp (once) hoare_drop_imps)+
+                                      apply (wp mapM_x_wp' getObject_inv | wpc | simp | wp (once) hoare_drop_imps)+
                     apply (rule_tac v=destState in monadic_rewrite_getThreadState
                            | rule monadic_rewrite_bind monadic_rewrite_refl)+
-                                apply (wp mapM_x_wp' getObject_inv | wpc | simp | wp (once) hoare_drop_imps)+
+                                 apply (wp mapM_x_wp' getObject_inv | wpc | simp | wp (once) hoare_drop_imps)+
 
                    apply (rule_tac P="inj (case_bool thread (hd (epQueue send_ep)))"
                             in monadic_rewrite_gen_asm)
@@ -839,8 +839,8 @@ lemma doReplyTransfer_simple:
   apply (simp add: doReplyTransfer_def liftM_def nullPointer_def getSlotCap_def)
   apply (rule monadic_rewrite_bind_tail)+
         apply (monadic_rewrite_symb_exec_l_known None, simp)
-           apply (rule monadic_rewrite_refl)
-          apply (wpsimp wp: threadGet_const gts_wp' getCTE_wp' simp: o_def)+
+         apply (rule monadic_rewrite_refl)
+        apply (wpsimp wp: threadGet_const gts_wp' getCTE_wp' simp: o_def)+
   done
 
 lemma receiveIPC_simple_rewrite:
@@ -855,13 +855,13 @@ lemma receiveIPC_simple_rewrite:
   supply empty_fail_getEndpoint[wp]
   apply (rule monadic_rewrite_gen_asm)
   apply (simp add: receiveIPC_def)
-   apply (monadic_rewrite_symb_exec_l_known ep)
-      apply monadic_rewrite_symb_exec_l+
-            apply (monadic_rewrite_l monadic_rewrite_if_l_False)
-            apply (rule monadic_rewrite_is_refl)
-            apply (cases ep; simp add: isSendEP_def)
-           apply (wpsimp wp: getNotification_wp gbn_wp' getEndpoint_wp
-                         simp: getBoundNotification_def)+
+  apply (monadic_rewrite_symb_exec_l_known ep)
+    apply monadic_rewrite_symb_exec_l+
+       apply (monadic_rewrite_l monadic_rewrite_if_l_False)
+       apply (rule monadic_rewrite_is_refl)
+       apply (cases ep; simp add: isSendEP_def)
+      apply (wpsimp wp: getNotification_wp gbn_wp' getEndpoint_wp
+                    simp: getBoundNotification_def)+
   apply (clarsimp simp: obj_at'_def projectKOs pred_tcb_at'_def)
   done
 
@@ -896,7 +896,7 @@ lemma cteDeleteOne_nullcap_rewrite:
   apply (simp add: cteDeleteOne_def unless_def when_def)
   apply (monadic_rewrite_l monadic_rewrite_if_l_False \<open>wpsimp wp: getCTE_wp'\<close>)
    apply (monadic_rewrite_symb_exec_l, rule monadic_rewrite_refl)
-     apply (wpsimp wp: getCTE_wp' simp: cte_wp_at_ctes_of)+
+   apply (wpsimp wp: getCTE_wp' simp: cte_wp_at_ctes_of)+
   done
 
 lemma deleteCallerCap_nullcap_rewrite:
@@ -965,7 +965,7 @@ lemma tcbSchedDequeue_rewrite_not_queued:
   apply (simp add: tcbSchedDequeue_def when_def)
   apply (monadic_rewrite_l monadic_rewrite_if_l_False \<open>wp threadGet_const\<close>)
    apply (monadic_rewrite_symb_exec_l, rule monadic_rewrite_refl)
-     apply wp+
+   apply wp+
   apply (clarsimp simp: o_def obj_at'_def)
   done
 
@@ -1239,28 +1239,28 @@ lemma emptySlot_replymaster_rewrite[OF refl]:
   supply if_split[split del]
   apply (rule monadic_rewrite_gen_asm)+
   apply (rule monadic_rewrite_guard_imp)
-    apply (rule_tac P="slot \<noteq> 0" in monadic_rewrite_gen_asm)
+   apply (rule_tac P="slot \<noteq> 0" in monadic_rewrite_gen_asm)
    apply (clarsimp simp: emptySlot_def setCTE_updateCapMDB)
    apply (monadic_rewrite_l clearUntypedFreeIndex_simple_rewrite, simp)
    apply (monadic_rewrite_symb_exec_l_known cte)
-      apply (simp add: updateMDB_def Let_def bind_assoc makeObject_cte case_Null_If)
-      apply (rule monadic_rewrite_bind_tail)
-       apply (rule monadic_rewrite_bind)
-         apply (rule_tac P="mdbFirstBadged (cteMDBNode ctea) \<and> mdbRevocable (cteMDBNode ctea)"
-                     in monadic_rewrite_gen_asm)
-         apply (rule monadic_rewrite_is_refl)
-         apply (case_tac ctea, rename_tac mdbnode, case_tac mdbnode)
-         apply simp
-        apply (simp add: Retype_H.postCapDeletion_def)
-        apply (rule monadic_rewrite_refl)
-       apply (solves wp | wp getCTE_wp')+
+    apply (simp add: updateMDB_def Let_def bind_assoc makeObject_cte case_Null_If)
+    apply (rule monadic_rewrite_bind_tail)
+     apply (rule monadic_rewrite_bind)
+       apply (rule_tac P="mdbFirstBadged (cteMDBNode ctea) \<and> mdbRevocable (cteMDBNode ctea)"
+                   in monadic_rewrite_gen_asm)
+       apply (rule monadic_rewrite_is_refl)
+       apply (case_tac ctea, rename_tac mdbnode, case_tac mdbnode)
+       apply simp
+      apply (simp add: Retype_H.postCapDeletion_def)
+      apply (rule monadic_rewrite_refl)
+     apply (solves wp | wp getCTE_wp')+
   apply (clarsimp simp: cte_wp_at_ctes_of reply_masters_rvk_fb_def)
   apply (fastforce simp: isCap_simps)
   done
 
 lemma all_prio_not_inQ_not_tcbQueued: "\<lbrakk> obj_at' (\<lambda>a. (\<forall>d p. \<not> inQ d p a)) t s \<rbrakk> \<Longrightarrow> obj_at' (\<lambda>a. \<not> tcbQueued a) t s"
   apply (clarsimp simp: obj_at'_def inQ_def)
-done
+  done
 
 crunches setThreadState, emptySlot, asUser
   for ntfn_obj_at[wp]: "obj_at' (P::(Structures_H.notification \<Rightarrow> bool)) ntfnptr"
@@ -1279,11 +1279,11 @@ lemma st_tcb_at_is_Reply_imp_not_tcbQueued: "\<And>s t.\<lbrakk> invs' s; st_tcb
    apply (case_tac "tcbState obj")
           apply ((clarsimp simp: inQ_def)+)[8]
   apply (clarsimp simp: valid_queues'_def obj_at'_def)
-done
+  done
 
 lemma valid_objs_ntfn_at_tcbBoundNotification:
   "ko_at' tcb t s \<Longrightarrow> valid_objs' s \<Longrightarrow> tcbBoundNotification tcb \<noteq> None
-    \<Longrightarrow> ntfn_at' (the (tcbBoundNotification tcb)) s"
+   \<Longrightarrow> ntfn_at' (the (tcbBoundNotification tcb)) s"
   apply (drule(1) ko_at_valid_objs', simp add: projectKOs)
   apply (simp add: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def)
   apply clarsimp
@@ -1471,13 +1471,13 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                    apply (simp add: ARM_HYP_H.switchToThread_def bind_assoc)
                    apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
 
-                      apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
-                      apply (wp mapM_x_wp' getObject_inv | wpc | simp add:
-                        | wp (once) hoare_drop_imps )+
+                     apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
+                          apply (wp mapM_x_wp' getObject_inv | wpc | simp add:
+                            | wp (once) hoare_drop_imps )+
 
-                      apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
-                      apply (wp setCTE_obj_at'_tcbIPCBuffer assert_inv mapM_x_wp' getObject_inv | wpc | simp
-                        | wp (once) hoare_drop_imps )+
+                    apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
+                                 apply (wp setCTE_obj_at'_tcbIPCBuffer assert_inv mapM_x_wp' getObject_inv | wpc | simp
+                                   | wp (once) hoare_drop_imps )+
 
                    apply (rule monadic_rewrite_trans)
                     apply (rule monadic_rewrite_trans)
@@ -1567,23 +1567,23 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                                       static_imp_wp cnode_caps_gsCNodes_lift
                                       hoare_vcg_ex_lift
                           | wps)+
-                      apply (strengthen imp_consequent[where Q="tcb_at' t s" for t s])
-                      apply ((wp setThreadState_oa_queued user_getreg_rv setThreadState_no_sch_change
-                                 setThreadState_obj_at_unchanged
-                                 sts_st_tcb_at'_cases sts_bound_tcb_at'
-                                 emptySlot_obj_at'_not_queued emptySlot_obj_at_ep
-                                 emptySlot_tcbContext[simplified comp_apply]
-                                 emptySlot_cte_wp_at_cteCap
-                                 emptySlot_cnode_caps
-                                 user_getreg_inv asUser_typ_ats
-                                 asUser_obj_at_not_queued asUser_obj_at' mapM_x_wp'
-                                 static_imp_wp hoare_vcg_all_lift hoare_vcg_imp_lift
-                                 static_imp_wp cnode_caps_gsCNodes_lift
-                                 hoare_vcg_ex_lift
-                                 fastpathBestSwitchCandidate_lift[where f="emptySlot a b" for a b]
-                              | simp del: comp_apply
-                              | clarsimp simp: obj_at'_weakenE[OF _ TrueI]
-                              | wps)+)
+                           apply (strengthen imp_consequent[where Q="tcb_at' t s" for t s])
+                           apply ((wp setThreadState_oa_queued user_getreg_rv setThreadState_no_sch_change
+                                      setThreadState_obj_at_unchanged
+                                      sts_st_tcb_at'_cases sts_bound_tcb_at'
+                                      emptySlot_obj_at'_not_queued emptySlot_obj_at_ep
+                                      emptySlot_tcbContext[simplified comp_apply]
+                                      emptySlot_cte_wp_at_cteCap
+                                      emptySlot_cnode_caps
+                                      user_getreg_inv asUser_typ_ats
+                                      asUser_obj_at_not_queued asUser_obj_at' mapM_x_wp'
+                                      static_imp_wp hoare_vcg_all_lift hoare_vcg_imp_lift
+                                      static_imp_wp cnode_caps_gsCNodes_lift
+                                      hoare_vcg_ex_lift
+                                      fastpathBestSwitchCandidate_lift[where f="emptySlot a b" for a b]
+                                   | simp del: comp_apply
+                                   | clarsimp simp: obj_at'_weakenE[OF _ TrueI]
+                                   | wps)+)
 
                             apply (wpsimp wp: fastpathBestSwitchCandidate_lift[where f="asUser a b" for a b])+
                            apply (clarsimp cong: conj_cong)
@@ -1602,12 +1602,12 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                    apply (simp add: ARM_HYP_H.switchToThread_def getTCB_threadGet bind_assoc)
                    apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
 
-                      apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
-                      apply (wp mapM_x_wp' handleFault_obj_at'_tcbIPCBuffer getObject_inv | wpc | simp
-                        | wp (once) hoare_drop_imps )+
-                      apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
-                      apply (wp setCTE_obj_at'_tcbIPCBuffer assert_inv mapM_x_wp' getObject_inv | wpc | simp
-                        | wp (once) hoare_drop_imps )+
+                     apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
+                                       apply (wp mapM_x_wp' handleFault_obj_at'_tcbIPCBuffer getObject_inv | wpc | simp
+                                         | wp (once) hoare_drop_imps )+
+                    apply (rule monadic_rewrite_bind monadic_rewrite_refl)+
+                                 apply (wp setCTE_obj_at'_tcbIPCBuffer assert_inv mapM_x_wp' getObject_inv | wpc | simp
+                                   | wp (once) hoare_drop_imps )+
 
                    apply (simp add: bind_assoc catch_liftE
                                     receiveIPC_def Let_def liftM_def

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -3497,16 +3497,14 @@ shows
     apply (rule_tac isBlocking=isBlocking and isCall=isCall and buffer=buffer
                 in decodeUntypedInvocation_ccorres_helper[unfolded K_def])
     apply assumption
-   apply (rule monadic_rewrite_transverse)
+   apply (rule monadic_rewrite_trans[rotated])
     apply (rule monadic_rewrite_bind_head)
-    apply (rule monadic_rewrite_bindE[OF monadic_rewrite_refl])
-     apply (simp add: liftE_bindE stateAssert_def2 bind_assoc)
-     apply (rule monadic_rewrite_bind_tail)
-      apply (rule_tac P=x in monadic_rewrite_gen_asm)
-      apply simp
+    apply (simp add: liftE_bindE stateAssert_def2 bind_assoc)
+    apply (monadic_rewrite_r monadic_rewrite_if_r_True)
+    apply (monadic_rewrite_r_method monadic_rewrite_symb_exec_r_drop wpsimp)
       apply (rule monadic_rewrite_refl)
-     apply (wp | simp)+
-   apply (simp add: gets_bind_ign)
+     apply wpsimp
+    apply (rule monadic_rewrite_refl)
    apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: ex_cte_cap_wp_to'_def excaps_in_mem_def)
   apply (drule(1) bspec)+

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -583,9 +583,8 @@ lemma getSanitiseRegisterInfo_moreMapM_comm:
 
 lemma monadic_rewrite_threadGet_return:
   "monadic_rewrite True False (tcb_at' r) (return x) (do t \<leftarrow> threadGet f r; return x od)"
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
-    apply wpsimp+
+  apply (wp_pre, monadic_rewrite_symb_exec_r_drop)
+   apply (auto intro: monadic_rewrite_refl)
   done
 
 context begin interpretation Arch .
@@ -600,16 +599,14 @@ end
 
 lemma monadic_rewrite_getSanitiseRegisterInfo_return:
   "monadic_rewrite True False (tcb_at' r) (return x) (do t \<leftarrow> getSanitiseRegisterInfo r; return x od)"
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
-    apply wpsimp+
+  apply (wp_pre, monadic_rewrite_symb_exec_r_drop)
+   apply (auto intro: monadic_rewrite_refl)
   done
 
 lemma monadic_rewrite_getSanitiseRegisterInfo_drop:
   "monadic_rewrite True False (tcb_at' r) (d) (do t \<leftarrow> getSanitiseRegisterInfo r; d od)"
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
-    apply wpsimp+
+  apply (wp_pre, monadic_rewrite_symb_exec_r_drop)
+   apply (auto intro: monadic_rewrite_refl)
   done
 
 context kernel_m begin interpretation Arch .

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -677,13 +677,13 @@ lemma handleFaultReply':
                      empty_fail_loadWordUser)+
     (* UnknownSyscallException *)
     apply (simp add: zip_append2 mapM_x_append asUser_bind_distrib split_def bind_assoc)
-    apply (rule monadic_rewrite_imp)
+    apply (rule monadic_rewrite_guard_imp)
      apply (rule monadic_rewrite_trans[rotated])
       apply (rule monadic_rewrite_do_flip)
       apply (rule monadic_rewrite_bind_tail)
        apply (rule_tac P="inj (case_bool s r)" in monadic_rewrite_gen_asm)
        apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
-         apply (rule monadic_rewrite_weaken[where F=False and E=True], simp)
+         apply (rule monadic_rewrite_weaken_flags[where F=False and E=True], simp)
          apply (rule isolate_thread_actions_rewrite_bind
                      bool.simps setRegister_simple
                      zipWithM_setRegister_simple
@@ -785,7 +785,7 @@ lemma handleFaultReply':
      apply wp+
     (* ArchFault *)
     apply (simp add: neq inj_case_bool split: bool.split)
-   apply (rule monadic_rewrite_imp)
+   apply (rule monadic_rewrite_guard_imp)
     apply (rule monadic_rewrite_is_refl)
     apply (rule ext)
     apply (unfold handleArchFaultReply'[symmetric] getMRs_def msgMaxLength_def

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -581,13 +581,11 @@ lemma getSanitiseRegisterInfo_moreMapM_comm:
    apply (auto split: option.splits)
   done
 
-
 lemma monadic_rewrite_threadGet_return:
   "monadic_rewrite True False (tcb_at' r) (return x) (do t \<leftarrow> threadGet f r; return x od)"
-  apply (rule monadic_rewrite_symb_exec_r')
-     apply wp+
-   apply (rule monadic_rewrite_refl)
-  apply wp
+  apply (rule monadic_rewrite_guard_imp)
+   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
+    apply wpsimp+
   done
 
 context begin interpretation Arch .
@@ -602,18 +600,16 @@ end
 
 lemma monadic_rewrite_getSanitiseRegisterInfo_return:
   "monadic_rewrite True False (tcb_at' r) (return x) (do t \<leftarrow> getSanitiseRegisterInfo r; return x od)"
-  apply (rule monadic_rewrite_symb_exec_r')
-     apply wp+
-   apply (rule monadic_rewrite_refl)
-  apply wp
+  apply (rule monadic_rewrite_guard_imp)
+   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
+    apply wpsimp+
   done
 
 lemma monadic_rewrite_getSanitiseRegisterInfo_drop:
   "monadic_rewrite True False (tcb_at' r) (d) (do t \<leftarrow> getSanitiseRegisterInfo r; d od)"
-  apply (rule monadic_rewrite_symb_exec_r')
-     apply wp+
-   apply (rule monadic_rewrite_refl)
-  apply wp
+  apply (rule monadic_rewrite_guard_imp)
+   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
+    apply wpsimp+
   done
 
 context kernel_m begin interpretation Arch .
@@ -635,6 +631,7 @@ lemma handleFaultReply':
     handleFaultReply f r (msgLabel tag) msg
   od) (handleFaultReply' f s r)"
   supply if_cong[cong]
+  supply empty_fail_asUser[wp] empty_fail_getRegister[wp]
   apply (unfold handleFaultReply'_def getMRs_def msgMaxLength_def
                 bit_def msgLengthBits_def msgRegisters_unfold
                 fromIntegral_simp1 fromIntegral_simp2
@@ -649,32 +646,32 @@ lemma handleFaultReply':
                             zip_Cons ARM_HYP_H.exceptionMessage_def
                             ARM_HYP.exceptionMessage_def
                             mapM_x_Cons mapM_x_Nil)
-      apply (rule monadic_rewrite_symb_exec_l, wp+)
-       apply (rule_tac P="tcb_at' s and tcb_at' r" in monadic_rewrite_inst)
-       apply (case_tac rv; (case_tac "msgLength tag < scast n_msgRegisters",
-               (erule disjE[OF word_less_cases],
-                 ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
-                                  mapM_x_Cons mapM_x_Nil bind_assoc
-                                  asUser_mapMloadWordUser_getSanitiseRegisterInfo_comm
-                                  asUser_getRegister_getSanitiseRegisterInfo_comm
-                                  asUser_getRegister_discarded asUser_mapMloadWordUser_threadGet_comm
-                                  asUser_comm[OF neq] asUser_getRegister_threadGet_comm
-                                  bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
-                                  word_le_nat_alt[of 4, simplified linorder_not_less[symmetric, of 4]]
-                                  asUser_return submonad_asUser.fn_stateAssert
-                 | rule monadic_rewrite_bind_tail monadic_rewrite_refl
-                        monadic_rewrite_symb_exec_l[OF stateAssert_inv]
-                        monadic_rewrite_symb_exec_l[OF mapM_x_mapM_valid[OF mapM_x_wp']]
-                 | wp lookupIPCBuffer_inv )+)+))
-      apply wp
+      apply (rule monadic_rewrite_symb_exec_l)
+         apply (rule_tac P="tcb_at' s and tcb_at' r" in monadic_rewrite_inst)
+         apply (case_tac sb; (case_tac "msgLength tag < scast n_msgRegisters",
+                 (erule disjE[OF word_less_cases],
+                   ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
+                                    mapM_x_Cons mapM_x_Nil bind_assoc
+                                    asUser_mapMloadWordUser_getSanitiseRegisterInfo_comm
+                                    asUser_getRegister_getSanitiseRegisterInfo_comm
+                                    asUser_getRegister_discarded asUser_mapMloadWordUser_threadGet_comm
+                                    asUser_comm[OF neq] asUser_getRegister_threadGet_comm
+                                    bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
+                                    word_le_nat_alt[of 4, simplified linorder_not_less[symmetric, of 4]]
+                                    asUser_return submonad_asUser.fn_stateAssert
+                   | rule monadic_rewrite_bind_tail monadic_rewrite_refl
+                          monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
+                          monadic_rewrite_symb_exec_l[OF _ mapM_x_mapM_valid[OF mapM_x_wp']]
+                   | wp)+)+))
+        apply wp+
      (* capFault *)
-     apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_asUser empty_fail_getRegister)+)+
-          apply(case_tac rv)
-          apply (clarsimp
-                | rule monadic_rewrite_bind_tail monadic_rewrite_refl
-                       monadic_rewrite_symb_exec_l[OF mapM_x_mapM_valid[OF mapM_x_wp']]
-                | wp mapM_x_mapM_valid[OF mapM_x_wp'[OF loadWordUser_inv]]
-                     empty_fail_loadWordUser)+
+     apply (repeat 5 \<open>rule monadic_rewrite_symb_exec_l\<close>) (* until case sb *)
+                    apply (case_tac sb)
+                     apply (clarsimp
+                           | rule monadic_rewrite_bind_tail monadic_rewrite_refl
+                                  monadic_rewrite_symb_exec_l[OF _ mapM_x_mapM_valid[OF mapM_x_wp']]
+                           | wp mapM_x_mapM_valid[OF mapM_x_wp'[OF loadWordUser_inv]]
+                                empty_fail_loadWordUser)+
     (* UnknownSyscallException *)
     apply (simp add: zip_append2 mapM_x_append asUser_bind_distrib split_def bind_assoc)
     apply (rule monadic_rewrite_guard_imp)
@@ -703,86 +700,86 @@ lemma handleFaultReply':
                             upto_enum_word mapM_x_Cons mapM_x_Nil)
      apply (simp add: getSanitiseRegisterInfo_moreMapM_comm asUser_getRegister_getSanitiseRegisterInfo_comm getSanitiseRegisterInfo_lookupIPCBuffer_comm)
      apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_bind_tail [where Q="\<lambda>_. tcb_at' r"])
-      apply (case_tac sb)
+      apply (rule monadic_rewrite_bind_tail [where Q="\<lambda>_. tcb_at' r"])
+       apply (case_tac sb)
+        apply (case_tac "msgLength tag < scast n_msgRegisters")
+         apply (erule disjE[OF word_less_cases],
+                  ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
+                                   mapM_x_Cons mapM_x_Nil bind_assoc
+                                   asUser_getRegister_discarded
+                                   asUser_comm[OF neq] take_zip
+                                   word_le_nat_alt[of 4, simplified linorder_not_less[symmetric, of 4]]
+                                   asUser_return submonad_asUser.fn_stateAssert
+                  | rule monadic_rewrite_bind_tail monadic_rewrite_refl
+                         monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
+                  | wp)+)+
        apply (case_tac "msgLength tag < scast n_msgRegisters")
         apply (erule disjE[OF word_less_cases],
-                 ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
-                                  mapM_x_Cons mapM_x_Nil bind_assoc
-                                  asUser_getRegister_discarded
-                                  asUser_comm[OF neq] take_zip
-                                  word_le_nat_alt[of 4, simplified linorder_not_less[symmetric, of 4]]
-                                  asUser_return submonad_asUser.fn_stateAssert
-                 | rule monadic_rewrite_bind_tail monadic_rewrite_refl
-                        monadic_rewrite_symb_exec_l[OF stateAssert_inv]
-                 | wp)+)+
-      apply (case_tac "msgLength tag < scast n_msgRegisters")
-       apply (erule disjE[OF word_less_cases],
-                 ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
-                                  mapM_x_Cons mapM_x_Nil bind_assoc
-                                  zipWithM_x_Nil
-                                  asUser_getRegister_discarded
-                                  asUser_comm[OF neq] take_zip
-                                  bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
-                                  asUser_return submonad_asUser.fn_stateAssert
-                 | rule monadic_rewrite_bind_tail monadic_rewrite_refl
-                        monadic_rewrite_symb_exec_l[OF mapM_x_mapM_valid[OF mapM_x_wp']]
-                        monadic_rewrite_symb_exec_l[OF stateAssert_inv]
-                        monadic_rewrite_threadGet_return
-                        monadic_rewrite_getSanitiseRegisterInfo_return
-                 | wp mapM_wp')+)+
-      apply (simp add: n_msgRegisters_def word_le_nat_alt n_syscallMessage_def
-                       linorder_not_less syscallMessage_unfold)
-      apply (clarsimp | frule neq0_conv[THEN iffD2, THEN not0_implies_Suc,
-                                        OF order_less_le_trans, rotated])+
-      apply (subgoal_tac "\<forall>n :: word32. n \<le> scast n_syscallMessage \<longrightarrow> [n .e. msgMaxLength]
-                                = [n .e. scast n_syscallMessage]
-                                    @ [scast n_syscallMessage + 1 .e. msgMaxLength]")
-       apply (simp only: upto_enum_word[where y="scast n_syscallMessage :: word32"]
-                         upto_enum_word[where y="scast n_syscallMessage + 1 :: word32"])
-       apply (clarsimp simp: bind_assoc asUser_bind_distrib asUser_getRegister_threadGet_comm
-                             mapM_x_Cons mapM_x_Nil threadGet_discarded
-                             asUser_comm [OF neq] asUser_getRegister_discarded
-                             submonad_asUser.fn_stateAssert take_zip
-                             bind_subst_lift [OF submonad_asUser.stateAssert_fn]
-                             word_less_nat_alt ARM_HYP_H.sanitiseRegister_def
-                             split_def n_msgRegisters_def msgMaxLength_def
-                             bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
-                             word_size msgLengthBits_def n_syscallMessage_def Let_def
-                       cong: if_weak_cong register.case_cong)
+                  ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
+                                   mapM_x_Cons mapM_x_Nil bind_assoc
+                                   zipWithM_x_Nil
+                                   asUser_getRegister_discarded
+                                   asUser_comm[OF neq] take_zip
+                                   bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
+                                   asUser_return submonad_asUser.fn_stateAssert
+                  | rule monadic_rewrite_bind_tail monadic_rewrite_refl
+                         monadic_rewrite_symb_exec_l[OF _ mapM_x_mapM_valid[OF mapM_x_wp']]
+                         monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
+                         monadic_rewrite_threadGet_return
+                         monadic_rewrite_getSanitiseRegisterInfo_return
+                  | wp mapM_wp')+)+
+       apply (simp add: n_msgRegisters_def word_le_nat_alt n_syscallMessage_def
+                        linorder_not_less syscallMessage_unfold)
+       apply (clarsimp | frule neq0_conv[THEN iffD2, THEN not0_implies_Suc,
+                                         OF order_less_le_trans, rotated])+
+       apply (subgoal_tac "\<forall>n :: word32. n \<le> scast n_syscallMessage \<longrightarrow> [n .e. msgMaxLength]
+                                 = [n .e. scast n_syscallMessage]
+                                     @ [scast n_syscallMessage + 1 .e. msgMaxLength]")
+        apply (simp only: upto_enum_word[where y="scast n_syscallMessage :: word32"]
+                          upto_enum_word[where y="scast n_syscallMessage + 1 :: word32"])
+        apply (clarsimp simp: bind_assoc asUser_bind_distrib asUser_getRegister_threadGet_comm
+                              mapM_x_Cons mapM_x_Nil threadGet_discarded
+                              asUser_comm [OF neq] asUser_getRegister_discarded
+                              submonad_asUser.fn_stateAssert take_zip
+                              bind_subst_lift [OF submonad_asUser.stateAssert_fn]
+                              word_less_nat_alt ARM_HYP_H.sanitiseRegister_def
+                              split_def n_msgRegisters_def msgMaxLength_def
+                              bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
+                              word_size msgLengthBits_def n_syscallMessage_def Let_def
+                        cong: if_weak_cong register.case_cong)
 
 
-       apply (rule monadic_rewrite_bind_tail)+
-               apply (subst (2) upto_enum_word)
-               apply (case_tac "ma < unat n_syscallMessage - 4")
+        apply (rule monadic_rewrite_bind_tail)+
+                apply (subst (2) upto_enum_word)
+                apply (case_tac "ma < unat n_syscallMessage - 4")
 
-                apply (erule disjE[OF nat_less_cases'],
-                       ( clarsimp simp: n_syscallMessage_def bind_assoc asUser_bind_distrib
-                                        mapM_x_Cons mapM_x_Nil zipWithM_x_mapM_x mapM_Cons
-                                        bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
-                                        asUser_loadWordUser_comm loadWordUser_discarded asUser_return
-                                        zip_take_triv2 msgMaxLength_def
-                                        no_fail_stateAssert
-                                  cong: if_weak_cong
-                       | simp
-                       | rule monadic_rewrite_bind_tail
-                              monadic_rewrite_refl
-                              monadic_rewrite_symb_exec_l[OF stateAssert_inv]
-                              monadic_rewrite_symb_exec_l[OF mapM_x_mapM_valid[OF mapM_x_wp']]
-                              monadic_rewrite_threadGet_return
-                              monadic_rewrite_getSanitiseRegisterInfo_return
-                              monadic_rewrite_getSanitiseRegisterInfo_drop
-                       | wp asUser_typ_ats empty_fail_loadWordUser)+)+
-      apply (clarsimp simp: upto_enum_word word_le_nat_alt simp del: upt.simps cong: if_weak_cong)
-      apply (cut_tac i="unat n" and j="Suc (unat (scast n_syscallMessage :: word32))"
-                                and k="Suc msgMaxLength" in upt_add_eq_append')
-        apply (simp add: n_syscallMessage_def)
-       apply (simp add: n_syscallMessage_def msgMaxLength_unfold)
-      apply (simp add: n_syscallMessage_def msgMaxLength_def
-                       msgLengthBits_def shiftL_nat
-                  del: upt.simps upt_rec_numeral)
-      apply (simp add: upto_enum_word cong: if_weak_cong)
-     apply wp+
+                 apply (erule disjE[OF nat_less_cases'],
+                        ( clarsimp simp: n_syscallMessage_def bind_assoc asUser_bind_distrib
+                                         mapM_x_Cons mapM_x_Nil zipWithM_x_mapM_x mapM_Cons
+                                         bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
+                                         asUser_loadWordUser_comm loadWordUser_discarded asUser_return
+                                         zip_take_triv2 msgMaxLength_def
+                                         no_fail_stateAssert
+                                   cong: if_weak_cong
+                        | simp
+                        | rule monadic_rewrite_bind_tail
+                               monadic_rewrite_refl
+                               monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
+                               monadic_rewrite_symb_exec_l[OF _ mapM_x_mapM_valid[OF mapM_x_wp']]
+                               monadic_rewrite_threadGet_return
+                               monadic_rewrite_getSanitiseRegisterInfo_return
+                               monadic_rewrite_getSanitiseRegisterInfo_drop
+                        | wp asUser_typ_ats empty_fail_loadWordUser)+)+
+       apply (clarsimp simp: upto_enum_word word_le_nat_alt simp del: upt.simps cong: if_weak_cong)
+       apply (cut_tac i="unat n" and j="Suc (unat (scast n_syscallMessage :: word32))"
+                                 and k="Suc msgMaxLength" in upt_add_eq_append')
+         apply (simp add: n_syscallMessage_def)
+        apply (simp add: n_syscallMessage_def msgMaxLength_unfold)
+       apply (simp add: n_syscallMessage_def msgMaxLength_def
+                        msgLengthBits_def shiftL_nat
+                   del: upt.simps upt_rec_numeral)
+       apply (simp add: upto_enum_word cong: if_weak_cong)
+      apply wp+
     (* ArchFault *)
     apply (simp add: neq inj_case_bool split: bool.split)
    apply (rule monadic_rewrite_guard_imp)

--- a/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
@@ -470,13 +470,13 @@ lemma thread_actions_isolatable_bind:
   apply (clarsimp simp: thread_actions_isolatable_def)
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
-    apply (erule monadic_rewrite_bind2, assumption)
+    apply (erule monadic_rewrite_bind_l, assumption)
     apply (rule hoare_vcg_all_lift, assumption)
    apply (subst isolate_thread_actions_wrap_bind, simp)
    apply simp
    apply (rule monadic_rewrite_in_isolate_thread_actions, assumption)
    apply (rule monadic_rewrite_transverse)
-    apply (erule monadic_rewrite_bind2, assumption)
+    apply (erule monadic_rewrite_bind_l, assumption)
     apply (rule hoare_vcg_all_lift, assumption)
    apply (simp add: bind_assoc id_def)
    apply (rule monadic_rewrite_refl)
@@ -919,7 +919,7 @@ lemma transferCaps_simple_rewrite:
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (simp add: transferCaps_simple, rule monadic_rewrite_refl)
-   apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getReceiveSlots)+)
+   apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getReceiveSlots)+)
    apply (rule monadic_rewrite_refl)
   apply simp
   done
@@ -985,9 +985,9 @@ lemma doIPCTransfer_simple_rewrite:
         apply (rule transferCaps_simple_rewrite)
        apply (wp threadGet_const)+
    apply (simp add: bind_assoc)
-   apply (rule monadic_rewrite_symb_exec2[OF lookupIPC_inv empty_fail_lookupIPCBuffer]
-               monadic_rewrite_symb_exec2[OF threadGet_inv empty_fail_threadGet]
-               monadic_rewrite_symb_exec2[OF user_getreg_inv' empty_fail_user_getreg]
+   apply (rule monadic_rewrite_symb_exec_drop[OF lookupIPC_inv empty_fail_lookupIPCBuffer]
+               monadic_rewrite_symb_exec_drop[OF threadGet_inv empty_fail_threadGet]
+               monadic_rewrite_symb_exec_drop[OF user_getreg_inv' empty_fail_user_getreg]
                monadic_rewrite_bind_head monadic_rewrite_bind_tail
                   | wp)+
     apply (case_tac "messageInfoFromWord msgInfo")
@@ -1045,10 +1045,10 @@ lemma setupCallerCap_rewrite:
      apply simp
      apply (rule monadic_rewrite_trans)
       apply (rule monadic_rewrite_bind_tail)
-       apply (rule monadic_rewrite_symb_exec2, (wp | simp)+)+
+       apply (rule monadic_rewrite_symb_exec_drop, (wp | simp)+)+
        apply (rule monadic_rewrite_refl)
       apply wp+
-     apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getCTE)+)+
+     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getCTE)+)+
      apply (rule monadic_rewrite_refl)
     apply (wp getCTE_wp' | simp add: cte_wp_at_ctes_of)+
   apply (clarsimp simp: reply_masters_rvk_fb_def)
@@ -1174,10 +1174,10 @@ lemma activateThread_simple_rewrite:
        apply simp
        apply (rule monadic_rewrite_refl)
       apply wp
-     apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getThreadState)+)
+     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getThreadState)+)
      apply (rule monadic_rewrite_refl)
     apply wp
-   apply (rule monadic_rewrite_symb_exec2,
+   apply (rule monadic_rewrite_symb_exec_drop,
           simp_all add: getCurThread_def)
    apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: ct_in_state'_def elim!: pred_tcb'_weakenE)
@@ -1473,7 +1473,7 @@ lemma tcbSchedDequeue_rewrite:
      apply (simp add: when_def)
      apply (rule monadic_rewrite_refl)
     apply (wp threadGet_const)
-   apply (rule monadic_rewrite_symb_exec2)
+   apply (rule monadic_rewrite_symb_exec_drop)
       apply wp+
    apply (rule monadic_rewrite_refl)
   apply (clarsimp)
@@ -1571,7 +1571,7 @@ lemma isolate_thread_actions_rewrite_bind:
    apply (subst isolate_thread_actions_wrap_bind, assumption)
    apply (rule monadic_rewrite_in_isolate_thread_actions, assumption)
    apply (rule monadic_rewrite_transverse)
-    apply (rule monadic_rewrite_bind2)
+    apply (rule monadic_rewrite_bind_l)
       apply (erule(1) thread_actions_isolatableD)
      apply (rule thread_actions_isolatableD, assumption+)
     apply (rule hoare_vcg_all_lift, assumption)
@@ -1684,14 +1684,14 @@ lemma monadic_rewrite_isolate_final2:
         apply auto[1]
        apply (rule_tac P="P and (\<lambda>s. tcbs = get_tcb_state_regs o ksPSpace s o idx
                                              \<and> sa = ksSchedulerAction s)"
-                    in monadic_rewrite_refl3)
+                    in monadic_rewrite_pre_imp_refl)
        apply (clarsimp simp: exec_modify eqs return_def)
       apply wp+
   apply (clarsimp simp: o_def eqs)
   done
 
 lemmas monadic_rewrite_isolate_final
-    = monadic_rewrite_isolate_final2[where R=\<top>, OF monadic_rewrite_refl2, simplified]
+    = monadic_rewrite_isolate_final2[where R=\<top>, OF monadic_rewrite_is_refl, simplified]
 
 lemma copy_registers_isolate_general:
   "\<lbrakk> inj idx; idx x = t; idx y = t' \<rbrakk> \<Longrightarrow>
@@ -1816,7 +1816,7 @@ lemma setThreadState_rewrite_simple:
           apply assumption
          apply (rule monadic_rewrite_refl)
         apply wp+
-     apply (rule monadic_rewrite_symb_exec2,
+     apply (rule monadic_rewrite_symb_exec_drop,
             (wp  empty_fail_isRunnable
                | (simp only: getCurThread_def getSchedulerAction_def
                       , rule empty_fail_gets))+)+

--- a/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
@@ -916,10 +916,9 @@ lemma transferCaps_simple_rewrite:
    (return (mi \<lparr> msgExtraCaps := 0, msgCapsUnwrapped := 0 \<rparr>))"
   including no_pre
   apply (rule monadic_rewrite_gen_asm)
+  apply (simp add: transferCaps_simple)
   apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (simp add: transferCaps_simple, rule monadic_rewrite_refl)
-   apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getReceiveSlots)+)
+   apply (rule monadic_rewrite_symb_exec_drop[OF _ empty_fail_getReceiveSlots], wp+)
    apply (rule monadic_rewrite_refl)
   apply simp
   done
@@ -1486,17 +1485,12 @@ lemma switchToThread_rewrite:
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
   apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_bind)
-     apply (rule tcbSchedDequeue_rewrite)
-      apply (rule monadic_rewrite_refl)
-     apply (wp Arch_switchToThread_obj_at_pre)+
    apply (rule monadic_rewrite_bind_tail)
-    apply (rule monadic_rewrite_symb_exec)
-       apply (wp+, simp)
+    apply (rule monadic_rewrite_trans)
+     apply (rule monadic_rewrite_bind_head[OF tcbSchedDequeue_rewrite])
+    apply (rule monadic_rewrite_symb_exec_drop, wp+)
     apply (rule monadic_rewrite_refl)
-   apply (wp)
+   apply (wp Arch_switchToThread_obj_at_pre)+
   apply (clarsimp simp: comp_def)
   done
 

--- a/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
@@ -918,9 +918,8 @@ lemma transferCaps_simple_rewrite:
   apply (rule monadic_rewrite_gen_asm)
   apply (simp add: transferCaps_simple)
   apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_drop[OF _ empty_fail_getReceiveSlots], wp+)
-   apply (rule monadic_rewrite_refl)
-  apply simp
+   apply (rule monadic_rewrite_symb_exec_l_drop[OF monadic_rewrite_refl _ empty_fail_getReceiveSlots])
+   apply wpsimp+
   done
 
 lemma lookupExtraCaps_simple_rewrite:
@@ -933,7 +932,8 @@ lemma lookupExtraCaps_simple_rewrite:
 lemma lookupIPC_inv: "\<lbrace>P\<rbrace> lookupIPCBuffer f t \<lbrace>\<lambda>rv. P\<rbrace>"
   by wp
 
-lemmas empty_fail_user_getreg = empty_fail_asUser[OF empty_fail_getRegister]
+(* FIXME move *)
+lemmas empty_fail_user_getreg[intro!, wp, simp] = empty_fail_asUser[OF empty_fail_getRegister]
 
 lemma copyMRs_simple:
   "msglen \<le> of_nat (length msgRegisters) \<longrightarrow>
@@ -975,20 +975,18 @@ lemma doIPCTransfer_simple_rewrite:
     apply (rule monadic_rewrite_bind_tail)+
       apply (rule_tac P="fault = None" in monadic_rewrite_gen_asm, simp)
       apply (rule monadic_rewrite_bind_tail)
-       apply (rule_tac x=msgInfo in monadic_rewrite_symb_exec,
-              (wp empty_fail_user_getreg user_getreg_rv)+)
-       apply (simp add: lookupExtraCaps_simple_rewrite returnOk_catch_bind)
-       apply (rule monadic_rewrite_bind)
-         apply (rule monadic_rewrite_from_simple, rule copyMRs_simple)
-        apply (rule monadic_rewrite_bind_head)
-        apply (rule transferCaps_simple_rewrite)
-       apply (wp threadGet_const)+
+       apply (rule_tac rv=msgInfo in monadic_rewrite_symb_exec_l_known_F)
+          apply (simp add: lookupExtraCaps_simple_rewrite returnOk_catch_bind)
+          apply (rule monadic_rewrite_bind)
+            apply (rule monadic_rewrite_from_simple, rule copyMRs_simple)
+           apply (rule monadic_rewrite_bind_head)
+           apply (rule transferCaps_simple_rewrite)
+          apply (wp threadGet_const user_getreg_rv asUser_inv)+
    apply (simp add: bind_assoc)
-   apply (rule monadic_rewrite_symb_exec_drop[OF lookupIPC_inv empty_fail_lookupIPCBuffer]
-               monadic_rewrite_symb_exec_drop[OF threadGet_inv empty_fail_threadGet]
-               monadic_rewrite_symb_exec_drop[OF user_getreg_inv' empty_fail_user_getreg]
-               monadic_rewrite_bind_head monadic_rewrite_bind_tail
-                  | wp)+
+   apply (rule monadic_rewrite_symb_exec_l_drop[OF _ lookupIPC_inv empty_fail_lookupIPCBuffer]
+               monadic_rewrite_symb_exec_l_drop[OF _ threadGet_inv empty_fail_threadGet]
+               monadic_rewrite_symb_exec_l_drop[OF _ user_getreg_inv' empty_fail_user_getreg]
+               monadic_rewrite_bind_head monadic_rewrite_bind_tail)+
     apply (case_tac "messageInfoFromWord msgInfo")
     apply simp
     apply (rule monadic_rewrite_refl)
@@ -1014,7 +1012,8 @@ lemma rescheduleRequired_simple_rewrite:
   apply auto
   done
 
-lemma empty_fail_isRunnable:
+(* FIXME move *)
+lemma empty_fail_isRunnable[intro!, wp, simp]:
   "empty_fail (isRunnable t)"
   by (simp add: isRunnable_def isStopped_def)
 
@@ -1044,12 +1043,12 @@ lemma setupCallerCap_rewrite:
      apply simp
      apply (rule monadic_rewrite_trans)
       apply (rule monadic_rewrite_bind_tail)
-       apply (rule monadic_rewrite_symb_exec_drop, (wp | simp)+)+
+       apply (rule monadic_rewrite_symb_exec_l_drop)+
+         apply (rule monadic_rewrite_refl)
+        apply wpsimp+
+     apply (rule monadic_rewrite_symb_exec_l_drop)+
        apply (rule monadic_rewrite_refl)
-      apply wp+
-     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getCTE)+)+
-     apply (rule monadic_rewrite_refl)
-    apply (wp getCTE_wp' | simp add: cte_wp_at_ctes_of)+
+      apply (wp getCTE_wp' | simp add: cte_wp_at_ctes_of)+
   apply (clarsimp simp: reply_masters_rvk_fb_def)
   apply fastforce
   done
@@ -1161,8 +1160,10 @@ lemma oblivious_switchToThread_schact:
          | simp_all add: oblivious_setVMRoot_schact  oblivious_vcpuSwitch_schact)+
   done
 
-lemma empty_fail_getCurThread[iff]:
+(* FIXME move *)
+lemma empty_fail_getCurThread[intro!, wp, simp]:
   "empty_fail getCurThread" by (simp add: getCurThread_def)
+
 lemma activateThread_simple_rewrite:
   "monadic_rewrite True True (ct_in_state' ((=) Running))
        (activateThread) (return ())"
@@ -1173,10 +1174,10 @@ lemma activateThread_simple_rewrite:
        apply simp
        apply (rule monadic_rewrite_refl)
       apply wp
-     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getThreadState)+)
-     apply (rule monadic_rewrite_refl)
-    apply wp
-   apply (rule monadic_rewrite_symb_exec_drop,
+     apply (rule monadic_rewrite_symb_exec_l_drop)
+       apply (rule monadic_rewrite_refl)
+      apply (wp empty_fail_getThreadState)+
+   apply (rule monadic_rewrite_symb_exec_l_drop,
           simp_all add: getCurThread_def)
    apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: ct_in_state'_def elim!: pred_tcb'_weakenE)
@@ -1472,9 +1473,9 @@ lemma tcbSchedDequeue_rewrite:
      apply (simp add: when_def)
      apply (rule monadic_rewrite_refl)
     apply (wp threadGet_const)
-   apply (rule monadic_rewrite_symb_exec_drop)
-      apply wp+
-   apply (rule monadic_rewrite_refl)
+   apply (rule monadic_rewrite_symb_exec_l_drop)
+     apply (rule monadic_rewrite_refl)
+    apply wp+
   apply (clarsimp)
   done
 
@@ -1488,9 +1489,9 @@ lemma switchToThread_rewrite:
    apply (rule monadic_rewrite_bind_tail)
     apply (rule monadic_rewrite_trans)
      apply (rule monadic_rewrite_bind_head[OF tcbSchedDequeue_rewrite])
-    apply (rule monadic_rewrite_symb_exec_drop, wp+)
-    apply (rule monadic_rewrite_refl)
-   apply (wp Arch_switchToThread_obj_at_pre)+
+    apply (rule monadic_rewrite_symb_exec_l_drop)
+      apply (rule monadic_rewrite_refl)
+     apply (wp Arch_switchToThread_obj_at_pre)+
   apply (clarsimp simp: comp_def)
   done
 
@@ -1678,7 +1679,7 @@ lemma monadic_rewrite_isolate_final2:
         apply auto[1]
        apply (rule_tac P="P and (\<lambda>s. tcbs = get_tcb_state_regs o ksPSpace s o idx
                                              \<and> sa = ksSchedulerAction s)"
-                    in monadic_rewrite_pre_imp_refl)
+                    in monadic_rewrite_pre_imp_eq)
        apply (clarsimp simp: exec_modify eqs return_def)
       apply wp+
   apply (clarsimp simp: o_def eqs)
@@ -1798,27 +1799,18 @@ lemma setThreadState_rewrite_simple:
      (setThreadState st t)
      (threadSet (tcbState_update (\<lambda>_. st)) t)"
   supply if_split[split del]
-  apply (simp add: setThreadState_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_trans)
-      apply (rule monadic_rewrite_bind_tail)+
-         apply (simp add: when_def)
-         apply (rule monadic_rewrite_gen_asm)
-         apply (subst if_not_P)
-          apply assumption
-         apply (rule monadic_rewrite_refl)
-        apply wp+
-     apply (rule monadic_rewrite_symb_exec_drop,
-            (wp  empty_fail_isRunnable
-               | (simp only: getCurThread_def getSchedulerAction_def
-                      , rule empty_fail_gets))+)+
-     apply (rule monadic_rewrite_refl)
-    apply (simp add: conj_comms, wp hoare_vcg_imp_lift threadSet_tcbState_st_tcb_at')
-     apply (clarsimp simp: obj_at'_def sch_act_simple_def st_tcb_at'_def)
+  apply (simp add: setThreadState_def when_def)
+  apply (monadic_rewrite_l
+           \<open>wpsimp wp: hoare_vcg_disj_lift hoare_vcg_imp_lift' threadSet_tcbState_st_tcb_at'\<close>
+           r: monadic_rewrite_if_l_False)
+   (* take the threadSet, drop everything until return () *)
+   apply (rule monadic_rewrite_trans[OF monadic_rewrite_bind_tail])
+     apply (rule monadic_rewrite_symb_exec_l_drop)+
+           apply (rule monadic_rewrite_refl)
+          apply (wpsimp simp: getCurThread_def
+                        wp: hoare_vcg_disj_lift hoare_vcg_imp_lift' threadSet_tcbState_st_tcb_at')+
    apply (rule monadic_rewrite_refl)
-  apply clarsimp
+  apply (clarsimp simp: obj_at'_def sch_act_simple_def st_tcb_at'_def)
   done
 
 end

--- a/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
@@ -468,7 +468,7 @@ lemma thread_actions_isolatable_bind:
        \<And>t. \<lbrace>tcb_at' t\<rbrace> f \<lbrace>\<lambda>rv. tcb_at' t\<rbrace> \<rbrakk>
      \<Longrightarrow> thread_actions_isolatable idx (f >>= g)"
   apply (clarsimp simp: thread_actions_isolatable_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (erule monadic_rewrite_bind2, assumption)
     apply (rule hoare_vcg_all_lift, assumption)
@@ -541,7 +541,7 @@ lemma select_f_isolatable:
   apply (clarsimp simp: thread_actions_isolatable_def
                         isolate_thread_actions_def
                         split_def select_f_selects liftM_def bind_assoc)
-  apply (rule monadic_rewrite_imp, rule monadic_rewrite_transverse)
+  apply (rule monadic_rewrite_guard_imp, rule monadic_rewrite_transverse)
     apply (rule monadic_rewrite_drop_modify monadic_rewrite_bind_tail)+
        apply wp+
    apply (simp add: gets_bind_ign getSchedulerAction_def)
@@ -916,7 +916,7 @@ lemma transferCaps_simple_rewrite:
    (return (mi \<lparr> msgExtraCaps := 0, msgCapsUnwrapped := 0 \<rparr>))"
   including no_pre
   apply (rule monadic_rewrite_gen_asm)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (simp add: transferCaps_simple, rule monadic_rewrite_refl)
    apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getReceiveSlots)+)
@@ -971,7 +971,7 @@ lemma doIPCTransfer_simple_rewrite:
   apply (simp add: doIPCTransfer_def bind_assoc doNormalTransfer_def
                    getMessageInfo_def
              cong: option.case_cong)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)+
       apply (rule_tac P="fault = None" in monadic_rewrite_gen_asm, simp)
@@ -1001,7 +1001,7 @@ lemma doIPCTransfer_simple_rewrite:
 lemma monadic_rewrite_setSchedulerAction_noop:
   "monadic_rewrite F E (\<lambda>s. ksSchedulerAction s = act) (setSchedulerAction act) (return ())"
   unfolding setSchedulerAction_def
-  apply (rule monadic_rewrite_imp, rule monadic_rewrite_modify_noop)
+  apply (rule monadic_rewrite_guard_imp, rule monadic_rewrite_modify_noop)
   apply simp
   done
 
@@ -1036,7 +1036,7 @@ lemma setupCallerCap_rewrite:
   apply (simp add: setupCallerCap_def getThreadCallerSlot_def
                    getThreadReplySlot_def locateSlot_conv
                    getSlotCap_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_bind_tail)+
      apply (rule monadic_rewrite_assert)+
      apply (rule_tac P="mdbFirstBadged (cteMDBNode masterCTE)
@@ -1168,7 +1168,7 @@ lemma activateThread_simple_rewrite:
   "monadic_rewrite True True (ct_in_state' ((=) Running))
        (activateThread) (return ())"
   apply (simp add: activateThread_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans, rule monadic_rewrite_bind_tail)+
        apply (rule_tac P="state = Running" in monadic_rewrite_gen_asm)
        apply simp
@@ -1466,7 +1466,7 @@ lemma thread_actions_isolatableD:
 lemma tcbSchedDequeue_rewrite:
   "monadic_rewrite True True (obj_at' (Not \<circ> tcbQueued) t) (tcbSchedDequeue t) (return ())"
   apply (simp add: tcbSchedDequeue_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule_tac P="\<not> queued" in monadic_rewrite_gen_asm)
@@ -1485,7 +1485,7 @@ lemma switchToThread_rewrite:
        (switchToThread t)
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule monadic_rewrite_bind)
@@ -1563,7 +1563,7 @@ lemma isolate_thread_actions_rewrite_bind:
     \<Longrightarrow> monadic_rewrite False True (\<lambda>s. \<forall>x. tcb_at' (idx x) s)
                (f >>= g) (isolate_thread_actions idx
                                   (f' >>= g') (g'' o f'') (g''' o f'''))"
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind, assumption+)
     apply (wp isolate_thread_actions_tcbs_at)
@@ -1676,7 +1676,7 @@ lemma monadic_rewrite_isolate_final2:
          (isolate_thread_actions idx f f' f'')
          (isolate_thread_actions idx g g' g'')"
   apply (simp add: isolate_thread_actions_def split_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_bind_tail)+
       apply (rule_tac P="\<lambda> s'. Q s" in monadic_rewrite_bind)
         apply (insert mr)[1]
@@ -1711,7 +1711,7 @@ lemma copy_registers_isolate_general:
                          select_f_returns o_def ksPSpace_update_partial_id)
    apply (simp add: return_def simpler_modify_def)
   apply (simp add: mapM_x_Cons)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule isolate_thread_actions_rewrite_bind, assumption)
         apply (rule copy_register_isolate, assumption+)
@@ -1805,7 +1805,7 @@ lemma setThreadState_rewrite_simple:
      (threadSet (tcbState_update (\<lambda>_. st)) t)"
   supply if_split[split del]
   apply (simp add: setThreadState_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule monadic_rewrite_trans)

--- a/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
@@ -8,25 +8,8 @@ theory IsolatedThreadAction
 imports ArchMove_C
 begin
 
-datatype tcb_state_regs = TCBStateRegs "thread_state" "MachineTypes.register \<Rightarrow> machine_word"
-
-definition
- "tsrContext tsr \<equiv> case tsr of TCBStateRegs ts regs \<Rightarrow> regs"
-
-definition
- "tsrState tsr \<equiv> case tsr of TCBStateRegs ts regs \<Rightarrow> ts"
-
-lemma accessors_TCBStateRegs[simp]:
-  "TCBStateRegs (tsrState v) (tsrContext v) = v"
-  by (cases v, simp add: tsrState_def tsrContext_def)
-
-lemma tsrContext_simp[simp]:
-  "tsrContext (TCBStateRegs st con) = con"
-  by (simp add: tsrContext_def)
-
-lemma tsrState_simp[simp]:
-  "tsrState (TCBStateRegs st con) = st"
-  by (simp add: tsrState_def)
+datatype tcb_state_regs =
+  TCBStateRegs (tsrState : thread_state) (tsrContext : "MachineTypes.register \<Rightarrow> machine_word")
 
 definition
   get_tcb_state_regs :: "kernel_object option \<Rightarrow> tcb_state_regs"

--- a/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
@@ -915,11 +915,11 @@ lemma transferCaps_simple_rewrite:
    (transferCaps mi caps ep r rBuf)
    (return (mi \<lparr> msgExtraCaps := 0, msgCapsUnwrapped := 0 \<rparr>))"
   including no_pre
+  supply empty_fail_getReceiveSlots[wp] (* FIXME *)
   apply (rule monadic_rewrite_gen_asm)
   apply (simp add: transferCaps_simple)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_l_drop[OF monadic_rewrite_refl _ empty_fail_getReceiveSlots])
-   apply wpsimp+
+  apply (monadic_rewrite_symb_exec_l_drop, rule monadic_rewrite_refl)
+  apply simp
   done
 
 lemma lookupExtraCaps_simple_rewrite:
@@ -972,10 +972,10 @@ lemma doIPCTransfer_simple_rewrite:
              cong: option.case_cong)
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)+
-      apply (rule_tac P="fault = None" in monadic_rewrite_gen_asm, simp)
+    apply (rule monadic_rewrite_bind_tail)
+      apply (monadic_rewrite_symb_exec_l_known None, simp)
       apply (rule monadic_rewrite_bind_tail)
-       apply (rule_tac rv=msgInfo in monadic_rewrite_symb_exec_l_known_F)
+       apply (monadic_rewrite_symb_exec_l_known msgInfo)
           apply (simp add: lookupExtraCaps_simple_rewrite returnOk_catch_bind)
           apply (rule monadic_rewrite_bind)
             apply (rule monadic_rewrite_from_simple, rule copyMRs_simple)
@@ -1034,23 +1034,19 @@ lemma setupCallerCap_rewrite:
   apply (simp add: setupCallerCap_def getThreadCallerSlot_def
                    getThreadReplySlot_def locateSlot_conv
                    getSlotCap_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_bind_tail)+
-     apply (rule monadic_rewrite_assert)+
-     apply (rule_tac P="mdbFirstBadged (cteMDBNode masterCTE)
-                        \<and> mdbRevocable (cteMDBNode masterCTE)"
-                 in monadic_rewrite_gen_asm)
-     apply simp
-     apply (rule monadic_rewrite_trans)
-      apply (rule monadic_rewrite_bind_tail)
-       apply (rule monadic_rewrite_symb_exec_l_drop)+
-         apply (rule monadic_rewrite_refl)
-        apply wpsimp+
-     apply (rule monadic_rewrite_symb_exec_l_drop)+
-       apply (rule monadic_rewrite_refl)
-      apply (wp getCTE_wp' | simp add: cte_wp_at_ctes_of)+
-  apply (clarsimp simp: reply_masters_rvk_fb_def)
-  apply fastforce
+  apply (rule monadic_rewrite_bind_tail)+
+    apply (rule monadic_rewrite_assert)+
+    apply (rule_tac P="mdbFirstBadged (cteMDBNode masterCTE)
+                       \<and> mdbRevocable (cteMDBNode masterCTE)"
+                in monadic_rewrite_gen_asm)
+    apply (rule monadic_rewrite_trans)
+     apply monadic_rewrite_symb_exec_l
+      apply monadic_rewrite_symb_exec_l_drop
+      apply (rule monadic_rewrite_refl)
+     apply wpsimp+
+    apply (rule monadic_rewrite_refl)
+   apply (wpsimp wp: getCTE_wp' simp: cte_wp_at_ctes_of)+
+  apply (fastforce simp: reply_masters_rvk_fb_def)
   done
 
 lemma oblivious_getObject_ksPSpace_default:
@@ -1168,18 +1164,11 @@ lemma activateThread_simple_rewrite:
   "monadic_rewrite True True (ct_in_state' ((=) Running))
        (activateThread) (return ())"
   apply (simp add: activateThread_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans, rule monadic_rewrite_bind_tail)+
-       apply (rule_tac P="state = Running" in monadic_rewrite_gen_asm)
-       apply simp
+  apply wp_pre
+  apply (monadic_rewrite_symb_exec_l)
+  apply (monadic_rewrite_symb_exec_l_known Running, simp)
        apply (rule monadic_rewrite_refl)
-      apply wp
-     apply (rule monadic_rewrite_symb_exec_l_drop)
-       apply (rule monadic_rewrite_refl)
-      apply (wp empty_fail_getThreadState)+
-   apply (rule monadic_rewrite_symb_exec_l_drop,
-          simp_all add: getCurThread_def)
-   apply (rule monadic_rewrite_refl)
+     apply wpsimp+
   apply (clarsimp simp: ct_in_state'_def elim!: pred_tcb'_weakenE)
   done
 
@@ -1466,17 +1455,9 @@ lemma thread_actions_isolatableD:
 lemma tcbSchedDequeue_rewrite:
   "monadic_rewrite True True (obj_at' (Not \<circ> tcbQueued) t) (tcbSchedDequeue t) (return ())"
   apply (simp add: tcbSchedDequeue_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule_tac P="\<not> queued" in monadic_rewrite_gen_asm)
-     apply (simp add: when_def)
-     apply (rule monadic_rewrite_refl)
-    apply (wp threadGet_const)
-   apply (rule monadic_rewrite_symb_exec_l_drop)
-     apply (rule monadic_rewrite_refl)
-    apply wp+
-  apply (clarsimp)
+   apply (wp_pre, monadic_rewrite_symb_exec_l_known False, simp)
+    apply (rule monadic_rewrite_refl)
+   apply (wpsimp wp: threadGet_const)+
   done
 
 lemma switchToThread_rewrite:
@@ -1485,13 +1466,8 @@ lemma switchToThread_rewrite:
        (switchToThread t)
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_bind_tail)
-    apply (rule monadic_rewrite_trans)
-     apply (rule monadic_rewrite_bind_head[OF tcbSchedDequeue_rewrite])
-    apply (rule monadic_rewrite_symb_exec_l_drop)
-      apply (rule monadic_rewrite_refl)
-     apply (wp Arch_switchToThread_obj_at_pre)+
+  apply (monadic_rewrite_l tcbSchedDequeue_rewrite, simp)
+   apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: comp_def)
   done
 
@@ -1800,9 +1776,8 @@ lemma setThreadState_rewrite_simple:
      (threadSet (tcbState_update (\<lambda>_. st)) t)"
   supply if_split[split del]
   apply (simp add: setThreadState_def when_def)
-  apply (monadic_rewrite_l
-           \<open>wpsimp wp: hoare_vcg_disj_lift hoare_vcg_imp_lift' threadSet_tcbState_st_tcb_at'\<close>
-           r: monadic_rewrite_if_l_False)
+  apply (monadic_rewrite_l monadic_rewrite_if_l_False
+           \<open>wpsimp wp: hoare_vcg_disj_lift hoare_vcg_imp_lift' threadSet_tcbState_st_tcb_at'\<close>)
    (* take the threadSet, drop everything until return () *)
    apply (rule monadic_rewrite_trans[OF monadic_rewrite_bind_tail])
      apply (rule monadic_rewrite_symb_exec_l_drop)+

--- a/proof/crefine/ARM_HYP/Refine_C.thy
+++ b/proof/crefine/ARM_HYP/Refine_C.thy
@@ -1131,7 +1131,7 @@ lemma kernel_all_subset_kernel:
                     check_active_irq_H_def checkActiveIRQ_def)
        apply clarsimp
        apply (erule in_monad_imp_rewriteE[where F=True])
-        apply (rule monadic_rewrite_imp)
+        apply (rule monadic_rewrite_guard_imp)
          apply (rule monadic_rewrite_bind_tail)+
            apply (rule monadic_rewrite_bind_head[where P=\<top>])
            apply (simp add: callKernel_C_def callKernel_withFastpath_C_def

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -5260,7 +5260,7 @@ lemma monadic_rewrite_placeNewObject_vcpu_decompose:
            (do placeNewObject v vcpupre 0;
                setObject v vcpu
             od)"
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans[rotated])
     apply (rule monadic_rewrite_bind_tail)
      apply clarsimp
@@ -5286,7 +5286,7 @@ lemma monadic_rewrite_setObject_vcpu_twice:
                setObject v vcpu
             od)"
   supply fun_upd_apply[simp del]
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans[rotated])
     apply (rule monadic_rewrite_bind_head)
     apply (rule monadic_rewrite_modify_setObject_vcpu)
@@ -5400,7 +5400,7 @@ lemma monadic_rewrite_setObject_vcpu_as_init:
   supply fun_upd_apply[simp del]
   apply (simp add: K_def)
   apply (rule monadic_rewrite_gen_asm)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (simp add: vcpuWriteReg_def vgicUpdate_def bind_assoc)
    apply (rule monadic_rewrite_trans[rotated])
     apply (clarsimp simp: vcpuUpdate_def bind_assoc)

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -5405,31 +5405,31 @@ lemma monadic_rewrite_setObject_vcpu_as_init:
    apply (rule monadic_rewrite_trans[rotated])
     apply (clarsimp simp: vcpuUpdate_def bind_assoc)
     (* explicitly state the vcpu we are setting for each setObject *)
-    apply (rule monadic_rewrite_symb_exec_r, wp+)
-     apply (rename_tac vcpu)
-     apply (rule_tac P="vcpu = vcpu0" in monadic_rewrite_gen_asm, simp)
-     apply (rule monadic_rewrite_bind_tail)
-      apply (rule monadic_rewrite_symb_exec_r, wp+)
-       apply (rename_tac vcpu')
-       apply (rule_tac P="vcpu' = vcpu1" in monadic_rewrite_gen_asm, simp)
+    apply (rule monadic_rewrite_symb_exec_r)
+       apply (rename_tac vcpu)
+       apply (rule_tac P="vcpu = vcpu0" in monadic_rewrite_gen_asm, simp)
        apply (rule monadic_rewrite_bind_tail)
-        apply (rule monadic_rewrite_symb_exec_r, wp+)
-         apply (rename_tac vcpu'')
-         apply (rule_tac P="vcpu'' = vcpu2" in monadic_rewrite_gen_asm, simp)
-       apply (rule monadic_rewrite_bind_tail)
-      apply (rule monadic_rewrite_symb_exec_r, wp+)
-         apply (rename_tac vcpu''')
-         apply (rule_tac P="vcpu''' = vcpu3" in monadic_rewrite_gen_asm, simp)
-         apply (rule monadic_rewrite_refl)
-        apply (wpsimp wp: getObject_vcpu_prop simp: vcpu1_def vcpu2_def vcpu3_def vcpu0_def)+
+        apply (rule monadic_rewrite_symb_exec_r)
+           apply (rename_tac vcpu')
+           apply (rule_tac P="vcpu' = vcpu1" in monadic_rewrite_gen_asm, simp)
+           apply (rule monadic_rewrite_bind_tail)
+            apply (rule monadic_rewrite_symb_exec_r)
+               apply (rename_tac vcpu'')
+               apply (rule_tac P="vcpu'' = vcpu2" in monadic_rewrite_gen_asm, simp)
+               apply (rule monadic_rewrite_bind_tail)
+                apply (rule monadic_rewrite_symb_exec_r)
+                   apply (rename_tac vcpu''')
+                   apply (rule_tac P="vcpu''' = vcpu3" in monadic_rewrite_gen_asm, simp)
+                   apply (rule monadic_rewrite_refl)
+                  apply (wpsimp wp: getObject_vcpu_prop simp: vcpu1_def vcpu2_def vcpu3_def vcpu0_def)+
+               apply (wp setObject_sets_object_vcpu)
+              apply (wpsimp wp: getObject_vcpu_prop)+
+           apply (wpsimp wp: getObject_vcpu_prop simp: vcpu1_def vcpu2_def vcpu0_def)+
+           apply (wp setObject_sets_object_vcpu)
+          apply (wpsimp wp: getObject_vcpu_prop)+
+       apply (wpsimp wp: getObject_vcpu_prop simp: vcpu1_def vcpu2_def vcpu0_def)+
        apply (wp setObject_sets_object_vcpu)
       apply (wpsimp wp: getObject_vcpu_prop)+
-     apply (wpsimp wp: getObject_vcpu_prop simp: vcpu1_def vcpu2_def vcpu0_def)+
-     apply (wp setObject_sets_object_vcpu)
-    apply (wpsimp wp: getObject_vcpu_prop)+
-     apply (wpsimp wp: getObject_vcpu_prop simp: vcpu1_def vcpu2_def vcpu0_def)+
-     apply (wp setObject_sets_object_vcpu)
-    apply (wpsimp wp: getObject_vcpu_prop)+
    (* now we have four setObjects in a row, fold them up using setObject-combining *)
    apply (rule monadic_rewrite_trans[rotated])
     apply (rule monadic_rewrite_bind_tail)

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -5260,13 +5260,9 @@ lemma monadic_rewrite_placeNewObject_vcpu_decompose:
            (do placeNewObject v vcpupre 0;
                setObject v vcpu
             od)"
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans[rotated])
-    apply (rule monadic_rewrite_bind_tail)
-     apply clarsimp
-     apply (rule monadic_rewrite_modify_setObject_vcpu)
-    apply (rule hoare_post_imp[OF _ placeNewObject_creates_object_vcpu])
-    apply (fastforce simp: ko_at_vcpu_at'D)
+  apply clarsimp
+  apply (monadic_rewrite_r monadic_rewrite_modify_setObject_vcpu
+                           \<open>wpsimp wp: placeNewObject_object_at_vcpu\<close>)
    apply (clarsimp simp: placeNewObject_def placeNewObject'_def bind_assoc split_def)
    apply (clarsimp simp: objBits_simps' archObjSize_def)
    apply (rule monadic_rewrite_bind_tail)+
@@ -5286,17 +5282,10 @@ lemma monadic_rewrite_setObject_vcpu_twice:
                setObject v vcpu
             od)"
   supply fun_upd_apply[simp del]
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans[rotated])
-    apply (rule monadic_rewrite_bind_head)
-    apply (rule monadic_rewrite_modify_setObject_vcpu)
-   apply (rule monadic_rewrite_trans[rotated])
-    apply (rule monadic_rewrite_bind_tail)
-     apply clarsimp
-     apply (rule monadic_rewrite_modify_setObject_vcpu)
-    apply wp
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_setObject_vcpu_modify)
+  apply simp
+  apply (monadic_rewrite_r monadic_rewrite_modify_setObject_vcpu)
+   apply (monadic_rewrite_r monadic_rewrite_modify_setObject_vcpu)
+   apply (monadic_rewrite_l monadic_rewrite_setObject_vcpu_modify)
    apply (rule monadic_rewrite_is_refl)
    apply (rule ext)
    apply (clarsimp simp: exec_modify)
@@ -5398,29 +5387,21 @@ lemma monadic_rewrite_setObject_vcpu_as_init:
       od)
      "
   supply fun_upd_apply[simp del]
-  apply (simp add: K_def)
+  apply simp
   apply (rule monadic_rewrite_gen_asm)
-  apply (rule monadic_rewrite_guard_imp)
+  apply wp_pre
    apply (simp add: vcpuWriteReg_def vgicUpdate_def bind_assoc)
-   apply (rule monadic_rewrite_trans[rotated])
     apply (clarsimp simp: vcpuUpdate_def bind_assoc)
     (* explicitly state the vcpu we are setting for each setObject *)
-    apply (rule monadic_rewrite_symb_exec_r)
-       apply (rename_tac vcpu)
-       apply (rule_tac P="vcpu = vcpu0" in monadic_rewrite_gen_asm, simp)
+   apply (rule monadic_rewrite_trans[rotated])
+    apply (monadic_rewrite_symb_exec_r_known vcpu0)
+     apply (rule monadic_rewrite_bind_tail)
+      apply (monadic_rewrite_symb_exec_r_known vcpu1)
        apply (rule monadic_rewrite_bind_tail)
-        apply (rule monadic_rewrite_symb_exec_r)
-           apply (rename_tac vcpu')
-           apply (rule_tac P="vcpu' = vcpu1" in monadic_rewrite_gen_asm, simp)
-           apply (rule monadic_rewrite_bind_tail)
-            apply (rule monadic_rewrite_symb_exec_r)
-               apply (rename_tac vcpu'')
-               apply (rule_tac P="vcpu'' = vcpu2" in monadic_rewrite_gen_asm, simp)
-               apply (rule monadic_rewrite_bind_tail)
-                apply (rule monadic_rewrite_symb_exec_r)
-                   apply (rename_tac vcpu''')
-                   apply (rule_tac P="vcpu''' = vcpu3" in monadic_rewrite_gen_asm, simp)
-                   apply (rule monadic_rewrite_refl)
+        apply (monadic_rewrite_symb_exec_r_known vcpu2)
+         apply (rule monadic_rewrite_bind_tail)
+          apply (monadic_rewrite_symb_exec_r_known vcpu3)
+           apply (rule monadic_rewrite_refl)
                   apply (wpsimp wp: getObject_vcpu_prop simp: vcpu1_def vcpu2_def vcpu3_def vcpu0_def)+
                apply (wp setObject_sets_object_vcpu)
               apply (wpsimp wp: getObject_vcpu_prop)+
@@ -5428,20 +5409,12 @@ lemma monadic_rewrite_setObject_vcpu_as_init:
            apply (wp setObject_sets_object_vcpu)
           apply (wpsimp wp: getObject_vcpu_prop)+
        apply (wpsimp wp: getObject_vcpu_prop simp: vcpu1_def vcpu2_def vcpu0_def)+
-       apply (wp setObject_sets_object_vcpu)
-      apply (wpsimp wp: getObject_vcpu_prop)+
+               apply (wp setObject_sets_object_vcpu)
+       apply (wpsimp wp: getObject_vcpu_prop simp: vcpu1_def vcpu2_def vcpu0_def)+
    (* now we have four setObjects in a row, fold them up using setObject-combining *)
-   apply (rule monadic_rewrite_trans[rotated])
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_bind_tail)
-      apply (rule monadic_rewrite_setObject_vcpu_twice[simplified])
-     apply wp+
-   apply (rule monadic_rewrite_trans[rotated])
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_setObject_vcpu_twice[simplified])
-    apply wp+
-   apply (rule monadic_rewrite_trans[rotated])
-    apply (rule monadic_rewrite_setObject_vcpu_twice[simplified])
+   apply (monadic_rewrite_r_method \<open>rule monadic_rewrite_setObject_vcpu_twice[simplified]\<close> wpsimp)
+   apply (monadic_rewrite_r_method \<open>rule monadic_rewrite_setObject_vcpu_twice[simplified]\<close> wpsimp)
+   apply (monadic_rewrite_r_method \<open>rule monadic_rewrite_setObject_vcpu_twice[simplified]\<close> wpsimp)
    apply (rule monadic_rewrite_is_refl)
    apply (fastforce simp: vcpu3_def vcpu2_def vcpu1_def vcpu0_def makeVCPUObject_def)
   apply (fastforce simp: vcpu0_def ko_at_vcpu_at'D)

--- a/proof/crefine/ARM_HYP/Schedule_C.thy
+++ b/proof/crefine/ARM_HYP/Schedule_C.thy
@@ -298,8 +298,6 @@ proof -
             apply (rule conseqPre, vcg)
             apply clarsimp
            apply (wp isRunnable_wp)+
-         apply (simp add: isRunnable_def)
-        apply wp
        apply (clarsimp simp: Let_def guard_is_UNIV_def)
        apply (drule invs_no_cicd'_queues)
        apply (case_tac queue, simp)

--- a/proof/crefine/RISCV64/Invoke_C.thy
+++ b/proof/crefine/RISCV64/Invoke_C.thy
@@ -1,6 +1,7 @@
 (*
- * Copyright 2014, General Dynamics C4 Systems
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)

--- a/proof/crefine/RISCV64/Invoke_C.thy
+++ b/proof/crefine/RISCV64/Invoke_C.thy
@@ -3453,16 +3453,14 @@ shows
     apply (rule_tac isBlocking=isBlocking and isCall=isCall and buffer=buffer
                 in decodeUntypedInvocation_ccorres_helper[unfolded K_def])
     apply assumption
-   apply (rule monadic_rewrite_transverse)
+   apply (rule monadic_rewrite_trans[rotated])
     apply (rule monadic_rewrite_bind_head)
-    apply (rule monadic_rewrite_bindE[OF monadic_rewrite_refl])
-     apply (simp add: liftE_bindE stateAssert_def2 bind_assoc)
-     apply (rule monadic_rewrite_bind_tail)
-      apply (rule_tac P=x in monadic_rewrite_gen_asm)
-      apply simp
+    apply (simp add: liftE_bindE stateAssert_def2 bind_assoc)
+    apply (monadic_rewrite_r monadic_rewrite_if_r_True)
+    apply (monadic_rewrite_r_method monadic_rewrite_symb_exec_r_drop wpsimp)
       apply (rule monadic_rewrite_refl)
-     apply (wp | simp)+
-   apply (simp add: gets_bind_ign)
+     apply wpsimp
+    apply (rule monadic_rewrite_refl)
    apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: ex_cte_cap_wp_to'_def excaps_in_mem_def)
   apply (drule(1) bspec)+

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -1,6 +1,7 @@
 (*
- * Copyright 2014, General Dynamics C4 Systems
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -504,9 +504,8 @@ lemma getSanitiseRegisterInfo_moreMapM_comm:
 
 lemma monadic_rewrite_threadGet_return:
   "monadic_rewrite True False (tcb_at' r) (return x) (do t \<leftarrow> threadGet f r; return x od)"
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
-    apply wpsimp+
+  apply (wp_pre, monadic_rewrite_symb_exec_r_drop)
+   apply (auto intro: monadic_rewrite_refl)
   done
 
 context begin interpretation Arch .
@@ -521,16 +520,14 @@ end
 
 lemma monadic_rewrite_getSanitiseRegisterInfo_return:
   "monadic_rewrite True False (tcb_at' r) (return x) (do t \<leftarrow> getSanitiseRegisterInfo r; return x od)"
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
-    apply wpsimp+
+  apply (wp_pre, monadic_rewrite_symb_exec_r_drop)
+   apply (auto intro: monadic_rewrite_refl)
   done
 
 lemma monadic_rewrite_getSanitiseRegisterInfo_drop:
   "monadic_rewrite True False (tcb_at' r) (d) (do t \<leftarrow> getSanitiseRegisterInfo r; d od)"
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
-    apply wpsimp+
+  apply (wp_pre, monadic_rewrite_symb_exec_r_drop)
+   apply (auto intro: monadic_rewrite_refl)
   done
 
 context kernel_m begin interpretation Arch .

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -596,13 +596,13 @@ lemma handleFaultReply':
                      empty_fail_loadWordUser)+
     (* UnknownSyscallException *)
     apply (simp add: zip_append2 mapM_x_append asUser_bind_distrib split_def bind_assoc)
-    apply (rule monadic_rewrite_imp)
+    apply (rule monadic_rewrite_guard_imp)
      apply (rule monadic_rewrite_trans[rotated])
       apply (rule monadic_rewrite_do_flip)
       apply (rule monadic_rewrite_bind_tail)
        apply (rule_tac P="inj (case_bool s r)" in monadic_rewrite_gen_asm)
        apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
-         apply (rule monadic_rewrite_weaken[where F=False and E=True], simp)
+         apply (rule monadic_rewrite_weaken_flags[where F=False and E=True], simp)
          apply (rule isolate_thread_actions_rewrite_bind
                      bool.simps setRegister_simple
                      zipWithM_setRegister_simple
@@ -705,7 +705,7 @@ lemma handleFaultReply':
      apply wp+
     (* ArchFault *)
     apply (simp add: neq inj_case_bool split: bool.split)
-   apply (rule monadic_rewrite_imp)
+   apply (rule monadic_rewrite_guard_imp)
     apply (rule monadic_rewrite_is_refl)
     apply (rule ext)
     apply (unfold handleArchFaultReply'[symmetric] getMRs_def msgMaxLength_def

--- a/proof/crefine/RISCV64/IsolatedThreadAction.thy
+++ b/proof/crefine/RISCV64/IsolatedThreadAction.thy
@@ -1,6 +1,7 @@
 (*
- * Copyright 2014, General Dynamics C4 Systems
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)

--- a/proof/crefine/RISCV64/IsolatedThreadAction.thy
+++ b/proof/crefine/RISCV64/IsolatedThreadAction.thy
@@ -715,11 +715,11 @@ lemma transferCaps_simple_rewrite:
    (transferCaps mi caps ep r rBuf)
    (return (mi \<lparr> msgExtraCaps := 0, msgCapsUnwrapped := 0 \<rparr>))"
   including no_pre
+  supply empty_fail_getReceiveSlots[wp] (* FIXME *)
   apply (rule monadic_rewrite_gen_asm)
   apply (simp add: transferCaps_simple)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_l_drop[OF monadic_rewrite_refl _ empty_fail_getReceiveSlots])
-   apply wpsimp+
+  apply (monadic_rewrite_symb_exec_l_drop, rule monadic_rewrite_refl)
+  apply simp
   done
 
 lemma lookupExtraCaps_simple_rewrite:
@@ -772,10 +772,10 @@ lemma doIPCTransfer_simple_rewrite:
              cong: option.case_cong)
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)+
-      apply (rule_tac P="fault = None" in monadic_rewrite_gen_asm, simp)
+    apply (rule monadic_rewrite_bind_tail)
+      apply (monadic_rewrite_symb_exec_l_known None, simp)
       apply (rule monadic_rewrite_bind_tail)
-       apply (rule_tac rv=msgInfo in monadic_rewrite_symb_exec_l_known_F)
+       apply (monadic_rewrite_symb_exec_l_known msgInfo)
           apply (simp add: lookupExtraCaps_simple_rewrite returnOk_catch_bind)
           apply (rule monadic_rewrite_bind)
             apply (rule monadic_rewrite_from_simple, rule copyMRs_simple)
@@ -834,23 +834,19 @@ lemma setupCallerCap_rewrite:
   apply (simp add: setupCallerCap_def getThreadCallerSlot_def
                    getThreadReplySlot_def locateSlot_conv
                    getSlotCap_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_bind_tail)+
-     apply (rule monadic_rewrite_assert)+
-     apply (rule_tac P="mdbFirstBadged (cteMDBNode masterCTE)
-                        \<and> mdbRevocable (cteMDBNode masterCTE)"
-                 in monadic_rewrite_gen_asm)
-     apply simp
-     apply (rule monadic_rewrite_trans)
-      apply (rule monadic_rewrite_bind_tail)
-       apply (rule monadic_rewrite_symb_exec_l_drop)+
-         apply (rule monadic_rewrite_refl)
-        apply wpsimp+
-     apply (rule monadic_rewrite_symb_exec_l_drop)+
-       apply (rule monadic_rewrite_refl)
-      apply (wp getCTE_wp' | simp add: cte_wp_at_ctes_of)+
-  apply (clarsimp simp: reply_masters_rvk_fb_def)
-  apply fastforce
+  apply (rule monadic_rewrite_bind_tail)+
+    apply (rule monadic_rewrite_assert)+
+    apply (rule_tac P="mdbFirstBadged (cteMDBNode masterCTE)
+                       \<and> mdbRevocable (cteMDBNode masterCTE)"
+                in monadic_rewrite_gen_asm)
+    apply (rule monadic_rewrite_trans)
+     apply monadic_rewrite_symb_exec_l
+      apply monadic_rewrite_symb_exec_l_drop
+      apply (rule monadic_rewrite_refl)
+     apply wpsimp+
+    apply (rule monadic_rewrite_refl)
+   apply (wpsimp wp: getCTE_wp' simp: cte_wp_at_ctes_of)+
+  apply (fastforce simp: reply_masters_rvk_fb_def)
   done
 
 lemma oblivious_getObject_ksPSpace_default:
@@ -929,18 +925,11 @@ lemma activateThread_simple_rewrite:
   "monadic_rewrite True True (ct_in_state' ((=) Running))
        (activateThread) (return ())"
   apply (simp add: activateThread_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans, rule monadic_rewrite_bind_tail)+
-       apply (rule_tac P="state = Running" in monadic_rewrite_gen_asm)
-       apply simp
+  apply wp_pre
+  apply (monadic_rewrite_symb_exec_l)
+  apply (monadic_rewrite_symb_exec_l_known Running, simp)
        apply (rule monadic_rewrite_refl)
-      apply wp
-     apply (rule monadic_rewrite_symb_exec_l_drop)
-       apply (rule monadic_rewrite_refl)
-      apply (wp empty_fail_getThreadState)+
-   apply (rule monadic_rewrite_symb_exec_l_drop,
-          simp_all add: getCurThread_def)
-   apply (rule monadic_rewrite_refl)
+     apply wpsimp+
   apply (clarsimp simp: ct_in_state'_def elim!: pred_tcb'_weakenE)
   done
 
@@ -1232,17 +1221,9 @@ lemma thread_actions_isolatableD:
 lemma tcbSchedDequeue_rewrite:
   "monadic_rewrite True True (obj_at' (Not \<circ> tcbQueued) t) (tcbSchedDequeue t) (return ())"
   apply (simp add: tcbSchedDequeue_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule_tac P="\<not> queued" in monadic_rewrite_gen_asm)
-     apply (simp add: when_def)
-     apply (rule monadic_rewrite_refl)
-    apply (wp threadGet_const)
-   apply (rule monadic_rewrite_symb_exec_l_drop)
-     apply (rule monadic_rewrite_refl)
-    apply wp+
-  apply (clarsimp)
+   apply (wp_pre, monadic_rewrite_symb_exec_l_known False, simp)
+    apply (rule monadic_rewrite_refl)
+   apply (wpsimp wp: threadGet_const)+
   done
 
 lemma switchToThread_rewrite:
@@ -1251,13 +1232,8 @@ lemma switchToThread_rewrite:
        (switchToThread t)
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_bind_tail)
-    apply (rule monadic_rewrite_trans)
-     apply (rule monadic_rewrite_bind_head[OF tcbSchedDequeue_rewrite])
-    apply (rule monadic_rewrite_symb_exec_l_drop)
-      apply (rule monadic_rewrite_refl)
-     apply (wp Arch_switchToThread_obj_at_pre)+
+  apply (monadic_rewrite_l tcbSchedDequeue_rewrite, simp)
+   apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: comp_def)
   done
 
@@ -1565,9 +1541,8 @@ lemma setThreadState_rewrite_simple:
      (threadSet (tcbState_update (\<lambda>_. st)) t)"
   supply if_split[split del]
   apply (simp add: setThreadState_def when_def)
-  apply (monadic_rewrite_l
-           \<open>wpsimp wp: hoare_vcg_disj_lift hoare_vcg_imp_lift' threadSet_tcbState_st_tcb_at'\<close>
-           r: monadic_rewrite_if_l_False)
+  apply (monadic_rewrite_l monadic_rewrite_if_l_False
+           \<open>wpsimp wp: hoare_vcg_disj_lift hoare_vcg_imp_lift' threadSet_tcbState_st_tcb_at'\<close>)
    (* take the threadSet, drop everything until return () *)
    apply (rule monadic_rewrite_trans[OF monadic_rewrite_bind_tail])
      apply (rule monadic_rewrite_symb_exec_l_drop)+

--- a/proof/crefine/RISCV64/IsolatedThreadAction.thy
+++ b/proof/crefine/RISCV64/IsolatedThreadAction.thy
@@ -716,10 +716,9 @@ lemma transferCaps_simple_rewrite:
    (return (mi \<lparr> msgExtraCaps := 0, msgCapsUnwrapped := 0 \<rparr>))"
   including no_pre
   apply (rule monadic_rewrite_gen_asm)
+  apply (simp add: transferCaps_simple)
   apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (simp add: transferCaps_simple, rule monadic_rewrite_refl)
-   apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getReceiveSlots)+)
+   apply (rule monadic_rewrite_symb_exec_drop[OF _ empty_fail_getReceiveSlots], wp+)
    apply (rule monadic_rewrite_refl)
   apply simp
   done
@@ -1252,17 +1251,12 @@ lemma switchToThread_rewrite:
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
   apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_bind)
-     apply (rule tcbSchedDequeue_rewrite)
-      apply (rule monadic_rewrite_refl)
-     apply (wp Arch_switchToThread_obj_at_pre)+
    apply (rule monadic_rewrite_bind_tail)
-    apply (rule monadic_rewrite_symb_exec)
-       apply (wp+, simp)
+    apply (rule monadic_rewrite_trans)
+     apply (rule monadic_rewrite_bind_head[OF tcbSchedDequeue_rewrite])
+    apply (rule monadic_rewrite_symb_exec_drop, wp+)
     apply (rule monadic_rewrite_refl)
-   apply (wp)
+   apply (wp Arch_switchToThread_obj_at_pre)+
   apply (clarsimp simp: comp_def)
   done
 

--- a/proof/crefine/RISCV64/IsolatedThreadAction.thy
+++ b/proof/crefine/RISCV64/IsolatedThreadAction.thy
@@ -11,25 +11,8 @@ begin
 
 context begin interpretation Arch .
 
-datatype tcb_state_regs = TCBStateRegs "thread_state" "MachineTypes.register \<Rightarrow> machine_word"
-
-definition
- "tsrContext tsr \<equiv> case tsr of TCBStateRegs ts regs \<Rightarrow> regs"
-
-definition
- "tsrState tsr \<equiv> case tsr of TCBStateRegs ts regs \<Rightarrow> ts"
-
-lemma accessors_TCBStateRegs[simp]:
-  "TCBStateRegs (tsrState v) (tsrContext v) = v"
-  by (cases v, simp add: tsrState_def tsrContext_def)
-
-lemma tsrContext_simp[simp]:
-  "tsrContext (TCBStateRegs st con) = con"
-  by (simp add: tsrContext_def)
-
-lemma tsrState_simp[simp]:
-  "tsrState (TCBStateRegs st con) = st"
-  by (simp add: tsrState_def)
+datatype tcb_state_regs =
+  TCBStateRegs (tsrState : thread_state) (tsrContext : "MachineTypes.register \<Rightarrow> machine_word")
 
 definition
   get_tcb_state_regs :: "kernel_object option \<Rightarrow> tcb_state_regs"

--- a/proof/crefine/RISCV64/IsolatedThreadAction.thy
+++ b/proof/crefine/RISCV64/IsolatedThreadAction.thy
@@ -518,13 +518,13 @@ lemma thread_actions_isolatable_bind:
   apply (clarsimp simp: thread_actions_isolatable_def)
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
-    apply (erule monadic_rewrite_bind2, assumption)
+    apply (erule monadic_rewrite_bind_l, assumption)
     apply (rule hoare_vcg_all_lift, assumption)
    apply (subst isolate_thread_actions_wrap_bind, simp)
    apply simp
    apply (rule monadic_rewrite_in_isolate_thread_actions, assumption)
    apply (rule monadic_rewrite_transverse)
-    apply (erule monadic_rewrite_bind2, assumption)
+    apply (erule monadic_rewrite_bind_l, assumption)
     apply (rule hoare_vcg_all_lift, assumption)
    apply (simp add: bind_assoc id_def)
    apply (rule monadic_rewrite_refl)
@@ -719,7 +719,7 @@ lemma transferCaps_simple_rewrite:
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (simp add: transferCaps_simple, rule monadic_rewrite_refl)
-   apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getReceiveSlots)+)
+   apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getReceiveSlots)+)
    apply (rule monadic_rewrite_refl)
   apply simp
   done
@@ -785,9 +785,9 @@ lemma doIPCTransfer_simple_rewrite:
         apply (rule transferCaps_simple_rewrite)
        apply (wp threadGet_const)+
    apply (simp add: bind_assoc)
-   apply (rule monadic_rewrite_symb_exec2[OF lookupIPC_inv empty_fail_lookupIPCBuffer]
-               monadic_rewrite_symb_exec2[OF threadGet_inv empty_fail_threadGet]
-               monadic_rewrite_symb_exec2[OF user_getreg_inv' empty_fail_user_getreg]
+   apply (rule monadic_rewrite_symb_exec_drop[OF lookupIPC_inv empty_fail_lookupIPCBuffer]
+               monadic_rewrite_symb_exec_drop[OF threadGet_inv empty_fail_threadGet]
+               monadic_rewrite_symb_exec_drop[OF user_getreg_inv' empty_fail_user_getreg]
                monadic_rewrite_bind_head monadic_rewrite_bind_tail
                   | wp)+
     apply (case_tac "messageInfoFromWord msgInfo")
@@ -845,10 +845,10 @@ lemma setupCallerCap_rewrite:
      apply simp
      apply (rule monadic_rewrite_trans)
       apply (rule monadic_rewrite_bind_tail)
-       apply (rule monadic_rewrite_symb_exec2, (wp | simp)+)+
+       apply (rule monadic_rewrite_symb_exec_drop, (wp | simp)+)+
        apply (rule monadic_rewrite_refl)
       apply wp+
-     apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getCTE)+)+
+     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getCTE)+)+
      apply (rule monadic_rewrite_refl)
     apply (wp getCTE_wp' | simp add: cte_wp_at_ctes_of)+
   apply (clarsimp simp: reply_masters_rvk_fb_def)
@@ -935,10 +935,10 @@ lemma activateThread_simple_rewrite:
        apply simp
        apply (rule monadic_rewrite_refl)
       apply wp
-     apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getThreadState)+)
+     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getThreadState)+)
      apply (rule monadic_rewrite_refl)
     apply wp
-   apply (rule monadic_rewrite_symb_exec2,
+   apply (rule monadic_rewrite_symb_exec_drop,
           simp_all add: getCurThread_def)
    apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: ct_in_state'_def elim!: pred_tcb'_weakenE)
@@ -1239,7 +1239,7 @@ lemma tcbSchedDequeue_rewrite:
      apply (simp add: when_def)
      apply (rule monadic_rewrite_refl)
     apply (wp threadGet_const)
-   apply (rule monadic_rewrite_symb_exec2)
+   apply (rule monadic_rewrite_symb_exec_drop)
       apply wp+
    apply (rule monadic_rewrite_refl)
   apply (clarsimp)
@@ -1333,7 +1333,7 @@ lemma isolate_thread_actions_rewrite_bind:
    apply (subst isolate_thread_actions_wrap_bind, assumption)
    apply (rule monadic_rewrite_in_isolate_thread_actions, assumption)
    apply (rule monadic_rewrite_transverse)
-    apply (rule monadic_rewrite_bind2)
+    apply (rule monadic_rewrite_bind_l)
       apply (erule(1) thread_actions_isolatableD)
      apply (rule thread_actions_isolatableD, assumption+)
     apply (rule hoare_vcg_all_lift, assumption)
@@ -1448,14 +1448,14 @@ lemma monadic_rewrite_isolate_final2:
         apply auto[1]
        apply (rule_tac P="P and (\<lambda>s. tcbs = get_tcb_state_regs o ksPSpace s o idx
                                              \<and> sa = ksSchedulerAction s)"
-                    in monadic_rewrite_refl3)
+                    in monadic_rewrite_pre_imp_refl)
        apply (clarsimp simp: exec_modify eqs return_def)
       apply wp+
   apply (clarsimp simp: o_def eqs)
   done
 
 lemmas monadic_rewrite_isolate_final
-    = monadic_rewrite_isolate_final2[where R=\<top>, OF monadic_rewrite_refl2, simplified]
+    = monadic_rewrite_isolate_final2[where R=\<top>, OF monadic_rewrite_is_refl, simplified]
 
 lemma copy_registers_isolate_general:
   "\<lbrakk> inj idx; idx x = t; idx y = t' \<rbrakk> \<Longrightarrow>
@@ -1581,7 +1581,7 @@ lemma setThreadState_rewrite_simple:
           apply assumption
          apply (rule monadic_rewrite_refl)
         apply wp+
-     apply (rule monadic_rewrite_symb_exec2,
+     apply (rule monadic_rewrite_symb_exec_drop,
             (wp  empty_fail_isRunnable
                | (simp only: getCurThread_def getSchedulerAction_def
                       , rule empty_fail_gets))+)+

--- a/proof/crefine/RISCV64/IsolatedThreadAction.thy
+++ b/proof/crefine/RISCV64/IsolatedThreadAction.thy
@@ -516,7 +516,7 @@ lemma thread_actions_isolatable_bind:
        \<And>t. \<lbrace>tcb_at' t\<rbrace> f \<lbrace>\<lambda>rv. tcb_at' t\<rbrace> \<rbrakk>
      \<Longrightarrow> thread_actions_isolatable idx (f >>= g)"
   apply (clarsimp simp: thread_actions_isolatable_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (erule monadic_rewrite_bind2, assumption)
     apply (rule hoare_vcg_all_lift, assumption)
@@ -589,7 +589,7 @@ lemma select_f_isolatable:
   apply (clarsimp simp: thread_actions_isolatable_def
                         isolate_thread_actions_def
                         split_def select_f_selects liftM_def bind_assoc)
-  apply (rule monadic_rewrite_imp, rule monadic_rewrite_transverse)
+  apply (rule monadic_rewrite_guard_imp, rule monadic_rewrite_transverse)
     apply (rule monadic_rewrite_drop_modify monadic_rewrite_bind_tail)+
        apply wp+
    apply (simp add: gets_bind_ign getSchedulerAction_def)
@@ -716,7 +716,7 @@ lemma transferCaps_simple_rewrite:
    (return (mi \<lparr> msgExtraCaps := 0, msgCapsUnwrapped := 0 \<rparr>))"
   including no_pre
   apply (rule monadic_rewrite_gen_asm)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (simp add: transferCaps_simple, rule monadic_rewrite_refl)
    apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getReceiveSlots)+)
@@ -771,7 +771,7 @@ lemma doIPCTransfer_simple_rewrite:
   apply (simp add: doIPCTransfer_def bind_assoc doNormalTransfer_def
                    getMessageInfo_def
              cong: option.case_cong)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)+
       apply (rule_tac P="fault = None" in monadic_rewrite_gen_asm, simp)
@@ -801,7 +801,7 @@ lemma doIPCTransfer_simple_rewrite:
 lemma monadic_rewrite_setSchedulerAction_noop:
   "monadic_rewrite F E (\<lambda>s. ksSchedulerAction s = act) (setSchedulerAction act) (return ())"
   unfolding setSchedulerAction_def
-  apply (rule monadic_rewrite_imp, rule monadic_rewrite_modify_noop)
+  apply (rule monadic_rewrite_guard_imp, rule monadic_rewrite_modify_noop)
   apply simp
   done
 
@@ -836,7 +836,7 @@ lemma setupCallerCap_rewrite:
   apply (simp add: setupCallerCap_def getThreadCallerSlot_def
                    getThreadReplySlot_def locateSlot_conv
                    getSlotCap_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_bind_tail)+
      apply (rule monadic_rewrite_assert)+
      apply (rule_tac P="mdbFirstBadged (cteMDBNode masterCTE)
@@ -929,7 +929,7 @@ lemma activateThread_simple_rewrite:
   "monadic_rewrite True True (ct_in_state' ((=) Running))
        (activateThread) (return ())"
   apply (simp add: activateThread_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans, rule monadic_rewrite_bind_tail)+
        apply (rule_tac P="state = Running" in monadic_rewrite_gen_asm)
        apply simp
@@ -1232,7 +1232,7 @@ lemma thread_actions_isolatableD:
 lemma tcbSchedDequeue_rewrite:
   "monadic_rewrite True True (obj_at' (Not \<circ> tcbQueued) t) (tcbSchedDequeue t) (return ())"
   apply (simp add: tcbSchedDequeue_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule_tac P="\<not> queued" in monadic_rewrite_gen_asm)
@@ -1251,7 +1251,7 @@ lemma switchToThread_rewrite:
        (switchToThread t)
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule monadic_rewrite_bind)
@@ -1325,7 +1325,7 @@ lemma isolate_thread_actions_rewrite_bind:
     \<Longrightarrow> monadic_rewrite False True (\<lambda>s. \<forall>x. tcb_at' (idx x) s)
                (f >>= g) (isolate_thread_actions idx
                                   (f' >>= g') (g'' o f'') (g''' o f'''))"
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind, assumption+)
     apply (wp isolate_thread_actions_tcbs_at)
@@ -1440,7 +1440,7 @@ lemma monadic_rewrite_isolate_final2:
          (isolate_thread_actions idx f f' f'')
          (isolate_thread_actions idx g g' g'')"
   apply (simp add: isolate_thread_actions_def split_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_bind_tail)+
       apply (rule_tac P="\<lambda> s'. Q s" in monadic_rewrite_bind)
         apply (insert mr)[1]
@@ -1475,7 +1475,7 @@ lemma copy_registers_isolate_general:
                          select_f_returns o_def ksPSpace_update_partial_id)
    apply (simp add: return_def simpler_modify_def)
   apply (simp add: mapM_x_Cons)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule isolate_thread_actions_rewrite_bind, assumption)
         apply (rule copy_register_isolate, assumption+)
@@ -1570,7 +1570,7 @@ lemma setThreadState_rewrite_simple:
      (threadSet (tcbState_update (\<lambda>_. st)) t)"
   supply if_split[split del]
   apply (simp add: setThreadState_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule monadic_rewrite_trans)

--- a/proof/crefine/RISCV64/Refine_C.thy
+++ b/proof/crefine/RISCV64/Refine_C.thy
@@ -1102,7 +1102,7 @@ lemma kernel_all_subset_kernel:
                     check_active_irq_H_def checkActiveIRQ_def)
        apply clarsimp
        apply (erule in_monad_imp_rewriteE[where F=True])
-        apply (rule monadic_rewrite_imp)
+        apply (rule monadic_rewrite_guard_imp)
          apply (rule monadic_rewrite_bind_tail)+
            apply (rule monadic_rewrite_bind_head[where P=\<top>])
            apply (simp add: callKernel_C_def callKernel_withFastpath_C_def

--- a/proof/crefine/RISCV64/Schedule_C.thy
+++ b/proof/crefine/RISCV64/Schedule_C.thy
@@ -269,8 +269,6 @@ proof -
             apply (rule conseqPre, vcg)
             apply clarsimp
            apply (wp isRunnable_wp)+
-         apply (simp add: isRunnable_def)
-        apply wp
        apply (clarsimp simp: Let_def guard_is_UNIV_def)
        apply (drule invs_no_cicd'_queues)
        apply (case_tac queue, simp)

--- a/proof/crefine/X64/Invoke_C.thy
+++ b/proof/crefine/X64/Invoke_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/crefine/X64/Invoke_C.thy
+++ b/proof/crefine/X64/Invoke_C.thy
@@ -3480,16 +3480,14 @@ shows
     apply (rule_tac isBlocking=isBlocking and isCall=isCall and buffer=buffer
                 in decodeUntypedInvocation_ccorres_helper[unfolded K_def])
     apply assumption
-   apply (rule monadic_rewrite_transverse)
+   apply (rule monadic_rewrite_trans[rotated])
     apply (rule monadic_rewrite_bind_head)
-    apply (rule monadic_rewrite_bindE[OF monadic_rewrite_refl])
-     apply (simp add: liftE_bindE stateAssert_def2 bind_assoc)
-     apply (rule monadic_rewrite_bind_tail)
-      apply (rule_tac P=x in monadic_rewrite_gen_asm)
-      apply simp
+    apply (simp add: liftE_bindE stateAssert_def2 bind_assoc)
+    apply (monadic_rewrite_r monadic_rewrite_if_r_True)
+    apply (monadic_rewrite_r_method monadic_rewrite_symb_exec_r_drop wpsimp)
       apply (rule monadic_rewrite_refl)
-     apply (wp | simp)+
-   apply (simp add: gets_bind_ign)
+     apply wpsimp
+    apply (rule monadic_rewrite_refl)
    apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: ex_cte_cap_wp_to'_def excaps_in_mem_def)
   apply (drule(1) bspec)+

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -505,13 +505,11 @@ lemma getSanitiseRegisterInfo_moreMapM_comm:
    apply (auto split: option.splits)
   done
 
-
 lemma monadic_rewrite_threadGet_return:
   "monadic_rewrite True False (tcb_at' r) (return x) (do t \<leftarrow> threadGet f r; return x od)"
-  apply (rule monadic_rewrite_symb_exec_r')
-     apply wp+
-   apply (rule monadic_rewrite_refl)
-  apply wp
+  apply (rule monadic_rewrite_guard_imp)
+   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
+    apply wpsimp+
   done
 
 context begin interpretation Arch .
@@ -526,18 +524,16 @@ end
 
 lemma monadic_rewrite_getSanitiseRegisterInfo_return:
   "monadic_rewrite True False (tcb_at' r) (return x) (do t \<leftarrow> getSanitiseRegisterInfo r; return x od)"
-  apply (rule monadic_rewrite_symb_exec_r')
-     apply wp+
-   apply (rule monadic_rewrite_refl)
-  apply wp
+  apply (rule monadic_rewrite_guard_imp)
+   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
+    apply wpsimp+
   done
 
 lemma monadic_rewrite_getSanitiseRegisterInfo_drop:
   "monadic_rewrite True False (tcb_at' r) (d) (do t \<leftarrow> getSanitiseRegisterInfo r; d od)"
-  apply (rule monadic_rewrite_symb_exec_r')
-     apply wp+
-   apply (rule monadic_rewrite_refl)
-  apply wp
+  apply (rule monadic_rewrite_guard_imp)
+   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
+    apply wpsimp+
   done
 
 context kernel_m begin interpretation Arch .
@@ -559,6 +555,7 @@ lemma handleFaultReply':
     handleFaultReply f r (msgLabel tag) msg
   od) (handleFaultReply' f s r)"
   supply if_cong[cong]
+  supply empty_fail_asUser[wp] empty_fail_getRegister[wp]
   apply (unfold handleFaultReply'_def getMRs_def msgMaxLength_def
                 bit_def msgLengthBits_def msgRegisters_unfold
                 fromIntegral_simp1 fromIntegral_simp2
@@ -573,32 +570,32 @@ lemma handleFaultReply':
                             zip_Cons X64_H.exceptionMessage_def
                             X64.exceptionMessage_def
                             mapM_x_Cons mapM_x_Nil)
-      apply (rule monadic_rewrite_symb_exec_l, wp+)
-       apply (rule_tac P="tcb_at' s and tcb_at' r" in monadic_rewrite_inst)
-       apply (case_tac rv; (case_tac "msgLength tag < scast n_msgRegisters",
-               (erule disjE[OF word_less_cases],
-                 ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
-                                  mapM_x_Cons mapM_x_Nil bind_assoc
-                                  asUser_mapMloadWordUser_getSanitiseRegisterInfo_comm
-                                  asUser_getRegister_getSanitiseRegisterInfo_comm
-                                  asUser_getRegister_discarded asUser_mapMloadWordUser_threadGet_comm
-                                  asUser_comm[OF neq] asUser_getRegister_threadGet_comm
-                                  bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
-                                  word_le_nat_alt[of 4, simplified linorder_not_less[symmetric, of 4]]
-                                  asUser_return submonad_asUser.fn_stateAssert
-                 | rule monadic_rewrite_bind_tail monadic_rewrite_refl
-                        monadic_rewrite_symb_exec_l[OF stateAssert_inv]
-                        monadic_rewrite_symb_exec_l[OF mapM_x_mapM_valid[OF mapM_x_wp']]
-                 | wp asUser_typ_ats lookupIPCBuffer_inv )+)+))
-      apply wp
+      apply (rule monadic_rewrite_symb_exec_l)
+         apply (rule_tac P="tcb_at' s and tcb_at' r" in monadic_rewrite_inst)
+         apply (case_tac sb; (case_tac "msgLength tag < scast n_msgRegisters",
+                 (erule disjE[OF word_less_cases],
+                   ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
+                                    mapM_x_Cons mapM_x_Nil bind_assoc
+                                    asUser_mapMloadWordUser_getSanitiseRegisterInfo_comm
+                                    asUser_getRegister_getSanitiseRegisterInfo_comm
+                                    asUser_getRegister_discarded asUser_mapMloadWordUser_threadGet_comm
+                                    asUser_comm[OF neq] asUser_getRegister_threadGet_comm
+                                    bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
+                                    word_le_nat_alt[of 4, simplified linorder_not_less[symmetric, of 4]]
+                                    asUser_return submonad_asUser.fn_stateAssert
+                   | rule monadic_rewrite_bind_tail monadic_rewrite_refl
+                          monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
+                          monadic_rewrite_symb_exec_l[OF _ mapM_x_mapM_valid[OF mapM_x_wp']]
+                   | wp)+)+))
+        apply wp+
      (* capFault *)
-     apply (rule monadic_rewrite_symb_exec_l, (wp empty_fail_asUser empty_fail_getRegister)+)+
-          apply(case_tac rv)
-          apply (clarsimp
-                | rule monadic_rewrite_bind_tail monadic_rewrite_refl
-                       monadic_rewrite_symb_exec_l[OF mapM_x_mapM_valid[OF mapM_x_wp']]
-                | wp mapM_x_mapM_valid[OF mapM_x_wp'[OF loadWordUser_inv]]
-                     empty_fail_loadWordUser)+
+     apply (repeat 5 \<open>rule monadic_rewrite_symb_exec_l\<close>) (* until case sb *)
+                    apply (case_tac sb)
+                     apply (clarsimp
+                           | rule monadic_rewrite_bind_tail monadic_rewrite_refl
+                                  monadic_rewrite_symb_exec_l[OF _ mapM_x_mapM_valid[OF mapM_x_wp']]
+                           | wp mapM_x_mapM_valid[OF mapM_x_wp'[OF loadWordUser_inv]]
+                                empty_fail_loadWordUser)+
     (* UnknownSyscallException *)
     apply (simp add: zip_append2 mapM_x_append asUser_bind_distrib split_def bind_assoc)
     apply (rule monadic_rewrite_guard_imp)
@@ -627,87 +624,87 @@ lemma handleFaultReply':
                             upto_enum_word mapM_x_Cons mapM_x_Nil)
      apply (simp add: getSanitiseRegisterInfo_moreMapM_comm asUser_getRegister_getSanitiseRegisterInfo_comm getSanitiseRegisterInfo_lookupIPCBuffer_comm)
      apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_bind_tail [where Q="\<lambda>_. tcb_at' r"])
-      apply (case_tac sb)
+      apply (rule monadic_rewrite_bind_tail [where Q="\<lambda>_. tcb_at' r"])
+       apply (case_tac sb)
+        apply (case_tac "msgLength tag < scast n_msgRegisters")
+         apply (erule disjE[OF word_less_cases],
+                  ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
+                                   mapM_x_Cons mapM_x_Nil bind_assoc
+                                   asUser_getRegister_discarded
+                                   asUser_comm[OF neq] take_zip
+                                   word_le_nat_alt[of 4, simplified linorder_not_less[symmetric, of 4]]
+                                   asUser_return submonad_asUser.fn_stateAssert
+                  | rule monadic_rewrite_bind_tail monadic_rewrite_refl
+                         monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
+                  | wp asUser_typ_ats)+)+
        apply (case_tac "msgLength tag < scast n_msgRegisters")
         apply (erule disjE[OF word_less_cases],
-                 ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
-                                  mapM_x_Cons mapM_x_Nil bind_assoc
-                                  asUser_getRegister_discarded
-                                  asUser_comm[OF neq] take_zip
-                                  word_le_nat_alt[of 4, simplified linorder_not_less[symmetric, of 4]]
-                                  asUser_return submonad_asUser.fn_stateAssert
-                 | rule monadic_rewrite_bind_tail monadic_rewrite_refl
-                        monadic_rewrite_symb_exec_l[OF stateAssert_inv]
-                 | wp asUser_typ_ats)+)+
-      apply (case_tac "msgLength tag < scast n_msgRegisters")
-       apply (erule disjE[OF word_less_cases],
-                 ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
-                                  mapM_x_Cons mapM_x_Nil bind_assoc
-                                  zipWithM_x_Nil
-                                  asUser_getRegister_discarded
-                                  asUser_comm[OF neq] take_zip
-                                  bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
-                                  asUser_return submonad_asUser.fn_stateAssert
-                 | rule monadic_rewrite_bind_tail monadic_rewrite_refl
-                        monadic_rewrite_symb_exec_l[OF mapM_x_mapM_valid[OF mapM_x_wp']]
-                        monadic_rewrite_symb_exec_l[OF stateAssert_inv]
-                        monadic_rewrite_threadGet_return
-                        monadic_rewrite_getSanitiseRegisterInfo_return
-                 | wp asUser_typ_ats mapM_wp')+)+
-      apply (simp add: n_msgRegisters_def word_le_nat_alt n_syscallMessage_def
-                       linorder_not_less syscallMessage_unfold)
-      apply (clarsimp | frule neq0_conv[THEN iffD2, THEN not0_implies_Suc,
-                                        OF order_less_le_trans, rotated])+
-      apply (subgoal_tac "\<forall>n :: machine_word. n \<le> scast n_syscallMessage \<longrightarrow> [n .e. msgMaxLength]
-                                = [n .e. scast n_syscallMessage]
-                                    @ [scast n_syscallMessage + 1 .e. msgMaxLength]")
-       apply (simp only: upto_enum_word[where y="scast n_syscallMessage :: machine_word"]
-                         upto_enum_word[where y="scast n_syscallMessage + 1 :: machine_word"])
-       apply (clarsimp simp: bind_assoc asUser_bind_distrib asUser_getRegister_threadGet_comm
-                             mapM_x_Cons mapM_x_Nil threadGet_discarded
-                             asUser_comm [OF neq] asUser_getRegister_discarded
-                             submonad_asUser.fn_stateAssert take_zip
-                             bind_subst_lift [OF submonad_asUser.stateAssert_fn]
-                             word_less_nat_alt X64_H.sanitiseRegister_def
-                             split_def n_msgRegisters_def msgMaxLength_def
-                             bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
-                             word_size msgLengthBits_def n_syscallMessage_def Let_def
-                  split del: if_split
-                       cong: if_weak_cong register.case_cong)
+                  ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
+                                   mapM_x_Cons mapM_x_Nil bind_assoc
+                                   zipWithM_x_Nil
+                                   asUser_getRegister_discarded
+                                   asUser_comm[OF neq] take_zip
+                                   bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
+                                   asUser_return submonad_asUser.fn_stateAssert
+                  | rule monadic_rewrite_bind_tail monadic_rewrite_refl
+                         monadic_rewrite_symb_exec_l[OF _ mapM_x_mapM_valid[OF mapM_x_wp']]
+                         monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
+                         monadic_rewrite_threadGet_return
+                         monadic_rewrite_getSanitiseRegisterInfo_return
+                  | wp asUser_typ_ats mapM_wp')+)+
+       apply (simp add: n_msgRegisters_def word_le_nat_alt n_syscallMessage_def
+                        linorder_not_less syscallMessage_unfold)
+       apply (clarsimp | frule neq0_conv[THEN iffD2, THEN not0_implies_Suc,
+                                         OF order_less_le_trans, rotated])+
+       apply (subgoal_tac "\<forall>n :: machine_word. n \<le> scast n_syscallMessage \<longrightarrow> [n .e. msgMaxLength]
+                                 = [n .e. scast n_syscallMessage]
+                                     @ [scast n_syscallMessage + 1 .e. msgMaxLength]")
+        apply (simp only: upto_enum_word[where y="scast n_syscallMessage :: machine_word"]
+                          upto_enum_word[where y="scast n_syscallMessage + 1 :: machine_word"])
+        apply (clarsimp simp: bind_assoc asUser_bind_distrib asUser_getRegister_threadGet_comm
+                              mapM_x_Cons mapM_x_Nil threadGet_discarded
+                              asUser_comm [OF neq] asUser_getRegister_discarded
+                              submonad_asUser.fn_stateAssert take_zip
+                              bind_subst_lift [OF submonad_asUser.stateAssert_fn]
+                              word_less_nat_alt X64_H.sanitiseRegister_def
+                              split_def n_msgRegisters_def msgMaxLength_def
+                              bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
+                              word_size msgLengthBits_def n_syscallMessage_def Let_def
+                   split del: if_split
+                        cong: if_weak_cong register.case_cong)
 
 
-       apply (rule monadic_rewrite_bind_tail)+
-               apply (subst (2) upto_enum_word)
-               apply (case_tac "ma < unat n_syscallMessage - 4")
+        apply (rule monadic_rewrite_bind_tail)+
+                apply (subst (2) upto_enum_word)
+                apply (case_tac "ma < unat n_syscallMessage - 4")
 
-                apply (erule disjE[OF nat_less_cases'],
-                       ( clarsimp simp: n_syscallMessage_def bind_assoc asUser_bind_distrib
-                                        mapM_x_Cons mapM_x_Nil zipWithM_x_mapM_x mapM_Cons
-                                        bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
-                                        asUser_loadWordUser_comm loadWordUser_discarded asUser_return
-                                        zip_take_triv2 msgMaxLength_def
-                                        no_fail_stateAssert
-                                  cong: if_weak_cong
-                       | simp
-                       | rule monadic_rewrite_bind_tail
-                              monadic_rewrite_refl
-                              monadic_rewrite_symb_exec_l[OF stateAssert_inv]
-                              monadic_rewrite_symb_exec_l[OF mapM_x_mapM_valid[OF mapM_x_wp']]
-                              monadic_rewrite_threadGet_return
-                              monadic_rewrite_getSanitiseRegisterInfo_return
-                              monadic_rewrite_getSanitiseRegisterInfo_drop
-                       | wp asUser_typ_ats empty_fail_loadWordUser)+)+
-      apply (clarsimp simp: upto_enum_word word_le_nat_alt simp del: upt.simps cong: if_weak_cong)
-      apply (cut_tac i="unat n" and j="Suc (unat (scast n_syscallMessage :: machine_word))"
-                                and k="Suc msgMaxLength" in upt_add_eq_append')
-        apply (simp add: n_syscallMessage_def)
-       apply (simp add: n_syscallMessage_def msgMaxLength_unfold)
-      apply (simp add: n_syscallMessage_def msgMaxLength_def
-                       msgLengthBits_def shiftL_nat
-                  del: upt.simps upt_rec_numeral)
-      apply (simp add: upto_enum_word cong: if_weak_cong)
-     apply wp+
+                 apply (erule disjE[OF nat_less_cases'],
+                        ( clarsimp simp: n_syscallMessage_def bind_assoc asUser_bind_distrib
+                                         mapM_x_Cons mapM_x_Nil zipWithM_x_mapM_x mapM_Cons
+                                         bind_comm_mapM_comm [OF asUser_loadWordUser_comm, symmetric]
+                                         asUser_loadWordUser_comm loadWordUser_discarded asUser_return
+                                         zip_take_triv2 msgMaxLength_def
+                                         no_fail_stateAssert
+                                   cong: if_weak_cong
+                        | simp
+                        | rule monadic_rewrite_bind_tail
+                               monadic_rewrite_refl
+                               monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
+                               monadic_rewrite_symb_exec_l[OF _ mapM_x_mapM_valid[OF mapM_x_wp']]
+                               monadic_rewrite_threadGet_return
+                               monadic_rewrite_getSanitiseRegisterInfo_return
+                               monadic_rewrite_getSanitiseRegisterInfo_drop
+                        | wp asUser_typ_ats empty_fail_loadWordUser)+)+
+       apply (clarsimp simp: upto_enum_word word_le_nat_alt simp del: upt.simps cong: if_weak_cong)
+       apply (cut_tac i="unat n" and j="Suc (unat (scast n_syscallMessage :: machine_word))"
+                                 and k="Suc msgMaxLength" in upt_add_eq_append')
+         apply (simp add: n_syscallMessage_def)
+        apply (simp add: n_syscallMessage_def msgMaxLength_unfold)
+       apply (simp add: n_syscallMessage_def msgMaxLength_def
+                        msgLengthBits_def shiftL_nat
+                   del: upt.simps upt_rec_numeral)
+       apply (simp add: upto_enum_word cong: if_weak_cong)
+      apply wp+
     (* ArchFault *)
     apply (simp add: neq inj_case_bool split: bool.split)
    apply (rule monadic_rewrite_guard_imp)

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -601,13 +601,13 @@ lemma handleFaultReply':
                      empty_fail_loadWordUser)+
     (* UnknownSyscallException *)
     apply (simp add: zip_append2 mapM_x_append asUser_bind_distrib split_def bind_assoc)
-    apply (rule monadic_rewrite_imp)
+    apply (rule monadic_rewrite_guard_imp)
      apply (rule monadic_rewrite_trans[rotated])
       apply (rule monadic_rewrite_do_flip)
       apply (rule monadic_rewrite_bind_tail)
        apply (rule_tac P="inj (case_bool s r)" in monadic_rewrite_gen_asm)
        apply (rule monadic_rewrite_trans[OF _ monadic_rewrite_transverse])
-         apply (rule monadic_rewrite_weaken[where F=False and E=True], simp)
+         apply (rule monadic_rewrite_weaken_flags[where F=False and E=True], simp)
          apply (rule isolate_thread_actions_rewrite_bind
                      bool.simps setRegister_simple
                      zipWithM_setRegister_simple
@@ -710,7 +710,7 @@ lemma handleFaultReply':
      apply wp+
     (* ArchFault *)
     apply (simp add: neq inj_case_bool split: bool.split)
-   apply (rule monadic_rewrite_imp)
+   apply (rule monadic_rewrite_guard_imp)
     apply (rule monadic_rewrite_is_refl)
     apply (rule ext)
     apply (unfold handleArchFaultReply'[symmetric] getMRs_def msgMaxLength_def

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -507,9 +507,8 @@ lemma getSanitiseRegisterInfo_moreMapM_comm:
 
 lemma monadic_rewrite_threadGet_return:
   "monadic_rewrite True False (tcb_at' r) (return x) (do t \<leftarrow> threadGet f r; return x od)"
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
-    apply wpsimp+
+  apply (wp_pre, monadic_rewrite_symb_exec_r_drop)
+   apply (auto intro: monadic_rewrite_refl)
   done
 
 context begin interpretation Arch .
@@ -524,16 +523,14 @@ end
 
 lemma monadic_rewrite_getSanitiseRegisterInfo_return:
   "monadic_rewrite True False (tcb_at' r) (return x) (do t \<leftarrow> getSanitiseRegisterInfo r; return x od)"
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
-    apply wpsimp+
+  apply (wp_pre, monadic_rewrite_symb_exec_r_drop)
+   apply (auto intro: monadic_rewrite_refl)
   done
 
 lemma monadic_rewrite_getSanitiseRegisterInfo_drop:
   "monadic_rewrite True False (tcb_at' r) (d) (do t \<leftarrow> getSanitiseRegisterInfo r; d od)"
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_r_drop_nE[OF monadic_rewrite_refl])
-    apply wpsimp+
+  apply (wp_pre, monadic_rewrite_symb_exec_r_drop)
+   apply (auto intro: monadic_rewrite_refl)
   done
 
 context kernel_m begin interpretation Arch .

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -723,10 +723,9 @@ lemma transferCaps_simple_rewrite:
    (return (mi \<lparr> msgExtraCaps := 0, msgCapsUnwrapped := 0 \<rparr>))"
   including no_pre
   apply (rule monadic_rewrite_gen_asm)
+  apply (simp add: transferCaps_simple)
   apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (simp add: transferCaps_simple, rule monadic_rewrite_refl)
-   apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getReceiveSlots)+)
+   apply (rule monadic_rewrite_symb_exec_drop[OF _ empty_fail_getReceiveSlots], wp+)
    apply (rule monadic_rewrite_refl)
   apply simp
   done
@@ -1263,17 +1262,12 @@ lemma switchToThread_rewrite:
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
   apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_bind)
-     apply (rule tcbSchedDequeue_rewrite)
-      apply (rule monadic_rewrite_refl)
-     apply (wp Arch_switchToThread_obj_at_pre)+
    apply (rule monadic_rewrite_bind_tail)
-    apply (rule monadic_rewrite_symb_exec)
-       apply (wp+, simp)
+    apply (rule monadic_rewrite_trans)
+     apply (rule monadic_rewrite_bind_head[OF tcbSchedDequeue_rewrite])
+    apply (rule monadic_rewrite_symb_exec_drop, wp+)
     apply (rule monadic_rewrite_refl)
-   apply (wp)
+   apply (wp Arch_switchToThread_obj_at_pre)+
   apply (clarsimp simp: comp_def)
   done
 

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -10,25 +10,8 @@ begin
 
 context begin interpretation Arch .
 
-datatype tcb_state_regs = TCBStateRegs "thread_state" "MachineTypes.register \<Rightarrow> machine_word"
-
-definition
- "tsrContext tsr \<equiv> case tsr of TCBStateRegs ts regs \<Rightarrow> regs"
-
-definition
- "tsrState tsr \<equiv> case tsr of TCBStateRegs ts regs \<Rightarrow> ts"
-
-lemma accessors_TCBStateRegs[simp]:
-  "TCBStateRegs (tsrState v) (tsrContext v) = v"
-  by (cases v, simp add: tsrState_def tsrContext_def)
-
-lemma tsrContext_simp[simp]:
-  "tsrContext (TCBStateRegs st con) = con"
-  by (simp add: tsrContext_def)
-
-lemma tsrState_simp[simp]:
-  "tsrState (TCBStateRegs st con) = st"
-  by (simp add: tsrState_def)
+datatype tcb_state_regs =
+  TCBStateRegs (tsrState : thread_state) (tsrContext : "MachineTypes.register \<Rightarrow> machine_word")
 
 definition
   get_tcb_state_regs :: "kernel_object option \<Rightarrow> tcb_state_regs"

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -722,11 +722,11 @@ lemma transferCaps_simple_rewrite:
    (transferCaps mi caps ep r rBuf)
    (return (mi \<lparr> msgExtraCaps := 0, msgCapsUnwrapped := 0 \<rparr>))"
   including no_pre
+  supply empty_fail_getReceiveSlots[wp] (* FIXME *)
   apply (rule monadic_rewrite_gen_asm)
   apply (simp add: transferCaps_simple)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_l_drop[OF monadic_rewrite_refl _ empty_fail_getReceiveSlots])
-   apply wpsimp+
+  apply (monadic_rewrite_symb_exec_l_drop, rule monadic_rewrite_refl)
+  apply simp
   done
 
 lemma lookupExtraCaps_simple_rewrite:
@@ -779,10 +779,10 @@ lemma doIPCTransfer_simple_rewrite:
              cong: option.case_cong)
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)+
-      apply (rule_tac P="fault = None" in monadic_rewrite_gen_asm, simp)
+    apply (rule monadic_rewrite_bind_tail)
+      apply (monadic_rewrite_symb_exec_l_known None, simp)
       apply (rule monadic_rewrite_bind_tail)
-       apply (rule_tac rv=msgInfo in monadic_rewrite_symb_exec_l_known_F)
+       apply (monadic_rewrite_symb_exec_l_known msgInfo)
           apply (simp add: lookupExtraCaps_simple_rewrite returnOk_catch_bind)
           apply (rule monadic_rewrite_bind)
             apply (rule monadic_rewrite_from_simple, rule copyMRs_simple)
@@ -841,23 +841,19 @@ lemma setupCallerCap_rewrite:
   apply (simp add: setupCallerCap_def getThreadCallerSlot_def
                    getThreadReplySlot_def locateSlot_conv
                    getSlotCap_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_bind_tail)+
-     apply (rule monadic_rewrite_assert)+
-     apply (rule_tac P="mdbFirstBadged (cteMDBNode masterCTE)
-                        \<and> mdbRevocable (cteMDBNode masterCTE)"
-                 in monadic_rewrite_gen_asm)
-     apply simp
-     apply (rule monadic_rewrite_trans)
-      apply (rule monadic_rewrite_bind_tail)
-       apply (rule monadic_rewrite_symb_exec_l_drop)+
-         apply (rule monadic_rewrite_refl)
-        apply wpsimp+
-     apply (rule monadic_rewrite_symb_exec_l_drop)+
-       apply (rule monadic_rewrite_refl)
-      apply (wp getCTE_wp' | simp add: cte_wp_at_ctes_of)+
-  apply (clarsimp simp: reply_masters_rvk_fb_def)
-  apply fastforce
+  apply (rule monadic_rewrite_bind_tail)+
+    apply (rule monadic_rewrite_assert)+
+    apply (rule_tac P="mdbFirstBadged (cteMDBNode masterCTE)
+                       \<and> mdbRevocable (cteMDBNode masterCTE)"
+                in monadic_rewrite_gen_asm)
+    apply (rule monadic_rewrite_trans)
+     apply monadic_rewrite_symb_exec_l
+      apply monadic_rewrite_symb_exec_l_drop
+      apply (rule monadic_rewrite_refl)
+     apply wpsimp+
+    apply (rule monadic_rewrite_refl)
+   apply (wpsimp wp: getCTE_wp' simp: cte_wp_at_ctes_of)+
+  apply (fastforce simp: reply_masters_rvk_fb_def)
   done
 
 lemma oblivious_getObject_ksPSpace_default:
@@ -938,18 +934,11 @@ lemma activateThread_simple_rewrite:
   "monadic_rewrite True True (ct_in_state' ((=) Running))
        (activateThread) (return ())"
   apply (simp add: activateThread_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans, rule monadic_rewrite_bind_tail)+
-       apply (rule_tac P="state = Running" in monadic_rewrite_gen_asm)
-       apply simp
+  apply wp_pre
+  apply (monadic_rewrite_symb_exec_l)
+  apply (monadic_rewrite_symb_exec_l_known Running, simp)
        apply (rule monadic_rewrite_refl)
-      apply wp
-     apply (rule monadic_rewrite_symb_exec_l_drop)
-       apply (rule monadic_rewrite_refl)
-      apply (wp empty_fail_getThreadState)+
-   apply (rule monadic_rewrite_symb_exec_l_drop,
-          simp_all add: getCurThread_def)
-   apply (rule monadic_rewrite_refl)
+     apply wpsimp+
   apply (clarsimp simp: ct_in_state'_def elim!: pred_tcb'_weakenE)
   done
 
@@ -1243,17 +1232,9 @@ lemma thread_actions_isolatableD:
 lemma tcbSchedDequeue_rewrite:
   "monadic_rewrite True True (obj_at' (Not \<circ> tcbQueued) t) (tcbSchedDequeue t) (return ())"
   apply (simp add: tcbSchedDequeue_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule_tac P="\<not> queued" in monadic_rewrite_gen_asm)
-     apply (simp add: when_def)
-     apply (rule monadic_rewrite_refl)
-    apply (wp threadGet_const)
-   apply (rule monadic_rewrite_symb_exec_l_drop)
-     apply (rule monadic_rewrite_refl)
-    apply wp+
-  apply (clarsimp)
+   apply (wp_pre, monadic_rewrite_symb_exec_l_known False, simp)
+    apply (rule monadic_rewrite_refl)
+   apply (wpsimp wp: threadGet_const)+
   done
 
 lemma switchToThread_rewrite:
@@ -1262,13 +1243,8 @@ lemma switchToThread_rewrite:
        (switchToThread t)
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_bind_tail)
-    apply (rule monadic_rewrite_trans)
-     apply (rule monadic_rewrite_bind_head[OF tcbSchedDequeue_rewrite])
-    apply (rule monadic_rewrite_symb_exec_l_drop)
-      apply (rule monadic_rewrite_refl)
-     apply (wp Arch_switchToThread_obj_at_pre)+
+  apply (monadic_rewrite_l tcbSchedDequeue_rewrite, simp)
+   apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: comp_def)
   done
 
@@ -1576,9 +1552,8 @@ lemma setThreadState_rewrite_simple:
      (threadSet (tcbState_update (\<lambda>_. st)) t)"
   supply if_split[split del]
   apply (simp add: setThreadState_def when_def)
-  apply (monadic_rewrite_l
-           \<open>wpsimp wp: hoare_vcg_disj_lift hoare_vcg_imp_lift' threadSet_tcbState_st_tcb_at'\<close>
-           r: monadic_rewrite_if_l_False)
+  apply (monadic_rewrite_l monadic_rewrite_if_l_False
+           \<open>wpsimp wp: hoare_vcg_disj_lift hoare_vcg_imp_lift' threadSet_tcbState_st_tcb_at'\<close>)
    (* take the threadSet, drop everything until return () *)
    apply (rule monadic_rewrite_trans[OF monadic_rewrite_bind_tail])
      apply (rule monadic_rewrite_symb_exec_l_drop)+

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -519,13 +519,13 @@ lemma thread_actions_isolatable_bind:
   apply (clarsimp simp: thread_actions_isolatable_def)
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
-    apply (erule monadic_rewrite_bind2, assumption)
+    apply (erule monadic_rewrite_bind_l, assumption)
     apply (rule hoare_vcg_all_lift, assumption)
    apply (subst isolate_thread_actions_wrap_bind, simp)
    apply simp
    apply (rule monadic_rewrite_in_isolate_thread_actions, assumption)
    apply (rule monadic_rewrite_transverse)
-    apply (erule monadic_rewrite_bind2, assumption)
+    apply (erule monadic_rewrite_bind_l, assumption)
     apply (rule hoare_vcg_all_lift, assumption)
    apply (simp add: bind_assoc id_def)
    apply (rule monadic_rewrite_refl)
@@ -726,7 +726,7 @@ lemma transferCaps_simple_rewrite:
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (simp add: transferCaps_simple, rule monadic_rewrite_refl)
-   apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getReceiveSlots)+)
+   apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getReceiveSlots)+)
    apply (rule monadic_rewrite_refl)
   apply simp
   done
@@ -792,9 +792,9 @@ lemma doIPCTransfer_simple_rewrite:
         apply (rule transferCaps_simple_rewrite)
        apply (wp threadGet_const)+
    apply (simp add: bind_assoc)
-   apply (rule monadic_rewrite_symb_exec2[OF lookupIPC_inv empty_fail_lookupIPCBuffer]
-               monadic_rewrite_symb_exec2[OF threadGet_inv empty_fail_threadGet]
-               monadic_rewrite_symb_exec2[OF user_getreg_inv' empty_fail_user_getreg]
+   apply (rule monadic_rewrite_symb_exec_drop[OF lookupIPC_inv empty_fail_lookupIPCBuffer]
+               monadic_rewrite_symb_exec_drop[OF threadGet_inv empty_fail_threadGet]
+               monadic_rewrite_symb_exec_drop[OF user_getreg_inv' empty_fail_user_getreg]
                monadic_rewrite_bind_head monadic_rewrite_bind_tail
                   | wp)+
     apply (case_tac "messageInfoFromWord msgInfo")
@@ -852,10 +852,10 @@ lemma setupCallerCap_rewrite:
      apply simp
      apply (rule monadic_rewrite_trans)
       apply (rule monadic_rewrite_bind_tail)
-       apply (rule monadic_rewrite_symb_exec2, (wp | simp)+)+
+       apply (rule monadic_rewrite_symb_exec_drop, (wp | simp)+)+
        apply (rule monadic_rewrite_refl)
       apply wp+
-     apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getCTE)+)+
+     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getCTE)+)+
      apply (rule monadic_rewrite_refl)
     apply (wp getCTE_wp' | simp add: cte_wp_at_ctes_of)+
   apply (clarsimp simp: reply_masters_rvk_fb_def)
@@ -944,10 +944,10 @@ lemma activateThread_simple_rewrite:
        apply simp
        apply (rule monadic_rewrite_refl)
       apply wp
-     apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getThreadState)+)
+     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getThreadState)+)
      apply (rule monadic_rewrite_refl)
     apply wp
-   apply (rule monadic_rewrite_symb_exec2,
+   apply (rule monadic_rewrite_symb_exec_drop,
           simp_all add: getCurThread_def)
    apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: ct_in_state'_def elim!: pred_tcb'_weakenE)
@@ -1250,7 +1250,7 @@ lemma tcbSchedDequeue_rewrite:
      apply (simp add: when_def)
      apply (rule monadic_rewrite_refl)
     apply (wp threadGet_const)
-   apply (rule monadic_rewrite_symb_exec2)
+   apply (rule monadic_rewrite_symb_exec_drop)
       apply wp+
    apply (rule monadic_rewrite_refl)
   apply (clarsimp)
@@ -1344,7 +1344,7 @@ lemma isolate_thread_actions_rewrite_bind:
    apply (subst isolate_thread_actions_wrap_bind, assumption)
    apply (rule monadic_rewrite_in_isolate_thread_actions, assumption)
    apply (rule monadic_rewrite_transverse)
-    apply (rule monadic_rewrite_bind2)
+    apply (rule monadic_rewrite_bind_l)
       apply (erule(1) thread_actions_isolatableD)
      apply (rule thread_actions_isolatableD, assumption+)
     apply (rule hoare_vcg_all_lift, assumption)
@@ -1459,14 +1459,14 @@ lemma monadic_rewrite_isolate_final2:
         apply auto[1]
        apply (rule_tac P="P and (\<lambda>s. tcbs = get_tcb_state_regs o ksPSpace s o idx
                                              \<and> sa = ksSchedulerAction s)"
-                    in monadic_rewrite_refl3)
+                    in monadic_rewrite_pre_imp_refl)
        apply (clarsimp simp: exec_modify eqs return_def)
       apply wp+
   apply (clarsimp simp: o_def eqs)
   done
 
 lemmas monadic_rewrite_isolate_final
-    = monadic_rewrite_isolate_final2[where R=\<top>, OF monadic_rewrite_refl2, simplified]
+    = monadic_rewrite_isolate_final2[where R=\<top>, OF monadic_rewrite_is_refl, simplified]
 
 lemma copy_registers_isolate_general:
   "\<lbrakk> inj idx; idx x = t; idx y = t' \<rbrakk> \<Longrightarrow>
@@ -1592,7 +1592,7 @@ lemma setThreadState_rewrite_simple:
           apply assumption
          apply (rule monadic_rewrite_refl)
         apply wp+
-     apply (rule monadic_rewrite_symb_exec2,
+     apply (rule monadic_rewrite_symb_exec_drop,
             (wp  empty_fail_isRunnable
                | (simp only: getCurThread_def getSchedulerAction_def
                       , rule empty_fail_gets))+)+

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -725,9 +725,8 @@ lemma transferCaps_simple_rewrite:
   apply (rule monadic_rewrite_gen_asm)
   apply (simp add: transferCaps_simple)
   apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_symb_exec_drop[OF _ empty_fail_getReceiveSlots], wp+)
-   apply (rule monadic_rewrite_refl)
-  apply simp
+   apply (rule monadic_rewrite_symb_exec_l_drop[OF monadic_rewrite_refl _ empty_fail_getReceiveSlots])
+   apply wpsimp+
   done
 
 lemma lookupExtraCaps_simple_rewrite:
@@ -740,7 +739,8 @@ lemma lookupExtraCaps_simple_rewrite:
 lemma lookupIPC_inv: "\<lbrace>P\<rbrace> lookupIPCBuffer f t \<lbrace>\<lambda>rv. P\<rbrace>"
   by wp
 
-lemmas empty_fail_user_getreg = empty_fail_asUser[OF empty_fail_getRegister]
+(* FIXME move *)
+lemmas empty_fail_user_getreg[intro!, wp, simp] = empty_fail_asUser[OF empty_fail_getRegister]
 
 lemma copyMRs_simple:
   "msglen \<le> of_nat (length msgRegisters) \<longrightarrow>
@@ -782,20 +782,18 @@ lemma doIPCTransfer_simple_rewrite:
     apply (rule monadic_rewrite_bind_tail)+
       apply (rule_tac P="fault = None" in monadic_rewrite_gen_asm, simp)
       apply (rule monadic_rewrite_bind_tail)
-       apply (rule_tac x=msgInfo in monadic_rewrite_symb_exec,
-              (wp empty_fail_user_getreg user_getreg_rv)+)
-       apply (simp add: lookupExtraCaps_simple_rewrite returnOk_catch_bind)
-       apply (rule monadic_rewrite_bind)
-         apply (rule monadic_rewrite_from_simple, rule copyMRs_simple)
-        apply (rule monadic_rewrite_bind_head)
-        apply (rule transferCaps_simple_rewrite)
-       apply (wp threadGet_const)+
+       apply (rule_tac rv=msgInfo in monadic_rewrite_symb_exec_l_known_F)
+          apply (simp add: lookupExtraCaps_simple_rewrite returnOk_catch_bind)
+          apply (rule monadic_rewrite_bind)
+            apply (rule monadic_rewrite_from_simple, rule copyMRs_simple)
+           apply (rule monadic_rewrite_bind_head)
+           apply (rule transferCaps_simple_rewrite)
+          apply (wp threadGet_const user_getreg_rv asUser_inv)+
    apply (simp add: bind_assoc)
-   apply (rule monadic_rewrite_symb_exec_drop[OF lookupIPC_inv empty_fail_lookupIPCBuffer]
-               monadic_rewrite_symb_exec_drop[OF threadGet_inv empty_fail_threadGet]
-               monadic_rewrite_symb_exec_drop[OF user_getreg_inv' empty_fail_user_getreg]
-               monadic_rewrite_bind_head monadic_rewrite_bind_tail
-                  | wp)+
+   apply (rule monadic_rewrite_symb_exec_l_drop[OF _ lookupIPC_inv empty_fail_lookupIPCBuffer]
+               monadic_rewrite_symb_exec_l_drop[OF _ threadGet_inv empty_fail_threadGet]
+               monadic_rewrite_symb_exec_l_drop[OF _ user_getreg_inv' empty_fail_user_getreg]
+               monadic_rewrite_bind_head monadic_rewrite_bind_tail)+
     apply (case_tac "messageInfoFromWord msgInfo")
     apply simp
     apply (rule monadic_rewrite_refl)
@@ -821,7 +819,8 @@ lemma rescheduleRequired_simple_rewrite:
   apply auto
   done
 
-lemma empty_fail_isRunnable:
+(* FIXME move *)
+lemma empty_fail_isRunnable[intro!, wp, simp]:
   "empty_fail (isRunnable t)"
   by (simp add: isRunnable_def isStopped_def)
 
@@ -851,12 +850,12 @@ lemma setupCallerCap_rewrite:
      apply simp
      apply (rule monadic_rewrite_trans)
       apply (rule monadic_rewrite_bind_tail)
-       apply (rule monadic_rewrite_symb_exec_drop, (wp | simp)+)+
+       apply (rule monadic_rewrite_symb_exec_l_drop)+
+         apply (rule monadic_rewrite_refl)
+        apply wpsimp+
+     apply (rule monadic_rewrite_symb_exec_l_drop)+
        apply (rule monadic_rewrite_refl)
-      apply wp+
-     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getCTE)+)+
-     apply (rule monadic_rewrite_refl)
-    apply (wp getCTE_wp' | simp add: cte_wp_at_ctes_of)+
+      apply (wp getCTE_wp' | simp add: cte_wp_at_ctes_of)+
   apply (clarsimp simp: reply_masters_rvk_fb_def)
   apply fastforce
   done
@@ -931,8 +930,10 @@ lemma oblivious_switchToThread_schact:
   by (safe intro!: oblivious_bind
               | simp_all add: oblivious_setVMRoot_schact)+
 
-lemma empty_fail_getCurThread[iff]:
+(* FIXME move *)
+lemma empty_fail_getCurThread[intro!, wp, simp]:
   "empty_fail getCurThread" by (simp add: getCurThread_def)
+
 lemma activateThread_simple_rewrite:
   "monadic_rewrite True True (ct_in_state' ((=) Running))
        (activateThread) (return ())"
@@ -943,10 +944,10 @@ lemma activateThread_simple_rewrite:
        apply simp
        apply (rule monadic_rewrite_refl)
       apply wp
-     apply (rule monadic_rewrite_symb_exec_drop, (wp empty_fail_getThreadState)+)
-     apply (rule monadic_rewrite_refl)
-    apply wp
-   apply (rule monadic_rewrite_symb_exec_drop,
+     apply (rule monadic_rewrite_symb_exec_l_drop)
+       apply (rule monadic_rewrite_refl)
+      apply (wp empty_fail_getThreadState)+
+   apply (rule monadic_rewrite_symb_exec_l_drop,
           simp_all add: getCurThread_def)
    apply (rule monadic_rewrite_refl)
   apply (clarsimp simp: ct_in_state'_def elim!: pred_tcb'_weakenE)
@@ -1249,9 +1250,9 @@ lemma tcbSchedDequeue_rewrite:
      apply (simp add: when_def)
      apply (rule monadic_rewrite_refl)
     apply (wp threadGet_const)
-   apply (rule monadic_rewrite_symb_exec_drop)
-      apply wp+
-   apply (rule monadic_rewrite_refl)
+   apply (rule monadic_rewrite_symb_exec_l_drop)
+     apply (rule monadic_rewrite_refl)
+    apply wp+
   apply (clarsimp)
   done
 
@@ -1265,9 +1266,9 @@ lemma switchToThread_rewrite:
    apply (rule monadic_rewrite_bind_tail)
     apply (rule monadic_rewrite_trans)
      apply (rule monadic_rewrite_bind_head[OF tcbSchedDequeue_rewrite])
-    apply (rule monadic_rewrite_symb_exec_drop, wp+)
-    apply (rule monadic_rewrite_refl)
-   apply (wp Arch_switchToThread_obj_at_pre)+
+    apply (rule monadic_rewrite_symb_exec_l_drop)
+      apply (rule monadic_rewrite_refl)
+     apply (wp Arch_switchToThread_obj_at_pre)+
   apply (clarsimp simp: comp_def)
   done
 
@@ -1453,7 +1454,7 @@ lemma monadic_rewrite_isolate_final2:
         apply auto[1]
        apply (rule_tac P="P and (\<lambda>s. tcbs = get_tcb_state_regs o ksPSpace s o idx
                                              \<and> sa = ksSchedulerAction s)"
-                    in monadic_rewrite_pre_imp_refl)
+                    in monadic_rewrite_pre_imp_eq)
        apply (clarsimp simp: exec_modify eqs return_def)
       apply wp+
   apply (clarsimp simp: o_def eqs)
@@ -1574,27 +1575,18 @@ lemma setThreadState_rewrite_simple:
      (setThreadState st t)
      (threadSet (tcbState_update (\<lambda>_. st)) t)"
   supply if_split[split del]
-  apply (simp add: setThreadState_def)
-  apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_trans)
-    apply (rule monadic_rewrite_bind_tail)
-     apply (rule monadic_rewrite_trans)
-      apply (rule monadic_rewrite_bind_tail)+
-         apply (simp add: when_def)
-         apply (rule monadic_rewrite_gen_asm)
-         apply (subst if_not_P)
-          apply assumption
-         apply (rule monadic_rewrite_refl)
-        apply wp+
-     apply (rule monadic_rewrite_symb_exec_drop,
-            (wp  empty_fail_isRunnable
-               | (simp only: getCurThread_def getSchedulerAction_def
-                      , rule empty_fail_gets))+)+
-     apply (rule monadic_rewrite_refl)
-    apply (simp add: conj_comms, wp hoare_vcg_imp_lift threadSet_tcbState_st_tcb_at')
-     apply (clarsimp simp: obj_at'_def sch_act_simple_def st_tcb_at'_def)
+  apply (simp add: setThreadState_def when_def)
+  apply (monadic_rewrite_l
+           \<open>wpsimp wp: hoare_vcg_disj_lift hoare_vcg_imp_lift' threadSet_tcbState_st_tcb_at'\<close>
+           r: monadic_rewrite_if_l_False)
+   (* take the threadSet, drop everything until return () *)
+   apply (rule monadic_rewrite_trans[OF monadic_rewrite_bind_tail])
+     apply (rule monadic_rewrite_symb_exec_l_drop)+
+           apply (rule monadic_rewrite_refl)
+          apply (wpsimp simp: getCurThread_def
+                        wp: hoare_vcg_disj_lift hoare_vcg_imp_lift' threadSet_tcbState_st_tcb_at')+
    apply (rule monadic_rewrite_refl)
-  apply clarsimp
+  apply (clarsimp simp: obj_at'_def sch_act_simple_def st_tcb_at'_def)
   done
 
 end

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -517,7 +517,7 @@ lemma thread_actions_isolatable_bind:
        \<And>t. \<lbrace>tcb_at' t\<rbrace> f \<lbrace>\<lambda>rv. tcb_at' t\<rbrace> \<rbrakk>
      \<Longrightarrow> thread_actions_isolatable idx (f >>= g)"
   apply (clarsimp simp: thread_actions_isolatable_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (erule monadic_rewrite_bind2, assumption)
     apply (rule hoare_vcg_all_lift, assumption)
@@ -590,7 +590,7 @@ lemma select_f_isolatable:
   apply (clarsimp simp: thread_actions_isolatable_def
                         isolate_thread_actions_def
                         split_def select_f_selects liftM_def bind_assoc)
-  apply (rule monadic_rewrite_imp, rule monadic_rewrite_transverse)
+  apply (rule monadic_rewrite_guard_imp, rule monadic_rewrite_transverse)
     apply (rule monadic_rewrite_drop_modify monadic_rewrite_bind_tail)+
        apply wp+
    apply (simp add: gets_bind_ign getSchedulerAction_def)
@@ -723,7 +723,7 @@ lemma transferCaps_simple_rewrite:
    (return (mi \<lparr> msgExtraCaps := 0, msgCapsUnwrapped := 0 \<rparr>))"
   including no_pre
   apply (rule monadic_rewrite_gen_asm)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (simp add: transferCaps_simple, rule monadic_rewrite_refl)
    apply (rule monadic_rewrite_symb_exec2, (wp empty_fail_getReceiveSlots)+)
@@ -778,7 +778,7 @@ lemma doIPCTransfer_simple_rewrite:
   apply (simp add: doIPCTransfer_def bind_assoc doNormalTransfer_def
                    getMessageInfo_def
              cong: option.case_cong)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)+
       apply (rule_tac P="fault = None" in monadic_rewrite_gen_asm, simp)
@@ -808,7 +808,7 @@ lemma doIPCTransfer_simple_rewrite:
 lemma monadic_rewrite_setSchedulerAction_noop:
   "monadic_rewrite F E (\<lambda>s. ksSchedulerAction s = act) (setSchedulerAction act) (return ())"
   unfolding setSchedulerAction_def
-  apply (rule monadic_rewrite_imp, rule monadic_rewrite_modify_noop)
+  apply (rule monadic_rewrite_guard_imp, rule monadic_rewrite_modify_noop)
   apply simp
   done
 
@@ -843,7 +843,7 @@ lemma setupCallerCap_rewrite:
   apply (simp add: setupCallerCap_def getThreadCallerSlot_def
                    getThreadReplySlot_def locateSlot_conv
                    getSlotCap_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_bind_tail)+
      apply (rule monadic_rewrite_assert)+
      apply (rule_tac P="mdbFirstBadged (cteMDBNode masterCTE)
@@ -938,7 +938,7 @@ lemma activateThread_simple_rewrite:
   "monadic_rewrite True True (ct_in_state' ((=) Running))
        (activateThread) (return ())"
   apply (simp add: activateThread_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans, rule monadic_rewrite_bind_tail)+
        apply (rule_tac P="state = Running" in monadic_rewrite_gen_asm)
        apply simp
@@ -1243,7 +1243,7 @@ lemma thread_actions_isolatableD:
 lemma tcbSchedDequeue_rewrite:
   "monadic_rewrite True True (obj_at' (Not \<circ> tcbQueued) t) (tcbSchedDequeue t) (return ())"
   apply (simp add: tcbSchedDequeue_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule_tac P="\<not> queued" in monadic_rewrite_gen_asm)
@@ -1262,7 +1262,7 @@ lemma switchToThread_rewrite:
        (switchToThread t)
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule monadic_rewrite_bind)
@@ -1336,7 +1336,7 @@ lemma isolate_thread_actions_rewrite_bind:
     \<Longrightarrow> monadic_rewrite False True (\<lambda>s. \<forall>x. tcb_at' (idx x) s)
                (f >>= g) (isolate_thread_actions idx
                                   (f' >>= g') (g'' o f'') (g''' o f'''))"
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind, assumption+)
     apply (wp isolate_thread_actions_tcbs_at)
@@ -1451,7 +1451,7 @@ lemma monadic_rewrite_isolate_final2:
          (isolate_thread_actions idx f f' f'')
          (isolate_thread_actions idx g g' g'')"
   apply (simp add: isolate_thread_actions_def split_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_bind_tail)+
       apply (rule_tac P="\<lambda> s'. Q s" in monadic_rewrite_bind)
         apply (insert mr)[1]
@@ -1486,7 +1486,7 @@ lemma copy_registers_isolate_general:
                          select_f_returns o_def ksPSpace_update_partial_id)
    apply (simp add: return_def simpler_modify_def)
   apply (simp add: mapM_x_Cons)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule isolate_thread_actions_rewrite_bind, assumption)
         apply (rule copy_register_isolate, assumption+)
@@ -1581,7 +1581,7 @@ lemma setThreadState_rewrite_simple:
      (threadSet (tcbState_update (\<lambda>_. st)) t)"
   supply if_split[split del]
   apply (simp add: setThreadState_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_rewrite_bind_tail)
      apply (rule monadic_rewrite_trans)

--- a/proof/crefine/X64/Refine_C.thy
+++ b/proof/crefine/X64/Refine_C.thy
@@ -1102,7 +1102,7 @@ lemma kernel_all_subset_kernel:
                     check_active_irq_H_def checkActiveIRQ_def)
        apply clarsimp
        apply (erule in_monad_imp_rewriteE[where F=True])
-        apply (rule monadic_rewrite_imp)
+        apply (rule monadic_rewrite_guard_imp)
          apply (rule monadic_rewrite_bind_tail)+
            apply (rule monadic_rewrite_bind_head[where P=\<top>])
            apply (simp add: callKernel_C_def callKernel_withFastpath_C_def

--- a/proof/crefine/X64/Schedule_C.thy
+++ b/proof/crefine/X64/Schedule_C.thy
@@ -265,8 +265,6 @@ proof -
             apply (rule conseqPre, vcg)
             apply clarsimp
            apply (wp isRunnable_wp)+
-         apply (simp add: isRunnable_def)
-        apply wp
        apply (clarsimp simp: Let_def guard_is_UNIV_def)
        apply (drule invs_no_cicd'_queues)
        apply (case_tac queue, simp)

--- a/proof/drefine/CNode_DR.thy
+++ b/proof/drefine/CNode_DR.thy
@@ -700,7 +700,7 @@ lemma cap_revoke_corres_helper:
   show ?case
   supply if_cong[cong]
   apply (subst cap_revoke.simps)
-  apply (rule monadic_rewrite_corres2[where P =\<top>,simplified])
+  apply (rule monadic_rewrite_corres_l[where P =\<top>,simplified])
    apply (rule Finalise_DR.monadic_trancl_preemptible_step)
   apply (rule dcorres_expand_pfx)
   apply (clarsimp simp:liftE_bindE)
@@ -719,7 +719,7 @@ lemma cap_revoke_corres_helper:
             apply (clarsimp simp:empty_set_eq)+
             apply (clarsimp simp:returnOk_def lift_def)
             apply (rule corres_guard_imp)
-              apply (rule monadic_rewrite_corres2[where P=\<top> ,simplified])
+              apply (rule monadic_rewrite_corres_l[where P=\<top> ,simplified])
                apply (rule monadic_trancl_preemptible_return)
               apply (rule corres_trivial)
               apply (clarsimp simp:returnOk_def boolean_exception_def)+
@@ -734,7 +734,7 @@ lemma cap_revoke_corres_helper:
               apply simp+
             apply (clarsimp simp: lift_def empty_set_eq)+
             apply (rule corres_guard_imp)
-              apply (rule monadic_rewrite_corres2[where P=\<top> ,simplified])
+              apply (rule monadic_rewrite_corres_l[where P=\<top> ,simplified])
                apply (rule monadic_trancl_preemptible_return)
               apply (rule corres_trivial)
               apply (clarsimp simp:returnOk_def boolean_exception_def)+

--- a/proof/drefine/Finalise_DR.thy
+++ b/proof/drefine/Finalise_DR.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/drefine/Finalise_DR.thy
+++ b/proof/drefine/Finalise_DR.thy
@@ -3214,7 +3214,7 @@ lemma finalise_slot_inner1_add_if_Null:
   apply (simp add: finalise_slot_inner1_def)
   apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_bind_tail)
-    apply (rule monadic_rewrite_if_rhs)
+    apply (rule monadic_rewrite_if_r)
      apply (simp add: PageTableUnmap_D.is_final_cap_def)
      apply (rule monadic_rewrite_trans)
       apply (rule monadic_rewrite_bind_tail[where j="\<lambda>_. j" for j, OF _ gets_wp])+
@@ -3275,12 +3275,12 @@ lemma finalise_preemption_corres:
            apply (rule dcorres_symb_exec_rE)
              apply (simp split: option.splits)
              apply (rule conjI, clarsimp)
-              apply (rule monadic_rewrite_corres2)
+              apply (rule monadic_rewrite_corres_l)
                apply (rule monadic_trancl_preemptible_return)
               apply (rule dcorres_returnOk, simp)
              apply clarsimp
              apply (rule corres_guard_imp)
-               apply (rule monadic_rewrite_corres2)
+               apply (rule monadic_rewrite_corres_l)
                 apply (rule monadic_trancl_preemptible_f)
                apply (rule corres_alternate2[OF dcorres_throw], simp_all)[4]
            apply ((wp | simp)+)[1]
@@ -3288,7 +3288,7 @@ lemma finalise_preemption_corres:
          apply ((simp add: reset_work_units_def | wp)+)[1]
         apply clarsimp
         apply (rule corres_guard_imp)
-          apply (rule monadic_rewrite_corres2)
+          apply (rule monadic_rewrite_corres_l)
            apply (rule monadic_trancl_preemptible_return)
           apply (rule dcorres_returnOk, simp_all)[3]
        apply (rule hoare_TrueI)
@@ -3405,7 +3405,7 @@ proof (induct arbitrary: S rule: rec_del.induct,
     apply (subst rec_del_simps_ext[unfolded split_def])
     apply simp
     apply (rule corres_guard_imp)
-      apply (rule monadic_rewrite_corres2)
+      apply (rule monadic_rewrite_corres_l)
        apply (rule monadic_trancl_preemptible_steps)
       apply (simp add: cutMon_walk_bindE)
       apply (rule corres_splitEE)
@@ -3414,7 +3414,7 @@ proof (induct arbitrary: S rule: rec_del.induct,
         apply (simp add: liftME_def[symmetric])
         apply (rule_tac R="fst rv" in corres_cases)
          apply (simp add: when_def)
-         apply (rule monadic_rewrite_corres2)
+         apply (rule monadic_rewrite_corres_l)
           apply (rule monadic_trancl_preemptible_f)
          apply (simp add: finalise_slot_inner2_def[unfolded split_def])
          apply (rule corres_alternate1, rule corres_alternate2)
@@ -3425,7 +3425,7 @@ proof (induct arbitrary: S rule: rec_del.induct,
          apply (simp add: liftM_def[symmetric] o_def dc_def[symmetric])
          apply (rule empty_slot_corres)
         apply (simp add: when_def)
-        apply (rule monadic_rewrite_corres2)
+        apply (rule monadic_rewrite_corres_l)
          apply (rule monadic_trancl_preemptible_return)
         apply (rule corres_trivial, simp add: returnOk_liftE)
        apply wp
@@ -3499,7 +3499,7 @@ next
     apply (rule stronger_corres_guard_imp)
       apply (simp add: cutMon_walk_bind)
       apply (rule corres_drop_cutMon_bind)
-      apply (rule monadic_rewrite_corres2)
+      apply (rule monadic_rewrite_corres_l)
        apply (rule monadic_rewrite_bindE_head)
        apply (rule monadic_trancl_preemptible_step)
       apply (simp add: finalise_slot_inner2_def
@@ -3508,7 +3508,7 @@ next
       apply (rule corres_alternate1)+
       apply (simp add: liftE_bindE bind_bindE_assoc bind_assoc)
       apply (rule select_pick_corres_asm, assumption)
-      apply (rule monadic_rewrite_corres2)
+      apply (rule monadic_rewrite_corres_l)
        apply (rule monadic_rewrite_bind_head)
        apply (rule finalise_slot_inner1_add_if_Null[unfolded split_def])
       apply (simp add: bind_assoc if_to_top_of_bind)
@@ -3521,7 +3521,7 @@ next
           apply simp
          apply (rule corres_drop_cutMon)
          apply (rule corres_underlying_gets_pre_lhs)+
-         apply (rule monadic_rewrite_corres2)
+         apply (rule monadic_rewrite_corres_l)
           apply (rule monadic_rewrite_bindE_head)
           apply (rule monadic_trancl_preemptible_return)
          apply simp
@@ -3551,7 +3551,7 @@ next
             apply (rule corres_if_rhs_only)
              apply (rule_tac F=remove in corres_note_assumption, simp)
              apply (simp add: when_def)
-             apply (rule monadic_rewrite_corres2)
+             apply (rule monadic_rewrite_corres_l)
               apply (rule monadic_rewrite_bind)
                 apply (rule monadic_rewrite_pick_alternative_1)
                apply (rule monadic_rewrite_bind_tail)
@@ -3565,7 +3565,7 @@ next
             apply (rule corres_if_rhs_only)
              apply simp
              apply (rule corres_drop_cutMon)
-             apply (rule monadic_rewrite_corres2)
+             apply (rule monadic_rewrite_corres_l)
               apply (rule monadic_rewrite_bind)
                 apply (rule monadic_rewrite_pick_alternative_2)
                apply (rule monadic_rewrite_bind_tail)
@@ -3576,7 +3576,7 @@ next
                apply (rule corres_underlying_gets_pre_lhs)
                apply (rule corres_trivial, simp add: returnOk_liftE)
               apply (wp | simp)+
-            apply (rule monadic_rewrite_corres2)
+            apply (rule monadic_rewrite_corres_l)
              apply (rule monadic_rewrite_bind_head)
              apply (rule monadic_rewrite_pick_alternative_2)
             apply (simp add: cutMon_walk_bind)
@@ -3599,7 +3599,7 @@ next
                  apply (frule cte_at_replicate_zbits)
                  apply (clarsimp simp: cte_wp_at_caps_of_state caps_of_state_transform_opt_cap)
                  apply (clarsimp simp: transform_cslot_ptr_def)
-                apply (rule monadic_rewrite_corres2)
+                apply (rule monadic_rewrite_corres_l)
                  apply (rule monadic_rewrite_bindE_head)
                  apply (rule monadic_rewrite_trans)
                   apply (rule monadic_trancl_preemptible_steps)
@@ -3674,7 +3674,7 @@ next
     apply (rule corres_drop_cutMon)
     apply (simp add: liftME_def[symmetric] liftE_bindE[symmetric])
     apply (rule stronger_corres_guard_imp)
-      apply (rule monadic_rewrite_corres2)
+      apply (rule monadic_rewrite_corres_l)
        apply (rule monadic_trancl_preemptible_f)
       apply (simp add: finalise_slot_inner2_def[unfolded split_def])
       apply (rule corres_alternate1, rule corres_alternate1, rule corres_alternate2)
@@ -3696,7 +3696,7 @@ next
     apply simp
     apply (rule stronger_corres_guard_imp)
       apply (simp add: cutMon_walk_bindE)
-      apply (rule monadic_rewrite_corres2)
+      apply (rule monadic_rewrite_corres_l)
        apply (rule monadic_trancl_preemptible_steps)
       apply (rule corres_splitEE)
          apply (rule "4.hyps"[simplified, folded dc_def])
@@ -3706,7 +3706,7 @@ next
         apply (simp add: liftE_bindE)
         apply (rule corres_symb_exec_r)
            apply (simp add: liftME_def[symmetric] split del: if_split)
-           apply (rule monadic_rewrite_corres2)
+           apply (rule monadic_rewrite_corres_l)
             apply (rule monadic_trancl_preemptible_return)
            apply (rule corres_if_rhs_only)
             apply (simp add: returnOk_liftE)

--- a/proof/drefine/Finalise_DR.thy
+++ b/proof/drefine/Finalise_DR.thy
@@ -2779,7 +2779,7 @@ lemma monadic_trancl_f:
 lemma monadic_trancl_step:
   "monadic_rewrite False False \<top>
        (monadic_trancl f x) (do y \<leftarrow> f x; monadic_trancl f y od)"
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_trancl_steps)
    apply (rule monadic_rewrite_bind_head)
@@ -2820,7 +2820,7 @@ lemma monadic_trancl_preemptible_steps:
       (doE y \<leftarrow> monadic_trancl_preemptible f x;
               monadic_trancl_preemptible f y odE)"
   apply (simp add: monadic_trancl_preemptible_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_trancl_steps)
    apply (simp add: bindE_def)
@@ -2837,7 +2837,7 @@ lemma monadic_trancl_preemptible_f:
   "monadic_rewrite False False (\<lambda>_. True)
      (monadic_trancl_preemptible f x) (f x)"
   apply (simp add: monadic_trancl_preemptible_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_trancl_f)
    apply (simp add: lift_def)
@@ -2850,7 +2850,7 @@ lemma monadic_trancl_preemptible_step:
       (monadic_trancl_preemptible f x)
       (doE y \<leftarrow> f x;
             monadic_trancl_preemptible f y odE)"
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_trancl_preemptible_steps)
    apply (rule monadic_rewrite_bindE_head)
@@ -2862,7 +2862,7 @@ lemma monadic_trancl_preemptible_return:
   "monadic_rewrite False False (\<lambda>_. True)
      (monadic_trancl_preemptible f x) (returnOk x)"
   apply (simp add: monadic_trancl_preemptible_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_trans)
     apply (rule monadic_trancl_return)
    apply (simp add: returnOk_def)
@@ -3212,7 +3212,7 @@ lemma finalise_slot_inner1_add_if_Null:
      od)"
   supply if_cong[cong]
   apply (simp add: finalise_slot_inner1_def)
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_bind_tail)
     apply (rule monadic_rewrite_if_rhs)
      apply (simp add: PageTableUnmap_D.is_final_cap_def)

--- a/proof/drefine/Ipc_DR.thy
+++ b/proof/drefine/Ipc_DR.thy
@@ -278,29 +278,10 @@ lemma cte_at_into_opt_cap:
   apply (clarsimp simp: caps_of_state_transform_opt_cap)
   done
 
-abbreviation
-  "meqv \<equiv> monadic_rewrite False True"
-
-lemma mr_opt_cap_into_object:
-  assumes mr: "\<And>obj. monadic_rewrite F E (Q obj) m m'"
-  shows   "monadic_rewrite F E ((\<lambda>s. \<forall>obj. cdl_objects s (fst p) = Some obj \<and> object_slots obj (snd p) \<noteq> None \<longrightarrow> Q obj s) and (\<lambda>s. opt_cap p s \<noteq> None)) m m'"
-  apply (rule monadic_rewrite_imp)
-  apply (rule monadic_rewrite_exists [where P = "\<lambda>obj s. cdl_objects s (fst p) = Some obj \<and> object_slots obj (snd p) \<noteq> None", OF mr])
-  apply clarsimp
-  apply (rule conjI)
-  apply simp
-  apply (simp add: opt_cap_def split_def KHeap_D.slots_of_def split: option.splits)
-  done
-
 lemma object_slots_has_slots [simp]:
   "object_slots obj p = Some v \<Longrightarrow> has_slots obj"
   unfolding object_slots_def has_slots_def
   by (simp split: cdl_object.splits)
-
-lemma meqv_sym:
-  "meqv P a a' \<Longrightarrow> meqv P a' a"
-  unfolding monadic_rewrite_def
-  by fastforce
 
 lemma dcorres_when_l:
   assumes tc: "R \<Longrightarrow> dcorres dc \<top> P l r"

--- a/proof/drefine/Untyped_DR.thy
+++ b/proof/drefine/Untyped_DR.thy
@@ -1207,15 +1207,6 @@ lemma mapME_x_upt_length_ys:
   by (metis mapME_x_map_simp[where f="\<lambda>_. ()" and m="\<lambda>_. m" for m,
             unfolded o_def] map_replicate_const length_upt minus_nat.diff_0)
 
-lemma monadic_set_cap_id:
-  "monadic_rewrite False True
-    (cte_wp_at ((=) cap) p)
-    (set_cap cap p) (return ())"
-  by (clarsimp simp: monadic_rewrite_def set_cap_id return_def)
-
-lemmas monadic_set_cap_id2
-    = monadic_rewrite_transverse[OF monadic_set_cap_id monadic_rewrite_refl]
-
 (* FIXME: move *)
 lemma mapME_x_append:
   "mapME_x f (xs @ ys) = (doE mapME_x f xs; mapME_x f ys odE)"

--- a/proof/infoflow/Ipc_IF.thy
+++ b/proof/infoflow/Ipc_IF.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only

--- a/proof/infoflow/Ipc_IF.thy
+++ b/proof/infoflow/Ipc_IF.thy
@@ -322,7 +322,7 @@ lemma no_fail_gts:
 lemma sts_noop:
    "monadic_rewrite True True (tcb_at tcb and (\<lambda>s. tcb \<noteq> cur_thread s))
                     (set_thread_state_ext tcb) (return ())"
-  apply (rule monadic_rewrite_imp)
+  apply (rule monadic_rewrite_guard_imp)
    apply (rule monadic_rewrite_add_get)
    apply (rule monadic_rewrite_bind_tail)
     apply (clarsimp simp: set_thread_state_ext_def)
@@ -349,7 +349,7 @@ lemma sts_to_modify':
   apply (clarsimp simp: set_thread_state_def set_object_def)
   apply (rule monadic_rewrite_add_get)
   apply (rule monadic_rewrite_bind_tail)
-   apply (rule monadic_rewrite_imp)
+   apply (rule monadic_rewrite_guard_imp)
     apply (rule monadic_rewrite_trans)
      apply (simp only: bind_assoc[symmetric])
      apply (rule monadic_rewrite_bind_tail)

--- a/proof/infoflow/Ipc_IF.thy
+++ b/proof/infoflow/Ipc_IF.thy
@@ -358,7 +358,7 @@ lemma sts_to_modify':
     apply (rule_tac x="the (get_tcb tcb x)" in monadic_rewrite_symb_exec, (wp | simp)+)
     apply (rule_tac x="x" in  monadic_rewrite_symb_exec, (wp | simp)+)
         apply (wpsimp wp: get_object_wp simp: a_type_def)+
-    apply (rule_tac P="(=) x" in monadic_rewrite_refl3)
+    apply (rule_tac P="(=) x" in monadic_rewrite_pre_imp_refl)
     apply (clarsimp simp add: put_def modify_def get_def bind_def)
    apply assumption
   apply wp
@@ -417,7 +417,7 @@ lemma cancel_ipc_to_blocked_nosts:
         apply (rule hoare_modifyE_var[where P="tcb_at tcb and (\<lambda>s. tcb \<noteq> cur_thread s)"])
         apply (clarsimp simp: tcb_at_def get_tcb_def)
        apply (simp add: modify_modify)
-       apply (rule monadic_rewrite_refl2)
+       apply (rule monadic_rewrite_is_refl)
        apply (fastforce simp add: simpler_modify_def o_def get_tcb_def)
       apply (wp gts_wp)+
   apply (simp add: set_thread_state_def bind_assoc gets_the_def)

--- a/proof/infoflow/Ipc_IF.thy
+++ b/proof/infoflow/Ipc_IF.thy
@@ -323,23 +323,20 @@ lemma sts_noop:
    "monadic_rewrite True True (tcb_at tcb and (\<lambda>s. tcb \<noteq> cur_thread s))
                     (set_thread_state_ext tcb) (return ())"
   apply (rule monadic_rewrite_guard_imp)
-   apply (rule monadic_rewrite_add_get)
-   apply (rule monadic_rewrite_bind_tail)
-    apply (clarsimp simp: set_thread_state_ext_def)
-    apply (rule_tac x="tcb_state (the (get_tcb tcb x))" in monadic_rewrite_symb_exec)
-       apply (wp gts_wp | simp)+
-    apply (rule monadic_rewrite_symb_exec)
-       apply wp+
-    apply (rule monadic_rewrite_symb_exec)
-       apply wp+
-    apply (simp only: when_def)
-    apply (rule monadic_rewrite_trans)
-     apply (rule monadic_rewrite_if)
-      apply (rule monadic_rewrite_impossible[where g="return ()"])
-     apply (rule monadic_rewrite_refl)
-    apply simp
-    apply (rule monadic_rewrite_refl)
-   apply wp
+  apply (rule monadic_rewrite_add_get)
+  apply (rule monadic_rewrite_bind_tail)
+  apply (clarsimp simp: set_thread_state_ext_def)
+  apply (rule_tac rv="tcb_state (the (get_tcb tcb x))" in monadic_rewrite_symb_exec_l_known_F)
+       apply (rule monadic_rewrite_symb_exec_l_known_F)
+          apply (rule monadic_rewrite_symb_exec_l_known_F)
+             apply (simp only: when_def)
+             apply (rule monadic_rewrite_trans)
+              apply (rule monadic_rewrite_if)
+               apply (rule monadic_rewrite_impossible[where g="return ()"])
+              apply (rule monadic_rewrite_refl)
+             apply simp
+             apply (rule monadic_rewrite_refl)
+            apply (wpsimp wp: gts_wp)+
   by (auto simp: pred_tcb_at_def obj_at_def is_tcb_def get_tcb_def)
 
 lemma sts_to_modify':
@@ -355,11 +352,11 @@ lemma sts_to_modify':
      apply (rule monadic_rewrite_bind_tail)
       apply (rule sts_noop)
      apply (wpsimp wp: get_object_wp, simp)
-    apply (rule_tac x="the (get_tcb tcb x)" in monadic_rewrite_symb_exec, (wp | simp)+)
-    apply (rule_tac x="x" in  monadic_rewrite_symb_exec, (wp | simp)+)
-        apply (wpsimp wp: get_object_wp simp: a_type_def)+
-    apply (rule_tac P="(=) x" in monadic_rewrite_pre_imp_refl)
-    apply (clarsimp simp add: put_def modify_def get_def bind_def)
+    apply (rule_tac rv="the (get_tcb tcb x)" in monadic_rewrite_symb_exec_l_known_F)
+       apply (rule_tac rv="x" in  monadic_rewrite_symb_exec_l_known_F)
+          apply (rule_tac P="(=) x" in monadic_rewrite_pre_imp_eq)
+          apply (clarsimp simp add: put_def modify_def get_def bind_def)
+         apply (wpsimp wp: get_object_wp simp: a_type_def)+
    apply assumption
   apply wp
   by (clarsimp simp: get_tcb_def tcb_at_def)

--- a/proof/refine/ARM/RAB_FN.thy
+++ b/proof/refine/ARM/RAB_FN.thy
@@ -116,13 +116,13 @@ proof (induct cap capptr bits rule: resolveAddressBits.induct)
                       if_to_top_of_bindE assertE_def stateAssert_def bind_assoc
                       assert_def if_to_top_of_bind getSlotCap_def
                split del: if_split cong: if_cong)
-     apply (rule monadic_rewrite_if_lhs monadic_rewrite_symb_exec_l'[OF get_wp]
+     apply (rule monadic_rewrite_if_l monadic_rewrite_symb_exec_l'[OF _ get_wp, rotated]
                  empty_fail_get no_fail_get impI
                  monadic_rewrite_refl get_wp
        | simp add: throwError_def returnOk_def locateSlotFun_def if_not_P
                    isCNodeCap_capUntypedPtr_capCNodePtr
              cong: if_cong split del: if_split)+
-          apply (rule monadic_rewrite_symb_exec_l'[OF getCTE_inv _ _ _ getCTE_cte_wp_at])
+          apply (rule monadic_rewrite_symb_exec_l'[OF _ getCTE_inv _ _ getCTE_cte_wp_at, rotated])
             apply simp
            apply (rule impI, rule no_fail_getCTE)
           apply (simp add: monadic_rewrite_def simpler_gets_def return_def returnOk_def

--- a/proof/refine/ARM/RAB_FN.thy
+++ b/proof/refine/ARM/RAB_FN.thy
@@ -94,23 +94,23 @@ proof (induct cap capptr bits rule: resolveAddressBits.induct)
     apply (subst resolveAddressBits.simps, subst resolveAddressBitsFn.simps)
     apply (simp only: Let_def haskell_assertE_def K_bind_def)
     apply (rule monadic_rewrite_name_pre)
-    apply (rule monadic_rewrite_imp)
+    apply (rule monadic_rewrite_guard_imp)
      apply (rule_tac P="(=) s" in monadic_rewrite_trans)
       (* step 1, apply the induction hypothesis on the lhs *)
       apply (rule monadic_rewrite_named_if monadic_rewrite_named_bindE
-                  monadic_rewrite_refl[THEN monadic_rewrite_imp, where f="returnOk y" for y]
-                  monadic_rewrite_refl[THEN monadic_rewrite_imp, where f="x $ y" for x y]
-                  monadic_rewrite_refl[THEN monadic_rewrite_imp, where f="assertE P" for P s]
+                  monadic_rewrite_refl[THEN monadic_rewrite_guard_imp, where f="returnOk y" for y]
+                  monadic_rewrite_refl[THEN monadic_rewrite_guard_imp, where f="x $ y" for x y]
+                  monadic_rewrite_refl[THEN monadic_rewrite_guard_imp, where f="assertE P" for P s]
                   TrueI)+
        apply (rule_tac g="case nextCap of CNodeCap a b c d
             \<Rightarrow> ?g nextCap cref bitsLeft
-            | _ \<Rightarrow> returnOk (slot, bitsLeft)" in monadic_rewrite_imp)
+            | _ \<Rightarrow> returnOk (slot, bitsLeft)" in monadic_rewrite_guard_imp)
         apply (wpc | rule monadic_rewrite_refl "1.hyps"
            | simp only: capability.case haskell_assertE_def simp_thms)+
        apply (clarsimp simp: in_monad locateSlot_conv getSlotCap_def
                       dest!: in_getCTE fst_stateAssertD)
        apply (fastforce elim: cte_wp_at_weakenE')
-      apply (rule monadic_rewrite_refl[THEN monadic_rewrite_imp], simp)
+      apply (rule monadic_rewrite_refl[THEN monadic_rewrite_guard_imp], simp)
      (* step 2, split and match based on the lhs structure *)
      apply (simp add: locateSlot_conv liftE_bindE unlessE_def whenE_def
                       if_to_top_of_bindE assertE_def stateAssert_def bind_assoc

--- a/proof/refine/ARM_HYP/RAB_FN.thy
+++ b/proof/refine/ARM_HYP/RAB_FN.thy
@@ -116,13 +116,13 @@ proof (induct cap capptr bits rule: resolveAddressBits.induct)
                       if_to_top_of_bindE assertE_def stateAssert_def bind_assoc
                       assert_def if_to_top_of_bind getSlotCap_def
                split del: if_split cong: if_cong)
-     apply (rule monadic_rewrite_if_lhs monadic_rewrite_symb_exec_l'[OF get_wp]
+     apply (rule monadic_rewrite_if_l monadic_rewrite_symb_exec_l'[OF _ get_wp, rotated]
                  empty_fail_get no_fail_get impI
                  monadic_rewrite_refl get_wp
        | simp add: throwError_def returnOk_def locateSlotFun_def if_not_P
                    isCNodeCap_capUntypedPtr_capCNodePtr
              cong: if_cong split del: if_split)+
-          apply (rule monadic_rewrite_symb_exec_l'[OF getCTE_inv _ _ _ getCTE_cte_wp_at])
+          apply (rule monadic_rewrite_symb_exec_l'[OF _ getCTE_inv _ _ getCTE_cte_wp_at, rotated])
             apply simp
            apply (rule impI, rule no_fail_getCTE)
           apply (simp add: monadic_rewrite_def simpler_gets_def return_def returnOk_def

--- a/proof/refine/ARM_HYP/RAB_FN.thy
+++ b/proof/refine/ARM_HYP/RAB_FN.thy
@@ -94,23 +94,23 @@ proof (induct cap capptr bits rule: resolveAddressBits.induct)
     apply (subst resolveAddressBits.simps, subst resolveAddressBitsFn.simps)
     apply (simp only: Let_def haskell_assertE_def K_bind_def)
     apply (rule monadic_rewrite_name_pre)
-    apply (rule monadic_rewrite_imp)
+    apply (rule monadic_rewrite_guard_imp)
      apply (rule_tac P="(=) s" in monadic_rewrite_trans)
       (* step 1, apply the induction hypothesis on the lhs *)
       apply (rule monadic_rewrite_named_if monadic_rewrite_named_bindE
-                  monadic_rewrite_refl[THEN monadic_rewrite_imp, where f="returnOk y" for y]
-                  monadic_rewrite_refl[THEN monadic_rewrite_imp, where f="x $ y" for x y]
-                  monadic_rewrite_refl[THEN monadic_rewrite_imp, where f="assertE P" for P s]
+                  monadic_rewrite_refl[THEN monadic_rewrite_guard_imp, where f="returnOk y" for y]
+                  monadic_rewrite_refl[THEN monadic_rewrite_guard_imp, where f="x $ y" for x y]
+                  monadic_rewrite_refl[THEN monadic_rewrite_guard_imp, where f="assertE P" for P s]
                   TrueI)+
        apply (rule_tac g="case nextCap of CNodeCap a b c d
             \<Rightarrow> ?g nextCap cref bitsLeft
-            | _ \<Rightarrow> returnOk (slot, bitsLeft)" in monadic_rewrite_imp)
+            | _ \<Rightarrow> returnOk (slot, bitsLeft)" in monadic_rewrite_guard_imp)
         apply (wpc | rule monadic_rewrite_refl "1.hyps"
            | simp only: capability.case haskell_assertE_def simp_thms)+
        apply (clarsimp simp: in_monad locateSlot_conv getSlotCap_def
                       dest!: in_getCTE fst_stateAssertD)
        apply (fastforce elim: cte_wp_at_weakenE')
-      apply (rule monadic_rewrite_refl[THEN monadic_rewrite_imp], simp)
+      apply (rule monadic_rewrite_refl[THEN monadic_rewrite_guard_imp], simp)
      (* step 2, split and match based on the lhs structure *)
      apply (simp add: locateSlot_conv liftE_bindE unlessE_def whenE_def
                       if_to_top_of_bindE assertE_def stateAssert_def bind_assoc

--- a/proof/refine/RISCV64/ArchAcc_R.thy
+++ b/proof/refine/RISCV64/ArchAcc_R.thy
@@ -969,7 +969,7 @@ lemma findVSpaceForASID_corres:
   using assms
   apply (simp add: findVSpaceForASID_def)
   apply (rule corres_gen_asm, simp add: ucast_down_ucast_id is_down_def target_size source_size)
-  apply (rule corres_guard_imp[where Q'="?Q"], rule monadic_rewrite_corres[where P="?P", rotated],
+  apply (rule corres_guard_imp[where Q'="?Q"], rule monadic_rewrite_corres_l[where P="?P"],
          rule find_vspace_for_asid_rewite; simp)
   apply (simp add: liftE_bindE asidRange_def flip: mask_2pm1)
   apply (rule_tac r'="\<lambda>x y. x = y o ucast"

--- a/proof/refine/RISCV64/RAB_FN.thy
+++ b/proof/refine/RISCV64/RAB_FN.thy
@@ -114,13 +114,13 @@ proof (induct cap capptr bits rule: resolveAddressBits.induct)
                       if_to_top_of_bindE assertE_def stateAssert_def bind_assoc
                       assert_def if_to_top_of_bind getSlotCap_def
                split del: if_split cong: if_cong)
-     apply (rule monadic_rewrite_if_lhs monadic_rewrite_symb_exec_l'[OF get_wp]
+     apply (rule monadic_rewrite_if_l monadic_rewrite_symb_exec_l'[OF _ get_wp, rotated]
                  empty_fail_get no_fail_get impI
                  monadic_rewrite_refl get_wp
        | simp add: throwError_def returnOk_def locateSlotFun_def if_not_P
                    isCNodeCap_capUntypedPtr_capCNodePtr
              cong: if_cong split del: if_split)+
-          apply (rule monadic_rewrite_symb_exec_l'[OF getCTE_inv _ _ _ getCTE_cte_wp_at])
+          apply (rule monadic_rewrite_symb_exec_l'[OF _ getCTE_inv _ _ getCTE_cte_wp_at, rotated])
             apply simp
            apply (rule impI, rule no_fail_getCTE)
           apply (simp add: monadic_rewrite_def simpler_gets_def return_def returnOk_def

--- a/proof/refine/RISCV64/RAB_FN.thy
+++ b/proof/refine/RISCV64/RAB_FN.thy
@@ -92,23 +92,23 @@ proof (induct cap capptr bits rule: resolveAddressBits.induct)
     apply (subst resolveAddressBits.simps, subst resolveAddressBitsFn.simps)
     apply (simp only: Let_def haskell_assertE_def K_bind_def)
     apply (rule monadic_rewrite_name_pre)
-    apply (rule monadic_rewrite_imp)
+    apply (rule monadic_rewrite_guard_imp)
      apply (rule_tac P="(=) s" in monadic_rewrite_trans)
       (* step 1, apply the induction hypothesis on the lhs *)
       apply (rule monadic_rewrite_named_if monadic_rewrite_named_bindE
-                  monadic_rewrite_refl[THEN monadic_rewrite_imp, where f="returnOk y" for y]
-                  monadic_rewrite_refl[THEN monadic_rewrite_imp, where f="x $ y" for x y]
-                  monadic_rewrite_refl[THEN monadic_rewrite_imp, where f="assertE P" for P s]
+                  monadic_rewrite_refl[THEN monadic_rewrite_guard_imp, where f="returnOk y" for y]
+                  monadic_rewrite_refl[THEN monadic_rewrite_guard_imp, where f="x $ y" for x y]
+                  monadic_rewrite_refl[THEN monadic_rewrite_guard_imp, where f="assertE P" for P s]
                   TrueI)+
        apply (rule_tac g="case nextCap of CNodeCap a b c d
             \<Rightarrow> ?g nextCap cref bitsLeft
-            | _ \<Rightarrow> returnOk (slot, bitsLeft)" in monadic_rewrite_imp)
+            | _ \<Rightarrow> returnOk (slot, bitsLeft)" in monadic_rewrite_guard_imp)
         apply (wpc | rule monadic_rewrite_refl "1.hyps"
            | simp only: capability.case haskell_assertE_def simp_thms)+
        apply (clarsimp simp: in_monad locateSlot_conv getSlotCap_def
                       dest!: in_getCTE fst_stateAssertD)
        apply (fastforce elim: cte_wp_at_weakenE')
-      apply (rule monadic_rewrite_refl[THEN monadic_rewrite_imp], simp)
+      apply (rule monadic_rewrite_refl[THEN monadic_rewrite_guard_imp], simp)
      (* step 2, split and match based on the lhs structure *)
      apply (simp add: locateSlot_conv liftE_bindE unlessE_def whenE_def
                       if_to_top_of_bindE assertE_def stateAssert_def bind_assoc

--- a/proof/refine/X64/RAB_FN.thy
+++ b/proof/refine/X64/RAB_FN.thy
@@ -114,13 +114,13 @@ proof (induct cap capptr bits rule: resolveAddressBits.induct)
                       if_to_top_of_bindE assertE_def stateAssert_def bind_assoc
                       assert_def if_to_top_of_bind getSlotCap_def
                split del: if_split cong: if_cong)
-     apply (rule monadic_rewrite_if_lhs monadic_rewrite_symb_exec_l'[OF get_wp]
+     apply (rule monadic_rewrite_if_l monadic_rewrite_symb_exec_l'[OF _ get_wp, rotated]
                  empty_fail_get no_fail_get impI
                  monadic_rewrite_refl get_wp
        | simp add: throwError_def returnOk_def locateSlotFun_def if_not_P
                    isCNodeCap_capUntypedPtr_capCNodePtr
              cong: if_cong split del: if_split)+
-          apply (rule monadic_rewrite_symb_exec_l'[OF getCTE_inv _ _ _ getCTE_cte_wp_at])
+          apply (rule monadic_rewrite_symb_exec_l'[OF _ getCTE_inv _ _ getCTE_cte_wp_at, rotated])
             apply simp
            apply (rule impI, rule no_fail_getCTE)
           apply (simp add: monadic_rewrite_def simpler_gets_def return_def returnOk_def

--- a/proof/refine/X64/RAB_FN.thy
+++ b/proof/refine/X64/RAB_FN.thy
@@ -92,23 +92,23 @@ proof (induct cap capptr bits rule: resolveAddressBits.induct)
     apply (subst resolveAddressBits.simps, subst resolveAddressBitsFn.simps)
     apply (simp only: Let_def haskell_assertE_def K_bind_def)
     apply (rule monadic_rewrite_name_pre)
-    apply (rule monadic_rewrite_imp)
+    apply (rule monadic_rewrite_guard_imp)
      apply (rule_tac P="(=) s" in monadic_rewrite_trans)
       (* step 1, apply the induction hypothesis on the lhs *)
       apply (rule monadic_rewrite_named_if monadic_rewrite_named_bindE
-                  monadic_rewrite_refl[THEN monadic_rewrite_imp, where f="returnOk y" for y]
-                  monadic_rewrite_refl[THEN monadic_rewrite_imp, where f="x $ y" for x y]
-                  monadic_rewrite_refl[THEN monadic_rewrite_imp, where f="assertE P" for P s]
+                  monadic_rewrite_refl[THEN monadic_rewrite_guard_imp, where f="returnOk y" for y]
+                  monadic_rewrite_refl[THEN monadic_rewrite_guard_imp, where f="x $ y" for x y]
+                  monadic_rewrite_refl[THEN monadic_rewrite_guard_imp, where f="assertE P" for P s]
                   TrueI)+
        apply (rule_tac g="case nextCap of CNodeCap a b c d
             \<Rightarrow> ?g nextCap cref bitsLeft
-            | _ \<Rightarrow> returnOk (slot, bitsLeft)" in monadic_rewrite_imp)
+            | _ \<Rightarrow> returnOk (slot, bitsLeft)" in monadic_rewrite_guard_imp)
         apply (wpc | rule monadic_rewrite_refl "1.hyps"
            | simp only: capability.case haskell_assertE_def simp_thms)+
        apply (clarsimp simp: in_monad locateSlot_conv getSlotCap_def
                       dest!: in_getCTE fst_stateAssertD)
        apply (fastforce elim: cte_wp_at_weakenE')
-      apply (rule monadic_rewrite_refl[THEN monadic_rewrite_imp], simp)
+      apply (rule monadic_rewrite_refl[THEN monadic_rewrite_guard_imp], simp)
      (* step 2, split and match based on the lhs structure *)
      apply (simp add: locateSlot_conv liftE_bindE unlessE_def whenE_def
                       if_to_top_of_bindE assertE_def stateAssert_def bind_assoc


### PR DESCRIPTION
This is the final significant PR for the Monadic_Rewrite overhaul funded by the seL4 Foundation. There is one item outstanding: re-indenting `Fastpath_Equiv` and `Fastpath_C` but I don't want the noise of that in this PR, and I want to hack together a little indenter improvement to fix up mis-indented comments / subgoal afterwards, for which there's no time right now.

Generally:
* we now have useful tactics to work with most simple cases of monadic rewriting, plus other quality-of-life such as `wp_pre` understanding `monadic_rewrite_guard_imp`
* the rules have names that make more sense and are at least consistent with each other
* a number of rules were redundant or had assumptions that were too strong
* monadic_rewrite proofs have generally gotten shorter, but the extreme specificity of walking over the code structure makes automation prohibitive in a fair few cases, more than I initially estimated

The hope is the availability of this tech will improve willingness to use it for the simple cases which used to be a huge pain previously.

The overhaul includes work that was merged as previous PRs:
* #487 
* #516 
* #517
* #518
* #521 

Unhappinesses that were not solved (and I don't know how to solve at a fundamental level):
* fragility of name bindings inside a monad: these are just lambdas and follow eta-contraction and other random rules
    * for symbolic execution at the head, we have done well to preserve the names in the monad even in adverse circumstances (see `no_name_eta` for example)
    * unfortunately rules that "step through", like `monadic_rewrite_bind_tail` can only make use of the name capturing trick (which is deep in Isabelle and used for stuff like `allE` preserving names) on the first subgoal, with later subgoals getting `rv` or `x` or whatever is the name in the rule
    * this means that targeted tactics like `monadic_rewrite_l` will damage all names until the point where the supplied rule matches
    * there might be a way to hack past this in the future, but it will always be a hack, because we do not have an actual name binding, just a lambda in a shallow embedding, so we'd have to dive in and try extract it, then apply a rename that sticks to other goals... yuck. Try capture the name in some kind of deeper embedding? no idea how that can work; etc.
