### PR TITLE
MCS: synchronise proof directories with master

### DIFF
--- a/proof/access-control/CNode_AC.thy
+++ b/proof/access-control/CNode_AC.thy
@@ -123,7 +123,7 @@ lemma set_original_integrity_autarch:
 
 lemma set_original_integrity:
   "\<lbrace>integrity aag X st and cdt_change_allowed' aag slot\<rbrace>
-      set_original slot orig
+   set_original slot orig
    \<lbrace>\<lambda>rv. integrity aag X st\<rbrace>"
   apply integrity_trans_start
   apply (wpsimp simp: set_original_def integrity_def)
@@ -163,15 +163,15 @@ rewriting (the equivalent equalities) in the wp proofs.
 
 definition authorised_cnode_inv ::
   "'a PAS \<Rightarrow> Invocations_A.cnode_invocation \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
- "authorised_cnode_inv aag ci \<equiv> K (case ci of
-    InsertCall cap ptr ptr' \<Rightarrow> pasObjectAbs aag ` {fst ptr, fst ptr'} \<subseteq> {pasSubject aag}
-  | MoveCall cap ptr ptr' \<Rightarrow> pasObjectAbs aag ` {fst ptr, fst ptr'} \<subseteq> {pasSubject aag}
-  | RotateCall s_cap p_cap src pivot dest \<Rightarrow>
-                           pasObjectAbs aag ` {fst src, fst pivot, fst dest} \<subseteq> {pasSubject aag}
-  | SaveCall ptr \<Rightarrow> is_subject aag (fst ptr)
-  | DeleteCall ptr \<Rightarrow> is_subject aag (fst ptr)
-  | CancelBadgedSendsCall cap \<Rightarrow> pas_cap_cur_auth aag cap
-  | RevokeCall ptr \<Rightarrow> is_subject aag (fst ptr))"
+  "authorised_cnode_inv aag ci \<equiv> K (case ci of
+     InsertCall cap ptr ptr' \<Rightarrow> pasObjectAbs aag ` {fst ptr, fst ptr'} \<subseteq> {pasSubject aag}
+   | MoveCall cap ptr ptr' \<Rightarrow> pasObjectAbs aag ` {fst ptr, fst ptr'} \<subseteq> {pasSubject aag}
+   | RotateCall s_cap p_cap src pivot dest \<Rightarrow>
+       pasObjectAbs aag ` {fst src, fst pivot, fst dest} \<subseteq> {pasSubject aag}
+   | SaveCall ptr \<Rightarrow> is_subject aag (fst ptr)
+   | DeleteCall ptr \<Rightarrow> is_subject aag (fst ptr)
+   | CancelBadgedSendsCall cap \<Rightarrow> pas_cap_cur_auth aag cap
+   | RevokeCall ptr \<Rightarrow> is_subject aag (fst ptr))"
 
 lemma resolve_address_bits_authorised_aux:
   "s \<turnstile> \<lbrace>pas_refined aag and K (is_cnode_cap (fst (cap, cref))
@@ -188,7 +188,7 @@ proof (induct arbitrary: s rule: resolve_address_bits'.induct)
     apply (cases cap', simp_all add: P split del: if_split)
     apply (rule hoare_pre_spec_validE)
      apply (wp "1.hyps", (assumption | simp add: in_monad | rule conjI)+)
-          apply (wp get_cap_wp)+
+        apply (wp get_cap_wp)+
     apply (auto simp: cte_wp_at_caps_of_state is_cap_simps cap_auth_conferred_def
                 dest: caps_of_state_pasObjectAbs_eq)
     done
@@ -200,7 +200,7 @@ lemma resolve_address_bits_authorised[wp]:
    \<lbrace>\<lambda>rv s. is_subject aag (fst (fst rv))\<rbrace>, -"
   apply (unfold validE_R_def)
   apply (rule hoare_pre)
-  apply (rule use_spec(2)[OF resolve_address_bits_authorised_aux])
+   apply (rule use_spec(2)[OF resolve_address_bits_authorised_aux])
   apply simp
   done
 
@@ -234,14 +234,14 @@ lemma get_cap_cur_auth:
   "\<lbrace>pas_refined aag and cte_wp_at (\<lambda>_. True) slot and K (is_subject aag (fst slot))\<rbrace>
    get_cap slot
    \<lbrace>\<lambda>rv s. pas_cap_cur_auth aag rv\<rbrace>"
-   apply (wp get_cap_wp)
+  apply (wp get_cap_wp)
   apply (clarsimp simp: cte_wp_at_caps_of_state cap_cur_auth_caps_of_state)
   done
 
 lemma decode_cnode_inv_authorised:
   "\<lbrace>pas_refined aag and invs and valid_cap cap
                     and K (\<forall>c \<in> {cap} \<union> set excaps. pas_cap_cur_auth aag c)\<rbrace>
-     decode_cnode_invocation label args cap excaps
+   decode_cnode_invocation label args cap excaps
    \<lbrace>\<lambda>rv s. authorised_cnode_inv aag rv s\<rbrace>,-"
   apply (simp add: authorised_cnode_inv_def decode_cnode_invocation_def
                    split_def whenE_def unlessE_def set_eq_iff
@@ -285,7 +285,7 @@ lemma sita_caps_update:
 
 lemma sita_caps_update2:
   "\<lbrakk> pas_wellformed aag; state_irqs_to_policy_aux aag caps \<subseteq> pasPolicy aag;
-    cap_links_irq aag (pasObjectAbs aag (fst ptr')) cap';
+     cap_links_irq aag (pasObjectAbs aag (fst ptr')) cap';
      cap_links_irq aag (pasObjectAbs aag (fst ptr)) cap \<rbrakk>
      \<Longrightarrow> state_irqs_to_policy_aux aag (caps(ptr \<mapsto> cap, ptr' \<mapsto> cap')) \<subseteq> pasPolicy aag"
   by (fastforce intro: state_irqs_to_policy_aux.intros
@@ -301,27 +301,27 @@ lemma set_cap_pas_refined:
           \<longrightarrow> is_transferable_cap cap \<or>
               abs_has_auth_to aag Control (fst $ the $ cdt s ptr) (fst ptr)) and
     K (aag_cap_auth aag (pasObjectAbs aag (fst ptr)) cap)\<rbrace>
-      set_cap cap ptr
+   set_cap cap ptr
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def aag_cap_auth_def)
   apply (rule hoare_pre)
    apply (wp set_cap_caps_of_state set_cap_state_vrefs  | wps)+
   apply clarsimp
   apply (intro conjI)  \<comment> \<open>auth_graph_map\<close>
-   apply (clarsimp dest!: auth_graph_map_memD)
-   apply (erule state_bits_to_policy.cases;
-          solves\<open>auto simp: cap_links_asid_slot_def label_owns_asid_slot_def
-                     intro: auth_graph_map_memI state_bits_to_policy.intros
-                     split: if_split_asm\<close>)
-  apply (erule (2) sata_update[unfolded fun_upd_def])
+    apply (clarsimp dest!: auth_graph_map_memD)
+    apply (erule state_bits_to_policy.cases;
+           solves\<open>auto simp: cap_links_asid_slot_def label_owns_asid_slot_def
+                      intro: auth_graph_map_memI state_bits_to_policy.intros
+                      split: if_split_asm\<close>)
+   apply (erule (2) sata_update[unfolded fun_upd_def])
   apply (erule (2) sita_caps_update[unfolded fun_upd_def])
   done
 
 lemma set_cap_pas_refined_not_transferable:
   "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
                     and cte_wp_at (\<lambda>c. \<not>is_transferable (Some c)) ptr
-       and K (aag_cap_auth aag (pasObjectAbs aag (fst ptr)) cap)\<rbrace>
-      set_cap cap ptr
+                    and K (aag_cap_auth aag (pasObjectAbs aag (fst ptr)) cap)\<rbrace>
+   set_cap cap ptr
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   by (wpsimp wp: set_cap_pas_refined simp: cte_wp_at_caps_of_state)
 
@@ -372,8 +372,8 @@ lemma cap_swap_respects[wp]:
 
 lemma cap_swap_for_delete_respects[wp]:
   "\<lbrace>integrity aag X st and pas_refined aag
-            and K (is_subject aag (fst slot) \<and> is_subject aag (fst slot'))\<rbrace>
-      cap_swap_for_delete slot slot'
+                       and K (is_subject aag (fst slot) \<and> is_subject aag (fst slot'))\<rbrace>
+   cap_swap_for_delete slot slot'
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   by (wpsimp simp: cap_swap_for_delete_def)
 
@@ -383,7 +383,7 @@ lemma dmo_no_mem_respects:
   shows "do_machine_op mop \<lbrace>integrity aag X st\<rbrace>"
   unfolding do_machine_op_def
   apply (rule hoare_pre)
-  apply (simp add: split_def)
+   apply (simp add: split_def)
    apply wp
   apply (clarsimp simp: integrity_def)
   apply (rule conjI)
@@ -416,7 +416,7 @@ lemmas cases_simp_options = cases_simp_option cases_simp_option[where 'a="'b \<t
 
 (* FIXME MOVE *)
 lemma cdt_change_allowed_all_children:
- "all_children (cdt_change_allowed aag subject (cdt s) (tcb_states_of_state s)) (cdt s)"
+  "all_children (cdt_change_allowed aag subject (cdt s) (tcb_states_of_state s)) (cdt s)"
   by (rule all_childrenI) (erule cdt_change_allowed_to_child)
 
 abbreviation cleanup_info_wf :: "cap \<Rightarrow> 'a PAS \<Rightarrow> bool" where
@@ -443,9 +443,9 @@ lemma empty_slot_integrity_spec:
   shows
   "s \<turnstile> \<lbrace>valid_list and valid_mdb and valid_objs and pas_refined aag
                    and K (is_subject aag (fst slot) \<and> cleanup_info_wf cleanup_info aag)\<rbrace>
-          empty_slot slot cleanup_info
+       empty_slot slot cleanup_info
        \<lbrace>\<lambda>_. integrity aag X s\<rbrace>"
-   apply (simp add: spec_valid_def)
+  apply (simp add: spec_valid_def)
   apply (simp add: empty_slot_def)
   apply (wp add: get_cap_wp set_cap_integrity_autarch set_original_integrity_autarch
                  empty_slot_extended_list_integ_lift empty_slot_list_integrity[where m="cdt s"]
@@ -462,7 +462,7 @@ lemma empty_slot_integrity[wp,wp_not_transferable]:
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (integrity_trans_start)
   apply (rule hoare_pre)
-  apply (wp empty_slot_integrity_spec[simplified spec_valid_def])
+   apply (wp empty_slot_integrity_spec[simplified spec_valid_def])
   by force
 
 end
@@ -474,7 +474,7 @@ lemma reply_masters_mdbD1:
 
 lemma reply_cap_no_grand_parent:
   "\<lbrakk> m \<Turnstile> pptr \<rightarrow>* slot ; reply_mdb m cs ; cs slot = Some (ReplyCap t False R) \<rbrakk>
-    \<Longrightarrow> pptr = slot \<or> (m \<Turnstile> pptr \<leadsto> slot \<and> (\<exists> R'. cs pptr = Some (ReplyCap t True R')))"
+     \<Longrightarrow> pptr = slot \<or> (m \<Turnstile> pptr \<leadsto> slot \<and> (\<exists> R'. cs pptr = Some (ReplyCap t True R')))"
   apply (clarsimp simp: reply_mdb_def del: disjCI)
   apply (erule(1) reply_caps_mdbE)
   apply (drule(1) reply_masters_mdbD1)
@@ -527,7 +527,7 @@ crunches set_original
 lemma set_cap_integrity_deletion_aux:
   "\<lbrace>integrity aag X st and valid_mdb and valid_objs and pas_refined aag and is_transferable_in slot
                        and cdt_change_allowed' aag slot and K(\<not> is_subject aag (fst slot))\<rbrace>
-      set_cap NullCap slot
+   set_cap NullCap slot
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (integrity_trans_start)
   apply (rule hoare_pre)
@@ -538,7 +538,7 @@ lemma set_cap_integrity_deletion_aux:
     apply (wp set_object_wp)
      apply wpc
          apply wp+
-   apply (wp get_object_wp)
+    apply (wp get_object_wp)
    apply wps
    apply (wp integrity_asids_set_cap_Nullcap hoare_vcg_all_lift)
   apply (safe ; clarsimp simp add: cte_wp_at_caps_of_state dest!: ko_atD)
@@ -561,7 +561,7 @@ lemma set_cap_integrity_deletion_aux:
          apply (fastforce dest: tcb_states_of_state_kheapD descendant_of_caller_slot[OF _ _ tcb_atI]
                                 parent_of_rtrancl_no_descendant)
          done
-           (* tcb_ctable *)
+       (* tcb_ctable *)
        subgoal for s obj tcb
          apply (rule_tac tro_tcb_empty_ctable, simp, simp, simp)
          apply (frule_tac addr="tcb_cnode_index 0" in caps_of_state_tcb)
@@ -604,7 +604,7 @@ lemma set_cap_integrity_deletion_aux:
                       dest: tcb_caller_slot_empty_on_recieve parent_of_rtrancl_no_descendant
                             descendant_of_caller_slot[OF _ _ tcb_atI] tcb_states_of_state_kheapD)
      done
-    (* tcb_ipcframe*)
+  (* tcb_ipcframe*)
   apply (rename_tac s obj tcb)
   apply (rule tro_orefl)
   apply (fastforce simp: is_nondevice_page_cap_simps caps_of_state_tcb
@@ -615,7 +615,7 @@ lemma set_cap_integrity_deletion_aux:
 lemma set_cap_integrity_deletion[wp_transferable]:
   "\<lbrace>integrity aag X st and valid_mdb and valid_objs
                        and pas_refined aag and cdt_change_allowed' aag slot\<rbrace>
-      set_cap NullCap slot
+   set_cap NullCap slot
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (cases "is_subject aag (fst slot)")
    apply (wpsimp wp: set_cap_integrity_autarch)
@@ -851,10 +851,10 @@ lemma empty_slot_shuffle:
        set_cdt c;
        post_cap_deletion NullCap od :: (det_ext state \<Rightarrow> _))"
   by (simp only: set_cdt_empty_slot_ext_comm[THEN K_bind_eqI', simplified K_bind_assoc]
-            set_cdt_set_original_comm[THEN K_bind_eqI', simplified K_bind_assoc]
+                 set_cdt_set_original_comm[THEN K_bind_eqI', simplified K_bind_assoc]
                  set_cdt_set_cap_comm[THEN K_bind_eqI', simplified K_bind_assoc]
-            set_original_set_cap_comm[THEN K_bind_eqI', simplified K_bind_assoc]
-            set_cap_empty_slot_ext_comm[THEN K_bind_eqI', simplified K_bind_assoc])
+                 set_original_set_cap_comm[THEN K_bind_eqI', simplified K_bind_assoc]
+                 set_cap_empty_slot_ext_comm[THEN K_bind_eqI', simplified K_bind_assoc])
 
 lemma empty_slot_integrity_transferable[wp_transferable]:
   "\<lbrace>integrity aag X st and valid_list and valid_objs and valid_mdb and pas_refined aag
@@ -927,10 +927,10 @@ lemmas set_untyped_cap_as_full_pas_refined'[wp] = set_untyped_cap_as_full_pas_re
 
 lemma update_cdt_pas_refined:
   "\<lbrace>pas_refined aag and (\<lambda>s. \<forall>x y. c (cdt s) x = Some y \<and> cdt s x \<noteq> Some y
-           \<longrightarrow> (is_transferable (caps_of_state s x) \<or>
+                                   \<longrightarrow> (is_transferable (caps_of_state s x) \<or>
                                         abs_has_auth_to aag Control (fst y) (fst x))
                                      \<and> abs_has_auth_to aag DeleteDerived (fst y) (fst x))\<rbrace>
-     update_cdt c
+   update_cdt c
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: update_cdt_def)
   apply (wp set_cdt_pas_refined)
@@ -974,7 +974,7 @@ lemma set_untyped_cap_as_full_is_transferable[wp]:
 lemma set_untyped_cap_as_full_is_transferable':
   "\<lbrace>\<lambda>s. is_transferable ((caps_of_state s(slot2 \<mapsto> new_cap)) slot3) \<and>
         Some src_cap = (caps_of_state s slot)\<rbrace>
-     set_untyped_cap_as_full src_cap new_cap slot
+   set_untyped_cap_as_full src_cap new_cap slot
    \<lbrace>\<lambda>_ s. is_transferable ((caps_of_state s(slot2 \<mapsto> new_cap)) slot3)\<rbrace>"
   apply (clarsimp simp: set_untyped_cap_as_full_def)
   apply safe
@@ -1019,8 +1019,8 @@ lemma cap_insert_pas_refined:
     (\<lambda>s. (is_transferable_in src_slot s \<and> (\<not> Option.is_none (cdt s src_slot)))
          \<longrightarrow> is_transferable_cap new_cap) and
     K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot)
-                                 \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
-     cap_insert new_cap src_slot dest_slot
+                                      \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
+   cap_insert new_cap src_slot dest_slot
    \<lbrace>\<lambda>rv. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: cap_insert_def)
@@ -1030,20 +1030,20 @@ lemma cap_insert_pas_refined:
             set_untyped_cap_as_full_cdt_is_original_cap get_cap_wp
             tcb_domain_map_wellformed_lift hoare_vcg_disj_lift
             set_untyped_cap_as_full_is_transferable'
-       | simp split del: if_split del: split_paired_All fun_upd_apply
-       | strengthen update_one_strg)+
+         | simp split del: if_split del: split_paired_All fun_upd_apply
+         | strengthen update_one_strg)+
   by (fastforce split: if_split_asm
                  simp: cte_wp_at_caps_of_state pas_refined_refl F[symmetric]
                        valid_mdb_def2 mdb_cte_at_def Option.is_none_def
              simp del: split_paired_All
-                dest: aag_cdt_link_Control aag_cdt_link_DeleteDerived cap_auth_caps_of_state)
+                 dest: aag_cdt_link_Control aag_cdt_link_DeleteDerived cap_auth_caps_of_state)
 
 lemma cap_insert_pas_refined':
   "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state and valid_mdb and
     (\<lambda>s. cte_wp_at is_transferable_cap src_slot s \<longrightarrow> is_transferable_cap new_cap) and
     K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot)
-                                 \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
-     cap_insert new_cap src_slot dest_slot
+                                      \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
+   cap_insert new_cap src_slot dest_slot
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   by (wp cap_insert_pas_refined)
      (fastforce dest: valid_mdb_mdb_cte_at[THEN mdb_cte_atD[rotated]]
@@ -1053,8 +1053,8 @@ lemma cap_insert_pas_refined_not_transferable:
   "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state and valid_mdb
                     and not cte_wp_at is_transferable_cap src_slot
                     and K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot)
-                                 \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
-     cap_insert new_cap src_slot dest_slot
+                                                          \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
+   cap_insert new_cap src_slot dest_slot
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
    by (wpsimp wp: cap_insert_pas_refined')
 
@@ -1063,7 +1063,7 @@ lemma cap_insert_pas_refined_same_object_as:
                     and cte_wp_at (same_object_as new_cap) src_slot
                     and K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot) \<and>
                            (\<not> is_master_reply_cap new_cap) \<and> pas_cap_cur_auth aag new_cap)\<rbrace>
-     cap_insert new_cap src_slot dest_slot
+   cap_insert new_cap src_slot dest_slot
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (wp cap_insert_pas_refined)
   apply (clarsimp simp: Option.is_none_def cte_wp_at_caps_of_state)
@@ -1075,8 +1075,8 @@ lemma cap_move_pas_refined[wp]:
                     and valid_mdb and cte_wp_at (weak_derived new_cap) src_slot
                     and cte_wp_at ((=) NullCap) dest_slot
                     and K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot)
-                       \<and> pas_cap_cur_auth aag new_cap)\<rbrace>
-     cap_move new_cap src_slot dest_slot
+                                                          \<and> pas_cap_cur_auth aag new_cap)\<rbrace>
+   cap_move new_cap src_slot dest_slot
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: cap_move_def)
   apply (rule hoare_pre)
@@ -1097,7 +1097,7 @@ crunches set_original, set_cdt
 lemma empty_slot_pas_refined[wp, wp_not_transferable]:
   "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
                     and valid_mdb and K (is_subject aag (fst slot))\<rbrace>
-      empty_slot slot irqopt
+   empty_slot slot irqopt
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: empty_slot_def post_cap_deletion_def)
   apply (wpsimp wp: set_cap_pas_refined get_cap_wp set_cdt_pas_refined
@@ -1111,7 +1111,7 @@ lemma empty_slot_pas_refined[wp, wp_not_transferable]:
 lemma empty_slot_pas_refined_transferable[wp_transferable]:
   "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
                     and valid_mdb and (\<lambda>s. is_transferable (caps_of_state s slot))\<rbrace>
-     empty_slot slot irqopt
+   empty_slot slot irqopt
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: empty_slot_def post_cap_deletion_def)
   apply (wpsimp wp: set_cap_pas_refined get_cap_wp set_cdt_pas_refined
@@ -1131,7 +1131,7 @@ lemma cap_swap_pas_refined[wp]:
                     and cte_wp_at (weak_derived cap') slot'
                     and K (is_subject aag (fst slot) \<and> is_subject aag (fst slot') \<and>
                            pas_cap_cur_auth aag cap \<and> pas_cap_cur_auth aag cap')\<rbrace>
-      cap_swap cap slot cap' slot'
+   cap_swap cap slot cap' slot'
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: cap_swap_def)
   apply (rule hoare_pre)
@@ -1172,7 +1172,7 @@ lemma cap_swap_pas_refined[wp]:
 
 lemma cap_swap_for_delete_pas_refined[wp]:
   "\<lbrace>pas_refined aag and invs and K (is_subject aag (fst slot) \<and> is_subject aag (fst slot'))\<rbrace>
-      cap_swap_for_delete slot slot'
+   cap_swap_for_delete slot slot'
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: cap_swap_for_delete_def)
   apply (wp get_cap_wp | simp)+
@@ -1198,7 +1198,7 @@ lemma sts_respects_restart_ep:
 lemma set_endpoint_respects:
   "\<lbrace>integrity aag X st and ep_at epptr and
     K (\<exists>auth. aag_has_auth_to aag auth epptr \<and> auth \<in> {Receive, SyncSend, Reset})\<rbrace>
-     set_endpoint epptr ep'
+   set_endpoint epptr ep'
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: set_simple_ko_def set_object_def)
   apply (wp get_object_wp)
@@ -1236,7 +1236,7 @@ lemma sts_thread_st_auth[wp]:
 
 lemma sbn_thread_bound_ntfns[wp]:
   "\<lbrace>\<lambda>s. P ((thread_bound_ntfns s)(t := ntfn))\<rbrace>
-     set_bound_notification t ntfn
+   set_bound_notification t ntfn
    \<lbrace>\<lambda>_ s. P (thread_bound_ntfns s)\<rbrace>"
   apply (simp add: set_bound_notification_def)
   apply (wpsimp wp: set_object_wp dxo_wp_weak)
@@ -1381,7 +1381,7 @@ lemma thread_set_pas_refined_triv:
             thread_set f t \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   by (wpsimp wp: tcb_domain_map_wellformed_lift thread_set_state_vrefs
            simp: pas_refined_def state_objs_to_policy_def
-        | wps thread_set_caps_of_state_trivial[OF cps]
+      | wps thread_set_caps_of_state_trivial[OF cps]
             thread_set_thread_st_auth_trivT[OF st]
             thread_set_thread_bound_ntfns_trivT[OF ntfn])+
 
@@ -1399,7 +1399,7 @@ lemma aag_owned_cdt_link:
 (* FIXME: MOVE *)
 lemma descendants_of_owned_or_transferable:
   "\<lbrakk> valid_mdb s; pas_refined aag s; p \<in> descendants_of q (cdt s); is_subject aag (fst q) \<rbrakk>
-       \<Longrightarrow> is_subject aag (fst p) \<or> is_transferable (caps_of_state s p)"
+     \<Longrightarrow> is_subject aag (fst p) \<or> is_transferable (caps_of_state s p)"
    using all_children_descendants_of pas_refined_all_children by blast
 
 
@@ -1408,7 +1408,7 @@ context CNode_AC_3 begin
 lemma set_ntfn_respects:
   "\<lbrace>integrity aag X st and
     K (\<exists>auth. aag_has_auth_to aag auth epptr \<and> auth \<in> {Receive, Notify, Reset})\<rbrace>
-     set_notification epptr ep'
+   set_notification epptr ep'
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: set_simple_ko_def set_object_def)
   apply (wp get_object_wp)
@@ -1453,7 +1453,7 @@ lemma cap_auth_conferred_cnode_cap:
 
 lemma get_cap_ret_is_subject:
   "\<lbrace>pas_refined aag and K (is_subject aag (fst slot))\<rbrace>
-     get_cap slot
+   get_cap slot
    \<lbrace>\<lambda>rv s. is_cnode_cap rv \<longrightarrow> is_subject aag (obj_ref_of rv)\<rbrace>"
   apply (clarsimp simp: valid_def)
   apply (frule get_cap_det)
@@ -1478,12 +1478,12 @@ definition auth_derived :: "cap \<Rightarrow> cap \<Rightarrow> bool" where
 
 definition cnode_inv_auth_derivations ::
   "Invocations_A.cnode_invocation \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
- "cnode_inv_auth_derivations ci \<equiv> case ci of
-    InsertCall cap ptr ptr' \<Rightarrow> cte_wp_at (auth_derived cap) ptr
-  | MoveCall cap ptr ptr' \<Rightarrow> cte_wp_at (auth_derived cap) ptr
+  "cnode_inv_auth_derivations ci \<equiv> case ci of
+     InsertCall cap ptr ptr' \<Rightarrow> cte_wp_at (auth_derived cap) ptr
+   | MoveCall cap ptr ptr' \<Rightarrow> cte_wp_at (auth_derived cap) ptr
    | RotateCall s_cap p_cap src pivot dest \<Rightarrow>
        cte_wp_at (auth_derived s_cap) src and cte_wp_at (auth_derived p_cap) pivot
-  | _ \<Rightarrow> \<top>"
+   | _ \<Rightarrow> \<top>"
 
 lemma UNIV_eq_single_card:
   "(UNIV = {x :: 'a}) \<Longrightarrow> (card (UNIV :: 'a set) = 1)"
@@ -1597,7 +1597,7 @@ begin
 
 lemma derive_cap_auth_derived:
   "\<lbrace>\<lambda>s :: det_ext state. cap \<noteq> NullCap \<longrightarrow> cte_wp_at (auth_derived cap) src_slot s\<rbrace>
-      derive_cap src_slot cap
+   derive_cap src_slot cap
    \<lbrace>\<lambda>rv s. rv \<noteq> NullCap \<longrightarrow> cte_wp_at (auth_derived rv) src_slot s\<rbrace>, -"
   apply (wpsimp wp: arch_derive_cap_auth_derived simp: derive_cap_def | wp hoare_drop_imps)+
   apply (auto simp: cte_wp_at_caps_of_state)
@@ -1617,7 +1617,7 @@ lemma auth_derived_mask_cap:
 
 lemma auth_derived_update_cap_data:
   "\<lbrakk> auth_derived cap cap'; update_cap_data pres w cap \<noteq> NullCap \<rbrakk>
-           \<Longrightarrow> auth_derived (update_cap_data pres w cap) cap'"
+     \<Longrightarrow> auth_derived (update_cap_data pres w cap) cap'"
   apply (clarsimp simp: update_cap_data_def badge_update_def Let_def split_def
                         is_cap_simps auth_derived_arch_update_cap_data
                  split: if_split_asm)
@@ -1626,12 +1626,12 @@ lemma auth_derived_update_cap_data:
 
 lemma cte_wp_at_auth_derived_mask_cap_strg:
   "cte_wp_at (auth_derived cap) p s
-      \<longrightarrow> cte_wp_at (auth_derived (mask_cap R cap)) p s"
+   \<longrightarrow> cte_wp_at (auth_derived (mask_cap R cap)) p s"
   by (clarsimp simp: cte_wp_at_caps_of_state auth_derived_mask_cap)
 
 lemma cte_wp_at_auth_derived_update_cap_data_strg:
   "cte_wp_at (auth_derived cap) p s \<and> update_cap_data pres w cap \<noteq> NullCap
-      \<longrightarrow> cte_wp_at (auth_derived (update_cap_data pres w cap)) p s"
+   \<longrightarrow> cte_wp_at (auth_derived (update_cap_data pres w cap)) p s"
   by (clarsimp simp: cte_wp_at_caps_of_state auth_derived_update_cap_data)
 
 lemma get_cap_auth_derived:
@@ -1649,12 +1649,12 @@ lemma decode_cnode_invocation_auth_derived:
               simp: cnode_inv_auth_derivations_If_Insert_Move[unfolded cnode_inv_auth_derivations_def]
                     cnode_inv_auth_derivations_def split_def whenE_def split_del: if_split
          | strengthen cte_wp_at_auth_derived_mask_cap_strg cte_wp_at_auth_derived_update_cap_data_strg
-            | wp (once) hoare_drop_imps)+
+         | wp (once) hoare_drop_imps)+
   done
 
 lemma derive_cap_clas:
   "\<lbrace>\<lambda>s :: det_ext state. cap_links_asid_slot aag p b \<rbrace>
-     derive_cap a b
+   derive_cap a b
    \<lbrace>\<lambda>rv s. cap_links_asid_slot aag p rv\<rbrace>, -"
   apply (simp add: derive_cap_def  cong: cap.case_cong)
   apply (rule hoare_pre)
@@ -1670,7 +1670,7 @@ lemma derive_cap_obj_refs_auth:
 
 lemma derive_cap_cli:
   "\<lbrace>K (cap_links_irq aag l cap)\<rbrace>
-  derive_cap slot cap
+   derive_cap slot cap
    \<lbrace>\<lambda>x s :: det_ext state. cap_links_irq aag l x\<rbrace>, -"
   unfolding derive_cap_def
   apply (rule hoare_pre)
@@ -1697,7 +1697,7 @@ lemma derive_cap_untyped_range_subset:
    \<lbrace>\<lambda>rv s. \<forall>x \<in> untyped_range rv. P x s\<rbrace>, -"
   unfolding derive_cap_def
   apply (rule hoare_pre)
-  apply (simp cong: cap.case_cong)
+   apply (simp cong: cap.case_cong)
    apply (wp arch_derive_cap_untyped_range_subset | wpc)+
   apply fastforce
   done

--- a/proof/access-control/Finalise_AC.thy
+++ b/proof/access-control/Finalise_AC.thy
@@ -73,17 +73,17 @@ begin
 lemma tcb_sched_action_dequeue_integrity':
   "\<lbrace>integrity aag X st and pas_refined aag and
     (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag (tcb_domain (the (ekheap s thread))))\<rbrace>
-    tcb_sched_action tcb_sched_dequeue thread
+   tcb_sched_action tcb_sched_dequeue thread
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (wpsimp simp: tcb_sched_action_def)
   apply (clarsimp simp: integrity_def integrity_ready_queues_def pas_refined_def
                         tcb_domain_map_wellformed_aux_def etcb_at_def get_etcb_def
-                  split: option.splits)
+                 split: option.splits)
   done
 
 lemma tcb_sched_action_dequeue_integrity[wp]:
   "\<lbrace>integrity aag X st and pas_refined aag and K (is_subject aag thread)\<rbrace>
-    tcb_sched_action tcb_sched_dequeue thread
+   tcb_sched_action tcb_sched_dequeue thread
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: tcb_sched_action_def)
   apply wp
@@ -109,7 +109,7 @@ text \<open>See comment for @{thm tcb_sched_action_dequeue_integrity'}\<close>
 lemma tcb_sched_action_append_integrity':
   "\<lbrace>integrity aag X st and
     (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag (tcb_domain (the (ekheap s thread))))\<rbrace>
-    tcb_sched_action tcb_sched_append thread
+   tcb_sched_action tcb_sched_append thread
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: tcb_sched_action_def)
   apply wp
@@ -119,7 +119,7 @@ lemma tcb_sched_action_append_integrity':
 
 lemma tcb_sched_action_append_integrity[wp]:
   "\<lbrace>integrity aag X st and pas_refined aag and K (is_subject aag thread)\<rbrace>
-    tcb_sched_action tcb_sched_append thread
+   tcb_sched_action tcb_sched_append thread
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: tcb_sched_action_def)
   apply wp
@@ -132,7 +132,7 @@ lemma tcb_sched_action_append_integrity[wp]:
 
 lemma tcb_sched_action_append_integrity_pasMayEditReadyQueues:
   "\<lbrace>integrity aag X st and pas_refined aag and K (pasMayEditReadyQueues aag)\<rbrace>
-    tcb_sched_action tcb_sched_append thread
+   tcb_sched_action tcb_sched_append thread
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: tcb_sched_action_def)
   apply wp
@@ -149,8 +149,8 @@ lemma reschedule_required_integrity[wp]:
 lemma cancel_badged_sends_respects[wp]:
   "\<lbrace>integrity aag X st and einvs and valid_objs
                        and (sym_refs \<circ> state_refs_of)
-           and K (aag_has_auth_to aag Reset epptr)\<rbrace>
-    cancel_badged_sends epptr badge
+                       and K (aag_has_auth_to aag Reset epptr)\<rbrace>
+   cancel_badged_sends epptr badge
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: cancel_badged_sends_def filterM_mapM
@@ -180,8 +180,8 @@ lemma cancel_badged_sends_respects[wp]:
 
 lemma cancel_all_ipc_respects [wp]:
   "\<lbrace>integrity aag X st and valid_objs and (sym_refs \<circ> state_refs_of)
-           and K (\<exists>auth. aag_has_auth_to aag Reset epptr)\<rbrace>
-    cancel_all_ipc epptr
+                       and K (\<exists>auth. aag_has_auth_to aag Reset epptr)\<rbrace>
+   cancel_all_ipc epptr
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (clarsimp simp: cancel_all_ipc_def get_ep_queue_def cong: endpoint.case_cong)
@@ -249,7 +249,7 @@ lemma sbn_pas_refined[wp]:
   "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state and
     K (case ntfn of None \<Rightarrow> True
                   | Some ntfn' \<Rightarrow> \<forall>auth \<in> {Receive, Reset}. abs_has_auth_to aag auth t ntfn')\<rbrace>
-      set_bound_notification t ntfn
+   set_bound_notification t ntfn
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def)
   apply (rule hoare_pre)
@@ -257,7 +257,7 @@ lemma sbn_pas_refined[wp]:
   apply (clarsimp dest!: auth_graph_map_memD)
   apply (erule state_bits_to_policy.cases)
   by (auto intro: state_bits_to_policy.intros auth_graph_map_memI
-              split: if_split_asm)
+           split: if_split_asm)
 
 lemma unbind_notification_pas_refined[wp]:
   "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
@@ -343,7 +343,7 @@ context Finalise_AC_1 begin
 
 lemma reply_cancel_ipc_pas_refined[wp]:
   "\<lbrace>pas_refined aag and invs and tcb_at t and K (is_subject aag t)\<rbrace>
-     reply_cancel_ipc t
+   reply_cancel_ipc t
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: reply_cancel_ipc_def)
@@ -357,7 +357,7 @@ lemma reply_cancel_ipc_pas_refined[wp]:
 
 lemma deleting_irq_handler_pas_refined[wp]:
   "\<lbrace>pas_refined aag and invs and K (is_subject_irq aag irq)\<rbrace>
-      deleting_irq_handler irq
+   deleting_irq_handler irq
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: deleting_irq_handler_def get_irq_slot_def)
   apply wp
@@ -374,7 +374,7 @@ crunch pas_refined[wp]: suspend "pas_refined aag"
 
 lemma finalise_cap_pas_refined[wp]:
   "\<lbrace>pas_refined aag and invs and valid_cap cap and K (pas_cap_cur_auth aag cap)\<rbrace>
-     finalise_cap cap fin
+   finalise_cap cap fin
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (cases cap; simp only: finalise_cap.simps)
@@ -386,8 +386,8 @@ lemma finalise_cap_pas_refined[wp]:
 
 lemma cancel_all_signals_respects[wp]:
   "\<lbrace>integrity aag X st and valid_objs and (sym_refs \<circ> state_refs_of)
-           and K (aag_has_auth_to aag Reset epptr)\<rbrace>
-    cancel_all_signals epptr
+                       and K (aag_has_auth_to aag Reset epptr)\<rbrace>
+   cancel_all_signals epptr
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (clarsimp simp add: cancel_all_signals_def)
@@ -409,7 +409,7 @@ end
 lemma sbn_unbind_respects[wp]:
   "\<lbrace>integrity aag X st and
     (\<lambda>s. (\<exists>ntfn. bound_tcb_at (\<lambda>a. a = Some ntfn) t s \<and> aag_has_auth_to aag Reset ntfn))\<rbrace>
-     set_bound_notification t None
+   set_bound_notification t None
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: set_bound_notification_def)
   apply (wpsimp wp: set_object_wp)
@@ -452,7 +452,7 @@ lemma unbind_notification_respects:
 
 lemma unbind_maybe_notification_respects:
   "\<lbrace>integrity aag X st and invs and pas_refined aag and
-      obj_at (\<lambda>ko. \<exists>ntfn. ko = (Notification ntfn) \<and>
+    obj_at (\<lambda>ko. \<exists>ntfn. ko = (Notification ntfn) \<and>
                         (case (ntfn_bound_tcb ntfn) of None \<Rightarrow> True
                                                      | Some t \<Rightarrow> aag_has_auth_to aag Reset a)) a\<rbrace>
    unbind_maybe_notification a
@@ -472,21 +472,21 @@ context Finalise_AC_1 begin
 lemma fast_finalise_respects[wp]:
   "\<lbrace>integrity aag X st and invs and pas_refined aag and valid_cap cap
                                 and K (pas_cap_cur_auth aag cap)\<rbrace>
-      fast_finalise cap fin
+   fast_finalise cap fin
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (cases cap; simp)
      apply (wpsimp wp: unbind_maybe_notification_valid_objs get_simple_ko_wp
-               unbind_maybe_notification_respects
+                       unbind_maybe_notification_respects
                  simp: cap_auth_conferred_def cap_rights_to_auth_def aag_cap_auth_def when_def
-           | fastforce)+
+            | fastforce)+
    apply (clarsimp simp: obj_at_def valid_cap_def is_ntfn invs_def valid_state_def valid_pspace_def
-                     split: option.splits)+
+                  split: option.splits)+
   apply (wp, simp)
   done
 
 lemma cap_delete_one_respects[wp,wp_not_transferable]:
   "\<lbrace>integrity aag X st and pas_refined aag and einvs and K (is_subject aag (fst slot))\<rbrace>
-     cap_delete_one slot
+   cap_delete_one slot
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: cap_delete_one_def unless_def bind_assoc)
   apply (wpsimp wp: hoare_drop_imps get_cap_auth_wp [where aag = aag])
@@ -498,7 +498,7 @@ end
 
 lemma fast_finalise_is_transferable[wp_transferable]:
   "\<lbrace>P and K (is_transferable (Some cap))\<rbrace>
-     fast_finalise cap final
+   fast_finalise cap final
    \<lbrace>\<lambda>_. P\<rbrace>"
   by (rule hoare_gen_asm) (erule is_transferable.cases; simp)
 
@@ -506,7 +506,7 @@ lemma cap_delete_one_respects_transferable[wp_transferable]:
   "\<lbrace>integrity aag X st and pas_refined aag and einvs
                        and cte_wp_at (\<lambda>c. is_transferable (Some c)) slot
                        and cdt_change_allowed' aag slot\<rbrace>
-      cap_delete_one slot
+   cap_delete_one slot
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: cap_delete_one_def unless_def bind_assoc)
   apply (wp add: hoare_drop_imps get_cap_wp wp_transferable del: wp_not_transferable | simp)+
@@ -524,7 +524,7 @@ lemma thread_set_tcb_state_trivial:
 
 lemma reply_cancel_ipc_respects[wp]:
   "\<lbrace>integrity aag X st and einvs and tcb_at t and K (is_subject aag t) and pas_refined aag\<rbrace>
-     reply_cancel_ipc t
+   reply_cancel_ipc t
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: reply_cancel_ipc_def)
   apply (rule hoare_pre)
@@ -541,12 +541,12 @@ lemma reply_cancel_ipc_respects[wp]:
    apply (fastforce simp: cte_wp_at_caps_of_state intro:is_transferable.intros
                    dest!: reply_cap_descends_from_master0)
   apply (rule cdt_change_allowed_all_children[where aag=aag, THEN all_children_descendants_of])
-   by fastforce+
+  by fastforce+
 
 lemma cancel_signal_respects[wp]:
   "\<lbrace>\<lambda>s. integrity aag X st s \<and> is_subject aag t \<and>
         (\<exists>auth. aag_has_auth_to aag auth ntfnptr \<and> (auth = Receive \<or> auth = Notify))\<rbrace>
-     cancel_signal t ntfnptr
+   cancel_signal t ntfnptr
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: cancel_signal_def)
   apply (rule hoare_seq_ext[OF _ get_simple_ko_sp])
@@ -556,13 +556,13 @@ lemma cancel_signal_respects[wp]:
 
 lemma cancel_ipc_respects[wp]:
   "\<lbrace>integrity aag X st and einvs and tcb_at t and K (is_subject aag t) and pas_refined aag\<rbrace>
-     cancel_ipc t
+   cancel_ipc t
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: cancel_ipc_def)
   apply (rule hoare_seq_ext[OF _ gts_sp])
   apply (rule hoare_pre)
    apply (wp set_thread_state_integrity_autarch set_endpoint_respects get_simple_ko_wp
-         | wpc
+          | wpc
           | simp (no_asm) add: blocked_cancel_ipc_def get_ep_queue_def get_blocking_object_def)+
   apply clarsimp
   apply (frule st_tcb_at_to_thread_st_auth, clarsimp+)
@@ -572,7 +572,7 @@ lemma cancel_ipc_respects[wp]:
 lemma update_restart_pc_integrity_autarch[wp]:
   "\<lbrace>integrity aag X st and K (is_subject aag t)\<rbrace>
    update_restart_pc t
-                                      \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: get_thread_state_def thread_get_def update_restart_pc_def)
   apply (wpsimp wp: as_user_integrity_autarch)
   done
@@ -602,7 +602,7 @@ lemma finalise_is_fast_finalise:
 
 lemma get_irq_slot_owns[wp]:
   "\<lbrace>pas_refined aag and K (is_subject_irq aag irq)\<rbrace>
-      get_irq_slot irq
+   get_irq_slot irq
    \<lbrace>\<lambda>rv _. is_subject aag (fst rv)\<rbrace>"
   unfolding get_irq_slot_def
   apply wp
@@ -623,32 +623,32 @@ context Finalise_AC_1 begin
 
 lemma finalise_cap_respects[wp]:
   "\<lbrace>integrity aag X st and pas_refined aag and einvs and valid_cap cap
-    and K (pas_cap_cur_auth aag cap)\<rbrace>
+                                           and K (pas_cap_cur_auth aag cap)\<rbrace>
    finalise_cap cap final
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (cases cap; simp; safe?;
-     (solves \<open>(wp | simp add: if_apply_def2 split del: if_split
-                  | clarsimp simp: cap_auth_conferred_def cap_rights_to_auth_def is_cap_simps
-                                   pas_refined_all_auth_is_owns aag_cap_auth_def
-                                   deleting_irq_handler_def cap_links_irq_def invs_valid_objs
-                        split del: if_split
+         (solves \<open>(wp | simp add: if_apply_def2 split del: if_split
+                      | clarsimp simp: cap_auth_conferred_def cap_rights_to_auth_def is_cap_simps
+                                       pas_refined_all_auth_is_owns aag_cap_auth_def
+                                       deleting_irq_handler_def cap_links_irq_def invs_valid_objs
+                            split del: if_split
                                 elim!: pas_refined_Control [symmetric])+\<close>)?)
    (*NTFN Cap*)
    apply ((wp unbind_maybe_notification_valid_objs get_simple_ko_wp
               unbind_maybe_notification_respects
-          | wpc
-          | simp add: cap_auth_conferred_def cap_rights_to_auth_def aag_cap_auth_def
-               split: if_split_asm
-          | fastforce)+;
+           | wpc
+           | simp add: cap_auth_conferred_def cap_rights_to_auth_def aag_cap_auth_def
+                split: if_split_asm
+           | fastforce)+;
           clarsimp simp: obj_at_def valid_cap_def is_ntfn invs_def
                          valid_state_def valid_pspace_def
                   split: option.splits)
   (* tcb cap *)
   apply (wp unbind_notification_respects unbind_notification_invs
-          | clarsimp simp: cap_auth_conferred_def cap_rights_to_auth_def aag_cap_auth_def
-                           unbind_maybe_notification_def
-                    elim!: pas_refined_Control[symmetric]
-          | simp add: if_apply_def2 split del: if_split )+
+         | clarsimp simp: cap_auth_conferred_def cap_rights_to_auth_def aag_cap_auth_def
+                          unbind_maybe_notification_def
+                   elim!: pas_refined_Control[symmetric]
+         | simp add: if_apply_def2 split del: if_split )+
   apply (clarsimp simp: valid_cap_def pred_tcb_at_def obj_at_def is_tcb
                  dest!: tcb_at_ko_at)
   apply (clarsimp split: option.splits elim!: pas_refined_Control[symmetric])
@@ -698,15 +698,15 @@ context Finalise_AC_1 begin
 
 lemma finalise_cap_auth':
   "\<lbrace>pas_refined aag and K (pas_cap_cur_auth aag cap)\<rbrace>
-      finalise_cap cap final
+   finalise_cap cap final
    \<lbrace>\<lambda>rv _. pas_cap_cur_auth aag (fst rv)\<rbrace>"
   including no_pre
   apply (rule hoare_gen_asm)
   apply (cases cap, simp_all split del: if_split)
              apply (wp | simp add: comp_def hoare_post_taut[where P = \<top>] split del: if_split
                        | fastforce simp: aag_cap_auth_Zombie aag_cap_auth_CNode aag_cap_auth_Thread)+
-  apply (rule hoare_pre)
-  apply (wp | simp)+
+    apply (rule hoare_pre)
+     apply (wp | simp)+
   apply (wp arch_finalise_cap_auth')
   done
 
@@ -744,11 +744,11 @@ lemma finalise_cap_makes_halted:
              apply (wp
                     | clarsimp simp: o_def valid_cap_def cap_table_at_typ is_tcb
                                      obj_at_def halted_if_tcb_def
-                           split: option.split
-                 | intro impI conjI
-                 | rule hoare_drop_imp)+
+                              split: option.split
+                    | intro impI conjI
+                    | rule hoare_drop_imp)+
    apply (fastforce simp: st_tcb_at_def obj_at_def is_tcb live_def
-                  dest!: final_zombie_not_live)
+                   dest!: final_zombie_not_live)
   apply (wp arch_finalise_cap_makes_halted)
   done
 
@@ -757,7 +757,7 @@ end
 
 lemma aag_Control_into_owns_irq:
   "\<lbrakk> (pasSubject aag, Control, pasIRQAbs aag irq) \<in> pasPolicy aag; pas_refined aag s \<rbrakk>
-    \<Longrightarrow> is_subject_irq aag irq"
+     \<Longrightarrow> is_subject_irq aag irq"
   apply (drule (1) pas_refined_Control)
   apply simp
   done
@@ -765,7 +765,7 @@ lemma aag_Control_into_owns_irq:
 lemma owns_slot_owns_irq:
   "\<lbrakk> is_subject aag (fst slot); pas_refined aag s;
      caps_of_state s slot = Some rv; cap_irq_opt rv = Some irq \<rbrakk>
-    \<Longrightarrow> is_subject_irq aag irq"
+     \<Longrightarrow> is_subject_irq aag irq"
   apply (rule aag_Control_into_owns_irq[rotated], assumption)
   apply (drule (1) cli_caps_of_state)
   apply (clarsimp simp: cap_links_irq_def cap_irq_opt_def split: cap.splits)
@@ -790,7 +790,7 @@ lemma rec_del_respects'_pre':
   rec_del call
   \<lbrace>\<lambda>rv. (\<lambda>s. trp \<longrightarrow> (case call of FinaliseSlotCall sl _ \<Rightarrow> (cleanup_info_wf (snd rv) aag)
                                  | _ \<Rightarrow> True) \<and> integrity aag X st s) and pas_refined aag\<rbrace>,
-   \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
+  \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
 proof (induct arbitrary: st rule: rec_del.induct, simp_all only: rec_del_fails)
   case (1 slot exposed s)
   show ?case
@@ -808,7 +808,7 @@ proof (induct arbitrary: st rule: rec_del.induct, simp_all only: rec_del_fails)
        apply (rule valid_validE_R, rule rec_del_invs)
       apply (rule "1.hyps"[simplified rec_del_call.simps slot_rdcall.simps])
      apply auto
-  done
+    done
 next
   case (2 slot exposed s)
   show ?case
@@ -911,14 +911,14 @@ lemma rec_del_respects'_pre:
    K (case call of ReduceZombieCall cap sl _ \<Rightarrow> \<forall>x \<in> obj_refs_ac cap. is_subject aag x | _ \<Rightarrow> True)\<rbrace>
   rec_del call
   \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>,
-   \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
+  \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
   apply (rule spec_strengthen_postE[OF rec_del_respects'_pre'])
   by simp
 
 lemmas rec_del_respects'' = rec_del_respects'_pre[THEN use_spec(2), THEN validE_valid]
 lemmas rec_del_respects =
   rec_del_respects''[of True, THEN hoare_conjD1, simplified]
-      rec_del_respects''[of False, THEN hoare_conjD2, simplified]
+  rec_del_respects''[of False, THEN hoare_conjD2, simplified]
 
 end
 
@@ -931,7 +931,7 @@ lemma finalise_cap_transferable:
 
 lemma rec_del_Finalise_transferable:
   "\<lbrace>(\<lambda>s. is_transferable (caps_of_state s slot)) and P\<rbrace>
-     rec_del (FinaliseSlotCall slot exposed)
+   rec_del (FinaliseSlotCall slot exposed)
    \<lbrace>\<lambda>rv. K (rv = (True,NullCap)) and P\<rbrace>, \<lbrace>\<lambda>_. P\<rbrace>"
   apply (subst rec_del.simps[abs_def])
   apply (wp hoare_K_bind | wpc )+
@@ -951,7 +951,7 @@ lemma rec_del_respects_CTEDelete_transferable':
   "\<lbrace>(\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag and einvs and
     simple_sched_action and emptyable slot and  cdt_change_allowed' aag slot and
     (\<lambda>s. \<not> exposed \<longrightarrow> ex_cte_cap_wp_to (\<lambda>cp. cap_irqs cp = {}) slot s)\<rbrace>
-     rec_del (CTEDeleteCall slot exposed)
+   rec_del (CTEDeleteCall slot exposed)
    \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>,
    \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
   apply (cases "is_subject aag (fst slot)")
@@ -961,13 +961,13 @@ lemma rec_del_respects_CTEDelete_transferable':
   apply (wp add: hoare_K_bind without_preemption_wp static_imp_wp wp_transferable
                  rec_del_Finalise_transferable
             del: wp_not_transferable
-        | wpc)+
+         | wpc)+
     apply (rule hoare_post_impErr,rule rec_del_Finalise_transferable)
      apply simp apply (elim conjE) apply simp apply simp
    apply (wp add: hoare_K_bind without_preemption_wp static_imp_wp wp_transferable
                   rec_del_Finalise_transferable
              del: wp_not_transferable
-         | wpc)+
+          | wpc)+
    apply (rule hoare_post_impErr,rule rec_del_Finalise_transferable)
     apply simp apply (elim conjE) apply simp apply simp
   apply (clarsimp)
@@ -991,7 +991,7 @@ context Finalise_AC_1 begin
 
 lemma set_eobject_integrity_autarch:
   "\<lbrace>integrity aag X st and K (is_subject aag ptr)\<rbrace>
-     set_eobject ptr obj
+   set_eobject ptr obj
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: set_eobject_def)
   apply wp
@@ -1014,12 +1014,12 @@ lemma rsubst':
 
 lemma thread_set_pas_refined_triv_idleT:
   assumes cps: "\<And>tcb. \<forall>(getF, v)\<in>ran tcb_cap_cases. getF (f tcb) = getF tcb"
-       and st: "\<And>tcb. P (tcb_state tcb) \<longrightarrow> tcb_state (f tcb) = tcb_state tcb"
+  and st: "\<And>tcb. P (tcb_state tcb) \<longrightarrow> tcb_state (f tcb) = tcb_state tcb"
   and ba: "\<And>tcb. Q (tcb_bound_notification tcb)
                   \<longrightarrow> tcb_bound_notification (f tcb) = tcb_bound_notification tcb"
   shows "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
                           and idle_tcb_at (\<lambda>(st, ntfn, arch). P st \<and> Q ntfn \<and> R arch) t\<rbrace>
-        thread_set f t
+         thread_set f t
          \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def)
   apply (rule hoare_pre)
@@ -1033,12 +1033,12 @@ lemma thread_set_pas_refined_triv_idleT:
   apply (subst state_vrefs_tcb_upd, fastforce+)
    apply (clarsimp simp: tcb_at_def)
   apply (rule conjI)
-  apply (erule_tac P="\<lambda> ts ba. auth_graph_map a (state_bits_to_policy cps ts ba cd vr) \<subseteq> ag"
-               for a cps cd vr ag in rsubst')
-   apply (drule get_tcb_SomeD)
+   apply (erule_tac P="\<lambda> ts ba. auth_graph_map a (state_bits_to_policy cps ts ba cd vr) \<subseteq> ag"
+                for a cps cd vr ag in rsubst')
+    apply (drule get_tcb_SomeD)
     apply (rule ext, clarsimp simp add: thread_st_auth_def get_tcb_def st tcb_states_of_state_def)
-  apply (drule get_tcb_SomeD)
-  apply (rule ext, clarsimp simp: thread_bound_ntfns_def get_tcb_def ba)
+   apply (drule get_tcb_SomeD)
+   apply (rule ext, clarsimp simp: thread_bound_ntfns_def get_tcb_def ba)
   apply (clarsimp)
   done
 
@@ -1047,29 +1047,29 @@ context Finalise_AC_1 begin
 
 lemma cap_delete_respects:
   "\<lbrace>integrity aag X st and cdt_change_allowed' aag slot and pas_refined aag
-            and einvs and simple_sched_action and emptyable slot\<rbrace>
-       cap_delete slot
+                       and einvs and simple_sched_action and emptyable slot\<rbrace>
+   cap_delete slot
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   by (simp add: cap_delete_def) (wpsimp wp: rec_del_respects_CTEDelete_transferable)
 
 lemma cap_delete_respects':
   "\<lbrace>integrity aag X st and K (is_subject aag (fst slot)) and pas_refined aag
-            and einvs and simple_sched_action and emptyable slot\<rbrace>
-       cap_delete slot
+                       and einvs and simple_sched_action and emptyable slot\<rbrace>
+   cap_delete slot
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   by (wp cap_delete_respects) fastforce
 
 lemma cap_delete_pas_refined:
   "\<lbrace>cdt_change_allowed' aag slot and pas_refined aag and einvs
                                  and simple_sched_action and emptyable slot\<rbrace>
-       cap_delete slot
+   cap_delete slot
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   by (simp add: cap_delete_def) (wpsimp wp: rec_del_respects_CTEDelete_transferable)
 
 lemma cap_delete_pas_refined':
   "\<lbrace>pas_refined aag and einvs and simple_sched_action
                     and emptyable slot and K(is_subject aag (fst slot))\<rbrace>
-       cap_delete slot
+   cap_delete slot
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   by (wp cap_delete_pas_refined) fastforce
 
@@ -1079,7 +1079,7 @@ end
 (* MOVE *)
 lemma empty_slot_cte_wp_at:
   "\<lbrace>\<lambda>s. (p = slot \<longrightarrow> P NullCap) \<and> (p \<noteq> slot \<longrightarrow> cte_wp_at P p s)\<rbrace>
-      empty_slot slot free_irq
+   empty_slot slot free_irq
    \<lbrace>\<lambda>_. cte_wp_at P p\<rbrace>"
   unfolding cte_wp_at_caps_of_state
   by (wpsimp wp: empty_slot_caps_of_state)
@@ -1105,8 +1105,8 @@ locale Finalise_AC_2 = Finalise_AC_1 +
        \<lbrace>\<lambda>_. (\<lambda>s. trp \<longrightarrow> integrity aag X st s) and pas_refined aag\<rbrace>"
   and finalise_cap_caps_of_state_nullinv:
     "\<And>P. \<lbrace>\<lambda>s :: det_ext state. P (caps_of_state s) \<and> (\<forall>p. P (caps_of_state s(p \<mapsto> NullCap)))\<rbrace>
-     finalise_cap cap final
-   \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
+          finalise_cap cap final
+          \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
   and finalise_cap_fst_ret:
     "\<And>P. \<lbrace>\<lambda>_ :: det_ext state. P NullCap \<and> (\<forall>a b c. P (Zombie a b c)) \<rbrace>
           finalise_cap cap is_final
@@ -1121,7 +1121,7 @@ lemmas cap_revoke_pas_refined[wp] =
 
 lemma finalise_cap_cte_wp_at_nullinv:
   "\<lbrace>\<lambda>s :: det_ext state. P NullCap \<and> cte_wp_at P p s\<rbrace>
-     finalise_cap cap final
+   finalise_cap cap final
    \<lbrace>\<lambda>_ s. cte_wp_at P p s\<rbrace>"
   apply (simp add: cte_wp_at_caps_of_state)
   apply (wp finalise_cap_caps_of_state_nullinv)
@@ -1135,7 +1135,7 @@ lemma rec_del_preserves_cte_zombie_null:
     "s \<turnstile> \<lbrace>\<lambda>s. ((slot_rdcall call \<noteq> p \<or> exposed_rdcall call) \<longrightarrow> cte_wp_at P p s) \<and>
               (case call of ReduceZombieCall remove slot _ \<Rightarrow> cte_wp_at ((=) remove) slot s
                                                        | _ \<Rightarrow> True)\<rbrace>
-              rec_del call
+         rec_del call
          \<lbrace>\<lambda>_ s :: det_ext state. (slot_rdcall call \<noteq> p \<or> exposed_rdcall call) \<longrightarrow> cte_wp_at P p s\<rbrace>,
          \<lbrace>\<lambda>_. \<top>\<rbrace>"
 proof (induct rule: rec_del.induct, simp_all only: rec_del_fails)
@@ -1174,7 +1174,7 @@ next
        apply (clarsimp simp: cte_wp_at_caps_of_state)
       apply (wp static_imp_wp set_cap_cte_wp_at' finalise_cap_cte_wp_at_nullinv
                 finalise_cap_fst_ret get_cap_wp
-         | simp add: is_final_cap_def)+
+             | simp add: is_final_cap_def)+
     apply (clarsimp simp add: P_Zombie is_cap_simps cte_wp_at_caps_of_state)+
     done
 next
@@ -1215,9 +1215,9 @@ lemma rec_del_preserves_cte_zombie_null_insts:
          \<lbrace>\<lambda>_. cte_wp_at P p\<rbrace>,-"
   and "\<lbrace>\<lambda>s :: det_ext state. cte_wp_at P p s\<rbrace> cap_delete slot \<lbrace>\<lambda>_. cte_wp_at P p\<rbrace>,-"
   by (simp add: validE_R_def P_Null P_Zombie cap_delete_def
-        | rule use_spec spec_strengthen_postE[OF hoare_pre_spec_validE
+      | rule use_spec spec_strengthen_postE[OF hoare_pre_spec_validE
                             [OF rec_del_preserves_cte_zombie_null[where P=P]]]
-        | wp)+
+      | wp)+
 
 lemma cap_revoke_preserves_cte_zombie_null:
   fixes p
@@ -1245,13 +1245,13 @@ lemma invoke_cnode_respects:
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: invoke_cnode_def authorised_cnode_inv_def split: cnode_invocation.split, safe)
   apply (wpsimp wp: get_cap_wp cap_insert_integrity_autarch
-            cap_revoke_respects cap_delete_respects
+                    cap_revoke_respects cap_delete_respects
               simp: real_cte_emptyable_strg is_transferable_weak_derived
-            | clarsimp simp: cte_wp_at_caps_of_state invs_valid_objs invs_sym_refs
-                             cnode_inv_auth_derivations_def
-            | drule(2) auth_derived_caps_of_state_impls
+         | clarsimp simp: cte_wp_at_caps_of_state invs_valid_objs invs_sym_refs
+                          cnode_inv_auth_derivations_def
+         | drule(2) auth_derived_caps_of_state_impls
          | strengthen invs_psp_aligned invs_vspace_objs invs_arch_state
-            | rule hoare_pre | rule cca_direct)+
+         | rule hoare_pre | rule cca_direct)+
   apply (auto simp: cap_auth_conferred_def cap_rights_to_auth_def aag_cap_auth_def)
   done
 
@@ -1259,14 +1259,14 @@ end
 
 lemma set_cap_cte_wp_at_separation:
   "\<lbrace>cte_wp_at P slot and K (slot \<noteq> slot')\<rbrace>
-     set_cap cap slot'
+   set_cap cap slot'
    \<lbrace>\<lambda>_. cte_wp_at P slot \<rbrace>"
   by (wpsimp simp: cte_wp_at_caps_of_state[abs_def])
 
 (* FIXME MOVE*)
 lemma cap_move_cte_wp_at_separation:
   "\<lbrace>cte_wp_at P slot and K(slot \<noteq> src \<and> slot \<noteq> dest)\<rbrace>
-     cap_move cap src dest
+   cap_move cap src dest
    \<lbrace>\<lambda>_. cte_wp_at P slot\<rbrace>"
   by (wpsimp wp: dxo_wp_weak set_cdt_cte_wp_at set_cap_cte_wp_at_separation
            simp: cap_move_def cte_wp_at_caps_of_state)
@@ -1274,7 +1274,7 @@ lemma cap_move_cte_wp_at_separation:
 (* FIXME MOVE *)
 lemma cap_move_empty_src_slot:
   "\<lbrace>K (src \<noteq> dest)\<rbrace>
-     cap_move cap src dest
+   cap_move cap src dest
    \<lbrace>\<lambda>_. cte_wp_at ((=) NullCap) src \<rbrace>"
   unfolding cap_move_def
   by (wpsimp wp: dxo_wp_weak set_cdt_cte_wp_at set_cap_sets_wp)
@@ -1292,9 +1292,9 @@ context Finalise_AC_2 begin
 
 lemma invoke_cnode_pas_refined:
   "\<lbrace>pas_refined aag and pas_cur_domain aag and einvs and simple_sched_action
-          and valid_cnode_inv ci and (\<lambda>s. is_subject aag (cur_thread s))
-          and cnode_inv_auth_derivations ci and authorised_cnode_inv aag ci\<rbrace>
-     invoke_cnode ci
+                    and valid_cnode_inv ci and (\<lambda>s. is_subject aag (cur_thread s))
+                    and cnode_inv_auth_derivations ci and authorised_cnode_inv aag ci\<rbrace>
+   invoke_cnode ci
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: invoke_cnode_def)
   apply (rule hoare_pre)
@@ -1308,8 +1308,8 @@ lemma invoke_cnode_pas_refined:
                 cnode_inv_auth_derivations_def integrity_def;
       (clarsimp simp: cte_wp_at_caps_of_state pas_refined_refl cap_links_irq_def
                       real_cte_emptyable_strg
-      | drule auth_derived_caps_of_state_impls
-      | fastforce intro: cap_cur_auth_caps_of_state dest: is_derived_is_transferable)+)
+       | drule auth_derived_caps_of_state_impls
+       | fastforce intro: cap_cur_auth_caps_of_state dest: is_derived_is_transferable)+)
 
 end
 

--- a/proof/bisim/Syscall_S.thy
+++ b/proof/bisim/Syscall_S.thy
@@ -290,13 +290,13 @@ lemma send_fault_ipc_bisim:
        apply (rule hoare_post_imp_R [OF lc_sep])
        apply (clarsimp simp: separate_cap_def)
       apply (wp | simp add: Let_def)+
-       apply (rule_tac P = "separate_cap handler_cap" in hoare_gen_asmE')
-       apply (erule separate_capE, simp_all)[1]
+        apply (rule_tac P = "separate_cap handler_cap" in hoare_gen_asmE')
+        apply (erule separate_capE, simp_all)[1]
          apply (wp | simp)+
-    apply (wp not_empty_lc)
+       apply (wp not_empty_lc)
       apply (rule_tac P = "separate_cap xa" in not_empty_gen_asm)
       apply (erule separate_capE, simp_all)[1]
-        apply wpsimp+
+       apply wpsimp+
   done
 
 lemma handle_fault_bisim:

--- a/proof/dpolicy/Dpolicy.thy
+++ b/proof/dpolicy/Dpolicy.thy
@@ -758,7 +758,7 @@ lemma state_vrefs_transform_rev:
   apply (simp add:kernel_pde_mask_def not_less[symmetric])
   apply (rule exI)
   apply (drule pde_ref_transform_rev, clarsimp)
-   apply fastforce
+  apply fastforce
   done
 
 lemma cdl_cdt_transform_rev:
@@ -1123,7 +1123,7 @@ lemma state_asids_transform_rev:
     apply (simp only: cap_asid'_member)
     apply (erule exE)
     apply (rule sata_asid; fastforce)
-     apply simp
+   apply simp
    apply (rule_tac poolptr="cap_object poolcap" in sata_asid_lookup)
     apply (clarsimp simp:transform_asid_high_bits_of')
     apply (simp add:asid_table_transform transform_asid_table_entry_def is_null_cap_def

--- a/proof/drefine/Arch_DR.thy
+++ b/proof/drefine/Arch_DR.thy
@@ -1264,11 +1264,11 @@ lemma store_pte_page_inv_entries_safe:
     apply simp
    apply (subst (asm) is_aligned_shiftr_add)
         apply (erule is_aligned_after_mask)
-       apply (simp add:pt_bits_def pageBits_def)+
-      apply (simp add:is_aligned_shiftl_self)
-     apply (rule shiftl_less_t2n)
-      apply (rule word_of_nat_less,simp)
-     apply simp+
+        apply (simp add:pt_bits_def pageBits_def)+
+       apply (simp add:is_aligned_shiftl_self)
+      apply (rule shiftl_less_t2n)
+       apply (rule word_of_nat_less,simp)
+      apply simp+
    apply (subst (asm) ucast_add)
     apply simp
    apply simp
@@ -1295,7 +1295,7 @@ lemma store_pde_page_inv_entries_safe:
   apply (clarsimp simp:obj_at_def page_inv_entries_safe_def split:if_splits)
   apply (intro conjI impI)
    apply (clarsimp simp: hd_map_simp upto_enum_def upto_enum_step_def drop_map
-     tl_map_simp map_eq_Cons_conv upt_eq_Cons_conv upto_0_to_n)
+                         tl_map_simp map_eq_Cons_conv upt_eq_Cons_conv upto_0_to_n)
    apply (clarsimp simp add:field_simps)
    apply (subst (asm) shiftl_t2n[where n = 2,simplified field_simps,simplified,symmetric])+
    apply (subst (asm) and_mask_plus[where a = "of_nat slot << 2"])
@@ -1305,11 +1305,11 @@ lemma store_pde_page_inv_entries_safe:
     apply simp
    apply (subst (asm) is_aligned_shiftr_add)
         apply (erule is_aligned_after_mask)
-       apply (simp add:pd_bits_def pageBits_def)+
-      apply (simp add:is_aligned_shiftl_self)
-     apply (rule shiftl_less_t2n)
-      apply (rule word_of_nat_less,simp)
-     apply simp+
+        apply (simp add:pd_bits_def pageBits_def)+
+       apply (simp add:is_aligned_shiftl_self)
+      apply (rule shiftl_less_t2n)
+       apply (rule word_of_nat_less,simp)
+      apply simp+
    apply (subst (asm) ucast_add)
     apply simp
    apply simp

--- a/proof/drefine/CNode_DR.thy
+++ b/proof/drefine/CNode_DR.thy
@@ -1275,7 +1275,7 @@ lemma dcorres_set_asid_pool_empty:
       apply clarsimp
      apply (clarsimp simp del:set_map simp: suffix_def)
     apply (wp | clarsimp simp:swp_def)+
-   apply (clarsimp simp:list_all2_iff transform_asid_def asid_low_bits_def set_zip)
+  apply (clarsimp simp:list_all2_iff transform_asid_def asid_low_bits_def set_zip)
   apply (clarsimp simp: upto_enum_def ucast_of_nat_small unat_of_nat)
   done
 
@@ -1324,7 +1324,7 @@ lemma dcorres_clear_object_caps_asid_pool:
   apply (clarsimp simp:invs_def valid_state_def valid_cap_def obj_at_def a_type_def
                        valid_pspace_def dest!: cte_wp_valid_cap)
   by (clarsimp split: Structures_A.kernel_object.split_asm
-                        arch_kernel_obj.split_asm if_splits)
+                      arch_kernel_obj.split_asm if_splits)
 
 lemmas valid_idle_invs_strg = invs_valid_idle_strg
 
@@ -1566,26 +1566,26 @@ lemma copy_global_mappings_dwp:
   "is_aligned word pd_bits\<Longrightarrow> \<lbrace>\<lambda>ps. valid_idle (ps :: det_state) \<and> transform ps = cs\<rbrace> copy_global_mappings word \<lbrace>\<lambda>r s. transform s = cs\<rbrace>"
   apply (simp add:copy_global_mappings_def)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. valid_idle s \<and> transform s = cs" in hoare_strengthen_post)
-    apply (rule mapM_x_wp')
-    apply wp
-     apply (rule_tac Q="\<lambda>s. valid_idle s \<and> transform s = cs" in hoare_vcg_precond_imp)
-      apply (rule dcorres_to_wp)
-      apply (rule corres_guard_imp[OF store_pde_set_cap_corres])
-        apply (clarsimp simp:kernel_mapping_slots_def)
+    apply (rule_tac Q = "\<lambda>r s. valid_idle s \<and> transform s = cs" in hoare_strengthen_post)
+     apply (rule mapM_x_wp')
+     apply wp
+       apply (rule_tac Q="\<lambda>s. valid_idle s \<and> transform s = cs" in hoare_vcg_precond_imp)
+        apply (rule dcorres_to_wp)
+        apply (rule corres_guard_imp[OF store_pde_set_cap_corres])
+          apply (clarsimp simp:kernel_mapping_slots_def)
           apply (simp add: kernel_base_def pd_bits_def pageBits_def)
           apply (simp add: mask_add_aligned)
-        apply (subst less_mask_eq,simp)
-         apply (simp add:shiftl_t2n)
-         apply (subst mult.commute)
-         apply (rule div_lt_mult,simp+,unat_arith,simp+)
-        apply (simp add:shiftl_shiftr1 word_size)
-        apply (subst less_mask_eq,simp)
-         apply unat_arith
-        apply (subst ucast_le_migrate[symmetric])
-          apply (simp add:word_size,unat_arith)
-         apply (simp add:word_size)+
-    apply (wp|clarsimp)+
+          apply (subst less_mask_eq,simp)
+           apply (simp add:shiftl_t2n)
+           apply (subst mult.commute)
+           apply (rule div_lt_mult,simp+,unat_arith,simp+)
+          apply (simp add:shiftl_shiftr1 word_size)
+          apply (subst less_mask_eq,simp)
+           apply unat_arith
+          apply (subst ucast_le_migrate[symmetric])
+            apply (simp add:word_size,unat_arith)
+           apply (simp add:word_size)+
+      apply (wp|clarsimp)+
   done
 
 lemma opt_cap_pd_not_None:

--- a/proof/drefine/Corres_D.thy
+++ b/proof/drefine/Corres_D.thy
@@ -229,17 +229,17 @@ lemma dcorres_gets_the:
   apply (subst bind_assoc)+
   apply (rule corres_split_keep_pfx[where r'="\<lambda>s s'. s = transform s'\<and> P s \<and> P' s'"
                                       and Q="\<lambda>x s. x = s" and Q'="\<lambda>x s. x = s "])
-    apply (clarsimp simp: corres_underlying_def get_def)
+     apply (clarsimp simp: corres_underlying_def get_def)
     apply (simp add: assert_opt_def)
     apply (rename_tac x)
     apply (case_tac "g' x = None")
-    apply (clarsimp split:option.splits simp:corres_free_fail)
+     apply (clarsimp split:option.splits simp:corres_free_fail)
     apply (subgoal_tac "\<exists>obj. g (transform x) \<noteq> None")
-      apply (clarsimp split:option.splits)
+     apply (clarsimp split:option.splits)
      apply (rule_tac Q="(=) (transform x)" and Q'="(=) x" in corres_guard_imp)
-    apply (simp add: A)+
-  using B
-  apply (wp|clarsimp)+
+       apply (simp add: A)+
+    using B
+    apply (wp|clarsimp)+
   done
 
 lemma wpc_helper_dcorres:

--- a/proof/drefine/Finalise_DR.thy
+++ b/proof/drefine/Finalise_DR.thy
@@ -870,7 +870,7 @@ lemma mask_pd_bits_less:
   apply (clarsimp simp:pd_bits_def pageBits_def simp del: nat_uint_eq)
   apply (unfold unat_def)
   apply (rule iffD2[OF nat_less_eq_zless[where z = 4096,simplified]])
-  apply (simp)
+   apply (simp)
   using shiftr_less_t2n'[where m = 12 and x ="(y && mask 14)" and n =2 ,simplified,THEN iffD1[OF word_less_alt]]
   apply (clarsimp simp:mask_twice)
   done
@@ -965,13 +965,13 @@ lemma slot_with_pd_section_relation:
   (a, unat (y && mask pd_bits >> 2)) \<in>
     (slots_with (\<lambda>x. \<exists>rights sz asid. x = cdl_cap.FrameCap False b rights sz Fake asid)) (transform s)"
   apply (erule disjE)
-    apply (clarsimp simp :pd_super_section_relation_def)
-    apply (frule page_directory_at_rev)
-    apply (frule(1) page_directory_not_idle)
-    apply (clarsimp simp:transform_def slots_with_def transform_objects_def obj_at_def)
-    apply (clarsimp simp:restrict_map_def page_table_not_idle not_idle_thread_def pt_bits_def)
-    apply (clarsimp simp:has_slots_def object_slots_def)
-    apply (clarsimp simp:transform_page_directory_contents_def transform_pde_def unat_map_def below_kernel_base)
+   apply (clarsimp simp :pd_super_section_relation_def)
+   apply (frule page_directory_at_rev)
+   apply (frule(1) page_directory_not_idle)
+   apply (clarsimp simp:transform_def slots_with_def transform_objects_def obj_at_def)
+   apply (clarsimp simp:restrict_map_def page_table_not_idle not_idle_thread_def pt_bits_def)
+   apply (clarsimp simp:has_slots_def object_slots_def)
+   apply (clarsimp simp:transform_page_directory_contents_def transform_pde_def unat_map_def below_kernel_base)
    apply (simp add: mask_pd_bits_less)
   apply (clarsimp simp :pd_section_relation_def)
   apply (frule page_directory_at_rev)
@@ -990,7 +990,7 @@ lemma opt_cap_page_table:
   apply (frule page_directory_at_rev)
   apply (frule(1) page_directory_not_idle)
   apply (clarsimp simp: transform_objects_def not_idle_thread_def page_directory_not_idle
-    restrict_map_def object_slots_def)
+                        restrict_map_def object_slots_def)
   apply (clarsimp simp: transform_page_directory_contents_def unat_map_def | rule conjI )+
    apply (clarsimp simp: transform_page_directory_contents_def unat_map_def transform_pde_def below_kernel_base)
   apply (simp add: mask_pd_bits_less )
@@ -1003,7 +1003,7 @@ lemma opt_cap_page:"\<lbrakk>valid_idle s;pt_page_relation a pg x S s \<rbrakk>\
   apply (frule page_table_at_rev)
   apply (frule(1) page_table_not_idle)
   apply (clarsimp simp: transform_objects_def not_idle_thread_def page_directory_not_idle
-    restrict_map_def object_slots_def)
+                        restrict_map_def object_slots_def)
   apply (clarsimp simp: transform_page_table_contents_def unat_map_def split:ARM_A.pte.split_asm | rule conjI )+
     apply (clarsimp simp: transform_page_table_contents_def unat_map_def transform_pte_def)
    apply (simp add: mask_pt_bits_less)+
@@ -1016,11 +1016,11 @@ lemma opt_cap_section:
   \<exists>f sz. (opt_cap (a, unat (x && mask pd_bits >> 2) ) (transform s))
     = Some (cdl_cap.FrameCap False pg f sz Fake None)"
   apply (erule disjE)
-    apply (clarsimp simp: pd_section_relation_def opt_cap_def transform_def slots_of_def)
-    apply (frule page_directory_at_rev)
-    apply (frule(1) page_directory_not_idle)
+   apply (clarsimp simp: pd_section_relation_def opt_cap_def transform_def slots_of_def)
+   apply (frule page_directory_at_rev)
+   apply (frule(1) page_directory_not_idle)
    apply (clarsimp simp: transform_objects_def not_idle_thread_def page_directory_not_idle
-    restrict_map_def object_slots_def)
+                         restrict_map_def object_slots_def)
    apply (clarsimp simp: transform_page_directory_contents_def unat_map_def split:ARM_A.pte.split_asm | rule conjI)+
     apply (clarsimp simp: transform_page_directory_contents_def unat_map_def transform_pde_def below_kernel_base)
    apply (simp add: mask_pd_bits_less)
@@ -1028,7 +1028,7 @@ lemma opt_cap_section:
   apply (frule page_directory_at_rev)
   apply (frule(1) page_directory_not_idle)
   apply (clarsimp simp: transform_objects_def not_idle_thread_def page_directory_not_idle
-    restrict_map_def object_slots_def)
+                        restrict_map_def object_slots_def)
   apply (clarsimp simp: transform_page_directory_contents_def unat_map_def split:ARM_A.pte.split_asm | rule conjI)+
    apply (clarsimp simp: transform_page_directory_contents_def unat_map_def transform_pde_def below_kernel_base)
   apply (simp add: mask_pd_bits_less)
@@ -1104,15 +1104,15 @@ lemma dcorres_set_pte_cap:
   apply (rule dcorres_absorb_get_l)
   apply (clarsimp simp: obj_at_def opt_object_page_table assert_opt_def has_slots_def object_slots_def)
   apply (clarsimp simp: KHeap_D.set_object_def get_object_def in_monad simpler_modify_def put_def bind_def
-                       corres_underlying_def update_slots_def return_def object_slots_def)
+                        corres_underlying_def update_slots_def return_def object_slots_def)
   apply (rule sym)
   apply (clarsimp simp: transform_def transform_current_thread_def)
   apply (rule ext)
   apply (clarsimp | rule conjI)+
-    apply (frule page_table_at_rev)
-    apply (frule(1) page_table_not_idle)
+   apply (frule page_table_at_rev)
+   apply (frule(1) page_table_not_idle)
    apply (clarsimp simp: transform_objects_def not_idle_thread_def)
-    apply (rule ext)
+   apply (rule ext)
    apply (clarsimp simp: transform_page_table_contents_def transform_pte_def unat_map_def)
    apply (clarsimp simp: mask_pt_bits_less mask_pt_bits_less')
    apply (simp only: ucast_nat_def[symmetric])
@@ -1150,7 +1150,7 @@ lemma transform_page_table_contents_upd:
   apply (rule ext)
   apply (clarsimp simp: transform_page_table_contents_def unat_map_def)
   apply (subgoal_tac "unat (y && mask pt_bits >> 2) < 256")
-  apply (rule conjI|clarsimp)+
+   apply (rule conjI|clarsimp)+
     apply (simp only: ucast_nat_def[symmetric])
     apply (drule word_of_nat_inj[rotated -1]; clarsimp simp: mask_pt_bits_less)
    apply simp
@@ -1173,11 +1173,11 @@ lemma transform_page_directory_contents_upd:
   apply (clarsimp simp: kernel_pde_mask_def kernel_mapping_slots_def)
   apply (simp only: ucast_nat_def[symmetric])
   apply (drule word_of_nat_inj[rotated -1]; clarsimp simp: mask_pt_bits_less)
-      apply (rule unat_less_helper)
+  apply (rule unat_less_helper)
   apply (subst shiftr_div_2n_w; simp add:word_size)
   apply (rule word_div_mult, simp)
   apply (clarsimp simp: pt_bits_def pd_bits_def pageBits_def)
-      apply (rule and_mask_less_size[where n = 14,simplified],simp add:word_size)
+  apply (rule and_mask_less_size[where n = 14,simplified],simp add:word_size)
   done
 
 lemma dcorres_set_pde_cap:
@@ -1192,14 +1192,14 @@ lemma dcorres_set_pde_cap:
   apply (clarsimp simp: KHeap_D.set_object_def get_object_def in_monad simpler_modify_def put_def
                         bind_def corres_underlying_def update_slots_def object_slots_def return_def)
   apply (clarsimp simp: transform_def transform_current_thread_def)
-    apply (rule ext)
-    apply (clarsimp | rule conjI)+
-      apply (frule page_directory_at_rev)
-      apply (frule(1) page_directory_not_idle)
-      apply (clarsimp simp: transform_objects_def not_idle_thread_def)
-      apply (rule sym)
-      apply (erule transform_page_directory_contents_upd)
-   apply (clarsimp simp: transform_objects_def restrict_map_def map_add_def)
+  apply (rule ext)
+  apply (clarsimp | rule conjI)+
+   apply (frule page_directory_at_rev)
+   apply (frule(1) page_directory_not_idle)
+   apply (clarsimp simp: transform_objects_def not_idle_thread_def)
+   apply (rule sym)
+   apply (erule transform_page_directory_contents_upd)
+  apply (clarsimp simp: transform_objects_def restrict_map_def map_add_def)
   done
 
 lemma dcorres_delete_cap_simple_set_pde:
@@ -2328,133 +2328,133 @@ lemma dcorres_unmap_page:
   apply (clarsimp simp:valid_cap_def)
   apply (case_tac vmpage_size)
   \<comment> \<open>ARMSmallPage\<close>
-  apply (simp add:ARM_A.unmap_page_def bindE_assoc mapM_x_singleton
-    PageTableUnmap_D.unmap_page_def cdl_page_mapping_entries_def)
-  apply (rule corres_guard_imp)
-    apply (rule_tac P = "\<lambda>x. x = transform s'" and P' = "(=) s'"
-      in corres_split_catch [where f = dc and E = dc and E' =dc])
-       apply simp
-      apply (rule corres_guard_imp)
-        apply (rule_tac corres_splitEE[OF _ dcorres_find_pd_for_asid,simplified])
+     apply (simp add:ARM_A.unmap_page_def bindE_assoc mapM_x_singleton
+       PageTableUnmap_D.unmap_page_def cdl_page_mapping_entries_def)
+     apply (rule corres_guard_imp)
+       apply (rule_tac P = "\<lambda>x. x = transform s'" and P' = "(=) s'"
+                       in corres_split_catch [where f = dc and E = dc and E' =dc])
+          apply simp
+         apply (rule corres_guard_imp)
+           apply (rule_tac corres_splitEE[OF _ dcorres_find_pd_for_asid,simplified])
              apply (simp_all add: cdl_page_mapping_entries_def liftE_distrib
-               pageBitsForSize_def bindE_assoc mapM_x_singleton)
-       apply (rule corres_splitEE[OF _ dcorres_lookup_pt_slot])
-         apply (rule corres_splitEE[OF _ dcorres_might_throw])
-          apply (rule corres_dummy_returnOk_l)
-          apply (rule corres_splitEE)
+                                  pageBitsForSize_def bindE_assoc mapM_x_singleton)
+          apply (rule corres_splitEE[OF _ dcorres_lookup_pt_slot])
+            apply (rule corres_splitEE[OF _ dcorres_might_throw])
+               apply (rule corres_dummy_returnOk_l)
+               apply (rule corres_splitEE)
                   prefer 2
-             apply (simp add:transform_pt_slot_ref_def)
-             apply (rule dcorres_store_invalid_pte[where pg_id = pg])
-            apply (simp add:liftE_distrib[symmetric] returnOk_liftE)
-            apply (rule dcorres_symb_exec_r)
-              apply (rule dcorres_flush_page)
-             apply (wp do_machine_op_wp | clarsimp)+
-         apply (simp add: imp_conjR)
-         apply ((wp check_mapping_pptr_pt_relation | wp (once) hoare_drop_imps)+)[1]
-        apply (simp | wp lookup_pt_slot_inv)+
-     apply (simp add: dc_def
-       | wp lookup_pt_slot_inv find_pd_for_asid_kernel_mapping_help
-       | rule conjI | clarify)+
+                  apply (simp add:transform_pt_slot_ref_def)
+                  apply (rule dcorres_store_invalid_pte[where pg_id = pg])
+                 apply (simp add:liftE_distrib[symmetric] returnOk_liftE)
+                 apply (rule dcorres_symb_exec_r)
+                   apply (rule dcorres_flush_page)
+                  apply (wp do_machine_op_wp | clarsimp)+
+            apply (simp add: imp_conjR)
+            apply ((wp check_mapping_pptr_pt_relation | wp (once) hoare_drop_imps)+)[1]
+           apply (simp | wp lookup_pt_slot_inv)+
+        apply (simp add: dc_def
+               | wp lookup_pt_slot_inv find_pd_for_asid_kernel_mapping_help
+               | rule conjI | clarify)+
 
    \<comment> \<open>ARMLargePage\<close>
 
     apply (simp add: ARM_A.unmap_page_def bindE_assoc mapM_x_singleton
-    PageTableUnmap_D.unmap_page_def cdl_page_mapping_entries_def)
-  apply (rule corres_guard_imp)
-    apply (rule_tac P = "\<lambda>x. x = transform s'" and P' = "(=) s'"
-      in corres_split_catch [where f = dc and E = dc and E' =dc])
-       apply simp
-      apply (rule corres_guard_imp)
-        apply (rule_tac corres_splitEE[OF _ dcorres_find_pd_for_asid,simplified])
+                     PageTableUnmap_D.unmap_page_def cdl_page_mapping_entries_def)
+    apply (rule corres_guard_imp)
+      apply (rule_tac P = "\<lambda>x. x = transform s'" and P' = "(=) s'"
+                      in corres_split_catch [where f = dc and E = dc and E' =dc])
+         apply simp
+        apply (rule corres_guard_imp)
+          apply (rule_tac corres_splitEE[OF _ dcorres_find_pd_for_asid,simplified])
             apply (simp_all add: cdl_page_mapping_entries_def liftE_distrib
-               pageBitsForSize_def bindE_assoc mapM_x_singleton)
-       apply (rule corres_splitEE[OF _ dcorres_lookup_pt_slot])
-         apply (rule corres_splitEE[OF _ dcorres_might_throw])
-            apply (rule dcorres_symb_exec_rE)
-              apply (rule corres_dummy_returnOk_l)
-              apply (rule corres_splitEE)
+                                 pageBitsForSize_def bindE_assoc mapM_x_singleton)
+         apply (rule corres_splitEE[OF _ dcorres_lookup_pt_slot])
+           apply (rule corres_splitEE[OF _ dcorres_might_throw])
+              apply (rule dcorres_symb_exec_rE)
+                apply (rule corres_dummy_returnOk_l)
+                apply (rule corres_splitEE)
                    prefer 2
-                 apply simp
-                 apply (rule_tac F = "is_aligned xa 6" in corres_gen_asm2)
-                 apply (erule dcorres_unmap_large_page[where pg_id = pg])
-                apply (simp add:liftE_distrib[symmetric] returnOk_liftE)
-                apply (rule dcorres_symb_exec_r)
-                  apply (rule dcorres_flush_page[unfolded dc_def])
-                 apply (wp do_machine_op_wp | clarsimp)+
-         apply (simp add: imp_conjR is_aligned_mask)
-         apply (rule hoare_vcg_conj_lift)
-          apply (wp hoare_drop_imps)[1]
-         apply (rule hoare_vcg_conj_lift)
-          apply (wp hoare_drop_imps)[1]
-         apply (rule hoare_strengthen_post[OF check_mapping_pptr_pt_relation])
-          apply fastforce
-        apply (simp | wp lookup_pt_slot_inv)+
+                   apply simp
+                   apply (rule_tac F = "is_aligned xa 6" in corres_gen_asm2)
+                   apply (erule dcorres_unmap_large_page[where pg_id = pg])
+                  apply (simp add:liftE_distrib[symmetric] returnOk_liftE)
+                  apply (rule dcorres_symb_exec_r)
+                    apply (rule dcorres_flush_page[unfolded dc_def])
+                   apply (wp do_machine_op_wp | clarsimp)+
+           apply (simp add: imp_conjR is_aligned_mask)
+           apply (rule hoare_vcg_conj_lift)
+            apply (wp hoare_drop_imps)[1]
+           apply (rule hoare_vcg_conj_lift)
+            apply (wp hoare_drop_imps)[1]
+           apply (rule hoare_strengthen_post[OF check_mapping_pptr_pt_relation])
+           apply fastforce
+          apply (simp | wp lookup_pt_slot_inv)+
        apply (simp add: dc_def
               | wp lookup_pt_slot_inv hoare_drop_imps find_pd_for_asid_kernel_mapping_help
-         | safe)+
+              | safe)+
 
   \<comment> \<open>Section\<close>
-  apply (simp add:ARM_A.unmap_page_def bindE_assoc mapM_x_singleton
-    PageTableUnmap_D.unmap_page_def cdl_page_mapping_entries_def)
-  apply (rule corres_guard_imp)
-    apply (rule_tac P = "\<lambda>x. x = transform s'" and P' = "(=) s'"
-      in corres_split_catch [where f = dc and E = dc and E' =dc])
-       apply simp
-      apply (rule corres_guard_imp)
-        apply (rule_tac corres_splitEE[OF _ dcorres_find_pd_for_asid,simplified])
+   apply (simp add:ARM_A.unmap_page_def bindE_assoc mapM_x_singleton
+     PageTableUnmap_D.unmap_page_def cdl_page_mapping_entries_def)
+   apply (rule corres_guard_imp)
+     apply (rule_tac P = "\<lambda>x. x = transform s'" and P' = "(=) s'"
+                     in corres_split_catch [where f = dc and E = dc and E' =dc])
+        apply simp
+       apply (rule corres_guard_imp)
+         apply (rule_tac corres_splitEE[OF _ dcorres_find_pd_for_asid,simplified])
            apply (simp_all add: cdl_page_mapping_entries_def liftE_distrib
-            pageBitsForSize_def bindE_assoc mapM_x_singleton)
-       apply (rule corres_splitEE[OF _ dcorres_might_throw])
-       apply (rule corres_dummy_returnOk_l)
-          apply (rule corres_splitEE)
+                                pageBitsForSize_def bindE_assoc mapM_x_singleton)
+        apply (rule corres_splitEE[OF _ dcorres_might_throw])
+           apply (rule corres_dummy_returnOk_l)
+           apply (rule corres_splitEE)
               prefer 2
-             apply simp
-             apply (rule dcorres_delete_cap_simple_section[where oid = pg])
-            apply (simp add:liftE_distrib[symmetric] returnOk_liftE)
-            apply (rule dcorres_symb_exec_r)
-              apply (rule dcorres_flush_page[unfolded dc_def])
-             apply (wp do_machine_op_wp | clarsimp)+
-         apply (simp add: imp_conjR)
-         apply ((wp check_mapping_pptr_section_relation | wp (once) hoare_drop_imps)+)[1]
-        apply (simp | wp lookup_pt_slot_inv)+
+              apply simp
+              apply (rule dcorres_delete_cap_simple_section[where oid = pg])
+             apply (simp add:liftE_distrib[symmetric] returnOk_liftE)
+             apply (rule dcorres_symb_exec_r)
+               apply (rule dcorres_flush_page[unfolded dc_def])
+              apply (wp do_machine_op_wp | clarsimp)+
+        apply (simp add: imp_conjR)
+        apply ((wp check_mapping_pptr_section_relation | wp (once) hoare_drop_imps)+)[1]
+       apply (simp | wp lookup_pt_slot_inv)+
      apply (simp add: dc_def
-       | wp lookup_pt_slot_inv find_pd_for_asid_kernel_mapping_help
-       | safe)+
+            | wp lookup_pt_slot_inv find_pd_for_asid_kernel_mapping_help
+            | safe)+
 
   \<comment> \<open>SuperSection\<close>
   apply (simp add: ARM_A.unmap_page_def bindE_assoc mapM_x_singleton
-    PageTableUnmap_D.unmap_page_def cdl_page_mapping_entries_def)
+                   PageTableUnmap_D.unmap_page_def cdl_page_mapping_entries_def)
   apply (rule corres_guard_imp)
     apply (rule_tac P = "\<lambda>x. x = transform s'" and P' = "(=) s'"
-      in corres_split_catch [where f = dc and E = dc and E' =dc])
+                    in corres_split_catch [where f = dc and E = dc and E' =dc])
        apply simp
       apply (rule corres_guard_imp)
         apply (rule_tac corres_splitEE[OF _ dcorres_find_pd_for_asid,simplified])
           apply (simp_all add: cdl_page_mapping_entries_def liftE_distrib
-               pageBitsForSize_def bindE_assoc mapM_x_singleton)
-        apply (rule corres_splitEE[OF _ dcorres_might_throw])
-           apply (rule dcorres_symb_exec_rE)
-             apply (rule corres_dummy_returnOk_l)
-             apply (rule corres_splitEE)
+                               pageBitsForSize_def bindE_assoc mapM_x_singleton)
+       apply (rule corres_splitEE[OF _ dcorres_might_throw])
+          apply (rule dcorres_symb_exec_rE)
+            apply (rule corres_dummy_returnOk_l)
+            apply (rule corres_splitEE)
                prefer 2
-                 apply simp
+               apply simp
                apply (rule_tac F = "is_aligned pd 14" in corres_gen_asm2)
-                 apply (erule(2) dcorres_unmap_large_section[where pg_id = pg])
-                apply (simp add:liftE_distrib[symmetric] returnOk_liftE)
-                apply (rule dcorres_symb_exec_r)
-                  apply (rule dcorres_flush_page[unfolded dc_def])
-                 apply (wp do_machine_op_wp | clarsimp)+
-         apply (simp add: imp_conjR is_aligned_mask)
-         apply (rule hoare_vcg_conj_lift)
-          apply (wp hoare_drop_imps)[1]
-         apply (rule hoare_vcg_conj_lift)
-          apply (wp hoare_drop_imps)[1]
-         apply (rule hoare_vcg_conj_lift)
-          apply (rule hoare_strengthen_post[OF check_mapping_pptr_super_section_relation])
-          apply clarsimp
+               apply (erule(2) dcorres_unmap_large_section[where pg_id = pg])
+              apply (simp add:liftE_distrib[symmetric] returnOk_liftE)
+              apply (rule dcorres_symb_exec_r)
+                apply (rule dcorres_flush_page[unfolded dc_def])
+               apply (wp do_machine_op_wp | clarsimp)+
+       apply (simp add: imp_conjR is_aligned_mask)
+       apply (rule hoare_vcg_conj_lift)
+        apply (wp hoare_drop_imps)[1]
+       apply (rule hoare_vcg_conj_lift)
+        apply (wp hoare_drop_imps)[1]
+       apply (rule hoare_vcg_conj_lift)
+        apply (rule hoare_strengthen_post[OF check_mapping_pptr_super_section_relation])
+        apply clarsimp
        apply (simp add:is_aligned_mask[symmetric] dc_def
               | wp lookup_pt_slot_inv hoare_drop_imps find_pd_for_asid_kernel_mapping_help
-         | safe)+
+              | safe)+
   done
 
 
@@ -3131,7 +3131,7 @@ lemma transform_object_irq_state_independent[intro!, simp]:
   by (rule ext, rule ext, rule ext,
       simp add: transform_object_def
            cong: option.case_cong
-         split: Structures_A.kernel_object.splits)
+           split: Structures_A.kernel_object.splits)
 
 lemma transform_objects_irq_state_independent[intro!, simp]:
   "transform_objects (s \<lparr> machine_state := machine_state s \<lparr> irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)

--- a/proof/drefine/Intent_DR.thy
+++ b/proof/drefine/Intent_DR.thy
@@ -276,10 +276,10 @@ lemma corres_corrupt_tcb_intent_return:
   supply option.case_cong[cong]
   apply (clarsimp simp: corres_underlying_def return_def corrupt_tcb_intent_def update_thread_def
                         select_def gets_the_def fail_def gets_def get_def assert_opt_def bind_def
-         put_def modify_def KHeap_D.set_object_def)
+                        put_def modify_def KHeap_D.set_object_def)
   apply (clarsimp split: option.splits
                   simp: transform_def tcb_at_def transform_objects_def not_idle_thread_def
-    dest!: get_tcb_SomeD)
+                  dest!: get_tcb_SomeD)
    apply (drule(1) valid_etcbs_tcb_etcb)
    apply (clarsimp)
   apply (force simp: transform_def transform_tcb_def transform_objects_def not_idle_thread_def

--- a/proof/drefine/Ipc_DR.thy
+++ b/proof/drefine/Ipc_DR.thy
@@ -1063,11 +1063,11 @@ lemma dcorres_symb_exec_r_evalMonad:
   assumes corres:"\<And>rv. evalMonad f s = Some rv \<Longrightarrow> dcorres r P ((=) s) h (g rv)"
   shows "\<lbrakk> empty_when_fail f; weak_det_spec ((=) s) f \<rbrakk> \<Longrightarrow> dcorres r P ((=) s) h (f>>=g)"
   apply (rule_tac Q'="\<lambda>r. (=) s and K_bind (evalMonad f s = Some r)" in corres_symb_exec_r)
-  apply (rule dcorres_expand_pfx)
-  using corres
-  apply (clarsimp simp:corres_underlying_def)
+     apply (rule dcorres_expand_pfx)
+     using corres
+     apply (clarsimp simp:corres_underlying_def)
     apply (wp wp, simp, rule evalMonad_wp)
-  apply (simp add:wp)+
+      apply (simp add:wp)+
   done
 
 lemma dcorres_store_word_offs_spec:
@@ -1674,50 +1674,50 @@ lemma dcorres_lookup_extra_caps:
      (Ipc_A.lookup_extra_caps thread buffer (data_to_message_info (arch_tcb_context_get (tcb_arch t) msg_info_register)))"
   apply (clarsimp simp:lookup_extra_caps_def liftE_bindE Endpoint_D.lookup_extra_caps_def)
   apply (rule corres_symb_exec_r)
-    apply (rule_tac F = "evalMonad (get_extra_cptrs buffer (data_to_message_info (arch_tcb_context_get (tcb_arch t) msg_info_register))) s = Some rv"
-      in corres_gen_asm2)
-  apply (rule corres_mapME[where S = "{(x,y). x = of_bl y \<and> length y = word_bits}"])
-    prefer 3
+     apply (rule_tac F = "evalMonad (get_extra_cptrs buffer (data_to_message_info (arch_tcb_context_get (tcb_arch t) msg_info_register))) s = Some rv"
+                     in corres_gen_asm2)
+     apply (rule corres_mapME[where S = "{(x,y). x = of_bl y \<and> length y = word_bits}"])
+           prefer 3
            apply simp
-    apply (rule dcorres_lookup_cap_and_slot[simplified])
-    apply (clarsimp simp:transform_cap_list_def)+
-    apply wp
-    apply simp
-    apply (case_tac buffer)
-      apply clarsimp
-      apply (simp add:transform_full_intent_def Let_def)
-      apply (rule get_ipc_buffer_words_empty)
-      apply (simp add:obj_at_def)
-      apply (erule get_tcb_SomeD)
-      apply simp
+           apply (rule dcorres_lookup_cap_and_slot[simplified])
+            apply (clarsimp simp:transform_cap_list_def)+
+       apply wp
+       apply simp
+      apply (case_tac buffer)
+       apply clarsimp
+       apply (simp add:transform_full_intent_def Let_def)
+       apply (rule get_ipc_buffer_words_empty)
+        apply (simp add:obj_at_def)
+        apply (erule get_tcb_SomeD)
+       apply simp
       apply clarify
       apply (subst evalMonad_get_extra_cptrs)
-        apply simp+
-   apply (case_tac buffer)
+         apply simp+
+     apply (case_tac buffer)
       apply clarsimp
-      apply clarify
-      apply (drule evalMonad_get_extra_cptrs)
+     apply clarify
+     apply (drule evalMonad_get_extra_cptrs)
        apply (simp del:get_extra_cptrs.simps add: zip_map_eqv[where g = "\<lambda>x. x",simplified])+
-      apply (simp add: word_bits_def del:get_extra_cptrs.simps)
-   apply (wp evalMonad_wp)
-   apply (case_tac buffer)
-     apply (simp add:get_extra_cptrs_def empty_when_fail_simps)+
-     apply (simp add:liftM_def)
-     apply (rule empty_when_fail_compose)
-     apply (simp add:empty_when_fail_simps)+
-     apply (rule empty_when_fail_mapM)
-     apply (simp add:weak_det_spec_load_word_offs empty_when_fail_load_word_offs)
-     apply (rule weak_det_spec_mapM)
-     apply (simp add:weak_det_spec_load_word_offs)
-   apply (case_tac buffer)
-     apply (simp add:get_extra_cptrs_def weak_det_spec_simps)+
+     apply (simp add: word_bits_def del:get_extra_cptrs.simps)
+    apply (wp evalMonad_wp)
+      apply (case_tac buffer)
+       apply (simp add:get_extra_cptrs_def empty_when_fail_simps)+
+      apply (simp add:liftM_def)
+      apply (rule empty_when_fail_compose)
+        apply (simp add:empty_when_fail_simps)+
+       apply (rule empty_when_fail_mapM)
+       apply (simp add:weak_det_spec_load_word_offs empty_when_fail_load_word_offs)
+      apply (rule weak_det_spec_mapM)
+      apply (simp add:weak_det_spec_load_word_offs)
+     apply (case_tac buffer)
+      apply (simp add:get_extra_cptrs_def weak_det_spec_simps)+
      apply (simp add:liftM_def)
      apply (rule weak_det_spec_compose)
-     apply (simp add:weak_det_spec_simps)
+      apply (simp add:weak_det_spec_simps)
      apply (rule weak_det_spec_mapM)
      apply (simp add:weak_det_spec_load_word_offs)
-   apply (clarsimp simp:valid_state_def valid_pspace_def cur_tcb_def)+
-  apply (wp|clarsimp)+
+    apply (clarsimp simp:valid_state_def valid_pspace_def cur_tcb_def)+
+   apply (wp|clarsimp)+
   done
 
 lemma dcorres_copy_mrs':

--- a/proof/drefine/KHeap_DR.thy
+++ b/proof/drefine/KHeap_DR.thy
@@ -473,7 +473,7 @@ lemma final_cap_set_map:
         apply simp+
    apply (thin_tac "opt_cap x y = Q" for x y Q)
    by (auto simp: transform_cap_def cap_has_object_def cap_counts_def cdl_cap_irq_def
-              split: cap.splits arch_cap.splits if_split_asm)
+            split: cap.splits arch_cap.splits if_split_asm)
 
 lemma opt_cap_wp_at_ex_opt_cap:
   "opt_cap_wp_at P p s = (\<exists>cap'. opt_cap p s = Some cap' \<and> P cap')"

--- a/proof/drefine/Tcb_DR.thy
+++ b/proof/drefine/Tcb_DR.thy
@@ -702,7 +702,7 @@ lemma not_idle_after_restart [wp]:
   apply wp
    apply (simp add:cancel_ipc_def)
    apply (wp not_idle_after_blocked_cancel_ipc not_idle_after_reply_cancel_ipc
-   not_idle_thread_cancel_signal | wpc)+
+             not_idle_thread_cancel_signal | wpc)+
    apply (rule hoare_strengthen_post[where Q="\<lambda>r. st_tcb_at ((=) r) obj_id'
                                                   and not_idle_thread obj_id' and invs"])
     apply (wp gts_sp)

--- a/proof/drefine/Untyped_DR.thy
+++ b/proof/drefine/Untyped_DR.thy
@@ -1811,7 +1811,7 @@ lemma decode_untyped_corres:
                 descendants_of_empty_lift word_neq_0_conv)
               apply (clarsimp simp: not_less is_cap_simps bits_of_def)
               apply (clarsimp simp: is_cap_simps transform_cslot_ptr_def bits_of_def
-                cap_aligned_def nat_bl_to_bin_nat_to_cref)
+                                    cap_aligned_def nat_bl_to_bin_nat_to_cref)
              apply (wp check_children_wp)
             apply simp
            apply (simp add:const_on_failure_def)

--- a/proof/infoflow/ADT_IF.thy
+++ b/proof/infoflow/ADT_IF.thy
@@ -13,7 +13,7 @@ text \<open>
 
 theory ADT_IF
 imports
-    Noninterference_Base
+  Noninterference_Base
   Access.ArchSyscall_AC
   Access.ArchADT_AC
   ArchIRQMasks_IF
@@ -189,7 +189,7 @@ lemma inv_holds_steps:
   apply (induct as rule: rev_induct)
    apply (simp add: steps_def)
    apply (rule set_mp)
-   apply (rule start_I)
+    apply (rule start_I)
    apply simp
   apply (simp add: steps_def)
   apply (erule ImageE)
@@ -210,11 +210,11 @@ locale serial_system_weak = system +
 begin
 
 lemma step_serial:
-     assumes nonempty_start: "B \<noteq> {}"
-     assumes invariant_start: "B \<subseteq> I"
+  assumes nonempty_start: "B \<noteq> {}"
+  assumes invariant_start: "B \<subseteq> I"
   shows "steps (Simulation.Step A) B as \<noteq> {}"
-    apply (induct as rule: rev_induct)
-  apply (simp add: steps_def nonempty_start)
+  apply (induct as rule: rev_induct)
+   apply (simp add: steps_def nonempty_start)
   apply (erule nonemptyE)
   apply (frule set_mp[OF inv_holds_steps[OF I invariant_start]])
   apply (frule_tac a=x in serial)
@@ -247,9 +247,9 @@ proof -
   show ?thesis
     apply (induct x rule: wf_induct)
      apply (rule wf_step_measuref_rel_from[OF rt si sR])
-  apply clarsimp
-  apply (frule sub_big_steps_I_holds[OF ss[THEN serial_system_weak.I] si])
-  apply (frule_tac  serial_system_weak.serial[OF ss])
+    apply clarsimp
+    apply (frule sub_big_steps_I_holds[OF ss[THEN serial_system_weak.I] si])
+    apply (frule_tac serial_system_weak.serial[OF ss])
     apply (erule exE, rename_tac s')
     apply (drule_tac x=s' in spec)
     apply (erule impE)
@@ -257,9 +257,9 @@ proof -
     apply (case_tac "R s s'")
      apply (rule_tac x="[]" in exI)
      apply (rule_tac x=x in exI)
-   apply fastforce
+     apply fastforce
     apply (fastforce intro: sub_big_steps.step)
-  done
+    done
 qed
 
 
@@ -296,7 +296,7 @@ proof -
   fix s  js jsa
   assume a: "s \<in> execution A s0 js"
   show "\<exists>s'. s' \<in> execution A s jsa"
-    proof -
+  proof -
     have er: "\<And>as. execution A s as = {s'. (s,s') \<in> Run (system.Step A) as}"
       apply (rule Step_system.execution_Run[OF st])
       using a apply (fastforce simp: system.reachable_def)
@@ -316,7 +316,7 @@ proof -
       apply (rule system_Step_one)
       apply (cut_tac x=b and xa=x in single_event[rule_format], simp)
       done
-    qed
+  qed
 qed
 
 lemma steps_subset:
@@ -329,8 +329,8 @@ lemma steps_subset:
 
 
 locale Init_Fin_serial_weak = serial_system_weak +
-     assumes Init_Fin: "\<And>s'. s' \<in> I \<Longrightarrow> s' \<in> Init A (Fin A s')"
-     assumes s0_I: "Init A s0 \<subseteq> I"
+  assumes Init_Fin: "\<And>s'. s' \<in> I \<Longrightarrow> s' \<in> Init A (Fin A s')"
+  assumes s0_I: "Init A s0 \<subseteq> I"
 begin
 
 lemma enabled:
@@ -339,12 +339,12 @@ lemma enabled:
   supply ex_image_cong_iff [simp del]
   apply (clarsimp simp: enabled_system_def)
   apply (rename_tac jsa, induct_tac jsa rule: rev_induct)
-  apply (clarsimp simp: execution_def steps_def)
+   apply (clarsimp simp: execution_def steps_def)
    apply (fold steps_def)
-    apply (rule_tac x="Fin A x" in exI)
+   apply (rule_tac x="Fin A x" in exI)
    apply (rule imageI)
    apply (rule Init_Fin)
-    apply (rule set_mp)
+   apply (rule set_mp)
     apply (rule inv_holds_steps[OF I])
     apply (rule s0_I)
    apply simp
@@ -382,7 +382,7 @@ lemma invariant_holds_steps:
   apply (induct as rule: rev_induct)
    apply (simp add: steps_def)
    apply (rule set_mp)
-   apply (rule start_I)
+    apply (rule start_I)
    apply simp
   apply (simp add: steps_def)
   apply (erule ImageE)
@@ -403,11 +403,11 @@ locale serial_system = system +
 begin
 
 lemma step_serial:
-     assumes nonempty_start: "B \<noteq> {}"
-     assumes invariant_start: "B \<subseteq> I"
+  assumes nonempty_start: "B \<noteq> {}"
+  assumes invariant_start: "B \<subseteq> I"
   shows "steps (Simulation.Step A) B as \<noteq> {}"
-    apply (induct as rule: rev_induct)
-  apply (simp add: steps_def nonempty_start)
+  apply (induct as rule: rev_induct)
+   apply (simp add: steps_def nonempty_start)
   apply (erule nonemptyE)
   apply (frule set_mp[OF invariant_holds_steps[OF I invariant_start]])
   apply (frule_tac a=x in serial)
@@ -424,7 +424,7 @@ lemma fw_sim_serial:
   assumes constrained_B: "\<And>s. s \<in> I_b' \<Longrightarrow> \<exists>s'. s' \<in> I \<and> (s,s') \<in> R"
   shows "serial_system B I_b'"
   apply unfold_locales
-     apply (rule B_I_b)
+   apply (rule B_I_b)
   apply (insert refines)
   apply (clarsimp simp: LI_def)
   apply (drule_tac x=a in spec)
@@ -440,8 +440,8 @@ end
 
 
 locale Init_Fin_serial = serial_system +
-     assumes Init_Fin: "\<And>s'. s' \<in> I \<Longrightarrow> s' \<in> Init A (Fin A s')"
-     assumes s0_I: "Init A s0 \<subseteq> I"
+  assumes Init_Fin: "\<And>s'. s' \<in> I \<Longrightarrow> s' \<in> Init A (Fin A s')"
+  assumes s0_I: "Init A s0 \<subseteq> I"
 begin
 
 lemma enabled:
@@ -449,7 +449,7 @@ lemma enabled:
   supply image_cong_simp [cong del]
   supply ex_image_cong_iff [simp del]
   apply (clarsimp simp: enabled_system_def)
-  apply (induct_tac jsa  rule: rev_induct)
+  apply (induct_tac jsa rule: rev_induct)
    apply (clarsimp simp: execution_def steps_def)
    apply (fold steps_def)
    apply (rule_tac x="Fin A x" in exI)
@@ -502,14 +502,14 @@ lemma big_step_adt_R_tranclp_inv:
 
 lemma  big_steps_I_holds:
   "\<lbrakk> (xa, x) \<in> big_steps A R exmap j; xa \<in> I; A [> I \<rbrakk>
-       \<Longrightarrow> x \<in> I"
+     \<Longrightarrow> x \<in> I"
   apply (erule big_stepsE)
   apply (frule sub_big_steps_I_holds, assumption+)
   apply (simp add: inv_holds_def)
   apply blast
   done
 
-lemma  big_step_adt_inv_holds:
+lemma big_step_adt_inv_holds:
   "A [> I \<Longrightarrow> big_step_adt A R exmap [> I"
   apply (simp add: big_step_adt_def inv_holds_def)
   apply clarsimp
@@ -619,7 +619,7 @@ lemma reachable_big_step_adt:
    \<Longrightarrow> system.reachable C s0 s"
   by (force dest: reachable_reachable_i
            intro: reachable_i_reachable reachable_i_big_step_adt
-                simp: big_step_adt_def)
+            simp: big_step_adt_def)
 
 lemma big_step_adt_Init_inv_Fin_system:
   "Init_inv_Fin_system A s0 \<Longrightarrow> Init_inv_Fin_system (big_step_adt A R exmap) s0"
@@ -697,11 +697,11 @@ text \<open>
 \<close>
 definition global_automaton_if ::
   "((user_context \<times> 'k) \<times> irq option \<times> (user_context \<times> 'k)) set
-      \<Rightarrow> ((user_context \<times> 'k) \<times> event option \<times> (user_context \<times> 'k)) set
-      \<Rightarrow> (event \<Rightarrow> ((user_context \<times> 'k) \<times> bool \<times> (user_context \<times> 'k)) set)
-      \<Rightarrow> (((user_context \<times> 'k) \<times> unit \<times> (user_context \<times> 'k)) set)
-      \<Rightarrow> (((user_context \<times> 'k) \<times> unit \<times> (user_context \<times> 'k)) set)
-      \<Rightarrow> (((user_context \<times> 'k) \<times> sys_mode \<times> (user_context \<times> 'k)) set)
+   \<Rightarrow> ((user_context \<times> 'k) \<times> event option \<times> (user_context \<times> 'k)) set
+   \<Rightarrow> (event \<Rightarrow> ((user_context \<times> 'k) \<times> bool \<times> (user_context \<times> 'k)) set)
+   \<Rightarrow> (((user_context \<times> 'k) \<times> unit \<times> (user_context \<times> 'k)) set)
+   \<Rightarrow> (((user_context \<times> 'k) \<times> unit \<times> (user_context \<times> 'k)) set)
+   \<Rightarrow> (((user_context \<times> 'k) \<times> sys_mode \<times> (user_context \<times> 'k)) set)
    \<Rightarrow> ('k global_sys_state \<times> 'k global_sys_state) set" where
   "global_automaton_if get_active_irqf do_user_opf kernel_callf preemptionf schedulef kernel_exitf \<equiv>
   \<comment> \<open>Kernel entry with preemption during event handling
@@ -719,11 +719,11 @@ definition global_automaton_if ::
      {((s, KernelExit), (s', m)) | s s' m. (s, m, s') \<in> kernel_exitf } \<union>
   \<comment> \<open>User runs, causes exception\<close>
      {((s, InUserMode), (s', KernelEntry e)) | s s_aux s' e. (s, None, s_aux) \<in> get_active_irqf \<and>
-                                 (s_aux, Some e, s') \<in> do_user_opf \<and>
-                                 e \<noteq> Interrupt} \<union>
+                                                             (s_aux, Some e, s') \<in> do_user_opf \<and>
+                                                             e \<noteq> Interrupt} \<union>
   \<comment> \<open>User runs, no exception happens\<close>
      {((s, InUserMode), (s', InUserMode) ) | s s_aux s'. (s, None, s_aux) \<in> get_active_irqf \<and>
-                             (s_aux, None, s') \<in> do_user_opf} \<union>
+                                                         (s_aux, None, s') \<in> do_user_opf} \<union>
   \<comment> \<open>Interrupt while in user mode\<close>
      {((s, InUserMode), (s', KernelEntry Interrupt)) | s s' i. (s, Some i, s') \<in> get_active_irqf} \<union>
   \<comment> \<open>Interrupt while in idle mode\<close>
@@ -761,9 +761,9 @@ definition kernel_entry_if ::
   "kernel_entry_if e tc \<equiv>
    do t \<leftarrow> gets cur_thread;
       thread_set (\<lambda>tcb. tcb \<lparr>tcb_arch := arch_tcb_context_set tc (tcb_arch tcb)\<rparr>) t;
-    r \<leftarrow> handle_event e;
-    return (r,tc)
-  od"
+      r \<leftarrow> handle_event e;
+      return (r,tc)
+   od"
 
 crunch cur_domain[wp]: kernel_entry_if "\<lambda>s. P (cur_domain s)"
 crunch idle_thread[wp]: kernel_entry_if "\<lambda>s::det_state. P (idle_thread s)"
@@ -779,7 +779,7 @@ lemma thread_set_tcb_context_update_not_ct_active[wp]:
   "thread_set (tcb_arch_update (arch_tcb_context_set f)) t \<lbrace>\<lambda>s. \<not> ct_active s\<rbrace>"
   apply (simp add: thread_set_def ct_in_state_def | wp set_object_wp)+
   apply (clarsimp simp: st_tcb_at_def obj_at_def get_tcb_def
-                split: kernel_object.splits option.splits)
+                 split: kernel_object.splits option.splits)
   done
 
 lemma kernel_entry_if_invs:
@@ -788,17 +788,17 @@ lemma kernel_entry_if_invs:
    \<lbrace>\<lambda>_. invs\<rbrace>"
   unfolding kernel_entry_if_def
   by (wpsimp wp: thread_set_invs_trivial static_imp_wp
-              simp: arch_tcb_update_aux2 ran_tcb_cap_cases)+
+           simp: arch_tcb_update_aux2 ran_tcb_cap_cases)+
 
 lemma kernel_entry_if_globals_equiv:
   "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and globals_equiv st
          and (\<lambda>s. ct_idle s \<longrightarrow> tc = idle_context s)\<rbrace>
-    kernel_entry_if e tc
+   kernel_entry_if e tc
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (simp add: kernel_entry_if_def)
   apply (wp static_imp_wp handle_event_globals_equiv
             thread_set_invs_trivial thread_set_context_globals_equiv
-        | simp add: ran_tcb_cap_cases arch_tcb_update_aux2)+
+         | simp add: ran_tcb_cap_cases arch_tcb_update_aux2)+
   apply (clarsimp simp: cur_thread_idle)
   done
 
@@ -827,7 +827,7 @@ lemma kernel_entry_silc_inv[wp]:
   "\<lbrace>silc_inv aag st and einvs and simple_sched_action and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)
                     and pas_refined aag and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))
                     and domain_sep_inv (pasMaySendIrqs aag) st'\<rbrace>
-     kernel_entry_if ev tc
+   kernel_entry_if ev tc
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding kernel_entry_if_def
   by (wpsimp simp: ran_tcb_cap_cases arch_tcb_update_aux2
@@ -1012,7 +1012,7 @@ lemma kernel_entry_pas_refined[wp]:
                     and einvs and schact_is_rct
                     and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))
                     and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
-     kernel_entry_if ev tc
+   kernel_entry_if ev tc
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   unfolding kernel_entry_if_def
   by (wpsimp simp: ran_tcb_cap_cases schact_is_rct_def arch_tcb_update_aux2
@@ -1022,26 +1022,26 @@ lemma kernel_entry_pas_refined[wp]:
 
 lemma kernel_entry_if_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
-     kernel_entry_if e tc
+   kernel_entry_if e tc
    \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
   unfolding kernel_entry_if_def
   by (wpsimp simp: ran_tcb_cap_cases arch_tcb_update_aux2
-          wp: handle_event_domain_sep_inv static_imp_wp
-            thread_set_invs_trivial thread_set_not_state_valid_sched)+
+               wp: handle_event_domain_sep_inv static_imp_wp
+                   thread_set_invs_trivial thread_set_not_state_valid_sched)+
 
 lemma kernel_entry_if_valid_sched:
   "\<lbrace>valid_sched and invs and (ct_active or ct_idle)
                 and (\<lambda>s. (e \<noteq> Interrupt \<longrightarrow> ct_active s) \<and> scheduler_action s = resume_cur_thread)\<rbrace>
-     kernel_entry_if e tc
+   kernel_entry_if e tc
    \<lbrace>\<lambda>_. valid_sched\<rbrace>"
   by (wpsimp simp: kernel_entry_if_def ran_tcb_cap_cases arch_tcb_update_aux2
-         wp: handle_event_valid_sched thread_set_invs_trivial hoare_vcg_disj_lift
-             thread_set_no_change_tcb_state ct_in_state_thread_state_lift
-             thread_set_not_state_valid_sched static_imp_wp)+
+               wp: handle_event_valid_sched thread_set_invs_trivial hoare_vcg_disj_lift
+                   thread_set_no_change_tcb_state ct_in_state_thread_state_lift
+                   thread_set_not_state_valid_sched static_imp_wp)+
 
 lemma kernel_entry_if_irq_masks:
   "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and invs\<rbrace>
-     kernel_entry_if e tc
+   kernel_entry_if e tc
    \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
   by (simp add: kernel_entry_if_def ran_tcb_cap_cases arch_tcb_update_aux2
       | wp handle_event_irq_masks thread_set_invs_trivial | force)+
@@ -1121,7 +1121,7 @@ crunch valid_list[wp]: handle_preemption_if "valid_list"
 definition kernel_handle_preemption_if ::
   "((user_context \<times> det_state) \<times> unit \<times> (user_context \<times> det_state)) set" where
   "kernel_handle_preemption_if \<equiv>
-      {(s, u, s'). s' \<in> fst (split handle_preemption_if s)}"
+     {(s, u, s'). s' \<in> fst (split handle_preemption_if s)}"
 
 lemma schedule_if_invs[wp]:
   "schedule_if tc \<lbrace>invs\<rbrace>"
@@ -1133,7 +1133,7 @@ lemma guarded_pas_domain_arch_state_update[simp]:
 
 lemma switch_to_thread_guarded_pas_domain:
   "\<lbrace>\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)\<rbrace>
-     switch_to_thread t
+   switch_to_thread t
    \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
   apply (simp add: switch_to_thread_def)
   apply (wp modify_wp hoare_drop_imps| simp add: guarded_pas_domain_def)+
@@ -1162,7 +1162,7 @@ lemma choose_thread_guarded_pas_domain:
   apply (clarsimp simp: pas_refined_def)
   apply (clarsimp simp: tcb_domain_map_wellformed_aux_def)
   apply (erule_tac x="(hd (max_non_empty_queue (ready_queues s (cur_domain s))), cur_domain s)"
-                   in ballE)
+                in ballE)
    apply simp
   apply (clarsimp simp: valid_queues_def is_etcb_at_def)
   apply (erule_tac x="cur_domain s" in allE)
@@ -1177,7 +1177,7 @@ lemma choose_thread_guarded_pas_domain:
   apply (erule_tac P="hd A \<in> B" for A B in notE)
   apply (rule Max_prop)
    apply force+
-   done
+  done
 
 lemma schedule_if_ct_running_or_ct_idle[wp]:
   "\<lbrace>invs\<rbrace> schedule_if tc \<lbrace>\<lambda>_ s. ct_running s \<or> ct_idle s\<rbrace>"
@@ -1206,28 +1206,28 @@ lemma schedule_guarded_pas_domain:
                     guarded_pas_domain_lift[where f="set_scheduler_action f" for f]
                     guarded_switch_to_lift switch_to_thread_guarded_pas_domain
                     next_domain_valid_queues activate_thread_cur_thread gts_wp
-          | wpc
-          | rule choose_thread_guarded_pas_domain
-          | simp add: schedule_choose_new_thread_def ethread_get_when_def split del: if_split
-          | wp (once) hoare_drop_imp[where f="ethread_get t v" for t v]
-          | wp (once) hoare_drop_imp[where f="schedule_switch_thread_fastfail c i cp p" for c i cp p])+
+         | wpc
+         | rule choose_thread_guarded_pas_domain
+         | simp add: schedule_choose_new_thread_def ethread_get_when_def split del: if_split
+         | wp (once) hoare_drop_imp[where f="ethread_get t v" for t v]
+         | wp (once) hoare_drop_imp[where f="schedule_switch_thread_fastfail c i cp p" for c i cp p])+
        apply (wp hoare_drop_imp)
       apply (wpsimp wp: guarded_pas_domain_lift[where f="activate_thread"]
-                    guarded_pas_domain_lift[where f="set_scheduler_action f" for f]
-                    guarded_switch_to_lift switch_to_thread_guarded_pas_domain
-                    next_domain_valid_queues activate_thread_cur_thread gts_wp
-          | wpc
-          | rule choose_thread_guarded_pas_domain
-          | simp add: schedule_choose_new_thread_def ethread_get_when_def split del: if_split
-          | wp (once) hoare_drop_imp[where f="ethread_get t v" for t v]
-          | wp (once) hoare_drop_imp[where f="schedule_switch_thread_fastfail c i cp p" for c i cp p])+
+                        guarded_pas_domain_lift[where f="set_scheduler_action f" for f]
+                        guarded_switch_to_lift switch_to_thread_guarded_pas_domain
+                        next_domain_valid_queues activate_thread_cur_thread gts_wp
+             | wpc
+             | rule choose_thread_guarded_pas_domain
+             | simp add: schedule_choose_new_thread_def ethread_get_when_def split del: if_split
+             | wp (once) hoare_drop_imp[where f="ethread_get t v" for t v]
+             | wp (once) hoare_drop_imp[where f="schedule_switch_thread_fastfail c i cp p" for c i cp p])+
   apply (fastforce intro: switch_to_cur_domain switch_thread_runnable
                     simp: valid_sched_def elim!: st_tcb_weakenE)+
   done
 
 lemma schedule_if_guarded_pas_domain[wp]:
   "\<lbrace>guarded_pas_domain aag and einvs and pas_refined aag\<rbrace>
-      schedule_if tc
+   schedule_if tc
    \<lbrace>\<lambda>_. guarded_pas_domain aag\<rbrace>"
   apply (simp add: schedule_if_def)
   apply (wp schedule_guarded_pas_domain)
@@ -1287,7 +1287,7 @@ text \<open>
 definition kernel_exit_if :: "user_context \<Rightarrow> (user_context,det_ext) s_monad" where
   "kernel_exit_if tc \<equiv>
    do t' \<leftarrow> gets cur_thread;
-    thread_get (arch_tcb_context_get o tcb_arch) t'
+      thread_get (arch_tcb_context_get o tcb_arch) t'
   od"
 
 crunch inv[wp]: kernel_exit_if "P"
@@ -1295,8 +1295,8 @@ crunch inv[wp]: kernel_exit_if "P"
 definition kernel_exit_A_if ::
   "((user_context \<times> det_state) \<times> sys_mode \<times> (user_context \<times> det_state)) set" where
   "kernel_exit_A_if \<equiv>
-      {(s, m, s'). s' \<in> fst (split kernel_exit_if s) \<and>
-                   m = (if ct_running (snd s') then InUserMode else InIdleMode)}"
+     {(s, m, s'). s' \<in> fst (split kernel_exit_if s) \<and>
+                  m = (if ct_running (snd s') then InUserMode else InIdleMode)}"
 
 
 subsection \<open>check_active_irq_if\<close>
@@ -1318,7 +1318,7 @@ subsection \<open>ADT_A_if definition\<close>
 definition check_active_irq_A_if :: "((user_context \<times> ('z :: state_ext) state) \<times> irq option \<times>
                                       (user_context \<times> ('z :: state_ext) state)) set" where
   "check_active_irq_A_if \<equiv>
-      {((tc, s), irq, (tc', s')). ((irq, tc'), s') \<in> fst (check_active_irq_if tc s)}"
+     {((tc, s), irq, (tc', s')). ((irq, tc'), s') \<in> fst (check_active_irq_if tc s)}"
 
 abbreviation internal_state_if :: "'a global_sys_state \<Rightarrow> 'a" where
   "internal_state_if \<equiv> \<lambda>s. (snd (fst s))"
@@ -1327,11 +1327,11 @@ abbreviation internal_state_if :: "'a global_sys_state \<Rightarrow> 'a" where
 (*Weakened invs_if to properties only necessary for refinement*)
 definition full_invs_if :: "observable_if set" where
   "full_invs_if \<equiv>
-    {s. einvs (internal_state_if s) \<and>
-        (snd s \<noteq> KernelSchedule True \<longrightarrow> domain_time (internal_state_if s) > 0) \<and>
-        (domain_time (internal_state_if s) = 0
-           \<longrightarrow> scheduler_action (internal_state_if s) = choose_new_thread) \<and>
-        valid_domain_list (internal_state_if s) \<and>
+     {s. einvs (internal_state_if s) \<and>
+         (snd s \<noteq> KernelSchedule True \<longrightarrow> domain_time (internal_state_if s) > 0) \<and>
+         (domain_time (internal_state_if s) = 0
+          \<longrightarrow> scheduler_action (internal_state_if s) = choose_new_thread) \<and>
+         valid_domain_list (internal_state_if s) \<and>
          (case (snd s) of
             KernelEntry e \<Rightarrow> (e \<noteq> Interrupt \<longrightarrow> ct_running (internal_state_if s)) \<and>
                              (ct_running (internal_state_if s) \<or> ct_idle (internal_state_if s)) \<and>
@@ -1342,7 +1342,7 @@ definition full_invs_if :: "observable_if set" where
                           scheduler_action (internal_state_if s) = resume_cur_thread
           | InIdleMode \<Rightarrow> ct_idle (internal_state_if s) \<and>
                           scheduler_action (internal_state_if s) = resume_cur_thread
-           | _ \<Rightarrow> True) }"
+          | _ \<Rightarrow> True) }"
 
 
 (*We'll define this later, currently it doesn't matter if
@@ -1351,23 +1351,23 @@ consts step_restrict :: "det_state global_sys_state \<Rightarrow> bool"
 
 definition ADT_A_if ::
   "user_transition_if \<Rightarrow> (det_state global_sys_state, observable_if, unit) data_type" where
- "ADT_A_if uop \<equiv>
+  "ADT_A_if uop \<equiv>
      \<lparr>Init = \<lambda>s. {s} \<inter> full_invs_if \<inter> {s. step_restrict s}, Fin = id,
-    Step = (\<lambda>u. global_automaton_if check_active_irq_A_if (do_user_op_A_if uop) kernel_call_A_if
-                                    kernel_handle_preemption_if kernel_schedule_if kernel_exit_A_if
-             \<inter> {(s,s'). step_restrict s'})\<rparr>"
+      Step = (\<lambda>u. global_automaton_if check_active_irq_A_if (do_user_op_A_if uop) kernel_call_A_if
+                                      kernel_handle_preemption_if kernel_schedule_if kernel_exit_A_if
+               \<inter> {(s,s'). step_restrict s'})\<rparr>"
 
 lemma check_active_irq_if_wp:
   "\<lbrace>\<lambda>s. P ((irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s))),tc)
-           (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>)\<rbrace>
-     check_active_irq_if tc
+          (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>)\<rbrace>
+   check_active_irq_if tc
    \<lbrace>P\<rbrace>"
   by (wpsimp wp: dmo_getActiveIRQ_wp simp: check_active_irq_if_def)
 
 lemma handle_preemption_if_only_timer_irq_inv[wp]:
   "handle_preemption_if tc \<lbrace>only_timer_irq_inv irq st\<rbrace>"
   by (wp only_timer_irq_inv_pres handle_preemption_if_irq_masks handle_preemption_if_domain_sep_inv
-        | simp | blast)+
+      | simp | blast)+
 
 lemma schedule_if_only_timer_irq_inv[wp]:
   "schedule_if tc \<lbrace>only_timer_irq_inv irq st\<rbrace>"
@@ -1432,44 +1432,44 @@ locale invariant_over_ADT_if =
   fixes det_inv :: "sys_mode \<Rightarrow> user_context \<Rightarrow> det_state \<Rightarrow> bool"
   fixes utf :: "user_transition_if"
   assumes det_inv_abs_state:
-     "\<And>e tc s. valid_machine_state s \<Longrightarrow> det_inv e tc s \<Longrightarrow> det_inv e tc (abs_state s)"
+    "\<And>e tc s. valid_machine_state s \<Longrightarrow> det_inv e tc s \<Longrightarrow> det_inv e tc (abs_state s)"
   assumes kernel_entry_if_det_inv:
-     "\<And>e tc. \<lbrace>einvs and det_inv (KernelEntry e) tc and ct_running and K (e \<noteq> Interrupt)\<rbrace>
-        kernel_entry_if e tc
-      \<lbrace>\<lambda>rv s. case (fst rv) of Inl irq \<Rightarrow> det_inv KernelPreempted (cur_context s) s
-              | Inr () \<Rightarrow> det_inv (KernelSchedule False) (cur_context s) s\<rbrace>"
+    "\<And>e tc. \<lbrace>einvs and det_inv (KernelEntry e) tc and ct_running and K (e \<noteq> Interrupt)\<rbrace>
+             kernel_entry_if e tc
+             \<lbrace>\<lambda>rv s. case (fst rv) of Inl irq \<Rightarrow> det_inv KernelPreempted (cur_context s) s
+                                    | Inr () \<Rightarrow> det_inv (KernelSchedule False) (cur_context s) s\<rbrace>"
   assumes kernel_entry_if_Interrupt_det_inv:
-     "\<And>tc. \<lbrace>einvs and det_inv (KernelEntry Interrupt) tc and (\<lambda>s. ct_running s \<or> ct_idle s)\<rbrace>
-        kernel_entry_if Interrupt tc
-      \<lbrace>\<lambda>rv s. case (fst rv) of Inl irq \<Rightarrow> det_inv KernelPreempted (cur_context s) s
-              | Inr () \<Rightarrow> det_inv (KernelSchedule True) (cur_context s) s\<rbrace>"
+    "\<And>tc. \<lbrace>einvs and det_inv (KernelEntry Interrupt) tc and (\<lambda>s. ct_running s \<or> ct_idle s)\<rbrace>
+           kernel_entry_if Interrupt tc
+           \<lbrace>\<lambda>rv s. case (fst rv) of Inl irq \<Rightarrow> det_inv KernelPreempted (cur_context s) s
+                                  | Inr () \<Rightarrow> det_inv (KernelSchedule True) (cur_context s) s\<rbrace>"
   assumes handle_preemption_if_det_inv:
-     "\<And>tc. \<lbrace>einvs and (\<lambda>s. det_inv KernelPreempted (cur_context s) s)\<rbrace>
-        handle_preemption_if tc
-      \<lbrace>\<lambda>rv s. det_inv (KernelSchedule True) (cur_context s) s\<rbrace>"
+    "\<And>tc. \<lbrace>einvs and (\<lambda>s. det_inv KernelPreempted (cur_context s) s)\<rbrace>
+           handle_preemption_if tc
+           \<lbrace>\<lambda>rv s. det_inv (KernelSchedule True) (cur_context s) s\<rbrace>"
   assumes schedule_if_det_inv:
-     "\<And>b tc. \<lbrace>einvs and (\<lambda>s. det_inv (KernelSchedule b) (cur_context s) s)\<rbrace>
-        schedule_if tc
-      \<lbrace>\<lambda>rv s. det_inv KernelExit (cur_context s) s\<rbrace>"
+    "\<And>b tc. \<lbrace>einvs and (\<lambda>s. det_inv (KernelSchedule b) (cur_context s) s)\<rbrace>
+             schedule_if tc
+             \<lbrace>\<lambda>rv s. det_inv KernelExit (cur_context s) s\<rbrace>"
   assumes kernel_exit_if_det_inv:
-     "\<And>tc. \<lbrace>einvs and (\<lambda>s. det_inv KernelExit (cur_context s) s) and (\<lambda>s. ct_running s \<or> ct_idle s)\<rbrace>
-        kernel_exit_if tc
+    "\<And>tc. \<lbrace>einvs and (\<lambda>s. det_inv KernelExit (cur_context s) s) and (\<lambda>s. ct_running s \<or> ct_idle s)\<rbrace>
+           kernel_exit_if tc
            \<lbrace>\<lambda>rv s. if ct_running s then det_inv InUserMode rv s else det_inv InIdleMode rv s\<rbrace>"
   assumes do_user_op_if_det_inv:
-     "\<And>tc. \<lbrace>einvs and det_inv InUserMode tc and ct_running\<rbrace>
-        do_user_op_if utf tc
-      \<lbrace>\<lambda>rv. case (fst rv) of Some e \<Rightarrow> det_inv (KernelEntry e) (snd rv)
-            | None \<Rightarrow> det_inv InUserMode (snd rv)\<rbrace>"
+    "\<And>tc. \<lbrace>einvs and det_inv InUserMode tc and ct_running\<rbrace>
+           do_user_op_if utf tc
+           \<lbrace>\<lambda>rv. case (fst rv) of Some e \<Rightarrow> det_inv (KernelEntry e) (snd rv)
+                                | None \<Rightarrow> det_inv InUserMode (snd rv)\<rbrace>"
   assumes check_active_irq_if_User_det_inv:
-     "\<And>tc. \<lbrace>einvs and det_inv InUserMode tc and ct_running\<rbrace>
-        check_active_irq_if tc
-      \<lbrace>\<lambda>rv. case (fst rv) of Some irq \<Rightarrow> det_inv (KernelEntry Interrupt) (snd rv)
-            | None \<Rightarrow> det_inv InUserMode (snd rv)\<rbrace>"
+    "\<And>tc. \<lbrace>einvs and det_inv InUserMode tc and ct_running\<rbrace>
+           check_active_irq_if tc
+           \<lbrace>\<lambda>rv. case (fst rv) of Some irq \<Rightarrow> det_inv (KernelEntry Interrupt) (snd rv)
+                                | None \<Rightarrow> det_inv InUserMode (snd rv)\<rbrace>"
   assumes check_active_irq_if_Idle_det_inv:
-     "\<And>tc. \<lbrace>einvs and det_inv InIdleMode tc and ct_idle\<rbrace>
-        check_active_irq_if tc
-      \<lbrace>\<lambda>rv. case (fst rv) of Some irq \<Rightarrow> det_inv (KernelEntry Interrupt) (snd rv)
-            | None \<Rightarrow> det_inv InIdleMode (snd rv)\<rbrace>"
+    "\<And>tc. \<lbrace>einvs and det_inv InIdleMode tc and ct_idle\<rbrace>
+           check_active_irq_if tc
+           \<lbrace>\<lambda>rv. case (fst rv) of Some irq \<Rightarrow> det_inv (KernelEntry Interrupt) (snd rv)
+                                | None \<Rightarrow> det_inv InIdleMode (snd rv)\<rbrace>"
 
 
 locale valid_initial_state_noenabled = invariant_over_ADT_if + (* FIXME: arch_split *)
@@ -1482,12 +1482,12 @@ locale valid_initial_state_noenabled = invariant_over_ADT_if + (* FIXME: arch_sp
   defines
     "current_aag t \<equiv> initial_aag\<lparr>pasSubject := the_elem (pasDomainAbs initial_aag (cur_domain t))\<rparr>"
   (* Run the system from right where we exit the kernel for the first time to user-space.
-   It shouldn't matter what the initial machine context is since the first
+     It shouldn't matter what the initial machine context is since the first
      thing that should happen on a KernelExit is to restore it from the cur_thread *)
   defines "s0 \<equiv> ((if ct_idle s0_internal then idle_context s0_internal else s0_context,s0_internal),
-          KernelExit)"
+                  KernelExit)"
   assumes cur_domain_subject_s0:
-  "pasSubject initial_aag \<in> pasDomainAbs initial_aag (cur_domain s0_internal)"
+    "pasSubject initial_aag \<in> pasDomainAbs initial_aag (cur_domain s0_internal)"
   assumes policy_wellformed: "pas_wellformed_noninterference initial_aag"
   fixes Invs
   defines "Invs s \<equiv> einvs s \<and> only_timer_irq_inv timer_irq s0_internal s \<and>
@@ -1516,8 +1516,8 @@ locale valid_initial_state_noenabled = invariant_over_ADT_if + (* FIXME: arch_sp
 locale valid_initial_state = valid_initial_state_noenabled +
    assumes ADT_A_if_enabled_system:
      "enabled_system (ADT_A_if utf) s0"
-       assumes ADT_A_if_Init_Fin_serial:
-       "Init_Fin_serial (ADT_A_if utf) s0 (full_invs_if \<inter> {s. step_restrict s})"
+   assumes ADT_A_if_Init_Fin_serial:
+     "Init_Fin_serial (ADT_A_if utf) s0 (full_invs_if \<inter> {s. step_restrict s})"
 
 
 subsection \<open>domain_field preserved on non-interrupt kernel event\<close>
@@ -1561,8 +1561,8 @@ context ADT_IF_1 begin
 lemma handle_event_domain_fields:
   notes hy_inv[wp del]
   shows "\<lbrace>domain_fields P and K (e \<noteq> Interrupt)\<rbrace>
-   handle_event e
-   \<lbrace>\<lambda>_. domain_fields P\<rbrace>"
+         handle_event e
+         \<lbrace>\<lambda>_. domain_fields P\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (rule hoare_pre)
    apply (case_tac e)
@@ -1587,7 +1587,7 @@ lemma kernel_entry_if_domain_time_sched_action:
    apply (simp add: kernel_entry_if_def)
    apply (wp handle_interrupt_valid_domain_time| wpc | simp)+
       apply (rule_tac Q="\<lambda>r s. domain_time s > 0" in hoare_strengthen_post)
-      apply (wp | simp)+
+       apply (wp | simp)+
       apply (wp hoare_false_imp kernel_entry_if_domain_fields | fastforce)+
   done
 
@@ -1625,7 +1625,7 @@ lemma exit_idle_context:
   apply (simp add: kernel_exit_if_def thread_get_def)
   apply wp
   apply (subgoal_tac "cur_thread s = idle_thread s")
-  apply (clarsimp simp: cur_thread_idle idle_context_def)+
+   apply (clarsimp simp: cur_thread_idle idle_context_def)+
   done
 
 lemma check_active_irq_context:
@@ -1652,11 +1652,11 @@ lemma get_tcb_machine_stat_update[simp]:
 
 lemma handle_preemption_globals_equiv[wp]:
   "\<lbrace>globals_equiv st and invs\<rbrace>
-      handle_preemption_if a
+   handle_preemption_if a
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (simp add: handle_preemption_if_def)
   apply (wp handle_interrupt_globals_equiv dmo_getActiveIRQ_globals_equiv crunch_wps
-        | simp add: crunch_simps)+
+         | simp add: crunch_simps)+
   done
 
 lemma schedule_if_globals_equiv_scheduler[wp]:
@@ -1665,9 +1665,9 @@ lemma schedule_if_globals_equiv_scheduler[wp]:
    \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
   apply (simp add: schedule_if_def)
   apply wp
-  apply (wp globals_equiv_scheduler_inv'[where P="invs"] activate_thread_globals_equiv)
+    apply (wp globals_equiv_scheduler_inv'[where P="invs"] activate_thread_globals_equiv)
     apply (simp add: invs_arch_state invs_valid_idle)
-  apply (wp | simp)+
+   apply (wp | simp)+
   done
 
 lemma dmo_user_memory_update_idle_equiv:
@@ -1717,36 +1717,36 @@ subsection \<open>@{term ADT_A_if} is a step system with the invs_if invariant\<
 definition cur_thread_context_of :: "observable_if \<Rightarrow> user_context" where
   "cur_thread_context_of \<equiv>
      \<lambda>s. case sys_mode_of s of InUserMode \<Rightarrow> user_context_of s
-         | InIdleMode \<Rightarrow> user_context_of s
-         | KernelEntry e \<Rightarrow> user_context_of s
-         | _ \<Rightarrow> cur_context (internal_state_if s)"
+                             | InIdleMode \<Rightarrow> user_context_of s
+                             | KernelEntry e \<Rightarrow> user_context_of s
+                             | _ \<Rightarrow> cur_context (internal_state_if s)"
 
 definition invs_if :: "observable_if \<Rightarrow> bool" where
   "invs_if s \<equiv>
-    Invs (internal_state_if s) \<and>
-    det_inv (sys_mode_of s) (cur_thread_context_of s) (internal_state_if s) \<and>
-    (snd s \<noteq> KernelSchedule True \<longrightarrow> domain_time (internal_state_if s) > 0) \<and>
-    (domain_time (internal_state_if s) = 0
-       \<longrightarrow> scheduler_action (internal_state_if s) = choose_new_thread) \<and>
-    (snd s \<noteq> KernelExit
-       \<longrightarrow> (ct_idle (internal_state_if s)
-             \<longrightarrow> user_context_of s = idle_context (internal_state_if s))) \<and>
+     Invs (internal_state_if s) \<and>
+     det_inv (sys_mode_of s) (cur_thread_context_of s) (internal_state_if s) \<and>
+     (snd s \<noteq> KernelSchedule True \<longrightarrow> domain_time (internal_state_if s) > 0) \<and>
+     (domain_time (internal_state_if s) = 0
+      \<longrightarrow> scheduler_action (internal_state_if s) = choose_new_thread) \<and>
+     (snd s \<noteq> KernelExit
+      \<longrightarrow> (ct_idle (internal_state_if s)
+      \<longrightarrow> user_context_of s = idle_context (internal_state_if s))) \<and>
      (case (snd s) of
         KernelEntry e \<Rightarrow> (e \<noteq> Interrupt \<longrightarrow> ct_running (internal_state_if s)) \<and>
-                     (ct_running (internal_state_if s) \<or> ct_idle (internal_state_if s)) \<and>
-                     scheduler_action (internal_state_if s) = resume_cur_thread
+                         (ct_running (internal_state_if s) \<or> ct_idle (internal_state_if s)) \<and>
+                         scheduler_action (internal_state_if s) = resume_cur_thread
       | KernelExit \<Rightarrow> (ct_running (internal_state_if s) \<or> ct_idle (internal_state_if s)) \<and>
-                     scheduler_action (internal_state_if s) = resume_cur_thread
+                      scheduler_action (internal_state_if s) = resume_cur_thread
       | InUserMode \<Rightarrow> ct_running (internal_state_if s) \<and>
-                     scheduler_action (internal_state_if s) = resume_cur_thread
+                      scheduler_action (internal_state_if s) = resume_cur_thread
       | InIdleMode \<Rightarrow> ct_idle (internal_state_if s) \<and>
-                     scheduler_action (internal_state_if s) = resume_cur_thread
-        | _ \<Rightarrow> True)"
+                      scheduler_action (internal_state_if s) = resume_cur_thread
+      | _ \<Rightarrow> True)"
 
 lemma invs_if_s0[simp]:
   "invs_if s0"
   apply (clarsimp simp: s0_def invs_if_def Invs_s0_internal[simplified]
-                       ct_running_or_ct_idle_s0_internal domain_time_s0_internal
+                        ct_running_or_ct_idle_s0_internal domain_time_s0_internal
                         det_inv_s0 cur_thread_context_of_def scheduler_action_s0_internal)
   using domain_time_s0_internal by fastforce
 
@@ -1776,7 +1776,7 @@ lemma subject_current_aag:
   by (simp add: current_aag_def)
 
 lemma pas_wellformed_cur[iff]:
- "pas_wellformed_noninterference (current_aag s)"
+  "pas_wellformed_noninterference (current_aag s)"
   apply (cut_tac policy_wellformed)
   apply (simp add: pas_wellformed_noninterference_def current_aag_def pas_domains_distinct_def)
   done
@@ -1891,7 +1891,7 @@ lemma idle_equiv_context_equiv:
 lemma kernel_entry_if_det_inv':
   "\<lbrace>einvs and det_inv (KernelEntry e) tc and (\<lambda>s. ct_running s \<or> ct_idle s)
                                          and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s)\<rbrace>
-      kernel_entry_if e tc
+   kernel_entry_if e tc
    \<lbrace>\<lambda>rv s. det_inv (case (fst rv) of Inl irq \<Rightarrow> KernelPreempted
                                    | Inr () \<Rightarrow> KernelSchedule (e = Interrupt)) (cur_context s) s\<rbrace>"
   apply (case_tac "e = Interrupt")
@@ -1950,14 +1950,14 @@ lemma invs_if_Step_ADT_A_if:
            apply (erule use_valid)
             apply (rule current_aag_lift)
              apply (wp kernel_entry_if_invs kernel_entry_silc_inv[where st'=s0_internal]
-                      kernel_entry_pas_refined[where st=s0_internal]
-                      kernel_entry_if_valid_sched kernel_entry_if_only_timer_irq_inv
-                      kernel_entry_if_domain_sep_inv kernel_entry_if_guarded_pas_domain
+                       kernel_entry_pas_refined[where st=s0_internal]
+                       kernel_entry_if_valid_sched kernel_entry_if_only_timer_irq_inv
+                       kernel_entry_if_domain_sep_inv kernel_entry_if_guarded_pas_domain
                        kernel_entry_if_domain_fields kernel_entry_if_idle_equiv
                        kernel_entry_if_domain_time_sched_action
                        hoare_false_imp ct_idle_lift
-                  | clarsimp intro!: guarded_pas_is_subject_current_aag[rule_format]
-                  | intro conjI)+
+                    | clarsimp intro!: guarded_pas_is_subject_current_aag[rule_format]
+                    | intro conjI)+
               apply (rule guarded_pas_is_subject_current_aag[rule_format],assumption+)
               apply (simp add: schact_is_rct_def)+
             apply (rule guarded_pas_is_subject_current_aag[rule_format],assumption+)
@@ -1965,12 +1965,12 @@ lemma invs_if_Step_ADT_A_if:
           apply (simp add: kernel_call_A_if_def | elim exE conjE)+
           apply (rule context_conjI)
            apply (erule use_valid)
-          apply (rule kernel_entry_if_invs,simp)
+            apply (rule kernel_entry_if_invs,simp)
           apply (subgoal_tac "idle_equiv s0_internal ba")
-          prefer 2
-          apply (erule use_valid)
-          apply (rule kernel_entry_if_idle_equiv)
-          apply simp
+           prefer 2
+           apply (erule use_valid)
+            apply (rule kernel_entry_if_idle_equiv)
+           apply simp
           apply (simp add: idle_equiv_context_equiv)
           apply (frule use_valid[OF _ kernel_entry_context],simp)
           apply (frule use_valid[OF _ kernel_entry_if_det_inv'])
@@ -1995,13 +1995,13 @@ lemma invs_if_Step_ADT_A_if:
          apply (elim exE conjE)
          apply (clarsimp simp add: kernel_handle_preemption_if_def)
          apply (subgoal_tac "idle_equiv s0_internal ba \<and> invs ba")
-         prefer 2
-         apply (erule use_valid)
-         apply (wp handle_preemption_if_invs | simp)+
+          prefer 2
+          apply (erule use_valid)
+           apply (wp handle_preemption_if_invs | simp)+
          apply (clarsimp simp add: idle_equiv_context_equiv)
          apply (erule use_valid)
           apply (rule hoare_add_post[OF handle_preemption_context, OF TrueI], simp,
-                rule hoare_drop_imps)
+                 rule hoare_drop_imps)
           apply (wp handle_preemption_if_invs handle_preemption_if_domain_sep_inv
                     handle_preemption_if_domain_time_sched_action
                     handle_preemption_if_det_inv ct_idle_lift)
@@ -2087,8 +2087,8 @@ lemma invs_if_Step_ADT_A_if:
   done
 
 lemma execution_invs:
- assumes e: "s \<in> execution (ADT_A_if utf) s0 js"
- shows "invs_if s"
+  assumes e: "s \<in> execution (ADT_A_if utf) s0 js"
+  shows "invs_if s"
   apply (insert e)
   apply (induct js arbitrary: s rule: rev_induct)
    apply (clarsimp simp add: execution_def Fin_ADT_if Init_ADT_if
@@ -2099,7 +2099,7 @@ lemma execution_invs:
   apply (unfold Image_def)
   apply (drule CollectD)
   apply (erule bexE)
-   apply simp
+  apply simp
   apply (rule invs_if_Step_ADT_A_if)
    apply (drule_tac meta_spec)
    apply (fastforce)
@@ -2111,11 +2111,11 @@ end
 
 
 lemma execution_restrict:
- assumes e: "s \<in> execution (ADT_A_if utf) s0 js"
- shows "step_restrict s"
+  assumes e: "s \<in> execution (ADT_A_if utf) s0 js"
+  shows "step_restrict s"
   apply (insert e)
   apply (induct js arbitrary: s rule: rev_induct)
-  apply (clarsimp simp add: execution_def ADT_A_if_def steps_def)
+   apply (clarsimp simp add: execution_def ADT_A_if_def steps_def)
   apply (clarsimp simp add: execution_def Fin_ADT_if Init_ADT_if steps_def)
   apply (simp add: ADT_A_if_def)
   done
@@ -2193,7 +2193,7 @@ definition measuref_if :: "det_state global_sys_state \<Rightarrow> det_state gl
   "measuref_if s s' \<equiv>
      (if (snd s) = KernelExit
       then (if interrupted_modes (snd s') then 0
-         else 1 + (4 * irq_measure_if (internal_state_if s')) +
+            else 1 + (4 * irq_measure_if (internal_state_if s')) +
                  (case (snd s') of (KernelEntry e) \<Rightarrow> 3
                                  | _ \<Rightarrow> (if (\<exists>b. (snd s') = KernelSchedule b) then 2
                                          else (if (snd s') = KernelExit then 1 else 0))))
@@ -2376,7 +2376,7 @@ lemma preemption_point_irq_state_inv'[wp]:
    \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
   apply (simp add: preemption_point_def)
   apply (wpsimp wp: OR_choiceE_wp[where P'="irq_state_inv st and K(irq_is_recurring irq st)"
-                            and P''="irq_state_inv st and K(irq_is_recurring irq st)"]
+                                    and P''="irq_state_inv st and K(irq_is_recurring irq st)"]
               simp: reset_work_units_def)+
      apply simp
      apply (wpsimp wp: OR_choiceE_wp dmo_getActiveIRQ_wp simp: reset_work_units_def)+
@@ -2385,14 +2385,14 @@ lemma preemption_point_irq_state_inv'[wp]:
      apply (clarsimp simp: irq_state_next_def)
      apply (simp add: next_irq_state_Suc'[OF _ recurring_next_irq_state_dom])
     apply (wp | simp add: update_work_units_def irq_state_inv_def | fastforce)+
-     done
+  done
 
 lemma validE_validE_E':
   "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f -, \<lbrace>E\<rbrace>"
   apply (rule validE_validE_E)
   apply (rule hoare_post_impErr)
-  apply assumption
-  apply simp+
+    apply assumption
+   apply simp+
   done
 
 lemmas preemption_point_irq_state_inv[wp] = validE_validE_R'[OF preemption_point_irq_state_inv']
@@ -2413,11 +2413,11 @@ lemma hoare_add_postE:
 lemma rec_del_irq_state_inv':
   notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del] rec_del.simps[simp del]
   shows
-  "s \<turnstile> \<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
-        rec_del call
+    "s \<turnstile> \<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
+         rec_del call
          \<lbrace>\<lambda>a s. (case call of FinaliseSlotCall x y \<Rightarrow> y \<or> fst a \<longrightarrow> snd a = NullCap
-          | _ \<Rightarrow> True) \<and>
-         domain_sep_inv False sta s \<and> irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+                            | _ \<Rightarrow> True) \<and>
+                domain_sep_inv False sta s \<and> irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
 proof (induct s arbitrary: rule: rec_del.induct, simp_all only: rec_del_fails hoare_fail_any)
   case (1 slot exposed s) show ?case
     apply (simp add: split_def rec_del.simps)
@@ -2443,8 +2443,8 @@ next
          apply (rule spec_strengthen_postE)
           apply (rule "2.hyps"[simplified], fastforce+)
            apply (wp  finalise_cap_domain_sep_inv_cap get_cap_wp
-                   finalise_cap_returns_NullCap[where irqs=False, simplified]
-                   drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
+                     finalise_cap_returns_NullCap[where irqs=False, simplified]
+                     drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
                   | simp add: without_preemption_def split del: if_split
                   | wp (once) hoare_drop_imps
                   | wp irq_state_inv_triv)+
@@ -2455,7 +2455,7 @@ next
     apply (simp add: rec_del.simps)
     apply (wp drop_spec_validE[OF returnOk_wp] drop_spec_validE[OF liftE_wp] irq_state_inv_triv)
     apply (rule hoare_pre_spec_validE)
-    apply (wp drop_spec_validE[OF assertE_wp])
+     apply (wp drop_spec_validE[OF assertE_wp])
     apply (fastforce)
     done
 next
@@ -2471,7 +2471,7 @@ qed
 
 lemma rec_del_irq_state_inv:
   "\<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
-    rec_del call
+   rec_del call
    \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
   apply (rule hoare_post_impErr)
     apply (rule use_spec)
@@ -2492,7 +2492,7 @@ lemma cap_revoke_irq_state_inv'':
   notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del]
   shows
     "s \<turnstile> \<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
-   cap_revoke slot
+         cap_revoke slot
          \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
 proof(induct rule: cap_revoke.induct[where ?a1.0=s])
   case (1 slot s)
@@ -2500,17 +2500,17 @@ proof(induct rule: cap_revoke.induct[where ?a1.0=s])
     apply (subst cap_revoke.simps)
     apply (rule hoare_spec_gen_asm)
     apply (rule hoare_pre_spec_validE)
-   apply (wp "1.hyps")
+     apply (wp "1.hyps")
             apply (wp spec_valid_conj_liftE2 | simp)+
             apply (wp drop_spec_validE[OF preemption_point_irq_state_inv[simplified validE_R_def]]
-                    drop_spec_validE[OF preemption_point_irq_state_inv'[where irq=irq]]
-                    drop_spec_validE[OF valid_validE[OF preemption_point_domain_sep_inv]]
+                      drop_spec_validE[OF preemption_point_irq_state_inv'[where irq=irq]]
+                      drop_spec_validE[OF valid_validE[OF preemption_point_domain_sep_inv]]
                       cap_delete_domain_sep_inv cap_delete_irq_state_inv select_wp
-                    drop_spec_validE[OF assertE_wp] drop_spec_validE[OF returnOk_wp]
+                      drop_spec_validE[OF assertE_wp] drop_spec_validE[OF returnOk_wp]
                       drop_spec_validE[OF liftE_wp] drop_spec_validE[OF hoare_vcg_conj_liftE1]
-                | simp | wp (once) hoare_drop_imps)+
-  apply fastforce
-  done
+                   | simp | wp (once) hoare_drop_imps)+
+    apply fastforce
+    done
 qed
 
 lemmas cap_revoke_irq_state_inv' = use_spec(2)[OF cap_revoke_irq_state_inv'']
@@ -2533,10 +2533,10 @@ lemma invoke_cnode_irq_state_inv:
   apply (rule hoare_pre)
    apply wpc
          apply ((wp cap_revoke_irq_state_inv' cap_delete_irq_state_inv hoare_vcg_all_lift
-               | wpc
-               | simp add: cap_move_def split del: if_split
-               | wp (once) irq_state_inv_triv
-               | wp (once) hoare_drop_imps)+)[7]
+                 | wpc
+                 | simp add: cap_move_def split del: if_split
+                 | wp (once) irq_state_inv_triv
+                 | wp (once) hoare_drop_imps)+)[7]
   apply fastforce
   done
 
@@ -2615,7 +2615,7 @@ lemma perform_invocation_irq_state_inv:
     \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
   apply (case_tac op; simp;
          (solves \<open>(wp invoke_untyped_irq_state_inv[where irq=irq] irq_state_inv_triv
-                 invoke_tcb_irq_state_inv invoke_cnode_irq_state_inv[simplified validE_R_def]
+                      invoke_tcb_irq_state_inv invoke_cnode_irq_state_inv[simplified validE_R_def]
                    | clarsimp | simp add: invoke_domain_def)+\<close>)?)
    apply wp
     apply (wp irq_state_inv_triv' invoke_irq_control_irq_masks)
@@ -2642,13 +2642,13 @@ lemma handle_invocation_irq_state_inv:
                    liftE_liftM_liftME liftME_def bindE_assoc
               split del: if_split)
   apply (wp syscall_valid)
-         apply ((wp irq_state_inv_triv | wpc | simp)+)[2]
+          apply ((wp irq_state_inv_triv | wpc | simp)+)[2]
         apply (wp static_imp_wp perform_invocation_irq_state_inv hoare_vcg_all_lift
-                hoare_vcg_ex_lift decode_invocation_IRQHandlerCap
-            | wpc
-            | wp (once) hoare_drop_imps
-            | simp split del: if_split
-            | wp (once) irq_state_inv_triv)+
+                  hoare_vcg_ex_lift decode_invocation_IRQHandlerCap
+               | wpc
+               | wp (once) hoare_drop_imps
+               | simp split del: if_split
+               | wp (once) irq_state_inv_triv)+
   apply fastforce
   done
 
@@ -2662,7 +2662,7 @@ lemma handle_event_irq_state_inv:
       apply (rename_tac syscall)
       apply (case_tac syscall)
   by (simp add: handle_send_def handle_call_def
-                    | wp handle_invocation_irq_state_inv[where sta=sta and irq=irq]
+      | wp handle_invocation_irq_state_inv[where sta=sta and irq=irq]
            irq_state_inv_triv[OF handle_recv_irq_state_of_state] irq_state_inv_triv
            irq_state_inv_triv[OF handle_reply_irq_state_of_state] hy_inv)+
 
@@ -2673,8 +2673,8 @@ lemma schedule_if_irq_state_inv:
   "schedule_if tc \<lbrace>irq_state_inv st\<rbrace>"
   by (wp irq_state_inv_triv
       | simp add: schedule_if_def activate_thread_def
-     | wpc
-     | wp (once) hoare_drop_imps)+
+      | wpc
+      | wp (once) hoare_drop_imps)+
 
 lemma irq_measure_if_inv:
   assumes irq_state:
@@ -2728,11 +2728,11 @@ context ADT_IF_1 begin
 lemma kernel_entry_if_next_irq_state_of_state:
   "\<lbrakk> event \<noteq> Interrupt; invs i_s; domain_sep_inv False (st :: det_state) i_s;
      irq_is_recurring irq i_s; ((Inr (), a), b) \<in> fst (kernel_entry_if event uc i_s) \<rbrakk>
-  \<Longrightarrow> next_irq_state_of_state b = next_irq_state_of_state i_s"
+     \<Longrightarrow> next_irq_state_of_state b = next_irq_state_of_state i_s"
   apply (simp add: kernel_entry_if_def in_bind in_return | elim conjE exE)+
   apply (erule use_validE_R)
    apply (rule_tac Q'="\<lambda>_. irq_state_inv i_s" in hoare_post_imp_R)
-   apply (rule validE_validE_R')
+    apply (rule validE_validE_R')
     apply (rule handle_event_irq_state_inv[where sta=st and irq=irq] | simp)+
    apply (clarsimp simp: irq_state_inv_def)
   apply (simp add: arch_tcb_update_aux2)
@@ -2748,7 +2748,7 @@ lemma kernel_entry_if_next_irq_state_of_state:
 lemma kernel_entry_if_next_irq_state_of_state_next:
   "\<lbrakk> event \<noteq> Interrupt; invs i_s; domain_sep_inv False (st :: det_state) i_s;
      irq_is_recurring irq i_s; ((Inl r, a), b) \<in> fst (kernel_entry_if event uc i_s) \<rbrakk>
-  \<Longrightarrow> irq_state_of_state b = next_irq_state_of_state i_s"
+     \<Longrightarrow> irq_state_of_state b = next_irq_state_of_state i_s"
   apply (simp add: kernel_entry_if_def in_bind in_return | elim conjE exE)+
   apply (erule use_validE_E)
    apply (rule validE_validE_E)
@@ -2769,8 +2769,8 @@ lemma kernel_entry_if_next_irq_state_of_state_next:
 lemma kernel_entry_if_irq_measure:
   "\<lbrakk> event \<noteq> Interrupt; invs i_s; domain_sep_inv False (st :: det_state) i_s;
      irq_is_recurring irq i_s; ((Inr (), a), b) \<in> fst (kernel_entry_if event uc i_s) \<rbrakk>
-  \<Longrightarrow> irq_measure_if b \<le> irq_measure_if i_s"
- apply (fold irq_measure_if_inv_def)
+     \<Longrightarrow> irq_measure_if b \<le> irq_measure_if i_s"
+  apply (fold irq_measure_if_inv_def)
   apply (rule mp)
    apply (erule_tac P="(=) i_s" and Q="\<lambda>rv s. (isRight (fst rv)) \<longrightarrow> Q s" for Q in use_valid)
     apply (simp_all add: isRight_def)
@@ -2872,18 +2872,18 @@ lemmas do_user_op_if_next_irq_state_of_state =
 
 lemma ADT_A_if_Step_measure_if':
   "\<lbrakk> (s,s') \<in> data_type.Step (ADT_A_if utf) x; invs_if s; measuref_if y s > 0 \<rbrakk>
-       \<Longrightarrow> measuref_if y s' < measuref_if y s \<and>
+     \<Longrightarrow> measuref_if y s' < measuref_if y s \<and>
          (\<not> interrupted_modes (snd s)
           \<longrightarrow> \<not> interrupted_modes (snd s')
               \<longrightarrow> next_irq_state_of_state (internal_state_if s') =
-               next_irq_state_of_state (internal_state_if s))"
+                  next_irq_state_of_state (internal_state_if s))"
   apply (frule invs_if_irq_is_recurring)
   apply (case_tac s, clarsimp)
   apply (rename_tac uc i_s mode)
   apply (case_tac mode)
        apply (simp_all add: rah_simp system.Step_def execution_def steps_def ADT_A_if_def
-                           global_automaton_if_def check_active_irq_A_if_def do_user_op_A_if_def
-                           check_active_irq_if_def in_monad measuref_if_def
+                            global_automaton_if_def check_active_irq_A_if_def do_user_op_A_if_def
+                            check_active_irq_if_def in_monad measuref_if_def
               | safe | split if_splits)+
                              apply (frule getActiveIRQ_None)
                              apply (erule use_valid[OF _ do_user_op_if_irq_measure_if])
@@ -2924,12 +2924,12 @@ lemma ADT_A_if_Step_measure_if':
                  apply (elim exE conjE)
                  apply (rule_tac event=x3 in kernel_entry_if_irq_measure)
                      apply ((simp add: invs_if_def Invs_def only_timer_irq_inv_def
-                           | elim conjE | assumption)+)[4]
+                             | elim conjE | assumption)+)[4]
                  apply (simp)
                 apply (simp add: kernel_call_A_if_def | elim conjE exE)+
                 apply (erule kernel_entry_if_next_irq_state_of_state)
                    apply ((simp add: invs_if_def Invs_def only_timer_irq_inv_def
-                          | elim conjE | assumption)+)[4]
+                           | elim conjE | assumption)+)[4]
                apply (clarsimp split: if_splits)
               apply (rule Suc_le_lessD)
               apply (simp add: kernel_schedule_if_def)
@@ -2960,11 +2960,11 @@ lemma ADT_A_if_Step_measure_if':
 
 lemma ADT_A_if_Step_measure_if'':
   "\<lbrakk> (s,s') \<in> data_type.Step (ADT_A_if utf) x; invs_if s; measuref_if y s > 0 \<rbrakk>
-       \<Longrightarrow> measuref_if y s' < measuref_if y s \<and>
+     \<Longrightarrow> measuref_if y s' < measuref_if y s \<and>
          (\<not> interrupted_modes (snd s)
           \<longrightarrow> interrupted_modes (snd s')
-            \<longrightarrow> irq_state_of_state (internal_state_if s') =
-                next_irq_state_of_state (internal_state_if s))"
+              \<longrightarrow> irq_state_of_state (internal_state_if s') =
+                  next_irq_state_of_state (internal_state_if s))"
   apply (frule invs_if_irq_is_recurring)
   apply (case_tac s, clarsimp)
   apply (rename_tac uc i_s mode)
@@ -2972,7 +2972,7 @@ lemma ADT_A_if_Step_measure_if'':
        apply (simp_all add: rah_simp system.Step_def execution_def steps_def ADT_A_if_def
                            global_automaton_if_def check_active_irq_A_if_def do_user_op_A_if_def
                            check_active_irq_if_def in_monad measuref_if_def
-             | safe | split if_splits)+
+              | safe | split if_splits)+
                         apply (frule getActiveIRQ_None)
                         apply (erule use_valid[OF _ do_user_op_if_irq_measure_if])
                         apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
@@ -2995,11 +2995,11 @@ lemma ADT_A_if_Step_measure_if'':
                      apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
                      apply (simp add: next_irq_state_Suc recurring_next_irq_state_dom)
                      apply (clarsimp split: if_splits)+
-                     apply (frule getActiveIRQ_Some)
+                    apply (frule getActiveIRQ_Some)
                     apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
                     apply (simp add: next_irq_state_Suc' recurring_next_irq_state_dom)
                    apply (clarsimp split: if_splits)
-                   apply (frule getActiveIRQ_Some)
+                  apply (frule getActiveIRQ_Some)
                   apply (erule use_valid[OF _ dmo_getActiveIRQ_wp])
                   apply (simp add: next_irq_state_Suc' recurring_next_irq_state_dom)
                  apply (clarsimp split: if_splits)
@@ -3010,9 +3010,9 @@ lemma ADT_A_if_Step_measure_if'':
                 apply (fastforce dest: next_irq_state_less)
                apply (clarsimp split: if_splits)
               apply (clarsimp simp: kernel_call_A_if_def in_monad)
-               apply (rule kernel_entry_if_next_irq_state_of_state_next,assumption+)
-                  prefer 4
-                  apply fastforce
+              apply (rule kernel_entry_if_next_irq_state_of_state_next,assumption+)
+                 prefer 4
+                 apply fastforce
                 apply ((simp add: invs_if_def Invs_def only_timer_irq_inv_def
                         | elim conjE | assumption)+)[3]
              apply (clarsimp split: if_splits)
@@ -3052,12 +3052,12 @@ lemma ADT_A_if_Step_measure_if'':
 
 lemma ADT_A_if_Step_irq_masks:
   "\<lbrakk> (s,s') \<in> data_type.Step (ADT_A_if utf) x; invs_if s \<rbrakk>
-       \<Longrightarrow> irq_masks_of_state (internal_state_if s') = irq_masks_of_state (internal_state_if s)"
+     \<Longrightarrow> irq_masks_of_state (internal_state_if s') = irq_masks_of_state (internal_state_if s)"
   apply (case_tac s, clarsimp)
   apply (rename_tac uc i_s mode)
   apply (case_tac mode)
        apply (simp_all add: system.Step_def steps_def ADT_A_if_def in_monad rah_simp execution_def
-                           global_automaton_if_def check_active_irq_A_if_def do_user_op_A_if_def
+                            global_automaton_if_def check_active_irq_A_if_def do_user_op_A_if_def
                             check_active_irq_if_def kernel_schedule_if_def  kernel_call_A_if_def
                             kernel_handle_preemption_if_def kernel_exit_A_if_def measuref_if_def
               | safe | split if_splits)+
@@ -3075,7 +3075,7 @@ lemma ADT_A_if_Step_irq_masks:
    apply fastforce
   apply (erule use_valid[OF _ kernel_exit_irq_masks])
   apply simp
-       done
+  done
 
 end
 
@@ -3148,7 +3148,7 @@ context ADT_valid_initial_state begin
 
 lemma invs_if_sub_big_steps_ADT_A_if:
   "\<lbrakk> (s', evs) \<in> sub_big_steps (ADT_A_if utf) big_step_R s; invs_if s \<rbrakk>
-   \<Longrightarrow> invs_if s'"
+     \<Longrightarrow> invs_if s'"
   apply (erule sub_big_steps.induct)
    apply simp
   apply (simp add: invs_if_Step_ADT_A_if)
@@ -3187,7 +3187,7 @@ lemma small_step_irq_state_next_irq:
     apply (rule sym)
     apply (rule ADT_A_if_Step_irq_masks,assumption+)
    apply (simp add: invs_if_sub_big_steps_ADT_A_if)+
-   done
+  done
 
 lemma big_step_irq_state_next_irq:
   "\<lbrakk> invs_if s1; big_step_R\<^sup>*\<^sup>* s0 s1; (s1, s2) \<in> Step (big_step_ADT_A_if utf) a;
@@ -3195,14 +3195,14 @@ lemma big_step_irq_state_next_irq:
      \<Longrightarrow> next_irq_state_of_state i_s1 = irq_state_of_state i_s2"
   apply simp
   apply (rule small_step_to_big_step)
-  apply (rule small_step_irq_state_next_irq,(simp add: big_step_R_def)+)
+   apply (rule small_step_irq_state_next_irq,(simp add: big_step_R_def)+)
   done
 
 lemmas ADT_A_if_Step_measure_if =
   ADT_A_if_Step_measure_if'[THEN conjunct1]
 
 lemmas ADT_A_if_Step_next_irq_state_of_state =
-               ADT_A_if_Step_measure_if'[THEN conjunct2, rule_format]
+  ADT_A_if_Step_measure_if'[THEN conjunct2, rule_format]
 
 lemma ADT_A_if_big_step_R_terminate:
   "rel_terminate (ADT_A_if utf) s0 big_step_R {s. invs_if s} measuref_if"
@@ -3218,7 +3218,7 @@ lemma ADT_A_if_big_step_R_terminate:
   apply (simp add: ADT_A_if_def)
   apply (drule tranclp_s0)
   apply (fastforce simp: measuref_if_def big_step_R_def Step_ADT_A_if
-                        Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
+                         Step_ADT_A_if_def_global_automaton_if global_automaton_if_def
                  split: if_splits)
   done
 
@@ -3286,7 +3286,7 @@ lemma inv_holdsE:
 lemma LI_sub_big_steps:
   "\<lbrakk> (s',as) \<in> sub_big_steps C (internal_R C R) s;
      LI A C S (Ia \<times> Ic); A \<Turnstile> Ia; C \<Turnstile> Ic; (t, s) \<in> S; s \<in> Ic; t \<in> Ia \<rbrakk>
-  \<Longrightarrow> \<exists>t'. (t',as) \<in> sub_big_steps A (internal_R A R) t \<and> (t', s') \<in> S \<and> t' \<in> Ia"
+     \<Longrightarrow> \<exists>t'. (t',as) \<in> sub_big_steps A (internal_R A R) t \<and> (t', s') \<in> S \<and> t' \<in> Ia"
   apply (induct rule: sub_big_steps.induct)
    apply (clarsimp simp: LI_def)
    apply (rule_tac x=t in exI)
@@ -3326,7 +3326,7 @@ lemma LI_sub_big_steps:
 lemma LI_big_steps:
   "\<lbrakk> (s, s') \<in> big_steps C (internal_R C R) exmap ev;
      LI A C S (Ia \<times> Ic); A \<Turnstile> Ia; C \<Turnstile> Ic; (t, s) \<in> S; s \<in> Ic; t \<in> Ia \<rbrakk>
-  \<Longrightarrow> \<exists>t'. (t, t') \<in> big_steps A (internal_R A R) exmap ev \<and> (t', s') \<in> S \<and> t' \<in> Ia"
+     \<Longrightarrow> \<exists>t'. (t, t') \<in> big_steps A (internal_R A R) exmap ev \<and> (t', s') \<in> S \<and> t' \<in> Ia"
   apply (drule big_stepsD)
   apply clarsimp
   apply (frule(2) sub_big_steps_I_holds[OF invariant_holds_inv_holds])
@@ -3369,7 +3369,7 @@ lemma inv_holds_Run_big_steps:
 lemma refines_Run_big_steps:
   "\<lbrakk> (s, s') \<in> Run (big_steps C (internal_R C R) exmap) js;
      LI A C S (Ia \<times> Ic); A \<Turnstile> Ia; C \<Turnstile> Ic; (t, s) \<in> S; s \<in> Ic; t \<in> Ia \<rbrakk>
-  \<Longrightarrow> \<exists>t'. (t, t') \<in> Run (big_steps A (internal_R A R) exmap) js \<and> (t', s') \<in> S \<and> t' \<in> Ia"
+     \<Longrightarrow> \<exists>t'. (t, t') \<in> Run (big_steps A (internal_R A R) exmap) js \<and> (t', s') \<in> S \<and> t' \<in> Ia"
   apply (induct js arbitrary: s' rule: rev_induct)
    apply force
   apply (frule Run_mid)
@@ -3392,7 +3392,7 @@ text\<open>
 
 lemma big_step_adt_refines:
   "\<lbrakk> LI A C S (Ia \<times> Ic); A \<Turnstile> Ia; C \<Turnstile> Ic \<rbrakk>
-  \<Longrightarrow> refines (big_step_adt C (internal_R C R) exmap) (big_step_adt A (internal_R A R) exmap)"
+     \<Longrightarrow> refines (big_step_adt C (internal_R C R) exmap) (big_step_adt A (internal_R A R) exmap)"
   apply (subst refines_def)
   apply (clarsimp simp: execution_def steps_eq_Run)
   apply (clarsimp simp: image_def)

--- a/proof/infoflow/CNode_IF.thy
+++ b/proof/infoflow/CNode_IF.thy
@@ -22,8 +22,8 @@ lemma cap_fault_on_failure_rev_g:
 definition gets_apply where
   "gets_apply f x \<equiv>
      do s \<leftarrow> get;
-   return ((f s) x)
-  od"
+        return ((f s) x)
+     od"
 
 lemma gets_apply_ev:
   "equiv_valid I A A (K (\<forall>s t. I s t \<and> A s t \<longrightarrow> (f s) x = (f t) x)) (gets_apply f x)"
@@ -58,21 +58,21 @@ proof(unfold resolve_address_bits_def, induct ref arbitrary: s rule: resolve_add
   case (1 z cap' cref' s') show ?case
     apply (subst resolve_address_bits'.simps)
     apply (cases cap')
-      apply (simp_all add: drop_spec_ev throwError_ev_pre
-                     cong: if_cong
-                split del: if_split)
-   apply (wp "1.hyps")
-    apply (assumption | simp add: in_monad | rule conjI)+
-   apply (wp get_cap_rev get_cap_wp whenE_throwError_wp)+
-   apply (auto simp: cte_wp_at_caps_of_state is_cap_simps cap_auth_conferred_def
-               dest: caps_of_state_pasObjectAbs_eq)
-   done
+               apply (simp_all add: drop_spec_ev throwError_ev_pre
+                              cong: if_cong
+                         split del: if_split)
+    apply (wp "1.hyps")
+                   apply (assumption | simp add: in_monad | rule conjI)+
+           apply (wp get_cap_rev get_cap_wp whenE_throwError_wp)+
+    apply (auto simp: cte_wp_at_caps_of_state is_cap_simps cap_auth_conferred_def
+                dest: caps_of_state_pasObjectAbs_eq)
+    done
 qed
 
 lemma resolve_address_bits_rev:
   "reads_equiv_valid_inv A aag
      (pas_refined aag and K (is_cnode_cap (fst ref) \<longrightarrow> is_subject aag (obj_ref_of (fst ref))))
-                (resolve_address_bits ref)"
+     (resolve_address_bits ref)"
   by (rule use_spec_ev[OF resolve_address_bits_spec_rev])
 
 lemma lookup_slot_for_thread_rev:
@@ -85,8 +85,8 @@ lemma lookup_slot_for_thread_rev:
    apply blast
   apply (clarsimp simp: tcb.splits)
   apply (erule (2) owns_thread_owns_cspace)
-  defer
-  apply (case_tac tcb_ctablea, simp_all)
+   defer
+   apply (case_tac tcb_ctablea, simp_all)
   done
 
 lemma lookup_cap_and_slot_rev[wp]:
@@ -94,11 +94,11 @@ lemma lookup_cap_and_slot_rev[wp]:
                          (lookup_cap_and_slot thread cptr)"
   unfolding lookup_cap_and_slot_def
   by (wp lookup_slot_for_thread_rev lookup_slot_for_thread_authorised get_cap_rev
-        | simp add: split_def
-        | strengthen aag_can_read_self)+
+      | simp add: split_def
+      | strengthen aag_can_read_self)+
 
 lemmas lookup_cap_and_slot_reads_respects_g =
-                  reads_respects_g_from_inv[OF lookup_cap_and_slot_rev lookup_cap_and_slot_inv]
+  reads_respects_g_from_inv[OF lookup_cap_and_slot_rev lookup_cap_and_slot_inv]
 
 lemma set_cap_reads_respects:
   "reads_respects aag l (K (aag_can_read aag (fst slot))) (set_cap cap slot)"
@@ -160,9 +160,9 @@ lemma thread_get_rev:
 
 lemma update_cdt_reads_respects:
   "reads_respects aag l (K (\<forall>rv rv'.
-       equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id rv rv' \<longrightarrow>
-       equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) f rv rv'))
-      (update_cdt f)"
+      equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id rv rv' \<longrightarrow>
+      equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) f rv rv'))
+     (update_cdt f)"
   unfolding update_cdt_def
   apply (rule gen_asm_ev)
   apply (unfold equiv_valid_def2)
@@ -176,9 +176,9 @@ lemma update_cdt_reads_respects:
 
 lemma update_cdt_list_reads_respects:
   "reads_respects aag l (K  (\<forall>rv rv'.
-       equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id rv rv' \<longrightarrow>
-       equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) f rv rv'))
-      (update_cdt_list f)"
+      equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) id rv rv' \<longrightarrow>
+      equiv_for ((aag_can_read aag or aag_can_affect aag l) \<circ> fst) f rv rv'))
+     (update_cdt_list f)"
   unfolding update_cdt_list_def
   apply (rule gen_asm_ev)
   apply (unfold equiv_valid_def2)
@@ -199,7 +199,7 @@ lemmas gen_asm_ev2 = gen_asm_ev2'[where P=\<top> and P'=\<top>, simplified]
 
 lemma set_untyped_cap_as_full_reads_respects:
   "reads_respects aag l (K (aag_can_read aag (fst src_slot)))
-        (set_untyped_cap_as_full src_cap new_cap src_slot)"
+     (set_untyped_cap_as_full src_cap new_cap src_slot)"
   unfolding set_untyped_cap_as_full_def
   apply (wp set_cap_reads_respects)
   apply auto
@@ -220,10 +220,10 @@ lemma cap_insert_reads_respects:
   apply (simp only: cap_insert_ext_extended.dxo_eq)
   apply (simp only: cap_insert_ext_def)
   apply (wp set_original_reads_respects update_cdt_reads_respects set_cap_reads_respects
-           gets_apply_ev update_cdt_list_reads_respects set_untyped_cap_as_full_reads_respects
-           get_cap_wp get_cap_rev
-       | simp split del: if_split
-       | clarsimp simp: equiv_for_def split: option.splits)+
+            gets_apply_ev update_cdt_list_reads_respects set_untyped_cap_as_full_reads_respects
+            get_cap_wp get_cap_rev
+         | simp split del: if_split
+         | clarsimp simp: equiv_for_def split: option.splits)+
   by (fastforce simp: reads_equiv_def2 equiv_for_def
                 elim: states_equiv_forE_is_original_cap states_equiv_forE_cdt
                 dest: aag_can_read_self
@@ -233,7 +233,7 @@ lemma cap_move_reads_respects:
   notes split_paired_All[simp del]
   shows
   "reads_respects aag l (K (is_subject aag (fst src_slot) \<and> is_subject aag (fst dest_slot)))
-                 (cap_move new_cap src_slot dest_slot)"
+                  (cap_move new_cap src_slot dest_slot)"
   unfolding cap_move_def
   apply (subst gets_apply)
   apply (simp add: bind_assoc[symmetric])
@@ -242,13 +242,13 @@ lemma cap_move_reads_respects:
   apply (rule gen_asm_ev)
   apply (elim conjE)
   apply (wp set_original_reads_respects gets_apply_ev update_cdt_reads_respects
-           set_cap_reads_respects update_cdt_list_reads_respects
-       | simp split del: if_split | fastforce simp: equiv_for_def split: option.splits)+
+            set_cap_reads_respects update_cdt_list_reads_respects
+         | simp split del: if_split | fastforce simp: equiv_for_def split: option.splits)+
   apply (intro impI conjI allI)
   apply (fastforce simp: reads_equiv_def2 equiv_for_def
-                  elim: states_equiv_forE_is_original_cap states_equiv_forE_cdt
-                  dest: aag_can_read_self
-                 split: option.splits)+
+                   elim: states_equiv_forE_is_original_cap states_equiv_forE_cdt
+                   dest: aag_can_read_self
+                  split: option.splits)+
   done
 
 lemma get_idemp:
@@ -390,7 +390,7 @@ locale CNode_IF_2 = CNode_IF_1 state_ext_t
   and f :: "('s state, 'a) nondet_monad" +
   assumes is_irq_at_triv:
     "(\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
-        f
+           f
            \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s))\<rbrace>)
      \<Longrightarrow> \<lbrace>(\<lambda>s. P (is_irq_at s)) and Q\<rbrace>
          f
@@ -402,7 +402,7 @@ begin
 lemma irq_is_recurring_triv:
   assumes a: "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
                    (f :: ('s state, 'a) nondet_monad)
-       \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s))\<rbrace>"
+                   \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s))\<rbrace>"
   shows "\<lbrace>irq_is_recurring irq and Q\<rbrace> f \<lbrace>\<lambda>_. irq_is_recurring irq\<rbrace>"
   apply (clarsimp simp: irq_is_recurring_def valid_def)
   apply (rule use_valid[OF _ is_irq_at_triv[OF a]])
@@ -425,7 +425,7 @@ lemma domain_sep_inv_to_interrupt_states_pres:
 
 lemma only_timer_irq_pres:
   assumes a: "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
-        f
+                   f
                    \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s))\<rbrace>"
   assumes b:
     "\<And>st :: 's state. \<lbrace>domain_sep_inv False st and P\<rbrace> f \<lbrace>\<lambda>_. domain_sep_inv False st\<rbrace>"
@@ -447,8 +447,8 @@ definition only_timer_irq_inv :: "irq \<Rightarrow> 'z :: state_ext state \<Righ
 
 lemma only_timer_irq_inv_pres:
   assumes a:
-  "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
-        f
+    "\<And>P. \<lbrace>(\<lambda>s. P (irq_masks (machine_state s))) and Q\<rbrace>
+          f
           \<lbrace>\<lambda>rv s. P (irq_masks (machine_state s))\<rbrace>"
   assumes b: "\<And>st :: 's state. \<lbrace>domain_sep_inv False st and P\<rbrace> f \<lbrace>\<lambda>_. domain_sep_inv False st\<rbrace>"
   shows "\<lbrace>only_timer_irq_inv irq (st :: 's state) and Q and P\<rbrace> f \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
@@ -502,7 +502,7 @@ lemma gets_irq_masks_equiv_valid:
 lemma irq_state_increment_reads_respects_memory:
   "equiv_valid_inv (equiv_machine_state P And equiv_irq_state)
                    (equiv_for (\<lambda>x. aag_can_affect_label aag l \<and>
-                 pasObjectAbs aag x \<in> subjectReads (pasPolicy aag) l)
+                                   pasObjectAbs aag x \<in> subjectReads (pasPolicy aag) l)
                               underlying_memory)
                    \<top> (modify (\<lambda>s. s\<lparr>irq_state := Suc (irq_state s)\<rparr>))"
   apply (simp add: equiv_valid_def2)
@@ -513,7 +513,7 @@ lemma irq_state_increment_reads_respects_memory:
 lemma irq_state_increment_reads_respects_device:
   "equiv_valid_inv (equiv_machine_state P And equiv_irq_state)
                    (equiv_for (\<lambda>x. aag_can_affect_label aag l \<and>
-                 pasObjectAbs aag x \<in> subjectReads (pasPolicy aag) l)
+                                   pasObjectAbs aag x \<in> subjectReads (pasPolicy aag) l)
                               device_state)
                    \<top> (modify (\<lambda>s. s\<lparr>irq_state := Suc (irq_state s)\<rparr>))"
   apply (simp add: equiv_valid_def2)
@@ -523,24 +523,24 @@ lemma irq_state_increment_reads_respects_device:
 
 lemma use_equiv_valid_inv:
   "\<lbrakk> x \<in> fst (f st); y \<in> fst (f s); g s; g st; I s st; P s st; equiv_valid_inv I P g f \<rbrakk>
-  \<Longrightarrow> fst x = fst y \<and> P (snd y) (snd x) \<and> I (snd y) (snd x)"
- apply (clarsimp simp add: equiv_valid_def spec_equiv_valid_def equiv_valid_2_def)
- apply (drule spec)+
- apply (erule impE)
- apply fastforce
- apply (drule(1) bspec | clarsimp)+
- done
+     \<Longrightarrow> fst x = fst y \<and> P (snd y) (snd x) \<and> I (snd y) (snd x)"
+  apply (clarsimp simp add: equiv_valid_def spec_equiv_valid_def equiv_valid_2_def)
+  apply (drule spec)+
+  apply (erule impE)
+   apply fastforce
+  apply (drule(1) bspec | clarsimp)+
+  done
 
 lemma equiv_valid_inv_conj_lift:
- assumes P: "equiv_valid_inv I (\<lambda>s s'. P s s') g f"
-     and P': "equiv_valid_inv I (\<lambda>s s'. P' s s') g f"
- shows "equiv_valid_inv I (\<lambda>s s'. P s s' \<and> P' s s') g f"
- apply (clarsimp simp add: equiv_valid_def spec_equiv_valid_def equiv_valid_2_def)
- apply (frule_tac st = t and s = st in use_equiv_valid_inv[OF _ _ _ _ _ _ P])
-  apply fastforce+
- apply (frule_tac st = t and s = st in use_equiv_valid_inv[OF _ _ _ _ _ _ P'])
-  apply fastforce+
- done
+  assumes P: "equiv_valid_inv I (\<lambda>s s'. P s s') g f"
+      and P': "equiv_valid_inv I (\<lambda>s s'. P' s s') g f"
+  shows "equiv_valid_inv I (\<lambda>s s'. P s s' \<and> P' s s') g f"
+  apply (clarsimp simp add: equiv_valid_def spec_equiv_valid_def equiv_valid_2_def)
+  apply (frule_tac st = t and s = st in use_equiv_valid_inv[OF _ _ _ _ _ _ P])
+       apply fastforce+
+  apply (frule_tac st = t and s = st in use_equiv_valid_inv[OF _ _ _ _ _ _ P'])
+       apply fastforce+
+  done
 
 lemma reset_work_units_reads_respects[wp]:
   "reads_respects aag l \<top> reset_work_units"
@@ -584,7 +584,7 @@ lemma preemption_point_def2:
 
 lemma all_children_descendants_equal:
   "\<lbrakk> equiv_for P id s t; all_children P s; all_children P t; P slot \<rbrakk>
-   \<Longrightarrow> descendants_of slot s = descendants_of slot t"
+     \<Longrightarrow> descendants_of slot s = descendants_of slot t"
   apply (clarsimp | rule equalityI)+
    apply (frule_tac p="(a, b)" and q="slot" and m=s in all_children_descendants_of)
      apply (simp)+
@@ -606,7 +606,7 @@ lemma all_children_descendants_equal:
 
 lemma cca_can_read:
   "\<lbrakk> valid_mdb s; valid_objs s; cdt_change_allowed' aag slot s; pas_refined aag s \<rbrakk>
-    \<Longrightarrow> aag_can_read aag (fst slot)"
+     \<Longrightarrow> aag_can_read aag (fst slot)"
   apply (frule(3) cdt_change_allowed_delete_derived)
   by (rule read_delder_thread_read_thread_rev[OF reads_lrefl])
 


### PR DESCRIPTION
Several proof directories on the rt branch had diverged from master in unexpected ways. This commit manually brings them back in sync.

The specific directories are access-control, bisim, dpolicy, drefine, and infoflow.