### PR TITLE
reduce AutoCorres dependencies

### DIFF
--- a/lib/CLib.thy
+++ b/lib/CLib.thy
@@ -1,0 +1,42 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *)
+
+theory CLib
+  imports Word_Lib.Many_More
+begin
+
+lemma nat_diff_less:
+  "\<lbrakk> x < y + z; z \<le> x\<rbrakk> \<Longrightarrow> x - z < y" for x :: nat
+  using less_diff_conv2 by blast
+
+lemma foldl_conv_concat:
+  "foldl (@) xs xss = xs @ concat xss"
+proof (induct xss arbitrary: xs)
+  case Nil show ?case by simp
+next
+  case Cons then show ?case by simp
+qed
+
+lemma foldl_concat_concat:
+  "foldl (@) [] (xs @ ys) = foldl (@) [] xs @ foldl (@) [] ys"
+  by (simp add: foldl_conv_concat)
+
+lemma take_drop_foldl_concat:
+  "\<lbrakk> \<And>y. y < m \<Longrightarrow> length (f y) = n; x < m \<rbrakk> \<Longrightarrow>
+   take n (drop (x * n) (foldl (@) [] (map f [0 ..< m]))) = f x"
+  apply (subst split_upt_on_n, assumption)
+  apply (simp only: foldl_concat_concat map_append)
+  apply (subst drop_append_miracle)
+   apply (induct x; simp)
+  apply simp
+  done
+
+lemma foldl_does_nothing:
+  "\<lbrakk> \<And>x. x \<in> set xs \<Longrightarrow> f s x = s \<rbrakk> \<Longrightarrow> foldl f s xs = s"
+  by (induct xs) auto
+
+end

--- a/lib/HaskellLib_H.thy
+++ b/lib/HaskellLib_H.thy
@@ -12,7 +12,6 @@
 theory HaskellLib_H
 imports
   Lib
-  NatBitwise
   More_Numeral_Type
   Monads.NonDetMonadVCG
 begin

--- a/lib/Lib.thy
+++ b/lib/Lib.thy
@@ -20,6 +20,7 @@ imports
   Eval_Bool
   Monads.Fun_Pred_Syntax
   Monads.Monad_Lib
+  CLib
   NICTATools
   "Word_Lib.WordSetup"
 begin
@@ -579,11 +580,6 @@ lemma min_of_mono':
   unfolding min_def
   by (subst if_distrib [where f = f, symmetric], rule arg_cong [where f = f], rule if_cong [OF _ refl refl]) fact+
 
-lemma nat_diff_less:
-  fixes x :: nat
-  shows "\<lbrakk> x < y + z; z \<le> x\<rbrakk> \<Longrightarrow> x - z < y"
-  using less_diff_conv2 by blast
-
 lemma take_map_Not:
   "(take n (map Not xs) = take n xs) = (n = 0 \<or> xs = [])"
   by (cases n; simp) (cases xs; simp)
@@ -748,9 +744,6 @@ lemma in_set_zip_refl :
 lemma map_conv_upd:
   "m v = None \<Longrightarrow> m o (f (x := v)) = (m o f) (x := None)"
   by (rule ext) (clarsimp simp: o_def)
-
-lemma split_distrib: "case_prod (\<lambda>a b. T (f a b)) = (\<lambda>x. T (case_prod (\<lambda>a b. f a b) x))"
-  by (clarsimp simp: split_def)
 
 lemma case_sum_triv [simp]:
     "(case x of Inl x \<Rightarrow> Inl x | Inr x \<Rightarrow> Inr x) = x"
@@ -2042,23 +2035,6 @@ shows "foldl (+) (x+y) zs = x + (foldl (+) y zs)"
 lemma (in monoid_add) foldl_absorb0:
 shows "x + (foldl (+) 0 zs) = foldl (+) x zs"
   by (induct zs) (simp_all add:foldl_assoc)
