### PR TITLE
modernise sum type discriminators+selectors

### DIFF
--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -1194,7 +1194,7 @@ lemmas corres_split_dc = corres_split[where r'=dc, simplified]
 
 lemma isLeft_case_sum:
   "isLeft v \<Longrightarrow> (case v of Inl v' \<Rightarrow> f v' | Inr v' \<Rightarrow> g v') = f (theLeft v)"
-  by (clarsimp simp: isLeft_def)
+  by (clarsimp split: sum.splits)
 
 lemma corres_symb_exec_catch_r:
   "\<lbrakk> \<And>rv. corres_underlying sr nf nf' r P (Q' rv) f (h rv);
@@ -1207,7 +1207,7 @@ lemma corres_symb_exec_catch_r:
    apply assumption
   apply (simp add: validE_def)
   apply (erule hoare_chain, simp_all)[1]
-  apply (simp add: isLeft_def split: sum.split_asm)
+  apply (simp split: sum.split_asm)
   done
 
 lemma corres_return_eq_same:

--- a/lib/LemmaBucket.thy
+++ b/lib/LemmaBucket.thy
@@ -100,10 +100,10 @@ lemmas mapM_x_accumulate_checks
 lemma isRight_rel_sum_comb2:
   "\<lbrakk> (f \<oplus> r) v v'; isRight v' \<rbrakk>
        \<Longrightarrow> isRight v \<and> r (theRight v) (theRight v')"
-  by (clarsimp simp: isRight_def)
+  by (cases v; clarsimp)
 
 lemma isRight_case_sum: "isRight x \<Longrightarrow> case_sum f g x = g (theRight x)"
-  by (clarsimp simp add: isRight_def)
+  by (cases x; clarsimp)
 
 lemma enumerate_append:"enumerate i (xs @ ys) = enumerate i xs @ enumerate (i + length xs) ys"
   apply (induct xs arbitrary:ys i)

--- a/lib/Lib.thy
+++ b/lib/Lib.thy
@@ -67,19 +67,31 @@ where
   "delete y [] = []"
 | "delete y (x#xs) = (if y=x then xs else x # delete y xs)"
 
-primrec (nonexhaustive)
-  theRight :: "'a + 'b \<Rightarrow> 'b" where
-  "theRight (Inr x) = x"
+(* Nicer names for sum discriminators and selectors *)
 
-primrec (nonexhaustive)
-  theLeft :: "'a + 'b \<Rightarrow> 'a" where
-  "theLeft (Inl x) = x"
+abbreviation theLeft :: "'a + 'b \<Rightarrow> 'a" where
+  "theLeft \<equiv> projl"
 
-definition
- "isLeft x \<equiv> (\<exists>y. x = Inl y)"
+lemmas theLeft_simps = sum.sel(1)
 
-definition
- "isRight x \<equiv> (\<exists>y. x = Inr y)"
+abbreviation theRight :: "'a + 'b \<Rightarrow> 'b" where
+  "theRight \<equiv> projr"
+
+lemmas theRight_simps = sum.sel(2)
+
+abbreviation isLeft :: "'a + 'b \<Rightarrow> bool" where
+  "isLeft \<equiv> isl"
+
+lemmas isLeft_def = isl_def
+
+(* When you feel the urge to match something like "?P (isRight ?x)", consider using
+   "?P (isLeft ?x)" instead, because there is no primitive "isr", just "\<not>isl _". *)
+abbreviation isRight :: "'a + 'b \<Rightarrow> bool" where
+  "isRight \<equiv> \<lambda>x. \<not> isl x"
+
+lemma isRight_def:
+  "isRight x = (\<exists>y. x = Inr y)"
+  by (cases x; simp)
 
 definition
  "const x \<equiv> \<lambda>y. x"
@@ -186,7 +198,7 @@ lemma ignore_if:
 
 lemma isRight_right_map:
   "isRight (case_sum Inl (Inr o f) v) = isRight v"
-  by (simp add: isRight_def split: sum.split)
+  by (simp split: sum.split)
 
 lemma first_in_uptoD:
   "a \<le> b \<Longrightarrow> (a::'a::order) \<in> {a..b}"

--- a/lib/MonadicRewrite.thy
+++ b/lib/MonadicRewrite.thy
@@ -633,7 +633,7 @@ lemma monadic_rewrite_case_sum:
      \<And>v. x = Inr v \<Longrightarrow> monadic_rewrite F E (Q v) (b v) (d v) \<rbrakk>
    \<Longrightarrow> monadic_rewrite F E (\<lambda>s. (\<not> isRight x \<longrightarrow> P (theLeft x) s) \<and> (isRight x \<longrightarrow> Q (theRight x) s))
         (case_sum a b x) (case_sum c d x)"
-  by (cases x, simp_all add: isRight_def)
+  by (cases x; simp)
 
 text \<open>WP proof via monadic rewriting\<close>
 

--- a/lib/NonDetMonadLemmaBucket.thy
+++ b/lib/NonDetMonadLemmaBucket.thy
@@ -40,7 +40,7 @@ lemma gets_the_validE_R_wp:
 
 lemma return_bindE:
   "isRight v \<Longrightarrow> return v >>=E f = f (theRight v)"
-  by (clarsimp simp: isRight_def return_returnOk)
+  by (cases v; clarsimp simp: return_returnOk)
 
 lemma list_case_return: (* FIXME lib: move to Lib *)
   "(case xs of [] \<Rightarrow> return v | y # ys \<Rightarrow> return (f y ys))
@@ -53,13 +53,15 @@ lemma lifted_if_collapse: (* FIXME lib: move to Lib *)
 
 lemmas list_case_return2 = list_case_return (* FIXME lib: eliminate *)
 
-lemma valid_isRight_theRight_split:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q True rv s\<rbrace>,\<lbrace>\<lambda>e s. \<forall>v. Q False v s\<rbrace> \<Longrightarrow>
-     \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q (isRight rv) (theRight rv) s\<rbrace>"
+(* We use isLeft, because isLeft=isl is the primitive concept; isRight=\<not>isl matches on isl. *)
+lemma valid_isLeft_theRight_split:
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q False rv s\<rbrace>,\<lbrace>\<lambda>e s. \<forall>v. Q True v s\<rbrace> \<Longrightarrow>
+     \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q (isLeft rv) (theRight rv) s\<rbrace>"
   apply (simp add: validE_def)
   apply (erule hoare_strengthen_post)
-  apply (simp add: isRight_def split: sum.split_asm)
+  apply (simp split: sum.split_asm)
   done
+
 
 (* depends on Lib.list_induct_suffix *)
 lemma mapM_x_inv_wp2:

--- a/proof/capDL-api/Invocation_DP.thy
+++ b/proof/capDL-api/Invocation_DP.thy
@@ -556,61 +556,61 @@ lemma call_kernel_with_intent_no_fault_helper:
   using unify
   apply (simp add:call_kernel_with_intent_def)
   apply wp
-       apply (rule_tac P = "thread_ptr = root_tcb_id" in hoare_gen_asm)
-       apply (simp add:call_kernel_loop_def)
-       apply (rule_tac Q = "\<lambda>r s. cdl_current_thread s = Some root_tcb_id
-                              \<and> cdl_current_domain s = minBound \<longrightarrow> Q s
-              " in hoare_strengthen_post[rotated])
-        apply fastforce
-       apply clarsimp
-       apply wp
-          apply (rule hoare_vcg_imp_lift)
-           apply (wpc|wp hoare_vcg_imp_lift|simp cong: if_cong)+
-           apply (rule hoare_pre_cont)
-          apply (wp has_restart_cap_sep_wp[where cap = RunningCap])[1]
-         apply wp
+        apply (rule_tac P = "thread_ptr = root_tcb_id" in hoare_gen_asm)
+        apply (simp add:call_kernel_loop_def)
         apply (rule_tac Q = "\<lambda>r s. cdl_current_thread s = Some root_tcb_id
-                             \<and> cdl_current_domain s = minBound \<longrightarrow> (Q s
-                             \<and>  <(root_tcb_id, tcb_pending_op_slot) \<mapsto>c RunningCap \<and>* (\<lambda>s. True)> s)"
-               in hoare_strengthen_post)
-         apply (rule schedule_no_choice_wp)
-        apply fastforce
-       apply (rule whileLoop_wp[where
-               I = "\<lambda>rv s. case rv of Inl _ \<Rightarrow> (tcb_at'
-                    (\<lambda>tcb. cdl_intent_op (cdl_tcb_intent tcb) = Some intent_op \<and>
-                           cdl_intent_cap (cdl_tcb_intent tcb) = cdl_intent_cap intent \<and>
-                           cdl_intent_extras (cdl_tcb_intent tcb) = cdl_intent_extras intent)
-                           root_tcb_id s
-                    \<and> cdl_current_thread s = Some root_tcb_id
-                    \<and> cdl_current_domain s = minBound \<and> Pd2 s)
-               | Inr rv \<Rightarrow> Q (Inr rv) s" and Q=Q for Q, rotated])
-        apply (case_tac r, simp_all add: isLeft_def)[1]
-       apply (simp add: validE_def[symmetric])
-       apply (rule hoare_pre, wp)
-         apply (simp add: validE_def, (wp | simp add: validE_def[symmetric])+)
-         apply (wp handle_pending_interrupts_no_ntf_cap)
-        apply (rule handle_event_syscall_no_decode_exception
-                  [where cur_thread = root_tcb_id
-                     and intent_op = intent_op
-                     and intent_cptr = intent_cptr
-                     and intent_extra = intent_extra])
-                apply (wp set_cap_wp set_cap_all_scheduable_tcbs
-                        set_cap_hold delete_cap_simple_wp[where cap = RestartCap])[1]
-               apply (rule decode_invocation_no_exception)
-              apply (rule lookup_extra_caps_exec)
-             apply (rule lookup_cap_and_slot_exec)
-            apply (rule non_ep_cap)
-           apply ((wp corrupt_ipc_buffer_sep_inv corrupt_ipc_buffer_active_tcbs
-                mark_tcb_intent_error_hold corrupt_ipc_buffer_hold | simp)+)[2]
-         apply (rule hoare_post_impErr[OF perform_invocation_hold])
-          apply (fastforce simp:sep_state_projection_def sep_any_def
-            sep_map_c_def sep_conj_def)
-         apply simp
-        apply (wp set_restart_cap_hold)
-       apply (clarsimp simp: isLeft_def)
+                               \<and> cdl_current_domain s = minBound \<longrightarrow> Q s
+               " in hoare_strengthen_post[rotated])
+         apply fastforce
+        apply clarsimp
+        apply wp
+           apply (rule hoare_vcg_imp_lift)
+            apply (wpc|wp hoare_vcg_imp_lift|simp cong: if_cong)+
+            apply (rule hoare_pre_cont)
+           apply (wp has_restart_cap_sep_wp[where cap = RunningCap])[1]
+          apply wp
+         apply (rule_tac Q = "\<lambda>r s. cdl_current_thread s = Some root_tcb_id
+                              \<and> cdl_current_domain s = minBound \<longrightarrow> (Q s
+                              \<and>  <(root_tcb_id, tcb_pending_op_slot) \<mapsto>c RunningCap \<and>* (\<lambda>s. True)> s)"
+                in hoare_strengthen_post)
+          apply (rule schedule_no_choice_wp)
+         apply fastforce
+        apply (rule whileLoop_wp[where
+                I = "\<lambda>rv s. case rv of Inl _ \<Rightarrow> (tcb_at'
+                     (\<lambda>tcb. cdl_intent_op (cdl_tcb_intent tcb) = Some intent_op \<and>
+                            cdl_intent_cap (cdl_tcb_intent tcb) = cdl_intent_cap intent \<and>
+                            cdl_intent_extras (cdl_tcb_intent tcb) = cdl_intent_extras intent)
+                            root_tcb_id s
+                     \<and> cdl_current_thread s = Some root_tcb_id
+                     \<and> cdl_current_domain s = minBound \<and> Pd2 s)
+                | Inr rv \<Rightarrow> Q (Inr rv) s" and Q=Q for Q, rotated])
+         apply (case_tac r, simp_all)[1]
+        apply (simp add: validE_def[symmetric])
+        apply (rule hoare_pre, wp)
+          apply (simp add: validE_def, (wp | simp add: validE_def[symmetric])+)
+          apply (wp handle_pending_interrupts_no_ntf_cap)
+         apply (rule handle_event_syscall_no_decode_exception
+                   [where cur_thread = root_tcb_id
+                      and intent_op = intent_op
+                      and intent_cptr = intent_cptr
+                      and intent_extra = intent_extra])
+                 apply (wp set_cap_wp set_cap_all_scheduable_tcbs
+                         set_cap_hold delete_cap_simple_wp[where cap = RestartCap])[1]
+                apply (rule decode_invocation_no_exception)
+               apply (rule lookup_extra_caps_exec)
+              apply (rule lookup_cap_and_slot_exec)
+             apply (rule non_ep_cap)
+            apply ((wp corrupt_ipc_buffer_sep_inv corrupt_ipc_buffer_active_tcbs
+                 mark_tcb_intent_error_hold corrupt_ipc_buffer_hold | simp)+)[2]
+          apply (rule hoare_post_impErr[OF perform_invocation_hold])
+           apply (fastforce simp:sep_state_projection_def sep_any_def
+             sep_map_c_def sep_conj_def)
+          apply simp
+         apply (wp set_restart_cap_hold)
+        apply (clarsimp split: sum.split_asm)
        apply (rule_tac P = "thread_ptr = root_tcb_id" in hoare_gen_asm)
-   apply simp
-   apply (wp upd_thread update_thread_wp)+
+       apply simp
+       apply (wp upd_thread update_thread_wp)+
   apply auto
   done
 
@@ -1043,87 +1043,86 @@ lemma call_kernel_with_intent_allow_error_helper:
   using unify
   apply (simp add:call_kernel_with_intent_def)
   apply (wp thread_has_error_wp)
-    apply (simp add:call_kernel_loop_def)
-    apply (rule_tac P = "thread_ptr = root_tcb_id" in hoare_gen_asm)
-    apply (rule_tac Q = "\<lambda>r s. (cdl_current_thread s = Some root_tcb_id
-                             \<and> cdl_current_domain s = minBound) \<longrightarrow> (
-      ((\<not> tcb_has_error (the (cdl_current_thread s)) s) \<longrightarrow> Q s) \<and>
-      ((tcb_has_error (the (cdl_current_thread s)) s) \<longrightarrow> Perror s))"
-      in hoare_strengthen_post[rotated])
-    apply (fastforce simp: error_imp)
-    apply wp
-       (* fragile , do not know why *)
-       apply (rule hoare_vcg_imp_lift[where P' = "\<lambda>s. cdl_current_thread s \<noteq> Some root_tcb_id
-                                                    \<or> cdl_current_domain s \<noteq> minBound"])
-        apply (rule hoare_pre,(wp hoare_vcg_imp_lift|wpc|simp cong: if_cong)+)[1]
-        apply (wp | wpc | simp)+
-        apply (rule hoare_pre_cont)
-       apply (wp has_restart_cap_sep_wp[where cap = RunningCap])+
-       apply simp
-      apply (rule_tac current_thread1=root_tcb_id and current_domain1=minBound in
-                        hoare_strengthen_post[OF schedule_no_choice_wp])
-      apply (clarsimp, assumption)
-     apply clarsimp
-    apply (rule_tac Q = "\<lambda>r a. (\<not> tcb_has_error root_tcb_id a \<longrightarrow> (Q a
-      \<and> cdl_current_thread a = Some root_tcb_id
-      \<and> cdl_current_domain a = minBound
-      \<and> <(root_tcb_id, tcb_pending_op_slot) \<mapsto>c RunningCap \<and>* (\<lambda>s. True)> a))
-      \<and> (tcb_has_error root_tcb_id a \<longrightarrow> (Perror a
-      \<and> cdl_current_thread a = Some root_tcb_id
-      \<and> cdl_current_domain a = minBound
-      \<and> <(root_tcb_id, tcb_pending_op_slot) \<mapsto>c RunningCap \<and>* (\<lambda>s. True)> a))"
-      in hoare_strengthen_post[rotated])
-     apply fastforce
-       apply (rule whileLoop_wp[where
-               I = "\<lambda>rv s. case rv of Inl _ \<Rightarrow> (tcb_at'
-                    (\<lambda>tcb. cdl_intent_op (cdl_tcb_intent tcb) = Some intent_op \<and>
-                           cdl_intent_cap (cdl_tcb_intent tcb) = cdl_intent_cap intent \<and>
-                           cdl_intent_extras (cdl_tcb_intent tcb) = cdl_intent_extras intent \<and>
-                           cdl_intent_error (cdl_tcb_intent tcb) = False)
-                           root_tcb_id s
-                    \<and> cdl_current_thread s = Some root_tcb_id
-                    \<and> cdl_current_domain s = minBound \<and> Pd2 s)
-               | Inr rv \<Rightarrow> Q (Inr rv) s" and Q=Q for Q, rotated])
-        apply (case_tac r, simp_all add: isLeft_def)[1]
-       apply (simp add: validE_def[symmetric])
-       apply (rule hoare_pre, wp)
-         apply (simp add: validE_def, (wp | simp add: validE_def[symmetric])+)
-         apply (wp handle_pending_interrupts_no_ntf_cap)
-
-    apply (rule handle_event_syscall_allow_error
-      [where cur_thread = root_tcb_id
-         and intent_op = intent_op
-         and intent_cptr = intent_cptr
-         and intent_extra = intent_extra])
-            apply (wp set_cap_wp
-              set_cap_hold delete_cap_simple_wp[where cap = RestartCap])[1]
-           apply (rule decode_invocation_allow_error)
-          apply (rule lookup_extra_caps_exec)
-         apply (rule lookup_cap_and_slot_exec)
-        apply (unfold validE_R_def)
-        apply (rule hoare_post_impErr)
-          apply (rule lookup_cap_and_slot_exec)
+        apply (simp add:call_kernel_loop_def)
+        apply (rule_tac P = "thread_ptr = root_tcb_id" in hoare_gen_asm)
+        apply (rule_tac Q = "\<lambda>r s. (cdl_current_thread s = Some root_tcb_id
+                                    \<and> cdl_current_domain s = minBound) \<longrightarrow>
+                                       (\<not>tcb_has_error (the (cdl_current_thread s)) s \<longrightarrow> Q s) \<and>
+                                       (tcb_has_error (the (cdl_current_thread s)) s \<longrightarrow> Perror s)"
+                        in hoare_strengthen_post[rotated])
+         apply (fastforce simp: error_imp)
+        apply wp (* fragile , do not know why *)
+           apply (rule hoare_vcg_imp_lift[where P' = "\<lambda>s. cdl_current_thread s \<noteq> Some root_tcb_id
+                                                          \<or> cdl_current_domain s \<noteq> minBound"])
+            apply (rule hoare_pre,(wp hoare_vcg_imp_lift|wpc|simp cong: if_cong)+)[1]
+           apply (wp | wpc | simp)+
+            apply (rule hoare_pre_cont)
+           apply (wp has_restart_cap_sep_wp[where cap = RunningCap])+
          apply simp
-        apply simp
-       apply ((wp corrupt_ipc_buffer_sep_inv corrupt_ipc_buffer_active_tcbs
-         mark_tcb_intent_error_hold corrupt_ipc_buffer_hold | simp)+)[4]
-     apply (rule hoare_post_impErr[OF perform_invocation_hold])
-       apply (fastforce simp:sep_state_projection_def sep_any_def
-         sep_map_c_def sep_conj_def)
-      apply simp
-     apply (wp set_restart_cap_hold)
-    apply (clarsimp dest!:error_imp)
-    apply (sep_cancel, simp)
-    apply (clarsimp simp: isLeft_def)
-   apply (rule_tac P = "thread_ptr = root_tcb_id" in hoare_gen_asm)
-   apply simp
-   apply (wp upd_thread update_thread_wp)+
-  apply (clarsimp)
-  apply (clarsimp simp:sep_map_c_conj sep_map_f_conj object_at_def
-    object_project_def sep_state_projection_def
-    split:option.splits cdl_object.split)
+         apply (rule_tac current_thread1=root_tcb_id and current_domain1=minBound in
+                         hoare_strengthen_post[OF schedule_no_choice_wp])
+         apply (clarsimp, assumption)
+        apply clarsimp
+        apply (rule_tac Q =
+               "\<lambda>r a. (\<not> tcb_has_error root_tcb_id a \<longrightarrow> (Q a
+                            \<and> cdl_current_thread a = Some root_tcb_id
+                            \<and> cdl_current_domain a = minBound
+                            \<and> <(root_tcb_id, tcb_pending_op_slot) \<mapsto>c RunningCap \<and>* (\<lambda>s. True)> a))
+                            \<and> (tcb_has_error root_tcb_id a \<longrightarrow> (Perror a
+                            \<and> cdl_current_thread a = Some root_tcb_id
+                            \<and> cdl_current_domain a = minBound
+                            \<and> <(root_tcb_id, tcb_pending_op_slot) \<mapsto>c RunningCap \<and>* (\<lambda>s. True)> a))"
+               in hoare_strengthen_post[rotated])
+         apply fastforce
+        apply (rule whileLoop_wp[where
+                I = "\<lambda>rv s. case rv of Inl _ \<Rightarrow>
+                     (tcb_at'
+                     (\<lambda>tcb. cdl_intent_op (cdl_tcb_intent tcb) = Some intent_op \<and>
+                            cdl_intent_cap (cdl_tcb_intent tcb) = cdl_intent_cap intent \<and>
+                            cdl_intent_extras (cdl_tcb_intent tcb) = cdl_intent_extras intent \<and>
+                            cdl_intent_error (cdl_tcb_intent tcb) = False)
+                            root_tcb_id s \<and>
+                     cdl_current_thread s = Some root_tcb_id \<and>
+                     cdl_current_domain s = minBound \<and> Pd2 s)
+                | Inr rv \<Rightarrow> Q (Inr rv) s" and Q=Q for Q, rotated])
+         apply (case_tac r, simp_all)[1]
+        apply (simp add: validE_def[symmetric])
+        apply (rule hoare_pre, wp)
+          apply (simp add: validE_def, (wp | simp add: validE_def[symmetric])+)
+          apply (wp handle_pending_interrupts_no_ntf_cap)
+
+         apply (rule handle_event_syscall_allow_error
+                       [where cur_thread = root_tcb_id
+                          and intent_op = intent_op
+                          and intent_cptr = intent_cptr
+                          and intent_extra = intent_extra])
+                    apply (wp set_cap_wp
+                              set_cap_hold delete_cap_simple_wp[where cap = RestartCap])[1]
+                   apply (rule decode_invocation_allow_error)
+                  apply (rule lookup_extra_caps_exec)
+                 apply (rule lookup_cap_and_slot_exec)
+                apply (unfold validE_R_def)
+                apply (rule hoare_post_impErr)
+                  apply (rule lookup_cap_and_slot_exec)
+                 apply simp
+                apply simp
+               apply ((wp corrupt_ipc_buffer_sep_inv corrupt_ipc_buffer_active_tcbs
+                          mark_tcb_intent_error_hold corrupt_ipc_buffer_hold | simp)+)[4]
+           apply (rule hoare_post_impErr[OF perform_invocation_hold])
+            apply (fastforce simp:sep_state_projection_def sep_any_def sep_map_c_def sep_conj_def)
+           apply simp
+          apply (wp set_restart_cap_hold)
+         apply (clarsimp dest!:error_imp)
+         apply (sep_cancel, simp)
+        apply (clarsimp split: sum.split_asm)
+       apply (rule_tac P = "thread_ptr = root_tcb_id" in hoare_gen_asm)
+       apply simp
+       apply (wp upd_thread update_thread_wp)+
+  apply (clarsimp simp: sep_map_c_conj sep_map_f_conj object_at_def
+                        object_project_def sep_state_projection_def
+                  split:option.splits cdl_object.split)
   apply (case_tac z)
-    apply (clarsimp dest!:arg_cong[where f= object_type],simp add:object_type_def)+
+           apply (clarsimp dest!:arg_cong[where f= object_type],simp add:object_type_def)+
   done
 
 definition

--- a/proof/crefine/ARM/Fastpath_C.thy
+++ b/proof/crefine/ARM/Fastpath_C.thy
@@ -1811,9 +1811,10 @@ proof -
           apply (simp add: from_bool_0 if_1_0_0 cong: if_cong)
           apply (rule ccorres_cond_true_seq)
           apply (rule ccorres_split_throws)
-           apply (fold dc_def)[1]
            apply (rule ccorres_call_hSkip)
-             apply (rule slowpath_ccorres, simp+)
+             apply (erule disjE; simp flip: dc_def; rule slowpath_ccorres)
+            apply simp
+           apply simp
           apply (vcg exspec=slowpath_noreturn_spec)
          apply (rule ccorres_rhs_assoc)+
          apply csymbr+
@@ -2329,7 +2330,7 @@ proof -
          apply (vcg exspec=endpoint_ptr_get_epQueue_head_modifies
                     exspec=endpoint_ptr_get_state_modifies)
         apply (simp add: if_1_0_0 getSlotCap_def)
-        apply (rule valid_isRight_theRight_split)
+        apply (rule valid_isLeft_theRight_split)
         apply simp
         apply (wp getCTE_wp')
         apply (rule validE_R_abstract_rv)
@@ -2640,9 +2641,8 @@ lemma fastpath_reply_recv_ccorres:
           apply (simp add: if_1_0_0 cong: if_cong)
           apply (rule ccorres_cond_true_seq)
           apply (rule ccorres_split_throws)
-           apply (fold dc_def)[1]
            apply (rule ccorres_call_hSkip)
-             apply (rule slowpath_ccorres)
+             apply (erule disjE; simp flip: dc_def; rule slowpath_ccorres)
             apply simp
            apply simp
           apply (vcg exspec=slowpath_noreturn_spec)
@@ -3084,7 +3084,7 @@ lemma fastpath_reply_recv_ccorres:
            apply (simp del: Collect_const)
            apply vcg
           apply (simp add: if_1_0_0 getSlotCap_def)
-          apply (rule valid_isRight_theRight_split)
+          apply (rule valid_isLeft_theRight_split)
           apply (wp getCTE_wp')
           apply (rule validE_R_abstract_rv)
           apply wp

--- a/proof/crefine/ARM_HYP/Fastpath_C.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_C.thy
@@ -1855,9 +1855,10 @@ proof -
           apply (simp add: from_bool_0 if_1_0_0 cong: if_cong)
           apply (rule ccorres_cond_true_seq)
           apply (rule ccorres_split_throws)
-           apply (fold dc_def)[1]
            apply (rule ccorres_call_hSkip)
-             apply (rule slowpath_ccorres, simp+)
+             apply (erule disjE; simp flip: dc_def; rule slowpath_ccorres)
+            apply simp
+           apply simp
           apply (vcg exspec=slowpath_noreturn_spec)
          apply (rule ccorres_rhs_assoc)+
          apply csymbr+
@@ -2370,7 +2371,7 @@ proof -
          apply (vcg exspec=endpoint_ptr_get_epQueue_head_modifies
                     exspec=endpoint_ptr_get_state_modifies)
         apply (simp add: if_1_0_0 getSlotCap_def)
-        apply (rule valid_isRight_theRight_split)
+        apply (rule valid_isLeft_theRight_split)
         apply simp
         apply (wp getCTE_wp')
         apply (rule validE_R_abstract_rv)
@@ -2682,9 +2683,8 @@ lemma fastpath_reply_recv_ccorres:
           apply (simp add: if_1_0_0 cong: if_cong)
           apply (rule ccorres_cond_true_seq)
           apply (rule ccorres_split_throws)
-           apply (fold dc_def)[1]
            apply (rule ccorres_call_hSkip)
-             apply (rule slowpath_ccorres)
+             apply (erule disjE; simp flip: dc_def; rule slowpath_ccorres)
             apply simp
            apply simp
           apply (vcg exspec=slowpath_noreturn_spec)
@@ -3126,7 +3126,7 @@ lemma fastpath_reply_recv_ccorres:
            apply (simp del: Collect_const)
            apply vcg
           apply (simp add: if_1_0_0 getSlotCap_def)
-          apply (rule valid_isRight_theRight_split)
+          apply (rule valid_isLeft_theRight_split)
           apply (wp getCTE_wp')
           apply (rule validE_R_abstract_rv)
           apply wp


### PR DESCRIPTION
Changes isLeft, isRight, theLeft, and theRight to abbreviations and updates the proofs accordingly.

Proof changes are small, the larger one in capDL-api is mostly fixing broken indentation of the original proof.