### PR TITLE
haskell-translator: suppress known-good warnings

### DIFF
--- a/tools/haskell-translator/lhs_pars.py
+++ b/tools/haskell-translator/lhs_pars.py
@@ -690,6 +690,7 @@ def newtype_transform(d):
 known_type_assignments = [
     'domain_schedule',
     'kernel',
+    'kernel_r',
     'kernel_f',
     'kernel_f f',  # there is a KernelF instance that gets transformed into this
     'kernel_init',
@@ -697,7 +698,10 @@ known_type_assignments = [
     'machine_data',
     'machine_monad',
     'ready_queue',
-    'user_monad'
+    'release_queue',
+    'user_monad',
+    'reader_m',
+    'reader_m s',
 ]
 
 
@@ -706,7 +710,8 @@ def typename_transform(line, header, d):
         [oldtype] = line.split()
     except:
         if header not in known_type_assignments:
-            warning('type assignment with parameters not supported %s' % d.body, filename)
+            warning('type assignment with parameters not supported %s, (%s)' %
+                    (d.body, header), filename)
             call.bad_type_assignment = True
         return
     if oldtype.startswith('Data.Word.Word'):

--- a/tools/haskell-translator/make_spec.sh
+++ b/tools/haskell-translator/make_spec.sh
@@ -70,20 +70,19 @@ ARCHES=("ARM" "RISCV64")
 function cpp_opts () {
     case ${1} in
         ARM)
-            L4CPP="-DPLATFORM=QEmu -DPLATFORM_QEmu -DTARGET=ARM -DTARGET_ARM"
+            L4CPP="-Wno-unicode -DPLATFORM=QEmu -DPLATFORM_QEmu -DTARGET=ARM -DTARGET_ARM"
             ;;
         ARM_HYP)
-            L4CPP="-DPLATFORM=TK1 -DPLATFORM_TK1 -DTARGET=ARM -DTARGET_ARM -DCONFIG_ARM_HYPERVISOR_SUPPORT"
+            L4CPP="-Wno-unicode -DPLATFORM=TK1 -DPLATFORM_TK1 -DTARGET=ARM -DTARGET_ARM -DCONFIG_ARM_HYPERVISOR_SUPPORT"
             ;;
         RISCV64)
-            L4CPP="-DPLATFORM=HiFive -DPLATFORM_HiFive -DTARGET=RISCV64 -DTARGET_RISCV64"
+            L4CPP="-Wno-unicode -DPLATFORM=HiFive -DPLATFORM_HiFive -DTARGET=RISCV64 -DTARGET_RISCV64"
             ;;
         AARCH64)
-            L4CPP="-DPLATFORM=TX2 -DPLATFORM_TX2 -DTARGET=AARCH64 -DTARGET_AARCH64"
+            L4CPP="-Wno-unicode -DPLATFORM=TX2 -DPLATFORM_TX2 -DTARGET=AARCH64 -DTARGET_AARCH64"
             ;;
         X64)
-            # this space intentionally left blank:
-            L4CPP=""
+            L4CPP="-Wno-unicode"
             ;;
         *)
             echo "Warning: No CPP configuration for achitecture ${1}"


### PR DESCRIPTION
MCS has a few more instances of type assignments that are handled manually, and the lambda `\usage` confuses the C preprocessor (potential unicode escape sequence). Switch these off, because we know they are fine.
