### PR TITLE
Autcorres 1.9 + CParser 1.19 release

### DIFF
--- a/lib/Value_Type.thy
+++ b/lib/Value_Type.thy
@@ -18,7 +18,7 @@ begin
       value_type num_something = "10 * num_domains"
 *)
 
-text \<open>See theory @{file "test/Value_Type_Test.thy"} for further example/demo.\<close>
+text \<open>See theory @{text "test/Value_Type_Test.thy"} for further example/demo.\<close>
 
 ML \<open>
 

--- a/tools/autocorres/tools/release.py
+++ b/tools/autocorres/tools/release.py
@@ -125,7 +125,7 @@ parser.add_argument('--no-cleanup', action='store_true',
 parser.add_argument('-r', '--repository', metavar='REPO',
                     type=str, help='Path to the L4.verified repository base.', default=None)
 parser.add_argument('--archs', metavar='ARCH,...',
-                    type=str, default='ARM,ARM_HYP,X64,RISCV64',
+                    type=str, default='ARM,ARM_HYP,X64,RISCV64,AARCH64',
                     help='L4V_ARCHs to include (comma-separated)')
 args = parser.parse_args()
 

--- a/tools/autocorres/tools/release_files/ChangeLog
+++ b/tools/autocorres/tools/release_files/ChangeLog
@@ -1,3 +1,8 @@
+AutoCorres 1.9 (31 October 2022)
+--------------
+
+	* Isabelle2021-1 edition of both AutoCorres and the C parser.
+
 AutoCorres 1.8 (31 October 2021)
 --------------
 

--- a/tools/autocorres/tools/release_files/README
+++ b/tools/autocorres/tools/release_files/README
@@ -32,12 +32,17 @@ AutoCorres is packaged as a theory for Isabelle2021:
 
     https://isabelle.in.tum.de
 
-AutoCorres currently supports three platforms: ARM, X64, and RISCV64.
+AutoCorres currently supports four platforms: ARM, AARCH64, X64, and RISCV64.
 The platform determines the sizes of C integral and pointer types.
 
 For ARM, the sizes are:
   - 64 bits: long long
   - 32 bits: pointers, long, int
+  - 16 bits: short
+
+For AARCH64:
+  - 64 bits: pointers, long long, long
+  - 32 bits: int
   - 16 bits: short
 
 For X64:
@@ -120,9 +125,9 @@ This package contains:
     * Compatibility word libraries and associated lemmas, for
       assisting with reasoning about words (such as 32-bit words).
 
-    * Libraries from Data61 for defining and reasoning about monads,
-      including definitions for nondeterministic state monads and option
-      monads, along with a large proof library relating to these
+    * Libraries from the l4v repository for defining and reasoning about
+      monads, including definitions for nondeterministic state monads and
+      option monads, along with a large proof library relating to these
       definitions.
 
     * The "wp" weakest precondition tool, which can be used to

--- a/tools/c-parser/RELEASES.md
+++ b/tools/c-parser/RELEASES.md
@@ -145,3 +145,14 @@
 - always use fresh names for generated temporary variables.
   This fixes a problem that could make some function call expressions unprovable. (VER-1389)
 - improve compile time performance for functional record update definitions
+
+## 1.19
+
+- Builds with Isabelle2021-1
+- setup for AARCH64/ARM64 targets
+- AST printing for top-level declarations annotated to make them easier to
+  consume in external tools. Annotations take the form:
+
+      ##<decl_type>: <name>
+
+  e.g. `##Function: ctzl`


### PR DESCRIPTION
This PR mostly has changelong updates and small tweaks to include AARCH64 and make the release scripts pass.

The actual release files can be uploaded once this PR is merged.