### PR TITLE
progress on aarch64 invariants

### DIFF
--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -42,6 +42,10 @@ lemma invs_valid_asid_table [elim!]:
   "invs s \<Longrightarrow> valid_asid_table s"
   by (simp add: invs_def valid_state_def valid_arch_state_def)
 
+lemma vspace_objs_of_arch_valid_obj:
+  "\<lbrakk> vspace_objs_of s p = Some ao; valid_objs s \<rbrakk> \<Longrightarrow> arch_valid_obj ao s"
+  by (fastforce simp: valid_obj_arch_valid_obj in_omonad vspace_obj_of_Some)
+
 lemmas pt_upd_simps[simp] = pt_upd_def[split_simps pt.split]
 
 lemma pt_range_upd:

--- a/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
@@ -141,8 +141,9 @@ lemma hyp_refs_of: "\<And>obj p. \<lbrakk> ko_at obj p s \<rbrakk> \<Longrightar
 lemma arch_valid_obj[detype_invs_proofs]:
     "\<And>p ao. \<lbrakk>ko_at (ArchObj ao) p s; arch_valid_obj ao s\<rbrakk>
        \<Longrightarrow> arch_valid_obj ao (detype (untyped_range cap) s)"
-  sorry (* FIXME AARCH64 VCPU
-  by simp *)
+  by (auto dest!: hyp_refs_of
+           simp: arch_valid_obj_def valid_vcpu_def
+           split: arch_kernel_obj.splits option.splits)
 
 lemma sym_hyp_refs_detype[detype_invs_proofs]:
   "sym_refs (state_hyp_refs_of (detype (untyped_range cap) s))"
@@ -181,8 +182,15 @@ lemma tcb_arch_detype[detype_invs_proofs]:
   "\<lbrakk>ko_at (TCB t) p s; valid_arch_tcb (tcb_arch t) s\<rbrakk>
       \<Longrightarrow> valid_arch_tcb (tcb_arch t) (detype (untyped_range cap) s)"
   apply (clarsimp simp: valid_arch_tcb_def)
-  sorry (* FIXME AARCH64 VCPU
-  done *)
+  apply (drule hyp_sym_refs_ko_atD, rule hyp_refsym)
+  apply clarsimp
+  apply rotate_tac (* do not pick typ_at *)
+  apply (drule live_okE)
+   apply (clarsimp simp: live_def hyp_live_def arch_live_def obj_at_def hyp_refs_of_def
+                         refs_of_ao_def vcpu_tcb_refs_def
+                  split: kernel_object.splits arch_kernel_obj.splits option.splits)
+  apply clarsimp
+  done
 
 declare arch_state_det[simp]
 
@@ -196,8 +204,7 @@ lemma pts_of_detype[simp]:
 
 lemma ptes_of_detype_Some[simp]:
   "(ptes_of (detype S s) pt_t p = Some pte) = (table_base pt_t p \<notin> S \<and> ptes_of s pt_t p = Some pte)"
-  sorry (* FIXME AARCH64
-  by (simp add: in_omonad ptes_of_def detype_def) *)
+  by (simp add: in_omonad ptes_of_def detype_def)
 
 lemma asid_pools_of_detype:
   "asid_pools_of (detype S s) = (\<lambda>p. if p\<in>S then None else asid_pools_of s p)"
@@ -218,16 +225,14 @@ lemma pool_for_asid_detype_Some[simp]:
 lemma vspace_for_pool_detype_Some[simp]:
   "(vspace_for_pool ap asid (\<lambda>p. if p \<in> S then None else pools p) = Some p) =
    (ap \<notin> S \<and> vspace_for_pool ap asid pools = Some p)"
-  sorry (* FIXME AARCH64
-  by (simp add: vspace_for_pool_def obind_def split: option.splits) *)
+  by (simp add: vspace_for_pool_def entry_for_pool_def obind_def split: option.splits)
 
 lemma vspace_for_asid_detype_Some[simp]:
   "(vspace_for_asid asid (detype S s) = Some p) =
    ((\<exists>ap. pool_for_asid asid s = Some ap \<and> ap \<notin> S) \<and> vspace_for_asid asid s = Some p)"
-  apply (simp add: vspace_for_asid_def obind_def asid_pools_of_detype split: option.splits)
-  apply (auto simp: pool_for_asid_def)
-  sorry (* FIXME AARCH64
-  done *)
+  by (simp add: vspace_for_asid_def obind_def asid_pools_of_detype entry_for_asid_def
+                entry_for_pool_def pool_for_asid_def
+           split: option.splits)
 
 lemma pt_walk_detype:
   "pt_walk level bot_level pt_ptr vref (ptes_of (detype S s)) = Some (bot_level, p) \<Longrightarrow>
@@ -239,9 +244,8 @@ lemma pt_walk_detype:
   apply (clarsimp simp: in_omonad split: if_split_asm)
   apply (erule disjE; clarsimp)
   apply (drule meta_spec, drule (1) meta_mp)
-  sorry (* FIXME AARCH64
   apply fastforce
-  done *)
+  done
 
 lemma vs_lookup_table:
   "vs_lookup_table level asid vref (detype S s) = Some (level, p) \<Longrightarrow>
@@ -270,29 +274,62 @@ lemma vs_lookup_target_preserved:
   apply (fastforce intro: no_obj_refs)
   done
 
+lemma asid_table_Some_not_untyped_range:
+  "asid_table s high_bits = Some table \<Longrightarrow> table \<notin> untyped_range cap"
+  using invs_valid_asid_pool_caps[OF invs]
+  by (auto simp add: valid_asid_pool_caps_def dest: no_obj_refs)
+
 lemma valid_asid_table:
   "valid_asid_table (detype (untyped_range cap) s)"
   using valid_arch_state
   apply (clarsimp simp: valid_asid_table_def valid_arch_state_def)
   apply (drule (1) subsetD)
-  apply (clarsimp simp: ran_def)
-  apply (subgoal_tac "valid_asid_pool_caps s")
-   prefer 2
-   using invs
-   apply (clarsimp simp: invs_def valid_state_def valid_arch_caps_def)
-  apply (simp add: valid_asid_pool_caps_def)
-  apply (erule allE, erule allE, erule (1) impE)
-  apply clarsimp
-  apply (drule no_obj_refs; simp)
+  apply (clarsimp simp: ran_def asid_table_Some_not_untyped_range)
   done
+
+lemma entry_for_pool_detype_Some[simp]:
+  "(entry_for_pool pool_ptr asid (\<lambda>p. if p \<in> S then None else pools p) = Some p) =
+   (pool_ptr \<notin> S \<and> entry_for_pool pool_ptr asid pools = Some p)"
+  by (clarsimp simp: entry_for_pool_def in_omonad)
+
+lemma vmid_for_asid_2_detype_Some[simp]:
+  "(vmid_for_asid_2 asid table (\<lambda>p. if p \<in> S then None else pools p) = Some p) =
+   ((\<exists>pool_ptr. table (asid_high_bits_of asid) = Some pool_ptr \<and> pool_ptr \<notin> S)
+    \<and> vmid_for_asid_2 asid table pools = Some p)"
+  by (fastforce simp: vmid_for_asid_def in_omonad)
 
 lemma vmid_inv_detype:
   "vmid_inv (detype (untyped_range cap) s)"
-  sorry (* FIXME AARCH64 *)
+  apply (prop_tac "vmid_inv s")
+   using valid_arch_state
+   apply (simp add: valid_arch_state_def)
+  apply (fastforce simp: vmid_inv_def is_inv_def asid_pools_of_detype vmid_for_asid_def
+                         in_omonad asid_table_Some_not_untyped_range)
+  done
+
+lemma vcpus_of_detype[simp]:
+  "(vcpus_of (detype S s) p = Some vcpu) = (p \<notin> S \<and> vcpus_of s p = Some vcpu)"
+  by (simp add: in_omonad detype_def)
+
+lemma vcpu_tcbs_of_detype[simp]:
+  "(vcpu_tcbs_of (detype S s) p = Some aobj) = (p \<notin> S \<and> vcpu_tcbs_of s p = Some aobj)"
+  by (simp add: in_omonad detype_def)
+
+(* FIXME AARCH64: move above obj_at_vcpu_hyp_live_of *)
+lemma obj_at_vcpu_hyp_live_of_s:
+  "obj_at (is_vcpu and hyp_live) p s = vcpu_hyp_live_of s p"
+  by (rule arg_cong[OF obj_at_vcpu_hyp_live_of, where f="\<lambda>x. x s"])
 
 lemma cur_vcpu_detype:
   "cur_vcpu (detype (untyped_range cap) s)"
-  sorry  (* FIXME AARCH64 VCPU *)
+  using valid_arch_state
+  apply (clarsimp simp: valid_arch_state_def cur_vcpu_def)
+  (* FIXME AARCH64: work around <| being an abbreviation for option_case *)
+  apply (case_tac "arm_current_vcpu (arch_state s)"; simp)
+  apply clarsimp
+  apply (frule obj_at_vcpu_hyp_live_of_s[THEN iffD2])
+  apply (clarsimp elim!: live_okE simp: hyp_live_strg split: option.splits)
+  done
 
 lemma valid_global_arch_objs:
   "valid_global_arch_objs (detype (untyped_range cap) s)"
@@ -323,8 +360,7 @@ proof (rule ccontr)
     using invs by (auto simp: invs_def valid_state_def valid_arch_state_def)
   ultimately
   have "\<exists>pt. pts_of s p = Some pt \<and> valid_vspace_obj level (PageTable pt) s"
-    sorry (* FIXME AARCH64
-    by (rule valid_vspace_objs_strongD) *)
+    by (blast dest!: valid_vspace_objs_strongD)
   with ap
   show False by (clarsimp simp: in_omonad)
 qed
@@ -353,32 +389,37 @@ lemma data_at_detype[simp]:
 
 lemma valid_vspace_obj:
   "\<lbrakk> valid_vspace_obj level ao s; vspace_objs_of s p = Some ao; \<exists>\<rhd>(level,p) s \<rbrakk> \<Longrightarrow>