-
-lemma foldl_conv_concat:
-  "foldl (@) xs xss = xs @ concat xss"
-proof (induct xss arbitrary: xs)
-  case Nil show ?case by simp
-next
-  interpret monoid_add "(@)" "[]" proof qed simp_all
-  case Cons then show ?case by (simp add: foldl_absorb0)
-qed
-
-lemma foldl_concat_concat:
-  "foldl (@) [] (xs @ ys) = foldl (@) [] xs @ foldl (@) [] ys"
-  by (simp add: foldl_conv_concat)
-
-lemma foldl_does_nothing:
-  "\<lbrakk> \<And>x. x \<in> set xs \<Longrightarrow> f s x = s \<rbrakk> \<Longrightarrow> foldl f s xs = s"
-  by (induct xs) auto
 
 lemma foldl_use_filter:
   "\<lbrakk> \<And>v x. \<lbrakk> \<not> g x; x \<in> set xs \<rbrakk> \<Longrightarrow> f v x = v \<rbrakk> \<Longrightarrow> foldl f v xs = foldl f v (filter g xs)"

--- a/lib/Lib.thy
+++ b/lib/Lib.thy
@@ -2513,38 +2513,6 @@ lemma option_Some_value_independent:
   "\<lbrakk> f x = Some v; \<And>v'. f x = Some v' \<Longrightarrow> f y = Some v' \<rbrakk> \<Longrightarrow> f y = Some v"
   by blast
 
-text \<open>Some int bitwise lemmas. Helpers for proofs about \<^file>\<open>NatBitwise.thy\<close>\<close>
-lemma int_2p_eq_shiftl:
-  "(2::int)^x = 1 << x"
-  by (simp add: shiftl_int_def)
-
-lemma nat_int_mul:
-  "nat (int a * b) = a * nat b"
-  by (simp add: nat_mult_distrib)
-
-lemma int_shiftl_less_cancel:
-  "n \<le> m \<Longrightarrow> ((x :: int) << n < y << m) = (x < y << (m - n))"
-  apply (drule le_Suc_ex)
-  apply (clarsimp simp: shiftl_int_def power_add)
-  done
-
-lemma int_shiftl_lt_2p_bits:
-  "0 \<le> (x::int) \<Longrightarrow> x < 1 << n \<Longrightarrow> \<forall>i \<ge> n. \<not> x !! i"
-  apply (clarsimp simp: shiftl_int_def)
-  by (metis bit_take_bit_iff not_less take_bit_int_eq_self_iff)
-\<comment> \<open>TODO: The converse should be true as well, but seems hard to prove.\<close>
-
-lemmas int_eq_test_bit = bin_eq_iff
-lemmas int_eq_test_bitI = int_eq_test_bit[THEN iffD2, rule_format]
-
-lemma le_nat_shrink_left:
-  "y \<le> z \<Longrightarrow> y = Suc x \<Longrightarrow> x < z"
-  by simp
-
-lemma length_ge_split:
-  "n < length xs \<Longrightarrow> \<exists>x xs'. xs = x # xs' \<and> n \<le> length xs'"
-  by (cases xs) auto
-
 text \<open>Support for defining enumerations on datatypes derived from enumerations\<close>
 lemma distinct_map_enum:
   "\<lbrakk> (\<forall> x y. (F x = F y \<longrightarrow> x = y )) \<rbrakk>

--- a/lib/ROOT
+++ b/lib/ROOT
@@ -87,7 +87,6 @@ session CLib (lib) in clib = CParser +
     LemmaBucket_C
     SIMPL_Lemmas
     SimplRewrite
-    TypHeapLib
     BitFieldProofsLib
     XPres
 

--- a/lib/clib/BitFieldProofsLib.thy
+++ b/lib/clib/BitFieldProofsLib.thy
@@ -6,8 +6,8 @@
 
 theory BitFieldProofsLib
 imports
-  "Eisbach_Tools.Eisbach_Methods"
-  TypHeapLib
+  Eisbach_Tools.Eisbach_Methods
+  CParser.TypHeapLib
 begin
 
 lemmas guard_simps =

--- a/lib/clib/LemmaBucket_C.thy
+++ b/lib/clib/LemmaBucket_C.thy
@@ -8,7 +8,7 @@ theory LemmaBucket_C
 imports
   "Lib.Lib"
   "Word_Lib.WordSetup"
-  TypHeapLib
+  CParser.TypHeapLib
   "CParser.ArrayAssertion"
 begin
 

--- a/proof/crefine/lib/CToCRefine.thy
+++ b/proof/crefine/lib/CToCRefine.thy
@@ -9,7 +9,8 @@ theory CToCRefine
 imports
     "CSpec.Substitute"
     "CLib.SimplRewrite"
