### PR TITLE
c-parser: fix default target for standalone parser

### DIFF
--- a/tools/c-parser/standalone-parser/Makefile
+++ b/tools/c-parser/standalone-parser/Makefile
@@ -40,10 +40,13 @@ TOKENIZERS=$(TOKENIZER_ARM) $(TOKENIZER_ARM_HYP) $(TOKENIZER_AARCH64) \
 
 .PHONY: all cparser_tools stp_all standalone-cparser standalone-tokenizer
 
+# Target "all" gains additional dependencies in the included Makefile below, so
+# we keep "stp_all" as the first (= default) target
+stp_all: standalone-cparser standalone-tokenizer
 all: stp_all
 
-standalone-cparser stp_all: $(STPARSERS)
-standalone-tokenizer stp_all: $(TOKENIZERS)
+standalone-cparser: $(STPARSERS)
+standalone-tokenizer: $(TOKENIZERS)
 
 include $(STP_PFX)/../Makefile
 


### PR DESCRIPTION
The default (=first) Makefile target for the standalone parser was `all`, which gains additional dependencies in the included Makefile. We want `make` in this directory to just build the standalone parser, so we set `stp_all` as the default.