-     valid_vspace_obj level ao (detype (untyped_range cap) s)"
+   valid_vspace_obj level ao (detype (untyped_range cap) s)"
   using invs
   apply (cases ao; clarsimp split del: if_split)
+   apply (rename_tac pool entry asid vref)
    apply (frule (1) vs_lookup_asid_pool_level, simp add: in_omonad vspace_obj_of_Some)
-   apply simp
-   sorry (* FIXME AARCH64
-   apply (drule vs_lookup_table_ap_step, simp add: in_omonad, assumption)
+   apply clarsimp
+   apply (drule_tac vs_lookup_table_ap_step[OF _ _ ranD])
+     apply (erule vspace_objs_of_Some_projections)
+    apply assumption
    apply clarsimp
    apply (erule (2) vs_lookup_target_preserved)
-  apply (rename_tac pt idx asid vref)
-  apply (case_tac "pt idx"; simp)
-   apply (frule_tac idx=idx in vs_lookup_table_pt_step; simp add: in_omonad)
-       apply (frule pspace_alignedD, fastforce)
-       apply (simp add: bit_simps)
-      apply (erule (1) vs_lookup_pt_level, simp add: in_omonad)
-     apply simp
-    apply fastforce
-   apply (fastforce elim: vs_lookup_target_preserved)
-  apply (frule_tac idx=idx in vs_lookup_table_pt_step; simp add: in_omonad)
-      apply (frule pspace_alignedD, fastforce)
-      apply (simp add: bit_simps)
+  apply (rename_tac pt pte asid vref)
+  apply (frule vspace_objs_of_arch_valid_obj, fastforce)
+  apply clarsimp
+  apply (case_tac pte; simp)
+   (* PagePTE *)
+   apply (frule_tac vs_lookup_table_pt_step; simp add: in_omonad)
+      apply (clarsimp simp: vspace_obj_of_def split: if_split_asm)
+      apply (drule pspace_alignedD; fastforce simp: pt_bits_def)
      apply (erule (1) vs_lookup_pt_level, simp add: in_omonad)
     apply simp
-   apply fastforce
-  apply (fastforce elim: vs_lookup_target_preserved)
-  done *)
+   apply (fastforce elim: vs_lookup_target_preserved)
+  (* PageTablePTE *)
+  apply clarsimp
+  apply (frule_tac vs_lookup_table_pt_step; simp add: in_omonad)
+     apply (clarsimp simp: vspace_obj_of_def split: if_split_asm)
+     apply (drule pspace_alignedD; fastforce simp: pt_bits_def)
+    apply (erule (1) vs_lookup_pt_level, simp add: in_omonad)
+   apply simp
+  apply (fastforce simp: pptr_from_pte_def elim: vs_lookup_target_preserved)
+  done
 
 lemma valid_vspace_obj_detype[detype_invs_proofs]: "valid_vspace_objs (detype (untyped_range cap) s)"
 proof -

--- a/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
@@ -50,38 +50,37 @@ lemma decode_tcb_invocation_empty_fail[wp]:
   by (simp add: decode_tcb_invocation_def split: gen_invocation_labels.splits invocation_label.splits
       | wp | intro conjI impI)+
 
-crunch (empty_fail) empty_fail[wp]: find_vspace_for_asid, check_vp_alignment (* FIXME AARCH64 , check_slot *)
+crunch (empty_fail) empty_fail[wp]: find_vspace_for_asid, check_vp_alignment, check_vspace_root
 
 lemma arch_decode_ARMASIDControlMakePool_empty_fail:
   "invocation_type label = ArchInvocationLabel ARMASIDControlMakePool
     \<Longrightarrow> empty_fail (arch_decode_invocation label b c d e f)"
   apply (simp add: arch_decode_invocation_def Let_def)
   apply (wpsimp simp: arch_decode_invocation_def decode_asid_pool_invocation_def)
-    apply (simp add: decode_asid_control_invocation_def)
-    apply (intro impI conjI allI)
-    apply (simp add: split_def)
-    apply wp
-     apply simp
-    apply (subst bindE_assoc[symmetric])
-    apply (rule empty_fail_bindE)
+     apply (simp add: decode_asid_control_invocation_def)
+     apply (intro impI conjI allI)
+     apply (simp add: split_def)
+     apply wp
+      apply simp
+     apply (subst bindE_assoc[symmetric])
+     apply (rule empty_fail_bindE)
       subgoal by (fastforce simp: empty_fail_def whenE_def throwError_def select_ext_def bindE_def
                                   bind_def return_def returnOk_def lift_def liftE_def fail_def
                                   gets_def get_def assert_def select_def
                            split: if_split_asm)
      apply wpsimp
-    apply (wpsimp simp: decode_frame_invocation_def)
-    subgoal sorry (* missing wp rule *)
-   subgoal sorry (* PTs *)
-  apply wpsimp
-  done (* FIXME AARCH64 VCPU and PageFlush invocations
-  apply (wpsimp simp: decode_page_table_invocation_def)
-  done *)
+    apply (wpsimp simp: decode_frame_invocation_def decode_fr_inv_flush_def Let_def)
+   apply (wpsimp simp: decode_vspace_invocation_def decode_vs_inv_flush_def
+                       decode_page_table_invocation_def Let_def)
+  apply (wpsimp simp: decode_vcpu_invocation_def)
+  done
 
 lemma arch_decode_ARMASIDPoolAssign_empty_fail:
   "invocation_type label = ArchInvocationLabel ARMASIDPoolAssign
     \<Longrightarrow> empty_fail (arch_decode_invocation label b c d e f)"
   unfolding arch_decode_invocation_def decode_page_table_invocation_def decode_frame_invocation_def
-            decode_asid_control_invocation_def
+            decode_asid_control_invocation_def decode_fr_inv_flush_def Let_def
+            decode_vspace_invocation_def decode_vs_inv_flush_def
   apply (wpsimp; wpsimp?)
   apply (simp add: decode_asid_pool_invocation_def)
   apply (intro impI allI conjI)
@@ -97,9 +96,8 @@ lemma arch_decode_ARMASIDPoolAssign_empty_fail:
    subgoal by (fastforce simp: empty_fail_def whenE_def throwError_def select_def bindE_def
                                bind_def return_def returnOk_def lift_def liftE_def select_ext_def
                                gets_def get_def assert_def fail_def)
-  sorry (* FIXME AARCH64
   apply wpsimp
-  done *)
+  done
 
 lemma arch_decode_invocation_empty_fail[wp]:
   "empty_fail (arch_decode_invocation label b c d e f)"
@@ -111,19 +109,20 @@ lemma arch_decode_invocation_empty_fail[wp]:
   apply (find_goal \<open>succeeds \<open>erule arch_decode_ARMASIDPoolAssign_empty_fail\<close>\<close>)
   apply ((simp add: arch_decode_ARMASIDControlMakePool_empty_fail
                     arch_decode_ARMASIDPoolAssign_empty_fail)+)[2]
-  sorry (* FIXME AARCH64 frame caps
-  by (all \<open>(wpsimp simp: arch_decode_invocation_def decode_asid_pool_invocation_def
-                         decode_asid_control_invocation_def decode_frame_invocation_def
-                         decode_page_table_invocation_def decode_pt_inv_map_def
-                         decode_fr_inv_map_def Let_def)\<close>) (* 15s *) *)
+  apply (all \<open>(wpsimp simp: arch_decode_invocation_def decode_asid_pool_invocation_def
+                            decode_asid_control_invocation_def decode_frame_invocation_def
+                            decode_page_table_invocation_def decode_pt_inv_map_def
+                            decode_fr_inv_map_def decode_fr_inv_flush_def
+                            decode_vspace_invocation_def decode_vs_inv_flush_def Let_def)\<close>) (* 15s *)
+  done
 
 end
 
 global_interpretation EmptyFail_AI_derive_cap?: EmptyFail_AI_derive_cap
-  proof goal_cases
+proof goal_cases
   interpret Arch .
   case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
+qed
 
 context Arch begin global_naming AARCH64
 
@@ -138,28 +137,20 @@ lemma empty_fail_pt_lookup_from_level[wp]:
 crunch (empty_fail) empty_fail[wp]: vcpu_update, vcpu_save_reg_range, vgic_update_lr, save_virt_timer
   (ignore: set_object get_object)
 
-lemma vcpu_save_empty_fail[wp,EmptyFail_AI_assms]: "empty_fail (vcpu_save a)"
-  apply (simp add:  vcpu_save_def)
-  sorry (* FIXME AARCH64 missing empty_fail_dsb
-  apply (wpsimp wp: empty_fail_dsb empty_fail_isb  simp: vgic_update_def)
-  done *)
-
 crunch (empty_fail) empty_fail[wp, EmptyFail_AI_assms]: maskInterrupt, empty_slot,
-    finalise_cap, preemption_point,
+    finalise_cap, preemption_point, vcpu_save,
     cap_swap_for_delete, decode_invocation
   (simp: Let_def catch_def split_def OR_choiceE_def mk_ef_def option.splits endpoint.splits
          notification.splits thread_state.splits sum.splits cap.splits arch_cap.splits
          kernel_object.splits vmpage_size.splits pte.splits bool.splits list.splits)
 
-crunch (empty_fail) empty_fail[wp, EmptyFail_AI_assms]: setRegister, setNextPC
-
 end
 
 global_interpretation EmptyFail_AI_rec_del?: EmptyFail_AI_rec_del
-  proof goal_cases
+proof goal_cases
   interpret Arch .
   case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
+qed
 
 context Arch begin global_naming AARCH64
 crunch (empty_fail) empty_fail[wp, EmptyFail_AI_assms]:
@@ -167,22 +158,22 @@ crunch (empty_fail) empty_fail[wp, EmptyFail_AI_assms]:
 end
 
 global_interpretation EmptyFail_AI_schedule_unit?: EmptyFail_AI_schedule_unit