-    "CLib.TypHeapLib"
+    Lib.Lib
+    "CParser.TypHeapLib"
 begin
 
 lemma spec_statefn_simulates_lookup_tree_Node:

--- a/spec/cspec/TypHeapLimits.thy
+++ b/spec/cspec/TypHeapLimits.thy
@@ -5,7 +5,7 @@
  *)
 
 theory TypHeapLimits
-imports "CLib.TypHeapLib"
+  imports CParser.TypHeapLib
 begin
 
 definition

--- a/tools/asmrefine/ExtraSpecs.thy
+++ b/tools/asmrefine/ExtraSpecs.thy
@@ -7,7 +7,7 @@
 theory ExtraSpecs
 
 imports
-  "CLib.TypHeapLib"
+  "CParser.TypHeapLib"
 
 begin
 

--- a/tools/asmrefine/FieldAccessors.thy
+++ b/tools/asmrefine/FieldAccessors.thy
@@ -5,9 +5,9 @@
  *)
 
 theory FieldAccessors
-
-imports "CLib.LemmaBucket_C"
-
+  imports
+    Lib.Lib
+    CLib.LemmaBucket_C
 begin
 
 lemma h_val_mono:
@@ -53,10 +53,10 @@ lemma heap_update_rotate:
                 heap_update_list_rotate)
 
 lemma c_guard_align_of:
