### PR TITLE
github: bump github action dependencies

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -45,7 +45,7 @@ jobs:
         AWS_SSH: ${{ secrets.AWS_SSH }}
         GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Upload logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: logs-${{ matrix.arch }}
         path: logs.tar.xz

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -30,7 +30,7 @@ jobs:
         AWS_SSH: ${{ secrets.AWS_SSH }}
         GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Upload logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: logs-${{ matrix.arch }}
         path: logs.tar.xz

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,7 +48,7 @@ jobs:
     - uses: seL4/ci-actions/thylint@master
       with:
         token: ${{ secrets.READ_TOKEN }}
-    - uses: yuzutech/annotations-action@v0.2.1
+    - uses: yuzutech/annotations-action@v0.4.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         title: 'File annotations for theory linter'

--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -102,7 +102,7 @@ jobs:
         path: verification-manifest.xml
     - name: Trigger binary verification
       if: steps.enabled.outputs.enabled
-      uses: peter-evans/repository-dispatch@v1
+      uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.PRIV_REPO_TOKEN }}
         repository: ${{ github.repository }}

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -42,7 +42,7 @@ jobs:
         AWS_SSH: ${{ secrets.AWS_SSH }}
         GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Upload logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: logs-${{ matrix.arch }}
         path: logs.tar.xz

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -20,7 +20,7 @@ jobs:
     name: CParser Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: peter-evans/repository-dispatch@v1
+      - uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.SSRG_BAMBOO_REPO }}
           repository: seL4/ci-actions

--- a/.github/workflows/weekly-clean.yml
+++ b/.github/workflows/weekly-clean.yml
@@ -28,7 +28,7 @@ jobs:
         AWS_SSH: ${{ secrets.AWS_SSH }}
         GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Upload logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: logs-${{ matrix.arch }}
         path: logs.tar.xz


### PR DESCRIPTION
Upgrade to node16 actions to reduce warnings on CI.