-  proof goal_cases
+proof goal_cases
   interpret Arch .
   case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
+qed
 
 global_interpretation EmptyFail_AI_schedule_det?: EmptyFail_AI_schedule_det
-  proof goal_cases
+proof goal_cases
   interpret Arch .
   case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
+qed
 
 global_interpretation EmptyFail_AI_schedule?: EmptyFail_AI_schedule
-  proof goal_cases
+proof goal_cases
   interpret Arch .
   case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
+qed
 
 context Arch begin global_naming AARCH64
 
@@ -209,21 +200,21 @@ crunches possible_switch_to, handle_event, activate_thread
 end
 
 global_interpretation EmptyFail_AI_call_kernel_unit?: EmptyFail_AI_call_kernel_unit
-  proof goal_cases
+proof goal_cases
   interpret Arch .
   case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
+qed
 
 global_interpretation EmptyFail_AI_call_kernel_det?: EmptyFail_AI_call_kernel_det
-  proof goal_cases
+proof goal_cases
   interpret Arch .
   case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
+qed
 
 global_interpretation EmptyFail_AI_call_kernel?: EmptyFail_AI_call_kernel
-  proof goal_cases
+proof goal_cases
   interpret Arch .
   case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
+qed
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -221,9 +221,7 @@ crunch tcb_at_arch: unmap_page "\<lambda>s. P (ko_at (TCB tcb) t s)"
 lemmas unmap_page_tcb_at = unmap_page_tcb_at_arch
 
 lemma unmap_page_tcb_cap_valid:
-  "\<lbrace>\<lambda>s. tcb_cap_valid cap r s\<rbrace>
-    unmap_page sz asid vaddr pptr
-   \<lbrace>\<lambda>rv s. tcb_cap_valid cap r s\<rbrace>"
+  "unmap_page sz asid vaddr pptr \<lbrace>\<lambda>s. tcb_cap_valid cap r s\<rbrace>"
   apply (rule tcb_cap_valid_typ_st)
     apply wp
    apply (simp add: pred_tcb_at_def2)

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -1663,17 +1663,6 @@ lemma set_vm_root_empty[wp]:
      apply (wpsimp+ | rule hoare_conjI[rotated] hoare_drop_imp hoare_allI)+
   done *)
 