-  "\<lbrakk> align_of TYPE('a :: c_type) + size_of TYPE('a) < 2 ^ word_bits;
-           align_of TYPE('a) \<noteq> 0 \<rbrakk> \<Longrightarrow>
-       c_guard (Ptr (of_nat (align_of TYPE('a))) :: 'a ptr)"
+  "\<lbrakk> align_of TYPE('a :: c_type) + size_of TYPE('a) < 2 ^ word_bits; align_of TYPE('a) \<noteq> 0 \<rbrakk> \<Longrightarrow>
+   c_guard (Ptr (of_nat (align_of TYPE('a))) :: 'a ptr)"
   unfolding c_guard_def
+  supply word_neq_0_conv[simp del]
   apply (simp add: ptr_aligned_def unat_of_nat c_null_guard_def)
   apply (clarsimp simp: intvl_def word_bits_conv take_bit_nat_eq_self)
   apply (drule trans[rotated], rule sym, rule Abs_fnat_hom_add)

--- a/tools/asmrefine/GraphLang.thy
+++ b/tools/asmrefine/GraphLang.thy
@@ -7,7 +7,7 @@
 theory GraphLang
 
 imports
-  "CLib.TypHeapLib"
+  "CParser.TypHeapLib"
   "Lib.SplitRule"
   "CommonOps"
 

--- a/tools/asmrefine/GraphRefine.thy
+++ b/tools/asmrefine/GraphRefine.thy
@@ -9,6 +9,7 @@ theory GraphRefine
 imports
   TailrecPre
   GraphLangLemmas
+  Lib.Lib
   "CLib.LemmaBucket_C"
   ExtraSpecs
 begin

--- a/tools/autocorres/AbstractArrays.thy
+++ b/tools/autocorres/AbstractArrays.thy
@@ -6,7 +6,7 @@
 
 theory AbstractArrays
 imports
-  "CLib.TypHeapLib"
+  "CParser.TypHeapLib"
   "Word_Lib.WordSetup"
 begin
 

--- a/tools/autocorres/CCorresE.thy
+++ b/tools/autocorres/CCorresE.thy
@@ -269,7 +269,7 @@ lemma ccorresE_termination':
   apply clarsimp
   apply (erule allE, erule (1) impE)
   apply (clarsimp split: sum.splits xstate.splits)
-  apply (erule (1) my_BallE)
+  apply (drule (1) bspec)
   apply clarsimp
   apply (erule allE, erule impE, rule refl)
   apply clarsimp
@@ -313,7 +313,7 @@ lemma ccorresE_While:
        apply (insert ccorresE_exec_Normal [OF body_refines])[1]
        apply clarsimp
        apply atomize
-       apply (erule allE2, erule (1) impE)
+       apply (erule allE, erule allE, erule (1) impE)
        apply (frule snd_whileLoopE_first_step, force simp: cond_match)
        apply clarsimp
        apply (erule impE)
@@ -329,7 +329,7 @@ lemma ccorresE_While:
       apply (insert ccorresE_exec_Abrupt [OF body_refines])[1]
       apply clarsimp
       apply atomize
-      apply (erule allE2, erule (1) impE)
+      apply (erule allE, erule allE, erule (1) impE)
       apply (frule snd_whileLoopE_first_step, force simp: cond_match)
       apply clarsimp
       apply (subst whileLoopE_unroll)
@@ -414,13 +414,10 @@ lemma ccorresE_symb_exec_l:
   apply (clarsimp simp: ccorresE_def validE_def valid_def exs_valid_def)
   apply (erule allE, erule impE, assumption)+
   apply (clarsimp)
-  apply (erule (1) my_BallE)
-  apply clarsimp
-  apply (erule_tac x=aa and y=s in allE2)
+  apply (drule (1) bspec)
   apply clarsimp
   apply (monad_eq simp: Bex_def Ball_def split: xstate.splits)
-  apply fastforce
-  done
+  by fastforce
 
 lemma ccorresE_no_fail_term:
   " \<lbrakk> ccorresE st ct \<Gamma> G G' A B; no_fail G A; s \<in> G'; G (st s); ct \<rbrakk> \<Longrightarrow> \<Gamma> \<turnstile> B \<down> Normal s"

--- a/tools/autocorres/ExceptionRewrite.thy
+++ b/tools/autocorres/ExceptionRewrite.thy
@@ -75,10 +75,10 @@ lemma no_return_bindE:
     apply (erule disjE)
      apply clarsimp
     apply clarsimp
-    apply (erule (1) my_BallE)
+    apply (drule (1) bspec)
     apply clarsimp
    apply clarsimp
-   apply (erule (1) my_BallE)
+   apply (drule (1) bspec)
    apply (clarsimp split: sum.splits)
   apply (clarsimp simp: snd_bindE no_return_def validE_def valid_def)
   apply (erule_tac x=x in allE)
@@ -344,13 +344,17 @@ lemma L1_catch_cond_seq:
   apply (rule L1_catch_single_cond)
   done
 
+lemma unit_not_Inr:
+  "(a \<noteq> Inr ()) = (a = Inl ())"
+  by (cases a; clarsimp)
+
 (* This exciting lemma lets up break up a L1_catch into two parts in
  * the exciting circumstance that "E" never returns. *)
 lemma L1_catch_seq_cond_noreturn_ex:
   "\<lbrakk> no_return \<top> E \<rbrakk> \<Longrightarrow> (L1_catch (L1_seq (L1_condition c A B) C) E) = (L1_seq (L1_catch (L1_condition c A B) E) (L1_catch C E))"
   apply (clarsimp simp: L1_defs)
-  apply (monad_eq simp: no_return_def valid_def validE_def Ball_def
-      Bex_def unit_Inl_or_Inr split:sum.splits)
+  apply (monad_eq simp: no_return_def valid_def validE_def Ball_def Bex_def unit_not_Inr
+                  split: sum.splits)
   apply (safe, (metis Inr_not_Inl)+)
   done
 

--- a/tools/autocorres/ExecConcrete.thy
+++ b/tools/autocorres/ExecConcrete.thy
@@ -179,8 +179,8 @@ lemma corresXF_simple_exec_concrete:
 lemma corresXF_exec_concrete_self:
     "corresXF st (\<lambda>r s. r) (\<lambda>r s. r) P (exec_concrete st M) M"
   apply (subst corresXF_simple_corresXF [symmetric])
-  apply clarsimp
-  apply (rule corresXF_simple_exec_concrete)
+  apply (simp add: surjective_sum[where f=id, simplified])
+  apply (rule corresXF_simple_exec_concrete)+
   done
 
 lemma corresXF_exec_concrete [intro?]:
@@ -307,7 +307,7 @@ lemma corresXF_simple_exec_abstract:
 lemma corresXF_exec_abstract_self:
     "corresXF st (\<lambda>r s. r) (\<lambda>r s. r) P M (exec_abstract st M)"
   apply (subst corresXF_simple_corresXF [symmetric])
-  apply clarsimp
+  apply (simp add: surjective_sum[where f=id, simplified])
   apply (rule corresXF_simple_exec_abstract)
   done
 

--- a/tools/autocorres/HeapLift.thy
+++ b/tools/autocorres/HeapLift.thy
@@ -157,9 +157,8 @@ definition "abs_spec st P (A :: ('a \<times> 'a) set) (C :: ('c \<times> 'c) set
 lemma L2Tcorres_spec [heap_abs]:
   "\<lbrakk> abs_spec st P A C \<rbrakk>
      \<Longrightarrow> L2Tcorres st (L2_seq (L2_guard P) (\<lambda>_. (L2_spec A))) (L2_spec C)"
-  apply (monad_eq simp: corresXF_def L2Tcorres_def L2_defs image_def set_eq_UNIV
-             split_def Ball_def state_select_def abs_spec_def split: sum.splits)
-  done
+  by (monad_eq simp: corresXF_def L2Tcorres_def L2_defs image_def split_def Ball_def
+                     state_select_def abs_spec_def)
 
 lemma abs_spec_constant [heap_abs]:
   "abs_spec st \<top> {(a, b). C} {(a, b). C}"
@@ -1368,7 +1367,7 @@ lemma heap_abs_expr_c_guard_array [heap_abs]:
    apply (subst (asm) (2) set_array_addrs)
    apply force
   apply clarsimp
-  apply (erule (1) my_BallE)
+  apply (drule (1) bspec)
   apply (drule (1) valid_typ_heap_c_guard)
   apply simp
   done

--- a/tools/autocorres/L2Defs.thy
+++ b/tools/autocorres/L2Defs.thy
@@ -174,8 +174,7 @@ lemma L2corres_spec:
   apply (clarsimp simp: L2corres_def L2_defs L1_spec_def corresXF_def
                         liftE_def spec_alt_def return_def bind_def select_def)
   apply (clarsimp simp: image_def)
-  apply (subst (asm) set_eq_UNIV)
-  apply metis
+  apply (smt (verit) UNIV_I mem_Collect_eq)
   done
 
 lemma L2corres_seq:
@@ -280,7 +279,7 @@ lemma corresXF_E:
   apply clarsimp
   apply (erule allE, erule impE, fastforce)
   apply clarsimp
-  apply (erule (1) my_BallE)
+  apply (drule (1) bspec)
   apply (clarsimp split: sum.splits)
   done
 
@@ -506,9 +505,7 @@ lemma L2_gets_bind: "\<lbrakk> \<And>s s'. V s = V s' \<rbrakk> \<Longrightarrow
   apply (rule ext)
   apply (clarsimp simp: L2_seq_def L2_gets_def gets_def get_def return_def bindE_def)
   apply (clarsimp simp: liftE_def2 bind_def lift_def)
-  apply atomize
-  apply (erule_tac x=x and y=undefined in allE2)
-  apply simp
+  apply metis
   done
 
 (* TODO: remove internal var if it is not user-visible *)

--- a/tools/autocorres/MonadMono.thy
+++ b/tools/autocorres/MonadMono.thy
@@ -12,7 +12,8 @@
 theory MonadMono
 imports
   NonDetMonadEx
-  "Monads.OptionMonadWP"
+  Monads.WhileLoopRulesCompleteness
+  Monads.OptionMonadWP
 begin
 
 (*
@@ -284,15 +285,11 @@ definition "option_monad_mono f \<equiv>
 lemma option_monad_mono_eq:
   "(\<And>m. f m = gets_the (f' m)) \<Longrightarrow> monad_mono f = option_monad_mono f'"
   apply (clarsimp simp: monad_mono_def option_monad_mono_def gets_the_def
-    gets_def get_def assert_opt_def return_def fail_def bind_def' split: option.splits)
-  apply (rule iff_allI iff_impI)+
-  apply (rule_tac t = "\<forall>r. f' x s = Some r \<longrightarrow> (\<exists>r'. f' y s = Some r') \<and> (\<forall>r'. f' y s = Some r' \<longrightarrow> r = r')"
-              and s = "\<forall>r. f' x s = Some r \<longrightarrow> f' y s = Some r" in subst)
-   apply (force intro: iff_allI iff_impI)
-  apply (rule iffI)
-   apply (metis (no_types) option.exhaust)
-  apply force
-  done
+                        gets_def get_def assert_opt_def return_def fail_def bind_def'
+                  split: option.splits)
+  apply (intro iff_allI iffI impI allI)
+   apply (metis option.collapse)
+  by fastforce
 
 lemma measure_ocall_ovalid [wp]:
     "\<lbrakk> \<forall> m. ovalid P (x m) Q; option_monad_mono x \<rbrakk> \<Longrightarrow> ovalid P (measure_ocall x) Q"

--- a/tools/autocorres/NatBitwise.thy
+++ b/tools/autocorres/NatBitwise.thy
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *)
 
-(* Instance of bit ops for nat. Used by HaskellLib and AutoCorres.
- * Lemmas about this instance should also go here. *)
+(* Instance of bit ops for nat.
+   Lemmas about this instance should also go here. *)
 theory NatBitwise
 imports
-  Lib
+  Word_Lib.WordSetup
 begin
 
 instantiation nat :: lsb
@@ -50,9 +50,19 @@ lemma nat_2p_eq_shiftl:
 
 lemmas shiftl_nat_alt_def = shiftl_nat_def
 
+lemma nat_int_mul:
+  "nat (int a * b) = a * nat b"
+  by (simp add: nat_mult_distrib)
+
 lemma shiftl_nat_def:
   "(x::nat) << y = nat (int x << y)"
   by (simp add: nat_int_mul push_bit_eq_mult shiftl_def)
+
+lemma int_shiftl_less_cancel:
+  "n \<le> m \<Longrightarrow> ((x :: int) << n < y << m) = (x < y << (m - n))"
+  apply (drule le_Suc_ex)
+  apply (clarsimp simp: shiftl_int_def power_add)
+  done
 
 lemma nat_shiftl_less_cancel:
   "n \<le> m \<Longrightarrow> ((x :: nat) << n < y << m) = (x < y << (m - n))"
@@ -68,5 +78,17 @@ lemma nat_shiftl_lt_2p_bits:
 
 lemmas nat_eq_test_bit = bit_eq_iff
 lemmas nat_eq_test_bitI = bit_eq_iff[THEN iffD2, rule_format]
+
+lemma int_2p_eq_shiftl:
+  "(2::int)^x = 1 << x"
+  by (simp add: shiftl_int_def)
+
+lemma int_shiftl_lt_2p_bits:
+  "0 \<le> (x::int) \<Longrightarrow> x < 1 << n \<Longrightarrow> \<forall>i \<ge> n. \<not> x !! i"
+  apply (clarsimp simp: shiftl_int_def)
+  by (metis bit_take_bit_iff not_less take_bit_int_eq_self_iff)
+\<comment> \<open>TODO: The converse should be true as well, but seems hard to prove.\<close>
+
+lemmas int_eq_test_bitI = bin_eq_iff[THEN iffD2, rule_format]
 
 end

--- a/tools/autocorres/NonDetMonadEx.thy
+++ b/tools/autocorres/NonDetMonadEx.thy
@@ -11,7 +11,11 @@
 theory NonDetMonadEx
 imports
   "Word_Lib.WordSetup"
-  "Lib.NonDetMonadLemmaBucket"
+  "Monads.NonDetMonadVCG"
+  "Lib.Monad_Equations"
+  "Lib.More_NonDetMonadVCG"
+  "Monads.No_Throw"
+  "Monads.No_Fail"
   "Monads.OptionMonadND"
 begin
 

--- a/tools/autocorres/TypHeapSimple.thy
+++ b/tools/autocorres/TypHeapSimple.thy
@@ -15,7 +15,7 @@
 
 theory TypHeapSimple
 imports
-  "CLib.TypHeapLib"
+  "CParser.TypHeapLib"
 begin
 
 (*

--- a/tools/autocorres/TypeStrengthen.thy
+++ b/tools/autocorres/TypeStrengthen.thy
@@ -101,6 +101,9 @@ lemma TS_return_L2_condition:
     "L2_condition (\<lambda>_. c) (TS_return A) (TS_return B) = TS_return (if c then A else B)"
   by (monad_eq simp: L2_defs TS_return_def)
 
+lemma split_distrib: "case_prod (\<lambda>a b. T (f a b)) = (\<lambda>x. T (case_prod (\<lambda>a b. f a b) x))"
+  by (clarsimp simp: split_def)
+
 lemmas [ts_rule pure] =
   TS_return_L2_gets
   TS_return_L2_seq

--- a/tools/autocorres/WordAbstract.thy
+++ b/tools/autocorres/WordAbstract.thy
@@ -8,7 +8,7 @@ theory WordAbstract
 imports
   L2Defs
   ExecConcrete
-  Lib.NatBitwise
+  NatBitwise
 begin
 
 definition "WORD_MAX x \<equiv> ((2 ^ (len_of x - 1) - 1) :: int)"

--- a/tools/autocorres/WordAbstract.thy
+++ b/tools/autocorres/WordAbstract.thy
@@ -322,8 +322,9 @@ lemma sint_shiftl_nonneg:
   apply (drule (1) int_shiftl_lt_2p_bits[rotated])
   apply (clarsimp simp: min_def split: if_split_asm)
   apply (rule conjI; clarsimp)
-   apply (smt (z3) decr_length_less_iff diff_Suc_Suc diff_is_0_eq diff_le_mono diff_le_self
-                   diff_zero le_def less_handy_casesE nat_less_le order_refl)
+   apply (smt (verit) One_nat_def bot_nat_0.extremum_uniqueI diff_Suc_eq_diff_pred
+                      le_diff_iff le_diff_iff' len_gt_0 len_of_finite_1_def less_eq_Suc_le
+                      nat_le_Suc_less_imp)
   using less_eq_decr_length_iff nat_le_linear by blast
 
 lemma abstract_val_signed_shiftl_signed:

--- a/tools/autocorres/tests/examples/Memcpy.thy
+++ b/tools/autocorres/tests/examples/Memcpy.thy
@@ -182,8 +182,7 @@ lemma memcpy_word:
      apply clarsimp
     apply (clarsimp simp: h_val_def)[1]
     apply (rule arg_cong[where f=from_bytes])
-    apply (subst numeral_eqs(3))+
-    apply simp
+    apply (simp add: numeral_nat)
     apply (rule_tac x=0 in allE, assumption, erule impE, unat_arith)
     apply (rule_tac x=1 in allE, assumption, erule impE, unat_arith)
     apply (rule_tac x=2 in allE, assumption, erule impE, unat_arith)
@@ -383,7 +382,8 @@ lemma update_bytes_postpend: "length bs = x + 1 \<Longrightarrow>
   apply (clarsimp simp:ptr_add_def)
   apply (subst heap_update_list_concat_fold_hrs_mem)
    apply clarsimp+
-  by (metis append_eq_conv_conj append_self_conv hd_drop_conv_nth2 lessI take_hd_drop)
+  apply (metis append.right_neutral append_eq_conv_conj lessI take_Suc_conv_app_nth)
+  done
 
 lemma h_val_not_id_general:
   fixes y :: "'a::mem_type ptr"
@@ -600,8 +600,7 @@ lemma memcpy_wp':
       apply clarsimp
       apply (rule update_bytes_eq)
         apply (subgoal_tac "min (unat i) (unat (i + 1)) = unat i")
-         apply clarsimp
-        apply clarsimp
+         apply presburger
         apply unat_arith
        apply (clarsimp simp:ptr_add_def)
       apply clarsimp

--- a/tools/c-parser/ROOT
+++ b/tools/c-parser/ROOT
@@ -15,10 +15,10 @@ session "Simpl-VCG" in Simpl = Word_Lib +
 session CParser = "Simpl-VCG" +
   sessions
     "HOL-Library"
-    "Lib"
     "ML_Utils"
   directories
     "umm_heap"
     "umm_heap/$L4V_ARCH"
   theories
     "CTranslation"
+    "TypHeapLib"

--- a/tools/c-parser/TypHeapLib.thy
+++ b/tools/c-parser/TypHeapLib.thy
@@ -5,12 +5,11 @@
  *)
 
 theory TypHeapLib
-imports "CParser.CTranslation"
+  imports CTranslation
 begin
 
 (* This file contains everything you need to know and use for the
-   day-to-day solving of TypHeap related goals.  See KernelState.thy for
-   abbreviations for cslift etc. *)
+   day-to-day solving of TypHeap related goals. *)
 
 section "Abbreviations and helpers"
 


### PR DESCRIPTION
This doesn't fully implement #545 yet, but it's worth a check point.

- remove all dependencies from C parser to Lib session
- reduce dependencies of AutoCorres session to theories that can be moved out of Lib

The only Lib imports in AutoCorres are now:

- `CLib.LemmaBucket_C` which can be moved to `CParser` session
- `Lib.Monad_Equations` and `Lib.More_NonDetMonadVCG` which can be moved to `Monads` session

- `CLib.LemmaBucket_C` itself depends on `Lib.CLib` which has no further dependencies. Naming and destination of `CLib.thy` still unclear. Ideas welcome.