### PR TITLE
factor out and generalise definition of pred_conj and friends

### DIFF
--- a/lib/Corres_Adjust_Preconds.thy
+++ b/lib/Corres_Adjust_Preconds.thy
@@ -104,8 +104,7 @@ ML \<open>
 
 structure Corres_Adjust_Preconds = struct
 
-val def_intros = @{thms conjI pred_conj_app[THEN iffD2]
-    bipred_conj_app[THEN fun_cong, THEN iffD2]}
+val def_intros = @{thms conjI pred_conjI}
 
 (* apply an intro rule, splitting preconds assumptions to
    provide unique assumptions for each goal. *)

--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -724,7 +724,7 @@ lemma corres_assert_gen_asm_cross:
   "\<lbrakk> \<And>s s'. \<lbrakk>(s, s') \<in> sr; P' s; Q' s'\<rbrakk> \<Longrightarrow> A;
      A \<Longrightarrow> corres_underlying sr nf nf' r P Q f (g ()) \<rbrakk>
   \<Longrightarrow> corres_underlying sr nf nf' r (P and P') (Q and Q') f (assert A >>= g)"
-  by (metis corres_assert_assume corres_assume_pre corres_guard_imp pred_andE)
+  by (metis corres_assert_assume corres_assume_pre corres_weaker_disj_division)
 
 lemma corres_state_assert:
   "corres_underlying sr nf nf' rr P Q f (g ()) \<Longrightarrow>

--- a/lib/EVTutorial/EquivValidTutorial.thy
+++ b/lib/EVTutorial/EquivValidTutorial.thy
@@ -140,15 +140,14 @@ where
 text \<open> We could just as well define equivalences similarly for
 \<open>inbox\<close>, \<open>outbox\<close>, or \<open>job\<close> -- we omit these here. \<close>
 
-text \<open> Furthermore, you can use the \<open>And\<close> alias provided by Lib.NonDetMonad
+text \<open> Furthermore, you can use the \<open>and\<close> alias provided by @{theory Lib.Fun_Pred_Syntax}
 to write the conjunction of two binary predicates.
-(Similarly, there is also an \<open>Or\<close> alias for disjunction.)\<close>
+(Similarly, there is also an \<open>or\<close> alias for disjunction.)\<close>
 
-thm bipred_conj_def bipred_disj_def
 lemma
-  "(desk_equivalence And window_equivalence) r1 r2 =
+  "(desk_equivalence and window_equivalence) r1 r2 =
    (desk r1 = desk r2 \<and> window r1 = window r2)"
-  unfolding bipred_conj_def desk_equivalence_def window_equivalence_def
+  unfolding desk_equivalence_def window_equivalence_def
   by simp
 
 text \<open> In this setting, we might consider a trivial program that just returns
@@ -294,12 +293,12 @@ text \<open> As before, however, we should expect this to hold with a pre-equiva
 that includes \<open>desk_equivalence\<close>. \<close>
 
 lemma reveal_desk_equiv_window_equiv:
-  "\<lbrace>|desk_equivalence And window_equivalence|, \<top>\<rbrace>
+  "\<lbrace>|desk_equivalence and window_equivalence|, \<top>\<rbrace>
      reveal_desk_to_window
-   \<lbrace>|desk_equivalence And window_equivalence|\<rbrace>"
+   \<lbrace>|desk_equivalence and window_equivalence|\<rbrace>"
   unfolding reveal_desk_to_window_def
   apply(rule modify_ev'')
-  unfolding bipred_conj_def desk_equivalence_def window_equivalence_def
+  unfolding desk_equivalence_def window_equivalence_def
   by clarsimp
 
 
@@ -349,13 +348,13 @@ thm reveal_desk_equiv_window_equiv
   modify_ev
 
 lemma reveal_desk_equiv_window_equiv_using_wp:
-  "\<lbrace>|desk_equivalence And window_equivalence|, \<top>\<rbrace>
+  "\<lbrace>|desk_equivalence and window_equivalence|, \<top>\<rbrace>
      reveal_desk_to_window
-   \<lbrace>|desk_equivalence And window_equivalence|\<rbrace>"
+   \<lbrace>|desk_equivalence and window_equivalence|\<rbrace>"
   unfolding reveal_desk_to_window_def
   apply(rule pre_ev)
    apply(wp add:modify_ev)
-  unfolding bipred_conj_def desk_equivalence_def window_equivalence_def
+  unfolding desk_equivalence_def window_equivalence_def
   by clarsimp
 
 text \<open> As another example:
@@ -513,9 +512,9 @@ thm return_ev2
   modify_ev2
 
 lemma reveal_desk_equiv_window_equiv_using_ev2:
-  "\<lbrace>|desk_equivalence And window_equivalence|, \<top>\<rbrace>
+  "\<lbrace>|desk_equivalence and window_equivalence|, \<top>\<rbrace>
      reveal_desk_to_window
-   \<lbrace>|desk_equivalence And window_equivalence|\<rbrace>"
+   \<lbrace>|desk_equivalence and window_equivalence|\<rbrace>"
   unfolding reveal_desk_to_window_def
   apply(clarsimp simp:equiv_valid_def2)
   \<comment> \<open> After peeling back to \<open>equiv_valid_2\<close> form, we can use its \<open>modify\<close> rule. \<close>

--- a/lib/EquivValid.thy
+++ b/lib/EquivValid.thy
@@ -235,7 +235,7 @@ abbreviation equiv_valid_rv_inv where
   "equiv_valid_rv_inv I A R P f \<equiv> equiv_valid_rv I A A R P f"
 
 lemma get_evrv:
-  "equiv_valid_rv_inv I A (I And A) \<top> get"
+  "equiv_valid_rv_inv I A (I and A) \<top> get"
   by(auto simp: equiv_valid_2_def get_def)
 
 lemma equiv_valid_rv_bind_general:
@@ -308,7 +308,7 @@ lemma get_bind_ev2:
   assumes "\<And> rv rv'. \<lbrakk>I rv rv'; A rv rv'\<rbrakk> \<Longrightarrow> equiv_valid_2 I A B R (P and ((=) rv)) (P' and ((=) rv')) (f rv) (f' rv')"
   shows "equiv_valid_2 I A B R P P' (get >>= f) (get >>= f')"
   apply(rule equiv_valid_2_guard_imp)
-  apply(rule_tac R'="I And A" in equiv_valid_2_bind_general)
+  apply(rule_tac R'="I and A" in equiv_valid_2_bind_general)
        apply(rule assms, simp+)
       apply(rule get_evrv)
      apply(wp get_sp)+

--- a/lib/Fun_Pred_Syntax.thy
+++ b/lib/Fun_Pred_Syntax.thy
@@ -1,0 +1,210 @@
+(*
+ * Copyright 2022, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *)
+
+(* Syntax for using multi-argument functions as predicates, e.g "P and Q" where P and Q are
+   functions to bool, taking one or more parameters. *)
+
+theory Fun_Pred_Syntax
+imports Main
+begin
+
+section \<open>Definitions\<close>
+
+text \<open>
+  Functions are already instances of Boolean algebras and provide all the standard laws one
+  would like to have. Default simplifications are automatic. Search for @{const inf}/
+  @{const sup}/@{const uminus} to find further laws and/or unfold via the definitions below.
+
+  The abbreviations here provide special syntax for the function instance of Boolean
+  algebras only, leaving other instances (such as @{typ bool}) untouched.\<close>
+
+abbreviation pred_conj :: "('a \<Rightarrow> 'b::boolean_algebra) \<Rightarrow> ('a \<Rightarrow> 'b) \<Rightarrow> ('a \<Rightarrow> 'b)" where
+  "pred_conj \<equiv> inf"
+
+abbreviation pred_disj :: "('a \<Rightarrow> 'b::boolean_algebra) \<Rightarrow> ('a \<Rightarrow> 'b) \<Rightarrow> ('a \<Rightarrow> 'b)" where
+  "pred_disj \<equiv> sup"
+
+abbreviation pred_neg :: "('a \<Rightarrow> 'b::boolean_algebra) \<Rightarrow> ('a \<Rightarrow> 'b)" where
+  "pred_neg \<equiv> uminus"
+
+
+text \<open>
+  Lifted True/False: ideally, we'd map these to top/bot, but top/bot are constants and there are
+  currently too many rules and tools that expect these conditions to beta-reduce and match against
+  True/False directly.\<close>
+
+abbreviation (input) pred_top :: "'a \<Rightarrow> bool" where
+  "pred_top \<equiv> \<lambda>_. True"
+
+abbreviation (input) pred_bot :: "'a \<Rightarrow> bool" where
+  "pred_bot \<equiv> \<lambda>_. False"
+
+
+text \<open>Version with two arguments for compatibility. Can hopefully be eliminated at some point.\<close>
+
+abbreviation (input) pred_top2 :: "'a \<Rightarrow> 'b \<Rightarrow> bool" where
+  "pred_top2 \<equiv> \<lambda>_ _. True"
+
+abbreviation (input) pred_bot2 :: "'a \<Rightarrow> 'b \<Rightarrow> bool" where
+  "pred_bot2 \<equiv> \<lambda>_ _. False"
+
+
+section \<open>Syntax bundles\<close>
+
+bundle fun_pred_syntax
+begin
+  (* infixl instead of infixr, because we want to split off conjuncts from the left *)
+  notation pred_conj (infixl "and" 35)
+  notation pred_disj (infixl "or" 30)
+  notation pred_neg ("not _" [40] 40)
+  notation pred_top ("\<top>")
+  notation pred_bot ("\<bottom>")
+  notation pred_top2 ("\<top>\<top>")
+  notation pred_bot2 ("\<bottom>\<bottom>")
+end
+
+bundle no_fun_pred_syntax
+begin
+  no_notation pred_conj (infixl "and" 35)
+  no_notation pred_disj (infixl "or" 30)
+  no_notation pred_neg ("not _" [40] 40)
+  no_notation pred_top ("\<top>")
+  no_notation pred_bot ("\<bottom>")
+  no_notation pred_top2 ("\<top>\<top>")
+  no_notation pred_bot2 ("\<bottom>\<bottom>")
+end
+
+unbundle fun_pred_syntax
+
+
+section \<open>Definitions specialised to @{typ bool} and @{text fun} instance of @{class boolean_algebra}\<close>
+
+lemmas pred_conj_def =
+  inf_fun_def[where 'b=bool, simplified]
+  inf_fun_def[where f="f::'a \<Rightarrow> 'b::boolean_algebra" for f]
+
+lemmas pred_disj_def =
+  sup_fun_def[where 'b=bool, simplified]
+  sup_fun_def[where f="f::'a \<Rightarrow> 'b::boolean_algebra" for f]
+
+lemmas pred_neg_def =
+  fun_Compl_def[where 'b=bool, simplified]
+  fun_Compl_def[where A="A::'a \<Rightarrow> 'b::boolean_algebra" for A]
+
+lemmas pred_top_def[simp] =
+  top_fun_def[where 'b=bool, simplified] top_fun_def[where 'b="'b::boolean_algebra"]
+
+lemmas pred_bot_def[simp] =
+  bot_fun_def[where 'b=bool, simplified] bot_fun_def[where 'b="'b::boolean_algebra"]
+
+
+section \<open>Other lemmas\<close>
+
+text \<open>AC rewriting renamed and specialised, so we don't have to remember inf/sup\<close>
+
+lemmas pred_conj_aci = inf_aci[where 'a="'a \<Rightarrow> 'b::boolean_algebra"]
+lemmas pred_disj_aci = sup_aci[where 'a="'a \<Rightarrow> 'b::boolean_algebra"]
+
+
+text \<open>Useful legacy names\<close>
+
+lemmas pred_conjI = inf1I inf2I
+
+lemmas pred_disjI1 = sup1I1[where 'a="'a \<Rightarrow> 'b::boolean_algebra"]
+lemmas pred_disjI2 = sup1I2[where 'a="'a \<Rightarrow> 'b::boolean_algebra"]
+
+lemmas pred_disj1CI[intro!] = sup1CI[where 'a="'a \<Rightarrow> 'b::boolean_algebra"]
+lemmas pred_disj2CI = sup2CI[where 'a="'a \<Rightarrow> 'b::boolean_algebra"]
+
+lemmas pred_conj_assoc = inf.assoc[where 'a="'a \<Rightarrow> 'b::boolean_algebra", symmetric]
+lemmas pred_conj_comm = inf.commute[where 'a="'a \<Rightarrow> 'b::boolean_algebra"]
+
+lemmas pred_disj_assoc = sup.assoc[where 'a="'a \<Rightarrow> 'b::boolean_algebra", symmetric]
+lemmas pred_disj_comm = sup.commute[where 'a="'a \<Rightarrow> 'b::boolean_algebra"]
+
+
+text \<open>Top/bot and function composition\<close>
+
+lemma pred_top_comp[simp]:
+  "\<top> \<circ> f = \<top>"
+  by (simp add: comp_def)
+
+lemma pred_bot_comp[simp]:
+  "\<bottom> \<circ> f = \<bottom>"
+  by (simp add: comp_def)
+
+
+text \<open>We would get these for free if we could instantiate pred_top/pred_bot to top/bot directly:\<close>
+
+lemmas pred_top_left_neutral[simp] =
+  inf_top.left_neutral[where 'a="'a \<Rightarrow> bool", unfolded pred_top_def]
+
+lemmas pred_top_right_neutral[simp] =
+  inf_top.right_neutral[where 'a="'a \<Rightarrow> bool", unfolded pred_top_def]
+
+lemmas pred_bot_left_neutral[simp] =
+  sup_bot.left_neutral[where 'a="'a \<Rightarrow> bool", unfolded pred_bot_def]
+
+lemmas pred_bot_right_neutral[simp] =
+  sup_bot.right_neutral[where 'a="'a \<Rightarrow> bool", unfolded pred_bot_def]
+
+lemmas pred_top_left[simp] =
+  sup_top_left[where 'a="'a \<Rightarrow> bool", unfolded pred_top_def]
+
+lemmas pred_top_right[simp] =
+  sup_top_right[where 'a="'a \<Rightarrow> bool", unfolded pred_top_def]
+
+lemmas pred_bot_left[simp] =
+  inf_bot_left[where 'a="'a \<Rightarrow> bool", unfolded pred_bot_def]
+
+lemmas pred_bot_right[simp] =
+  inf_bot_right[where 'a="'a \<Rightarrow> bool", unfolded pred_bot_def]
+
+lemmas pred_neg_top_eq[simp] =
+  compl_top_eq[where 'a="'a \<Rightarrow> bool", unfolded pred_bot_def pred_top_def]
+
+lemmas pred_neg_bot_eq[simp] =
+  compl_bot_eq[where 'a="'a \<Rightarrow> bool", unfolded pred_bot_def pred_top_def]
+
+(* no special setup for pred_top2/pred_bot2 at the moment, since we hope to eliminate these
+   entirely in the future *)
+
+
+section \<open>Examples\<close>
+
+experiment
+begin
+
+(* Standard laws are available by default: *)
+lemma "(P and P) = P" for P :: "'a \<Rightarrow> bool"
+  by simp
+
+(* Works for functions with multiple arguments: *)
+lemma "(P and Q) = (Q and P)" for P :: "'a \<Rightarrow> 'b \<Rightarrow> bool"
+  by (simp add: pred_conj_aci)
+
+(* Unfolds automatically when applied: *)
+lemma "(P and Q) s t = (P s t \<and> Q s t)"
+  by simp
+
+(* pred_top and pred_bot work for only one argument currently: *)
+lemma "(P and not P) = \<bottom>" for P :: "'a \<Rightarrow> bool"
+  by simp
+
+(* You can still use them with more arguments and sometimes get simplification: *)
+lemma "(P and not P) = (\<lambda>_ _. \<bottom>)" for P :: "'a \<Rightarrow> 'b \<Rightarrow> 'c \<Rightarrow> bool"
+  by simp
+
+(* But sometimes you need to fold pred_top_def/pred_bot_def for rules on top/bot to fire: *)
+lemma "(P and (\<lambda>_ _. \<bottom>)) = (\<lambda>_ _. \<bottom>)"
+  by (simp flip: pred_bot_def)
+
+lemma "(P and \<bottom>\<bottom>) = \<bottom>\<bottom>"
+  by (simp flip: pred_bot_def)
+
+end
+
+end

--- a/lib/Lib.thy
+++ b/lib/Lib.thy
@@ -18,6 +18,7 @@ imports
   Extract_Conjunct
   ML_Goal
   Eval_Bool
+  Fun_Pred_Syntax
   NICTATools
   "Word_Lib.WordSetup"
 begin
@@ -77,33 +78,6 @@ lemma prod_injects:
   "(x,y) = p \<Longrightarrow> x = fst p \<and> y = snd p"
   "p = (x,y) \<Longrightarrow> x = fst p \<and> y = snd p"
   by auto
-
-definition
-  pred_conj :: "('a \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> bool)" (infixl "and" 35)
-where
-  "pred_conj P Q \<equiv> \<lambda>x. P x \<and> Q x"
-
-lemma pred_conj_absorb[simp]:
-  "(P and P) = P"
-  by (simp add: pred_conj_def)
-
-definition
-  pred_disj :: "('a \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> bool)" (infixl "or" 30)
-where
-  "pred_disj P Q \<equiv> \<lambda>x. P x \<or> Q x"
-
-lemma pred_disj_absorb[simp]:
-  "(P or P) = P"
-  by (simp add: pred_disj_def)
-
-definition
-  pred_neg :: "('a \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> bool)" ("not _" [40] 40)
-where
-  "pred_neg P \<equiv> \<lambda>x. \<not> P x"
-
-lemma pred_neg_simp[simp]:
-  "(not P) s \<longleftrightarrow> \<not> (P s)"
-  by (simp add: pred_neg_def)
 
 definition "K \<equiv> \<lambda>x y. x"
 
@@ -238,7 +212,7 @@ lemma delete_remove1:
 
 lemma ignore_if:
   "(y and z) s \<Longrightarrow> (if x then y else z) s"
-  by (clarsimp simp: pred_conj_def)
+  by simp
 
 lemma zipWith_Nil2 :
   "zipWith f xs [] = []"

--- a/lib/Monad_WP/NonDetMonad.thy
+++ b/lib/Monad_WP/NonDetMonad.thy
@@ -791,46 +791,6 @@ where
  "\<lbrace>P\<rbrace> f -,\<lbrace>Q\<rbrace> \<equiv> validE P f (\<lambda>x y. True) Q"
 
 
-text \<open>Abbreviations for trivial preconditions:\<close>
-abbreviation(input)
-  top :: "'a \<Rightarrow> bool" ("\<top>")
-where
-  "\<top> \<equiv> \<lambda>_. True"
-
-abbreviation(input)
-  bottom :: "'a \<Rightarrow> bool" ("\<bottom>")
-where
-  "\<bottom> \<equiv> \<lambda>_. False"
-
-text \<open>Abbreviations for trivial postconditions (taking two arguments):\<close>
-abbreviation(input)
-  toptop :: "'a \<Rightarrow> 'b \<Rightarrow> bool" ("\<top>\<top>")
-where
- "\<top>\<top> \<equiv> \<lambda>_ _. True"
-
-abbreviation(input)
-  botbot :: "'a \<Rightarrow> 'b \<Rightarrow> bool" ("\<bottom>\<bottom>")
-where
- "\<bottom>\<bottom> \<equiv> \<lambda>_ _. False"
-
-text \<open>
-  Lifting @{text "\<and>"} and @{text "\<or>"} over two arguments.
-  Lifting @{text "\<and>"} and @{text "\<or>"} over one argument is already
-  defined (written @{text "and"} and @{text "or"}).
-\<close>
-definition
-  bipred_conj :: "('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool)"
-  (infixl "And" 96)
-where
-  "bipred_conj P Q \<equiv> \<lambda>x y. P x y \<and> Q x y"
-
-definition
-  bipred_disj :: "('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool)"
-  (infixl "Or" 91)
-where
-  "bipred_disj P Q \<equiv> \<lambda>x y. P x y \<or> Q x y"
-
-
 subsection "Determinism"
 
 text \<open>A monad of type @{text nondet_monad} is deterministic iff it

--- a/lib/Monad_WP/NonDetMonadVCG.thy
+++ b/lib/Monad_WP/NonDetMonadVCG.thy
@@ -148,70 +148,6 @@ lemma bind_eqI:
   apply (auto simp: split_def)
   done
 
-subsection "Simplification Rules for Lifted And/Or"
-
-lemma pred_andE[elim!]: "\<lbrakk> (A and B) x; \<lbrakk> A x; B x \<rbrakk> \<Longrightarrow> R \<rbrakk> \<Longrightarrow> R"
-  by(simp add:pred_conj_def)
-
-lemma pred_andI[intro!]: "\<lbrakk> A x; B x \<rbrakk> \<Longrightarrow> (A and B) x"
-  by(simp add:pred_conj_def)
-
-lemma pred_conj_app[simp]: "(P and Q) x = (P x \<and> Q x)"
-  by(simp add:pred_conj_def)
-
-lemma bipred_andE[elim!]: "\<lbrakk> (A And B) x y; \<lbrakk> A x y; B x y \<rbrakk> \<Longrightarrow> R \<rbrakk> \<Longrightarrow> R"
-  by(simp add:bipred_conj_def)
-
-lemma bipred_andI[intro!]: "\<lbrakk> A x y; B x y \<rbrakk> \<Longrightarrow> (A And B) x y"
-  by (simp add:bipred_conj_def)
-
-lemma bipred_conj_app[simp]: "(P And Q) x = (P x and Q x)"
-  by(simp add:pred_conj_def bipred_conj_def)
-
-lemma pred_disjE[elim!]: "\<lbrakk> (P or Q) x; P x \<Longrightarrow> R; Q x \<Longrightarrow> R \<rbrakk> \<Longrightarrow> R"
-  by (fastforce simp: pred_disj_def)
-
-lemma pred_disjI1[intro]: "P x \<Longrightarrow> (P or Q) x"
-  by (simp add: pred_disj_def)
-
-lemma pred_disjI2[intro]: "Q x \<Longrightarrow> (P or Q) x"
-  by (simp add: pred_disj_def)
-
-lemma pred_disj_app[simp]: "(P or Q) x = (P x \<or> Q x)"
-  by auto
-
-lemma bipred_disjI1[intro]: "P x y \<Longrightarrow> (P Or Q) x y"
-  by (simp add: bipred_disj_def)
-
-lemma bipred_disjI2[intro]: "Q x y \<Longrightarrow> (P Or Q) x y"
-  by (simp add: bipred_disj_def)
-
-lemma bipred_disj_app[simp]: "(P Or Q) x = (P x or Q x)"
-  by(simp add:pred_disj_def bipred_disj_def)
-
-lemma pred_notnotD[simp]: "(not not P) = P"
-  by(simp add:pred_neg_def)
-
-lemma pred_and_true[simp]: "(P and \<top>) = P"
-  by(simp add:pred_conj_def)
-
-lemma pred_and_true_var[simp]: "(\<top> and P) = P"
-  by(simp add:pred_conj_def)
-
-lemma pred_and_false[simp]: "(P and \<bottom>) = \<bottom>"
-  by(simp add:pred_conj_def)
-
-lemma pred_and_false_var[simp]: "(\<bottom> and P) = \<bottom>"
-  by(simp add:pred_conj_def)
-
-lemma pred_conj_assoc:
-  "(P and Q and R) = (P and (Q and R))"
-  unfolding pred_conj_def by simp
-
-lemma pred_conj_comm:
-  "(P and Q) = (Q and P)"
-  by (auto simp: pred_conj_def)
-
 subsection "Hoare Logic Rules"
 
 lemma validE_def2:
@@ -280,15 +216,15 @@ lemma hoare_True_E_R [simp]:
   by (auto simp add: validE_R_def validE_def valid_def split: sum.splits)
 
 lemma hoare_post_conj [intro]:
-  "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> Q \<rbrace>; \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> a \<lbrace> Q And R \<rbrace>"
-  by (fastforce simp: valid_def split_def bipred_conj_def)
+  "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> Q \<rbrace>; \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> a \<lbrace> Q and R \<rbrace>"
+  by (fastforce simp: valid_def)
 
 lemma hoare_pre_disj [intro]:
   "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace>; \<lbrace> Q \<rbrace> a \<lbrace> R \<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace> P or Q \<rbrace> a \<lbrace> R \<rbrace>"
   by (simp add:valid_def pred_disj_def)
 
 lemma hoare_conj:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q And Q'\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q and Q'\<rbrace>"
   unfolding valid_def by auto
 
 lemma hoare_post_taut: "\<lbrace> P \<rbrace> a \<lbrace> \<top>\<top> \<rbrace>"
@@ -1247,7 +1183,7 @@ lemma hoare_vcg_conj_lift:
   assumes x: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   assumes y: "\<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>"
   shows      "\<lbrace>\<lambda>s. P s \<and> P' s\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>"
-  apply (subst bipred_conj_def[symmetric], rule hoare_post_conj)
+  apply (subst pred_conj_def[symmetric], subst pred_conj_def[symmetric], rule hoare_post_conj)
    apply (rule hoare_pre_imp [OF _ x], simp)
   apply (rule hoare_pre_imp [OF _ y], simp)
   done
@@ -1808,7 +1744,7 @@ lemma hoare_fun_app_wp[wp]:
   by simp+
 
 lemma hoare_validE_pred_conj:
-  "\<lbrakk> \<lbrace>P\<rbrace>f\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace>f\<lbrace>R\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>f\<lbrace>Q And R\<rbrace>,\<lbrace>E\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace>f\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace>f\<lbrace>R\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>f\<lbrace>Q and R\<rbrace>,\<lbrace>E\<rbrace>"
   unfolding valid_def validE_def by (simp add: split_def split: sum.splits)
 
 lemma hoare_validE_conj:
@@ -2038,7 +1974,7 @@ lemma validNF_prop [wp_unsafe]:
   by (wp validNF)+
 
 lemma validNF_post_conj [intro!]:
-  "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> Q \<rbrace>!; \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace>! \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> a \<lbrace> Q And R \<rbrace>!"
+  "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> Q \<rbrace>!; \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace>! \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> a \<lbrace> Q and R \<rbrace>!"
   by (auto simp: validNF_def)
 
 lemma no_fail_or:
@@ -2095,7 +2031,7 @@ lemma validNF_if_split [wp_split]:
 lemma validNF_vcg_conj_lift:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>!; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>! \<rbrakk> \<Longrightarrow>
       \<lbrace>\<lambda>s. P s \<and> P' s\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>!"
-  apply (subst bipred_conj_def[symmetric], rule validNF_post_conj)
+  apply (subst pred_conj_def[symmetric], subst pred_conj_def[symmetric], rule validNF_post_conj)
    apply (erule validNF_weaken_pre, fastforce)
   apply (erule validNF_weaken_pre, fastforce)
   done

--- a/lib/Monad_WP/TraceMonad.thy
+++ b/lib/Monad_WP/TraceMonad.thy
@@ -941,54 +941,17 @@ where
   "\<lbrace>P\<rbrace> f -,\<lbrace>Q\<rbrace> \<equiv> validE P f (\<lambda>x y. True) Q"
 
 
-text \<open> Abbreviations for trivial preconditions: \<close>
-abbreviation(input)
-  top :: "'a \<Rightarrow> bool" ("\<top>")
-where
-  "\<top> \<equiv> \<lambda>_. True"
-
-abbreviation(input)
-  bottom :: "'a \<Rightarrow> bool" ("\<bottom>")
-where
-  "\<bottom> \<equiv> \<lambda>_. False"
-
-text \<open> Abbreviations for trivial postconditions (taking two arguments): \<close>
-abbreviation(input)
-  toptop :: "'a \<Rightarrow> 'b \<Rightarrow> bool" ("\<top>\<top>")
-where
-  "\<top>\<top> \<equiv> \<lambda>_ _. True"
-
+text \<open> Abbreviations for trivial postconditions (taking three arguments): \<close>
 abbreviation(input)
   toptoptop :: "'a \<Rightarrow> 'b \<Rightarrow> 'b \<Rightarrow> bool" ("\<top>\<top>\<top>")
 where
   "\<top>\<top>\<top> \<equiv> \<lambda>_ _ _. True"
 
 abbreviation(input)
-  botbot :: "'a \<Rightarrow> 'b \<Rightarrow> bool" ("\<bottom>\<bottom>")
-where
-  "\<bottom>\<bottom> \<equiv> \<lambda>_ _. False"
-
-abbreviation(input)
   botbotbot :: "'a \<Rightarrow> 'b \<Rightarrow> 'b \<Rightarrow> bool" ("\<bottom>\<bottom>\<bottom>")
 where
   "\<bottom>\<bottom>\<bottom> \<equiv> \<lambda>_ _ _. False"
 
-text \<open>
-  Lifting @{text "\<and>"} and @{text "\<or>"} over two arguments.
-  Lifting @{text "\<and>"} and @{text "\<or>"} over one argument is already
-  defined (written @{text "and"} and @{text "or"}).
-\<close>
-definition
-  bipred_conj :: "('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool)"
-  (infixl "And" 96)
-where
-  "bipred_conj P Q \<equiv> \<lambda>x y. P x y \<and> Q x y"
-
-definition
-  bipred_disj :: "('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool)"
-  (infixl "Or" 91)
-where
-  "bipred_disj P Q \<equiv> \<lambda>x y. P x y \<or> Q x y"
 
 subsection "Determinism"
 

--- a/lib/Monad_WP/TraceMonadVCG.thy
+++ b/lib/Monad_WP/TraceMonadVCG.thy
@@ -256,8 +256,8 @@ lemma rg_validI:
      "\<lbrace>Pg\<rbrace>,\<lbrace>Rg\<rbrace> g \<lbrace>Gg\<rbrace>,\<lbrace>Qg\<rbrace>"
   and compat: "R \<le> Rf" "R \<le> Rg" "Gf \<le> G" "Gg \<le> G"
      "Gf \<le> Rg" "Gg \<le> Rf"
-  shows "\<lbrace>Pf And Pg\<rbrace>,\<lbrace>R\<rbrace> parallel f g \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Qf rv And Qg rv\<rbrace>"
-  apply (clarsimp simp: validI_def rely_def bipred_conj_def
+  shows "\<lbrace>Pf and Pg\<rbrace>,\<lbrace>R\<rbrace> parallel f g \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Qf rv and Qg rv\<rbrace>"
+  apply (clarsimp simp: validI_def rely_def pred_conj_def
                         parallel_prefix_closed validI[THEN validI_prefix_closed])
   apply (drule(3) parallel_rely_induct0[OF _ _ _ validI order_refl order_refl compat])
   apply clarsimp
@@ -633,62 +633,8 @@ lemma bind_eqI:
 
 subsection "Simplification Rules for Lifted And/Or"
 
-lemma pred_andE[elim!]: "\<lbrakk> (A and B) x; \<lbrakk> A x; B x \<rbrakk> \<Longrightarrow> R \<rbrakk> \<Longrightarrow> R"
-  by(simp add:pred_conj_def)
-
-lemma pred_andI[intro!]: "\<lbrakk> A x; B x \<rbrakk> \<Longrightarrow> (A and B) x"
-  by(simp add:pred_conj_def)
-
-lemma pred_conj_app[simp]: "(P and Q) x = (P x \<and> Q x)"
-  by(simp add:pred_conj_def)
-
-lemma bipred_andE[elim!]: "\<lbrakk> (A And B) x y; \<lbrakk> A x y; B x y \<rbrakk> \<Longrightarrow> R \<rbrakk> \<Longrightarrow> R"
-  by(simp add:bipred_conj_def)
-
-lemma bipred_andI[intro!]: "\<lbrakk> A x y; B x y \<rbrakk> \<Longrightarrow> (A And B) x y"
-  by (simp add:bipred_conj_def)
-
-lemma bipred_conj_app[simp]: "(P And Q) x = (P x and Q x)"
-  by(simp add:pred_conj_def bipred_conj_def)
-
-lemma pred_disjE[elim!]: "\<lbrakk> (P or Q) x; P x \<Longrightarrow> R; Q x \<Longrightarrow> R \<rbrakk> \<Longrightarrow> R"
-  by (fastforce simp: pred_disj_def)
-
-lemma pred_disjI1[intro]: "P x \<Longrightarrow> (P or Q) x"
-  by (simp add: pred_disj_def)
-
-lemma pred_disjI2[intro]: "Q x \<Longrightarrow> (P or Q) x"
-  by (simp add: pred_disj_def)
-
-lemma pred_disj_app[simp]: "(P or Q) x = (P x \<or> Q x)"
-  by auto
-
-lemma bipred_disjI1[intro]: "P x y \<Longrightarrow> (P Or Q) x y"
-  by (simp add: bipred_disj_def)
-
-lemma bipred_disjI2[intro]: "Q x y \<Longrightarrow> (P Or Q) x y"
-  by (simp add: bipred_disj_def)
-
-lemma bipred_disj_app[simp]: "(P Or Q) x = (P x or Q x)"
-  by(simp add:pred_disj_def bipred_disj_def)
-
-lemma pred_notnotD[simp]: "(not not P) = P"
-  by(simp add:pred_neg_def)
-
-lemma pred_and_true[simp]: "(P and \<top>) = P"
-  by(simp add:pred_conj_def)
-
-lemma pred_and_true_var[simp]: "(\<top> and P) = P"
-  by(simp add:pred_conj_def)
-
-lemma pred_and_false[simp]: "(P and \<bottom>) = \<bottom>"
-  by(simp add:pred_conj_def)
-
-lemma pred_and_false_var[simp]: "(\<bottom> and P) = \<bottom>"
-  by(simp add:pred_conj_def)
-
 lemma bipred_disj_op_eq[simp]:
-  "reflp R \<Longrightarrow> (=) Or R = R"
+  "reflp R \<Longrightarrow> ((=) or R) = R"
   apply (rule ext, rule ext)
   apply (auto simp: reflp_def)
   done
@@ -759,15 +705,15 @@ lemma hoare_True_E_R [simp]:
   by (auto simp add: validE_R_def validE_def valid_def split: sum.splits)
 
 lemma hoare_post_conj [intro!]:
-  "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> Q \<rbrace>; \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> a \<lbrace> Q And R \<rbrace>"
-  by (fastforce simp: valid_def split_def bipred_conj_def)
+  "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> Q \<rbrace>; \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> a \<lbrace> Q and R \<rbrace>"
+  by (fastforce simp: valid_def split_def pred_conj_def)
 
 lemma hoare_pre_disj [intro!]:
   "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace>; \<lbrace> Q \<rbrace> a \<lbrace> R \<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace> P or Q \<rbrace> a \<lbrace> R \<rbrace>"
   by (simp add:valid_def pred_disj_def)
 
 lemma hoare_conj:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q And Q'\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q and Q'\<rbrace>"
   unfolding valid_def
   by (auto)
 
@@ -1656,7 +1602,7 @@ lemma hoare_vcg_conj_lift:
   assumes x: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   assumes y: "\<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>"
   shows      "\<lbrace>\<lambda>s. P s \<and> P' s\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>"
-  apply (subst bipred_conj_def[symmetric], rule hoare_post_conj)
+  apply (subst pred_conj_def[symmetric], subst pred_conj_def[symmetric], rule hoare_post_conj)
    apply (rule hoare_pre_imp [OF _ x], simp)
   apply (rule hoare_pre_imp [OF _ y], simp)
   done
@@ -2082,7 +2028,7 @@ lemma hoare_fun_app_wp[wp]:
   by simp+
 
 lemma hoare_validE_pred_conj:
-  "\<lbrakk> \<lbrace>P\<rbrace>f\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace>f\<lbrace>R\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>f\<lbrace>Q And R\<rbrace>,\<lbrace>E\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace>f\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace>f\<lbrace>R\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>f\<lbrace>Q and R\<rbrace>,\<lbrace>E\<rbrace>"
   unfolding valid_def validE_def by (simp add: split_def split: sum.splits)
 
 lemma hoare_validE_conj:
@@ -2285,7 +2231,7 @@ lemma validNF_prop [wp_unsafe]:
   by (wp validNF)+
 
 lemma validNF_post_conj [intro!]:
-  "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> Q \<rbrace>!; \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace>! \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> a \<lbrace> Q And R \<rbrace>!"
+  "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> Q \<rbrace>!; \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace>! \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> a \<lbrace> Q and R \<rbrace>!"
   by (clarsimp simp: validNF_def)
 
 lemma no_fail_or:
@@ -2342,7 +2288,7 @@ lemma validNF_split_if [wp_split]:
 lemma validNF_vcg_conj_lift:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>!; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>! \<rbrakk> \<Longrightarrow>
       \<lbrace>\<lambda>s. P s \<and> P' s\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>!"
-  apply (subst bipred_conj_def[symmetric], rule validNF_post_conj)
+  apply (subst pred_conj_def[symmetric], subst pred_conj_def[symmetric], rule validNF_post_conj)
    apply (erule validNF_weaken_pre, fastforce)
   apply (erule validNF_weaken_pre, fastforce)
   done

--- a/lib/Monad_WP/wp/Eisbach_WP.thy
+++ b/lib/Monad_WP/wp/Eisbach_WP.thy
@@ -66,7 +66,7 @@ method post_asm_raw methods m =
    rule trivial_imp)
 
 method post_asm methods m =
-  (post_asm_raw \<open>(simp only: bipred_conj_def pred_conj_def)?,(elim conjE)?,m\<close>)
+  (post_asm_raw \<open>(simp only: pred_conj_def)?,(elim conjE)?,m\<close>)
 
 
 named_theorems packed_validEs
@@ -86,7 +86,7 @@ method post_raw methods m =
 
 method post_strong methods m_distinct m_all =
   (post_raw
-     \<open>(simp only: pred_conj_def bipred_conj_def)?,
+     \<open>(simp only: pred_conj_def)?,
       (intro impI conjI allI)?,
       distinct_subgoals_strong \<open>m_distinct\<close>,
       all \<open>m_all\<close>,
@@ -121,6 +121,9 @@ private lemma hoare_decomposeE:
   by (fastforce simp add: validE_R_def validE_E_def validE_def valid_def pred_conj_def split: prod.splits sum.splits)
 
 private lemmas hoare_decomposes' = hoare_decompose hoare_decomposeE_R hoare_decomposeE_E hoare_decomposeE
+
+private lemmas bipred_conj_def =
+  inf_fun_def[where 'b="'b \<Rightarrow> bool", unfolded inf_fun_def[where 'b="bool"], simplified]
 
 private method add_pred_conj = (subst pred_conj_def[symmetric])
 private method add_bipred_conj = (subst bipred_conj_def[symmetric])

--- a/lib/Monad_WP/wp/WPEx.thy
+++ b/lib/Monad_WP/wp/WPEx.thy
@@ -95,7 +95,7 @@ fun get_wp_simps_strgs ctxt rules asms = let
 
 fun postcond_ss ctxt = ctxt
     |> put_simpset HOL_basic_ss
-    |> (fn ctxt => ctxt addsimps [@{thm pred_conj_def}])
+    |> (fn ctxt => ctxt addsimps @{thms pred_conj_def})
     |> simpset_of
 
 fun wp_default_ss ctxt = ctxt

--- a/lib/MonadicRewrite.thy
+++ b/lib/MonadicRewrite.thy
@@ -148,13 +148,13 @@ lemma monadic_rewrite_bindE:
   done
 
 lemmas monadic_rewrite_bind_tail
-  = monadic_rewrite_bind[OF monadic_rewrite_refl, simplified pred_and_true_var]
+  = monadic_rewrite_bind[OF monadic_rewrite_refl, simplified pred_top_left_neutral]
 
 lemmas monadic_rewrite_bind_head
-  = monadic_rewrite_bind[OF _ monadic_rewrite_refl hoare_vcg_prop, simplified pred_and_true]
+  = monadic_rewrite_bind[OF _ monadic_rewrite_refl hoare_vcg_prop, simplified pred_top_right_neutral]
 
 lemmas monadic_rewrite_bindE_tail
-  = monadic_rewrite_bindE[OF monadic_rewrite_refl, simplified pred_and_true_var]
+  = monadic_rewrite_bindE[OF monadic_rewrite_refl, simplified pred_top_left_neutral]
 
 lemmas monadic_rewrite_bindE_head
     = monadic_rewrite_bindE[OF _ monadic_rewrite_refl hoare_vcg_propE_R]
@@ -521,7 +521,7 @@ lemma monadic_rewrite_bind_alternative:
   done
 
 lemmas monadic_rewrite_bind_alternative_l
-  = monadic_rewrite_trans[OF monadic_rewrite_bind_alternative, simplified pred_and_true_var]
+  = monadic_rewrite_trans[OF monadic_rewrite_bind_alternative, simplified pred_top_left_neutral]
 
 lemma monadic_rewrite_alternative_l:
   "monadic_rewrite F False \<top> (alternative f g) g"

--- a/lib/NonDetMonadLemmaBucket.thy
+++ b/lib/NonDetMonadLemmaBucket.thy
@@ -1485,7 +1485,7 @@ lemma hoare_eq_P:
   by (rule assms)
 
 lemma hoare_validE_R_conj:
-  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, -; \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>, -\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q And R\<rbrace>, -"
+  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, -; \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>, -\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q and R\<rbrace>, -"
   by (simp add: valid_def validE_def validE_R_def Let_def split_def split: sum.splits)
 
 lemma hoare_vcg_const_imp_lift_R:

--- a/lib/StateMonad.thy
+++ b/lib/StateMonad.thy
@@ -10,7 +10,7 @@
 
 chapter "Monads"
 
-theory StateMonad (* FIXME: untested/unused *)
+theory StateMonad (* unused *)
 imports Lib
 begin
 
@@ -400,34 +400,6 @@ lemma validE_def2:
   "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> \<equiv> \<lbrace>P\<rbrace> f \<lbrace> \<lambda>r s. case r of Inr b \<Rightarrow> Q b s | Inl a \<Rightarrow> R a s \<rbrace>"
   by (unfold valid_def validE_def)
 
-(* FIXME: modernize *)
-syntax top :: "'a \<Rightarrow> bool" ("\<top>")
-       bottom :: "'a \<Rightarrow> bool" ("\<bottom>")
-
-translations
-  "\<top>" == "\<lambda>_. CONST True"
-  "\<bottom>" == "\<lambda>_. CONST False"
-
-definition
-  bipred_conj :: "('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool)" (infixl "And" 96)
-where
-  "bipred_conj P Q \<equiv> \<lambda>x y. P x y \<and> Q x y"
-
-definition
-  bipred_disj :: "('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool)" (infixl "Or" 91)
-where
-  "bipred_disj P Q \<equiv> \<lambda>x y. P x y \<or> Q x y"
-
-definition
-  bipred_neg :: "('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool)" ("Not _") where
-  "bipred_neg P \<equiv> \<lambda>x y. \<not> P x y"
-
-syntax toptop :: "'a \<Rightarrow> 'b \<Rightarrow> bool" ("\<top>\<top>")
-       botbot :: "'a \<Rightarrow> 'b \<Rightarrow> bool" ("\<bottom>\<bottom>")
-
-translations "\<top>\<top>" == "\<lambda>_ _. CONST True"
-             "\<bottom>\<bottom>" == "\<lambda>_ _. CONST False"
-
 definition
   pred_lift_exact :: "('a \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool)" ("\<guillemotleft>_,_\<guillemotright>") where
   "pred_lift_exact P Q \<equiv> \<lambda>x y. P x \<and> Q y"
@@ -445,47 +417,11 @@ lemma pred_liftI[intro!]: "\<lbrakk> P x; Q y \<rbrakk> \<Longrightarrow> \<guil
   by (simp add:pred_lift_exact_def)
 
 lemma pred_exact_split:
-  "\<guillemotleft>P,Q\<guillemotright> = (\<guillemotleft>P,\<top>\<guillemotright> And \<guillemotleft>\<top>,Q\<guillemotright>)"
-  by (simp add:pred_lift_exact_def bipred_conj_def)
-
-lemma pred_andE[elim!]: "\<lbrakk> (A and B) x; \<lbrakk> A x; B x \<rbrakk> \<Longrightarrow> R \<rbrakk> \<Longrightarrow> R"
-  by (simp add:pred_conj_def)
-
-lemma pred_andI[intro!]: "\<lbrakk> A x; B x \<rbrakk> \<Longrightarrow> (A and B) x"
-  by (simp add:pred_conj_def)
-
-lemma bipred_conj_app[simp]: "(P And Q) x = (P x and Q x)"
-  by (simp add:pred_conj_def bipred_conj_def)
-
-lemma bipred_disj_app[simp]: "(P Or Q) x = (P x or Q x)"
-  by (simp add:pred_disj_def bipred_disj_def)
-
-lemma pred_conj_app[simp]: "(P and Q) x = (P x \<and> Q x)"
-  by (simp add:pred_conj_def)
-
-lemma pred_disj_app[simp]: "(P or Q) x = (P x \<or> Q x)"
-  by (simp add:pred_disj_def)
-
-lemma pred_notnotD[simp]: "(not not P) = P"
-  by (simp add:pred_neg_def)
-
-lemma bipred_notnotD[simp]: "(Not Not P) = P"
-  by (simp add:bipred_neg_def)
+  "\<guillemotleft>P,Q\<guillemotright> = (\<guillemotleft>P,\<top>\<guillemotright> and \<guillemotleft>\<top>,Q\<guillemotright>)"
+  by (simp add:pred_lift_exact_def pred_conj_def)
 
 lemma pred_lift_add[simp]: "\<guillemotleft>P,Q\<guillemotright> x = ((\<lambda>s. P x) and Q)"
   by (simp add:pred_lift_exact_def pred_conj_def)
-
-lemma pred_and_true[simp]: "(P and \<top>) = P"
-  by (simp add:pred_conj_def)
-
-lemma pred_and_true_var[simp]: "(\<top> and P) = P"
-  by (simp add:pred_conj_def)
-
-lemma pred_and_false[simp]: "(P and \<bottom>) = \<bottom>"
-  by (simp add:pred_conj_def)
-
-lemma pred_and_false_var[simp]: "(\<bottom> and P) = \<bottom>"
-  by (simp add:pred_conj_def)
 
 lemma seq':
   "\<lbrakk> \<lbrace>A\<rbrace> f \<lbrace>B\<rbrace>;
@@ -569,8 +505,8 @@ lemma return_sp:
   by (simp add:return_def valid_def)
 
 lemma hoare_post_conj [intro!]:
-  "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> Q \<rbrace>; \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> a \<lbrace> Q And R \<rbrace>"
-  by (simp add:valid_def split_def bipred_conj_def)
+  "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> Q \<rbrace>; \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> a \<lbrace> Q and R \<rbrace>"
+  by (simp add:valid_def split_def pred_conj_def)
 
 lemma hoare_pre_disj [intro!]:
   "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace>; \<lbrace> Q \<rbrace> a \<lbrace> R \<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace> P or Q \<rbrace> a \<lbrace> R \<rbrace>"

--- a/lib/concurrency/Prefix_Refinement.thy
+++ b/lib/concurrency/Prefix_Refinement.thy
@@ -441,15 +441,15 @@ lemma validI_drop_next_G:
 lemma tr_in_parallel_validI:
   assumes elem: "(tr, res) \<in> parallel (K {(f_tr, res)}) (K {(g_tr, res)}) s"
   and trs: "(f_tr, res) \<in> f s" "(g_tr, res) \<in> g s"
-  and validI: "\<lbrace>P\<rbrace>, \<lbrace>E Or Gg\<rbrace> f \<lbrace>Gf\<rbrace>, \<lbrace>Q\<rbrace>" "\<lbrace>P\<rbrace>, \<lbrace>E Or Gf\<rbrace> g \<lbrace>Gg\<rbrace>, \<lbrace>Q2\<rbrace>"
+  and validI: "\<lbrace>P\<rbrace>, \<lbrace>E or Gg\<rbrace> f \<lbrace>Gf\<rbrace>, \<lbrace>Q\<rbrace>" "\<lbrace>P\<rbrace>, \<lbrace>E or Gf\<rbrace> g \<lbrace>Gg\<rbrace>, \<lbrace>Q2\<rbrace>"
   and P: "P s0 s" and rel: "rely_cond E s0 tr"
-  shows "rely_cond (E Or Gg) s0 f_tr \<and> rely_cond (E Or Gf) s0 g_tr"
+  shows "rely_cond (E or Gg) s0 f_tr \<and> rely_cond (E or Gf) s0 g_tr"
   using parallel_rely_induct0[where R=E and G="\<top>\<top>", OF elem _ _ validI, OF P P]
   by (clarsimp simp: rel trs predicate2I)
 
 lemma env_closed_parallel_fragment:
-  "is_matching_fragment sr osr rvr ctr1 cres1 s0 (E Or Gg) s f
-    \<Longrightarrow> is_matching_fragment sr osr' rvr ctr2 cres2 s0 (E Or Gf) s g
+  "is_matching_fragment sr osr rvr ctr1 cres1 s0 (E or Gg) s f
+    \<Longrightarrow> is_matching_fragment sr osr' rvr ctr2 cres2 s0 (E or Gf) s g
     \<Longrightarrow> par_tr_fin_principle f
     \<Longrightarrow> par_tr_fin_principle g
     \<Longrightarrow> cres1 = cres2 \<Longrightarrow> length ctr1 = length ctr2
@@ -470,7 +470,7 @@ lemma env_closed_parallel_fragment:
   apply (frule(1) is_matching_fragment_trD[where f=f])
   apply (frule(1) is_matching_fragment_trD[where f=g])
   apply (clarsimp simp: matching_tr_pfx_aCons rely_cond_Cons_eq
-                        last_st_tr_map_zip bipred_disj_def)
+                        last_st_tr_map_zip pred_disj_def)
   apply (drule spec2, drule(1) mp[where P="Q xs s" for xs s])
   apply clarsimp
   apply (drule_tac s'=s' in env_closedD[where f=f, OF is_matching_fragment_env_closed, rotated];
@@ -486,13 +486,13 @@ lemma env_closed_parallel_fragment:
 lemma self_closed_parallel_fragment:
   notes if_split[split del]
   shows
-  "is_matching_fragment sr osr rvr ctr1 cres1 s0 (E Or Gg) s f
-    \<Longrightarrow> is_matching_fragment sr osr' rvr ctr2 cres2 s0 (E Or Gf) s g
+  "is_matching_fragment sr osr rvr ctr1 cres1 s0 (E or Gg) s f
+    \<Longrightarrow> is_matching_fragment sr osr' rvr ctr2 cres2 s0 (E or Gf) s g
     \<Longrightarrow> par_tr_fin_principle f
     \<Longrightarrow> par_tr_fin_principle g
     \<Longrightarrow> list_all2 (\<lambda>y z. (fst y = Env \<or> fst z = Env) \<and> snd y = snd z) ctr1 ctr2
-    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>E Or Gg\<rbrace> f \<lbrace>Gf\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
-    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>E Or Gf\<rbrace> g \<lbrace>Gg\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
+    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>E or Gg\<rbrace> f \<lbrace>Gf\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
+    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>E or Gf\<rbrace> g \<lbrace>Gg\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
     \<Longrightarrow> P s0 s
     \<Longrightarrow> cres1 = cres2
     \<Longrightarrow> Q = (\<lambda>xs. length xs < length ctr1 \<and> (fst (rev ctr1 ! length xs) \<noteq> Env
@@ -570,15 +570,15 @@ lemma rely_env_closed:
   done
 
 theorem prefix_refinement_parallel:
-  "prefix_refinement sr isr osr rvr P Q (AE Or Gc) (E Or Gd) a b
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P Q (AE Or Ga) (E Or Gb) c d
+  "prefix_refinement sr isr osr rvr P Q (AE or Gc) (E or Gd) a b
+    \<Longrightarrow> prefix_refinement sr isr osr rvr P Q (AE or Ga) (E or Gb) c d
     \<Longrightarrow> par_tr_fin_principle a
     \<Longrightarrow> par_tr_fin_principle c
-    \<Longrightarrow> \<lbrace>Q\<rbrace>,\<lbrace>E Or Gd\<rbrace> b \<lbrace>Gb\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
-    \<Longrightarrow> \<lbrace>Q\<rbrace>,\<lbrace>E Or Gb\<rbrace> d \<lbrace>Gd\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
+    \<Longrightarrow> \<lbrace>Q\<rbrace>,\<lbrace>E or Gd\<rbrace> b \<lbrace>Gb\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
+    \<Longrightarrow> \<lbrace>Q\<rbrace>,\<lbrace>E or Gb\<rbrace> d \<lbrace>Gd\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
     \<Longrightarrow> (Ga = \<top>\<top> \<and> Gc = \<top>\<top>)
-        \<or> (\<lbrace>P\<rbrace>,\<lbrace>AE Or Gc\<rbrace> a \<lbrace>Ga\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
-            \<and> \<lbrace>P\<rbrace>,\<lbrace>AE Or Ga\<rbrace> c \<lbrace>Gc\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>)
+        \<or> (\<lbrace>P\<rbrace>,\<lbrace>AE or Gc\<rbrace> a \<lbrace>Ga\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
+            \<and> \<lbrace>P\<rbrace>,\<lbrace>AE or Ga\<rbrace> c \<lbrace>Gc\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>)
     \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AE E (parallel a c) (parallel b d)"
   apply (subst prefix_refinement_def, clarsimp)
   apply (drule tr_in_parallel, clarify)
@@ -893,7 +893,7 @@ theorem prefix_refinement_bind_general[rule_format]:
     \<Longrightarrow> (\<forall>x y. rvr x y \<longrightarrow> prefix_refinement sr intsr osr rvr' (P'' x) (Q'' y) AR R (b x) (d y))
     \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>AR\<rbrace> a \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>P''\<rbrace> \<or> \<lbrace>\<lambda>s. \<exists>s0. P' s0 s\<rbrace> a \<lbrace>\<lambda>rv s. \<forall>s0. P'' rv s0 s\<rbrace>
     \<Longrightarrow> \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> c \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>Q''\<rbrace>
-    \<Longrightarrow> prefix_refinement sr isr osr rvr' (P And P') (Q And Q') AR R (a >>= b) (c >>= d)"
+    \<Longrightarrow> prefix_refinement sr isr osr rvr' (P and P') (Q and Q') AR R (a >>= b) (c >>= d)"
   apply (subst prefix_refinement_def, clarsimp simp: bind_def)
   apply (rename_tac c_tr c_res cd_tr cd_res)
   apply (drule(5) prefix_refinementD, simp)
@@ -978,7 +978,7 @@ theorem prefix_refinement_validI:
     \<Longrightarrow> \<forall>s0 t0 t. sr s0 t0 \<and> R t0 t \<longrightarrow> (\<exists>s. R' s0 s \<and> sr s t)
     \<Longrightarrow> prefix_closed g
     \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
-  apply (subst validI_def, clarsimp simp: bipred_conj_def rely_def)
+  apply (subst validI_def, clarsimp simp: rely_def)
   apply (drule spec2, drule(1) mp, clarsimp)
   apply (drule(6) prefix_refinement_rely_cond_trD[where R'=R', simplified])
     apply blast
@@ -1021,7 +1021,7 @@ lemma prefix_refinement_bind_v[rule_format]:
   "prefix_refinement sr isr intsr rvr P Q AR R a c
     \<Longrightarrow> (\<forall>x y. rvr x y \<longrightarrow> prefix_refinement sr intsr osr rvr' (\<lambda>s0. P'' x) (Q'' y) AR R (b x) (d y))
     \<Longrightarrow> \<lbrace>P'\<rbrace> a \<lbrace>P''\<rbrace> \<Longrightarrow> \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> c \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>Q''\<rbrace>
-    \<Longrightarrow> prefix_refinement sr isr osr rvr' (\<lambda>s0. P s0 and P') (Q And Q') AR R (a >>= b) (c >>= d)"
+    \<Longrightarrow> prefix_refinement sr isr osr rvr' (\<lambda>s0. P s0 and P') (Q and Q') AR R (a >>= b) (c >>= d)"
   apply (rule prefix_refinement_weaken_pre,
     rule prefix_refinement_bind_general[where P'="\<lambda>_. P'"])
        apply assumption
@@ -1323,13 +1323,13 @@ lemmas pfx_refn_bind = prefix_refinement_bind_v[where sr=sr
     and isr=sr and osr=sr and intsr=sr for sr]
 lemmas pfx_refn_bindT
     = pfx_refn_bind[where P'="\<top>" and Q'="\<lambda>_ _. True", OF _ _ hoare_post_taut validI_triv,
-        simplified bipred_conj_def, simplified]
+        simplified pred_conj_def, simplified]
 
 lemma prefix_refinement_assume_pre:
   "(P \<Longrightarrow> prefix_refinement sr isr osr rvr P' Q' AR R f g)
-    \<Longrightarrow> prefix_refinement sr isr osr rvr (P' And (\<lambda>_ _. P)) Q' AR R f g"
+    \<Longrightarrow> prefix_refinement sr isr osr rvr (P' and (\<lambda>_ _. P)) Q' AR R f g"
   "(P \<Longrightarrow> prefix_refinement sr isr osr rvr P' Q' AR R f g)
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P' (Q' And (\<lambda>_ _. P)) AR R f g"
+    \<Longrightarrow> prefix_refinement sr isr osr rvr P' (Q' and (\<lambda>_ _. P)) AR R f g"
   by (auto simp: prefix_refinement_def)
 
 lemma prefix_refinement_modify:
@@ -1351,7 +1351,7 @@ lemmas pfx_refn_modifyT = prefix_refinement_modify[where P="\<top>" and Q="\<top
 lemmas prefix_refinement_get_pre
     = prefix_refinement_bind[OF prefix_refinement_get _
         valid_validI_wp[OF _ get_sp] valid_validI_wp[OF _ get_sp],
-    simplified bipred_conj_def no_trace_all, simplified]
+    simplified pred_conj_def no_trace_all, simplified]
 
 lemma prefix_refinement_gets:
   "\<forall>s t. iosr s t \<and> P s \<and> Q t \<longrightarrow> rvr (f s) (f' t)
@@ -1454,7 +1454,7 @@ lemma prefix_refinement_mapM:
         apply (rule prefix_refinement_triv_pre, rule prefix_refinement_return_imp, simp)
        apply (wp validI_triv)+
       apply (blast intro: validI_prefix_closed)
-     apply (wp validI_triv | simp add: bipred_conj_def
+     apply (wp validI_triv | simp add: pred_conj_def
         | blast dest: validI_prefix_closed)+
   done
 

--- a/lib/concurrency/examples/Peterson_Atomicity.thy
+++ b/lib/concurrency/examples/Peterson_Atomicity.thy
@@ -597,7 +597,7 @@ theorem peterson_proc_refinement:
          apply (rule critical_section_refinement)
         apply (rule release_lock_refinement)
        apply (wpsimp wp: validI_triv acquire_lock_wp
-                     simp: bipred_conj_def)+
+                     simp: pred_conj_def)+
   done
 
 definition

--- a/lib/concurrency/examples/Plus2_Prefix.thy
+++ b/lib/concurrency/examples/Plus2_Prefix.thy
@@ -90,8 +90,8 @@ corollary plus2_x_parallel:
   apply (rule validI_weaken_pre)
    apply (rule validI_strengthen_post)
     apply ((rule rg_validI plus2_x_property[where tids="{1, 2}"])+; simp add: plus2_rel_def le_fun_def)
-   apply (clarsimp simp: plus2_inv_def bipred_conj_def)
-  apply (clarsimp simp add: bipred_conj_def plus2_inv_def)
+   apply (clarsimp simp: plus2_inv_def)
+  apply (clarsimp simp add: plus2_inv_def)
   done
 
 section \<open>Mapping across prefix refinement.\<close>
@@ -170,7 +170,7 @@ lemma plus2_x_n_parallel_induct:
     rule rg_validI, rule plus2_x_property[where tids="{..< N}"],
     assumption, (clarsimp simp: plus2_rel_def)+)
    apply (auto dest: less_Suc_eq[THEN iffD1])[1]
-  apply (clarsimp simp: bipred_conj_def)
+  apply clarsimp
   done
 
 theorem plus2_x_n_parallel:
@@ -204,9 +204,9 @@ lemma fold_parallel_prefix_closed[where xs="rev xs" for xs, simplified]:
   by (induct xs, simp_all add: parallel_prefix_closed)
 
 lemma bipred_disj_top_eq:
-  "(Rel Or (\<lambda>_ _. True)) = (\<lambda>_ _. True)"
-  "((\<lambda>_ _. True) Or Rel) = (\<lambda>_ _. True)"
-  by (auto simp add: bipred_disj_def)
+  "(Rel or (\<lambda>_ _. True)) = (\<lambda>_ _. True)"
+  "((\<lambda>_ _. True) or Rel) = (\<lambda>_ _. True)"
+  by auto
 
 lemma fold_parallel_pfx_refn_induct:
   "list_all2 (prefix_refinement sr sr sr (\<lambda>_ _. True) P Q (\<top>\<top>) (\<top>\<top>)) xs ys

--- a/lib/crunch-cmd.ML
+++ b/lib/crunch-cmd.ML
@@ -493,7 +493,7 @@ fun get_inst_precond ctxt pre extra (mapply, goal) = let
        match what we were trying to prove, thus a THM exception from RS *)
   handle THM _ => NONE;
 
-fun split_precond (Const (@{const_name pred_conj}, _) $ P $ Q)
+fun split_precond (Const (@{const_name inf}, _) $ P $ Q)
     = split_precond P @ split_precond Q
   | split_precond (Abs (n, T, @{const "HOL.conj"} $ P $ Q))
     = maps (split_precond o Envir.eta_contract) [Abs (n, T, P), Abs (n, T, Q)]
@@ -517,7 +517,7 @@ fun combine_preconds ctxt pre pres = let
       |> remove (op aconv) pre |> distinct (op aconv)
       |> filter (precond_needed ctxt pre ctxt);
     val T = fastype_of pre;
-    val conj = Const (@{const_name pred_conj}, T --> T --> T)
+    val conj = Const (@{const_name inf}, T --> T --> T)
   in case pres' of
       [] => pre
     | _ => let val precond = foldl1 (fn (a, b) => conj $ a $ b) pres'

--- a/lib/sep_algebra/Sep_Forward.thy
+++ b/lib/sep_algebra/Sep_Forward.thy
@@ -59,7 +59,8 @@ lemma sep_conj_coimpl_cancel''':
 lemma sep_coimpl_cancel':
   "(\<And>s. pred_imp Q P s) \<Longrightarrow> (P \<leadsto>* R) s   \<Longrightarrow>
    (\<And>s. R s \<Longrightarrow> R' s) \<Longrightarrow> (Q \<leadsto>* R') s"
-  by (metis pred_neg_def sep_coimpl_def sep_conj_def)
+  by (metis sep_coimpl_weaken sep_snake_septraction septraction_snake_trivial)
+
 
 definition "pointer P \<equiv> (\<forall>x y. \<forall>s R. (P x \<and>* R) s \<longrightarrow> (P y \<leadsto>* R and (\<lambda>s. x = y)) s)"
 

--- a/proof/access-control/Ipc_AC.thy
+++ b/proof/access-control/Ipc_AC.thy
@@ -671,7 +671,7 @@ lemma remove_rights_cur_auth:
   by (clarsimp dest!: remove_rights_cap_auth_conferred_subset)
 
 (* FIXME MOVE *)
-lemmas hoare_gen_asmE2 = hoare_gen_asmE[where P'=\<top>,simplified pred_and_true_var]
+lemmas hoare_gen_asmE2 = hoare_gen_asmE[where P'=\<top>,simplified pred_top_left_neutral]
 
 lemma derive_cap_is_transferable:
   "\<lbrace>K (is_transferable_cap cap)\<rbrace> derive_cap slot cap \<lbrace>\<lambda>rv _. is_transferable_cap rv\<rbrace>, -"

--- a/proof/capDL-api/IRQ_DP.thy
+++ b/proof/capDL-api/IRQ_DP.thy
@@ -433,7 +433,7 @@ lemma seL4_IRQHandler_SetEndpoint_wp:
   apply (rule hoare_gen_asm)
   apply (wp seL4_IRQHandler_SetEndpoint_wp_helper [where irq_handler_slot=endpoint_slot
                                                      and cap'=old_cap and t="obj_tcb root_tcb"], simp)
-  apply (rule pred_andI)
+  apply (rule pred_conjI)
    apply sep_solve
   apply clarsimp
   apply (case_tac endpoint_cap, simp_all add: is_memory_cap_def cap_type_def)

--- a/proof/crefine/lib/AutoCorres_C.thy
+++ b/proof/crefine/lib/AutoCorres_C.thy
@@ -256,11 +256,11 @@ method ccorres_to_corres_pre_step =
   (rule ccorres_to_corres_pre_intros | erule ccorres_to_corres_pre_elims)
 
 method ccorres_to_corres_pre_process = (
-  (elim pred_andE)?,
+  (elim inf1E inf2E)?,
   (simp only: Int_assoc)?,
   (ccorres_to_corres_pre_step+)?,
   (rule ccorres_to_corres_pre_finalise),
-  (intro pred_andI TrueI; clarsimp)
+  (intro pred_conjI TrueI; clarsimp)
 )
 
 text \<open>

--- a/proof/drefine/Intent_DR.thy
+++ b/proof/drefine/Intent_DR.thy
@@ -555,12 +555,6 @@ lemma mapM_load_word_offs_do_machine_op:
   apply (simp add: load_word_offs_def[abs_def] mapM_map_simp o_def)
   done
 
-lemma and_assoc:
-  "(A and B and C) = (A and (B and C))"
-  apply (rule ext)
-  apply clarsimp
-done
-
 lemma det_spec_return:
   "det_spec P (return x)"
   by (clarsimp simp:return_def det_spec_def)
@@ -1044,7 +1038,7 @@ lemma get_ipc_buffer_words:
   "\<lbrace>(=) sa and ko_at (TCB obj) thread and K_bind (evalMonad (lookup_ipc_buffer in_receive thread) sa = Some (Some buf))\<rbrace>
     mapM (load_word_offs (buf)) (ls)
    \<lbrace>\<lambda>buf_mrs s. buf_mrs = get_ipc_buffer_words (machine_state sa) obj (ls)\<rbrace>"
-  apply (simp add:and_assoc get_ipc_buffer_words_def)
+  apply (simp add: pred_conj_aci get_ipc_buffer_words_def)
   apply (rule wp_spec)
   apply clarsimp
   apply (drule lookup_ipc_buffer_SomeB_evalMonad)

--- a/proof/drefine/Ipc_DR.thy
+++ b/proof/drefine/Ipc_DR.thy
@@ -1987,13 +1987,13 @@ lemma dcorres_handle_arch_fault_reply:
   "dcorres dc \<top> (tcb_at y and valid_idle and not_idle_thread y and  valid_etcbs)
    (corrupt_tcb_intent y)
    (handle_arch_fault_reply a y mi mrs)"
-   apply (cases a)
-   apply (clarsimp simp: handle_arch_fault_reply_def)
-   apply (rule corres_guard_imp)
-     apply (rule corres_corrupt_tcb_intent_return)
-    apply assumption
-   apply (erule pred_andE | rule pred_andI | assumption)+
-   done
+  apply (cases a)
+  apply (clarsimp simp: handle_arch_fault_reply_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_corrupt_tcb_intent_return)
+   apply assumption
+  apply clarsimp
+  done
 
 
 lemma dcorres_handle_fault_reply:

--- a/proof/infoflow/CNode_IF.thy
+++ b/proof/infoflow/CNode_IF.thy
@@ -500,7 +500,7 @@ lemma gets_irq_masks_equiv_valid:
   by (fastforce simp: equiv_valid_def2 equiv_valid_2_def in_monad)
 
 lemma irq_state_increment_reads_respects_memory:
-  "equiv_valid_inv (equiv_machine_state P And equiv_irq_state)
+  "equiv_valid_inv (equiv_machine_state P and equiv_irq_state)
                    (equiv_for (\<lambda>x. aag_can_affect_label aag l \<and>
                                    pasObjectAbs aag x \<in> subjectReads (pasPolicy aag) l)
                               underlying_memory)
@@ -511,7 +511,7 @@ lemma irq_state_increment_reads_respects_memory:
   done
 
 lemma irq_state_increment_reads_respects_device:
-  "equiv_valid_inv (equiv_machine_state P And equiv_irq_state)
+  "equiv_valid_inv (equiv_machine_state P and equiv_irq_state)
                    (equiv_for (\<lambda>x. aag_can_affect_label aag l \<and>
                                    pasObjectAbs aag x \<in> subjectReads (pasPolicy aag) l)
                               device_state)

--- a/proof/infoflow/InfoFlow_IF.thy
+++ b/proof/infoflow/InfoFlow_IF.thy
@@ -764,14 +764,14 @@ lemma gets_kheap_revrv:
 
 lemma gets_machine_state_revrv:
   "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
-     (equiv_machine_state (aag_can_read aag or aag_can_affect aag l) And equiv_irq_state)
+     (equiv_machine_state (aag_can_read aag or aag_can_affect aag l) and equiv_irq_state)
      \<top> (gets machine_state)"
   by (fastforce simp: equiv_valid_2_def gets_def get_def return_def bind_def
                 elim: reads_equivE affects_equivE equiv_forE
                intro: equiv_forI)
 
 lemma gets_machine_state_revrv':
-  "reads_equiv_valid_rv_inv A aag (equiv_machine_state (aag_can_read aag) And equiv_irq_state)
+  "reads_equiv_valid_rv_inv A aag (equiv_machine_state (aag_can_read aag) and equiv_irq_state)
                             \<top> (gets machine_state)"
   by (fastforce simp: equiv_valid_2_def gets_def get_def return_def bind_def
                 elim: reads_equivE affects_equivE equiv_forE
@@ -892,7 +892,7 @@ context InfoFlow_IF_1 begin
 
 lemma do_machine_op_spec_reads_respects':
   assumes equiv_dmo:
-   "equiv_valid_inv (equiv_machine_state (aag_can_read aag) And equiv_irq_state)
+   "equiv_valid_inv (equiv_machine_state (aag_can_read aag) and equiv_irq_state)
                     (equiv_machine_state (aag_can_affect aag l)) Q f"
   assumes guard:
     "\<And>s. P s \<Longrightarrow> Q (machine_state s)"
@@ -948,7 +948,7 @@ lemma do_machine_op_rev:
   unfolding do_machine_op_def equiv_valid_def2
   apply (rule_tac W="\<lambda> rv rv'. equiv_machine_state (aag_can_read aag) rv rv' \<and> equiv_irq_state rv rv'"
              and Q="\<lambda> rv s. rv = machine_state s " in equiv_valid_rv_bind)
-    apply (blast intro: equiv_valid_rv_guard_imp[OF gets_machine_state_revrv'[simplified bipred_conj_def]])
+    apply (blast intro: equiv_valid_rv_guard_imp[OF gets_machine_state_revrv'[simplified pred_conj_def]])
    apply (rule_tac R'="\<lambda> (r, ms') (r', ms'').  r = r' \<and> equiv_machine_state (aag_can_read aag) ms' ms''"
               and Q="\<lambda> (r,ms') s. ms' = rv \<and> rv = machine_state s "
               and Q'="\<lambda> (r',ms'') s. ms'' = rv' \<and> rv' = machine_state s"

--- a/proof/infoflow/refine/RISCV64/ArchADT_IF_Refine_C.thy
+++ b/proof/infoflow/refine/RISCV64/ArchADT_IF_Refine_C.thy
@@ -53,7 +53,7 @@ lemma handleInvocation_ccorres'[ADT_IF_Refine_assms]:
        (UNIV \<inter> {s. isCall_' s = from_bool isCall}
              \<inter> {s. isBlocking_' s = from_bool isBlocking}) []
        (handleInvocation isCall isBlocking) (Call handleInvocation_'proc)"
-  apply (simp only: arch_extras_def pred_and_true)
+  apply (simp only: arch_extras_def pred_top_right_neutral)
   apply (rule handleInvocation_ccorres)
   done
 

--- a/proof/invariant-abstract/Deterministic_AI.thy
+++ b/proof/invariant-abstract/Deterministic_AI.thy
@@ -41,10 +41,8 @@ declare dxo_wp_weak[wp del]
 
  (*Some nasty hackery to get around lack of polymorphic type class operations*)
 
-lemma and_assoc: "(A and (B and C)) = (A and B and C)"
-  apply (rule ext)
-  apply simp
-done
+lemma and_assoc: "(A and (B and C)) = (A and B and C)" (* FIXME: eliminate *)
+  by (simp add: pred_conj_aci)
 
 lemma no_children_empty_desc:
   "(\<forall>c. m c \<noteq> Some slot) = (descendants_of slot m = {})"

--- a/proof/invariant-abstract/Tcb_AI.thy
+++ b/proof/invariant-abstract/Tcb_AI.thy
@@ -721,12 +721,12 @@ where
 | "tcb_inv_wf (tcb_invocation.ThreadControl t sl fe mcp pr croot vroot buf)
              = (tcb_at t and case_option \<top> (valid_cap \<circ> fst) croot
                         and K (case_option True (is_cnode_cap \<circ> fst) croot)
-                        and case_option \<top> ((cte_at And ex_cte_cap_to) \<circ> snd) croot
+                        and case_option \<top> ((cte_at and ex_cte_cap_to) \<circ> snd) croot
                         and case_option \<top> (no_cap_to_obj_dr_emp \<circ> fst) croot
                         and K (case_option True (is_valid_vtable_root \<circ> fst) vroot)
                         and case_option \<top> (valid_cap \<circ> fst) vroot
                         and case_option \<top> (no_cap_to_obj_dr_emp \<circ> fst) vroot
-                        and case_option \<top> ((cte_at And ex_cte_cap_to) \<circ> snd) vroot
+                        and case_option \<top> ((cte_at and ex_cte_cap_to) \<circ> snd) vroot
                         and (case_option \<top> (case_option \<top> (valid_cap o fst) o snd) buf)
                         and (case_option \<top> (case_option \<top>
                               (no_cap_to_obj_dr_emp o fst) o snd) buf)
@@ -735,7 +735,7 @@ where
                                ((swp valid_ipc_buffer_cap (fst v)
                                     and is_arch_cap and is_cnode_or_valid_arch)
                                               o fst) (snd v)) buf)
-                        and (case_option \<top> (case_option \<top> ((cte_at And ex_cte_cap_to) o snd) o snd) buf)
+                        and (case_option \<top> (case_option \<top> ((cte_at and ex_cte_cap_to) o snd) o snd) buf)
                         and (\<lambda>s. {croot, vroot, option_map undefined buf} \<noteq> {None}
                                     \<longrightarrow> cte_at sl s \<and> ex_cte_cap_to sl s)
                         and K (case_option True (\<lambda>bl. length bl = word_bits) fe)

--- a/proof/invariant-abstract/VSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/VSpaceEntries_AI.thy
@@ -164,16 +164,13 @@ lemma hoare_vcg_const_Ball_liftE:
   "\<lbrakk> \<And>x. x \<in> S \<Longrightarrow> \<lbrace>P x\<rbrace> f \<lbrace>Q x\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>\<lambda>s. True\<rbrace> f \<lbrace>\<lambda>r s. True\<rbrace>, \<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x\<in>S. P x s\<rbrace> f \<lbrace>\<lambda>rv s. \<forall>x\<in>S. Q x rv s\<rbrace>,\<lbrace>E\<rbrace>"
   by (fastforce simp: validE_def valid_def split: sum.splits)
 
-lemma hoare_post_conjE:
-  "\<lbrakk> \<lbrace> P \<rbrace> a \<lbrace> Q \<rbrace>,\<lbrace>E\<rbrace>; \<lbrace> P \<rbrace> a \<lbrace> R \<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> a \<lbrace> Q And R \<rbrace>,\<lbrace>E\<rbrace>"
-  by (clarsimp simp: validE_def valid_def split_def bipred_conj_def
-              split: sum.splits)
+lemmas hoare_post_conjE = hoare_validE_pred_conj (* FIXME: eliminate *)
 
-lemma hoare_vcg_conj_liftE:
+lemma hoare_vcg_conj_liftE: (* FIXME: move *)
   assumes x: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   assumes y: "\<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace>"
   shows      "\<lbrace>\<lambda>s. P s \<and> P' s\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>,\<lbrace>E\<rbrace>"
-  apply (subst bipred_conj_def[symmetric], rule hoare_post_conjE)
+  apply (subst pred_conj_def[symmetric], subst pred_conj_def[symmetric], rule hoare_post_conjE)
    apply (rule hoare_vcg_precond_impE [OF x], simp)
   apply (rule hoare_vcg_precond_impE [OF y], simp)
   done

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -7148,13 +7148,11 @@ next
   case (4 ptr bits n slot)
   let ?target = "(ptr, nat_to_cref (zombie_cte_bits bits) n)"
   note hyps = "4.hyps"[simplified rec_del_concrete_unfold spec_corres_liftME2]
-  have pred_conj_assoc: "\<And>P Q R. (P and (Q and R)) = (P and Q and R)"
-    by (rule ext, simp)
   show ?case
     apply (simp only: rec_del_concrete_unfold cap_relation.simps)
     apply (simp add: reduceZombie_def Let_def
                      liftE_bindE
-                del: pred_conj_app)
+                del: inf_apply)
     apply (subst rec_del_simps_ext)
     apply (rule_tac F="ptr + 2 ^ cte_level_bits * of_nat n
                          = cte_map ?target"

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -2561,7 +2561,6 @@ lemma removeFromBitmap_bitmapQ_no_L2_orphans[wp]:
   unfolding bitmap_fun_defs
   apply (wp, clarsimp simp: bitmap_fun_defs bitmapQ_no_L2_orphans_def)+
   apply (rule conjI, clarsimp)
-   apply (rule conjI, clarsimp)
    apply (clarsimp simp: complement_nth_w2p l2BitmapSize_def')
   apply clarsimp
   apply metis

--- a/proof/refine/ARM_HYP/CNodeInv_R.thy
+++ b/proof/refine/ARM_HYP/CNodeInv_R.thy
@@ -7222,13 +7222,11 @@ next
   case (4 ptr bits n slot)
   let ?target = "(ptr, nat_to_cref (zombie_cte_bits bits) n)"
   note hyps = "4.hyps"[simplified rec_del_concrete_unfold spec_corres_liftME2]
-  have pred_conj_assoc: "\<And>P Q R. (P and (Q and R)) = (P and Q and R)"
-    by (rule ext, simp)
   show ?case
     apply (simp only: rec_del_concrete_unfold cap_relation.simps)
     apply (simp add: reduceZombie_def Let_def
                      liftE_bindE
-                del: pred_conj_app)
+                del: inf_apply)
     apply (subst rec_del_simps_ext)
     apply (rule_tac F="ptr + 2 ^ cte_level_bits * of_nat n
                          = cte_map ?target"

--- a/proof/refine/ARM_HYP/TcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/TcbAcc_R.thy
@@ -2645,7 +2645,6 @@ lemma removeFromBitmap_bitmapQ_no_L2_orphans[wp]:
   unfolding bitmap_fun_defs
   apply (wp, clarsimp simp: bitmap_fun_defs bitmapQ_no_L2_orphans_def)+
   apply (rule conjI, clarsimp)
-   apply (rule conjI, clarsimp)
    apply (clarsimp simp: complement_nth_w2p l2BitmapSize_def')
   apply clarsimp
   apply metis

--- a/proof/refine/RISCV64/CNodeInv_R.thy
+++ b/proof/refine/RISCV64/CNodeInv_R.thy
@@ -7153,13 +7153,11 @@ next
   case (4 ptr bits n slot)
   let ?target = "(ptr, nat_to_cref (zombie_cte_bits bits) n)"
   note hyps = "4.hyps"[simplified rec_del_concrete_unfold spec_corres_liftME2]
-  have pred_conj_assoc: "\<And>P Q R. (P and (Q and R)) = (P and Q and R)"
-    by (rule ext, simp)
   show ?case
     apply (simp only: rec_del_concrete_unfold cap_relation.simps)
     apply (simp add: reduceZombie_def Let_def
                      liftE_bindE
-                del: pred_conj_app)
+                del: inf_apply)
     apply (subst rec_del_simps_ext)
     apply (rule_tac F="ptr + 2 ^ cte_level_bits * of_nat n
                          = cte_map ?target"

--- a/proof/refine/RISCV64/TcbAcc_R.thy
+++ b/proof/refine/RISCV64/TcbAcc_R.thy
@@ -2612,7 +2612,6 @@ lemma removeFromBitmap_bitmapQ_no_L2_orphans[wp]:
   unfolding bitmap_fun_defs
   apply (wp, clarsimp simp: bitmap_fun_defs bitmapQ_no_L2_orphans_def)+
   apply (rule conjI, clarsimp)
-   apply (rule conjI, clarsimp)
    apply (clarsimp simp: complement_nth_w2p l2BitmapSize_def')
   apply clarsimp
   apply metis

--- a/proof/refine/X64/CNodeInv_R.thy
+++ b/proof/refine/X64/CNodeInv_R.thy
@@ -7295,13 +7295,11 @@ next
   case (4 ptr bits n slot)
   let ?target = "(ptr, nat_to_cref (zombie_cte_bits bits) n)"
   note hyps = "4.hyps"[simplified rec_del_concrete_unfold spec_corres_liftME2]
-  have pred_conj_assoc: "\<And>P Q R. (P and (Q and R)) = (P and Q and R)"
-    by (rule ext, simp)
   show ?case
     apply (simp only: rec_del_concrete_unfold cap_relation.simps)
     apply (simp add: reduceZombie_def Let_def
                      liftE_bindE
-                del: pred_conj_app)
+                del: inf_apply)
     apply (subst rec_del_simps_ext)
     apply (rule_tac F="ptr + 2 ^ cte_level_bits * of_nat n
                          = cte_map ?target"

--- a/proof/refine/X64/TcbAcc_R.thy
+++ b/proof/refine/X64/TcbAcc_R.thy
@@ -2599,7 +2599,6 @@ lemma removeFromBitmap_bitmapQ_no_L2_orphans[wp]:
   unfolding bitmap_fun_defs
   apply (wp, clarsimp simp: bitmap_fun_defs bitmapQ_no_L2_orphans_def)+
   apply (rule conjI, clarsimp)
-   apply (rule conjI, clarsimp)
    apply (clarsimp simp: complement_nth_w2p l2BitmapSize_def')
   apply clarsimp
   apply metis

--- a/sys-init/CreateIRQCaps_SI.thy
+++ b/sys-init/CreateIRQCaps_SI.thy
@@ -455,7 +455,7 @@ lemma create_irq_caps_sep:
   apply (elim conjE)
   apply (subst si_objects_extra_caps'_split, assumption+)
   apply (rule hoare_chain [OF create_irq_caps_sep_helper, where orig_caps1=orig_caps])
-   apply (rule pred_andI)
+   apply (rule pred_conjI)
     apply sep_solve
    apply clarsimp
   apply clarsimp

--- a/sys-init/InitIRQ_SI.thy
+++ b/sys-init/InitIRQ_SI.thy
@@ -66,7 +66,7 @@ lemma seL4_IRQHandler_SetEndpoint_irq_initialised_helper_sep:
                  (si_cnode_id, unat seL4_CapInitThreadCNode) \<mapsto>c si_cnode_cap \<and>*
                  (si_cnode_id, unat seL4_CapIRQControl) \<mapsto>c IrqControlCap \<and>*
                   si_asid \<and>*  R"])
-   apply (intro pred_andI)
+   apply (intro pred_conjI)
     apply (clarsimp simp: object_type_is_object default_cap_def)
     apply (sep_drule sep_map_c_sep_map_s [where cap=NullCap])
      apply (rule object_slots_object_default_state_NullCap', (simp add: object_type_has_slots)+)

--- a/sys-init/Proof_SI.thy
+++ b/sys-init/Proof_SI.thy
@@ -254,7 +254,7 @@ lemma sys_init_explicit:
   apply (subst objects_empty_by_parts, assumption)+
   apply (subst objects_empty_objects_initialised_capless)+
   apply (clarsimp simp: linorder_not_le)
-  apply (intro conjI allI impI pred_andI | sep_cancel+)+
+  apply (intro conjI allI impI pred_conjI | sep_cancel+)+
          apply fastforce
         apply (clarsimp simp: less_diff_conv)
         apply (rule list_all_drop, erule (1) le_list_all)

--- a/tools/autocorres/Polish.thy
+++ b/tools/autocorres/Polish.thy
@@ -475,9 +475,8 @@ lemma boringE_bind_K_bind [simp, polish]:
   done
 
 (* Misc *)
-
-declare pred_and_true_var [L2opt, polish]
-declare pred_and_true [L2opt, polish]
+declare pred_top_left_neutral [L2opt, polish]
+declare pred_top_right_neutral [L2opt, polish]
 
 lemmas [polish] = rel_simps eq_numeral_extra
 

--- a/tools/autocorres/doc/quickstart/ROOT
+++ b/tools/autocorres/doc/quickstart/ROOT
@@ -5,7 +5,7 @@
  *)
 
 session "AutoCorresQuickstart" = "AutoCorres" +
-  options [document = pdf, document_output = output, show_question_marks = false]
+  options [document = pdf, document_output = "output", show_question_marks = false]
   theories
     Chapter1_MinMax
     Chapter2_HoareHeap

--- a/tools/autocorres/local_var_extract.ML
+++ b/tools/autocorres/local_var_extract.ML
@@ -32,7 +32,7 @@ val the' = Utils.the'
 
 (* Simpset we use for automated tactics. *)
 fun setup_l2_ss ctxt = put_simpset AUTOCORRES_SIMPSET ctxt
-                         addsimps [@{thm pred_conj_def}]
+                         addsimps @{thms pred_conj_def}
 
 (* Convert a set of variable names into an Isabelle list of strings. *)
 fun var_set_to_isa_list prog_info s =
@@ -1354,7 +1354,7 @@ fun get_l2corres_thm ctxt prog_info l1_infos l1_call_info do_opt trace_opt fn_na
     |> apply_tac "solve main goal" (resolve_tac ctxt [thm] 1)
     |> apply_tac "solve guard_imp" (REPEAT (FIRST [
           resolve_tac ctxt @{thms HOL.refl} 1,
-          resolve_tac ctxt @{thms pred_andI} 1,
+          resolve_tac ctxt @{thms pred_conjI} 1,
           resolve_tac ctxt @{thms conjI} 1,
           CHANGED (asm_full_simp_tac (setup_l2_ss ctxt) 1)]))
     |> Goal.finish ctxt

--- a/tools/autocorres/utils.ML
+++ b/tools/autocorres/utils.ML
@@ -678,7 +678,7 @@ fun isa_str_list_to_ml t =
 fun chain_preds stateT [] = Abs ("s", stateT, @{term "HOL.True"})
   | chain_preds     _ [x] = x
   | chain_preds stateT (x::xs) =
-      Const (@{const_name "pred_conj"},
+      Const (@{const_name "inf_class.inf"},
           (stateT --> @{typ bool}) --> (stateT --> @{typ bool}) --> (stateT --> @{typ bool}))
         $ x $ (chain_preds stateT xs)
 


### PR DESCRIPTION
The idea is to use the pre-defined boolean algebra class to have `pred_conj` (`_ and _`) not only on one-argument predicates `'s => bool`, but on predicates (functions to bool) with any number of arguments. In particular, this eliminates the need for a second `And` constant and specialised rules for that.

In addition, it turns out that we defined this setup multiple times separately in each monad development instead of once in a library.

The new `pred_conj` ends up as just an abbreviation for `inf_class.inf` from boolean algebras (to be precise, from the semilattice class that is used to construct the boolean algebra class).

Contains:

- lib update
- proof update
- a fix for a problem in AutoCorresDoc ROOT that for some reason hasn't triggered until now