-lemma set_asid_pool_empty[wp]:
-  "\<lbrace>obj_at (empty_table S) word\<rbrace> set_asid_pool x2 pool' \<lbrace>\<lambda>xb. obj_at (empty_table S) word\<rbrace>"
-  by (wpsimp wp: set_object_wp simp: set_asid_pool_def obj_at_def in_omonad empty_table_def)
-
-lemma delete_asid_empty_table_pt[wp]:
-  "delete_asid a word \<lbrace>\<lambda>s. obj_at (empty_table S) word s\<rbrace>"
-   apply (simp add: delete_asid_def)
-   apply wpsimp
-   sorry (* FIXME AARCH64
-   done *)
-
 lemma ucast_less_shiftl_helper3:
   "\<lbrakk> len_of TYPE('b) + 3 < len_of TYPE('a); 2 ^ (len_of TYPE('b) + 3) \<le> n\<rbrakk>
     \<Longrightarrow> (ucast (x :: 'b::len word) << 3) < (n :: 'a::len word)"

--- a/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
@@ -104,12 +104,11 @@ lemma no_cap_to_obj_with_diff_IRQHandler_ARCH[Interrupt_AI_asms]:
 lemma (* set_irq_state_valid_cap *)[Interrupt_AI_asms]:
   "\<lbrace>valid_cap cap\<rbrace> set_irq_state IRQSignal irq \<lbrace>\<lambda>rv. valid_cap cap\<rbrace>"
   apply (clarsimp simp: set_irq_state_def)
-  sorry (* FIXME AARCH64 missing crunch
   apply (wp do_machine_op_valid_cap)
   apply (auto simp: valid_cap_def valid_untyped_def
              split: cap.splits option.splits arch_cap.splits
          split del: if_split)
-  done *)
+  done
 
 crunch valid_global_refs[Interrupt_AI_asms]: set_irq_state "valid_global_refs"
 

--- a/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
@@ -143,7 +143,7 @@ lemma invoke_irq_handler_invs'[Interrupt_AI_asms]:
    done
   show ?thesis
   apply (cases i, simp_all)
-    apply (wp dmo_plic_complete_claim)
+    apply (wp dmo_plic_complete_claim maskInterrupt_invs)
     apply simp+
    apply (rename_tac irq cap prod)
    apply (rule hoare_pre)

--- a/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
@@ -1849,6 +1849,12 @@ lemma pte_at_eq:
   "pte_at pt_t p s = (ptes_of s pt_t p \<noteq> None)"
   by (auto simp: obj_at_def pte_at_def in_omonad)
 
+lemma vspace_objs_of_Some_projections[simp]:
+  "vspace_objs_of s p = Some (ASIDPool pool) \<Longrightarrow> asid_pools_of s p = Some pool"
+  "vspace_objs_of s p = Some (PageTable pt) \<Longrightarrow> pts_of s p = Some pt"
+  (* no projections for data pages *)
+  by (auto simp: in_omonad vspace_obj_of_def split: if_splits)
+
 lemma valid_vspace_objsI [intro?]:
   "(\<And>p ao asid vref level.
        \<lbrakk> vs_lookup_table level asid (vref_for_level vref (level+1)) s = Some (level, p);
@@ -2521,7 +2527,7 @@ lemma pool_for_asid_and_mask[simp]:
 
 lemma vs_lookup_table_ap_step:
   "\<lbrakk> vs_lookup_table asid_pool_level asid vref s = Some (asid_pool_level, p);
-     asid_pools_of s p = Some ap; ap ap_idx = Some entry \<rbrakk> \<Longrightarrow>
+     asid_pools_of s p = Some ap; \<exists>ap_idx. ap ap_idx = Some entry \<rbrakk> \<Longrightarrow>
    \<exists>asid'. vs_lookup_target asid_pool_level asid' vref s = Some (asid_pool_level, ap_vspace entry)"
   apply (clarsimp simp: vs_lookup_target_def vs_lookup_slot_def in_omonad ran_def)
   apply (rule_tac x="asid && ~~mask asid_low_bits || ucast ap_idx" in exI)

--- a/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -434,21 +435,21 @@ crunch obj_at[wp, Ipc_AI_assms]:  make_arch_fault_msg "\<lambda>s. P (obj_at P' 
 
 lemma dmo_addressTranslateS1_valid_machine_state[wp]:
   "do_machine_op (addressTranslateS1 addr) \<lbrace> valid_machine_state \<rbrace>"
-  sorry (* FIXME AARCH64 *)
+  by (wpsimp wp: dmo_valid_machine_state)
 
 crunch vms[wp, Ipc_AI_assms]: make_arch_fault_msg valid_machine_state
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 lemma dmo_addressTranslateS1_valid_irq_states[wp]:
   "do_machine_op (addressTranslateS1 addr) \<lbrace> valid_irq_states \<rbrace>"
-  sorry (* FIXME AARCH64 *)
+  by (wpsimp wp: dmo_valid_irq_states)
 
 crunch valid_irq_states[wp, Ipc_AI_assms]: make_arch_fault_msg "valid_irq_states"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 lemma dmo_addressTranslateS1_cap_refs_respects_device_region[wp]:
   "do_machine_op (addressTranslateS1 addr) \<lbrace> cap_refs_respects_device_region \<rbrace>"
-  sorry (* FIXME AARCH64 *)
+  by (wpsimp wp: cap_refs_respects_device_region_dmo)
 
 crunch cap_refs_respects_device_region[wp, Ipc_AI_assms]: make_arch_fault_msg "cap_refs_respects_device_region"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
@@ -467,7 +468,7 @@ named_theorems Ipc_AI_cont_assms
 
 lemma dmo_addressTranslateS1_pspace_respects_device_region[wp]:
   "do_machine_op (addressTranslateS1 addr) \<lbrace> pspace_respects_device_region \<rbrace>"
-  sorry (* FIXME AARCH64 *)
+  by (wpsimp wp: pspace_respects_device_region_dmo)
 
 crunch pspace_respects_device_region[wp]: make_fault_msg "pspace_respects_device_region"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
@@ -516,8 +517,8 @@ lemma valid_arch_mdb_cap_swap:
 end
 
 interpretation Ipc_AI_cont?: Ipc_AI_cont
-  proof goal_cases
+proof goal_cases
   interpret Arch .
   case 1 show ?case by (unfold_locales;(fact Ipc_AI_cont_assms)?)
-  qed
+qed
 end

--- a/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
@@ -108,9 +108,8 @@ lemma dmo_eq_kernel_restricted [wp, Retype_AI_assms]:
   "\<lbrace>\<lambda>s. equal_kernel_mappings (kheap_update (f (kheap s)) s)\<rbrace>
        do_machine_op m
    \<lbrace>\<lambda>rv s. equal_kernel_mappings (kheap_update (f (kheap s)) s)\<rbrace>"
-  sorry (* FIXME AARCH64
-  unfolding do_machine_op_def equal_kernel_mappings_def has_kernel_mappings_def
-  by (wpsimp simp: in_omonad vspace_for_asid_def pool_for_asid_def) *)
+  unfolding do_machine_op_def equal_kernel_mappings_def
+  by (wpsimp simp: in_omonad vspace_for_asid_def pool_for_asid_def)
 
 definition
   "post_retype_invs_check tp \<equiv> False"
@@ -317,12 +316,11 @@ lemma pts_of:
 
 lemma pts_of':
   "pts_of s' p = Some pt \<Longrightarrow>
-   pts_of s p = Some pt \<or> pt = (empty_pt (pt_type pt_t)) \<and> p \<in> set (retype_addrs ptr ty n us)"
-  sorry (* FIXME AARCH64
+   pts_of s p = Some pt \<or> pt = (empty_pt (pt_type pt)) \<and> p \<in> set (retype_addrs ptr ty n us)"
   apply (clarsimp simp: in_opt_map_eq s'_def ps_def split: if_split_asm)
-  apply (simp add: default_object_def default_arch_object_def tyunt
+  apply (auto simp: default_object_def default_arch_object_def empty_pt_def tyunt
               split: apiobject_type.splits aobject_type.splits)
-  done *)
+  done
 
 lemma valid_asid_table:
   "valid_asid_table s \<Longrightarrow> valid_asid_table s'"
@@ -334,19 +332,17 @@ lemma valid_global_arch_objs:
 
 lemma ptes_of:
   "ptes_of s pt_t p = Some pte \<Longrightarrow> ptes_of s' pt_t p = Some pte"
-  sorry (* FIXME AARCH64
-  by (simp add: pte_of_def obind_def pts_of split: option.splits) *)
+  by (auto simp: level_pte_of_def obind_def pts_of split: option.splits)
 
 lemma default_empty:
   "default_object ty dev us = ArchObj (PageTable pt) \<Longrightarrow> pt = (empty_pt (pt_type pt))"
-  sorry (* FIXME AARCH64 ^exists pt_t?
-  by (simp add: default_object_def default_arch_object_def tyunt
-           split: apiobject_type.splits aobject_type.splits) *)
+  by (auto simp: default_object_def default_arch_object_def empty_pt_def tyunt
+           split: apiobject_type.splits aobject_type.splits)
 
 lemma ptes_of':
   "ptes_of s' pt_t p = Some pte \<Longrightarrow> ptes_of s pt_t p = Some pte \<or> pte = InvalidPTE"
-  sorry (* FIXME AARCH64
-  by (fastforce simp: ptes_of_def in_omonad s'_def ps_def split: if_splits dest: default_empty) *)
+  by (cases pt_t;
+      fastforce simp: level_pte_of_def in_omonad s'_def ps_def split: if_splits dest: default_empty)
 
 lemma pt_walk:
   "pt_walk top_level bot_level pt vref (ptes_of s) = Some (level, p) \<Longrightarrow>
@@ -397,44 +393,61 @@ lemma global_no_retype:
 
 lemma global_pts_no_retype:
   "valid_global_refs s \<Longrightarrow> global_pt s \<notin> set (retype_addrs ptr ty n us)"
-  sorry (* FIXME AARCH64
-  by (drule riscv_global_pts_global_ref, erule global_no_retype) *)
+  by (erule global_no_retype[rotated], simp add: valid_global_refs_def)
 
 lemma vcpu_hyp_live_of':
   "vcpu_hyp_live_of s' = vcpu_hyp_live_of s"
-  sorry (* FIXME AARCH64 VCPU *)
+  apply (clarsimp simp: in_opt_map_eq s'_def ps_def split: if_split_asm)
+  apply (clarsimp del: ext intro!: ext split: option.splits)
+  apply (rule iffI; clarsimp simp: in_omonad split: if_splits)
+   apply (fastforce simp: default_object_def default_arch_object_def default_vcpu_def tyunt
+                    split: apiobject_type.splits aobject_type.splits)
+  apply (erule (1) pspace_no_overlapC[OF orth _ _ cover vp])
+  done
+
+lemma dom_vmid_for_asid[simplified]:
+  "dom (vmid_for_asid s') = dom (vmid_for_asid s)"
+  apply (clarsimp simp: dom_def s'_def ps_def obj_at_def vmid_for_asid_def in_omonad
+                  split: if_split_asm)
+  apply (rule set_eqI)
+  apply (rule iffI; clarsimp simp: entry_for_pool_def in_omonad split: if_split_asm)
+   apply (fastforce simp: default_object_def default_arch_object_def default_vcpu_def tyunt
+                    split: apiobject_type.splits aobject_type.splits)
+  apply (fastforce elim: pspace_no_overlapC[OF orth _ _ cover vp])
+  done
 
 lemma vmid_inv':
   "vmid_inv s \<Longrightarrow> vmid_inv s'"
-  sorry (* FIXME AARCH64 *)
+  by (clarsimp simp: vmid_inv_def is_inv_def dom_vmid_for_asid)
+     (fastforce simp: s'_def ps_def vmid_for_asid_def entry_for_pool_def in_omonad
+                elim!: pspace_no_overlapC[OF orth _ _ cover vp])
 
 lemma valid_arch_state:
   "valid_arch_state s \<Longrightarrow> valid_arch_state s'"
   apply (simp add: valid_arch_state_def valid_asid_table vcpu_hyp_live_of' vmid_inv'
+                   valid_global_arch_objs
               del: arch_state)
   apply simp
-  sorry (* FIXME AARCH64 *)
+  done
 
 lemma vspace_for_pool1:
   "(vspace_for_pool asid p (asid_pools_of s) = Some pt) \<Longrightarrow>
    vspace_for_pool asid p (asid_pools_of s') = Some pt"
-  sorry (* FIXME AARCH64
-  by (simp add: vspace_for_pool_def asid_pools obind_def split: option.splits) *)
+  by (simp add: vspace_for_pool_def entry_for_pool_def asid_pools obind_def split: option.splits)
 
 lemma vspace_for_pool2:
   "vspace_for_pool asid p (asid_pools_of s') = Some pt \<Longrightarrow>
    vspace_for_pool asid p (asid_pools_of s) = Some pt"
-  apply (clarsimp simp: vspace_for_pool_def in_omonad s'_def ps_def split: if_split_asm)
-  sorry (* FIXME AARCH64
+  apply (clarsimp simp: vspace_for_pool_def entry_for_pool_def in_omonad s'_def ps_def
+                  split: if_split_asm)
   apply (clarsimp simp: default_object_def default_arch_object_def tyunt
                   split: apiobject_type.splits aobject_type.splits)
-  done *)
+  done
 
 lemma vspace_for_pool[simp]:
   "(vspace_for_pool asid p (asid_pools_of s') = Some pt) =
    (vspace_for_pool asid p (asid_pools_of s) = Some pt)"
-  sorry (* FIXME AARCH64
-  by (rule iffI, erule vspace_for_pool2, erule vspace_for_pool1) *)
+  by (rule iffI, erule vspace_for_pool2, erule vspace_for_pool1)
 
 lemma vs_lookup_table':
   "(vs_lookup_table level asid vref s' = Some (level, p)) =
@@ -458,10 +471,8 @@ lemma wellformed_default_obj[Retype_AI_assms]:
    "\<lbrakk> ptr' \<notin> set (retype_addrs ptr ty n us);
       kheap s ptr' = Some (ArchObj ao); arch_valid_obj ao s\<rbrakk> \<Longrightarrow>
     arch_valid_obj ao s'"
-  sorry (* FIXME AARCH64 VCPU: valid_vcpu s'
-  apply (cases ao; clarsimp elim!: obj_at_pres
-                   split: arch_kernel_obj.splits option.splits)+
-  done *)
+  by (cases ao; clarsimp elim!: obj_at_pres simp: valid_vcpu_def
+                         split: arch_kernel_obj.splits option.splits)+
 
 end
 
@@ -471,16 +482,13 @@ context retype_region_proofs_arch begin
 lemma hyp_refs_eq:
   "state_hyp_refs_of s' = state_hyp_refs_of s"
   unfolding s'_def ps_def
-  sorry (* FIXME AARCH64 VCPU
   apply (rule ext)
   apply (clarsimp simp: state_hyp_refs_of_def orthr split: option.splits)
   apply (cases ty; simp add: tyunt default_object_def default_tcb_def hyp_refs_of_def tcb_hyp_refs_def
                              default_arch_tcb_def)
-  apply (rename_tac ao)
-  apply (clarsimp simp: refs_of_a_def ARM_HYP.vcpu_tcb_refs_def default_arch_object_def
-                        ARM_A.default_vcpu_def
+  apply (clarsimp simp: refs_of_ao_def vcpu_tcb_refs_def default_arch_object_def default_vcpu_def
                   split: aobject_type.splits)
-  done *)
+  done
 
 lemma obj_at_valid_pte:
   "\<lbrakk>valid_pte level pte s; \<And>P p. obj_at P p s \<Longrightarrow> obj_at P p s'\<rbrakk>
@@ -507,34 +515,41 @@ lemma valid_vspace_obj_pres:
 
 lemma valid_vspace_objs':
   assumes va: "valid_vspace_objs s"
+  assumes asid: "valid_asid_table s"
+  assumes pspace: "pspace_aligned s"
   shows "valid_vspace_objs s'"
 proof
   fix level p ao asid vref
   assume p: "vs_lookup_table level asid (vref_for_level vref (level + 1)) s' = Some (level, p)"
   assume vref: "vref \<in> user_region"
-  assume "vspace_objs_of s' p = Some ao"
-  hence "vspace_objs_of s p = Some ao \<or> ArchObj ao = default_object ty dev us"
-    by (simp add: ps_def obj_at_def s'_def in_opt_map_eq vspace_obj_of_Some split: if_split_asm)
-  moreover
-  { assume "ArchObj ao = default_object ty dev us" with tyunt
-    have "valid_vspace_obj level ao s'"
-      apply -
-      apply (rule valid_vspace_obj_default; assumption?)
-      sorry (* FIXME AARCH64: this argument is no longer valid; we have to show that p cannot
-                              be on a  lookup path in retype *)
-  }
-  moreover
-  { assume "vspace_objs_of s p = Some ao"
-    with va p vref
-    have "valid_vspace_obj level ao s"
-      by (auto simp: vs_lookup_table' vref_for_level_user_region elim: valid_vspace_objsD)
-    hence "valid_vspace_obj level ao s'"
-      by (rule valid_vspace_obj_pres)
-  }
-  ultimately
-  show "valid_vspace_obj level ao s'" by blast
-qed
+  assume vsp: "vspace_objs_of s' p = Some ao"
 
+  { assume "level = asid_pool_level"
+    hence "valid_vspace_obj level ao s'" using va p vref vsp asid
+      apply (simp add: vs_lookup_table')
+      apply (frule (1) vs_lookup_asid_pool)
+      apply (rule valid_vspace_obj_pres)
+      apply (auto dest!: valid_vspace_objsD
+                  simp: s'_def ps_def opt_map_def vref_for_level_user_region
+                  split: option.splits if_split_asm
+                  elim!: pspace_no_overlapC[OF orth _ _ cover vp])
+      done
+  }
+  moreover {
+    assume "level \<le> max_pt_level"
+    hence "valid_vspace_obj level ao s'" using va p vref vsp pspace asid
+      apply (simp add: vs_lookup_table')
+      apply (drule (1) valid_vspace_objs_strongD; simp add: vref_for_level_user_region)
+      apply (clarsimp simp: opt_map_def split: option.splits)
+      apply (subst (asm) s'_def, subst (asm) ps_def)
+      apply (clarsimp simp: split: if_split_asm)
+       apply (erule (1) pspace_no_overlapC[OF orth _ _ cover vp])
+      apply (fastforce intro: obj_at_valid_pte[OF _ obj_at_pres])
+      done
+  }
+  ultimately show "valid_vspace_obj level ao s'"
+    by fastforce
+qed
 
 sublocale retype_region_proofs_gen?: retype_region_proofs_gen
   by (unfold_locales,
@@ -700,8 +715,12 @@ lemma valid_asid_map:
 
 lemma vspace_for_asid:
   "vspace_for_asid asid s' = Some pt \<Longrightarrow> vspace_for_asid asid s = Some pt"
-  sorry (* FIXME AARCH64
-  by (clarsimp simp: vspace_for_asid_def in_omonad pool_for_asid_def) *)
+  apply (clarsimp simp: s'_def ps_def vspace_for_asid_def entry_for_asid_def pool_for_asid_def
+                        in_omonad entry_for_pool_def
+                  split: if_split_asm)
+  apply (fastforce simp: default_object_def default_arch_object_def tyunt
+                   split: apiobject_type.splits aobject_type.splits)
+  done
 
 lemma equal_kernel_mappings:
   "equal_kernel_mappings s'"
@@ -803,7 +822,8 @@ lemma post_retype_invs:
                      valid_global_refs valid_arch_state
                      valid_irq_node_def obj_at_pres
                      valid_arch_caps valid_global_objs_def
-                     valid_vspace_objs' valid_irq_handlers
+                     valid_vspace_objs'[OF _ valid_arch_state_asid_table valid_pspace_aligned2]
+                     valid_irq_handlers
                      valid_mdb_rep2 mdb_and_revokable
                      valid_pspace cur_tcb only_idle
                      valid_kernel_mappings valid_asid_map
@@ -821,7 +841,8 @@ sublocale retype_region_proofs_invs?: retype_region_proofs_invs
   where region_in_kernel_window = region_in_kernel_window
     and post_retype_invs_check = post_retype_invs_check
     and post_retype_invs = post_retype_invs
-  using post_retype_invs valid_cap valid_global_refs valid_arch_state valid_vspace_objs'
+  using post_retype_invs valid_cap valid_global_refs valid_arch_state
+        valid_vspace_objs'[OF _ invs_valid_asid_table invs_psp_aligned]
   by unfold_locales (auto simp: s'_def ps_def)
 
 (* local_setup \<open>note_new_facts pre_ctxt_1\<close> *)

--- a/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
@@ -31,26 +31,22 @@ lemma dmo_mapM_storeWord_0_invs[wp,Schedule_AI_asms]:
 global_naming Arch
 
 lemma arch_stt_invs [wp,Schedule_AI_asms]:
-  "\<lbrace>invs\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"
+  "arch_switch_to_thread t' \<lbrace>invs\<rbrace>"
   apply (wpsimp simp: arch_switch_to_thread_def)
   by (rule sym_refs_VCPU_hyp_live; fastforce)
 
 lemma arch_stt_tcb [wp,Schedule_AI_asms]:
-  "\<lbrace>tcb_at t'\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. tcb_at t'\<rbrace>"
+  "arch_switch_to_thread t' \<lbrace>tcb_at t'\<rbrace>"
   by (wpsimp simp: arch_switch_to_thread_def wp: tcb_at_typ_at)
 
 lemma arch_stt_runnable[Schedule_AI_asms]:
-  "\<lbrace>st_tcb_at runnable t\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>r . st_tcb_at runnable t\<rbrace>"
+  "arch_switch_to_thread t \<lbrace>st_tcb_at runnable t\<rbrace>"
   by (wpsimp simp: arch_switch_to_thread_def)
 
 lemma idle_strg:
   "thread = idle_thread s \<and> invs s \<Longrightarrow> invs (s\<lparr>cur_thread := thread\<rparr>)"
   by (clarsimp simp: invs_def valid_state_def valid_idle_def cur_tcb_def
                      pred_tcb_at_def valid_machine_state_def obj_at_def is_tcb_def)
-
-lemma set_vcpu_ct[wp]:
-  "\<lbrace>\<lambda>s. P (cur_thread s)\<rbrace> set_vcpu v v' \<lbrace>\<lambda>_ s. P (cur_thread s)\<rbrace>"
-  by (wpsimp simp: set_vcpu_def wp: get_object_wp)
 
 crunches
   vcpu_update, vgic_update, vgic_update_lr, vcpu_restore_reg_range, vcpu_save_reg_range,
@@ -60,11 +56,11 @@ crunches
   (wp: mapM_x_wp mapM_wp subset_refl)
 
 lemma arch_stit_invs[wp, Schedule_AI_asms]:
-  "\<lbrace>invs\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>r. invs\<rbrace>"
+  "arch_switch_to_idle_thread \<lbrace>invs\<rbrace>"
   by (wpsimp simp: arch_switch_to_idle_thread_def)
 
 lemma arch_stit_tcb_at[wp]:
-  "\<lbrace>tcb_at t\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>r. tcb_at t\<rbrace>"
+  "arch_switch_to_idle_thread \<lbrace>tcb_at t\<rbrace>"
   by (wpsimp simp: arch_switch_to_idle_thread_def wp: tcb_at_typ_at)
 
 crunches set_vm_root
@@ -73,19 +69,19 @@ crunches set_vm_root
   (simp: crunch_simps wp: hoare_drop_imps)
 
 lemma arch_stit_activatable[wp, Schedule_AI_asms]:
-  "\<lbrace>ct_in_state activatable\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>rv . ct_in_state activatable\<rbrace>"
+  "arch_switch_to_idle_thread \<lbrace>ct_in_state activatable\<rbrace>"
   apply (clarsimp simp: arch_switch_to_idle_thread_def)
   apply (wpsimp simp: ct_in_state_def wp: ct_in_state_thread_state_lift)
   done
 
 lemma stit_invs [wp,Schedule_AI_asms]:
-  "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv. invs\<rbrace>"
+  "switch_to_idle_thread \<lbrace>invs\<rbrace>"
   apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def)
   apply (wpsimp|strengthen idle_strg)+
   done
 
 lemma stit_activatable[Schedule_AI_asms]:
-  "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv . ct_in_state activatable\<rbrace>"
+  "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>_. ct_in_state activatable\<rbrace>"
   apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def)
   apply (wpsimp simp: ct_in_state_def)
   apply (clarsimp simp: invs_def valid_state_def cur_tcb_def valid_idle_def
@@ -93,7 +89,7 @@ lemma stit_activatable[Schedule_AI_asms]:
   done
 
 lemma stt_invs [wp,Schedule_AI_asms]:
-  "\<lbrace>invs\<rbrace> switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"
+  "switch_to_thread t' \<lbrace>invs\<rbrace>"
   apply (simp add: switch_to_thread_def)
   apply wp
      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
@@ -109,17 +105,17 @@ lemma stt_invs [wp,Schedule_AI_asms]:
 end
 
 interpretation Schedule_AI_U?: Schedule_AI_U
-  proof goal_cases
+proof goal_cases
   interpret Arch .
   case 1 show ?case
-  by (intro_locales; (unfold_locales; fact Schedule_AI_asms)?)
-  qed
+    by (intro_locales; (unfold_locales; fact Schedule_AI_asms)?)
+qed
 
 interpretation Schedule_AI?: Schedule_AI
-  proof goal_cases
+proof goal_cases
   interpret Arch .
   case 1 show ?case
-  by (intro_locales; (unfold_locales; fact Schedule_AI_asms)?)
-  qed
+    by (intro_locales; (unfold_locales; fact Schedule_AI_asms)?)
+qed
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
@@ -37,17 +37,11 @@ lemma arch_stt_invs [wp,Schedule_AI_asms]:
 
 lemma arch_stt_tcb [wp,Schedule_AI_asms]:
   "\<lbrace>tcb_at t'\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. tcb_at t'\<rbrace>"
-  apply (simp add: arch_switch_to_thread_def)
-  apply (wp)
-  sorry (* FIXME AARCH64 VCPU
-  done *)
+  by (wpsimp simp: arch_switch_to_thread_def wp: tcb_at_typ_at)
 
 lemma arch_stt_runnable[Schedule_AI_asms]:
   "\<lbrace>st_tcb_at runnable t\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>r . st_tcb_at runnable t\<rbrace>"
-  apply (simp add: arch_switch_to_thread_def)
-  apply wp
-  sorry (* FIXME AARCH64 VCPU
-  done *)
+  by (wpsimp simp: arch_switch_to_thread_def)
 
 lemma idle_strg:
   "thread = idle_thread s \<and> invs s \<Longrightarrow> invs (s\<lparr>cur_thread := thread\<rparr>)"
@@ -67,15 +61,11 @@ crunches
 
 lemma arch_stit_invs[wp, Schedule_AI_asms]:
   "\<lbrace>invs\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>r. invs\<rbrace>"
-  sorry (* FIXME AARCH64 VSpace & VCPU
-  by (wpsimp simp: arch_switch_to_idle_thread_def) *)
+  by (wpsimp simp: arch_switch_to_idle_thread_def)
 
 lemma arch_stit_tcb_at[wp]:
   "\<lbrace>tcb_at t\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>r. tcb_at t\<rbrace>"
-  apply (simp add: arch_switch_to_idle_thread_def )
-  apply (wp tcb_at_typ_at)
-  sorry (* FIXME AARCH64 VSpace & VCPU
-  done *)
+  by (wpsimp simp: arch_switch_to_idle_thread_def wp: tcb_at_typ_at)
 
 crunches set_vm_root
   for ct[wp]: "\<lambda>s. P (cur_thread s)"
@@ -86,24 +76,21 @@ lemma arch_stit_activatable[wp, Schedule_AI_asms]:
   "\<lbrace>ct_in_state activatable\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>rv . ct_in_state activatable\<rbrace>"
   apply (clarsimp simp: arch_switch_to_idle_thread_def)
   apply (wpsimp simp: ct_in_state_def wp: ct_in_state_thread_state_lift)
-  sorry (* FIXME AARCH64 VCPU
-  done *)
+  done
 
 lemma stit_invs [wp,Schedule_AI_asms]:
   "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv. invs\<rbrace>"
   apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def)
   apply (wpsimp|strengthen idle_strg)+
-  sorry (* FIXME AARCH64 VSpace & VCPU
-  done *)
+  done
 
 lemma stit_activatable[Schedule_AI_asms]:
   "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv . ct_in_state activatable\<rbrace>"
   apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def)
-  apply (wp | simp add: ct_in_state_def)+
-  sorry (* FIXME AARCH64 VCPU
+  apply (wpsimp simp: ct_in_state_def)
   apply (clarsimp simp: invs_def valid_state_def cur_tcb_def valid_idle_def
                  elim!: pred_tcb_weaken_strongerE)
-  done *)
+  done
 
 lemma stt_invs [wp,Schedule_AI_asms]:
   "\<lbrace>invs\<rbrace> switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"

--- a/proof/invariant-abstract/AARCH64/ArchSyscall_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSyscall_AI.thy
@@ -65,7 +65,7 @@ lemma do_machine_op_getIFSR_inv[wp]:
   by (rule dmo_inv) wp
 
 lemma hv_invs[wp, Syscall_AI_assms]: "\<lbrace>invs\<rbrace> handle_vm_fault t' flt \<lbrace>\<lambda>r. invs\<rbrace>"
-  unfolding handle_vm_fault_def by (cases flt; wpsimp)
+  unfolding handle_vm_fault_def by (cases flt; wpsimp wp: dmo_invs_lift)
 
 lemma hv_inv_ex [Syscall_AI_assms]:
   "\<lbrace>P\<rbrace> handle_vm_fault t vp \<lbrace>\<lambda>_ _. True\<rbrace>, \<lbrace>\<lambda>_. P\<rbrace>"

--- a/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
@@ -21,23 +21,19 @@ lemma activate_idle_invs[Tcb_AI_asms]:
   by (simp add: arch_activate_idle_thread_def)
 
 
-lemma empty_fail_getRegister [intro!, simp, Tcb_AI_asms]:
-  "empty_fail (getRegister r)"
-  by (simp add: getRegister_def)
-
+declare getRegister_empty_fail [Tcb_AI_asms]
 
 lemma same_object_also_valid:  (* arch specific *)
   "\<lbrakk> same_object_as cap cap'; s \<turnstile> cap'; wellformed_cap cap;
      cap_asid cap = None \<or> (\<exists>asid. cap_asid cap = Some asid \<and> 0 < asid \<and> asid \<le> 2^asid_bits - 1);
      cap_vptr cap = None; cap_asid_base cap = None \<rbrakk>
      \<Longrightarrow> s \<turnstile> cap"
-  sorry (* FIXME AARCH64
   apply (cases cap,
          (clarsimp simp: same_object_as_def is_cap_simps cap_asid_def
                          wellformed_cap_def wellformed_acap_def
                          valid_cap_def bits_of_def cap_aligned_def
                    split: cap.split_asm arch_cap.split_asm option.splits)+)
-  done *)
+  done
 
 lemma same_object_obj_refs[Tcb_AI_asms]:
   "\<lbrakk> same_object_as cap cap' \<rbrakk>
@@ -140,11 +136,10 @@ lemma finalise_cap_not_cte_wp_at[Tcb_AI_asms]:
             | rule impI
             | rule hoare_drop_imps)+
      apply (clarsimp simp: ball_ran_eq x)
-    sorry (* FIXME AARCH64 VCPU
     apply (wp delete_one_caps_of_state
          | rule impI
          | simp add: deleting_irq_handler_def get_irq_slot_def x ball_ran_eq)+
-    done *)
+    done
 
 
 lemma table_cap_ref_max_free_index_upd[simp,Tcb_AI_asms]:
@@ -156,10 +151,10 @@ end
 global_interpretation Tcb_AI_1?: Tcb_AI_1
   where state_ext_t = state_ext_t
   and is_cnode_or_valid_arch = is_cnode_or_valid_arch
-  proof goal_cases
-    interpret Arch .
-    case 1 show ?case by (unfold_locales; (fact Tcb_AI_asms)?)
-  qed
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact Tcb_AI_asms)?)
+qed
 
 context Arch begin global_naming AARCH64
 
@@ -272,16 +267,13 @@ lemma tc_invs[Tcb_AI_asms]:
         | strengthen use_no_cap_to_obj_asid_strg use_no_cap_to_obj_asid_strg[simplified conj_comms]
                      tcb_cap_always_valid_strg[where p="tcb_cnode_index 0"]
                      tcb_cap_always_valid_strg[where p="tcb_cnode_index (Suc 0)"])+)
-  apply (intro conjI impI; clarsimp?;
-     (clarsimp simp: tcb_at_cte_at_0 tcb_at_cte_at_1[simplified]
-                        is_cap_simps is_valid_vtable_root_def
-                        is_cnode_or_valid_arch_def tcb_cap_valid_def
-                        invs_valid_objs cap_asid_def vs_cap_ref_def
-                        case_bool_If valid_ipc_buffer_cap_def option_case_eq_None
-                       | split cap.splits arch_cap.splits if_splits)+)
-  sorry (* FIXME AARCH64
-  apply (simp split: option.splits)
-  done *)
+  by (intro conjI impI; clarsimp?;
+      (clarsimp simp: tcb_at_cte_at_0 tcb_at_cte_at_1[simplified]
+                      is_cap_simps is_valid_vtable_root_def
+                      is_cnode_or_valid_arch_def tcb_cap_valid_def
+                      invs_valid_objs cap_asid_def vs_cap_ref_def
+                      case_bool_If valid_ipc_buffer_cap_def option_case_eq_None
+       | split cap.splits arch_cap.splits if_splits pt_type.splits option.splits)+)
 
 lemma check_valid_ipc_buffer_inv: (* arch_specific *)
   "\<lbrace>P\<rbrace> check_valid_ipc_buffer vptr cap \<lbrace>\<lambda>rv. P\<rbrace>"
@@ -371,9 +363,8 @@ lemma update_cap_valid[Tcb_AI_asms]:
   done
 
 
-(* FIXME AARCH64 VCPU
 crunch pred_tcb_at: switch_to_thread "pred_tcb_at proj P t"
-  (wp: crunch_wps simp: crunch_simps) *)
+  (wp: crunch_wps simp: crunch_simps)
 
 crunch typ_at[wp]: invoke_tcb "\<lambda>s. P (typ_at T p s)"
   (ignore: check_cap_at setNextPC zipWithM
@@ -389,9 +380,9 @@ end
 
 global_interpretation Tcb_AI?: Tcb_AI
   where is_cnode_or_valid_arch = AARCH64.is_cnode_or_valid_arch
-  proof goal_cases
-    interpret Arch .
-    case 1 show ?case by (unfold_locales; (fact Tcb_AI_asms)?)
-  qed
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact Tcb_AI_asms)?)
+qed
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
@@ -299,13 +299,12 @@ lemma create_cap_valid_arch_caps[wp, Untyped_AI_assms]:
   apply (rule conjI)
    apply (auto simp: is_cap_simps valid_cap_def second_level_tables_def
                      obj_at_def nonempty_table_def a_type_simps in_omonad)[1]
-  sorry (* FIXME AARCH64
   apply (clarsimp simp del: imp_disjL)
   apply (case_tac "\<exists>x. x \<in> obj_refs cap")
    apply (clarsimp dest!: obj_ref_elemD)
    apply fastforce
   apply (auto simp: is_cap_simps)[1]
-  done *)
+  done
 
 
 lemma create_cap_cap_refs_in_kernel_window[wp, Untyped_AI_assms]:
@@ -340,9 +339,8 @@ lemma nonempty_default[simp, Untyped_AI_assms]:
   "tp \<noteq> Untyped \<Longrightarrow> \<not> nonempty_table S (default_object tp dev us)"
   apply (case_tac tp, simp_all add: default_object_def nonempty_table_def a_type_def)
   apply (rename_tac aobject_type)
-  apply (case_tac aobject_type; simp add: default_arch_object_def)
-  sorry (* FIXME AARCH64
-  done *)
+  apply (case_tac aobject_type; simp add: default_arch_object_def empty_pt_def)
+  done
 
 crunch cte_wp_at_iin[wp]: init_arch_objects "\<lambda>s. P (cte_wp_at (P' (interrupt_irq_node s)) p s)"
 
@@ -358,8 +356,7 @@ lemma obj_is_device_vui_eq[Untyped_AI_assms]:
   apply (intro impI conjI allI, simp_all add: is_frame_type_def default_object_def)
   apply (simp add: default_arch_object_def split: aobject_type.split)
   apply (auto simp: arch_is_frame_type_def)
-  sorry (* FIXME AARCH64
-  done *)
+  done
 
 end
 

--- a/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
@@ -441,6 +441,7 @@ lemma unmap_page_state_hyp_refs_of[wp]:
 
 crunches delete_asid, vcpu_finalise, unmap_page_table, finalise_cap
   for state_hyp_refs_of[wp]: "\<lambda>s. sym_refs (state_hyp_refs_of s)"
+  (wp: crunch_wps)
 
 lemma preemption_point_state_hyp_refs_of[wp]:
   "preemption_point \<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>"

--- a/proof/invariant-abstract/AARCH64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpaceEntries_AI.thy
@@ -31,7 +31,7 @@ lemmas obj_valid_vspace_simps[simp]
         [split_simps Structures_A.kernel_object.split
                      arch_kernel_obj.split]
 
-abbreviation
+locale_abbrev
   valid_vspace_objs' :: "'z state \<Rightarrow> bool"
 where
  "valid_vspace_objs' s \<equiv> \<forall>x \<in> ran (kheap s). obj_valid_vspace x"
@@ -77,37 +77,29 @@ lemma valid_vspace_objs'_vsD:
 lemma store_pte_valid_vspace_objs'[wp]:
   "store_pte pt_t p pte \<lbrace>valid_vspace_objs'\<rbrace>"
   apply (simp add: store_pte_def set_pt_def, wp get_object_wp)
-  apply (clarsimp simp: obj_at_def)
-  sorry (* FIXME AARCH64
-  apply (rule valid_entries_overwrite_0)
-   apply (fastforce simp:ran_def)
-  apply (drule bspec)
-   apply fastforce
+  apply (clarsimp simp: obj_at_def pt_upd_def split: pt.splits)
+  apply (rule conjI; clarsimp; rename_tac pt)
+   apply (rule valid_entries_overwrite_0, fastforce simp:ran_def)
+   apply (case_tac "pt pa"; case_tac pte; simp)
+  apply (rule valid_entries_overwrite_0, fastforce simp:ran_def)
   apply (case_tac "pt pa"; case_tac pte; simp)
-  done *)
+  done
+
+crunches invalidate_tlb_by_asid_va, invalidate_tlb_by_asid, unmap_page_table
+  for vspace_objs'[wp]: valid_vspace_objs'
 
 lemma unmap_page_valid_vspace_objs'[wp]:
   "\<lbrace>valid_vspace_objs'\<rbrace> unmap_page sz asid vptr pptr \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
   apply (simp add: unmap_page_def mapM_discarded
              cong: vmpage_size.case_cong)
-  sorry (* FIXME AARCH64
-  apply (wpsimp wp: store_pte_valid_vspace_objs')
-  done *)
-
-lemma unmap_page_table_valid_vspace_objs'[wp]:
-  "\<lbrace>valid_vspace_objs'\<rbrace> unmap_page_table asid vptr pt \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
-  apply (simp add: unmap_page_table_def)
-  sorry (* FIXME AARCH64
-  apply (wp get_object_wp store_pte_valid_vspace_objs' | wpc)+
-  apply (simp add: obj_at_def)
-  done *)
+  apply wpsimp
+  done
 
 crunch valid_vspace_objs'[wp]: set_simple_ko "valid_vspace_objs'"
   (wp: crunch_wps)
 
-(* FIXME AARCH64
 crunch valid_vspace_objs'[wp]: finalise_cap, cap_swap_for_delete, empty_slot "valid_vspace_objs'"
-  (wp: crunch_wps select_wp preemption_point_inv simp: crunch_simps unless_def ignore:set_object) *)
+  (wp: crunch_wps select_wp preemption_point_inv simp: crunch_simps unless_def ignore:set_object)
 
 lemma preemption_point_valid_vspace_objs'[wp]:
   "\<lbrace>valid_vspace_objs'\<rbrace> preemption_point \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
@@ -120,10 +112,8 @@ lemmas cap_revoke_preservation_valid_vspace_objs = cap_revoke_preservation[OF _,
 lemmas rec_del_preservation_valid_vspace_objs = rec_del_preservation[OF _ _ _ _,
                                                     where P=valid_vspace_objs', simplified]
 
-(* FIXME AARCH64
 crunch valid_vspace_objs'[wp]: cap_delete, cap_revoke "valid_vspace_objs'"
   (rule: cap_revoke_preservation_valid_vspace_objs)
-*)
 
 crunch valid_vspace_objs'[wp]: cancel_badged_sends "valid_vspace_objs'"
   (simp: crunch_simps filterM_mapM wp: crunch_wps ignore: filterM)
@@ -132,16 +122,12 @@ crunch valid_vspace_objs'[wp]: cap_move, cap_insert "valid_vspace_objs'"
 
 lemma invoke_cnode_valid_vspace_objs'[wp]:
   "\<lbrace>valid_vspace_objs' and invs and valid_cnode_inv i\<rbrace> invoke_cnode i \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
-  apply (simp add: invoke_cnode_def)
-  apply (rule hoare_pre)
-   apply (wp get_cap_wp | wpc | simp split del: if_split)+
-  sorry (* FIXME AARCH64
-  done *)
+  unfolding invoke_cnode_def
+  by (wpsimp wp: get_cap_wp split_del: if_split)
 
-(* FIXME AARCH64
 crunch valid_vspace_objs'[wp]: invoke_tcb "valid_vspace_objs'"
   (wp: check_cap_inv crunch_wps simp: crunch_simps
-       ignore: check_cap_at) *)
+       ignore: check_cap_at)
 
 lemma invoke_domain_valid_vspace_objs'[wp]:
   "\<lbrace>valid_vspace_objs'\<rbrace> invoke_domain t d \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
@@ -150,11 +136,10 @@ lemma invoke_domain_valid_vspace_objs'[wp]:
 crunch valid_vspace_objs'[wp]: set_extra_badge, transfer_caps_loop "valid_vspace_objs'"
   (rule: transfer_caps_loop_pres)
 
-(* FIXME AARCH64
 crunch valid_vspace_objs'[wp]: send_ipc, send_signal,
     do_reply_transfer, invoke_irq_control, invoke_irq_handler "valid_vspace_objs'"
   (wp: crunch_wps simp: crunch_simps
-         ignore: clearMemory const_on_failure set_object) *)
+         ignore: clearMemory const_on_failure set_object)
 
 lemma valid_vspace_objs'_trans_state[simp]: "valid_vspace_objs' (trans_state f s) = valid_vspace_objs' s"
   apply (simp add: obj_valid_vspace_def)
@@ -168,8 +153,7 @@ lemma retype_region_valid_vspace_objs'[wp]:
                  elim!: ranE split: if_split_asm simp del:fun_upd_apply)
   apply (simp add: default_object_def default_arch_object_def
             split: kernel_object.splits apiobject_type.split aobject_type.split)+
-  sorry (* FIXME AARCH64
-  done *)
+  done
 
 lemma detype_valid_vspace[elim!]:
   "valid_vspace_objs' s \<Longrightarrow> valid_vspace_objs' (detype S s)"
@@ -224,12 +208,7 @@ lemma perform_asid_pool_invocation_valid_vspace_objs'[wp]:
    \<lbrace> \<lambda>_. valid_vspace_objs' \<rbrace>"
   apply (simp add: perform_asid_pool_invocation_def)
   apply (wpsimp wp: get_cap_wp)
-  sorry (* FIXME AARCH64
-  apply (simp add: cte_wp_at_caps_of_state)
-  apply (drule (1) valid_capsD)
-  apply (clarsimp simp: is_ArchObjectCap_def is_PageTableCap_def valid_cap_def)
-  apply (erule (1) is_aligned_pt)
-  done *)
+  done
 
 crunch valid_vspace_objs'[wp]: perform_asid_pool_invocation,
      perform_asid_control_invocation "valid_vspace_objs'"
@@ -246,16 +225,16 @@ lemma perform_page_valid_vspace_objs'[wp]:
                 split: sum.split arch_cap.split option.split,
          safe intro!: hoare_gen_asm hoare_gen_asm[unfolded K_def],
          simp_all add: mapM_x_Nil mapM_x_Cons mapM_x_map)
-  sorry (* FIXME AARCH64
     apply (wp store_pte_valid_vspace_objs' hoare_vcg_imp_lift[OF set_cap_arch_obj_neg]
               hoare_vcg_all_lift
            | clarsimp simp: cte_wp_at_weakenE[OF _ TrueI] obj_at_def swp_def valid_page_inv_def
                             valid_slots_def perform_pg_inv_map_def perform_pg_inv_unmap_def
-                            perform_pg_inv_get_addr_def
+                            perform_pg_inv_get_addr_def perform_flush_def
                      split: pte.splits
+           | rule conjI
            | wpc
            | wp (once) hoare_drop_imps)+
-  done *)
+  done
 
 lemma perform_page_table_valid_vspace_objs'[wp]:
   "\<lbrace>valid_vspace_objs' and valid_pti pinv\<rbrace>
@@ -265,28 +244,22 @@ lemma perform_page_table_valid_vspace_objs'[wp]:
              cong: page_table_invocation.case_cong
                    option.case_cong cap.case_cong arch_cap.case_cong)
   apply (rule hoare_pre)
-  sorry (* FIXME AARCH64
    apply (wp hoare_vcg_ex_lift store_pte_valid_vspace_objs'
              set_cap_arch_obj hoare_vcg_all_lift mapM_x_wp'
               | wpc
               | simp add: swp_def
               | strengthen all_imp_ko_at_from_ex_strg
               | wp (once) hoare_drop_imps)+
-  done *)
+  done
 
 lemma perform_invocation_valid_vspace_objs'[wp]:
   "\<lbrace>invs and ct_active and valid_invocation i and valid_vspace_objs'\<rbrace>
       perform_invocation blocking call i
          \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
-  apply (cases i, simp_all)
-  apply (wp send_signal_interrupt_states | simp)+
-  sorry (* FIXME AARCH64
-  apply (clarsimp simp:)
-  apply (wp | wpc | simp)+
-  apply (simp add: arch_perform_invocation_def)
-  apply (wp | wpc | simp)+
+  apply (cases i; wpsimp)
+   apply (wpsimp simp: arch_perform_invocation_def perform_vspace_invocation_def perform_flush_def)
   apply (auto simp: valid_arch_inv_def intro: valid_objs_caps)
-  done *)
+  done
 
 crunch valid_vspace_objs'[wp]: handle_fault, reply_from_kernel "valid_vspace_objs'"
   (simp: crunch_simps wp: crunch_wps)
@@ -299,29 +272,25 @@ lemma handle_invocation_valid_vspace_objs'[wp]:
                | simp add: split_def | wpc
                | wp (once) hoare_drop_imps)+
   apply (auto simp: ct_in_state_def elim: st_tcb_ex_cap)
-  sorry (* FIXME AARCH64
-  done *)
+  done
 
-(* FIXME AARCH64
 crunch valid_vspace_objs'[wp]: activate_thread,switch_to_thread, handle_hypervisor_fault,
        switch_to_idle_thread, handle_call, handle_recv, handle_reply,
        handle_send, handle_yield, handle_interrupt "valid_vspace_objs'"
   (simp: crunch_simps wp: crunch_wps alternative_valid select_wp OR_choice_weak_wp select_ext_weak_wp
       ignore: without_preemption getActiveIRQ resetTimer ackInterrupt
-              OR_choice set_scheduler_action) *)
+              OR_choice set_scheduler_action)
 
 lemma handle_event_valid_vspace_objs'[wp]:
   "\<lbrace>valid_vspace_objs' and invs and ct_active\<rbrace> handle_event e \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
-  sorry (* FIXME AARCH64
-  by (case_tac e; simp) (wpsimp simp: Let_def handle_vm_fault_def | wp (once) hoare_drop_imps)+ *)
+  by (case_tac e; simp) (wpsimp simp: Let_def handle_vm_fault_def | wp (once) hoare_drop_imps)+
 
 lemma schedule_valid_vspace_objs'[wp]:
   "\<lbrace>valid_vspace_objs'\<rbrace> schedule :: (unit,unit) s_monad \<lbrace>\<lambda>_. valid_vspace_objs'\<rbrace>"
   apply (simp add: schedule_def allActiveTCBs_def)
   apply (wp alternative_wp select_wp)
   apply simp
-  sorry (* FIXME AARCH64
-  done *)
+  done
 
 lemma call_kernel_valid_vspace_objs'[wp]:
   "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s) and valid_vspace_objs'\<rbrace>
@@ -333,8 +302,7 @@ lemma call_kernel_valid_vspace_objs'[wp]:
                  | rule conjI | clarsimp simp: ct_in_state_def
                  | erule pred_tcb_weakenE
                  | wp (once) hoare_drop_imps)+
-  sorry (* FIXME AARCH64 missing crunches
-  done *)
+  done
 
 end
 

--- a/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
@@ -918,11 +918,14 @@ lemma invalidate_vmid_entry_vmid_for_asid_None[wp]:
   by wpsimp
 
 lemma invalidate_asid_vmid_for_asid_None[wp]:
-  "invalidate_asid asid' \<lbrace>\<lambda>s. vmid_for_asid s asid = None\<rbrace>"
+  "\<lbrace>\<lambda>s. asid' \<noteq> asid \<longrightarrow> vmid_for_asid s asid = None \<rbrace>
+   invalidate_asid asid'
+   \<lbrace>\<lambda>_ s. vmid_for_asid s asid = None\<rbrace>"
   unfolding invalidate_asid_def update_asid_pool_entry_def
   supply fun_upd_apply[simp del]
   apply (wpsimp|wps)+
-  apply (auto simp: vmid_for_asid_def entry_for_pool_def fun_upd_apply obind_def in_opt_map_None_eq
+  apply (auto simp: pool_for_asid_def vmid_for_asid_def entry_for_pool_def fun_upd_apply obind_def
+                    in_opt_map_None_eq
               split: option.split)
   done
 

--- a/proof/invariant-abstract/Invariants_AI.thy
+++ b/proof/invariant-abstract/Invariants_AI.thy
@@ -1278,6 +1278,10 @@ lemma valid_objsE [elim]:
   "\<lbrakk> valid_objs s; kheap s x = Some obj; valid_obj x obj s \<Longrightarrow> R \<rbrakk> \<Longrightarrow> R"
   unfolding valid_objs_def by (auto simp: dom_def)
 
+lemma valid_obj_arch_valid_obj:
+  "valid_obj p (ArchObj ao) s = arch_valid_obj ao s"
+  by (simp add: valid_obj_def)
+
 
 lemma obj_at_ko_at:
   "obj_at P p s \<Longrightarrow> \<exists>ko. ko_at ko p s \<and> P ko"

--- a/proof/invariant-abstract/LevityCatch_AI.thy
+++ b/proof/invariant-abstract/LevityCatch_AI.thy
@@ -127,4 +127,8 @@ lemma mask_alignment_ugliness:
    apply (meson linorder_not_le)
   by (auto simp: le_def)
 
+lemma ranD:
+  "v \<in> ran f \<Longrightarrow> \<exists>x. f x = Some v"
+  by (auto simp: ran_def)
+
 end

--- a/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
@@ -1090,16 +1090,6 @@ lemma set_vm_root_empty[wp]:
   apply (wpsimp wp: get_cap_wp)
   done
 
-lemma set_asid_pool_empty[wp]:
-  "\<lbrace>obj_at (empty_table S) word\<rbrace> set_asid_pool x2 pool' \<lbrace>\<lambda>xb. obj_at (empty_table S) word\<rbrace>"
-  by (wpsimp wp: set_object_wp simp: set_asid_pool_def obj_at_def empty_table_def)
-
-lemma delete_asid_empty_table_pt[wp]:
-  "delete_asid a word \<lbrace>\<lambda>s. obj_at (empty_table S) word s\<rbrace>"
-   apply (simp add: delete_asid_def)
-   apply wpsimp
-   done
-
 lemma ucast_less_shiftl_helper3:
   "\<lbrakk> len_of TYPE('b) + 3 < len_of TYPE('a); 2 ^ (len_of TYPE('b) + 3) \<le> n\<rbrakk>
     \<Longrightarrow> (ucast (x :: 'b::len word) << 3) < (n :: 'a::len word)"

--- a/proof/invariant-abstract/Retype_AI.thy
+++ b/proof/invariant-abstract/Retype_AI.thy
@@ -1904,7 +1904,7 @@ locale retype_region_proofs_invs
   fixes region_in_kernel_window :: "machine_word set \<Rightarrow> 'state_ext state \<Rightarrow> bool"
   assumes valid_global_refs: "valid_global_refs s \<Longrightarrow> valid_global_refs s'"
   assumes valid_arch_state: "valid_arch_state s \<Longrightarrow> valid_arch_state s'"
-  assumes valid_vspace_objs': "valid_vspace_objs s \<Longrightarrow> valid_vspace_objs s'"
+  assumes valid_vspace_objs': "\<lbrakk> invs s; valid_vspace_objs s \<rbrakk> \<Longrightarrow> valid_vspace_objs s'"
   assumes valid_cap:
     "(s::'state_ext state) \<turnstile> cap \<and>
         untyped_range cap \<inter> {ptr .. (ptr && ~~ mask sz) + 2 ^ sz - 1} = {}

--- a/spec/abstract/AARCH64/ArchVSpace_A.thy
+++ b/spec/abstract/AARCH64/ArchVSpace_A.thy
@@ -263,6 +263,8 @@ definition delete_asid :: "asid \<Rightarrow> obj_ref \<Rightarrow> (unit,'z::st
          when (\<exists>vmid. pool (asid_low_bits_of asid) = Some (ASIDPoolVSpace vmid pt)) $ do
            invalidate_tlb_by_asid asid;
            invalidate_asid_entry asid;
+           \<comment> \<open>re-read here, because @{text invalidate_asid_entry} changes the ASID pool:\<close>
+           pool \<leftarrow> get_asid_pool pool_ptr;
            pool' \<leftarrow> return $ pool (asid_low_bits_of asid := None);
            set_asid_pool pool_ptr pool';
            tcb \<leftarrow> gets cur_thread;

--- a/spec/abstract/AARCH64/Arch_Structs_A.thy
+++ b/spec/abstract/AARCH64/Arch_Structs_A.thy
@@ -304,7 +304,11 @@ datatype aobject_type =
   | VCPUObj
 
 definition arch_is_frame_type :: "aobject_type \<Rightarrow> bool" where
-  "arch_is_frame_type aobj \<equiv> aobj \<noteq> PageTableObj"
+  "arch_is_frame_type aobj \<equiv> case aobj of
+     SmallPageObj \<Rightarrow> True
+   | LargePageObj \<Rightarrow> True
+   | HugePageObj \<Rightarrow> True
+   | _ \<Rightarrow> False"
 
 definition arch_default_cap :: "aobject_type \<Rightarrow> obj_ref \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> arch_cap" where
   "arch_default_cap tp r n dev \<equiv> case tp of

--- a/spec/haskell/src/SEL4/Kernel/VSpace/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Kernel/VSpace/AARCH64.hs
@@ -299,6 +299,8 @@ deleteASID asid pt = do
             when (maybeRoot == Just pt) $ do
                 invalidateTLBByASID asid
                 invalidateASIDEntry asid
+                -- re-read pool, because invalidateASIDEntry changes it
+                ASIDPool pool <- getObject poolPtr
                 let pool' = pool//[(asid .&. mask asidLowBits, Nothing)]
                 setObject poolPtr $ ASIDPool pool'
                 tcb <- getCurThread


### PR DESCRIPTION
This PR clears all sorries up to the theory `ArchFinalise_AI` and in addition clears `ArchEmptyFail`, `ArchInterrupt`, `ArchTcb`, `ArchIPC`, and `ArchVSpaceEntries`.

In the spec, we add an additional read operation to model the atomic ASID pool field update that happens C, and we correct the definition of `arch_is_frame_type` to properly take into account the presence of VCPU objects.