### PR TITLE
cparser: annotate AST printing for top-level decls

### DIFF
--- a/tools/c-parser/standalone-parser/main.sml
+++ b/tools/c-parser/standalone-parser/main.sml
@@ -408,6 +408,7 @@ in
   app (print_lines o defn_lines) ast
 end
 
+
 fun adjusted_complex_fncalls cse ast = let
   open Absyn_Serial
 


### PR DESCRIPTION
In order to compare ASTs for appearance/disappearance/modification of declarations, it is easier to have the annotations obvious to any external tool for ease of parsing.

Annotations take the form:
"##<decl_type>: <name>", e.g. "##Function: ctzl"

Signed-off-by: Rafal Kolanski <rafal.kolanski@proofcraft.systems>